### PR TITLE
niv nixpkgs: update 42015a12 -> bc449339

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "42015a129a2ae1cd43a44490e8235d2b24c8a2e2",
-        "sha256": "03vyfa73w3f6np58xiaan9337m5fj4h9rd7xfmvjmyaa2qcff45g",
+        "rev": "bc4493390ffec8b4e023dc8874ef103ed854e4e0",
+        "sha256": "0svw4lj789s8b2kg9pfh6qsf8x63hkbslskslyqmnspjzn5ammnk",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/42015a129a2ae1cd43a44490e8235d2b24c8a2e2.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/bc4493390ffec8b4e023dc8874ef103ed854e4e0.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@42015a12...bc449339](https://github.com/nixos/nixpkgs/compare/42015a129a2ae1cd43a44490e8235d2b24c8a2e2...bc4493390ffec8b4e023dc8874ef103ed854e4e0)

* [`69537e6a`](https://github.com/NixOS/nixpkgs/commit/69537e6aa64a03d027a5e98247e9df7b2f6db4c0) libssh2: add some key reverse-dependencies to passthru.tests
* [`e6dc0fb1`](https://github.com/NixOS/nixpkgs/commit/e6dc0fb1a1e4d191fd7f663cb1cbf93fa7f43609) rustPlatform.importCargoLock: Adding sparse protocol
* [`804bc033`](https://github.com/NixOS/nixpkgs/commit/804bc033a6d4736dabd996e1168c3630e77e83c7) nixos/btrfs: refactor global `with lib;`
* [`d0239a1e`](https://github.com/NixOS/nixpkgs/commit/d0239a1e50a4aac0a768fe226eb4cc0acbd540d6) nixos/btrfs: improve default selection of filesystems for `autoScrub`
* [`392a10f5`](https://github.com/NixOS/nixpkgs/commit/392a10f528c6ad36f94c57daed558dd99cb72df9) shellclear: set buildAndTestSubdir
* [`814c2095`](https://github.com/NixOS/nixpkgs/commit/814c20956308e52b446c80c3e282c2f325b7066c) tokio-console: set buildAndTestSubdir
* [`dc9f57c2`](https://github.com/NixOS/nixpkgs/commit/dc9f57c229809c2c1ed8abe004935693a644101e) llm-ls: set buildAndTestSubdir
* [`4392e5a5`](https://github.com/NixOS/nixpkgs/commit/4392e5a53cba868164811553e63a9fd30ec656b7) overrideSDK: handle propagated lists of inputs
* [`fc97c1c9`](https://github.com/NixOS/nixpkgs/commit/fc97c1c9d7f9e206079ac70ae67bc6a1df43870f) ntp: 4.2.8p17 -> 4.2.8p18
* [`93550574`](https://github.com/NixOS/nixpkgs/commit/9355057472638b6269edc72dac967756ff22bdb5) syncall: mark as broken
* [`fc0fdbe8`](https://github.com/NixOS/nixpkgs/commit/fc0fdbe85ed4b70f56fd5d81bc6769e034fce779) nixos/gitlab-runner: allow access to podman socket
* [`9c4622d0`](https://github.com/NixOS/nixpkgs/commit/9c4622d0738ae30829d4a23419833795f1276ae8) maintainers: add eriedaberrie
* [`0a753aeb`](https://github.com/NixOS/nixpkgs/commit/0a753aebc93ef87fce3574b7849750efd69a428b) haskell-modules/generic-builder.nix: use runCommand instead of phases
* [`69a367c4`](https://github.com/NixOS/nixpkgs/commit/69a367c4ab96d8c4491d0fa715ff94013db9889c) python3Packages.scrapy-deltafetch: update dependencies and cleanup
* [`19e49c4b`](https://github.com/NixOS/nixpkgs/commit/19e49c4b866eda859e44a4424def479885d6b4f7) python3Packages.flask-cors: add key reverse-dependencies to passthru.tests
* [`b15945b4`](https://github.com/NixOS/nixpkgs/commit/b15945b43c05deaf013aa088393d727684cac003) tplay: fix runtime ffprobe dependency
* [`64575c36`](https://github.com/NixOS/nixpkgs/commit/64575c36c1822e8791f4807abcfdd82fb4c54cf2) maintainers: add rixxc
* [`c6c5e5cd`](https://github.com/NixOS/nixpkgs/commit/c6c5e5cd67bf448c7cb70777ba6f18302f8f75fd) oqs-provider: init at 0.6.1
* [`98100c75`](https://github.com/NixOS/nixpkgs/commit/98100c759ad7174c9df990f45dac1581a0632c5f) python312Packages.localstack: fix build
* [`ec2ae3e0`](https://github.com/NixOS/nixpkgs/commit/ec2ae3e0df54e20303276bd1a5bbccc9a55dd3f9) nixos/firefox: add missing language packs
* [`def1da0b`](https://github.com/NixOS/nixpkgs/commit/def1da0b7f305d2afa7e9b9074c7c5c8bb068861) hareThirdParty.hare-ev: 0-unstable-2024-07-07 -> 0-unstable-2024-07-11
* [`c5c92fef`](https://github.com/NixOS/nixpkgs/commit/c5c92feff79f44c85b4ed00cbc6a3e1e84840d5e) nixos/oci-containers: document firewall bypass
* [`ad7e8826`](https://github.com/NixOS/nixpkgs/commit/ad7e8826530703b47cd679a0886bc5d675dc57e1) helm-docs: 1.13.1 -> 1.14.2
* [`7ede72fd`](https://github.com/NixOS/nixpkgs/commit/7ede72fd0b1655ab7f3f239357788677e389a25a) centrifugo: 5.4.1 -> 5.4.2
* [`1af9acb5`](https://github.com/NixOS/nixpkgs/commit/1af9acb57f4c4a1d3e30c6d63855059f81563196) jdk22: 22.0.1-ga -> 22.0.2-ga
* [`b8997471`](https://github.com/NixOS/nixpkgs/commit/b899747113ae8463e4235d47338a456ca8c24e06) colloid-icon-theme: new scheme variants
* [`782e8513`](https://github.com/NixOS/nixpkgs/commit/782e8513d3c9dffcfecd09165255a5487e2ddc5f) nixos/cloudflare-dyndns: introduce package option
* [`588188fe`](https://github.com/NixOS/nixpkgs/commit/588188fefce51faebe15aec1b37c68d976e067d0) renode-unstable: 1.15.1+20240627git66a08265a -> 1.15.1+20240716gita55a3d050
* [`6c3304da`](https://github.com/NixOS/nixpkgs/commit/6c3304da83fd1f6d6633aef878ffc6429778459b) python312Packages.echo: 0.8.0 -> 0.9.0
* [`8e3cf7d9`](https://github.com/NixOS/nixpkgs/commit/8e3cf7d9b64938cca3bbc3e750dee7f8ca9e5893) snac2: 2.55 -> 2.56
* [`c7191262`](https://github.com/NixOS/nixpkgs/commit/c719126205096bf7d6d80b092945a80305315e65) kube-state-metrics: 2.12.0 -> 2.13.0
* [`19d042f2`](https://github.com/NixOS/nixpkgs/commit/19d042f29542b66106a5741b5fb5f74f0261919e) jazzy: 0.13.5 -> 0.15.1
* [`1ff77ae5`](https://github.com/NixOS/nixpkgs/commit/1ff77ae5ac102ca6d301c2be69f6168ce6eb7b0e) proto: 0.38.0 -> 0.38.3
* [`f236dfa8`](https://github.com/NixOS/nixpkgs/commit/f236dfa809494d389967e67ffc5a43dbf2a3b7a3) openpgp-ca: 0.13.1 -> 0.14.0
* [`6210c985`](https://github.com/NixOS/nixpkgs/commit/6210c985c3ef251502f0f995ecbf49291be55288) ghorg: 1.9.12 -> 1.9.13
* [`3939831d`](https://github.com/NixOS/nixpkgs/commit/3939831dad7645c330b409e961527a01c4732ff9) notesnook: 3.0.8 -> 3.0.11
* [`50a847ea`](https://github.com/NixOS/nixpkgs/commit/50a847ea04478eef0f9b353a925be5050f67b696) supermariowar: 2.0-unstable-2024-06-22 -> 2023-unstable-2024-07-16
* [`3892e83f`](https://github.com/NixOS/nixpkgs/commit/3892e83f95a61e3da7e264ad69c3795ec7a44b5f) pslib: 0.4.6 -> 0.4.8
* [`94e7afa7`](https://github.com/NixOS/nixpkgs/commit/94e7afa70acd17b173c4b71c6294399278b8ad36) syncyomi: init at 1.1.1
* [`79e55e32`](https://github.com/NixOS/nixpkgs/commit/79e55e325b48e86635a295b9c75edb39ce0ef504) beluga: 1.1.1 -> 1.1.2
* [`3f3074d9`](https://github.com/NixOS/nixpkgs/commit/3f3074d93dc53cd590de78fe9097cf1d87da284b) gr-framework: 0.73.6 -> 0.73.7
* [`5b2975fb`](https://github.com/NixOS/nixpkgs/commit/5b2975fb48c4c2efc6bb71e1b509d058b3ebd1ec) home-assistant-custom-components.mass: enable tests
* [`860c9b60`](https://github.com/NixOS/nixpkgs/commit/860c9b608d4994c4ed33aab65f5b72d45f04fbad) python312Packages.pyindego: 3.2.1 -> 3.2.2
* [`721388ec`](https://github.com/NixOS/nixpkgs/commit/721388eccaf7d475e71b657401ffa67b4554ee0c) home-assistant-custom-components.indego: 5.7.2 -> 5.7.4
* [`e28178e6`](https://github.com/NixOS/nixpkgs/commit/e28178e6e33ebbcd0f2b56c6763eed4ca582fd13) aiac: 5.0.1 -> 5.2.1
* [`92889dbc`](https://github.com/NixOS/nixpkgs/commit/92889dbc2fadcac1e929a1362915bb888ed7a8c5) heroku: 8.11.5 -> 9.0.0
* [`65949484`](https://github.com/NixOS/nixpkgs/commit/65949484a264817c454ac9996bd7b93364ae072f) asterisk: 20.8.1 -> 20.9.0
* [`d5dcf82d`](https://github.com/NixOS/nixpkgs/commit/d5dcf82d19a5598c40fb874a25153dbd3f234dc3) seafile-shared: 9.0.6 -> 9.0.7
* [`087a46f1`](https://github.com/NixOS/nixpkgs/commit/087a46f14faba47ac0032fdd96d1b46a11210a57) seafile-client: 9.0.6 -> 9.0.7
* [`0a398a90`](https://github.com/NixOS/nixpkgs/commit/0a398a909050e46631426f7feed4cb95dffe84d6) praat: 6.4.13 -> 6.4.14
* [`c032450a`](https://github.com/NixOS/nixpkgs/commit/c032450a0ce9ef63601cf360e72c679b65adf871) cirrus-cli: 0.120.3 -> 0.121.0
* [`67e62119`](https://github.com/NixOS/nixpkgs/commit/67e62119072682e85be0efc0b050930d38b2815e) caf: 1.0.0 -> 1.0.1
* [`ff60f2ca`](https://github.com/NixOS/nixpkgs/commit/ff60f2ca07e5007933e1bf2921520d2d76d607c0) maintainers: add Mange.
* [`ed308b0d`](https://github.com/NixOS/nixpkgs/commit/ed308b0d06429761119a78d19a4b719147bb8844) ocamlPackages.ringo: 1.0.0 -> 1.1.0
* [`1432699c`](https://github.com/NixOS/nixpkgs/commit/1432699caab578b84d2d6b9b508a9bc7bc76b798) ut: 2.0.1 -> 2.1.0
* [`9d67a1f6`](https://github.com/NixOS/nixpkgs/commit/9d67a1f61e06fe425e9ab8d23c0dc43838d5eb72) rofi-emoji: Split into v4 and v3 versions
* [`7739b0cb`](https://github.com/NixOS/nixpkgs/commit/7739b0cb1e866ca66803be11053a4cb9c004498d) linuxkit: 1.3.0 -> 1.4.0
* [`000336e4`](https://github.com/NixOS/nixpkgs/commit/000336e4b7929475e1bb140c82e198b99f2fdf38) umpire: 2024.02.1 -> 2024.07.0
* [`679d037e`](https://github.com/NixOS/nixpkgs/commit/679d037ea7673b747ea466aeb1026a9d56d90fad) busybox: fix building with llvm
* [`0fbbce44`](https://github.com/NixOS/nixpkgs/commit/0fbbce440f5fb67442b28a6d70f0374d32f4d905) maintainers: add CnTeng
* [`90addb6b`](https://github.com/NixOS/nixpkgs/commit/90addb6b7f0bf0c25ddf0d73fe24fdd2b9dbca84) mysql-shell-innovation: 9.0.0 -> 9.0.1
* [`8383d1dd`](https://github.com/NixOS/nixpkgs/commit/8383d1dddd33f078c7156459f83bca46a1999279) kitex: 0.10.1 -> 0.10.2
* [`3dc43c38`](https://github.com/NixOS/nixpkgs/commit/3dc43c3821d1410d6431981c40282c7af9dc906f) python312Packages.neuronpy: 8.2.4 -> 8.2.6
* [`e05ca1fd`](https://github.com/NixOS/nixpkgs/commit/e05ca1fd73ba29e787dc893fa28667953bb68387) kulala-fmt: init at 1.1.0
* [`96742945`](https://github.com/NixOS/nixpkgs/commit/96742945ce538502447064a62d0b1689d62b5c52) looking-glass-client: switch to finalAttrs
* [`37af97ea`](https://github.com/NixOS/nixpkgs/commit/37af97ea73d30fe38b3a17126cd7f2d7de83860d) libfakekey: 0.1 -> 0.3
* [`43696936`](https://github.com/NixOS/nixpkgs/commit/43696936e0254a88c87512218b7173405f96cf88) libfakekey: format to nixfmt-rfc-style
* [`5786c01e`](https://github.com/NixOS/nixpkgs/commit/5786c01e945b454c3a14088ec2927e4d2daf389b) prqlc: 0.12.2 -> 0.13.0
* [`e632d193`](https://github.com/NixOS/nixpkgs/commit/e632d1937bc3119e2d52525734fab6cb1ffc6010) liblscp: 0.9.4 -> 1.0.0
* [`3080daa5`](https://github.com/NixOS/nixpkgs/commit/3080daa5562c9bff274086eeb416a35039dffa32) kor: 0.5.2 -> 0.5.3
* [`5c71c9d6`](https://github.com/NixOS/nixpkgs/commit/5c71c9d6b920b7c446f79b22afabc1d20a0816ca) reuse: install man page and docs
* [`1c9d7a12`](https://github.com/NixOS/nixpkgs/commit/1c9d7a12dc700779746d30b3965f5884a61e00ee) unifi8: 8.2.93 -> 8.3.32
* [`181c0c1c`](https://github.com/NixOS/nixpkgs/commit/181c0c1cef231de02f6236686af25937def10b8e) ombi: 4.43.5 -> 4.44.1
* [`849eb6fe`](https://github.com/NixOS/nixpkgs/commit/849eb6fe97e50d397c931c3e02976535035e539a) beeper: 3.107.2 -> 3.108.3
* [`9694e917`](https://github.com/NixOS/nixpkgs/commit/9694e917b9a9102bd8a92ea0de174aa5bbf1a410) cobang: build with Python 3.11
* [`39e1b97d`](https://github.com/NixOS/nixpkgs/commit/39e1b97d33c7a1fd76850ab6767783828e4a1ac7) powershell: 7.4.3 -> 7.4.4
* [`88a40d78`](https://github.com/NixOS/nixpkgs/commit/88a40d78309f19e18354b3f988b7fab309a60c7a) graphite2: fix compiling with llvm
* [`05113f61`](https://github.com/NixOS/nixpkgs/commit/05113f61f031f04d404a4f6d982c75b1ab1c64ae) nixos/stirling-pdf: init module
* [`3ca692c5`](https://github.com/NixOS/nixpkgs/commit/3ca692c54468825f32d031d076cdf4bd4cf7aa5a) xorg.libXt: fix cpp usage under llvm
* [`87ba2715`](https://github.com/NixOS/nixpkgs/commit/87ba2715acfb753a84c17546166a6fceb4db9554) deno: 1.45.2 -> 1.45.4
* [`b7009522`](https://github.com/NixOS/nixpkgs/commit/b7009522ed5af5dcb7b4e298543b9744de4528b1) maintainers: add oleina
* [`e4da18a6`](https://github.com/NixOS/nixpkgs/commit/e4da18a6923e3a332448d96fc03a78feff3b4492) kakoune: create a directory for bins that kakoune needs
* [`183218bf`](https://github.com/NixOS/nixpkgs/commit/183218bf50c37f7c5469cc31da1856df53f0d97f) pythonPackages.mako: disable test_future_import test under llvm
* [`68bbcef2`](https://github.com/NixOS/nixpkgs/commit/68bbcef275d61cf7ea7eee6375ba0b3fab8557cc) libplctag: 2.6.0 -> 2.6.1
* [`38653c5b`](https://github.com/NixOS/nixpkgs/commit/38653c5be27143fcff1dd7297b63269121c0fd6e) eg25-manager: init at 0.4.6
* [`a61d4728`](https://github.com/NixOS/nixpkgs/commit/a61d4728e8903284688909db392b53a0d75b27ab) nixos/eg25-manager: init
* [`28da83bb`](https://github.com/NixOS/nixpkgs/commit/28da83bb52c46cd661f3b0d4e6e4afb0968955f6) maintainers: add bwkam
* [`e640bd83`](https://github.com/NixOS/nixpkgs/commit/e640bd83b7b8a00e380169726c168279f6af7b1c) python311Packages.pwinput: init at 1.3.0
* [`fa466bad`](https://github.com/NixOS/nixpkgs/commit/fa466badd86e776cbd8e042d85cbfeeccf7e8869) zotify: init at 0.6.13
* [`ac10b9b2`](https://github.com/NixOS/nixpkgs/commit/ac10b9b20cb97c4b0af0ce24dc9ae16bc5dac23d) silverbullet: 0.8.2 -> 0.8.4
* [`1f88956b`](https://github.com/NixOS/nixpkgs/commit/1f88956b959196af4de00276153fe6a88fba72bf) nixos/kmscon: fix cfgfile missing trailing newline
* [`1bfc7052`](https://github.com/NixOS/nixpkgs/commit/1bfc705287d5b9bf65a07c4a7b46ff75217efd13) hyprland-per-window-layout: 2.11 -> 2.12
* [`aea44d2f`](https://github.com/NixOS/nixpkgs/commit/aea44d2f19311078531268063ba559e578c94e5e) canon-cups-ufr2: 5.70 -> 5.90
* [`f2134034`](https://github.com/NixOS/nixpkgs/commit/f2134034408cbd2c7dfda87881d1c1f2e7f33796) rofi-bluetooth: add bc to binPath
* [`5d1917eb`](https://github.com/NixOS/nixpkgs/commit/5d1917eb29e6a17e23d472c8efd931b8153e8d8a) hcloud: 1.44.2 -> 1.46.0
* [`cb71a751`](https://github.com/NixOS/nixpkgs/commit/cb71a7512a4f7687b6b9cb7f4d2f684ed845071d) obs-studio-plugins.obs-vertical-canvas: 1.4.5 -> 1.4.7
* [`e193983e`](https://github.com/NixOS/nixpkgs/commit/e193983e08a32be793bde5bfd4a5b99a8ae57161) nats-server: 2.10.17 -> 2.10.18
* [`5140316b`](https://github.com/NixOS/nixpkgs/commit/5140316b10b51ee75ff9321dad8feccb68de4c1f) octavePackages.fuzzy-logic-toolkit: 0.4.6 -> 0.6.0
* [`ae580cbe`](https://github.com/NixOS/nixpkgs/commit/ae580cbeb5876bdaf059261291fc64c1e8976060) eigenlayer: 0.8.2 -> 0.9.2
* [`53e8bc05`](https://github.com/NixOS/nixpkgs/commit/53e8bc05bf18d315f1f91b9cf2cebbeff5727571) supabase-cli: 1.187.2 -> 1.187.8
* [`7308c0da`](https://github.com/NixOS/nixpkgs/commit/7308c0da1ff125d7be2b1956b41c890fae80efc1) protonup-qt: 2.9.2 -> 2.10.2
* [`7bc9b3b5`](https://github.com/NixOS/nixpkgs/commit/7bc9b3b5040e03eaa70080c42f1795fbc0483781) plandex: init at 1.1.1
* [`081d6924`](https://github.com/NixOS/nixpkgs/commit/081d6924b1b3c91942e73d531eea5852cd8c6bb3) plandex-server: init at 1.1.1
* [`f6ab8464`](https://github.com/NixOS/nixpkgs/commit/f6ab84649e027ae042a2d836feaf005cea083d03) simple-dftd3: 1.0.0 -> 1.1.0
* [`9c0712b0`](https://github.com/NixOS/nixpkgs/commit/9c0712b0805de202697980b8afc0062e8387aa09) openutau: 0.1.327 -> 0.1.529
* [`8690f872`](https://github.com/NixOS/nixpkgs/commit/8690f8722d23a388d96c15fe6d76472d9a954db2) awscli2: 2.17.13 -> 2.17.18
* [`7347ab16`](https://github.com/NixOS/nixpkgs/commit/7347ab1697705fac2a8e67c9f58e8dd1fe3da62d) handheld-daemon: 3.2.1 -> 3.3.3
* [`87b7b173`](https://github.com/NixOS/nixpkgs/commit/87b7b17351a65527520a5451575b32a7e327b237) tellico: 3.5.3 -> 3.5.5
* [`bc0f0921`](https://github.com/NixOS/nixpkgs/commit/bc0f09212c8c9f067a66c7e16a94beae1cb9d2ba) python312Packages.lib4sbom: 0.7.1 -> 0.7.2
* [`e7182ec6`](https://github.com/NixOS/nixpkgs/commit/e7182ec60cfd0dbca8f6c78d4f10d7cfbed01db6) cve-bin-tool: fix dependencies
* [`c4b2816e`](https://github.com/NixOS/nixpkgs/commit/c4b2816ead7d64be922a2418638a9fef35f9f2a2) cve-bin-tool: format with `nixfmt-rfc-style`
* [`0b29d629`](https://github.com/NixOS/nixpkgs/commit/0b29d6297692145fe5e8e7232c9e54ba0b167e44) nuclear: move to by-name
* [`31ab3c25`](https://github.com/NixOS/nixpkgs/commit/31ab3c256482bf26015bdb7755a109b8a513d069) nuclear; nixfmt; modernize derivation
* [`fec2cc37`](https://github.com/NixOS/nixpkgs/commit/fec2cc372738796daf9ccc3e2ce9acc06c2fefd4) maintainer-list: add pinage404
* [`69eeceba`](https://github.com/NixOS/nixpkgs/commit/69eecebabf5bdcade02774934892e363261af2ab) nuclear: 0.6.30 -> 0.6.31
* [`8d0814b1`](https://github.com/NixOS/nixpkgs/commit/8d0814b1102a36201ba36b349ad1a82600a7116b) masklint: init at 0.3.0
* [`a4eb4b0a`](https://github.com/NixOS/nixpkgs/commit/a4eb4b0a62df92e4845c6256d61023966c0802a0) bino3d: remove LTO workaround
* [`15fd5fb7`](https://github.com/NixOS/nixpkgs/commit/15fd5fb7e94dabe9335b50fa7e353352bfd0dbec) hiredis: fix cross compilation
* [`ca86dd2d`](https://github.com/NixOS/nixpkgs/commit/ca86dd2db2404dd570c56a91f3fb50dba089b920) glasskube: 0.13.0 -> 0.14.0
* [`1d4821cd`](https://github.com/NixOS/nixpkgs/commit/1d4821cd659b72a58e094d3040835f0dff6ce273) kakounePlugins.hop-kak: init at 0.2.0
* [`3a58ef57`](https://github.com/NixOS/nixpkgs/commit/3a58ef5743d1e418d851e15c9b05aa5222a48a5f) opencc: 1.1.7 -> 1.1.8
* [`dcaa4a1c`](https://github.com/NixOS/nixpkgs/commit/dcaa4a1cede5d72642f543db874307f6d2afadff) virtualbox: 7.0.18 -> 7.0.20
* [`1b89337d`](https://github.com/NixOS/nixpkgs/commit/1b89337dab565c79eba966512a2c8dafc98e1197) python312Packages.single-source: 0.3.0 -> 0.4.0
* [`a96197f9`](https://github.com/NixOS/nixpkgs/commit/a96197f98ee1bc035476164fcfef536f5f1be852) python312Packages.single-source: add nickcao to maintainers
* [`623e8888`](https://github.com/NixOS/nixpkgs/commit/623e8888013d774958bd643f4730e99b47858516) tell-me-your-secrets: modernize
* [`89be977c`](https://github.com/NixOS/nixpkgs/commit/89be977c5836405727e5219324cfb410ff4b5f55) dbcsr: 2.6.0 -> 2.7.0
* [`5d705a6a`](https://github.com/NixOS/nixpkgs/commit/5d705a6a3bc2489d830c420b64e130c28eedd062) python312Packages.textx: 3.0.0 -> 4.0.1
* [`5acc1027`](https://github.com/NixOS/nixpkgs/commit/5acc10275598559799669413c28f8c04353f8035) strictdoc: relax dep for textx
* [`66a70052`](https://github.com/NixOS/nixpkgs/commit/66a700525cf5c6bdc35f5266273733adec4f1c0c) kubectl-cnpg: 1.23.2 -> 1.23.3
* [`25fe9c17`](https://github.com/NixOS/nixpkgs/commit/25fe9c17b87309946761ef52b68670801a141ae1) zsh-abbr: 5.8.0 -> 5.8.2
* [`2f9ad760`](https://github.com/NixOS/nixpkgs/commit/2f9ad760d2e5c4ebd6b4924de897b6bd8f3c95ae) mill: 0.11.9 -> 0.11.10
* [`62bfaf2f`](https://github.com/NixOS/nixpkgs/commit/62bfaf2f8f9906d645c05172b4ffd71e888010fc) python3Packages.nuclear: 2.2.5 -> 2.3.1
* [`e9a3870a`](https://github.com/NixOS/nixpkgs/commit/e9a3870a3b7d7f7394ff5a0d8cc84ec443f2bc6b) python3Packages.wat: 0.1.2 -> 0.3.0
* [`b1352ca7`](https://github.com/NixOS/nixpkgs/commit/b1352ca7d7d38b95287c164e0d12f04745e98e19) polkadot: 1.14.0 -> stable2407
* [`49296452`](https://github.com/NixOS/nixpkgs/commit/4929645269e44a62651ca9470a6b45f0e990ad23) k3d: 5.6.0 -> 5.7.2
* [`453bb3cd`](https://github.com/NixOS/nixpkgs/commit/453bb3cdb940fb1e1408a229f488d35ff2a7fc3f) aiken: init at 1.0.29-alpha
* [`66f63313`](https://github.com/NixOS/nixpkgs/commit/66f63313539b5955d9286da21b37e79f6b1ecc83) python312Packages.backports-strenum: 1.2.8 -> 1.3.1
* [`793e6d9a`](https://github.com/NixOS/nixpkgs/commit/793e6d9a1812c60b71d6ba38502bbd5a1ed747c0) box86: Fix updateScript
* [`eeacf85f`](https://github.com/NixOS/nixpkgs/commit/eeacf85fb9e459ccac88b56a9ec60157c3c15218) k3s: add airgap images to passthru attributes
* [`3ac99356`](https://github.com/NixOS/nixpkgs/commit/3ac993566c8287f51383a502dd6effd1814027f4) nixos/k3s: add test for airgap images import
* [`5af67404`](https://github.com/NixOS/nixpkgs/commit/5af67404149106f33d1c8486f091c909e5098cca) linux_xanmod: 6.6.42 -> 6.6.43
* [`f8766a07`](https://github.com/NixOS/nixpkgs/commit/f8766a076245f8af0a1297468900f9a5979eb29f) linux_xanmod_latest: 6.9.11 -> 6.9.12
* [`fdfaaae0`](https://github.com/NixOS/nixpkgs/commit/fdfaaae011a36b46bf192476805fc3e6464c5940) libdwarf-lite: init at 0.10.1
* [`03f1c7ee`](https://github.com/NixOS/nixpkgs/commit/03f1c7eefa59ad90a77e9e08aaec21e53b252d1c) naja: init at 0-unstable-2024-07-21
* [`b11f4692`](https://github.com/NixOS/nixpkgs/commit/b11f469249bbb656a5c9570943c0ef19f901a807) llvmPackages.clang: set CLANG_DEFAULT_CXX_STDLIB for pkgsLLVM
* [`a534cc07`](https://github.com/NixOS/nixpkgs/commit/a534cc07ffd2c369258f05b40341fcf98dccb765) waffle: 1.8.0 -> 1.8.1
* [`06d0e0e8`](https://github.com/NixOS/nixpkgs/commit/06d0e0e8a22a107b5aa1946c287d271a0043e964) gapless: 3.8 -> 3.8.1
* [`084f5223`](https://github.com/NixOS/nixpkgs/commit/084f5223b9b8a8d42701f71422a71077c8b818e8) volk: 2.5.0 -> 3.0.0 (for aarch64-darwin only); move to pkgs/by-name
* [`9964f0d0`](https://github.com/NixOS/nixpkgs/commit/9964f0d02d58d8f3bb95988cabe902faa0a45fd3) volk: 3.0.0 -> 3.1.2; cleanup
* [`61a18c55`](https://github.com/NixOS/nixpkgs/commit/61a18c5508bbe1802d3b8c64b2ad8ac2730d6b29) volk: nixfmt (rfc 166)
* [`d15b7226`](https://github.com/NixOS/nixpkgs/commit/d15b7226b3b1df0e6661bfeffbfa28ab5fcd6514) gnuradio3_9: try to fix build by disabling doxygen
* [`47fa6173`](https://github.com/NixOS/nixpkgs/commit/47fa6173fcd246d4dc2687943d88593b717d36dc) gnuradio3_9{,Minimal}: remove
* [`06823daf`](https://github.com/NixOS/nixpkgs/commit/06823daf53703a307b40dc96888d5e3d5e267702) gnuradio3_8Packages.ais: mark as broken on Darwin
* [`87e26eee`](https://github.com/NixOS/nixpkgs/commit/87e26eeed44595446f006d533a159bf2cdc64efc) volk_2: init at 2.5.0
* [`97f944d4`](https://github.com/NixOS/nixpkgs/commit/97f944d47368d9324e7e8093f06b2fc32f1dfffd) gnuradio3_8: fix build by using volk_2
* [`a77ec886`](https://github.com/NixOS/nixpkgs/commit/a77ec8862d37ca70d9cb3b1ecc8d4e64a89271e9) suscan: unstable-2022-07-05 -> 0.3.0
* [`bb01e59d`](https://github.com/NixOS/nixpkgs/commit/bb01e59debd15accb23229325202eec2e6615554) suscan: fix build by adding zlib
* [`cae1f154`](https://github.com/NixOS/nixpkgs/commit/cae1f154e597bfba4842ef687fd214601fdde6cd) gnuradio{,3_8}: use removeReferencesTo from nativeBuildInputs
* [`e05dc5df`](https://github.com/NixOS/nixpkgs/commit/e05dc5df3ab6c707f6c4534e03be22164a42ed91) cargo-swift: 0.7.1 -> 0.8.0
* [`d82d2c49`](https://github.com/NixOS/nixpkgs/commit/d82d2c4919af04dc8535baf6c7de973db958f1b8) otpclient: 3.7.0 -> 4.0.0
* [`66549815`](https://github.com/NixOS/nixpkgs/commit/6654981565213710fcb7626237de0bb8941e44b6) qxmpp: 1.7.1 -> 1.8.0
* [`42e1111a`](https://github.com/NixOS/nixpkgs/commit/42e1111aff039355d057af5d239a5fdade9bf14b) jaq: 1.5.1 -> 1.6.0
* [`a1d89d55`](https://github.com/NixOS/nixpkgs/commit/a1d89d55031f7d498a16b93866c0d97c97c3fd25) python3Packages.rtree: add geospatial team to maintainers
* [`019d0919`](https://github.com/NixOS/nixpkgs/commit/019d0919383f5b28f0339020bb85fb291000bf54) llvmPackages.clangUseLLVM: add --undefined-version by default
* [`ed47080c`](https://github.com/NixOS/nixpkgs/commit/ed47080c943a7ecfb2a3d08dcf6d322af8fa23fa) heh: 0.5.0 -> 0.6.0
* [`07471b39`](https://github.com/NixOS/nixpkgs/commit/07471b398d990ed3cdf594909e497f774907e0a6) gruvbox-plus-icons: 5.4.0 -> 5.5.0
* [`21ed61f0`](https://github.com/NixOS/nixpkgs/commit/21ed61f0afdc187f26ee73d880497d305cc088b7) raycast: 1.79.0 -> 1.80.0
* [`7f997e6a`](https://github.com/NixOS/nixpkgs/commit/7f997e6a8147174a51335118f3cc999f20fb0c97) python312Packages.http-ece: 1.2.0 -> 1.2.1
* [`0c54982f`](https://github.com/NixOS/nixpkgs/commit/0c54982fa16962b9687563c81c73c61e6162bbc4) python312Packages.http-ece: modernize
* [`f2416db5`](https://github.com/NixOS/nixpkgs/commit/f2416db518c85e46e1e5f0f5cfa38d45eb556b97) python3Packages.lm-format-enforcer: init at 0.10.4
* [`5377367b`](https://github.com/NixOS/nixpkgs/commit/5377367b0db675619f8fa806c94cfe2e2639e32d) python3Packages.pyairports: init at 2.1.1
* [`a96e5f0a`](https://github.com/NixOS/nixpkgs/commit/a96e5f0ae06f5fe61d9f2b211ca7087864d2ef29) python311Packages.vllm: 0.3.2->0.5.2
* [`dbed1775`](https://github.com/NixOS/nixpkgs/commit/dbed177528493a0b7fb29ed02d207ba5669ebe4d) nostui: init 0.1.0
* [`d40fd0fd`](https://github.com/NixOS/nixpkgs/commit/d40fd0fd8203bdd2142f953abfcf681e539787ff) python311Packages.vllm: reorder, filter, rename attrs as conventional
* [`4fb7cb4a`](https://github.com/NixOS/nixpkgs/commit/4fb7cb4a2e4e41c23433f9e51bdfdcad4fede189) python311Packages.vllm: postPatch -> patches
* [`cc473a33`](https://github.com/NixOS/nixpkgs/commit/cc473a33bb2c67f11cf3ccea5546d30bdd846429) python311Packages.vllm: export in preBuild -> env
* [`b9344b4e`](https://github.com/NixOS/nixpkgs/commit/b9344b4e5248770f9d3aa70fdde96a109adc3741) python312Packages.vllm: allow building for 3.12
* [`17a50f14`](https://github.com/NixOS/nixpkgs/commit/17a50f14daaf1ef506f1ef61c7f5bcbbb922c629) python312Packages.vllm: unbreak in vanilla nixpkgs (default to rocm)
* [`7df877ab`](https://github.com/NixOS/nixpkgs/commit/7df877abd75f038dfb2c8a596291c20031616a3c) esphome: 2024.7.2 -> 2024.7.3
* [`5927a45d`](https://github.com/NixOS/nixpkgs/commit/5927a45d817220224650cb042edcc573976c889f) platformio: 6.1.11 -> 6.1.15
* [`f76f48b6`](https://github.com/NixOS/nixpkgs/commit/f76f48b6e0bbf75a878b35d1fcf129e3b7bf84c5) valkey: 7.2.5 -> 7.2.6
* [`4f9ba477`](https://github.com/NixOS/nixpkgs/commit/4f9ba47795f876e60f2c829ae7c434ab2e3de48d) prometheus-consul-exporter: 0.12.0 -> 0.12.1
* [`d6664f53`](https://github.com/NixOS/nixpkgs/commit/d6664f5367e93ab00ed874166c8cbaac732ae2b3) nova: 3.9.0 -> 3.10.0
* [`21e8dda8`](https://github.com/NixOS/nixpkgs/commit/21e8dda86eec192dec4ca9694854bd697eaaf266) home-assistant-custom-components.frigate: 5.2.0 -> 5.3.0
* [`1a624644`](https://github.com/NixOS/nixpkgs/commit/1a624644879a4d73112cf5f8262842970bacf857) mssql_jdbc: 12.6.3 -> 12.8.0
* [`01b18115`](https://github.com/NixOS/nixpkgs/commit/01b1811560b514a29f28d8a1676eebe776ebffe0) datovka: 4.24.0 -> 4.24.1
* [`5a4e1dae`](https://github.com/NixOS/nixpkgs/commit/5a4e1dae67a1f901972c274e1fcf06558e19edc9) mongodb-compass: 1.43.4 -> 1.43.5
* [`33b73dee`](https://github.com/NixOS/nixpkgs/commit/33b73deeb256afa286a8447fcc7fc948ff78f63e) python312Packages.gradio: 4.36.1 -> 4.40.0
* [`e82f7f70`](https://github.com/NixOS/nixpkgs/commit/e82f7f703e72b3c18fde5e5a6a092aa0f6e364d1) python312Packages.gradio-client: 1.0.1 -> 1.2.0
* [`56123b37`](https://github.com/NixOS/nixpkgs/commit/56123b37a66159b02cbb5aadf22dfe65ea3d48f4) humioctl: 0.35.1 -> 0.36.0
* [`e4a4da87`](https://github.com/NixOS/nixpkgs/commit/e4a4da8794d0b3856b3cbe07feb90b57f8fac042) nixos/restic: ensure newline in --files-from
* [`5757a3c0`](https://github.com/NixOS/nixpkgs/commit/5757a3c0bb6b24e287b9285da104c87307c56c49) nginxModules.vod: 1.32 -> 1.33
* [`eeb13b18`](https://github.com/NixOS/nixpkgs/commit/eeb13b181f785d928c85384de94483453e3d0be9) grin: modernize
* [`22af46b5`](https://github.com/NixOS/nixpkgs/commit/22af46b51256a504531630d48425256374299911) grin: 1.3.0 -> 1.3.0-unstable-2023-08-30
* [`4094f03f`](https://github.com/NixOS/nixpkgs/commit/4094f03ffdaa27004b7e8a0b721d24ca028a9f8e) svtplay-dl: use `buildPythonApplication`
* [`0fa536d5`](https://github.com/NixOS/nixpkgs/commit/0fa536d5b27978048fd06e6547eea8f640c8d731) svtplay-dl: migrate to pytest
* [`7ef27e14`](https://github.com/NixOS/nixpkgs/commit/7ef27e1420a824f8ac259574fab58868df0eee20) python3Packages.pkutils: drop
* [`5db8f3da`](https://github.com/NixOS/nixpkgs/commit/5db8f3da5f1fde50eae7080a0593f31ebea69a9a) gixy: modernize
* [`6bd2c757`](https://github.com/NixOS/nixpkgs/commit/6bd2c7576ab97dffc4c0442c24efd7e40618c459) gixy: add pytest migration patch
* [`5111b7af`](https://github.com/NixOS/nixpkgs/commit/5111b7afd7a60d34c0fd475ed286de95e9bf6747) gixy: pass‐through nginx tests
* [`9b7e7d74`](https://github.com/NixOS/nixpkgs/commit/9b7e7d74161b4ed14bea376c1dc07c0aad0bca15) python3Packages.nose3: drop
* [`e0640d88`](https://github.com/NixOS/nixpkgs/commit/e0640d882b2ecec2f28b33b5ea259edc0051225a) gcsfuse: 2.3.2 -> 2.4.0
* [`0e5f46b7`](https://github.com/NixOS/nixpkgs/commit/0e5f46b7275f6a096fecdd74ff5b71c2d02f50db) boogie: 3.2.1 -> 3.2.3
* [`9d80e128`](https://github.com/NixOS/nixpkgs/commit/9d80e128f72afbb921e848f21c123801d406935e) python312Packages.fakeredis: 2.23.3 -> 2.23.4
* [`29c5b286`](https://github.com/NixOS/nixpkgs/commit/29c5b2860959ea200c8c3a40cbd4b8cede09fb36) murex: 6.2.3000 -> 6.2.4000
* [`57e6d796`](https://github.com/NixOS/nixpkgs/commit/57e6d796a2d1069ca9393500e6260546a7859e90) octavePackages.miscellaneous: 1.3.0 -> 1.3.1
* [`c882d9b6`](https://github.com/NixOS/nixpkgs/commit/c882d9b673e8d6eb6a29b0954519c72871b91e08) nixos/screego: init module
* [`29735f37`](https://github.com/NixOS/nixpkgs/commit/29735f370b72f137852cbf0ddf9f884a255a0917) srm-cuarzo: 0.6.3-1 -> 0.7.0-1
* [`53312369`](https://github.com/NixOS/nixpkgs/commit/53312369ef9cb57245c5a4c4bdce0f55742b4fc5) hadolint-sarif: 0.5.0 -> 0.6.0
* [`a2312ca7`](https://github.com/NixOS/nixpkgs/commit/a2312ca74f4e686328e79398046c444e8da31fb5) sarif-fmt: 0.5.0 -> 0.6.0
* [`14d701db`](https://github.com/NixOS/nixpkgs/commit/14d701db54781bb2aa8101f366b4621c9f0f75d9) clippy-sarif: 0.5.0 -> 0.6.0
* [`186d7806`](https://github.com/NixOS/nixpkgs/commit/186d7806a6cdb7d799d673d2e064037c79293450) shellcheck-sarif: 0.5.0 -> 0.6.0
* [`4c946aea`](https://github.com/NixOS/nixpkgs/commit/4c946aea09f079db6cee5f52d62ed39e702d61ae) python3Packages.sourmash: 4.8.4 -> 4.8.11
* [`273ed6d5`](https://github.com/NixOS/nixpkgs/commit/273ed6d57aad64c382b1edaab76ad78561bb3129) txtpbfmt: move to by-name
* [`11b4c29c`](https://github.com/NixOS/nixpkgs/commit/11b4c29cfa34ae83ab6743559bd38ca07b749f3d) ethercat: 1.6.0 -> 1.6.1
* [`fbb011af`](https://github.com/NixOS/nixpkgs/commit/fbb011af0f002087f4c8849db64b7989991f8547) deck: 1.39.3 -> 1.39.4
* [`f728dd56`](https://github.com/NixOS/nixpkgs/commit/f728dd56afcc6355e50238db7beacb1cd11adb9c) naja: Mark broken on Darwin, add temporary note about maintenance
* [`57d79f60`](https://github.com/NixOS/nixpkgs/commit/57d79f6095a820737c84a471e35799413b10a65e) quarto: 1.5.55 -> 1.5.56
* [`07dfa0de`](https://github.com/NixOS/nixpkgs/commit/07dfa0de033b914777a8279eeadbe2e1b8e80a23) dissent: 0.0.25 -> 0.0.26
* [`f2fb5aa2`](https://github.com/NixOS/nixpkgs/commit/f2fb5aa2e79f57f30c5825be8d1117bd1f36aa28) media-downloader: 4.8.0 -> 4.9.0
* [`82bae7f3`](https://github.com/NixOS/nixpkgs/commit/82bae7f3663b64de765c8d01381daace0d4f4c34) python312Packages.binwalk: 2.4.1 -> 2.4.2
* [`e7194085`](https://github.com/NixOS/nixpkgs/commit/e7194085b737f0b0ba557c5fd748c9cb24cb6d80) python3.bork: 8.0.0 → 9.0.0
* [`18b3cc81`](https://github.com/NixOS/nixpkgs/commit/18b3cc81db442d0dc92f77ca83013f652df49eff) python3.homf: init at 1.0.0
* [`bbf0c6fc`](https://github.com/NixOS/nixpkgs/commit/bbf0c6fcd1d08b85e158c8b862434b7992774e8e) silice: 0-unstable-2024-07-15 -> 0-unstable-2024-07-22
* [`9853cc66`](https://github.com/NixOS/nixpkgs/commit/9853cc66869a64bb5e1687861e09d687e80a6755) python312Packages.automx2: 2024.1 -> 2024.2
* [`6525c157`](https://github.com/NixOS/nixpkgs/commit/6525c157c1286c6eab9e74108ea1c262cbd9c051) atac: 0.15.1 -> 0.16.0
* [`4da61526`](https://github.com/NixOS/nixpkgs/commit/4da61526d9e45866701c97ef2656494f5d3a746a) yt-dlp: 2024.7.25 -> 2024.8.1
* [`5be99f30`](https://github.com/NixOS/nixpkgs/commit/5be99f30e97e5e8c3a76f67b458404dc1b7d07ca) audacity: unpin FFmpeg 6
* [`ea32b785`](https://github.com/NixOS/nixpkgs/commit/ea32b7855329db2348ca5e31ff67697873dba4e3) aardvark-dns: 1.11.0 -> 1.12.0
* [`812a66db`](https://github.com/NixOS/nixpkgs/commit/812a66dbd67455c83db78fb76fb439a01669ee26) libjson-rpc-cpp: 1.3.0 -> 1.4.1
* [`2775b81e`](https://github.com/NixOS/nixpkgs/commit/2775b81e4e3155a41cc014e064ffb8c883e17467) superfile: 1.1.3 -> 1.1.4
* [`4b074638`](https://github.com/NixOS/nixpkgs/commit/4b0746388bffded10c132a04388ce02356a054f6) superfile: add redyf as maintainer
* [`6ae6635e`](https://github.com/NixOS/nixpkgs/commit/6ae6635e54f64b20c3ba6ce4ddd7a941156a4cdb) zed-editor: 0.146.3 -> 0.146.4
* [`1cd7d129`](https://github.com/NixOS/nixpkgs/commit/1cd7d129abbbeff8d9d6c3024f506c4b5a330bbe) python312Packages.aioymaps: 1.2.4 -> 1.2.5
* [`ac184d1a`](https://github.com/NixOS/nixpkgs/commit/ac184d1a52a6fb04b2a485447cc63131ac110f83) mysql80: 8.0.38 -> 8.0.39
* [`6917964f`](https://github.com/NixOS/nixpkgs/commit/6917964f10b7dfba375e73a9e61c96b70ec6ea91) tfupdate: 0.8.2 -> 0.8.4
* [`25d11dfb`](https://github.com/NixOS/nixpkgs/commit/25d11dfb27b1f2f24f6b87e12d68f0a9e2fe7205) python312Packages.sse-starlette: 2.1.2 -> 2.1.3
* [`fc7a83f8`](https://github.com/NixOS/nixpkgs/commit/fc7a83f8b62e90de5679e993d4d49ca014ea013d) step-cli: format package.nix with nixfmt
* [`ab8e7df7`](https://github.com/NixOS/nixpkgs/commit/ab8e7df7502fede509280324e98f5e3b8c26a9a1) s3ql: 5.1.3 -> 5.2.1
* [`be556244`](https://github.com/NixOS/nixpkgs/commit/be556244a4d8e7719fc1c9a4baa455061abf0a1d) iosevka: 30.3.3 -> 31.0.0
* [`d30e4a2f`](https://github.com/NixOS/nixpkgs/commit/d30e4a2f5907c665fcf4c906584122e1bbb24d32) attract-mode: move to `pkgs/by-name`
* [`7b2c57a0`](https://github.com/NixOS/nixpkgs/commit/7b2c57a072daa15fa658b43d7799acefdd95a30a) attract-mode: format with `nixfmt-rfc-style`
* [`1c8f82e0`](https://github.com/NixOS/nixpkgs/commit/1c8f82e0b3aa565f0adb723eb9dcfd058dc774ba) simdjson: 3.9.5 -> 3.10.0
* [`2f3e77e1`](https://github.com/NixOS/nixpkgs/commit/2f3e77e1f28336e8446168d521e20aeded6b98fe) kakoune: add philiptaron as maintainer to most kakoune-related things
* [`fae007be`](https://github.com/NixOS/nixpkgs/commit/fae007be061dce15b771ee61174b229055438519) steampipePackages.steampipe-plugin-aws: 0.138.0 -> 0.144.0
* [`3ab88dc2`](https://github.com/NixOS/nixpkgs/commit/3ab88dc28b6fd7a5851057f122aaedab27d140a4) pmacct: 1.7.8 -> 1.7.9
* [`2d44e42d`](https://github.com/NixOS/nixpkgs/commit/2d44e42d984fa31fd1fea99fc88833a68a63cd2d) steampipePackages.steampipe-plugin-github: 0.41.0 -> 0.42.0
* [`5e1a7105`](https://github.com/NixOS/nixpkgs/commit/5e1a7105f53fe14eeeb983ec85928691b164cf2d) laurel: 0.6.2 -> 0.6.3
* [`b93ae5ca`](https://github.com/NixOS/nixpkgs/commit/b93ae5ca502e62d26ced54d42717ee4d5496d9a7) ctlptl: 0.8.29 -> 0.8.30
* [`00a6ef35`](https://github.com/NixOS/nixpkgs/commit/00a6ef358ae4a46735955626cd7a707ab82be707) txtpbfmt: 0-unstable-2024-04-16 -> 0-unstable-2024-06-11
* [`be324846`](https://github.com/NixOS/nixpkgs/commit/be32484672e66f8356daea9806b08923c78ae649) oxker: 0.6.4 -> 0.7.0
* [`bbb9f070`](https://github.com/NixOS/nixpkgs/commit/bbb9f070f6493e939ce2ed501fb32c448a683829) gotify-cli: 2.2.4 -> 2.3.2
* [`d0d88e73`](https://github.com/NixOS/nixpkgs/commit/d0d88e7376df237ac89b9a43293fcbb9cf19d263) spire: 1.10.0 -> 1.10.1
* [`73cf5e40`](https://github.com/NixOS/nixpkgs/commit/73cf5e4073bb95a4016123b960dcd2a0bc17dafc) cri-o-unwrapped: 1.30.3 -> 1.30.4
* [`dd3d68af`](https://github.com/NixOS/nixpkgs/commit/dd3d68af7c97d8ee42d18c4e4cf579d687ccf74e) python312Packages.asteval: 1.0.1 -> 1.0.2
* [`dc696e80`](https://github.com/NixOS/nixpkgs/commit/dc696e8084dbd13b915357ff51920253927cfc3c) brave: 1.67.134 -> 1.68.134
* [`bba5e3f4`](https://github.com/NixOS/nixpkgs/commit/bba5e3f4e0cb6937a214fbf8f1fd0b1ec4d136f1) python312Packages.rioxarray: extend disabled failing tests to aarch64-darwin
* [`cdc9919a`](https://github.com/NixOS/nixpkgs/commit/cdc9919a562332b5b9b9ae8679822e72b599b233) nixosTests.bittorrent: avoid use of an alias
* [`08aff56c`](https://github.com/NixOS/nixpkgs/commit/08aff56c8004a09e378121f875d59ca621fa7017) libretro.play: unstable-2024-07-19 -> unstable-2024-07-29
* [`5a914acc`](https://github.com/NixOS/nixpkgs/commit/5a914acca69348ea06e87e94a717761763e75201) python311Packages.torhchrl: skip failing test
* [`71c908fd`](https://github.com/NixOS/nixpkgs/commit/71c908fdddcb697172019a18be2f5156f111bd49) libretro.snes9x: unstable-2024-07-14 -> unstable-2024-07-29
* [`09a8321a`](https://github.com/NixOS/nixpkgs/commit/09a8321a0d0b9f290ba16f7dbc65d45fae4d50b1) libretro.beetle-psx-hw: unstable-2024-07-19 -> unstable-2024-07-26
* [`3d50ff5d`](https://github.com/NixOS/nixpkgs/commit/3d50ff5d5ebcfeac31cc29157b4970fc9f7f2916) libretro.pcsx-rearmed: unstable-2024-07-16 -> unstable-2024-07-24
* [`a94d03b0`](https://github.com/NixOS/nixpkgs/commit/a94d03b049b959ceecda040f6536128be293c50f) libretro.stella: unstable-2024-06-30 -> unstable-2024-07-30
* [`1d14cfac`](https://github.com/NixOS/nixpkgs/commit/1d14cfac70c9d537ccb11ea66aec61e020c14740) libretro.beetle-pce-fast: unstable-2024-07-19 -> unstable-2024-07-26
* [`c7733a3a`](https://github.com/NixOS/nixpkgs/commit/c7733a3ad267022886538ff6890ad614e572da2f) fractal: 7 -> 8
* [`0a4a62d3`](https://github.com/NixOS/nixpkgs/commit/0a4a62d31d39ddb3f5e9287a60db65377c6b453f) libretro.beetle-pce: unstable-2024-07-19 -> unstable-2024-07-26
* [`24e26f7a`](https://github.com/NixOS/nixpkgs/commit/24e26f7ade2bc390dda095beb4256854b8561bc0) libretro.beetle-supergrafx: unstable-2024-06-28 -> unstable-2024-07-26
* [`770c5028`](https://github.com/NixOS/nixpkgs/commit/770c5028f938cb79c22342c7ee5aee71b03dae3a) libretro.smsplus-gx: unstable-2024-07-20 -> unstable-2024-07-22
* [`affaf77b`](https://github.com/NixOS/nixpkgs/commit/affaf77b398f56cbc62942fa8deeebf596a970e1) libretro.mame2003-plus: unstable-2024-07-20 -> unstable-2024-07-28
* [`fc3190f6`](https://github.com/NixOS/nixpkgs/commit/fc3190f6f14df825ba50ed90019c67757bec0836) libretro.ppsspp: unstable-2024-07-20 -> unstable-2024-07-29
* [`066bc7b3`](https://github.com/NixOS/nixpkgs/commit/066bc7b35200244a198d5c80f9de4f6c56f0b06b) micromdm: init at 1.12.1
* [`1989ea18`](https://github.com/NixOS/nixpkgs/commit/1989ea1826e2748bac93d5e9fcb18fd94034a734) libretro.fbneo: unstable-2024-07-12 -> unstable-2024-07-27
* [`0c019c4c`](https://github.com/NixOS/nixpkgs/commit/0c019c4ca6478c78fc5359e41e2a6e904e4a74dc) linux-wifi-hotspot: format with nixfmt-rfc-style
* [`8a1ea7dd`](https://github.com/NixOS/nixpkgs/commit/8a1ea7ddd1adc0ee6d61934945e6c6433bde8ec6) linux-wifi-hotspot: move to pkgs/by-name
* [`a0f9d3e7`](https://github.com/NixOS/nixpkgs/commit/a0f9d3e709152fdf5f1d83323f300fc2ee446853) linux-wifi-hotspot: add johnrtitor as maintainer
* [`aa1fde65`](https://github.com/NixOS/nixpkgs/commit/aa1fde65aff7f209ccaf3255e080e7458f06a56f) avml: init at 0.14.0
* [`7985734e`](https://github.com/NixOS/nixpkgs/commit/7985734e0fafdba50aded28b956074699d7ad433) switcheroo: add missing imagemagick dependency
* [`1cb3083b`](https://github.com/NixOS/nixpkgs/commit/1cb3083bb456b191a2c59769d54f2b34fd188adb) rye: 0.37.0 -> 0.38.0
* [`dbe537c0`](https://github.com/NixOS/nixpkgs/commit/dbe537c0c4f426a472879154e182f7b479008ac3) powerpipe: 0.4.0 -> 0.4.1
* [`3de47145`](https://github.com/NixOS/nixpkgs/commit/3de4714572e31844922990e05f2654d3c2b4a19f) make-initrd-ng: also print json itself if it fails to parse
* [`d79b03a5`](https://github.com/NixOS/nixpkgs/commit/d79b03a59c448b31bef79fd156337cb2baae898d) fix netboot image
* [`8ea37d03`](https://github.com/NixOS/nixpkgs/commit/8ea37d03085f647e9d7220ca44499a534282405c) libretro.atari800: unstable-2024-05-18 -> unstable-2024-07-25
* [`4c77c39e`](https://github.com/NixOS/nixpkgs/commit/4c77c39e127a1edb38d39f066ea736785df64a05) libretro.bsnes: unstable-2024-07-19 -> unstable-2024-07-26
* [`befba320`](https://github.com/NixOS/nixpkgs/commit/befba32076c33e50320437a5a043bc5386fd0365) libretro.flycast: unstable-2024-07-19 -> unstable-2024-07-29
* [`e34f0306`](https://github.com/NixOS/nixpkgs/commit/e34f03060e394a7812d8a4b9ced35a4f8978bee4) libretro.genesis-plus-gx: unstable-2024-07-20 -> unstable-2024-07-26
* [`119103de`](https://github.com/NixOS/nixpkgs/commit/119103deda9878a150e539975e0b3b31bc8326ec) libretro.gambatte: unstable-2024-07-19 -> unstable-2024-07-26
* [`e09e81ff`](https://github.com/NixOS/nixpkgs/commit/e09e81ff278d3cf070872e190a56023d4a4b86cf) libretro.swanstation: unstable-2024-07-15 -> unstable-2024-07-24
* [`cfa3e57c`](https://github.com/NixOS/nixpkgs/commit/cfa3e57cd9accf657ed8933295fc8717ad3d2476) bitwarden-cli: 2024.7.1 -> 2024.7.2
* [`06815290`](https://github.com/NixOS/nixpkgs/commit/06815290ce626fcdc142627a98e11ba75b6fdddd) ffmpeg_7-full: Enable xev{d,e} on all Darwin system
* [`b0d7dec1`](https://github.com/NixOS/nixpkgs/commit/b0d7dec1b5a2fac3dcd74cf0b777b1831295b9f6) python312Packages.pyoverkiz: only depend on backports-strenum on Python < 3.11
* [`4e0cc1ba`](https://github.com/NixOS/nixpkgs/commit/4e0cc1ba6197906c189a3818acba8ebf66448fdb) nextcloudPackages: update
* [`8426bb23`](https://github.com/NixOS/nixpkgs/commit/8426bb23b4dac27dbae234b684f32e7bd0fa59b7) libretro.dosbox-pure: unstable-2024-07-20 -> unstable-2024-08-01
* [`0e33ef9a`](https://github.com/NixOS/nixpkgs/commit/0e33ef9a30ee0c717934dc82bf1e03c3568ab5d0) werf: 2.8.0 -> 2.9.3
* [`7d1134ba`](https://github.com/NixOS/nixpkgs/commit/7d1134ba7d46a730ad995b467804a8b310aeafaa) spotify: 1.2.40.599.g606b7f29 -> 1.2.42.290.g242057a2
* [`60b0489e`](https://github.com/NixOS/nixpkgs/commit/60b0489ee327cbbbc6432c771b5d38756b3b809b) gradle: fix update-deps.sh to use Nix bash
* [`5c354f19`](https://github.com/NixOS/nixpkgs/commit/5c354f19ea79a4bb52e29465d672a01e82c7c6d5) ghidra: restore configurability to buildGhidraExtension
* [`b61731fc`](https://github.com/NixOS/nixpkgs/commit/b61731fc0f7a0e77ab098e72dbc509e63787eb35) cdecl: 18.1 -> 18.2
* [`21bc814a`](https://github.com/NixOS/nixpkgs/commit/21bc814ab5a58eed47dc1a53dc3a9c117332024a) bork: add missing `meta.license` attribute
* [`4a7c3967`](https://github.com/NixOS/nixpkgs/commit/4a7c396766098b2f2f756dc477d2821d2e9efd57) koboldcpp: 1.71.1 -> 1.72
* [`1e93b01c`](https://github.com/NixOS/nixpkgs/commit/1e93b01c8e4f63306e5b6ca7546e1722257414cc) python3.homf: apply natsukium's suggestions
* [`db150cf9`](https://github.com/NixOS/nixpkgs/commit/db150cf9939c3974845db45d5a92209420559a05) python3.homf: add missing `meta.license` attribute
* [`85afc222`](https://github.com/NixOS/nixpkgs/commit/85afc2222066b16bcaa425309e07a052cad70a84) python3.bork: use python's default `meta.platforms`
* [`9f6e9449`](https://github.com/NixOS/nixpkgs/commit/9f6e9449fca3a7f5a5775eb6db6711431f1114e8) fallout-ce: remove TheBrainScrambler as maintainer
* [`4ccb94d2`](https://github.com/NixOS/nixpkgs/commit/4ccb94d239ca55cc7d5a1833a64f20a494042023) zigbee2mqtt: 1.39.0 -> 1.39.1
* [`91b406a0`](https://github.com/NixOS/nixpkgs/commit/91b406a073f91e4ce408053648997ef3b6b074d0) nss_latest: 3.102.1 -> 3.103
* [`9578e706`](https://github.com/NixOS/nixpkgs/commit/9578e7064f5fd8f33b9a5eb9d4168daa8d3b5b03) python312Packages.airgradient: 0.7.0 -> 0.7.1
* [`4ec74633`](https://github.com/NixOS/nixpkgs/commit/4ec746337634ceebbaa0a35372dc2227412be55a) carapace: 1.0.4 -> 1.0.5
* [`861eee7e`](https://github.com/NixOS/nixpkgs/commit/861eee7e2b5a2dffe68b93082be6a43ad4aebc0d) clickhouse-backup: 2.5.20 -> 2.5.21
* [`2a3d5d1e`](https://github.com/NixOS/nixpkgs/commit/2a3d5d1e9fd2877cdd8a149b7e1e8f1c69eb0ddb) d2: 0.6.5 -> 0.6.6
* [`300c7e6c`](https://github.com/NixOS/nixpkgs/commit/300c7e6cc380b03330070906e41d0d448521c076) coldsnap: 0.6.1 -> 0.6.2
* [`58d7f08e`](https://github.com/NixOS/nixpkgs/commit/58d7f08e1ce549d9d5c9a6c8336c2e154d328cd0) stalwart-mail: 0.8.5 -> 0.9.0
* [`29c6f7db`](https://github.com/NixOS/nixpkgs/commit/29c6f7dbcfc8b4e562f9285ec516f83a6ffed97e) maintainers: add matthiasdotsh
* [`126e6855`](https://github.com/NixOS/nixpkgs/commit/126e6855f925d70a41924bf1fd83f454075e7a8f) difftastic: 0.59.0 -> 0.60.0
* [`06b85385`](https://github.com/NixOS/nixpkgs/commit/06b853859ff5f26af9d2b93cb7aa18c51380b576) kubectl-view-secret: 0.12.0 -> 0.12.1
* [`d8d017d9`](https://github.com/NixOS/nixpkgs/commit/d8d017d906e427e4ee162bd6998fd7e07374d188) go-mockery: 2.43.2 -> 2.44.1
* [`ab2c4b7a`](https://github.com/NixOS/nixpkgs/commit/ab2c4b7afbf747bce275e797474e257729189287) ollama: update hash for 0.3.1
* [`6c1956f2`](https://github.com/NixOS/nixpkgs/commit/6c1956f2af1ea6a42996e29377c7defae69a9467) wayneko: init at 0-unstable-2024-03-29
* [`e263600b`](https://github.com/NixOS/nixpkgs/commit/e263600b33b6de6245e642fab9b92bb2323b836e) gobgpd: 3.28.0 -> 3.29.0
* [`7c908d40`](https://github.com/NixOS/nixpkgs/commit/7c908d40bb7eb6674e3e5edb672aef77bfee0b70) gobgp: 3.28.0 -> 3.29.0
* [`77a49025`](https://github.com/NixOS/nixpkgs/commit/77a4902508ec390c891a10299fb7be953b450d84) pixelfed: drop raitobezarius as a maintainer
* [`8d8ab8ca`](https://github.com/NixOS/nixpkgs/commit/8d8ab8cabf3a297c2904e6297701bcaa93a73bb3) python312Packages.patch-ng: 1.17.4 -> 1.18.0
* [`6fc72f65`](https://github.com/NixOS/nixpkgs/commit/6fc72f65d18c74a402673969a76aad5e585ee9d4) translatelocally: enable wayland support
* [`956b068e`](https://github.com/NixOS/nixpkgs/commit/956b068eaf776ec937bf833cfecc30521db70a71) translatelocally: unstable-2023-09-20 -> 0-unstable-2024-05-12
* [`cc6fa17c`](https://github.com/NixOS/nixpkgs/commit/cc6fa17c0074790af5480d271960ede6c389dab5) translatelocally-models: update
* [`c5e72a3c`](https://github.com/NixOS/nixpkgs/commit/c5e72a3ce5c45281287d2828387c5afb072de6d1) python312Packages.pywaze: 1.0.2 -> 1.1.0
* [`5048af9f`](https://github.com/NixOS/nixpkgs/commit/5048af9f17b5650112c5571cc32af89b1325cbfa) python312Packages.scikit-rf: 1.1.0 -> 1.2.0
* [`c596b526`](https://github.com/NixOS/nixpkgs/commit/c596b526d6eacafeea46da7e46108dea0c507f72) python312Packages.scikit-rf: refactor
* [`de2ebd24`](https://github.com/NixOS/nixpkgs/commit/de2ebd24b0b3659179206f25b008ca4aff27eab9) restic-integrity: 1.3.0 -> 1.3.1
* [`d23beba7`](https://github.com/NixOS/nixpkgs/commit/d23beba7aea28dba8e96433c0a5b205ac5e1fc8d) python312Packages.aioymaps: refactor
* [`ea6f4d5e`](https://github.com/NixOS/nixpkgs/commit/ea6f4d5e8604ebcedd46f136f1dc93a4da86852b) treewide: remove periods from lib.mkEnableOption
* [`2ccadf20`](https://github.com/NixOS/nixpkgs/commit/2ccadf206746c1f8cbeef6494035d9da5465f437) jcli: install shell completions
* [`7e6aa644`](https://github.com/NixOS/nixpkgs/commit/7e6aa6441a99d0bfe4caa39c1c1da35137ba8114) jcli: migrate to by-name
* [`35aef7f6`](https://github.com/NixOS/nixpkgs/commit/35aef7f6b5e3b482f788ecda14d1e19f8ffe902c) hugo: 0.130.0 -> 0.131.0
* [`16b90c0d`](https://github.com/NixOS/nixpkgs/commit/16b90c0d769231c9ca88f293fdc8bc56842327d9) serie: 0.1.1 -> 0.1.2
* [`c0553579`](https://github.com/NixOS/nixpkgs/commit/c05535798dcae0da3bf5983e8673e94187a7eb8c) python312Packages.datalad: 1.1.1 -> 1.1.2
* [`50962e28`](https://github.com/NixOS/nixpkgs/commit/50962e2880f1a2ef3a464759767789b1161c437e) arti: 1.2.4 -> 1.2.6
* [`95791c8e`](https://github.com/NixOS/nixpkgs/commit/95791c8e9565d54c46057546de9a8a0e29dc52d5) python312Packages.sphinx-design: 0.6.0 -> 0.6.1
* [`49de6926`](https://github.com/NixOS/nixpkgs/commit/49de6926407dd583edaabcceed8b068be7fb0142) python312Packages.weconnect: 0.60.3 -> 0.60.4
* [`6b5fd209`](https://github.com/NixOS/nixpkgs/commit/6b5fd20954150d2b8c58264897e41fb066e993f2) cargo-hakari: 0.9.28 -> 0.9.30
* [`23417302`](https://github.com/NixOS/nixpkgs/commit/23417302b94bab7608d5a9f7de4d52e0c9ad26cd) emacs: bump emacs2nix to fix generating duplicated entries
* [`a5952658`](https://github.com/NixOS/nixpkgs/commit/a595265893b36c0927d474fbb74d583538b5fcf5) sttr: 0.2.22 -> 0.2.23
* [`9d80cddf`](https://github.com/NixOS/nixpkgs/commit/9d80cddfbe4995436af8946c17d54d3e0afeda54) cargo-hakari: rfc style formatting
* [`d9b57ba7`](https://github.com/NixOS/nixpkgs/commit/d9b57ba729bcaf22b9a8168ebaec94b645806e77) wl-screenrec: 0.1.3 -> 0.1.4-unstable-2024-07-28
* [`53774f10`](https://github.com/NixOS/nixpkgs/commit/53774f1026255aa65c31be8cd09e21dda128cfd6) undmg: format
* [`d7bf713f`](https://github.com/NixOS/nixpkgs/commit/d7bf713fbe2eaabf8494c5717ae2acb2bf1e43f8) undmg: refactor meta
* [`dcd8a19b`](https://github.com/NixOS/nixpkgs/commit/dcd8a19b7c8734e15f90252729810de02daef25e) undmg: 1.1.0 -> 1.1.0-unstable-2024-08-02
* [`fbf4f332`](https://github.com/NixOS/nixpkgs/commit/fbf4f33286540d40f06f3fc62404e747ea63bd23) sqlpage : 0.24.0 -> 0.25.0
* [`ff0a196c`](https://github.com/NixOS/nixpkgs/commit/ff0a196c65bca84ce286e43297ef7fa9a6dd9c02) podman: 5.1.2 -> 5.2.0
* [`8b8b6acc`](https://github.com/NixOS/nixpkgs/commit/8b8b6acc49f101a0def178de10e308f8ba5b4d7c) ugrep: 6.2.0 -> 6.3.0
* [`b74c97b3`](https://github.com/NixOS/nixpkgs/commit/b74c97b315b1c663b0bd780d00a11071ee9d0cbf) python3Packages.soundcard: init at 0.4.3
* [`31fb8596`](https://github.com/NixOS/nixpkgs/commit/31fb859666abf1b359d83e2a59b56eb5aa0e01e6) mimir: added various tools
* [`e95f4261`](https://github.com/NixOS/nixpkgs/commit/e95f4261cf4b598a739d6d49d9874a58c08faa3f) circt: 1.79 -> 1.80
* [`cf9c8caf`](https://github.com/NixOS/nixpkgs/commit/cf9c8caf7f5acac227c959e39dffa9defee0af90) python311Packages.openai: 1.37.0 -> 1.38.0
* [`0a7e45cc`](https://github.com/NixOS/nixpkgs/commit/0a7e45cc95c5e9f16320d5500ec9006a59302e40) python312Packages.boto3-stubs: 1.34.151 -> 1.34.152
* [`c35ec339`](https://github.com/NixOS/nixpkgs/commit/c35ec339609a85078beb5a311a67566a452f2dd4) python312Packages.botocore-stubs: 1.34.151 -> 1.34.152
* [`a18c10b8`](https://github.com/NixOS/nixpkgs/commit/a18c10b8c1dd6eeea5eaf413625de34044eb2356) wavebox: 10.124.17-2 -> 10.127.10-2 ([nixos/nixpkgs⁠#324822](https://togithub.com/nixos/nixpkgs/issues/324822))
* [`7a8f47ac`](https://github.com/NixOS/nixpkgs/commit/7a8f47ac1e31ef85eb331e09bd3cc167c2938bbb) python312Packages.tencentcloud-sdk-python: 3.0.1201 -> 3.0.1203
* [`fd8e9d77`](https://github.com/NixOS/nixpkgs/commit/fd8e9d775e62d84cffd40a675ba51072bb3ba387) checkov: 3.2.216 -> 3.2.217
* [`2ca365ca`](https://github.com/NixOS/nixpkgs/commit/2ca365ca515ec4ad0a0711e14a68776d5d8b073d) dbip-country-lite: 2024-07 -> 2024-08
* [`12955826`](https://github.com/NixOS/nixpkgs/commit/129558261d9f1fb92c99f93ef259c698bc93db20) buildkite-agent: 3.59.0 -> 3.76.1 ([nixos/nixpkgs⁠#331340](https://togithub.com/nixos/nixpkgs/issues/331340))
* [`57d30c7a`](https://github.com/NixOS/nixpkgs/commit/57d30c7a61d8fb3d8964a1f60c37f8f9c0b34a9c) nixos/wg-quick: add generatePrivateKeyFile option ([nixos/nixpkgs⁠#331253](https://togithub.com/nixos/nixpkgs/issues/331253))
* [`0c69b24d`](https://github.com/NixOS/nixpkgs/commit/0c69b24df08f3e6a13a2679e8209207028bee0ab) timetagger_cli: 23.8.3 -> 24.7.1
* [`a57d9656`](https://github.com/NixOS/nixpkgs/commit/a57d965604c291fdf4c1b8d493bf65877c193092) signal-desktop: 7.17.0 -> 7.18.0
* [`4ce55aef`](https://github.com/NixOS/nixpkgs/commit/4ce55aef1cbce8e8af7d412924354ce2b27bc3e8) signal-desktop-beta: 7.18.0-beta1 -> 7.19.0-beta1
* [`c7962597`](https://github.com/NixOS/nixpkgs/commit/c7962597fece3e65e4200c5367da58467e8fed9e) ruff: 0.5.5 -> 0.5.6
* [`4c445ed4`](https://github.com/NixOS/nixpkgs/commit/4c445ed4790c68e50e623cd56e70521e59addf6f) nix-du: 1.2.0 -> 1.2.1
* [`3bfeae14`](https://github.com/NixOS/nixpkgs/commit/3bfeae1428eac1e60a304268bf7dc218f152b145) ipu6: Don't build out-of-tree driver for kernels that have it
* [`e58878b8`](https://github.com/NixOS/nixpkgs/commit/e58878b8a1e796fec5bd1b75f454345974b02b9a) nbqa: fix by adding distutils test dependency
* [`6f0a079b`](https://github.com/NixOS/nixpkgs/commit/6f0a079ba56be107075d543cf3ef260ec58d03c1) await: 1.0.1 -> 1.0.2
* [`473f1bb5`](https://github.com/NixOS/nixpkgs/commit/473f1bb5f11524659dc32afe2c7450193bbaa53a) gate: 0.38.0 -> 0.38.2
* [`ca2c985f`](https://github.com/NixOS/nixpkgs/commit/ca2c985fc732cd06fb180b57a6f8cf86254f3d55) python312Packages.awkward-cpp: 35 -> 37
* [`5ab29098`](https://github.com/NixOS/nixpkgs/commit/5ab29098a22b464d2dfbd3e4e6ad77912d4a299a) python312Packages.awkward: 2.6.6 -> 2.6.7
* [`81343957`](https://github.com/NixOS/nixpkgs/commit/81343957e651c19f5199f3c032a4b67bee92e973) step-cli: install shell completion
* [`b506b66a`](https://github.com/NixOS/nixpkgs/commit/b506b66affa57a87bde86f3aa8a5508c6958b428) step-cli: update .git-blame-ignore-revs
* [`35789184`](https://github.com/NixOS/nixpkgs/commit/35789184457accfa04fac029424e4fb14bfc8d48) python312Packages.botorch: disable stuck tests on x86_64-linux
* [`e210e620`](https://github.com/NixOS/nixpkgs/commit/e210e620be7a40ac4b5e3b4d2444cc0d6b516439) python312Packages.vector: clean and fix
* [`2c19ea97`](https://github.com/NixOS/nixpkgs/commit/2c19ea977c9ff46115aa3ab59c7dffce0826d144) feishin: move to pkgs/by-name
* [`bd6cce92`](https://github.com/NixOS/nixpkgs/commit/bd6cce921864449860b6681fdb52df52e4a0cb45) feishin: 0.7.1 -> 0.7.3
* [`72f35a0a`](https://github.com/NixOS/nixpkgs/commit/72f35a0af42576b936942c82b93fb47fe6ad6560) veilid: 0.3.3 -> 0.3.4
* [`217c61a1`](https://github.com/NixOS/nixpkgs/commit/217c61a1d718f9449a1823f14fb72de28e7ca66f) freshBootstrapTools: remove top-level `with` statement
* [`003725a9`](https://github.com/NixOS/nixpkgs/commit/003725a97d50b3a9c918168f907d366bf4bac4ad) freshBootstrapTools.bootstrapTools: extract as a package
* [`1cd5d684`](https://github.com/NixOS/nixpkgs/commit/1cd5d6843aa6ca1b40714a9487e5ef2f7c2754d5) freshBootstrapTools.test: extract as a package
* [`ef150d02`](https://github.com/NixOS/nixpkgs/commit/ef150d021c094f83f77f52d70e7958419e31216a) bombono: 1.2.4 -> 1.2.4-unstable-2022-02-06
* [`d7c66f09`](https://github.com/NixOS/nixpkgs/commit/d7c66f099624a966e5b2d0fbe0c047392e76a8b6) freshBootstrapTools.build: extract as a package
* [`d0d5a7a1`](https://github.com/NixOS/nixpkgs/commit/d0d5a7a112ac7c836dc8c6811107e047b162d0b9) freshBootstrapTools: extract bootstrapFiles as a passthru on its core derivation
* [`91e1f1c9`](https://github.com/NixOS/nixpkgs/commit/91e1f1c9d6dc7c80e6940e73d43b66aba6e4d2a9) freshBootstrapTools: nixfmt make-bootstrap-tools.nix
* [`1441f48d`](https://github.com/NixOS/nixpkgs/commit/1441f48d9952de0dcff900bfb943b87a9d0120a7) freshBootstrapTools: remove rec in favor of explicit attrset building
* [`5cbe9df9`](https://github.com/NixOS/nixpkgs/commit/5cbe9df983e107f96fab9f2227527eae6e2b78e1) fzf-make: 0.35.0 -> 0.36.0
* [`62a8e330`](https://github.com/NixOS/nixpkgs/commit/62a8e3308ecc8658b3876a1d11b0973133bf3286) python312Packages.botorch: require big-parallel system feature
* [`e0816431`](https://github.com/NixOS/nixpkgs/commit/e0816431a23a06692d86c0b545b4522b9a9bc939) treewide: Pass self when overriding Python
* [`de92c8b0`](https://github.com/NixOS/nixpkgs/commit/de92c8b0cb5e3065b5a13c5941b9d0c9bcd06d43) python3Packages.pynvim-pp: unstable-2024-03-11 -> unstable-2024-07-31
* [`ed4cd6ab`](https://github.com/NixOS/nixpkgs/commit/ed4cd6ab512b4d49cc8e5eb5d80b5539a2f183a9) freshBootstrapTools.build: extract a package
* [`67a5dcdc`](https://github.com/NixOS/nixpkgs/commit/67a5dcdc4124b886759baf3ed5c813c206cdc713) freshBootstrapTools.test: extract a package
* [`fd5887f5`](https://github.com/NixOS/nixpkgs/commit/fd5887f5d07b63e3913ec4e5659e8885249c1030) freshBootstrapTools.build: put bootstrapFiles into stdenv-bootstrap-tools.nix
* [`0a8120ff`](https://github.com/NixOS/nixpkgs/commit/0a8120ff7d864a6575425ae8655b9d21f88aa8fc) freshBootstrapTools: avoid top-level with
* [`052ecdbf`](https://github.com/NixOS/nixpkgs/commit/052ecdbfaebcaf63dcad2b43c7b97991906a01bb) freshBootstrapTools: unify glibc and musl into the same directory
* [`2587d88e`](https://github.com/NixOS/nixpkgs/commit/2587d88ee89b4b29870703d94090f37c97d9f3af) freshBootstrapTools.bootstrapTools: extract as a sort of package
* [`e915f6b3`](https://github.com/NixOS/nixpkgs/commit/e915f6b32ee29405e803cd67e0c80cbfafd61319) freshBootstrapTools: run nixfmt
* [`4b111056`](https://github.com/NixOS/nixpkgs/commit/4b111056cf46e08c76f329a3c9716b83dfefaa25) pkgs/top-level/aliases.nix: move llvmPackages_git back in
* [`daadebae`](https://github.com/NixOS/nixpkgs/commit/daadebae3e610fd757c2e569b870183eeaf8165d) kubedock: 0.16.0 -> 0.17.0
* [`01890a28`](https://github.com/NixOS/nixpkgs/commit/01890a284a0902246e00f3bfda54715e0a8e6981) lua-language-server: 3.9.3 -> 3.10.1
* [`9913cedc`](https://github.com/NixOS/nixpkgs/commit/9913cedc5b4fd6384aacce3eb6e15687f956ef29) nest: 3.7 -> 3.8
* [`7f3849b3`](https://github.com/NixOS/nixpkgs/commit/7f3849b3bec37b9b452b79d081a333028d13028a) hcledit: 0.2.11 -> 0.2.13
* [`f4dbe80c`](https://github.com/NixOS/nixpkgs/commit/f4dbe80c4d069a5cf5abc992e4a612b73be71d00) pfetch-rs: 2.10.0 -> 2.11.0
* [`6b309be9`](https://github.com/NixOS/nixpkgs/commit/6b309be9a661d680f7c3daa0d8524aa3b135d0f9) src-cli: 5.4.0 -> 5.5.0
* [`fd8384af`](https://github.com/NixOS/nixpkgs/commit/fd8384af70f78388ba6a36033fe29510e586aa80) python312Packages.f90nml: Migrate away from `setup.py test`
* [`6bad8d62`](https://github.com/NixOS/nixpkgs/commit/6bad8d6232d6b047a892e5042f654e2afee9fe31) python312Packages.f90nml: modernize
* [`8ce22530`](https://github.com/NixOS/nixpkgs/commit/8ce22530d09160accdc771164d72bfb5c17874a0) tile38: 1.33.1 -> 1.33.2
* [`8bd2e0ed`](https://github.com/NixOS/nixpkgs/commit/8bd2e0edf16e2b598bf769aa1a1d38ecc294580c) httpx: 1.6.6 -> 1.6.7
* [`9a47dadc`](https://github.com/NixOS/nixpkgs/commit/9a47dadc72d6906334dbc82cdd2b9e0738c4af35) wit-bindgen: 0.28.0 -> 0.29.0
* [`537b1128`](https://github.com/NixOS/nixpkgs/commit/537b11289a2c2c26675c8ef168cf6873560e1e2d) python312Packages.python-nvd3: migrate from `setup.py test`
* [`41dcce09`](https://github.com/NixOS/nixpkgs/commit/41dcce094ed1fcbc40328e623efc2dabb04c57e2) python312Packages.python-nvd3: modernize
* [`9221b42b`](https://github.com/NixOS/nixpkgs/commit/9221b42b43881053ca26cf535cc9f71041297206) rehex: 0.62.0 -> 0.62.1
* [`60d35394`](https://github.com/NixOS/nixpkgs/commit/60d35394e3555be44e15f46649890b74f300afe7) sqlx-cli: 0.7.4 -> 0.8.0
* [`e787df99`](https://github.com/NixOS/nixpkgs/commit/e787df99a3d80c4efd3dd162b23cb760bc492378) grafana-agent: 0.41.1 -> 0.42.0
* [`373e2305`](https://github.com/NixOS/nixpkgs/commit/373e23053ac7196d274058b19fffd881a5df7146) python312Packages.outlines: 0.0.45 -> 0.0.46
* [`1130d8c4`](https://github.com/NixOS/nixpkgs/commit/1130d8c4bc7b6776501808a72529cda5a28ed888) dotenv-cli: remove usage of mkYarnPackage
* [`b71a4af0`](https://github.com/NixOS/nixpkgs/commit/b71a4af0075f888103f4e8eea8799418ee23ca6f) python312Packages.anthropic: 0.31.2 -> 0.32.0
* [`624e692a`](https://github.com/NixOS/nixpkgs/commit/624e692ae1b4af2da682041ee326e542ec623b74) python312Packages.strawberry-graphql: 0.236.0 -> 0.237.3
* [`6f13ea46`](https://github.com/NixOS/nixpkgs/commit/6f13ea465a2496f4139b61263e97bbe1977b6bbc) railway: 3.11.1 -> 3.11.2
* [`b3ddca49`](https://github.com/NixOS/nixpkgs/commit/b3ddca49aa745add8a1529291e2113f57e3f80be) railway: nixfmt
* [`9246489a`](https://github.com/NixOS/nixpkgs/commit/9246489a8af4a093f60460ce0e07e63072edcdfd) railway: move to pkgs/by-name
* [`da04e028`](https://github.com/NixOS/nixpkgs/commit/da04e028fc69c5f7dce2ba1a0034b028860944da) qovery-cli: 0.97.0 -> 1.1.0
* [`c19698cb`](https://github.com/NixOS/nixpkgs/commit/c19698cb744ed60e447b2cab4667fd294488cb0e) telepresence2: 2.19.0 -> 2.19.1
* [`58a7c9b4`](https://github.com/NixOS/nixpkgs/commit/58a7c9b434f201cf13f8f35d57670d77ee2072ae) pytrainer: replace `setup.py test` by `-m unittest`
* [`90d02f00`](https://github.com/NixOS/nixpkgs/commit/90d02f008685aa188baab45b75d9d722a5a26e73) cloc: 2.00 -> 2.02
* [`943635f1`](https://github.com/NixOS/nixpkgs/commit/943635f1b87a2b9087a4d2b95377d144695074da) syshud: 0-unstable-2024-07-16 -> 0-unstable-2024-07-29
* [`6b618f73`](https://github.com/NixOS/nixpkgs/commit/6b618f7371f11d30a22d13000a4667e90280337f) remnote: 1.16.72 -> 1.16.93
* [`368f21fe`](https://github.com/NixOS/nixpkgs/commit/368f21fed1bd8245fef997ef22e6829974869117) quba: init at 1.4.0
* [`5fc0daaf`](https://github.com/NixOS/nixpkgs/commit/5fc0daaf3cfdd840168420cdef1c0e1070b2ec66) wayfirePlugins.wwp-switcher: unstable-2023-09-09 -> 0-unstable-2024-07-23
* [`23aa9f6c`](https://github.com/NixOS/nixpkgs/commit/23aa9f6c5e71d37ba8029320e33d3c4b6e3c1769) pdf-sign: 0-unstable-2023-08-08 -> 0-unstable-2024-07-16
* [`e7d978fb`](https://github.com/NixOS/nixpkgs/commit/e7d978fba3bd76ae0a87b77c66f104e0df1f85df) typodermic-public-domain: 2022-11 -> 2024-04
* [`caa189d7`](https://github.com/NixOS/nixpkgs/commit/caa189d71a9b658033e519b5305400c0162ebb61) typodermic-free-fonts: 2023a -> 2024-04
* [`04554b15`](https://github.com/NixOS/nixpkgs/commit/04554b15a35963d4a7f99a7518ecb2c8e887751b) tclcurl: init at 7.22.0
* [`f940d69b`](https://github.com/NixOS/nixpkgs/commit/f940d69b27e4e0ceb14f45b6e4666cd3a53a1ffe) tclmagick: init at 1.3.43
* [`057e1661`](https://github.com/NixOS/nixpkgs/commit/057e1661480dbf1b50058b9e934f5becdfd10e8c) python312Packages.pynvim-pp: cosmetic changes
* [`1a3d7752`](https://github.com/NixOS/nixpkgs/commit/1a3d77522d8b995851ca07b59ebb5d068eab0d69) cambalache: 0.90.2 → 0.90.4
* [`9c9107c7`](https://github.com/NixOS/nixpkgs/commit/9c9107c7cb4e54cea7edf909e044586f6c32a075) eog: 45.3 → 45.4
* [`0c3b6fc8`](https://github.com/NixOS/nixpkgs/commit/0c3b6fc89870b2a6787469a97014608e6c093a27) evince: 46.3 → 46.3.1
* [`b68a4382`](https://github.com/NixOS/nixpkgs/commit/b68a4382941c5eed7f4a2782b9b3ef175ce8d8cb) podman-tui: move to by-name
* [`d465c585`](https://github.com/NixOS/nixpkgs/commit/d465c58549dc48721728bc20d4be00ccc8cf1e59) lief: 0.15.0 -> 0.15.1
* [`ec601990`](https://github.com/NixOS/nixpkgs/commit/ec601990ce07fba09064949c17441e6a5056b40b) podman-tui: 1.1.0 -> 1.2.0
* [`2573d1b0`](https://github.com/NixOS/nixpkgs/commit/2573d1b095b0b7b5d41de911552c0a10518346eb) apx-gui: 1.0.2 -> 1.0.3
* [`648fefc4`](https://github.com/NixOS/nixpkgs/commit/648fefc4ddb9909ac18305db0890d4f799a7daeb) alpaca: 1.0.1 -> 1.0.5
* [`d2be09bc`](https://github.com/NixOS/nixpkgs/commit/d2be09bc893776bb76257711ed3959eb1754ad06) application-title-bar: 0.6.8 -> 0.6.9
* [`ef385999`](https://github.com/NixOS/nixpkgs/commit/ef3859991abc6811ee1bb1f4bc9f18bdd2de6eb2) python312Packages.pyvista: 0.44.0 -> 0.44.1
* [`3ad3b5c9`](https://github.com/NixOS/nixpkgs/commit/3ad3b5c925fa7e9d33692daeb1cc290c6036f118) fluent-bit: 3.1.3 -> 3.1.4
* [`90ee91b6`](https://github.com/NixOS/nixpkgs/commit/90ee91b6d6bee695707a3b6af6e6d475da07fdee) teleport: darwin unbroken
* [`28c45bac`](https://github.com/NixOS/nixpkgs/commit/28c45bac2efbe44b63bd8ae8a8fd9fdf538f3c86) qownnotes: 24.7.2 -> 24.8.2
* [`3d46ea7e`](https://github.com/NixOS/nixpkgs/commit/3d46ea7eaa3cf40a0d9c78c59f2a7fe7db3e6370) evince, papers: Remove broken supportXPS option
* [`54d521ee`](https://github.com/NixOS/nixpkgs/commit/54d521ee09e55d2948948d6a2be9ce7c0e857f92) evolution: 3.52.3 → 3.52.4
* [`57cc14d3`](https://github.com/NixOS/nixpkgs/commit/57cc14d39080659f219ed468792e567ee0288c4d) evolution-data-server: 3.52.3 → 3.52.4
* [`6e97411a`](https://github.com/NixOS/nixpkgs/commit/6e97411a7a63cecdf75cc363af6522bee93e45d3) evolution-ews: 3.52.3 → 3.52.4
* [`c17e6425`](https://github.com/NixOS/nixpkgs/commit/c17e6425756167ab3e960e20419beb912545e5ad) gnome.gnome-bluetooth: 46.0 → 46.1
* [`b56b289f`](https://github.com/NixOS/nixpkgs/commit/b56b289f6185ba05c72cfc2c2ebf5aeb31b5f785) gnome-builder: 46.2 → 46.3
* [`63705187`](https://github.com/NixOS/nixpkgs/commit/637051873183ce529d60308e8606ac5ed0837c9b) gnome.gnome-music: 46.0 → 46.1
* [`5adfa811`](https://github.com/NixOS/nixpkgs/commit/5adfa811afa06876b3653beedf7a5bad88ae8c38) libshumate: 1.2.2 → 1.2.3
* [`3412c2fa`](https://github.com/NixOS/nixpkgs/commit/3412c2fad41481077c1bf7f46dd064d557ad3d64) python312Packages.scancode-toolkit: 32.2.0 -> 32.2.1
* [`18b03536`](https://github.com/NixOS/nixpkgs/commit/18b035363b08f50c55f94fbcaf9d6e43746241a5) tdlib: 1.8.33 -> 1.8.34
* [`54d0da01`](https://github.com/NixOS/nixpkgs/commit/54d0da017b1d065ed6f0ff4ebf3a371a5ba718d5) python312Packages.tinytag: init at 1.10.1
* [`d8a7e169`](https://github.com/NixOS/nixpkgs/commit/d8a7e169ea3274632ddb9221d1f72b6d57b324ff) calibre: 7.15.0 -> 7.16.0
* [`00b9996c`](https://github.com/NixOS/nixpkgs/commit/00b9996c9ad5726c49dfdb0974a75fe7a2f03b0a) stdenv: Take nested env.NIX_CFLAGS_LINK into account when making static binaries
* [`cca7b430`](https://github.com/NixOS/nixpkgs/commit/cca7b43071a9088b8212b6fc499a46779c0d97e9) libnvme: 1.9 -> 1.10
* [`927fc72f`](https://github.com/NixOS/nixpkgs/commit/927fc72f6a5e35823543b194b6aa14a57fcfc8b2) nvme-cli: 2.9.1 -> 2.10
* [`df67de07`](https://github.com/NixOS/nixpkgs/commit/df67de074785eca6a45767221c2307a85c283783) nushellPlugins.query: fix build
* [`96a9c815`](https://github.com/NixOS/nixpkgs/commit/96a9c815086fe9a517112c59d8e89f5669fb07b6) python312Packages.azure-mgmt-resource: 23.0.1 -> 23.1.1
* [`2dd798f2`](https://github.com/NixOS/nixpkgs/commit/2dd798f27beab6522862fa78efa706cee199d0db) python312Packages.azure-mgmt-powerbiembedded: 2.0.0 -> 3.0.0
* [`865e755a`](https://github.com/NixOS/nixpkgs/commit/865e755a38209deb3750a7112d5a2f7e4db61fc2) python312Packages.pyenphase: 1.21.0 -> 1.22.0
* [`8a5184b5`](https://github.com/NixOS/nixpkgs/commit/8a5184b51f449368db552406a762eccd5079a959) freetube: 0.21.2 -> 0.21.3
* [`c3358727`](https://github.com/NixOS/nixpkgs/commit/c335872786f8c1a8f038ec46d372435a41f32f9d) cargo-deny: 0.15.0 -> 0.16.0
* [`c9d2f9ea`](https://github.com/NixOS/nixpkgs/commit/c9d2f9ea12cfb6a3c1a1dd57aa8ac8a3f6882d17) python312Packages.dns-lexicon: 3.16.1 -> 3.17.0
* [`5d78a018`](https://github.com/NixOS/nixpkgs/commit/5d78a0185ea191e430cf33c06f7687fc1c103f1b) kubelogin-oidc: 1.28.1 -> 1.28.2
* [`30d807f9`](https://github.com/NixOS/nixpkgs/commit/30d807f937f5943db8d04b98960060f5981a2fc1) rqlite: 8.26.7 -> 8.26.8
* [`a6b29ac9`](https://github.com/NixOS/nixpkgs/commit/a6b29ac954b428f06b9f59b5b24d0527a556e859) ryujinx: 1.1.1358 -> 1.1.1364
* [`af69223f`](https://github.com/NixOS/nixpkgs/commit/af69223f4666c1f9dd4f68c375727415838f1376) nixos/flatpak: add package option
* [`460b0d97`](https://github.com/NixOS/nixpkgs/commit/460b0d97e1a9793fded723f1a42d7ebfd3220f52) gitlab-ci-local: 4.52.1 -> 4.52.2
* [`1e100267`](https://github.com/NixOS/nixpkgs/commit/1e10026712a7700d7328966562cd212e6e051e35) skaffold: 2.13.0 -> 2.13.1
* [`b091f9cb`](https://github.com/NixOS/nixpkgs/commit/b091f9cb295ef6e5136466b686a29cf34fa1466e) langgraph-cli: 0.1.49 -> 0.1.50
* [`ecea394b`](https://github.com/NixOS/nixpkgs/commit/ecea394b12b7e69e15641e5ef70893ff7556f517) gping: 1.17.1 -> 1.17.3
* [`8a5f82d7`](https://github.com/NixOS/nixpkgs/commit/8a5f82d7bc1c1028b3a5c2f3c29a5e111e6f324b) stgit: 2.4.8 -> 2.4.9
* [`fec9ad5c`](https://github.com/NixOS/nixpkgs/commit/fec9ad5c37c2c5c493b7abe195dd6e16b4ed8791) python312Packages.borb: 2.1.24 -> 2.1.25
* [`91107bd5`](https://github.com/NixOS/nixpkgs/commit/91107bd5ef5a04b5625768e9edfaa20d3098f856) neatvnc: 0.8.0 -> 0.8.1
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
