### PR TITLE
niv zsh-you-should-use: update 1f9cb008 -> 823a97ca

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -209,10 +209,10 @@
         "homepage": "",
         "owner": "MichaelAquilina",
         "repo": "zsh-you-should-use",
-        "rev": "1f9cb008076d4f2011d5f814dfbcfbece94a99e0",
-        "sha256": "0qap4yxc9skk7sqcwjz9x4arkl51zqa9scch0c8zmixp2473mawl",
+        "rev": "823a97ca638f962edeee0feb7889b8cbf968495b",
+        "sha256": "16vnngwskblzq6pydd52y4vpmxr95xyhl8j5ns30y86nmxjz0p96",
         "type": "tarball",
-        "url": "https://github.com/MichaelAquilina/zsh-you-should-use/archive/1f9cb008076d4f2011d5f814dfbcfbece94a99e0.tar.gz",
+        "url": "https://github.com/MichaelAquilina/zsh-you-should-use/archive/823a97ca638f962edeee0feb7889b8cbf968495b.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }


### PR DESCRIPTION
## Changelog for zsh-you-should-use:
Branch: master
Commits: [MichaelAquilina/zsh-you-should-use@1f9cb008...823a97ca](https://github.com/MichaelAquilina/zsh-you-should-use/compare/1f9cb008076d4f2011d5f814dfbcfbece94a99e0...823a97ca638f962edeee0feb7889b8cbf968495b)

* [`f9cf64f6`](https://github.com/MichaelAquilina/zsh-you-should-use/commit/f9cf64f6e41f6690d41f921583f4945af960d534) fix failing tests when key and value are not split correctly
* [`823a97ca`](https://github.com/MichaelAquilina/zsh-you-should-use/commit/823a97ca638f962edeee0feb7889b8cbf968495b) bump version to 1.7.4
