### PR TITLE
niv home-manager: update 44677a1c -> e3ad5108

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -41,10 +41,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "44677a1c96810a8e8c4ffaeaad10c842402647c1",
-        "sha256": "0bhwgi7mjrngv1fyv8cl0iwqkn1al7dj65rbw1b6wffrq776x572",
+        "rev": "e3ad5108f54177e6520535768ddbf1e6af54b59d",
+        "sha256": "1cp8p31yg8lzma6hydc0qzgd4l7a919cxvgigmmzqy7ggwrp5njv",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/44677a1c96810a8e8c4ffaeaad10c842402647c1.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/e3ad5108f54177e6520535768ddbf1e6af54b59d.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@44677a1c...e3ad5108](https://github.com/nix-community/home-manager/compare/44677a1c96810a8e8c4ffaeaad10c842402647c1...e3ad5108f54177e6520535768ddbf1e6af54b59d)

* [`65b74b20`](https://github.com/nix-community/home-manager/commit/65b74b20450cd54fc6389b43ec7c7e6e58630370) espanso: add n8henrie to maintainers
* [`e3ad5108`](https://github.com/nix-community/home-manager/commit/e3ad5108f54177e6520535768ddbf1e6af54b59d) espanso: remove `background` process type on Darwin
