### PR TITLE
niv home-manager: update 4be04644 -> a561ad6a

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,10 +53,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "4be0464472675212654dedf3e021bd5f1d58b92f",
-        "sha256": "0p1bllhsijgqng1zag88ww16s52f2lg2q93qw2zbm4pyj3pcws9v",
+        "rev": "a561ad6ab38578c812cc9af3b04f2cc60ebf48c9",
+        "sha256": "1x9l68pppg2sqhbf5ar8dqngydm6fa9isch8q0splxx12mndn3aq",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/4be0464472675212654dedf3e021bd5f1d58b92f.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/a561ad6ab38578c812cc9af3b04f2cc60ebf48c9.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@4be04644...a561ad6a](https://github.com/nix-community/home-manager/compare/4be0464472675212654dedf3e021bd5f1d58b92f...a561ad6ab38578c812cc9af3b04f2cc60ebf48c9)

* [`6396954c`](https://github.com/nix-community/home-manager/commit/6396954c0d26ffd7601c478c11443f454926bf27) bacon: add package option
* [`e429a609`](https://github.com/nix-community/home-manager/commit/e429a60900c1c8f6c07bbd4926b79f05a98544c9) bacon: add default value for settings
* [`81cd7199`](https://github.com/nix-community/home-manager/commit/81cd71995ade24333017e7930802040363ce1946) hyprland: fix systemd variables example
* [`aca33e99`](https://github.com/nix-community/home-manager/commit/aca33e99551250cfb23f384789d9fecea0254ac4) Translate using Weblate (Russian)
* [`58e5ae81`](https://github.com/nix-community/home-manager/commit/58e5ae81ceb274a249ae69659f3150419673f14c) Translate using Weblate (Romanian)
* [`80546b22`](https://github.com/nix-community/home-manager/commit/80546b220e95a575c66c213af1b09fe255299438) Translate using Weblate (Norwegian Bokmål)
* [`7e91f2a0`](https://github.com/nix-community/home-manager/commit/7e91f2a0ba4b62b88591279d54f741a13e36245b) xmonad: fix cp failure if libFiles with subdirectories
* [`9de3aab0`](https://github.com/nix-community/home-manager/commit/9de3aab0917914baad72e32023834f9b39e77610) kdeconnect: add package option
* [`0c73c1b8`](https://github.com/nix-community/home-manager/commit/0c73c1b8da28a24c4fe842ced3f2548d5828b550) zoxide: remove obsolete workaround
* [`1ffd393c`](https://github.com/nix-community/home-manager/commit/1ffd393cba9eb12df94641238f4436cabb285c9b) Translate using Weblate (Catalan)
* [`782eed8b`](https://github.com/nix-community/home-manager/commit/782eed8bb64b27acaeb7c17be4a095c85e65717f) programs.khal: add "addresses" option + tidy up ([nix-community/home-manager⁠#5221](https://togithub.com/nix-community/home-manager/issues/5221))
* [`b787726a`](https://github.com/nix-community/home-manager/commit/b787726a8413e11b074cde42704b4af32d95545c) home-manager: extract inline shell script to file
* [`a561ad6a`](https://github.com/nix-community/home-manager/commit/a561ad6ab38578c812cc9af3b04f2cc60ebf48c9) flake.lock: Update
