### PR TITLE
niv nixpkgs: update c5707d86 -> c25f8a85

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -113,10 +113,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c5707d8602df948cbc4b11ad3c6737a4a49cc6be",
-        "sha256": "0ms0w20z0a92zrh8srxmmz5an3m61nnnp4w3sfh04qqi74fmwk37",
+        "rev": "c25f8a85ebf191a14126221d041222999f20f110",
+        "sha256": "1fra23xycf51pzac34h0sngqqcz5nmziwpsx4xhc6153xwlcvd1p",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/c5707d8602df948cbc4b11ad3c6737a4a49cc6be.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/c25f8a85ebf191a14126221d041222999f20f110.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@c5707d86...c25f8a85](https://github.com/nixos/nixpkgs/compare/c5707d8602df948cbc4b11ad3c6737a4a49cc6be...c25f8a85ebf191a14126221d041222999f20f110)

* [`904ecf0b`](https://github.com/NixOS/nixpkgs/commit/904ecf0b4e055dc465f5ae6574be2af8cc25dec3) extlinux-conf-builder: specialisations entries
* [`3d14617f`](https://github.com/NixOS/nixpkgs/commit/3d14617fc7006d161d531a9e9ddff9c163f84734) cloud-init: enable filesystems based on what is used
* [`01d078d9`](https://github.com/NixOS/nixpkgs/commit/01d078d9702aa032fece5d21ae1670dae538843f) vmTools.runInLinuxImage: allow setting root filesystem
* [`e6a4a3fe`](https://github.com/NixOS/nixpkgs/commit/e6a4a3feea46c11c9daaba01d8acfe52839e185b) vmTools/deb tools: pass through args
* [`5a4f4079`](https://github.com/NixOS/nixpkgs/commit/5a4f40797c98c8eb33d2e86b8eb78624a36b83ea) vmTools.debClosureGenerator: remove apparently obsolete bugfix
* [`72b3e9b5`](https://github.com/NixOS/nixpkgs/commit/72b3e9b5a0d838ff3a374f9e35e9da0880c01b85) webkitgtk: support cross compilation
* [`48562415`](https://github.com/NixOS/nixpkgs/commit/48562415281958ca585bda0fe605dfc06c60e642) passt: init at 0.2023_11_10.5ec3634
* [`125fc579`](https://github.com/NixOS/nixpkgs/commit/125fc5796233cf4e46ba2c43b9eb07bfd36394ef) zandronum-alpha: init at 3.2-230709-1914
* [`547fea8f`](https://github.com/NixOS/nixpkgs/commit/547fea8f6f2ba3086f183620c5f092c651fa899f) doomseeker: 2018-03-05 -> 2023-08-09
* [`383eba59`](https://github.com/NixOS/nixpkgs/commit/383eba59d3b0b8ddcd0b723a6362a0f6de2b6547) rakarrack: fix segmentation fault
* [`b5654da7`](https://github.com/NixOS/nixpkgs/commit/b5654da7e66fb79326df7efe86ace441ad8503e8) pulumi: 3.93.0 -> 3.99.0
* [`08d28f1f`](https://github.com/NixOS/nixpkgs/commit/08d28f1f1d93fc453e14d600036d982a1fb4fbf4) vscode-utils: add relativeLocation in toExtensionJson
* [`4b35e53f`](https://github.com/NixOS/nixpkgs/commit/4b35e53ffda3a94bd30d63829e9e18de86ff4ec8) capstone: 4.0.2 -> 5.0.1
* [`08304db4`](https://github.com/NixOS/nixpkgs/commit/08304db4447b2b5e4dd45d9989438a8067a3918d) python3Packages.capstone: 4.0.2 -> 5.0.1
* [`b861ecbc`](https://github.com/NixOS/nixpkgs/commit/b861ecbcd59ae2f1bfe6074cc77f7e0585a139b3) capstone_4: init at 4.0.2
* [`96366f6f`](https://github.com/NixOS/nixpkgs/commit/96366f6f051969c24382f01e3ef2122ec86fd1f2) python3Packages.pyocd: pin capstone to 4.0.2
* [`9e015e03`](https://github.com/NixOS/nixpkgs/commit/9e015e03345181e6b03c2c998f90a0e1a0b181ed) edb: pin capstone to 4.0.2
* [`1ec01c34`](https://github.com/NixOS/nixpkgs/commit/1ec01c34d79cb1c9dd8536a966684dd75dced2b7) zsh-syntax-highlighting: 0.7.1 -> 0.8.0
* [`7d4c0832`](https://github.com/NixOS/nixpkgs/commit/7d4c083215f1532750c5121cd896c185b1186c25) zsh-syntax-highlighting: switch to finalAttrs pattern and cleanup
* [`bf85950d`](https://github.com/NixOS/nixpkgs/commit/bf85950d9a093ed825eb121e9399966f671f7b85) zsh-syntax-highlighting: add maintainer gepbird
* [`ebf18553`](https://github.com/NixOS/nixpkgs/commit/ebf185539f80684efbfdd4a6c5fbd5d50a4868f3) cudaPackages: remove libstdc++ from nsight-systems from cuda 10
* [`05e97cbd`](https://github.com/NixOS/nixpkgs/commit/05e97cbddd98f5eb294a1a0c0783193ec185840f) miraclecast: 1.0-20190403 -> 1.0-20231112
* [`cf0edc33`](https://github.com/NixOS/nixpkgs/commit/cf0edc3321ebbcc3c37f16d915a25381671609b5) commandergenius: 2.3.3 -> 3.5.0
* [`9f2a705f`](https://github.com/NixOS/nixpkgs/commit/9f2a705f7f25f048e18a7fb8a321e621b1dc6818) nix-optimise: only create timer unit if needed
* [`32abbb17`](https://github.com/NixOS/nixpkgs/commit/32abbb17cd1acd65953bb8aa744e5d863eda24ff) maintainers: add birkb
* [`66d312f8`](https://github.com/NixOS/nixpkgs/commit/66d312f8a16bed78883a722f37aef0f27314bdf8) drbd: 9.19.1 -> 9.27.0
* [`d586d4dc`](https://github.com/NixOS/nixpkgs/commit/d586d4dcef6fd29b0d77c22b00887178a49091fb) drbd kernel driver added
* [`543c6ce4`](https://github.com/NixOS/nixpkgs/commit/543c6ce4f8d0553f312dfa186de1e2f03e05bf28) clairvoyant: 3.1.2 -> 3.1.3
* [`e0905a87`](https://github.com/NixOS/nixpkgs/commit/e0905a878ffef427950d38d7ae25dc851004a4a1) clairvoyant: Add wrapGAppsHook4 and use finalAttrs pattern
* [`4beb6898`](https://github.com/NixOS/nixpkgs/commit/4beb6898f89249b09c18cc473200a3b8ae07cbfa) clairvoyant: Add hideUnsupportedVersionBanner option
* [`8af634a8`](https://github.com/NixOS/nixpkgs/commit/8af634a8ace910951c80e95c693da3826fda22f0) lib.nng: fix mbedtlsSupport override
* [`4dd2148c`](https://github.com/NixOS/nixpkgs/commit/4dd2148ca611aac4627e433f5fcdbdfd7596044d) otto-matic: 4.0.1 -> unstable-2023-11-13
* [`ae48df3e`](https://github.com/NixOS/nixpkgs/commit/ae48df3ebb08c524af1af76e5c5ec54ce217a68d) nixos/getty: add option to autologin once per boot
* [`2ab5c8b5`](https://github.com/NixOS/nixpkgs/commit/2ab5c8b5faa93d7f19214026b1b4b5dc713066f5) netevent: 20201018 -> 20230429
* [`7fa9a0c8`](https://github.com/NixOS/nixpkgs/commit/7fa9a0c8968c67ee6dfcf8ea8e604c72de9c21ec) python3Packages.mip: fix cffi version
* [`deae0161`](https://github.com/NixOS/nixpkgs/commit/deae0161005f1fe8b7e4b7eb0c4897cfe73dd8cb) geeqie: 2.1 -> 2.2
* [`a87488e9`](https://github.com/NixOS/nixpkgs/commit/a87488e9f145df692ce3b44ac399c19db209e335) maintainers: add oo-infty
* [`8794795c`](https://github.com/NixOS/nixpkgs/commit/8794795cb90537d477d8a5998c88026f7c385f53) ugm: init at 1.4.0
* [`ca81a898`](https://github.com/NixOS/nixpkgs/commit/ca81a89839176c2e0d0b0fb01a931a4a65404fa6) lib.types.attrTag: init
* [`0feea2db`](https://github.com/NixOS/nixpkgs/commit/0feea2dbd2eb76ffa1ba1db7d291bcb1a274d529) doc/option-types: Write about sum and union types
* [`2ceb5558`](https://github.com/NixOS/nixpkgs/commit/2ceb5558f95f978f1df70a2873b0fdf6ee87ff9f) doc/option-types: Move either and oneOf to Union types
* [`1ad30772`](https://github.com/NixOS/nixpkgs/commit/1ad30772ea4feca0b597446e102fb323c89c41a0) doc/option-types: Move attrTag to Sum types, remove redundant paragraph
* [`6949bc21`](https://github.com/NixOS/nixpkgs/commit/6949bc21ce1de068bc1b21e273d15620c0e5770e) doc/option-types: Move nullOr to Union types
* [`9cd5f606`](https://github.com/NixOS/nixpkgs/commit/9cd5f606b09aaae3222f79ded3aea59b9f0532bd) maintainers: add phdyellow
* [`9c3d536f`](https://github.com/NixOS/nixpkgs/commit/9c3d536f0061ecf604cfeb2bf7b86e642bdb7fc2) discount: 2.2.7b -> 3.0.0d
* [`5c84f893`](https://github.com/NixOS/nixpkgs/commit/5c84f893106b6ee55711ec1924052e600c09384b) nixos/tinc: fix user to not include . in its name
* [`2768ac9c`](https://github.com/NixOS/nixpkgs/commit/2768ac9c9f3596127d1d6f9afc460f978175fcad) xgboost: preserve cmake targets in install phase
* [`8f384467`](https://github.com/NixOS/nixpkgs/commit/8f384467cce40d5298337bce5d8be24da1a4eb0d) vscode-utils: Set the sourceRoot attribute on vscode extensions
* [`c0b1470a`](https://github.com/NixOS/nixpkgs/commit/c0b1470a9a6345e8f9aaa8b78bc629d99e1932d7) python311Packages.gpsoauth: fix build
* [`ddeb49e0`](https://github.com/NixOS/nixpkgs/commit/ddeb49e0ae72d4b09fedbf5e11aa269dfea98bb0) gup: 0.9.0 -> 0.9.1
* [`f73a0793`](https://github.com/NixOS/nixpkgs/commit/f73a0793528c57c85fd7737317ee1293c336c774) dockerTools: Test changing compression of `buildLayeredImage`
* [`f4871a62`](https://github.com/NixOS/nixpkgs/commit/f4871a62d2dcf5e580dcd565a10ebb1ff14b3c9b) dockerTools: Do not pass `compressor` to `streamLayeredImage`
* [`b34ca295`](https://github.com/NixOS/nixpkgs/commit/b34ca295cb18cac7b853883cda21e516070213df) azure-cli: immutable command index
* [`4efe7f93`](https://github.com/NixOS/nixpkgs/commit/4efe7f93607f98c93b18460a43519cdab86ffd53) azure-cli: add extensions
* [`d6030ed9`](https://github.com/NixOS/nixpkgs/commit/d6030ed90c5aee2965d781f9b9e64abf18324dd8) azure-cli: add passthru function to override extensions
* [`aacf05da`](https://github.com/NixOS/nixpkgs/commit/aacf05daec3141ce2bb34fd7c021a86401ac8c51) azure-cli: explicitly construct PYTHONPATH
* [`f090c1cd`](https://github.com/NixOS/nixpkgs/commit/f090c1cd6bb5bbb14a86ec90ced78ca1a165a4fe) mpvScripts.uosc: 5.1.1 -> 5.2.0
* [`3b6cbc4d`](https://github.com/NixOS/nixpkgs/commit/3b6cbc4da2084a8669078ca4091a6fba84e21a4e) pablodraw: init at 3.3.13-beta
* [`df71fdde`](https://github.com/NixOS/nixpkgs/commit/df71fdde05c44b51077b47f745f335990d07f1c9) burpsuite: 2023.10.2.4 -> 2024.1.1.4
* [`8e3ed28f`](https://github.com/NixOS/nixpkgs/commit/8e3ed28f8972295ab0524d90f370221c573ac9bb) mpvScripts.dynamic-crop: init at 0-unstable-2023-12-22
* [`a8728bf0`](https://github.com/NixOS/nixpkgs/commit/a8728bf01b17ff5250ab25ccf2770de086f23ddd) kdePackages.kcolorpicker: 0.3.0 -> 0.3.1
* [`4e936216`](https://github.com/NixOS/nixpkgs/commit/4e93621647790cc20d286b7b00d9303770548a42) libsForQt5.kimageannotator: 0.7.0 -> 0.7.1
* [`a805ae9f`](https://github.com/NixOS/nixpkgs/commit/a805ae9f3a91702ddb542e6c8b4f260701749ae5) ksnip: fix build with latest kcolorpicker
* [`b7b5ba66`](https://github.com/NixOS/nixpkgs/commit/b7b5ba669fea7c43c3f6fbc63e5565dccc2aadc0) maintainers/team-list: add cloudposse team for atmos
* [`b1f23d40`](https://github.com/NixOS/nixpkgs/commit/b1f23d4045bbc9388a1125fccea59ab72fff93b8) looking-glass-client: B6 -> B7-rc1
* [`9f665273`](https://github.com/NixOS/nixpkgs/commit/9f6652732882f32067f35bc44f5a5eee83fd8375) looking-glass-client: enable support for opengl by default
* [`7e409bb2`](https://github.com/NixOS/nixpkgs/commit/7e409bb2f28be292945742ae8262125cf93f879b) looking-glass-client: add patch to fix wayland only build
* [`f27ac4a2`](https://github.com/NixOS/nixpkgs/commit/f27ac4a21c9481f1172cb79442c24b95500f6e0a) kernel-doc: fix build
* [`49922ef2`](https://github.com/NixOS/nixpkgs/commit/49922ef2999d721fb4ad6718e046a1e583b18c95) hyprland-monitor-attached: init at 0.1.5
* [`f03a4d8e`](https://github.com/NixOS/nixpkgs/commit/f03a4d8e97967e2103f00351fae4acfdf109aabe) mermaid-cli: 10.4.0 -> 10.8.0
* [`c197e4a1`](https://github.com/NixOS/nixpkgs/commit/c197e4a1e0e3bc8a628e4de197b2e88c23af605e) restic-rest-server: add nixos test
* [`7762c223`](https://github.com/NixOS/nixpkgs/commit/7762c2233c801f22cb0e377dcef2a2b510609f9b) nixos/restic-rest-server: Add additional service hardening
* [`9e1fe5cd`](https://github.com/NixOS/nixpkgs/commit/9e1fe5cddd5c786c0fcceff37a90d9837dc68bcb) nixos/restic-rest-server: Make the service socket activated
* [`beb13949`](https://github.com/NixOS/nixpkgs/commit/beb139496afe7d5badef702f2fa5a03a1d8d5dc7) nixos/resolvconf: add option "trust-ad" when `useLocalResolver` is enabled
* [`750d2575`](https://github.com/NixOS/nixpkgs/commit/750d257532550cb0564c31a15b7ff19fcafb8246) libcdio-paranoia: 10.2+0.94+2 -> 10.2+2.0.1
* [`f313fe0c`](https://github.com/NixOS/nixpkgs/commit/f313fe0c70a25e06b7335d05b3a39fe7f589bbe2) jna: make deterministic and clean up
* [`b0a8cf52`](https://github.com/NixOS/nixpkgs/commit/b0a8cf5243b92b20c2e8bf44d77a1e03126328aa) dmd: migrate to pkgs/by-name
* [`d87c4e1a`](https://github.com/NixOS/nixpkgs/commit/d87c4e1a720f827996c282d0e194850a8903cebe) digital-ocean: make it easier to use disko
* [`3f71d1bc`](https://github.com/NixOS/nixpkgs/commit/3f71d1bc02b6100222e440a6ad0571d8e0db4896) digital-ocean: no longer disable multiple nixos generations in bootloader
* [`8f5bbcc3`](https://github.com/NixOS/nixpkgs/commit/8f5bbcc32721cfa8da85929a7007c2c1755cef0e) bird: 2.15 -> 2.15.1
* [`5f7be1b9`](https://github.com/NixOS/nixpkgs/commit/5f7be1b9a30b753560c76d416f28da3546b96584) dyalog: 18.2.45405 -> 19.0.48958
* [`e335ef79`](https://github.com/NixOS/nixpkgs/commit/e335ef799143a9cf15a9cc97b9728b6d30b20d8f) tvbrowser: user stripJavaArchivesHook for determinism
* [`91238caa`](https://github.com/NixOS/nixpkgs/commit/91238caafb3ecf0c91fbb19dbc36da932bfbd443) python3Packages.pysimplegui: change license to unfree
* [`642b9fc7`](https://github.com/NixOS/nixpkgs/commit/642b9fc72b7c08d47ab0f8b01c5982d956e109bc) python3Packages.pysimplegui: mark as broken
* [`eccde464`](https://github.com/NixOS/nixpkgs/commit/eccde4643b8ea82e11fd45f79ff5b912a871f09c) paperless-ngx: fix subpath installation
* [`f528df9f`](https://github.com/NixOS/nixpkgs/commit/f528df9f37632a8b0b833022db4251c1ff97002c) rocmPackages_6.hiprand: init at 6.0.2
* [`51180840`](https://github.com/NixOS/nixpkgs/commit/51180840714b17c09c466f2a172a4cfb5e35039d) maintainers: add ok-nick
* [`c4304c2a`](https://github.com/NixOS/nixpkgs/commit/c4304c2afae4abf0e40672f72ac6729a226bf6b3) iroh: 0.11.0 -> 0.13.0
* [`b390d53e`](https://github.com/NixOS/nixpkgs/commit/b390d53ee8cd1eb9cf6ee37af67ca80a9f1de2f5) yquake2: add desktop item
* [`39035bd2`](https://github.com/NixOS/nixpkgs/commit/39035bd2630b15e2f18ed3eb7d399d85d53db5af) gnunet: 0.20.0 -> 0.21.1
* [`8922d75e`](https://github.com/NixOS/nixpkgs/commit/8922d75e9314b1b9586e4241bf4cead018046dae) gnunet-gtk: 0.20.0 -> 0.21.0
* [`84a7adec`](https://github.com/NixOS/nixpkgs/commit/84a7adecfaf541644e860f7898c89bdca2344747) vscode-extensions.teabyii.ayu: init at 1.0.5
* [`06208fad`](https://github.com/NixOS/nixpkgs/commit/06208fadd6eef4d7f9a9a44f7be3978b9f77a3af) vimPlugins.gruvbox-baby: init at 2024-01-25
* [`571ecbf8`](https://github.com/NixOS/nixpkgs/commit/571ecbf8897ce54719175b67eda7243212a9e072) charm-freeze: init at 0.1.4
* [`71401e8d`](https://github.com/NixOS/nixpkgs/commit/71401e8d39f75823469799cb2f256dc3f925cb8c) python3Packages.snakemake: init at 8.4.12
* [`37d707fb`](https://github.com/NixOS/nixpkgs/commit/37d707fb47e084080006bf67b68a7cc8acfd4f03) python311Packages.snakemake-storage-plugin-s3: init at 0.2.10
* [`2f520017`](https://github.com/NixOS/nixpkgs/commit/2f5200175fa9da14e5a328e878ffe97d3483cb04) python311Packages.snakemake-storage-plugin-xrootd: init at unstable-2023-12-16
* [`3dd227aa`](https://github.com/NixOS/nixpkgs/commit/3dd227aacbc9418a96bef91a0932aa0573019896) garnet: init at 1.0.1
* [`de757d16`](https://github.com/NixOS/nixpkgs/commit/de757d162ccddfbc56202142c6049cd3c5879731) python311Packages.sentry-sdk: 1.42.0 -> 1.43.0
* [`974a3a22`](https://github.com/NixOS/nixpkgs/commit/974a3a22aa6481adf99d02c334aea62110398b76) python312Packages.attrdict: refactor
* [`2a858691`](https://github.com/NixOS/nixpkgs/commit/2a85869152a4967491f8084721216dd3c721d3ae) snippetexpander: 1.0.1 -> 1.0.2
* [`580150a7`](https://github.com/NixOS/nixpkgs/commit/580150a7675b1a9be1183af7e68d7c52833445aa) parsec-bin: 150-91a -> 150-93b
* [`98280b59`](https://github.com/NixOS/nixpkgs/commit/98280b593631d6731207e9bf09b529f57fbc43ef) quantlib: 1.29 -> 1.33
* [`4896b1d5`](https://github.com/NixOS/nixpkgs/commit/4896b1d57f086bc6f2c369425f03de15729fb05f) rPackages.RQuantLib: fix build error
* [`24aa3480`](https://github.com/NixOS/nixpkgs/commit/24aa3480231a2c37548121e09d33db097db67eae) yutto: 2.0.0b36-unstable-2024-03-04 -> 2.0.0-beta.37
* [`e400baa3`](https://github.com/NixOS/nixpkgs/commit/e400baa30fee44fb0c8c7893e6b6400e7c4b4411) haskellPackages: stackage LTS 22.13 -> LTS 22.14
* [`9103af4d`](https://github.com/NixOS/nixpkgs/commit/9103af4df1a15d68331cefd3b44d09c7cddb75dd) all-cabal-hashes: 2024-03-16T22:28:08Z -> 2024-03-31T04:36:22Z
* [`11251775`](https://github.com/NixOS/nixpkgs/commit/1125177568a762024d594d04e4924521511134b3) haskellPackages: regenerate package set based on current config
* [`28179dd8`](https://github.com/NixOS/nixpkgs/commit/28179dd8942b0d98e4c79153ea54001b53866a78) python311Packages.flask-admin: add nickcao to maintainers
* [`ba5cd1cc`](https://github.com/NixOS/nixpkgs/commit/ba5cd1ccfdcd458f8ffa6c4a711ca9c3044e3487) python311Packages.flask-admin: fetch source from github
* [`a41d4c10`](https://github.com/NixOS/nixpkgs/commit/a41d4c10cc9e097d28ba138da88108a85387dfb9) python311Packages.flask-admin: modernize
* [`5ee48ebd`](https://github.com/NixOS/nixpkgs/commit/5ee48ebd34521df8c5bdb71691167718b21adb01) haskell.packages.ghc98.aeson: jailbreak
* [`156f69bb`](https://github.com/NixOS/nixpkgs/commit/156f69bbcb280c059a6418de7fd0921fab64ea1b) postgresqlPackages.pg_safeupdate: add myself as maintainer
* [`7a358ffd`](https://github.com/NixOS/nixpkgs/commit/7a358ffd0ec3e867fa118bdeb01bf45f2131082b) postgresqlPackages.postgis: add myself as maintainer
* [`5e0eeb36`](https://github.com/NixOS/nixpkgs/commit/5e0eeb362bcfa4017e6e57b091c95a0dcb8ba571) postgresql{12,13}Packages.pg_safeupdate: 1.5 -> 1.4
* [`51657795`](https://github.com/NixOS/nixpkgs/commit/516577950334e577d880f7f6ddc490338a2d0e3d) rocmPackages_5.miopen: correctly link gtest
* [`4eac13a8`](https://github.com/NixOS/nixpkgs/commit/4eac13a88cadc64d65c90a34bb699a31f239aa3b) rocmPackages_6.miopen: correctly link gtest
* [`f622969b`](https://github.com/NixOS/nixpkgs/commit/f622969b9aa5f49270e42e22955d1a41061fd007) haskellPackages.optparse-applicative-cmdline-util: unbreak
* [`829ed359`](https://github.com/NixOS/nixpkgs/commit/829ed35978fe3b594c71eaba15c192602a6ae52e) haskellPackages: fix eval
* [`fbad66da`](https://github.com/NixOS/nixpkgs/commit/fbad66daa54da694be13df7b24b18b7bad843d56) add "Check cherry-picks" github action
* [`7b0a5c54`](https://github.com/NixOS/nixpkgs/commit/7b0a5c54045c87cc5284389063a107e6665416fb) haskellPackages.smtp-mail: remove obsolete patch
* [`67fc6ff7`](https://github.com/NixOS/nixpkgs/commit/67fc6ff7ff2cdef01a83d8518b9c0b598577e65f) haskellPackages.castagnoli: unbreak
* [`71caf098`](https://github.com/NixOS/nixpkgs/commit/71caf0987d4aea89faa33bddea7b9fbc30050bd7) boinc: 7.24.3 -> 8.0.1
* [`3cf7d830`](https://github.com/NixOS/nixpkgs/commit/3cf7d830e2274557450f8f3a43687785d9b234ac) man-pages: 6.05.01 -> 6.7
* [`080c08d3`](https://github.com/NixOS/nixpkgs/commit/080c08d3c1d6525f92c7a9eb9f04bd000e772b63) nixosTests.networking: split router into a separate file and remove `with lib;` antipattern
* [`ccf3cfcd`](https://github.com/NixOS/nixpkgs/commit/ccf3cfcdf6d0db22be34af601fbe8d022880fc02) dmd: modernize
* [`d1fec21f`](https://github.com/NixOS/nixpkgs/commit/d1fec21f6470b913d0f1a164fd807f65d79ae6a4) dtools: migrate to pkgs/by-name
* [`b01c88e6`](https://github.com/NixOS/nixpkgs/commit/b01c88e620c8e9205123b608b84801729537a09e) dtools: refactor
* [`e85f7c6c`](https://github.com/NixOS/nixpkgs/commit/e85f7c6c9d494fa19204fd8584bea5f2c34d6179) dtools: 2.106.1 -> 2.108.0
* [`9b3cf68e`](https://github.com/NixOS/nixpkgs/commit/9b3cf68ef2aa71c1d9c6fe33bdb8aa45d978252f) dmd: 2.106.1 -> 2.108.0
* [`a878acdf`](https://github.com/NixOS/nixpkgs/commit/a878acdf0ec9a6af606525b11af79a76a5a7ed74) python311Packages.torch: 2.2.1 -> 2.2.2
* [`46ad2b23`](https://github.com/NixOS/nixpkgs/commit/46ad2b23f58e6e3429862c8dc857c9a06c230a0c) python311Packages.torch-bin: 2.2.1 -> 2.2.2
* [`fe826e91`](https://github.com/NixOS/nixpkgs/commit/fe826e91f85522d28b23c809dac8d1323980ddde) python311Packages.torchaudio: 2.2.1 -> 2.2.2
* [`940adc0c`](https://github.com/NixOS/nixpkgs/commit/940adc0c5544b10a15c7d924427ebeac0fd58162) python311Packages.torchaudio-bin: 2.2.1 -> 2.2.2
* [`56a86116`](https://github.com/NixOS/nixpkgs/commit/56a86116cb6b1ed3565d41f38cb0bc40e801d8da) python311Packages.torchvision: 0.17.1 -> 0.17.2
* [`91b6d8b4`](https://github.com/NixOS/nixpkgs/commit/91b6d8b4b3375d7315976d5c9dc1650d4d98c29b) python311Packages.torchvision-bin: 0.17.1 -> 0.17.2
* [`ebda6b8f`](https://github.com/NixOS/nixpkgs/commit/ebda6b8f90821993d1177420de2d51b0136f21cd) virglrenderer: expose and enable va-api option by default
* [`1443bac3`](https://github.com/NixOS/nixpkgs/commit/1443bac30aaabb78b8f0ef366c0e0ad6ebc8190e) bird: remove globin as maintainer
* [`02c86f89`](https://github.com/NixOS/nixpkgs/commit/02c86f89ca09348d1f5a6454f1affc6fed760f00) haskellPackages: add slotThe as maintainer for kmonad
* [`adb6af6e`](https://github.com/NixOS/nixpkgs/commit/adb6af6e871baef8e07e9fa44756a2292fa0e3c8) haskellPackages.kmonad: unbreak
* [`368dd6c7`](https://github.com/NixOS/nixpkgs/commit/368dd6c7a549146d3266ca1c21284895aa3bbbec) setools: 4.4.4 -> 4.5.0
* [`4874517e`](https://github.com/NixOS/nixpkgs/commit/4874517e27163fa16d37028bce318287fc70ec6a) python31Packages.nibabel: unbreak by disabling test requiring `distutils`
* [`6cf68fd4`](https://github.com/NixOS/nixpkgs/commit/6cf68fd40180b38e2ada10cfb95d724b9b1161f6) skaffold: 2.10.1 -> 2.11.0
* [`6b6683dd`](https://github.com/NixOS/nixpkgs/commit/6b6683ddf486870ff451d2552fe2daf6ce5cf284) igraph: 0.10.10 -> 0.10.11
* [`c3eb87ff`](https://github.com/NixOS/nixpkgs/commit/c3eb87ffd2373e4089e161792e8bb9a7f9c6aa86) pulldown-cmark: 0.10.0 -> 0.10.2
* [`677b3f4a`](https://github.com/NixOS/nixpkgs/commit/677b3f4acb41f9d6064c8b2530b51c97a176fd72) ceph-csi: 3.10.2 -> 3.11.0
* [`c7a1fb29`](https://github.com/NixOS/nixpkgs/commit/c7a1fb29bf5608372ee671dfc44c46b2e805902b) frugal: 3.17.9 -> 3.17.10
* [`78ec6893`](https://github.com/NixOS/nixpkgs/commit/78ec6893a13139b9c38bb482ec6037c242301798) aerospike: 7.0.0.6 -> 7.0.0.7
* [`1ea6485c`](https://github.com/NixOS/nixpkgs/commit/1ea6485c108322320beb25673008efac739d316f) c2patool: init at 0.8.2
* [`77ea4d6b`](https://github.com/NixOS/nixpkgs/commit/77ea4d6b9020c2eec5f1bed859ccfaad67ebb952) catppuccin: add lxqt theme
* [`43fc4b09`](https://github.com/NixOS/nixpkgs/commit/43fc4b091264110f59a085539981d3b9ea90f631) opera: 108.0.5067.29 -> 109.0.5097.38
* [`543d39e0`](https://github.com/NixOS/nixpkgs/commit/543d39e0579075f1fa193b5c0353983b474bb73c) mdadm: update homepage
* [`a2954dea`](https://github.com/NixOS/nixpkgs/commit/a2954dea377e749d9cff5f71f3815330a5907ee9) cudaPackages: make getOutput work again
* [`9c555ad2`](https://github.com/NixOS/nixpkgs/commit/9c555ad2ea67ba4ac8a68bd6395509d9a61b0bc6) open-stage-control: 1.26.1 -> 1.26.2
* [`7d6914b6`](https://github.com/NixOS/nixpkgs/commit/7d6914b6f563d1b22abc27680fb245389e17661f) dotslash: 0.2.0 -> 0.3.0
* [`360db45b`](https://github.com/NixOS/nixpkgs/commit/360db45b01e30c65816321b8f6ab0eab6f01d95f) csvkit: 1.4.0 -> 1.5.0
* [`c3428248`](https://github.com/NixOS/nixpkgs/commit/c3428248d986b1b6a7cb929103c7020330a604b5) fuse2: add to top-level
* [`4e71d4b8`](https://github.com/NixOS/nixpkgs/commit/4e71d4b8ed88214296b4835bd8e46bde16bc888b) rar2fs: use fuse2
* [`c07cc015`](https://github.com/NixOS/nixpkgs/commit/c07cc01560d7095dda8dc4037beb80ca333a0508) cabal-install: fix
* [`0641ee45`](https://github.com/NixOS/nixpkgs/commit/0641ee458cb7340ba3d26fe23d38ba170db942eb) fblog: 4.8.0 -> 4.9.0
* [`7f276089`](https://github.com/NixOS/nixpkgs/commit/7f2760891546ea9df15bb47b171b3915ec47491d) prometheus-ping-exporter: 1.1.1 -> 1.1.3
* [`77f34ccf`](https://github.com/NixOS/nixpkgs/commit/77f34ccf4d7faff8b007e8f581bdf659ebe37629) apko: 0.10.0 -> 0.13.2
* [`ca563369`](https://github.com/NixOS/nixpkgs/commit/ca56336922ed269b7643426bd6ee6b78e1a373d3) elasticmq-server-bin: 1.5.7 -> 1.5.8
* [`40a13527`](https://github.com/NixOS/nixpkgs/commit/40a1352775e54d1579ac7c8a1cf6a19cd7a7e2b0) doppler: 3.67.1 -> 3.68.0
* [`db457641`](https://github.com/NixOS/nixpkgs/commit/db457641934498f3cc7f2c952533070442beefd6) jose: 12 -> 13
* [`acbf75bf`](https://github.com/NixOS/nixpkgs/commit/acbf75bf2255cf65c1578d0fb028444f1e510e06) python311Packages.elasticsearchdsl: 8.12.0 -> 8.13.0
* [`2f509171`](https://github.com/NixOS/nixpkgs/commit/2f509171e9f6e3083ab6ec78dde03e4e2f31fded) ndiswrapper: use elfutils instead of abandoned libelf
* [`a9868929`](https://github.com/NixOS/nixpkgs/commit/a986892985ff9639224acdcaeb3453c9772343fd) chatterino2: build with Qt6
* [`279ba486`](https://github.com/NixOS/nixpkgs/commit/279ba486a7f09f55d74e5748d649e4e56793d44c) maintainers: add supa
* [`756672d1`](https://github.com/NixOS/nixpkgs/commit/756672d106479410e71e8f8db16f34d9d4804f71) chatterino2: add supa as maintainer
* [`35223519`](https://github.com/NixOS/nixpkgs/commit/3522351939a888a23c92d60c2a540a27f0b75cad) colstr: init at 1.0.0
* [`f9f1092c`](https://github.com/NixOS/nixpkgs/commit/f9f1092c7393d662382fb45fb7a216a42985e5a0) koji: init at 2.2.0
* [`03cb76ec`](https://github.com/NixOS/nixpkgs/commit/03cb76ec6b6078654e79406f043b3bee4606c0c2) chipsec: use elfutils instead of abandoned libelf
* [`7090b51c`](https://github.com/NixOS/nixpkgs/commit/7090b51ca63393b022dba4e20a961a38a6bca5f8) wallabag: 2.6.8 -> 2.6.9
* [`9e2765df`](https://github.com/NixOS/nixpkgs/commit/9e2765dfd583832d056f178964de01cd5cce5efc) virter: 0.26.0 -> 0.27.0
* [`7583ec12`](https://github.com/NixOS/nixpkgs/commit/7583ec12b017ed207a9410f83b3b9a49b80c5a63) dhcpig: init at 1.6
* [`bd5839cd`](https://github.com/NixOS/nixpkgs/commit/bd5839cd1e194f321fab466db293b8317f533763) packages-config.nix: add `agdaPackages`
* [`57f9cc10`](https://github.com/NixOS/nixpkgs/commit/57f9cc103f1e62ee1b27e73051d78f2acf2bce17) ptouch-print: 1.4.3 -> 1.5-unstable-2024-02-11
* [`0e0d4344`](https://github.com/NixOS/nixpkgs/commit/0e0d43445658106654f64807e2fc698d3a77c27f) forgejo-runner: rename from forgejo-actions-runner
* [`7c18b967`](https://github.com/NixOS/nixpkgs/commit/7c18b96700e6b350710647cefcce03a9bb209010) forgejo-runner: add emilylange as maintainer
* [`a9da75cb`](https://github.com/NixOS/nixpkgs/commit/a9da75cb7ffac76d4cb120982043d323f388613f) forgejo-runner: fix `meta.changelog`
* [`b821720d`](https://github.com/NixOS/nixpkgs/commit/b821720d255122f34056b6c886d494629b61f625) forgejo-runner: 3.3.0 -> 3.4.1
* [`69c45635`](https://github.com/NixOS/nixpkgs/commit/69c456355107b2e7e6939ff38a0efb5570e6c9a0) nixos/yubikey-agent: update doc ref to pinentry
* [`5c9c36ef`](https://github.com/NixOS/nixpkgs/commit/5c9c36ef67729eca4f2baa62e756c58a8566d052) fishPlugins.sdkman-for-fish: 2.0.0 -> 2.1.0
* [`d68cf482`](https://github.com/NixOS/nixpkgs/commit/d68cf48284214eb3664897c1934b20a7f5679f31) python312Packages.xyzservices: 2023.10.1 -> 2024.4.0
* [`b52736a3`](https://github.com/NixOS/nixpkgs/commit/b52736a31b1a2b8240e10cafa9324179550d8f5d) sentry-native: 0.7.1 -> 0.7.2
* [`c9e7fbc3`](https://github.com/NixOS/nixpkgs/commit/c9e7fbc38f6577cd5c525f1b72a190aa496428ad) nco: 5.2.2 -> 5.2.3
* [`bc576f9c`](https://github.com/NixOS/nixpkgs/commit/bc576f9c0ebd397225ac312ab7f16856589a6c76) cemu: 2.0-73 -> 2.0-74
* [`40256d1d`](https://github.com/NixOS/nixpkgs/commit/40256d1dd4851e102cf7d6253aebba140545db58) tryton: 7.0.7 -> 7.0.8
* [`7eb7e71e`](https://github.com/NixOS/nixpkgs/commit/7eb7e71eb8bcb439b7425c781ae71d5381598d5c) mueval,diagrams-builder: fix GHC libdir
* [`5b49672a`](https://github.com/NixOS/nixpkgs/commit/5b49672af44875df0449f7ff1b55965eedeec1da) lib.types.attrTag: Support module docs
* [`42d3b54f`](https://github.com/NixOS/nixpkgs/commit/42d3b54f0dab73e42e6643e0a3c0ee140b6c8112) lib.types.attrTag: Take options instead of types
* [`0bc97832`](https://github.com/NixOS/nixpkgs/commit/0bc978322178fe6dbe91fe1477d275e1005d5e77) lib.types.attrTag: Support type merging
* [`e090bb55`](https://github.com/NixOS/nixpkgs/commit/e090bb55f0599afcdfda63f3e7e27bfd1cfd0691) lib/types.nix: Fix getSubOptions doc
* [`4c7d990b`](https://github.com/NixOS/nixpkgs/commit/4c7d990badc4a6ef9adcffb0790902de94faa51e) lib.types.attrTag: Provide declarations, definitions
* [`2e1d4705`](https://github.com/NixOS/nixpkgs/commit/2e1d470569f5a2a1a9154efdf6f21d12c659631d) lib.modules.evalOptionValue: Undeprecate for lib.types
* [`475a55b2`](https://github.com/NixOS/nixpkgs/commit/475a55b2f0433d5324817ab9882102db65e3733e) lib.types.attrTag: Remove tags from description
* [`c0f54d3d`](https://github.com/NixOS/nixpkgs/commit/c0f54d3dea047729d754dc2419ecfe8ab2cce23b) doc/option-types: Add attrTag example
* [`fa8b46ad`](https://github.com/NixOS/nixpkgs/commit/fa8b46adf467eec196da8808d62c9e03d69caa37) doc/option-types: Make attrTag example self-contained
* [`bcd77460`](https://github.com/NixOS/nixpkgs/commit/bcd774606a257fd6f14bda50effac67474005447) lib/tests/modules/types-attrTag: Test against unexpected attrs
* [`1465777b`](https://github.com/NixOS/nixpkgs/commit/1465777b63d38988d5ecd81683d2975321e59d1a) lib.types.attrTag: Custom error when passing bare type
* [`47e4a18d`](https://github.com/NixOS/nixpkgs/commit/47e4a18d018be9efaa93a199e24fbeedc80f14be) types.attrTagWith: remove
* [`2d791b5f`](https://github.com/NixOS/nixpkgs/commit/2d791b5f7b6575f2153f5971a2046bec15f637f7) types.attrTag: Remove substSubmodules
* [`f3546865`](https://github.com/NixOS/nixpkgs/commit/f354686536823a0bedb95abf13b090b961485bf9) doc/option-types: Update sum types
* [`74831d8b`](https://github.com/NixOS/nixpkgs/commit/74831d8b38ad4754940d25a03a39ce66b6b6cf4f) lib/tests/modules/types-attrTag.nix: Clean up unneeded comment
* [`cf4968a9`](https://github.com/NixOS/nixpkgs/commit/cf4968a9045e7404ba54598ee9608f7e33458006) lib/tests/modules/types-attrTag.nix: Test other option doc attrs
* [`22d7f146`](https://github.com/NixOS/nixpkgs/commit/22d7f146a4b11f89118fc4dd5939e09d2e4e652d) lib.types.attrTag: Fix declarationPositions after merge
* [`35fe5383`](https://github.com/NixOS/nixpkgs/commit/35fe538330b738b90d527d908ee487e38d42de40) types.attrTag: Remove unnecessary definitions override
* [`2bf96698`](https://github.com/NixOS/nixpkgs/commit/2bf96698281d49ec9002e180b577b19353c3d806) terraform: use `--replace-fail`
* [`d9bfea98`](https://github.com/NixOS/nixpkgs/commit/d9bfea98bd23acf3939beeaa109113898e587b95) coder: 0.17.1 -> 2.9.1
* [`b5cea4a3`](https://github.com/NixOS/nixpkgs/commit/b5cea4a3c5a6ea3050f8223b8c9c72d2be1f825e) python311Packages.umap-learn: 0.5.5 -> 0.5.6
* [`44fd320d`](https://github.com/NixOS/nixpkgs/commit/44fd320df69d7331ff94d5e6975281b5d41efd26) nixos/borgbackup: fix network-online.target warning
* [`1dc8a2c3`](https://github.com/NixOS/nixpkgs/commit/1dc8a2c39ec9e8f3b545c6dbb8fecbb89886d9af) zed-editor: init at 0.129.2
* [`ba0f5fd9`](https://github.com/NixOS/nixpkgs/commit/ba0f5fd90809cfe4742c4e26f0aa216086441cbb) power-profiles-daemon: 0.20 -> 0.21
* [`2eb99744`](https://github.com/NixOS/nixpkgs/commit/2eb99744ce9bda4db6a9ba21d429f299d590bfc5) ocamlPackages.stdlib-shims: use Dune 3
* [`b9fe4b1e`](https://github.com/NixOS/nixpkgs/commit/b9fe4b1e26e573089ae23a458151eb6898f2b011) nixos/repart-image: supply explicit --architecture to repart
* [`14a4dcf9`](https://github.com/NixOS/nixpkgs/commit/14a4dcf948e5395f6dba759142e8919f0440331c) sonarr: 4.0.2.1183 -> 4.0.3.1413
* [`e4c96529`](https://github.com/NixOS/nixpkgs/commit/e4c965299639ad5bb41e135890c7229ed4f95400) vmagent: 1.99.0 -> 1.100.0
* [`b9722d3f`](https://github.com/NixOS/nixpkgs/commit/b9722d3f3a535b65ceac6b6e1608555d4ab7a4fd) intiface-central: 2.5.3 -> 2.5.6
* [`bb145640`](https://github.com/NixOS/nixpkgs/commit/bb145640a099594032c5e3a4d96f8f259a357afe) chromium: fix vulkan-loader
* [`230e5586`](https://github.com/NixOS/nixpkgs/commit/230e558635d80b333f2558b4863f7f6628c5f3a2) electron-*-bin: fix vulkan-loader
* [`54332d94`](https://github.com/NixOS/nixpkgs/commit/54332d94955863997b61ad3bb0ebeb0bcc2709a8) jetbrains: 2023.3 EAP -> 2024.1
* [`41e0d7f9`](https://github.com/NixOS/nixpkgs/commit/41e0d7f95f89dfcbedef778c5962c0496650fe54) jetbrains.plugins: update
* [`676aeada`](https://github.com/NixOS/nixpkgs/commit/676aeada576ae093164658837b96c4c746080761) jetbrains.gateway: add libgcc to fix build
* [`9e5bab31`](https://github.com/NixOS/nixpkgs/commit/9e5bab31bef64c6276004a39e7ac20c83071df94) heimer: 4.3.0 -> 4.4.0
* [`eede8946`](https://github.com/NixOS/nixpkgs/commit/eede894699d33de216d75187929ecb1ebb7f4794) libtommath: 1.2.1 -> 1.3.0
* [`a9be06cc`](https://github.com/NixOS/nixpkgs/commit/a9be06cc4da77181052e7db00bf54653dcf3708a) minimap2: 2.27 -> 2.28
* [`48f1ff4e`](https://github.com/NixOS/nixpkgs/commit/48f1ff4e74f6d1851a9ac61b246a1f4a6fd1d101) apkeep: 0.15.0 -> 0.16.0
* [`a58d45a1`](https://github.com/NixOS/nixpkgs/commit/a58d45a160ea9115be1bf19282ffb24c57708ad9) tangerine: init at 2024-04-05
* [`1536ad09`](https://github.com/NixOS/nixpkgs/commit/1536ad097bb2823e353723ee17c27a6393ea2813) fluent-bit: 3.0.0 -> 3.0.1
* [`4792dfa6`](https://github.com/NixOS/nixpkgs/commit/4792dfa696c75f1496f9bbaab58b4ea92364dbd7) kubeseal: 0.26.0 -> 0.26.2
* [`110961b4`](https://github.com/NixOS/nixpkgs/commit/110961b41048c56a318e9b107e4545be980d9e4d) piv-agent: init at 0.21.0
* [`9598063d`](https://github.com/NixOS/nixpkgs/commit/9598063d6873884bda8f5568adb6eb2babddc77c) make devenv release blocker
* [`7002413a`](https://github.com/NixOS/nixpkgs/commit/7002413a6b41ccd7a50b89de9ff9eea17285699f) technitium-dns-server: build from source instead of binary
* [`4d151d7a`](https://github.com/NixOS/nixpkgs/commit/4d151d7a336f7acc8490cf4da4379123b894516a) mlv-app: 1.11 -> 1.14
* [`02188060`](https://github.com/NixOS/nixpkgs/commit/02188060d9ba6ff08d51ca89016d214ea7107484) rmfakecloud: 0.0.17 -> 0.0.18
* [`35725d3b`](https://github.com/NixOS/nixpkgs/commit/35725d3bea68a8733f34dde540ebfc0c46efcc78) gdal: 3.8.4 -> 3.8.5
* [`fb5d9b77`](https://github.com/NixOS/nixpkgs/commit/fb5d9b77a6afa1e4acb08fd268fecdab4571b47a) solo5: move to pkgs/by-name
* [`a1008592`](https://github.com/NixOS/nixpkgs/commit/a100859273fba3d8678ba7fd9f38e98749f466f1) solo5: 0.8.0 -> 0.8.1
* [`0b7ae75f`](https://github.com/NixOS/nixpkgs/commit/0b7ae75f536b89cd001738e76cd0ea5c24b752a1) curl-impersonate: 0.5.4 -> 0.6.1
* [`078a46ab`](https://github.com/NixOS/nixpkgs/commit/078a46ab20526ea8d36183e2cb76e7b5be0000f1) opensc: 0.25.0 -> 0.25.1
* [`d143f645`](https://github.com/NixOS/nixpkgs/commit/d143f645104b28ca2e2e675380814491c0d4a664) ooniprobe-cli: 3.21.0 -> 3.21.1
* [`f45a488e`](https://github.com/NixOS/nixpkgs/commit/f45a488ecb584a8c0bdb0efd12406757db9bac3f) maintainers: add imrying
* [`39cdfe0c`](https://github.com/NixOS/nixpkgs/commit/39cdfe0cfd9c61ef6b2f7e6593984d21b81c514b) sesh: 1.0.1 -> 1.1.0
* [`c793e550`](https://github.com/NixOS/nixpkgs/commit/c793e5509278f29a38dd537f148da0348ae95315) nixos/xss-lock: restart if xss-lock exits
* [`d2429207`](https://github.com/NixOS/nixpkgs/commit/d242920707fa99e5f3de8369a49a475ede22c7d3) imhex: 1.32.2 -> 1.33.2
* [`c0fe794b`](https://github.com/NixOS/nixpkgs/commit/c0fe794bff594f35b968a998091638bba641c5db) ffmpeg_7: init at 7.0
* [`30cf86a5`](https://github.com/NixOS/nixpkgs/commit/30cf86a53696828f048935b65dede5c6f9a4ad0b) vimPlugins.persisted-nvim: init at 2024-04-04
* [`49f361d3`](https://github.com/NixOS/nixpkgs/commit/49f361d3c241e7593a100f120d9aaaffad2b4bb6) diffoscope: 261 -> 263
* [`11d077f1`](https://github.com/NixOS/nixpkgs/commit/11d077f10aca14a7178f3dbee323089ea7d0b6eb) python312Packages.astropy-iers-data: 0.2024.03.04.00.30.17 -> 0.2024.04.01.00.33.14
* [`9598f1f3`](https://github.com/NixOS/nixpkgs/commit/9598f1f34dc487f906a79c0a413e259b54127057) svdtools: 0.3.11 -> 0.3.14
* [`90d3a8bf`](https://github.com/NixOS/nixpkgs/commit/90d3a8bfe82dad67b0722f68c70df6e9c77cee81) bookstack: 24.02.2 -> 24.02.3
* [`f5729868`](https://github.com/NixOS/nixpkgs/commit/f57298689f96433087c51891148e2f5b7908aef0) ngrid: init at 0.1.0
* [`55e622f7`](https://github.com/NixOS/nixpkgs/commit/55e622f7d2c9e334f1afefa689306066c62015f8) vivaldi: 6.6.3271.55 -> 6.6.3271.57
* [`859826ce`](https://github.com/NixOS/nixpkgs/commit/859826ce1da84746392000bd612ed63e5ff84e12) nilaway: unstable-2023-11-17 -> 0-unstable-2024-04-04
* [`48a3d1ca`](https://github.com/NixOS/nixpkgs/commit/48a3d1ca2ec6bbefaa7b4416ba511afae31b7365) unparam: fix build
* [`0742e802`](https://github.com/NixOS/nixpkgs/commit/0742e80275e3926922795a7638d1aa3aee9ad18e) kokkos: 4.2.01 -> 4.3.00
* [`a32a48f8`](https://github.com/NixOS/nixpkgs/commit/a32a48f804d7fbf74aec909453898a1cdbb5df4c) vmware-horizon-client: 2312 -> 2312.1
* [`5cf2f8b9`](https://github.com/NixOS/nixpkgs/commit/5cf2f8b9dbe29557c7b58e077ac377b7bbe7b752) brave: fix for https://github.com/NixOS/nixpkgs/issues/302054
* [`d6416c0b`](https://github.com/NixOS/nixpkgs/commit/d6416c0bde54a67694a2fff342ad3f6c2f67533f) python311Packages.pytorch-metric-learning: 2.4.1 -> 2.5.0
* [`723ae849`](https://github.com/NixOS/nixpkgs/commit/723ae84900e0a2de03f87cd0af90cabf34ccc0a4) python311Packages.zodb: 5.8.1 -> 6.0
* [`08fd8484`](https://github.com/NixOS/nixpkgs/commit/08fd84846e33f4387285257421b0198032e70979) foomatic-db-engine: unstable-2024-02-10 -> unstable-2024-04-05
* [`2f0a7b95`](https://github.com/NixOS/nixpkgs/commit/2f0a7b9584ef6f5b34de8bc0c1268e4f6ed70f43) yamlscript: 0.1.46 -> 0.1.52
* [`94793640`](https://github.com/NixOS/nixpkgs/commit/94793640c55525345833e192a38994cad38ccd3d) liquibase: 4.26.0 -> 4.27.0
* [`9773be3a`](https://github.com/NixOS/nixpkgs/commit/9773be3a4ed56d46e482131c9460cab983b8dca1) realmd: init at 0.17.1
* [`e0896413`](https://github.com/NixOS/nixpkgs/commit/e08964133d774595d4695b4d6b24e30aed9397aa) cloudlog: 2.6.7 -> 2.6.8
* [`4d5101b1`](https://github.com/NixOS/nixpkgs/commit/4d5101b1b6214348510022b821968244eb208379) python3Packages.skytemple-rust: 1.6.3 -> 1.6.5
* [`aeb1209c`](https://github.com/NixOS/nixpkgs/commit/aeb1209cbc35a4bca7c8bd78c66373bec648496d) python3Packages.skytemple-files: 1.6.3 -> 1.6.5
* [`ded01930`](https://github.com/NixOS/nixpkgs/commit/ded0193048db47bc51cd944b336e8cee8621d936) python3Packages.skytemple-ssb-emulator: 1.6.1.post1 -> 1.6.4
* [`bde74bb0`](https://github.com/NixOS/nixpkgs/commit/bde74bb03cf2f557e52df5b63867ad208e3575c3) python3Packages.skytemple-ssb-debugger: 1.6.2 -> 1.6.4
* [`8dcbf0d8`](https://github.com/NixOS/nixpkgs/commit/8dcbf0d8d8f07cb27e0d10b1d511760c84b5cf40) skytemple: 1.6.3 -> 1.6.5
* [`cd95ef10`](https://github.com/NixOS/nixpkgs/commit/cd95ef10831d1d9f36e8b25776f60ea33cf0380d) loksh: 7.4 -> 7.5
* [`bd9f1f21`](https://github.com/NixOS/nixpkgs/commit/bd9f1f215588bb69755a4a283a3a0f9d0ba9de70) podofo: fix library path in pkg-config file
* [`cc1ef6b3`](https://github.com/NixOS/nixpkgs/commit/cc1ef6b3cb54702c92bf35fe7beeccbd43cf2905) cozy: clean up and misc fixes
* [`c1b2e9f2`](https://github.com/NixOS/nixpkgs/commit/c1b2e9f22fb4760e92e9a5b3b9c316d86f127804) cozy: add aleksana as maintainer
* [`bfbaff18`](https://github.com/NixOS/nixpkgs/commit/bfbaff18e09cf4614c5ee2e62af87a4470b2a5c7) trunk: add ctron as maintainer
* [`d218cc51`](https://github.com/NixOS/nixpkgs/commit/d218cc5138d818ca509ebe1b7cd1b5214fcbc37a) pest-ide-tools: 0.3.6 -> 0.3.9
* [`d160d9a6`](https://github.com/NixOS/nixpkgs/commit/d160d9a6a153e9142efe54d7dd1480b0c2f9d695) swayimg: 2.1 -> 2.2
* [`ebd06e10`](https://github.com/NixOS/nixpkgs/commit/ebd06e1036563a09c93ca0c2061d6856ab60bdfd) microsoft-edge: 123.0.2420.53 -> 123.0.2420.81
* [`fe393030`](https://github.com/NixOS/nixpkgs/commit/fe3930301b67dc4b544e418a072af46bdc4ec417) uboot: 2024.01 -> 2024.04
* [`97ace155`](https://github.com/NixOS/nixpkgs/commit/97ace155ce711fb2f92dd2388e77051ec589d014) jenkins-job-builder: 6.1.0 -> 6.2.0
* [`54b3c6f2`](https://github.com/NixOS/nixpkgs/commit/54b3c6f2eabe3c5452d63a460d8a28143b8dabb4) python3Packages.spsdk: 2.1.0 -> 2.1.1
* [`fb536c56`](https://github.com/NixOS/nixpkgs/commit/fb536c56058f40c3d3c5dff395d2ce3937a54f16) python3Packages.pytest-notebook: disable more tests
* [`4c1c80ef`](https://github.com/NixOS/nixpkgs/commit/4c1c80ef1acbb2b6ca164154a8bfe4107148f660) pynitrokey: 0.4.45 -> 0.4.46
* [`4f6dbf26`](https://github.com/NixOS/nixpkgs/commit/4f6dbf2696503bfaf6c2644f7e9a7cda6c887785) dstep: init at 1.0.4
* [`8f604a4e`](https://github.com/NixOS/nixpkgs/commit/8f604a4e4a8fe830516c1e667268cc382c4a24d1) matrix-synapse-tools.synadm: 0.45 -> 0.46
* [`dd2cb323`](https://github.com/NixOS/nixpkgs/commit/dd2cb323413bc86a41f3367cc1690fff31342a8d) mise: 2024.3.10 -> 2024.4.0
* [`2d3b672d`](https://github.com/NixOS/nixpkgs/commit/2d3b672da7dbd4c5f6e69b564e104c51ff919674) mycli: 1.27.1 -> 1.27.2
* [`5af750a4`](https://github.com/NixOS/nixpkgs/commit/5af750a43a74327a3f66cc3ff427aa52f6005c32) lightningcss: 1.24.0 -> 1.24.1
* [`ce6a887e`](https://github.com/NixOS/nixpkgs/commit/ce6a887ed222ff051a53632f180622ce539eda09) rPackages.SpatialDecon: fix build
* [`73142ffe`](https://github.com/NixOS/nixpkgs/commit/73142ffe160957ebc3c942cede0359de69eea4d8) rPackages.diffHic: add deps
* [`e659299d`](https://github.com/NixOS/nixpkgs/commit/e659299d1c603a44e18c7193f185b7d307b9d5ef) rPackages.eds: fix build
* [`da661986`](https://github.com/NixOS/nixpkgs/commit/da6619866409b8af6b55187b02849f6c6ea6a47e) rPackages.ChemmineOB: fix build
* [`58b3ea45`](https://github.com/NixOS/nixpkgs/commit/58b3ea45ae28ab7ac0e367bc84de7f06b299c9b6) rPackages.hpar: mark as broken
* [`49b8ddad`](https://github.com/NixOS/nixpkgs/commit/49b8ddad0584c4d2cf87677e3bdbb8e58a135253) rPackages.signatureSearch: disable package
* [`a9b20bb1`](https://github.com/NixOS/nixpkgs/commit/a9b20bb178ddefdc6f1b98c7efb3f0bd64b8e150) apvlv: 0.1.5 -> 0.5.0
* [`0d86a49d`](https://github.com/NixOS/nixpkgs/commit/0d86a49d54710edaa6f23e913dbe57671d3391f8) apvlv: add anthonyroussel to maintainers
* [`bc2e4a53`](https://github.com/NixOS/nixpkgs/commit/bc2e4a537e0160fbf591aefb6c70d363f926147b) apvlv: move to pkgs/by-name
* [`00161565`](https://github.com/NixOS/nixpkgs/commit/00161565e25b0c0982eacffdedc6cded6217ee8a) rPackages.deepSNV: fix build
* [`694bef76`](https://github.com/NixOS/nixpkgs/commit/694bef76b9b44c065eaecbb1bfae27d78e580b55) nixos/logrotate docs: clarify settings
* [`de2b0339`](https://github.com/NixOS/nixpkgs/commit/de2b0339b3fa26d11565a6f96a7cc5a367d8734b) rPackages.Rfastp: fix build
* [`611a6545`](https://github.com/NixOS/nixpkgs/commit/611a6545449fdaa7eaf5e90ba9604fac03d7c4ca) rPackages.scPipe: fix build
* [`909948ed`](https://github.com/NixOS/nixpkgs/commit/909948edb5753b97648850896116827fae73a3de) upbound: 0.26.0 -> 0.28.0
* [`b583c955`](https://github.com/NixOS/nixpkgs/commit/b583c9554d38f90203f0d8798f7354bac7862a7a) minio: 2024-03-26T22-10-45Z -> 2024-04-06T05-26-02Z
* [`1eee0a15`](https://github.com/NixOS/nixpkgs/commit/1eee0a157c680c4305974b6ec19b829ae8434a9a) bosh-cli: 7.5.5 -> 7.5.6
* [`9b383de7`](https://github.com/NixOS/nixpkgs/commit/9b383de757ea6a5cdf911e7c6d4e36fcddce5363) bind: allow recursive queries from IPv6 loopback
* [`9186b1a4`](https://github.com/NixOS/nixpkgs/commit/9186b1a49589f43826f4aac2c0d06239e44bf633) phinger-cursors: 1.1 -> 2.0
* [`699cfb5e`](https://github.com/NixOS/nixpkgs/commit/699cfb5e5d26d69c66a8590337bec0576ac26989) calibre: 7.7.0 -> 7.8.0
* [`8c7ec235`](https://github.com/NixOS/nixpkgs/commit/8c7ec2357d8227f027041b84616665ed3f138033) fm-go: 0.16.0 -> 1.0.0
* [`3c70755c`](https://github.com/NixOS/nixpkgs/commit/3c70755cd37a01d22a74370455a2b90df446140f) opentelemetry-collector: 0.96.0 -> 0.97.0
* [`dc701446`](https://github.com/NixOS/nixpkgs/commit/dc70144603be8760def7358420a0ff3535b09add) _86Box: reformat according to RFC166
* [`b17d1291`](https://github.com/NixOS/nixpkgs/commit/b17d1291408e093831c7e47d85cf0118b445ff6c) _86Box: 4.1 -> 4.1.1
* [`7c903732`](https://github.com/NixOS/nixpkgs/commit/7c9037320d53a16c49ad7a7d9ddbe927a166bf20) git-gr: 1.2.1 -> 1.4.1
* [`1a18819d`](https://github.com/NixOS/nixpkgs/commit/1a18819d4d6e81d4644f444ee7f732958c7b8714) yarn: allow to install without node
* [`227f0a70`](https://github.com/NixOS/nixpkgs/commit/227f0a708e3f8e78895813c6f2bd5ff17b7d5a2c) yarn-berry: fix name
* [`4d3478f5`](https://github.com/NixOS/nixpkgs/commit/4d3478f52b90b41e1d0266407dc00eadc1e2266e) passt: 0.2023_11_10.5ec3634 -> 2024_04_05.954589b
* [`8c29b8d7`](https://github.com/NixOS/nixpkgs/commit/8c29b8d726bc0e6dbaef1c6cf0439e8af3d1d307) yarn: add passthru.updateScript
* [`ec8b9c39`](https://github.com/NixOS/nixpkgs/commit/ec8b9c392bd9ab48fbebcce7966967e1d7819b44) yarn-berry: add version tester
* [`ab64efad`](https://github.com/NixOS/nixpkgs/commit/ab64efadc67934d1b46cdea21fcd10c0ecadae02) qq: use makeShellWrapper instead to wrap program
* [`943b7323`](https://github.com/NixOS/nixpkgs/commit/943b7323ece9aabedb9ea1063a75f4598c1e4dad) chatterino2: use `callPackage` directly
* [`c29744a0`](https://github.com/NixOS/nixpkgs/commit/c29744a0fe393e19b4ee7d103f48c232cd11c142) tpm2-openssl: init at 1.2.0
* [`636a1226`](https://github.com/NixOS/nixpkgs/commit/636a1226a893de34207f4737f6a45552efc65f0a) haskellPackages.zip: Don't check
* [`5cd16ae0`](https://github.com/NixOS/nixpkgs/commit/5cd16ae016dc671cadd8de6fcb9c15929eb5c3c0) python311Packages.trytond: 7.0.8 -> 7.0.9
* [`e0346dd5`](https://github.com/NixOS/nixpkgs/commit/e0346dd599e347db345e09361c1af8d4c29559bc) python311Packages.django-countries: 7.5.1 -> 7.6.1
* [`69605890`](https://github.com/NixOS/nixpkgs/commit/6960589038b25d78ce5c4e0c023c3d2fb3bb6599) pretix: relax django-countries constraint
* [`0f248ad5`](https://github.com/NixOS/nixpkgs/commit/0f248ad5dbdb2ba2008069efa076c9ef5bbe8304) pretalx: relax cssutils & django-filter constraint
* [`429b414f`](https://github.com/NixOS/nixpkgs/commit/429b414ffc6988130e4438633d427fc30ae3a275) edid-decode: unstable-2024-01-29 -> unstable-2024-04-02
* [`d13af949`](https://github.com/NixOS/nixpkgs/commit/d13af9492b97c0c699893d6ed93ea3c221421cea) python311Packages.multiset: 3.0.2 -> 3.1.0
* [`317125a2`](https://github.com/NixOS/nixpkgs/commit/317125a2e9b40f8d92518a62960bc6b474e68289) python311Packages.google-cloud-securitycenter: 1.30.0 -> 1.30.1
* [`a8922724`](https://github.com/NixOS/nixpkgs/commit/a89227243ab3c590269446c95eb92925c76f181f) werf: 1.2.301 -> 1.2.305
* [`d2699e10`](https://github.com/NixOS/nixpkgs/commit/d2699e10b415367a208214d084bec7f624376794) phosh-mobile-settings: 0.37.0 -> 0.38.0
* [`315792df`](https://github.com/NixOS/nixpkgs/commit/315792df5749cabfe06715d06eccaee8f26f4405) doublecmd: 1.1.11 -> 1.1.12
* [`a31fc6b1`](https://github.com/NixOS/nixpkgs/commit/a31fc6b1b89856f3932340d7d6e0ed60e3040855) hwatch: 0.3.11 -> 0.3.12
* [`294245f7`](https://github.com/NixOS/nixpkgs/commit/294245f7501e0a8e69b83346a4fa5afd4ed33ab3) haskellPackages.Agda: Split outputs to reduce closure size
* [`6e1c1a9c`](https://github.com/NixOS/nixpkgs/commit/6e1c1a9c2860bdaadfe21504c6082f9065f83d1f) diffoscope: fix build after disablement of OpenSSH DSA keys
* [`a494d7b3`](https://github.com/NixOS/nixpkgs/commit/a494d7b37bbc50fe98a21ecec0c75c7a1f741187) ockam: 0.119.0 -> 0.120.0
* [`e380b530`](https://github.com/NixOS/nixpkgs/commit/e380b5303715016fca18df860d97340345b52aef) rocmPackages.llvm: compress outputs of clang-offload-bundler
* [`772dbad3`](https://github.com/NixOS/nixpkgs/commit/772dbad3d41932f08d44aaa63a571d4e26c5d143) rocmPackages.llvm: replace --replace with --replace-fail (cleanup)
* [`9bc7c1d2`](https://github.com/NixOS/nixpkgs/commit/9bc7c1d25429b95412aa5e73bc8059bf0127f36d) python311Packages.orbax-checkpoint: 0.5.7 -> 0.5.9
* [`79b79606`](https://github.com/NixOS/nixpkgs/commit/79b79606db2c009a48ba180d0355de204f49e5f0) python312Packages.sagemaker: fix build by adding patch removing dependency on distutils
* [`f3f3c19e`](https://github.com/NixOS/nixpkgs/commit/f3f3c19e46674b10f9523d0055c35dfe57bbfd6a) python312Packages.sagemaker: modernize
* [`9bcd91ba`](https://github.com/NixOS/nixpkgs/commit/9bcd91ba09dbe6d7cb93b2774a77596d914563ca) build-fhsenv-bubblewrap: reference 32-bit binaries only if multiArch
* [`fc2679ec`](https://github.com/NixOS/nixpkgs/commit/fc2679ecffc135e739aa4e0186d1355f7bf417f8) cloudsmith-cli: 1.1.1 -> 1.2.2
* [`4818458b`](https://github.com/NixOS/nixpkgs/commit/4818458b24ab9e78a99540e76d1533bc16bbe1be) cargo-unfmt: init at 0.3.3
* [`3829c3a3`](https://github.com/NixOS/nixpkgs/commit/3829c3a390b61a12968e685e9b74d46830a80821) python311Packages.qdldl: 0.1.7.post0 -> 0.1.7.post1
* [`0b967359`](https://github.com/NixOS/nixpkgs/commit/0b967359d329aa1737886b8a8f7ecbdaa44f1fdc) vaultwarden.webvault: 2024.3.0 -> 2024.3.1
* [`15f795e3`](https://github.com/NixOS/nixpkgs/commit/15f795e391c77d21ee2bef5ec5840bd7bf3775a0) nixos/plasma6: don't add kio's KCMs to systemsettings
* [`62e853a2`](https://github.com/NixOS/nixpkgs/commit/62e853a2656ffffb58364b311aac665b428efd74) python312Packages.orbax-checkpoint: refactor
* [`bebdac46`](https://github.com/NixOS/nixpkgs/commit/bebdac46ff83a90a6cd5583ee2e442a915432d28) python312Packages.orbax-checkpoint: format with nixfmt
* [`b38e188f`](https://github.com/NixOS/nixpkgs/commit/b38e188f7d733dc9cf36a2706cd5999e4919b8dd) polymake: unpin perl536, perl536Packages
* [`946f357e`](https://github.com/NixOS/nixpkgs/commit/946f357e45b8237b18ada02ac11a088f257b6421) hap-py: init 0.3.15
* [`5db72db7`](https://github.com/NixOS/nixpkgs/commit/5db72db7fae5923fec96a45b1d37b3039b42f54d) hap-py: use rtgtools vcfeval as default core
* [`83c5b107`](https://github.com/NixOS/nixpkgs/commit/83c5b107971a08c907d5c79f5479cbeb8b3b209f) python311Packages.jaraco-abode: 5.1.0 -> 5.1.1
* [`1fcc6b0e`](https://github.com/NixOS/nixpkgs/commit/1fcc6b0ea4dcaf60270e247cc9e26ea22800a3b5) mcumgr-client: init at 0.0.4
* [`d32968e3`](https://github.com/NixOS/nixpkgs/commit/d32968e367e1b3da3c881760fff83bdf9fc4da9e) python3Packages.hikari: init at 2.0.0.dev124
* [`da155d70`](https://github.com/NixOS/nixpkgs/commit/da155d700dcbd8bec8ea24400e4e8a5afa0d3960) uiua: 0.10.0 -> 0.10.1
* [`4959d7bc`](https://github.com/NixOS/nixpkgs/commit/4959d7bcd8f41d05a29fed8cb86a0456a1cf557f) nixos/soju: add package option
* [`5207bb72`](https://github.com/NixOS/nixpkgs/commit/5207bb723ab36f402a5705f43d97eb49d342540a) nixos/soju: add adminSocket.enable option
* [`d772ac18`](https://github.com/NixOS/nixpkgs/commit/d772ac182f949c6290b95b7ac6cd24265598d961) nixos/soju: add sojuctl wrapper with config path
* [`e9fed4bc`](https://github.com/NixOS/nixpkgs/commit/e9fed4bcad77e0d04a77a42886d51282f96c2163) nixos/soju: add tests
* [`5b11e74a`](https://github.com/NixOS/nixpkgs/commit/5b11e74a01fd5c112150170bab271f6d9c63ce89) rPackages.multiMiR: fix loading test error
* [`1a63e7b2`](https://github.com/NixOS/nixpkgs/commit/1a63e7b260419cf3f2202f235a5156cba21be173) tfswitch: 1.0.0 -> 1.0.2
* [`a9d19011`](https://github.com/NixOS/nixpkgs/commit/a9d1901115b47b532a249a37f33f3141cd952ee7) gvisor: 20240311.0-unstable-2024-03-25 -> 20240401.0
* [`559c9ddd`](https://github.com/NixOS/nixpkgs/commit/559c9ddd9bae08c5959562a90d59ced874c65490) python311Packages.linien-common: 1.0.1 -> 1.0.2
* [`fa04bf24`](https://github.com/NixOS/nixpkgs/commit/fa04bf2432ed9d66b0c7d5baab14932ac6c0bc9a) rPackages.Rarr: fix build
* [`1164a96e`](https://github.com/NixOS/nixpkgs/commit/1164a96e58fa3ed9f7dbb2cab8d62d1c15b951ef) rPackages.ReactomeContentService4R: fix loading test
* [`9fcda445`](https://github.com/NixOS/nixpkgs/commit/9fcda4451a1f60cb3b3dff50b9de9ca326001b56) owncast: 0.1.2 -> 0.1.3
* [`b60a8104`](https://github.com/NixOS/nixpkgs/commit/b60a810408b7271e8d676b62a35127f91a70b522) signal-cli: 0.12.8 -> 0.13.2
* [`52fe9650`](https://github.com/NixOS/nixpkgs/commit/52fe9650a9c0d82901a75f7b198bf1679fce2f36) gramps: 5.2.1 -> 5.2.2
* [`e16a1eb2`](https://github.com/NixOS/nixpkgs/commit/e16a1eb28dbe2801a78992a04d6672166c0d661c) uxn: unstable-2024-03-30 -> unstable-2024-04-05
* [`7b9aa23d`](https://github.com/NixOS/nixpkgs/commit/7b9aa23df550076f506195bb5935491c56c96753) scilla: 1.2.7 -> 1.3.0
* [`decb18c0`](https://github.com/NixOS/nixpkgs/commit/decb18c0606b3ae5f96172c2af05822293156c05) metasploit: 6.4.1 -> 6.4.2
* [`f1b9f1c8`](https://github.com/NixOS/nixpkgs/commit/f1b9f1c85962aaf904b45fb73d05b42bcffe27f9) scilla: add ldflags
* [`a80624bf`](https://github.com/NixOS/nixpkgs/commit/a80624bfc192a78d9623a54ad3979c7111d1fc2d) scilla: format with nixfmt
* [`cca5a228`](https://github.com/NixOS/nixpkgs/commit/cca5a2286cc6fe96992af8a294fe71f42d581ca0) python312Packages.velbus-aio: 2024.4.0 -> 2024.4.1
* [`1a4dc94d`](https://github.com/NixOS/nixpkgs/commit/1a4dc94d1e30d5c02aeee1b21a962d09c8c582a6) python312Packages.velbus-aio: format with nixfmt
* [`610e0d43`](https://github.com/NixOS/nixpkgs/commit/610e0d4320e243419f718b7d684fb9f9a7946bc5) python312Packages.axis: 60 -> 61
* [`105655d7`](https://github.com/NixOS/nixpkgs/commit/105655d740effe76b336a17ace2fe50ebae12197) python312Packages.pyfibaro: 0.7.6 -> 0.7.7
* [`52fc9bf1`](https://github.com/NixOS/nixpkgs/commit/52fc9bf1b58a3aad564562a2a1c9874a3cc30196) python312Packages.pyfibaro:refactor
* [`67729a80`](https://github.com/NixOS/nixpkgs/commit/67729a808a925d8cb473a31d069510efa497ef78) python312Packages.pyfibaro: format with nixfmt
* [`2942a15f`](https://github.com/NixOS/nixpkgs/commit/2942a15fdc034939db09fd72a23a0a024c276d74) rapidfuzz-cpp: 3.0.3 -> 3.0.4
* [`26307aa9`](https://github.com/NixOS/nixpkgs/commit/26307aa932786a6141d9a034b4f0e3c4bd070298) python311Packages.rapidfuzz: 3.7.0 -> 3.8.1
* [`ba488417`](https://github.com/NixOS/nixpkgs/commit/ba4884179ea473e41c4a5d35f0e4862cd982fef3) klipper: unstable-2024-03-25 -> unstable-2024-04-05
* [`2863680e`](https://github.com/NixOS/nixpkgs/commit/2863680e43ca2dca4badaf2a1a641a0eff708616) btcdeb: 0.3.20-unstable-2024-02-06 -> 0.3.20-unstable-2024-03-26
* [`46397933`](https://github.com/NixOS/nixpkgs/commit/46397933b3c59fe4c9ecfbf0beb0db294d48868f) cakelisp: 0.3.0-unstable-2024-03-21 -> 0.3.0-unstable-2024-04-01
* [`61b2b7bd`](https://github.com/NixOS/nixpkgs/commit/61b2b7bd3b8feca71461f88f5e2f61ada64ca7d0) cpm-cmake: 0.38.7 -> 0.38.8
* [`2fd33908`](https://github.com/NixOS/nixpkgs/commit/2fd339082345103537d2c15d43904f9a0b6bd627) aichat: 0.14.0 -> 0.15.0
* [`77387aa6`](https://github.com/NixOS/nixpkgs/commit/77387aa696220e9a13ca04203671aca451340686) pupdate: 3.9.1 -> 3.10.1
* [`2b6b838f`](https://github.com/NixOS/nixpkgs/commit/2b6b838f0900e744198b7064b2c72dc8d46f14fe) axel: 2.17.13 -> 2.17.14
* [`3c8ecd4b`](https://github.com/NixOS/nixpkgs/commit/3c8ecd4b898299c3c630ac320ef09508a971960f) bpftop: 0.4.0 -> 0.4.1
* [`55bc6865`](https://github.com/NixOS/nixpkgs/commit/55bc6865350811ad48532d8ea909f05eaf4f1e08) konstraint: 0.35.0 -> 0.36.0
* [`1d887599`](https://github.com/NixOS/nixpkgs/commit/1d887599bae19533b5af8f24bd77f3daaaa99cce) i3status-rust: 0.33.0 -> 0.33.1
* [`6e5a0136`](https://github.com/NixOS/nixpkgs/commit/6e5a0136cf4d1088d3f97b3ea560cd2651b64e30) openvi: 7.4.27 -> 7.5.28
* [`68fcd27c`](https://github.com/NixOS/nixpkgs/commit/68fcd27c6971ed79d42f8ee21649c39fa0698fd7) pyenv: 2.3.36 -> 2.4.0
* [`38b68216`](https://github.com/NixOS/nixpkgs/commit/38b68216a50fa6b80c93361c6438bb2cd7aa37c3) nixos/zfs: install zfs udev rules on stage1
* [`0041c6bc`](https://github.com/NixOS/nixpkgs/commit/0041c6bc0bd7bc77d27490a5b68a8e115f15dc35) python312Packages.crytic-compile: 0.3.6 -> 0.3.7
* [`e78e0bc8`](https://github.com/NixOS/nixpkgs/commit/e78e0bc8a112f394f07c1cc4a8a97d11757a1f8b) python312Packages.django-vite: 3.0.3 -> 3.0.4
* [`bb7feffc`](https://github.com/NixOS/nixpkgs/commit/bb7feffcafedf050b3da2bd224fbe438fa11f028) python312Packages.javaobj-py3: 0.4.3 -> 0.4.4
* [`266c8809`](https://github.com/NixOS/nixpkgs/commit/266c8809684a9244d9fec71b66f7d0c92758056a) spire: 1.9.2 -> 1.9.3
* [`b0dab7cc`](https://github.com/NixOS/nixpkgs/commit/b0dab7cc34ef4d8a1b2de36178da801090bcb271) python311Packages.xmlschema: 3.0.2 -> 3.2.1
* [`d9f56c35`](https://github.com/NixOS/nixpkgs/commit/d9f56c353ed2b755d79fb219a64d2d84e03b609f) stgit: 2.4.5 -> 2.4.6
* [`18a5476a`](https://github.com/NixOS/nixpkgs/commit/18a5476aa7779b916e588e99fb438c631a464d77) nixos/ollama: add options to override `HOME` and `OLLAMA_MODELS`
* [`02f20eb7`](https://github.com/NixOS/nixpkgs/commit/02f20eb7ec257ed4acc0a40778032cb3d6c531f5) typos: 1.20.3 -> 1.20.4
* [`0fd66d6c`](https://github.com/NixOS/nixpkgs/commit/0fd66d6c59419584a4606f72e8dc4a0c0a15cfac) simdutf: 5.2.0 -> 5.2.3
* [`f601f6b8`](https://github.com/NixOS/nixpkgs/commit/f601f6b835ff67b95fd34b02163cf4df3b2f86ce) heroic: 2.14.0 -> 2.14.1
* [`a0b3ee3a`](https://github.com/NixOS/nixpkgs/commit/a0b3ee3a3e84f892aa4b978eec50e42fb6b0467c) python312Packages.pytest-cases: 3.8.4 -> 3.8.5
* [`0214a0aa`](https://github.com/NixOS/nixpkgs/commit/0214a0aa71dc59f8c119fe944c6de186dd43c4b4) pocketbase: 0.22.7 -> 0.22.8
* [`d5749032`](https://github.com/NixOS/nixpkgs/commit/d5749032b489c05423ec39a664f4a0581cb48a07) crawley: 1.7.4 -> 1.7.5
* [`a314f1ec`](https://github.com/NixOS/nixpkgs/commit/a314f1ecf076bdf3996fe21a5e73906601552f6d) cloudfoundry-cli: 8.7.9 -> 8.7.10
* [`4fd42c86`](https://github.com/NixOS/nixpkgs/commit/4fd42c86fa4539c460dd078fc020f653c25cee82) haskellPackages.currencies: Unbroken
* [`09a7c4ae`](https://github.com/NixOS/nixpkgs/commit/09a7c4aeb4a57df3dca13e84e05f0df0cb82f708) xorg.xorgserver: 21.1.11 -> 21.1.12 (security)
* [`69f10827`](https://github.com/NixOS/nixpkgs/commit/69f108271fa8ec7a268aa76fe9743ad8ef61dcdc) gigalixir: 1.11.1 -> 1.12.0
* [`c26135d6`](https://github.com/NixOS/nixpkgs/commit/c26135d648d42fc7ca7d11791a0ba702831ffd42) shell_gpt: 1.4.0 -> 1.4.3
* [`811ce925`](https://github.com/NixOS/nixpkgs/commit/811ce9252950616d86dbffd6f9b5b5f8e64e6662) ast-grep: 0.20.2 -> 0.20.3
* [`845c3eb1`](https://github.com/NixOS/nixpkgs/commit/845c3eb15eab9ea90fae7da7d93029534e018d0e) simplotask: 1.14.1 -> 1.15.0
* [`fb0d5157`](https://github.com/NixOS/nixpkgs/commit/fb0d5157280d7073c21f2a20e7e163b80ef0bbb3) cider: set meta.mainProgram, set ozone platform hints
* [`4479cc7c`](https://github.com/NixOS/nixpkgs/commit/4479cc7cff3dfe6b71f5cc4b7f5ee362f0b2cf11) python312.pkgs.capstone_4: mark as broken
* [`4de36aba`](https://github.com/NixOS/nixpkgs/commit/4de36aba89a8403c0b2bc3eba149dc8aba24cb02) irods: 4.3.0 -> 4.3.1 + fix pam auth
* [`83e8acb8`](https://github.com/NixOS/nixpkgs/commit/83e8acb86b30dd2ccf4f77464961dde33fe37c1b) apkg: 0.4.1 -> 0.5.0
* [`72fd7cc7`](https://github.com/NixOS/nixpkgs/commit/72fd7cc73739a3f7dcda7554c56ec5604791e245) python3Packages.gdb-pt-dump: init at 0-unstable-2024-04-01
* [`d06a34e9`](https://github.com/NixOS/nixpkgs/commit/d06a34e95d071d268cdcbde69401e5d65a869fb9) python3Packages.pwndbg: init at 2024.02.14
* [`7711331a`](https://github.com/NixOS/nixpkgs/commit/7711331add4a6f50da039828b3df5fd73ec73f52) pwndbg: 2022.12.19 -> 2024.02.14
* [`aa71ddad`](https://github.com/NixOS/nixpkgs/commit/aa71ddadfa6158532d5267dda4d6db01237db5bd) gamescope: move to by-name
* [`57f72cfb`](https://github.com/NixOS/nixpkgs/commit/57f72cfbc2b9b242d075618351baf5b6296012f7) gamescope: pin to wlroots_0_17
* [`2ad0f8ca`](https://github.com/NixOS/nixpkgs/commit/2ad0f8ca0f32b4f8e32eb37d6f444fce6d5c54f7) eigenlayer: 0.6.3 -> 0.7.0
* [`2b54eba0`](https://github.com/NixOS/nixpkgs/commit/2b54eba0f403adfc7278546c8ca7d1d93f6bf458) rustdesk-flutter: 1.2.3-unstable-2024-02-11 -> 1.2.3-2
* [`73d91b52`](https://github.com/NixOS/nixpkgs/commit/73d91b52e1546e3eb757726bdc1ae16b2934d07f) supabase-cli: 1.153.3 -> 1.155.1
* [`1c896bd6`](https://github.com/NixOS/nixpkgs/commit/1c896bd6e13d32dafc0cd09d26ff06164002cc89) nixos/manual: fix sshfs keygen output
* [`9b71e6a1`](https://github.com/NixOS/nixpkgs/commit/9b71e6a1a758a805b48ca7b9d34100c2a7a44e4d) reuse: 3.0.1 -> 3.0.2
* [`e50cb99f`](https://github.com/NixOS/nixpkgs/commit/e50cb99f36f130f5c07c2c04dbc8bae9d9aa402f) sad: 0.4.27 -> 0.4.28
* [`ebf053d4`](https://github.com/NixOS/nixpkgs/commit/ebf053d4fe4303c7ffeeff72220a41fff32d7c61) circt: 1.71.0 -> 1.72.0
* [`1706ba10`](https://github.com/NixOS/nixpkgs/commit/1706ba10e2f13ccac7edbc79caed745dce469ff2) vale: 3.3.1 -> 3.4.0
* [`75b52b99`](https://github.com/NixOS/nixpkgs/commit/75b52b992bc342b458ac5c0f09f8c0ab4f237a2d) botan3: 3.2.0 -> 3.3.0
* [`4400b268`](https://github.com/NixOS/nixpkgs/commit/4400b26870334dae814be7d6e886ba45bde7dc5c) mopidy-jellyfin: 1.0.4 -> 1.0.5
* [`3174508c`](https://github.com/NixOS/nixpkgs/commit/3174508c52219fcab1434f7cd17635dc90d91518) add powerpc64 arch
* [`0c8919db`](https://github.com/NixOS/nixpkgs/commit/0c8919db2429e54395adca5030a40964f8f451d2) python311Packages.javaobj-py3: 0.4.3 -> 0.4.4
* [`c67b7cf5`](https://github.com/NixOS/nixpkgs/commit/c67b7cf506bbd5245998f9fac6192dff892d6388) carp: mark broken
* [`8654d13a`](https://github.com/NixOS/nixpkgs/commit/8654d13a6e5c4f904064ac35a762cb6e89b28f5d) python311Packages.mkdocstrings: 0.24.2 -> 0.24.3
* [`d658bf38`](https://github.com/NixOS/nixpkgs/commit/d658bf38b434a434b34692e86c4fe9f28ca83d2e) gmid: 1.8.6 -> 2.0.2
* [`5e7b94d6`](https://github.com/NixOS/nixpkgs/commit/5e7b94d64bfa8ac51a245511449836f252c58278) python3Packages.rasterio: don't propagate setuptools
* [`69a76a7d`](https://github.com/NixOS/nixpkgs/commit/69a76a7dd5f1c7efecc863795bb83cc745f06cf6) conmon-rs: 0.6.1 -> 0.6.2
* [`58815a66`](https://github.com/NixOS/nixpkgs/commit/58815a66c85c3954f67e04d07d5beb6f03b0c349) python311Packages.ipyvuetify: 1.9.2 -> 1.9.3
* [`3c6b55a6`](https://github.com/NixOS/nixpkgs/commit/3c6b55a63ed6d362884d4108a4d658170d4bc93c) python312Packages.tencentcloud-sdk-python: 3.0.1123 -> 3.0.1124
* [`d0990954`](https://github.com/NixOS/nixpkgs/commit/d0990954e02afd3380766a8ed967ce191693876b) python311Packages.mkdocstrings: format with nixfmt
* [`455a8672`](https://github.com/NixOS/nixpkgs/commit/455a8672f6e41db4c71bdcc86d74424145a1d7ad) python311Packages.trafilatura: 1.8.0 -> 1.8.1
* [`58b0ab9a`](https://github.com/NixOS/nixpkgs/commit/58b0ab9a5c97d1b6905d90c39a8258dcd69a2165) checkov: 3.2.53 -> 3.2.55
* [`2ac1517a`](https://github.com/NixOS/nixpkgs/commit/2ac1517a6b5aa9edd27d067f2af3de20cf1c556c) maintainers: add peefy
* [`347bdce1`](https://github.com/NixOS/nixpkgs/commit/347bdce1c43c191b013caac6ba49bd626c16ca7b) offat: 0.16.0 -> 0.17.0
* [`ff7266a2`](https://github.com/NixOS/nixpkgs/commit/ff7266a2b93acb4c8fec3378e42b523140d93e06) prometheus-smokeping-prober: 0.8.0 -> 0.8.1
* [`b993dd65`](https://github.com/NixOS/nixpkgs/commit/b993dd655ae45bea7c2ffcfa65d1e584d141d700) nwg-hello: 0.1.8 -> 0.1.9
* [`fe0c9257`](https://github.com/NixOS/nixpkgs/commit/fe0c92572faf77e18e42353637c3cb8ab680a9b0) doc/stdenv: document prefixKey more precisely ([nixos/nixpkgs⁠#302535](https://togithub.com/nixos/nixpkgs/issues/302535))
* [`f3d439a2`](https://github.com/NixOS/nixpkgs/commit/f3d439a25791c0b79038aebf3dcd3c0e1e1a35c3) typos-lsp: 0.1.16 -> 0.1.17
* [`3ab33847`](https://github.com/NixOS/nixpkgs/commit/3ab33847c63d9f32a8609a1dd0b31252fda6b894) kaggle: 1.6.8 -> 1.6.11
* [`91a8a267`](https://github.com/NixOS/nixpkgs/commit/91a8a2678998264c4a52edf28466e88c22ba31c7) win-pvdrivers: use stdenvNoCC
* [`39e37b11`](https://github.com/NixOS/nixpkgs/commit/39e37b1168d35c465b51e83bbbddd378819cef26) tomb: use stdenvNoCC
* [`a5947471`](https://github.com/NixOS/nixpkgs/commit/a59474718d0544d530abbe0ba35fed5f8473c0c1) jetty: use stdenvNoCC
* [`d53210f7`](https://github.com/NixOS/nixpkgs/commit/d53210f7e09febc2cd386df91e3f62d0fa02f8b2) axis2: use stdenvNoCC
* [`b32b0c51`](https://github.com/NixOS/nixpkgs/commit/b32b0c5183d8e53d8d42d81245fac4c77e703341) tomcat: use stdenvNoCC
* [`30762f89`](https://github.com/NixOS/nixpkgs/commit/30762f89b041dbd6e88b50510b3b59ba06a3301a) tomb: use `--replace-fail`
* [`0c8faaf6`](https://github.com/NixOS/nixpkgs/commit/0c8faaf6c535fe015b92912763d3162683364293) python312Packages.aplpy: fix build
* [`90e1453d`](https://github.com/NixOS/nixpkgs/commit/90e1453d5a9e854312495ddf296eee476b20f14d) dart-sass: 1.72.0 -> 1.74.1
* [`3cd5ed24`](https://github.com/NixOS/nixpkgs/commit/3cd5ed249e2a51078f9cd9422d2009ee6b75bcc2) crc: 2.33.0 -> 2.34.1
* [`deb119e7`](https://github.com/NixOS/nixpkgs/commit/deb119e7f77627934657db589f986eb9b4b8997e) paperless-ngx: fix frontend build on darwin ([nixos/nixpkgs⁠#278377](https://togithub.com/nixos/nixpkgs/issues/278377))
* [`22ed2f58`](https://github.com/NixOS/nixpkgs/commit/22ed2f5890d6162bf50a01a7b9b3598ee0bd718a) paperless-ngx: 2.7.1 -> 2.7.2
* [`215d144f`](https://github.com/NixOS/nixpkgs/commit/215d144f770a25713d82552c9543c738f819a173) nixos/outline: fix s3 storage ([nixos/nixpkgs⁠#302567](https://togithub.com/nixos/nixpkgs/issues/302567))
* [`6472aaca`](https://github.com/NixOS/nixpkgs/commit/6472aacaed9cbeb448dad4fb9cd7e8d5ead8a4fd) granted: 0.22.0 -> 0.23.0
* [`69ff4517`](https://github.com/NixOS/nixpkgs/commit/69ff451762c93fdcc512126cf75a5ea2d247d6a3) python311Packages.dirigera: 1.0.14 -> 1.1.0
* [`75d6be6c`](https://github.com/NixOS/nixpkgs/commit/75d6be6c9984e182f67ca52841beebee99e9bd3c) erlang: add wrapGAppsHook
* [`62df8fb2`](https://github.com/NixOS/nixpkgs/commit/62df8fb2c07fd75b544c364f863d1d7b7665ca9f) python311Packages.django-import-export: 3.3.7 -> 3.3.8
* [`120ce1e1`](https://github.com/NixOS/nixpkgs/commit/120ce1e1a7cdb8dc2af6bd768766b523c41332a0) mkgmap: 4918 -> 4919
* [`e487bc2a`](https://github.com/NixOS/nixpkgs/commit/e487bc2ae19b0c4acde44dfd6a7c2adadba0ea8f) python312Packages.radio-beam: Fix build
* [`bcc8eabb`](https://github.com/NixOS/nixpkgs/commit/bcc8eabb74f015b547a2d82140686a753516c3b3) python311Packages.kubernetes: 28.1.0 -> 29.0.0
* [`f90d8885`](https://github.com/NixOS/nixpkgs/commit/f90d888548110626fe752ed84ed57df26422e55c) tts: mark as broken
* [`380aba5d`](https://github.com/NixOS/nixpkgs/commit/380aba5d92ccbca11e79f88ff8ee1872ba849576) unciv: 4.10.21 -> 4.11.2
* [`229f62c4`](https://github.com/NixOS/nixpkgs/commit/229f62c4d21f6041f55413f2cdc3216994a25653) python312Packages.cvss: 3.0 -> 3.1
* [`348bbf90`](https://github.com/NixOS/nixpkgs/commit/348bbf9015562ad668226c12a382dbcb4f2bfcfb) fheroes2: set platforms.unix instead of platforms.linux
* [`1f761a49`](https://github.com/NixOS/nixpkgs/commit/1f761a49ceb749debbf3349d6e62586e43ed70c7) i2p: cleanup and build jbigi from source
* [`d16233cc`](https://github.com/NixOS/nixpkgs/commit/d16233cc92371b1797e4509b97b9ef43be0790f6) i2p: change maintainer to linsui
* [`812c1ea9`](https://github.com/NixOS/nixpkgs/commit/812c1ea95d38152a60fc46345cf2bdbe47c52b06) organicmaps: 2024.03.18-5 -> 2024.03.31-8
* [`a09ac660`](https://github.com/NixOS/nixpkgs/commit/a09ac6605320f3cdee544cc16f748ad436355e11) i2p: move to by-name
* [`dce97415`](https://github.com/NixOS/nixpkgs/commit/dce974151f4a2dfafbe8f9128a268800423f99be) soundtracker: 1.0.4 -> 1.0.5
* [`829ca395`](https://github.com/NixOS/nixpkgs/commit/829ca395c4b1d4a160032bf7dec6dcc5228a77ab) soundtracker: disable sdl-config darwin time out
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
