### PR TITLE
niv home-manager: update 10c7c219 -> 9b53a10f

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -41,10 +41,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "10c7c219b7dae5795fb67f465a0d86cbe29f25fa",
-        "sha256": "02f6xpn863vjxzamizd5my2hc8jz974v798q0kg6v8vl2p0jqcdf",
+        "rev": "9b53a10f4c91892f5af87cf55d08fba59ca086af",
+        "sha256": "1hn0fnrczpiccaiqrdil5zvr2hvxqnwa9nkfg5sd7prfjyjh8bay",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/10c7c219b7dae5795fb67f465a0d86cbe29f25fa.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/9b53a10f4c91892f5af87cf55d08fba59ca086af.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@10c7c219...9b53a10f](https://github.com/nix-community/home-manager/compare/10c7c219b7dae5795fb67f465a0d86cbe29f25fa...9b53a10f4c91892f5af87cf55d08fba59ca086af)

* [`373ead20`](https://github.com/nix-community/home-manager/commit/373ead20606efa9181cd15ba19a5deac7ead1492) tests: fix broken overlay in mpv test
* [`a9b36cbe`](https://github.com/nix-community/home-manager/commit/a9b36cbe9292a649222b89fdb9ae9907e9c74086) gpg-agent: fix usage of splitString
* [`04bc391a`](https://github.com/nix-community/home-manager/commit/04bc391a90f8ae2a953035f33ddebaeccbc0a36b) yazi: support plugins and flavors
* [`1b589257`](https://github.com/nix-community/home-manager/commit/1b589257f72c9c54e92d1d631e988e5346156736) home-manager: check FQDN for '--flake .' attribute
* [`60b85414`](https://github.com/nix-community/home-manager/commit/60b85414b49d5d69816c2453865adb6cc39df33a) Translate using Weblate (Korean)
* [`29c69d9a`](https://github.com/nix-community/home-manager/commit/29c69d9a466e41d46fd3a7a9d0591ef9c113c2ae) kdeconnect: fix service with 24.05 package version
* [`0eb314b4`](https://github.com/nix-community/home-manager/commit/0eb314b4f0ba337e88123e0b1e57ef58346aafd9) home-manager: use short -f instead of --fqdn
* [`c497bdc1`](https://github.com/nix-community/home-manager/commit/c497bdc12f591e57f85a6941976daec78db3f529) flake.lock: Update
* [`bf381585`](https://github.com/nix-community/home-manager/commit/bf3815854e6c24d28ad4e7df96f2d3c3beda20f1) Translate using Weblate (Finnish)
* [`62da78e1`](https://github.com/nix-community/home-manager/commit/62da78e1f8897706b9e5e890ffb86389b1d87333) Translate using Weblate (Vietnamese)
* [`9b53a10f`](https://github.com/nix-community/home-manager/commit/9b53a10f4c91892f5af87cf55d08fba59ca086af) swayidle: wait for WAYLAND_DISPLAY
