### PR TITLE
niv home-manager: update 792757f6 -> afc892db

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -41,10 +41,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "792757f643cedc13f02098d8ed506d82e19ec1da",
-        "sha256": "1xfj2qicq9px95dbgsvpp38z1679zi3pzhhlj9dkzqwhqha7jmgp",
+        "rev": "afc892db74d65042031a093adb6010c4c3378422",
+        "sha256": "1w362j8vl57v7bwgb7c9ai94w0kfiaphrkrsbfh2k40i2gs3zws1",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/792757f643cedc13f02098d8ed506d82e19ec1da.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/afc892db74d65042031a093adb6010c4c3378422.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@792757f6...afc892db](https://github.com/nix-community/home-manager/compare/792757f643cedc13f02098d8ed506d82e19ec1da...afc892db74d65042031a093adb6010c4c3378422)

* [`89670e27`](https://github.com/nix-community/home-manager/commit/89670e27e101b9b30f5900fc1eb6530258d316b1) home-manager: ignore hostname -f lookup errors
* [`db40fead`](https://github.com/nix-community/home-manager/commit/db40fead89db185dfd863aed5dad1d675f82a3fc) nix-gc: call nix-collect-garbage in a shell script
* [`d34aaf7b`](https://github.com/nix-community/home-manager/commit/d34aaf7b3b4c98f2aefe0429b8946f2bcd36a59a) nix-gc: set service type to oneshot
* [`4fcd54df`](https://github.com/nix-community/home-manager/commit/4fcd54df7cbb1d79cbe81209909ee8514d6b17a4) firefox: fix userChrome example
* [`58cef379`](https://github.com/nix-community/home-manager/commit/58cef3796271aaeabaed98884d4abaab5d9d162d) nix-gc: remove extraneous quotes from shell script
* [`6e090576`](https://github.com/nix-community/home-manager/commit/6e090576c4824b16e8759ebca3958c5b09659ee8) flake.lock: Update
* [`afc892db`](https://github.com/nix-community/home-manager/commit/afc892db74d65042031a093adb6010c4c3378422) Translate using Weblate (Vietnamese)
