### PR TITLE
niv nixpkgs: update 5cd5002c -> 8e3eab28

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5cd5002ca676d3c3ba9e4094c4b6a4967c4b1072",
-        "sha256": "1hrscqjb4lrrzqzpks0vkdva9vppc0gsd71sdgl515wj7z963bi1",
+        "rev": "8e3eab28d876d770f7103c26f3d995588202862c",
+        "sha256": "0c6lsklvi7pr7rvlpbhnd5wpsnqwrz9wq4rdbfd6lnk2ifm5sg64",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/5cd5002ca676d3c3ba9e4094c4b6a4967c4b1072.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/8e3eab28d876d770f7103c26f3d995588202862c.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@5cd5002c...8e3eab28](https://github.com/nixos/nixpkgs/compare/5cd5002ca676d3c3ba9e4094c4b6a4967c4b1072...8e3eab28d876d770f7103c26f3d995588202862c)

* [`ef036bfb`](https://github.com/NixOS/nixpkgs/commit/ef036bfba51d9f1f0a4f705e8726c7ac90649618) fakeroot: 1.29 -> 1.32.2
* [`054927c2`](https://github.com/NixOS/nixpkgs/commit/054927c2f17fca05149bf8192c5320d77dbb0d75) po4a: Use absolute path to perl
* [`0d41cda7`](https://github.com/NixOS/nixpkgs/commit/0d41cda7df9c8df8cc0869e98fae064ca75364da) mantainers: add vsharathchandra
* [`25a46651`](https://github.com/NixOS/nixpkgs/commit/25a46651dfcc24c186eb4fad9587b62154891499) python311Packages.tensorflow-estimator-bin: 2.11.0 -> 2.15.0
* [`7a98f6d3`](https://github.com/NixOS/nixpkgs/commit/7a98f6d3ca84ba3cbee695787352d7d8bf6ae123) bubblewrap: 0.8.0 -> 0.9.0
* [`1343c795`](https://github.com/NixOS/nixpkgs/commit/1343c795cb59b273a4893a8ba85ff258ed63702b) flatbuffers: 23.5.26 -> 24.3.25
* [`1c942bab`](https://github.com/NixOS/nixpkgs/commit/1c942babfa83fbf3eb5c0f42f115d5e04d1cac1c) libmicrohttpd: init at 1.0.1
* [`f7250f37`](https://github.com/NixOS/nixpkgs/commit/f7250f372a686599d7db607c5e5a9252e3d25886) lib.warn: Use or behave like builtins.warn
* [`691ae179`](https://github.com/NixOS/nixpkgs/commit/691ae1799766379bfa1f140280fde697a0790b31) appstream: 1.0.2 -> 1.0.3
* [`046691a4`](https://github.com/NixOS/nixpkgs/commit/046691a4997a9302ccf582c3bbcdf1dc0ce4ae80) nixos/restic: Use cat config command in pre-start command for repo initialization
* [`c0558450`](https://github.com/NixOS/nixpkgs/commit/c0558450693d798481f91bbb4d0ccd04371a23c4) dockerTools.streamLayeredImage: add includeNixDB argument, expose conf and streamScript
* [`62e9e0f9`](https://github.com/NixOS/nixpkgs/commit/62e9e0f963afed39d02cba9d9d88dbb7f3bb47cf) dockerTools: add includeNixDB to buildImage and document
* [`4d51990b`](https://github.com/NixOS/nixpkgs/commit/4d51990bc5c4831bc25c29ea3efbcfe3630e2d45) dockerTools: document streamLayeredImage's includeNixDB argument
* [`8891e98f`](https://github.com/NixOS/nixpkgs/commit/8891e98f24db151da233b74725067ea91b19d85a) dockerTools: add nixDB tests
* [`aae4c611`](https://github.com/NixOS/nixpkgs/commit/aae4c61160304a84b06b477808e40c7b8e20ec93) adns: 1.6.0 -> 1.6.1
* [`1cd1651d`](https://github.com/NixOS/nixpkgs/commit/1cd1651d771e6032b03acbe2603aec6a97fc711f) kdePackages.wayland-protocols: 1.35 -> 1.36
* [`7d9102e7`](https://github.com/NixOS/nixpkgs/commit/7d9102e75bad58d9b1460bf4dde70cc31acca76d) libimagequant: 4.3.0 -> 4.3.1
* [`a02f1965`](https://github.com/NixOS/nixpkgs/commit/a02f19658522c5da57adb0234328e3e2643fb46c) tree-sitter: 0.22.5 -> 0.22.6
* [`31edf291`](https://github.com/NixOS/nixpkgs/commit/31edf2914fc5254b0bfed4bf657fd4938205ffed) libplist: 2.4.0 -> 2.6.0
* [`5b37d2cf`](https://github.com/NixOS/nixpkgs/commit/5b37d2cf811b6c7af8f4decc33cd1938fd6ac66f) libcap: 2.69 -> 2.70
* [`39dc5d0d`](https://github.com/NixOS/nixpkgs/commit/39dc5d0d768ec5cb51636b449f08fefd96c70745) faiss: 1.7.4 -> 1.8.0
* [`7ed5395b`](https://github.com/NixOS/nixpkgs/commit/7ed5395b6be6db29b0539440b907b42bb5182c76) libedit: 20230828-3.1 -> 20240517-3.1
* [`6b2acc10`](https://github.com/NixOS/nixpkgs/commit/6b2acc10bd75bab0fde5ce3dc570e836262081b6)  openldap: 2.6.7 -> 2.6.8
* [`ca630f61`](https://github.com/NixOS/nixpkgs/commit/ca630f6102f6cf946bdbb96ecb3f68fdf4f34fcf) gbenchmark: 1.8.3 -> 1.8.4
* [`c51d3e9e`](https://github.com/NixOS/nixpkgs/commit/c51d3e9e145d9e00cecd2d7a798418353d312cfc) sqlite, sqlite-analyzer: 3.45.3 -> 3.46.0
* [`e6aa049f`](https://github.com/NixOS/nixpkgs/commit/e6aa049fa825309bc18cdfd359d433434d91fb56) cmdpack: refactor build/installPhase, fix cross compilation
* [`30971173`](https://github.com/NixOS/nixpkgs/commit/30971173aba3105b42b9cc7976f1c6c9e018b56c) ruby-modules: improve cross-compilation support
* [`b93964f5`](https://github.com/NixOS/nixpkgs/commit/b93964f5e94c073af003a95481242b6beddfd77e) dhcpcd: 10.0.6 -> 10.0.8
* [`923627a8`](https://github.com/NixOS/nixpkgs/commit/923627a8432baa6659c4cb7ad71f18d18994caff) umockdev: 0.18.2 -> 0.18.3
* [`7db2d0f8`](https://github.com/NixOS/nixpkgs/commit/7db2d0f85e38e9700ccc845e5f5076ddf73dfd01) python311Packages.pipx: fix cross compilation
* [`02828ac3`](https://github.com/NixOS/nixpkgs/commit/02828ac32324446552109118f78c35dfb3e8e494) wayland: 1.22.0 -> 1.23.0
* [`8e945401`](https://github.com/NixOS/nixpkgs/commit/8e945401d59dd4a47f7851ab660321da6ad1518d) bind: make systemd service wait for BIND to be ready
* [`9d76da31`](https://github.com/NixOS/nixpkgs/commit/9d76da314b9262ae22086f859f4a815e7b33a54d) meson: 1.4.0 -> 1.4.1
* [`441a9926`](https://github.com/NixOS/nixpkgs/commit/441a99263f90e0b16e778031afc38e3ac1038bde) maintainers: add vglfr
* [`806a3556`](https://github.com/NixOS/nixpkgs/commit/806a3556e04c070160045bc6caba0f3bcf319a42) python312Packages.jupyterlab-execute-time: init at 3.1.2
* [`6e0ab7a9`](https://github.com/NixOS/nixpkgs/commit/6e0ab7a9d55d12b7040e881d074d395ddde78a23) python312Packages.pbar: init at 2.2.1
* [`4ea8c252`](https://github.com/NixOS/nixpkgs/commit/4ea8c252aa80bf84d8cf0239be6d8361dd700e8c) libevdev: 1.13.1 -> 1.13.2
* [`aa8b17ba`](https://github.com/NixOS/nixpkgs/commit/aa8b17baf32467031e2265cf57be77f852d8af1b) buildRubyGem: do not patch shebangs in non-existent directory
* [`f1fd29c7`](https://github.com/NixOS/nixpkgs/commit/f1fd29c7b93b8e0fa12b16ca5bb681ce85dbcc73) python312Packages.oddsprout: init at 0.1.0
* [`f049304b`](https://github.com/NixOS/nixpkgs/commit/f049304b69147dd74d8a0eb82d3150dafd3eb97e) ell: 0.65 -> 0.66
* [`6c4c7909`](https://github.com/NixOS/nixpkgs/commit/6c4c7909de30d2f0e6ec4ca7f322cb27b84741d1) iwd: 2.17 -> 2.18
* [`4584ea07`](https://github.com/NixOS/nixpkgs/commit/4584ea07677102f3d93088fb7b842ef6a91ab433) lib.warn: Say _evaluation_ warning, like builtins.warn
* [`bdb5db09`](https://github.com/NixOS/nixpkgs/commit/bdb5db0942bc37bd2e6423c9cd95a738ad519843) mailcap: 2.1.53 -> 2.1.54
* [`1d974646`](https://github.com/NixOS/nixpkgs/commit/1d974646eac4be2e9aa4aa1860af635dc3986bf4) python312Packages.samarium: init at 0.5.3
* [`f44584d4`](https://github.com/NixOS/nixpkgs/commit/f44584d4dedc7f7a83318aa68f3a5a2dd37a0235) mailcap: add update script
* [`aef7273b`](https://github.com/NixOS/nixpkgs/commit/aef7273b6ca48d041bad01b16788ae0a69dabb9c) frei0r: 2.3.2 -> 2.3.3
* [`0626ef81`](https://github.com/NixOS/nixpkgs/commit/0626ef812400f2653a56674d293e4749a7dddc8c) texinfo: refactor
* [`e6f90729`](https://github.com/NixOS/nixpkgs/commit/e6f90729d2a9cef030b48b58fad9180b134d2796) texinfo: 7.0.3 -> 7.1
* [`3ddf4322`](https://github.com/NixOS/nixpkgs/commit/3ddf4322faa28893ea837a11559cd272db7bea35) texinfo: Format with nixfmt
* [`192b17b5`](https://github.com/NixOS/nixpkgs/commit/192b17b56937c985ad619ccb43ac4da7f4316519) ensureNewerSourcesHook: handle $sourceRoot that starts with dash
* [`a3f1b476`](https://github.com/NixOS/nixpkgs/commit/a3f1b476c71154478fe844ea293adc399ccd9271) setup-hooks/set-source-date-epoch-to-latest.sh: handle $path that starts with dash
* [`193fd8a2`](https://github.com/NixOS/nixpkgs/commit/193fd8a237ce715a94ce89ec6e7f61c2da9510d1) generic/setup.sh: handle $sourceRoot that starts with dash
* [`b20e29f3`](https://github.com/NixOS/nixpkgs/commit/b20e29f3673d909f952349838b391ec937c8b0cf) libmaxminddb: 1.9.1 -> 1.10.0
* [`463a120c`](https://github.com/NixOS/nixpkgs/commit/463a120c25e48616e4c2ece380720cee2aaf7c56) libaom: 3.9.0 -> 3.9.1
* [`e6503862`](https://github.com/NixOS/nixpkgs/commit/e65038628b54a0536748a2d93551d9516b984448) jansson: migrate to by-name
* [`326bbd2a`](https://github.com/NixOS/nixpkgs/commit/326bbd2a1bb3cc18695d1921d508f41d40a292ad) jansson: format with nixfmt
* [`9b11c7fd`](https://github.com/NixOS/nixpkgs/commit/9b11c7fdef7723e62240ed1220faa27b672e7649) jansson: adopt
* [`547c1ca8`](https://github.com/NixOS/nixpkgs/commit/547c1ca823ae706d5e1490a75fd5a29eb7dfde4b) jansson: modernize
* [`d7598538`](https://github.com/NixOS/nixpkgs/commit/d75985387e9aab0ba89bc2de2ca720c6e5f69255) jansson: add validatePkgConfig hook
* [`fb10cb80`](https://github.com/NixOS/nixpkgs/commit/fb10cb806862cebb53360ab3db7c60aac52bcdda) jansson: add pkg-config test
* [`cc3f383f`](https://github.com/NixOS/nixpkgs/commit/cc3f383f563cbc007df91a1ec1277eee5696ff6c) jansson: add updateScript
* [`7bde538b`](https://github.com/NixOS/nixpkgs/commit/7bde538b09855752d07c1c0e3abf015031d941cc) jansson: split outputs
* [`507a9dee`](https://github.com/NixOS/nixpkgs/commit/507a9dee1dc2d10ee35a142667a870c094688947) chiaki4deck: restore check for curl websocket support
* [`767cf0c7`](https://github.com/NixOS/nixpkgs/commit/767cf0c71478fdd63debbd9fdb45907cbb497edb) av1an: init at 0.4.2
* [`3fbb2358`](https://github.com/NixOS/nixpkgs/commit/3fbb235809eaf5309ec58a85f3b32c06f49e7cf7) freeglut: 3.4.0 -> 3.6.0
* [`081b77fc`](https://github.com/NixOS/nixpkgs/commit/081b77fce315f2a4f3def5043cbb9b733434a7a9) dav1d: 1.4.1 -> 1.4.3
* [`d544b125`](https://github.com/NixOS/nixpkgs/commit/d544b1259ac1e15d4ac0e49daa6ac5a4f7fee92b) trivial: fix pkgs.writeText test to pass string
* [`5aa55272`](https://github.com/NixOS/nixpkgs/commit/5aa55272c2f3fa7b720b5231d3b2f4f2dc731a13) trivial: input type assertions for writeText
* [`9f4b1064`](https://github.com/NixOS/nixpkgs/commit/9f4b1064c6c9464194eb47cca6f2f42bdbd5c6da) trivial: make pkgs.writeText always fixed output
* [`0b95f8d9`](https://github.com/NixOS/nixpkgs/commit/0b95f8d98d03dc439c0d8a2b8d8694e59959152e) libfido2: 1.14.0 -> 1.15.0
* [`1f908baa`](https://github.com/NixOS/nixpkgs/commit/1f908baaa169621f81192d5c2ba1a07c31a532b9) ruby_3_1: 3.1.5 -> 3.1.6
* [`aa86df04`](https://github.com/NixOS/nixpkgs/commit/aa86df04519693f7c8778b954900719304ed433a) ruby_3_3: 3.3.2 -> 3.3.3
* [`56e85096`](https://github.com/NixOS/nixpkgs/commit/56e85096ef2d3b31b5d6fae6699d9fc6d1b145c7) curl: fix ca certificates with gnutls
* [`89621518`](https://github.com/NixOS/nixpkgs/commit/89621518871e0e9bffc6fc8bce6164b7c161b2e4) kdePackages.packagekit-qt: 1.1.1 -> 1.1.2
* [`b51c105f`](https://github.com/NixOS/nixpkgs/commit/b51c105f921fc2d93c1e7e76f7293b31679504c4) packagekit: 1.2.8 -> 1.3.0
* [`f39973fe`](https://github.com/NixOS/nixpkgs/commit/f39973fe655705d99f290fa8530d54c74bf58858) libbsd: 0.11.8 -> 0.12.2
* [`e66447ad`](https://github.com/NixOS/nixpkgs/commit/e66447ad4db1e10ccc47c0fa45a9569c15d1b8a5) openpam: migrate to by-name
* [`d30ba201`](https://github.com/NixOS/nixpkgs/commit/d30ba201bf2159ba55a936560b53f9cf76a34cfd) openpam: 20170430 -> 20230627
* [`a447ebb0`](https://github.com/NixOS/nixpkgs/commit/a447ebb01b24ae1e7e30f9aeef7e4fabe0d15e68) google-cloud-sql-proxy: add passthru.updateScript
* [`fdcb3bc4`](https://github.com/NixOS/nixpkgs/commit/fdcb3bc46dfd65f73ecd21962e978b318642a965) python312Packages.prometheus-fastapi-instrumentator: init at 7.0.0
* [`bf2a2ed4`](https://github.com/NixOS/nixpkgs/commit/bf2a2ed403573166284a69aca0de72ddbb8ec79a) tailscale-gitops-pusher: init at 1.68.0
* [`d20d33da`](https://github.com/NixOS/nixpkgs/commit/d20d33daac3541ee289ebb5c9b46de644d0ae4d5) gnustep.gui: 0.30.0 -> 0.31.1
* [`6a4a325e`](https://github.com/NixOS/nixpkgs/commit/6a4a325e33cb859e3fcce40bb41110eaa9107fad) gnustep.back: 0.30.0 -> 0.31.0
* [`534985fe`](https://github.com/NixOS/nixpkgs/commit/534985feaaf54b84e69e58087df4c2edadd3c92f) ldb: 2.9.0 -> 2.9.1
* [`0a881454`](https://github.com/NixOS/nixpkgs/commit/0a8814545a1e224a7d5eacedfdb0f195e9189f08) dns-root-data: add DS for the new KSK-2024
* [`32c15de8`](https://github.com/NixOS/nixpkgs/commit/32c15de8d19123e837bf145b72d4c7703ba720d5) python312Packages.htmltools: init at 0.5.2
* [`e2051347`](https://github.com/NixOS/nixpkgs/commit/e2051347b4bf0cf3c046172d4de268051392ee36) appstream: fix cross compilation
* [`ce56358d`](https://github.com/NixOS/nixpkgs/commit/ce56358d224003b4c31cbc0f6302a3decaa27dc4) switch-to-configuration-ng: update dependencies
* [`6a6b710f`](https://github.com/NixOS/nixpkgs/commit/6a6b710fbf9ab575619725d37205fa19caf5c6d4) switch-to-configuration-ng: fix error messages
* [`3d1ecbd9`](https://github.com/NixOS/nixpkgs/commit/3d1ecbd9c8a509f9faac2919e93890f1774ccba8) switch-to-configuration-ng: fix running on WSL
* [`54742720`](https://github.com/NixOS/nixpkgs/commit/5474272067063b084c3a57635ef72e2822a27c47) openjdk: configure build to support a Clang-based stdenv
* [`4105fb33`](https://github.com/NixOS/nixpkgs/commit/4105fb3312e8fe2b87cd212e17d84aaa8284d79a) python3Packages.ansitable: init at 0.10.0
* [`b9116dc0`](https://github.com/NixOS/nixpkgs/commit/b9116dc0a275745961daf94a2a9ef5bebdf57f9c) python3Packages.rtb-data: init at 1.0.1
* [`df5bf2f5`](https://github.com/NixOS/nixpkgs/commit/df5bf2f5f08d9c3ddbb611d09f656020b37addb0) rsync: fix missing ipv6 support (again)
* [`e00e2a2a`](https://github.com/NixOS/nixpkgs/commit/e00e2a2a4ac99307403bad92f0209dde293dee87) libva: 2.21.0 -> 2.22.0
* [`2d53d43c`](https://github.com/NixOS/nixpkgs/commit/2d53d43c1cf3da318c15caa14290f6cb04352063) bluez: 5.75 → 5.76
* [`9088fd75`](https://github.com/NixOS/nixpkgs/commit/9088fd75ebd32b25a71e9508ce0427e186185e61) cups: 2.4.8 -> 2.4.10
* [`26b7b2fe`](https://github.com/NixOS/nixpkgs/commit/26b7b2fe4d95856c1d44751f0035292b5d98362c) polkit: Apply unreleased patch to fix pkexec without a graphical agent
* [`7a365824`](https://github.com/NixOS/nixpkgs/commit/7a36582458547076a4aea2b1e5c66b0aa77c81d7) haskellPackages.safe-exceptions: fix strictDeps build
* [`4a86b9e5`](https://github.com/NixOS/nixpkgs/commit/4a86b9e517b7b9c62b63254530cc8d72017ca454) msgpack-c: 6.0.1 -> 6.0.2
* [`aa9f33fc`](https://github.com/NixOS/nixpkgs/commit/aa9f33fc9a1df5eb7a9c02b029389e0be07b0dea) kdePackages.qca: 2.3.8 -> 2.3.9
* [`65da162f`](https://github.com/NixOS/nixpkgs/commit/65da162fa7e8ebf9f31bf82341210acacefd2e22) meson: use _accumFlagsArray
* [`92df0c63`](https://github.com/NixOS/nixpkgs/commit/92df0c6308d257226a014abdcd4643e691d34030) glslang: 14.2.0 -> 14.3.0
* [`8a826cb8`](https://github.com/NixOS/nixpkgs/commit/8a826cb8f8de93b4b494e12808e2b87fcc7fe611) pahole: 1.26 -> 1.27
* [`d354c891`](https://github.com/NixOS/nixpkgs/commit/d354c891fbb0587a6a05fe3b67a902cfb3d8543c) pahole: reproducibility: use --reproducible_build instead of -j1
* [`df03fbf3`](https://github.com/NixOS/nixpkgs/commit/df03fbf358920369685d8b88d68da366af78cb03) pahole: fix issue with LLVM compiled kernels
* [`dbd9745e`](https://github.com/NixOS/nixpkgs/commit/dbd9745e11c65cb89fa81b0181b322cd5683f4cb) openjdk: remove gnome_vfs & GConf
* [`92bc04ea`](https://github.com/NixOS/nixpkgs/commit/92bc04eae7292d566b53453b00cb81de7e7c784a) nodejs_20: 20.14.0 -> 20.15.0 ([nixos/nixpkgs⁠#321292](https://togithub.com/nixos/nixpkgs/issues/321292))
* [`3d4e7b46`](https://github.com/NixOS/nixpkgs/commit/3d4e7b461c0420b02ac68bdceb59b77a7953d92e) audit: apply patches unconditionally
* [`b87367d6`](https://github.com/NixOS/nixpkgs/commit/b87367d6cea7958c14ec4e959af5d17629806503) iproute2: add libbpf support
* [`35420c7d`](https://github.com/NixOS/nixpkgs/commit/35420c7d2478d02a43d5440ea1fa744c0b76d62c) libsepol: 3.6 -> 3.7
* [`1e217f05`](https://github.com/NixOS/nixpkgs/commit/1e217f05a3b6b27d2f3e94ed8abd7d989753b6d5) libdrm: 2.4.121 -> 2.4.122
* [`0a4b34b2`](https://github.com/NixOS/nixpkgs/commit/0a4b34b2096276eed790b6d38656f328e0149e38) kmod: backport patch for musl 1.2.5 ([nixos/nixpkgs⁠#322720](https://togithub.com/nixos/nixpkgs/issues/322720))
* [`6ea4bc06`](https://github.com/NixOS/nixpkgs/commit/6ea4bc06ebfb94fa693f2afe1e4aaa28bd1d79f5) libcanberra: enable systemd support
* [`0774766f`](https://github.com/NixOS/nixpkgs/commit/0774766ffe9cb1304d69cbb4f4b8fb261900b258) openjdk: rename enableGnome2 to enableGtk
* [`b68dd007`](https://github.com/NixOS/nixpkgs/commit/b68dd007fa2708e505e142751e2c8c1c8c50018d) python312Packages.brotli: fix src FOD hash
* [`48f68c20`](https://github.com/NixOS/nixpkgs/commit/48f68c20546949d31d56e3d68b648636f4f5094c) python3Packages.asgiref: 3.7.2 -> 3.8.1
* [`cd0000cc`](https://github.com/NixOS/nixpkgs/commit/cd0000cc68935ae1dc6b0a0260d7b013989c5fd3) libjxl: 0.10.2 -> 0.10.3
* [`8a19e84b`](https://github.com/NixOS/nixpkgs/commit/8a19e84bc41970f0576403c2f29ea31df07c5b91) linux: enable CONFIG_BT_HCIUART_BCM
* [`14d17610`](https://github.com/NixOS/nixpkgs/commit/14d17610a912a810741c58ae2498d540179f5215) linux: enable CONFIG_SND_HDA_CODEC_CS8409
* [`a63b515b`](https://github.com/NixOS/nixpkgs/commit/a63b515bdf447c4290b0274f7da575e35c622d26) libinput: 1.26.0 -> 1.26.1
* [`ef9be5dd`](https://github.com/NixOS/nixpkgs/commit/ef9be5ddebbc7aac8510d4d3f3a16810f6b944e7) krb5: 1.21.2 -> 1.21.3
* [`f814e5cb`](https://github.com/NixOS/nixpkgs/commit/f814e5cb8f08ef2687595ba03a0d9c8511a3ddfe) Revert "trivial: make pkgs.writeText always fixed output"
* [`a54099c1`](https://github.com/NixOS/nixpkgs/commit/a54099c1b85e14bf57e13edb55dfe4879b8efb5d) nodejs_18: 18.20.2 -> 18.20.3 ([nixos/nixpkgs⁠#316262](https://togithub.com/nixos/nixpkgs/issues/316262))
* [`98e868a0`](https://github.com/NixOS/nixpkgs/commit/98e868a0949afab2d375a292910bfe60b0242955) s2n-tls: 1.4.16 -> 1.4.17
* [`3beb1da1`](https://github.com/NixOS/nixpkgs/commit/3beb1da1931e2f613c1f1e13cfa4d6285751027b) nss: 3.90.2 -> 3.101.1
* [`b528eac1`](https://github.com/NixOS/nixpkgs/commit/b528eac1873635d7c6cdf2dcc6a86bae694de3b5) watchman: fix build with rustc >= 1.79
* [`c5e1c750`](https://github.com/NixOS/nixpkgs/commit/c5e1c7505cfeebc3261e3118b46f1ce0287fbe54) svt-av1: 2.0.0 -> 2.1.2
* [`e2cb76e4`](https://github.com/NixOS/nixpkgs/commit/e2cb76e4ce18ad1992d21959ce9b63dbce825d8f) go: drop gccgo bootstrap, drop autoPatchelfHook from bootstrap ([nixos/nixpkgs⁠#322825](https://togithub.com/nixos/nixpkgs/issues/322825))
* [`319736f6`](https://github.com/NixOS/nixpkgs/commit/319736f69f10f920cec25b2b72a1aa9f6038f2a5) lib.getLicenseFromSpdxId: improve documentation
* [`10d2e6c9`](https://github.com/NixOS/nixpkgs/commit/10d2e6c906ab535232549e23546aa29fd6f9cf76) lib.getLicenseFromSpdxIdOr: init
* [`4f8de0d5`](https://github.com/NixOS/nixpkgs/commit/4f8de0d5512a4a25448bf2c6588fc401139ff5c7) cmake: Add -type f filter to find command
* [`eafa0f0f`](https://github.com/NixOS/nixpkgs/commit/eafa0f0f42b400302d1f85399d5345c658f4700d) maintainers: add tfkhdyt
* [`662ad7a3`](https://github.com/NixOS/nixpkgs/commit/662ad7a3f626760fa964b63d699a2a3a29b85b90) urban-cli: init at 0.2.4
* [`543efca4`](https://github.com/NixOS/nixpkgs/commit/543efca465ee63602491b5e05f15e5e8e18bea80) glfw: add missing substitutions in glfw3
* [`f2f7ea87`](https://github.com/NixOS/nixpkgs/commit/f2f7ea87e8e97e20ea21b8125eda3d6845ebcdcb) nodejs: fix impure configure phase
* [`3a9d1c72`](https://github.com/NixOS/nixpkgs/commit/3a9d1c727d8eac4032dbe716c8b323e1113e1c26) jetbrains.plugins: add scala
* [`96c60c6b`](https://github.com/NixOS/nixpkgs/commit/96c60c6b09322a6aae67dd3df83aadeffe1959ab) nixos/freshrss: add ability to use socket path
* [`484dd2f9`](https://github.com/NixOS/nixpkgs/commit/484dd2f92f13113c2c5367952d19c7733c60d7d8) addOpenGLRunpath: deprecate
* [`416ba880`](https://github.com/NixOS/nixpkgs/commit/416ba8804bf31201778202a2bfc33c9cfaaf602b) treewide: use addDriverRunpath
* [`14d51d6e`](https://github.com/NixOS/nixpkgs/commit/14d51d6ebc4021939b57dd2554bd75e1cba2ad1f) linux: enable CONFIG_SND_HDA_CODEC_CS8409: restrict kernel >=6.6
* [`e986a0d5`](https://github.com/NixOS/nixpkgs/commit/e986a0d56c1889960c6affd3713a6937f2d1b4b5) zls: 0.12 -> 0.13
* [`8001cc40`](https://github.com/NixOS/nixpkgs/commit/8001cc402f61b8fd6516913a57ec94382455f5e5) zls: add 0x5a4 as maintainer
* [`2fdd709e`](https://github.com/NixOS/nixpkgs/commit/2fdd709e7a385179aceee46adca4e1d8a72b50e3) cacert: 3.101 -> 3.101.1
* [`040c4602`](https://github.com/NixOS/nixpkgs/commit/040c460262aa3165ab6e95cefbb320a05ef03622) Revert "rustc: avoid rebuild on linux right now"
* [`04cc8a59`](https://github.com/NixOS/nixpkgs/commit/04cc8a59346ae933215a5612bc2eb63b1e16da4f) re2: 2024-06-01 -> 2024-07-02
* [`0812283b`](https://github.com/NixOS/nixpkgs/commit/0812283be90a8db2ce04afea7965f3c3189eb9d8) nodePackages: remove __attrsFailEvaluation in all-packages
* [`fedd6b2e`](https://github.com/NixOS/nixpkgs/commit/fedd6b2efaf49aa04fd94621e50b2e1fd5577afd) eclipses.plugins: remove __attrsFailEvaluation
* [`a1614c9d`](https://github.com/NixOS/nixpkgs/commit/a1614c9d561ec9ccf747c4d562c417cb485ee5aa) scons: move to by-name, update to 4.7.0, drop all the old versions
* [`ecfc551f`](https://github.com/NixOS/nixpkgs/commit/ecfc551ff8782a494718639c8b807c439f951d30) ffado: fix eval
* [`1fd673ac`](https://github.com/NixOS/nixpkgs/commit/1fd673ac02a3cc2e5c7a69de3be5769d4be80696) openvino: fix eval
* [`90cb9fa1`](https://github.com/NixOS/nixpkgs/commit/90cb9fa187df144d5dfe32cc0f7f027346223159) python312Packages.jupyterlab-execute-time: review fixes
* [`78d5ebed`](https://github.com/NixOS/nixpkgs/commit/78d5ebed1acd3b7931cee7d0914ed225d8e22090) zlib-ng: 2.1.7 -> 2.2.1
* [`ba16633f`](https://github.com/NixOS/nixpkgs/commit/ba16633fea5a0548ba1606a918cace2f5dc5cf30) mealie: fix Darwin builds
* [`55e50221`](https://github.com/NixOS/nixpkgs/commit/55e502211ad3cd95903538b1bd6f2b9dc8587c2a) libplacebo: 6.338.2 -> 7.349.0
* [`37007db7`](https://github.com/NixOS/nixpkgs/commit/37007db77c5d7517e19a4c2bf290eaf4cb50ac96) linux: move hexdump to nativeBuildInputs
* [`2299f666`](https://github.com/NixOS/nixpkgs/commit/2299f66620bb88558d509decd0f6a03fafde0cae) python311Packages.textual: refactor
* [`b3bef99d`](https://github.com/NixOS/nixpkgs/commit/b3bef99d14e1f178bcf62188faade16d3f74274e) onlyoffice: drop 7.2.0 version
* [`41ffc4bf`](https://github.com/NixOS/nixpkgs/commit/41ffc4bf9a7627b514336de05b723e62c0764bdb) python312Packages.pybind11: 2.12.0 -> 2.13.1
* [`1fe40c00`](https://github.com/NixOS/nixpkgs/commit/1fe40c0034c4e76dc241f97c033bd28906112abe) python312Packages.scipy: relax pybind11 constraint
* [`a9709c29`](https://github.com/NixOS/nixpkgs/commit/a9709c299b8a48839ad044cccaaf11f6caf614c3) treewide: change cargoSha256 with SRI hash to cargoHash
* [`5b63ef2a`](https://github.com/NixOS/nixpkgs/commit/5b63ef2a48545b449121e522a8d8cfd86dfc9dd5) treewide: change cargoSha256 with SRI hash to cargoHash manually
* [`1862813d`](https://github.com/NixOS/nixpkgs/commit/1862813d11b34e56e4724a9fac69610b5d8d2015) treewide: convert cargoSha256 to cargoHash
* [`ede1ffbd`](https://github.com/NixOS/nixpkgs/commit/ede1ffbdfc75b5546db0218f9c6c7dd6761de473) rover: use cargoHash instead of cargoSha256 in updateScript
* [`07fddc62`](https://github.com/NixOS/nixpkgs/commit/07fddc62e49dc8dbe7fe99266602826f305a041a) buildRustPackage: deprecate cargoSha256 in favor of cargoHash
* [`cb931492`](https://github.com/NixOS/nixpkgs/commit/cb93149275bb21205650bc942f4b5993bc5c9394) doc/rust: deprecate cargoSha256
* [`f6ee8a0b`](https://github.com/NixOS/nixpkgs/commit/f6ee8a0bdcace1518c86fcb3b5ad76b167e95ef1) nixos/doc/rl-2411: mention cargoSha256 deprecation
* [`2082109d`](https://github.com/NixOS/nixpkgs/commit/2082109d30094f95bf852ebf31cb25a1234155a1) linux: enable EFI_ZBOOT for generic compression support
* [`fd4cba37`](https://github.com/NixOS/nixpkgs/commit/fd4cba375d1b5e021f4d35ddba1b9112d3ee6681) gnome2.libgnomeui: remove
* [`9dcf8132`](https://github.com/NixOS/nixpkgs/commit/9dcf8132c996c788d67f842fe78492a593b5be68) gnome2.libgnome: remove
* [`77f5a747`](https://github.com/NixOS/nixpkgs/commit/77f5a747f44917e040a1bd0dfbde5c1a01e17410) gnome2.gnome_vfs: remove
* [`9fb7750c`](https://github.com/NixOS/nixpkgs/commit/9fb7750cdd51ad5d289391e8f72cb86634203b26) gnome2.libbonoboui: Remove
* [`9f3282ec`](https://github.com/NixOS/nixpkgs/commit/9f3282ec3b54ebca61476e8955c509b497c87990) gnome2.libbonobo: Drop
* [`44cce81d`](https://github.com/NixOS/nixpkgs/commit/44cce81d0f084abd6468120f36f798271f4e125b) gnutls: 3.8.5 -> 3.8.6
* [`d5c83b4a`](https://github.com/NixOS/nixpkgs/commit/d5c83b4a42ce9d7e4414ab7e4dbf8c69b40fa97c) linux: restrict zboot to aarch64
* [`0a5599cd`](https://github.com/NixOS/nixpkgs/commit/0a5599cda2cd2c442c27bc37d36826956245f2ab) ffado: 2.4.8 → 2.4.9
* [`f94db727`](https://github.com/NixOS/nixpkgs/commit/f94db72728355b347c71d1823f232b01c93685ac) ffado: Remove Qt dependency
* [`343caa6c`](https://github.com/NixOS/nixpkgs/commit/343caa6c47b554fdb802d4bda759c97528afa169) meson: add patch to find boost via pkg-config
* [`821841dd`](https://github.com/NixOS/nixpkgs/commit/821841dd87f4fa90c60a08f9d4e1c36130259250) boost: add a pkg-config file
* [`cde3f1ca`](https://github.com/NixOS/nixpkgs/commit/cde3f1cadacfe853b1afe6429300d16b15aa367b) treewide: Remove now unnecessary boost vars
* [`d0eebe82`](https://github.com/NixOS/nixpkgs/commit/d0eebe82f63b05fd6fb4061d0d51720cd427936d) bluez: fix hid devices
* [`f0769acc`](https://github.com/NixOS/nixpkgs/commit/f0769acc65ac7c4085d757cfde2e0667bff79956) s2n-tls: 1.4.16 -> 1.4.17 ([nixos/nixpkgs⁠#314094](https://togithub.com/nixos/nixpkgs/issues/314094))
* [`39984096`](https://github.com/NixOS/nixpkgs/commit/399840962e3290e870e4deb2ee6677d51812f0cf) p11-kit: 0.25.3 -> 0.25.5
* [`87327df1`](https://github.com/NixOS/nixpkgs/commit/87327df1061ee068d2a1d1b2d8bd72a68e010cc5) nodejs_22: 22.3.0 -> 22.4.0 ([nixos/nixpkgs⁠#323982](https://togithub.com/nixos/nixpkgs/issues/323982))
* [`cba1e458`](https://github.com/NixOS/nixpkgs/commit/cba1e458a84949a0e5324f00ecf2e3feeb15afa2) netdata: 1.45.4 -> 1.46.1
* [`8f413d8a`](https://github.com/NixOS/nixpkgs/commit/8f413d8a44d713dc9cff2ad1e4bcc248a7961fa3) binlore: migrate override lore to package passthru
* [`3abc5f70`](https://github.com/NixOS/nixpkgs/commit/3abc5f7093e5849eccc7e1ab82a48861c4ac4489) pidginPackages: move __attrsFailEvaluation to allow deeper evaluation
* [`1ba85e5f`](https://github.com/NixOS/nixpkgs/commit/1ba85e5fd5ed2d2607b6cfebd8dbb1369a1e7d84) qt5.srcs: remove __attrsFailEvaluation
* [`4122d072`](https://github.com/NixOS/nixpkgs/commit/4122d072e5c32490b8da55975f84e03743eb47f9) rustPackages.buildRustPackages: allow one level of introspection before applying __attrsFailEvaluation
* [`4640ede4`](https://github.com/NixOS/nixpkgs/commit/4640ede492f5c279604ae846a0de85132a0f2822) coqPackages: allow one level of introspection before applying __attrsFailEvaluation
* [`ca22006a`](https://github.com/NixOS/nixpkgs/commit/ca22006a5098b414220438a275f405168fe930d6) plasma5Packages: all attrsets evaluate, so remove __attrsFailEvaluation
* [`a6e78a2f`](https://github.com/NixOS/nixpkgs/commit/a6e78a2fa44975e9634fdacfa6edf9b71c0c48a2) javaPackages.compiler.adoptopenjdk: all attrsets evaluate, so remove __attrsFailEvaluation
* [`0213840c`](https://github.com/NixOS/nixpkgs/commit/0213840cd81107c120699c2fb898b2829df2c370) pythonPackages: move __attrsFailEvaluation to allow deeper inspection
* [`89fcddbc`](https://github.com/NixOS/nixpkgs/commit/89fcddbc8c233343a5b97d40b8283257d3448487) doc/meta: Add sourceProvenance to "Standard meta-attributes" section
* [`704677d1`](https://github.com/NixOS/nixpkgs/commit/704677d109df94fb9360ce4e60329b0578537e3f) haskellPackages: remove __attrsFailEvaluation, buildHaskellPackages, and generateOptparseApplicativeCompletions special cases
* [`9507e176`](https://github.com/NixOS/nixpkgs/commit/9507e176ae0af6ddcb32b08815a2ff34dbcf80ba) resticprofile: init at 0.27.0
* [`befa36d8`](https://github.com/NixOS/nixpkgs/commit/befa36d8b0dbb12461bd9ef7ca29f936ab8a7123) llvmPackages: 17.0.6 -> 18.1.5 on Linux ([nixos/nixpkgs⁠#312981](https://togithub.com/nixos/nixpkgs/issues/312981))
* [`3f6aa201`](https://github.com/NixOS/nixpkgs/commit/3f6aa2017aa8a61a173b343dc4a551182488e1f9) libkrunfw: 4.0.0 -> 4.0.0-unstable-2024-06-10, build on aarch64
* [`0d44d96f`](https://github.com/NixOS/nixpkgs/commit/0d44d96f5b9b838358fbdead146ddee8d551c858) libkrun: 1.9.2 -> 1.9.3, add more options
* [`ab4247be`](https://github.com/NixOS/nixpkgs/commit/ab4247be8c8dd04b8bd49057e0fdd64a95f8937c) krun: init at 0-unstable-2024-06-18
* [`9e54afc0`](https://github.com/NixOS/nixpkgs/commit/9e54afc0aab1ee5462b033fc3351e703aa163995) libunistring: 1.1 -> 1.2
* [`963c56ce`](https://github.com/NixOS/nixpkgs/commit/963c56ce6fb9c7fb4697eef301bdc14acf30a06b) libunistring: rec -> finalAttrs, nixfmt-rfc-style
* [`19b834e1`](https://github.com/NixOS/nixpkgs/commit/19b834e17fc9189ea94d02a6c4a63818c93d8528) libunistring: fix build on darwin
* [`bdaad464`](https://github.com/NixOS/nixpkgs/commit/bdaad46436bb868945514442e675105c3add52c4) python312Packages.discordpy: 2.3.2 -> 2.4.0
* [`e2254dba`](https://github.com/NixOS/nixpkgs/commit/e2254dbadf909ce97a0c1aedeaec45a39fd08d32) gpgme: patch out LFS64 usage ([nixos/nixpkgs⁠#324771](https://togithub.com/nixos/nixpkgs/issues/324771))
* [`4dec9be4`](https://github.com/NixOS/nixpkgs/commit/4dec9be42a2e1589874956221e6e976b23bd7954) buildRubyGem: do not override fixupPhase ([nixos/nixpkgs⁠#323587](https://togithub.com/nixos/nixpkgs/issues/323587))
* [`d976a671`](https://github.com/NixOS/nixpkgs/commit/d976a67189123a259d08093b6ff353a8f49696cf) zsh: fix compatibility with texinfo 7.1
* [`21ad4b3a`](https://github.com/NixOS/nixpkgs/commit/21ad4b3a71f6dd460fae07fe04090039f91c53bf) shadow: 4.14.6 -> 4.16.0
* [`e99754e3`](https://github.com/NixOS/nixpkgs/commit/e99754e3a456c0248e15e35d26850a5e180ca5d1) hwdata: 0.383 -> 0.384
* [`83aaf618`](https://github.com/NixOS/nixpkgs/commit/83aaf6183611b2816a35d3d437eb99177d43378f) cargo,clippy,rustc,rustfmt: 1.78.0 -> 1.79.0
* [`45c85e2b`](https://github.com/NixOS/nixpkgs/commit/45c85e2b1d6d3a26b9bc846e0146b1d6f498000c) ffado: Add comment about Python 3.11 override
* [`5bf99d06`](https://github.com/NixOS/nixpkgs/commit/5bf99d06948c6e6dc7de7dff3d7518d207f442e0) nodejs: remove unused bypass-xcodebuild.diff
* [`ce685a84`](https://github.com/NixOS/nixpkgs/commit/ce685a84225f553a22a47b79abbf7e7e009a8e26) nodejs: fix sandboxed build on darwin
* [`97240ea0`](https://github.com/NixOS/nixpkgs/commit/97240ea0ac7bfec5aed52b1899ce371b85436edc) nodejs: add testVersion to passthru.tests
* [`90b11e40`](https://github.com/NixOS/nixpkgs/commit/90b11e4031a6d1236657d7509ff0790ea4285712) openssl: fix CVE-2024-5535
* [`ca9096d7`](https://github.com/NixOS/nixpkgs/commit/ca9096d7e85c292a0e40373ad1fbb72ebe95eb35) libgpg-error: 1.49 -> 1.50
* [`ae5109cf`](https://github.com/NixOS/nixpkgs/commit/ae5109cf597d3b724ddac4e8976ef95b522f0a98) python312Packages.fastapi-cli: add mainProgram and changelog
* [`7b40ca9e`](https://github.com/NixOS/nixpkgs/commit/7b40ca9eb22f07d0696fdca0aa80884134af01f6) nghttp2: 1.61.0 -> 1.62.1
* [`9d5d4154`](https://github.com/NixOS/nixpkgs/commit/9d5d41542dcd467c39fd510ba0b22ee9fae375e8) harfbuzz: 8.4.0 -> 9.0.0
* [`ad9505dd`](https://github.com/NixOS/nixpkgs/commit/ad9505ddce7bb6d88429906ebf65925f92799b15) python3Packages.pythonRelaxDepsHook: update example
* [`b85639c5`](https://github.com/NixOS/nixpkgs/commit/b85639c5890abf2eb3ab6757b036529a035b6235) lib.licenses: refactor internal mkLicense to avoid future typo bugs
* [`c00d3f94`](https://github.com/NixOS/nixpkgs/commit/c00d3f940fdce5afa80d704a3f1755bb66bc30ed) gdb: 14.2 -> 15.1
* [`f2e5e8b1`](https://github.com/NixOS/nixpkgs/commit/f2e5e8b1add751e01b077e573963f6500bd9d9b4) libunistring: fix sdk version
* [`9e5e340f`](https://github.com/NixOS/nixpkgs/commit/9e5e340fb8e44cb1aa409c7f3e44c4b6077747cc) multipass: reformat with nixfmt-rfc-style
* [`816ff1ce`](https://github.com/NixOS/nixpkgs/commit/816ff1ce7518e2df87f824d0839774bc1a7d5ab7) multipass: use `--replace-fail` in calls to `substituteInPlace`
* [`eb3235cb`](https://github.com/NixOS/nixpkgs/commit/eb3235cb2ac8a38be305181ce2eebcb7af704537) python312Packages.py-serializable: 1.0.3 -> 1.1.0
* [`81e5c46c`](https://github.com/NixOS/nixpkgs/commit/81e5c46c1207dfde7bc9515155d579171c73581f) lorri: fix cargoHash
* [`0ce32a5a`](https://github.com/NixOS/nixpkgs/commit/0ce32a5a5cc966d88bf52551c52ac66621176c4b) mercurial: 6.7.4 -> 6.8
* [`1344a0f5`](https://github.com/NixOS/nixpkgs/commit/1344a0f515518bd57b3732a2b8d5b609dd0fa6d9) python313Packages.legacy-cgi: init at 2.6.1
* [`5922945c`](https://github.com/NixOS/nixpkgs/commit/5922945c861a8f0b3e607fb091a9ae7d8a96014b) python312Packages.time-machine: 2.13.0 -> 2.14.2
* [`b571fd7e`](https://github.com/NixOS/nixpkgs/commit/b571fd7e526c51fc3cf48354f7a5408e4f4f6103) python313Packages.webob: fix build
* [`2f176571`](https://github.com/NixOS/nixpkgs/commit/2f1765713f65e84aadc3f87cc0e577c0e5813efd) nodejs_18: 18.20.3 -> 18.20.4
* [`e11b071d`](https://github.com/NixOS/nixpkgs/commit/e11b071dbc4aa5b59a94dabbb5f7379dc43e46aa) nodejs_22: 22.4.0 -> 22.4.1
* [`92b04c82`](https://github.com/NixOS/nixpkgs/commit/92b04c826bcbf1006dc9d65f8180e5344f15ef11) libass: 0.17.2 -> 0.17.3
* [`96d6f0a2`](https://github.com/NixOS/nixpkgs/commit/96d6f0a2ddb07916cd1a3230fbe6a21e4dc6b29e) pcsclite: 2.1.0 -> 2.2.3
* [`3e99b5ae`](https://github.com/NixOS/nixpkgs/commit/3e99b5aec1668549bf4f608e74e84f18d4eb8375) ffmpeg_5: add patch for CVE-2023-51794
* [`0aded325`](https://github.com/NixOS/nixpkgs/commit/0aded3256340f896837cbd03496acbd80114b8ec) ffmpeg_4: add patch for CVE-2023-51794
* [`cf39694b`](https://github.com/NixOS/nixpkgs/commit/cf39694bd2644e94066f85f62305f0e0b84fc841) python312Packages.pycountry: 23.12.11 -> 24.6.1
* [`9b544959`](https://github.com/NixOS/nixpkgs/commit/9b544959d9190152bb21bf2c72756fd9359d6bfe) python312Packages.django_4: 4.2.12 -> 4.2.14
* [`4ddb1c3f`](https://github.com/NixOS/nixpkgs/commit/4ddb1c3fa3c299b4b8c2ce9ca7c1bd5f0484ed6e) glib: 2.80.3 -> 2.80.4
* [`afa6f75b`](https://github.com/NixOS/nixpkgs/commit/afa6f75b75020d204a38092e1e148128542f6380) ell: 0.66 -> 0.67
* [`6ca5b11a`](https://github.com/NixOS/nixpkgs/commit/6ca5b11ad8ec0624343614c927fbd844205fe5df) iwd: 2.18 -> 2.19
* [`eb8d90ec`](https://github.com/NixOS/nixpkgs/commit/eb8d90ecec8363f67b1531a9b0813e5f51e0c8d8) python312Packages.django-storages: 1.14.2 -> 1.14.4
* [`6c879c9e`](https://github.com/NixOS/nixpkgs/commit/6c879c9e5e207201408f163322e7ec6b0b2de4c3) mongodb: pin scons to python311
* [`8af30139`](https://github.com/NixOS/nixpkgs/commit/8af30139699360e70b8892ef2fee3b2a796e167c) python312Packages.trove-classifiers: 2024.5.22 -> 2024.7.2
* [`5a111d13`](https://github.com/NixOS/nixpkgs/commit/5a111d13dd5bd7a3d2b3604cc9aae16f02ac0316) maintainers: add nw
* [`149c046f`](https://github.com/NixOS/nixpkgs/commit/149c046f4d6772bf6148ceaa30659d3d67986158) nodejs_20: 20.15.0 -> 20.15.1 ([nixos/nixpkgs⁠#325616](https://togithub.com/nixos/nixpkgs/issues/325616))
* [`162c184b`](https://github.com/NixOS/nixpkgs/commit/162c184b6248b1dcd486b1c8d498370ab72b4cb9) rsync: use enableFeature
* [`63f25148`](https://github.com/NixOS/nixpkgs/commit/63f25148f4779b0ccd461e0462329b55df8be00e) lldap-cli: init at 0-unstable-2024-02-24
* [`0a35e776`](https://github.com/NixOS/nixpkgs/commit/0a35e77651202c8cb3f99444db582f1a351080cc) pyqt5: 5.15.9 -> 5.15.10
* [`29cc0b4a`](https://github.com/NixOS/nixpkgs/commit/29cc0b4a6b63b3b89df2d2bb1e9f6d6219e53285) generateLuarocksConfig: dont generate rocks_subdir by default
* [`749f7b30`](https://github.com/NixOS/nixpkgs/commit/749f7b3061e00314d8231e78a08cb667b43b1109) python312Packages.nose: use pep517 builder
* [`f5a03f40`](https://github.com/NixOS/nixpkgs/commit/f5a03f4035da040b2b66756bd90060b1a6ade7c7) python312Packages.nose: fix build
* [`bf050703`](https://github.com/NixOS/nixpkgs/commit/bf05070350f5ae4a26969d35b3b6e8877a8de155) hydrus: re-enable tests on 3.12
* [`79e06f0f`](https://github.com/NixOS/nixpkgs/commit/79e06f0f1a4b0f7f5254d229a35cd0323f28582a) python312Packages.actdiag: re-enable tests
* [`8f374ae5`](https://github.com/NixOS/nixpkgs/commit/8f374ae5635a9c3f0be6f72a35c5baaf43d65a99) python312Packages.biopandas: re-enable tests
* [`6f959090`](https://github.com/NixOS/nixpkgs/commit/6f959090a1a5a628fff5bcf3264508a47ad9c0da) python312Packages.blockdiag: re-enable tests
* [`095a9171`](https://github.com/NixOS/nixpkgs/commit/095a91716bbe5f4f5cfd01c708ce2dbbff80c87b) python312Packages.hkdf: re-enable tests
* [`7328dcbe`](https://github.com/NixOS/nixpkgs/commit/7328dcbe94711a4e7f2d96eb04324eaa972e3342) python312Packages.lockfile: re-enable tests
* [`04332cda`](https://github.com/NixOS/nixpkgs/commit/04332cda7f1319f98c78953c2c995b8b859a2fbe) python312Packages.nwdiag: re-enable tests
* [`d65482c4`](https://github.com/NixOS/nixpkgs/commit/d65482c4601fdb42ee9e084ae03bb31d86805d03) python312Packages.pprintpp: re-enable tests
* [`9bdacf3e`](https://github.com/NixOS/nixpkgs/commit/9bdacf3e43e7b95c68a58c2120bc03120a6ddd47) python312Packages.pydy: re-enable tests
* [`b43e2adf`](https://github.com/NixOS/nixpkgs/commit/b43e2adfd56ff631c2b9ad9cc92ffa0e20780af0) python312Packages.pypass: re-enable tests
* [`7df95dce`](https://github.com/NixOS/nixpkgs/commit/7df95dce170b5a9fd2a16a63138f7c955cc2c716) python312Packages.pytimeparse: re-enable tests
* [`cadf0bfb`](https://github.com/NixOS/nixpkgs/commit/cadf0bfb924b32f63cf27b7778a9ac92237b61c7) python312Packages.seqdiag: re-enable tests
* [`6efa41df`](https://github.com/NixOS/nixpkgs/commit/6efa41df1f00902e25bddf88ac8eabfe178f75ca) python312Packages.sphinx-rtd-dark-mode: re-enable tests
* [`b2592613`](https://github.com/NixOS/nixpkgs/commit/b25926136ea45e080bf61fc67afe1a72b8d57b13) python312Packages.uvcclient: re-enable tests
* [`599e471d`](https://github.com/NixOS/nixpkgs/commit/599e471d78801f95ccd2c424a37e76ce177e50b9) python312Packages.xlwt: re-enable tests
* [`bae30f20`](https://github.com/NixOS/nixpkgs/commit/bae30f206d83e0940cdd3b416b615dc7157b1a2e) darwin.xnu: use unwrapped clang for MIGCC
* [`5df12940`](https://github.com/NixOS/nixpkgs/commit/5df12940bde11980e326cfc307521096256ae4dd) nixos/udev: remove rules for /dev/kvm
* [`49ec969b`](https://github.com/NixOS/nixpkgs/commit/49ec969b5be164cc6d57b3c9fb0f6cb4288655e9) fix cuda_gdb for libexpat.so.1 on aarch64
* [`2279f8b2`](https://github.com/NixOS/nixpkgs/commit/2279f8b2808d3514e09e27657abbaa695a9b44fa) narsil: refactor
* [`3695eebf`](https://github.com/NixOS/nixpkgs/commit/3695eebfd4cbfab1f58f4d0ee12e317cc33fe938) narsil: add changelog
* [`5a71df92`](https://github.com/NixOS/nixpkgs/commit/5a71df92074bd25cb745b2998336421e4825b6b6) python3Packages.gotenberg-client: 0.5.0 -> 0.6.0
* [`504308e4`](https://github.com/NixOS/nixpkgs/commit/504308e427630aa14e2fb434f4e135561131b1c7) narsil: set updateScript
* [`7640cf52`](https://github.com/NixOS/nixpkgs/commit/7640cf52d5307b909ea5f6848f209c0c2ed676e6) narsil: 1.3.0-49-gc042b573a -> 1.3.0-84-g042c39e9c
* [`6e44ea53`](https://github.com/NixOS/nixpkgs/commit/6e44ea5353d9af063089206cdc2460dc429bb334) narsil: add x123 as maintainer
* [`ee1638a5`](https://github.com/NixOS/nixpkgs/commit/ee1638a54f8339741a770594b3eb7bc8b8b9834f) paperless-ngx: 2.10.2 -> 2.11.0
* [`0979f40a`](https://github.com/NixOS/nixpkgs/commit/0979f40aeb6da0a027ece586055c9b599cae5f96) cgoban: use jdk17 instead of adoptopenjdk-bin
* [`535dd969`](https://github.com/NixOS/nixpkgs/commit/535dd96948f070e4f61735c89472db2389f04a32) openjdk: remove adoptopenjdk-bin, openjdk 12/13/14/15/16
* [`e708e7a1`](https://github.com/NixOS/nixpkgs/commit/e708e7a14d9108d4b61cb0d869d980f6af56e8b1) nixos/nvidia: enable modesetting by default on driver versions >= 535
* [`1a2bca4d`](https://github.com/NixOS/nixpkgs/commit/1a2bca4debe8c332e07f15c15f1d0a006d0c56e3) Re-revert "mypy: 1.10.0 → 1.10.1"
* [`b2e9329b`](https://github.com/NixOS/nixpkgs/commit/b2e9329b5851b19d0d41e354bd509080ce2a13aa) minecraft-servers: replace openjdk16 with openjdk17
* [`1e7d7e8d`](https://github.com/NixOS/nixpkgs/commit/1e7d7e8ddcc50a9421a2297caebc903488d7f866) libavif: 1.0.4 -> 1.1.0
* [`e550655a`](https://github.com/NixOS/nixpkgs/commit/e550655a7119693b90c1dfc271169a1ff7dccf24) godot3-mono: fix scons override python3 argument
* [`b7795e7a`](https://github.com/NixOS/nixpkgs/commit/b7795e7a415860ec7ca1f10b6d9e8157a77ca458) rust-analyzer: use cargoHash instead of deprecated cargoSha256
* [`bfb87624`](https://github.com/NixOS/nixpkgs/commit/bfb87624b3d66198acb768700f812790eb3afe67) cartridges: use webp for tiff compression
* [`7b1b48f8`](https://github.com/NixOS/nixpkgs/commit/7b1b48f8126493d6b8053f7336e0eb65eb8697ad) cartridges: wrap gnome search provider
* [`bfb36913`](https://github.com/NixOS/nixpkgs/commit/bfb36913f1527dae20d8270209ceecea01486eba) qpdf: add meta.mainProgram
* [`17726eb8`](https://github.com/NixOS/nixpkgs/commit/17726eb8bb6926ccc24ca846ba24c49c54138857) libbpf: 1.4.3 -> 1.4.5
* [`b99be9cc`](https://github.com/NixOS/nixpkgs/commit/b99be9ccc7ba4eba576bb3b4443e19a590fb5078) ffado: actually get rid of Qt dependency for real this time
* [`3f6e5f0a`](https://github.com/NixOS/nixpkgs/commit/3f6e5f0a4762d9bf2570bbde84982ee8edec8f69) pipewire: 1.2.0 -> 1.2.1
* [`4591e286`](https://github.com/NixOS/nixpkgs/commit/4591e2868c7d2bde3f33e2414b23d4b6d8016894) bruno: be explicit about darwin support
* [`79866be3`](https://github.com/NixOS/nixpkgs/commit/79866be383814a8ab5e35436b43629c8486ec6a9) ed: a huge rewrite
* [`d6666a90`](https://github.com/NixOS/nixpkgs/commit/d6666a90a273f8f979fcd4a5c831f32702271d7a) edUnstable: convert to throw
* [`c8b473aa`](https://github.com/NixOS/nixpkgs/commit/c8b473aa97d3cbbdf2abd910a0cfaddc0c5b6b04) grafterm, konf, octosql, promql: move to by-name hierarchy
* [`1deafc47`](https://github.com/NixOS/nixpkgs/commit/1deafc47c9e88dd76d2a3a2e1df52b7e93517cfa) calibre-web: add jsonschema dependency
* [`af6690a7`](https://github.com/NixOS/nixpkgs/commit/af6690a77161745a59d5c94719113d9b3ddf9505) bundler: 2.5.11 -> 2.5.15
* [`edb4e41b`](https://github.com/NixOS/nixpkgs/commit/edb4e41b4b0d5f2e36e53718ed00bc86c517d8e0) ruby.rubygems: 3.5.11 -> 3.5.15
* [`a1d6c177`](https://github.com/NixOS/nixpkgs/commit/a1d6c177ecbaa6464cc515aae2a848fb405fe93f) ruby.rubygems: add passthru.updateScript
* [`a1a29bd6`](https://github.com/NixOS/nixpkgs/commit/a1a29bd6f4564eb88d05310642c0989feedf3e81) ruby_3_3: 3.3.3 -> 3.3.4
* [`62a46e82`](https://github.com/NixOS/nixpkgs/commit/62a46e824bb9d1059223d2918fb7e4f6acad31b2) llvm_18, lld_18: Patch to support more OpenBSD sections
* [`25bc6182`](https://github.com/NixOS/nixpkgs/commit/25bc618215a72f681678bf58300f72b1a6f920c4) libxml2: 2.12.7 → 2.13.2
* [`9634d9c6`](https://github.com/NixOS/nixpkgs/commit/9634d9c6399e3f21968cd00f105fbaffd8f85aed) libxslt: 1.1.41 → 1.1.42
* [`d203ca98`](https://github.com/NixOS/nixpkgs/commit/d203ca98569fca1f9a0641a30cd9841b3b646c0a) gns3-gui: fix build by pinning python to 3.11, update sip
* [`db558497`](https://github.com/NixOS/nixpkgs/commit/db558497e5770246832bd3da58fa67d6a5855bb0) physac: fix incorrect version
* [`2c2cdd6f`](https://github.com/NixOS/nixpkgs/commit/2c2cdd6fe00c15f67beae1746c17e3502b28d566) nano: 8.0 -> 8.1
* [`ec8d29ab`](https://github.com/NixOS/nixpkgs/commit/ec8d29ab82a4e664abd900898ea5d0afe4b36f7c) cc-wrapper hardeningFlags tests: fix expected behaviour in corner cases
* [`f89edac3`](https://github.com/NixOS/nixpkgs/commit/f89edac370f3a15950320025e7a112490386372b) glances: 4.0.8-unstable-2024-06-09 -> 4.1.2.1
* [`72fa2510`](https://github.com/NixOS/nixpkgs/commit/72fa251097a124d424156a80e82d0c633ae48091) scalapack: fix build by suppressing implicit function warnings
* [`9950cee4`](https://github.com/NixOS/nixpkgs/commit/9950cee4132ef31c1f49351cd6b4e72d18ed0ec5) python311Packages.azure-search-documents: init at 11.4.0
* [`a194071b`](https://github.com/NixOS/nixpkgs/commit/a194071b8e7a9a2dd77894e1a4a9b3043db73849) python311Packages.datashaper: init at 0.0.49
* [`362ec3fa`](https://github.com/NixOS/nixpkgs/commit/362ec3fa31ec5803af6eba104b34bcc9d2375d2b) python312Packages.pyaml-env: init at 1.2.1
* [`f72bebe4`](https://github.com/NixOS/nixpkgs/commit/f72bebe4afeea484c54f267876d10b64479680c9) python312Packages.swifter: init at 1.4.0
* [`d2c2cc8e`](https://github.com/NixOS/nixpkgs/commit/d2c2cc8e61831c65d929de41c782858123e7187e) python312Packages.graphrag: init at 0.1.1
* [`f6f5b1fd`](https://github.com/NixOS/nixpkgs/commit/f6f5b1fde533c28780adad9144177b0626f1568b) gss: drop a crashing test
* [`a78b3c85`](https://github.com/NixOS/nixpkgs/commit/a78b3c85be57795c5e2c0191536b1213e8556176) tomb: 2.10 -> 2.11
* [`5a56b5df`](https://github.com/NixOS/nixpkgs/commit/5a56b5dfb19b1b2db9360a3bc1dd98c7cc42b331) mesa: 24.1.2 -> 24.1.3
* [`e6625328`](https://github.com/NixOS/nixpkgs/commit/e6625328346f2449033df2efea360c475c773cf3) tomb: format with nixfmt-rfc-style, remove `with lib;`
* [`88e8ae10`](https://github.com/NixOS/nixpkgs/commit/88e8ae101aacfe5b559cd7b229fac170b226b9df) tomb: move to pkgs/by-name
* [`2efa5e16`](https://github.com/NixOS/nixpkgs/commit/2efa5e16a246a7b5fe8dc4c6016bc792e1e8febb) openssh_hpn: 9.7p1 -> 9.8p1
* [`1cb18535`](https://github.com/NixOS/nixpkgs/commit/1cb1853573de833ff506579c8ece3d1f896e15d8) ld-wrapper: use a temporary file for reponse file
* [`4712e8fe`](https://github.com/NixOS/nixpkgs/commit/4712e8fe80f44c6fd12a79b1f279461135ac838a) libredirect: use llvmPackages unconditionally
* [`91d8dd92`](https://github.com/NixOS/nixpkgs/commit/91d8dd928fff9f2626d3359fcb2e63bd6b075b1e) darwin.apple_sdk_10_12.sdkRoot: specify exact SDK version
* [`3a545f67`](https://github.com/NixOS/nixpkgs/commit/3a545f673ecba345ee6bd2d33f0e52b58efd77a8) darwin.AvailabilityVersions: init at 140.1
* [`542b1779`](https://github.com/NixOS/nixpkgs/commit/542b17798aeb7248e2824af22431d21dc8fa32c8) packcc: 1.8.0 -> 2.0.2
* [`7360a278`](https://github.com/NixOS/nixpkgs/commit/7360a278bc231f81e0b421918ae2da7d942b5533) certdump: mark broken on aarch64-darwin
* [`7f45223b`](https://github.com/NixOS/nixpkgs/commit/7f45223beaaf264b5dfd20c88a58237143258947) darwin.binutils: add dwarfdump and fix typo
* [`b7952b47`](https://github.com/NixOS/nixpkgs/commit/b7952b4729a1fe67c06c8323771403b7a371624b) darwin.Libsystem: get headers from AvailabilityVersions
* [`4ee4fe5f`](https://github.com/NixOS/nixpkgs/commit/4ee4fe5fe75f8243e8885eb58c65b80fde92a6c4) darwin.configd: remove dependency on CF for private headers
* [`baf3568f`](https://github.com/NixOS/nixpkgs/commit/baf3568fb28809041f3efa6956194f4c82fc3e45) darwin.libdispatch: 442.1.4 -> 703.50.37
* [`cdf968c6`](https://github.com/NixOS/nixpkgs/commit/cdf968c68d603d1a0188ab7e84718bf739d9f5ef) libtapi: 1100.0.11 -> 1500.0.12.3
* [`f02b50ba`](https://github.com/NixOS/nixpkgs/commit/f02b50ba18e55e389501414228d5581472026f99) ld64: init at 951.9
* [`9f68d60b`](https://github.com/NixOS/nixpkgs/commit/9f68d60b5c2a3052efb5bac97557a94a75fba2a7) cctools: 973.0.1 -> 1010.6
* [`65a37e7b`](https://github.com/NixOS/nixpkgs/commit/65a37e7b14db909adf9c7a74d713425ba590d301) darwin.stdenv: make sure curl cannot be used
* [`8559d646`](https://github.com/NixOS/nixpkgs/commit/8559d6466beed15d731248b37ec3d926578ff98b) darwin.stdenv: always use a response file
* [`78da51cd`](https://github.com/NixOS/nixpkgs/commit/78da51cdb0caffa84a7976bc87527bd640460f9e) darwin.stdenv: adjust flags for llvm-strip in bootstrap tools
* [`7f1bc0d5`](https://github.com/NixOS/nixpkgs/commit/7f1bc0d5c1d0d669990cd59c2c8cf5a8b58e8cf2) binutils: drop Darwin hack
* [`05e5d7f7`](https://github.com/NixOS/nixpkgs/commit/05e5d7f73e4fc30cf8b702adb358993d3bf1b927) darwin.stdenv: clean up GNU binutils ban
* [`9403fdc4`](https://github.com/NixOS/nixpkgs/commit/9403fdc4a615e0f3301621cc63b5dee83513b649) darwin.stdenv: consolidate stage 2 into one stage
* [`10c87ee2`](https://github.com/NixOS/nixpkgs/commit/10c87ee2c7661b0e699b270744439b2643aaa43b) stdenv: set NIX_DONT_SET_RPATH_FOR_TARGET on Darwin
* [`c922cb27`](https://github.com/NixOS/nixpkgs/commit/c922cb27b6f52f17a522d3a4940a8fc36fa5c246) bintools-wrapper: drop postLinkSignHook
* [`a49dbb25`](https://github.com/NixOS/nixpkgs/commit/a49dbb2544d8711c965e138d500f4a49dcf59d6a) darwin.stdenv: switch to top-level cctools and ld64
* [`ca92415e`](https://github.com/NixOS/nixpkgs/commit/ca92415e874ccd86a312dc83bc0e72a0705d4a33) dotnet: use dwarfdump from darwin.binutils
* [`3bc1b22d`](https://github.com/NixOS/nixpkgs/commit/3bc1b22db66346b80a614ad3c2fb0a7b560f3d15) emacsPackages: remove enlight from manual-packages
* [`3a522fd7`](https://github.com/NixOS/nixpkgs/commit/3a522fd765453ab81c96b7a0205c75c74ef08b8a) emacsPackages: remove beancount from manual-packages
* [`ccda691e`](https://github.com/NixOS/nixpkgs/commit/ccda691e7c790a5d547ed8e58254d8039e061c16) elpa-packages: updated 2024-07-13 (from overlay)
* [`2fc52deb`](https://github.com/NixOS/nixpkgs/commit/2fc52debb5dccd7713ff37b1adb622a2cc122fc3) elpa-devel-packages: updated 2024-07-13 (from overlay)
* [`ce760599`](https://github.com/NixOS/nixpkgs/commit/ce760599f4221879bd8d8b76afaf7e22273e41f6) melpa-packages: updated 2024-07-13 (from overlay)
* [`8773aced`](https://github.com/NixOS/nixpkgs/commit/8773aced5ed944d43a286be2db3ed4863fc61d32) nongnu-packages: updated 2024-07-13 (from overlay)
* [`79f5f9bf`](https://github.com/NixOS/nixpkgs/commit/79f5f9bf1b805412634f2688e6c2068723d0ea35) ghc: update Darwin bintools references
* [`76e12091`](https://github.com/NixOS/nixpkgs/commit/76e12091eb3131a9638315808343a2ae1f6bb329) darwin.{cctools,libtapi}: drop old source
* [`9641ac52`](https://github.com/NixOS/nixpkgs/commit/9641ac5251847c2f8f299b1d8a91f3c038ea06cb) darwin.cctools-{apple,llvm}: add to darwin-aliases.nix
* [`c6d7e859`](https://github.com/NixOS/nixpkgs/commit/c6d7e859960316a79515779b509ad3306a4e5697) ffmpeg: add lcms2 option
* [`8817329d`](https://github.com/NixOS/nixpkgs/commit/8817329dec82ef9d5c7034749ab48b12bf62c0d3) bsc: add sigmanificient to maintainers
* [`4eb1a24e`](https://github.com/NixOS/nixpkgs/commit/4eb1a24ea253964db9aeda82720abcc4bffd3426) librsvg: 2.58.1 -> 2.58.2
* [`33c52f27`](https://github.com/NixOS/nixpkgs/commit/33c52f27d678854317e57e527c941758c54b1ae4) tenacity: unpin ffmpeg_5
* [`e3d715ee`](https://github.com/NixOS/nixpkgs/commit/e3d715eed9de68ccf88bdfd12e853a740f692a41) unpaper: unpin ffmpeg_5
* [`b801dc28`](https://github.com/NixOS/nixpkgs/commit/b801dc281320413584dd7b9d167e176a49914899) nixos/frigate: unpin ffmpeg_5
* [`aef28c78`](https://github.com/NixOS/nixpkgs/commit/aef28c78342df54cf064b10dc95b2902df0420f2) nixos/akkoma: unpin ffmpeg_5
* [`ca258d2d`](https://github.com/NixOS/nixpkgs/commit/ca258d2d393eb240fd4eddf9a40093e422c33116) python3Packages.av: 11.0.0 -> 12.2.0
* [`bc160398`](https://github.com/NixOS/nixpkgs/commit/bc16039841add3a6cb02e7bcdf61c950f20830b8) python3Packages.torchaudio-bin: drop ffmpeg_{4,5}
* [`fa8873ca`](https://github.com/NixOS/nixpkgs/commit/fa8873cad09c310e4f5ff2f69a28f16f212f443b) wl-screenrec: pin ffmpeg_6
* [`fb40c829`](https://github.com/NixOS/nixpkgs/commit/fb40c82929a35dfd55564e78ff94208eb8c30719) parsec-bin: pin ffmpeg_4
* [`d25171fc`](https://github.com/NixOS/nixpkgs/commit/d25171fc8e662f9df9626878948ab5897a1dea56) dim: bump nightfall for FFmpeg >= 6 support
* [`58c4f3cf`](https://github.com/NixOS/nixpkgs/commit/58c4f3cfc89e6486b5460a1b4bb30fc359a3796f) gifski: pin ffmpeg_6
* [`f9eee6b0`](https://github.com/NixOS/nixpkgs/commit/f9eee6b0a730590f936a1d72f2d391ed7b8bb151) ffmpeg_5: drop
* [`47f435db`](https://github.com/NixOS/nixpkgs/commit/47f435dbbf023caa27bbd5b955d3286fb700c32a) mercurial: add setuptools' distutils to test env
* [`837238af`](https://github.com/NixOS/nixpkgs/commit/837238af9df6ae5ad8539bffcb71e0bc094c5899) prowler: 3.15.0 -> 3.16.11
* [`e0e2b709`](https://github.com/NixOS/nixpkgs/commit/e0e2b709816018e9fa23fbd26f4ea1bee55cd68d) python312Packages.bc-detect-secrets: 1.5.12 -> 1.5.15
* [`269c681f`](https://github.com/NixOS/nixpkgs/commit/269c681f609e09fa00d22e9138618ed18935171c) checkov: relax schema
* [`0bc3db2e`](https://github.com/NixOS/nixpkgs/commit/0bc3db2ef1134898d8a39bed0613e6b971eae304) python312Packages.georss-qld-bushfire-alert-client: 0.7 -> 0.8
* [`57a38b02`](https://github.com/NixOS/nixpkgs/commit/57a38b02f96d6e72040b5c54e745e528622eec22) llvm: make hardeningDisable of trivialautovarinit common across all llvms
* [`920853f0`](https://github.com/NixOS/nixpkgs/commit/920853f0790328084b5594a3664b71de5bd60e5c) python312Packages.georss-qld-bushfire-alert-client: refactor
* [`c65cf1b9`](https://github.com/NixOS/nixpkgs/commit/c65cf1b9c5a2bf258135fcccc302a6cc100fb32c) pkgs/stdenv/generic/setup.sh: fix unbound variables and pass ShellCheck checks ([nixos/nixpkgs⁠#298831](https://togithub.com/nixos/nixpkgs/issues/298831))
* [`1e6acaba`](https://github.com/NixOS/nixpkgs/commit/1e6acabaebb2d3eb13cde9d8742aadb9480abcd7) nix-channel: do not set empty nix-path when disabling channels
* [`70c7038f`](https://github.com/NixOS/nixpkgs/commit/70c7038fa6ff29b28e72eea86deec606902d3112) cmake-lint: remove nose dependency
* [`66de60eb`](https://github.com/NixOS/nixpkgs/commit/66de60ebc87d663ee53406413c4469db549642de) ddns-go: 6.6.3 -> 6.6.4
* [`4f776579`](https://github.com/NixOS/nixpkgs/commit/4f7765794bfa378c0d97f287d684807f7ac64a3e) python312Packages.ofxhome: remove nose and fix tests
* [`2443fa3b`](https://github.com/NixOS/nixpkgs/commit/2443fa3bf524755b13bf739d79f57c6c8a632821) youtrack: 2024.2.35942 -> 2024.2.37269
* [`e426922e`](https://github.com/NixOS/nixpkgs/commit/e426922e81620f6c9e92abb1d96924b6662d0a8a) python3Packages.pastescript: remove nose dependency
* [`37ed5e4e`](https://github.com/NixOS/nixpkgs/commit/37ed5e4ea51224b6e043a766a0081aecfed54c0e) yamlscript: 0.1.64 -> 0.1.66
* [`4caee5e3`](https://github.com/NixOS/nixpkgs/commit/4caee5e3808bb98d4b1b73ec334e914b2e834451) rke2: set the correct working directory for the update script
* [`83d8cf69`](https://github.com/NixOS/nixpkgs/commit/83d8cf69460c589022e3f8ca18643d45ac79f307) python3Packages.shapely: 2.0.4 -> 2.0.5
* [`87a3ea0e`](https://github.com/NixOS/nixpkgs/commit/87a3ea0e6d22f1f591e0de220da9a6b415b4e3ab) onionshare: use real meek
* [`e25e0523`](https://github.com/NixOS/nixpkgs/commit/e25e0523d668122d379dc16aa7068cc62cb0606d) phinger-cursors: 2.0 -> 2.1
* [`5e4e8aba`](https://github.com/NixOS/nixpkgs/commit/5e4e8abae28b49a64cd97ddd8f7eb88a9e2eac77) maturin: 1.6.0 -> 1.7.0
* [`f0e0fd63`](https://github.com/NixOS/nixpkgs/commit/f0e0fd63f2c68b0a32ebb15ffc40af8a8b576ccc) emacs.pkgs.org: remove old patches
* [`bee041df`](https://github.com/NixOS/nixpkgs/commit/bee041dfc4705d7c9e75d8879ddf098e8f747870) clang-tidy-sarif: 0.4.2 -> 0.5.0
* [`fe7795d1`](https://github.com/NixOS/nixpkgs/commit/fe7795d1da1ddedade253002c98fc0c84e7921f5) scfbuild: fix runtime error on Python 3.12
* [`594ddbd1`](https://github.com/NixOS/nixpkgs/commit/594ddbd12fd7794c3f9385714ab535d0ace596d1) clang-tidy-sarif: fetchFromGitHub -> fetchCrate
* [`6cd6e411`](https://github.com/NixOS/nixpkgs/commit/6cd6e4112735dd75fc2209a97127daadbab5cbdf) clang-tidy-sarif: add updateScript
* [`b77dea2e`](https://github.com/NixOS/nixpkgs/commit/b77dea2ecce1b73a7df74f611561d7b2416006f8) clang-tidy-sarif: testers.testVersion -> versionCheckHook
* [`38b580b2`](https://github.com/NixOS/nixpkgs/commit/38b580b21abf4182681dd6f6aa068acfa02da8d9) cc-wrapper hardeningFlags tests: add tests for stackclashprotection
* [`2e0d7e23`](https://github.com/NixOS/nixpkgs/commit/2e0d7e230a022096bb4d9c744f636f417ad71c84) cc-wrapper hardeningFlags tests: fix stdenvUnsupport-based tests
* [`2630b3cf`](https://github.com/NixOS/nixpkgs/commit/2630b3cfe481e0692e7d1080fcd14992ed31f105) freeradius: replace FTP with HTTPS
* [`186e0e75`](https://github.com/NixOS/nixpkgs/commit/186e0e75ed098f94ac03661ea0c6456d0cf88c8e) qpdf: split outputs
* [`a2fc17f7`](https://github.com/NixOS/nixpkgs/commit/a2fc17f77befefc545386e2a44d5434956e5705a) qpdf: add pkg-config & version tests
* [`f9330b60`](https://github.com/NixOS/nixpkgs/commit/f9330b606583879b5b4cda6b3f79d734718f7a57) qpdf: don't overuse `with lib;`
* [`5ce49c84`](https://github.com/NixOS/nixpkgs/commit/5ce49c845ebf19407c52c114948b0669bd0f10b0) cracklib: 2.9.11 -> 2.10.0
* [`1dd44eaf`](https://github.com/NixOS/nixpkgs/commit/1dd44eaf6766ea7c9e2c11f91d9f978aa13e2aec) nixos/pam: use Kanidm's package option
* [`0add1c4f`](https://github.com/NixOS/nixpkgs/commit/0add1c4f8aa2fad9a4646f51d7a10a5ff483246f) python3Packages.beaker: replace nose tests with pytest
* [`5c3ad3f8`](https://github.com/NixOS/nixpkgs/commit/5c3ad3f8954df4e54ba1798ca573c1f325171720) kent: 467 -> 468
* [`979bca38`](https://github.com/NixOS/nixpkgs/commit/979bca38d788f0f31d234877d3ecee841bec112e) tidal-hifi: 5.14.1 -> 5.15.0
* [`32bd0637`](https://github.com/NixOS/nixpkgs/commit/32bd063789d46ef98d45f0e8d553dac57d11b350) python311Packages.pyprecice: 3.1.0 -> 3.1.1
* [`a2d1e55d`](https://github.com/NixOS/nixpkgs/commit/a2d1e55d52886883f649f572df2737729a44a453) git-series: unstable-2019-10-15 -> 0.9.1-unstable-2024-02-02
* [`f0045477`](https://github.com/NixOS/nixpkgs/commit/f0045477ec1dd49bad19120d8b6be1454309732c) git-series: format with nixfmt-rfc-style
* [`02616453`](https://github.com/NixOS/nixpkgs/commit/0261645302370ce45aa3e0bcdec8812593480dbe) git-series: add aleksana to maintainers
* [`5eb2c4b6`](https://github.com/NixOS/nixpkgs/commit/5eb2c4b661d065e16ed40071e7ec373777dfd122) cherrytree: 1.1.3 -> 1.1.4
* [`8ec1df76`](https://github.com/NixOS/nixpkgs/commit/8ec1df7609ab9e00aca44e23a31200c83a3bf4a3) sshs: 4.2.1 -> 4.4.1
* [`40097d59`](https://github.com/NixOS/nixpkgs/commit/40097d591349631dbeb4623bb27a704f9e190553) sshs: format with nixfmt-rfc-style
* [`a01e0a26`](https://github.com/NixOS/nixpkgs/commit/a01e0a2617246944f44ed55d527630c99f57846d) mercurial: skip some tests broken with python 3.12
* [`a0242c2d`](https://github.com/NixOS/nixpkgs/commit/a0242c2d552d5eed73fbf50d0c4f529f08e500b7) roomeqwizard: 5.31.1 -> 5.31.2
* [`e577b966`](https://github.com/NixOS/nixpkgs/commit/e577b966bde8d34298829043220e44885a619d57) python3Packages.av: fix build
* [`c2d8eb6b`](https://github.com/NixOS/nixpkgs/commit/c2d8eb6b4b36bec5cf5da7760f303c7e3f2d54fd) python3Packages.debugpy: 1.8.1 -> 1.8.2
* [`ad348b3f`](https://github.com/NixOS/nixpkgs/commit/ad348b3f178f5c6ae8ec548a715def164e1d47fa) altair: 7.2.2 -> 7.2.4
* [`fc83a9b9`](https://github.com/NixOS/nixpkgs/commit/fc83a9b97d9b302e8ec5aab441b4a76e3c2e9e9d) bino3d: 1.6.8 -> 2.2
* [`afe278a9`](https://github.com/NixOS/nixpkgs/commit/afe278a98d4d72ce6cd2a658701e520165f881d4) libheif: 1.17.6 -> 1.18.0
* [`f621ab92`](https://github.com/NixOS/nixpkgs/commit/f621ab9204a8615c626cd611d8467a8a24d33837) lib.warn: Fix color
* [`7d4a9a57`](https://github.com/NixOS/nixpkgs/commit/7d4a9a5772966bf10f31c6dc51ff7cfa1c8ce02f) lib.warn: Remove color from the message itself
* [`696f0b62`](https://github.com/NixOS/nixpkgs/commit/696f0b6228aa29fecb2e204388e7e2fe632a1869) far2l: 2.6.1 -> 2.6.2
* [`b0c193d9`](https://github.com/NixOS/nixpkgs/commit/b0c193d9d9222d35639e75c0c1bc08b92b61717b) gomuks: 0.3.0 -> 0.3.1
* [`ec649827`](https://github.com/NixOS/nixpkgs/commit/ec649827e1126143834a866ffe9e5ab67b72d0e7) python312Packages.textdistance: 4.6.2 -> 4.6.3
* [`68eddfae`](https://github.com/NixOS/nixpkgs/commit/68eddfae577c991d70676739ac412fedb5961145) python312Packages.meraki: 1.46.0 -> 1.48.0
* [`b306e0ed`](https://github.com/NixOS/nixpkgs/commit/b306e0edf2162536528e417345f2769b2aa48f96) python312Packages.mpi4py: 3.1.6 -> 3.1.6-unstable-2024-07-08; rewrite
* [`4c08f901`](https://github.com/NixOS/nixpkgs/commit/4c08f901dc7117a5ae7e0b33916619cae35f84ae) python312Packages.nethsm: 1.1.0 -> 1.2.0
* [`3dfaa447`](https://github.com/NixOS/nixpkgs/commit/3dfaa447a8383dd839935d1056e4c7f2f2a302b3) @⁠angular/cli: install shell completions
* [`3fb14db0`](https://github.com/NixOS/nixpkgs/commit/3fb14db08a2f7b48427bdb39372f89bcab16df39) testers.shellcheck: init
* [`1022da85`](https://github.com/NixOS/nixpkgs/commit/1022da85abc8df47c7a4b7e8791ecbabd3d0770c) nixos/activation-script: Add lib.sh with warn()
* [`34fee8c8`](https://github.com/NixOS/nixpkgs/commit/34fee8c804ed6649b18c1716f021540f616c4e68) nixos/nix-channel: Highlight and tidy the warnings
* [`46df92b2`](https://github.com/NixOS/nixpkgs/commit/46df92b27028a36d6150726923f8472217851d1d) nixosTests.installer.switchToFlake: Adjust for workaround in [nixos/nixpkgs⁠#323613](https://togithub.com/nixos/nixpkgs/issues/323613)
* [`3f76dcea`](https://github.com/NixOS/nixpkgs/commit/3f76dcea9375379a30beb546b72ee02702b7da8f) nixosTests.installer.switchToFlake: It is probably really stupid
* [`17f76e26`](https://github.com/NixOS/nixpkgs/commit/17f76e2661b87a718dc9b23265fcf64aa19af8b5) home-assistant: use PyAV directly
* [`2d9a6864`](https://github.com/NixOS/nixpkgs/commit/2d9a6864833e3cca4b05aa6bd4ef88c8813989ca) nixos/nix-channel.nix: shellcheck and fix the activation check
* [`332c4cc6`](https://github.com/NixOS/nixpkgs/commit/332c4cc64d1515302f7207f07ed08121168bd9c6) python312Packages.pytest-mpi: init at 0.6
* [`dc60dc1a`](https://github.com/NixOS/nixpkgs/commit/dc60dc1adabef2ebf7d5bc076a230a19b9cb6f80) python311Packages.h5py: enable tests
* [`da048921`](https://github.com/NixOS/nixpkgs/commit/da048921cb17ed92e0689f057480c9a748876980) python311Packages.h5py: no with lib; in meta
* [`1b81d87d`](https://github.com/NixOS/nixpkgs/commit/1b81d87d243f1cc59eca57307a08421a75555ffe) python311Packages.h5py: add doronbehar to maintainers
* [`d7f917fc`](https://github.com/NixOS/nixpkgs/commit/d7f917fc14c1f863990e43e3ec20f726e45ac1e6) python312Packages.pytest-asyncio: 0.23.6 -> 0.23.7
* [`1b501500`](https://github.com/NixOS/nixpkgs/commit/1b501500259e6bb60f80842dbd618459a92baa86) libnftnl: 1.2.6 -> 1.2.7
* [`3cdaaea5`](https://github.com/NixOS/nixpkgs/commit/3cdaaea5d461cc738d2d947512fd3fd27141a80a) git-repo: 2.45 -> 2.46
* [`882c4a9d`](https://github.com/NixOS/nixpkgs/commit/882c4a9d0a9479a81b9835d6f762db051729bd42) aichat: add shell completion
* [`89199803`](https://github.com/NixOS/nixpkgs/commit/891998030ba539af86954825bb5d4270a47265f7) python312Packages.gurobipy: 11.0.2 -> 11.0.3
* [`2c8486cf`](https://github.com/NixOS/nixpkgs/commit/2c8486cf24f910945c72495f69e60655941b91be) gurobi: 11.0.2 -> 11.0.3
* [`8c26a3b1`](https://github.com/NixOS/nixpkgs/commit/8c26a3b19340d40869463f443ec9973faaa1d972) python312Packages.pyvista: 0.43.10 -> 0.44.0
* [`141c8c9a`](https://github.com/NixOS/nixpkgs/commit/141c8c9ad5bebaf6004f018d74ce2cf26e01e386) weechat-unwrapped: 4.3.4 -> 4.3.5
* [`21befe0e`](https://github.com/NixOS/nixpkgs/commit/21befe0e2e07b20b23b5d377e5b46834afbad84c) python312Packages.kornia: 0.7.2 -> 0.7.3
* [`e02368e3`](https://github.com/NixOS/nixpkgs/commit/e02368e3e8859b2e66211b11d870a4172cefa356) beancount: maintainers remove bhipple, add sharzy & polarmutex
* [`c97d0ff9`](https://github.com/NixOS/nixpkgs/commit/c97d0ff9cb1f730e0dafe694de421b9ea7e3ee29) home-assistant: drop ha-av override
* [`0d80324f`](https://github.com/NixOS/nixpkgs/commit/0d80324ffd231aee815c0e0a576eef1d5eee9161) joplin-desktop: 3.0.12 -> 3.0.13
* [`60362b17`](https://github.com/NixOS/nixpkgs/commit/60362b173eb6a719ec30be4932f6bc58062d59f3) treewide: use apache mirror where possible
* [`aba1b58d`](https://github.com/NixOS/nixpkgs/commit/aba1b58d1fd2c32c1febc635031062823cd6f74c) python312: make portability backport unconditional
* [`08675bba`](https://github.com/NixOS/nixpkgs/commit/08675bba98bb0dbc61ffacb3e90a627aa201881f) prometheus-pve-exporter: 3.2.4 -> 3.4.3
* [`dbba11e2`](https://github.com/NixOS/nixpkgs/commit/dbba11e241d1c8dfc51b58cb7a501e74f9600748) nixos/prometheus-pve-exporter: added new options introduced in v3.4.3
* [`d2719ca4`](https://github.com/NixOS/nixpkgs/commit/d2719ca4e11a036f9d67e0a02f4d011c3721f218) rocksdb: 9.3.1 -> 9.4.0
* [`20215bee`](https://github.com/NixOS/nixpkgs/commit/20215bee7461f9d900b433cdb1e53589d641dbfd) top-level/python-packages.nix: move removal notice to python-aliases.nix
* [`beae2027`](https://github.com/NixOS/nixpkgs/commit/beae2027686e2c5eff2a206b2ae0b3c9136f22d1) top-level/all-packages.nix: move removal notice to aliases.nix
* [`1017cdf9`](https://github.com/NixOS/nixpkgs/commit/1017cdf9bcf44d6a49663d6f63107b1a4d5f61ac) systemd: 255.6 -> 255.9
* [`606cfb42`](https://github.com/NixOS/nixpkgs/commit/606cfb42f116bf28749d4a585598b4f92195e01b) hare: refactor cross-compilation tests
* [`cb74af26`](https://github.com/NixOS/nixpkgs/commit/cb74af26e868368737d1bc867482d518937390e3) python312Packages.h5py: small cleanup
* [`78df9764`](https://github.com/NixOS/nixpkgs/commit/78df97642439eba28b71ab7b3ed1ab061597a037) python312Packages.busylight-for-humans: init at 0.32.0
* [`07768c8c`](https://github.com/NixOS/nixpkgs/commit/07768c8c73b1fe0ca4cb1b30506165aa4b011941) asciidoc: 10.2.0 -> 10.2.1
* [`b6c5ad33`](https://github.com/NixOS/nixpkgs/commit/b6c5ad3349d9867af7cae997aca83bd4576a9a02) lollypop: refactor
* [`c6ba378b`](https://github.com/NixOS/nixpkgs/commit/c6ba378b7bb174f38eb4552f0c6a094f9f6c923f) airsonic: update context-path directive
* [`058112ec`](https://github.com/NixOS/nixpkgs/commit/058112ecfa1e480ad4a6702cff620f2894af1f6f) freerdp: 3.6.0 -> 3.6.3
* [`29c6f7ae`](https://github.com/NixOS/nixpkgs/commit/29c6f7ae70167d5c53c69664836af92c309e8c45) lollypop: 1.4.39 -> 1.4.40
* [`7813502c`](https://github.com/NixOS/nixpkgs/commit/7813502cce7b5b447cf2f8c146ab100c7a13a3ef) flannel: 0.25.4 -> 0.25.5
* [`9dac499a`](https://github.com/NixOS/nixpkgs/commit/9dac499aecd438f51cef1162591f100fda0e38fc) libgcrypt: add bin and lib outputs
* [`cca14690`](https://github.com/NixOS/nixpkgs/commit/cca146900a886abf4245cbc6e474d91e02c1d387) mesa: 24.1.3 -> 24.1.4
* [`dab6632e`](https://github.com/NixOS/nixpkgs/commit/dab6632ebedb8fd38fdf97ccaa3e79142f44867a) lollypop: move to by-name
* [`68f49a06`](https://github.com/NixOS/nixpkgs/commit/68f49a06619380d9dc6b0271f3323da28517218c) iproute2: 6.9.0 -> 6.10.0
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
