### PR TITLE
niv home-manager: update 3d65009e -> 0a7ffb28

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -41,10 +41,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "3d65009effd77cb0d6e7520b68b039836a7606cf",
-        "sha256": "1vfaiyh5k634m5jmc2fj8k2fzy85f7v5l55zhi2kx200sy3icgsb",
+        "rev": "0a7ffb28e5df5844d0e8039c9833d7075cdee792",
+        "sha256": "1qd5sdpgpadd0972gmngjl0gf96h4cz0xvmv0186pgj6xgzc7amh",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/3d65009effd77cb0d6e7520b68b039836a7606cf.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/0a7ffb28e5df5844d0e8039c9833d7075cdee792.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@3d65009e...0a7ffb28](https://github.com/nix-community/home-manager/compare/3d65009effd77cb0d6e7520b68b039836a7606cf...0a7ffb28e5df5844d0e8039c9833d7075cdee792)

* [`892f76bd`](https://github.com/nix-community/home-manager/commit/892f76bd0aa09a0f7f73eb41834b8a904b6d0fad) mpv: fix package if wrapMpv not found
* [`8d5e27b4`](https://github.com/nix-community/home-manager/commit/8d5e27b4807d25308dfe369d5a923d87e7dbfda3) nix: add a declarative alternative to Nix channels ([nix-community/home-manager⁠#4031](https://togithub.com/nix-community/home-manager/issues/4031))
* [`03c45b98`](https://github.com/nix-community/home-manager/commit/03c45b982c4e1ec683dbcbb587cddb41691bf52a) flake.lock: Update
* [`f2f25464`](https://github.com/nix-community/home-manager/commit/f2f254640ef74ee99cc4d6e76a7a13ec56ed5205) Add translation using Weblate (Arabic)
* [`6396c032`](https://github.com/nix-community/home-manager/commit/6396c03229a8efa21a7550375de26620e07020b6) Add translation using Weblate (Hungarian)
* [`0a7ffb28`](https://github.com/nix-community/home-manager/commit/0a7ffb28e5df5844d0e8039c9833d7075cdee792) Translate using Weblate (Hungarian)
