### PR TITLE
niv powerlevel10k: update bde5ca4c -> 2b7da93d

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -113,10 +113,10 @@
         "homepage": "",
         "owner": "romkatv",
         "repo": "powerlevel10k",
-        "rev": "bde5ca4c2aa6e0c52dd7f15cf216dffdb1ec788c",
-        "sha256": "19ydglwbrj0r1ns2rj7kxb7iinbry0qfgzizixzzykqndwysj390",
+        "rev": "2b7da93df04acd04d84f5de827e5b14077839a4b",
+        "sha256": "06qx1dq3vgp5ly8k425ai10axrx2g2abfq52chcm61y1nb2dcclg",
         "type": "tarball",
-        "url": "https://github.com/romkatv/powerlevel10k/archive/bde5ca4c2aa6e0c52dd7f15cf216dffdb1ec788c.tar.gz",
+        "url": "https://github.com/romkatv/powerlevel10k/archive/2b7da93df04acd04d84f5de827e5b14077839a4b.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "rh": {


### PR DESCRIPTION
## Changelog for powerlevel10k:
Branch: master
Commits: [romkatv/powerlevel10k@bde5ca4c...2b7da93d](https://github.com/romkatv/powerlevel10k/compare/bde5ca4c2aa6e0c52dd7f15cf216dffdb1ec788c...2b7da93df04acd04d84f5de827e5b14077839a4b)

* [`df8ed163`](https://github.com/romkatv/powerlevel10k/commit/df8ed163438c1989da4daeb4174bfcb30abb285e) wizard: prefer POWERLEVEL9K_MODE=nerdfont-v3 over nerdfont-complete"
* [`4a2ef610`](https://github.com/romkatv/powerlevel10k/commit/4a2ef610ef893b47a539327195050adb50cbaf06) Add instructions on setting Conemu font
* [`2b7da93d`](https://github.com/romkatv/powerlevel10k/commit/2b7da93df04acd04d84f5de827e5b14077839a4b) docs: fixup for [romkatv/powerlevel10k⁠#2718](https://togithub.com/romkatv/powerlevel10k/issues/2718)
