### PR TITLE
niv doomemacs: update 286be1b2 -> 9620bb45

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "doomemacs",
         "repo": "doomemacs",
-        "rev": "286be1b2496a3ffa2280a16a41f56babebea93f0",
-        "sha256": "0mdaijxpzls0n6s0cj2ggxz3iivkx8qxc0qwlkhg1v8bxa3afsv0",
+        "rev": "9620bb45ac4cd7b0274c497b2d9d93c4ad9364ee",
+        "sha256": "0hi504pkiwx1m7vd1ak2zc2hcl1dnpaa0gjzs5xlhz2wd7hsn60n",
         "type": "tarball",
-        "url": "https://github.com/doomemacs/doomemacs/archive/286be1b2496a3ffa2280a16a41f56babebea93f0.tar.gz",
+        "url": "https://github.com/doomemacs/doomemacs/archive/9620bb45ac4cd7b0274c497b2d9d93c4ad9364ee.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "emacs-overlay": {


### PR DESCRIPTION
## Changelog for doomemacs:
Branch: master
Commits: [doomemacs/doomemacs@286be1b2...9620bb45](https://github.com/doomemacs/doomemacs/compare/286be1b2496a3ffa2280a16a41f56babebea93f0...9620bb45ac4cd7b0274c497b2d9d93c4ad9364ee)

* [`90070c63`](https://github.com/doomemacs/doomemacs/commit/90070c639a1549a781720d97411be8b6d6eafdfe) fix(workspaces): remove ivy integration
* [`639fcc6a`](https://github.com/doomemacs/doomemacs/commit/639fcc6a2e4dd3df9effef2da7b9d605aaf72214) tweak(emacs-lisp): remove pin truncation
* [`7acfb0c7`](https://github.com/doomemacs/doomemacs/commit/7acfb0c77cde54dd2cc6a5962735518fed1f43e3) nit: minor comment reformatting & revision
* [`45fd8930`](https://github.com/doomemacs/doomemacs/commit/45fd893074f608cc1e40443345ce1a93010aeff8) refactor(ligatures): test for harfbuzz feature
* [`d256b597`](https://github.com/doomemacs/doomemacs/commit/d256b597f2c6768e759ac2b866b110ba580c6f9f) bump: :tools magit
* [`12a765c5`](https://github.com/doomemacs/doomemacs/commit/12a765c5099c4aab8165d1ee944b71f105e42fe1) feat(cli): doom sync: change -B to suppress rebuilding
* [`c0c52f0f`](https://github.com/doomemacs/doomemacs/commit/c0c52f0f610245df88391008972436f97ff2b5e3) fix: ensure load-path et co are set on doom/reload
* [`d5bad5b4`](https://github.com/doomemacs/doomemacs/commit/d5bad5b43061b6dfac6d2e8adf9d23f44d66ee5a) fix(cli): straight: regurgitate type errors as connection errors
* [`aef2b121`](https://github.com/doomemacs/doomemacs/commit/aef2b12100d92b176bf6482826c03e5a7e6fe0ad) feat(cli): doom upgrade: add -B option
* [`201051c3`](https://github.com/doomemacs/doomemacs/commit/201051c368cfdabf3f68c372939297380999e28d) fix(cli): doom sync: suppress rebuild prompt when upgrading
* [`b6b755de`](https://github.com/doomemacs/doomemacs/commit/b6b755dea4546a7ae6d7dfb3fbfdbd71036a01fc) fix(cli): doom install: $DOOMDIR paths in output
* [`d6a34509`](https://github.com/doomemacs/doomemacs/commit/d6a345091770bfc9078ace70c3c65daa805317cb) fix(cli): shell-quote-argument: wrong-number-of-args error
* [`3f966f49`](https://github.com/doomemacs/doomemacs/commit/3f966f49d8f97202ef018b51e24f65f629750182) fix(cli): doom upgrade: remove doom-compile-clean call
* [`89c56a33`](https://github.com/doomemacs/doomemacs/commit/89c56a3393467d84ea4bf3d1aabf9ab4a9d0bed0) fix(cli): doom install: $DOOMDIR templates
* [`b4433719`](https://github.com/doomemacs/doomemacs/commit/b44337198171bf612047d78f99968e17054cf48c) fix(cli): doom install: $DOOMDIR templates (part 2)
* [`544e579c`](https://github.com/doomemacs/doomemacs/commit/544e579c448e83b4600ded44f6f997bbfbee1b8b) fix(cli): doom upgrade: ensure upgrade remote is deleted
* [`b533f549`](https://github.com/doomemacs/doomemacs/commit/b533f5496c154bc35a9db80c58f64dda52b72a8e) tweak(corfu): corfu-auto-delay: 0.1 -> 0.18
* [`65240e9b`](https://github.com/doomemacs/doomemacs/commit/65240e9b92f2c8f166a6d8f4b9b9aca37230ec9a) fix(cli): suppress 'checked out X' when X = nil
* [`b01e4964`](https://github.com/doomemacs/doomemacs/commit/b01e496405b6a515f2f434350d7a06492ffd1757) fix(cli): doom sync: rebuild-all loop
* [`5f5a163c`](https://github.com/doomemacs/doomemacs/commit/5f5a163c49207a7083ab1ecc9e78d268fd6600b8) bump: :lang org
* [`3643c4da`](https://github.com/doomemacs/doomemacs/commit/3643c4dadd53e26d20bfaa38c33526854093e66a) fix(cli): void-function directory-empty-p error
* [`a8446213`](https://github.com/doomemacs/doomemacs/commit/a84462133dfbc632804198ab27cdc9f591ce97c0) fix(neotree): don't use all-the-icons
* [`5589722c`](https://github.com/doomemacs/doomemacs/commit/5589722c8e5179b52469ef6b5372c89ff462fac4) fix(popup): fix typo in local variable name
* [`230c82fc`](https://github.com/doomemacs/doomemacs/commit/230c82fc9590cfa056f6d1b3798af41e38144fea) docs: remove unintended repetition
* [`142f28eb`](https://github.com/doomemacs/doomemacs/commit/142f28eb9a32fe0218de8d0d120bf186bbad1a87) fix(fold): properly support outline-minor-mode
* [`dd95f8fb`](https://github.com/doomemacs/doomemacs/commit/dd95f8fb3d7cd50c8b6a76abc9aa9723a4cb7773) feat(common-lisp): add more sly packages
* [`1176aaae`](https://github.com/doomemacs/doomemacs/commit/1176aaae0b8b5bd1ccabb7871ad156ede320553a) feat(mu4e): use built-in notifications instead of mu4e-alert
* [`1598444b`](https://github.com/doomemacs/doomemacs/commit/1598444bd9aa2d5fb702a44fdce7d7b17164d2d4) docs(corfu): disabling auto-completion
* [`22fa4cca`](https://github.com/doomemacs/doomemacs/commit/22fa4ccac715a6e0b6c180ef1966779a58ac5703) tweak(vertico): consult-dir: use projectile
* [`ea4792cc`](https://github.com/doomemacs/doomemacs/commit/ea4792ccd215c4b153373da9551dc94557067f9a) docs: bump 29.2 -> 29.3
* [`392fe88e`](https://github.com/doomemacs/doomemacs/commit/392fe88ed00311c129d56cc0f3d62fbb9e813f4f) fix(lib): sudo-{this,save}-file: file path for indirect clones
* [`c6fc0e5b`](https://github.com/doomemacs/doomemacs/commit/c6fc0e5bc018efc7ee8174dbbec8cff28644ad54) fix(cli): don't delete repos beyond $DOOMLOCALDIR
* [`13b60b97`](https://github.com/doomemacs/doomemacs/commit/13b60b9702ea7868ecf5716d352a7e053ec6dd3f) bump: :editor evil
* [`34a9c3d0`](https://github.com/doomemacs/doomemacs/commit/34a9c3d0b3a5e3645fb7fe564eb02c0ebc51ee68) bump: :editor snippets
* [`3192816c`](https://github.com/doomemacs/doomemacs/commit/3192816c22f25368847ac463fe41f4025a22a177) bump: :tools debugger lsp
* [`e5fb4f3d`](https://github.com/doomemacs/doomemacs/commit/e5fb4f3dd90034c8315393b0cff24cd5b6ab801c) bump: :lang scala
* [`beb6e876`](https://github.com/doomemacs/doomemacs/commit/beb6e8763696658b4aada08c71bc749889ea90d8) bump: :tools magit :emacs vc
* [`52599ab5`](https://github.com/doomemacs/doomemacs/commit/52599ab536473be867205e397a2e971365760dcf) bump: :completion
* [`747a57fe`](https://github.com/doomemacs/doomemacs/commit/747a57fe547c205f059bf6ef7c94960b1d31867b) bump: :tools
* [`2a2565f0`](https://github.com/doomemacs/doomemacs/commit/2a2565f05916387fbf89adb578f01e97aa012a9b) bump: :term eshell
* [`fdb9e6b4`](https://github.com/doomemacs/doomemacs/commit/fdb9e6b4999c5ef64ab1fb286503fce9dd491153) fix(org): org-download: remove unneeded advice
* [`2debe85a`](https://github.com/doomemacs/doomemacs/commit/2debe85a8aecda2e46e74bf701d14f513845c77c) fix(cli): doom upgrade: void-variable num
* [`869ad10f`](https://github.com/doomemacs/doomemacs/commit/869ad10f34fdbb9132994e85b0dbe7cf0ce2274c) refactor: startup optimizations
* [`d166d754`](https://github.com/doomemacs/doomemacs/commit/d166d754d630479664c76b73323531897aa52095) release(modules): 24.04.0-dev
* [`38a3adcf`](https://github.com/doomemacs/doomemacs/commit/38a3adcf0e1d02f3d9f6f7e965e24447467790d9) fix(lib): find-subling-file-search: wrong-number-of-args error
* [`19e27764`](https://github.com/doomemacs/doomemacs/commit/19e27764eabeb4ef5b368c2ade18f04013a891e3) fix(cc): make *.c(c|pp) siblings of *.h(h|pp) files
* [`4ca87463`](https://github.com/doomemacs/doomemacs/commit/4ca87463de7058ebaea953b7cf965bd7cd5e1a47) fix(web): make *.((s[ac]|le)ss|styl) siblings of *.css
* [`0b93ecf4`](https://github.com/doomemacs/doomemacs/commit/0b93ecf42c96677710426f446f5ecb5a307f60c3) fix(lib): sudo-{find,this}-file: disable auto-save
* [`8d370d56`](https://github.com/doomemacs/doomemacs/commit/8d370d5608c7a3b56a16d1950a6e100e52235717) refactor: doom--last-frame: remove unused symbol
* [`d205643c`](https://github.com/doomemacs/doomemacs/commit/d205643cabf1c3305bfc1ccd1cbbb9e9067d2e59) bump: :tools pdf
* [`881defae`](https://github.com/doomemacs/doomemacs/commit/881defae2da5cbc7395cecf6f6d0f95b9a66bacf) fix(julia): duplicate popup rules
* [`59f35682`](https://github.com/doomemacs/doomemacs/commit/59f3568217fc57b5afde661acf0b6db4c6da99be) docs(julia): reformat & fix package/flag links
* [`fb96c8df`](https://github.com/doomemacs/doomemacs/commit/fb96c8df5a7c850cbcdfe85e94033b1fc6410138) refactor(corfu): use hook symbols in add-hook! calls
* [`82e0641b`](https://github.com/doomemacs/doomemacs/commit/82e0641bf758c782ebf9ed0a9ba9561f4c379b5a) refactor: remove redundant auto-mode-alist entries
* [`a6a011fc`](https://github.com/doomemacs/doomemacs/commit/a6a011fc9c769e6b292a73d956310bf50731a6e7) fix(mu4e): void-function mu4e-clear-caches error
* [`cf6d44d8`](https://github.com/doomemacs/doomemacs/commit/cf6d44d82d39ccfd70925c02154893597ab92862) fix(rust): lsp-mode: produce better hover info
* [`f18603e6`](https://github.com/doomemacs/doomemacs/commit/f18603e66a1160927044d13a46f15bbddfd72d39) feat(lib): sudo-{find,this}-file: invoke save-place
* [`0cf78242`](https://github.com/doomemacs/doomemacs/commit/0cf782425657831dbbed5726462fe59f2f57540a) refactor(eval): avoid seq-uniq & cl-{first,second}
* [`854f4103`](https://github.com/doomemacs/doomemacs/commit/854f4103ff286f05462cf4facda7445eaff0503a) fix(factor): repl handler
* [`1f921ca7`](https://github.com/doomemacs/doomemacs/commit/1f921ca7a7cdb7755bd7d518ad55bce8c0279e48) fix(factor): package association for lookup handlers & keybinds
* [`681dd7bb`](https://github.com/doomemacs/doomemacs/commit/681dd7bb554d844c3c6d386dd654daf755a59520) fix(factor): handle fuel popups
* [`ac331072`](https://github.com/doomemacs/doomemacs/commit/ac3310722803a4577a80ccebb2d1c565c11f373f) bump: :lang factor
* [`57f43e09`](https://github.com/doomemacs/doomemacs/commit/57f43e095344c562778859acfa300668f78af031) fix(vc): *vc-{diff,change-log}* popup rules
* [`f79bb46c`](https://github.com/doomemacs/doomemacs/commit/f79bb46c9b639b10613b1b4ed8a485a233f61526) fix(corfu): prevent void-variable error
* [`4f07e83b`](https://github.com/doomemacs/doomemacs/commit/4f07e83b6e0b21b66c9e18b48cef8a11de77dda5) fix(vertico): missing command error in consult
* [`813c9615`](https://github.com/doomemacs/doomemacs/commit/813c96151143f147ad6b71ee7e916918bdfb0a42) perf(tabs): rate limit centaur-tabs-buffer-update-groups
* [`a3de6ad0`](https://github.com/doomemacs/doomemacs/commit/a3de6ad04f79bcd28f3c905b918ceb3116074b94) bump: :editor evil
* [`4f516521`](https://github.com/doomemacs/doomemacs/commit/4f51652111d35081347576e4ebd31ec6c823e5db) fix(lib): remove-recent-file: improve completion UI
* [`69bc4717`](https://github.com/doomemacs/doomemacs/commit/69bc4717225b244aff448c28e3d41fca4b1d0ed2) fix(workspaces): dual *Warnings* windows at startup
* [`ead2ad19`](https://github.com/doomemacs/doomemacs/commit/ead2ad19dcac2d9696d735dfc9180260b1f203e0) bump: :lang scala
* [`95ba26ba`](https://github.com/doomemacs/doomemacs/commit/95ba26ba6805c8a45e4306055f55556c5d210257) bump: :app everywhere
* [`96897466`](https://github.com/doomemacs/doomemacs/commit/968974663d236045aa3acc0a059847ded36cd979) bump: :editor snippets
* [`f99863b9`](https://github.com/doomemacs/doomemacs/commit/f99863b9f5edaffb4f48135fb165fe6ec3ea8d06) bump: :ui doom
* [`67569117`](https://github.com/doomemacs/doomemacs/commit/675691172119266e5a27c6d2f03f6ee26357b0b2) fix(syntax): flycheck popups clearing active region
* [`a8d61238`](https://github.com/doomemacs/doomemacs/commit/a8d612385fcc001f711f21eda2e275a78cdf1efb) tweak(corfu): update dabbrev-ignore-buffer-modes
* [`21f6fb75`](https://github.com/doomemacs/doomemacs/commit/21f6fb7576262cc366c7ee13aca094268728c563) fix(eval): warnings after eval error
* [`a4b7aa1c`](https://github.com/doomemacs/doomemacs/commit/a4b7aa1c56f47bdf33796099e3006cbafe194b71) fix(helm): helm-descbinds-disable-which-key = nil
* [`42de6282`](https://github.com/doomemacs/doomemacs/commit/42de6282f42f9dce3e1e69f4b4fb25b496d65867) tweak(helm): helm-always-two-windows = t
* [`da3d0687`](https://github.com/doomemacs/doomemacs/commit/da3d0687c5008edbbe5575ac1077798553549a6a) fix: doom-init-fonts-h: don't run more than needed
* [`d317fa46`](https://github.com/doomemacs/doomemacs/commit/d317fa4667630df69f3adb6d2c1b8484f033b8d4) refactor: menu-bar (re)initialization on MacOS
* [`96e3255c`](https://github.com/doomemacs/doomemacs/commit/96e3255c330af96900437cee5a1ff3465b18d6b8) nit: reformat+revise comments
* [`ff4a0bc5`](https://github.com/doomemacs/doomemacs/commit/ff4a0bc54a661f77bae8fe844fea3386c26bc594) fix: doom-run-hook-on: check context & chain hooks unconditionally
* [`fdeb8562`](https://github.com/doomemacs/doomemacs/commit/fdeb8562109125f74edd04a9843db6e9094b69c2) fix(spell): spell-fu: remove unneeded advice
* [`5b7d6763`](https://github.com/doomemacs/doomemacs/commit/5b7d6763f8f899e556c7c5d89556bf39a1c81f64) revert: org
* [`5a92e1b9`](https://github.com/doomemacs/doomemacs/commit/5a92e1b94aeaba60149bb150bbadded0a0f5a1bd) fix: doom-initialize-core-packages: extract plist from alist
* [`ede616fd`](https://github.com/doomemacs/doomemacs/commit/ede616fdd7c4c8d61094011fb9e1b9d7a61a4187) fix(cli): doom-packages-ensure: ensure local packages are built
* [`0a635e9d`](https://github.com/doomemacs/doomemacs/commit/0a635e9df9bea8a4cfa56e9cec0203aa28c61df2) fix(direnv): fix void function error in emacs30
* [`46bcd7e9`](https://github.com/doomemacs/doomemacs/commit/46bcd7e922f5370043252f23cd150d2a3fa33012) bump: :lang go
* [`2f7b3092`](https://github.com/doomemacs/doomemacs/commit/2f7b30925238d02d43a59b23c7fc06224d0fe935) tweak(default): remove +vc/gutter-hydra keybind
* [`0349dab0`](https://github.com/doomemacs/doomemacs/commit/0349dab09abf6fe918a2fb59a6723d3573d8b4b3) tweak(default): ensure '<leader> g S' is silent
* [`9620bb45`](https://github.com/doomemacs/doomemacs/commit/9620bb45ac4cd7b0274c497b2d9d93c4ad9364ee) fix(evil): ]f/[f opening broken symlinks
