### PR TITLE
niv nixpkgs: update 3881b74f -> 8f73cd84

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3881b74fa87197d8a481d31ed7698c70dde5edd9",
-        "sha256": "1ivc5adx87mc501723zhbzmrnjnjp42fpqnzz8a45yzz9kmv3j4m",
+        "rev": "8f73cd84480daef9326ee7b1be8c391334211347",
+        "sha256": "0adyjd1w8k2lhiv18kaywz5skppvf2a3y2m4vvc6fv1kzcsgsnc8",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/3881b74fa87197d8a481d31ed7698c70dde5edd9.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/8f73cd84480daef9326ee7b1be8c391334211347.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@3881b74f...8f73cd84](https://github.com/nixos/nixpkgs/compare/3881b74fa87197d8a481d31ed7698c70dde5edd9...8f73cd84480daef9326ee7b1be8c391334211347)

* [`1f2535dc`](https://github.com/NixOS/nixpkgs/commit/1f2535dcd8727032d1f2529011535c0e7e390645) nvidia-x11: Package nvidia-bug-report.sh
* [`3c3cb142`](https://github.com/NixOS/nixpkgs/commit/3c3cb142f1221df7f7c83fddc89efdcb2ba41a0d) dracula-qt5-theme: init at unstable-2022-05-21
* [`6da9ffc6`](https://github.com/NixOS/nixpkgs/commit/6da9ffc641b753cae17983634a154fabb65dcb41) ember-cli: init at 5.3.0
* [`39ae2bab`](https://github.com/NixOS/nixpkgs/commit/39ae2babceff26ce76669d9a5352815176ebd54b) nixos/networkd: allow KeepCarrier in tunConfig and tapConfig
* [`82d48bb4`](https://github.com/NixOS/nixpkgs/commit/82d48bb4f9ee338f30342a2874455d3d02e6c389) qemu-guest: Remove hwclock workaround as it breaks xtime on VMs.
* [`1d341245`](https://github.com/NixOS/nixpkgs/commit/1d341245939489cd90345ba333e07d24e4fe10ef) nixos/samba: add system-samba.slice
* [`fb5bd634`](https://github.com/NixOS/nixpkgs/commit/fb5bd634ec0abfac2dafc6ce15ee356ea557121d) rotonda: init at 0.1.0
* [`22bf6bff`](https://github.com/NixOS/nixpkgs/commit/22bf6bff58af5845960a84fc98304a0717e19e05) nixos/rtorrent: rpcsock perm should reflect provided options
* [`21dad26a`](https://github.com/NixOS/nixpkgs/commit/21dad26a9cf44f5f7ae94359db776d5f9d6088f0) trrntzip: init at 1.1
* [`d260e2e2`](https://github.com/NixOS/nixpkgs/commit/d260e2e2e363f491d935abba455fd03365a8561d) android-studio-for-platform: init at 2023.2.1.20
* [`88441020`](https://github.com/NixOS/nixpkgs/commit/88441020acb55c87bed9401fc8aaf75dd77881e7) saxon-he: 11.5 -> 12.4
* [`e4391a5d`](https://github.com/NixOS/nixpkgs/commit/e4391a5d29aac212862ccfb0114ee83df13f10d9) exe2hex: init at 1.5.2-unstable-2020-04-27
* [`73945051`](https://github.com/NixOS/nixpkgs/commit/73945051ade72f28717cd6024f7e22cfa2b56f64) closurecompiler: 20231112 -> 20240317
* [`596ca95c`](https://github.com/NixOS/nixpkgs/commit/596ca95c5724194b37e37bfa797d2da8421a63aa) cmake: enable cross compilation
* [`c8a38ab1`](https://github.com/NixOS/nixpkgs/commit/c8a38ab177aa9d58ae0a16615a7f6ac70fdd55a9) python311Packages.niaaml: change upstream
* [`2b1cb187`](https://github.com/NixOS/nixpkgs/commit/2b1cb18799e131f301e7781d0e9d1180b6e33b50) blastem: init at 0.6.2-unstable-2024-03-31
* [`36da6659`](https://github.com/NixOS/nixpkgs/commit/36da6659911bd9667b7ee7b9218ddf1e05a2d7a6) Test
* [`2b39c90d`](https://github.com/NixOS/nixpkgs/commit/2b39c90d97e302d0edb95b4025ea0b4f792a6c75) apparmor: 3.1.7 -> 4.0.1
* [`6e140aaf`](https://github.com/NixOS/nixpkgs/commit/6e140aaf3fb2d15c041d35de7a3815543f98d029) ocamlPackages.ocamlfuse: 2.7.1_cvs9 -> 2.7.1_cvs11
* [`e7a78e95`](https://github.com/NixOS/nixpkgs/commit/e7a78e95d40027450960656a4239601308eb22ac) peazip: 9.6.0 -> 9.7.1
* [`67a80a7f`](https://github.com/NixOS/nixpkgs/commit/67a80a7f5e5dfc4f3b5e424043c890347dc7bcfd) ocamlPackages.unisim_archisec: 0.0.5 -> 0.0.8
* [`60f36e58`](https://github.com/NixOS/nixpkgs/commit/60f36e58fdc809c3a4edf180155feb979c5ff5a1) ocamlPackages.hidapi: 1.1.2 -> 1.2.1
* [`6190f284`](https://github.com/NixOS/nixpkgs/commit/6190f2844ce3bdf4e321e00b04f75f59d37e40f3) ocamlPackages.ocsigen_server: 5.1.0 -> 5.1.2
* [`8ca428d9`](https://github.com/NixOS/nixpkgs/commit/8ca428d9994e49d2f7bf5c3c4be32c30edafa153) ocamlPackages.kqueue: 0.3.0 -> 0.4.0
* [`29485666`](https://github.com/NixOS/nixpkgs/commit/294856664e399c0ebb662593f11b6845567b389a) fribidi: 1.0.13 -> 1.0.14
* [`64c8af6b`](https://github.com/NixOS/nixpkgs/commit/64c8af6bb76c9917f333c3ec5ced7397be4bea9a) ocamlPackages.tdigest: 2.1.2 -> 2.2.0
* [`9589bf7c`](https://github.com/NixOS/nixpkgs/commit/9589bf7c8e3b50e61549010012c2fa1be0abea99) python311Packages.executing: Disable flaky test
* [`d86fc0d0`](https://github.com/NixOS/nixpkgs/commit/d86fc0d0f16cae948dac0d5978ff46a902def172) emacs: darwin: use architecture-native SDK
* [`46b48b8d`](https://github.com/NixOS/nixpkgs/commit/46b48b8d3f21b184659b9a5a08fd7e4152f0db95) spdlog: 1.13.0 -> 1.14.1
* [`ea9e6209`](https://github.com/NixOS/nixpkgs/commit/ea9e6209b9ca5e07ed3b31412ff0da631b873fb0) edac-utils: unstable-2015-01-07 -> unstable-2023-01-30
* [`bfb338e8`](https://github.com/NixOS/nixpkgs/commit/bfb338e8638663165a63b3751ac2ed15329215e3) edac-utils: fixup edac-ctl perl shebang
* [`66d42797`](https://github.com/NixOS/nixpkgs/commit/66d42797df999261e830f2abce2d961d3fa09674) v2ray: 5.15.3 -> 5.16.1
* [`d1ac6d92`](https://github.com/NixOS/nixpkgs/commit/d1ac6d921a565384379fa6332c8465cadfd5a456) edac-utils: use substituteInPlace instead of wrapProgram
* [`a1408e6e`](https://github.com/NixOS/nixpkgs/commit/a1408e6e217bea84ce729f965436718d19fe6e90) edac-utils: remove sysv init script
* [`a2c17aa5`](https://github.com/NixOS/nixpkgs/commit/a2c17aa5d1fd5929e91dc45978a9830dce32e15a) edac-utils: use correct system directories
* [`0d2ce06c`](https://github.com/NixOS/nixpkgs/commit/0d2ce06cf5a144a32fdce411fc0d8ba4d7cc132a) rootlesskit: 2.0.2 -> 2.1.0
* [`4d83f0eb`](https://github.com/NixOS/nixpkgs/commit/4d83f0ebfb2a6c2c6960b13f69f1841918a57d0c) ocamlPackages.xenstore: 2.2.0 -> 2.3.0
* [`60bffa57`](https://github.com/NixOS/nixpkgs/commit/60bffa57b08a07e6eff61c85153238cb5d262aec) taskflow: 3.6.0 -> 3.7.0
* [`5e521059`](https://github.com/NixOS/nixpkgs/commit/5e5210597bc98c7e65d525eb4c73ef91fe7eab15) ocamlPackages.shared-memory-ring: 3.1.1 -> 3.2.1
* [`8266a087`](https://github.com/NixOS/nixpkgs/commit/8266a08755f0e346fc59b3d9554a21390009739d) memcached: 1.6.26 -> 1.6.27
* [`3e16910c`](https://github.com/NixOS/nixpkgs/commit/3e16910c4a1e8b9585193f39f788d3adb51a4702) libslirp: 4.7.0 -> 4.8.0
* [`51411836`](https://github.com/NixOS/nixpkgs/commit/5141183658eda7149134f471d64dda33b6b4a235) enchant: enable disabling providers
* [`7ee75d6a`](https://github.com/NixOS/nixpkgs/commit/7ee75d6aa9b088922b47b69c1912b2afe000ae52) enchant: enable optional Applespell support on darwin
* [`6ccd956f`](https://github.com/NixOS/nixpkgs/commit/6ccd956fd4e8dd81ebf7ed4a4d0515f276668aa0) glib: fix installing gdb scripts
* [`a5d2d2b4`](https://github.com/NixOS/nixpkgs/commit/a5d2d2b4b9808657dd14ff9c68d7cb98da9632dd) ocamlPackages.ppx_deriving_yaml: 0.2.2 -> 0.3.0
* [`dda5e2f6`](https://github.com/NixOS/nixpkgs/commit/dda5e2f67513f1a7ffdf2595694c36458eddd1df) tmuxPlugins.tokyo-night-tmux: init at 1.5.3
* [`a54f00ab`](https://github.com/NixOS/nixpkgs/commit/a54f00abfb5fcfc6f50c4ec9eacb0c008fa86f9d) lidarr: 2.2.5.4141 -> 2.3.3.4204
* [`8af4bfe3`](https://github.com/NixOS/nixpkgs/commit/8af4bfe3620098cc2789b70d3d09b729c2cd69c2) iproute2: 6.8.0 -> 6.9.0
* [`dbd1d2f8`](https://github.com/NixOS/nixpkgs/commit/dbd1d2f8913e2e39ba727186390294e47213c42d) maintainers: add gcleroux
* [`a380256a`](https://github.com/NixOS/nixpkgs/commit/a380256a93ad31fd42cddc3d71035866c8d42cce) uhdm: 1.82 -> 1.83
* [`903dd9f8`](https://github.com/NixOS/nixpkgs/commit/903dd9f8dbb170a29495ff52235ee50f49472214) surelog: 1.82 -> 1.83
* [`5f64af98`](https://github.com/NixOS/nixpkgs/commit/5f64af98428514e56a09ed4c7f531f0bf4726d9b) re2c: amend updater script to skip non-release tags
* [`6325fa12`](https://github.com/NixOS/nixpkgs/commit/6325fa1206034b1df8bf5ce3c262141b75f85380) libass: 0.17.1 -> 0.17.2
* [`62da2315`](https://github.com/NixOS/nixpkgs/commit/62da2315662886ff8e1032b07c65c76d2061334a) phosh-mobile-settings: 0.38.0 -> 0.39.0
* [`c0c5e877`](https://github.com/NixOS/nixpkgs/commit/c0c5e877376c7bb94c83e1d59b374a8356c9fde7) python3Packages.pydyf: 0.9.0 -> 0.10.0
* [`dbf62576`](https://github.com/NixOS/nixpkgs/commit/dbf62576e5419b3146ac981ce7cdfed4a1097b08) python3Packages.tinycss2: 1.2.1 -> 1.3.0
* [`58d01764`](https://github.com/NixOS/nixpkgs/commit/58d017642d848129100efd1dbf26da9c4cf8e297) python3Packages.weasyprint: 61.2 -> 62.1
* [`920b6be0`](https://github.com/NixOS/nixpkgs/commit/920b6be002256a8af9980776807dc30cc1489428) fossil: 2.23 -> 2.24
* [`a0010c88`](https://github.com/NixOS/nixpkgs/commit/a0010c88d4294b9932ce9970eb9d040b85df5a8b) ocamlPackages.terminal: 0.2.2 -> 0.4.0
* [`2aa65319`](https://github.com/NixOS/nixpkgs/commit/2aa653193fc71b70b098b0dc12419362088b3f63) ocamlPackages.macaddr: 5.5.0 -> 5.6.0
* [`48bcfb3c`](https://github.com/NixOS/nixpkgs/commit/48bcfb3c9ead2a967ec021496721ae4a28808e87) hicolor-icon-theme: 0.17 -> 0.18
* [`8d37b16f`](https://github.com/NixOS/nixpkgs/commit/8d37b16fb3884f03fce05f9272a856bc2ed22d84) hicolor-icon-theme: adopt
* [`9db19e0c`](https://github.com/NixOS/nixpkgs/commit/9db19e0cffb604c216fa9ba6a3d1e5510a90278e) hicolor-icon-theme: format with rfc formater
* [`362fd800`](https://github.com/NixOS/nixpkgs/commit/362fd800d189f00fe24bd511517f9c1fc3fb6f0e) hicolor-icon-theme: refactor
* [`6dd35467`](https://github.com/NixOS/nixpkgs/commit/6dd354678292792c88c913f423843273798cfe32) snappy: 1.2.0 -> 1.2.1
* [`6b6073f1`](https://github.com/NixOS/nixpkgs/commit/6b6073f1fb70ee48e9ab626778a70f14f6829bf5) installShellCompletion: add sanity check
* [`7acc3566`](https://github.com/NixOS/nixpkgs/commit/7acc35660635c5fb4dadb50383ab1e3457cc3f0f) stdenv: log hooks as they run (take II)
* [`cc817ea5`](https://github.com/NixOS/nixpkgs/commit/cc817ea5d54f791649587115b1bbc69a998e9626) openjdk: 21+35 -> 21.0.3+9
* [`a1ecc282`](https://github.com/NixOS/nixpkgs/commit/a1ecc28282b3c06abe0ad1196717bfbab89ff919) openjfx: 21-ga -> 21.0.3-ga
* [`20eab24a`](https://github.com/NixOS/nixpkgs/commit/20eab24a92261b3df10c4b53339b50c408a48d7f) hdf5: 1.14.3 -> 1.14.4.2
* [`38c661b1`](https://github.com/NixOS/nixpkgs/commit/38c661b1aad58b01f4c0abfb20c7c2a159cca016) hdf5: 1.14.4.2 -> 1.14.4.3
* [`368fe3cd`](https://github.com/NixOS/nixpkgs/commit/368fe3cd3b86071b07b899405a5af26fae2c9fde) xdg-utils: make procmail optional when cross-compiling
* [`6acab27f`](https://github.com/NixOS/nixpkgs/commit/6acab27f52e0f655bf2b19d7430927e0bf8fbf33) sbctl: add update script
* [`a6561788`](https://github.com/NixOS/nixpkgs/commit/a6561788627adc510f1ab5dc9921cac5f6e469f7) sbctl: 0.13 -> 0.14
* [`19674ecb`](https://github.com/NixOS/nixpkgs/commit/19674ecb5cac26a84703848237a84658a9f85d5e) jasper: fix cross compilation
* [`1949b0d1`](https://github.com/NixOS/nixpkgs/commit/1949b0d16bbab48228392c590457069693edadee) Annotate substituteStream deprecation warning
* [`74d3efab`](https://github.com/NixOS/nixpkgs/commit/74d3efab9832dab5e2d39089209e098ee73366cb) lutris: 0.5.16 -> 0.5.17
* [`8d00345f`](https://github.com/NixOS/nixpkgs/commit/8d00345f2b761fe74d6d808cac98b3abb1aba64f) bazecor: add wayland support
* [`713d2074`](https://github.com/NixOS/nixpkgs/commit/713d2074d63d4b9acfc8e4ceee55dcd9f99baff4) temurin-bin: fix issue with 1-tuple `impls`
* [`64073966`](https://github.com/NixOS/nixpkgs/commit/64073966b4a9b1bd08ecccb00ede17a9abee8935) temurin-bin: init at 22
* [`2dea579e`](https://github.com/NixOS/nixpkgs/commit/2dea579e3ea1903a560bb66234716ac366d72a9f) temurin-bin: mark EOL releases as vulnerable
* [`d9b2c5cf`](https://github.com/NixOS/nixpkgs/commit/d9b2c5cff8b00ab9c0e0e5c2349a0974db30adc1) temurin-bin: formatting fixes
* [`7717ee97`](https://github.com/NixOS/nixpkgs/commit/7717ee97b669446d5b616105b6a06aaa6ab2a548) temurin-bin: update sources
* [`c96227f2`](https://github.com/NixOS/nixpkgs/commit/c96227f29b03917a97b69df564de8d707973f4da) git-fixup: init at 1.6.1
* [`ce0985a4`](https://github.com/NixOS/nixpkgs/commit/ce0985a4b31f6c538e96b7df99a419b26c2d31c6) pythonPackages3.pikepdf: 8.14.0 -> 8.15.1
* [`93a9ca34`](https://github.com/NixOS/nixpkgs/commit/93a9ca34febfe274cd7056b4b83b235a1de0caba) ghostscript: add output `fonts`
* [`1b85fead`](https://github.com/NixOS/nixpkgs/commit/1b85fead2304203b1f9ded64ab9f9f31d57a8acc) wash-cli: 0.24.0 -> 0.28.1
* [`b26563aa`](https://github.com/NixOS/nixpkgs/commit/b26563aae2a1fce011ac52e28ff23a460866e82f) nodejs: run JS test suite as part of the checks
* [`1e930af9`](https://github.com/NixOS/nixpkgs/commit/1e930af9dd359cb0d1feb82d37647c290ec2bbff) libunistring: enable updateAutotoolsGnuConfigScriptsHook
* [`77ff1492`](https://github.com/NixOS/nixpkgs/commit/77ff1492aad9880404bde8d08ddd06deb1e64af1) expect: Fix build on native FreeBSD
* [`6f979d1e`](https://github.com/NixOS/nixpkgs/commit/6f979d1ed9f58db51d24d490424a1cd694af7e53) python311Packages.pyquil: 4.9.2 -> 4.10.1
* [`9722a074`](https://github.com/NixOS/nixpkgs/commit/9722a074d459513e1b0a3568400f844a8900391c) pciutils: 3.12.0 -> 3.13.0
* [`c56d0d26`](https://github.com/NixOS/nixpkgs/commit/c56d0d263be11283a8a5db25c7db5f1f24be8da4) melpaPackages: fix commit of melpaBuild for generated MELPA packages
* [`95d49e0d`](https://github.com/NixOS/nixpkgs/commit/95d49e0d5eceec325faad41f6ec59d79952cc2a8) python311Packages.qcs-api-client: 0.25.1 -> 0.25.3
* [`0f007929`](https://github.com/NixOS/nixpkgs/commit/0f007929ef63f0ecb485c5f1bdd0dd1e5a0d2aaf) libvpx: 1.14.0 -> 1.14.1
* [`e0b48c1c`](https://github.com/NixOS/nixpkgs/commit/e0b48c1c33c2c75c4cc304799172287b6c9f3092) llvmPackages_17.llvm: remove origin variable
* [`d3e5a168`](https://github.com/NixOS/nixpkgs/commit/d3e5a16866c77c470be6afa4e22db53aa1e5d918) wimboot: 2.7.6 -> 2.8.0
* [`9e93493c`](https://github.com/NixOS/nixpkgs/commit/9e93493c647311a419ac75e913abdded7563c545) hwdata: 0.382 -> 0.383
* [`10c458b4`](https://github.com/NixOS/nixpkgs/commit/10c458b4bc96cda85cbb61685afe08acb64f19f9) re2: 2024-05-01 -> 2024-06-01
* [`8a45e936`](https://github.com/NixOS/nixpkgs/commit/8a45e936ac04e33133fe118fa1e3eea3cf2a5980) libcamera: 0.2.0 → 0.3.0
* [`3a6141ac`](https://github.com/NixOS/nixpkgs/commit/3a6141ac961e42df4ac2c20cf92ebc25dee0b651) freebsdPackages.libcxx: switch back to libcxxrt on FreeBSD
* [`2a8132e5`](https://github.com/NixOS/nixpkgs/commit/2a8132e5bc610564027e0330492bf1e9fe5cb71e) llvmPackages_18.compiler-rt: adjust FreeBSD assert patch for LLVM 18
* [`8135af13`](https://github.com/NixOS/nixpkgs/commit/8135af13f11ecdd7d9e623ff83c7a6cf69c21df3) rustc: Add support for FreeBSD
* [`af63e5d2`](https://github.com/NixOS/nixpkgs/commit/af63e5d21b2b69a581da994acc6680d1808f69e2) icu: 73.2 -> 74.2
* [`a394cdd7`](https://github.com/NixOS/nixpkgs/commit/a394cdd7d2c2dd75d41614c1fa1b2226ae87749a) luaPackages.luv: 1.44.2-1 -> 1.48.0-2
* [`d4954e0d`](https://github.com/NixOS/nixpkgs/commit/d4954e0df299615e28b1f209c521ef11c9c22336) nixos/prosody: support mod_http_file_share
* [`91a237cd`](https://github.com/NixOS/nixpkgs/commit/91a237cd7ae47ae2db7a103dc243aca5c121cad7) fixDarwinDylibNames: fix error message output
* [`e7b08ca3`](https://github.com/NixOS/nixpkgs/commit/e7b08ca3e232d05c4bd2000af7c5486e63606246) pixelfed: 0.11.13 -> 0.12.1
* [`b966c334`](https://github.com/NixOS/nixpkgs/commit/b966c334d7e7a0d35382ef68d903964a61bffb49) nixos/pixelfed: default to php82
* [`26baea83`](https://github.com/NixOS/nixpkgs/commit/26baea838880613783c9e099000c3a5f77315558) buildGoModule: don't pass buildFlagsArray as file
* [`9bc39f4d`](https://github.com/NixOS/nixpkgs/commit/9bc39f4df570caf2f55bada656ac4d92c06e5b2d) findutils: 4.9.0 -> 4.10.0
* [`4daee8c0`](https://github.com/NixOS/nixpkgs/commit/4daee8c0bc69af2cd775075fc8b496da659c7d3b) libdrm: 2.4.120 -> 2.4.121
* [`75ecc0a1`](https://github.com/NixOS/nixpkgs/commit/75ecc0a1ec8f27cee84fafd70496c77b576924f5) libvpx: add some key reverse-dependencies to passthru.tests
* [`f8d01a8d`](https://github.com/NixOS/nixpkgs/commit/f8d01a8da313ac470d3871f158f0c9efd29b17df) nodejs: add bash shell completion
* [`ee46aa8a`](https://github.com/NixOS/nixpkgs/commit/ee46aa8a13bfcdcfa84459b98810bdde6093793f) melpaBuild: allow nix unstable version format
* [`c85826c3`](https://github.com/NixOS/nixpkgs/commit/c85826c3dfa3234257685ab08f5dba4eecdc2eac) llvmPackages_17.llvm: add patch to fix -fzero-call-used-regs crashes
* [`dd80ca4d`](https://github.com/NixOS/nixpkgs/commit/dd80ca4d00c685ad1df5d312d1a6fc9e02265539) stdenv: promote zerocallusedregs to defaultHardeningFlags
* [`409cbbe6`](https://github.com/NixOS/nixpkgs/commit/409cbbe61a551410d109b739a5cb0959a2c8db16) apptainer, singularity: prioritize original defaultPath
* [`e57c669d`](https://github.com/NixOS/nixpkgs/commit/e57c669d9d15cdac54df3d7f386f6cb5237c4c24) texlivePackages: fix symlimk creation condition
* [`f6d9b4b6`](https://github.com/NixOS/nixpkgs/commit/f6d9b4b6fc7f376e5f5ecacace951f57c155045c) apptainer, singularity: add argument systemBinPaths
* [`dbcf7cf6`](https://github.com/NixOS/nixpkgs/commit/dbcf7cf697c601fc92da45453290b81587b87ef5) apptainer, singularity: add release note entry about systemBinPaths
* [`c3026ac9`](https://github.com/NixOS/nixpkgs/commit/c3026ac986b6b21409a0240dcad4a411dad0d419) apptainer, singularity: warn abuot argument deprecation
* [`f1034cab`](https://github.com/NixOS/nixpkgs/commit/f1034cab0621adc6f16907d6791eca9192287114) nixos/mihomo: drop default value from cfg.configFile
* [`818fe57b`](https://github.com/NixOS/nixpkgs/commit/818fe57b73c18ac169c3310b1e1bf5f84be525fd) nixos/mihomo: format using nixfmt
* [`18ea06a7`](https://github.com/NixOS/nixpkgs/commit/18ea06a77e58ab2a6d4649ce7499f967d9c27b20) moarvm: 2024.01 -> 2024.05
* [`8d5563ec`](https://github.com/NixOS/nixpkgs/commit/8d5563ec253a5efe68246f4fe20c0cbe9d5c3c1b) iwona: fix build failure caused by src being a symlink
* [`8d2a765a`](https://github.com/NixOS/nixpkgs/commit/8d2a765adf01d45bddc63fbc2e97d0e5cf1638f8) Let-float various fromJSON calls to avoid repeated JSON reading/parsing
* [`35b3c163`](https://github.com/NixOS/nixpkgs/commit/35b3c1633181a22746f796a6ffe40e1e73f1646e) nixos/doc/rl-2411: `zerocallusedregs` hardening flag enabled by default
* [`52ec0675`](https://github.com/NixOS/nixpkgs/commit/52ec0675e7463d44d8fe8909b317d8a5e478c3f2) python3Packages.result: 0.16.1 -> 0.17.0
* [`7eb3f277`](https://github.com/NixOS/nixpkgs/commit/7eb3f2778d491fae8d41db7542d3e259bd2874f8) macvim: fix overrides
* [`ee555572`](https://github.com/NixOS/nixpkgs/commit/ee5555720b637a6de8d68aade4187785324a15d4) waf: 2.0.27 -> 2.1.1
* [`de35337d`](https://github.com/NixOS/nixpkgs/commit/de35337dccaee550e46b0375dbed2e23a97d08a0) libbpf: 1.4.2 -> 1.4.3
* [`dce3dd59`](https://github.com/NixOS/nixpkgs/commit/dce3dd59addbd29711165b1d090a1c27a2c200c3) python311Packages.iptools: refactor and remove nose
* [`6ee48fe5`](https://github.com/NixOS/nixpkgs/commit/6ee48fe55c0c58b3f8123f8208975374e8be4bc8) python311Packages.hdmedians: refactor and remove nose
* [`b3aa19a5`](https://github.com/NixOS/nixpkgs/commit/b3aa19a57b6867e611aaa5a00aed400b5201991d) python311Packages.hdmedians: fix license
* [`b3b929f3`](https://github.com/NixOS/nixpkgs/commit/b3b929f3b12e05544d3dc35997b99ce9e84eda0f) python311Packages.hkdf: refactor and remove nose
* [`e8059fc2`](https://github.com/NixOS/nixpkgs/commit/e8059fc26ad23146540a2d5796ce8dd5114ab618) python312Packages.exceptiongroup: 1.2.0 -> 1.2.1
* [`d163f12f`](https://github.com/NixOS/nixpkgs/commit/d163f12f2c48055e99cca3e3a0382906093d1c77) python/hooks/python-imports-check-hook: use $python output if existing
* [`436d13bb`](https://github.com/NixOS/nixpkgs/commit/436d13bb145ac1ee86216b990723378d6aa9d284) jq: disable two testcases failing on FreeBSD
* [`29ee41fe`](https://github.com/NixOS/nixpkgs/commit/29ee41feff51c3269c2c160fa4d67de6ba5cca36) openssl_3: 3.0.13 -> 3.0.14
* [`8e9d7fb6`](https://github.com/NixOS/nixpkgs/commit/8e9d7fb6af2525637c60e6fb44e7c35f147ec0be) openssl_3_2: 3.2.1 -> 3.2.2
* [`88f9412f`](https://github.com/NixOS/nixpkgs/commit/88f9412faa53de2910fe893b5442c070f4beac38) openssl_3_3: 3.3.0 -> 3.3.1
* [`448a3c06`](https://github.com/NixOS/nixpkgs/commit/448a3c064c2de3cce70482f3596bc56c6a4f439c) icu: enable updateAutotoolsGnuConfigScriptsHook
* [`0d7d3d60`](https://github.com/NixOS/nixpkgs/commit/0d7d3d60afec7db3133c863c1e3cd17447bebc2f) CODEOWNERS: add @⁠NixOS/acme
* [`9dbed7df`](https://github.com/NixOS/nixpkgs/commit/9dbed7df55ec5e9e57d3653af1398604f4bcc80f) boost-build: build correctly with clang (on FreeBSD)
* [`31c5a59b`](https://github.com/NixOS/nixpkgs/commit/31c5a59bf4fbb762bf763788f99c9d67d517d257) go_1_22: 1.22.3 -> 1.22.4
* [`a7cf502c`](https://github.com/NixOS/nixpkgs/commit/a7cf502c5d338d0f931aafc380cc8f29eac2ae99) ocamlPackages.miou: 0.1.0 -> 0.2.0
* [`b5859ca6`](https://github.com/NixOS/nixpkgs/commit/b5859ca66f2d31e9aba4072f6c2bc83a1a4880b5) rocketchat-desktop: 3.9.15 -> 4.0.0
* [`d72c4e57`](https://github.com/NixOS/nixpkgs/commit/d72c4e57039dd392b318d3e537bc11ff63ef5b89) rosenpass: 0.2.1 -> 0.2.2
* [`3b262523`](https://github.com/NixOS/nixpkgs/commit/3b2625231ef9cc3e9056367cbfab3f6f4a271b00) lokalise2-cli: 2.6.14 -> 3.0.0
* [`d4f459fa`](https://github.com/NixOS/nixpkgs/commit/d4f459fa893068693def96d0c461b56f1f9e6b96) nixos/networkd: add new Network section options
* [`e532cb8e`](https://github.com/NixOS/nixpkgs/commit/e532cb8e4ebdd14edb9372f3f3a1f5425a71afbe) qt5.qtbase: refresh patchset, drop vendored patch copy
* [`84f62506`](https://github.com/NixOS/nixpkgs/commit/84f6250666d79c4db60a8001cac5ac127479a1c2) kronosnet: 1.28 -> 1.29
* [`37672eb7`](https://github.com/NixOS/nixpkgs/commit/37672eb7c35e46c939c3ae851c7c49afa6dee1b2) pgmoneta: 0.11.1 -> 0.12.0
* [`a74035f0`](https://github.com/NixOS/nixpkgs/commit/a74035f061b7346c31f6e498e8176e8bbb12b097) maintainers: add rubenhoenle
* [`858867ae`](https://github.com/NixOS/nixpkgs/commit/858867aea9ad9c4b097948a97a147354185700d5) libinput: 1.25.0 -> 1.26.0
* [`4d114fc5`](https://github.com/NixOS/nixpkgs/commit/4d114fc5a267281790cb9046a07135fba3358eff) dgraph: 23.1.1 -> 24.0.0
* [`f58da4a9`](https://github.com/NixOS/nixpkgs/commit/f58da4a91d346fb34e4721767073a89a5d7a6b57) python312: 3.12.3 -> 3.12.4
* [`b873135b`](https://github.com/NixOS/nixpkgs/commit/b873135b40173faaab47d63068912582adf5b1d2) tomcat_connectors: 1.2.48 -> 1.2.49
* [`e0a905ef`](https://github.com/NixOS/nixpkgs/commit/e0a905ef96e58f8ec1d7cecfcfba63e31ef61d69) apacheHttpdPackages.mod_jk: rename from tomcat_connectors
* [`2866cf57`](https://github.com/NixOS/nixpkgs/commit/2866cf57e9c3deee489130d11b721638cb557ed4) apacheHttpdPackages.mod_jk: add anthonyroussel to maintainers
* [`3b62ca16`](https://github.com/NixOS/nixpkgs/commit/3b62ca16cc9fc530311e655149a08100e89d268d) all-packages: reorder apacheHttpdPackages
* [`ddd27023`](https://github.com/NixOS/nixpkgs/commit/ddd27023898022b18beccfa3d42b20518743a112) pyrosimple: 2.13.0 -> 2.14.0
* [`b1e72e80`](https://github.com/NixOS/nixpkgs/commit/b1e72e80825efcb60cd39c00c150f9772b50a137) ffmpeg: add metal support
* [`932bf58e`](https://github.com/NixOS/nixpkgs/commit/932bf58e90c733f016d41e255b89bef80a5cc33e) doc/stdenv: hardening flags: move zerocallusedregs  into "enabled by default" section
* [`3db93c35`](https://github.com/NixOS/nixpkgs/commit/3db93c351d221365556200d48d318a6f89c4339f) cc-wrapper: add stack clash protection hardening flag
* [`0e49cbda`](https://github.com/NixOS/nixpkgs/commit/0e49cbda2ed5bb6082e680faa98140f965d1616f) wine: disable stackclashprotection hardening flag
* [`d7ee5936`](https://github.com/NixOS/nixpkgs/commit/d7ee5936f487098a8d4008cba0510faeef90fc35) mingw-w64: disable stackclashprotection hardening flag
* [`a3f5640d`](https://github.com/NixOS/nixpkgs/commit/a3f5640dd7e24b97f6fdbdd734f9f144e1344964) doc/stdenv: hardening flags: add section on stackclashprotection
* [`23a45b44`](https://github.com/NixOS/nixpkgs/commit/23a45b446647eb02d6726a75ee4ab1cd961661fb) diffoscope: 269 -> 271
* [`6375a587`](https://github.com/NixOS/nixpkgs/commit/6375a5878dbd1b9e6f601ecd655708eef0093203) doc/release-notes: 24.11: addition of stackclashprotection hardening flag
* [`fd8ff68e`](https://github.com/NixOS/nixpkgs/commit/fd8ff68ed82b93b800d576116072aed7465a7104) qpdf: 11.9.0 -> 11.9.1
* [`49a09016`](https://github.com/NixOS/nixpkgs/commit/49a09016bcc827e6f9a184adad4fcfbcdfe4c4e6) libevent: enable updateAutotoolsGnuConfigScriptsHook
* [`48af3a05`](https://github.com/NixOS/nixpkgs/commit/48af3a05ae6f16f0484557d77499303b9d4b2c93) cacert: 3.98 -> 3.101
* [`5f2ad80f`](https://github.com/NixOS/nixpkgs/commit/5f2ad80fca28639287fe53d5b2499c9132364acb) ffado: fix hash, see https://ffado.org/posts/ffado-2.4.8-tarball_fix/
* [`87505cd6`](https://github.com/NixOS/nixpkgs/commit/87505cd6a58a42de6d62f7a040e1bf5189131f2c) livecaptions: 0.4.1 -> 0.4.2
* [`f991af45`](https://github.com/NixOS/nixpkgs/commit/f991af45eaf1282f2ce6843fe717a6ebd78e0226) livecaptions: move to by-name
* [`561a1df9`](https://github.com/NixOS/nixpkgs/commit/561a1df912a96f59785491e939e0baf5741a24e9) maintainers: add jcelerier
* [`7b8c1b97`](https://github.com/NixOS/nixpkgs/commit/7b8c1b97ddb10c3b66ac85ad03b50fa4e17edd09) python311Packages.pytorch-metric-learning: refactor
* [`b7af54ce`](https://github.com/NixOS/nixpkgs/commit/b7af54ce2d74622773644a21e29485b25b864481) atomicparsley: 20221229.172126.d813aa6 -> 20240608.083822.1ed9031
* [`a43dc641`](https://github.com/NixOS/nixpkgs/commit/a43dc6418af5688b2288b6a64b4c3293dc2f7f68) opensplat: 1.1.2 -> 1.1.3
* [`64e5a049`](https://github.com/NixOS/nixpkgs/commit/64e5a0493b939f8d7e82ae18a4466c001ba5421a) glm: 0.9.9.8 -> 1.0.1
* [`e0547a61`](https://github.com/NixOS/nixpkgs/commit/e0547a611e347e572df63466198042cf4345740c) frogatto/anura-engine: fix build
* [`0849efa1`](https://github.com/NixOS/nixpkgs/commit/0849efa1312dcae9317a22dff714674a5d44d473) EmptyEpsilon: define GLM_ENABLE_EXPERIMENTAL
* [`41dc236d`](https://github.com/NixOS/nixpkgs/commit/41dc236d788f2d5de99cce4f89aad7ebc91092e6) xkeyboard_config: 2.41 -> 2.42
* [`ab5e512b`](https://github.com/NixOS/nixpkgs/commit/ab5e512b8d81fa1766ce9746028658144002b52d) ipset: 7.21 -> 7.22
* [`0591be3b`](https://github.com/NixOS/nixpkgs/commit/0591be3bcf467bca8fe40249ec3ac5df78efe17f) frida-python: enable support for aarch64-darwin
* [`bdc870b1`](https://github.com/NixOS/nixpkgs/commit/bdc870b17ac2f548120194415a67acebc4390441) glib: make sure RTLD_LOCAL is used for G_MODULE_BIND_LOCAL
* [`0aee4fdd`](https://github.com/NixOS/nixpkgs/commit/0aee4fdd5db4cfeec53a1d11e5b6baf407e02dab) python311Packages.sphinx-codeautolink: 0.15.1 -> 0.15.2
* [`07c48ff2`](https://github.com/NixOS/nixpkgs/commit/07c48ff2c9f43cd433a4841b789db9cc3bf16dd1) gi-docgen: 2023.3 → 2024.1
* [`ead86855`](https://github.com/NixOS/nixpkgs/commit/ead868553bb3e9b7ef6834843050299e297dd746) lz4: use CMake to build
* [`59238b72`](https://github.com/NixOS/nixpkgs/commit/59238b728ca666478123c95e591aff727d0ae141) lz4: use finalAttrs
* [`6772b782`](https://github.com/NixOS/nixpkgs/commit/6772b7822fbbfad90ff2a84d9f17e9e6ad0b0424) lz4: separate binaries and libraries
* [`216e8c8c`](https://github.com/NixOS/nixpkgs/commit/216e8c8ce7641d5880f1987109f8059d88e56f43) lz4: add tests
* [`10143bc4`](https://github.com/NixOS/nixpkgs/commit/10143bc4973859e750f8dda581d97cf86b35de61) nixos/prometheus-fastly-exporter: unwrap execstart
* [`091d852f`](https://github.com/NixOS/nixpkgs/commit/091d852f6f11396bf5583abff369727d064ddf1d) nixos/tests/prometheus-exporters: add test script for fastly-exporter
* [`9221978d`](https://github.com/NixOS/nixpkgs/commit/9221978d746f02551621b769e26c570e60285a4e) python311Packages.trackpy: 0.6.2 -> 0.6.3
* [`e80ea5fa`](https://github.com/NixOS/nixpkgs/commit/e80ea5fa3420e00526cbf20c385ea6a9b45471ba) decibels: init at 46.0
* [`32398b6f`](https://github.com/NixOS/nixpkgs/commit/32398b6f13cb002306b9ff75e25eb69e95c8edec) commit: init at 4.1
* [`c96f50c3`](https://github.com/NixOS/nixpkgs/commit/c96f50c31469709aad20cc0a9fe4460054ad83ac) libzbc: 5.14.0 -> 6.0.0
* [`b409bf6a`](https://github.com/NixOS/nixpkgs/commit/b409bf6a25c41590fec5bb91b05c8340b089db4d) rio: 0.0.39 -> 0.1.0
* [`bcc04f1d`](https://github.com/NixOS/nixpkgs/commit/bcc04f1de8a91d160098cfdfb65a32837519cabf) lidarr: 2.2.5.4141 -> 2.3.3.4204
* [`53ca4258`](https://github.com/NixOS/nixpkgs/commit/53ca42587f32f9cb663dc6c252f0517c7a6f66aa) ffmpeg: refactor mapped fetchpatch2 application
* [`f959d366`](https://github.com/NixOS/nixpkgs/commit/f959d366f1fc4276cf48891ec9cff1251badf4a0) ffmpeg: add patches for CVE-2023-49501, CVE-2023-49502, CVE-2023-50007, CVE-2023-50008
* [`59f7e201`](https://github.com/NixOS/nixpkgs/commit/59f7e20118f8d5b404a88cc0e3620bf83f348f7b) ffmpeg_5: add patches for CVE-2023-49502, CVE-2023-50008, CVE-2023-51793, CVE-2023-51796
* [`ca1a9579`](https://github.com/NixOS/nixpkgs/commit/ca1a9579566a098ef27c4862d048c3cda5beb4fe) raze: init at 1.10.2
* [`81ed0532`](https://github.com/NixOS/nixpkgs/commit/81ed0532b64bef06433ec89ce96c26246d71d05f) biome: 1.7.3 -> 1.8.1
* [`d6c5acd5`](https://github.com/NixOS/nixpkgs/commit/d6c5acd56b0f2a1d4c4276255f18ea7d0d720579) qgroundcontrol: 4.3.0 -> 4.4.0
* [`f2deac15`](https://github.com/NixOS/nixpkgs/commit/f2deac15305d6b2888fd93dc501582ffd7cb63a5) openxr-loader: 1.1.37 -> 1.1.38
* [`16f2eaa1`](https://github.com/NixOS/nixpkgs/commit/16f2eaa1588cdcb201ff6b8f4b85dedac58cf0ca) ffado: Format expression
* [`1c544e1f`](https://github.com/NixOS/nixpkgs/commit/1c544e1f7ca46014c86b68b098286f4bcf56a8d9) ffado: correct metainfo install path
* [`0f49f8db`](https://github.com/NixOS/nixpkgs/commit/0f49f8dbebf2728256faa488d2b939b0d3de0f97) libmysqlconnectorcpp: 8.3.0 -> 8.4.0
* [`a79ece36`](https://github.com/NixOS/nixpkgs/commit/a79ece3659724fbd6ee68afccba6ec887a4f6cc2) xz: 5.4.6 -> 5.6.2
* [`b8ead77a`](https://github.com/NixOS/nixpkgs/commit/b8ead77a91b4a4f9cd069864ec0609bf48667a66) pcre2: 10.43 -> 10.44
* [`e1b06496`](https://github.com/NixOS/nixpkgs/commit/e1b0649603d44683e4f1162b1dcc7074a1c1f748) nixos/tests/kernel-generic: add passthru for configfiles
* [`79c15abc`](https://github.com/NixOS/nixpkgs/commit/79c15abc7d141591515d7c7db2b76de07b8ced9a) linux/hardened: remove redundant config
* [`ff5cd230`](https://github.com/NixOS/nixpkgs/commit/ff5cd230678058a13ce5f780c95081a9bba19371) linux: add space to avoid attributing comments too widely
* [`dd666b86`](https://github.com/NixOS/nixpkgs/commit/dd666b86ad8921528d8dbb05ea2cae20d2b04bfb) linux: enable STRICT_KERNEL_RWX & STRICT_MODULE_RWX
* [`b23e741b`](https://github.com/NixOS/nixpkgs/commit/b23e741b70551c29507ec28881bcfbc57117a3b7) linux: enable SHUFFLE_PAGE_ALLOCATOR
* [`b6c752bd`](https://github.com/NixOS/nixpkgs/commit/b6c752bddb8c9efee682a8ad7bab2838b6c5456d) linux: enable INIT_ON_ALLOC_DEFAULT_ON
* [`55d9c320`](https://github.com/NixOS/nixpkgs/commit/55d9c320ad23dd18a9f5f759706079b39d5e7305) linux: enable BUG
* [`f2f6a322`](https://github.com/NixOS/nixpkgs/commit/f2f6a3228a02b31b3ca554e3ffcbd106c03f4eae) linux: enable BUG_ON_DATA_CORRUPTION
* [`aa55ab50`](https://github.com/NixOS/nixpkgs/commit/aa55ab5010b34d4007c23054c8780a11afddeafd) linux: set higher DEFAULT_MMAP_MIN_ADDR for x86_64 & aarch64
* [`b143a96b`](https://github.com/NixOS/nixpkgs/commit/b143a96bb218a8f6443c49c73085c6cb3aae24b6) protoc-gen-go: 1.34.1 -> 1.34.2
* [`cfcd38ce`](https://github.com/NixOS/nixpkgs/commit/cfcd38ceeb7abf93d77fea9586e5a634d240f159) flite: migrate to by-name
* [`6428ef50`](https://github.com/NixOS/nixpkgs/commit/6428ef50fa51a188ab923ec10a1267fd26224a9c) flite: format with nixfmt
* [`071811b0`](https://github.com/NixOS/nixpkgs/commit/071811b0fe99ba4050a5c867a59c0d9b7b69322b) flite: modernize
* [`fea7be8d`](https://github.com/NixOS/nixpkgs/commit/fea7be8dcb5065e7cc181be2d314579da157138a) flite: add version test
* [`1e927c9b`](https://github.com/NixOS/nixpkgs/commit/1e927c9b6843303637abfe75eca36581583c7d4b) flite: add `meta.mainProgram`
* [`995a987f`](https://github.com/NixOS/nixpkgs/commit/995a987f3cab0819a92125a59e690b8bd69d7dea) flite: split outputs
* [`5f6511b4`](https://github.com/NixOS/nixpkgs/commit/5f6511b4398a3c2609bf89307dfa256d553c3acd) pyzy: init at 1.1-unstable-2023-02-28
* [`12a2db47`](https://github.com/NixOS/nixpkgs/commit/12a2db4789be7bb39ef85acdc0db9719acff4f3f) ibus-engines.pinyin: init at 1.5.1
* [`6fe1fd54`](https://github.com/NixOS/nixpkgs/commit/6fe1fd542191f08e7890ca1414f6b22cfb404664) neovim.tests: test lua transitive deps are available
* [`294f7a76`](https://github.com/NixOS/nixpkgs/commit/294f7a767f95e19a332007d95f35175b37725a45) luaPackages.luarocks 3.11.0 -> 3.11.1
* [`390ca00b`](https://github.com/NixOS/nixpkgs/commit/390ca00b5b2d6fa4b2fd16bcfe3550f27b7a0021) neovimUtils.packDir: init: extend vimUtils.packDir
* [`7e1ae5e8`](https://github.com/NixOS/nixpkgs/commit/7e1ae5e8bbb9f6733c50aebdba9a242ee8d61d04) neovim: wrap LUA_PATH and LUA_CPATH
* [`665f3f69`](https://github.com/NixOS/nixpkgs/commit/665f3f694bfc6c2f3a95a98b1abf71d2961879bb) lua: take into propagated-build-inputs when building LUA_PATH
* [`cd2255b9`](https://github.com/NixOS/nixpkgs/commit/cd2255b9ed83c95b7aa474af122245af98be71eb) hyperspeedcube: 1.0.6 -> 1.0.7
* [`0130cdcb`](https://github.com/NixOS/nixpkgs/commit/0130cdcba46b676ab265db23075f5fef084903c0) segger-jlink: add `updateScript`
* [`96a36465`](https://github.com/NixOS/nixpkgs/commit/96a36465896c176f3d6fc94abb290dccd5b540fd) segger-jlink: 796b -> 796k
* [`66fc9e60`](https://github.com/NixOS/nixpkgs/commit/66fc9e60cf2bba5be74e1a4dc0a5c2d196a9a001) segger-jlink: add `headless` variant
* [`d4cbe1f3`](https://github.com/NixOS/nixpkgs/commit/d4cbe1f370e2924fb8c095dc1de330bff1210e84) segger-jlink: move `qt4-bundled` expression to separate file
* [`8855f6bc`](https://github.com/NixOS/nixpkgs/commit/8855f6bcbad6fd34984bb34dd48a07d398141355) segger-jlink: add `meta.changelog`
* [`053ded01`](https://github.com/NixOS/nixpkgs/commit/053ded012b89017d8c757a4a51301d96f7674681) segger-jlink: add h7x4 to maintainers
* [`61eaf7be`](https://github.com/NixOS/nixpkgs/commit/61eaf7be2262c82ec665ba46866a681d3e317275) python12Packages.pytest-regressions: remove unused disabledTestPathss
* [`0714fbaf`](https://github.com/NixOS/nixpkgs/commit/0714fbafb3b352fd738c159a7acc8fa5058051b8) alsa-plugins: 1.2.7.1 -> 1.2.12
* [`aeba240c`](https://github.com/NixOS/nixpkgs/commit/aeba240cf3fb6a0f076d7b46930f039950a339ce) moonlight-qt: 5.0.1 -> 6.0.0
* [`b85aa336`](https://github.com/NixOS/nixpkgs/commit/b85aa336208dac3a2fca679516265e5a84c389a3) moonlight-qt: Use upstream patches to handle darwin prebuilts
* [`bc8e771f`](https://github.com/NixOS/nixpkgs/commit/bc8e771f1d8bde197449194f04218618d76f760b) moonlight-qt: New upstream deps libplacebo and vulkan-headers
* [`eba57e50`](https://github.com/NixOS/nixpkgs/commit/eba57e502d369663d48113246753f57109d66e8c) moonlight-qt: Move to pkgs/by-name
* [`75fe4b50`](https://github.com/NixOS/nixpkgs/commit/75fe4b503944c87fe6f7ec0a28787641a1aced20) moonlight-qt: Format using nixfmt-rfc-style and sort args
* [`e475bdd5`](https://github.com/NixOS/nixpkgs/commit/e475bdd5a230aee2ebf926c12242cb847a8b8f6d) luaPackages.luarocks_bootstrap: update pname
* [`28a49fea`](https://github.com/NixOS/nixpkgs/commit/28a49fea7eb0643139d964f7b57153297a3da44b) libopenmpt: 0.7.7 -> 0.7.8
* [`fbd21c50`](https://github.com/NixOS/nixpkgs/commit/fbd21c50672e32aa74e8073b5ffd986f172b2d5c) rustPlatform.maturinBuildHook: specify the output directory ([nixos/nixpkgs⁠#291025](https://togithub.com/nixos/nixpkgs/issues/291025))
* [`8163ae0b`](https://github.com/NixOS/nixpkgs/commit/8163ae0bb1c330b661d1ff567b90b5c065d08227) clblast: 1.6.2 -> 1.6.3
* [`f4a664b4`](https://github.com/NixOS/nixpkgs/commit/f4a664b4ef59a5a1c0d3773aecff18a658df4eec) netmaker: 0.24.1 -> 0.24.2
* [`1ac2ad12`](https://github.com/NixOS/nixpkgs/commit/1ac2ad124b671c855d1cc112c7520c66abac63ee) python312Packages.matplotlib: 3.8.4 -> 3.9.0
* [`468a859e`](https://github.com/NixOS/nixpkgs/commit/468a859e832e7c5406758a06372daad3c39c9ae1) python311Packages.matplotlib: add a testing derivation to passthru.tests
* [`fda3d690`](https://github.com/NixOS/nixpkgs/commit/fda3d6903ad2d0cc34eefcfa3d2beacbc8024037) python311Packages.pygments: add sigmanificient to maintainers
* [`c7153cc3`](https://github.com/NixOS/nixpkgs/commit/c7153cc3501bfe99b3a31183fa7173c0de937328) python311Packages.pygments: 2.17.2 -> 2.18.0
* [`21db1640`](https://github.com/NixOS/nixpkgs/commit/21db1640cd5bb92d59f7901d2fabbbb97d7f6eff) git: update.sh fix grep warning
* [`53054089`](https://github.com/NixOS/nixpkgs/commit/53054089b25f3a55c8ca7af466223b94e80941b6) git: 2.45.1 -> 2.45.2
* [`3bfb20e6`](https://github.com/NixOS/nixpkgs/commit/3bfb20e63832e703bb7a380e761e9b9438a303d7) mk-python-derivation: add pythonRelaxDepsHook
* [`58ca0215`](https://github.com/NixOS/nixpkgs/commit/58ca0215997f192f00ad7bff9607503fedcb7f0c) docs/language-frameworks/python: update relaxDepsHook docs
* [`abdf5dc7`](https://github.com/NixOS/nixpkgs/commit/abdf5dc772759bcef53effd5f05955b4a3ac0fd8)  treewide: remove pythonRelaxDepsHook references
* [`9be52e31`](https://github.com/NixOS/nixpkgs/commit/9be52e31b7d32565e4f4fc348840c4e4600ad9d7) ride: add darwin support
* [`86775175`](https://github.com/NixOS/nixpkgs/commit/867751755870b1a6926f553208936768ee9f5a08) openssh: put tests into passthru
* [`44107b3c`](https://github.com/NixOS/nixpkgs/commit/44107b3c90411d6f4485214d0e3d03514f34e65d) garnet: 1.0.6 -> 1.0.13
* [`d410d051`](https://github.com/NixOS/nixpkgs/commit/d410d0516153166db070f1b9726be4e5176817ca) garnet: format with nixfmt
* [`7f1b82fb`](https://github.com/NixOS/nixpkgs/commit/7f1b82fb32b8dc11d93bbea9004e7b876101ce1a) garnet: don't use broken recursion scheme
* [`82f5a2a3`](https://github.com/NixOS/nixpkgs/commit/82f5a2a336105fd2f0c9a975fe3b86b711f55f4d) garnet: don't overuse `with lib;`
* [`45217e7d`](https://github.com/NixOS/nixpkgs/commit/45217e7de9098528ea7041fad63b4a880d0f8f19) garnet: add updateScript
* [`02b55745`](https://github.com/NixOS/nixpkgs/commit/02b55745cf914dcaf8f1a2e5c0281227f65c9d8f) garnet: only build with dotnet 8
* [`eb54b641`](https://github.com/NixOS/nixpkgs/commit/eb54b641875c75b3499f5582134521d67af53732) Revert "pcre2: fix build for loongarch64"
* [`6f756b40`](https://github.com/NixOS/nixpkgs/commit/6f756b40658650d2b5e7c9a69c98f8f140e8a3b7) clang: don't set machine flags for overridden target
* [`b00f2625`](https://github.com/NixOS/nixpkgs/commit/b00f262516fa3c491fb8d43cf98117f1d38fdd14) Revert "rustc: disable wasm32 if some gcc options are set"
* [`f9723bc4`](https://github.com/NixOS/nixpkgs/commit/f9723bc4deb6d2201334fa5c617a70507f5e5ff2) treewide: get rid of ~all mesa.{drivers,osmesa,libdrm} references
* [`dda100f2`](https://github.com/NixOS/nixpkgs/commit/dda100f27bcdfd2f8325f83183dcb2deb321e3e2) mesa: split out the Darwin build into a separate expression, heavily clean up Linux
* [`b0a82fe9`](https://github.com/NixOS/nixpkgs/commit/b0a82fe902ac966c231389c5c42ad4271c28fb1e) mesa: add llvmpipeHook for software rendering setup
* [`31ff88c9`](https://github.com/NixOS/nixpkgs/commit/31ff88c94d38bf1781ccf5f5eb1e5352a2a2135f) nwipe: 0.34 -> 0.37; move to by-name
* [`396d54d8`](https://github.com/NixOS/nixpkgs/commit/396d54d8b391fad8087087509e743d943e0542f9) patchelfUnstable: 0.18.0-unstable-2024-01-15 -> 0.18.0-unstable-2024-06-15
* [`0adac36f`](https://github.com/NixOS/nixpkgs/commit/0adac36fd57b24e339d1bf4caba11d9f32b8118c) nixos/languagetool: add jvm options
* [`571ec703`](https://github.com/NixOS/nixpkgs/commit/571ec7031a149acf105c5b395620e3806bc8e609) nixos/languagetool: add restart on failure
* [`8bcc42fc`](https://github.com/NixOS/nixpkgs/commit/8bcc42fc59075cdf57533c486d43be119f339aad) python312Packages.furl: disable failing test
* [`f3731419`](https://github.com/NixOS/nixpkgs/commit/f3731419c8cbdb07f07e2eb7535e29fd6fd4b4c2) python312Packages.sphinx: disable failing test
* [`56606341`](https://github.com/NixOS/nixpkgs/commit/566063411d05a53a8508f7dbf650284dc2d15a2c) python312Packages.pydantic-core: 2.16.3 -> 2.18.4
* [`de8015cc`](https://github.com/NixOS/nixpkgs/commit/de8015cca2bfdf90c4dec96b5fafb82b694031f6) python312Packages.pydantic: 2.6.3 -> 2.7.4
* [`762abd82`](https://github.com/NixOS/nixpkgs/commit/762abd826ee335f7c7f528ef144142e2fd311b52) libtiff: Add patch to fix missing `Lerc` in libtiff-4.pc
* [`86edfad3`](https://github.com/NixOS/nixpkgs/commit/86edfad3823ae90a09f762e9eb4752f48a3dec81) python313Packages.greenlet: backport build fixes
* [`dc9640a1`](https://github.com/NixOS/nixpkgs/commit/dc9640a12e0c9de3cc4130cd197af38b12cfc4cc) python313Packages.cffi: fix build
* [`79510630`](https://github.com/NixOS/nixpkgs/commit/79510630263700ce787e50e1484176e781918c7c) python312Packages.zope-interface: 5.5.2 -> 6.4.post2
* [`1f944cea`](https://github.com/NixOS/nixpkgs/commit/1f944ceaf583e95d1e53a6004adb312d7e037f63) python313Packages.sphinx: fix tests
* [`4aab2f4d`](https://github.com/NixOS/nixpkgs/commit/4aab2f4d6c30291ee13f2b27b5fcdc5f1d5c777d) python312Packages.freezegun: 1.4.0 -> 1.5.1
* [`7b11c351`](https://github.com/NixOS/nixpkgs/commit/7b11c3513fa71aae8d8b35fe3b91e54c7ba366c7) python313Packages.jinja2: disable failing tests
* [`259f830f`](https://github.com/NixOS/nixpkgs/commit/259f830fc41007e3722adc795116ffc90e3ada3e) defusedxml: 0.7.1 -> 0.8.0rc2
* [`877e248c`](https://github.com/NixOS/nixpkgs/commit/877e248c1654bf6472723ad2ee816f7bbd0be06c) pkcs11-provider: 0.4 -> 0.5
* [`67dcd62b`](https://github.com/NixOS/nixpkgs/commit/67dcd62bab28d86682a5982f3cbe1383ce873286) liburing: format with nixfmt
* [`801bbb1a`](https://github.com/NixOS/nixpkgs/commit/801bbb1aa29b4e4c7c890c5d0da7b35bfcbcb8ed) liburing: 2.5 -> 2.6, fetch source from github
* [`7db1dff7`](https://github.com/NixOS/nixpkgs/commit/7db1dff736026c8ba2a64aef09161bdbc43d46d2) liburing: install all examples
* [`ca4011b8`](https://github.com/NixOS/nixpkgs/commit/ca4011b8530d80a25fc04e86783a864bbb7c47a8) openblas: disable trivialautovarinit on aarch64
* [`c8568ce5`](https://github.com/NixOS/nixpkgs/commit/c8568ce5535448d9c71bda1efb05a50f824b625a) nwg-hello: 0.2.0 -> 0.2.2
* [`422d0aee`](https://github.com/NixOS/nixpkgs/commit/422d0aee60a9368c373c925c5e0a3e3c8fa46c44) mercurial: 6.6.3 -> 6.7.4
* [`51ede1ea`](https://github.com/NixOS/nixpkgs/commit/51ede1ea8819f468dfe887455d3eb3a7c3fb8f90) python312Packages.numpy_2: init at 2.0.0
* [`c0333f0e`](https://github.com/NixOS/nixpkgs/commit/c0333f0eee3cdc3971e7781ea344afa91b525797) python313Packages.ptyprocess: fix tests
* [`7a1b6c2b`](https://github.com/NixOS/nixpkgs/commit/7a1b6c2be4d19e3e1974352e666976ea574f7294) jdk22: 22-ga -> 22.0.1-ga
* [`727d620f`](https://github.com/NixOS/nixpkgs/commit/727d620f8f6afde0f2b91d6bc71d6c550b2c9267) nettle: 3.9.1 -> 3.10
* [`f76271c4`](https://github.com/NixOS/nixpkgs/commit/f76271c4df97a9b84acc3b354c1b66c69067975e) llvm: Don't use libunwind on FreeBSD
* [`2cc0692e`](https://github.com/NixOS/nixpkgs/commit/2cc0692eef934f069749f09317bf45feaeb92c45) freebsd.libcxxrt: don't copy unwind headers
* [`5d69b153`](https://github.com/NixOS/nixpkgs/commit/5d69b1533e9e9291eaa5828581ed64986bfbc81a) python3Packages.orjson: 3.10.3 -> 3.10.5
* [`8b3c4b49`](https://github.com/NixOS/nixpkgs/commit/8b3c4b49696a78776e9aa0e49c1afd9228bfe90a) python312Packages.makefun: disable failing test
* [`3215c604`](https://github.com/NixOS/nixpkgs/commit/3215c604ed3968c8bf8dbbe79587b758c0b55935) python312Packages.twisted: disable failing tests
* [`e1fcc33f`](https://github.com/NixOS/nixpkgs/commit/e1fcc33fcdb4c9bb9c6f0d544777c14a8310e2aa) maintainers: add Bot-wxt1221
* [`816cb8e9`](https://github.com/NixOS/nixpkgs/commit/816cb8e9e9daee33715c53e0e0b3ea783963e4b5) qq: 3.2.9_240606 -> 3.2.9_240617
* [`77177e30`](https://github.com/NixOS/nixpkgs/commit/77177e301e52a9d8f7caad64974555206b79cb2e) freebsd.sysctl: init
* [`c171489c`](https://github.com/NixOS/nixpkgs/commit/c171489cc5c4dc1b9d86c86b93153eda4c51206a) freebsd.top: init
* [`b51604ab`](https://github.com/NixOS/nixpkgs/commit/b51604ab2a4d6c1e60614a17dede66cafef61b90) freebsd.mount: init
* [`27b9567e`](https://github.com/NixOS/nixpkgs/commit/27b9567edddefdf72871e27703afb35ec2929d80) freebsd.nscd: init
* [`d942e3fe`](https://github.com/NixOS/nixpkgs/commit/d942e3fec67439d5e571c9169665409656b50e14) freebsd.pwd_mkdb: init
* [`c9b08ff7`](https://github.com/NixOS/nixpkgs/commit/c9b08ff772399201037f041591aef27ea154191a) freebsd.getent: init
* [`4d5f87ef`](https://github.com/NixOS/nixpkgs/commit/4d5f87ef1fc8efdf7e4f0bb0331fca7b31150f07) keymapp: migrate to pkgs/by-name
* [`fa49d6ec`](https://github.com/NixOS/nixpkgs/commit/fa49d6ecd19edc99e63c5652eab82023b595aacc) keymapp: reformat with nixfmt-rfc-style
* [`3f82beef`](https://github.com/NixOS/nixpkgs/commit/3f82beef06fb1e8e990bdcfac1d6b1dbe3639e2e) keymapp: 1.1.1 -> 1.2.1
* [`f841f96b`](https://github.com/NixOS/nixpkgs/commit/f841f96b0f0ba84f2d577cd3bdd850d99137b5bf) kubernetes-helmPlugins.helm-git: 0.16.0 -> 0.16.1
* [`505578f0`](https://github.com/NixOS/nixpkgs/commit/505578f08321a4b9f8dcbb230d809d37a0cab526) python311Packages.meilisearch: 0.31.2 -> 0.31.3
* [`7d4a2059`](https://github.com/NixOS/nixpkgs/commit/7d4a20592e119d26023500acac1ec8e26682f632) socket_wrapper: 1.4.2 -> 1.4.3
* [`970fa0b6`](https://github.com/NixOS/nixpkgs/commit/970fa0b6131d6f812ec8485e4d2fae40f3ef885d) f2fs-tools: move to pkgs/by-name
* [`6c80237e`](https://github.com/NixOS/nixpkgs/commit/6c80237e35b92d7ade0edf5bffa53b1663d8b7ed) f2fs-tools: build with lz4 lzo
* [`502b1ac2`](https://github.com/NixOS/nixpkgs/commit/502b1ac291b58703a9c84a8c414c77fa88607ce6) asfa: init at 0.10.0
* [`436b46b6`](https://github.com/NixOS/nixpkgs/commit/436b46b69f4244528ab382a8d09a3514335149d8) cmake: 3.29.3 -> 3.29.6
* [`5f35127c`](https://github.com/NixOS/nixpkgs/commit/5f35127c52ae96115895d7e817e7ecd6d289c47a) novnc: 1.4.0 -> 1.5.0
* [`d1b53c4f`](https://github.com/NixOS/nixpkgs/commit/d1b53c4f6fe1e7b7d6581715ece7082f20c87457) grafanaPlugins: added versionPrefix argument
* [`5b23554d`](https://github.com/NixOS/nixpkgs/commit/5b23554d4a82550a745c0af091db6e05b2b7c283) grafanaPlugins.grafana-oncall-app: 1.5.1 -> 1.7.1
* [`c033e3ad`](https://github.com/NixOS/nixpkgs/commit/c033e3ad69193874409e2bf5cae0d2d2ea81f027) python311Packages.wurlitzer: 3.1.0 -> 3.1.1
* [`55d48b15`](https://github.com/NixOS/nixpkgs/commit/55d48b15ca0b546e39ac646b8f25db4b972d04a7) maintainers: add jamalam
* [`1451a58a`](https://github.com/NixOS/nixpkgs/commit/1451a58a57e1bd1592460268bdde30cf72923010) mattermost: fix version-regex and support webapp update
* [`db863ae6`](https://github.com/NixOS/nixpkgs/commit/db863ae6a444853ba42ef89f52197041002587d2) liburing: don't emit extra static libraries
* [`c9ab1fcb`](https://github.com/NixOS/nixpkgs/commit/c9ab1fcb3722726c9f9e46680530a58c95189af7) liburing: fix build with static stdenv
* [`65a6502a`](https://github.com/NixOS/nixpkgs/commit/65a6502a69c4208fd326da0596feaa57de15328e) rocksdb: add enableLiburing option
* [`36a188fe`](https://github.com/NixOS/nixpkgs/commit/36a188fe16d922e95f99f126bd6724ad3ec93409) python311Packages.testrail-api: 1.13.0 -> 1.13.1
* [`24c728e2`](https://github.com/NixOS/nixpkgs/commit/24c728e237bd1c9b3aa4e77386e9ec1c67e1cf20) SDL2: 2.30.3 -> 2.30.4
* [`0cbde447`](https://github.com/NixOS/nixpkgs/commit/0cbde4476a54a7e9fb9ea521b92bbe6e7eff8c9b) liburing: disable trivialautovarinit hardening flag
* [`7ea13320`](https://github.com/NixOS/nixpkgs/commit/7ea13320bf8eedced05d0f5545f5b90169c7a100) libhwy: disable trivialautovarinit hardening flag on aarch64
* [`59339a45`](https://github.com/NixOS/nixpkgs/commit/59339a45b7f6860f3dc19ff3c29160b54c267479) python312Packages.sqlalchemy: 2.0.30 -> 2.0.31
* [`a16d7f09`](https://github.com/NixOS/nixpkgs/commit/a16d7f09f48bede60fe11b62b728d3d5cd3fdaf7) python313Packages.pybind11: fix build
* [`9ae2f080`](https://github.com/NixOS/nixpkgs/commit/9ae2f08097b8753f0d6ac49ceb23d3d5dd5e4a89) cadical: 1.9.5 -> 2.0.0
* [`2be7c665`](https://github.com/NixOS/nixpkgs/commit/2be7c665bd32a38013705bf982e27eb775445631) python312Packages.typeguard: 4.2.1 -> 4.3.0
* [`599b8eba`](https://github.com/NixOS/nixpkgs/commit/599b8ebad130e5dc958a36df2c1fc3c6ac1d7119) llvmPackages_18: 18.1.7 -> 18.1.8
* [`615b0f47`](https://github.com/NixOS/nixpkgs/commit/615b0f47c8cc16218e61ebd9228aceae75ec596f) python311Packages.pyasn1-modules: 0.3.0 -> 0.4.0 ([nixos/nixpkgs⁠#313613](https://togithub.com/nixos/nixpkgs/issues/313613))
* [`b7c782f8`](https://github.com/NixOS/nixpkgs/commit/b7c782f8a41410867e5d34aafb3d8a6d6d6b81d4) sonarr: build from source
* [`5d7d3dcf`](https://github.com/NixOS/nixpkgs/commit/5d7d3dcfe78215b8eb7906aea52ca33d201c6d85) nixos/sonarr: use lib.getExe and escape args
* [`96857a6c`](https://github.com/NixOS/nixpkgs/commit/96857a6cf8e7144a70bb093a91de47a47bab51bf) dart-sass: 1.77.4 -> 1.77.6
* [`d88ee3f9`](https://github.com/NixOS/nixpkgs/commit/d88ee3f9c3720a133261c5a093ac8e0d616dc07e) dart-sass: migrate to by-name
* [`f8f4c2f7`](https://github.com/NixOS/nixpkgs/commit/f8f4c2f795a56e915c1a1dc8e409a2730c3db58c) dart-sass: use conventional code structure
* [`dc502210`](https://github.com/NixOS/nixpkgs/commit/dc502210d6c1aeec0c73a9a2ebfe2f8d70129b72) dart-sass: reformat with nixfmt-rfc-style
* [`599f5c2c`](https://github.com/NixOS/nixpkgs/commit/599f5c2c8c50caeb8e13100ceee21445ff5cd853) python3Packages: trivial toPythonModule fixes
* [`fd531cc5`](https://github.com/NixOS/nixpkgs/commit/fd531cc55c28eac6b77c7155deb12b0cde3a93ad) python3Packages.hoomd-blue: build with buildPythonPackage
* [`01ef5abc`](https://github.com/NixOS/nixpkgs/commit/01ef5abcfa26d719b85fcc2cf6bb845556223d71) python3Packages.py3buddy: build with buildPythonPackage
* [`1fef68b0`](https://github.com/NixOS/nixpkgs/commit/1fef68b065403f0b7db29016e52a164dd4552863) python3Packages.pyunbound: migrate to python-modules and build with buildPythonPackage
* [`1fec6771`](https://github.com/NixOS/nixpkgs/commit/1fec67710971470546fe862071cf9fba723a77c2) python3Packages.segyio: build with buildPythonPackage, fix build
* [`892f509d`](https://github.com/NixOS/nixpkgs/commit/892f509d6ccb040eb6b63e63577f47e00bd12455) nodejs_20: 20.12.2 -> 20.14.0 ([nixos/nixpkgs⁠#316258](https://togithub.com/nixos/nixpkgs/issues/316258))
* [`d3b55ee8`](https://github.com/NixOS/nixpkgs/commit/d3b55ee8f7106f39c7a9c2ac9ce882cf86aaa23f) cryptsetup: 2.7.1 -> 2.7.3
* [`e19d28db`](https://github.com/NixOS/nixpkgs/commit/e19d28db2a9e4564d1a4ef1a9f1a464bce788756) re2: use ICU, enable tests, refactor
* [`fe4760b7`](https://github.com/NixOS/nixpkgs/commit/fe4760b753a8cbaf05fb2c0567d1b8be75a6b8eb) re2: apply nixfmt and sort inputs
* [`e1154859`](https://github.com/NixOS/nixpkgs/commit/e1154859b7dd3a685b694b6d9b01028abe3c41ca) zlib-ng: 2.1.6 -> 2.1.7
* [`ae96067a`](https://github.com/NixOS/nixpkgs/commit/ae96067a6de4955c3d39b613cea507603970c5c1) nixos/cloudflared: fix links in doc
* [`16d8c11a`](https://github.com/NixOS/nixpkgs/commit/16d8c11a33452b57e4604c9644953e7b6897a127) nixos/networkd-dispatcher: fix links in doc
* [`d42c42b1`](https://github.com/NixOS/nixpkgs/commit/d42c42b164b670152d96289fe2cf455d3010deb7) yazi: add eljamm as maintainer
* [`22427857`](https://github.com/NixOS/nixpkgs/commit/22427857b82e39f0793e1c51cbfb5ee7b125532a) spotify: 1.2.17.834.g26ee1129 -> 1.2.38.720.ga4a70a0e
* [`3f7663c1`](https://github.com/NixOS/nixpkgs/commit/3f7663c1d7cb0721ba5156364fc1d5c93674de15) rust: Write to .cargo/config.toml instead of .cargo/config
* [`9957993a`](https://github.com/NixOS/nixpkgs/commit/9957993a93e218889efefce51527f4d5cb3c47fc) libimobiledevice: 1.3.0-date=2023-04-30 -> 1.3.0-unstable-2024-06-19
* [`6c53c67b`](https://github.com/NixOS/nixpkgs/commit/6c53c67b438d72ee5564b87fcae8e7a1173f9134) libimobiledevice-glue: 1.2.0 -> 1.3.0
* [`161355f6`](https://github.com/NixOS/nixpkgs/commit/161355f6c3713deb29f2bfcb954ba9fc7c630217) edk2: simplify src by using postFetch
* [`62921811`](https://github.com/NixOS/nixpkgs/commit/62921811ddc0e9b4e0f5ba41f96b628def6269be) edk2: move to by-name
* [`0de2895c`](https://github.com/NixOS/nixpkgs/commit/0de2895c09d4bcea2ec141aef56abb36f84dcb4a) edk2: add updateScript and changelog
* [`24efbe2c`](https://github.com/NixOS/nixpkgs/commit/24efbe2c36e56bf92b645207e581be2e951a6fe0) edk2: 202402 -> 202405
* [`e8242061`](https://github.com/NixOS/nixpkgs/commit/e82420614ef183587b868af2b89c584599025a2b) tomcat9: 9.0.88 -> 9.0.90
* [`4eae55aa`](https://github.com/NixOS/nixpkgs/commit/4eae55aad9b4de40a905031f4c6a8b3018be7ca2) tomcat10: 10.1.23 -> 10.1.25
* [`f814553d`](https://github.com/NixOS/nixpkgs/commit/f814553d48c81d5c7889a8fd8951dcd94b1dd901) docker-buildx: 0.14.1 -> 0.15.1
* [`250e3068`](https://github.com/NixOS/nixpkgs/commit/250e3068ca95c7f1b3094f68288ee4a60ee86453) maintainers: add andershus
* [`80c2b2b9`](https://github.com/NixOS/nixpkgs/commit/80c2b2b902479c0da1f0f065655f563ded14714b) python3Packages.deltalake: init at 0.18.1
* [`26bae045`](https://github.com/NixOS/nixpkgs/commit/26bae0456708d52c3e2bc3073a19701a72d96b32) tests/acme: check consistent account hash for legacy settings
* [`6466b84c`](https://github.com/NixOS/nixpkgs/commit/6466b84c25492bcd93e98432ae719fd6673bc127) gmime3: 3.2.14 -> 3.2.15
* [`94578454`](https://github.com/NixOS/nixpkgs/commit/94578454b18198f1f18368a58834f937d324dfa1) binutils 2.41 -> 2.42
* [`f302a0e1`](https://github.com/NixOS/nixpkgs/commit/f302a0e1d45c3119627efea375f4ab3b6c1ab442) python311Packages.gunicorn: 21.2.0 -> 22.0.0
* [`d2761b2e`](https://github.com/NixOS/nixpkgs/commit/d2761b2ea3cbfa9ee9cca725179ff04663bba7d4) python311Packages.apsw: 3.46.0.0 -> 3.46.0.1
* [`833a9841`](https://github.com/NixOS/nixpkgs/commit/833a9841fec2fd672456fb758c328159b987e79a) gcc12: 12.3.0 -> 12.4.0
* [`31cfac47`](https://github.com/NixOS/nixpkgs/commit/31cfac475b385ee2c4ae01f713b3ec8f05670669) python3Packages.pymysql: 1.1.0 -> 1.1.1
* [`a6894fba`](https://github.com/NixOS/nixpkgs/commit/a6894fba4218663ab455cbaec645cd3a4d718a93) xsimd: fix cross compilation, enable strictDeps
* [`24886056`](https://github.com/NixOS/nixpkgs/commit/2488605670f0ca83fdbe340d4adb3c9a740fb630) xsimd: move package to by-name
* [`b75ea1a7`](https://github.com/NixOS/nixpkgs/commit/b75ea1a777aeea33aa99b1727f462b00c8012e90) xsimd: add meta.changelog
* [`c4e9fc91`](https://github.com/NixOS/nixpkgs/commit/c4e9fc91a543abb321e4ae5be0d993fb99243577) editorconfig-core-c: 0.12.8 -> 0.12.9
* [`fea1c46b`](https://github.com/NixOS/nixpkgs/commit/fea1c46bcf9f88f0c24f64a48d3300452415c203) magic-vlsi: 8.3.483 -> 8.3.486
* [`7861a5d6`](https://github.com/NixOS/nixpkgs/commit/7861a5d64245ba146306e83edbbb8bcce07ddb7c) vim: 9.1.0412 -> 9.1.0509
* [`dc54e70b`](https://github.com/NixOS/nixpkgs/commit/dc54e70b114f412c1c7b476f01e39db3b1e9f119) python311Packages.ocrmypdf: 16.3.1 -> 16.4.0
* [`f806d30a`](https://github.com/NixOS/nixpkgs/commit/f806d30ae28a1df7708f2b21ad186255d94d52ff) gst_all_1.gst-plugins-good: restore support for dlopen libsoup on Darwin
* [`1ce8bebc`](https://github.com/NixOS/nixpkgs/commit/1ce8bebc61c219ed8d5ac7d988681bc633a80d46) libxslt: 1.1.39 → 1.1.41
* [`65319e29`](https://github.com/NixOS/nixpkgs/commit/65319e291ba6a8aa0b24dd95cc75efe5449e6b63) butler: remove
* [`10afd368`](https://github.com/NixOS/nixpkgs/commit/10afd368334b487ec6c96dd80425f65c80445932) itch: 26.1.3 -> 26.1.9
* [`83ebc114`](https://github.com/NixOS/nixpkgs/commit/83ebc1143fe193e101bd7d573374ac45e950cdaf) libdc1394: disable trivialautovarinit
* [`f52a4c68`](https://github.com/NixOS/nixpkgs/commit/f52a4c681050d2c42bd387a1b8b80dc104fd8603) doc/stdenv: hardening flags: add example error for trivialautovarinit
* [`0069ee23`](https://github.com/NixOS/nixpkgs/commit/0069ee2352c9ba8596d9382215b1f8ab0e3fcfdf) python311Packages.datasette: 0.64.7 -> 0.64.8
* [`c387e1d2`](https://github.com/NixOS/nixpkgs/commit/c387e1d2ce0c927b9c4c4b1f43ac8c19152055fc) buf: 1.32.2 -> 1.34.0
* [`12021c78`](https://github.com/NixOS/nixpkgs/commit/12021c78369619667aa76ce6d767e4015e2aa548) calibre: remove `removeReferencesTo` since it makes no difference for calibre now
* [`53e0568a`](https://github.com/NixOS/nixpkgs/commit/53e0568ae8f4182ae24130c43cace4782b9ae21f) calibre: add `popplerSupport` and `speechSupport` args
* [`5e49730c`](https://github.com/NixOS/nixpkgs/commit/5e49730c7417d9aa412c8b1e2d135d2b96c7d598) python312Packages.aioesphomeapi: apply upstream patch
* [`1f6b8d25`](https://github.com/NixOS/nixpkgs/commit/1f6b8d25b8b364908ca2aeac3bfc4b9ebb7d6aa4) yazi: clean up wrapper, add options and format
* [`af24569f`](https://github.com/NixOS/nixpkgs/commit/af24569fd04194ece55368e1a061ab88967eb340) python311Packages.icalendar: 5.0.12 -> 5.0.13
* [`de493c4f`](https://github.com/NixOS/nixpkgs/commit/de493c4f8cf6c208d86616c63c401d2405627b07) libwacom: 2.11.0 -> 2.12.2
* [`2309b354`](https://github.com/NixOS/nixpkgs/commit/2309b354bf7811cd1e0b92295c23aa7095899a69) spotify: 1.2.38.720.ga4a70a0e -> 1.2.40.599.g606b7f29
* [`771e8cf3`](https://github.com/NixOS/nixpkgs/commit/771e8cf391f3650aceb09889bedb84f305548551) libimobiledevice: enable build parallelism
* [`0fc457d1`](https://github.com/NixOS/nixpkgs/commit/0fc457d161ef51966733fb8fd8fabee6e90298f4) libimobiledevice: pull `gcc-14` fix pending upstream inclusion
* [`4ee5871b`](https://github.com/NixOS/nixpkgs/commit/4ee5871bf70f89df8240af47cf0b2556eac390b3) discordchatexporter-cli: 2.43.1 -> 2.43.3
* [`7cd4c3d0`](https://github.com/NixOS/nixpkgs/commit/7cd4c3d0de0a18954289f932fab107a9a40e997f) maintainers: add dseelp
* [`e8716949`](https://github.com/NixOS/nixpkgs/commit/e8716949975a04de790327f57b13eef6e6b98ddf) python311Packages.pvlib: 0.10.5 -> 0.11.0
* [`5ebae541`](https://github.com/NixOS/nixpkgs/commit/5ebae5413dd7582ca8ebf50bec03a0d5859b428a) python311Packages.sagemaker: 2.219.0 -> 2.224.1
* [`a52dfe81`](https://github.com/NixOS/nixpkgs/commit/a52dfe8145f8d335c7affc39031991c03409b6b4) apio: 0.8.1 -> 0.9.5
* [`6aff2d5b`](https://github.com/NixOS/nixpkgs/commit/6aff2d5bd46f63e443a3f2736316c7d82c23cade) mesa: remove unused deps
* [`85d5736c`](https://github.com/NixOS/nixpkgs/commit/85d5736c3069c1c6173e8d981a928e8100256b46) geoserver: 2.25.1 -> 2.25.2
* [`e81266cf`](https://github.com/NixOS/nixpkgs/commit/e81266cf34ef354e4dfcff4f185d51b88920686d) libgnome-keyring3: Apply cross-fixes from libgnome-keyring
* [`755c400a`](https://github.com/NixOS/nixpkgs/commit/755c400a929002ece6219e76e7130b9f66ce9ba9) {libGL,libGLU}: use the OpenGL framework on Darwin
* [`c884bc32`](https://github.com/NixOS/nixpkgs/commit/c884bc326059d8a018549decb0079296b6972eeb) libglut: add cross‐platform alias
* [`fbda1dbf`](https://github.com/NixOS/nixpkgs/commit/fbda1dbfd648632226b2953dd87f15955d659f4f) treewide: replace freeglut with libglut
* [`8696744c`](https://github.com/NixOS/nixpkgs/commit/8696744ce929ceecba6422879c55fcad6423c867) treewide: clean up uses of lib{GL,GLU,glut}.dev
* [`0b0a66ca`](https://github.com/NixOS/nixpkgs/commit/0b0a66ca70aef262c9c570ab4156cf4c600e418f) mesa_glu: use libGLX explicitly
* [`61c1de31`](https://github.com/NixOS/nixpkgs/commit/61c1de31fbfddefed370a43ae7db78b58813f13c) freeglut: use libGLX explicitly
* [`8768181d`](https://github.com/NixOS/nixpkgs/commit/8768181db1966d5de0178aac6d35460209f1e739) geant4: use libGLX explicitly
* [`03be5af6`](https://github.com/NixOS/nixpkgs/commit/03be5af68ec8f84982a3c7c910b700ee7209f9a4) xorg.xorgserver: add explicit Mesa dependency to Darwin build
* [`3307e926`](https://github.com/NixOS/nixpkgs/commit/3307e926edaf8528b3b6daa64d21fe32660653dd) python3Packages.vispy: skip patch on Darwin
* [`45aa182b`](https://github.com/NixOS/nixpkgs/commit/45aa182b6b325b6d3a3243f25893953d42f59ce6) ddnet: skip tests on Darwin
* [`e0798e1d`](https://github.com/NixOS/nixpkgs/commit/e0798e1d52876607f649403f01613918fa439ab9) jasper: add Cocoa dependency on Darwin
* [`ee6ffaf9`](https://github.com/NixOS/nixpkgs/commit/ee6ffaf921ea9db5d986f89bc1b21d4ddead1732) unixbench: depend on libGLX explicitly
* [`25f7f9a6`](https://github.com/NixOS/nixpkgs/commit/25f7f9a636fc3525689dad8d65bfd9f8ad87cbf5) fox: use mesa_glu explicitly
* [`5cb1babe`](https://github.com/NixOS/nixpkgs/commit/5cb1babeb3cfd51b417976023b05017b392116aa) python3Packages.pyftgl: fix build on Darwin
* [`fd276f75`](https://github.com/NixOS/nixpkgs/commit/fd276f75c868c3a3e62f16c54b0d52e1d48bec66) ocamlPackages.lablgl: simplify build and fix Darwin
* [`82c97b5c`](https://github.com/NixOS/nixpkgs/commit/82c97b5cdeb58b73c787f5e11cb47d80b17e5b72) minetest: fix build on Darwin
* [`95bd48a0`](https://github.com/NixOS/nixpkgs/commit/95bd48a0762ce6d55502c861a959dfac09d41117) SDL_compat: fix build on Darwin
* [`db82f166`](https://github.com/NixOS/nixpkgs/commit/db82f16668c666fcdc6218d593d20256bc294387) mar1d: 0.3.1 -> unstable-2023-02-02
* [`760eabad`](https://github.com/NixOS/nixpkgs/commit/760eabadbbb40c2b4df3d27b24c6c431524d3408) mar1d: add patch for Darwin
* [`8504c286`](https://github.com/NixOS/nixpkgs/commit/8504c286914df8e4b45bc381692561171af8c32c) bicgl: replace mesa_glu with libGLU
* [`e568a6f0`](https://github.com/NixOS/nixpkgs/commit/e568a6f0e41a2dca2d17d78781016e1bd2a550c0) nodejs: backport openssl fixes
* [`41419ca2`](https://github.com/NixOS/nixpkgs/commit/41419ca2883f7a3294711faf4961d043868e27ef) nixos/fcgiwrap: refactor for multiple instances
* [`bf2ad6f4`](https://github.com/NixOS/nixpkgs/commit/bf2ad6f48c95eea96768cc62dda7c6eb2097cbf4) nixos/fcgiwrap: adapt consumer modules and tests
* [`022289f2`](https://github.com/NixOS/nixpkgs/commit/022289f2fadb3a3bad83273cd45d8a3e4753991e) nixos/fcgiwrap: group options logically, fix doc
* [`8101ae41`](https://github.com/NixOS/nixpkgs/commit/8101ae41f8cefce9e518a550881302c4f58a8c5b) nixos/fcgiwrap: adapt consumer modules and tests
* [`3955eaf4`](https://github.com/NixOS/nixpkgs/commit/3955eaf45015c9dd8a5a59412bf9c5e47b789a65) nixos/fcgiwrap: improve readability of CLI args
* [`289c1585`](https://github.com/NixOS/nixpkgs/commit/289c1585c2a1f9ff9e159cbcdab664620dc9f7b3) nixos/fcgiwrap: limit prefork type to positives
* [`81f72015`](https://github.com/NixOS/nixpkgs/commit/81f72015f0b96b1227a2de38409049fba0e73aad) nixos/fcgiwrap: add unix socket owner, private by default
* [`c5dc3e20`](https://github.com/NixOS/nixpkgs/commit/c5dc3e203410bc3bfc77182cd8c6955b1bd64cfd) nixos/fcgiwrap: adapt consumer modules and tests
* [`51b246a1`](https://github.com/NixOS/nixpkgs/commit/51b246a1acd4ce4926b8a78e3e7e0e6927d546ff) nixos/fcgiwrap: do not run as root by default
* [`2d8626bf`](https://github.com/NixOS/nixpkgs/commit/2d8626bf0a35659a480c1a92bbd2682625a66e0f) nixos/cgit: configurable user instead of root
* [`3d10deb7`](https://github.com/NixOS/nixpkgs/commit/3d10deb7a5631e057bb5d84b5a6bd8fdf361a00a) nixos/cgit: fix GIT_PROJECT_ROOT ownership
* [`3556302b`](https://github.com/NixOS/nixpkgs/commit/3556302b64fade9729a036289a48a116f25b80ea) plasticity: 24.1.6 -> 24.1.7
* [`66076798`](https://github.com/NixOS/nixpkgs/commit/660767982d22371ad706a6c0bcc0d78844d6379a) libgnome-keyring: Replace with libgnome-keyring3
* [`859183c0`](https://github.com/NixOS/nixpkgs/commit/859183c05892035e0ac9414ceaaa5999595c86ac) libgnome-keyring: move from gnome scope to top-level
* [`16e84009`](https://github.com/NixOS/nixpkgs/commit/16e8400968a1d1d027f298bc1e4851cefc7b1700) linux: handle case where ZBOOT EFI stub is the target
* [`23336b66`](https://github.com/NixOS/nixpkgs/commit/23336b6607074cfb99f4171587f2e18bbd35f75b) ffmpeg: add twolame option
* [`974b7ae5`](https://github.com/NixOS/nixpkgs/commit/974b7ae5b38449031aaf5756541a20818ad8affc) endless-sky: 0.10.6 -> 0.10.8
* [`25bc4a5a`](https://github.com/NixOS/nixpkgs/commit/25bc4a5a200c75bc5fdc75e0687e48a6bac5a49b) emacs: 29.3 -> 29.4
* [`0b7dc69b`](https://github.com/NixOS/nixpkgs/commit/0b7dc69b2fbac0b7ae7bed1f6ecfef07c85f08d9) python311Packages.azure-mgmt-imagebuilder: 1.3.0 -> 1.4.0
* [`36f93e80`](https://github.com/NixOS/nixpkgs/commit/36f93e80c4aa114cd5bb8fad84e403f358e6b616) ssocr: 2.23.1 -> 2.24.0
* [`eec46c96`](https://github.com/NixOS/nixpkgs/commit/eec46c96b9417461ae5b08e19de639cb1d02e42f) python312Packages.albucore: init at 0.0.11
* [`c84a4733`](https://github.com/NixOS/nixpkgs/commit/c84a4733813fa1fd1104ae32e626915c822402a1) spring-boot-cli: 3.3.0 -> 3.3.1
* [`ad5bb782`](https://github.com/NixOS/nixpkgs/commit/ad5bb782cebebe6528471f77d9dcb2b4fc752be5) glib: 2.80.2 -> 2.80.3
* [`9515b3c5`](https://github.com/NixOS/nixpkgs/commit/9515b3c5b903546ed7e6afd8686b63b9c2539a1a) hiawatha: 11.5 -> 11.6
* [`10293296`](https://github.com/NixOS/nixpkgs/commit/10293296b0cd91d992e872dfc714684e68b51c28) mesa: 24.1.1 -> 24.1.2
* [`43ebb05c`](https://github.com/NixOS/nixpkgs/commit/43ebb05c575221362b44d7cc9a0f0cd1b5d3a53d) xvfb: promote to proper package
* [`42c4ffb9`](https://github.com/NixOS/nixpkgs/commit/42c4ffb9192a93a78a518a4daef0c4a406377fd0) treewide: replace xorgserver with xvfb in places where only xvfb is used
* [`e3617db4`](https://github.com/NixOS/nixpkgs/commit/e3617db49dedee4c346fe87088dc9816b85d3181) radarr: 5.6.0.8846 -> 5.7.0.8882
* [`d1aa1357`](https://github.com/NixOS/nixpkgs/commit/d1aa13577265f5e675576bb83ded81bf95c20d80) python311Packages.llama-index: 0.10.47 -> 0.10.48.post1
* [`6f01a401`](https://github.com/NixOS/nixpkgs/commit/6f01a4014bca22cd8523cd2561c47a3b8ed37117) gnupg22: fix cross compilation
* [`2de1fd60`](https://github.com/NixOS/nixpkgs/commit/2de1fd60fc655321c406711c3f80a9ca61506991) Revert "rust: Write config.toml not config"
* [`da53b161`](https://github.com/NixOS/nixpkgs/commit/da53b161f22233809109ee5b16f10e8c8e218024) sketchybar-app-font: build from source
* [`52b57fa9`](https://github.com/NixOS/nixpkgs/commit/52b57fa96e2306525a2b71f8695d8720bfdf61e7) wallust: 2.10.0 -> 3.0.0-beta
* [`42ec27ea`](https://github.com/NixOS/nixpkgs/commit/42ec27ea42b3231c619114bc9ead3d019e5f4c5c) python311Packages.livereload: 2.6.3 -> 2.7.0
* [`494a92ba`](https://github.com/NixOS/nixpkgs/commit/494a92bae1c011ab9276f3446841413e8e1eaf22) python311Packages.plexapi: 4.15.13 -> 4.15.14
* [`fecb940a`](https://github.com/NixOS/nixpkgs/commit/fecb940afa9df200eab3b6a24656ef0ad15fd02b) space-station-14-launcher: 0.27.2 -> 0.28.0
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
