### PR TITLE
niv emacs-overlay: update 9059feb4 -> 445662a3

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "9059feb48648e980cdd797cd828377c08989ca8f",
-        "sha256": "1g420669addbg1079v6z8wcp8nhhya3l9l6kdwq639855yvfmc33",
+        "rev": "445662a366f5360a8a1b1cf1dbf21df483cd5a5b",
+        "sha256": "14pd2rkbyj1fdfzdz0g6j0wyjphzmrp23sp30f7zsqw7ml5yv81p",
         "type": "tarball",
-        "url": "https://github.com/nix-community/emacs-overlay/archive/9059feb48648e980cdd797cd828377c08989ca8f.tar.gz",
+        "url": "https://github.com/nix-community/emacs-overlay/archive/445662a366f5360a8a1b1cf1dbf21df483cd5a5b.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "fast-syntax-highlighting": {


### PR DESCRIPTION
## Changelog for emacs-overlay:
Branch: master
Commits: [nix-community/emacs-overlay@9059feb4...445662a3](https://github.com/nix-community/emacs-overlay/compare/9059feb48648e980cdd797cd828377c08989ca8f...445662a366f5360a8a1b1cf1dbf21df483cd5a5b)

* [`4737a618`](https://github.com/nix-community/emacs-overlay/commit/4737a618f64a6e575347224d4b3b098ec4f60440) Updated elpa
* [`9dd348fb`](https://github.com/nix-community/emacs-overlay/commit/9dd348fbc5c9708a607cda51b70958491bf925b3) Updated melpa
* [`6b14b134`](https://github.com/nix-community/emacs-overlay/commit/6b14b1346a81aba358b2fe747e9f3de0e205945d) Updated flake inputs
* [`8f443b4c`](https://github.com/nix-community/emacs-overlay/commit/8f443b4c2ff53a91a391382e880cb013db6fcacc) Updated nongnu
* [`4086d908`](https://github.com/nix-community/emacs-overlay/commit/4086d9080ff20be767bbf3b8ea8f8e144574d93d) Updated elpa
* [`3b7942fc`](https://github.com/nix-community/emacs-overlay/commit/3b7942fc6a8f7b67e285b4ca38f4b8c311cd17b0) Updated melpa
* [`a84a0ab3`](https://github.com/nix-community/emacs-overlay/commit/a84a0ab3a00ec3042de1b7f14e910296970f38a2) Updated emacs
* [`bbe883e6`](https://github.com/nix-community/emacs-overlay/commit/bbe883e60c65dd9254d010e98a1a8a654a26f9d8) Updated flake inputs
* [`83a4223d`](https://github.com/nix-community/emacs-overlay/commit/83a4223d1df768ef50c683b688a71b8fe1636db6) Updated nongnu
* [`6090c122`](https://github.com/nix-community/emacs-overlay/commit/6090c122978df8fcd0cf94765e6792610a7b7f07) Updated elpa
* [`5f5f339b`](https://github.com/nix-community/emacs-overlay/commit/5f5f339b20efae70b0c70c7bb3ef222167a05364) Updated elpa
* [`35380942`](https://github.com/nix-community/emacs-overlay/commit/353809424c9f6c849a411d9b73bbc9df442887aa) Updated melpa
* [`44cd01cf`](https://github.com/nix-community/emacs-overlay/commit/44cd01cff6f778fed1fdef78e54972c81f0986f1) Updated emacs
* [`61c19985`](https://github.com/nix-community/emacs-overlay/commit/61c199857a70446f374ea76ef0941f4b88375d8b) Updated flake inputs
* [`1da0807e`](https://github.com/nix-community/emacs-overlay/commit/1da0807e2f2dca14c7595c306018d98ccbdf0913) Updated melpa
* [`b397731f`](https://github.com/nix-community/emacs-overlay/commit/b397731fab95687acb28789f261192e5e8a102be) Updated flake inputs
* [`dd2fd545`](https://github.com/nix-community/emacs-overlay/commit/dd2fd5453376f5f99be0a3e05f288ba249d3fb0a) Updated elpa
* [`8988d02a`](https://github.com/nix-community/emacs-overlay/commit/8988d02ae03a4a6ffaa7f56078daa0930b3f49c5) Updated melpa
* [`160e167f`](https://github.com/nix-community/emacs-overlay/commit/160e167fee1bb84587aa7ba26005e974903490cc) Updated emacs
* [`edb6d7b4`](https://github.com/nix-community/emacs-overlay/commit/edb6d7b4d9c1cae8ec2906bf8bd1a2b25f8ddb49) Updated elpa
* [`90d89e8c`](https://github.com/nix-community/emacs-overlay/commit/90d89e8cffc7f41e3d9a063dd6d0c0984728cf2d) Updated melpa
* [`19212150`](https://github.com/nix-community/emacs-overlay/commit/19212150460a6e07993b58e20b215a71a50fd04b) Updated emacs
* [`12d3706d`](https://github.com/nix-community/emacs-overlay/commit/12d3706dced99883120d7dd787a42dacef6a876d) Updated melpa
* [`e2e8c730`](https://github.com/nix-community/emacs-overlay/commit/e2e8c7303eafd8d3657e06c28be7b3b74c7024e6) Updated emacs
* [`abd7f6c6`](https://github.com/nix-community/emacs-overlay/commit/abd7f6c607b007baf5f53cbe25b84b678c533c72) Updated elpa
* [`76ed4c02`](https://github.com/nix-community/emacs-overlay/commit/76ed4c021f3185ab80de6c22f584e80e8ebd14ff) Updated melpa
* [`99ba4a77`](https://github.com/nix-community/emacs-overlay/commit/99ba4a7778f783fdd054d090e08fb025b26f6ee0) Updated emacs
* [`515e324e`](https://github.com/nix-community/emacs-overlay/commit/515e324ee073b95cbb1adfe0548a1198131a3f24) Updated emacs
* [`c77f9bf3`](https://github.com/nix-community/emacs-overlay/commit/c77f9bf365589fa9506f1173fc9fdd8c99754f31) Updated elpa
* [`fceeefa2`](https://github.com/nix-community/emacs-overlay/commit/fceeefa2383706a2839adbcdbe83b2aab1ae0d24) Updated melpa
* [`af8fc9e9`](https://github.com/nix-community/emacs-overlay/commit/af8fc9e91b7bdb508252717e3f3ce5fca57ce50a) flake: drop aarch64-linux cross and build native
* [`3cf2f10f`](https://github.com/nix-community/emacs-overlay/commit/3cf2f10ff9ea5ecbd67351440b4302da4c0f8493) Updated melpa
* [`6d983712`](https://github.com/nix-community/emacs-overlay/commit/6d9837126e1be779c8f34ed9fdd609e676a1b891) Updated emacs
* [`c79cda93`](https://github.com/nix-community/emacs-overlay/commit/c79cda93afc88d8497b8bf90cf0ec501a775e04c) Updated elpa
* [`2fd2345c`](https://github.com/nix-community/emacs-overlay/commit/2fd2345c7fae391aa8ed4e30e44d236e5f639f5e) Updated melpa
* [`c4f2a993`](https://github.com/nix-community/emacs-overlay/commit/c4f2a9939e365b0c6ef8cbaed8781a9e144d5bdf) Updated emacs
* [`190ca830`](https://github.com/nix-community/emacs-overlay/commit/190ca830e9b11908d25a5baf69641e90518553c9) Updated elpa
* [`e277db6f`](https://github.com/nix-community/emacs-overlay/commit/e277db6fa25c262c27457e8628fa4c77c9e9471c) Updated melpa
* [`b2eb2322`](https://github.com/nix-community/emacs-overlay/commit/b2eb23229761144c87efe5cd481bf352ee853172) Updated emacs
* [`6dae6120`](https://github.com/nix-community/emacs-overlay/commit/6dae61202926e138f53bb026db26f5a42b1d4a67) flake: bump nixpkgs-stable to 24.05
* [`1d930311`](https://github.com/nix-community/emacs-overlay/commit/1d9303117bda0da1895e8d5cca43503dd0e01634) flake: use a better name for stable hydra jobs
* [`81100a8b`](https://github.com/nix-community/emacs-overlay/commit/81100a8b75ae0a5c7f126a4a407afbd5eeaeeed3) Updated flake inputs
* [`a9c8464e`](https://github.com/nix-community/emacs-overlay/commit/a9c8464ed78de06dd5b7934499c20d4b724bead6) Updated melpa
* [`907ffaed`](https://github.com/nix-community/emacs-overlay/commit/907ffaedc98068a23118e7d9d90ac7200095b3cd) Updated emacs
* [`b84280a6`](https://github.com/nix-community/emacs-overlay/commit/b84280a674261ca24008a40959a306bd572d3f14) Updated flake inputs
* [`968b1efe`](https://github.com/nix-community/emacs-overlay/commit/968b1efefa2bd2a534c46090602e1ed4bcac87c9) Updated elpa
* [`01875064`](https://github.com/nix-community/emacs-overlay/commit/018750646b05c583aa3d4f1aa3bb14fcfa0b756d) Updated melpa
* [`91c8f114`](https://github.com/nix-community/emacs-overlay/commit/91c8f1140e9286f71f1fd38f7dc608d774798f64) Updated emacs
* [`ce9d4b14`](https://github.com/nix-community/emacs-overlay/commit/ce9d4b140f27816de62d6124019f0578edc2eeb7) Updated elpa
* [`5c173e5b`](https://github.com/nix-community/emacs-overlay/commit/5c173e5b9950e77cc008bc5a2c227556de0338cc) Updated melpa
* [`83b74938`](https://github.com/nix-community/emacs-overlay/commit/83b749382e550dc9047f9c5f53a168878e560959) Updated emacs
* [`7c19b4d8`](https://github.com/nix-community/emacs-overlay/commit/7c19b4d8b7896819ce9624728d1c323f5d00beff) Updated melpa
* [`743e01cc`](https://github.com/nix-community/emacs-overlay/commit/743e01cc6f5be48230b99178e3f14b34da84022e) Updated emacs
* [`45f6b86b`](https://github.com/nix-community/emacs-overlay/commit/45f6b86b3816422c4d1d3f146e6f320823c62888) Updated flake inputs
* [`793e6e4e`](https://github.com/nix-community/emacs-overlay/commit/793e6e4e1dee1d4d890ffee53d52e45ce1f0c790) Updated elpa
* [`2cd3970a`](https://github.com/nix-community/emacs-overlay/commit/2cd3970ae5d7b1bd8e1781736e8857b365788db8) Updated emacs
* [`69a0cd04`](https://github.com/nix-community/emacs-overlay/commit/69a0cd04fc52ecea9d545eacfb1035a013102cf8) Updated flake inputs
* [`696c6597`](https://github.com/nix-community/emacs-overlay/commit/696c65979377b32a9a64d9851bc37f974927dd2e) Updated elpa
* [`19de34f6`](https://github.com/nix-community/emacs-overlay/commit/19de34f6ff3a71bd5f4dbfb7080030c6cf7a7537) Updated melpa
* [`dab13c5c`](https://github.com/nix-community/emacs-overlay/commit/dab13c5ce01de3047241c5ec5701f808192831ff) Updated melpa
* [`bd468024`](https://github.com/nix-community/emacs-overlay/commit/bd468024d6ec4fcbddb65f3184a5bb19c4ebef82) Updated emacs
* [`179c0d4b`](https://github.com/nix-community/emacs-overlay/commit/179c0d4bdcb67096b770803a4463f9c9a4b7f387) Updated elpa
* [`f248e933`](https://github.com/nix-community/emacs-overlay/commit/f248e933564ccaf8a61c2d81d095cf35820b426b) Updated melpa
* [`5f5a1ea7`](https://github.com/nix-community/emacs-overlay/commit/5f5a1ea7e6c0deab773d9a060a4695bbcd3e054c) Updated emacs
* [`e8e95c71`](https://github.com/nix-community/emacs-overlay/commit/e8e95c711dad30522209090073cf30441ef72e5e) Updated elpa
* [`3f9f83b2`](https://github.com/nix-community/emacs-overlay/commit/3f9f83b24f4a9abf2bdeca8d014fa9e5ef219825) Updated melpa
* [`3a674072`](https://github.com/nix-community/emacs-overlay/commit/3a674072d755ea4c31fe37d5d4e1d98e90029203) Updated emacs
* [`0c450f32`](https://github.com/nix-community/emacs-overlay/commit/0c450f32d6a19990f8fea1e0db2a786c67643011) Updated melpa
* [`77ddb402`](https://github.com/nix-community/emacs-overlay/commit/77ddb4021ae40a3a6aac74d7730f36cdb3dde4ba) Updated emacs
* [`5ac5fde1`](https://github.com/nix-community/emacs-overlay/commit/5ac5fde10e34da0a67ebcdf2797586869f69e26b) Updated elpa
* [`b1b64aa1`](https://github.com/nix-community/emacs-overlay/commit/b1b64aa130fb9c5293da895064b1902f692a92fe) Updated melpa
* [`9cb438ce`](https://github.com/nix-community/emacs-overlay/commit/9cb438ce0f2ac37fe8a9935a250e9b85581cd69d) Updated emacs
* [`e5c3098c`](https://github.com/nix-community/emacs-overlay/commit/e5c3098cf66a5e1a5d5bf462bddf9aafa9c17450) Updated flake inputs
* [`4517501a`](https://github.com/nix-community/emacs-overlay/commit/4517501acd17233be8aece4a3e3d6b3d1d2c133d) Updated elpa
* [`827f4759`](https://github.com/nix-community/emacs-overlay/commit/827f475978317378d537adb9e0458aa7ffc54761) Updated melpa
* [`8b44a1dc`](https://github.com/nix-community/emacs-overlay/commit/8b44a1dc99fed9e71d1a8d6880cd2827a1def65f) Updated emacs
* [`490ac846`](https://github.com/nix-community/emacs-overlay/commit/490ac8465d9c6677c9056e6911b02a8f346f058e) Updated flake inputs
* [`b4330d68`](https://github.com/nix-community/emacs-overlay/commit/b4330d68fe8578e4eaa62b825ec34c571d0bf440) Updated nongnu
* [`497bb499`](https://github.com/nix-community/emacs-overlay/commit/497bb499753986ce2ca3b7359532e7147cfb7f30) Updated elpa
* [`b399117d`](https://github.com/nix-community/emacs-overlay/commit/b399117d716c26fcfbe858988ca01ab0c132893b) Updated melpa
* [`862212a4`](https://github.com/nix-community/emacs-overlay/commit/862212a4e798845254e4ae2ad97f69b7b4d85a72) Updated emacs
* [`472d957f`](https://github.com/nix-community/emacs-overlay/commit/472d957ff40e23b1048b092d8f48fe856dd06edf) Updated elpa
* [`fc91f5c6`](https://github.com/nix-community/emacs-overlay/commit/fc91f5c6f25426022edd3950fa6c5e2e1499c1b5) Updated melpa
* [`ebf448cc`](https://github.com/nix-community/emacs-overlay/commit/ebf448cc64c89dc77af3df7e269a32d03a8f143e) Updated emacs
* [`35f368cd`](https://github.com/nix-community/emacs-overlay/commit/35f368cd5675e3b1ecdbf1f3f12e69bac9672bbb) Updated elpa
* [`d3a85a94`](https://github.com/nix-community/emacs-overlay/commit/d3a85a94d62c7ea076363e2946caa74fd6bd5a5f) Updated melpa
* [`2bfc08cb`](https://github.com/nix-community/emacs-overlay/commit/2bfc08cbf0c21fe50fd88ccfd05bbc979d823c79) Updated flake inputs
* [`e810adf1`](https://github.com/nix-community/emacs-overlay/commit/e810adf1b90e6133689531097a23919ee58bdbad) Updated melpa
* [`76e9df7e`](https://github.com/nix-community/emacs-overlay/commit/76e9df7e3f701466fb91591a985f2e3ef73cf65b) Updated emacs
* [`d867960e`](https://github.com/nix-community/emacs-overlay/commit/d867960eab795fefa48a9b2cdc204d4c82e51b56) Updated elpa
* [`1facfd15`](https://github.com/nix-community/emacs-overlay/commit/1facfd15b6498f435fb5843b8d94bb4fa7f80a39) Updated melpa
* [`186361c0`](https://github.com/nix-community/emacs-overlay/commit/186361c0684b9eed32261d395708821a8a8d02fb) Updated elpa
* [`942a1ea9`](https://github.com/nix-community/emacs-overlay/commit/942a1ea9dc400bb01dcfb7d3a0304fc47de12747) Updated melpa
* [`b4d48b8e`](https://github.com/nix-community/emacs-overlay/commit/b4d48b8ee6b73dd4b676cf87f61d09e417ea052b) Updated emacs
* [`c4f4b5c2`](https://github.com/nix-community/emacs-overlay/commit/c4f4b5c25406d98dcfc1992c6676405a1b19b8af) Updated melpa
* [`7d49a83b`](https://github.com/nix-community/emacs-overlay/commit/7d49a83b5da8301df021ef5c86ce37564ad062a6) Updated elpa
* [`af082307`](https://github.com/nix-community/emacs-overlay/commit/af08230704729e326317a14aa726b131f9ca8ca5) Updated melpa
* [`5e9c9736`](https://github.com/nix-community/emacs-overlay/commit/5e9c97365e40a9a7f576dba8516eae5fd4f0fc62) Updated emacs
* [`b5a840a0`](https://github.com/nix-community/emacs-overlay/commit/b5a840a03acdb814fadfb3b7e5cbc2ea51a1f0c5) Updated flake inputs
* [`a3000b09`](https://github.com/nix-community/emacs-overlay/commit/a3000b0964a202b16d7cd2a9ed2ac47b006ea6a7) Updated flake inputs
* [`de1df2f5`](https://github.com/nix-community/emacs-overlay/commit/de1df2f522cc5c248efc0df37bff5210350f4813) Updated elpa
* [`1e722196`](https://github.com/nix-community/emacs-overlay/commit/1e722196c1a7cc5006d764540e04f52b83a9307a) Updated melpa
* [`7e5ec6c9`](https://github.com/nix-community/emacs-overlay/commit/7e5ec6c999ac57992e70d6983ae4ea1634e41ad9) Updated emacs
* [`bb942440`](https://github.com/nix-community/emacs-overlay/commit/bb942440280672e820ede7066c602265681c30a0) Updated elpa
* [`8104ab45`](https://github.com/nix-community/emacs-overlay/commit/8104ab457e4041a3f406504096c0f3de85ff64d3) Updated melpa
* [`21c9330e`](https://github.com/nix-community/emacs-overlay/commit/21c9330e6de6d5412798a83883ec6da217668f1c) Updated emacs
* [`fa0e9665`](https://github.com/nix-community/emacs-overlay/commit/fa0e96656954a654a8e891081091245f38aa075a) Updated elpa
* [`ef442e07`](https://github.com/nix-community/emacs-overlay/commit/ef442e079f14a33c65724b977aa423997bf66441) Updated melpa
* [`c1ac8f21`](https://github.com/nix-community/emacs-overlay/commit/c1ac8f2191b2906bc4e43ac144e6ebc8a95cb9b3) Updated emacs
* [`39f173b9`](https://github.com/nix-community/emacs-overlay/commit/39f173b9d8aa62957e05f6fe513eb2974c072b09) Updated flake inputs
* [`5e28d451`](https://github.com/nix-community/emacs-overlay/commit/5e28d451ba7a03b0ce2a9337dc3c3644ef23e211) Updated melpa
* [`cd4b62bb`](https://github.com/nix-community/emacs-overlay/commit/cd4b62bb90079d4ec11757b81b29e92d5393de6f) Updated emacs
* [`17b77edc`](https://github.com/nix-community/emacs-overlay/commit/17b77edc944055ac4b139101df23ae21fb1a2a64) Updated flake inputs
* [`cd6064d9`](https://github.com/nix-community/emacs-overlay/commit/cd6064d9f768c412081fb509ae85d49e9932583b) Updated elpa
* [`faff2936`](https://github.com/nix-community/emacs-overlay/commit/faff2936c1cc6c1f85061c0f20f0aebc4b3f1485) Updated melpa
* [`7c521a93`](https://github.com/nix-community/emacs-overlay/commit/7c521a93160b3f3deb2325ba5485eabaecc76100) Updated emacs
* [`57c23dc6`](https://github.com/nix-community/emacs-overlay/commit/57c23dc60fc0184da4da3fcd5e481a0c0851d087) Updated nongnu
* [`f6ec5972`](https://github.com/nix-community/emacs-overlay/commit/f6ec59723fa18425e4577decb2048d35442a15c1) Updated elpa
* [`0adbb017`](https://github.com/nix-community/emacs-overlay/commit/0adbb017f8a566bb6f6a6ce9ca421e5811b03cd7) Updated melpa
* [`a3bc0652`](https://github.com/nix-community/emacs-overlay/commit/a3bc06525a510d3ac6bdbe3ec4239eb2331accc9) Updated emacs
* [`d496b8db`](https://github.com/nix-community/emacs-overlay/commit/d496b8db2b514dd57c8365b71ae5df03fff9ca61) Updated elpa
* [`11c06c64`](https://github.com/nix-community/emacs-overlay/commit/11c06c6444c0336abda4c61441ed1e8b18c21748) Updated melpa
* [`9dd72e16`](https://github.com/nix-community/emacs-overlay/commit/9dd72e16f2ac68649d7fb5bdf1e3fbeb08503dbb) Updated elpa
* [`754cbb7c`](https://github.com/nix-community/emacs-overlay/commit/754cbb7ce6f33dc11161c02b512d800d1542c5d6) Updated melpa
* [`b92d12e4`](https://github.com/nix-community/emacs-overlay/commit/b92d12e48fa86f107cbeaf09586b488854a83985) Updated emacs
* [`9aa34421`](https://github.com/nix-community/emacs-overlay/commit/9aa34421d15e96046b0cab8df3c3478a3391ff45) Updated elpa
* [`cec5116c`](https://github.com/nix-community/emacs-overlay/commit/cec5116cb48b950f71faa35a0b0b252e33ab388d) Updated melpa
* [`6f278c19`](https://github.com/nix-community/emacs-overlay/commit/6f278c19282d891942272ee10cadcbd16678fda8) Updated emacs
* [`9ad5a95f`](https://github.com/nix-community/emacs-overlay/commit/9ad5a95fcf6cec20c7f0ab68feec1a2fdde01851) Updated nongnu
* [`551b77a2`](https://github.com/nix-community/emacs-overlay/commit/551b77a23374230ec96cd43835872f7e0ec6894a) Updated elpa
* [`3bbe0ad8`](https://github.com/nix-community/emacs-overlay/commit/3bbe0ad8b6c1f771b1777022d9aa69f83dbe7f3b) Updated melpa
* [`6caf4269`](https://github.com/nix-community/emacs-overlay/commit/6caf426904a6394d5030b6009606166df0abf783) Updated flake inputs
* [`cd9d7180`](https://github.com/nix-community/emacs-overlay/commit/cd9d718095f00e7e81a1eb7d1dcdbab522255c3f) Updated elpa
* [`38f04918`](https://github.com/nix-community/emacs-overlay/commit/38f049180cd747c6bce83358c1922d13c7c9d83f) Updated melpa
* [`b9c53531`](https://github.com/nix-community/emacs-overlay/commit/b9c535317f1acd888a4095c486b6f2bc19d2cf1d) Updated emacs
* [`05cce233`](https://github.com/nix-community/emacs-overlay/commit/05cce233b039d3e74a31bc07af0ba1a805478824) Updated elpa
* [`339d4a27`](https://github.com/nix-community/emacs-overlay/commit/339d4a270eb8cbaebbc75c5ff7420384072bbf1f) Updated melpa
* [`3eae83ad`](https://github.com/nix-community/emacs-overlay/commit/3eae83adf4308dc534ee7b22a46f3dbdc0bd3f7b) Updated emacs
* [`355921de`](https://github.com/nix-community/emacs-overlay/commit/355921de5ccda55682b37f181294bb70dbe7dfa3) Updated melpa
* [`93fa9461`](https://github.com/nix-community/emacs-overlay/commit/93fa94618a3048ccc427847d37c872fa46aa96c8) Updated nongnu
* [`f497642c`](https://github.com/nix-community/emacs-overlay/commit/f497642c635235c375ed8f9090768e91a8d5e29f) Updated melpa
* [`d2160011`](https://github.com/nix-community/emacs-overlay/commit/d21600113d97cd83a0a7271410a6b137a2853238) Updated flake inputs
* [`b3100595`](https://github.com/nix-community/emacs-overlay/commit/b31005958cab83f8ea0683bfde0fa2df74d310a1) Updated elpa
* [`60cdeb60`](https://github.com/nix-community/emacs-overlay/commit/60cdeb609b14991cad7c1eb2ab06038288596cca) Updated melpa
* [`56a27553`](https://github.com/nix-community/emacs-overlay/commit/56a275531c6bc329a0851ba34902a2b5f021a03f) Updated emacs
* [`5f86ac8c`](https://github.com/nix-community/emacs-overlay/commit/5f86ac8cbd9aff1f8f86ca1a569a10a077d9db54) Updated melpa
* [`f5e69f54`](https://github.com/nix-community/emacs-overlay/commit/f5e69f54e55881c07792e278f622f7efb2146ef9) Updated emacs
* [`55522f47`](https://github.com/nix-community/emacs-overlay/commit/55522f475afa8ce5bd89501e34d0cf96cdc6d276) Updated elpa
* [`f765e26c`](https://github.com/nix-community/emacs-overlay/commit/f765e26c7970f9d2ea74b901bdd25649c2622643) Updated melpa
* [`173aa23e`](https://github.com/nix-community/emacs-overlay/commit/173aa23e22b32c9d3585a96df74ec7c53d64de92) Updated emacs
* [`d5e3454d`](https://github.com/nix-community/emacs-overlay/commit/d5e3454df11542bd7a8e1a2c17ba431a43070633) Updated flake inputs
* [`717ae15d`](https://github.com/nix-community/emacs-overlay/commit/717ae15d3131b195df37cc807ec3c4bff2342c06) Updated elpa
* [`21ae5ddf`](https://github.com/nix-community/emacs-overlay/commit/21ae5ddfc3cfe05093ca65c2227944d733a4cbe0) Updated melpa
* [`23699d9f`](https://github.com/nix-community/emacs-overlay/commit/23699d9fc7faba4eb84719109cad6eee3a17e143) Updated emacs
* [`e16eb52f`](https://github.com/nix-community/emacs-overlay/commit/e16eb52f5e739a646dbca648324fd6c8950240d5) Updated melpa
* [`ab15d82f`](https://github.com/nix-community/emacs-overlay/commit/ab15d82f94c8f6373fec1f363c5b6c631453950b) Updated emacs
* [`019fdbcd`](https://github.com/nix-community/emacs-overlay/commit/019fdbcd87086d7abbdc8c4cff39a678a1f7aa40) Updated elpa
* [`e3dcebb7`](https://github.com/nix-community/emacs-overlay/commit/e3dcebb7675ef9526800c81ba8bb6aeaccd8ab24) Updated melpa
* [`fb91e18d`](https://github.com/nix-community/emacs-overlay/commit/fb91e18dab80d78ccbde35e5fc696f0656cfba0f) Updated emacs
* [`8b934665`](https://github.com/nix-community/emacs-overlay/commit/8b934665f7b6cbbcb9cd615da46fb6bab17bec33) Updated elpa
* [`5abf9060`](https://github.com/nix-community/emacs-overlay/commit/5abf9060bb5d33927b997975d88076c0a016a179) Updated melpa
* [`65fb8336`](https://github.com/nix-community/emacs-overlay/commit/65fb83360b883ecf3c2ef6fc616e13df33087077) Updated emacs
* [`67a90aca`](https://github.com/nix-community/emacs-overlay/commit/67a90aca5db402d3384ee5bb56c3709b0d649e66) Updated flake inputs
* [`97e5554d`](https://github.com/nix-community/emacs-overlay/commit/97e5554d3e59c1c27d41d8a45e677e1a991b4323) Updated melpa
* [`76894d02`](https://github.com/nix-community/emacs-overlay/commit/76894d029f43323bd650bfa97aa7dabb0d9ab0b6) Updated emacs
* [`97a62e58`](https://github.com/nix-community/emacs-overlay/commit/97a62e58c990d0c907fc2b79e5db335fad841a79) Updated nongnu
* [`5dbd58b2`](https://github.com/nix-community/emacs-overlay/commit/5dbd58b2c594b5718b98497628fdf9236a4a929b) Updated elpa
* [`0beb30e0`](https://github.com/nix-community/emacs-overlay/commit/0beb30e0d89b86d27e01386abcc6d5a7c58faac1) Updated melpa
* [`7164cf7c`](https://github.com/nix-community/emacs-overlay/commit/7164cf7ca4318ffad776682ef8cf8aa9e24a1216) Updated emacs
* [`3af443a6`](https://github.com/nix-community/emacs-overlay/commit/3af443a64b493252cfa7f2c9ffe30018fa5cf0a5) Updated flake inputs
* [`0e47ebff`](https://github.com/nix-community/emacs-overlay/commit/0e47ebffec109705bf80b7e632e67ec003e7d3f7) Updated elpa
* [`b3c3f03e`](https://github.com/nix-community/emacs-overlay/commit/b3c3f03e594177220148b3e2f9aef9228cc04321) Updated melpa
* [`1965b634`](https://github.com/nix-community/emacs-overlay/commit/1965b634e79296e181101800bc60d0a2316521df) Updated melpa
* [`332246b2`](https://github.com/nix-community/emacs-overlay/commit/332246b2177be3523f6c87db1e3961784b6796d1) Updated emacs
* [`3c3de3eb`](https://github.com/nix-community/emacs-overlay/commit/3c3de3ebf4c722387607b12d6fe6c4d9b32ce777) Updated elpa
* [`07cc763d`](https://github.com/nix-community/emacs-overlay/commit/07cc763d0c5adb901139b63f1e733e9d99bfdb08) Updated melpa
* [`1f4e4263`](https://github.com/nix-community/emacs-overlay/commit/1f4e4263a6a95d07efb23253b67e8205a4c4187d) Updated emacs
* [`28de0477`](https://github.com/nix-community/emacs-overlay/commit/28de0477cdc4dfc0256f6c01382c4a40681e3462) Updated melpa
* [`a5bbacc2`](https://github.com/nix-community/emacs-overlay/commit/a5bbacc26626537716855de5034dfaccdab7b2f6) Updated emacs
* [`77582006`](https://github.com/nix-community/emacs-overlay/commit/775820069cf252237b49003f71264f5dd4a44a32) Updated flake inputs
* [`d2e9b1e2`](https://github.com/nix-community/emacs-overlay/commit/d2e9b1e2799db376de58699e3b82843e2586611b) Updated elpa
* [`83af36b5`](https://github.com/nix-community/emacs-overlay/commit/83af36b5cc1c68a9e78b9d35ff9031a8e72b9b85) Updated melpa
* [`6ad922f8`](https://github.com/nix-community/emacs-overlay/commit/6ad922f8168b6b6aa8c5894dbbcc82840758aea5) Updated emacs
* [`0e17249c`](https://github.com/nix-community/emacs-overlay/commit/0e17249c87ae24e5aaae68d45372e6d44be7b250) Updated melpa
* [`659148d7`](https://github.com/nix-community/emacs-overlay/commit/659148d712070acc244ccacc7ca2e49e866bf9b3) Updated emacs
* [`19ab45c7`](https://github.com/nix-community/emacs-overlay/commit/19ab45c775322251c223c909656405101758661f) Updated flake inputs
* [`629f2fd3`](https://github.com/nix-community/emacs-overlay/commit/629f2fd3c0c5179c09b5c3cb137f85aba926f8f8) Updated elpa
* [`3f4fe9c2`](https://github.com/nix-community/emacs-overlay/commit/3f4fe9c2ed3dd720ef5dee881faeb2664102fb9e) Updated melpa
* [`a4058dae`](https://github.com/nix-community/emacs-overlay/commit/a4058dae60d3034fe97bda79ec4897938d1e69ed) Updated emacs
* [`51c6a6c7`](https://github.com/nix-community/emacs-overlay/commit/51c6a6c79c90dd9313057f7d5155e04e3599d049) Updated nongnu
* [`b7940b26`](https://github.com/nix-community/emacs-overlay/commit/b7940b26504eae53f8d9d30b07e32679f232e703) Updated elpa
* [`f22b1491`](https://github.com/nix-community/emacs-overlay/commit/f22b14910e7ea3f0a85b68654ba8d9ab8998e27b) Updated melpa
* [`007c4a84`](https://github.com/nix-community/emacs-overlay/commit/007c4a84ed9f5b939a36a9aa765ad300858ee711) Updated emacs
* [`8851dd60`](https://github.com/nix-community/emacs-overlay/commit/8851dd60fa094d0fbe16a6fc01f0e74a08e91785) Updated melpa
* [`24c391d8`](https://github.com/nix-community/emacs-overlay/commit/24c391d8fe03854d1eedea66c241b176e97f5f6c) Updated emacs
* [`af42a5a6`](https://github.com/nix-community/emacs-overlay/commit/af42a5a6074b254bb37046b6f9a1e1abe56e209a) Updated flake inputs
* [`3d76951f`](https://github.com/nix-community/emacs-overlay/commit/3d76951f6c40bd1b46fadf3ace2ce2a902ec8cd5) Updated nongnu
* [`e49a586d`](https://github.com/nix-community/emacs-overlay/commit/e49a586d58f59d49e5b7e9f5ec2e17c8a970020c) Updated elpa
* [`44914c00`](https://github.com/nix-community/emacs-overlay/commit/44914c003e0e3287f913621b1ef5cc995af465ef) Updated melpa
* [`3ef26454`](https://github.com/nix-community/emacs-overlay/commit/3ef26454ce6b554b28ec5061b20844e976841e07) Updated emacs
* [`b1b0e234`](https://github.com/nix-community/emacs-overlay/commit/b1b0e2345da628cc77ec23eb5105b679024edab2) Updated elpa
* [`162ad850`](https://github.com/nix-community/emacs-overlay/commit/162ad8507817ae68b8f28ec2bc183e1574e05df5) Updated melpa
* [`aa74b71e`](https://github.com/nix-community/emacs-overlay/commit/aa74b71e29e612818a23cf2a973728d412f8f46b) Updated emacs
* [`8d4db328`](https://github.com/nix-community/emacs-overlay/commit/8d4db3288333f08cf01b9f958954ee69743597ec) Updated melpa
* [`52f334bf`](https://github.com/nix-community/emacs-overlay/commit/52f334bf7c461704ceb9685b5b1dceef29d8e049) Updated emacs
* [`133d4b96`](https://github.com/nix-community/emacs-overlay/commit/133d4b96d77152a39bf4ab94e9dda50bdb8b0419) Updated elpa
* [`04f89fb3`](https://github.com/nix-community/emacs-overlay/commit/04f89fb39aee8ea06efad8ce85c6b30ea9ed7d87) Updated melpa
* [`3f5b9a39`](https://github.com/nix-community/emacs-overlay/commit/3f5b9a39a01538a802013d14f0ca374ee85d316c) Updated emacs
* [`1ebfe528`](https://github.com/nix-community/emacs-overlay/commit/1ebfe528f07f0ba6d4b0d530332012749b36eee5) Updated flake inputs
* [`03ec7b09`](https://github.com/nix-community/emacs-overlay/commit/03ec7b0945ae5f1533324be2c492db98f9014a5c) Updated elpa
* [`1ab53417`](https://github.com/nix-community/emacs-overlay/commit/1ab53417ca9953ce6779d317b915fd6fefd76636) Updated melpa
* [`a4b1f96f`](https://github.com/nix-community/emacs-overlay/commit/a4b1f96fb2f5839190add821f3ddfaf9dfa47ab9) Updated emacs
* [`0c240033`](https://github.com/nix-community/emacs-overlay/commit/0c240033e4178a6555828df5e980685342ba5ad3) Updated melpa
* [`443b6591`](https://github.com/nix-community/emacs-overlay/commit/443b6591a1640ef4bf21dd8d29a0d8da6e401696) Updated emacs
* [`1f7571fc`](https://github.com/nix-community/emacs-overlay/commit/1f7571fcfea341a104d626ec12d3c0d46d90876b) Updated elpa
* [`67fe128c`](https://github.com/nix-community/emacs-overlay/commit/67fe128ca01b54501f2e816aaac79f93363ec854) Updated melpa
* [`2e3aa163`](https://github.com/nix-community/emacs-overlay/commit/2e3aa16322991f8f97928815e5ad62b253e99a36) Updated emacs
* [`31f777ab`](https://github.com/nix-community/emacs-overlay/commit/31f777aba2c488344f76361001ac4156a004ce2b) Updated elpa
* [`0507cd56`](https://github.com/nix-community/emacs-overlay/commit/0507cd56200326038c2656893738e05720f26bbd) Updated melpa
* [`e32cafd5`](https://github.com/nix-community/emacs-overlay/commit/e32cafd5b6e25f3bd1629177c8abdf2c0ca7030e) Updated emacs
* [`39bfba26`](https://github.com/nix-community/emacs-overlay/commit/39bfba263aba4644c4a68986b3c651bb5f0cb1a2) Updated melpa
* [`15abcf02`](https://github.com/nix-community/emacs-overlay/commit/15abcf023994ffba0a59420ec752b5450cad946d) Updated nongnu
* [`10d9aaa7`](https://github.com/nix-community/emacs-overlay/commit/10d9aaa73d465c9bfc48d8eae4c51cc5b8e8c4e4) Updated elpa
* [`07fcd70d`](https://github.com/nix-community/emacs-overlay/commit/07fcd70dca60adaf114f2739fef27f20e2e3ff42) Updated melpa
* [`087cf452`](https://github.com/nix-community/emacs-overlay/commit/087cf45264b4487b2848e08548bb4c5f933d460c) Updated emacs
* [`dff87248`](https://github.com/nix-community/emacs-overlay/commit/dff87248d2f71044be58701d0675780f15daad07) Updated melpa
* [`e237f6ef`](https://github.com/nix-community/emacs-overlay/commit/e237f6ef7ddd6d76c9e52125f88620a9051e85db) Updated emacs
* [`3f03cd5f`](https://github.com/nix-community/emacs-overlay/commit/3f03cd5fed0e3f2665b0a5e8587f9fa640f49a1f) Updated flake inputs
* [`dad25825`](https://github.com/nix-community/emacs-overlay/commit/dad25825410285c0c23ce741134854a95bfb8799) Updated nongnu
* [`541bfb0a`](https://github.com/nix-community/emacs-overlay/commit/541bfb0aa8675ea04dcad7df8dba534757bda606) Updated elpa
* [`d5cd0476`](https://github.com/nix-community/emacs-overlay/commit/d5cd047625d3d653ae535287864c1bf89bc2392b) Updated melpa
* [`a859acf1`](https://github.com/nix-community/emacs-overlay/commit/a859acf1434ed9cdaece7d332490e59e00bed9b1) Updated nongnu
* [`b90a7328`](https://github.com/nix-community/emacs-overlay/commit/b90a73284d3a7ad098c60b57a641492dd74f0c32) Updated elpa
* [`e0dd2809`](https://github.com/nix-community/emacs-overlay/commit/e0dd2809968ffe70240ca48b3c3841bdf23821fa) Updated melpa
* [`a24bf55f`](https://github.com/nix-community/emacs-overlay/commit/a24bf55fe66fc100fc584e3a400287a5b92f721c) Updated emacs
* [`70497f8b`](https://github.com/nix-community/emacs-overlay/commit/70497f8b17f0bdafddc197b125f54cd5f73162cf) Updated melpa
* [`4e79bd57`](https://github.com/nix-community/emacs-overlay/commit/4e79bd5756f66dfdccc5ddf3d1fe91e80f3f0183) Updated elpa
* [`fb62874b`](https://github.com/nix-community/emacs-overlay/commit/fb62874b50788a4772ce8235454582eda838cdc7) Updated melpa
* [`445662a3`](https://github.com/nix-community/emacs-overlay/commit/445662a366f5360a8a1b1cf1dbf21df483cd5a5b) Updated emacs
