### PR TITLE
niv devenv: update e106743b -> 808caa6a

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://devenv.sh",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "e106743bdbd788742f516b3eaea3e21e7162a38e",
-        "sha256": "1aznyj4d9nkkz37h5qplpvllkiw9mj6spfvx4zxvw41bp5wc6p7z",
+        "rev": "808caa6a89779c1b22bcae57d16d803bde1f631d",
+        "sha256": "0hf75dzpal5332yv3zrf42mhkgx2fwkg9glnb7s67kl2rmd98ip1",
         "type": "tarball",
-        "url": "https://github.com/cachix/devenv/archive/e106743bdbd788742f516b3eaea3e21e7162a38e.tar.gz",
+        "url": "https://github.com/cachix/devenv/archive/808caa6a89779c1b22bcae57d16d803bde1f631d.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "doomemacs": {


### PR DESCRIPTION
## Changelog for devenv:
Branch: main
Commits: [cachix/devenv@e106743b...808caa6a](https://github.com/cachix/devenv/compare/e106743bdbd788742f516b3eaea3e21e7162a38e...808caa6a89779c1b22bcae57d16d803bde1f631d)

* [`fb081dd5`](https://github.com/cachix/devenv/commit/fb081dd5392f155d292b2e4ad053fcbbbda7b85f) when user isn't trusted, still display the new public key
* [`2da0aff4`](https://github.com/cachix/devenv/commit/2da0aff4c957976883d828d548b56d4594eef657) trusted: clarify that you also need to disable cachix
* [`a72055d4`](https://github.com/cachix/devenv/commit/a72055d4b3588cea2dcf08163a3be5781e838a72) Allow overriding stdenv
* [`0b6e48f3`](https://github.com/cachix/devenv/commit/0b6e48f31449ca368c000b52731e5f0c28cbdf05) Fix pnpm script
* [`d3325417`](https://github.com/cachix/devenv/commit/d3325417232863cdf83d46efcc04eb5261bb0238) Add missing dependency for phoenix example
* [`a71b6e23`](https://github.com/cachix/devenv/commit/a71b6e236aea662b7b5bd0ac806bf0ee9686eb06) Add generated directories to examples' .gitignore
* [`c14d6dec`](https://github.com/cachix/devenv/commit/c14d6decabd74fb79c991b5873c094f1047746fc) Initialize DB to fix phoenix test
* [`621bc767`](https://github.com/cachix/devenv/commit/621bc767dc096b20a8a8f1dfa8f26340552f6bc3) Auto generate docs/reference/options.md
* [`e5bf2a56`](https://github.com/cachix/devenv/commit/e5bf2a56f9ebfd8b56fd8ff8581844aa9276cce5) nixpkgs-python: follow nixpkgs
* [`99f93f78`](https://github.com/cachix/devenv/commit/99f93f78f309d83dbf4bf12c35ff20427001eb03) Add a test failure case for the impure option
* [`bdcb4574`](https://github.com/cachix/devenv/commit/bdcb457450a574632519af6aae6112a0c48e8dad) Fix devenv up with the impure option
* [`e2b5e2b3`](https://github.com/cachix/devenv/commit/e2b5e2b30aff7a4bc5037c1cbb5b45350097fd5d) v1.0.3
* [`316d87ce`](https://github.com/cachix/devenv/commit/316d87cec0ebd7a99e969aaca2e60992e8f2e667) Auto generate docs/reference/options.md
* [`ef7390e2`](https://github.com/cachix/devenv/commit/ef7390e29f7a2af49bb690b39f08e7b6f2a22ba5) fix: Terraform example
* [`dc93d75c`](https://github.com/cachix/devenv/commit/dc93d75c17d33b6bd1c2c286e103e1ab4b276fc5) flake.lock: Update
* [`7653285a`](https://github.com/cachix/devenv/commit/7653285a17cae2773a220f92bce7cd0f0b130115) Run `devenv update`
* [`8827aa19`](https://github.com/cachix/devenv/commit/8827aa19daf1fc3f53e7adcc7201933ef28f8652) Auto generate docs/reference/options.md
* [`7a734975`](https://github.com/cachix/devenv/commit/7a73497514ca08792acefac9780a3364c045c4e1) docs: nix-darwin linux-builder module link
* [`dce1b9c7`](https://github.com/cachix/devenv/commit/dce1b9c775f6dcce528c41cb2b989ab322981c17) fix [cachix/devenv⁠#1051](https://togithub.com/cachix/devenv/issues/1051): properly handle dangling symlinks
* [`c632c945`](https://github.com/cachix/devenv/commit/c632c9452a08f8b94dd09cfa5ee8747b0aee5055) fix: `Env` should not be escaped
* [`a71323c6`](https://github.com/cachix/devenv/commit/a71323c618664a6b7a39bc183b0ce22ac8511cf9) fix [cachix/devenv⁠#1109](https://togithub.com/cachix/devenv/issues/1109): only disable tui if we're in detached mode
