### PR TITLE
niv nixpkgs: update a5f04045 -> 3881b74f

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a5f040459a99b8bbc373d5f04ba7e6ce467b98d1",
-        "sha256": "074c1yvnqq519fcadz2x4r3idaw06684v5mwmjj9svwxn0wadaf7",
+        "rev": "3881b74fa87197d8a481d31ed7698c70dde5edd9",
+        "sha256": "1ivc5adx87mc501723zhbzmrnjnjp42fpqnzz8a45yzz9kmv3j4m",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/a5f040459a99b8bbc373d5f04ba7e6ce467b98d1.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/3881b74fa87197d8a481d31ed7698c70dde5edd9.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@a5f04045...3881b74f](https://github.com/nixos/nixpkgs/compare/a5f040459a99b8bbc373d5f04ba7e6ce467b98d1...3881b74fa87197d8a481d31ed7698c70dde5edd9)

* [`6c13e122`](https://github.com/NixOS/nixpkgs/commit/6c13e122c4963db61bec6e9e5fb28f7096924a57) freertos-gdb: init at 1.0.2
* [`dff96ae6`](https://github.com/NixOS/nixpkgs/commit/dff96ae65dd83bb5a49637edfd1fee8e3d0a7c2e) nixos/kmscon: use upstream service file
* [`edc2eeaf`](https://github.com/NixOS/nixpkgs/commit/edc2eeaf4849bda75afaf67f127164462892704f) pugixml: 1.13 -> 1.14
* [`829d529c`](https://github.com/NixOS/nixpkgs/commit/829d529c7caf3d6a3bd853e570de6bb71c7547a7) spip: unstable 2023-04-19
* [`dd7a04b3`](https://github.com/NixOS/nixpkgs/commit/dd7a04b36a19a2841979fa78c5276c1b0bb400d9) yourkit-java: init at 2023.9-b103
* [`7ea650ca`](https://github.com/NixOS/nixpkgs/commit/7ea650ca3f446459bd6c1046ddf4eaaf885fc925) yourkit-java: refine meta info
* [`7fc8aa0d`](https://github.com/NixOS/nixpkgs/commit/7fc8aa0d52ec74f6635f79dee0c7ea94267acd19) yourkit-java: reformat let
* [`7fcafd3f`](https://github.com/NixOS/nixpkgs/commit/7fcafd3f1eec76710ef4c503414e0612b86a0168) yourkit-java: refactored
* [`9283dcc9`](https://github.com/NixOS/nixpkgs/commit/9283dcc91df816cb29f39c9fade5c1d8ea477f6e) yourkit-java: simplify the definition of arch
* [`b8ae9833`](https://github.com/NixOS/nixpkgs/commit/b8ae983352a67e50949886a600bfb8f66ee54b9f) yourkit-java: change the references to profiler.sh
* [`b37d9c61`](https://github.com/NixOS/nixpkgs/commit/b37d9c6168126cace30cde7925a0232cee52c3a3) yourkit-java: use our desktop item
* [`935e4b3b`](https://github.com/NixOS/nixpkgs/commit/935e4b3ba2a2fcf307e350f7e9f09b7c87ef9be6) yourkit-java: convert profiler.ico into a PNG file
* [`606bfe72`](https://github.com/NixOS/nixpkgs/commit/606bfe729898d3733c24dbb42e0804d81da2fd03) yourkit-java: refactor
* [`0519b56a`](https://github.com/NixOS/nixpkgs/commit/0519b56a2a8545f9224cd08a317617b996d99525) yourkit-java: refine desktop item entries
* [`d0d3241c`](https://github.com/NixOS/nixpkgs/commit/d0d3241c3caa8a53df325e6471b3f1aafe122dfb) yourkit-java: add `%f` to desktop item's `exec`
* [`104220d9`](https://github.com/NixOS/nixpkgs/commit/104220d983be42b949d7520acbf7abb45fe9cf14) yourkit-java: restore `CONFIG_DIR`
* [`9b6920de`](https://github.com/NixOS/nixpkgs/commit/9b6920dedf226a15afd54174711dc5c433ddc1ee) yourkit-java: move to by-name
* [`d4ebb89e`](https://github.com/NixOS/nixpkgs/commit/d4ebb89ef02670f5b34f5d27f7b09982197971ec) openresty: 1.21.4.3 -> 1.25.3.1
* [`9bb9d548`](https://github.com/NixOS/nixpkgs/commit/9bb9d548ad4cc84199319853525004f98391b487) stepmania: fix aarch64-linux build by using libpng from nixpkgs
* [`7142e28c`](https://github.com/NixOS/nixpkgs/commit/7142e28c8b3735f659ea8d320d1329e40ddb6cb0) yourkit-java: 2023.9-b103 -> 2023.9-b107
* [`46451b66`](https://github.com/NixOS/nixpkgs/commit/46451b661472b69c5ad7544dbeba657e8f42381c) css-checker: init at 0.4.1
* [`956a23b5`](https://github.com/NixOS/nixpkgs/commit/956a23b5d21bd2ab9f9da14f570df9438c99d9a0) yourkit-java: 2023.9-b107 -> 2023.9-b109
* [`42f03f32`](https://github.com/NixOS/nixpkgs/commit/42f03f3229a8da79d54ffea0ec6d989185b776d1) yourkit-java: 2023.9-b107 -> 2023.9-b109
* [`881fc0de`](https://github.com/NixOS/nixpkgs/commit/881fc0de6a197a87c24c91b4721fb2d669f01900) yourkit-java: 2023.9-b109 -> 2023.9-b110
* [`9c5d9dcf`](https://github.com/NixOS/nixpkgs/commit/9c5d9dcf458026fda32b6bee27414a2f8194ddac) ingress2gateway: init at 0.2.0
* [`7287165e`](https://github.com/NixOS/nixpkgs/commit/7287165e84f9a5a7135b757d8d7583bf227d448c) yourkit-java: 2023.9-b110 -> 2024.3-b148
* [`16367beb`](https://github.com/NixOS/nixpkgs/commit/16367bebf75f1beaa64dcda55ebcc2c87cb7cd34) onlykey-agent: add missing `pkg_resources` dependency
* [`0467bb79`](https://github.com/NixOS/nixpkgs/commit/0467bb79a05e33ef2e7cdab1b061d79216e5720f) yourkit-java: 2024.3-b148 -> 2024.3-b150
* [`42de9f06`](https://github.com/NixOS/nixpkgs/commit/42de9f06d5f4179410eb5e43dcf19617497e319b) nixos/vagrant-guest: prefer 'install' over 'chmod'
* [`a87dd78c`](https://github.com/NixOS/nixpkgs/commit/a87dd78cddf03ccedc56acf538d7e823955a6685) genericUpdater: fix ignoredVersions
* [`91a2d90c`](https://github.com/NixOS/nixpkgs/commit/91a2d90c87d95373d7a2a1e3c294c7f431975e1c) ocamlPackages.printbox: 0.6.1 -> 0.11
* [`cb2b1427`](https://github.com/NixOS/nixpkgs/commit/cb2b1427ef4df2514f38d18a2a6ad992aecacc2f) mantainers: add Tommimon
* [`d41922a0`](https://github.com/NixOS/nixpkgs/commit/d41922a01688da4470fd461243e59ee798bd6a33) ddnet 18.1 -> 18.2 (plus one patch to workaround a libcurl problem)
* [`03bc8922`](https://github.com/NixOS/nixpkgs/commit/03bc8922b0b6b08fc3d25b05511cc43700f3cdcd) maintainers: add mi-ael
* [`a8da5dbf`](https://github.com/NixOS/nixpkgs/commit/a8da5dbf32870048279626d47bc9587462e7d955) nixos/tomcat: add 'port' option
* [`1a3afdf8`](https://github.com/NixOS/nixpkgs/commit/1a3afdf8526d7c30a64900d2041ebc5d1276488c) doc: migrate lib.derivations to doc-comment format
* [`450931d0`](https://github.com/NixOS/nixpkgs/commit/450931d09355aa4b1a13f87bd2df0d086149879a) doc: migrate lib.gvariant to doc-comment format
* [`7f38a9ce`](https://github.com/NixOS/nixpkgs/commit/7f38a9ce115a87e42ac7f8afc3bd857801e26139) Apply suggestions from code review
* [`8ee634f5`](https://github.com/NixOS/nixpkgs/commit/8ee634f5a65b8bda919f12e95ed4a391fac6e171) doc: init lib.generators reference documentation
* [`793ed729`](https://github.com/NixOS/nixpkgs/commit/793ed729f2cfe0e387e1237d6aacd8770ce16509) doc: add arguments for toKeyValue
* [`f26287d1`](https://github.com/NixOS/nixpkgs/commit/f26287d1a4f634eb50929002864d9ea386ab5220) maintainers/scripts/bootstrap-files: document the procedure of adding a new target
* [`9ed3d240`](https://github.com/NixOS/nixpkgs/commit/9ed3d240c98b25b35861dd86ce5bc80635af8542) scip-go: init at 0.1.14
* [`b6f6e507`](https://github.com/NixOS/nixpkgs/commit/b6f6e50765e1957e53088d2a850bf4017c2de780) doc: swap ANDROID_HOME and ANDROID_SDK_ROOT in android section
* [`19a3000c`](https://github.com/NixOS/nixpkgs/commit/19a3000c32a2a58b9a96f8b35eca8faff0ad00c7) cli.nix: improve documentation, including arguments
* [`c682f2b4`](https://github.com/NixOS/nixpkgs/commit/c682f2b49174b49107bab2868973a363437730b9) gcc: provide a $libgcc/$target/lib -> $libgcc/lib symlink
* [`4697088f`](https://github.com/NixOS/nixpkgs/commit/4697088fc0c3b6a1aee64d74033ef92321266898) wideriver: init at 1.1.0
* [`42197a7c`](https://github.com/NixOS/nixpkgs/commit/42197a7c535e602374ca7daad2603479ca6c90c1) soapui: 5.7.0 -> 5.7.2
* [`45333a64`](https://github.com/NixOS/nixpkgs/commit/45333a64c997fc0343c40750fdb6d9d09f79df73) python311Packages.pydata-sphinx-theme: 0.15.2 -> 0.15.3
* [`f6831060`](https://github.com/NixOS/nixpkgs/commit/f683106052bdd3f4c0d9e630ab8253027a6374ac) dtv-scan-tables: migrate to `pkgs/by-name` overlay
* [`aba8e447`](https://github.com/NixOS/nixpkgs/commit/aba8e44778523cb4824ecc9ed6854930d47b389d) dtv-scan-tables: use `finalAttrs` pattern instead of `rec`
* [`7e4f6f48`](https://github.com/NixOS/nixpkgs/commit/7e4f6f48d2b2281c0f46e2dd22f3f6eb68b5da26) dtv-scan-tables: remove `meta = with lib;`
* [`66daba4e`](https://github.com/NixOS/nixpkgs/commit/66daba4ef0c3aec2078f18022fac01d9008a6a34) dtv-scan-tables: 2022-04-30-57ed29822750 -> 2024-03-24-7098bdd27548
* [`15560bfc`](https://github.com/NixOS/nixpkgs/commit/15560bfca8a623cff40421eeb9eccdd5cc8aa49f) cups-brother-mfcl2800dw: init at 4.1.0-1
* [`60c88171`](https://github.com/NixOS/nixpkgs/commit/60c881713318031a3cedab89b25cddbb89f5c0d5) lime3ds: init at 2114
* [`fff7a2e1`](https://github.com/NixOS/nixpkgs/commit/fff7a2e1ce9f79475d7126e5f4a13e4d8fc132b6) python311Packages.uritools: 4.0.2 -> 4.0.3
* [`6324bc77`](https://github.com/NixOS/nixpkgs/commit/6324bc777cfe340911fc7a48eb0ce66e52a89052) openvas-smb: init at 22.5.6
* [`3f0bd8ab`](https://github.com/NixOS/nixpkgs/commit/3f0bd8ab85bf448bd7aee7c78a0ac128350a6568) nixos/healthchecks: add settingsFile option
* [`c170fbef`](https://github.com/NixOS/nixpkgs/commit/c170fbef21b71cd68179ccf1dd8c32e63fa13d04) webcord: pass --enable-wayland-ime to electron under wayland session
* [`f01dbb90`](https://github.com/NixOS/nixpkgs/commit/f01dbb90e8405c307c5324049656788dce3227d6) maintainers: add 0x5a4
* [`1ec428d1`](https://github.com/NixOS/nixpkgs/commit/1ec428d1765bc3e26ee8fa573d943c85bf9b72bd) wlinhibit: add 0x5a4 as maintainer
* [`16f70459`](https://github.com/NixOS/nixpkgs/commit/16f704595dec1cca1dc7db2aba26d960736a9c74) clippy-sarif: init at 0.4.2
* [`946357b8`](https://github.com/NixOS/nixpkgs/commit/946357b866c031ab5e1b377147bd0532e64b9b48) python-exiv2: init at 0.16.3
* [`55fcb611`](https://github.com/NixOS/nixpkgs/commit/55fcb611f471f8f1dd387edb688ec04b9b1d46f2) photini: init at 2025.5.0
* [`7fdb988e`](https://github.com/NixOS/nixpkgs/commit/7fdb988e123c677d1a447a08dd52f22507c1e4a7) maintainers: add amozeo
* [`61d1d59c`](https://github.com/NixOS/nixpkgs/commit/61d1d59c32e650d97dc55d40a55788cb21115d13) mackup: init at 0.8.40
* [`57830823`](https://github.com/NixOS/nixpkgs/commit/5783082382a7ccf62d276b67084803b3b2dcda58) libva-vdpau-driver: rename from vaapiVdpau
* [`9ced2991`](https://github.com/NixOS/nixpkgs/commit/9ced2991402cc567753e26e6196bf5cdf3629f53) yourkit-java: 2024.3-b150 -> 2024.3-b154
* [`360fecb8`](https://github.com/NixOS/nixpkgs/commit/360fecb837f41ef56e05614022a85531539576a3) stylelint-lsp: init at 2.0.0
* [`234f48f8`](https://github.com/NixOS/nixpkgs/commit/234f48f8ee848092e34cad3c8cba3688b51a3782) geos: 3.12.1 -> 3.12.2
* [`f4e79757`](https://github.com/NixOS/nixpkgs/commit/f4e79757df1a0822d41504e504857bb3e3548d90) geos: 3.11.2 -> 3.11.4
* [`36da2028`](https://github.com/NixOS/nixpkgs/commit/36da2028263db38748e199ce50cce95e9ff62db8) rtrtr: 0.2.2 -> 0.3.0
* [`4a2232e2`](https://github.com/NixOS/nixpkgs/commit/4a2232e27ee99ad45cf18ebb5d6f67beb6412e6d) signal-cli: 0.13.3 -> 0.13.4
* [`8fb7400f`](https://github.com/NixOS/nixpkgs/commit/8fb7400f566d16d9fcfd6425ec1411365cb3e16b) stress-ng: 0.17.08 -> 0.18.00
* [`3bc7854e`](https://github.com/NixOS/nixpkgs/commit/3bc7854ee81fa4c4257db37146e8350566fcbb02) shotcut: 24.04.28 -> 24.06.02
* [`3b21d006`](https://github.com/NixOS/nixpkgs/commit/3b21d0067efc804e8774b74b16646faf2f2865e6) mercure: 0.16.0 -> 0.16.2
* [`a9b1b1aa`](https://github.com/NixOS/nixpkgs/commit/a9b1b1aa35bf3afe9bcacb358f7cd226f1fe89ca) yourkit-java: modify as suggested
* [`1755fd1b`](https://github.com/NixOS/nixpkgs/commit/1755fd1be1138aa0933b310af58091fd4a31badb) yourkit-java: use a more precise name
* [`0256192d`](https://github.com/NixOS/nixpkgs/commit/0256192dfce9d78bc00dc84bfe2a3d44d8349eff) ocamlPackages.yojson: 2.2.0 -> 2.2.1
* [`65074c6f`](https://github.com/NixOS/nixpkgs/commit/65074c6f3fb00a0c266b3bdc923a49b79bdd21fc) bosh-cli: 7.6.0 -> 7.6.1
* [`afcd7bc4`](https://github.com/NixOS/nixpkgs/commit/afcd7bc478d4205a41efc8e67d8e088b468fb3b7) fedifetcher: 7.0.4 -> 7.0.5
* [`23050e56`](https://github.com/NixOS/nixpkgs/commit/23050e569e59a6373cecc37fa0f9fae38e1f891c) texstudio: 4.8.0 -> 4.8.1
* [`54332f47`](https://github.com/NixOS/nixpkgs/commit/54332f47cea331a38f17521cd74ec79e326a27c1) nixos/initrd-ssh: set KexAlgorithms/Ciphers/MACs only if non-null
* [`a5b14dd0`](https://github.com/NixOS/nixpkgs/commit/a5b14dd0632d430c4a53a70af9d8d9a24f820bb8) unciv: 4.11.16 -> 4.11.17
* [`58fab371`](https://github.com/NixOS/nixpkgs/commit/58fab3716806d3e8e7948bc099fc35a4306b0a26) rocmPackages_5.clr: patch ICD vendor path
* [`d35c5d63`](https://github.com/NixOS/nixpkgs/commit/d35c5d63403fb7b95e2c2d5ee2e94c4651c8f065) rocmPackages.clr: patch ICD vendor path
* [`29dad86f`](https://github.com/NixOS/nixpkgs/commit/29dad86f17c3f940d9f53495b59a3c93314add67) python312Packages.python-logging-loki: init at 0.3.1
* [`67271b74`](https://github.com/NixOS/nixpkgs/commit/67271b7480f97a4188f13102c5802faff8126c78) pywal16: init at 3.5.4
* [`fba7a111`](https://github.com/NixOS/nixpkgs/commit/fba7a111f21e4601203862964edf06389f0a25c4) leetgo: 1.4.1 -> 1.4.7
* [`f5870f15`](https://github.com/NixOS/nixpkgs/commit/f5870f15f38d811e4ee08ed25cc311b28cf75568) basex: 10.7 -> 11.0
* [`1807aec1`](https://github.com/NixOS/nixpkgs/commit/1807aec1513a4b701060c458dca72d9a71b22511) ivy: 0.2.10 -> 0.3.4
* [`162d342d`](https://github.com/NixOS/nixpkgs/commit/162d342d7d3290d91c0323cd97728eb717229503) adriconf: 2.7.1 -> 2.7.2
* [`78e446ab`](https://github.com/NixOS/nixpkgs/commit/78e446ab07f04e67362b1e1906fddd8046ca70d6) mpop: 1.4.18 -> 1.4.19
* [`a10d39c9`](https://github.com/NixOS/nixpkgs/commit/a10d39c9e1ef6030e2109306c9f562b1cc9f6c6b) virtiofsd: 1.10.1 -> 1.11.0
* [`0b9da0f1`](https://github.com/NixOS/nixpkgs/commit/0b9da0f1cc9ed5c3c80a2091dbbdb8f2ca09381e) greetd.greetd: 0.10.0 -> 0.10.3
* [`8322cb91`](https://github.com/NixOS/nixpkgs/commit/8322cb91b7b2879163f80a303274e44767908f08) arti: 1.2.3 -> 1.2.4
* [`0ed670a7`](https://github.com/NixOS/nixpkgs/commit/0ed670a7a3e52409a739f5a89effadaaab83981d) hyperrogue: 13.0i -> 13.0o
* [`4fac8896`](https://github.com/NixOS/nixpkgs/commit/4fac8896f065712df3fbfa973e24985d71a908d6) typst-preview: 0.11.6 -> 0.11.7
* [`d5f51cfd`](https://github.com/NixOS/nixpkgs/commit/d5f51cfde2d05346867221bc14877b1a66e5c9ee) deck: 1.38.0 -> 1.38.1
* [`cb688ae9`](https://github.com/NixOS/nixpkgs/commit/cb688ae976bed28a08f7113b4fc89d24e2fc1d4e) vtm: 0.9.82 -> 0.9.83
* [`1dd0d41b`](https://github.com/NixOS/nixpkgs/commit/1dd0d41b9cb8771be147233186f61db59b400d91) kubevirt: 1.2.1 -> 1.2.2
* [`7bc8a84e`](https://github.com/NixOS/nixpkgs/commit/7bc8a84e9b95b8975f9effaaba751cee743db3d0) oapi-codegen: 2.1.0 -> 2.3.0
* [`36ceabac`](https://github.com/NixOS/nixpkgs/commit/36ceabaca53ff5378aad2279f2e3a8228d58299c) abseil-cpp_202308: drop as unused
* [`08851a14`](https://github.com/NixOS/nixpkgs/commit/08851a1407120fa08ce0b02f56d562936995d527) python311Packages.onnx: use latest abseil-cpp
* [`35406a74`](https://github.com/NixOS/nixpkgs/commit/35406a74d9451210557c8e457691c415d7fa32af) redpanda-server: remove
* [`7467b881`](https://github.com/NixOS/nixpkgs/commit/7467b88130001a9fe68ef3ffeefa84c4b6f9ecb2) or-tools: use latest abseil-ccp
* [`465ef491`](https://github.com/NixOS/nixpkgs/commit/465ef491279af6a7c0a2b8dd8861832330151fe6) abseil-cpp_202206: drop
* [`06fc7db2`](https://github.com/NixOS/nixpkgs/commit/06fc7db29e1aea71cfaeacb1749f8221a1843c69) python311Packages.dm-tree: unpin abseil-cpp
* [`02c5e9e6`](https://github.com/NixOS/nixpkgs/commit/02c5e9e601ee67959a8e4f52f83746f96843fa8a) kuttl: 0.16.0 -> 0.17.0
* [`e137ed68`](https://github.com/NixOS/nixpkgs/commit/e137ed68fea1a91e953fa31a71b8cf2fa8ad302e) python311Packages.spotipy: 2.23.0 -> 2.24.0
* [`9b34b3f7`](https://github.com/NixOS/nixpkgs/commit/9b34b3f7379fd3fc8a7098949205f16401384c40) eyewitness: init at 20230525.1
* [`8f530a14`](https://github.com/NixOS/nixpkgs/commit/8f530a144c85522877fc195c0e16a82b4b19644a) nixdoc: 3.0.5 -> 3.0.7
* [`44efd4f6`](https://github.com/NixOS/nixpkgs/commit/44efd4f673f844b83d9585be8fbee1654e0031c0) xfe: 1.46.1 -> 1.46.2
* [`2f5918d5`](https://github.com/NixOS/nixpkgs/commit/2f5918d558deb806c23a6aa3521f79183bd4da6c) praat: 6.4.12 -> 6.4.13
* [`bb0baa0a`](https://github.com/NixOS/nixpkgs/commit/bb0baa0ab3e5a38b90971038f45617a287d972b1) alglib: 4.01.0 -> 4.02.0
* [`4438aef1`](https://github.com/NixOS/nixpkgs/commit/4438aef1a23958faacf1a75afbf84e57e98f11c7) deepin.dde-shell: init at 0.0.17
* [`10a7facb`](https://github.com/NixOS/nixpkgs/commit/10a7facbdfc9c5513e51c71ad8b69ca4eeeae86d) deepin.dde-launchpad: 0.4.4 -> 0.6.10
* [`505fbdb9`](https://github.com/NixOS/nixpkgs/commit/505fbdb97e07fd00defb2ea79fd7b401bc49cbf0) deepin.dtkcommon: 5.6.21 -> 5.6.29
* [`8bfa4dd2`](https://github.com/NixOS/nixpkgs/commit/8bfa4dd2cc0704dd0b2899f1cb3015731cd286cb) deepin.dtkcore: 5.6.22 -> 5.6.29
* [`a469dd4f`](https://github.com/NixOS/nixpkgs/commit/a469dd4fb8735d6fae639fb9c1d07fe05bcc0c49) deepin.dtkgui: 5.6.22 -> 5.6.29
* [`f7697d14`](https://github.com/NixOS/nixpkgs/commit/f7697d14d204fbb16de1d17d72ba474d499d75c3) deepin.dtkwidget: 5.6.22 -> 5.6.29
* [`e2864158`](https://github.com/NixOS/nixpkgs/commit/e2864158d27471b821d2a296e68bd0cba7406a2d) deepin.dtkdeclarative: 5.6.24 -> 5.6.29
* [`333c3719`](https://github.com/NixOS/nixpkgs/commit/333c37196e52f79df8bfa005bbcb4f6d44c0b1ce) deepin.qt5integration: 5.6.20 -> 5.6.29
* [`aa013981`](https://github.com/NixOS/nixpkgs/commit/aa0139812baf098950362e85987fdcd5c73f9b88) deepin.qt5platform-plugins: 5.6.22 -> 5.6.29
* [`41c948e1`](https://github.com/NixOS/nixpkgs/commit/41c948e12359eb5f26cebd354f424c58e5708c9e) deepin.deepin-shortcut-viewer: 5.0.7 -> 5.0.9
* [`3f3c3d6f`](https://github.com/NixOS/nixpkgs/commit/3f3c3d6f71b37a59e2eb7e1a9f74856c652bdfad) deepin.deepin-icon-theme: 2024.01.31 -> 2024.04.16
* [`993b9efb`](https://github.com/NixOS/nixpkgs/commit/993b9efb71d02e135debe935b64ae89be296235b) deepin.dde-device-formatter: 0.0.1.15 -> 0.0.1.16
* [`43c7023c`](https://github.com/NixOS/nixpkgs/commit/43c7023ca693b03028097d821c9db900d3038b2f) deepin.deepin-kwin: 5.25.17 -> 5.25.26
* [`f24c01e7`](https://github.com/NixOS/nixpkgs/commit/f24c01e7cffb5fa4325953a513343bc51419fde8) deepin.util-dfm: 1.2.21 -> 1.2.24
* [`1024aad5`](https://github.com/NixOS/nixpkgs/commit/1024aad55552b917e9ef4d2d3ab1c75181982c22) deepin.dde-polkit-agent: 6.0.5 -> 6.0.7
* [`0830bef3`](https://github.com/NixOS/nixpkgs/commit/0830bef3c819f31df547e4d4e1252305e969447e) deepin.dde-session-shell: 6.0.17 -> 6.0.20
* [`cd627017`](https://github.com/NixOS/nixpkgs/commit/cd627017817a79f2e7e8a6ccd15c9482e0ea6248) deepin.dde-session-ui: 6.0.16 -> 6.0.19
* [`f85cb635`](https://github.com/NixOS/nixpkgs/commit/f85cb635d47b5cb8ebd40dcf65b0d33cf53e8cdb) deepin.dde-widgets: 6.0.19 -> 6.0.22
* [`162552d4`](https://github.com/NixOS/nixpkgs/commit/162552d4e55109eda6f784cd0ea99de104ebc582) deepin.dde-network-core: 2.0.21 -> 2.0.26
* [`bf989ada`](https://github.com/NixOS/nixpkgs/commit/bf989adabb23f02faac2a21959bba2879abd7e4f) deepin.deepin-desktop-theme: 1.0.9 -> 1.0.13
* [`04ff4c5c`](https://github.com/NixOS/nixpkgs/commit/04ff4c5c52f0394baae67450f86e95c91e50a2a6) deepin.dde-session: 1.2.5 -> 1.2.10
* [`743e3bf9`](https://github.com/NixOS/nixpkgs/commit/743e3bf933399b1dfef4077b595d59439f8f0fe9) deepin.dde-control-center: 6.0.44 -> 6.0.55
* [`602cff3e`](https://github.com/NixOS/nixpkgs/commit/602cff3e0c7e9445e62241397443dc4cdf8e25c5) deepin.dde-application-manager: 1.1.8 -> 1.2.13
* [`cf7b36c5`](https://github.com/NixOS/nixpkgs/commit/cf7b36c5f68545ceeec8eaddb1aafd3cd3679449) deepin.dtk6core: 6.0.15 -> 6.0.16
* [`a1d81d6c`](https://github.com/NixOS/nixpkgs/commit/a1d81d6cfb2aa87e74854e3cac0f712a2e58694c) deepin.dde-file-manager: 6.0.40 -> 6.0.51
* [`751809fb`](https://github.com/NixOS/nixpkgs/commit/751809fb339e6dbffc2eb3cc26a431f05551c34f) deepin.dde-calendar: 5.12.1 -> 5.13.1
* [`6169f667`](https://github.com/NixOS/nixpkgs/commit/6169f667928539a4bf26b6e7f318488c58aac610) deepin.dde-clipboard: 6.0.7 -> 6.0.9
* [`c4e23c50`](https://github.com/NixOS/nixpkgs/commit/c4e23c50e5eb21abadc8bd0f4b2fee1b51cbdf7d) deepin.dtk6gui: 6.0.15 -> 6.0.16
* [`d536b267`](https://github.com/NixOS/nixpkgs/commit/d536b267bc546b881ba2fe89e13722b21fecb50a) deepin.dtk6widget: 6.0.15 -> 6.0.16
* [`ea314aae`](https://github.com/NixOS/nixpkgs/commit/ea314aae72e695bc0a34ddf3d3ee5f91a8500a8a) deepin.dtk6declarative: 6.0.15 -> 6.0.16
* [`7b14239e`](https://github.com/NixOS/nixpkgs/commit/7b14239eba1fb7ddd0f2170fce36859b47c7c323) deepin.go-lib: remove
* [`8a11f404`](https://github.com/NixOS/nixpkgs/commit/8a11f404b40d0c297ab6abda9288b38ef11f3b0e) deepin.go-gir-generator: remove
* [`2cf6e466`](https://github.com/NixOS/nixpkgs/commit/2cf6e466a72921fd6bcaa6347316a16f59a2649d) deepin.go-dbus-factory: remove
* [`ccbf715d`](https://github.com/NixOS/nixpkgs/commit/ccbf715d43d813d1686e225a5db20d4a43b25c34) deepin: don't install deepin-turbo as it's unmaintained
* [`cab91311`](https://github.com/NixOS/nixpkgs/commit/cab913114a0591d77dac60f93b7d4c7fecfee74c) deepin: new deepin 23 components
* [`702ee1d7`](https://github.com/NixOS/nixpkgs/commit/702ee1d7403ef564dcbe3aca980cc435e129b372) deepin.qt6platform-plugins: init at 6.0.16
* [`be6b9d7b`](https://github.com/NixOS/nixpkgs/commit/be6b9d7bd3c815f34611084c1cf3ab70bc4a77dd) deepin.qt6integration: init at 6.0.16
* [`71b88333`](https://github.com/NixOS/nixpkgs/commit/71b88333b6d747074a4e505a1f5976155c4d1b4d) deepin.startdde: 6.0.13 -> 6.0.14
* [`ca86ee82`](https://github.com/NixOS/nixpkgs/commit/ca86ee82e4a8f5a3954b6611b9c814fef70caa96) deepin.dde-api: 6.0.9 -> 6.0.11
* [`88674ae8`](https://github.com/NixOS/nixpkgs/commit/88674ae89c97f8c44afe041100490106ecee4c8a) deepin.dde-grand-search: init at 5.4.9
* [`9fa4925d`](https://github.com/NixOS/nixpkgs/commit/9fa4925d0e58faa90892ea77e9574adf67a4110b) deepin.deepin-desktop-schemas: 6.0.5 -> 6.0.6
* [`bbd2c1da`](https://github.com/NixOS/nixpkgs/commit/bbd2c1dae162673bdc21366a6c46e4a74f050c70) deepin.dde-gsettings-schemas: update
* [`9cf457ff`](https://github.com/NixOS/nixpkgs/commit/9cf457ffe76669b7befd95004e5b49a0132ac5a9) deepin.dde-launchpad: 0.6.10 -> 0.7.0
* [`d8cb64ad`](https://github.com/NixOS/nixpkgs/commit/d8cb64ad2561302b01194dc6db4eef52820a6eb8) deepin.dde-shell: 0.0.17 -> 0.0.23-unstable-2024-06-11
* [`aac47c9a`](https://github.com/NixOS/nixpkgs/commit/aac47c9a7fbddbc542b21745d15633be33d4b4c1) kubecm: 0.29.1 -> 0.30.0
* [`921ea9a6`](https://github.com/NixOS/nixpkgs/commit/921ea9a6c6315a1ff4369cdd0b4362f6165f16e4) scip: 0.3.3 -> 0.4.0
* [`7284a200`](https://github.com/NixOS/nixpkgs/commit/7284a2000ace95772ed11f72d046e3763080235d) protoc-gen-dart: add passthru.updateScript
* [`882faa69`](https://github.com/NixOS/nixpkgs/commit/882faa69892023c54b901ae92a82598572f0b7c7) clusterctl: 1.7.2 -> 1.7.3
* [`799c6d78`](https://github.com/NixOS/nixpkgs/commit/799c6d78e96b01abebf4f478e9e04445b75dbcea) micronaut: 4.4.3 -> 4.5.0
* [`c8697fdd`](https://github.com/NixOS/nixpkgs/commit/c8697fdd049db35ac950527fcfdb8006afae4150) pkgs/top-level/release-attrpaths-superset.nix: add attributes to skip to prevent [nixos/nixpkgs⁠#319147](https://togithub.com/nixos/nixpkgs/issues/319147)
* [`111b1996`](https://github.com/NixOS/nixpkgs/commit/111b1996ac916777e4e42578ebd6b7f4ea86056e) rapidyaml: 0.6.0 -> 0.7.0
* [`b461eef2`](https://github.com/NixOS/nixpkgs/commit/b461eef2ed98ce4bef669b178a9a87fedfbe7499) oils-for-unix: 0.21.0 -> 0.22.0
* [`c39a83ac`](https://github.com/NixOS/nixpkgs/commit/c39a83acf04de3ca64176cb712dba3d88aaaa228) wazero: 1.7.2 -> 1.7.3
* [`c727732f`](https://github.com/NixOS/nixpkgs/commit/c727732f6602a28f07bb5f1cacbe0304b4989856) dazel: init at 0.0.42
* [`4df3c4c1`](https://github.com/NixOS/nixpkgs/commit/4df3c4c17b3622c2f3f2dc8bb877ac8470efc1c6) nixos/clevis: add support for parent encrypted zfs datasets
* [`bd36b3a0`](https://github.com/NixOS/nixpkgs/commit/bd36b3a05a1a85f9df525f5ed3190160c6d75d2f) fedimint: init at 0.3.2-rc.0
* [`22ccc86b`](https://github.com/NixOS/nixpkgs/commit/22ccc86bfb44bbc276bff7cbf76f3877dc52e3cb) avalanchego: 1.11.7 -> 1.11.8
* [`4cf78288`](https://github.com/NixOS/nixpkgs/commit/4cf7828872f3b6b8045e5a177a619fdb3b575120) maintainers: add TakWolf
* [`94ee620a`](https://github.com/NixOS/nixpkgs/commit/94ee620a3f79064e2615a208cc053894c4c1abcc) python311Packages.unidata-blocks: set python 3.10
* [`7fc47397`](https://github.com/NixOS/nixpkgs/commit/7fc47397703245060db05bd640d62fea8a07c8cc) python311Packages.character-encoding-utils: set python 3.10
* [`759d6dcd`](https://github.com/NixOS/nixpkgs/commit/759d6dcd3ea6801b1e3db758aece4b9a10582250) python311Packages.bdffont: set python 3.10
* [`e617f54c`](https://github.com/NixOS/nixpkgs/commit/e617f54ca2979c3f62571c7bcd4dc586bbcf3d68) python311Packages.pcffont: use fetchPypi
* [`689caa9b`](https://github.com/NixOS/nixpkgs/commit/689caa9b0d1b23899d20ced7f5462b1610d01d3c) python311Packages.pixel-font-builder: cleanup
* [`b1676e25`](https://github.com/NixOS/nixpkgs/commit/b1676e25e3ea6e319a03fb470372e2949a47d354) regex-cli: 0.2.0 -> 0.2.1
* [`7b970f39`](https://github.com/NixOS/nixpkgs/commit/7b970f39cd20d96803b9874c867c57826b63a828) wesnoth: 1.18.0 -> 1.18.1
* [`d18b83e9`](https://github.com/NixOS/nixpkgs/commit/d18b83e955f01cce51d97b1be05c7760a520513b) bootstrap-studio: 6.7.0 -> 6.7.2
* [`15d4c23f`](https://github.com/NixOS/nixpkgs/commit/15d4c23f58c5b4ce3924111227580ba66ab3b5d9) kclvm: init at 0.8.7
* [`e95ac764`](https://github.com/NixOS/nixpkgs/commit/e95ac7643cbf3c92e558583d27d967f956ab7958) kclvm_cli: init at 0.8.7
* [`e92c574d`](https://github.com/NixOS/nixpkgs/commit/e92c574d1e39a029c9ed373a51f659d7d0f540b3) kcl: rename kcl-cli to kcl
* [`456de86f`](https://github.com/NixOS/nixpkgs/commit/456de86f8f104a8af825888de54d9563c0d6ada1) livi: 0.1.0 -> 0.2.0
* [`89ccfd37`](https://github.com/NixOS/nixpkgs/commit/89ccfd3765c841e015be5dc42a9df08bc6d66934) re-flex: 4.2.1 -> 4.4.0
* [`dcd747d9`](https://github.com/NixOS/nixpkgs/commit/dcd747d9776be3b3ac8ded10ca93edbd1d6991df) surrealist: 1.11.7 -> 2.0.6
* [`7aff15e8`](https://github.com/NixOS/nixpkgs/commit/7aff15e8c4fd3f304d82979a49aa47e9780a105b) nixos/systemd-repart: respect NIX_BUILD_CORES for image compression
* [`7d8742da`](https://github.com/NixOS/nixpkgs/commit/7d8742da87c1b06cd6db5eba1fe5a2cf8a7b2568) treewide: fix mkEnableOption usage
* [`200bd299`](https://github.com/NixOS/nixpkgs/commit/200bd2995e04d24935fcd74bdbcc308e6ad3baf0) cinzel: init at 0-unstable-2020-07-22
* [`25e3c526`](https://github.com/NixOS/nixpkgs/commit/25e3c526c5ab98516016871af704c18bdcc0c927) haproxy: 2.9.7 -> 3.0.2
* [`5c003de3`](https://github.com/NixOS/nixpkgs/commit/5c003de3177befb5e197ccafb4ce7321e669c206) embree: 4.3.1 -> 4.3.2
* [`476091ce`](https://github.com/NixOS/nixpkgs/commit/476091ce22797718990bfcc925790eb09e4ce3b0) dart: 3.4.2 -> 3.4.4
* [`8d0312a0`](https://github.com/NixOS/nixpkgs/commit/8d0312a07ee6bc408580d07d001f503144b717b4) devpod: 0.5.12 -> 0.5.15
* [`17fdf1d5`](https://github.com/NixOS/nixpkgs/commit/17fdf1d5aacab44dc26041db6dc446d39793e8c3) infisical: 0.22.3 -> 0.22.6
* [`a04c9118`](https://github.com/NixOS/nixpkgs/commit/a04c91182387b1042b604ce98238fe6c4852bba1) cherrytree: 1.1.2 -> 1.1.3
* [`478a3ac5`](https://github.com/NixOS/nixpkgs/commit/478a3ac5cd4da0188d38f0d26e9021705b58ca54) fsmon: 1.8.5 -> 1.8.6
* [`74150186`](https://github.com/NixOS/nixpkgs/commit/7415018674ad59460d6fa854661cdf11322fe983) nagios: 4.5.2 -> 4.5.3
* [`23ce5265`](https://github.com/NixOS/nixpkgs/commit/23ce5265d005584386aeed4a7fbb7f4f85db99c1) pkgs/build-support/kernel/make-initrd.nix: fix eval for test on darwin
* [`69e344db`](https://github.com/NixOS/nixpkgs/commit/69e344db4f46313f43a828f2b1d6642c94fd4850) uid_wrapper: 1.3.0 -> 1.3.1
* [`1c6b01d6`](https://github.com/NixOS/nixpkgs/commit/1c6b01d65b83140e652f08ed7a910b52d5c5bf19) pplite: 0.11 -> 0.12
* [`96aa63b3`](https://github.com/NixOS/nixpkgs/commit/96aa63b3d3e2ab6dfddd30da1dcad14748505f41) nsd: 4.9.1 -> 4.10.0
* [`9ffeef46`](https://github.com/NixOS/nixpkgs/commit/9ffeef46121d936876113799eadf5e2c062d164d) last: 1544 -> 1548
* [`ebfb1974`](https://github.com/NixOS/nixpkgs/commit/ebfb1974fa3a535bff8d98f821f1ab2becf33d28) chibi: 0.10 -> 0.11
* [`70038668`](https://github.com/NixOS/nixpkgs/commit/700386681fb2687fa83a0d82f654f63bf1a2855f) keepalived: 2.3.0 -> 2.3.1
* [`f77f9f56`](https://github.com/NixOS/nixpkgs/commit/f77f9f5645fb32dd11c206bd255c89b72d997aa7) vue-language-server: init at 2.0.21
* [`771b7eba`](https://github.com/NixOS/nixpkgs/commit/771b7eba2684ad4d6a3253ed6de73dac1e62518d) alfaview: 9.11.0 -> 9.12.0
* [`5a1e9de3`](https://github.com/NixOS/nixpkgs/commit/5a1e9de369abbffb5dba2646334731e02d777895) altair: 7.0.1 -> 7.1.0
* [`b339a999`](https://github.com/NixOS/nixpkgs/commit/b339a999966f5b7666f4f808f3a3600e69e74240) remnote: add update script
* [`bb71e98e`](https://github.com/NixOS/nixpkgs/commit/bb71e98eee413a24ace43d4603c82809068a3113) xlights: 2024.10 -> 2024.11
* [`48daa321`](https://github.com/NixOS/nixpkgs/commit/48daa32124bddddde23fde5f2862b92063757229) ircdHybrid: 8.2.43 -> 8.2.44
* [`d4255257`](https://github.com/NixOS/nixpkgs/commit/d4255257c3a65b187731fd2dace665edbdf97df9) trytond: 7.2.3 -> 7.2.4
* [`72406a54`](https://github.com/NixOS/nixpkgs/commit/72406a54e79044a7480b71cfba3b773fb2e40419) nixos/vaultwarden: backup all rsa_keys
* [`227afde6`](https://github.com/NixOS/nixpkgs/commit/227afde6d8eeb9c08b4f9bb3c42521925e2977a5) db4: fix configure with llvm
* [`6443d95b`](https://github.com/NixOS/nixpkgs/commit/6443d95bda5103bd598f09fc84b9ffc7ae2636c0) nodePackages.@⁠volar/vue-language-server: remove deprecated package
* [`8242e326`](https://github.com/NixOS/nixpkgs/commit/8242e326d5e44ff8f883b6bb12b82e23c0058f29) python312Packages.duckdb-engine: enable python3.12 by trimming checkInputs
* [`0f4a14b2`](https://github.com/NixOS/nixpkgs/commit/0f4a14b21098b75e32c4f7419745d021ded5da72) iniparser: 4.2.3 -> 4.2.4
* [`65bed59e`](https://github.com/NixOS/nixpkgs/commit/65bed59e91df9213c1ed900ee33a4ee153f8bfcb) barman: 3.10.0 -> 3.10.1
* [`b89d2aa4`](https://github.com/NixOS/nixpkgs/commit/b89d2aa42bff8c05f6100135d8092db5d0824dac) livekit: 1.6.1 -> 1.6.2
* [`1a6e223a`](https://github.com/NixOS/nixpkgs/commit/1a6e223a43a02a94a951b2448baf0f686f88ac4d) iniparser: format with nixfmt-rfc-style
* [`cf77d47c`](https://github.com/NixOS/nixpkgs/commit/cf77d47c83270103be226a7175a2bcd2508be10d) mcontrolcenter: init at 0.4.1
* [`4251886e`](https://github.com/NixOS/nixpkgs/commit/4251886e0b2f84b07c53e83500b1ef4a2501f88b) scdl: 2.7.9 -> 2.7.12
* [`17202b78`](https://github.com/NixOS/nixpkgs/commit/17202b7859d810fa1c5328771f6cb71ff4d3a415) opencomposite: 0-unstable-2024-06-01 -> 0-unstable-2024-06-12
* [`56ff6ca8`](https://github.com/NixOS/nixpkgs/commit/56ff6ca8556108e8ed79713699d6b3cf0daa38a0) wishbone-tool: 0.6.9 -> 0.7.9
* [`f6039ec1`](https://github.com/NixOS/nixpkgs/commit/f6039ec1a2b19ed6acf2bd1084d6cca34498def3) atlauncher: 3.4.36.6 -> 3.4.36.9
* [`e63e9271`](https://github.com/NixOS/nixpkgs/commit/e63e9271bb7eebfe6159d544bec875ecd64c96ba) apacheKafka: 3.5.0 -> 3.5.2
* [`1f45118e`](https://github.com/NixOS/nixpkgs/commit/1f45118e73e5fdcb28faf618952ef913d0aca8e5) apacheKafka: init version 3.6.1, make default
* [`27a384a0`](https://github.com/NixOS/nixpkgs/commit/27a384a0ab5c65d15732ab721bf5703a3b79b6e9) apacheKafka: drop 3.4 and older
* [`ff5e9d2c`](https://github.com/NixOS/nixpkgs/commit/ff5e9d2cd8dd559dd94c77bf123e102af9bdc97c) apacheKafka: callPackages
* [`4e5d9043`](https://github.com/NixOS/nixpkgs/commit/4e5d90435044118493fa59c4f3b82222ebbf1a76) apacheKafka: init 3.7.0. make default
* [`03e0cf25`](https://github.com/NixOS/nixpkgs/commit/03e0cf25d9bb0adb292bc8abfc9517f193288d71) apacheKafka: 3.6.1 → 3.6.2
* [`412cce13`](https://github.com/NixOS/nixpkgs/commit/412cce1388910d95980aa06f9fcb687f258240a0) apacheKafka: Drop 3.5 series
* [`6f8d36ae`](https://github.com/NixOS/nixpkgs/commit/6f8d36aeedd0a5acd3e592300beb1cc287a06a19) ludusavi: 0.23.0 -> 0.24.1
* [`2d55fc92`](https://github.com/NixOS/nixpkgs/commit/2d55fc92ecb560c4c3c5498d31dd1a0b7c7dfa7c) obs-studio-plugins.advanced-scene-switcher: 1.26.2 -> 1.26.4
* [`35c2e4bf`](https://github.com/NixOS/nixpkgs/commit/35c2e4bf4e17cfa091b7db1487bde79ee62cb62e) questdb: 8.0.0 -> 8.0.1
* [`653397e1`](https://github.com/NixOS/nixpkgs/commit/653397e1ab2236a47e786a48d561c5cbb53a8ccf) paho-mqtt-cpp: 1.3.2 → 1.4.0
* [`73424ef9`](https://github.com/NixOS/nixpkgs/commit/73424ef948b13410673463d9bb3a59c462cd4b14) tidal-hifi: 5.13.1 -> 5.14.1
* [`ae8f685e`](https://github.com/NixOS/nixpkgs/commit/ae8f685ec9cbad823e5cf4caf362e6c0d6377f45) tryton: 7.2.1 -> 7.2.2
* [`f22c4e61`](https://github.com/NixOS/nixpkgs/commit/f22c4e61ac394e15f51abf1d26ac178c71a95d1f) maintainers: add mkez
* [`5ce23547`](https://github.com/NixOS/nixpkgs/commit/5ce2354724a0e58b36902f17082604ab591c2fa2) posy-cursors: init at 1.6
* [`bad4c65e`](https://github.com/NixOS/nixpkgs/commit/bad4c65e90880a3df4ce722e52388170003fc6f4) minizincide: 2.8.4 -> 2.8.5
* [`ba59b792`](https://github.com/NixOS/nixpkgs/commit/ba59b79291e962d3d3a40546e4a34efdebaae82c) minify: 2.20.16 -> 2.20.34
* [`330bb874`](https://github.com/NixOS/nixpkgs/commit/330bb87490b1c6c3224fa33e6fdd257dab0c2094) oneDNN: 3.4.3 -> 3.5
* [`ca0eb242`](https://github.com/NixOS/nixpkgs/commit/ca0eb2420e952a0e6a3fc717c7f07d5ef14da461) chafa: 1.14.0 -> 1.14.1
* [`57bb750f`](https://github.com/NixOS/nixpkgs/commit/57bb750f45679d880264adb1db3646ec7b11bf1c) libwbxml: 0.11.9 -> 0.11.10
* [`cc700114`](https://github.com/NixOS/nixpkgs/commit/cc7001149d63c8b4903d625e4b2e63b7599c63f9) e1s: 1.0.37 -> 1.0.38
* [`6ca4f804`](https://github.com/NixOS/nixpkgs/commit/6ca4f804f24878f728b178a42d2103236f323b6d) sdrangel: 7.21.2 -> 7.21.3
* [`653d1145`](https://github.com/NixOS/nixpkgs/commit/653d1145638f506c668c83b410f3cac1050b10b1) velero: 1.13.2 -> 1.14.0
* [`a65d13a6`](https://github.com/NixOS/nixpkgs/commit/a65d13a67e4f564b816c0bf766974e925c91517b) flutter.engine: use builtins for store & add out name attrib
* [`504d414d`](https://github.com/NixOS/nixpkgs/commit/504d414dbddfe7e61d7ae7a0d2fc70a0c0a99408) flutter.engine: remove unnecessary files
* [`12e6408a`](https://github.com/NixOS/nixpkgs/commit/12e6408a6131b2446c9dd79c26f688df8fc37b09) flutter: disable linux artifacts if engine is used
* [`9f0188e6`](https://github.com/NixOS/nixpkgs/commit/9f0188e6cd903412f8b182cf993d0e571603e1ff) flutter.engine: less verbose building
* [`f14d70d5`](https://github.com/NixOS/nixpkgs/commit/f14d70d5dc476c867c0319eca7c09bb1ac44a87d) flutter.engine.src: actually fix making logs silent
* [`f20386e2`](https://github.com/NixOS/nixpkgs/commit/f20386e27d98901dbc40c2a8582c802d48593d81) flutter.engine: enable tests
* [`df1bef18`](https://github.com/NixOS/nixpkgs/commit/df1bef18e09b2984a8acecc904087ba044e62154) flutter: use engine dart when available
* [`32a6b1ef`](https://github.com/NixOS/nixpkgs/commit/32a6b1ef7a6856e087a2f9ebeeb3ec58d02143cd) klee: make llvmPackages and uclibc overridable
* [`0513d66f`](https://github.com/NixOS/nixpkgs/commit/0513d66f10602321e83deb6bac570daa7bd69efb) klee: add nix-update-script
* [`bc9fffbb`](https://github.com/NixOS/nixpkgs/commit/bc9fffbb3b62a9894c3bcd49356f09cb02adafd6) klee: add mainProgram
* [`2d919453`](https://github.com/NixOS/nixpkgs/commit/2d91945388d57a9b61724a725b651764ed1fbfd5) elastic: 0.1.4 -> 0.1.5
* [`763062c7`](https://github.com/NixOS/nixpkgs/commit/763062c7265f585d136f81fb16fc46c6123fc7e2) python311Packages.pygame-gui: 0611 -> 0612
* [`73fc8f90`](https://github.com/NixOS/nixpkgs/commit/73fc8f901acfd983ecfe08b2fb9cef7f32bb0025) kdePackages.qtpbfimageplugin: 3.0 -> 3.1
* [`22a59a7b`](https://github.com/NixOS/nixpkgs/commit/22a59a7bb2b57c3fcd9f5d0d8ff94f22cdab49de) rgp: 2.0 -> 2.1
* [`b47b66f1`](https://github.com/NixOS/nixpkgs/commit/b47b66f19b0282de36484f23f0d636046b4a7fbc) subxt: 0.36.0 -> 0.37.0
* [`c8b62501`](https://github.com/NixOS/nixpkgs/commit/c8b62501242cc436f2f52907ef212cabcad28f49) hishtory: 0.295 -> 0.297
* [`617fd13c`](https://github.com/NixOS/nixpkgs/commit/617fd13c71cb457d6b78308afb1d1fedb4532a75) mods: 1.4.0 -> 1.4.1
* [`70ff2154`](https://github.com/NixOS/nixpkgs/commit/70ff2154497cc235594f01d2531a3647311a6e43) nixos/nvidia: move the TOPOLOGY_FILE_PATH and DATABASE_PATH keys from hardware.nvidia.datacenter.settings default into the service file
* [`e47c01ad`](https://github.com/NixOS/nixpkgs/commit/e47c01adf946b0d24ba0a7056b11967164a36aec) clash-verge-rev: 1.6.5 -> 1.6.6
* [`c7c8222e`](https://github.com/NixOS/nixpkgs/commit/c7c8222e5692ae956ff7c51d8c43ab3b01011cc5) libphonenumber: 8.13.37 -> 8.13.39
* [`5086a5b7`](https://github.com/NixOS/nixpkgs/commit/5086a5b7220e8cb0988c111bc6bf264e972fbaa2) nextcloudPackages.integration_paperless: init
* [`a92626df`](https://github.com/NixOS/nixpkgs/commit/a92626dfa5d8c1bdc21c87b0d5c1c1bcdd0e82f5) python311Packages.openai-triton: move postPatch up to src
* [`530d5769`](https://github.com/NixOS/nixpkgs/commit/530d5769d57e88bde975c5fefb9ecfcddba89742) python311Packages.torch: prevent libcuda_dirs() from running ldconfig
* [`45ed866c`](https://github.com/NixOS/nixpkgs/commit/45ed866c55c1bdaa7ffb2c77acf491faafd2d46d) mendeley: 2.115.0 -> 2.117.0
* [`46d01595`](https://github.com/NixOS/nixpkgs/commit/46d015953ad14ec3ddfadf89d2f9edaeae34062e) schemes: 0.2.0 -> 46.0
* [`74eeece8`](https://github.com/NixOS/nixpkgs/commit/74eeece8d159d2464d49ca9aec1b0a05d92c52cf) qsynth: 0.9.91 -> 1.0.0
* [`0fa6da5c`](https://github.com/NixOS/nixpkgs/commit/0fa6da5c6fa046aa392ef53ea988f7d45a0a0e6c) datovka: 4.23.8 -> 4.24.0
* [`d1197b44`](https://github.com/NixOS/nixpkgs/commit/d1197b4419706c5e715973e1897c736641802b8c) python3Packages.eigenpy: build with buildPythonPackage
* [`f73d4566`](https://github.com/NixOS/nixpkgs/commit/f73d4566473471f883e7f5e68a18c7b1e25ba1cd) python3Packages.eigenpy: 3.6.0 -> 3.7.0
* [`84df7726`](https://github.com/NixOS/nixpkgs/commit/84df77263db2e7c1193d5b4257a0c97694ad527c) virtualboxKvm: 20240515 -> 20240617
* [`9cec4b55`](https://github.com/NixOS/nixpkgs/commit/9cec4b55f69077d9e6d3d938fec055be54745020) nixos/virtualbox-host: remove obsolete warnings
* [`a037d637`](https://github.com/NixOS/nixpkgs/commit/a037d6378fe99349605a37f8747b89f37b1f3162) flutter.engine: bring source size down to hydra limits
* [`f935b3d0`](https://github.com/NixOS/nixpkgs/commit/f935b3d0d0102afd9c428ddc0b23de22f45b104e) vesktop: Add option for middle click scroll
* [`ac9010b1`](https://github.com/NixOS/nixpkgs/commit/ac9010b15efa606ef484d2e961385dc89dd75b29) polypane: 19.0.2 -> 20.0.0
* [`f23003d8`](https://github.com/NixOS/nixpkgs/commit/f23003d839add72cfef677889ee4ca7e101dbfe9) metabase: 0.49.12 -> 0.50.5
* [`87f51495`](https://github.com/NixOS/nixpkgs/commit/87f51495e56bbdcc9d74763ac47095b74da337dc) cloudflared: 2024.4.1 -> 2024.6.1
* [`60e3aeef`](https://github.com/NixOS/nixpkgs/commit/60e3aeefceff2354eb636a170d51f8be9939c7bd) sexpp: 0.8.7 -> 0.8.8
* [`6c67124c`](https://github.com/NixOS/nixpkgs/commit/6c67124c2b8344d76ef57cf5ded5957019f7f990) flink: 1.19.0 -> 1.19.1
* [`433ca103`](https://github.com/NixOS/nixpkgs/commit/433ca1031c0949bd7ce758ad802e20b1934497e6) opentelemetry-collector-contrib: 0.102.0 -> 0.103.0
* [`352bd9f7`](https://github.com/NixOS/nixpkgs/commit/352bd9f79124d89aa24a7e067c1945a493e9e537) python3Packages.pyogrio: 0.8.0 → 0.9.0
* [`cd0da047`](https://github.com/NixOS/nixpkgs/commit/cd0da047e1ab44d778d377884a9e7e22625dcd7c) emblem: 1.3.0 -> 1.4.0
* [`cdff8ddb`](https://github.com/NixOS/nixpkgs/commit/cdff8ddb0bef64e318f41c4da3e1d22b9948826b) emblem: add aleksana as maintainer
* [`434da283`](https://github.com/NixOS/nixpkgs/commit/434da283a5c614f2f19b1990662ab36096ca14f9) spaceship-prompt: 4.15.3 -> 4.16.0
* [`3e78dcea`](https://github.com/NixOS/nixpkgs/commit/3e78dcea49a1ec6774cc16005ab30f1c5ba62190) emote: move to pkgs/by-name
* [`1b5d2b08`](https://github.com/NixOS/nixpkgs/commit/1b5d2b080174b3a92e8f894a62c6cde5463afe6a) emote: format with nixfmt-rfc-style
* [`5652a964`](https://github.com/NixOS/nixpkgs/commit/5652a964df0bd3199f0e55ef0eda9d153da5c49b) quarkus: 3.11.1 -> 3.11.2
* [`e795e679`](https://github.com/NixOS/nixpkgs/commit/e795e679be79a6e7efeffa6aa07254b01709641f) pdftitle: init at 0.11
* [`8a7c77e2`](https://github.com/NixOS/nixpkgs/commit/8a7c77e2a76c4f6e733d4694bd8d787782c2d8d3) metals: 1.3.1 -> 1.3.2
* [`0a2c7020`](https://github.com/NixOS/nixpkgs/commit/0a2c702068b4ce93d58665c54605967462d40d43) oo7: 0.3.2 -> 0.3.3
* [`f8224aa8`](https://github.com/NixOS/nixpkgs/commit/f8224aa8c709890a2c488fbdd8a41e20642c9959) oo7: format with nixfmt
* [`9111403d`](https://github.com/NixOS/nixpkgs/commit/9111403d164db9db1f6e30cea033d0bc12066c87) oo7: temporarily remove updateScript
* [`539fd357`](https://github.com/NixOS/nixpkgs/commit/539fd3578f2a2f0d8951d164d6f651bcd189a203) oo7: add meta.changelog
* [`b222997d`](https://github.com/NixOS/nixpkgs/commit/b222997dd1d05fdf534f17e301eed73b4c2a1c16) openlibm: 0.8.2 -> 0.8.3
* [`a2b84543`](https://github.com/NixOS/nixpkgs/commit/a2b84543425b72147fa5ffc016b8a3867147da47) nco: 5.2.4 -> 5.2.5
* [`091d3ceb`](https://github.com/NixOS/nixpkgs/commit/091d3ceb7d0b3d4106f3df393ffcab7b1257f1fa) maintainers: add floriansanderscc
* [`d319f7c3`](https://github.com/NixOS/nixpkgs/commit/d319f7c3d00785453a7f6cfa037a24cdc4df78c7) maintainers/team-list: add clevercloud
* [`4bca415f`](https://github.com/NixOS/nixpkgs/commit/4bca415f562418660a9ea27f74538708c8091b6e) juicefs: 1.1.2 -> 1.2.0
* [`afb4861c`](https://github.com/NixOS/nixpkgs/commit/afb4861c7290ef444881d179cc206bc6042f7f98) ckbcomp: 1.227 -> 1.228
* [`82f78e75`](https://github.com/NixOS/nixpkgs/commit/82f78e7510dc96646fdaad368755df10be22ed75) lilypond-unstable: 2.25.16 -> 2.25.17
* [`a4897fda`](https://github.com/NixOS/nixpkgs/commit/a4897fdabe56574bc17d9dfc95d490a9704b0ad1) python311Packages.slackclient: 3.28.0 -> 3.29.0
* [`71f06deb`](https://github.com/NixOS/nixpkgs/commit/71f06deb49afb59d50e7abb7f276a0981eae7a90) esphome: 2024.5.4 -> 2024.6.1
* [`0e832817`](https://github.com/NixOS/nixpkgs/commit/0e832817a02a7c0d9ba7bbb6ec576853bb828bcd) emote: 4.0.1 -> 4.1.0
* [`aed83405`](https://github.com/NixOS/nixpkgs/commit/aed8340530b2fd5749275a88d6f6d8bd2e79e1c3) emote: add aleksana as maintainer
* [`af7995aa`](https://github.com/NixOS/nixpkgs/commit/af7995aa159dead11d8bd826035a028fa96ca876) cargo-zigbuild: 0.18.4 -> 0.19.0
* [`c75640cd`](https://github.com/NixOS/nixpkgs/commit/c75640cd5eb4629a4402882d15b6a2cd7514491f) cargo-swift: 0.6.1 -> 0.7.1
* [`d44ea8e2`](https://github.com/NixOS/nixpkgs/commit/d44ea8e29bed9762424baa6c21d404cb65f01a8f) python311Packages.{pyside,shiboken}6: 6.7.0 -> 6.7.2
* [`1d4535ec`](https://github.com/NixOS/nixpkgs/commit/1d4535ec011c7f96fb24cc60880a10652825da9a) routinator: 0.13.2 -> 0.14.0
* [`7850fd2a`](https://github.com/NixOS/nixpkgs/commit/7850fd2a0c4188f13b5e5feca49a6d4f0fe3bca6) routinator: convert to by-name
* [`2a502154`](https://github.com/NixOS/nixpkgs/commit/2a50215418eb0564fd62edb02f3852f182e92388) spotify: 1.2.31.1205.g4d59ad7c -> 1.2.37.701.ge66eb7bc
* [`89490ebd`](https://github.com/NixOS/nixpkgs/commit/89490ebd2ed4a9ec9e8e16845e162dfd3ac40ee3) arduino-cli: 0.35.3 -> 1.0.0
* [`86101aa2`](https://github.com/NixOS/nixpkgs/commit/86101aa2c7fc6637ff739118f6bd808ac1b09ff2) arduino-cli: 1.0.0 -> 1.0.1
* [`daa6db2b`](https://github.com/NixOS/nixpkgs/commit/daa6db2b3905c9d8ec17187eb6e0f9b4b25b47ad) kshutdown: 5.91-beta -> 5.92-beta
* [`ffdfbeb5`](https://github.com/NixOS/nixpkgs/commit/ffdfbeb5eee0b062f97e7435f7fc032f01b428ac) python311Packages.distributed: 2024.6.0 -> 2024.6.2
* [`3bb7edec`](https://github.com/NixOS/nixpkgs/commit/3bb7edec427852e98e5c061cec2a13ea519d40d0) python311Packages.dask: 2024.6.0 -> 2024.6.2
* [`2f3ea2a0`](https://github.com/NixOS/nixpkgs/commit/2f3ea2a07f3b0cd533ba33ccd3fe0bedbadc6b35) python311Packages.dask-expr: 1.1.3 -> 1.1.4
* [`8696c624`](https://github.com/NixOS/nixpkgs/commit/8696c6243a2274a67b8d9db8b7bcf134d035c523) streamlink: 6.7.4 -> 6.8.1
* [`7485d712`](https://github.com/NixOS/nixpkgs/commit/7485d712188e2d4d6b6a2411e15b6d24afc8a835) papermc: add udev to LD_LIBRARY_PATH
* [`87bbd5fb`](https://github.com/NixOS/nixpkgs/commit/87bbd5fbb213d2daf1b0e512602c55f6a0883f78) tautulli: 2.14.2 -> 2.14.3
* [`e546e8ff`](https://github.com/NixOS/nixpkgs/commit/e546e8ff516328a6500b68a7ebb72882f8ff4df7) libndp: apply patch for CVE-2024-5564
* [`4155ea3e`](https://github.com/NixOS/nixpkgs/commit/4155ea3e4fd77c1a55d1ef86387026b5f1273b81) python3Packages.osmnx: 1.9.1 → 1.9.3
* [`d993580d`](https://github.com/NixOS/nixpkgs/commit/d993580d1c3ca0dff7633a2384535b3b9b71794b) ex_doc: 0.32.1 -> 0.34.1
* [`9b3a2648`](https://github.com/NixOS/nixpkgs/commit/9b3a264822c9a68c9bf73e53db669310c6911e3d) fluidd: 1.30.0 -> 1.30.1
* [`c2e1caac`](https://github.com/NixOS/nixpkgs/commit/c2e1caaceccf12dc1305d9844ff8f68dc9d1a3cd) rimgo: 1.2.3 -> 1.2.5
* [`f46f201e`](https://github.com/NixOS/nixpkgs/commit/f46f201e8b76d9478baff55d9ab74356afa838ef) inform6: 6.42-r1 -> 6.42-r2
* [`bc14efcd`](https://github.com/NixOS/nixpkgs/commit/bc14efcda5a6981debc2c85aede4386dfeb2c215) s3backer: 2.1.2 -> 2.1.3
* [`ad3648c7`](https://github.com/NixOS/nixpkgs/commit/ad3648c733b5a2d6171043b73c39a6efd52dd40c) qcad: 3.30.0.0 -> 3.30.1.1
* [`a666395a`](https://github.com/NixOS/nixpkgs/commit/a666395a228308ba98a42b3f31244c3fbad98d38) octoprint: 1.10.1 -> 1.10.2
* [`96d8a58f`](https://github.com/NixOS/nixpkgs/commit/96d8a58f7b4b34db0a4625f6408aa3aa52fd7356) reveal-md: 5.5.2 -> 6.1.2
* [`4d4c3abe`](https://github.com/NixOS/nixpkgs/commit/4d4c3abe34a089e2fe5ab35a7fed432abe6eb3c6) syshud: init at 0-unstable-2024-06-20
* [`e3945f25`](https://github.com/NixOS/nixpkgs/commit/e3945f2507862d0b1d3346e5a0ad177c2e3c223c) gnomeExtensions.systemd-manager: package manually
* [`4c0a299d`](https://github.com/NixOS/nixpkgs/commit/4c0a299d2c685d9180c2928dff0bb6cb53df60fc) gnomeExtensions.systemd-manager: allow install polkit files
* [`679224d7`](https://github.com/NixOS/nixpkgs/commit/679224d7c76a17da4ac5e5d6170f8e3023217fea) gnomeExtensions.systemd-manager: nixfmt & add doronbehar as maintainer
* [`57609481`](https://github.com/NixOS/nixpkgs/commit/57609481a8e3c1518ad014a3240311d685324970) maintainers: add emneo
* [`4c5935d6`](https://github.com/NixOS/nixpkgs/commit/4c5935d62c276d6784121b1221b32e4914aa9e74) microsoft-edge: 125.0.2535.92 -> 126.0.2592.68
* [`99a01ed5`](https://github.com/NixOS/nixpkgs/commit/99a01ed596ecfe3f401caed643cc239996a874da) licensure: enable darwin builds
* [`f8bb2bbe`](https://github.com/NixOS/nixpkgs/commit/f8bb2bbe2d0d38c99324759a8fa0c86e9a751ac0) kubectl-validate: 0.0.3 -> 0.0.4
* [`245a3c31`](https://github.com/NixOS/nixpkgs/commit/245a3c31474b350accf05be96c24563c02385f15) zerotierone: fix darwin build
* [`c6e86bb1`](https://github.com/NixOS/nixpkgs/commit/c6e86bb19203fd7217186a74834a3bd040db6fd6) yad: 13.0 -> 14.0
* [`47eb5bf3`](https://github.com/NixOS/nixpkgs/commit/47eb5bf3f6df74fe7faa68f81a5f04ec0a23830f) awscli2: 2.16.4 -> 2.17.0
* [`79d24eb4`](https://github.com/NixOS/nixpkgs/commit/79d24eb4873ecc0980096962a84946e62871a93e) wails: 2.8.2 -> 2.9.1
* [`75be03a8`](https://github.com/NixOS/nixpkgs/commit/75be03a801794de4c2b8ade418b94df4e17cf121) awscli2: remove `with py.pkgs`
* [`a88480fa`](https://github.com/NixOS/nixpkgs/commit/a88480fa1de11b069669761c70a88f70a3122c47) qgis-ltr: 3.34.7 -> 3.34.8
* [`8762c035`](https://github.com/NixOS/nixpkgs/commit/8762c035f5e5fdf6fb56c66c65952b8cc0ccd4d7) beekeeper-studio: 4.4.0 -> 4.6.0
* [`03698a66`](https://github.com/NixOS/nixpkgs/commit/03698a665b43a7c446ef8f83e6c82e3dbc16ac46) beekeeper-studio: use --replace-fail
* [`5c5678d9`](https://github.com/NixOS/nixpkgs/commit/5c5678d9f70969dc857c78ca6f224948ec9d5639) hashrat: 1.15 -> 1.21
* [`9d41fe6f`](https://github.com/NixOS/nixpkgs/commit/9d41fe6fcc4df838a56b1cfb2512b65e5e655958) nixos/gdm: add fingerprint pam rules
* [`45d41e77`](https://github.com/NixOS/nixpkgs/commit/45d41e77b329a307175b94ad46500638dd17e7eb) mujs: 1.3.4 -> 1.3.5
* [`bc3c7853`](https://github.com/NixOS/nixpkgs/commit/bc3c7853628fbf95365d6d69454e1ac9d49d1757) obs-vkcapture: install 32bit wrappers
* [`1e27366d`](https://github.com/NixOS/nixpkgs/commit/1e27366d68d6666491b9332fa10eb6687dc0702e) aerospike: 7.1.0.0 -> 7.1.0.2
* [`e5e5da76`](https://github.com/NixOS/nixpkgs/commit/e5e5da76dc5d3c6a5b3d7ecff086219597024a01) tpnote: 1.24.2 -> 1.24.4
* [`40aff072`](https://github.com/NixOS/nixpkgs/commit/40aff0721595f997138df554ff4609c905eb6512) zed: 1.15.0 -> 1.16.0
* [`6dcbda2a`](https://github.com/NixOS/nixpkgs/commit/6dcbda2a20ff8062115ebc636daa230fd244b7b0) cdecl: 17.0 -> 17.0.1
* [`3eb83599`](https://github.com/NixOS/nixpkgs/commit/3eb83599aef7e39b4e60f3f1bf2f5b30f133762b) wootility: add sodiboo as maintainer
* [`0f9c4bfe`](https://github.com/NixOS/nixpkgs/commit/0f9c4bfe940ab7a03f7076a7f8b623f37f50ae51) wootility: add NIXOS_OZONE_WL, wootility-lekker.desktop, icons
* [`ea0c623d`](https://github.com/NixOS/nixpkgs/commit/ea0c623db58dbb02c82f676e5eb514d06da0845f) maintainers: add theobori
* [`d949aea6`](https://github.com/NixOS/nixpkgs/commit/d949aea659e4e753c50cf02be13b301bc0a38fd8) ibus-engines.bamboo: 0.8.4-rc3 -> 0.8.4-rc6
* [`495d0374`](https://github.com/NixOS/nixpkgs/commit/495d0374ef5f8c13425d2d0ac3df6378da5483de) ghidra: reformat to rfc style
* [`adaf51e7`](https://github.com/NixOS/nixpkgs/commit/adaf51e750c202827c627ce7117ce8a657371757) ghidra: 11.0.3 -> 11.1.1
* [`ff0671b1`](https://github.com/NixOS/nixpkgs/commit/ff0671b1c457ce16255d6322f476dbe00a07c815) radicle-httpd: init at 0.11.0
* [`27749da4`](https://github.com/NixOS/nixpkgs/commit/27749da4f773605758eedd11c0bcb471fa601470) quickemu: 4.9.4 -> 4.9.4-unstable-2024-05-28
* [`863df88d`](https://github.com/NixOS/nixpkgs/commit/863df88d1cd676e930eaf06a40c179d861568d8d) beekeeper-studio: avoid with lib; add sourceProvenance
* [`414c6a43`](https://github.com/NixOS/nixpkgs/commit/414c6a432d7bf76ed5c58185e5c816be4976acc2) appflowy: 0.5.7 -> 0.6.1
* [`0cc66c26`](https://github.com/NixOS/nixpkgs/commit/0cc66c26bc8d330f45e7cf11396c46705ca2d527) gh-gei: init at 1.7.1
* [`ff36e3da`](https://github.com/NixOS/nixpkgs/commit/ff36e3da5d930738a254fe074e718123db13a52d) pinniped: 0.30.0 -> 0.32.0
* [`89520db5`](https://github.com/NixOS/nixpkgs/commit/89520db5e44844d83d4a87227aa4a7e26a502ecf) iosevka-bin: 30.1.1 -> 30.2.0
* [`1b78c75b`](https://github.com/NixOS/nixpkgs/commit/1b78c75b0cdaca2a708bef6af74306649361e4f9) ear2ctl: init at 0.1.0
* [`1c79272d`](https://github.com/NixOS/nixpkgs/commit/1c79272d8728b9ee3506b435713201339e84593d) npm-lockfile-fix: add felschr as maintainer
* [`2e132e1c`](https://github.com/NixOS/nixpkgs/commit/2e132e1cadbe174c221feb6bf2610d8b4860c8cd) npm-lockfile-fix: add meta.homepage
* [`0e8924bd`](https://github.com/NixOS/nixpkgs/commit/0e8924bdd4c55c9ff83c3bf6ffb62efd3b6aefa4) protoc-gen-{tonic,prost{,-serde,-crate}}: migrate to pkgs/by-name
* [`518778a5`](https://github.com/NixOS/nixpkgs/commit/518778a5e3a08f0ef614f546b41a392e1da6a926) protoc-gen-{tonic,prost{,-serde,-crate}}: reformat
* [`efee88f3`](https://github.com/NixOS/nixpkgs/commit/efee88f382bf0543af5ae4d6a0ac1fb2a6a9fc7f) protoc-gen-{tonic,prost{,-serde,-crate}}: add update scripts
* [`793a7263`](https://github.com/NixOS/nixpkgs/commit/793a7263474eb7112dc4fc2be6bb1a449111cf14) knossosnet: 1.1.0 -> 1.2.0
* [`8a9fe0aa`](https://github.com/NixOS/nixpkgs/commit/8a9fe0aa41638a4e71f89e67883b2726127e16ed) jetbrains.plugins: add asciidoc
* [`beb118d5`](https://github.com/NixOS/nixpkgs/commit/beb118d588268900935680246fb7010860dd3f36) jetbrains.plugins: add string-manipulation
* [`4e01e033`](https://github.com/NixOS/nixpkgs/commit/4e01e03387338514af60a4b5050b960f1ff4c883) jetbrains.plugins: add acejump
* [`60168fcf`](https://github.com/NixOS/nixpkgs/commit/60168fcfd63478ea63f5766535d3386b5d220bae) jetbrains.plugins: add mermaid
* [`92f2ec7e`](https://github.com/NixOS/nixpkgs/commit/92f2ec7ec8ae2ca6bcf135d1641dd8bee070b3cf) jetbrains.plugins: add aws-toolkit
* [`54dfcae9`](https://github.com/NixOS/nixpkgs/commit/54dfcae99bb8e57ae46c43e81607315e8228bd04) python3Packages.amaranth-boards: fix fetchFromGitHub hash stability
* [`1ecbd690`](https://github.com/NixOS/nixpkgs/commit/1ecbd6907151aa5a09ca8897a303793b1e94e069) python312Packages.flexcache: init at 0.3
* [`0b8fdadf`](https://github.com/NixOS/nixpkgs/commit/0b8fdadfa273eb849172895d6c20f2b3caadf795) python312Packages.flexparser: init at 0.3.1
* [`12844b00`](https://github.com/NixOS/nixpkgs/commit/12844b0068dd2bd76f887214af0c546dc581c47e) python312Packages.uncertainties: 3.1.7 -> 3.2.1
* [`3c695504`](https://github.com/NixOS/nixpkgs/commit/3c69550446db39f18559ef46cb78f671ab41a866) python311Packages.pint: 0.23 -> 0.24
* [`45e59249`](https://github.com/NixOS/nixpkgs/commit/45e59249d67b92873cadac0744403eac3c66a6ea) python311Packages.pint: fix pint-convert executable
* [`33c2d303`](https://github.com/NixOS/nixpkgs/commit/33c2d3038ef079def23d97d73c56d23c0003c034) cobang: 0.12.0 -> 0.14.1
* [`0c1205d4`](https://github.com/NixOS/nixpkgs/commit/0c1205d42b6bce2c993279796b6dacc22ac6f9d7) aws-sso-cli: 1.15.1 -> 1.16.1
* [`7521b25e`](https://github.com/NixOS/nixpkgs/commit/7521b25ed3ee948579d20ad4660af3fbc94cc57d) shadowsocks-rust: 1.19.2 -> 1.20.1
* [`a187a715`](https://github.com/NixOS/nixpkgs/commit/a187a715110f9b95266199b10cb8175d32e72688) thunderbird-unwrapped: 115.12.0 -> 115.12.2
* [`519b678e`](https://github.com/NixOS/nixpkgs/commit/519b678e122f475769728e1506cb641d624408bf) codeium: 1.8.61 -> 1.8.69
* [`afa35b5e`](https://github.com/NixOS/nixpkgs/commit/afa35b5e7a63b1c82a79591b06a7829308e7be9e) wlx-overlay-s: 0.4.1 -> 0.4.2
* [`7663ec03`](https://github.com/NixOS/nixpkgs/commit/7663ec0316c813cf79ca5a69fc695e7a39f6c30e) wootility: set license to unfree
* [`c7165be9`](https://github.com/NixOS/nixpkgs/commit/c7165be950e4f6192518855e78254c32b8def669) containerlab: 0.55.0 -> 0.55.1
* [`e589523b`](https://github.com/NixOS/nixpkgs/commit/e589523b7ffd09127be7bd3cd72a2d34b5cec749) python311Packages.python-socketio: 5.11.2 -> 5.11.3
* [`dce34fd3`](https://github.com/NixOS/nixpkgs/commit/dce34fd38b6cd06d2938807c74e731b81f677da6) prismlauncher: migrate to by-name
* [`b40318aa`](https://github.com/NixOS/nixpkgs/commit/b40318aaf71299220228c71a3b14fd1d2880eb37) prismlauncher: format with nixfmt
* [`88039bb8`](https://github.com/NixOS/nixpkgs/commit/88039bb875585904972c9598a681e63ed2a18263) prismlauncher: 8.3 -> 8.4
* [`40581e9e`](https://github.com/NixOS/nixpkgs/commit/40581e9eed5ec929a67e0c4109a8e83dbeb12f63) prismlauncher: refactor
* [`ea1cf5da`](https://github.com/NixOS/nixpkgs/commit/ea1cf5da523b1febfa5078a2c5db09fd056ffe92) prismlauncher: add updateScript
* [`7ee76c32`](https://github.com/NixOS/nixpkgs/commit/7ee76c32d88c516d237227b09f2904b6b5aabcfc) python311Packages.anywidget: 0.9.12 -> 0.9.13
* [`6592f312`](https://github.com/NixOS/nixpkgs/commit/6592f3126d8f61d0ad2c5f45b7933a50605f8d22) hyperlink: 0.1.31 -> 0.1.32
* [`0506fb14`](https://github.com/NixOS/nixpkgs/commit/0506fb140b8ba2d330d1c026f53e647426efb4c5) tuba: 0.7.2 -> 0.8.1
* [`4174a85e`](https://github.com/NixOS/nixpkgs/commit/4174a85e052fc1c8e398ce73f1455b678555c4e9) anytype: 0.40.9 -> 0.41.1
* [`d9ff2d16`](https://github.com/NixOS/nixpkgs/commit/d9ff2d16ac8821d5b80bbf596a002c6a527122d0) timeular: 6.7.9 -> 6.8.1
* [`923a8660`](https://github.com/NixOS/nixpkgs/commit/923a86602e7f70b818cd96b357c3b234f576bb1f) nixos/oink: wait for network.target
* [`1b3df1d5`](https://github.com/NixOS/nixpkgs/commit/1b3df1d5b47af5b2470d46667301f2421c656d94) whistle: 2.9.73 -> 2.9.76
* [`2725312e`](https://github.com/NixOS/nixpkgs/commit/2725312e0301b6b999eac517fb023b13238eb155) panvimdoc: init at 4.0.1
* [`82aa005d`](https://github.com/NixOS/nixpkgs/commit/82aa005d8e97b2137a47386dfc59fa545c4dc78e) texlive.withPackages: process new packages before existing ones
* [`7f1a82fd`](https://github.com/NixOS/nixpkgs/commit/7f1a82fdee08ef865781828d9353571b368a2bb0) texlive.withPackages: resolve dependencies by pname only
* [`b12809df`](https://github.com/NixOS/nixpkgs/commit/b12809df40c7bbb464a7bc0f61379ae8609f4e92) openai-whisper-cpp: 1.5.4 -> 1.6.2
* [`3bb58a1e`](https://github.com/NixOS/nixpkgs/commit/3bb58a1ea6cc064e9620da58815185e03de2d483) protoc-gen-es: init at 1.10.0
* [`974b5eb2`](https://github.com/NixOS/nixpkgs/commit/974b5eb2d5ef3d564b5b358a3743eac415ed6af5) protoc-gen-connect-es: init at 1.4.0
* [`fa346c84`](https://github.com/NixOS/nixpkgs/commit/fa346c841d677200c72f329e434f2e1a5b02368e) technitium-dns-server: 12.1 -> 12.2.1
* [`9593fc49`](https://github.com/NixOS/nixpkgs/commit/9593fc49a20bc6a0d109302a1754d0926dcb6310) codespell: 2.2.6 -> 2.3.0
* [`442cd7de`](https://github.com/NixOS/nixpkgs/commit/442cd7dee5ddba627eb9aeecade5e78ab0febd85) chezmoi: 2.49.0 -> 2.49.1
* [`7abf7509`](https://github.com/NixOS/nixpkgs/commit/7abf750927b688cb834a53eb52ffe72a1cf71c0f) pocketbase: 0.22.13 -> 0.22.14
* [`d8e75b56`](https://github.com/NixOS/nixpkgs/commit/d8e75b566283bcc8167084b50b696c12cf72f16c) wiremock: 3.6.0 -> 3.7.0
* [`491ab390`](https://github.com/NixOS/nixpkgs/commit/491ab390ad819f031fbd63f363a19e447d6b4312) lscolors: 0.17.0 -> 0.18.0
* [`1c25bad6`](https://github.com/NixOS/nixpkgs/commit/1c25bad679a0e2d6d75991f25b1c1413369f21ec) kodiPackages.future: 0.18.3+matrix.1 -> 1.0.0+matrix.1
* [`20a73ab5`](https://github.com/NixOS/nixpkgs/commit/20a73ab51d8652b7c5c2ea3683baf981d94e501d) nixos/smartd: add systembus-notify notifications
* [`10962c7c`](https://github.com/NixOS/nixpkgs/commit/10962c7ca2f5003de1109330316337d22b782f15) nixos/zerotierone: fix default value for localConf
* [`04efc006`](https://github.com/NixOS/nixpkgs/commit/04efc006a4ebb9641952976667edbe43dc3e6bbf) etc.overlay: fix cross-build
* [`d42810fb`](https://github.com/NixOS/nixpkgs/commit/d42810fb29ed0ff3d54c6357bb69fe6cd613ffe4) super-productivity: 8.0.7 -> 8.0.10
* [`85c18bcd`](https://github.com/NixOS/nixpkgs/commit/85c18bcd36a2b9a214af244f0e5def5b5184f76c) idris2Packages.buildIdris: More lenient and ergonomic dependency inputs
* [`84cde749`](https://github.com/NixOS/nixpkgs/commit/84cde749e6d23d281812701d9fcd280148466e31) idris2Packages.idris2Lsp: apply ergonomics improvements facilitated by latest buildIdris changes
* [`2550a743`](https://github.com/NixOS/nixpkgs/commit/2550a743850900402f936990199bb47c43ec58e9) deepin-anything: init at 6.1.9
* [`f670b474`](https://github.com/NixOS/nixpkgs/commit/f670b4741560caaaf821f32cd4dc4a543855fe79) deepin-anything-module: init
* [`6ce48438`](https://github.com/NixOS/nixpkgs/commit/6ce484389329ebfdd19ddc9024b3281b5e7062bf) nixos/modules: init deepin-anything
* [`8e793b45`](https://github.com/NixOS/nixpkgs/commit/8e793b457aa62035b71209ccc839dd8f3653c860) deepin.nix: update
* [`08c2d186`](https://github.com/NixOS/nixpkgs/commit/08c2d1865d07ec19817f7c6fe24729a60b991eb8) typora: 1.8.10 -> 1.9.3
* [`169fbf64`](https://github.com/NixOS/nixpkgs/commit/169fbf6464dbb6c98aabf70e7417dac8d610c4bb) git-cola: 4.7.1 -> 4.8.0
* [`431c2c30`](https://github.com/NixOS/nixpkgs/commit/431c2c3086d2dcec80f492fbbf31bc95d6022a12) spotube: 3.6.0 -> 3.7.1
* [`dbc9dcd3`](https://github.com/NixOS/nixpkgs/commit/dbc9dcd31183e3c42d21c024f437c41bce0d2c9a) loopwm: init at 1.0.0
* [`77a37cde`](https://github.com/NixOS/nixpkgs/commit/77a37cde203873ac8be0ee8cfdb6770e5dfd3ecf) doc: adopt new buildIdris changes in docs
* [`6c081949`](https://github.com/NixOS/nixpkgs/commit/6c0819491ac27bee7c6654a57c879cc4373f3045) gtest: Allow specifying a newer C++ standard
* [`948aaf3b`](https://github.com/NixOS/nixpkgs/commit/948aaf3bce26934892bb07275aac08b1dcecf23b) gerbolyze: unbreak by downgrading resvg
* [`d035998c`](https://github.com/NixOS/nixpkgs/commit/d035998c9375d22b3410fb827cb085caaed87f67) purescript: rework src selection
* [`09fcff38`](https://github.com/NixOS/nixpkgs/commit/09fcff386c62fdc2ca0797233a250c8c70ccfd32) purescript: add `aarch64-linux` support
* [`d681d912`](https://github.com/NixOS/nixpkgs/commit/d681d9126f2f59f45badb84bd4cf61e1e08df717) substudy: init at 0.6.10
* [`22b34878`](https://github.com/NixOS/nixpkgs/commit/22b3487860c61629ce06e1e9e869037e4544a79b) rclip: 1.10.0 -> 1.10.1
* [`29709f87`](https://github.com/NixOS/nixpkgs/commit/29709f87d73517bdb3068c91cebf2ff363a43c7d) monado: Enable FEATURE_TRACING
* [`d68244cf`](https://github.com/NixOS/nixpkgs/commit/d68244cf1f038709fac2517c8bac803e3758c4ad) victoriametrics: add support to enable/disable subpackages
* [`728715db`](https://github.com/NixOS/nixpkgs/commit/728715dbc1f96fba8fa7c76af916aa554b3cf1a0) vmagent: build from victoriametrics package
* [`9e08d3e1`](https://github.com/NixOS/nixpkgs/commit/9e08d3e197f410f1d05ffa3ade33451f6b002fc4) victoriametrics: add shawn8901 as maintainer
* [`3b2969b1`](https://github.com/NixOS/nixpkgs/commit/3b2969b1a569e1f95ad0e51b8fdb05f76efdf1cc) prismlauncher: improve assertions
* [`94ad1c37`](https://github.com/NixOS/nixpkgs/commit/94ad1c37a84a2065fe30470125d577aa5e3b3994) prismlauncher: use `lib.cmakeFeature`
* [`7a9fdd23`](https://github.com/NixOS/nixpkgs/commit/7a9fdd2390c74984c8507b03ca29837cd5710c37) reindeer: 2024.06.10.00 -> 2024.06.17.00
* [`88d93487`](https://github.com/NixOS/nixpkgs/commit/88d934879a445cdf150baa5d48393d70939ffddf) nixos/services.kubernetes.kubelet: handle non-lower case characters in hostname
* [`426c92a4`](https://github.com/NixOS/nixpkgs/commit/426c92a494bdef08adb46606bccb6f257255725e) jetbrains.pycharm-community: adds glibcLocales to pycharm-community
* [`053ad7bc`](https://github.com/NixOS/nixpkgs/commit/053ad7bcd4bc8c0f9262e6d1775fa0e9add0422d) babashka-unwrapped: 1.3.190 -> 1.3.191
* [`55e4d5af`](https://github.com/NixOS/nixpkgs/commit/55e4d5af1bbe3f303bde5131d39abe0cf05194a3) python312Packages.drawsvg: 2.3.0 -> 2.4.0
* [`9b648599`](https://github.com/NixOS/nixpkgs/commit/9b648599eaff67fd4d7045e22fa85f7656777eff) mysql80: 8.0.36 -> 8.0.37
* [`0415c9c1`](https://github.com/NixOS/nixpkgs/commit/0415c9c1f48878426e078fd8a397c59c90b14ce0) epson-escpr2: 1.2.10 -> 1.2.11
* [`f1b2ef46`](https://github.com/NixOS/nixpkgs/commit/f1b2ef46843c2b08306cc9b728e0c4d35efec52d) lndhub-go: 1.0.0 -> 1.0.1
* [`2c40f69c`](https://github.com/NixOS/nixpkgs/commit/2c40f69cb3a4b6c7c57d5ec843f50ea42a8c1be7) tenv: 2.0.7 -> 2.1.8
* [`4154834b`](https://github.com/NixOS/nixpkgs/commit/4154834be5af054e54afdb225e10d4c7bc37a255) bitwig-studio5: 5.18 -> 5.19
* [`8f217146`](https://github.com/NixOS/nixpkgs/commit/8f2171468e3fb90fadaab710d6f8e3a830a92a16) python312Packages.yalexs: 6.4.0 -> 6.4.1
* [`afe26983`](https://github.com/NixOS/nixpkgs/commit/afe26983233919e67bae94070ef67b7e6c713cef) python312Packages.aioraven: 0.5.3 -> 0.6.0
* [`69c67cf4`](https://github.com/NixOS/nixpkgs/commit/69c67cf44e7d9cd183e382790d0a38f395915c5a) python312Packages.hatch-regex-commit: init at 0.0.3
* [`f0d126e4`](https://github.com/NixOS/nixpkgs/commit/f0d126e4753eae8a8a6e194f78c7f429200db21e) python312Packages.pyloadapi: init at 1.2.0
* [`7983160a`](https://github.com/NixOS/nixpkgs/commit/7983160ab17e15d3e440ecb6b0dae382a3a59df3) linkerd_edge: 24.6.2 -> 24.6.3
* [`38ca339c`](https://github.com/NixOS/nixpkgs/commit/38ca339cfb1ecc0b18fc4e4b2bc1a918cc8425ce) ldtk: install desktop icon in correct directory
* [`6f9daa9d`](https://github.com/NixOS/nixpkgs/commit/6f9daa9d3deda181698a869d58f7bfdca717ac83) perl538Packages.DevelCover: init at 1.44
* [`a5af8a01`](https://github.com/NixOS/nixpkgs/commit/a5af8a01299234b025a78f9a977bafdf5ec9543e) perl538Packages.MemoryUsage: init at 0.201
* [`6d551ad2`](https://github.com/NixOS/nixpkgs/commit/6d551ad2704bfac32723f0008e283790ed6c4128) perl538Packages.MemoryProcess: init at 0.06
* [`50033f01`](https://github.com/NixOS/nixpkgs/commit/50033f01897b9dc4f2830542f096cd625ac4d359) python311Packages.django-import-export: 4.0.8 -> 4.0.9
* [`f756ee76`](https://github.com/NixOS/nixpkgs/commit/f756ee76674e2afb569c5159fee784eb4d1fa7a7) lcov: 1.16 -> 2.1
* [`69074b67`](https://github.com/NixOS/nixpkgs/commit/69074b67a36d30a8eef6e76343246441c2c13730) e16: fix e_gen_menu script for NixOS
* [`87334687`](https://github.com/NixOS/nixpkgs/commit/873346871d412241219a62249feb881f8c1b297e) emblem: fix build on darwin
* [`d6ac9fd6`](https://github.com/NixOS/nixpkgs/commit/d6ac9fd6012a30de0f8a44e408dfbcbe3ea84b4f) python311Packages.fasttext-predict: unbreak on darwin
* [`4a2b827c`](https://github.com/NixOS/nixpkgs/commit/4a2b827c716ffcd67f6c12d14024ae63a5311c34) treewide: use cmakeCudaArchitecturesString
* [`9bb686f0`](https://github.com/NixOS/nixpkgs/commit/9bb686f064217ee326ada56ffe1f6c833c881f8d) dwarfs: 0.7.5 → 0.9.10.
* [`f3237242`](https://github.com/NixOS/nixpkgs/commit/f323724293885bb8c9da8500e72d714be61fc44d) qdrant: 1.9.4 -> 1.9.6
* [`c35d04dc`](https://github.com/NixOS/nixpkgs/commit/c35d04dccb6fb3c82c4b7b61eae45a3743efc2bd) crip: `--replace` -> `--replace-fail`
* [`b0b4d2d0`](https://github.com/NixOS/nixpkgs/commit/b0b4d2d06d44c971dd744d19d1b4edf1baab3658) pkgs/top-level: stop permitting openssl 1.1
* [`b534b7e5`](https://github.com/NixOS/nixpkgs/commit/b534b7e5a5cd3774baca73337c4dbbe5963e4fae) obs-studio-plugins.obs-teleport: 0.7.1 -> 0.7.2
* [`0fda1046`](https://github.com/NixOS/nixpkgs/commit/0fda1046bb9c181df980b19571ded990e754390b) gotify-server: 2.4.0 -> 2.5.0
* [`adf24f8b`](https://github.com/NixOS/nixpkgs/commit/adf24f8b90191ce85498be2f2d7db69c4f2bf24f) ols: 0-unstable-2024-06-13 -> 0-unstable-2024-06-18
* [`e631ecaa`](https://github.com/NixOS/nixpkgs/commit/e631ecaa8b87b36efaaa895b4a1d80187497eeb9) wayland-proxy-virtwl: 0-unstable-2024-04-08 -> 0-unstable-2024-06-17
* [`4465c275`](https://github.com/NixOS/nixpkgs/commit/4465c275aad68075a82e8009cdc570239f37ddf8) ipfs-cluster: 1.1.0 -> 1.1.1
* [`dace0b64`](https://github.com/NixOS/nixpkgs/commit/dace0b6431587e21e6ee03d2e9702d230952d9df) noson: 5.6.6 -> 5.6.7
* [`a910bc81`](https://github.com/NixOS/nixpkgs/commit/a910bc81467ed9032b5c35eb8525a239bbd5886a) nixos/keycloak: relax hostname settings assertion
* [`aa38b880`](https://github.com/NixOS/nixpkgs/commit/aa38b880289b7ae835ba5dd6a8c0247db313499b) imagemagick: 7.1.1-33 -> 7.1.1-34
* [`afb24545`](https://github.com/NixOS/nixpkgs/commit/afb245456e6fef7c0a1f5de830b2993f1f6e05c6) gitu: 0.21.0 -> 0.21.1
* [`8c33dddc`](https://github.com/NixOS/nixpkgs/commit/8c33dddc3f7ce64488411bf6ea390124abe3065a) cartridges: migrate to by-name
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
