### PR TITLE
niv powerlevel10k: update 3395c828 -> 16e58484

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -113,10 +113,10 @@
         "homepage": "",
         "owner": "romkatv",
         "repo": "powerlevel10k",
-        "rev": "3395c828b27f2cf528b3cec6e48f97a986c5f086",
-        "sha256": "0f2sq2dhzr9r14dpskq9f6pnc4np0asnhdayskhifiw21ps6pfy2",
+        "rev": "16e58484262de745723ed114e09217094655eaaa",
+        "sha256": "108i97w4p79fxd13a7jhj0zdv8jd95lcv3p2chm7xmr1kggc22ny",
         "type": "tarball",
-        "url": "https://github.com/romkatv/powerlevel10k/archive/3395c828b27f2cf528b3cec6e48f97a986c5f086.tar.gz",
+        "url": "https://github.com/romkatv/powerlevel10k/archive/16e58484262de745723ed114e09217094655eaaa.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "rh": {


### PR DESCRIPTION
## Changelog for powerlevel10k:
Branch: master
Commits: [romkatv/powerlevel10k@3395c828...16e58484](https://github.com/romkatv/powerlevel10k/compare/3395c828b27f2cf528b3cec6e48f97a986c5f086...16e58484262de745723ed114e09217094655eaaa)

* [`16e58484`](https://github.com/romkatv/powerlevel10k/commit/16e58484262de745723ed114e09217094655eaaa) Doc: Use shorter readme link ([romkatv/powerlevel10k⁠#2671](https://togithub.com/romkatv/powerlevel10k/issues/2671))
