### PR TITLE
niv home-manager: update 9b53a10f -> 3d65009e

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -41,10 +41,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "9b53a10f4c91892f5af87cf55d08fba59ca086af",
-        "sha256": "1hn0fnrczpiccaiqrdil5zvr2hvxqnwa9nkfg5sd7prfjyjh8bay",
+        "rev": "3d65009effd77cb0d6e7520b68b039836a7606cf",
+        "sha256": "1vfaiyh5k634m5jmc2fj8k2fzy85f7v5l55zhi2kx200sy3icgsb",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/9b53a10f4c91892f5af87cf55d08fba59ca086af.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/3d65009effd77cb0d6e7520b68b039836a7606cf.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@9b53a10f...3d65009e](https://github.com/nix-community/home-manager/compare/9b53a10f4c91892f5af87cf55d08fba59ca086af...3d65009effd77cb0d6e7520b68b039836a7606cf)

* [`83bfe1ba`](https://github.com/nix-community/home-manager/commit/83bfe1bac8e0d930f36cee6874bd17e77c8754d1) nix-gc: add `persistent` option ([nix-community/home-manager⁠#5490](https://togithub.com/nix-community/home-manager/issues/5490))
* [`07b2c41d`](https://github.com/nix-community/home-manager/commit/07b2c41d2df2878a5c71229a66fb1f8ccef71c47) ci: bump all actions versions ([nix-community/home-manager⁠#5496](https://togithub.com/nix-community/home-manager/issues/5496))
* [`1a577c13`](https://github.com/nix-community/home-manager/commit/1a577c135cad84eb0cd5a922efe2de9cc467772a) ci/labeler: upgrade to v5 format
* [`2cacdd6a`](https://github.com/nix-community/home-manager/commit/2cacdd6a27477f1fa46b7026dd806de30f164d3b) ci/labeler: fix upgrade to v5 format
* [`a7117efb`](https://github.com/nix-community/home-manager/commit/a7117efb3725e6197dd95424136f79147aa35e5b) accounts.email: add clarifying documentation
* [`8f1b183c`](https://github.com/nix-community/home-manager/commit/8f1b183c91c65c81131bbf7d76f0d845580c60bd) fcitx5: fix tests
* [`8bdb74ea`](https://github.com/nix-community/home-manager/commit/8bdb74eaffa21cfce02d7d5d55cbde5524d50b84) docs: add redirect from the previous options.html
* [`885c0371`](https://github.com/nix-community/home-manager/commit/885c037109fdbc05f37da8fa1b81c5a2f91f718b) flake.lock: Update
* [`8a20efbb`](https://github.com/nix-community/home-manager/commit/8a20efbb00b096d7d30211cd306cc360c8eba38c) hyprland: install xwayland if enabled
* [`3d65009e`](https://github.com/nix-community/home-manager/commit/3d65009effd77cb0d6e7520b68b039836a7606cf) waybar: remove modules-* from defaults
