### PR TITLE
niv nixpkgs: update 9dc4bec1 -> aa606b10

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9dc4bec1a2ece069bd3bed8590f7a9ed994acf75",
-        "sha256": "1bfzdwapdgx508fvb6j5sq0hi61x3ar7p5v8b7vi0kvk0x982msl",
+        "rev": "aa606b10cc142ada35360bb0b2218cbf57a27cf3",
+        "sha256": "1lk4cy64dpn6s2fmc2vp4q1md7gbadn30y6xcccd6467ymv6rrrz",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/9dc4bec1a2ece069bd3bed8590f7a9ed994acf75.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/aa606b10cc142ada35360bb0b2218cbf57a27cf3.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@9dc4bec1...aa606b10](https://github.com/nixos/nixpkgs/compare/9dc4bec1a2ece069bd3bed8590f7a9ed994acf75...aa606b10cc142ada35360bb0b2218cbf57a27cf3)

* [`4f2747cc`](https://github.com/NixOS/nixpkgs/commit/4f2747cccfceb558dc0dedca97f2fe5155db636d) maintainers: add YvesStraten
* [`bd6966bc`](https://github.com/NixOS/nixpkgs/commit/bd6966bc4a5609108b916123350f547ae8343256) nixos/pam: Secure default for `sshAgentAuth.authorizedKeysFiles`
* [`385f21ae`](https://github.com/NixOS/nixpkgs/commit/385f21ae20a8466ff70d6b9db408e9898de21536) sonic-pi: add pipewire.jack
* [`30332b97`](https://github.com/NixOS/nixpkgs/commit/30332b97c376ee71c3a7bbf2b489954a252bbc7f) sonic-pi: bump elixir
* [`91514e00`](https://github.com/NixOS/nixpkgs/commit/91514e00c077b322b8a46ae65fd0a482b7dc25a7) python312Packages.libpcap: 1.11.0b7 -> 1.11.0b8
* [`6944778b`](https://github.com/NixOS/nixpkgs/commit/6944778bdb17b65aa0e3db2958e79d2554924daa) gnome-frog: 1.4.2 -> 1.5.1
* [`787b9af3`](https://github.com/NixOS/nixpkgs/commit/787b9af321067e8a284675c6c1a02111ab262c53) hashid: init at 3.1.4-unstable-2015-03-17
* [`cc1743d6`](https://github.com/NixOS/nixpkgs/commit/cc1743d6c6693290962f3844e40b90a788a3f4d8) quictls: 3.1.4 -> 3.1.5
* [`c7f51f00`](https://github.com/NixOS/nixpkgs/commit/c7f51f0032641a3fae293336070f42dd91b288d8) libeatmydata: patch out LFS64 usage
* [`222da55e`](https://github.com/NixOS/nixpkgs/commit/222da55eef3e4cda78322c2c6397748efbd978a0) unstableGitUpdater: Use stableVersion, update to new format, offer hardcoded 0 version
* [`460374eb`](https://github.com/NixOS/nixpkgs/commit/460374eb04229b5e5ed2bb4a9ddaf76cecef3717) unstableGitUpdater: Support non-shallow clones in tag search
* [`3cd4a35e`](https://github.com/NixOS/nixpkgs/commit/3cd4a35e710230c2e19838a4f45c555280e66e14) unstableGitUpdater: Try full history if failed to find any tags in shallow clone
* [`c145f59d`](https://github.com/NixOS/nixpkgs/commit/c145f59d48e9e6c2fb55edc9321a74470d7d17c9) unstableGitUpdater: Add option to run the tag through a converter program
* [`e30288bc`](https://github.com/NixOS/nixpkgs/commit/e30288bceda633fb3c3a16565b7e12944c8ec34c) unstableGitUpdater: Add option to apply a pattern to found tags, to ignore non-matching tags
* [`ce91e357`](https://github.com/NixOS/nixpkgs/commit/ce91e3572b588ae41296140e63c6f062ddce86f0) unstableGitUpdater: Address review feedback
* [`ce3a2f64`](https://github.com/NixOS/nixpkgs/commit/ce3a2f648e52001596548585ee779e3efc1c863f) unstableGitUpdater: Drop --bare cloning
* [`3a38edd5`](https://github.com/NixOS/nixpkgs/commit/3a38edd5899205b3c8cc3574b4d14e973efc398b) sgx-sdk/ipp-crypto: 2021.9.0 -> 2021.10.0
* [`25955eed`](https://github.com/NixOS/nixpkgs/commit/25955eed5ce01dbee70bfe98713c4e74a8317e33) sgx-sdk: 2.21 -> 2.23
* [`422a8930`](https://github.com/NixOS/nixpkgs/commit/422a8930192559acd54c9dabd56f4b3ed124c316) sgx-psw: 2.21 -> 2.23
* [`6721126b`](https://github.com/NixOS/nixpkgs/commit/6721126b853d819990be499963b82e393690035a) sgx-azure-dcap-client: 1.12.1 -> 1.12.3
* [`418b770a`](https://github.com/NixOS/nixpkgs/commit/418b770aab1e01d27bdfaaa3147a05a21b2eae9b) sgx-ssl: 1.1.1u -> 3.0.12
* [`fd3978c1`](https://github.com/NixOS/nixpkgs/commit/fd3978c1646aaa947ffb6377c1e6d045b613df6b) sgx-sdk: add 'phlip9' as maintainer of sgx packages
* [`9dd20575`](https://github.com/NixOS/nixpkgs/commit/9dd20575b3915ffddbac50f5df35024bc8449d6d) sgx-sdk: disable mtime in bundled zip file for reproducible builds
* [`bf15997e`](https://github.com/NixOS/nixpkgs/commit/bf15997e3d43db9967e394f1541f8c7b27d32fa7) sgx-ssl: split out tests. build-only by default.
* [`4bf3e6cf`](https://github.com/NixOS/nixpkgs/commit/4bf3e6cf24af275628c335b7f385b80065c20bf3) catboost: 1.2.2 -> 1.2.3
* [`c8cfe98c`](https://github.com/NixOS/nixpkgs/commit/c8cfe98c9efc85b31e0482f795d3f195b7421b9e) catboost: refactor
* [`3b088c5a`](https://github.com/NixOS/nixpkgs/commit/3b088c5a7160fe42b93ba3763ef206beb873b5da) python3Packages.panphon: init at 0.20.0
* [`1e01835f`](https://github.com/NixOS/nixpkgs/commit/1e01835f072e832806d4e5097856ca21faf9811c) bazel: 7.0.2 -> 7.1.0
* [`39c11f58`](https://github.com/NixOS/nixpkgs/commit/39c11f587ef9cb0af331a17a6105967ea6539cab) python311Packages.graphviz: 0.20.1 -> 0.20.2
* [`da106344`](https://github.com/NixOS/nixpkgs/commit/da10634406b26dfe8b3a2c98ddf6f958610a4ef4) pika-backup: 0.7.0 -> 0.7.1
* [`1c2d9d6f`](https://github.com/NixOS/nixpkgs/commit/1c2d9d6f451d1fa892878e868032bdfe6e5e781b) projectlibre: clean up
* [`287d631a`](https://github.com/NixOS/nixpkgs/commit/287d631ab316c0c3d4152fd5cc6e15dee06987ac) projectlibre: make deterministic
* [`d36c0cca`](https://github.com/NixOS/nixpkgs/commit/d36c0cca7f4117f1ef66dc8ff64d671401f6dd61) brmodelo: make deterministic and clean up
* [`160997c7`](https://github.com/NixOS/nixpkgs/commit/160997c79346ef23e53d61b0eaeb0d26f60784b6) prs: 0.5.0 -> 0.5.1
* [`6ab1bed5`](https://github.com/NixOS/nixpkgs/commit/6ab1bed5eb1da8f16fe25e1eb438315abe60e95e) DisnixWebService: make deterministic and clean up
* [`7e2aa854`](https://github.com/NixOS/nixpkgs/commit/7e2aa854bf05e168be7246acf61a0da0b1fe4c55) getmail6: 6.18.13 -> 6.18.14
* [`a9d746c4`](https://github.com/NixOS/nixpkgs/commit/a9d746c4c862520192f538ae3cf6359f19898c71) etcd: document release process, version upkeep and user guidelines
* [`6e371cf2`](https://github.com/NixOS/nixpkgs/commit/6e371cf263c6761b3e7a1daf047872049f2c21b7) texlive: make packages proper multi-output derivations
* [`a2b3416a`](https://github.com/NixOS/nixpkgs/commit/a2b3416a9c9cc2d26ebf4481f6b224ce0029571c) texlive: add short description to meta
* [`479abadf`](https://github.com/NixOS/nixpkgs/commit/479abadf530bd125b53b1000e08ddc20d21ccbd4) texlivePackages: init
* [`c30b73b3`](https://github.com/NixOS/nixpkgs/commit/c30b73b3ec1ef9359f36750ef4eb76102f5f5952) texlivePackages: omit texsource in Hydra builds
* [`9dcacf53`](https://github.com/NixOS/nixpkgs/commit/9dcacf5377c9882e19b53badc6238e0f61484f43) ibus-engines.mozc: 2.29.5268.102 -> 2.29.5374.102
* [`c4019f81`](https://github.com/NixOS/nixpkgs/commit/c4019f81b741e8429fa02ed0c145f620048853d9) unstableGitUpdater: Move copy-pasted git describe call into reusable function
* [`48f45999`](https://github.com/NixOS/nixpkgs/commit/48f45999b329fea816445685aad191960139e1bb) arduino-core-unwrapped: make deterministic
* [`335d0f29`](https://github.com/NixOS/nixpkgs/commit/335d0f2977d66a467cdb003decac30c659cca61a) openrocket: make deterministic
* [`209e418d`](https://github.com/NixOS/nixpkgs/commit/209e418d861e4c5b0c076d0924ed469512d6bbea) processing: make deterministic
* [`9efa8faf`](https://github.com/NixOS/nixpkgs/commit/9efa8fafd5eb2e3713ee2c51f91c7d64dfd4929c) xtreemfs: make deterministic
* [`4fc417df`](https://github.com/NixOS/nixpkgs/commit/4fc417df2543c34626801bbd55b48645bf75ce1b) sweethome3d.*: make deterministic
* [`acd985cd`](https://github.com/NixOS/nixpkgs/commit/acd985cdae29841752486465856b887653779517) qtwebkit: Upstream patch for python 3.9 json
* [`80ffc608`](https://github.com/NixOS/nixpkgs/commit/80ffc6089789e7629f94b1175f75d9c4744f2639) torctl: init at 0.5.7
* [`971f75d5`](https://github.com/NixOS/nixpkgs/commit/971f75d50dae1698a0ee74a42519c337a2e495e8) scenebuilder: 20.0.0 -> 21.0.1, make deterministic
* [`03339517`](https://github.com/NixOS/nixpkgs/commit/03339517ec5518f41f9d107f26bceff90250388f) maintainers: add lonyelon
* [`751e9b6c`](https://github.com/NixOS/nixpkgs/commit/751e9b6c7f8de129532df03806cadf5dc86e9b5d) writeShellApplication: add argument extraShellCheckFlags
* [`4a63197f`](https://github.com/NixOS/nixpkgs/commit/4a63197f0e15683898b06dac9f1d9476e2bd49b6) python312Packages.recurring-ical-events: 2.1.3 -> 2.2.0
* [`8d6af726`](https://github.com/NixOS/nixpkgs/commit/8d6af7263701ec1507f06a389e89e9a65e88c25f) calendar-cli: add meta.mainProgram
* [`451eb783`](https://github.com/NixOS/nixpkgs/commit/451eb7835dbd42461098070c97d020692c36060f) calendar-cli: use pyproject = true
* [`5e264e2d`](https://github.com/NixOS/nixpkgs/commit/5e264e2d13bd5571865672bbad2ff3bd3aac3443) tplay: 0.4.0 -> 0.5.0
* [`ac7cf005`](https://github.com/NixOS/nixpkgs/commit/ac7cf005910f7aa388a2cb6cc77ffb2dd9a9954c) rtl8852au: init at 70bdde2
* [`260cc947`](https://github.com/NixOS/nixpkgs/commit/260cc9477282f860ec85bf6abf1d239113caf82e) otel-cli: 0.4.4 -> 0.4.5
* [`c617f190`](https://github.com/NixOS/nixpkgs/commit/c617f1908d88342cf8fbcee9ce88998d5c85e14a) nanoboyadvance: init at 1.8.1
* [`b556b8b3`](https://github.com/NixOS/nixpkgs/commit/b556b8b378c6a76d9643287fea28e610ae33bd37) python3Packages.nanobind: init at 1.9.2
* [`4f879807`](https://github.com/NixOS/nixpkgs/commit/4f8798074765d2fedba6108cce6b41051c88cfde) has: update 1.4.0 -> 1.5.0
* [`3d001952`](https://github.com/NixOS/nixpkgs/commit/3d00195259fa9224c5763948d796057294a848fb) shipwright: 8.0.4 -> 8.0.5
* [`7dc39246`](https://github.com/NixOS/nixpkgs/commit/7dc39246a0076ce09ea8ccca7468f3200004f03b) warp-terminal: enabled wayland support
* [`3a525f84`](https://github.com/NixOS/nixpkgs/commit/3a525f84f812e77732f2cb43686015e0bb1983f8) diffoscope: fix pypdf support
* [`681a32ff`](https://github.com/NixOS/nixpkgs/commit/681a32ff37da860a8311028400de31244ad45219) threema-desktop: 1.2.31 -> 1.2.41, build from source
* [`7cb1b52d`](https://github.com/NixOS/nixpkgs/commit/7cb1b52dbf1d8c01be934b8310026588af480252) bazel_6: 6.4.0 -> 6.5.0
* [`6528de1a`](https://github.com/NixOS/nixpkgs/commit/6528de1a4f140a62612c939356c7820d445e03e1) bazel_6: Add check to assert GSON serialization works
* [`bccdc675`](https://github.com/NixOS/nixpkgs/commit/bccdc6751f9cbb7817721059757b560e0dfa3ae7) bazel_6: Skip building the execlog parser on darwin
* [`bb8574dd`](https://github.com/NixOS/nixpkgs/commit/bb8574ddb8133749379974353b7584fed5109c2b) bazel_6: Add patch for system sleep on Darwin
* [`a75d0a73`](https://github.com/NixOS/nixpkgs/commit/a75d0a734f0df8280d2b7ddec23050a1b8fa903b) bazel_6: Add sigtool and set up codesign allocate appropriately
* [`4f857cd1`](https://github.com/NixOS/nixpkgs/commit/4f857cd1de7ce8d4b8db568c6a405a8a62bbf1b1) bazel_6: Enable local networking for tests on Darwin
* [`a3d4328f`](https://github.com/NixOS/nixpkgs/commit/a3d4328fb77178fb7c9ea8e9522e7c55f34d7a76) python311Packages.kornia-rs: init at 0.1.2
* [`a5ed5b19`](https://github.com/NixOS/nixpkgs/commit/a5ed5b19baa8988cf08947adda40d6bd2f2baba1) python311Packages.kornia: 0.7.1 -> 0.7.2
* [`f4ed855c`](https://github.com/NixOS/nixpkgs/commit/f4ed855c24c13495a68b352fc7c39acb15dc0447) diffoscope: add r2pipe
* [`9e2322eb`](https://github.com/NixOS/nixpkgs/commit/9e2322eb1014a9d9c1766841d415aa9faf964a7a) diffoscope: update doc2txt comment
* [`d1daaeb1`](https://github.com/NixOS/nixpkgs/commit/d1daaeb1280c5df7b8dc1c24e6a894f8f3411a44) openjfx{11,17,19,20,21,22}: fix build when withWebKit is enabled
* [`5e10198a`](https://github.com/NixOS/nixpkgs/commit/5e10198a525fa876213d6d526ddcfa16ddfd5adf) xml2rfc: 3.20.1 -> 3.21.0
* [`78f4d9fb`](https://github.com/NixOS/nixpkgs/commit/78f4d9fb5cc3a65ef14befcf10b56d80378c53aa) DBG: change name of tests so it is clear if hacks are enabled
* [`94ab2859`](https://github.com/NixOS/nixpkgs/commit/94ab2859e9c05e369af7847b1ff216e8b73e4608) openttd-jgrpp: 0.58.1 -> 0.58.2
* [`6f5128dd`](https://github.com/NixOS/nixpkgs/commit/6f5128ddc52eccbb4f6be149e5da2e850839ff82) cloudflared: 2024.3.0 -> 2024.4.0
* [`95d2a5e5`](https://github.com/NixOS/nixpkgs/commit/95d2a5e53714fd35190c7bb5998a0efad1e236cc) ncnn: 20240102 -> 20240410
* [`68ed9da5`](https://github.com/NixOS/nixpkgs/commit/68ed9da5e3ef13bf80fa22ff99dcb1d39bcf72dc) hyprlock: 0.2.0 -> 0.3.0
* [`f28620c3`](https://github.com/NixOS/nixpkgs/commit/f28620c34f09cd10a7adca8a5da80b4722c6a625) python311Packages.xml2rfc: 3.20.1 -> 3.21.0
* [`f3d86452`](https://github.com/NixOS/nixpkgs/commit/f3d864521bf40e3df27b05b674677f0243103127) python3Packages.pip-tools: fix build
* [`0c04ce64`](https://github.com/NixOS/nixpkgs/commit/0c04ce64161d350c1f49d8443d05099c7949a43c) icingaweb2-ipl: 0.13.1 -> 0.13.2
* [`855607aa`](https://github.com/NixOS/nixpkgs/commit/855607aa20a0cbb0a6702ddbab5163bd9dc43302) python3Packages.git-versioner: init at 7.1
* [`abd1c832`](https://github.com/NixOS/nixpkgs/commit/abd1c832fdad62e45a42a963066416e9b972aa92) python3Packages.pip-system-certs: init at 4.0
* [`cd384cce`](https://github.com/NixOS/nixpkgs/commit/cd384ccef34a8775139806ffaaf4877fa4772000) anki: 23.12.1 -> 24.04
* [`76ae3e3a`](https://github.com/NixOS/nixpkgs/commit/76ae3e3a06d18c62c26fc209dbaea1558e7d4093) kubernetes-helmPlugins.helm-git: 0.15.1 -> 0.16.0
* [`231bb74f`](https://github.com/NixOS/nixpkgs/commit/231bb74f99a9d7305169d9cafd95a0b412728b01) steamPackages.steam-fhsenv: fix IME issues
* [`6545f73b`](https://github.com/NixOS/nixpkgs/commit/6545f73b2e949703edab795cd502e91d3d1bf9e9) firewalld-gui: 2.1.1 -> 2.1.2
* [`f8cfeabd`](https://github.com/NixOS/nixpkgs/commit/f8cfeabdb38f275f19447c8d5508f35751bf9b98) firewalld: 2.1.1 -> 2.1.2
* [`4980d273`](https://github.com/NixOS/nixpkgs/commit/4980d273c5aeffb49da9859cae6ffce46b981a78) matrix-synapse-tools.rust-synapse-compress-state: 0.1.3 -> 0.1.4
* [`8f978660`](https://github.com/NixOS/nixpkgs/commit/8f978660bd0a4f4c28128a8eb81de1942f5b350f) cpm-cmake: 0.38.8 -> 0.39.0
* [`80dffe12`](https://github.com/NixOS/nixpkgs/commit/80dffe120d96a72a9397347b3996f7dc98346a70) google-drive-ocamlfuse: 0.7.31 -> 0.7.32
* [`b6ed076f`](https://github.com/NixOS/nixpkgs/commit/b6ed076fc3c4e968a0e9f0bfd1f186b32679502f) python312Packages.vacuum-map-parser-base: 0.1.2 -> 0.1.3
* [`bcd517d2`](https://github.com/NixOS/nixpkgs/commit/bcd517d2adced03582f578106f0a8e3ea21afb4b) gnome.networkmanager-l2tp: 1.20.12 -> 1.20.14
* [`748d185a`](https://github.com/NixOS/nixpkgs/commit/748d185aa1a7f5ff8e418b8b730069be8b558ec5) stats: add passthru.updateScript
* [`a359b46f`](https://github.com/NixOS/nixpkgs/commit/a359b46f7f721b9627c862b697e767ae7631df16) stats: add maintainer donteatoreo
* [`69bf7a51`](https://github.com/NixOS/nixpkgs/commit/69bf7a51821c2c890ec7f1bc7f986a84d5d237e8) python311Packages.cassandra-driver: 3.28.0 -> 3.29.1
* [`a55e0fa9`](https://github.com/NixOS/nixpkgs/commit/a55e0fa92d85beabbd8203fcb81d3ee762ed1287) simulide: factor out sources
* [`345c3a0a`](https://github.com/NixOS/nixpkgs/commit/345c3a0ace08622363b5eef4571ecd6e0f49d51d) simulide: format with nixfmt
* [`b22f0e99`](https://github.com/NixOS/nixpkgs/commit/b22f0e999ec06f1e00e0634efa5c262e1e59b912) kile: 2.9.93 -> 2.9.94
* [`9258f576`](https://github.com/NixOS/nixpkgs/commit/9258f57625b474c542938a295ee0e85c9c5533ff) systemd: add a name option to all systemd units
* [`447f80a6`](https://github.com/NixOS/nixpkgs/commit/447f80a66f42d6c582f2c9caba68081da7710e53) python311Packages.pipdeptree: 2.16.2 -> 2.18.1
* [`2ff5b02f`](https://github.com/NixOS/nixpkgs/commit/2ff5b02ffe7a4e5fec26cae59d3710f3fd3ade80) gplates: 2.4 -> 2.5
* [`b21e427a`](https://github.com/NixOS/nixpkgs/commit/b21e427a9578c58f61d30fdc79f33f27b07762ce) openxr-loader: 1.0.34 -> 1.1.36
* [`04cfdbcf`](https://github.com/NixOS/nixpkgs/commit/04cfdbcf19c4ff460da203f68536155612b52e66) php83Extensions.xdebug: 3.3.1 -> 3.3.2
* [`f39106a7`](https://github.com/NixOS/nixpkgs/commit/f39106a7b92fb72aa0e38498fc94a24ed8e58069) metals: 1.2.2 -> 1.3.0
* [`2666e17d`](https://github.com/NixOS/nixpkgs/commit/2666e17d3ff7d456d5af3defd1ec7a8ea909d4ba) qdrant: add patch for CVE-2024-3078
* [`fb41c8c6`](https://github.com/NixOS/nixpkgs/commit/fb41c8c62235d40b73e71442739d8c5bae21f366) maintainers: add Qyriad
* [`2b7a86a8`](https://github.com/NixOS/nixpkgs/commit/2b7a86a8223a37281a0932a45ea445d042b88cf8) hunspell.th_TH: experimental-2024-02-27 → experimental-2024-04-15
* [`14ef362b`](https://github.com/NixOS/nixpkgs/commit/14ef362b0fd986acd4e6b969929593138da76bf5) cinny-desktop: support macos
* [`7b4b3589`](https://github.com/NixOS/nixpkgs/commit/7b4b35895d15c8a421b076545cd9b63428cfa0a9) curtail: 1.8.0 -> 1.9.1
* [`4f7cb34d`](https://github.com/NixOS/nixpkgs/commit/4f7cb34d635d098efbc07353660cee18501ca2f9) Revert "python-qt: hit it in the head with a hammer"
* [`04a1d9b2`](https://github.com/NixOS/nixpkgs/commit/04a1d9b204e49a8f936a41d407f18aba48472a3c) python-qt: update to v3.5.0
* [`c01125ff`](https://github.com/NixOS/nixpkgs/commit/c01125ff83aca0b1ca36085ee57ca57cd0f1c644) csound: clean after python-qt update
* [`d338ea83`](https://github.com/NixOS/nixpkgs/commit/d338ea8382164334ce48d41a7f36e7bee0cd1ad4) python-qt: clean
* [`7246b503`](https://github.com/NixOS/nixpkgs/commit/7246b5035cfabc26b9fa7fb9eaad94527457311a) python-qt: switch to libsForQt5.callPackage
* [`4f6b4534`](https://github.com/NixOS/nixpkgs/commit/4f6b45344920cb8e9f5b396ff1513047776fdcc5) buildMavenPackage: use nativeBuildInputs in .fetchedMavenDeps as well
* [`a69334e5`](https://github.com/NixOS/nixpkgs/commit/a69334e5ad3b90ccd3ce009e5e088e33827e874a) python-qt: fix for darwin
* [`54b90c14`](https://github.com/NixOS/nixpkgs/commit/54b90c14cba77dd22a1b980a1d8e33a2c4dbfd52) python-qt: prefix lib with $out on darwin
* [`0b6a38c5`](https://github.com/NixOS/nixpkgs/commit/0b6a38c517944d4e5fcb6f0d08e6de94e3e547eb) zsh-prezto: unstable-2024-03-17 -> unstable-2024-04-15
* [`ede4a205`](https://github.com/NixOS/nixpkgs/commit/ede4a205ba8a40ba1f85fd3dae476b7d4c5bb316) jackett: 0.21.2342 -> 0.21.2392
* [`aa347646`](https://github.com/NixOS/nixpkgs/commit/aa3476462ad0296315013a67b84739c2096e050e) wl-clip-persist: 0.3.1 -> 0.4.0
* [`cb01675d`](https://github.com/NixOS/nixpkgs/commit/cb01675dd19753f6aaa4d9c7b66e2dc81d2a14b9) wl-clip-persist: add `name-snrl` to maintainers
* [`b2eca02a`](https://github.com/NixOS/nixpkgs/commit/b2eca02a0ab4d255c111706f85bb4eb1f2b3b958) deno: 1.42.3 -> 1.42.4
* [`fa0d4eaa`](https://github.com/NixOS/nixpkgs/commit/fa0d4eaa9b31d7e6f334e5c39011e7448fc67436) spot: 0.4.0 -> 0.4.1
* [`cf1752d2`](https://github.com/NixOS/nixpkgs/commit/cf1752d253c2ac1cf17b1d4aa551d5cb14782f17) spot: make msfjarvis the maintainer
* [`23df3266`](https://github.com/NixOS/nixpkgs/commit/23df3266c9a42e990229852b4695f0ed9cf941c4) python-qt: fix code signing on darwin
* [`1dc73453`](https://github.com/NixOS/nixpkgs/commit/1dc7345389a2baced186589cab9824cec3dc0281) haskell.compiler.ghc981: build stage 2 compiler for “native cross”
* [`490114a2`](https://github.com/NixOS/nixpkgs/commit/490114a2e13eced195b9027b44d4e0d9d85a6a20) haskellPackages.ghc: 9.6.4 -> 9.6.5
* [`1cda3009`](https://github.com/NixOS/nixpkgs/commit/1cda30090accdc5888fac6319d92599b1da8330d) all-cabal-hashes: 2024-04-09T20:48:09Z -> 2024-04-16T17:36:35Z
* [`8767abc3`](https://github.com/NixOS/nixpkgs/commit/8767abc31ef3cd2d2fdabab85414ff2e980e211e) haskellPackages: stackage LTS 22.16 -> LTS 22.17
* [`9ce35fc0`](https://github.com/NixOS/nixpkgs/commit/9ce35fc0a8e2672cca605254d5d143a06331236b) haskellPackages: regenerate package set based on current config
* [`3b704f5d`](https://github.com/NixOS/nixpkgs/commit/3b704f5dd3c90cb6b9b2b3e7f5eb441df52575a1) python312Packages.reuse: add changelog to meta
* [`c3723943`](https://github.com/NixOS/nixpkgs/commit/c37239431b6fb7d7a4379d26096ddd84da13cc12) python312Packages.reuse: refactor
* [`34966fa0`](https://github.com/NixOS/nixpkgs/commit/34966fa09840ec91b461d377e8cb70646bc62ca4) python312Packages.reuse: format with nixfmt
* [`5b779e61`](https://github.com/NixOS/nixpkgs/commit/5b779e61962f5fe8615d405dda75f6d01e19606b) flexoptix-app: 5.20.0 -> 5.21.2
* [`5f2bbdea`](https://github.com/NixOS/nixpkgs/commit/5f2bbdeab402ff99cf7a24f256344e8123471e7b) clusterctl: 1.6.3 -> 1.7.0
* [`03e73b11`](https://github.com/NixOS/nixpkgs/commit/03e73b1151f8e802b51c7ec6aed4cbb0acca54c5) readarr: 0.3.22.2499 -> 0.3.23.2506
* [`095ebe5a`](https://github.com/NixOS/nixpkgs/commit/095ebe5adcc7c802a8ad99c93d414867fe7aabfe) python312Packages.emcee: 3.1.4 -> 3.1.5
* [`1aaceb59`](https://github.com/NixOS/nixpkgs/commit/1aaceb59743c61995a1b210a10c91e1fe1687b7d) python312Packages.jedi-language-server: 0.41.3 -> 0.41.4
* [`3b94be44`](https://github.com/NixOS/nixpkgs/commit/3b94be44918caf7a5820981baf71514804105851) homepage-dashboard: 0.8.11 -> 0.8.12
* [`4a061aa6`](https://github.com/NixOS/nixpkgs/commit/4a061aa690062c3ccd3bc1a9d7ea704e5fd9b01c) homepage-dashboard: remove unused arguments
* [`c8e7f71b`](https://github.com/NixOS/nixpkgs/commit/c8e7f71b447255f7668ed4f86354958adc3104ee) python311Packages.testcontainers: 4.3.3 -> 4.4.0
* [`7a3dbe9a`](https://github.com/NixOS/nixpkgs/commit/7a3dbe9ad8cf004ba3201271661a30bef1171c0c) matrix-hookshot: 5.2.1 -> 5.3.0
* [`5005f0f0`](https://github.com/NixOS/nixpkgs/commit/5005f0f0b29c186ef39c97874dc013fca501d1d4) nemu: init at 3.3.1
* [`c224f433`](https://github.com/NixOS/nixpkgs/commit/c224f4337b837707ce2d1a79cbced3dd8d44466c) ddev: 1.22.7 -> 1.23.0
* [`767d8921`](https://github.com/NixOS/nixpkgs/commit/767d892193e5e8afd9a077efaa51ecac7a9c48ab) dotnet: fix typo which was breaking the console test
* [`7150d7e2`](https://github.com/NixOS/nixpkgs/commit/7150d7e203ab92fb914e08a780d30b6493e6988d) dotnet: add self-contained test
* [`81693c96`](https://github.com/NixOS/nixpkgs/commit/81693c96bab62e166a9828a76533823370def2a8) dotnet: force ICU to be loaded during tests
* [`bd934093`](https://github.com/NixOS/nixpkgs/commit/bd934093f4dd2528403f5ee8aa67788e8843d238) dotnet: patch apphost as well as singlefilehost
* [`e4046407`](https://github.com/NixOS/nixpkgs/commit/e40464070ee4f503a78134534a854c1d54c56593) shotcut: 24.02.29 -> 24.04.13
* [`4d7f8d9e`](https://github.com/NixOS/nixpkgs/commit/4d7f8d9e712226584f3c48ad2927e952179ec5d6) promptfoo: 0.51.0 -> 0.53.0
* [`e4c39500`](https://github.com/NixOS/nixpkgs/commit/e4c395006982bfdf0e0a055836164c6bb21df46a) libdatachannel: 0.20.2 -> 0.20.3
* [`ec4f269d`](https://github.com/NixOS/nixpkgs/commit/ec4f269ddd02f154578308d627042056ba2f3a45) mosdepth: 0.3.7 -> 0.3.8
* [`c8714ece`](https://github.com/NixOS/nixpkgs/commit/c8714ece6c25b9c26259851a46ace712bcdf779e) obs-studio-plugins.obs-command-source: 0.4.0 -> 0.5.0
* [`85f37b0d`](https://github.com/NixOS/nixpkgs/commit/85f37b0dbba32806dfa1ff560cf7fa6c6f227454) python311Packages.awscrt: 0.20.6 -> 0.20.9
* [`b09e4d38`](https://github.com/NixOS/nixpkgs/commit/b09e4d3815a6a8ce680dbf641beaeba889f7fa6b) python311Packages.mlflow: 2.11.3 -> 2.12.1
* [`39f864dd`](https://github.com/NixOS/nixpkgs/commit/39f864ddfb0b07d86b6d8423c6336bfa4c8e708e) python312Packages.influxdb-client: 1.41.0 -> 1.42.0
* [`4883fc40`](https://github.com/NixOS/nixpkgs/commit/4883fc4008ccb27189e48632ba1cb0731c7e039a) python312Packages.sphinx-codeautolink: 0.15.0 -> 0.15.1
* [`fa78a15e`](https://github.com/NixOS/nixpkgs/commit/fa78a15eb36d59c696a759e697f978289896e6e4) upterm: 0.13.2 -> 0.13.3
* [`1aae1c31`](https://github.com/NixOS/nixpkgs/commit/1aae1c31e813b3c00ee2812494c93f4dacc67396) zwave-js-server: 1.34.0 -> 1.35.0
* [`41033c84`](https://github.com/NixOS/nixpkgs/commit/41033c8438c639a91a9bf7b14e388588ef8d3937) velero: 1.13.1 -> 1.13.2
* [`a673115e`](https://github.com/NixOS/nixpkgs/commit/a673115e9634266972b1de6e6e1c0c2caed9e68f) gensio: 2.8.3 -> 2.8.4
* [`283a2815`](https://github.com/NixOS/nixpkgs/commit/283a28158511cdac7d4ab554833d35b616b43ae2) broadlink-cli: 0.18.3 -> 0.19.0
* [`7bc38afb`](https://github.com/NixOS/nixpkgs/commit/7bc38afb3d2734f2957b5a23b5abf96514de9826) python311Packages.fast-histogram: 0.12 -> 0.14
* [`810558a4`](https://github.com/NixOS/nixpkgs/commit/810558a46bff49a214454c60039dff9e195e629a) nixos/libinput: move out of xserver
* [`cb8b6a5d`](https://github.com/NixOS/nixpkgs/commit/cb8b6a5d00464c268db7452e698ea6094649e9bd) treewide: reanme renamed libinput options
* [`4756db92`](https://github.com/NixOS/nixpkgs/commit/4756db9277bcbf15b26d1c98d681d358f05077ab) dart: 3.3.3 -> 3.3.4
* [`57d6e5bd`](https://github.com/NixOS/nixpkgs/commit/57d6e5bda67775c68b198d0ac62efd3ecb3eb898) treewide: remove autoPatchelfHook from dotnet packages
* [`9e952fea`](https://github.com/NixOS/nixpkgs/commit/9e952fea588f36ee6cc060f99e3cdf1215e1c59f) bitcoin-abc: 0.29.1 -> 0.29.2
* [`ee55a72b`](https://github.com/NixOS/nixpkgs/commit/ee55a72b1dc96375e63c249f62508760f8e5b313) csmith: fix build with explicit std
* [`d183a293`](https://github.com/NixOS/nixpkgs/commit/d183a2939daac933c51d17b7815f41b2e19f64ec) kics: 1.7.13 -> 2.0.0
* [`959b906d`](https://github.com/NixOS/nixpkgs/commit/959b906d047bf8aa4c9e266f03e28f4e64d48211) micronaut: 4.3.8 -> 4.4.0
* [`0ff1a7e2`](https://github.com/NixOS/nixpkgs/commit/0ff1a7e21bd5036be010d9d6200adbbd286dd4b7) netclient: 0.23.0 -> 0.24.0
* [`db43ff38`](https://github.com/NixOS/nixpkgs/commit/db43ff38d52444f50a9eb1d6e1878a6ea2f6f9ad) netmaker: 0.23.0 -> 0.24.0
* [`c2d6f579`](https://github.com/NixOS/nixpkgs/commit/c2d6f57960c161ed0ffb7ce78649f1db5a4d7350) dorion: 4.1.3 -> 4.2.0
* [`439b318e`](https://github.com/NixOS/nixpkgs/commit/439b318e01384fe64fdfbc0890dac026568da32c) ocaml-ng.ocamlPackages_5_2.ocaml: 5.2.0-β1 → 5.2.0-β2
* [`fbb4d816`](https://github.com/NixOS/nixpkgs/commit/fbb4d816e88bbfd53e1eb01d58d0d408ea3b74aa) lidarr: 2.1.7.4030 -> 2.2.5.4141
* [`db894a92`](https://github.com/NixOS/nixpkgs/commit/db894a928a65f0040854991f44c200928cbf8cd0) aeron, aeron-cpp: 1.43.0 -> 1.44.1
* [`0107e9e6`](https://github.com/NixOS/nixpkgs/commit/0107e9e6d77a8d4ac3ec7d42d9560c67e1e286f2) python311Packages.influxdb-client: 1.41.0 -> 1.42.0
* [`0ef5f787`](https://github.com/NixOS/nixpkgs/commit/0ef5f787de90257f5f86f9dc14f318e0ec42a4c4) cri-tools: 1.29.0 -> 1.30.0
* [`2747deeb`](https://github.com/NixOS/nixpkgs/commit/2747deeb49d9f6ca34445072431a9917d0a8a0bf) hubble: 0.13.2 -> 0.13.3
* [`a162b35b`](https://github.com/NixOS/nixpkgs/commit/a162b35b1deb0b562bcaf8822a7c4ab0bd45514b) komga: 1.10.4 -> 1.11.0
* [`ce6fec65`](https://github.com/NixOS/nixpkgs/commit/ce6fec65864acdb423add60148afe174cadd1b03) lenovo-legion: 0.0.9 -> 0.0.12
* [`6a121887`](https://github.com/NixOS/nixpkgs/commit/6a121887fa5329897fc9e56a9f735ba1ea1ca4bc) oh-my-posh: 19.20.0 -> 19.21.0
* [`05410eaf`](https://github.com/NixOS/nixpkgs/commit/05410eafeacf379a5cb48058053e0e488c56c21c) prometheus-nats-exporter: 0.14.0 -> 0.15.0
* [`6be3a62c`](https://github.com/NixOS/nixpkgs/commit/6be3a62cf9b8ab90f795494c8cde03fd1f34ee9b) seaweedfs: 3.62 -> 3.65
* [`2e89eb46`](https://github.com/NixOS/nixpkgs/commit/2e89eb4605d35f507fdccaae2c691cb79b825d41) tbls: 1.73.3 -> 1.74.0
* [`53036eea`](https://github.com/NixOS/nixpkgs/commit/53036eeac13450e6ff8446f4a39fae8476b4108b) vtm: 0.9.77 -> 0.9.78
* [`6e6181d1`](https://github.com/NixOS/nixpkgs/commit/6e6181d1d81b568ddf6ccd91e653e8e948b1c670) erlang_27: rc2 -> rc3
* [`5ed50acd`](https://github.com/NixOS/nixpkgs/commit/5ed50acd51abc14a3942544ff11899ee24e7bf4d) weaviate: 1.24.8 -> 1.24.9
* [`772c958f`](https://github.com/NixOS/nixpkgs/commit/772c958fa89c2662e77ba138060facbf295cd253) eclipses: 2023-12 -> 2024-03
* [`bf2a10e1`](https://github.com/NixOS/nixpkgs/commit/bf2a10e15b8ec74cc21c6ba8e3463e75452831eb) haskell.compiler.ghc8107: support {LD,AR}_STAGE0
* [`2df126c3`](https://github.com/NixOS/nixpkgs/commit/2df126c3ddd251ab9207b0a021fba18c63451866) graphene-hardened-malloc: migrate to by-name, build light variant
* [`16c31e6a`](https://github.com/NixOS/nixpkgs/commit/16c31e6a1e2e8801fbf27fa86b0b3d6ce47b8d25) bind: 9.18.25 -> 9.18.26
* [`b1e8c3bd`](https://github.com/NixOS/nixpkgs/commit/b1e8c3bdeaa2b32bda121cd0e5b2058051afbec0) graphene-hardened-malloc: 12 -> 2024040900
* [`af65b87b`](https://github.com/NixOS/nixpkgs/commit/af65b87b2346d608d90654b09050a40ee1e565b4) nixos/malloc: add graphene-hardened-light
* [`774cd77f`](https://github.com/NixOS/nixpkgs/commit/774cd77f2b7952f5ba75933f980212923462e1ef) nixos/akkoma: Fix media proxy URLs after upgrade
* [`4b094f51`](https://github.com/NixOS/nixpkgs/commit/4b094f5153758057a3b9e152ec0dd24517d0dfdc) skimpdf: init at 1.7.2
* [`5b718130`](https://github.com/NixOS/nixpkgs/commit/5b718130ad311d7bfeee7be9adf6c0784aed709c) docker-buildx: 0.13.1 -> 0.14.0
* [`fdb56277`](https://github.com/NixOS/nixpkgs/commit/fdb56277ab67beef927ba4fa810af67bfd913cde) linuxKernel.packages.linux_6_8.r8125: 9.012.03 -> 9.013.02
* [`82468379`](https://github.com/NixOS/nixpkgs/commit/82468379d3c79662960af535130f248b798766fe) prometheus-fastly-exporter: 7.6.1 -> 8.0.0
* [`d5c1792f`](https://github.com/NixOS/nixpkgs/commit/d5c1792fdca71dd7b70664e9bb702e8af1d2aaa8) tev: 1.26 -> 1.27
* [`0cb12b71`](https://github.com/NixOS/nixpkgs/commit/0cb12b719b8314ef2a40011fe9e09b8601417b8d) tela-icon-theme: 2023-06-25 -> 2024-04-19
* [`4880437d`](https://github.com/NixOS/nixpkgs/commit/4880437ddeef49cdc793af638d90f99be766a866) uptime-kuma: 1.23.11 -> 1.23.12
* [`0b41c451`](https://github.com/NixOS/nixpkgs/commit/0b41c45147b332d5d0ea9485ba0173b28af0967c) ssw: 0.8 -> 0.10
* [`90cdb085`](https://github.com/NixOS/nixpkgs/commit/90cdb085c7d72daf04cbfeefe6c9ff868f0c7540) am2rlauncher: fix error with missing GSettings schemas
* [`5707a913`](https://github.com/NixOS/nixpkgs/commit/5707a9130534d6bc06ed4c242efa800934f3f608) python312Packages.aiodiscover: 2.0.0 -> 2.1.0
* [`539d3bce`](https://github.com/NixOS/nixpkgs/commit/539d3bce23509748295c7fdd0a46f21b5b3bae80) python312Packages.aiodiscover: format with nixfmt
* [`a650164a`](https://github.com/NixOS/nixpkgs/commit/a650164af3f2fb12143fa248fa777a16ce12313e) python312Packages.bluetooth-auto-recovery: 1.4.0 -> 1.4.1
* [`8b42c3f4`](https://github.com/NixOS/nixpkgs/commit/8b42c3f4a738fbf7bdca4fdb59edeaa29a736ba0) python312Packages.bluetooth-auto-recovery: format with nixfmt
* [`838182b2`](https://github.com/NixOS/nixpkgs/commit/838182b2a6e50d0ec898864aa701b715fa7574c4) python3Packages.ducc0: 0.33.0 -> 0.34.0
* [`0d446bea`](https://github.com/NixOS/nixpkgs/commit/0d446bea137af02077c85fe50345186f0165f61a) nginx-language-server: init at 0.8.0
* [`6834a0d2`](https://github.com/NixOS/nixpkgs/commit/6834a0d26051012cf773358e94189c3d11fedca7) python311Packages.dbt-redshift: 1.7.6 -> 1.7.7
* [`d4558d70`](https://github.com/NixOS/nixpkgs/commit/d4558d707ae6033c911bef4722b93addbed3b8a7) python311Packages.types-redis: 4.6.0.20240409 -> 4.6.0.20240417
* [`ad321e06`](https://github.com/NixOS/nixpkgs/commit/ad321e0602a6eb9cc5bc6fa4676371053d8183c4) release-haskell.nix/mergeable: include darwin again
* [`40bc356b`](https://github.com/NixOS/nixpkgs/commit/40bc356bc601d0441e235c447634ff5551ee78e1) release-haskell.nix/mergeable: include shellcheck
* [`4884f67d`](https://github.com/NixOS/nixpkgs/commit/4884f67df1cfa0b34802df465a741f559a21e044) terminal-stocks: 1.0.16 -> 1.0.17
* [`2dc85cf8`](https://github.com/NixOS/nixpkgs/commit/2dc85cf8c0106a273f545d91e6445e314abc8300) linuxPackages.nct6687d: add updateScript
* [`51a865e8`](https://github.com/NixOS/nixpkgs/commit/51a865e8e40a0148800d6eb7a8fc4e317307280e) linuxPackages.nct6687d: unstable-2023-09-22 -> 0-unstable-2024-02-23
* [`9b818bcc`](https://github.com/NixOS/nixpkgs/commit/9b818bcc11ad88409cc1b6c84cc53c4b82e06327) haskell.packages.*.cabal-install: reflect process 1.6.18 -> 1.6.19
* [`cc7c76e1`](https://github.com/NixOS/nixpkgs/commit/cc7c76e1f48da739425b08d5fef63b472ca4cb74) clipman: 1.6.3 -> 1.6.4
* [`d6479240`](https://github.com/NixOS/nixpkgs/commit/d6479240ca003cb767d51e32c595d18e0781be85) shelldap: fix on darwin using shortenPerlShebang
* [`fa764a30`](https://github.com/NixOS/nixpkgs/commit/fa764a30271ca5f52e9e7c069a39fb87cb22fc33) rPackages.mBvs: fixed build
* [`5e71d28e`](https://github.com/NixOS/nixpkgs/commit/5e71d28e5d0df1528161fe3fce04c3d0ea80f9b2) gtklock-userinfo-module: 2.1.0 -> 3.0.0
* [`1fb5e205`](https://github.com/NixOS/nixpkgs/commit/1fb5e20587eb339d6b022f22f22d025bbef3a19b) go-migrate: 4.17.0 -> 4.17.1
* [`9070ffe6`](https://github.com/NixOS/nixpkgs/commit/9070ffe650b44dbee6dd56aeba503846ee188066) mkjson: init at 0.4.0
* [`22e2e4f9`](https://github.com/NixOS/nixpkgs/commit/22e2e4f9eb4c8e9972bc21dd7003d4f22fcac77f) python3Packages.ducc0: switch to pyproject and refactor
* [`ee0f7772`](https://github.com/NixOS/nixpkgs/commit/ee0f777255ea0ffca72733ac90a9485f3d2e44f5) gtklock-powerbar-module: 2.0.1 -> 3.0.0
* [`3e93684d`](https://github.com/NixOS/nixpkgs/commit/3e93684dee8f32416def5bddaf6f6c8df9ad1f33) gtklock-playerctl-module: 2.0.1 -> 3.0.0
* [`923dd751`](https://github.com/NixOS/nixpkgs/commit/923dd75140ff3176426dac09316d9da14f33b570) python312Packages.griffe: 0.42.2 -> 0.44.0
* [`db9f90c3`](https://github.com/NixOS/nixpkgs/commit/db9f90c38e9a51a9f44461c9efe71314918c14b1) zpaqfranz: 59.2 -> 59.3
* [`bf047fe5`](https://github.com/NixOS/nixpkgs/commit/bf047fe5d94986c2d7faac037588a235907097d8) python311Packages.openai: 1.20.0 -> 1.23.2
* [`2a6bc86a`](https://github.com/NixOS/nixpkgs/commit/2a6bc86a37a7b8c36a44ed22c6486c6ef30e9930) live555: 2024.03.08 -> 2024.04.14
* [`56928ade`](https://github.com/NixOS/nixpkgs/commit/56928ade2fe5a59e0b43df8531859d6e60aa9d88) argo: 3.5.5 -> 3.5.6
* [`96a74aa9`](https://github.com/NixOS/nixpkgs/commit/96a74aa982971ae11d6e21e6a114d7065af6430f) git-town: 14.0.0 -> 14.1.0
* [`5c4f18af`](https://github.com/NixOS/nixpkgs/commit/5c4f18afbe409f8c352202fcb3f52316c42d86d5) janet: 1.33.0 -> 1.34.0
* [`9b24d063`](https://github.com/NixOS/nixpkgs/commit/9b24d0634a4861aaa21df4ab67fe742bc7d7c63d) minikube: 1.32.0 -> 1.33.0
* [`f98db752`](https://github.com/NixOS/nixpkgs/commit/f98db7521f8c4fd9afb2d13605f416eb3852bd1f) mpvpaper: 1.4 -> 1.5
* [`174d455c`](https://github.com/NixOS/nixpkgs/commit/174d455cd22ab36d984bbef0f8bf912ef4d80c2a) sttr: 0.2.19 -> 0.2.20
* [`f4607696`](https://github.com/NixOS/nixpkgs/commit/f460769696afdae0751733432c15e46eb0f89912) signal-cli: 0.13.2 -> 0.13.3
* [`32da45d9`](https://github.com/NixOS/nixpkgs/commit/32da45d943575e585c4a03b1d2b9039745c5c545) python311Packages.opentelemetry-api: add updateScript
* [`a86f7b67`](https://github.com/NixOS/nixpkgs/commit/a86f7b674f09a8f3d5e8e6ea0f69ab5d643762fc) python311Packages.opentelemetry-api: 1.23.0 -> 1.24.0
* [`96bb1fe6`](https://github.com/NixOS/nixpkgs/commit/96bb1fe6abbb1f618acc99302d3195c2fd8ec5fa) python311Packages.opentelemetry-instrumentation: 0.44b0 -> 0.45b0
* [`18a4e083`](https://github.com/NixOS/nixpkgs/commit/18a4e0830c070a021e4311c026f217bb77a0299e) mmtf-cpp: relax platform restriction
* [`8902f1bf`](https://github.com/NixOS/nixpkgs/commit/8902f1bfd07e1ef425ce83508a1181c590882784) mmtf-cpp: adopt finalAttrs pattern
* [`72b5564c`](https://github.com/NixOS/nixpkgs/commit/72b5564c4dfe449424e225b1000e6dc2c1ef85fa) kodiPackages.jellyfin: 1.0.1 -> 1.0.2
* [`85f94ec4`](https://github.com/NixOS/nixpkgs/commit/85f94ec4b652c5978915317606531c1d5cc98d40) maintainers: add gdifolco
* [`1c3fa285`](https://github.com/NixOS/nixpkgs/commit/1c3fa28588f251d8cc4889eca742498a641cf44c) mmlgui: unstable-2023-11-16 -> unstable-2024-04-15
* [`f284c347`](https://github.com/NixOS/nixpkgs/commit/f284c34780ea09cbffe7eb0be58d51a9c6193357) pyprland: 2.2.5 -> 2.2.10
* [`f35531bc`](https://github.com/NixOS/nixpkgs/commit/f35531bc9e200e386df0806a76b2acb448bcd49d) python312Packages.asteval: refactor
* [`db1732a6`](https://github.com/NixOS/nixpkgs/commit/db1732a6af7f7cf87c307d32c6577b45eb95fc65) python312Packages.asteval: 0.9.31 -> 0.9.32
* [`7429e993`](https://github.com/NixOS/nixpkgs/commit/7429e993a7012f17881dd6b13a1d72dd3ae97354) python312Packages.asteval: format with nixfmt
* [`70364d30`](https://github.com/NixOS/nixpkgs/commit/70364d30df28f57fffc5d9f71b608e0f408b9f37) miriway: unstable-2024-04-04 -> unstable-2024-04-16
* [`e7f04d8c`](https://github.com/NixOS/nixpkgs/commit/e7f04d8cb9ea9bd0a8d5157bf24e46dc8417966b) maintainers: add daru-san
* [`2e123b6f`](https://github.com/NixOS/nixpkgs/commit/2e123b6f6da098871fab71481c1702e7dff7aa03) brave: 1.64.122 -> 1.65.114
* [`cb0ecfc0`](https://github.com/NixOS/nixpkgs/commit/cb0ecfc02553e3590085002f7c1fa5ea2b421a40) gotosocial: 0.14.2 -> 0.15.0
* [`d244dc96`](https://github.com/NixOS/nixpkgs/commit/d244dc962d48cabbb000ccd0eac73f07e77833cc) gotosocial: do not skip TestValidateEmail
* [`f92bbde7`](https://github.com/NixOS/nixpkgs/commit/f92bbde73ffeb2c29240d7fc61b42217d7049f04) gotosocial: do not run test for now
* [`63e7c2ea`](https://github.com/NixOS/nixpkgs/commit/63e7c2ea43bf8fc0dee168c035481daaf385abc1) marimo: 0.4.0 -> 0.4.2
* [`e6a7bc29`](https://github.com/NixOS/nixpkgs/commit/e6a7bc29249575d4b6d38b6c1cef855cc8e98146) ocamlPackages.lacaml: 11.0.8 -> 11.0.10
* [`01353ad2`](https://github.com/NixOS/nixpkgs/commit/01353ad24ef390c6eff070b1266a5dad0cba6058) ocamlPackages.zmq-lwt: 5.2.1 -> 5.3.0
* [`2fc12a77`](https://github.com/NixOS/nixpkgs/commit/2fc12a7743b0072d8c066cba61ff5055b809cc57) go-mockery: 2.42.2 -> 2.42.3
* [`ebe1a3ff`](https://github.com/NixOS/nixpkgs/commit/ebe1a3ff98ecea35f5064ddc0e633184587d92a9) kde-rounded-corners: 0.6.1 -> 0.6.2
* [`7daa782e`](https://github.com/NixOS/nixpkgs/commit/7daa782ef3e1d9f37f0c979f151af42df1759467) livekit-cli: 1.4.1 -> 1.4.2
* [`66cd4111`](https://github.com/NixOS/nixpkgs/commit/66cd4111d15bb2aca7507d379b28933b2b6fff96) prismlauncher-qt5: drop
* [`69366775`](https://github.com/NixOS/nixpkgs/commit/693667750c240ba2ccf73af6ed343cd0763fdf8e) pet: 0.7.0 -> 0.7.1
* [`cb753cbf`](https://github.com/NixOS/nixpkgs/commit/cb753cbf7ec484c50adc0cc226d03e7173fbcc00) signalbackup-tools: 20240415-2 -> 20240420-1
* [`77bbfbd4`](https://github.com/NixOS/nixpkgs/commit/77bbfbd498fa85682316f4e5d70f817f2b6077a5) tailscale-nginx-auth: 1.64.0 -> 1.64.2
* [`851ba0b6`](https://github.com/NixOS/nixpkgs/commit/851ba0b692fad1197ec0d6825aa1d95e253903d1) wfa2-lib: 2.3.4 -> 2.3.5
* [`79458460`](https://github.com/NixOS/nixpkgs/commit/79458460fd3e94210fac94f0fd97561f61964dd4) watchexec: 1.25.1 -> 2.0.0
* [`cd5f77b5`](https://github.com/NixOS/nixpkgs/commit/cd5f77b5a8d986f875c7330382b52eec1a94ca6b) hyprland-workspaces: init at 2.0.0
* [`945a3bbb`](https://github.com/NixOS/nixpkgs/commit/945a3bbb8b52f953ef03b2679f3b65ed5ec9044c) postgresqlPackages.promscale_extension: remove deprecated and broken package
* [`a0a13286`](https://github.com/NixOS/nixpkgs/commit/a0a1328606a6a0c1f182272a9822448255182711) buildPgxExtension: remove old versions
* [`38cdbc17`](https://github.com/NixOS/nixpkgs/commit/38cdbc17439a2cc2bea0135dfd7053baf58d3560) atmos: 1.69.0 -> 1.70.0
* [`5e9ba95f`](https://github.com/NixOS/nixpkgs/commit/5e9ba95ffead6b1a9b4a0c964f8bd753a6924f5f) tuifimanager: 3.3.5 -> 4.0.0
* [`8463dad6`](https://github.com/NixOS/nixpkgs/commit/8463dad6c820f8378807c7a60a6940ed87c4412b) rkboot: init
* [`27843dd4`](https://github.com/NixOS/nixpkgs/commit/27843dd41023e012eb68b92fcd27296452476ac9) rkbin: set platforms to lib.platforms.all
* [`8cb65690`](https://github.com/NixOS/nixpkgs/commit/8cb6569074bcd091fa9b03f498f0d63514282f4f) python311Packages.pillow-heif: don't skip test_full_build
* [`d1577279`](https://github.com/NixOS/nixpkgs/commit/d1577279d97985c8edb97ff12c749626abee1fc3) sitespeed-io: 33.5.0 -> 33.6.0
* [`72c2b8bc`](https://github.com/NixOS/nixpkgs/commit/72c2b8bc87bb0650b3dc545dd1846581bf33e63d) hyprland-activewindow: init at 1.0.1
* [`cddcb2a4`](https://github.com/NixOS/nixpkgs/commit/cddcb2a4f133d25684968c9140b23ce922830b64) python312Packages.avro: ubreak
* [`cf2633cd`](https://github.com/NixOS/nixpkgs/commit/cf2633cdb61ec559f418e4a6b1ec8b77a75adeec) reaper: 7.14 -> 7.15
* [`117f86f9`](https://github.com/NixOS/nixpkgs/commit/117f86f9fa6d01d1041ed9186ecbdcad9e42d57f) prismlauncher: fix darwin
* [`4ab4ab0e`](https://github.com/NixOS/nixpkgs/commit/4ab4ab0e2ac85d4a4c8afaa47715c257bc47ed8a) python311Packages.ocrmypdf: 16.1.2 -> 16.2.0
* [`a92a4878`](https://github.com/NixOS/nixpkgs/commit/a92a4878ab2d304827a8d2d8c9a83fa12d2c8780) omnictl: 0.32.2 -> 0.33.2
* [`43a48177`](https://github.com/NixOS/nixpkgs/commit/43a481774b918564b77f3a6ea576c9d70838164e) robin-map: 1.2.2 -> 1.3.0
* [`3c009e35`](https://github.com/NixOS/nixpkgs/commit/3c009e35d31e1a9066b12763a39cfef5150e9f66) contributing: add link to rebasing+squashing
* [`30de194f`](https://github.com/NixOS/nixpkgs/commit/30de194f8072314abc8d51d243466bdb35860bd7) emacsPackages.lsp-bridge: fix passthru.updateScript
* [`c30c183b`](https://github.com/NixOS/nixpkgs/commit/c30c183baec7c7e0c029e41f8e6e3b90e82ae38a) postgresqlPackages.lantern: set pname to postgresql-lantern
* [`779ba669`](https://github.com/NixOS/nixpkgs/commit/779ba6696be66fe85a5515516cc19c64f59b100e) emacsPackages.lsp-bridge: 20231021.309 -> 20240423.38
* [`8fcdec42`](https://github.com/NixOS/nixpkgs/commit/8fcdec4243956a26d2eaf4b95858ab6cac2448e0) recoll-nox: add alias
* [`d1d5568d`](https://github.com/NixOS/nixpkgs/commit/d1d5568d94788976716e101a2d97d6670e816d57) _1password: add passthru.updateScript
* [`e5b83af9`](https://github.com/NixOS/nixpkgs/commit/e5b83af91b97f669b5b1d36b04d2ebbe88fb2140) cemu: 2.0-78 -> 2.0-79
* [`e4ff4ccc`](https://github.com/NixOS/nixpkgs/commit/e4ff4ccc0cff59fa0451769e0558aa4faf31eb69) tela-circle-icon-theme: 2023-10-07 -> 2024-04-19
* [`9aca4d5e`](https://github.com/NixOS/nixpkgs/commit/9aca4d5e0bd65c3ea265605565d816b89b124ee4) python312Packages.identify: 2.5.35 -> 2.5.36
* [`9fafd6e1`](https://github.com/NixOS/nixpkgs/commit/9fafd6e1df00faaafb18819db436a2dad412d946) python312Packages.identify: refactor
* [`7e61ef9c`](https://github.com/NixOS/nixpkgs/commit/7e61ef9c482a825271e048791b45719e21e64034) kdePackages/ecm: format
* [`fdcc5233`](https://github.com/NixOS/nixpkgs/commit/fdcc5233d8b72a69c0369e6ae19fbdaaac2cc08c) llama-cpp: 2674 -> 2700
* [`5f99ae1b`](https://github.com/NixOS/nixpkgs/commit/5f99ae1b34a18f1e5d899946c1b6f798cff5e9b4) strictdoc: 0.0.51 -> 0.0.54
* [`1c5e7fda`](https://github.com/NixOS/nixpkgs/commit/1c5e7fda0005778ce7128e39ff7d8293df5acfd4) monophony: 2.8.2 -> 2.9.0
* [`0dd89bbd`](https://github.com/NixOS/nixpkgs/commit/0dd89bbdc6c5aa2f6db710e34af523826c889618) calibre: 7.8.0 -> 7.9.0
* [`cb8b9c3f`](https://github.com/NixOS/nixpkgs/commit/cb8b9c3fc043f84a1b9a2bf7a69772364a43228d) touchosc: 1.3.0.202 -> 1.3.1.204
* [`34604d41`](https://github.com/NixOS/nixpkgs/commit/34604d41492037e3bd1173028412cfcb0d96dd31) stats: 2.10.7 -> 2.10.10
* [`020de0e8`](https://github.com/NixOS/nixpkgs/commit/020de0e8d14ba13a06fdea01ba66d3a557247f90) fallout2-ce: 1.2.0 -> 1.3.0
* [`c6439dcf`](https://github.com/NixOS/nixpkgs/commit/c6439dcf9a9a6dee03125314e6a6d69df2517537) jnv: 0.2.1 -> 0.2.2
* [`d5ae51a6`](https://github.com/NixOS/nixpkgs/commit/d5ae51a685e7b0b168111d0bf7e2622be3064a89) prowlarr: 1.15.0.4361 -> 1.16.2.4435
* [`df3a6986`](https://github.com/NixOS/nixpkgs/commit/df3a6986afeb3ab34460bdfb2fd583fc2e43c476) python312Packages.aranet4: refactor
* [`f6fff778`](https://github.com/NixOS/nixpkgs/commit/f6fff778b2364242daff4ec90755d4cef8d184f6) python312Packages.aranet4: format with nixfmt
* [`5d571400`](https://github.com/NixOS/nixpkgs/commit/5d571400e44b9689827dfdbf2bf4ff50b31b8bb6) prometheus-redis-exporter: 1.58.0 -> 1.59.0
* [`38702447`](https://github.com/NixOS/nixpkgs/commit/3870244788b3b47090b95a0c6580ac2d0b9f5d53) gdu: 5.27.0 -> 5.28.0
* [`1c175dae`](https://github.com/NixOS/nixpkgs/commit/1c175dae0425a2adfb881534db4171851e5e5fb4) gdu: foramt with nixfmt
* [`33e02424`](https://github.com/NixOS/nixpkgs/commit/33e02424d2c9165bef7799bc8ea25f8bbdfe2c1c) lib: Document status of deprecated.nix and move it
* [`b5ed5121`](https://github.com/NixOS/nixpkgs/commit/b5ed51215e7885e2cbe36fa013e62ee19aa3e2c6) vimix-gtk-themes: 2023-09-09 -> 2024-04-20
* [`08cf70ce`](https://github.com/NixOS/nixpkgs/commit/08cf70ce5ab7f9c557dcd2a2a87235fb02798baf) discord: 0.0.49 -> 0.0.50
* [`89b8f2e2`](https://github.com/NixOS/nixpkgs/commit/89b8f2e2988f456cdae15c8134afaceb02fbd76d) discord-ptb: 0.0.78 -> 0.0.80
* [`9e35527f`](https://github.com/NixOS/nixpkgs/commit/9e35527f8d2f06f5fb05aa3631476a85ea519185) discord-canary: 0.0.346 -> 0.0.357
* [`a3247618`](https://github.com/NixOS/nixpkgs/commit/a324761827080b46a47c159e1b421a5b0b61396a) pkgsCross.aarch64-darwin.discord: 0.0.300 -> 0.0.301
* [`38876bf2`](https://github.com/NixOS/nixpkgs/commit/38876bf2d76ea89935e107159cc4ebc6e08ba347) pkgsCross.aarch64-darwin.discord-ptb: 0.0.107 -> 0.0.109
* [`eb11fbda`](https://github.com/NixOS/nixpkgs/commit/eb11fbdab7e680b2304e4b874a8bbe4ca8bd6b02) pkgsCross.aarch64-darwin.discord-canary: 0.0.468 -> 0.0.477
* [`7b2e4223`](https://github.com/NixOS/nixpkgs/commit/7b2e4223346a8e0d362b1a32419217118a964fa5) zrok: 0.4.26 -> 0.4.27
* [`9f7cb709`](https://github.com/NixOS/nixpkgs/commit/9f7cb709c1cfd90967dcd688046c9ec41abf52fc) python311Packages.pyaml: 23.12.0 -> 24.4.0
* [`d4f78fde`](https://github.com/NixOS/nixpkgs/commit/d4f78fde662a67fb2115f79627500ccc3426190a) mueval: broken on aarch64
* [`f4060e55`](https://github.com/NixOS/nixpkgs/commit/f4060e55394a0c0da6439a6a7d2af9dfaf824b63) graphite-cli: 1.2.8 -> 1.3.3
* [`f90ad8af`](https://github.com/NixOS/nixpkgs/commit/f90ad8afb528ffbcfcdd2ffaa3e64bfcbd7fa966) tmuxp: Remove kaptan and click dependency (unused)
* [`07f3dbf2`](https://github.com/NixOS/nixpkgs/commit/07f3dbf22d2c060889a7b0938ff1ee71d40e92c4) wine-staging: 9.6 -> 9.7
* [`8df8f916`](https://github.com/NixOS/nixpkgs/commit/8df8f916b8801a6dbe82f3c9a41db82f66cd231a) signal-desktop(aarch64): 7.3.0 -> 7.5.1
* [`58b5b274`](https://github.com/NixOS/nixpkgs/commit/58b5b2748f6be02dbed4a11d820ffa7223ec6fa2) treewide: fix version in changelog
* [`9fd30b8b`](https://github.com/NixOS/nixpkgs/commit/9fd30b8be477f25819e1ec208c8e9f4debf5e304) kdePackages.solid: backport fix for mounting LUKS devices
* [`20cd0607`](https://github.com/NixOS/nixpkgs/commit/20cd060754562e439dfe03115482c9c804849643) kdePackages/ecm: add `python3` to `extraPropagatedBuildInputs`
* [`acfd2113`](https://github.com/NixOS/nixpkgs/commit/acfd21135b5665a870aac253fcc9ab47daab9606) python311Packages.backports-shutil-which: normalize pname
* [`4be0d11e`](https://github.com/NixOS/nixpkgs/commit/4be0d11e2e6cccdbfe17082c5e60422dde051adb) texlive.tlpdb.nix: replace gplX licenses with gplXOnly
* [`e1835b50`](https://github.com/NixOS/nixpkgs/commit/e1835b50115294260b7e73ebbc1ea5ef986b6aae) texlive.bin.core: use gpl2Plus license instead of gpl2
* [`75b5cf27`](https://github.com/NixOS/nixpkgs/commit/75b5cf271082d6ebbc29f5026aa90548ebd9b1d0) python312Packages.openai-whisper: remove unused runtime dependencies
* [`4e148d66`](https://github.com/NixOS/nixpkgs/commit/4e148d6603b62c18c37f73ccedb430d0ecf586c3) python3Packages.maestral: 1.9.2 -> 1.9.3
* [`b5fa4f0c`](https://github.com/NixOS/nixpkgs/commit/b5fa4f0c8520fe68aeb1d0b5b0c21c9beeb9522c) maestral-qt: 1.9.2 -> 1.9.3
* [`bcaf5dd0`](https://github.com/NixOS/nixpkgs/commit/bcaf5dd0fba1a902aa1377971560d6fd82a427dd) python-qt: 3.5.0 -> 3.5.1
* [`b7440798`](https://github.com/NixOS/nixpkgs/commit/b7440798d3e769e370535220d5dfb14abb06d104) asymptote: move texliveSmall to nativeBuildInputs
* [`e2d64efd`](https://github.com/NixOS/nixpkgs/commit/e2d64efdcbc0b5987d72bfa1e4524845a0f54aee) asymptote: do not build sty, docs if provided via texlive
* [`22d4287a`](https://github.com/NixOS/nixpkgs/commit/22d4287ad287488ea9dcda626c7382399aaac10f) texlive.bin.asymptote: use sty, docs shipped by texlive
* [`a733987c`](https://github.com/NixOS/nixpkgs/commit/a733987ca028e2c9dfa85cb3ab49e3a377d25086) texlive.bin.xindy: do not build docs and rules already shipped by texlive
* [`783fb1cb`](https://github.com/NixOS/nixpkgs/commit/783fb1cbe2c5e047070655c57f2368649b8fd25b) asymptote: 2.88 -> 2.89
* [`18e37282`](https://github.com/NixOS/nixpkgs/commit/18e3728274442184b7a293155f198080ee455dda) normcap: unbreak by disabling failing tests
* [`e475ed64`](https://github.com/NixOS/nixpkgs/commit/e475ed648e5d41265d8029d7bd9189de4cdc99db) drbd driver: 9.2.7 -> 9.2.8
* [`0d3b34f4`](https://github.com/NixOS/nixpkgs/commit/0d3b34f45acefcaef9ab7596ee1ed32c6b4d1e61) maintainers: remove KamilaBorowska
* [`cf930207`](https://github.com/NixOS/nixpkgs/commit/cf93020709ad3f28ff6e25a10895da44738191d5) python311Packages.mesa: mark as broken
* [`07fcd33b`](https://github.com/NixOS/nixpkgs/commit/07fcd33b93d60d655d7174079f666cb346f59fe1) koodo-reader: init at 1.6.6
* [`88318d91`](https://github.com/NixOS/nixpkgs/commit/88318d910a57adc3fbe2ac024e6a2c5760ef3a44) libretro.dolphin: unstable-2022-12-17 -> unstable-2024-04-19
* [`6076fe05`](https://github.com/NixOS/nixpkgs/commit/6076fe0564d2b855cfa7296d5f4ede4991a253bf) libretro.beetle-psx-hw: unstable-2024-04-12 -> unstable-2024-04-19
* [`aae689f5`](https://github.com/NixOS/nixpkgs/commit/aae689f5e69c1c7269db2016fe92931b0b667daa) retroarch-assets: unstable-2024-01-02 -> unstable-2024-04-18
* [`c05b98d9`](https://github.com/NixOS/nixpkgs/commit/c05b98d9495c62561fd7f73e182db30ac25a0e89) libretro.play: unstable-2024-04-10 -> unstable-2024-04-15
* [`9791d7aa`](https://github.com/NixOS/nixpkgs/commit/9791d7aa862edddbc0ff46d4bfd39118e5023f7c) whitesur-icon-theme: 2024-04-08 -> 2024-04-22
* [`aa3a280b`](https://github.com/NixOS/nixpkgs/commit/aa3a280b8dfd3fb5b59207b8cb1d9cf268cdd8d0) godot_4: 4.2.1-stable -> 4.2.2-stable
* [`2af4510e`](https://github.com/NixOS/nixpkgs/commit/2af4510ed28706e309f2c04a6a14ac4e60bccaaa) godot_4-export-templates: init 4.2.2-stable
* [`e5346362`](https://github.com/NixOS/nixpkgs/commit/e53463627cff6159df6923b3fa0834d5834a4d3c) godot_4: enable debug flag
* [`1912515d`](https://github.com/NixOS/nixpkgs/commit/1912515d378497feac53430bb2ba4edd3d091cb1) godot_4: refactor nested with
* [`824ba819`](https://github.com/NixOS/nixpkgs/commit/824ba819434d6fa18cef5e0c9c9ece6922253d7d) godot_4: add superherointj as maintainer
* [`7bb471b3`](https://github.com/NixOS/nixpkgs/commit/7bb471b3e8d0529af588b73fa715c729a9c5d92b) nixos/roundcube: use php 8.3
* [`51bf6902`](https://github.com/NixOS/nixpkgs/commit/51bf6902c8e41bb2137dadb6daf64720b68c7af4) libretro.pcsx-rearmed: unstable-2024-04-14 -> unstable-2024-04-18
* [`52c22bd7`](https://github.com/NixOS/nixpkgs/commit/52c22bd7570a1cd1c8a0289c5448b0af72215a1e) libretro.mame2003-plus: unstable-2024-04-13 -> unstable-2024-04-19
* [`4496db09`](https://github.com/NixOS/nixpkgs/commit/4496db09bb6b732b4299a648c338cf2ded6ebb75) libretro.ppsspp: unstable-2024-04-14 -> unstable-2024-04-20
* [`628b7783`](https://github.com/NixOS/nixpkgs/commit/628b778397ac735c9224397793ebe598991a6cea) libretro.snes9x: unstable-2024-04-13 -> unstable-2024-04-20
* [`1d5354ec`](https://github.com/NixOS/nixpkgs/commit/1d5354ec4db51a5cb71f283055e3c4b4b9e5c617) fffuu: allow building with split-0.2.5
* [`0642b663`](https://github.com/NixOS/nixpkgs/commit/0642b6635090c3e9e29707eb42d9af6a2277e4a3) isolate: add more outputs included in v2
* [`6eb807ee`](https://github.com/NixOS/nixpkgs/commit/6eb807eef0430cea6af7785a3c7fbb1161d839e4) isolate: patch to take config file by environment variable
* [`b450c1c3`](https://github.com/NixOS/nixpkgs/commit/b450c1c310a7acf5e4a0eba08e078c7638a0deb2) libretro.genesis-plus-gx: unstable-2024-04-05 -> unstable-2024-04-20
* [`c7841bef`](https://github.com/NixOS/nixpkgs/commit/c7841bef95172af69e25a241a172e4a7f8a5a01f) libretro.puae: unstable-2024-04-12 -> unstable-2024-04-19
* [`a30ab0bf`](https://github.com/NixOS/nixpkgs/commit/a30ab0bff5772696594ffc044c70bcb284a3778d) libretro.fbneo: unstable-2024-04-15 -> unstable-2024-04-20
* [`43292146`](https://github.com/NixOS/nixpkgs/commit/4329214630984dc083de4ef3381950e4a41d4776) libretro.flycast: unstable-2024-04-12 -> unstable-2024-04-19
* [`8347d265`](https://github.com/NixOS/nixpkgs/commit/8347d265bfe70425ecd957bb72022f5a24f26e9a) python311Packages.distributed: 2023.12.0 -> 2024.4.2
* [`caa3289d`](https://github.com/NixOS/nixpkgs/commit/caa3289d465298df746eeb9df1f0421b7028ac4a) python311Packages.dask-expr: init at 1.0.12
* [`c7294aaf`](https://github.com/NixOS/nixpkgs/commit/c7294aaf8169da36bc3a214a4a87eb1d96c4c99e) python311Packages.dask: 2024.1.1 -> 2024.4.2
* [`6b8cec20`](https://github.com/NixOS/nixpkgs/commit/6b8cec207bd06930a180275ecf987f846c36231b) python311Packages.coffea: 2024.2.2 -> 2024.4.1
* [`ec6c7d7c`](https://github.com/NixOS/nixpkgs/commit/ec6c7d7c901acc921091ff0122cd4f989e0fa944) python311Packages.awkward: disable failing test for darwin
* [`e5c2ae5f`](https://github.com/NixOS/nixpkgs/commit/e5c2ae5fc2d8413971ef3b86bdf40a2b67c3fc25) gumbo: update project link
* [`ed9f8852`](https://github.com/NixOS/nixpkgs/commit/ed9f885286ff5690470d0c94d46f714a8c1f5a68) libretro.swanstation: unstable-2024-01-26 -> unstable-2024-04-18
* [`78b68904`](https://github.com/NixOS/nixpkgs/commit/78b689043876b08a8bfd7a0afe2238d8c5f3ac1e) plex: 1.40.1.8227-c0dd5a73e -> 1.40.2.8395-c67dce28e
* [`12d2f386`](https://github.com/NixOS/nixpkgs/commit/12d2f3864db6a9ebb6b8e63d2d5a1d22566d0fb7) python312Packages.jedi-language-server: disable tests failing on Darwin.
* [`75cf19b1`](https://github.com/NixOS/nixpkgs/commit/75cf19b19bd20bc8ad72d78e394b1ae6354860b3) tetrio-plus: unstable-2024-03-31 -> unstable-2024-04-20
* [`3b142ae5`](https://github.com/NixOS/nixpkgs/commit/3b142ae5ad09f278a58824c43790ce6a561e16ed) python311Packages.pyfritzhome: 0.6.10 -> 0.6.11
* [`bce71e97`](https://github.com/NixOS/nixpkgs/commit/bce71e97a07bc342d89ce85480fb3b134e1395d8) haskellPackages.cabal2nix-unstable: 2024-02-05 -> 2024-04-21
* [`fd8ab543`](https://github.com/NixOS/nixpkgs/commit/fd8ab54324450671c5de41177e776045b732b7ec) git-annex: don't use redundant installation targets
* [`cdedb410`](https://github.com/NixOS/nixpkgs/commit/cdedb410393cacc4756422d7d64b5144b816ff28) git-annex: fix installation location of .desktop files and icons
* [`69e0d2cb`](https://github.com/NixOS/nixpkgs/commit/69e0d2cb42847a5a977fa5c62713e38480699ce7) git-annex: crypto test no longer fails on darwin
* [`4a129919`](https://github.com/NixOS/nixpkgs/commit/4a1299190e087eead9ef5bc288e6015564fbe146) git-annex: skip test requiring unavailable tool on darwin
* [`157b2441`](https://github.com/NixOS/nixpkgs/commit/157b2441a7485d239469fa77163413f0f22250e9) maa-cli: 0.4.5 -> 0.4.6
* [`e1c38d17`](https://github.com/NixOS/nixpkgs/commit/e1c38d17a0f8f922d9e5725d8af4c55e6bcc579a) nng: 1.7.3 -> 1.8.0
* [`d08c0dbc`](https://github.com/NixOS/nixpkgs/commit/d08c0dbc47c7be7f8db9ebfbfc49b8e66d5b5d86) workflows: force CLI color when running nixpkgs-check-by-name
* [`a97d8db6`](https://github.com/NixOS/nixpkgs/commit/a97d8db6c704be51924ed0fbb7a106f779a75702) librewolf-unwrapped: 124.0.2-1 -> 125.0.1-1
* [`91354da6`](https://github.com/NixOS/nixpkgs/commit/91354da6662d7f5f2714e8532e27cc43bb1d58bd) miranda: fix build with clang
* [`e2173b5f`](https://github.com/NixOS/nixpkgs/commit/e2173b5f147e2f41154c63cec07136bea72c0bcf) snow: fix build
* [`6a577114`](https://github.com/NixOS/nixpkgs/commit/6a57711408d399e1796d41a69737b57da714c29f) python311Packages.ical: 7.0.3 -> 8.0.0
* [`13cd8b84`](https://github.com/NixOS/nixpkgs/commit/13cd8b8437c43cafadf7c039372be95f16fbd4ec) lambda-delta: fix build with clang
* [`93286737`](https://github.com/NixOS/nixpkgs/commit/932867377362aad91abf8d41cd23b2495e8db29b) cargo-mutants: 24.3.0 -> 24.4.0
* [`4ca92fb6`](https://github.com/NixOS/nixpkgs/commit/4ca92fb6eca42b3caa9b14b2f02eed98fa9abdd6) nixos/isolate: init module
* [`4a0a12ef`](https://github.com/NixOS/nixpkgs/commit/4a0a12efc2433642f6fa28d7837983a3c83796aa) nixos/isolate: add tests
* [`2eeab3a8`](https://github.com/NixOS/nixpkgs/commit/2eeab3a8933f5fb53329511b4e1cbe3e9aba829c) chickenPackages_5: fix build with clang
* [`82864d1b`](https://github.com/NixOS/nixpkgs/commit/82864d1bfd3086da54e3bac894e088b8ab70ec78) ocamlPackages.janeStreet_0_9_0: drop
* [`2a30fa8c`](https://github.com/NixOS/nixpkgs/commit/2a30fa8ccbfe463f8c792ab91bd194b9772d3ec9) msgpack-tools: include darwin
* [`a952ecf9`](https://github.com/NixOS/nixpkgs/commit/a952ecf90b24f973ba6372fa951dc6fb2d76fa85) troubadix: 24.4.0 -> 24.4.1
* [`195fc2ed`](https://github.com/NixOS/nixpkgs/commit/195fc2ed796ea0bbb69c05a0dc6e9b09da4aa34b) bngblaster: 0.8.44 -> 0.8.47
* [`3634c008`](https://github.com/NixOS/nixpkgs/commit/3634c00898e3e8a2e6d09bc37b58e51e46e51107) cargo-expand: 1.0.84 -> 1.0.85
* [`f576198e`](https://github.com/NixOS/nixpkgs/commit/f576198e981027ac9c62de2ae6d5b7068cd6dee9) ocamlPackages.letsencrypt: 0.5.0 -> 0.5.1
* [`011fdb05`](https://github.com/NixOS/nixpkgs/commit/011fdb05da90f0e918fb594190730af55a320105) gqlgenc: 0.20.0 -> 0.21.1
* [`2978052a`](https://github.com/NixOS/nixpkgs/commit/2978052a7700e7dc8931f52885090209c59da6bd) python312Packages.airtouch5py: init at 0.2.8
* [`a16e053b`](https://github.com/NixOS/nixpkgs/commit/a16e053bf9d90a23b50f21398d5f46dbdc594960) home-assistant: update component packages
* [`a60104ea`](https://github.com/NixOS/nixpkgs/commit/a60104eaf70a57b36b5a82e912209b9896043994) kubecolor: 0.2.2 -> 0.3.1
* [`25ee61a4`](https://github.com/NixOS/nixpkgs/commit/25ee61a4b4cf3c9285a562adc3c99678db6044af) lux: 0.23.0 -> 0.24.0
* [`1ba8ecf0`](https://github.com/NixOS/nixpkgs/commit/1ba8ecf069ffc2f2be911f00854e04d33c323d29) reviewdog: 0.17.3 -> 0.17.4
* [`11acfa59`](https://github.com/NixOS/nixpkgs/commit/11acfa59d248643a0a8fb335242d279d2f533182) protoc-gen-entgrpc: 0.4.5 -> 0.5.0
* [`2a7974fe`](https://github.com/NixOS/nixpkgs/commit/2a7974fe9b3ebedc9230fb565ea13991a6b491c4) pv-migrate: 1.7.1 -> 1.8.0
* [`d03346fe`](https://github.com/NixOS/nixpkgs/commit/d03346fee1aad7905bc9c72e214c4197f7bedfe0) waycheck: 1.2.0 -> 1.2.1
* [`fc67f455`](https://github.com/NixOS/nixpkgs/commit/fc67f455c73b369035d2ca6e5312854568b29b8c) haxe: 4.3.3 → 4.3.4
* [`db06045c`](https://github.com/NixOS/nixpkgs/commit/db06045c71e8f3e7024f6911ca3386f6ebba5871) haxe: use OCaml 4.14
* [`1fe3651d`](https://github.com/NixOS/nixpkgs/commit/1fe3651deba5809e19f81ed6fd8422fb5f10b990) Remove .../ocaml-modules/janestreet/old.nix
* [`32bd0dde`](https://github.com/NixOS/nixpkgs/commit/32bd0dde1ff27bda9487677116e76a514a920171) obs-studio-plugins.input-overlay: 5.0.4 -> 5.0.5
* [`35e2279b`](https://github.com/NixOS/nixpkgs/commit/35e2279be6e8c1fcfea855433b88b2f0c737367e) files-cli: 2.13.2 -> 2.13.7
* [`f728350b`](https://github.com/NixOS/nixpkgs/commit/f728350b29d2d5937589b7efb7fbf5416fe6b57e) ocamlPackages.awa: 0.3.0 -> 0.3.1
* [`927c7e41`](https://github.com/NixOS/nixpkgs/commit/927c7e41d1a014e6e072ecb0205e2aad88e62200) exploitdb: 2024-04-20 -> 2024-04-22
* [`57d31b8c`](https://github.com/NixOS/nixpkgs/commit/57d31b8c5414fef3a22121a1e41d3c181f096143) redlib.tests: fix eval
* [`b87173a6`](https://github.com/NixOS/nixpkgs/commit/b87173a6ad4576f04451b471e282ae5f5c6406b7) python312Packages.tencentcloud-sdk-python: 3.0.1132 -> 3.0.1133
* [`a933217c`](https://github.com/NixOS/nixpkgs/commit/a933217c14b312762beccea157b7b8fbc3c141eb) python310Packages.ovoenergy: add changelog to meta
* [`4f63d084`](https://github.com/NixOS/nixpkgs/commit/4f63d0846fbf14ed361c84040bbc7c14dfe035f2) python312Packages.ovoenergy: 1.3.1 -> 2.0.0
* [`161c71f5`](https://github.com/NixOS/nixpkgs/commit/161c71f5b756209c381fcf8553c6e8339b0b7133) python312Packages.ovoenergy: refactor
* [`75b43a46`](https://github.com/NixOS/nixpkgs/commit/75b43a467ed0a9407757c8ceaaf771441aa54b82) python312Packages.ovoenergy: format with nixfmt
* [`af938ef5`](https://github.com/NixOS/nixpkgs/commit/af938ef5d654e65e3ce5eb39390725af2529f7aa) scalafix.tests: fix eval
* [`7ea90559`](https://github.com/NixOS/nixpkgs/commit/7ea90559ca29e7fe048916a3f12c6868765d8e47) ocamlPackages.gen_js_api: 1.1.1 -> 1.1.2
* [`38324986`](https://github.com/NixOS/nixpkgs/commit/383249860ed2072ccc3b4ffdd360ce6c86af642a) csharp-ls: 0.11.0 -> 0.12.0
* [`0b6210f4`](https://github.com/NixOS/nixpkgs/commit/0b6210f491f1c17ad33181ccf47d86845b7e69cd) ocamlPackages.bwd: 2.2.0 -> 2.3.0
* [`01f8eb13`](https://github.com/NixOS/nixpkgs/commit/01f8eb1383bc75b3b7832e1f16fb132529ecd884) nawk: 20240311 -> 20240422
* [`03cf072b`](https://github.com/NixOS/nixpkgs/commit/03cf072bfa632a0320d255e5a2a86e04c66d3a3e) python312Packages.model-bakery: 1.17.0 -> 1.18.0
* [`3e97b42b`](https://github.com/NixOS/nixpkgs/commit/3e97b42b829431c8e6bd76f00bae5d973a815f1e) python312Packages.model-bakery: refactor
* [`1cd9327d`](https://github.com/NixOS/nixpkgs/commit/1cd9327dc47bc45ebac521ea8ccb6d020f830e7c) python312Packages.model-bakery: format with nixfmt
* [`67648e56`](https://github.com/NixOS/nixpkgs/commit/67648e566f00916e3a9388ef79c424db5d18efe5) python312Packages.levenshtein: 0.25.0 -> 0.25.1
* [`576b9e6e`](https://github.com/NixOS/nixpkgs/commit/576b9e6eaf35ad4898988f861a92be1d42f4a93f) python312Packages.levenshtein: format with nixfmt
* [`cbf36308`](https://github.com/NixOS/nixpkgs/commit/cbf36308a5a75d1f74f7ec3245322a7ff769e23b) python311Packages.types-tqdm: 4.66.0.20240106 -> 4.66.0.20240417
* [`9bf5100f`](https://github.com/NixOS/nixpkgs/commit/9bf5100f71f042e0f1abdd66b34a09dc9763eb99) glasskube: 0.1.0 -> 0.2.0
* [`97fd6d57`](https://github.com/NixOS/nixpkgs/commit/97fd6d573e6e60cce26d51bc164b99364fe20695) pixi: 0.19.1 -> 0.20.0
* [`d0302a29`](https://github.com/NixOS/nixpkgs/commit/d0302a298cc8ae211702bf320e0e52d5b2ed8a72) bngblaster: 0.8.44 -> 0.8.47
* [`f1b7d783`](https://github.com/NixOS/nixpkgs/commit/f1b7d78325cabf9551fef2345d3f1ed09e102cc2) bngblaster: format with nixfmt
* [`edbf8617`](https://github.com/NixOS/nixpkgs/commit/edbf8617881e20b27a80a67e15dabfe5e6ab9d93) amqpcat: 0.2.5 -> 1.0.0
* [`af270165`](https://github.com/NixOS/nixpkgs/commit/af270165beea00ab87abbeae1d2ac54c08e48a44) vimPlugins.arrow-nvim: init at 2024-04-19
* [`de662f40`](https://github.com/NixOS/nixpkgs/commit/de662f409a9a656e8780fa6c1acb7dd201ab6730) stirling-pdf: 0.22.8 -> 0.23.0
* [`be137fd0`](https://github.com/NixOS/nixpkgs/commit/be137fd0d047c1f7e36009c90d6e18c30972d475) neovim: propagate pname and version through wrapper
* [`07f52e27`](https://github.com/NixOS/nixpkgs/commit/07f52e27934b8005e25a324b3d99f724b02cad5d) okteto: 2.25.4 -> 2.26.0
* [`06978812`](https://github.com/NixOS/nixpkgs/commit/06978812fcee537b8f7ed0fb1f452e5773b68782) ocamlPackages.syslog-message: 1.1.0 -> 1.2.0
* [`e102133f`](https://github.com/NixOS/nixpkgs/commit/e102133fa1067d0d6acfdf9253eb8e0c1a7c9934) release-haskell.nix: include new nixfmt-* attributes
* [`58e28b38`](https://github.com/NixOS/nixpkgs/commit/58e28b3888f5bb753d65ee19f56566c5e6db9753) ocamlPackages.ca-certs-nss: 3.92 -> 3.98
* [`2456bfc6`](https://github.com/NixOS/nixpkgs/commit/2456bfc6c38b3167d297aa912073685a594efab0) busybox: lower priority to 15, below systemd and coreutils
* [`476a7bfa`](https://github.com/NixOS/nixpkgs/commit/476a7bfaa3fd79be1b8dc826f58c64471916d05a) ntfy-sh: Remove unused dependency mkdocs-simple-hooks
* [`700546b2`](https://github.com/NixOS/nixpkgs/commit/700546b2c1f798d8f26bab2c66756e56fb4ccbcd) pachyderm: 2.9.3 -> 2.9.4
* [`cba6664c`](https://github.com/NixOS/nixpkgs/commit/cba6664c24e8b67d96bc8e3297b90b909b6c9adf) namespace-cli: 0.0.356 -> 0.0.359
* [`9b1a0cad`](https://github.com/NixOS/nixpkgs/commit/9b1a0cadd9b9c2fd2eea153a490803bb29294687) kubectl-klock: 0.5.1 -> 0.6.1
* [`dc1287e4`](https://github.com/NixOS/nixpkgs/commit/dc1287e4a6a541b5830c35c7d52038338e992549) rocksdb: 8.3.2 -> 9.1.0, rocksdb_8_3: init at 8.3.2
* [`f730844b`](https://github.com/NixOS/nixpkgs/commit/f730844b298055f662a001b6b64ff5be7316cc75) imagelol: fix darwin build
* [`78667e9c`](https://github.com/NixOS/nixpkgs/commit/78667e9c1b40c35c8c8eea32efa6811160699783) haskellPackages.mkDerivation: fix logic error
* [`f7709cf1`](https://github.com/NixOS/nixpkgs/commit/f7709cf1b33a050044bde96d66d22f8472fd080c) treewide: switch from rocksdb -> rocksdb_8_3
* [`01aedd3f`](https://github.com/NixOS/nixpkgs/commit/01aedd3f93015b871bceb633407bb25783013873) railway: 3.5.2 -> 3.7.0
* [`cda9faf0`](https://github.com/NixOS/nixpkgs/commit/cda9faf00a5af13d4254fca320933cc6b3c3efd2) libcxxrt: unstable-2024-02-05 -> unstable-2024-04-15
* [`6bc4e63f`](https://github.com/NixOS/nixpkgs/commit/6bc4e63f5f107ad0843f55dd00acdc0390dc66f7) build(deps): bump actions/checkout from 4.1.1 to 4.1.3
* [`8533a6f3`](https://github.com/NixOS/nixpkgs/commit/8533a6f3f89ab0a482dc452d83522c3e8254fdb6) build(deps): bump peter-evans/create-pull-request from 6.0.2 to 6.0.4
* [`044b3342`](https://github.com/NixOS/nixpkgs/commit/044b3342d1500fb2b741e87e4d10894f4d8fd716) libjxl: fix cross compilation by only conditionally enabling plugins
* [`38ea017d`](https://github.com/NixOS/nixpkgs/commit/38ea017d79d6fba18acbca0b626c7afdcc4e2400) stratis-cli: 3.6.0 -> 3.6.2
* [`e8b6d29b`](https://github.com/NixOS/nixpkgs/commit/e8b6d29b6daf11ee7fd0f1a261cf86e74db8c710) maintainers: add AnyTimeTraveler
* [`b81e0261`](https://github.com/NixOS/nixpkgs/commit/b81e02613c57c2edd91065ae14f1786597bb76aa) aphorme: init at 0.1.19
* [`6c309c37`](https://github.com/NixOS/nixpkgs/commit/6c309c37abc0def6877310d044f4c6822b2fc8f2) mwprocapture: fix incorrect hash
* [`718851b2`](https://github.com/NixOS/nixpkgs/commit/718851b229754c86bb20507404a50ec07719d057) haskellPackages.mkDerivation: use emcc as C compiler for ghcjs
* [`7e0bc287`](https://github.com/NixOS/nixpkgs/commit/7e0bc287e385ab6a8d45bf27a6206ef5c0e415b6) vitess: 19.0.1 -> 19.0.3
* [`f171f4ff`](https://github.com/NixOS/nixpkgs/commit/f171f4ffd47a3cc3ad571a70f265bb9c5e73503b) nixos/lxc: add package option and use for incus/lxd
* [`657ad0f3`](https://github.com/NixOS/nixpkgs/commit/657ad0f3c7c9002f08413eb7ebb99cbba2c01834) ddns-go: 6.3.2 -> 6.3.3
* [`b702f1e6`](https://github.com/NixOS/nixpkgs/commit/b702f1e69aa78941f15eb3e675eb65b0c4434d78) cri-o-unwrapped: 1.29.2 -> 1.29.3
* [`7e73ead5`](https://github.com/NixOS/nixpkgs/commit/7e73ead5d0ab1fce66c3122c5e8b9c5bc5bb608a) lxc: 5.0.3 -> 6.0.0, pin to lts, move/format
* [`8db512da`](https://github.com/NixOS/nixpkgs/commit/8db512dae899024237337c78571839eda630ee55) nixos/nginx: update ciphers list
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
