### PR TITLE
niv home-manager: update 1c43dcfa -> 67de98ae

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -41,10 +41,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1c43dcfac48a2d622797f7ab741670fdbcf8f609",
-        "sha256": "08w56pa7l8n2rs9g186ynfkz6lks825jvdkk7dsrj4vcm6ngyhxp",
+        "rev": "67de98ae6eed5ad6f91b1142356d71a87ba97f21",
+        "sha256": "1psx5s925r3ag2ghvk0nwdxaj4k312lrbsxnzpjf4sn9adnz23bb",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/1c43dcfac48a2d622797f7ab741670fdbcf8f609.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/67de98ae6eed5ad6f91b1142356d71a87ba97f21.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@1c43dcfa...67de98ae](https://github.com/nix-community/home-manager/compare/1c43dcfac48a2d622797f7ab741670fdbcf8f609...67de98ae6eed5ad6f91b1142356d71a87ba97f21)

* [`fa8c16e2`](https://github.com/nix-community/home-manager/commit/fa8c16e2452bf092ac76f09ee1fb1e9f7d0796e7) systemd: add `enable` option
* [`93b917d4`](https://github.com/nix-community/home-manager/commit/93b917d49f0b2ab75ff91e17573e112b95fdd95c) flake.lock: Update
* [`f46814ec`](https://github.com/nix-community/home-manager/commit/f46814ec7cbef9c2aef18ca1cbe89f2bb1e8c394) treewide: prefer the official wiki
* [`178e2689`](https://github.com/nix-community/home-manager/commit/178e26895b3aef028a00a32fb7e7ed0fc660645c) home-manager: error out on missing option argument
* [`7cebe921`](https://github.com/nix-community/home-manager/commit/7cebe921eaffd5f9880f0dab7a23789d15f6169b) Update translation files
* [`b31019d6`](https://github.com/nix-community/home-manager/commit/b31019d64f9ddd1a869fa8fdb371c32c7ed9b578) qt: add adwaita platform theme
* [`be2b1761`](https://github.com/nix-community/home-manager/commit/be2b17615c536c31d0ea4989a959298b115353b3) qt: fix adwaita decorations link
* [`54e35e0e`](https://github.com/nix-community/home-manager/commit/54e35e0e1c1b6b4888c34423335a448ab3ec78d5) qt: use warnings API
* [`ffc3600f`](https://github.com/nix-community/home-manager/commit/ffc3600f4009ca39b6cb63b24127ca4f93792854) fd: add module
* [`f3506ba8`](https://github.com/nix-community/home-manager/commit/f3506ba86cbc5f8620ea6b4e108146702a4627e9) bash: add bash package to home.packages
* [`8ff7bb3f`](https://github.com/nix-community/home-manager/commit/8ff7bb3f4d82a05a52d5242ec454bba14f5d6cc6) tofi: add module
* [`b5b2b1ac`](https://github.com/nix-community/home-manager/commit/b5b2b1ac63458357e205bcb2df2d0840a2acca13) helix: add ignores option
* [`b62cad68`](https://github.com/nix-community/home-manager/commit/b62cad68b754224caec1e3b0dbadf86821b0b255) spotify-player: add module
* [`b1a5b3d6`](https://github.com/nix-community/home-manager/commit/b1a5b3d6a524c80c7dd20888bff227d52adf5f03) vdirsyncer: set `postHook` to null when not set ([nix-community/home-manager⁠#5294](https://togithub.com/nix-community/home-manager/issues/5294))
* [`0184c818`](https://github.com/nix-community/home-manager/commit/0184c8180f5cbb8e3a54a239b874fe849d3073cb) neomutt: add some options
* [`dc906b19`](https://github.com/nix-community/home-manager/commit/dc906b197bc20c518e497fb040bb8240543fa634) kdeconnect: require "tray.target" for kdeconnect
* [`7ca7025c`](https://github.com/nix-community/home-manager/commit/7ca7025cf2fa88bebc2190955c44263c3989b706) alacritty: fix escape sequence in example and test
* [`068dd4ae`](https://github.com/nix-community/home-manager/commit/068dd4ae292b5bf64bda18a48bcd80f39dd76257) alacritty: cleanup after 0.13 merge in nixpkgs
* [`31c77dcc`](https://github.com/nix-community/home-manager/commit/31c77dcc2e4b6b9f73df0e7eaa89536f175954e8) sway: systemd customization
* [`1f305c36`](https://github.com/nix-community/home-manager/commit/1f305c363ecd7c6505f03fc7baba15505f3aa630) remmina: add module
* [`6a171bfd`](https://github.com/nix-community/home-manager/commit/6a171bfd84ee9b3df83f6eb76dab042219978439) kconfig: add module
* [`938357cb`](https://github.com/nix-community/home-manager/commit/938357cb234e85da37109df2cdd9cc59ab9c1cc0) hyprland: remove enableNvidiaPatches option
* [`5682ccdc`](https://github.com/nix-community/home-manager/commit/5682ccdcaf72aef74be97e4b683545a9de27c386) Translate using Weblate (Spanish)
* [`991f6faf`](https://github.com/nix-community/home-manager/commit/991f6fafce729e6d7d64107a66e445114194b778) Translate using Weblate (Portuguese)
* [`7c61e400`](https://github.com/nix-community/home-manager/commit/7c61e400a99f33cdff3118c1e4032bcb049e1a30) Translate using Weblate (Turkish)
* [`95888b15`](https://github.com/nix-community/home-manager/commit/95888b153c24c36971c4b4b66beecf32593064fb) sway: writeText -> writeTextFile
* [`3a435342`](https://github.com/nix-community/home-manager/commit/3a435342e2e5e2bff1d3331c2bd9e70f25693ea2) sway: check config file validity
* [`a2040822`](https://github.com/nix-community/home-manager/commit/a20408227466032a16e73893b09a67092258cf67) firefox: fix test
* [`057117a4`](https://github.com/nix-community/home-manager/commit/057117a401a34259c9615ce62218aea7afdee4d3) kdeconnect: fix "tray.target" requires
* [`4cec20db`](https://github.com/nix-community/home-manager/commit/4cec20dbf5c0a716115745ae32531e34816ecbbe) flake.lock: Update
* [`147b5a5e`](https://github.com/nix-community/home-manager/commit/147b5a5e1c04e1f27e30b6df720966422fb4bc09) qt: fix platform theme package install
* [`ad83c154`](https://github.com/nix-community/home-manager/commit/ad83c154bdfedad9807e86dd0633729ea3b116c5) qt: fix `qt.platformTheme = "gtk3"`
* [`2846d523`](https://github.com/nix-community/home-manager/commit/2846d5230a3c3923618eabb367deaf8885df580f) joplin-desktop: allow undefined options
* [`670d9ecc`](https://github.com/nix-community/home-manager/commit/670d9ecc3e46a6e3265c203c2d136031a3d3548e) poetry: add module
* [`46833c31`](https://github.com/nix-community/home-manager/commit/46833c3115e8858370880d892748f0927d8193c3) bat: allow overriding package ([nix-community/home-manager⁠#5301](https://togithub.com/nix-community/home-manager/issues/5301))
* [`2ad154bd`](https://github.com/nix-community/home-manager/commit/2ad154bd1be2441ac8c624704587734dddb9f41a) Translate using Weblate (Swedish)
* [`e2e7ea9b`](https://github.com/nix-community/home-manager/commit/e2e7ea9b8f3de1e6a09f4fc512eae75f6e413a10) kconfig: fix missing quoting
* [`1451d286`](https://github.com/nix-community/home-manager/commit/1451d2866d9ef3739c20f964c9c8bd6db39cc373) foot: unset PATH in server's systemd unit file
* [`e866aae5`](https://github.com/nix-community/home-manager/commit/e866aae5bbbcfe6798ca05d3004a4e62f1828954) amberol: add module
* [`67de98ae`](https://github.com/nix-community/home-manager/commit/67de98ae6eed5ad6f91b1142356d71a87ba97f21) tealdeer: documentation typo
