### PR TITLE
niv nerd-icons.el: update 5ed32f43 -> 43222903

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -77,10 +77,10 @@
         "homepage": null,
         "owner": "rainstormstudio",
         "repo": "nerd-icons.el",
-        "rev": "5ed32f43f2e92ac2600d0ff823ec75e4476cc53e",
-        "sha256": "0x0zipfdm6w861kmw3jjjsc1jqxdw0ggpylvwxbgbspfngl83awj",
+        "rev": "4322290303f2e12efd5685a0d22d76ed76ec7349",
+        "sha256": "0z360gr820a1xig9samxzgzmc99hjx17hkfrmpqwb8bzix37n84j",
         "type": "tarball",
-        "url": "https://github.com/rainstormstudio/nerd-icons.el/archive/5ed32f43f2e92ac2600d0ff823ec75e4476cc53e.tar.gz",
+        "url": "https://github.com/rainstormstudio/nerd-icons.el/archive/4322290303f2e12efd5685a0d22d76ed76ec7349.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "niv": {


### PR DESCRIPTION
## Changelog for nerd-icons.el:
Branch: main
Commits: [rainstormstudio/nerd-icons.el@5ed32f43...43222903](https://github.com/rainstormstudio/nerd-icons.el/compare/5ed32f43f2e92ac2600d0ff823ec75e4476cc53e...4322290303f2e12efd5685a0d22d76ed76ec7349)

* [`5a7bd1d6`](https://github.com/rainstormstudio/nerd-icons.el/commit/5a7bd1d6c92271249d2575b586322a26c19d331c) Add pptx icon
* [`4e54405e`](https://github.com/rainstormstudio/nerd-icons.el/commit/4e54405e371304d0c84540ba824d698f71c90063) ci: Exclude macos tests below 28.x
