### PR TITLE
niv nixpkgs: update d7aefbf2 -> cd7ec241

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d7aefbf252617947b9ab519e192d4c1d8af1975b",
-        "sha256": "0pzwg00drvi79asl9vy1agszgqypkxqsb3z4i9ldcv0qrmglpl19",
+        "rev": "cd7ec2419a9a98e9119d64f5b0cbaa069e53c298",
+        "sha256": "15m5k51g5lnk49dfm7gfisgnz21lknzl3hljgzx7dhyb1v2ljp6q",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/d7aefbf252617947b9ab519e192d4c1d8af1975b.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/cd7ec2419a9a98e9119d64f5b0cbaa069e53c298.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@d7aefbf2...cd7ec241](https://github.com/nixos/nixpkgs/compare/d7aefbf252617947b9ab519e192d4c1d8af1975b...cd7ec2419a9a98e9119d64f5b0cbaa069e53c298)

* [`cbc1db7b`](https://github.com/NixOS/nixpkgs/commit/cbc1db7b1ab12db3303da0067633c252b8279ee6) pythonPackages.repl-python-wakatime: init at 0.0.6
* [`12a31716`](https://github.com/NixOS/nixpkgs/commit/12a3171606b262304ab36bafd18f13cb8d8b0509) xenon: init at 0.9.1
* [`535bf0cc`](https://github.com/NixOS/nixpkgs/commit/535bf0cc6976ae84c9286a0b0ecd8d6aa26940a3) frink: 2023-07-31 -> 2023-12-02
* [`cae164e8`](https://github.com/NixOS/nixpkgs/commit/cae164e80b8b9aed2bdca8db86b3f0e6d7cfe7c4) quinze: init at 2018-09-22
* [`363cea29`](https://github.com/NixOS/nixpkgs/commit/363cea29239ee412b17fd79ffa759e40d75f7ab5) okolors: init at 0.5.1
* [`48c1930c`](https://github.com/NixOS/nixpkgs/commit/48c1930c860281012a9cf30a926b2d0a858f05bd) adl: 3.0.1 -> 3.2.8
* [`9ee85134`](https://github.com/NixOS/nixpkgs/commit/9ee851341fccb9476e7c26b8e5662a40091f05d1) webkitgtk: add support for experimental features
* [`de488190`](https://github.com/NixOS/nixpkgs/commit/de488190ae367886cdaf298dd0e475d6c122b727) desktop-postflop: init at 0.2.7
* [`3f209044`](https://github.com/NixOS/nixpkgs/commit/3f209044980b0ae58a17c3f03c2f5b696c1cdfd2) tests/acme: check consistent account hash
* [`f97594c7`](https://github.com/NixOS/nixpkgs/commit/f97594c700c61543725871ee488b164946e186f7) tests/acme: drop unused variables
* [`5dec2b86`](https://github.com/NixOS/nixpkgs/commit/5dec2b868940d8766e139659be7e401f0e6de735) leetgo: init at 1.4.1
* [`e8fea0a5`](https://github.com/NixOS/nixpkgs/commit/e8fea0a5598b5aa2a8990625135e439c082eef74) kubefwd: init at 1.22.5
* [`c7317a58`](https://github.com/NixOS/nixpkgs/commit/c7317a582b9a6ac69061b9930a400ab767d59932) kalamine: init at 0.22
* [`24d00917`](https://github.com/NixOS/nixpkgs/commit/24d00917fb54cda381bb705e5cf5da93e169ee0f) mathmod: init at 11.1-unstable-2024-01-26
* [`f181a5de`](https://github.com/NixOS/nixpkgs/commit/f181a5dec76cbfda21600c11c05810c691423ab0) celluloid: add youtubeSupport
* [`c49cfc7b`](https://github.com/NixOS/nixpkgs/commit/c49cfc7bee7d547daabcea8d911b2249bf58d83f) gambit-project: init at 16.1.1
* [`53cec001`](https://github.com/NixOS/nixpkgs/commit/53cec001a5e91a815019f6942f7dbec16bb5fb20) csv2md: init at 1.3.0
* [`0d84174a`](https://github.com/NixOS/nixpkgs/commit/0d84174af5cd05ad2cfe8385a5b08901c4eccc42) rabbitmq-c: 0.13.0 -> 0.14.0
* [`109205be`](https://github.com/NixOS/nixpkgs/commit/109205bee873bd546c9e0e68fa5e170ec83ea7f3) git-toolbelt: init at 1.9.1
* [`1e776514`](https://github.com/NixOS/nixpkgs/commit/1e7765143c74873f695e588873b432a1207d6c20) dnss: init at 0-unstable-2023-10-22
* [`12b2f372`](https://github.com/NixOS/nixpkgs/commit/12b2f372c0d53ca841c82ab734bf1c161301e795) horcrux: init at 0.3-unstable-2023-09-19
* [`dd70b632`](https://github.com/NixOS/nixpkgs/commit/dd70b6320bd887d868f7746aa8cd3bbf3d65a898) tuxmux: 0.1.1 -> 0.2.1
* [`c1388008`](https://github.com/NixOS/nixpkgs/commit/c1388008b46e7891b1e2641e8c7bcb98b090db22) python312Packages.torchsummary: init at 1.5.1
* [`e32f6a13`](https://github.com/NixOS/nixpkgs/commit/e32f6a13f11295d7b78f17169d2ef0c52e1cedea) mokuro: init at 0.1.8
* [`d54b5eae`](https://github.com/NixOS/nixpkgs/commit/d54b5eae17a58130631a910500a381f81c29c240) amdvlk: 2023.Q4.2 -> 2024.Q2.1
* [`25d96b4c`](https://github.com/NixOS/nixpkgs/commit/25d96b4c4a367e636d3f93b2cc5cf3a0da56a05f) corrosion: 0.4.8 -> 0.5
* [`753cb681`](https://github.com/NixOS/nixpkgs/commit/753cb6817d72c51dddadf9c23305082c2a8920e1) wxGTK32: 3.2.4 -> 3.2.5
* [`71ce6b58`](https://github.com/NixOS/nixpkgs/commit/71ce6b582b473982c66eadc91081b5601dda7819) nixos/network-interfaces: prevent failure when a network address already exists
* [`f7e37fbf`](https://github.com/NixOS/nixpkgs/commit/f7e37fbfb08ecbf86ec20a52800f92f7a062e4d3) pgpool: 4.5.1 -> 4.5.2
* [`31a42541`](https://github.com/NixOS/nixpkgs/commit/31a42541af1866336297216b421d7abbc3566018) changelog-d: 0.1-git-2816ddb -> 1.0
* [`bdb39a26`](https://github.com/NixOS/nixpkgs/commit/bdb39a26e63fa29202e1af3987b307fd6ee2c955) protoc-gen-twirp_php: 0.10.0 -> 0.11.0
* [`cc944208`](https://github.com/NixOS/nixpkgs/commit/cc9442089c595dae400fafbff4d64a4ad5d04112) stress-ng: add missing dependencies for --gpu flag support
* [`a5d88942`](https://github.com/NixOS/nixpkgs/commit/a5d889421111dcf23fd692e0b9baff648660ff5a) challenger: init at 0.10.0
* [`819ec789`](https://github.com/NixOS/nixpkgs/commit/819ec789ded582a5dc6fe95941ef4f15c5b49534) python311Packages.b2sdk: 2.2.1 -> 2.3.0
* [`fd9b3e12`](https://github.com/NixOS/nixpkgs/commit/fd9b3e120022ddb3954a19e888b2daed02a089d6) python312Packages.torchio: 0.19.5 -> 0.19.6
* [`5774b136`](https://github.com/NixOS/nixpkgs/commit/5774b136eac48d136974efd2378188d3db5323e5) unifiedpush-common-proxies: 1.5.0 -> 2.0.0
* [`31c87c65`](https://github.com/NixOS/nixpkgs/commit/31c87c65455498d35d474a034ee7d72af7c5af1a) python311Packages.pyperscan: 0.2.2 -> 0.3.0
* [`62a02b41`](https://github.com/NixOS/nixpkgs/commit/62a02b41d4552542ceef3ceb363ab3f176ed0b7e) neovide: remove unsupported x86_64-darwin
* [`29341c26`](https://github.com/NixOS/nixpkgs/commit/29341c261097dd2ce730874568acb7ae649e6409) python311Packages.gspread: 6.1.0 -> 6.1.2
* [`91930ef6`](https://github.com/NixOS/nixpkgs/commit/91930ef67e5ed7e62ff18ae1034720069c8bfa91) python311Packages.pep8-naming: 0.13.3 -> 0.14.1
* [`06157e52`](https://github.com/NixOS/nixpkgs/commit/06157e52f9083757c0e8d7c1a92cae7f6f5a1ab2) nixdoc: 3.0.2 -> 3.0.5
* [`d4b726e0`](https://github.com/NixOS/nixpkgs/commit/d4b726e07098708a3908bbdbfdd632a991be21c8) koodo-reader: fix darwin build
* [`22f15e41`](https://github.com/NixOS/nixpkgs/commit/22f15e4151bc3b7b3405e97f45cd162a5039abe5) sqlcipher: 4.5.7 -> 4.6.0
* [`1c72baa0`](https://github.com/NixOS/nixpkgs/commit/1c72baa05e65254056b9be24cabd51efc3f76934) python3Packages.pydy: enable check
* [`802ba380`](https://github.com/NixOS/nixpkgs/commit/802ba3806b63ff1104456831d84d2e945c1792ed) quorum: 23.4.0 -> 24.4.0
* [`26225754`](https://github.com/NixOS/nixpkgs/commit/2622575436253b2ecdc50507638302cb49b290be) python311Packages.smmap: replace nosexcover with pytest
* [`61799e2c`](https://github.com/NixOS/nixpkgs/commit/61799e2c0b5241fb1054b3bfbd721d713de96c13) python311Packages.smmap: modernize
* [`583d561c`](https://github.com/NixOS/nixpkgs/commit/583d561c793118d4ee55b90c97fa1eca698d54db) python311Packages.nosexcover: remove
* [`636aa8dc`](https://github.com/NixOS/nixpkgs/commit/636aa8dc98a8c81a5263533b9b7afb8d146924cc) prosody: point prosodyctl by default to correct directories
* [`59530dbd`](https://github.com/NixOS/nixpkgs/commit/59530dbdbce1133173e8e1c18bec7b9572629dd2) prosody: don't wrap prosodyctl
* [`54382867`](https://github.com/NixOS/nixpkgs/commit/54382867214c6704670cea1992a639f93f3fda9f) mirtk: pin itk = itk_5_2
* [`1a40f8e7`](https://github.com/NixOS/nixpkgs/commit/1a40f8e76fd978f85613a94962e4a8efa5c96ed9) itk: 5.3.0 -> 5.4.0
* [`ba7ff4a2`](https://github.com/NixOS/nixpkgs/commit/ba7ff4a26b2f505e45216cccd2fb62c85eddb72b) highlight: 4.11 -> 4.12
* [`bb460d64`](https://github.com/NixOS/nixpkgs/commit/bb460d640464e048846129ba6765ef257b7b79ec) open62541: move to by-name
* [`e1f3c022`](https://github.com/NixOS/nixpkgs/commit/e1f3c02267183f10c712376216888d60f6a32bbe) opencomposite: 0-unstable-2024-05-08 -> 0-unstable-2024-05-24
* [`1b4bba62`](https://github.com/NixOS/nixpkgs/commit/1b4bba62c6ca634b0b1192573b889dce7a180f86) python312Packages.crc32c: 2.3.post0 -> 2.4
* [`1f1f0cdf`](https://github.com/NixOS/nixpkgs/commit/1f1f0cdf249c55c6dec824a2e4923996352fae5f) sbt: fix sbtn on apple-darwin
* [`2ed51a3f`](https://github.com/NixOS/nixpkgs/commit/2ed51a3ff0a69a6d2e6359a2bcf5da70f7313789) deterministic-uname: Overridable platform
* [`ef5ff2a0`](https://github.com/NixOS/nixpkgs/commit/ef5ff2a075d8a9af793b524cbe69962963264a34) nixos/xdg/portal: Fix typo
* [`9ab91b56`](https://github.com/NixOS/nixpkgs/commit/9ab91b56ddffa0c89156ab5e9c0d9a6f07a2d926) glew110: fix cross compiling
* [`3932ebe3`](https://github.com/NixOS/nixpkgs/commit/3932ebe39d7737bd5c20304dd9e81d781ef3bc2e) python311Packages.theano: drop
* [`aae5de8a`](https://github.com/NixOS/nixpkgs/commit/aae5de8a9fbb1eddc67c7c6b7fec58d8561af544) python311Packages.theano-pymc: drop
* [`c96db157`](https://github.com/NixOS/nixpkgs/commit/c96db157d3311fc0d7bb48a205277878258a850b) python311Packages.clint: refactor and clean up dependencies
* [`11c95d57`](https://github.com/NixOS/nixpkgs/commit/11c95d5751690d0ebe3acd2e494473bb17aa9dcf) python311Packages.flask-mail: 0.9.1 -> 0.10.0
* [`2e096741`](https://github.com/NixOS/nixpkgs/commit/2e0967410f7ad10389a2794da8fe5e693fc1773b) python311Packages.flask-mail: enable tests and update meta
* [`c23eeb99`](https://github.com/NixOS/nixpkgs/commit/c23eeb99931d80d4221a350e4051054b891d7122) python3Packages.pypdf2: fix
* [`b0e8337c`](https://github.com/NixOS/nixpkgs/commit/b0e8337c3aed748de1383aba68df971ed3ff0962) deterministic-host-uname: init
* [`11e3c90f`](https://github.com/NixOS/nixpkgs/commit/11e3c90f613b9926cb25a1f3b32d7b5bfc0fc9f0) python311Packages.django-sr: remove
* [`bfa34827`](https://github.com/NixOS/nixpkgs/commit/bfa34827f12e552f957b71b54ade1863ce89841e) python311Packages.python-crontab: 3.0.0 -> 3.1.0
* [`18d0e327`](https://github.com/NixOS/nixpkgs/commit/18d0e327e7ad173eb5f7878ff08347b3d550910e) mobile-broadband-provider-info: 20230416 -> 20240407
* [`120f2420`](https://github.com/NixOS/nixpkgs/commit/120f24202b4a0f0bf6986130ff15eef7c0609f50) haskellPackages.mkDerivation: limit GHC_PACKAGE_PATH to test suite
* [`82522c99`](https://github.com/NixOS/nixpkgs/commit/82522c99d46e35fcc9e8ee7bb66d2bc9eaecee43) probe-rs: 0.23.0 -> 0.24.0; rename
* [`550a6900`](https://github.com/NixOS/nixpkgs/commit/550a690039b513ab6fb5f5180a2624813cd71ecf) vimPlugins.ts-comments-nvim: init at 2024-05-26
* [`2eb7d7e3`](https://github.com/NixOS/nixpkgs/commit/2eb7d7e345048143c47bb56abdc875d7f0d334c0) yandex-browser: 24.4.1.915-1 -> 24.4.1.951-1
* [`8adaa32a`](https://github.com/NixOS/nixpkgs/commit/8adaa32ad38d2c7239225c4a56ad3944234be4d1) payloadsallthethings: init at 3.0-unstable-2024-01-21
* [`69bdf62e`](https://github.com/NixOS/nixpkgs/commit/69bdf62eb6620b2d8204a36c202b2b650cd577b3) haskell.compiler.ghc9{6,8}: fix elfutils splicing
* [`f1ab18f3`](https://github.com/NixOS/nixpkgs/commit/f1ab18f3b8947d897edcc8d0184af1a68a3c927f) level-zero: 1.17.2 -> 1.17.6
* [`6b7ce9b4`](https://github.com/NixOS/nixpkgs/commit/6b7ce9b42ba6576b3e3669e0a714c166bdbfe85a) python312Packages.dicom2nifti: 2.4.8 -> 2.4.11
* [`2473ad96`](https://github.com/NixOS/nixpkgs/commit/2473ad96e07d1c214782d9119c0acb582a4a86fa) inochi-creator: 0.8.4 -> 0.8.5
* [`019f5c29`](https://github.com/NixOS/nixpkgs/commit/019f5c29c5afeb215587e17bf1ec31dc1913595b) inochi-session: 0.8.3 -> 0.8.4
* [`d479b819`](https://github.com/NixOS/nixpkgs/commit/d479b819a1bddfc64a5ff8b040b6864ad536f613) rstudio: 2023.12.1+402 -> 2024.04.1+738
* [`ce20f220`](https://github.com/NixOS/nixpkgs/commit/ce20f2207c97edcc56b3dcc3a903814545c1af34) snx-rs: init at 2.2.0
* [`e91c8caf`](https://github.com/NixOS/nixpkgs/commit/e91c8cafc262f2d57278fbfecb59d3264b0a3d52) nwjs: 0.87.0 -> 0.88.0
* [`5a11647e`](https://github.com/NixOS/nixpkgs/commit/5a11647eeaa9f05ceb37294d796e8c2395597457) python312Packages.stone: enable on python 3.12
* [`9dd7a822`](https://github.com/NixOS/nixpkgs/commit/9dd7a8222cac2e2174f6e6db44993fbb0d8a9f19) elmPackages.elm: fix build failure on darwin
* [`d2618822`](https://github.com/NixOS/nixpkgs/commit/d2618822ab1a3f7bcae64fb49c36a51b09a03f1f) haskell.lib.compose.justStaticExecutables: Forbid references to GHC
* [`0454f7b8`](https://github.com/NixOS/nixpkgs/commit/0454f7b8ee334ddcb3dd1b690719f5acfb625d2f) haskellPackages.mkDerivation: no rebuild w/o disallowedRequisites
* [`095ba4fd`](https://github.com/NixOS/nixpkgs/commit/095ba4fdc3fe7dd5894833cd1446a2ad348ff39b) ldc: merge into single file
* [`ad4a42b2`](https://github.com/NixOS/nixpkgs/commit/ad4a42b2ce5089d39c3a1fd11b027dec2da73f17) ldc: migrate to pkgs/by-name
* [`0552108c`](https://github.com/NixOS/nixpkgs/commit/0552108c7d831144ff2cb7205041ae48394cb7c1) python311Packages.pypugjs: 5.9.12 -> 5.10.1
* [`08a65c6e`](https://github.com/NixOS/nixpkgs/commit/08a65c6e9611eac18256618d96d388ff7752101b) python311Packages.oracledb: 2.2.0 -> 2.2.1
* [`f507e32a`](https://github.com/NixOS/nixpkgs/commit/f507e32abe74dbfc85b613788fd89df824e7cc4f) touchosc: 1.3.1.204 -> 1.3.3.207
* [`c8e6c3c2`](https://github.com/NixOS/nixpkgs/commit/c8e6c3c21ed81d1b458e7d1dd13c9aa93293c8a0) marcel: 0.27.2 -> 0.28
* [`89914ad4`](https://github.com/NixOS/nixpkgs/commit/89914ad41b55754e243487efa30e8b5dcf390ea5) legba: 0.8.0 -> 0.9.0
* [`d1a1ad9a`](https://github.com/NixOS/nixpkgs/commit/d1a1ad9af37ca84e9fa7b05a1227b932dcd224e0) sway-contrib.grimshot: add grep to wrapper
* [`5bdfce16`](https://github.com/NixOS/nixpkgs/commit/5bdfce162ce332b2499d327e75ddc76a9e526399) bee: 2.0.1 -> 2.1.0
* [`2d567c68`](https://github.com/NixOS/nixpkgs/commit/2d567c689de96fbc5e3e3c1b5bb61a6b7c7c39e0) sway-contrib.grimshot: 0-unstable-2024-01-20 -> 0-unstable-2024-03-19
* [`aceaa9ed`](https://github.com/NixOS/nixpkgs/commit/aceaa9eddb1cd2ec6389a622bbe9192757d4c3c3) sway-contrib.grimshot: add bash shell-completion
* [`16bf0bee`](https://github.com/NixOS/nixpkgs/commit/16bf0beed823b8cea7658589327cfb0b767425cc) kubevirt: 1.2.0 -> 1.2.1
* [`75219f7f`](https://github.com/NixOS/nixpkgs/commit/75219f7f8c75b1c46e0fed84de905b910e8b0324) tanka: 0.26.0 -> 0.27.1
* [`aac4b24c`](https://github.com/NixOS/nixpkgs/commit/aac4b24c02cb2c19b2486f990a9a1d2d28a1a5c0) gpu-screen-recorder: unstable-2023-11-18 -> unstable-2024-05-21
* [`482ab920`](https://github.com/NixOS/nixpkgs/commit/482ab9206612494f4a34b38ded9fc919b7d1e31c) git-annex: pass setup package db to GHC used for building installer
* [`633a4ed4`](https://github.com/NixOS/nixpkgs/commit/633a4ed4c8024cb17c97206c66cdc23518deecda) python3Packages.tpm2-pytss: bring fix for tpm2-tss 4.1
* [`52eff50e`](https://github.com/NixOS/nixpkgs/commit/52eff50ea50166f26fe0332d4bface4d9b5b51ed) cdxgen: 10.5.1 -> 10.5.2
* [`f69f5c20`](https://github.com/NixOS/nixpkgs/commit/f69f5c20bf8ce5f5c98d85773f072ee1dedb2c6b) bitcoin-abc: 0.29.4 -> 0.29.5
* [`c2d5cda8`](https://github.com/NixOS/nixpkgs/commit/c2d5cda80c963d54a3d3b660ae624517253c736c) junicode: 2.206 -> 2.207
* [`6af61687`](https://github.com/NixOS/nixpkgs/commit/6af616875ffee16d76f811ebeb6b454d4232d6b4) melange: 0.8.0 -> 0.8.1
* [`8702b841`](https://github.com/NixOS/nixpkgs/commit/8702b84107e07d7bc57a7decd5a6e3b4acf9a39a) nix-index-unwrapped: 0.1.7 -> 0.1.8
* [`170e38c3`](https://github.com/NixOS/nixpkgs/commit/170e38c3c7254ea1dedfa0781dbab9b78fea34e2) docker-buildx: 0.14.0 -> 0.14.1
* [`3120e82a`](https://github.com/NixOS/nixpkgs/commit/3120e82ad8a881b7143f0de209d66608826f7972) atmos: 1.73.0 -> 1.76.0
* [`934604b3`](https://github.com/NixOS/nixpkgs/commit/934604b31b22db2cee55d50ccfe4c2ea13930d8d) saml2aws: 2.36.15 -> 2.36.16
* [`8f2509d7`](https://github.com/NixOS/nixpkgs/commit/8f2509d79f295b0f74484a44d8163d559e99c62d) violet: init at 0.4.6
* [`b7c0afd1`](https://github.com/NixOS/nixpkgs/commit/b7c0afd1fa6e85e802d642dcb68703ace4ae4fd3) pkcs11-provider: 0.3 -> 0.4
* [`9048353e`](https://github.com/NixOS/nixpkgs/commit/9048353e3c3382d5738b27e98a00c63f835e1095) vivaldi: 6.7.3329.31 -> 6.7.3329.35
* [`4d3ad26b`](https://github.com/NixOS/nixpkgs/commit/4d3ad26b0401c2f19545128d007408e53c46c8ef) python311Packages.azure-mgmt-network: 25.3.0 -> 25.4.0
* [`cb4edfcc`](https://github.com/NixOS/nixpkgs/commit/cb4edfcc55ab74dcdac4214aaf166558cef88ac0) musescore: 4.3.0 -> 4.3.1
* [`30ebc6ab`](https://github.com/NixOS/nixpkgs/commit/30ebc6ab7cacc5ad57c78df5070e6c59a0a70aba) elvis-erlang: 3.0.1 -> 3.1.0
* [`b0a14018`](https://github.com/NixOS/nixpkgs/commit/b0a14018d37f64f4fbd831ec6aea64a7042454e5) pcsx2: migrate to by-name
* [`2a41818f`](https://github.com/NixOS/nixpkgs/commit/2a41818f80cdec16786c3a001ca4471b12154240) gcsfuse: 2.1.0 -> 2.2.0
* [`dcbb4588`](https://github.com/NixOS/nixpkgs/commit/dcbb4588c27ca9dce620f169fbb5e84083a35ac4) flowblade: 2.14.0.2 -> 2.16
* [`2957fb04`](https://github.com/NixOS/nixpkgs/commit/2957fb0426e31e9d5b3c1cd346e535b7aa2a431e) flow: 0.236.0 -> 0.237.0
* [`1959e590`](https://github.com/NixOS/nixpkgs/commit/1959e590cbe6afa60e8398fc8521590bb0101103) go-libp2p-daemon: 0.6.1 -> 0.8.0
* [`636e5933`](https://github.com/NixOS/nixpkgs/commit/636e5933e5ac6114d0f58d236728a041f0a50e4c) sbcl: configuration check: GC requires threads
* [`0a3596c6`](https://github.com/NixOS/nixpkgs/commit/0a3596c690badc7b8079d6015255de76dbec0a0c) shairport-sync: 4.3.2 -> 4.3.3
* [`ee5090d3`](https://github.com/NixOS/nixpkgs/commit/ee5090d33eec205e949d194eddc36af78765c65d) delfin: 0.4.4 -> 0.4.5
* [`e3eb571e`](https://github.com/NixOS/nixpkgs/commit/e3eb571efc73126b82600164969b77dce8630713) cloudlog: 2.6.13 -> 2.6.14
* [`b389e85b`](https://github.com/NixOS/nixpkgs/commit/b389e85bd2a531217e544c3bed4182e698d10ac9) sommelier: 124.0 -> 125.0
* [`c24ce99d`](https://github.com/NixOS/nixpkgs/commit/c24ce99dbec9d01828a742508dbbf5e10af9d454) ringfairy: init at 0.1.2-unstable-2024-05-11
* [`53108159`](https://github.com/NixOS/nixpkgs/commit/5310815991865e35a06962d88ad8f7ddf605c414) xcaddy: 0.4.1 -> 0.4.2
* [`23041e59`](https://github.com/NixOS/nixpkgs/commit/23041e593123b9b2d9cce4550eb67159a6a06055) treesheets: 0-unstable-2024-05-20 -> 0-unstable-2024-05-29
* [`99bccbc5`](https://github.com/NixOS/nixpkgs/commit/99bccbc5a55e906d23dcc457de11861ac3119d1e) hpx: 1.9.1 -> 1.10.0
* [`0553e541`](https://github.com/NixOS/nixpkgs/commit/0553e5416563118896983c199f1639fc3ca2e981) libtransmission_4: 4.0.5 -> 4.0.6
* [`221aa462`](https://github.com/NixOS/nixpkgs/commit/221aa4628fcceda371a1650ab104b3522cc13857) tulip: 5.7.3 -> 5.7.4
* [`cfe52e8a`](https://github.com/NixOS/nixpkgs/commit/cfe52e8a5c47bdf9eb02014b6f09aba5eeba84c0) reaction: 1.3.0 -> 1.3.1
* [`6b175502`](https://github.com/NixOS/nixpkgs/commit/6b175502963397fa091840773b1786a7a7a8bf3d) alglib: 3.18.0 -> 4.01.0
* [`d2ebb454`](https://github.com/NixOS/nixpkgs/commit/d2ebb454b6b7ad68b81ac47b6e892590901c3c88) helio-workstation: 3.12 -> 3.13
* [`2837822c`](https://github.com/NixOS/nixpkgs/commit/2837822c4a1530bd41b7449635de49ea0af78eed) dprint: 0.45.1 -> 0.46.1
* [`e4661e18`](https://github.com/NixOS/nixpkgs/commit/e4661e18b2c0594804f7ff8346b92bd6c97e3c27) glab: 1.40.0 -> 1.41.0
* [`ae509d3c`](https://github.com/NixOS/nixpkgs/commit/ae509d3c59a6d021509e6b61ac96d435191e3735) flat-remix-gnome: 20240503 -> 20240526
* [`774c00e4`](https://github.com/NixOS/nixpkgs/commit/774c00e4b9c14d5682202efe21f106aef129aa79) timeular: 6.7.8 -> 6.7.9
* [`34a2673e`](https://github.com/NixOS/nixpkgs/commit/34a2673edf0cb0948facd1867ee5f1693814df2f) normaliz: 3.10.2 -> 3.10.3
* [`6b39e88b`](https://github.com/NixOS/nixpkgs/commit/6b39e88b9bf702a4c735d444d1849beed816dcd9) fretboard: 6.1 -> 7.0
* [`0b0b7cef`](https://github.com/NixOS/nixpkgs/commit/0b0b7cefcce7f67bd56e2903be34db579b22528a) nixos/hyprland: disable wlr-portal for Hyprland
* [`ce85d67e`](https://github.com/NixOS/nixpkgs/commit/ce85d67efa7ee6fb906d029f6a41539e60114125) python3Packages.ray: 2.10.0 -> 2.23.0
* [`98f9f995`](https://github.com/NixOS/nixpkgs/commit/98f9f9951aa9a2457fbaad18039bae477df0c32d) nixos/hyprland: add fufexan as maintainer
* [`934d609f`](https://github.com/NixOS/nixpkgs/commit/934d609fe6b03d772d5744823f7fb116e18868f7) groovy: 3.0.11 -> 4.0.21
* [`babcf8c5`](https://github.com/NixOS/nixpkgs/commit/babcf8c5b31195f371d66fce749ea9902df8f065) geesefs: init at 0.41.0
* [`35899e75`](https://github.com/NixOS/nixpkgs/commit/35899e7573c5c50a986f8030986af8392c8c4d6d) changedetection-io: 0.45.22 -> 0.45.23
* [`2093ef28`](https://github.com/NixOS/nixpkgs/commit/2093ef28d9410f274af967c44f7386a6749ae89e) doc/meta: mention how Hydra and other tools don't run passthru.tests
* [`f4e7ce77`](https://github.com/NixOS/nixpkgs/commit/f4e7ce7719ef657ee9de9fb23e750c44e46989df) doc/meta: small link target shortenning
* [`f4e6f41b`](https://github.com/NixOS/nixpkgs/commit/f4e6f41b726bae27f110b78c67480d9ab154dc9a) doc/meta: better explain an advantage or passthru.tests
* [`444c2b6d`](https://github.com/NixOS/nixpkgs/commit/444c2b6dd06e02f4bd8f153fb6a574e2350d861f) doc/meta: Mention --version as a good usecase for installCheckPhase
* [`0aa90433`](https://github.com/NixOS/nixpkgs/commit/0aa9043370cc9ea101b5c5b9427c74298252ed5c) doc/meta: still mention testVersion near the installCheckPhase recommendation
* [`5c418b66`](https://github.com/NixOS/nixpkgs/commit/5c418b66e8fe24ab9e2dbf37eba4385d951e8ffd) oras: 1.1.0 -> 1.2.0
* [`42029a9e`](https://github.com/NixOS/nixpkgs/commit/42029a9e641b3743e44da22382719e124ccf7fc8) mangareader: move to by-name
* [`e124b02e`](https://github.com/NixOS/nixpkgs/commit/e124b02edd3f2a7ce8149e5b9cbdc577234eafaf) nixosTests.nix-misc: Split from `nixosTests.misc`
* [`53a22159`](https://github.com/NixOS/nixpkgs/commit/53a221591772ba4ae1b0627686615751f5ab3bac) nixosTests.misc: Revert nix changes
* [`e60c483e`](https://github.com/NixOS/nixpkgs/commit/e60c483eb9de378593218c23142cb19ddbc199f3) nixosTests.misc: Remove nix tests
* [`4c289e94`](https://github.com/NixOS/nixpkgs/commit/4c289e941b2fd97ad82194e8229418b30ce1e85f) nixVersions.stable: reference nix-misc in tests
* [`833de4fa`](https://github.com/NixOS/nixpkgs/commit/833de4fa88da73445f05532e1b227bd7c381ccd1) scala_3: 3.3.1 -> 3.3.3
* [`9e65a7fb`](https://github.com/NixOS/nixpkgs/commit/9e65a7fba2f52b391271fb1de5c700f72591da87) tinycc: fix build on x86_64-darwin
* [`91c4c979`](https://github.com/NixOS/nixpkgs/commit/91c4c979a93f131aca7dd36db77b4b19ffd9468f) simpleBluez: init at 0.7.3
* [`ac56a9d7`](https://github.com/NixOS/nixpkgs/commit/ac56a9d7a28a0e6fef38a854e0fd44cb53c7c486) simpleDBus: init at 0.7.3
* [`8d6ab126`](https://github.com/NixOS/nixpkgs/commit/8d6ab1262d2a139eabeb9cbab730c8aee2fb1f58) rewind-ai: init at 1.5284-15284.1-dcd0176-20240504
* [`156757ea`](https://github.com/NixOS/nixpkgs/commit/156757eaf71ea812ed4e0743b8dfe6f322656603) nixos/systemd-user: add generators option
* [`25ad0cdb`](https://github.com/NixOS/nixpkgs/commit/25ad0cdbfcd2e3d0c62a77cf78a2c2067ac7831b) nixos/systemd: link user-generators
* [`413707f4`](https://github.com/NixOS/nixpkgs/commit/413707f484902c7b42329faea6c5b9037c13b902) nixos/release-combined: add `nixosTests.nix-misc` to blockers
* [`8d53f3a3`](https://github.com/NixOS/nixpkgs/commit/8d53f3a37438840b6f865ebf1be9f85c3483d636) cockpit: 316 -> 317
* [`09f960ef`](https://github.com/NixOS/nixpkgs/commit/09f960efb7108cf011ccf9cd3a07764201211847) zmkBATx: init at 1.0.1
* [`dff9ba60`](https://github.com/NixOS/nixpkgs/commit/dff9ba604a7a2e24ecc988cb99af5d9b6f36a318) moon: 1.24.6 -> 1.25.1
* [`62942da8`](https://github.com/NixOS/nixpkgs/commit/62942da8548170c1d78e1799558a1e3ccb1f2672) morgen: 3.4.3 -> 3.4.4
* [`92b8f812`](https://github.com/NixOS/nixpkgs/commit/92b8f812ac50740c2e05f877a158c10ded5481df) python311Packages.skl2onnx: 1.16.0 -> 1.17.0
* [`a6a98862`](https://github.com/NixOS/nixpkgs/commit/a6a98862d0da89cc812fc4d0d8e5182c3671e4de) amazon-ssm-agent: 3.3.131.0 -> 3.3.484.0
* [`a5fb12f2`](https://github.com/NixOS/nixpkgs/commit/a5fb12f29612eee52921b5cf6a558d5ff569f16f) iodine: unstable-2019-09-27 -> 0.8.0
* [`dddd08d1`](https://github.com/NixOS/nixpkgs/commit/dddd08d188e219f6cae33a509a2c3f5911a66a99) nixos/nextcloud: make memory_limit of nextcloud-cron configurable
* [`7aa5c903`](https://github.com/NixOS/nixpkgs/commit/7aa5c903320737ecf424832c0ba447eba3d561fc) fanficfare: 4.33.0 -> 4.34.0
* [`6caa12ea`](https://github.com/NixOS/nixpkgs/commit/6caa12eae4e576d6008590b566e006f4b696a30a) blst: 0.3.11 -> 0.3.12
* [`41227222`](https://github.com/NixOS/nixpkgs/commit/41227222a213d0c6d76374c5090da9751efb21dc) bkcrack: 1.6.1 -> 1.7.0
* [`63d29606`](https://github.com/NixOS/nixpkgs/commit/63d29606ad7660098549b9e63601f33344402583) python311Packages.ufo2ft: 3.2.2 -> 3.2.4
* [`077b780f`](https://github.com/NixOS/nixpkgs/commit/077b780ff27734361b53174ee6e2eb6536a766d4) printrun: 2.0.1 -> 2.1.0
* [`355e250f`](https://github.com/NixOS/nixpkgs/commit/355e250f4689af8d8871f0ef78bd44381092bdae) infisical: 0.22.2 -> 0.22.3
* [`4b0fd379`](https://github.com/NixOS/nixpkgs/commit/4b0fd3799011f074c15531bba6027b04133e4e10) nixos/alsa: fix audio state loading on system start
* [`d9023256`](https://github.com/NixOS/nixpkgs/commit/d90232565e55e4bbdf0cfc93b7323f2fb84fe2c9) haskellPackages.ad: disable problematic test on x86_64-darwin
* [`aa5be78c`](https://github.com/NixOS/nixpkgs/commit/aa5be78c39c05b76cd0c4ae5fcb59b9c5c1d91cc) python311Packages.ionhash: mark as broken
* [`cbf30c16`](https://github.com/NixOS/nixpkgs/commit/cbf30c16c96ac37ee2281ade8361c8ed9a85683e) gnustep.make: 2.9.1 -> 2.9.2
* [`1d5db358`](https://github.com/NixOS/nixpkgs/commit/1d5db3589963d8a13c33a2c7a8c90ffee7881d9c) hid-t150: init at 0.8a
* [`8e1bad95`](https://github.com/NixOS/nixpkgs/commit/8e1bad95481d9fdee1cc8416c40c93c7c58d7b8b) yubioath-flutter: pin to flutter 3.19
* [`fa12dda7`](https://github.com/NixOS/nixpkgs/commit/fa12dda70e9d544b846762bf63bd2c7abfbaccb2) fluffychat: pin to flutter 3.19
* [`44f3630b`](https://github.com/NixOS/nixpkgs/commit/44f3630b91602f20bd7121c3cf49f1dcef38954d) flet-client-flutter: pin to flutter 3.19
* [`09fa054a`](https://github.com/NixOS/nixpkgs/commit/09fa054a4d62dece3715b9813f8f24fbce29566a) doc/dart: require to specify flutter version
* [`d2b6d1a0`](https://github.com/NixOS/nixpkgs/commit/d2b6d1a0a5a8a46c368688478994548e947f1b30) jrl-cmakemodules: unstable-2024-04-11 -> 0-unstable-2024-05-22
* [`32a22d7f`](https://github.com/NixOS/nixpkgs/commit/32a22d7f488b840e546bf55f706ebc301751c858) pinocchio: 2.7.1 -> 3.0.0
* [`6d581993`](https://github.com/NixOS/nixpkgs/commit/6d581993d6fcfed11c86133689b073880d068dd0) example-robot-data: patch for pinocchio v3.0.0
* [`8c303b9c`](https://github.com/NixOS/nixpkgs/commit/8c303b9c4c430c357176a29b434436ed9476b493) ganttproject-bin: 3.3.3300 -> 3.3.3309
* [`a65eead7`](https://github.com/NixOS/nixpkgs/commit/a65eead717aa6d13c4746836bf972e4b5a789cc5) freeipa: 4.11.1 -> 4.12.0
* [`d849229e`](https://github.com/NixOS/nixpkgs/commit/d849229ef607ea7e5e1333403666973e440ceef9) crocoddyl: 2.0.2 -> 2.1.0
* [`0133e216`](https://github.com/NixOS/nixpkgs/commit/0133e21626dc8cd3cd910306910f37c121b1e7be) nixos/tests/podman: add test for rootless quadlet
* [`dfd0d14e`](https://github.com/NixOS/nixpkgs/commit/dfd0d14efc14c5673be1ce76753ea4e8140868bc) lxd-virtual-machine-image: install initial configuration read-write
* [`c49ca827`](https://github.com/NixOS/nixpkgs/commit/c49ca8273de1c3a3bb9cd2455b3b4ff8aaf24a87) coq-lsp: 0.1.8 -> 0.1.9
* [`0bef709e`](https://github.com/NixOS/nixpkgs/commit/0bef709e874a1371928ee3a82ce3ce785b9de1aa) glances: 4.0.6 -> 4.0.7
* [`bf19510e`](https://github.com/NixOS/nixpkgs/commit/bf19510e3a552ddbe74902747d3c6b0b2f8b02ae) python311Packages.google-cloud-container: 2.45.0 -> 2.46.0
* [`7b5c2133`](https://github.com/NixOS/nixpkgs/commit/7b5c2133b0491de75a20ff794e4381d2cab5f29d) python311Packages.gradio-pdf: 0.0.7 -> 0.0.9
* [`2ea757a0`](https://github.com/NixOS/nixpkgs/commit/2ea757a0299331deda57fda9395cf2592ee460ee) luaPackages.luarocks: generate luarocks as well
* [`ddff8a6e`](https://github.com/NixOS/nixpkgs/commit/ddff8a6e51eb7ede69ce33779af4ac0f5a9d0145) python311Packages.gradio-client: 0.16.1 -> 0.20.1
* [`88dcf659`](https://github.com/NixOS/nixpkgs/commit/88dcf659122b529a0614407865f908120d0b984b) python311Packages.gradio: 4.29.0 -> 4.32.1
* [`fc1e8093`](https://github.com/NixOS/nixpkgs/commit/fc1e8093b56f24cf5323bdd626b9583bfaa3e2b1) haskell.packages.ghc910: work around aarch64-darwin output cycles
* [`a8150b35`](https://github.com/NixOS/nixpkgs/commit/a8150b351d934ffa452463e9145ae716bc194dc3) pdm: 2.15.3 -> 2.15.4
* [`af1d2bd1`](https://github.com/NixOS/nixpkgs/commit/af1d2bd13a27e39eb306fe206ce0389c06c0e9b9) lomiri.lomiri-app-launch: Inject /run/current-system/sw/bin into PATH
* [`20c9038e`](https://github.com/NixOS/nixpkgs/commit/20c9038e157ddb5152a0693f75d46f158c805c05) lomiri.lomiri-app-launch: Modernise abit
* [`0ddd3a49`](https://github.com/NixOS/nixpkgs/commit/0ddd3a49e916136451ccab8689d2dc9f718e35f5) lomiri.content-hub: Fetch patch to fix data transfer
* [`120fda2e`](https://github.com/NixOS/nixpkgs/commit/120fda2ef344872c39b57f703a033548806687f8) lomiri.content-hub: Modernise abit
* [`9910485a`](https://github.com/NixOS/nixpkgs/commit/9910485a9febcc21bb36b62de831bad8d6832eee) catppuccin-catwalk: 0.1.0 -> 1.3.1
* [`985c38aa`](https://github.com/NixOS/nixpkgs/commit/985c38aa1ae8af225d5a99cd5cf7318ddbeb94fa) treewide: remove buildFHSEnv `name = pname` workarounds
* [`2735184f`](https://github.com/NixOS/nixpkgs/commit/2735184f6d8fdb7f32265fd4a3a92bce29ee52a7) lomiri.lomiri: Try to consider services.xserver.xkb.layout
* [`15e4bdad`](https://github.com/NixOS/nixpkgs/commit/15e4bdad9e3a9953164394675ed682daff5578e2) zoom-us: 6.0.10.5325 -> 6.0.12.5501
* [`33dc3daf`](https://github.com/NixOS/nixpkgs/commit/33dc3daf4325ef741bd74dd4480890e3a38c1f12) tidal-hifi: 5.13.0 -> 5.13.1
* [`b1c9f4d0`](https://github.com/NixOS/nixpkgs/commit/b1c9f4d04134b5715d80b3906749c741ac898b2d) juju: 3.5.0 -> 3.5.1
* [`b2f8c6cf`](https://github.com/NixOS/nixpkgs/commit/b2f8c6cfe5b77181f8069ec9ac0e27e5e8b62307) unifi8: 8.1.127 -> 8.2.93
* [`4041a758`](https://github.com/NixOS/nixpkgs/commit/4041a7586149de7ecf8a6a673273bf87c019e37f) python311Packages.django-modeltranslation: 0.19.0 -> 0.19.2
* [`d2a8b0de`](https://github.com/NixOS/nixpkgs/commit/d2a8b0de5d509ba15f7fca3f42c416b5632c63e9) python311Packages.simplemma: 0.9.1 -> 1.0.0
* [`cf2847ee`](https://github.com/NixOS/nixpkgs/commit/cf2847ee7c820adf2169ee543ede9ac540fe9227) rain: 1.9.0 -> 1.10.0
* [`153754ee`](https://github.com/NixOS/nixpkgs/commit/153754ee8ec76cd589a84f0c6d9524d6f356e3c6) mainsail: refactor to build from source
* [`adb42158`](https://github.com/NixOS/nixpkgs/commit/adb421589c9817662a832a1f5fd70cc90a09d40b) eigenlayer: 0.8.0 -> 0.8.1
* [`e251d46b`](https://github.com/NixOS/nixpkgs/commit/e251d46be5d1e400dc0701d2fb62a369dd5d4e3d) reindeer: 2024.05.20.00 -> 2024.05.27.00
* [`5c524523`](https://github.com/NixOS/nixpkgs/commit/5c5245230f956b3238c19a77c8a77494ffd12bbf) dart-sass: 1.77.2 -> 1.77.4
* [`717e0dcb`](https://github.com/NixOS/nixpkgs/commit/717e0dcb77262f438f89c5f4087ea4c41ac48c66) python312Packages.dahlia: init at 2.3.2
* [`c4b46f7c`](https://github.com/NixOS/nixpkgs/commit/c4b46f7c5445bbfd6a6a1f99fa73fd9d6a0da373) python312Packages.crossandra: init at 2.2.1
* [`d5dfba03`](https://github.com/NixOS/nixpkgs/commit/d5dfba037a1b4c55d2773f20c96f38ec671b500a) python312Packages.ixia: init at 1.3.1
* [`31c0f2f1`](https://github.com/NixOS/nixpkgs/commit/31c0f2f14375e570093887f9ecde0bc1e2173aad) python312Packages.outspin: init at 0.3.2
* [`b9221f90`](https://github.com/NixOS/nixpkgs/commit/b9221f9007146dc7cb96a1dc6b1b0e5adad61aa1) python312Packages.paperbush: init at 0.2.0
* [`d6ece75b`](https://github.com/NixOS/nixpkgs/commit/d6ece75b2f094288254af4ac179491b5e14951df) autotrash: init at 0.4.7
* [`76244576`](https://github.com/NixOS/nixpkgs/commit/76244576357193ac27ef61f091933235ea63f721) kodiPackages.youtube: 7.0.6.3 -> 7.0.7
* [`50499530`](https://github.com/NixOS/nixpkgs/commit/504995307c78439ad0e5ab0e05051d6f2e2972ea) raycast: 1.75.1 -> 1.75.2
* [`dcf68052`](https://github.com/NixOS/nixpkgs/commit/dcf680520d3fd28b793adbac9d4fef7e99579d62) raycast: remove pipefail
* [`c6d3e8c1`](https://github.com/NixOS/nixpkgs/commit/c6d3e8c115a8bcb579de8b8d945aea724513a9d6) cargo-dist: 0.14.1 -> 0.15.0
* [`1fd084b2`](https://github.com/NixOS/nixpkgs/commit/1fd084b2648f5fb2cd0b15f3fc700b162ccf8375) zfs_unstable: 2.2.4 → 2.2.4-unstable-2024-05-29
* [`d35cdfc5`](https://github.com/NixOS/nixpkgs/commit/d35cdfc5cc8c32d35428e4fe890c705e8410b2e0) maintainers: add matteopacini
* [`195626df`](https://github.com/NixOS/nixpkgs/commit/195626dfe43a99ba498faa8724a60befa5ab0311) epiphany: 46.0 → 46.1
* [`c4f8dbd2`](https://github.com/NixOS/nixpkgs/commit/c4f8dbd24525678a67e2f92ba0caa536dc1f848f) gnome.gdm: 46.0 → 46.2
* [`4655367a`](https://github.com/NixOS/nixpkgs/commit/4655367aee141847887ce018cc1710e93a207b22) gnome.gnome-control-center: 46.1 → 46.2
* [`89aa8a70`](https://github.com/NixOS/nixpkgs/commit/89aa8a7078caaf2398bfdce63923309b1b001aa7) gtksourceview5: 5.12.0 → 5.12.1
* [`053ce2df`](https://github.com/NixOS/nixpkgs/commit/053ce2dfe9379d8541ef617303842669c0d2f0c1) libdex: 0.6.0 → 0.6.1
* [`f0c6b175`](https://github.com/NixOS/nixpkgs/commit/f0c6b1752868a779d96f6da7c472a60e0fb0038e) brave: 1.66.115 -> 1.66.118
* [`124d4a00`](https://github.com/NixOS/nixpkgs/commit/124d4a0031fb838b990b11bbb7f14b483a97ebc4) networkmanager: 1.46.0 → 1.48.0
* [`65a1917b`](https://github.com/NixOS/nixpkgs/commit/65a1917baf5f36f1bb85750f2af61536428dbcd0) resvg: 0.41.0 -> 0.42.0
* [`96be89a3`](https://github.com/NixOS/nixpkgs/commit/96be89a314cf458dc8d4c8e9cbf9677df8223d1f) rofi-obsidian: 0.1.0 -> 0.1.5
* [`e5466972`](https://github.com/NixOS/nixpkgs/commit/e5466972c5cc3da68977a4f1dee05519c0ec73f1) networkmanager-iodine: Clean up
* [`84262182`](https://github.com/NixOS/nixpkgs/commit/842621827567f5fbbbe48c5fb717cee7bea7cdec) networkmanager-iodine: Fix update script
* [`9e5f97e4`](https://github.com/NixOS/nixpkgs/commit/9e5f97e405541170499f137dbf2473dc9a2d1a9d) networkmanager-iodine: unstable-2019-11-05 → 1.2.0-unstable-2024-05-12
* [`7b2a2824`](https://github.com/NixOS/nixpkgs/commit/7b2a2824b39888364738c5fca848aa2508366110) nixos/wayland-session: force running xdg autostart for WM-only sessions
* [`50fb6d1e`](https://github.com/NixOS/nixpkgs/commit/50fb6d1eafe59ed596f6211843252583a77d9245) fantomas: 6.3.4 -> 6.3.7
* [`f6660806`](https://github.com/NixOS/nixpkgs/commit/f6660806b85f3c3e03d170f0022aa004ab68092d) tarsnapper: use pynose to run tests
* [`0756450c`](https://github.com/NixOS/nixpkgs/commit/0756450ca085a272fe683705acdf48ea8b842ec3) libmpd: init at 11.8.17
* [`a94afacd`](https://github.com/NixOS/nixpkgs/commit/a94afacd53923e094417a69baaad0c66e81a7cd3) k3s_1_27: remove
* [`0ba89854`](https://github.com/NixOS/nixpkgs/commit/0ba898546b24fa642a00c010ff5dbdcb788fb568) alt-tab-macos: 6.69.0 -> 6.70.1
* [`11967e5d`](https://github.com/NixOS/nixpkgs/commit/11967e5d840372f8d6828d0474c49b1732cc2af7) alt-tab-macos: refactor updateScript
* [`501d7c53`](https://github.com/NixOS/nixpkgs/commit/501d7c532b9ce21baf21259e096c284a7e7be977) qownnotes: 24.5.8 -> 24.6.0
* [`2bbaf390`](https://github.com/NixOS/nixpkgs/commit/2bbaf390ffd24c277a68d6c86b33a400a7ac5d2a) iina: 1.3.4 -> 1.3.5
* [`7173015b`](https://github.com/NixOS/nixpkgs/commit/7173015b46aa27a081a58d4f83f9540e4d9a2849) iina: add maintainer donteatoreo
* [`0cac0b7e`](https://github.com/NixOS/nixpkgs/commit/0cac0b7e95d585ef093366d5cde3610fa3265dcb) iina: use finalAttrs pattern
* [`5b281e4f`](https://github.com/NixOS/nixpkgs/commit/5b281e4f3008329550b6b50fe77191c1a8f7cf40) iina: sort meta alphabetically
* [`ff3bced4`](https://github.com/NixOS/nixpkgs/commit/ff3bced431be3fddbe3514320430de0e0df68a85) iina: remove `with lib;` from meta
* [`f19a7101`](https://github.com/NixOS/nixpkgs/commit/f19a7101dec159bc0efa5fb875fc354272af0338) iina: refactor stdenv -> stdenvNoCC
* [`8ea8729f`](https://github.com/NixOS/nixpkgs/commit/8ea8729f12371422e602730c726360c43179f692) iina: format with nixfmt-rfc-style
* [`04ce310d`](https://github.com/NixOS/nixpkgs/commit/04ce310ddc698dd4747a335edba17a71148c4d1f) gallery-dl: 1.26.9 -> 1.27.0
* [`7c64f88d`](https://github.com/NixOS/nixpkgs/commit/7c64f88d0410d11f9010a3aa24e9f97f7896eedf) gallery-dl: format with nixfmt
* [`01d19622`](https://github.com/NixOS/nixpkgs/commit/01d19622b0a96c74fd4f9dd9cae743d2987151db) gallery-dl: remove `meta = with lib;`
* [`8b89e34d`](https://github.com/NixOS/nixpkgs/commit/8b89e34d1b10c0eb8bac6f2cc7b7a941f4acb171) python311Packages.google-cloud-dlp: 3.17.0 -> 3.18.0
* [`a93d013e`](https://github.com/NixOS/nixpkgs/commit/a93d013e31e7611f4c6fda18d508fd50d9612771) python312Packages.hahomematic: 2024.4.12 -> 2024.5.4
* [`86394aaf`](https://github.com/NixOS/nixpkgs/commit/86394aafdd8e3cbc5abbc97081cb881f8574bee6) home-assistant-custom-components.homematicip_local: 1.60.1 -> 1.62.0
* [`aba2712c`](https://github.com/NixOS/nixpkgs/commit/aba2712cb067e4050ac2702d33240e491384cade) clickhouse-backup: add devusb to maintainers
* [`5272d01c`](https://github.com/NixOS/nixpkgs/commit/5272d01c259689f536df0fc4667770582a403ed0) clickhouse-backup: support on all platforms
* [`c791fe7a`](https://github.com/NixOS/nixpkgs/commit/c791fe7ac07fa1cc95e41df5404a0d3c050409dc) clickhouse-backup: update repo owner
* [`3eba04d8`](https://github.com/NixOS/nixpkgs/commit/3eba04d862e778f218c2c08ff8e4b7e387daebb0) clips: 6.40 -> 6.4.1
* [`e1d07998`](https://github.com/NixOS/nixpkgs/commit/e1d079982c5eaad312073277c977a587fb322c7d) clips: expose library and headers
* [`36963cc3`](https://github.com/NixOS/nixpkgs/commit/36963cc30be8f4d90d6df862d42f189ed6a4c0ef) signal-desktop-beta: 7.10.0-beta.1 -> 7.12.0-beta.2
* [`1e69af82`](https://github.com/NixOS/nixpkgs/commit/1e69af82ed24d525055b695853cb8db63a7fec97) python311Packages.diffusers: 0.27.2 -> 0.28.0
* [`d2767bbd`](https://github.com/NixOS/nixpkgs/commit/d2767bbd2432456c825aeb3edc64c6e68d593486) python311Packages.diffusers: move tests to passthru.tests
* [`d962083c`](https://github.com/NixOS/nixpkgs/commit/d962083c37d0cc90f757c81008d7fd1e19afae5f) maintainers: add o0th
* [`0a32172a`](https://github.com/NixOS/nixpkgs/commit/0a32172a2255651044cf6c81df93a71908d5438d) tmuxPlugins.tmux-nova: init at 1.2.0
* [`f014663f`](https://github.com/NixOS/nixpkgs/commit/f014663fe4d84e06d34cbe555aee77ecc19032cf) bitwuzla: 0.4.0 -> 0.5.0
* [`e26e6215`](https://github.com/NixOS/nixpkgs/commit/e26e62157951b9586e730980fb6b9e961cdac256) haskellPackages: add alexfmpe as maintainer
* [`db2b9eb1`](https://github.com/NixOS/nixpkgs/commit/db2b9eb1398f8cb60fd37d21c2c720a1acc0c56e) grub2: make localization resources deterministic
* [`f5bef14d`](https://github.com/NixOS/nixpkgs/commit/f5bef14d31ed42376b9fe6e4a94d3af8ef5ebcdc) highlight-pointer: init at 1.1.3
* [`73070eff`](https://github.com/NixOS/nixpkgs/commit/73070effca150676369f68a679a65e8788e23943) waylock: fix pam file to use login service
* [`f54bdb97`](https://github.com/NixOS/nixpkgs/commit/f54bdb97fda75a59901a1cff0a207639cfe0bf27) python311Packages.plugwise: 0.37.9 -> 0.38.0
* [`4f8f18d4`](https://github.com/NixOS/nixpkgs/commit/4f8f18d4fc8ab50f0c4491856aab45fa4bb4db3c) okteto: 2.27.2 -> 2.27.4
* [`b5c7987b`](https://github.com/NixOS/nixpkgs/commit/b5c7987b5232927c8df3fe23ee065722e49a63ea) nixos/gollum: fix systemd tempfile permission
* [`30849a39`](https://github.com/NixOS/nixpkgs/commit/30849a39590932e89a2f91b740efe15a8eb98a91) emacsPackages.lsp-bridge: 20240520.1548 -> 20240601.1149
* [`778f4b07`](https://github.com/NixOS/nixpkgs/commit/778f4b076ced4e63b6d3390866a6922ae69e2281) xpipe: 9.3 -> 9.4
* [`61ed9b45`](https://github.com/NixOS/nixpkgs/commit/61ed9b4594accbff69f6f25e0888aa381856300e) greetd.tuigreet: 0.9.0 -> 0.9.1
* [`5b588a2e`](https://github.com/NixOS/nixpkgs/commit/5b588a2e9f41181ade56bc66a6b06645b75df5eb) stirling-pdf: 0.24.6 -> 0.25.1
* [`4549773e`](https://github.com/NixOS/nixpkgs/commit/4549773edf119c40f3285fd46b662a5ceec2e456) nodePackages: enable overriding src and name attrs
* [`53af969d`](https://github.com/NixOS/nixpkgs/commit/53af969d621c29357788baf5642ed28ada3b5f00) pnpm: init at 9.1.1
* [`cd31ffcc`](https://github.com/NixOS/nixpkgs/commit/cd31ffccf73cf708f0a6059bee63f90213986773) megacmd: 1.6.3 -> 1.7.0
* [`76810d17`](https://github.com/NixOS/nixpkgs/commit/76810d17760c39f16edf4328679b57754c71eb30) medfile: 4.1.1 -> 5.0.0, fix darwin build and refactoring
* [`d8f7c592`](https://github.com/NixOS/nixpkgs/commit/d8f7c592846d18d7732bc5b1156fadd4a60421fb) python311Packages.stripe: 9.8.0 -> 9.9.0
* [`fbd37219`](https://github.com/NixOS/nixpkgs/commit/fbd37219c3f829a4ef6974053c175d7470740d9e) goodvibes: 0.7.9 -> 0.8.0
* [`74f5ff78`](https://github.com/NixOS/nixpkgs/commit/74f5ff78bfb0caae8dff6554b57dab7ca5ea9ca4) pnpm.fetchDeps: init
* [`728d4828`](https://github.com/NixOS/nixpkgs/commit/728d48285e5c17ed9764bc7067b9cece3ae81f15) pnpm.fetchDeps: add serve script
* [`444b9863`](https://github.com/NixOS/nixpkgs/commit/444b9863a94dbc5f0040e6a615f5c0c2b15e57f2) vesktop: use pnpm.fetchDeps
* [`1ec98f0d`](https://github.com/NixOS/nixpkgs/commit/1ec98f0d1080443e28730e2db2de3ddd0a5f1817) pot: use pnpm.fetchDeps
* [`3b2e68d2`](https://github.com/NixOS/nixpkgs/commit/3b2e68d242a97d9cc5488b80773eb679ffb06dce) vikunja: use pnpm.fetchDeps
* [`18b12484`](https://github.com/NixOS/nixpkgs/commit/18b124840feaf69c7cff3914d9258cc2a2b0ce25) kiwitalk: use pnpm.fetchDeps
* [`6fe1507a`](https://github.com/NixOS/nixpkgs/commit/6fe1507ab21f6cb4d00f899440329c7a234bc01f) gephgui-wry: use pnpm.fetchDeps
* [`b6925002`](https://github.com/NixOS/nixpkgs/commit/b69250022976c1e91b27e2762cea0b417e087206) youtube-music: use pnpm.fetchDeps
* [`9ad87bb9`](https://github.com/NixOS/nixpkgs/commit/9ad87bb974292c29306866d73d5ea78f2db1bdc6) algolia-cli: 1.6.10 -> 1.6.11
* [`7ebcae23`](https://github.com/NixOS/nixpkgs/commit/7ebcae230b5d4ae6c55564886a5d0dcd5d8fdd02) irust: init at 1.71.23
* [`ef56def1`](https://github.com/NixOS/nixpkgs/commit/ef56def164e128b6e308268a84b9b8b12cfc7709) jitterentropy: 3.4.1 -> 3.5.0
* [`4c54c0fb`](https://github.com/NixOS/nixpkgs/commit/4c54c0fb43140c0ce50213ee3b20abf977ea5b93) minio: 2024-05-27T19-17-46Z -> 2024-05-28T17-19-04Z
* [`56edbd69`](https://github.com/NixOS/nixpkgs/commit/56edbd693fea404435b054c612496c1f9055406f) fflogs: 8.5.9 -> 8.5.10
* [`e8f703ab`](https://github.com/NixOS/nixpkgs/commit/e8f703ab9bfa90dd0e16b246463f103579c00aab) libratbag: fix `ratbagctl` typelib error
* [`43cdb75c`](https://github.com/NixOS/nixpkgs/commit/43cdb75ca3f0bac2ce1485c9936cb13e193efd01) openrazer-daemon: Fix typelib error
* [`0e87e555`](https://github.com/NixOS/nixpkgs/commit/0e87e55595031aad7369a8f21086a0b5ad168588) openrazer-daemon: move deps to correct attributes
* [`b75575e1`](https://github.com/NixOS/nixpkgs/commit/b75575e178906486edb72c05ad0e65c45ca7a215) whipper: Fix typelib error
* [`01eb221a`](https://github.com/NixOS/nixpkgs/commit/01eb221ace7b7d5f11f0ef39221892b847c8f569) dotnetCorePackages.sdk_6_0: 6.0.30 -> 6.0.31
* [`6113a9f6`](https://github.com/NixOS/nixpkgs/commit/6113a9f660144427e7e79e868825611384a2f852) dotnetCorePackages.sdk_7_0: 7.0.19 -> 7.0.20
* [`5f7390af`](https://github.com/NixOS/nixpkgs/commit/5f7390af48af1645620cc47976420bb7b384feac) dotnetCorePackages.sdk_8_0: 8.0.5 -> 8.0.6
* [`f44b27ce`](https://github.com/NixOS/nixpkgs/commit/f44b27ce93b6bb137180162ac8aa03697fa0876e) dotnetCorePackages.dotnet_8: 8.0.5 -> 8.0.6
* [`a7a6356c`](https://github.com/NixOS/nixpkgs/commit/a7a6356c14ddfe1b2c6a017606d96c474c519a39) tests.dotnet.project-references: use dir instead of file output
* [`7959272c`](https://github.com/NixOS/nixpkgs/commit/7959272c13e32a55748817fd02acc2a3053e93c3) session-desktop: file desktop exec path
* [`f643e4fa`](https://github.com/NixOS/nixpkgs/commit/f643e4fa5b15333bc776d0e52bfd0a04e5e35e86) nixos/tailscale-auth: fix enable option description
* [`54bcb9a0`](https://github.com/NixOS/nixpkgs/commit/54bcb9a02aa8ae5d718509cd6ca033ade31deb4f) grafana-agent: 0.40.5 -> 0.41.0
* [`7a4ccc54`](https://github.com/NixOS/nixpkgs/commit/7a4ccc54941c15fd9c8cb04b8144e03ebba0d367) python311Packages.riscv-config: 3.18.2 -> 3.18.3
* [`c9cc3280`](https://github.com/NixOS/nixpkgs/commit/c9cc328009011847b020d86adf87cec826a8d42c) ytdownloader: 3.17.4 -> 3.18.0
* [`db8da5f9`](https://github.com/NixOS/nixpkgs/commit/db8da5f977263b43069c43c064b321dd2bfc9ee7) zigbee2mqtt: 1.37.1 -> 1.38.0
* [`b7dd52f3`](https://github.com/NixOS/nixpkgs/commit/b7dd52f329fbf6af6319d87ee7488e6626eda2d4) atuin: only generate completions if program can be executed
* [`6823e661`](https://github.com/NixOS/nixpkgs/commit/6823e661ee44cbab60ef7acd2100970215b69e53) home-assistant-custom-lovelace-modules.mushroom: 3.6.0 -> 3.6.1
* [`2f1f6c3b`](https://github.com/NixOS/nixpkgs/commit/2f1f6c3b509d920a0af987ce8dc68cc64238cd91) volatility3: 2.5.2 -> 2.7.0
* [`81f21862`](https://github.com/NixOS/nixpkgs/commit/81f218628bb2fdb0c565ee091c5e20c6ac592d88) .github/labeler.yml: add dotnet label
* [`40df049f`](https://github.com/NixOS/nixpkgs/commit/40df049f425e9ef5e550ac9855dc87a724b8d9b0) xmltoman: init at 0.6
* [`138ad7b7`](https://github.com/NixOS/nixpkgs/commit/138ad7b73ac34a289403ba9bf4d5b0da691ab3e4) nixos.tests.musescore: fix and improve
* [`1ecfccd2`](https://github.com/NixOS/nixpkgs/commit/1ecfccd265c868c79792d87916a1b391a5ee125e) python311Packages.k5test: works on darwin
* [`a2ab68ab`](https://github.com/NixOS/nixpkgs/commit/a2ab68ab9263224bb01b92a62852ef741dd6880f) buildMavenPackage: add doCheck support
* [`af11e018`](https://github.com/NixOS/nixpkgs/commit/af11e0182ce58de8fa01b1f8aa5fed08fa7c196d) mariadb-connector-java: normalize doCheck
* [`1ca1182e`](https://github.com/NixOS/nixpkgs/commit/1ca1182e537bd52ce9c1870de42e186f8d64f7e1) forge-mtg: normalize doCheck
* [`2c5961d4`](https://github.com/NixOS/nixpkgs/commit/2c5961d4b7cd70a738e6d2e6f54309beabf96ef8) java-language-server: normalize doCheck
* [`66472eba`](https://github.com/NixOS/nixpkgs/commit/66472eba4d12ba882b7c53f262d7ac7bd3c78c92) commafeed: normalize doCheck
* [`2037c8fe`](https://github.com/NixOS/nixpkgs/commit/2037c8febc673d2f21b923d0241732c5dbe8b48f) openrefine: normalize doCheck
* [`5c263158`](https://github.com/NixOS/nixpkgs/commit/5c263158043914f50da9d489f371a6ddd6a45656) ns-usbloader: normalize doCheck
* [`9855e223`](https://github.com/NixOS/nixpkgs/commit/9855e223acb301475f463743b3543ef4ba66e846) sonarlint-ls: normalize doCheck
* [`aa993504`](https://github.com/NixOS/nixpkgs/commit/aa993504e77e78b7e52f0c67f11b884ef0c78d42) kotlin-interactive-shell: normalize doCheck
* [`44e435d2`](https://github.com/NixOS/nixpkgs/commit/44e435d24151be6878eee6eb88629843810b40eb) h2: normalize doCheck
* [`6ab6515d`](https://github.com/NixOS/nixpkgs/commit/6ab6515def09d321385be3b657071ae8142b4e9d) s3proxy: normalize doCheck
* [`0c66b010`](https://github.com/NixOS/nixpkgs/commit/0c66b01048e26cfd0de41c60af06ad2024c6fd41) ejson2env: add tests
* [`1c8e6101`](https://github.com/NixOS/nixpkgs/commit/1c8e6101197b0e3895ebdb4fbd967ea18f3875c3) glances: reformat and update dependencies
* [`83fbdd8c`](https://github.com/NixOS/nixpkgs/commit/83fbdd8c85707fc03bbef36e40cfdd6f7bc33296) ast-grep: 0.22.4 -> 0.22.5
* [`99467507`](https://github.com/NixOS/nixpkgs/commit/9946750788b2ce80279f1b75aaca03377787701e) centerpiece: 1.0.0 -> 1.1.0
* [`e4839f5b`](https://github.com/NixOS/nixpkgs/commit/e4839f5b27d7b9e4b01c2ee1f7dd0e3c6699e7fa) icloudpd: 1.18.0 -> 1.19.0
* [`16309fd8`](https://github.com/NixOS/nixpkgs/commit/16309fd8d9cdffe4b054fd5f0d895e353d77a6ab) ollama: 0.1.39 -> 0.1.41
* [`5d737927`](https://github.com/NixOS/nixpkgs/commit/5d7379277acfc5a581494b98bf39fc9152927171) nmap-formatter: 2.1.6 -> 3.0.0
* [`4a1330b4`](https://github.com/NixOS/nixpkgs/commit/4a1330b47741816964c60c8edb0cde327ff0315d) flawz: 0.2.0 -> 0.2.1
* [`09c5ca7d`](https://github.com/NixOS/nixpkgs/commit/09c5ca7d212dd5acdf7f8771a23a31654c239fe6) gomplate: 3.11.7 -> 3.11.8
* [`e8bdfaf8`](https://github.com/NixOS/nixpkgs/commit/e8bdfaf8a1673f49319d33d83a5f92fa6631c49a) osl: 1.13.9.0 -> 1.13.10.0
* [`e685d1d0`](https://github.com/NixOS/nixpkgs/commit/e685d1d043eea8601881350ece7f64c0d65bd99f) gitui: 0.26.2 -> 0.26.3
* [`de777188`](https://github.com/NixOS/nixpkgs/commit/de777188870259d3a1633a41dad963cc19bee6a1) nixos/wayland-session: cleanup
* [`346e0f6b`](https://github.com/NixOS/nixpkgs/commit/346e0f6be178d576728417558ca28458c83035fa) ticker: 4.6.2 -> 4.6.3
* [`d6401eed`](https://github.com/NixOS/nixpkgs/commit/d6401eeda1f9845bf7bcb81082d4e1d3572f40da) steamguard-cli: 0.13.0 -> 0.14.0
* [`d67961fe`](https://github.com/NixOS/nixpkgs/commit/d67961fe4e4f2af2731702477635ed7afc1bee5c) virtualbox: 7.0.14 -> 7.0.18
* [`65292ff2`](https://github.com/NixOS/nixpkgs/commit/65292ff26568337fef4f725534cdc6b71088a417) lx-music-desktop: 2.7.0 -> 2.8.0
* [`4d1bc277`](https://github.com/NixOS/nixpkgs/commit/4d1bc277568b5fa623c2493ceb33440e37eea03d) llama-cpp: 3015 -> 3070
* [`0d2e9913`](https://github.com/NixOS/nixpkgs/commit/0d2e99132d2c60f5766281cbe2d7df63bcc4dd03) nh: 3.5.15 -> 3.5.16
* [`9f3c5f53`](https://github.com/NixOS/nixpkgs/commit/9f3c5f53d29f4e887b5a3d3a47cfaf1bba63acab) linuxKernel.kernels.linux_zen: 6.9.2-zen1 -> 6.9.3-zen1
* [`f4501736`](https://github.com/NixOS/nixpkgs/commit/f450173677a97317a044cafdac258622c25ac94c) linuxKernel.kernels.linux_lqx: 6.8.11-lqx1 -> 6.9.3-lqx1
* [`ba913eda`](https://github.com/NixOS/nixpkgs/commit/ba913eda2df8eb72147259189d55932012df6301) caddy: 2.7.6 -> 2.8.4
* [`6031652e`](https://github.com/NixOS/nixpkgs/commit/6031652ebf6c0eb0602d0edaf069bcec5f9b9ea1) twm: 0.9.1 -> 0.10.2
* [`0fe55e42`](https://github.com/NixOS/nixpkgs/commit/0fe55e4233c953685970ebc0e4596c8853267ccc) trezor-suite: update hash for `aarch64-linux`
* [`73dee902`](https://github.com/NixOS/nixpkgs/commit/73dee9023bda28cac7d0f5077c055abcc787b471) python311Packages.llama-index-graph-stores-neo4j: 0.2.0 -> 0.2.2
* [`d97eb00a`](https://github.com/NixOS/nixpkgs/commit/d97eb00a066263892a2bed41a94b79c7e2874f8f) python311Packages.llama-index-graph-stores-nebula: 0.1.3 -> 0.2.0
* [`80092798`](https://github.com/NixOS/nixpkgs/commit/80092798606fa627aa91a151350e0f8b7fc03a9d) prowlarr: 1.17.2.4511 -> 1.18.0.4543
* [`6d55e12f`](https://github.com/NixOS/nixpkgs/commit/6d55e12fa73a35a29825b8cc290bdb4434592505) python311Packages.nodeenv: 1.8.0 -> 1.9.0
* [`2042b626`](https://github.com/NixOS/nixpkgs/commit/2042b62621bbb0578205127fa8d5569feebdeccc) python311Packages.lupa: 2.1 -> 2.2
* [`0bee554a`](https://github.com/NixOS/nixpkgs/commit/0bee554a73ba5cab621789f76ee5efbb1ee47a4e) python311Packages.pyexploitdb: 0.2.19 -> 0.2.20
* [`57e5f84d`](https://github.com/NixOS/nixpkgs/commit/57e5f84dd8bc0137dd10143075655555f635b1ec) python311Packages.reolink-aio: 0.8.11 -> 0.9.0
* [`1f8ea9a7`](https://github.com/NixOS/nixpkgs/commit/1f8ea9a702725d47ab14da0bcf8834988d229978) python312Packages.tencentcloud-sdk-python: 3.0.1159 -> 3.0.1160
* [`d9d37f73`](https://github.com/NixOS/nixpkgs/commit/d9d37f73b5eb1c8d063ff9cf272a8b498ab55b55) usort: 1.0.7 -> 1.0.8
* [`32cd5a83`](https://github.com/NixOS/nixpkgs/commit/32cd5a83ef5c3a82fd33a1b52b181ec6f823a448) vscode-extensions.streetsidesoftware.code-spell-checker: 4.0.1 -> 4.0.2
* [`5f8cd457`](https://github.com/NixOS/nixpkgs/commit/5f8cd4575263332705c90a49b1297e9feb63d064) python311Packages.tf-keras: init at 2.16.0
* [`216e8141`](https://github.com/NixOS/nixpkgs/commit/216e8141868b85e62dc1dfa07d62cdf7386e2c5e) proj: 9.4.0 -> 9.4.1
* [`5305327b`](https://github.com/NixOS/nixpkgs/commit/5305327b009ee0564c0e70c74277f2a357e12fd9) maa-assistant-arknights: support darwin
* [`88c495fd`](https://github.com/NixOS/nixpkgs/commit/88c495fdf62d926b2b0770537d1a65c4efda79a2) maa-cli: support darwin
* [`f7393d13`](https://github.com/NixOS/nixpkgs/commit/f7393d13fe676bc74cc015838a248493439a9041) nixos/garage: fix replication 1.0 assertion
* [`01ac0865`](https://github.com/NixOS/nixpkgs/commit/01ac08654164ec1474fba7c75a7be3efa7ffd538) python311Packages.dask: 2024.5.1 -> 2024.5.2
* [`232513f3`](https://github.com/NixOS/nixpkgs/commit/232513f379cf8977b5405da5dac97cf333b700a4) pkcs11-provider: add nix-update-script
* [`ed75226c`](https://github.com/NixOS/nixpkgs/commit/ed75226cdf67037dec1060e97f75e2bcbbd6ca0f) ytdownloader: disable updates
* [`bfe23d4f`](https://github.com/NixOS/nixpkgs/commit/bfe23d4fad97a5ad6607a937593210a1a5257337) ytdownloader: refactor code with copyDesktopItems & nixfmt
* [`7aa1c9dc`](https://github.com/NixOS/nixpkgs/commit/7aa1c9dca2e1cc41be4635fd103ee555e4191ff8) python311Packages.dask-expr: 1.1.1 -> 1.1.2
* [`c4e0154f`](https://github.com/NixOS/nixpkgs/commit/c4e0154f803da060b960563033251f846e577b59) hdf5-fortran: move F90 mod files to dev output; remove refs to gfortran
* [`08869be0`](https://github.com/NixOS/nixpkgs/commit/08869be075d4ce0a95f6e740e066de8c5b2528f8) kodiPackages.youtube: fix dependencies
* [`b75e9046`](https://github.com/NixOS/nixpkgs/commit/b75e904686fbd4fab73865866a05886be92e7da6) python311Packages.model-bakery: 1.18.0 -> 1.18.1
* [`f42fa63d`](https://github.com/NixOS/nixpkgs/commit/f42fa63d192d4678210e4ed65fd91dead062e0bb) python311Packages.etils: 1.8.0 -> 1.9.0
* [`3823c546`](https://github.com/NixOS/nixpkgs/commit/3823c5464ddea17d0ee117157ce347fa17f7d7a7) python311Packages.meep: 1.28.0 -> 1.29.0
* [`fbbc41f7`](https://github.com/NixOS/nixpkgs/commit/fbbc41f7daeab95dbec8df18e83c4fa41b69f51f) nixos/systemd: simplify hooks function
* [`c5b09348`](https://github.com/NixOS/nixpkgs/commit/c5b09348a6ebb1560646bea695bcbd57c32310f3) xfce.xfce4-sensors-plugin: Enable xnvctrl by default
* [`9f901d59`](https://github.com/NixOS/nixpkgs/commit/9f901d59dbaef099d7c9a8ed8829578715df872a) yazi: fix plugins and flavors config
* [`97904031`](https://github.com/NixOS/nixpkgs/commit/97904031e20e659d946a30be7c30d4bf5020737d) python312Packages.iterfzf: init at 1.4.0.51.0
* [`1a9df063`](https://github.com/NixOS/nixpkgs/commit/1a9df0630934ff5d56dd6177d469fd82241c18af) python312Packages.typer-shell: init at 0.1.9
* [`4ce21890`](https://github.com/NixOS/nixpkgs/commit/4ce21890829b1ff5955a4941c23c512c5f326b85) nixos/davfs2: Remove deprecated extraConfig
* [`ebbd6135`](https://github.com/NixOS/nixpkgs/commit/ebbd613587758567d62555cfe91a770148e1a30f) jdt-language-server: 1.31.0 -> 1.36.0
* [`2ffe7afc`](https://github.com/NixOS/nixpkgs/commit/2ffe7afc65315ee748f20fed5f1dd4af994e0a8a) cargo-llvm-cov: 0.6.9 -> 0.6.10
* [`10d12cd7`](https://github.com/NixOS/nixpkgs/commit/10d12cd771de59e218523420db6b1d67e83cc365) github-runner: 2.316.1 -> 2.317.0 ([nixos/nixpkgs⁠#316806](https://togithub.com/nixos/nixpkgs/issues/316806))
* [`85878872`](https://github.com/NixOS/nixpkgs/commit/858788722e7f1a83b2a02eba6fa22bfa739504fe) uiua: 0.10.3 -> 0.11.0
* [`fc4f5b6f`](https://github.com/NixOS/nixpkgs/commit/fc4f5b6f1f343c7a3b750a9358ee2929ecc754ff) vscode-extensions.uiua-lang.uiua-vscode: 0.0.42 -> 0.0.44
* [`51fd7221`](https://github.com/NixOS/nixpkgs/commit/51fd7221521e9ed456de79bd1e15f2a573eade12) graphite-cli: 1.3.5 -> 1.3.6
* [`0ffca977`](https://github.com/NixOS/nixpkgs/commit/0ffca9772fe6479ebdb1bc8b7b054a5191c99f8f) tftui: 0.13.2 -> 0.13.3
* [`73ef41b9`](https://github.com/NixOS/nixpkgs/commit/73ef41b931b4615d1b4038d0ba07637d2d6ce973) python311Packages.pyomo: 6.7.2 -> 6.7.3
* [`eb77fcd0`](https://github.com/NixOS/nixpkgs/commit/eb77fcd0b10e7ceae69f6eb7d278a9eb5c195d08) buildbot: apply upstream fix for gitpoller
* [`87cb6c5a`](https://github.com/NixOS/nixpkgs/commit/87cb6c5abd5097096e2b2b54dfd8ec7ba9ff134f) papermc: fix update script
* [`41452802`](https://github.com/NixOS/nixpkgs/commit/41452802cb03853e797d0ecc3621cb71bf0be21f) treewide: fix all obviously wrong mkEnableOptions
* [`6f04c3a0`](https://github.com/NixOS/nixpkgs/commit/6f04c3a01a95284f6b5f7d5088319787a00edc41) python3Packages.pyproj: fix test failure caused by EPSG DB update
* [`428940aa`](https://github.com/NixOS/nixpkgs/commit/428940aa9a38f1c99674ba77e3cf75f7a8d2a6e3) python3Packages.pyproj: alphabetical re-ordering of function parameters
* [`35d3f8e1`](https://github.com/NixOS/nixpkgs/commit/35d3f8e1c2bd446752014833a695b53c8d8d235f) mueval: remove check
* [`617a79dd`](https://github.com/NixOS/nixpkgs/commit/617a79dd1078d2b61a66e4e81294038dc0c7e056) doc/release-notes: repalce security.pam.enableSSHAgentAuth with security.pam.sshAgentAuth.enable
* [`c429fa2f`](https://github.com/NixOS/nixpkgs/commit/c429fa2ffa21229eeadbe37c11a47aff35f53ce0) bazel_7: 7.1.0 -> 7.1.2 ([nixos/nixpkgs⁠#314279](https://togithub.com/nixos/nixpkgs/issues/314279))
* [`ae5ef9e6`](https://github.com/NixOS/nixpkgs/commit/ae5ef9e6d054c8115c7f4f3342e73c71e7aacbdc) retroarch-assets: 1.17.0-unstable-2024-04-24 -> 1.19.0-unstable-2024-05-30
* [`e7ad6bf7`](https://github.com/NixOS/nixpkgs/commit/e7ad6bf7a1e0d9af2ed9c221d788d73ce22bcb6f) libretro.play: unstable-2024-05-27 -> unstable-2024-05-28
* [`72650ede`](https://github.com/NixOS/nixpkgs/commit/72650edecf7c16f21dc7940768fbfeb81be8e0ff) simplex-chat-desktop: 5.7.4 -> 5.7.5
* [`fb8ffb1d`](https://github.com/NixOS/nixpkgs/commit/fb8ffb1d4cc60e98f1ccde9c2593cd54652679d6) libretro.pcsx-rearmed: unstable-2024-05-20 -> unstable-2024-05-30
* [`5417906f`](https://github.com/NixOS/nixpkgs/commit/5417906fa0bd6bdc06bb48f99e16f5dec07c6473) nix-direnv: 3.0.4 -> 3.0.5
* [`ab6157cb`](https://github.com/NixOS/nixpkgs/commit/ab6157cb934fb6fc26d20646a04bc176c70d55e0) python311Packages.graph-tool: 2.65 -> 2.68
* [`200514ec`](https://github.com/NixOS/nixpkgs/commit/200514ec0b45a21387d49ff2fa8ac99c71270cd3) hugo: 0.126.2 -> 0.126.3
* [`809ee9ba`](https://github.com/NixOS/nixpkgs/commit/809ee9baa298af79e9ca71e40c63695463ffc6fe) libretro.mame2003: unstable-2024-05-27 -> unstable-2024-06-01
* [`fe6b43e3`](https://github.com/NixOS/nixpkgs/commit/fe6b43e366a1520179fb75f924f29770f0277e1b) libretro.ppsspp: unstable-2024-05-28 -> unstable-2024-06-03
* [`22194659`](https://github.com/NixOS/nixpkgs/commit/2219465989823c1652f0c32926d89d0824f076d2) libretro.mame2003-plus: unstable-2024-05-28 -> unstable-2024-05-29
* [`56cf1db8`](https://github.com/NixOS/nixpkgs/commit/56cf1db80834df347426d5f52d8bc1aae62cd20e) fnm: 1.36.0 -> 1.37.0
* [`69deec43`](https://github.com/NixOS/nixpkgs/commit/69deec439c0a5576fbb0d9b44d816f7a844c3749) clang-uml: init at 0.5.1
* [`4fdaae34`](https://github.com/NixOS/nixpkgs/commit/4fdaae34eb6b67b75347dee343974d58b0e0546d) whitebox_tools: 2.2.0 -> 2.4.0
* [`eb17962e`](https://github.com/NixOS/nixpkgs/commit/eb17962e97eaf13c322b4d1bd2773ba061de6b98) whitebox-tools: cleanup
* [`9f5f2746`](https://github.com/NixOS/nixpkgs/commit/9f5f2746ade58a454b513118644c519854e36f5d) ananicy-cpp: move to by-name
* [`e634c822`](https://github.com/NixOS/nixpkgs/commit/e634c822b5e754171dd459cf88a2e950e87c102b) maintainers: add Golo300
* [`f65bd7b7`](https://github.com/NixOS/nixpkgs/commit/f65bd7b775d459bfa55f9535f41c1b3324d70b8c) ananicy-cpp: enable regex support
* [`1501a531`](https://github.com/NixOS/nixpkgs/commit/1501a531dbe77d4bf0bddc96cfc2fa805315dc71) ananicy-cpp: add johnrtitor as maintainer
* [`10a18145`](https://github.com/NixOS/nixpkgs/commit/10a18145b5b7ae60ae08682f97f1aa3832cd2cdc) fits-cloudctl: 0.12.19 -> 0.12.20
* [`cd66ee7b`](https://github.com/NixOS/nixpkgs/commit/cd66ee7bc746aba4a0a5303791d496f01bfc6fd4) httpx: 1.6.2 -> 1.6.3
* [`9b8f3f4a`](https://github.com/NixOS/nixpkgs/commit/9b8f3f4ab19572d66c72686e527960e4141cab68) gef: 2024.01 -> 2024.06
* [`f5e5ce66`](https://github.com/NixOS/nixpkgs/commit/f5e5ce66efff5f6f710e306183b5ff38b60cd57d) git-cliff: 2.2.2 -> 2.3.0
* [`128a21ae`](https://github.com/NixOS/nixpkgs/commit/128a21ae7aa246d01b18b3452bf8c5c27ad5c5e8) libretro.fbneo: unstable-2024-05-28 -> unstable-2024-06-02
* [`711884c5`](https://github.com/NixOS/nixpkgs/commit/711884c56608d76285b681c5024818e5ddc76d05) pnpm_{8,9}: remove uneeded binary files from src
* [`c704c029`](https://github.com/NixOS/nixpkgs/commit/c704c029566aaf525d949b54b8a8d85bb6aab29b) doc/javascript: pnpm: mention lack of monorepos/workspaces support
* [`514fd17e`](https://github.com/NixOS/nixpkgs/commit/514fd17eff435f458c5189556f5d4e74404bfee9) izrss: 0.0.6 -> 0.1.0
* [`2d2e0b12`](https://github.com/NixOS/nixpkgs/commit/2d2e0b127e5732da453e738feaa9179e38ff4ee9) top-level/release-haskell.nix: test more attributes with GHC 9.8
* [`a88fb925`](https://github.com/NixOS/nixpkgs/commit/a88fb925bb26327644e0877e27720fadfd471925) nixos/installation-cd-plasma5: don't use alias for konsole
* [`1c2132f7`](https://github.com/NixOS/nixpkgs/commit/1c2132f7146a3f94370ae1e70f39b9a69015a3d9) nixos/installation-cd-plasma5: fix even more aliases
* [`0541ecf3`](https://github.com/NixOS/nixpkgs/commit/0541ecf38104477926574d7932c526b6625ace14) bitwarden-menu: refactor
* [`e5504d52`](https://github.com/NixOS/nixpkgs/commit/e5504d52eb880a2fbd746b9d0c1e2c9cb4017c8f) maintainers: update email for lelgenio
* [`d768cbfa`](https://github.com/NixOS/nixpkgs/commit/d768cbfa4c31f0d5fcd31263dca2e7e70453e5c2) volatility3: refactor
* [`7a44183c`](https://github.com/NixOS/nixpkgs/commit/7a44183c8698e8254e6921032381363fe367a71e) gitea: build from source
* [`fbe20f60`](https://github.com/NixOS/nixpkgs/commit/fbe20f603bb62789d67a019c3ab9a18caae50529) gitea: move to by-name
* [`e1a657b7`](https://github.com/NixOS/nixpkgs/commit/e1a657b7521da01ba4000c75f1e524e977e122dd) python311Packages.nodeenv: refactor
* [`5208f336`](https://github.com/NixOS/nixpkgs/commit/5208f33633beae825d185e2e205c09777dfd89d7) halo: 2.15.2 -> 2.16.0
* [`adca0283`](https://github.com/NixOS/nixpkgs/commit/adca0283c21390b700b0c4099427f871079f44a7) pfetch-rs: 2.9.1 -> 2.9.2
* [`df8c4c6b`](https://github.com/NixOS/nixpkgs/commit/df8c4c6b1d0114cb5e29fe93e4e5777c72a4a0bd) hishtory: 0.294 -> 0.295
* [`c234b47c`](https://github.com/NixOS/nixpkgs/commit/c234b47cc71ff528357f0d60d5153432fc4a1a2a) radicale: 3.2.0 -> 3.2.1
* [`5a010b30`](https://github.com/NixOS/nixpkgs/commit/5a010b3067da04e3aade7a40acd6c6ac9ec0eba4) opentofu: 1.7.1 -> 1.7.2
* [`b3f36c3b`](https://github.com/NixOS/nixpkgs/commit/b3f36c3b58ae028cca34720644a1e2bcbea6cfc8) qutebrowser: 3.1.0 -> 3.2.0
* [`bd734c35`](https://github.com/NixOS/nixpkgs/commit/bd734c35d8f4abb0746d00592e4987950de217be) vmware-horizon-client: fix URL in update script
* [`1a8183ee`](https://github.com/NixOS/nixpkgs/commit/1a8183eebb4f6e55449b3d193695d0e4294b362d) vscode-extensions.chenglou92.rescript-vscode: 1.50.0 -> 1.52.0
* [`cc5a80f5`](https://github.com/NixOS/nixpkgs/commit/cc5a80f5cddf2d831217924f140152fc3c434f04) stash: init at 0.25.1
* [`5a89767c`](https://github.com/NixOS/nixpkgs/commit/5a89767c33b163ebfe182aed5d111ff5318c515d) renode-dts2repl: 0-unstable-2024-05-29 -> 0-unstable-2024-05-31
* [`6659fa37`](https://github.com/NixOS/nixpkgs/commit/6659fa37f92c35974ef264a78816122032078229) renode-unstable: 1.15.0+20240517gitf683c4f59 -> 1.15.0+20240603gitf830e6345
* [`9742a3b6`](https://github.com/NixOS/nixpkgs/commit/9742a3b6f51c9fe31eb9296ba94dc62431a9b225) svlint: 0.9.2 -> 0.9.3
* [`6d8e514c`](https://github.com/NixOS/nixpkgs/commit/6d8e514c7854a0ae69c04b54d442d5019bb152b5) svls: 0.2.11 -> 0.2.12
* [`52c000b9`](https://github.com/NixOS/nixpkgs/commit/52c000b937a75ce49a8975d94483cd6e6324e732) trivy: 0.51.4 -> 0.52.0
* [`95a07b0b`](https://github.com/NixOS/nixpkgs/commit/95a07b0be28e4698eeda7a3d9a10bb5541663063) difftastic: fix build on x86_64-darwin
* [`aa10d70b`](https://github.com/NixOS/nixpkgs/commit/aa10d70b2199855fa9d45b8a2eb535b463a86207) uuu: 1.5.181 -> 1.5.182
* [`18146b32`](https://github.com/NixOS/nixpkgs/commit/18146b325a9e0c19174af9b9069be8b5ddfa3ba8) kdePackages.kdenlive: add missed dependency
* [`fd87dea3`](https://github.com/NixOS/nixpkgs/commit/fd87dea36de95a7831984473c5316a3f29144a7e) snx-rs: fix license
* [`3123ed53`](https://github.com/NixOS/nixpkgs/commit/3123ed5324e9c879dfcf5857900ee287211fe127) hyperspeedcube: init at 1.0.6
* [`500618d2`](https://github.com/NixOS/nixpkgs/commit/500618d21f6d44651e5a06a9ae1696840a3da078) jan: 0.4.14 -> 0.5.0
* [`e910454d`](https://github.com/NixOS/nixpkgs/commit/e910454dc80be851a4e1fa815b1e8a353fbe96a1) nixpacks: 1.23.0 -> 1.24.1
* [`865db850`](https://github.com/NixOS/nixpkgs/commit/865db850d7b5b0b31dad64b7262b0b5f6d86b705) libretro.bsnes: unstable-2024-05-17 -> unstable-2024-05-31
* [`19c9241c`](https://github.com/NixOS/nixpkgs/commit/19c9241c0bc17a13cd649c73c3302fda58452d4c) libretro.flycast: unstable-2024-05-27 -> unstable-2024-06-02
* [`8fd92a1d`](https://github.com/NixOS/nixpkgs/commit/8fd92a1dc29c6f81e7ed6605c37d1a00a0557adc) python312Packages.pytrydan: 0.6.1 -> 0.7.0
* [`f0c031cc`](https://github.com/NixOS/nixpkgs/commit/f0c031cc6711a864e72f7bf611dc3c8d39caa23d) libretro.fceumm: unstable-2024-05-27 -> unstable-2024-05-29
* [`0ff6a8b8`](https://github.com/NixOS/nixpkgs/commit/0ff6a8b88c94d8d60c0da4bba7f4d544edabe588) paperless-ngx: 2.8.6 -> 2.9.0
* [`bc72d82b`](https://github.com/NixOS/nixpkgs/commit/bc72d82bbdc427d4eff7cecc2c8fddcd9d86eb7a) neomutt: 20231221 -> 20240425
* [`b0e8aea4`](https://github.com/NixOS/nixpkgs/commit/b0e8aea401acda527de710902fce523140d33574) cemu: fix build
* [`46346347`](https://github.com/NixOS/nixpkgs/commit/46346347cbb93180809fd59d1d2a0270f8bfd50f) ulauncher: add semver
* [`f878224f`](https://github.com/NixOS/nixpkgs/commit/f878224fd74a4830935a592815506b50184027a4) libretro.swanstation: unstable-2024-05-27 -> unstable-2024-05-30
* [`36e8f6d7`](https://github.com/NixOS/nixpkgs/commit/36e8f6d73b9c48b37f9f8e2d4731f7602e52f565) libretro.gambatte: unstable-2024-05-17 -> unstable-2024-06-02
* [`a1d2fb30`](https://github.com/NixOS/nixpkgs/commit/a1d2fb30d064d294d92e01e271cc82d98b0a6f51) mill: use finalAttrs
* [`5780590f`](https://github.com/NixOS/nixpkgs/commit/5780590f503cde0059483d95c5a607bc784fa894) libretro.dosbox-pure: unstable-2024-05-20 -> unstable-2024-06-03
* [`a79f4a91`](https://github.com/NixOS/nixpkgs/commit/a79f4a9161f86df8322baf6e6a7336c306ef7378) angie: 1.5.1 -> 1.5.2
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
