### PR TITLE
niv nixpkgs: update cd7ec241 -> 311a2516

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "cd7ec2419a9a98e9119d64f5b0cbaa069e53c298",
-        "sha256": "15m5k51g5lnk49dfm7gfisgnz21lknzl3hljgzx7dhyb1v2ljp6q",
+        "rev": "311a2516f09102b069951a94a15d61f7a1772427",
+        "sha256": "0jxn47a2d67pcmkjir0m9i8swidyyd63s4sziq7fm2xwjy6j6iq6",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/cd7ec2419a9a98e9119d64f5b0cbaa069e53c298.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/311a2516f09102b069951a94a15d61f7a1772427.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@cd7ec241...311a2516](https://github.com/nixos/nixpkgs/compare/cd7ec2419a9a98e9119d64f5b0cbaa069e53c298...311a2516f09102b069951a94a15d61f7a1772427)

* [`912071c4`](https://github.com/NixOS/nixpkgs/commit/912071c4cafcf09ca99b7865f82ba3152648960f) croaring: 0.2.61 -> 2.0.3
* [`e690006e`](https://github.com/NixOS/nixpkgs/commit/e690006ede3afabff0835331fd9000464116a652) smc-chilanka: init at 1.7
* [`0b5b3863`](https://github.com/NixOS/nixpkgs/commit/0b5b3863fafa019484e6b6d3d5f58b8fef4a1de6) inspec: 5.21.29 -> 6.6.0
* [`129208c5`](https://github.com/NixOS/nixpkgs/commit/129208c5f73d79b4f65dbb13165e9112f726fed6) bleachbit: 4.4.0 -> 4.6.0
* [`0347fe6d`](https://github.com/NixOS/nixpkgs/commit/0347fe6daa7ac992b955b3695683ff90c8f87079) scalafmt: 3.7.9 -> 3.7.17
* [`eb3e05dc`](https://github.com/NixOS/nixpkgs/commit/eb3e05dc8c6c76978f05f80183477c2de22621ba) phantomsocks: unstable-2023-04-05 -> unstable-2023-11-30
* [`3bd8f63b`](https://github.com/NixOS/nixpkgs/commit/3bd8f63b7b51e28e41b538c9a21c349f47d382ae) rgp: 1.15.1 -> 2.0
* [`01a2741e`](https://github.com/NixOS/nixpkgs/commit/01a2741e7ad33b86e0c8533568a85666af70a4bc) k2pdfopt: 2.53 -> 2.55
* [`58ff8a12`](https://github.com/NixOS/nixpkgs/commit/58ff8a126c5de1f23663fa07b5942d16c5940c7f) vimPlugins/copilot-vim: specify license (unfree)
* [`0fff2137`](https://github.com/NixOS/nixpkgs/commit/0fff21370261f89be3c4d4636b43c5c9a1261f2b) neocities: init at 0.0.18
* [`a9119a21`](https://github.com/NixOS/nixpkgs/commit/a9119a21ee8895da47d68a6b35fe7224fe56fd17) thonny: add dependency dbus-next
* [`0cc0698b`](https://github.com/NixOS/nixpkgs/commit/0cc0698bef6ca2606afa1605b0b3158550b88390) fpm: 1.13.0 -> 1.15.1
* [`0dfdc9a8`](https://github.com/NixOS/nixpkgs/commit/0dfdc9a874789b2848eb9ccb3aa4eafb5da6be7b) gfxreconstruct: wrap properly
* [`110df92d`](https://github.com/NixOS/nixpkgs/commit/110df92da3015d14cf303419e524afd21df94d2d) latte-dock: unstable-2023-03-31 -> unstable-2024-01-31
* [`4f6ceb1a`](https://github.com/NixOS/nixpkgs/commit/4f6ceb1ac7357713eb00aa3731eb8938dddba963) swaywsr: 1.1.1 -> 1.3.0
* [`40c0cfa3`](https://github.com/NixOS/nixpkgs/commit/40c0cfa30b2e65649fa76eccccce25d638d6db0c) maintainers: add modderme123
* [`1bd37c81`](https://github.com/NixOS/nixpkgs/commit/1bd37c817537596d5bcf5d47a0b9c0bad5bb776a) spoof: init at 2.0.4
* [`60e5fc27`](https://github.com/NixOS/nixpkgs/commit/60e5fc2781c4b871740bb2e0e9ae86a1da21f6a6) leiningen: 2.10.0 -> 2.11.2
* [`be2f611e`](https://github.com/NixOS/nixpkgs/commit/be2f611e26db4b765811ea8c21880678f281e50c) gitoxide: Add shell completions for ein
* [`097ce68c`](https://github.com/NixOS/nixpkgs/commit/097ce68cc6aebee63dac435d0152a1d104854762) openzwave: 1.6 -> 1.6-unstable-2022-11-17
* [`f9844ba1`](https://github.com/NixOS/nixpkgs/commit/f9844ba120ada24b4a2dc0da9aa66bf38479ddb3) rusty-psn: 0.3.0 -> 0.3.7
* [`e9a83b6e`](https://github.com/NixOS/nixpkgs/commit/e9a83b6e25e874b5a497d94401f91b0b7820c890) deltachat-rpc-server: init at 1.136.3
* [`dbc26271`](https://github.com/NixOS/nixpkgs/commit/dbc26271c2791fd0d01e38c8112a2e7d8330165b) maintainers: add caralice
* [`2dfbaf98`](https://github.com/NixOS/nixpkgs/commit/2dfbaf98530864ec36c3f6b00408d4653fb9d5f6) maintainers: add vasissualiyp
* [`c1570f63`](https://github.com/NixOS/nixpkgs/commit/c1570f6341b640454d56683a961273ad2d454ce2) plasma5Packages.plasma-firewall: init
* [`0f285b40`](https://github.com/NixOS/nixpkgs/commit/0f285b40021e15c298dd190982f45800f15549e4) pybibget: init at 0.1.0
* [`dd37bb14`](https://github.com/NixOS/nixpkgs/commit/dd37bb14b9f03ef7f91a7f6be9b3a89ab8745f4b) python312Packages.configparser: 6.0.1 -> 7.0.0
* [`a1e68fe2`](https://github.com/NixOS/nixpkgs/commit/a1e68fe201e261fc68678aa074e7c5806b55a05e) maintainers: add timhae
* [`0abce575`](https://github.com/NixOS/nixpkgs/commit/0abce57578930450ab173e20121d9562aa3bef96) impression: 3.1.0 -> 3.2.0
* [`31c9eec0`](https://github.com/NixOS/nixpkgs/commit/31c9eec06175c493dcc6efdb4be3722abb93b0c0) nixos/aria2: add settings option
* [`1389666a`](https://github.com/NixOS/nixpkgs/commit/1389666a117fd1698f388948ca506423c7df9870) nixos/aria2: add test
* [`36b16a08`](https://github.com/NixOS/nixpkgs/commit/36b16a08fe7e63698e121dce2adf6ff5d1c0a4e9) cups: 2.4.7 -> 2.4.8
* [`4559e354`](https://github.com/NixOS/nixpkgs/commit/4559e354bf99af4a50e22e00a24e1b078a8588c2) ell: 0.64 -> 0.65
* [`c8723bd5`](https://github.com/NixOS/nixpkgs/commit/c8723bd59aed61c75035179cf855dce10f8794eb) jasper: 4.2.3 -> 4.2.4
* [`ea9b8be1`](https://github.com/NixOS/nixpkgs/commit/ea9b8be175a5ce324e60ebcc85b581ae2d36b9e6) libgpg-error: 1.48 -> 1.49
* [`abe7e6ea`](https://github.com/NixOS/nixpkgs/commit/abe7e6ea0342454ce79a3edf8f267d618910cc6b) srgn: init at 0.12.0
* [`70386b02`](https://github.com/NixOS/nixpkgs/commit/70386b021357653aa44cd3f514398e41db2c64a3) kernelPatches.rust_1_77-6_8,kernelPatches.rust_1_77-6_9: update
* [`7297ffe6`](https://github.com/NixOS/nixpkgs/commit/7297ffe63450a72302a667b01e2f63cc652ff5c7) kernelPatches.rust_1_78: init
* [`09cb8b1c`](https://github.com/NixOS/nixpkgs/commit/09cb8b1c81d45ce135eafd85b1e927b812870553) systemd: fix build in macOS sandbox
* [`3e86aba9`](https://github.com/NixOS/nixpkgs/commit/3e86aba9d2dca5cbfa5f9f16e8942d5c0f2781e1) nixos/adguardhome: run --check-config before merging
* [`0a0b584c`](https://github.com/NixOS/nixpkgs/commit/0a0b584cde309f7cf5e6d9903bec6c906abb94cb) bundler: 2.5.9 -> 2.5.10
* [`4720fb16`](https://github.com/NixOS/nixpkgs/commit/4720fb16c30aaaa053ae38dc7b122394f8bc38b6) ruby.rubygems: 3.5.9 -> 3.5.10
* [`a086a669`](https://github.com/NixOS/nixpkgs/commit/a086a6698cfd6adb9b4c5195178ea58576e678e8) SDL2: 2.30.2 -> 2.30.3
* [`e6680013`](https://github.com/NixOS/nixpkgs/commit/e66800136473f8a4713b91c53e6aa0b65a6d95ca) valgrind: 3.22.0 -> 3.23.0
* [`a4373b21`](https://github.com/NixOS/nixpkgs/commit/a4373b21daaa1d20afbe22db3ae87d833344076f) python311Packages.plotly: 5.21.0 -> 5.22.0
* [`14c3b266`](https://github.com/NixOS/nixpkgs/commit/14c3b26610dcc86311393a2c0e3f01df048127fd) boehmgc: disable tests on aarch64-linux
* [`c52b1240`](https://github.com/NixOS/nixpkgs/commit/c52b12407fda6578ea35927fe569fa44a4aca127) python311Packages.merge3: 0.0.14 -> 0.0.15
* [`0cee1346`](https://github.com/NixOS/nixpkgs/commit/0cee134634cef06e17e88f3999243b2d89f17264) buildMozillaMach: add patches for LLVM 18 and Rust 1.78
* [`23d4f834`](https://github.com/NixOS/nixpkgs/commit/23d4f834536bbc48503051d3dcd1984bcc67f734) cargo,clippy,rustc,rustfmt: 1.77.2 -> 1.78.0
* [`5000178a`](https://github.com/NixOS/nixpkgs/commit/5000178a97c807e0e81750046e033d9e14d895bd) rdkafka: 2.3.0 -> 2.4.0
* [`b281d60c`](https://github.com/NixOS/nixpkgs/commit/b281d60c481374f33abae51507bc962eff451674) protobuf-c: unstable-2023-07-08 -> 1.5.0
* [`bb75cbc2`](https://github.com/NixOS/nixpkgs/commit/bb75cbc27d15f483a5fbdb68d254293054012ab2) swig2: fix cross-building
* [`651971f2`](https://github.com/NixOS/nixpkgs/commit/651971f2f34fd6e16ae68ea168a839139436ac9e) cmake: 3.29.2 -> 3.29.3
* [`a5772002`](https://github.com/NixOS/nixpkgs/commit/a577200220051578df938a199e4cb80f3e7e1478) kddockwidgets: 2.0.0 -> 2.1.0
* [`7aef1dc2`](https://github.com/NixOS/nixpkgs/commit/7aef1dc247f99ad5ed236e3b88cd451b235f771d) maintainers: add joanmassachs
* [`e94abc72`](https://github.com/NixOS/nixpkgs/commit/e94abc723e30fdea8379f228467a7005476fd853) xkb-switch-i3: 1.8.5 -> 2.0.1
* [`0b3332c6`](https://github.com/NixOS/nixpkgs/commit/0b3332c695cedb53fca263af914b8d3c26d6c74f) python311Packages.azure-storage-queue: 12.9.0 -> 12.10.0
* [`81a58be2`](https://github.com/NixOS/nixpkgs/commit/81a58be20b4634615d17df3466ba65714a24d626) nixos/tailscale: add extraSetFlags to configure daemon
* [`6e51504c`](https://github.com/NixOS/nixpkgs/commit/6e51504c791f11895e8e05a8204e127851c6a5b6) python311Packages.azure-servicebus: 7.12.1 -> 7.12.2
* [`97faf3a1`](https://github.com/NixOS/nixpkgs/commit/97faf3a16d67dca8526e78a270429329e8b46528) edge-runtime: remove comment incorrectly indicating auto-generated
* [`5e950880`](https://github.com/NixOS/nixpkgs/commit/5e9508802dd7572031c7aa892c643ff596a2a408) treewide: mark librusty_v8 as binaryNativeCode
* [`4040c21e`](https://github.com/NixOS/nixpkgs/commit/4040c21ed8e7196b1883ce4672993109cbc04871) s2n-tls: 1.4.12 -> 1.4.14
* [`65e766bd`](https://github.com/NixOS/nixpkgs/commit/65e766bdd1e361bbe0c9a40d09ed947499212e8a) python311Packages.datasets: 2.19.0 -> 2.19.1
* [`31bf40d2`](https://github.com/NixOS/nixpkgs/commit/31bf40d20a92bc470126d3195e8d70be540cf67c) python311Packages.itemadapter: 0.8.0 -> 0.9.0
* [`637c1c82`](https://github.com/NixOS/nixpkgs/commit/637c1c82bfb005a48d2a0e9defe2c93b95d8f71d) texlivePackages: use proper multioutput derivations
* [`da9e5f85`](https://github.com/NixOS/nixpkgs/commit/da9e5f858cf895a36b68fdcf512b3898072ccfc5) linuxPackages.r8168: 8.052.01 -> 8.053.00, remove broken
* [`705099d1`](https://github.com/NixOS/nixpkgs/commit/705099d123339e2cc874344beb4b85deb84e096a) python311Packages.patiencediff: 0.2.14 -> 0.2.15
* [`493d74ef`](https://github.com/NixOS/nixpkgs/commit/493d74ef4a597b7c00bb2db4134f8912df0697f1) ninja: migrate to pkgs/by-name
* [`4852dc64`](https://github.com/NixOS/nixpkgs/commit/4852dc647998d029dce997e217063a2920f40d00) ninja: 1.11.1 -> 1.12.0
* [`36d4305d`](https://github.com/NixOS/nixpkgs/commit/36d4305d4079f68c015af592e4cb93f44d2808cf) meson: add patch to allow building via ninja 1.12
* [`c0bb6f9c`](https://github.com/NixOS/nixpkgs/commit/c0bb6f9c81a800475b27e851a5137f5cbd4f0c37) ninja: 1.12.0 -> 1.12.1
* [`598fca77`](https://github.com/NixOS/nixpkgs/commit/598fca77bdee47b44bf19597d3630ec633a85004) libopenmpt: 0.7.6 -> 0.7.7
* [`0a58cfd6`](https://github.com/NixOS/nixpkgs/commit/0a58cfd63c0c8dbadaa59f6664388eb422b065c0) Update pkgs/os-specific/linux/r8168/default.nix
* [`b757e385`](https://github.com/NixOS/nixpkgs/commit/b757e385e62e28648845ff2211db8f3de6b02a49) emilua: use mesonCheckFlags
* [`cd98e378`](https://github.com/NixOS/nixpkgs/commit/cd98e37806dd7398524bcfeb0146d7ed9b571d82) folks: use mesonCheckFlags
* [`06a15575`](https://github.com/NixOS/nixpkgs/commit/06a15575b068d1e7290bf9bf0e4c598c80cf4d97) glib: use mesonCheckFlags
* [`e5b250b3`](https://github.com/NixOS/nixpkgs/commit/e5b250b3c28184ef6ee1d09cc7846aec5043218e) fix: systemd build flag combinations
* [`78da6b37`](https://github.com/NixOS/nixpkgs/commit/78da6b378b84f3217890f2b1db98f8a838ed8375) liblxi: fix darwin build, use finalAttrs
* [`4dec85d6`](https://github.com/NixOS/nixpkgs/commit/4dec85d68b81ed971e7f2953cfea895f0f0c0c2c) meson.setupHook: always set --print-errorlogs
* [`5a1987d3`](https://github.com/NixOS/nixpkgs/commit/5a1987d3818df8bf06a986dc7437e7a3a6ab2869) deterministic-uname: add support for FreeBSD
* [`a4d0d49a`](https://github.com/NixOS/nixpkgs/commit/a4d0d49a52e422bb95d5ce827f972539bcd12b63) libtiff: Add ZSTD support
* [`67641d05`](https://github.com/NixOS/nixpkgs/commit/67641d0589ea6a3ab821cae0278fc2c013940a3a) wafHook: don't add cross compilation flags
* [`eb7fd13a`](https://github.com/NixOS/nixpkgs/commit/eb7fd13a93f04e89405eb72dc8b6ddee44996bb3) ncurses: Build standard terminfo dirs into static ncurses
* [`b24bf79b`](https://github.com/NixOS/nixpkgs/commit/b24bf79b6c2b37304739e4587bc50d2ab6c4d5ac) tpm2-tss: 4.1.1 -> 4.1.2
* [`bb8e9daa`](https://github.com/NixOS/nixpkgs/commit/bb8e9daada938acd402eb9a25a22efe592789363) busybox: disable tc
* [`87d17e20`](https://github.com/NixOS/nixpkgs/commit/87d17e20381033671244d905efad9992eba1a285) linuxHeaders: 6.7 -> 6.9
* [`3f878c71`](https://github.com/NixOS/nixpkgs/commit/3f878c71e15b53d8f817bb7aa95b5dce1b1071e1) qemu: 8.2.4 -> 9.0.0
* [`f9ebf19e`](https://github.com/NixOS/nixpkgs/commit/f9ebf19e8b18f0c576701ae1f602c44276d0dce5) relic: 7.6.2 -> 8.0.1
* [`6eb8d097`](https://github.com/NixOS/nixpkgs/commit/6eb8d0976c9eb3880cac8b7163a407dcf1161ab1) starpls-bin: init at 0.1.14
* [`cfaa0292`](https://github.com/NixOS/nixpkgs/commit/cfaa0292b9214c0f9e1b6e2b5617c7c45fd2dd5f) symfony-cli: 5.8.17 -> 5.8.19
* [`6faa002d`](https://github.com/NixOS/nixpkgs/commit/6faa002dc17370e1de7fc8412e409d69cf5af18e) ghostscript: 10.02.1 -> 10.03.0
* [`7a7de0be`](https://github.com/NixOS/nixpkgs/commit/7a7de0beb0b930f4c2b7e6c01488b0fa0cc19d9b) kexec-tools: pull upstream fix for binutils-2.42
* [`aadbb9eb`](https://github.com/NixOS/nixpkgs/commit/aadbb9eb6fd266a59bcfe893e4d167c2b7ea792e) vim: 9.1.0377 -> 9.1.0412
* [`93fa7170`](https://github.com/NixOS/nixpkgs/commit/93fa7170872d7638f7adf25dd3b526f918c16b1a) git: 2.44.1 -> 2.45.1
* [`f3692ef6`](https://github.com/NixOS/nixpkgs/commit/f3692ef627883be00dd6c4b3a4d45d2c21af18b7) git: add passthru.update script
* [`0c34636a`](https://github.com/NixOS/nixpkgs/commit/0c34636a5690cf8d75ecbab62d41179c56571f79) make-binary-wrapper: add cc to propagatedBuildInputs
* [`e49098e9`](https://github.com/NixOS/nixpkgs/commit/e49098e99d6925e5f10a593e44105c5dbd43c9fe) llvmPackages: add support for native FreeBSD
* [`074b0897`](https://github.com/NixOS/nixpkgs/commit/074b0897bc0feb2c36c38a203821bd3b3c96406f) ncurses: include release number in version
* [`3095f2de`](https://github.com/NixOS/nixpkgs/commit/3095f2de2e79eb1ca9df2e78ab01a3ae423d4699) llvmPackages: move comments in common/llvm/default.nix outside strings
* [`497d4b38`](https://github.com/NixOS/nixpkgs/commit/497d4b38369a099f9d056145bd2fb46e097daf1e) meson: fix build for native FreeBSD
* [`fc246ead`](https://github.com/NixOS/nixpkgs/commit/fc246ead19bebd1c42eba3e1f0b82398b8852faa) bash: Fix build on FreeBSD cross
* [`4816a73b`](https://github.com/NixOS/nixpkgs/commit/4816a73bb53c7b11ee180646ca30b9f16ba4e084) rustPlatform: --frozen -> --offline
* [`48028914`](https://github.com/NixOS/nixpkgs/commit/480289147c730acf599d5d493a500e65bb5a6368) gdk-pixbuf: 2.42.11 -> 2.42.12
* [`7e5879ff`](https://github.com/NixOS/nixpkgs/commit/7e5879ff42e61ab4247916288864dda367705e79) bash-completion: 2.13.0 -> 2.14.0
* [`b08a9155`](https://github.com/NixOS/nixpkgs/commit/b08a915532fc42c71253c4cf261d13bec2ef298a) treewide: drop workarounds for cargo --frozen
* [`79ca5a6f`](https://github.com/NixOS/nixpkgs/commit/79ca5a6f55252da38530c00038cb7cc348b746b7) python311Packages.curio: disable flaky test
* [`19e30cb9`](https://github.com/NixOS/nixpkgs/commit/19e30cb9633c693c129bd669f4d24928a2289070) redis: 7.2.4 -> 7.2.5
* [`3e05406f`](https://github.com/NixOS/nixpkgs/commit/3e05406f80dce17c5339be98173a11da18b5c786) luajit_2_0: 2.0.1693340858 -> 2.0.1713483859
* [`42574383`](https://github.com/NixOS/nixpkgs/commit/4257438318965115e911141fd92536f05bc3b838) luajit_2_1: 2.1.1693350652 -> 2.1.1713773202
* [`382c3ce5`](https://github.com/NixOS/nixpkgs/commit/382c3ce5d01391c2820139a3266e8b3c981ae81c) pkgsStatic.polkit: mark unsupported
* [`1646a97b`](https://github.com/NixOS/nixpkgs/commit/1646a97bbc535e24fd3b738a70aca938d9b15c30) modemmanager: fix cross with no emulator available
* [`6b162222`](https://github.com/NixOS/nixpkgs/commit/6b1622221227aa2628134bc768f22d8074b377bc) pkgsStatic.modemmanager: fix build
* [`a961be38`](https://github.com/NixOS/nixpkgs/commit/a961be3814df0152a15b733c90ee8acad46783ce) pkgsStatic.openfec: fix build
* [`700f1a4b`](https://github.com/NixOS/nixpkgs/commit/700f1a4bcd4c1a6dee3d9f1e31510a03b2f3c5bb) libcamera: disable tracing if unavailable
* [`11f90585`](https://github.com/NixOS/nixpkgs/commit/11f90585cd4994cc0fad92e47935e66a5b647f2b) cmake: propagate ps as a build input on native FreeBSD
* [`ffb78182`](https://github.com/NixOS/nixpkgs/commit/ffb781820b3d354ff4186df5591213e3288fbe43) cmake: remove propagatedBuildInput ps and patch to use an abspath
* [`bc7dc2b9`](https://github.com/NixOS/nixpkgs/commit/bc7dc2b99d8d30b7f47eeeb09cef970f60996fbc) protobuf: protobuf: 24.4 -> 25.2
* [`d0e553da`](https://github.com/NixOS/nixpkgs/commit/d0e553dafe5ba4dc783002a666708f7a6cca622d) coreutils: disable single-binary on native FreeBSD
* [`4cb9ec8a`](https://github.com/NixOS/nixpkgs/commit/4cb9ec8a1e51b8d9b9e6edc061c92da2ec0752dc) coreutils: make autoreconfHook dependency conditional
* [`feef074d`](https://github.com/NixOS/nixpkgs/commit/feef074d47e7f6b66802beeb55c016a7bc4e787d) freebsd: Don't discard request to strip installed binaries
* [`f9835681`](https://github.com/NixOS/nixpkgs/commit/f98356812553eb23b62295ea82b5dbc6553d93b2) xsimd: 12.1.1 -> 13.0.0
* [`3558ec4b`](https://github.com/NixOS/nixpkgs/commit/3558ec4b9d2eeee0f396d91e638e957f0bf36904) xsimd: always build the tests
* [`cbe19213`](https://github.com/NixOS/nixpkgs/commit/cbe19213b4c0f41fcdc77fc41235fe489eee0be0) xtensor: Remove . at end of meta.description
* [`cc19c5c4`](https://github.com/NixOS/nixpkgs/commit/cc19c5c475e957f89a35d9d741c282db0f587353) xtensor: 0.24.7 -> 0.25.0
* [`e28b9960`](https://github.com/NixOS/nixpkgs/commit/e28b99600481454045d3ba104435c40981208003) xtensor: use lib.cmakeBool
* [`a8badac0`](https://github.com/NixOS/nixpkgs/commit/a8badac01b7ec38146fdca30a49d24f76436e93e) xtensor: always build tests
* [`9a78139e`](https://github.com/NixOS/nixpkgs/commit/9a78139e38673402017d8b252d1f4e03ebc4bd3b) python311Packages.xtensor-python: 0.26.1 -> 0.27.0
* [`2f8ae866`](https://github.com/NixOS/nixpkgs/commit/2f8ae866d1f0ed9776cd68868da27aabbf535336) python311Packages.xtensor: always build tests
* [`e2ff9af8`](https://github.com/NixOS/nixpkgs/commit/e2ff9af8290c72e0708856e7b501467fdb3ce61e) python312Packages.pytest-httpbin: refactor
* [`78b98026`](https://github.com/NixOS/nixpkgs/commit/78b98026dfbe6898c0606c1eee6cae3ddd312288) python312Packages.pytest-httpbin: format with nixfmt
* [`eee3b06d`](https://github.com/NixOS/nixpkgs/commit/eee3b06d83d2089b665a7d1a2e5e40e29dfd19da) python312Packages.pytest-httpbin: disable failing test
* [`08b422c1`](https://github.com/NixOS/nixpkgs/commit/08b422c16992f3f687fe594090f60012a0585cef) umockdev: 0.18.1 -> 0.18.2
* [`814665f6`](https://github.com/NixOS/nixpkgs/commit/814665f6bd960482ce3f76d15ee8143a3bdc2fe0) gnu-efi: 3.0.15 -> 3.0.18
* [`695505d5`](https://github.com/NixOS/nixpkgs/commit/695505d580042e6f3df8ea5ff9dc019466eca6bc) fwupd-efi: drop patch for gnu-efi 3.0.15
* [`72a48916`](https://github.com/NixOS/nixpkgs/commit/72a4891639ba2c3077860fdd42c47a7938459b99) efitools: add patch for gnu-efi 3.0.18
* [`cca8c498`](https://github.com/NixOS/nixpkgs/commit/cca8c498a39b55f87e96450742835cc44a479660) botocore: 1.34.87 -> 1.34.109
* [`5bfa96be`](https://github.com/NixOS/nixpkgs/commit/5bfa96be70e6bb6759946616ed824aeaaa9ec08d) boto3: 1.34.58 -> 1.34.109
* [`03691df0`](https://github.com/NixOS/nixpkgs/commit/03691df07e22658384970783cb4524b4e425bb56) awscli: 1.32.58 -> 1.32.109
* [`491cafe4`](https://github.com/NixOS/nixpkgs/commit/491cafe46fada62b9d5f0c3f909e5450c2fc75d8) python3Packages.boto3: version depends on python3Packages.botocore version
* [`82ea1a73`](https://github.com/NixOS/nixpkgs/commit/82ea1a7345c3e9f027f20454ac34e7fcb50ba960) libfaketime: backport LFS64 fix for musl 1.2.4 ([nixos/nixpkgs⁠#313663](https://togithub.com/nixos/nixpkgs/issues/313663))
* [`c354a342`](https://github.com/NixOS/nixpkgs/commit/c354a3421e07cf0cef8e0424d5aec93fa28fe3ac) gst_all_1.gstreamer: 1.24.2 -> 1.24.3
* [`f2b478da`](https://github.com/NixOS/nixpkgs/commit/f2b478da88bf5524d6da4b7208982ef32b8fb1db) gst_all_1.gst-plugins-base: 1.24.2 -> 1.24.3
* [`d31b7586`](https://github.com/NixOS/nixpkgs/commit/d31b7586054bb0afc0ccb08647a583311dfe6635) gst_all_1.gst-plugins-good: 1.24.2 -> 1.24.3
* [`5dc0e49d`](https://github.com/NixOS/nixpkgs/commit/5dc0e49d7db42d21581b6417087a51228773b000) gst_all_1.gst-plugins-bad: 1.24.2 -> 1.24.3
* [`88114562`](https://github.com/NixOS/nixpkgs/commit/88114562716d367f52966bd932606ad30eb75788) gst_all_1.gst-plugins-ugly: 1.24.2 -> 1.24.3
* [`f4673049`](https://github.com/NixOS/nixpkgs/commit/f46730494e67ede49798fbe2cb00e78f9134899e) gst_all_1.gst-libav: 1.24.2 -> 1.24.3
* [`3421e4a5`](https://github.com/NixOS/nixpkgs/commit/3421e4a51849a0eaf7745e441bfd2deea0b9aa9f) gst_all_1.gst-vaapi: 1.24.2 -> 1.24.3
* [`03beee7b`](https://github.com/NixOS/nixpkgs/commit/03beee7bcbc1122022e771f62a8b4a85f4c3c3e0) gst_all_1.gst-rtsp-server: 1.24.2 -> 1.24.3
* [`246b27f6`](https://github.com/NixOS/nixpkgs/commit/246b27f60de7f5b9cdeb85f29513531717bc5b31) gst_all_1.gst-devtools: 1.24.2 -> 1.24.3
* [`2545f0d2`](https://github.com/NixOS/nixpkgs/commit/2545f0d27dc25451831553ae79940f91b259b572) gst_all_1.gst-editing-services: 1.24.2 -> 1.24.3
* [`29665662`](https://github.com/NixOS/nixpkgs/commit/29665662b761d30aae5fc3f1e5f35788cdae10d0) python311Packages.gst-python: 1.24.2 -> 1.24.3
* [`43750642`](https://github.com/NixOS/nixpkgs/commit/437506429acfb3b77e7b9acd29d83e372e615e85) curl: 8.7.1 -> 8.8.0
* [`ef3d271c`](https://github.com/NixOS/nixpkgs/commit/ef3d271c3b45eb153854b2ea30192e9740bf2da0) tpm2-tss: 4.1.2 -> 4.1.3 ([nixos/nixpkgs⁠#313445](https://togithub.com/nixos/nixpkgs/issues/313445))
* [`94bdc4bb`](https://github.com/NixOS/nixpkgs/commit/94bdc4bbbb1ae53474c219a1770385b9c6a92082) zip: fix forward declaration errors with clang ([nixos/nixpkgs⁠#313305](https://togithub.com/nixos/nixpkgs/issues/313305))
* [`d2b0bf56`](https://github.com/NixOS/nixpkgs/commit/d2b0bf5658256ccc85f2cad097d45f82e7804e9c) Revert "util-linux: also downgrade static builds already"
* [`125b5dcf`](https://github.com/NixOS/nixpkgs/commit/125b5dcfb5871af68c8709d8933efc41286bbb90) Revert "util-linux: 2.40.1 -> 2.39.4 (except 64-bit linux for now)"
* [`7a870b74`](https://github.com/NixOS/nixpkgs/commit/7a870b7464dc985c34577340b7daf49c210074f7) Revert "util-linux: try to fix parallel build failures"
* [`0dbb16a0`](https://github.com/NixOS/nixpkgs/commit/0dbb16a0030a6f30a94217c6ae3d48e5e95c717a) Revert "util-linux: 2.39.3 -> 2.40.1"
* [`d4fe4961`](https://github.com/NixOS/nixpkgs/commit/d4fe4961b743939455fb4dc4fa4940652cf14563) python3Packages.tappy: refactor, add optional dependencies
* [`52fd0f93`](https://github.com/NixOS/nixpkgs/commit/52fd0f93dfff4034e2664092fa82c085a5a10d4a) coreutils: enable single-binary build on FreeBSD
* [`2dcfa478`](https://github.com/NixOS/nixpkgs/commit/2dcfa4787b6fb9fb9e6cb087db382f9ce8556f99) ghostscript: 10.3.0 -> 10.3.1
* [`854b6b28`](https://github.com/NixOS/nixpkgs/commit/854b6b28813a18b2fdb3077dde9c193dcb2f1988) dolphin-emu: 5.0-21088 -> 5.0-21460
* [`d0f6f51c`](https://github.com/NixOS/nixpkgs/commit/d0f6f51cb8f03b939ab2587b44524b2bcceb63ba) dolphin-emu: fix build on x86_64-darwin
* [`00062ab8`](https://github.com/NixOS/nixpkgs/commit/00062ab8ef61b22cb113706da48cce6876ea893f) maintainers: add felbinger
* [`573aa7d7`](https://github.com/NixOS/nixpkgs/commit/573aa7d7d1f85afcdce5e3a3c7fea1f351734cfb) Reapply "systemd: enable debug info"
* [`7f0dd68a`](https://github.com/NixOS/nixpkgs/commit/7f0dd68a6393759e64bd17628a502eac3f32d204) python312Packages.scipy: 1.13.0 -> 1.13.1
* [`35f36cd0`](https://github.com/NixOS/nixpkgs/commit/35f36cd087e6e6ab119407351f034e83159626ee) glib: Apply fix for memory issues
* [`9cc8febc`](https://github.com/NixOS/nixpkgs/commit/9cc8febc343e08e36e6174ec6436bf6470f3a7ff) python311Packages.apsw: 3.45.3.0 -> 3.46.0.0
* [`35cdb489`](https://github.com/NixOS/nixpkgs/commit/35cdb4894217a2a844c9b1a484f030a2a7f92c08) btrfs-progs: backport fix build with e2fsprogs 1.47.1
* [`76787698`](https://github.com/NixOS/nixpkgs/commit/767876986fa8e507e23702cfffaeb628b42f4035) e2fsprogs: 1.47.0 -> 1.47.1
* [`5e9dc71d`](https://github.com/NixOS/nixpkgs/commit/5e9dc71d53ed830449352682087f68d2bc523e5c) e2fsprogs: use fuse3
* [`9ffb5583`](https://github.com/NixOS/nixpkgs/commit/9ffb5583b1f5bb2285611887c832cde2c3e3e15a) util-linux: 2.39.3 -> 2.39.4
* [`0a35ee2d`](https://github.com/NixOS/nixpkgs/commit/0a35ee2d584673a80ee87b3561d908629037e799) pipewire: 1.0.6 -> 1.0.7
* [`4d6d293f`](https://github.com/NixOS/nixpkgs/commit/4d6d293fad1a84b953e6decb32959425fb9d2043) setup-hooks/strip: uniqify files by inode number before stripping
* [`04548e7e`](https://github.com/NixOS/nixpkgs/commit/04548e7e1f256a0ff270f48d0a4dbc224aeeb728) nixos/journalwatch: add package option
* [`fd1bccc8`](https://github.com/NixOS/nixpkgs/commit/fd1bccc8a52ba78d31430cc3b8cece8fac1bf141) libdvdnav_4_2_1: Explain configureScript=./configure2
* [`6715ab49`](https://github.com/NixOS/nixpkgs/commit/6715ab49bd58a5c24e59f6a97fc375d2ea7ebb08) libdvdnav_4_2_1: Tell the configuration script to use the specified C compiler
* [`d865ebfd`](https://github.com/NixOS/nixpkgs/commit/d865ebfd5b58372fafebf6c485e57caf5aa5d4fa) libdvdnav_4_2_1: disable binary stripping during make install
* [`c4681a43`](https://github.com/NixOS/nixpkgs/commit/c4681a43e64ef2eff3baad710a26b061165eb94b) libdvdnav_4_2_1: add makeFlags for prefixed build tools
* [`179feb81`](https://github.com/NixOS/nixpkgs/commit/179feb81f7ab52e9ce2fdf96d785a388107ec87a) plasma-wayland-protocols: 1.12.0 -> 1.13.0
* [`8164fd64`](https://github.com/NixOS/nixpkgs/commit/8164fd64c9fc9d3c9d1033254fda71fcb1a74d63) llvmPackages_{12,13,14,15,16,17,18,git}: Simplify argument passthrough
* [`1b288bca`](https://github.com/NixOS/nixpkgs/commit/1b288bca003d5c9edc851bbf268c43591cea3aac) nixos/etc: support direct symlinks with etc overlay
* [`255fd98d`](https://github.com/NixOS/nixpkgs/commit/255fd98d68432909dd5ca97f062762956342a6ad) libfakeXinerama: refactor build/installPhase, fix cross compilation
* [`9ee1fbe3`](https://github.com/NixOS/nixpkgs/commit/9ee1fbe399c694c9a67d72012fe71b9ea3f3f282) libfakeXinerama: add nickcao to maintainers
* [`18a29caf`](https://github.com/NixOS/nixpkgs/commit/18a29caf93cc2cd1b754380081187a5c32ca9445) ethtool: 6.7 -> 6.9
* [`72a631cb`](https://github.com/NixOS/nixpkgs/commit/72a631cb5bf28d0ac4706e318d4beddf25f59fa3) gtk4: 4.14.3 → 4.14.4
* [`81736c5f`](https://github.com/NixOS/nixpkgs/commit/81736c5f250fd815a68f1bd999a7de4710884b85) gtk3: 3.24.41 → 3.24.42
* [`b8144002`](https://github.com/NixOS/nixpkgs/commit/b81440020ef2ea7a7256cf6c5f23fe010738b7fa) gyb: 1.80 -> 1.81
* [`e64c5efb`](https://github.com/NixOS/nixpkgs/commit/e64c5efb0f59ce718bb15d70a5a83436e40a7336) python311Packages.sphinx-design: 0.5.0 -> 0.6.0
* [`82cf9702`](https://github.com/NixOS/nixpkgs/commit/82cf9702163e6df4b2acf2c2cc216b7ee0aa5c4e) librsvg: 2.58.0 -> 2.58.1
* [`67dea634`](https://github.com/NixOS/nixpkgs/commit/67dea634b9ea2f82f29fad65abb7fb7f1c796b13) libtiff: build with webp & zstd support
* [`7643ac57`](https://github.com/NixOS/nixpkgs/commit/7643ac578d43e90214e37dc490ba7d5d9983aef6) elpa-packages: updated 2024-05-22 (from overlay)
* [`39325242`](https://github.com/NixOS/nixpkgs/commit/393252426573c19248a1272bac47b9f55565e072) elpa-devel-packages: updated 2024-05-22 (from overlay)
* [`1996c2e1`](https://github.com/NixOS/nixpkgs/commit/1996c2e1119aa794cbd35b5788300d0fe56fc88e) melpa-packages: updated 2024-05-22 (from overlay)
* [`c7639d5f`](https://github.com/NixOS/nixpkgs/commit/c7639d5fbf90ef75ae426fb71e87817ac4263081) nongnu-packages: updated 2024-05-22 (from overlay)
* [`797283d6`](https://github.com/NixOS/nixpkgs/commit/797283d64fcf48ddf3bbe480305f6200f62eef6a) elisp packages: update-from-overlay.nix3.sh, a flakey thin wrapper
* [`34a57d98`](https://github.com/NixOS/nixpkgs/commit/34a57d98c708a4074ef46a1842cb1cc9048d017d) polkit: fix build with !useSystemd
* [`ba5aa8de`](https://github.com/NixOS/nixpkgs/commit/ba5aa8deb9ee941c23caad67501f22aec9198697) python311Packages.hiyapyco: 0.5.6 -> 0.6.0
* [`e0cbd6c7`](https://github.com/NixOS/nixpkgs/commit/e0cbd6c7c7cae7287713fed1545da0ac73dc3ddb) gettext: remove spurious xz
* [`9f481b39`](https://github.com/NixOS/nixpkgs/commit/9f481b394bc47c1b4ea449399b1bf29b8d550f84) texinfo: remove spurious xz buildInput
* [`948d0cf5`](https://github.com/NixOS/nixpkgs/commit/948d0cf589ee818549e20c4315429c6aae2802a0) python3: fix build on native FreeBSD
* [`63a8461b`](https://github.com/NixOS/nixpkgs/commit/63a8461b203c8d3b567eec1c858ece3d82dc9142) ed: Add runtimeShell to buildInputs
* [`be0a8249`](https://github.com/NixOS/nixpkgs/commit/be0a824971392d38ceba9f871f4922f04e8e332f) gzip: Add runtimeShell to buildInputs
* [`fa8c2ac3`](https://github.com/NixOS/nixpkgs/commit/fa8c2ac3be0df58c8787004e69f284916ec089ab) gawk: Add runtimeShell to buildInputs
* [`125d947e`](https://github.com/NixOS/nixpkgs/commit/125d947ed51cad2e9fdb30fdd89e573619ebfb1f) gnugrep: Add runtimeShell to buildInputs
* [`cd5b04be`](https://github.com/NixOS/nixpkgs/commit/cd5b04bee79ff332e4865cd1acb1eee638d668bd) abaddon: fix null audio backend
* [`3db6ef1b`](https://github.com/NixOS/nixpkgs/commit/3db6ef1b777f87f55f42002eb6816bea30d2f014) libsodium: 1.0.19 -> 1.0.20
* [`affa8f75`](https://github.com/NixOS/nixpkgs/commit/affa8f75ec85c03c093a67be9e5fb6de1b3f9354) Reapply "srcOnly: reflink if possible and preserve attributes"
* [`2a7c649d`](https://github.com/NixOS/nixpkgs/commit/2a7c649d52479363c11cd5c772680fdf8d21e1bc) Update realtek website for kernel module source
* [`846de80d`](https://github.com/NixOS/nixpkgs/commit/846de80d1cc8afab75283f4b4251a6281d6c0295) various: Enable updateAutotoolsGnuConfigScriptsHook
* [`70f855d6`](https://github.com/NixOS/nixpkgs/commit/70f855d67da2de765e24df74549004bf3304465d) util-linux: add hd symlink for hexdump --canonical
* [`f82a1d12`](https://github.com/NixOS/nixpkgs/commit/f82a1d12eb60abd555c0a8a0fbd407411bb0eca3) Revert "make-binary-wrapper: add cc to propagatedBuildInputs"
* [`9a21575b`](https://github.com/NixOS/nixpkgs/commit/9a21575b5ffdeefcf505afd7059c4259aaefe524) e2fsprogs: apply patches to fix libblockdev
* [`b1e96bad`](https://github.com/NixOS/nixpkgs/commit/b1e96badbf395e5519680927905be5446ee3f118) flamegraph: set meta.mainProgram
* [`c0f72f27`](https://github.com/NixOS/nixpkgs/commit/c0f72f27cc490aca80dc567965a8e0e2c4e0afa3) flamegraph: run tests during checkPhase
* [`87c8b87a`](https://github.com/NixOS/nixpkgs/commit/87c8b87a1e035478e7ef03c016d551af76f36576) flamegraph: 2019-02-16 -> 2023-11-06
* [`f7b22f6d`](https://github.com/NixOS/nixpkgs/commit/f7b22f6de56dde9eb22558a7bb2168058cd60b7f) tbb: fix version script with lld 17+
* [`4c621ef8`](https://github.com/NixOS/nixpkgs/commit/4c621ef88639a125059848c6359b98f5b4a72333) nixos/loki: add network.target to after
* [`ee429344`](https://github.com/NixOS/nixpkgs/commit/ee429344a5d6e54dd77c73ccc6eae11903a7c6ff) pghero: init at 3.5.0
* [`a5499ee5`](https://github.com/NixOS/nixpkgs/commit/a5499ee5356975f4bc50a0e24fc6238f48fc4666) nixos/pghero: init
* [`6d9f4caa`](https://github.com/NixOS/nixpkgs/commit/6d9f4caa6505204b4842b0ce10af39552e0b4ae9) jemalloc: fix linking against libc++ with lld
* [`01649bd8`](https://github.com/NixOS/nixpkgs/commit/01649bd81cfcd13d7ffc869de139802a8c84a2d4) directx-shader-compiler: 1.7.2308 -> 1.8.2405
* [`3d17ec58`](https://github.com/NixOS/nixpkgs/commit/3d17ec58d43de9cd21b375a6159f66f3ffd92cdf) ruby.rubygems: 3.5.10 -> 3.5.11
* [`cd2d05a3`](https://github.com/NixOS/nixpkgs/commit/cd2d05a39917b939270261b043303492eb3d8a6b) bundler: 2.5.10 -> 2.5.11
* [`f6d41588`](https://github.com/NixOS/nixpkgs/commit/f6d41588d762174672ad0b1e01a7b79ef4fa2610) bdt: init 0.18.0
* [`a3fc3f0b`](https://github.com/NixOS/nixpkgs/commit/a3fc3f0b59c43c5a556a367c1755bc77da346739) maintainers: add matthiasq
* [`17cb55ed`](https://github.com/NixOS/nixpkgs/commit/17cb55edc64ac00a0fd05b445c4ac74df69cf4e6) bdt: add maintainer information
* [`cb1b8ce5`](https://github.com/NixOS/nixpkgs/commit/cb1b8ce5d1d253e127a8f22703c27b8dac400cb4) kubebuilder: 3.15.1 -> 4.0.0
* [`2bb8ac38`](https://github.com/NixOS/nixpkgs/commit/2bb8ac384820d42cb359a305950b446817a4e983) questdb: 7.4.2 -> 8.0.0
* [`40f7dd84`](https://github.com/NixOS/nixpkgs/commit/40f7dd84f35e387f4194f2a049f3b601c2dbb88b) purescm: Fix self-inclusive src
* [`83782220`](https://github.com/NixOS/nixpkgs/commit/83782220043f32ff942ce0f76981526e8ec76c60) buildLinux: allow changing the pname
* [`3e9f8c52`](https://github.com/NixOS/nixpkgs/commit/3e9f8c52fe2fe14c06e599d1596e091c85db5d62) linux_xanmod: set pname
* [`a55e90b5`](https://github.com/NixOS/nixpkgs/commit/a55e90b58c014d43ede0ab6301d7cce72cbeee36) linux_hardened: set pname
* [`b4bc6ed3`](https://github.com/NixOS/nixpkgs/commit/b4bc6ed34fd3530eb90cf0565bef8aebd644ae0a) linux_rt: set pname
* [`eb7362f5`](https://github.com/NixOS/nixpkgs/commit/eb7362f5c41c6d256e3d6457ecbf2a3bd829e68a) linux_rpi: set pname
* [`89b11d8d`](https://github.com/NixOS/nixpkgs/commit/89b11d8d759bd54feff1f00a92de5fc6ec64ad38) linux_libre: set pname
* [`61113994`](https://github.com/NixOS/nixpkgs/commit/61113994ae4e75e6fd1c90747da41f09cb01aefa) zen-kernels: set pname
* [`067ad059`](https://github.com/NixOS/nixpkgs/commit/067ad059428b0f8f110ff207f265b261ea08f316) libiconv-darwin: add support for static builds
* [`edfc324c`](https://github.com/NixOS/nixpkgs/commit/edfc324c7a5f9f44d51dd8768b927882e5f2df78) libiconv-darwin: fix ISO-2022 with escape sequences crash
* [`aec83876`](https://github.com/NixOS/nixpkgs/commit/aec838761b54d59493c8aa0876781940ddf8a0fc) python312Packages.requests: 2.31.0 -> 2.32.2
* [`2c83f841`](https://github.com/NixOS/nixpkgs/commit/2c83f84113aa5dc1629e89b24272482402bfd0c2) python312Packages.hypothesis: 6.100.1 -> 6.103.0
* [`ea7c17ae`](https://github.com/NixOS/nixpkgs/commit/ea7c17ae2eb2044923df60b043417d9280241afd) python312Packages.elastic-transport: 8.13.0 -> 8.13.1
* [`fde4c961`](https://github.com/NixOS/nixpkgs/commit/fde4c961c77d938ffc59d7598b37a7bb2d2b4f22) python312Packages.orjson: 3.10.1 -> 3.10.3
* [`4ea81dd5`](https://github.com/NixOS/nixpkgs/commit/4ea81dd5286ea9f2508bc21054a211ab87a11574) python3Packages.docker-py: drop in favor of docker
* [`d2db3bae`](https://github.com/NixOS/nixpkgs/commit/d2db3bae0fe94392f7537783724a9a0ba1327ca2) python312Packages.docker: 7.0.0 -> 7.1.0
* [`07f40e68`](https://github.com/NixOS/nixpkgs/commit/07f40e68920c149c9c8ce62e283d73bd98a1413b) rustc: don't try to use non-existent rust-lld
* [`29d1407d`](https://github.com/NixOS/nixpkgs/commit/29d1407d06c7f40a96b515702a761e0ff7f63774) python312Packages.typing-extensions: 4.11.0 -> 4.12.0
* [`4bb545d1`](https://github.com/NixOS/nixpkgs/commit/4bb545d1c76ca98b89bbd618c8b913f90e041fa7) qt5.qtwebengine: fix build with Ninja 1.12
* [`2e89aba1`](https://github.com/NixOS/nixpkgs/commit/2e89aba144329a0107e94671433357966e9053a2) m1ddc: init at 1.2.0
* [`ce5cc263`](https://github.com/NixOS/nixpkgs/commit/ce5cc26328cba147efa399b19513e15f8841f7c7) gcc13: 13.2.0 -> 13.3.0
* [`1b84dafe`](https://github.com/NixOS/nixpkgs/commit/1b84dafe228e7c2afddc7624573ff743e19e5366) metabase: 0.49.11 -> 0.49.12
* [`ef12b15a`](https://github.com/NixOS/nixpkgs/commit/ef12b15a5b6308b84d2fdcdc50e922fafac7e832) mesa: 24.0.7 -> 24.0.8
* [`d2a06d25`](https://github.com/NixOS/nixpkgs/commit/d2a06d2573b735af095109081ab2e24b496ef689) flutter: drop moreutils for more bash
* [`07ab74e4`](https://github.com/NixOS/nixpkgs/commit/07ab74e4aa9ae2d51986075edffe17ec0c2551c6) python3: fix build on Darwin
* [`82c3726b`](https://github.com/NixOS/nixpkgs/commit/82c3726b76c025d6b6f6e5d8cecb59008a3a21be) librewolf-unwrapped: 126.0-1 -> 126.0.1-1
* [`ba6025ce`](https://github.com/NixOS/nixpkgs/commit/ba6025ce4150d66954ce443a0564a8b72017245a) maintainers: add yomaq
* [`1f5c2993`](https://github.com/NixOS/nixpkgs/commit/1f5c2993a55d8b00f8ac000fd23ae955bf33431e) crowdsec: 1.6.1 -> 1.6.2
* [`57c8bec6`](https://github.com/NixOS/nixpkgs/commit/57c8bec62d5b2ea78be89648dd8b6d5697852ba4) github: add llvm/clang label
* [`77d03eb6`](https://github.com/NixOS/nixpkgs/commit/77d03eb68cfb2602c5b2b8b10c214ce98648fa8a) llvmPackages_{12,13,14,15,16,17,18,git}.lldb: add patch to remove origin variable
* [`6851e98a`](https://github.com/NixOS/nixpkgs/commit/6851e98ae8ec49250e388c55535459ded651bda5) devpod: 0.5.8 -> 0.5.12
* [`ea648db7`](https://github.com/NixOS/nixpkgs/commit/ea648db7e0f1669b052946efe6457c52232efb7d) freeradius: 3.2.3 -> 3.2.4
* [`5f2151f6`](https://github.com/NixOS/nixpkgs/commit/5f2151f6ba42bf3d770381a138b1c76133b649c1) blueman: 2.4.1 -> 2.4.2
* [`95016007`](https://github.com/NixOS/nixpkgs/commit/95016007bf71b2cb3be2abc368f8af481dd8ef25) ki: fix beartype error and format with nixfmt
* [`456ba8de`](https://github.com/NixOS/nixpkgs/commit/456ba8dec946bd589755c542291fb7ef199d2b27) unstableGitUpdater: Remove bitrotten comment about hardcodeZeroVersion on tag-less projects
* [`3a8211a3`](https://github.com/NixOS/nixpkgs/commit/3a8211a3aeef52ac68b480cf1905fe851f029602) dlib: 19.24.2 -> 19.24.4
* [`661165e5`](https://github.com/NixOS/nixpkgs/commit/661165e502a301ba1c9c2a4c23fe90d53fb0a3fa) resorter: init at 0-unstable-2023-07-14
* [`a122af10`](https://github.com/NixOS/nixpkgs/commit/a122af10cabed737751d83478195a002475b99ae) pulumi-esc: init at 0.9.0
* [`9067316f`](https://github.com/NixOS/nixpkgs/commit/9067316ffea24dabed703c85d15cfcc0456ebc15) openiscsi: 2.1.9 -> 2.1.10
* [`d3f4a086`](https://github.com/NixOS/nixpkgs/commit/d3f4a086cf13c91a1b28ff56a690b18724ddbc95) super-productivity: 8.0.5 -> 8.0.7
* [`db188dcc`](https://github.com/NixOS/nixpkgs/commit/db188dcc7c08b473bd8efaaafa5f75696838a38e) tempo: 2.4.2 -> 2.5.0
* [`f88c037c`](https://github.com/NixOS/nixpkgs/commit/f88c037c739803d28c8a1c40927f4ad5dc31117e) clang18Stdenv: init
* [`198cae60`](https://github.com/NixOS/nixpkgs/commit/198cae60b3a76880d33b1af19890b107f190dc3e) unigine-heaven: Set mainProgram to heaven
* [`128f6c77`](https://github.com/NixOS/nixpkgs/commit/128f6c7775b74faf898d1666851fb6e638a4c7e7) simp_le: 0.17.0 -> 0.20.0
* [`dcbf69fd`](https://github.com/NixOS/nixpkgs/commit/dcbf69fd20b629eefe0f9dac459624ce71de1258) simp_le: use PEP517 builder
* [`7f447ce0`](https://github.com/NixOS/nixpkgs/commit/7f447ce0f88323cc61ce43e538a62379baa2b608) nixos/espanso: fix espanso options
* [`56a601af`](https://github.com/NixOS/nixpkgs/commit/56a601af653552396aecd8065439d53b6ccac844) rsass: 0.28.8 -> 0.28.10
* [`cbc77772`](https://github.com/NixOS/nixpkgs/commit/cbc777729f3d7242c35aad2d10c07ca7244e99bd) ckbcomp: 1.226 -> 1.227
* [`f541e553`](https://github.com/NixOS/nixpkgs/commit/f541e553dd5980849ef80e99509f7f62a6cb1f3f) decker: 1.41 -> 1.43
* [`0a509b23`](https://github.com/NixOS/nixpkgs/commit/0a509b237a29841b9236b2bc3296d93d7c4d96a6) doc/languages-frameworks/python: update the description for pypa builder/instller
* [`cf73a29d`](https://github.com/NixOS/nixpkgs/commit/cf73a29daefa18960d440e09060d778d531646d9) qlcplus: 4.13.0 -> 4.13.1
* [`bbe5fc70`](https://github.com/NixOS/nixpkgs/commit/bbe5fc70c70f50474139d13d1c4ae9696b277c21) opera: 110.0.5130.23 -> 110.0.5130.49
* [`b4a1d25e`](https://github.com/NixOS/nixpkgs/commit/b4a1d25e5554b64be5bd822e94769f7dad924448) tutanota-desktop: 229.240514.1 -> 229.240517.0
* [`ad9d0263`](https://github.com/NixOS/nixpkgs/commit/ad9d026335c3ac19fe662b41533016a370b6c69b) Revert "python312Packages.typing-extensions: 4.11.0 -> 4.12.0"
* [`a7389a78`](https://github.com/NixOS/nixpkgs/commit/a7389a7866f4c537bf71f7fab0d51209923d8722) groonga: 14.0.2 -> 14.0.4
* [`22a81ded`](https://github.com/NixOS/nixpkgs/commit/22a81dedb0c878bd50299521d8df7aac8a6d34f2) python312Packages.typing-extensions: test reverse deps in passthru
* [`6f93c3d3`](https://github.com/NixOS/nixpkgs/commit/6f93c3d3483a7c30205b6a3b3b31fa28915e5bc0) scc: 3.3.3 -> 3.3.4
* [`cbf63579`](https://github.com/NixOS/nixpkgs/commit/cbf635795d2c40b1f5c1983248e327e872c13f6e) datatrove: init at 0.2.0
* [`f2701340`](https://github.com/NixOS/nixpkgs/commit/f2701340c7bb4e3071f3a554b45aca8479bd8fd5) archivy: revert to using fetchPypi for overriding source of wtforms
* [`a850b586`](https://github.com/NixOS/nixpkgs/commit/a850b586decfa4088fbdfbdb16bd0ce7e24c6c66) oneDNN: 3.4.1 -> 3.4.3
* [`ea3e192b`](https://github.com/NixOS/nixpkgs/commit/ea3e192be60561c1d0b064828823021032e6bca1) python311Packages.pydal: 20240428.2 -> 20240601.3
* [`9e2b80d4`](https://github.com/NixOS/nixpkgs/commit/9e2b80d4de1dcd0aae81df33216666e1dc9e5cd8) quickemu: format with nixfmt-rfc-style
* [`1fe0639a`](https://github.com/NixOS/nixpkgs/commit/1fe0639a8bf30c22f2ca2e33a77576e4055b5231) quickemu: decrease windows ram requirements
* [`9ea61d43`](https://github.com/NixOS/nixpkgs/commit/9ea61d43d4ce1b676a471a5de17ad62ab98f35f4) wonderdraft: 1.1.7.3 -> 1.1.8.2b
* [`23fc7e91`](https://github.com/NixOS/nixpkgs/commit/23fc7e91b424b5b161e6b91c402564b47921cf93) subtitleedit: 4.0.5 -> 4.0.6
* [`033515f1`](https://github.com/NixOS/nixpkgs/commit/033515f1adcc1cdc3810ec84aefe8d60c35ea5f4) e1s: 1.0.36 -> 1.0.37
* [`771c931a`](https://github.com/NixOS/nixpkgs/commit/771c931a9fe9807ff1dcc46750817e3f4cf0785b) bazarr: 1.4.2 -> 1.4.3
* [`c4c389c7`](https://github.com/NixOS/nixpkgs/commit/c4c389c771211f3c10b64a7782bdd29790e36d37) ratarmount: 0.15.0 -> 0.15.1
* [`6efcddca`](https://github.com/NixOS/nixpkgs/commit/6efcddca4e76e264aa64df9385145f564c528daf) web-ext: 7.11.0 -> 8.0.0
* [`283e6058`](https://github.com/NixOS/nixpkgs/commit/283e6058ca2498e65cf18bb525a41c9978b3455f) strictdoc: 0.0.55 -> 0.0.56
* [`03c93ec4`](https://github.com/NixOS/nixpkgs/commit/03c93ec4ed5bbba6e87e024d7981e6394fde76b3) mtools: 4.0.43 -> 4.0.44
* [`f70722d3`](https://github.com/NixOS/nixpkgs/commit/f70722d3421d9af09d30aaa436731b5b783e14a0) indi-full: update indi-3rdparty sources
* [`be9752be`](https://github.com/NixOS/nixpkgs/commit/be9752bef9c67355b7a2693dd4a4ba5a6f7ce009) spdk: 24.01 -> 24.05
* [`7e788a28`](https://github.com/NixOS/nixpkgs/commit/7e788a28d030f1b59c3a9d1fb36e8258ade742bc) ayatana-indicator-session: 24.2.0 -> 24.5.0
* [`0f97aa74`](https://github.com/NixOS/nixpkgs/commit/0f97aa74da7a21be6159c44790bebe3712924904) ayatana-indicator-power: 24.5.0 -> 24.5.1
* [`abd1525c`](https://github.com/NixOS/nixpkgs/commit/abd1525cd80f5805fde7b4116aa8f7a262c5dce1) libnvme: 1.7.1 -> 1.9
* [`de3e916b`](https://github.com/NixOS/nixpkgs/commit/de3e916be82759d082a3bbfd509a8863252461be) nvme-cli: 2.7.1 -> 2.9.1
* [`f426c2ce`](https://github.com/NixOS/nixpkgs/commit/f426c2ce631006521143eea100c862ee23f17e81) plumed: 2.9.0 -> 2.9.1
* [`a07740ff`](https://github.com/NixOS/nixpkgs/commit/a07740ff15a9b03c9a353ce3f3d09f361a295c17) minizinc: 2.8.4 -> 2.8.5
* [`6f871a77`](https://github.com/NixOS/nixpkgs/commit/6f871a7736cd0d9630496f9dd69c46ac55f390cc) jbrowse: 2.11.1 -> 2.11.2
* [`ad9b2ad9`](https://github.com/NixOS/nixpkgs/commit/ad9b2ad91250d88cae94cebf29797926d3bc274a) lomiri.lomiri-session: Unset QT_QPA_PLATFORMTHEME
* [`3e88b1aa`](https://github.com/NixOS/nixpkgs/commit/3e88b1aadcdbc88016e66e8807bcf220670ff325) pinentry: 1.2.1 -> 1.3.0
* [`130da0dd`](https://github.com/NixOS/nixpkgs/commit/130da0dd424b94d694ccc6034e61b423ae107fe1) doc/languages-frameworks/python: update the description for tests
* [`1c90c05b`](https://github.com/NixOS/nixpkgs/commit/1c90c05bbc1ec53541a0b88d1692645108f369d7) doc/languages-frameworks/python: disable check explicitly and add pythonImportsCheck
* [`1b4462bb`](https://github.com/NixOS/nixpkgs/commit/1b4462bb0c01bcc633d07c9e316d12af5281ac0a) doc/languages-frameworks/python: clean up build-system
* [`8f9e8615`](https://github.com/NixOS/nixpkgs/commit/8f9e861543ff115d6ebec3be41a1690f092a699b) doc/languages-frameworks/python: add extra information for pythonRelaxDepsHook
* [`a4d5b564`](https://github.com/NixOS/nixpkgs/commit/a4d5b5644888cc94403e332934458b321db2ffbf) doc/languages-frameworks/python: fix typo
* [`ef61a633`](https://github.com/NixOS/nixpkgs/commit/ef61a6339c7ea3e84e58f3a48fc76a6d02556e0f) doc/languages-frameworks/python: normalize pname and add description
* [`b6bf10bf`](https://github.com/NixOS/nixpkgs/commit/b6bf10bf70af2f788a4db24041a211b87ef876cb) doc/languages-frameworks/python: adjust expression to explanation
* [`513573a5`](https://github.com/NixOS/nixpkgs/commit/513573a582c78cfe02c89d30938cbabe892267ab) doc/languages-frameworks/python: update contributing section
* [`f06f376b`](https://github.com/NixOS/nixpkgs/commit/f06f376b65ece8752e7192db8bf87705cc239139) bitwarden-desktop: 2024.4.1 -> 2024.5.0
* [`f86bcce2`](https://github.com/NixOS/nixpkgs/commit/f86bcce2f07bb1a788ef2199fd9ee45502d29520) neo4j-desktop: 1.5.8 -> 1.5.9
* [`4809b3b3`](https://github.com/NixOS/nixpkgs/commit/4809b3b39ecd5a26826013326d64a9e24f3b6b9e) jetbrains-toolbox: 2.3.1.31116 -> 2.3.2.31487
* [`88ef7a85`](https://github.com/NixOS/nixpkgs/commit/88ef7a859897a84bd526b0cdeae034daf03ce1c2) {android-studio,androidenv}: add withSdk passthru and androidPkgs
* [`2ac0fcce`](https://github.com/NixOS/nixpkgs/commit/2ac0fcce4232bb501ae44c1a741da5f4b586eb90) android-studio: add numinit as maintainer
* [`859a6056`](https://github.com/NixOS/nixpkgs/commit/859a6056d3311b4292b8585b86d3b35fbe483b9e) android-studio-full: init
* [`7f03a67b`](https://github.com/NixOS/nixpkgs/commit/7f03a67b0b4fa5743f3eccfa3eeaebe68e49b15e) {doc/android,release-notes}: update android-studio and androidenv
* [`c1adf2f6`](https://github.com/NixOS/nixpkgs/commit/c1adf2f6c0f59af2502ae5d8ce45cf679193fe17) android-studio: add sdk passthru
* [`a603e351`](https://github.com/NixOS/nixpkgs/commit/a603e35149f48594193bb1742c6bd5381828565e) codeql: 2.17.3 -> 2.17.4
* [`348a462c`](https://github.com/NixOS/nixpkgs/commit/348a462cb77d692d04f83f049e110f2ecbad3724) genymotion: 3.7.0 -> 3.7.1
* [`720d3ed3`](https://github.com/NixOS/nixpkgs/commit/720d3ed3a8c9fd84b4471837d7479713e84816f6) aws-sdk-cpp: 1.11.318 -> 1.11.336
* [`3da795b0`](https://github.com/NixOS/nixpkgs/commit/3da795b0b507d9cfdb4cb7fe714964775436604a) seafile-client: 9.0.5 -> 9.0.6
* [`2de5ff8a`](https://github.com/NixOS/nixpkgs/commit/2de5ff8a81e5cb36f71e92d824dc99d861f1e565) aws-c-cal: 0.6.12 -> 0.6.15
* [`1613e71d`](https://github.com/NixOS/nixpkgs/commit/1613e71dbed44e5ba9e6bfa1d036fc0c114f66be) python311Packages.sqlmodel: 0.0.18 -> 0.0.19
* [`5d5834eb`](https://github.com/NixOS/nixpkgs/commit/5d5834eb8f58bcaf1204dfe379230f105f7a8c5c) ruby_3_3: 3.3.1 -> 3.3.2
* [`b5f3ca62`](https://github.com/NixOS/nixpkgs/commit/b5f3ca622c8a1c71aee084109972857ef59416ff) mako: fix cross-compilation
* [`cf78f547`](https://github.com/NixOS/nixpkgs/commit/cf78f547aa6157567c2a2802584a7c963c970382) python311Packages.pipdeptree: 2.21.0 -> 2.22.0
* [`cf215482`](https://github.com/NixOS/nixpkgs/commit/cf215482cba098389d2b64ab0928614c88e6923c) clash-verge-rev: 1.6.4 -> 1.6.5
* [`bf16ab6f`](https://github.com/NixOS/nixpkgs/commit/bf16ab6fce7e0e6e463685723116548c94754bb3) rust-analyzer-unwrapped: 2024-04-29 -> 2024-06-03
* [`58709c01`](https://github.com/NixOS/nixpkgs/commit/58709c01c3264a42d1e52c54c90aef5345d148ad) syncthing: 1.27.7 -> 1.27.8
* [`cb6a6a6d`](https://github.com/NixOS/nixpkgs/commit/cb6a6a6dd8f77bb7caeff6f9f09c0f0330c69eb4) syncthing-discovery: 1.27.7 -> 1.27.8
* [`e8b0c7cb`](https://github.com/NixOS/nixpkgs/commit/e8b0c7cbb1d7e2e5646c34e1ddd577c0f93a8c7b) syncthing-relay: 1.27.7 -> 1.27.8
* [`d0b62766`](https://github.com/NixOS/nixpkgs/commit/d0b6276662eed83fd95202c6d56c02b53741dc1f) opentelemetry-collector-contrib: 0.101.0 -> 0.102.0
* [`93eb450b`](https://github.com/NixOS/nixpkgs/commit/93eb450b4ce85d6f79031d68efa2801d5de931a0) maintainers: add traverseda
* [`c73d7809`](https://github.com/NixOS/nixpkgs/commit/c73d7809589538ee3dcb1124d47782e62408efb0) python312Packages.py-slvs: init at 1.0.6
* [`873b986f`](https://github.com/NixOS/nixpkgs/commit/873b986f65c512747b0a129e6781baba751fdaa6) waagent: 2.10.0.8 -> 2.11.1.4
* [`44be0c69`](https://github.com/NixOS/nixpkgs/commit/44be0c694662e47964e5fad4ad0d1f1a5028d56a) gwyddion: 2.65 -> 2.66
* [`a02532fa`](https://github.com/NixOS/nixpkgs/commit/a02532fa726cb6a16b2f2e17e3d9ec389d0e8ce9) python311Packages.sphinx-design: drop support for Python 3.8
* [`2e9c2a5c`](https://github.com/NixOS/nixpkgs/commit/2e9c2a5c3c6ac2b3af8091fefcc8827b539cad20) mongodb: add avxSupport override
* [`4c74dbf2`](https://github.com/NixOS/nixpkgs/commit/4c74dbf2bb3ab3e05bdc9adaa5943af0ca1caa1b) mongodb-5_0: 5.0.26 -> 5.0.27
* [`2e21e651`](https://github.com/NixOS/nixpkgs/commit/2e21e651d4d0f5ec80e2758bc975c33664765ecc) apitrace: 11.1 -> 12.0
* [`b5cb32b4`](https://github.com/NixOS/nixpkgs/commit/b5cb32b44921b43897406fdc960a9072bb44bd68) python3Packages.fipy: disable on Python 3.12+ and skip checkPhase
* [`75b44dac`](https://github.com/NixOS/nixpkgs/commit/75b44dac88a1651fffb18f7d382f85d37657f3a0) istioctl: 1.22.0 -> 1.22.1
* [`8660eec4`](https://github.com/NixOS/nixpkgs/commit/8660eec49383165c51e3cb9833ecdfd840781b81) junicode: 2.207 -> 2.208
* [`91bc5060`](https://github.com/NixOS/nixpkgs/commit/91bc5060f7dbc4fd1647a82200d558ba2de4b2c2) validator-nu: set meta.platforms
* [`ddc356c1`](https://github.com/NixOS/nixpkgs/commit/ddc356c1f074bf2d5c86e890185e6854205252dd) buildPackages.rustc: fix cross
* [`25bb1bd8`](https://github.com/NixOS/nixpkgs/commit/25bb1bd86076de3ca00ee7f719575b4a5ead16b5) gitlab-ci-local: 4.49.0 -> 4.50.1
* [`3effc139`](https://github.com/NixOS/nixpkgs/commit/3effc1397c81069918cc7f2ed03df1e43e792609) basedpyright: 1.12.4 -> 1.12.5
* [`f397b400`](https://github.com/NixOS/nixpkgs/commit/f397b4008d311ff57dc0b7dca44128f53b2d94f9) wxformbuilder: 4.1.0 -> 4.2.1
* [`ebf78adb`](https://github.com/NixOS/nixpkgs/commit/ebf78adbd034947ddf411d8f4b4baf7f26850b38) wasmtime: 21.0.0 -> 21.0.1
* [`7ab1719f`](https://github.com/NixOS/nixpkgs/commit/7ab1719f86b922b67027cd9ed987535971703508) qt5: 5.15.12 -> 5.15.14, 5.15.16 -> 5.15.17
* [`f8ae7d47`](https://github.com/NixOS/nixpkgs/commit/f8ae7d47a51e305a0941abc156c93029afa67b02) papermc: 1.20.4-435 -> 1.20.6-137
* [`144bcba0`](https://github.com/NixOS/nixpkgs/commit/144bcba078e8003f3f8fc0aec317413e492f1941) kratos: 1.1.0 -> 1.2.0
* [`61708747`](https://github.com/NixOS/nixpkgs/commit/61708747573b913c8d5765397caec7b8ffd8c8d4) kubedb-cli: 0.45.0 -> 0.46.0
* [`57e82817`](https://github.com/NixOS/nixpkgs/commit/57e82817c65016958aa9b38bfa64dd124cd0b9a3) python311Packages.ansible-compat: 4.1.11 -> 24.6.1
* [`e5269101`](https://github.com/NixOS/nixpkgs/commit/e52691019f510a0c9c9bf8d99c40418917054543) sickgear: 3.30.20 -> 3.31.0
* [`0af27a56`](https://github.com/NixOS/nixpkgs/commit/0af27a5615aedb7ba48496875974fcc4389024f1) libvpx: fix cross compiling
* [`3a0306c6`](https://github.com/NixOS/nixpkgs/commit/3a0306c622edbc71fa285e6881cb24ab8180bd67) lcsync: use pname instead of name
* [`f248ef99`](https://github.com/NixOS/nixpkgs/commit/f248ef99c32d81e182dd83434fd44cbb49ddf158) librecast: use pname instead of name
* [`79833cef`](https://github.com/NixOS/nixpkgs/commit/79833cef24a0ebe6929ed36de1383aaa0c54f9ed) lcrq: use pname instead of name
* [`32ce8588`](https://github.com/NixOS/nixpkgs/commit/32ce85880bf463353477870c6c92adda4f508ccf) bombsquad: use pname instead of name
* [`3fd86629`](https://github.com/NixOS/nixpkgs/commit/3fd8662924eee33f09028d858741752f2222f166) c64-debugger: use pname instead of name
* [`dcf56446`](https://github.com/NixOS/nixpkgs/commit/dcf56446e598ee4e5696bcf4fadba1b4b028e00a) cano: use pname instead of name
* [`27cde9a0`](https://github.com/NixOS/nixpkgs/commit/27cde9a05a6a3d3abea2a78e044e66495ebadace) disko: use pname instead of name
* [`0819e505`](https://github.com/NixOS/nixpkgs/commit/0819e505be22a3e60250d596924d8c06ca1735cc) dorion: use pname instead of name
* [`da933de6`](https://github.com/NixOS/nixpkgs/commit/da933de6c3f83e31f2b11de34dd3ebd3b4268fda) holochain-launcher: use pname instead of name
* [`49322f51`](https://github.com/NixOS/nixpkgs/commit/49322f516720b81b4bf6b9a503308e575db3f21a) jailer: use pname instead of name
* [`7c6d92aa`](https://github.com/NixOS/nixpkgs/commit/7c6d92aa60024b44a9a9b68f6eeb6bc99f6dd1e4) jtdx: use pname instead of name
* [`92471765`](https://github.com/NixOS/nixpkgs/commit/92471765a94274b2e18a8d777dcbce7f57c18bd8) python311Packages.py3status: 3.57 -> 3.58
* [`338bbf8f`](https://github.com/NixOS/nixpkgs/commit/338bbf8fdb7c3efa73c4b0c815e28652305affdd) zsh-prezto: 0-unstable-2024-04-15 -> 0-unstable-2024-06-03
* [`c16d8c98`](https://github.com/NixOS/nixpkgs/commit/c16d8c982b783547abba1d1e59d159e6bde67689) flow: 0.237.0 -> 0.237.2
* [`081f7546`](https://github.com/NixOS/nixpkgs/commit/081f7546d1c5ec146bcc1d7bc324ee34f3e8ad5f) flowblade: 2.16 -> 2.16.2
* [`3afe0790`](https://github.com/NixOS/nixpkgs/commit/3afe0790128fcd1013972d7c222f3f706b027e33) svelte-language-server: 0.16.9 -> 0.16.10
* [`96456e3a`](https://github.com/NixOS/nixpkgs/commit/96456e3a41464c97279f58ec7d0331feb8628416) python311Packages.google-cloud-bigquery-datatransfer: 3.15.2 -> 3.15.3
* [`5be6c450`](https://github.com/NixOS/nixpkgs/commit/5be6c450923834b1073c3eea9d6194574dbaf17f) avalanchego: 1.11.6 -> 1.11.7
* [`973d4e65`](https://github.com/NixOS/nixpkgs/commit/973d4e65af289288f1ab71ebbc9dde96c7d6157c) firebase-tools: 13.10.2 -> 13.11.0
* [`ee8d2d40`](https://github.com/NixOS/nixpkgs/commit/ee8d2d40044b957b5c5cd34450ba952d05e47afe) microsoft-edge: 125.0.2535.67 -> 125.0.2535.85
* [`3ab79e41`](https://github.com/NixOS/nixpkgs/commit/3ab79e413a5233653bf9e5a1e845193466ba71ce) directx-headers: 1.611.0 -> 1.614.0
* [`1e443beb`](https://github.com/NixOS/nixpkgs/commit/1e443beb3058038100a385bbbf34765bd1a197ed) mesa: 24.0.8 -> 24.1.1
* [`7d9f4350`](https://github.com/NixOS/nixpkgs/commit/7d9f4350663a413bc2c5a6ade533f8bb2ef8a4ab) qt5.qtbase: cherry-pick build fix for Darwin
* [`23f4ef15`](https://github.com/NixOS/nixpkgs/commit/23f4ef15fc62cbfb1a58cfa92a74f8539202a7ac) lima-bin: 0.21.0 -> 0.22.0
* [`4082c0d4`](https://github.com/NixOS/nixpkgs/commit/4082c0d4395e231409086df8d1ade2a4be43d3f9) gns3-gui: 2.2.46 -> 2.2.47
* [`773fb3e2`](https://github.com/NixOS/nixpkgs/commit/773fb3e21d3b4d48d9a2e172719c0f4d44e91828) gns3-server: 2.2.46 -> 2.2.47
* [`09794af0`](https://github.com/NixOS/nixpkgs/commit/09794af0dd40f0430e7b456be14543a7084e2813) pdk: 3.0.1 -> 3.2.0
* [`d7c878b2`](https://github.com/NixOS/nixpkgs/commit/d7c878b25cf6221d33ba600dc4fc25c420642aaa) snowsql: 1.2.26 -> 1.3.0
* [`afd7a4fc`](https://github.com/NixOS/nixpkgs/commit/afd7a4fc7d6ba4e69d8fee547dfaf9119b8a9b7e) pie-cli: init at 2.0.1
* [`5219bced`](https://github.com/NixOS/nixpkgs/commit/5219bcedc3aceac37461802f7563b97020d28b60) python312Packages.loguru-logging-intercept: init at 0.1.4
* [`0790af32`](https://github.com/NixOS/nixpkgs/commit/0790af3209eaf844f9c3b7cf6c66ebc1096c4c23) xevd: 0.4.1 -> 0.5.0
* [`40204596`](https://github.com/NixOS/nixpkgs/commit/4020459604761af3a9d85c522b3d1a5af75bca42) warp-terminal: 0.2024.05.21.16.09.stable_02 -> 0.2024.06.04.08.02.stable_02
* [`06e0900b`](https://github.com/NixOS/nixpkgs/commit/06e0900b201b4195c89dde9383dd7b77d2c1c5e4) talosctl: 1.7.2 -> 1.7.4
* [`1e0e5e07`](https://github.com/NixOS/nixpkgs/commit/1e0e5e072fa8842856cdb71ba11ec1f1f36455af) cue: 0.8.2 -> 0.9.0
* [`cee4f894`](https://github.com/NixOS/nixpkgs/commit/cee4f894dda442234e7359bf6ab53db181afe253) maintainers: add qubitnano
* [`bfb185ed`](https://github.com/NixOS/nixpkgs/commit/bfb185ed0a3ec790df0a7083ae5511d2d12bd0bb) famistudio: 4.2.0 -> 4.2.1
* [`2291af02`](https://github.com/NixOS/nixpkgs/commit/2291af026d70e24ac2cd520cc8e26f7c58e427a3) 2ship2harkinian: init at 1.0.1
* [`d2adfad3`](https://github.com/NixOS/nixpkgs/commit/d2adfad3bdb649679d40b79d8bc61169dd643714) pkgs/top-level/release{,-lib}.nix: remove hardcoded system
* [`013e398b`](https://github.com/NixOS/nixpkgs/commit/013e398b0fbd51ef36930a91284156241300d38c) lib/tests/release.nix: make pure
* [`8233812d`](https://github.com/NixOS/nixpkgs/commit/8233812d546ab7eb23e830d7c516f067893cad88) flake.nix: make pure
* [`831bdcb9`](https://github.com/NixOS/nixpkgs/commit/831bdcb97432536391e3a6ccab6b1c6c8649f374) sdrangel: 7.21.1 -> 7.21.2
* [`9ebed2c8`](https://github.com/NixOS/nixpkgs/commit/9ebed2c8ea6d93b9279b835a20b604c58394f1de) flake.nix: make checks friendly for non-x86_64-linux systems
* [`9d19ce83`](https://github.com/NixOS/nixpkgs/commit/9d19ce837e71a39167b8a67372b92141bcc2a24f) vscode-extensions.ms-python.vscode-pylance: 2024.5.1 -> 2024.6.1
* [`01587e33`](https://github.com/NixOS/nixpkgs/commit/01587e33aec78bd4c511c0a914341eadda85401e) mesa: fix build on Darwin
* [`84e2b5d0`](https://github.com/NixOS/nixpkgs/commit/84e2b5d05ceeeed34f93588be618c3344ce90e9f) git-town: 14.2.1 -> 14.2.2
* [`db32fe79`](https://github.com/NixOS/nixpkgs/commit/db32fe79bd067d562700241a03e3125552a5fd29) gnomeExtensions: auto-update
* [`b5dff14c`](https://github.com/NixOS/nixpkgs/commit/b5dff14c82667fa0a598fee94e8cf494eb242bb9) famistudio: Fix GLFW startup
* [`4ace1c0f`](https://github.com/NixOS/nixpkgs/commit/4ace1c0faf14ec65193800bd8bea6bf6cb1b52f8) nixos/mqtt2influxdb: add missing package option
* [`2cae5846`](https://github.com/NixOS/nixpkgs/commit/2cae584657970116b86252cfbaa3085dd40b339a) pgadmin4: 8.7 -> 8.8
* [`a741eff4`](https://github.com/NixOS/nixpkgs/commit/a741eff44a26e1cdc2d3fa9c23d43ac5054fd075) vals: enable proxyVendor to get consistent vendorHash between darwin and linux
* [`9094c4b2`](https://github.com/NixOS/nixpkgs/commit/9094c4b2ed0d7dbb254c8db66925c852ac45535a) python312Packages.dahlia: 2.3.2 -> 3.0.0
* [`b37bdda9`](https://github.com/NixOS/nixpkgs/commit/b37bdda9f1e5e7e42b067593165d21f084add30b) qq: 3.2.8 -> 3.2.9
* [`6973b9a3`](https://github.com/NixOS/nixpkgs/commit/6973b9a3423bebf2169909ca6ca218ffcf68a99c) hypnotix: 4.3 -> 4.4
* [`f1502c49`](https://github.com/NixOS/nixpkgs/commit/f1502c49c8bd9f3916560f4d6c4228e278bc1308) gnunet: add patch for taler-merchant
* [`22a06381`](https://github.com/NixOS/nixpkgs/commit/22a063811e95080591caea1daf5ced0933463403) taler-exchange: 0.10.2 -> 0.11.2
* [`89ae4308`](https://github.com/NixOS/nixpkgs/commit/89ae43089fb98a6de13ec33e64574d0d04f0215a) taler-merchant: 0.10.2 -> 0.11.3
* [`6649f40a`](https://github.com/NixOS/nixpkgs/commit/6649f40ab96c19279f7f9a952e988d0dee2cfabe) sync: 0.10.0 -> 0.11.0
* [`275236f0`](https://github.com/NixOS/nixpkgs/commit/275236f0be322314e6b5a7c85a000528ad1d8027) challenger: 0.10.0 -> 0.11.0
* [`4a89ffc4`](https://github.com/NixOS/nixpkgs/commit/4a89ffc4e398ba16bf48d77f96c412c36a97797f) jcef: 767 -> 867
* [`ed2c6b53`](https://github.com/NixOS/nixpkgs/commit/ed2c6b5327a7f8910d177dce7f6a1057b5a12eac) jetbrains-jdk: 17.0.11b1207.24 -> 21.0.3b465.3
* [`abbd01ae`](https://github.com/NixOS/nixpkgs/commit/abbd01ae5c1641c7ccc735344b1c6f2cad534bff) jetbrains: feed jdk21 as jdk
* [`b6a4ffcf`](https://github.com/NixOS/nixpkgs/commit/b6a4ffcfe60d4d5f415680e697d84d3f7a15d1e0) memorado: init at 0.3
* [`6ab94260`](https://github.com/NixOS/nixpkgs/commit/6ab942600d46744addeaf9a7acee506333c246ec) g4music: 3.6 -> 3.6.2
* [`e21eb95c`](https://github.com/NixOS/nixpkgs/commit/e21eb95cc404c91a8e21a6e9e279524caa04be13) go-upower-notify: unstable-2016-03-10 -> 0-unstable-2019-01-06
* [`111f133d`](https://github.com/NixOS/nixpkgs/commit/111f133db422e5629e79aeda45c1166ebbfcaf04) aws-assume-role: migrate to buildGoModule
* [`7058dccc`](https://github.com/NixOS/nixpkgs/commit/7058dccca5b62d2d2dc8c260bef220fd1364c856) simplehttp2server: migrate to buildGoModule
* [`6528e80c`](https://github.com/NixOS/nixpkgs/commit/6528e80c2dab4f5dbf80b263c61adf877731be9e) libgit2: correct license
* [`55a3c7e3`](https://github.com/NixOS/nixpkgs/commit/55a3c7e3cfedaedfdf926c02e6decca8f1685229) mlkit: 4.7.10 -> 4.7.11
* [`ffe47019`](https://github.com/NixOS/nixpkgs/commit/ffe47019de2fa12ec46582599b186938013f1f7c) beeper: 3.105.2 -> 3.106.2
* [`1daa3806`](https://github.com/NixOS/nixpkgs/commit/1daa3806b811fbf1c6a75a85a7df661dec41a322) libplctag: 2.5.5 -> 2.5.6
* [`da11bdb8`](https://github.com/NixOS/nixpkgs/commit/da11bdb8ba2bf991dc53c585711836cdf9621c90) jellyfin-mpv-shim: 2.7.0.post2 -> 2.8.0
* [`277c8578`](https://github.com/NixOS/nixpkgs/commit/277c8578ac2cfcee3b7c063839d4d9309d3806c3) upbound: 0.30.0 -> 0.31.0
* [`186a2f86`](https://github.com/NixOS/nixpkgs/commit/186a2f861bc1fe2af7ff9c0ddd8dd010139f679c) steam-rom-manager: 2.5.8 -> 2.5.9
* [`55fcb63b`](https://github.com/NixOS/nixpkgs/commit/55fcb63b2c3c245f5f9d1aafa68671c4d6304881) zig_0_13: init
* [`f51fda9c`](https://github.com/NixOS/nixpkgs/commit/f51fda9caba6192c87d67bcb774bc93e17e23f79) zig: 0.12 -> 0.13
* [`2e0b011b`](https://github.com/NixOS/nixpkgs/commit/2e0b011b0f477f6294915227a46e8957c97e91f1) moodle-dl: 2.3.7 -> 2.3.9
* [`d13628ee`](https://github.com/NixOS/nixpkgs/commit/d13628ee2bde4d9f3ea17d033f26b69ac8c01ac1) cmake-lint: init at 1.4.3
* [`09d329ea`](https://github.com/NixOS/nixpkgs/commit/09d329ea03b3b06ff847ed64f34e6de804d50d35) lunacy: 9.6.1 -> 9.6.2
* [`a69f5dad`](https://github.com/NixOS/nixpkgs/commit/a69f5dad544ce8a63a95cdc09d6a6d50d2372933) nss_latest: 3.100 -> 3.101
* [`8acd6f32`](https://github.com/NixOS/nixpkgs/commit/8acd6f32b72981bace44297f8ec43be19a518609) reaction: 1.3.1 → 1.4.1
* [`bc90ac0c`](https://github.com/NixOS/nixpkgs/commit/bc90ac0c873b3d88e5df5680e33d2271ec303706) circt: 1.75.0 -> 1.76.0
* [`343d9152`](https://github.com/NixOS/nixpkgs/commit/343d91526a23fee3ba9079c743174a0b2eca8add) python311Packages.ipywidgets: 8.1.2 -> 8.1.3
* [`0115271a`](https://github.com/NixOS/nixpkgs/commit/0115271a28e296c9cd4068494bff1c55efd806f6) python311Packages.jupyter-server: 2.14.0 -> 2.14.1
* [`c141cf5b`](https://github.com/NixOS/nixpkgs/commit/c141cf5bc9240e953bfe73bd7c40e26b5f71619a) python311Packages.jupyterlab-widgets: 3.0.10 -> 3.0.11
* [`67bf4e83`](https://github.com/NixOS/nixpkgs/commit/67bf4e83325a16a73ac07f304b063ad4d89ee4fb) python311Packages.marimo: 0.6.14 -> 0.6.17
* [`164f03d9`](https://github.com/NixOS/nixpkgs/commit/164f03d97108aec32ffd1988f636351f61239e5c) python311Packages.mediapy: 1.2.1 -> 1.2.2
* [`ce313f16`](https://github.com/NixOS/nixpkgs/commit/ce313f16f1cb1e0a3f382fe838ed60a24870ce26) python311Packages.nbdev: 2.3.23 -> 2.3.25
* [`d30c7b6d`](https://github.com/NixOS/nixpkgs/commit/d30c7b6d42f7959a81b19bcd43a4830a0bc97f79) reindeer: 2024.05.27.00 -> 2024.06.03.00
* [`701429c7`](https://github.com/NixOS/nixpkgs/commit/701429c7e9445d2ee7c635de4fafbcbdf4b1d8a8) python311Packages.notebook: 7.2.0 -> 7.2.1
* [`beae7d2b`](https://github.com/NixOS/nixpkgs/commit/beae7d2b520138591c8f654d4460b263a9115ae5) python311Packages.widgetsnbextension: 4.0.10 -> 4.0.11
* [`3a19eca9`](https://github.com/NixOS/nixpkgs/commit/3a19eca9ca4eabb80afc5ec578219c946cd55de9) protoc-gen-twirp: migrate to buildGoModule
* [`a8368d70`](https://github.com/NixOS/nixpkgs/commit/a8368d70aaf3b1d0f8f12ab880f80bab778fba85) makima: 0.9.1 -> 0.9.3
* [`8a60bc9b`](https://github.com/NixOS/nixpkgs/commit/8a60bc9b70569999ef4f17f687551c9567bf4413) cargo-binstall: 1.6.8 -> 1.6.9
* [`225752be`](https://github.com/NixOS/nixpkgs/commit/225752be5cb9fb7353ca6d36d3584200fa3f0d4e) python311Packages.einops: set __darwinAllowLocalNetworking
* [`2561c168`](https://github.com/NixOS/nixpkgs/commit/2561c1684d6546e05404cd76ab25b29b01593542) python311Packages.mkdocs-jupyter: set __darwinAllowLocalNetworking
* [`9345da9e`](https://github.com/NixOS/nixpkgs/commit/9345da9eddde3703c4e836347e5527de15df7325) python311Packages.nbexec: set __darwinAllowLocalNetworking
* [`d76e4030`](https://github.com/NixOS/nixpkgs/commit/d76e403082c1303bbc272667016bfea38c378210) python311Packages.nbexec: adopt pypa build
* [`448a3501`](https://github.com/NixOS/nixpkgs/commit/448a35014e8a135271da938adf82e215cee3e689) python311Packages.pytest-notebook: set __darwinAllowLocalNetworking
* [`a3930f10`](https://github.com/NixOS/nixpkgs/commit/a3930f1096e2b307e0c7678993bdf0b87fca2c74) python311Packages.wasabi: set __darwinAllowLocalNetworking
* [`4cc778c5`](https://github.com/NixOS/nixpkgs/commit/4cc778c5b5f2b08a8780828daedcb3cfd72578fe) pyxel: 2.0.7 -> 2.0.13
* [`9d183b91`](https://github.com/NixOS/nixpkgs/commit/9d183b919c3549a82ba9c4b24724172eb584427e) python311Packages.oauthenticator: add missing inputs
* [`4b12b091`](https://github.com/NixOS/nixpkgs/commit/4b12b091ce5b5de9acb9b2b3381bb5e78ac44738) _64gram: 1.1.24 -> 1.1.27
* [`b035d8cc`](https://github.com/NixOS/nixpkgs/commit/b035d8cc1b9108afef01ee3f91cf96e0d366fa77) vimPlugins.nvim-parinfer: init at 2023-08-09
* [`6e7ff76e`](https://github.com/NixOS/nixpkgs/commit/6e7ff76ec8aba4e5630a3c1b0725589dab64c1ea) vimPlugins.nvim-paredit: init at 2024-03-30
* [`4ec4b303`](https://github.com/NixOS/nixpkgs/commit/4ec4b3039d26e6f978a52d53ca86a32adf04f723) vimPlugins.parpar-nvim: init at 2023-09-12
* [`3becb0c8`](https://github.com/NixOS/nixpkgs/commit/3becb0c8397a8c8ef3278352116fae92faa709ae) maintainers: add qwqawawow
* [`640f8590`](https://github.com/NixOS/nixpkgs/commit/640f859070116994e4264c574232af6644cb52ab) python3Packages.terminaltexteffects: init at 0.10.1
* [`d1d1a7ca`](https://github.com/NixOS/nixpkgs/commit/d1d1a7cabe3630ef0f802a7ae5dabb73c916daa9) vscode-extensions.ms-toolsai.jupyter: 2024.2.0 -> 2024.5.0
* [`70ec7548`](https://github.com/NixOS/nixpkgs/commit/70ec754878074cb76ae3a9e5c70e1c939e86b289) ols: 0-unstable-2024-06-04 -> 0-unstable-2024-06-05
* [`94002e4d`](https://github.com/NixOS/nixpkgs/commit/94002e4d0381a854dbe67bd45c5f5632f8e2b394) turso-cli: 0.93.8 -> 0.95.0
* [`12bd55a1`](https://github.com/NixOS/nixpkgs/commit/12bd55a1a346d773224e318a225c62f7f50aa3ee) nixos/power-profiles-daemon: Add assertion with auto-cpufreq
* [`0acc5576`](https://github.com/NixOS/nixpkgs/commit/0acc5576ae1e85be4e71e40ae45f4cb4576bbfca) weston: 13.0.2 -> 13.0.3
* [`b30a172b`](https://github.com/NixOS/nixpkgs/commit/b30a172bd4ce4960c01a75cbbd23ea1a0c66fd67) openipmi: enable compile with openssl
* [`f3cb4593`](https://github.com/NixOS/nixpkgs/commit/f3cb45939f4ee8f1a88ee1ce42ef519c1a872209) awscli2: 2.15.62 -> 2.16.4
* [`195d155a`](https://github.com/NixOS/nixpkgs/commit/195d155a1c43f23c9f7d9c4d27ae2ed2771a8599) nixos/kerberos_server: use krb format generator, plus misc cleanup
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
