### PR TITLE
niv devenv: update 93875897 -> e106743b

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://devenv.sh",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "93875897c86651f19b242ac8b71fbd977b877f6d",
-        "sha256": "0fdaqhxmpj3j6v4ibn0kn5rcnhr4hj0qn4a4w0daj8i73y7nds66",
+        "rev": "e106743bdbd788742f516b3eaea3e21e7162a38e",
+        "sha256": "1aznyj4d9nkkz37h5qplpvllkiw9mj6spfvx4zxvw41bp5wc6p7z",
         "type": "tarball",
-        "url": "https://github.com/cachix/devenv/archive/93875897c86651f19b242ac8b71fbd977b877f6d.tar.gz",
+        "url": "https://github.com/cachix/devenv/archive/e106743bdbd788742f516b3eaea3e21e7162a38e.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "doomemacs": {


### PR DESCRIPTION
## Changelog for devenv:
Branch: main
Commits: [cachix/devenv@93875897...e106743b](https://github.com/cachix/devenv/compare/93875897c86651f19b242ac8b71fbd977b877f6d...e106743bdbd788742f516b3eaea3e21e7162a38e)

* [`5eb0ceb0`](https://github.com/cachix/devenv/commit/5eb0ceb065fae0a05a7b229c1cce55697b3c9b30) init: expose all common function inputs
* [`36b40c2e`](https://github.com/cachix/devenv/commit/36b40c2eb81aa84a30d9f428729e924572a2b71f) processes: add documentation url to processes help output
* [`6969e844`](https://github.com/cachix/devenv/commit/6969e844b08cbda36466b54f61254cc7ed519a30) up: add missing new line to log message
* [`2ebe412f`](https://github.com/cachix/devenv/commit/2ebe412f81504c9ed889cb057c900da30019a7e9) fix short flag for --cores
* [`2733e274`](https://github.com/cachix/devenv/commit/2733e2744aeb8390575f9c068e18aae718ae8d06) fix [cachix/devenv⁠#1057](https://togithub.com/cachix/devenv/issues/1057)
* [`1ebb7c8c`](https://github.com/cachix/devenv/commit/1ebb7c8cc049426205cfab3ba76cee6f88042234) containers: documentation update
* [`15f55864`](https://github.com/cachix/devenv/commit/15f55864583ffec378694d6b1c3889b8b597204c) fix [cachix/devenv⁠#1057](https://togithub.com/cachix/devenv/issues/1057)
* [`a225f6b7`](https://github.com/cachix/devenv/commit/a225f6b772c6bde53c2b3a817771fb9453be328c) Fix [cachix/devenv⁠#1065](https://togithub.com/cachix/devenv/issues/1065)
* [`b4d768f0`](https://github.com/cachix/devenv/commit/b4d768f05f181f723bf1803163f3358985b8d4aa) expose options as json
* [`971f4912`](https://github.com/cachix/devenv/commit/971f49121d37ef7dcd484ae78964c538adcbadf5) Fix [cachix/devenv⁠#1054](https://togithub.com/cachix/devenv/issues/1054)
* [`26d703fb`](https://github.com/cachix/devenv/commit/26d703fb93be9e738e0021d03a3c55ea14cb42a4) turn untrusted user options into a) b) and c)
* [`4f4675c6`](https://github.com/cachix/devenv/commit/4f4675c6e7f97550bc0bd4992aa0f45d23734b91) docs: tests add note for more function
* [`aefe64cc`](https://github.com/cachix/devenv/commit/aefe64cc9bc42c3ddc36059f865d1bc95e51b780) docs: add instructions for creating dev project
* [`76021cbc`](https://github.com/cachix/devenv/commit/76021cbc88b05ec44b17c80146cbbe156178e733) Pass command line arguments to mysql commands
* [`6c88af55`](https://github.com/cachix/devenv/commit/6c88af555a46ad7340976f116a856482d1feb514) Add tests for mysql scripts and fix existing test script
* [`475046dc`](https://github.com/cachix/devenv/commit/475046dc4915e7a06eae8971380e5a92e8d917b2) docs: Fix undefined variable in minimal flake-parts example
* [`3099aa3e`](https://github.com/cachix/devenv/commit/3099aa3e853d80bce9620a4771b20a108fdb0641) Update restart Nix command for MacOS to include -k flag
* [`4cfbdb40`](https://github.com/cachix/devenv/commit/4cfbdb405fa60e7d57732e6982cfc2c2c472fcc8) examples/rubyonrails: fail early
* [`16897f44`](https://github.com/cachix/devenv/commit/16897f444fa386284b2202c425422d7cdc0c4d57) examples/rubyonrails: add required git and curl cli
