### PR TITLE
niv home-manager: update 6b1f90a8 -> 59ce796b

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -41,10 +41,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "6b1f90a8ff92e81638ae6eb48cd62349c3e387bb",
-        "sha256": "0hmpljazjk11g2hjs4dgz283k728wvfdaplr3a8ix9chjadk745x",
+        "rev": "59ce796b2563e19821361abbe2067c3bb4143a7d",
+        "sha256": "0mc4mi23mds8c9r50r8f50sczcpb6fwgml2bcypld57micw8fxxn",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/6b1f90a8ff92e81638ae6eb48cd62349c3e387bb.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/59ce796b2563e19821361abbe2067c3bb4143a7d.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@6b1f90a8...59ce796b](https://github.com/nix-community/home-manager/compare/6b1f90a8ff92e81638ae6eb48cd62349c3e387bb...59ce796b2563e19821361abbe2067c3bb4143a7d)

* [`d3bf2a06`](https://github.com/nix-community/home-manager/commit/d3bf2a06129c2493ec55e217be2907b92279f30f) yazi: add eljamm as maintainer
* [`92a26bf6`](https://github.com/nix-community/home-manager/commit/92a26bf6df1f00cbbed16a99d2547531ff4b3a83) yazi: add shellWrapperName & rename wrappers to yy
* [`7a88ff6a`](https://github.com/nix-community/home-manager/commit/7a88ff6ad1e001043f876ebdb1d7460cdfe874d2) systemd: fix sd-switch error on empty target directory
* [`607f969f`](https://github.com/nix-community/home-manager/commit/607f969f5dca2dc100cbc53e24ab49ac24ef8987) systemd: don't try to restart templates
* [`1a4f12ae`](https://github.com/nix-community/home-manager/commit/1a4f12ae0bda877ec4099b429cf439aad897d7e9) docs: introduction chapter
* [`19e2f43e`](https://github.com/nix-community/home-manager/commit/19e2f43e0b0aec2067e5101f7d1ec75a43f64778) rbw: fix url option examples
* [`f50e2779`](https://github.com/nix-community/home-manager/commit/f50e2779edbc905ab131ce7ce36b14a09ab44f3c) flake.lock: Update
* [`7e68e55d`](https://github.com/nix-community/home-manager/commit/7e68e55d2e16d3a1e92a679430728c35a30fd24e) glance: add module
* [`c2f806e6`](https://github.com/nix-community/home-manager/commit/c2f806e60ac55c604708250ba0ebcf96bccbbafe) pulseeffects: fix test evaluation
* [`36317d4d`](https://github.com/nix-community/home-manager/commit/36317d4d38887f7629876b0e43c8d9593c5cc48d) direnv: add silent option
* [`ef74bacb`](https://github.com/nix-community/home-manager/commit/ef74bacbb48cf5f33dda7b7565a7986fbc489a45) ci: bump DeterminateSystems/update-flake-lock from 22 to 23
* [`59ce796b`](https://github.com/nix-community/home-manager/commit/59ce796b2563e19821361abbe2067c3bb4143a7d) flake.lock: Update
