### PR TITLE
niv home-manager: update 67de98ae -> f8e6694e

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -41,10 +41,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "67de98ae6eed5ad6f91b1142356d71a87ba97f21",
-        "sha256": "1psx5s925r3ag2ghvk0nwdxaj4k312lrbsxnzpjf4sn9adnz23bb",
+        "rev": "f8e6694edabe4aaa7a85aac47b43ea5d978b116d",
+        "sha256": "1i6g2i69n5nk0vzm6j2by7nf1bl524xahq46kq9f5wmjlgy508j9",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/67de98ae6eed5ad6f91b1142356d71a87ba97f21.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/f8e6694edabe4aaa7a85aac47b43ea5d978b116d.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@67de98ae...f8e6694e](https://github.com/nix-community/home-manager/compare/67de98ae6eed5ad6f91b1142356d71a87ba97f21...f8e6694edabe4aaa7a85aac47b43ea5d978b116d)

* [`33a20182`](https://github.com/nix-community/home-manager/commit/33a20182e3164f451b6a4ac2ecadcab5c2c36703) home-manager: improve session variables comment
* [`bfa7c064`](https://github.com/nix-community/home-manager/commit/bfa7c06436771e3a0c666ccc6ee01e815d4c33aa) swayosd: add custom style option
* [`2f072c12`](https://github.com/nix-community/home-manager/commit/2f072c127c041eec36621b8e38a531fe0fe07961) zsh: use correct autosuggestion color variable ([nix-community/home-manager⁠#5320](https://togithub.com/nix-community/home-manager/issues/5320))
* [`4c157f84`](https://github.com/nix-community/home-manager/commit/4c157f84e8fbd6a0fd1688b458c6ce04d047a165) flake.lock: Update
* [`3ebcff8d`](https://github.com/nix-community/home-manager/commit/3ebcff8d1219c9e0fb3c880ef7959feca7ea2c4a) Translate using Weblate (Icelandic)
* [`6864ca2d`](https://github.com/nix-community/home-manager/commit/6864ca2d2657d57a041110dcaf8be0c4b71346c0) Add translation using Weblate (Icelandic)
* [`0c5704ec`](https://github.com/nix-community/home-manager/commit/0c5704eceefcb7bb238a958f532a86e3b59d76db) home-manager: make newsReadIdsFile more reliable
* [`26e72d85`](https://github.com/nix-community/home-manager/commit/26e72d85e6fbda36bf2266f1447215501ec376fd) home-manager: set module class to "homeManager"
* [`c1609d58`](https://github.com/nix-community/home-manager/commit/c1609d584a6b5e9e6a02010f51bd368cb4782f8e) xdg-portal: improve description of `enable` option
* [`d1980931`](https://github.com/nix-community/home-manager/commit/d1980931de8252b6ac1104b7191fd68bbbe3a291) psd: add module
* [`02002a08`](https://github.com/nix-community/home-manager/commit/02002a08b489b43e3ac1400609a9bf1b7c08e384) flake.lock: Update
* [`c002bc08`](https://github.com/nix-community/home-manager/commit/c002bc08c8ea6c87198f3024e8bfd6fdb1c90c9e) cliphist: support images in clipboard history
* [`9fe79591`](https://github.com/nix-community/home-manager/commit/9fe79591c1005ce6f93084ae7f7dab0a2891440d) direnv: add nix-direnv to lib instead of sourcing
* [`2af7c78b`](https://github.com/nix-community/home-manager/commit/2af7c78b7bb9cf18406a193eba13ef9f99388f49) thefuck: add nushell integration
* [`b8d81ef1`](https://github.com/nix-community/home-manager/commit/b8d81ef15ed8ec4c72ffc610279d39aa0c4ccbf0) mpv: add extraInput option
* [`08d3cbfe`](https://github.com/nix-community/home-manager/commit/08d3cbfe4d400dad74e54815127fd67c76608a55) firefox: update extensions option description
* [`ba97ffcf`](https://github.com/nix-community/home-manager/commit/ba97ffcfb2bd3ef026bb0a14d8808e9926f57fd7) Translate using Weblate (French)
* [`7ec0ae18`](https://github.com/nix-community/home-manager/commit/7ec0ae18cda5e3aae80996d35f6d0ebd418f1ac8) Translate using Weblate (Japanese)
* [`1a91cb7c`](https://github.com/nix-community/home-manager/commit/1a91cb7cdbcf6b18c27bbead57241baf279d4513) neomutt: allow binds to override vimKeys
* [`9fdd301a`](https://github.com/nix-community/home-manager/commit/9fdd301a5e4d8cf4d4cf3f990e799000a54a3737) lib/generators: toHyprconf init
* [`4fe1f064`](https://github.com/nix-community/home-manager/commit/4fe1f064bd1a37754266eb4c190eac784ca4aaa9) hyprland: use lib.generators.toHyprconf
* [`0125041f`](https://github.com/nix-community/home-manager/commit/0125041fc9ca3127fe95cf53f15c49c482ebaf70) maintainers: add abayomi185 as maintainer
* [`56326598`](https://github.com/nix-community/home-manager/commit/563265988637c27ba3abe39acb9be3ba2cb35a29) swaync: add module
* [`f8e6694e`](https://github.com/nix-community/home-manager/commit/f8e6694edabe4aaa7a85aac47b43ea5d978b116d) files: make collision error message more helpful
