### PR TITLE
niv home-manager: update 1c2c5e4c -> 4be04644

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,10 +53,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1c2c5e4cabba4c43504ef0f8cc3f3dfa284e2dbb",
-        "sha256": "0sjnfw4ia5m0yvpr4y4d7frizvs6si3w2xy931z5xmxszy2rm4sq",
+        "rev": "4be0464472675212654dedf3e021bd5f1d58b92f",
+        "sha256": "0p1bllhsijgqng1zag88ww16s52f2lg2q93qw2zbm4pyj3pcws9v",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/1c2c5e4cabba4c43504ef0f8cc3f3dfa284e2dbb.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/4be0464472675212654dedf3e021bd5f1d58b92f.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@1c2c5e4c...4be04644](https://github.com/nix-community/home-manager/compare/1c2c5e4cabba4c43504ef0f8cc3f3dfa284e2dbb...4be0464472675212654dedf3e021bd5f1d58b92f)

* [`eb869521`](https://github.com/nix-community/home-manager/commit/eb869521cb6c895b6d351be0b9e010c578de0e4b) darkman: allow no configuration
* [`179f6aca`](https://github.com/nix-community/home-manager/commit/179f6acaf7c068c7870542cdae72afec9427a5b0) antidote: Use builtins.storeDir ([nix-community/home-manager⁠#5182](https://togithub.com/nix-community/home-manager/issues/5182))
* [`3142bdcc`](https://github.com/nix-community/home-manager/commit/3142bdcc470e1e291e1fbe942fd69e06bd00c5df) readline: optionally place config file in XDG dir
* [`c0ef0dab`](https://github.com/nix-community/home-manager/commit/c0ef0dab55611c676ad7539bf4e41b3ec6fa87d2) home-environment: fix formatting
* [`c09deb86`](https://github.com/nix-community/home-manager/commit/c09deb869b2e7a4612e489d4bbb11517f78b618e) Translate using Weblate (Vietnamese)
* [`30f2ec39`](https://github.com/nix-community/home-manager/commit/30f2ec39519f4f5a8a96af808c439e730c15aeab) flake.lock: Update
* [`820be197`](https://github.com/nix-community/home-manager/commit/820be197ccf3adaad9a8856ef255c13b6cc561a6) programs.khal: ability to set RGB color ([nix-community/home-manager⁠#5192](https://togithub.com/nix-community/home-manager/issues/5192))
* [`4be04644`](https://github.com/nix-community/home-manager/commit/4be0464472675212654dedf3e021bd5f1d58b92f) home-manager: fix missing string context
