### PR TITLE
niv doomemacs: update a189c211 -> 8be1ef49

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "doomemacs",
         "repo": "doomemacs",
-        "rev": "a189c211bf72aaa093289f5afb33763d2f36ecbd",
-        "sha256": "0cdsr7ykybifc80861pcsbh70a1jqlanfh31c66wmif0pprkas6q",
+        "rev": "8be1ef498b81628214ab5e78739661faaf9d950f",
+        "sha256": "0cfn8i5322bm2v2cywpgw4fr64q8s6ibwkdhgr93f4a8xhqam93h",
         "type": "tarball",
-        "url": "https://github.com/doomemacs/doomemacs/archive/a189c211bf72aaa093289f5afb33763d2f36ecbd.tar.gz",
+        "url": "https://github.com/doomemacs/doomemacs/archive/8be1ef498b81628214ab5e78739661faaf9d950f.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "emacs-overlay": {


### PR DESCRIPTION
## Changelog for doomemacs:
Branch: master
Commits: [doomemacs/doomemacs@a189c211...8be1ef49](https://github.com/doomemacs/doomemacs/compare/a189c211bf72aaa093289f5afb33763d2f36ecbd...8be1ef498b81628214ab5e78739661faaf9d950f)

* [`d75f9be0`](https://github.com/doomemacs/doomemacs/commit/d75f9be0d4dd5ee7a1b0cc79eecb220744a1c9c6) release(modules): 24.08.0-dev
* [`4d2eeab7`](https://github.com/doomemacs/doomemacs/commit/4d2eeab7f024300c77ab5c3c3142029c0404ecac) module: remove :tools rgb
* [`52e53272`](https://github.com/doomemacs/doomemacs/commit/52e53272212cdf5541a07c81cc7887c9c12ee524) module: remove :app twitter
* [`27539e22`](https://github.com/doomemacs/doomemacs/commit/27539e225e2b51f1e864eea389d787d6facef6cd) module: remove :tools taskrunner
* [`91156dba`](https://github.com/doomemacs/doomemacs/commit/91156dbaeb3818e0567fc37c421f0382bdbd9487) dev: update CODEOWNERS
* [`39ee7129`](https://github.com/doomemacs/doomemacs/commit/39ee7129efc5b242632915398eacedb9df2e51bd) refactor(evil): remove unneeded advice
* [`25d0b406`](https://github.com/doomemacs/doomemacs/commit/25d0b4065f5e49cc5e3121112514c10dc3bd7bb3) dev: format CODEOWNERS with more whitespace
* [`5da8304c`](https://github.com/doomemacs/doomemacs/commit/5da8304c4620d3b38c4bd6eb61366a83a89c0427) fix(python): wrong-number-of-args error for eglot users
* [`f9dfb7e9`](https://github.com/doomemacs/doomemacs/commit/f9dfb7e92ad134884b30ec5c9d7045160d4eb7d5) tweak(treemacs): use treemacs-add-and-display-current-project-exclusively
* [`481753bd`](https://github.com/doomemacs/doomemacs/commit/481753bd5e165d0a748536e831ded2d7b734234c) refactor!: remove pcre2el package
* [`321f2d22`](https://github.com/doomemacs/doomemacs/commit/321f2d2249a5a933e4a4a3ef684e30ce0a7a74cf) refactor!(org): remove org-yt
* [`c91c29c0`](https://github.com/doomemacs/doomemacs/commit/c91c29c03e1c344055dba6cdcbd69e3037d6ba13) refactor(org): remove redundant org-catch-invisible-edits setting
* [`7761eea6`](https://github.com/doomemacs/doomemacs/commit/7761eea6aa85c085683f627402269309ffec58dc) fix(spell): initialize ispell fully
* [`d7f5e703`](https://github.com/doomemacs/doomemacs/commit/d7f5e7033e1baf9ad85614443c6532095473cbfb) bump: :ui doom modeline
* [`b08c2c74`](https://github.com/doomemacs/doomemacs/commit/b08c2c745fd206becece48162ccc39e94d95d381) module: remove :ui hydra
* [`d81f1862`](https://github.com/doomemacs/doomemacs/commit/d81f1862f733a596b97320860251b01c997db20a) refactor(php): remove php-cs-fixer
* [`b7954f92`](https://github.com/doomemacs/doomemacs/commit/b7954f927f7832a1f6a1e726a481e9a5d870e2b8) refactor!(org): remove ob-ipython
* [`934141a0`](https://github.com/doomemacs/doomemacs/commit/934141a01e48d041c6abc9a2281f7a11e5f4eb4d) refactor!(python): remove lsp-python-ms
* [`52898611`](https://github.com/doomemacs/doomemacs/commit/528986110921c3032dcabc8f9fee28a95df055f7) refactor(workspaces): +workspace/delete: rename to +workspace/kill
* [`f44309cb`](https://github.com/doomemacs/doomemacs/commit/f44309cb635b4d3fd01080096477a02f40e5d660) fix(default): replace void function +yas-active-p
* [`6e69b290`](https://github.com/doomemacs/doomemacs/commit/6e69b29084e17afb2c92a321f9f26dc10dd71faf) fix(lib): reset font size before setting big font mode
* [`b767beac`](https://github.com/doomemacs/doomemacs/commit/b767beaca61efa4413b7844259f651de1c434659) fix(lib): don't call doom-adjust-font-size twice
* [`2bfb7821`](https://github.com/doomemacs/doomemacs/commit/2bfb7821b6e0474d9f818adff8ee30c6ecf9703b) refactor(evil): +evil--window-swap: no-op if on edge
* [`7bb5df4c`](https://github.com/doomemacs/doomemacs/commit/7bb5df4cd4ae3a0916616dd7e50566b3caa9c931) fix(zig): update zls download URL
* [`b0e16dc2`](https://github.com/doomemacs/doomemacs/commit/b0e16dc24332f7334a8b2aee9cad342079a63676) fix(org): reload org-mode in half-loaded capture buffers
* [`8072762d`](https://github.com/doomemacs/doomemacs/commit/8072762de8dd9bf43651a8676642081d92027782) refactor(format): redesign module
* [`f6e65c40`](https://github.com/doomemacs/doomemacs/commit/f6e65c4010c8507e93dfc689feb4a65d4d2498b7) feat(org): add +org/reformat-at-point command
* [`cc358a60`](https://github.com/doomemacs/doomemacs/commit/cc358a60c41e60d0204659d3593cb263cfddae8e) refactor(org): remove unused hooks
* [`1cc83dce`](https://github.com/doomemacs/doomemacs/commit/1cc83dce358afc729e7b0db0b304d903155ab928) fix(cli): wrong-number-of-args error on choosing 'abort'
* [`d7075b24`](https://github.com/doomemacs/doomemacs/commit/d7075b24205ad4e85f1855c23d7efa47878fa7f4) tweak(lib): doom-project-find-file: use transient project
* [`d330642c`](https://github.com/doomemacs/doomemacs/commit/d330642c2e6b0f443a2cfccb4827c9df25ee3fa2) feat(literate): add +literate/find-heading command
* [`4e795c3a`](https://github.com/doomemacs/doomemacs/commit/4e795c3a558c7c2247e9e339db41c7e622ca2e39) tweak(org): use consult-outline instead of imenu
* [`17d4aaac`](https://github.com/doomemacs/doomemacs/commit/17d4aaace33e7323639deb5878e24d31cf2dc3c7) fix(format): add lsp functions
* [`21a427c3`](https://github.com/doomemacs/doomemacs/commit/21a427c33b57ab66eb7caa2830c0dfe930509318) fix(format): eglot-managed{,-mode}-hook hook
* [`3cd60518`](https://github.com/doomemacs/doomemacs/commit/3cd605182f362bb05d4064b4bd088a43b6f0c14b) fix(mu4e): remove stray +workspace-delete invokation
* [`a99863a7`](https://github.com/doomemacs/doomemacs/commit/a99863a76f927cabdbd903a610db11646fe1ec73) bump: :tools magit
* [`c45c8cee`](https://github.com/doomemacs/doomemacs/commit/c45c8cee355a22bfa9c7eb87f05537aa7458288a) tweak(beancount): +beancount/balance w/ prefix arg
* [`deb59ca4`](https://github.com/doomemacs/doomemacs/commit/deb59ca4ad774d62975a8b6926bcd5faccd14409) fix(format): LSP formatters before Apheleia is loaded
* [`5e78ed09`](https://github.com/doomemacs/doomemacs/commit/5e78ed09114fb1a22e2a050522b96c6f0d6df9e3) refactor(format): use eglot-server-capable
* [`c5c7f0bc`](https://github.com/doomemacs/doomemacs/commit/c5c7f0bc9917bbf9014a8bd8a16ab9afb26e3a1c) feat(format): add +format-inhibit alias
* [`9224ac56`](https://github.com/doomemacs/doomemacs/commit/9224ac56f0ff47aa5fb9160f8bddde6ded174ae3) tweak(default): bind '<leader> g U' to magit-unstage-buffer-file
* [`d648bfda`](https://github.com/doomemacs/doomemacs/commit/d648bfda40e6a15448c9131e8dba95896b70b6c4) docs(format): revise docstrings and comments
* [`cca40c02`](https://github.com/doomemacs/doomemacs/commit/cca40c0277198a13500a375be5e944d337f4fcba) tweak(format): doom-debug-variables: add apheleia-log-debug-info
* [`fd1941b9`](https://github.com/doomemacs/doomemacs/commit/fd1941b95f22ce3649ef7c5b28b9b5c982586bb4) refactor!(format): simplify & gate lsp/eglot impl behind +lsp
* [`f104f10c`](https://github.com/doomemacs/doomemacs/commit/f104f10c5b145c3a89ea86ea82837b8d8c67804a) docs(format): revise README.org
* [`6b526b1b`](https://github.com/doomemacs/doomemacs/commit/6b526b1b475ca95415d87b1c52c5c68aa7b1457f) refactor(format): +format/org-block: make arg optional
* [`6e19452f`](https://github.com/doomemacs/doomemacs/commit/6e19452f749a577d117e447194f3f26a09bf09f1) fix(python): missing labels for keybind prefixes
* [`7d25ba3f`](https://github.com/doomemacs/doomemacs/commit/7d25ba3f6c10eba2b869a3cbe0bfd28dc4739aa9) fix(format): void function +format-with-lsp-maybe-h error
* [`dfe9d572`](https://github.com/doomemacs/doomemacs/commit/dfe9d572a79e37ea19f433753bfdac03b7d49b7f) docs(format): hacks: mention save-buffer advice
* [`21a252d9`](https://github.com/doomemacs/doomemacs/commit/21a252d994d3c349fc884dc8f34d66cb14697942) bump!: :lang latex
* [`af2b1a62`](https://github.com/doomemacs/doomemacs/commit/af2b1a62dcb55c6c2f4b823a1f5c2926548ab97d) bump: :tools ansible
* [`081231b7`](https://github.com/doomemacs/doomemacs/commit/081231b73fc2a7edc0356dcdabcde398325e5780) fix(format): apheleia doesn't invoke lsp formatter
* [`f2696d73`](https://github.com/doomemacs/doomemacs/commit/f2696d730200f0cc83751e1b01357a33fd117d08) perf(vc-gutter): diff-hl-update-async = t
* [`96de02c7`](https://github.com/doomemacs/doomemacs/commit/96de02c76900768ae144019ff8d69737857ebac0) fix(latex): auctex: build tex-site.el
* [`944eef90`](https://github.com/doomemacs/doomemacs/commit/944eef90ec7962c3b17cf3e6df65bbac5f03dfdc) fix(lib): doom-plist-merge causing side-effects
* [`1131d5b3`](https://github.com/doomemacs/doomemacs/commit/1131d5b36d17421b78b1a246c22aa85a02256fdf) refactor(org): remove +org--recenter-after-follow-link-a
* [`e43d575c`](https://github.com/doomemacs/doomemacs/commit/e43d575cafd957cdc9de4eb8518f654a5a5487c5) refactor(lib): don't use smartparens' API
* [`8bd6b8ab`](https://github.com/doomemacs/doomemacs/commit/8bd6b8ab68081a9b45a4450a0f5b29d21c8a66b8) perf: suppress local-vars hooks in temp buffers
* [`a4869f32`](https://github.com/doomemacs/doomemacs/commit/a4869f32e73922bea52c25db0c9b8f321ad4e10f) refactor(org): org-src-lang-modes: move md alias
* [`fe0548e8`](https://github.com/doomemacs/doomemacs/commit/fe0548e820ff0fb9f3096a7f49847aa3c4e174cc) tweak: unbind SPC in y-or-n-p prompts
* [`9d7885ab`](https://github.com/doomemacs/doomemacs/commit/9d7885abbfea0022d12e435e060cbfd7012ae2f0) fix(evil): q/Q keybinds in view-mode
* [`16b24373`](https://github.com/doomemacs/doomemacs/commit/16b243733b8fca4efc5c79db854321a412f91e1a) fix(org): restart org in all optimized buffers
* [`b4b1b48e`](https://github.com/doomemacs/doomemacs/commit/b4b1b48e26ddc24ce8d7b681cdffd0251a3fd306) nit(org): update outdated comment
* [`68771150`](https://github.com/doomemacs/doomemacs/commit/68771150ba3eb4bdfdebaac9674d31c4526b7495) fix(lib): avoid writing customized faces to custom.el
* [`df5f6696`](https://github.com/doomemacs/doomemacs/commit/df5f6696ecf1ffad46a08942d22b1120b6d47ac3) tweak(markdown): fontify code blocks natively
* [`78304f4d`](https://github.com/doomemacs/doomemacs/commit/78304f4d798dfe52b953a72d863fc0c904d695ec) perf(vc-gutter): optimize bitmaps
* [`f1f72c29`](https://github.com/doomemacs/doomemacs/commit/f1f72c291a691bb1be77bc71876a317a7728c9df) refactor(vc-gutter): simplify & DRY
* [`6ef86098`](https://github.com/doomemacs/doomemacs/commit/6ef86098cb454cbd0547e87f36f6d54827b723d9) fix(ivy): counsel-rg dying on non-zero exit code
* [`234cc27b`](https://github.com/doomemacs/doomemacs/commit/234cc27b77d2da72841225a5770961a4229f70e7) fix(ivy): +counsel-rg-suppress-error-code-a
* [`0b135252`](https://github.com/doomemacs/doomemacs/commit/0b13525252331a9a2d3212899263427f74994fb7) fix(lib): avoid writing customized faces to custom.el (take 2)
* [`afb9773d`](https://github.com/doomemacs/doomemacs/commit/afb9773d7c14ffdb06b3d1b8a90d73f19e034d4f) fix(lib): avoid writing customized faces to custom.el (take 3)
* [`c2c24166`](https://github.com/doomemacs/doomemacs/commit/c2c241666b3e54786a7f37a9e0b793283b7f44b1) fix(lib): autoload doom--run-customize-theme-hook
* [`778fc9ad`](https://github.com/doomemacs/doomemacs/commit/778fc9ad3f7a2cc3e8fdeef2b2988bf0e0c07b26) fix(vc-gutter): disable diff-hl-update-async in with-editor-mode
* [`c8b5bf7b`](https://github.com/doomemacs/doomemacs/commit/c8b5bf7bd152fec71718a054468be9335073686a) feat(flycheck): add +icons flag
* [`a6ba70ae`](https://github.com/doomemacs/doomemacs/commit/a6ba70aed796688e35e7eec7c4df7a16e59ecebd) fix(lib): avoid writing customized faces to custom.el (take 4)
* [`c45318d4`](https://github.com/doomemacs/doomemacs/commit/c45318d493788190ec1c60178f18fa22de70b28a) nit(markdown): revise comments & reformat
* [`ef1aa5ef`](https://github.com/doomemacs/doomemacs/commit/ef1aa5efe3543afa13ff92a6226c29db9c1170e2) fix(ansible): void-function ansible error
* [`86517122`](https://github.com/doomemacs/doomemacs/commit/86517122bdb0cbe5b73e3b05b4e69d764e9b7744) bump: :core
* [`ba467fea`](https://github.com/doomemacs/doomemacs/commit/ba467fea5702fbcabc50cb7d5997fde93649c2c4) bump: :tools lsp tree-sitter
* [`250f3a38`](https://github.com/doomemacs/doomemacs/commit/250f3a389923b0129e67e55cbeb79989537badcf) feat(org): bind <localleader> l y to +org/yank-link
* [`11cf61fe`](https://github.com/doomemacs/doomemacs/commit/11cf61fef2d5a3537b8fdbf31043899c1270377a) feat(org): display link at point in eldoc
* [`3965df56`](https://github.com/doomemacs/doomemacs/commit/3965df56e87bb71ada343fe4324e7b6940d0e414) docs(org): +org--fix-inconsistent-uuidgen-case-a: link to bug report
* [`12dc1957`](https://github.com/doomemacs/doomemacs/commit/12dc1957746a32cdeac0388808d88812f47e3b9d) fix: kill-current-buffer: respect kill-buffer-query-functions
* [`20ee9061`](https://github.com/doomemacs/doomemacs/commit/20ee90614ae86828a7141251a4c245428cd9470b) nit(cli): revise comment over site-run-file loader
* [`76845a2e`](https://github.com/doomemacs/doomemacs/commit/76845a2ea8f21f15e561201122cfa8d0a3800e7c) bump: :lang latex
* [`b0e1e68e`](https://github.com/doomemacs/doomemacs/commit/b0e1e68e78429659f6fd3b26e6691e921fa0d7e1) fix(cc): disable modern-cpp-font-lock if +tree-sitter
* [`af0dcdcd`](https://github.com/doomemacs/doomemacs/commit/af0dcdcd946f22699f27760e450c44576f44501d) bump: :checkers syntax
* [`b9f1d5d2`](https://github.com/doomemacs/doomemacs/commit/b9f1d5d2616751defd838266f6c8506faf642097) tweak(syntax): use close-circle-outline icon for errors
* [`8ab42fa7`](https://github.com/doomemacs/doomemacs/commit/8ab42fa774bac1130bc159c89d714e04a4fa8ac6) nit: revise site-lisp comments
* [`ce84690d`](https://github.com/doomemacs/doomemacs/commit/ce84690dc53f8fe98d6d44b4e7dcf649f08a578c) feat(evil): vim completion keybinds on C-x
* [`b3ef2024`](https://github.com/doomemacs/doomemacs/commit/b3ef2024513d52d3cba228e509686f42131593e4) refactor(corfu): conform to naming conventions
* [`3b689247`](https://github.com/doomemacs/doomemacs/commit/3b689247239de260cd948911efb85f893239f815) fix(gdscript): async :documentation lookup handler
* [`3cc2d83e`](https://github.com/doomemacs/doomemacs/commit/3cc2d83ee80fd7104ee798134a2251727a5c0898) tweak(gdscript): gdscript-docs-use-eww = nil
* [`3d99fbf5`](https://github.com/doomemacs/doomemacs/commit/3d99fbf5256456ea72ee8e06c1a2a7db3aa36a45) tweak(gdscript): open godot log buffers in popup
* [`49d833fa`](https://github.com/doomemacs/doomemacs/commit/49d833fa6466326c6862a8cf134acb9ff3c54741) fix(gdscript): accommodate version-suffixed godot binaries
* [`15ea9b64`](https://github.com/doomemacs/doomemacs/commit/15ea9b6452ea4206d4c0252bfc68237d5b81688c) refactor(gdscript): remove format keybinds
* [`378d0b8d`](https://github.com/doomemacs/doomemacs/commit/378d0b8db6c76252b364eb29d1d88cf069a37200) fix(cli): doom env: omit XDG_BACKEND & DOOMLOCALDIR
* [`7543b04e`](https://github.com/doomemacs/doomemacs/commit/7543b04e15661f0c9cc58dcdff68efce1a434b73) feat(format): add +format/org-block-in-region
* [`1eaa1aef`](https://github.com/doomemacs/doomemacs/commit/1eaa1aef2ccbb2efbf71bc10b0526a63b8d6121f) refactor(format): rename to +format/org-blocks-in-region
* [`5485b912`](https://github.com/doomemacs/doomemacs/commit/5485b912deba85c1311942363bfca6bc30fd6b18) bump: :ui vc-gutter
* [`c616831a`](https://github.com/doomemacs/doomemacs/commit/c616831a8ff928d5f611b497251edd4e9e5ecedd) fix(org): TAB in org-mode (for corfu users)
* [`ba3f30ef`](https://github.com/doomemacs/doomemacs/commit/ba3f30ef67f948438c4b8ec65d502108702be333) nit(org): punctuate docstrings
* [`fb0402e8`](https://github.com/doomemacs/doomemacs/commit/fb0402e89cd671955dd37ca9011ea2fdce3a5688) bump: :tools magit
* [`bd728fd2`](https://github.com/doomemacs/doomemacs/commit/bd728fd2a8490f99c2497cb77a61e9d0ff829c9d) fix(lib): doom-project-find-file: fall back to find-file if DIR is empty
* [`3f66400d`](https://github.com/doomemacs/doomemacs/commit/3f66400d62cd5c3ceecf5ef6fbb7275e374afeb2) fix(treemacs): open last treemacs session if in $HOME or non-project
* [`13ed89f2`](https://github.com/doomemacs/doomemacs/commit/13ed89f2354026b9c176f5c6861704aeda07723b) fix(format): disengage selection after +format-region
* [`58375306`](https://github.com/doomemacs/doomemacs/commit/58375306ad9dd36191e252218fc985e7821d772a) bump: :ui doom
* [`3391cb76`](https://github.com/doomemacs/doomemacs/commit/3391cb76bb194f67abcb553f57aa1c7699c47ed2) fix(julia): eglot-jl: use included server
* [`90bbd710`](https://github.com/doomemacs/doomemacs/commit/90bbd7101aa3bec6873b68c16b2a051fa5955e45) fix(beancount): beancount-fava failing to open browser
* [`08fdcd2a`](https://github.com/doomemacs/doomemacs/commit/08fdcd2abfc55d901ba865342c76d2e12747c339) docs(macos): doctor: mention auth-source-macos-keychain bug in <29.3
* [`f5a9f5d7`](https://github.com/doomemacs/doomemacs/commit/f5a9f5d7adce4b4c8b1495fd4c71370967e9415b) docs(popup): set-popup-rule!: update docstring
* [`98a3cad5`](https://github.com/doomemacs/doomemacs/commit/98a3cad54d1a14978c1bd6570ded8c4136b5fd19) docs: minor docstring revisions
* [`db36c74b`](https://github.com/doomemacs/doomemacs/commit/db36c74bbb806a0eb675142152e96c0f74681272) refactor: minor refactors
* [`36e7aaa6`](https://github.com/doomemacs/doomemacs/commit/36e7aaa619342eff61b1daf3ac664f94d5272db7) nit(default): remove refs to doom-point-in-*-functions
* [`f9583ee3`](https://github.com/doomemacs/doomemacs/commit/f9583ee30c96ee5e24e7dca233932100099dfe3f) bump: :lang scheme
* [`4fa24d15`](https://github.com/doomemacs/doomemacs/commit/4fa24d153330c0123f147d15703c7d8f5e716de5) bump: :tools magit :emacs vc
* [`d66dd559`](https://github.com/doomemacs/doomemacs/commit/d66dd5593afd45ff932d7263ddf6411104acf60e) bump: :lang org
* [`f5b39583`](https://github.com/doomemacs/doomemacs/commit/f5b3958331cebf66383bf22bdc8b61cd44eca645) fix(gdscript): make dtrt-indent aware
* [`2f2c2945`](https://github.com/doomemacs/doomemacs/commit/2f2c2945291edfeae84e4c77fe214c0576a982b1) refactor(irc): remove obsolete tls.el workaround
* [`c95ecc62`](https://github.com/doomemacs/doomemacs/commit/c95ecc6293a4d2c6e59ee4a86cf7eaa6910a9553) refactor(irc): remove unnecessary variables
* [`6d7e3ad3`](https://github.com/doomemacs/doomemacs/commit/6d7e3ad36523de67cb62f9c1be424b29d53aae78) fix(irc): circe-color-nicks & circe-new-day-notifier
* [`a6d0f101`](https://github.com/doomemacs/doomemacs/commit/a6d0f101bdfb450116fce92be29e74a9cf56b362) fix(irc): enable flyspell appropriately
* [`f99a5890`](https://github.com/doomemacs/doomemacs/commit/f99a58906b0c258194e0f010a6490c3fd6af3f98) refactor(irc): minor reformatting
* [`bb79a760`](https://github.com/doomemacs/doomemacs/commit/bb79a7603f6a329216742f610328780978383f90) fix(irc): lui-autopaste & lui-track init
* [`dab08759`](https://github.com/doomemacs/doomemacs/commit/dab08759ef43dda11909f660126aed41f996ff78) feat(irc): enable-lui-irc-colors
* [`d4577a05`](https://github.com/doomemacs/doomemacs/commit/d4577a054c95dc40f6b084efb49db026d11ba225) fix(irc): lui-logging-directory = doom-profile-state-dir
* [`95bf26c6`](https://github.com/doomemacs/doomemacs/commit/95bf26c6cd346fd54717df8075baeb67cb9e38c4) bump: :app
* [`201d90a7`](https://github.com/doomemacs/doomemacs/commit/201d90a7e3dc6bff840bf143e417d29c67d3ed1f) docs(irc): merge & revise auth-source section
* [`69f4b700`](https://github.com/doomemacs/doomemacs/commit/69f4b70069c3bcd41203e343aa96e3bfab233e56) fix(evil): remove gA keybind
* [`a8b836da`](https://github.com/doomemacs/doomemacs/commit/a8b836dac3d97f7e9aac9cee602560521b3ed61e) fix(vc-gutter): use global-diff-hl-mode
* [`7c5d8641`](https://github.com/doomemacs/doomemacs/commit/7c5d8641a141777dd48ba52bc1406a534959c724) fix(vc-gutter): respect diff-hl-disable-on-remote in dired
* [`5852b2ec`](https://github.com/doomemacs/doomemacs/commit/5852b2ecf58cde77421b94ebdf008d8079cd6452) fix(cli): properly overwrite last line of output
* [`54a084fe`](https://github.com/doomemacs/doomemacs/commit/54a084fed7e1051339ce61561d61af54d269c94e) fix(cli): some package files not being byte-compiled
* [`dec2a387`](https://github.com/doomemacs/doomemacs/commit/dec2a387ad35ca1a13295b4d518c69c56a8a32a9) fix(modeline): remove advice causing org-element cache errors in org
* [`ff3fd15b`](https://github.com/doomemacs/doomemacs/commit/ff3fd15b0249954f3a859e533f6c09a8b1988a72) fix(vc-gutter): check 'diff-hl-disable-on-remote is bound
* [`b163c21f`](https://github.com/doomemacs/doomemacs/commit/b163c21fe515fe6c43fcd5fa3ff73045bc4d20a8) fix(cli): --force: handle more straight prompts
* [`bc948c38`](https://github.com/doomemacs/doomemacs/commit/bc948c38c215aed695e2004406088313c67e9345) refactor(vc): remove hydra
* [`bc5a8ec3`](https://github.com/doomemacs/doomemacs/commit/bc5a8ec3fa67c888a7c61b244a7321fce9be25eb) fix(zig): update zls download URL sooner
* [`4ca92f3d`](https://github.com/doomemacs/doomemacs/commit/4ca92f3dd0f6ee37e5de75c52d317259deb6fb2c) module: deprecate :completion ivy
* [`559c1eef`](https://github.com/doomemacs/doomemacs/commit/559c1eef39e329db4f9c08c9d348634ebb1aff5a) module: deprecate :completion company
* [`5f798cf8`](https://github.com/doomemacs/doomemacs/commit/5f798cf8e7338f2fdf4236c069b8a0d18def60df) feat(indent-guides): add +indent-guides-inhibit-functions
* [`740aa4d7`](https://github.com/doomemacs/doomemacs/commit/740aa4d786d14ebc68da5819d463cd70956b0d36) tweak: use :completion corfu by default
* [`0f30e1ec`](https://github.com/doomemacs/doomemacs/commit/0f30e1eca5f7cb9220d2d1caf4fef7214a86c339) bump: :ui vc-gutter :tools magit :emacs vc
* [`2cb8328f`](https://github.com/doomemacs/doomemacs/commit/2cb8328f6870dec32ac603c536e6910d20cc7127) bump: evil-org
* [`04efd825`](https://github.com/doomemacs/doomemacs/commit/04efd825900849e1b601c00c0a5c78706c83721b) feat(evil): optionally wrap move-window commands
* [`9cdcfdac`](https://github.com/doomemacs/doomemacs/commit/9cdcfdac36d3264bd9a8282606472d2267ddf1a7) feat(workspaces): add +workspace/delete
* [`014112c1`](https://github.com/doomemacs/doomemacs/commit/014112c16cbd3d45bc6e7187bd6edda1d260eecf) docs(org): remove org-yt custom link type
* [`93dfb0ac`](https://github.com/doomemacs/doomemacs/commit/93dfb0acfbde80382a11726dc1240681a27fb12e) fix(lsp): set lsp-zig-download-url-format earlier
* [`85b7b615`](https://github.com/doomemacs/doomemacs/commit/85b7b6151b99aba90350b9c1bd13b7349f83b015) fix(lsp): force lsp-zig-download-url-format to change
* [`0bac5fe1`](https://github.com/doomemacs/doomemacs/commit/0bac5fe132bf791e3bfb6aef39d8b8978ce53dc9) fix(format): register shfmt for sh-mode
* [`8be1ef49`](https://github.com/doomemacs/doomemacs/commit/8be1ef498b81628214ab5e78739661faaf9d950f) fix(lsp): void-variable args error
