### PR TITLE
niv home-manager: update 2fb5c1e0 -> 90ae324e

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -41,10 +41,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2fb5c1e0a17bc6059fa09dc411a43d75f35bb192",
-        "sha256": "0vxzl3anrvvyyq8b5yx869hzcz7wpjkwdlfl87wg2agr3gh41yzd",
+        "rev": "90ae324e2c56af10f20549ab72014804a3064c7f",
+        "sha256": "1nl57zw3y85mx2w2kj634ra54p9alfsnzb67c1z3fbbdwgqr1rcx",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/2fb5c1e0a17bc6059fa09dc411a43d75f35bb192.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/90ae324e2c56af10f20549ab72014804a3064c7f.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@2fb5c1e0...90ae324e](https://github.com/nix-community/home-manager/compare/2fb5c1e0a17bc6059fa09dc411a43d75f35bb192...90ae324e2c56af10f20549ab72014804a3064c7f)

* [`f749fabe`](https://github.com/nix-community/home-manager/commit/f749fabeccb1587e4c1562e4f818cf33b8f77a51) atuin: use 'lib.getExe'
* [`f79d950a`](https://github.com/nix-community/home-manager/commit/f79d950ac23a4c63e60bb71475d3321fbd9ace2d) atuin: fix tests
* [`57d85c6c`](https://github.com/nix-community/home-manager/commit/57d85c6c6d625c45bbf848ed77fbdb5794aa8414) xdg-desktop-entries: allow `terminal` to be null
* [`c085b984`](https://github.com/nix-community/home-manager/commit/c085b984ff2808bf322f375b10fea5a415a9c43d) gnome-keyring: update package
* [`90ae324e`](https://github.com/nix-community/home-manager/commit/90ae324e2c56af10f20549ab72014804a3064c7f) sd-switch: respect xdg directory specifications
