### PR TITLE
niv home-manager: update 59ce796b -> 2fb5c1e0

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -41,10 +41,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "59ce796b2563e19821361abbe2067c3bb4143a7d",
-        "sha256": "0mc4mi23mds8c9r50r8f50sczcpb6fwgml2bcypld57micw8fxxn",
+        "rev": "2fb5c1e0a17bc6059fa09dc411a43d75f35bb192",
+        "sha256": "0vxzl3anrvvyyq8b5yx869hzcz7wpjkwdlfl87wg2agr3gh41yzd",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/59ce796b2563e19821361abbe2067c3bb4143a7d.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/2fb5c1e0a17bc6059fa09dc411a43d75f35bb192.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@59ce796b...2fb5c1e0](https://github.com/nix-community/home-manager/compare/59ce796b2563e19821361abbe2067c3bb4143a7d...2fb5c1e0a17bc6059fa09dc411a43d75f35bb192)

* [`36e2f9da`](https://github.com/nix-community/home-manager/commit/36e2f9da91ce8b63a549a47688ae60d47c50de4b) maintainers: remove ivar
* [`269cc18d`](https://github.com/nix-community/home-manager/commit/269cc18d945dd44bcbc22d58df3876a5d0dbac0b) sway: fix systemd variables example
* [`e9158314`](https://github.com/nix-community/home-manager/commit/e9158314725af06854009b829d2249d0d6c23c79) yazi: allow literal string for `initLua`
* [`58268b4d`](https://github.com/nix-community/home-manager/commit/58268b4d7745f6747be18033e6f10011466ce8d4) flake.lock: Update
* [`0a30138c`](https://github.com/nix-community/home-manager/commit/0a30138c694ab3b048ac300794c2eb599dc40266) mpd: specify dependency of service on socket
* [`c23060ce`](https://github.com/nix-community/home-manager/commit/c23060ce95c4856157789b0636e1b6206be335c4) hyprland: emphasize usage of the NixOS module
* [`6ea6fafa`](https://github.com/nix-community/home-manager/commit/6ea6fafa3e0f1691ec1555ce4281d7d993546131) mpv: remove tadeokondrak as maintainer
* [`c514e862`](https://github.com/nix-community/home-manager/commit/c514e862cd5705e51edb6fe8d01146fdeec661f2) treewide: fix eval after Nixpkgs maintainer changes
* [`bbe6e947`](https://github.com/nix-community/home-manager/commit/bbe6e94737289c8cb92d4d8f9199fbfe4f11c0ba) dunst: fix warning for lib.cartesianProductOfSets
* [`b7b55e28`](https://github.com/nix-community/home-manager/commit/b7b55e285cfc92e84f243012516bbc414691b747) sway: stop sway-session.target on exit
* [`e3582e51`](https://github.com/nix-community/home-manager/commit/e3582e5151498bc4d757e8361431ace8529e7bb7) sway: unfail units before starting session target
* [`10486e6b`](https://github.com/nix-community/home-manager/commit/10486e6b311b3c5ae1c3477fee058704cea7cb4a) starship: fix type of settings to allow all valid value
* [`6b7ce96f`](https://github.com/nix-community/home-manager/commit/6b7ce96f34b324e4e104abc30d06955d216bac71) Translate using Weblate (Hungarian)
* [`dfaf0ff2`](https://github.com/nix-community/home-manager/commit/dfaf0ff2e7e536e404a260845e436bd888c4bb5f) systemd: only set old units directory when available
* [`2fb5c1e0`](https://github.com/nix-community/home-manager/commit/2fb5c1e0a17bc6059fa09dc411a43d75f35bb192) tests: update to match new sd-switch version
