### PR TITLE
niv nixpkgs: update aa606b10 -> db5f88c4

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "aa606b10cc142ada35360bb0b2218cbf57a27cf3",
-        "sha256": "1lk4cy64dpn6s2fmc2vp4q1md7gbadn30y6xcccd6467ymv6rrrz",
+        "rev": "db5f88c41a638e4ff1f67a61310a6e958eaa07a8",
+        "sha256": "0y9kc2np0s55mj15bhjqanzxlng4y3mwmf7r4vymfvflr8cnmgp8",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/aa606b10cc142ada35360bb0b2218cbf57a27cf3.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/db5f88c41a638e4ff1f67a61310a6e958eaa07a8.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@aa606b10...db5f88c4](https://github.com/nixos/nixpkgs/compare/aa606b10cc142ada35360bb0b2218cbf57a27cf3...db5f88c41a638e4ff1f67a61310a6e958eaa07a8)

* [`6cfaec09`](https://github.com/NixOS/nixpkgs/commit/6cfaec09e015935ebe6ecd29ae5bf0d889f5f586) libgnt: 2.14.1 -> 2.14.3
* [`8c71ab22`](https://github.com/NixOS/nixpkgs/commit/8c71ab22c6df4e5ce290e131a7769688b0c5a017) gcr: remove build gnupg from runtime closure
* [`fe5ed8cd`](https://github.com/NixOS/nixpkgs/commit/fe5ed8cd20428fe8c5fd468926ac9f3aaac485d9) unvanquished: 0.54.0 -> 0.54.1
* [`bf044cc9`](https://github.com/NixOS/nixpkgs/commit/bf044cc98840491aff630f0a11efac06e44e5d47) fead: 0.1.3 -> 1.0.0
* [`274b5b5b`](https://github.com/NixOS/nixpkgs/commit/274b5b5b3d81c656afb976fd3e0c6721188c13c9) doomrunner: bump to 1.8.2
* [`b9e5637a`](https://github.com/NixOS/nixpkgs/commit/b9e5637ade701b450c2e66f00cd3d048e247636c) config.replaceCrossStdenv: add
* [`bf193eb2`](https://github.com/NixOS/nixpkgs/commit/bf193eb258158901de0f02925544c290b409ed9f) softhsm: enable db backend
* [`838c3b3f`](https://github.com/NixOS/nixpkgs/commit/838c3b3fa06bdfb687768ed46c21d9d2c1b08d92) pls: 0.0.1-beta.4 -> 0.0.1-beta.6
* [`777f5b67`](https://github.com/NixOS/nixpkgs/commit/777f5b67c2dd48b445de457243ee480c4bec7fb3) nixos/qemu-vm: add option to specify security model to use for a shared directory
* [`200e3a93`](https://github.com/NixOS/nixpkgs/commit/200e3a934bec15ed3df2e1510789162cc3bdb904) nixos/qemu-vm: added description of security model options, removed 'mapped' security model
* [`2c74da89`](https://github.com/NixOS/nixpkgs/commit/2c74da898e44eedde7589c965eb67c35a04504e2) nixos/qemu-vm: changed default security model
* [`a77095a2`](https://github.com/NixOS/nixpkgs/commit/a77095a2af0475ed1d4584995eb0ac130bdeabab) nixos/qemu-vm: added security model for shared host nix store
* [`647adf75`](https://github.com/NixOS/nixpkgs/commit/647adf75d035205cf0775c26a1774b5f064b13bb) maintainers: add pkulak
* [`933a5a1c`](https://github.com/NixOS/nixpkgs/commit/933a5a1c4a42e95be0a173eb2edb706c3d4a7f28) river-filtile: init at 1.1.0
* [`495d56cd`](https://github.com/NixOS/nixpkgs/commit/495d56cd3795b7ce62150b44dafef7d19b14dd63) python311Packages.mahotas: remove freeimage dependency
* [`f79a8177`](https://github.com/NixOS/nixpkgs/commit/f79a81770f57635c5662711fb7c5ee6c770fc9df) jprofiler: update icon hash
* [`eb3addea`](https://github.com/NixOS/nixpkgs/commit/eb3addea3c3a6c8bd843f6eca41b7d32f6312aaa) river-filtile: 1.1.0 -> 1.2.0
* [`86cc8539`](https://github.com/NixOS/nixpkgs/commit/86cc8539732f9f8a98ad6f6e8d2f7e225c72b283) flutter: 3.19.0 -> 3.19.3
* [`52fb8fe4`](https://github.com/NixOS/nixpkgs/commit/52fb8fe470c599ae61f49eb0ccec0414cee4dfa1) wxGTK32: repro build and disable rpath
* [`616f7e3b`](https://github.com/NixOS/nixpkgs/commit/616f7e3b7e9287ac309f1d397d76aebe22b02d4e) libbluray: fix build using withJava, make java build deterministic
* [`ec3c6e10`](https://github.com/NixOS/nixpkgs/commit/ec3c6e104e1a13a035b394ee5804d99ccd75d5ac) boehmgc: 8.2.4 -> 8.2.6
* [`6315cf18`](https://github.com/NixOS/nixpkgs/commit/6315cf18db0695cd37a907eeb6f641e2a4414fe8) ndi: 5.6.0 -> 5.6.1
* [`15ee2ca4`](https://github.com/NixOS/nixpkgs/commit/15ee2ca47fa98561af8f4b25c26cbeddd024ca26) ndi: update src and fix lib symlink
* [`6f520b27`](https://github.com/NixOS/nixpkgs/commit/6f520b273ea10d0cc6c4be108ab90015891115e1) nixos/ebusd: permit "none" as a log level
* [`da25f95b`](https://github.com/NixOS/nixpkgs/commit/da25f95bf4f0cbfdcb853f48e60229d6b30bb550) glibc: expose enableCET as overridable argument, default "permissive"
* [`8e6349b7`](https://github.com/NixOS/nixpkgs/commit/8e6349b7eb8a6150c0eb785040261857b8b881fc) iproute2: enable auto colorization
* [`0490e4de`](https://github.com/NixOS/nixpkgs/commit/0490e4de0f22cd1fc21d6fab9e16da8bd2cf76c9) mesa: fix indentation inside rustDeps
* [`9b99f9e7`](https://github.com/NixOS/nixpkgs/commit/9b99f9e790d4be56e9993bfacde37d914a4b478e) mesa: get rid of nested `with` in meta
* [`cbae8be8`](https://github.com/NixOS/nixpkgs/commit/cbae8be861cabc709d399b3b758511291dbe5647) mesa: reorder argset
* [`8e24e515`](https://github.com/NixOS/nixpkgs/commit/8e24e515c4b7285b6570a3d6a225c6ac48f31bb0) mesa: reword mesonFlags list by using lib.meson* functions
* [`4a25e78d`](https://github.com/NixOS/nixpkgs/commit/4a25e78d56d6c002fcfe5d45cf6a7ffbf566a90b) mesa: get rid of lib.optional
* [`9a86e0f0`](https://github.com/NixOS/nixpkgs/commit/9a86e0f0754071421edb81a57a95dbb0e087f57a) mesa: reorder lists
* [`ffe2d2fe`](https://github.com/NixOS/nixpkgs/commit/ffe2d2fe9db00bafda4847e4b51fb0e0fa264dbd) mesa: rewrite env.NIX_CFLAGS_COMPILE
* [`29912337`](https://github.com/NixOS/nixpkgs/commit/299123370f45fb519171005d95ba75e3c83d9058)  python3Packages.xdis: 6.0.5 -> 6.1.0
* [`ad91edc2`](https://github.com/NixOS/nixpkgs/commit/ad91edc21794a630d72615799a0d51cae868e898) flutter: 3.19.3 -> 3.19.4
* [`dbd5d47b`](https://github.com/NixOS/nixpkgs/commit/dbd5d47b0338bb70259f10bfcdfbc61b5902f82d) cargo-c: 0.9.29 -> 0.9.31
* [`8ddb0e2d`](https://github.com/NixOS/nixpkgs/commit/8ddb0e2dba8aa9325534873e1f6160efaeed5d63) affine: 0.13.1 -> 0.13.3
* [`531f1921`](https://github.com/NixOS/nixpkgs/commit/531f1921154bb8232e81b4e5d87736670656e4f8) libmcfp: 1.2.4 -> 1.3.3
* [`a6930766`](https://github.com/NixOS/nixpkgs/commit/a69307661758600629cd3ddbccbb10b915b023f5) photonvision: 2024.2.3 -> 2024.3.1
* [`8bf32c68`](https://github.com/NixOS/nixpkgs/commit/8bf32c6841ee3c495d948d322710b7ae37954132) re2: 2024-03-01 -> 2024-04-01
* [`78ff0192`](https://github.com/NixOS/nixpkgs/commit/78ff01921b06b266a056d37121ce9b384c357c74) python311Packages.pillow: 10.2.0 -> 10.3.0
* [`5d32909c`](https://github.com/NixOS/nixpkgs/commit/5d32909cad0e04ad87d79e42ceeb351c92839252) python3Packages.uncompyle6: 3.9.0 -> 3.9.1
* [`fa222a32`](https://github.com/NixOS/nixpkgs/commit/fa222a324c01b361593641d9af5e005dfa2fc409) ffmpeg: add avisynth support
* [`9cb585dd`](https://github.com/NixOS/nixpkgs/commit/9cb585ddf2bf6adaf5b20dd9fe79efec296200ee) python311Packages.stack-data: 0.2.0 -> 0.6.3
* [`4b894df4`](https://github.com/NixOS/nixpkgs/commit/4b894df400701f37a34151473037bb5825193595) mattermost-desktop: support NIXOS_OZONE_WL and fix sso login redirects
* [`64fbb2bb`](https://github.com/NixOS/nixpkgs/commit/64fbb2bbd01a23cbfe590072de88905392eba5aa) llhttp: 9.2.0 -> 9.2.1
* [`283865c4`](https://github.com/NixOS/nixpkgs/commit/283865c4b34df5b14e4dd88d3b3debef7b41b197) llhttp: add python aiohttp as reverse dependency to passthru.tests
* [`aea4ba84`](https://github.com/NixOS/nixpkgs/commit/aea4ba847a8ebaa452424ce7654f5127e37efb17) postgresql: remove thisAttr argument by calling tests directly
* [`29d5adb6`](https://github.com/NixOS/nixpkgs/commit/29d5adb676dd70c326b799f87ea295ffd2b0e34e) postgresql: change pname for postgresql_jit attributes to postgresql-jit
* [`605618c2`](https://github.com/NixOS/nixpkgs/commit/605618c2e8ba6257fd17479f76e0d08682c4bc7f) postgresql: clean up patches
* [`154215cf`](https://github.com/NixOS/nixpkgs/commit/154215cfd8f81f76e8a9f054ef52679564bf40c1) postgresql: rename patches
* [`c3c52231`](https://github.com/NixOS/nixpkgs/commit/c3c52231f02e9ea1cb5a77128734719c1738d845) postgresql: remove left-over LC_ALL environment variable
* [`6c1e2a44`](https://github.com/NixOS/nixpkgs/commit/6c1e2a44013ca3c1d209914cc186cbe1785a2945) postgresql: remove preConfigure CC variable
* [`4adcc41c`](https://github.com/NixOS/nixpkgs/commit/4adcc41cd99cfcd128fff3d65b2580ff00d8e42b) postgresql: move explicit libxml2 include behind version flag
* [`9f90ad30`](https://github.com/NixOS/nixpkgs/commit/9f90ad30fa9b61a985693ae938e901948e6c8c2e) postgresql: enable parallel building on darwin
* [`ec7b4581`](https://github.com/NixOS/nixpkgs/commit/ec7b4581d7e4cab10b4f3184ae5965cb2046a385) pkgsMusl.postgresql: mark v12 and v13 with JIT as broken
* [`c6017567`](https://github.com/NixOS/nixpkgs/commit/c6017567e02b632a25c4b4c9e8aa46c36f67d009) git-blame-ignore-revs: add postgresql cleanup
* [`1682b4cc`](https://github.com/NixOS/nixpkgs/commit/1682b4cc393dffbadedf8b869a3942965b056743) nixos/postgresql: fix enableJIT = false
* [`30fa4dca`](https://github.com/NixOS/nixpkgs/commit/30fa4dca882a91a18629fb93b31f8c4ee79285c8) pkgsMusl.postgresql: remove icu-collations-hack patch
* [`67510f6b`](https://github.com/NixOS/nixpkgs/commit/67510f6baacdcb005d106fbc1f22e4f7e343a410) nixosTests.postgresql-wal-receiver: remove left-over v12 conditionals
* [`81201ce8`](https://github.com/NixOS/nixpkgs/commit/81201ce88947c945794d37115de2982eb0ba97ae) pkgsMusl.postgresql: add TODO to run all regression tests
* [`c8b1d4fa`](https://github.com/NixOS/nixpkgs/commit/c8b1d4fa6de1fdd53ef87a95fe46e78cc12ada64) msgpack-c: 6.0.0 -> 6.0.1
* [`8c0390a3`](https://github.com/NixOS/nixpkgs/commit/8c0390a354b902e5e8ed25405ee423781b462706) xmlto: format with nixfmt-rfc-style
* [`c1ae842f`](https://github.com/NixOS/nixpkgs/commit/c1ae842f7c13b3cfcbccad6da0667e0674ec5cba) xmlto: use docbook-xml-ns package XSD files (offline mode)
* [`1370339c`](https://github.com/NixOS/nixpkgs/commit/1370339c755af511c76fb2c4e35b183367d8a959) xmlto: add passthru.tests.version
* [`53248e55`](https://github.com/NixOS/nixpkgs/commit/53248e5576a9e0695cf049d5f98f61e34a3df7f6) turbo: 1.11.3 -> 1.13.2
* [`06780641`](https://github.com/NixOS/nixpkgs/commit/0678064189983b3b2256ed1cd4b59f52ee0a9405) python3Packages.pytest-order: add Luflosi as maintainer
* [`4892527f`](https://github.com/NixOS/nixpkgs/commit/4892527f68f1e8c7945f3ea7407011b1e92c09d4) python3Packages.pytest-order: enable strictDeps
* [`35e8bace`](https://github.com/NixOS/nixpkgs/commit/35e8bace71635081a6e7d8cf21c35c113114d082) python3Packages.pytest-order: 1.2.0 -> 1.2.1
* [`8df695fe`](https://github.com/NixOS/nixpkgs/commit/8df695fef421b739013e263e9ac0cb6cb62f65b9) maintainers: add aos
* [`d6b43c87`](https://github.com/NixOS/nixpkgs/commit/d6b43c875815b38bcd755f4cd2d71d88e47f3872) snappy: 1.1.10 -> 1.2.0
* [`5603d4c2`](https://github.com/NixOS/nixpkgs/commit/5603d4c2e69a282c0b640de33827f67a8241881b) enchant: 2.6.8 -> 2.6.9
* [`f5efe376`](https://github.com/NixOS/nixpkgs/commit/f5efe3768a56d98bca4ea26c76c3df6ab1e5b89a) imagemagick: 7.1.1-29 -> 7.1.1-30
* [`e748b3a3`](https://github.com/NixOS/nixpkgs/commit/e748b3a37e2f0bcb58952e81a6ae7335eff4499f) giflib: don't build HTML documentation
* [`864a0f2e`](https://github.com/NixOS/nixpkgs/commit/864a0f2e0c713618b9756335f6c9d6ae6f0d83f0) river-filtile: 1.2.0 -> 1.2.1
* [`e3f6f574`](https://github.com/NixOS/nixpkgs/commit/e3f6f5742facac13428354c6fca13abac32738e1) meson: fix cross-compilation of rust proc-macro
* [`6486868c`](https://github.com/NixOS/nixpkgs/commit/6486868c2849b64dceebf9ea0048863ee1b7f823) cargoBuildHook: Fix features with __structuredAttrs
* [`bda70c98`](https://github.com/NixOS/nixpkgs/commit/bda70c98f1aa7604fd20a4281c37b92fac818c4d) pkgsStatic.dtc: fix build
* [`2d4efe50`](https://github.com/NixOS/nixpkgs/commit/2d4efe5046854bb01a6be19cb6f55673aa7992b5) alsa-ucm-conf: patches to fix rt1318 typo and copy paste errors
* [`1ff77afc`](https://github.com/NixOS/nixpkgs/commit/1ff77afc4ce94959f0e44a30aa44864a81ff3520) libcap_ng: 0.8.4 -> 0.8.5
* [`cb0f520b`](https://github.com/NixOS/nixpkgs/commit/cb0f520bf39170f8996184ec5876be699e03aee1) kubernetes-helmPlugins.helm-git: Switch to gitMinimal to reduce size
* [`8d4191df`](https://github.com/NixOS/nixpkgs/commit/8d4191df38e941c693721f91fac842508669aec8) google-cloud-sdk: Remove bundled python to reduce size
* [`8f604328`](https://github.com/NixOS/nixpkgs/commit/8f604328e6a1941ef9f007a59d067452eac09bd3) pam: 1.6.0 -> 1.6.1
* [`9a21177e`](https://github.com/NixOS/nixpkgs/commit/9a21177e8a7f1fef32820f12e7c529686897a45b) python312Packages.bc-detect-secrets: 1.5.5 -> 1.5.6
* [`00822db2`](https://github.com/NixOS/nixpkgs/commit/00822db219fa460973a065e9551203263971e5ae) python312Packages.bc-detect-secrets: format with nixfmt
* [`6b147fe5`](https://github.com/NixOS/nixpkgs/commit/6b147fe5a69a078e897bd251ebb7860538cbcf3c) libarchive: 3.7.2 -> 3.7.3
* [`67039671`](https://github.com/NixOS/nixpkgs/commit/67039671961c611edbfac1a20baa610fe3c3ae24) linuxManualConfig: Sometimes depend on ubootTools
* [`d101387e`](https://github.com/NixOS/nixpkgs/commit/d101387e6b55f3a682f96f84be33a8e48b31594f) python311Packages.aiohttp: 3.9.3 -> 3.9.4
* [`748ac9b6`](https://github.com/NixOS/nixpkgs/commit/748ac9b6bf03c5be94d1e6d85bdb89567d095ccc) python312Packages.idna: 3.6 -> 3.7
* [`8f5da4db`](https://github.com/NixOS/nixpkgs/commit/8f5da4db6ed48d64188657a5e645346787a5e7d8) ffmpeg: codec2 support
* [`9c41cab7`](https://github.com/NixOS/nixpkgs/commit/9c41cab75c1eed72f6081f84bfa7b9ed659862f3) ruby.rubygems: 3.5.7 -> 3.5.9
* [`b571ed6c`](https://github.com/NixOS/nixpkgs/commit/b571ed6c5c4aeb6db96045b58c4436184886b4b6) bundler: 2.5.7 -> 2.5.9
* [`553ab357`](https://github.com/NixOS/nixpkgs/commit/553ab357e867751a9480daeb21dd48ab31660c33) python311Packages.sphinx: disable flaky test
* [`28fb9243`](https://github.com/NixOS/nixpkgs/commit/28fb92431e36d0c4f5862521c3a6a8bb12fd2582) chromium: fix cross-compilation
* [`168279c7`](https://github.com/NixOS/nixpkgs/commit/168279c7cdf325f9b81c00dd0175377f71a02d89) python311Packages.sphinx: disable flaky test
* [`9a9e475c`](https://github.com/NixOS/nixpkgs/commit/9a9e475ca4f96eb50fb2c8576b93496a252d88d9) ffmpeg: jxl support
* [`861d23c3`](https://github.com/NixOS/nixpkgs/commit/861d23c31153113fcf0e18f7ed1b95e33c961720) netpbm: 11.6.0 -> 11.6.1
* [`063fa3f3`](https://github.com/NixOS/nixpkgs/commit/063fa3f37d1076d4151dd1a0b3e59f457c81512d) luaPackages: update on 2024-04-12
* [`883caebc`](https://github.com/NixOS/nixpkgs/commit/883caebc3419393c4fdaf8f8420c706028b6de9f) luaPackages.busted: fix build
* [`13fc1a91`](https://github.com/NixOS/nixpkgs/commit/13fc1a9154d84b72b854d305c254d93583a9f5f0) luaPackages.fzy: fix build
* [`1bb142ed`](https://github.com/NixOS/nixpkgs/commit/1bb142edc70ca49c795d9aed48146550590ed68e) luaPackages.luasnip: fix build
* [`8a79a0ea`](https://github.com/NixOS/nixpkgs/commit/8a79a0eaa19a02b94521df9a1b5160d00947c182) luaPackages.vusted: fix build
* [`cad647ca`](https://github.com/NixOS/nixpkgs/commit/cad647ca6f6b53d204512ab5c1f253e90c66579a) luaPackages.lua-resty-openidc: fix build
* [`1c8e4a07`](https://github.com/NixOS/nixpkgs/commit/1c8e4a0700b4c12ee66429a3e1ff8f7427101b2f) luaPackages.toml: fix build
* [`e8b22843`](https://github.com/NixOS/nixpkgs/commit/e8b228437c5bbe48c16e4549815b59578d1fe67f) python311Packages.starlette-wtf: 0.4.3 -> 0.4.5
* [`0f3baa90`](https://github.com/NixOS/nixpkgs/commit/0f3baa90444ecc9302d4af244fa8d4ca746c656a) s2n-tls: 1.4.9 -> 1.4.11
* [`5032948d`](https://github.com/NixOS/nixpkgs/commit/5032948d037d6d6502b1638db561a6e5b1bffc56) openblas: 0.3.26 -> 0.3.27
* [`14069907`](https://github.com/NixOS/nixpkgs/commit/14069907d9f47901829f877dd45b2a6cd99b14f6) openblas: add scikit-learn to passthru.tests
* [`cc724de3`](https://github.com/NixOS/nixpkgs/commit/cc724de3d148f93b5c5f1121b07edd8170e3aae9) xorg.lndir: 1.0.4 -> 1.0.5
* [`43287cb5`](https://github.com/NixOS/nixpkgs/commit/43287cb521d418de4a69aaf4b02c629884036ede) python311Packages.numba-scipy: 0.3.1 -> 0.4.0
* [`ce4ab12b`](https://github.com/NixOS/nixpkgs/commit/ce4ab12bfc93f56f2460f73699e13ff61c6df1c3) wildmidi: 0.4.5 -> 0.4.6
* [`0897e8b6`](https://github.com/NixOS/nixpkgs/commit/0897e8b6db11e65547758d1fd04fc5766cb2fe7a) glibc: allow (cross)-build on case-insensitive fs
* [`89f87a7a`](https://github.com/NixOS/nixpkgs/commit/89f87a7a8b70de035fe5892f84262cd6dba3fd57) libxlsxwriter: 1.1.5 -> 1.1.7
* [`2941e519`](https://github.com/NixOS/nixpkgs/commit/2941e519667acbe39e5a1e921deb24cb06c66965) llvmPackages_{12,13,14,15,16,17,18,git}: use common llvm
* [`36ba9343`](https://github.com/NixOS/nixpkgs/commit/36ba93434879027d3c482a77c0bcdea8d17d84cb) pcsclite: add passthru.tests.pkg-config, meta.pkgConfigModules
* [`64fa2dee`](https://github.com/NixOS/nixpkgs/commit/64fa2dee5776ae15fad37d3d18b9086345698952) pcsclite: remove `with lib;`, use `--replace-fail`
* [`d92148a8`](https://github.com/NixOS/nixpkgs/commit/d92148a86e03f1b0544978d928aee33c764b47d9) pcsclite: 2.0.3 -> 2.1.0
* [`ff86fbae`](https://github.com/NixOS/nixpkgs/commit/ff86fbaef5dccc3c061e81f88436085e66269ebf) goxlr-utility: 1.0.0 -> 1.1.1
* [`f8c0830b`](https://github.com/NixOS/nixpkgs/commit/f8c0830b18983f91b1a7532ef7288c7728343ebe) cloudflare-warp: 2023.3.470 -> 2024.4.133
* [`56470bb5`](https://github.com/NixOS/nixpkgs/commit/56470bb5d6f5576801e532152fcf42b200f11890) libopus: 1.5.1 -> 1.5.2
* [`80dac46d`](https://github.com/NixOS/nixpkgs/commit/80dac46dcfc94030b0f6ad832b0bb4d45d9ac01d) cmake: 3.29.1 -> 3.29.2
* [`e95a2286`](https://github.com/NixOS/nixpkgs/commit/e95a228693d2d60afa4715bb12945af092553705) nftables: split python package from main
* [`9b8156b4`](https://github.com/NixOS/nixpkgs/commit/9b8156b4a44c6577392e58d0cc728966e933c0b9) nftables: remove python patch
* [`e60cff0f`](https://github.com/NixOS/nixpkgs/commit/e60cff0f9873eef8aa067bbac310e2f904a02945) tree-sitter: 0.22.2 -> 0.22.5
* [`eddac71a`](https://github.com/NixOS/nixpkgs/commit/eddac71a68c7abfbcbb14be610f43744f51894b1) tree-sitter-grammars.tree-sitter-wing: fix build with latest tree-sitter
* [`44414723`](https://github.com/NixOS/nixpkgs/commit/444147235314913c15299fc13c000bbabe5994ab) tree-sitter: update grammars
* [`0b54bdbf`](https://github.com/NixOS/nixpkgs/commit/0b54bdbf59a08385f68321301dfb840e77171519) tree-sitter: add passthru.updateScript
* [`55c4ae69`](https://github.com/NixOS/nixpkgs/commit/55c4ae6984221c0902084f7345888f1b598c2247) wireviz: init at 0.3.2
* [`d7624be1`](https://github.com/NixOS/nixpkgs/commit/d7624be1a71b96261298ff853b243ce2993548f7) libwebp: 1.3.2 -> 1.4.0
* [`052c1581`](https://github.com/NixOS/nixpkgs/commit/052c15810b8d47e1b0abbc5426d6da9dea31ad71) libwebp: drop freeimage from passthru.tests
* [`a2325229`](https://github.com/NixOS/nixpkgs/commit/a232522964f54886e91b28d4cb262d4c06db5262) cosmic-term: 0-unstable-2024-02-28 -> 0-unstable-2024-04-15
* [`9dcc454f`](https://github.com/NixOS/nixpkgs/commit/9dcc454f7c97e8314028f75ecaf101f524b1c4a0) libwacom: 2.10.0 -> 2.11.0
* [`852ef048`](https://github.com/NixOS/nixpkgs/commit/852ef04876e7f5c9f3adf45ae3a47b03223be4ee) llvmPackages_{12,13,14,15,16,17,18,git}.clang: fix libLTO.dylib path
* [`a856906e`](https://github.com/NixOS/nixpkgs/commit/a856906eab24e3b3b96c50abba875b0d8df8195e) xorg.libpciaccess: 0.18 -> 0.18.1
* [`40cbfe89`](https://github.com/NixOS/nixpkgs/commit/40cbfe89b5942d54544327015f64d9d2812e61de) functionalplus: 0.2.23 -> 0.2.24
* [`1a9a8926`](https://github.com/NixOS/nixpkgs/commit/1a9a8926617fb70229144f0c62587ef031576270) libusb: add doc output
* [`31f935b5`](https://github.com/NixOS/nixpkgs/commit/31f935b59e5acec841e72f4dd8d429c732a74c9a) mo: init at 3.5.0
* [`1c8a2b65`](https://github.com/NixOS/nixpkgs/commit/1c8a2b65215bd23205460920621d93782e295ab8) texturepacker: 7.2.0 -> 7.3.0
* [`e4166e06`](https://github.com/NixOS/nixpkgs/commit/e4166e065189443e91fbd39b36919e6dda1d9f91) monetdb: 11.49.5 -> 11.49.7
* [`a594a0ae`](https://github.com/NixOS/nixpkgs/commit/a594a0ae4427503a93f653041098eb86e7d08b73) xorg.libXaw: 1.0.15 -> 1.0.16
* [`35a17a4e`](https://github.com/NixOS/nixpkgs/commit/35a17a4e434274c81b850268d21544fb61bd98cf) release-cross: remove guile_1_8 from windowsCommon
* [`16a2927a`](https://github.com/NixOS/nixpkgs/commit/16a2927a5eecd5a6ec144e0c72581c6b877802bb) python312Packages.google-api-python-client: 2.125.0 -> 2.126.0
* [`6430a5db`](https://github.com/NixOS/nixpkgs/commit/6430a5db806464f384762da45109a51f9ddab7ac) aws-c-common: 0.9.14 -> 0.9.15
* [`9cf87a29`](https://github.com/NixOS/nixpkgs/commit/9cf87a29ee14ca4680030b261aaae9f8f2e8b8a3) aws-c-io: 0.14.6 -> 0.14.7
* [`be80f8bd`](https://github.com/NixOS/nixpkgs/commit/be80f8bd504be271ef400d87e482e9baa90927f7) aws-c-auth: 0.7.16 -> 0.7.17
* [`e6ffb441`](https://github.com/NixOS/nixpkgs/commit/e6ffb441636bce811a28d816bfb4e50ead418ddc) aws-c-s3: 0.5.4 -> 0.5.7
* [`ee768eb5`](https://github.com/NixOS/nixpkgs/commit/ee768eb5da9240150bdbb55a47a20ce4d87350b7) aws-crt-cpp: 0.26.4 -> 0.26.8
* [`82048b01`](https://github.com/NixOS/nixpkgs/commit/82048b01f618d353583d41e2c3abf79b0fc3ba8a) aws-sdk-cpp: 1.11.296 -> 1.11.309
* [`6256ccb9`](https://github.com/NixOS/nixpkgs/commit/6256ccb916f5b42bf7e7b48fcfd81ba651fc23a4) python312Packages.google-api-python-client: refactor
* [`7aef871d`](https://github.com/NixOS/nixpkgs/commit/7aef871d8e2df0942c74050b9d5696e2a4df95eb) python312Packages.google-api-python-client: format with nixfmt
* [`5ffabd61`](https://github.com/NixOS/nixpkgs/commit/5ffabd61d0a8a8745e4f0feab4cae9ac7224c11c) glibc: 2.39-5 -> 2.39-31
* [`4a6511fb`](https://github.com/NixOS/nixpkgs/commit/4a6511fb9820ee8cfe172a790b8ac22fb96e698e) nodejs: make buildNpmPackage git dep lockfile fixup fail gracefully when no lockfile exists and git deps forced
* [`1bfce042`](https://github.com/NixOS/nixpkgs/commit/1bfce042b93ce55f094d5fb4744a5eef7d993c27) s2n-tls: 1.4.11 -> 1.4.12
* [`77b86776`](https://github.com/NixOS/nixpkgs/commit/77b86776335890bea9485ebc03d22240e95824b4) xorg.utilmacros: 1.20.0 -> 1.20.1
* [`3083d2ab`](https://github.com/NixOS/nixpkgs/commit/3083d2abe37408a713f325d901e1f3e01edc8f66) icu: refactor to avoid runtime dependency on bash
* [`6d6ab741`](https://github.com/NixOS/nixpkgs/commit/6d6ab741997f79bad92fe383ce4bfb31cdab3707) lomiri.lomiri-ui-toolkit: 1.3.5012 -> 1.3.5100
* [`167194b4`](https://github.com/NixOS/nixpkgs/commit/167194b43739c918a9a06570d73cab982104fb7f) ayatana-indicator-datetime: 23.10.1 -> 24.2.0
* [`d0805fa8`](https://github.com/NixOS/nixpkgs/commit/d0805fa861d589dcaf9127961a937dc8d6a544b4) lomiri.lomiri-system-settings-unwrapped: 1.0.2 -> 1.1.0
* [`8693247f`](https://github.com/NixOS/nixpkgs/commit/8693247fc8836f584910404d3f7b674363438742) python311Packages.approvaltests: 11.1.3 -> 11.2.1
* [`9118fc1e`](https://github.com/NixOS/nixpkgs/commit/9118fc1ebe37cba726f4b13fb196ecee84f80af8) maintainers: add buurro
* [`319c8736`](https://github.com/NixOS/nixpkgs/commit/319c87362fba17225e677c277256b50a8062c63b) trak: init at 0.0.4
* [`06e2c60c`](https://github.com/NixOS/nixpkgs/commit/06e2c60cc2ea59d3fa48b846cd8ef546076a18ac) jetbrains.clion: Add .NET SDK for ReSharper engine
* [`ec9dc94c`](https://github.com/NixOS/nixpkgs/commit/ec9dc94cdaed06942fd2b4109a4238d944782627) trak: suggested refactoring
* [`eeb87387`](https://github.com/NixOS/nixpkgs/commit/eeb87387aca914cab46a96692fe47c2dc13122b9) trak: 0.0.4 -> 0.0.5
* [`18c0dc27`](https://github.com/NixOS/nixpkgs/commit/18c0dc279259716faeceac14eeb08b9c772f6c8d) trak: use dependencies attr
* [`6500de41`](https://github.com/NixOS/nixpkgs/commit/6500de413a71678ee741aee7dc7974774091bf18) buildGoModule: warn about flags only when using provided buildPhase
* [`8d861e61`](https://github.com/NixOS/nixpkgs/commit/8d861e611873e55330fc2ef39bbf8591af0aef34) buildGoModule: place GOFLAGS-related warnings around GOFLAGS specification
* [`f8788e21`](https://github.com/NixOS/nixpkgs/commit/f8788e21f4770f6468c98b83f4855a59a88f0b01) daytona-bin: 0.9.0 -> 0.12.0
* [`a9b250db`](https://github.com/NixOS/nixpkgs/commit/a9b250db6010e52b96b1dc8a1fc5e6003e937fb6) maintainers: add osslate
* [`b0c13e32`](https://github.com/NixOS/nixpkgs/commit/b0c13e3247bd96a9bbc1bf51cc080ee819038ff7) daytona-bin: add osslate as maintainer
* [`d086dea7`](https://github.com/NixOS/nixpkgs/commit/d086dea772a375a850857cc4232d9d56dd15bf8c) nix-inspect: 0.1.1 -> 0.1.2
* [`13270e7f`](https://github.com/NixOS/nixpkgs/commit/13270e7feb05976dbde5e94e6b155f35592436e3) pcsclite: remove isLinux condition from --enable-ipcdir configureFlag
* [`dec7ebf0`](https://github.com/NixOS/nixpkgs/commit/dec7ebf0cd4176770cbf3f17dba913f8c3f8e373) pcsclite: make systemdSupport optional
* [`a87a0753`](https://github.com/NixOS/nixpkgs/commit/a87a075306b505030823ff051342c99351e4cd84) pcsclite: make dbusSupport optional
* [`2c387ccc`](https://github.com/NixOS/nixpkgs/commit/2c387ccce11e0723b94f99cec4901c3543eb149a) pcsclite: make udevSupport optional
* [`b9fe1f4e`](https://github.com/NixOS/nixpkgs/commit/b9fe1f4e3b9efc7e6b636a380a87f056d9a19907) perlPackages.ChipcardPCSC: fix cross
* [`12cf9126`](https://github.com/NixOS/nixpkgs/commit/12cf912670a45f3adb0e1eee97be5b9a8dfcc4ae) pcsc-tools: make gui, dbus, and systemd each (independently) optional
* [`21604e8d`](https://github.com/NixOS/nixpkgs/commit/21604e8d2bf42519fd3eeb9fc539d92919bea92e) rsync: 3.2.7 -> 3.3.0
* [`62d9b8f7`](https://github.com/NixOS/nixpkgs/commit/62d9b8f7c980c1057549a78870526ed5765f7374) maintainers: buurro email
* [`132f097b`](https://github.com/NixOS/nixpkgs/commit/132f097b479e132f6d8127c6acc9998676e5d1f9) pcsc-tools: use lib.meta.availableOn for systemdSupport
* [`a770f545`](https://github.com/NixOS/nixpkgs/commit/a770f545e349a46563a54dfe67ebd08e4c536e8d) libjxl: 0.9.1 -> 0.10.2
* [`c60dd90d`](https://github.com/NixOS/nixpkgs/commit/c60dd90d1f04f58ad631a546e732bd1e706dbdf2) nixos/adguardhome: update config to match new schema
* [`64e3c021`](https://github.com/NixOS/nixpkgs/commit/64e3c021c5cbb6ef395880f4a06a05534e2b55da) adguardhome: 0.107.36 -> 0.107.48
* [`5612e8ba`](https://github.com/NixOS/nixpkgs/commit/5612e8ba7b8c95820ff2a89c9da62dc84e2c55d7) nixos/qemu-vm: removed use of lib.mdDoc
* [`c642665a`](https://github.com/NixOS/nixpkgs/commit/c642665a0473fd44360fd603f067e94931affa2e) stdenv: fix missing dependencies in __sandboxProfile and __impureHostDeps
* [`2bb9ac64`](https://github.com/NixOS/nixpkgs/commit/2bb9ac64423daf473876bd5c2bfa3d7015c66f86) znapzend: add --mailErrorSummaryTo
* [`4b0a16aa`](https://github.com/NixOS/nixpkgs/commit/4b0a16aad30dfc8a3f9d7847c0d0ef91fa3abf34) pcsclite: use lib.meta.availableOn for systemdSupport
* [`c0daeabc`](https://github.com/NixOS/nixpkgs/commit/c0daeabc305ec2ba3c7259bc7052be449397b3a3) rPackages.CTdata: skip package load test
* [`d60cd409`](https://github.com/NixOS/nixpkgs/commit/d60cd409926ca0371cd64847b81fa06982fab6e8) rPackages.rfaRm: skip package load test
* [`0a078439`](https://github.com/NixOS/nixpkgs/commit/0a07843935a2a8156195f75e14484a1e704b27fd) rPackages.cfdnakit: add home
* [`69fe0146`](https://github.com/NixOS/nixpkgs/commit/69fe0146e518e012ef52dfa9bfc1151b18589dbf) rPackages.CaDrA: add home
* [`cde4c558`](https://github.com/NixOS/nixpkgs/commit/cde4c558e151fa706c6714bc970086733a95b48e) rPackage.GNOSIS: add home
* [`bb44d989`](https://github.com/NixOS/nixpkgs/commit/bb44d9890fece35b1c2a7476c6cd3fbc36ee0a94) xorg.libXmu: 1.1.4 -> 1.2.1
* [`489c3d29`](https://github.com/NixOS/nixpkgs/commit/489c3d29dfd2f36bfa835a8699ad138c2dc72ab8) talosctl: 1.6.5 -> 1.7.0
* [`67f9a8a5`](https://github.com/NixOS/nixpkgs/commit/67f9a8a51e29321b76fa5cb98f365e9e3c0aa629) python311Packages.peewee: 3.17.1 -> 3.17.3
* [`1541a030`](https://github.com/NixOS/nixpkgs/commit/1541a0306939b9fead6eb8f3b9c3e861e3c09800) pymol: 2.5.0 -> 3.0.0
* [`1bb46ec3`](https://github.com/NixOS/nixpkgs/commit/1bb46ec3c6475ccbb2390828ca362e0dbb08b682) pymol: modernize
* [`0fdb5bfb`](https://github.com/NixOS/nixpkgs/commit/0fdb5bfbe6ca1d10d04864c1eddab24f7da89f7f) python311Packages.django-ipware: 6.0.5 -> 7.0.1
* [`45b42d23`](https://github.com/NixOS/nixpkgs/commit/45b42d23b0d0d2e20656440cd16c76726d3b7f26) Update digiKam
* [`a37d6de1`](https://github.com/NixOS/nixpkgs/commit/a37d6de1fb6f9688a39b8428188ea026601fb8db) maintainers: add jcaesar
* [`676ca4e6`](https://github.com/NixOS/nixpkgs/commit/676ca4e68f512dadba80fb87893ea6e1e4d3e116) gdk-pixbuf: 2.42.10 -> 2.42.11
* [`ce1a7e51`](https://github.com/NixOS/nixpkgs/commit/ce1a7e5161932da7db46fef3258c31e13b19f849) shaderc: 2023.8 -> 2024.0
* [`b409a1d3`](https://github.com/NixOS/nixpkgs/commit/b409a1d3be0a45835e9e82e0d138f219e67b59c5) gst_all_1.gst-plugins-rs: 0.11.0+fixup -> 0.11.3
* [`242a3a2f`](https://github.com/NixOS/nixpkgs/commit/242a3a2f30709c5f0712d207d81ed1c2fe48db63) xorg: add update script
* [`2ab9d8c0`](https://github.com/NixOS/nixpkgs/commit/2ab9d8c078155b28ce2dbd8b11c0d7796a67c713) xorg.*: update
* [`34090efe`](https://github.com/NixOS/nixpkgs/commit/34090efe1885d110108ff5d0150da87673e3ed4c) xorg.xf86videosavage: mark as not broken anymore after update
* [`c59cbaf5`](https://github.com/NixOS/nixpkgs/commit/c59cbaf5bf3c5bd4c1f16f7574752201f11c686e) toVimPlugin: prepends 'vimPlugin' to the name
* [`5d0c7789`](https://github.com/NixOS/nixpkgs/commit/5d0c7789353e0239686464efc68d2f7204d2164b) way-displays: 1.10.2 -> 1.11.0
* [`96defb79`](https://github.com/NixOS/nixpkgs/commit/96defb793f12d8270bc87dbf308400150781fe3c) peergos: 0.14.1 -> 0.17.0
* [`51d2aba8`](https://github.com/NixOS/nixpkgs/commit/51d2aba8e90fb141c0aeed9bdbfe8da9e72b6876) python311Packages.python-telegram-bot: 21.1 -> 21.1.1
* [`4a54a02c`](https://github.com/NixOS/nixpkgs/commit/4a54a02ce298b77810797c0a04507438870131a5) lttng-ust: 2.13.7 -> 2.13.8
* [`699f4b49`](https://github.com/NixOS/nixpkgs/commit/699f4b49260a0b445caf4d7d48b6da0a29cf23c3) xorg.libfontenc: 1.1.7 -> 1.1.8
* [`e792793b`](https://github.com/NixOS/nixpkgs/commit/e792793b220b63abf24f5e85756d97197be24c3c) python311Packages.netutils: 1.8.0 -> 1.8.1
* [`f0621abc`](https://github.com/NixOS/nixpkgs/commit/f0621abc3ad3d017c11bb4651fe5fa3a32553cf9) symphony: init at version 5.7.2
* [`5521c238`](https://github.com/NixOS/nixpkgs/commit/5521c2380feddf6e1a01cedf4fd7140ea43e4d64) rPackages.Rsymphony: fixed build
* [`e9ae1719`](https://github.com/NixOS/nixpkgs/commit/e9ae1719ffb99be22ef8808bcf5ddc5f094159e8) maintainers: add b-rodrigues
* [`ec81fe00`](https://github.com/NixOS/nixpkgs/commit/ec81fe00d90995f7b14fe8823c894fe133015e2f) rPackages.Rhisat2: fix build
* [`13617579`](https://github.com/NixOS/nixpkgs/commit/1361757956ac49b89ec2027a2922f2c7f777efe6) argc: format Nix expression with nixfmt (Nix RFC 166)
* [`ac947d31`](https://github.com/NixOS/nixpkgs/commit/ac947d31aa49b5db3ec22baadd83da7e054878ef) gst_all_1.gst-plugins-rs: 0.11.3 -> 0.12.4
* [`11dfebc3`](https://github.com/NixOS/nixpkgs/commit/11dfebc306f5bd905c79ead894cbb15366e63932) nixos/qemu-vm: set security model 'none' for shared xchg directory
* [`bccb95d6`](https://github.com/NixOS/nixpkgs/commit/bccb95d6f7a65e9bfa20fcb2ca2c722d86d28485) python311Packages.beartype: 0.17.2 -> 0.18.5
* [`0136fde5`](https://github.com/NixOS/nixpkgs/commit/0136fde5152603543993fec99e4adab4d1a308f1) storm: 2.4.0 -> 2.6.2
* [`c00d9adb`](https://github.com/NixOS/nixpkgs/commit/c00d9adbaf767943d41b7b1471fbf1f1962b283b) argc: move to pkgs/by-name
* [`df9bc1f9`](https://github.com/NixOS/nixpkgs/commit/df9bc1f9a7dcc6bca044024eac76b62b6b32bdb2) nixos/gitlab: Rename postgresql port option
* [`c743d6d6`](https://github.com/NixOS/nixpkgs/commit/c743d6d61728d2eca1c232c99761bf4788efe125) nixos/gitlab: Add a second database connection
* [`56fc0166`](https://github.com/NixOS/nixpkgs/commit/56fc01663d11d6cca8c0e8fce9517d4fd37d794c) openssl: update comments and add 1.1 deprecation notice
* [`7766bbe7`](https://github.com/NixOS/nixpkgs/commit/7766bbe7bb14654ff13ed837643c41f3326f3201) liblc3: 1.1.0 -> 1.1.1
* [`35bee185`](https://github.com/NixOS/nixpkgs/commit/35bee18562c5a2f68fb0a4df3d1c1b72a2fbc8a0) tdl: 0.16.2 -> 0.17.0
* [`72ed3377`](https://github.com/NixOS/nixpkgs/commit/72ed33777c6b6bc797b2b3e11ea127424dd95693) nixos/wireplumber: add `extraConfig`/`extraScripts` options
* [`7151eeec`](https://github.com/NixOS/nixpkgs/commit/7151eeec4819222c181df80696f1bf43547bca51) treewide: `--replace` -> `--replace-fail`
* [`19df8269`](https://github.com/NixOS/nixpkgs/commit/19df82695b385c909e616ee74423737d6ee7aaad) biodiff: 1.1.0 -> 1.2.1
* [`19f23dfd`](https://github.com/NixOS/nixpkgs/commit/19f23dfdde80134846aa93cf3ad35d3d7ea272be) llvmPackages_16.llvm: actually enable libLLVMGold.so
* [`697bba98`](https://github.com/NixOS/nixpkgs/commit/697bba98920fb88ebf84c1564880747739f6f11e) fetchgit: Support fetching signed tags over dumb http transport
* [`c16ff7f9`](https://github.com/NixOS/nixpkgs/commit/c16ff7f9f3f15723f77d4db13ef6ad6bb7619933) nixos/qemu-vm: set security model for 'xchg' directory to 'none'
* [`7aa7920f`](https://github.com/NixOS/nixpkgs/commit/7aa7920fb0439c3b9c13a2d39f449beee9c7c9c8) Revert "nixos/qemu-vm: set security model for 'xchg' directory to 'none'"
* [`cb46e686`](https://github.com/NixOS/nixpkgs/commit/cb46e6864bec508dbfa461d3d5b592bbeb041d25) nixos/qemu-vm: set secrurity model for 'shared' and 'certs' directories to 'none'
* [`9f8eacf0`](https://github.com/NixOS/nixpkgs/commit/9f8eacf0b21562e69d056cc5579e5bf204d0c3fe) Revert "Merge [nixos/nixpkgs⁠#302770](https://togithub.com/nixos/nixpkgs/issues/302770): python3.pkgs.sphinx: disable flaky test"
* [`8f696cee`](https://github.com/NixOS/nixpkgs/commit/8f696cee9428b56a0b3a3c16cc8b0bbd317c65ec) spirit: 0-unstable-2024-03-20 -> 0-unstable-2024-04-18
* [`7a73706d`](https://github.com/NixOS/nixpkgs/commit/7a73706daddc722477d4126b961746eda5986ec6) mesa: convert vulkanLayers option to use lib.meson*
* [`eefd56e3`](https://github.com/NixOS/nixpkgs/commit/eefd56e328b91836be01e199029808e7f4ad08f0) mesa: reorder buildInputs
* [`a2a68138`](https://github.com/NixOS/nixpkgs/commit/a2a681387f721ec8a206643b9050a09167ade314) txtpbfmt: unstable-2023-10-25 -> 0-unstable-2024-04-16
* [`ebfbaaf2`](https://github.com/NixOS/nixpkgs/commit/ebfbaaf2817c95fa1540460f1db35d31c576c902) doc: remove discouraged enablePHP config from abstractions example
* [`1eec131d`](https://github.com/NixOS/nixpkgs/commit/1eec131dd8e8ee2ffc084008e8fc1a5f07bed4a5) listenbrainz-mpd: 2.3.4 -> 2.3.5
* [`10496cd8`](https://github.com/NixOS/nixpkgs/commit/10496cd886fbd3516d8314775cc1e8a01a98f542) python312Packages.build: 1.1.1 -> 1.2.1
* [`bbca5dc9`](https://github.com/NixOS/nixpkgs/commit/bbca5dc9905acfb592b436ce353be72bffb1edf0) python312Packages.setuptools: 69.2.0 -> 69.5.1
* [`00e5f210`](https://github.com/NixOS/nixpkgs/commit/00e5f21096021a60282bc883ce8ef637dfb83607) python312Packages.pdm-backend: 2.1.8 -> 2.2.1
* [`0a86ec62`](https://github.com/NixOS/nixpkgs/commit/0a86ec622f147dcfc25af0c9e17e3a45b733ac55) python312Packages.hypothesis: 6.99.12 -> 6.100.1
* [`9f42d238`](https://github.com/NixOS/nixpkgs/commit/9f42d2382e6a69b0021d94461162043d3e22bfc9) python311Packages.orjson: 3.9.15 -> 3.10.1
* [`275ba0f1`](https://github.com/NixOS/nixpkgs/commit/275ba0f1cb3779ed1f07438ad7f7a4d70efe72a5) python311Packages.dbus-python: 1.2.18 -> 1.3.2
* [`b5dda802`](https://github.com/NixOS/nixpkgs/commit/b5dda802437d6eccea277c9b851e8d98c826607e) ffado: remove unused kernel argument, cleanup python env creation
* [`6e27ff87`](https://github.com/NixOS/nixpkgs/commit/6e27ff8751124c693e427602f79041724edbcd4c) python312Packages.types-python-dateutil: 2.8.19.20240106 -> 2.8.19.20240311
* [`07cabb68`](https://github.com/NixOS/nixpkgs/commit/07cabb68f8dfcd4d68001bef2566fadba7bb9e07) python312Packages.validators: 0.22.0 -> 0.28.0
* [`7b426fc8`](https://github.com/NixOS/nixpkgs/commit/7b426fc85dfce08d34202f3147d7a25ab02f0553) python311Packages.httpcore: 1.0.4 -> 1.0.5
* [`11eb8710`](https://github.com/NixOS/nixpkgs/commit/11eb8710eb71f106e16e949c56e3c29c253a5e14) python311Packages.httpcore: add respx to passthru.tests
* [`2663fb96`](https://github.com/NixOS/nixpkgs/commit/2663fb9632249866f9ac53468baaa8be97894aa2) python311Packages.jpylyzer: 2.2.0 -> 2.2.1
* [`755dddb2`](https://github.com/NixOS/nixpkgs/commit/755dddb2b154a055a1a6991243981ed38a35a167) python312Packages.markdown: 3.5.2 -> 3.6.0
* [`08a04383`](https://github.com/NixOS/nixpkgs/commit/08a04383b601c6481a7327f75ad3618401d3af3c) python312Packages.aiodns: 3.1.1 -> 3.2.0
* [`f518a64f`](https://github.com/NixOS/nixpkgs/commit/f518a64f67eedb0b6737cbe86ce8c42ce406a528) python312Packages.referencing: 0.33.0 -> 0.34.0
* [`3a59ed7c`](https://github.com/NixOS/nixpkgs/commit/3a59ed7cc1dd3400f3df56e6d8fcf5fb27d8e715) python311Packages.uvicorn: 0.27.1 -> 0.29.0
* [`923c500d`](https://github.com/NixOS/nixpkgs/commit/923c500db2ebb1a1f5b69e0880a01d0bd227d0c0) python311Packages.pikepdf: 8.13.0 -> 8.14.0
* [`57cf17d3`](https://github.com/NixOS/nixpkgs/commit/57cf17d34ace8cc6fdfe3dc0bc463b8f89a851c1) python311Packages.aiohttp: remove reference to dev dependencies
* [`9718b32d`](https://github.com/NixOS/nixpkgs/commit/9718b32dc63b52a5eb5d6f6bf08eb4962e754a33) python3Packages.accelerate: 0.27.0 -> 0.29.3
* [`d9f19eae`](https://github.com/NixOS/nixpkgs/commit/d9f19eae2bece9234996faac053257900af741ad) python3Packages.aioairzone-cloud: 0.4.7 -> 0.5.1
* [`ca3dacc8`](https://github.com/NixOS/nixpkgs/commit/ca3dacc8f67ef6b5daf46689bd74d07e479b0843) python3Packages.aiobotocore: 2.12.1 -> 2.12.3
* [`97b53be7`](https://github.com/NixOS/nixpkgs/commit/97b53be7078dc8938fcedfb244459bd82884145c) python3Packages.aiorpcx: 0.22.1 -> 0.23.1
* [`124e38e2`](https://github.com/NixOS/nixpkgs/commit/124e38e23dfe2b15240282578e46424b5168f44e) python3Packages.albumentations: 1.4.2 -> 1.4.4
* [`b5d9aaa3`](https://github.com/NixOS/nixpkgs/commit/b5d9aaa3609f9d12c7c79e67657077b26d2e89e8) python3Packages.allure-behave: 2.13.2 -> 2.13.5
* [`3a804556`](https://github.com/NixOS/nixpkgs/commit/3a80455642122dd4dd8ba1cb41a90e51cf56fe39) python3Packages.allure-pytest: 2.13.2 -> 2.13.5
* [`8745b722`](https://github.com/NixOS/nixpkgs/commit/8745b7221aa2cbcee53abaf77100721b6b09f8a3) python3Packages.allure-python-commons: 2.13.2 -> 2.13.5
* [`d184c29d`](https://github.com/NixOS/nixpkgs/commit/d184c29dd41ba6be35f3eed5b6efa2d199d4a838) python3Packages.allure-python-commons-test: 2.13.4 -> 2.13.5
* [`b7b9bde8`](https://github.com/NixOS/nixpkgs/commit/b7b9bde887dcada0d6dd31f41e0778f3f46f0c0b) python3Packages.astropy-healpix: 1.0.2 -> 1.0.3
* [`fdb814f7`](https://github.com/NixOS/nixpkgs/commit/fdb814f78ca5ea5eb831e19725ae31f4ca0845b1) python3Packages.astroquery: 0.4.6 -> 0.4.7
* [`09346ffb`](https://github.com/NixOS/nixpkgs/commit/09346ffb3f7499db83a6e46529afe565070456ad) python3Packages.atpublic: 4.0 -> 4.1.0
* [`4c8653ae`](https://github.com/NixOS/nixpkgs/commit/4c8653ae613a23b5b69718895f47a2b4ac0e18e4) python3Packages.awscrt: 0.20.6 -> 0.20.9
* [`5a712879`](https://github.com/NixOS/nixpkgs/commit/5a71287905844e0b98cf7c3c2f3236d12d884b45) python3Packages.azure-identity: 1.15.0 -> 1.16.0
* [`c1f901fe`](https://github.com/NixOS/nixpkgs/commit/c1f901fe7ebcd5ad17c276b71505f19707daf878) python3Packages.azure-mgmt-cdn: 13.0.0 -> 13.1.0
* [`22779937`](https://github.com/NixOS/nixpkgs/commit/227799377950477a95e79e69e2ec59873043f26b) python3Packages.bdffont: 0.0.17 -> 0.0.20
* [`b8ce55d2`](https://github.com/NixOS/nixpkgs/commit/b8ce55d2c9df82db09be9a7ff68a8f78ee3ffaa6) python3Packages.beartype: 0.17.2 -> 0.18.3
* [`cf42aceb`](https://github.com/NixOS/nixpkgs/commit/cf42aceb508f10068e7c4703d389f2e4c5f1ddba) python3Packages.bids-validator: 1.14.4 -> 1.14.5
* [`e33c6b16`](https://github.com/NixOS/nixpkgs/commit/e33c6b16c67332b66e5f1893ce5e18e5d83a466f) python3Packages.black: 24.3.0 -> 24.4.0
* [`3344f66b`](https://github.com/NixOS/nixpkgs/commit/3344f66b4fa29c0ee9d878068b6a44809e629449) python3Packages.bokeh: 3.3.4 -> 3.4.1
* [`c0946fa0`](https://github.com/NixOS/nixpkgs/commit/c0946fa0d941aca9376f85371dd35f6c75058ae5) python3Packages.botocore: 1.34.58 -> 1.34.87
* [`661e6521`](https://github.com/NixOS/nixpkgs/commit/661e65216d820e88b669a17d1a472143ad457c46) python3Packages.boxx: 0.10.13 -> 0.10.14
* [`d7f947b9`](https://github.com/NixOS/nixpkgs/commit/d7f947b95bb82cbba0b677ecf7c9e55893639c15) python3Packages.cartopy: 0.22.0 -> 0.23.0
* [`6c3057fe`](https://github.com/NixOS/nixpkgs/commit/6c3057fed9aea8af30c9f38308aad1533f344a86) python3Packages.casa-formats-io: 0.2.2 -> 0.3.0
* [`e3a756fa`](https://github.com/NixOS/nixpkgs/commit/e3a756faecb5602d8b9c5a6945a4000ee022dada) python3Packages.cbor2: 5.6.2 -> 5.6.3
* [`d90347f0`](https://github.com/NixOS/nixpkgs/commit/d90347f0407254853525e9ed630663f95dc16cec) python3Packages.celery: 5.3.6 -> 5.4.0
* [`da9ffc46`](https://github.com/NixOS/nixpkgs/commit/da9ffc4605b134ba549449aaa46b86cbf0d71ca1) python3Packages.click-didyoumean: 0.3.0 -> 0.3.1
* [`d8201268`](https://github.com/NixOS/nixpkgs/commit/d8201268f7b39ea73b03002226590211857f1c76) python3Packages.cohere: 4.56 -> 4.57
* [`ca63fdca`](https://github.com/NixOS/nixpkgs/commit/ca63fdcacb0e9edaaed1a4d6ebc76a28720ccd0a) python3Packages.coverage: 7.4.3 -> 7.4.4
* [`c1f2b15a`](https://github.com/NixOS/nixpkgs/commit/c1f2b15ac0a0d0b7e567807897c6e6e81663fa63) python3Packages.cvxpy: 1.4.2 -> 1.4.3
* [`7ad5916c`](https://github.com/NixOS/nixpkgs/commit/7ad5916c31bbfd9b903c3425444b930b52a6ba45) python3Packages.cython: 3.0.9 -> 3.0.10
* [`a8e982fc`](https://github.com/NixOS/nixpkgs/commit/a8e982fcef21cac5682e63ca9a7d95719d79bb6e) python3Packages.databricks-connect: 11.3.26 -> 11.3.33
* [`605a7ad6`](https://github.com/NixOS/nixpkgs/commit/605a7ad692a119e4bf015973e910e989fa26715c) python3Packages.dbutils: 3.0.3 -> 3.1.0
* [`85fc3dd6`](https://github.com/NixOS/nixpkgs/commit/85fc3dd61976a6ad5003b3b73e02cdf7b3afc9fb) python3Packages.django-auth-ldap: 4.7.0 -> 4.8.0
* [`49de8394`](https://github.com/NixOS/nixpkgs/commit/49de83945344c4e79f532c03aeabda1653143cae) python3Packages.django-configurations: 2.5 -> 2.5.1
* [`081a2431`](https://github.com/NixOS/nixpkgs/commit/081a24310c03531c044ba29b1ce1e42f7763c3f1) python3Packages.django-mailman3: 1.3.11 -> 1.3.12
* [`14846b06`](https://github.com/NixOS/nixpkgs/commit/14846b06fd8a85022d6b32414434d31c4201453c) python3Packages.dkimpy: 1.1.5 -> 1.1.6
* [`94590ec1`](https://github.com/NixOS/nixpkgs/commit/94590ec1b2dcb191e50d03618d3cccc08869da0e) python3Packages.docplex: 2.25.236 -> 2.27.239
* [`cae2b904`](https://github.com/NixOS/nixpkgs/commit/cae2b904da22e69675251c9dad69847caf781264) python3Packages.docutils: 0.20.1 -> 0.21.1
* [`2c07c637`](https://github.com/NixOS/nixpkgs/commit/2c07c637f430a3a82a44186bda6f3abaee231257) python3Packages.dwdwfsapi: 1.0.7 -> 1.1.0
* [`432511f2`](https://github.com/NixOS/nixpkgs/commit/432511f21af361548ef0c1a118805f0805cda327) python3Packages.ecdsa: 0.18.0 -> 0.19.0
* [`ceaf3e7e`](https://github.com/NixOS/nixpkgs/commit/ceaf3e7e6a2c655820a74310f054332328f83463) python3Packages.elasticsearch8: 8.12.1 -> 8.13.0
* [`dcaa157e`](https://github.com/NixOS/nixpkgs/commit/dcaa157e889a9f174b2b43cb5445d672d71cffaa) python3Packages.elasticsearch: 8.12.1 -> 8.13.0
* [`4b18b449`](https://github.com/NixOS/nixpkgs/commit/4b18b449dc5db0a10537ebba69a31e72ebcda9fd) python3Packages.execnet: 2.0.2 -> 2.1.1
* [`f5c3c9a3`](https://github.com/NixOS/nixpkgs/commit/f5c3c9a317de8ccc8ab885c8cc7a2248c7a46c91) python3Packages.faker: 24.0.0 -> 24.11.0
* [`dc065ebd`](https://github.com/NixOS/nixpkgs/commit/dc065ebd194a3d90f6cd981cac1bc0dbf4037026) python3Packages.filelock: 3.13.1 -> 3.13.4
* [`6e7ce8a7`](https://github.com/NixOS/nixpkgs/commit/6e7ce8a7303a5950b2f3d86d66bcbe5a482d78de) python3Packages.flask: 3.0.2 -> 3.0.3
* [`317214c2`](https://github.com/NixOS/nixpkgs/commit/317214c280315b9060b522a9e1083fe5c4ea75e5) python3Packages.flexmock: 0.12.0 -> 0.12.1
* [`9bb199e4`](https://github.com/NixOS/nixpkgs/commit/9bb199e444ac4dc993fc880e2ff505915f033de1) python3Packages.fontbakery: 0.11.2 -> 0.12.2
* [`55016a06`](https://github.com/NixOS/nixpkgs/commit/55016a0658e86debd38783e27bd97000ec04b7db) python3Packages.fontmake: 3.8.1 -> 3.9.0
* [`e314ebd8`](https://github.com/NixOS/nixpkgs/commit/e314ebd871d20420459a649d5bea2a71259e98bc) python3Packages.gamble: 0.11 -> 0.13
* [`6014b935`](https://github.com/NixOS/nixpkgs/commit/6014b9357e29d20251d1e0a9c810f1b3aadc4747) python3Packages.geventhttpclient: 2.0.12 -> 2.3.0
* [`a669d1d4`](https://github.com/NixOS/nixpkgs/commit/a669d1d423d5d4228f0cec0fbaa1033380b6934c) python3Packages.glyphsets: 0.6.14 -> 0.6.19
* [`a02a7b1d`](https://github.com/NixOS/nixpkgs/commit/a02a7b1d219d86471429103c5641e5ad4c92dace) python3Packages.google-api-python-client: 2.125.0 -> 2.126.0
* [`33a6a5c1`](https://github.com/NixOS/nixpkgs/commit/33a6a5c1d42060e205750e60a4866903f39c3c9c) python3Packages.google-auth: 2.28.1 -> 2.29.0
* [`64010602`](https://github.com/NixOS/nixpkgs/commit/6401060221f1498312360d29a9189dcf3fd658c2) python3Packages.google-cloud-iam: 2.14.3 -> 2.15.0
* [`8f1ac712`](https://github.com/NixOS/nixpkgs/commit/8f1ac712f88981a7f62e29967329d4b297c88cdd) python3Packages.google-cloud-kms: 2.21.3 -> 2.21.4
* [`22a8ebe4`](https://github.com/NixOS/nixpkgs/commit/22a8ebe48879dfe85efb49b246a1631b3280ad62) python3Packages.google-cloud-monitoring: 2.19.3 -> 2.21.0
* [`500581c7`](https://github.com/NixOS/nixpkgs/commit/500581c72c6420b1392b4a918ce9b7f37c2862a2) python3Packages.google-cloud-spanner: 3.44.0 -> 3.45.0
* [`12ab6acb`](https://github.com/NixOS/nixpkgs/commit/12ab6acbfde5bd318d7543bb4ec6fb79a56c89b6) python3Packages.gradio: 4.22.0 -> 4.27.0
* [`b8dbb277`](https://github.com/NixOS/nixpkgs/commit/b8dbb277c652c95a262515ab1a7b612af3ba82e0) python3Packages.grpcio-channelz: 1.62.1 -> 1.62.2
* [`b4d4401b`](https://github.com/NixOS/nixpkgs/commit/b4d4401b703e88c470264f1dd3bcb56e358a981d) python3Packages.grpcio: 1.62.1 -> 1.62.2
* [`762d66d5`](https://github.com/NixOS/nixpkgs/commit/762d66d5433c12d091959e6782ec0b7a4bdd1b75) python3Packages.grpcio-status: 1.62.1 -> 1.62.2
* [`30fd15ef`](https://github.com/NixOS/nixpkgs/commit/30fd15efd16d87ded7579ec7bac2c0d592e504cb) python3Packages.grpcio-testing: 1.62.1 -> 1.62.2
* [`4ff848aa`](https://github.com/NixOS/nixpkgs/commit/4ff848aaab4a198f7e0706d934fae4863afe8b71) python3Packages.grpcio-tools: 1.62.1 -> 1.62.2
* [`2bba5c50`](https://github.com/NixOS/nixpkgs/commit/2bba5c5061d5d191375eb5a6956971be8ded4c75) python3Packages.h5py: 3.10.0 -> 3.11.0
* [`bbcab64b`](https://github.com/NixOS/nixpkgs/commit/bbcab64b6ab4531b7d545830df9ba599e2e2426c) python3Packages.hatchling: 1.22.4 -> 1.24.1
* [`b0aed05c`](https://github.com/NixOS/nixpkgs/commit/b0aed05ce1be35be28539e04726062adc12363f7) python3Packages.ibm-cloud-sdk-core: 3.19.2 -> 3.20.0
* [`cd261047`](https://github.com/NixOS/nixpkgs/commit/cd261047d3da69a28b6b57ee741cff7f45ee954b) python3Packages.importlib-metadata: 7.0.2 -> 7.1.0
* [`52b1da61`](https://github.com/NixOS/nixpkgs/commit/52b1da618a85a09c24fa9ae870e09e1b07d88515) python3Packages.importlib-resources: 6.1.3 -> 6.3.2
* [`d81a587a`](https://github.com/NixOS/nixpkgs/commit/d81a587a1a222a6034ee0480c83ba6377223dbf9) python3Packages.inflect: 7.0.0 -> 7.2.0
* [`37967af5`](https://github.com/NixOS/nixpkgs/commit/37967af5c15075d55dcca213ba560875047cb3eb) python3Packages.ipympl: 0.9.3 -> 0.9.4
* [`cc9d9f62`](https://github.com/NixOS/nixpkgs/commit/cc9d9f62dbc159d91db3f027a2b13853401eff96) python3Packages.itsdangerous: 2.1.2 -> 2.2.0
* [`1b0a43af`](https://github.com/NixOS/nixpkgs/commit/1b0a43af1912d4fe3c73f42dde60f83348700d6e) python3Packages.jaraco-collections: 5.0.0 -> 5.0.1
* [`b0796820`](https://github.com/NixOS/nixpkgs/commit/b07968204202a1309b8f1f872cba7806e871d54d) python3Packages.jaraco-functools: 4.0.0 -> 4.0.1
* [`8f4c6cf0`](https://github.com/NixOS/nixpkgs/commit/8f4c6cf0048266e91838800179709222e50dbf73) python3Packages.joblib: 1.3.2 -> 1.4.0
* [`5e049742`](https://github.com/NixOS/nixpkgs/commit/5e04974231d2f0490a2b3843cd4ee30face5c854) python3Packages.jsonpickle: 3.0.3 -> 3.0.4
* [`a3cc73f2`](https://github.com/NixOS/nixpkgs/commit/a3cc73f2a34a502f027bdb5604361332144331a0) python3Packages.keras: 3.0.5 -> 3.2.1
* [`2d36e52f`](https://github.com/NixOS/nixpkgs/commit/2d36e52fc49bfa5782a004a98142b8c6069b8353) python3Packages.keyrings-alt: 5.0.0 -> 5.0.1
* [`fc53a3d8`](https://github.com/NixOS/nixpkgs/commit/fc53a3d886084c966a7d1c2b0b22a10dca6db2cb) python3Packages.kombu: 5.3.5 -> 5.3.7
* [`e98a86a9`](https://github.com/NixOS/nixpkgs/commit/e98a86a91f2c605535f008c51efd4c3819fd5846) python3Packages.ledgerblue: 0.1.48 -> 0.1.50
* [`db32dc23`](https://github.com/NixOS/nixpkgs/commit/db32dc23b29be65f28623590a33fceb367a63035) python3Packages.lmfit: 1.2.2 -> 1.3.0
* [`b2aa09d0`](https://github.com/NixOS/nixpkgs/commit/b2aa09d072f6526eb2259f0086993a3aea0b651e) python3Packages.localstack-ext: 3.2.0 -> 3.3.0
* [`7eae7147`](https://github.com/NixOS/nixpkgs/commit/7eae7147a005b128c730afe87ce2509991ba9dbe) python3Packages.magic-wormhole: 0.13.0 -> 0.14.0
* [`c1884693`](https://github.com/NixOS/nixpkgs/commit/c1884693e58c6c5e35aaf32eec398a2321ca4c40) python3Packages.magika: 0.5.0 -> 0.5.1
* [`d564364d`](https://github.com/NixOS/nixpkgs/commit/d564364d96b8a9d20d4da4a4f5cff2700a24dd96) python3Packages.mako: 1.3.2 -> 1.3.3
* [`2927ab4c`](https://github.com/NixOS/nixpkgs/commit/2927ab4ca4685c1e1a31272c45743ca94d7629d8) python3Packages.matplotlib: 3.8.3 -> 3.8.4
* [`bff48723`](https://github.com/NixOS/nixpkgs/commit/bff48723c1a43b47f3d7cc7897113e09becbe63d) python3Packages.matplotlib-inline: 0.1.6 -> 0.1.7
* [`57de8a0a`](https://github.com/NixOS/nixpkgs/commit/57de8a0a5b28e7c8f620df961db5d052ba23bf4b) python3Packages.maxminddb: 2.5.2 -> 2.6.1
* [`90751188`](https://github.com/NixOS/nixpkgs/commit/907511887c40b0632ce7888dcb9b050961f75d01) python3Packages.mecab-python3: 1.0.8 -> 1.0.9
* [`8591c37e`](https://github.com/NixOS/nixpkgs/commit/8591c37efc6299b4b0c8a9194352ebdfcad8ad3e) python3Packages.meson-python: 0.15.0 -> 0.16.0
* [`a012c8d3`](https://github.com/NixOS/nixpkgs/commit/a012c8d37bac30b7f4bb0056da7add345c9173cf) python3Packages.mlflow: 2.11.3 -> 2.12.1
* [`e8577aeb`](https://github.com/NixOS/nixpkgs/commit/e8577aeb3790932d692e9d400e19ff28edad5117) python3Packages.mocket: 3.12.4 -> 3.12.5
* [`eb8a3c5c`](https://github.com/NixOS/nixpkgs/commit/eb8a3c5c44ed3ac764b32f8322176bdd986de498) python3Packages.mpi4py: 3.1.5 -> 3.1.6
* [`1602c418`](https://github.com/NixOS/nixpkgs/commit/1602c418afc5979bd37c472eb340f764d3deccce) python3Packages.mypy-protobuf: 3.5.0 -> 3.6.0
* [`26b745b0`](https://github.com/NixOS/nixpkgs/commit/26b745b0924759d853313ee9f0b739b625add9c3) python3Packages.netcdf4: 1.6.2 -> 1.6.5
* [`c0051d3c`](https://github.com/NixOS/nixpkgs/commit/c0051d3c435a94d5787a66496801063d3e72f39e) python3Packages.networkx: 3.2.1 -> 3.3
* [`29f985ff`](https://github.com/NixOS/nixpkgs/commit/29f985ffde602557cc1c4b103956d14eafe846f4) python3Packages.nilearn: 0.10.3 -> 0.10.4
* [`da15c884`](https://github.com/NixOS/nixpkgs/commit/da15c884f9eece14ed76a3cbde42769774ba8bd0) python3Packages.numba-scipy: 0.3.1 -> 0.4.0
* [`5a0c1b7c`](https://github.com/NixOS/nixpkgs/commit/5a0c1b7c9836ea9a187caadb6069a184dd24b196) python3Packages.numexpr: 2.9.0 -> 2.10.0
* [`e46e5661`](https://github.com/NixOS/nixpkgs/commit/e46e56617314b9201b3e9268b416e671c988318f) python3Packages.paddle2onnx: 1.1.0 -> 1.2.0
* [`6efcc2d7`](https://github.com/NixOS/nixpkgs/commit/6efcc2d7148a33c14778d854dc34113e01fa5e54) python3Packages.panel: 1.3.8 -> 1.4.1
* [`17401efc`](https://github.com/NixOS/nixpkgs/commit/17401efcb4649238b764d59e317a747ccd6aeb9f) python3Packages.parsedmarc: 8.8.0 -> 8.11.0
* [`1fb8638f`](https://github.com/NixOS/nixpkgs/commit/1fb8638f1c6d3d27c63fd7bae43fd8144257a983) python3Packages.parsel: 1.9.0 -> 1.9.1
* [`cc60595b`](https://github.com/NixOS/nixpkgs/commit/cc60595be6316d53dd4ced5054a133dce9164fc4) python3Packages.parso: 0.8.3 -> 0.8.4
* [`05254557`](https://github.com/NixOS/nixpkgs/commit/052545579a841c269a68a9af28018e346f8320e1) python3Packages.path: 16.10.0 -> 16.14.0
* [`e76c2017`](https://github.com/NixOS/nixpkgs/commit/e76c20179d965ac24d8c5a4c1caa1aea2a79d487) python3Packages.pathlib-abc: 0.1.1 -> 0.2.0
* [`c40390b8`](https://github.com/NixOS/nixpkgs/commit/c40390b8ffdabbab70a9d78ba54e8f9ba9d5335c) python3Packages.pg8000: 1.30.5 -> 1.31.1
* [`25d7aa4a`](https://github.com/NixOS/nixpkgs/commit/25d7aa4a7e8a6589550f2c25fb676250e7c3ca87) python3Packages.phonenumbers: 8.13.31 -> 8.13.34
* [`3b1e89cc`](https://github.com/NixOS/nixpkgs/commit/3b1e89ccafaf01e781876b3b907b7585a9371c78) python3Packages.pixel-font-builder: 0.0.15 -> 0.0.19
* [`bbadc236`](https://github.com/NixOS/nixpkgs/commit/bbadc2361b50c5d722b3237ca53928777b94331e) python3Packages.plotly: 5.20.0 -> 5.21.0
* [`f9e5f5d9`](https://github.com/NixOS/nixpkgs/commit/f9e5f5d9d6e079b133ba8ae810eeb08438e0e16b) python3Packages.pyasn1: 0.5.1 -> 0.6.0
* [`04689f97`](https://github.com/NixOS/nixpkgs/commit/04689f972627e8459c65c687f3853fdc630cccdb) python3Packages.pycparser: 2.21 -> 2.22
* [`3edeb8fa`](https://github.com/NixOS/nixpkgs/commit/3edeb8fac849743833cb06981b66673d8e988e76) python3Packages.pycups: 2.0.1 -> 2.0.4
* [`430940d3`](https://github.com/NixOS/nixpkgs/commit/430940d35f8782b7f0784d41eb187b0e7f62a73f) python3Packages.pyerfa: 2.0.1.1 -> 2.0.1.4
* [`62ce4f73`](https://github.com/NixOS/nixpkgs/commit/62ce4f73e1e374910eb0cbd327fd3e19629cd5fc) python3Packages.pyfakefs: 5.3.5 -> 5.4.1
* [`66447f34`](https://github.com/NixOS/nixpkgs/commit/66447f345e5d7eb53b3a3cb42005bd55bfc7ced1) python3Packages.pykalman: 0.9.5 -> 0.9.7
* [`fc31caaa`](https://github.com/NixOS/nixpkgs/commit/fc31caaa0b54144b1fba153529dd4c180053946a) python3Packages.pykdtree: 1.3.11 -> 1.3.12
* [`ce786dd8`](https://github.com/NixOS/nixpkgs/commit/ce786dd85c2bdc2832cc81a60c0c487f7334f2b0) python3Packages.pymongo: 4.6.2 -> 4.6.3
* [`aef5d1b3`](https://github.com/NixOS/nixpkgs/commit/aef5d1b31d8bb84942d5bda3d27ddfe825225fb7) python3Packages.pymysql: 1.0.2 -> 1.1.0
* [`b50d6d2d`](https://github.com/NixOS/nixpkgs/commit/b50d6d2d79c6cf3d7bad176283bfdbdba23c8dad) python3Packages.pyopenssl: 24.0.0 -> 24.1.0
* [`4224cafd`](https://github.com/NixOS/nixpkgs/commit/4224cafdae29bf696b6fa3f720a4598b464b4981) python3Packages.pyproject-metadata: 0.7.1 -> 0.8.0
* [`df6a65d8`](https://github.com/NixOS/nixpkgs/commit/df6a65d88c65387d308b37373cca27016b5a3f7e) python3Packages.pyqt-builder: 1.15.4 -> 1.16.0
* [`b0a8bbcb`](https://github.com/NixOS/nixpkgs/commit/b0a8bbcb2099e22911ed0276ce38b414c54d5a04) python3Packages.pyramid-beaker: 0.8 -> 0.9
* [`65077dba`](https://github.com/NixOS/nixpkgs/commit/65077dbae526dba3fb1a40e72387b293f303bc27) python3Packages.pysimplegui: 5.0.3 -> 5.0.4
* [`c10f7f36`](https://github.com/NixOS/nixpkgs/commit/c10f7f367e711af8b97b52f422d4453e286ec605) python3Packages.pytest-mock: 3.12.0 -> 3.14.0
* [`0ad16e26`](https://github.com/NixOS/nixpkgs/commit/0ad16e264b4190b9bd26ed75fd18cf282efe8a7a) python3Packages.python-musicpd: 0.8.0 -> 0.9.0
* [`9306d965`](https://github.com/NixOS/nixpkgs/commit/9306d96568a87d4bfa910fa04b3d74608e003c38) python3Packages.pywavelets: 1.4.1 -> 1.6.0
* [`f52b7417`](https://github.com/NixOS/nixpkgs/commit/f52b74172d8c6bd98e8258b7608b0bc2d94cc2f3) python3Packages.pywbem: 1.6.3 -> 1.7.1
* [`e6b76a28`](https://github.com/NixOS/nixpkgs/commit/e6b76a28ceaaa32b70d4da1987c9f6be9bd2a4be) python3Packages.qdldl: 0.1.7.post1 -> 0.1.7.post2
* [`c3c3f80d`](https://github.com/NixOS/nixpkgs/commit/c3c3f80dda091d4540e17b270ada86bf102a520b) python3Packages.redis: 5.0.1 -> 5.0.3
* [`661f8333`](https://github.com/NixOS/nixpkgs/commit/661f83334e76eca817490d45a258f5d92f6cb30d) python3Packages.reportlab: 4.1.0 -> 4.2.0
* [`513d6c05`](https://github.com/NixOS/nixpkgs/commit/513d6c054e3bc3c3812e24e21e580f10e66af14a) python3Packages.reproject: 0.13.0 -> 0.13.1
* [`29198e63`](https://github.com/NixOS/nixpkgs/commit/29198e63cb514cb23f753568352f9033820776e0) python3Packages.requests-mock: 1.11.0 -> 1.12.1
* [`8633d615`](https://github.com/NixOS/nixpkgs/commit/8633d61593d7d771569ba65c78289823df10889a) python3Packages.rpy2: 3.5.15 -> 3.5.16
* [`9e087535`](https://github.com/NixOS/nixpkgs/commit/9e0875351fd9191528b1994beb287ee50d086a41) python3Packages.safety: 3.0.1 -> 3.1.0
* [`90dec7aa`](https://github.com/NixOS/nixpkgs/commit/90dec7aa08d607df096f8b7e04d25b10037c5ea2) python3Packages.scalene: 1.5.38 -> 1.5.39
* [`c175f25e`](https://github.com/NixOS/nixpkgs/commit/c175f25e89a293b410d6358cc115a81b3ee6c599) python3Packages.schwifty: 2024.1.1.post0 -> 2024.4.0
* [`69a46582`](https://github.com/NixOS/nixpkgs/commit/69a465824e70f28fc3040694f790c63c4bd6b473) python3Packages.scikit-bio: 0.5.9 -> 0.6.0
* [`f16e58fd`](https://github.com/NixOS/nixpkgs/commit/f16e58fd87ff140234ba106b29ac8d689a80e744) python3Packages.scikit-learn: 1.4.1.post1 -> 1.4.2
* [`8eeb029f`](https://github.com/NixOS/nixpkgs/commit/8eeb029f416c0e7686503bdeb5406be0786e5add) python3Packages.sigstore-protobuf-specs: 0.3.0 -> 0.3.1
* [`36ba406e`](https://github.com/NixOS/nixpkgs/commit/36ba406e9eae4bb4437029564712257028145813) python3Packages.slicer: 0.0.7 -> 0.0.8
* [`13074479`](https://github.com/NixOS/nixpkgs/commit/13074479fdb5eff40f5cad64b1df328db96fea0e) python3Packages.snowflake-sqlalchemy: 1.5.1 -> 1.5.3
* [`0f1d66d6`](https://github.com/NixOS/nixpkgs/commit/0f1d66d64dcb817d2e0ebcab2e3c96703de5ef0d) python3Packages.spglib: 2.3.1 -> 2.4.0
* [`b33ba4b1`](https://github.com/NixOS/nixpkgs/commit/b33ba4b180d3d548b3edb584468b30d595353b99) python3Packages.sphinx-autobuild: 2024.2.4 -> 2024.4.16
* [`9de06114`](https://github.com/NixOS/nixpkgs/commit/9de06114bc7885cf6b6975bb03d7f7f9a75187f9) python3Packages.sphinx-autodoc-typehints: 2.0.0 -> 2.1.0
* [`b7b04207`](https://github.com/NixOS/nixpkgs/commit/b7b0420740c2bdda4b67695828cb0ac4e53774a4) python3Packages.sphinxcontrib-tikz: 0.4.18 -> 0.4.19
* [`19580d15`](https://github.com/NixOS/nixpkgs/commit/19580d1559164f603a6a58d4ba58017951b557c6) python3Packages.spyder: 5.5.3 -> 5.5.4
* [`a1924118`](https://github.com/NixOS/nixpkgs/commit/a1924118610f40405ab325dec780bd94671c5e34) python3Packages.sqlalchemy-utils: 0.41.1 -> 0.41.2
* [`5c0e0350`](https://github.com/NixOS/nixpkgs/commit/5c0e0350046ff1230eb725e602d8d74adb772b6b) python3Packages.sqlparse: 0.4.4 -> 0.5.0
* [`a2388261`](https://github.com/NixOS/nixpkgs/commit/a2388261f10ecd8edc774dfba535779ee58ed784) python3Packages.statsmodels: 0.14.1 -> 0.14.2
* [`16864083`](https://github.com/NixOS/nixpkgs/commit/16864083de9a3c0833a87351075332c7fe64f694) python3Packages.stripe: 8.9.0 -> 8.11.0
* [`242920c1`](https://github.com/NixOS/nixpkgs/commit/242920c156d4342bad2a4ed42a499f06c24424ac) python3Packages.sunpy: 5.1.1 -> 5.1.2
* [`3d4624ae`](https://github.com/NixOS/nixpkgs/commit/3d4624aeb9208134fe47939d26c7d71d122bc93e) python3Packages.tablib: 3.5.0 -> 3.6.1
* [`3af81d5b`](https://github.com/NixOS/nixpkgs/commit/3af81d5b0c8b32878b3b98731854c2279e518cce) python3Packages.tidalapi: 0.7.5 -> 0.7.6
* [`2e5bfce8`](https://github.com/NixOS/nixpkgs/commit/2e5bfce86a5a8637b11dcf4322b9eab435f44e85) python3Packages.tifffile: 2024.2.12 -> 2024.4.18
* [`5851a12d`](https://github.com/NixOS/nixpkgs/commit/5851a12dad9539f28b1f5b15f1cb3ffb13283a05) python3Packages.traitlets: 5.14.1 -> 5.14.2
* [`cf2206ed`](https://github.com/NixOS/nixpkgs/commit/cf2206ed18a8c8453f3b0bb6c041a2d07a453cf1) python3Packages.trio: 0.24.0 -> 0.25.0
* [`79ab81dc`](https://github.com/NixOS/nixpkgs/commit/79ab81dccc26bbe763de850d081a6e7c0ca5c1cc) python3Packages.trove-classifiers: 2024.3.3 -> 2024.4.10
* [`094bf05e`](https://github.com/NixOS/nixpkgs/commit/094bf05e73b8f2f82a2ecd57bf28de6a809fef21) python3Packages.trytond: 7.0.9 -> 7.0.10
* [`bf5999db`](https://github.com/NixOS/nixpkgs/commit/bf5999db1e9426aff90e040333fb9429a5027b4f) python3Packages.typed-settings: 24.1.0 -> 24.2.0
* [`34b4786e`](https://github.com/NixOS/nixpkgs/commit/34b4786ef7383c403b8c8e071d75cf55656e27f3) python3Packages.type-infer: 0.0.18 -> 0.0.19
* [`9ec66194`](https://github.com/NixOS/nixpkgs/commit/9ec66194f089c53efb07df11344b4bee7de2c29c) python3Packages.typer: 0.9.0 -> 0.12.3
* [`4d2b81d1`](https://github.com/NixOS/nixpkgs/commit/4d2b81d181bd1776a4c1f918c014f3e8a8023914) python3Packages.types-pillow: 10.2.0.20240331 -> 10.2.0.20240415
* [`4ad9c9e6`](https://github.com/NixOS/nixpkgs/commit/4ad9c9e677c64ac79b563659a40e9befa008ee02) python3Packages.types-protobuf: 4.24.0.20240311 -> 4.25.0.20240417
* [`d6fd5e13`](https://github.com/NixOS/nixpkgs/commit/d6fd5e1354be651c03e4bc48d967685127d11201) python3Packages.types-pyopenssl: 24.0.0.20240311 -> 24.0.0.20240417
* [`fb474983`](https://github.com/NixOS/nixpkgs/commit/fb474983e353b02de5ba017efca8d25a0a7461aa) python3Packages.types-python-dateutil: 2.8.19.20240311 -> 2.9.0.20240316
* [`344bf228`](https://github.com/NixOS/nixpkgs/commit/344bf2289944cdd1c95ce037165f735fcef93cf7) python3Packages.types-pytz: 2024.1.0.20240203 -> 2024.1.0.20240417
* [`38023ec1`](https://github.com/NixOS/nixpkgs/commit/38023ec1c26d0435cd88f934fbf88febd9d14452) python3Packages.types-pyyaml: 6.0.12.12 -> 6.0.12.20240311
* [`7b0d9530`](https://github.com/NixOS/nixpkgs/commit/7b0d9530928a1870210b84021971b66105737a65) python3Packages.types-redis: 4.6.0.20240409 -> 4.6.0.20240417
* [`25911738`](https://github.com/NixOS/nixpkgs/commit/25911738586dbfc50db8930ae319bcd077da992c) python3Packages.types-s3transfer: 0.10.0 -> 0.10.1
* [`17c03fdc`](https://github.com/NixOS/nixpkgs/commit/17c03fdc4c0e50d5b5655f5069a1b1fbeff4c845) python3Packages.types-setuptools: 69.2.0.20240317 -> 69.5.0.20240415
* [`d5c01fef`](https://github.com/NixOS/nixpkgs/commit/d5c01fef96dbf95e589f676353f34e3b50d4e33d) python3Packages.types-toml: 0.10.8.7 -> 0.10.8.20240310
* [`110f0921`](https://github.com/NixOS/nixpkgs/commit/110f0921e3f532848bdae5b42ba8c6e43ff9ad6f) python3Packages.types-tqdm: 4.66.0.20240106 -> 4.66.0.20240417
* [`496ec69f`](https://github.com/NixOS/nixpkgs/commit/496ec69f2c3d8ede5e8fbd72264477d0117a8770) python3Packages.typing-extensions: 4.10.0 -> 4.11.0
* [`3eae15f9`](https://github.com/NixOS/nixpkgs/commit/3eae15f99061c3e8b3c44f9ec2e68a178471514c) python3Packages.ufo2ft: 3.1.0 -> 3.2.1
* [`83627886`](https://github.com/NixOS/nixpkgs/commit/83627886f5a99416d67277d1c741e5a64d77961d) python3Packages.uncompyle6: 3.9.0 -> 3.9.1
* [`764829cc`](https://github.com/NixOS/nixpkgs/commit/764829ccb27b5e2e6cef103add39e7ebeb753728) python3Packages.uqbar: 0.7.3 -> 0.7.4
* [`67b2d677`](https://github.com/NixOS/nixpkgs/commit/67b2d677736fb55b45179b336d5189654f68f99d) python3Packages.versioningit: 3.0.0 -> 3.1.0
* [`59c9900b`](https://github.com/NixOS/nixpkgs/commit/59c9900bb26b5f2be99c776f5172bb96e3a907a7) python3Packages.virt-firmware: 24.2 -> 24.4
* [`feea7ce5`](https://github.com/NixOS/nixpkgs/commit/feea7ce589686bc97596705ade64c76cc42bc5b1) python3Packages.virtualenv: 20.25.1 -> 20.25.3
* [`c131ea48`](https://github.com/NixOS/nixpkgs/commit/c131ea48feee207ed1c8c7bc11b3e4afd12adae8) python3Packages.weaviate-client: 4.5.1 -> 4.5.5
* [`09e25934`](https://github.com/NixOS/nixpkgs/commit/09e25934368d659488fd9f1f80c7dd73cec4698f) python3Packages.werkzeug: 3.0.1 -> 3.0.2
* [`6ead03b3`](https://github.com/NixOS/nixpkgs/commit/6ead03b39769b6f0b146cdf5376a9c477aec9926) python3Packages.xmlsec: 1.3.13 -> 1.3.14
* [`b94e75d9`](https://github.com/NixOS/nixpkgs/commit/b94e75d99a377f66b9b8122b110b67e20db09ecd) python3Packages.ydiff: 1.2 -> 1.3
* [`3d80d37e`](https://github.com/NixOS/nixpkgs/commit/3d80d37e767c4e5dd128592020be1d146e3183d2) python3Packages.zarr: 2.17.1 -> 2.17.2
* [`3e1603b9`](https://github.com/NixOS/nixpkgs/commit/3e1603b9135ac24d04e5d640fdaef8dd2687c841) python3Packages.zephyr-python-api: 0.0.4 -> 0.0.5
* [`88716748`](https://github.com/NixOS/nixpkgs/commit/88716748dac432d0d6292f1f348bf4b9af66edba) python3Packages.zipp: 3.17.0 -> 3.18.1
* [`b61f94d7`](https://github.com/NixOS/nixpkgs/commit/b61f94d7a263d41e56caf3730b1fae8a1e8c4ff7) python311Package.css-inline: 0.13.0 -> 0.14.0
* [`4b5291d3`](https://github.com/NixOS/nixpkgs/commit/4b5291d3b77ab253902781ae71959c3ff94fdf80) python311Packages.numpy: relax meson-python constraint
* [`e58f256b`](https://github.com/NixOS/nixpkgs/commit/e58f256bd82aeabb92d36b582e0623774044fff3) python311Packages.sphinx: 7.2.6 -> 7.3.7
* [`47674e2b`](https://github.com/NixOS/nixpkgs/commit/47674e2b668ec7e4139b2088201b742afbacc6cb) python312Packages.sphinxcontrib-jquery: provide defusedxml for tests
* [`e4249b7c`](https://github.com/NixOS/nixpkgs/commit/e4249b7c768e442366b9dcf5c9a2130b97f8db1a) python312Packages.scikit-build: disable failing tests
* [`b1d57eda`](https://github.com/NixOS/nixpkgs/commit/b1d57eda3ca3b0372482e1d00bd307e81a5b2cae) python311Packages.sphinx-pytest: provide defusedxml for tests
* [`b572b76f`](https://github.com/NixOS/nixpkgs/commit/b572b76f591ab6949b00f63d402aa6fa10e08f84) python312Packages.sphinx-rtd-theme: disable failing test
* [`4dc5e6bd`](https://github.com/NixOS/nixpkgs/commit/4dc5e6bde6098de56cc32c2cbdc4485f5f3be086) python312Packages.pyelftools: 0.30 -> 0.31
* [`804cca75`](https://github.com/NixOS/nixpkgs/commit/804cca754d113754dc176976ba6ea997cb692527) python312Packages.s3transfer: 0.10.0 -> 0.10.1
* [`611f3174`](https://github.com/NixOS/nixpkgs/commit/611f3174f83ce9319df6d0115dfd019989e00a60) python311Packages.aiosmtpd: add changelog to meta
* [`b693e0a6`](https://github.com/NixOS/nixpkgs/commit/b693e0a6a9e18eda34ea0180e0605033ac17bdf8) python311Packages.aiosmtpd: refactor
* [`9c2d2665`](https://github.com/NixOS/nixpkgs/commit/9c2d2665fe59b897d8a7c7066aa2c203fdd62b98) python312Packages.pyelftools: refactor
* [`d0ca2f5f`](https://github.com/NixOS/nixpkgs/commit/d0ca2f5fd76b4d99f8bd6cad959a4b02eff9f0f3) python312Packages.sqlparse: refactor
* [`c6cbe689`](https://github.com/NixOS/nixpkgs/commit/c6cbe6895d06cb295a554d2c0d72d68352570d90) python312Packages.readme-renderer: clean-up disabled tests
* [`516c9aef`](https://github.com/NixOS/nixpkgs/commit/516c9aef6069e773a777ae6e7997debd29195cd0) python3Packages.qrcode: disable sandbox-incompatible test
* [`2e4e8ddb`](https://github.com/NixOS/nixpkgs/commit/2e4e8ddb9ca9c77cc6aaf0a2583e957dd8794754) python3Packages.myst-parser: disable sphinx sensitive tests
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
