### PR TITLE
niv devenv: update 808caa6a -> 01e01a3b

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://devenv.sh",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "808caa6a89779c1b22bcae57d16d803bde1f631d",
-        "sha256": "0hf75dzpal5332yv3zrf42mhkgx2fwkg9glnb7s67kl2rmd98ip1",
+        "rev": "01e01a3b4d991983dda055d10dcf93e86e1e1f8a",
+        "sha256": "1v36bmb318hl569i06zq6jymd53z0l2wjl9vqlkd5fv58p3h51ac",
         "type": "tarball",
-        "url": "https://github.com/cachix/devenv/archive/808caa6a89779c1b22bcae57d16d803bde1f631d.tar.gz",
+        "url": "https://github.com/cachix/devenv/archive/01e01a3b4d991983dda055d10dcf93e86e1e1f8a.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "doomemacs": {


### PR DESCRIPTION
## Changelog for devenv:
Branch: main
Commits: [cachix/devenv@808caa6a...01e01a3b](https://github.com/cachix/devenv/compare/808caa6a89779c1b22bcae57d16d803bde1f631d...01e01a3b4d991983dda055d10dcf93e86e1e1f8a)

* [`03ae5d63`](https://github.com/cachix/devenv/commit/03ae5d6311ee2b0738c1cbd148e7463854e89bb2) docs: add django example
* [`aa791339`](https://github.com/cachix/devenv/commit/aa791339afc01c6a38397813277359aa729b3d26) add uv pip replacement
* [`0c168b5f`](https://github.com/cachix/devenv/commit/0c168b5f661809ae8062da1994885880cb1da341) remove devenv lock & yaml
* [`a2998733`](https://github.com/cachix/devenv/commit/a2998733fcfb8308083f0fede6473f5885a3dc09) remove devenv shell from runserver process
* [`ace29900`](https://github.com/cachix/devenv/commit/ace299000d34f83090d1d740ec61f4482703a573) Fix disabling process compose TUI on detach
* [`c7851e1d`](https://github.com/cachix/devenv/commit/c7851e1d60daeffc0ba4d35fe325cbdfce049698) tweak django example
* [`3c84a0fc`](https://github.com/cachix/devenv/commit/3c84a0fc1afcff3a9e2d8a3a9a9fafcfb612e8f7) django: use postgresql unix sockets
* [`b144756a`](https://github.com/cachix/devenv/commit/b144756ad9a95dde56c505fdf6230516e2d713f1) add uv test
* [`6ff0c3a8`](https://github.com/cachix/devenv/commit/6ff0c3a81ccbf79f00b5f3289f77df21114bd87e) use if else statement
* [`0ba41c72`](https://github.com/cachix/devenv/commit/0ba41c72f52b457d65574d9ec73b7f43106a053a) Auto generate docs/reference/options.md
* [`d1a11d14`](https://github.com/cachix/devenv/commit/d1a11d14dbe96a03c7f9068e4d3af05f283734e0) Remove unneeded devenv.yaml
* [`815d71e3`](https://github.com/cachix/devenv/commit/815d71e3152a3174b327787a13288c10de4fc462) tailwind
* [`4436770c`](https://github.com/cachix/devenv/commit/4436770c846de9870060238d2d35ca0ab1f2809f) revamp website
* [`e7485291`](https://github.com/cachix/devenv/commit/e7485291f950f28cf78731be7ecc6a6763a5587a) disable rss plugin as it breaks development
* [`e4fad187`](https://github.com/cachix/devenv/commit/e4fad187dcb0b461717782f8d1db145ce8fe0744) frontpage: add more text
* [`69d1effa`](https://github.com/cachix/devenv/commit/69d1effa2e6f7b5e3d9559f66cb14df63fee7ef8) allow for any url prefix
* [`452b7bd2`](https://github.com/cachix/devenv/commit/452b7bd2f883c44a43145b7bad57da722f790804) garden
* [`c85c879f`](https://github.com/cachix/devenv/commit/c85c879f71a9593e5192c3d9aeba132df244b8b7) fixes [cachix/devenv⁠#1116](https://togithub.com/cachix/devenv/issues/1116): properly propagate devenv.tmpdir and devenv.runtime
* [`ee64aabc`](https://github.com/cachix/devenv/commit/ee64aabc83c8f53651240f5377cd953a44b29266) garden
* [`f69a72d6`](https://github.com/cachix/devenv/commit/f69a72d65d4715bb3dc5417eddc7b8e2387e2aee) fix [cachix/devenv⁠#1078](https://togithub.com/cachix/devenv/issues/1078): allow devenv.nix to be unversioned
* [`6e544a2f`](https://github.com/cachix/devenv/commit/6e544a2fa20225ca3d46baed0bc380c5c1144d0a) Auto generate docs/reference/options.md
* [`71f7783f`](https://github.com/cachix/devenv/commit/71f7783fb130a09a441149203c3c3b58932da1cc) docs: fixup homepage styling
* [`1af93652`](https://github.com/cachix/devenv/commit/1af93652caf48bfeef6ba7d1cf59fc66e506e5c2) docs: fix typo in example
* [`ed0ff456`](https://github.com/cachix/devenv/commit/ed0ff456f1063f1907e9a65cf92f4ed6101f2c08) Update home.html
* [`45796a9b`](https://github.com/cachix/devenv/commit/45796a9b7a16a09e3eb41f626f79e30b419498bb) Fix [cachix/devenv⁠#1118](https://togithub.com/cachix/devenv/issues/1118): add --offline
* [`a4eb473c`](https://github.com/cachix/devenv/commit/a4eb473c8104f9a177a26b0344fc1255815da094) Fix [cachix/devenv⁠#1086](https://togithub.com/cachix/devenv/issues/1086): fix gleam
* [`5684af4f`](https://github.com/cachix/devenv/commit/5684af4fada7258eff6864ba821d9ae062384846) v1.0.4
* [`de824c66`](https://github.com/cachix/devenv/commit/de824c66bce7a07f3f454062aef67471038905ad) Auto generate docs/reference/options.md
* [`50717876`](https://github.com/cachix/devenv/commit/50717876b1664abcdcbe04dbdcb2ee1487eabaee) docs: rescale tailwind to match mkdocs base font-size
* [`89f46b3e`](https://github.com/cachix/devenv/commit/89f46b3e9b9b808cd7f30ad6a79985f74fcc7ddf) docs: use blocks for scripts and fix misplaced nav
* [`d449979f`](https://github.com/cachix/devenv/commit/d449979f479ffbbbeef11c1c90d098d33ee41c5f) docs: use shell highlighting for console output
* [`d5a43357`](https://github.com/cachix/devenv/commit/d5a43357f07e685276a3151f77c371a2ad17bd0c) docs: update subtitle styling
* [`db15fca7`](https://github.com/cachix/devenv/commit/db15fca7185175d33c2d4fd4be65012914157350) docs: move github code css to styles block
* [`7182d55e`](https://github.com/cachix/devenv/commit/7182d55ecba2bf7477b085d7d0b8ebc8d1c28f7b) docs: fix typo
* [`b336108a`](https://github.com/cachix/devenv/commit/b336108a956429dba721842f42b4590d1efe8dfd) docs: fixup tailwind setup
* [`24796d1e`](https://github.com/cachix/devenv/commit/24796d1efbd4432d24aa8aeb3101f5fa016c5184) docs: add shell prefix for shell examples
* [`751b6515`](https://github.com/cachix/devenv/commit/751b65155a688608ac6f3329fcef19ad04412859) dev: install node_modules
* [`a656c071`](https://github.com/cachix/devenv/commit/a656c071c81a130a7943c81d44f1fb2d7ad517f5) chore: use 'follows' to reduce inputs
* [`a0c300e6`](https://github.com/cachix/devenv/commit/a0c300e645274d8da80f313d2ce40dd7264df452) fix 1.0.4 regression: python venv always recreated
* [`d1d3fdcd`](https://github.com/cachix/devenv/commit/d1d3fdcdd30b4d42332e9379fefc6df4001cddf6) fix [cachix/devenv⁠#1127](https://togithub.com/cachix/devenv/issues/1127): bump mkdocs/modules once nixpkgs is synced up
* [`e4dc2b42`](https://github.com/cachix/devenv/commit/e4dc2b42ecd9e0b010bccfe370d475203b470ec8) fix [cachix/devenv⁠#1069](https://togithub.com/cachix/devenv/issues/1069): remove dontAddDisableDepTrack env var
* [`3e1de2fe`](https://github.com/cachix/devenv/commit/3e1de2fe0b4b58da61201f7b9afe5f4740d05661) Auto generate docs/reference/options.md
* [`60a38e43`](https://github.com/cachix/devenv/commit/60a38e432b95bade824eff4eb0fd4fcaa4d49707) tests: remove nixpkgs override for python-native-libs
* [`f31d9eec`](https://github.com/cachix/devenv/commit/f31d9eec25b4a9d6393a7d79c3485ee77195bf5d) docs: fix mobile nav on landing page
* [`8d77a553`](https://github.com/cachix/devenv/commit/8d77a5538a6a25f7b83babee8af5464fd1d9be65) -o conflicts between offline and override-input
* [`605d79f5`](https://github.com/cachix/devenv/commit/605d79f5d5211c9306d17224ec5312756e12660f) Add targets in rust
* [`40f434d5`](https://github.com/cachix/devenv/commit/40f434d512d1d7cf3954dc5bd693c36685aef418) Add rust-wasm-cross example
* [`e5de12ca`](https://github.com/cachix/devenv/commit/e5de12ca0005d18b19671f98b65b4129cb79717b) home: Rust can do targets now
* [`a7939d53`](https://github.com/cachix/devenv/commit/a7939d53e20cd2f44b209fac0aaa5389a9078127) Auto generate docs/reference/options.md
* [`01e01a3b`](https://github.com/cachix/devenv/commit/01e01a3b4d991983dda055d10dcf93e86e1e1f8a) docs: highlight code when navigating to home
