### PR TITLE
niv doomemacs: update 9620bb45 -> a189c211

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "doomemacs",
         "repo": "doomemacs",
-        "rev": "9620bb45ac4cd7b0274c497b2d9d93c4ad9364ee",
-        "sha256": "0hi504pkiwx1m7vd1ak2zc2hcl1dnpaa0gjzs5xlhz2wd7hsn60n",
+        "rev": "a189c211bf72aaa093289f5afb33763d2f36ecbd",
+        "sha256": "0cdsr7ykybifc80861pcsbh70a1jqlanfh31c66wmif0pprkas6q",
         "type": "tarball",
-        "url": "https://github.com/doomemacs/doomemacs/archive/9620bb45ac4cd7b0274c497b2d9d93c4ad9364ee.tar.gz",
+        "url": "https://github.com/doomemacs/doomemacs/archive/a189c211bf72aaa093289f5afb33763d2f36ecbd.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "emacs-overlay": {


### PR DESCRIPTION
## Changelog for doomemacs:
Branch: master
Commits: [doomemacs/doomemacs@9620bb45...a189c211](https://github.com/doomemacs/doomemacs/compare/9620bb45ac4cd7b0274c497b2d9d93c4ad9364ee...a189c211bf72aaa093289f5afb33763d2f36ecbd)

* [`cfdae236`](https://github.com/doomemacs/doomemacs/commit/cfdae2365c7783382532096d4489609e16bc2a51) feat(corfu): update smart tab completion
* [`cfb860f7`](https://github.com/doomemacs/doomemacs/commit/cfb860f71a8a9d2c15bd023bd74c8c75268553ac) doc(corfu): update troubleshooting section
* [`0a4d22e5`](https://github.com/doomemacs/doomemacs/commit/0a4d22e5b78c90d07bfbb0b587d93be91f2c489e) fix(config): fix corfu smart tab behavior
* [`2729a3f7`](https://github.com/doomemacs/doomemacs/commit/2729a3f7e34bd3ff64df416141da381378e87b7b) fix: obey the comp namespace change
* [`47fce87d`](https://github.com/doomemacs/doomemacs/commit/47fce87d86e4f4cdecbaf5ce4b0e0dbd34f8e42c) fix(magit): forge-browse-dwim -> forge-browse
* [`c625b78e`](https://github.com/doomemacs/doomemacs/commit/c625b78eb4a024f5759e2a63996495756441d86c) fix(gdscript): replace removed functions with new binding
* [`e7408020`](https://github.com/doomemacs/doomemacs/commit/e740802035dcbe083d3f8a9c760ab10bea1ac326) feat(debugger): add gdscript dap-mode support
* [`c9df1c5d`](https://github.com/doomemacs/doomemacs/commit/c9df1c5d42ff53cf2a70dac20bae6c488f8d9627) fix(evil): bind git time machine without vc-gutter
* [`e203309e`](https://github.com/doomemacs/doomemacs/commit/e203309e5cdc178a03c3d843019f0a2a68e7bb57) refactor(lib): use ripgrep instead of `git grep`
* [`c70b9668`](https://github.com/doomemacs/doomemacs/commit/c70b9668507c32e1f551386f7fe2ba0fc5a7756e) fix(cli): auto-generated script error
* [`63605189`](https://github.com/doomemacs/doomemacs/commit/63605189f3b8b15379463f33bdf329efe87a8c3e) nit(org): reformat or block
* [`587f237e`](https://github.com/doomemacs/doomemacs/commit/587f237e93aa32b05f9415dff34c376e5b133c9b) fix(org): avoid `(file-exists-p "file://")` on Windows
* [`e18a509f`](https://github.com/doomemacs/doomemacs/commit/e18a509f713b5d8c395e7896b45f76753407d0cb) fix: suppress lexical-binding warnings on 30+
* [`1d302868`](https://github.com/doomemacs/doomemacs/commit/1d3028688fdb9002d260a5c82bf86b757e6d537e) perf(cli): bin/doom startup
* [`6edd4a33`](https://github.com/doomemacs/doomemacs/commit/6edd4a334884c755f550a04bc00de8476718b546) perf(chinese): lazy load liberime
* [`b4531dd3`](https://github.com/doomemacs/doomemacs/commit/b4531dd359827c0cf1b67493ec0ef403d8737f3f) tweak(web): remove M-/ keybind
* [`49eaa532`](https://github.com/doomemacs/doomemacs/commit/49eaa532e13e81d6e79e8b20ffc7e1b175e6fa6a) bump: :lang emacs-lisp scheme web zig
* [`7c20ef26`](https://github.com/doomemacs/doomemacs/commit/7c20ef261926794e2ee30689f295d9cd3362c46b) bump: :editor parinfer
* [`5a8d65bc`](https://github.com/doomemacs/doomemacs/commit/5a8d65bc515d8a0372e4cb6a4c2be7a09c458eb0) bump: :tools magit :emacs vc
* [`afa7a24e`](https://github.com/doomemacs/doomemacs/commit/afa7a24eee4c3f2d6a0218756041e973f1da3bce) bump: :tools debugger lsp
* [`517daa4e`](https://github.com/doomemacs/doomemacs/commit/517daa4ed9168855c202ba2fd28920f6ee17249f) bump: :core
* [`6479fc71`](https://github.com/doomemacs/doomemacs/commit/6479fc71327b55e65ac2cbf69bcdeccab8996fcb) fix(word-wrap): choose first element if indent-var is list
* [`874b5368`](https://github.com/doomemacs/doomemacs/commit/874b536892fad38e8ae02679c75222ceb1ddc520) fix(ligatures): set-font-ligatures! reset on nil
* [`bdcf433b`](https://github.com/doomemacs/doomemacs/commit/bdcf433b04f6be5fad57d3f12e6cc542f1e6f79f) tweak(wanderlust): hide more technical headers
* [`95474830`](https://github.com/doomemacs/doomemacs/commit/954748308bba3755ade685dd6d75cfece08b1d05) tweak(wanderlust): switch to use UTF-8 as default charset
* [`c76b336f`](https://github.com/doomemacs/doomemacs/commit/c76b336f0dc6d3597a0f514080d429c7b863d857) bump: :email wanderlust
* [`cffb3838`](https://github.com/doomemacs/doomemacs/commit/cffb3838ecb0c2c93845a006ca750a4f72d88f1e) bump: :completion
* [`0a2bcf92`](https://github.com/doomemacs/doomemacs/commit/0a2bcf928c868db5cf41041bd707d3f395504130) feat(lookup): +lookup/file: search file tree for relative paths
* [`3037d364`](https://github.com/doomemacs/doomemacs/commit/3037d364b2d2d907467998af5694960f1dbcc7a2) bump: :lang javascript
* [`04057003`](https://github.com/doomemacs/doomemacs/commit/04057003c2a7320e5a0d543df73bb9405c189541) docs: update supported Emacs version in version check
* [`a61e2912`](https://github.com/doomemacs/doomemacs/commit/a61e2912cfe353079daca25dd037bf08a2591d28) refactor(cli): bin/doomscript: simplify redirs, update commment
* [`56f33bc7`](https://github.com/doomemacs/doomemacs/commit/56f33bc7ed1bc978de1399567c3332a39398d0fe) fix(tabs): workaround for ema2159/centaur-tabs[doomemacs/doomemacs⁠#231](https://togithub.com/doomemacs/doomemacs/issues/231)
* [`fddc912f`](https://github.com/doomemacs/doomemacs/commit/fddc912f81ce546fc3d105c99a6748b1e00ce23a) fix(tabs): defer centaur-tabs-mode in daemon sessions
* [`ea1f72e8`](https://github.com/doomemacs/doomemacs/commit/ea1f72e8755c67cce4d3683dd4d4cc9af6ad89bf) fix(tabs): reload centaur-tabs when changing themes
* [`6ba70df1`](https://github.com/doomemacs/doomemacs/commit/6ba70df1055f79b729e4bf7cfe8cd07295e36be4) docs(dired): update flags & package listing
* [`39588a15`](https://github.com/doomemacs/doomemacs/commit/39588a15f6665c0bc0f648559b747fc3854fab90) bump: :core
* [`1c18a0cc`](https://github.com/doomemacs/doomemacs/commit/1c18a0cc7e2d723b5ee3ff0eda3e37000336c5a4) bump: :emacs undo
* [`ee10764c`](https://github.com/doomemacs/doomemacs/commit/ee10764c220c790625381c245416cb0864a4168d) bump: :tools tree-sitter
* [`9116ec2e`](https://github.com/doomemacs/doomemacs/commit/9116ec2ec729bc30732dfd15a3fcac9ae4988025) release(modules): 24.07.0-dev
* [`7fe64293`](https://github.com/doomemacs/doomemacs/commit/7fe642938db45fe1ab85ec102c08e8db96df98de) fix: 'doom sync' generates autoload files for symbolic link files
* [`1f404bae`](https://github.com/doomemacs/doomemacs/commit/1f404bae9649903aeda952baf4d08582e40575e2) fix(ocaml): fix incorrect package name in README
* [`046cfd81`](https://github.com/doomemacs/doomemacs/commit/046cfd816a3bf8e63171bbbd5fa4580262d54282) feat(ocaml): switch to using opam-switch-mode
* [`4f4718e6`](https://github.com/doomemacs/doomemacs/commit/4f4718e6d151bef9278f8e87da566640c451865d) bump: :ui tabs
* [`7719991b`](https://github.com/doomemacs/doomemacs/commit/7719991badf3a47c1b0620b46505294f132b4ecc) bump: :tools
* [`62248f83`](https://github.com/doomemacs/doomemacs/commit/62248f836674dcae71c36036276193ad103d070f) bump: :ui
* [`391babd7`](https://github.com/doomemacs/doomemacs/commit/391babd7bb4a0b4ba376f0b485df35065ffb00c7) bump: :tools tree-sitter
* [`0aede163`](https://github.com/doomemacs/doomemacs/commit/0aede16322fb10b66a2b1a59f61d22099d5d4c2e) bump: :lang org
* [`b405225b`](https://github.com/doomemacs/doomemacs/commit/b405225b90949852eae8fb9b35b7377b3a38a44d) refactor!(vc-gutter): drop git-gutter for diff-hl
* [`a3a0629e`](https://github.com/doomemacs/doomemacs/commit/a3a0629e03b4440b6e02662352f6eaa7c0697c53) bump: :editor
* [`17119c5d`](https://github.com/doomemacs/doomemacs/commit/17119c5df71db0bc5255f7fa38b48828ed801f2f) refactor(lib): tweak user-error messages
* [`703173a6`](https://github.com/doomemacs/doomemacs/commit/703173a6d25a48b05e1d8bce6e3410349f716a9a) feat(lib): doom-print: allow lexical redirection
* [`7e7d8ebd`](https://github.com/doomemacs/doomemacs/commit/7e7d8ebdfd790d431afcb203067ec1578fe90a76) fix(lib): print!: don't resolve printed symlinks
* [`d8411192`](https://github.com/doomemacs/doomemacs/commit/d84111927c649784c0b26e42ad9162933bef1a1f) fix(lib): doom/bumpify-diff: ignore malformed package! statements
* [`415792d3`](https://github.com/doomemacs/doomemacs/commit/415792d37beeda574a10b534504f3c663a43e6d3) bump: :lang org
* [`0f09d6f7`](https://github.com/doomemacs/doomemacs/commit/0f09d6f748432e653ecd3c94fd0084b516689b1f) fix(dired): update dirvish keybindings
* [`4af60fe0`](https://github.com/doomemacs/doomemacs/commit/4af60fe066f3f0eb3b70cb8a35c3a18a50f1548f) feat(dired): add subtree bindings to dirvish
* [`c48a5e5f`](https://github.com/doomemacs/doomemacs/commit/c48a5e5f9c2fd171e6a714840992c6370d5f4528) fix(god): cursor color change
* [`5c50b65e`](https://github.com/doomemacs/doomemacs/commit/5c50b65e9508e2326af7202fcd577fda6b7d7553) bump: ws-butler
* [`3431ddd4`](https://github.com/doomemacs/doomemacs/commit/3431ddd44c105083a2eccfa454b159f466750d0d) refactor!(ophints): replace volatile-highlights w/ goggles
* [`a99c6b90`](https://github.com/doomemacs/doomemacs/commit/a99c6b9036bde2f60697ce9f2ac259dfa2266dbf) docs(mu4e): instructions for SMTP setup
* [`1ea2b58f`](https://github.com/doomemacs/doomemacs/commit/1ea2b58fe67c576a3d7b1e10abf4fb39bb35dc10) bump: :lang clojure
* [`7ce9a995`](https://github.com/doomemacs/doomemacs/commit/7ce9a995833d0bd95543c279c6972aac5c129260) fix(fold): only enable ts-fold-mode in tree-sitter buffers
* [`1427179d`](https://github.com/doomemacs/doomemacs/commit/1427179d98610168df54c4b31891421bd5faeb6c) feat(sh): assoc zsh compdef files with sh-mode
* [`cc7a509e`](https://github.com/doomemacs/doomemacs/commit/cc7a509e10785dba94f899a0d428d01e6b8bb078) bump: :editor fold
* [`c471ab00`](https://github.com/doomemacs/doomemacs/commit/c471ab00a602994db24abc2368154045daa90904) fix(fold): don't expect evil-vimish-fold
* [`56e998c5`](https://github.com/doomemacs/doomemacs/commit/56e998c5776f4a8fb16ea2be1a05c5675f129b8b) fix(fold): properly handle recursive folds
* [`9405cf03`](https://github.com/doomemacs/doomemacs/commit/9405cf0379c2648073f49a2e925e110a8bdbd6ce) fix(lookup): project search backend no-op
* [`5718e4e9`](https://github.com/doomemacs/doomemacs/commit/5718e4e96e98ae3132f3498f50460b6fe55b6f07) bump: :lang
* [`a24ff58a`](https://github.com/doomemacs/doomemacs/commit/a24ff58a5afea0f2ba1bab85cc39f5c49a688e97) fix(lib): don't kill buffers visible in another frame
* [`bff7baca`](https://github.com/doomemacs/doomemacs/commit/bff7baca69d7cb8c2c7507bba6527c0660fb0ed2) fix(fold): fold-levels off-by-one
* [`42ae401d`](https://github.com/doomemacs/doomemacs/commit/42ae401deb7c39a72c6e24bd899abab9c10a687c) fix(fold): +fold/next: actually support outlines
* [`d2efb01d`](https://github.com/doomemacs/doomemacs/commit/d2efb01d29ee6d03954e158799b51127d07b2a64) fix(org): attachment image inline preview
* [`42923be0`](https://github.com/doomemacs/doomemacs/commit/42923be0b3626b7f8dcf53470a684883a9adb619) bump: :ui tabs
* [`83aa4079`](https://github.com/doomemacs/doomemacs/commit/83aa40797e068f78064f11886e8d572946787e5e) fix(cli): suppress secondary prompts from straight on -!/--force
* [`c4ee9868`](https://github.com/doomemacs/doomemacs/commit/c4ee986818c9c17135b4af28079d1dd0765db7e4) docs: fix badges & update 29.3->29.4
* [`ae9e1fea`](https://github.com/doomemacs/doomemacs/commit/ae9e1feaa6b8b741a8f1a745e19aebb553f030b3) refactor: avoid needless macro calls
* [`4788dd60`](https://github.com/doomemacs/doomemacs/commit/4788dd60fe696b36c05f3ed2f206e3dfd5a09761) fix(org): serve evil-org-mode from @⁠doomelpa
* [`36a1cda7`](https://github.com/doomemacs/doomemacs/commit/36a1cda72432cf07319f0314b62d5bcc46f65ee5) fix(org): revise org-crypt init
* [`d9c5f747`](https://github.com/doomemacs/doomemacs/commit/d9c5f747abc29991b55009534ee3244e869eb109) tweak(org): org-effort-property = EFFORT
* [`d3d50474`](https://github.com/doomemacs/doomemacs/commit/d3d50474888195ab43db03c7607f356424b09d18) fix(lsp): revert refactor of map! call
* [`98d0b528`](https://github.com/doomemacs/doomemacs/commit/98d0b528369b5d1a81ab766eb2a69a707cce9d96) refactor(org): remove unneeded advice
* [`5d1e5806`](https://github.com/doomemacs/doomemacs/commit/5d1e580696080403326aeb81007126cb45adf4e8) bump: :app
* [`95b7fb1b`](https://github.com/doomemacs/doomemacs/commit/95b7fb1b75fd28855852e36a6a4b8f1dccd1a200) bump: :os tty :input chinese
* [`a0dadda2`](https://github.com/doomemacs/doomemacs/commit/a0dadda2666886840e63f28d96a03a6f635a4fe6) bump: :term
* [`d14ddbf6`](https://github.com/doomemacs/doomemacs/commit/d14ddbf69426bf74b80babe60dbffda4d217870d) fix(python): ensure anaconda-mode and +lsp are mutually exclusive
* [`378272bc`](https://github.com/doomemacs/doomemacs/commit/378272bcabe684592a59d16f714d2a0febc11931) refactor(lsp): remove lsp-racket fix
* [`819c20bb`](https://github.com/doomemacs/doomemacs/commit/819c20bb69e3e73131b635e74061e61136d8d051) feat(common-lisp): make quicklisp directory configurable
* [`a189c211`](https://github.com/doomemacs/doomemacs/commit/a189c211bf72aaa093289f5afb33763d2f36ecbd) tweak(syntax): hide posframe on next user input
