### PR TITLE
niv nixpkgs: update 11273b60 -> c5707d86

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -113,10 +113,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "11273b60c8b3b6036bc3c86e135b940154668f58",
-        "sha256": "01qxch6j8889cmh7wx9r70f50a1487z0kqdcx0650b3a202wmxqg",
+        "rev": "c5707d8602df948cbc4b11ad3c6737a4a49cc6be",
+        "sha256": "0ms0w20z0a92zrh8srxmmz5an3m61nnnp4w3sfh04qqi74fmwk37",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/11273b60c8b3b6036bc3c86e135b940154668f58.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/c5707d8602df948cbc4b11ad3c6737a4a49cc6be.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@11273b60...c5707d86](https://github.com/nixos/nixpkgs/compare/11273b60c8b3b6036bc3c86e135b940154668f58...c5707d8602df948cbc4b11ad3c6737a4a49cc6be)

* [`eddd1e46`](https://github.com/NixOS/nixpkgs/commit/eddd1e46e627cfcb138461d443d0ef7ec827a58e) prometheus-exporters: support nftables
* [`81d20b30`](https://github.com/NixOS/nixpkgs/commit/81d20b3065dfe1228da115812653e352f61f36e3) nut: fix nut-scanner cross-compilation
* [`70db5d09`](https://github.com/NixOS/nixpkgs/commit/70db5d0937f8497320d55455ef8d11063a6af764) nixos/installer-tools: mention PulseAudio+PipeWire instead of ALSA+PulseAudio in generated config
* [`775c6f49`](https://github.com/NixOS/nixpkgs/commit/775c6f4943cb8500533b45ab11960b0c9de1c5a0) bws: 0.3.0 -> 0.4.0
* [`be1106fd`](https://github.com/NixOS/nixpkgs/commit/be1106fd958f735ae3c0db50824fd556cfcdfadd) deqp-runner: 0.16.1 -> 0.18.0
* [`e9fbf030`](https://github.com/NixOS/nixpkgs/commit/e9fbf030d9a5945a6dd28f061fce1d3c6d30f6f1) jetbrains.rider: fix build on aarch64-linux
* [`44aa45fe`](https://github.com/NixOS/nixpkgs/commit/44aa45fe2d41fdea508a8c81991254ba28efa699) python311Packages.plone-testing: 8.0.3 -> 9.0.1
* [`70093e0f`](https://github.com/NixOS/nixpkgs/commit/70093e0f2c7cb6baead81f0cb24a3c981ad4789d) maintainers: add poptart
* [`124fbc2a`](https://github.com/NixOS/nixpkgs/commit/124fbc2aec3cab29b9cadef931610a200357580f) inflow: init at 1.0.1
* [`ad614140`](https://github.com/NixOS/nixpkgs/commit/ad61414046a27d108cd4e2398bc411903f42aeb4) go-bare: init at 2021-04-06
* [`01634059`](https://github.com/NixOS/nixpkgs/commit/016340590ba125356f60484550496088c569ccc7) nixos/terraria: prefer 'serviceConfig' over 'chmod/chgrp'
* [`100af695`](https://github.com/NixOS/nixpkgs/commit/100af695bf0ae85a2af3c394fe5230c0c1a293c9) opencryptoki: 3.20.0 -> 3.23.0
* [`6f4b02cd`](https://github.com/NixOS/nixpkgs/commit/6f4b02cd8de79435ec343d048c210b83150744f2) python311Packages.auth0-python: fix build
* [`ba63f2fb`](https://github.com/NixOS/nixpkgs/commit/ba63f2fbe573c6769d8806d9cbeda03fbead6841) maintainers: add dav-wolff
* [`b83e5607`](https://github.com/NixOS/nixpkgs/commit/b83e5607575b1cb499f56cd146473048a0bf8c39) stylance-cli: init at 0.3.0
* [`ba62c668`](https://github.com/NixOS/nixpkgs/commit/ba62c668a50a0633e05a321f9475a4e892e1b1fc) linuxKernel.packages.linux_zen.kvdo: 8.2.1.6 -> 8.2.3.3
* [`b26b1ed7`](https://github.com/NixOS/nixpkgs/commit/b26b1ed73919e3028e96adbafddac9025db8b9f7) xdg-utils: add xdg-terminal
* [`3cd77751`](https://github.com/NixOS/nixpkgs/commit/3cd7775172487141c1ef1fbe75722e1633082205) substituteAll: fix typo in comment
* [`c7145973`](https://github.com/NixOS/nixpkgs/commit/c7145973608e786a2be803aa581d01c1afd5cfc4) calamares: 3.2.62 -> 3.3.3
* [`9e68e652`](https://github.com/NixOS/nixpkgs/commit/9e68e6520ce36c526ad1a901214aace62e15d446) calamares-nixos-extensions: 0.3.14 -> 0.3.15
* [`be97d5f5`](https://github.com/NixOS/nixpkgs/commit/be97d5f5b95290445886244257c4d3580c439aaa) crowdsec: fix versioning flags in build
* [`90211718`](https://github.com/NixOS/nixpkgs/commit/90211718d97896327d12db496f3491c24df52e40) coqPackages.LibHyps: 2.0.4.1 -> 2.0.8
* [`3056904c`](https://github.com/NixOS/nixpkgs/commit/3056904cb3743653d033f09c170ef220e004cdff) libgpg-error: 1.47 -> 1.48
* [`c5bfa262`](https://github.com/NixOS/nixpkgs/commit/c5bfa2626e11067135681cfd150ea460eeda2830) kord: fix build due to changed compiler features
* [`54e0dba1`](https://github.com/NixOS/nixpkgs/commit/54e0dba1d2ac0ed0b7219ade72d6301eb206147e) krita: create wrapper
* [`d4bb486c`](https://github.com/NixOS/nixpkgs/commit/d4bb486c8df40b44acf6909c0a7ce9f875c1d933) krita-plugin-gmic: init at 3.2.4.1
* [`1c6cad32`](https://github.com/NixOS/nixpkgs/commit/1c6cad3251a8cdd6c2a3185aa05d6d6c70af3f4d) passExtensions.pass-update: 2.1 -> 2.2.1
* [`f0c30a34`](https://github.com/NixOS/nixpkgs/commit/f0c30a34c80a1a6e035d9fa6fe90881eb6210a11) nwg-displays: Default to enabled hyprland support
* [`8b24908a`](https://github.com/NixOS/nixpkgs/commit/8b24908a76ac20bb12503c7a32ee4d3cea245a74) glibc: 2.38-44 -> 2.39-5
* [`1c003da7`](https://github.com/NixOS/nixpkgs/commit/1c003da73c7ca9e997a85781261ecd379eb4dd9a) _389ds-base: mark as broken
* [`2dcdf602`](https://github.com/NixOS/nixpkgs/commit/2dcdf602729e7923ec59b2e1ce67a0cb3f0d5c7a) swift: fix build w/ glibc-2.39
* [`f2201789`](https://github.com/NixOS/nixpkgs/commit/f2201789fe442282c7ec17c225a9a78dd1973a09) rss-bridge: add config option
* [`a949f4b6`](https://github.com/NixOS/nixpkgs/commit/a949f4b6e22f9207281accb60f487719463dc458) rss-bridge: Integrate filecache path with config
* [`f7a6e75b`](https://github.com/NixOS/nixpkgs/commit/f7a6e75b42a052345a9b7853ef31c7388712c88d) rss-bridge: Move whitelist option to general config
* [`84f41005`](https://github.com/NixOS/nixpkgs/commit/84f41005203d66b328328da1ee17094c74db5f39) rss-bridge: Use new tmpfiles syntax
* [`899a9d82`](https://github.com/NixOS/nixpkgs/commit/899a9d82ca27bb93ed55831032b9dd937fc419b4) Xaw3d: 1.6.5 -> 1.6.6
* [`6f9d0755`](https://github.com/NixOS/nixpkgs/commit/6f9d07551c5802d23f085300caece82d5e393a32) anyrun: init at 0-unstable-2023-12-01
* [`2da974bf`](https://github.com/NixOS/nixpkgs/commit/2da974bf8e1b5f74d99a0535a800745bd08b2357) dropbear: fix pkgsStatic build
* [`1a56b351`](https://github.com/NixOS/nixpkgs/commit/1a56b3515b8434f91af104e987b05227a0b28eff) ostree: version bump and removing old patches
* [`9a5b86c1`](https://github.com/NixOS/nixpkgs/commit/9a5b86c1894dba9c49dd0be91ec221ca3ac18e31) writers: add support for wrapping
* [`40c9679c`](https://github.com/NixOS/nixpkgs/commit/40c9679c8b2401fb71aa53a97b7d5d8d760b19d7) elfutils: 0.190 -> 0.191
* [`07bc5cd3`](https://github.com/NixOS/nixpkgs/commit/07bc5cd3fe5bf9ef37926b6f1d9b1a76ce16eb9d) gdb: 14.1 -> 14.2
* [`3c91e920`](https://github.com/NixOS/nixpkgs/commit/3c91e92068fe657a19e729b8235e27ce6d4243ac) onevpl-intel-gpu: init at 23.4.3
* [`88add7e2`](https://github.com/NixOS/nixpkgs/commit/88add7e28ef9e6610619bac4752a11be0830a0d2) ffmpeg: add withVPL option for libvpl
* [`bcb2eaea`](https://github.com/NixOS/nixpkgs/commit/bcb2eaea45a3dff4442e20fbadb4d095eeade5ce) gnupg: 2.4.4 -> 2.4.5
* [`d5f75896`](https://github.com/NixOS/nixpkgs/commit/d5f75896470ee8e5dc60d122ee5d6cfae1ad9954) keybase: 6.2.4 -> 6.2.8
* [`994232c0`](https://github.com/NixOS/nixpkgs/commit/994232c0341269b4eda21707b781ad6a0e28af96) mdadm: 4.2 -> 4.3
* [`25a9bf0f`](https://github.com/NixOS/nixpkgs/commit/25a9bf0fe6f3ce3de5c96ab38651ec19cf1edcc0) python312Packages.pyqt5: normalize pname
* [`f1cf5008`](https://github.com/NixOS/nixpkgs/commit/f1cf50080b9f59c4c11ab7f7bdd8b5ad6d65199a) camunda-modeler: 5.20.0 -> 5.21.0
* [`d5ae8569`](https://github.com/NixOS/nixpkgs/commit/d5ae85691a8822e47b4968700d9eb64d0b25b778) nixos/vaultwarden: drop with lib over entire file
* [`4799ffc6`](https://github.com/NixOS/nixpkgs/commit/4799ffc61db05b132c080c7bca99b1f9cb754713) nixos/vaultwarden: drop lib.mdDoc
* [`7e6f67dc`](https://github.com/NixOS/nixpkgs/commit/7e6f67dcb15840cfc12b38d2f1463a127df1a96e) catppuccin-gtk: fix git reset behavior to support multiple accents
* [`f8106f1c`](https://github.com/NixOS/nixpkgs/commit/f8106f1cf49ddf407050cebc0c1eb8ec617b494b) python312Packages.pymysql: normalize pname
* [`70a13133`](https://github.com/NixOS/nixpkgs/commit/70a1313337490ebe9150caf11c99d5b4552bd3be) python312Packages.sqlalchemy: normalize pname
* [`d061d198`](https://github.com/NixOS/nixpkgs/commit/d061d19858f41c150fb57743c8c7703142310bca) python312Packages.sqlalchemy-i18n: normalize pname
* [`06263797`](https://github.com/NixOS/nixpkgs/commit/06263797cb4c81b78e129e8c7324712f692a6b31) python312Packages.pyqrcode: normalize pname
* [`0f884c71`](https://github.com/NixOS/nixpkgs/commit/0f884c719b3f5af8883e61f2e1b86e0f7e15c4dc) waf: 2.0.26 -> 2.0.27
* [`bcb2393e`](https://github.com/NixOS/nixpkgs/commit/bcb2393ebdabb8d7988dccbcd1578d6f622d5631) iproute2: 6.7.0 -> 6.8.0
* [`ebadd512`](https://github.com/NixOS/nixpkgs/commit/ebadd512ecac15b5cef6bde015eb3bffab775ec1) glib-networking: 2.78.0 → 2.78.1
* [`0e6fcbc7`](https://github.com/NixOS/nixpkgs/commit/0e6fcbc70d3c7e2fa6cf9cd043b00ff649dc26f8) libhandy: 1.8.2 → 1.8.3
* [`8fecf8f4`](https://github.com/NixOS/nixpkgs/commit/8fecf8f411228aacd63669a72af14d8f241738fe) pango: 1.51.0 → 1.51.2
* [`54e99a96`](https://github.com/NixOS/nixpkgs/commit/54e99a96fdafbff29106a4ead85be746923a8963) libva: 2.20.0 -> 2.21.0
* [`c627cf3a`](https://github.com/NixOS/nixpkgs/commit/c627cf3a869524662cb034f286ace3e898bd90dc) sqlite: 3.45.1 -> 3.45.2
* [`f3401920`](https://github.com/NixOS/nixpkgs/commit/f3401920ddcd7974d99e9a976927a93cedb52644) edencommon: 2024.01.22.00 -> 2024.03.11.00
* [`bfc2be28`](https://github.com/NixOS/nixpkgs/commit/bfc2be289652b4959cf16555f5733429e4dd7ea1) fb303: 2024.01.22.00 -> 2024.03.11.00
* [`235f36ee`](https://github.com/NixOS/nixpkgs/commit/235f36ee5aca23c035200bbd0fa6e60914de6452) expat: 2.6.0 -> 2.6.2
* [`19fee24f`](https://github.com/NixOS/nixpkgs/commit/19fee24f51e9f0d176bed6ac725f8f72d8a86f4d) python312Packages.django_4: normalize pname
* [`e343efdb`](https://github.com/NixOS/nixpkgs/commit/e343efdba176f144710262d1a158e7a9c59fd8a1) maintainers: add arduano
* [`3bea2b1f`](https://github.com/NixOS/nixpkgs/commit/3bea2b1f5eb27d8fbc0e256b9dff5869494dde6e) svt-av1: 1.8.0 -> 2.0.0
* [`acaf847d`](https://github.com/NixOS/nixpkgs/commit/acaf847d4f57d595c062ad21eda487dc486e836e) nuget-to-nix: fix the bug of wrong url in the generated nix file when the package base address of the nuget source does not have a trailing slash
* [`0c9c3b70`](https://github.com/NixOS/nixpkgs/commit/0c9c3b70b29878f8eee7509cf93be746f64ee759) glib-networking: disable pkcs11 tests
* [`ae14246d`](https://github.com/NixOS/nixpkgs/commit/ae14246d19a8fe391766ec32d2b548022d56aebb) s2n-tls: 1.4.6 -> 1.4.7
* [`af3101e9`](https://github.com/NixOS/nixpkgs/commit/af3101e90abb6c5fcdc5f9f08b9314ac7dea14d9) luarocks: 3.10.0 -> 3.11.0
* [`f075bf7e`](https://github.com/NixOS/nixpkgs/commit/f075bf7e05d88a0a98be04bb85e281fda6684b89) .github/labeler.yml: add luarocks to `6.topic: lua`
* [`5ba9ce0e`](https://github.com/NixOS/nixpkgs/commit/5ba9ce0e3606d2a414306595089d4796ee9ad653) fbthrift: 2024.01.22.00 -> 2024.03.11.00
* [`6c1a2933`](https://github.com/NixOS/nixpkgs/commit/6c1a293376860e1a1a106f2d3176c7332b1899d2) fizz: 2024.01.22.00 -> 2024.03.11.00
* [`722f0b05`](https://github.com/NixOS/nixpkgs/commit/722f0b0554666f4120a67d62f8116be513798bc5) folly: 2024.01.22.00 -> 2024.03.11.00
* [`ba2a898f`](https://github.com/NixOS/nixpkgs/commit/ba2a898fe329114345d44aae0e27351da0db43be) mvfst: 2024.01.22.00 -> 2024.03.11.00
* [`7c0f63e2`](https://github.com/NixOS/nixpkgs/commit/7c0f63e27646307a5a6352718f213e6f5f6d016f) wangle: 2024.01.22.00 -> 2024.03.11.00
* [`45c549b9`](https://github.com/NixOS/nixpkgs/commit/45c549b98c01ecd8289fe52c9f3dce2bdae9c563) watchman: 2024.01.22.00 -> 2024.03.11.00
* [`cff0adfc`](https://github.com/NixOS/nixpkgs/commit/cff0adfc1b36fb099cb4ae1d382ece0f6b335e31) SDL: put only SDL-related paths in SDL_LIB_PATH
* [`8b2816a1`](https://github.com/NixOS/nixpkgs/commit/8b2816a1b0110b6f7187a99ef961d7a97b110197) SDL: note that sdl hook won’t work with split dev packages
* [`be51056b`](https://github.com/NixOS/nixpkgs/commit/be51056b8538aa23f18e7f4fff72e44b4dd56c59) pythonRelaxDepsHook: don't rely on pname as that could be normalized already
* [`4dd9a352`](https://github.com/NixOS/nixpkgs/commit/4dd9a3526cb396fdf60f0534cedb7b51f0b6c598) ffmpeg: enable ffplay in small variant
* [`61baca01`](https://github.com/NixOS/nixpkgs/commit/61baca011c1523b596f965df7cb73fa521d178b1) python27: 2.7.18.7 -> 2.7.18.8
* [`ecdf55e0`](https://github.com/NixOS/nixpkgs/commit/ecdf55e09167b0bd306a22f10002cf8ce751a2cf) dav1d: 1.4.0 -> 1.4.1
* [`6cf1820d`](https://github.com/NixOS/nixpkgs/commit/6cf1820d4d288b1434f5ae5efe289f48bd191dd6) python3Packages.numba: unbreak cuda
* [`b81284ec`](https://github.com/NixOS/nixpkgs/commit/b81284ec71a1d66aeb11e2ecdcf72fd192d309d8) gcc: link $lib/lib -> $lib/$targetConfig correctly and consistently
* [`d2b36580`](https://github.com/NixOS/nixpkgs/commit/d2b365806e6e84cd2b7e239718861158a9437085) librsvg: 2.57.1 -> 2.57.2
* [`912752b5`](https://github.com/NixOS/nixpkgs/commit/912752b5b95a6bc0b7d0fa47e226e7829b6e800d) appleDerivation: support `mkDerivation` fixpoint
* [`b2e5dc07`](https://github.com/NixOS/nixpkgs/commit/b2e5dc07d36a55e4d335a9ef76088898c250ee06) srb2: migrate to by-name
* [`f188bff3`](https://github.com/NixOS/nixpkgs/commit/f188bff3fd209b4537e167f256759608a8350a3b) srb2: add missing phase hooks
* [`d7f34103`](https://github.com/NixOS/nixpkgs/commit/d7f3410393bce541b53055d933729c47d621ee2b) srb2: add startupWMClass to desktop item
* [`28248506`](https://github.com/NixOS/nixpkgs/commit/28248506ae9c6544587c75c98959e5180667063d) pulseaudio: fix crash with alsa_ucm devices
* [`0714cd83`](https://github.com/NixOS/nixpkgs/commit/0714cd83df6d400b36eeed6e6a5ce90b40150c31) srb2: fetchurl -> fetchzip
* [`640cdcb8`](https://github.com/NixOS/nixpkgs/commit/640cdcb814ce7476d002a306816ed9d88baaf4f3) lua: smarter/more correct patching
* [`815d3683`](https://github.com/NixOS/nixpkgs/commit/815d3683f70470e4c1b6c72535576e5e41d731ae) lua.tests: update golden values for default LUA_PATH
* [`0c941710`](https://github.com/NixOS/nixpkgs/commit/0c9417100fb3172cfa874f0d8641471d91a94c76) lua: update setup-hook to limit LUA_PATH size
* [`545c14d5`](https://github.com/NixOS/nixpkgs/commit/545c14d5e4d65d8ac8aa282bf5720e83695cd1f8) doc/lua: mention the patching of interpreters
* [`99bb198c`](https://github.com/NixOS/nixpkgs/commit/99bb198cddd7c6d39d86736d5dbb27c9b0d21cd4) doc: update release notes for 24.05
* [`3886fc92`](https://github.com/NixOS/nixpkgs/commit/3886fc9297ba2f2bc599bb6060f03e16e9adabda) libxml2: 2.12.5 → 2.12.6
* [`2a3a8b03`](https://github.com/NixOS/nixpkgs/commit/2a3a8b035972dc4ff72614b5e3b1159d4208f498) scope-tui: init at 0-unstable-2024-03-16
* [`faa50307`](https://github.com/NixOS/nixpkgs/commit/faa50307c84ca697f4d940fe97132c034f0e7eb3) kubectl-view-allocations: 0.16.3 -> 0.18.1
* [`9291ce4e`](https://github.com/NixOS/nixpkgs/commit/9291ce4e24870c375e4581cc0a08c21ba373d3b2) maintainers: add aorith
* [`7238c476`](https://github.com/NixOS/nixpkgs/commit/7238c47669204333298772f35d86e7af9236500d) silverbullet: init at 0.7.6
* [`a1301766`](https://github.com/NixOS/nixpkgs/commit/a1301766ebc835843fb509eb03638f079c030aeb) nixos/silverbullet: init module
* [`b8f91b87`](https://github.com/NixOS/nixpkgs/commit/b8f91b87a34b7322b8a0a52b97280c1c05e52e1b) nixosTests.silverbullet: init
* [`557e24c4`](https://github.com/NixOS/nixpkgs/commit/557e24c4d3380e01b1505696d9cd551cd45774d3) svt-av1: add ffmpeg to passthru.tests
* [`1e6a3c81`](https://github.com/NixOS/nixpkgs/commit/1e6a3c8115143c1131c8104c0f4a5e4f98122269) at-spi2-core: 2.50.1 → 2.50.2
* [`0fb28567`](https://github.com/NixOS/nixpkgs/commit/0fb285678db687d8768ccc282a0b6110a57d1544) darwin.apple_sdk.darwin-stubs: add SDK-specific stubs
* [`b5526122`](https://github.com/NixOS/nixpkgs/commit/b55261221775d99deaea5f67be80c45171120b38) darwin.CoreSymbolication: build as a framework
* [`55505c55`](https://github.com/NixOS/nixpkgs/commit/55505c558fb8a6c4285c9c5d93675a04727e04fc) darwin.libplatform: fix build of 11.0 SDK source release
* [`25af398f`](https://github.com/NixOS/nixpkgs/commit/25af398f885bf51b0c89837850888af115828f6b) darwin.system_cmds: 735.50.6 -> 970.0.4
* [`01c71435`](https://github.com/NixOS/nixpkgs/commit/01c714358059865e38c16adb410e9a4e15da5541) libnice: 0.1.21 -> 0.1.22
* [`99adc28d`](https://github.com/NixOS/nixpkgs/commit/99adc28d655088254a162ccb35fdfb86f97d27cf) python312Packages.pytest-cases: 3.8.2 -> 3.8.4
* [`2ad2295b`](https://github.com/NixOS/nixpkgs/commit/2ad2295bb3d6093b93f6a3a0617119e54e162156) autoPatchelfHook: move multiline hook into a function
* [`89a6254a`](https://github.com/NixOS/nixpkgs/commit/89a6254accafc77162a271271fbcc1266d63ada1) libxml2: Remove Darwin bootstrapping hack
* [`b82d8dea`](https://github.com/NixOS/nixpkgs/commit/b82d8dea03b7df0eb166110251286834d511d6b9) Add maintainer rutherther
* [`f5010e8d`](https://github.com/NixOS/nixpkgs/commit/f5010e8d04a5479df73bffd482c22e1eecbbc715) python311Packages.aiomisc: 17.5.2 -> 17.5.4
* [`07451425`](https://github.com/NixOS/nixpkgs/commit/07451425e7a6c177444381d1f51074cbeaaf11bc) darwin.stdenv: drop curl from the bootstrap
* [`a098790c`](https://github.com/NixOS/nixpkgs/commit/a098790c312ed57ee175118a3b74d8ce28f5f6cd) srb2: fetch assets from upstream GitLab
* [`a30f610e`](https://github.com/NixOS/nixpkgs/commit/a30f610e4fb348b70b8e566b33bbefa19d3ecc4c) python311Packages.apispec: 6.5.0 -> 6.6.0
* [`4cb5b43a`](https://github.com/NixOS/nixpkgs/commit/4cb5b43a566e81bc0747475cf5237cea1c382a11) rosa: init at 1.2.35
* [`d084853e`](https://github.com/NixOS/nixpkgs/commit/d084853edd672751d35dbd0b44e1222d63c130b1) sdl: fix comment
* [`d1bd8a3d`](https://github.com/NixOS/nixpkgs/commit/d1bd8a3d52b749b557d3309e8fd1fffe0215dcf1) maintainers: add @⁠ferrine
* [`4d75eb84`](https://github.com/NixOS/nixpkgs/commit/4d75eb84891c70f780486cfd4c218bef327b8dfa) python3Packages.pymc: add @⁠ferrine to maintainers
* [`d031a4d8`](https://github.com/NixOS/nixpkgs/commit/d031a4d8c0b9ecbfcedda43ed4486ebb4395f63c) python3Packages.pytensor: add @⁠ferrine to maintainers
* [`d84179f6`](https://github.com/NixOS/nixpkgs/commit/d84179f63642dce236a9e2b28fd1f23335eb1387) maintainers: add giodamelio
* [`9106d1ee`](https://github.com/NixOS/nixpkgs/commit/9106d1ee46798ff09d8f5fe732e722341ef85ffa) umockdev: 0.17.18 -> 0.18.0
* [`5007c8b5`](https://github.com/NixOS/nixpkgs/commit/5007c8b574d96748c78794bf049dc75ed03570f6) python312Packages.ukpostcodeparser: normalize pname
* [`feb4af11`](https://github.com/NixOS/nixpkgs/commit/feb4af11ee9b2cbdcf80dd0eb00875a9c3ed65a6) python312Packages.send2trash: normalize pname
* [`efab38f7`](https://github.com/NixOS/nixpkgs/commit/efab38f7655d668d4c552846e513579436ec6c37) systemd: 255.2 -> 255.4
* [`0f8f7d09`](https://github.com/NixOS/nixpkgs/commit/0f8f7d097ae35dc3bd53d82a0caf87744f23b1db) python311Packages.scipy: remove nose dependency
* [`52e41daf`](https://github.com/NixOS/nixpkgs/commit/52e41dafee17ed0bf43f2636ffff4d28ccdf2af3) maintainers: add clot27
* [`f92f91aa`](https://github.com/NixOS/nixpkgs/commit/f92f91aa0b668d191c0786cf393281a0c22a8048) little_boxes: init at 1.10.0
* [`cf53c81a`](https://github.com/NixOS/nixpkgs/commit/cf53c81a2d7e322fa5fdd167732b28ac30278f14) vimUtils.neovimRequireCheckHook: fix hook by adding plugin dependencies to rtp
* [`2bf7196d`](https://github.com/NixOS/nixpkgs/commit/2bf7196dd4c447481fafc469937c58a47e51f9d5) vimPlugins.hardhat-nvim: add nvimRequireCheck
* [`8c4a1e8d`](https://github.com/NixOS/nixpkgs/commit/8c4a1e8d66579084147e85cf483a91d03f9f1dd1) Avoid top-level `with ...;` in pkgs/build-support/agda/default.nix
* [`e0611b7b`](https://github.com/NixOS/nixpkgs/commit/e0611b7ba70844eb3f5bb875b9ddf8ea579a73af) Avoid top-level `with ...;` in pkgs/build-support/bintools-wrapper/default.nix
* [`a14127aa`](https://github.com/NixOS/nixpkgs/commit/a14127aa647d31582aaf481cec6b4112bc744973) Avoid top-level `with ...;` in pkgs/build-support/build-fhsenv-bubblewrap/default.nix
* [`03962f07`](https://github.com/NixOS/nixpkgs/commit/03962f077c087ec71551e0f3a33c83fce51e5efa) Avoid top-level `with ...;` in pkgs/build-support/coq/default.nix
* [`4fc5d505`](https://github.com/NixOS/nixpkgs/commit/4fc5d50549057933db2b40fe9654398ead5dfef2) Avoid top-level `with ...;` in pkgs/build-support/coq/meta-fetch/default.nix
* [`aa32ce52`](https://github.com/NixOS/nixpkgs/commit/aa32ce526a31503cf4990775559a4e23503c8fde) Avoid top-level `with ...;` in pkgs/build-support/fetchrepoproject/default.nix
* [`869e5566`](https://github.com/NixOS/nixpkgs/commit/869e55660606c401d4dec02f9ab1adda5b450521) Avoid top-level `with ...;` in pkgs/build-support/fetchsourcehut/default.nix
* [`997e54a4`](https://github.com/NixOS/nixpkgs/commit/997e54a4fb050e62a36865f6c3daea7125a89bf7) Avoid top-level `with ...;` in pkgs/build-support/nix-gitignore/default.nix
* [`b7bcfbae`](https://github.com/NixOS/nixpkgs/commit/b7bcfbaeeb0cbf328441a08ccb0fea087150c67d) Avoid top-level `with ...;` in pkgs/build-support/pkg-config-wrapper/default.nix
* [`7c4a7108`](https://github.com/NixOS/nixpkgs/commit/7c4a71081cb4a52e5fac535f6a27143bb354ec77) Avoid top-level `with ...;` in pkgs/build-support/replace-dependency.nix
* [`f36441db`](https://github.com/NixOS/nixpkgs/commit/f36441dbd8eedf6864540b3476e3873c3328258b) Avoid top-level `with ...;` in pkgs/build-support/release/default.nix
* [`102a33d3`](https://github.com/NixOS/nixpkgs/commit/102a33d30eb2bb015b264992d46beda33fdac58f) Avoid top-level `with ...;` in pkgs/build-support/vm/test.nix
* [`c4d42034`](https://github.com/NixOS/nixpkgs/commit/c4d420345dd9cd05fadbd5472025c2c52ca70d45) Avoid top-level `with ...;` in pkgs/build-support/coq/extra-lib.nix
* [`efb603b2`](https://github.com/NixOS/nixpkgs/commit/efb603b277598033b95dd30c98eb254b9f6d7af9) Avoid top-level `with ...;` in pkgs/build-support/writers/test.nix
* [`17b1e7be`](https://github.com/NixOS/nixpkgs/commit/17b1e7be2b9c7c1e90fc260873ef853582cf8b25) robin-map: 1.2.1 -> 1.2.2
* [`cf38d088`](https://github.com/NixOS/nixpkgs/commit/cf38d08863cf19d67d3bc5798b3a7b126c000f4b) rkbin: init at unstable-2024.02.22
* [`070737c9`](https://github.com/NixOS/nixpkgs/commit/070737c9b76be7b7d231d1f9195fd4f0152194bc) arm-trusted-firmware: add RK3588
* [`95d1f949`](https://github.com/NixOS/nixpkgs/commit/95d1f9499a0ca6f2ba45b38ad74bdcb460f33dd5) ubootRock5ModelB: init at 2024.01
* [`d2458445`](https://github.com/NixOS/nixpkgs/commit/d245844528d54eb158c792e07f37f6d3d124da87) ubootOrangePi5: init at 2024.01
* [`5d8ee3b3`](https://github.com/NixOS/nixpkgs/commit/5d8ee3b3199b0d1f657f9ab58c00c8574f71722a) python312Packages.s3fs: 2024.3.0 -> 2024.3.1
* [`2c658565`](https://github.com/NixOS/nixpkgs/commit/2c6585657cf7ab0c093582a6042702fa825d7a26) audible-cli: 0.2.6 -> 0.3.1
* [`0a1ede55`](https://github.com/NixOS/nixpkgs/commit/0a1ede550a1cd5cf52d87b88b3a83d1acb6abad8) python311Packages.batchspawner: 1.2.0 -> 1.3.0
* [`32dd56f4`](https://github.com/NixOS/nixpkgs/commit/32dd56f420ad27eae44af2e47a59898529512b29) rkbin: removed thefossguy from maintainer list
* [`c0264952`](https://github.com/NixOS/nixpkgs/commit/c0264952b56e4abe99a91abe1bf2b8ec1d937d82) python312Packages.python-uinput: 0.11.2 -> 1.0.1
* [`72cfa3ac`](https://github.com/NixOS/nixpkgs/commit/72cfa3ac542e23a87ced8275e629874a68d6604e) s2n-tls: 1.4.7 -> 1.4.8
* [`8da44aaa`](https://github.com/NixOS/nixpkgs/commit/8da44aaa891451c8b9f03cbe712bd7b6f11ad176) maintainers: add thefossguy
* [`911c1a8e`](https://github.com/NixOS/nixpkgs/commit/911c1a8ecaa26705717ccfa7863961be4f49855d) rkbin: re-add thefossguy as the package maintainer
* [`b6d2a429`](https://github.com/NixOS/nixpkgs/commit/b6d2a4294e4b9452bdc930932902a61e35382224) gnutls: 3.8.3 -> 3.8.4 (medium security)
* [`f5487165`](https://github.com/NixOS/nixpkgs/commit/f5487165d689a157e0c44e242a18d051e2b4f3b4) gnutls: revert switching compression libs to dlopen()
* [`98685bbb`](https://github.com/NixOS/nixpkgs/commit/98685bbb5cac987b6b1673a57a19949e3c26037b) cherrytree: 1.0.4 -> 1.1.0
* [`ac94801b`](https://github.com/NixOS/nixpkgs/commit/ac94801b02226aa417cf29e3d5151f7307c188c3) ocamlPackages.linenoise: 1.5 -> 1.5.1
* [`f5702242`](https://github.com/NixOS/nixpkgs/commit/f570224278abf044f7b03993ba6e584d8958f91b) rnd-name: init at 1.0.0
* [`303a8dff`](https://github.com/NixOS/nixpkgs/commit/303a8dffb9d26f8cf306f52238f45337b62f429f) hunspellDictsChromium: add fr_FR
* [`00155e6f`](https://github.com/NixOS/nixpkgs/commit/00155e6f423cf485c353b913dc4d78a4d0ce8897) python311Packages.batchspawner: refactor
* [`f8887537`](https://github.com/NixOS/nixpkgs/commit/f888753776bccfcc8616e400aac823c651fb83ed) python311Packages.batchspawner: enable tests
* [`545e5962`](https://github.com/NixOS/nixpkgs/commit/545e59625799f404a78fb24560ad61c24e570a8a) jetbrains.jcef: make deterministic
* [`2df36c1c`](https://github.com/NixOS/nixpkgs/commit/2df36c1c9b71bc990ab7975ece66c48554183659) vals: fix repo origin and upgrade to latest
* [`c38ad034`](https://github.com/NixOS/nixpkgs/commit/c38ad034ac5a5252f0a9e770eea5957ae44286e0) grafana-dash-n-grab: 0.5.2 -> 0.6.0
* [`234bb31f`](https://github.com/NixOS/nixpkgs/commit/234bb31f611f43f8b744b305ab82035de637aaca) Fix venv creation in Python environments
* [`96118850`](https://github.com/NixOS/nixpkgs/commit/96118850f323f41c163f1f5a8231128879fb2f2e) Unwrap python scripts when building an environment
* [`545de247`](https://github.com/NixOS/nixpkgs/commit/545de24791b0c8471abe3bc1be683eeb7aa18ea7) vulkan-headers: 1.3.275.0 -> 1.3.280.0
* [`28975c73`](https://github.com/NixOS/nixpkgs/commit/28975c7385dc5a901e65ec62752d782010b50c60) vulkan-loader: 1.3.275.0 -> 1.3.280.0
* [`3787eff1`](https://github.com/NixOS/nixpkgs/commit/3787eff1ec6ecc6da2922d276500e4c529b65203) vulkan-validation-layers: 1.3.275.0 -> 1.3.280.0
* [`ba7516ae`](https://github.com/NixOS/nixpkgs/commit/ba7516ae83aac73fbe4594d2ad6b4c7444284442) vulkan-tools: 1.3.275.0 -> 1.3.280.0
* [`ad61d5c9`](https://github.com/NixOS/nixpkgs/commit/ad61d5c9d7cb304a932aa85c97c46fc9548a8a9e) vulkan-tools-lunarg: 1.3.275.0 -> 1.3.280.0
* [`5897219a`](https://github.com/NixOS/nixpkgs/commit/5897219a928860ca86e7f05fc3a1ed82712311ff) vulkan-extension-layer: 1.3.275.0 -> 1.3.280.0
* [`8b60fc97`](https://github.com/NixOS/nixpkgs/commit/8b60fc973762eafe0d741613e286393c91ca304c) vulkan-utility-libraries: 1.3.275.0 -> 1.3.280.0
* [`9939e9dd`](https://github.com/NixOS/nixpkgs/commit/9939e9dd82cdfc6a2cdb05b0ac69075ea21c7c5b) vulkan-volk: 1.3.275.0 -> 1.3.280.0
* [`84d16ce8`](https://github.com/NixOS/nixpkgs/commit/84d16ce84b291dc27c5806ec7484603ad374fba4) spirv-headers: 1.3.275.0 -> 1.3.280.0
* [`c0e45491`](https://github.com/NixOS/nixpkgs/commit/c0e45491bf2f278752fb612cb6767d676d8ab73d) spirv-cross: 1.3.275.0 -> 1.3.280.0
* [`3fbc0885`](https://github.com/NixOS/nixpkgs/commit/3fbc0885d46bb20608bacb8e51bd19918f549994) spirv-tools: 1.3.275.0 -> 1.3.280.0
* [`ad60aa50`](https://github.com/NixOS/nixpkgs/commit/ad60aa50e224deac5f1cc6edf7855c11af242266) libtiff: Add LERC support
* [`79129b7c`](https://github.com/NixOS/nixpkgs/commit/79129b7cd272e9e3483b3f1003a17373c4d1d145) wayland-protocols: 1.33 -> 1.34
* [`50fcbfbe`](https://github.com/NixOS/nixpkgs/commit/50fcbfbe26ef6fedd867f0f5a2ea681dec780e56) nixos/thanos: Added query.grpc-compression and receive.grpc-compression option.
* [`25d492ef`](https://github.com/NixOS/nixpkgs/commit/25d492efeaa9875580d16bdc6d6a939bd2c45420) gitlab-runner: 16.9.1 -> 16.10.0
* [`9804a6c7`](https://github.com/NixOS/nixpkgs/commit/9804a6c7031b00536d1277414c932b556b1c858a) kernels.linux_lqx: fix build
* [`c41df327`](https://github.com/NixOS/nixpkgs/commit/c41df327432aa5dba382dc863011606e375c8089) kernel/generic: fix overrides
* [`7feed229`](https://github.com/NixOS/nixpkgs/commit/7feed22946968af8249ac0e38368f43e15e8ad36) dpdk-kmods: unbreak hardened kernels
* [`bcd6e799`](https://github.com/NixOS/nixpkgs/commit/bcd6e799e0a53f8f85e1faf6676bfab20e02ca4d) python3.pkgs.pythonRuntimeDepsCheckHook: skip empty specifiers
* [`2c68d6b0`](https://github.com/NixOS/nixpkgs/commit/2c68d6b0298d430fdd0f498ec6b27b49193f8b1c) python311Packages.packaging: 23.2 -> 24.0
* [`e7533df8`](https://github.com/NixOS/nixpkgs/commit/e7533df80fd18b4a06b44142e863738c3f3bced5) nixos/mastodon: stop mastodon-init-db.service if check for seeded DB fails
* [`02e833b2`](https://github.com/NixOS/nixpkgs/commit/02e833b2dcd328713572aeb24a5054711e566190) dolphin-emu: fix build w/ glibc-2.39
* [`91d85fb0`](https://github.com/NixOS/nixpkgs/commit/91d85fb0e654a1d187e39fd2460df78fb09628ce) cataclysm-dda: fix build w/ glibc-2.39
* [`180b5c1c`](https://github.com/NixOS/nixpkgs/commit/180b5c1c8c1a40a36e849e576d97e1e775972e7a) pkgsMusl.npth: backport patch to fix build
* [`38bd8816`](https://github.com/NixOS/nixpkgs/commit/38bd8816b53ef7615419c97980731cb2b9547204) python312Packages.bids-validator: 1.14.1 -> 1.14.4
* [`e20ff763`](https://github.com/NixOS/nixpkgs/commit/e20ff76306fac43c024832d41bbaca2e11730e46) xmrig: 6.21.1 -> 6.21.2
* [`b14d2bfb`](https://github.com/NixOS/nixpkgs/commit/b14d2bfbe6f9a8dd796618d0eb37a5d7adf7b7a6) ocamlPackages.ocaml-version: 3.6.4 -> 3.6.5
* [`22a979fe`](https://github.com/NixOS/nixpkgs/commit/22a979fe338d3b6970a59938135fcd453f6c9e92) darwin.moltenvk: 1.2.7 -> 1.2.8
* [`760688e2`](https://github.com/NixOS/nixpkgs/commit/760688e21b2ccef160ec61f9003d9509de9726d1) libstrophe: move to by-name structure
* [`ca5e6189`](https://github.com/NixOS/nixpkgs/commit/ca5e6189d42a8d27bbc133f23479d9b8011bb51b) libstrophe: 0.12.3 -> 0.13.1
* [`28e05d60`](https://github.com/NixOS/nixpkgs/commit/28e05d601def6ba444440297af47679fd6f86741) python311Packages.types-protobuf: 4.24.0.20240302 -> 4.24.0.20240311
* [`e662b937`](https://github.com/NixOS/nixpkgs/commit/e662b937b2e488f9494ce2fa06a706256796fe75) python311Packages.azure-mgmt-netapp: 11.0.0 -> 12.0.0
* [`1892e136`](https://github.com/NixOS/nixpkgs/commit/1892e1361a222f7d3cdf67411fd800f723b5f5f0) feat(uboot): add rock4cplus support
* [`2ffca11e`](https://github.com/NixOS/nixpkgs/commit/2ffca11eb2d5c198334ad3406edb12d2fd6894d7) mullvad-vpn: 2023.6 -> 2024.1
* [`0697a4a5`](https://github.com/NixOS/nixpkgs/commit/0697a4a55b7cf4dda0503e157886fe2b7178207f) ncnn: fix build on Darwin
* [`78ebe0cf`](https://github.com/NixOS/nixpkgs/commit/78ebe0cf68596cc214491b2d789836e54b6f4117) perlPackages.Gtk3: fix build on Darwin
* [`dcccf09f`](https://github.com/NixOS/nixpkgs/commit/dcccf09f976a9465c5fb265345921d3086a06d96) keepassxc: add and enable passkeys build option
* [`80939098`](https://github.com/NixOS/nixpkgs/commit/80939098540ec3f239663dbf67eb47958ab81bb7) python311Packages.sqlalchemy: 2.0.28 -> 2.0.29
* [`43f4738f`](https://github.com/NixOS/nixpkgs/commit/43f4738f8bcbcb637115930d7d354f6b60f935a7) nzbget: change pname from nzbget-ng to nzbget
* [`087be5ef`](https://github.com/NixOS/nixpkgs/commit/087be5ef73385d436bf58e745f4beb8a61b34073) nzbget: add buffer overflow patch
* [`ec4a6600`](https://github.com/NixOS/nixpkgs/commit/ec4a6600efa595c6e21759a737d3051b6523a38b) python311Packages.jaraco-test: 5.3.0 -> 5.4.0
* [`62d1bddc`](https://github.com/NixOS/nixpkgs/commit/62d1bddc117263ea95f3744e6d16e3072363d28a) python312Packages.inlinestyler: fix build
* [`44ca82ae`](https://github.com/NixOS/nixpkgs/commit/44ca82aeb208addf46880c4e312064451bebd2b9) jitsi-meet: 1.0.7790 -> 1.0.7874
* [`b236a18d`](https://github.com/NixOS/nixpkgs/commit/b236a18d08d427fd29849e0ea356ed7d786cab13) netbox: 3.7.3 -> 3.7.4
* [`c84e03c9`](https://github.com/NixOS/nixpkgs/commit/c84e03c9a6328d59705afa7fdd182ecf5a243d32) python312Packages.panflute: 2.3.0 -> 2.3.1
* [`b64f0eae`](https://github.com/NixOS/nixpkgs/commit/b64f0eaee61a056f156e70e3f2601bfb4a2b0d0a) python311Packages.flask-security-too: 5.4.2 -> 5.4.3
* [`0e050d5c`](https://github.com/NixOS/nixpkgs/commit/0e050d5c21632d7d5da9b65bb973863c5d7e833a) simplotask: 1.13.1 → 1.14.1
* [`8392816b`](https://github.com/NixOS/nixpkgs/commit/8392816b82d3c79bdda61ed3bf951e68609c7a85) simplotask: migrate to by-name
* [`ddbfea89`](https://github.com/NixOS/nixpkgs/commit/ddbfea89f23467605d3bf7346ee584d0f8fbd362) python312Packages.parsel: 1.8.1 -> 1.9.0
* [`e6a5b5f9`](https://github.com/NixOS/nixpkgs/commit/e6a5b5f924091c4d52d2921de4291f8108acc07c) kubescape: 2.9.1 -> 3.0.7
* [`debcd567`](https://github.com/NixOS/nixpkgs/commit/debcd5675a235abaf24a995c5fa09f288df363a1) fzf: 0.47.0 -> 0.48.1
* [`01b53551`](https://github.com/NixOS/nixpkgs/commit/01b5355140dd2d484eef7fc8f2ef94376e8a20e8) python312Packages.types-psutil: 5.9.5.20240205 -> 5.9.5.20240316
* [`e3812e18`](https://github.com/NixOS/nixpkgs/commit/e3812e187592c866349630cc097c786b353130c7) fzf: Update package and module (shell-completions)
* [`838750a9`](https://github.com/NixOS/nixpkgs/commit/838750a9fd84b4228c741e89a0e1a1f137885e1c) hydra_unstable: 2023-12-24 -> 2024-03-08, use nix_2_20
* [`e7267009`](https://github.com/NixOS/nixpkgs/commit/e72670091620c725176d46ec44b6a6eb4bf86e37) ldc: add meta.mainProgram
* [`9eb38aa6`](https://github.com/NixOS/nixpkgs/commit/9eb38aa6f425cd1ebccb2497bbe22859bc686e12) ytmdesktop: remove
* [`578fe469`](https://github.com/NixOS/nixpkgs/commit/578fe4699234086a82f3841aa188ccfe6babcb50) knossosnet: 1.0.0 -> 1.1.0
* [`811fae61`](https://github.com/NixOS/nixpkgs/commit/811fae61aa241db4a74d3a944ae1660258989a5e) ocamlPackages.metadata: 0.2.0 -> 0.3.0
* [`70465372`](https://github.com/NixOS/nixpkgs/commit/704653725ea8e646f861311d9f509c6bf2fdd49c) rPackages: CRAN and BioC update
* [`c06318fb`](https://github.com/NixOS/nixpkgs/commit/c06318fb151b4055d3054316e32a8d227c90cf9c) rPackages.igraph: fix build
* [`6bd9d579`](https://github.com/NixOS/nixpkgs/commit/6bd9d579ea4eff7a426adb51e8e22c13b01e75f3) rPackages.Rsamtools: fix build
* [`9fcadd01`](https://github.com/NixOS/nixpkgs/commit/9fcadd01330247042b1d5caacc886b299b909e60) rPackages.Rhdf5lib: use newer hdf5
* [`26452b88`](https://github.com/NixOS/nixpkgs/commit/26452b883ea0d63d7668c82b7c2d743fc3a778cd) python311Packages.cryptolyzer: 0.12.2 -> 0.12.3
* [`46d94fca`](https://github.com/NixOS/nixpkgs/commit/46d94fca94e57778618264a6f3f3016b0b4ec135) ruffle: nightly-2024-02-09 -> nightly-2024-03-25
* [`304768b6`](https://github.com/NixOS/nixpkgs/commit/304768b6eac2a5a6f2707c3381af2918d08f7805) ffmpeg: switch to fetchpatch2, remove unused patch
* [`229b4d20`](https://github.com/NixOS/nixpkgs/commit/229b4d208a7bff2325f426c32e2e0c8dab93ba38) ffmpeg: cherry-pick build fix for latest vulkan-headers
* [`72f23522`](https://github.com/NixOS/nixpkgs/commit/72f2352214dc0c4621b3559c9d15dfdda782218a) poco: 1.12.5p2 -> 1.13.2
* [`9304c9ae`](https://github.com/NixOS/nixpkgs/commit/9304c9ae3a38d1418c755d38d3ee6cc8cb157cad) floorp: 11.10.5 -> 11.11.2
* [`e1d57158`](https://github.com/NixOS/nixpkgs/commit/e1d57158b489dd522b2e1f90cf46743ec3a00909) python312Packages.tadasets: 0.0.4 -> 0.2.1
* [`ee2b899f`](https://github.com/NixOS/nixpkgs/commit/ee2b899ff708ba8d94567c3cea8a0e823d262513) nixos/nfsd: settings for /etc/nfs.conf
* [`02d77549`](https://github.com/NixOS/nixpkgs/commit/02d77549979548a90baa7bf9442178a759ab64ff) merkaartor: fix postInstall
* [`c50a23dc`](https://github.com/NixOS/nixpkgs/commit/c50a23dca8ac95e2ccb423a24ad87c91e03c4d2c) python312Packages.click-command-tree: 1.1.1 -> 1.2.0
* [`c27b6c38`](https://github.com/NixOS/nixpkgs/commit/c27b6c38346ec42ecb143d99000da74ebff60729) gradle: 8.6 -> 8.7
* [`7bdab228`](https://github.com/NixOS/nixpkgs/commit/7bdab22812e3e3ef50582f5cdc2921406d3d9768) k3s: document upkeep process
* [`2d682158`](https://github.com/NixOS/nixpkgs/commit/2d682158688e242988a3d8446bac8a92264387ad) nerdfetch: init at 8.1.0
* [`6e4f9389`](https://github.com/NixOS/nixpkgs/commit/6e4f93892fbde110100b15bc3c4956016c256679) level-zero: 1.16.1 -> 1.16.11
* [`f3c430f5`](https://github.com/NixOS/nixpkgs/commit/f3c430f5ebd44ca5883b606e5dd6341f0c068127) python311Packages.kaggle: 1.6.6 -> 1.6.8
* [`3e426221`](https://github.com/NixOS/nixpkgs/commit/3e426221d91bb3c596f6f23c563e6f77aa5f5a2b) dwm: add updateScript
* [`dd4ff7bb`](https://github.com/NixOS/nixpkgs/commit/dd4ff7bb3531d4ef3516233a453baa0c1282f206) sloth-app: init at 3.2
* [`0a8bbd48`](https://github.com/NixOS/nixpkgs/commit/0a8bbd48dcb79fff66c47669b7f00d540130a4eb) bee: 1.18.2 -> 2.0.0
* [`1901177c`](https://github.com/NixOS/nixpkgs/commit/1901177c9e601beff5071e32be0c1da517b0cf9b) floorp: add `updateScript`
* [`f72e4902`](https://github.com/NixOS/nixpkgs/commit/f72e49025e54a283d2e9e4994083253958300135) python312Packages.icalendar: 5.0.10 -> 5.0.12
* [`1bfd1463`](https://github.com/NixOS/nixpkgs/commit/1bfd14632e682c8f0f34c711903e0f81b9ec557a) aws-sso-creds: 1.5.0 -> 2.0.0
* [`6d46950f`](https://github.com/NixOS/nixpkgs/commit/6d46950f17b945a771ebf8c6562be5ccecff7b39) python312Packages.querystring-parser: refactor
* [`f0ec46ed`](https://github.com/NixOS/nixpkgs/commit/f0ec46ed1309e30908db3479615ad83e4e0e36e7) python311Packages.ftfy: 6.1.3 -> 6.2.0
* [`2d28cc4c`](https://github.com/NixOS/nixpkgs/commit/2d28cc4c2806e046e131452fd0ca64d2648e8631) libchardet: add autoreconfHook, fixing cross compilation
* [`48e9fb56`](https://github.com/NixOS/nixpkgs/commit/48e9fb568507aa353297b7425d0df76c6cf33104) drawio: 24.0.4 -> 24.1.0
* [`3c9c0169`](https://github.com/NixOS/nixpkgs/commit/3c9c016904a00746707e283ab93287a329143a80) maintainers: add marmolak
* [`9629f921`](https://github.com/NixOS/nixpkgs/commit/9629f921796ad5810387e6cdc51dd98b3223165a) python311Packages.vobject: 0.9.6.1 -> 0.9.7
* [`d3112aaa`](https://github.com/NixOS/nixpkgs/commit/d3112aaaa0b10609f226e4a584fcdb81661a2e84) litebrowser: unstable-2022-10-31 -> unstable-2024-02-25
* [`404317c2`](https://github.com/NixOS/nixpkgs/commit/404317c27011331e16f071d1ae62ea662d5b3cf0) sanjuuni: add patch to build with c++17
* [`bf6c95a4`](https://github.com/NixOS/nixpkgs/commit/bf6c95a420c1bdd6f90177f9457ee0878393a38a) eval-type-backport: init at 0.1.3
* [`9ba39231`](https://github.com/NixOS/nixpkgs/commit/9ba392312c37c3e31524ff5cb9eb41b2b22cc5c5) pydantic: fix build failure on Python 3.9
* [`f7fdda79`](https://github.com/NixOS/nixpkgs/commit/f7fdda79d3e078452533fff290ed16826a8b6c33) tart: 2.6.0 -> 2.7.2
* [`7c5c656b`](https://github.com/NixOS/nixpkgs/commit/7c5c656be620b96f078637440c98fe06b86dc661) bazel-buildtools: 6.4.0 -> 7.1.0
* [`aee2b5bd`](https://github.com/NixOS/nixpkgs/commit/aee2b5bda6af462f9e3c39cc9db284838322f065) fio: 3.36 -> 3.37
* [`a5217645`](https://github.com/NixOS/nixpkgs/commit/a5217645138d91745690095f9ea73f788f4a6a7e) sketchybar: add passthru.updateScript
* [`c164c8db`](https://github.com/NixOS/nixpkgs/commit/c164c8dbc76b6bd7c77f1ea50d829a80c035c82d) python312Packages.motor: 3.3.2 -> 3.4.0
* [`1dacec9b`](https://github.com/NixOS/nixpkgs/commit/1dacec9bb9a7eb7907c4d0d959ef869d6aa92b5c) nixos/llama-cpp: fix example flags
* [`dbb569d2`](https://github.com/NixOS/nixpkgs/commit/dbb569d2269349ac7870645a1456b84cadbf7791) opentelemetry-collector-contrib: 0.96.0 -> 0.97.0
* [`88d183af`](https://github.com/NixOS/nixpkgs/commit/88d183af8555f34169d8214350b234dc45606e78) init
* [`bc71d924`](https://github.com/NixOS/nixpkgs/commit/bc71d9242d3e1ae6746a56ece179b6bf6d8b3688) maintainers: add assistant
* [`d12a131e`](https://github.com/NixOS/nixpkgs/commit/d12a131e6757490eff3c992eb1c9b3bde0386b9a) k3s_1_26: 1.26.14+k3s1 -> 1.26.15+k3s1
* [`559d9a8a`](https://github.com/NixOS/nixpkgs/commit/559d9a8aebfc1b30bef4b22b41ba76c0e77e1487) touchosc: 1.2.9.200 -> 1.3.0.202
* [`7a3e224c`](https://github.com/NixOS/nixpkgs/commit/7a3e224c96237374a7fd802ac94d4ebca637d5ef) python312Packages.glad2: 2.0.5 -> 2.0.6
* [`56bd37f5`](https://github.com/NixOS/nixpkgs/commit/56bd37f57b5ca6f48580fc89326014e0bcea1557) abaddon: 0.1.14 -> 0.2.0
* [`3b6ce9e8`](https://github.com/NixOS/nixpkgs/commit/3b6ce9e83e74a689109707ed25eb78464ef0cf5e) trickle, nodepackages.pyright: add meta.mainProgram
* [`8930b25e`](https://github.com/NixOS/nixpkgs/commit/8930b25eaf6c2902a96f2dc2874c65cff97e7e73) ttyd: 1.7.4 -> 1.7.5
* [`11b290a5`](https://github.com/NixOS/nixpkgs/commit/11b290a5d8a2484e7ea0f1aa9e883a530e8c6be0) wxsqlite3: 4.9.9 -> 4.9.10
* [`3cb77cec`](https://github.com/NixOS/nixpkgs/commit/3cb77cecea1ef489cc90bc8f3b511d29330ddfab) emacs: 29.2 -> 29.3
* [`647c2aa2`](https://github.com/NixOS/nixpkgs/commit/647c2aa286f0ef6fdcf22193ca3880cb62d81eef) elpa-packages: updated 2024-03-25 (from nix-community/emacs-overlay)
* [`fa774684`](https://github.com/NixOS/nixpkgs/commit/fa774684443dcfaab3a8e062b58b6741cd9ba218) elpa-devel-packages: updated 2024-03-25 (from nix-community/emacs-overlay)
* [`1f5deed7`](https://github.com/NixOS/nixpkgs/commit/1f5deed77009d91430afb7fc1df79cf1da0a34f4) melpa-packages: updated 2024-03-25 (from nix-community/emacs-overlay)
* [`7f7f6aa8`](https://github.com/NixOS/nixpkgs/commit/7f7f6aa8f1ac0c90d600079477210e7841c7fc06) nongnu-packages: updated 2024-03-25 (from nix-community/emacs-overlay)
* [`b6f7ac62`](https://github.com/NixOS/nixpkgs/commit/b6f7ac6249a0ceb424b3d503b214f1dc3859952d) discord: 0.0.46 -> 0.0.47
* [`60d5c000`](https://github.com/NixOS/nixpkgs/commit/60d5c00005150473b5c5d1dd6276eec311c264d1) discord: 0.0.296 -> 0.0.298
* [`a76795da`](https://github.com/NixOS/nixpkgs/commit/a76795da9a23fea41cda73ee7c6439dfa81e5854) discord-canary: 0.0.323 -> 0.0.326
* [`ff1203ea`](https://github.com/NixOS/nixpkgs/commit/ff1203ea7c1004b22cbd2a3d966f3b8de6dd2857) discord-canary: 0.0.435 -> 0.0.451
* [`4f6f827c`](https://github.com/NixOS/nixpkgs/commit/4f6f827c98a6808ed9d55b76ef35902189ceaaa1) discord-ptb: 0.0.102 -> 0.0.105
* [`810348fa`](https://github.com/NixOS/nixpkgs/commit/810348fab3a624a36ea9c1f46751cc4ca41cad7e) discord-development: 0.0.31 -> 0.0.39
* [`3ad55657`](https://github.com/NixOS/nixpkgs/commit/3ad55657876b3d698c6434875abab01941323589) sketchybar-app-font: 2.0.12 -> 2.0.14
* [`2f21ef16`](https://github.com/NixOS/nixpkgs/commit/2f21ef168393c9398a4485f4d5234cf017a55db4) sketchybar-app-font: 2.0.14 -> 2.0.15
* [`72de67d2`](https://github.com/NixOS/nixpkgs/commit/72de67d24893e6b1f30446434f1142971d674456) gci: 0.13.1 -> 0.13.2
* [`eac0c48f`](https://github.com/NixOS/nixpkgs/commit/eac0c48f385db730f2ac7ecf64f5952b3f45d154) govc: 0.36.1 -> 0.36.2
* [`00c52fb2`](https://github.com/NixOS/nixpkgs/commit/00c52fb204890e249282351ca964c0c5203cc34c) catppuccin-sddm-corners: add passthru.updateScript
* [`9b0e1b7f`](https://github.com/NixOS/nixpkgs/commit/9b0e1b7fce6d31762ca20ed8b4dbb86a0055e129) dooit: add passthru.updateScript
* [`803d0616`](https://github.com/NixOS/nixpkgs/commit/803d061696b6646a6c22610590f110eb27bf4e0a) waybar: add passthru.updateScript
* [`57784e8b`](https://github.com/NixOS/nixpkgs/commit/57784e8bd6f500bd4d127f6409be919fc7a8e383) jankyborders: add passthru.updateScript
* [`da65da96`](https://github.com/NixOS/nixpkgs/commit/da65da96961b8d03c9be24e212d5d8848551e3f8) waybar-mpris: add passthru.updateScript
* [`7345c87c`](https://github.com/NixOS/nixpkgs/commit/7345c87cd90fdf22075afb4ace9c53a2c7346b9e) btrfs-assistant: add passthru.updateScript
* [`3582fa96`](https://github.com/NixOS/nixpkgs/commit/3582fa96eeef600657b2c1c4d7013468796c88c1) wttrbar: add passthru.updateScript
* [`8c77632c`](https://github.com/NixOS/nixpkgs/commit/8c77632c331f102179a3d6434cbcc4ab4e5204e4) skhd: add passthru.updateScript
* [`c59f26f3`](https://github.com/NixOS/nixpkgs/commit/c59f26f329839830b96696b3554fa599db84c045) ycmd: autoformat with nixpkgs-fmt
* [`fb037b6d`](https://github.com/NixOS/nixpkgs/commit/fb037b6dacb31c1cf8737a8e9be634e6b0ca5e33) ycmd: Fix build on darwin
* [`678dcdfa`](https://github.com/NixOS/nixpkgs/commit/678dcdfa80f78b03a5356d90d5819149b7034b4a) rPackages.Rhdf5lib: downgrade hdf5
* [`33d886c0`](https://github.com/NixOS/nixpkgs/commit/33d886c0116dd1eb5443df26fa705929eb7c84fb) ycmd: Migrate to by-name
* [`24e8ccf6`](https://github.com/NixOS/nixpkgs/commit/24e8ccf60ca0147c50b708cba5f041fdc888c83f) kubefirst: 2.4.2 -> 2.4.3
* [`c7924db7`](https://github.com/NixOS/nixpkgs/commit/c7924db7c2835d4dbeb5946f1636d5147c00ca67) haruna: 0.12.3 -> 1.0.2
* [`a9a8aba3`](https://github.com/NixOS/nixpkgs/commit/a9a8aba3826071401196744521f3e2cbda241762) unit: 1.32.0 -> 1.32.1
* [`f290c590`](https://github.com/NixOS/nixpkgs/commit/f290c5901b7cfbe132097bf53c3cd96e2ba056b8) Avoid top-level `with ...;` in nixos/lib/systemd-lib.nix
* [`d509d284`](https://github.com/NixOS/nixpkgs/commit/d509d28475ef135b8e93b4058125fdb2e411fd1a) Avoid top-level `with ...;` in nixos/lib/systemd-network-units.nix
* [`7d130cf7`](https://github.com/NixOS/nixpkgs/commit/7d130cf7520f3cc471c1de3dd40e50ed6bf1ee96) Avoid top-level `with ...;` in nixos/lib/systemd-types.nix
* [`ad920b32`](https://github.com/NixOS/nixpkgs/commit/ad920b32c2f83b7aed765cde8c345b97f263e023) Avoid top-level `with ...;` in nixos/lib/systemd-unit-options.nix
* [`546fc672`](https://github.com/NixOS/nixpkgs/commit/546fc6724237ba93fab6417d3564f7e90f3f77da) Avoid top-level `with ...;` in nixos/lib/utils.nix
* [`c79bb39f`](https://github.com/NixOS/nixpkgs/commit/c79bb39f813b0668bc5e79ecfd6278166f49f552) nixos/archisteamfarm: fix empty check for bots
* [`525f8d94`](https://github.com/NixOS/nixpkgs/commit/525f8d9433a7916ba83843b70b33053a66ce912d) pkgsStatic.gnutls: fix build
* [`e5a5f91c`](https://github.com/NixOS/nixpkgs/commit/e5a5f91c4b1c23b77a9f280bbb710ca3bc56f671) trinsic-cli: 1.13.0 -> 1.14.0
* [`29cbb246`](https://github.com/NixOS/nixpkgs/commit/29cbb246c066fa7060eb323e53d86788150eaec3) python3Packages.milc: 1.4.2 -> 1.8.0
* [`ed23e726`](https://github.com/NixOS/nixpkgs/commit/ed23e726ef322a5fef32cbe6cb71528d10a92d50) qmk: 1.1.2 -> 1.1.5
* [`d7d6471a`](https://github.com/NixOS/nixpkgs/commit/d7d6471a6958f0a2047a4da7d15aae7e3ec285e1) bind: doCheck = false;
* [`6ee3a444`](https://github.com/NixOS/nixpkgs/commit/6ee3a444b9388293ae70d82534c8a4dd8f9f53e7) python3Packages.apsw: 3.45.1.0 -> 3.45.2.0
* [`79468d06`](https://github.com/NixOS/nixpkgs/commit/79468d06a05f7c8092abca385d91d581f3216f1b) min: init at 0.43.0
* [`7d4615df`](https://github.com/NixOS/nixpkgs/commit/7d4615df8195c857c620fd9aabff7de09d394e8f) libint: 2.8.2 -> 2.9.0
* [`e87da97f`](https://github.com/NixOS/nixpkgs/commit/e87da97f1700ec6276692805eebe0123c23c64e0) python312Packages.numpydoc: 1.6.0 -> 1.7.0
* [`be1bcdc8`](https://github.com/NixOS/nixpkgs/commit/be1bcdc890f6a08c6789cdfadd83198af9d876b5) ode: 0.16.4 -> 0.16.5
* [`c50477a6`](https://github.com/NixOS/nixpkgs/commit/c50477a62588737bebd352ae07734f418e8e2ca5) python311Packages.mlflow: relax packaging constraint
* [`faf432ed`](https://github.com/NixOS/nixpkgs/commit/faf432ed57aa194327ad32ccba4e170a73030292) vyper: relax packaging constraint
* [`d80c3e86`](https://github.com/NixOS/nixpkgs/commit/d80c3e8652dff649e0cec2bb0f6f40f34077d102) streamlit: relax packaging constraint
* [`41c5e6c5`](https://github.com/NixOS/nixpkgs/commit/41c5e6c5756d3781c7e1256adddde958ea9776d7) python311Packages.rmscene: relax packaging constraint
* [`4067f4cb`](https://github.com/NixOS/nixpkgs/commit/4067f4cb183fe86a7699db5b3d04a7464f4808e1) python311Packages.woob: relax packaging constraint
* [`91aab1d0`](https://github.com/NixOS/nixpkgs/commit/91aab1d01556c8b8be32a70df4116a48550b0a5a) python312Packages.notus-scanner: relax packaging constraint
* [`b49e22fd`](https://github.com/NixOS/nixpkgs/commit/b49e22fdc8eca387632d2ec689611094a05dc2c6) python311Packages.diffsync: relax packaging constraint
* [`d4e71393`](https://github.com/NixOS/nixpkgs/commit/d4e713934687eba999f6c99e40b5853a5f8ea4a0) python311Packages.flet: relax packaging constraint
* [`26bd025b`](https://github.com/NixOS/nixpkgs/commit/26bd025b2e2acc6ce21045271fad58a3d22e921e) gnome-extensions-cli: relax packaging constraint
* [`9a1204cd`](https://github.com/NixOS/nixpkgs/commit/9a1204cdf559edc388edb8c673619eac49e92f66) checkov: relax packaging constraint
* [`bac08d89`](https://github.com/NixOS/nixpkgs/commit/bac08d89a651a6c9fb962608d1b07a94577150e0) python312Packages.pathtools: disable
* [`b17785e4`](https://github.com/NixOS/nixpkgs/commit/b17785e4bb0f780cc0271a08d1ae5f5d0a074bfb) python312Packages.logical-unification: disable failing test
* [`1a8fea04`](https://github.com/NixOS/nixpkgs/commit/1a8fea04dcba8cc81e8cf432c222ca8e1ed53311) python312Packages.ed25519: disable
* [`25b4744f`](https://github.com/NixOS/nixpkgs/commit/25b4744f6e0ecaf42d0f85e825db945faa5849b6) python311Packages.glyphslib: 6.6.6 -> 6.7.0
* [`d55fb2ae`](https://github.com/NixOS/nixpkgs/commit/d55fb2ae4d43bef7c709352788889027f257cc78) python311Packages.chex: 0.1.85 -> 0.1.86
* [`1d0d19f4`](https://github.com/NixOS/nixpkgs/commit/1d0d19f43db525cdc2bc93b5343539fe01d8f9eb) python311Packages.thrift: 0.16.0 -> 0.20.0
* [`2b145255`](https://github.com/NixOS/nixpkgs/commit/2b1452550072f9dbd13b9c3b5d15b105622b5e92) waagent: 2.9.1.1 -> 2.10.0.8
* [`2406f6e0`](https://github.com/NixOS/nixpkgs/commit/2406f6e0fcb8749d068cda2cdab5c6e5f5fc3d9f) rPackages.connections: fixed build
* [`c703682f`](https://github.com/NixOS/nixpkgs/commit/c703682fdd48c39d63b1d2f0157b35662c45e160) rPackages.pexm: fixed build
* [`8772fdda`](https://github.com/NixOS/nixpkgs/commit/8772fdda28ef710f5932c78a9042699a239054a4) rPackages.cartogramR: fixed build
* [`a55d0aea`](https://github.com/NixOS/nixpkgs/commit/a55d0aeac117c4c92dd3ee15f14abbefabd0a272) rPackages.image_textlinedetector: fixed build
* [`40487cd2`](https://github.com/NixOS/nixpkgs/commit/40487cd275cd02782a43d8cf36f6d74ff779fb3d) python312Packages.elementpath: refactor
* [`9d4dad10`](https://github.com/NixOS/nixpkgs/commit/9d4dad105e31b45579b70157404cfc82d40ef2d3) python312Packages.elementpath: 4.3.0 -> 4.4.0
* [`0b17d13e`](https://github.com/NixOS/nixpkgs/commit/0b17d13eb21e5dcb797b73b6a8ad26a84d21870c) rPackages.VariantAnnotation: fix build
* [`a035bac0`](https://github.com/NixOS/nixpkgs/commit/a035bac0aa7b870d138cfd4070dd174d754e4942) gns3-server: pin pytest to pytest_7 to avoid test failures
* [`ec2c82fa`](https://github.com/NixOS/nixpkgs/commit/ec2c82fa16c58a6941c69befa20ddeabb04f26aa) rPackages.Rhdf5lib: enable c++ bindings
* [`e3f2f66e`](https://github.com/NixOS/nixpkgs/commit/e3f2f66eb332e781faf914b708eb53a11dbfe165) quilt: 0.67 -> 0.68
* [`6a4fbe87`](https://github.com/NixOS/nixpkgs/commit/6a4fbe87cf6eaec1b3676dc26c1e4c140b4511d8) rPackages.bamsignals: fix build
* [`ac66d159`](https://github.com/NixOS/nixpkgs/commit/ac66d15937815cf3a87ff1070b97c572248f53ae) rPackages.maftools: fix build
* [`120c0c19`](https://github.com/NixOS/nixpkgs/commit/120c0c1924c1775755ec5658ce902da0a8c64464) rPackages.RcppCGAL: fix build
* [`b346923a`](https://github.com/NixOS/nixpkgs/commit/b346923ac875f49f7545fad4f4dd05857ddf14e7) python312Packages.torchaudio: 2.2.1 -> 2.2.2
* [`284dde67`](https://github.com/NixOS/nixpkgs/commit/284dde675522cf0df3c1f2dcd342dc5858429fa7) rPackages.hdf5r: fix build
* [`ab40cff7`](https://github.com/NixOS/nixpkgs/commit/ab40cff7a113c75dcfbadd83f6b355a5504a9f41) packet: remove
* [`6079148e`](https://github.com/NixOS/nixpkgs/commit/6079148ec852531bb4adb22926ef1370b86b558a) mesos-dns: 0.1.2 -> 0.9.0
* [`c2b0bf3d`](https://github.com/NixOS/nixpkgs/commit/c2b0bf3dd52585d7e8898c8cb33eebeeedf8c8e4) python3Packages.mlflow: 2.11.1 -> 2.11.3
* [`2e732f8d`](https://github.com/NixOS/nixpkgs/commit/2e732f8d8e151d111e6e1aaf293024e8dbdb2d5f) oapi-codegen: 1.13.4 -> 2.1.0
* [`584544ef`](https://github.com/NixOS/nixpkgs/commit/584544efc9e540415fe60a6910cd1ecf1c06bd15) rPackages.string2path: fixed build
* [`e1892f2e`](https://github.com/NixOS/nixpkgs/commit/e1892f2e15526a9c010d1d40e31e4befa4e042de) python311Packages.black: 24.2.0 -> 24.3.0
* [`537c4653`](https://github.com/NixOS/nixpkgs/commit/537c46531e6e02b3a51edf4d9bc630a4e5f88fbf) python312Packages.zope-testrunner: 5.6 -> 6.4
* [`dd289c48`](https://github.com/NixOS/nixpkgs/commit/dd289c485afe8ae1159e2fba429bd7616f2d3149) python312Packages.qtpy: 2.4.0 -> 2.4.1
* [`65f93157`](https://github.com/NixOS/nixpkgs/commit/65f9315740e80c70e8c4ed99b3d3cb6486aa5e83) darwin.insert_dylib: refactor, drop xcbuildHook
* [`890d496d`](https://github.com/NixOS/nixpkgs/commit/890d496ddaeb82da688e3c9825fc67a915d3b8fc) flatito: init at 0.1.1
* [`f650c2c0`](https://github.com/NixOS/nixpkgs/commit/f650c2c0781716d97e5dff94b42d6c609ab19aa6) rPackages.rmsb: fixed build
* [`7e0c09e1`](https://github.com/NixOS/nixpkgs/commit/7e0c09e12ed914d5803a6c301f578a56b72559ce) mbusd: 0.5.1 → 0.5.2
* [`854f5dbf`](https://github.com/NixOS/nixpkgs/commit/854f5dbff2a4cc390543b6de3757dfeca87bf29c) mbusd: migrate to by-name
* [`f9c9aeb5`](https://github.com/NixOS/nixpkgs/commit/f9c9aeb54c70aa8d1071bb0367b110867b0d4738) python312Packages.threadpoolctl: 3.3.0 -> 3.4.0
* [`30fa2e0c`](https://github.com/NixOS/nixpkgs/commit/30fa2e0c616306076a975936b7ae1ca0e2c01bf8) python3Packages.b2sdk: add packaging dependency
* [`f1be43a5`](https://github.com/NixOS/nixpkgs/commit/f1be43a54e483e8dff0b11d4a029af2afa8d6c48) ncftp: fix darwin build
* [`1699d1fa`](https://github.com/NixOS/nixpkgs/commit/1699d1fa8815f13c9979e7859eaeb9a8ab20e73c) python3Packages.psd-tools: fixed build
* [`37f61fa6`](https://github.com/NixOS/nixpkgs/commit/37f61fa6238aabf4f5e094ae0085e240ba81e6a9) prusa-slicer: 2.7.2 -> 2.7.3
* [`f37744a5`](https://github.com/NixOS/nixpkgs/commit/f37744a597b385b3e40855d76daa37033cbb8430) dhewm3: 1.5.2 -> 1.5.3
* [`45bc53b6`](https://github.com/NixOS/nixpkgs/commit/45bc53b654bd6586bc8441b38bb061d1472b25f3) grandorgue: 3.14.0 -> 3.14.0-1
* [`8645d231`](https://github.com/NixOS/nixpkgs/commit/8645d231906977d295ef793798c1307949083317) python312Packages.nbconvert: 7.16.2 -> 7.16.3
* [`776aa3e2`](https://github.com/NixOS/nixpkgs/commit/776aa3e2a7384582e8c4ef9597097a94b2318ece) python312Packages.azure-servicebus: 7.12.0 -> 7.12.1
* [`099cd219`](https://github.com/NixOS/nixpkgs/commit/099cd21983b2ec954c034a31c1d41e943fb391c5) azure-static-sites-client: 1.0.026164 -> 1.0.026361
* [`699ac331`](https://github.com/NixOS/nixpkgs/commit/699ac3316c2618ff1e4cd176a35df2a19b5f226c) Revert "xz: 5.6.0 -> 5.6.1"
* [`f7212315`](https://github.com/NixOS/nixpkgs/commit/f72123158996b8d4449de481897d855bc47c7bf6) Revert "xz: 5.4.6 -> 5.6.0"
* [`f93d5f56`](https://github.com/NixOS/nixpkgs/commit/f93d5f5602477bb96fb6414e1d132ffed0e5d0b1) ryujinx: 1.1.1242 -> 1.1.1248
* [`1c333171`](https://github.com/NixOS/nixpkgs/commit/1c333171f872c5b2ddb61f4e6c44dc7b9b040e92) python311Packages.aiomisc: update disabled
* [`5bdd8429`](https://github.com/NixOS/nixpkgs/commit/5bdd8429ca029f11f0782517284c6807691542f2) python311Packages.aiomisc: refactor
* [`e908a93c`](https://github.com/NixOS/nixpkgs/commit/e908a93cfafd754f0a56a4444be8bb58e73b7b9f) synology-drive-client: 3.3.0 -> 3.4.0
* [`3207c75a`](https://github.com/NixOS/nixpkgs/commit/3207c75ac03ba5cf5fec9a70ef57862d466e89fe) k3s_1_28: 1.28.7+k3s1 -> 1.28.8+k3s1
* [`663059bd`](https://github.com/NixOS/nixpkgs/commit/663059bd9af0c3a154bd3857fb0e882c3783d5f0) cnquery: 10.8.4 -> 10.9.2
* [`7ab3cff4`](https://github.com/NixOS/nixpkgs/commit/7ab3cff4557c351c8cb05933f834963260cd720b) vivaldi: 6.6.3271.53 -> 6.6.3271.55
* [`27842f06`](https://github.com/NixOS/nixpkgs/commit/27842f0606414c0178d157faaa061f2ec818e64e) bngblaster: 0.8.39 -> 0.8.44
* [`b84dc529`](https://github.com/NixOS/nixpkgs/commit/b84dc529d6e736a1de993220a0d94f5730d2613c) v2ray-domain-list-community: 20240316051411 -> 20240324094850
* [`699e0918`](https://github.com/NixOS/nixpkgs/commit/699e09188d04f4348bc6cfd01560821037c1e6d9) python311Packages.dvc-task: 0.3.0 -> 0.4.0
* [`0c8952f7`](https://github.com/NixOS/nixpkgs/commit/0c8952f776095fac2e34aeee4c9496799b31da60) vvvvvv: 2.4 -> 2.4.1
* [`b6c7ea1a`](https://github.com/NixOS/nixpkgs/commit/b6c7ea1a1aec992df3a71d74b56b4aad30e88f23) libiscsi: 1.19.0 -> 1.20.0
* [`3e1c1ccf`](https://github.com/NixOS/nixpkgs/commit/3e1c1ccfc8cba4b80dea105910fe84db7f3fee16) rPackages.pkgdepends: fix compile error
* [`3030b58d`](https://github.com/NixOS/nixpkgs/commit/3030b58d8a1ea3869e05113bb7b93b2f83f0d6a5) libblockdev: 3.0.4 -> 3.1.1
* [`40962223`](https://github.com/NixOS/nixpkgs/commit/40962223c8ed325005c056bed750ff68cf3c7b04) python311Packages.plotly: 5.19.0 -> 5.20.0
* [`25e44c0d`](https://github.com/NixOS/nixpkgs/commit/25e44c0d1977d60ca0f8875152900366ac5763d0) rPackages.KSgeneral: add missing deps
* [`df32b558`](https://github.com/NixOS/nixpkgs/commit/df32b558b5227746c46bc94519aa10467c40b864) nixos/systemd: Enable debug-shell.service.
* [`14405dcc`](https://github.com/NixOS/nixpkgs/commit/14405dccb71bc834569ae79df568b00d95a06104) vvvvvv: move to pkgs/by-name
* [`c949c1ca`](https://github.com/NixOS/nixpkgs/commit/c949c1cacdafa109ba98a034883d79950d0baf26) guitarix: use `finalAttrs`
* [`9538a854`](https://github.com/NixOS/nixpkgs/commit/9538a854cf7c22da4bd51262d55e0a1b266d55e7) python311Packages.ansible: 9.3.0 -> 9.4.0
* [`3fb49b67`](https://github.com/NixOS/nixpkgs/commit/3fb49b676f43871a9fc35952780f02e86f45f3c9) python311Packages.dvc-task: refactor
* [`9240c26c`](https://github.com/NixOS/nixpkgs/commit/9240c26c9393c62c8873b2b9550877854901246f) python311Packages.dvc-task: update disabled
* [`af7b0f1b`](https://github.com/NixOS/nixpkgs/commit/af7b0f1bd82f3cd31b0f01013d6f9c40482812df) guitarix: 0.44.1 -> 0.46.0
* [`16bbaef5`](https://github.com/NixOS/nixpkgs/commit/16bbaef50b3863e0f973cb36f9c0a759304eda46) python311Packages.zope-testrunner: 5.6 -> 6.4
* [`604d7ef0`](https://github.com/NixOS/nixpkgs/commit/604d7ef0c0c307c3e4070565a77e3be78d757461) archi: updated download-urls
* [`0e968784`](https://github.com/NixOS/nixpkgs/commit/0e9687843d8eae74d94a4d3d4b1c04e0800be093) python312Packages.empy: 4.0.1 -> 4.1
* [`b6faaa7c`](https://github.com/NixOS/nixpkgs/commit/b6faaa7c3951c601e5a8e6410a9d664b3bb3f239) mtdutils: 2.1.6 -> 2.2.0
* [`d6272b0c`](https://github.com/NixOS/nixpkgs/commit/d6272b0ce865da66f4daa3a032ea4fea9c8dd084) python312Packages.rnc2rng: 2.6.6 -> 2.7.0
* [`bae8fd5e`](https://github.com/NixOS/nixpkgs/commit/bae8fd5efc4c60fadd03cca2dade435d2b9e01a4) lttng-tools: 2.13.11 -> 2.13.12
* [`dedbd531`](https://github.com/NixOS/nixpkgs/commit/dedbd53141643e05c928ce3658bbfece62ed0448) blueman: 2.3.5 -> 2.4
* [`8934717e`](https://github.com/NixOS/nixpkgs/commit/8934717ed5b01baf0d1501b12ef5ee5ed438b75e) zed: 1.14.0 -> 1.15.0
* [`5a27015f`](https://github.com/NixOS/nixpkgs/commit/5a27015f92a8d742eb54e6a2c0bce538fd47cb5f) groonga: 14.0.1 -> 14.0.2
* [`47ec95ca`](https://github.com/NixOS/nixpkgs/commit/47ec95ca335d802f624ef650314525b7122b266e) python312Packages.shortuuid: 1.0.12 -> 1.0.13
* [`83af1580`](https://github.com/NixOS/nixpkgs/commit/83af1580ad41799a8142515d758e515f9fb49374) buildah-unwrapped: 1.35.1 -> 1.35.3
* [`93d273ff`](https://github.com/NixOS/nixpkgs/commit/93d273ffaa5bdf0d2484a4956f0b5f2c447aa819) ldb: 2.8.0 -> 2.9.0
* [`697246c9`](https://github.com/NixOS/nixpkgs/commit/697246c92c5c9d66d7395bee9f97af93babdc093) samba: 4.19.5 -> 4.20.0
* [`e816e5c9`](https://github.com/NixOS/nixpkgs/commit/e816e5c96af4d8551680fadc9869cafbc1db07ae) libfabric: 1.20.1 -> 1.21.0
* [`29901ea6`](https://github.com/NixOS/nixpkgs/commit/29901ea63088dcee5a32edf3e636c1e34cfe5bae) ubootNanoPCT6: init at 2024.01
* [`95a9e7ff`](https://github.com/NixOS/nixpkgs/commit/95a9e7ffdfd2c41e3cc3837280338a2afccec4ba) oneDNN: 3.4 -> 3.4.1
* [`953623a8`](https://github.com/NixOS/nixpkgs/commit/953623a89550213ee73c57afb1d17b1537e2889d) gollum: update dependencies
* [`d499a426`](https://github.com/NixOS/nixpkgs/commit/d499a4261ed14bf50e99f27f12e051e0892857f0) thermald: 2.5.6 -> 2.5.7
* [`4c528ce9`](https://github.com/NixOS/nixpkgs/commit/4c528ce90a2aa639073ee92cf599c44b5a7b2a3a) python312Packages.pynndescent: 0.5.11 -> 0.5.12
* [`302eec26`](https://github.com/NixOS/nixpkgs/commit/302eec2650cb4d8c1e3ac0d059c84c3ac34046f9) miru: 5.0.0 -> 5.0.3
* [`6aa50d08`](https://github.com/NixOS/nixpkgs/commit/6aa50d08087b8a5265ca3a41174341245ed69fe0) xz: switch to a working src URL, add warning
* [`558757a6`](https://github.com/NixOS/nixpkgs/commit/558757a689362e94f00cc74f755ac19acf802bbd) python311Packages.zope-location: 4.3 -> 5.0
* [`14cd8984`](https://github.com/NixOS/nixpkgs/commit/14cd89844107e095f85329b47836efaaaaee33be) python311Packages.jupyterhub: 4.1.0 -> 4.1.3
* [`8391b2c6`](https://github.com/NixOS/nixpkgs/commit/8391b2c6abf96b208b98f6b144a1a66c89f0b76d) nixos/redmine: Adjust database password conditionally
* [`0b11c8f4`](https://github.com/NixOS/nixpkgs/commit/0b11c8f47c29c8ef93631ca2fd077a661d30addb) nixos/redmine: Use attribute set for storing database settings
* [`19edccb0`](https://github.com/NixOS/nixpkgs/commit/19edccb0eed14b297863817cbc032932600f5203) redmine: Add sqlite3 gem
* [`ddd15dc2`](https://github.com/NixOS/nixpkgs/commit/ddd15dc2d92f52138b8cac9be2a2f5e6c277b1c0) nixos/redmine: Allow using SQLite as database backend
* [`a803b327`](https://github.com/NixOS/nixpkgs/commit/a803b32736dab14d441edaed5bf695e9a7d3362e) redmine: 5.0.6 -> 5.1.2
* [`187a5f88`](https://github.com/NixOS/nixpkgs/commit/187a5f88dc3f2cc04610a19a6780b33134197a90) redmine: Move package files into pkgs/by-name directory
* [`2e5c506c`](https://github.com/NixOS/nixpkgs/commit/2e5c506c69bfdd73b8be0666a8b6f13ec26c2847) rPackages.rswipl: fixed build
* [`dd1bc494`](https://github.com/NixOS/nixpkgs/commit/dd1bc4940b0b9529856293cac6c8982a07d3826e) rPackages.unigd: fixed build
* [`f436ae51`](https://github.com/NixOS/nixpkgs/commit/f436ae5115e8d823f8d67c9109a5e20b6637f273) rPackages.gdalcubes: fixed build
* [`08cf03a4`](https://github.com/NixOS/nixpkgs/commit/08cf03a45a8baaa997df1d3b49d5da47772ee25a) rPackages.iemisc: fixed build
* [`330e781d`](https://github.com/NixOS/nixpkgs/commit/330e781d09c23f57dfc9dbb91c94a377eac59364) rPackages.jackalope: fix build
* [`b8cbb8bc`](https://github.com/NixOS/nixpkgs/commit/b8cbb8bc47682fa1c0842e8f53d74befc60b37b3) rPackages.spectralGraphTopology: fixed build
* [`753c6564`](https://github.com/NixOS/nixpkgs/commit/753c6564bf2714230abdf7f68b4b747b05cf6d80) python311Packages.googleapis-common-protos: 1.62.0 -> 1.63.0
* [`b32be09c`](https://github.com/NixOS/nixpkgs/commit/b32be09c12d13dca1e64eb067556b6013de8da63) spirv-llvm-translator: 14.0.0+unstable-2024-01-23 -> 14.0.0+unstable-2024-02-14
* [`160e7d11`](https://github.com/NixOS/nixpkgs/commit/160e7d11b1f6fe443347f5b8f09510bce55659b3) intel-graphics-compiler: 1.0.15985.7 -> 1.0.16238.4
* [`ef47461a`](https://github.com/NixOS/nixpkgs/commit/ef47461a7730b2bbc5565e3e61c06824e08b4cfd) qpwgraph: 0.6.2 -> 0.6.3
* [`8cf2cf33`](https://github.com/NixOS/nixpkgs/commit/8cf2cf33ec787721b0dac5f67ca0641ed2d7abaa) python312Packages.async-upnp-client: 0.38.2 -> 0.38.3
* [`d8b3f3fb`](https://github.com/NixOS/nixpkgs/commit/d8b3f3fb46243d231645ba179f11c536982172c8) python312Packages.async-upnp-client: refactor
* [`892e9214`](https://github.com/NixOS/nixpkgs/commit/892e9214c8169c36e5aae84946bf61af5c14e337) intel-compute-runtime: 24.05.28454.6 -> 24.09.28717.12
* [`5142b7af`](https://github.com/NixOS/nixpkgs/commit/5142b7afa88db6ccec229521ad96df4419f6abe4) nixos/postgresql: turn `settings` into a submodule
* [`afe953b1`](https://github.com/NixOS/nixpkgs/commit/afe953b10545f7754a7b6cc425694cc398f34109) sqldef: 0.17.1 -> 0.17.5
* [`78cb8949`](https://github.com/NixOS/nixpkgs/commit/78cb894955fa314653643d12b81ea3b5d7e734af) readarr: 0.3.20.2452 -> 0.3.21.2475
* [`8e7ee0f8`](https://github.com/NixOS/nixpkgs/commit/8e7ee0f82100f20b75f44e553614ccd48f13e966) python311Packages.google-api-core: 2.17.1 -> 2.18.0
* [`9504dba8`](https://github.com/NixOS/nixpkgs/commit/9504dba8c0c7b98f8d38c29756c03eb9f08d559b) python311Packages.asf-search: 7.0.7 -> 7.0.8
* [`530d16e5`](https://github.com/NixOS/nixpkgs/commit/530d16e5430c22d830310ba66e61099ad27b1ce6) maintainers: add noaccos
* [`1ee02d4f`](https://github.com/NixOS/nixpkgs/commit/1ee02d4fc5309ad9b46b158711bf22954f3cb894) python312Packages.publicsuffixlist: 0.10.0.20240312 -> 0.10.0.20240328
* [`c75e9c60`](https://github.com/NixOS/nixpkgs/commit/c75e9c601d4724d66932c3b7c812a10f0a4128de) python312Packages.publicsuffixlist: refactor
* [`f967ccf5`](https://github.com/NixOS/nixpkgs/commit/f967ccf511af6ef3bafd8551a9ae00bbc0471dfc) mycli: 1.27.0 -> 1.27.1
* [`b65cd9bb`](https://github.com/NixOS/nixpkgs/commit/b65cd9bb4df254b62fb7a97d175f1a5792505c11) httpdirfs: format with nixfmt-rfc-style
* [`2ebe93cb`](https://github.com/NixOS/nixpkgs/commit/2ebe93cb8caf8c07efaa8d8723503c6c4028cc8d) httpdirfs: add passthru.{tests.version,updateScript}
* [`00632e23`](https://github.com/NixOS/nixpkgs/commit/00632e239431b7e845fb7f20d0e0933fbc65caf7) httpdirfs: 1.2.3 -> 1.2.5
* [`4bc9e022`](https://github.com/NixOS/nixpkgs/commit/4bc9e0221b2e942087a987f622f3ef3d1b4e649a) httpdirfs: add anthonyroussel to maintainers
* [`3de8f433`](https://github.com/NixOS/nixpkgs/commit/3de8f433e235e16ebc53f8198f381347efc2168b) httpdirfs: move to pkgs/by-name
* [`81295a47`](https://github.com/NixOS/nixpkgs/commit/81295a476a484e20d810f3fa21c4758b9bfd84fb) {lib}mediainfo{-gui}: move to by-name structure
* [`2e719185`](https://github.com/NixOS/nixpkgs/commit/2e71918588eeb944a87e979a384c69e8fea0ad75) lima: 0.20.2 -> 0.21.0
* [`f4e42002`](https://github.com/NixOS/nixpkgs/commit/f4e420025a70ca1da675705c78d002b1c5c0873b) {lib}mediainfo{-gui}: 24.01{.1} -> 24.03
* [`73cb5278`](https://github.com/NixOS/nixpkgs/commit/73cb5278cbd84512ce5fed32714e42db14eceabe) kubescape: disable on darwin
* [`72ea5561`](https://github.com/NixOS/nixpkgs/commit/72ea5561d6554eb4595d81ead25c9dc196228090) kubescape: 3.0.7 -> 3.0.8
* [`2c60e3b2`](https://github.com/NixOS/nixpkgs/commit/2c60e3b2dda7d4381ef2b4579e25614210bc577c) sidplayfp: 2.6.2 -> 2.7.0
* [`32432b71`](https://github.com/NixOS/nixpkgs/commit/32432b7108fc6669ddb796aab8c7a579ac15c1e1) spaceship-prompt: 4.14.1 -> 4.15.1
* [`9d56bbe7`](https://github.com/NixOS/nixpkgs/commit/9d56bbe738a40d1ccbbcf3234eec770329c92393) libpointmatcher: 1.3.1 -> 1.4.2
* [`951378b0`](https://github.com/NixOS/nixpkgs/commit/951378b00f75244a6c5e2e60f00b38ba850c530e) astartectl: init at 23.5.0
* [`07950a59`](https://github.com/NixOS/nixpkgs/commit/07950a598ed2b5ddf038c27aa86788d5ec21ee02) miru: update homepage
* [`62cc7fa3`](https://github.com/NixOS/nixpkgs/commit/62cc7fa3346ea9644d5e09dd745aa67af61ec5dd) gordonflashtool: init at 10
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
