### PR TITLE
niv emacs-overlay: update 7c0c76c9 -> 35b305a1

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "7c0c76c9e970eb75efa0a8dc2a3b8aa5b1028613",
-        "sha256": "0j4mh0j5x5w4dzgjwficvhwy2v78k94z8skdqcqjv1d775cdqx41",
+        "rev": "35b305a1706b6fa284f81aa5dc37ccfdbfcb2e99",
+        "sha256": "1z9ayvsdvr09kz33pn7vcdr2jdkqb20wzmvbxhrddn83xc2yrcfp",
         "type": "tarball",
-        "url": "https://github.com/nix-community/emacs-overlay/archive/7c0c76c9e970eb75efa0a8dc2a3b8aa5b1028613.tar.gz",
+        "url": "https://github.com/nix-community/emacs-overlay/archive/35b305a1706b6fa284f81aa5dc37ccfdbfcb2e99.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "fast-syntax-highlighting": {


### PR DESCRIPTION
## Changelog for emacs-overlay:
Branch: master
Commits: [nix-community/emacs-overlay@7c0c76c9...35b305a1](https://github.com/nix-community/emacs-overlay/compare/7c0c76c9e970eb75efa0a8dc2a3b8aa5b1028613...35b305a1706b6fa284f81aa5dc37ccfdbfcb2e99)

* [`61ab87f5`](https://github.com/nix-community/emacs-overlay/commit/61ab87f5593d4b9478f0be00dab8a72ea667eea1) Updated flake inputs
* [`ba78fc2c`](https://github.com/nix-community/emacs-overlay/commit/ba78fc2ce1946ddd7185d1fd15e5cc7fb655b236) Updated elpa
* [`bc8db8d6`](https://github.com/nix-community/emacs-overlay/commit/bc8db8d6d01141ab90b17590446a2699557bec9b) Updated melpa
* [`2a294b09`](https://github.com/nix-community/emacs-overlay/commit/2a294b099b479a62a5e37964dfe5ceb75e74fdd8) Updated emacs
* [`1b287b19`](https://github.com/nix-community/emacs-overlay/commit/1b287b19f392c04b4e0314885339e89c2393a347) Updated melpa
* [`ed33acec`](https://github.com/nix-community/emacs-overlay/commit/ed33acecc69155dc98587331236e7d5bc2308205) Updated emacs
* [`0b739e0c`](https://github.com/nix-community/emacs-overlay/commit/0b739e0c6688d86c481285477495fde28316f011) Updated nongnu
* [`ce14ca66`](https://github.com/nix-community/emacs-overlay/commit/ce14ca664285a33988892c485f12d20fcb792d49) Updated elpa
* [`c06c47b0`](https://github.com/nix-community/emacs-overlay/commit/c06c47b024dd6d92f7b7062ce3b14897f7b43c99) Updated melpa
* [`ab32c6d8`](https://github.com/nix-community/emacs-overlay/commit/ab32c6d8e3f0a20d448540beb31208894066a6c7) Updated emacs
* [`69156805`](https://github.com/nix-community/emacs-overlay/commit/69156805053e7ca62dbf081b3910d5ee068d3ce6) Updated flake inputs
* [`7f1f3037`](https://github.com/nix-community/emacs-overlay/commit/7f1f3037c9c447b60ccd51f35e4565feef3d7849) Updated nongnu
* [`ff9afc2d`](https://github.com/nix-community/emacs-overlay/commit/ff9afc2dc6fff897e02c211a460d9574cf9d39a3) Updated elpa
* [`6f76c97c`](https://github.com/nix-community/emacs-overlay/commit/6f76c97c31de970e2654025725098b254c6ae032) Updated melpa
* [`cccda850`](https://github.com/nix-community/emacs-overlay/commit/cccda8508481ea8c8ff4e50a297900ed54b26dc3) Updated emacs
* [`16d97618`](https://github.com/nix-community/emacs-overlay/commit/16d976187c0e855c506b10d12e977eba24f6e9fc) Updated melpa
* [`b49e31f5`](https://github.com/nix-community/emacs-overlay/commit/b49e31f50e9772f18e582b8e75bbe9d5f08d2b1f) Updated emacs
* [`172b32e3`](https://github.com/nix-community/emacs-overlay/commit/172b32e362e021efb78fbfcbf7ced88698ef03e0) Updated nongnu
* [`0696b2f1`](https://github.com/nix-community/emacs-overlay/commit/0696b2f1559daf7602cec05b2675ee0731cce4d8) Updated elpa
* [`3d3e4841`](https://github.com/nix-community/emacs-overlay/commit/3d3e48415335b09ceec614d4cdd0fdbb8fb0199e) Updated melpa
* [`8f772539`](https://github.com/nix-community/emacs-overlay/commit/8f77253911c7dc3ac829781ac7f37d1d35447c5a) Updated emacs
* [`08e21057`](https://github.com/nix-community/emacs-overlay/commit/08e210578b472597476754952196ce66b6fdffcc) Updated flake inputs
* [`163af23c`](https://github.com/nix-community/emacs-overlay/commit/163af23c6cf7a425ca94f58981d82ab0c996d8a3) Updated elpa
* [`8363d3fb`](https://github.com/nix-community/emacs-overlay/commit/8363d3fbffd191406fb6874fca78cfc6325c6ad0) Updated melpa
* [`1a2b6855`](https://github.com/nix-community/emacs-overlay/commit/1a2b6855018b3351cfc434fac9dc89df395b93a6) Updated emacs
* [`24949fef`](https://github.com/nix-community/emacs-overlay/commit/24949fef43a9d00443ea080f9a56868bf9414614) Updated melpa
* [`ac73346a`](https://github.com/nix-community/emacs-overlay/commit/ac73346af1405eb21d5c39071cc30f468a3789c3) Updated emacs
* [`d58f4039`](https://github.com/nix-community/emacs-overlay/commit/d58f4039cf75aa882f1b87a164b695fcca64b625) Updated elpa
* [`a698edfd`](https://github.com/nix-community/emacs-overlay/commit/a698edfdf26c436e20856dc60606ae7321f70a9d) Updated melpa
* [`d72860d6`](https://github.com/nix-community/emacs-overlay/commit/d72860d651e27709884a8a2ef85f1e99e5eae21c) Updated emacs
* [`e1f832c7`](https://github.com/nix-community/emacs-overlay/commit/e1f832c78cbcdf726a08234a5da608c0e42b4e4e) Updated elpa
* [`2b0d7e1d`](https://github.com/nix-community/emacs-overlay/commit/2b0d7e1d97b9585f902f5b1f726d120926ec1e8d) Updated melpa
* [`baf77948`](https://github.com/nix-community/emacs-overlay/commit/baf779480d5a7adc11a5e7439a088855051024bf) Updated emacs
* [`54d8489f`](https://github.com/nix-community/emacs-overlay/commit/54d8489f448aa8c7ee9a7c54b4ca962be43bf244) Updated flake inputs
* [`4b953338`](https://github.com/nix-community/emacs-overlay/commit/4b953338bac72ba61ff39ae80a542b09dd4c58f7) Updated melpa
* [`95efc569`](https://github.com/nix-community/emacs-overlay/commit/95efc569e1dd1fd3f25aeb1baaf754415e4eafe2) Updated emacs
* [`b5fdda76`](https://github.com/nix-community/emacs-overlay/commit/b5fdda760466419fd065bf1a0bd5c7a72aeb39e3) Updated elpa
* [`5c7d78da`](https://github.com/nix-community/emacs-overlay/commit/5c7d78da8c4506263b991239eda23d179c3ba183) Updated melpa
* [`146fe1e3`](https://github.com/nix-community/emacs-overlay/commit/146fe1e340847eeee5243f77af634d9d1b990c8e) Updated emacs
* [`e73f687f`](https://github.com/nix-community/emacs-overlay/commit/e73f687f6a20850ae4aa8b3a613e183a87d9aba0) Updated elpa
* [`5eda9c89`](https://github.com/nix-community/emacs-overlay/commit/5eda9c899cf20973476526f88680ba0309715be6) Updated melpa
* [`53d749b4`](https://github.com/nix-community/emacs-overlay/commit/53d749b467ee0727d8417756137f4dcf657917dc) Updated emacs
* [`a14984ea`](https://github.com/nix-community/emacs-overlay/commit/a14984eac4945b941e0b209d76d31766cd3a2cd6) Updated flake inputs
* [`85a01953`](https://github.com/nix-community/emacs-overlay/commit/85a0195343cd4de9093117b953b06b657a988c1a) Updated melpa
* [`055941ef`](https://github.com/nix-community/emacs-overlay/commit/055941efd5f9a4fc0477c3c9779ffca30c55f5f0) Updated emacs
* [`e8108cc8`](https://github.com/nix-community/emacs-overlay/commit/e8108cc8f392ef1719bc96e31c94d7cef819feec) Updated flake inputs
* [`7d5a0b46`](https://github.com/nix-community/emacs-overlay/commit/7d5a0b46e8cf9d0079539c8873d65b4fc1c1a5af) Updated elpa
* [`936895c7`](https://github.com/nix-community/emacs-overlay/commit/936895c776d3d965453dc972435b65e0f293b164) Updated melpa
* [`e01c8755`](https://github.com/nix-community/emacs-overlay/commit/e01c875522b70bc2791e795980d61b2e80b9f30b) Updated emacs
* [`a24fa568`](https://github.com/nix-community/emacs-overlay/commit/a24fa56819355b496c545797c0747504649613f8) Updated flake inputs
* [`136fe1fe`](https://github.com/nix-community/emacs-overlay/commit/136fe1fe9c4f491810613ebfaea38394b76d5122) Updated elpa
* [`ddc32ad5`](https://github.com/nix-community/emacs-overlay/commit/ddc32ad5afdcb4625e42683de878a07846e9616e) Updated melpa
* [`03e77b28`](https://github.com/nix-community/emacs-overlay/commit/03e77b28d0e617a9961762986a9645e8fd21a8d2) Updated emacs
* [`f9c0d9af`](https://github.com/nix-community/emacs-overlay/commit/f9c0d9afdf959f34738e528af323291993492230) Updated melpa
* [`410be154`](https://github.com/nix-community/emacs-overlay/commit/410be154ee103e0477f00ea0edc28fe9050dd69f) Updated emacs
* [`33ef99d1`](https://github.com/nix-community/emacs-overlay/commit/33ef99d1547a6a3647b0a75be44d7766d1e1db2d) Updated elpa
* [`e395276e`](https://github.com/nix-community/emacs-overlay/commit/e395276e0db915ae9400c764a71672852771c9ed) Updated melpa
* [`efbc49e6`](https://github.com/nix-community/emacs-overlay/commit/efbc49e6be628b0a4ef55b731255a266bdaafd97) Updated emacs
* [`4767b555`](https://github.com/nix-community/emacs-overlay/commit/4767b55535736a016ac4e900905ed35c69b4064e) Updated flake inputs
* [`85142911`](https://github.com/nix-community/emacs-overlay/commit/851429115e5ba64520fc5f4e9b3b665ad59df996) Updated elpa
* [`b4ea3fd0`](https://github.com/nix-community/emacs-overlay/commit/b4ea3fd0daf8c699e45026217c356bd0378464b7) Updated melpa
* [`f2804916`](https://github.com/nix-community/emacs-overlay/commit/f2804916dbc4655722f743b5299b6f706335b25b) Updated emacs
* [`03e43bed`](https://github.com/nix-community/emacs-overlay/commit/03e43bed591d54c2a65370567d9e1ca2f0798d11) Updated elpa
* [`3123b5c4`](https://github.com/nix-community/emacs-overlay/commit/3123b5c48655266adfba5979a88264f1d8d72ba9) Updated melpa
* [`2fd9e33a`](https://github.com/nix-community/emacs-overlay/commit/2fd9e33a0e73cd390f35ecefe89ec9e271e4c2cb) Updated emacs
* [`ba02b473`](https://github.com/nix-community/emacs-overlay/commit/ba02b47330f73f776047a15a09dac06e3c423795) Updated elpa
* [`6c7114f4`](https://github.com/nix-community/emacs-overlay/commit/6c7114f4bb26d1f7ad19502e63c06a201188b6e5) Updated melpa
* [`157ca12a`](https://github.com/nix-community/emacs-overlay/commit/157ca12a7b661b7c8cf4aec0ee77b5ec12bf115b) Updated emacs
* [`d4426bf5`](https://github.com/nix-community/emacs-overlay/commit/d4426bf5cc0e37247fb48b391c553e3957ceaafc) Updated melpa
* [`fec26d98`](https://github.com/nix-community/emacs-overlay/commit/fec26d980c4598c52d6dd697660a60026fe96f3a) Updated emacs
* [`c1cb824a`](https://github.com/nix-community/emacs-overlay/commit/c1cb824a430bc5cdee2ff6f53a65de91fd95951a) Updated elpa
* [`05b36231`](https://github.com/nix-community/emacs-overlay/commit/05b362313783e1069406ed5279897bc63ec10d4d) Updated melpa
* [`b2b29771`](https://github.com/nix-community/emacs-overlay/commit/b2b29771bfc8b8ce80839915c0d6828ed5ade2fa) Updated emacs
* [`cb2d643b`](https://github.com/nix-community/emacs-overlay/commit/cb2d643b5aed7de08b762fd6e1db3f8adb619580) Updated flake inputs
* [`3c3b4dbc`](https://github.com/nix-community/emacs-overlay/commit/3c3b4dbceb17a230909e8e17c6b539871e2fa4d3) Updated elpa
* [`7dc34ea1`](https://github.com/nix-community/emacs-overlay/commit/7dc34ea1703ab236983800ef9470759a2f3ed548) Updated melpa
* [`2a6f4ebb`](https://github.com/nix-community/emacs-overlay/commit/2a6f4ebbe6ce61ad2cdcd826581d8c6fb3dfcce8) Updated emacs
* [`92a51c0a`](https://github.com/nix-community/emacs-overlay/commit/92a51c0acabbf30f6d4c3b2e6ecd72d520903382) Updated flake inputs
* [`89397da3`](https://github.com/nix-community/emacs-overlay/commit/89397da38d451c86d683bdfa19efe52eda7ad2f6) Updated elpa
* [`7c9dbbcb`](https://github.com/nix-community/emacs-overlay/commit/7c9dbbcb358be717e1d602a85d9903441b5e8d3a) Updated melpa
* [`c6e73087`](https://github.com/nix-community/emacs-overlay/commit/c6e7308733e76548d10615d74669919a243e93c8) Updated emacs
* [`5e0523b3`](https://github.com/nix-community/emacs-overlay/commit/5e0523b3b8ec36d713c09ac8cec1d94ce9906c46) Updated nongnu
* [`3c648e44`](https://github.com/nix-community/emacs-overlay/commit/3c648e440c12f85e7521861753ec6bf4e041f595) Updated elpa
* [`b6f89e18`](https://github.com/nix-community/emacs-overlay/commit/b6f89e181c3a90712f0108ff42ca964b1acb57da) Updated melpa
* [`248d81ee`](https://github.com/nix-community/emacs-overlay/commit/248d81eeb6153e7fe12f279f850b423b857516cf) Updated emacs
* [`692fcf42`](https://github.com/nix-community/emacs-overlay/commit/692fcf42b78e12ef216a4bec99b109cfd0288a44) Updated flake inputs
* [`fbaa77e2`](https://github.com/nix-community/emacs-overlay/commit/fbaa77e266724ead2faf525c0e272d051cb954ef) Updated melpa
* [`2971e734`](https://github.com/nix-community/emacs-overlay/commit/2971e734eab0a7692800174c27e96c23dbca263f) Updated emacs
* [`1e108b1c`](https://github.com/nix-community/emacs-overlay/commit/1e108b1c8ed684c55f4e72901d4523fa53182310) Updated nongnu
* [`a2eb5a3b`](https://github.com/nix-community/emacs-overlay/commit/a2eb5a3bbcde61ed12e7474b22b35119e6b9f5d5) Updated elpa
* [`169c56cc`](https://github.com/nix-community/emacs-overlay/commit/169c56cc67e22e8796ab877b4a6af385fc2e10af) Updated melpa
* [`dab95160`](https://github.com/nix-community/emacs-overlay/commit/dab951609a54ec6e0dfee52950c49d7edac5cd90) Updated emacs
* [`601b0ebf`](https://github.com/nix-community/emacs-overlay/commit/601b0ebf30284fe8c39a4334ec9f20d334aa82e7) Updated nongnu
* [`4a814b7d`](https://github.com/nix-community/emacs-overlay/commit/4a814b7d5ab563fc6a6513f5df7aaa01b490f50f) Updated elpa
* [`e522fe44`](https://github.com/nix-community/emacs-overlay/commit/e522fe44165986ea385c1e3bd3c54499deb774b5) Updated melpa
* [`62004f5e`](https://github.com/nix-community/emacs-overlay/commit/62004f5ead76e154c4f19e27a94cd24fb4db59aa) Updated emacs
* [`60218560`](https://github.com/nix-community/emacs-overlay/commit/60218560e0c7ccfd27af007a5e861fc93a075f20) Updated melpa
* [`e41288bc`](https://github.com/nix-community/emacs-overlay/commit/e41288bc8adbd180681d12eb4b9274a7bae7f974) Updated emacs
* [`4a9ff1b5`](https://github.com/nix-community/emacs-overlay/commit/4a9ff1b53fde5dc90c1464b03676f4d9af9ad8bf) Updated nongnu
* [`de2b6b5f`](https://github.com/nix-community/emacs-overlay/commit/de2b6b5f2f87ecd993eaf8368f48d487f023f953) Updated elpa
* [`eac55caf`](https://github.com/nix-community/emacs-overlay/commit/eac55caf45920552d8f4af95e8418aefec9d74fa) Updated melpa
* [`1f711204`](https://github.com/nix-community/emacs-overlay/commit/1f7112047b60e5a5719721b357477178675f8c5e) Updated emacs
* [`c43b24f8`](https://github.com/nix-community/emacs-overlay/commit/c43b24f81989a040ae98d3e4ffae71c7e0463057) Updated flake inputs
* [`1628a0f7`](https://github.com/nix-community/emacs-overlay/commit/1628a0f7cc9558e57c5d6d3a48665f5ee15e220e) Updated elpa
* [`1efe49d8`](https://github.com/nix-community/emacs-overlay/commit/1efe49d8a72bdbbe4c2a55c95f50900066befb5d) Updated melpa
* [`cacd688b`](https://github.com/nix-community/emacs-overlay/commit/cacd688b09b4ef4ddff5ff12ede2f24ca25119ad) Updated emacs
* [`0197196a`](https://github.com/nix-community/emacs-overlay/commit/0197196a4b3568f8a78fe17462f81a379c70560f) Updated melpa
* [`8ccd52ca`](https://github.com/nix-community/emacs-overlay/commit/8ccd52ca342806a99fba8c684bfd43c1d3fe43dd) Updated emacs
* [`5c04ea98`](https://github.com/nix-community/emacs-overlay/commit/5c04ea9889392eb547bcfce8ea0f9a8eb65451e7) Updated flake inputs
* [`7adfc898`](https://github.com/nix-community/emacs-overlay/commit/7adfc8989f7bc72302277a41383a8f5a37767315) Updated elpa
* [`8ec7104a`](https://github.com/nix-community/emacs-overlay/commit/8ec7104a671ea3dce152a5c40b2f7b3395f1291a) Updated melpa
* [`dc94f94b`](https://github.com/nix-community/emacs-overlay/commit/dc94f94b49abb487f80e91978a1392e3e2b19fae) Updated emacs
* [`19e2ace4`](https://github.com/nix-community/emacs-overlay/commit/19e2ace4b58097896974577165045386ea307bd5) Updated nongnu
* [`a5c58d38`](https://github.com/nix-community/emacs-overlay/commit/a5c58d38a46c3639d8400a6b3e6f937e6c29bf0c) Updated elpa
* [`4fe6cc37`](https://github.com/nix-community/emacs-overlay/commit/4fe6cc37d9fee05e46aed5cc94ed145defb72380) Updated melpa
* [`6ca9fed2`](https://github.com/nix-community/emacs-overlay/commit/6ca9fed2e0e1584d6394456aed3a9b2ed3571ac6) Updated emacs
* [`d704255d`](https://github.com/nix-community/emacs-overlay/commit/d704255dce2f76bc791111f12e5824bf633daec1) Updated melpa
* [`cf4f7778`](https://github.com/nix-community/emacs-overlay/commit/cf4f77786a4805f0f815d5859913b03da6009270) Updated emacs
* [`066147df`](https://github.com/nix-community/emacs-overlay/commit/066147dff84b10accaa698940dc0707853c0ac15) Updated flake inputs
* [`0c29d29c`](https://github.com/nix-community/emacs-overlay/commit/0c29d29cc9b96949b1b94e8717b986ccd8c12268) Updated melpa
* [`c806a21d`](https://github.com/nix-community/emacs-overlay/commit/c806a21d556a5d2c623ddfa24ca35e4138df62e8) Updated emacs
* [`aa7267e7`](https://github.com/nix-community/emacs-overlay/commit/aa7267e779349886b4132611e147607afc633edb) Updated elpa
* [`aaa7fa57`](https://github.com/nix-community/emacs-overlay/commit/aaa7fa576683e31f4eca6fe884d3c894f821507d) Updated melpa
* [`f5692c4b`](https://github.com/nix-community/emacs-overlay/commit/f5692c4baf5f689f1c0f574f4b744ad146fc4a30) Updated emacs
* [`f7cdbd5e`](https://github.com/nix-community/emacs-overlay/commit/f7cdbd5e8bc8a79e484d81ac77a204b0b3034ae7) Updated melpa
* [`14922c0e`](https://github.com/nix-community/emacs-overlay/commit/14922c0e5074b5532ab003cd0fa6b9003c666045) Updated emacs
* [`799a40e1`](https://github.com/nix-community/emacs-overlay/commit/799a40e18eb3be564a33966a0bc177e5a50ec588) Updated elpa
* [`d9bc5860`](https://github.com/nix-community/emacs-overlay/commit/d9bc58601058e7876ed591460b1614d7fa297a18) Updated melpa
* [`0a98303e`](https://github.com/nix-community/emacs-overlay/commit/0a98303e2db66b6106623829ef681706d772b9cd) Updated emacs
* [`f36a1da9`](https://github.com/nix-community/emacs-overlay/commit/f36a1da91bed335d50a00a29147d70a4f30f9472) Updated nongnu
* [`c93fb504`](https://github.com/nix-community/emacs-overlay/commit/c93fb504806f8df5e4ddbd2eea813fe0cc2baef9) Updated elpa
* [`e25b6be3`](https://github.com/nix-community/emacs-overlay/commit/e25b6be33695d35ceb5059b37af4da3ba7af8e4d) Updated melpa
* [`06566ce7`](https://github.com/nix-community/emacs-overlay/commit/06566ce72388a0f620df7322bceb3d310a0723ec) Updated emacs
* [`ce95fab9`](https://github.com/nix-community/emacs-overlay/commit/ce95fab9373f83495aa8966d58dc92b67c2abf25) Updated melpa
* [`c20b99a4`](https://github.com/nix-community/emacs-overlay/commit/c20b99a4ea0750681a9aba949a91cce211c64dc5) Updated emacs
* [`015d5bd7`](https://github.com/nix-community/emacs-overlay/commit/015d5bd777501fedbebf4de4ed5c2911f1adfe67) Updated flake inputs
* [`8a69eae9`](https://github.com/nix-community/emacs-overlay/commit/8a69eae94cd179992e50bf758d727765c32092a5) Updated elpa
* [`4d33075e`](https://github.com/nix-community/emacs-overlay/commit/4d33075e0c272afc89ded7cb5e6d11745905dee7) Updated melpa
* [`05adf94f`](https://github.com/nix-community/emacs-overlay/commit/05adf94f1e6e12f3765f175c91943b4597a4c9c8) Updated emacs
* [`d31697b7`](https://github.com/nix-community/emacs-overlay/commit/d31697b702a37e2fbab10c3b2dacabf7bf6e30d9) Updated elpa
* [`3f90b6b9`](https://github.com/nix-community/emacs-overlay/commit/3f90b6b9cc160553c05fb76962f5eaab2bd95e47) Updated melpa
* [`f7262386`](https://github.com/nix-community/emacs-overlay/commit/f72623860d10a4fe8c49ced4fb1e62b8aafba83b) Updated emacs
* [`964aa45b`](https://github.com/nix-community/emacs-overlay/commit/964aa45bbf942907446db4a389c6a0086072dee8) Updated flake inputs
* [`79987143`](https://github.com/nix-community/emacs-overlay/commit/799871438560ec035b58b44199971a8ac13037d0) Updated emacs
* [`dfce4faf`](https://github.com/nix-community/emacs-overlay/commit/dfce4fafbf0b0b9b1d62cb500815929aeeb55353) Updated nongnu
* [`32ffea68`](https://github.com/nix-community/emacs-overlay/commit/32ffea682df7a1302c17fef48b3067370b71cfca) Updated elpa
* [`753b273b`](https://github.com/nix-community/emacs-overlay/commit/753b273b71af6d181b6182ba530e8eb12e5178e9) Updated emacs
* [`07d8fe47`](https://github.com/nix-community/emacs-overlay/commit/07d8fe47e57552af55a256ca3edff1e87718903b) Updated elpa
* [`238eefc3`](https://github.com/nix-community/emacs-overlay/commit/238eefc3f18c7079b2ec3fa4c1b9b11e1c7dcc7c) Updated emacs
* [`29f0f1b3`](https://github.com/nix-community/emacs-overlay/commit/29f0f1b300f29d8a662666d96f04770c96d14617) Updated emacs
* [`bcd5bf2e`](https://github.com/nix-community/emacs-overlay/commit/bcd5bf2e7eb903ce279dbe3430b06bb89b009cd2) Updated elpa
* [`f01ccf8b`](https://github.com/nix-community/emacs-overlay/commit/f01ccf8bce08f1f65c1d22cc46c34154fbf9b951) Updated emacs
* [`8e63e08e`](https://github.com/nix-community/emacs-overlay/commit/8e63e08e9ce32ab53a77cd235b85eefb88c8e51c) Updated elpa
* [`49e8b316`](https://github.com/nix-community/emacs-overlay/commit/49e8b3163e27221484c57c76f4a86fb5e8a4cc6f) Updated emacs
* [`9ddac5b5`](https://github.com/nix-community/emacs-overlay/commit/9ddac5b56467772b1962c71191de3e22b4d1fff6) Updated emacs
* [`95d1baf2`](https://github.com/nix-community/emacs-overlay/commit/95d1baf2d97bd7da291b0316fbe29d8f6671b02b) recipes-archive-melpa: fix incorrect source hashes
* [`0b7067e4`](https://github.com/nix-community/emacs-overlay/commit/0b7067e48e2901ec91b3fa69bb45f7d5a8a7de96) recipes-archive-melpa: fix more incorrect source hashes
* [`8e6b8353`](https://github.com/nix-community/emacs-overlay/commit/8e6b835321a09fad89b4835e408c9a1c88205b88) Updated flake inputs
* [`bef180cf`](https://github.com/nix-community/emacs-overlay/commit/bef180cfb57fd1b1f1cbaea1cea0817dfef9710d) Updated elpa
* [`b54ed655`](https://github.com/nix-community/emacs-overlay/commit/b54ed655e16db6d9b43b147f8e3b23cb704f1733) Updated emacs
* [`b89d09e9`](https://github.com/nix-community/emacs-overlay/commit/b89d09e904b449fb6140c2f3e3dfc7af03749b3b) Updated flake inputs
* [`bde229e6`](https://github.com/nix-community/emacs-overlay/commit/bde229e68fadd64f09386be9e21a7b748ad37d32) Updated elpa
* [`aa7850d6`](https://github.com/nix-community/emacs-overlay/commit/aa7850d6fbbaf64a26c0c6be6931ac9b8c98b881) Updated melpa
* [`66d6cd21`](https://github.com/nix-community/emacs-overlay/commit/66d6cd2197e49ce0fd42a4b896bd35c500fd1d15) Updated emacs
* [`999b0485`](https://github.com/nix-community/emacs-overlay/commit/999b048552f496803b01c445834a9ef70410a5cb) Updated emacs
* [`c04b7ca8`](https://github.com/nix-community/emacs-overlay/commit/c04b7ca8b9b5be09acadfcba1bdd3db109ca4b6d) Updated flake inputs
* [`4e92dba0`](https://github.com/nix-community/emacs-overlay/commit/4e92dba0291d4ee1804947e1cfeb46617e37df28) Updated elpa
* [`4f3236a5`](https://github.com/nix-community/emacs-overlay/commit/4f3236a5687ef4608205e15dee1d85b663b2a45e) Updated emacs
* [`d9480cbd`](https://github.com/nix-community/emacs-overlay/commit/d9480cbdf6bd8313a09fb498779f8062a0739548) Updated elpa
* [`aa8ac9a2`](https://github.com/nix-community/emacs-overlay/commit/aa8ac9a29c08356bd9285f66b18dd49631cc2227) Updated melpa
* [`de7acd06`](https://github.com/nix-community/emacs-overlay/commit/de7acd064205dd8e5d316209b636513807b6a039) Updated melpa
* [`96e0ae1f`](https://github.com/nix-community/emacs-overlay/commit/96e0ae1f75b858ce26b84fb2b4bb2a0249dab918) Updated emacs
* [`cc961816`](https://github.com/nix-community/emacs-overlay/commit/cc961816f69f9d3b4a0a62e8f56dd6bfd6f6c69b) Updated flake inputs
* [`aecc8d6e`](https://github.com/nix-community/emacs-overlay/commit/aecc8d6e8be6afc6c8a47ae43652705d89c49390) Updated flake inputs
* [`929636d0`](https://github.com/nix-community/emacs-overlay/commit/929636d0a71c563603786ef642d1efd1c0e6bf83) Updated elpa
* [`a47befd9`](https://github.com/nix-community/emacs-overlay/commit/a47befd90c6409d2286c9d5d06d6b482814fceaa) Updated melpa
* [`00193d83`](https://github.com/nix-community/emacs-overlay/commit/00193d839cb752bccc8f6508e54afd2dab60c7c9) Updated emacs
* [`9a5071e5`](https://github.com/nix-community/emacs-overlay/commit/9a5071e5f8a4ab04787c19dc09b895b9b8e8c30d) Updated elpa
* [`856bc088`](https://github.com/nix-community/emacs-overlay/commit/856bc088accbf65128f5c6f9cb09cdfd2e28a13c) Updated melpa
* [`04c759ff`](https://github.com/nix-community/emacs-overlay/commit/04c759ffb7af09dbce3c9068c4da7f2f0343da89) Updated emacs
* [`bff0644e`](https://github.com/nix-community/emacs-overlay/commit/bff0644ec3157050821cfe784cde74a4caa522e7) Updated flake inputs
* [`ccc9f43a`](https://github.com/nix-community/emacs-overlay/commit/ccc9f43a8b06969f775dabed9c03c2e8c780e8de) Updated nongnu
* [`00c0d859`](https://github.com/nix-community/emacs-overlay/commit/00c0d859072429157c21484dc525361ff33ddea3) Updated elpa
* [`32905ebb`](https://github.com/nix-community/emacs-overlay/commit/32905ebbe68418ed897572318c94fe21f632afaa) Updated melpa
* [`6eb679f5`](https://github.com/nix-community/emacs-overlay/commit/6eb679f5e75b80580e8d3fa1594369e128b37911) Updated emacs
* [`e038ab50`](https://github.com/nix-community/emacs-overlay/commit/e038ab5096e0487d9916ac2435c34c807f364ef6) Updated melpa
* [`35e5b442`](https://github.com/nix-community/emacs-overlay/commit/35e5b442c1602ed30b588addb66d3289f33dfb76) Updated emacs
* [`4b244d63`](https://github.com/nix-community/emacs-overlay/commit/4b244d6333f6f1dfe73e7af316e9bc8bdd958a1a) Updated nongnu
* [`03779f3d`](https://github.com/nix-community/emacs-overlay/commit/03779f3d809d42b7376c42dac99e74c57d9a497e) Updated elpa
* [`36563a42`](https://github.com/nix-community/emacs-overlay/commit/36563a429d6bb373271ae634d32fc144f3baa0de) Updated melpa
* [`7481fce8`](https://github.com/nix-community/emacs-overlay/commit/7481fce8f1bec8f8478c06142f75a6f4703dbba5) Updated emacs
* [`3cc252cd`](https://github.com/nix-community/emacs-overlay/commit/3cc252cd574f1be29d63868e0c672fc1a07e749c) Updated flake inputs
* [`c0c22226`](https://github.com/nix-community/emacs-overlay/commit/c0c222260782cae1995b4c4d9a6d6808f873ca91) Updated elpa
* [`83a065a1`](https://github.com/nix-community/emacs-overlay/commit/83a065a16db7cf1f69339d5a6a0443129e20a7b8) Updated melpa
* [`34b3ff9d`](https://github.com/nix-community/emacs-overlay/commit/34b3ff9dd528ab8169725217a8df36489faeb43c) Updated emacs
* [`1d97205b`](https://github.com/nix-community/emacs-overlay/commit/1d97205bdc4148fb8a49b4c376ec8fba4d055e17) Updated flake inputs
* [`f5806ba6`](https://github.com/nix-community/emacs-overlay/commit/f5806ba6cb84c60bad49a7e0dffc153ec6659e26) Updated melpa
* [`794d2f94`](https://github.com/nix-community/emacs-overlay/commit/794d2f9436e63c33350caf36f5009dd81f465d38) Updated emacs
* [`32e74f9a`](https://github.com/nix-community/emacs-overlay/commit/32e74f9af9beaa8359dd606d152034904b43b6e4) Updated nongnu
* [`3b77704a`](https://github.com/nix-community/emacs-overlay/commit/3b77704a0f293ca6e29346045c896d734e941f51) Updated elpa
* [`e83840bf`](https://github.com/nix-community/emacs-overlay/commit/e83840bf9ee76be3b3481f844d2b7ebde08f32dd) Updated melpa
* [`20090620`](https://github.com/nix-community/emacs-overlay/commit/200906203163742224c35b827e0f3c8adc9454d0) Updated emacs
* [`7d2e7272`](https://github.com/nix-community/emacs-overlay/commit/7d2e7272b3c1748f6c4878c65baf843b6258e5e0) Updated nongnu
* [`bc6f0184`](https://github.com/nix-community/emacs-overlay/commit/bc6f018463f357bf040605eaee474928594a316f) Updated elpa
* [`f76e194a`](https://github.com/nix-community/emacs-overlay/commit/f76e194a9a4bf032a74c544abfe3fbf9119476d2) Updated melpa
* [`3ba06331`](https://github.com/nix-community/emacs-overlay/commit/3ba06331405227702c827478f0aee79ba0b917fb) Updated emacs
* [`1d3e117f`](https://github.com/nix-community/emacs-overlay/commit/1d3e117fd927a1a66c80f1667b6b7983dd7bec40) Updated melpa
* [`a424973c`](https://github.com/nix-community/emacs-overlay/commit/a424973c6bb1d08171cf53e70e75afde0501e97a) Updated nongnu
* [`9f951330`](https://github.com/nix-community/emacs-overlay/commit/9f9513304aec104557bee0e17474543b312211ce) Updated elpa
* [`b0e58504`](https://github.com/nix-community/emacs-overlay/commit/b0e585048dcc3468a9c8a9b6e5862b74730cdd75) Updated melpa
* [`f287f51a`](https://github.com/nix-community/emacs-overlay/commit/f287f51a45923bb12b50e403276338084a73ffe0) Updated emacs
* [`da2ac645`](https://github.com/nix-community/emacs-overlay/commit/da2ac64503ed60603d688b5f54eb54008947b71c) Updated elpa
* [`3c86fd79`](https://github.com/nix-community/emacs-overlay/commit/3c86fd79cbc9d1e9c44429466e7709b70e06a85c) Updated melpa
* [`ead4e219`](https://github.com/nix-community/emacs-overlay/commit/ead4e219ec8cd7341a7975f355b2450868fbb214) Updated emacs
* [`f8fdd4e4`](https://github.com/nix-community/emacs-overlay/commit/f8fdd4e417ac58e35e4f64ae4f41c2b950e2c08f) Updated melpa
* [`d043446a`](https://github.com/nix-community/emacs-overlay/commit/d043446aeed157740a40998dc87c692cd5e2e228) Updated emacs
* [`dec5b434`](https://github.com/nix-community/emacs-overlay/commit/dec5b434a4c37d47328195dcb461c49a5d055100) Updated flake inputs
* [`bf76da05`](https://github.com/nix-community/emacs-overlay/commit/bf76da057a2dc9b9c99b52d28420fcf0ddf0df9a) Updated elpa
* [`ed4fe386`](https://github.com/nix-community/emacs-overlay/commit/ed4fe386f6012f6a902308ada42420f213742d1a) Updated melpa
* [`a651c662`](https://github.com/nix-community/emacs-overlay/commit/a651c662f8e94370ec3632dc5693e9df0e8b1098) Updated emacs
* [`7ad0bb79`](https://github.com/nix-community/emacs-overlay/commit/7ad0bb79181f7f7f72b747e09f59892db1e3fde2) Updated elpa
* [`bca13400`](https://github.com/nix-community/emacs-overlay/commit/bca1340066e154b6ee28fddb6f678fc46c0e07b2) Updated melpa
* [`07be0e35`](https://github.com/nix-community/emacs-overlay/commit/07be0e35817635c528bb07b2ae366bd87571ddd0) Updated emacs
* [`b31b49e8`](https://github.com/nix-community/emacs-overlay/commit/b31b49e84f34a0a023c5229be794aefb0d83fd20) Updated melpa
* [`929e0970`](https://github.com/nix-community/emacs-overlay/commit/929e09706815a9e10cc749393eaa5895761de32a) Updated emacs
* [`ccbcf22b`](https://github.com/nix-community/emacs-overlay/commit/ccbcf22b92b944a831c18b9b8df259729ea20587) Updated elpa
* [`4ff7d2d9`](https://github.com/nix-community/emacs-overlay/commit/4ff7d2d97adac58b454d8100e99f7512ee0db9e5) Updated melpa
* [`98aa2d30`](https://github.com/nix-community/emacs-overlay/commit/98aa2d306590b9ad5d62fea389b06a8651b406b5) Updated emacs
* [`bd3b130e`](https://github.com/nix-community/emacs-overlay/commit/bd3b130e4caadd999f6fa667c3f7bb6a57dad9ac) Updated flake inputs
* [`bc6682aa`](https://github.com/nix-community/emacs-overlay/commit/bc6682aa8c5dfb95999133b887f3d47155bc5200) Updated nongnu
* [`f342e146`](https://github.com/nix-community/emacs-overlay/commit/f342e14602f413c03d269a14e58a622bd2718d81) Updated elpa
* [`5be1ab11`](https://github.com/nix-community/emacs-overlay/commit/5be1ab11ded3ceb19e77598737f840b283714766) Updated melpa
* [`9971a64f`](https://github.com/nix-community/emacs-overlay/commit/9971a64fecb140433f2bde06f35383b281a13c1c) Updated emacs
* [`165e4bc5`](https://github.com/nix-community/emacs-overlay/commit/165e4bc50493e402cf296c413edb479b04aeb339) Updated melpa
* [`64f33517`](https://github.com/nix-community/emacs-overlay/commit/64f33517c7516354ad15bb26245dc48166f40d05) Updated elpa
* [`39544a03`](https://github.com/nix-community/emacs-overlay/commit/39544a03cafafa80989bdd259f32c1309d9aac73) Updated melpa
* [`2f61d16c`](https://github.com/nix-community/emacs-overlay/commit/2f61d16c26d7f54753eeb93d3c39fe7040ef99c9) Updated emacs
* [`2086eb3b`](https://github.com/nix-community/emacs-overlay/commit/2086eb3b9b6bb72a45b0efb9957ff0d9cb8d7d98) Updated nongnu
* [`87be032a`](https://github.com/nix-community/emacs-overlay/commit/87be032a80d6aef6948bededf825c79c60d80374) Updated elpa
* [`cb5c8a74`](https://github.com/nix-community/emacs-overlay/commit/cb5c8a74fe070dc40ffd3536df99752fe6e489bc) Updated melpa
* [`76c2bc6a`](https://github.com/nix-community/emacs-overlay/commit/76c2bc6a106076a377fca4334a612d2fad5d49b0) Updated emacs
* [`6d2e1466`](https://github.com/nix-community/emacs-overlay/commit/6d2e14666ff067074bb80e32ae9d1383743c6487) Updated melpa
* [`116abf13`](https://github.com/nix-community/emacs-overlay/commit/116abf13437982f49be465151c066f116c9af9ce) Updated elpa
* [`a087aa6a`](https://github.com/nix-community/emacs-overlay/commit/a087aa6a87647ff1b853d5536c8e63761eeb1a1a) Updated melpa
* [`b6c62d81`](https://github.com/nix-community/emacs-overlay/commit/b6c62d8135f943ea1e2733aa644cbd146afe2d62) Updated emacs
* [`27cda0d5`](https://github.com/nix-community/emacs-overlay/commit/27cda0d551a0d064f88112c1501a6d4a00e0c20a) Updated elpa
* [`74a67c68`](https://github.com/nix-community/emacs-overlay/commit/74a67c68d0b6ec02ff7c300a7f6a0b50abc116d6) Updated melpa
* [`1ca845e9`](https://github.com/nix-community/emacs-overlay/commit/1ca845e99884cb7d515ae7d773a186231cfae242) Updated emacs
* [`30b19743`](https://github.com/nix-community/emacs-overlay/commit/30b19743d243f97e0a6d71ff9fe3522e1b7bc581) Updated melpa
* [`0a555986`](https://github.com/nix-community/emacs-overlay/commit/0a5559861c7b49371d0d36af854ba8353cd05199) Updated flake inputs
* [`521b7d79`](https://github.com/nix-community/emacs-overlay/commit/521b7d79e98d68fa2d2e4a104f1396613f8e60ca) Updated elpa
* [`d3b55246`](https://github.com/nix-community/emacs-overlay/commit/d3b55246685cbac16e5c93020b56f6a8bf5c7a29) Updated melpa
* [`2453a7df`](https://github.com/nix-community/emacs-overlay/commit/2453a7df92d199d96c198320d493cbabb8312b2e) Updated emacs
* [`937b7305`](https://github.com/nix-community/emacs-overlay/commit/937b73051a869f54030b1a45600389950aba01b2) Updated melpa
* [`441ed869`](https://github.com/nix-community/emacs-overlay/commit/441ed86922224973b0853255785d3ce88b683b1a) Updated emacs
* [`9207151d`](https://github.com/nix-community/emacs-overlay/commit/9207151d430aa8514e72acf98ccfe7dc6235cc4c) Updated melpa
* [`6162935b`](https://github.com/nix-community/emacs-overlay/commit/6162935b3e287a34e4432d35dbbccbddc5491cfe) Updated emacs
* [`7a959dc4`](https://github.com/nix-community/emacs-overlay/commit/7a959dc4f78eb0bfc815bec18fd4f468a05024f4) Updated flake inputs
* [`48a482db`](https://github.com/nix-community/emacs-overlay/commit/48a482db3cc3ed0895a52cf89ea9874efce31a09) Updated elpa
* [`e674f65c`](https://github.com/nix-community/emacs-overlay/commit/e674f65caed9780a87ea6fa51e66bf1a79919528) Updated melpa
* [`d846281f`](https://github.com/nix-community/emacs-overlay/commit/d846281fcce0a7a9a51dd10a57d6f53417a358c0) Updated emacs
* [`ad68f81c`](https://github.com/nix-community/emacs-overlay/commit/ad68f81c44e5dda35a4e32a76b117e21f3e2b1db) Updated flake inputs
* [`ce2b59df`](https://github.com/nix-community/emacs-overlay/commit/ce2b59df2742620e297e94c51d1467d60af0901b) Updated nongnu
* [`c6686aae`](https://github.com/nix-community/emacs-overlay/commit/c6686aae1070e491e43310ba392f48b422277c39) Updated elpa
* [`69069178`](https://github.com/nix-community/emacs-overlay/commit/69069178a14d1a475a5ada9a1f5d9e747631d3f4) Updated melpa
* [`891d7b17`](https://github.com/nix-community/emacs-overlay/commit/891d7b17960d98be8cd9115927290f7c527ae97e) Updated emacs
* [`e09d25d8`](https://github.com/nix-community/emacs-overlay/commit/e09d25d8f76dbf4bc5dc1b1ff6dbe01ee80f3d7a) Updated melpa
* [`b95883a0`](https://github.com/nix-community/emacs-overlay/commit/b95883a0b9701e7d716e5c298e5d7961076301cd) Updated emacs
* [`d598b660`](https://github.com/nix-community/emacs-overlay/commit/d598b66018e4653fc95fca5906a855fcd8bf5f03) Updated nongnu
* [`c10227a9`](https://github.com/nix-community/emacs-overlay/commit/c10227a90c6d0e900ed292c1983fa48c4c149aa2) Updated elpa
* [`d5fc3b94`](https://github.com/nix-community/emacs-overlay/commit/d5fc3b94668ca9c75c94142dbae6967bb72bfb1b) Updated melpa
* [`35b305a1`](https://github.com/nix-community/emacs-overlay/commit/35b305a1706b6fa284f81aa5dc37ccfdbfcb2e99) Updated emacs
