### PR TITLE
niv nixpkgs: update 4cd4ad24 -> 9ca3f649

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4cd4ad242e70fa4475a9c10eeed87cbada8639dc",
-        "sha256": "11jgj2w82jwl15fp5g4phgsg50mmcgcaq8cf2i1js0kra49lk5h6",
+        "rev": "9ca3f649614213b2aaf5f1e16ec06952fe4c2632",
+        "sha256": "1753bcq3c30fd570jllkya3v5wqb8zibf840sdsfghw1jmpw6igc",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/4cd4ad242e70fa4475a9c10eeed87cbada8639dc.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/9ca3f649614213b2aaf5f1e16ec06952fe4c2632.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@4cd4ad24...9ca3f649](https://github.com/nixos/nixpkgs/compare/4cd4ad242e70fa4475a9c10eeed87cbada8639dc...9ca3f649614213b2aaf5f1e16ec06952fe4c2632)

* [`2903f85f`](https://github.com/NixOS/nixpkgs/commit/2903f85f5d18725aa93cc017b9b1d29031a6bc9d) maintainers: Add johnjohnstone
* [`ab3f8547`](https://github.com/NixOS/nixpkgs/commit/ab3f8547cbddc167abe1be7092d3a531d7e9f28c) bzip2: update patch URL
* [`4bdb997e`](https://github.com/NixOS/nixpkgs/commit/4bdb997e48ae014b1c078d9ccfd2229714dd05f3) streamrip: init at 2.0.5
* [`e339f0a1`](https://github.com/NixOS/nixpkgs/commit/e339f0a1fbf7463ca9d11d9878c01a5efd9957b8) nixos/systemd-sysusers: make uid/gid allocation stable
* [`16f713d5`](https://github.com/NixOS/nixpkgs/commit/16f713d5378c582b87cc0aaf64b99d39a8b99334) rhash: Support FreeBSD by adding unreleased patches
* [`2422a655`](https://github.com/NixOS/nixpkgs/commit/2422a6553991263c9a5fffec4f38ea6986ee61d9) astartectl: 23.5.0 -> 23.5.1
* [`6ce6559a`](https://github.com/NixOS/nixpkgs/commit/6ce6559ad89a385fb99a1973914351793ed1f112) polkit: upstream moved to github
* [`5ea359c8`](https://github.com/NixOS/nixpkgs/commit/5ea359c878c6f82ed9cbcd510aaee8d23d528de0) polkit: 123 -> 124
* [`8c3a2b0a`](https://github.com/NixOS/nixpkgs/commit/8c3a2b0a104fe7af24901c7bc7970c606c9abbae) nixos/portunus: add note about allowed characters to id
* [`4b8fa41e`](https://github.com/NixOS/nixpkgs/commit/4b8fa41e8346f39387fd49538153944c59b4a444) polkit: move patch from archived upstream to local
* [`fe516ada`](https://github.com/NixOS/nixpkgs/commit/fe516ada1d74e6af0d3b8a9feb20b6f97c03bd6e) gcs: format with nixfmt
* [`4903f64b`](https://github.com/NixOS/nixpkgs/commit/4903f64bcddf766edf72fbc9f496e95a8e59f0ba) gcs: 5.20.4 -> 5.21.0
* [`0d015895`](https://github.com/NixOS/nixpkgs/commit/0d015895debd63b937f1b3ee10cb3a73aa180a8f) nixos/test-driver: separate the subtest log call
* [`c2c525f5`](https://github.com/NixOS/nixpkgs/commit/c2c525f5bcf44918f43b00f8424c30b56f1ac73b) nixos/test-driver: add junit-xml python package
* [`a6160e57`](https://github.com/NixOS/nixpkgs/commit/a6160e576347358db79071cf2e4ee5dc623ce7ec) nixos/test-driver: use function instead of var
* [`b8abbbf7`](https://github.com/NixOS/nixpkgs/commit/b8abbbf7b3d8ef72b84bdfaa8369c1694c8655c6) tdlib: 1.8.27 -> 1.8.28
* [`001ed295`](https://github.com/NixOS/nixpkgs/commit/001ed29519b178e4c0b8add95998eede4bc46492) dbd: init at 1.50-unstable-2016-01-04
* [`d69d444f`](https://github.com/NixOS/nixpkgs/commit/d69d444fe1d1628782a911820fd8d17c2b7906e9) rPackages.immunotation: cache external URLs
* [`21833407`](https://github.com/NixOS/nixpkgs/commit/21833407b4364b7266a1b234d06182f655ec6cb7) pythonCatchConflictsHook: add test for multiple dependency chains
* [`a25e43e6`](https://github.com/NixOS/nixpkgs/commit/a25e43e6d7089d4655f945c9874bd6756fbb5c90) pythonCatchConflictsHook: prevent exponential worst-case
* [`7f14d675`](https://github.com/NixOS/nixpkgs/commit/7f14d675a7e1e2bdef3c9c1b6f83c42474715e51) pythonCatchConflictsHook: cleanup due to visiting each path once
* [`f9de72f2`](https://github.com/NixOS/nixpkgs/commit/f9de72f24776538e7e2243f54ab46f3e3a921ab5) pythonCatchConflictsHook: split propagated-build-inputs on runs of whitespace
* [`58b98e9a`](https://github.com/NixOS/nixpkgs/commit/58b98e9a2541a0d031971c53ba7ac27f60ab0468) windows.mcfgthreads_pre_gcc_13: drop
* [`e4de1c0b`](https://github.com/NixOS/nixpkgs/commit/e4de1c0b19fd9a968b306a5bab27f2245773e57e) nixos/bitwarden-directory-connector-cli: add wants network-online.target
* [`69e0abf2`](https://github.com/NixOS/nixpkgs/commit/69e0abf2d1ca3c7ce208a86c8ca0283ac886c289) mlt: Use selected version of ffmpeg for all dependencies
* [`fa232f0a`](https://github.com/NixOS/nixpkgs/commit/fa232f0a93620de50e14724c5f13b71ff2df4eb3) matio: 1.5.26 -> 1.5.27
* [`fb0ddd91`](https://github.com/NixOS/nixpkgs/commit/fb0ddd9186170fe297e2274c01ee410d79874f9f) libcamera: fix binary reproduciblity
* [`8654c882`](https://github.com/NixOS/nixpkgs/commit/8654c88213707b05eac130295f856b0c94c72015) python312Packages.rich-click: 1.7.4 -> 1.8.0
* [`2c423560`](https://github.com/NixOS/nixpkgs/commit/2c42356012257af72ba9069e47c830034d98fca8) python312Packages.rich-click: refactor
* [`6c41cbcd`](https://github.com/NixOS/nixpkgs/commit/6c41cbcd5729b9dbad8d2832f180e54906fee5c1) python312Packages.rich-click: format with nixfmt
* [`c6bd08a2`](https://github.com/NixOS/nixpkgs/commit/c6bd08a21101ac5f1ad4b4a3b5a96530ed595177) python311Packages.sparklines: 0.4.2 -> 0.5.0
* [`068981b8`](https://github.com/NixOS/nixpkgs/commit/068981b87b1de8dc60911bf1f857d91e13f77abe) libpkgconf: 2.1.1 -> 2.2.0
* [`0293a353`](https://github.com/NixOS/nixpkgs/commit/0293a353ee6de952cb9c5449c91912d86b200509) apple-source-releases: always use python3Minimal
* [`5d66721a`](https://github.com/NixOS/nixpkgs/commit/5d66721a92942592fb52639460079f3aa344502a) scotch: 6.1.1 -> 7.0.4
* [`97057551`](https://github.com/NixOS/nixpkgs/commit/97057551543ba76f35373b9d8ba3a0074d85bdf2) opensmtpd: 7.4.0p0 -> 7.5.0p0
* [`e26b27a2`](https://github.com/NixOS/nixpkgs/commit/e26b27a23a6ce7628963632316ead52f15dbfedc) tracker: 3.7.2 -> 3.7.3
* [`cdd12552`](https://github.com/NixOS/nixpkgs/commit/cdd125528422fac1272d7db1fad394f47c29ed91) weechat-matrix: substitute matrix_upload with the right nix store path
* [`06cc2f26`](https://github.com/NixOS/nixpkgs/commit/06cc2f266bef5b91cc12de4ef078722452bd526a) weechat-matrix: change --replace to --replace-fail
* [`ab2517c9`](https://github.com/NixOS/nixpkgs/commit/ab2517c9bc05f413f8d6774d0d1e7b1dc0a5ba61) gr-framework: 0.72.11 -> 0.73.5
* [`0220f7cc`](https://github.com/NixOS/nixpkgs/commit/0220f7ccc2d3b7df299e28435f208b42572ffe1e) catboost: 1.2.3 -> 1.2.5
* [`fcab5d3e`](https://github.com/NixOS/nixpkgs/commit/fcab5d3e0afebe7a9a8b338decbe86b45f38c4af) gdcm: 3.0.23 -> 3.0.24
* [`e69ace56`](https://github.com/NixOS/nixpkgs/commit/e69ace568e16728dd82336c260ee48dd9e1035a4) gdk-pixbuf: enable other loaders
* [`9b10f901`](https://github.com/NixOS/nixpkgs/commit/9b10f90188dd7954b082026f7419b4ce024fe15c) gdk-pixbuf: disable ani loader
* [`b7ef78ce`](https://github.com/NixOS/nixpkgs/commit/b7ef78ce9adba9bdc670aecba40f4670f6f90dfb) po4a: formatting cleanup
* [`fd7787f3`](https://github.com/NixOS/nixpkgs/commit/fd7787f37c39bc23e6ef6d021e94a793b5ff5976) po4a: 0.62 -> 0.71
* [`be0cfacc`](https://github.com/NixOS/nixpkgs/commit/be0cfacc2ed3db4ed50b43e9bd7f00e4c03c6e52) maintainers: update datahearth fingerprints
* [`aac727ee`](https://github.com/NixOS/nixpkgs/commit/aac727eef0ffb6c5db016a1c00a4dbbf937bf0ca) insomnia: 8.6.1 -> 9.0.0
* [`22a7de63`](https://github.com/NixOS/nixpkgs/commit/22a7de63547f38571243d9275f355db38df5699a) plasma6: mark dolphin + spectacle as optional packages
* [`0a8f72f2`](https://github.com/NixOS/nixpkgs/commit/0a8f72f2ed23fb0dfce42f6076ca9a5995f6b5d1) plasma6: reorganize & describe dependencies
* [`2b0894a9`](https://github.com/NixOS/nixpkgs/commit/2b0894a9d0b6fb886919c49f47b54dc1c47843fb) ruffle: reformat
* [`3b9ec25c`](https://github.com/NixOS/nixpkgs/commit/3b9ec25c51487d1c94d3528ac4f367fce5847153) ruffle: refactor
* [`7588c9a9`](https://github.com/NixOS/nixpkgs/commit/7588c9a9d1cb197242ecf1634f6bd50245c785d0) ruffle: nightly-2024-03-25 -> nightly-2024-05-01
* [`ec66c888`](https://github.com/NixOS/nixpkgs/commit/ec66c8886b5ead46ff575b099aed9210f4d488cb) sgx-sdk/ipp-crypto: 2021.10.0 -> 2021.11.1
* [`0c918484`](https://github.com/NixOS/nixpkgs/commit/0c918484fbcdb37a50a2095cd392c7e42b805386) sgx-sdk: 2.23 -> 2.24
* [`fcc7d2be`](https://github.com/NixOS/nixpkgs/commit/fcc7d2be753560cdf34228a398f7a44202f09aaa) sgx-psw: 2.23 -> 2.24
* [`8b050cc9`](https://github.com/NixOS/nixpkgs/commit/8b050cc91144446f957656b2cc1bcfffae2ab11d) sgx-azure-dcap-client: fix warnings
* [`3dd129f7`](https://github.com/NixOS/nixpkgs/commit/3dd129f7db85e75c407cd09bbfc714ebfb4c2b3e) sgx-ssl: openssl: 3.0.12 -> 3.0.13
* [`1d2d850e`](https://github.com/NixOS/nixpkgs/commit/1d2d850e72c0279cc1dc53208b490c35ff5c4b25) wechat-uos: 1.0.0.238 -> 1.0.0.241
* [`5ee714da`](https://github.com/NixOS/nixpkgs/commit/5ee714da81a4e979ce6737e257b505880ed7586a) promptfoo: 0.55.0 -> 0.57.1
* [`dc88b850`](https://github.com/NixOS/nixpkgs/commit/dc88b85084fda624276871fc76b96fc12f19eeb0) python311Packages.rich-rst: 1.3.0 -> 1.3.1
* [`8e729c70`](https://github.com/NixOS/nixpkgs/commit/8e729c70a1192691fc4eb93017415de88d791883) enet: 1.3.17 -> 1.3.18
* [`5bc4581f`](https://github.com/NixOS/nixpkgs/commit/5bc4581f35b7e27025ef8d6aba534d623a34a591) dotconf: 1.3 -> 1.4.1
* [`16c5281a`](https://github.com/NixOS/nixpkgs/commit/16c5281a261d2011c4448cd3a1478322f168f9b6) at-spi2-core: add flag to disable systemd support
* [`8d285d87`](https://github.com/NixOS/nixpkgs/commit/8d285d87723d9e962377dd707c7ec2ca915ac26b) dummyhttp: init at 1.0.3
* [`8b592066`](https://github.com/NixOS/nixpkgs/commit/8b592066f0132a4dda9cea3e62b75068fc0c5ad1) directfb: use POSIX basename()
* [`0ff673ac`](https://github.com/NixOS/nixpkgs/commit/0ff673ac5979f2989221753fc2e66251b0420994) glibc: 2.39-31 -> 2.39-52
* [`2eeec259`](https://github.com/NixOS/nixpkgs/commit/2eeec259f833a9193c1205b46a528414b784bf49) rocmPackages.rocgdb: Build with amdgpu support
* [`65e47ee4`](https://github.com/NixOS/nixpkgs/commit/65e47ee45a9b399b3953f6994b13f57ef20eaa9b) rocmPackckages.rocgdb: Fix license
* [`f96a9083`](https://github.com/NixOS/nixpkgs/commit/f96a90834c5e2fb1fd9cebfba862c6d5a01f7601) secp256k1: 0.4.1 -> 0.5.0
* [`1970f0ff`](https://github.com/NixOS/nixpkgs/commit/1970f0ffd6542851ab369fbc59d53d30f3da28ac) edgedb: 4.1.1 -> 5.1.0
* [`0f0c2eb3`](https://github.com/NixOS/nixpkgs/commit/0f0c2eb381faf98626a10a6a704220856c502757) edgedb: format with nixfmt
* [`6234b3e8`](https://github.com/NixOS/nixpkgs/commit/6234b3e818ccbcf22fafeef17584e88f8298c4e3) zlib: link with --undefined-version on lld
* [`57bdbabe`](https://github.com/NixOS/nixpkgs/commit/57bdbabed57431940bafd22371c910c187213ea2) util-linux: 2.39.3 -> 2.40.1
* [`24d45318`](https://github.com/NixOS/nixpkgs/commit/24d453186792290a2188343c289d6504daecc5aa) python311Packages.minio: 7.2.6 -> 7.2.7
* [`fe06c43d`](https://github.com/NixOS/nixpkgs/commit/fe06c43d7091c56c8e054b71c64ce81628fa6f13) gauche: remove dependency onto gaucheBootstrap
* [`b505db6f`](https://github.com/NixOS/nixpkgs/commit/b505db6f6df1f67ba437e60d7070a8f6698f6113) nixos/test-driver: add AbstractLogger interface
* [`9d90df51`](https://github.com/NixOS/nixpkgs/commit/9d90df51a9cdfaee321216997a0413c85672545f) nixos/test-driver: Separate XML and Terminal log
* [`9e8d6bbe`](https://github.com/NixOS/nixpkgs/commit/9e8d6bbe2488d1305b276e3e0686c6ebee7eaba8) nixos/test-driver: add junit-xml logger
* [`303618c7`](https://github.com/NixOS/nixpkgs/commit/303618c7e12f002f3c6ce35013c09ae5ac8f69e9) nixos/test-driver: enable XML log selectively
* [`d07866cd`](https://github.com/NixOS/nixpkgs/commit/d07866cddc4bbbd57c5b6853995459bd0f084a4a) nixos/test-driver: rm global logger
* [`234502f3`](https://github.com/NixOS/nixpkgs/commit/234502f34803c2630d97a55c2d5b98b1108192fc) libmbim: remove unused systemd dependency
* [`ea424909`](https://github.com/NixOS/nixpkgs/commit/ea424909106ddedfffbef2526cf04dad2f6b9137) tpm2-tss: 4.1.0 -> 4.1.1
* [`8ea6b8dc`](https://github.com/NixOS/nixpkgs/commit/8ea6b8dcacecd3b6565978c552c8148f8ce19d77) libmbim: remove unused systemd input
* [`4581de4d`](https://github.com/NixOS/nixpkgs/commit/4581de4df40093b08190109759b25e889e36dab5) python311Packages.truststore: 0.8.0 -> 0.9.1
* [`f05f40d6`](https://github.com/NixOS/nixpkgs/commit/f05f40d64fefa2ff1308f8b28677875f963accf3) python3Packages.python-jose: add patches for CVE-2024-33663 and CVE-2024-33664
* [`ff0e3078`](https://github.com/NixOS/nixpkgs/commit/ff0e3078532c0ebf4320c18d03ef471c5c112771) go: 1.22.2 -> 1.22.3
* [`ff804251`](https://github.com/NixOS/nixpkgs/commit/ff8042515983b75db625af3454f3faa2a5f9ffa9) pkgsStatic.libgudev: fix build
* [`2b3d191a`](https://github.com/NixOS/nixpkgs/commit/2b3d191a28dc8ba81adae4ccfa8e2d93c9c89f35) libndp: fix cross compilation to musl
* [`7441c52c`](https://github.com/NixOS/nixpkgs/commit/7441c52c79c7b4d7bcc8aef9c4bedda431319486) pantheon.elementary-gtk-theme: 7.3.0 -> 8.0.0
* [`0a1e4ef4`](https://github.com/NixOS/nixpkgs/commit/0a1e4ef429073cee7ef975258b7170910f817280) pipewire: 1.0.5 -> 1.0.6
* [`8291b47c`](https://github.com/NixOS/nixpkgs/commit/8291b47cb2f785db7a57dba2b3593aa61e94883e) libwacom-surface: 2.7.0 -> 2.10.0
* [`705a99f0`](https://github.com/NixOS/nixpkgs/commit/705a99f06720bfebea078d81ea3b57256ed87579) nghttp3: 1.2.0 -> 1.3.0
* [`68c889da`](https://github.com/NixOS/nixpkgs/commit/68c889daa000c7ba5fefe507aed70dbd61e76bce) glib: 2.80.0 -> 2.80.2
* [`11d974e6`](https://github.com/NixOS/nixpkgs/commit/11d974e67a3099d2a5a0d6d1e7e7feda474a38fa) curl-impersonate: fix darwin build and make cross-compilation work
* [`1acb0ea6`](https://github.com/NixOS/nixpkgs/commit/1acb0ea6a93c5a98a6d079a3c8522ba361664414) curl-impersonate: add meta.mainProgram
* [`f6f3c694`](https://github.com/NixOS/nixpkgs/commit/f6f3c69442370d5191b1e862dc61a635e2d38ab1) mesa: 24.0.6 → 24.0.7
* [`7a2be5b7`](https://github.com/NixOS/nixpkgs/commit/7a2be5b7d6a28def87520629f25b8ae5fd167a4d) miniupnpc: 2.2.6 -> 2.2.7
* [`ba9318ec`](https://github.com/NixOS/nixpkgs/commit/ba9318ecf4e1eec280fb927e4699ea9e645d933f) syft: disable update check by default
* [`8128cdff`](https://github.com/NixOS/nixpkgs/commit/8128cdff479e3bd89ae9ff4326eb4b5e4f5a1440) systemd: 255.4 -> 255.6
* [`2be8d75e`](https://github.com/NixOS/nixpkgs/commit/2be8d75ed6df7e0bb51554a68278c5302cebaf02) libnbd: 1.18.2 -> 1.20.1
* [`51be8cec`](https://github.com/NixOS/nixpkgs/commit/51be8cec20cccaea8558437b6f84624b499cada2) systemd: fix disabling seccomp
* [`6ffea0de`](https://github.com/NixOS/nixpkgs/commit/6ffea0de4c13c1987adec5e06f369514c1b15eb2) python3Packages.dbus-python: fix cross
* [`3c038116`](https://github.com/NixOS/nixpkgs/commit/3c03811683fecb816d2b8eb01e918f83956c7220) llvmPackages_*.libcxx: include libcxxabi within libcxx
* [`e1b9b3e2`](https://github.com/NixOS/nixpkgs/commit/e1b9b3e251e61e8c0bb7e2da6b55257b42a34757) element-desktop: fix cross build
* [`2fe65e94`](https://github.com/NixOS/nixpkgs/commit/2fe65e94c1d09047ed0d65fef82891c5aea8a4f0) electron: fix cross compilation
* [`8df62b07`](https://github.com/NixOS/nixpkgs/commit/8df62b078d46adec7da4daf8ab6b4132082283a1) python3.pkgs.dbus-python: fix cross build
* [`533ec49f`](https://github.com/NixOS/nixpkgs/commit/533ec49f1f2c7fab771a9f50419c2f453cbeaf6d) gnu-config: 2023-09-19 -> 2024-01-01
* [`d450529c`](https://github.com/NixOS/nixpkgs/commit/d450529c1db479caeb34dc6014831481dabe2da4) libbpf: 1.4.1 -> 1.4.2
* [`4fc3b0b3`](https://github.com/NixOS/nixpkgs/commit/4fc3b0b3a4c75f91d87a811b9bd07ee7eee1b1bd) pkgsStatic.xorg.libpciaccess: mark unsupported
* [`ef0e3af8`](https://github.com/NixOS/nixpkgs/commit/ef0e3af8ef3710f623f3ef18e41aa7e7cc1c35a0) pkgsStatic.libdrm: fix build
* [`db5ed5d7`](https://github.com/NixOS/nixpkgs/commit/db5ed5d7fb8eb88ba74a50b8fca9e868298b1b5d) pipewire: fix enableSystemd option
* [`c69eb60b`](https://github.com/NixOS/nixpkgs/commit/c69eb60b61b6df79642830b72beeff8f12933f98) postgresql_12: 12.18 -> 12.19
* [`3b6b7fda`](https://github.com/NixOS/nixpkgs/commit/3b6b7fda094507634cc9d6c06421d68eef6e246b) postgresql_13: 13.14 -> 13.15
* [`90fdcc61`](https://github.com/NixOS/nixpkgs/commit/90fdcc61127f1325512451c61d606ef349b825fa) postgresql_14: 14.11 -> 14.12, fix CVE-2024-4317
* [`1f657f2c`](https://github.com/NixOS/nixpkgs/commit/1f657f2ce9532d0e72dfc347208a188752a51345) postgresql_15: 15.6 -> 15.7, fix CVE-2024-4317
* [`0616f7a4`](https://github.com/NixOS/nixpkgs/commit/0616f7a44f81f64154ae85e5db0a5c4068f6c1a6) postgresql_16: 16.2 -> 16.3, fix CVE-2024-4317
* [`3ad254b1`](https://github.com/NixOS/nixpkgs/commit/3ad254b1c4cb547740550f1bf7f19232b197db86) postgresql: drop obsolete musl checkPhase fix
* [`4230c04c`](https://github.com/NixOS/nixpkgs/commit/4230c04c74490357bb0af56a833a74e7180100d3) ffmpeg_5: add patch for CVE-2024-31585
* [`ff06e7d5`](https://github.com/NixOS/nixpkgs/commit/ff06e7d5e91d9416a1c5147deb53f49992285682) ffmpeg, ffmpeg_5: add patches for CVE-2024-31582
* [`c23f9d58`](https://github.com/NixOS/nixpkgs/commit/c23f9d58ffa775eb60c2b4cc69a732ec805a22a3) ffmpeg, ffmpeg_5: add patches for CVE-2024-31578
* [`f7836b17`](https://github.com/NixOS/nixpkgs/commit/f7836b17f1b0872afedb27e29af071a10117ed61) libjpeg: 3.0.2 -> 3.0.3
* [`8e36cb36`](https://github.com/NixOS/nixpkgs/commit/8e36cb36eaa3f74f697655c563585fe3b9be9228) python311Packages.ipython: 8.23.0 -> 8.24.0
* [`d4186518`](https://github.com/NixOS/nixpkgs/commit/d4186518db69d0387cd013b201ea92568142323f) upx: 4.2.3 -> 4.2.4
* [`c9677979`](https://github.com/NixOS/nixpkgs/commit/c96779791a59a2b29a4005c94ca065f93bf58d1f) python311Packages.werkzeug: 3.0.2 -> 3.0.3
* [`1d4d9fac`](https://github.com/NixOS/nixpkgs/commit/1d4d9facbcb00d2bce2fe15d9c8fdaa2137833eb) tests.testers.hasPkgConfigModules: test the `versionCheck` parameter
* [`4af3b807`](https://github.com/NixOS/nixpkgs/commit/4af3b807fccfddfceb4aad422018a5f9e8cdb8a0) testers.hasPkgConfigModules: fix `versionCheck` conditional
* [`7587ff8d`](https://github.com/NixOS/nixpkgs/commit/7587ff8d1a5ad6ea85a00e8c550216ecd328c3be) python3Packages.shouldbe: drop
* [`99e1d2c3`](https://github.com/NixOS/nixpkgs/commit/99e1d2c38a857eb2e282ea57844cd4087661e885) python312Packages.gssapi: test with pytest, use pep517 builder
* [`43efaaaa`](https://github.com/NixOS/nixpkgs/commit/43efaaaae80c77e81145067c0b2b57109dd0b33d) testers.hasPkgConfigModules: don't display ❌ on ignored version mismatches
* [`b2af5ee1`](https://github.com/NixOS/nixpkgs/commit/b2af5ee152b41b496b355c8c9c65ebb1e56769e4) sqlmc: init at 1.0.0
* [`35d05033`](https://github.com/NixOS/nixpkgs/commit/35d05033a839943cf22de44b341278bbde4de2e7) spicetify-cli: rename bin
* [`5a5298d9`](https://github.com/NixOS/nixpkgs/commit/5a5298d9f0dd4ffaf1395284d3ee6ea959fd6f0b) percollate: 4.0.5 -> 4.2.0
* [`201a5ff6`](https://github.com/NixOS/nixpkgs/commit/201a5ff61faa1552c31ec6dd3389c9aa31e2b486) nixos/plex: add systemd hardening configuration
* [`560957ba`](https://github.com/NixOS/nixpkgs/commit/560957bae1ee123b43d6534eebf2a5917a78e0a2) edk2: building of `antlr` and `dlg` should be built with native architecture.
* [`d2f1139b`](https://github.com/NixOS/nixpkgs/commit/d2f1139b7f0ded69beba91c21c4a3297b7a8f722) whois: 5.5.22 -> 5.5.23
* [`bf4d46e3`](https://github.com/NixOS/nixpkgs/commit/bf4d46e338590ffb19bae620e7a7eff64b0baf89) fixup! testers.hasPkgConfigModules: don't display ❌ on ignored version mismatches
* [`2e13f168`](https://github.com/NixOS/nixpkgs/commit/2e13f1685977cd4573970a1e12db540445caa5cc) modemmanager: run tests again
* [`3605676d`](https://github.com/NixOS/nixpkgs/commit/3605676da26e447b2b75308b737ff35f0985573d) modemmanager: remove unused udev input
* [`dc5d2c62`](https://github.com/NixOS/nixpkgs/commit/dc5d2c6221259e729b33d1d817de95eb5e1d6530) unbound: 1.19.3 -> 1.20.0
* [`f22cbdca`](https://github.com/NixOS/nixpkgs/commit/f22cbdca656529ec1543eb5cb148a98b66ac6acf) unbound: migrate to by-name
* [`e4975a60`](https://github.com/NixOS/nixpkgs/commit/e4975a606b82345fca631a63ec30303e1e72b4b7) blueutil: 2.9.1 -> 2.10.0
* [`f1a746de`](https://github.com/NixOS/nixpkgs/commit/f1a746de733107227e2492320801ad7a3f6acd6f) textlint: repackage with buildNpmPackage
* [`1553285a`](https://github.com/NixOS/nixpkgs/commit/1553285a1131571a5df1797e034afff0fbedbc99) python3Packages.uxsim: 1.1.1 -> 1.3.0
* [`cd59be30`](https://github.com/NixOS/nixpkgs/commit/cd59be301d5c005db23c8499cdcd358849983542) textlint: make textlint pluggable with passthru.withPackages
* [`ac4fb74b`](https://github.com/NixOS/nixpkgs/commit/ac4fb74bd28027187e6a965c62a0686689fe28ef) vrc-get: 1.8.0 -> 1.8.1
* [`6493d500`](https://github.com/NixOS/nixpkgs/commit/6493d50082b3eb68263842036f88482a56a6fa35) aaaaxy: 1.5.54 -> 1.5.129
* [`1eaa9f52`](https://github.com/NixOS/nixpkgs/commit/1eaa9f52bda3b0035adbd94e5513916423157adc) gromacs: 2024 -> 2024.1
* [`67f368f3`](https://github.com/NixOS/nixpkgs/commit/67f368f3a82a310261d35eb8bf02b3c652b9a7d1) rocm5: use elfutils instead of unmaintained libelf
* [`d466c123`](https://github.com/NixOS/nixpkgs/commit/d466c123166f7854a5f12f498595a2a20d1a8589) rocm6: use elfutils instead of unmaintained libelf
* [`bccc97cd`](https://github.com/NixOS/nixpkgs/commit/bccc97cd9b56cd19b7b3f3ad99674ff4d742d31c) libxml2: 2.12.6 -> 2.12.7
* [`8bc86ee0`](https://github.com/NixOS/nixpkgs/commit/8bc86ee03659e75491f2fff19ef9251458ca321b) paraview: 5.11.2 -> 5.12.0
* [`48a52a28`](https://github.com/NixOS/nixpkgs/commit/48a52a281c5051801d49f35d7f0a92af06a5adca) gnomeExtensions: auto-update
* [`a79e2409`](https://github.com/NixOS/nixpkgs/commit/a79e24099e460868569e993b735c43961e19cf7e) hmcl: update to 3.5.7 from 3.5.5
* [`1cb1f3bc`](https://github.com/NixOS/nixpkgs/commit/1cb1f3bcad45c844a54b1398b426bfc240868d56) hmcl: add daru-san as a maintainer
* [`8eea66b3`](https://github.com/NixOS/nixpkgs/commit/8eea66b3f69ad1cd47c5359271d2833d40f5de65) goperf: 0-unstable-2023-11-08 -> 0-unstable-2024-05-10
* [`bce1863b`](https://github.com/NixOS/nixpkgs/commit/bce1863bc9f2bc3da9dea7637af01cf65d96a316) famistudio: 4.1.3 -> 4.2.0
* [`16685630`](https://github.com/NixOS/nixpkgs/commit/16685630aa8f8d1bb17c853e1613c7b9cd84cfc4) open-watcom-v2-unwrapped: 0-unstable-2023-11-24 -> 0-unstable-2024-05-14
* [`1d73babc`](https://github.com/NixOS/nixpkgs/commit/1d73babc8d9fd984122d0eee9e4891ad1a26e0ee) python3Packages.xmldiff: 2.6.3 -> 2.7.0
* [`e1c76d93`](https://github.com/NixOS/nixpkgs/commit/e1c76d93e5edcdf5f5d36cd33b8543196f05b3c8) heaptrack: support darwin
* [`da5ec6b0`](https://github.com/NixOS/nixpkgs/commit/da5ec6b0c3e0bfce25dc9e5c3e45fdd8c38affdf) edk2: Fix OVMF cross compilation
* [`474fe1a9`](https://github.com/NixOS/nixpkgs/commit/474fe1a90547c7d1b8509e8b4aeef9e8935f94a4) edk2: use patchShebangs for fixing up shell wrappers
* [`7e2c76bb`](https://github.com/NixOS/nixpkgs/commit/7e2c76bb84c4cd7cccf07a3ef645c14516f09b6b) edk2: fix cross-compilation by using an upstream patch
* [`93f6f278`](https://github.com/NixOS/nixpkgs/commit/93f6f278c5a4be0ed37b1414e373d513e2768f3d) sigi: 3.6.3 -> 3.6.4
* [`0118cc1d`](https://github.com/NixOS/nixpkgs/commit/0118cc1d67e4deabcf39c1166cb088ee407b187e) grafana: 10.4.2 -> 11.0.0
* [`0ad69fc6`](https://github.com/NixOS/nixpkgs/commit/0ad69fc6116d613185b8017933c524f778b23499) astrolog: 7.30 -> 7.70
* [`3a9f2d8f`](https://github.com/NixOS/nixpkgs/commit/3a9f2d8f26896aadcfe776e0832845cba4240e13) signalbackup-tools: 20240509-1 -> 20240514
* [`1de1b81f`](https://github.com/NixOS/nixpkgs/commit/1de1b81f12c9df498039378d26cd2549cde7f9d5) syncplay: 1.7.2 -> 1.7.3
* [`4d045a7d`](https://github.com/NixOS/nixpkgs/commit/4d045a7de8c674a71a7a1c2c6b5ac5cb19c3f607) libaom: don't disable runtime cpu detection on aarch64-darwin
* [`3130575f`](https://github.com/NixOS/nixpkgs/commit/3130575f4f78e0b73cb34c7a57d4030d7f139d0b) git: 2.44.0 -> 2.44.1
* [`5cf5a3c6`](https://github.com/NixOS/nixpkgs/commit/5cf5a3c6e347b1a6a0423fd08ce34783edb5645c) libomxil-bellagio: fix compiling with llvm
* [`7f301eab`](https://github.com/NixOS/nixpkgs/commit/7f301eab1b3989fefb49f6c1f4edd7eb7b274756) imagemagick: fix passthru.tests.pkg-config
* [`62623162`](https://github.com/NixOS/nixpkgs/commit/62623162cdcb4c5eab975accbcfc8c0ad8bc9a13) glslang: 14.1.0 -> 14.2.0
* [`a6f3cc62`](https://github.com/NixOS/nixpkgs/commit/a6f3cc62f7cb3335c9c7e0c38c462da8abe6bdad) vulkan-headers: 1.3.280.0 -> 1.3.283.0
* [`5ba3b41f`](https://github.com/NixOS/nixpkgs/commit/5ba3b41faeb2a75221b0c06851b5982eb0e28a25) vulkan-loader: 1.3.280.0 -> 1.3.283.0
* [`bbfb3a5c`](https://github.com/NixOS/nixpkgs/commit/bbfb3a5c0b56b731d1b93fd463a3a5e945b15bbe) vulkan-validation-layers: 1.3.280.0 -> 1.3.283.0
* [`a17bfb3d`](https://github.com/NixOS/nixpkgs/commit/a17bfb3d7ff67bc6136cb7a54a62d4fc5e934a7e) vulkan-tools: 1.3.280.0 -> 1.3.283.0
* [`72fb6fbf`](https://github.com/NixOS/nixpkgs/commit/72fb6fbfcacfb51ab25b8588a99cdb376754a158) vulkan-tools-lunarg: 1.3.280.0 -> 1.3.283.0
* [`d85a738f`](https://github.com/NixOS/nixpkgs/commit/d85a738fbb50eb1fc8d2752419cfdb3fbd13ac48) vulkan-extension-layer: 1.3.280.0 -> 1.3.283.0
* [`fb7aed3f`](https://github.com/NixOS/nixpkgs/commit/fb7aed3fffd5e6f14995e1fdcd5146ce53b5c2a8) vulkan-utility-libraries: 1.3.280.0 -> 1.3.283.0
* [`fb98282b`](https://github.com/NixOS/nixpkgs/commit/fb98282b40a8e87b1680de1d6658e46ec5fcae26) vulkan-volk: 1.3.280.0 -> 1.3.283.0
* [`7a4be713`](https://github.com/NixOS/nixpkgs/commit/7a4be713424c8cc9372939e42d6ccfa1e3f35e72) spirv-headers: 1.3.280.0 -> 1.3.283.0
* [`5f747957`](https://github.com/NixOS/nixpkgs/commit/5f747957b1bcedc9ad2fcd42d4443783bddf9612) spirv-cross: 1.3.280.0 -> 1.3.283.0
* [`097b4c8a`](https://github.com/NixOS/nixpkgs/commit/097b4c8ae9812c0d121a77b11d0cdbca5cc7a9ae) spirv-tools: 1.3.280.0 -> 1.3.283.0
* [`cb467836`](https://github.com/NixOS/nixpkgs/commit/cb4678361a0cf41a886153ae23075bf6ba902071) gnutls: fix an upstream regression in RSA certificates
* [`146148e3`](https://github.com/NixOS/nixpkgs/commit/146148e3232ee4edbb4091f94a30ffd873065aaa) espanso: 2.1.8 -> 2.2.1
* [`bd5f19d0`](https://github.com/NixOS/nixpkgs/commit/bd5f19d0c1862e70d0f5c88bd1d05aacbcdcfee6) findutils: Fix build on native FreeBSD
* [`5424ae8e`](https://github.com/NixOS/nixpkgs/commit/5424ae8ee5739dbcb05e850f2ab0d41580dee2c5) prometheus-frr-exporter: init at 1.2.0
* [`7acc08c9`](https://github.com/NixOS/nixpkgs/commit/7acc08c9833e876447675f2a89e1a154e22fa6bc) doc: clarify consequences of `lib.meta.setName`
* [`17386eba`](https://github.com/NixOS/nixpkgs/commit/17386ebad2cce6d1d39b2c443f2596a0f6ab1d04) crc: 2.34.1 -> 2.36.0
* [`1dfe0c3b`](https://github.com/NixOS/nixpkgs/commit/1dfe0c3b38b9df4fa5f202a2cffe6b491836bccc) imagemagick6: 6.9.12-68->6.9.13-10, fix build
* [`3f60325b`](https://github.com/NixOS/nixpkgs/commit/3f60325bf1044e5e8cbb1f348c292500c92b395a) darwin.moltenvk: 1.2.8 -> 1.2.9
* [`ee776dd5`](https://github.com/NixOS/nixpkgs/commit/ee776dd5df012280b004b025c92c9a7d0c229cd1) Pick [nixos/nixpkgs⁠#311675](https://togithub.com/nixos/nixpkgs/issues/311675): fix: systemd build flag combinations
* [`8dc64481`](https://github.com/NixOS/nixpkgs/commit/8dc644818790363b40f86700f3d0399f2aa7d966) rasm: 0.117 -> 2.2.3, change upstream source
* [`dfffdf14`](https://github.com/NixOS/nixpkgs/commit/dfffdf14269b78f7a7a84a5ab9a2da5d4b698b49) doc: migrate lib.debug to doc-comment format
* [`9cc138ce`](https://github.com/NixOS/nixpkgs/commit/9cc138cec4235518ee2071c612988210afc04524) maintainers: add nhnn
* [`dd990848`](https://github.com/NixOS/nixpkgs/commit/dd99084843ee2d94d2efb127231a6358f0cf0daf) buildFHSEnvBubblewrap: allow more varied $DISPLAY syntax
* [`4d6e0117`](https://github.com/NixOS/nixpkgs/commit/4d6e011773176acead319a9869fc7420a5872349) ablog: move to by-name, fix build
* [`1e1685f1`](https://github.com/NixOS/nixpkgs/commit/1e1685f116d30b0dcddc4e022cd2ee87d320493f) ablog: 0.11.8 -> 0.11.10
* [`a4caad4e`](https://github.com/NixOS/nixpkgs/commit/a4caad4eaf2ebae9dca8830fdba90d1148f5a5ed) python3Packages.wrapio: refactor
* [`2002403a`](https://github.com/NixOS/nixpkgs/commit/2002403a527c03fa5094c4168e12f6f9e88a89ab) python3Packages.survey: refactor
* [`c3802712`](https://github.com/NixOS/nixpkgs/commit/c3802712feaaf15c79c948d5559633fe95e41891) python3Packages.pyprof2calltree: refactor
* [`d59f3162`](https://github.com/NixOS/nixpkgs/commit/d59f31622bb6448895a8b8d09e4ccf0d9a0483fa) python3Packages.dbus-next: refactor
* [`cea08a97`](https://github.com/NixOS/nixpkgs/commit/cea08a97fd572e8a9c82ab6a3083f9970c2c45e1) warp-terminal: 0.2024.05.07.08.02.stable_02 -> 0.2024.05.14.08.01.stable_04
* [`9ca1cf51`](https://github.com/NixOS/nixpkgs/commit/9ca1cf51be5407ef7c8c165a72a9ce0965bfe2c7) python312Packages.tqdm: 4.66.2 -> 4.66.4
* [`f4dc8f8e`](https://github.com/NixOS/nixpkgs/commit/f4dc8f8e7994f45bbedca8034d64fff197528e54) sword: 1.8.1 -> 1.9.0
* [`0062a1d3`](https://github.com/NixOS/nixpkgs/commit/0062a1d3305118b17c3854e92db78b464313b799) rexml: 3.2.6 -> 3.2.8
* [`4c7be300`](https://github.com/NixOS/nixpkgs/commit/4c7be300526d13313f26c7a6435c740c317ea6d0) python312Packages.pybrowserid: Fix on Darwin
* [`9c253cdf`](https://github.com/NixOS/nixpkgs/commit/9c253cdf5e4b6b69fb48a45b30eb8cc473728157) dbeaver-bin: install to `$out/opt`
* [`f467be8e`](https://github.com/NixOS/nixpkgs/commit/f467be8e15f8905e2e9d117eb2b21978a6c90e0c) dbeaver-bin: wrap program to find `openjdk17`
* [`1d1f1cdb`](https://github.com/NixOS/nixpkgs/commit/1d1f1cdb907fa512a614e2cd99a436e3d4f31ee5) dbeaver-bin: add `.desktop` file
* [`f8e39fef`](https://github.com/NixOS/nixpkgs/commit/f8e39fefa362336351008c6d6824738d8235a3b8) espanso: 2.2.1 -> 2.2-unstable-2024-05-14
* [`85814f82`](https://github.com/NixOS/nixpkgs/commit/85814f82e05e85383738692d5b51e4969b4ccbf9) ruler: refactor
* [`07f9f358`](https://github.com/NixOS/nixpkgs/commit/07f9f358bf1297e2f7134f0793b42d14df20c5e2) ruler: format with nixfmt
* [`0f362cf7`](https://github.com/NixOS/nixpkgs/commit/0f362cf7c530071179edfa959d3ea679439c5188) gtkterm: 1.3.0 -> 1.3.1
* [`3c1e446a`](https://github.com/NixOS/nixpkgs/commit/3c1e446a17800bd5bd2db456d3cb85724432d602) gtkterm: Update repo owner and homepage
* [`064f4c55`](https://github.com/NixOS/nixpkgs/commit/064f4c55c0fa81a38839878adeef390548661cac) doc: migrate lib.fixedPoints to doc-comment format
* [`b258b44a`](https://github.com/NixOS/nixpkgs/commit/b258b44a5d0f2c68838eb631fd142f6ac7513d1e) build-support/php: add `composerGlobal` variable
* [`7415f9ec`](https://github.com/NixOS/nixpkgs/commit/7415f9eccf7c113b548a1a4bfc6935c56ce5ff0a) maintainers: add jonochang
* [`815fd450`](https://github.com/NixOS/nixpkgs/commit/815fd450701e117c52b29391d1f047a832310621) aws-c-auth: 0.7.18 -> 0.7.22
* [`73861211`](https://github.com/NixOS/nixpkgs/commit/73861211016f0b0a038795aa1594ba50ed8de447) twm: 0.9.0 -> 0.9.1, add updateScript
* [`cd985d12`](https://github.com/NixOS/nixpkgs/commit/cd985d12924c652ec1a273c027e0c49fc2f117c1) _7zz: fix update script
* [`2a8bd9ba`](https://github.com/NixOS/nixpkgs/commit/2a8bd9ba3e81ba6022bcf3d99594656a6f5683b4) _7zz: 23.01 -> 24.05
* [`176c7baa`](https://github.com/NixOS/nixpkgs/commit/176c7baa9f406e3913b5d06c7d05ea3db363944a) _7zz: remove `meta = with lib;`
* [`169a7d53`](https://github.com/NixOS/nixpkgs/commit/169a7d53e4153803cd7f5653cd72b8e8656ff2c2) _7zz: fix passing package to tests
* [`cb8fa2b7`](https://github.com/NixOS/nixpkgs/commit/cb8fa2b758f8b3f5b7dfacf46d877ef1635938ea) util-linux: try to fix parallel build failures
* [`68c7f8e5`](https://github.com/NixOS/nixpkgs/commit/68c7f8e5ab16d76a6010d1af0cfd0e5390467ab1) textlint: add test utility
* [`f26194c4`](https://github.com/NixOS/nixpkgs/commit/f26194c4f163d1835d134d1e4b8e1f869d1bab32) textlint-rule-preset-ja-technical-writing: init at 10.0.1
* [`95507da6`](https://github.com/NixOS/nixpkgs/commit/95507da635c22e0c33b85ddfedb0e124d292588a) textlint-rule-max-comma: repackage with fetchYarnDeps
* [`e633e333`](https://github.com/NixOS/nixpkgs/commit/e633e33303176f9d3e7349d82b04a38e544683ea) textlint-rule-alex: repackage with buildNpmPackage
* [`c28503fd`](https://github.com/NixOS/nixpkgs/commit/c28503fd79755124700ec611adbd6f030f83937b) textlint-rule-write-good: repackage with fetchYarnDeps
* [`d47ef024`](https://github.com/NixOS/nixpkgs/commit/d47ef02451dfa3b68261b6c3be189c493d0184d7) textlint-rule-diacritics: repackage with buildNpmPackage
* [`c4db484f`](https://github.com/NixOS/nixpkgs/commit/c4db484f1438489334971f1279f6f967ab3ebe31) textlint-rule-stop-words: repackage with buildNpmPackage
* [`dc4a3ade`](https://github.com/NixOS/nixpkgs/commit/dc4a3ade28f0260ccd8b2b0ebf8af7701d6e7145) textlint-plugin-latex2e: init at 1.2.1-unstable-2024-02-05
* [`9587d0c8`](https://github.com/NixOS/nixpkgs/commit/9587d0c8f9577832891a12584cb49b2d696a57f8) textlint-plugin-latex: remove
* [`3109179f`](https://github.com/NixOS/nixpkgs/commit/3109179f68472dccb1fa5200eeb4c30010035156) textlint-rule-terminology: repackage with buildNpmPackage
* [`8fc1968c`](https://github.com/NixOS/nixpkgs/commit/8fc1968cb284d6d824a468a617de3ff5946f811d) textlint-rule-en-max-word-count: repackage with fetchYarnDeps
* [`2aaa9011`](https://github.com/NixOS/nixpkgs/commit/2aaa9011e18c5db23360cff91d6cdc6055dc73ef) textlint-rule-unexpanded-acronym: repackage with fetchYarnDeps
* [`e242a02e`](https://github.com/NixOS/nixpkgs/commit/e242a02edc425581d9b898914573a28c2b6c2543) textlint-rule-period-in-list-item: repackage with fetchYarnDeps
* [`1e813266`](https://github.com/NixOS/nixpkgs/commit/1e8132663768e0381499469251e2eadc5b1d3a20) textlint-rule-abbr-within-parentheses: repackage with fetchYarnDeps
* [`950ff0df`](https://github.com/NixOS/nixpkgs/commit/950ff0df9280eaaf8fd6d2a7cb0f0b300a1ac42d) textlint-rule-no-start-duplicated-conjunction: repackage with fetchYarnDeps
* [`d0de5c02`](https://github.com/NixOS/nixpkgs/commit/d0de5c02571bbfe293b4fc82c65c9b9709c04b4a) snd: 24.3 -> 24.4
* [`e8130af3`](https://github.com/NixOS/nixpkgs/commit/e8130af3b850229a0fd98798c272fe66e97d5132) rawtherapee: fix build
* [`d6c00ca6`](https://github.com/NixOS/nixpkgs/commit/d6c00ca6967f055fe1d5d019e2fdee765c0d4d6e) mullvad-vpn: 2024.1 -> 2024.3
* [`446bb88b`](https://github.com/NixOS/nixpkgs/commit/446bb88bb07644bc588dece492b46d5aeb67e573) blockattack: migrate to by-name
* [`9d511f87`](https://github.com/NixOS/nixpkgs/commit/9d511f87c8ce76adcdb8299a236b7815c8054044) blockattack: refactor
* [`8ec62b50`](https://github.com/NixOS/nixpkgs/commit/8ec62b508f9779654a7501435920de328c57f876) blockattack: use ninja
* [`abaecccc`](https://github.com/NixOS/nixpkgs/commit/abaecccc88dae6bcd6b5fcc47702f1929a263b58) blockattack: nixfmt
* [`195936e0`](https://github.com/NixOS/nixpkgs/commit/195936e03a08384eec83391f73c28af6b3a17805) blockattack: 2.8.0 -> 2.9.0
* [`a1c8fe35`](https://github.com/NixOS/nixpkgs/commit/a1c8fe355c1f9809e72c320d0b629cdc3849d5d4) rasm: migrate to by-name
* [`33d978eb`](https://github.com/NixOS/nixpkgs/commit/33d978ebc069f3d826e52f09b489339996e53688) mattermost: 9.5.4 → 9.5.5
* [`010c4a33`](https://github.com/NixOS/nixpkgs/commit/010c4a334eaf96112bc812bd4ed70818376b889a) intune-portal: 1.2404.23-jammy -> 1.2404.25-jammy
* [`e8680f6e`](https://github.com/NixOS/nixpkgs/commit/e8680f6e3ee1cfeb2c1a9b53755db3a81e8a9c40) keymapper: 4.0.2 -> 4.3.0
* [`0d2c6642`](https://github.com/NixOS/nixpkgs/commit/0d2c66423820f17a0e3dcc6b8331b4b4e0efbd61) navidrome: 0.52.0 -> 0.52.5
* [`01a48206`](https://github.com/NixOS/nixpkgs/commit/01a48206f33590889675ec2e6764f5fab8dfa4dd) kubevpn: 2.2.8 -> 2.2.9
* [`1e2db6c5`](https://github.com/NixOS/nixpkgs/commit/1e2db6c5d8ea44b3ff8925418d24aaa404c8107e) icomoon-feather: init at 0-unstable-2024-05-12
* [`6a8e27ad`](https://github.com/NixOS/nixpkgs/commit/6a8e27add392ac05749d8c1ebd44ba8d3826a0a1) cano: 0-unstable-2024-31-3 -> 0.1.0-alpha
* [`24d3f815`](https://github.com/NixOS/nixpkgs/commit/24d3f81575f47b34fdd163e16af27a73b933062d) dwarfs: 0.7.5 → 0.9.8
* [`0efbb4c4`](https://github.com/NixOS/nixpkgs/commit/0efbb4c4bba586c3fb5181341fe894c938c9957b) hyprwayland-scanner: 0.3.7 -> 0.3.8
* [`96d9451c`](https://github.com/NixOS/nixpkgs/commit/96d9451c86541d91d8debd84b2cb364666e38f6f) ferdium: 6.7.3 -> 6.7.4
* [`0660e869`](https://github.com/NixOS/nixpkgs/commit/0660e869722f33ac34e075fed9d110fe4cfefdbf) python311Packages.dask: 2024.5.0 -> 2024.5.1
* [`4dc44306`](https://github.com/NixOS/nixpkgs/commit/4dc443067572c9e4305fd5d9d37f0ea2fcf7cbd9) python311Packages.dask-expr: 1.1.0 -> 1.1.1
* [`6a01a6ac`](https://github.com/NixOS/nixpkgs/commit/6a01a6ac24b0d1315bd94d06294d9eb5569d416b) kanidm: 1.2.0 -> 1.2.1
* [`f62effe2`](https://github.com/NixOS/nixpkgs/commit/f62effe2cf6788754277fba31feedc646661c95c) vivaldi: 6.7.3329.27 -> 6.7.3329.31
* [`5aae3a45`](https://github.com/NixOS/nixpkgs/commit/5aae3a45cb6ec45fa9c7f6bb3a9036ccd13aa152) pulsar: 1.114.0 -> 1.117.0
* [`ae9df3ab`](https://github.com/NixOS/nixpkgs/commit/ae9df3abffae8e99a7fd3e61d39291ef7d0d25da) pulsar: move to pkgs/by-name
* [`b2b37b54`](https://github.com/NixOS/nixpkgs/commit/b2b37b543e433d48da97c548f2c2ec817701475b) rofi-blezz: init at unstable-2022-09-07
* [`4488f0a1`](https://github.com/NixOS/nixpkgs/commit/4488f0a15ce3ebf18f2c4015a97372faa38410fc) nitrokey-app2: 2.2.2 -> 2.3.0, unpin pynitrokey
* [`c755b8bc`](https://github.com/NixOS/nixpkgs/commit/c755b8bc267c866fa53d6149aa89b05a05cfa7fb) flood-for-transmission: 2024-02-10T19-10-27 → 2024-05-18T08-04-58
* [`dcf8ea60`](https://github.com/NixOS/nixpkgs/commit/dcf8ea60144743a385f962e65255f2ca9d1d5490) python312Packages.pillow-jpls: refactor
* [`d9443cb2`](https://github.com/NixOS/nixpkgs/commit/d9443cb26b5817427abd61deb1b8aef94a2fb94b) plasma6: move ffmpegthumbs to optional, clarify comments
* [`0cebfcea`](https://github.com/NixOS/nixpkgs/commit/0cebfcea11ab82a6ae9cc72d05f910e8c4166029) go-musicfox: 4.4.0 -> 4.4.1
* [`18e089be`](https://github.com/NixOS/nixpkgs/commit/18e089be7feb381d5fb7defb1648706d64c5c7c4) nixos/navidrome: fix settings type
* [`a74fd692`](https://github.com/NixOS/nixpkgs/commit/a74fd69291a5c3b82a363ff5a1625ba6b0ff9935) nixos/navidrome: run nixfmt-rfc-style
* [`431ae11b`](https://github.com/NixOS/nixpkgs/commit/431ae11b25b20bb6657abcdf7c6d0fff22826062) deno: 1.43.1 -> 1.43.5
* [`9aebde2a`](https://github.com/NixOS/nixpkgs/commit/9aebde2aecf4f527becb370de1f70da3e3bc7558) cloudlog: 2.6.11 -> 2.6.12
* [`ece660ca`](https://github.com/NixOS/nixpkgs/commit/ece660caff4a88c9f2b0cec38ac9e40c7e1df8fd) python311Packages.aioshelly: 9.0.0 -> 10.0.0
* [`1759b400`](https://github.com/NixOS/nixpkgs/commit/1759b400b2370792873e55b3284099c6244e0266) tautulli: 2.13.4 -> 2.14.2
* [`f2f31ba8`](https://github.com/NixOS/nixpkgs/commit/f2f31ba8a7bcb0bf053869daf33ccd6d69229a1a) microsoft-edge: 124.0.2478.97 -> 125.0.2535.51
* [`69a006b0`](https://github.com/NixOS/nixpkgs/commit/69a006b014b91d49e9a0b20a81b10e169f9a66cd) semgrep: 1.72.0 -> 1.73.0
* [`da7ae1ba`](https://github.com/NixOS/nixpkgs/commit/da7ae1baf8102e2f266bfce03230fe7b85604a6a) gvisor: fix ldconfig path
* [`18109864`](https://github.com/NixOS/nixpkgs/commit/1810986433e8ddce000c77876d52b44c8be5bd88) coreboot-utils: 24.02 -> 24.05
* [`01ba455c`](https://github.com/NixOS/nixpkgs/commit/01ba455c791c76c75a7ed4474b92c9f3f6702693) coreboot-utils: add jmbaur as maintainer
* [`7f3fe813`](https://github.com/NixOS/nixpkgs/commit/7f3fe8138af963b0a919600799ae38b9573a50f4) coreboot-toolchain: 24.02 -> 24.05
* [`a2afcbef`](https://github.com/NixOS/nixpkgs/commit/a2afcbefac6437b8d9450d519ae67912add70463) coreboot-toolchain: add jmbaur as maintainer
* [`2d0c213f`](https://github.com/NixOS/nixpkgs/commit/2d0c213fd4afd80f204dd2356848f00a3c9fcdda) brave: 1.65.126 -> 1.66.110
* [`ae9e4dd8`](https://github.com/NixOS/nixpkgs/commit/ae9e4dd850b7b7074826914260a0221369efc089) libressl: backport to replace expiring certs
* [`0914e6cb`](https://github.com/NixOS/nixpkgs/commit/0914e6cb2b8920b4afbae7fd15af7ce822950b16) normcap: 0.5.6 -> 0.5.7
* [`e18412f7`](https://github.com/NixOS/nixpkgs/commit/e18412f72b536db6199c78a919eade353bd84194) go-musicfox: unbreak on darwin
* [`43a918ee`](https://github.com/NixOS/nixpkgs/commit/43a918ee2e44802fede4d59780ed26929e387530) python312Packages.pdoc: 14.4.0 -> 14.5.0
* [`b493094c`](https://github.com/NixOS/nixpkgs/commit/b493094c6184e68cfceadc3342b8387295ccf9ff) netbeans: 20 -> 21
* [`be09acba`](https://github.com/NixOS/nixpkgs/commit/be09acba5397717fafd42c6a7001e43815d75f0a) python311Packages.urwid: 2.6.11 -> 2.6.12
* [`f2994c51`](https://github.com/NixOS/nixpkgs/commit/f2994c5167cfc25dd0fcc033c3044ab28798aa6e) python311Packages.trimesh: 4.3.2 -> 4.4.0
* [`c8c6dbe5`](https://github.com/NixOS/nixpkgs/commit/c8c6dbe5fc59de01f494072ca2126a8f09ec432d) ddns-go: 6.5.0 -> 6.6.0
* [`0371acc7`](https://github.com/NixOS/nixpkgs/commit/0371acc73743471dfc87fda25874d0b1c3f6d599) temporal-cli: tctl: 1.18.0 -> 1.18.1
* [`64cba052`](https://github.com/NixOS/nixpkgs/commit/64cba0525ad617bb7c9301a438cf67ee0fdcea0a) initool: 0.14.1 -> 0.15.0
* [`557aac6e`](https://github.com/NixOS/nixpkgs/commit/557aac6e99a64664575448fe91c830ac14d5d3d4) waylock: move to by-name
* [`c30b6138`](https://github.com/NixOS/nixpkgs/commit/c30b613879c691a2db664dc68f8a21acb19ffa74) mediamtx: 1.8.1 -> 1.8.2
* [`43848db5`](https://github.com/NixOS/nixpkgs/commit/43848db5300a640d4e809e92529e3d24f22818a2) morgen: 3.4.1 -> 3.4.2
* [`0af7ef7e`](https://github.com/NixOS/nixpkgs/commit/0af7ef7e4f3b3a21706edd669bdf5b627af4e25b) juju: 3.3.0 -> 3.3.5
* [`41f5f1ef`](https://github.com/NixOS/nixpkgs/commit/41f5f1ef4bddf1c115fed1bb7c86b7b7a26092f5) roundcube: 1.6.6 -> 1.6.7
* [`a2d1abe2`](https://github.com/NixOS/nixpkgs/commit/a2d1abe2371bfc568cde5ff0ad992e31d7c5c3ce) trealla: nixfmt
* [`939e2d94`](https://github.com/NixOS/nixpkgs/commit/939e2d94c2220558fa56732fb4e782f5b16db124) man-pages: 6.7 -> 6.8
* [`99c29c98`](https://github.com/NixOS/nixpkgs/commit/99c29c9820cf8648a340d80b968d8f1e206d8385) python311Packages.anthropic: 0.25.8 -> 0.26.0
* [`5b84606d`](https://github.com/NixOS/nixpkgs/commit/5b84606d50d1d4f6fd58f111fc4796e55a11d6a0) protobuf_25.tests.pythonProtobuf: Fix build
* [`954508bc`](https://github.com/NixOS/nixpkgs/commit/954508bcb51c5803a0052d4ab912c18a5a1d5339) home-manager: 0-unstable-2024-05-12 -> 0-unstable-2024-05-17
* [`1d3e6733`](https://github.com/NixOS/nixpkgs/commit/1d3e6733771b05b8e0c65fa8d107b04c6ec8d414) linux_xanmod: 6.6.30 -> 6.6.31
* [`13420b3b`](https://github.com/NixOS/nixpkgs/commit/13420b3b0e9bcc938cfa219bef81cd1b2e1c3aae) sing-box: 1.8.13 -> 1.8.14
* [`dd1fc095`](https://github.com/NixOS/nixpkgs/commit/dd1fc0955d0b69246d9b6aa5b22b7cfffd2e9fb1) linux_xanmod_latest: 6.8.9 -> 6.8.10
* [`42ba7dfb`](https://github.com/NixOS/nixpkgs/commit/42ba7dfbef884198746a9af6a34510b9ef727ff2) python311Packages.pycomposefile: 0.0.30 -> 0.0.31
* [`57f37e2c`](https://github.com/NixOS/nixpkgs/commit/57f37e2c8c5ccd4780e234bd2b8ff55de44cf3ad) xanmod-kernels: enable writeback throttling by default
* [`2d609c05`](https://github.com/NixOS/nixpkgs/commit/2d609c053845cfa1e88c033c819574fed9c14997) v2ray-domain-list-community: 20240426060244 -> 20240508170917
* [`4782b1dc`](https://github.com/NixOS/nixpkgs/commit/4782b1dc02869bc3d0f244ee2ac69d97f3ae3c15) python311Packages.oelint-parser: 3.5.2 -> 3.5.3
* [`0811c853`](https://github.com/NixOS/nixpkgs/commit/0811c853b88e164a0321a007d57ee4d4f66a56a3) all-cabal-hashes: 2024-05-15T11:29:34Z -> 2024-05-19T16:27:24Z
* [`517b3e7f`](https://github.com/NixOS/nixpkgs/commit/517b3e7fadbc44baa958921781ae6eb4fff74e46) haskellPackages: regenerate package set based on current config
* [`8af9f30c`](https://github.com/NixOS/nixpkgs/commit/8af9f30c524d78805f8e9eca9322a2ecff0bdfcc) catppuccin-gtk: 0.7.4 -> 0.7.5
* [`75d0c401`](https://github.com/NixOS/nixpkgs/commit/75d0c401baaf3670a2e1f0cd42a75f7f40d72e52) librewolf-unwrapped: 125.0.3-1 -> 126.0-1
* [`35df8612`](https://github.com/NixOS/nixpkgs/commit/35df861244b80213618c1ea59f945d0d5a0c23e7) lan-mouse: 0.7.3 -> 0.8.0
* [`81c15b0e`](https://github.com/NixOS/nixpkgs/commit/81c15b0ed222475c0914dfb7a7927fa97290c531) seaweedfs: 3.66 -> 3.67
* [`092f1e79`](https://github.com/NixOS/nixpkgs/commit/092f1e794a3f5f9ab30bbecef50223baa8938a8d) python3Packages.wordcloud: fix error "no stopwords"
* [`06ee9076`](https://github.com/NixOS/nixpkgs/commit/06ee90767db4d6c13658b2ff2c16aa5ac4fd2cc0) git-mit: 5.12.200 -> 5.12.201
* [`0cccca49`](https://github.com/NixOS/nixpkgs/commit/0cccca4926ffecdf2a6a8b9009b8e4b1055d7175) kf5: 5.115 -> 5.116
* [`903403da`](https://github.com/NixOS/nixpkgs/commit/903403da6d19d7bad3f7a5e9544c84050ed268f0) neovim-unwrapped: remove unused dependencies
* [`c60d763b`](https://github.com/NixOS/nixpkgs/commit/c60d763b96d9f686398fdd9a3106d070ab2d6e43) parabolic: 2023.12.0 -> 2024.5.0
* [`4db7a776`](https://github.com/NixOS/nixpkgs/commit/4db7a776d26a22a343eb09e6c40d7dc804439e4d) regclient: 0.5.7 -> 0.6.1
* [`04672f8f`](https://github.com/NixOS/nixpkgs/commit/04672f8f6d4c049fd5e41747210330265f19a993) python311Packages.mailchecker: 6.0.4 -> 6.0.5
* [`8c8c6886`](https://github.com/NixOS/nixpkgs/commit/8c8c688678c7d0d7516f55a8f038d0155db9139b) apkleaks: 2.6.1 -> 2.6.2
* [`f3f8d8d2`](https://github.com/NixOS/nixpkgs/commit/f3f8d8d2133a997b2236ff8817adf3e8b2e02ed7) devpod: 0.5.4 -> 0.5.7
* [`bd92bef3`](https://github.com/NixOS/nixpkgs/commit/bd92bef332afec55f2871c21a875e5d3c0fbe6d4) php.buildComposerWithPlugin: init new builder
* [`d503bc4f`](https://github.com/NixOS/nixpkgs/commit/d503bc4f4a20f137a253d4575e2d32ab7c013f8d) php.packages.composer-local-repo-plugin: init at 1.1.0
* [`6bad2e21`](https://github.com/NixOS/nixpkgs/commit/6bad2e219e75bac3e5b3f3959c07cb20894b5d51) build-support/php: use `php.packages.composer-local-repo-plugin`
* [`450e9396`](https://github.com/NixOS/nixpkgs/commit/450e9396fd52fe309f4e7ba42a3eecea316f3091) php.packages.composer: do not use `buildComposerProject`
* [`c99246f1`](https://github.com/NixOS/nixpkgs/commit/c99246f169aa2ae68a483a86d733a7645ad44089) php.packages.cyclonedx-php-composer: init at 5.2.0
* [`a35fac79`](https://github.com/NixOS/nixpkgs/commit/a35fac798e9965ed11ac2a41348f1af5ae839094) apx: 2.4.0 -> 2.4.2
* [`9d9702de`](https://github.com/NixOS/nixpkgs/commit/9d9702de2b25450d32f237fdaaad7964cd2c1597) python311Packages.azure-storage-file-share: 12.15.0 -> 12.16.0
* [`1a38ad5c`](https://github.com/NixOS/nixpkgs/commit/1a38ad5c5639fbdba01106dc6a4651522446c483) haskell.packages.ghc98.aeson: 2.2.1.0 -> 2.2.2.0
* [`3b12d3ea`](https://github.com/NixOS/nixpkgs/commit/3b12d3ea94ee6ecd37d2a6d54e7e1ec2710b5f31) trealla: remove update script
* [`ea52d6d5`](https://github.com/NixOS/nixpkgs/commit/ea52d6d5936154a0e03de6492d97ca418226e862) python311Packages.vmprof: remove patches, enable checks, clean up
* [`c835cde4`](https://github.com/NixOS/nixpkgs/commit/c835cde46b70b1b6adc15c819288f1cfbb29a57e) linuxPackages_latest.prl-tools: 19.3.0-54924 -> 19.3.1-54941
* [`9be321d6`](https://github.com/NixOS/nixpkgs/commit/9be321d6bba5bfd38881d7e834ef7ddcbe8f1f09) python311Packages.craft-parts: 1.29.0 -> 1.30.0
* [`32c14363`](https://github.com/NixOS/nixpkgs/commit/32c143639dbab7ef0af6ee17ad24ce2b32a848a3) ascii-draw: 0.3.2 -> 0.3.4
* [`362c7c7f`](https://github.com/NixOS/nixpkgs/commit/362c7c7fc077d5671fd9e079ac878fbd29c34c32) python312Packages.pillow-jpls: format with nixftm
* [`d1af472d`](https://github.com/NixOS/nixpkgs/commit/d1af472dc04421d4c3af2ea71edc15cf8afbca9f) trealla: add version tester
* [`fd42ba75`](https://github.com/NixOS/nixpkgs/commit/fd42ba7511a93862efa63909cb0072a02f93d896) trealla: 2.34.0 -> 2.35.0
* [`cb2f18d7`](https://github.com/NixOS/nixpkgs/commit/cb2f18d7861d96a95bafc3474ed561e617a1c9b8) trealla: 2.35.0 -> 2.36.0
* [`8ca2e68c`](https://github.com/NixOS/nixpkgs/commit/8ca2e68cbcd771e2436d2523642d491ee1f3056f) trealla: 2.36.0 -> 2.37.0
* [`d758da94`](https://github.com/NixOS/nixpkgs/commit/d758da94de6ed64b4ab22afcfd743899fae6b5bc) trealla: 2.37.0 -> 2.38.0
* [`9fe32398`](https://github.com/NixOS/nixpkgs/commit/9fe32398d5ccb1028d738ea33a6f2417aad1ec84) trealla: 2.38.0 -> 2.39.0
* [`406af3f7`](https://github.com/NixOS/nixpkgs/commit/406af3f789e011ea4de6bd308ca0a8abce466e8b) trealla: 2.39.0 -> 2.40.0
* [`8b06c479`](https://github.com/NixOS/nixpkgs/commit/8b06c4793b62b48a110ede4bff8c92ce2e6c1a95) trealla: 2.40.0 -> 2.50.0
* [`3331d1ec`](https://github.com/NixOS/nixpkgs/commit/3331d1ec2647f7267969ec5fb7b7b8b930219317) trealla: 2.50.0 -> 2.52.6
* [`0ca46da2`](https://github.com/NixOS/nixpkgs/commit/0ca46da2697f1d9cff9cb50779c56b6590f35f4e) python311Packages.influxdb-client: 1.42.0 -> 1.43.0
* [`d646eed9`](https://github.com/NixOS/nixpkgs/commit/d646eed968f42c462e5e13518b2d0197f7cef173) python311Packages.ibm-watson: 8.0.0 -> 8.1.0
* [`9836ec42`](https://github.com/NixOS/nixpkgs/commit/9836ec421fd3366560e113b9105cafa1deda8f01) python311Packages.rapidfuzz: 3.8.1 -> 3.9.1
* [`3b7d9fa9`](https://github.com/NixOS/nixpkgs/commit/3b7d9fa95d8170796cac2aa47dfaaff9fc75a587) golangci-lint: 1.58.1 -> 1.58.2
* [`42420dbc`](https://github.com/NixOS/nixpkgs/commit/42420dbc060d4c0cf0c2979bf8ba7400336ed9ee) golangci-lint: replace inactive maintainers with myself
* [`2318c231`](https://github.com/NixOS/nixpkgs/commit/2318c2311f7dfaf10fb8072dde65513c4709b2e2) python311Packages.python-engineio: 4.9.0 -> 4.9.1
* [`10813396`](https://github.com/NixOS/nixpkgs/commit/10813396d3c0fb2b08db2d51ccaf51c479d53fb6) jellyfin-web: 10.9.1 -> 10.9.2
* [`78771400`](https://github.com/NixOS/nixpkgs/commit/7877140075610ffde57bc215a7e2302798620630) buildDotnetModule: do not run dotnet command using env
* [`ae1cbfc2`](https://github.com/NixOS/nixpkgs/commit/ae1cbfc2dfaf6c202037869edc8ae0e77ad68303) plasticity: 1.4.20 -> 24.1.5
* [`cdc080bb`](https://github.com/NixOS/nixpkgs/commit/cdc080bbd5fd54b9c062ae41a8bd70539f07cefb) cargo-tauri: 1.6.5 -> 1.6.6
* [`c9e9061f`](https://github.com/NixOS/nixpkgs/commit/c9e9061fccc03584c5e38b63d0de7f290f012422) maintainers: add ifd3f
* [`28a5b3cd`](https://github.com/NixOS/nixpkgs/commit/28a5b3cd870cd63685ee7e92ed08ef37b7140fad) caligula: update 0.4.5 -> 0.4.6
* [`909a32d3`](https://github.com/NixOS/nixpkgs/commit/909a32d3c3bc590b248152549a99c5424c8bd2bb) dbeaver-bin: 24.0.4 -> 24.0.5
* [`c7f879bc`](https://github.com/NixOS/nixpkgs/commit/c7f879bcf0bd2c67a2b54e624a1d4274c4dbd1f9) cargo-careful: 0.4.1 -> 0.4.2
* [`3655026a`](https://github.com/NixOS/nixpkgs/commit/3655026a109108e926e32121c0825182287ffd01) openvas-scanner: 23.2.1 -> 23.3.0
* [`b272e5fe`](https://github.com/NixOS/nixpkgs/commit/b272e5fe1446f2be13ef6da330b7d4373950a1d8) python312Packages.quart: 0.19.5 -> 0.19.6
* [`42077426`](https://github.com/NixOS/nixpkgs/commit/42077426dadc785db85b2053978ecc33044bd68e) httpx: 1.6.0 -> 1.6.1
* [`60a109b3`](https://github.com/NixOS/nixpkgs/commit/60a109b34ecd9f6f61792ddadda9c368318bcd3b) helm-ls: 0.0.16 -> 0.0.17
* [`1daa08ed`](https://github.com/NixOS/nixpkgs/commit/1daa08edb9b4c4cb3e223a89e0093c9d53ef94ca) home-assistant-custom-lovelace-modules.android-tv-card: 3.7.0 -> 3.7.1
* [`06d7c87d`](https://github.com/NixOS/nixpkgs/commit/06d7c87d7450e787159a182bab72e1a5be7b4e18) oculante: 0.8.21 -> 0.8.22
* [`cfccb20d`](https://github.com/NixOS/nixpkgs/commit/cfccb20de8e3deccfdf568c692b9644188cdf11d) mdbook-admonish: 1.15.0 -> 1.16.0
* [`f72f6715`](https://github.com/NixOS/nixpkgs/commit/f72f67152a44df2d2c09a578bac8e09b9390279b) texlive: set allowSubstitutes, preferLocalBuild values ([nixos/nixpkgs⁠#312049](https://togithub.com/nixos/nixpkgs/issues/312049))
* [`21355e98`](https://github.com/NixOS/nixpkgs/commit/21355e98bad28420e5070567fafb5c9968bf9370) structorizer: 3.32-21 -> 3.32-22
* [`ae709479`](https://github.com/NixOS/nixpkgs/commit/ae7094798d53ee0923ead8d87861e8e77ab0471d) tp-auto-kbbl: use sri hash
* [`b25c0be8`](https://github.com/NixOS/nixpkgs/commit/b25c0be880c2093448d3efd82ea06e67d4a48773) ventoy-full: 1.0.97 -> 1.0.98
* [`204a20a5`](https://github.com/NixOS/nixpkgs/commit/204a20a512c28d9ae70d3706975e2ba669016760) ghidra: support extensions
* [`4e3898b7`](https://github.com/NixOS/nixpkgs/commit/4e3898b79a5d8b4008d370b6518d6c5cec1a1977) ghidra-extensions.ghidraninja-ghidra-scripts: init at unstable-2020-10-07
* [`5a7c5c4c`](https://github.com/NixOS/nixpkgs/commit/5a7c5c4c48f9866a0bffde3ede36259f32396257) ghidra-extensions.gnudisassembler: init at 11.0.2
* [`85dc0632`](https://github.com/NixOS/nixpkgs/commit/85dc0632cd7b05b6e5f7ff84623dc7c1781d13f4) ghidra-extensions.sleighdevtools: init at 11.0.2
* [`0c4afba0`](https://github.com/NixOS/nixpkgs/commit/0c4afba0b34275f3ea8fd8468a561db87a7f6241) ghidra-extensions.machinelearning: init at 11.0.2
* [`a44a2981`](https://github.com/NixOS/nixpkgs/commit/a44a2981efcd3f964434f600efeddb6cb14a88e7) make vringar maintainer
* [`48236dbe`](https://github.com/NixOS/nixpkgs/commit/48236dbe30b6eef18807f0dfe6cbb06cb9eb26db) weather: 2.4.4 -> 2.5.0
* [`af487fbf`](https://github.com/NixOS/nixpkgs/commit/af487fbf3927678ffb00045e3f0094e18a149e91) flarum: init at 1.8.1
* [`7ad171b5`](https://github.com/NixOS/nixpkgs/commit/7ad171b5add5ad362febb7fbb7de12dd0b0ddaed) nixos/flarum: init module
* [`a2353716`](https://github.com/NixOS/nixpkgs/commit/a2353716f6adc0ec2616492f9e8f6e4f36fa40c9) treewide: remove unused occurence of fetchurl argument
* [`fc54c37c`](https://github.com/NixOS/nixpkgs/commit/fc54c37c974b47f37ed3760c82b3f55e6d7d9287) listenbrainz-mpd: 2.3.5 -> 2.3.6
* [`05b0c497`](https://github.com/NixOS/nixpkgs/commit/05b0c4973fe19e0da13d520dbc930424ef26ec89) nixos/screen: fix assertion to actually execute
* [`eb9c0fab`](https://github.com/NixOS/nixpkgs/commit/eb9c0fab4b2ef8d16f5a11524de130efa5c3a8d6) hvm: 1.0.9 -> 2.0.12
* [`931de4bd`](https://github.com/NixOS/nixpkgs/commit/931de4bd6fb7a97c49ee61421950befd247e92ea) git-credential-1password: remove package
* [`ba213c00`](https://github.com/NixOS/nixpkgs/commit/ba213c00399889fc76a3323206d81da55c84a14e) thunderbird-unwrapped: 115.10.2 -> 115.11.0
* [`bb6a7baa`](https://github.com/NixOS/nixpkgs/commit/bb6a7baa6a19d8ca7bb14a8cffaf0a863c5cce04) httpx: format with nixfmt
* [`cdd1aaa8`](https://github.com/NixOS/nixpkgs/commit/cdd1aaa86fa3205b86f0c6c746c8884ba783d4b2) klipper: 0.12.0-unstable-2024-05-14 -> 0.12.0-unstable-2024-05-16
* [`25618a3a`](https://github.com/NixOS/nixpkgs/commit/25618a3ace3355d7643b744b27be723e726fbbcd) apkleaks: refactor
* [`c2440d2f`](https://github.com/NixOS/nixpkgs/commit/c2440d2f0be3d534daadad99cb434d99a8850d29) apkleaks: format with nixfmt
* [`7e531efe`](https://github.com/NixOS/nixpkgs/commit/7e531efea561dc05bf5d30ebc6628b0884b466cb) python311Packages.gehomesdk: 0.5.27 -> 0.5.28
* [`a897418a`](https://github.com/NixOS/nixpkgs/commit/a897418a3f806bef4be41223b828ca6e2251fbc5) python311Packages.pbs-installer: 2024.4.1 -> 2024.4.24
* [`303fbde3`](https://github.com/NixOS/nixpkgs/commit/303fbde3fcca6a785d882d44600232d3768cfd0a) yabai: 7.1.0 -> 7.1.1
* [`e2f08e06`](https://github.com/NixOS/nixpkgs/commit/e2f08e06d820a03ce3a8bb72b63e9103710e2896) dbeaver-bin: add `autoPatchelfHook`
* [`fa8ec670`](https://github.com/NixOS/nixpkgs/commit/fa8ec6702a3ee117c98d5519b6b054b0f75c6e9b) util-linux: 2.40.1 -> 2.39.4 (except 64-bit linux for now)
* [`b71f9b07`](https://github.com/NixOS/nixpkgs/commit/b71f9b07efd497ad01e944609a95da4a5fa3faea) python312Packages.influxdb-client: refactor
* [`49c2a98d`](https://github.com/NixOS/nixpkgs/commit/49c2a98d11471fd7d573f511bafe466bc094505a) python312Packages.influxdb-client: format with nixfmt
* [`11c93207`](https://github.com/NixOS/nixpkgs/commit/11c9320791c85daec91c1a84ae1232897e5a00d0) python311Packages.azure-storage-file-share: refactor
* [`8c656077`](https://github.com/NixOS/nixpkgs/commit/8c656077f84449470b9a415c6eef5f06a60c4dc0) python312Packages.azure-storage-file-share: format with nixfmt
* [`0c936f24`](https://github.com/NixOS/nixpkgs/commit/0c936f2466697f9b7c706b3aaa394f35ab0e41fa) python3Packages.pythonocc-core: fix build
* [`0517ff2a`](https://github.com/NixOS/nixpkgs/commit/0517ff2a5ea8ee9963f78ced0060ddf7ec5c0cd2) python312Packages.python-engineio: refactor
* [`23fa60a5`](https://github.com/NixOS/nixpkgs/commit/23fa60a5259325edf8c27023d59b0a55b96bcdf2) python311Packages.python-engineio: format with nixfmt
* [`b4c5d536`](https://github.com/NixOS/nixpkgs/commit/b4c5d536b69730cb35e3b7186fb328a7213c7a93) python311Packages.ibm-watson: refactor
* [`708d255c`](https://github.com/NixOS/nixpkgs/commit/708d255c12e208260c9c2254402cb775f24ba61d) python311Packages.ibm-watson: format with nixfmt
* [`c8599279`](https://github.com/NixOS/nixpkgs/commit/c859927990d2cfcca82ec56dd5a17fa16753b40b) python311Packages.ibm-cloud-sdk-core: refactor
* [`9929a6bb`](https://github.com/NixOS/nixpkgs/commit/9929a6bb3bde653edfff0964d673b93191a14c3f) python311Packages.ibm-cloud-sdk-core: format with nixfmt
* [`5f3ffd31`](https://github.com/NixOS/nixpkgs/commit/5f3ffd31a74a8e2b2745eb0a6dd69be85f559e4f) python312Packages.ibm-cloud-sdk-core: disable failing test on Python 3.12
* [`1e2940bb`](https://github.com/NixOS/nixpkgs/commit/1e2940bb253376994128c0a908507ce6b0e44c9f) python312Packages.urwid: refactor
* [`46b41b0c`](https://github.com/NixOS/nixpkgs/commit/46b41b0c2c454316d342e43fdd7ed0aa3e026be1) python312Packages.urwid: format with nixfmt
* [`4f9fb7a8`](https://github.com/NixOS/nixpkgs/commit/4f9fb7a8d040dabee4a3b501e5dc27939c82c0bc) pulseview: 0.4.2-unstable-2024-01-26 -> 0.4.2-unstable-2024-03-14
* [`55641354`](https://github.com/NixOS/nixpkgs/commit/55641354d0c9ac205f883bfe34a8ff35311d531b) metasploit: 6.4.8 -> 6.4.9
* [`1e21ed67`](https://github.com/NixOS/nixpkgs/commit/1e21ed67acebacc97e3106f420701bf629368d5a) python312Packages.tencentcloud-sdk-python: 3.0.1149 -> 3.0.1150
* [`4d0ee6c9`](https://github.com/NixOS/nixpkgs/commit/4d0ee6c9ec2b215097be03b9e594bf4b142b9a7c) python312Packages.gehomesdk: refactor
* [`ea99f712`](https://github.com/NixOS/nixpkgs/commit/ea99f71214667f2b42254206a630dd26259b124b) python312Packages.gehomesdk: format with nixfmt
* [`6c9a160f`](https://github.com/NixOS/nixpkgs/commit/6c9a160f7005a70a04f1e7e16c1f83dcf5cf65bc) ntpd-rs: 1.1.0 -> 1.1.2
* [`f255e6b7`](https://github.com/NixOS/nixpkgs/commit/f255e6b7276b24b5005a3d4e4bafe20b24bdf6ca) python312Packages.pycomposefile: refactor
* [`b51ff963`](https://github.com/NixOS/nixpkgs/commit/b51ff963a04886b2a1bd403f9fac4fe40e526ea3) python312Packages.pycomposefile: format with nixfmt
* [`f059856d`](https://github.com/NixOS/nixpkgs/commit/f059856d3456a06d0d7824fe01e004f2f2f6dc6f) ntpd-rs: inherit nixos test
* [`b24f690c`](https://github.com/NixOS/nixpkgs/commit/b24f690c5cbea9c21388c85b3cb2384875b21b0a) ntpd-rs: add mainProgram
* [`e5faee92`](https://github.com/NixOS/nixpkgs/commit/e5faee92224cd93c7fc763a9d6393e9acf5c22ec) ntpd-rs: add version test
* [`dfb5e8dc`](https://github.com/NixOS/nixpkgs/commit/dfb5e8dcabf81b54b378b04566c8e36b0440aa13) ntpd-rs: add getchoo to maintainers
* [`2656955e`](https://github.com/NixOS/nixpkgs/commit/2656955ebe2b84809e276cecce1787a9dc4c2b36) python312Packages.cssselect2: refactor
* [`d16fcc59`](https://github.com/NixOS/nixpkgs/commit/d16fcc59e61215adb8dacac97ce7902ec2032f3e) python312Packages.cssselect2: format with nixfmt
* [`243d4e27`](https://github.com/NixOS/nixpkgs/commit/243d4e27ec337dacc5247554930cabe3b07e0d6a) ntpd-rs: format with nixfmt
* [`038aa846`](https://github.com/NixOS/nixpkgs/commit/038aa8460b3c9fcc8b53f10b307e45658d2ae521) python312Packages.pbs-installer: format with nixfmt
* [`9121844b`](https://github.com/NixOS/nixpkgs/commit/9121844bf7d7f883d29fe5624a46ed82711066b3) wiki-js: 2.5.302 -> 2.5.303
* [`bb395fef`](https://github.com/NixOS/nixpkgs/commit/bb395fef030c9a2995d94bd46b4ead4471537a34) earthly: 0.8.10 -> 0.8.11
* [`be417b88`](https://github.com/NixOS/nixpkgs/commit/be417b886f254f7dbd3c10efc080e68c59468538) cargo-tally: 1.0.45 -> 1.0.46
* [`f37122b9`](https://github.com/NixOS/nixpkgs/commit/f37122b916c2f14de61cf67faaed5265895d0a2b) roon-server: 2.0-1407 -> 2.0-1413
* [`584c9b78`](https://github.com/NixOS/nixpkgs/commit/584c9b78cbef8a9e8715ef667cf190e061490315) pkgsStatic.libcamera: mark unsupported
* [`83986fea`](https://github.com/NixOS/nixpkgs/commit/83986fea035be8811e7d9448cbff46ac85bf3819) cargo-expand: 1.0.87 -> 1.0.88
* [`85e1f479`](https://github.com/NixOS/nixpkgs/commit/85e1f479d7ad1b30d4f81f9a95c571132d7ba84c) pkgsStatic.libGL: mark unsupported
* [`7849f680`](https://github.com/NixOS/nixpkgs/commit/7849f68032c52f9b8922c9773be0475bbf5103ab) pkgsStatic.SDL: fix build
* [`b054d170`](https://github.com/NixOS/nixpkgs/commit/b054d170785fceabcf4fef592dbb82914d78f03c) pipewire: fix cross to executable host
* [`8608070c`](https://github.com/NixOS/nixpkgs/commit/8608070cd2a691ab85d24ddec08ec30f604e8d8f) codeql: 2.17.2 -> 2.17.3
* [`e05216d1`](https://github.com/NixOS/nixpkgs/commit/e05216d1dce6c79b67464eaab3aedecc31bf7e5c) vscode-langservers-extracted: 4.9.0 -> 4.10.0
* [`d3bdb7a5`](https://github.com/NixOS/nixpkgs/commit/d3bdb7a53afbf45552386c129260e22c66bf9079) linux_rt_default: 5.4 -> 5.15 ([nixos/nixpkgs⁠#312287](https://togithub.com/nixos/nixpkgs/issues/312287))
* [`9ad7795e`](https://github.com/NixOS/nixpkgs/commit/9ad7795e146044c0fc6690010bfa3971dc1fc334) nwg-panel: 0.9.31 -> 0.9.32
* [`7d411dc9`](https://github.com/NixOS/nixpkgs/commit/7d411dc9b4efd3284ef8ddaa0674fa4a47356a3d) drawio: 24.2.5 -> 24.4.0
* [`7ae67c6f`](https://github.com/NixOS/nixpkgs/commit/7ae67c6fa2811783f214bb9227d791e5fc3e362c) espanso: update darwin patches
* [`d4d4513d`](https://github.com/NixOS/nixpkgs/commit/d4d4513dfb75bd2d9cd614248cd0e9635cb87e26) espanso: add n8henrie as maintainer
* [`8c919b68`](https://github.com/NixOS/nixpkgs/commit/8c919b68f33fab465979f4146cbb849d35b032f2) python311Packages.pymc: fix hash mismatch
* [`f093fccc`](https://github.com/NixOS/nixpkgs/commit/f093fccc9e3d761b90fa94ef7e6b80872d0bf5b7) terminal-stocks: 1.0.17 -> 1.0.18
* [`79224a65`](https://github.com/NixOS/nixpkgs/commit/79224a65d6785e9b0db1a0c86d124eaf9ecdcb3c) maintainers: add roshaen
* [`15d8d27b`](https://github.com/NixOS/nixpkgs/commit/15d8d27bd66a336e2a26537448d87cfe2d025b7a) util-linux: also downgrade static builds already
* [`bd4c5f46`](https://github.com/NixOS/nixpkgs/commit/bd4c5f46b7e0e90e2c4751e2b4cec3312b1e96d9) maintainers: add k3yss
* [`554314fe`](https://github.com/NixOS/nixpkgs/commit/554314fea549bca0e7e297aaf5aa3427d0861d64) bend: init at 0.2.9
* [`f04c6462`](https://github.com/NixOS/nixpkgs/commit/f04c646291f9b1b1b674d1533793bb5cecc8853a) owmods-cli: 0.13.1 -> 0.14.0
* [`d479157b`](https://github.com/NixOS/nixpkgs/commit/d479157bde14a9e05cdc449324d0ff9728778cb3) python311Packages.devgoldyutils, python312Packages.devgoldyutils: init at 3.0.0
* [`0a86610c`](https://github.com/NixOS/nixpkgs/commit/0a86610c1f10302c4fc7f4df49074ad1ce6f3b24) qgis: 3.36.2 -> 3.36.3
* [`b2803be0`](https://github.com/NixOS/nixpkgs/commit/b2803be04436826f832cb90faedb828c42d9f163) qgis-ltr: 3.34.6 -> 3.34.7
* [`a108d7ee`](https://github.com/NixOS/nixpkgs/commit/a108d7eee6821551f0a5c174c579e3d780e914c4) python311Packages.django-modeltranslation: 0.18.12 -> 0.18.13
* [`10b1cee6`](https://github.com/NixOS/nixpkgs/commit/10b1cee6ca731dd6537bbed1282c52b087aec686) cri-o-unwrapped: 1.30.0 -> 1.30.1
* [`b19c3d52`](https://github.com/NixOS/nixpkgs/commit/b19c3d52110e0cf60a42505a485d20fc76160728) mongosh: 2.2.5 -> 2.2.6
* [`60cdaa38`](https://github.com/NixOS/nixpkgs/commit/60cdaa38d220a4ae049af2b474a6b5cc09f5521b) libsidplayfp: 2.7.0 -> 2.7.1
* [`a6bb510c`](https://github.com/NixOS/nixpkgs/commit/a6bb510c706563f541583f094ad8729c659c19fb) haskell.packages.ghc98.attoparsec-aeson: 2.2.0.1 -> 2.2.2.0
* [`45087e16`](https://github.com/NixOS/nixpkgs/commit/45087e1666ea066a241f975aac3e9bf104c40c32) apx: install shell completions
* [`7d516d94`](https://github.com/NixOS/nixpkgs/commit/7d516d945d723314dd58aa86df72523718bd4848) firefly-iii: 6.1.15 -> 6.1.16
* [`89284c21`](https://github.com/NixOS/nixpkgs/commit/89284c211189ef8590f9d82f7b790419e45b8908) python311Packages.litellm: 1.37.9 -> 1.37.16
* [`f2ab6138`](https://github.com/NixOS/nixpkgs/commit/f2ab61384ce0e344b12131904340286dab74e536) nixVersions.git: 2.23.0pre20240510_87ab3c0e -> 2.23.0pre20240520_b7709d14
* [`b5169354`](https://github.com/NixOS/nixpkgs/commit/b5169354ffde77b9211fd4ffe5a512ab1ce5b269) haskell.packages.ghc98.ghc-exactprint: pin at 1.8.*
* [`82a02ca2`](https://github.com/NixOS/nixpkgs/commit/82a02ca25b3a3a27bf20b9525c771ac72e458972) supabase-cli: 1.167.4 -> 1.168.1
* [`eee8b0bf`](https://github.com/NixOS/nixpkgs/commit/eee8b0bff3a0d6380b1b745dd04ba545e40ba3fd) nixos/firefly-iii: Changes to module and tests
* [`5e3026b6`](https://github.com/NixOS/nixpkgs/commit/5e3026b6c5df36d8d93c44f52dcbfef28b0cf018) python311Packages.piccolo-theme: 0.21.0 -> 0.22.0
* [`5f8bc922`](https://github.com/NixOS/nixpkgs/commit/5f8bc92297bebb84379f6b35335ca83f0311ae20) cadzinho: 0.5.0 -> 0.6.0
* [`99f446dd`](https://github.com/NixOS/nixpkgs/commit/99f446dd84d651c774de60a44094c17afa0c353a) bacon: 2.17.0 -> 2.18.0
* [`6b8812ea`](https://github.com/NixOS/nixpkgs/commit/6b8812eac36529cff0b5da273df847783229d2b7) cni-plugins: 1.4.1 -> 1.5.0
* [`5411e413`](https://github.com/NixOS/nixpkgs/commit/5411e41321940f7e9c7eae31c1790722abb886f9) container2wasm: 0.6.3 -> 0.6.4
* [`ff2c7056`](https://github.com/NixOS/nixpkgs/commit/ff2c70563d9c369e70dc4d49976aa0e47eb420a2) dovecot_fts_xapian: 1.7.11 -> 1.7.12
* [`8541cdb0`](https://github.com/NixOS/nixpkgs/commit/8541cdb0d3a0a2b36f6874afaa3f315f441ddb5a) python311Packages.pythonfinder: fix build
* [`9ee17ce7`](https://github.com/NixOS/nixpkgs/commit/9ee17ce743b4ba53878fcad5639f6b3ee057177a) lxqt.qtermwidget: 1.4.0 -> 2.0.0
* [`3bd6e4e5`](https://github.com/NixOS/nixpkgs/commit/3bd6e4e5b0670bae5df44c4f88f2e243a50fb930) lxqt.qterminal: 1.4.0 -> 2.0.0
* [`22d07198`](https://github.com/NixOS/nixpkgs/commit/22d071984e45e6ef7397a18bdd8c6eaed4a1b08d) haskellPackages.cabal2nix-unstable: 2024-04-21 -> 2024-05-20
* [`3606e447`](https://github.com/NixOS/nixpkgs/commit/3606e4475ff195fad113fed4b1f24653a9000146) jan: 0.4.12 -> 0.4.13
* [`872ed3c8`](https://github.com/NixOS/nixpkgs/commit/872ed3c823667dda7d95677690e7ce9f0d6e82fe) circt: 1.74.0 -> 1.75.0
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
