### PR TITLE
niv home-manager: update afc892db -> 086f619d

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -41,10 +41,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "afc892db74d65042031a093adb6010c4c3378422",
-        "sha256": "1w362j8vl57v7bwgb7c9ai94w0kfiaphrkrsbfh2k40i2gs3zws1",
+        "rev": "086f619dd991a4d355c07837448244029fc2d9ab",
+        "sha256": "1vlfxqma4g20vffn2ysw1jwd7kwhyc655765dz6af6k15392gg7p",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/afc892db74d65042031a093adb6010c4c3378422.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/086f619dd991a4d355c07837448244029fc2d9ab.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@afc892db...086f619d](https://github.com/nix-community/home-manager/compare/afc892db74d65042031a093adb6010c4c3378422...086f619dd991a4d355c07837448244029fc2d9ab)

* [`a6c74398`](https://github.com/nix-community/home-manager/commit/a6c743980e23f4cef6c2a377f9ffab506568413a) dunst: use `-config` flag when `configFile` is set
* [`b3d5ea65`](https://github.com/nix-community/home-manager/commit/b3d5ea65d88d67d4ec578ed11d4d2d51e3de525e) fastfetch: update example for JsonConfig settings
* [`8b7cdfce`](https://github.com/nix-community/home-manager/commit/8b7cdfceaf877086fba641bad4607f5db4c4002a) Translate using Weblate (Catalan)
* [`086f619d`](https://github.com/nix-community/home-manager/commit/086f619dd991a4d355c07837448244029fc2d9ab) flake.lock: Update
