### PR TITLE
niv niv: update 6f6529db -> 04c1cec1

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -89,10 +89,10 @@
         "homepage": "https://github.com/nmattia/niv",
         "owner": "nmattia",
         "repo": "niv",
-        "rev": "6f6529db3a69cf3c4dd81eebcb5b46f1d34170e5",
-        "sha256": "1qbyprn08917cszfm5syppi4r5p467qii4fzb2v1s0lrqqn0das4",
+        "rev": "04c1cec14801d2b18fc1a771cf40cec249cb8670",
+        "sha256": "1xl4mni4az9wiwq3ygk0f53gwkjw5pnfgrl69r5vwji2jqc96a11",
         "type": "tarball",
-        "url": "https://github.com/nmattia/niv/archive/6f6529db3a69cf3c4dd81eebcb5b46f1d34170e5.tar.gz",
+        "url": "https://github.com/nmattia/niv/archive/04c1cec14801d2b18fc1a771cf40cec249cb8670.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {


### PR DESCRIPTION
## Changelog for niv:
Branch: master
Commits: [nmattia/niv@6f6529db...04c1cec1](https://github.com/nmattia/niv/compare/6f6529db3a69cf3c4dd81eebcb5b46f1d34170e5...04c1cec14801d2b18fc1a771cf40cec249cb8670)

* [`04c1cec1`](https://github.com/nmattia/niv/commit/04c1cec14801d2b18fc1a771cf40cec249cb8670) README: update nixos link to official wiki ([nmattia/niv⁠#399](https://togithub.com/nmattia/niv/issues/399))
