### PR TITLE
niv powerlevel10k: update da9b0377 -> bcef7caf

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -125,10 +125,10 @@
         "homepage": "",
         "owner": "romkatv",
         "repo": "powerlevel10k",
-        "rev": "da9b03777c4f2390c7e3f5c720ee4689336f811b",
-        "sha256": "0w50la8pcxpcbl5b33s6f2awwc4gwfsm039m3nvcb1jbyscgaza1",
+        "rev": "bcef7cafdf3005a3d59335df618f89474ef4dd8b",
+        "sha256": "1nrlgmwhg4n8cgwxf93c82fv3dijvkfl9k53xcqy9qwlzcd88j9r",
         "type": "tarball",
-        "url": "https://github.com/romkatv/powerlevel10k/archive/da9b03777c4f2390c7e3f5c720ee4689336f811b.tar.gz",
+        "url": "https://github.com/romkatv/powerlevel10k/archive/bcef7cafdf3005a3d59335df618f89474ef4dd8b.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "rh": {


### PR DESCRIPTION
## Changelog for powerlevel10k:
Branch: master
Commits: [romkatv/powerlevel10k@da9b0377...bcef7caf](https://github.com/romkatv/powerlevel10k/compare/da9b03777c4f2390c7e3f5c720ee4689336f811b...bcef7cafdf3005a3d59335df618f89474ef4dd8b)

* [`d6a0fed1`](https://github.com/romkatv/powerlevel10k/commit/d6a0fed1d9b2ff8746d1535eb6c7e83bfe0df093) Ease regex pattern when reading pyenv.cfg prompt value
* [`aeff1153`](https://github.com/romkatv/powerlevel10k/commit/aeff1153d405ebc9f60d4a8cb7afce5451c07358) handle unquoted `prompt` when parsing pyenv.cfg
* [`bcef7caf`](https://github.com/romkatv/powerlevel10k/commit/bcef7cafdf3005a3d59335df618f89474ef4dd8b) fixes taskwarrior init data for taskwarrior v3 ([romkatv/powerlevel10k⁠#2635](https://togithub.com/romkatv/powerlevel10k/issues/2635))
