### PR TITLE
niv nixpkgs: update 9ca3f649 -> d7aefbf2

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9ca3f649614213b2aaf5f1e16ec06952fe4c2632",
-        "sha256": "1753bcq3c30fd570jllkya3v5wqb8zibf840sdsfghw1jmpw6igc",
+        "rev": "d7aefbf252617947b9ab519e192d4c1d8af1975b",
+        "sha256": "0pzwg00drvi79asl9vy1agszgqypkxqsb3z4i9ldcv0qrmglpl19",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/9ca3f649614213b2aaf5f1e16ec06952fe4c2632.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/d7aefbf252617947b9ab519e192d4c1d8af1975b.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@9ca3f649...d7aefbf2](https://github.com/nixos/nixpkgs/compare/9ca3f649614213b2aaf5f1e16ec06952fe4c2632...d7aefbf252617947b9ab519e192d4c1d8af1975b)

* [`46d3fff3`](https://github.com/NixOS/nixpkgs/commit/46d3fff34d431bb2e7ef81f0292678c45025c3ae) flat-remix-icon-theme: disable fixup to improve build time
* [`0049424c`](https://github.com/NixOS/nixpkgs/commit/0049424c0b2cbcaa276596d79fbb65a77d9f3773) briar-desktop: 0.5.0-beta -> 0.6.0-beta
* [`33dc92d6`](https://github.com/NixOS/nixpkgs/commit/33dc92d62a9c33286ea028da4db79062f73afbd6) cups-brother-hl1210w: fix ppd symlink path
* [`40095d71`](https://github.com/NixOS/nixpkgs/commit/40095d71842402eaa90cbc4597b7079e0757bf18) cloudlogoffline: 1.1.4 -> 1.1.5
* [`d5850d5c`](https://github.com/NixOS/nixpkgs/commit/d5850d5c60f9024f852701e58f245266a471d03f) nixos/sane: fix disabling backends which are subwords of other backends
* [`8d80e5df`](https://github.com/NixOS/nixpkgs/commit/8d80e5df81f7d367fcc949c09ccdc05c62d2b7e4) seer: 1.17 -> 2.4
* [`17718ac2`](https://github.com/NixOS/nixpkgs/commit/17718ac2552873bc9b6bbeb0c5b9469284a5d03b) check-meta: fix 'predicate' instructions
* [`a27e94f6`](https://github.com/NixOS/nixpkgs/commit/a27e94f671aa15d704438b89aa0c23a46297fc88) spdk: 23.09 -> 24.01
* [`b344ba1a`](https://github.com/NixOS/nixpkgs/commit/b344ba1a3cc0a20c6d72a971e84fe8801f324ff5) sqlpage : 0.15.1 -> 0.20.0
* [`a50981d5`](https://github.com/NixOS/nixpkgs/commit/a50981d576e348bb39c5f06d0d5059bf281af980) gegl: disable lua on platforms where luajit is unavailable
* [`1e8685d3`](https://github.com/NixOS/nixpkgs/commit/1e8685d3411639326ef6be778e6d5b06b3be7c9a) dockutil: 3.0.2 -> 3.1.3
* [`41e6e653`](https://github.com/NixOS/nixpkgs/commit/41e6e65375ac68f088c8934a81f140c9cf4cfa25) python3Packages.pytun: 2.3.0 -> 2.4.1
* [`f27f3cdc`](https://github.com/NixOS/nixpkgs/commit/f27f3cdc10c3962e6b5f152cdb78b38db46f71ab) nixos/tests/centrifugo: fix shards address list order in tests
* [`e466d10c`](https://github.com/NixOS/nixpkgs/commit/e466d10cbfaed0b3a444fb21bc626a5df95e9dd7) pandoc-include: add update.sh
* [`a1a38c30`](https://github.com/NixOS/nixpkgs/commit/a1a38c30efc875f779dccaa7a2e615ea676a8ab8) scaleft : 1.67.4 -> 1.80.1
* [`0eb28706`](https://github.com/NixOS/nixpkgs/commit/0eb287064152cef65267a03aa13f366dd3b281cf) _86Box: add updateScript
* [`453aff31`](https://github.com/NixOS/nixpkgs/commit/453aff31c66ef414c7a6b82511bd79f648d76386) dockutil: refactor to build from source on aarch64
* [`9bf31eab`](https://github.com/NixOS/nixpkgs/commit/9bf31eaba05c0d7796f076662fb58c2e5ae82df4) inkscape: fix path patch
* [`080ffe39`](https://github.com/NixOS/nixpkgs/commit/080ffe391a6e3d4e84b2374399bbe1bf268a6f3a) ricochet-refresh: 3.0.22 -> 3.0.23
* [`fae8ec30`](https://github.com/NixOS/nixpkgs/commit/fae8ec30eabc4dc29051ab26a37ba1ba89827031) inkscape: add unit test for ps2pdf plugin
* [`2457df92`](https://github.com/NixOS/nixpkgs/commit/2457df9282e5127727e706bf8d55a134cd01e645) castopod: 1.10.5 -> 1.11.0
* [`733527fe`](https://github.com/NixOS/nixpkgs/commit/733527fec99c78ab8ef4b504298940dfb886dacf) python311Packages.quil: 0.7.1 -> 0.9.1
* [`cb6c01ff`](https://github.com/NixOS/nixpkgs/commit/cb6c01fff80ba50cc978cb74e9d5ffe7b7009820) python311Packages.qcs-sdk-python: 0.17.4 -> 0.17.7
* [`db195a8b`](https://github.com/NixOS/nixpkgs/commit/db195a8bedc44d62266582a8aacbf64c0b294607) python311Packages.qcs-api-client: 0.25.0 -> 0.25.1
* [`cb2a4266`](https://github.com/NixOS/nixpkgs/commit/cb2a4266c1fbb6d578e2de5d7fe68e28fabe5749) python311Packages.pyquil: 4.8.0 -> 4.9.2
* [`9a031ece`](https://github.com/NixOS/nixpkgs/commit/9a031ecea74f197ed964f354b5924daf0aafc2ad) httm: 0.23.3 -> 0.38.1
* [`7131b737`](https://github.com/NixOS/nixpkgs/commit/7131b7379614949099bab58561730edfb386701d) fcitx5-catppuccin: init at 0-unstable-2022-10-05
* [`78d7179c`](https://github.com/NixOS/nixpkgs/commit/78d7179c4671e700c2f94675ca436d7e879535eb) fcitx5-tokyonight: init at 0-unstable-2024-01-28
* [`7a8bdf76`](https://github.com/NixOS/nixpkgs/commit/7a8bdf766d97f0a72a35506d4111332dc11a8eac) apptainer, singularity: add mount to defaultPathInputs
* [`2ab02402`](https://github.com/NixOS/nixpkgs/commit/2ab024029523a6239330b48b47878896dde5d201) apptainer, singularity: refactor defaultPath substitution
* [`d09aedb1`](https://github.com/NixOS/nixpkgs/commit/d09aedb1a06530d3a62650f14f78d21674fe1ce7) singularity-tools.buildImage: increase default memSize
* [`d8ee498a`](https://github.com/NixOS/nixpkgs/commit/d8ee498af73f48cf2b1472c4fd02a10526930023) ocamlPackages.minisat: 0.5 -> 0.6
* [`6b2373ae`](https://github.com/NixOS/nixpkgs/commit/6b2373aee1eb920acc6413c26fb506556cb90b4b) nixos/proxmox-image: remove raw image from hydra-build-products
* [`b90b63db`](https://github.com/NixOS/nixpkgs/commit/b90b63db929dc454aee85ef5d7ec5b484a576ef8) nixos/proxmox-image: qemu: 7.2.1 -> 8.1.5
* [`fe35866a`](https://github.com/NixOS/nixpkgs/commit/fe35866a2e23e737ce9ae253bbb5c148ccf10778) nixos/proxmox-image: add cloud init disk and use cloud-init by default
* [`cd16cff4`](https://github.com/NixOS/nixpkgs/commit/cd16cff47e1bd01d9e2c2cc9758cc585777b68ac) greetd.wlgreet: 0.4.1 -> 0.5.0
* [`523f157d`](https://github.com/NixOS/nixpkgs/commit/523f157dba0a1eec1a42090fcd5bc58b71593fbd) nixos/proxmox-image: change scsi controller model to upstream default
* [`b418d69a`](https://github.com/NixOS/nixpkgs/commit/b418d69ad17f731f923c09032fbf3dc5ceddb72b) python311Packages.reqif: 0.0.40 -> 0.0.42
* [`3a838c99`](https://github.com/NixOS/nixpkgs/commit/3a838c99d45b8eaca0436abab90083d084266ccc) python311Packages.troposphere: 4.7.0 -> 4.8.0
* [`09426fe8`](https://github.com/NixOS/nixpkgs/commit/09426fe8710936526444619b21dc349cb9efc917) joypixels: 6.6.0 -> 8.0.0
* [`74e591dc`](https://github.com/NixOS/nixpkgs/commit/74e591dc460a04eea2e835ee2f3787cf19fa2222) joypixels: Narrow unfree recommendation
* [`3317c406`](https://github.com/NixOS/nixpkgs/commit/3317c406d42ca3cf54bac8ba036d5e8cb742a5d8) joypixels: Add sourceProvenance and prevent building on Hydra
* [`1c8fd6eb`](https://github.com/NixOS/nixpkgs/commit/1c8fd6eb611d27ff7e410a33d73ed5df1363c3d3) joypixels: Switch to general JoyPixels Free License
* [`e87da138`](https://github.com/NixOS/nixpkgs/commit/e87da138d38faefdc8c939579f6c8bfcafba4b81) boost_process: drop
* [`609a4d21`](https://github.com/NixOS/nixpkgs/commit/609a4d2121ec97f3df637c2a1911461dc8ea7cf9) python311Packages.eccodes: 2.34.1 -> 2.35.0
* [`02b94455`](https://github.com/NixOS/nixpkgs/commit/02b944557888ea9e2273ba82df97d9f08f379736) systemc: 2.3.4 -> 3.0.0
* [`2c0d991d`](https://github.com/NixOS/nixpkgs/commit/2c0d991d9ed26ea78cb70a13c0de762177af1fbd) zabbix-agent2-plugin-postgresql: 6.4.12 -> 6.4.14
* [`edb38f40`](https://github.com/NixOS/nixpkgs/commit/edb38f40835f13e969170381d0ac37dddd32f61e) castero: propagate requests[socks]
* [`a5d8b244`](https://github.com/NixOS/nixpkgs/commit/a5d8b24480615fcb2d73c84f2ce3aed7f4aebe8a) apk-tools: 2.14.1 -> 2.14.4
* [`0599ed51`](https://github.com/NixOS/nixpkgs/commit/0599ed519eecb29a59a21b77b3f525f336db0e59) ibus: 1.5.29 -> 1.5.30
* [`c6c9cea9`](https://github.com/NixOS/nixpkgs/commit/c6c9cea94445e49ded18169a25bddb91c87b4595) matrix-conduit: 0.6.0 -> 0.7.0
* [`6b6ca235`](https://github.com/NixOS/nixpkgs/commit/6b6ca2356914477a05e8c1068971ca92bf8e7e36) python311Packages.pydal: 20231114.3 -> 20240428.2
* [`24b0a3c6`](https://github.com/NixOS/nixpkgs/commit/24b0a3c6234b22f6b1aa3f81f8b040c170922c33) python311Packages.mmcv: 2.1.0 -> 2.2.0
* [`7b98881b`](https://github.com/NixOS/nixpkgs/commit/7b98881bcec199d7fc2305f2f23a091428f1c4c6) maintainers: add jn-sena
* [`38abd30d`](https://github.com/NixOS/nixpkgs/commit/38abd30d8e07ef6898d87f217dcac25aed8074d2) everforest-gtk-theme: init at 0-unstable-2023-03-20
* [`1f0ba9f7`](https://github.com/NixOS/nixpkgs/commit/1f0ba9f7f494a1a495bd4e8e98f86e929f2f3a42) dbt: 1.7.13 -> 1.7.14
* [`6a6b3eac`](https://github.com/NixOS/nixpkgs/commit/6a6b3eacac8e728ae33805e99ac1594dda595e94) python311Packages.elasticsearch-dsl: 8.13.0 -> 8.13.1
* [`3043c093`](https://github.com/NixOS/nixpkgs/commit/3043c09398c6f480045b7c424beecf26c26e9129) jetbrains.plugins: allow non-bundled plugins to be discovered
* [`c2fbe8c0`](https://github.com/NixOS/nixpkgs/commit/c2fbe8c06eec0759234fce4a0453df200be021de) jetbrains.plugins: remove unused constructs
* [`ff1c82ee`](https://github.com/NixOS/nixpkgs/commit/ff1c82ee07514b770092a2651d3d5d27f5003cee) nixos/ssh: add services.openssh.package
* [`fe1b471a`](https://github.com/NixOS/nixpkgs/commit/fe1b471a5b848d48f0dd86b18f41877e44a4b7a1) whatsapp-for-linux: 1.6.4 -> 1.6.5
* [`df4cbbc5`](https://github.com/NixOS/nixpkgs/commit/df4cbbc521e2a416dadaddeabf251880fe136a5d) foomatic-db*: migrate to `pkgs/by-name` overlay
* [`c7d03d90`](https://github.com/NixOS/nixpkgs/commit/c7d03d905d115bfaf6eed669637036d0570ac645) foomatic-db{,-nonfree}: use `finalAttrs` pattern instead of `rec`
* [`3c7f4039`](https://github.com/NixOS/nixpkgs/commit/3c7f4039d9aea32a25c9d14f71c86283bfa828a6) python311Packages.emcee: 3.1.5 -> 3.1.6
* [`a08e26be`](https://github.com/NixOS/nixpkgs/commit/a08e26bed861e7b5b5bda25a74d6475cb4329113) foomatic-db: unstable-2024-02-09 -> unstable-2024-05-04
* [`360d400f`](https://github.com/NixOS/nixpkgs/commit/360d400fdedbdda79e7c537c9151fa292ff17209) mysql_jdbc: 8.3.0 -> 8.4.0
* [`7a04d30b`](https://github.com/NixOS/nixpkgs/commit/7a04d30b417e0b790081afcba106b516b33e85f2) marked-man: init at 2.1.0
* [`e153bc88`](https://github.com/NixOS/nixpkgs/commit/e153bc88e94d554d2d7e4c42efddf506dab8ea9b) wluma: use upstream Makefile's install command
* [`da93c33f`](https://github.com/NixOS/nixpkgs/commit/da93c33f4745d1fff713c81cd14978b41feb1a85) keepassxc: 2.7.7 -> 2.7.8
* [`f95da495`](https://github.com/NixOS/nixpkgs/commit/f95da4954bf2c05a6490ef263748d9aeb4a1a295) python311Packages.testfixtures: 8.1.0 -> 8.2.0
* [`c87b7e07`](https://github.com/NixOS/nixpkgs/commit/c87b7e076b4775a29df95da3b312094a16f423ff) python311Packages.tatsu: 5.12.0 -> 5.12.1
* [`96dee71e`](https://github.com/NixOS/nixpkgs/commit/96dee71e84fb72b74651a5303d3c705db84f567c) yubico-piv-tool: 2.5.1 -> 2.5.2
* [`aa0e4fc0`](https://github.com/NixOS/nixpkgs/commit/aa0e4fc0ba35e83088ca297b4ee4e2584c42c46b) matrix-commander: 7.2.0 -> 7.6.2
* [`b564b4b9`](https://github.com/NixOS/nixpkgs/commit/b564b4b93b0f2072f444838c1c3258a38d6778ad) lima: 0.21.0 -> 0.22.0
* [`eb0a31c2`](https://github.com/NixOS/nixpkgs/commit/eb0a31c2598cf149153b394d0939b03af14ef944) thanos: 0.34.1 → 0.35.0
* [`758ac9de`](https://github.com/NixOS/nixpkgs/commit/758ac9de53d70e9fc09612c55c28bf868f05f43f) beyond-identity: 2.60.0-0 -> 2.97.0-0
* [`dec6295f`](https://github.com/NixOS/nixpkgs/commit/dec6295fc64609cfaaecff74abc3a176df347599) zita-at1: 0.6.2 -> 0.8.2
* [`21bd69a5`](https://github.com/NixOS/nixpkgs/commit/21bd69a51e79f61e396eaacc767fcde3e39c81b3) linuxPackages.apfs: 0.3.8 -> 0.3.9
* [`bab0370c`](https://github.com/NixOS/nixpkgs/commit/bab0370ccaa9fbf1e6f83e892ff38bc85b545e2c) fcitx5: substitute path in all desktop files and dbus service files
* [`5803cb21`](https://github.com/NixOS/nixpkgs/commit/5803cb219ec66ade518210ee99fbb9528cf67a25) maintainers: add TheHans255
* [`31c44b85`](https://github.com/NixOS/nixpkgs/commit/31c44b853c2dcc367ece9cd24c0a254f1721ba0c) setools: 4.5.0 -> 4.5.1
* [`42356245`](https://github.com/NixOS/nixpkgs/commit/4235624542a782a43e3ed3d5acda192cea19949a) liboqs: 0.8.0 -> 0.10.0
* [`e2cf9212`](https://github.com/NixOS/nixpkgs/commit/e2cf921236568103048b50df7fb5aa8e5837a3a5) dool: 1.3.1 -> 1.3.2
* [`1848bdb3`](https://github.com/NixOS/nixpkgs/commit/1848bdb3cfd91af7362dc41ca009d704190e73ff) igir: 2.6.3 -> 2.7.0
* [`0196fafd`](https://github.com/NixOS/nixpkgs/commit/0196fafd974a5086bb90b4250ee807c1379e58bf) Remove modification of polkit policy.
* [`69c2090e`](https://github.com/NixOS/nixpkgs/commit/69c2090e988b0a062b9ac2fa178e39989e2e080c) amazon-image: allow pkgs overrides
* [`28e25a6d`](https://github.com/NixOS/nixpkgs/commit/28e25a6ddcb1746fcd23c836c83723e60447ab46) nixos-shell: 1.1.0 -> 1.1.1
* [`2feebdb5`](https://github.com/NixOS/nixpkgs/commit/2feebdb5be7fca77e56020d9b87801daa7d1ca2c) tradingview 2.7.2 -> 2.7.7
* [`531e5ae1`](https://github.com/NixOS/nixpkgs/commit/531e5ae1931d693eb6cb256c36edd640a507666b) osinfo-db: 20231215 -> 20240510
* [`8585a50f`](https://github.com/NixOS/nixpkgs/commit/8585a50f640a7677ff4f14a731222a2b1e47d0c4) texstudio: 4.7.3 -> 4.8.0
* [`c1bd6828`](https://github.com/NixOS/nixpkgs/commit/c1bd6828edae4ef6ad1455d611d9bd2bc1444f4f) lilypond-unstable: 2.25.15 -> 2.25.16
* [`ca58ea3c`](https://github.com/NixOS/nixpkgs/commit/ca58ea3c60d654147657c86a2705ad20b660ba94) kaldi: 0-unstable-2024-01-31 -> 0-unstable-2024-04-30
* [`d4cb4c5f`](https://github.com/NixOS/nixpkgs/commit/d4cb4c5fedb40549a535e34dc079b0bf41d238c2) sbt-extras: 2024-02-27 -> 2024-05-06
* [`5875b592`](https://github.com/NixOS/nixpkgs/commit/5875b59270948cb60d17fe5b39b012008b379186) virtualbox: remove with lib
* [`0507f64d`](https://github.com/NixOS/nixpkgs/commit/0507f64d9fc84799b19c5631c5ff5ee137ac75b3) virtualboxGuestAdditions: remove with lib
* [`4b3ae365`](https://github.com/NixOS/nixpkgs/commit/4b3ae365f6c7595f69da6ddd74d7168dd850a98a) virtualboxGuestAdditions: move more buildInputs to nativeBuildInputs
* [`b9d92aff`](https://github.com/NixOS/nixpkgs/commit/b9d92aff71306d69eff907d4746abb554141dcef) virtualbox: introduce finalAttrs
* [`f9966d5f`](https://github.com/NixOS/nixpkgs/commit/f9966d5fb7bfb2112eb638d3aab7572c9e6b78d9) virtualbox: remove old patch
* [`64512b62`](https://github.com/NixOS/nixpkgs/commit/64512b62004dd29acf5c91c6fdc450f765154b59) virtualboxGuestAdditions: Add dragAndDrop service
* [`52b84947`](https://github.com/NixOS/nixpkgs/commit/52b8494767f9f301ff71d24857709afb89b866a0) virtualbox: disable VBOX_WITH_UPDATE_AGENT
* [`0d8d6237`](https://github.com/NixOS/nixpkgs/commit/0d8d62378addefa14e3a025a797bffd0e8a42258) virtualboxGuestAdditions: disable VBOX_WITH_UPDATE_AGENT
* [`0aaed921`](https://github.com/NixOS/nixpkgs/commit/0aaed9212aeddd193bce895b55275e9233ba5171) virtualboxGuestAdditions: disable more includes
* [`b9b8904b`](https://github.com/NixOS/nixpkgs/commit/b9b8904bdde499e338f2c23e443ce93bd7f9c90e) virtualboxGuestAdditions: ignore more includes when building
* [`81f4b1d0`](https://github.com/NixOS/nixpkgs/commit/81f4b1d0a5f98bf6847fae6488f1eab13285c0bb) virtualboxGuestAdditions: cleanup
* [`fae0e70f`](https://github.com/NixOS/nixpkgs/commit/fae0e70f0ca92307f046b8cbdd67b02cbb8d52e4) virtualboxGuestAdditions: remove alsa & pulse deps
* [`b9ed0a34`](https://github.com/NixOS/nixpkgs/commit/b9ed0a34effda7460c0079cc0285eaf5d5b5eaea) virtualboxGuestAdditions: remove makeWrapper dep
* [`296a513c`](https://github.com/NixOS/nixpkgs/commit/296a513c842d837c0a9588628bc1c1ccf0367d4f) virtualboxGuestAdditions: use nix packaged lzma
* [`9496bd26`](https://github.com/NixOS/nixpkgs/commit/9496bd2687ed0518b763b764e8e46ab0426a2610) virtualbox: remove nasm
* [`9a0df564`](https://github.com/NixOS/nixpkgs/commit/9a0df56451c902b43627c48f258b68bcdfd42417) fix ncurses5 with LD_LIBRARY_PATH hack
* [`da3bbd96`](https://github.com/NixOS/nixpkgs/commit/da3bbd96b0063597d5b75b15a4ba542063918381) houdini: 20.0.506 -> 20.0.688
* [`6ae3ced5`](https://github.com/NixOS/nixpkgs/commit/6ae3ced59e52bb3fd99d82913e299273a3d4f18a) Fix for jcef 241
* [`d2eeeb45`](https://github.com/NixOS/nixpkgs/commit/d2eeeb450a8d9c2e02d8d2e2c2101b39df07e17d) tailscale: fix tailscale ssh
* [`361874c9`](https://github.com/NixOS/nixpkgs/commit/361874c944599d40faf1e810a287b3c1d4d29610) licenses: Add NCBI-PD
* [`438273da`](https://github.com/NixOS/nixpkgs/commit/438273dac74c61f3c03c81a06dfce4b96454120c) sratoolkit: Assign correct license
* [`43d607fe`](https://github.com/NixOS/nixpkgs/commit/43d607fe97ce2bac78586b68bc20f59dd28da7c6) bitwarden-cli: 2024.3.1 -> 2024.4.1
* [`c6ffec07`](https://github.com/NixOS/nixpkgs/commit/c6ffec07af786125a0971b2edd5fdfa71f5d556b) amazon-ecr-credential-helper: 0.7.1 -> 0.8.0
* [`ff1eb41f`](https://github.com/NixOS/nixpkgs/commit/ff1eb41ffe2a8fa7a9d7bdee17d2f2540bcec1ad) everdo: init at 1.9.0
* [`f789a362`](https://github.com/NixOS/nixpkgs/commit/f789a362e0cfff7f9190cd176c5e65d976ec6ed7) harmonia: migrate to by-name
* [`5a1dff9e`](https://github.com/NixOS/nixpkgs/commit/5a1dff9e7506d133518ed481580b20efdf220507) harmonia: 0.7.5 -> 0.8.0
* [`d93fb1bd`](https://github.com/NixOS/nixpkgs/commit/d93fb1bd1008b376a536a4a82ba189742b47293c) nixos/hardware/printers: fix ppdOptions of ensured printers
* [`ce95595c`](https://github.com/NixOS/nixpkgs/commit/ce95595c1f3f848692908639edc922c7daacba9c) cdecl: copy to cdecl-blocks, cdecl: 2.5 -> 16.3, changed upstream url
* [`62f5fe5b`](https://github.com/NixOS/nixpkgs/commit/62f5fe5b14168cec48e097c3cace7b13c39db10c) bowtie2: 2.5.3 -> 2.5.4
* [`74cb0406`](https://github.com/NixOS/nixpkgs/commit/74cb0406c04ab842486ad70c7f0c225f48f6740a) wootility: 4.6.18 -> 4.6.20
* [`9a36d96d`](https://github.com/NixOS/nixpkgs/commit/9a36d96d6050d0e941c6e0e5d4bc8354e77653bb) snipaste: init at 2.9-Beta2
* [`b465e5a8`](https://github.com/NixOS/nixpkgs/commit/b465e5a80a880661a3ecdb36016f222fa3b6ebe8) EmptyEpsilon: 2023.06.17 -> 2024.05.16
* [`e2e1ceb5`](https://github.com/NixOS/nixpkgs/commit/e2e1ceb529b612ae8e5c974dac63dc0281a70ebf) ultrastardx: 2024.3.0 -> 2024.5.1
* [`e92be3e0`](https://github.com/NixOS/nixpkgs/commit/e92be3e05062ad1a1589153796e58c8c7756b75d) aspectj: 1.9.22 -> 1.9.22.1
* [`695124ad`](https://github.com/NixOS/nixpkgs/commit/695124ad5e2066ff4f431ea126e039c2122abf20) wxSVG: 1.5.24 -> 1.5.25
* [`b22ad0a7`](https://github.com/NixOS/nixpkgs/commit/b22ad0a7e34a92e077ae1411983494e0e03abc10) maintainers: add zimeg
* [`1ddda198`](https://github.com/NixOS/nixpkgs/commit/1ddda1989f2862b864384640c9db8f5ff65e7b27) dracula-theme: 4.0.0-unstable-2024-05-12 -> 4.0.0-unstable-2024-05-18
* [`36821ef7`](https://github.com/NixOS/nixpkgs/commit/36821ef78764f75bfbc26a085ffdd4f479200587) python311Packages.azure-eventhub: 5.11.7 -> 5.12.0
* [`42f0ef87`](https://github.com/NixOS/nixpkgs/commit/42f0ef87e49621b51065246452d30c34717d399d) readarr: 0.3.26.2526 -> 0.3.27.2538
* [`05f27db5`](https://github.com/NixOS/nixpkgs/commit/05f27db56224e141b751c6f5f08b8b8996785ca3) mariadb-connector-java: 3.3.3 -> 3.4.0
* [`b5b02d4a`](https://github.com/NixOS/nixpkgs/commit/b5b02d4a1b2973cdd44338130af5c9e24d01a17b) python311Packages.aws-lambda-builders: 1.49.0 -> 1.50.0
* [`256bd32c`](https://github.com/NixOS/nixpkgs/commit/256bd32ca3f58ca0898428b36537ab910fc27190) dbmate: 2.15.0 -> 2.16.0
* [`afd35776`](https://github.com/NixOS/nixpkgs/commit/afd35776d69b5b545f47ae1eabda6f38e7467b97) rnnoise-plugin: 1.03 -> 1.10
* [`4aadb47d`](https://github.com/NixOS/nixpkgs/commit/4aadb47dd5fe3309f2c3ee42b90af985f6ee6c46) lunacy: fix "Unsupported file format" toast at startup
* [`f176f7e1`](https://github.com/NixOS/nixpkgs/commit/f176f7e1b8b0b95d5be9f49877deb3a86f35a555) tanka: add fish and zsh shell completions
* [`ff6f0120`](https://github.com/NixOS/nixpkgs/commit/ff6f0120505bf3e1c1d69f2d6f9639c384eb7508) trunk-ng: 0.17.11 -> 0.17.16
* [`f93a9465`](https://github.com/NixOS/nixpkgs/commit/f93a9465c606aeacef5fd18f383e0fadcb79ed00) trunk-ng: fix hash
* [`e415bc4b`](https://github.com/NixOS/nixpkgs/commit/e415bc4b9400df6ba73353773877c8ad7ecdd72d) godu: 1.4.1 -> 1.5.2
* [`b2e800a6`](https://github.com/NixOS/nixpkgs/commit/b2e800a60c55682512630292aa654638f4f83f57) maskromtool: 2024-01-28 -> 2024-05-19
* [`035d6e34`](https://github.com/NixOS/nixpkgs/commit/035d6e343fdfddfed68f429a6b20b7f55b2fd3c4) ventoy: 1.0.97 -> 1.0.98
* [`1a684a23`](https://github.com/NixOS/nixpkgs/commit/1a684a23d78eff45d406414b3917fd7d0b10905a) pyotherside: 1.6.0 -> 1.6.1
* [`a17e9671`](https://github.com/NixOS/nixpkgs/commit/a17e9671e4d72e918a3ee0aadec7a08964c02595) clap: 1.2.0 -> 1.2.1
* [`30fbff4c`](https://github.com/NixOS/nixpkgs/commit/30fbff4c41e89e5dc542cb5dcb54212898ab217f) asciidoctorj: 2.5.12 -> 2.5.13
* [`5f56e7bc`](https://github.com/NixOS/nixpkgs/commit/5f56e7bcf7b3982f76f67a8d0f86453fb40cdc33) grass-sass: 0.13.2 -> 0.13.3
* [`15038dc4`](https://github.com/NixOS/nixpkgs/commit/15038dc4fde1ab0794e4bc631b541442b1117a64) whistle: 2.9.70 -> 2.9.71
* [`f812d706`](https://github.com/NixOS/nixpkgs/commit/f812d70646ef6f0f6b3ca39d030bceea0793d161) python311Packages.bdffont: 0.0.24 -> 0.0.25
* [`54f72179`](https://github.com/NixOS/nixpkgs/commit/54f72179590486731b5b6bf377906e15a9604894) python311Packages.types-pillow: 10.2.0.20240415 -> 10.2.0.20240520
* [`3907a566`](https://github.com/NixOS/nixpkgs/commit/3907a5667373200aed478ab579449b46b936ff19) minetest: add update script
* [`10b8ae9b`](https://github.com/NixOS/nixpkgs/commit/10b8ae9b40b483e557bf737c1b7dd47425d50240) kuma-cp: 2.7.2 -> 2.7.3
* [`98021dcb`](https://github.com/NixOS/nixpkgs/commit/98021dcbb8c09c5c97447a903ce49f6a786502f5) flat-remix-icon-theme: 20220525 -> 20240201
* [`150203f6`](https://github.com/NixOS/nixpkgs/commit/150203f66be1a3719dea5aed1775238b27ddab1a) fwupd: 1.9.19 -> 1.9.20
* [`c2a1c5f8`](https://github.com/NixOS/nixpkgs/commit/c2a1c5f8fc8e86fdc6816a0f7d2c27cf51426b91) win-disk-writer: init at 1.3
* [`8f9e6745`](https://github.com/NixOS/nixpkgs/commit/8f9e67451946060b227b8429c1f9e7d386f8eb17) python311Packages.approvaltests: 11.2.1 -> 12.2.0
* [`c4fd7cf1`](https://github.com/NixOS/nixpkgs/commit/c4fd7cf16d531b09c6178294f5cdaaaa2bc55b01) nixos/networkd: get rid of *Config attributes in lists
* [`f9f943b3`](https://github.com/NixOS/nixpkgs/commit/f9f943b36eb1f9f13b23a177fc6f8bc40071534b) nixos/networking: use optionalAttrs -> mkIf for networkd route generation
* [`b9c91953`](https://github.com/NixOS/nixpkgs/commit/b9c9195337aea327dd395aef740f518733ed6a2f) rquickshare: init at 0.7.1
* [`e19d14f0`](https://github.com/NixOS/nixpkgs/commit/e19d14f05c0699c7846a73c20d74e57a4d9b7453) space-station-14-launcher: 0.26.0 -> 0.27.2
* [`de0fdc1c`](https://github.com/NixOS/nixpkgs/commit/de0fdc1c784e8742d96ca18b1691a368f8b87e75) androidenv: fix NDK toolchain linking issues
* [`0b43348b`](https://github.com/NixOS/nixpkgs/commit/0b43348b0679f6bf92054e4b56e23e6feef5e45a) mpack: move to pkgs/by-name/mp
* [`86a7622c`](https://github.com/NixOS/nixpkgs/commit/86a7622c74a862e124adc0f1f510a1f1b89311b5) mpack: format with nixfmt-rfc-style
* [`84b113b9`](https://github.com/NixOS/nixpkgs/commit/84b113b900e65f0434a9847222f3f0ad440df552) mpack: adopt
* [`c2e1c242`](https://github.com/NixOS/nixpkgs/commit/c2e1c242f469f2d11c6a077ee2de4b1e26701905) mpack: add passthru.tests.version
* [`5ab548fb`](https://github.com/NixOS/nixpkgs/commit/5ab548fb79d4f5a2925332f8ba7ad0701a779dff) ecs-agent: 1.82.3 -> 1.82.4
* [`02d00add`](https://github.com/NixOS/nixpkgs/commit/02d00add9cb22e3fa69767f82d8f12b3c635048b) python311Packages.peft: 0.10.0 -> 0.11.1
* [`fd9684a5`](https://github.com/NixOS/nixpkgs/commit/fd9684a507dc05969f8a91226d4f3e4d89eae3e6) vtm: 0.9.81 -> 0.9.82
* [`385ff1af`](https://github.com/NixOS/nixpkgs/commit/385ff1af43b73d0c415e11fdd7de0240d3469ecc) python311Packages.flask-limiter: 3.5.1 -> 3.7.0
* [`e1447de2`](https://github.com/NixOS/nixpkgs/commit/e1447de226ae4a7857b33d9a6a3a66fce5aab46a) minizincide: 2.8.3 -> 2.8.4
* [`f71a753d`](https://github.com/NixOS/nixpkgs/commit/f71a753d66c25c1494cf89bdae4890ca6a3275d0) maintainers: add anas
* [`c40cc2a9`](https://github.com/NixOS/nixpkgs/commit/c40cc2a9f2aa57c6c7731bc6919e3e0c2271a586) renode-unstable: 1.15.0+20240515gita6b1d773d -> 1.15.0+20240517gitf683c4f59
* [`604b680d`](https://github.com/NixOS/nixpkgs/commit/604b680d072e912242272787248a3b9cbd7d5ce5) monocraft: 2.4 -> 3.0
* [`9f022871`](https://github.com/NixOS/nixpkgs/commit/9f022871c65a691553585585389ae9b02a87b502) dorion: 4.2.1 -> 4.3.0
* [`54abec67`](https://github.com/NixOS/nixpkgs/commit/54abec679adfd22e678a2041d2031f04670e0490) steampipe: 0.23.1 -> 0.23.2
* [`e9ee0ff4`](https://github.com/NixOS/nixpkgs/commit/e9ee0ff4b0c71b8787b3f70d97a2748ed8f67bf0) hare: fix mime module
* [`7fe23b68`](https://github.com/NixOS/nixpkgs/commit/7fe23b68a3a765a096f9c2468970b32523276903) cider: 1.6.2 -> 1.6.3
* [`955fa7d7`](https://github.com/NixOS/nixpkgs/commit/955fa7d7e05a878662a70afd0ab469927785a484) qxmpp: 1.6.1 -> 1.7.0
* [`4fba1588`](https://github.com/NixOS/nixpkgs/commit/4fba1588a6f3f79b064a55c75f3847b62bfe2903) _1password-gui: 8.10.30 -> 8.10.33
* [`040acd1f`](https://github.com/NixOS/nixpkgs/commit/040acd1f12eeb2d72ab455b093e1330cf8719348) vimPlugins.markdown-nvim: init at 2024-04-23
* [`e6fe91d1`](https://github.com/NixOS/nixpkgs/commit/e6fe91d186771b09ad5a59527e89f5eca1caaa65) ringracers: init at 2.3
* [`6467f8b0`](https://github.com/NixOS/nixpkgs/commit/6467f8b0173acfa26b08206318344b58613ca1b4) llama-cpp: Add rpc and remove mpi support
* [`90de11ce`](https://github.com/NixOS/nixpkgs/commit/90de11ce8ad2e1d273be933078c98061832e2d02) node-problem-detector: 0.8.18 -> 0.8.19
* [`70b284d6`](https://github.com/NixOS/nixpkgs/commit/70b284d60cbddb0f16f19693ee84e3f12c57e171) nixos/thunderbird: init module
* [`96c7f8a0`](https://github.com/NixOS/nixpkgs/commit/96c7f8a0db3c77a335cf2d99cd01597ebf3fd520) pykanidm: 0.0.3 -> 1.0.0
* [`9c046fc2`](https://github.com/NixOS/nixpkgs/commit/9c046fc2f968a726a3799de775dcf95d3b2d5b7e) roam-research: 0.0.18 -> 0.0.19
* [`d65713d7`](https://github.com/NixOS/nixpkgs/commit/d65713d7a6ca0c30ad53238b45e805c4b5c92126) keepalived: 2.2.8 -> 2.3.0
* [`cb7760c2`](https://github.com/NixOS/nixpkgs/commit/cb7760c205ee701eb8e8a0e5d6dcd01c9a50cea0) smplayer: migrate to by-name
* [`16fc9a5a`](https://github.com/NixOS/nixpkgs/commit/16fc9a5a6532063a05ea13e8e687c8b5f21c7196) smplayer: nixfmt
* [`93b021a4`](https://github.com/NixOS/nixpkgs/commit/93b021a440bd392660d990740ce91e157aee71ef) smplayer: 23.12.0 -> 24.5.0
* [`c9158a1b`](https://github.com/NixOS/nixpkgs/commit/c9158a1b25116ddfdc150a46f1fc7dd5ff8721ba) elmPackages.elm-analyse: fix starting server
* [`d861a403`](https://github.com/NixOS/nixpkgs/commit/d861a4033f5ced1b991e465a1057e7fce1f96d9e) ooniprobe-cli: 3.21.1 -> 3.22.0
* [`dcb4b77b`](https://github.com/NixOS/nixpkgs/commit/dcb4b77bf9ab9be34aa79f4849651bd7e1290736) bombsquad: fix updater script
* [`0a625176`](https://github.com/NixOS/nixpkgs/commit/0a625176495115bf79de919f797272666d21a50c) bombsquad: 1.7.34 -> 1.7.35
* [`d44080dd`](https://github.com/NixOS/nixpkgs/commit/d44080dded77d67d1b409a5af43cd60e422649eb) vmware-horizon-client: replace buildFHSEnvChroot with buildFHSEnv
* [`2eaea707`](https://github.com/NixOS/nixpkgs/commit/2eaea7071a65a37b8102685c14b392467bdc0ede) evcc: 0.126.3 -> 0.126.4
* [`5aa9fc92`](https://github.com/NixOS/nixpkgs/commit/5aa9fc927306617ad428e50a54c638224c37bf5c) nixos/stage-1-init: notify during copytoram
* [`ea012b09`](https://github.com/NixOS/nixpkgs/commit/ea012b09640eb951b7bdcd3276a8cb8f275a88cf) iw: migrate to by-name
* [`0bd1bacb`](https://github.com/NixOS/nixpkgs/commit/0bd1bacb94e89e1f4516e620af7f147cc70ff5e0) iw: adopt and refactor
* [`ca940221`](https://github.com/NixOS/nixpkgs/commit/ca940221fddfe4c5c55f8aa55f83928e8ceaa01a) iw: 5.19 -> 6.7
* [`c528b38a`](https://github.com/NixOS/nixpkgs/commit/c528b38a510c39d5737f677606c1fa955362baa6) rocketchat-desktop: 3.9.14 -> 3.9.15
* [`061dad6a`](https://github.com/NixOS/nixpkgs/commit/061dad6a49062672bce39501b36faba428657620) spdx-license-list-data: 3.23 -> 3.24.0
* [`48765ef0`](https://github.com/NixOS/nixpkgs/commit/48765ef01641e29e11ae6ec63ee18194245dce6d) quarkus: 3.10.1 -> 3.10.2
* [`27e770f8`](https://github.com/NixOS/nixpkgs/commit/27e770f81563375caa63bd6cc755231ebc74c0dc) azure-static-sites-client: 1.0.026361 -> 1.0.026911
* [`3065f83f`](https://github.com/NixOS/nixpkgs/commit/3065f83fb84e28c133d6d429cbf3f8546560b9b0) vimPlugins.vim-clap: 0.53 -> 0.54
* [`559bffb2`](https://github.com/NixOS/nixpkgs/commit/559bffb2cb8ba041b285e44383f3f117c2e03827) git: correct update script
* [`e836d5a4`](https://github.com/NixOS/nixpkgs/commit/e836d5a4be6155dc8fe45abca7c5617361cc522b) signal-desktop: 7.9.0 -> 7.10.0
* [`cc59831e`](https://github.com/NixOS/nixpkgs/commit/cc59831e42ac07edf2128d6d4fe945233a45e806) evdevhook2: init at 1.0.2
* [`c0d0b657`](https://github.com/NixOS/nixpkgs/commit/c0d0b6579794ca82dab6cbf3226b2b97457871b0) protobuf_27: init at 27.0
* [`cf50bd0a`](https://github.com/NixOS/nixpkgs/commit/cf50bd0aa1a0d9271fd0c547f435b5c9a2a0f2c0) nixos/networking: use mkIfs on the inner attributes
* [`bbb19a13`](https://github.com/NixOS/nixpkgs/commit/bbb19a1371191046e75805ae7c3033bf618acc81) maintainers: add aveltras
* [`077512f1`](https://github.com/NixOS/nixpkgs/commit/077512f15672d6406753e0e7b03e16c4796d8a16) libgeotiff: 1.7.1 -> 1.7.2
* [`b18b35e1`](https://github.com/NixOS/nixpkgs/commit/b18b35e1056ef1552cce91a7adebe052a46f3f33) hieroglyphic: 1.0.1 -> 1.1.0
* [`78afb196`](https://github.com/NixOS/nixpkgs/commit/78afb19682e601817c9157eaf6e071e971d4c549) keymapper: 4.3.0 -> 4.3.1
* [`976504ea`](https://github.com/NixOS/nixpkgs/commit/976504ea6b7ef512c174da9b46d7d4c4e40df4e2) roxctl: 4.3.5 -> 4.4.2
* [`4d59f6ae`](https://github.com/NixOS/nixpkgs/commit/4d59f6ae53568b60406cdc6018e7c5de0d654208) jitsi-meet-electron: fix darwin build
* [`79f6157c`](https://github.com/NixOS/nixpkgs/commit/79f6157c2775c351bdac98d8ffd96ba0e7c58785) python311Packages.tempest: 38.0.0 -> 39.0.0
* [`4e1ee799`](https://github.com/NixOS/nixpkgs/commit/4e1ee79946054e8490427a9436afab0502788f58) libphonenumber: 8.12.37 -> 8.13.37
* [`ead03f47`](https://github.com/NixOS/nixpkgs/commit/ead03f474aa2d9e9af2b3479b279fe9d140b3429) chatty: 0.8.2 -> 0.8.3
* [`13b430fd`](https://github.com/NixOS/nixpkgs/commit/13b430fd028938482996886231a2272b67c0859a) avalanchego: 1.11.5 -> 1.11.6
* [`32fdfea7`](https://github.com/NixOS/nixpkgs/commit/32fdfea7c6a2a85e9ddc63f635e5587dfbfc7615) buildah-unwrapped: 1.35.4 -> 1.36.0
* [`b49599be`](https://github.com/NixOS/nixpkgs/commit/b49599be7220e2745382a4f6f75dd9015baf6815) wayfreeze: init at 0-unstable-2024-05-23
* [`1ad936e7`](https://github.com/NixOS/nixpkgs/commit/1ad936e7ce78f591f095f872543821b204a4a5d0) gnome.gnome-keyring: support cross compilation
* [`d73785b4`](https://github.com/NixOS/nixpkgs/commit/d73785b4b76159c603ddb2a6bc4e1d17f46008e7) zarf: 0.33.2 -> 0.34.0
* [`751d0910`](https://github.com/NixOS/nixpkgs/commit/751d0910407127b2b9f99d4695dffa1d7773ce7f) deno: 1.43.5 -> 1.43.6
* [`ccd9a989`](https://github.com/NixOS/nixpkgs/commit/ccd9a98951fe3434303eb78875044cc57eee8162) chirp: 0.4.0-unstable-2024-05-10 -> 0.4.0-unstable-2024-05-23
* [`e37e42f5`](https://github.com/NixOS/nixpkgs/commit/e37e42f5b64591af53699e07544c01b43aa4ffa2) filterpath: init at 1.0.1
* [`b42dc081`](https://github.com/NixOS/nixpkgs/commit/b42dc0819a3b708c7dbc83da23aa929c2cd63c1b) nextcloud-notify_push.tests: fix eval
* [`aeb080b7`](https://github.com/NixOS/nixpkgs/commit/aeb080b7b4f48aede23248bde0763d36a73bb53c) precice: 3.0.0 -> 3.1.1
* [`5564130e`](https://github.com/NixOS/nixpkgs/commit/5564130ecf771127b509a12670ce6fa26120279d) feishu: fix build error
* [`20962431`](https://github.com/NixOS/nixpkgs/commit/209624313619222ea8175542b6010cc7a2c723c9) feishu: add updateScript
* [`91fc33b0`](https://github.com/NixOS/nixpkgs/commit/91fc33b0bdece0c9e41c2afc7af303be8cb94b67) python311Packages.types-requests: 2.31.0.20240406 -> 2.32.0.20240523
* [`e675e240`](https://github.com/NixOS/nixpkgs/commit/e675e2406c43b2e24279062b951e800b5f4d80b1) setup-envtest: init at 0.18.2
* [`c5bfba14`](https://github.com/NixOS/nixpkgs/commit/c5bfba14e5fe979d1ee0ed1245fd8525be0b3482) calibre: 7.10.0 -> 7.11.0
* [`bcaf6de4`](https://github.com/NixOS/nixpkgs/commit/bcaf6de4675240018d07849b6fb86ae98591dce0) mealie: 1.2.0 -> 1.7.0
* [`fc81ca64`](https://github.com/NixOS/nixpkgs/commit/fc81ca6408312662c0eb0505b2710e826117403b) mealie: add 'anoa' as maintainer
* [`fad7ecc3`](https://github.com/NixOS/nixpkgs/commit/fad7ecc30f22b6ea8f82b450d306b3fc69953b78) mealie: set the correct port in BASE_URL
* [`84419e5c`](https://github.com/NixOS/nixpkgs/commit/84419e5c378577c04e4ec3869c3afd1533432031) lix: build in release mode with link time optimizations
* [`682e77dc`](https://github.com/NixOS/nixpkgs/commit/682e77dc8f1508ba382a86cd728af7e86d8aa0a3) docker-compose: 2.27.0 -> 2.27.1
* [`91bc7b40`](https://github.com/NixOS/nixpkgs/commit/91bc7b40cf1a1e8d874fee26db4ab2b32f456344) php81Extensions.blackfire: 1.92.15 -> 1.92.16
* [`8f0a46d4`](https://github.com/NixOS/nixpkgs/commit/8f0a46d4a87c12ed84f000fc8dcb49899b1aa294) caligula: 0.4.6 -> 0.4.7
* [`7679eb41`](https://github.com/NixOS/nixpkgs/commit/7679eb41cdbe715dc4a09185bcb280b9e195f899) gitnuro: add libGL
* [`8986eb40`](https://github.com/NixOS/nixpkgs/commit/8986eb40ec7b2a0b934072720d4efdcdc259b94f) ome_zarr: 0.8.3 -> 0.9.0
* [`b6aaa1a6`](https://github.com/NixOS/nixpkgs/commit/b6aaa1a62d4a853ee1820ff2eac84081de0fde8b) erlang_21: remove
* [`ed46c357`](https://github.com/NixOS/nixpkgs/commit/ed46c35731cbaeba8e80a3724c206dd47262b4f2) erlang_22: remove
* [`740e0c4a`](https://github.com/NixOS/nixpkgs/commit/740e0c4a0ed115242a95417bb899f6db78054479) erlang_23: remove
* [`cebb9f98`](https://github.com/NixOS/nixpkgs/commit/cebb9f98ee9c727f46b9913facdb55976fed8c63) erlangR24: remove
* [`2b64accb`](https://github.com/NixOS/nixpkgs/commit/2b64accb4c312d7ebfb903304a407ea5c5a9df0e) erlangR25: remove
* [`d13510ad`](https://github.com/NixOS/nixpkgs/commit/d13510ad5ff086ce928d995efaad35682518bbdf) erlangR26: remove
* [`6df7de55`](https://github.com/NixOS/nixpkgs/commit/6df7de555a7bb1442a1f5e8bbb26282742bb5b30) erlangR: remove
* [`b2730c48`](https://github.com/NixOS/nixpkgs/commit/b2730c480c422d761e09b1ce9c0fbe4a35290e36) youtrack: 2024.1.29548 -> 2024.1.32323
* [`19861fce`](https://github.com/NixOS/nixpkgs/commit/19861fcec622b3a3f7f3c833e327badd163f5e0a) lxgw-neoxihei: 1.121 -> 1.123
* [`d3d76906`](https://github.com/NixOS/nixpkgs/commit/d3d7690624a0dd8beb0c867680dcd16adb97af39) aws-sam-cli: 1.116.0 -> 1.117.0
* [`d30b662e`](https://github.com/NixOS/nixpkgs/commit/d30b662ed9f20f98131623ac981a2d88dd00564a) maintainers: add jdev082
* [`5b10517e`](https://github.com/NixOS/nixpkgs/commit/5b10517e438a4e030bd99b8b99be07669affa29a) junest: init at 7.4.8
* [`2e31e2ee`](https://github.com/NixOS/nixpkgs/commit/2e31e2ee4b4cfd8bc8c2c23d8cf3bf9a8e84621d) handbrake: 1.7.3 -> 1.8.0
* [`b064e2db`](https://github.com/NixOS/nixpkgs/commit/b064e2db6973927b9662ed223c07415e4ee2cc0c) nixos/mopidy: add wants network-online.target to fix warning
* [`d6823f42`](https://github.com/NixOS/nixpkgs/commit/d6823f421160e480c53919ab88cc74d481274694) nixpkgs-lint: patch shebang
* [`e9e8f72b`](https://github.com/NixOS/nixpkgs/commit/e9e8f72b3f8c97eca5a23472bd0ad475a2798bff) nixpkgs-lint: refactor to pname+version and dontBuild
* [`8411d7c5`](https://github.com/NixOS/nixpkgs/commit/8411d7c52033d90405282f2841d841c7cc3a85d8) live555: reorder
* [`ecee36b4`](https://github.com/NixOS/nixpkgs/commit/ecee36b4c244a69bed8afcfc978e3d654f9d2bf1) live555: 2024.05.05 -> 2024.05.15
* [`72b6de3b`](https://github.com/NixOS/nixpkgs/commit/72b6de3b3338aa4018a8d89d3fca6b95c8509c51) tbb: fix cross compiling for i686
* [`2528dc85`](https://github.com/NixOS/nixpkgs/commit/2528dc85efa438f6b9dffb091d44f7fc6d9a6375) hyprcursor: 0.1.8 -> 0.1.9
* [`d7b97be3`](https://github.com/NixOS/nixpkgs/commit/d7b97be32ece18882cd55fa40b5437dc1fdb1809) maintainers: add 9yokuro
* [`ed109780`](https://github.com/NixOS/nixpkgs/commit/ed1097803aca99e81ed2b2f19f32611a5656a1ee) kpcli: 4.0 -> 4.1
* [`da15a296`](https://github.com/NixOS/nixpkgs/commit/da15a2965e272727570bf3631f41cb28b476efbe) gnuradio3_9Packages.osmosdr: 0.2.5 -> 0.2.6
* [`f9f8f8bd`](https://github.com/NixOS/nixpkgs/commit/f9f8f8bd7f03b032eafddac9ff7ebd46084e874f) spring-boot-cli: 3.2.5 -> 3.3.0
* [`f2fad878`](https://github.com/NixOS/nixpkgs/commit/f2fad878759755c32bcafe563e3c7ecb3c6baea6) neo4j: 5.19.0 -> 5.20.0
* [`d553a49d`](https://github.com/NixOS/nixpkgs/commit/d553a49d50b59c78f39afac598616f54a3b0a346) alfaview: 9.10.1 -> 9.11.0
* [`9a4741e2`](https://github.com/NixOS/nixpkgs/commit/9a4741e2f4d29d14d86441de440d55c789e4d662) openttd-jgrpp: 0.59.0 -> 0.59.1
* [`ffc4826c`](https://github.com/NixOS/nixpkgs/commit/ffc4826c30d0a556bdd637c76a641aaa3034b912) maintainers: add pyle
* [`4434bc6a`](https://github.com/NixOS/nixpkgs/commit/4434bc6ac233085bde38e85851380ae3bb1ac360) python3Packages.plugp100: init at 5.1.3
* [`ab773559`](https://github.com/NixOS/nixpkgs/commit/ab7735598b27f92c04d828d1edb38fc0f3df0f9c) maintainers: add clebs
* [`34e11fff`](https://github.com/NixOS/nixpkgs/commit/34e11fff18f67efeaec01681842bb08e7c405a34) simplescreenrecorder: add update script
* [`65c5904b`](https://github.com/NixOS/nixpkgs/commit/65c5904b209dca7496a1dca668040dcaad2274f9) simplescreenrecorder: 0.4.3 -> 0.4.4
* [`6df575e9`](https://github.com/NixOS/nixpkgs/commit/6df575e903d6fa82a9aff8426ff0ba10a76b9b19) font-manager: add update script
* [`415bb195`](https://github.com/NixOS/nixpkgs/commit/415bb195784832ce0f813f883c621bd0888fb5c8) font-manager: 0.8.8 -> 0.8.9
* [`34a197ee`](https://github.com/NixOS/nixpkgs/commit/34a197ee29db70b8e7febb3fce99e6c767ca38ae) ch341eeprom: 0-unstable-2021-01-05 -> 0-unstable-2024-05-06
* [`43b1df20`](https://github.com/NixOS/nixpkgs/commit/43b1df204b746fcc7682d88d4f3a23909346d6c7) stargazer: 1.1.0 -> 1.2.1
* [`09be64ec`](https://github.com/NixOS/nixpkgs/commit/09be64ecc8ca784400d99decd75eaa1fae6c335e) nixos/prometheus: Add query_log_file option
* [`8d3e378f`](https://github.com/NixOS/nixpkgs/commit/8d3e378f97a52faf3b18d6380818104f5b08bed7) Update discord packages
* [`ff5f14a5`](https://github.com/NixOS/nixpkgs/commit/ff5f14a54c884565b636269acbd41d814870f2f8) openrefine: 3.7.9 -> 3.8.1
* [`8f31c8a2`](https://github.com/NixOS/nixpkgs/commit/8f31c8a21416acdcb58c28f4f7c5e078d5e4e080) flawz: init at 0.2.0
* [`9d2533a6`](https://github.com/NixOS/nixpkgs/commit/9d2533a66c067bec0008e6789d9852a0cab7d022) devpod: 0.5.7 -> 0.5.8
* [`fda42f1b`](https://github.com/NixOS/nixpkgs/commit/fda42f1beeda22cfe110562f5da943420eb06a09) editline: enable sigstop
* [`fce0a352`](https://github.com/NixOS/nixpkgs/commit/fce0a3529351b896acc8bf763fb23a8ecf69f820) libideviceactivation: init at 1.1.1
* [`6c62ac1b`](https://github.com/NixOS/nixpkgs/commit/6c62ac1befce0185d89e139182a4fe9e2e49c141) jetty: 12.0.8 -> 12.0.9
* [`31bd95c8`](https://github.com/NixOS/nixpkgs/commit/31bd95c8769ecd296e5bae31b3657740377a433b) opencv: expose runAccuracyTests, runPerformanceTests booleans
* [`b28f7c53`](https://github.com/NixOS/nixpkgs/commit/b28f7c5303a1ccb8a0d73b91df415b6d86c8eb9d) python3Packages.apricot-select: move scikit-learn and torchvision to dependencies
* [`b8c7244b`](https://github.com/NixOS/nixpkgs/commit/b8c7244baec13d29cb499beb0cfc29fe3eb98422) opencv3: don't build with CUDA newer than 11
* [`5d9de240`](https://github.com/NixOS/nixpkgs/commit/5d9de240e36e961d38bd703cc3140be38aac3dc6) vms-empire: migrate to by-name
* [`3c08c133`](https://github.com/NixOS/nixpkgs/commit/3c08c1332494166beb96bf73b90da8417d9ed28a) python3Packages.qrcode-terminal: init at 0.8
* [`46d0b373`](https://github.com/NixOS/nixpkgs/commit/46d0b37373766fd16896bae06f7306b18c2ec626) python3Packages.bilibili-api-python: init at 16.2.0
* [`0ae59f20`](https://github.com/NixOS/nixpkgs/commit/0ae59f20e2693d597b5cdfed17c1943b8b4101db) vms-empire: refactor
* [`b6cceadf`](https://github.com/NixOS/nixpkgs/commit/b6cceadf9c8d288d8c59a768c766089dbbee76fc) vms-empire: 1.16 -> 1.17
* [`428e60ca`](https://github.com/NixOS/nixpkgs/commit/428e60cad951567a9ee316eecc7c80c3c596b865) nixos/ollama: split `listenAddress` into `host` and `port`
* [`836e86c9`](https://github.com/NixOS/nixpkgs/commit/836e86c9804748826cdb34d901206c2e477f7ab8) krane: 3.5.3 -> 3.6.0
* [`3b72de99`](https://github.com/NixOS/nixpkgs/commit/3b72de99ab615d936f5f428645aa9f930dea0200) python311Packages.wallbox: 0.6.0 -> 0.7.0
* [`88f3879b`](https://github.com/NixOS/nixpkgs/commit/88f3879b2353fe4553dfec2463664e4d3b787c40) python311Packages.pyvo: 1.5.1 -> 1.5.2
* [`876498a7`](https://github.com/NixOS/nixpkgs/commit/876498a7d68a28a08ebaeaa41d69b71ea061fa0a) python311Packages.azure-mgmt-netapp: 12.0.0 -> 13.0.0
* [`af71e175`](https://github.com/NixOS/nixpkgs/commit/af71e175a2925be9feb73b10c64864c16cdbb975) python311Packages.sphinxcontrib-plantuml: 0.29 -> 0.30
* [`1a4934d1`](https://github.com/NixOS/nixpkgs/commit/1a4934d100dc441c558db8164aac911ae8582515) python311Packages.sphinxcontrib-plantuml: add pythonImportsCheck
* [`ea95a42c`](https://github.com/NixOS/nixpkgs/commit/ea95a42ccdabbf5f262491f85a4eacb2fa3a03e0) python3Packages.import-expression: 1.1.4 -> 1.1.5
* [`37a42999`](https://github.com/NixOS/nixpkgs/commit/37a42999fc81d7784dadecaf42d0ca94e47d3998) python3Packages.llmx: init at 0.0.21a0
* [`3def226b`](https://github.com/NixOS/nixpkgs/commit/3def226b6db2adfc0930af1a3f2992f25c160fe6) python311Packages.pytorch-lightning: 2.2.4 -> 2.2.5
* [`1de24ea8`](https://github.com/NixOS/nixpkgs/commit/1de24ea8429e0c50f20b91287ae35a3a885cf1b5) python311Packages.pytorch-lightning: update meta
* [`48f502c1`](https://github.com/NixOS/nixpkgs/commit/48f502c155850e37bdd8f4cd2466c6882713533a) obs-studio-plugins.obs-move-transition: 2.12.0 -> 3.0.0
* [`b1c46e1d`](https://github.com/NixOS/nixpkgs/commit/b1c46e1d2e20ba001be75dd197ad3adbe19b89d2) python3Packages.apricot-select: disable flaky tests
* [`8e437816`](https://github.com/NixOS/nixpkgs/commit/8e437816fc9b817d0774a13acaccdd2e31d92834) beeper: 3.104.7 -> 3.105.2
* [`7f59ff50`](https://github.com/NixOS/nixpkgs/commit/7f59ff50abd526ec5a6ddd9738542f8892cb8da6) python311Packages.robotframework-seleniumlibrary: 6.3.0 -> 6.4.0
* [`9d19167e`](https://github.com/NixOS/nixpkgs/commit/9d19167e4e1b8ac8122900d0c826f394dbaed671) scdl: 2.7.7 -> 2.7.9
* [`27f69fa9`](https://github.com/NixOS/nixpkgs/commit/27f69fa93e485d747261d8068aecc9dc0e547a27) ghidra: improve desktop support
* [`e4380f5b`](https://github.com/NixOS/nixpkgs/commit/e4380f5b86161a0ac17644c2b223ce20b7b84b7c) jellyfin-mpv-shim: 2.6.0 -> 2.7.0.post2
* [`da496b0c`](https://github.com/NixOS/nixpkgs/commit/da496b0c40526000e482d50a94e994a07a6fb5f6) immich-go: 0.14.1 -> 0.15.0
* [`ec304065`](https://github.com/NixOS/nixpkgs/commit/ec304065cdd3dc333bad6d35793c90e3cfbd1979) python311Packages.zipstream: remove
* [`cdcccd94`](https://github.com/NixOS/nixpkgs/commit/cdcccd94adf673122a425020abf895e1cdfec6be) wlr-layout-ui: 1.6.10 -> 1.6.11
* [`a05c4e94`](https://github.com/NixOS/nixpkgs/commit/a05c4e94b2a6e1ed014b3d1dacc3a5b35c2f7c85) python311Packages.nuitka: 2.1.4 -> 2.2.3
* [`36de695b`](https://github.com/NixOS/nixpkgs/commit/36de695b0e23926eaed4f3377a58615c80d2ffa9) qemu: fix cross
* [`2005aa65`](https://github.com/NixOS/nixpkgs/commit/2005aa65a1fd01d6dca149655d4e7f7b6c90428b) errands: 46.2 -> 46.2.2
* [`c0f55c79`](https://github.com/NixOS/nixpkgs/commit/c0f55c7917d5def5a52d8a595ce745c50023814b) angie: add withAcme option
* [`1836470c`](https://github.com/NixOS/nixpkgs/commit/1836470c42550f3949188902e324cd1140ab1d64) glooctl: 1.16.11 -> 1.16.14
* [`9a889b33`](https://github.com/NixOS/nixpkgs/commit/9a889b33c4e15259f74f337e76acc66f4863c3de) esbuild: 0.20.2 -> 0.21.4
* [`31878275`](https://github.com/NixOS/nixpkgs/commit/318782758531a8e79c31c357eec1e3f7e95879f0) wiremock: 3.5.4 -> 3.6.0
* [`3370fbe7`](https://github.com/NixOS/nixpkgs/commit/3370fbe7856092a38f73dc07f15171d6f090bd17) ayatana-indicator-datetime: 24.2.0 -> 24.5.0
* [`b4cc5151`](https://github.com/NixOS/nixpkgs/commit/b4cc51513b2c80e8ea695e36d81666ab34543c8e) kodi.packages.controller-topology-project: unstable-2022-11-19 -> 1.0.0
* [`c8e12726`](https://github.com/NixOS/nixpkgs/commit/c8e127268a79262489b92421493a3b859439cfe5) kernelshark: 2.2.1 -> 2.3.1
* [`e873fe96`](https://github.com/NixOS/nixpkgs/commit/e873fe965b5e903648e2dce9ee57c22114072caf) json-fortran: 8.4.0 -> 8.5.0
* [`4a1def69`](https://github.com/NixOS/nixpkgs/commit/4a1def69592aa995f86c4862c3d2dcbb496287fd) lazydocker: 0.23.1 -> 0.23.3
* [`c91fbf4f`](https://github.com/NixOS/nixpkgs/commit/c91fbf4f4b0994e4196698c4128296dd4a3ee0fb) lemonbar: 1.4 -> 1.5
* [`079824d5`](https://github.com/NixOS/nixpkgs/commit/079824d5ca8c88936558c6e42c052f5e5ae58797) nix-janitor: 0.2.0 -> 0.3.1
* [`448c182d`](https://github.com/NixOS/nixpkgs/commit/448c182dffe131aa6f598f600cd35b9bcca0b01c) mbqn: unstable-2023-05-17 -> 0-unstable-2024-05-13
* [`dfeff03c`](https://github.com/NixOS/nixpkgs/commit/dfeff03c6f497b71fb4c7f6757e8bcce3c606ec5) bqn: migrate to by-name
* [`9fba6efd`](https://github.com/NixOS/nixpkgs/commit/9fba6efd7231181c60779921c2e5bfb74ac7a052) instawow: 4.3.0 -> 4.4.0
* [`7429b37a`](https://github.com/NixOS/nixpkgs/commit/7429b37a8dc8e7a275ceccec4d1696ffb7cfec0a) plantuml-server: 1.2024.4 -> 1.2024.5
* [`cf4d0c4e`](https://github.com/NixOS/nixpkgs/commit/cf4d0c4e3f66a2edb49c161f7117240914548864) stats: 2.10.14 -> 2.10.15
* [`1e5cbf80`](https://github.com/NixOS/nixpkgs/commit/1e5cbf80383f7fa4d4ba423ef942512b1ff04fb9) evince: 46.1 → 46.3
* [`aa2d96b2`](https://github.com/NixOS/nixpkgs/commit/aa2d96b2b865121583665344b4839f8539a7e2ad) gnome.file-roller: 44.2 → 44.3
* [`dd7db60d`](https://github.com/NixOS/nixpkgs/commit/dd7db60d7bf346f0a8db37e60d26c8b640dd809c) gnome.gnome-initial-setup: 46.0 → 46.2
* [`c130d93c`](https://github.com/NixOS/nixpkgs/commit/c130d93c68aee5e2373826ef5f45035d53342cde) gnome.gnome-maps: 46.10 → 46.11
* [`15024190`](https://github.com/NixOS/nixpkgs/commit/15024190f5681e7c9d08d6ddd019dc8e882f07ed) gnome.gnome-software: 46.1 → 46.2
* [`1886558b`](https://github.com/NixOS/nixpkgs/commit/1886558b274e70dc1466787439dc3c6d77953481) gvfs: 1.54.0 → 1.54.1
* [`46f93484`](https://github.com/NixOS/nixpkgs/commit/46f9348479b395644d04570f3d14a67f2c4b143f) gnome.rygel: 0.42.5 → 0.42.6
* [`fa4611e4`](https://github.com/NixOS/nixpkgs/commit/fa4611e465e6b55ac1bb85ea00ed40220f6b66e6) gnome-builder: 46.1 → 46.2
* [`62ee5cad`](https://github.com/NixOS/nixpkgs/commit/62ee5cadbe423982b7b00107e7361589dfedc898) gnome-online-accounts: 3.50.1 → 3.50.2
* [`4653e5d0`](https://github.com/NixOS/nixpkgs/commit/4653e5d070eb404d91ff9cc5705b65ff55c0f47b) libadwaita: 1.5.0 → 1.5.1
* [`8a08782e`](https://github.com/NixOS/nixpkgs/commit/8a08782e4dfc5b8d31063e2eb5d047f030bf9c79) libmsgraph: 0.2.1 → 0.2.2
* [`a90ad835`](https://github.com/NixOS/nixpkgs/commit/a90ad835fdfed0c0393e9a1c8b5ee24ea8b0f0fc) libshumate: 1.2.1 → 1.2.2
* [`2b0062f5`](https://github.com/NixOS/nixpkgs/commit/2b0062f5fa7b6c625258dccf7ff476759ec61997) gnome.aisleriot: 3.22.32 → 3.22.33
* [`184ffd7b`](https://github.com/NixOS/nixpkgs/commit/184ffd7bee330f13af1244246d03f81086821fdf) gnome.gucharmap: 15.1.2 → 15.1.5
* [`8c463bfe`](https://github.com/NixOS/nixpkgs/commit/8c463bfeb0437447b31d3fa0cae5e89ebb08f0be) gnome.gnome-shell-extensions: 46.1 → 46.2
* [`41e94d87`](https://github.com/NixOS/nixpkgs/commit/41e94d87d8a6b758354bae651d61856e2c6b905a) gnome.gnome-terminal: 3.52.1 → 3.52.2
* [`49097abd`](https://github.com/NixOS/nixpkgs/commit/49097abda92e0e5444c70687067ab288ea2a42b4) gnome.mutter: 46.1 → 46.2
* [`e6719289`](https://github.com/NixOS/nixpkgs/commit/e6719289cdd68c290fa076a6409a2d89535ade5e) gnome.mutter: remove unneeded dependencies
* [`891e0fb1`](https://github.com/NixOS/nixpkgs/commit/891e0fb10bc0e3a6e1adecce210b5608f0639ce7) xdg-desktop-portal-gnome: 46.1 → 46.2
* [`ca3b765c`](https://github.com/NixOS/nixpkgs/commit/ca3b765cfbb69f5324ce07266ad471522c7423bb) gnome.nautilus: 46.1 → 46.2
* [`1cf80c71`](https://github.com/NixOS/nixpkgs/commit/1cf80c71d4c6c2a2a0d59e200ffca9baec9ddba5) gnome.gnome-shell: 46.1 → 46.2
* [`c9890591`](https://github.com/NixOS/nixpkgs/commit/c989059161765aa4b9fe298a9b12696d08e93047) vte: 0.76.1 → 0.76.2
* [`f4df7f0e`](https://github.com/NixOS/nixpkgs/commit/f4df7f0e7e98452f3dd83669fe8f8839fdd8f8ca) libgtop: 2.41.2 → 2.41.3
* [`07ae3d80`](https://github.com/NixOS/nixpkgs/commit/07ae3d806bd308b1d9ac46dbbd24a88518e615d7) gnome.geary: 44.1 → 46.0
* [`846ed7f3`](https://github.com/NixOS/nixpkgs/commit/846ed7f3e0ee8e17e6c38a00638317e5c8be2c9c) python311Packages.jupyter-client: 8.6.1 -> 8.6.2
* [`3bd44b0c`](https://github.com/NixOS/nixpkgs/commit/3bd44b0c64778ae117674a504efc0dd3313b8d17) python311Packages.jupyter-client: add teams.jupyter as maintainers
* [`f2a44535`](https://github.com/NixOS/nixpkgs/commit/f2a445353e4416935567c3d9da5dc7b5f60975e5) python311Packages.jupyterhub: 4.1.5 -> 5.0.0
* [`8bef19fc`](https://github.com/NixOS/nixpkgs/commit/8bef19fcbaba48915860093453c26dd1d2c1bb2e) python311Packages.jupyterhub: refactor
* [`d7cf5a7f`](https://github.com/NixOS/nixpkgs/commit/d7cf5a7f731bc3d0df9410bb51359022acce42d4) python311Packages.jupyterlab: 4.2.0 -> 4.2.1
* [`5ec93285`](https://github.com/NixOS/nixpkgs/commit/5ec93285fd9580df6d6880dc5c51d159db977658) python311Packages.jupyterlab-server: 2.27.1 -> 2.27.2
* [`153047f4`](https://github.com/NixOS/nixpkgs/commit/153047f419e75f793752300352f94afa1d1c000b) python311Packages.nbclassic: 1.0.0 -> 1.1.0
* [`5f554e68`](https://github.com/NixOS/nixpkgs/commit/5f554e685382c4e24e9ea7f4855602debd3b0c59) python311Packages.nbclassic: refactor
* [`cdda685c`](https://github.com/NixOS/nixpkgs/commit/cdda685ca98d59074ecdc8b074e34e1967d388e2) python3Packages.zconfig: 4.0 -> 4.1
* [`d9c9da5d`](https://github.com/NixOS/nixpkgs/commit/d9c9da5d659631aaa927c5a37713e39119abdd0c) netbsd.makeMinimal: Make it possible to override the rules
* [`222a29eb`](https://github.com/NixOS/nixpkgs/commit/222a29eb534527fc82d96cd681242c6e788cabc1) llvmPackages.clang: Fix special-case for OpenBSD to be less special
* [`0c6d2eee`](https://github.com/NixOS/nixpkgs/commit/0c6d2eee3c9edd7d2d357c09e4dac7369e6afd2f) llvmPackages.libcxx: Fix compiling for OpenBSD
* [`d0b08ab5`](https://github.com/NixOS/nixpkgs/commit/d0b08ab5de26f0764c5ebbb4d05a1d642ba96f01) llvmPackages: libcxx: link stdlib
* [`ad6fa01c`](https://github.com/NixOS/nixpkgs/commit/ad6fa01c066f86f233f82023bd4b47431937b3e9) llvmPackages.compiler-rt: Add flag to force libcompiler-rt.a creation
* [`c78228cc`](https://github.com/NixOS/nixpkgs/commit/c78228cc020b12830eeb7510ff357cc490bbabbc) wiper: init at 0.2.1
* [`888dee44`](https://github.com/NixOS/nixpkgs/commit/888dee445d72fa292f52bd477950b2eaf3ee8c3e) openbsd: init at 7.5
* [`b27e7bb4`](https://github.com/NixOS/nixpkgs/commit/b27e7bb41e574e10407f05bb99c548bffda7951a) mutt: fix cross compilation, set strictDeps
* [`68c7c414`](https://github.com/NixOS/nixpkgs/commit/68c7c4140126c1cb4a39166f01976f52231a710d) icewm: fix cross compilation, set strictDeps
* [`b788b6fc`](https://github.com/NixOS/nixpkgs/commit/b788b6fc8c55732448c5f07f61aa8ca1cc93b549) box64: Add LoongArch dynarec
* [`4911cf57`](https://github.com/NixOS/nixpkgs/commit/4911cf572e870d89c02483992a266203b576e670) mangohud: 0.7.1 -> 0.7.2
* [`fc4ed4e9`](https://github.com/NixOS/nixpkgs/commit/fc4ed4e94186aab3c09874a992a3bb3bdb191fb8) box64: Modernise abit
* [`cefebba4`](https://github.com/NixOS/nixpkgs/commit/cefebba4ff3cacca41353656ce9641f6deb93c6c) box64: Format with nixfmt-rfc-style
* [`b8e86a8f`](https://github.com/NixOS/nixpkgs/commit/b8e86a8f6b07d50f4aaaf916bfdbf297985f7b98) python311Packages.litellm: 1.37.16 -> 1.38.8
* [`8275088b`](https://github.com/NixOS/nixpkgs/commit/8275088b464f5f35a9a09e79e32de1ff30e11f07) telescope: 0.9 -> 0.9.1
* [`9127f7b3`](https://github.com/NixOS/nixpkgs/commit/9127f7b3e87ab2cb3a767464b5ef87fcab559378) cbqn: huge refactor
* [`4897c075`](https://github.com/NixOS/nixpkgs/commit/4897c075fccc8f44c35ffcc5d7600e63c930139c) cbqn: 0.5.0 -> 0.6.0
* [`fb6123be`](https://github.com/NixOS/nixpkgs/commit/fb6123bedfb921623c30538b8241fe381522b659) cbqn: 0.6.0 -> 0.7.0
* [`9247f579`](https://github.com/NixOS/nixpkgs/commit/9247f579f154b450eab7afa9a010c10f197d29ee) headphones: 0.6.1 -> 0.6.3
* [`06b2f773`](https://github.com/NixOS/nixpkgs/commit/06b2f7730a0a744099ddccabee2b568a57c3b063) python311Packages.rowan: init at 1.3.0
* [`66cf4ae7`](https://github.com/NixOS/nixpkgs/commit/66cf4ae72b7f30d85d06553af119945cb8d27e94) python311Packages.llama-index: 0.10.38 -> 0.10.39
* [`3fe773a1`](https://github.com/NixOS/nixpkgs/commit/3fe773a17452ecb0d5ca7379e33cfbd6924a52b5) nixos/openssh: allow removing settings
* [`7ba8d49b`](https://github.com/NixOS/nixpkgs/commit/7ba8d49bd5d7f8a0fc7fdb098fe933dd58f93c20) pomerium: 0.25.2 -> 0.26.0
* [`e6d3a228`](https://github.com/NixOS/nixpkgs/commit/e6d3a228b1faf4fa4ce1d055e9be0b28956f66b7) supabase-cli: 1.168.1 -> 1.169.5
* [`121fcdf8`](https://github.com/NixOS/nixpkgs/commit/121fcdf845f08c2decc7319b066f0e8905f4f104) python311Packages.google-cloud-bigquery: 3.23.0 -> 3.23.1
* [`58cd93be`](https://github.com/NixOS/nixpkgs/commit/58cd93becdd7d43f7857757173da7883cbca87bf) fable: 4.13.0 -> 4.18.0
* [`61167e9c`](https://github.com/NixOS/nixpkgs/commit/61167e9c2a42b05b508dec15f27e0d100e01326d) zathuraPkgs: run nixfmt-rfc-style
* [`0d29dc50`](https://github.com/NixOS/nixpkgs/commit/0d29dc5000b6011fdaeb71031cdad70be44944e6) zathura: update homepage
* [`c7926261`](https://github.com/NixOS/nixpkgs/commit/c792626170654fb953cfe5c55f9ee47a1b6da946) neocmakelsp: 0.6.25 -> 0.6.26
* [`8155c2b1`](https://github.com/NixOS/nixpkgs/commit/8155c2b1e27cfabdf481d98758531688dbb35c0e) reindeer: 2024.05.13.00 -> 2024.05.20.00
* [`c926b454`](https://github.com/NixOS/nixpkgs/commit/c926b4540af300a6e7eac322aa1fac2753dbb863) python312Packages.asyncwhois: 1.1.2 -> 1.1.3
* [`2ed2738f`](https://github.com/NixOS/nixpkgs/commit/2ed2738fceaa90797eed893b03064592e2f60d9f) python312Packages.model-checker: 0.3.21 -> 0.4.4
* [`28a2669a`](https://github.com/NixOS/nixpkgs/commit/28a2669abadcea42fa46303a9b3cc0a0bfe1c510) opencv: add option to only compile specific modules
* [`3f2725c4`](https://github.com/NixOS/nixpkgs/commit/3f2725c451fa399a5c1ec52a7a0fd78a96f9066f) templ: 0.2.697 -> 0.2.707
* [`70ec3a3c`](https://github.com/NixOS/nixpkgs/commit/70ec3a3c0f248f24da9ad42c4c7ec5e90107c284) gst_all_1.gst-plugins-rs: add withGtkPlugins option
* [`cb58275d`](https://github.com/NixOS/nixpkgs/commit/cb58275dc676d0ef90671feb260957098de8e47b) nixos/no-x-libs: build gst-plugins-rs without gtk
* [`db66127c`](https://github.com/NixOS/nixpkgs/commit/db66127c5ba6dd50513e8dd6decff996bd352a6a) nixos/no-x-libs: make sure gst-plugins-base has enableGl disabled
* [`7e492aff`](https://github.com/NixOS/nixpkgs/commit/7e492aff4b23e27915771b4a979527020bbd59d2) gst_all_1.gst-plugins-bad: remove wayland packages if gst-plugins-base has wayland disabled
* [`064730b5`](https://github.com/NixOS/nixpkgs/commit/064730b54f13497b5a1a91a7f816124d513097e0) gnomeExtensions.system-monitor: patch to add GTop to the extension's path
* [`50f266fc`](https://github.com/NixOS/nixpkgs/commit/50f266fc9cfe760d8f0f178402444b54f2d2df1b) ustreamer: enable v4p (video passthrough)
* [`7a7770c4`](https://github.com/NixOS/nixpkgs/commit/7a7770c46c6b9a096c6900d464a0ab934a2e6122) ustreamer: 6.4 -> 6.12
* [`cc48fad5`](https://github.com/NixOS/nixpkgs/commit/cc48fad505d1c4c923f5e0322043db9cee060b46) meshcentral: 1.1.22 -> 1.1.24
* [`3b35fb98`](https://github.com/NixOS/nixpkgs/commit/3b35fb98d05e4a087a3d0bfc5d1f342006201d5a) granted: 0.26.2 -> 0.27.0
* [`89222336`](https://github.com/NixOS/nixpkgs/commit/89222336b09dd9f9aafd7e537de943c53c9ee50e) spire: 1.9.5 -> 1.9.6
* [`4b507632`](https://github.com/NixOS/nixpkgs/commit/4b5076329674f4fafadab918eb621623e120f573) misconfig-mapper: 1.2.0 -> 1.3.0
* [`b1d4e99a`](https://github.com/NixOS/nixpkgs/commit/b1d4e99af4a6b458982c1d8d9111ed79a4acdc1c) nixos-artwork.wallpapers.*: Make license wallpaper-specific
* [`fe8d364f`](https://github.com/NixOS/nixpkgs/commit/fe8d364ff15233b3179ddae687d47ec9237402e5) python312Packages.pymongo-inmemory: 0.4.1 -> 0.4.2
* [`00e4a164`](https://github.com/NixOS/nixpkgs/commit/00e4a1647832cda1576fe2d6a4d404b8cc187d8d) nixos-artwork.wallpapers.*: Switch to SRI hash format
* [`2daa66fd`](https://github.com/NixOS/nixpkgs/commit/2daa66fdee75d48887c65b64d2c29cc0d1f0ff2e) nixos-artwork.wallpapers.gradient-grey: init at 2018-10-20
* [`8dd0b1d0`](https://github.com/NixOS/nixpkgs/commit/8dd0b1d0ab4d34615abd0fd3b6d8ce5ce5a42aa0) grafana-image-renderer: 3.10.2 -> 3.10.5
* [`5968598e`](https://github.com/NixOS/nixpkgs/commit/5968598e5f2938fb5b3c7cfcec419ade47d59611) nixos-artwork.wallpapers.nineish-solarized-dark,nixos-artwork.wallpapers.nineish-solarized-light: init at 2021-07-20
* [`a6ae8972`](https://github.com/NixOS/nixpkgs/commit/a6ae8972a5f4ee9d0aa63318767ffa61c9b15b40) nixos-artwork.wallpapers.{gear,moonscape,recursive,waterfall,watersplash}: init at 2022-04-19
* [`bbc5af4f`](https://github.com/NixOS/nixpkgs/commit/bbc5af4fccca60d453d95ef451e027877ffc526a) nixVersions.git: 2.23.0pre20240520_b7709d14 -> 2.23.0pre20240526_7de033d6
* [`8fbd83c8`](https://github.com/NixOS/nixpkgs/commit/8fbd83c8a1dd3ec020bde979765ec8f3dddf860c) nixos-artwork.wallpapers.binary-{black,blue,red,white}: init at 2024-02-15
* [`91da428e`](https://github.com/NixOS/nixpkgs/commit/91da428e7864b3de465c47704f58aaaeb7dae0de) nixos-artwork.wallpapers.catppuccin-{frappe,latte,macchiato,mocha}: init at 2024-02-15
* [`3381fdd7`](https://github.com/NixOS/nixpkgs/commit/3381fdd745616f199deed6b4fe33a9bf81b9351a) nixos/no-x-libs: add pinentry-tty
* [`147bdf3c`](https://github.com/NixOS/nixpkgs/commit/147bdf3ca158f0679c2fd21c6f94ac36b7ab3962) tenv: 1.11.2 -> 1.11.5
* [`208c33fa`](https://github.com/NixOS/nixpkgs/commit/208c33fa1cd7c595a08128d5290bf953c45a0810) _64gram: 1.1.22 -> 1.1.23
* [`14de0380`](https://github.com/NixOS/nixpkgs/commit/14de0380da76de3f4cd662a9ef2352eed0c95b7d) binutils: do not build with -static-libgcc on FreeBSD
* [`9e51ea4d`](https://github.com/NixOS/nixpkgs/commit/9e51ea4d9dc8436b0055133b4ef97e1232ebdeda) python311Packages.rapidgzip: 0.13.3 -> 0.14.2
* [`28957496`](https://github.com/NixOS/nixpkgs/commit/2895749614391902db3144d295616bb53cf30397) python311Packages.meeko: 0.5.0 -> 0.5.1
* [`0d8fe4b4`](https://github.com/NixOS/nixpkgs/commit/0d8fe4b47638fcaf77a0c908c834388e6aa8783f) python311Packages.openrazer: fix indentation
* [`9dd5cef4`](https://github.com/NixOS/nixpkgs/commit/9dd5cef4984e223cf2033406942156ef5442b5bb) python311Packages.openrazer: fix gobjects, double wrapping
* [`37eb5218`](https://github.com/NixOS/nixpkgs/commit/37eb5218276d571ce7f19fc63e3206bbb8d07d45) hifile: 0.9.9.11 -> 0.9.9.12
* [`77e53003`](https://github.com/NixOS/nixpkgs/commit/77e53003c2b474db7e758852193a7fc81b6c1103) python311Packages.django-import-export: 4.0.3 -> 4.0.5
* [`1316066c`](https://github.com/NixOS/nixpkgs/commit/1316066c97d50f09b95dcdbb0b66ddb87a94cf52) python311Packages.githubkit: 0.11.4 -> 0.11.5
* [`7e077231`](https://github.com/NixOS/nixpkgs/commit/7e0772313acd8c9437f49291910d3b60f0611206) zsh-wd: init at 0.7.0
* [`fb9bfe8f`](https://github.com/NixOS/nixpkgs/commit/fb9bfe8f74d8391cbc201715d580c49a14c32a3b) hvm: 2.0.12 -> 2.0.17
* [`65ad6899`](https://github.com/NixOS/nixpkgs/commit/65ad689912987ca9e9bc3c623dc376db389d96f0) bend: 0.2.9 -> 0.2.22
* [`089b208a`](https://github.com/NixOS/nixpkgs/commit/089b208a7bce383713d5cf15186cf01a9533aef5) vitess: 19.0.3 -> 19.0.4
* [`6393c9ba`](https://github.com/NixOS/nixpkgs/commit/6393c9bad387fde70b18016c57532f8842dc2d1d) g3kb-switch: 1.4 -> 1.5
* [`7568ee06`](https://github.com/NixOS/nixpkgs/commit/7568ee06c9f8db787588c2168895301a5db4cded) python3Packages.apricot-select: disable tests by default
* [`3b1b7987`](https://github.com/NixOS/nixpkgs/commit/3b1b7987af4c3ac94c90f8f7a0e4a317d7d03353) unison-fsmonitor: 0.3.3 -> 0.3.4
* [`e3fced5a`](https://github.com/NixOS/nixpkgs/commit/e3fced5a3a774074fe8d7e17e01241d65cd1bce5) cargo-public-api: 0.34.1 -> 0.34.2
* [`dab82e69`](https://github.com/NixOS/nixpkgs/commit/dab82e69152e1ebeecf4e08577beed45f8ad0eed) node-hp-scan-to: 1.4.2 -> 1.4.3
* [`ad43b9c0`](https://github.com/NixOS/nixpkgs/commit/ad43b9c0cf4bd6584c80f50b5388b366ae489621) python3Packages.import-expression: update legacy attributes
* [`a5e81cea`](https://github.com/NixOS/nixpkgs/commit/a5e81ceadd8b6cc8fbb649b135d59b80d53726e2) figma-linux: 0.11.3 -> 0.11.4
* [`ef1e2e21`](https://github.com/NixOS/nixpkgs/commit/ef1e2e2160160f8a22dd132eef38db04e8bdd454) pgbackrest: 2.51 -> 2.52
* [`3097e881`](https://github.com/NixOS/nixpkgs/commit/3097e8818d51075b8364545bd09054a124cf95a3) checkstyle: 10.16.0 -> 10.17.0
* [`b9e42275`](https://github.com/NixOS/nixpkgs/commit/b9e422759ae08746f6bab017644b3f31884c0f6a) sing-box: 1.8.14 -> 1.9.0
* [`afdc6156`](https://github.com/NixOS/nixpkgs/commit/afdc61569b32ff2b32b3d1efa8d45a7705a546a5) micronaut: 4.4.2 -> 4.4.3
* [`fbf0287b`](https://github.com/NixOS/nixpkgs/commit/fbf0287b3dfa1bfcad657ada12f3f16b9b3cdb32) sarasa-gothic: 1.0.12 -> 1.0.13
* [`9bb9fb21`](https://github.com/NixOS/nixpkgs/commit/9bb9fb21e088e8c5b342e8b65213cafe7478b435) chiaki4deck: 1.7.0 -> 1.7.1
* [`e4419b7e`](https://github.com/NixOS/nixpkgs/commit/e4419b7e0d2ceeec529ff5dc3f75dd486634c4aa) ocamlPackages.js_of_ocaml-ppx_deriving_json: 5.8.1 -> 5.8.2
* [`539c851f`](https://github.com/NixOS/nixpkgs/commit/539c851f7978a43f07626cfc5dbc7614138b0121) ocamlPackages.js_of_ocaml-compiler: 5.8.1 -> 5.8.2
* [`150a859d`](https://github.com/NixOS/nixpkgs/commit/150a859d345353d6a42876360dbe70a038a5c786) coqPackages.mathcomp-infotheo: 0.6.1 → 0.7.1
* [`7359e7f5`](https://github.com/NixOS/nixpkgs/commit/7359e7f57c4b2a463ff3e678a4b25a8835d98250) linuxKernel.kernels.linux_zen: 6.9.1-zen1 -> 6.9.2-zen1
* [`df4f7744`](https://github.com/NixOS/nixpkgs/commit/df4f774429ad9a1ade3aa9a2551ad46125c3a6d9) ocamlPackages.js_of_ocaml-ppx: 5.8.1 -> 5.8.2
* [`d5e8abb1`](https://github.com/NixOS/nixpkgs/commit/d5e8abb120939ea2a8617154a6df24d9b1fd2f9b) ocamlPackages.js_of_ocaml-tyxml: 5.8.1 -> 5.8.2
* [`d3140b0b`](https://github.com/NixOS/nixpkgs/commit/d3140b0bf71e605c6201091be76dc5b2a83f7fa2) ocamlPackages.js_of_ocaml-lwt: 5.8.1 -> 5.8.2
* [`b0e19dea`](https://github.com/NixOS/nixpkgs/commit/b0e19dea992ba28d17bc0f95af728d131c7ea217) sickgear: 3.30.19 -> 3.30.20
* [`69992537`](https://github.com/NixOS/nixpkgs/commit/69992537d5e8720abb153d8cfadef9ee6a0f8116) home-assistant-custom-lovelace-modules.android-tv-card: 3.7.3 -> 3.7.4
* [`1c11e092`](https://github.com/NixOS/nixpkgs/commit/1c11e0920c0f831974fce25ca525ad8161b07a11) golangci-lint: 1.58.2 -> 1.59.0
* [`2ced1d73`](https://github.com/NixOS/nixpkgs/commit/2ced1d73b211c978188f4fcc48c480f2e6ff2aa0) faraday-agent-dispatcher: 3.3.0 -> 3.4.1
* [`0334aba6`](https://github.com/NixOS/nixpkgs/commit/0334aba6ebbed276339c9bdb97fc64f086f68ac3) sketchybar-app-font: 2.0.18 -> 2.0.19
* [`484ca81b`](https://github.com/NixOS/nixpkgs/commit/484ca81b754e8f96e9bb440071a5fe0c6716193f) python311Packages.peaqevcore: 19.10.8 -> 19.10.12
* [`8984b534`](https://github.com/NixOS/nixpkgs/commit/8984b5343456ce8a60bbc010dd0bcb40da21c0f7) ols: 0-unstable-2024-05-18 -> 0-unstable-2024-05-22
* [`8e3ef297`](https://github.com/NixOS/nixpkgs/commit/8e3ef297e121f45665b2e5253f012c2059ffde57) deepdiff: fix cli binary
* [`27f9914e`](https://github.com/NixOS/nixpkgs/commit/27f9914e586991e2e0544c13001fde89e0130a6d) pyprland: 2.3.2 -> 2.3.4
* [`3dfc7246`](https://github.com/NixOS/nixpkgs/commit/3dfc7246ccda0290c905d1a9f9d98b1364791651) zk: 0.14.0 -> 0.14.1
* [`0b331b26`](https://github.com/NixOS/nixpkgs/commit/0b331b2636683e5f39043209e883592c68f8bebd) ghciwatch: 0.5.12 -> 0.5.16
* [`1208b297`](https://github.com/NixOS/nixpkgs/commit/1208b2978c292dd4b353592bb4eea40c5668a885) maintainers: update email address for Jeremy Baxter
* [`e8e045b1`](https://github.com/NixOS/nixpkgs/commit/e8e045b1fc47a9bacdd750498b35cb0ef18024bc) besu: use jemalloc (Linux) & add tests ([nixos/nixpkgs⁠#282523](https://togithub.com/nixos/nixpkgs/issues/282523))
* [`06208ec0`](https://github.com/NixOS/nixpkgs/commit/06208ec00206cad213b8a9bed01b66bb667f1d66) kanidm: don't LTO tests
* [`8746b7cb`](https://github.com/NixOS/nixpkgs/commit/8746b7cb886e0a97ce7cb8743163992e04129777) extism-cli: 1.4.0 -> 1.5.0
* [`6f8ce597`](https://github.com/NixOS/nixpkgs/commit/6f8ce597d0d5308af43661cda1ed84d8c80a9007) croc: 9.6.16 -> 10.0.5
* [`c9a4d2e5`](https://github.com/NixOS/nixpkgs/commit/c9a4d2e5fa7804e957bc744b55baac41effb79f3) python311Packages.huggingface-hub: 0.23.1 -> 0.23.2
* [`4082d7e1`](https://github.com/NixOS/nixpkgs/commit/4082d7e1153ec015299bda271c5909eef476ea42) dbeaver-bin: add `wrapGAppsHook3`
* [`7042f95f`](https://github.com/NixOS/nixpkgs/commit/7042f95f884ae4c836a856840f966baed4ab20f7) haskellPackages.di-core: unbreak on darwin ([nixos/nixpkgs⁠#314627](https://togithub.com/nixos/nixpkgs/issues/314627))
* [`603c0346`](https://github.com/NixOS/nixpkgs/commit/603c0346d1dcdc329c4cf423a5cce510f1db3b57) pythonPackages.shiboken2: mark as broken on Python ≥ 3.12 ([nixos/nixpkgs⁠#314968](https://togithub.com/nixos/nixpkgs/issues/314968))
* [`f3607265`](https://github.com/NixOS/nixpkgs/commit/f360726554051d9d4aaa404d319239b741c13e8f) python311Packages.dploot: 2.7.1 -> 2.7.2
* [`d7062ba8`](https://github.com/NixOS/nixpkgs/commit/d7062ba870086eca86f903774e190ae0aa982ac7) nixosTests.gnome-extensions: `emoji-selector` has been removed
* [`3106519f`](https://github.com/NixOS/nixpkgs/commit/3106519f148cc4dac68d02c4a8787bf07d35ae1f) discourse: rely on packaging module for version comparison
* [`5cf00511`](https://github.com/NixOS/nixpkgs/commit/5cf005119ab3f2d3ce18b83ce9321f18e23d9585) discourse: strip markers from plugin compat spec
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
