### PR TITLE
niv nixpkgs: update 5ba94df4 -> 11273b60

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -113,10 +113,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5ba94df425e26980b88e7f89e8d78cc33e6cf962",
-        "sha256": "158f175mjyxa56ys5wbfr68ykvkzdq7mh0c71vcmzsyzmp17b13b",
+        "rev": "11273b60c8b3b6036bc3c86e135b940154668f58",
+        "sha256": "01qxch6j8889cmh7wx9r70f50a1487z0kqdcx0650b3a202wmxqg",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/5ba94df425e26980b88e7f89e8d78cc33e6cf962.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/11273b60c8b3b6036bc3c86e135b940154668f58.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@5ba94df4...11273b60](https://github.com/nixos/nixpkgs/compare/5ba94df425e26980b88e7f89e8d78cc33e6cf962...11273b60c8b3b6036bc3c86e135b940154668f58)

* [`ad152c62`](https://github.com/NixOS/nixpkgs/commit/ad152c62f8c1cb75e37d04a9f5741001d13cd20b)  rime-data: 0.38.20211002 -> 0.38.20231116
* [`b333f267`](https://github.com/NixOS/nixpkgs/commit/b333f2676c963e7d17f948afd0caa9edae5bd0bd) nixos/flatpak: pass system icons and fonts
* [`5527c1cf`](https://github.com/NixOS/nixpkgs/commit/5527c1cf7510eb18a7523a1f0a1a8988091eb39f) thelounge: migrate to prefetch-yarn-deps
* [`f553bdbb`](https://github.com/NixOS/nixpkgs/commit/f553bdbb07743d06c73c68bee31db4520ab0c435) nixos/jitsi-meet: allow to customize jitsi auth
* [`4892d105`](https://github.com/NixOS/nixpkgs/commit/4892d1050416e3d41df0df13dbbddb63c753e7ed) python3Packages.naked: init at 0.1.32
* [`32e7476d`](https://github.com/NixOS/nixpkgs/commit/32e7476d02071b746f2ce28f554afeb045ca38f1) python3Packages.hsh: init at 1.1.0
* [`42766a46`](https://github.com/NixOS/nixpkgs/commit/42766a4606fc18ef4dc16b9f62435ee4ce9126e8) surelog: 1.80 -> 1.82
* [`ff3d9902`](https://github.com/NixOS/nixpkgs/commit/ff3d9902e02ba47f2b4f2ed0be22778aab8c3b9b) nixos-rebuild: use --pipe instead of --pty in systemd-run
* [`82bffa43`](https://github.com/NixOS/nixpkgs/commit/82bffa43b558831b41e1ed763eb17762d3e0340b) geonkick: 2.9.1 -> 3.3.1
* [`d73d17b9`](https://github.com/NixOS/nixpkgs/commit/d73d17b934c47499d8feb76e3689f439cbb3cd33) bibata-cursors: move to `pkgs/by-name`
* [`a742e5da`](https://github.com/NixOS/nixpkgs/commit/a742e5da2e8a00f47d1b81d8755e14d0c6831726) bibata-cursors: 2.0.3 -> 2.0.6
* [`bc67fc6d`](https://github.com/NixOS/nixpkgs/commit/bc67fc6decea9f0811e0bc250b87144626dca2df) bibata-cursors: fix meta
* [`955bc676`](https://github.com/NixOS/nixpkgs/commit/955bc676eb3557429ab4c4e67091b439d012cd4c) material-icons: 3.0.1 -> 4.0.0
* [`e36c7a9a`](https://github.com/NixOS/nixpkgs/commit/e36c7a9a989b2f32316aef20dd1a5b8dd01e9aa6) material-icons: skip unwanted phases
* [`3a440b11`](https://github.com/NixOS/nixpkgs/commit/3a440b118627d5047b541c7ae8c3c0d3a5efd59a) material-icons: rec -> finalAttrs
* [`009036e6`](https://github.com/NixOS/nixpkgs/commit/009036e6ebf29d9591a34c22797ca4da1f69b2c9) material-icons: add update script
* [`c3933fdc`](https://github.com/NixOS/nixpkgs/commit/c3933fdc40adb18d2e494bfd06435a054893e2f8) google-fonts: fix font name format
* [`da6bfeee`](https://github.com/NixOS/nixpkgs/commit/da6bfeee123d493d726da240eb03e67227eae804) xfsprogs: 6.4.0 -> 6.6.0
* [`2b6b734c`](https://github.com/NixOS/nixpkgs/commit/2b6b734c1a18d6505cbefc3332372672d1f8c7d8) dra-cla: unstable-2023-10-10 -> unstable-2024-02-07
* [`2214a3f6`](https://github.com/NixOS/nixpkgs/commit/2214a3f6e447e7627bd0331ce07ca6ab0e095355) makeInitrdNGTool: 0.1.0 -> 0.1.0
* [`00e4bf4d`](https://github.com/NixOS/nixpkgs/commit/00e4bf4d026bf4dcc28ebf559770e90b1c92ce36) peertube: 5.2.1 -> 6.0.3
* [`6e612271`](https://github.com/NixOS/nixpkgs/commit/6e61227199263919fa1dafe5ef1d976718053eac) peertube: split peertube-cli utility
* [`1bdbfd57`](https://github.com/NixOS/nixpkgs/commit/1bdbfd5778114ea49b94be97bd99ba3b3be394f3) peertube: add peertube-runnerr utility
* [`b0b1f734`](https://github.com/NixOS/nixpkgs/commit/b0b1f7347376cede73bbdc51756d4843c6721cb4) nixos/tests/peertube: update peertube-cli tests
* [`93722044`](https://github.com/NixOS/nixpkgs/commit/937220442c4c20a1b37add5387f20294b34e18f7) nixos/peertube: update nginx configuration
* [`5701b288`](https://github.com/NixOS/nixpkgs/commit/5701b288e242dc3247e553770799e5bafcf272db) python311Packages.rchitect: 0.4.4 -> 0.4.6
* [`dd403268`](https://github.com/NixOS/nixpkgs/commit/dd4032683643df7699ac6a71235e3c56dff2d021) python311Packages.radian: 0.6.8 -> 0.6.12
* [`fb39dd6f`](https://github.com/NixOS/nixpkgs/commit/fb39dd6f729dfb36d9f5405756233a8f9e936afa) update-python-libraries: ignore yanked releases on PyPI
* [`314c2806`](https://github.com/NixOS/nixpkgs/commit/314c2806ccfece9eec5e2ae7eb475f9e8865ea30) kmeet: init at 2.0.1
* [`0f55a965`](https://github.com/NixOS/nixpkgs/commit/0f55a965236c95594dbe38488966d330ba983c90) komikku: 1.38.1 -> 1.39.0
* [`fb757e30`](https://github.com/NixOS/nixpkgs/commit/fb757e30facdfb9e64800b9f3562e8d585df18bc) mk-python-derivation: Refactor lib usage
* [`d77190ae`](https://github.com/NixOS/nixpkgs/commit/d77190aeaa376052190f67ad2feaf5e2c3183488) mk-python-derivation: Refactor internal function validatePythonMatches
* [`c9b61a32`](https://github.com/NixOS/nixpkgs/commit/c9b61a32059f8c3bb73fb012823f4856e810501e) easyrsa: default EASYRSA_OPENSSL, add installCheckPhase
* [`eb9b60a2`](https://github.com/NixOS/nixpkgs/commit/eb9b60a2de7e9f406efed12f68c2024d5955b35e) cudaPackages.nccl: 2.20.3-1 -> 2.20.5-1
* [`fd0ad1ec`](https://github.com/NixOS/nixpkgs/commit/fd0ad1ecca0b74686d7f45db6331d4adff75a317) libhttpserver: init at 0.19.0
* [`1656fe1b`](https://github.com/NixOS/nixpkgs/commit/1656fe1bf62224e488057b611e48d588fa8e2eb1) mk-python-derivation: Precompute static lists
* [`de402796`](https://github.com/NixOS/nixpkgs/commit/de402796a7472113bc3f2bbd53adfa8852748f4a) mk-python-derivation: Break out attribute set cleaning into a separate function
* [`5a7bdf9d`](https://github.com/NixOS/nixpkgs/commit/5a7bdf9d38e2425068e4151a843e26595d7d22fb) vagrant: install zsh completion
* [`cb176b27`](https://github.com/NixOS/nixpkgs/commit/cb176b27b1a3070be48bf2641e9ce4585ff198c0) zabbix-agent2-plugin-postgresql: 6.0.25 -> 6.4.12
* [`ecad5a11`](https://github.com/NixOS/nixpkgs/commit/ecad5a115d9f20670c6cac7d40b6e9c81a9ae233) dotnet: add publish and web tests
* [`3b2d1beb`](https://github.com/NixOS/nixpkgs/commit/3b2d1bebd61a7d4815fb1734fcef00272b1b9a2a) python3Packages.tendo: init at 0.4.0
* [`32adfce1`](https://github.com/NixOS/nixpkgs/commit/32adfce17cbc39a570660bc6f7196ea2ae194b9f) goldwarden: package GUI, drop pinentry
* [`09b82b34`](https://github.com/NixOS/nixpkgs/commit/09b82b349a12789585fcc4afb4a181c0388409d9) build-fhsenv-bubblewrap: fix fhsenv etc entries
* [`54f1d8f1`](https://github.com/NixOS/nixpkgs/commit/54f1d8f19990c9be8887ca945c90abd82edb5daf) maintainers: add dflores
* [`00af5222`](https://github.com/NixOS/nixpkgs/commit/00af52229ec39be87e7633db7f2dbc090adc3dff) fastqc: init at 0.12.1
* [`88312612`](https://github.com/NixOS/nixpkgs/commit/88312612cb5cdc040b7ff26439c083897dc65d6f) maintainers: add n8henrie
* [`436f4e2f`](https://github.com/NixOS/nixpkgs/commit/436f4e2f06763421faa1d0d7862877ed7d7a0a85) validator-nu: 22.9.29 -> 23.4.11-unstable-2023-12-18
* [`f362114e`](https://github.com/NixOS/nixpkgs/commit/f362114e1f56c9c41f7317ab24dea3fcb4061c63) validator-nu: add myself to maintainers
* [`555c7d1b`](https://github.com/NixOS/nixpkgs/commit/555c7d1ba153b738356518ab1cfce4342582c3e5) llvmPackages_17.clangUseLLVM: apply [nixos/nixpkgs⁠#220520](https://togithub.com/nixos/nixpkgs/issues/220520)
* [`50106784`](https://github.com/NixOS/nixpkgs/commit/5010678492eddb9f6d076082bd912d726abf5e82) checkpointBuildTools.prepareCheckpointBuild: stop at install
* [`05491696`](https://github.com/NixOS/nixpkgs/commit/05491696c54969386968d43771db19ffb36f689a) hello: add postInstallCheck
* [`f2d82a2c`](https://github.com/NixOS/nixpkgs/commit/f2d82a2cfd9057c424f52f455ef5b357a419b501) maintainers: add hennk
* [`7d9c7032`](https://github.com/NixOS/nixpkgs/commit/7d9c70324621b4bb7010110104ebbf3b318d252b) python312Packages.pyaudio: normalize pname
* [`92dd0387`](https://github.com/NixOS/nixpkgs/commit/92dd0387a1dde26aa45fc5c789b02ad4714c5592) python312Packages.pybrowserid: normalize pname
* [`ab8e8503`](https://github.com/NixOS/nixpkgs/commit/ab8e85035dce9478d97df281d651489ea45c8f85) python312Packages.heapdict: normalize pname
* [`495613d5`](https://github.com/NixOS/nixpkgs/commit/495613d5552b7bda0d1c222f87dabb48c0a804b5) attic: init at unstable-2024-2-8
* [`881d9d8d`](https://github.com/NixOS/nixpkgs/commit/881d9d8d01c55d9425cd11791e30bca06c9c0db2) python312Packages.webhelpers: normalize pname
* [`f9e026bf`](https://github.com/NixOS/nixpkgs/commit/f9e026bf7d119bfdb08f12aa242d0bfd3b64b2df) python312Packages.cjkwrap: normalize pname
* [`337f42fa`](https://github.com/NixOS/nixpkgs/commit/337f42fa6d058c5e62f2312e498591ce700784f1) python312Packages.cppheaderparser: normalize pname
* [`95eb164e`](https://github.com/NixOS/nixpkgs/commit/95eb164eded540b246eb2a45830498273ecd4b20) ugrep-indexer: init at 0.9.6
* [`24ae9830`](https://github.com/NixOS/nixpkgs/commit/24ae98307652ded76946984d72f57fbe776bfeca) darwin.linux-builder: Exit scripts on error
* [`465151cd`](https://github.com/NixOS/nixpkgs/commit/465151cdb2355c845de03e538ea8f6862aa93396) cue: 0.7.1 -> 0.8.0
* [`3f99c895`](https://github.com/NixOS/nixpkgs/commit/3f99c895320e3c7380801db442eb551288b4296e) iferr: 2018-06-15 -> 0-unstable-2024-01-22
* [`08f76a1d`](https://github.com/NixOS/nixpkgs/commit/08f76a1dc7bd016603c3d20b4f6fee77de629c1a) rm-improved: 0.13.0 -> 0.13.1
* [`476d65aa`](https://github.com/NixOS/nixpkgs/commit/476d65aa457ffe6b10419295f27f5d83ba8f0eac) python312Packages.delorean: normalize pname
* [`3415d94d`](https://github.com/NixOS/nixpkgs/commit/3415d94d968ce79208958d148e8e8286e7c8cce2) python312Packages.ecpy: normalize pname
* [`cba95759`](https://github.com/NixOS/nixpkgs/commit/cba957590c9b3d807fdd408605b762b0ccbe1816) haskellPackages: stackage LTS 22.8 -> LTS 22.13
* [`031a7e83`](https://github.com/NixOS/nixpkgs/commit/031a7e833d12fb3b8b69fdb1e2bbad8c5d27e02e) all-cabal-hashes: 2024-02-12T23:23:22Z -> 2024-03-16T22:28:08Z
* [`4d47470e`](https://github.com/NixOS/nixpkgs/commit/4d47470ee02cecbbdb82dfe0d01a75e17ff6bd31) haskellPackages: regenerate package set based on current config
* [`7522f97c`](https://github.com/NixOS/nixpkgs/commit/7522f97cbef26c7ca6b15615ad2144730232dbe4) pantheon: Manage user session with systemd
* [`0b41a85c`](https://github.com/NixOS/nixpkgs/commit/0b41a85c95d15a72b9be9aca9d68d5dde46a1740) nixos/display-managers: Don't force graphical-session.target activation for Pantheon
* [`e49a58b8`](https://github.com/NixOS/nixpkgs/commit/e49a58b847a4eae91203cbaad128dc82c39f46e1) nixosTests.pantheon: Fix gala environ subtest
* [`a4bca9aa`](https://github.com/NixOS/nixpkgs/commit/a4bca9aaef02c625ffcb2c11322d7a87192ac33b) nixos/pantheon: Add missing gala-daemon systemd services
* [`bf2ba6e6`](https://github.com/NixOS/nixpkgs/commit/bf2ba6e62972d4f7fc1e788747344530089e5ece) nixosTests.pantheon: Add test for io.elementary.gala.daemon@x11.service
* [`fcf286b6`](https://github.com/NixOS/nixpkgs/commit/fcf286b6fa11a718eff17b2b0fe8032cba9cf932) haskellPackages: fix evaluation of configuration-ghc-9.8.x.nix
* [`ecc6829d`](https://github.com/NixOS/nixpkgs/commit/ecc6829d2f8c78956e99940ee6c8bd4f67901a98) python312Packages.keras-applications: normalize pname
* [`66cdc5f5`](https://github.com/NixOS/nixpkgs/commit/66cdc5f5d554025029dec01b25fcf4ea642a8570) python312Packages.keras-preprocessing: normalize pname
* [`dc423ccc`](https://github.com/NixOS/nixpkgs/commit/dc423ccc93ede691fc13fa8452a32bade66369c5) haskellPackages.csound-expression: Drop overrides because of new release
* [`476b362a`](https://github.com/NixOS/nixpkgs/commit/476b362a5dd5cc0c9e5b0917617495f1bdabcbda) haskell.packages.ghc98.haskell-language-server: Drop overrides
* [`7177f435`](https://github.com/NixOS/nixpkgs/commit/7177f435b8735a95ca86b532091f028bdee0ec23) python312Packages.modestmaps: normalize pname
* [`e2ec64ef`](https://github.com/NixOS/nixpkgs/commit/e2ec64eff0b072473f4e6eedbfb85ba9fd10acc4) haskell.packages.ghc98: Drop some overrides because they might be obsolete
* [`013cdb0c`](https://github.com/NixOS/nixpkgs/commit/013cdb0c0bb651567d2adb8f99d5f5aa3b4b2d16) haskellPackages: Remove obsolete overrides for hls dependencies
* [`83dc1376`](https://github.com/NixOS/nixpkgs/commit/83dc13764b53a930c0fba9dfa67964fc250a630d) python312Packages.mutatormath: normalize pname
* [`c6e364bf`](https://github.com/NixOS/nixpkgs/commit/c6e364bf4091ab650b49b1c67ea4789f0671fd40) python312Packages.netcdf4: normalize pname
* [`c52b0f1c`](https://github.com/NixOS/nixpkgs/commit/c52b0f1c7cb2a1522f5658341e1ca9fca0770f8b) haskellPackages.reflex-gi-gtk: Drop obsolete override
* [`53219eb5`](https://github.com/NixOS/nixpkgs/commit/53219eb55fc6bab6c1de3ef906f9662f89b2ce5f) haskellPackages.lsp: Drop backpins
* [`33614e92`](https://github.com/NixOS/nixpkgs/commit/33614e9200a64401c8913e46011ff208b03b032d) haskell.packages.gh98.hiedb: Drop hopefully obsolete dontCheck
* [`5bf82773`](https://github.com/NixOS/nixpkgs/commit/5bf82773b6cd00ead9c22a6cebb30e5eb134cef4) haskellPackages.portmidi-utility: Unsupported on darwin
* [`908f7245`](https://github.com/NixOS/nixpkgs/commit/908f72458a17ad12df49f1693af2f5c14f881f01) crunchy-cli: 3.2.5 -> 3.3.1
* [`cd8069c7`](https://github.com/NixOS/nixpkgs/commit/cd8069c733eb9df5146c3c112a7227a3fdc2c11b) haskellPackages.specup: unbreak
* [`e1f82f75`](https://github.com/NixOS/nixpkgs/commit/e1f82f75119cb95c0f16f170b86edf2e11278c11) python312Packages.pymeeus: normalize pname
* [`2da73a5a`](https://github.com/NixOS/nixpkgs/commit/2da73a5ac21e474721aeea06325bd99c3bfc8ddd) kdePackages.extra-cmake-modules: fix hook offset
* [`24509a75`](https://github.com/NixOS/nixpkgs/commit/24509a75242b1866cb4246b9920d306e97699d00) python312Packages.pyogg: normalize pname
* [`1fd69657`](https://github.com/NixOS/nixpkgs/commit/1fd6965780a4abb50139e42fa4a12b52ddc85870) python312Packages.pyplatec: normalize pname
* [`0fdc2486`](https://github.com/NixOS/nixpkgs/commit/0fdc24869b82896ff966dca261dd803e916d5db0) python312Packages.pyprind: normalize pname
* [`5903b9dd`](https://github.com/NixOS/nixpkgs/commit/5903b9dd62b0ba6045fe4d498032b05a4bed86c9) python312Packages.pyreaderwriterlock: normalize pname
* [`93b179bc`](https://github.com/NixOS/nixpkgs/commit/93b179bcabe962416ac77eef62c9a52d1d119fcb) python312Packages.pysc2: normalize pname
* [`9fa44aba`](https://github.com/NixOS/nixpkgs/commit/9fa44aba86767aa59f3f19641bf794d28f12d91d) python312Packages.pyspice: normalize pname
* [`d5847ac5`](https://github.com/NixOS/nixpkgs/commit/d5847ac508000a8632240de3bd4f825cf9212571) python312Packages.pysychonaut: normalize pname
* [`1db622de`](https://github.com/NixOS/nixpkgs/commit/1db622deab05863a1711e538f39cbee8cde223d8) haskellPackages.ShellCheck: remove patch
* [`8759d485`](https://github.com/NixOS/nixpkgs/commit/8759d4853fde8ba8c812267630166f54f027cac9) gwyddion: remove broken python support
* [`a89f27b4`](https://github.com/NixOS/nixpkgs/commit/a89f27b448809afc11e173877157250ee4e6d762) uni-sync: init at 0.2.0
* [`05901fba`](https://github.com/NixOS/nixpkgs/commit/05901fbaec6e00f9841f62da4bbd72b68096f763) nixos/uni-sync: init
* [`249b9513`](https://github.com/NixOS/nixpkgs/commit/249b9513d502834dd233c574e1536c694c7da7fb) nethack: update darwin hints file
* [`12ffb29d`](https://github.com/NixOS/nixpkgs/commit/12ffb29d61a5785a0aa62a17522ad7e47063ecd6) haskellPackages: regenerate package set based on current config
* [`c71f3556`](https://github.com/NixOS/nixpkgs/commit/c71f355699c070e6e2d13ca3dce9f2445e01cda3) haskellPackages: Fix eval warnings and errors
* [`10c80b99`](https://github.com/NixOS/nixpkgs/commit/10c80b993425f377c86c2bb36da9f10b79de6fe2) haskell-language-server: Enable master build on ghc 9.8
* [`30036c3d`](https://github.com/NixOS/nixpkgs/commit/30036c3d109caff4a1ff8597b57f9b6953b975f5) nixos/initrd-ssh: Add authorizedKeyFiles option
* [`bdb47597`](https://github.com/NixOS/nixpkgs/commit/bdb4759727c9f03b7e19396fd73d9a3a901eb060) haskellPackages.cpython: unbreak and add @⁠sheepforce as maintainer
* [`4f1964f7`](https://github.com/NixOS/nixpkgs/commit/4f1964f7c4fb615538fb9b01334eb304a5cdeb30) haskellPackages.double-conversion: fix broken patch
* [`12e62036`](https://github.com/NixOS/nixpkgs/commit/12e62036282f15163be3320ba2a98f12c22708a0) obs-studio-plugins.obs-source-clone: 0.1.4 -> 0.1.4-unstable-2024-02-19
* [`0b2e8638`](https://github.com/NixOS/nixpkgs/commit/0b2e86386fc22fbc0f612a914ecf9d820c3a3b22) maintainers: add rsniezek
* [`6e68974c`](https://github.com/NixOS/nixpkgs/commit/6e68974cf3c378dc0e91593f7331ed0ffbd537b5) maintainers: add kintrix
* [`f0bced10`](https://github.com/NixOS/nixpkgs/commit/f0bced1070836489cf118c553ac8f2e7cb290464) agdaPackages.agda-categories: remove heap size increase
* [`01738bd3`](https://github.com/NixOS/nixpkgs/commit/01738bd3bd77231a485e4ab1b99fa1caabeb75e5) fzf-git-sh: Fix substituting to many `git` occurrences
* [`d733d76b`](https://github.com/NixOS/nixpkgs/commit/d733d76b411a46e6ac8abf69538f128855f5c1d6) python312Packages.pynamecheap: normalize pname
* [`e7868a70`](https://github.com/NixOS/nixpkgs/commit/e7868a7023fa7b08e0229d4b22b38187a03dfbb4) python312Packages.pyscss: normalize pname
* [`0e035e2a`](https://github.com/NixOS/nixpkgs/commit/0e035e2a4f0ea017392f89e22512d0e13ed49c78) python312Packages.shapely_1_8: normalize pname
* [`ec4fe824`](https://github.com/NixOS/nixpkgs/commit/ec4fe8242f6d5ac2c55b620d5f611a1ce46ac655) python312Packages.twiggy: normalize pname
* [`b062a953`](https://github.com/NixOS/nixpkgs/commit/b062a95308a58c3f643254c1e91909912073e91e) python312Packages.txamqp: normalize pname
* [`f85b97c3`](https://github.com/NixOS/nixpkgs/commit/f85b97c3fb96eb3bd65bee850c86fbdcf36df803) python312Packages.pypdf2: normalize pname
* [`16426544`](https://github.com/NixOS/nixpkgs/commit/16426544536ddbe939e28b08d0b638ae78667dc6) agda: Remove the --local-interfaces flag
* [`b9343ad4`](https://github.com/NixOS/nixpkgs/commit/b9343ad4c63f7fb9b72690c018c1ff4a3650d2a4) agda: Don't be too picky about `everythingFile`
* [`a9846659`](https://github.com/NixOS/nixpkgs/commit/a9846659ccd93003cd33bde327bae5f16ffdf805) python312Packages.setuptools-dso: rename from setuptools_dso
* [`4a734cd7`](https://github.com/NixOS/nixpkgs/commit/4a734cd738a5b2c96311224a60461dc4689ad45a) delfin: 0.4.0 -> 0.4.2
* [`b2e89c6d`](https://github.com/NixOS/nixpkgs/commit/b2e89c6d53c499a55f4f78303c31f924067014cb) agdaPackages._1lab: 2023-12-04 -> 2024-03-07
* [`35c89f0f`](https://github.com/NixOS/nixpkgs/commit/35c89f0fbceb053d1492f836fc1b8514362d4fc5) gscreenshot: 3.4.2 -> 3.5.0
* [`feb6862d`](https://github.com/NixOS/nixpkgs/commit/feb6862d50589895b64d7749eb5beeb175d7d5fe) haskellPackages.minio-hs: Use crypton-connection instead of unmaintained connection
* [`fbd5aa08`](https://github.com/NixOS/nixpkgs/commit/fbd5aa08d98168614bc43b3dd0712745757139f6) haskellPackages.haskell-to-elm: Unbroken
* [`01ed0605`](https://github.com/NixOS/nixpkgs/commit/01ed0605969e9b43a1fd4d9c37c0424a651e278a) haskellPackages.smtp-mail: Use crypton-connection instead of unmainta… ([nixos/nixpkgs⁠#297123](https://togithub.com/nixos/nixpkgs/issues/297123))
* [`5fc2fba0`](https://github.com/NixOS/nixpkgs/commit/5fc2fba04491a9afadd22404ba8a7a7a5d5167de) haskellPackages: regenerate package set based on current config
* [`6a3ecb0f`](https://github.com/NixOS/nixpkgs/commit/6a3ecb0f6a13b7b6eef775596bcc16e49b817b31) poetryPlugins.poetry-plugin-poeblix: init at 0.10.0
* [`27f7ae49`](https://github.com/NixOS/nixpkgs/commit/27f7ae498975e66dcc1f6b4ee7bfc933e6f564cb) haskellPackages.massiv: unbreak pvar and massiv, add  @⁠sheepforce as maintainer
* [`d43e0309`](https://github.com/NixOS/nixpkgs/commit/d43e030972410a4d54040ca34019f60212ff0633) haskellPackages.pandoc: disable tests
* [`871aaab0`](https://github.com/NixOS/nixpkgs/commit/871aaab0d404125e3f5a29f6f0fe7fd5c1fa531d) haskellPackages.{irc-client,shake}: add ncfavier as maintainer
* [`0b9c5e20`](https://github.com/NixOS/nixpkgs/commit/0b9c5e20c9832df160986f9a2582263dc32b00ba) haskellPackages.raven-haskell: Unbreak on GHC9.8
* [`62232e8d`](https://github.com/NixOS/nixpkgs/commit/62232e8d7eab180c6c5a938e6ff10cce468869c2) wechat-uos: init at 1.0.0.238
* [`d85d0016`](https://github.com/NixOS/nixpkgs/commit/d85d0016cab19ea9289707c0e322128006920f45) haskell.packages.ghc98.ghc-exactprint: pin to 1.8
* [`aa0c4ac4`](https://github.com/NixOS/nixpkgs/commit/aa0c4ac441399c2a532911f0aeb10f047a3baa5a) haskellPackages: regenerate package set based on current config
* [`e1140ba5`](https://github.com/NixOS/nixpkgs/commit/e1140ba5263bb49fe95a9fd0dc49cf8364b11d93) haskellPackages.haskell-to-elm: remove generics-sop override
* [`b3d4e19a`](https://github.com/NixOS/nixpkgs/commit/b3d4e19a087a5b262ab0127902ca98d30d0381ef) maintainers: add j1nxie
* [`18e22e8b`](https://github.com/NixOS/nixpkgs/commit/18e22e8b13b5501c4d95e947718ebcda48e69d48) haskellPackages.haskell-to-elm: oops
* [`d5df84e3`](https://github.com/NixOS/nixpkgs/commit/d5df84e399955797503ecf8539d639cf6d3ac97c) haskellPackages.HaskellNet-SSL: Unbreak ([nixos/nixpkgs⁠#297148](https://togithub.com/nixos/nixpkgs/issues/297148))
* [`734c29c3`](https://github.com/NixOS/nixpkgs/commit/734c29c3d754d9e31a4e8ebaf78d0922dd3d7235) doge: 3.7.0 -> 3.8.0
* [`c360696d`](https://github.com/NixOS/nixpkgs/commit/c360696de9710f01e83d485eae8e6cb36a96db8b) hdfview: make deterministic
* [`2bc295aa`](https://github.com/NixOS/nixpkgs/commit/2bc295aae8326d48f76d3f6c55f6518ef6f39ba3) haskell.packages.ghc98.haskell-language-server: fix
* [`6cb851ca`](https://github.com/NixOS/nixpkgs/commit/6cb851cae864622bfa5a9609e909c29896c1bf27) hermitcli: 0.38.2 -> 0.39.0
* [`0b1ae7b3`](https://github.com/NixOS/nixpkgs/commit/0b1ae7b3c9dedfdc1f57bbb2f125200592efcdc7) retext: 8.0.1 -> 8.0.2
* [`d1a9032d`](https://github.com/NixOS/nixpkgs/commit/d1a9032d66a4e962c0674d35f936293aa489c180) jenkins-job-builder: 6.0.0 -> 6.1.0
* [`d9745239`](https://github.com/NixOS/nixpkgs/commit/d9745239170677aa52b332f83fcb4174061eb411) fido2luks: move to pkgs/by-name
* [`ac958b38`](https://github.com/NixOS/nixpkgs/commit/ac958b38f4db7c7d5a6663a343a5e35ee60bc719) lima-bin: 0.20.2 -> 0.21.0
* [`e8dcb276`](https://github.com/NixOS/nixpkgs/commit/e8dcb2763cdfa8d51ef2a702b4cc5fa0607a9890) memtest_vulkan: init at 0.5.0
* [`9a4adbf4`](https://github.com/NixOS/nixpkgs/commit/9a4adbf49639ba11b97a25213d54829872787898) haskellPackages.pattern-arrows: unbreak
* [`73aeb193`](https://github.com/NixOS/nixpkgs/commit/73aeb193869b5c0973c6ac0818b86415813e9312) haskellPackages.aeson-better-errors: unbreak
* [`569e3d27`](https://github.com/NixOS/nixpkgs/commit/569e3d277e0ca2bd714a15e8c76112433e8094eb) maintainers: add ByteSudoer
* [`eaf992fa`](https://github.com/NixOS/nixpkgs/commit/eaf992fa45136a6b695ae17128400b07d0899ee1) haskellPackages.cheapskate: unbreak
* [`8d66827a`](https://github.com/NixOS/nixpkgs/commit/8d66827a2d0e21c9a92d56e69b1d375ae82af560) haskellPackages: Add t4ccer as maintainer
* [`419d0caa`](https://github.com/NixOS/nixpkgs/commit/419d0caae4192688e0dadabb02daa7c161a30dcf) haskellPackages: regenerate package set based on current config
* [`f553e521`](https://github.com/NixOS/nixpkgs/commit/f553e52103a6c05dc01ba243f469d7e1572d5734) darcs: build with GHC 9.6
* [`fae0418b`](https://github.com/NixOS/nixpkgs/commit/fae0418b0490db863f1a9fa336c791e274b10152) haskellPackages: regenerate package set based on current config
* [`1dc0d9d2`](https://github.com/NixOS/nixpkgs/commit/1dc0d9d29bbd686079fde2b04c104ced5e024543) cilium-cli: 0.16.0 -> 0.16.3
* [`bb6858cd`](https://github.com/NixOS/nixpkgs/commit/bb6858cdabb183f20ddd4a47d9f1c71c0e5a1f76) irqbalance: 1.9.3 -> 1.9.4
* [`5988f8f8`](https://github.com/NixOS/nixpkgs/commit/5988f8f841d7fde752edf611cd0a9c2ea942b4bd) lib.systems: use explicit attrset instead of `rec`
* [`123a2f0f`](https://github.com/NixOS/nixpkgs/commit/123a2f0fcc96cc7828ef942a88d3608b55d6d81c) lib/systems: use lib.systems.parse and lib.systems.inspect.predicates instead of re-importing
* [`af634f14`](https://github.com/NixOS/nixpkgs/commit/af634f14baa740e26664a9643788a35b8385b437) lib/systems: inherit from lib.systems.parse in lib/systems/inspect.nix
* [`07d3270d`](https://github.com/NixOS/nixpkgs/commit/07d3270dbccfc520cc4ffc85e8dee5efe2fe1676) lib/systems: inherit from lib.systems.inspect.predicates in lib/systems/parse.nix
* [`c02fcc94`](https://github.com/NixOS/nixpkgs/commit/c02fcc946a1786cad114f9ec04686e19642b5f48) Avoid top-level `with ...;` in lib/systems/inspect.nix
* [`79ce46fe`](https://github.com/NixOS/nixpkgs/commit/79ce46fe49f27bf034f1d8792c92120018a50dc3) Avoid top-level `with ...;` in lib/systems/parse.nix
* [`29a46d28`](https://github.com/NixOS/nixpkgs/commit/29a46d28027016dc9dbed88b7258306b35662158) nixos/nvidia: Set SidebandSocketPath to a user-writable path in `/run`
* [`efa38182`](https://github.com/NixOS/nixpkgs/commit/efa38182497c2e2a955182094edc07f8445c91c6) poetryPlugins.poetry-plugin-export: 1.7.0 -> 1.7.1
* [`405ce27d`](https://github.com/NixOS/nixpkgs/commit/405ce27d019ad51facfe5fecaa8b3bb1ca23111c) tabbed: 0.7 -> 0.8
* [`028674c1`](https://github.com/NixOS/nixpkgs/commit/028674c11310ec9a1c48b3db82394ebd79859935) saml2aws: 2.36.13 -> 2.36.14
* [`46d4f4ec`](https://github.com/NixOS/nixpkgs/commit/46d4f4ece76c17ef006158e76bdf80202c47f127) dwm: 6.4 -> 6.5
* [`6e9f95b0`](https://github.com/NixOS/nixpkgs/commit/6e9f95b0859a763f48ccff6c33d7f3873b0869b4) atlauncher: 3.4.35.4 -> 3.4.35.9
* [`deb5be50`](https://github.com/NixOS/nixpkgs/commit/deb5be50c46fe9785fe56e8fdfff1a51c9017ef1) incus: move wrapper to nixos module
* [`99c0c32a`](https://github.com/NixOS/nixpkgs/commit/99c0c32a49132c38cc67aa992408d82c3ceee3d1) usbguard: fix policy enums
* [`1e2f8f2a`](https://github.com/NixOS/nixpkgs/commit/1e2f8f2a84f459719c5e9d33df9c9ed1cc31df41) stdenv/check-meta: Remove outputsToInstall list concat from common meta
* [`5ef1bd95`](https://github.com/NixOS/nixpkgs/commit/5ef1bd952c61299878cea030a1acb5b427504ae8) build-support/lib/cmake: Statically compute default cmake flags
* [`085c1723`](https://github.com/NixOS/nixpkgs/commit/085c1723480c7afb3d73a86b225f2353a04db6b0) build-support/lib/meson: Statically compute default meson flags
* [`9a14ffe5`](https://github.com/NixOS/nixpkgs/commit/9a14ffe5eee582099a4abeca26f26b42a5b12e9a) visualvm: 2.1.7 -> 2.1.8
* [`249369b0`](https://github.com/NixOS/nixpkgs/commit/249369b0dda5e47694efdb8bd7223bf2db72a8a1) strongswan: 5.9.13 -> 5.9.14
* [`fd4e4347`](https://github.com/NixOS/nixpkgs/commit/fd4e4347a43aec11c20c05f32a5c2c26c2eb7e23) tempo: 2.4.0 -> 2.4.1
* [`908f4e07`](https://github.com/NixOS/nixpkgs/commit/908f4e078955b61031328022d01405e557ccbc04) haskell.packages.ghc9{2,4}.primitive-addr: pin to 0.1.0.2
* [`eeaf1e7a`](https://github.com/NixOS/nixpkgs/commit/eeaf1e7ace7a9fe5511c9a072297825bd21eca23) pmtiles: 1.17.0 -> 1.19.1
* [`e9e0bda3`](https://github.com/NixOS/nixpkgs/commit/e9e0bda36adc0e376b29c2e3cb61eeb03434e338) mailctl: fix build
* [`3bcb5512`](https://github.com/NixOS/nixpkgs/commit/3bcb55122ffbd8504326610e5b72b9f0cf07dec4) suricata: 7.0.3 -> 7.0.4
* [`9e7236ee`](https://github.com/NixOS/nixpkgs/commit/9e7236eeaa509a8b1509101d12577653d9b3dac0) Add maintainer Lucas De Angelis
* [`7378927a`](https://github.com/NixOS/nixpkgs/commit/7378927aafcd4d5ac45c698ad8700e1ee6e5552e) fn-cli: 0.6.29 -> 0.6.30
* [`561eefec`](https://github.com/NixOS/nixpkgs/commit/561eefecdbbfc15efc5c90988d9685b0be551f9a) fused-effects: jailbreak and unbreak dependents
* [`0cbd598e`](https://github.com/NixOS/nixpkgs/commit/0cbd598e0c92d4324f6cb52fa97a112e9134945a) gramps: 5.1.6 -> 5.2.0
* [`bc40f51d`](https://github.com/NixOS/nixpkgs/commit/bc40f51d1a50d6027d285fe2b673656930812be8) dockerTools: discard closure reference in imageTag
* [`e2c5d4d1`](https://github.com/NixOS/nixpkgs/commit/e2c5d4d11cd13628e5ea9e8d40d97b5678360275) optifine: 1.20.1_HD_U_I6 -> 1.20.4_HD_U_I7
* [`60b53db2`](https://github.com/NixOS/nixpkgs/commit/60b53db2614f81d0cc3e36e1c8873e6c14a0d252) unciv: 4.10.19 -> 4.10.21
* [`beff2b4c`](https://github.com/NixOS/nixpkgs/commit/beff2b4c799e2776f10a00d9ab4521f6b2d61aac) neo4j: 5.18.0 -> 5.18.1
* [`1124b563`](https://github.com/NixOS/nixpkgs/commit/1124b563ccef25c37549eded5499123b10598d3d) git-annex: Bump source hash
* [`7c668395`](https://github.com/NixOS/nixpkgs/commit/7c668395e41a9057d42986bf78e93bbd8bc09b96) haskellPackages.eventlog2html: Add patch
* [`11075319`](https://github.com/NixOS/nixpkgs/commit/11075319f28b5fc85c095c96e9538e5313f2fb9b) init vidmerger at 0.3.2
* [`8fbff694`](https://github.com/NixOS/nixpkgs/commit/8fbff694dc026378011ce5fceaf087a909d8141f) mongodb-compass: 1.42.2 -> 1.42.3
* [`4835f1ca`](https://github.com/NixOS/nixpkgs/commit/4835f1ca1cdeb1d504b316391d109df090469137) libucl: 0.9.0 -> 0.9.1
* [`ba193b44`](https://github.com/NixOS/nixpkgs/commit/ba193b442db0ff99a8fe873021823889bde32f96) fend: 1.4.3 -> 1.4.5
* [`9cf31fa3`](https://github.com/NixOS/nixpkgs/commit/9cf31fa3d38c35fadddb8a0808f43586be386b9e) ocenaudio: 3.13.4 -> 3.13.5
* [`7c6425a2`](https://github.com/NixOS/nixpkgs/commit/7c6425a21af9cf1f828e14a83064246d228b244c) openvpn: 2.6.9 -> 2.6.10
* [`32f2120b`](https://github.com/NixOS/nixpkgs/commit/32f2120b01d44d004c9ecbfbea25fe6367031c85) uhdm: 1.80 -> 1.82
* [`ebdf6a1d`](https://github.com/NixOS/nixpkgs/commit/ebdf6a1d1e084bd73bc4123226ba5e700e8a1f5e) lib.licenses: added The commons clause license
* [`d1095978`](https://github.com/NixOS/nixpkgs/commit/d109597875fd64f4f13e6d898a0a62180e81e33a) highlight: 4.10 -> 4.11
* [`e66ede95`](https://github.com/NixOS/nixpkgs/commit/e66ede958e3db470627978959810534185b75209) nixos/fcitx5: stop using renamed option services.xserver.desktopManager.plasma6.enable
* [`0a17d00c`](https://github.com/NixOS/nixpkgs/commit/0a17d00c913bef3988f92b887a6797febf07f7ab) pythia: 8.310 -> 8.311
* [`34c2feed`](https://github.com/NixOS/nixpkgs/commit/34c2feed70aaaba582bc9ea65cadadb014322232) mailpit: 1.13.1 -> 1.15.0
* [`480989ea`](https://github.com/NixOS/nixpkgs/commit/480989eab740cfde03a62d4291780e41961fb5be) runelite: 2.6.13 -> 2.7.1
* [`7e0c9fa4`](https://github.com/NixOS/nixpkgs/commit/7e0c9fa4eedbb89fe37027d6f8bd211156c942f1) python311Packages.comm: 0.2.1 -> 0.2.2
* [`eedaca8e`](https://github.com/NixOS/nixpkgs/commit/eedaca8ef1b08b201c1cf135e19488b69f4ba5ad) update license: added the common clause license
* [`89ea04dc`](https://github.com/NixOS/nixpkgs/commit/89ea04dc7091bc9bf3ffe4be19205706b14e8fdc) Update licenses.nix
* [`dcdcfdd5`](https://github.com/NixOS/nixpkgs/commit/dcdcfdd5773193835d25f51f6004fe7c2fdb47a8) maintainers: add takac
* [`60d35e05`](https://github.com/NixOS/nixpkgs/commit/60d35e0522add19ee4d5de0ee330350624ea2b8e) python311Packages.hatch-jupyter-builder: 0.8.3 -> 0.9.1
* [`99af2cb7`](https://github.com/NixOS/nixpkgs/commit/99af2cb71ce964e4ca9b34443b7ac79aaa009301) python311Packages.ipyvuetify: 1.9.1 -> 1.9.2
* [`6f0641a5`](https://github.com/NixOS/nixpkgs/commit/6f0641a5bbc6287763b8b0900015c6d2b5632134) python311Packages.jupyter-client: 8.6.0 -> 8.6.1
* [`2cc49d75`](https://github.com/NixOS/nixpkgs/commit/2cc49d7508551aca3c11ef922bc50333b2f8f312) python311Packages.jupyter-collaboration: 2.0.4 -> 2.0.5
* [`b97116d5`](https://github.com/NixOS/nixpkgs/commit/b97116d5586467482701e6ac0f81c64ae6c5ad14) python311Packages.jupyter-core: 5.7.1 -> 5.7.2
* [`6c71c0a5`](https://github.com/NixOS/nixpkgs/commit/6c71c0a5bf7739cfd3898bb26d2a0506e9409dd0) python311Packages.jupyter-events: 0.9.0 -> 0.10.0
* [`02bc1253`](https://github.com/NixOS/nixpkgs/commit/02bc12538d4c1296b933c0ec8b6d3472b64c9cdb) python311Packages.jupyter-server-terminals: 0.5.2 -> 0.5.3
* [`6b0c0bbc`](https://github.com/NixOS/nixpkgs/commit/6b0c0bbc9ddad7ca59b427bf290f4e88219d65b2) python311Packages.jupyterhub: 4.0.2 -> 4.1.0
* [`cc527f26`](https://github.com/NixOS/nixpkgs/commit/cc527f268e9d7174d65c800c2ebafc8ff6c5bff7) python311Packages.jupyterlab: 4.1.4 -> 4.1.5
* [`a67ee476`](https://github.com/NixOS/nixpkgs/commit/a67ee476484e1bed4462c5f78d97d83e87f6b763) python311Packages.nbclient: 0.9.0 -> 0.10.0
* [`f64ad2e3`](https://github.com/NixOS/nixpkgs/commit/f64ad2e39887f8e6b45ea25152705114a8409594) python311Packages.nbformat: 5.9.2 -> 5.10.3
* [`59e5aea0`](https://github.com/NixOS/nixpkgs/commit/59e5aea080b09bcc12d9e0b6905a528afbea033c) python311Packages.notebook: 7.1.1 -> 7.1.2
* [`86712c60`](https://github.com/NixOS/nixpkgs/commit/86712c60451089631f5801ae6d827fcca564c25a) python311Packages.oauthenticator: 16.2.1 -> 16.3.0
* [`e570d5d5`](https://github.com/NixOS/nixpkgs/commit/e570d5d535fea9a198b3f5620938ce56e5d42241) python311Packages.pytest-jupyter: 0.9.0 -> 0.9.1
* [`a7336def`](https://github.com/NixOS/nixpkgs/commit/a7336def2a2c98732bf686daee3d3b5b1d79bb27) codeql: 2.16.4 -> 2.16.5
* [`564c3749`](https://github.com/NixOS/nixpkgs/commit/564c3749d90b865df2b978482659d73fe7ee2e7c) nixos/users-groups: fix broken linger
* [`e8177a92`](https://github.com/NixOS/nixpkgs/commit/e8177a92b36624a271243875293574e9dbc23251) decker: 1.39 -> 1.41
* [`76a44b3c`](https://github.com/NixOS/nixpkgs/commit/76a44b3c4a7f4296fdbabe2ad67df750c3856cbe) normaliz: 3.10.1 -> 3.10.2
* [`a28cab87`](https://github.com/NixOS/nixpkgs/commit/a28cab879f70bada7f71432ccf3b7ed0ce177e12) python312Packages.shapely_1_8: set pyproject
* [`38eb40b7`](https://github.com/NixOS/nixpkgs/commit/38eb40b7f18ea6377967f06b715c8ef2649e5e91) dataexplorer: make deterministic and clean up
* [`36263f5c`](https://github.com/NixOS/nixpkgs/commit/36263f5cd1e0feea56138ce79871577073f4bce1) libation: 11.3.1 -> 11.3.6
* [`20155eee`](https://github.com/NixOS/nixpkgs/commit/20155eee75e20e81513785ceb68af59902edf937) futhark: build with zlib-0.7.0.0
* [`70a00dff`](https://github.com/NixOS/nixpkgs/commit/70a00dffc8988359e1f877c269b9fd6c8a22be70) jacinda: provide alex-3.5.1.0 as requested
* [`8944725b`](https://github.com/NixOS/nixpkgs/commit/8944725b1e4512c00f5cc2a2c79d6030713e7175) subxt: 0.34.0 -> 0.35.0
* [`2f08b495`](https://github.com/NixOS/nixpkgs/commit/2f08b4959bdae757261f2395d0895ebbe6176420) boundary: 0.15.2 -> 0.15.3
* [`790fb86a`](https://github.com/NixOS/nixpkgs/commit/790fb86a7f46dff6c89445fe332aee5b9740e19b) nixos/users-groups: move linger to oneshot and add nixos test
* [`a649e0e5`](https://github.com/NixOS/nixpkgs/commit/a649e0e5f75b2186b8a802ec9f58deadea7af7f0) fflas-ffpack: mark as unbroken on darwin
* [`178fe4e1`](https://github.com/NixOS/nixpkgs/commit/178fe4e17f85295c738e128640e7e34aceb21154) m4rie: fix build on aarch64-darwin
* [`088d5a98`](https://github.com/NixOS/nixpkgs/commit/088d5a98c6346a3f9956a81e68e86a216f47ffb9) glasskube: 0.0.4 -> 0.1.0
* [`2d9761c7`](https://github.com/NixOS/nixpkgs/commit/2d9761c7362d1018213d5923ed3209a357a72219) avalanchego: 1.11.2 -> 1.11.3
* [`d5b4c50a`](https://github.com/NixOS/nixpkgs/commit/d5b4c50a2f6b7fa859cb36365c9ac2aa59ff2ac5) mendeley: 2.110.2 -> 2.111.0
* [`1a7ea453`](https://github.com/NixOS/nixpkgs/commit/1a7ea453d7721859d149ba7be9fc57a54a445063) tachyon: build on aarch64-darwin
* [`c8d30c0a`](https://github.com/NixOS/nixpkgs/commit/c8d30c0af9f4b2be3918694b8a9132a235ae975c) sage: drop flintqs
* [`69c71fc6`](https://github.com/NixOS/nixpkgs/commit/69c71fc6835785ffef9e5ebe05abf4485ee3819c) givaro: fix clang build
* [`909b7ce7`](https://github.com/NixOS/nixpkgs/commit/909b7ce7bb691d52e4894c1f21606064171643de) gfan: fix clang build
* [`4d795950`](https://github.com/NixOS/nixpkgs/commit/4d7959506e74a610fda1273709dde2451782b1b7) rubiks: fix clang build
* [`b3c46584`](https://github.com/NixOS/nixpkgs/commit/b3c465849172a7c941510f852d5190383d473368) vscode-extensions.astro-build.astro-vscode: 2.3.3 -> 2.8.3
* [`ed061a50`](https://github.com/NixOS/nixpkgs/commit/ed061a50724ef618a18af645e7d50ad34f069167) libnabo: 1.1.0 -> 1.1.1
* [`c5dc5619`](https://github.com/NixOS/nixpkgs/commit/c5dc5619a2d8dc2a90f008ed260198ffdfb2e675) vscode-extensions.svelte.svelte-vscode: 107.12.0 -> 108.3.3
* [`1d45945b`](https://github.com/NixOS/nixpkgs/commit/1d45945b3319554d8d72bbac2a47d41ae4ff3055) microsoft-identity-broker: 1.7.0 -> 2.0.0
* [`9a05581e`](https://github.com/NixOS/nixpkgs/commit/9a05581e2cf80d656e00abc17bb65b42e1eb9fc1) pixi: 0.15.2 -> 0.17.1
* [`b0e0783e`](https://github.com/NixOS/nixpkgs/commit/b0e0783ed5e4dda555716ec81f16a9b61c19a203) space-cadet-pinball: 2.0.1 -> 2.1.0
* [`8871be39`](https://github.com/NixOS/nixpkgs/commit/8871be39b15763ded437771e21ca936d85f1ad0e) mpvScripts.modernx: init at 0.6.0
* [`ac1be15e`](https://github.com/NixOS/nixpkgs/commit/ac1be15e00dfb1de9c9b8d56a27ec3860daf29f3) mpvScripts.modernx-zydezu: init at 0.2.8
* [`320550f1`](https://github.com/NixOS/nixpkgs/commit/320550f17a213a44724a7699823bf42729e956ea) mpvScripts.mpv-osc-modern: init at 1.1.1
* [`a351f3ec`](https://github.com/NixOS/nixpkgs/commit/a351f3ecaa950408371b5a279d21b1db452eeb44) memtree: unstable-2024-01-04 -> 0-unstable-2024-01-04
* [`8695511c`](https://github.com/NixOS/nixpkgs/commit/8695511c0c924444b919082e891c1a785e7fb18f) tflint-plugins.tflint-ruleset-google: 0.26.0 -> 0.27.1
* [`a2d3d02a`](https://github.com/NixOS/nixpkgs/commit/a2d3d02ac7181a13a4a1f3fc6a711400a56975d1) odp-dpdk: 1.42.0.0_DPDK_22.11 -> 1.44.0.0_DPDK_22.11
* [`3bde60c0`](https://github.com/NixOS/nixpkgs/commit/3bde60c0e39924d353203f9fb3513f55448dab20) haskell-ci: build with pinned ShellCheck == 0.9.0
* [`ae679c40`](https://github.com/NixOS/nixpkgs/commit/ae679c40db95f5531e80ef1b46f791f1e320be8f) tamarin-prover: pick patch for Stackage LTS 22 dependencies
* [`26e23b18`](https://github.com/NixOS/nixpkgs/commit/26e23b1899c55de7b920a3607d267d4b80cc5e5d) haskellPackages.type-errors: fix build ([nixos/nixpkgs⁠#297432](https://togithub.com/nixos/nixpkgs/issues/297432))
* [`28a98de4`](https://github.com/NixOS/nixpkgs/commit/28a98de40e3878f45941a8691fe8fccc58179d35) ferretdb: 1.20.1 -> 1.21.0
* [`9a3cd10a`](https://github.com/NixOS/nixpkgs/commit/9a3cd10ad14b60a39f72d8814fade22bd5ab017c) blueprint-compiler: 0.10.0 -> 0.12.0
* [`51adef6f`](https://github.com/NixOS/nixpkgs/commit/51adef6fc88c061726ac9f93e52c57f45da1ee81) yaru-theme: 23.10.0 -> 24.04.0
* [`a69b7b56`](https://github.com/NixOS/nixpkgs/commit/a69b7b563b69627025434d9c6e653c861069217a) gerrit: 3.9.1 -> 3.9.2
* [`d8bfc220`](https://github.com/NixOS/nixpkgs/commit/d8bfc22089b397f4dff8d446609ee97ee5ae5a5f) android-tools: 34.0.4 -> 34.0.5
* [`9e48631e`](https://github.com/NixOS/nixpkgs/commit/9e48631eb9d2c152fb4f07a0ac80901decc33a1f) vintagestory: 1.19.4 -> 1.19.5
* [`1ac8e42f`](https://github.com/NixOS/nixpkgs/commit/1ac8e42f7743d7d2e4cd471eee00fdaccf0eca77) python311Packages.llama-parse: 0.3.9 -> 0.4.0
* [`996f1be8`](https://github.com/NixOS/nixpkgs/commit/996f1be880ba684d8f55c6729b72548f08fd1293) python311Packages.llama-parse: refactor
* [`0a310fc3`](https://github.com/NixOS/nixpkgs/commit/0a310fc3c4b4a35f3e3941f6b35aefe0db2a244b) github-desktop 3.3.6 -> 3.3.10
* [`730e570c`](https://github.com/NixOS/nixpkgs/commit/730e570c2990dcd722936aaa6c986ff8335364d2) ryujinx: 1.1.1239 -> 1.1.1242
* [`b485d07e`](https://github.com/NixOS/nixpkgs/commit/b485d07e84f908f14afcc702fbd247a3e0408efd) prometheus-nextcloud-exporter: 0.6.2 -> 0.7.0
* [`cc364c7a`](https://github.com/NixOS/nixpkgs/commit/cc364c7ac9c6f71c81b64a0c503bc1f44a2c0fed) local-ai: Build go modules as separate package and fix tts
* [`9229eb6e`](https://github.com/NixOS/nixpkgs/commit/9229eb6e7e9626ddddbd6c977ecbce6deb0baa96) messer-slim: 4.1 -> 4.2
* [`b594e2e3`](https://github.com/NixOS/nixpkgs/commit/b594e2e328f69a9e7932a62375f1a2c233a2eb89) micronaut: 4.3.6 -> 4.3.7
* [`3585b626`](https://github.com/NixOS/nixpkgs/commit/3585b62658d9389dbaac1997bca37a37b8711279) vitess: 18.0.2 -> 19.0.1
* [`58509993`](https://github.com/NixOS/nixpkgs/commit/5850999312f98600a7f83e14f45963d90f53d2cc) etcd_3_5: add update script
* [`dd7b21c9`](https://github.com/NixOS/nixpkgs/commit/dd7b21c96732eb68ce1c7dfc65ac02936b0e5a52) etcd_3_5: add superherointj as maintainer
* [`eca35aef`](https://github.com/NixOS/nixpkgs/commit/eca35aef770c2c00d1aefc853af120ae4b448c1d) vulkan-cts: 1.3.7.3 -> 1.3.8.1
* [`f0991413`](https://github.com/NixOS/nixpkgs/commit/f0991413e3348dcc13dac2c0c34566e1620b8749) spleen: 2.0.2 -> 2.1.0
* [`009ccf2c`](https://github.com/NixOS/nixpkgs/commit/009ccf2ce760d27ead3b97faa264e25fb52a6ac7) questdb: 7.3.10 -> 7.4.0
* [`d2ccd0b5`](https://github.com/NixOS/nixpkgs/commit/d2ccd0b5be5e7d3682d5cccde00025bd7c4b6c13) aprx: init at 2.9.1-unstable-2021-09-21
* [`f1bb72c4`](https://github.com/NixOS/nixpkgs/commit/f1bb72c4819bf90e5bd59c73275a64cbadc9e7f7) python311Packages.gradio-clients: 0.10.1 -> 0.14.0
* [`d5447ea7`](https://github.com/NixOS/nixpkgs/commit/d5447ea7509e3cb2ae8c2402961a87cd0139082b) backgroundremover: init at 0.2.6
* [`b7cdcb35`](https://github.com/NixOS/nixpkgs/commit/b7cdcb35cbf714de1d5f51c20b92d9a7c20aacfd) postgresqlPackages.pg_libversion: init at 2.0.0
* [`c27a1d2f`](https://github.com/NixOS/nixpkgs/commit/c27a1d2fac82c6502fdc4b33e38c21091e3e86ab) tinygo: 0.31.1 -> 0.31.2
* [`e2e43f6c`](https://github.com/NixOS/nixpkgs/commit/e2e43f6ce75044a353c3846e00840ac17cf5440e) nixos/systemd/initrd: make systemd mount root as rw if gpt-auto is set
* [`3f4d0561`](https://github.com/NixOS/nixpkgs/commit/3f4d0561dbe964686411c383570421170093eeb7) pspp: 2.0.0 -> 2.0.1
* [`1c9ad9d3`](https://github.com/NixOS/nixpkgs/commit/1c9ad9d3eb853cde96a18e4dfbcf1f293cad1efa) aspectj: 1.9.21 -> 1.9.21.2
* [`268d627d`](https://github.com/NixOS/nixpkgs/commit/268d627db6fb89df3315c0b483c2b9edc31d6908) nco: 5.2.1 -> 5.2.2
* [`7cd602ea`](https://github.com/NixOS/nixpkgs/commit/7cd602eab411775a3129f82b647f04b94226e61c) open-vm-tools: 12.3.5 -> 12.4.0
* [`187c8cd3`](https://github.com/NixOS/nixpkgs/commit/187c8cd37ca3e785d9991bff0a6776cb8db0cdbc) zulip: 5.10.5 → 5.11.0
* [`341f75d8`](https://github.com/NixOS/nixpkgs/commit/341f75d8f39e71ef97210460922e7c7a4860ddf2) miniupnpd: 2.3.5 -> 2.3.6
* [`3a5873a3`](https://github.com/NixOS/nixpkgs/commit/3a5873a32e8e3bea265673002caa79b9a0ca9032) fwupd-efi: 1.4 -> 1.5
* [`8e2bf517`](https://github.com/NixOS/nixpkgs/commit/8e2bf517ccb3e76170c0690f1a5f69bcf016aa37) sqldef: 0.16.15 -> 0.17.1
* [`b4e3816f`](https://github.com/NixOS/nixpkgs/commit/b4e3816f544b140f00b433fda4ed76e53705c207) swww: 0.8.2 -> 0.9.1
* [`faede06e`](https://github.com/NixOS/nixpkgs/commit/faede06ebb62811a43c34e379ac698efacc49d2c) libcloudproviders: 0.3.5 -> 0.3.6
* [`3a20259f`](https://github.com/NixOS/nixpkgs/commit/3a20259f1a664a6fb8e5a589837c5b254e3879cb) nwg-displays: 0.3.14 -> 0.3.16
* [`bb309ecb`](https://github.com/NixOS/nixpkgs/commit/bb309ecb70340e9c040d1e6259df3b5c81a12373) python311Packages.mkdocs-material: 9.5.14 -> 9.5.15
* [`f99f5b44`](https://github.com/NixOS/nixpkgs/commit/f99f5b440950bd80567602f3adf68a4323b698ae) python39: 3.9.18 -> 3.9.19
* [`ffdc7661`](https://github.com/NixOS/nixpkgs/commit/ffdc76613b4771c294097b4e78df626684ba875a) python310: 3.10.13 -> 3.10.14
* [`d41c24a0`](https://github.com/NixOS/nixpkgs/commit/d41c24a011f28471a7cfbc13f338297c27fd7e61) gpg-tui: 0.10.0 -> 0.11.0
* [`cff3d4db`](https://github.com/NixOS/nixpkgs/commit/cff3d4db9700d3722bd39153195b93511f08277d) gpg-tui: Add meta.mainProgram
* [`9c967fef`](https://github.com/NixOS/nixpkgs/commit/9c967fef3244b41c9c9e6554814b9783ad859dff) kraft: 0.7.5 -> 0.7.14
* [`152f8696`](https://github.com/NixOS/nixpkgs/commit/152f8696a6b0ddf01013d12c7ec1df1eb33a6e64) upbound: 0.24.2 -> 0.26.0
* [`d5f8aa51`](https://github.com/NixOS/nixpkgs/commit/d5f8aa51b9e6f0c2e82de4b106d70b223c7e533a) local-ai: use cmake for whisper-cpp
* [`f2137e11`](https://github.com/NixOS/nixpkgs/commit/f2137e117500435e5e24c07e6ffcd03265e67d64) minio: 2024-03-10T02-53-48Z -> 2024-03-15T01-07-19Z
* [`b79cc961`](https://github.com/NixOS/nixpkgs/commit/b79cc961fe98b158ea051ae3c71616872ffe8212) haskell.packages.ghc{810,90}.primitive-addr: lift lower base bound
* [`75924f72`](https://github.com/NixOS/nixpkgs/commit/75924f72d92e4d6607e79cf8e3caf9019dc153a9) dmalloc: init at 5.6.5
* [`e15c4cb4`](https://github.com/NixOS/nixpkgs/commit/e15c4cb4652b5d7b6282e8bf063d83a8ca91c37a) wayfire: 0.8.0 -> 0.8.1
* [`af4164cb`](https://github.com/NixOS/nixpkgs/commit/af4164cb914d12090b11a481190060b6b881e9cf) handbrake: 1.6.1 -> 1.7.3
* [`c774347c`](https://github.com/NixOS/nixpkgs/commit/c774347c25bf4c7e0a47e84dcbe18ca2bb9363a6) haskell.compiler.ghcHEAD: 9.9.20231121 -> 9.11.20240323
* [`fb6044c8`](https://github.com/NixOS/nixpkgs/commit/fb6044c8d2624261522becdaebf8ab280ccd8cf3) igir: 2.5.2 -> 2.6.0
* [`772278e4`](https://github.com/NixOS/nixpkgs/commit/772278e4b84519ff9d1d5087cba1cfbd672eda3e) atasm: 1.09 -> 1.23, move to an active fork
* [`b06adf8b`](https://github.com/NixOS/nixpkgs/commit/b06adf8b0155778283a8c2b533be826304684977) jibri: 8.0-160-g5af7dd7 -> 8.0-169-g1258814
* [`a26fa45c`](https://github.com/NixOS/nixpkgs/commit/a26fa45c8028180d4cc18608bf4f1804606d5f21) docuum: init at 0.23.1
* [`aa712c92`](https://github.com/NixOS/nixpkgs/commit/aa712c9252586ac6d49248a92b4d71cbd80ff57e) home-manager: unstable-2024-03-19 -> unstable-2024-03-22
* [`94d6d4e9`](https://github.com/NixOS/nixpkgs/commit/94d6d4e93a3ce6b467d4b165aa74a71482d344e3) nixos/docuum: add module for docuum package
* [`808d9f9f`](https://github.com/NixOS/nixpkgs/commit/808d9f9ffb64d910e8b847f2db41e466c1603a14) local-ai: use cmake to install grpc-server
* [`3a14bff9`](https://github.com/NixOS/nixpkgs/commit/3a14bff91f6b180ee64d70e6eca4eee7b0cc02d6) local-ai: add feature flags for CPU extensions
* [`768b6a7b`](https://github.com/NixOS/nixpkgs/commit/768b6a7b81063b283084ceeb711f975012ac51a7) fits-cloudctl: 0.12.16 -> 0.12.17
* [`a8853c6b`](https://github.com/NixOS/nixpkgs/commit/a8853c6b021b434a5400756fec519d1c5bf4c9d7) local-ai: reuse derivation ncnn for go-tiny-dream
* [`6a1496d9`](https://github.com/NixOS/nixpkgs/commit/6a1496d966bafdc865ea979f46161fb32c90e7e4) waylyrics: 0.2.12 -> 0.2.13
* [`0b2963c4`](https://github.com/NixOS/nixpkgs/commit/0b2963c4aaff606354d0741cddc5182f27f7ef00) sqlfluff: 3.0.2 -> 3.0.3
* [`2b075b0a`](https://github.com/NixOS/nixpkgs/commit/2b075b0a2b5908b305acc099aa170ce0850e043c) gmsh: 4.11.1 -> 4.12.2
* [`eea28288`](https://github.com/NixOS/nixpkgs/commit/eea28288d03100d1018b9db47498728a1153ac15) instawow: 3.2.0 -> 3.3.0
* [`4e3f9394`](https://github.com/NixOS/nixpkgs/commit/4e3f93947b22875334cbb7505c4af238f26a583d) signalbackup-tools: 20240319 -> 20240320
* [`91f46a15`](https://github.com/NixOS/nixpkgs/commit/91f46a155121f4d88c4e80aeb0da4ecb7c2470a6) libdwarf_20210528: drop
* [`960c144f`](https://github.com/NixOS/nixpkgs/commit/960c144f167f46380ff1d7808f65696ac6bd0d3d) kubectl-view-secret: 0.11.0 -> 0.12.0
* [`56b4159e`](https://github.com/NixOS/nixpkgs/commit/56b4159e234d92f6aedfc201de3a7b6df1be30d1) nixos/tests/k3s: sync meta.maintainers to k3s package
* [`82dfd3cd`](https://github.com/NixOS/nixpkgs/commit/82dfd3cdd95855a16fb0522f23543e636cc52fee) k3s: add superherointj as maintainer
* [`06c30f68`](https://github.com/NixOS/nixpkgs/commit/06c30f68c602e9a460c58e4e0f04a762ff2fa1b7) niv: wrap binary supplying runtime nix dependency in PATH
* [`93c638d4`](https://github.com/NixOS/nixpkgs/commit/93c638d405d1d6bd86eabcd3eec8497e2bc77895) fsverity-utils: 1.5 -> 1.6
* [`24ebdb1b`](https://github.com/NixOS/nixpkgs/commit/24ebdb1b060f5de85ef5468574ea784004ebd31e) haskellPackages.mmark-ext: unbreak on ghc9.8
* [`e33b7e1b`](https://github.com/NixOS/nixpkgs/commit/e33b7e1bad11049a75141be8971b2dcd6800393b) oci-cli: install shell completion
* [`ef0ed768`](https://github.com/NixOS/nixpkgs/commit/ef0ed76841855b401ab67a81d7dd4f6e1f2fd705) regclient: add shell completions and fix version output
* [`8c7aa803`](https://github.com/NixOS/nixpkgs/commit/8c7aa803dac4761781e423752c36aa5da173786d) stylelint: 16.2.1 -> 16.3.0
* [`c1153cb0`](https://github.com/NixOS/nixpkgs/commit/c1153cb0070ad895bfe2f641d5f03ecf237b6aa4) pipx: disable failing test
* [`dddb894f`](https://github.com/NixOS/nixpkgs/commit/dddb894fd1cf2470ad09dc5154e06e23861c2475) pipx: refactor
* [`aa1f35a4`](https://github.com/NixOS/nixpkgs/commit/aa1f35a41cae0ea89492c04c95a3e1ea44504e12) beeper: 3.100.26 -> 3.101.24
* [`5cd992be`](https://github.com/NixOS/nixpkgs/commit/5cd992bea02feb4de02bd84f6fd472fa854cc071) local-ai: buildGoModules do not allow to use buildFlags
* [`dacf3de5`](https://github.com/NixOS/nixpkgs/commit/dacf3de5aa5e5a9de6385d400db8bf89baa89b86) maintainers: Add dghubble
* [`03344be9`](https://github.com/NixOS/nixpkgs/commit/03344be9865efc998f6e7fa338bfe25687f584d3) matchbox-server: init at v0.11.0
* [`d799001c`](https://github.com/NixOS/nixpkgs/commit/d799001cdf47b47524fd6d93f5a5dabe11db08c3) python312Packages.google-ai-generativelanguage: 0.5.4 -> 0.6.0
* [`74afe609`](https://github.com/NixOS/nixpkgs/commit/74afe6096f2929f30c5795b3937d7eb6c9645600) python312Packages.google-ai-generativelanguage: refactor
* [`b8782a70`](https://github.com/NixOS/nixpkgs/commit/b8782a707b0e2cab3caf4b6d9fb06d5b9598adcf) geoserver: 2.24.2 -> 2.25.0
* [`3a8e8369`](https://github.com/NixOS/nixpkgs/commit/3a8e8369a67cb68e0e267413c36d997e9e3f670c) envfs: 1.0.3 -> 1.0.6
* [`762fa71d`](https://github.com/NixOS/nixpkgs/commit/762fa71dcee420e2b956352d10979197b0733f69) ntfs2btrfs: init at 20240115
* [`a87fb0b8`](https://github.com/NixOS/nixpkgs/commit/a87fb0b8d26bb984ae2f8a898bdc04ce25281856) maintainers: add stv0g
* [`3ed42083`](https://github.com/NixOS/nixpkgs/commit/3ed420832799a01b99932a0a459baf15deb56743) quickwit: 0.6.4 -> 0.8.0
* [`ba4ee667`](https://github.com/NixOS/nixpkgs/commit/ba4ee6679877dbcdfa5f1415debf9d9f8f3c962f) docker-credential-gcr: add passthru.updateScript
* [`4b012709`](https://github.com/NixOS/nixpkgs/commit/4b012709cd69687ea2f4ec073d4943c2d8d8224d) docker-credential-gcr: 2.1.8 -> 2.1.22
* [`57dc687f`](https://github.com/NixOS/nixpkgs/commit/57dc687f2f2ad250390776f899aaf32be74faf87) docker-credential-gcr: add anthonyroussel to maintainers
* [`332ebc60`](https://github.com/NixOS/nixpkgs/commit/332ebc60b09516bd8798210f4de630c1486528ac) docker-credential-gcr: move to pkgs/by-name
* [`d964e7ac`](https://github.com/NixOS/nixpkgs/commit/d964e7ac2aeb781f6a725df0238faac0bbe18007) python311Packages.es-client: 8.12.5 -> 8.12.8
* [`ef35305c`](https://github.com/NixOS/nixpkgs/commit/ef35305c3bf36121323ab272af6ece231f5c20f1) elasticsearch-curator: add passthru.{tests.version,updateScript}
* [`303ec902`](https://github.com/NixOS/nixpkgs/commit/303ec90277b42e2d08611f7aa23fa852f2d1cc57) elasticsearch-curator: 8.0.10 -> 8.0.12
* [`2ac8d672`](https://github.com/NixOS/nixpkgs/commit/2ac8d67212c46e60f8383bed96a107c9cd309e48) elasticsearch-curator: move to by-name
* [`f182ef3a`](https://github.com/NixOS/nixpkgs/commit/f182ef3a4f7735594d7b46dfa000878d5aaa2611) cloudfoundry-cli: 8.7.8 -> 8.7.9
* [`a78abbad`](https://github.com/NixOS/nixpkgs/commit/a78abbad4adf84d2c6451b43964b7e23fd07d2ff) nix-ld: move to pkgs/by-name
* [`e29150b7`](https://github.com/NixOS/nixpkgs/commit/e29150b7fed98496afa8d2314066802346419d48) nix-ld: use dynamicLinker as provided by stdenv
* [`04ec4568`](https://github.com/NixOS/nixpkgs/commit/04ec4568c62f38e5387c18a192b2bc9d67a2b740) nix-ld-rs: init at 2024-03-23
* [`8fa66a23`](https://github.com/NixOS/nixpkgs/commit/8fa66a23d4984419ba1a192eb8dd6e8dd9e9228f) starship: 1.18.0 -> 1.18.1
* [`1a4591f7`](https://github.com/NixOS/nixpkgs/commit/1a4591f71467ef88dedd2a7f7ba246abd185f1dd) lib60870: init at 2.3.2
* [`1d7d7484`](https://github.com/NixOS/nixpkgs/commit/1d7d7484c87284348b66bb5f715ad04000332e9c) libiec61850: init at 1.5.3
* [`df540713`](https://github.com/NixOS/nixpkgs/commit/df5407130f000b790d219cc7bc672b73d543d2bc) xfce.xfce4-dict: Drop configure-gio.patch
* [`dea81c90`](https://github.com/NixOS/nixpkgs/commit/dea81c90bd8b3265294d3ce6b3b830d3f00c1355) xfce.xfce4-pulseaudio-plugin: Drop automakeAddFlags
* [`7fb812af`](https://github.com/NixOS/nixpkgs/commit/7fb812afbff2df569ecaf7e92cd39524862a6927) xfce.automakeAddFlags: Drop
* [`8b31f1a9`](https://github.com/NixOS/nixpkgs/commit/8b31f1a9da067d357b7859c3a67c96acee6b4d8f) xfce.mousepad: Build shortcuts plugin
* [`e04b5ee7`](https://github.com/NixOS/nixpkgs/commit/e04b5ee7a83b2480f64abfc02fcb11e420f653f8) goresym: 2.3 -> 2.7.2
* [`2ee752e3`](https://github.com/NixOS/nixpkgs/commit/2ee752e3f777fd355a65682cbc6308038d7f3aa6) cgterm: init at 1.7b2
* [`c70bc6c3`](https://github.com/NixOS/nixpkgs/commit/c70bc6c3321f63bd11f8830b3d2d7b51b5b98003) ast-grep: 0.19.4 -> 0.20.0
* [`2685c876`](https://github.com/NixOS/nixpkgs/commit/2685c876a71ade348591e40ee2368d7866eb43e3) python312Packages.setuptools-dso: refactor
* [`c667f803`](https://github.com/NixOS/nixpkgs/commit/c667f803b681fe51ef5085ff7185754a1cf0b7d0) haskell.packages.ghc9{2,4}.primitive-addr: lift bounds over downgrading
* [`49d9251c`](https://github.com/NixOS/nixpkgs/commit/49d9251c1af6fa49124a8f310433cdd244ac3613) clifm: 1.17 -> 1.18
* [`0bda80b6`](https://github.com/NixOS/nixpkgs/commit/0bda80b6faad95f3147c308d1b916d1bcda53dba) xfce.libxfce4windowing: 4.19.2 -> 4.19.3
* [`fd077ac5`](https://github.com/NixOS/nixpkgs/commit/fd077ac57e488f551d3f5ebd7c1058e760921908) budgie.budgie-desktop: Fix build with libxfce4windowing 4.19.3
* [`4c9331d5`](https://github.com/NixOS/nixpkgs/commit/4c9331d517d59a05764a4f06619f4ccbf0b96059) budgie.budgie-desktop: Backport a few fixes
* [`ebc479ec`](https://github.com/NixOS/nixpkgs/commit/ebc479ecc5062a2586edf3b5dc4deba2859b709a) vimPlugins.sniprun: 1.3.11 -> 1.3.12
* [`7659c3b5`](https://github.com/NixOS/nixpkgs/commit/7659c3b55fbb42ff63c3a8e80c27baac3aedad2a) python311Packages.scapy: don't propagate library with dev dependencies
* [`0fcb4ccf`](https://github.com/NixOS/nixpkgs/commit/0fcb4ccfc2f00183601a4dd97df521730bef31d3) python311Packages.pyzbar: don't propagate library with dev dependencies
* [`35a41d0d`](https://github.com/NixOS/nixpkgs/commit/35a41d0dae4f5bd18f09c30be4a1ca6470cd3975) glances: 3.4.0.3 -> 3.4.0.5
* [`820400bc`](https://github.com/NixOS/nixpkgs/commit/820400bc34ddc25f2ed024e912d052b08f6bad61) nwg-hello: 0.1.7 -> 0.1.8
* [`cd1e59d3`](https://github.com/NixOS/nixpkgs/commit/cd1e59d35096d28751cf4fcb13eb61ce0f24dc33) linkerd_edge: 24.2.4 -> 24.3.4
* [`a5404e6d`](https://github.com/NixOS/nixpkgs/commit/a5404e6de94a11b9cd4fc439dd38b6afd1d40831) goldwarden: 0.2.13 -> 0.2.13-unstable-2024-03-14, install browser native extension files
* [`c4feb885`](https://github.com/NixOS/nixpkgs/commit/c4feb885b6de06d336e0469c7b20552c2fe908fd) python312Packages.llama-index-embeddings-gemini: 0.1.3 -> 0.1.5
* [`5ba311a0`](https://github.com/NixOS/nixpkgs/commit/5ba311a026ad3e6f3ad210e82428d222fdb4eca8) maintainers: add funkeleinhorn
* [`8b42cf26`](https://github.com/NixOS/nixpkgs/commit/8b42cf2618ac3637e31e823fe83ce761cf1c1626) swtpm: 0.8.1 -> 0.8.2
* [`7ce968a3`](https://github.com/NixOS/nixpkgs/commit/7ce968a38e90a9dbddf584985e03d57d60f5753a) python312Packages.oracledb: 2.1.0 -> 2.1.1
* [`b89fd0f2`](https://github.com/NixOS/nixpkgs/commit/b89fd0f2d61e302fd6b3aa0bd164ec4f8f8054a6) python312Packages.oracledb: refactor
* [`7f6fd46a`](https://github.com/NixOS/nixpkgs/commit/7f6fd46ab697081bca68f79bcd8d0db69b2fdf2e) raycast: 1.66.2 -> 1.70.2
* [`1c92ae96`](https://github.com/NixOS/nixpkgs/commit/1c92ae96141390907d63a6a5a315b9d040cbcf17) python3Packages.torchWithRocm: switch back to ROCm 5.7
* [`ad991789`](https://github.com/NixOS/nixpkgs/commit/ad9917895286e4b24413e2fe886a6bd01f406880) autosuspend: 6.0.0 -> 6.1.1
* [`19d0baef`](https://github.com/NixOS/nixpkgs/commit/19d0baefa9de0cb67ac2ad99f1f93e10453e478e) autosuspend: move to pkgs/by-name
* [`10aa8cf0`](https://github.com/NixOS/nixpkgs/commit/10aa8cf06ab2c1225c4ef412436c791e260cac7d) rcp: 0.6.0 -> 0.7.0
* [`c531d48e`](https://github.com/NixOS/nixpkgs/commit/c531d48ec60b2f0d6c76a6b991f5680525f9fff2) iosevka: 28.1.0 -> 29.0.3
* [`c3a16206`](https://github.com/NixOS/nixpkgs/commit/c3a1620624bc68eb90a305d9ce9e50a9681bc3f3) firefoxpwa: init at 2.11.1
* [`ad1f4164`](https://github.com/NixOS/nixpkgs/commit/ad1f4164b3835edc0a9cd0af757d1b6d5df890f0) kodiPackages.trakt: 3.5.0 -> 3.6.1
* [`86309c41`](https://github.com/NixOS/nixpkgs/commit/86309c4124d180a315d54080cb22024eaebcb240) python3Packages.pure-protobuf: 2.3.0 -> 3.0.1
* [`f2b7738e`](https://github.com/NixOS/nixpkgs/commit/f2b7738e26120a06d921f20ec0a5ae9da9b36c9c) xemu: migrate to by-name
* [`143e28d8`](https://github.com/NixOS/nixpkgs/commit/143e28d8403d85aa92ca40b231f1c6f19bd4f3bc) portfolio: 0.68.2 -> 0.68.3
* [`f970fa30`](https://github.com/NixOS/nixpkgs/commit/f970fa30e00ea06adc80819ffce0430bb80cc92f) python312Packages.homeassistant-stubs: 2024.3.0 -> 2024.3.3
* [`4594fc20`](https://github.com/NixOS/nixpkgs/commit/4594fc201d192b94839597b66fd40bc8e0223cf1) python311Packages.asyncstdlib: 3.12.1 -> 3.12.2
* [`2e805456`](https://github.com/NixOS/nixpkgs/commit/2e8054564245e4df8a9d3ccda41fd98a4b0f497f) clifm: format with nixfmt-rfc-style
* [`306fe56f`](https://github.com/NixOS/nixpkgs/commit/306fe56f63d8b14e7e50a5abc4a527032f2538b2) flashprog: refactor make jlink and gpio support configurable
* [`d347f29d`](https://github.com/NixOS/nixpkgs/commit/d347f29dc76687d92a49540698f774c4204609b8) pachyderm: 2.9.0 -> 2.9.2
* [`b5244c47`](https://github.com/NixOS/nixpkgs/commit/b5244c47aa0c32f2477585216b6f4c153c1b1d9b) questdb: mark with sourceProvenance binaryBytecode
* [`4dec7295`](https://github.com/NixOS/nixpkgs/commit/4dec72957cfb461a50fc3eb942b9838ea59f2edd) python311Packages.approvaltests: 11.1.2 -> 11.1.3
* [`a69e5266`](https://github.com/NixOS/nixpkgs/commit/a69e5266aed28cf7d62ffa12dda840b8a155ed6b) python311Packages.robotframework-pythonlibcore: 4.3.0 -> 4.4.0
* [`3937a5d9`](https://github.com/NixOS/nixpkgs/commit/3937a5d97913a399d7ba4c0d60bf9b32b17965c0) python311Packages.gradio: 4.20.1 -> 4.22.0
* [`ee62d2dd`](https://github.com/NixOS/nixpkgs/commit/ee62d2dd74268d74ffa02dd09d1b0725830cc29d) vaultwarden: set VW_VERSION
* [`8e4b61dc`](https://github.com/NixOS/nixpkgs/commit/8e4b61dc907e02ece07bf1ab93e7d329026b5357) xemu: refactor
* [`6356d977`](https://github.com/NixOS/nixpkgs/commit/6356d9773821fb1af5cb4b887d36eefac0734572) asciigraph: 0.5.6 -> 0.6.0
* [`a66efbf2`](https://github.com/NixOS/nixpkgs/commit/a66efbf278567fb45c9b1d44d6dd15d6a96d78d4) cargo-update: 13.3.0 -> 13.4.0
* [`5ac0b126`](https://github.com/NixOS/nixpkgs/commit/5ac0b126e8be4a25284855fe1c1d0ab2b30f9d77) xedit: 1.2.3 -> 1.2.4
* [`c239be04`](https://github.com/NixOS/nixpkgs/commit/c239be04a83036725109795a117d3e637caa3805) affine: init at 0.13.1
* [`eea14e8c`](https://github.com/NixOS/nixpkgs/commit/eea14e8cc658f34d4de3dc27face8dc618f68f13) alacritty: 0.13.1 -> 0.13.2
* [`ea9337dc`](https://github.com/NixOS/nixpkgs/commit/ea9337dc685f66f4756883edadef80195aa6b318) libck: 0.7.1 -> 0.7.2
* [`014105ee`](https://github.com/NixOS/nixpkgs/commit/014105ee385a6580a05e51f31a71da25c3f6c67a) fortran-fpm: 0.10.0 -> 0.10.1
* [`43fa9212`](https://github.com/NixOS/nixpkgs/commit/43fa9212df8d207dfb107a42f68f4d68619f6db8) maintainers: add melvyn2
* [`5ff11d6c`](https://github.com/NixOS/nixpkgs/commit/5ff11d6c1ff3d19bccbf5996429ca8946ce92f12) cargo-machete: 0.6.1 -> 0.6.2
* [`d4ac12d5`](https://github.com/NixOS/nixpkgs/commit/d4ac12d5c20c73cc169de663ec8c2f642dcba9c9) diswall: 0.5.1 -> 0.5.2
* [`4da76cc6`](https://github.com/NixOS/nixpkgs/commit/4da76cc6f486dfb7ff3c45e64fdb3e65e020463b) nixos/slskd: refactor and add config file options
* [`27bca5e4`](https://github.com/NixOS/nixpkgs/commit/27bca5e4b012540ce473b7ec627429348d7fa996) hishtory: 0.277 -> 0.282
* [`99271380`](https://github.com/NixOS/nixpkgs/commit/99271380d0037ba865e1db1dd554a7ca752c6bb9) kor: 0.3.6 -> 0.3.7
* [`67bc46cd`](https://github.com/NixOS/nixpkgs/commit/67bc46cd41d7007918ba881bb9ff5913c7a486f8) cargo-mutants: 24.2.1 -> 24.3.0
* [`8c6f086c`](https://github.com/NixOS/nixpkgs/commit/8c6f086c7bf0fcd51c60aa2bae2bf842fc2bebec) swtpm: add a platform entry to meta attributes
* [`ad2d5b41`](https://github.com/NixOS/nixpkgs/commit/ad2d5b41f3af3d4955c4b86b38ce8814a1a06dd1) whistle: 2.9.66 -> 2.9.67
* [`56d33d48`](https://github.com/NixOS/nixpkgs/commit/56d33d48c9cd67aba9cfb216eb4158430b3ce843) python311Packages.pygithub: 2.2.0 -> 2.3.0
* [`e7bd72ba`](https://github.com/NixOS/nixpkgs/commit/e7bd72ba0ab81fa4f123dc9e32e83986a3c10673) ginkgo: 2.17.0 -> 2.17.1
* [`5d820591`](https://github.com/NixOS/nixpkgs/commit/5d820591e93462fe2d12d579997bfb7934d5d01d) pict-rs: 0.5.9 -> 0.5.10
* [`263b8f97`](https://github.com/NixOS/nixpkgs/commit/263b8f97d2474e52e3b06135cb7bafdb6bacf698) python312Packages.app-model: 0.2.5 -> 0.2.6
* [`85ee2996`](https://github.com/NixOS/nixpkgs/commit/85ee2996129a34312362835446029d991ffb57fb) keycloak: 24.0.1 -> 24.0.2
* [`2d4b419b`](https://github.com/NixOS/nixpkgs/commit/2d4b419be37d444e2d8f94ea720317a65fa5a676) python312Packages.clickhouse-connect: 0.7.3 -> 0.7.4
* [`2ec32cf2`](https://github.com/NixOS/nixpkgs/commit/2ec32cf2decfd94fe67cc71b3f214bdbb3c45f93) python312Packages.cypari2: 2.1.4 -> 2.1.5
* [`5f712e79`](https://github.com/NixOS/nixpkgs/commit/5f712e79a3818276d560885ca70e1f74af9aa222) python312Packages.pygithub: 2.2.0 -> 2.3.0
* [`5c1cc75a`](https://github.com/NixOS/nixpkgs/commit/5c1cc75ad3b2f528e8d2b17c168b1741f3889866) libisoburn: update expression
* [`2de37473`](https://github.com/NixOS/nixpkgs/commit/2de37473bba0baa84c134f4b6fdf5b71431c3ed2) xorriso: alias to libisoburn
* [`1aae798e`](https://github.com/NixOS/nixpkgs/commit/1aae798e7e22737cd11ba63432940c8de8bc5187) python312Packages.rapidfuzz: 3.6.2 -> 3.7.0
* [`a3389a0c`](https://github.com/NixOS/nixpkgs/commit/a3389a0c30277406e069e12ad1481a06abf98fd2) python312Packages.rope: 1.12.0 -> 1.13.0
* [`5c17f1cc`](https://github.com/NixOS/nixpkgs/commit/5c17f1cc3e91205a7ce37754c3f5dabf6136b001) python312Packages.xiaomi-ble: 0.27.1 -> 0.28.0
* [`ffce7933`](https://github.com/NixOS/nixpkgs/commit/ffce793315fd942053effda471fd27cf5d4b658f) semantic-release: 23.0.5 -> 23.0.6
* [`c6a12be6`](https://github.com/NixOS/nixpkgs/commit/c6a12be6eaad485990e8f77fc3d4c7a375579c39) tidal-hifi: 5.9.0 -> 5.10.0
* [`409800ef`](https://github.com/NixOS/nixpkgs/commit/409800ef12bf73cf647204c2904a592b016888ac) python311Packages.django-auth-ldap: 4.6.0 -> 4.7.0
* [`ebb1bd45`](https://github.com/NixOS/nixpkgs/commit/ebb1bd454156fdd4f24a8895f4758e9d3bf1f588) openafs: 1.8.10 → 1.8.11
* [`025e62c6`](https://github.com/NixOS/nixpkgs/commit/025e62c60fe868113b74730144d6ce12f0c952f5) linuxPackages.openafs: Patch for Linux kernel 6.8
* [`cd5d14d9`](https://github.com/NixOS/nixpkgs/commit/cd5d14d96f519782484873f47062806d872ebcbe) tailscale-nginx-auth: 1.58.2 -> 1.62.0
* [`aba8ce92`](https://github.com/NixOS/nixpkgs/commit/aba8ce92d0cd268a36a7fdff554477c831f516f3) roadrunner: 2023.3.10 -> 2023.3.12
* [`a8504796`](https://github.com/NixOS/nixpkgs/commit/a85047967011abbdff0dbabc5b973b6f4c62fe13) turso-cli: 0.89.0 -> 0.90.3
* [`23f1661c`](https://github.com/NixOS/nixpkgs/commit/23f1661c7e9697b88dab5b319314015c4f88a6e9) rqbit: 5.5.0 -> 5.5.3
* [`59b3f88f`](https://github.com/NixOS/nixpkgs/commit/59b3f88fbf67d6e6fb902cc30a4902d90f2a8452) papis: fix build
* [`57804027`](https://github.com/NixOS/nixpkgs/commit/5780402798722696d9d2b0cb5e7fe6281f8b8c7e) uv: install completions
* [`af3037b9`](https://github.com/NixOS/nixpkgs/commit/af3037b91d7c86f51bc33781d3b21358f2f354c0) integresql: init at 1.1.0
* [`2d8a9a0b`](https://github.com/NixOS/nixpkgs/commit/2d8a9a0bf4d9b433ee70323f26ef69b60d5dbe9f) postgresqlPackages.pg_roaringbitmap: init at 0.5.4
* [`2b7d08ce`](https://github.com/NixOS/nixpkgs/commit/2b7d08ce89348d24977a4e0d8fd4fdeb99117b72) postgres-lsp: unstable-2024-01-11 -> 0-unstable-2024-03-24
* [`69d879de`](https://github.com/NixOS/nixpkgs/commit/69d879dec3bdc4677701b2953ab3b70df6d69022) pinentry_mac: fix mainProgram name
* [`6829739e`](https://github.com/NixOS/nixpkgs/commit/6829739ee033526c475e96914ddafa5f0e5afe46) gat: init at 0.17.0
* [`3f430e23`](https://github.com/NixOS/nixpkgs/commit/3f430e23701e60b4346664916f50fe5663e6fa60) python311Packages.stim: 1.12.1 -> 1.13.0
* [`0772542c`](https://github.com/NixOS/nixpkgs/commit/0772542ccac69ca28a59a15523a59be76df2594d) zfs-replicate: 3.2.10 -> 3.2.11
* [`3d3e48b1`](https://github.com/NixOS/nixpkgs/commit/3d3e48b1149f94d4d5dc51b376fee9afba847e0f) awscli2: 2.15.31 -> 2.15.32
* [`f3a5ac03`](https://github.com/NixOS/nixpkgs/commit/f3a5ac034aacf9be8eae292b78da80efea6021b1) ocamlPackages.topkg: 1.0.5 → 1.0.7
* [`8898f511`](https://github.com/NixOS/nixpkgs/commit/8898f511ba30c568f52f52b07f68b5dee8776e0d) ocamlPackages.js_of_ocaml: 5.6.0 -> 5.7.1
* [`5013e3cc`](https://github.com/NixOS/nixpkgs/commit/5013e3cc40efc07d95a65469300bc9f230254e14) uv: 0.1.22 -> 0.1.24
* [`19e6b1aa`](https://github.com/NixOS/nixpkgs/commit/19e6b1aa7a0dcad3742a9d5a1c06a63fcbd89bf8) nextcloud-client: 3.12.1 -> 3.12.2
* [`54bd4c46`](https://github.com/NixOS/nixpkgs/commit/54bd4c46e960771f9c427c20bacada7712dbd4f4) sq: 0.47.4 -> 0.48.3
* [`41781200`](https://github.com/NixOS/nixpkgs/commit/41781200a448110340ae769bc20f2a2d6c18e65d) apache-jena: 4.10.0 -> 5.0.0
* [`82d121f4`](https://github.com/NixOS/nixpkgs/commit/82d121f40bd926d5e3a7fa213c66b8ea6340a1a6) abcmidi: 2024.03.13 -> 2024.03.21
* [`6bd8317f`](https://github.com/NixOS/nixpkgs/commit/6bd8317f2e4975a1722f8961b7faac3337b206cc) xpipe: 8.4 -> 8.5
* [`ae2b2e89`](https://github.com/NixOS/nixpkgs/commit/ae2b2e89e46b304ec67202dd1ae8a22648f7d781) oh-my-posh: 19.13.0 -> 19.18.1
* [`a01dd74e`](https://github.com/NixOS/nixpkgs/commit/a01dd74ebe7c9680c12e21289de7c910af5e4abb) podman-tui: 0.18.0 -> 1.0.0
* [`30f62e74`](https://github.com/NixOS/nixpkgs/commit/30f62e7478f64f9ccf5017079b10cae619177fd3) python311Packages.llama-index-cli: 0.10.20 -> 0.1.11
* [`19bdc20b`](https://github.com/NixOS/nixpkgs/commit/19bdc20b9eea71b34c2e1ae5b0a56e314a1cae44) nexttrace: 1.2.8 -> 1.2.9
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
