### PR TITLE
niv home-manager: update a561ad6a -> 1c43dcfa

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,10 +53,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a561ad6ab38578c812cc9af3b04f2cc60ebf48c9",
-        "sha256": "1x9l68pppg2sqhbf5ar8dqngydm6fa9isch8q0splxx12mndn3aq",
+        "rev": "1c43dcfac48a2d622797f7ab741670fdbcf8f609",
+        "sha256": "08w56pa7l8n2rs9g186ynfkz6lks825jvdkk7dsrj4vcm6ngyhxp",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/a561ad6ab38578c812cc9af3b04f2cc60ebf48c9.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/1c43dcfac48a2d622797f7ab741670fdbcf8f609.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@a561ad6a...1c43dcfa](https://github.com/nix-community/home-manager/compare/a561ad6ab38578c812cc9af3b04f2cc60ebf48c9...1c43dcfac48a2d622797f7ab741670fdbcf8f609)

* [`40a99619`](https://github.com/nix-community/home-manager/commit/40a99619da804a78a0b166e5c6911108c059c3a8) fzf: add compatibility with fzf≥0.48.0
* [`b00d0e4f`](https://github.com/nix-community/home-manager/commit/b00d0e4fe9cba0047f54e77418ddda5f17e6ef2c) bun: add module
* [`18f89ef7`](https://github.com/nix-community/home-manager/commit/18f89ef74f0d48635488ccd6a5e30dc9d48a3a87) firefox: add containersForce flag
* [`31357486`](https://github.com/nix-community/home-manager/commit/31357486b0ef6f4e161e002b6893eeb4fafc3ca9) fish: use the subcommand style for the status command ([nix-community/home-manager⁠#4584](https://togithub.com/nix-community/home-manager/issues/4584))
* [`40ab43ae`](https://github.com/nix-community/home-manager/commit/40ab43ae98cb3e6f07eaeaa3f3ed56d589da21b0) foot: set PATH in server's systemd unit file
* [`8fdf3295`](https://github.com/nix-community/home-manager/commit/8fdf329526f06886b53b94ddf433848a0d142984) neovim: enable use of external package manager ([nix-community/home-manager⁠#5225](https://togithub.com/nix-community/home-manager/issues/5225))
* [`f33d5086`](https://github.com/nix-community/home-manager/commit/f33d5086d3f9128aba126135ea2a901c121ebf06) rio: remove redundant `lib.mdDoc` call
* [`4cc3c916`](https://github.com/nix-community/home-manager/commit/4cc3c91601b6083c3715516d5d891fa46c679e59) flake.lock: Update
* [`630a0992`](https://github.com/nix-community/home-manager/commit/630a0992b3627c64e34f179fab68e3d48c6991c0) nushell: fix nushell config path on darwin
* [`76a1650c`](https://github.com/nix-community/home-manager/commit/76a1650c45df8ed130e66eeeb8275a149562c4c5) k9s: fix typos in configuration file names
* [`9f32c66a`](https://github.com/nix-community/home-manager/commit/9f32c66a51d05e6d4ec0dea555bbff9135749ec7) k9s: configuration files in Darwin without XDG
* [`59d50bc5`](https://github.com/nix-community/home-manager/commit/59d50bc582bdf439df096a9ae1781e6c9c8a7523) espanso: enable module on darwin
* [`1c43dcfa`](https://github.com/nix-community/home-manager/commit/1c43dcfac48a2d622797f7ab741670fdbcf8f609) ci: bump peaceiris/actions-gh-pages from 3 to 4
