### PR TITLE
niv home-manager: update 0a7ffb28 -> 6b1f90a8

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -41,10 +41,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "0a7ffb28e5df5844d0e8039c9833d7075cdee792",
-        "sha256": "1qd5sdpgpadd0972gmngjl0gf96h4cz0xvmv0186pgj6xgzc7amh",
+        "rev": "6b1f90a8ff92e81638ae6eb48cd62349c3e387bb",
+        "sha256": "0hmpljazjk11g2hjs4dgz283k728wvfdaplr3a8ix9chjadk745x",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/0a7ffb28e5df5844d0e8039c9833d7075cdee792.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/6b1f90a8ff92e81638ae6eb48cd62349c3e387bb.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@0a7ffb28...6b1f90a8](https://github.com/nix-community/home-manager/compare/0a7ffb28e5df5844d0e8039c9833d7075cdee792...6b1f90a8ff92e81638ae6eb48cd62349c3e387bb)

* [`fab8e511`](https://github.com/nix-community/home-manager/commit/fab8e511d58f9c3f1cf8456abd685bfd381f7ebe) firefox: update expected container settings
* [`0dd1c149`](https://github.com/nix-community/home-manager/commit/0dd1c1495af6e6424695670343236f0053bf4947) Translate using Weblate (Polish)
* [`d7830d05`](https://github.com/nix-community/home-manager/commit/d7830d05421d0ced83a0f007900898bdcaf2a2ca) flake.lock: Update
* [`c559542f`](https://github.com/nix-community/home-manager/commit/c559542f0aa87971a7f4c1b3478fe33cc904b902) gtk: explicitly set default font size
* [`cd886711`](https://github.com/nix-community/home-manager/commit/cd886711998fe5d9ff7979fdd4b4cbd17b1f1511) blanket: add module
* [`8be82697`](https://github.com/nix-community/home-manager/commit/8be82697f797ce2190b6e2d7b11cd384076caae7) ssh-agent: fix evaluation of maintainer field
* [`6a9a1e51`](https://github.com/nix-community/home-manager/commit/6a9a1e51bbb8c301eae5aa63c9fc3c751ec5315b) flake.lock: Update
* [`5ccc3d67`](https://github.com/nix-community/home-manager/commit/5ccc3d6739b5e694841ced27cb5c06b50b163695) yazi: Ensure plugin suffix `.yazi`
* [`340b98c0`](https://github.com/nix-community/home-manager/commit/340b98c0abb56ae24d7ee7dee64104583ad8a8c6) yazi: Assert that plugins have valid structure
* [`09bc5c59`](https://github.com/nix-community/home-manager/commit/09bc5c5949c73cf6b217badaae25feb2b4a7a2e5) yazi: plugin names should be in kebab case (test)
* [`16f86c94`](https://github.com/nix-community/home-manager/commit/16f86c94ce2399ae09ae99b8f071f37bbc964b4f) yazi: Assert plugin/flavor structure and warn about plugin/flavor suffix
* [`216d51eb`](https://github.com/nix-community/home-manager/commit/216d51eb22f9ce1a4c50a4737a4adcdb42fb6306) yazi: Fix expected structure of flavors
* [`6b1f90a8`](https://github.com/nix-community/home-manager/commit/6b1f90a8ff92e81638ae6eb48cd62349c3e387bb) stalonetray: move config file to XDG_CONFIG_HOME
