### PR TITLE
niv niv: update 5f0defe2 -> f7c53883

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -89,10 +89,10 @@
         "homepage": "https://github.com/nmattia/niv",
         "owner": "nmattia",
         "repo": "niv",
-        "rev": "5f0defe2f71020812e39a51dab68a64fb293ace1",
-        "sha256": "12wscam2163pirzbmz0pw6cmnn6xa0dy8ax5kxi5bgxcp728vxyd",
+        "rev": "f7c538837892dd2eb83567c9f380a11efb59b53f",
+        "sha256": "0xl33k24vfc29cg9lnp95kvcq69qbq5fzb7jk9ig4lgrhaarh651",
         "type": "tarball",
-        "url": "https://github.com/nmattia/niv/archive/5f0defe2f71020812e39a51dab68a64fb293ace1.tar.gz",
+        "url": "https://github.com/nmattia/niv/archive/f7c538837892dd2eb83567c9f380a11efb59b53f.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {


### PR DESCRIPTION
## Changelog for niv:
Branch: master
Commits: [nmattia/niv@5f0defe2...f7c53883](https://github.com/nmattia/niv/compare/5f0defe2f71020812e39a51dab68a64fb293ace1...f7c538837892dd2eb83567c9f380a11efb59b53f)

* [`0ca27c51`](https://github.com/nmattia/niv/commit/0ca27c51ab5a1944af99409bef7c3db881c8115a) --- ([nmattia/niv⁠#401](https://togithub.com/nmattia/niv/issues/401))
* [`84fed676`](https://github.com/nmattia/niv/commit/84fed676e415431ab5b62c9e0ac09776313de25d) Add info when init with cached Nixpkgs ([nmattia/niv⁠#402](https://togithub.com/nmattia/niv/issues/402))
* [`f7c53883`](https://github.com/nmattia/niv/commit/f7c538837892dd2eb83567c9f380a11efb59b53f) hlint refactor ([nmattia/niv⁠#403](https://togithub.com/nmattia/niv/issues/403))
