### PR TITLE
niv nixpkgs: update e309c5b4 -> 5cd5002c

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e309c5b40c25615c6e46556994eedd8cafefef69",
-        "sha256": "0wp51npvpkpv7az3krkkyd7bv1ycnfr4ca15g49nl4pgyqqgpqql",
+        "rev": "5cd5002ca676d3c3ba9e4094c4b6a4967c4b1072",
+        "sha256": "1hrscqjb4lrrzqzpks0vkdva9vppc0gsd71sdgl515wj7z963bi1",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/e309c5b40c25615c6e46556994eedd8cafefef69.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/5cd5002ca676d3c3ba9e4094c4b6a4967c4b1072.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@e309c5b4...5cd5002c](https://github.com/nixos/nixpkgs/compare/e309c5b40c25615c6e46556994eedd8cafefef69...5cd5002ca676d3c3ba9e4094c4b6a4967c4b1072)

* [`3b3b6dcb`](https://github.com/NixOS/nixpkgs/commit/3b3b6dcbd545503fb10b234488b7141b0f9612c1) wpa_supplicant: enable WPA3-Enterprise
* [`4481ce60`](https://github.com/NixOS/nixpkgs/commit/4481ce601f188d383f2c3cb7a0ddd4d0309525f7) nixos/mailman: increase nginx proxy timeout
* [`f25ad9c5`](https://github.com/NixOS/nixpkgs/commit/f25ad9c54757eddb2b1040ffe75f154a85a3388c) aflplusplus: 4.10c -> 4.20c
* [`4d12a2d7`](https://github.com/NixOS/nixpkgs/commit/4d12a2d7177f9126b8d1be9ec494b6c6c47f03c7) tilt: 0.33.10 -> 0.33.13
* [`f46833c5`](https://github.com/NixOS/nixpkgs/commit/f46833c5d662daed5e54276d1b9918ab24b6e5d3) vimPlugins.advanced-git-search-nvim: init at 2024-05-13
* [`72c75d01`](https://github.com/NixOS/nixpkgs/commit/72c75d010197999a8686cba42eb001483cc25791) qwerty-fr: init at 0.7.3
* [`146f08b8`](https://github.com/NixOS/nixpkgs/commit/146f08b87ad2fa039d0be5e8299dd80ab4ceb745) maintainers: add potb
* [`92a6247b`](https://github.com/NixOS/nixpkgs/commit/92a6247bc23a9242a59b4656e7ea635cb4640197) nixos/ssh: don't write addressfamily with default value in config
* [`a6ccb54a`](https://github.com/NixOS/nixpkgs/commit/a6ccb54ac291b98dc00e96cef989c88fd38e3340) linuxPackages.openafs: Patch for Linux kernel 6.9
* [`73edf6a8`](https://github.com/NixOS/nixpkgs/commit/73edf6a87f4365811e0b0f858ca40574eeb347d8) ubuntu-sans: init at 1.004
* [`c5fac654`](https://github.com/NixOS/nixpkgs/commit/c5fac65484102af057ee548929446712bac34639) ubuntu-sans-mono: init at 1.004
* [`03f1e583`](https://github.com/NixOS/nixpkgs/commit/03f1e5833a21d6593c007cd42bada17c356dde25) ubuntu-classic: init at 0.83-6ubuntu2
* [`b3c8c0e4`](https://github.com/NixOS/nixpkgs/commit/b3c8c0e48166f164839ead7a20fe85f3fde90d10) ubuntu_font_family: replace with ubuntu-classic
* [`9dbe4855`](https://github.com/NixOS/nixpkgs/commit/9dbe4855b1aac0b59f3433f800599a0cbf66f597) fnott: 1.5.0 -> 1.6.0
* [`93bfcaf0`](https://github.com/NixOS/nixpkgs/commit/93bfcaf0ef6cc3183e67dd3fa655a3ebdd702e8a) dep2nix: remove
* [`7f3fcae7`](https://github.com/NixOS/nixpkgs/commit/7f3fcae7214f19283a046963418c0c973aaa2d4d) mdt: init at 0.8.1
* [`01b15909`](https://github.com/NixOS/nixpkgs/commit/01b159092f9ff80ae76fb40ee61a342729d6160e) nixos/proxmox-lxc: fix ping in unprivileged LXCs
* [`8d704b09`](https://github.com/NixOS/nixpkgs/commit/8d704b095ec311d1b01d0f02cfd7753ea6368a10) rivercarro: 0.3.0 -> 0.4.0
* [`9080e906`](https://github.com/NixOS/nixpkgs/commit/9080e9067e5101d6c3f116b8a67162c77dbeb8b8) linuxPackages.broadcom_sta: remove i686-build-failure.patch since it was applied upstream
* [`d4854eb6`](https://github.com/NixOS/nixpkgs/commit/d4854eb63289740cc96c7063a0fc9be8f63016cd) linuxPackages.broadcom_sta: use git format-patch to make all the patches trivially applicable
* [`5d78a892`](https://github.com/NixOS/nixpkgs/commit/5d78a89291f2dc45f26776ed4d74e31b5106f6b9) linuxPackages.broadcom_sta: amend a patch that introduced a local copy of eth_hw_addr_set; it is no longer needed
* [`d432fc39`](https://github.com/NixOS/nixpkgs/commit/d432fc39ff65f0f9945836f21e0db9794e7d6d8a) librewolf: remove redundant build flag that reveals "LibreWolf" in the user agent string when resistFingerprinting is disabled
* [`ff584098`](https://github.com/NixOS/nixpkgs/commit/ff584098ef54faf57bf34146b85edce49874c78c) man-pages: 6.9 -> 6.9.1
* [`a5deaf9e`](https://github.com/NixOS/nixpkgs/commit/a5deaf9e935f716ed3200c37abc656108c21cfad) nixos/kubernetes: adds argument to mkCert defaulting to kubernetes group
* [`0ce09b94`](https://github.com/NixOS/nixpkgs/commit/0ce09b94c307c5fa7e54a51c0ddc770c1d5ad079) irpf: add update script
* [`df0ba5c9`](https://github.com/NixOS/nixpkgs/commit/df0ba5c92d6853e48101814f585af52df253850e) irpf: move derivation to /pkgs/by-name/ir/irpf
* [`0bd8b0ed`](https://github.com/NixOS/nixpkgs/commit/0bd8b0ed2f639f9d37cb275ea540ebb35ca31a39) irpf: change from using rec to finalAttrs syntax
* [`cef69659`](https://github.com/NixOS/nixpkgs/commit/cef69659f9e0143d47381d3a4df56fe35f4b2edf) irpf: 2024-1.1 -> 2024-1.2
* [`a7e1ea97`](https://github.com/NixOS/nixpkgs/commit/a7e1ea970b92794c98c3a40c331144fc61bd7aff) nixos/perlless: enable switch-to-configuration-ng for perlless profile
* [`317c9562`](https://github.com/NixOS/nixpkgs/commit/317c95620a59bd2b53b508424a2f30e01da0343a) switch-to-configuration-ng: add a README
* [`0144b6a2`](https://github.com/NixOS/nixpkgs/commit/0144b6a270f25097d0db2f2b773de1d8862eafea) nixos/switch-to-configuration: add a note for future modifications
* [`6f1f3c81`](https://github.com/NixOS/nixpkgs/commit/6f1f3c810dc147ae3dfa07265f3ed6e27b2c3ff0) nixos/perlless: fix perl showing up!
* [`e761e8a9`](https://github.com/NixOS/nixpkgs/commit/e761e8a9798f6f40a3b12682cc88d16097d2e6e0) hadoop: init 3.4, drop 3.2
* [`6b8f92c0`](https://github.com/NixOS/nixpkgs/commit/6b8f92c020ae444d3952991eb4b5c39a6ad3ea87) terramate: 0.8.4 -> 0.9.0
* [`a86d369b`](https://github.com/NixOS/nixpkgs/commit/a86d369b5a2252df98ba137374c58836d0753625) python3.pkgs.django-picklefield: 3.0.1 -> 3.2.0
* [`141358a6`](https://github.com/NixOS/nixpkgs/commit/141358a69b82ad66b9956296d28451b4866f88d5) lighthouse: 4.6.0 -> 5.2.0
* [`64e884c3`](https://github.com/NixOS/nixpkgs/commit/64e884c3a1a35d29aa82ea3e24382efe450cc16d) nixos/lighthouse: update networks for 5.2.0
* [`81bce575`](https://github.com/NixOS/nixpkgs/commit/81bce575de62d8a0212eded2afbbae9319f4751a) flatpak: 1.14.6 -> 1.14.8
* [`7828cfd9`](https://github.com/NixOS/nixpkgs/commit/7828cfd939a4521ad8a6019ee0476d41d921bf14) spot: migrate to by-name
* [`dcd96f46`](https://github.com/NixOS/nixpkgs/commit/dcd96f460247de8ef79797b11c0f009a27638f70) spot: format with nixfmt
* [`4a67d03c`](https://github.com/NixOS/nixpkgs/commit/4a67d03c1d72d576d78efb5e00127ecd02d82765) spot: adopt
* [`c20f3b70`](https://github.com/NixOS/nixpkgs/commit/c20f3b70abe262daa3eaad9c4a79cb0ddc70e9f2) nixos/proxmox-lxc: allow importing module without activation, for used in mixed machine clusters
* [`c90d5099`](https://github.com/NixOS/nixpkgs/commit/c90d50992ee037c77aa0964c07af95aea9384c9d) ngrok: 3.9.0 -> 3.10.1
* [`3b9f4e91`](https://github.com/NixOS/nixpkgs/commit/3b9f4e913bed991b3009bbfaf6182dcd319928a3) eudic: init at 13.5.2
* [`42b1bc89`](https://github.com/NixOS/nixpkgs/commit/42b1bc89a230a74d5cf7a7db6d60a78621a0b036) firefly-iii: Streamlined derivation
* [`94644ca8`](https://github.com/NixOS/nixpkgs/commit/94644ca8aacba4770862554f1eb949c57fc62f9b) myrescue: add myrescue-bitmap2ppm, myrescue-stat
* [`e37145d7`](https://github.com/NixOS/nixpkgs/commit/e37145d7212f04f23d45af5293d42a1b073fa3cf) netpbm: 11.6.1 -> 11.7.0
* [`41844ddf`](https://github.com/NixOS/nixpkgs/commit/41844ddf269f3100aa6712434f330732688a90e3) plex-desktop: add detroyejr to maintainers list
* [`1e68bdf3`](https://github.com/NixOS/nixpkgs/commit/1e68bdf3a42e6a7a713a265405fd5a04976cae4f) nixos/udev: Fix grep: warning: stray \ before /
* [`4e27e900`](https://github.com/NixOS/nixpkgs/commit/4e27e900c9165d6fbd753534ef82533e4a95757b) mkl: fix self-inclusive src
* [`882e48ea`](https://github.com/NixOS/nixpkgs/commit/882e48ea1aec2cf020aaf3489c932edcdbf62d80) emacsPackages: remove __attrsFailEvaluation
* [`e7808666`](https://github.com/NixOS/nixpkgs/commit/e7808666ea6abbe5fb9037d72710df77b1be6b01) nixos/tests/darling-dmg: init
* [`90806244`](https://github.com/NixOS/nixpkgs/commit/9080624466f5dbdcde31d8d2738e937d95d2d87b) darling-dmg: 1.0.4+git20200427 -> 1.0.4-unstable-2023-07-26
* [`49609964`](https://github.com/NixOS/nixpkgs/commit/496099641c37292cc00e438336fec1cb5f0ceeb7) darling-dmg: migrate to by-name
* [`7370f5d0`](https://github.com/NixOS/nixpkgs/commit/7370f5d0fa0b3e791eeda492f9c595ef9775b430) python3Packages.formbox: 0.4.3 -> 1.0.0
* [`09d92586`](https://github.com/NixOS/nixpkgs/commit/09d92586514f91ae2bfa8bcb2d45efc7eee85091) python312Packages.huawei-lte-api: 1.8.1 -> 1.9.3
* [`f1040f41`](https://github.com/NixOS/nixpkgs/commit/f1040f412cada833739aba80b004667dec8eb978) python312Packages.krakenex: 2.2.1 -> 2.2.2
* [`3a2073ec`](https://github.com/NixOS/nixpkgs/commit/3a2073ec5b3a2ea9aabd99a246212cdd891541b1) treewide: remove printed 'ls'
* [`aa5ebae1`](https://github.com/NixOS/nixpkgs/commit/aa5ebae159f732012dc6164b08c14a97637c9a62) programs/kde-pim: init
* [`4169ba89`](https://github.com/NixOS/nixpkgs/commit/4169ba8920a9c1110783811274ee777ccf838dfb) nixos/plasma6: enable programs.kde-pim by default
* [`5f752484`](https://github.com/NixOS/nixpkgs/commit/5f7524844ee7790250a22254f6e038686dc6c168) nss_latest: 3.101.1 -> 3.102
* [`c1f87bca`](https://github.com/NixOS/nixpkgs/commit/c1f87bcaccd1c19cfbc3eacebe520f5c31c6846a) mysql_jdbc: 8.4.0 -> 9.0.0
* [`686c27bf`](https://github.com/NixOS/nixpkgs/commit/686c27bf09b1b28fb23834c053688b8cd65c84f8) mdbook: remove rec and with
* [`a02f964d`](https://github.com/NixOS/nixpkgs/commit/a02f964d4cda4ead48814e21136490646eee41f7) ldc: split includes to separate output
* [`c9196e15`](https://github.com/NixOS/nixpkgs/commit/c9196e150a1597d8acbbd1d966cbdabf06c99b35) spade: 0.8.0 -> 0.9.0
* [`1ca3d78e`](https://github.com/NixOS/nixpkgs/commit/1ca3d78e13b9c88790c7eae9516c0f3c0f9ff000) spot: refactor
* [`1d9b7eca`](https://github.com/NixOS/nixpkgs/commit/1d9b7ecaed4af5318711eebcdf4d8c17e65784b4) spot: add `appstream-glib` to nativeBuildInputs
* [`412f4852`](https://github.com/NixOS/nixpkgs/commit/412f485211e10aa4587b24c98235075ab824000e) graylog-6_0: init at 6.0.4
* [`ed904c25`](https://github.com/NixOS/nixpkgs/commit/ed904c256fcd9553ca91ef70602d0d6465689dda) nixos/graylog: add option dataDir
* [`fb79d5e2`](https://github.com/NixOS/nixpkgs/commit/fb79d5e2f4dc94c150c816d23763ce4a6b282246) maintainers: add camcalaquian
* [`f4c81f91`](https://github.com/NixOS/nixpkgs/commit/f4c81f9134038562fac88c6a308f96fb942ad00a) snipe-it: 7.0.6 -> 7.0.7
* [`76afcbdc`](https://github.com/NixOS/nixpkgs/commit/76afcbdc30fd2d2a2dca07e01658c0f19625f33a) pixelfed: 0.12.1 -> 0.12.3
* [`88fb6d37`](https://github.com/NixOS/nixpkgs/commit/88fb6d37e393a8d7f4214953940a678541a80892) nixos/radicle: init services
* [`bf0b7d6d`](https://github.com/NixOS/nixpkgs/commit/bf0b7d6d2d0d3d15d7161278d2936235e4454d2d) qbittorrent-enhanced: init at 4.6.5.10
* [`7e7852d1`](https://github.com/NixOS/nixpkgs/commit/7e7852d166b535c3f320f3d1bf0ecbfd9aad8544) qdrant: 1.9.7 -> 1.10.0
* [`82ab3a87`](https://github.com/NixOS/nixpkgs/commit/82ab3a870f042dc86df8106b4ec63f42e5ab2be6) imageworsener: move to `pkgs/by-name`
* [`a023d4df`](https://github.com/NixOS/nixpkgs/commit/a023d4dff6a60cb4bae2053917c5c7d1c0f59b74) imageworsener: format with `nixfmt-rfc-style`
* [`cd4fb1fe`](https://github.com/NixOS/nixpkgs/commit/cd4fb1fe7a68691c844c61008a664935a188cde2) ugs: 2.1.7 -> 2.1.8
* [`4116344d`](https://github.com/NixOS/nixpkgs/commit/4116344dc909925f4305b2d3a177d9b38d4af8ca) matrix-hookshot: 5.3.0 -> 5.4.1
* [`442f0d7e`](https://github.com/NixOS/nixpkgs/commit/442f0d7e6905374c1a10c123b74e14d43919875d) oxlint: 0.2.15 -> 0.5.2
* [`0433f701`](https://github.com/NixOS/nixpkgs/commit/0433f701615b6f18c5aa7624eeb2f979a2b2012f) nagstamon 3.2.1 > 3.14.0
* [`e7442f53`](https://github.com/NixOS/nixpkgs/commit/e7442f53ad2516c9b040ef00e002dc291a4af397) opera: 111.0.5168.43 -> 111.0.5168.61
* [`bf0c8956`](https://github.com/NixOS/nixpkgs/commit/bf0c89562b7908da55b7ced4db700ddf7c2be08d) qwerty-fr: apply review suggestions
* [`3c4dc205`](https://github.com/NixOS/nixpkgs/commit/3c4dc205fe56b307750a3e0e0f34ff4528db1dcd) signal-desktop-beta: 7.15.0-beta.1 -> 7.16.0-beta.1
* [`7fa52244`](https://github.com/NixOS/nixpkgs/commit/7fa522446b3b6189e71a5bce38d8e41398e0bcb6) petsc: 3.21.0 -> 3.21.3
* [`c0a7daff`](https://github.com/NixOS/nixpkgs/commit/c0a7daff965087c15e7e4c7d2200ed3773e457f5) ukmm: 0.11.1 -> 0.12.1
* [`6b75aa0a`](https://github.com/NixOS/nixpkgs/commit/6b75aa0af800b0cc6d2a2d6aef160a77c0660240) adguardhome: 0.107.51 -> 0.107.52
* [`a231b6ea`](https://github.com/NixOS/nixpkgs/commit/a231b6ea37668c1b7abdd40edc095785506d8fff) llama-cpp: 3260 -> 3328
* [`19123264`](https://github.com/NixOS/nixpkgs/commit/19123264df5e839c03615cb9813395c6313298ca) kavita: 0.8.1 -> 0.8.2
* [`bee394b9`](https://github.com/NixOS/nixpkgs/commit/bee394b999ba9f3456914072b51a48dd052a11f5) prowlarr: 1.19.0.4568 -> 1.20.1.4603
* [`8eb0fc8d`](https://github.com/NixOS/nixpkgs/commit/8eb0fc8d1b11abfc8934b4ffffd4c5c2a274fa2b) gnucash: 5.6 -> 5.8
* [`08cb23c8`](https://github.com/NixOS/nixpkgs/commit/08cb23c875953f3278a2ed3e06e9fe46b9e2d61a) saxon-he: 12.4 -> 12.5
* [`cdbac5df`](https://github.com/NixOS/nixpkgs/commit/cdbac5df1225e951eb94253ec3d5a4195852606a) astyle: 3.5.1 -> 3.5.2
* [`5ba8d3a0`](https://github.com/NixOS/nixpkgs/commit/5ba8d3a083a9e5e70bdb97b92df63076c8ae6611) mysql-shell-innovation: 8.4.0 -> 9.0.0
* [`522ec18e`](https://github.com/NixOS/nixpkgs/commit/522ec18ea2416fce26ca430b1c7ef35448910ade) py-spy: pin python311
* [`4d29aa8d`](https://github.com/NixOS/nixpkgs/commit/4d29aa8d5245652920a400a7ed6aec1a0581aca7) mysql-shell_8: init at 8.4.1
* [`7e47a024`](https://github.com/NixOS/nixpkgs/commit/7e47a024dcaeea12a0440c60568eae3f8fb9503b) mysql-shell: point to mysql-shell_8
* [`51c347bd`](https://github.com/NixOS/nixpkgs/commit/51c347bd13f2654de9b203dbbd388bb7e032fdaf) python3Packages.kserve: relax psutil
* [`fedc0b23`](https://github.com/NixOS/nixpkgs/commit/fedc0b231a6b34f03d08d7f5723184ff0605f5e3) openjph: init at 0.14.2
* [`6d942c64`](https://github.com/NixOS/nixpkgs/commit/6d942c64031031b41880722d77deb316d16debbd) python311Packages.approvaltests: 12.2.1 -> 14.0.0
* [`0cbbd28a`](https://github.com/NixOS/nixpkgs/commit/0cbbd28a4ddffadef0098d9d8c2fc87fd922374a) python311Packages.robotframework-pythonlibcore: 4.4.0 -> 4.4.1
* [`0dc4e4ce`](https://github.com/NixOS/nixpkgs/commit/0dc4e4ceb7e3ddb65919b8f60750989da50f0f60) python311Packages.robotframework-seleniumlibrary: 6.4.0 -> 6.5.0
* [`805943e5`](https://github.com/NixOS/nixpkgs/commit/805943e5fa5e0985ad01cc691327a4382a7f3d99) python312Packages.pykeepass: 4.0.7 -> 4.1.0
* [`fa262929`](https://github.com/NixOS/nixpkgs/commit/fa262929a3e3598c55e00cedd2577414906b833f) pulumi: 3.99.0 -> 3.122.0
* [`3c4a1253`](https://github.com/NixOS/nixpkgs/commit/3c4a12537b0be1013eaa6c03f4627b4141f0f1f9) moodle-dl: 2.3.9 -> 2.3.11
* [`f1828861`](https://github.com/NixOS/nixpkgs/commit/f18288618beb76a426f06f9e120d768a6dff8a7b) python312Packages.dnslib: 0.9.24 -> 0.9.25
* [`49a526b9`](https://github.com/NixOS/nixpkgs/commit/49a526b98a92d02812ab46906a1782410ecc91d7) appflowy: 0.6.2 -> 0.6.3
* [`02083c79`](https://github.com/NixOS/nixpkgs/commit/02083c79cfa2a85491f2b5bf38793a023753591b) imageworsener: modernize
* [`fdb840f0`](https://github.com/NixOS/nixpkgs/commit/fdb840f002c1d524b80464b8ced6f779e8918aee) imageworsener: add `longDescription`
* [`db313ef3`](https://github.com/NixOS/nixpkgs/commit/db313ef39f4e90f50a9d66b0211c78248267ab5c) imageworsener: fetch source from GitHub
* [`8e484a4c`](https://github.com/NixOS/nixpkgs/commit/8e484a4cd100b11b5968d4ff335b55237a9b69f5) imageworsener: fix tests
* [`65c851cd`](https://github.com/NixOS/nixpkgs/commit/65c851cd7523c669b8fb25236b1c48283a2f43ec) vmTools: allow qemu to be overridden via customQemu argument
* [`646d8a45`](https://github.com/NixOS/nixpkgs/commit/646d8a4577477acd8f07db6d93bde17129f1507c) python311Packages.mayavi: unbreak, set mainProgram
* [`0cbb90ea`](https://github.com/NixOS/nixpkgs/commit/0cbb90ea939e8e1d41df89c9ebaad1c725ea6a29) cpplint: 1.5.5 -> 1.6.1
* [`adb0bda1`](https://github.com/NixOS/nixpkgs/commit/adb0bda124e17e7bc81bd02f257de92517ae12f0) pyinotify: add pythonImportsCheck for itself
* [`7ea81e03`](https://github.com/NixOS/nixpkgs/commit/7ea81e03624a5d28ddab807d1c145de241762911) pyinotify: patch to skip asyncore for python 3.12+
* [`3aaf5355`](https://github.com/NixOS/nixpkgs/commit/3aaf535569297cfde6cd70328285592cbf8e4f4e) mbuffer: 20240107 -> 20240707
* [`bb7e6e1a`](https://github.com/NixOS/nixpkgs/commit/bb7e6e1ac5e4bb4b201fb9da6cb1d7823ba71e0b) python312Packages.stanio: 0.5.0 -> 0.5.1
* [`484b5022`](https://github.com/NixOS/nixpkgs/commit/484b50224d820a4445ad31b3a07e710ec7b9e628) imgproxy: 3.24.1 -> 3.25.0
* [`2308f886`](https://github.com/NixOS/nixpkgs/commit/2308f886079614235420fdaee577aecade88f411) chatty: 0.8.3 -> 0.8.4
* [`fd0f5d38`](https://github.com/NixOS/nixpkgs/commit/fd0f5d381fba6458f3443ecc9b728aafe632327c) swagger-codegen3: 3.0.57 -> 3.0.58
* [`690f3871`](https://github.com/NixOS/nixpkgs/commit/690f3871c207c6b2bf4ba8d3afc47c9f8c88aeb4) pb: 0.5.0 -> 0.5.1
* [`f9d0b50c`](https://github.com/NixOS/nixpkgs/commit/f9d0b50c8a734144b1d8fdbad35a041fe77e4c34) quarto: 1.5.53 -> 1.5.54
* [`f42f07ba`](https://github.com/NixOS/nixpkgs/commit/f42f07bad242e507d0236cfd392a5829a7c98cdd) rsyslog: 8.2404.0 -> 8.2406.0
* [`e7fde690`](https://github.com/NixOS/nixpkgs/commit/e7fde69078434e06d28cf14321c938ba6ea7a171) metabase: 0.50.8 -> 0.50.10
* [`b2c50a59`](https://github.com/NixOS/nixpkgs/commit/b2c50a596d397b6ff5d51a0ec83aaa609c18310c) python312Packages.pytools: 2024.1.5 -> 2024.1.6
* [`603baa1f`](https://github.com/NixOS/nixpkgs/commit/603baa1f83dfc41b05a539fe923ec4295bc51306) atmos: 1.83.0 -> 1.83.1
* [`627e00a6`](https://github.com/NixOS/nixpkgs/commit/627e00a6279e71fceec4ce2375ed164da7f1a7ac) transcribe: 9.41.0 -> 9.41.2
* [`5d642d9f`](https://github.com/NixOS/nixpkgs/commit/5d642d9f502a02e82001c064472c277742fbba0a) python312Packages.pydata-sphinx-theme: 0.15.3 -> 0.15.4
* [`d3bba1d5`](https://github.com/NixOS/nixpkgs/commit/d3bba1d575a3b84b389235b59bf854def28a95f6) font-manager: 0.8.9 -> 0.9.0
* [`ad7fa788`](https://github.com/NixOS/nixpkgs/commit/ad7fa788a5f37668e5ab41680bcf5ccd0a4d69fc) errbot: 6.1.9 -> 6.2.0
* [`81756aab`](https://github.com/NixOS/nixpkgs/commit/81756aaba124e580e8826c65e466ec3a6a7e8621) dcm2niix: 1.0.20230411 -> 1.0.20240202
* [`56295005`](https://github.com/NixOS/nixpkgs/commit/56295005ef2da06caad300824f2a2026cc3663de) oathkeeper: init at 0.40.7
* [`a572d515`](https://github.com/NixOS/nixpkgs/commit/a572d5151ca4c9bb67f668fa5644800302b50a22) nixos/prometheus-nginxlog-exporter: define types of inner options
* [`1a4bd06a`](https://github.com/NixOS/nixpkgs/commit/1a4bd06ac434a68428bea43eb866449c3d2d5831) evcc: 0.128.1 -> 0.128.2
* [`b73a0183`](https://github.com/NixOS/nixpkgs/commit/b73a0183a2eda73f549ef9b8af8c4e12c97c0eab) treewide: remove unused args
* [`50d5bc7b`](https://github.com/NixOS/nixpkgs/commit/50d5bc7b2d7ee10d56f93af4871a789422c1965d) treewide: replace python3 with python within python package set
* [`beaea78b`](https://github.com/NixOS/nixpkgs/commit/beaea78be5bb9964b4854f54e1d76e53df6dc3eb) python311Packages.llm: fix build
* [`19d8a780`](https://github.com/NixOS/nixpkgs/commit/19d8a7800f9b628b572d9276c52fe59e3b1d47e4) python311Packages.python-secp256k1-cardano: fix build
* [`3c7638a7`](https://github.com/NixOS/nixpkgs/commit/3c7638a736c76dc2eb10752afe9f4de32b3d8020) python311Packages.tabcmd: use correct interpreter version
* [`bedf04b1`](https://github.com/NixOS/nixpkgs/commit/bedf04b195769f70197ebac995697bef881072f9) python311Packages.tabcmd: mark broken
* [`c7e90d9f`](https://github.com/NixOS/nixpkgs/commit/c7e90d9f2042ebc59e7340a131528579f5b60bdf) vttest: 20240218 -> 20240708
* [`1dfc405d`](https://github.com/NixOS/nixpkgs/commit/1dfc405d10f33a4c39e7b7dac803ad3e8a699cb1) monetdb: 11.49.9 -> 11.49.11
* [`63c623c3`](https://github.com/NixOS/nixpkgs/commit/63c623c3ffc67db74de65a8ccc23a559b05126c9) freeradius: 3.2.4 -> 3.2.5
* [`256a0b89`](https://github.com/NixOS/nixpkgs/commit/256a0b89d919873981f0132bc8e2d7976b6164d2) ballerina: 2201.9.1 -> 2201.9.2
* [`1a933234`](https://github.com/NixOS/nixpkgs/commit/1a933234992b1d82c4628d0542eaf416e9ac6e46) containerlab: 0.55.1 -> 0.56.0
* [`1cc927dd`](https://github.com/NixOS/nixpkgs/commit/1cc927dd629620adf681c0d5d8c411acdcc82f82) python312Packages.types-protobuf: 5.26.0.20240422 -> 5.27.0.20240626
* [`bd3a7b66`](https://github.com/NixOS/nixpkgs/commit/bd3a7b6617565f4e103653360800f01d40a61333) python3Packages.ledgerwallet: 0.2.4 -> 0.5.0
* [`c852c7b5`](https://github.com/NixOS/nixpkgs/commit/c852c7b5e0de2e29bb0d2dee5049c54cbc4e14ea) networkmanager: 1.48.2 -> 1.48.4
* [`736c1c7f`](https://github.com/NixOS/nixpkgs/commit/736c1c7f89305dffae66ebd94121f881fb59eb2a) glasskube: 0.11.0 -> 0.13.0
* [`c359e73b`](https://github.com/NixOS/nixpkgs/commit/c359e73b8ea1a89eba75632c97aa82ae9f28cab9) n8n: refactor build process
* [`e33042a9`](https://github.com/NixOS/nixpkgs/commit/e33042a9fbff7d136154c3a549c2408e81a617e6) n8n: 1.46.0 -> 1.48.3
* [`2d68785b`](https://github.com/NixOS/nixpkgs/commit/2d68785b6e8cd91d52d335bc36d96e2175cb2f82) python312Packages.opensearch-py: fix build
* [`3ded3277`](https://github.com/NixOS/nixpkgs/commit/3ded32777177c123f2a717caa244bbe9e2e4dd40) anki: disable test_create_open
* [`2b888575`](https://github.com/NixOS/nixpkgs/commit/2b888575da870d7143b782ace7dcc2fdb51c5f64) github-desktop: 3.3.12 -> 3.4.2
* [`c7524db0`](https://github.com/NixOS/nixpkgs/commit/c7524db0a8e619487cb164537cfa2bc550568fa8) tradingview: 2.7.7 -> 2.8.1
* [`8e8a9e16`](https://github.com/NixOS/nixpkgs/commit/8e8a9e16143d6b53131bf7e74bd0de76f8370015) maintainers: add averyanalex
* [`d69d6aa3`](https://github.com/NixOS/nixpkgs/commit/d69d6aa32d29e42ef9b93cbfb5735f2f7c4a80e9) seabird: 0.3.2 -> 0.4.2
* [`a4472dc7`](https://github.com/NixOS/nixpkgs/commit/a4472dc7ab496888cd3449c72617efaf510c7787) cassette: init at 0.2.0
* [`335505c0`](https://github.com/NixOS/nixpkgs/commit/335505c0e37f976d2662363a4bfc87dfe21a2922) cewler: init at 1.2.0
* [`caccd8a8`](https://github.com/NixOS/nixpkgs/commit/caccd8a8b2cd1fae2a2e5445af6112e5874c81da) python311Packages.corner: init at 2.2.2
* [`ab43e16f`](https://github.com/NixOS/nixpkgs/commit/ab43e16f7d45ce0e3a3c71a9b4ff05d1a4d4e3e3) python311Packages.evosax: init at 0.1.6
* [`e0ce73da`](https://github.com/NixOS/nixpkgs/commit/e0ce73daf0709756f22b1953a4fca67e43a11486) python311Packages.flowmc: init at 0.3.4
* [`4c07a740`](https://github.com/NixOS/nixpkgs/commit/4c07a740f43135887fc3615e15cc6a7b91563be9) rsshub: init at 0-unstable-2024-07-08
* [`6bbd9f56`](https://github.com/NixOS/nixpkgs/commit/6bbd9f5625ee00dc3d49748cd17f3ac2d6ade38d) cassette: reformat
* [`aacbcb19`](https://github.com/NixOS/nixpkgs/commit/aacbcb197d2047ed86208e64692e86a6c05b59cd) distribution: 3.0.0-alpha.1 -> 3.0.0-beta.1
* [`c917ea43`](https://github.com/NixOS/nixpkgs/commit/c917ea43eb2bf119958fca67644af514638d1a74) cassette: enable strictDeps
* [`edf67597`](https://github.com/NixOS/nixpkgs/commit/edf67597b3d71285094eb9cf6be8a120484d429e) vscode-extensions.rust-lang.rust-analyzer: 0.3.1850 -> 0.3.2029
* [`4c535b9c`](https://github.com/NixOS/nixpkgs/commit/4c535b9c43741b5d4d01a52f14e1f2586051507f) gittuf: 0.4.0 -> 0.5.1
* [`1df86971`](https://github.com/NixOS/nixpkgs/commit/1df869716369d4c178bec55e2fdb099826ac968f) python3Packages.python-redis-locks: fix tests for django support
* [`2d50c5eb`](https://github.com/NixOS/nixpkgs/commit/2d50c5eb6860ea49ac0f3995448fef3b268c39ef) molecule: 24.6.1 -> 24.7.0
* [`f6ccd9d4`](https://github.com/NixOS/nixpkgs/commit/f6ccd9d45106f1dcd631c30b595db1f92b7b65b5) pocketbase: 0.22.15 -> 0.22.17
* [`4f5c6cc3`](https://github.com/NixOS/nixpkgs/commit/4f5c6cc337b3f186ec221f0c7ceca89ae9602c51) python311Packages.suds: init at 1.1.2
* [`2a3320e0`](https://github.com/NixOS/nixpkgs/commit/2a3320e08b6a285594e383a7b21e77f12ff07bd4) chirp: 0.4.0-unstable-2024-05-10 -> 0.4.0-unstable-2024-07-05
* [`a445123f`](https://github.com/NixOS/nixpkgs/commit/a445123f0c8c29ff940dc146f791a3530e42cab3) chirp: add maintainer wrmilling
* [`b5228d2b`](https://github.com/NixOS/nixpkgs/commit/b5228d2b3a77368ac5faa57403509ac88f80f44c) xwayland-satellite: correctly pass xwayland dependency in PATH
* [`fbb80bc6`](https://github.com/NixOS/nixpkgs/commit/fbb80bc6b38f75c36e1fe30708c5920469ddf991) tilt: 0.33.13 -> 0.33.17
* [`2e47e43b`](https://github.com/NixOS/nixpkgs/commit/2e47e43b89a6849c7a060ce75c9ba55d983cac1c) silverbullet: 0.7.7 -> 0.8.1
* [`ea92f722`](https://github.com/NixOS/nixpkgs/commit/ea92f7224417a42a971459557734fda8bee2b315) maintainers: add ulysseszhan
* [`64a4b5a2`](https://github.com/NixOS/nixpkgs/commit/64a4b5a25068ab49d20839e490095f1a82044926) py-spy: 0.3.14 -> 0.3.14-unstable-2024-02-27
* [`2a5de4b0`](https://github.com/NixOS/nixpkgs/commit/2a5de4b0eedba3f52332360e292e10b0b48183da) python312Packages.manhole: 1.8.0 -> 1.8.1
* [`644ffe62`](https://github.com/NixOS/nixpkgs/commit/644ffe6218bd70b22d367654eab2155f406cd398) feed2imap-go: 1.7.0 -> 1.7.2
* [`adcc0e3c`](https://github.com/NixOS/nixpkgs/commit/adcc0e3c8fe9592daf264223fe61546bf1377ab5) exim: 4.97.1 -> 4.98
* [`a43f0d07`](https://github.com/NixOS/nixpkgs/commit/a43f0d07b2fdfde753bd9315c10371c3573632a9) php81Packages.phpspy: 0.6.0 -> 0.7.0
* [`581eb8bc`](https://github.com/NixOS/nixpkgs/commit/581eb8bcc8f1b7cb969156267c7fdccbd38c1188) rinutils: 0.10.2 -> 0.10.3
* [`ab8a9040`](https://github.com/NixOS/nixpkgs/commit/ab8a9040533adc6451a0210d33c936995216b743) cargo-shear: 1.0.0 -> 1.1.0
* [`e6b4fde9`](https://github.com/NixOS/nixpkgs/commit/e6b4fde9918d81d5c4a66c9c6d9eb68239a50e1c) linuxkit: 1.2.0 -> 1.3.0
* [`d6eb80a5`](https://github.com/NixOS/nixpkgs/commit/d6eb80a5214d5ccc1ee5b0ccf8a22ea681ac97ef) pioneer: 20240314 -> 20240710
* [`c3aa859e`](https://github.com/NixOS/nixpkgs/commit/c3aa859ebcd96a40141e08be64e17bb2d4a2da08) lollypop: switch youtubeSupport dependency to yt-dlp
* [`6baa815d`](https://github.com/NixOS/nixpkgs/commit/6baa815d01faa86ae50a07a715fe6589ab0ed812) azuredatastudio: 1.44.1 -> 1.48.1
* [`9bb024aa`](https://github.com/NixOS/nixpkgs/commit/9bb024aa1f864f77112299d7ac170a797d15d480) firewalld-gui: 2.1.2 -> 2.2.0
* [`cce045c5`](https://github.com/NixOS/nixpkgs/commit/cce045c5207ef83ff8caacc9dabfc0c579ab43a0) libsolv: 0.7.29 -> 0.7.30
* [`e7ded0a5`](https://github.com/NixOS/nixpkgs/commit/e7ded0a5e0ae70e8c4e0058971e822f573a02609) retrospy: 6.4.8 -> 6.5
* [`42e552d2`](https://github.com/NixOS/nixpkgs/commit/42e552d2ff56453d07a827bf2701f23007cdf815) jmusicbot: 0.4.1 -> 0.4.2
* [`f1b946d0`](https://github.com/NixOS/nixpkgs/commit/f1b946d0b0c185e78df5ce1c71a42934a4562795) gnmic: 0.37.0 -> 0.38.0
* [`d6ec16b2`](https://github.com/NixOS/nixpkgs/commit/d6ec16b28d7692fa11709e8ab44aed4f5462d932) vscode-extensions.sourcery.sourcery: 1.19.0 -> 1.21.0
* [`fbb2c488`](https://github.com/NixOS/nixpkgs/commit/fbb2c488860b9187f361d65c01152d3bd5a72d0c) wireshark: 4.2.5 -> 4.2.6
* [`535597b7`](https://github.com/NixOS/nixpkgs/commit/535597b70c6c43b94408961be7680623e23b8d63) xwayland-satellite: add sodiboo as maintainer
* [`c6caa09b`](https://github.com/NixOS/nixpkgs/commit/c6caa09ba264a3f865bcc23339c4775f98ad28eb) fastfetch: 2.17.2-> 2.18.1
* [`8d9ef579`](https://github.com/NixOS/nixpkgs/commit/8d9ef57935f30d4e4c8d94f41e8c8b19ee1d1183) python311Packages.whenever: 0.5.2 -> 0.6.1
* [`11c2e561`](https://github.com/NixOS/nixpkgs/commit/11c2e561b6e7554892efe7aaec3aebafc7244c51) juju: 3.5.1 -> 3.5.2
* [`aeed98d0`](https://github.com/NixOS/nixpkgs/commit/aeed98d0da2cd186907f579af5b77eb192d33f03) mcfly: 0.9.0 -> 0.9.1
* [`9485537d`](https://github.com/NixOS/nixpkgs/commit/9485537de608224d1751ebcbf88ac55e56bf24fd) clamav: Fix check failure of clamscan no tests
* [`4d75a540`](https://github.com/NixOS/nixpkgs/commit/4d75a540cbad21476da8b4a167d7538166a96d16) matrix-media-repo: 1.3.4 -> 1.3.6
* [`e5090a50`](https://github.com/NixOS/nixpkgs/commit/e5090a50af81e22b280ebb9994d744d62b859126) python312Packages.makefun: 1.15.2 -> 1.15.4
* [`3b744c95`](https://github.com/NixOS/nixpkgs/commit/3b744c95861509bcb4f2a892e34039ce334c6d11) commitizen-go: init at 1.0.3
* [`dd42ff82`](https://github.com/NixOS/nixpkgs/commit/dd42ff820e5b0cb6ecb78b37d763b06dbb780d9c) bruno: fix css issue with patch file
* [`1112448a`](https://github.com/NixOS/nixpkgs/commit/1112448a1a2760ceae3db290221da7eb299c33fa) python312Packages.python-lsp-server: avoid qt dependencies
* [`2aff719a`](https://github.com/NixOS/nixpkgs/commit/2aff719a093e2efb8dd889f8014b82847121458b) unison-ucm: 0.5.22 -> 0.5.24
* [`bfb000ff`](https://github.com/NixOS/nixpkgs/commit/bfb000ff685cbbefb5433eace6e2d3652118d0c7) freecad: fix build
* [`2813a59c`](https://github.com/NixOS/nixpkgs/commit/2813a59c9d876fba733e1065d052bdbac2929974) pricehist: 1.4.6 -> 1.4.7
* [`60e0149a`](https://github.com/NixOS/nixpkgs/commit/60e0149a1668d441ead86b88e79be9074eb5ae30) qutebrowser: don't use distutils
* [`da062e0e`](https://github.com/NixOS/nixpkgs/commit/da062e0e15d2805d5e0c0f3a33280c3571ffbf5b) qutebrowser: update dependencies
* [`2bf90681`](https://github.com/NixOS/nixpkgs/commit/2bf90681b642dd3754592274768c9b0cc233ea94) emuflight-configurator: 0.4.1 -> 0.4.3
* [`9756142a`](https://github.com/NixOS/nixpkgs/commit/9756142adc8c0aa9a234b696059a31aa78134d35) nomad-driver-podman: 0.5.2 -> 0.6.0
* [`9b839f69`](https://github.com/NixOS/nixpkgs/commit/9b839f69b17eaab3235ded2be774ad5f23a460d0) buildkit: 0.14.1 -> 0.15.0
* [`d42ba49c`](https://github.com/NixOS/nixpkgs/commit/d42ba49cbf1764169de0f27212cfc9955f12b96b) incus: 6.2.0 -> 6.3.0
* [`8058a2a4`](https://github.com/NixOS/nixpkgs/commit/8058a2a484ada8ac539a9e67f52e9f6ccd67bcee) nixfmt-rfc-style: unstable-2024-07-03 -> unstable-2024-07-12
* [`eefeee7f`](https://github.com/NixOS/nixpkgs/commit/eefeee7fdebd8b70f6a8b0d08d0b79d2f3fcb0a8) python312Packages.pylink-square: 1.2.0 -> 1.2.1
* [`7eebae76`](https://github.com/NixOS/nixpkgs/commit/7eebae7648819e4cadf4436a80f7b0f17f9b1466) metals: 1.3.2 -> 1.3.3
* [`91d38a07`](https://github.com/NixOS/nixpkgs/commit/91d38a07073f97e9fcb65e8add7ee0c16d50396e) tcpreplay: 4.4.4 -> 4.5.1
* [`e41561f6`](https://github.com/NixOS/nixpkgs/commit/e41561f68b4df0a25b07addfb304d0a93034b884) stackit-cli: 0.8.1 -> 0.9.0
* [`92d14281`](https://github.com/NixOS/nixpkgs/commit/92d14281068c8e96dd084663c79820be76a86446) stylelint: 16.6.1 -> 16.7.0
* [`523b575d`](https://github.com/NixOS/nixpkgs/commit/523b575d8eded28ffb84a1fe5edab9107fab3592) got: 0.100 -> 0.101
* [`2b717676`](https://github.com/NixOS/nixpkgs/commit/2b71767607a9efd128a79e40de1475aaea72db62) got: fix build on x86_64-darwin
* [`c2a12db1`](https://github.com/NixOS/nixpkgs/commit/c2a12db1a456a4b2a7b85a92143d26fda794f4e2) nixos/incus: add skopeo and umoci
* [`acc1b326`](https://github.com/NixOS/nixpkgs/commit/acc1b3260e9291eadd678096895f0f852b81e585) spotifyd: set default arguments internally
* [`e932f909`](https://github.com/NixOS/nixpkgs/commit/e932f90954fb9f0a3e2658d2a748c6b208a0a827) spotifyd: migrate to by-name
* [`c2ebccb9`](https://github.com/NixOS/nixpkgs/commit/c2ebccb950423d7d3b57de1457e3ec66a90f559e) spotifyd: format with nixfmt
* [`b3cd2a1d`](https://github.com/NixOS/nixpkgs/commit/b3cd2a1df25a1ffdcde6fe4c143e9a2ac0d7e95e) spotifyd: modernize
* [`13c5512f`](https://github.com/NixOS/nixpkgs/commit/13c5512f1e1462b80eb66dcd209c587c2228da7c) spotifyd: add getchoo as maintainer
* [`94a6fbf3`](https://github.com/NixOS/nixpkgs/commit/94a6fbf3213f8e0599a92b2b451191df6865e11b) spotifyd: add version test
* [`fb033f0b`](https://github.com/NixOS/nixpkgs/commit/fb033f0be1953936f42767db575813d6ee4938c7) spotifyd: 0.3.5-unstable-2024-02-18 -> 0.3.5-unstable-2024-07-10
* [`41e79c9e`](https://github.com/NixOS/nixpkgs/commit/41e79c9e11005208bbd929588ed880cdd7727da7) spotifyd: add `withJack` option
* [`b0df3a33`](https://github.com/NixOS/nixpkgs/commit/b0df3a330f781f791d33318bc9773b4f29fd6152) spotifyd: enable `withKeyring` by default
* [`cb12f505`](https://github.com/NixOS/nixpkgs/commit/cb12f50511d7d96aced6eeb5cf4b74e09df75a69) conan: 2.0.17 -> 2.5.0
* [`f706e209`](https://github.com/NixOS/nixpkgs/commit/f706e209c8864de07951acffd46577fb66935931) python3Packages.libmambapy: fix build failure
* [`e95ee887`](https://github.com/NixOS/nixpkgs/commit/e95ee887f024d3e13ee38a93c2c0f26b7d4136ce) python3Packages.conda: fix build failure
* [`bb72032f`](https://github.com/NixOS/nixpkgs/commit/bb72032fc56f32152165acb13cd6c6c676ccc57a) deno: 1.44.4 -> 1.45.2
* [`5f7fe4cc`](https://github.com/NixOS/nixpkgs/commit/5f7fe4ccedf3b813798bc18488686176c925b82d) python312Packages.coinmetrics-api-client: 2024.2.6.16 -> 2024.7.11.18
* [`bc7c2dc7`](https://github.com/NixOS/nixpkgs/commit/bc7c2dc70d54d1ead2ee0180c3d552e430545361) python312Packages.generic: 1.1.2 -> 1.1.3
* [`7a4736a6`](https://github.com/NixOS/nixpkgs/commit/7a4736a620828aa53adaea58c432cf965d75c896) python312Packages.typeshed-client: 2.5.1 -> 2.6.0
* [`09374ff3`](https://github.com/NixOS/nixpkgs/commit/09374ff354c5d089eb36de85a56001073f30dfa3) pscale: 0.197.0 -> 0.204.0
* [`5daa6f21`](https://github.com/NixOS/nixpkgs/commit/5daa6f210287cbd829593afab0e31486f20ed60b) regclient: 0.6.1 -> 0.7.0
* [`4be0be7e`](https://github.com/NixOS/nixpkgs/commit/4be0be7e34649f5725c0bead2d2c1078339a6bd6) python312Packages.qtile-extras: 0.26.0 -> 0.27.0
* [`10f34301`](https://github.com/NixOS/nixpkgs/commit/10f34301bb71a4345567819b9b2513b45f7b7341) numworks-epsilon: 22.2.0 -> 23.2.2
* [`0f5dbcbf`](https://github.com/NixOS/nixpkgs/commit/0f5dbcbfbb7a9f7419cc22da0fb1bedff0933069) python312Packages.qtile: 0.26.0 -> 0.27.0
* [`e390a241`](https://github.com/NixOS/nixpkgs/commit/e390a2413116022e492bbc15ddc6899dd95be693) earthly: 0.8.14 -> 0.8.15
* [`dbefca31`](https://github.com/NixOS/nixpkgs/commit/dbefca319188dbcdd0ea9bd981a9a9c7dfef322f) frankenphp: 1.2.1 -> 1.2.2
* [`03d18400`](https://github.com/NixOS/nixpkgs/commit/03d18400251f981ec34f69e80f3206626cbec5b2) xcbeautify: 1.4.0 -> 2.4.1
* [`8435137a`](https://github.com/NixOS/nixpkgs/commit/8435137aba4953d8e74fec00a98dc4234896fc30) vault: 1.17.1 -> 1.17.2
* [`4b7d2575`](https://github.com/NixOS/nixpkgs/commit/4b7d2575d7c71af6d10a59a33fc1cd41366e0619) osv-scanner: 1.8.1 -> 1.8.2
* [`9be68208`](https://github.com/NixOS/nixpkgs/commit/9be682083cd3c292e74628acae37eafad706b8bb) mdbook: 0.4.37 -> 0.4.40
* [`9835d7e5`](https://github.com/NixOS/nixpkgs/commit/9835d7e5bce3c2c8b254a80327ced6e6c82007ef) python312Packages.irc: 20.4.1 -> 20.4.3
* [`653e50c7`](https://github.com/NixOS/nixpkgs/commit/653e50c7fd250812c2b3ac1c8ea9a5a322771cd7) ecs-agent: 1.84.0 -> 1.85.0
* [`1e049fb1`](https://github.com/NixOS/nixpkgs/commit/1e049fb14fa83adf6bed8c04697327ad13b7bc47) fflogs: 8.5.25 -> 8.6.0
* [`44d19c66`](https://github.com/NixOS/nixpkgs/commit/44d19c66e3845c66673527554f79b6beff71b46b) level-zero: 1.17.17 -> 1.17.19
* [`61be8d2f`](https://github.com/NixOS/nixpkgs/commit/61be8d2f64919f8f7c05122d5ecf1c59b0c305f4) nextcloud-client: only update after official release
* [`4fb38a9c`](https://github.com/NixOS/nixpkgs/commit/4fb38a9c2cfaa510d43fc64a3375fa94125f4971) mdbook: remove arguments to callPackage
* [`9894294f`](https://github.com/NixOS/nixpkgs/commit/9894294f10ed8d826e0e66ee59bf11a65ce6812f) mdbook: format with nixfmt-rfc-style
* [`2caa0658`](https://github.com/NixOS/nixpkgs/commit/2caa06582ca2d81da40c01f6e5b809cc134f79b9) mdbook: move to pkgs/by-name
* [`62a3d293`](https://github.com/NixOS/nixpkgs/commit/62a3d293e972e0f818789d29cc411a2e097eaf0d) rocketchat-desktop: 4.0.0 -> 4.0.1
* [`7459b7ce`](https://github.com/NixOS/nixpkgs/commit/7459b7ce657eba6809eb0c98ddae4b01205a8ca9) ossia-score: 3.2.3-3 -> 3.2.4
* [`7f3e7bcf`](https://github.com/NixOS/nixpkgs/commit/7f3e7bcf4eb1367d6f931411f4d386903724ef78) maelstrom-clj: init at 0.2.3
* [`8bd601fc`](https://github.com/NixOS/nixpkgs/commit/8bd601fc2789da6839e9b6b1a9aa32dfaeacbda6) nvc: 1.12.2 -> 1.13.0
* [`a6ede4e0`](https://github.com/NixOS/nixpkgs/commit/a6ede4e0d0b8208722ce9f27129a679d56ebbdc9) neovide: 0.13.1 -> 0.13.2
* [`83783072`](https://github.com/NixOS/nixpkgs/commit/8378307266c09bc51c8d7708c86588f3651bcf89) clipper2: 1.3.0 -> 1.4.0
* [`3df1fec4`](https://github.com/NixOS/nixpkgs/commit/3df1fec46e74e2af3df3bac6996a332292fb5f6c) python312Packages.sphinxcontrib-tikz: 0.4.19 -> 0.4.20
* [`7e9e215b`](https://github.com/NixOS/nixpkgs/commit/7e9e215bbc673d31a5141cc66618608d0abd155a) ocis-bin: support more architectures and add update script
* [`5b71e54f`](https://github.com/NixOS/nixpkgs/commit/5b71e54faa32073df9c958264f80498e92ed20f0) python312Packages.pysilero-vad: 1.0.0 -> 2.0.0
* [`d1ba7611`](https://github.com/NixOS/nixpkgs/commit/d1ba7611538c5e1c5903132fe73ebe0b28605842) python312Packages.pyvmomi: 8.0.2.0.1 -> 8.0.3.0.1
* [`8bad9956`](https://github.com/NixOS/nixpkgs/commit/8bad99561b239ac9d36442775353192334ef9807) fmt: reformat
* [`b5dade8c`](https://github.com/NixOS/nixpkgs/commit/b5dade8ca0fef21d44f49d1ff3ffb12031ebe3c1) fmt_11: init at 11.0.1
* [`942ae171`](https://github.com/NixOS/nixpkgs/commit/942ae171abfeb3ca2db303a93069597e42786239) rspamd: reformat
* [`eda516d4`](https://github.com/NixOS/nixpkgs/commit/eda516d4ed24c7800fadc72b8f125962a650027a) rspamd: 3.8.4 -> 3.9.0
* [`9158c43c`](https://github.com/NixOS/nixpkgs/commit/9158c43c06b6e1385bbfb7cac5b44ba3491c8435) gscreenshot: 3.5.1 -> 3.6.1
* [`d45168b2`](https://github.com/NixOS/nixpkgs/commit/d45168b22441d4bfbcc82da2f0f044638232e3d2) suwayomi-server: 1.0.0 -> 1.1.1
* [`ff8edd40`](https://github.com/NixOS/nixpkgs/commit/ff8edd4024eed454bbae294c9b7d1ba3954e556b) openai: 1.35.9 -> 1.35.13
* [`98978743`](https://github.com/NixOS/nixpkgs/commit/98978743f31e074e216b60d487481c5318f942cb) brainflow: init at 5.12.1
* [`78936724`](https://github.com/NixOS/nixpkgs/commit/78936724cd8ac005ce04461b184f2b1e6a0e1510) python3Packages.brainflow: init at 5.12.1
* [`31f7d2af`](https://github.com/NixOS/nixpkgs/commit/31f7d2af5f692bdd982aea59e8b9d5f71a3c1026) python311Packages.objexplore: init at 1.5.4
* [`adf3e496`](https://github.com/NixOS/nixpkgs/commit/adf3e496489c169cd512665c0d3a3e50ff38d382) tutanota-desktop: 232.240626.0 -> 235.240712.0
* [`d14c296d`](https://github.com/NixOS/nixpkgs/commit/d14c296d19a9b1489b50d96d997072bc1864160e) ubootOrangePiZero3: init
* [`1f49800c`](https://github.com/NixOS/nixpkgs/commit/1f49800c21d2c4de6807456d5abfd5391db5c89c) nest-cli: 10.4.0 -> 10.4.2
* [`03a94c77`](https://github.com/NixOS/nixpkgs/commit/03a94c776f261b78b95de0971a94dea0199b4cd8) papermc: 1.21-40 -> 1.21-62
* [`765b0810`](https://github.com/NixOS/nixpkgs/commit/765b0810d69daa3a94c62e89299fa2ee9beb0d9b) python312Packages.galois: 0.3.10 -> 0.4.1
* [`5117c868`](https://github.com/NixOS/nixpkgs/commit/5117c868ce447f396f6804cafceaaaf1322205b1) docker-buildx: 0.15.1 -> 0.16.0
* [`dd0e1ee3`](https://github.com/NixOS/nixpkgs/commit/dd0e1ee3fd55f482ff6be034101723b8ed3bdd6c) thunderbird: refactor (prepare for version 128)
* [`22601be9`](https://github.com/NixOS/nixpkgs/commit/22601be95cba9652b9f8fce48580a1924e53cd5f) thunderbird-128: init at 128.0esr
* [`72a3c73d`](https://github.com/NixOS/nixpkgs/commit/72a3c73d8539f3be03e960a6ef4d5d6be958b16b) ios-webkit-debug-proxy: move to `pkgs/by-name`
* [`1dd31a78`](https://github.com/NixOS/nixpkgs/commit/1dd31a7861b25fdfa63f6ee0590a612fa2447a92) ios-webkit-debug-proxy: reformat
* [`8de2a265`](https://github.com/NixOS/nixpkgs/commit/8de2a2656feeb67b47e6174031b75416487434f5) ios-webkit-debug-proxy: add the `updateScript` and the version test
* [`671396fe`](https://github.com/NixOS/nixpkgs/commit/671396fe510ebf03110c6fb81bc0359402bf7b70) ios-webkit-debug-proxy: 1.9.0 -> 1.9.1
* [`9b863ca5`](https://github.com/NixOS/nixpkgs/commit/9b863ca5f62b8798cb7d7c01a8db73669bbf76dd) tageditor: 3.9.0 -> 3.9.1
* [`f88960c7`](https://github.com/NixOS/nixpkgs/commit/f88960c7b6a18483791535dac0b133566759ba70) ukmm: fix running on x11
* [`4349a61a`](https://github.com/NixOS/nixpkgs/commit/4349a61a715bb29e0c326076f3666a8c419130ec) nextcloudPackages: Revamp package generation script
* [`d5d501b7`](https://github.com/NixOS/nixpkgs/commit/d5d501b799ab338b5262cbe3fa771a9dc49a512a) nextcloud28Packages: update
* [`fe3e80ad`](https://github.com/NixOS/nixpkgs/commit/fe3e80ad3883e9ddf9b3f471692b8f5f2c3033d2) nextcloud29Packages: update
* [`a4b0afdf`](https://github.com/NixOS/nixpkgs/commit/a4b0afdfbdc92d8f0887d2dcf330b1bd6685b476) openrct2: 0.4.11 -> 0.4.12
* [`943b886f`](https://github.com/NixOS/nixpkgs/commit/943b886f6118ab1e58db60cd63626874ff71ceb2) fheroes2: 1.1.0 -> 1.1.1
* [`b283cb4c`](https://github.com/NixOS/nixpkgs/commit/b283cb4ce8db43d7e7ec907617faa5745f686e93) libpointmatcher: 1.4.2 -> 1.4.3
* [`949e81ad`](https://github.com/NixOS/nixpkgs/commit/949e81ade255f06cf4011323ffb40411b7de00e3) legit-web: 0.2.2 -> 0.2.3
* [`c7b72954`](https://github.com/NixOS/nixpkgs/commit/c7b7295447b4e4a8948ed0e2e8ffc214adbbad94) goreleaser: 2.0.1 -> 2.1.0
* [`1b656e51`](https://github.com/NixOS/nixpkgs/commit/1b656e513c2cd84b0c82fbcf74154602139e6f8e) python312Packages.webdav4: 0.9.8 -> 0.10.0
* [`5ccae813`](https://github.com/NixOS/nixpkgs/commit/5ccae8130ec131d89a3412fd1aeff34fa6a87b32) python312Packages.whatthepatch: 1.0.5 -> 1.0.6
* [`1d62892b`](https://github.com/NixOS/nixpkgs/commit/1d62892b1cceb750d8bf32bff1735cdd6ceb2dae) pprof: 0-unstable-2024-05-09 -> 0-unstable-2024-07-10
* [`8a1e588f`](https://github.com/NixOS/nixpkgs/commit/8a1e588f1650124e10fd60890f7e9c8b57513f41) perf_data_converter: 0-unstable-2024-03-12 -> 0-unstable-2024-07-10
* [`d13af345`](https://github.com/NixOS/nixpkgs/commit/d13af34577e9913b63db821514fe387c360b2d59) yaws: 2.1.1 -> 2.2.0
* [`51b88716`](https://github.com/NixOS/nixpkgs/commit/51b887167e17039e2ec49943db2efd111cd0710c) igir: 2.9.0 -> 2.9.2
* [`927918a2`](https://github.com/NixOS/nixpkgs/commit/927918a291db8a7f5477119904ea9ac3cd53d65a) libjpeg: add sigmanificient to maintainers
* [`23349d3e`](https://github.com/NixOS/nixpkgs/commit/23349d3e280eb7bcd7e90c098852d0068695d7f1) drawterm: 0-unstable-2024-06-10 -> 0-unstable-2024-07-03
* [`f606fe4f`](https://github.com/NixOS/nixpkgs/commit/f606fe4fef3b2c66fef761c8dc7fe7fa95e17b39) libjpeg: format with nixfmt, change sha56 -> hash
* [`8f102923`](https://github.com/NixOS/nixpkgs/commit/8f10292335f146656f6044e32036fb04e689eba4) obs-studio-plugins.obs-source-record: 0.3.2 -> 0.3.4
* [`d79b48bd`](https://github.com/NixOS/nixpkgs/commit/d79b48bd74a64364d9a7d29ac79ba9b4e00cca30) maintainers: add shackra
* [`b39d7984`](https://github.com/NixOS/nixpkgs/commit/b39d7984c14626ef0c10f89451b48758d9c3c729) obs-studio-plugins.obs-source-record: add maintainer shackra
* [`e9382cc3`](https://github.com/NixOS/nixpkgs/commit/e9382cc356109d52cd9b33839e5f3f1d6d43524b) python312Packages.django-ninja: 1.1.0 -> 1.2.1
* [`5a894486`](https://github.com/NixOS/nixpkgs/commit/5a894486fbf7fe370f950353ebd4b05b29395787) python312Packages.packageurl-python: 0.15.1 -> 0.15.3
* [`e9a97fda`](https://github.com/NixOS/nixpkgs/commit/e9a97fda63ff5888743dfbc76880ab675fb3d3b4) microsoft-edge: 126.0.2592.87 -> 126.0.2592.102
* [`cd577b39`](https://github.com/NixOS/nixpkgs/commit/cd577b39a5a8f658004acd7a88e4ff3e84a9f192) media-downloader: 4.7.0 -> 4.8.0
* [`9178b8e4`](https://github.com/NixOS/nixpkgs/commit/9178b8e4eef4da8b71273d29fde96100e8e28f7b) librime-lua: init at 0-unstable-2024-05-19
* [`2bbfe90e`](https://github.com/NixOS/nixpkgs/commit/2bbfe90eee015cc44f6fa5636df952d58b159389) librime: add librime-lua plugin by default following Arch Linux
* [`375ef3c1`](https://github.com/NixOS/nixpkgs/commit/375ef3c12778f0e04177c83c76cd803d2a1e4cc5) nixos/sssd: fix KCM to use new krb5 settings
* [`4155672b`](https://github.com/NixOS/nixpkgs/commit/4155672b5dd19cf289bcc3d33167181435cc8a73) python3Packages.twitter-common-collections: remove
* [`7980a823`](https://github.com/NixOS/nixpkgs/commit/7980a8230f4c570d190a1188c597f637f429f7fd) python3Packages.twitter-common-confluence: remove
* [`9fb5d8ca`](https://github.com/NixOS/nixpkgs/commit/9fb5d8ca4a2431fddff04971780f55152e841bb6) python3Packages.twitter-common-dirutil: remove
* [`75e249ce`](https://github.com/NixOS/nixpkgs/commit/75e249cecbe250d1ef3e922ef8342e6c3d7c4c89) python3Packages.twitter-common-lang: remove
* [`811f3347`](https://github.com/NixOS/nixpkgs/commit/811f3347fe215489fd2423ed75c6935426e72a11) python3Packages.twitter-common-log: remove
* [`d2adf589`](https://github.com/NixOS/nixpkgs/commit/d2adf58973a45f9afe8b3e21daf1f56e9cfb40d4) python3Packages.twitter-common-options: remove
* [`b735b0be`](https://github.com/NixOS/nixpkgs/commit/b735b0bee3820e43f29ba619247a68482e32c497) ibus-engines.hangul: bulid from git source
* [`564dd254`](https://github.com/NixOS/nixpkgs/commit/564dd254b6ebdc9c2eca032bf64a5ab6dec81913) proton-pass: 1.19.2 -> 1.20.1
* [`e20001db`](https://github.com/NixOS/nixpkgs/commit/e20001dbf61071adcd32a4079fb5c523e0e0ce1f) python312Packages.awscrt: 0.20.12 -> 0.21.1
* [`fe57dcab`](https://github.com/NixOS/nixpkgs/commit/fe57dcab1f2b55de90a175284f68f3bc6f672cb4) python312Packages.python-telegram-bot: 21.3 -> 21.4
* [`26595b1e`](https://github.com/NixOS/nixpkgs/commit/26595b1e41539ba5f141c7d885171858a88b80e6) python312Packages.eliot: 1.14.0 -> 1.15.0
* [`d7047e2f`](https://github.com/NixOS/nixpkgs/commit/d7047e2fbfa573db11521da895e0b2b957123aa6) eliot-tree: make usable with Python 3.12
* [`7abe9d11`](https://github.com/NixOS/nixpkgs/commit/7abe9d11615af5ce0266e56aa13a162272c6cb16) tahoe-lafs: use Python 3.11
* [`86307866`](https://github.com/NixOS/nixpkgs/commit/86307866c2563dd6ac5a37070d1df9dd32c8262d) pacman: 6.1.0 -> 7.0.0
* [`2a0f95db`](https://github.com/NixOS/nixpkgs/commit/2a0f95dbaf85fa913fd8c2b222c6b5a6b694afb0) arc-browser: 1.49.1-51495 -> 1.51.0-51691
* [`0e0ffd4b`](https://github.com/NixOS/nixpkgs/commit/0e0ffd4b728540c5d0ddd0cb949b49ffac2f07a8) obconf: use finalAttrs, hash instead of sha256
* [`20d8ea02`](https://github.com/NixOS/nixpkgs/commit/20d8ea02b3b286125ff1cb9986061f90f0e3f733) obconf: reformat for RFC166
* [`aa9ffbf2`](https://github.com/NixOS/nixpkgs/commit/aa9ffbf2b0d96c86b9e0fa6faf42cbc4a60e3db4) obconf: move to by-name
* [`7264bbf8`](https://github.com/NixOS/nixpkgs/commit/7264bbf85b2f4e63f74b3cb3e7ce50ed661252bb) h5dump: use finalAttrs, hash instead of sha256, remove with lib
* [`ba942e86`](https://github.com/NixOS/nixpkgs/commit/ba942e865e538394bee682e694e35aa3eb246af7) h5utils: reformat for RFC166
* [`c002109f`](https://github.com/NixOS/nixpkgs/commit/c002109fb2f700924eb94c037a355bd6b313d2e9) python312Packages.pylink-square: switch to pypa build
* [`9aaab749`](https://github.com/NixOS/nixpkgs/commit/9aaab7493ca32c55fc61028df137c8cd68985855) h5utils: move to by-name
* [`4a965c5d`](https://github.com/NixOS/nixpkgs/commit/4a965c5df18e481dca59d0b4ce38c3dd217c6140) h5utils: remove more 'with lib'
* [`daf541ea`](https://github.com/NixOS/nixpkgs/commit/daf541ea9e1aa986e949a2b58af7354b2f504c63) python312Packages.remi: add setuptools as dependency
* [`fe4e0899`](https://github.com/NixOS/nixpkgs/commit/fe4e0899325ba9835717a0f46cb8233f134cfede) kodiPackages.jellyfin: 1.0.3 -> 1.0.4
* [`3c9f658e`](https://github.com/NixOS/nixpkgs/commit/3c9f658e847e97607a27c164d74665727eeb44dc) mainsail: 2.11.2 -> 2.12.0
* [`ddc35970`](https://github.com/NixOS/nixpkgs/commit/ddc35970180d2ecfb6e214da458461c9af5363c7) tomcat9: 9.0.90 -> 9.0.91
* [`eda65c2b`](https://github.com/NixOS/nixpkgs/commit/eda65c2b4348500d33917c48e11622aba3e5b4ff) tomcat10: 10.1.25 -> 10.1.26
* [`8c1f535d`](https://github.com/NixOS/nixpkgs/commit/8c1f535d375efa70a6957b94e9a69fc1911fccfa) tomcat: add passthru.updateScript
* [`4796b6af`](https://github.com/NixOS/nixpkgs/commit/4796b6afabeb2ea993bae1472970f30859c2461c) tomcat: format with nixfmt-rfc-style, remove `with lib;`
* [`267f23a0`](https://github.com/NixOS/nixpkgs/commit/267f23a0b67a50853190ab3cb9baf19ad180da11) nerdfix: 0.4.0 -> 0.4.1
* [`b4c767fb`](https://github.com/NixOS/nixpkgs/commit/b4c767fb83ae7aa42e987dcdf3ee7d88fd981c61) nix-eval-jobs: 2.22.1 -> 2.23.0
* [`e5feb419`](https://github.com/NixOS/nixpkgs/commit/e5feb4198a3c012594b414ec1f25e339b5485686) python312Packages.fastcore: 1.5.51 -> 1.5.53
* [`d7978826`](https://github.com/NixOS/nixpkgs/commit/d7978826fdd6c81fdb188ffff48618e5f40ad6f5) python312Packages.google-generativeai: 0.7.1 -> 0.7.2
* [`82fbceb1`](https://github.com/NixOS/nixpkgs/commit/82fbceb1fa6c188346f0649bb89c105d2d123162) python312Packages.google-cloud-workflows: 1.14.3 -> 1.14.4
* [`437216ee`](https://github.com/NixOS/nixpkgs/commit/437216ee0506186aceaf2e742e10c31e756664b9) python312Packages.graph-tool: 2.71 -> 2.72
* [`77d4e832`](https://github.com/NixOS/nixpkgs/commit/77d4e832d142a311954ca2ea21dd6b356d3347cb) php81Extensions.blackfire: 1.92.18 -> 1.92.19
* [`8a5d37e8`](https://github.com/NixOS/nixpkgs/commit/8a5d37e883b732a8e1c7824fb5b389e29ea43065) codeql: 2.17.6 -> 2.18.0
* [`fe27814e`](https://github.com/NixOS/nixpkgs/commit/fe27814e39622f911d34d15fd8c89f9406d53a8f) blendfarm: init at 1.1.6
* [`f312bdb5`](https://github.com/NixOS/nixpkgs/commit/f312bdb5d72abc526487e5907cf3585b3e7c41ad) nixos/blendfarm: init
* [`f3f52741`](https://github.com/NixOS/nixpkgs/commit/f3f52741e62202a3e67d54a5f4dd3c76ef31f42e) tandoor-recipes: pin to python311
* [`1f803e4e`](https://github.com/NixOS/nixpkgs/commit/1f803e4edb952f78e777d623e34adeff77d61d18) tandoor-recipes: pin lxml to 5.1.0
* [`7423c47d`](https://github.com/NixOS/nixpkgs/commit/7423c47d8609a6ee2c1eb81759b923b45a9cf850) stats: 2.10.19 -> 2.11.1
* [`67052c60`](https://github.com/NixOS/nixpkgs/commit/67052c60269d765bc398eace05f15c3f9ed22af9) xlights: 2024.12 -> 2024.13
* [`bc225112`](https://github.com/NixOS/nixpkgs/commit/bc2251120c0019b913943ab4c953a5792fb08692) python312Packages.dukpy: init at 0.4.0
* [`af3f6ca5`](https://github.com/NixOS/nixpkgs/commit/af3f6ca5ff30df83fabd71674b460a8420d468d1) pjsip: format
* [`cde51ec8`](https://github.com/NixOS/nixpkgs/commit/cde51ec87855d4088253dbff0d60c92a41fd5844) circt: 1.76.0 -> 1.77.0
* [`e5d65aef`](https://github.com/NixOS/nixpkgs/commit/e5d65aefac6778f21734bda0d0feead36dca6d84) keymapp: 1.3.0 -> 1.3.1
* [`0b8eaf08`](https://github.com/NixOS/nixpkgs/commit/0b8eaf081fafbf495104038e1378dcbfc63d4862) fetchCrate: sha256 -> hash
* [`7f9dcdbb`](https://github.com/NixOS/nixpkgs/commit/7f9dcdbbe9330bb1648cdf1937e4835e219d3bef) rure: sha256 -> hash, update Cargo.lock
* [`9e00289e`](https://github.com/NixOS/nixpkgs/commit/9e00289e5635ed3ccb054b3f2f920f6991eb2874) yaml-filter: init at 0.2.0
* [`d0c8078b`](https://github.com/NixOS/nixpkgs/commit/d0c8078b2cac37323446c96b8975116aca20c981) siyuan: 3.0.11 -> 3.1.0
* [`8a2af2b5`](https://github.com/NixOS/nixpkgs/commit/8a2af2b57e658b575b7c68b1611337277a060cba) pjsip: fix build on python 3.12
* [`9ca50736`](https://github.com/NixOS/nixpkgs/commit/9ca507365baf1d6fd0012fb688b249e41ddaef6d) osquery: restore tests in passthru
* [`011fa90c`](https://github.com/NixOS/nixpkgs/commit/011fa90c868055d97923667257213baf04cdfc65) empty-epsilon: 2024.05.16 -> 2024.06.20
* [`a8259e25`](https://github.com/NixOS/nixpkgs/commit/a8259e25e5d9d942f12a45b8d799d1e378072fa4) empty-epsilon: simplify defining version, cleanup a little
* [`f634371d`](https://github.com/NixOS/nixpkgs/commit/f634371d2115c3f0b6ec8e4df81e1f36e4675cd7) {blackmagic-desktop-video,decklink}: init at 14.0.1a2
* [`73ffe01d`](https://github.com/NixOS/nixpkgs/commit/73ffe01d1af42f0aa70b76b83b742c930b75df02) nixos/decklink: init
* [`ab9078d4`](https://github.com/NixOS/nixpkgs/commit/ab9078d49fdd2c84c0a082909bc334de37618600) k3s: document onboarding maintainer
* [`8ba624c7`](https://github.com/NixOS/nixpkgs/commit/8ba624c7192622a3a26908bcc8c9cb073702b97d) jetty_11: 11.0.20 -> 11.0.22
* [`fa9c8bb1`](https://github.com/NixOS/nixpkgs/commit/fa9c8bb1b14c035f6bcd4284020f0088a1be744a) jetty_12: 12.0.9 -> 12.0.11
* [`f0e575ba`](https://github.com/NixOS/nixpkgs/commit/f0e575ba95603472f3ebb137bdf63f4cdfd35811) jetty: add passthru.updateScript
* [`96829d14`](https://github.com/NixOS/nixpkgs/commit/96829d14b785b1fe9c82b1e5a5e64261216a2ae1) jetty: add meta.changelog, update meta.homepage
* [`26c319e9`](https://github.com/NixOS/nixpkgs/commit/26c319e9c60d6bf34ddbb72536dfacc4f0a1e5b3) empty-epsilon: normalize attr
* [`21822061`](https://github.com/NixOS/nixpkgs/commit/2182206180b32b440b9e6ffb08e0fa0298c01034) teamspeak5_client: add mesa dependency
* [`a850bde6`](https://github.com/NixOS/nixpkgs/commit/a850bde6a6516edb00dcda94f24eed19be7b079d) bdf2psf: 1.228 -> 1.229
* [`4c4ae4f7`](https://github.com/NixOS/nixpkgs/commit/4c4ae4f77b35a9a18da3d5ba98160dfc48a1b003) empty-epsilon: move to pkgs/by-name
* [`09a3539b`](https://github.com/NixOS/nixpkgs/commit/09a3539b37b5f72b273096a04fc1b7b6d8e18250) doctl: 1.108.0 -> 1.109.1
* [`7e150e2e`](https://github.com/NixOS/nixpkgs/commit/7e150e2e4386cbf8bab296149b0a8e948615d1db) budgie{,Plugins}: format with nixfmt
* [`ba97c97f`](https://github.com/NixOS/nixpkgs/commit/ba97c97f321f0f7f0ea8d51f180dd6d1bd026309) budgie-backgrounds: move from budgie scope to top-level
* [`4c87e35a`](https://github.com/NixOS/nixpkgs/commit/4c87e35ad2a05bd2f221b4201e849a0f2f706a02) budgie-backgrounds: modernize
* [`96bab1b8`](https://github.com/NixOS/nixpkgs/commit/96bab1b8b0a81f41ef0e85509a5c31e5f6d98e67) budgie-control-center: move from budgie scope to top-level
* [`c4212408`](https://github.com/NixOS/nixpkgs/commit/c4212408fa1ace475775cf374ab988b952173ff3) budgie-control-center: modernize
* [`e2421481`](https://github.com/NixOS/nixpkgs/commit/e24214811979bc573cc1d457596835f0ccbd8940) budgie-control-center: add version test
* [`417179ab`](https://github.com/NixOS/nixpkgs/commit/417179abbdfec986f31b712d64988818bc91176e) budgie-desktop{,with-plugins}: move from budgie scope to top-level
* [`02cd3e36`](https://github.com/NixOS/nixpkgs/commit/02cd3e363283c2d7afbf052ce4dab456dba68003) budgie-desktop: split outputs
* [`5aa2e5ce`](https://github.com/NixOS/nixpkgs/commit/5aa2e5ce36148051053406ce839a213db30240b8) budgie-desktop: modernize
* [`cbd92467`](https://github.com/NixOS/nixpkgs/commit/cbd92467d44cfd6feee3e3ee6e7c309194d73207) budgie-desktop: add validatePkgConfig hook
* [`94b69c9c`](https://github.com/NixOS/nixpkgs/commit/94b69c9c465fb32c55cbfd48350b2659abfa100f) budgie-desktop: add pkg-config test
* [`a3881259`](https://github.com/NixOS/nixpkgs/commit/a3881259e9d1e338bf3decadd6155077a8cb5576) budgie-desktop-with-plugins: fix meta info
* [`9bfabc5a`](https://github.com/NixOS/nixpkgs/commit/9bfabc5a06a13cf02fda8a5b3bddb2aef86e5862) budgie-desktop-view: move from budgie scope to top-level
* [`14dfaa83`](https://github.com/NixOS/nixpkgs/commit/14dfaa831f8f07b4569fd8a286626f915ca60936) budgie-desktop-view: modernize
* [`51bfa798`](https://github.com/NixOS/nixpkgs/commit/51bfa7985c4a2a5822e8e2e2887533c05cfc705f) budgie-gsettings-override: move from budgie scope to top-level
* [`228edade`](https://github.com/NixOS/nixpkgs/commit/228edade412a2856276b8c232791db859ceca8e3) budgie-screensaver: move from budgie scope to top-level
* [`94d8f9bc`](https://github.com/NixOS/nixpkgs/commit/94d8f9bcaa5fdfc80912ee32f2c14cf810f3a8ff) budgie-screensaver: modernize
* [`9af16f0c`](https://github.com/NixOS/nixpkgs/commit/9af16f0c401b6f0e9c1ee51aca1bce0ea1631f7c) budgie-screensaver: split outputs
* [`32a48145`](https://github.com/NixOS/nixpkgs/commit/32a481458583c34eed92602821d15de234a16a60) budgie-screensaver: add version test
* [`50124d6c`](https://github.com/NixOS/nixpkgs/commit/50124d6c9f3cc0c6d55e6ca0cf4f0dfdc1513ace) budgie-session: move from budgie scope to top-level
* [`d6237362`](https://github.com/NixOS/nixpkgs/commit/d623736294070d367157cea695e8ed5769f13766) budgie-session: split outputs
* [`0470485f`](https://github.com/NixOS/nixpkgs/commit/0470485ff946998fe1fe96b3f264b222b7590d01) budgie-session: modernize
* [`fef55ad1`](https://github.com/NixOS/nixpkgs/commit/fef55ad1caac960eb1cd352ceed8118cbb1b6f6c) magpie: move from budgie scope to top-level
* [`285f1f32`](https://github.com/NixOS/nixpkgs/commit/285f1f32d97357db12cda7a93b17bb10e939261b) magpie: use validatePkgConfig hook
* [`ca1ec13d`](https://github.com/NixOS/nixpkgs/commit/ca1ec13de5886b56a12ecd8c769ef42a814f7816) magpie: add pkg-config test
* [`ece9778f`](https://github.com/NixOS/nixpkgs/commit/ece9778f28f7b5616ff27b75c6543d196eee07c1) magpie: modernize
* [`26f83d25`](https://github.com/NixOS/nixpkgs/commit/26f83d251c2efbe92701238b55662a310d66c6dd) budgie: drop scope
* [`731fb747`](https://github.com/NixOS/nixpkgs/commit/731fb7477cffb5578f674d1bec0f6dafc6e3416b) budgie-analogue-clock-applet: move from budgiePlugins scope to top-level
* [`4c3e9f67`](https://github.com/NixOS/nixpkgs/commit/4c3e9f67f6dabcb4028c8ce68afcbd5e96d55905) budgie-analogue-clock-applet: ensure updateScript & meta.changelog
* [`cb1ef2ba`](https://github.com/NixOS/nixpkgs/commit/cb1ef2ba8b65b95a6d4a2376e6f2ec81d08c3be8) budgie-media-player-applet: move from budgiePlugins scope to top-level
* [`ec4ac2bf`](https://github.com/NixOS/nixpkgs/commit/ec4ac2bffc45829ca972e22460dee1aadc6b8a98) budgie-media-player-applet: ensure updateScript & meta.changelog
* [`6a8e6c20`](https://github.com/NixOS/nixpkgs/commit/6a8e6c209fcf02a02e52d478aec036d590d0428e) budgie-user-indicator-redux: move from budgiePlugins scope to top-level
* [`e287c7a3`](https://github.com/NixOS/nixpkgs/commit/e287c7a3d248cc84a55a1dac19f0d77e43097b43) budgie-user-indicator-redux: add updateScript
* [`d419ba0b`](https://github.com/NixOS/nixpkgs/commit/d419ba0b56bd46acd87e88cda19fb819133f92f5) budgiePlugins: drop scope
* [`1b26960b`](https://github.com/NixOS/nixpkgs/commit/1b26960b0561305bac2a3a604f651153a0c591ff) nixos/doc/rl-2411: `budgie` and `budgiePlugins` have been removed
* [`f0f3d0dc`](https://github.com/NixOS/nixpkgs/commit/f0f3d0dc56a495058c4d7f31da1273835995062f) maintainers/team-list: add getchoo to budgie
* [`4bd01dd7`](https://github.com/NixOS/nixpkgs/commit/4bd01dd76948a71de6bfd9ccaadcbc0de9d9f9f3) budgie-desktop: passthru nixosTests.budgie
* [`823539a3`](https://github.com/NixOS/nixpkgs/commit/823539a37d8881ccf39b9a19bf287831e2e7858a) slither-analyzer: 0.10.2 -> 0.10.3
* [`1ef35e5a`](https://github.com/NixOS/nixpkgs/commit/1ef35e5a732e80dda7836b27ae8b6d447b4a08bc) yle-dl: 20240130 -> 20240706
* [`f8d18763`](https://github.com/NixOS/nixpkgs/commit/f8d18763ecc5e6c1dcd8780c5aed5de9f86259cc) jenkins: 2.452.2 -> 2.452.3
* [`aec02f12`](https://github.com/NixOS/nixpkgs/commit/aec02f12cb361dfbc8f4451373338f30ec36c817) application-title-bar: 0.6.7 -> 0.6.8
* [`32fcc3bd`](https://github.com/NixOS/nixpkgs/commit/32fcc3bd85396bb2d7f6b6bcefc71fe33f4d5e70) application-title-bar: add passthru.updateScript
* [`ba529803`](https://github.com/NixOS/nixpkgs/commit/ba52980377166b499e46a0d73ccec49ace678c09) talosctl: 1.7.4 -> 1.7.5
* [`a0f413fd`](https://github.com/NixOS/nixpkgs/commit/a0f413fd819fb8a1cf5f97477569383d1ed46a54) devbox: 0.11.0 -> 0.12.0
* [`0e6664a3`](https://github.com/NixOS/nixpkgs/commit/0e6664a30cd217c9c0ad08fd9088efa06a2bb999) clever-tools: fix cleanup for cross compilation
* [`d41bae0f`](https://github.com/NixOS/nixpkgs/commit/d41bae0f1479c4a2759bb2a88f7165df4e0172b7) archipelago,archipelago-minecraft: init at 0.5.0
* [`9649c795`](https://github.com/NixOS/nixpkgs/commit/9649c79580edfdc2a5710a6f352c9a7b394c796e) ghidra: 11.1.1 -> 11.1.2
* [`85633662`](https://github.com/NixOS/nixpkgs/commit/85633662209366000446788f6f9a26b398b1a63a) ghidra: upgrade to gradle 8, openjdk 21
* [`348834b5`](https://github.com/NixOS/nixpkgs/commit/348834b510e3acbef89798a2c4593a84005455eb) yarg: remove nose and modernize
* [`91edc515`](https://github.com/NixOS/nixpkgs/commit/91edc515baabce99abed39eadc7afe78df78d6b9) adafruit-nrfutil: remove nose and modernize
* [`89f29219`](https://github.com/NixOS/nixpkgs/commit/89f29219567e98772c5e7029ee17d13ca2178152) pcsx2-bin: added passthru.updateScript
* [`7c725a1d`](https://github.com/NixOS/nixpkgs/commit/7c725a1dc65eb531e42f8bd0db12f9081187a19b) pyenv: 2.4.5 -> 2.4.7
* [`1b769886`](https://github.com/NixOS/nixpkgs/commit/1b7698864bf9ced4137d6cb24660634cc5f81f40) lcrq: 0.1.2 -> 0.2.1
* [`2d4e578c`](https://github.com/NixOS/nixpkgs/commit/2d4e578c1291b13331dc18c77270d0ed406826db) lerc: move to finalAttrs
* [`e778af3e`](https://github.com/NixOS/nixpkgs/commit/e778af3e6a74523aabf80179f873b20241570130) lerc: expose available pkg-config modules via meta
* [`027d5e71`](https://github.com/NixOS/nixpkgs/commit/027d5e7197d251440b1ac4b4d29ffff2d248e138) vnote: 3.18.0 -> 3.18.1
* [`03f3d633`](https://github.com/NixOS/nixpkgs/commit/03f3d633b0982773c80958c5deb585da3bb307cd) python312Packages.binance-connector: 3.7.0 -> 3.8.0
* [`3faf7673`](https://github.com/NixOS/nixpkgs/commit/3faf76731dd66a3bfbb7835e623dd0b3bb4bb0eb) openvswitch: add dpdk variant
* [`7d7b2a54`](https://github.com/NixOS/nixpkgs/commit/7d7b2a54bcfc93c0351675bb4efff56ba98b8e47) cot: mark as broken on Python 3.12 or superior
* [`db27ef75`](https://github.com/NixOS/nixpkgs/commit/db27ef752da7bc6f2815f8a1bfb566fdf4f598af) geographiclib: 2.3 -> 2.4
* [`0b5fb2f3`](https://github.com/NixOS/nixpkgs/commit/0b5fb2f36b025a1096e7cbfd73c02b099651d3fa) abracadabra: 2.5.0 -> 2.5.1
* [`7d968d34`](https://github.com/NixOS/nixpkgs/commit/7d968d346faf58cc06f53ede287a361871ebf955) python312Packages.homematicip: 1.1.1 -> 1.1.2
* [`e3fa8771`](https://github.com/NixOS/nixpkgs/commit/e3fa8771d8fc0e1a9df5be06d3eb6d12d96ec21b) ardugotools: 0.5.2 -> 0.6.0
* [`db8eacb2`](https://github.com/NixOS/nixpkgs/commit/db8eacb2f5b1de09f4e2ed7f55843db671844700) fdupes: 2.3.1 -> 2.3.2
* [`f9deccea`](https://github.com/NixOS/nixpkgs/commit/f9decceab11197c0c7039fbc11564933608cdb8e) bmake: 20240625 -> 20240711
* [`706b879e`](https://github.com/NixOS/nixpkgs/commit/706b879e91ca3cd6ebc98069627b5782a81d5654) maskromtool: 2024-06-23 -> 2024-07-14
* [`40eb217f`](https://github.com/NixOS/nixpkgs/commit/40eb217fa5e5720d9876d44a7e1b1576fa68dd98) wasmer: 4.3.3 -> 4.3.4
* [`494ce2b8`](https://github.com/NixOS/nixpkgs/commit/494ce2b85339d5e04e2091b6497c463074dd19f3) granted: 0.29.0 -> 0.29.1
* [`99e919bf`](https://github.com/NixOS/nixpkgs/commit/99e919bf6b737016030e6079f33e4dace4094e7b) progress-tracker: 1.5.1 -> 1.5.2
* [`aa8e0258`](https://github.com/NixOS/nixpkgs/commit/aa8e02582dddb739a02b15175d14f42e13a08335) nixos/ollama: split cuda and rocm from service test
* [`8923ec72`](https://github.com/NixOS/nixpkgs/commit/8923ec72b511cf2dbb91623d189de3ad796b0216) lxcfs: lxc.mount.hook: add coreutils to PATH
* [`c2e6a0cf`](https://github.com/NixOS/nixpkgs/commit/c2e6a0cf7ffa1663072ac5f9af79443bb66a0198) k3s_1_29: 1.29.6+k3s1 -> 1.29.6+k3s2
* [`eafccaac`](https://github.com/NixOS/nixpkgs/commit/eafccaac795440d3de103dc9943e784b39f77b6f) stevenblack-blocklist: 3.14.84 -> 3.14.87
* [`03580033`](https://github.com/NixOS/nixpkgs/commit/035800332b99e9be29484af5529e754f11070e3b) python3Packages.pyocd: python 3.12 fixes
* [`dcce54a0`](https://github.com/NixOS/nixpkgs/commit/dcce54a0a765389288d66bdc518d76984c5cd0b4) python3Packages.libusbsio 2.1.11 -> 2.1.12
* [`719a79df`](https://github.com/NixOS/nixpkgs/commit/719a79df78c1d92b4aec6302ed9c44c313fccbac) python3Packages.spsdk 2.1.1 -> 2.2.0
* [`d94a7ad3`](https://github.com/NixOS/nixpkgs/commit/d94a7ad3484f11f966a1b69449e447938e94570c) llvmPackages_git: 19.0.0-git-2024-07-08 -> 19.0.0-git-2024-07-14
* [`5db33d7d`](https://github.com/NixOS/nixpkgs/commit/5db33d7d00cca9cf160792b37f0f1a59b3790f66) warp-terminal: 0.2024.06.25.08.02.stable_01 -> 0.2024.07.09.08.01.stable_00
* [`9b8aaf12`](https://github.com/NixOS/nixpkgs/commit/9b8aaf12dc6a1ecce15f07e328e59ec1bd41c34c) melonDS: 0.9.5-unstable-2024-07-04 -> 0.9.5-unstable-2024-07-14
* [`ce60c7bd`](https://github.com/NixOS/nixpkgs/commit/ce60c7bdd4f68638bf19af93878ed4586fb40d87) python312Packages.twitchapi: 4.2.0 -> 4.2.1
* [`45c22fa4`](https://github.com/NixOS/nixpkgs/commit/45c22fa4a79c14610395bbf4aae8887a2d46edf9) oboete: 0.1.4 -> 0.1.5
* [`ef6a5b71`](https://github.com/NixOS/nixpkgs/commit/ef6a5b71eae8726f0b0429baa2fed7d97f8b2749) envision-unwrapped: 0-unstable-2024-06-25 -> 0-unstable-2024-07-03
* [`b948dc68`](https://github.com/NixOS/nixpkgs/commit/b948dc68a6de885fd2a995ede97af7dea8a256fa) tinymist: 0.11.14 -> 0.11.15
* [`d874e38a`](https://github.com/NixOS/nixpkgs/commit/d874e38a86ad9a001708286ba97214d1df2ddb31) python312Packages.optree: 0.11.0 -> 0.12.1
* [`6ee491a2`](https://github.com/NixOS/nixpkgs/commit/6ee491a2f25002144e2dba415c39210dbfb946d0) python312Packages.aiolifx-themes: 0.4.18 -> 0.4.21
* [`0118b68a`](https://github.com/NixOS/nixpkgs/commit/0118b68af229012ad4b1549d35a2e0030c00f22e) reposilite: 3.5.13 -> 3.5.14
* [`717235bc`](https://github.com/NixOS/nixpkgs/commit/717235bcd232f6f9b9cdbaf2f76470931aa063b7) tuifimanager: 4.0.6 -> 4.1.7 ([nixos/nixpkgs⁠#326616](https://togithub.com/nixos/nixpkgs/issues/326616))
* [`9fdd1c1e`](https://github.com/NixOS/nixpkgs/commit/9fdd1c1e586c337abdf881f51b0088f234a55b34) maintainers: add liammurphy14
* [`8012d2fd`](https://github.com/NixOS/nixpkgs/commit/8012d2fdefa632a416af503213156a7022839359) electron-chromedriver: init at 29.4.4, 30.2.0, 31.2.0
* [`ca66c0da`](https://github.com/NixOS/nixpkgs/commit/ca66c0dadbc164e4c7b7c6d6ee80d4daf92e810b) electron: support updating chromedriver with update.py
* [`8f4567a4`](https://github.com/NixOS/nixpkgs/commit/8f4567a448a115c6abd799bad70024ae4ebc3fc9) kyverno: 1.12.4 -> 1.12.5 ([nixos/nixpkgs⁠#326612](https://togithub.com/nixos/nixpkgs/issues/326612))
* [`c8c6d073`](https://github.com/NixOS/nixpkgs/commit/c8c6d073d9e33d286f5ede2990decc0a6b6987e3) python312Packages.clarifai-grpc: 10.5.4 -> 10.6.3
* [`f0e87420`](https://github.com/NixOS/nixpkgs/commit/f0e87420c94bb89fb46b95f7701bf7b9fca8ce57) linux_6_10: init at 6.10
* [`9d2fa89a`](https://github.com/NixOS/nixpkgs/commit/9d2fa89a58d1f4d826535769ddd81cd3d4e85896) vscode-extensions.elixir-lsp.vscode-elixir-ls: 0.22.0 -> 0.22.1
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
