### PR TITLE
niv home-manager: update 6ebe7be2 -> 44677a1c

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -41,10 +41,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "6ebe7be2e67be7b9b54d61ce5704f6fb466c536f",
-        "sha256": "1rlhl2dq04z5mk0fv91cz8560rk43fjmlgb05b4ji349a3dx8zvg",
+        "rev": "44677a1c96810a8e8c4ffaeaad10c842402647c1",
+        "sha256": "0bhwgi7mjrngv1fyv8cl0iwqkn1al7dj65rbw1b6wffrq776x572",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/6ebe7be2e67be7b9b54d61ce5704f6fb466c536f.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/44677a1c96810a8e8c4ffaeaad10c842402647c1.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@6ebe7be2...44677a1c](https://github.com/nix-community/home-manager/compare/6ebe7be2e67be7b9b54d61ce5704f6fb466c536f...44677a1c96810a8e8c4ffaeaad10c842402647c1)

* [`6e277d95`](https://github.com/nix-community/home-manager/commit/6e277d9566de9976f47228dd8c580b97488734d4) jujutsu: add ediff option
* [`f61917cb`](https://github.com/nix-community/home-manager/commit/f61917cbaa6dba317e757aefd0bbb56403aff2f8) fastfetch: add module
* [`4855bfb6`](https://github.com/nix-community/home-manager/commit/4855bfb6ce20225a1b0e2aae2379da909ab38350) kanshi: update configuration to better match upstream
* [`c6ddd80f`](https://github.com/nix-community/home-manager/commit/c6ddd80fb1e5a286b3a5cb32ef94a2e4e346a9d3) hyprlock: add module
* [`22374331`](https://github.com/nix-community/home-manager/commit/223743313bab8b0b44a57eaf9573de9f69082b4d) hyprpaper: add module
* [`f55718ae`](https://github.com/nix-community/home-manager/commit/f55718aec361f6a5101f07e3203106f85d6cad20) hyprland: add support for XDG autostart using systemd
* [`e6a31590`](https://github.com/nix-community/home-manager/commit/e6a315900db775da3bb3138bab8caa70dafdaf9e) flake.lock: Update
* [`f2c5ba5e`](https://github.com/nix-community/home-manager/commit/f2c5ba5e720fd584d83f2f97399dac0d26ae60b9) fontconfig: add defaultFonts.* options
* [`5514ed32`](https://github.com/nix-community/home-manager/commit/5514ed321087f0b5af42564352d135acad4ff055) yambar: add module
* [`15d7ec30`](https://github.com/nix-community/home-manager/commit/15d7ec30511199349c6cf8b6cbdc5e205a6a15e8) darwin: misc defaults (dock, menu clock, finder)
* [`d939ce58`](https://github.com/nix-community/home-manager/commit/d939ce585c611c00ca44145a74acab04c20619ad) mopidy: make scan service depend on `mopidy-local`
* [`d7682620`](https://github.com/nix-community/home-manager/commit/d7682620185f213df384c363288093b486b2883f) jujutsu: switch to XDG config home
* [`44677a1c`](https://github.com/nix-community/home-manager/commit/44677a1c96810a8e8c4ffaeaad10c842402647c1) flake.lock: Update
