### PR TITLE
niv nerd-icons.el: update fb395120 -> 66658b89

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -77,10 +77,10 @@
         "homepage": null,
         "owner": "rainstormstudio",
         "repo": "nerd-icons.el",
-        "rev": "fb395120e9de33b276d16caaccaefd98d4340b92",
-        "sha256": "0iyjd18b3v730ixz5ayr72m4z8p6vv5m0nplpndl0s7a7ypdm9l9",
+        "rev": "66658b89287c3599c7b9b6babea7bcb3dff9a9e4",
+        "sha256": "0ihxgm82zxg9dyawb7a58kkj2is708nwprhas7g4jygqblbxkw74",
         "type": "tarball",
-        "url": "https://github.com/rainstormstudio/nerd-icons.el/archive/fb395120e9de33b276d16caaccaefd98d4340b92.tar.gz",
+        "url": "https://github.com/rainstormstudio/nerd-icons.el/archive/66658b89287c3599c7b9b6babea7bcb3dff9a9e4.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "niv": {


### PR DESCRIPTION
## Changelog for nerd-icons.el:
Branch: main
Commits: [rainstormstudio/nerd-icons.el@fb395120...66658b89](https://github.com/rainstormstudio/nerd-icons.el/compare/fb395120e9de33b276d16caaccaefd98d4340b92...66658b89287c3599c7b9b6babea7bcb3dff9a9e4)

* [`66658b89`](https://github.com/rainstormstudio/nerd-icons.el/commit/66658b89287c3599c7b9b6babea7bcb3dff9a9e4) feat: Support GDScript and Godot config
