### PR TITLE
niv nixpkgs: update db5f88c4 -> a7cdcbc9

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "db5f88c41a638e4ff1f67a61310a6e958eaa07a8",
-        "sha256": "0y9kc2np0s55mj15bhjqanzxlng4y3mwmf7r4vymfvflr8cnmgp8",
+        "rev": "a7cdcbc9510061404543da63f05e631db07f1eb3",
+        "sha256": "05njlfl2idzgakl1v1fl89cdh9sxr436iy8bkf718jblnm237mn6",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/db5f88c41a638e4ff1f67a61310a6e958eaa07a8.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/a7cdcbc9510061404543da63f05e631db07f1eb3.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@db5f88c4...a7cdcbc9](https://github.com/nixos/nixpkgs/compare/db5f88c41a638e4ff1f67a61310a6e958eaa07a8...a7cdcbc9510061404543da63f05e631db07f1eb3)

* [`051a10c4`](https://github.com/NixOS/nixpkgs/commit/051a10c4e2c93703fe4b260df718203a561b213d) colobot: 0.2.0-alpha -> 0.2.1-alpha
* [`03b68f14`](https://github.com/NixOS/nixpkgs/commit/03b68f14319c179b146e04405763a458a23247c2) nixos-rebuild: Fetch Flake's default configurationName (Hostname) from targetHost
* [`beff2458`](https://github.com/NixOS/nixpkgs/commit/beff245878325f7013320dfc11b5a2af27523880) python3Packages.piep: enable for python3
* [`d5f1b641`](https://github.com/NixOS/nixpkgs/commit/d5f1b641a82db1d9a19f6d443653ca5aa2e28896) maintainers: add msladecek
* [`f5e9743d`](https://github.com/NixOS/nixpkgs/commit/f5e9743d1df5428de01bc4e7cdc3c03b04f37caa) maintainers: add ryze
* [`6821c0c2`](https://github.com/NixOS/nixpkgs/commit/6821c0c23cc5895fec25a3d367e2f8c9cdc4b014) ff2mpv-rust: add ryze as a maintainer
* [`0ca719c5`](https://github.com/NixOS/nixpkgs/commit/0ca719c52b5a169af58141e82a4341d5106a6f92) ff2mpv-rust: 1.1.1 -> 1.1.2
* [`301425c6`](https://github.com/NixOS/nixpkgs/commit/301425c66477e3b0502b18eb328b554576df5277) ff2mpv-rust: support Chromium based browsers
* [`cd12d7f8`](https://github.com/NixOS/nixpkgs/commit/cd12d7f8bd6c939ed258c3eae2af0b2dea730fd5) ff2mpv-rust: 1.1.2 -> 1.1.3
* [`a149965e`](https://github.com/NixOS/nixpkgs/commit/a149965e947989718c8dd0694b373c15c6903fda) ff2mpv-rust: use cargoHash in place of cargoLock
* [`5d18e249`](https://github.com/NixOS/nixpkgs/commit/5d18e249abf573e3f88eab63be35b870f287e25f) maintainers: Add momeemt
* [`54e79c5a`](https://github.com/NixOS/nixpkgs/commit/54e79c5ac502836527b33a14bad8b5e2b7c85526) pcre: Fetch patch for powerpc64-linux
* [`98bf2cae`](https://github.com/NixOS/nixpkgs/commit/98bf2cae2583e67dcd8e1bdb18a443fb4823bfae) python311Packages.webdataset: 0.2.86 -> 0.2.88
* [`3747f8d5`](https://github.com/NixOS/nixpkgs/commit/3747f8d562864efd5112a1713ffbfa09ece2d48f) python311Packages.webdataset: add changelog to meta
* [`fb1b6c9d`](https://github.com/NixOS/nixpkgs/commit/fb1b6c9d576955eba4ba6cc7da6862f60c431b8e) catch2_3: fix build on riscv and armv7l
* [`82d2bc1b`](https://github.com/NixOS/nixpkgs/commit/82d2bc1b3e0771d7e37d36ed8e6c7f5a121b072a) python311Packages.open-clip-torch: fix build due to failing test
* [`b46cee67`](https://github.com/NixOS/nixpkgs/commit/b46cee679f6904b0854c68c901372d0bc2237d84) idris2: prefer chez 10 over chez-racket
* [`a5314b94`](https://github.com/NixOS/nixpkgs/commit/a5314b94ed4f6d864e478f264dce77632b55995a) starsector: passthrough cli args to jvm
* [`c07cf3d1`](https://github.com/NixOS/nixpkgs/commit/c07cf3d14f34258f6b8050d78f0f9b9998bcf0fc) starsector: fail build if unable to insert required cli args
* [`9f9aa31d`](https://github.com/NixOS/nixpkgs/commit/9f9aa31d99628c877a25cd69b34d3dc4c27e227a) gitnuro 1.1.1 -> 1.3.1
* [`b962fbf0`](https://github.com/NixOS/nixpkgs/commit/b962fbf0fb8eda357ea0f788b76f3d10587dc911) realesrgan-ncnn-vulkan: fix build for glslang 14.1.0
* [`d8c18f96`](https://github.com/NixOS/nixpkgs/commit/d8c18f961b02406788b5abff1b5934d72ee7dbdf) ldutils: 1.10 -> 1.15
* [`809593e7`](https://github.com/NixOS/nixpkgs/commit/809593e7623cf05383c7ad99d003ce1d99013a1f) zombietrackergps: 1.10 -> 1.15
* [`c414bf8e`](https://github.com/NixOS/nixpkgs/commit/c414bf8e78733bf432098fdcb7b654f29b2665a7) teamviewer: add qtgraphicaleffects
* [`732c6d24`](https://github.com/NixOS/nixpkgs/commit/732c6d245bb6a0cd041f62bee09d7c15acbad490) i3lock-fancy: unstable-2018-11-25 -> unstable-2023-04-28
* [`5e9ce01f`](https://github.com/NixOS/nixpkgs/commit/5e9ce01f9b583b4deee3994072c5f7d5a16e1b77) i3lock-fancy: add reedrw as maintainer
* [`d737eafb`](https://github.com/NixOS/nixpkgs/commit/d737eafb5635c0e1306a500a9a0462b4fac2a65e) google-cloud-sdk: fix gcloud storage sign-url error due to missing pyopenssl dependency
* [`2662a65c`](https://github.com/NixOS/nixpkgs/commit/2662a65c4ae1ed1f907bdd8ea2375cdbdceca916) mopidy-youtube: add extraPkgs to allow adding alternative backends
* [`59ef524f`](https://github.com/NixOS/nixpkgs/commit/59ef524f69962e5b5de5b767aadb9af325dd7f65) botan2: 2.19.3 -> 2.19.4
* [`dd540970`](https://github.com/NixOS/nixpkgs/commit/dd540970e215516c6682bd5f7c7eb9f4bb666c62) buildGoModule: announce removal of `buildFlags`
* [`e17aeff8`](https://github.com/NixOS/nixpkgs/commit/e17aeff80705a318b7dd1f14c2dcc50cd8fde498) gradience: add python3Packages.packaging to propagatedBuildInputs
* [`b2f0e730`](https://github.com/NixOS/nixpkgs/commit/b2f0e7301eaa8fdeb2b1975f01304dabd1a540d1) treewide: remove buildFlags use in buildGoModule
* [`61aef540`](https://github.com/NixOS/nixpkgs/commit/61aef5404ebb5fd1bfe762a15232b14c92091eba) coreutils: Skip df/total-verify test
* [`2bc88cd2`](https://github.com/NixOS/nixpkgs/commit/2bc88cd28e9aa08804eadd951c95e5cdbe441b29) libxmlb: 0.3.15 → 0.3.18
* [`e0c24055`](https://github.com/NixOS/nixpkgs/commit/e0c2405594d29b3e7295e2b9a2bc9554fff8c751) isync: add default SASL mechanisms when using `cyrus-sasl-xoauth2`
* [`f3dee8a2`](https://github.com/NixOS/nixpkgs/commit/f3dee8a2e201ee0672d4268a062c3ec6f8f855c4) icu: Make static linking possible
* [`225a332d`](https://github.com/NixOS/nixpkgs/commit/225a332d3c97a4b653c36da6313374d8726c5006) kvmfr: fix build failure for B7-rc1
* [`4621ec1e`](https://github.com/NixOS/nixpkgs/commit/4621ec1ec77e4e17687d217f483bf316a12fbf82) maintainers: add pigeonf
* [`a3376425`](https://github.com/NixOS/nixpkgs/commit/a33764258dc33643ede59836bcbe890ead31cc20) gns3-server: add util-linux to PATH
* [`ebe855c8`](https://github.com/NixOS/nixpkgs/commit/ebe855c855b0dcd00774232f44d48d575b95be81) gns3-server: replace `python3.pkgs` by `python3Packages`
* [`b171ecfe`](https://github.com/NixOS/nixpkgs/commit/b171ecfe9750ffa13ac297be48c6842f0e140848) committed: init at 1.0.20
* [`5bf1b868`](https://github.com/NixOS/nixpkgs/commit/5bf1b868867f3e315e69a9d3faf86febffb48b30) cargo-information: 0.4.2 -> 0.6.0
* [`1a2e7b5d`](https://github.com/NixOS/nixpkgs/commit/1a2e7b5dbbc3dd51da696985eed48063c95372f9) tracker: pull upstream fix for sqlite-3.45.3 compatibility
* [`018aeacb`](https://github.com/NixOS/nixpkgs/commit/018aeacbeef3f72b749ed330abc029010091f168) sqlite, sqlite-analyzer: 3.45.2 -> 3.45.3
* [`20b47164`](https://github.com/NixOS/nixpkgs/commit/20b471643e651ac93dc50a48bc3f1947ce95cbc9) nasm: 2.16.02 -> 2.16.03
* [`c3498215`](https://github.com/NixOS/nixpkgs/commit/c3498215bb8f927e89099e402525334c8a16a17d) primesieve: 12.1 -> 12.3
* [`9c2f773c`](https://github.com/NixOS/nixpkgs/commit/9c2f773c985704551e4cc09ff66e4bb612195e36) factorio: 1.1.104 -> 1.1.107
* [`378177d2`](https://github.com/NixOS/nixpkgs/commit/378177d2693bf4b7751251dc7021e60d6a446089) linux kernel: prefer zstd where possible
* [`b6ef9ffd`](https://github.com/NixOS/nixpkgs/commit/b6ef9ffdfd54e91cce180c306852489f5ebc3098) nixos/udev: compress firmware with zstd if possible
* [`a9054ee8`](https://github.com/NixOS/nixpkgs/commit/a9054ee8f6a42dd672c3031c59394ece30e19a34) infisical: remove jgoux from maintainers
* [`8bcb8d7f`](https://github.com/NixOS/nixpkgs/commit/8bcb8d7febfb522f6bd0813fd39b1b7decd6c220) infisical: add akhilmhdh in maintainer-list
* [`6284c8aa`](https://github.com/NixOS/nixpkgs/commit/6284c8aac12a5e11bcf377c45886ac144963abdf) infisical: create infisical team
* [`4e869f07`](https://github.com/NixOS/nixpkgs/commit/4e869f07b2f4cb5bc8bffd2745b845438b44965e) infisical: set infisical team members as the maintainers
* [`39de88f3`](https://github.com/NixOS/nixpkgs/commit/39de88f344388852907ca59245d601de42be4fad) mkosi: 20.2 -> 21
* [`4908b1a6`](https://github.com/NixOS/nixpkgs/commit/4908b1a604220a2e57938d4181c1b40fb3592740) resholve: 0.10.2 -> 0.10.5
* [`1d438821`](https://github.com/NixOS/nixpkgs/commit/1d4388214d8515d3dfb438adf46703ed2878a542) iproute2: fix static build
* [`3e34332b`](https://github.com/NixOS/nixpkgs/commit/3e34332bd984e4d4f5b477b04b88517c102cbaf5) bluez: 5.72 → 5.75
* [`b2cf9595`](https://github.com/NixOS/nixpkgs/commit/b2cf9595f94bc1fd86e6fd2c1ef91cada0649209) pythonPackages.customtkinter: init at 5.2.2
* [`6a261572`](https://github.com/NixOS/nixpkgs/commit/6a26157205a3552451015502a95b45bbd2af0035) wlsunset: 0.3.0 -> 0.4.0
* [`581f3500`](https://github.com/NixOS/nixpkgs/commit/581f350083124603679025034c0c9409f9a7f623) yara: backport LFS64 removal
* [`601827af`](https://github.com/NixOS/nixpkgs/commit/601827afda7355a766a61f8cc1fe37acb2cfcc7b) wayland-protocols: 1.34 -> 1.35
* [`331d80d9`](https://github.com/NixOS/nixpkgs/commit/331d80d9e534d94478f709b8758b2c1248d70469) virtualbox: fix symlink to guest additions iso
* [`1ffbe253`](https://github.com/NixOS/nixpkgs/commit/1ffbe2530eb50d62c810c875a98b95b363f1e619) curl: backport unreleased curl 8.7 bugfix
* [`fb09556b`](https://github.com/NixOS/nixpkgs/commit/fb09556b12b99360df5d65994f312a25efa6a795) neovim: Use cmakeFlagsArray instead of cmakeFlags
* [`b0a2a754`](https://github.com/NixOS/nixpkgs/commit/b0a2a754fee66bbc5f5075510ec8efbad0baf187) cargo,clippy,rustc,rustfmt: 1.77.1 -> 1.77.2
* [`307ef900`](https://github.com/NixOS/nixpkgs/commit/307ef900a9c93d5df01e90b6105246c761046768) gnutls: 3.8.4 -> 3.8.5
* [`067d46bc`](https://github.com/NixOS/nixpkgs/commit/067d46bc663dc27a7d7bbdae0b3f65d63bb2260f) photoprism: 231128-f48ff16ef -> 240420-ef5f14bc4
* [`ff5eaadb`](https://github.com/NixOS/nixpkgs/commit/ff5eaadbfd39af5e1e7074e44ef7a4f2172994d4) libaom: 3.8.2 -> 3.9.0
* [`e267e062`](https://github.com/NixOS/nixpkgs/commit/e267e0629d0018d6be0aba7f9ba0266d33f7d843) pragtical: init at 3.3.1
* [`30e655fe`](https://github.com/NixOS/nixpkgs/commit/30e655fe86c04ac058b84ed6a3230919b515af22) libxmlb: 0.3.18 -> 0.3.19
* [`bec370d3`](https://github.com/NixOS/nixpkgs/commit/bec370d3065eba3599f5c3143374eae287664df8) tracker: 3.7.1 -> 3.7.2
* [`37a3ad0c`](https://github.com/NixOS/nixpkgs/commit/37a3ad0c01a099de366a42574fff9311fb1187fe) nixos/networkd: allow IPv6PrivacyExtensions in networkd.conf
* [`10d978b2`](https://github.com/NixOS/nixpkgs/commit/10d978b260987d46b885f22efc40afe76794fce3) portablemc: init at 4.3.0
* [`0b0685ab`](https://github.com/NixOS/nixpkgs/commit/0b0685ab4be2ac483bfe5715702d5101aaef13bb) atf: init at 0.21-unstable-2021-09-01
* [`1e497778`](https://github.com/NixOS/nixpkgs/commit/1e497778a371cb3051e4727b7857fc6f0888b1bc) darwin.system_cmds: fix build without CoreFoundation hook
* [`bd19851e`](https://github.com/NixOS/nixpkgs/commit/bd19851ef5df15233e6be8b76d3b6ae139f8ad6e) passt: 2024_04_05.954589b -> 2024_04_26.d03c4e2
* [`8b84a4ea`](https://github.com/NixOS/nixpkgs/commit/8b84a4ea999ffd66f4448814ac772170b2f8395d) python3Packages.docutils: 0.21.1 -> 0.21.2
* [`cb58d0c0`](https://github.com/NixOS/nixpkgs/commit/cb58d0c06e00417d92cb7626083ea4222801618c) tracker-miners: 3.7.1 → 3.7.2
* [`d61450d9`](https://github.com/NixOS/nixpkgs/commit/d61450d95d68cb933005de820bf76c3d90a7c046) gollum: 5.3.2 -> 5.3.3
* [`156a6720`](https://github.com/NixOS/nixpkgs/commit/156a6720d8a8a4158b229a01009abe14997e17d7) libarchive: 3.7.3 -> 3.7.4
* [`54378d3f`](https://github.com/NixOS/nixpkgs/commit/54378d3f0a63019763337aace1cbeec6c60df066) libaom: add some key reverse-dependencies to passthru.tests
* [`f7464c77`](https://github.com/NixOS/nixpkgs/commit/f7464c77d3be1d802333ba39976d4351feafa061) python312Packages.av: Fix cross build
* [`19c02159`](https://github.com/NixOS/nixpkgs/commit/19c0215967f45c4bca1a6b555cc2d1e6589e7882) maintainers: add wr7
* [`d2ca701f`](https://github.com/NixOS/nixpkgs/commit/d2ca701f821885478cea9795d5ed06e7ec320e57) psitransfer: 2.1.2 -> 2.2.0
* [`e413f82e`](https://github.com/NixOS/nixpkgs/commit/e413f82e056c5a17cf63a56aecde318369974206) taskwarrior3: 3.0.0-unstable-2024-04-07 -> 3.0.1
* [`7d7a9f69`](https://github.com/NixOS/nixpkgs/commit/7d7a9f6990ee3077ab5ad2b7ea0e6ee38d5cc5be) taskwarrior3: 3.0.1 -> 3.0.2
* [`7709e10c`](https://github.com/NixOS/nixpkgs/commit/7709e10c5f70d45cb4929aec92c0755470418738) lutok: init at 0.4
* [`a3d75b1d`](https://github.com/NixOS/nixpkgs/commit/a3d75b1d849e8710ad30c16599bfc8d650fe3360) kyua: init at 0.13-unstable-2024-01-22
* [`60fb2a6c`](https://github.com/NixOS/nixpkgs/commit/60fb2a6c19dface3b32e8074de16f562531e9e06) libiconv: expose setup hooks for use by other libiconv implementations
* [`3157d728`](https://github.com/NixOS/nixpkgs/commit/3157d7286053c17585820cde0086ea0af35f0fd7) libiconv-darwin: init at 99
* [`ad38102a`](https://github.com/NixOS/nixpkgs/commit/ad38102a672675f1959ff4f9e3c01489b372e920) darwin.stdenv: avoid an infinite recursion
* [`89c9b73c`](https://github.com/NixOS/nixpkgs/commit/89c9b73ce7e1e542e21c78a0918d22b80c961fa4) darwin.stdenv: propagate atf and kyua
* [`c88b4906`](https://github.com/NixOS/nixpkgs/commit/c88b49062a8beda372c0a3ab35667881f828bdb9) libiconv: use libiconv-darwin
* [`e7b5b44f`](https://github.com/NixOS/nixpkgs/commit/e7b5b44f9df793129be5610d91d1256626c8b181) darwin.libiconv: remove and add to darwin-aliases
* [`afb7fd40`](https://github.com/NixOS/nixpkgs/commit/afb7fd40b799abfcbdc1f37d4145ab68a380a808) vim: 9.1.0200 -> 9.1.0377
* [`43340b8b`](https://github.com/NixOS/nixpkgs/commit/43340b8b9b756f033819fd33ecea26e6a4dd4d3b) fontbakery: fix passthru test script for command-line changes in 0.12
* [`83d65683`](https://github.com/NixOS/nixpkgs/commit/83d65683a47d34a1c34f9666f926c3cc59db0826) python3Packages.fonttools: 4.49.0 → 4.51.0
* [`82367655`](https://github.com/NixOS/nixpkgs/commit/823676555d29c0390c19d8bb2ae32af06c4584bb) python3Packages.glyphsets: add missing dependency on pyyaml
* [`e2114839`](https://github.com/NixOS/nixpkgs/commit/e21148397b8df74ccf9ff6cb6e7c1f842eb09a80) python3Packages.ufo2ft: add missing dependency on fontmath
* [`3ed44ea3`](https://github.com/NixOS/nixpkgs/commit/3ed44ea3a56001c50adbcea1d4a25adca612e330) ed: 1.20.1 -> 1.20.2
* [`a064513a`](https://github.com/NixOS/nixpkgs/commit/a064513ad395d680ec3d5f56abc4ed30c23150ee) tabby: 0.8.3 -> 0.10.0
* [`e3e8de93`](https://github.com/NixOS/nixpkgs/commit/e3e8de93349baa46d31ed72a88b82c2f8b76be72) gtk4: use mesonBool/mesonEnable for package options
* [`0efb88dd`](https://github.com/NixOS/nixpkgs/commit/0efb88dd82adbff1df43e45fd159019215389948) prometheus-tor-exporter: add Scrumplex as maintainer
* [`73be5103`](https://github.com/NixOS/nixpkgs/commit/73be5103dd772e4a87cf199ce7b2853d4f2367c3) wlr-protocols: add Scrumplex as maintainer
* [`5ffda4c1`](https://github.com/NixOS/nixpkgs/commit/5ffda4c121efb1ee805f72bfe4923e26d4123c28) sops: add Scrumplex as maintainer
* [`dcf2a734`](https://github.com/NixOS/nixpkgs/commit/dcf2a734a3ad26434a23fd9a8341db7091695b26) libproxy: 0.5.3 → 0.5.6
* [`f5df1382`](https://github.com/NixOS/nixpkgs/commit/f5df1382ab4329da5e263c0241c22381ad71792d) winePackages.{stable,unstable,staging}: cleanups
* [`cba5ac96`](https://github.com/NixOS/nixpkgs/commit/cba5ac9614242b31734d49e9bc842848fe7d523a) openvino: 2024.0.0 -> 2024.1.0
* [`ce4252be`](https://github.com/NixOS/nixpkgs/commit/ce4252be50a642e9612e8761981f70800e23f865) autosuspend: 6.1.1 -> 7.0.0
* [`35e6efef`](https://github.com/NixOS/nixpkgs/commit/35e6efefa15316be330f29d6a3978c5ec42cc8e6) html-proofer: bump nokogiri to 1.16.0 to fix build
* [`8dd36b86`](https://github.com/NixOS/nixpkgs/commit/8dd36b86bc524633aca590dee2e2b3cf75a0b8f1) labwc-tweaks-gtk: wrapGAppsHook -> wrapGAppsHook3
* [`be1299a6`](https://github.com/NixOS/nixpkgs/commit/be1299a6ef5be655506ba10c1e90abe85b25bcf5) llvmPackages*.llvm: Disable checkPhase on powerpc64-linux
* [`54de37bb`](https://github.com/NixOS/nixpkgs/commit/54de37bbe620d49a4b26b62b12459a035b3c888b) glsl_analyzer: init at 1.4.5
* [`efdf534c`](https://github.com/NixOS/nixpkgs/commit/efdf534c19892520cd7a3ab28eefcf2a825840d3) ethtool: 6.1 -> 6.7
* [`00fc2d27`](https://github.com/NixOS/nixpkgs/commit/00fc2d271cfd25b03990c72b20e93c6f96c7f7ab) python311Packages.wktutils: 1.1.6 -> 2.0.0
* [`27262b7d`](https://github.com/NixOS/nixpkgs/commit/27262b7d82301faa101b3c6e84c423438c75b9cd) sops: add myself as a maintainer
* [`4694d42a`](https://github.com/NixOS/nixpkgs/commit/4694d42a7d66a2869b88eacb37dea2809343b14b) sphinx-intl: 2.1.0 -> 2.2.0
* [`0afd9177`](https://github.com/NixOS/nixpkgs/commit/0afd91778a8fa98aadeafa3542b30aa27be88f49) atlas: 0.21.1 -> 0.22.0
* [`9ee62aba`](https://github.com/NixOS/nixpkgs/commit/9ee62abae9e791845b5c0f8af50a770a003a714d) nerdctl: 1.7.5 -> 1.7.6
* [`9f5332c8`](https://github.com/NixOS/nixpkgs/commit/9f5332c849f6ef7e32eb7df9b483c908d087ad0b) nerdctl: remove nested with in meta
* [`5b872f4d`](https://github.com/NixOS/nixpkgs/commit/5b872f4d4992c187af1068bbb03b797a4562b204) undefined-medium: 1.2 -> 1.3
* [`ccbd91e9`](https://github.com/NixOS/nixpkgs/commit/ccbd91e98f325326c23aa311f5b224d144de8d23) julia_110-bin: 1.10.2 -> 1.10.3
* [`0d4729da`](https://github.com/NixOS/nixpkgs/commit/0d4729da8315d6cbe9a66f55e3c440ef5fba2849) julia_110: 1.10.2 -> 1.10.3
* [`ffff1890`](https://github.com/NixOS/nixpkgs/commit/ffff18906931ae80ed18d81e90c3142feae8c222) lychee: 0.15.0 -> 0.15.1
* [`037e6c79`](https://github.com/NixOS/nixpkgs/commit/037e6c79c65f3aa166f764c7a58b699d02b41d99) tomcat9: 9.0.87 -> 9.0.88
* [`c027a183`](https://github.com/NixOS/nixpkgs/commit/c027a183a2865da4e95ea6bbbe672e8ef63a4ad2) tomcat10: 10.1.20 -> 10.1.23
* [`b73ec84b`](https://github.com/NixOS/nixpkgs/commit/b73ec84b9eed8de7e9095e779ee3d4066ceb091e) luarocks: set meta.mainProgram
* [`9e22d749`](https://github.com/NixOS/nixpkgs/commit/9e22d74930ab684e1a17d24b0c5a50ab35d609f6) luarocks-packages.csv: changed repo by rockspec uri
* [`98661281`](https://github.com/NixOS/nixpkgs/commit/986612811d2990722315ff3c47f0eaa6006b0bc6) luarocks: wrap propagatedBuildInputs in PATH
* [`a4d95408`](https://github.com/NixOS/nixpkgs/commit/a4d954080f71f72f95aee116db8f753f3ded3c2d) lua: fixed the way to create environments
* [`bc4f6fa5`](https://github.com/NixOS/nixpkgs/commit/bc4f6fa54321533b250984f7b3813f8d343dfde1) luarocks-nix: bumped to avoid systematically fetching submodules
* [`80011bef`](https://github.com/NixOS/nixpkgs/commit/80011bef3cc3e5b2d860660bd5e3c04e30739fc7) luaPackages: update on 2024-04-21
* [`6427d04c`](https://github.com/NixOS/nixpkgs/commit/6427d04c2364b79e07d59c0853f86be65e4b7fd0) lua:: reworked setup-hook to source utils.sh
* [`779d38cb`](https://github.com/NixOS/nixpkgs/commit/779d38cb1331cd14702bee0ec8855941150f99b6) rocks-dev-nvim: rolled back because of missing dependency rtp-nvim
* [`89699935`](https://github.com/NixOS/nixpkgs/commit/89699935726b6fb95b7a7f3d559090054e0ac861) luaPackages.rtp-nvim: init at 1.0
* [`ed2e4fee`](https://github.com/NixOS/nixpkgs/commit/ed2e4feeace8c7b390452b03099d7b1761348caf) luaPackages.busted: fix substitution
* [`e5a0a458`](https://github.com/NixOS/nixpkgs/commit/e5a0a4588254f5328788ec6f8f10a772461e0aae) luaPackages.fzy-lua: fix tests
* [`199efdb1`](https://github.com/NixOS/nixpkgs/commit/199efdb1dead77efa41fbed267cdb1285f907000) luaPackages.vusted: fix build by setting bounds
* [`f18e2b89`](https://github.com/NixOS/nixpkgs/commit/f18e2b892636cf9ebdbee5a3be657785770281a5) luaPackages.rtoml: 0.4 -> 0.3
* [`3e72972a`](https://github.com/NixOS/nixpkgs/commit/3e72972a25dcbb99891841e8bb12a5fb6151916e) lms: init at 3.51.1
* [`c966cd01`](https://github.com/NixOS/nixpkgs/commit/c966cd01664758af0fde7b3b1a4352291917c435) avalanchego: 1.11.4 -> 1.11.5
* [`fdf91cce`](https://github.com/NixOS/nixpkgs/commit/fdf91cceb1eca73fb33dfa9d324a968072333c8e) aws-c-auth: 0.7.17 -> 0.7.18
* [`771faa28`](https://github.com/NixOS/nixpkgs/commit/771faa2876fba839d77244b60d14996dd73027d1) aws-c-common: 0.9.15 -> 0.9.17
* [`c3462c3f`](https://github.com/NixOS/nixpkgs/commit/c3462c3f6c5df87da6eb06a0f921409388e70441) aws-c-mqtt: 0.10.3 -> 0.10.4
* [`c11f7488`](https://github.com/NixOS/nixpkgs/commit/c11f7488c768f40dbdc7f3a215ddd6e9220d6b91) aws-c-sdkutils: 0.1.15 -> 0.1.16
* [`39c439c0`](https://github.com/NixOS/nixpkgs/commit/39c439c0d7207233d1257e834b67147b1dbd399c) aws-c-cal: 0.6.10 -> 0.6.12
* [`21d9d5a7`](https://github.com/NixOS/nixpkgs/commit/21d9d5a770ceb57b99425e4d8c4937126d9f65c5) aws-sdk-cpp: 1.11.309 -> 1.11.318
* [`73150bcf`](https://github.com/NixOS/nixpkgs/commit/73150bcf504785cd45468ec9049f508d276aa0f1) libsolv: 0.7.28 -> 0.7.29
* [`43169dc8`](https://github.com/NixOS/nixpkgs/commit/43169dc85edee0ecfcabf9d643104b79a295a5a4) datovka: 4.23.6 -> 4.23.7
* [`27d6d7ec`](https://github.com/NixOS/nixpkgs/commit/27d6d7ecfe64a57533f407681d08ffc9080af5dc) wootility: 4.6.15 -> 4.6.18
* [`e7d9d816`](https://github.com/NixOS/nixpkgs/commit/e7d9d816868f23a1fdb764e258a2ce5ab290f966) commonsIo: 2.15.1 -> 2.16.1
* [`56ba4ccb`](https://github.com/NixOS/nixpkgs/commit/56ba4ccb6316a34d04eb6cb23bf2d711ce3da60d) alfaview: 9.9.1 -> 9.10.1
* [`d86ac883`](https://github.com/NixOS/nixpkgs/commit/d86ac883a4f6d17041b03148b9974e9587956780) snd: 24.2 -> 24.3
* [`9e1764c0`](https://github.com/NixOS/nixpkgs/commit/9e1764c02e119ccd7fbf3cc2a6baf80037d299ad) commonsLogging: 1.3.0 -> 1.3.1
* [`342684a7`](https://github.com/NixOS/nixpkgs/commit/342684a707e7141400fb8f59e0aaf218a4db96e6) suricata: 7.0.4 -> 7.0.5
* [`3ca557a4`](https://github.com/NixOS/nixpkgs/commit/3ca557a430fd1d1e2d237d078b9be8f502706515) orchis-theme: 2024-04-18 -> 2024-05-01
* [`28a872e9`](https://github.com/NixOS/nixpkgs/commit/28a872e94a25bb1e76af96c9c6876bf409def8a7) tqsl: 2.7.2 -> 2.7.3
* [`8b9f0abc`](https://github.com/NixOS/nixpkgs/commit/8b9f0abc3f9777f4062b9adf3c4aab8fda8786ee) malcontent: 0.11.1 -> 0.12.0
* [`5ab90338`](https://github.com/NixOS/nixpkgs/commit/5ab9033804c994f9fffae48ff1977f11c9d48779) free42: 3.1.5 -> 3.1.8
* [`f635f023`](https://github.com/NixOS/nixpkgs/commit/f635f023283b4bc2e64e14957f2829397e84cfb3) elpa-packages: updated 2024-04-28 (from overlay)
* [`60eebe0e`](https://github.com/NixOS/nixpkgs/commit/60eebe0ec887e125c27a2f7c3ff9bb264cff4575) elpa-devel-packages: updated 2024-04-28 (from overlay)
* [`2e4df21e`](https://github.com/NixOS/nixpkgs/commit/2e4df21e3dbe0c3a7ac91072a8b91ab7eac7a449) melpa-packages: updated 2024-04-28 (from overlay)
* [`912560ea`](https://github.com/NixOS/nixpkgs/commit/912560ea8c06300471b12fee524d83185f702de6) nongnu-packages: updated 2024-04-28 (from overlay)
* [`2a3cdc36`](https://github.com/NixOS/nixpkgs/commit/2a3cdc36ef6f09be725a7c29d9d9e0deb59b365a) windows10-icons: init at 1.0
* [`d88ebb82`](https://github.com/NixOS/nixpkgs/commit/d88ebb8213003521ae55c7136b8219fa9a879821) termsonic: init at 0-unstable-2024-02-02
* [`c1102c0a`](https://github.com/NixOS/nixpkgs/commit/c1102c0a8023bb8e1691182d39f2a139988300cb) mediainfo: 24.03 -> 24.04
* [`3c24d2f1`](https://github.com/NixOS/nixpkgs/commit/3c24d2f1b287fd5e7e9e00424742978caa7874bf) archi: 5.2.0 -> 5.3.0
* [`9f1a2da3`](https://github.com/NixOS/nixpkgs/commit/9f1a2da3e97ccc4c51e8fa1adbe5ca3e313d7e11) archi: fix GBM-DRV error
* [`a70cc6d8`](https://github.com/NixOS/nixpkgs/commit/a70cc6d8669272f204a0a478ff74c7039a35ff79) emacs: use lib.* functions
* [`5be5d718`](https://github.com/NixOS/nixpkgs/commit/5be5d718c64bfe0224c4e5583ea96ba5cd5322ab) emacs: add mailutils support
* [`d0fb5490`](https://github.com/NixOS/nixpkgs/commit/d0fb5490ef08f9e3e4d63b30915aba216530baf7) aribb24: init at 1.0.4
* [`57775b3f`](https://github.com/NixOS/nixpkgs/commit/57775b3ffea34b16428884e88e86146f8240d295) xdg-utils: Ensure `xdg-mime` can find `shared-mime-info`
* [`5ef467d6`](https://github.com/NixOS/nixpkgs/commit/5ef467d6f5f4dc95653a22905f4e478469d00041) nixos/nextcloud: add nextcloud-update-db.service, nextcloud-cron isn't oneshot
* [`08fde07d`](https://github.com/NixOS/nixpkgs/commit/08fde07df903a88d4364b8ccdcbeb72bf3f3025d) rtabmap: 0.21.4 -> 0.21.4.1
* [`3c4fd0af`](https://github.com/NixOS/nixpkgs/commit/3c4fd0afae9f54977105c40222796b759170a258) pan: 0.157 -> 0.158
* [`040e3e60`](https://github.com/NixOS/nixpkgs/commit/040e3e60c54ad8bab9ce98e6e0e0e9566aa4209f) haruna: 1.0.2 -> 1.1.0
* [`464b4283`](https://github.com/NixOS/nixpkgs/commit/464b428371f29d000a22a8ff9c8a059fd23d097b) s3backer: 2.0.2 -> 2.1.2
* [`9e3310fd`](https://github.com/NixOS/nixpkgs/commit/9e3310fdf5d6f4032a8644232f0a5aa9de8c6fe1) coreth: 0.13.2 -> 0.13.3
* [`8d1c177d`](https://github.com/NixOS/nixpkgs/commit/8d1c177db0cf98ff5404384a72d6c4c473936945) fluidd: 1.29.1 -> 1.30.0
* [`0a195ce4`](https://github.com/NixOS/nixpkgs/commit/0a195ce41153981b6eff1483ce164d271dd86352) faudio: 24.04 -> 24.05
* [`bd07c3b4`](https://github.com/NixOS/nixpkgs/commit/bd07c3b47077bf81fef3921940de5835749a16ae) libbpf: 1.4.0 -> 1.4.1
* [`8f9ca14f`](https://github.com/NixOS/nixpkgs/commit/8f9ca14fc0c0306c14696c6554e8edc7affa4d3f) osl: 1.13.8.0 -> 1.13.9.0
* [`d94076a6`](https://github.com/NixOS/nixpkgs/commit/d94076a6e2766b2f91fb34939a9a6c68a71c4a65) arti: 1.2.1 -> 1.2.2
* [`33409921`](https://github.com/NixOS/nixpkgs/commit/33409921656f48ac91cddf5a7d0106080f03f6fe) lightburn: 1.5.06 -> 1.6.00
* [`c727fff7`](https://github.com/NixOS/nixpkgs/commit/c727fff763507d49f7a9a7412fd6d311eb1145fb) roon-server: 2.0-1392 -> 2.0-1407
* [`84726cfe`](https://github.com/NixOS/nixpkgs/commit/84726cfe4263043e3c55290680c6e47dfc3d9e9d) fastahack: init at 1.0.0
* [`455be5c8`](https://github.com/NixOS/nixpkgs/commit/455be5c8bcf0da7033b8d1c09ee2b97c88213aef) python311Packages.htseq: format with nixfmt
* [`1a9e2e0b`](https://github.com/NixOS/nixpkgs/commit/1a9e2e0b2ff07c5d8e87bd54c2fd47f356f70ac9) python311Packages.htseq: add update script
* [`586d563f`](https://github.com/NixOS/nixpkgs/commit/586d563fe2f611d3eb1bfe6fbbbabee4dfceefa1) python311Packages.htseq: 0.12.4 -> 2.0.4
* [`77dc1504`](https://github.com/NixOS/nixpkgs/commit/77dc1504a277b3bcd28e5870bfe9583e1839fc48) migrate: format with nixfmt
* [`5a075604`](https://github.com/NixOS/nixpkgs/commit/5a075604433d2213380ee1ac64a868cc0b6c4655) mkosi: 21 -> 22
* [`c93b55db`](https://github.com/NixOS/nixpkgs/commit/c93b55dba5a78990c191afc2f1406dc058a0a1ed) mkosi: use --replace-fail on substituteInPlace
* [`d3f04e5b`](https://github.com/NixOS/nixpkgs/commit/d3f04e5bac4406f69d4bbb4fff1af917efd181bc) mkosi-full: use systemd with kernel-install
* [`ddb1ac2b`](https://github.com/NixOS/nixpkgs/commit/ddb1ac2b9090ed9c8e18cb2fe6246a761a8bc7fc) mkosi-full: mark broken
* [`e789c579`](https://github.com/NixOS/nixpkgs/commit/e789c579c10b838f4894fd3d8eaf226211570720) migrate: 3.7.2 -> 5.0.6
* [`f5d23a16`](https://github.com/NixOS/nixpkgs/commit/f5d23a16edf9ae205ef73139c6145e44d144fe13) migrate: add meta.mainProgram
* [`50a020aa`](https://github.com/NixOS/nixpkgs/commit/50a020aa5637929897d12409b284e30d3e1f2244) root: add back explicit disabling of compiler warnings for clang
* [`21c42b3d`](https://github.com/NixOS/nixpkgs/commit/21c42b3d39cea12839452be335f699277cc9ee30) migrate: refactor
* [`fc1f5ac2`](https://github.com/NixOS/nixpkgs/commit/fc1f5ac2baa6601354f4a5970e3138210cc0f62d) libmediainfo: 24.03 -> 24.04
* [`bfe5c0c4`](https://github.com/NixOS/nixpkgs/commit/bfe5c0c4df03e877a3c824dfaa4ad8f4e1aa1194) infisical: fix typo in team scope
* [`4f78a2b7`](https://github.com/NixOS/nixpkgs/commit/4f78a2b7c4bfde62321bd17a21e4fa032f90ff0f) stress-ng: 0.17.07 -> 0.17.08
* [`003eac7d`](https://github.com/NixOS/nixpkgs/commit/003eac7d39c70030331cb10d2c242c73774f6ba0) apko: 0.13.2 -> 0.14.0
* [`b6091482`](https://github.com/NixOS/nixpkgs/commit/b60914820d8cfbe999a4d75606129cbcb3a2f8ab) mongodb-compass: 1.42.5 -> 1.43.0
* [`6e709483`](https://github.com/NixOS/nixpkgs/commit/6e709483a2c126cecaf964685bfeea4db0971807) stylelint: 16.4.0 -> 16.5.0
* [`a59ea1b6`](https://github.com/NixOS/nixpkgs/commit/a59ea1b6c100f608979b3e694a7f44366fed607e) payme: 1.2.0 -> 1.2.2
* [`166487c9`](https://github.com/NixOS/nixpkgs/commit/166487c9a6bc25c3e148d4727792e795137a4625) tart: 2.7.2 -> 2.10.0
* [`8814c364`](https://github.com/NixOS/nixpkgs/commit/8814c364a386d7ff271b6a6058301bc89d49d199) nixos/top-level: Rename `system.forbiddenDependenciesRegex` to `system.forbiddenDependenciesRegexes`
* [`1322f22e`](https://github.com/NixOS/nixpkgs/commit/1322f22ef18ad4659e71a48385f47ed2cc3aa5f1) python311Packages.pydeck: 0.8.0 -> 0.9.0
* [`46bdc2ab`](https://github.com/NixOS/nixpkgs/commit/46bdc2ab8343fc298827fc7243d6e4dea18ebd4c) python311Packages.logutils: refactor
* [`f8e791bd`](https://github.com/NixOS/nixpkgs/commit/f8e791bd0ab777db7f644fa95e90d7be0577c671) python311Packages.logutils: patch outdated test
* [`faa6495d`](https://github.com/NixOS/nixpkgs/commit/faa6495d78a2c1c64ee71a64f8fe1b1a494c7779) python312Packages.logutils: patch path to redis-server
* [`218d74f7`](https://github.com/NixOS/nixpkgs/commit/218d74f794da2e28e6d2e5a2e7629a88c3068df9) xdg-utils: add test for `xdg-mime`
* [`4facacb5`](https://github.com/NixOS/nixpkgs/commit/4facacb5f7b000dea87c8b78c746100b6faa6c48) cosmic-tasks: use renamed wrapGAppsHook3
* [`832f7920`](https://github.com/NixOS/nixpkgs/commit/832f7920a62e3ea9b3a75ee4a51b19314f826d63) tflint: 0.50.3 -> 0.51.0
* [`1dd1e0b5`](https://github.com/NixOS/nixpkgs/commit/1dd1e0b538e22afe1039449ae81230c72ef132cc) libcifpp: 7.0.3 -> 7.0.4
* [`7d27d397`](https://github.com/NixOS/nixpkgs/commit/7d27d397a5ee26cf261286d35fd5032d6192c1cf) dssp: 4.4.5 -> 4.4.7
* [`381c5bf6`](https://github.com/NixOS/nixpkgs/commit/381c5bf69fda582fd3dc16ffcc1a7642743b44dc) manim-slides: 5.1.5 -> 5.1.6
* [`231d8ea4`](https://github.com/NixOS/nixpkgs/commit/231d8ea48effcd25ccd068260ea2df33ef78b436) cloud-custodian: 0.9.35.0 -> 0.9.36.0
* [`7ad57dac`](https://github.com/NixOS/nixpkgs/commit/7ad57dac8040632c53fb093584d36627c9f82e09) codeberg-cli: 0.3.5 -> 0.4.0
* [`5a92bab5`](https://github.com/NixOS/nixpkgs/commit/5a92bab5eb8a0a32a870c35173a4769f92ff4f56) tt: init at v0.4.2
* [`5a92d566`](https://github.com/NixOS/nixpkgs/commit/5a92d56689862ec63b4830db4189977e0a8ca07c) tpm2-tss: 4.0.1 -> 4.1.0
* [`ad15bfe8`](https://github.com/NixOS/nixpkgs/commit/ad15bfe81ab5b81738d04021c436b6a6b0b77298) tpm2-pytss: adopt syntax for defines used in tpm2-tss 4.1.0
* [`fd44d43a`](https://github.com/NixOS/nixpkgs/commit/fd44d43abbb05bdb3242abcbdc436624ced92c71) maintainers: add eeedean
* [`35c95666`](https://github.com/NixOS/nixpkgs/commit/35c956668e8420d1aad36ab51b3f5e693cb00d1e) lmstudio: add new maintainer
* [`143636c5`](https://github.com/NixOS/nixpkgs/commit/143636c5ce4dbc5dfd0e7e980032f6f36b33629f) lmstudio: 0.2.20 -> 0.2.22
* [`90ee270c`](https://github.com/NixOS/nixpkgs/commit/90ee270cf5b406dd260ae61ca94d6f91d15ac1f0) lmstudio: enable aarch64-darwin build
* [`5b671b7f`](https://github.com/NixOS/nixpkgs/commit/5b671b7fc8ba3c315fb584f75c3fb61c09ebf582) nixos/zfs: Default autoscrub interval to monthly
* [`b7f4262d`](https://github.com/NixOS/nixpkgs/commit/b7f4262d4070c9d6d2cb8a8bc0418db232132d61) python312Packages.attacut: init at 1.1.0-dev
* [`a3897417`](https://github.com/NixOS/nixpkgs/commit/a3897417a42b844e3e25958deef8e565fc0541b2) python312Packages.phunspell: init at 0.1.6
* [`e503207f`](https://github.com/NixOS/nixpkgs/commit/e503207f1a54e33146aac912d726e9c0c31e84de) hwdata: 0.381 -> 0.382
* [`8e0e9bde`](https://github.com/NixOS/nixpkgs/commit/8e0e9bdee874c3a3cdb50100f93f99c98ac7a7c6) nixos/zfs: Added a randomizedDelaySec option to ZFS autoscrub/trim timers
* [`ed716bf8`](https://github.com/NixOS/nixpkgs/commit/ed716bf802a0d0a5b01359acce972d5067e3df81) qlog: 0.34.0 -> 0.35.0
* [`0bcf9f36`](https://github.com/NixOS/nixpkgs/commit/0bcf9f3610680b9e615fe64785bafe0ec28b9578) gnomeExtensions.gsconnect: 56 → 57
* [`6f2c1521`](https://github.com/NixOS/nixpkgs/commit/6f2c152108738085d76bb6cf7e322330f2490c39) mixxx: add wrapGAppsHook3 to fix file dialog
* [`dcc5bc74`](https://github.com/NixOS/nixpkgs/commit/dcc5bc7447f97f19030617df0146ebcdf2509731) libation: remove outdated practices and format
* [`1271860b`](https://github.com/NixOS/nixpkgs/commit/1271860b5eb39783f3bba73bcebc9592da2d181f) Move lucperkins packages into by-name
* [`d043c404`](https://github.com/NixOS/nixpkgs/commit/d043c404bed3d4f1a0726c3ff43491b82760c63f) warp-terminal: 0.2024.04.16.08.02.stable_00 -> 0.2024.05.07.08.02.stable_02
* [`88d6b79d`](https://github.com/NixOS/nixpkgs/commit/88d6b79d2e8ffed880085822fc3b643eec858d14) aws-encryption-sdk-cli: fix build
* [`2282713d`](https://github.com/NixOS/nixpkgs/commit/2282713d038b7d360a27f13aa8c11b15e7c6f5df) pcsclite: fix loading of libpcsclite_real.so.1
* [`1eea09cc`](https://github.com/NixOS/nixpkgs/commit/1eea09ccf96931c15d9181dcf9ae528255118ce2) re2: 2024-04-01 -> 2024-05-01
* [`21d5496b`](https://github.com/NixOS/nixpkgs/commit/21d5496b4997cb7f580b757ae1156b09af27b09a) redisinsight: 2.32 -> 2.48.0
* [`13702a18`](https://github.com/NixOS/nixpkgs/commit/13702a189931d562bdfacb3dd8125ffde368998d) intune-portal: 1.2402.12-jammy -> 1.2404.23-jammy
* [`37941d2c`](https://github.com/NixOS/nixpkgs/commit/37941d2caafd947e859abbcf12f0a365a93c2f32) fwts: 24.01.00 -> 24.03.00
* [`558c5c65`](https://github.com/NixOS/nixpkgs/commit/558c5c6559730420356ee6703c0c351b2f97d3fb) criterion: 2.4.1 -> 2.4.2
* [`b128e4bb`](https://github.com/NixOS/nixpkgs/commit/b128e4bb7315ce302cac06581c511936f92ca5d9) criterion: add myself as maintainer
* [`c4af7e8b`](https://github.com/NixOS/nixpkgs/commit/c4af7e8bfd14a901cf8769052ee395c7c78fe4af) raider: 2.1.0 -> 3.0.0
* [`01575f3d`](https://github.com/NixOS/nixpkgs/commit/01575f3de7c2cee5cea605d26eeab6d4ea2ea27c) webcord-vencord: disable nixpkgs-update
* [`5c994ecc`](https://github.com/NixOS/nixpkgs/commit/5c994eccd45cbd5db6fe1f8c67e0fdaad60ccf63) webcord: move to pkgs/by-name
* [`5f423cc7`](https://github.com/NixOS/nixpkgs/commit/5f423cc71e316381fd3f6fbc04f368f166466b01) webcord: set rev more explicitly to help update scripts
* [`774290e3`](https://github.com/NixOS/nixpkgs/commit/774290e3e51a118a6c7c7728888a8b14e77be976) webcord: format with nixfmt (RFC 166)
* [`70304164`](https://github.com/NixOS/nixpkgs/commit/703041640be466b52c6ba96d4082d27b31fb178a) webcord: update electron version via update script
* [`d7cd24a9`](https://github.com/NixOS/nixpkgs/commit/d7cd24a91fc797b4b7086d4f1786df98d33df667) poethepoet: 0.25.1 -> 0.26.1
* [`8dd1681c`](https://github.com/NixOS/nixpkgs/commit/8dd1681c2116fa67ec60c79a65d931e4022b0090) libxkbcommon: 1.5.0 -> 1.7.0
* [`10988d8a`](https://github.com/NixOS/nixpkgs/commit/10988d8adeea21aaa8485fb5eac83caec6c673cf) apostrophe: move to pkgs/by-name
* [`6a67984a`](https://github.com/NixOS/nixpkgs/commit/6a67984ae076908dd92c466911aa7ebabcf0f7b3) endlessh-go: 20230625-3 -> 2024.0119.1
* [`a52252c9`](https://github.com/NixOS/nixpkgs/commit/a52252c919049cb9c00551cc1b794eb6c6cd16ce) parallel-full: fix missing files and meta
* [`a1347423`](https://github.com/NixOS/nixpkgs/commit/a1347423d217390ac86cf406350a6d6d867a3575) parallel-full: add missing package metadata
* [`7342beea`](https://github.com/NixOS/nixpkgs/commit/7342beeae6ddbcbdd87ef5f3c8b524cc1ea80a35) go-judge: 1.8.3 -> 1.8.4
* [`649f99bf`](https://github.com/NixOS/nixpkgs/commit/649f99bf8498fa2128a8a116f91923f505f4279a) rPackages.instantiate: fixed build
* [`c5a0d5f1`](https://github.com/NixOS/nixpkgs/commit/c5a0d5f10e14af74bf8c3a6affa204a48c1b79c6) rPackages.luajr: fixed build
* [`e34b4548`](https://github.com/NixOS/nixpkgs/commit/e34b454848f9a9ce17f5e86e0c6948eba1054734) rPackages.interpolation: fixed build
* [`887fed1d`](https://github.com/NixOS/nixpkgs/commit/887fed1d6755d7d28daeaab19b01860f12dab109) ptyxis: init at 46.1
* [`7153787b`](https://github.com/NixOS/nixpkgs/commit/7153787bcda2c1e0eaa5ca69bb19e1092167555f) nezha-agent: 0.16.5 -> 0.16.6
* [`5f1daf04`](https://github.com/NixOS/nixpkgs/commit/5f1daf04129bac9d6a86a32c1d08574fd0ec3ec4) python311Packages.mdtraj: fix runtime error
* [`7a1e7edb`](https://github.com/NixOS/nixpkgs/commit/7a1e7edb678981961b17e70c1377d859669b4ad7) livi: 0.0.6 -> 0.1.0
* [`3996e53c`](https://github.com/NixOS/nixpkgs/commit/3996e53c2d1f352c184ae5b91ff2ff71f50b916d) webcord-vencord: move to pkgs/by-name
* [`c8de2c32`](https://github.com/NixOS/nixpkgs/commit/c8de2c32b011800789101ee93985de3710d6a7ea) webcord-vencord: format with nixfmt (RFC 166)
* [`22b2188e`](https://github.com/NixOS/nixpkgs/commit/22b2188e12f003f6b38ff7c0a918e829a4707604) webcord-vencord: fix meta
* [`76766e2e`](https://github.com/NixOS/nixpkgs/commit/76766e2e4e54c33edc605f10b5be9447d42cd46c) jruby: 9.4.6.0 -> 9.4.7.0
* [`6576dca1`](https://github.com/NixOS/nixpkgs/commit/6576dca12e1fc3a6c76331398a97c3605e952064) misconfig-mapper: init at 1.1.0
* [`135e9831`](https://github.com/NixOS/nixpkgs/commit/135e98312b4999e6dc78a5f4b8036193be2f8f5c) talosctl: 1.7.0 -> 1.7.1
* [`c650982a`](https://github.com/NixOS/nixpkgs/commit/c650982a43ec7af6d5d70a318fcd0ecfdc35c1ae) nixos/restic: Add runCheck option
* [`26c3d687`](https://github.com/NixOS/nixpkgs/commit/26c3d6878a3c30b726fba660bf31d22adef2edcf) dotnet: fix dotnet executables in darwin sandbox
* [`4d00d19c`](https://github.com/NixOS/nixpkgs/commit/4d00d19cd0a63ef9ba750c832a3dd62640e2c3c8) dotnet: fix race condition in web test
* [`6f7eccf4`](https://github.com/NixOS/nixpkgs/commit/6f7eccf45071b4c16a96d90632f031e68546ec93) dotnet: fix web test on darwin
* [`80e4a7cd`](https://github.com/NixOS/nixpkgs/commit/80e4a7cd8de40e749e98d6ea2c21a5fa4e1caedd) greenmask: init at 0.1.12
* [`38bb74ac`](https://github.com/NixOS/nixpkgs/commit/38bb74acec80a6b6c3dc8922699d52f6bdef1f97) vimPlugins.vim-clap: 0.52 -> 0.53
* [`63e30780`](https://github.com/NixOS/nixpkgs/commit/63e307802c9cfca4b8b3e0c9d4cf50ee7f3df172) nixos/intel-gpu-tools: init basic security wrapper
* [`eb878491`](https://github.com/NixOS/nixpkgs/commit/eb87849122814dc0f4684e80ee19ed8c42f5771d) ballerina: 2201.8.6 -> 2201.9.0
* [`f73c7012`](https://github.com/NixOS/nixpkgs/commit/f73c7012ea746b7a0fb30fbdd125d5a36e467577) doublecmd: 1.1.13 -> 1.1.14
* [`1ffed6c1`](https://github.com/NixOS/nixpkgs/commit/1ffed6c14ddd16bc8303fd83c60e770cbe02fe3c) clash-verge-rev: 1.6.0 -> 1.6.1
* [`27e6eb22`](https://github.com/NixOS/nixpkgs/commit/27e6eb22203f69c47e2ca3fa45f3c08aa32e44c0) python311Packages.mahotas: 1.4.13 -> 1.4.14
* [`081e6f30`](https://github.com/NixOS/nixpkgs/commit/081e6f300b21109b3802b16f6767ff1bc3c4e396) uclibc: 1.0.47 -> 1.0.48
* [`0c56c244`](https://github.com/NixOS/nixpkgs/commit/0c56c244409eb4424611f37953bfd03c2534bcce) python311Packages.zephyr-python-api: 0.0.5 -> 0.1.0
* [`80b1594b`](https://github.com/NixOS/nixpkgs/commit/80b1594b4d7c40d969345175a44ff9b7575c60c5) aspectj: 1.9.21.2 -> 1.9.22
* [`472fc059`](https://github.com/NixOS/nixpkgs/commit/472fc059560306eeea6834d5923930f1c3968724) ghidra: 11.0.2 -> 11.0.3
* [`fc417a07`](https://github.com/NixOS/nixpkgs/commit/fc417a07685c9e432e233c067710a00bbbb7c2df) chirp: 0.4.0-unstable-2024-02-08 -> 0.4.0-unstable-2024-05-03
* [`2c32ec2d`](https://github.com/NixOS/nixpkgs/commit/2c32ec2d78437ca0e7c681db7ad7cd9626576ebf) remmina: 1.4.33 -> 1.4.35
* [`ef3ee860`](https://github.com/NixOS/nixpkgs/commit/ef3ee8602ed4d47caead727855c7e2e5e6d474f8) microsoft-edge: 124.0.2478.67 -> 124.0.2478.80
* [`346d23fd`](https://github.com/NixOS/nixpkgs/commit/346d23fdf267022e7fa3895e0ec55a03f5502bce) nixos/mautrix-signal: add module
* [`f0d5255d`](https://github.com/NixOS/nixpkgs/commit/f0d5255debf00ccf6f2735dafe39287250f9b835) adrs: init at 0.2.8
* [`35bbca41`](https://github.com/NixOS/nixpkgs/commit/35bbca41da0ee1a12bb1aea631676f5d0e82bc7a) root: remove redundant cmake flags
* [`c2378ab1`](https://github.com/NixOS/nixpkgs/commit/c2378ab16cb5701fbb9014dabac34c967879ca47) radicle: reinit at 1.0.0-rc.8
* [`23ca9c93`](https://github.com/NixOS/nixpkgs/commit/23ca9c93d911e8c7f3ee8d57fd37140835b0dde4) flacon: 11.3.0 -> 11.4.0
* [`a91fdc50`](https://github.com/NixOS/nixpkgs/commit/a91fdc500c11dc1cae7622086e66e4d1669b193b) cinnamon.mint-artwork: 1.8.0 -> 1.8.2
* [`9c33def4`](https://github.com/NixOS/nixpkgs/commit/9c33def46f520e7ac31bd7790d80d8792e2f322b) cinnamon.cinnamon-common: Don't ship 00_cinnamon.styles
* [`4c974364`](https://github.com/NixOS/nixpkgs/commit/4c97436473b756ee6d02e58e43de673d367c73fb) onedriver: add glib-networking to buildInputs
* [`acc50428`](https://github.com/NixOS/nixpkgs/commit/acc504282f168c8911ac76f90c104eb1c1751c6d) go-cover-treemap: init at 1.4.2
* [`93349f74`](https://github.com/NixOS/nixpkgs/commit/93349f742f9af822e0b6a3f5ab0f319630291856) epsonscan2: 6.7.61.0 -> 6.7.63.0
* [`9283efe7`](https://github.com/NixOS/nixpkgs/commit/9283efe75770b8b58b9e30d19988f2e822445f69) c0: unstable-2023-09-05 -> 0-unstable-2023-09-05
* [`5c85ae0b`](https://github.com/NixOS/nixpkgs/commit/5c85ae0bac4480d800b4e1991b3e5c9b46ecff48) open-watcom-v2-unwrapped: unstable-2023-11-24 -> 0-unstable-2023-11-24
* [`0122b825`](https://github.com/NixOS/nixpkgs/commit/0122b82531e23279384ef3877523383ccfa9a7e9) zig-shell-completions: unstable-2023-11-18 -> 0-unstable-2023-11-18
* [`402d9d64`](https://github.com/NixOS/nixpkgs/commit/402d9d64e259255a75d66cc153392637d0aae630) femtolisp: unstable-2023-07-12 -> 0-unstable-2023-07-12
* [`85a40080`](https://github.com/NixOS/nixpkgs/commit/85a40080aab1ceb9ba3de22031fb465fde637982) nelua: unstable-2024-04-20 -> 0-unstable-2024-04-20
* [`83ceecf1`](https://github.com/NixOS/nixpkgs/commit/83ceecf14899dabfd2c84ba95cbd25cfe2120c62) apostrophe: format with nixfmt-rfc-style
* [`95d941d4`](https://github.com/NixOS/nixpkgs/commit/95d941d41616a9dddedbfe905df4f523dd9b09da) apostrophe: 2.6.3 -> 3.0
* [`ca303639`](https://github.com/NixOS/nixpkgs/commit/ca30363956b0317592b82330aa7d1009bae02489) apostrophe: add aleksana as maintainers
* [`867f47f8`](https://github.com/NixOS/nixpkgs/commit/867f47f8d3790914b40db552a98b5974aa58f190) python311Packages.geoalchemy2: 0.15.0 -> 0.15.1
* [`8cb0b06e`](https://github.com/NixOS/nixpkgs/commit/8cb0b06ed78054ba8b2294575fa8be1b9bbd0e3f) slumber: 1.0.1 -> 1.1.0
* [`0120f3d2`](https://github.com/NixOS/nixpkgs/commit/0120f3d2c924057038ad5031b5dea1e0715f84df) tflint-plugins.tflint-ruleset-google: 0.27.1 -> 0.28.0
* [`95c85aaf`](https://github.com/NixOS/nixpkgs/commit/95c85aafd3a8095e93da66ed98243168c659914a) maintainers: add mjoerg
* [`849dc914`](https://github.com/NixOS/nixpkgs/commit/849dc914c00b5fd8e8f91b76dd0b10fbddf5a8b9) magic-wormhole-mailbox-server: adopt, switch to pyproject, disable for Python 3.12
* [`262a33ed`](https://github.com/NixOS/nixpkgs/commit/262a33eddea4b9ed925f30672860b1d7360c9522) magic-wormhole-transit-relay: adopt, switch to pyproject, disable for Python 3.12
* [`df9398d4`](https://github.com/NixOS/nixpkgs/commit/df9398d405848fa4ed9b3927eb0b17087532d2a2) python3Packages.iterable-io: init at 1.0.0
* [`88254172`](https://github.com/NixOS/nixpkgs/commit/8825417285d72910369d0a6a3c424ac585929f29) magic-wormhole: adopt, add new dependencies required for 0.14.0
* [`9293af31`](https://github.com/NixOS/nixpkgs/commit/9293af315e4603d4ee1383f1440e98fabbdea51d) scheme-manpages: unstable-2024-02-11 -> 0-unstable-2024-02-11
* [`4712ec00`](https://github.com/NixOS/nixpkgs/commit/4712ec00cfd393fbe8e7036b001bc743efb343e6) dracula-theme: unstable-2024-04-24 -> 4.0.0-unstable-2024-04-24
* [`caa9e587`](https://github.com/NixOS/nixpkgs/commit/caa9e587a4e698731873c928f251026b6a3e5613) material-kwin-decoration: unstable-2023-01-15 -> 7-unstable-2023-01-15
* [`4b084efb`](https://github.com/NixOS/nixpkgs/commit/4b084efb0d969403cdcfe828cd0d96ed9a074605) nixos-bgrt-plymouth: unstable-2023-03-10 -> 0-unstable-2023-03-10
* [`b03e4865`](https://github.com/NixOS/nixpkgs/commit/b03e486569e1201872bb433e982ca62ede4bc294) litecli: 1.10.1 -> 1.11.0
* [`7f284908`](https://github.com/NixOS/nixpkgs/commit/7f2849087e32e584017530bb5b6d2e71882306d2) go-errorlint: 1.4.5 -> 1.5.1
* [`3b7eb42b`](https://github.com/NixOS/nixpkgs/commit/3b7eb42bff7550309177ba5a263fad262d4c8644) autosuspend: drop support for older versions of python
* [`dbc2ce50`](https://github.com/NixOS/nixpkgs/commit/dbc2ce50b5ca9cd6c70caa57859ed0e3af8aa2be) ets: 0.2.1 -> 0.3.0
* [`29a16ce2`](https://github.com/NixOS/nixpkgs/commit/29a16ce2a73d78639a539a324ef7ef74f9c2befc) pantheon.file-roller-contract: unstable-2021-02-22 -> 0-unstable-2021-02-22
* [`cfc30e70`](https://github.com/NixOS/nixpkgs/commit/cfc30e70941243b2e67eb7e864e23675e2392760) wingpanel-indicator-ayatana: unstable-2023-04-18 -> 2.0.7-unstable-2023-04-18
* [`abb24383`](https://github.com/NixOS/nixpkgs/commit/abb24383d2c0b172c5df26d196985b5776abe177) sladeUnstable: unstable-2023-09-30 -> 3.2.4-unstable-2023-09-30
* [`a4dac9ef`](https://github.com/NixOS/nixpkgs/commit/a4dac9efcb2625a8e4b06e2d022c9578db25a494) criterion: migrate to by-name
* [`af00738a`](https://github.com/NixOS/nixpkgs/commit/af00738aa463ff6b64b5b79c6a89e8cd0dbaf258) prometheus-process-exporter: 0.7.10 -> 0.8.2
* [`c7a1616b`](https://github.com/NixOS/nixpkgs/commit/c7a1616be77793c4af33d2b98a5db6ee203e514f) nixos/nextcloud: add trailing slashes to carddav/caldav redirect
* [`a26cbf4c`](https://github.com/NixOS/nixpkgs/commit/a26cbf4cdf670f66309bdf02c2056eb62ce8a3b8) nixos/rl-2405: document that in some cases no photos are shown in Nextcloud
* [`98d8d1e5`](https://github.com/NixOS/nixpkgs/commit/98d8d1e58762be50fe96bf2757a661826518c9f9) glib: enable introspection on cross
* [`b2332fb2`](https://github.com/NixOS/nixpkgs/commit/b2332fb2b4dfe9b37ccf41084fb4c97ff8f52b51) python312Packages.pdm-backend: 2.2.1 -> 2.3.0
* [`87e62398`](https://github.com/NixOS/nixpkgs/commit/87e623980ae267d921791cee209224b63980ad1e) python312Packages.hatchling: 1.24.1 -> 1.24.2
* [`45248f57`](https://github.com/NixOS/nixpkgs/commit/45248f5782b620bdbbd5af1b54de41c6c0e5bd8a) python312Packages.wheel: 0.42.0 -> 0.43.0
* [`5dac1edb`](https://github.com/NixOS/nixpkgs/commit/5dac1edbfd983609e502ce89d33c9dafc3c52507) sphinx: fix build with python<3.11
* [`90530e09`](https://github.com/NixOS/nixpkgs/commit/90530e096036ef5f56c358da7a3c9b73be8d808a) streamlink: add missing dependency
* [`563a41d6`](https://github.com/NixOS/nixpkgs/commit/563a41d61621c05c9d646f91e564c49bbc3225fc) sourcehut: Fix werkzueg dependency build
* [`3cbfe5c4`](https://github.com/NixOS/nixpkgs/commit/3cbfe5c47b18883d0ff127c69dfe69bab19fd4ee) githooks: init at 3.0.1
* [`8a375a4f`](https://github.com/NixOS/nixpkgs/commit/8a375a4f8d7faeae1854c4f069253f19b3f3c6e3) polkadot: 1.10.0 -> 1.11.0
* [`adaa3668`](https://github.com/NixOS/nixpkgs/commit/adaa3668ef115f5b418c0fee4e901fba3ddfa91f) crosvm: 123.0 -> 124.0
* [`8eafd7bf`](https://github.com/NixOS/nixpkgs/commit/8eafd7bf31643a65e7f375f9618382c06ecfcd32) openturns: migrate to by-name
* [`a2bd19b1`](https://github.com/NixOS/nixpkgs/commit/a2bd19b1d444c66b6326b39958c95d7c59695d7e) hieroglypic: fix darwin build
* [`ebe32d6a`](https://github.com/NixOS/nixpkgs/commit/ebe32d6a21740f4d31436492b5411e13942f5a41) hyprdim: 2.2.4 -> 2.2.5
* [`19e0ed81`](https://github.com/NixOS/nixpkgs/commit/19e0ed8128a41a29249a8a92a215a6367cd00949) openturns: pick `lib` output from primesieve
* [`659b429e`](https://github.com/NixOS/nixpkgs/commit/659b429eedda55f7ca8d0953b3d9e4366ccb8456) openturns: refactor
* [`37678d5f`](https://github.com/NixOS/nixpkgs/commit/37678d5f20fd7a823f590bedf7035d0a77f1239a) vulkan-cts: 1.3.8.2 -> 1.3.8.3
* [`14248535`](https://github.com/NixOS/nixpkgs/commit/14248535a21bab81ebfaeeb518d0f4292e3670d7) renode-dts2repl: 0-unstable-2024-04-16 -> 0-unstable-2024-04-30
* [`e83b8cfd`](https://github.com/NixOS/nixpkgs/commit/e83b8cfd4337c15098b0b00884f217414771af50) nixos/tayga: add mappings option
* [`0cef9a0e`](https://github.com/NixOS/nixpkgs/commit/0cef9a0ee44c441c07a97cdd0e1685186d771e49) python311Packages.mdformat-mkdocs: 2.0.10 -> 2.0.11
* [`58eb2a6e`](https://github.com/NixOS/nixpkgs/commit/58eb2a6e349e56fbf62f3881b24a3325f368c48b) python312Packages.sqlalchemy: 2.0.29 -> 2.0.30
* [`5aa2b249`](https://github.com/NixOS/nixpkgs/commit/5aa2b249b3a7b5f5278ec1ab7b69079db31b9dcf) mise: 2024.4.8 -> 2024.5.2
* [`53ec8006`](https://github.com/NixOS/nixpkgs/commit/53ec8006650852dd530a27876177f82753ef6270) aliyun-cli: 3.0.203 -> 3.0.204
* [`ee51b718`](https://github.com/NixOS/nixpkgs/commit/ee51b718220076390905439166e7bf67f0098356) cargo-deny: 0.14.22 -> 0.14.23
* [`e6a3a956`](https://github.com/NixOS/nixpkgs/commit/e6a3a956b90361eda775d49576015873d8145e2c) python312Packages.pyproject-hooks: 1.0.0 -> 1.1.0
* [`3dbf9041`](https://github.com/NixOS/nixpkgs/commit/3dbf904108e30fa289a889d3c551e02942345d93) Revert "python312Packages.pyproject-hooks: 1.0.0 -> 1.1.0"
* [`9cffec76`](https://github.com/NixOS/nixpkgs/commit/9cffec76cf84996d1e705db159bfb3c1828b0493) gcsfuse: 2.0.0 -> 2.0.1
* [`e8aee1e2`](https://github.com/NixOS/nixpkgs/commit/e8aee1e222aed4e4ae4c8f98bf133cbf94fafc83) python311Packages.okta: 2.9.5 -> 2.9.6
* [`87e9db73`](https://github.com/NixOS/nixpkgs/commit/87e9db7345af816d2c550cdab49592bc3d6c5a3b) python311Packages.streamlit: 1.33.0 -> 1.34.0
* [`3d20a75e`](https://github.com/NixOS/nixpkgs/commit/3d20a75e9a6d0e67d185d173d1860414da51db4c) patroni: 2.1.3 -> 3.3.0
* [`60d2263d`](https://github.com/NixOS/nixpkgs/commit/60d2263d86dd75e4a779a1ea000cb5a1da3ce791) nile: unstable-2024-03-09 -> 1.0.2-unstable-2024-03-09
* [`4d15920c`](https://github.com/NixOS/nixpkgs/commit/4d15920cd16128fb3ebff4289d659395d2cf4aaf) bloat: unstable-2024-02-12 -> 0-unstable-2024-02-12
* [`5ae0b96f`](https://github.com/NixOS/nixpkgs/commit/5ae0b96fa2a54efe9e9a549f9e678ad1b17d1f1a) klipper: unstable-2024-04-20 -> 0.12.0-unstable-2024-04-20
* [`cbf9e8f3`](https://github.com/NixOS/nixpkgs/commit/cbf9e8f389556f6956d973d7ff297978e5a15001) moonraker: unstable-2023-12-27 -> 0.8.0-unstable-2023-12-27
* [`77f1d883`](https://github.com/NixOS/nixpkgs/commit/77f1d8831c98b41160cc4383536bed3fea40e929) postgresqlPackages.pgjwt: unstable-2023-03-02 -> 0-unstable-2023-03-02
* [`92dcac93`](https://github.com/NixOS/nixpkgs/commit/92dcac933996e1d56d4ce34d1dc8b9dae3edfc63) postgresqlPackages.tds_fdw: unstable-2024-02-10 -> 2.0.3-unstable-2024-02-10
* [`be077886`](https://github.com/NixOS/nixpkgs/commit/be077886cd21429930edfe7585755b3cc4e23282) nushellPlugins.net: unstable-2024-04-05 -> 0-unstable-2024-04-05
* [`e1c10217`](https://github.com/NixOS/nixpkgs/commit/e1c10217f95693ac6335e7573a82137d4fd65cab) rc-9front: unstable-2022-11-01 -> 0-unstable-2022-11-01
* [`693b3374`](https://github.com/NixOS/nixpkgs/commit/693b337466340eace2090621aea3a3a651d16475) zsh-prezto: unstable-2024-04-15 -> 0-unstable-2024-04-15
* [`40912288`](https://github.com/NixOS/nixpkgs/commit/409122886c930b2e6c787ce97c547c0c29a29b41) throttled: fix execution
* [`408b2344`](https://github.com/NixOS/nixpkgs/commit/408b2344bbe3555e385b251508a6377b493201ed) maintainers: add proggerx
* [`80d00f11`](https://github.com/NixOS/nixpkgs/commit/80d00f1152c5b2780aeeda70b050ae98c9d20724) fasole: init at 1.2.3
* [`6a41eab7`](https://github.com/NixOS/nixpkgs/commit/6a41eab7bf7453665e02bc34158350c455b65146) treesheets: 0-unstable-2024-04-27 -> 0-unstable-2024-05-04
* [`b2fd3016`](https://github.com/NixOS/nixpkgs/commit/b2fd3016038c82a3ac8c9c938ba82301b70fb6d2) nixos/openrazer: properly rename mouseBatteryNotifier option
* [`e53cfeee`](https://github.com/NixOS/nixpkgs/commit/e53cfeee3e7d56bed6e01ec4f508f3abe40ffd7a) root: enable `clad` for automatic differentiation in ROOT
* [`cdefff65`](https://github.com/NixOS/nixpkgs/commit/cdefff65b8474a454f5fefeb92ea21e55e915977) root: fix typos
* [`db942c10`](https://github.com/NixOS/nixpkgs/commit/db942c10c8e811ef9b5b79ee7cf9004fa6a56ad9) root: update homepage
* [`fca44ccf`](https://github.com/NixOS/nixpkgs/commit/fca44ccfdcb1ad28343880283ee24606bb527a5d) azure-cli: 2.58.0 -> 2.60.0
* [`f413cc02`](https://github.com/NixOS/nixpkgs/commit/f413cc022ef8bb2f02ab6181f88851b9c3964b19) php81Extensions.blackfire: 1.92.13 -> 1.92.14
* [`58132358`](https://github.com/NixOS/nixpkgs/commit/58132358f92449714852a162d4cf6d72ee97ac47) goldendict-ng: 24.01.22 -> 24.05.05
* [`693393d3`](https://github.com/NixOS/nixpkgs/commit/693393d3aae314433b24f4a610f8d4c8a397b27c) s0ix-selftest-tool: unstable-2022-11-04 -> 0-unstable-2024-02-07
* [`0dc23f22`](https://github.com/NixOS/nixpkgs/commit/0dc23f226c2557dd1444c1d082d2f93a728316ff) s0ix-selftest-tool: move to by-name
* [`8c1235a5`](https://github.com/NixOS/nixpkgs/commit/8c1235a549ee7545e1322be084f27e238fe6b8fd) python312Packages.aiodhcpwatcher: restrict to linux
* [`923517ac`](https://github.com/NixOS/nixpkgs/commit/923517acd6b73d13f28283aae05ad9e696af9020) python312Packages.faster-fifo: pin to gcc12 on linux
* [`28ebb58c`](https://github.com/NixOS/nixpkgs/commit/28ebb58c192ae051f465e877ac6bc5fb2e3f5dff) python312Packages.paypalhttp: fix tests
* [`a9ca1927`](https://github.com/NixOS/nixpkgs/commit/a9ca19279fb03ddc8cfc7884f27f234674dceaaf) python312Packages.samplerate: 0.1.0 -> 0.2.1
* [`3e29c48b`](https://github.com/NixOS/nixpkgs/commit/3e29c48b7de5c0b23366a672a8522e90ec92d132) python312Packages.wxpython: disable
* [`9c477c5e`](https://github.com/NixOS/nixpkgs/commit/9c477c5e569c44d808500c8ae70434076483000c) pretix: disable unreliable test
* [`8b7a1252`](https://github.com/NixOS/nixpkgs/commit/8b7a1252d2115f672be75fa79da535f5f7febb3c) python311Packages.meraki: 1.45.0 -> 1.46.0
* [`82c83d7f`](https://github.com/NixOS/nixpkgs/commit/82c83d7f5746df9bebee055376825347abe1dae8) mpris-scrobbler: 0.5.2 -> 0.5.3
* [`f7c19fed`](https://github.com/NixOS/nixpkgs/commit/f7c19fedfa0b39ccc03a7a47e7cd128dc3c713a0) python312Packages.pytest-mpl: migrate to pynose
* [`f409d2f9`](https://github.com/NixOS/nixpkgs/commit/f409d2f9ae334b777960681017a54fedf4533c1d) curl-impersonate: patch knownVulnerabilities
* [`d0440fd0`](https://github.com/NixOS/nixpkgs/commit/d0440fd0fff3b08f57e339a6a898754b2ed847cd) python311Packages.clarifai: 10.3.1 -> 10.3.2
* [`50b8f193`](https://github.com/NixOS/nixpkgs/commit/50b8f1937f39f11d77e56750e7b3c2a59b2fef67) python312Packages.jinja2: 3.1.3 -> 3.1.4
* [`96cc5335`](https://github.com/NixOS/nixpkgs/commit/96cc53351adc8cbd37146610e57315eb4773f519) atac: 0.14.0 -> 0.15.1
* [`92163354`](https://github.com/NixOS/nixpkgs/commit/92163354aa39805eaf22f6d640aea35d9574d4ff) flowtime: 6.1 -> 6.5
* [`a5ebdde1`](https://github.com/NixOS/nixpkgs/commit/a5ebdde1087380ed84037b1d912b02c8b7173991) cargo-duplicates: 0.5.1 -> 0.6.0
* [`433ab0a1`](https://github.com/NixOS/nixpkgs/commit/433ab0a16348fe1a1158bfc251993f4d69cfbcce) jqp: 0.5.0 -> 0.6.0
* [`d994fadf`](https://github.com/NixOS/nixpkgs/commit/d994fadf4de913a7be8cce757934859a0f7c5439) sispmctl: 4.11 -> 4.12
* [`92104ecf`](https://github.com/NixOS/nixpkgs/commit/92104ecfe99d55d76f09331aeb5dc7e631dde242) gnome-network-displays: 0.92.1 -> 0.92.2
* [`727f7708`](https://github.com/NixOS/nixpkgs/commit/727f770806bf440ced17680974473389b6285ce6) icnsify: init at 0.1.0
* [`7b6b627a`](https://github.com/NixOS/nixpkgs/commit/7b6b627a6653c5917c74406896575f0a7c138a30) nixos/caddy: Comment why ExecStart is reset
* [`b72561a3`](https://github.com/NixOS/nixpkgs/commit/b72561a394695ef56f06ff169d693594c172daa3) ffmpeg-full: disable avisynth on Darwin
* [`65598072`](https://github.com/NixOS/nixpkgs/commit/655980724f8814574c14f53713cfbc96947fbf64) julia-mono: 0.054 -> 0.055
* [`ffc65485`](https://github.com/NixOS/nixpkgs/commit/ffc654851f30b7cd9ab9ec2da0c1d894b0e5581f) xplr: 0.21.7 -> 0.21.8
* [`fffe2ee5`](https://github.com/NixOS/nixpkgs/commit/fffe2ee546cd872eeb56c3f2d0d481c4643ba612) memtier-benchmark: 2.0.0 -> 2.1.0
* [`1e59180a`](https://github.com/NixOS/nixpkgs/commit/1e59180ac426265b64b0264be31d71e546595069) air: 1.51.0 -> 1.52.0
* [`55cf427d`](https://github.com/NixOS/nixpkgs/commit/55cf427ddf635dfadc48b30bdf23d3dd6247cfc5) tidal-hifi: 5.10.0 -> 5.11.0
* [`d5edb2e2`](https://github.com/NixOS/nixpkgs/commit/d5edb2e2f5279e78a775a6bf2c7061618e2fa9be) messer-slim: 4.2.1 -> 4.2.2
* [`881fec3c`](https://github.com/NixOS/nixpkgs/commit/881fec3c23cee02ff9d92ff9a780002cd84e4317) carapace: 1.0.1 -> 1.0.2
* [`ed06640a`](https://github.com/NixOS/nixpkgs/commit/ed06640a5af30f4f2fa858671dd87485508bc397) mediamtx: 1.8.0 -> 1.8.1
* [`658e5adf`](https://github.com/NixOS/nixpkgs/commit/658e5adf388489d1c1c9857b54273306538ce5af) proto: 0.34.4 -> 0.35.0
* [`537333fa`](https://github.com/NixOS/nixpkgs/commit/537333fad46a871bd342ee14f558266cf276cd76) codux: 15.25.0 -> 15.25.1
* [`ed138a03`](https://github.com/NixOS/nixpkgs/commit/ed138a03065a2526da75233e1a1bf5022ef7adb3) updatecli: 0.76.0 -> 0.76.1
* [`e124f624`](https://github.com/NixOS/nixpkgs/commit/e124f624bc0ad7fc6d135358f5733afb01bb3109) rocksdb: 9.1.0 -> 9.1.1
* [`14d8019e`](https://github.com/NixOS/nixpkgs/commit/14d8019e7d842fba88ffada021fe9ab698e3cae1) sigtop: 0.10.0 -> 0.11.0
* [`2f0e5844`](https://github.com/NixOS/nixpkgs/commit/2f0e584448aef518251c9dcc1f46373401670a24) stgit: 2.4.6 -> 2.4.7
* [`c5f0dbd9`](https://github.com/NixOS/nixpkgs/commit/c5f0dbd9dc75efa28d01ba9f1b99a648a907eef1) rst2pdf: Fix postInstall build
* [`10959baf`](https://github.com/NixOS/nixpkgs/commit/10959baf1aa92b683d284f272ddc6becfa4f77de) jetbrains: 2024.1 -> 2024.1.1
* [`ecf637d2`](https://github.com/NixOS/nixpkgs/commit/ecf637d248c5c3de723edb4ca51c5c19078c0d28) jetbrains.plugins: update
* [`d4480179`](https://github.com/NixOS/nixpkgs/commit/d448017963eaf0e27bc170edeca3282b483da6f9) btrfs-auto-snapshot: init at 2.0.4
* [`25fd4e60`](https://github.com/NixOS/nixpkgs/commit/25fd4e6075b3ac63025dff4eda1c39d4a57a8828) mattermost: 9.5.3 -> 9.5.4
* [`931964e3`](https://github.com/NixOS/nixpkgs/commit/931964e3009f8ced440076223717acd0a3bc2f42) lollypop: format file
* [`ff59531e`](https://github.com/NixOS/nixpkgs/commit/ff59531e8319d7c068e54989923e70d8801bef94) lollypop: 1.4.37 -> 1.4.39
* [`93ecf949`](https://github.com/NixOS/nixpkgs/commit/93ecf9499319389c332bb7c810cdb086ec6d4ac3) lollypop: add kid3 to build inputs.
* [`c2f77d2e`](https://github.com/NixOS/nixpkgs/commit/c2f77d2e09b7f6bf09653111033c7e2bd6fa0777) dwarf-fortress: 50.12 -> 50.13
* [`a0bbb789`](https://github.com/NixOS/nixpkgs/commit/a0bbb7891ede5ea27f97c354d57f528970895974) home-manager: 0-unstable-2024-04-29 -> 0-unstable-2024-05-05
* [`18fa2009`](https://github.com/NixOS/nixpkgs/commit/18fa20098ca82882f965c0544226e964b1c644bf) ironbar: 0.15.0 -> 0.15.1
* [`a87e3fed`](https://github.com/NixOS/nixpkgs/commit/a87e3fedb68e40469f0f804307364ea1d76f633e) cvehound: 1.2.0 -> 1.2.1
* [`7c608fa2`](https://github.com/NixOS/nixpkgs/commit/7c608fa2036d84aeabfc3fd281942db6129853f6) mainsail: 2.11.0 -> 2.11.2
* [`c3dcc669`](https://github.com/NixOS/nixpkgs/commit/c3dcc669bc0b5b6acb52d9b8bc2eaa9a605c1e3f) local-ai: 2.13.0 -> 2.14.0
* [`735fffa1`](https://github.com/NixOS/nixpkgs/commit/735fffa17bd6d2adaecd248911378cae3f19b8b0) chore: migrate to by-name package
* [`f9adf47a`](https://github.com/NixOS/nixpkgs/commit/f9adf47a5f01bc57f55fc9f7e32afc00ede95c3c) vimPlugins.auto-save-nvim: switch to maintained fork
* [`c1ca85fb`](https://github.com/NixOS/nixpkgs/commit/c1ca85fb28211f720749fb093868d18022b718f2) vimPlugins/triptych.nvim: fix typo in repo URL
* [`53eae8c2`](https://github.com/NixOS/nixpkgs/commit/53eae8c23c2147f4fe1a17a9470a8013cf631790) python311Packages.oelint-parser: 3.5.0 -> 3.5.1
* [`15278019`](https://github.com/NixOS/nixpkgs/commit/1527801914cbbd6c124784334604678bc2180d99) python311Packages.frozendict: 2.4.2 -> 2.4.3
* [`bbc4836a`](https://github.com/NixOS/nixpkgs/commit/bbc4836a6131b6ca1c0b9e17e6038353323ea488) dwarf-therapist: remove texlive build-input
* [`06d9c1c8`](https://github.com/NixOS/nixpkgs/commit/06d9c1c85f8e27243afa7c3a12abbb817e08d368) vimPlugins: update on 2024-05-06
* [`0d39087c`](https://github.com/NixOS/nixpkgs/commit/0d39087c7ec314847e41422916a1faecfac90bad) vimPlugins: resolve github repository redirects
* [`48157ff0`](https://github.com/NixOS/nixpkgs/commit/48157ff02accb824a42b3b40ba9f1061fbaa054a) vimPlugins.nvim-treesitter: update grammars
* [`002054c9`](https://github.com/NixOS/nixpkgs/commit/002054c95f359f6f55731a813e05c0663cf28d90) python: add error message for debugging infinite recursion
* [`e611540f`](https://github.com/NixOS/nixpkgs/commit/e611540f7bc292e6ccc0b3023dc757447b49ef79) cri-o: 1.29.4 -> 1.30.0
* [`9e3ffad0`](https://github.com/NixOS/nixpkgs/commit/9e3ffad0a6dca531ddb7a2bd245457b375407daa) carapace: 1.0.1 -> 1.0.2
* [`99b07094`](https://github.com/NixOS/nixpkgs/commit/99b070940c8137a0b27f47d2431f85f015ab2100) mesa: 24.0.5 -> 24.0.6
* [`4612b930`](https://github.com/NixOS/nixpkgs/commit/4612b9309c9f5fb98ff032636346043d7b369f24) cargo-shear: 0.0.24 -> 0.0.25
* [`83a25f05`](https://github.com/NixOS/nixpkgs/commit/83a25f057ca8f8142f122014f967cb486c962aa7) iosevka-bin: 29.2.1 -> 30.0.0
* [`a7ef879f`](https://github.com/NixOS/nixpkgs/commit/a7ef879fd56789abd8e07f5790741e20e534faa1) python311Packages.sagemaker: 2.217.0 -> 2.218.1
* [`b9fcbf99`](https://github.com/NixOS/nixpkgs/commit/b9fcbf99b6766416e5b4e5693be1c508e37d2090) distrobox: 1.7.1 -> 1.7.2.1
* [`eeea181c`](https://github.com/NixOS/nixpkgs/commit/eeea181cd421d1cde2b32f9f60a2e9b163e750fe) ergochat: 2.13.0 -> 2.13.1
* [`6e8b3000`](https://github.com/NixOS/nixpkgs/commit/6e8b300029249dbdfcec34564a12184f66664928) exploitdb: 2024-05-02 -> 2024-05-05
* [`8b01ade8`](https://github.com/NixOS/nixpkgs/commit/8b01ade8a6d94d9fe73bd3b414e860f4321e90a2) python312Packages.tencentcloud-sdk-python: 3.0.1139 -> 3.0.1140
* [`a7d8f5a7`](https://github.com/NixOS/nixpkgs/commit/a7d8f5a79a5205df6b6ae898bcac6208386a9f2e) python312Packages.speechrecognition: 3.10.3 -> 3.10.4
* [`6c412b44`](https://github.com/NixOS/nixpkgs/commit/6c412b44afcc5a8bf79fbcbca5dff89544f81b90) python312Packages.speechrecognition: add changelog to meta
* [`1c6ab3bf`](https://github.com/NixOS/nixpkgs/commit/1c6ab3bfc3bf258cffa0aa75b67359b8c97f7622) python312Packages.speechrecognition: format with nixfmt
* [`3e109082`](https://github.com/NixOS/nixpkgs/commit/3e10908268926879bde81478648ebbc13418a491) librewolf-unwrapped: 125.0.2-1 -> 125.0.3-1
* [`8c9c0106`](https://github.com/NixOS/nixpkgs/commit/8c9c01060637d6153333523526e350fd97c037ba) python312Packages.xiaomi-ble: 0.28.0 -> 0.29.0
* [`79e15fca`](https://github.com/NixOS/nixpkgs/commit/79e15fca8e76cf18fd0c7f58c9b268712712c052) python311Packages.awkward-cpp: 32 -> 33
* [`681e0d87`](https://github.com/NixOS/nixpkgs/commit/681e0d87ad5d222dbdfe144ebed31c75f0c2db37) python311Packages.awkward: 2.6.3 -> 2.6.4
* [`4fee1280`](https://github.com/NixOS/nixpkgs/commit/4fee1280bf009827d4cbcf8b30ead9708736ddb6) python312Packages.xiaomi-ble: refactor
* [`f26d0eb6`](https://github.com/NixOS/nixpkgs/commit/f26d0eb6ff38d46be9b654ce498384abb577561a) python312Packages.xiaomi-ble: format with nixfmt
* [`812b4871`](https://github.com/NixOS/nixpkgs/commit/812b487141089b2ac4f83c9fa4e8ee13825fb093) recipes-archive-melpa: fix incorrect source hashes
* [`20cd7ed2`](https://github.com/NixOS/nixpkgs/commit/20cd7ed276aa5d1fb13c43fe724c0c543ea017e5) python312Packages.peaqevcore: 19.9.2 -> 19.9.4
* [`aa21f5b9`](https://github.com/NixOS/nixpkgs/commit/aa21f5b9a3fb2beb181bf0cdf5bb06bca4daabb6) python312Packages.publicsuffixlist: 0.10.0.20240502 -> 0.10.0.20240506
* [`0ac91541`](https://github.com/NixOS/nixpkgs/commit/0ac9154150bb69421ca8a84eb9afff6437e31d38) maintainers: add email for nazarewk
* [`2c538184`](https://github.com/NixOS/nixpkgs/commit/2c5381845d3bf12f230eefb247de19be141eef49) openrct2: 0.4.8 -> 0.4.11
* [`aef8750e`](https://github.com/NixOS/nixpkgs/commit/aef8750ef1a305b4f20fd63e9c1baab9943eae2b) python312Packages.rns: 0.7.3 -> 0.7.4
* [`9d10b85b`](https://github.com/NixOS/nixpkgs/commit/9d10b85b5e369f8f1567f3e8683638404f0e0411) hwatch: 0.3.12 -> 0.3.13
* [`e55e1a4d`](https://github.com/NixOS/nixpkgs/commit/e55e1a4d469d5be3737bf4024313484644a3abc8) python312Packages.rns: refactor
* [`d2a6274b`](https://github.com/NixOS/nixpkgs/commit/d2a6274b847f9fb0469c7f39f38289d8eb4c63ea) python312Packages.rns: format with nixfmt
* [`a2d71d4a`](https://github.com/NixOS/nixpkgs/commit/a2d71d4aecf7a46f508a335bd11f50e508ad763c) python312Packages.librosa: 0.10.1 -> 0.10.2
* [`60eb15ec`](https://github.com/NixOS/nixpkgs/commit/60eb15ecd4ec646286c08cf5a6d3f0af29bc5f7a) python312Packages.goodwe: 0.3.3 -> 0.3.4
* [`e9c787b1`](https://github.com/NixOS/nixpkgs/commit/e9c787b1c872fd87c62b600ae3af378b4c7201a7) lux: 0.24.0 -> 0.24.1
* [`5f67138f`](https://github.com/NixOS/nixpkgs/commit/5f67138fa75c580aa9ac8455cf33f2e50d3dae0a) mdk-sdk: 0.26.0 -> 0.27.0
* [`bb87c527`](https://github.com/NixOS/nixpkgs/commit/bb87c52706cb4d8fe2ab6356ed2d6f1b6550588b) alacritty-theme: 0-unstable-2024-04-24 → 0-unstable-2024-05-03 ([nixos/nixpkgs⁠#309420](https://togithub.com/nixos/nixpkgs/issues/309420))
* [`d0b4bc8d`](https://github.com/NixOS/nixpkgs/commit/d0b4bc8ddf414bd4cddfda11c822fb65c7953602) python312Packages.pyct: disable
* [`30796946`](https://github.com/NixOS/nixpkgs/commit/307969461c162f162ae13ea1d1188e14c57a7d34) vunnel: 0.22.0 -> 0.22.2
* [`4ed944db`](https://github.com/NixOS/nixpkgs/commit/4ed944dbb58eb2d1b76cae29b7b7cd1aa466796e) maker-panel: bump dependency to fix compilation error
* [`3c5119e3`](https://github.com/NixOS/nixpkgs/commit/3c5119e3b4b0372d1d938af0ac631092dc460880) suricata: resolve runtimme dependency
* [`60be9246`](https://github.com/NixOS/nixpkgs/commit/60be9246349c791225d775714300c593d7e0850d) python311Packages.execnb: 0.1.5 -> 0.1.6
* [`91d79459`](https://github.com/NixOS/nixpkgs/commit/91d7945974ca9efc12f59e2911fa2cd6423a8de6) nixos/terminfo: always use buildPlatform's terminfo ([nixos/nixpkgs⁠#309108](https://togithub.com/nixos/nixpkgs/issues/309108))
* [`869434b4`](https://github.com/NixOS/nixpkgs/commit/869434b4f630a154b5c9c64e14ef3794b67af796) python311Packages.schwifty: add missing dependency
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
