### PR TITLE
niv nixpkgs: update c25f8a85 -> 9dc4bec1

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c25f8a85ebf191a14126221d041222999f20f110",
-        "sha256": "1fra23xycf51pzac34h0sngqqcz5nmziwpsx4xhc6153xwlcvd1p",
+        "rev": "9dc4bec1a2ece069bd3bed8590f7a9ed994acf75",
+        "sha256": "1bfzdwapdgx508fvb6j5sq0hi61x3ar7p5v8b7vi0kvk0x982msl",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/c25f8a85ebf191a14126221d041222999f20f110.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/9dc4bec1a2ece069bd3bed8590f7a9ed994acf75.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@c25f8a85...9dc4bec1](https://github.com/nixos/nixpkgs/compare/c25f8a85ebf191a14126221d041222999f20f110...9dc4bec1a2ece069bd3bed8590f7a9ed994acf75)

* [`c73e6e89`](https://github.com/NixOS/nixpkgs/commit/c73e6e892d6f968fa4ba6c40fff438edfabaf892) pulumiPackages.pulumi-yandex-unofficial: init at 0.98.0
* [`f391429b`](https://github.com/NixOS/nixpkgs/commit/f391429b917a2f9ffb4136808c73fe3e11e46acd) ruby: fix build with content-addressed derivations
* [`9305ed35`](https://github.com/NixOS/nixpkgs/commit/9305ed35ec7f38c6fed16e9d6d0dcd788f007b4d) neovim: fix build with content-addressed derivations
* [`cd23ec7c`](https://github.com/NixOS/nixpkgs/commit/cd23ec7c7b8c46b729780c728b9e380730b64e6b) nixos/coder: add environment.extra and environment.file
* [`96cfe578`](https://github.com/NixOS/nixpkgs/commit/96cfe578446b6e32ba565a104d9c6b8f4be62678) codeberg-pages: 4.6.2 -> 5.0
* [`b173a5c7`](https://github.com/NixOS/nixpkgs/commit/b173a5c7cd6fa21ec27b6f12de31c7cfa24e202c) find-billy: init at 0.37.3
* [`737f21ef`](https://github.com/NixOS/nixpkgs/commit/737f21efae138a49a7644448698a7817b950919d) ktls-utils: add passthru.updateScript
* [`ee967c77`](https://github.com/NixOS/nixpkgs/commit/ee967c77a2cea3caf4981a6aec84b33133165a59) fira-mono: migrate to by-name
* [`81b35a5d`](https://github.com/NixOS/nixpkgs/commit/81b35a5dbe2b15ab89a33587925d7d7974532461) fira-sans: init at 4.202
* [`4d22cc50`](https://github.com/NixOS/nixpkgs/commit/4d22cc500f34560853d561d80f4aa980d98efd10) fira: migrate to by-name, refactor
* [`0aed5c3b`](https://github.com/NixOS/nixpkgs/commit/0aed5c3b542938a7ddba9f82e9b22d75c5c65794) {redshift,gammastep}: fix build with `strictDeps = true;`
* [`9d5e1917`](https://github.com/NixOS/nixpkgs/commit/9d5e1917bff2508f6530182864948d0651281d5c) python3Packages.pyqtdarktheme: init at 2.1.0
* [`3b505b3e`](https://github.com/NixOS/nixpkgs/commit/3b505b3ed049d1b013a17585d342cbf3bb37769a) albert: change license to unfree
* [`71e72bd6`](https://github.com/NixOS/nixpkgs/commit/71e72bd66ad60b16e01dfb989933942e917282b8) obs-studio-plugins.input-overlay: 5.0.0 -> 5.0.4
* [`5e4ebef1`](https://github.com/NixOS/nixpkgs/commit/5e4ebef1f8805d780f957fd0795274b2a8f27f0e) pokemon-cursor: init at 2.0.0
* [`467fd5bd`](https://github.com/NixOS/nixpkgs/commit/467fd5bd7d977078eac2c76ea2a24c1706623542) betula: 1.1.0 -> 1.2.0
* [`d6eff9ae`](https://github.com/NixOS/nixpkgs/commit/d6eff9ae51b8bbc923244851cf1dc226692cd897) writefreely: 0.14.0 -> 0.15.0
* [`f68f8fe4`](https://github.com/NixOS/nixpkgs/commit/f68f8fe4a042b16c2b1bce49ad46a8eeac83716b) vaults: init at 0.7.1
* [`b4338acf`](https://github.com/NixOS/nixpkgs/commit/b4338acf4ce90a08d44437e41cdb1419c4a55ed2) obs-studio-plugins.waveform: fix data directory
* [`e57d5580`](https://github.com/NixOS/nixpkgs/commit/e57d5580acc75aaca8fc255515b552dc76c8e081) git-pw: init at 2.6.0
* [`05d1bac6`](https://github.com/NixOS/nixpkgs/commit/05d1bac6199a2ab7810c32fb1e15d72a984e45e6) converseen: init at 0.12.1.0
* [`bc42e158`](https://github.com/NixOS/nixpkgs/commit/bc42e158a6bd6469d98c2aad7487b7c8a5df6ea3) sshesame: init at 0.0.27
* [`a77bfd0f`](https://github.com/NixOS/nixpkgs/commit/a77bfd0f1528be2e885e4c4c8d41e70dfa6bae0d) nixos-rebuild: fix --specialisation with remote builder and target
* [`2263152d`](https://github.com/NixOS/nixpkgs/commit/2263152d2876c3c4ec99beb495439b0efdbeef31) aeron, aeron-cpp: 1.42.1 -> 1.43.0
* [`4f38e413`](https://github.com/NixOS/nixpkgs/commit/4f38e4136c2c779732f570c2a94da19f1cd14faa) lbd: init at 0-unstable-2024-02-17
* [`f6032a82`](https://github.com/NixOS/nixpkgs/commit/f6032a82017395daf1906fcd800113586dbea10c) noto-fonts-monochrome-emoji: refactor to use github
* [`1831206c`](https://github.com/NixOS/nixpkgs/commit/1831206c650d057f85f190eef311a21fa2f099af) libplist: 2.3.0 -> 2.4.0
* [`a5e79024`](https://github.com/NixOS/nixpkgs/commit/a5e790248ab70ae58b96f4633532be8ea0cc46fe) release-notes/23.05: fix link to alice-lg
* [`58a70323`](https://github.com/NixOS/nixpkgs/commit/58a70323a42729bdf94ecb277de79b84be900864) python311Packages.influxdb3-python: init at 0.3.6
* [`f6ba649d`](https://github.com/NixOS/nixpkgs/commit/f6ba649ddc6ba92668be65fa5c0f9571ed21339c) appimage-run: set meta.mainProgram
* [`a5c2fa96`](https://github.com/NixOS/nixpkgs/commit/a5c2fa9641a00c9c214c5c044337e76864ed49b4) ovftool: init at 4.6.2 for x86_64-darwin
* [`756f5370`](https://github.com/NixOS/nixpkgs/commit/756f537026bdde28778d64f475714ffdc79de20a) orc: 0.4.36 -> 0.4.38
* [`4dd5d82e`](https://github.com/NixOS/nixpkgs/commit/4dd5d82e483f03387183803e7d1bd7727b9cbfc2) ktlint: 1.1.1 -> 1.2.1
* [`777e5f1d`](https://github.com/NixOS/nixpkgs/commit/777e5f1deb649674ac94df0f907c0fa81188dd9d) vpsfree-client: 0.17.1 -> 0.18.0
* [`31515815`](https://github.com/NixOS/nixpkgs/commit/31515815da5d4aeedab830e0f266ac0b6078f368) python3Packages.python-i18n: replace use of deprecated assertRaisesRegexp
* [`77b6d1e7`](https://github.com/NixOS/nixpkgs/commit/77b6d1e7d3acc6f5fda77240b4ae46d78f82c090) cryptsetup: 2.7.0 -> 2.7.1
* [`84558a3e`](https://github.com/NixOS/nixpkgs/commit/84558a3e378c53170e1960c8e657f07516337e2a) wike: move to by-name
* [`f6396255`](https://github.com/NixOS/nixpkgs/commit/f6396255f98c81490f74cb3def841e6eedce7c51) wike: 2.1.0 -> 3.0.0
* [`d8f70bf6`](https://github.com/NixOS/nixpkgs/commit/d8f70bf6156f85db515052ac46241ee545a451d2) reactphysics3d: 0.9.0 -> 0.10.0
* [`73e2b29b`](https://github.com/NixOS/nixpkgs/commit/73e2b29bef33989d79e219158ed33896d6eb9a73) space-station-14-launcher: 0.25.1 -> 0.26.0
* [`593fd780`](https://github.com/NixOS/nixpkgs/commit/593fd780ae33f11d3c985a81f458f5a61d37b68f) tree-sitter: 0.20.9 -> 0.22.1
* [`be2f7c37`](https://github.com/NixOS/nixpkgs/commit/be2f7c376cb07b332ddb9195d6c32c6c1bc5ce79) tree-sitter: update grammars broken by the 0.22.1
* [`af50a356`](https://github.com/NixOS/nixpkgs/commit/af50a356daa276fca1a123f9bc71c428ab1d8802) tree-sitter: update grammars
* [`8f86f82b`](https://github.com/NixOS/nixpkgs/commit/8f86f82b1a60175e14bbb21fb2cac6a620605231) nixos/pretalx: fix /media/ nginx location block
* [`503f9242`](https://github.com/NixOS/nixpkgs/commit/503f9242bd909424b9fc34a971444f46d5ab02c7) restls: init at 0.1.1
* [`bc55ffb1`](https://github.com/NixOS/nixpkgs/commit/bc55ffb14ab98a83c38507eca9e25c11bfeff9d6) espflash: 2.1.0 -> 3.0.0
* [`52b1af9c`](https://github.com/NixOS/nixpkgs/commit/52b1af9c18855d555a84f09cd2f85d024e50ebd4) libaom: 3.8.1 -> 3.8.2
* [`91acdf36`](https://github.com/NixOS/nixpkgs/commit/91acdf36ef4b86b8c93fc5052e175dfdb76b8e4e) pixman: Raise individual test timeout to 240 seconds
* [`4e840e80`](https://github.com/NixOS/nixpkgs/commit/4e840e807f02fc5965464987ac30a39705f4b63e) nwjs: 0.84.0 -> 0.85.0
* [`1d2cf1d1`](https://github.com/NixOS/nixpkgs/commit/1d2cf1d1abf24e58e729c0f3a850964293a9d2d9) fsautocomplete: 0.69.0 -> 0.71.0
* [`a348c67e`](https://github.com/NixOS/nixpkgs/commit/a348c67ea20bc810d0a596b62e1cd3208ac1727f) simde: add riscv platforms
* [`a7c88406`](https://github.com/NixOS/nixpkgs/commit/a7c88406a6ae1fb0a170ec92179f8e3da756f7de) busybox: Set shellPath up so that ash can be a login shell
* [`e0de8da0`](https://github.com/NixOS/nixpkgs/commit/e0de8da00a8df7557d3e0b9af963e9ca99715665) unison-ucm: 0.5.17 -> 0.5.19
* [`cedeb6c3`](https://github.com/NixOS/nixpkgs/commit/cedeb6c36bef2df4897a4d022fdcce433551a0fc) linuxPackages.rtl8821au: unstable-2023-07-23 -> unstable-2024-03-16
* [`08d1546b`](https://github.com/NixOS/nixpkgs/commit/08d1546b1bd31f5a4f06268e5e2999bb8f1b0765) tree-sitter: 0.22.1 -> 0.22.2
* [`6007a24b`](https://github.com/NixOS/nixpkgs/commit/6007a24b794deb454c53ac5401dfb79642520e5e) tree-sitter: update grammars
* [`d4c904a7`](https://github.com/NixOS/nixpkgs/commit/d4c904a7c8b2750307a5950ccd9f6e7a45b12fd8) tree-sitter: add lunarvim as reverse dependency to passthru.tests
* [`2836864a`](https://github.com/NixOS/nixpkgs/commit/2836864a9994863f014362668aa1d0b82496a877) harfbuzz: 8.3.0 -> 8.3.1
* [`fe30c452`](https://github.com/NixOS/nixpkgs/commit/fe30c4525c5365b8befd29650f3b8a603e232b2e) beets-unstable: unstable-2024-10-26 -> unstable-2024-03-16
* [`f0152c8c`](https://github.com/NixOS/nixpkgs/commit/f0152c8c2c678da5902cc5ca4cbac6607b15ee0c) leanify: 2023-10-19 -> 2023-12-17
* [`f9094faf`](https://github.com/NixOS/nixpkgs/commit/f9094faf70fe5be3973bc8aa7d77d76d0acbe066) stdenv: pass --mode=+w to tar, ensuring extraction is possible
* [`b831e46d`](https://github.com/NixOS/nixpkgs/commit/b831e46dd1a599ea4e630566cbac28181502d912) gogui: make deterministic and clean up
* [`53136b68`](https://github.com/NixOS/nixpkgs/commit/53136b68e20422b6c77b568f72f37a312de59377) gruppled-cursors: init at 1.0.0
* [`60d5e3df`](https://github.com/NixOS/nixpkgs/commit/60d5e3df4e828df6c79bef8fa4ae59a08593c159) gruppled-lite-cursors: init at 1.0.0
* [`3c0088e8`](https://github.com/NixOS/nixpkgs/commit/3c0088e8a8f894493e5528e166bc4eb451590ed1) darwin.binutils: properly handle cctools-llvm
* [`de8b2467`](https://github.com/NixOS/nixpkgs/commit/de8b24678debb4014f7fcc86e591fead60eeae3d) gruppled-cursors: follow RFC140
* [`34336ae7`](https://github.com/NixOS/nixpkgs/commit/34336ae7bad91f96acc2543ceee1782d2e30aa14) python311Packages.ocrmypdf: 16.1.1 -> 16.1.2
* [`21a59137`](https://github.com/NixOS/nixpkgs/commit/21a59137a649f9a8f6c898a7259028757846eaca) nixos/podgrab: add user/group options
* [`d5998390`](https://github.com/NixOS/nixpkgs/commit/d599839060400762a67d2c01d15b102ffe75e703) gnupg: fix cross compilation
* [`aab705b2`](https://github.com/NixOS/nixpkgs/commit/aab705b24d0d973e7fa041b62619213d0e1e5d28) default-gcc-version: 12 -> 13 if stdenv.isDarwin
* [`f8ad6442`](https://github.com/NixOS/nixpkgs/commit/f8ad6442d58e4c1d445e175038b1bcda2a526c51) stdenv.darwin: bootstrap darwin using updated tools
* [`6254db61`](https://github.com/NixOS/nixpkgs/commit/6254db6165231d0e5a3eedb84daf555fd86b50ce) python3Packages.openusd: 23.11 -> 24.03
* [`249e5d41`](https://github.com/NixOS/nixpkgs/commit/249e5d41d2492dd3af9cfc7c4633b9c424ba8d2d) qt6.qtdeclarative: add mingw support
* [`bd8bafe3`](https://github.com/NixOS/nixpkgs/commit/bd8bafe359711874a822511b387e6c0f96b8d617) qt6.qtmultimedia: add mingw support
* [`961584c3`](https://github.com/NixOS/nixpkgs/commit/961584c3dc003967c7c96d097aee43e64734911e) tsm-client: 8.1.21.0 -> 8.1.22.0
* [`79e53d87`](https://github.com/NixOS/nixpkgs/commit/79e53d8772ce0d3ba9362020be9931149eec30f4) a2jmidid: update upstream data
* [`4f344cd9`](https://github.com/NixOS/nixpkgs/commit/4f344cd923589db55cf6f7e3029326047d965472) a2jmidid: 9 -> 12
* [`f200ad50`](https://github.com/NixOS/nixpkgs/commit/f200ad50768e0dd3895dd16af80e3a7b2acfbf9a) python311Packages.jsonslicer: init at 0.1.7
* [`0ed4e834`](https://github.com/NixOS/nixpkgs/commit/0ed4e834cfeecda157fd122e1c48cef889085f60) enchant: 2.6.7 -> 2.6.8
* [`b14e87ed`](https://github.com/NixOS/nixpkgs/commit/b14e87ed5fe5fb71dfe3c741de95cb95629358ab) libdeflate: 1.19 -> 1.20
* [`7cb11ac4`](https://github.com/NixOS/nixpkgs/commit/7cb11ac43a77dc6cce4f70b48ab0ff2695fb8428) python3Packages.ray: 2.9.0 -> 2.10.0
* [`44319aa7`](https://github.com/NixOS/nixpkgs/commit/44319aa7885784cd7760ebe621ed630e6802ecbd) iana-etc: 20231227 -> 20240318
* [`007cb572`](https://github.com/NixOS/nixpkgs/commit/007cb57290875d90c6389b9d5bb3d3f629df45da) python312Packages.pympler: normalize pname
* [`ab0bd8ca`](https://github.com/NixOS/nixpkgs/commit/ab0bd8ca527f9e21a80562f39eb4a5a9a565780a) puppet-lint: add meta, passthru.{tests,updateScript}
* [`1e2f6ebb`](https://github.com/NixOS/nixpkgs/commit/1e2f6ebbedc567823c188b256c7e55fc9612f51d) puppet-lint: 2.5.2 -> 4.2.4
* [`5b7b5e9e`](https://github.com/NixOS/nixpkgs/commit/5b7b5e9e1df432451ae1d955537b4b9d96bd2233) puppet-lint: move to pkgs/by-name
* [`2e1fe503`](https://github.com/NixOS/nixpkgs/commit/2e1fe503f85c2244328c3a5df239bbf63e6c6976) puppet-bolt: 3.24.0 -> 3.28.0
* [`79f0d47b`](https://github.com/NixOS/nixpkgs/commit/79f0d47bb9daca4c191be13e16633ce5bd0fb183) puppet-bolt: add meta.changelog, maintainers, and remove `with lib;`
* [`408f89c6`](https://github.com/NixOS/nixpkgs/commit/408f89c6ccc85df7b45474c2c436bf086e44cb5f) puppet-bolt: move to pkgs/by-name
* [`fd3715a4`](https://github.com/NixOS/nixpkgs/commit/fd3715a45d5c90bd5aef993b0da99063c6d303c7) r10k: add anthonyroussel to maintainers
* [`8928b126`](https://github.com/NixOS/nixpkgs/commit/8928b12689971f57edf37caa75a7f26bb3836258) r10k: 3.4.1 -> 4.0.1
* [`bc833bf0`](https://github.com/NixOS/nixpkgs/commit/bc833bf0250e61ee702deac1750e68aaf3630e62) r10k: add passthru.tests.version
* [`dc611ed7`](https://github.com/NixOS/nixpkgs/commit/dc611ed73dd741ca81e94cc11bf812bb70502742) r10k: move to pkgs/by-name
* [`e3441a96`](https://github.com/NixOS/nixpkgs/commit/e3441a964a96478639acbfc0c9ffc07882c5f5f9) emacs: 29.2 -> 29.3
* [`5ccb83a9`](https://github.com/NixOS/nixpkgs/commit/5ccb83a906d114d69c938fc09a57c04de9398cb6) pdk: format with nixfmt-rfc-style
* [`6826d9de`](https://github.com/NixOS/nixpkgs/commit/6826d9de871ca589f1b34970c87ab5cbd1070dec) pdk: add anthonyroussel to maintainers
* [`6efd3efc`](https://github.com/NixOS/nixpkgs/commit/6efd3efcb147e2cae621aad1e6aa6993f63c454c) pdk: add passthru.tests.version, meta.changelog, meta.mainProgram
* [`ea80fbe7`](https://github.com/NixOS/nixpkgs/commit/ea80fbe7c3d3d235dfbedef24ab4bd1c7b55b941) facter: 3.14.17 -> 4.6.1
* [`fe26578b`](https://github.com/NixOS/nixpkgs/commit/fe26578be988f00bd629d7775a04c7ae87c3574e) facter: move to pkgs/by-name
* [`7705fda4`](https://github.com/NixOS/nixpkgs/commit/7705fda40a3f262ce0afe352e7dbd57a62d250d1) pdk: fix build for all ruby platforms
* [`37610f43`](https://github.com/NixOS/nixpkgs/commit/37610f43c67cbd9139cc58843c7c0157699bdef0) libimobiledevice-glue: 1.0.0 -> 1.2.0
* [`4cc1cf9c`](https://github.com/NixOS/nixpkgs/commit/4cc1cf9c380553f594ea728b2dc5135d1a834d6e) maintainers: add rhelmot
* [`e9ad2609`](https://github.com/NixOS/nixpkgs/commit/e9ad260948ec3c23a7dbf4e9a3bad6b705a95048) rsync: Explicitly disable configure feature flags when nixpkgs feature flags are disabled
* [`2d98ada3`](https://github.com/NixOS/nixpkgs/commit/2d98ada3cdc0c075ae5d165440fcca47d8bc2ff8) python311Packages.argcomplete: 3.2.2 -> 3.2.3
* [`55876e02`](https://github.com/NixOS/nixpkgs/commit/55876e02de164e822ce85ffcb1a6de0915884108) bundler: 2.5.6 -> 2.5.7
* [`5c54742e`](https://github.com/NixOS/nixpkgs/commit/5c54742eb82f9356b4baba7d014fbe89416995a4) ruby.rubygems: 3.5.6 -> 3.5.7
* [`92aca9c6`](https://github.com/NixOS/nixpkgs/commit/92aca9c6b5516d7959c46ff70cfed22eed510768) python311Packages.scipy: remove references to dev outputs
* [`26ccdea3`](https://github.com/NixOS/nixpkgs/commit/26ccdea3d777937f3dd9607b9b9e3853c996b406) python3Packages.setuptoolsBuildHook: delete broken setuptoolsShellHook
* [`d521f033`](https://github.com/NixOS/nixpkgs/commit/d521f033032b9afa800f7752ecdf1dc093c52ee1) python3Packages.setuptoolsBuildHook: correct name
* [`51434a09`](https://github.com/NixOS/nixpkgs/commit/51434a095d6fb6efb999bcfc69a7973927b0afa5) vim: 9.1.0148 -> 9.1.0200
* [`9a6a13cc`](https://github.com/NixOS/nixpkgs/commit/9a6a13cc09894963665148e06be4ee2f76eb89b0) avahi: use fetchpatch's "exclude" option instead of manual patch maintenance
* [`88d2a029`](https://github.com/NixOS/nixpkgs/commit/88d2a029e986e236cb53fcdaa846cedc3024cbc1) avahi: patch to handle bogus services gracefully
* [`a4e8e247`](https://github.com/NixOS/nixpkgs/commit/a4e8e2477ac5d068d40ca43d5723906fa4cc3ce5) avahi: patches to handle malformed content from the network
* [`187ac583`](https://github.com/NixOS/nixpkgs/commit/187ac583a0090cb529eefc424fc5ee0a6ba97b38) python/hooks/setuptools-build-hook.sh: use `--parallel` flag only for fresh setuptools
* [`3eedc01a`](https://github.com/NixOS/nixpkgs/commit/3eedc01a980ac4be464fd5dd2f22801cba72f5a0) cmake: 3.28.3 -> 3.29.0
* [`30d1d1cf`](https://github.com/NixOS/nixpkgs/commit/30d1d1cf28224c95149b9bb3c2b4078add355192) newsboat: 2.34 -> 2.35
* [`de72aac8`](https://github.com/NixOS/nixpkgs/commit/de72aac807a4a5c125fee1b68d6578b21838f4f3) ffmpeg: cleanup darwin libraries
* [`ad594b45`](https://github.com/NixOS/nixpkgs/commit/ad594b450386bbc658196638cc778382c4d0a665) urserver: 3.10.0.2467 -> 3.13.0.2505
* [`ce845d58`](https://github.com/NixOS/nixpkgs/commit/ce845d58a1d9e009cf02efd53185201d791c04f6) urserver: use finalAttrs instead of rec
* [`5680f319`](https://github.com/NixOS/nixpkgs/commit/5680f319fd8e0225bcad0550ee0fb25a0590e1dc) python311Packages.pytest7CheckHook: init
* [`f7c4bb3f`](https://github.com/NixOS/nixpkgs/commit/f7c4bb3f000f003fe75131b33a2ea529fbed255f) python312Packages.setuptools: 69.1.1 -> 69.2.0
* [`e06f4af9`](https://github.com/NixOS/nixpkgs/commit/e06f4af9fb003b6975d04f90b9702235556b4da7) python312Packages.hatchling: 1.21.1 -> 1.22.3
* [`663a1174`](https://github.com/NixOS/nixpkgs/commit/663a11749aaade4fd7c709e8078b01040786a652) python312Packages.pytest: 8.0.2 -> 8.1.1
* [`3b44190e`](https://github.com/NixOS/nixpkgs/commit/3b44190ef486f81ea051867bf0cd662c7c0e4d16) python312Packages.pytest-asyncio: 0.23.5.post1 -> 0.23.6
* [`ea752a4b`](https://github.com/NixOS/nixpkgs/commit/ea752a4b687aafe2cfc01ab657ffad9533b35dec) python312Packages.hypothesis: 6.98.17 -> 6.99.12
* [`b974abcc`](https://github.com/NixOS/nixpkgs/commit/b974abcc5d85bf1a1a121ff1ef41936ff1ae900c) python312Packages.flaky: 3.7.0 -> 3.8.1
* [`0e904c28`](https://github.com/NixOS/nixpkgs/commit/0e904c2845d82838d165fb6fafa5a85500e8f0e6) elpa-packages: updated 2024-03-25 (from nix-community/emacs-overlay)
* [`bf16eab8`](https://github.com/NixOS/nixpkgs/commit/bf16eab8002278301715013acd494afe3c71da98) elpa-devel-packages: updated 2024-03-25 (from nix-community/emacs-overlay)
* [`53ca2844`](https://github.com/NixOS/nixpkgs/commit/53ca2844f18ec831564b3b2a314883d32f50591c) melpa-packages: updated 2024-03-25 (from nix-community/emacs-overlay)
* [`02883ac5`](https://github.com/NixOS/nixpkgs/commit/02883ac5a17d354542ddb57d4c90f8a73e52fdb2) nongnu-packages: updated 2024-03-25 (from nix-community/emacs-overlay)
* [`2c944d20`](https://github.com/NixOS/nixpkgs/commit/2c944d20379397c96ff6af697aa04369c9f07dba) nodejs_20: 20.11.1 -> 20.12.0
* [`f3fa245f`](https://github.com/NixOS/nixpkgs/commit/f3fa245f2391fbb68e1a821c8d5c06abb13be111) python3Packages.maestral: 1.8.0 -> 1.9.0
* [`e9ea01eb`](https://github.com/NixOS/nixpkgs/commit/e9ea01eb6d7c1ab8ff6bc3fb92828fb6e491696d) maestral-qt: 1.8.0 -> 1.9.0
* [`660b0a68`](https://github.com/NixOS/nixpkgs/commit/660b0a6831d85f6deab139811627dbd2db7ecb61) python3Packages.maestral: 1.9.0 -> 1.9.1
* [`790526d2`](https://github.com/NixOS/nixpkgs/commit/790526d28445159e6cc8adcde7736722557afcf7) maestral-qt: 1.9.0 -> 1.9.1
* [`03c3d8c1`](https://github.com/NixOS/nixpkgs/commit/03c3d8c1d1c9fc8172c21b2795245cbe2ec07c0c) umockdev: 0.18.0 -> 0.18.1
* [`b71bc311`](https://github.com/NixOS/nixpkgs/commit/b71bc311296cf47bce29823e6e30a771f154b873) python3Packages.maestral: 1.9.1 -> 1.9.2
* [`a5854398`](https://github.com/NixOS/nixpkgs/commit/a5854398de549cff8d59d27bdc2bb5ea9c25a7f1) maestral-qt: 1.9.1 -> 1.9.2
* [`89fd3034`](https://github.com/NixOS/nixpkgs/commit/89fd3034c987256c156731a79f09a74480064996) budgie.budgie-desktop-view: disable werror
* [`a0a4b45b`](https://github.com/NixOS/nixpkgs/commit/a0a4b45ba9e500f1461572c9ccb88c2ab3728a73) meson: 1.3.2 -> 1.4.0
* [`66e1473e`](https://github.com/NixOS/nixpkgs/commit/66e1473eaf3e463297cf1144bdfe5614305cdec4) npth: add musl regression test
* [`47c36c50`](https://github.com/NixOS/nixpkgs/commit/47c36c508d016c1e1c679a2f3421433e3b7319d3) stellarium: 23.4 -> 24.1
* [`601c9025`](https://github.com/NixOS/nixpkgs/commit/601c9025c1b707501c830bbf2697d09120bdc376) maturin: 1.5.0 -> 1.5.1
* [`11eb9de1`](https://github.com/NixOS/nixpkgs/commit/11eb9de13be88953c25c3e2ac3127f058230b330) ffmpeg: make pkgConfigModules depend on included libs
* [`e42eb68d`](https://github.com/NixOS/nixpkgs/commit/e42eb68de4ac14e9fad3a62b8944995aae5d901f) ffmpeg: enable opengpl on full variant
* [`782da363`](https://github.com/NixOS/nixpkgs/commit/782da363e9774edd6377492403719f7f8bebc7cc) ffmpeg: enable rtmp on full variant
* [`887dd17f`](https://github.com/NixOS/nixpkgs/commit/887dd17f4543aae6b0bfe78f95f5313d02d00d01) ffmpeg: add comment about why tensorflow is disabled
* [`984c056f`](https://github.com/NixOS/nixpkgs/commit/984c056f86226f17989c4daf4032668e6cdbb985) ffmpeg: make nvidia dependencies explicit
* [`2a6ec422`](https://github.com/NixOS/nixpkgs/commit/2a6ec422f3e61646fad13b2f23a1e647c5649b3b) libsamplerate: 0.1.9 -> 0.2.2
* [`528354e6`](https://github.com/NixOS/nixpkgs/commit/528354e66c26cf947b04cc94db7185f5d127ca31) python312Packages.cython: 0.29.36 -> 3.0.9
* [`bd301635`](https://github.com/NixOS/nixpkgs/commit/bd3016357f70ddf770df27d537f7772dbaa3ea43) python312Packages.pystemmer: 2.2.0 -> 2.2.0.1
* [`d72f2724`](https://github.com/NixOS/nixpkgs/commit/d72f272463e9b50aef06e52826a3f17c07a48141) python312Packages.certifi: 2023.11.17 -> 2024.02.02
* [`b984244a`](https://github.com/NixOS/nixpkgs/commit/b984244adb53de0238ded48a0e04cd0a0f7f83f4) python312Packages.flexmock: 0.11.3 -> 0.12.0
* [`885b5666`](https://github.com/NixOS/nixpkgs/commit/885b5666f2fd7b1fe4f6d8498823c285536d0aba) python311Packages.alembic: test with pytest_7
* [`35a12fc9`](https://github.com/NixOS/nixpkgs/commit/35a12fc9b1b86be21607211353da12f0e48813a6) python312Packages.apsw: 3.45.1.0 -> 3.45.2.0
* [`fdb60267`](https://github.com/NixOS/nixpkgs/commit/fdb60267ab631dc8ba3ace6342dc8d46569f4e6e) python311Packages.vine: disable failing tests
* [`b88f337e`](https://github.com/NixOS/nixpkgs/commit/b88f337e4746bdb01aa7b21e885689ead2833d52) python312Packages.nocaselist: test with pytest_7
* [`811e4ff1`](https://github.com/NixOS/nixpkgs/commit/811e4ff12485794c07fb85f162c62d2c5a31cc1e) python312Packages.paramiko: patch pytest8 compat
* [`d57e54b5`](https://github.com/NixOS/nixpkgs/commit/d57e54b504307fd2c3d8acd85be3e58b36c7b91e) python312Packages.pint: disable failing tests & benchmarks
* [`fad18b0c`](https://github.com/NixOS/nixpkgs/commit/fad18b0c0e4d33c115a79e0f23821ba5a30ee885) python312Packages.isort: disable failing test
* [`bad4ddcf`](https://github.com/NixOS/nixpkgs/commit/bad4ddcfd404a6057a85c3abaed1cd6717cb0ae6) ceph: disable failing test in pyopenssl
* [`37606d32`](https://github.com/NixOS/nixpkgs/commit/37606d323b600c3395eb90f9151a0710d86565a0) python312Packages.ndindex: restore disabled test
* [`c7eb0179`](https://github.com/NixOS/nixpkgs/commit/c7eb0179e32e2a416bac2ef3e59cb85b982d2584) python312Packages.fastjsonschema: 2.18.1 -> 2.19.1
* [`9d9885e9`](https://github.com/NixOS/nixpkgs/commit/9d9885e9491e1375f48fdb21880c38a6b2676271) python311Packages.torchsde: test with pytest_7
* [`2e2ec07f`](https://github.com/NixOS/nixpkgs/commit/2e2ec07f9decde5ddac366ab064c5d6318c829e1) python312Packages.devtools: drop pytest8 removal warning ignore
* [`2d191c4e`](https://github.com/NixOS/nixpkgs/commit/2d191c4e7a2e223fcf732249e635c9172f634b5e) python311Packages.pmdarima: test with pytest_7
* [`7d6e33f8`](https://github.com/NixOS/nixpkgs/commit/7d6e33f8200e5c100159d19749c431f339eecfaf) python311Packages.dask: 2024.1.1 -> 2024.2.1
* [`375a4132`](https://github.com/NixOS/nixpkgs/commit/375a4132df27d7eec92e346193ffc18bb45180e6) python311Packages.aws-encryption-sdk: disable failing test
* [`a48a3496`](https://github.com/NixOS/nixpkgs/commit/a48a34965754c5c44ae892578e6d9f50a85724d1) python311Packages.deal: 4.24.3 -> 4.24.4
* [`312523f9`](https://github.com/NixOS/nixpkgs/commit/312523f9f5078106bba947979fadb7ed775e42c3) python311Packages.scikit-fuzzy: refactor
* [`41aace96`](https://github.com/NixOS/nixpkgs/commit/41aace96d25b87e0f5ae4985045e1f5870ea0509) python311PAckages.detect-secrets: test with pytest 7
* [`0781e7f9`](https://github.com/NixOS/nixpkgs/commit/0781e7f976515487b476ccb04f4e5b64ccdafc0e) python311Packages.cssutils: test with pytest 7
* [`ccaa2b9f`](https://github.com/NixOS/nixpkgs/commit/ccaa2b9ff34eb7ef904720e9d2a3b0333e09dc89) python311Packages.chalice: test with pytest 7
* [`a4c2f399`](https://github.com/NixOS/nixpkgs/commit/a4c2f399b86eaddec7ab60ffef672311bca319d1) python311Packages.demes: test with pytest 7
* [`3bfe2944`](https://github.com/NixOS/nixpkgs/commit/3bfe29446dbd9683175519b241f7ccb30835b1f0) python311Packages.ipywidgets: test with pytest 7
* [`91b95f5b`](https://github.com/NixOS/nixpkgs/commit/91b95f5b1eff9a00a309e1f00937c31abe38497c) python311Packages.papermill: disable failing test
* [`4607bde2`](https://github.com/NixOS/nixpkgs/commit/4607bde2028226993d03fc52c7956d9f74a1f6c1) python311Packages.hid-parser: test with pytest 7
* [`968876ed`](https://github.com/NixOS/nixpkgs/commit/968876ed8368363083c89a9683680e9bc833ae57) python311Packages.nocasedict: test with pytest 7
* [`73072f31`](https://github.com/NixOS/nixpkgs/commit/73072f314a3007d8b87c9bab6d75c5ca3f2f3c05) python311Packages.djangorestframework: test with pytest 7
* [`db6c2bcf`](https://github.com/NixOS/nixpkgs/commit/db6c2bcf1a90b608d5368aecf8be30f6ef805d43) python311Packages.django-filter: 23.5 -> 24.1
* [`3bef83ba`](https://github.com/NixOS/nixpkgs/commit/3bef83ba5725f0678fa0335f8664814d65d2f1c3) python311Packages.graphene: test with pytest 7
* [`f8107134`](https://github.com/NixOS/nixpkgs/commit/f8107134fa7675d0ad33bc0469deceeab987f425) python311Packages.graphene-django: test with pytest 7, disable failing tests
* [`f32a6a6d`](https://github.com/NixOS/nixpkgs/commit/f32a6a6d7c290dd0b429b0baabd8212dfe120bed) python311Packages.marshmallow-enum: test with pytest 7
* [`51df12a5`](https://github.com/NixOS/nixpkgs/commit/51df12a53b3359a45e9a4459f7d6299bd3e2c272) python311Packages.favicon: test with pytest 7
* [`d493ffff`](https://github.com/NixOS/nixpkgs/commit/d493ffff030da9d770b4ef534107854d8b62c6ce) python311Packages.anytree: 2.12.0 -> 2.12.1
* [`064e5e03`](https://github.com/NixOS/nixpkgs/commit/064e5e034fd19fae4589c565fc28ee59c46b3bf0) python311Packages.quart: test with pytest 7
* [`95f00d82`](https://github.com/NixOS/nixpkgs/commit/95f00d82f7ee7c8ef337ccdf5b732162d1ff46bd) python311Packages.librouteros: test with pytest 7
* [`38edccbc`](https://github.com/NixOS/nixpkgs/commit/38edccbcb46ac3942f13986d9d1af4a2b880b4cc) python311Packages.kombu: test with pytest 7
* [`aa83e777`](https://github.com/NixOS/nixpkgs/commit/aa83e777392ec833cf984ec6ea23ff3991042d12) python311Packages.barectf: test with pytest 7
* [`3bf5b41d`](https://github.com/NixOS/nixpkgs/commit/3bf5b41d2288acea755a8c758da4611e57d065a1) python311Packages.uarray: test with pytest7
* [`db5d5bb7`](https://github.com/NixOS/nixpkgs/commit/db5d5bb7535e48448793e5707068313cdeb035d9) python311Packages.json-tricks: test with pytest 7
* [`e1feaa95`](https://github.com/NixOS/nixpkgs/commit/e1feaa95441947ea7f5361a05b60a46b744820ab) radicale: test with pytest 7
* [`bfd67ec5`](https://github.com/NixOS/nixpkgs/commit/bfd67ec538ba4633d9774fab005b28d8ab245162) python312Packages.starlette: 0.37.1 -> 0.37.2
* [`a184e834`](https://github.com/NixOS/nixpkgs/commit/a184e834528ac729b8ea1c914008c351e766b0e5) python311Packages.openpyxl: test with pytest 7
* [`44ee4bbc`](https://github.com/NixOS/nixpkgs/commit/44ee4bbc608e87646d7a37a9505527fe096b208b) python312Packages.pytest-doctestplus: 1.2.0 -> 1.2.1
* [`8919ff73`](https://github.com/NixOS/nixpkgs/commit/8919ff737bba11de4c49d1b6ba96fb3cbf972765) python311Packages.pymeeus: refactor
* [`bc08c0d4`](https://github.com/NixOS/nixpkgs/commit/bc08c0d477b733e630633280c8a13d256cc51f31) python311Packages.pylint: test with pytest 7
* [`9664cf96`](https://github.com/NixOS/nixpkgs/commit/9664cf9671a75d08be356a39fe4380adecdffaa9) python312Packages.protobuf3: fix tests
* [`354ccf49`](https://github.com/NixOS/nixpkgs/commit/354ccf49802d3313190756444d5a824b1af89c27) python311Packages.limits: 3.9.0 -> 3.10.1
* [`48ff13dc`](https://github.com/NixOS/nixpkgs/commit/48ff13dcd7901b98743c99661df5044554bd2d32) python312Packages.rpyc: fix tests
* [`3d3f4d4d`](https://github.com/NixOS/nixpkgs/commit/3d3f4d4db50696d8059a383d555e8f676b857d75) python311Packages.rangehttpserver: test with pytest 7
* [`268640cf`](https://github.com/NixOS/nixpkgs/commit/268640cf0d2ec2d8dc366600f949172fd37782f7) python311Packages.colorcet: fix build
* [`8b50e4c4`](https://github.com/NixOS/nixpkgs/commit/8b50e4c4be8b9ef81a77ce7915584355744a4422) python311Packages.smart-open: 7.0.1 -> 7.0.3
* [`befeb64a`](https://github.com/NixOS/nixpkgs/commit/befeb64a9c8872bef95a4798468aa69f4353b24d) python312Packages.pytest-bdd: 6.1.1 -> 7.1.2
* [`92898415`](https://github.com/NixOS/nixpkgs/commit/928984152777e58c4dac6753d8fba09ee09b4d3b) python312Packages.langchain-core: 0.1.32 -> 0.1.33
* [`11e596c5`](https://github.com/NixOS/nixpkgs/commit/11e596c56d9c0e6519189aa740c60d6f571cc8ba) python311Packages.lz4: fix pname, use pep517 builder
* [`4dd692fb`](https://github.com/NixOS/nixpkgs/commit/4dd692fb1ae43b5a5effce061735e2088a9d87f0) python312Packages.protobuf: fix build
* [`a87b4307`](https://github.com/NixOS/nixpkgs/commit/a87b43072d60300ce161f7bb445394d7c0dd5e34) python312Packages.nibabel: fix tests
* [`12da7d7d`](https://github.com/NixOS/nixpkgs/commit/12da7d7d1913b83448b2cba81ed06fa63408b3ec) python312Packages.kubernetes: fix tests
* [`1cc58910`](https://github.com/NixOS/nixpkgs/commit/1cc5891098190ad7568b89ab84580e9e3ed8e406) python311Packages.pydash: test with pytest 7
* [`e4156a9b`](https://github.com/NixOS/nixpkgs/commit/e4156a9b61b9a1c95ba204417e5159889d331acf) python312Packages.ed25519: disable
* [`86fcd199`](https://github.com/NixOS/nixpkgs/commit/86fcd19953e0380435d085ca9e8fc183d1b180d6) python311Packages.palace: fix build, refactor
* [`49138150`](https://github.com/NixOS/nixpkgs/commit/4913815067f023c627d1ebab0bc0b99c8e15c119) python311Packages.taskw: fix build, use pep517 build, reformat
* [`97011cdd`](https://github.com/NixOS/nixpkgs/commit/97011cdd1c9f3c8ac713e82653447a46830eb769) python311Packages.mido: fix build, set up optional dependencies
* [`4389e321`](https://github.com/NixOS/nixpkgs/commit/4389e321d1279cdca7fdc01428cdf78fd58fcc90) python312Packages.pytest-factoryboy: 2.5.1 -> 2.6.1
* [`7dbce171`](https://github.com/NixOS/nixpkgs/commit/7dbce171d7296385b7df22d402e0bf50a49d27b3) python311Packages.python-zbar: fix build
* [`500ab0f1`](https://github.com/NixOS/nixpkgs/commit/500ab0f102001d628ac575c840534aa9017a201e) python311Packages.pynetdicom: test with pytest 7
* [`906f524a`](https://github.com/NixOS/nixpkgs/commit/906f524a9dfd099d4e12cb78a2ddc6feb631b3d9) python311Packages.psd-tools: drop pytest cov parameters
* [`afb3a233`](https://github.com/NixOS/nixpkgs/commit/afb3a23307ad261be9aceff3ac9fa60d402c8284) pretix: relax django-filter constraint
* [`107e42fe`](https://github.com/NixOS/nixpkgs/commit/107e42fe1a824bd73a628db4f7bf341a38fe5286) pretalx: relax django-filter constraint
* [`1aaa4413`](https://github.com/NixOS/nixpkgs/commit/1aaa4413765f3155455c08b948c06db232a98a28) python311Packages.betterproto: test with pytest 7
* [`34c24ad3`](https://github.com/NixOS/nixpkgs/commit/34c24ad3c178092e674fb413505d8f4ad4e85439) python311Packages.chart-studio: fix hash
* [`729d8031`](https://github.com/NixOS/nixpkgs/commit/729d8031257e18718820d0af80b048d69018f5fc) python311Packages.awswrangler: relax packaging constraint
* [`1c1182c2`](https://github.com/NixOS/nixpkgs/commit/1c1182c2e2152d60c54988942898fd292092177a) python311Packages.mlflow: relax packaging constraint
* [`ceaf99b9`](https://github.com/NixOS/nixpkgs/commit/ceaf99b977750cf1cc245cfc26784d2df91a32cc) python312Packages.logical-unification: disable failing test
* [`d23258c4`](https://github.com/NixOS/nixpkgs/commit/d23258c45d54c2e9a26bf8ec759cd5d5ffdb545c) python311Packages.dbt-core: relax pathspec constraint
* [`f76b6164`](https://github.com/NixOS/nixpkgs/commit/f76b61649553ee825db81a9aad49f768ac794263) python311Packages.nampa: test with pytest 7
* [`bfdfb547`](https://github.com/NixOS/nixpkgs/commit/bfdfb5476a5c65b10bb2d64a9948c6834386e40e) python311Packages.sparse: fix build
* [`6678c6bb`](https://github.com/NixOS/nixpkgs/commit/6678c6bb08eb607ad755509d3f894a710a117828) python311Packages.razdel: test with pytest 7
* [`6510f642`](https://github.com/NixOS/nixpkgs/commit/6510f6425912d13091138dfc24227bb9a5393090) python311Packages.shlib: fix build
* [`dccedfd9`](https://github.com/NixOS/nixpkgs/commit/dccedfd9eaf39bdfd92f3876a1c2317f2f7c2ee4) python311Packages.sqlmodel: test with pytest 7
* [`6c72529e`](https://github.com/NixOS/nixpkgs/commit/6c72529eaee3d4ee9f9595eaa975ba55960baa02) vyper: relax packaging constraint
* [`ae7d16c4`](https://github.com/NixOS/nixpkgs/commit/ae7d16c46ba277f23aaa9fa8a126319e810d3120) streamlit: relax packaging constraint
* [`44ebcb5e`](https://github.com/NixOS/nixpkgs/commit/44ebcb5ea735c651f8620a744f283dde3e933ce0) virt-manager: test with pytest 7
* [`5e66d3a5`](https://github.com/NixOS/nixpkgs/commit/5e66d3a50c5cfded493dc1718dbae5600e1577b2) python311Packages.rmscene: relax packaging constraint
* [`b879dfd1`](https://github.com/NixOS/nixpkgs/commit/b879dfd10fe62166e2f514b54d34831d8088eec6) python311Packages.woob: relax packaging constraint
* [`98d8acbc`](https://github.com/NixOS/nixpkgs/commit/98d8acbcf1e6b8c553606130112a2b20ba212bff) python312Packages.notus-scanner: relax packaging constraint
* [`d675450a`](https://github.com/NixOS/nixpkgs/commit/d675450a98141a6267c2ff1e4c0d15caddea0636) python311Packages.diffsync: relax packaging constraint
* [`bcec8bc4`](https://github.com/NixOS/nixpkgs/commit/bcec8bc401307cba004c94f8b44de52864360840) python311Packages.flet: relax packaging constraint
* [`60721565`](https://github.com/NixOS/nixpkgs/commit/607215653b1ff0bc745c4685ddc6bf4e8843d7df) onlykey-cli: don't propagate cython
* [`3ef70b3f`](https://github.com/NixOS/nixpkgs/commit/3ef70b3fcf347b09cd954d7a84c7921c38f4cb68) python311Packages.hidapi: don't propagate cython
* [`11186616`](https://github.com/NixOS/nixpkgs/commit/1118661647cec194c691fbc52da9f06d5fe33df2) gnome-extensions-cli: relax packaging constraint
* [`6575699c`](https://github.com/NixOS/nixpkgs/commit/6575699cbb0d83f30208d33eeb52d7a1f0289c27) git-up: test with pytest 7
* [`50e06243`](https://github.com/NixOS/nixpkgs/commit/50e0624367e00e058a4b749d08f66aeb49bd4372) electron-cash: don't propagate cython
* [`82d206fb`](https://github.com/NixOS/nixpkgs/commit/82d206fbb5f3b36daff73d0b29a2b12439e3122a) checkov: relax packaging constraint
* [`33dc78e7`](https://github.com/NixOS/nixpkgs/commit/33dc78e7e0138114177f637727e19a89b9e916e6) libiconv: use libiconvReal on Darwin with compat ABI
* [`4004cd45`](https://github.com/NixOS/nixpkgs/commit/4004cd4536ed4454bd81983e1ed5f1bcdaec6a93) zstd: 1.5.5 -> 1.5.6
* [`521ea079`](https://github.com/NixOS/nixpkgs/commit/521ea079b9e39d6bd66a919cb3449493d975ab6d) darwin.libiconv: remove and add to darwin-aliases
* [`d34e8544`](https://github.com/NixOS/nixpkgs/commit/d34e8544edb0fd768c945b6c1c4128843e979f14) python311Packages.smart-open: 7.0.3 -> 7.0.4
* [`0ba196c5`](https://github.com/NixOS/nixpkgs/commit/0ba196c57c178744b8abbb7dfb3312659ba4b654) python311Packages.chex: 0.1.85 -> 0.1.86
* [`7b09e8e8`](https://github.com/NixOS/nixpkgs/commit/7b09e8e8d5b2951a42e8f1eb1dbc676d02844859) python312Packages.openstep-plist: 0.3.0.post1 -> 0.3.1
* [`8616de22`](https://github.com/NixOS/nixpkgs/commit/8616de22799d4e901f98b21885c77782af83e03c) Avoid top-level `with ...;` in pkgs/development/compilers/gcc/common/meta.nix
* [`64f4bdb7`](https://github.com/NixOS/nixpkgs/commit/64f4bdb7e1133eac11bd4ec1725b677483b63540) Avoid top-level `with ...;` in pkgs/development/compilers/gcc/default.nix
* [`92a26847`](https://github.com/NixOS/nixpkgs/commit/92a268479041f2556e873ab4b05a5da1b6274e59) python312Packages.pathtools: disable
* [`0454a99b`](https://github.com/NixOS/nixpkgs/commit/0454a99b8e1cc4b68b344e94cb8a31f58424c022) liblc3: 1.0.4 -> 1.1.0
* [`2a1c9c50`](https://github.com/NixOS/nixpkgs/commit/2a1c9c5062deadc5d82755b89b2ee4d3afb7364e) miniplayer: fix build
* [`aba056a1`](https://github.com/NixOS/nixpkgs/commit/aba056a13cd6f2dc0248f115bfc5c6b545b8b2f0) ryujinx: Add udev dependency
* [`ac306ef3`](https://github.com/NixOS/nixpkgs/commit/ac306ef3360448b542625e036febf9e8157e01fe) ryujinx: 1.1.1242 → 1.1.1248
* [`18a6b20d`](https://github.com/NixOS/nixpkgs/commit/18a6b20de0c1db88cf991b3af23bc957153e514a) aws-c-common: 0.9.10 -> 0.9.14
* [`bd9bdd84`](https://github.com/NixOS/nixpkgs/commit/bd9bdd84c66df39ab54e8d42f3714762f490fa10) aws-c-io: 0.13.36 -> 0.14.6
* [`438a710d`](https://github.com/NixOS/nixpkgs/commit/438a710dbbf02f480e480dee519dcdf15e9bed2d) aws-c-http: 0.7.14 -> 0.8.1
* [`b7f5afe9`](https://github.com/NixOS/nixpkgs/commit/b7f5afe90a1fab041f968d22be0b223d37092a87) aws-c-sdkutils: 0.1.12 -> 0.1.15
* [`0cfc0b0b`](https://github.com/NixOS/nixpkgs/commit/0cfc0b0b72ffd61fa22be36e65ada801a8d1421b) aws-c-auth: 0.7.10 -> 0.7.16
* [`d6dccb1e`](https://github.com/NixOS/nixpkgs/commit/d6dccb1e97f88c8ec01fc4e766ea12690c506bc8) aws-c-mqtt: 0.9.10 -> 0.10.3
* [`4e0f3a54`](https://github.com/NixOS/nixpkgs/commit/4e0f3a5498edb3197140a37c6be6da2c17586314) aws-c-s3: 0.4.0 -> 0.5.4
* [`84e45fef`](https://github.com/NixOS/nixpkgs/commit/84e45fef1da0232122ed3abe554fff675411b04f) aws-c-event-stream: 0.3.2 -> 0.4.2
* [`735d7f98`](https://github.com/NixOS/nixpkgs/commit/735d7f982ee41dfa56010daab72caae1262f35dc) aws-crt-cpp: 0.24.7 -> 0.26.4
* [`e46643aa`](https://github.com/NixOS/nixpkgs/commit/e46643aa400ba815554d1fb9f48ce574fae8573a) aws-sdk-cpp: 1.11.207 -> 1.11.296
* [`82c3b6c0`](https://github.com/NixOS/nixpkgs/commit/82c3b6c06bb1eb1be41c7e9c5cdec20b7eba1e59) python3Packages.gevent: avoid use of vendored libraries
* [`49521230`](https://github.com/NixOS/nixpkgs/commit/495212307ee5eee425325be3111ef02e6b816827) espflash: fix build on darwin
* [`d31a6d78`](https://github.com/NixOS/nixpkgs/commit/d31a6d78c21d53549b57ea3404803e034639c5af) fluidsynth: 2.3.4 -> 2.3.5
* [`e7246dee`](https://github.com/NixOS/nixpkgs/commit/e7246dee1edf80f21ae48a6a0292f63d37428e2e) python312Packages.xlsxwriter: 3.1.9 -> 3.2.0
* [`e7231a24`](https://github.com/NixOS/nixpkgs/commit/e7231a2475db44dcfe2e8463ce29e36a52f0ae9c) python312Packages.xlsxwriter: refactor
* [`71a67fc4`](https://github.com/NixOS/nixpkgs/commit/71a67fc4a839781d5895033fe5db43bb945264f1) libiconv: use --replace-fail instead of --replace
* [`8d312206`](https://github.com/NixOS/nixpkgs/commit/8d312206a8a0b570792f8d1d858254c35e29f857) python3Packages.rustworkx: 0.13.1 -> 0.14.2
* [`56d5b181`](https://github.com/NixOS/nixpkgs/commit/56d5b181c9f2bf748a44526f4db9861524e1dbb2) resholve: 0.9.1 -> 0.10.2, ongoing cross fixes
* [`6cf9a893`](https://github.com/NixOS/nixpkgs/commit/6cf9a8930a0f16ab1e0f5e88d3b1e1ab4baaeeef) xdg-utils: override lore for perl
* [`26154be2`](https://github.com/NixOS/nixpkgs/commit/26154be2779fbe3f8cd9b8903710ecc8a86c9dd1) linux-pam: pull upstream fix to restore empty password handling
* [`2573f2c4`](https://github.com/NixOS/nixpkgs/commit/2573f2c44a604d24bed51772eea68c5a52d292d1) darwin.apple_sdk_10_12: add Libsystem
* [`79db5b64`](https://github.com/NixOS/nixpkgs/commit/79db5b641e3b3269a1a1da38740e0eba64988e80) darwin.apple_sdk_10_12: add objc4
* [`39a5f4a6`](https://github.com/NixOS/nixpkgs/commit/39a5f4a6eea916a919c5e39d01beeb650d76c11c) darwin.apple_sdk.sdkRoot: init at 10.12 and 11.0
* [`017eda24`](https://github.com/NixOS/nixpkgs/commit/017eda24aebe8302f32f213df52d0ebeff9973f6) darwin.stdenv: use wrapBintoolsWith instead of a direct import
* [`1f231173`](https://github.com/NixOS/nixpkgs/commit/1f231173a5897d030fbd01c31741d0e885dba0fe) darwin.stdenv: drop curl from assertions
* [`f61e189a`](https://github.com/NixOS/nixpkgs/commit/f61e189ad369d873d247a6db01370732b4f6bf39) overrideSDK: support all deps attributes
* [`71c6ee92`](https://github.com/NixOS/nixpkgs/commit/71c6ee929561c149c81f3511697b1d43c6fbb1d8) darwin.stdenv: add sdkRoot to extraNativeBuildInputs
* [`6b44d9d6`](https://github.com/NixOS/nixpkgs/commit/6b44d9d62d315818ca399b9fd94979410ba2a697) Revert "stdenv.darwin: bootstrap darwin using updated tools"
* [`2970d6ef`](https://github.com/NixOS/nixpkgs/commit/2970d6ef5f313031e1e2976596ddbabc1449f674) lilypond-unstable: 2.25.13 -> 2.25.14
* [`1c614c0e`](https://github.com/NixOS/nixpkgs/commit/1c614c0e19fc9c44fb224f4729d7c0df064cf83d) python312Packages.periodiq: Relax pendulum dependency
* [`632c46f0`](https://github.com/NixOS/nixpkgs/commit/632c46f07bcee96895070b5c465789d96a54ef08) valeStyles: init
* [`c3be03ad`](https://github.com/NixOS/nixpkgs/commit/c3be03ad44d9d54c8aab051c19d439e78319da2f) vale: deprecate the data output
* [`557c36bd`](https://github.com/NixOS/nixpkgs/commit/557c36bdbaf73659a7feb53c059ebd4f36f315e0) harfbuzz: 8.3.1 -> 8.4.0
* [`fdd354f1`](https://github.com/NixOS/nixpkgs/commit/fdd354f1974b713046c02b8f0ec739e9fd4708f0) libopenmpt: 0.7.4 -> 0.7.6
* [`089a4fc5`](https://github.com/NixOS/nixpkgs/commit/089a4fc5a20ba495776227b1e983cce46108523e) memcached: 1.6.24 -> 1.6.26
* [`3488e374`](https://github.com/NixOS/nixpkgs/commit/3488e3741973030f7525188c0192a4b7d369b598) ell: 0.63 -> 0.64
* [`72a89d12`](https://github.com/NixOS/nixpkgs/commit/72a89d124337d0567d68074dce860824fb41f31c) borgbackup: 1.2.7 -> 1.2.8
* [`cc2adde5`](https://github.com/NixOS/nixpkgs/commit/cc2adde5315640763dd3507f08672d8a8f462c88) borgbackup: modernize
* [`34836ba5`](https://github.com/NixOS/nixpkgs/commit/34836ba568b55e15a93767816a728e9d4d91b50f) coreutils: 9.4 -> 9.5
* [`60963ed2`](https://github.com/NixOS/nixpkgs/commit/60963ed2fe4303ba34131de1127b6b0e36eb6369) waycheck: 1.1.1 -> 1.2.0
* [`c321e9d0`](https://github.com/NixOS/nixpkgs/commit/c321e9d0e7e5a6877306e7e9f8b00af34da4287f) soundtouch: 2.3.2 -> 2.3.3
* [`dd2c6f18`](https://github.com/NixOS/nixpkgs/commit/dd2c6f1840ff3919e5bbf1943d0f6995c5812bfd) nixos/sunshine: init
* [`c44ca352`](https://github.com/NixOS/nixpkgs/commit/c44ca352868d7c9e8ce5b1b90d7df28a28643be6) sunshine: add NixOS test
* [`426ed128`](https://github.com/NixOS/nixpkgs/commit/426ed12890ff62a1ecb600d1104a8f3dc33ee845) jasper: 4.2.2 -> 4.2.3
* [`0ac77691`](https://github.com/NixOS/nixpkgs/commit/0ac77691c9db9a1e55340eb1f0cc2f8e70d4e201) iwd: 2.16 -> 2.17
* [`55b4583c`](https://github.com/NixOS/nixpkgs/commit/55b4583c4ff04f69258c84207bcaae77c6a4c85a) orca-slicer: 1.9.1 -> 2.0.0
* [`319f05e7`](https://github.com/NixOS/nixpkgs/commit/319f05e7db9e84302557f1279f4d68a707932e1d) libjxl: build gdk-pixbuf loader and thumbnailer
* [`45e1a531`](https://github.com/NixOS/nixpkgs/commit/45e1a531c1596efd7bf7df8fbf3095b5467df822) libical: 3.0.17 -> 3.0.18
* [`a426aa3a`](https://github.com/NixOS/nixpkgs/commit/a426aa3a3fbfdcf56f4acfd5f29d81d1594cc8e6) Revert "darwin.libiconv: remove and add to darwin-aliases"
* [`b5ba0bd8`](https://github.com/NixOS/nixpkgs/commit/b5ba0bd88274b98d9c525a1f4fc8bcef20812933) Revert "libiconv: use libiconvReal on Darwin with compat ABI"
* [`593ff6a0`](https://github.com/NixOS/nixpkgs/commit/593ff6a0ee5a9dbe40e991f21dd9909f2a811a77) python311Packages.pillow-jpls: remove unused inputs
* [`5698a2c1`](https://github.com/NixOS/nixpkgs/commit/5698a2c158f1f193c05d895d7c3b806492b8cfef) python311Packages.ome-zarr: remove unused inputs
* [`52e00e33`](https://github.com/NixOS/nixpkgs/commit/52e00e33f32fcc819d5f2af19044107dfdde3e25) python311Packages.batchgenerators: remove unused inputs
* [`707fdaa8`](https://github.com/NixOS/nixpkgs/commit/707fdaa869f3caacd3733f2ed411f0e8c5bba164) python311Packages.tensorly: remove unused inputs
* [`c4ee05df`](https://github.com/NixOS/nixpkgs/commit/c4ee05df25a4a93e42e20c7702b4c4add480754f) python311Packages.monai-deploy: remove unused inputs
* [`ed414c2c`](https://github.com/NixOS/nixpkgs/commit/ed414c2ce25a1483c4b7951f9cbd11ffa14a6bc7) python311Packages.evaluate: remove unused inputs
* [`1efaa4eb`](https://github.com/NixOS/nixpkgs/commit/1efaa4eba6506fdec9c40d5655e5df471d2f64ad) python311Packages.templateflow: remove unused inputs
* [`60b90af1`](https://github.com/NixOS/nixpkgs/commit/60b90af1b78a40da1d9c2ef89f7c229a3eabfc74) python311Packages.pyorthanc: remove unused inputs
* [`272aacc1`](https://github.com/NixOS/nixpkgs/commit/272aacc19d65811032768d2899015b89dd9ccd17) openexr_3: 3.2.2 -> 3.2.4
* [`b5f1bca2`](https://github.com/NixOS/nixpkgs/commit/b5f1bca2813a98bcb9e06580dbd45c7e916498fb) pcre2: backport jit auto-detection
* [`12149046`](https://github.com/NixOS/nixpkgs/commit/121490461b1c4228bdb2e315e77c1e14a57dc653) nixos/inadyn: init
* [`1a88442d`](https://github.com/NixOS/nixpkgs/commit/1a88442d4a62c90601a726f3b393de2901a02d9c) python3Packages.bubop: init at 0.1.12
* [`7b6853a7`](https://github.com/NixOS/nixpkgs/commit/7b6853a779a1601f66ae5948c203f1f466b23449) python3Packages.item-synchronizer: init at 1.1.5
* [`0bde7713`](https://github.com/NixOS/nixpkgs/commit/0bde771323267667ec2e31f3943e126e53297ede) taskw-ng: init at 0.2.6
* [`f535df51`](https://github.com/NixOS/nixpkgs/commit/f535df51b9263d5053488b1cf42fceb3c31f8db9) syncall: init at 1.8.5
* [`4f911a72`](https://github.com/NixOS/nixpkgs/commit/4f911a72471aaeabad41f5c1f3d30ac4f43672af) `Libsystem`: fix broken `postFetch` step in  `darling.src`
* [`50063d79`](https://github.com/NixOS/nixpkgs/commit/50063d79d511224465319493c8f149da0d149238) slock: add updateScript
* [`399c65ac`](https://github.com/NixOS/nixpkgs/commit/399c65ac8159cb76e9d4cd97f5f0651fed1add00) slock: add qusic to maintainers
* [`c4e06020`](https://github.com/NixOS/nixpkgs/commit/c4e06020b4a49db2ddcfb5c741c1e6581610ea6c) antares: init at 0.7.22
* [`1287b64d`](https://github.com/NixOS/nixpkgs/commit/1287b64ddedad99eebccff5bfd4585cd76f2321b) libarchive: pull the fix for a suspicious commit
* [`7d63c774`](https://github.com/NixOS/nixpkgs/commit/7d63c7740545dc0eefb8348c273240877ad24b94) ruby: improve failure message when missing cargoHash
* [`24f6dc16`](https://github.com/NixOS/nixpkgs/commit/24f6dc164f475c385e1c4c82f643caef3135c7f5) libbpf: 1.3.0 -> 1.4.0
* [`923ebca2`](https://github.com/NixOS/nixpkgs/commit/923ebca2480107027d4ed39532bb7b62318c1144) SDL2: 2.30.1 -> 2.30.2
* [`b8be0164`](https://github.com/NixOS/nixpkgs/commit/b8be0164260e61c1859d12b5d973c0f3f67d379c) lua.tests.checkSetupHook: test lua setup hook for http package
* [`c55b4dbc`](https://github.com/NixOS/nixpkgs/commit/c55b4dbcd2af7ff8065ee4fece2c8793427ec88b) lua: fix setup-hook *.lua matching
* [`2e4e6618`](https://github.com/NixOS/nixpkgs/commit/2e4e6618cb8695b42c8cc63d0facb4b8f459017b) curl: 8.6.0 -> 8.7.1
* [`413f779b`](https://github.com/NixOS/nixpkgs/commit/413f779bc048b5daf3267ff86a6ff38712774148) nixos/udev: don't create modprobe config if modprobe is disabled
* [`4677729c`](https://github.com/NixOS/nixpkgs/commit/4677729c56baa64814a0e0cff4cf999cf543e343) nixos/udev: only load firmware from udev when the nixos kernel is used
* [`54fd2bb7`](https://github.com/NixOS/nixpkgs/commit/54fd2bb7729ca64f53d0e580ec4d47e3e1428bd8) librsvg: 2.57.92 -> 2.58.0
* [`eb4b8635`](https://github.com/NixOS/nixpkgs/commit/eb4b86353dc7fa6d58df8aa6bd698eb029279fa8) refind: fix typo: compatbile to compatible
* [`269a99d6`](https://github.com/NixOS/nixpkgs/commit/269a99d6b87916ceab49f90793389c3838ddfb4f) postgresqlPackages.citus: fix typo: compatibilty to compatibility
* [`6e6d0b86`](https://github.com/NixOS/nixpkgs/commit/6e6d0b869a46e57edb3be550236772d3108e21ce) eza: fix typo: compatibilty to compatibility
* [`4b2e46dd`](https://github.com/NixOS/nixpkgs/commit/4b2e46dd39d87bd20ac67e85f8075d4ce86ca883) lib.fileset: fix typo: compatibity to compatibility
* [`a4bed8f2`](https://github.com/NixOS/nixpkgs/commit/a4bed8f2e08b46d8f8e5e00d339a2a20a9411434) pkgs/top-level/config.nix: fix typo: compatibity to compatibility
* [`25f91c20`](https://github.com/NixOS/nixpkgs/commit/25f91c20b65250fe34951c768d13941df862d130) formats.hocon: fix typo: compatability to compatibility
* [`0c73cbb6`](https://github.com/NixOS/nixpkgs/commit/0c73cbb6f018178cd0642d3f1f652d451c678859) libdispatch: fix typo: compatability to compatibility
* [`562b2c58`](https://github.com/NixOS/nixpkgs/commit/562b2c589671f4b4ddfea5789471bf4ba6f43380) postgresqlPackages.pg_bigm: fix typo: compatiblity to compatibility
* [`c9c67a96`](https://github.com/NixOS/nixpkgs/commit/c9c67a961be2595f6dfd288cc466494179b6a80e) zoom: fix typo: compatiblity to compatibility
* [`1c242513`](https://github.com/NixOS/nixpkgs/commit/1c242513a001bdd8f35b02db13b8c80e726836c3) gnat-bootstrap: gate elfutils on package availability rather than isLinux
* [`b80a7bb5`](https://github.com/NixOS/nixpkgs/commit/b80a7bb5a648c5ae34bdad44a86017c9c470049b) qt6.qtmultimedia: gate elfutils on package availability rather than isLinux
* [`61815c17`](https://github.com/NixOS/nixpkgs/commit/61815c17d97ec71597a44aa50ed7f584bb85b90f) opencpn: gate elfutils on package availability rather than isLinux
* [`bb8c1316`](https://github.com/NixOS/nixpkgs/commit/bb8c13160e80e274508aff2bfffc8be20bdcd506) nvc: gate elfutils on package availability rather than isLinux
* [`5996ad01`](https://github.com/NixOS/nixpkgs/commit/5996ad015bb5b2658d57f1f04a23e2149536351d) gstreamer: gate elfutils on package availability rather than isLinux
* [`b5ea844d`](https://github.com/NixOS/nixpkgs/commit/b5ea844d0dfb1a7c26cd98b060dd1ade0f4c9a4e) mesa: gate elfutils on package availability rather than isLinux
* [`61990ae1`](https://github.com/NixOS/nixpkgs/commit/61990ae11dbfeacbab9ab2809a38432255d324fd) rpm: gate elfutils on package availability rather than isLinux
* [`8dab62f6`](https://github.com/NixOS/nixpkgs/commit/8dab62f640018f77e9512a47e3355c81a7cce842) nodejs_20: 20.12.0 -> 20.12.1
* [`c1f34f55`](https://github.com/NixOS/nixpkgs/commit/c1f34f5558723697d66a705b39b898f5ae807e24) libsamplerate: Fix build on Darwin
* [`f45c76b5`](https://github.com/NixOS/nixpkgs/commit/f45c76b5c5eae3ae50a2c7484f0fad8edba500a5) x264: unstable-2021-06-13 -> 0-unstable-2023-10-01
* [`d60c9c66`](https://github.com/NixOS/nixpkgs/commit/d60c9c6671c157cb3f4ae73128750b7171c51e77) python311Packages.sphinx: disable flaky test
* [`243a3db9`](https://github.com/NixOS/nixpkgs/commit/243a3db9c90e722bd2db1a480f8c1ca8060a28b3) bcc: 0.29.1 -> 0.30.0
* [`1e7ef10e`](https://github.com/NixOS/nixpkgs/commit/1e7ef10e847a440b131c4ca6bee51377ee34747b) s2n-tls: 1.4.8 -> 1.4.9
* [`96da6f53`](https://github.com/NixOS/nixpkgs/commit/96da6f53e02e8ac7fc5136461429a742db5550db) tetrio-desktop: use nixpkgs electron
* [`65b9c406`](https://github.com/NixOS/nixpkgs/commit/65b9c406397dc9bb0b24428ddc28ed7a251e858f) rocmPackages_5.mivisionx: patch libjpeg-turbo
* [`c3157ea4`](https://github.com/NixOS/nixpkgs/commit/c3157ea4aa805d04e12301bc79c17996f0181152) rocmPackages_5.mivisionx: add __STDC_CONSTANT_MACROS to fix build
* [`91319cde`](https://github.com/NixOS/nixpkgs/commit/91319cde130a511aa6eb3794aa52d409b5f86079) rocmPackages_6.mivisionx: patch libjpeg-turbo
* [`48b253cf`](https://github.com/NixOS/nixpkgs/commit/48b253cf6e5e843b239c3858e52cab3eb21db8e3) rocmPackages_6.mivisionx: add __STDC_CONSTANT_MACROS
* [`4ffd610a`](https://github.com/NixOS/nixpkgs/commit/4ffd610a37ca4f243700e6708f00ef392acfae51) rocmPackages_6.mivisionx: remove duplicate patches
* [`6ef0689a`](https://github.com/NixOS/nixpkgs/commit/6ef0689a2d2f76a78f1081b159ffda079c3daa64) ternimal: init at 0.1.0-unstable-2017-12-31
* [`abeb34f6`](https://github.com/NixOS/nixpkgs/commit/abeb34f68372916f951088849f0996246e758a7f) go_1_22: 1.22.1 -> 1.22.2
* [`1eb26d41`](https://github.com/NixOS/nixpkgs/commit/1eb26d4140323bf7505a1782c3b8695c264b64da) nixos/firewall-nftables: allow adding additional rules to the rpfilter chain
* [`5e67bf7b`](https://github.com/NixOS/nixpkgs/commit/5e67bf7b5e83567503ba34d0e8a8a70a644c5eb6) hwdata: 0.380 -> 0.381
* [`2dd8d20e`](https://github.com/NixOS/nixpkgs/commit/2dd8d20e3f855737ec65fcdc43caa1f26a067e0f) nghttp2: 1.60.0 -> 1.61.0
* [`bf6eeb31`](https://github.com/NixOS/nixpkgs/commit/bf6eeb31e8d090b20d7ed8bb8dd3286a397b4d69) luneta: init at 0.7.4
* [`80592f5b`](https://github.com/NixOS/nixpkgs/commit/80592f5bcd620d6f6263f3776627d2cd14d6072c) Revert "fixup! knot-resolver: temporarily make it pass"
* [`d6f46ee3`](https://github.com/NixOS/nixpkgs/commit/d6f46ee34e62a5dfff79a9e94f034df322423e42) Revert "knot-resolver: temporarily make it pass"
* [`643f047f`](https://github.com/NixOS/nixpkgs/commit/643f047f5a0094cb040bb229a9ba8ef207674474) unbound: 1.19.2 -> 1.19.3
* [`6083fb0a`](https://github.com/NixOS/nixpkgs/commit/6083fb0a158607ce76c1cc0849e89eb35d66cfa7) cmake: 3.29.0 -> 3.29.1
* [`c926d1d9`](https://github.com/NixOS/nixpkgs/commit/c926d1d9294a01aae1914bfd5b440cedbe933035) ocamlPackages.ppx_blob: 0.7.2 -> 0.8.0
* [`243c22a6`](https://github.com/NixOS/nixpkgs/commit/243c22a6cedf1e26f73585c3e67bd22ff9ff901b) python311Packages.ansible-pylibssh: fix eval
* [`b760e193`](https://github.com/NixOS/nixpkgs/commit/b760e1937c5c330a70b912f5648c2bcd676e3bd1) kexec-tools: 2.0.26 -> 2.0.28
* [`642a1dd4`](https://github.com/NixOS/nixpkgs/commit/642a1dd450a241a8a9a12c1740ee0aadb76c034e) fcast-receiver: init at 1.0.14
* [`6995f312`](https://github.com/NixOS/nixpkgs/commit/6995f312291a1d998b287dffce3616e3ac022baa) ovn: fix update script
* [`ef2e0986`](https://github.com/NixOS/nixpkgs/commit/ef2e0986dd4b218edfdd1e684af0f27b0844943e) ovn: 23.09.1 -> 24.03.1
* [`cc554b24`](https://github.com/NixOS/nixpkgs/commit/cc554b249fea794e29a01ec317399c37f452ffd3) ovn-lts: 22.03.5 -> 22.03.7
* [`7dd39270`](https://github.com/NixOS/nixpkgs/commit/7dd3927034cb7625a45a531279830e2b7479b2fa) ovn/ovn-lts: disable tests
* [`7bdb28f3`](https://github.com/NixOS/nixpkgs/commit/7bdb28f3554dfb3000e5e81be9d3df33c622c1c3) feat: bump scalafix to 12.0
* [`48520951`](https://github.com/NixOS/nixpkgs/commit/4852095139df567fe439270420b571fe35516e02) tree-sitter: embed path to `emcc` so `tree-sitter build --wasm` works
* [`3e9e7d09`](https://github.com/NixOS/nixpkgs/commit/3e9e7d092f59234b45b1fa42d09f16bbbd7addb9) tetrio-desktop: re-add tetrio-plus, now from source
* [`e79b3963`](https://github.com/NixOS/nixpkgs/commit/e79b396303c55e905922654d2333d9fe95a70a3a) catppuccin-sddm-corners: unstable-2023-02-17 -> unstable-2023-05-30
* [`ed0c2371`](https://github.com/NixOS/nixpkgs/commit/ed0c2371a111791f347bb962be8a6760d6a3dda9) catppuccin-sddm-corners: add qt dependencies
* [`ca8bf15d`](https://github.com/NixOS/nixpkgs/commit/ca8bf15da92a0165278f27236270e356857102aa) uclibc-ng: 1.0.45 -> 1.0.47
* [`f11d3508`](https://github.com/NixOS/nixpkgs/commit/f11d350852721e4d4d5b56499b25f8d3158b22c9) uclibc-ng: add passthru.updateScript
* [`868b1800`](https://github.com/NixOS/nixpkgs/commit/868b1800300885bf11224b0d20b84258787ce19f) python3Packages.proton-vpn-killswitch: 0.2.0-unstable-2023-09-05 -> 0.4.0
* [`e3466f56`](https://github.com/NixOS/nixpkgs/commit/e3466f56e1fe5121c8fb5cc1c6207f4a6b26c7a7) samba: add meta.pkgConfigModules, passthru.tests.{pkg-config,version}
* [`598b8843`](https://github.com/NixOS/nixpkgs/commit/598b8843f5163166075a05f5198c9ca7c1eb015d) ldb: add meta.pkgConfigModules, passthru.tests.pkg-config
* [`05dedd38`](https://github.com/NixOS/nixpkgs/commit/05dedd387f3e8f40f1e9470a1eab51d67aea4ce7) python3Packages.onnxruntime: fix build with cudaSupport
* [`9996f284`](https://github.com/NixOS/nixpkgs/commit/9996f28455e6578904d699fcfeb66e1256696b83) nixpkgs-hammering: add passthru.updateScript
* [`ac0cdeb1`](https://github.com/NixOS/nixpkgs/commit/ac0cdeb10c961bf0453a5283be0936201a81178f) nixpkgs-hammering: unstable-2023-11-06 -> unstable-2024-03-25
* [`93fbdd30`](https://github.com/NixOS/nixpkgs/commit/93fbdd30ad3c28f2884d8a0e705406e773f5176f) mesa: 24.0.3 -> 24.0.4
* [`3569a115`](https://github.com/NixOS/nixpkgs/commit/3569a1158f38ac75f1ee2465b108bc577dca314b) python311Packages.pybind11: 2.11.1 -> 2.12.0
* [`11d0dfa2`](https://github.com/NixOS/nixpkgs/commit/11d0dfa2743c58f17b885f59425bc0130f2799f8) python311Packages.scipy: 1.12.0 -> 1.13.0
* [`966afdd1`](https://github.com/NixOS/nixpkgs/commit/966afdd1a25ef0cb6feebb6fbfe138922e4b8b2c) pciutils: 3.11.1 -> 3.12.0
* [`46544475`](https://github.com/NixOS/nixpkgs/commit/46544475f629e2bac801b3735b47a18fa277a021) nasm: 2.16.01 -> 2.16.02
* [`f23aacbd`](https://github.com/NixOS/nixpkgs/commit/f23aacbd5f69186c4e5b362d2943704485d89b9c) mtdev: 1.1.6 -> 1.1.7
* [`d1001631`](https://github.com/NixOS/nixpkgs/commit/d1001631bc1aa6fb9afe257c681100669cc75956) bash-completion: 2.11 -> 2.13.0
* [`ef69d712`](https://github.com/NixOS/nixpkgs/commit/ef69d7129c702e86dfbdca42682f98d40e40e498) mpg123: 1.32.5 -> 1.32.6
* [`8efea342`](https://github.com/NixOS/nixpkgs/commit/8efea342ea7aa0da8e65f137594041243b810a1f) man: 2.12.0 -> 2.12.1
* [`64d67e6b`](https://github.com/NixOS/nixpkgs/commit/64d67e6b52caf0f38729b95329b6aeadb7f2ebf8) maintainers: add dylan-gonzalez
* [`dbb47840`](https://github.com/NixOS/nixpkgs/commit/dbb47840223d249d0e8c2da5977f08b67ddc6aa0) tcsh: 6.24.11 -> 6.24.12
* [`2433c1b4`](https://github.com/NixOS/nixpkgs/commit/2433c1b4b7aaa584bd5c2acee1e24add17d935c1) twingate: 2024.63.115357 -> 2024.98.119333
* [`6a327a48`](https://github.com/NixOS/nixpkgs/commit/6a327a489c62222f02a0ad65f768e30dcc2718f1) python311Packages.ipython: 8.22.2 -> 8.23.0
* [`6ea5b5f2`](https://github.com/NixOS/nixpkgs/commit/6ea5b5f2c55759ed8df79931912c8a01d86cbc5c) rustls-ffi: temporarily drop passthru.tests.curl
* [`8e7f7b4f`](https://github.com/NixOS/nixpkgs/commit/8e7f7b4fa06751ae42c9daa728a7de9d818aa479) stdenv.darwin: bootstrap darwin using updated tools
* [`f318c22b`](https://github.com/NixOS/nixpkgs/commit/f318c22bbe648729d0a9adf26bd9d387f1fb42b2) pdfmm: fix build on (at least) macOS
* [`2cf2146e`](https://github.com/NixOS/nixpkgs/commit/2cf2146e6493a6e0756d27eb0736a532a0d4f85c) supermodel: init at 0-unstable-2024-04-05
* [`0ca89abf`](https://github.com/NixOS/nixpkgs/commit/0ca89abf6a8addee13c943791e8db3e083d055c8) liberation-circuit: general cleanup
* [`f68451b1`](https://github.com/NixOS/nixpkgs/commit/f68451b18ada0d77fc772b09a0f28f244d2289b7) liberation-circuit: fix wrapper for non-gnome environments
* [`5d721fa7`](https://github.com/NixOS/nixpkgs/commit/5d721fa700d46261a951306413183f9404f9ba82) rpm-ostree: 2023.7 -> 2024.4
* [`73efb6e7`](https://github.com/NixOS/nixpkgs/commit/73efb6e71905b94e84fff46109df5a99dedffd2e) maintainers: add id3v1669
* [`31476f44`](https://github.com/NixOS/nixpkgs/commit/31476f448651e1f149dfd025009e66f447eab03b) wayshot: 1.3.0 -> 1.3.1
* [`0def3203`](https://github.com/NixOS/nixpkgs/commit/0def320369b49a9adb5e1ca98f0609a7c55a0de8) maestral-qt: use qt6Packages.callPackage
* [`9d42d7b6`](https://github.com/NixOS/nixpkgs/commit/9d42d7b64574bba8ca82ab511f050056f534106a) exiftool: 12.80 -> 12.82
* [`cafa7d14`](https://github.com/NixOS/nixpkgs/commit/cafa7d144345106e9ffad5c944589885e0200217) sngrep: 1.8.0 -> 1.8.1
* [`c0b692fb`](https://github.com/NixOS/nixpkgs/commit/c0b692fbb97b98641dfa7e5dc2cc806a0bf39525) sniffnet: 1.2.2 -> 1.3.0
* [`9b12bba0`](https://github.com/NixOS/nixpkgs/commit/9b12bba047464dcf3a566624468cc31405cd056c) kernelPatches.rust_1_77-6_8,kernelPatches.rust_1_77-6_9: init
* [`9bbc57f5`](https://github.com/NixOS/nixpkgs/commit/9bbc57f5a1c56ae3a11c2badbd07a0116a493a34) cargo,clippy,rustc,rustfmt: 1.76.0 -> 1.77.1
* [`92565406`](https://github.com/NixOS/nixpkgs/commit/925654065dbcb64f6158e9f93c6cde4f1fe609e0) semgrep: 1.66.2 -> 1.67.0
* [`375b4e2f`](https://github.com/NixOS/nixpkgs/commit/375b4e2f8e7ff216bf3d613ea74ff7f426b4bffe) nasin-nanpa: 2.5.1 -> 3.1.0
* [`36625172`](https://github.com/NixOS/nixpkgs/commit/366251726eff7eb3473186ac9eed671c254687b0) node-problem-detector: 0.8.16 -> 0.8.18
* [`9d05397e`](https://github.com/NixOS/nixpkgs/commit/9d05397e502674799ad3a983fcd19e5763940d39) soundmodem: add desktop item
* [`a172aaec`](https://github.com/NixOS/nixpkgs/commit/a172aaec9b12473ffb6c4596dec1fd964538d62c) nixos/soundmodem: init
* [`98f0fb13`](https://github.com/NixOS/nixpkgs/commit/98f0fb13adaaca42450b30e0c0ac1cdf3669c16b) python311Packages.pytest-spec: fix version name
* [`b851b1c6`](https://github.com/NixOS/nixpkgs/commit/b851b1c68fd1de2f4daeff0b8bd7d2f23932872b) python311Packages.pytest-spec: format, remove unused, use new names
* [`c4f3df41`](https://github.com/NixOS/nixpkgs/commit/c4f3df41de0520fc64cf77a2e52a883c8d6c4d37) jellyfin-ffmpeg: 6.0.1-3 -> 6.0.1-5
* [`a0b2df00`](https://github.com/NixOS/nixpkgs/commit/a0b2df0017df62ffc1209f773dffe90fe401012e) upower: 1.90.2 -> 1.90.4
* [`f9c070a0`](https://github.com/NixOS/nixpkgs/commit/f9c070a07e2e95f615e2a7bfcb00f1cc66153c23) bitwarden-cli: 2024.2.1 -> 2024.3.1
* [`c3083158`](https://github.com/NixOS/nixpkgs/commit/c3083158d345e24e6d96b292603e8f4c248af613) inochi-creator: init at 0.8.4, inochi-session: init at 0.8.3
* [`89f6f01a`](https://github.com/NixOS/nixpkgs/commit/89f6f01a7ee351783f2a597e9d04e0ed19b5f678) mpris-notifier: init at 0.1.7
* [`67f3c384`](https://github.com/NixOS/nixpkgs/commit/67f3c384bc1c2f1e0293c7e231022e6cd0b01d3f) rivalcfg: 4.12.0 -> 4.13.0
* [`39da9ccb`](https://github.com/NixOS/nixpkgs/commit/39da9ccb498d8c8a526e706f0c548e6fd5a8d1df) geoipupdate: 6.1.0 -> 7.0.1
* [`a935b194`](https://github.com/NixOS/nixpkgs/commit/a935b1941910eec4f3b896f6a61ec7d246197360) istioctl: 1.21.0 -> 1.21.1
* [`1bbd8501`](https://github.com/NixOS/nixpkgs/commit/1bbd8501ee01d307a1fbb76376d0d59d573ae234) use finalAttrs instead of rec
* [`0e16431e`](https://github.com/NixOS/nixpkgs/commit/0e16431ee301709c73ade9eebda68d400a17d723) obs-studio-plugins.advanced-scene-switcher: 1.25.3 -> 1.25.4
* [`dd1b905a`](https://github.com/NixOS/nixpkgs/commit/dd1b905af696491081b4b9f28ff807964872b96f) level-zero: 1.16.11 -> 1.16.14
* [`b9837788`](https://github.com/NixOS/nixpkgs/commit/b983778816e2652cba78ec714f2d19e3d25e0c61) mongodb-compass: 1.42.3 -> 1.42.5
* [`287b462f`](https://github.com/NixOS/nixpkgs/commit/287b462f856656bc5115e2fde137ef794a2995c8) sosreport: 4.7.0 -> 4.7.1
* [`6bbb71e0`](https://github.com/NixOS/nixpkgs/commit/6bbb71e0cb6e8f936516b522499594e21a726c04) meson: fix cross-compilation of rust proc-macro
* [`fff76295`](https://github.com/NixOS/nixpkgs/commit/fff7629541923b29b99db1f0c1c305582ac28784) python312Packages.psd-tools: fix eval
* [`f5b40ab6`](https://github.com/NixOS/nixpkgs/commit/f5b40ab6b5b3c986a055e18813d0e32219eb6092) podman: 4.9.3 -> 5.0.1
* [`b5e2755a`](https://github.com/NixOS/nixpkgs/commit/b5e2755a2948e5210165fe9c3a8aaf11e526a729) abseil-cpp_202401: 20240116.1 -> 20240116.2
* [`f89c670a`](https://github.com/NixOS/nixpkgs/commit/f89c670a01ba9b5e2c29c2f692fd654dfab686b5) asusctl: 5.0.7 -> 5.0.10
* [`3dcf7c5c`](https://github.com/NixOS/nixpkgs/commit/3dcf7c5c245dad0eab734da16e873b45a9555d45) linuxPackages.mwprocapture: 1.3.0.4373 -> 1.3.0.4390
* [`e797b7fd`](https://github.com/NixOS/nixpkgs/commit/e797b7fd3b0820f1db02df6911249fa5b6ef5825) renderdoc: 1.31 -> 1.32
* [`5e32dc21`](https://github.com/NixOS/nixpkgs/commit/5e32dc21242d55078aea30faa233f730f718986c) pgroll: init at 0.5.0
* [`e7175bb7`](https://github.com/NixOS/nixpkgs/commit/e7175bb727accdab6105f2b08bfa4735af537f91) python311Packages.py-partiql-parser: 0.5.1 -> 0.5.4
* [`f0eac23a`](https://github.com/NixOS/nixpkgs/commit/f0eac23a1c9f168798818321b61dedcc7e906fae) python311Packages.moto: 5.0.3 -> 5.0.5
* [`0fb5cc00`](https://github.com/NixOS/nixpkgs/commit/0fb5cc0053599bfd54dcd95e21a848df996644a5) pgroll: init at 0.5.0
* [`dc040be6`](https://github.com/NixOS/nixpkgs/commit/dc040be6f8f48e460754da2f72679da455c3044e) tridactyl-native: 0.3.7 -> 0.4.1
* [`644341b1`](https://github.com/NixOS/nixpkgs/commit/644341b1de6facb1bbe64e6cd489e6679c57d4b7) Add myself as maintainer
* [`86225575`](https://github.com/NixOS/nixpkgs/commit/86225575c0d07ba8428ca23e2b2f88d9298b196c) frp: 0.56.0 -> 0.57.0
* [`bd0b014e`](https://github.com/NixOS/nixpkgs/commit/bd0b014e47398ff2313d9ff34c952875d902c7aa) fuc: 2.0.0 -> 2.1.0
* [`b3781c38`](https://github.com/NixOS/nixpkgs/commit/b3781c38182459cc5bad4c2a2c6aa7fc5d352083) go-task: 3.35.1 -> 3.36.0
* [`ebf91c6f`](https://github.com/NixOS/nixpkgs/commit/ebf91c6fb5ddba041ad04c5d03660da629f43491) wasmedge: unpin llvmPackages_12
* [`5e221931`](https://github.com/NixOS/nixpkgs/commit/5e221931a44bcf95b36076002dbdbaf902a01d25) rosa: set passthru.updateScript to nix-update-script
* [`125d7728`](https://github.com/NixOS/nixpkgs/commit/125d7728432b50ba34e49ce13f4a0e045748669f) pingtunnel: init at 2.8
* [`84b92fff`](https://github.com/NixOS/nixpkgs/commit/84b92fff91010912ef1b053abe9d502fedf831c1) dnscontrol: 4.8.2 -> 4.9.0
* [`d44e3ce2`](https://github.com/NixOS/nixpkgs/commit/d44e3ce231a35fe0afc1537df3ca7b9aa3e276e6) codeql: 2.16.6 -> 2.17.0
* [`40de6132`](https://github.com/NixOS/nixpkgs/commit/40de613243911feebb204e22ee8df68e9e091ddf) python311Packages.parfive: 2.0.2 -> 2.1.0
* [`9bb98c69`](https://github.com/NixOS/nixpkgs/commit/9bb98c69ad65df80ad80e53b970f70bcce4b36ad) haskellPackages: stackage LTS 22.14 -> LTS 22.16
* [`8f2ca208`](https://github.com/NixOS/nixpkgs/commit/8f2ca20859c824caeb061ed561bc4c32d085df8f) all-cabal-hashes: 2024-03-31T04:36:22Z -> 2024-04-09T20:48:09Z
* [`d9bbcd5f`](https://github.com/NixOS/nixpkgs/commit/d9bbcd5f81c1abcccc275c0777c86605b4173da7) haskellPackages: regenerate package set based on current config
* [`f89299e2`](https://github.com/NixOS/nixpkgs/commit/f89299e248d3834913f9e4d6963339cc3c862e61) lbreakouthd: 1.1.6 -> 1.1.7
* [`91a91b9a`](https://github.com/NixOS/nixpkgs/commit/91a91b9ae468de8500dccb74c7896b1218e9c1de) haskell.compiler.ghcHEAD: fix hash mismatch on case insensitive fs
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
