### PR TITLE
niv home-manager: update e3ad5108 -> 10c7c219

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -41,10 +41,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e3ad5108f54177e6520535768ddbf1e6af54b59d",
-        "sha256": "1cp8p31yg8lzma6hydc0qzgd4l7a919cxvgigmmzqy7ggwrp5njv",
+        "rev": "10c7c219b7dae5795fb67f465a0d86cbe29f25fa",
+        "sha256": "02f6xpn863vjxzamizd5my2hc8jz974v798q0kg6v8vl2p0jqcdf",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/e3ad5108f54177e6520535768ddbf1e6af54b59d.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/10c7c219b7dae5795fb67f465a0d86cbe29f25fa.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@e3ad5108...10c7c219](https://github.com/nix-community/home-manager/compare/e3ad5108f54177e6520535768ddbf1e6af54b59d...10c7c219b7dae5795fb67f465a0d86cbe29f25fa)

* [`25dedb0d`](https://github.com/nix-community/home-manager/commit/25dedb0d52c20448f6a63cc346df1adbd6ef417e) version: allow 24.11 as state version
* [`850cb322`](https://github.com/nix-community/home-manager/commit/850cb322046ef1a268449cf1ceda5fd24d930b05) ci: make dependabot consider the release-24.05
* [`548ba194`](https://github.com/nix-community/home-manager/commit/548ba194d0676849424657cc41c59ab57d94b344) home-manager: prepare release 24.05
* [`d179da4e`](https://github.com/nix-community/home-manager/commit/d179da4e81bcd4227e8abf4b62b92c4ae214ae39) home-manager: prepare 24.11-pre
* [`e4611630`](https://github.com/nix-community/home-manager/commit/e4611630c3cc8ed618b48d92f6291f65be9f7913) ci: fix manual build in sourcehut build
* [`6a35d196`](https://github.com/nix-community/home-manager/commit/6a35d1969e4626a0f8d285e60b6cfd331e2687a9) ci: bump cachix/cachix-action from 13 to 15
* [`fb7feac5`](https://github.com/nix-community/home-manager/commit/fb7feac55b2b95692b58e388a608fc326ec66608) Translate using Weblate (Chinese (Simplified))
* [`943f1e97`](https://github.com/nix-community/home-manager/commit/943f1e97fc171476f0235d7657448f9315465f18) Translate using Weblate (German)
* [`cd29501b`](https://github.com/nix-community/home-manager/commit/cd29501b799c2621276376fb714cd2532fb2f0f7) Translate using Weblate (Japanese)
* [`517682ed`](https://github.com/nix-community/home-manager/commit/517682ed21a19c193f09f043ecd8dc4002a962c3) Translate using Weblate (Japanese)
* [`05e6ba83`](https://github.com/nix-community/home-manager/commit/05e6ba83eb3585ce0aff7b41e4bd0e317d05ad4a) Translate using Weblate (Danish)
* [`b2a4ddf6`](https://github.com/nix-community/home-manager/commit/b2a4ddf657e6ad87569665545ffaf7dd5e9a02af) flake.lock: Update
* [`5d151429`](https://github.com/nix-community/home-manager/commit/5d151429e1e79107acf6d06dcc5ace4e642ec239) kanshi: fix configuration example
* [`8f8eb15c`](https://github.com/nix-community/home-manager/commit/8f8eb15c6d66afa7eef0dd6357bbb41c3aeb1099) fd: don't create shell aliases with empty args
* [`65e0f5aa`](https://github.com/nix-community/home-manager/commit/65e0f5aa25619ee992e1eb3ad69f227a46b0a1b1) eza: don't create shell aliases with empty args
* [`e8482a79`](https://github.com/nix-community/home-manager/commit/e8482a798fd85d6316dcf42387ad30b3a079585e) yazi: use builtin cd
* [`0cf552f3`](https://github.com/nix-community/home-manager/commit/0cf552f39f1f8567a8e76e14c90e2843634182b5) bash: add missing 'ignoreboth' to historyControl
* [`7ac529c2`](https://github.com/nix-community/home-manager/commit/7ac529c22129ee9fb024744ede18f73e6b148ede) hyprland: onChange: check XDG_RUNTIME_DIR as well
* [`7e769959`](https://github.com/nix-community/home-manager/commit/7e769959e8ec80333bb262d685333003bf013c1b) hyprland: onChange: remove subshell comment
* [`939375b3`](https://github.com/nix-community/home-manager/commit/939375b39661c7b5d2533c9cd7be6117ed98896a) khal: add package option
* [`90010df1`](https://github.com/nix-community/home-manager/commit/90010df15878762ff359e4fe391355a9dcad0bcf) topgrade: update example config
* [`10c7c219`](https://github.com/nix-community/home-manager/commit/10c7c219b7dae5795fb67f465a0d86cbe29f25fa) listenbrainz-mpd: fix config example
