### PR TITLE
niv emacs-overlay: update b7e580bd -> 7c0c76c9

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b7e580bd8e698b784a02a20071007930f993de99",
-        "sha256": "13msb0syy5189i70rjy2a7r2c9f05ns6y05sxy6ag08408ifsjq6",
+        "rev": "7c0c76c9e970eb75efa0a8dc2a3b8aa5b1028613",
+        "sha256": "0j4mh0j5x5w4dzgjwficvhwy2v78k94z8skdqcqjv1d775cdqx41",
         "type": "tarball",
-        "url": "https://github.com/nix-community/emacs-overlay/archive/b7e580bd8e698b784a02a20071007930f993de99.tar.gz",
+        "url": "https://github.com/nix-community/emacs-overlay/archive/7c0c76c9e970eb75efa0a8dc2a3b8aa5b1028613.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "fast-syntax-highlighting": {


### PR DESCRIPTION
## Changelog for emacs-overlay:
Branch: master
Commits: [nix-community/emacs-overlay@b7e580bd...7c0c76c9](https://github.com/nix-community/emacs-overlay/compare/b7e580bd8e698b784a02a20071007930f993de99...7c0c76c9e970eb75efa0a8dc2a3b8aa5b1028613)

* [`c2e5f187`](https://github.com/nix-community/emacs-overlay/commit/c2e5f187f0efa2668c08e228152f7b561c5b65bd) Updated elpa
* [`6be3f18f`](https://github.com/nix-community/emacs-overlay/commit/6be3f18f4547b7e16b914a3e1e55baa1e775a3e3) Updated melpa
* [`a508458c`](https://github.com/nix-community/emacs-overlay/commit/a508458c9b6e99c5b8cf8785177306f3c54b204b) Updated melpa
* [`81d4eb04`](https://github.com/nix-community/emacs-overlay/commit/81d4eb044fac45daf51281a046d413a40f05d103) Updated emacs
* [`e8388bf6`](https://github.com/nix-community/emacs-overlay/commit/e8388bf6202d0de9f8f8dc04223e1557a5637a45) Updated elpa
* [`97092bb3`](https://github.com/nix-community/emacs-overlay/commit/97092bb3498e0a13eac1493d5cb7f5233cc29f8e) Updated melpa
* [`13612d96`](https://github.com/nix-community/emacs-overlay/commit/13612d96aa95d84cdea6fe0c8fef8117e98ef256) Updated emacs
* [`4070a9eb`](https://github.com/nix-community/emacs-overlay/commit/4070a9eb413f0a7a5501148eb47faf493122b807) Updated flake inputs
* [`03e4eb5d`](https://github.com/nix-community/emacs-overlay/commit/03e4eb5d359e86d3e0cc0a44997bba91fd66b75f) Updated nongnu
* [`63eeb71d`](https://github.com/nix-community/emacs-overlay/commit/63eeb71dc0537e29dcb2136d9c3514b77d4f1a82) Updated elpa
* [`e81dca95`](https://github.com/nix-community/emacs-overlay/commit/e81dca95f5e2c41606cbe9f8dbe2829912698c7a) Updated melpa
* [`945d1bb0`](https://github.com/nix-community/emacs-overlay/commit/945d1bb0aa1424fce01b7107fbb6ec7254bbde55) Updated emacs
* [`9a108561`](https://github.com/nix-community/emacs-overlay/commit/9a108561c43448933272f8709e3936f2242c2abc) README: emacsGit is deprecated, replace it with emacs-git
* [`ccdff575`](https://github.com/nix-community/emacs-overlay/commit/ccdff5758d380ae55c5fef7c7dd6d992e7fe64b2) Updated melpa
* [`9f6f38ce`](https://github.com/nix-community/emacs-overlay/commit/9f6f38ce57d29b78cc6db45cf87813ae631641ec) Updated emacs
* [`d2d0ea13`](https://github.com/nix-community/emacs-overlay/commit/d2d0ea1363528e8584f3b20158470ffe64fc3208) Updated flake inputs
* [`c49d537b`](https://github.com/nix-community/emacs-overlay/commit/c49d537b62bf547ea62f6f5e2a7ae54ff7710d4e) Updated elpa
* [`eae4e64c`](https://github.com/nix-community/emacs-overlay/commit/eae4e64cf625ebad08f65c5c46cb53ad369ec8fb) Updated emacs
* [`f187c8ee`](https://github.com/nix-community/emacs-overlay/commit/f187c8eeef74acb227cf5c3a2fae34c6e1a7dac5) Updated melpa
* [`31f8f393`](https://github.com/nix-community/emacs-overlay/commit/31f8f3937b359e6be3c6d547c7546c2e5d426d93) Updated elpa
* [`02a3dbf2`](https://github.com/nix-community/emacs-overlay/commit/02a3dbf25ff3e2d14c3eb5e03b2f80c7c2b0573b) Updated melpa
* [`57bef37f`](https://github.com/nix-community/emacs-overlay/commit/57bef37f7da3ab0f1c5924aa7e19fdf09d6d9618) Updated flake inputs
* [`89b9788c`](https://github.com/nix-community/emacs-overlay/commit/89b9788ca819ee2f25606c2df4825612bdc8d9ac) Updated melpa
* [`619dd15c`](https://github.com/nix-community/emacs-overlay/commit/619dd15c78edea5b3236c841f25a03d77f260154) Updated emacs
* [`0ecb38ec`](https://github.com/nix-community/emacs-overlay/commit/0ecb38ec45621eaacffb62fcbf9595d7bc200c7f) Updated elpa
* [`04518449`](https://github.com/nix-community/emacs-overlay/commit/04518449b13898684d17bb14baf5213e66cbf602) Updated elpa
* [`8189846d`](https://github.com/nix-community/emacs-overlay/commit/8189846d4d123e9056541088a75c255c6cde3c2d) Updated melpa
* [`8dbeee1c`](https://github.com/nix-community/emacs-overlay/commit/8dbeee1c4befdeb36fbb3a951d5c3bf2b7f1ae05) Updated emacs
* [`673b9304`](https://github.com/nix-community/emacs-overlay/commit/673b93046cd4bf71ad5284e29e9df96e50ef4c82) Updated melpa
* [`82e74326`](https://github.com/nix-community/emacs-overlay/commit/82e74326336ef6fd3b802207bf073ee5c52c4441) Updated nongnu
* [`734cfa5f`](https://github.com/nix-community/emacs-overlay/commit/734cfa5f4f5183076552cb14497768f768be9904) Updated elpa
* [`63c6ebdb`](https://github.com/nix-community/emacs-overlay/commit/63c6ebdb1426947d8e5f3daa3f29f247f8eac218) Update patch
* [`825ea7a5`](https://github.com/nix-community/emacs-overlay/commit/825ea7a501bae55ceea334b3e83a0ac740b137ac) Manually update Emacs
* [`b2b55327`](https://github.com/nix-community/emacs-overlay/commit/b2b55327ffdc55cbc873f86335503ca65a489034) Updated melpa
* [`307fe8bd`](https://github.com/nix-community/emacs-overlay/commit/307fe8bd8599c228f6062e37dd70c10d981434f2) Updated flake inputs
* [`ac7d8c8a`](https://github.com/nix-community/emacs-overlay/commit/ac7d8c8afeb66f66cd1e72194de52f9fb00de25b) Updated nongnu
* [`0986a439`](https://github.com/nix-community/emacs-overlay/commit/0986a439e17fadf35e618f049f48722c3bc46557) Updated elpa
* [`082f1fc8`](https://github.com/nix-community/emacs-overlay/commit/082f1fc8593b304c201439d700c4d89bf08d9a03) Updated melpa
* [`af307726`](https://github.com/nix-community/emacs-overlay/commit/af307726ea14d3be3627790a40ab6d6b2ae1938f) Updated melpa
* [`f8ad90d4`](https://github.com/nix-community/emacs-overlay/commit/f8ad90d467e2a48cf91aa0b3b75ac7929dc07425) Updated emacs
* [`ccd0043a`](https://github.com/nix-community/emacs-overlay/commit/ccd0043a3fb5758b0d17a92e907872cdc4f63ab7) Updated elpa
* [`33f182c7`](https://github.com/nix-community/emacs-overlay/commit/33f182c768a59d1a403bd00f1f1614a0bc3595ef) Updated nongnu
* [`b58ea7d9`](https://github.com/nix-community/emacs-overlay/commit/b58ea7d9c253d9eea3bbf4d5153a9f1f7bc21722) Updated elpa
* [`9dd27fd6`](https://github.com/nix-community/emacs-overlay/commit/9dd27fd6abfe59bab0b99a403f9f2d9caccfeb49) Updated melpa
* [`40c0f10c`](https://github.com/nix-community/emacs-overlay/commit/40c0f10c423a5031eccac9cf61410cc7c266de29) Updated emacs
* [`5bf33997`](https://github.com/nix-community/emacs-overlay/commit/5bf3399794a19f542b99b00db6b6f89edab120fe) Updated melpa
* [`c4d37df2`](https://github.com/nix-community/emacs-overlay/commit/c4d37df2341ca6ed9269e3bff81984fde865aa70) Updated emacs
* [`98f098ea`](https://github.com/nix-community/emacs-overlay/commit/98f098ead66cd01b7eda6877c506882d6ddb6ee1) Updated nongnu
* [`3bfb56ed`](https://github.com/nix-community/emacs-overlay/commit/3bfb56ed6e9c26b13828ccff013578575141c5e9) Updated elpa
* [`95915c61`](https://github.com/nix-community/emacs-overlay/commit/95915c61f4d578c77380f2f8b3d3ee986c5abaee) Updated melpa
* [`dbf1f7fd`](https://github.com/nix-community/emacs-overlay/commit/dbf1f7fdcc2fa15cb60ed0ec6ee84fb75646ed92) Updated emacs
* [`54defcb9`](https://github.com/nix-community/emacs-overlay/commit/54defcb983fa875fd03e9ed1b58aa84dbeb163dc) Updated elpa
* [`37fa5a16`](https://github.com/nix-community/emacs-overlay/commit/37fa5a168a8990ed07f432ac3e79304cab606ef4) Updated melpa
* [`86bd2c62`](https://github.com/nix-community/emacs-overlay/commit/86bd2c6212fcd9adc1e294036423b79bf11f3fc1) Updated emacs
* [`837e7dbc`](https://github.com/nix-community/emacs-overlay/commit/837e7dbc8f34e079cffa396ce759a11ebe51da27) Updated melpa
* [`75fe065d`](https://github.com/nix-community/emacs-overlay/commit/75fe065d92f293d13ee6147254a4de7d893eb431) Updated emacs
* [`f60aa998`](https://github.com/nix-community/emacs-overlay/commit/f60aa998a13ad757eb329561be73a54c69bf90cd) Updated elpa
* [`2ae5595e`](https://github.com/nix-community/emacs-overlay/commit/2ae5595e645ebd754186869d958f33889ec0baf0) Updated melpa
* [`ca072922`](https://github.com/nix-community/emacs-overlay/commit/ca072922f5ccde8a5deb9bc3a8307b95ce37f971) Updated emacs
* [`664dac1c`](https://github.com/nix-community/emacs-overlay/commit/664dac1cc0f5308f5ec6c673c2d0e0d41bcd6407) Updated elpa
* [`fb64abf8`](https://github.com/nix-community/emacs-overlay/commit/fb64abf84f49dc419caa9f5545afe597382bb30e) Updated emacs
* [`5dee04f5`](https://github.com/nix-community/emacs-overlay/commit/5dee04f5269dffad92faf3a8210c03e639d86db2) Updated melpa
* [`a5e600b3`](https://github.com/nix-community/emacs-overlay/commit/a5e600b3947b736643670367d8380317420f3b33) Updated melpa
* [`66655d2a`](https://github.com/nix-community/emacs-overlay/commit/66655d2a1b6faf4a354722bf8f6ef8df80f7524c) Updated elpa
* [`a8983cd1`](https://github.com/nix-community/emacs-overlay/commit/a8983cd18bcca841368f2c56aae4d7efd0bc049e) Updated melpa
* [`7bfcd741`](https://github.com/nix-community/emacs-overlay/commit/7bfcd7412b5b0c0677d41444ff3c4f5d23ee74d8) Updated elpa
* [`d20dbcb7`](https://github.com/nix-community/emacs-overlay/commit/d20dbcb705e84848953212db68d5067d5bb99b05) Updated melpa
* [`5d0a1093`](https://github.com/nix-community/emacs-overlay/commit/5d0a10938c32f3cb95d1f1f18127948d239c6720) Updated emacs
* [`9ff3efce`](https://github.com/nix-community/emacs-overlay/commit/9ff3efceeec20ae2b8c3d42d6057cae2f1f55f36) Updated elpa
* [`451efa21`](https://github.com/nix-community/emacs-overlay/commit/451efa21977d503139fa2235de324f99e6d99c05) Updated melpa
* [`caa3f53e`](https://github.com/nix-community/emacs-overlay/commit/caa3f53e460e97f0499f1006de35cf3f898a66d9) Updated emacs
* [`7480617f`](https://github.com/nix-community/emacs-overlay/commit/7480617fd05f6ed921ee879af6948bbbda53f731) Updated flake inputs
* [`46294460`](https://github.com/nix-community/emacs-overlay/commit/462944602d2eaa43bf51b958e7f453887e9ba3c1) Updated elpa
* [`3a2a6fd5`](https://github.com/nix-community/emacs-overlay/commit/3a2a6fd5bbfe5066377afcae6e001698e5dcdf81) Updated melpa
* [`d8c28bca`](https://github.com/nix-community/emacs-overlay/commit/d8c28bca43275f1503a029cc73629cd1aa585af7) Updated emacs
* [`56cbce1f`](https://github.com/nix-community/emacs-overlay/commit/56cbce1f396f9c98dd899cbc0bd7105d8eace6c5) Updated melpa
* [`4b1e5663`](https://github.com/nix-community/emacs-overlay/commit/4b1e5663bb9c6754d72c722bc2c3acf2dc460066) Updated emacs
* [`07a1b83c`](https://github.com/nix-community/emacs-overlay/commit/07a1b83c60f69503cf2bca8de5d4de26da3e5d8d) Updated flake inputs
* [`cbecad87`](https://github.com/nix-community/emacs-overlay/commit/cbecad879e445e56788ae41cc0133721e69110d4) Updated elpa
* [`ac67d5fc`](https://github.com/nix-community/emacs-overlay/commit/ac67d5fc4081a29e7baaafd9bd9bce85f0a3477b) Updated melpa
* [`2abacaa0`](https://github.com/nix-community/emacs-overlay/commit/2abacaa07d19f6bddd832d451478c95663792da6) Updated emacs
* [`c8b9a44b`](https://github.com/nix-community/emacs-overlay/commit/c8b9a44be2d65bc91549b3c3c1fd2c941072411d) Updated elpa
* [`68c88287`](https://github.com/nix-community/emacs-overlay/commit/68c882877c24a34b032eae7f0a871c020b0a6095) Updated melpa
* [`773d8e0c`](https://github.com/nix-community/emacs-overlay/commit/773d8e0c4f2d1c7c14081a1973e46da651e9aae6) Updated emacs
* [`899b8a69`](https://github.com/nix-community/emacs-overlay/commit/899b8a69149986f51fd9dc414a97f564a1e3ba66) Updated elpa
* [`6a9992d6`](https://github.com/nix-community/emacs-overlay/commit/6a9992d6bc959bab580c98aeeed371f75c2c77c7) Updated melpa
* [`b82c7765`](https://github.com/nix-community/emacs-overlay/commit/b82c77652e4191f41842c6ae39853490f0cc1e13) Updated emacs
* [`9c47d498`](https://github.com/nix-community/emacs-overlay/commit/9c47d498651720aff2f63b3876f4cce56053ee53) Updated nongnu
* [`d33745f8`](https://github.com/nix-community/emacs-overlay/commit/d33745f85f5b61bbe4cd48e81d9abe0083b677a1) Updated elpa
* [`dce01fc2`](https://github.com/nix-community/emacs-overlay/commit/dce01fc2a65d23815a026e946114009b81d21f45) Updated melpa
* [`1c772b55`](https://github.com/nix-community/emacs-overlay/commit/1c772b55c22f91a1b26c4318671deb1788628f24) Updated emacs
* [`71596f24`](https://github.com/nix-community/emacs-overlay/commit/71596f248d13b1d0f5a1b22851c4cb56bf79f9a3) Updated melpa
* [`149186b1`](https://github.com/nix-community/emacs-overlay/commit/149186b1156c0da8d9624bde981d2e5c02aa1376) Updated emacs
* [`4427f0bc`](https://github.com/nix-community/emacs-overlay/commit/4427f0bce9c9df356afa89c7cb6625c19be6ccff) Fix cache miss due to bytecomp-revert
* [`b09fd02f`](https://github.com/nix-community/emacs-overlay/commit/b09fd02f2e2cd256965a8f92d4f94b0de3074b68) Updated flake inputs
* [`015a0575`](https://github.com/nix-community/emacs-overlay/commit/015a05757ddf4c5d0f10cd628d78cac23ca8110c) Updated elpa
* [`d6438783`](https://github.com/nix-community/emacs-overlay/commit/d6438783e19983886e460462b2f114a34b7a6d74) Updated melpa
* [`57048e83`](https://github.com/nix-community/emacs-overlay/commit/57048e832be022087f098c998f9b4d3481a1ccf5) Updated emacs
* [`5d141af6`](https://github.com/nix-community/emacs-overlay/commit/5d141af64a57b0cfdf12a4c4156ecd44ae802057) Updated elpa
* [`9024c37e`](https://github.com/nix-community/emacs-overlay/commit/9024c37e24119939f2d2ac49bcaf6cd7a98d666a) Updated melpa
* [`de404693`](https://github.com/nix-community/emacs-overlay/commit/de404693eaa05689a237f3fd5d4fce4f15ef9a07) Updated emacs
* [`e085f947`](https://github.com/nix-community/emacs-overlay/commit/e085f9471491c9385ef9c719149432ebbafa855b) Updated flake inputs
* [`97f33a07`](https://github.com/nix-community/emacs-overlay/commit/97f33a07d97911da5c41858e083236e7bcea994f) Updated melpa
* [`e6b7c7ee`](https://github.com/nix-community/emacs-overlay/commit/e6b7c7ee1429b7569e1b6c5c833d0c3dd8806633) Updated emacs
* [`7c752907`](https://github.com/nix-community/emacs-overlay/commit/7c752907ac904be4d47d470a940410a0894f4272) Updated flake inputs
* [`2ac5d4ab`](https://github.com/nix-community/emacs-overlay/commit/2ac5d4ab30ee2c3eb6ab737c692f4ccf510b23e6) Updated nongnu
* [`6cf9f89c`](https://github.com/nix-community/emacs-overlay/commit/6cf9f89c9822a892d79b84e05a2901c406603218) Updated elpa
* [`12225c53`](https://github.com/nix-community/emacs-overlay/commit/12225c53c0c629a324d218216ab3b8ebb5164c3e) Updated melpa
* [`f7fcac14`](https://github.com/nix-community/emacs-overlay/commit/f7fcac1403356fd09e2320bc3d61ccefe36c1b91) Updated emacs
* [`b7e4986c`](https://github.com/nix-community/emacs-overlay/commit/b7e4986c45397644eeefce8ec5b06b06c689ae49) Updated elpa
* [`1e9632f3`](https://github.com/nix-community/emacs-overlay/commit/1e9632f3571c4c3aa910dc4798b68cc736f3ed07) Updated melpa
* [`4283007a`](https://github.com/nix-community/emacs-overlay/commit/4283007a03481a77a83d1be97c728fd8abf2128d) Updated emacs
* [`b0dbb78d`](https://github.com/nix-community/emacs-overlay/commit/b0dbb78d0327813a105dbf06ad13f6fce6199f0f) Updated melpa
* [`3ef9acae`](https://github.com/nix-community/emacs-overlay/commit/3ef9acae671e1eab0a71ee982ef9097a9707b665) Updated emacs
* [`ab785fd3`](https://github.com/nix-community/emacs-overlay/commit/ab785fd3e0d1d2751eba53510637cdf7f5e5bb9f) Updated elpa
* [`2b5885f2`](https://github.com/nix-community/emacs-overlay/commit/2b5885f25d2242820c3e54f8a4c787ce07dccdd5) Updated melpa
* [`8402fc02`](https://github.com/nix-community/emacs-overlay/commit/8402fc022dcde86acf1865fea82dcbe9c74ddf88) Updated emacs
* [`33e32b3d`](https://github.com/nix-community/emacs-overlay/commit/33e32b3d576a04293e02a13e311bbc904d9be32e) Updated nongnu
* [`74c67bc2`](https://github.com/nix-community/emacs-overlay/commit/74c67bc2840f3db59755d6e71f19184bdd710f79) Updated elpa
* [`76e82143`](https://github.com/nix-community/emacs-overlay/commit/76e82143c93b4e9584a4f44a2f9d7a248e8aafd3) Updated melpa
* [`6491d496`](https://github.com/nix-community/emacs-overlay/commit/6491d49607ebece99d6118780e194ec1941ad389) Updated emacs
* [`7ffd0eee`](https://github.com/nix-community/emacs-overlay/commit/7ffd0eee86b472149411b78bdb627e9fcb03fb40) Updated melpa
* [`66f48ac7`](https://github.com/nix-community/emacs-overlay/commit/66f48ac73046a9dab5f896f0bfa5c618b94417cb) Updated emacs
* [`f4051448`](https://github.com/nix-community/emacs-overlay/commit/f4051448dfea5f3b4559c90f979ef5021cef69c2) Updated flake inputs
* [`e77c9b29`](https://github.com/nix-community/emacs-overlay/commit/e77c9b29da7b9f2684858c5a6f8a25ddb4540f01) Updated elpa
* [`88af7104`](https://github.com/nix-community/emacs-overlay/commit/88af7104915a697de774d33cf178e175c5294931) Updated melpa
* [`38d5a672`](https://github.com/nix-community/emacs-overlay/commit/38d5a6724f4ad6bbc1d8a92850c9cc9573be8959) Updated emacs
* [`32841c37`](https://github.com/nix-community/emacs-overlay/commit/32841c375d2b05c57539ac428e8e25ee4bd8df0e) Updated flake inputs
* [`09ef7d5d`](https://github.com/nix-community/emacs-overlay/commit/09ef7d5d9f37fd1193d9c03c0cf97a41db93801f) Updated elpa
* [`e90dc8dd`](https://github.com/nix-community/emacs-overlay/commit/e90dc8dd0338420ad78b7c9b7d2e8e22fa290975) Updated melpa
* [`d08457d4`](https://github.com/nix-community/emacs-overlay/commit/d08457d425b0a1f15f44f6d9faa17240f2bd29a6) Updated emacs
* [`d940c775`](https://github.com/nix-community/emacs-overlay/commit/d940c775557a9fb4d9586dfa3f7d9b734f7c0b20) Updated melpa
* [`1bff8265`](https://github.com/nix-community/emacs-overlay/commit/1bff826527840aefa0234d7a381a02fd74ad6868) Updated emacs
* [`5fe8b6dd`](https://github.com/nix-community/emacs-overlay/commit/5fe8b6ddd77f1536e41a72a1785e2894a79af5bf) Updated elpa
* [`5ed94cc2`](https://github.com/nix-community/emacs-overlay/commit/5ed94cc242bd12c516b2f79e73f10a6ecdd78b7b) Updated melpa
* [`d4d9c62d`](https://github.com/nix-community/emacs-overlay/commit/d4d9c62d5e11ad212aee995ad56b8885067179e7) Updated emacs
* [`2b46008a`](https://github.com/nix-community/emacs-overlay/commit/2b46008a2a346141d38fb57a87cb22f9219f75dd) Updated elpa
* [`0a2c51c5`](https://github.com/nix-community/emacs-overlay/commit/0a2c51c571bf98fcb8b219bcd0b26a942c3ae7de) Updated melpa
* [`9b79fd13`](https://github.com/nix-community/emacs-overlay/commit/9b79fd139ff55062e46191bd5dd42fcb79696328) Updated emacs
* [`a69a3e1a`](https://github.com/nix-community/emacs-overlay/commit/a69a3e1ab68f4442e52d8b69da86f2df4fff2679) Updated flake inputs
* [`50620dc0`](https://github.com/nix-community/emacs-overlay/commit/50620dc0fe98d1b97032e0dae8ffd47329297167) Updated nongnu
* [`1e87f115`](https://github.com/nix-community/emacs-overlay/commit/1e87f11534fab2ae74551cb394e0916d5ab47fa6) Updated elpa
* [`0d45d704`](https://github.com/nix-community/emacs-overlay/commit/0d45d7041fa75d5312d3cf4abd4be2cd66533796) Updated melpa
* [`705fbd14`](https://github.com/nix-community/emacs-overlay/commit/705fbd143cc7ee5899525003feda2267e23b4bd6) Updated emacs
* [`c0172f74`](https://github.com/nix-community/emacs-overlay/commit/c0172f7428f7b594721351c394471b4c45dbee8e) Updated nongnu
* [`86055b72`](https://github.com/nix-community/emacs-overlay/commit/86055b7247d4b9192ae3bb4c087de5786c9789ba) Updated elpa
* [`39dc9983`](https://github.com/nix-community/emacs-overlay/commit/39dc9983ae9a65f12b4cbb7a80f4586aa6c78b51) Updated melpa
* [`d97f4109`](https://github.com/nix-community/emacs-overlay/commit/d97f41093894dd5e2d2548fe1e67e0b556a4f250) Updated emacs
* [`9a6b212e`](https://github.com/nix-community/emacs-overlay/commit/9a6b212ead9f4b57809493369c412f79e833ea17) Updated flake inputs
* [`8de63fb7`](https://github.com/nix-community/emacs-overlay/commit/8de63fb7fbddaec406db99adc302174ec6b4016d) Updated melpa
* [`9414446d`](https://github.com/nix-community/emacs-overlay/commit/9414446dfdc600c060284afc74d8dd5aa78208d1) Updated emacs
* [`2c7ff266`](https://github.com/nix-community/emacs-overlay/commit/2c7ff266de758a5fd1a29685ff2d6f299ec632d4) Updated nongnu
* [`aa451ac0`](https://github.com/nix-community/emacs-overlay/commit/aa451ac08eb3330749f75c4aa33c26e90d0362b2) Updated elpa
* [`e84bd87d`](https://github.com/nix-community/emacs-overlay/commit/e84bd87de2cf761c359dc6931c76326cde33e8d2) Updated melpa
* [`9f440671`](https://github.com/nix-community/emacs-overlay/commit/9f4406718ada7af83892e17355ef7fd202c20897) Updated emacs
* [`a27b0ec3`](https://github.com/nix-community/emacs-overlay/commit/a27b0ec305e09e9de940b37a2eec44eb764adeac) Updated elpa
* [`3b76a907`](https://github.com/nix-community/emacs-overlay/commit/3b76a907042b19ec237fe870f65a3e3595e47383) Updated melpa
* [`6436aa6e`](https://github.com/nix-community/emacs-overlay/commit/6436aa6e70126e1cc401eec83a5ab9c909cf1708) Updated emacs
* [`6c6d6be1`](https://github.com/nix-community/emacs-overlay/commit/6c6d6be17dbbe0204d9c3b32f458b2658be64d57) Updated melpa
* [`f3745199`](https://github.com/nix-community/emacs-overlay/commit/f3745199a37f2a6196d1d98a7912cd70e318aa7d) Updated emacs
* [`cedcee8e`](https://github.com/nix-community/emacs-overlay/commit/cedcee8ed57f4f715e487c1a35b06745f7f54cf8) Updated flake inputs
* [`4163cf55`](https://github.com/nix-community/emacs-overlay/commit/4163cf558682e33b06b3ceaada03161d687edaf7) Updated nongnu
* [`86e121f2`](https://github.com/nix-community/emacs-overlay/commit/86e121f22763f18336d18980dd5d9a1d554a6874) Updated elpa
* [`ea70f9df`](https://github.com/nix-community/emacs-overlay/commit/ea70f9df1ff67d1b37abd0893959ff315a599517) Updated melpa
* [`fb0a8410`](https://github.com/nix-community/emacs-overlay/commit/fb0a841062d30d512632144a0b8f429d3d83c9c1) Updated emacs
* [`1ec32758`](https://github.com/nix-community/emacs-overlay/commit/1ec327581332f85fb273487226b102ee1af3d6db) Updated elpa
* [`8b543264`](https://github.com/nix-community/emacs-overlay/commit/8b543264eb28d8953911bcf1bc0d94d7e89c2d7a) Updated melpa
* [`0c36a0d1`](https://github.com/nix-community/emacs-overlay/commit/0c36a0d16b7ca94731eee246d00238885d22490f) Updated emacs
* [`f4bc6d72`](https://github.com/nix-community/emacs-overlay/commit/f4bc6d7272120520122cfef5867d92a92e81bf62) Updated elpa
* [`6cfac69a`](https://github.com/nix-community/emacs-overlay/commit/6cfac69a49d02b98869683e0776857662ae06a39) Updated melpa
* [`8a3f1e57`](https://github.com/nix-community/emacs-overlay/commit/8a3f1e574aa11b3f0aee99bcb453b56c8d6f1ac7) Updated emacs
* [`5b014959`](https://github.com/nix-community/emacs-overlay/commit/5b014959f1634723bfce7bf137a181031b1c6e7c) Updated flake inputs
* [`f92b1cf3`](https://github.com/nix-community/emacs-overlay/commit/f92b1cf3105eb9eab992e585861a762ad8cb0037) Updated elpa
* [`3b158dc7`](https://github.com/nix-community/emacs-overlay/commit/3b158dc76f3bb67ee9f32bb9bb15571d7ea2074c) Updated melpa
* [`1cc0a115`](https://github.com/nix-community/emacs-overlay/commit/1cc0a11542f4feba8430a001b20c2c0151978706) Updated emacs
* [`86488b45`](https://github.com/nix-community/emacs-overlay/commit/86488b451ae54961218f3c85a8554aa7fcdb8731) Updated melpa
* [`1b01966e`](https://github.com/nix-community/emacs-overlay/commit/1b01966ee01008bcec18702ea5e543b93236ecef) Updated emacs
* [`61264683`](https://github.com/nix-community/emacs-overlay/commit/612646835968f663fd0e8f1a21ef52b5d0b88c57) Updated melpa
* [`5e8cb839`](https://github.com/nix-community/emacs-overlay/commit/5e8cb83995ca355ebed239e66ec4b078f595a1b3) Updated elpa
* [`ef7430cd`](https://github.com/nix-community/emacs-overlay/commit/ef7430cdf20c9d82d75ca9331ecc0f8f3115da3c) Updated melpa
* [`cf218237`](https://github.com/nix-community/emacs-overlay/commit/cf218237d0d80f1ec8109677ebc82ded2ca84c43) Updated emacs
* [`86d9b02f`](https://github.com/nix-community/emacs-overlay/commit/86d9b02f8d928ea1c27bcf421ec685df5e68c6bb) Updated flake inputs
* [`bcd935f9`](https://github.com/nix-community/emacs-overlay/commit/bcd935f930b6b673170331e484426cfeefc06e0d) Updated elpa
* [`35f1a712`](https://github.com/nix-community/emacs-overlay/commit/35f1a712b49b07233a8aa29823ca9f0bf1adb11e) Updated melpa
* [`0eb7c2ed`](https://github.com/nix-community/emacs-overlay/commit/0eb7c2ed361b74817364818fc0289eb44208e76a) Updated emacs
* [`e8fd7616`](https://github.com/nix-community/emacs-overlay/commit/e8fd7616e8b998a5835755dbc7c963fe66967565) Updated melpa
* [`433c5449`](https://github.com/nix-community/emacs-overlay/commit/433c54490f99473a5fb9d41e857044a62ffa9baf) Updated emacs
* [`63221ee3`](https://github.com/nix-community/emacs-overlay/commit/63221ee331da17e5c14e6682224218573bdc3951) Updated elpa
* [`10b148d3`](https://github.com/nix-community/emacs-overlay/commit/10b148d3b245cd8abf3064c9ed4470125b0d5816) Updated melpa
* [`502906af`](https://github.com/nix-community/emacs-overlay/commit/502906af674eae890790ec48cad959d42dc2f040) Updated emacs
* [`dd5697cf`](https://github.com/nix-community/emacs-overlay/commit/dd5697cf3687ddc010b66b8eeecd43a144f5ed88) Updated flake inputs
* [`d3c01e02`](https://github.com/nix-community/emacs-overlay/commit/d3c01e025103a7fc9a1946775e191a82cf3af4fa) Updated nongnu
* [`32256276`](https://github.com/nix-community/emacs-overlay/commit/32256276525e8cdc4e9ec285660acd5e7e26e4e1) Updated elpa
* [`b40ce49e`](https://github.com/nix-community/emacs-overlay/commit/b40ce49e63df574d5de122796e60ab8089e6ea78) Updated melpa
* [`68ed87aa`](https://github.com/nix-community/emacs-overlay/commit/68ed87aa28ef073f9e6a482977f07591aae61639) Updated emacs
* [`50b2646a`](https://github.com/nix-community/emacs-overlay/commit/50b2646a6560eeb9119e66b22da87a3dce1e272a) Updated melpa
* [`03342208`](https://github.com/nix-community/emacs-overlay/commit/0334220804cb13f86e1e7ba83b135c9fbffa9d89) Updated emacs
* [`57295046`](https://github.com/nix-community/emacs-overlay/commit/57295046afe433216a389f73b1bcd351de852842) Updated elpa
* [`68b08d5c`](https://github.com/nix-community/emacs-overlay/commit/68b08d5cd11d3c005f017ca2199c5164362d26d1) Updated melpa
* [`208d00a7`](https://github.com/nix-community/emacs-overlay/commit/208d00a7f96d920a153ab90f257357e1aa1d6d77) Updated emacs
* [`cd78b29e`](https://github.com/nix-community/emacs-overlay/commit/cd78b29e11bd11d9569eb51d857e43b144deaf9d) Updated elpa
* [`d40c0689`](https://github.com/nix-community/emacs-overlay/commit/d40c0689b14e99cc930671008913e81bf7b73e62) Updated melpa
* [`d925614f`](https://github.com/nix-community/emacs-overlay/commit/d925614faac9750fcdba7072576b0ce366dd7229) Updated emacs
* [`4cdb48fe`](https://github.com/nix-community/emacs-overlay/commit/4cdb48fe37dcea1ace636a943ebed823de84d5f6) Updated melpa
* [`7d09630b`](https://github.com/nix-community/emacs-overlay/commit/7d09630bc39feefd09f165bc31d98563eee5bb02) Updated emacs
* [`a7f6c87c`](https://github.com/nix-community/emacs-overlay/commit/a7f6c87c5d1d2bdb2e4e5c2b73834a08b5fb360d) Updated flake inputs
* [`b8bf90d8`](https://github.com/nix-community/emacs-overlay/commit/b8bf90d80070c41f391f0919c0f2683687110ccb) Updated elpa
* [`b5e46308`](https://github.com/nix-community/emacs-overlay/commit/b5e4630819981552584ff27fc69fa0c472b461e7) Updated melpa
* [`925e7b36`](https://github.com/nix-community/emacs-overlay/commit/925e7b367814ff67e1e8cbf96835c0c68534a4ed) Updated emacs
* [`e63c323f`](https://github.com/nix-community/emacs-overlay/commit/e63c323fdd81ca2a50542ed02eb3870a0f95c415) Updated flake inputs
* [`380de855`](https://github.com/nix-community/emacs-overlay/commit/380de855a8d44f009c50306ec9585c60a12371f8) Updated nongnu
* [`1457c4eb`](https://github.com/nix-community/emacs-overlay/commit/1457c4ebe76260189cd021766876b17ef13eadf3) Updated elpa
* [`d2d351a8`](https://github.com/nix-community/emacs-overlay/commit/d2d351a80e5487cd45269ff5dfc6247c7478948c) Updated melpa
* [`65297336`](https://github.com/nix-community/emacs-overlay/commit/65297336c6db39d94adb8156d811d800b253fded) Updated emacs
* [`d66e33b9`](https://github.com/nix-community/emacs-overlay/commit/d66e33b94492c5e897729f1aac2094e618a5001a) Updated melpa
* [`a8692d4e`](https://github.com/nix-community/emacs-overlay/commit/a8692d4e570e93061d2bbe10af4a1590afe82e15) Updated emacs
* [`7600854b`](https://github.com/nix-community/emacs-overlay/commit/7600854b9d7d7e4a897638a1df6ea2275682a8ab) Updated elpa
* [`0be1306b`](https://github.com/nix-community/emacs-overlay/commit/0be1306bf44aedaf54642c4dc9bbbc210267dcd7) Updated melpa
* [`c5caaf3b`](https://github.com/nix-community/emacs-overlay/commit/c5caaf3b6d4f711e5a408ada4dc4c36537a18372) Updated emacs
* [`545b3e14`](https://github.com/nix-community/emacs-overlay/commit/545b3e143fad7f7da693e708f65718e03d1c3646) Updated elpa
* [`250ff243`](https://github.com/nix-community/emacs-overlay/commit/250ff24376059a1495058985c229e0c71cd46c1d) Updated melpa
* [`9ba8ea91`](https://github.com/nix-community/emacs-overlay/commit/9ba8ea91b7d79baf8ced9723abc06d0217acace5) Updated emacs
* [`ddb89e84`](https://github.com/nix-community/emacs-overlay/commit/ddb89e842095c88b82b5334e0c87bde1875e7e01) Updated flake inputs
* [`917a11da`](https://github.com/nix-community/emacs-overlay/commit/917a11da8f010b4881d654967214a536b6cab2ba) Updated melpa
* [`98442aa3`](https://github.com/nix-community/emacs-overlay/commit/98442aa32bbe5f20c0065d9c81257cfe79959972) Updated emacs
* [`7028dd82`](https://github.com/nix-community/emacs-overlay/commit/7028dd8249bb1306dfb7250d70bd9333dd056401) Updated elpa
* [`832a762e`](https://github.com/nix-community/emacs-overlay/commit/832a762e2789007887ab0720a14bbd03e6798f03) Updated melpa
* [`557a6976`](https://github.com/nix-community/emacs-overlay/commit/557a69764e1aeb16c3d0f7d53ff4c3001a4ccafc) Updated emacs
* [`5ca32142`](https://github.com/nix-community/emacs-overlay/commit/5ca321429707401c358ca92d3a11615904591ac9) Updated flake inputs
* [`1bfe488b`](https://github.com/nix-community/emacs-overlay/commit/1bfe488b3692880609a32576ab47bd3911b2fa00) Updated nongnu
* [`0313ac9c`](https://github.com/nix-community/emacs-overlay/commit/0313ac9c196ba3a90566b72666a5220b2a841b71) Updated elpa
* [`e4ee7be8`](https://github.com/nix-community/emacs-overlay/commit/e4ee7be879a0300b414d5565602a8b70d38c3467) Updated melpa
* [`a9c6d1dc`](https://github.com/nix-community/emacs-overlay/commit/a9c6d1dc8ddcf32d9e67ea95761aac0f3f34b4cc) Updated emacs
* [`c663a0f8`](https://github.com/nix-community/emacs-overlay/commit/c663a0f86514516f717479075a07b31f93f31e75) Updated melpa
* [`89247aa1`](https://github.com/nix-community/emacs-overlay/commit/89247aa1a7d6d113c859f2f3b2e6674066369aa1) Updated elpa
* [`9fa2385d`](https://github.com/nix-community/emacs-overlay/commit/9fa2385df7c4d8ccf8727b74f2edccc1dea7a914) Updated melpa
* [`46a2877d`](https://github.com/nix-community/emacs-overlay/commit/46a2877d1f0f661627d1d104cbf4963e97391e95) Updated emacs
* [`ea1a2b4b`](https://github.com/nix-community/emacs-overlay/commit/ea1a2b4b74c0fb2d8b73ca48d289b540827dd913) Updated elpa
* [`9fecfffa`](https://github.com/nix-community/emacs-overlay/commit/9fecfffa2dd8069cc4c4be8edfc68fb7a77ecc8b) Updated melpa
* [`d2bac20c`](https://github.com/nix-community/emacs-overlay/commit/d2bac20cd3336c3c16452940195aca431b9c9413) Updated emacs
* [`cb16f015`](https://github.com/nix-community/emacs-overlay/commit/cb16f015f4dd579cf5bd00d09e6a7ada6e72f5ab) Updated flake inputs
* [`5e4b4002`](https://github.com/nix-community/emacs-overlay/commit/5e4b4002be2553de0510e34b1ac4bdcadca2c7d4) Updated flake inputs
* [`3ae41e39`](https://github.com/nix-community/emacs-overlay/commit/3ae41e3981032d6de1f147c8121ff822428f6973) Updated nongnu
* [`1cbf4672`](https://github.com/nix-community/emacs-overlay/commit/1cbf4672adc9c1a26f76da384d0f0685d2c2f561) Updated elpa
* [`cb7b4758`](https://github.com/nix-community/emacs-overlay/commit/cb7b475812320db2263340c11b4edf484011ba33) Updated melpa
* [`6e8f627b`](https://github.com/nix-community/emacs-overlay/commit/6e8f627bd82b5885e1808b772fcaebe4ebd40967) Updated emacs
* [`9b960970`](https://github.com/nix-community/emacs-overlay/commit/9b960970b5d0e7594aae8732d92561b988e3e1f0) Updated melpa
* [`e4f883ea`](https://github.com/nix-community/emacs-overlay/commit/e4f883ea9d8314280968f460709f1df31c2801a3) Updated emacs
* [`1ecf1d71`](https://github.com/nix-community/emacs-overlay/commit/1ecf1d7150a6e8c313092dace9bb6eed36de80c2) Updated nongnu
* [`17920802`](https://github.com/nix-community/emacs-overlay/commit/1792080299ec0204c3472e6a782b5e472c568ce8) Updated elpa
* [`5de71851`](https://github.com/nix-community/emacs-overlay/commit/5de71851e1cde4e80a0babfa7ea6fd537952b12f) Updated melpa
* [`404b72d6`](https://github.com/nix-community/emacs-overlay/commit/404b72d67877f73f029ddc77848a85e7d0f6edd0) Updated emacs
* [`015c96d0`](https://github.com/nix-community/emacs-overlay/commit/015c96d07f171ae7f9061648b4a492d193ebe20d) Updated elpa
* [`c72d8b8b`](https://github.com/nix-community/emacs-overlay/commit/c72d8b8b670309f06f9e24432ea0f1de67ec3aae) Updated melpa
* [`1f8c4bc8`](https://github.com/nix-community/emacs-overlay/commit/1f8c4bc8b3d395ff65844930b562e775fd18fc23) Updated emacs
* [`aabdc120`](https://github.com/nix-community/emacs-overlay/commit/aabdc120398f3bf7d1ba0a95cbe06c7b141c87d5) Updated melpa
* [`7da709f5`](https://github.com/nix-community/emacs-overlay/commit/7da709f57affaa4367e192a4ab4d70e44234a77e) Updated emacs
* [`faa7885d`](https://github.com/nix-community/emacs-overlay/commit/faa7885de7e62e0812b9a3319766014e5021fa40) Updated flake inputs
* [`fda03f22`](https://github.com/nix-community/emacs-overlay/commit/fda03f226ba263c589289f61d0389266b6f5dcae) Updated nongnu
* [`64203264`](https://github.com/nix-community/emacs-overlay/commit/642032648deb48237ac587fc8d7c7b3e21ddaff8) Updated elpa
* [`735a40ab`](https://github.com/nix-community/emacs-overlay/commit/735a40ab43a9e362c8437986460bf13d38277791) Updated melpa
* [`2426b41b`](https://github.com/nix-community/emacs-overlay/commit/2426b41b8b6be7ccac87159476b109c81894d0bf) Updated emacs
* [`8bb3595c`](https://github.com/nix-community/emacs-overlay/commit/8bb3595ccc40b0ab2a60fbbf715887c855edea95) Correct Smart Parens hash
* [`f89dcf04`](https://github.com/nix-community/emacs-overlay/commit/f89dcf04b4f28d1216754e7e9f2db2eba9e1abc8) Updated flake inputs
* [`9f7f7f3e`](https://github.com/nix-community/emacs-overlay/commit/9f7f7f3ec123281ecb01e525dcf716b35e8769d2) Updated elpa
* [`9b6590d9`](https://github.com/nix-community/emacs-overlay/commit/9b6590d9fb34872137e09585c853e6960dd22c30) Updated melpa
* [`788512ea`](https://github.com/nix-community/emacs-overlay/commit/788512ea00d4bd46740a283125aa0853ff10ce8a) Updated melpa
* [`4db70e79`](https://github.com/nix-community/emacs-overlay/commit/4db70e7955dee1ed9446a2f910144c560f704f9d) Updated emacs
* [`9f647da4`](https://github.com/nix-community/emacs-overlay/commit/9f647da449cfbab30c6b6d0a90e2e8a04cba66e6) Updated flake inputs
* [`57150222`](https://github.com/nix-community/emacs-overlay/commit/571502222fdaf84c428834167ac1bd9ed41e10be) Updated elpa
* [`9795b38d`](https://github.com/nix-community/emacs-overlay/commit/9795b38ddf2674def112303e4a3ab7792c776a5b) Updated melpa
* [`a1e3efaa`](https://github.com/nix-community/emacs-overlay/commit/a1e3efaa0ff7cd4e19463d5fcadf4c20380980a8) Updated emacs
* [`16a15efb`](https://github.com/nix-community/emacs-overlay/commit/16a15efb0989db2e9b9ffa678f79583ef8817960) Updated elpa
* [`25943a54`](https://github.com/nix-community/emacs-overlay/commit/25943a543cccc1348d636a2564037450f67a792e) Updated melpa
* [`1c3facbb`](https://github.com/nix-community/emacs-overlay/commit/1c3facbb9e90bb80e985d7a91138dadd09e9e7f3) Updated emacs
* [`40463aaa`](https://github.com/nix-community/emacs-overlay/commit/40463aaa81fc44a2908716ca79d29c16c5fef81b) Updated melpa
* [`c6f3c11c`](https://github.com/nix-community/emacs-overlay/commit/c6f3c11c47d674116a9fa6526ff9d703fd491151) Updated flake inputs
* [`67b49d43`](https://github.com/nix-community/emacs-overlay/commit/67b49d4343f33e624d610b2ce1f8fb023504df95) Updated elpa
* [`f0ee04fd`](https://github.com/nix-community/emacs-overlay/commit/f0ee04fd09a388ada67b93cd72493df0c93a67e2) Updated melpa
* [`e641ac10`](https://github.com/nix-community/emacs-overlay/commit/e641ac1008eb11b0b0bb0a07f507061eed1690a8) Updated emacs
* [`2cd9606b`](https://github.com/nix-community/emacs-overlay/commit/2cd9606b3a736f1523fd2cceb30a1b603ebfadb7) Updated elpa
* [`fbbffc93`](https://github.com/nix-community/emacs-overlay/commit/fbbffc93fc04ca59b01f23ffac35eef284d5770b) Updated melpa
* [`c1c08e62`](https://github.com/nix-community/emacs-overlay/commit/c1c08e6209a53c037032f5314d136efa7993f73c) Updated melpa
* [`ebf498ef`](https://github.com/nix-community/emacs-overlay/commit/ebf498ef8ba1f45c25e50013ec715e6b0dedac62) Updated emacs
* [`9d470ca5`](https://github.com/nix-community/emacs-overlay/commit/9d470ca5c1a24de8fe4830a33c2c3c178c1cd426) Updated nongnu
* [`21684073`](https://github.com/nix-community/emacs-overlay/commit/2168407308427714e82ce8bb541dc841d55d7a23) Updated elpa
* [`020ebe57`](https://github.com/nix-community/emacs-overlay/commit/020ebe5726a5ad409870688dcb3195b40cccf621) Updated melpa
* [`aee4d3da`](https://github.com/nix-community/emacs-overlay/commit/aee4d3daa7cb71f903492103d1ea522efcf6f740) Updated emacs
* [`bcd6700a`](https://github.com/nix-community/emacs-overlay/commit/bcd6700ad46dcf331c668fae0dd2584db7cebe0e) Updated elpa
* [`21cde010`](https://github.com/nix-community/emacs-overlay/commit/21cde01069588bc3827c80aaa19b70ba6aae3601) Updated melpa
* [`ce6068e2`](https://github.com/nix-community/emacs-overlay/commit/ce6068e25235bfe396f0c954a9fefe9da7540183) Updated emacs
* [`cfcc1669`](https://github.com/nix-community/emacs-overlay/commit/cfcc1669779b0abc206761895ff1515d02bd4e12) Updated melpa
* [`12d9a5fe`](https://github.com/nix-community/emacs-overlay/commit/12d9a5fe7968aa89ed37fdb28f32fdff29d01c0f) Updated emacs
* [`bfa0e3d8`](https://github.com/nix-community/emacs-overlay/commit/bfa0e3d8b4a4987b433b915cc63f77fa491c7a89) Updated flake inputs
* [`641b8f42`](https://github.com/nix-community/emacs-overlay/commit/641b8f42e2069a021279c4ef0bf2f9070f431ae6) Updated nongnu
* [`5b574344`](https://github.com/nix-community/emacs-overlay/commit/5b574344d31962522a23cfc6152e01fcb0f32a6a) Updated elpa
* [`17b457e7`](https://github.com/nix-community/emacs-overlay/commit/17b457e79d6b331fbdaa1958933750b4fd9ea172) Updated melpa
* [`bb943ccf`](https://github.com/nix-community/emacs-overlay/commit/bb943ccf9c2572550ddfdb7c92373c6671b870af) Updated emacs
* [`257f63e6`](https://github.com/nix-community/emacs-overlay/commit/257f63e680234ff7513e885b4f19a5725738538d) Updated elpa
* [`509a62d6`](https://github.com/nix-community/emacs-overlay/commit/509a62d6cec302e020c5ad546c02815b0bb8acf8) Updated emacs
* [`17580157`](https://github.com/nix-community/emacs-overlay/commit/175801574b4bafe2ce03d6d0ae0e69b47e3ac805) Updated melpa
* [`1ac3c76d`](https://github.com/nix-community/emacs-overlay/commit/1ac3c76d7ec5d1eaaebe3ead670d40197eb7b6b7) Updated melpa
* [`482bc474`](https://github.com/nix-community/emacs-overlay/commit/482bc4749bcbfcaf19a668a3d0e5ba3423be730c) Updated emacs
* [`eb68e0a2`](https://github.com/nix-community/emacs-overlay/commit/eb68e0a24851f80f8e66a8545d8c0bf76f435f21) Revert "Correct SmartParens hash"
* [`1e218600`](https://github.com/nix-community/emacs-overlay/commit/1e2186001f600b56c393bc2ef4d3ea27200dc116) Updated elpa
* [`d7e1758b`](https://github.com/nix-community/emacs-overlay/commit/d7e1758bf7cf62a5e46a8c56276123997a07f401) Updated melpa
* [`2bdab12a`](https://github.com/nix-community/emacs-overlay/commit/2bdab12a3077f6f25be03d93569a06a177425c47) Updated emacs
* [`bd27cee9`](https://github.com/nix-community/emacs-overlay/commit/bd27cee9e668598f5d40518f780f84bd14f800db) Updated melpa
* [`bf941592`](https://github.com/nix-community/emacs-overlay/commit/bf94159254c238a379f54bd4c3d11a50322e6469) Updated emacs
* [`7967f4ed`](https://github.com/nix-community/emacs-overlay/commit/7967f4ede6a1bae247e3e90523a82908855a2e5b) Updated elpa
* [`ab2169f5`](https://github.com/nix-community/emacs-overlay/commit/ab2169f53db94a7628e54780179080920768e20b) Updated melpa
* [`7c0c76c9`](https://github.com/nix-community/emacs-overlay/commit/7c0c76c9e970eb75efa0a8dc2a3b8aa5b1028613) Updated emacs
