### PR TITLE
niv emacs-overlay: update 35b305a1 -> 9059feb4

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "35b305a1706b6fa284f81aa5dc37ccfdbfcb2e99",
-        "sha256": "1z9ayvsdvr09kz33pn7vcdr2jdkqb20wzmvbxhrddn83xc2yrcfp",
+        "rev": "9059feb48648e980cdd797cd828377c08989ca8f",
+        "sha256": "1g420669addbg1079v6z8wcp8nhhya3l9l6kdwq639855yvfmc33",
         "type": "tarball",
-        "url": "https://github.com/nix-community/emacs-overlay/archive/35b305a1706b6fa284f81aa5dc37ccfdbfcb2e99.tar.gz",
+        "url": "https://github.com/nix-community/emacs-overlay/archive/9059feb48648e980cdd797cd828377c08989ca8f.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "fast-syntax-highlighting": {


### PR DESCRIPTION
## Changelog for emacs-overlay:
Branch: master
Commits: [nix-community/emacs-overlay@35b305a1...9059feb4](https://github.com/nix-community/emacs-overlay/compare/35b305a1706b6fa284f81aa5dc37ccfdbfcb2e99...9059feb48648e980cdd797cd828377c08989ca8f)

* [`23228436`](https://github.com/nix-community/emacs-overlay/commit/232284363384a1fb7be279c9d4c19f81454b4076) Updated nongnu
* [`33b510ef`](https://github.com/nix-community/emacs-overlay/commit/33b510ef28317acbda6833a498830f46ed9b6a0c) Updated melpa
* [`08dd5fc2`](https://github.com/nix-community/emacs-overlay/commit/08dd5fc2b327774d7b605a39273b23af7d4af08f) Updated melpa
* [`b79423d0`](https://github.com/nix-community/emacs-overlay/commit/b79423d0334e6397528aa3b4f5ff97b4adeadef5) Updated emacs
* [`bfe71a04`](https://github.com/nix-community/emacs-overlay/commit/bfe71a041403577234417b51632cbfb56330d08a) Updated elpa
* [`177491c0`](https://github.com/nix-community/emacs-overlay/commit/177491c08fa49c820cb22181f41f6fe85416fe64) Updated melpa
* [`a381a93c`](https://github.com/nix-community/emacs-overlay/commit/a381a93c2b94b40013958f180a7228602762ed2c) Updated emacs
* [`32135244`](https://github.com/nix-community/emacs-overlay/commit/3213524454e755e98b4146cc9b0b25741e7d64a0) Updated elpa
* [`38fe5f06`](https://github.com/nix-community/emacs-overlay/commit/38fe5f067eb715e655a63cbb6b6fca15a4055fee) Updated melpa
* [`bcccabf8`](https://github.com/nix-community/emacs-overlay/commit/bcccabf80dbeaa8cfad827c6ff29ae8672405792) Updated emacs
* [`c860797a`](https://github.com/nix-community/emacs-overlay/commit/c860797a8d534f4a64065132c94c8bf102fcaf5e) Updated melpa
* [`d63f0592`](https://github.com/nix-community/emacs-overlay/commit/d63f059257d78a7d6ddd6e6c6df03c9a4f0e9378) Updated emacs
* [`9ac7e962`](https://github.com/nix-community/emacs-overlay/commit/9ac7e962959995a731405eb8c0d1425e83dc6b85) Updated flake inputs
* [`82a57c7f`](https://github.com/nix-community/emacs-overlay/commit/82a57c7f245ae86c1122a5fa5c4fe85ae28ae2ca) Updated melpa
* [`0b6f0831`](https://github.com/nix-community/emacs-overlay/commit/0b6f083187662135ddad8b6b28f4713e372c3572) Updated emacs
* [`1380b7b1`](https://github.com/nix-community/emacs-overlay/commit/1380b7b1b0519dd5f7d410a4a090a5e13e0f2346) Updated nongnu
* [`9a589248`](https://github.com/nix-community/emacs-overlay/commit/9a589248a3211cd25ca96b8dd879610bf17ea9a5) Updated elpa
* [`ca6e8941`](https://github.com/nix-community/emacs-overlay/commit/ca6e8941f81e9b32f9824e58483e1c7991427124) Updated melpa
* [`76082b22`](https://github.com/nix-community/emacs-overlay/commit/76082b226e29dd266a67b6f4df4fcaa771152f9c) Updated emacs
* [`fefb7504`](https://github.com/nix-community/emacs-overlay/commit/fefb7504e796296ee5b8202823cc07c82f90e169) Updated flake inputs
* [`c9c813d0`](https://github.com/nix-community/emacs-overlay/commit/c9c813d0721caaefa4bdbce2eed4f5a2b2c35d89) Updated melpa
* [`088f3035`](https://github.com/nix-community/emacs-overlay/commit/088f3035f29f2de3cc2d666ff6cbcee248eb3d43) Updated emacs
* [`b4b97919`](https://github.com/nix-community/emacs-overlay/commit/b4b979191084994b1785ee7f2c0350b6369117c7) Updated nongnu
* [`7170f4f1`](https://github.com/nix-community/emacs-overlay/commit/7170f4f162f07fe89ee02d510238698e4befcd70) Updated elpa
* [`736b3e4d`](https://github.com/nix-community/emacs-overlay/commit/736b3e4d342f7b4b46772e28b9ad1ed2c0cc6bde) Updated melpa
* [`33b9d0e9`](https://github.com/nix-community/emacs-overlay/commit/33b9d0e966a2299a38263f2b325a93ea6632d3ed) Updated emacs
* [`52fc908c`](https://github.com/nix-community/emacs-overlay/commit/52fc908cbc39f3fa88bba9848511f1ea7a7dfff0) Updated elpa
* [`abdbe2c1`](https://github.com/nix-community/emacs-overlay/commit/abdbe2c108ba01e201a2f793281f571fd418e171) Updated melpa
* [`170a4920`](https://github.com/nix-community/emacs-overlay/commit/170a49203727005b68444786bea716039aa332bf) Updated emacs
* [`418c50b0`](https://github.com/nix-community/emacs-overlay/commit/418c50b09bd9ec9c008e8c7a2b38b4e853c1b401) Updated melpa
* [`84d45dec`](https://github.com/nix-community/emacs-overlay/commit/84d45decb6ee4cfee67c27e0237edaae2d95af79) Updated emacs
* [`70263b28`](https://github.com/nix-community/emacs-overlay/commit/70263b28668b915ec509f7bc6e975bee66065099) Updated elpa
* [`ef36cb44`](https://github.com/nix-community/emacs-overlay/commit/ef36cb44e5db28cadcfb13780d681419287512dd) Updated melpa
* [`a433759c`](https://github.com/nix-community/emacs-overlay/commit/a433759c9f9d46c02e0818ca88f1f35d4c204afb) Updated emacs
* [`783d5b31`](https://github.com/nix-community/emacs-overlay/commit/783d5b3143f7ee264ecd5258f606fb99a93e8243) Updated nongnu
* [`c9aca5d4`](https://github.com/nix-community/emacs-overlay/commit/c9aca5d40537037b1b20d4f6cc1e8516f4100d00) Updated elpa
* [`d7476f25`](https://github.com/nix-community/emacs-overlay/commit/d7476f259d0ec19134e5bf957cfcc1325e585182) Updated melpa
* [`d619b5b5`](https://github.com/nix-community/emacs-overlay/commit/d619b5b5ba751d6e3c16da1ca8178a31ef130047) Updated emacs
* [`67604448`](https://github.com/nix-community/emacs-overlay/commit/67604448a402e3f600e6b921fa6ad34a62c6f55c) Updated flake inputs
* [`47f5d84a`](https://github.com/nix-community/emacs-overlay/commit/47f5d84a429df497a8df488a114b4976509ee44b) Updated melpa
* [`63688083`](https://github.com/nix-community/emacs-overlay/commit/6368808339236389daf8eec2e187094647e1f203) Updated emacs
* [`a0991adb`](https://github.com/nix-community/emacs-overlay/commit/a0991adb1ef4b29c4c8623bbb2a1fb99da48cf85) Updated flake inputs
* [`fc1036d1`](https://github.com/nix-community/emacs-overlay/commit/fc1036d1a2463e7aa9e4cb7bac8b5e1e4b58556d) Updated nongnu
* [`27e23bcd`](https://github.com/nix-community/emacs-overlay/commit/27e23bcded29d416b8edf1e1ed984e86212297a9) Updated elpa
* [`fbdd576e`](https://github.com/nix-community/emacs-overlay/commit/fbdd576e9d6ec9d93178cf3369930040818eafe3) Updated melpa
* [`6411a583`](https://github.com/nix-community/emacs-overlay/commit/6411a583159b7baeb6230f5fa2ed6524b5456c2a) Updated emacs
* [`013bdc70`](https://github.com/nix-community/emacs-overlay/commit/013bdc70be91a26cef4a12c6b2a703df2dcc0d06) Updated elpa
* [`f6c8bd1e`](https://github.com/nix-community/emacs-overlay/commit/f6c8bd1e52d9ebf8435956fab29e024180bf067e) Updated melpa
* [`4f97985d`](https://github.com/nix-community/emacs-overlay/commit/4f97985d133a12a5991ae8445b0bebbaedf399a6) Updated emacs
* [`338d2aa0`](https://github.com/nix-community/emacs-overlay/commit/338d2aa007b87ff16210935d3ac3a16ab3dd5efa) Updated melpa
* [`28779a7a`](https://github.com/nix-community/emacs-overlay/commit/28779a7abf781d387806f2567b578af6fd165705) Updated emacs
* [`29545023`](https://github.com/nix-community/emacs-overlay/commit/29545023b76d3e4196908f66a5cfc9b2b3bd764e) Updated flake inputs
* [`27dbf1db`](https://github.com/nix-community/emacs-overlay/commit/27dbf1db4515f663e761af229067f7e103cd3b35) Updated nongnu
* [`e511f80c`](https://github.com/nix-community/emacs-overlay/commit/e511f80cc31ba3f6b447d962016648178dfd5e32) Updated elpa
* [`c2f34064`](https://github.com/nix-community/emacs-overlay/commit/c2f3406485193e96371e792f83770429a92a73a5) Updated melpa
* [`aa9303c7`](https://github.com/nix-community/emacs-overlay/commit/aa9303c7769729a544a6c69ee531b9e6ae0e672d) Updated emacs
* [`ce89a70d`](https://github.com/nix-community/emacs-overlay/commit/ce89a70dcb4b243be6acb31578cd82a50d380dd6) Updated flake inputs
* [`535a9385`](https://github.com/nix-community/emacs-overlay/commit/535a9385c072bd3e781e0f5cceaa157759d89749) Updated elpa
* [`54d02051`](https://github.com/nix-community/emacs-overlay/commit/54d020519c696e9a11179a25b2a989bef156a741) Updated melpa
* [`b6765fc0`](https://github.com/nix-community/emacs-overlay/commit/b6765fc07d26b716af4193faa60b1da2d3406518) Updated emacs
* [`6ed3efc8`](https://github.com/nix-community/emacs-overlay/commit/6ed3efc83a696461fcfdac5b075913522aa96dce) Updated melpa
* [`101db880`](https://github.com/nix-community/emacs-overlay/commit/101db880b015dd8e7b49c54da99f8d6ffaefc0b2) Updated emacs
* [`7a24ecfb`](https://github.com/nix-community/emacs-overlay/commit/7a24ecfb43f2c223bb171358ee1858fa1bcf568d) Updated nongnu
* [`3f06166e`](https://github.com/nix-community/emacs-overlay/commit/3f06166ed11a7b774a01cd2e4fd86dc74cb5c373) Updated elpa
* [`34b757de`](https://github.com/nix-community/emacs-overlay/commit/34b757de8b5ffd9631f5875e7fae0af37e7c1f91) Updated melpa
* [`ac3c2954`](https://github.com/nix-community/emacs-overlay/commit/ac3c29547bf7a87fe5911694f45a5192aaaf92ee) Updated emacs
* [`f755987d`](https://github.com/nix-community/emacs-overlay/commit/f755987d23a4581cdcc1999b0b3c1a6806de20c9) Updated nongnu
* [`671703d6`](https://github.com/nix-community/emacs-overlay/commit/671703d6eae67d2a836e6f5c4d6f74b2937b8c44) Updated elpa
* [`1382dd1c`](https://github.com/nix-community/emacs-overlay/commit/1382dd1cfd1bbcab56e870a7aea99c6c479e934a) Updated melpa
* [`7ff674d6`](https://github.com/nix-community/emacs-overlay/commit/7ff674d6a61f4a3af339e82cfebf5e67d24d1714) Updated emacs
* [`c1cb1f0d`](https://github.com/nix-community/emacs-overlay/commit/c1cb1f0d8c41d9eb8a4150259597d692c60b7bbc) Updated melpa
* [`007b1e19`](https://github.com/nix-community/emacs-overlay/commit/007b1e192409decce73d39948ae862d1b38c6f20) Updated emacs
* [`defefd9e`](https://github.com/nix-community/emacs-overlay/commit/defefd9ee454ba8edad86e4ba1cc7294916c26bc) Updated elpa
* [`f7b523a6`](https://github.com/nix-community/emacs-overlay/commit/f7b523a65d6c4e215319266957005908f27dc731) Updated melpa
* [`f648fe67`](https://github.com/nix-community/emacs-overlay/commit/f648fe67704b26f123a6a31953957dadec561380) Updated emacs
* [`7f45e461`](https://github.com/nix-community/emacs-overlay/commit/7f45e461db1fd628a9a1df6d99ed0221662c9cb1) Updated flake inputs
* [`76c6c988`](https://github.com/nix-community/emacs-overlay/commit/76c6c98859267088ee2a906628712c92ddcbb3b2) Updated elpa
* [`46764f40`](https://github.com/nix-community/emacs-overlay/commit/46764f40d8c0f8a1b2113ec3bc6e7e828fa0f401) Updated melpa
* [`4530e5dd`](https://github.com/nix-community/emacs-overlay/commit/4530e5dd23f6a07a229a7bc351e936d628543684) Updated emacs
* [`03489b65`](https://github.com/nix-community/emacs-overlay/commit/03489b65f30d0b0920bad58790dbf00f2f2086a9) Updated melpa
* [`a5143ff8`](https://github.com/nix-community/emacs-overlay/commit/a5143ff8b6be9201f6b7aabe209a4c2a4a832ae3) Updated emacs
* [`8e5228d7`](https://github.com/nix-community/emacs-overlay/commit/8e5228d792ab72adbca3cb383fcca2df268cccee) Updated nongnu
* [`7ec95550`](https://github.com/nix-community/emacs-overlay/commit/7ec9555006793730288fcd858291604110a1662b) Updated elpa
* [`cc4cef19`](https://github.com/nix-community/emacs-overlay/commit/cc4cef1937a07bc5131eff526177e3bb10b3e79c) Updated melpa
* [`e520afec`](https://github.com/nix-community/emacs-overlay/commit/e520afecae9cce738909a889e560fefaaccce281) Updated emacs
* [`6c9771b2`](https://github.com/nix-community/emacs-overlay/commit/6c9771b25e77789cda08b2b2bf291754fe6abba1) Updated flake inputs
* [`3ef2f91f`](https://github.com/nix-community/emacs-overlay/commit/3ef2f91f1a4cc0ed11586ed6992e2bf88356c340) Updated elpa
* [`d0ad609b`](https://github.com/nix-community/emacs-overlay/commit/d0ad609b90b481a70d8e9522e95d1b0b9d917e44) Updated melpa
* [`e3a8a67c`](https://github.com/nix-community/emacs-overlay/commit/e3a8a67ce663448e33f01c8dd94c4d7218b634a6) Updated emacs
* [`b4b62725`](https://github.com/nix-community/emacs-overlay/commit/b4b62725d288c93301666852fb87c924263370f0) Updated melpa
* [`e618bb81`](https://github.com/nix-community/emacs-overlay/commit/e618bb81b46a182758c649c734294f55d73e05bc) Updated emacs
* [`def15ece`](https://github.com/nix-community/emacs-overlay/commit/def15ece48a4902188ece92b094b3aaae9ca5530) Updated elpa
* [`d6b46a7b`](https://github.com/nix-community/emacs-overlay/commit/d6b46a7b91b519cccd69ab92f70cb441cdbedec7) Updated melpa
* [`27232402`](https://github.com/nix-community/emacs-overlay/commit/272324023f7740c2c615b42283d46770f9b24bc2) Updated emacs
* [`7ea79179`](https://github.com/nix-community/emacs-overlay/commit/7ea791798cd20dd222f26ebb62f9dc6ad8d07e9b) Updated nongnu
* [`41b5e012`](https://github.com/nix-community/emacs-overlay/commit/41b5e01283907444ca08b9dd4f53e049b27e2fca) Updated elpa
* [`dc9f6720`](https://github.com/nix-community/emacs-overlay/commit/dc9f67207661f911db7d474214bbfa567b3e721c) Updated melpa
* [`f916315b`](https://github.com/nix-community/emacs-overlay/commit/f916315b134a1a752272e7bd91fad9ee2ef6856d) Updated emacs
* [`aa9f52e9`](https://github.com/nix-community/emacs-overlay/commit/aa9f52e9aa1a53e7050bf280bd2634efd86e2a93) Updated flake inputs
* [`1d8cd0dc`](https://github.com/nix-community/emacs-overlay/commit/1d8cd0dc3cdd20e6b29922b1bcef4587d4579279) Updated melpa
* [`d2404a42`](https://github.com/nix-community/emacs-overlay/commit/d2404a42ad3ae9c5ee5c481b7c7a4c91627d161f) Updated emacs
* [`adbda7f8`](https://github.com/nix-community/emacs-overlay/commit/adbda7f8007c723c5e41ab30a9c63a51e9a2c9f4) Updated flake inputs
* [`8ae1db3f`](https://github.com/nix-community/emacs-overlay/commit/8ae1db3fe4f290915d0256f27a2d6167c9308139) Updated melpa
* [`f7d66a9a`](https://github.com/nix-community/emacs-overlay/commit/f7d66a9af3c76f573dc35c3d7e731ad066ca5430) Updated emacs
* [`e8d9d10a`](https://github.com/nix-community/emacs-overlay/commit/e8d9d10ad9c1d6ed1dcd6a251458bebaffae4187) Updated elpa
* [`5b111560`](https://github.com/nix-community/emacs-overlay/commit/5b111560d56ffec80a4d7557289ddcfe1288f951) Updated melpa
* [`1b9813a3`](https://github.com/nix-community/emacs-overlay/commit/1b9813a3822e4187f5a62c4a897ded4cdae5f648) Updated emacs
* [`c5bafd07`](https://github.com/nix-community/emacs-overlay/commit/c5bafd07d0c30da00a82880228008f00c1abb6f7) Updated melpa
* [`7aa1c144`](https://github.com/nix-community/emacs-overlay/commit/7aa1c14402a09fc043110d6477aa5cc90e60e409) Updated emacs
* [`6323b404`](https://github.com/nix-community/emacs-overlay/commit/6323b40449eb7cf809d7b204f118ec4916b96576) add dependabot to keep github actions up to date
* [`74c6cf77`](https://github.com/nix-community/emacs-overlay/commit/74c6cf777743ddd173b7cc54a58483f2bb35dd02) Bump cachix/cachix-action from 13 to 15
* [`68faf314`](https://github.com/nix-community/emacs-overlay/commit/68faf3145d3359fc6d0b7cf153d37f59cd5153f1) Bump actions/checkout from 4.1.1 to 4.1.7
* [`67905f5d`](https://github.com/nix-community/emacs-overlay/commit/67905f5d4bb4eb057f5061d5a50b87aba7bb92b3) Bump cachix/install-nix-action from 20 to 27
* [`4c6467dc`](https://github.com/nix-community/emacs-overlay/commit/4c6467dc3125791a712addb1abe317d601feb681) Updated flake inputs
* [`007fd371`](https://github.com/nix-community/emacs-overlay/commit/007fd371192b2b61cdbe756e5821ec5f31a15513) Updated nongnu
* [`36f6d5a0`](https://github.com/nix-community/emacs-overlay/commit/36f6d5a0b9697a1a33e64d4b7dce8a2a4305c9e6) Updated elpa
* [`6eec644a`](https://github.com/nix-community/emacs-overlay/commit/6eec644a9c95b886d70eb22817df6f5ac4e6d648) Updated melpa
* [`861f55c2`](https://github.com/nix-community/emacs-overlay/commit/861f55c25608758931cb7c526de4ea5cbee11b2f) Updated emacs
* [`2754639e`](https://github.com/nix-community/emacs-overlay/commit/2754639ed2c6bd40e59ae7b0c478c6a92e352760) Updated melpa
* [`9a4bbb3e`](https://github.com/nix-community/emacs-overlay/commit/9a4bbb3e6b3a1f7c4f870c2906d404d16f65bc44) Updated emacs
* [`e38459a3`](https://github.com/nix-community/emacs-overlay/commit/e38459a340d92451592a3156287a99c510d65904) Updated melpa
* [`2d878eb0`](https://github.com/nix-community/emacs-overlay/commit/2d878eb04f770effe1fe9828e0391edb8e5f3df9) Updated emacs
* [`df7d6fef`](https://github.com/nix-community/emacs-overlay/commit/df7d6fef0acd97af7ae3d00e8625d1ded3452ac7) Updated elpa
* [`b31222ee`](https://github.com/nix-community/emacs-overlay/commit/b31222ee9f1d93680514325f818f7adac4db5852) Updated melpa
* [`7154c01a`](https://github.com/nix-community/emacs-overlay/commit/7154c01acab213910b80b4f788d1e35d8aa88769) Updated emacs
* [`3395ed77`](https://github.com/nix-community/emacs-overlay/commit/3395ed77493ffdd75514f78e7dd098dcd6bfc3ed) Updated nongnu
* [`8c7fac5e`](https://github.com/nix-community/emacs-overlay/commit/8c7fac5e8938572ec941f718892bb367a66913e7) Updated elpa
* [`892bbaae`](https://github.com/nix-community/emacs-overlay/commit/892bbaae6b7a22c64dc04c2c43282a27d1c53ab0) Updated melpa
* [`182987af`](https://github.com/nix-community/emacs-overlay/commit/182987afab0e1ef77703b46c16d7213de3d77f93) Updated emacs
* [`ea2aee03`](https://github.com/nix-community/emacs-overlay/commit/ea2aee03216671e9dd2f71c0c182bdb3fec90e5f) Updated melpa
* [`a3bb4fef`](https://github.com/nix-community/emacs-overlay/commit/a3bb4fefef1ed47a18480ab14d65d409d1f9b9c0) Updated emacs
* [`19f99d5e`](https://github.com/nix-community/emacs-overlay/commit/19f99d5e8e662bf228b388f12fa2f0e4d5928ec2) Updated nongnu
* [`8ecf3957`](https://github.com/nix-community/emacs-overlay/commit/8ecf395742cda40ca27ac7f3a0faaa69a3c67a35) Updated melpa
* [`4d7d1626`](https://github.com/nix-community/emacs-overlay/commit/4d7d16266b8a9f7077c2514d487bf828caf121ca) Updated emacs
* [`3fecf01c`](https://github.com/nix-community/emacs-overlay/commit/3fecf01c3acd18b3b3c0069aa94c2e27ed0949ca) Updated elpa
* [`8e5fb649`](https://github.com/nix-community/emacs-overlay/commit/8e5fb649bdf2db2fa2df5db9864c8121a64bd129) Updated melpa
* [`6439e136`](https://github.com/nix-community/emacs-overlay/commit/6439e136f3e93e21040f0e8483ed7744056b9d71) Updated emacs
* [`66b7bfa0`](https://github.com/nix-community/emacs-overlay/commit/66b7bfa068e2bf81a4096c8196512075ceb39ec2) Updated melpa
* [`292ec202`](https://github.com/nix-community/emacs-overlay/commit/292ec2022a1d758d0a91232e524eab5e4a36a219) Updated emacs
* [`3cfce01b`](https://github.com/nix-community/emacs-overlay/commit/3cfce01be3211cac316b2e07929849e52992a543) Updated flake inputs
* [`41dcf6b0`](https://github.com/nix-community/emacs-overlay/commit/41dcf6b00a196a4d806a804ada2d36a9d670ea6c) Updated elpa
* [`5e079b99`](https://github.com/nix-community/emacs-overlay/commit/5e079b9904fcac005ccd60adbe39d04b3a4eee23) Updated melpa
* [`1f57a659`](https://github.com/nix-community/emacs-overlay/commit/1f57a6596440c15e6135dfbde5f93c2851f01ac9) Updated emacs
* [`f9906ea2`](https://github.com/nix-community/emacs-overlay/commit/f9906ea2849fb8d54d2cc4d7089736d743b62dba) Updated flake inputs
* [`2957aa6c`](https://github.com/nix-community/emacs-overlay/commit/2957aa6cfd14a46cadad9d07d64f110bece1978d) Updated nongnu
* [`b63132f9`](https://github.com/nix-community/emacs-overlay/commit/b63132f970a0f0f4a11ddde5f6b109b3a555922e) Updated elpa
* [`d6ffb22d`](https://github.com/nix-community/emacs-overlay/commit/d6ffb22d2831cef6cdea0af22d043130bd08c462) Updated melpa
* [`27e6ef6f`](https://github.com/nix-community/emacs-overlay/commit/27e6ef6f477ba42dc8682ed854a519cbea4bacaf) Updated emacs
* [`40400234`](https://github.com/nix-community/emacs-overlay/commit/40400234c06e01b61d8fe33aa512cc8b0d0fb7a9) Updated elpa
* [`ecfedc0d`](https://github.com/nix-community/emacs-overlay/commit/ecfedc0d607abf7df2b077f421872fdfcc457ce7) Updated melpa
* [`d98b82fa`](https://github.com/nix-community/emacs-overlay/commit/d98b82faa313f3a3ac1c3f00f98819eb75bfc00d) Updated emacs
* [`9d798ee1`](https://github.com/nix-community/emacs-overlay/commit/9d798ee197f5464f79afe05e64518b553dfe23ef) Updated nongnu
* [`6e7cd8e5`](https://github.com/nix-community/emacs-overlay/commit/6e7cd8e535254cdc023151b04f6d2344c9c74d4a) Updated elpa
* [`9ad6e94c`](https://github.com/nix-community/emacs-overlay/commit/9ad6e94c659fdf303e34ec19af5f55f61a40ed94) Updated melpa
* [`3d4fbfcc`](https://github.com/nix-community/emacs-overlay/commit/3d4fbfcca3379975205ff861c2055c014ba8b77e) Updated emacs
* [`667ba506`](https://github.com/nix-community/emacs-overlay/commit/667ba50635165b62df075a6be4b41fb43860eee6) Updated melpa
* [`b90ce397`](https://github.com/nix-community/emacs-overlay/commit/b90ce397ca6331e20ffcb52d7434d1acd5ad6b22) Updated emacs
* [`0fef1e1e`](https://github.com/nix-community/emacs-overlay/commit/0fef1e1e08554183d9e2502f7184cb2dc08bf94d) Update README.org
* [`6b277f41`](https://github.com/nix-community/emacs-overlay/commit/6b277f418652f9e869a2c839553c6355592a656c) Updated elpa
* [`269fa8a1`](https://github.com/nix-community/emacs-overlay/commit/269fa8a1a1d458938c8a9b9c8c55e1be07ac760f) Updated nongnu
* [`30b63b76`](https://github.com/nix-community/emacs-overlay/commit/30b63b76bc88190c81239f781303284f9166606d) Updated melpa
* [`24f168cf`](https://github.com/nix-community/emacs-overlay/commit/24f168cf0db8c87ca16ac34066a586114ecaa182) Updated emacs
* [`97df499f`](https://github.com/nix-community/emacs-overlay/commit/97df499fb0d81979ae0997d46039a81c455377ed) Updated nongnu
* [`c8b1d61d`](https://github.com/nix-community/emacs-overlay/commit/c8b1d61d79f43d4a6bfbf6fcb40012d1a0089a7c) Updated elpa
* [`41c0d4a1`](https://github.com/nix-community/emacs-overlay/commit/41c0d4a18d609381a3e961873b3f69cdfbfef87a) Updated melpa
* [`c287c23f`](https://github.com/nix-community/emacs-overlay/commit/c287c23f43187bfe829e07e667a2dc36f9427fbc) Updated emacs
* [`ddb45572`](https://github.com/nix-community/emacs-overlay/commit/ddb455723166a611e0399169197b7454313f1ffc) Updated melpa
* [`a438495f`](https://github.com/nix-community/emacs-overlay/commit/a438495f2375b3067998c971718b3619f4ff07a8) Updated flake inputs
* [`4afd31ad`](https://github.com/nix-community/emacs-overlay/commit/4afd31ada85dc547f07651c1ce1e108564ed16dc) Updated nongnu
* [`90d92953`](https://github.com/nix-community/emacs-overlay/commit/90d92953fd3d438943f65a2bf094f5627af11819) Updated elpa
* [`c7d105f6`](https://github.com/nix-community/emacs-overlay/commit/c7d105f68c47ff9b6114b5473eeb9a3f7ea9ac06) Updated melpa
* [`496c42b1`](https://github.com/nix-community/emacs-overlay/commit/496c42b156668e2fa266019704ea4aafc9ce351d) Updated emacs
* [`9dfcde97`](https://github.com/nix-community/emacs-overlay/commit/9dfcde97c51b6ac22c48dedd367040a9c915fc18) Updated elpa
* [`04dc1d60`](https://github.com/nix-community/emacs-overlay/commit/04dc1d602efe32ab0be4e8a39f381f525691dba8) Updated melpa
* [`728439cd`](https://github.com/nix-community/emacs-overlay/commit/728439cd9e68339c306d6152b8950dcb87e604cf) Updated emacs
* [`9786a3ab`](https://github.com/nix-community/emacs-overlay/commit/9786a3ab448958deab4257cc820c4cb496435b6f) Updated flake inputs
* [`ee6a09cc`](https://github.com/nix-community/emacs-overlay/commit/ee6a09cc436d70f7e9e99e031033f037d29bd2ce) Updated nongnu
* [`bf2dbcf3`](https://github.com/nix-community/emacs-overlay/commit/bf2dbcf3cda2ff7ddbe42acd11ef764752f34284) Updated elpa
* [`b205ea48`](https://github.com/nix-community/emacs-overlay/commit/b205ea48fe3b8cc70d86658a80d37ce157d65057) Updated melpa
* [`26dc8270`](https://github.com/nix-community/emacs-overlay/commit/26dc8270e154711306a25d0d2921bd6dda545521) Updated emacs
* [`c7154f8a`](https://github.com/nix-community/emacs-overlay/commit/c7154f8a439a56e49ad921fff3406df72746f214) Updated nongnu
* [`5c505876`](https://github.com/nix-community/emacs-overlay/commit/5c5058765c0d3deb3b6edd3de434fe18af50e4b5) Updated elpa
* [`101c896d`](https://github.com/nix-community/emacs-overlay/commit/101c896dbb79c4b5f01e45fb3ab5a2846ea14e08) Updated melpa
* [`6944d9b0`](https://github.com/nix-community/emacs-overlay/commit/6944d9b030689cf37cdf01e14fa828fff195d8f7) Updated emacs
* [`7e9e872a`](https://github.com/nix-community/emacs-overlay/commit/7e9e872a431d5de1f34bd8af3ba72644640eeccf) Updated melpa
* [`9a699fa0`](https://github.com/nix-community/emacs-overlay/commit/9a699fa0f15ae69e7d12038640d34b8f5fb92e00) Updated emacs
* [`1cca3f01`](https://github.com/nix-community/emacs-overlay/commit/1cca3f01ffb976e03fd4b7879f99ec5b24cd22c3) Updated elpa
* [`614301b1`](https://github.com/nix-community/emacs-overlay/commit/614301b151f4d25fd7e73f57e6872fb875301bce) Updated melpa
* [`5e8f95ab`](https://github.com/nix-community/emacs-overlay/commit/5e8f95ab8a282758813e3d8922fdaa0783ee5b41) Updated emacs
* [`08ecd3e0`](https://github.com/nix-community/emacs-overlay/commit/08ecd3e099dce75a35d5096d6b049943353ac7dd) Updated elpa
* [`b5e4ae0a`](https://github.com/nix-community/emacs-overlay/commit/b5e4ae0a33bb011e9515181ff1634471a975539f) Updated melpa
* [`f20b9cfd`](https://github.com/nix-community/emacs-overlay/commit/f20b9cfd2c52c2ea5351008d008fd8b2f1419c30) Updated emacs
* [`ce81f683`](https://github.com/nix-community/emacs-overlay/commit/ce81f683a7f0806cecf57012a295ec7e1fa467d5) Updated flake inputs
* [`afdfe84c`](https://github.com/nix-community/emacs-overlay/commit/afdfe84c77aef4664773b11d84b4b3c2d36d5d72) Updated melpa
* [`dc376600`](https://github.com/nix-community/emacs-overlay/commit/dc376600483aae0272de58ea9b2d06c9f4e132eb) Updated emacs
* [`3dddf556`](https://github.com/nix-community/emacs-overlay/commit/3dddf55641599cb16f6e95ae3398761fdf6d7311) Updated elpa
* [`bdf81ad8`](https://github.com/nix-community/emacs-overlay/commit/bdf81ad80a4319ffd0a10ed176451ac5a1fa0b24) Updated melpa
* [`44398152`](https://github.com/nix-community/emacs-overlay/commit/443981528ce117ec3055d0fd182793d6cacbe778) Updated emacs
* [`3532a16b`](https://github.com/nix-community/emacs-overlay/commit/3532a16bb3dc791b6a1ac45c656bb010462e4665) Updated nongnu
* [`b96a1062`](https://github.com/nix-community/emacs-overlay/commit/b96a106247cc8b5bce04299b905631040eaff816) Updated elpa
* [`e3e9ef4c`](https://github.com/nix-community/emacs-overlay/commit/e3e9ef4c9904fddbd8c00f3288e6a3be26a6bf0b) Updated melpa
* [`b6082d10`](https://github.com/nix-community/emacs-overlay/commit/b6082d10feac69203dac419818daa47c5fe36464) Updated flake inputs
* [`34b29b9d`](https://github.com/nix-community/emacs-overlay/commit/34b29b9d04e9eaabafdcf3d7dacdcd3f5bf3d29a) Updated nongnu
* [`fd904f28`](https://github.com/nix-community/emacs-overlay/commit/fd904f28fb1d3d3a3d87db312fac97cb4a146db4) Updated elpa
* [`2005d1e0`](https://github.com/nix-community/emacs-overlay/commit/2005d1e0260e31e7775349c62eabbcd8ae5bd6e6) Updated flake inputs
* [`f2541c14`](https://github.com/nix-community/emacs-overlay/commit/f2541c145a994837ba3fe732531197f65672ae65) Updated elpa
* [`71aeeb45`](https://github.com/nix-community/emacs-overlay/commit/71aeeb45c76777bb24898d5a793999b402445fc7) Updated melpa
* [`4ffecf56`](https://github.com/nix-community/emacs-overlay/commit/4ffecf56a5faa4cf163da6da9690752365376e99) Updated emacs
* [`41ad3629`](https://github.com/nix-community/emacs-overlay/commit/41ad3629eaa64a587bd58f8bb9271cc5b17011e2) Updated flake inputs
* [`a9911a9e`](https://github.com/nix-community/emacs-overlay/commit/a9911a9e50ad51d8acd402c60b0bcbce4291784e) Updated elpa
* [`eeebb49e`](https://github.com/nix-community/emacs-overlay/commit/eeebb49e6f53c56612e0ac87154ad81f3d11a728) Updated melpa
* [`a2e483e0`](https://github.com/nix-community/emacs-overlay/commit/a2e483e0969dcad460f7bed3ae359d526d772fa1) Updated emacs
* [`cb0e2cbf`](https://github.com/nix-community/emacs-overlay/commit/cb0e2cbfad5eedcbe33cc2bff0e83e37e22afa12) Updated elpa
* [`aa2bfbde`](https://github.com/nix-community/emacs-overlay/commit/aa2bfbde35e9ed5edd64f037fc97a1515d40bfee) Updated elpa
* [`7f48c7d3`](https://github.com/nix-community/emacs-overlay/commit/7f48c7d3d44a5c6e8f3db67f2202759b8589f36a) Updated melpa
* [`950ed590`](https://github.com/nix-community/emacs-overlay/commit/950ed5909d7b4f3941c68a6119eaeb1a3665e239) Updated emacs
* [`e3a4b715`](https://github.com/nix-community/emacs-overlay/commit/e3a4b715f2a60efafa9cbe6bfa6b8bb5b659a381) Updated elpa
* [`d44d81ab`](https://github.com/nix-community/emacs-overlay/commit/d44d81ab57dc102db479400e958355b7e8e67660) Updated elpa
* [`afe79087`](https://github.com/nix-community/emacs-overlay/commit/afe79087f7f5727e87b80bfdc118767974e64969) Updated melpa
* [`3d38ddfb`](https://github.com/nix-community/emacs-overlay/commit/3d38ddfb5229e78c66a3896de47f7ee9edfb4bc3) Updated emacs
* [`021c59f8`](https://github.com/nix-community/emacs-overlay/commit/021c59f8e4138bbbc9d2f42ad53b43e57c066b65) Updated elpa
* [`95344642`](https://github.com/nix-community/emacs-overlay/commit/953446423db93b32f3e8bb57f91e8dfce8d34439) Updated melpa
* [`01240973`](https://github.com/nix-community/emacs-overlay/commit/012409732a53433d75db7bb2e06dd0bdaf8ca7ea) Updated emacs
* [`b87395d2`](https://github.com/nix-community/emacs-overlay/commit/b87395d2c708ce7ad43020d941a734c26c063c94) Updated flake inputs
* [`ebb1edb7`](https://github.com/nix-community/emacs-overlay/commit/ebb1edb7dfd8bfd176cfe931d8ebcb7c6ce88bca) Updated elpa
* [`a7dc10dc`](https://github.com/nix-community/emacs-overlay/commit/a7dc10dcdb880401734ce33b45dc6245cbf87808) Updated flake inputs
* [`a9a84712`](https://github.com/nix-community/emacs-overlay/commit/a9a8471214818720e26b9602495bac67ed9472cd) Updated elpa
* [`7c222bca`](https://github.com/nix-community/emacs-overlay/commit/7c222bca07a021406d9a5386523c093ade7c8ebd) Updated melpa
* [`9059feb4`](https://github.com/nix-community/emacs-overlay/commit/9059feb48648e980cdd797cd828377c08989ca8f) Updated emacs
