### PR TITLE
niv nixpkgs: update 311a2516 -> a5f04045

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "311a2516f09102b069951a94a15d61f7a1772427",
-        "sha256": "0jxn47a2d67pcmkjir0m9i8swidyyd63s4sziq7fm2xwjy6j6iq6",
+        "rev": "a5f040459a99b8bbc373d5f04ba7e6ce467b98d1",
+        "sha256": "074c1yvnqq519fcadz2x4r3idaw06684v5mwmjj9svwxn0wadaf7",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/311a2516f09102b069951a94a15d61f7a1772427.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/a5f040459a99b8bbc373d5f04ba7e6ce467b98d1.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@311a2516...a5f04045](https://github.com/nixos/nixpkgs/compare/311a2516f09102b069951a94a15d61f7a1772427...a5f040459a99b8bbc373d5f04ba7e6ce467b98d1)

* [`b7a7ec94`](https://github.com/NixOS/nixpkgs/commit/b7a7ec94b2f589e2b0947ca0dbd306321dd51b84) maintainers: add CompileTime
* [`64a508ca`](https://github.com/NixOS/nixpkgs/commit/64a508ca14454d8fc93ef673fb62d9712703c125) keym: init at unstable-2022-07-10
* [`2039ace2`](https://github.com/NixOS/nixpkgs/commit/2039ace2f4008fb413834b8f236462ba1f02a458) pipenv: 2023.2.4 -> 2023.10.24
* [`9fb55f49`](https://github.com/NixOS/nixpkgs/commit/9fb55f492c750da2ffcfd69bd958f156fe86f2a7) auto-multiple-choice: use absolute paths instead of "portable" strategy
* [`b94b1515`](https://github.com/NixOS/nixpkgs/commit/b94b15151a2d3c9ff8f13dad82fbd1f0d8354563) auto-multiple-choice: add itself to PATH in the wrapper
* [`0bc46513`](https://github.com/NixOS/nixpkgs/commit/0bc465130d2edc57adddc25b678091bf01b0f77c) turbovnc: 3.1 -> 3.1.1
* [`52224652`](https://github.com/NixOS/nixpkgs/commit/5222465234b92964917c55fe7711e88743bdeb82) libadwaita: Fully move demo files to devdoc output
* [`0c5ac1a7`](https://github.com/NixOS/nixpkgs/commit/0c5ac1a76d520b8567f338421cd9963bbc5031eb) libadwaita: Add desktop-file-utils optional build dep
* [`01156661`](https://github.com/NixOS/nixpkgs/commit/011566614fe435126d96794a88798ebb819f6850) qpdf: add some key reverse-dependencies to passthru.tests
* [`abf7172b`](https://github.com/NixOS/nixpkgs/commit/abf7172bfafdd6f67d5df62d08d9cd2d4d107975) tests.references: migrate from nixosTest to runNixOSTest
* [`453e3947`](https://github.com/NixOS/nixpkgs/commit/453e3947068d9beb1153b59f0062d84b20b5f969) maintainers: add fidgetingbits
* [`e81b4c07`](https://github.com/NixOS/nixpkgs/commit/e81b4c07ac872cb80e1ab01ecc9b900b4fe4788d) maintainers: add caralice
* [`6729c6c6`](https://github.com/NixOS/nixpkgs/commit/6729c6c653f17a5f9f1dcf5439d3e98652406042) nixos: sourcehut: fix some binary paths
* [`17e810e5`](https://github.com/NixOS/nixpkgs/commit/17e810e5c66ef08ee36d0f9e7b9ad6652368e160) python312Packages.dunamai: 1.19.2 -> 1.20.0
* [`68d999f6`](https://github.com/NixOS/nixpkgs/commit/68d999f63d304bd3c0bf4335fa552677947dba50) python3Packages.hatch-odoo: init at 0.1
* [`ad7afa95`](https://github.com/NixOS/nixpkgs/commit/ad7afa95c63bfa760f9bf6aeb1e33c12b808dd43) aircrack-ng: refactor
* [`e9570410`](https://github.com/NixOS/nixpkgs/commit/e9570410a1a9d0f5fea3fe06486d65acfb0f0866) nixos/postsrsd: prefer 'install' over 'chmod/chown'
* [`01189fb8`](https://github.com/NixOS/nixpkgs/commit/01189fb83231e02ff9226384836d3e3da9f70238) flatpak: fix config location
* [`900df250`](https://github.com/NixOS/nixpkgs/commit/900df250350fd51c101a92efdde6b222b2c8d228) gummy: 0.3 -> 0.5.4
* [`f2f833d8`](https://github.com/NixOS/nixpkgs/commit/f2f833d852ac4dd587a88c6c1f46a037920c9255) gummy: 0.5.4 -> 0.6.0
* [`f498f8ef`](https://github.com/NixOS/nixpkgs/commit/f498f8ef4a0142acacbe9b945f3939efb6670b58) nixos/kubeswitch: use 'runCommand' instead of 'phases'
* [`470a5547`](https://github.com/NixOS/nixpkgs/commit/470a55471207f9de70893f2ef788f11fee607053) hyprpaper: 0.6.0 -> 0.7.0
* [`25f30dac`](https://github.com/NixOS/nixpkgs/commit/25f30dac19f57fcf97902bd86eccc2599130a71c) igraph: 0.10.11 -> 0.10.12
* [`a456465e`](https://github.com/NixOS/nixpkgs/commit/a456465e6b3fd7356c5efad300a11ecf542630ef) yubico-piv-tool: add meta.pkgConfigModules, passthru.tests.pkg-config
* [`3801a6e4`](https://github.com/NixOS/nixpkgs/commit/3801a6e450de7b086e2e60cdeda8a04e334b9c06) yubico-piv-tool: remove `with lib;`, use `--replace-fail`
* [`e4d2291c`](https://github.com/NixOS/nixpkgs/commit/e4d2291c0e5d781de277e578bbb7c051ef0c3eba) yubico-piv-tool: move check to nativeCheckInputs
* [`ecb29e46`](https://github.com/NixOS/nixpkgs/commit/ecb29e46676b21fa3dcd5ce6779b15cb32ce202c) yubico-piv-tool: use lib.cmakeFeature, lib.cmakeBool
* [`e4d99c82`](https://github.com/NixOS/nixpkgs/commit/e4d99c8236129a45c4199370f0943c6ce4ef7288) steamPackages.steam-runtime: 0.20231127.68515 -> 0.20240415.84615
* [`751a2882`](https://github.com/NixOS/nixpkgs/commit/751a2882d09983ae64afb26eb2222ad4edc1e071) figma-linux: add NIXOS_OZONE_WL workaround
* [`615d19be`](https://github.com/NixOS/nixpkgs/commit/615d19beb3065a9b35495e0ba2d905d6ed4f9a66) nixos/swap: prefer 'umask' over 'chmod'
* [`fb609d55`](https://github.com/NixOS/nixpkgs/commit/fb609d558bdc475755dc138015fe42d02a403406) figma-linux: pass wrapper gapps arguments directly
* [`aa4afc89`](https://github.com/NixOS/nixpkgs/commit/aa4afc89317e684899b96068bdf74c59961083c7) tg-archive: init at 1.1.3
* [`6cacd45b`](https://github.com/NixOS/nixpkgs/commit/6cacd45bb6f880ef68c36648f9235ef9c07c30ab) maintainers: add redhawk
* [`d32a192b`](https://github.com/NixOS/nixpkgs/commit/d32a192ba91f4f93c84b2dab632dc573c25a1ae7) coin3d: unstable-2022-07-27 -> 4.0.2
* [`29f44177`](https://github.com/NixOS/nixpkgs/commit/29f441773047e39e77d0b17ace887e0f3284ea33) lib/licenses: sort xskat
* [`15718cc8`](https://github.com/NixOS/nixpkgs/commit/15718cc856f7f856cf16dcfcc6c356475760ea4c) lib/license: add zsh license
* [`4e841288`](https://github.com/NixOS/nixpkgs/commit/4e8412889f48f84fabc79203ffcf1bb49d0522ea) zsh-completions: add licenses
* [`089952b7`](https://github.com/NixOS/nixpkgs/commit/089952b7f31a1b6ca040afaf76a9c4b390da1eac) caligula: mark darwin as no longer broken
* [`abbbac60`](https://github.com/NixOS/nixpkgs/commit/abbbac60701a118c210ff3b72b9680946e594122) R: 4.3.3 -> 4.4.0
* [`d44a08dd`](https://github.com/NixOS/nixpkgs/commit/d44a08dd6574bfc8c701fd0bab02a01391a422f3) rPackages Bioc: changed mirror from Dortmund to main
* [`2627dd46`](https://github.com/NixOS/nixpkgs/commit/2627dd4684ab16d1278683b3c72fe1c81e703b18) rPackages: CRAN and BioC update
* [`86bab9af`](https://github.com/NixOS/nixpkgs/commit/86bab9af82a60ff21f107a0cea86cc5e4c55a45f) rPackages.rJava: fixed build by adding libdeflate
* [`9face069`](https://github.com/NixOS/nixpkgs/commit/9face0697a5f0c3bcaee11b910d98726a66df235) rPackages.rtracklayer: fixed build by adding curl.dev
* [`fdc6bf98`](https://github.com/NixOS/nixpkgs/commit/fdc6bf98372798f79ec01cc7cd93e135b7041bb1) python312Packages.rpy2: add libdeflate dependency
* [`3c2a7509`](https://github.com/NixOS/nixpkgs/commit/3c2a75098003690387d3d2606ee7ab8db9ff6996) ispc: 1.23.0 -> 1.24.0
* [`e555b9f2`](https://github.com/NixOS/nixpkgs/commit/e555b9f29781adb5cf706aac3272c02f34a638a0) rPackages.quarto: use replace-fail instead of replace and update pattern
* [`408d8043`](https://github.com/NixOS/nixpkgs/commit/408d80432dee15b26a60aa02f3f69e33d24b1499) rPackages.RNifti: fixed build
* [`3ea9dd81`](https://github.com/NixOS/nixpkgs/commit/3ea9dd816eafb55fda7b5b948951c474e663c2cf) prometheus-jmx-javaagent: init at 0.20.0
* [`6209d8dc`](https://github.com/NixOS/nixpkgs/commit/6209d8dc0aeab22e3565c19a84cba58d9a2b43f8) rPackages.arcgisutils: fixed build
* [`76e58606`](https://github.com/NixOS/nixpkgs/commit/76e5860619b467a4cd5cee8088c6119340ea31aa) rPackages.ratioOfQsprays: fixed build
* [`d0537e0b`](https://github.com/NixOS/nixpkgs/commit/d0537e0b052dec9a406a06c575482ae9bf85b791) rPackages.littler: fixed build
* [`58be6378`](https://github.com/NixOS/nixpkgs/commit/58be6378f41dd0e6583689543ddf02e59aad331c) rPackages.asciicast: fixed build
* [`511c1289`](https://github.com/NixOS/nixpkgs/commit/511c128969ac3fe48126362769153c9e5a9141d1) python3Packages/rpi-gpio2: remove package
* [`779cbe5f`](https://github.com/NixOS/nixpkgs/commit/779cbe5f41621044cea6a9c42739b3a0fe354c54) rPackages.Colossus: fixed build
* [`fe028ad1`](https://github.com/NixOS/nixpkgs/commit/fe028ad1f576beb52d0087353186c2fccf1c2306) rPackages.unrtf: fixed build
* [`b841a48d`](https://github.com/NixOS/nixpkgs/commit/b841a48d3a20d0d6b8457e7892b84350d5c2c993) rPackages.spMC: fixed build
* [`d3c936b0`](https://github.com/NixOS/nixpkgs/commit/d3c936b0b7d81a783f88a22367b5e041a688e260) rPackages.loon_tourr: fixed build
* [`8d94ef07`](https://github.com/NixOS/nixpkgs/commit/8d94ef0736e1de6fef0c3782ce38c2e339f405f0) rPackages.fangs: fixed build
* [`f90460c9`](https://github.com/NixOS/nixpkgs/commit/f90460c95343ae8e3ab3e175442e2dc88df9c578) rPackages.rGADEM: Fix build
* [`99216362`](https://github.com/NixOS/nixpkgs/commit/99216362bff012c3990533e55feb546784f2a41c) rPackages.cisPath: fix build
* [`b3f67825`](https://github.com/NixOS/nixpkgs/commit/b3f67825d5a65f7ee0327716526700fae761963c) rPackages.HilbertVis: fix build
* [`c7864c9a`](https://github.com/NixOS/nixpkgs/commit/c7864c9ad22a7aaa03bf98e74a8d06e9903cc2ba) rPackages.MANOR: fix build
* [`486ee88d`](https://github.com/NixOS/nixpkgs/commit/486ee88d17cb4243cf348b0c373abf6d2e6be159) rPackages.Rbwa: fix build
* [`f7d8046f`](https://github.com/NixOS/nixpkgs/commit/f7d8046fb83cf0bb4e0a8ad179dee89bcbe0335d) buildDotnetModule: fix structured attributes support
* [`949dcfa9`](https://github.com/NixOS/nixpkgs/commit/949dcfa9c92cb96457e5100cfe4669f9b5cb9d81) dosbox-staging: add patch to fix darwin build
* [`307e221f`](https://github.com/NixOS/nixpkgs/commit/307e221f0d712134cfc73dda010f87428b841a09) sbcl: make deriv options overridable attributes
* [`88d44eda`](https://github.com/NixOS/nixpkgs/commit/88d44edacb2c5ab37e02993fdd849a4789a784e1) rPackages.beer: fix build
* [`773c17e7`](https://github.com/NixOS/nixpkgs/commit/773c17e75258d2aa44dcef17123f129447f0ea11) postgresqlPackages.plv8: 3.1.10 -> 3.2.2
* [`ca5654ba`](https://github.com/NixOS/nixpkgs/commit/ca5654ba7dc0c6226b91d3b24a986da316aef761) zammad: use nodejs.libv8
* [`826cc7fa`](https://github.com/NixOS/nixpkgs/commit/826cc7fa1c45a8a5d54c9aa7e262f8a72d056472) rubyPackages.libv8: use nodejs.libv8
* [`3fcfa7a8`](https://github.com/NixOS/nixpkgs/commit/3fcfa7a8ea8ce012d211dda1a10d9443c83e8590) rPackages.OpenRepGrid: fixed build
* [`214a77ff`](https://github.com/NixOS/nixpkgs/commit/214a77ff836ff093229ec6cb6643bac284cfee7d) rPackages.V8: use nodejs.libv8
* [`bea2f0a2`](https://github.com/NixOS/nixpkgs/commit/bea2f0a2eaed6e0d7e139c5d5e55095843cc875f) v8: mark vulnerable
* [`f1e6327a`](https://github.com/NixOS/nixpkgs/commit/f1e6327a874bdf32ac2246084f81a7133ba69926) scala: make scala 3 the default
* [`7dd3ce29`](https://github.com/NixOS/nixpkgs/commit/7dd3ce2932f8d104fde6ba6165b2e95e22d0ab38) jasp-desktop: disable format hardening for R 4.4.0
* [`9d5ba9c8`](https://github.com/NixOS/nixpkgs/commit/9d5ba9c86e06ceb6f0933e3148c6f22ad297373f) rPackages.oligo: disabling format hardening
* [`86f8e104`](https://github.com/NixOS/nixpkgs/commit/86f8e1049ad279303f08f9d3284ee574969de97b) rPackages.Rdisop: disable format hardening
* [`7e71c44c`](https://github.com/NixOS/nixpkgs/commit/7e71c44c9b77f4e8ce81d08db84ac2a9b59850c1) rPackages.dbarts: x86 platform only
* [`e68ebc7c`](https://github.com/NixOS/nixpkgs/commit/e68ebc7c8db2f33c80c228a44331f9f271ec10c2) rPackages.SharedObject: fix build
* [`c56c1481`](https://github.com/NixOS/nixpkgs/commit/c56c1481e02f3564f5f1e4e513f3cac746185c58) rPackages.Rhisat2: remove backport and disable parallel building
* [`a227067e`](https://github.com/NixOS/nixpkgs/commit/a227067e0328554f241fc613e7a82b4fc0b0eb47) rPackages.cubature: disable parallel building
* [`f9620920`](https://github.com/NixOS/nixpkgs/commit/f9620920f9ded59b11f0192cad0aace0860bb932) rPackages.networkscaleup: disable parallel building and ignored attributes warning
* [`9e2e8395`](https://github.com/NixOS/nixpkgs/commit/9e2e839505ea5ffce9c08755d3a7ab04d9731f51) rPackages.FlexReg: disable parallel building and ignored attributes warning
* [`0d17c3d9`](https://github.com/NixOS/nixpkgs/commit/0d17c3d98ae31a9b3afd8be359416d362459e3e2) rPackages.covidmx: fix build
* [`2c8ad1d1`](https://github.com/NixOS/nixpkgs/commit/2c8ad1d1eb1ea686ec39befb36d8202085bd8051) nixos/gnome/gnome-keyring: rewrite the implementation
* [`bcaca235`](https://github.com/NixOS/nixpkgs/commit/bcaca23529cd7d51dc432ca661076a54036e1143) freebsd.compat: re-add lost patch
* [`295c645d`](https://github.com/NixOS/nixpkgs/commit/295c645d807e4754b7d1f89ffdb65263cae9f042) freebsd.boot-install: wrap coreutils install instead of netbsd
* [`2785d4f4`](https://github.com/NixOS/nixpkgs/commit/2785d4f4aea77ac220eb329bc7c028f9819e9bff) freebsd.filterSource: use a less featureful rsync
* [`ba5f1b44`](https://github.com/NixOS/nixpkgs/commit/ba5f1b4400d3180563fc0822bb529eaf3239875c) freebsd.mkDerivation: process patches generated with git
* [`61202561`](https://github.com/NixOS/nixpkgs/commit/61202561d92cf1cd74532fcbd8b9d6662c5bc57b) freebsd.{libc,compat,include}: use no-libs stdenv
* [`d78f853f`](https://github.com/NixOS/nixpkgs/commit/d78f853f7e3bf84924d54c0280f4bca2e0665d57) freebsd.libxo: init
* [`95fa436f`](https://github.com/NixOS/nixpkgs/commit/95fa436fbe232a7da493775eeef9a794d249de15) freebsd.libelf: init
* [`d792ea2d`](https://github.com/NixOS/nixpkgs/commit/d792ea2d412b9229bbb265d08e3b07a669d696d2) freebsd.{libncurses,libncurses-tinfo}: init
* [`98587064`](https://github.com/NixOS/nixpkgs/commit/98587064a0d688f9fbfc4437571734b77dde6601) freebsd.libedit: init
* [`a753d385`](https://github.com/NixOS/nixpkgs/commit/a753d385dad0a3603ac9ddb378da1727bad9ebe3) freebsd.libjail: init
* [`ae993bd1`](https://github.com/NixOS/nixpkgs/commit/ae993bd1e345cf4bb822bda3fce12f688cd523c4) freebsd.libdl: init
* [`78536028`](https://github.com/NixOS/nixpkgs/commit/78536028670181b6e1c78b6bbbb50724dcd7cd02) freebsd.libcasper: init
* [`892f600e`](https://github.com/NixOS/nixpkgs/commit/892f600edd9608ee277cf8c5cb4bf31f1a677a3e) freebsd.libcapsicum: init
* [`ce0a5ce3`](https://github.com/NixOS/nixpkgs/commit/ce0a5ce3400e952c9e400a5785dd9539dba1c2d2) freebsd.localedef: init
* [`2c41534d`](https://github.com/NixOS/nixpkgs/commit/2c41534d75174f30e770ac58363242cce9cfaeef) freebsd.locales: init
* [`fe0a4053`](https://github.com/NixOS/nixpkgs/commit/fe0a405397cf84861b4b866f40142f3a2c362b54) freebsd.locale: init
* [`2bf35078`](https://github.com/NixOS/nixpkgs/commit/2bf350788ce698b1f9bd8c73bb74a53bfbce65b9) freebsd.bin: init
* [`1bc374d9`](https://github.com/NixOS/nixpkgs/commit/1bc374d91d74d0f0a4736196998ed2f280c3457b) freebsd.cp: init
* [`8d5db1db`](https://github.com/NixOS/nixpkgs/commit/8d5db1db1619a5b0963a3abb49600ff71ee96405) freebsd.iconv: init
* [`41c2bba8`](https://github.com/NixOS/nixpkgs/commit/41c2bba81ec7c3c03b5841ad8c981b6f98a261be) freebsd.ldd: init
* [`57814866`](https://github.com/NixOS/nixpkgs/commit/57814866676a49111385ac5380be4983cc0b465f) itools: init at 1.1
* [`509bbd7a`](https://github.com/NixOS/nixpkgs/commit/509bbd7a4ade8fbc92b84d47a85b4fff2cadda99) nixos-rebuild: Document all supported builder flags in manpage
* [`fc7b2411`](https://github.com/NixOS/nixpkgs/commit/fc7b241197602f306f01b24c7cced74afd76c4b5) rPackages.loon_shiny: fixed build
* [`d9ebb9c2`](https://github.com/NixOS/nixpkgs/commit/d9ebb9c2cdbd6f28de9d6bf97af5a7a865be5ef0) rPackages.RNiftyReg: fixed build
* [`411d794f`](https://github.com/NixOS/nixpkgs/commit/411d794f1ff612ee1d8e4ce9fe1e93a9b47a5955) rPackages.crc32c: fixed build
* [`a5e6faa0`](https://github.com/NixOS/nixpkgs/commit/a5e6faa0991e165aee51d41417aae109add2adf1) rPackages.RcppGetconf: fixed build
* [`cd5ff1aa`](https://github.com/NixOS/nixpkgs/commit/cd5ff1aa4a3ffe8ab34d8bda3ece93abd9f8c27e) rPackages.frailtyMMpen: fixed build
* [`d6464325`](https://github.com/NixOS/nixpkgs/commit/d6464325b51e042f3c78dfc680f8a1702fe86005) rPackages.rshift: fixed build
* [`81cb0518`](https://github.com/NixOS/nixpkgs/commit/81cb05183ba6cac0d7f1353f483d733d4df85acc) rPackages.imbibe: fixed build
* [`8d88d51f`](https://github.com/NixOS/nixpkgs/commit/8d88d51fabbb02eb3c29639d161c6982034f8609) rPackages.registr: fixed build
* [`bde1aa58`](https://github.com/NixOS/nixpkgs/commit/bde1aa5882f00ed8ac9880bb617f17a15cda7f74) rPackages.bigrquerystorage: fixed build
* [`93e3fd18`](https://github.com/NixOS/nixpkgs/commit/93e3fd181fe0a2bb67191d3010d79d441ca5939d) rPackages.optbdmaeAT: fixed build
* [`5ae801af`](https://github.com/NixOS/nixpkgs/commit/5ae801af006c9a0f3271f8385f755f063daa62e7) rPackages.symbolicQspray: fixed build
* [`639e0406`](https://github.com/NixOS/nixpkgs/commit/639e040640f4d06597419b23b80905a8c398f21c) rPackages.sbrl: fixed build
* [`9cd6afe4`](https://github.com/NixOS/nixpkgs/commit/9cd6afe46b2ef47a4b5183c3627f75e49e3835b2) rPackages.tkImgR: fixed build
* [`29af2e1c`](https://github.com/NixOS/nixpkgs/commit/29af2e1c17b99567ae04719f9a1e81f6578a94a6) rPackages.fingerPro: fixed build
* [`1bf608e4`](https://github.com/NixOS/nixpkgs/commit/1bf608e490ebc997596fcf4f475141deeb61f9fd) rPackages.libstable4u: fixed build
* [`dff72aa7`](https://github.com/NixOS/nixpkgs/commit/dff72aa7654c05d802064d2f8aa76b16a8e506bc) rPackages.gpuMagic: fixed build
* [`2ccd4e4c`](https://github.com/NixOS/nixpkgs/commit/2ccd4e4ccf27887639d51e649b52485098a5b2cd) rPackages.Apollonius: fixed build
* [`8b55254b`](https://github.com/NixOS/nixpkgs/commit/8b55254b52130878ee0208ca0ab6c5aa992106b7) rPackages.neojags: fixed build
* [`98350903`](https://github.com/NixOS/nixpkgs/commit/983509037960dfc30e62d259b2d56bcec6e21a17) doc/release-notes: fix mention of ankisyncd
* [`f0957fdc`](https://github.com/NixOS/nixpkgs/commit/f0957fdc7752fc121138c8f34bf68a15b1b119d7) rPackages.hgwrr: fixed build
* [`13a755b6`](https://github.com/NixOS/nixpkgs/commit/13a755b61838474d4f699f25f262e34274a37862) rPackages.soptdmaeA: fixed build
* [`741dabd6`](https://github.com/NixOS/nixpkgs/commit/741dabd6cc5db7cc05b341374fefbfb368c651e3) rPackages.PEPBVS: fixed build
* [`24904590`](https://github.com/NixOS/nixpkgs/commit/24904590808691064bed015384d2096c1521b053) rPackages.smcryptoR: fixed build
* [`53a98977`](https://github.com/NixOS/nixpkgs/commit/53a98977b01467871d27886547a379b2fa225f03) rPackages.sphereTessellation: fixed build
* [`28458c6e`](https://github.com/NixOS/nixpkgs/commit/28458c6ef2304a35d34ed4f48b0156876acea5c2) rPackages.gasanalyzer: fixed build
* [`594c902f`](https://github.com/NixOS/nixpkgs/commit/594c902f225e2ad708ccc433d8a5e22e6ea8f3b9) rPackages.optrcdmaeAT: fixed build
* [`b8873a8a`](https://github.com/NixOS/nixpkgs/commit/b8873a8a8038db832d5c8620bac1a7f7e773cce6) top-level/aliases: Clean up outdated Nix aliases
* [`a9116cef`](https://github.com/NixOS/nixpkgs/commit/a9116cef2b1027d25389951333e847ef6d842ea1) lib.systems.riscv-multiplatform: set linux-kernel.preferBuiltin
* [`50a6be5f`](https://github.com/NixOS/nixpkgs/commit/50a6be5f8b0d316f44d9a10282cc10be1d6fa977) lib.systems.riscv-multiplatform: drop linux-kernel.extraConfig
* [`68a90126`](https://github.com/NixOS/nixpkgs/commit/68a9012606146432c03bd0ed2f864ba6723c552d) rPackages.rgoslin: fix build
* [`987beab5`](https://github.com/NixOS/nixpkgs/commit/987beab599b903924bdf1d4e5b06ba42ea45b8d5) rPackages.HilbertVisGUI: fix build
* [`3895812b`](https://github.com/NixOS/nixpkgs/commit/3895812b01eeba03afbac3e9b607588890d0f8bf) rPackages.arcgisgeocode: fix build
* [`69b21aa8`](https://github.com/NixOS/nixpkgs/commit/69b21aa8778dd0c7f4a1ad0a6e807d0b7ad7580d) rPackages.arcgisplaces: fix build
* [`607240ec`](https://github.com/NixOS/nixpkgs/commit/607240ec3df61ea03d80bb0fb730ff4ece37111b) rPackages.heck: fixed build
* [`fe68d339`](https://github.com/NixOS/nixpkgs/commit/fe68d3398fd2e53506c7e171e7af9f4dc89704c8) rPackages.gamstransfer: fixed build
* [`3ac1afe4`](https://github.com/NixOS/nixpkgs/commit/3ac1afe403d99d0a1a417209528deb9c1f808aaa) zhook: init at 0-unstable-10-31-2021
* [`67ec6da0`](https://github.com/NixOS/nixpkgs/commit/67ec6da0eb470279fc786a3876038b9b1a44b507) rPackages.image_CannyEdges: fixed build
* [`897f0a56`](https://github.com/NixOS/nixpkgs/commit/897f0a56c647dbb2f3e2b0d64a86134dab94a6ed) rPackages.disbayes: fix build
* [`70b4eb93`](https://github.com/NixOS/nixpkgs/commit/70b4eb935b34fb9d328450a87da8420558b54ae1) rPackages.tipsae: fix build
* [`eadd62c2`](https://github.com/NixOS/nixpkgs/commit/eadd62c2c78b85b83224d5ae2e23f80f31c71431) rPackages.TriDimRegression: fix build
* [`8fb0719b`](https://github.com/NixOS/nixpkgs/commit/8fb0719b10cdddc7fa23a8b910d88be3f24bb5c0) rPackages.bbmix: fix build
* [`53dbb997`](https://github.com/NixOS/nixpkgs/commit/53dbb997251c44da23f0d9c74a388c9cf0ce58f1) rPackages.surveyvoi: fixed build
* [`48d567fc`](https://github.com/NixOS/nixpkgs/commit/48d567fc7b299de90f70a48e4263e31f690ba03e) gradle: 8.7 → 8.8
* [`d276f057`](https://github.com/NixOS/nixpkgs/commit/d276f0573b60ecb1c87f4f25d6569d4926e8f02a) nixos/prometheus: Renamed existing Prometheus test to Thanos.
* [`d6296ece`](https://github.com/NixOS/nixpkgs/commit/d6296eceaf3792e5a8b00bd6c76bbcb2cca0bc43) nixos/prometheus: Added simple two Prometheus server testcase
* [`61e79152`](https://github.com/NixOS/nixpkgs/commit/61e7915267bbaf1bf1e9a84a747442b9db11274c) nixos/prometheus: Added remote-write test case
* [`87cb2d58`](https://github.com/NixOS/nixpkgs/commit/87cb2d582e32fa75a07be128674b8aa0f1eeb234) nixos/prometheus: Added pushgateway test case
* [`38495e1e`](https://github.com/NixOS/nixpkgs/commit/38495e1ec0399ab6b8873eee45d40cb0e525ed69) nixos/prometheus: Added federation test case
* [`8c159a43`](https://github.com/NixOS/nixpkgs/commit/8c159a4342f8adf1bfcb67997c31552a401d3603) maintainer-list.nix: Added jpds.
* [`03161fa5`](https://github.com/NixOS/nixpkgs/commit/03161fa57114f32ec36a8e1e6256b9aa91e59d7f) alertmanager-webhook-logger: init at 1.0
* [`571db452`](https://github.com/NixOS/nixpkgs/commit/571db452695e0d7996501c9904fbb47ebd1e08f3) nixos/alertmanager-webhook-logger: init module
* [`0c99c5f8`](https://github.com/NixOS/nixpkgs/commit/0c99c5f8b7de18deb882bcfb09c297c90fc947f0) nixos/prometheus: Added Alertmanager test case
* [`2c6830c4`](https://github.com/NixOS/nixpkgs/commit/2c6830c47e9fea0dd54eed51ed5f88e974c87334) nixos/prometheus: Move config reload test to subtest
* [`0cb65f8e`](https://github.com/NixOS/nixpkgs/commit/0cb65f8e4832c4559b661c4de0ff6c1ec5dcd336) alertmanager: Added nixosTests to passthru.tests
* [`5adadf25`](https://github.com/NixOS/nixpkgs/commit/5adadf25c6eba445401bd2a270a74a9c3bac73c2) pushgateway: Added nixosTests to passthru.tests
* [`42936433`](https://github.com/NixOS/nixpkgs/commit/42936433795024f3eaca3b5d7cf998ab61e592e1) rPackages.CTexploreR: mark as broken
* [`f299deba`](https://github.com/NixOS/nixpkgs/commit/f299debaac1cd0271291e9061aae486b46be2400) bundlerEnv: Fix passthru not being passed-through
* [`f4724cf6`](https://github.com/NixOS/nixpkgs/commit/f4724cf6d53fff1910b725574873fd151fe04988) pywalfox-native: fix install
* [`0fe45895`](https://github.com/NixOS/nixpkgs/commit/0fe4589526affa4c997a88b2a32aadfb72966d22) python311Packages.htmllaundry: remove
* [`f9b9794d`](https://github.com/NixOS/nixpkgs/commit/f9b9794d934ebf5246c46ac457a72c02bf2ec390) nix: make boehmgc patch respect HAVE_PTHREAD_ATTR_GET_NP
* [`c51da30a`](https://github.com/NixOS/nixpkgs/commit/c51da30a140948f451317bc432ab02fc56a2b5c0) libreoffice: add libreoffice-qt6{,-unwrapped} aliases, little cleanup
* [`b81838e3`](https://github.com/NixOS/nixpkgs/commit/b81838e36b0295a2c5f2ebe008c32bb238f2d5bc) maintainers: add mimvoid
* [`524cca35`](https://github.com/NixOS/nixpkgs/commit/524cca3578e5b3d9fa3ef7ba80a57eb69e51c8d9) catppuccin-grub: init at 1.0.0
* [`1516a756`](https://github.com/NixOS/nixpkgs/commit/1516a75687501f31aa91824c2e4183dcb281bc4d) haskellPackages.leveldb-haskell: unbreak
* [`9106eb8a`](https://github.com/NixOS/nixpkgs/commit/9106eb8ad99147c1bc5830a903479672d2bd8cdf) haskellPackages.selda: unbreak
* [`6cf36aaf`](https://github.com/NixOS/nixpkgs/commit/6cf36aaf6354991c61fc087d5d5d61a3256c0bbe) cmus: add sndioSupport feature flag
* [`7f2f59e3`](https://github.com/NixOS/nixpkgs/commit/7f2f59e34e9295d659bd0fbde1b0b79c8929a509) cmus: 2.10.0-unstable-2023-11-05 -> 2.11.0
* [`57aff44e`](https://github.com/NixOS/nixpkgs/commit/57aff44e39e7eb86d45241ff3caa8686b641b3f2) kicad: 8.0.2 -> 8.0.3
* [`2ac24498`](https://github.com/NixOS/nixpkgs/commit/2ac24498410de0d9cebc988e5773df7fdef2b4ea) nixos-rebuild: document supported flake-related options
* [`4636757b`](https://github.com/NixOS/nixpkgs/commit/4636757b18c6c3496f74d5908b871ba56c8273f6) haskellPackages.scat: unbreak
* [`ee7cf64d`](https://github.com/NixOS/nixpkgs/commit/ee7cf64d90544e1de0ebc65d777cd3c925a10eaf) acl2: update SBCL override to overrideAttrs
* [`706084cf`](https://github.com/NixOS/nixpkgs/commit/706084cfd186533f00587ae5ceaac2f7cd4c6840) python311Packages.rapidfuzz: 3.9.2 -> 3.9.3
* [`3ef17e2e`](https://github.com/NixOS/nixpkgs/commit/3ef17e2e9fe415d07dd9cd737be11b3151f3eb52) losslesscut-bin: 3.58.0 -> 3.61.1
* [`0b8fdfd9`](https://github.com/NixOS/nixpkgs/commit/0b8fdfd917b4994325312c1b5e7ad24e34a6b997) nixos/pretix: fix defaultText for celery options
* [`598462ad`](https://github.com/NixOS/nixpkgs/commit/598462adbd5322dee73893cb135ce2389f293665) c3c: specify meta.mainProgram
* [`809e6a82`](https://github.com/NixOS/nixpkgs/commit/809e6a82a49daae236f02f7c509a85be56d76735) losslesscut-bin: *-dmg: unpack with _7zz instead of undmg
* [`c47da573`](https://github.com/NixOS/nixpkgs/commit/c47da5739fb9ee0cc9fcb02d02f53b5c722097ce) losslesscut-bin: *-dmg: refactor
* [`56e05f27`](https://github.com/NixOS/nixpkgs/commit/56e05f27a3a9da27f74a03e0c7a5907f53c14d14) losslesscut-bin: *-windows: refactor
* [`46db91c0`](https://github.com/NixOS/nixpkgs/commit/46db91c0d789d62d5e44e9ef01f97b12f465c33e) nixos/samba: only create /etc/samba/smb.conf when samba is enabled
* [`82cd5ab3`](https://github.com/NixOS/nixpkgs/commit/82cd5ab3e137738df038e6f27e491be73a0639d8) qlog: 0.35.2 -> 0.36.0
* [`872ec390`](https://github.com/NixOS/nixpkgs/commit/872ec3906394bed40e177d669264a43ddaf0be38) mpvScripts.mpvacious: 0.34 -> 0.35
* [`2d1ba655`](https://github.com/NixOS/nixpkgs/commit/2d1ba655487ce56667c53a8cd0439a1f184d02b1) nex: migrate to buildGoModule
* [`8e981f20`](https://github.com/NixOS/nixpkgs/commit/8e981f2094c1081b80851d65d2d70bde4c5698d4) licenses: add FSL-1.1-MIT
* [`6ae60446`](https://github.com/NixOS/nixpkgs/commit/6ae604462f79ae60d7347171e92fe19ad7f6162e) gitbutler: init at 0.12.2
* [`5ed483f0`](https://github.com/NixOS/nixpkgs/commit/5ed483f0d79461c2c2d63b46ee62f77a37075bae) arcanist: remove
* [`f0bf230b`](https://github.com/NixOS/nixpkgs/commit/f0bf230b99120aaa6914ba4e1d21f78cb9294212) less: add upstream patch to fix FreeBSD build
* [`6a11289f`](https://github.com/NixOS/nixpkgs/commit/6a11289f145264d31648f0e7d5b62476324eb208) consul-alerts: migrate to buildGoModule
* [`70722078`](https://github.com/NixOS/nixpkgs/commit/7072207806bc46b122f4c95a105bd9c886dd395f) prometheus-surfboard-exporter: migrate to buildGoModule
* [`52e351b5`](https://github.com/NixOS/nixpkgs/commit/52e351b5164f78b271677047ea47f5da261b0460) alttpr-opentracker: fix build errors.
* [`131ef6d2`](https://github.com/NixOS/nixpkgs/commit/131ef6d2ed52eb3a670f50d1f33b1307230286f8) nixos/no-x-libs: fix gjs
* [`6457cf0c`](https://github.com/NixOS/nixpkgs/commit/6457cf0c0141933ed396d2544b8f52202d5d6803) haskell.compiler.ghc96: hadrian patch fix for fully_static
* [`922322cf`](https://github.com/NixOS/nixpkgs/commit/922322cf5eaeafa99cf0d6ad90367601b4d10fb1) numi: init at 3.32.721
* [`3fab5ebf`](https://github.com/NixOS/nixpkgs/commit/3fab5ebff01f5b9094ab96d207438ad1e271e0b1) haskellPackages.lens-sop: fix build
* [`fb516932`](https://github.com/NixOS/nixpkgs/commit/fb516932c7bc35d583127976382597b1b7e597ca) fix Spock-core haskellPackage
* [`39949a1b`](https://github.com/NixOS/nixpkgs/commit/39949a1b908d5c9d33d75eecec6b6f91b467c9bc) rPackages.vegan3d: fix build
* [`2d9eab10`](https://github.com/NixOS/nixpkgs/commit/2d9eab10b61c33d6acd5fe82bde0036eb8759de0) rPackages.fcl: fixed build
* [`9dc3b262`](https://github.com/NixOS/nixpkgs/commit/9dc3b2622f7d1ce349234385c367bd6b9d7c6a22) rPackages.GrafGen: fixed build
* [`6e06ea9c`](https://github.com/NixOS/nixpkgs/commit/6e06ea9ca7b4f9639edc1ded09fd30c5b4292c38) avr-libc: 2.1.0 -> 2.2.0
* [`e64cfbbf`](https://github.com/NixOS/nixpkgs/commit/e64cfbbf9957eba0711a02528311f2a1d75fd384) ArchiSteamFarm: 6.0.1.24 -> 6.0.3.4, switch to generic upstream variant to support Monitoring Plugin
* [`9d7bf348`](https://github.com/NixOS/nixpkgs/commit/9d7bf348e1a13bbea9ed59cc59af251d9786a7c9) libosmocore: 1.9.2 -> 1.9.3
* [`596da91f`](https://github.com/NixOS/nixpkgs/commit/596da91f8e5c93db92fffcb5a5eeabddbddc252b) liboqs: 0.10.0 -> 0.10.1
* [`edab8892`](https://github.com/NixOS/nixpkgs/commit/edab8892eef6add7cf410907ba8a38288ec214ba) lix: move `lix-doc` as a formal parameter
* [`3c179579`](https://github.com/NixOS/nixpkgs/commit/3c179579c558848ab139c60c66e971416ec55017) lix: drop the `self` let binding
* [`97bbd80c`](https://github.com/NixOS/nixpkgs/commit/97bbd80c1dfd0fb22070f7783fe644aae89ca4d9) lix-doc: support `cargoLock` as well
* [`f6c8f4ad`](https://github.com/NixOS/nixpkgs/commit/f6c8f4adf6765ade77e2bd90d5b17f8e0d5235b6) lix-doc: support path `src` instead of attribute `src`
* [`dccc9491`](https://github.com/NixOS/nixpkgs/commit/dccc9491ea57e0379e2d6c72164b34f14bae7a1c) lix: support `docCargoLock` propagation to `lix-doc`
* [`88ad897d`](https://github.com/NixOS/nixpkgs/commit/88ad897d2a22c8aadcbcd3936604e9f99562d18f) lix: support `lixVersions.buildLix` helper
* [`1ddd2fa9`](https://github.com/NixOS/nixpkgs/commit/1ddd2fa945038f6de1ff75951b471a5330f7e004) grafana-reporter: migrate to buildGoModule
* [`c5023467`](https://github.com/NixOS/nixpkgs/commit/c502346767ae323b253e0faa548d9faf3324dcf5) giada: move to `finalAttrs`
* [`7813e1f3`](https://github.com/NixOS/nixpkgs/commit/7813e1f32abcae12c00ce936b3efbcb254a490b0) onthespot: desktop file
* [`55d18686`](https://github.com/NixOS/nixpkgs/commit/55d18686750432f6a569aab9bdc5fe0a0f08d241) ffms: 2.40 → 5.0
* [`28d29422`](https://github.com/NixOS/nixpkgs/commit/28d29422b25062e8fd558b00b602f5581918cdb4) openjdk22: remove redundant let binding
* [`0cb601e3`](https://github.com/NixOS/nixpkgs/commit/0cb601e32cd8673f764b232fe400570d579c7edb) bilibili: 1.13.2-1 -> 1.13.5-2
* [`de1f4538`](https://github.com/NixOS/nixpkgs/commit/de1f4538e8c711fd5a2d9d17d7537414867e5a6e) nixos/tests/nextcloud: Add test for object store
* [`f91c4d43`](https://github.com/NixOS/nixpkgs/commit/f91c4d43eaad88736dd27c3fe2c69cb6e43a5d92) catppuccin-gtk: 0.7.5 -> 1.0.3
* [`e160c2af`](https://github.com/NixOS/nixpkgs/commit/e160c2afdd6cb9966c5f4d2e4ec9768259a9c17c) haskellPackages: build with RTS -A64M options
* [`a1c5b0fe`](https://github.com/NixOS/nixpkgs/commit/a1c5b0fe2aa0715b1c863f344a5ee80c140393f4) vscode-extensions.continue.continue: 0.8.25 -> 0.8.40
* [`9a1d2b98`](https://github.com/NixOS/nixpkgs/commit/9a1d2b98add7ab665398d3fad5fd83da88da77bf) design: init at 46-alpha1
* [`cd180e8a`](https://github.com/NixOS/nixpkgs/commit/cd180e8ae912db00b09a915937a03b650c22f8b9) jellyfin-media-player: 1.10.1 -> 1.11.1
* [`7e854568`](https://github.com/NixOS/nixpkgs/commit/7e854568cc86a6283812bd2ac669f8e890f12b25) sqlpage : 0.22.0 -> 0.23.0
* [`e23df553`](https://github.com/NixOS/nixpkgs/commit/e23df553b06baf30ffd515f8820dd0b0d2a2ba18) doc/release-notes: migration note for stalwart-mail user
* [`fe07b5a3`](https://github.com/NixOS/nixpkgs/commit/fe07b5a3561a96d61671192babe1ff823bb4c947) maintainer: add iivusly
* [`8b4e9350`](https://github.com/NixOS/nixpkgs/commit/8b4e93505239b76c9b6ee478a5924cf4437ee19d) poretools: remove
* [`4f1a81e9`](https://github.com/NixOS/nixpkgs/commit/4f1a81e9faf706339b460d8a436b4927c2bf5c21) coyim: migrate to buildGoModule
* [`47b63502`](https://github.com/NixOS/nixpkgs/commit/47b635023459c73120854e7b80ec587425c504f6) Update pkgs/by-name/co/coyim/package.nix
* [`6ecafb1c`](https://github.com/NixOS/nixpkgs/commit/6ecafb1c38b5d443834f6040b861d8169bf26b9a) nixos/nextcloud: fix objectstore/s3 test
* [`1d86418d`](https://github.com/NixOS/nixpkgs/commit/1d86418da726035f4d88ffe17169d81dab2efa40) kchat: 2.4.0 -> 3.3.1
* [`6bafd4c7`](https://github.com/NixOS/nixpkgs/commit/6bafd4c769e65e7524e004e7d738449c1704c3ac) cosmic-files: unstable-2024-02-28 -> 0-unstable-2024-06-10
* [`617571a2`](https://github.com/NixOS/nixpkgs/commit/617571a28e0039ab76e487fe4421c33e0963ca31) limine: 7.7.0 -> 7.7.2
* [`df7ffb7f`](https://github.com/NixOS/nixpkgs/commit/df7ffb7f4b6e59fa1b4cae348a406f2400420b54) maintainers:  add d4rkstar
* [`5d09f92c`](https://github.com/NixOS/nixpkgs/commit/5d09f92c53c8bbc5fc14c8d673b233c217ea05a9) maintainers:  add msciabarra
* [`cf567da3`](https://github.com/NixOS/nixpkgs/commit/cf567da3711e06a60c95e9199dc474a62a2636a1) rPackages.covidsymptom: fix build
* [`0b76b065`](https://github.com/NixOS/nixpkgs/commit/0b76b065ac9fd730555bf5800530fd606ec7bf99) git-branchless: make fetchpatch url reproducible
* [`a0b5c51f`](https://github.com/NixOS/nixpkgs/commit/a0b5c51f2346d79945bd09e33fce962a0db42205) modern-cpp-kafka: make fetchpatch url reproducible
* [`463c72bb`](https://github.com/NixOS/nixpkgs/commit/463c72bb6e4979166e19f37ecebe397217ff784b) mpvScripts.mpv-notify-send: make fetchpatch url reproducible
* [`5c10264d`](https://github.com/NixOS/nixpkgs/commit/5c10264dd7e98e724fa912bf4e5395c13252541a) python311Packages.dazl: make fetchpatch url reproducible
* [`22ca7bfe`](https://github.com/NixOS/nixpkgs/commit/22ca7bfea200b6944b3eeae1d9a0e3ba75dd6bed) python311Packages.pymilter: make fetchpatch url reproducible
* [`ef15362c`](https://github.com/NixOS/nixpkgs/commit/ef15362c97daaffa385c85f5b593bec2dbcfbed0) python311Packages.xgboost: make fetchpatch url reproducible
* [`8e1e4c64`](https://github.com/NixOS/nixpkgs/commit/8e1e4c64035a440870492dc6635df6412203a603) webtorrent_desktop: make fetchpatch url reproducible
* [`feff02cf`](https://github.com/NixOS/nixpkgs/commit/feff02cf107840bd0c7ec8d4e3b612142ecbb12b) libsbml: make fetchpatch url reproducible
* [`7e9245b3`](https://github.com/NixOS/nixpkgs/commit/7e9245b3de657857257d8abd06e77073e059c1af) haskell.packages.ghc98.libmpd: make fetchpatch urls reproducible
* [`7cf9e13d`](https://github.com/NixOS/nixpkgs/commit/7cf9e13d0fe0fcacbfb3fab5082cffafbadbbdf6) python311Packages.execnet: adopt
* [`ddafc2b4`](https://github.com/NixOS/nixpkgs/commit/ddafc2b4641b11e98a130fadd66a55eaba00652f) python311Packages.execnet: modernize
* [`7d67170c`](https://github.com/NixOS/nixpkgs/commit/7d67170ca904a72862c43328a0ed7ceacbbed046) orchard: 0.18.0 -> 0.19.0
* [`d0126c05`](https://github.com/NixOS/nixpkgs/commit/d0126c0508e46fff6b7560f60f2d9e9f1067b096) make-disk-image: fix build for systems that use boot.loader.grub.devices
* [`f3987648`](https://github.com/NixOS/nixpkgs/commit/f3987648641fdc489e246bb8d54012ecfecef71f) seclists: 2024.1 -> 2024.2
* [`ffc1e44c`](https://github.com/NixOS/nixpkgs/commit/ffc1e44c32d7be18dc918f83dee1b7ec84485a2b) arkenfox-userjs: init at 126.1
* [`0b31ada9`](https://github.com/NixOS/nixpkgs/commit/0b31ada92bde7f573d2a616d5111e396d501a76f) nixos/nextcloud: refactor tests
* [`06c9d396`](https://github.com/NixOS/nixpkgs/commit/06c9d396bdabc505c53e5ad0d336cf8fa35c7155) gdal: 3.8.5 -> 3.9.0
* [`e18cf4f3`](https://github.com/NixOS/nixpkgs/commit/e18cf4f3cbd236180c0780033ded4bf0579b13f5) python3Packages.rasterio: disable tests failing with latest gdal version
* [`6997f673`](https://github.com/NixOS/nixpkgs/commit/6997f6739f9919b054aa1d4f2b5d4a9887fea388) gdal: fix build with latest hdf5 version
* [`04a9b513`](https://github.com/NixOS/nixpkgs/commit/04a9b513e37867e59e7459eb6eeb771ae2bb47b5) pdal: temporary disable test failing with latest gdal version
* [`0e012f36`](https://github.com/NixOS/nixpkgs/commit/0e012f363ffbb618e8b2ad99e522e90476a765bd) python3Packages.geopandas: fix compatibility with latest gdal version
* [`ba70d8f1`](https://github.com/NixOS/nixpkgs/commit/ba70d8f1c11cd2ddd9e60d96e6bbfa42418b8721) wasmer: 4.3.1 -> 4.3.2
* [`44d3de2f`](https://github.com/NixOS/nixpkgs/commit/44d3de2f17a4d06af91c96c8fd67b4acaaeaadb1) blockbench: remove electron version pin
* [`49444276`](https://github.com/NixOS/nixpkgs/commit/494442762c4f515b2b8e437a61cf76fd3af3d584) amazon-ssm-agent: remove overrideEtc parameter
* [`9add0986`](https://github.com/NixOS/nixpkgs/commit/9add0986c865cf7e984fad731c79d5d8cf20a1e6) sfwbar: 1.0_beta13 -> 1.0_beta14
* [`edaab670`](https://github.com/NixOS/nixpkgs/commit/edaab670f8eaa9561504df5963974511e8d93148) libdevil: 1.7.8 -> 1.8.0
* [`34165eab`](https://github.com/NixOS/nixpkgs/commit/34165eab42e211bbbbce30169fd7fa084472d28b) libdevil: Drop redundant `sed`s
* [`eb510a1b`](https://github.com/NixOS/nixpkgs/commit/eb510a1bde539c44071b7987185cc4762ebe01f6) libdevil: Drop CVE patch
* [`02c395d4`](https://github.com/NixOS/nixpkgs/commit/02c395d446313096ebcd49687f1246e730534737) libdevil: Drop libpng 1.5 patch
* [`f353aa41`](https://github.com/NixOS/nixpkgs/commit/f353aa412be818264e32e56432df511b940ef39b) libdevil: Update endianness handling patch
* [`adf72c84`](https://github.com/NixOS/nixpkgs/commit/adf72c84ce42d3ba1d18140f676d6b1b6ec92ead) libdevil: Retarget substitute command
* [`16999590`](https://github.com/NixOS/nixpkgs/commit/16999590ce0cb09df693fe0d2470153c86d27d5f) opencl-info: drop
* [`ae7c4ca1`](https://github.com/NixOS/nixpkgs/commit/ae7c4ca17ff8afe9a8bc771cb68d78e6186295a5) freebsd.libcxxrt: fixup in preparation for inclusion in stdenv
* [`71efa22e`](https://github.com/NixOS/nixpkgs/commit/71efa22e55c6fa00eace7c89e51fff0e977824b7) cargo-bolero: 0.9.0 → 0.11.2
* [`b81447c6`](https://github.com/NixOS/nixpkgs/commit/b81447c6318286622abb221ea77815153b7cd12a) shipwright: darwin build, add maintainer
* [`44e73caa`](https://github.com/NixOS/nixpkgs/commit/44e73caa2029f0f410a9a83ba372947c608049c4) aspellDicts.en-science: point sources & homepage to archive.org and add licensing information
* [`ccb45277`](https://github.com/NixOS/nixpkgs/commit/ccb45277d35fd0a8b156a6ba83efba59b5f27607) rPackages.jack: fix build
* [`17e2421e`](https://github.com/NixOS/nixpkgs/commit/17e2421e08da31b1c79aa795f1e12babd19cf328) nixVersions.latest: 2.22.1 -> 2.23.0
* [`702d636d`](https://github.com/NixOS/nixpkgs/commit/702d636d789428464d4be337381ab13937b4e0b9) haskell.compiler.ghc948: fix expression file name
* [`8ebd50f6`](https://github.com/NixOS/nixpkgs/commit/8ebd50f67a350d7c779971d02925bed6fad4e18b) haskell.compiler.*: calculate tool path using common function
* [`6826f109`](https://github.com/NixOS/nixpkgs/commit/6826f109017de4064616393d78cd2c23bfccab3c) temporal-cli: tctl-next: 0.12.0 -> 0.13.0
* [`099266ab`](https://github.com/NixOS/nixpkgs/commit/099266ab84a55b9bf6262958cf4f719ac8d8ad84) maintainers: add vigress8
* [`86deab11`](https://github.com/NixOS/nixpkgs/commit/86deab11f9c6b8700d32ba9db6a83149996a3df7) python311Packages.tree-sitter-html: init at 0.20.3
* [`3413a199`](https://github.com/NixOS/nixpkgs/commit/3413a199158a85470941752d070fdc4f656a2a40) python311Packages.tree-sitter-python: init at 0.21.0
* [`70ace442`](https://github.com/NixOS/nixpkgs/commit/70ace4421f35b9e5a99d4955e0d177830436f0da) python311Packages.tree-sitter-rust: init at 0.21.2
* [`05662e45`](https://github.com/NixOS/nixpkgs/commit/05662e4560fbf6c6fb5afe5e2085c88bf4b59759) python311Packages.tree-sitter-javascript: init at 0.21.3
* [`d9d65067`](https://github.com/NixOS/nixpkgs/commit/d9d650676114886859b17c9a6ff6305d6c878fd5) python311Packages.tree-sitter-json: init at 0.21.0
* [`98ba196e`](https://github.com/NixOS/nixpkgs/commit/98ba196e247b4830979808b1f481db86aaaca9e3) python311Packages.tree-sitter: 0.21.1 -> 0.22.3
* [`a1a791a5`](https://github.com/NixOS/nixpkgs/commit/a1a791a5856ad2e1d7255797d7664106df64dfe4) python311Packages.tree-sitter0_21: init at 0.21.3
* [`ca26bc13`](https://github.com/NixOS/nixpkgs/commit/ca26bc13e27a433de50cb3a1b71e1818d6d0e5bc) httping: format with nixfmt-rfc-style
* [`bc7d0c3e`](https://github.com/NixOS/nixpkgs/commit/bc7d0c3ed19d226b6d2cb6d3ee5bca504aa208e9) httping: add passthru.{tests.version,updateScript}
* [`e6cb8bef`](https://github.com/NixOS/nixpkgs/commit/e6cb8bef457f52e2bcc124fa0c23b7be13586ed4) httping: 2.9 -> 3.6
* [`b5bbd44a`](https://github.com/NixOS/nixpkgs/commit/b5bbd44a8cb6efe63aee2df963a172ca493a84ad) httping: remove `with lib;`
* [`e06d19df`](https://github.com/NixOS/nixpkgs/commit/e06d19df93001511f333a8841b9741ae2b840aa6) httping: migrate to pkgs/by-name
* [`8e6c03f3`](https://github.com/NixOS/nixpkgs/commit/8e6c03f300aab9ba972e8fee155de471bb33a94f) httping: add anthonyroussel to maintainers
* [`ead69bba`](https://github.com/NixOS/nixpkgs/commit/ead69bba03d019c3f491918da9f341dafa632b08) obsidian: add commandLineArgs
* [`a212ec08`](https://github.com/NixOS/nixpkgs/commit/a212ec08b8c8ca76db5123d2f5cf66a60a3a8b90) ord: init at 0.18.5
* [`957cbdc5`](https://github.com/NixOS/nixpkgs/commit/957cbdc5fb55459e07280f94129118be16e54af0) ananicy-cpp: add diniamo as a maintainer
* [`2a995012`](https://github.com/NixOS/nixpkgs/commit/2a99501296cc28fa3bc9ffb626daee8ac3ad131a) plexRaw: 1.40.2.8395-c67dce28e -> 1.40.3.8555-fef15d30c
* [`bdcb7eb5`](https://github.com/NixOS/nixpkgs/commit/bdcb7eb588da7817117e299f044f2f173a720dd7) jenkins: 2.440.3 -> 2.452.2
* [`64520717`](https://github.com/NixOS/nixpkgs/commit/64520717431e72c7c0fd11c2a0730da3a48c353c) plumber: 2.6.1 -> 2.7.0
* [`82d8d501`](https://github.com/NixOS/nixpkgs/commit/82d8d5016f5c1e35583e5e5dec28e5dd52a7f945) mpvScripts.thumbnail: 0.5.3 -> 0.5.4
* [`1d0f8a06`](https://github.com/NixOS/nixpkgs/commit/1d0f8a067b7d063adb0647954befcd47da3d3330) citrix_workspace: 24.2.0.65 -> 24.5.0.76
* [`0487937a`](https://github.com/NixOS/nixpkgs/commit/0487937af3e78f5e651716bf16ea6c4d8d783f70) postgresql: add readme with eol-policy
* [`d97b752a`](https://github.com/NixOS/nixpkgs/commit/d97b752ae136452187c116569748a3e420767832) moon: 1.25.1 -> 1.25.6
* [`b23bf066`](https://github.com/NixOS/nixpkgs/commit/b23bf066664571655a7aa1aba36f5c46339e5919) python311Packages.tree-sitter-languages: init at 1.10.2
* [`81521b9e`](https://github.com/NixOS/nixpkgs/commit/81521b9e38969ac8622c3617caa9cb7d19ff3717) python312Packages.lsp-tree-sitter: init at 0.0.15
* [`306018c0`](https://github.com/NixOS/nixpkgs/commit/306018c0405d13fe4d4de44d851ec19a7cdf3b0d) autotools-language-server: init at 0.0.19
* [`da65f214`](https://github.com/NixOS/nixpkgs/commit/da65f2146fa62104866421979ba0ad795f1c2b49) pgraphs: init at 0.6.12
* [`18661709`](https://github.com/NixOS/nixpkgs/commit/1866170943b5cbfedb4b3048af3a8429d6bd6d5f) owncloud-client: 5.3.0 -> 5.3.1
* [`0d214644`](https://github.com/NixOS/nixpkgs/commit/0d214644f78e6749b825a5613a32d1fbf34854fb) lib60870: enable tls support
* [`34252922`](https://github.com/NixOS/nixpkgs/commit/34252922533a76c20cbca3bed6801cf448c70e5b) atlas: 0.23.0 -> 0.24.0
* [`01aed33c`](https://github.com/NixOS/nixpkgs/commit/01aed33c9153a59b0cf642d1ebd351a3f0d53e83) bun: 1.1.10 -> 1.1.13
* [`5be6e19f`](https://github.com/NixOS/nixpkgs/commit/5be6e19f01fca57899c7049f13a1ca56adcc1a17) jwasm: migrate to by-name
* [`7f5127eb`](https://github.com/NixOS/nixpkgs/commit/7f5127eb52044f64b1cecde8c75cbc69ceca9852) jwasm: get rid of nested with at meta
* [`a3ba1e40`](https://github.com/NixOS/nixpkgs/commit/a3ba1e408b58ad923fcd244958167e86dfa72ac4) jwasm: 2.17 -> 2.18
* [`82bff8fc`](https://github.com/NixOS/nixpkgs/commit/82bff8fc884a46f329ef4dfcc512ba59a77e6175) vkd3d: migrate to by-name
* [`8453d43b`](https://github.com/NixOS/nixpkgs/commit/8453d43b0524538c83a2fca9fcd4b1dd7e686394) vkd3d: refactor
* [`6c631cfc`](https://github.com/NixOS/nixpkgs/commit/6c631cfc47d2d7a80c320fe19688cf37d9b0897d) vkd3d: 1.10 -> 1.11
* [`7c5ef0c3`](https://github.com/NixOS/nixpkgs/commit/7c5ef0c3afa20badc0c85ea89b7c5fae31e804d9) vkd3d: 1.11 -> 1.12
* [`504729ee`](https://github.com/NixOS/nixpkgs/commit/504729eeb4d21f792534c616521c182139a5e877) haskellPackages.set-extra: Unmark broken
* [`582d0178`](https://github.com/NixOS/nixpkgs/commit/582d01787a861c9d19bc0ae70a3fe36c5a0118f6) python311Packages.testfixtures: 8.2.0 -> 8.3.0
* [`ceebde5c`](https://github.com/NixOS/nixpkgs/commit/ceebde5c627cdfb9c495b3f1c47c30f2747546a9) haskellPackages.push-notify-apn: unbroken
* [`17f4944c`](https://github.com/NixOS/nixpkgs/commit/17f4944c59331227b2d1cd7386bf24fb121010f4) python311Packages.requests-kerberos: 0.14.0 -> 0.15.0
* [`1067ebc9`](https://github.com/NixOS/nixpkgs/commit/1067ebc949e4785927c7b98437359033b06010c6) getmail6: 6.19.00 -> 6.19.01
* [`cadb3d1d`](https://github.com/NixOS/nixpkgs/commit/cadb3d1df5cc2a98cc62a98a1622ab13af6fb9eb) haskellPackages.ghcjs-dom: build on js backend of ghc 9.8
* [`a42717b8`](https://github.com/NixOS/nixpkgs/commit/a42717b875f8d9da831ed7a8ceab1dc986ce518b) python311Packages.dask: 2024.5.2 -> 2024.6.0
* [`9b7f2cc3`](https://github.com/NixOS/nixpkgs/commit/9b7f2cc30bdd5a0d9738e2e6c4227c17255c1d57) python311Packages.dask-awkward: 2024.3.0 -> 2024.6.0
* [`3cdf6478`](https://github.com/NixOS/nixpkgs/commit/3cdf6478fc0c4343d041f60e889e1cf9be6bed33) python311Packages.distributed: 2024.5.0 -> 2024.6.0
* [`b237046e`](https://github.com/NixOS/nixpkgs/commit/b237046e72a45d097ea5c78d992c6d00d90736f6) python311Packages.dask-expr: 1.1.2 -> 1.1.3
* [`3532ff0e`](https://github.com/NixOS/nixpkgs/commit/3532ff0eaee85d55cf31c8b80a52c029ac618fad) sfwbar: move to pkgs/by-name
* [`21b92225`](https://github.com/NixOS/nixpkgs/commit/21b922257fb0441dd4d90f24d1027314d7a8ac76) bpftune: 0-unstable-2024-05-17 -> 0-unstable-2024-06-07
* [`6d9600d3`](https://github.com/NixOS/nixpkgs/commit/6d9600d379142912c56b5af5548ee70ebf5f27f4) python312Packages.spacy: clean source for annotation test
* [`803ca835`](https://github.com/NixOS/nixpkgs/commit/803ca835fb45c52ec68d48475989c9c6d8a5fbb8) python312Packages.spacy-transformers: clean source for annotation test
* [`f2e2f928`](https://github.com/NixOS/nixpkgs/commit/f2e2f92866aa68488495fd17268e60685eabfedc) deno: 1.43.6 -> 1.44.2
* [`2c0a91b2`](https://github.com/NixOS/nixpkgs/commit/2c0a91b217004119f87ec09e9b2c6b475f01f3a3) man-pages: 6.8 -> 6.9
* [`f9fcf28a`](https://github.com/NixOS/nixpkgs/commit/f9fcf28ade39d397d592f2ab9a51565b58edeb5f) freeipa: 4.12.0 -> 4.12.1
* [`6a8cbe9c`](https://github.com/NixOS/nixpkgs/commit/6a8cbe9c2357a13d6309c9ccdb2749c04e9133ce) python311Packages.msal: 1.28.0 -> 1.28.1
* [`aa5aa63b`](https://github.com/NixOS/nixpkgs/commit/aa5aa63be72021dba2ff1782102d8750227d387f) python311Packages.spectral-cube: patch distutils to provide python3.12 compatibility
* [`eb0f8499`](https://github.com/NixOS/nixpkgs/commit/eb0f84991d33113676346184da17b538118a91bc) discord-gamesdk: set autoPatchelfHook for linux targets only
* [`e6af6773`](https://github.com/NixOS/nixpkgs/commit/e6af677352d4e59e194786420a00989485f202b7) rubyPackages.rails: 7.1.3.2 ->  7.1.3.4
* [`76c3ae0b`](https://github.com/NixOS/nixpkgs/commit/76c3ae0bc0780ed97be70db14617f37b4b8193d7) python311Packages.jupyter-ui-poll: 0.2.2 -> 1.0.0
* [`03288b94`](https://github.com/NixOS/nixpkgs/commit/03288b944b70ff8a146bcaadd3dfef61aa1dbedc) lightgbm: 4.3.0 -> 4.4.0
* [`c697f203`](https://github.com/NixOS/nixpkgs/commit/c697f20356174bfa7dfb844d1dabb058387156e8) python312Packages.berkeleydb: init at 18.1.8
* [`892f87e2`](https://github.com/NixOS/nixpkgs/commit/892f87e2147b0d44471c78b00fbfd1c211d17fc6) nanopb: Fix self-inclusive src
* [`e2d1f0ae`](https://github.com/NixOS/nixpkgs/commit/e2d1f0aee64a25dabd8f3c086d5588ab7a8ae96b) mcaselector: move makeWrapper to preFixup
* [`18ab855a`](https://github.com/NixOS/nixpkgs/commit/18ab855ad08e332ba78f92e4c2f8b42c4a79d47d) ticktick: 2.0.10 -> 2.0.20
* [`2be37441`](https://github.com/NixOS/nixpkgs/commit/2be37441da9a0667194c631d3ad696c812c93d6a) doc: Improve the `makeSetupHook` example
* [`0fb9dc13`](https://github.com/NixOS/nixpkgs/commit/0fb9dc1375b8acaccb4f471cdc1b260ef7bf4bd1) djview: 4.10.6 -> 4.12
* [`bd5d563f`](https://github.com/NixOS/nixpkgs/commit/bd5d563f2d4fd2de18b36d2764773c42c006c897) nsncd: unstable-2024-01-16 -> unstable-2024-03-18
* [`3a7ba639`](https://github.com/NixOS/nixpkgs/commit/3a7ba639678075148171c89ec438211e0b76528f) s2n-tls: 1.4.14 -> 1.4.16
* [`f85f6e2a`](https://github.com/NixOS/nixpkgs/commit/f85f6e2a98165551610091df4d959f77c6925aea) release-plz: init at 0.3.72
* [`bbd3c9f6`](https://github.com/NixOS/nixpkgs/commit/bbd3c9f6670e870658c74cf568a28771b98966a4) bore: mark broken on darwin
* [`42f97614`](https://github.com/NixOS/nixpkgs/commit/42f976148457ce8465ccbeccd374b78d174c69cb) ccd2iso: fix darwin build
* [`d0944be9`](https://github.com/NixOS/nixpkgs/commit/d0944be9eb4b3ccf63ed28b5ccca1da67843f3f6) ecpdap: 0.1.8 -> 0.2.0
* [`9e1c9c8a`](https://github.com/NixOS/nixpkgs/commit/9e1c9c8a15b1b172dda979200a1844a85c4bdb94) python311Packages.tensorly: 0.8.1 -> 0.8.2
* [`d1378ed4`](https://github.com/NixOS/nixpkgs/commit/d1378ed481f6a075c0493ad9fd68ea3f16b8d57a) python312Packages.pylibjpeg-libjpeg: 2.02 -> 2.1.0
* [`541458b4`](https://github.com/NixOS/nixpkgs/commit/541458b4644b92a981727b7e40419024907cbdbc) influxdb2: 2.7.1 -> 2.7.6
* [`746c1846`](https://github.com/NixOS/nixpkgs/commit/746c18462587129dec96052dfde42c2bc53c3754) influxdb: 1.10.5 -> 1.10.7
* [`d7aecd3c`](https://github.com/NixOS/nixpkgs/commit/d7aecd3cb0073633628806fc1ee215b69f3384a0) {influxdb, influxdb2}: fix build on aarch64-linux
* [`78149c77`](https://github.com/NixOS/nixpkgs/commit/78149c77397613394a825cf842cd6d8c040a1cd3) aspellDicts.*: add licensing information
* [`0dfa1472`](https://github.com/NixOS/nixpkgs/commit/0dfa1472d894c8643abafc65f954bfb4cbe0cecc) telegram-desktop.tg_owt: 0-unstable-2023-12-21 -> 0-unstable-2024-06-15
* [`73406d27`](https://github.com/NixOS/nixpkgs/commit/73406d271827272b5bfd47f0f7efc78bffc60b52) macfuse: 4.4.1 -> 4.8.0
* [`d82009ba`](https://github.com/NixOS/nixpkgs/commit/d82009ba8086ab7ee245fa39a0b4ae99fd02010a) libgcrypt: fix version script with lld 17+
* [`38ab61e7`](https://github.com/NixOS/nixpkgs/commit/38ab61e74b50cd677bca070f3e97e1a01997c353) vlc: add update script
* [`bf628c2b`](https://github.com/NixOS/nixpkgs/commit/bf628c2b2d67aaf61e0d301660e3fd3bdb7e87bb) python311Packages.piccolo-theme: 0.22.0 -> 0.23.0
* [`951601cc`](https://github.com/NixOS/nixpkgs/commit/951601ccab7c3e8f9afa3ed78f2046863e6fa81d) treewide: drop amdgpu-pro
* [`dd5ba25e`](https://github.com/NixOS/nixpkgs/commit/dd5ba25ecbf452a030f82c67e78f6ffc8130bcd6) grafana-image-renderer: 3.10.5 -> 3.11.0
* [`700f27b1`](https://github.com/NixOS/nixpkgs/commit/700f27b185e21fa33b4ddf3e7bc25b5d77e90b1b) python311Packages.rich-argparse: 1.5.1 -> 1.5.2
* [`98cef4c2`](https://github.com/NixOS/nixpkgs/commit/98cef4c27326d0f9e521654441929c1c7c64f8e9) treewide: big opengl cleanup
* [`1e3c610b`](https://github.com/NixOS/nixpkgs/commit/1e3c610b8442bb22be3ca39542894f16d3c94d5c) nixos/hardware/video/virtualbox: move from generic opengl module
* [`dd1ea8f3`](https://github.com/NixOS/nixpkgs/commit/dd1ea8f3077098b09d0f57deb8b04b5a8f6e0838) nodejs-slim_22: 22.2.0 -> 22.3.0
* [`9350b55d`](https://github.com/NixOS/nixpkgs/commit/9350b55d2c1efcd2da23b56f5cee0db9e98a51fb) kvmtool: unstable-2023-07-12 -> 0-unstable-2024-04-09
* [`7633d03f`](https://github.com/NixOS/nixpkgs/commit/7633d03f354a0f7e9813471496bf3e917fbf7c65) maintainers: add peigongdsd
* [`b1ece0f6`](https://github.com/NixOS/nixpkgs/commit/b1ece0f65eaf862b045edbd14cef95108b53a2cd) kvmtool: add peigongdsd as maintainer
* [`82db32ec`](https://github.com/NixOS/nixpkgs/commit/82db32ec2bf1b13bb0c6b934fcd1a884fcade8bc) python311Packages.confluent-kafka: 2.3.0 -> 2.4.0
* [`40c832b3`](https://github.com/NixOS/nixpkgs/commit/40c832b32c40e461f96f19bbe70d4697306a090b) CHOWTapeModel: rename to chow-tape-model
* [`3565fd8b`](https://github.com/NixOS/nixpkgs/commit/3565fd8bf698bac7ba072c7938393ab5f5e7f352) ananicy-cpp: support wrapped applications
* [`a479d38d`](https://github.com/NixOS/nixpkgs/commit/a479d38d7060317ecd7391167ec4ae3d31059585) ChowCentaur: rename to chow-centaur
* [`0663ce95`](https://github.com/NixOS/nixpkgs/commit/0663ce95fd2fc659ba2f73a8f86d671691136dd2) gotosocial: 0.15.0 -> 0.16.0
* [`c203af85`](https://github.com/NixOS/nixpkgs/commit/c203af85968f03b5798862b48b71445e96e5e43e) escambo: init at 0.1.2
* [`fccc9249`](https://github.com/NixOS/nixpkgs/commit/fccc9249de3e5a633d4741841c59e934d8c45f81) stats: 2.10.16 -> 2.10.18
* [`ec6678c0`](https://github.com/NixOS/nixpkgs/commit/ec6678c0f6a6129b9e7d7c45537cc3b789e47ee4) ChowPhaser: rename to chow-phaser
* [`96e490fb`](https://github.com/NixOS/nixpkgs/commit/96e490fbb9ecf8e0c1911c421daa01855349a52d) ChowKick: rename to chow-kick
* [`098f96b6`](https://github.com/NixOS/nixpkgs/commit/098f96b6d9b43e25e394ea9c885fbd8853a81fda) python312Packages.publicsuffixlist: 0.10.1.20240605 -> 0.10.1.20240616
* [`c84042b9`](https://github.com/NixOS/nixpkgs/commit/c84042b9ce975a6dee32fa7d1e416ea2dc7d51ba) python312Packages.sse-starlette: 2.1.0 -> 2.1.2
* [`6a7dc952`](https://github.com/NixOS/nixpkgs/commit/6a7dc95227d497b894535dfe098ce7b13d180b2f) python312Packages.pyexploitdb: 0.2.21 -> 0.2.22
* [`ef98dbcc`](https://github.com/NixOS/nixpkgs/commit/ef98dbcc9854cff98413ebc352498e1537e13129) grype: 0.77.4 -> 0.79.0
* [`0c3c6d87`](https://github.com/NixOS/nixpkgs/commit/0c3c6d879fc462d5be1079c7cc9fcc0aec9d5c83) llvmPackages.clang: don't pass -Wno-maybe-uninitialized to clang
* [`8cac5cf3`](https://github.com/NixOS/nixpkgs/commit/8cac5cf31b485b81642f481ab9236a699942781d) python312Packages.timezonefinder: 6.5.0 -> 6.5.1
* [`734d0f3e`](https://github.com/NixOS/nixpkgs/commit/734d0f3ef99262d762e5a17e341af5ca796ae32d) trivy: 0.52.1 -> 0.52.2
* [`5fc6ac58`](https://github.com/NixOS/nixpkgs/commit/5fc6ac58c8a0db924dada2b796fdd5699e7cd49d) python312Packages.slack-sdk: 3.28.0 -> 3.29.0
* [`db06c687`](https://github.com/NixOS/nixpkgs/commit/db06c687e08cef62bf738a581585264fd804122c) LibreArp{,-lv2}: rename to librearp{,-lv2}
* [`9efeb0b0`](https://github.com/NixOS/nixpkgs/commit/9efeb0b0aa36eb4f1d21f3a25a3aa852d4e35c4e) python311Packages.piccolo-theme: refactor
* [`305f2d8d`](https://github.com/NixOS/nixpkgs/commit/305f2d8dd46f27ba0e255268017d2e9328b62baa) sxcs: init at 1.1.0
* [`e63cb4ed`](https://github.com/NixOS/nixpkgs/commit/e63cb4ed39f0ba732663f51ae4a4837e0bfdb8d7) MIDIVisualizer: rename to midivisualizer
* [`005c08d4`](https://github.com/NixOS/nixpkgs/commit/005c08d4f60c54e3558612f8c924853905b82be2) postgresqlPackages.pgvecto-rs: fix build failure on rust 1.78
* [`5cec4807`](https://github.com/NixOS/nixpkgs/commit/5cec48072d6ffadb46fe2e39b2c314f7683b3b78) python311Packages.python-utils: mark test_timeout_generator flaky on linux too
* [`cc6c8bd0`](https://github.com/NixOS/nixpkgs/commit/cc6c8bd02a14be99602ae3b7e0a7d86f7c521320) iterm2: 3.4.23 → 3.5.2
* [`51bc895e`](https://github.com/NixOS/nixpkgs/commit/51bc895e2ac7d86667554daff51c69091760575c) svd2rust: 0.33.3 -> 0.33.4
* [`f24d7e64`](https://github.com/NixOS/nixpkgs/commit/f24d7e64a5e577884e8de5d729ab9f5e2d776118) xplr: 0.21.8 -> 0.21.9
* [`9e70b73a`](https://github.com/NixOS/nixpkgs/commit/9e70b73ace3ff83fc33646577eee2e1e397af836) tenv: 2.0.3 -> 2.0.7
* [`a83610d6`](https://github.com/NixOS/nixpkgs/commit/a83610d6177537a4574e46a0453632eae0008877) gmic: 3.3.6 -> 3.4.0
* [`a58896d4`](https://github.com/NixOS/nixpkgs/commit/a58896d4536b28f11cf1581c613554377f13c6f9) gmic-qt: 3.3.6 -> 3.4.0
* [`76c02046`](https://github.com/NixOS/nixpkgs/commit/76c020466b9042eb79972f48c24d6a04cd56bcb7) linux-rpi: 6.1.63-stable_20231123 -> 6.6.31-stable_20240529
* [`146bd2d9`](https://github.com/NixOS/nixpkgs/commit/146bd2d9cf749ac4e6b90ac731a22a7e8b7b8c94) raspberrypifw: stable_20231123 -> 1.20240529
* [`02b05c0d`](https://github.com/NixOS/nixpkgs/commit/02b05c0d32cae323db949c7ad700308f94cca921) raspberrypiWirelessFirmware: unstable-2023-11-15 -> unstable-2024-02-26
* [`16619820`](https://github.com/NixOS/nixpkgs/commit/16619820ba80c838faa52ef2db5673fd3134089e) _64gram: 1.1.27 -> 1.1.29
* [`86290a18`](https://github.com/NixOS/nixpkgs/commit/86290a18a095829ef7434a91e26c19f084bdd174) python311Packages.branca: 0.7.2 -> 0.8.0
* [`1ee81ae9`](https://github.com/NixOS/nixpkgs/commit/1ee81ae941aff0102881d44e873b0cfa806f41de) multiplex: init at 0.1.4
* [`5bf4f16c`](https://github.com/NixOS/nixpkgs/commit/5bf4f16cbce24c0c288a3fc58a972896a691ffa4) python311Packages.sqlite-anyio: 0.2.0 -> 0.2.2
* [`40a7f218`](https://github.com/NixOS/nixpkgs/commit/40a7f218c554ef239062629b7db97bf1beedca58) llvmPackages_{12,13,14,15,16,17,18,git}: Allow overriding dependencies
* [`6f565453`](https://github.com/NixOS/nixpkgs/commit/6f565453f4cf3c3eb217f82d33fc685d716adaf3) media-downloader: move to pkgs/by-name
* [`d7dcb48b`](https://github.com/NixOS/nixpkgs/commit/d7dcb48bf4ffdc3651c97baec38a0907f0def724) media-downloader: format with nixfmt-rfc-style
* [`996fbc60`](https://github.com/NixOS/nixpkgs/commit/996fbc60f9e97e3b019af6ed368891a8545721ba) HentaiAtHome: rename to hentai-at-home
* [`b5a20ff9`](https://github.com/NixOS/nixpkgs/commit/b5a20ff900009b972cb8434f7850cddc0bae8a0b) python311Packages.django-import-export: 4.0.7 -> 4.0.8
* [`508182bd`](https://github.com/NixOS/nixpkgs/commit/508182bd81d1d09e11fb6697484ecb25ea654114) maintainers: add obreitwi
* [`a922c21a`](https://github.com/NixOS/nixpkgs/commit/a922c21a79acf9405e6219a12cad9040b8847f67) hentai-at-home: format with rfc formatter
* [`51803d6d`](https://github.com/NixOS/nixpkgs/commit/51803d6dbcbef6e2f9b32a3003544ec0dfb6955c) hentai-at-home: add meta.platforms, fix meta.description & refactor
* [`c44274e8`](https://github.com/NixOS/nixpkgs/commit/c44274e8b1d93990acefa1a235542b3f2f68ae4e) rpcs3: 0.0.31-16391-39e946630 -> 0.0.32-16614-5b973448b
* [`7af35f2c`](https://github.com/NixOS/nixpkgs/commit/7af35f2cc49283748684d89c7e95fb03270dbede) python3Packages.pyreqwest-impersonate: init at 0.4.7
* [`61f63be6`](https://github.com/NixOS/nixpkgs/commit/61f63be6d860ee3bba291830270118522a240661) python3Packages.duckduckgo-search: fix dependencies
* [`d3752b00`](https://github.com/NixOS/nixpkgs/commit/d3752b00c2785c3db32a56cc725710cc6ba25966) python3Packages.curl-cffi: fix version string
* [`10318b71`](https://github.com/NixOS/nixpkgs/commit/10318b71e8132fd91b9341e6bcc06184897d5608) nickel: 1.6.0 -> 1.7.0
* [`4db07aa7`](https://github.com/NixOS/nixpkgs/commit/4db07aa7c3c70179468175b31f4ae9b79917927e) marp-cli: 3.2.0 -> 3.4.0
* [`8a862af4`](https://github.com/NixOS/nixpkgs/commit/8a862af4610a6c8183040002be7a0dec1aa1e0b6) media-downloader: disable automatically update
* [`59bc5093`](https://github.com/NixOS/nixpkgs/commit/59bc5093bf5d2d3da2e2efeca9322ce3ac3b6c03) media-downloader: allow wrapping with more extensions
* [`d17b2be6`](https://github.com/NixOS/nixpkgs/commit/d17b2be69b1bab6b6f2a91de407ac736fe269a4d) media-downloader: add aleksana as maintainer
* [`47df37bb`](https://github.com/NixOS/nixpkgs/commit/47df37bb0e8e5f5ad8d2d5a8d52ab9526206eb79) maintainers: add Name
* [`a7fdc4dc`](https://github.com/NixOS/nixpkgs/commit/a7fdc4dceb75a778e0875430d17f11aefddc2886) catppuccin-whiskers: init at 2.4.0
* [`011d47ec`](https://github.com/NixOS/nixpkgs/commit/011d47ec63571bf539d410fcafe15e99ac017f8e) lmstudio: disabled unsupported linux versions (AVX2 is required on linux)
* [`7712ff7a`](https://github.com/NixOS/nixpkgs/commit/7712ff7afe82412a16f876e1551b1a0bebf44193) lmstudio: 0.2.24 -> 0.2.25
* [`b784eb33`](https://github.com/NixOS/nixpkgs/commit/b784eb33af3bd11e3bcbb8e03fd95bb10d72d4e4) vesktop: fix icon file locations
* [`391c7303`](https://github.com/NixOS/nixpkgs/commit/391c730310782ac9d69e913ae72824be86990f18) poutine: init at 0.11.0
* [`024b429c`](https://github.com/NixOS/nixpkgs/commit/024b429c7a243e9d20cac066006e66ff513af930) python311Packages.sqlite-anyio: add changelog to meta
* [`396629c7`](https://github.com/NixOS/nixpkgs/commit/396629c7b65ab97ce9187bf0e895eb27c3649802) check-meta: fix instructions
* [`aff01c1b`](https://github.com/NixOS/nixpkgs/commit/aff01c1b1d20f15f90b8eb3f40e03bcc438dd3e3) teleport: resolve broken for non-wasm builds
* [`7de15277`](https://github.com/NixOS/nixpkgs/commit/7de15277bb0d24ad8496aab392561c40a12b2c27) argo-rollouts: 1.6.0 -> 1.7.0
* [`d3f25d54`](https://github.com/NixOS/nixpkgs/commit/d3f25d54bbe94e8ce370df707dcfb9e909af80ed) svix-cli: init at 0.21.1
* [`222c3446`](https://github.com/NixOS/nixpkgs/commit/222c34462124c207e66526a42b5baa73e560b6e5) evcc: 0.127.1 -> 0.127.2
* [`cae03b78`](https://github.com/NixOS/nixpkgs/commit/cae03b78b484b952422854834b7de02cb29c1e3f) zig: fix build on Darwin with sandbox enabled
* [`41c0c024`](https://github.com/NixOS/nixpkgs/commit/41c0c02418dde5bb9fee8d9d4749b9a1583f1734) age: 1.1.1 -> 1.2.0
* [`7789a9b5`](https://github.com/NixOS/nixpkgs/commit/7789a9b522a359a1305582a5bac3910cee049c88) nom: 2.5.0 -> 2.5.1
* [`15f84237`](https://github.com/NixOS/nixpkgs/commit/15f84237717486c8583a828305e2d4c07083ff9b) python312Packages.homeassistant-stubs: 2024.6.2 -> 2024.6.3
* [`0f5b0485`](https://github.com/NixOS/nixpkgs/commit/0f5b04859037f59a0df1dd7e62cba4994b6f1ed3) nspr: update homepage
* [`e3a9b942`](https://github.com/NixOS/nixpkgs/commit/e3a9b942b8b49cda4cfe046bd6c426f5cdd405ce) pinnwand: update homepage
* [`5b7eece8`](https://github.com/NixOS/nixpkgs/commit/5b7eece87ae950a6dda9af3e611ee5b039adca3b) python311Packages.tlds: update homepage
* [`f873c8da`](https://github.com/NixOS/nixpkgs/commit/f873c8da8028aa8e5ba170e97ae9088f1c75450e) python311Packages.jsonrpclib-pelix: 0.4.3.2 -> 0.4.3.3
* [`efdd611b`](https://github.com/NixOS/nixpkgs/commit/efdd611b5e9cee65b0940d8ab4ac3b11f270d99d) nuclei: 3.2.8 -> 3.2.9
* [`4a7043fd`](https://github.com/NixOS/nixpkgs/commit/4a7043fd6c6d1293b00aa13d2f57f592fa6c4cf4) mdbook-graphviz: 0.1.7 -> 0.2.0
* [`a460dbac`](https://github.com/NixOS/nixpkgs/commit/a460dbac5030504b2687a0176ffb83de7cd1fcdd) wlr-which-key: 0.1.1 -> 0.1.3
* [`97b983d0`](https://github.com/NixOS/nixpkgs/commit/97b983d0d803123130281ef77be2c534577ce267) ols: 0-unstable-2024-06-05 -> 0-unstable-2024-06-13
* [`a9dd28fb`](https://github.com/NixOS/nixpkgs/commit/a9dd28fb99a5f4872f155c25dec864662a1449d0) python311Packages.django-crispy-forms: 2.1 -> 2.2
* [`debfb4aa`](https://github.com/NixOS/nixpkgs/commit/debfb4aaf5b035b039239b0db6d0aba3c070648a) python311Packages.psd-tools: 1.9.32 -> 1.9.33
* [`1aa2b72a`](https://github.com/NixOS/nixpkgs/commit/1aa2b72a7bdbda58b9924026375f915a32ccedd1) revolt-desktop: darwin support
* [`75c1d9bf`](https://github.com/NixOS/nixpkgs/commit/75c1d9bf299b56d2c6cc0fc00b3121675eb02c97) ghciwatch: 0.5.16 -> 1.0.0
* [`0b0a11c9`](https://github.com/NixOS/nixpkgs/commit/0b0a11c94f37be413078bb8e6936293e4b5fd50d) gitu: 0.20.1 -> 0.21.0
* [`28f16977`](https://github.com/NixOS/nixpkgs/commit/28f1697741e6add7c62abca1e75c265a36b8d086) libreddit: 0.30.0 -> 0.30.1
* [`e61e81ef`](https://github.com/NixOS/nixpkgs/commit/e61e81ef7e482cfdf4c689aac3783e68bcd54abe) lc0: 0.30.0 -> 0.31.0
* [`b1dd5f01`](https://github.com/NixOS/nixpkgs/commit/b1dd5f01ff7cd4b9333765306d0a488dcc6702ff) mermerd: 0.10.0 -> 0.11.0
* [`b51d1c72`](https://github.com/NixOS/nixpkgs/commit/b51d1c7259c7fd50b5dbb4b36218fbbbe5a3cf66) miru: 5.1.0 -> 5.1.3
* [`2c3d9c24`](https://github.com/NixOS/nixpkgs/commit/2c3d9c24f727e6a7795d4f139f9f413e9ad4f5a4) pv: 1.8.9 -> 1.8.10
* [`2f9a552b`](https://github.com/NixOS/nixpkgs/commit/2f9a552b3f55fecd8d2d76667f7704d65ee4428f) sslscan: 2.1.3 -> 2.1.4
* [`ca4f0bec`](https://github.com/NixOS/nixpkgs/commit/ca4f0becf996b69b22598649b0bc9b52ef9f7b5d) nixos/oauth2-proxy: restart service when keyFile option changes ([nixos/nixpkgs⁠#320325](https://togithub.com/nixos/nixpkgs/issues/320325))
* [`9bbfd2e5`](https://github.com/NixOS/nixpkgs/commit/9bbfd2e5c56d58f6bc6fef304a27eb9677fffe5f) boinc: 8.0.2 -> 8.0.3
* [`620979a9`](https://github.com/NixOS/nixpkgs/commit/620979a9f7eb7223d2e86698bb356f35b8a8ed9b) brave: 1.66.118 -> 1.67.116
* [`ecdae5aa`](https://github.com/NixOS/nixpkgs/commit/ecdae5aa8caa25014127642e0abb4408647b3343) python311Packages.tabcmd: 2.0.13 -> 2.0.14
* [`564e6222`](https://github.com/NixOS/nixpkgs/commit/564e6222e6617fae1386f39487292e3c29b43615) marimo: 0.6.17 -> 0.6.19
* [`b0b6d5a4`](https://github.com/NixOS/nixpkgs/commit/b0b6d5a4b6664b6283278a01d0fb88f56f54a9c4) python311Packages.niworkflows: 1.10.1 -> 1.10.2
* [`8e8aa62f`](https://github.com/NixOS/nixpkgs/commit/8e8aa62fe86f8c9a2b82733af07d5375f5acc646) neocmakelsp: 0.7.3 -> 0.7.4
* [`31099084`](https://github.com/NixOS/nixpkgs/commit/31099084c7b4d3c634156952ba0b93be1a491bf9) scaleway-cli: 2.27.0 -> 2.31.0
* [`678d20a7`](https://github.com/NixOS/nixpkgs/commit/678d20a7050ba795f9f9b272fad3c0542df045f6) clickhouse-backup: 2.5.12 -> 2.5.14
* [`d2b892c7`](https://github.com/NixOS/nixpkgs/commit/d2b892c753ec8ef2bb7d491f0453a6ef517961f1) faiss: refactor buildPhase, installPhase and fixupPhase
* [`f2bc52d1`](https://github.com/NixOS/nixpkgs/commit/f2bc52d157ba63fcd7a4029217efe6e6a880457c) arxiv-latex-cleaner: 1.0.5 -> 1.0.6
* [`f6e67788`](https://github.com/NixOS/nixpkgs/commit/f6e67788cb770eb213a06b7de8e769256e991fe9) perl: explicitly tell FreeBSD cross that crypt is available
* [`1c38fff3`](https://github.com/NixOS/nixpkgs/commit/1c38fff303902e008a9e4a118049deec4c11bf02) azure-cli-extensions: allow specifying maintainers
* [`249b0c23`](https://github.com/NixOS/nixpkgs/commit/249b0c23b8e5b9daebdce7ce15e390846404e682) azure-cli: propagate build inputs of extensions
* [`4e798ba0`](https://github.com/NixOS/nixpkgs/commit/4e798ba01d048d9a6eb131e4c5295aa6e2fda886) azure-cli-extensions.rdbms-connect: init at 1.0.6
* [`1ea78076`](https://github.com/NixOS/nixpkgs/commit/1ea7807659c90aa3c6d48a1086cae61862d19c7e) libnftnl: fix version script with lld 17+
* [`ffc1f8e2`](https://github.com/NixOS/nixpkgs/commit/ffc1f8e29f143f235b3af56ae412400e462a9123) meilisearch: 1.7.6 -> 1.8.2
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
