### PR TITLE
niv home-manager: update 635563f2 -> 792757f6

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -41,10 +41,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "635563f245309ef5320f80c7ebcb89b2398d2949",
-        "sha256": "14inia1p99rfsg8alwddzbcp3m77rsbyh52wrynd6ac9lj8lx5jy",
+        "rev": "792757f643cedc13f02098d8ed506d82e19ec1da",
+        "sha256": "1xfj2qicq9px95dbgsvpp38z1679zi3pzhhlj9dkzqwhqha7jmgp",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/635563f245309ef5320f80c7ebcb89b2398d2949.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/792757f643cedc13f02098d8ed506d82e19ec1da.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@635563f2...792757f6](https://github.com/nix-community/home-manager/compare/635563f245309ef5320f80c7ebcb89b2398d2949...792757f643cedc13f02098d8ed506d82e19ec1da)

* [`7560dc94`](https://github.com/nix-community/home-manager/commit/7560dc942a6fbd37ebd1310b3dbda513de2d4b82) kbfs: avoid using PrivateTmp for systemd service
* [`465ea1f9`](https://github.com/nix-community/home-manager/commit/465ea1f994a4e2b498b847c35caa205af7b261df) swayosd: avoid restarting too quickly
* [`af70fc50`](https://github.com/nix-community/home-manager/commit/af70fc502a15d7e1e4c5a4c4fc8e06c2ec561e0c) flake.lock: Update
* [`304a0113`](https://github.com/nix-community/home-manager/commit/304a011325b7ac7b8c9950333cd215a7aa146b0e) firefox: add languagePacks option
* [`bc2b96ac`](https://github.com/nix-community/home-manager/commit/bc2b96acda50229bc99925dde5c8e561e90b0b00) zsh: add programs.zsh.autosuggestions.strategy option ([nix-community/home-manager⁠#5396](https://togithub.com/nix-community/home-manager/issues/5396))
* [`180158b4`](https://github.com/nix-community/home-manager/commit/180158b46ea02f1c8f794367f122e8f2a2e49cf8) mcfly: add settings option
* [`975b83ca`](https://github.com/nix-community/home-manager/commit/975b83ca560d17db51a66cb2b0dc0e44213eab27) treewide: fix eval after Nixpkgs maintainer changes
* [`d0240a06`](https://github.com/nix-community/home-manager/commit/d0240a064db3987eb4d5204cf2400bc4452d9922) gnome-terminal: update package name
* [`cd520fbd`](https://github.com/nix-community/home-manager/commit/cd520fbd31934deaa1cda11297a99ef1fa369dbf) maintainers: remove polykernel
* [`9fdadb1c`](https://github.com/nix-community/home-manager/commit/9fdadb1cb65093015fc8cd65a592c983b490c75c) flake.lock: Update
* [`ea72cf54`](https://github.com/nix-community/home-manager/commit/ea72cf548fafb2876232a3ae22fcc03d5fb354de) jujutsu: support darwin guidelines for config placement
* [`a11cfcd0`](https://github.com/nix-community/home-manager/commit/a11cfcd0a18fdf6257808da631a956800af764bf) micro: add package option
* [`587fcca6`](https://github.com/nix-community/home-manager/commit/587fcca66e9d11c8e2357053c096a8a727c120ab) eww: add terminal integration options
* [`792757f6`](https://github.com/nix-community/home-manager/commit/792757f643cedc13f02098d8ed506d82e19ec1da) firefox: support firefox derivatives
