### PR TITLE
niv home-manager: update f8e6694e -> 6ebe7be2

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -41,10 +41,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f8e6694edabe4aaa7a85aac47b43ea5d978b116d",
-        "sha256": "1i6g2i69n5nk0vzm6j2by7nf1bl524xahq46kq9f5wmjlgy508j9",
+        "rev": "6ebe7be2e67be7b9b54d61ce5704f6fb466c536f",
+        "sha256": "1rlhl2dq04z5mk0fv91cz8560rk43fjmlgb05b4ji349a3dx8zvg",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/f8e6694edabe4aaa7a85aac47b43ea5d978b116d.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/6ebe7be2e67be7b9b54d61ce5704f6fb466c536f.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@f8e6694e...6ebe7be2](https://github.com/nix-community/home-manager/compare/f8e6694edabe4aaa7a85aac47b43ea5d978b116d...6ebe7be2e67be7b9b54d61ce5704f6fb466c536f)

* [`3c0df2a7`](https://github.com/nix-community/home-manager/commit/3c0df2a7e43b432b739d8e9d289dcb362a44b308) freetube: add module
* [`28ef93bb`](https://github.com/nix-community/home-manager/commit/28ef93bb8e5208ae4230f59efe7b96e115e5ddd2) maintainers: add kaleocheng
* [`6d3b6dc9`](https://github.com/nix-community/home-manager/commit/6d3b6dc9222c12b951169becdf4b0592ee9576ef) conky: add module
* [`67d0e7db`](https://github.com/nix-community/home-manager/commit/67d0e7db8827abc3634c02de62f3e651a0c92d8c) Translate using Weblate (Persian)
* [`9036fe9e`](https://github.com/nix-community/home-manager/commit/9036fe9ef8e15a819fa76f47a8b1f287903fb848) flake.lock: Update
* [`e0825ea2`](https://github.com/nix-community/home-manager/commit/e0825ea2112d09d9f0680833cd716f6aee3b973f) swaync: fix style path
* [`2a44f4d0`](https://github.com/nix-community/home-manager/commit/2a44f4d09f891d8a9d72b9a7331fa8d94b066119) flake.lock: Update
* [`f69bf670`](https://github.com/nix-community/home-manager/commit/f69bf670d29d3921e00cc626d174654769d743c6) cliphist: add extraOptions option
* [`fdaaf543`](https://github.com/nix-community/home-manager/commit/fdaaf543bad047639ef0b356ea2e6caec2f1215c) hypridle: add module
* [`3dfe05aa`](https://github.com/nix-community/home-manager/commit/3dfe05aa9b5646995ace887931fa60269a039777) wlsunset: update options
* [`2b87a111`](https://github.com/nix-community/home-manager/commit/2b87a11125f988a9f67ee63eeaa3682bc841d9b5) git: add realName inside From field
* [`6ebe7be2`](https://github.com/nix-community/home-manager/commit/6ebe7be2e67be7b9b54d61ce5704f6fb466c536f) gnome-shell: add module
