### PR TITLE
niv nixpkgs: update a7cdcbc9 -> 4cd4ad24

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a7cdcbc9510061404543da63f05e631db07f1eb3",
-        "sha256": "05njlfl2idzgakl1v1fl89cdh9sxr436iy8bkf718jblnm237mn6",
+        "rev": "4cd4ad242e70fa4475a9c10eeed87cbada8639dc",
+        "sha256": "11jgj2w82jwl15fp5g4phgsg50mmcgcaq8cf2i1js0kra49lk5h6",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/a7cdcbc9510061404543da63f05e631db07f1eb3.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/4cd4ad242e70fa4475a9c10eeed87cbada8639dc.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@a7cdcbc9...4cd4ad24](https://github.com/nixos/nixpkgs/compare/a7cdcbc9510061404543da63f05e631db07f1eb3...4cd4ad242e70fa4475a9c10eeed87cbada8639dc)

* [`6ec2b2d1`](https://github.com/NixOS/nixpkgs/commit/6ec2b2d1be12fb291589825cbae73c5e4b8fc8df) mullvad-vpn: respect NIXOS_OZONE_WL
* [`c82896c2`](https://github.com/NixOS/nixpkgs/commit/c82896c292841e755ee75b172e3a9649b59d9ca0) nixos/binfmt: added assertion to prevent emulation of current system
* [`a1230037`](https://github.com/NixOS/nixpkgs/commit/a1230037b3d0f90d8a1ad2387ce2f668e20a3205) gxkb: 0.9.3 -> 0.9.5
* [`ac43ec34`](https://github.com/NixOS/nixpkgs/commit/ac43ec34d9181114a290ca734d13f16e25229d7f) torch: passthru rocmSupport flag
* [`2eedfae4`](https://github.com/NixOS/nixpkgs/commit/2eedfae46b0e632089aefad388cbc7093e7eea0b) torchaudio: add rocm support
* [`8a229206`](https://github.com/NixOS/nixpkgs/commit/8a229206ddf2fd197ffbaeb6254118dd658df38c) lego: 4.15.0 -> 4.16.1
* [`077affc2`](https://github.com/NixOS/nixpkgs/commit/077affc20fc6c4600fa167177d4b4f1dff8cdcc9) maxfetch: init at unstable-2023-07-31
* [`44d7f66c`](https://github.com/NixOS/nixpkgs/commit/44d7f66c40c3315b72a49e8e13d0861433218e3b) citrix_workspace: preload pcsclite lib
* [`9c2c6f35`](https://github.com/NixOS/nixpkgs/commit/9c2c6f35de1ed1e18467cf224ed86689e6f589c4) kavita: restore db migrations
* [`7e375a74`](https://github.com/NixOS/nixpkgs/commit/7e375a74a2a56caddee696fd98f399768f868d62) prooftree: use prefixKey
* [`fa188528`](https://github.com/NixOS/nixpkgs/commit/fa188528484ed0b055db8d9be48453e2fa9d8b1b) persepolis: 3.2.0 -> 4.0.0
* [`cc0a9478`](https://github.com/NixOS/nixpkgs/commit/cc0a9478d4aae9ee0a83e091bef99282ba4703c8) persepolis: refactor: re-enable checkPhase
* [`ecd975ff`](https://github.com/NixOS/nixpkgs/commit/ecd975fffb8f202f1eb5c0485ca230f86e1f5cbe) persepolis: formatting
* [`5047bcf3`](https://github.com/NixOS/nixpkgs/commit/5047bcf30a3b8e592c0656fb7093661e7cea55dc) persepolis: apply Darwin patches on Linux as well
* [`b502a1d4`](https://github.com/NixOS/nixpkgs/commit/b502a1d4d5f4e4f7f68afc26bbdb1d8bbab421ec) persepolis: fix incorrect meta fields
* [`1e04dc2a`](https://github.com/NixOS/nixpkgs/commit/1e04dc2a54cbf84b041509cce01b89295751f882) persepolis: migrate to by-name
* [`0535756b`](https://github.com/NixOS/nixpkgs/commit/0535756bb00c8313624e98a4a95b2459a71c60ea) persepolis: 4.0.0 -> 4.0.1
* [`0fa62a0a`](https://github.com/NixOS/nixpkgs/commit/0fa62a0a4ebcbd264f78cb46b06ef2fdb7017471) python311Packages.gremlinpython: 3.6.4 -> 3.7.1
* [`1a00458a`](https://github.com/NixOS/nixpkgs/commit/1a00458a66b604c39dd391b3145d59965e8521db) python3Packages.spsdk: remove meta.broken as spsdk 2.1.1 uses cryptography 42, pynitrokey, nitrokey-app2: unpin cryptgraphy
* [`c3fad51a`](https://github.com/NixOS/nixpkgs/commit/c3fad51a016c59d4c9f0b5891033d0fe3f852964) nitrokey-app2: 2.1.5 -> 2.2.2, use qt6 wrap hook
* [`f02fed09`](https://github.com/NixOS/nixpkgs/commit/f02fed09a64bc20a30ebb19f964fae0f5eec895c) cosmic-store: unstable-2024-03-13 -> 0-unstable-2024-04-15
* [`83664646`](https://github.com/NixOS/nixpkgs/commit/8366464661c1e56efeb5cf51a0d14fdbab1e21ea) cosmic-edit: 0-unstable-2024-02-28 -> 0-unstable-2024-04-15
* [`a2a28e73`](https://github.com/NixOS/nixpkgs/commit/a2a28e73b02f30dbf6d415b8ee24ddc42084e6c7) katago: 1.14.0 -> 1.14.1
* [`47cb5ed0`](https://github.com/NixOS/nixpkgs/commit/47cb5ed04395c21cff120dff227a963ea0e8309e) libcxxrt: Add multiple outputs
* [`42bf0cb6`](https://github.com/NixOS/nixpkgs/commit/42bf0cb6860f0753f292484d54c7f8a6c2d2ebce) fcrackzip: fix clang/darwin build
* [`80cc0cb9`](https://github.com/NixOS/nixpkgs/commit/80cc0cb940d000304848156de4571f5976726a1a) spago: 0.20.9 -> 0.21.0
* [`2a76047d`](https://github.com/NixOS/nixpkgs/commit/2a76047d229816dcac2957160d73f4e0b0657ddc) spago: move completions override to configuration-nix.nix
* [`e8400e1f`](https://github.com/NixOS/nixpkgs/commit/e8400e1f44262e1e955cc5cea6c1f15acd5b8e40) glasskube: 0.2.0 -> 0.2.1
* [`edccb3a4`](https://github.com/NixOS/nixpkgs/commit/edccb3a4bd529608208dd66b7cbf82273b182214) python3Packages.uxsim: init at 1.1.1
* [`5ff3f221`](https://github.com/NixOS/nixpkgs/commit/5ff3f2218aefc3b3ba915befdf031ec02cc6f9f5) syncplay: 1.7.0 -> 1.7.2
* [`f4cf580b`](https://github.com/NixOS/nixpkgs/commit/f4cf580b9ed896ab09638bc9dfd51c4eb0c36d1a) syncplay: add assistant to maintainers
* [`ff0f4540`](https://github.com/NixOS/nixpkgs/commit/ff0f4540c088913db38d9a5006b4a85e768c9ae5) snapper: Add persistentTimer option to config
* [`60a9a797`](https://github.com/NixOS/nixpkgs/commit/60a9a797766d0b397234f4e634390d404e740a25) commafeed: init at 4.3.3
* [`3a0fa1e7`](https://github.com/NixOS/nixpkgs/commit/3a0fa1e7aab9caf72f7262d3d5c7414d52edab44) nixos/commafeed: init module
* [`abdeca34`](https://github.com/NixOS/nixpkgs/commit/abdeca343a8683c6bc752958907bc3c45452d99b) nixos/qtile: add finalPackage option
* [`3ce10797`](https://github.com/NixOS/nixpkgs/commit/3ce10797535119f1e84770a97395f8d0afe18950) lib.fetchers: Add uppercase proxy environment variables
* [`73d98d9b`](https://github.com/NixOS/nixpkgs/commit/73d98d9b4a9f031ef3ba21b053c5d9af1d2ab71d) nginxStable: 1.24.0 -> 1.26.0
* [`76406bb3`](https://github.com/NixOS/nixpkgs/commit/76406bb31ef9dffafea3d104e40b49df42eb2717) ovftool: init at 4.6.2 for x86_64-darwin
* [`abe0b34c`](https://github.com/NixOS/nixpkgs/commit/abe0b34ca9feccfda300ff0328d9a305f0bd5c7d) haskellPackages: stackage LTS 22.17 -> LTS 22.18
* [`969d2cc9`](https://github.com/NixOS/nixpkgs/commit/969d2cc975528d8dccf3dcf28d5482f8d9367903) all-cabal-hashes: 2024-04-16T17:36:35Z -> 2024-04-27T10:57:54Z
* [`1b84c9a7`](https://github.com/NixOS/nixpkgs/commit/1b84c9a77c1b7fab4a2ef20338d4abb39a070fce) haskellPackages.Cabal_3_10_3_0: preserve for cabal-install
* [`9edba2c9`](https://github.com/NixOS/nixpkgs/commit/9edba2c97c165858763b148c2972afcd8cef7c41) haskellPackages: regenerate package set based on current config
* [`4398d970`](https://github.com/NixOS/nixpkgs/commit/4398d970b30b75166611f23fc5b7417c5af362d8) haskellPackages.futhark: adjust for newly released zlib version
* [`675bcbb9`](https://github.com/NixOS/nixpkgs/commit/675bcbb917a13567e3fad8bb00afada19db791d6) haskell.compiler.ghc9{6,8}: pass patched source to hadrian
* [`c93aff17`](https://github.com/NixOS/nixpkgs/commit/c93aff17d599feb24ca6a0e2156afd3b184a7afb) haskell.compiler.ghc9{6,8}: apply hadrian patches to shared ghcSrc
* [`b4dc0f71`](https://github.com/NixOS/nixpkgs/commit/b4dc0f7158a655d4d2006ba9437063dc9a8aded4) haskell.packages.ghcjs.stm: fix eval
* [`e40acae4`](https://github.com/NixOS/nixpkgs/commit/e40acae431529946ef6e0a1cd7e83f8d9f95240e) sqlcl: 23.4.0.023.2321 -> 24.1.0.087.0929
* [`08026fcd`](https://github.com/NixOS/nixpkgs/commit/08026fcd47a5c2d6a7fc8a754f683bbd937d5b32) haskellPackages.linux-namespaces: fix build in ghc < 9.6
* [`aa530c59`](https://github.com/NixOS/nixpkgs/commit/aa530c595a12cec60d82fa0d44cc542dbbc2ac46) haskellPackages.proto-lens-arbitrary: unmark broken
* [`1e687bc6`](https://github.com/NixOS/nixpkgs/commit/1e687bc61223315e542856bbf86d1836cad3c521) haskellPackages.cbor-tool: Unbroken
* [`b509436a`](https://github.com/NixOS/nixpkgs/commit/b509436a771c000303b3e5146f7c0ed4dd83d512) python3Packages.ziafont: 0.7 -> 0.8
* [`fc6d0644`](https://github.com/NixOS/nixpkgs/commit/fc6d0644e08d0e72f4b71e4e25c363c2f944b41b) python3Packages.ziamath: 0.9 -> 0.10
* [`415b57a0`](https://github.com/NixOS/nixpkgs/commit/415b57a01076720b674867cbb9dd614906f0c5b8) python3Packages.schemdraw: 0.18 -> 0.19
* [`5818d1b9`](https://github.com/NixOS/nixpkgs/commit/5818d1b9500a98520f2e32a26618f26ed4e0d166) nixops_unstablePlugins.nixops-aws: unstable-2024-02-29 -> 1.0.0-unstable-2024-02-29
* [`14efba2d`](https://github.com/NixOS/nixpkgs/commit/14efba2dbabc5fd904f297b7303c6dcfbfedaf0f) nixops_unstablePlugins.nixops-digitalocean: unstable-2022-08-14 -> 0.1.0-unstable-2022-08-14
* [`d84e0f79`](https://github.com/NixOS/nixpkgs/commit/d84e0f79b84dbb7fd427d56d09a76858a6a98714) nixops_unstablePlugins.nixops-encrypted-links: unstable-2021-02-16 -> 0-unstable-2021-02-16
* [`c62e583e`](https://github.com/NixOS/nixpkgs/commit/c62e583ed82ab81d560aaa72b121610312bb5b78) nixops_unstablePlugins.nixops-gce: unstable-2023-05-26 -> 0-unstable-2023-05-26
* [`ae746715`](https://github.com/NixOS/nixpkgs/commit/ae746715e1d9db430c0ac0048d4d2c14e2c6aae5) nixops_unstablePlugins.nixops-hercules-ci: unstable-2021-10-06 -> 0-unstable-2021-10-06
* [`b5992782`](https://github.com/NixOS/nixpkgs/commit/b5992782bfde12b7c12b6e73bc367bc7890d3d7d) nixops_unstablePlugins.nixops-hetzner: unstable-2022-04-23 -> 1.0.1-unstable-2022-04-24
* [`fa7c4cac`](https://github.com/NixOS/nixpkgs/commit/fa7c4cace920761cda64e541591c715e9b1fbe6a) nixops_unstablePlugins.nixops-hetznercloud: unstable-2023-02-19 -> 0-unstable-2023-02-19
* [`4a42a218`](https://github.com/NixOS/nixpkgs/commit/4a42a2186151d7a91813128368a50aad36521839) nixops_unstablePlugins.nixops-libvirtd: unstable-2023-09-01 -> 1.0.0-unstable-2023-09-01
* [`b025275d`](https://github.com/NixOS/nixpkgs/commit/b025275d1818d4926b792d9ed089c4cbfecc45a8) nixops_unstablePlugins.nixops-vbox: unstable-2023-08-10 -> 1.0.0-unstable-2023-08-10
* [`225b7a42`](https://github.com/NixOS/nixpkgs/commit/225b7a425ead5d2aa60dc1325cee8396dd2c3283) nixops_unstablePlugins.nixos-modules-contrib: unstable-2021-01-20 -> 0-unstable-2021-01-20
* [`02fa6f4d`](https://github.com/NixOS/nixpkgs/commit/02fa6f4ddb162d5fd132fb47d54f8e0d4d7c8603) nixops_unstable_minimal,nixops_unstable_full: unstable-2024-02-28 -> 1.7-unstable-2024-02-28
* [`6633abfa`](https://github.com/NixOS/nixpkgs/commit/6633abfa6e06e8997479f21c6bb2ce02d6133551) python311Packages.inform: 1.28 -> 1.29
* [`99337435`](https://github.com/NixOS/nixpkgs/commit/993374351f1b5325ddad3adbad614989fb6fe672) haskellPackages.jsaddle-clib: unmark broken
* [`dace374b`](https://github.com/NixOS/nixpkgs/commit/dace374b25132089a2bbc1fcb02c76c22bdb468a) haskellPackages.jsaddle-wkwebview: build on darwin
* [`bf265004`](https://github.com/NixOS/nixpkgs/commit/bf2650045952f5f79177d5e47906d61ca6e14ac0) haskellPackages.jsaddle-dom: remove jailbreak
* [`8a55e42d`](https://github.com/NixOS/nixpkgs/commit/8a55e42de4ecd75b3ac25ca34127e2649d2ef6c5) haskellPackages.dependent-sum: remove doJailbreak
* [`a78477d2`](https://github.com/NixOS/nixpkgs/commit/a78477d2ba0022ec78d0a6a98fdf52232aee4372) haskellPackages.patch: remove dontCheck
* [`c17cf689`](https://github.com/NixOS/nixpkgs/commit/c17cf689c9ba9242d531cc1fdcc3f20119d8cea5) haskellPackages.patch: fix build on ghc 9.8
* [`f514937e`](https://github.com/NixOS/nixpkgs/commit/f514937e7e4d24ff24e0bd1ddc14df6f6a1f7abb) haskellPackages.reflex: fix build on 9.8
* [`266f40a5`](https://github.com/NixOS/nixpkgs/commit/266f40a5ccf5ce7ab6b211c42cb237c1be2493b2) man-pages: restore `$out/bin` to fix `nix-shell -p man-pages`
* [`7b580f97`](https://github.com/NixOS/nixpkgs/commit/7b580f9758c2e5ef59ba641bf31628f293061ed2) haskellPackages.universe-some: remove broken flag
* [`6209b167`](https://github.com/NixOS/nixpkgs/commit/6209b167b32611dddcc076c9d11d04340c2f8942) maintainers: add weitzj
* [`dd5115d0`](https://github.com/NixOS/nixpkgs/commit/dd5115d0384fe75ab537a6346b0b7a5ac12bb462) powerpipe: init at 0.2.0
* [`8991c1cf`](https://github.com/NixOS/nixpkgs/commit/8991c1cfbb48bf31c9419e72d60b12b7a8a35f75) sse2neon: init at 1.7.0
* [`f5b77f11`](https://github.com/NixOS/nixpkgs/commit/f5b77f110212760bfc20f472d983281de09b8e08) openpgl: add darwin build
* [`e895d0e1`](https://github.com/NixOS/nixpkgs/commit/e895d0e115af3acab5a36537ec5f03021ed4ba25) openpgl: remove superfluous use of pname
* [`2a6e74ce`](https://github.com/NixOS/nixpkgs/commit/2a6e74ce5c1dc5866be5957ce0bd099b3700ed2d) openimagedenoise: fix darwin build
* [`e0b67e5e`](https://github.com/NixOS/nixpkgs/commit/e0b67e5e815de6cb89e8654e5c71724288bf2c73) circt: fix darwin linking issues
* [`dccf5b56`](https://github.com/NixOS/nixpkgs/commit/dccf5b561897f2987d585eecc33f14a61aae19e3) Revert "gnu-efi: 3.0.15 → 3.0.18"
* [`8a9a1e63`](https://github.com/NixOS/nixpkgs/commit/8a9a1e6369d83265d9a21dc62ced894b3e08edb4) nodejs_22: 22.0.0 -> 22.1.0
* [`7612072e`](https://github.com/NixOS/nixpkgs/commit/7612072e80f4f4e082e18e982a734fd4c713acde) python311Packages.icoextract: 0.1.4 -> 0.1.5
* [`d41a2944`](https://github.com/NixOS/nixpkgs/commit/d41a2944866bee61e249e32e56b53ec87453bada) worldofgoo: deprecate phases
* [`51cd84ba`](https://github.com/NixOS/nixpkgs/commit/51cd84ba57e5acde737d71919b1728fb309b1296) pkgs/README.md: add `meta.mainProgram` to new-package checklist template
* [`2c9c7814`](https://github.com/NixOS/nixpkgs/commit/2c9c781478b0c4f66effd6f9509350f261a11654) espanos: add package option
* [`96f889a8`](https://github.com/NixOS/nixpkgs/commit/96f889a809190995d45b647200e2e513d93a1aaa) python311Packages.icoextract: add changelog to meta
* [`8873c255`](https://github.com/NixOS/nixpkgs/commit/8873c2554ee6e6d76396dc0b5d56bcaf37ec4c06) python311Packages.icoextract: refactor
* [`8bb698e4`](https://github.com/NixOS/nixpkgs/commit/8bb698e4ca50037eb0887fd7fe2d8a3020548805) nagios: 4.5.1 -> 4.5.2
* [`6edec231`](https://github.com/NixOS/nixpkgs/commit/6edec2311c2acf1086cb5379026acea76c821f4c) nagios: add passthru.tests.version
* [`d4d29642`](https://github.com/NixOS/nixpkgs/commit/d4d29642b03be147104e4854108ee5bbbc7b76f3) nagios: enable darwin support
* [`3afb2cb9`](https://github.com/NixOS/nixpkgs/commit/3afb2cb944c508a6bdd435215b544aef10781e93) haskellPackages: fix build of gargoyle libs
* [`243da734`](https://github.com/NixOS/nixpkgs/commit/243da73491d23de980b1f30bbbc4dac2551b7903) libsForQt5.qtkeychain: 0.14.2 -> 0.14.3
* [`58f0ebf2`](https://github.com/NixOS/nixpkgs/commit/58f0ebf2c58b3301f4d0ce78b083959a8e76aa8b) haskellPackages.xmobar: Enable separate bin output
* [`07d12f14`](https://github.com/NixOS/nixpkgs/commit/07d12f14d5d920c12651a73591a41cd69b0547fc) python311Packages.line-profiler: 4.1.2 -> 4.1.3
* [`45e6042f`](https://github.com/NixOS/nixpkgs/commit/45e6042fd50e7ce720ce82f664dceba911c598a7) python311Packages.pymatgen: 2024.4.13 -> 2024.5.1
* [`6795a93b`](https://github.com/NixOS/nixpkgs/commit/6795a93b2ef6ad18d0bc9adf934dc93c83fe1503) haskellPackages.haveibeenpwned: unbreak
* [`e11b9dd5`](https://github.com/NixOS/nixpkgs/commit/e11b9dd5fda5cffc1b0b73ee993df798ac264775) davinci-resolve: add updateScript
* [`0987d0f8`](https://github.com/NixOS/nixpkgs/commit/0987d0f81e1091f6c61b3ac34f609c7bad18103a) haskellPackages.dependent-sum-template_0_2_0_1: build with ghc 9.8
* [`2a67a92c`](https://github.com/NixOS/nixpkgs/commit/2a67a92c8805108ccf5aa4ac7757663c3099545a) haskellPackages.dependent-sum-aeson-orphans: replace jailbreak with patch
* [`3f938016`](https://github.com/NixOS/nixpkgs/commit/3f9380167d88258f8524b944ba50068dc2cb78b7) haskellPackages.monoidal-containers: remove jailbreak for 8.10
* [`1d495de4`](https://github.com/NixOS/nixpkgs/commit/1d495de4d32c03ed5c494029813cc21ecf23a5b5) haskellPackages.dependent-monoidal-map: unbreak
* [`40698337`](https://github.com/NixOS/nixpkgs/commit/40698337b327cd7603af12a00708d1137bcdd73d) python311Packages.niaaml: 1.2.0 -> 2.0.0
* [`fe7232a5`](https://github.com/NixOS/nixpkgs/commit/fe7232a5914df8386df6ad9992ceb2aa69277d64) python311Packages.phonopy: 2.22.1 -> 2.23.1
* [`9993a754`](https://github.com/NixOS/nixpkgs/commit/9993a754075fa6d81ba9b1449669b0d7dd0a3cbb) python311Packages.queuelib: 1.6.2 -> 1.7.0
* [`2278fc07`](https://github.com/NixOS/nixpkgs/commit/2278fc07477f87cf24aca8653d11b0f4638e482f) python311Packages.dvclive: 3.45.0 -> 3.46.0
* [`a3e4e837`](https://github.com/NixOS/nixpkgs/commit/a3e4e8375fbd635d19122baf2b804584d27fc33e) python311Packages.google-cloud-bigquery-storage: 2.24.0 -> 2.25.0
* [`120d6696`](https://github.com/NixOS/nixpkgs/commit/120d66967510bb8d30fc7f0c94fdd7460dc7a5ef) python311Packages.nethsm: 1.0.0 -> 1.1.0
* [`4871a4e0`](https://github.com/NixOS/nixpkgs/commit/4871a4e0daaaedfac0b8a5685f35605a67ac07e2) nixos/systemd-stage-1: Fix fsck.xfs needing bash's sh symlink
* [`da635f35`](https://github.com/NixOS/nixpkgs/commit/da635f35de3f9a471112a63f49fcb3c00e5bd334) nixos/systemd-stage-1: Enable LVM installer test
* [`526b8f68`](https://github.com/NixOS/nixpkgs/commit/526b8f683b2c8b33fbc7845ef65ede8dd93149b2) libretro.ppssspp: use bundled ffmpeg
* [`212c34f8`](https://github.com/NixOS/nixpkgs/commit/212c34f8c024a76d1cfe9b737b020c0a94c583b0) nixos/miniflux: use systemd notify and watchdog
* [`98ec215e`](https://github.com/NixOS/nixpkgs/commit/98ec215e95cda61bbca74f5b73b974cdc4c045e4) python311Packages.aioconsole: 0.7.0 -> 0.7.1
* [`d1525013`](https://github.com/NixOS/nixpkgs/commit/d1525013e27f3b1475ab29afa56668009103370b) python311Packages.dbt-bigquery: 1.7.7 -> 1.7.8
* [`a7975f9a`](https://github.com/NixOS/nixpkgs/commit/a7975f9a540baae0f4f081022887fc93e4a92ed3) opencascade-occt_7_6: init at 7.6.2
* [`adc8a19f`](https://github.com/NixOS/nixpkgs/commit/adc8a19f062cc8a4d989752baf825d78944c4fd4) opencascade-occt: 7.6.2 -> 7.8.1
* [`ab2d6f78`](https://github.com/NixOS/nixpkgs/commit/ab2d6f785322ca20cf62779ec206539721d3ba4a) treewide: switch from opencascade-occt -> opencascade-occt_7_6
* [`81dcb723`](https://github.com/NixOS/nixpkgs/commit/81dcb7239caf415e3a6b28efb39dbbb5a93fee53) python311Packages.dash: 2.16.1 -> 2.17.0
* [`340ded6f`](https://github.com/NixOS/nixpkgs/commit/340ded6fc4b64334dade8a9a053174b982c48ebd) python311Packages.aws-lambda-builders: 1.48.0 -> 1.49.0
* [`4863f58e`](https://github.com/NixOS/nixpkgs/commit/4863f58e758aba4a14b6a4de7e63a7916e714868) python311Packages.pytado: 0.17.5 -> 0.17.6
* [`15be7007`](https://github.com/NixOS/nixpkgs/commit/15be700779460a73b330785c35579d3f881be8df) lxgw-wenkai-tc: init at version 1.330
* [`46d128df`](https://github.com/NixOS/nixpkgs/commit/46d128df320ac937879aeba07848fe4a32e8ad48) maintainers: add lebensterben
* [`3c2cdc96`](https://github.com/NixOS/nixpkgs/commit/3c2cdc96163cb2e67e594404277b1f77d4aa5e4d) python311Packages.paste: 3.10.0 -> 3.10.1
* [`baf9468f`](https://github.com/NixOS/nixpkgs/commit/baf9468fcc3a5bce2efe2384cf064b8d3b91e5a3) stats: 2.10.11 -> 2.10.13
* [`280e2cf3`](https://github.com/NixOS/nixpkgs/commit/280e2cf336dce53bcbcad71e201b2b5149782f2a) python311Packages.trytond: 7.0.10 -> 7.2.1
* [`c33c0efc`](https://github.com/NixOS/nixpkgs/commit/c33c0efc801b10b07a9d8b0ba026adbc0e0e1fd6) python311Packages.pywbem: 1.7.1 -> 1.7.2
* [`6879aef5`](https://github.com/NixOS/nixpkgs/commit/6879aef52dbceec629e71540131ebff9e3f2df01) gnome-extension-manager: 0.4.3 -> 0.5.1
* [`8950e22d`](https://github.com/NixOS/nixpkgs/commit/8950e22d8cb1c554b730633bd197c3990979033f) nixos/garage: drop replication_mode setting
* [`aa93972d`](https://github.com/NixOS/nixpkgs/commit/aa93972d0b595dff3b0bd66821e5c45c076a6eb4) nixos/vsftpd: fix invalid implication in assertions
* [`7d105f24`](https://github.com/NixOS/nixpkgs/commit/7d105f243509acee4b026357a12f549558d6da47) audio-sharing: 0.2.2 -> 0.2.4
* [`0914dbea`](https://github.com/NixOS/nixpkgs/commit/0914dbea7c545c66fb3ae8dafba36a8c85b2838b) bitmagnet: 0.7.14 -> 0.8.0
* [`7f9e729f`](https://github.com/NixOS/nixpkgs/commit/7f9e729fe22318d1d8f5504e3ed1ccccfa2cc9f8) oh-my-zsh: 2024-04-25 -> 2024-05-03
* [`45c1d2a3`](https://github.com/NixOS/nixpkgs/commit/45c1d2a3ae2d96709c1109bb2359e70d1a3f5c3d) imagemagick: 7.1.1-30 -> 7.1.1-32
* [`8c61a345`](https://github.com/NixOS/nixpkgs/commit/8c61a345004cd0eb42a1cf57698bae895b806450) haskellPackages.ghcjs-base: generate attribute as expected
* [`4787ce67`](https://github.com/NixOS/nixpkgs/commit/4787ce67c87df1c598c7b232875585fd909eb518) python311Packages.bdffont: 0.0.20 -> 0.0.24
* [`ea960350`](https://github.com/NixOS/nixpkgs/commit/ea960350b353b315fed4a7ab08aa19bf2b717a8e) got: 0.98.2 -> 0.99
* [`8ac7e50b`](https://github.com/NixOS/nixpkgs/commit/8ac7e50b13b9ba8ded7af8df95917044bebff86d) codeql: 2.17.1 -> 2.17.2
* [`282f8b7b`](https://github.com/NixOS/nixpkgs/commit/282f8b7be35c1e7ea576a27004a9df99bba4714e) nixos/bcg: fix usage without environment files
* [`4ef08407`](https://github.com/NixOS/nixpkgs/commit/4ef084073ce400d92694016bc485f4ea414fe491) igvm-tooling: allow for determinist id block signing
* [`f660b186`](https://github.com/NixOS/nixpkgs/commit/f660b186327d9c2a37ece2a21f3038d803b9bc16) nova: 3.8.0 -> 3.9.0
* [`d2524bf3`](https://github.com/NixOS/nixpkgs/commit/d2524bf33a9c69902bc311522930e457652c2a5c) glooctl: 1.16.10 -> 1.16.11
* [`0a914808`](https://github.com/NixOS/nixpkgs/commit/0a91480843ece95ddb081ef938daa12af8e9e241) weaviate: 1.24.10 -> 1.24.11
* [`f68797be`](https://github.com/NixOS/nixpkgs/commit/f68797befe20fc56153363e71ea0f0b74542db4b) vscode-langservers-extracted: 4.8.0 -> 4.9.0
* [`59478e81`](https://github.com/NixOS/nixpkgs/commit/59478e811929a66e797def84ec0680ba343889db) maintainers: add syedahkam
* [`0999991e`](https://github.com/NixOS/nixpkgs/commit/0999991e93c21db12bdfee6191f36135ae384a72) percona-server_8_3: init at 8.3.0-1
* [`3aaebbe7`](https://github.com/NixOS/nixpkgs/commit/3aaebbe74354300c9079bcc0a5cad91798161ce1) materialx: init at 1.38.10
* [`cc7c7fa6`](https://github.com/NixOS/nixpkgs/commit/cc7c7fa6d2eeddca9f72c5f28e18cf116bf7b0fb) openvdb: also build nanovdb
* [`eb5f1e64`](https://github.com/NixOS/nixpkgs/commit/eb5f1e64f306876b319b466f49d2515c7497015f) python311Packages.openusd: also build with materialx support
* [`b9ca7691`](https://github.com/NixOS/nixpkgs/commit/b9ca769194883025502f9eeb2bcdaf59a877bbec) blender: un-break darwin
* [`44286088`](https://github.com/NixOS/nixpkgs/commit/442860880f7fc4e100275ecb52c206e4f2451964) blender: add materialx
* [`031f89dd`](https://github.com/NixOS/nixpkgs/commit/031f89ddf3b207646a54fca83ad38bc5e62a890d) python3Packages.pipetools: init at 1.1.0
* [`af99d82f`](https://github.com/NixOS/nixpkgs/commit/af99d82fb5226bc22f3bf250c88489c42855c2c2) mongodb-5_0: 5.0.24 -> 5.0.26
* [`8f704722`](https://github.com/NixOS/nixpkgs/commit/8f70472232df5e4bb6532348122c58e17da2ecef) mongodb-6_0: 6.0.13 -> 6.0.15
* [`58240f80`](https://github.com/NixOS/nixpkgs/commit/58240f80691a086abe911d9e9781f51c3a356acd) percona-xtrabackup_8_3: init at 8.3.0-1
* [`52506a27`](https://github.com/NixOS/nixpkgs/commit/52506a2744f3a1a6dce813a1cdc8ac85fc1db5f9) percona: adapt upstream release model
* [`9164c33a`](https://github.com/NixOS/nixpkgs/commit/9164c33ab66913fd394f008408d323bbff741856) percona: apply required multi-version package structure
* [`1b897f87`](https://github.com/NixOS/nixpkgs/commit/1b897f8741fc1de25a0e25f95ca2c5f0c7785dbd) c2patool: 0.8.2 -> 0.9.0
* [`15a1ff78`](https://github.com/NixOS/nixpkgs/commit/15a1ff783b82cbd1a4c4ab250dfd5e937f518a14) armadillo: 12.8.2 -> 12.8.3
* [`38226b3a`](https://github.com/NixOS/nixpkgs/commit/38226b3a5bd2cd0416813f5ed358d4f9caaf86f5) erg: 0.6.35 -> 0.6.36
* [`8ec7d834`](https://github.com/NixOS/nixpkgs/commit/8ec7d8347b996b43a425a940c728aaef69999e89) kdiff3: 1.10.7 -> 1.11.0
* [`1f8b4c89`](https://github.com/NixOS/nixpkgs/commit/1f8b4c897bccaff97d20bfef76c6ddd101c36186) ironicclient: 5.5.0 -> 5.6.0
* [`23dedf27`](https://github.com/NixOS/nixpkgs/commit/23dedf27d2647b7a963c40e994121d1d5a4117b0) python3Packages.ziafont: refactor
* [`35f095b7`](https://github.com/NixOS/nixpkgs/commit/35f095b712a40b16cf9fb70816c4f475c4c135f6) python3Packages.ziamath: refactor
* [`edcbc9ac`](https://github.com/NixOS/nixpkgs/commit/edcbc9acf4bb1d740986c4af2bf5b9ddb91dca37) python3Packages.schemdraw: refactor
* [`fdf193cb`](https://github.com/NixOS/nixpkgs/commit/fdf193cb3ccdfb3e7406d004521ae866e6e81e3d) rcu: 2024.001n -> 2024.001o
* [`93f5aaf3`](https://github.com/NixOS/nixpkgs/commit/93f5aaf31bbf41110b316ff8a70046d1da8ab4f8) kratos: pass version & commit in linker flags to fix 'kratos version' command
* [`9630d00c`](https://github.com/NixOS/nixpkgs/commit/9630d00c18f20c2d75ed33c24ac2690e2f693cb0) nixos/virt-manager: use dconf to autoconnect QEMU/KVM
* [`0af6614f`](https://github.com/NixOS/nixpkgs/commit/0af6614fac80e8f2086ae232317bd81d9e8e3712) python312Packages.fakeredis: 2.21.3 -> 2.23.0
* [`6bcc2e00`](https://github.com/NixOS/nixpkgs/commit/6bcc2e004b6adc24593e58d46b96676d827fa38c) python312Packages.fakeredis: refactor
* [`93e545b2`](https://github.com/NixOS/nixpkgs/commit/93e545b271419e55f912f946dc426453ab1c075d) python312Packages.fakeredis: format with nixfmt
* [`7a6f77f7`](https://github.com/NixOS/nixpkgs/commit/7a6f77f760da099b4cf2cca3cccf6bc9a275805f) haskellPackages.hie-bios: Pin to fix hls
* [`d0438109`](https://github.com/NixOS/nixpkgs/commit/d0438109dbce657025ef989819691a9d7b13e812) modrinth-app: init at 0.7.1
* [`e26bfee9`](https://github.com/NixOS/nixpkgs/commit/e26bfee964c393ecfb01de7486dd2b65def79b49) shellcheck-sarif: init at 0.4.2
* [`ed125cf2`](https://github.com/NixOS/nixpkgs/commit/ed125cf2d431bf1815328e1c2049ab760110b789) signal-desktop-beta: only build on x86_64-linux
* [`8a2c1e2b`](https://github.com/NixOS/nixpkgs/commit/8a2c1e2ba19122c8ea0fc730b512336ed31f1fc7) python311Packages.dtlssocket: 0.1.16 -> 0.1.18
* [`36b4eac4`](https://github.com/NixOS/nixpkgs/commit/36b4eac4e74af099aa01b4ab2e779bc144b86f32) openipmi: 2.0.34 -> 2.0.35
* [`4499fcab`](https://github.com/NixOS/nixpkgs/commit/4499fcab0d4134dfac75cc27becf82e18952ac5a) podman: Improve packaging
* [`576e848d`](https://github.com/NixOS/nixpkgs/commit/576e848da0da23c551de2a3bbf052aea4fc2a4fc) qsynth: 0.9.90 -> 0.9.91
* [`40160091`](https://github.com/NixOS/nixpkgs/commit/4016009137056faa15bbc0c5604d750056a7d40a) artalk: init at 2.8.6
* [`4ee96b38`](https://github.com/NixOS/nixpkgs/commit/4ee96b38dc476508da6b11125ad5c3ed97026f63) deepin.dtk6core: init at 6.0.15
* [`bdc7fd3c`](https://github.com/NixOS/nixpkgs/commit/bdc7fd3ca999ed697e19404f6ed4407d81f3f0e7) deepin.dtk6gui: init at 6.0.15
* [`703ccfb3`](https://github.com/NixOS/nixpkgs/commit/703ccfb34aa3bdfc61399e53c72a671dc48958a8) deepin.dtk6widget: init at 6.0.15
* [`6a52b0a1`](https://github.com/NixOS/nixpkgs/commit/6a52b0a1ec343e01b2d67368afb59d616113aeb9) deepin.dtk6declarative: init at 6.0.15
* [`1c0f273d`](https://github.com/NixOS/nixpkgs/commit/1c0f273dbb64858dc694cdca8a104859cc524e61) deepin.dtk6systemsettings: init at 6.0.2
* [`00346bff`](https://github.com/NixOS/nixpkgs/commit/00346bff2ba3d9952727fa029890ee649436482d) nixos/borgbackup: add an option to ignore warnings
* [`8cd73735`](https://github.com/NixOS/nixpkgs/commit/8cd73735dc09a4f32ae9311eabdc03eb026bdc4c) buildsupport/php: add passthru.updateScript
* [`d550945a`](https://github.com/NixOS/nixpkgs/commit/d550945abb94bf8aa4cd4f7f6f5643780cfe6930) graylog-5_2: 5.2.4 -> 5.2.7
* [`58286e51`](https://github.com/NixOS/nixpkgs/commit/58286e510cd6c9a736a926c38e736485ddd9f54a) nixos/oauth2-proxy: fix invalid comparison between list and attrset
* [`616dc50a`](https://github.com/NixOS/nixpkgs/commit/616dc50aad9860aa4c3baf17c39efc468c39d205) python312Packages.dbus-fast: 2.21.1 -> 2.21.2
* [`5f0f2e50`](https://github.com/NixOS/nixpkgs/commit/5f0f2e5064a08ef5b90d4a46aa2b9184c689bcad) python312Packages.dbus-fast: refactor
* [`378345e8`](https://github.com/NixOS/nixpkgs/commit/378345e8ffd8ae47ca9b35e210eb9189d83f480d) python312Packages.dbus-fast: format with nixfmt
* [`64b4d9de`](https://github.com/NixOS/nixpkgs/commit/64b4d9dec9b5a788a7728449a2d220957f1f8b4f) rwpspread: 0.2.6 -> 0.3.0
* [`31f65948`](https://github.com/NixOS/nixpkgs/commit/31f659482fec9a796035d18a82c79bbd7441fdae) python311Packages.google-cloud-dlp: 3.16.0 -> 3.17.0
* [`d68e2539`](https://github.com/NixOS/nixpkgs/commit/d68e2539b1ce8cfeda1425cc81402a0203197fa3) haskellPackages.generics-sop: build with ghc 9.8
* [`876d0550`](https://github.com/NixOS/nixpkgs/commit/876d055062bffc9b2b2ccc4c8247015770394a02) callCabal2nixWithOptions: add srcModifier argument
* [`109035a7`](https://github.com/NixOS/nixpkgs/commit/109035a742033375f9c8b8cd6bfa0d0ab6477425) haskellPackages.records-sop: fix build
* [`3535522a`](https://github.com/NixOS/nixpkgs/commit/3535522a6c07c60bcb6f01f29f9e91a3969c6727) haskellPackages.basic-sop: unmark broken
* [`90e0533f`](https://github.com/NixOS/nixpkgs/commit/90e0533ffa6828a3e0e5a78e2667545370efc00b) haskellPackages.lens-sop: unmark broken
* [`67eb894b`](https://github.com/NixOS/nixpkgs/commit/67eb894b10ad927d12c06dddabf70306ecb1c648) haskellPackages.json-sop: build with ghc 9.8
* [`4414ea73`](https://github.com/NixOS/nixpkgs/commit/4414ea738e80c14c989e79574f62d737190f97f7) pinniped: 0.29.0 -> 0.30.0
* [`a5655b39`](https://github.com/NixOS/nixpkgs/commit/a5655b3955ee4bda218a0f28754f718cefed3fb9) flow: 0.235.1 -> 0.236.0
* [`00725d86`](https://github.com/NixOS/nixpkgs/commit/00725d8642865503b39ccdb22fcd77a192349bc3) pcre2: fix build for loongarch64
* [`ba4748e4`](https://github.com/NixOS/nixpkgs/commit/ba4748e40e1502e450cfb54df27234d1363917bd) libsystemtap: 5.0 -> 5.1
* [`c618e377`](https://github.com/NixOS/nixpkgs/commit/c618e3778cda9d78b3b83ba0b2f03bb1260a5783) minizinc: 2.8.3 -> 2.8.4
* [`f215b49c`](https://github.com/NixOS/nixpkgs/commit/f215b49c687aea47aada6d28f280abd36c698b28) geekbench: add asininemonkey to maintainers
* [`18f5938d`](https://github.com/NixOS/nixpkgs/commit/18f5938d09710b58ab81794af9b9becd74035e24) geekbench: 6.2.0 -> 6.3.0
* [`6fcc7493`](https://github.com/NixOS/nixpkgs/commit/6fcc749376b257ec3875e7a964ceb78ae68cab61) earlyoom: 1.8.1 -> 1.8.2
* [`d206b6d7`](https://github.com/NixOS/nixpkgs/commit/d206b6d73be5c8f698671c05c862ec41d2495dd1) beam-migrate: jailbreak because of too strict upper bound on pqueue
* [`94a20990`](https://github.com/NixOS/nixpkgs/commit/94a20990ce9447c51111ad0cdf6229c938bc4feb) renode-unstable: 1.15.0+20240502gita79411a5d -> 1.15.0+20240509git8750f2500
* [`4919275d`](https://github.com/NixOS/nixpkgs/commit/4919275d5157c83d2208d5b26620bbf63669612c) python311Packages.stripe: 9.5.0 -> 9.6.0
* [`94b6d81e`](https://github.com/NixOS/nixpkgs/commit/94b6d81e72bb8a9de07e8e9d458c9f73abcb1e9b) vesktop: don't use system vencord by default
* [`4d07bdc0`](https://github.com/NixOS/nixpkgs/commit/4d07bdc03028089f152ebc900dd80a722d450f98) vesktop: refactor
* [`2aa16f19`](https://github.com/NixOS/nixpkgs/commit/2aa16f19beda7d078db3afdc41a30b001b54d0cf) vesktop: reformat
* [`32bf051b`](https://github.com/NixOS/nixpkgs/commit/32bf051ba48d9e0c7120d335ca2f33f858e3de97) nixos/switch-to-configuration: add new implementation
* [`55d093f0`](https://github.com/NixOS/nixpkgs/commit/55d093f0decdb9b886a67cfcf01dffd6a1619e3b) bazelisk: 1.19.0 -> 1.20.0
* [`576a3973`](https://github.com/NixOS/nixpkgs/commit/576a39734e816dbed0d8ef7e541dc24271e81930) buildah-unwrapped: 1.35.3 -> 1.35.4
* [`bb00d3ec`](https://github.com/NixOS/nixpkgs/commit/bb00d3ecbbefe53ccbf7f2c838a3c513c5f60e0c) podman: 5.0.2 -> 5.0.3
* [`73dec69c`](https://github.com/NixOS/nixpkgs/commit/73dec69cab599b5c3a54a6ad58b826712af45d7f) monetdb: 11.49.7 -> 11.49.9
* [`e1ce1cae`](https://github.com/NixOS/nixpkgs/commit/e1ce1caec0f3d089b6073ceea720bf1b67dcadd6) hyperrogue: 13.0d -> 13.0i
* [`7f91efb8`](https://github.com/NixOS/nixpkgs/commit/7f91efb80da645b864cf78a85e36012b21ee623c) obs-studio-plugins.advanced-scene-switcher: 1.25.5 -> 1.26.0
* [`8786fdec`](https://github.com/NixOS/nixpkgs/commit/8786fdec30a030bb76f1c259917a3e670a404a61) kratos: git rid of 'with' and 'rec' where possible, fix Makefile shell path patching, move commit hash to variables
* [`c3d848e2`](https://github.com/NixOS/nixpkgs/commit/c3d848e2b1b62370ba11f91a1a7e5dec060b482b) semantic-release: 23.0.8 -> 23.1.1
* [`e94a2d47`](https://github.com/NixOS/nixpkgs/commit/e94a2d47cd363499696679f297eaddca9d13366f) llama-cpp: 2781 -> 2843
* [`da9ba9a2`](https://github.com/NixOS/nixpkgs/commit/da9ba9a213f0b999c9b7b8257a9399cc018aec00) zxtune: 5060 -> 5061
* [`3e1464af`](https://github.com/NixOS/nixpkgs/commit/3e1464aff56e5c26996e974a0a5702357a01a127) tabby: 0.10.0 -> 0.11.0
* [`f7c5051e`](https://github.com/NixOS/nixpkgs/commit/f7c5051e94dd76472340d2a97a750b7dbddacf09) rednotebook: 2.32 -> 2.33
* [`10d0542a`](https://github.com/NixOS/nixpkgs/commit/10d0542ae767595df183e5a155e38bf1abba83fd) add kbudde to maintainers
* [`6c0b38d8`](https://github.com/NixOS/nixpkgs/commit/6c0b38d8096344e66cd699a61662eb9b9d333a30) new package myks
* [`6dd3061c`](https://github.com/NixOS/nixpkgs/commit/6dd3061cae058c84f9e6dc81e901c3464a21b286) nixos/greetd: add option to make greetd not stop Plymouth early
* [`aa002616`](https://github.com/NixOS/nixpkgs/commit/aa0026163f87d37fd36a081094657dbd32a3fce8) move myks to pkgs/by-name
* [`17c0b6ab`](https://github.com/NixOS/nixpkgs/commit/17c0b6ab5943eb860f1c1c80e8700fafd37902e0) zrok: 0.4.27 -> 0.4.30
* [`cc7488ac`](https://github.com/NixOS/nixpkgs/commit/cc7488ac8d5139a3c999a1f3948d3bd991c0766a) video2midi: 0.4.7.2 -> 0.4.8
* [`2099ff76`](https://github.com/NixOS/nixpkgs/commit/2099ff760f8e36e67e86a2cb0da811d1a4a10341) thermald: fixed handling of an external config
* [`d123209a`](https://github.com/NixOS/nixpkgs/commit/d123209adebe964827a87f67d66e98e34e49c567) add a version test
* [`d8eb6d3b`](https://github.com/NixOS/nixpkgs/commit/d8eb6d3b974a4e6851166c6390e8a04efe2eaf5f) nixos/tests/systemd-initrd-modprobe: use loadable module
* [`d2b4b553`](https://github.com/NixOS/nixpkgs/commit/d2b4b553d924adaab78876c0d1281f217cdd9b8b) calicoctl: 3.27.3 -> 3.28.0
* [`1f6513a1`](https://github.com/NixOS/nixpkgs/commit/1f6513a145cc61dd1533a4a385ba3e995835001a) kakoune: 2023.08.05 -> 2024.05.09
* [`f8522cdd`](https://github.com/NixOS/nixpkgs/commit/f8522cddbc138e75ac01671d022d10b3dab4c11e) calico-cni-plugin: 3.27.3 -> 3.28.0
* [`c70fd286`](https://github.com/NixOS/nixpkgs/commit/c70fd286f02a5e1f7fe83ea86f570beb1884bef2) calico-apiserver: 3.27.3 -> 3.28.0
* [`afd63ddd`](https://github.com/NixOS/nixpkgs/commit/afd63ddd65b9cac19b5132986ec7845f3de27ce6) calico-app-policy: 3.27.3 -> 3.28.0
* [`58a77b04`](https://github.com/NixOS/nixpkgs/commit/58a77b044977bc4c41d84a9687943f494c38e4cc) runitor: 1.2.0 -> 1.3.0
* [`f56f4c9f`](https://github.com/NixOS/nixpkgs/commit/f56f4c9feca8c6f755186863a73afa3c0397468d) jbrowse: 2.11.0 -> 2.11.1
* [`b83a7a9a`](https://github.com/NixOS/nixpkgs/commit/b83a7a9a7fe24b851859fd3f662b93eaee735a69) fix: exec shellCompletion only if not crosscompiled [nixos/nixpkgs⁠#308283](https://togithub.com/nixos/nixpkgs/issues/308283)
* [`0b85c400`](https://github.com/NixOS/nixpkgs/commit/0b85c40042d88d47ee5af62628c8078cefbb7d4e) harden package definition
* [`6e22a417`](https://github.com/NixOS/nixpkgs/commit/6e22a417e6d547fa5375849e2d6d86300d674b5d) nixos/xserver: remove duplicate display-manager.script declaration
* [`844c1dcf`](https://github.com/NixOS/nixpkgs/commit/844c1dcf92e3f2cc620bc9983008d91b92cd65c9) python312Packages.pyrainbird: refactor
* [`c019fcde`](https://github.com/NixOS/nixpkgs/commit/c019fcde714510cc14d196dda96b411ee84ede85) python312Packages.pyrainbird: 4.0.2 -> 5.0.0
* [`fa030ff6`](https://github.com/NixOS/nixpkgs/commit/fa030ff6a54162ea131516c1907ee0b28d1d58d6) python312Packages.pyrainbird: format with nixfmt
* [`9cfdf95d`](https://github.com/NixOS/nixpkgs/commit/9cfdf95d276eafe719bed8c277aa48044ae21656) python311Packages.pyrainbird: 5.0.0 -> 6.0.1
* [`2e004c8f`](https://github.com/NixOS/nixpkgs/commit/2e004c8f90cbbaa735dd1ecb5eed92b4a59e1545) ssdfs-utils: 4.39 -> 4.40
* [`93220978`](https://github.com/NixOS/nixpkgs/commit/93220978d1f72314291ac4f4e7e56560abd0e17c) undocker: 1.0.4 -> 1.2.2
* [`d1f428a7`](https://github.com/NixOS/nixpkgs/commit/d1f428a716c177df35b4b8c4c8d39623fec17e2d) monaspace: 1.100 -> 1.101
* [`6261fccd`](https://github.com/NixOS/nixpkgs/commit/6261fccd9cdc420ea44aa0f74b01d34331046624) kubevpn: 2.2.7 -> 2.2.8
* [`2e48435c`](https://github.com/NixOS/nixpkgs/commit/2e48435cfe2b73fcbf5308c58605b47e23a1a609) python312Packages.asdf: 2.13.0 -> 3.2.0, unbreak
* [`0b1f0db7`](https://github.com/NixOS/nixpkgs/commit/0b1f0db71793e91b5adaa5a5ad302138d7d7804e) rmfakecloud: migrate to by-name
* [`6cc30987`](https://github.com/NixOS/nixpkgs/commit/6cc30987ce014d0b0902e0a52f6b1ee51d96ed7c) pahole: migrate to by-name
* [`e9531dec`](https://github.com/NixOS/nixpkgs/commit/e9531dec25324e179b04f5e763e64566e529a2e2) bcc: migrate to by-name
* [`dbe53bea`](https://github.com/NixOS/nixpkgs/commit/dbe53bea959588cf51e92b0ca3df59ae904437a7) bpftrace: migrate to by-name
* [`07562247`](https://github.com/NixOS/nixpkgs/commit/07562247506f0e1e9014bdbc34d9e943b87fcc4a) hledger-ui: pin to 1.32.* to match hledger{,-lib}
* [`22b02ed5`](https://github.com/NixOS/nixpkgs/commit/22b02ed53b9255cc87f19362d7b8eb340885bea2) mako: 1.8.0 -> 1.9.0
* [`2fae5b4e`](https://github.com/NixOS/nixpkgs/commit/2fae5b4eab56fc1e9cbdf5184bfd49536c834732) haskellPackages.mueval: disable reverse deps to fix maintained job
* [`8066db1e`](https://github.com/NixOS/nixpkgs/commit/8066db1e3c6744a874d766a912769e4630c038a7) npins: 0.2.2 -> 0.2.4
* [`45b1cdc8`](https://github.com/NixOS/nixpkgs/commit/45b1cdc87b30f102ed1db340754ad707e4ec2871) python311Packages.pycrdt-websocket: 0.13.3 -> 0.13.4
* [`9236e8ff`](https://github.com/NixOS/nixpkgs/commit/9236e8ff31d28733077cb36a895e94e4fd217d67) uxplay: migrate to pkgs/by-name and other enhancements
* [`4cd5eb84`](https://github.com/NixOS/nixpkgs/commit/4cd5eb84270717145103c3111db09499d614a7a7) python311Packages.contexttimer: mark as unsopported on python 3.12
* [`316f9349`](https://github.com/NixOS/nixpkgs/commit/316f9349887a796271913268e4ef1c1d68a9f211) gitlab-ci-local: 4.48.2 -> 4.49.0
* [`4c0f9d57`](https://github.com/NixOS/nixpkgs/commit/4c0f9d5733b7efeed4d32cf2a071a3e0da867b66) dualsensectl: migrate to pkgs/by-name and other enhancements
* [`700a3858`](https://github.com/NixOS/nixpkgs/commit/700a3858ff7cc40a0c1818f36996a05358125e5b) python3Packages.hikari: 2.0.0.dev124 -> 2.0.0.dev125
* [`8b0b8e89`](https://github.com/NixOS/nixpkgs/commit/8b0b8e893f3aa914299094a5b9c786fa67226b42) nixVersions.git: 2.23.0pre20240502_00ca2b05 -> 2.23.0pre20240510_87ab3c0e
* [`41097641`](https://github.com/NixOS/nixpkgs/commit/41097641870c6eb9d6272c891dd06488973eb5f8) gmetronome: 0.3.3 -> 0.3.4
* [`1669ab4a`](https://github.com/NixOS/nixpkgs/commit/1669ab4a47041630b9c516b917b24e10c538afba) home-assistant-custom-components.xiaomi_gateway3: 4.0.3 -> 4.0.5
* [`c73813bc`](https://github.com/NixOS/nixpkgs/commit/c73813bced138b1189d9ac5f4e9e8f5bcb1cb109) home-assistant-custom-components.xiaomi_miot: 0.7.17 -> 0.7.18
* [`0fd53882`](https://github.com/NixOS/nixpkgs/commit/0fd5388266182ba3682bb760a595720c1fbb6dbf) vivaldi: 6.7.3329.17 -> 6.7.3329.27
* [`1b2469b6`](https://github.com/NixOS/nixpkgs/commit/1b2469b661fa067a837397138688aa7316c3741a) python311Packages.b2sdk: 2.1.0 -> 2.2.1
* [`be3dadb5`](https://github.com/NixOS/nixpkgs/commit/be3dadb56318b1683d91e3759d208e3628b902e6) pypy: drop pycparser dependency to fix build
* [`171d83f8`](https://github.com/NixOS/nixpkgs/commit/171d83f81dbec52eba69b7ea0ef4c1e102729c34) haskellPackages.large-generics: unbreak
* [`7cc7df9f`](https://github.com/NixOS/nixpkgs/commit/7cc7df9f8fb67b6a3ae71b56761951814c223b04) haskellPackages.proto3-wire: unbreak
* [`5fda88c5`](https://github.com/NixOS/nixpkgs/commit/5fda88c5d6b925a8d8ffb7c7eb4f7b455862ef45) dosbox-staging: 0.80.1 -> 0.81.1
* [`5e304f60`](https://github.com/NixOS/nixpkgs/commit/5e304f6043bfd9ec032d25418fa339d2ee11c78e) dosbox-staging: format with nixfmt-rfc-style
* [`8ffb132e`](https://github.com/NixOS/nixpkgs/commit/8ffb132e1e101629fc1a1f7f6b478ff6f369f814) pymilter: fix deprecation for Python test function
* [`1653bb38`](https://github.com/NixOS/nixpkgs/commit/1653bb385f0a7552cc67be39c7206501e3fea35a) scalene: 1.5.39 -> 1.5.41
* [`783b0168`](https://github.com/NixOS/nixpkgs/commit/783b0168e5e2b1a2532a69e007364d11fc67a0dd) regols: 0.2.2 -> 0.2.3
* [`7ed60aae`](https://github.com/NixOS/nixpkgs/commit/7ed60aae1ed7e43c4919776710f48a61f5950ea5) squeezelite: 2.0.0.1486 -> 2.0.0.1488
* [`871e5c3b`](https://github.com/NixOS/nixpkgs/commit/871e5c3b2eeb5058f230dbaef449977e9985135e) python311Packages.jaxlib: 0.4.24 -> 0.4.28
* [`6d585139`](https://github.com/NixOS/nixpkgs/commit/6d585139fb736b88d0761a14851bed5904ff3d43) python311Packages.jaxlib: switch from cudaPackagesGoogle to cudaPackages
* [`463d9fca`](https://github.com/NixOS/nixpkgs/commit/463d9fca6376d1e5e451bd555e95564f29867504) python311Packages.jaxlib-bin: 0.4.24 -> 0.4.28
* [`1380cf0f`](https://github.com/NixOS/nixpkgs/commit/1380cf0f0b6508557e7e3a2cd7cb474a5401d973) python311Packages.jaxlib-bin: switch from cudaPackagesGoogle to cudaPackages
* [`cdf5d711`](https://github.com/NixOS/nixpkgs/commit/cdf5d711535abfee236a398b16865c2ab7c95619) python311Packages.jax: 0.4.25 -> 0.4.28
* [`9c9f01b6`](https://github.com/NixOS/nixpkgs/commit/9c9f01b6706f11a80a30f31d39a53675c03191e3) cudaPackagesGoogle: deprecate as only used by tensorflow
* [`ce3f3668`](https://github.com/NixOS/nixpkgs/commit/ce3f3668a26d1990545cd63bf99ebdb7188b5a6d) python311Packages.jaxopt: disable broken tests
* [`6267389e`](https://github.com/NixOS/nixpkgs/commit/6267389e95d50b3a265c4496bb4069637f86a112) python311Packages.flax: 0.8.2 -> 0.8.3
* [`0790d174`](https://github.com/NixOS/nixpkgs/commit/0790d174d2d38ea1bde544ce8be48fb79c26f332) python311Packages.equinox: skip failing tests
* [`24e02939`](https://github.com/NixOS/nixpkgs/commit/24e02939e9d41ee2525ff6b971a591fac74aaf28) python311Packages.blackjax: 1.2.0 -> 1.2.1
* [`0ab7fd77`](https://github.com/NixOS/nixpkgs/commit/0ab7fd77beb6a463fc4ccb09b2273a918de37344) python311Packages.objax: patch deprecated device_buffers code
* [`32d1bb1e`](https://github.com/NixOS/nixpkgs/commit/32d1bb1e3a15b047555a6f9c66d940e32f53d5fa) python311Packages.nanobind: temporarily remove jax from test dependencies to fix build
* [`0244a8d5`](https://github.com/NixOS/nixpkgs/commit/0244a8d5d77102d96496fc624ecb2a441ab6d441) nixos/caddy: don't set ExecReload if enableReload is disabled
* [`e5282895`](https://github.com/NixOS/nixpkgs/commit/e52828954639621b226281ff750a17b773009714) wireguard-vanity-keygen: 0.0.8 -> 0.0.9
* [`6d83438f`](https://github.com/NixOS/nixpkgs/commit/6d83438f9377510c1b325ea039326efa1b368f23) zam-plugins: 4.2 -> 4.3
* [`bd23342b`](https://github.com/NixOS/nixpkgs/commit/bd23342b94939f950ea416aad7e60f33fdd2d9fe) wakapi: 2.11.1 -> 2.11.2
* [`f5e9b18d`](https://github.com/NixOS/nixpkgs/commit/f5e9b18d483cb4ad92bf5d99671e3e7df6c82d19) python311Packages.pytrydan: 0.6.0 -> 0.6.1
* [`4c3ab00f`](https://github.com/NixOS/nixpkgs/commit/4c3ab00fde5afc057bf1bc4dff5824c2485c1cad) python311Packages.pysigma-backend-insightidr: 0.2.2 -> 0.2.3
* [`5ec7f4af`](https://github.com/NixOS/nixpkgs/commit/5ec7f4afad2c6ae8ea3f392fc1208ac2efcbcf23) git-cola: 4.7.0 -> 4.7.1
* [`51059eda`](https://github.com/NixOS/nixpkgs/commit/51059eda287e837160405a146fbe41f0b194c8cd) python311Packages.proxy-py: 2.4.4rc5 -> 2.4.4
* [`873139fd`](https://github.com/NixOS/nixpkgs/commit/873139fda339e5a8ec1d1de32363ea9e35494a50) python311Packages.devito: 4.8.3 -> 4.8.6
* [`c8e99f0d`](https://github.com/NixOS/nixpkgs/commit/c8e99f0d10b6ecadffcd1854d7a839208f8344a3) sherlock: unstable-2023-10-06 -> unstable-2024-05-12
* [`3195ca59`](https://github.com/NixOS/nixpkgs/commit/3195ca59c8c7541dc39b4b1f72f74620c2dd0333) python311Packages.limnoria: 2023.11.18 -> 2024.4.26
* [`e453e9d3`](https://github.com/NixOS/nixpkgs/commit/e453e9d3c695b720d8bfad8bb6dd7c60e3482aad) protonplus: 0.4.9 -> 0.4.10
* [`29894a14`](https://github.com/NixOS/nixpkgs/commit/29894a149b0be0d20268ab190a91f90763dd64d6) vimPlugins: update on 2024-05-12
* [`d94fb55f`](https://github.com/NixOS/nixpkgs/commit/d94fb55fdc5f51b339355e59981706d7f3167081) vimPlugins: resolve github repository redirects
* [`950555d4`](https://github.com/NixOS/nixpkgs/commit/950555d42ba07b29a12c48c1f09b7ff87993cfbb) vimPlugins.nvim-treesitter: update grammars
* [`a4522b58`](https://github.com/NixOS/nixpkgs/commit/a4522b58126e05bd96b514596162ca01039b9ba1) nezha-agent: 0.16.6 -> 0.16.7
* [`86669c52`](https://github.com/NixOS/nixpkgs/commit/86669c5217b9e8e1a742514e3f386b9fa0ff4e90) python311Packages.pytorch-lightning: 2.2.3 -> 2.2.4
* [`fbf94e8b`](https://github.com/NixOS/nixpkgs/commit/fbf94e8b9bcaf132aa9e53a6a6bb73ad78ce3d1d) mako: use `finalAttrs` instead of `rec`
* [`0a915ab9`](https://github.com/NixOS/nixpkgs/commit/0a915ab926c697a1c21c3f80b67ac4c116ecf37b) mako: remove `depsBuildBuild`
* [`c3c98db9`](https://github.com/NixOS/nixpkgs/commit/c3c98db9ab031680267dd629bf5f6bfd59964164) mako: remove `meta = with lib;`
* [`d66b7cfb`](https://github.com/NixOS/nixpkgs/commit/d66b7cfb8be28457982c10fc8bf731cb2acabc4a) python312Packages.pykdtree: relax build-system numpy; unbreak
* [`a145b3e9`](https://github.com/NixOS/nixpkgs/commit/a145b3e9157199baaf19bfa8ab0962a2a95e2ce6) mako: migrate to `pkgs/by-name`
* [`38281e72`](https://github.com/NixOS/nixpkgs/commit/38281e723910cc810be0057a99022a67df6114bc) python312Packages.pyannote-pipeline: remove vendorized versioneer.py
* [`d17ed378`](https://github.com/NixOS/nixpkgs/commit/d17ed378edcafe028dc6e21ffe3176ab93f0d33c) python312Packages.pyannote-pipeline: format with nixfmt
* [`3a7e9c14`](https://github.com/NixOS/nixpkgs/commit/3a7e9c14821c87bb56203ed69e2b7612ebbf0737) kodiPackages.visualization-projectm: 20.2.0 -> 21.0.1
* [`a023d61f`](https://github.com/NixOS/nixpkgs/commit/a023d61fdbc12fcc4d8a2e45ce8981195635f2d5) signalbackup-tools: 20240506 -> 20240509-1
* [`228c11d0`](https://github.com/NixOS/nixpkgs/commit/228c11d09df9ad4bc968d7e5b0dc7d2972360e64) odin: fix patches for darwin
* [`16589d35`](https://github.com/NixOS/nixpkgs/commit/16589d357def7a11fab186d5a92f0fca0f759897) maintainers: add fangpen
* [`fb17e8b1`](https://github.com/NixOS/nixpkgs/commit/fb17e8b1d4d1b4cc7e2701a789b52a51e77ae3be) kokkos: 4.3.00 -> 4.3.01
* [`d95cd83e`](https://github.com/NixOS/nixpkgs/commit/d95cd83e5bf0fc1b65a511d69e032a9421c52978) python311Packages.waybackpy: init at 3.0.6
* [`d796bb97`](https://github.com/NixOS/nixpkgs/commit/d796bb97aa9bcb8dc8e90e14fdb9c0946b32bf8f) anyk: 3.26.0 -> 3.33.0
* [`53c2fa78`](https://github.com/NixOS/nixpkgs/commit/53c2fa78f091be3223c9a510ee29912c752c2e03) python311Packages.imgtool: 2.0.0 -> 2.1.0
* [`f1876e3d`](https://github.com/NixOS/nixpkgs/commit/f1876e3d73415aa0334f4bcee7e5416986526734) python311Packages.plantuml-markdown: 3.9.6 -> 3.9.7
* [`dff3c958`](https://github.com/NixOS/nixpkgs/commit/dff3c958a5e521e11f27e5e27813caa031722f06) rqlite: 8.24.1 -> 8.24.7
* [`ede69094`](https://github.com/NixOS/nixpkgs/commit/ede69094b3f98cbb1ef1311749a058deb7de68d3) spicetify-cli: 2.36.10 -> 2.36.11
* [`b3835300`](https://github.com/NixOS/nixpkgs/commit/b3835300f265616532c8754799a5796af09253fd) nixVersions.latest: 2.22.0 -> 2.22.1
* [`50dbda37`](https://github.com/NixOS/nixpkgs/commit/50dbda375ae5c49d110648f154c1f5d1514640c2) ffmpegthumbnailer: refactor code with nixfmt
* [`f6f7014c`](https://github.com/NixOS/nixpkgs/commit/f6f7014ce43ae087c01e4dc9316c3f22d485347c) ffmpegthumbnailer: unstable-2022-02-18 -> unstable-2024-01-04
* [`11a75884`](https://github.com/NixOS/nixpkgs/commit/11a75884338700ef39c243abfcb0654205e48d1c) streamlink: 6.7.3 -> 6.7.4
* [`153afc96`](https://github.com/NixOS/nixpkgs/commit/153afc9602578f141e135e45a429fec464848c74) throttled: use small GApps wrapper
* [`659d66c6`](https://github.com/NixOS/nixpkgs/commit/659d66c68bc5b58947d777b8622dd7dbba83773f) rectangle: 0.77 -> 0.79
* [`4fe67312`](https://github.com/NixOS/nixpkgs/commit/4fe673128bebf630bd6963154386fe0ab982591d) cnquery: 11.2.0 -> 11.3.1
* [`f0e4ac03`](https://github.com/NixOS/nixpkgs/commit/f0e4ac034a63b5b90c5857a03626009ba83441ab) nodeinfo: init at 0.3.2
* [`cc814582`](https://github.com/NixOS/nixpkgs/commit/cc814582139b04747459dfa2746bd0421f495df8) adwsteamgtk: 0.6.10 -> 0.6.11
* [`fa736d73`](https://github.com/NixOS/nixpkgs/commit/fa736d735114d7babe807639f22c1746021f71a3) jackett: 0.21.2496 -> 0.21.2586
* [`511fa9d6`](https://github.com/NixOS/nixpkgs/commit/511fa9d63daca0d2e73d7bbfeeeabb550d850743) python311Packages.dogpile-cache: 1.3.2 -> 1.3.3
* [`cbe462d0`](https://github.com/NixOS/nixpkgs/commit/cbe462d0723a598dc87f0adb6dfff1e0f556a4f9) fontbakery: 0.12.2 -> 0.12.5
* [`68e1d7b2`](https://github.com/NixOS/nixpkgs/commit/68e1d7b2aa40c2b988ce56c03e64d4d7ec4cda40) go-musicfox: 4.3.3 -> 4.4.0
* [`51887265`](https://github.com/NixOS/nixpkgs/commit/5188726544f15302a59f575816c5408b102991a2) python3Packages.pxml: remove
* [`20eff53a`](https://github.com/NixOS/nixpkgs/commit/20eff53a0a23c8e3e8d54ec2253abc218d735ab2) python3Packages.cadquery: remove
* [`d6334e81`](https://github.com/NixOS/nixpkgs/commit/d6334e819ca065b8b07b0aa1d305436d4b34cb36) python3Packages.globre: remove
* [`e82979d6`](https://github.com/NixOS/nixpkgs/commit/e82979d6f7c46b7577ad402971e0d8295e297950) python3Packages.cryptacular: remove
* [`08949784`](https://github.com/NixOS/nixpkgs/commit/08949784fb900bab114b049047b31129799457a4) python3Packages.pathlib: remove
* [`11bfb37f`](https://github.com/NixOS/nixpkgs/commit/11bfb37f0d8dad64b205939ee9e2db2fafdd5bb1) python311Packages.sphinxcontrib-confluencebuilder: 2.5.1 -> 2.5.2
* [`3167a2a6`](https://github.com/NixOS/nixpkgs/commit/3167a2a6efb0784088e5b9990f2c6aeaa459963b) python311Packages.apprise: disable nondeterministic tests
* [`b1e8ff61`](https://github.com/NixOS/nixpkgs/commit/b1e8ff61785d8a447f6dc429c5aaa7b34d65dde3) python311Packages.apprise: modernize
* [`ef91aa44`](https://github.com/NixOS/nixpkgs/commit/ef91aa449e076b802dc18740e72f04c0c7ee1f84) python311Packages.apprise: adopt
* [`d283c135`](https://github.com/NixOS/nixpkgs/commit/d283c135bc42434c9afdde7a5256b7d8bee5a44b) python3Packages.qtile: add sigmanificient in maintainers
* [`2d8cfea9`](https://github.com/NixOS/nixpkgs/commit/2d8cfea95d5122d7776f0663c20bb4920e3ebe50) bevelbar: move to by-name
* [`eaaf17a9`](https://github.com/NixOS/nixpkgs/commit/eaaf17a9e038a872a3e9b5cc06648395fc835e31) python311Packages.py-synologydsm-api: 2.4.2 -> 2.4.3
* [`a6326e27`](https://github.com/NixOS/nixpkgs/commit/a6326e273ba90eba32bc2f736b2cd2f33930b6f5) bevelbar: format with nixfmt and remove `with lib;`
* [`dca280c9`](https://github.com/NixOS/nixpkgs/commit/dca280c9ca8349143e5f5a28b54140befc1b1dc6) bevelbar: add updateScript
* [`82e96764`](https://github.com/NixOS/nixpkgs/commit/82e9676428133f468bed082055ca3e9a2dc1023b) bevelbar: 22.06 -> 23.08
* [`5c81e2c4`](https://github.com/NixOS/nixpkgs/commit/5c81e2c45b9427223a2853e18a0cab6a153c7e50)  pyload-ng: 0.5.0b3.dev80 -> 0.5.0b3.dev85
* [`f6281ebf`](https://github.com/NixOS/nixpkgs/commit/f6281ebf9a4aa4037429a6bd34f380f8d74b5b61) acr: 2.1.2 -> 2.1.4
* [`99ecfc12`](https://github.com/NixOS/nixpkgs/commit/99ecfc12a0bd3c468068b3676f12b2c610204b3f) glance: 0.3.0 -> 0.4.0
* [`100dcc55`](https://github.com/NixOS/nixpkgs/commit/100dcc553be28f7a8a5cf82aa1638b6accc654da) python311Packages.osc-sdk-python: 0.27.0 -> 0.29.0
* [`943bca52`](https://github.com/NixOS/nixpkgs/commit/943bca52eca79a67bac1268369692da052529cc1) megapixels: 1.8.1 -> 1.8.2
* [`868cc3f7`](https://github.com/NixOS/nixpkgs/commit/868cc3f77f62f8dfc2e074f620fe2bb0a1882fdf) katriawm: format with nixfmt
* [`d57ce05c`](https://github.com/NixOS/nixpkgs/commit/d57ce05c498d239b8f28df310688ce79393ce629) katriawm: add updateScript
* [`09bc20ed`](https://github.com/NixOS/nixpkgs/commit/09bc20ed991ffe499d4fd711051227fc1f236ed4) chezmoi: 2.48.0 -> 2.48.1
* [`979596d8`](https://github.com/NixOS/nixpkgs/commit/979596d8e48be31ccd4efab129b1726d1cfd57c2) colloid-gtk-theme: 2024-04-14 -> 2024-05-13
* [`55661b78`](https://github.com/NixOS/nixpkgs/commit/55661b782be9150038c5063e34e4c299fa2535e4) catppuccin-sddm-corners: unstable-2023-05-30 -> 0-unstable-2024-05-07
* [`cf075f41`](https://github.com/NixOS/nixpkgs/commit/cf075f41ea5bde7afa08c4023503e2a1aa5d89d0) hishtory: 0.293 -> 0.294
* [`2d39d770`](https://github.com/NixOS/nixpkgs/commit/2d39d7708d608f8b29b23fd7ddb793933627a4c0) wttrbar: 0.9.4 -> 0.10.1
* [`87485af9`](https://github.com/NixOS/nixpkgs/commit/87485af904057a1f6a70750712853432f8aaf077) kor: 0.3.8 -> 0.4.0
* [`639bdd59`](https://github.com/NixOS/nixpkgs/commit/639bdd598816a0c483ae2a1f82a79a40496c9985) mpvpaper: 1.5 -> 1.6
* [`958ff50d`](https://github.com/NixOS/nixpkgs/commit/958ff50da9f531d606fcd35a723576c418215105) openspecfun: 0.5.6 -> 0.5.7
* [`afa11c82`](https://github.com/NixOS/nixpkgs/commit/afa11c824b219e86b7d43c5539d155a0a245b6a3) cloudlog: 2.6.10 -> 2.6.11
* [`36d4c3bb`](https://github.com/NixOS/nixpkgs/commit/36d4c3bbc3feb8db00fc825bda1ca1ab63d32728) mysql-shell: 8.0.36 -> 8.0.37
* [`a5d08f11`](https://github.com/NixOS/nixpkgs/commit/a5d08f1184c30eb28a9f32dad475391e058ce168) eigenmath: 0-unstable-2024-05-03 -> 0-unstable-2024-05-12
* [`8cbbeae8`](https://github.com/NixOS/nixpkgs/commit/8cbbeae8d55738a75f01dc26f2376e453fb03613) octavePackages.ga: 0.10.3 -> 0.10.4
* [`051021c5`](https://github.com/NixOS/nixpkgs/commit/051021c597aa07065b66b478c9f7ff44c5b3d9d1) chirp: 0.4.0-unstable-2024-05-03 -> 0.4.0-unstable-2024-05-10
* [`41356ebb`](https://github.com/NixOS/nixpkgs/commit/41356ebb1ebe6aa72d069271960cbb4ddb5f68e7) python311Packages.griffe: 0.44.0 -> 0.45.0
* [`a7b2fb00`](https://github.com/NixOS/nixpkgs/commit/a7b2fb008eaadf5a4f3dc1f0facf6523e65fe56b) electrum-ltc: apply aiorpcX version bump patch
* [`3a86eb9e`](https://github.com/NixOS/nixpkgs/commit/3a86eb9e05df6f40788280abe126bb64ec4092e4) zsh-fzf-tab: 1.1.1 -> 1.1.2
* [`5e1c7cca`](https://github.com/NixOS/nixpkgs/commit/5e1c7cca0f119f14c899b059ccac774c156a7716) wpsoffice: add proxyImpureEnvVars to src fetcher
* [`6c0d9ddc`](https://github.com/NixOS/nixpkgs/commit/6c0d9ddc37ed7a6fdce9db6a7fd0bf5edd62f93a) sqlite3-to-mysql: 2.1.9 -> 2.1.10
* [`9ed7e32d`](https://github.com/NixOS/nixpkgs/commit/9ed7e32d10fda06f8af8bdabe288edb90389f523) python3Packages.pipdeptree: Fix ModuleNotFoundError
* [`95b53749`](https://github.com/NixOS/nixpkgs/commit/95b537491810a763fe1432ba8486b87a5419e904) sarasa-gothic: 1.0.11 -> 1.0.12
* [`e57a0596`](https://github.com/NixOS/nixpkgs/commit/e57a05965bea349343e72b396cb438f6249666f1) python311Packages.langchain: 0.1.16 -> 0.1.52
* [`5f333c1d`](https://github.com/NixOS/nixpkgs/commit/5f333c1d4a5c9c1048286f25fa95525a33e6af67) ttyplot: 1.6.2 -> 1.6.4
* [`383a61e8`](https://github.com/NixOS/nixpkgs/commit/383a61e88801c3fd76e53107349dd1deeb95a7c6) twitch-tui: 2.6.7 -> 2.6.8
* [`17011717`](https://github.com/NixOS/nixpkgs/commit/170117170ade927f2388ef78c506322520c5af92) wazero: 1.7.1 -> 1.7.2
* [`2cc3b4ed`](https://github.com/NixOS/nixpkgs/commit/2cc3b4ed74f7e7474621c8cd7bf1437d9eb5fdc3) tui-journal: 0.8.3 -> 0.8.4
* [`428378f6`](https://github.com/NixOS/nixpkgs/commit/428378f6fc5c3640e9b6a37a7169783ee47dcbca) microsoft-edge: 124.0.2478.80 -> 124.0.2478.97
* [`796bf41d`](https://github.com/NixOS/nixpkgs/commit/796bf41d6cbcc0d09b1ed692fb5759e6228225d6) bitcoin-knots: 25.1.knots20231115 -> 26.1.knots20240325
* [`fb331042`](https://github.com/NixOS/nixpkgs/commit/fb331042de467a7d7450f122c221cbcd3d73beac) semgrep: 1.71.0 -> 1.72.0
* [`1ead048b`](https://github.com/NixOS/nixpkgs/commit/1ead048b1d181b4587941aa5919c3ae45ab68750) bitcoin-knots: disable BDB for darwin
* [`4a513845`](https://github.com/NixOS/nixpkgs/commit/4a5138455ce3e60edb49199146d9c5ecfdb9c665) dracula-theme: 4.0.0-unstable-2024-04-24 -> 4.0.0-unstable-2024-05-12
* [`d12a7641`](https://github.com/NixOS/nixpkgs/commit/d12a76414f78901f108b48b2ed61ad6cdc08e103) minecraft-server: 1.20.5 -> 1.20.6
* [`36b19053`](https://github.com/NixOS/nixpkgs/commit/36b190536dd009806eeab6fe0e3fea97a08b4be0) smartgithg: 23.1.2 -> 23.1.3
* [`435a273f`](https://github.com/NixOS/nixpkgs/commit/435a273fbb4ea9318be987d6a44af8a049ab0d03) ocamlPackages.pecu: 0.6 → 0.7
* [`b23e278c`](https://github.com/NixOS/nixpkgs/commit/b23e278cb38e1435238f5fde6834f94a92938a74) kdePackages.kirigami: 6.2.0 -> 6.2.1
* [`e526629d`](https://github.com/NixOS/nixpkgs/commit/e526629d759949faea584911171a4e1c71f9cc60) kdePackages.kdeconnect-kde: hardcode sshfs path
* [`dd85e24e`](https://github.com/NixOS/nixpkgs/commit/dd85e24ecd2175600a53d6d0d2508dbc3afe4fb4) sublime-music: unpin dependencies, fix build
* [`68f07ded`](https://github.com/NixOS/nixpkgs/commit/68f07ded7302ffa0d611a2af62dbbb6e9129a8b2) ocamlPackages.unstrctrd: 0.3 → 0.4
* [`6d249cae`](https://github.com/NixOS/nixpkgs/commit/6d249cae653406d41fd94cd4a5c99888e400cdd0) linux_6_9: init at 6.9
* [`9a907c13`](https://github.com/NixOS/nixpkgs/commit/9a907c13afddceb3737ad6433b205b7612504d60) python311Packages.unstructured: 0.13.4 -> 0.13.7
* [`88647a00`](https://github.com/NixOS/nixpkgs/commit/88647a007490a4a91aef07fc7b39cb70033f3406) home-assistant-custom-components.tuya_local: init at 2024.5.2
* [`65bfaad3`](https://github.com/NixOS/nixpkgs/commit/65bfaad3cc771a1c6b34cf34f55a253495949e0f) ocamlPackages.odoc: 2.2.1 → 2.4.2
* [`95c22c71`](https://github.com/NixOS/nixpkgs/commit/95c22c71b0ec5c87361f07f0f1706cdf2bae64c0) nicotine-plus: 3.3.2 -> 3.3.4
* [`5c6c8118`](https://github.com/NixOS/nixpkgs/commit/5c6c8118096730ecd8d157b90230c0f18bd89503) python311Packages.pynws: 1.7.0 -> 1.8.0
* [`e8cec63e`](https://github.com/NixOS/nixpkgs/commit/e8cec63ebf1a8ad613329dec1f3f3166d049fed1) ocamlPackages.eliom: 10.3.1 → 10.4.1
* [`c2a88a1c`](https://github.com/NixOS/nixpkgs/commit/c2a88a1c0e615b2cbe011ae9e449673dbf5877cd) libui-ng: 4.1-unstable-2024-02-05 -> 4.1-unstable-2024-05-03
* [`026247df`](https://github.com/NixOS/nixpkgs/commit/026247dfbab6d231f2dce79a5c648d97307c5a41) python312Packages.unittest-xml-reporting: disable failing test
* [`2397b818`](https://github.com/NixOS/nixpkgs/commit/2397b818ef296d87d1b39b0c806d482ddcc1d607) pinocchio: 2.7.0 -> 2.7.1
* [`a010f5e9`](https://github.com/NixOS/nixpkgs/commit/a010f5e9c5018c90c53fd0b948f8115a47d3dc22) jellyfin-web: 10.8.13 -> 10.9.1
* [`a937d575`](https://github.com/NixOS/nixpkgs/commit/a937d575a2747b74ddd7e679ce88a9cbb5598c19) jellyfin: 10.8.13 -> 10.9.1
* [`f7c2ec5d`](https://github.com/NixOS/nixpkgs/commit/f7c2ec5d307f487663e185bd7349130ee7ca4acf) blackfire: 2.27.0 -> 2.28.1
* [`6924256d`](https://github.com/NixOS/nixpkgs/commit/6924256de0429055ce49223b5864b6dbb350812f) python312Packages.dj-rest-auth: 5.0.2 -> 6.0.0
* [`1f7e33d7`](https://github.com/NixOS/nixpkgs/commit/1f7e33d7095202c917860c26db664f97016f3b63) python311Packages.globus-sdk: 3.39.0 -> 3.41.0
* [`f3bf21db`](https://github.com/NixOS/nixpkgs/commit/f3bf21db324845079a6d415c144efd8ebf4045b6) python312Packages.unittest-xml-reporting: format with nixfmt
* [`396d7e2e`](https://github.com/NixOS/nixpkgs/commit/396d7e2e1921c3bb1a28dbf708d27395241c3396) pinocchio: patch for example-robot-data models
* [`5c1d3a46`](https://github.com/NixOS/nixpkgs/commit/5c1d3a46c851fe567111b6c1eff3a4b95884be89) python312Packages.dj-rest-auth: format with nixfmt
* [`fa334d69`](https://github.com/NixOS/nixpkgs/commit/fa334d6946edaa5487d4d2bc34f2901461ca9ea5) pinocchio: remove "with lib;"
* [`b74bbe88`](https://github.com/NixOS/nixpkgs/commit/b74bbe882117ec3e5cec8adaa3a8d0403bc3f94c) python312Packages.drf-spectacular: refactor
* [`9dae30d6`](https://github.com/NixOS/nixpkgs/commit/9dae30d67f2800c5e3b155219f51a5d389bc8b86) python312Packages.drf-spectacular: 0.27.1 -> 0.27.2
* [`aa64bb27`](https://github.com/NixOS/nixpkgs/commit/aa64bb27bab9ec06de96d92a41dbeafc8e4d732f) nixos/garage: add assertion for replication_factor
* [`a966d523`](https://github.com/NixOS/nixpkgs/commit/a966d523d947976e9e3975e56420fa2b251875f2) python312Packages.drf-spectacular: format with nixfmt
* [`fa8184dd`](https://github.com/NixOS/nixpkgs/commit/fa8184ddcbb52042464f73d56bdb4d5a5c4571c3) httpie-desktop: init at 2024.1.2 ([nixos/nixpkgs⁠#311163](https://togithub.com/nixos/nixpkgs/issues/311163))
* [`b2699dee`](https://github.com/NixOS/nixpkgs/commit/b2699dee1859095be18891e76e7d03ff18fd765d) rHttp: init at unstable-2024-04-28 ([nixos/nixpkgs⁠#311116](https://togithub.com/nixos/nixpkgs/issues/311116))
* [`c59a9d29`](https://github.com/NixOS/nixpkgs/commit/c59a9d297be9c5f1b86877d57499cd7b309f64ae) hyprland-activewindow: 1.0.2 -> 1.0.3 ([nixos/nixpkgs⁠#310874](https://togithub.com/nixos/nixpkgs/issues/310874))
* [`0755c031`](https://github.com/NixOS/nixpkgs/commit/0755c03103ff270fec105c352a45b876f4e86c3f) python311Packages.rotary-embedding-torch: 0.5.3 -> 0.6.1
* [`0fa8227b`](https://github.com/NixOS/nixpkgs/commit/0fa8227be481c8ff75646df3e5a087e04d8da9b1) pkgsStatic.systemd: don't mark broken
* [`6e18225c`](https://github.com/NixOS/nixpkgs/commit/6e18225ca66ec05459b69f0db79410891757bd75) xdg-terminal-exec-mkhl: init at 0.2.0 ([nixos/nixpkgs⁠#310740](https://togithub.com/nixos/nixpkgs/issues/310740))
* [`2ec060b9`](https://github.com/NixOS/nixpkgs/commit/2ec060b94ebd81598603bb5ea49455e255928f9c) nixos/zsh: remove `lib.lib`
* [`9d4c60c0`](https://github.com/NixOS/nixpkgs/commit/9d4c60c01999b240fbc0109bb9286e212d8bbbdc) pkgsStatic.pcsclite: fix build
* [`4705b6bc`](https://github.com/NixOS/nixpkgs/commit/4705b6bc235a9e5ee4fe0ae08779c5aeabcea0e3) pkgsStatic.networkmanager: mark unsupported
* [`20ca4f55`](https://github.com/NixOS/nixpkgs/commit/20ca4f5529ed66eafe661b66ef28265406890399) doc: fix meta.badPlatforms example
* [`6b2dd148`](https://github.com/NixOS/nixpkgs/commit/6b2dd148f885f6ac9e7962435481d5274b717d10) webrtc-audio-processing: fix URL in comment
* [`101e8a0a`](https://github.com/NixOS/nixpkgs/commit/101e8a0a2b2eecc11c0977e6cace10fd4a5febfd) pgvecto-rs: mark as broken in pg12 and pg13
* [`6b9924ce`](https://github.com/NixOS/nixpkgs/commit/6b9924ced21119083450331731279d3fb778e390) alacarte: init at 3.52.0 ([nixos/nixpkgs⁠#310442](https://togithub.com/nixos/nixpkgs/issues/310442))
* [`fee1c308`](https://github.com/NixOS/nixpkgs/commit/fee1c3082320ffee452a3d01a4da986fdc551e89) onagre: 1.0.0-alpha.0 -> 1.1.0
* [`7be23ec0`](https://github.com/NixOS/nixpkgs/commit/7be23ec058c826715a64d0c28bfb78d56f401542) Revert "libeatmydata: patch out LFS64 usage"
* [`a9218624`](https://github.com/NixOS/nixpkgs/commit/a92186244b92d3d0866562d8e1328e57fed7970b) python3Packages.gguf: init at 0.6.0 ([nixos/nixpkgs⁠#311060](https://togithub.com/nixos/nixpkgs/issues/311060))
* [`24cf8c3e`](https://github.com/NixOS/nixpkgs/commit/24cf8c3e9e41408157e933f5b436b38c4e861e50) renode-dts2repl: 0-unstable-2024-04-30 -> 0-unstable-2024-05-09
* [`05a032a7`](https://github.com/NixOS/nixpkgs/commit/05a032a728ced350e7aa93a7273fce4fc4493c2e) komikku: 1.45.1 -> 1.46.0
* [`9545c7e6`](https://github.com/NixOS/nixpkgs/commit/9545c7e6a04ad468298d2e41da37d52215c3cd42) python311Packages.augmax: switch to fetchFromGitHub
* [`d60ffedd`](https://github.com/NixOS/nixpkgs/commit/d60ffedd118ed6930f4becd10db06d6111667e27) retrospy: fix icon resolution ([nixos/nixpkgs⁠#311127](https://togithub.com/nixos/nixpkgs/issues/311127))
* [`df269771`](https://github.com/NixOS/nixpkgs/commit/df26977114cf64ddeec13f6d6227b276ee1f0e1e) pkgsStatic.sox: fix
* [`6dfc689e`](https://github.com/NixOS/nixpkgs/commit/6dfc689e95f2085bac2ac9c949ccfd5ce4b639ec) cinny: fix build on x86_64-darwin
* [`12ff1d15`](https://github.com/NixOS/nixpkgs/commit/12ff1d1517692f501a5a0dea650371dab306ae88) checkov: 3.2.90 -> 3.2.91
* [`24da8cfa`](https://github.com/NixOS/nixpkgs/commit/24da8cfa913385c13f65592eb6cd24efd2a87c06) whisper-ctranslate2: 0.4.2 -> 0.4.3
* [`3f385ad9`](https://github.com/NixOS/nixpkgs/commit/3f385ad906f32dff57657b8eaf8d191956902892) fsautocomplete: 0.71.0 -> 0.72.3 ([nixos/nixpkgs⁠#309967](https://togithub.com/nixos/nixpkgs/issues/309967))
* [`c375149d`](https://github.com/NixOS/nixpkgs/commit/c375149dd1f50507457e922f8a101c597efb284b) glib: disable introspection for cross-endian
* [`5a37ed1b`](https://github.com/NixOS/nixpkgs/commit/5a37ed1bc009242796de4f206aeb6e2faf5dff2c) keto: init at 0.13.0-alpha.0
* [`6024fafb`](https://github.com/NixOS/nixpkgs/commit/6024fafb6c486986add3dad0c0a70983e63430ac) python312Packages.pynws: add changelog to meta
* [`a28ee491`](https://github.com/NixOS/nixpkgs/commit/a28ee4912ccb722cfb44fb8c31cee4e7c52e7e13) maintainers: update email for michaelpj
* [`c3c7c331`](https://github.com/NixOS/nixpkgs/commit/c3c7c331348827f904e1f62db85c539fff2258e9) throttled: remove michaelpj as maintainer
* [`bf5bec15`](https://github.com/NixOS/nixpkgs/commit/bf5bec1538289c65d5722e38215f860aa4d44202) arbtt: remove michaeplj as maintainer
* [`e8771cc3`](https://github.com/NixOS/nixpkgs/commit/e8771cc3c74de4d06f60c09272a1c5c6b558c7d5) heatseeker: remove michaelpj as maintainer
* [`cd981c1c`](https://github.com/NixOS/nixpkgs/commit/cd981c1cc61b588a688e54879ee9ec0fd65945bc) tzupdate: remove michaelpj as maintainer
* [`7321c7cb`](https://github.com/NixOS/nixpkgs/commit/7321c7cb6f8631dc2ab7e17cf94e028f347b064a) onagre: moved to pkgs/by-name
* [`bdf0c96d`](https://github.com/NixOS/nixpkgs/commit/bdf0c96d386b2ca539bb32cda43317c4b05b3ce0) google-cloud-sdk: reduce closure size when using extra components
* [`969eb3b1`](https://github.com/NixOS/nixpkgs/commit/969eb3b16acf62e8f81afbf0336629420834f77d) mkvtoolnix: patch to build on Darwin & FreeBSD ([nixos/nixpkgs⁠#311133](https://togithub.com/nixos/nixpkgs/issues/311133))
* [`b734aa61`](https://github.com/NixOS/nixpkgs/commit/b734aa61461b9a2f7b9c571a44d04ef3e73a5bef) mise: 2024.5.2 -> 2024.5.9
* [`aac3aeaf`](https://github.com/NixOS/nixpkgs/commit/aac3aeaf2ff230af121534e26262feb6428214ff) symbolic-preview: 0.0.3 -> 0.0.9
* [`52e0ad74`](https://github.com/NixOS/nixpkgs/commit/52e0ad744d55f92d0127173d9859aca2d7609944) nixos/devpi-server: init
* [`41efcb97`](https://github.com/NixOS/nixpkgs/commit/41efcb97ef14cbade22bb9a74b830b1daaa0bcd0) treefmt: move to pkgs/by-name
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
