### PR TITLE
niv niv: update 04c1cec1 -> 5f0defe2

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -89,10 +89,10 @@
         "homepage": "https://github.com/nmattia/niv",
         "owner": "nmattia",
         "repo": "niv",
-        "rev": "04c1cec14801d2b18fc1a771cf40cec249cb8670",
-        "sha256": "1xl4mni4az9wiwq3ygk0f53gwkjw5pnfgrl69r5vwji2jqc96a11",
+        "rev": "5f0defe2f71020812e39a51dab68a64fb293ace1",
+        "sha256": "12wscam2163pirzbmz0pw6cmnn6xa0dy8ax5kxi5bgxcp728vxyd",
         "type": "tarball",
-        "url": "https://github.com/nmattia/niv/archive/04c1cec14801d2b18fc1a771cf40cec249cb8670.tar.gz",
+        "url": "https://github.com/nmattia/niv/archive/5f0defe2f71020812e39a51dab68a64fb293ace1.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {


### PR DESCRIPTION
## Changelog for niv:
Branch: master
Commits: [nmattia/niv@04c1cec1...5f0defe2](https://github.com/nmattia/niv/compare/04c1cec14801d2b18fc1a771cf40cec249cb8670...5f0defe2f71020812e39a51dab68a64fb293ace1)

* [`5f0defe2`](https://github.com/nmattia/niv/commit/5f0defe2f71020812e39a51dab68a64fb293ace1) Bump cachix/install-nix-action from 26 to 27 ([nmattia/niv⁠#400](https://togithub.com/nmattia/niv/issues/400))
