### PR TITLE
niv zsh-histdb: update f73d9c84 -> 90a6c104

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -161,10 +161,10 @@
         "homepage": "",
         "owner": "larkery",
         "repo": "zsh-histdb",
-        "rev": "f73d9c843b512fe08ececea3edf512eb60ac84d1",
-        "sha256": "092fb15a6bp6dngx22s4jl8pns3xnirml5b3dc9wf7rcbka6rwa7",
+        "rev": "90a6c104d0fcc0410d665e148fa7da28c49684eb",
+        "sha256": "0n71m6k2w7zn5pmd5fdvmw7f14ss6lchm3q2zzdvfmcihskbbldy",
         "type": "tarball",
-        "url": "https://github.com/larkery/zsh-histdb/archive/f73d9c843b512fe08ececea3edf512eb60ac84d1.tar.gz",
+        "url": "https://github.com/larkery/zsh-histdb/archive/90a6c104d0fcc0410d665e148fa7da28c49684eb.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "zsh-histdb-fzf": {


### PR DESCRIPTION
## Changelog for zsh-histdb:
Branch: master
Commits: [larkery/zsh-histdb@f73d9c84...90a6c104](https://github.com/larkery/zsh-histdb/compare/f73d9c843b512fe08ececea3edf512eb60ac84d1...90a6c104d0fcc0410d665e148fa7da28c49684eb)

* [`7b010a65`](https://github.com/larkery/zsh-histdb/commit/7b010a65157f0bbdac26f6feb825d3858b0ee8ad) Add support to zsh's HISTORY_IGNORE parameter.
* [`2304ae27`](https://github.com/larkery/zsh-histdb/commit/2304ae279edb651e187bce5ee4beb76dbcfaf635) Update README.org
