### PR TITLE
niv powerlevel10k: update 178fcda3 -> b28d68f4

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -113,10 +113,10 @@
         "homepage": "",
         "owner": "romkatv",
         "repo": "powerlevel10k",
-        "rev": "178fcda3487afb3bd540d784cf472c60ec0de94a",
-        "sha256": "12iqfgxfldzggn08kd2czhcy4ydn6hr0g5vwj8rd0lk1ppq1m93l",
+        "rev": "b28d68f44b42f25703673fac514d0777f0af9d8a",
+        "sha256": "1ba6ac8q5pvqr7r8dginjq1jczhn1s1gx7731nldy8cv43amx6fv",
         "type": "tarball",
-        "url": "https://github.com/romkatv/powerlevel10k/archive/178fcda3487afb3bd540d784cf472c60ec0de94a.tar.gz",
+        "url": "https://github.com/romkatv/powerlevel10k/archive/b28d68f44b42f25703673fac514d0777f0af9d8a.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "rh": {


### PR DESCRIPTION
## Changelog for powerlevel10k:
Branch: master
Commits: [romkatv/powerlevel10k@178fcda3...b28d68f4](https://github.com/romkatv/powerlevel10k/compare/178fcda3487afb3bd540d784cf472c60ec0de94a...b28d68f44b42f25703673fac514d0777f0af9d8a)

* [`808ba80a`](https://github.com/romkatv/powerlevel10k/commit/808ba80ab005cdb66be19d2c22695c9bab9747f3) fail more gracefully on timewarrior v3.0.1 ([romkatv/powerlevel10k⁠#2648](https://togithub.com/romkatv/powerlevel10k/issues/2648))
* [`01e3f0b4`](https://github.com/romkatv/powerlevel10k/commit/01e3f0b4baeb499c63909e3caeaff575c79d51ce) bump version
* [`b28d68f4`](https://github.com/romkatv/powerlevel10k/commit/b28d68f44b42f25703673fac514d0777f0af9d8a) allow ~/.timewarrior to be a symbolic link ([romkatv/powerlevel10k⁠#2603](https://togithub.com/romkatv/powerlevel10k/issues/2603))
