### PR TITLE
niv nixpkgs: update 8e3eab28 -> 42015a12

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "8e3eab28d876d770f7103c26f3d995588202862c",
-        "sha256": "0c6lsklvi7pr7rvlpbhnd5wpsnqwrz9wq4rdbfd6lnk2ifm5sg64",
+        "rev": "42015a129a2ae1cd43a44490e8235d2b24c8a2e2",
+        "sha256": "03vyfa73w3f6np58xiaan9337m5fj4h9rd7xfmvjmyaa2qcff45g",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/8e3eab28d876d770f7103c26f3d995588202862c.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/42015a129a2ae1cd43a44490e8235d2b24c8a2e2.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@8e3eab28...42015a12](https://github.com/nixos/nixpkgs/compare/8e3eab28d876d770f7103c26f3d995588202862c...42015a129a2ae1cd43a44490e8235d2b24c8a2e2)

* [`ee1604d8`](https://github.com/NixOS/nixpkgs/commit/ee1604d8c702d110c5fc6f9de1543c8a291505b8) networking.wireguard: generate leaner units
* [`bee4fcb0`](https://github.com/NixOS/nixpkgs/commit/bee4fcb001334bf98cfe158e7a9b91e3adb78cf1) haskellPackages.kmonad: mark as broken on darwin
* [`4f960314`](https://github.com/NixOS/nixpkgs/commit/4f96031495903a6762ea0463f31551351b107a67) nixos/boot.plymouth.font: escape font path
* [`d40141c7`](https://github.com/NixOS/nixpkgs/commit/d40141c7274083797d679fa44c102dd4bf172461) vscode: fixing libdbusmenu on kde
* [`8ce8e14e`](https://github.com/NixOS/nixpkgs/commit/8ce8e14e86a09c2431bf6ee914aae5efc76d182d) python312Packages.google-cloud-spanner: 3.45.0 -> 3.47.0
* [`121b49a9`](https://github.com/NixOS/nixpkgs/commit/121b49a9b1e8d2cc31a01be7340b6515d0d0455a) steampipePackages.steampipe-plugins-aws: init at 0.138.0
* [`d9e0c501`](https://github.com/NixOS/nixpkgs/commit/d9e0c501b1a3ab9a168c50081ebd84500914323b) steampipePackages.steampipe-plugin-github: init at 0.41.0
* [`2cf9fd0a`](https://github.com/NixOS/nixpkgs/commit/2cf9fd0add4e283c6ea534b64b1b5c3b74db460f) python312Packages.hypchat: disable python >=3.12
* [`8d8a0e2a`](https://github.com/NixOS/nixpkgs/commit/8d8a0e2a378479cab9f01ec7b3ac1c51f498ea20) x2vnc: set C standard
* [`14296c45`](https://github.com/NixOS/nixpkgs/commit/14296c45a33ce0890fe468f6e736c97c8ddde447) python312Packages.pydaikin: 2.11.1 -> 2.13.0
* [`6e1b60d1`](https://github.com/NixOS/nixpkgs/commit/6e1b60d17adc6d94db8061bbe922c86217840774) box86: init at 0.3.6
* [`036792c1`](https://github.com/NixOS/nixpkgs/commit/036792c1714d4ab1be13a9f329e7adcb8b03ac39) box86: Add 32-bit mapping for 64-bit platforms
* [`36175fb9`](https://github.com/NixOS/nixpkgs/commit/36175fb9ad17d77116b760d11d7030509fe8caaa) nixos/wireless: fix quotes in config path
* [`69f9b44a`](https://github.com/NixOS/nixpkgs/commit/69f9b44a7aa1672ce373b591a64e60b555e7ccef) mpdcron: mark broken on darwin
* [`db256988`](https://github.com/NixOS/nixpkgs/commit/db25698843caa07978c198eac5a0bcc3c5d559b7) jre_miniman.tests: fix pre/post hook running
* [`e68ac7fa`](https://github.com/NixOS/nixpkgs/commit/e68ac7fa2afcf78e565c4fc3f3c9901818db96b7) pkgs/anki: 24.04 -> 24.06.2
* [`36da32ae`](https://github.com/NixOS/nixpkgs/commit/36da32aeb5dbb783f3b01e3aefa4d28fd5360bf7) xpdf: replaced rejected CVE with correct one
* [`eac769dd`](https://github.com/NixOS/nixpkgs/commit/eac769ddaf1370c56be9b87f640e339d7b46fe0e) xpdf: removed rejected CVEs
* [`6723eac7`](https://github.com/NixOS/nixpkgs/commit/6723eac7618c97e2d6f96afd27558ead82a69d98) xpdf: replaced rejected CVE with correct CVE
* [`94dc8189`](https://github.com/NixOS/nixpkgs/commit/94dc8189410e862744663c06329a5547af287f28) xpdf: removed CVEs fixed in 4.05
* [`8252d108`](https://github.com/NixOS/nixpkgs/commit/8252d108b83ca08adf243390f39b88a1f795f549) xpdf: added new CVEs
* [`5ea0207b`](https://github.com/NixOS/nixpkgs/commit/5ea0207b73c8dc314be4982a45355860b235adb2) nixos/nats: Implemented configuration verification
* [`404fb5ab`](https://github.com/NixOS/nixpkgs/commit/404fb5ab9cd5fd82b67813d523450916b792b7dc) nixos/ec2-data: skip unrecognized keys in print-host-keys
* [`e542b743`](https://github.com/NixOS/nixpkgs/commit/e542b7432fe08339c94c91fb2a5033765cf558f3) pebble: fix version info
* [`38572248`](https://github.com/NixOS/nixpkgs/commit/38572248116762d34783858425d0947153753651) pebble: 2.4.0 -> 2.6.0
* [`b3c4da5c`](https://github.com/NixOS/nixpkgs/commit/b3c4da5cdf8b88a5e124aa4e858a86b4211cd56c) journalist: init at 1.0.0-unstable-2024-06-15
* [`f2b128f5`](https://github.com/NixOS/nixpkgs/commit/f2b128f5b5dbb199c34796aeaffefb145c02252f) handbrake: 1.8.0 -> 1.8.1
* [`31250663`](https://github.com/NixOS/nixpkgs/commit/312506638cd985f4567bc5319f304cb0dbdd611d) maintainers: add husky
* [`482e7aee`](https://github.com/NixOS/nixpkgs/commit/482e7aeeb52c381cd206e9c9e8e3f1742a49b429) maintainers: add vcele
* [`ba53e4ab`](https://github.com/NixOS/nixpkgs/commit/ba53e4ab7800e23e1e8817104bd2717a6fad3669) prisma-engines: remove ivan from maintainers
* [`8fbfdcec`](https://github.com/NixOS/nixpkgs/commit/8fbfdcec4a1b31dbfb2f7c8cb8ce5938d63d723f) postgresqlPackages.pg_embedding: remove ivan from maintainers
* [`a8038698`](https://github.com/NixOS/nixpkgs/commit/a8038698d3fc2e2f450809d713fe1d9f707d3289) nixos/restic: add option to inhibit going to sleep
* [`e9bbad73`](https://github.com/NixOS/nixpkgs/commit/e9bbad73863d22a5610edfef413726f3051e1cc1) lib/licenses: add radiance
* [`248ffcef`](https://github.com/NixOS/nixpkgs/commit/248ffcefe6c4524f331422727e02f2946a61104a) rustls-ffi: 0.10.0 -> 0.13.0
* [`87051a8f`](https://github.com/NixOS/nixpkgs/commit/87051a8f44389ac080afc13b089b2e91db173192) nixos/sogo: prefer 'install' over 'chmod'/'chown'
* [`dd782463`](https://github.com/NixOS/nixpkgs/commit/dd782463b9e221dd6065da9ae826bb50bfc93ece) renderdoc: pin to python 3.11
* [`530a1191`](https://github.com/NixOS/nixpkgs/commit/530a1191a20b9e7bf25fdde50b046d940aeaa64c) sratoolkit: 2.11.3 -> 3.1.1
* [`71b28e35`](https://github.com/NixOS/nixpkgs/commit/71b28e353ce926683b6b176568afd63373d6c480) grass: sync packaging with upstream
* [`1c5c6e19`](https://github.com/NixOS/nixpkgs/commit/1c5c6e19c25bd70653b06692ebd9da686b7bd851) python312Packages.social-auth-app-django: 5.4.1 -> 5.4.2
* [`bdb085d8`](https://github.com/NixOS/nixpkgs/commit/bdb085d86877575d256d636e2a01ff75f75b5f65) dxvk_2: 2.3.1 -> 2.4
* [`dd78e3f1`](https://github.com/NixOS/nixpkgs/commit/dd78e3f1687675b3b3a6c83a5bee640246684870) python312Packages.pytest-ansible: 24.1.3 -> 24.7.0
* [`9462e79b`](https://github.com/NixOS/nixpkgs/commit/9462e79b87450cd6294fbec6a2a893162fc29a9d) python312Packages.django-import-export: 4.0.9 -> 4.1.1
* [`c62daf9d`](https://github.com/NixOS/nixpkgs/commit/c62daf9d0d80db79d0f475fcd667312068cfa607) python312Packages.atom: 0.10.4 -> 0.10.5
* [`92d848bf`](https://github.com/NixOS/nixpkgs/commit/92d848bf6fec063dbf38cc444316ddd8339cb3da) haskellPackages: stackage LTS 22.26 -> LTS 22.29
* [`163c195b`](https://github.com/NixOS/nixpkgs/commit/163c195b689a6d792aafc6456f4f1cdaef2eaf42) all-cabal-hashes: 2024-06-23T10:38:31Z -> 2024-07-14T21:17:20Z
* [`fada32b9`](https://github.com/NixOS/nixpkgs/commit/fada32b96a291399bfb3f40c0c34158595eff18f) haskellPackages: regenerate package set based on current config
* [`198c24e0`](https://github.com/NixOS/nixpkgs/commit/198c24e04ee310ec0ef85f66a73044d5eb09d6b3) haskellPackages.ghc: 9.6.5 -> 9.6.6
* [`34fad0e8`](https://github.com/NixOS/nixpkgs/commit/34fad0e813891d2d54cdfb71f5787a75f846b42c) python312Packages.sphinxcontrib-confluencebuilder: 2.5.2 -> 2.6.0
* [`b4dffa96`](https://github.com/NixOS/nixpkgs/commit/b4dffa96980829e794ac98dbce64372c3bd83dde) python312Packages.jinja2-git: 1.3.0 -> 1.4.0
* [`5f2e02ba`](https://github.com/NixOS/nixpkgs/commit/5f2e02bafe9107e293ff49917bccb86c7ee770b9) haskellPackages.with-utf8: fix build on x86 darwin.
* [`9d739156`](https://github.com/NixOS/nixpkgs/commit/9d739156560a5d02879c03637c32b79e1ab53a5e) klaus: patch for python 3.12
* [`48fb9492`](https://github.com/NixOS/nixpkgs/commit/48fb94927e7dc09205996c5a568b87ce277f1783) haskellPackages.cpython: remove python 3.11 pin
* [`11b3d864`](https://github.com/NixOS/nixpkgs/commit/11b3d86444abd59a9066ce02f596751be48090cd) wootility: 4.6.20 -> 4.6.21
* [`c07e06bf`](https://github.com/NixOS/nixpkgs/commit/c07e06bfe2c33268d1e88dd4f6984253ac3fce63) libiconv with comment for with-utf8
* [`bea3a3f5`](https://github.com/NixOS/nixpkgs/commit/bea3a3f50c29836b0c6b6f3a29bbe4fbc734996e) miru: added passthru.updateScript
* [`9a636a1a`](https://github.com/NixOS/nixpkgs/commit/9a636a1ac60de1e52fdbc04371d2b0c1b9a326c8) haskellPackages.free-algebras: Unmark broken
* [`7d0356ef`](https://github.com/NixOS/nixpkgs/commit/7d0356ef2b50f84c723305c6dc1d064387ef0a58) python312Packages.django-debug-toolbar: 4.4.2 -> 4.4.6
* [`36598b71`](https://github.com/NixOS/nixpkgs/commit/36598b714f47df19575a9e3ab481a8bb26f66577) python312Packages.kmapper: 2.0.1 -> 2.1.0
* [`37ba8970`](https://github.com/NixOS/nixpkgs/commit/37ba8970e7c7e5bd09415a8fc043296333a2a540) llvmPackages_13.compiler-rt-libc: don't use distutils.spawn
* [`750deacc`](https://github.com/NixOS/nixpkgs/commit/750deacc011aca493a024d7d509690a4a003d7c1) libsForQt5.libqofono: Add updateScript
* [`083c370e`](https://github.com/NixOS/nixpkgs/commit/083c370e9e92f725fcc74063ca87e1f63c1daeff) libsForQt5.libqofono: 0.103 -> 0.123
* [`0629c43b`](https://github.com/NixOS/nixpkgs/commit/0629c43b4f2b08bf85f65dcaa929755a1b266ba6) lomiri.lomiri-system-settings-unwrapped: Fix compatibility with newer libqofono
* [`6ea3ec6f`](https://github.com/NixOS/nixpkgs/commit/6ea3ec6fd642c870369a5b6cfc27cf7be7d25a0b) lomiri.lomiri-system-settings-security-privacy: Fix compatibility with newer libqofono
* [`3d411fd3`](https://github.com/NixOS/nixpkgs/commit/3d411fd3408ce56eb970f28635b48843cd09ab99) darcs: adjust to crypton-connection 0.4.0 -> 0.4.1
* [`2ea0fc9b`](https://github.com/NixOS/nixpkgs/commit/2ea0fc9b6f7c548af63eeca3bdf55433c560f266) haskellPackages: adjust to Cabal 3.12.0.0 -> 3.12.1.0
* [`8ed9b3f6`](https://github.com/NixOS/nixpkgs/commit/8ed9b3f67babd9e621bdd5ef4346c61ceb49fa3f) llama-cpp: 3403 -> 3423
* [`248b5d60`](https://github.com/NixOS/nixpkgs/commit/248b5d60f1008ddfe50a41b7942815f506179446) thunderbird-bin-unwrapped: 115.10.1 -> 115.13.0
* [`a0e85379`](https://github.com/NixOS/nixpkgs/commit/a0e853797586abb5629f705f1566d1c07cccdd47) haskellPackages.large-records: adjust to new release
* [`245f3d4a`](https://github.com/NixOS/nixpkgs/commit/245f3d4aee493165de1108a249633c7d08766655) haskellPackages.nettle: remove dontCheck
* [`972fa691`](https://github.com/NixOS/nixpkgs/commit/972fa69158ec82851332138a4507ee9b0e727e0e) haskellPackages.polysemy-plugin: remove override
* [`0c8fc898`](https://github.com/NixOS/nixpkgs/commit/0c8fc898b7ecf47e85775a55f74249c7247e096e) haskellPackages.trial-optparse-applicative: remove override
* [`2eb87409`](https://github.com/NixOS/nixpkgs/commit/2eb87409b04e53609ee1e61db397948c27f16baf) haskellPackages.language-lua: remove overide
* [`58e72565`](https://github.com/NixOS/nixpkgs/commit/58e725657030400d90b9604998087bfe6f1ea865) haskellPackages.email-validate: remove overide
* [`b6f921c1`](https://github.com/NixOS/nixpkgs/commit/b6f921c1bb259ecf0d6a01492eb22d5cbf2e314c) haskellPackages.streamly-bytestring: remove dontCheck
* [`a0aeb6ba`](https://github.com/NixOS/nixpkgs/commit/a0aeb6bae52c1f9d07ffc1481e1e1f9c1c676820) haskellPackages.trie-simple: remove override
* [`fb7bb748`](https://github.com/NixOS/nixpkgs/commit/fb7bb748253e52f4e193b8f78db3a919d7a968e9) haskellPackages.iconv: remove override
* [`c9a6949e`](https://github.com/NixOS/nixpkgs/commit/c9a6949ee748078ef84a09e37facec659644c13b) haskellPackages.retrie: remove override
* [`d63390ab`](https://github.com/NixOS/nixpkgs/commit/d63390ab7ac9d7ac033ad510c53855ff03dde9e6) haskellPackages.shower: remove dontCheck
* [`2b16e31a`](https://github.com/NixOS/nixpkgs/commit/2b16e31a7eb20c8e66bf911b68164cee878cb23c) haskellPackages.base64: remove override
* [`bd47af96`](https://github.com/NixOS/nixpkgs/commit/bd47af9693a36d385d2096169f68dcb8f9f2e512) haskellPackages.tzdata: remove override
* [`5b25c2ab`](https://github.com/NixOS/nixpkgs/commit/5b25c2ab2609d6838564f9d7efaf64d6a3124cfb) haskellPackages.avro: unbreak with upstream patch
* [`390fccd1`](https://github.com/NixOS/nixpkgs/commit/390fccd1e8532460ed37ecc03fa6ebb1ddfe1c50) go-upower-notify: 0-unstable-2019-01-06 -> 0-unstable-2024-07-20
* [`be896c0d`](https://github.com/NixOS/nixpkgs/commit/be896c0d9b61dbf8190d9d2c99cf608f14806460) upower-notify: move to by-name, rename
* [`fb12dde0`](https://github.com/NixOS/nixpkgs/commit/fb12dde0e8531a3ab1f7d5ebb99abada0172bdaa) lomiri.lomiri: Fix compatibility with newer libqofono
* [`000c3a2c`](https://github.com/NixOS/nixpkgs/commit/000c3a2cce4e117b31357a7e7b1f90072ddc62ab) python3Packages.pytest-cov-stub: init at 1.0.0
* [`9fa22ab0`](https://github.com/NixOS/nixpkgs/commit/9fa22ab0f11c7e9210a8fc43be6a45985374df41) todoman: migrate to pytest-cov-stub
* [`f38a12b0`](https://github.com/NixOS/nixpkgs/commit/f38a12b0c673b765044058417192331154200563) python3Packages.strt: migrate to pytest-cov-stub
* [`4619c4c4`](https://github.com/NixOS/nixpkgs/commit/4619c4c49255b77506c2eabe408e37641349db9a) remote-exec: migrate to pytest-cov-stub
* [`8292b944`](https://github.com/NixOS/nixpkgs/commit/8292b944af48b08084ba9b7b0b5ef6a80b6edb7b) nf-test: 0.8.4 -> 0.9.0
* [`8bb380ef`](https://github.com/NixOS/nixpkgs/commit/8bb380efbb57f64be149d84b22fe6bd677c75455) haskellPackages.pipes-aeson: fix build
* [`ee3278a6`](https://github.com/NixOS/nixpkgs/commit/ee3278a62e9e5aced150cb0457b0542baa98d7e5) haskellPackages.push-notify-apn: Drop patch
* [`804de78a`](https://github.com/NixOS/nixpkgs/commit/804de78a0a1046430afda950deb5d734f8d98f6e) art: init at 1.22.1
* [`a04915fe`](https://github.com/NixOS/nixpkgs/commit/a04915fe1780f869cc9d86db3f7e798d9ad91683) pnpm_9: 9.4.0 -> 9.6.0
* [`1d8ea76d`](https://github.com/NixOS/nixpkgs/commit/1d8ea76d5407dc316225b8aa254fa8c3cdbab0f6) pnpm_8: 8.15.8 -> 8.15.9
* [`5813d109`](https://github.com/NixOS/nixpkgs/commit/5813d109b4b229f29b217e548631fc5f370427bf) python312Packages.django-compressor: 4.5 -> 4.5.1
* [`afce93f7`](https://github.com/NixOS/nixpkgs/commit/afce93f73261ff78befc3a44bb67a70b48a9372a) purescript: unbreak package by fixing imports for new mtl
* [`f7dd6b8f`](https://github.com/NixOS/nixpkgs/commit/f7dd6b8f2ae882a4315cb4fcc581495b2cb8be1e) purenix: unbreak package by adapting to purescript 0.15.12
* [`3f7e9843`](https://github.com/NixOS/nixpkgs/commit/3f7e98434210158f2aac76bbfb8253b8f8a1bcf9) nanoboyadvance: Disable portable mode
* [`5362da9a`](https://github.com/NixOS/nixpkgs/commit/5362da9ab92424aa546b171a26d2b44493453ba4) stu: 0.5.0 -> 0.5.1
* [`443bea4a`](https://github.com/NixOS/nixpkgs/commit/443bea4a5e656d422b58d33ce9e99cbcb5444d48) cni: 1.2.2 -> 1.2.3
* [`e7897271`](https://github.com/NixOS/nixpkgs/commit/e789727192a3fd8394f33f3378aab391ddd5ea72) ddnet: 18.3.1 -> 18.4
* [`82816bac`](https://github.com/NixOS/nixpkgs/commit/82816bac618021fcad28b954f21184de84bc9ea1) immersed-vr: Add pandapip1 as maintainer
* [`f73ef076`](https://github.com/NixOS/nixpkgs/commit/f73ef0768048adba78e38bd5d670d63f6e8503bb) nixos/immersed-vr: init module
* [`467f7b25`](https://github.com/NixOS/nixpkgs/commit/467f7b25f68e412ce9bae60352e079a3308e369e) nixos/doc/rl-2411: Document programs.immersed-vr
* [`b23dd56d`](https://github.com/NixOS/nixpkgs/commit/b23dd56df3b27f92d28ea1b5f7635de4415c59d6) python312Packages.pytest-flake8: 1.2.0 -> 1.2.2 and mark broken
* [`b3be02be`](https://github.com/NixOS/nixpkgs/commit/b3be02beaaf6ceedad411220863c0e82eba9a1b6) slack: fix update script
* [`7c2bc1f0`](https://github.com/NixOS/nixpkgs/commit/7c2bc1f05a95e19342cf27ae58478b5f4d3e369f) datalad: 1.0.2 -> 1.1.1
* [`6b01d8cb`](https://github.com/NixOS/nixpkgs/commit/6b01d8cba686200269f4c91ccde377140bd47e11) linuxPackages.nvidiaPackages.beta: 555.52.04 -> 560.28.03
* [`0384602e`](https://github.com/NixOS/nixpkgs/commit/0384602eac8bc57add3227688ec242667df3ffe3) nvidia-settings: add vulkan-headers dependency
* [`21bc7a6e`](https://github.com/NixOS/nixpkgs/commit/21bc7a6efdcb1d158826547a2609d0a845ebe0cb) linuxPackages.nvidiaPackages.beta: fix icds
* [`0e226315`](https://github.com/NixOS/nixpkgs/commit/0e2263158bc09f92fd19e7eaa691fb837a2522d9) microsoft-edge: 126.0.2592.102 -> 126.0.2592.113
* [`bfeb6e74`](https://github.com/NixOS/nixpkgs/commit/bfeb6e74cf4db5674a837aed5e4ecafca6fea353) nixos/nvidia: default open for version 560+
* [`f21d4e70`](https://github.com/NixOS/nixpkgs/commit/f21d4e7004ae3a2eaa9f6cf3f768981ece245fed) mongocxx: 3.8.1 -> 3.10.2
* [`43204447`](https://github.com/NixOS/nixpkgs/commit/432044471635f115ad0335fd8cbc14590063d58f) syslogng: 4.7.1 -> 4.8.0
* [`6397b780`](https://github.com/NixOS/nixpkgs/commit/6397b78082faca213ecf4f46d67405fd93f07c53) dep-tree: 0.20.3 -> 0.23.0
* [`9273e989`](https://github.com/NixOS/nixpkgs/commit/9273e9898db15315202bb33376c70c64c1b82f10) terraform-ls: 0.33.1 -> 0.34.1
* [`e7c74a75`](https://github.com/NixOS/nixpkgs/commit/e7c74a75a2ae75a9e6061843fb57ea15868eecf1) maintainers: add definfo
* [`20a03723`](https://github.com/NixOS/nixpkgs/commit/20a037237cc4ba866a35d575115337c7611a67b0) appimage-run: Expose $APPIMAGE
* [`b1d0e56b`](https://github.com/NixOS/nixpkgs/commit/b1d0e56bc4132a2df2ccdecddf04815fbbbbfe0d) coqPackages.high-school-geometry: init at 8.16
* [`dc969616`](https://github.com/NixOS/nixpkgs/commit/dc969616d4bec9af888548330cacd29b6c68404e) chromedriver: fix build failure on aarch64-darwin
* [`99181fe9`](https://github.com/NixOS/nixpkgs/commit/99181fe9138193ac50f99d70627ef02075bd5bf5) haskellPackages.pdftotext: unbreak
* [`52fb468f`](https://github.com/NixOS/nixpkgs/commit/52fb468f16e8bc1bd0a2e0de2c87b11c38abbf01) haskellPackages.pdftotext: add mpscholten as maintainer
* [`e1bd3a50`](https://github.com/NixOS/nixpkgs/commit/e1bd3a50a35bfcd9fe9d5fe70daa5b1848df8a82) xdg-terminal-exec: 0.10.0 -> 0.10.1
* [`a21dedff`](https://github.com/NixOS/nixpkgs/commit/a21dedffd03f99c2b0a1d91b814347c2c68c70d3) fastapi-cli: refactor to use python3Packages.fastapi-cli
* [`eaaf0eba`](https://github.com/NixOS/nixpkgs/commit/eaaf0eba0b6f6687c79b6c6ba289999740968fe7) lilypond: 2.24.3 -> 2.24.4
* [`70148eb3`](https://github.com/NixOS/nixpkgs/commit/70148eb3b03b516aa399f18215a8147e89edb14c) flare-signal: 0.14.3 -> 0.15.0
* [`4a79f0bc`](https://github.com/NixOS/nixpkgs/commit/4a79f0bce26d4f978ff45b1992aeff59aa37bd4a) lutok: update meta.description
* [`a032cb96`](https://github.com/NixOS/nixpkgs/commit/a032cb961ef57f3c63e1dbe7f06b4f4d8fcc744a) geoserver: 2.25.2 -> 2.25.3
* [`4ea4381e`](https://github.com/NixOS/nixpkgs/commit/4ea4381e8973c339a048a6aeb89c78b4f2c9c476) infisical: 0.25.0 -> 0.26.1
* [`736ea47a`](https://github.com/NixOS/nixpkgs/commit/736ea47a11916b2eadf1add01058f3629a4a4f7b) tomcat-native: 2.0.7 -> 2.0.8
* [`9919b666`](https://github.com/NixOS/nixpkgs/commit/9919b666ab142a2b47ea153154f39301bd4b01d8) haskell.packages.ghc{96,98}.cabal-install: fix build of 3.12
* [`76cf9b6d`](https://github.com/NixOS/nixpkgs/commit/76cf9b6df23bef2860a0bca229cea26a254313be) metals: 1.3.3 -> 1.3.4
* [`089be297`](https://github.com/NixOS/nixpkgs/commit/089be29749fc4e81aa5395bc057e34b55a76a535) checkov: disable flaky test
* [`94701b1d`](https://github.com/NixOS/nixpkgs/commit/94701b1d1712a8b19947b03bdb2f37ae785732fe) python312Packages.ytmusicapi: 1.7.5 -> 1.8.0
* [`75679635`](https://github.com/NixOS/nixpkgs/commit/756796359c6815046271966303dfff9d17fd0aa1) python312Packages.ansimarkup: 1.5.0 -> 2.1.0
* [`a715d725`](https://github.com/NixOS/nixpkgs/commit/a715d72582851723c11a8126f9c1c378dd252bb4) haguichi: 1.4.6 -> 1.5.0
* [`f30c8b03`](https://github.com/NixOS/nixpkgs/commit/f30c8b032c58b7efcb76ec45f178504ec2123f96) haguichi: Modernise
* [`6abfa24a`](https://github.com/NixOS/nixpkgs/commit/6abfa24a98ddbb341811b017c640f346ab9594a2) Revert "haskellPackages.with-utf8: fix build on x86 darwin."
* [`bdecf6fd`](https://github.com/NixOS/nixpkgs/commit/bdecf6fd338ab4cc47ae8686805d2ba0c55ba26a) haskellPackages: regenerate package set based on current config
* [`b7903bfe`](https://github.com/NixOS/nixpkgs/commit/b7903bfec97a56ccc96f23d1ed9b932993af327f) haskellPackages.reflex-dom: fix eval on js backend
* [`d01482ec`](https://github.com/NixOS/nixpkgs/commit/d01482ec08db66f5341002d8a019fb21bd31b9d9) koboldcpp: fix gpu-architecture flags from CUDA_DOCKER_ARCH
* [`f0ff2935`](https://github.com/NixOS/nixpkgs/commit/f0ff29350933140f2d69ef044c11414f74e89df2) koboldcpp: add separator to the prefix option of makeWrapper
* [`3b0431e1`](https://github.com/NixOS/nixpkgs/commit/3b0431e14d8915ae056b16a8f267ece8efc55c28) fava: 1.27.3 -> 1.28
* [`bff7842b`](https://github.com/NixOS/nixpkgs/commit/bff7842b1e53ee7d8bc1356d38ea8ddbdda9b783) fava: replace python.pkgs to python3Packages due to splicing
* [`acb2c75e`](https://github.com/NixOS/nixpkgs/commit/acb2c75e701b031eaf12c54146663d42a72c672f) fava: fix disabled cli test
* [`248a1649`](https://github.com/NixOS/nixpkgs/commit/248a1649a56c7087fe817c918e61999b900bc879) fava: modernize
* [`145580ed`](https://github.com/NixOS/nixpkgs/commit/145580edb6e7c78edb89c5e6a1d16308d7e8eed0) fava: migrate to pkgs/by-name
* [`e9607889`](https://github.com/NixOS/nixpkgs/commit/e96078899dbe456d663521702441fdfcf6940f3c) fava: add sigmanificient to maintainers
* [`0164c884`](https://github.com/NixOS/nixpkgs/commit/0164c884bf4d7cdaed7b0dec88d26601c013fa63) rubyPackages.curses: fix build with clang 16
* [`5a5fda7a`](https://github.com/NixOS/nixpkgs/commit/5a5fda7a906b9c4add5e93d17716a6c7f427826b) rubyPackages.gtk3: fix build on Darwin and Linux
* [`e1d14f12`](https://github.com/NixOS/nixpkgs/commit/e1d14f12b1d778cbd55436052835fd589383efc1) rubyPackages.hpricot: fix build with clang 16
* [`2536713f`](https://github.com/NixOS/nixpkgs/commit/2536713f70c6832498efbd7736604b01e0a57d18) rubyPackages.iconv: fix build on Darwin
* [`1aa9412f`](https://github.com/NixOS/nixpkgs/commit/1aa9412f3e95afec26f52d9d9bb993c82e935cc9) rubyPackages.libxml-ruby: fix build on Darwin
* [`4f800a22`](https://github.com/NixOS/nixpkgs/commit/4f800a227fe9098cade0982111f6ea9c7bd45055) libabigail: 2.1 -> 2.5
* [`6b348f94`](https://github.com/NixOS/nixpkgs/commit/6b348f9482c2e6022e50f5fa6dac785e6154cecb) libdnet: 1.12 -> 1.18.0; change source to github
* [`0bad7670`](https://github.com/NixOS/nixpkgs/commit/0bad76709f10e06af6e1a264b486c78e8d51baf6) blueman: 2.4.2 -> 2.4.3
* [`9d3f8250`](https://github.com/NixOS/nixpkgs/commit/9d3f8250cb03ba4448c644f6c0c362597eaee0bd) deltachat-desktop: don't depend on libdeltachat
* [`d295b0c2`](https://github.com/NixOS/nixpkgs/commit/d295b0c2efa754ca5266698dae27556ecfaa5311) deltachat-desktop: check that correct electron version is used
* [`1538319d`](https://github.com/NixOS/nixpkgs/commit/1538319d171ca0c0c19207315a94b6ceb65b79a3) python312Packages.aresponses: 2.1.6 -> 3.0.0
* [`81a8702f`](https://github.com/NixOS/nixpkgs/commit/81a8702fd9021d2887d3a04a6d81db9fafc606f2) textlint-rule-prh: init at 6.0.0
* [`9e0f47d6`](https://github.com/NixOS/nixpkgs/commit/9e0f47d6dc7b2cf5ed845f3df61ee8dd3c31074d) qmplay2: prepare to by-name migration
* [`8d69d772`](https://github.com/NixOS/nixpkgs/commit/8d69d772441358c0dcab782f241996dd8849107f) qmplay2: migrate to by-name
* [`02dfdf73`](https://github.com/NixOS/nixpkgs/commit/02dfdf731e801a6181ff4838d48c0da9ada02075) qmplay2: detach sources acquisition to `sources.nix`
* [`365e7e5d`](https://github.com/NixOS/nixpkgs/commit/365e7e5d07f3b2962ab87ed28fcf74204577a712) qmplay2: fetch submodules directly (get rid of fetchSubmodules)
* [`eec12ba4`](https://github.com/NixOS/nixpkgs/commit/eec12ba4fd4a88ac0a219b8c4b72e1b092bf3efc) qmplay2: create symlink at postInstall
* [`3900d02a`](https://github.com/NixOS/nixpkgs/commit/3900d02aa87758b00c758040b489433d8ae48afb) qmplay2: set strictDeps
* [`f667a7e2`](https://github.com/NixOS/nixpkgs/commit/f667a7e27034b8ad5e9ab96eefd315d2c5980c0a) qmplay2: delete changelog link
* [`fe47a55f`](https://github.com/NixOS/nixpkgs/commit/fe47a55fa3c957bc37e32ed66147fbc4bf546fc6) imhex: 1.33.2 -> 1.35.3
* [`1db62e6f`](https://github.com/NixOS/nixpkgs/commit/1db62e6fb734146b49d057ca9350510fd158ad88) imhex: fix RUNPATH to find libGL and plugins
* [`3728d33b`](https://github.com/NixOS/nixpkgs/commit/3728d33b72684639dccaaae6aa6d16a26198490d) imhex: nixfmt-rfc-style
* [`b2d53203`](https://github.com/NixOS/nixpkgs/commit/b2d53203f2c1cc2ba898e1fe22f61d781ffb89f9) docs: show `pyproject = true;` instead of `format = "pyproject";`
* [`466acbdd`](https://github.com/NixOS/nixpkgs/commit/466acbdd5088727d690420132c59250a78a01d51) qmplay2: fix longDescription
* [`5a499e70`](https://github.com/NixOS/nixpkgs/commit/5a499e703f2f5dafc6a1130c952574b15f7a39a8) qmplay2: 24.04.07 -> 24.05.23
* [`644bdba6`](https://github.com/NixOS/nixpkgs/commit/644bdba6d08fa164e640fe6ff5ec539f54d0faf7) qmplay2: 24.05.23 -> 24.06.16
* [`fb86fc7d`](https://github.com/NixOS/nixpkgs/commit/fb86fc7d25c76dc3a5460c79a2c370732c821b98) qmplay2: nixfmt-rfc-style
* [`8ef3d571`](https://github.com/NixOS/nixpkgs/commit/8ef3d571f06e54e0e5937460aa8cbe7c32eecf34) geoserver: migrate to by-name
* [`2551138e`](https://github.com/NixOS/nixpkgs/commit/2551138e307aba146d4d2a08f2be7613198f77d8) pkgsLLVM: use target platform to fix cross
* [`9c6f292f`](https://github.com/NixOS/nixpkgs/commit/9c6f292f411a76fa19a0119abd5875c22378f177) libselinux: fix version script with lld 17+
* [`b381163c`](https://github.com/NixOS/nixpkgs/commit/b381163c0b6e97395d9750d7abc591d9f745112f) docker: move default from 24.x to 27.x
* [`8ae868da`](https://github.com/NixOS/nixpkgs/commit/8ae868da8282f5e5adcc725337eb8e64a6295e2c) docker_24: add known CVEs
* [`e0ff5b54`](https://github.com/NixOS/nixpkgs/commit/e0ff5b54485f70a4e0a43f7a8cf9b043aeb3e13e) docker_25: 25.0.5 -> 25.0.6
* [`e2963b79`](https://github.com/NixOS/nixpkgs/commit/e2963b7913f7c4c6c75d50518d8f20c91dd91646) docker_26: 26.1.4 -> 26.1.5
* [`130ab429`](https://github.com/NixOS/nixpkgs/commit/130ab4295c9b282c2d295d8c17566aa6b6d9460c) armcord: package from source
* [`b7cba6a5`](https://github.com/NixOS/nixpkgs/commit/b7cba6a511e630149216f65555df82f3ebd1a933) armcord: add water-sucks as maintainer
* [`ad93085a`](https://github.com/NixOS/nixpkgs/commit/ad93085a699ab59abd43186d0ca762697986ec71) resilio-sync: 2.7.3 -> 2.8.1
* [`96d2da63`](https://github.com/NixOS/nixpkgs/commit/96d2da6316cab2abbdfbf6d00671ce3bf1e135ad) railway-wallet: init at 5.17.0
* [`344902e0`](https://github.com/NixOS/nixpkgs/commit/344902e09835cd90cb29661e3066b95be7fca9ce) llvm: Fix compiler-rt missing sanitizers when using useLLVM
* [`6b3e2a4f`](https://github.com/NixOS/nixpkgs/commit/6b3e2a4fbd6661768441d808287efa2e27088ac1) stack: pin to hpack-0.36.0
* [`ac64c152`](https://github.com/NixOS/nixpkgs/commit/ac64c1522ae76adc7f13c5bf2b5c554e6fcbbbcb) tree-sitter-grammars: add bqn
* [`408d5fa3`](https://github.com/NixOS/nixpkgs/commit/408d5fa30b310a493e991d8b4b1f62361963ffee) python312Packages.kmapper: fix build
* [`47b3b812`](https://github.com/NixOS/nixpkgs/commit/47b3b812c9e46a6cc7353e615b6e12827d35503e) buildah-unwrapped: 1.36.0 -> 1.37.0
* [`c701b578`](https://github.com/NixOS/nixpkgs/commit/c701b5787b6b9c70e3e52768220e920490c58f4d) haskellPackages.proto3-suite: fix build
* [`ad7d5a87`](https://github.com/NixOS/nixpkgs/commit/ad7d5a8764f88a733c978e202d2dabdd632c2aaa) radicle-httpd: 0.14.0 -> 0.15.0
* [`0ac40a06`](https://github.com/NixOS/nixpkgs/commit/0ac40a06c50bfafbd46a627367425fd631584473) python312Packages.opentelemetry-api: 1.25.0 -> 1.26.0
* [`38047274`](https://github.com/NixOS/nixpkgs/commit/38047274fc3bab187a8ea1988e4b929d6cebb934) python312Packages.opentelemetry-instrumentation: 0.46b0 -> 0.47b0
* [`85213416`](https://github.com/NixOS/nixpkgs/commit/85213416e8ae73387811bee257f7f5cff8da66be) gasket: 1.0-18-unstable-2023-09-05 -> 1.0-18-unstable-2024-04-25
* [`1a31cc7b`](https://github.com/NixOS/nixpkgs/commit/1a31cc7bf3aac59310a9daed64422ca5f2b15f95) python312Packages.opentelemetry-exporter-otlp-proto-grpc: fix tests
* [`d3c042f0`](https://github.com/NixOS/nixpkgs/commit/d3c042f02c58288035ffec7d6d712089e9468f9d) python312Packages.opentelemetry-instrumentation-grpc: mark as broken
* [`559e9a7f`](https://github.com/NixOS/nixpkgs/commit/559e9a7f9d48be9005b9f68ef466c09174a33945) resticprofile: disable some additional tests
* [`9f1c9a3c`](https://github.com/NixOS/nixpkgs/commit/9f1c9a3ca4bbb3626cb58c415c7670ccaa84e0f5) ext4fuse: init at 0.1.3
* [`c32bbdcd`](https://github.com/NixOS/nixpkgs/commit/c32bbdcde9736b9468a38861f1380d3b46b66be9) dooit: pin to python 3.11
* [`40ff23c5`](https://github.com/NixOS/nixpkgs/commit/40ff23c50efb9dc88a8fc0b9605701ecfd57c8a8) _2ship2harkinian: 1.0.1 -> 1.0.2
* [`c1351171`](https://github.com/NixOS/nixpkgs/commit/c1351171180cd7ddea5fd8c262389ae124a98626) _2ship2harkinian: reorganize
* [`da272fc5`](https://github.com/NixOS/nixpkgs/commit/da272fc5616442f2b44882c4591076bfe2c0cd3c) python312Packages.conda-libmamba-solver: 24.1.0 -> 24.7.0
* [`3b6dcb3a`](https://github.com/NixOS/nixpkgs/commit/3b6dcb3aab34e5322527d5dedded436d837e8cad) immich-cli: 2.2.4 -> 2.2.12
* [`e84e0197`](https://github.com/NixOS/nixpkgs/commit/e84e0197b53062f65d4d809bdc8b63bcbfd57f60) python312Packages.mkdocs-material: 9.5.29 -> 9.5.30
* [`72ee905f`](https://github.com/NixOS/nixpkgs/commit/72ee905f056cadb5b98305f92c30704f0ca2b58e) python312Packages.jinja2-git: refactor
* [`e2143121`](https://github.com/NixOS/nixpkgs/commit/e2143121ce8b6078da637c41c9104c31a57dea89) skypilot: 0.6.0 -> 0.6.1
* [`15a1c9eb`](https://github.com/NixOS/nixpkgs/commit/15a1c9ebb183cebb5fe4d0112e701a8a4869779c) deepin.deepin-draw: 6.0.5 -> 7.0.2
* [`027037fd`](https://github.com/NixOS/nixpkgs/commit/027037fd724728f7190d83b2265ba3afdbecec03) kaggle: 1.6.14 -> 1.6.17
* [`8bc0c345`](https://github.com/NixOS/nixpkgs/commit/8bc0c3453b2a9f875d0303bab038a766bea98d50) deepin.deepin-screen-recorder: unstable-2023-07-10 -> 6.0.6
* [`df39ab7a`](https://github.com/NixOS/nixpkgs/commit/df39ab7ae7fe19659fb90d3332988c803e307895) rpcs3: 0.0.32-16659-33851d51a -> 0.0.32-16711-501e9260b
* [`91a7e98b`](https://github.com/NixOS/nixpkgs/commit/91a7e98b2589e1e6bf96da74e57d9c6f9110489d) sketchybar-app-font: 2.0.19 -> 2.0.20
* [`3dda8c7f`](https://github.com/NixOS/nixpkgs/commit/3dda8c7f451b095b5ec8de13772e8dc3bfc91b5e) nitrokey-app2: 2.3.0 -> 2.3.1
* [`87e96ef4`](https://github.com/NixOS/nixpkgs/commit/87e96ef48ca17123ea84348be5895e696f3c4e47) ghciwatch: 1.0.0 -> 1.0.1
* [`2203c6b5`](https://github.com/NixOS/nixpkgs/commit/2203c6b5e3f52e44b73b895f83e441857c151a08) redocly: 1.18.0 -> 1.18.1
* [`88c37d8b`](https://github.com/NixOS/nixpkgs/commit/88c37d8b9942b2ee8f097ad91d4ebfa226148e3b) librewolf-unwrapped: 128.0-2 -> 128.0.3-1
* [`f348ae03`](https://github.com/NixOS/nixpkgs/commit/f348ae03dcf6cae94c28bdd0445af2faf3945cce) step-ca: fix hash
* [`ffbef012`](https://github.com/NixOS/nixpkgs/commit/ffbef01262c6ac8b87381cb1022a4294f3c60096) python312Packages.pex: 2.7.0 -> 2.12.1
* [`6b2255a2`](https://github.com/NixOS/nixpkgs/commit/6b2255a2af697e7548f0a59c95dcd1680e9c8ac5) aerospike: 7.1.0.3 -> 7.1.0.4
* [`9dc86a23`](https://github.com/NixOS/nixpkgs/commit/9dc86a2318cb0bfc462476e14063aa67bc92c696) haskellPackages.tasty_1_5_1: fix
* [`0fcde6e3`](https://github.com/NixOS/nixpkgs/commit/0fcde6e3435add598610d44822ce8bf79c92f7c6) haskell.compiler.ghc963Binary: work around `ar -L` issue on Darwin
* [`ac9122dd`](https://github.com/NixOS/nixpkgs/commit/ac9122dd71fe63ada6f60c46736703f2e2bc7eee) Revert "haskell.compiler.{ghc98*,ghcHEAD}: bootstrap using source built 9.6"
* [`61e29664`](https://github.com/NixOS/nixpkgs/commit/61e296641361767fb531ee56d492cf99dbe0f924) luaPackages.llscheck: init at 0.5.0-1
* [`0046a074`](https://github.com/NixOS/nixpkgs/commit/0046a074cc7189d05b918ea212ca96f065df656f) nexttrace: 1.3.1 -> 1.3.2
* [`50c332eb`](https://github.com/NixOS/nixpkgs/commit/50c332ebd9f0235785d5077756f3ba27fbbcff4e) rapidjson: 1.1.0 -> unstable-2024-04-09, rapidjson-unstable: drop
* [`4535a564`](https://github.com/NixOS/nixpkgs/commit/4535a5649555f0eb89ff7d689f10708123229c06) ghostscript, logrotate, linux-perf: adopt
* [`3a46d96d`](https://github.com/NixOS/nixpkgs/commit/3a46d96dde07b5ed387bd42e44cdf91f3a67bb8e) xpano: 0.18.1 -> 0.19.0
* [`acb853e1`](https://github.com/NixOS/nixpkgs/commit/acb853e12ee8937f7fbdc278cb60e415b779e1ef) regols: 0.2.3 -> 0.2.4
* [`6429e875`](https://github.com/NixOS/nixpkgs/commit/6429e875753552e88ded7ea154508d3348221203) python312Packages.xsdata: 24.6.1 -> 24.7
* [`3e9479c9`](https://github.com/NixOS/nixpkgs/commit/3e9479c95354cff14eadad076facffde2360a5bf) friture: use python 3.12
* [`e80fcf7a`](https://github.com/NixOS/nixpkgs/commit/e80fcf7a3dd815dd3da0e67df176dcb2f7715c0b) checkov: 3.2.208 -> 3.2.209
* [`c71dc054`](https://github.com/NixOS/nixpkgs/commit/c71dc05434981ab0e867e80c47c14f7050ed3f34) python3Packages.fissix: init at 24.4.24
* [`6bf6e021`](https://github.com/NixOS/nixpkgs/commit/6bf6e021f2c7f01fe489f4ca78ad0f226e8f0697) python312Packages.cyclonedx-python-lib: refactor
* [`2f0d7b0b`](https://github.com/NixOS/nixpkgs/commit/2f0d7b0ba8351ed3f5d817a551b1cbecabf43078) rust-analyzer-unwrapped: 2024-07-15 -> 2024-07-22
* [`1c87a85a`](https://github.com/NixOS/nixpkgs/commit/1c87a85a6541e87bffc2a5de9f3cb0c17ab617b0) kubeshark: 52.3.69 -> 52.3.72
* [`97dc5d68`](https://github.com/NixOS/nixpkgs/commit/97dc5d6809b590f6fce2e4e0d77ec5bde9b370fb) haskellPackages: Format configuration-ghcjs-9.x.nix
* [`fe15250d`](https://github.com/NixOS/nixpkgs/commit/fe15250dd8e67148ade40d971ea5a901044adced) python312Packages.pylibjpeg: 2.0.0 -> 2.0.1
* [`34644eb7`](https://github.com/NixOS/nixpkgs/commit/34644eb71ac141f8c1b9ef6bc18e9c9ec01da1e3) xdgmenumaker: 2.2 -> 2.3
* [`43fb06aa`](https://github.com/NixOS/nixpkgs/commit/43fb06aa929990e6e6d44a13ba35cc28d4c91384) freebsd: 14.0 -> 14.1
* [`c2baace7`](https://github.com/NixOS/nixpkgs/commit/c2baace76d145f4b542fb01f56b6384034f7f300) python312Packages.bring-api: 0.7.3 -> 0.8.1
* [`bed7864b`](https://github.com/NixOS/nixpkgs/commit/bed7864b47c1b2c59b28fe789a2d4f0b5b902499) gitu: 0.23.0 -> 0.23.1
* [`b5fc3a09`](https://github.com/NixOS/nixpkgs/commit/b5fc3a09e191b7401d52b4226fc8ebce8dd7051e) openstackclient-full: init
* [`a1e38ef3`](https://github.com/NixOS/nixpkgs/commit/a1e38ef32c8f315f143bb7f80c8ecc13eb839b21) openstackclient: add passthru.tests.version
* [`17260b29`](https://github.com/NixOS/nixpkgs/commit/17260b299f6db0f5c47b2f272995a6e339329a1e) lexical: 0.6.1 -> 0.7.0
* [`d93419d8`](https://github.com/NixOS/nixpkgs/commit/d93419d83721acbabf95e870721e29041e5df07e) proton-ge-bin: GE-Proton9-10 -> GE-Proton9-11
* [`43df2b50`](https://github.com/NixOS/nixpkgs/commit/43df2b50f94cd7528fd1d20c552140aeeb3cbf21) devShellTools.{unstructuredDerivationInputEnv,derivationOutputEnv}: extract
* [`33aaac17`](https://github.com/NixOS/nixpkgs/commit/33aaac17c5720270ff9d7277254e5c8070bd15c9) devShellTools.unstructuredDerivationInputEnv: Return attrsOf str
* [`bde2e05c`](https://github.com/NixOS/nixpkgs/commit/bde2e05c7043a71ba1272b5849e94906c95592ee) devShellTools.unstructuredDerivationInputEnv: Skip args
* [`7237aa70`](https://github.com/NixOS/nixpkgs/commit/7237aa700f6b73743a0671873877fa889c8db1ca) devShellTools: Docs, fix args env
* [`1cf3103b`](https://github.com/NixOS/nixpkgs/commit/1cf3103bcaf3b45aed2e8e0801f96207d2e98745) devShellTools.unstructuredDerivationInputEnv: Match passAsFile basename
* [`6881d9b1`](https://github.com/NixOS/nixpkgs/commit/6881d9b181198418cff2c9052082f5cc17ab0819) nixosTests.docker-tools-nix-shell: Extract
* [`41260169`](https://github.com/NixOS/nixpkgs/commit/412601690e7f696f2037e5dfa6b654780799fa99) build-support/docker/default.nix: Refer to docs and tests
* [`b3561f17`](https://github.com/NixOS/nixpkgs/commit/b3561f17f6df73b079cc81600ee88853fa2ffa13) devShellTools.unstructuredDerivationInputEnv: Support older Nix
* [`32c9e319`](https://github.com/NixOS/nixpkgs/commit/32c9e3193cb0b4e263707fc7bba0ef6d1541b952) tests.devShellTools: Fix release.nix / ofborg eval
* [`fdf76201`](https://github.com/NixOS/nixpkgs/commit/fdf76201ea1b58c53934c7df4cb7fa48ded50ee8) python312Packages.apprise: don't overuse `with lib;`
* [`08a4dcf0`](https://github.com/NixOS/nixpkgs/commit/08a4dcf0fadf4221dc095b1cbb404d007b88cd31) python312Packages.apprise: remove test path `test/test_plugin_workflows.py`
* [`758def96`](https://github.com/NixOS/nixpkgs/commit/758def96458c3c5c3ca82d3e412f3e192e16261c) python312Packages.apprise: disable more nondeterministic tests
* [`39055f53`](https://github.com/NixOS/nixpkgs/commit/39055f534e52bb4d4fd9495ec94bcd880408b1b1) python312Packages.apprise: add version test
* [`b5389e2a`](https://github.com/NixOS/nixpkgs/commit/b5389e2ae9cef0dfacbdb0aad492f39d6b9397b7) nixosTests.docker-tools-nix-shell: Enable on aarch64-linux
* [`1a70c803`](https://github.com/NixOS/nixpkgs/commit/1a70c803cbebc4d4c5d506e6fb03dffd86e284f2) Format
* [`58db6204`](https://github.com/NixOS/nixpkgs/commit/58db6204aca1cd69edb6d1e39b7b56e6e6cd6a0a) python312Packages.biopandas: Remove nose dependency
* [`bde55288`](https://github.com/NixOS/nixpkgs/commit/bde552884537a09118d67b661fa478d8002e59ed) python311Packages.finetuning-scheduler: init at 2.3.3
* [`ea7a4557`](https://github.com/NixOS/nixpkgs/commit/ea7a455700ab28840e41bbaeb36954dc2f879150) quill-log: init at 6.0.0
* [`76a55aaf`](https://github.com/NixOS/nixpkgs/commit/76a55aafc1bf1b1cce70749a99ac173ae745ffd4) maintainers: add odygrd
* [`6a4cf944`](https://github.com/NixOS/nixpkgs/commit/6a4cf944ef840faf63efd4b699b46e6ef60c013a) jre_minimal.tests: convert to an attribute set
* [`cfac36ce`](https://github.com/NixOS/nixpkgs/commit/cfac36ceaafe4b35eb946cb9e3c6b7606417c437) python312Packages.mlflow: add setuptools to propagatedBuildInputs
* [`c15eea34`](https://github.com/NixOS/nixpkgs/commit/c15eea348d25d0be000efa5b6549dff56c566921) nixos/nvidia: fix potential null value in versionOlder check
* [`7e893695`](https://github.com/NixOS/nixpkgs/commit/7e893695b859a693f5c1e40134383e41e02b3174) freebsd: Handle MACHINE/MACHINE_ARCH/MACHINE_CPUARCH differences
* [`39fba22f`](https://github.com/NixOS/nixpkgs/commit/39fba22f3e8f0c6fadfcb51049d2dfcffd0056cc) lightworks: 2023.2-146240 -> 2023.2-146752
* [`3ae2dd92`](https://github.com/NixOS/nixpkgs/commit/3ae2dd92a763b0f04faaad58cae59cb040a93289) python312Packages.kaggle: refactor
* [`7a98264f`](https://github.com/NixOS/nixpkgs/commit/7a98264f30119ed1adacb9978ca528b8b9392b14) python312Packages.pyais: 2.6.6 -> 2.7.0
* [`9b36743f`](https://github.com/NixOS/nixpkgs/commit/9b36743f0029d5086a2b8bc0d9bf089e363e21b2) python312Packages.pyexcel-ods: remove nose dependency
* [`792b0849`](https://github.com/NixOS/nixpkgs/commit/792b0849b7a83e732cdc566f830e6c6ee1e33a68) python312Packages.pyexcel-xls: remove nose dependency
* [`3d205a7c`](https://github.com/NixOS/nixpkgs/commit/3d205a7ce90e0dd88909f0901739ee630e279db9) python312Packages.pyexcel-ods: modernize
* [`32d6a3c3`](https://github.com/NixOS/nixpkgs/commit/32d6a3c359b0a0fa9077ad45c3245b312736cc05) python312Packages.pyexcel-xls: modernize
* [`53564204`](https://github.com/NixOS/nixpkgs/commit/5356420466c4d7901b63acc5e337c5bf30573f8a) treewide: remove unused with statements from maintainer lists
* [`b0c05184`](https://github.com/NixOS/nixpkgs/commit/b0c051842f45617865355b7ccf43319582958f38) terraform-providers.bitwarden: init at 0.8.0
* [`e742f464`](https://github.com/NixOS/nixpkgs/commit/e742f4648a57b83a14a744bfee88a6f35a6bb174) python312Packages.pyutilib: drop
* [`d6b601b9`](https://github.com/NixOS/nixpkgs/commit/d6b601b914bf110e724ecb8bc66a05062f04a1bf) python312Packages.dodgy: Drop nose dependency
* [`c1e2064f`](https://github.com/NixOS/nixpkgs/commit/c1e2064f49f6aea1c915e14717ad2032d42da0ea) python312Packages.habanero: Drop nose dependency
* [`dfac396c`](https://github.com/NixOS/nixpkgs/commit/dfac396c77b1cc31ca9d2aa7f5e7693c7e0e9676) emacs: move elpaBuild together with other builders
* [`22ac317e`](https://github.com/NixOS/nixpkgs/commit/22ac317eb3b567d21f890f1c72d83a8444c8db43) kotlin-language-server: 1.3.9 -> 1.3.12
* [`17bedbfc`](https://github.com/NixOS/nixpkgs/commit/17bedbfc7cedde9df2db9fec1782f25b7d0fba9c) rapidjson: remove questionable options
* [`c895be9c`](https://github.com/NixOS/nixpkgs/commit/c895be9c58e584160af55bedf171851ecc8f61ad) parallel-disk-usage: 0.9.2 -> 0.9.3
* [`0860e7ef`](https://github.com/NixOS/nixpkgs/commit/0860e7ef3b79513d4391d8385258c7b55cd9b6f4) python312Packages.isbnlib: drop nose dependency
* [`d554eb04`](https://github.com/NixOS/nixpkgs/commit/d554eb04425a296ab957bb445250e6e3ebe1bc95) python312Packages.isbnlib: modernize
* [`919a5242`](https://github.com/NixOS/nixpkgs/commit/919a5242afa4d13e26252f195168b37a1b80e670) python312Packages.jsonable: drop nose dependency
* [`8989a703`](https://github.com/NixOS/nixpkgs/commit/8989a7038e93d3238110f059d32a9ffb71db9d97) python312Packages.jsonable: modernize
* [`f68963c3`](https://github.com/NixOS/nixpkgs/commit/f68963c3648ccf2dedddc6c3d50eb4e030813d83) mackup: drop nose and six dependencies; modernize
* [`65c30b34`](https://github.com/NixOS/nixpkgs/commit/65c30b34ca241738322c931bf2348611caff6005) coc-diagnostic: migrate from nodePackages
* [`f74f40b5`](https://github.com/NixOS/nixpkgs/commit/f74f40b53696edf02a14d9232b1a8690e3ec9215) python312Packages.pyside6: allow optional dependencies for darwin
* [`20418bec`](https://github.com/NixOS/nixpkgs/commit/20418bec25c28575bd2c0fb69a9b4dd81597a633) python312Packages.pyside6: format
* [`0d808547`](https://github.com/NixOS/nixpkgs/commit/0d808547126da96c983ead818fb040dd2c580753) python312Packages.commitizen: Add library along with binary
* [`7e45f8f9`](https://github.com/NixOS/nixpkgs/commit/7e45f8f9c4c1cc39105edf53492a09a6b8c5496e) kodiPackages.pvr-vdr-vnsi: 21.1.1 -> 21.1.2
* [`6ac8f5c1`](https://github.com/NixOS/nixpkgs/commit/6ac8f5c13c75ec21e7b6b5ebd505d1c261cae82f) kodiPackages.pvr-iptvsimple: 21.8.4 -> 21.8.5
* [`c40ce90d`](https://github.com/NixOS/nixpkgs/commit/c40ce90d28e607d3b967963a0240c43d1210dbc5) python312Packages.pyside6: add pythonImportsCheck
* [`c34bd548`](https://github.com/NixOS/nixpkgs/commit/c34bd548e9cf15a4be7560b757eb5c88b6dc8216) python312Packages.timm: 1.0.7 -> 1.0.8
* [`5852d9f4`](https://github.com/NixOS/nixpkgs/commit/5852d9f458752171d705a561049ead06f715555b) satty: 0.13.0 -> 0.14.0
* [`0b62c871`](https://github.com/NixOS/nixpkgs/commit/0b62c871caac864484a30b217959205dda69be72) floorp: fix substitution of executable
* [`d31361e6`](https://github.com/NixOS/nixpkgs/commit/d31361e61abc8a19dfc49fa8d6114c740ccd6acd) supersonic-wayland: 0.12.0 -> 0.13.0
* [`15b92d66`](https://github.com/NixOS/nixpkgs/commit/15b92d66545738f8b7ca027c1a0f70caf40d7397) kodiPackages.pvr-hts: 21.2.4 -> 21.2.5
* [`8109e721`](https://github.com/NixOS/nixpkgs/commit/8109e721b7bc803009477ec38dff3e57d4090c52) Revert "bazarr: use libarchive instead of unar"
* [`63a6c2d9`](https://github.com/NixOS/nixpkgs/commit/63a6c2d95b866d7f0349dba35f3f46632d7ab497) plasmusic-toolbar: 1.3.0 -> 1.4.0
* [`9d38caf2`](https://github.com/NixOS/nixpkgs/commit/9d38caf2ad85668a265186ded9d8ed1f21239b8a) mpvScripts.modernx-zydezu: 0.3.5.5 -> 0.3.6
* [`df469220`](https://github.com/NixOS/nixpkgs/commit/df469220b4074efe453fb859d0cf4387745f1ebf) goa: 3.17.2 -> 3.18.0
* [`4a26db38`](https://github.com/NixOS/nixpkgs/commit/4a26db388508bb467af5e470253f40932beb3e9c) flexget: add missing dependency
* [`f0461bc9`](https://github.com/NixOS/nixpkgs/commit/f0461bc93b9ee0ad44ba129e17f8f89bff82ef4e) {scenefx,swayfx-unwrapped}: depend on wlroots_0_17
* [`febcfca9`](https://github.com/NixOS/nixpkgs/commit/febcfca9ce1fcddf2675fcb76e623442b3ce7163) wlroots_0_18: init at 0.18.0
* [`41ad9a1f`](https://github.com/NixOS/nixpkgs/commit/41ad9a1fda6669cfe99d0a474a3d9c6d10f3c39b) path-of-building.data: 2.46.0 -> 2.47.2
* [`0619f395`](https://github.com/NixOS/nixpkgs/commit/0619f395dd1423d2d34c9b6513979ad6705806fe) python312Packages.fastcore: 1.5.55 -> 1.6.1
* [`58cd3ef4`](https://github.com/NixOS/nixpkgs/commit/58cd3ef4bc2744b8150eb318b7953e798347dbb7) python312Packages.iocsearcher: 2.3-unstable-2024-03-04 -> 1.0.0
* [`992af654`](https://github.com/NixOS/nixpkgs/commit/992af6544d7fdad9ddfe99185020e5bd21f16c08) python312Packages.tencentcloud-sdk-python: 3.0.1198 -> 3.0.1199
* [`2249b3a3`](https://github.com/NixOS/nixpkgs/commit/2249b3a3a966a457433658215c5dfff14e6c4b57) pr-tracker: 1.4.0 -> 1.5.0
* [`37e3efa3`](https://github.com/NixOS/nixpkgs/commit/37e3efa305433a29d13e7c30700bfc938c1e9d80) vscode-extensions.continue.continue: 0.8.40 -> 0.8.44
* [`199a8f85`](https://github.com/NixOS/nixpkgs/commit/199a8f8548fa7c095b712877bbd976ea1ecc7d45) google-cloud-sdk: 483.0.0 -> 485.0.0
* [`7ab0f4fc`](https://github.com/NixOS/nixpkgs/commit/7ab0f4fca9de157f5bb8502afbf8eb40b2833555) slack: 4.38.125 -> 4.39.90
* [`3b7f8934`](https://github.com/NixOS/nixpkgs/commit/3b7f89348e111dac9bcc3c8289443fd8fedcc112) meson.meta.maintainers: add myself
* [`185a57d2`](https://github.com/NixOS/nixpkgs/commit/185a57d2b5776031719e0a6af3d071a01c69383c) ocamlPackages.swhid_core: init at 0.1
* [`fd9cbc66`](https://github.com/NixOS/nixpkgs/commit/fd9cbc663dd29c041244242a02955af301a0ea7b) ocamlPackages.opam-core: fix for opam 2.2
* [`60fef874`](https://github.com/NixOS/nixpkgs/commit/60fef87420b75aa2aa74aa767bf2a2309b3139a8) ocamlPackages.opam-repository: fix for opam 2.2
* [`816c9b4d`](https://github.com/NixOS/nixpkgs/commit/816c9b4d4586badd15133c3414516fb8b8990a09) ocamlPackages.spdx_licenses: init at 1.2.0
* [`3bb78ca8`](https://github.com/NixOS/nixpkgs/commit/3bb78ca87fbbc1991ae9a799a0deb235f51e78bc) ocamlPackages.opam-state: fix for opam 2.2
* [`8d839aa8`](https://github.com/NixOS/nixpkgs/commit/8d839aa80913351d74bbcab1ca22de66ef9bbcd6) ocamlPackages.opam-format: clean
* [`95e11ca0`](https://github.com/NixOS/nixpkgs/commit/95e11ca0a9197b2c4c92bb4d2a3b1593be06f840) opam-publish: 2.3.0 → 2.3.1
* [`ce15ea8b`](https://github.com/NixOS/nixpkgs/commit/ce15ea8bcb4344dabb33ea5733aeb49c59e3c8e0) tiny-dfr: 0.3.0-unstable-2024-07-10 -> 0.3.1
* [`801cacf8`](https://github.com/NixOS/nixpkgs/commit/801cacf89bc1089b8c6574d3a4e0891c9902996a) ffmpeg: add myself to maintainers
* [`d2225a1c`](https://github.com/NixOS/nixpkgs/commit/d2225a1ce36cf2666be717589655c937acce3e72) ffmpeg_7: add a Chromium patch to expose a private API
* [`3be3946f`](https://github.com/NixOS/nixpkgs/commit/3be3946fc39517fd879e7389c5145821904101a9) {qt5,qt6}.qtwebengine: add patches for FFmpeg 7
* [`1b74cb45`](https://github.com/NixOS/nixpkgs/commit/1b74cb45fe84b53af37e62c16e480fa25e722393) pipewire_0_2: drop
* [`2166381c`](https://github.com/NixOS/nixpkgs/commit/2166381c28d7af691f9498a9c2b6fb3f8b913256) qt6.qtmultimedia: pin FFmpeg 7 for now
* [`6d00f45e`](https://github.com/NixOS/nixpkgs/commit/6d00f45e36e4cb670afa4b7754c3344197749a07) goldendict-ng: disable FFmpeg backend
* [`a402e62e`](https://github.com/NixOS/nixpkgs/commit/a402e62e07cf54c7b489f1edcd7a9008e4c2c429) openboard: add patches for FFmpeg 7
* [`edc0b772`](https://github.com/NixOS/nixpkgs/commit/edc0b7727fd0a381a05e06a49cb7640a3f9125be) doc/interoperability: new chapter and section on CycloneDX ([nixos/nixpkgs⁠#316626](https://togithub.com/nixos/nixpkgs/issues/316626))
* [`15f1ec77`](https://github.com/NixOS/nixpkgs/commit/15f1ec77832aeaa4afbcea241a45c949a8958c07) python312Package.safe: drop
* [`d4da0440`](https://github.com/NixOS/nixpkgs/commit/d4da0440e71273e9e5c98b0219086ca7d1e73655) python312Packages.ptable: drop nose dependency
* [`10c865e8`](https://github.com/NixOS/nixpkgs/commit/10c865e804c855b8e3797af5f894b9c50a49ef9a) python312Packages.prox-tv: drop nose dependency
* [`9eec19ff`](https://github.com/NixOS/nixpkgs/commit/9eec19ff11befdecda4c3c74f939e99b8f6ed1b2) xevd: Link libm into shared library
* [`6b69b647`](https://github.com/NixOS/nixpkgs/commit/6b69b647e0f4d2caafe7a2e7dc4b052d2a70bd41) xeve: Link libm into shared library
* [`5a863267`](https://github.com/NixOS/nixpkgs/commit/5a86326716677eb492598d8887cb9400654743c4) ssm-session-manager-plugin: fix executable name
* [`76453af3`](https://github.com/NixOS/nixpkgs/commit/76453af3d1c7634bfabfe9268d9de77922df24a6) python312Packages.pprintpp: drop nose dependency; change source
* [`e73d97b2`](https://github.com/NixOS/nixpkgs/commit/e73d97b2d6a61f1fd729ede4fe62d88112c1f3c0) miracle-wm: init at 0.2.1
* [`051250a0`](https://github.com/NixOS/nixpkgs/commit/051250a049ac641c68c4f05d2ab6c8d47ebfb1fb) bpftop: 0.5.1 -> 0.5.2
* [`a161c82e`](https://github.com/NixOS/nixpkgs/commit/a161c82eef4f7ad876ba099964879f031614d801) ashuffle: 3.14.7 -> 3.14.8
* [`f839347f`](https://github.com/NixOS/nixpkgs/commit/f839347f18aae0e1406e6080620fb13287ad7292) pizauth: 1.0.4 -> 1.0.5
* [`161d0f0d`](https://github.com/NixOS/nixpkgs/commit/161d0f0d0a66f95bd8ced206e8da816f7f1876d2) svtplay-dl: 4.89 -> 4.97.1
* [`1b7f1644`](https://github.com/NixOS/nixpkgs/commit/1b7f16448342498a0ebb0a1e4346fdaee0f1abfc) bs-platform: remove
* [`1a0c9bd3`](https://github.com/NixOS/nixpkgs/commit/1a0c9bd3b15b9e9f816e372dfe2b462134e1cb60) cpm-cmake: 0.40.0 -> 0.40.1
* [`af832f8c`](https://github.com/NixOS/nixpkgs/commit/af832f8ceb0caae69d95532c8f15ba8b9c27eab4) pavucontrol: format with nixfmt-rfc-style
* [`ca6667b5`](https://github.com/NixOS/nixpkgs/commit/ca6667b535fdbcf1682056aa77e70b17ce4a3cc3) pavucontrol: use finalAttrs pattern
* [`11ff4aef`](https://github.com/NixOS/nixpkgs/commit/11ff4aefaeb5132904f05267db01a74705f2226c) rapidjson: additional cleanup
* [`96a5271f`](https://github.com/NixOS/nixpkgs/commit/96a5271f928ed1ce9f2837bb5f582dae7a23b921) keymapper: 4.4.4 -> 4.5.2
* [`ed443c58`](https://github.com/NixOS/nixpkgs/commit/ed443c58a8f0021142b5da39fbf38ef99b114aa7) nixos/miracle-wm: init
* [`e21cf452`](https://github.com/NixOS/nixpkgs/commit/e21cf452e251522b3952f4aba1a4ac9fb05a767e) pavucontrol: refactor meta
* [`5659ea3d`](https://github.com/NixOS/nixpkgs/commit/5659ea3d6ba5f1da0a09c9d8a656eaebf14b5b73) tests/miracle-wm: init
* [`c8b213a2`](https://github.com/NixOS/nixpkgs/commit/c8b213a297314454db73054a50b444efdd82ad55) miracle-wm: 0.2.1 -> 0.3.0
* [`56956e39`](https://github.com/NixOS/nixpkgs/commit/56956e39dde7233422c8e0a47800820ce6c726bf) pavucontrol: 5.0 -> 6.0
* [`c928625c`](https://github.com/NixOS/nixpkgs/commit/c928625c6d1889029da6137b7a2ae19e2b27013b) azure-cli-extensions.aks-preview: 6.0.0b1 -> 7.0.0b2
* [`f447d7fc`](https://github.com/NixOS/nixpkgs/commit/f447d7fc8e37d6311d93fe64078e7b614052b236) azure-cli-extensions.amg: 1.3.5 -> 1.3.6
* [`e603eb27`](https://github.com/NixOS/nixpkgs/commit/e603eb2768e4b6f96afb2c06209bccc51f0d570f) azure-cli-extensions.azure-firewall: 1.0.1 -> 1.1.0
* [`29a15dd7`](https://github.com/NixOS/nixpkgs/commit/29a15dd79768f54275ff125aae2d9ea1b65da265) azure-cli-extensions.dataprotection: 1.5.1 -> 1.5.2
* [`f31b0cf6`](https://github.com/NixOS/nixpkgs/commit/f31b0cf680d3ab6e88c0f256f4add034e56f0bd1) tlrc: 1.9.2 -> 1.9.3
* [`57e27770`](https://github.com/NixOS/nixpkgs/commit/57e277704b821e74bbd238f287e5bbba99818a77) uwsm: add kai-tub to maintainers
* [`276441cc`](https://github.com/NixOS/nixpkgs/commit/276441cced99b310b37f2a769727dfea06d6428b) uwsm: 0.17.0 -> 0.17.2
* [`6317528b`](https://github.com/NixOS/nixpkgs/commit/6317528b1a8830e4ac79462dc55636f08c514fa9) uwsm: fix dependencies add wrap the binary as well
* [`2c60d671`](https://github.com/NixOS/nixpkgs/commit/2c60d67129917da73d08a279958f1829288c8f71) uwsm: also wrap sway and hyprland's paths
* [`6830a7fa`](https://github.com/NixOS/nixpkgs/commit/6830a7fab03b5c029c8b84ca621695783d1bd0e8) electron-chromedriver_31: 31.2.0 -> 31.3.0
* [`6b340c80`](https://github.com/NixOS/nixpkgs/commit/6b340c80e6f062fc1797a8b50b5e61e604701582) deemix: change homepage
* [`b3930d40`](https://github.com/NixOS/nixpkgs/commit/b3930d40f802b67d6b9ce0ad439a469bd2997b41) python3Packages.nose-xunitmp: drop
* [`42acd4b7`](https://github.com/NixOS/nixpkgs/commit/42acd4b779cae9c379008c9d3fed7b4f3eea955f) syndicate_utils: 20231130 -> 20240509
* [`fbda8edd`](https://github.com/NixOS/nixpkgs/commit/fbda8edd0f319e79919375e3499f7ae3d6a1ff9f) python3Packages.dm-control: drop nose dependency
* [`a52a1ccd`](https://github.com/NixOS/nixpkgs/commit/a52a1ccdfb5ad8a773a3d4961b1a7198d7df7a2c) vscode-extensions.ms-dotnettools.csharp: 2.34.12 -> 2.39.29
* [`596a7e65`](https://github.com/NixOS/nixpkgs/commit/596a7e65516e87a55f94f413e5d290d82f48495c) vscode-extensions.ms-dotnettools.csdevkit: 1.7.27 -> 1.8.14
* [`be7717e7`](https://github.com/NixOS/nixpkgs/commit/be7717e777fc4d68e40513eb9146202fedf04858) azure-cli-extensions.oracle-database: init at 1.0.0b1
* [`3f55cc36`](https://github.com/NixOS/nixpkgs/commit/3f55cc361c9f7a167b225efeb58097dd5b617454) nixos/wayfire: fix import file with settings required to start service
* [`be7dc045`](https://github.com/NixOS/nixpkgs/commit/be7dc0453a7746327946009976f32dc684fd2f9b) vscode-extensions: fix typo in README.md
* [`f7856360`](https://github.com/NixOS/nixpkgs/commit/f7856360504d399afd58c1a431884bd8e883a26d) pavucontrol: fetchurl -> fetchFromGitLab
* [`304e66dc`](https://github.com/NixOS/nixpkgs/commit/304e66dcc7a092b6be93a8ebb6d19875992f278b) bs-platform: add deprecation alias
* [`df349265`](https://github.com/NixOS/nixpkgs/commit/df349265a1a86b9220651b58dd8d9aedfaf8b61e) pwvucontrol: 0.4.2 -> 0.4.5
* [`0a69e193`](https://github.com/NixOS/nixpkgs/commit/0a69e1935a7a6607466c4f214f3828fecc6731f1) pwvucontrol: add johnrtitor as maintainer
* [`a36e69c8`](https://github.com/NixOS/nixpkgs/commit/a36e69c83df03f90391ea7b4040679bf38b0e43d) xilinx-bootgen: xilinx_v2023.2 -> xilinx_v2024.1
* [`6ee57962`](https://github.com/NixOS/nixpkgs/commit/6ee5796295db502678fb3dffd3c961c1537c8c8c) xilinx-bootgen: reformat
* [`49bc45b5`](https://github.com/NixOS/nixpkgs/commit/49bc45b59c82bbf7fcac1fa48c15cefc66f4acdb) xilinx-bootgen: add jmbaur as maintainer
* [`303bc9a0`](https://github.com/NixOS/nixpkgs/commit/303bc9a08ea89d46772aef55aba61eea326b802f) xilinx-bootgen: move to pkgs/by-name
* [`f633fcf7`](https://github.com/NixOS/nixpkgs/commit/f633fcf7b83b55fccc0e72f7d1710ee64b1135c9) linuxPackages.ena: reformat, use upstream patch, remove problematic flag
* [`91897777`](https://github.com/NixOS/nixpkgs/commit/91897777defb06ae4ceafcff7137c55bd9801960) linuxPackages.ena: 2.12.0 -> 2.12.1
* [`37b2df81`](https://github.com/NixOS/nixpkgs/commit/37b2df819b7a4e6f74e8b2f3f52d885cafeda4e4) linuxPackages.ena: add arianvp as maintainer
* [`2483ea35`](https://github.com/NixOS/nixpkgs/commit/2483ea35cd29d26d206319032fcdb67e144e5dfb) modules/wayfire: nixfmt
* [`e597d01d`](https://github.com/NixOS/nixpkgs/commit/e597d01d8dffc5053803483e80ed0389c31ea164) roslyn-ls:  4.10.0-2.24124.2 -> 4.12.0-1.24359.11
* [`146ee44c`](https://github.com/NixOS/nixpkgs/commit/146ee44c702cba19ef1023d0b36c7c9627d80142) aide: fix default DB/config location
* [`063251a8`](https://github.com/NixOS/nixpkgs/commit/063251a83f8115882cc9b5f5a894ceca13f37076) mailpit: fix `passthru.updateScript`
* [`7d2595db`](https://github.com/NixOS/nixpkgs/commit/7d2595db330c7f7b96f5414b6209c150fc580d10) linuxPackages.nvidiaPackages.production: 550.100 -> 550.107.02
* [`569d6d66`](https://github.com/NixOS/nixpkgs/commit/569d6d66da4201028c26f6b5d0cd84938336a234) lsp-plugins: use php82
* [`edf6a2bb`](https://github.com/NixOS/nixpkgs/commit/edf6a2bbf2b0282fcdc2333344abaa36aaa3b33a) python312Packages.python-hglib: Remove nose dependency
* [`96b6d4ac`](https://github.com/NixOS/nixpkgs/commit/96b6d4ac48205aca94b33d6710350e4850a3963a) balls: init 5.4.0
* [`28e14b32`](https://github.com/NixOS/nixpkgs/commit/28e14b32a89accfba6d5314f152f0d68cd96a61a) mailpit: 1.15.1 -> 1.19.3
* [`ea02102a`](https://github.com/NixOS/nixpkgs/commit/ea02102a7c0f3eb77e9c536614e714c73c6fb048) python312Packages.glean-parser: 4.1.2 -> 4.3.0
* [`2ec9bc5d`](https://github.com/NixOS/nixpkgs/commit/2ec9bc5d5b5c0a2df98049b859439f6636d3276c) python312Packages.glean-sdk: 52.7.0 -> 60.4.0
* [`531e796a`](https://github.com/NixOS/nixpkgs/commit/531e796aff9d8eddf31db6d2a0fe54ca89c21ae5) mozphab: Disable failing tests
* [`43a5b1e6`](https://github.com/NixOS/nixpkgs/commit/43a5b1e66c17a66c08baba67861907f308e26678) python312Packages.python-hglib: modernize
* [`d69bd1a7`](https://github.com/NixOS/nixpkgs/commit/d69bd1a75bb01427cdaaf2eab1a3d22a2091fcbb) wineWow64Packages.unstableFull: 9.12 -> 9.14
* [`fe0481e7`](https://github.com/NixOS/nixpkgs/commit/fe0481e7d8755d09a257787a898f7c870dd10fa0) wineWow64Packages.stagingFull: fix patch failure
* [`1737d9fa`](https://github.com/NixOS/nixpkgs/commit/1737d9fa7d790451940e30e6880533a2adf34c9e) home-assistant-custom-lovelace-modules.atomic-calendar-revive: init at 10.0.0
* [`62d6e3ed`](https://github.com/NixOS/nixpkgs/commit/62d6e3ed9c38451aa9b765873fcc1ca1eaf72478) home-assistant-custom-lovelace-modules.rmv-card: init
* [`976d87f5`](https://github.com/NixOS/nixpkgs/commit/976d87f553a88e0e14d90901b017e7cb61f2fc2c) home-assistant-custom-lovelace-modules.template-entity-row: init at 1.4.1
* [`f0f2a07a`](https://github.com/NixOS/nixpkgs/commit/f0f2a07aeed70a38479a6ae48232a3b10b08644b) .editorconfig: accept package.json indent as is
* [`ac4f160f`](https://github.com/NixOS/nixpkgs/commit/ac4f160f787f3f2ac32e44d229b0139e644ec225) ncbi-vdb: init at 3.1.1
* [`35db6ff3`](https://github.com/NixOS/nixpkgs/commit/35db6ff3e7cfedecea745b29af1ba6f14506a05f) sratoolkit: build from source
* [`47b4b80c`](https://github.com/NixOS/nixpkgs/commit/47b4b80c07b4b7b32bc7d34bf432db44b74b6ab2) datalad: add python tests, use new PEP builder
* [`9e885bb1`](https://github.com/NixOS/nixpkgs/commit/9e885bb15bef25f87f768762b21d8c522653b350) datalad: format
* [`ca165721`](https://github.com/NixOS/nixpkgs/commit/ca1657217d7c85884adaa8d8be89f85e19ba4bf7) streamLayeredImage: add dynamic tagging of docker image ([nixos/nixpkgs⁠#329425](https://togithub.com/nixos/nixpkgs/issues/329425))
* [`2b67819d`](https://github.com/NixOS/nixpkgs/commit/2b67819d554a791380f1d8619939366d959ebdf0) nixos-test-driver: avoid top-level with in shell.nix
* [`4c7b4961`](https://github.com/NixOS/nixpkgs/commit/4c7b49613a66bce18baf9efffe9f8ea4ff881f9b) nixcfg-azure-devenv: avoid top-level with in shell.nix
* [`fc267a3e`](https://github.com/NixOS/nixpkgs/commit/fc267a3eb32a5f7b5d78e8e27a71666349ff2509) travis-env: avoid top-level with in shell.nix
* [`1dfa4e2a`](https://github.com/NixOS/nixpkgs/commit/1dfa4e2a3f0a2c7f0f214257eb854a06d0c8173a) metasploit-env: avoid top-level with in shell.nix
* [`4089e292`](https://github.com/NixOS/nixpkgs/commit/4089e292e56c928b9cc6a2700567f9ecf89f3b80) convert-to-import-cargo-lock: avoid top-level with in shell.nix
* [`ed607c12`](https://github.com/NixOS/nixpkgs/commit/ed607c1291fe0666281fde6fe59c03884f89281f) docker-compose_1: drop
* [`c191a6dc`](https://github.com/NixOS/nixpkgs/commit/c191a6dce07c47a96427fc3bdefc354dda35f210) python3Packages.oauth2client: fix license
* [`587f64a2`](https://github.com/NixOS/nixpkgs/commit/587f64a26459ffb7f2af0a7a0d454b4a6a76aec4) nixpkgs-manual: use injected revision only
* [`b56adcaa`](https://github.com/NixOS/nixpkgs/commit/b56adcaac7159701ba6414df9f9a1dd7953fda1b) python311Packages.dm-tree: fix darwin build
* [`c1d26a15`](https://github.com/NixOS/nixpkgs/commit/c1d26a15a3367aa20b4031095f730fbfb3c84315) epson-escpr2: 1.2.12 -> 1.2.13
* [`c0e7a955`](https://github.com/NixOS/nixpkgs/commit/c0e7a9559507758a876218e82021f5bcdf654119) python312Packages.py-synologydsm-api: update dependencies
* [`f0b5f849`](https://github.com/NixOS/nixpkgs/commit/f0b5f849fd7b106798767c683e4c28488e664a85) python312Packages.synologydsm-api: drop
* [`fe1b5c5b`](https://github.com/NixOS/nixpkgs/commit/fe1b5c5bb6959dde3dcae3d9e5ae9842939284af) mu: 1.12.5 -> 1.12.6
* [`9c22897e`](https://github.com/NixOS/nixpkgs/commit/9c22897eaa6a2d81c7651ae45ed9671861d52382) gnu-cobol: 3.1.2 -> 3.2
* [`5df71176`](https://github.com/NixOS/nixpkgs/commit/5df7117630c0e5e194c48b7b3de0fa718991f472) gnu-cobol: add techknowlogick as maintainer
* [`41315b2d`](https://github.com/NixOS/nixpkgs/commit/41315b2d9659be30a13b012e0201497863ea930e) python312Packages.ax-platform: rename from ax
* [`bb65f97e`](https://github.com/NixOS/nixpkgs/commit/bb65f97e8850eb80db110615e14de0d7593e01c3) nix-doc: fix build for Rust 1.79+
* [`22e506be`](https://github.com/NixOS/nixpkgs/commit/22e506be575421540e7a9f4d7af3773ac2d42c59) python312Packages.botorch: 0.11.1 -> 0.11.3
* [`e430cf4d`](https://github.com/NixOS/nixpkgs/commit/e430cf4dbd58f516b46f72c15c17888485a89655) nix-doc: sign up to maintain this tool in nixpkgs
* [`b88ea493`](https://github.com/NixOS/nixpkgs/commit/b88ea493fc9387d64db96b0678f123361e752dde) python312Packages.ax-platform: 0.4.0 -> 0.4.1
* [`aaeeab9d`](https://github.com/NixOS/nixpkgs/commit/aaeeab9df270e5fdd46268164209ab8c14a21368) bitwarden-cli: 2024.6.1 -> 2024.7.1
* [`95052df0`](https://github.com/NixOS/nixpkgs/commit/95052df0bed6d11730cf70538ac21eecf8bdd324) python312Packages.asyncarve: init at 0.1.1
* [`2fec1cfe`](https://github.com/NixOS/nixpkgs/commit/2fec1cfee837a39ba75110cf44f3ce3486fbace5) home-assistant: support arve component
* [`dc8eafa9`](https://github.com/NixOS/nixpkgs/commit/dc8eafa9a705cfc94a2b38fdbb2b7528ffd560dc) python311Packages.migen: small cleanups
* [`b7fb6c38`](https://github.com/NixOS/nixpkgs/commit/b7fb6c386036417a48269316fc08b17745d17651) python312Packages.migen: unstable-2022-09-02 -> 0-unstable-2024-07-21
* [`68910174`](https://github.com/NixOS/nixpkgs/commit/68910174af134c8aa8de2350862b34838cbf4986) python311Packages.misoc: small cleanups
* [`bb0dcb70`](https://github.com/NixOS/nixpkgs/commit/bb0dcb70b7d16d3b645629562c25fb28a0f4b056) python312Packages.misoc: unstable-2022-10-08 -> 0-unstable-2024-05-14
* [`a93f967a`](https://github.com/NixOS/nixpkgs/commit/a93f967a09678613ad1640ecdc122794e0072510) emacsPackages.copilot: add aarch64-darwin to copilot.el
* [`268299ad`](https://github.com/NixOS/nixpkgs/commit/268299ad045bd71e3339434ceab2de990b743f6d) nixos/i2pd: fix warning
* [`b66f04e7`](https://github.com/NixOS/nixpkgs/commit/b66f04e7df60337ccff62489051530021b3ceac2) python312Packages.mozart-api: init at 3.4.1.8.6
* [`134b9f72`](https://github.com/NixOS/nixpkgs/commit/134b9f72e2264ce22376dd41acba0c75e98c0bd2) home-assistant: support bang_olufsen component
* [`a8f203cf`](https://github.com/NixOS/nixpkgs/commit/a8f203cf8e6f52f62f5e828fce8e5a2fcf350b59) vector: 0.39.0 → 0.40.0
* [`382f37aa`](https://github.com/NixOS/nixpkgs/commit/382f37aa4089210080021a1464ecc259f599ad7d) nixos/vector: Delete superfluous host field from demo_logs source in Quickwit test
* [`560a3b59`](https://github.com/NixOS/nixpkgs/commit/560a3b59b5035a5c230fcfe758604d189c16260a) mujoco: 3.1.6 -> 3.2.0
* [`9a6eda65`](https://github.com/NixOS/nixpkgs/commit/9a6eda65e37434b8588f48d8f827d10c1ddbcbc2) python311Packages.mujoco: 3.1.6 -> 3.2.0
* [`3b959ec0`](https://github.com/NixOS/nixpkgs/commit/3b959ec00fe2553ab7d3c5d2bbaf36027cfed1b3) python311Packages.dm-control: 1.0.20 -> 1.0.21
* [`627a9c72`](https://github.com/NixOS/nixpkgs/commit/627a9c727b1f4659d715b11e268d46af1c7378dc) python312Packages.dm-tree: fix hashes
* [`ea3cfd5c`](https://github.com/NixOS/nixpkgs/commit/ea3cfd5ca7b0df10d4f496466382c0ad71dfedba) python312Packages.huggingface-hub: 0.24.2 -> 0.24.3
* [`e45bce4e`](https://github.com/NixOS/nixpkgs/commit/e45bce4ecf9f8df8a51ab6b9d35b6df8d2537e86) python312Packages.html-table-parser-python3: init at 0.3.1
* [`c451d9d0`](https://github.com/NixOS/nixpkgs/commit/c451d9d0312774abf03b3c548dc0c2f25f558d1e) python312Packages.bthomehub5-devicelist: init at 0.1.1
* [`d84b852b`](https://github.com/NixOS/nixpkgs/commit/d84b852b66b32b039b44913f9393e097cfd40278) home-assistant: support bt_home_hub_5 component
* [`a16ce157`](https://github.com/NixOS/nixpkgs/commit/a16ce1577e3577b63559106e8ee26cab0d28a935) python312Packages.py-ccm15: init at 0.0.9
* [`ca6ede4a`](https://github.com/NixOS/nixpkgs/commit/ca6ede4a1d8cd365892960c4025c126be90a5a6c) home-assistant: support ccm15 component
* [`ef5b5ade`](https://github.com/NixOS/nixpkgs/commit/ef5b5adea63f4664c58c3b9bc9c3f61c51b8072f) aerc: 0.18.1 -> 0.18.2
* [`2b430b6f`](https://github.com/NixOS/nixpkgs/commit/2b430b6f10da043bf4297a302c90a61a2bf8630a) xevd: Fix Darwin build
* [`d95b9673`](https://github.com/NixOS/nixpkgs/commit/d95b9673ca7e89fdd164df9f2d50e97e199fdc08) xeve: Fix Darwin build
* [`56102498`](https://github.com/NixOS/nixpkgs/commit/56102498bee171e05266cd4f0fe11bc9db25c12b) aerc: remove excess quotes
* [`61795c13`](https://github.com/NixOS/nixpkgs/commit/61795c13ba98ec73709f4ba7c328696fc63cbe94) python312Packages.aioaseko: 0.1.1 -> 0.2.0
* [`55569648`](https://github.com/NixOS/nixpkgs/commit/555696489e8636a15bde964aa0af93fa1ae3ae27) mdbook-alerts: 0.6.0 -> 0.6.1
* [`4632cd07`](https://github.com/NixOS/nixpkgs/commit/4632cd070318b9a7f5ecb471c93e038995349036) python312Packages.hpp-fcl: 2.4.4 -> 2.4.5
* [`2f9c0490`](https://github.com/NixOS/nixpkgs/commit/2f9c0490358da478f2473f39adc9320e51d5bb83) python312Packages.xmlschema: 3.3.1 -> 3.3.2
* [`3cb5f362`](https://github.com/NixOS/nixpkgs/commit/3cb5f3621495ab8afa44f292c9326b97b27bc349) fastcdr: 2.2.2 -> 2.2.3
* [`4a2ff2df`](https://github.com/NixOS/nixpkgs/commit/4a2ff2df010d193b7343dc2e68ce306ed89d9455) natscli: 0.1.4 -> 0.1.5
* [`584ab07a`](https://github.com/NixOS/nixpkgs/commit/584ab07a6d1d8267119b1c8d952573c0ee1565f6) yaydl: 0.14.0 -> 0.14.1
* [`fd254308`](https://github.com/NixOS/nixpkgs/commit/fd2543085353878cc8731c0f285519177bc5ebb9) rustypaste: 0.15.0 -> 0.15.1
* [`02c7a60e`](https://github.com/NixOS/nixpkgs/commit/02c7a60eab5c409e825f6b961be72f502f1beb18) trurl: 0.13 -> 0.14
* [`88e47678`](https://github.com/NixOS/nixpkgs/commit/88e47678ee524b41acde9e9f2722139beab73787) polypane: 20.0.0 -> 20.1.1
* [`7a6fd8a1`](https://github.com/NixOS/nixpkgs/commit/7a6fd8a116fc48a81b120820dab96032667f72dc) xmake: 2.9.3 -> 2.9.4
* [`5895b342`](https://github.com/NixOS/nixpkgs/commit/5895b342d5d6c052de7b5715553f11c0a57684b2) operator-sdk: 1.35.0 -> 1.36.0
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
