### PR TITLE
niv nixpkgs: update 4e7d996a -> 4b2b2d5c

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4e7d996aa858660e3261b4834ab00415cfe9b0fe",
-        "sha256": "1dd7kzrs0pnmf03mxcbn06439rq8p5qpga5da6q3v4yfskjq64m2",
+        "rev": "4b2b2d5c8cbf659337c0d781b763def0c2da461f",
+        "sha256": "1aj6ylnzcsbxxbsifi9wyaz3fx72mz38gvk80bxcpvxg5vxm4qmf",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/4e7d996aa858660e3261b4834ab00415cfe9b0fe.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/4b2b2d5c8cbf659337c0d781b763def0c2da461f.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@4e7d996a...4b2b2d5c](https://github.com/nixos/nixpkgs/compare/4e7d996aa858660e3261b4834ab00415cfe9b0fe...4b2b2d5c8cbf659337c0d781b763def0c2da461f)

* [`634ceb1f`](https://github.com/NixOS/nixpkgs/commit/634ceb1fbc230ea1561a617bce5e4251f0a8fdf1) rosie: 1.3.0 -> 1.4.0
* [`a71502af`](https://github.com/NixOS/nixpkgs/commit/a71502aff04a5b04f9e0d3aeceb61eab8eab2ed5) nixos/borgmatic: added test
* [`9d94b98e`](https://github.com/NixOS/nixpkgs/commit/9d94b98e46f8cf5f8abdcdc3cf0a271071922bc8) nixos/borgmatic: refactor
* [`535ceaaa`](https://github.com/NixOS/nixpkgs/commit/535ceaaa0e7bce78a226f1cacf84b4b413391da1) nixos/networkd: allow IPv6OnlyPreferredSec in networkd.conf
* [`5e9ee3e3`](https://github.com/NixOS/nixpkgs/commit/5e9ee3e380f7934f420021eaf3a212524ee21461) xxhash: pkgConfigModules, drop flags
* [`381c7ccf`](https://github.com/NixOS/nixpkgs/commit/381c7ccf76adda7e88f56570c4189b2bdb1a34bd) x265: 3.5 -> 3.6
* [`e6bb2e63`](https://github.com/NixOS/nixpkgs/commit/e6bb2e638d731588ffa85fc5269ecda4772b5df2) libproxy: 0.5.6 -> 0.5.7
* [`366f8032`](https://github.com/NixOS/nixpkgs/commit/366f8032ceaddd094972ba27b77d3e7e00474533) libksba: 1.6.6 -> 1.6.7
* [`896027bc`](https://github.com/NixOS/nixpkgs/commit/896027bc0e89cbd9269b869c4dfe9179cf0f2a7e) publicsuffix-list: add update script
* [`31cf9da8`](https://github.com/NixOS/nixpkgs/commit/31cf9da817371c35695a17eaf28afaebb50baebf) publicsuffix-list: 0-unstable-2024-01-07 -> 0-unstable-2024-06-19
* [`cf6ae5b7`](https://github.com/NixOS/nixpkgs/commit/cf6ae5b73467083899565186a65d90d6c63315c8) fribidi: 1.0.14 -> 1.0.15
* [`1043d247`](https://github.com/NixOS/nixpkgs/commit/1043d2477e0059bd8dcbbb806578bab03a30e276) vyper: 0.3.10 -> 0.4.0
* [`5f897e2a`](https://github.com/NixOS/nixpkgs/commit/5f897e2abb090e4410159ea2aabb51626c1a0d0d) maccy: 0.28.0 -> 0.31.0
* [`f8f44e16`](https://github.com/NixOS/nixpkgs/commit/f8f44e161099a2a921fa643964992dc462729f47) Revert "db4: fix configure with llvm"
* [`91069620`](https://github.com/NixOS/nixpkgs/commit/91069620eaaa0cc8386d4589b6a6b93a284bbfa3) db4: fix pthread configure detection
* [`b8031896`](https://github.com/NixOS/nixpkgs/commit/b803189674cb5c15a5730dafa951208951749700) pam: packaging cleanups
* [`e8913e8f`](https://github.com/NixOS/nixpkgs/commit/e8913e8f3eb0a0f5c79ae394470bb95140beab95) SDL2: 2.30.4 -> 2.30.5
* [`5ef0a3a0`](https://github.com/NixOS/nixpkgs/commit/5ef0a3a0e5f067fd2650cf30c2d239320fa714b5) libical: fix strict deps
* [`df83a721`](https://github.com/NixOS/nixpkgs/commit/df83a721daa094fc6b15b24e94965821ebd01bec) xonsh: fix wrapper
* [`9e655beb`](https://github.com/NixOS/nixpkgs/commit/9e655bebf19dac0fabe9cd0895349c192269118c) dotool: 1.3 -> 1.5
* [`0f7da287`](https://github.com/NixOS/nixpkgs/commit/0f7da2878df8a34397026ca896de56b2e4244a5e) python312Packages.faether-format: init at 0.4.1
* [`ef936f76`](https://github.com/NixOS/nixpkgs/commit/ef936f760a58d8e22256540a6db4fa2c9e4de3a2) python312Packages.nemosis: init at 3.7.0
* [`72a442d4`](https://github.com/NixOS/nixpkgs/commit/72a442d42de52492082b0b0ec6efd68dc235d2af) cproto: 4.7v -> 4.7w
* [`5b2d9330`](https://github.com/NixOS/nixpkgs/commit/5b2d93300f55347b6ad2e15f907df91f6a25f555) nix-ld: 1.2.3 -> 2.0.0
* [`c68739f4`](https://github.com/NixOS/nixpkgs/commit/c68739f4f0c3d1b3d3278da299865d8be772a0be) bootstrap-tools-musl: match bootstrap-tools hardeningUnsupportedFlags
* [`b207b6ef`](https://github.com/NixOS/nixpkgs/commit/b207b6ef740dd402cfa96dac681c0523996835ae) cc-wrapper: add support for shadowstack hardening flag
* [`3ebc7bbf`](https://github.com/NixOS/nixpkgs/commit/3ebc7bbf61dfd9b0fa2bc65d6484ea9a44adb3e4) glibc: add option enableCETRuntimeDefault to runtime-enable CET by default
* [`7ec88581`](https://github.com/NixOS/nixpkgs/commit/7ec8858169be19adfb45cc98b8781a0c3dd127fd) telescope: 0.10 -> 0.10.1
* [`d042bd5c`](https://github.com/NixOS/nixpkgs/commit/d042bd5c3047f2ba0e713a668e9584ec9be7001b) nixops: Remove broken nixops plugins
* [`8848c9c1`](https://github.com/NixOS/nixpkgs/commit/8848c9c1d64a8b28f6921a2d1e3aee0cb992b99e) nixops: mark nixops-aws as broken and remove from the full list
* [`be0b28bc`](https://github.com/NixOS/nixpkgs/commit/be0b28bc8956e691e9761f6eb46cf367907bb4b4) rabbitvcs: remove
* [`3171c975`](https://github.com/NixOS/nixpkgs/commit/3171c975e7b6632aad45da03e394887d008568ca) fq: 0.11.0 -> 0.12.0
* [`41cae89e`](https://github.com/NixOS/nixpkgs/commit/41cae89e6b8a7f1f6fffd0e965c8db43e3e47db4) glibc: enableCETRuntimeDefault for pkgsExtraHardening
* [`227049e2`](https://github.com/NixOS/nixpkgs/commit/227049e2f3031ec30151a6854503c9a730ed992d) ox: 0.2.7 -> 0.3.0
* [`bd20a780`](https://github.com/NixOS/nixpkgs/commit/bd20a78042b3d35be9a500505bccf13cc567818b) slsa-verifier: 2.5.1 -> 2.6.0
* [`c2952baf`](https://github.com/NixOS/nixpkgs/commit/c2952baf6aca7471eccaff502875c8502d174f38) osrm-backend: 5.26.0 -> 5.27.1
* [`821d27e0`](https://github.com/NixOS/nixpkgs/commit/821d27e0c969fc2012705240d78f618590d30bff) visualvm: 2.1.8 -> 2.1.9
* [`20456039`](https://github.com/NixOS/nixpkgs/commit/20456039ec2c3c28b5fad1bf5b2c528b0d279ff0) libsvm: 3.32 -> 3.33
* [`bb39c065`](https://github.com/NixOS/nixpkgs/commit/bb39c065ad79624210b8f029ef0bcc59e7057814) vcpkg: 2024.06.15 -> 2024.07.12
* [`a596bb07`](https://github.com/NixOS/nixpkgs/commit/a596bb07c246bd8958794461fdff26a628c5afe4) vendir: 0.40.2 -> 0.41.0
* [`f35916e1`](https://github.com/NixOS/nixpkgs/commit/f35916e1d998a06f708fa5c85ff5783b1f701fe1) vcpkg-tool: 2024-06-10 -> 2024-07-10
* [`f2f8f302`](https://github.com/NixOS/nixpkgs/commit/f2f8f302fdaf59a90e8ab93ed910723a1f4aa236) nixos/swap: add progress to swapfile creation
* [`b10c9c48`](https://github.com/NixOS/nixpkgs/commit/b10c9c4824039b6b1fa57c2f4d246d710e5e9f81) gparted: fix GParted not running on Wayland
* [`8b3833de`](https://github.com/NixOS/nixpkgs/commit/8b3833de283d71ac31d820ae07823ae7cc8e1bde) paru: init at 2.0.3
* [`3d6784a1`](https://github.com/NixOS/nixpkgs/commit/3d6784a1adcdc90bfc37fa6d2a3253651e257ac1) sof-tools: 2.9 -> 2.10
* [`09a8a7dd`](https://github.com/NixOS/nixpkgs/commit/09a8a7ddbb43b1a5de1ee4cf934015cb09d4ac9e) waf: 2.1.1 -> 2.1.2
* [`3fb8f04f`](https://github.com/NixOS/nixpkgs/commit/3fb8f04fd426c02ec161706c8ea68f8a82e0934e) antidote: 1.9.6 -> 1.9.7
* [`242593b0`](https://github.com/NixOS/nixpkgs/commit/242593b0a06ebffe58b5fe27f977f01dd39a33ff) gcc11: 11.4.0 -> 11.5.0
* [`5f533e31`](https://github.com/NixOS/nixpkgs/commit/5f533e318c5b80f481afbec9125e7575709faea3) commonsDaemon: 1.3.4 -> 1.4.0
* [`87482f59`](https://github.com/NixOS/nixpkgs/commit/87482f591503c548bb44820c5cbd665a4aa69072) spring-boot-cli: 3.3.1 -> 3.3.2
* [`52e3f9db`](https://github.com/NixOS/nixpkgs/commit/52e3f9dbf40d7b0c4bfebee96ad021101dde45bc) xonsh: remove indefinite article from meta.description
* [`66c02758`](https://github.com/NixOS/nixpkgs/commit/66c027584373426c3d8707ec4933485ab4043289) openstack-config: remove hardcoded default password for the root account
* [`2cc76299`](https://github.com/NixOS/nixpkgs/commit/2cc76299592fb976313830db8fd6e7887e492d35) libgit2: 1.7.2 -> 1.8.1
* [`602760ce`](https://github.com/NixOS/nixpkgs/commit/602760ce42b83bf9071f52d97adcbebc046f5fe1) libgit2: fix incorrect recursive structure in tests
* [`1e8b1425`](https://github.com/NixOS/nixpkgs/commit/1e8b1425efef8829ea000f2a8da9a4903ff05a2c) python312Packages.pygit2: 1.14.1 -> 1.15.0
* [`e92ee335`](https://github.com/NixOS/nixpkgs/commit/e92ee335fa2a6599e18498a404a422993ad27fd4) pcre: update gnu config scripts
* [`97e18621`](https://github.com/NixOS/nixpkgs/commit/97e18621b0be225b24a341b7a8d7d050419cdb2f) libpipeline: update gnu config scripts
* [`d995c283`](https://github.com/NixOS/nixpkgs/commit/d995c2837451362fe7e8f44a9f914806f376ba24) scli: 0.7.4 -> 0.7.5
* [`ef593db9`](https://github.com/NixOS/nixpkgs/commit/ef593db9caff6d700c0c72ba03a7ee79a58c9575) systemd: re-enable bpf-framework
* [`cd8e0282`](https://github.com/NixOS/nixpkgs/commit/cd8e02828ae319868c096c3ad7d27425a68524af) meson: 1.4.1 -> 1.5.0
* [`f09ab69a`](https://github.com/NixOS/nixpkgs/commit/f09ab69a7e15a170060e7c459008f31c1d31b058) nixos/zerotierone: clean up local.conf symlinks unconditionally
* [`24917d46`](https://github.com/NixOS/nixpkgs/commit/24917d46ab276dcb25c2d0cf00a3faad60e72a1f) john: disable unfree code by default
* [`feabbe8b`](https://github.com/NixOS/nixpkgs/commit/feabbe8bc4e0d5b0390c823ee58206d20d05d52e) libpsl: make python both a build and runtime dependency
* [`488bac5e`](https://github.com/NixOS/nixpkgs/commit/488bac5e766600c87dca34eeb4c6648a92e4b357) w3m: update gnu config scripts
* [`53844218`](https://github.com/NixOS/nixpkgs/commit/538442183767c52b2c40f5e45e3b7fae139a3583) freebsd.libstdthreads: init
* [`f24b1939`](https://github.com/NixOS/nixpkgs/commit/f24b19390b7717773e1bc6775f99afed184756a8) docbook2x: add runtime dependency on iconv binary
* [`aac6eaa1`](https://github.com/NixOS/nixpkgs/commit/aac6eaa1e86430f0f3cf71a153b4e2c778253da0) poethepoet: 0.26.1 -> 0.27.0
* [`3f15de59`](https://github.com/NixOS/nixpkgs/commit/3f15de5959114a7b7b793b2fc9568b6605eb069d) wayland: don't propagate bin output
* [`2ea2276b`](https://github.com/NixOS/nixpkgs/commit/2ea2276b3032dc1ae8d21d23fd87b1fc5c3f0f66) texinfo: set texinfo_cv_sys_iconv_converts_euc_cn=yes when cross compiling version >= 7.1
* [`3a6026ad`](https://github.com/NixOS/nixpkgs/commit/3a6026ad2368c9f214eae6856c0eb7fb013e1577) python312Packages.cryptography: 42.0.8 -> 43.0.0
* [`f75d5032`](https://github.com/NixOS/nixpkgs/commit/f75d50324faf773abf9c66c04fa1ff1fe2bf0919) nodejs: use upstream patch instead of custom one
* [`070791fb`](https://github.com/NixOS/nixpkgs/commit/070791fba6ce4cf0ebb16e490f25397bcc562e59) nodejs_22: 22.4.1 -> 22.5.1
* [`e2514012`](https://github.com/NixOS/nixpkgs/commit/e2514012631946c9e6723dae89dfcb3699af928f) freecad: add freecad-wayland that runs on wayland natively
* [`dca354dd`](https://github.com/NixOS/nixpkgs/commit/dca354dd14e087e22a248fa5f1cee7c4dae2aa82) xapian: 1.4.25 -> 1.4.26
* [`551928bf`](https://github.com/NixOS/nixpkgs/commit/551928bf932b60163957cd51c19836122c8d9eaa) xapian: add (more) key reverse-dependencies to passthru.tests
* [`3cf28607`](https://github.com/NixOS/nixpkgs/commit/3cf28607c1403dc63479982796942b5023089e30) pipewire: remove superfluous args
* [`616637d8`](https://github.com/NixOS/nixpkgs/commit/616637d813b260d397a4bac3fe7202a15e4f3607) source-highlight: update gnu config scripts
* [`488168b7`](https://github.com/NixOS/nixpkgs/commit/488168b7c1d3732831ef9cf03ab28095135fec81) mpfr: update gnu config scripts
* [`df7a52b4`](https://github.com/NixOS/nixpkgs/commit/df7a52b48a0c7bdad72f5c81a4b9c0d8442cbfe3) libipt: Add libstdthreads dependency on FreeBSD
* [`beb34f1b`](https://github.com/NixOS/nixpkgs/commit/beb34f1b960494e167c1674e31d0beddf51cd647) gdb: mark support for FreeBSD
* [`c6c7efd8`](https://github.com/NixOS/nixpkgs/commit/c6c7efd88da1f6476ff01e5c8689b648e5939862) libwacom: Load config from /etc
* [`b9a250ea`](https://github.com/NixOS/nixpkgs/commit/b9a250eaedeb6292c93361404c13a088b628e7f6) storm: 2.6.2 -> 2.6.3
* [`0fef31c2`](https://github.com/NixOS/nixpkgs/commit/0fef31c2f0fc358c90fc9a03c51cb3a20cba251b) swagger-codegen3: 3.0.58 -> 3.0.59
* [`41eb430d`](https://github.com/NixOS/nixpkgs/commit/41eb430dc5b49481b81079d09214e5432ccb4f75) rke: 1.5.10 -> 1.6.0
* [`0ad5a4c2`](https://github.com/NixOS/nixpkgs/commit/0ad5a4c2f3419b0aac6337ba9007678b4894a7da) typescript: 5.5.3 -> 5.5.4
* [`2101706a`](https://github.com/NixOS/nixpkgs/commit/2101706acf086f623a132cc288c3a02d444b8d60) python312Packages.pikepdf: 9.0.0 -> 9.1.0
* [`c2d8a912`](https://github.com/NixOS/nixpkgs/commit/c2d8a9127e0ae5a29d925213ef9dab3a34be29f2) kubebuilder: 4.1.0 -> 4.1.1
* [`2c25ed66`](https://github.com/NixOS/nixpkgs/commit/2c25ed6677c3324e2333a7f73a5c18ba76981397) kuma-dp: 2.8.1 -> 2.8.2
* [`0c225068`](https://github.com/NixOS/nixpkgs/commit/0c22506820c7f8a1322d4e753dd8b598df780b45) myanon: 0.5 -> 0.6
* [`3f547bd5`](https://github.com/NixOS/nixpkgs/commit/3f547bd512a485877a71f5a9b1f84377fb7629e6) libopenmpt: 0.7.8 -> 0.7.9
* [`85ee1d8a`](https://github.com/NixOS/nixpkgs/commit/85ee1d8a3ce055caef35e3a1d44917838d0f4274) nco: 5.2.6 -> 5.2.7
* [`0b29e62a`](https://github.com/NixOS/nixpkgs/commit/0b29e62aa1af595290d59c9b046ee8158e4181e8) Revert "wayland: don't propagate bin output"
* [`e5475349`](https://github.com/NixOS/nixpkgs/commit/e54753495c34c8fc6df4622fce91ec8370a40e06) linux/common-config: restrict access to dmesg
* [`bf2d0404`](https://github.com/NixOS/nixpkgs/commit/bf2d040432f7a98c67c124141928d748e3e721bd) postgresql: 15 -> 16 for 24.11+
* [`89b8ad68`](https://github.com/NixOS/nixpkgs/commit/89b8ad6898068a2c9b78a9936a0fd50833b4cc5a) curl: 8.8.0 -> 8.9.0
* [`e2bc2e52`](https://github.com/NixOS/nixpkgs/commit/e2bc2e52568594de34f47811203777d9d3d0b27f) tokyonight-gtk-theme: 0-unstable-2024-06-27 -> 0-unstable-2024-07-22
* [`f951f5e2`](https://github.com/NixOS/nixpkgs/commit/f951f5e29630c72464662b1fcb7fa432b26b1884) python312Packages.validators: 0.28.0 -> 0.33.0
* [`8e14f63b`](https://github.com/NixOS/nixpkgs/commit/8e14f63b37be18a0e7b7a533235de31b933bc0c8) libxml2: 2.13.2 -> 2.13.3
* [`dba5e28f`](https://github.com/NixOS/nixpkgs/commit/dba5e28f7212ebc7197402faa5e93153f1a71662) gvproxy: 0.7.3 -> 0.7.4
* [`3c6127cf`](https://github.com/NixOS/nixpkgs/commit/3c6127cf0129f8d82e5350ac4b0474db198b3636) cc-wrapper: exclude clang flags when cpp
* [`54f2c3cd`](https://github.com/NixOS/nixpkgs/commit/54f2c3cd0d5ea3c8cde91ee78fb15dcabac6924d) xorg.libX11: fix cpp usage under llvm
* [`6bb17e1b`](https://github.com/NixOS/nixpkgs/commit/6bb17e1b038b642d447aca6a0faa438594543598) firewalld-gui: 2.2.0 -> 2.2.1
* [`6a163e2a`](https://github.com/NixOS/nixpkgs/commit/6a163e2a36a27e0e52b098b43342bd8531c9ccd9) rustc: fix building with llvm ([nixos/nixpkgs⁠#320432](https://togithub.com/nixos/nixpkgs/issues/320432))
* [`be8112b3`](https://github.com/NixOS/nixpkgs/commit/be8112b3e2a7025b0e79c70fc13ad39c086f71cb) protobuf: 25.3 -> 25.4
* [`81a1e039`](https://github.com/NixOS/nixpkgs/commit/81a1e0392be0d374675207a29fe0ae7ef5f415f8) python3Packages.geoparquet: init at 0.7.5
* [`1144d46f`](https://github.com/NixOS/nixpkgs/commit/1144d46f9510b8c31d0195e8049caa0df3eb3fec) treewide: Rename android `sdkVer` and `ndkVer`
* [`35e5943d`](https://github.com/NixOS/nixpkgs/commit/35e5943d69e0bfd7d3f265bf91f27b3c32b41d1b) lib.systems: throw if `sdkVer` or `ndkVer` are used for android.
* [`a169c2d3`](https://github.com/NixOS/nixpkgs/commit/a169c2d3eeac4bf810dff278cfb45a0aaea849a7) libva: fix building with llvm
* [`b2d88d41`](https://github.com/NixOS/nixpkgs/commit/b2d88d41e70c93a4cf8fbe8ab20834a854a7a58a) vala: remove unconditional work around for clang 16 function pointer errors
* [`f9a16f2b`](https://github.com/NixOS/nixpkgs/commit/f9a16f2beeee07a0fc5c4a07fe8832d94d5b7e7f) _1oom: 1.8.1 -> 1.10.1
* [`a065bf03`](https://github.com/NixOS/nixpkgs/commit/a065bf03e55c78165955c6fa58f85ebac091ad4a) _1oom: format to nixfmt-rfc-style
* [`9852a4bb`](https://github.com/NixOS/nixpkgs/commit/9852a4bb24dd28b24d549a4c346026e182b2ebf9) gdbm: migrate to by-name
* [`68b4bf30`](https://github.com/NixOS/nixpkgs/commit/68b4bf305cd7ea614cb6d77f447613a7a5a0d192) gdbm: rework
* [`bdbc71bf`](https://github.com/NixOS/nixpkgs/commit/bdbc71bf3907be2c2a70d53db974a7e562a60b82) gdbm: nixfmt-rfc-style
* [`9cbf7192`](https://github.com/NixOS/nixpkgs/commit/9cbf7192e110d6b7bb9eb2e46f5f49d79453c696) gdbm: 1.23 -> 1.24
* [`cccb368d`](https://github.com/NixOS/nixpkgs/commit/cccb368dc66404b9aecdae495e73f1a0f1e93180) libivykis: 0.42.4 -> 0.43.1
* [`6149730a`](https://github.com/NixOS/nixpkgs/commit/6149730abeadc8ec6d739d4da648d954ff11e4c1) kdePackages: fix build under real strictDeps
* [`8d6d118c`](https://github.com/NixOS/nixpkgs/commit/8d6d118c6b8a4fa4648bc9caa4667b057c55e16c) libcgroup: 3.0 -> 3.1
* [`7dfd840d`](https://github.com/NixOS/nixpkgs/commit/7dfd840d4f7e3b763a2ee12674111d0a4736c795) avalanchego: 1.11.9 -> 1.11.10
* [`64a86018`](https://github.com/NixOS/nixpkgs/commit/64a8601822413526cbdaafea37eea21e4775e8a5) python312Packages.inflect: add missing dependency + cleaning
* [`8bee2ced`](https://github.com/NixOS/nixpkgs/commit/8bee2ceda23703e976581190bae98465c65253b1) python3Packages.email-validator: 2.1.2 -> 2.2.0
* [`29c01705`](https://github.com/NixOS/nixpkgs/commit/29c0170563e90b23f87e613d90dee37e31b8da0f) python3Packages.pydantic-core: 2.18.4 -> 2.20.1
* [`14efd3de`](https://github.com/NixOS/nixpkgs/commit/14efd3de2c6d387cfad6ae7771fc98818ae24e77) python3Packages.pydantic: 2.7.4 -> 2.8.2
* [`59c3e5ec`](https://github.com/NixOS/nixpkgs/commit/59c3e5ecf8513fa4c6b7c0b77620166bde061757) python3Packages.pydantic-settings: 2.3.2 -> 2.3.4
* [`0acf0b1b`](https://github.com/NixOS/nixpkgs/commit/0acf0b1b2bcfe3be0d736de8f5335cd218c3a4c3) python3Packages.pydantic-extra-types: 2.8.2 -> 2.9.0
* [`5e7e9567`](https://github.com/NixOS/nixpkgs/commit/5e7e9567f875abb9609d92a092bd336fb0dd6b73) tvm: 0.16.0 -> 0.17.0
* [`d131ecd6`](https://github.com/NixOS/nixpkgs/commit/d131ecd6285146d8c99405505e5a685b97a1573c) libavif: propagate the newly-required dependencies
* [`7a01a1bd`](https://github.com/NixOS/nixpkgs/commit/7a01a1bd6b382c7baef0e0a5526010dd02a57dfe) Revert "kdePackages.kimageformats: explicitly add libavif dependencies"
* [`daa97965`](https://github.com/NixOS/nixpkgs/commit/daa97965e10084840e428d6e1db258c2567aefa3) Revert "haskell-builder.nix: work around useSystemCoreFoundationFramework hook"
* [`e88f0cf2`](https://github.com/NixOS/nixpkgs/commit/e88f0cf2f292f1ff0d0b89eea2411939336fd01f) Revert "ruby_3_3: work around useSystemCoreFoundationFramework"
* [`2c549528`](https://github.com/NixOS/nixpkgs/commit/2c549528478664ab79c0819660bda95ade102826) darwin.apple_sdk.frameworks: remove NIX_COREFOUNDATION_RPATH hook
* [`bc32f013`](https://github.com/NixOS/nixpkgs/commit/bc32f013360a79114bbfbe597be5894ab3e4a791) meson: fix extraframework dependencies on case-sensitive APFS
* [`59a69abc`](https://github.com/NixOS/nixpkgs/commit/59a69abc4d96c7fe2741467455ec2e5bb2e8c3dd) python312Packages.sure: drop nose dependency
* [`9a5faca2`](https://github.com/NixOS/nixpkgs/commit/9a5faca25fb60414bea972ed5c8ce95b500441f5) python312Packages.sure: add sigmanificient to maintainers
* [`3b6f64bb`](https://github.com/NixOS/nixpkgs/commit/3b6f64bb88bd0ac8ce31b85068e5df19add2296a) python312Packages.sure: migrate to pyproject
* [`b31eae6c`](https://github.com/NixOS/nixpkgs/commit/b31eae6c5aa74a513ae9213db46137e4681c99a3) udns: 0.5 -> 0.6
* [`ce10eed7`](https://github.com/NixOS/nixpkgs/commit/ce10eed7c883529fd70d61f8c0c64984a9d22468) python3Packages.passlib: fix bcrypt version compatibility issue
* [`a414c8b4`](https://github.com/NixOS/nixpkgs/commit/a414c8b4ac37780260339086fd04dfb659377986) abpoa: 1.5.1 -> 1.5.2
* [`c62608da`](https://github.com/NixOS/nixpkgs/commit/c62608da31e6cd2f52ac3885123a57d25e19aa2e) libjodycode: 3.1 -> 3.1.1
* [`d21d7e96`](https://github.com/NixOS/nixpkgs/commit/d21d7e96647d706bfa906bf95e67e6aca13c3a78) libosmocore: 1.9.3 -> 1.10.0
* [`00cb5c8f`](https://github.com/NixOS/nixpkgs/commit/00cb5c8fc429437faae24eea9d859850a6f9c3ce) cmake: use addToSearchPath
* [`f9a7cf52`](https://github.com/NixOS/nixpkgs/commit/f9a7cf528b2369337b1c3f47bd2ecd56d34aa3be) meson: add support for NIXPKGS_CMAKE_PREFIX_PATH
* [`8c9c8ade`](https://github.com/NixOS/nixpkgs/commit/8c9c8ade2f88a85ccdd4858cc802d7b7d6c48fe0) cmake: fix strictDeps
* [`7b9761cb`](https://github.com/NixOS/nixpkgs/commit/7b9761cb23db85024b08b60887cc3b39179705f1) lksctp-tools: 1.0.17 -> 1.0.19
* [`8f3ceb4a`](https://github.com/NixOS/nixpkgs/commit/8f3ceb4a81681a2fa097f8e45c5ae229e5656ec1) corrscope: 0.9.1 -> 0.10.0
* [`b3e2ac82`](https://github.com/NixOS/nixpkgs/commit/b3e2ac82e27e211533488e39de17890848dd5daf) sozu: 0.15.19 -> 1.0.4
* [`23de3579`](https://github.com/NixOS/nixpkgs/commit/23de357949b5f9a3ac31aaa95b00a9b428108575) nss: 3.101.1 -> 3.101.2
* [`65c81d4e`](https://github.com/NixOS/nixpkgs/commit/65c81d4eaec6dc8acf7c5b84caf55fc029442f45) zig: add cc wrapper
* [`e9fb54b2`](https://github.com/NixOS/nixpkgs/commit/e9fb54b256fb4b63436a617345879953c885a4bd) cc-wrapper: add zig
* [`c472b840`](https://github.com/NixOS/nixpkgs/commit/c472b840a3a637b09b0ade8287a987a6cbe49639) pkgs/stdenv/cross: add zig
* [`945426bc`](https://github.com/NixOS/nixpkgs/commit/945426bccc502f0b93956c0a41361d325dbf0712) zig: add stdenv
* [`2d4c9e69`](https://github.com/NixOS/nixpkgs/commit/2d4c9e69663fd844c7d7b944588c1bfd00ad0413) pkgs/top-level/{release,stage}.nix: add zig package set
* [`f822fae2`](https://github.com/NixOS/nixpkgs/commit/f822fae2bea397be89ec825238cdde084a7ec35f) meson: include patch for zig cc
* [`8045879c`](https://github.com/NixOS/nixpkgs/commit/8045879c8876fc0dcf8219a93b8e6a6b21e71bb6) sqlite: fix build issue with zig cc
* [`9f589ea3`](https://github.com/NixOS/nixpkgs/commit/9f589ea3a088fd2cdca91a14c0f59fb2331f972f) arocc: init at 0-unstable-06-01
* [`fbeb9728`](https://github.com/NixOS/nixpkgs/commit/fbeb9728c878038500f482abb9bb288cbbd8ec22) arxiv-latex-cleaner: 1.0.6 -> 1.0.8
* [`a0b73eb2`](https://github.com/NixOS/nixpkgs/commit/a0b73eb252b6907b51b8b8eebe8685d7e66a5657) maintainers: add diadatp
* [`5ce990eb`](https://github.com/NixOS/nixpkgs/commit/5ce990eb576e6539fee662b510adf93bd1cc22ee) doc/stdenv: add section on shadowstack hardening flag
* [`a30f7948`](https://github.com/NixOS/nixpkgs/commit/a30f794865e77b6fc3a9a6474970173b18356b45) pcre: expose enableJit argument, disable shadowstack when enabled
* [`7a4736e1`](https://github.com/NixOS/nixpkgs/commit/7a4736e1ef32baa85208cd08bf2a146f15659142) llvm: disable shadowstack hardening flag
* [`b84da125`](https://github.com/NixOS/nixpkgs/commit/b84da125d0021cb350b486b254a1649093a17e71) lix: disable shadowstack hardening flag
* [`0dacfda0`](https://github.com/NixOS/nixpkgs/commit/0dacfda0af4dfcad051341e6e2dd47b3bbd4407b) nix: disable shadowstack hardening flag
* [`48bde3a1`](https://github.com/NixOS/nixpkgs/commit/48bde3a18998965707d7243ff976095f964ba987) cc-wrapper: add support for pacret hardening flag on aarch64
* [`745046d2`](https://github.com/NixOS/nixpkgs/commit/745046d26650d11880d1a6612dab1d1a711487ad) doc/stdenv: hardening flags: add section on pacret hardening flag
* [`97c400a0`](https://github.com/NixOS/nixpkgs/commit/97c400a0e8f9703f398d48218229bd5955c345f5) cc-wrapper: fix -Bprefix to not confuse lib/libc++.so and bin/c++
* [`317929b8`](https://github.com/NixOS/nixpkgs/commit/317929b849a8171ba6f85425afd96a074a15de29) libjodycode: add jdupes as reverse dependency
* [`d8c8ee0c`](https://github.com/NixOS/nixpkgs/commit/d8c8ee0c11f95a550a315cfecb449f2e028af812) libjodycode: nixfmt
* [`3c6109c6`](https://github.com/NixOS/nixpkgs/commit/3c6109c6883941c7e07e5d8593c98e901b1093df) maintainers: add DrymarchonShaun
* [`37671895`](https://github.com/NixOS/nixpkgs/commit/37671895b59d8c26c23c6682f2bda62c128969cc) arma3-unix-launcher: init at 413
* [`193b9808`](https://github.com/NixOS/nixpkgs/commit/193b98084a08ed2b8b55880f77f0525ed915e16e) ffmpeg-headless: enable additional encoders by default
* [`7cb636da`](https://github.com/NixOS/nixpkgs/commit/7cb636da6721b6c99342e8a8a9017b39f50040f6) rustc: wrap llvmPackages when using LLVM with callPackage
* [`332946ab`](https://github.com/NixOS/nixpkgs/commit/332946ab2fc75123b65f7b0c5ec66a44da084462) meson: 1.5.0 -> 1.5.1
* [`bd872b4a`](https://github.com/NixOS/nixpkgs/commit/bd872b4a778d36c3f1fdd8dd123673c84b68fe36) stdenv: fix unbound NIX_LOG_FD in `nix develop`
* [`9fc48e3b`](https://github.com/NixOS/nixpkgs/commit/9fc48e3b7420527bd4c86b82cc0464d1d2440ff0) python312packages.paramz: drop nose dependency
* [`af6f4306`](https://github.com/NixOS/nixpkgs/commit/af6f4306abc61dda69aca9b827db8c40748b34e6) Revert "libsForQt5.kimageformats: provide dav1d, libaom and libyuv"
* [`1014f47b`](https://github.com/NixOS/nixpkgs/commit/1014f47bcbf98eba33cee9f36f95c60d4f593dfa) xorg.libX11: 1.8.9 -> 1.8.10
* [`5f2e83c7`](https://github.com/NixOS/nixpkgs/commit/5f2e83c77747e3eaa3b66854d0d697c42ab740bf) xmlto: 0.0.28 -> 0.0.29
* [`cd23e5ec`](https://github.com/NixOS/nixpkgs/commit/cd23e5ec5ebb56e0dd633ebb1028b0ce5fdf928e) python312Packages.pydantic: tests don't depend on faker
* [`1760a709`](https://github.com/NixOS/nixpkgs/commit/1760a7098240cb4d8a7ca334e15c7377e88e274f) xorg.appres: 1.0.6 -> 1.0.7
* [`b34a1239`](https://github.com/NixOS/nixpkgs/commit/b34a123911b3c53af5e61800ce6e7a4766ccb285) xorg.xconsole: 1.0.8 -> 1.1.0
* [`1767a127`](https://github.com/NixOS/nixpkgs/commit/1767a1279f87417b200d7afba9eaaadb14ab4bcc) xorg.xfs: 1.2.1 -> 1.2.2
* [`08cd0641`](https://github.com/NixOS/nixpkgs/commit/08cd0641c3e6c90d87d7f11efba0f8c1fa61beec) groonga: 14.0.5 -> 14.0.6
* [`d6977767`](https://github.com/NixOS/nixpkgs/commit/d6977767d39d50a830aaf91e26e750cf6f0dbbf1) gabutdm: 2.5.0 -> 2.6.0
* [`331fbac6`](https://github.com/NixOS/nixpkgs/commit/331fbac69c39a060a26b32a36d3d5bd81dcec9e9) python312Packages.pymemcache: modernize
* [`42e7fd46`](https://github.com/NixOS/nixpkgs/commit/42e7fd46e76d48d07874635d1873c72dee3ebd72) nixos/nvidia-container-toolkit: add device-name-strategy option
* [`53daf0d2`](https://github.com/NixOS/nixpkgs/commit/53daf0d29ff4cef99e08852f3d1711bb3c9d1e7a) SDL2: apply formatting
* [`1e5b7660`](https://github.com/NixOS/nixpkgs/commit/1e5b7660b2327b2c66bcdf05a53d9433b6748d49) postgresql: fix postgis
* [`424415e7`](https://github.com/NixOS/nixpkgs/commit/424415e7564eeb62350fae24a0c3c4c020708e30) nixos/systemd-boot: Fix 'bootctl update' regression
* [`89700ef3`](https://github.com/NixOS/nixpkgs/commit/89700ef3d9dbb87fd480f9dd93c92f18ad6886f4) systemd: 256.2 -> 256.4
* [`0bfa3d04`](https://github.com/NixOS/nixpkgs/commit/0bfa3d044d3f08b5aa65eb89f09b029f1683f864) Revert "darktable: fix build"
* [`0f37de9f`](https://github.com/NixOS/nixpkgs/commit/0f37de9fe637b5dcb6ecb3921515f2e7d323b618) aws-c-auth: 0.7.22 -> 0.7.23
* [`3f900de5`](https://github.com/NixOS/nixpkgs/commit/3f900de54047c932b67c226980669ac4c394e254) nstool: init at 1.9.0
* [`e4f405d0`](https://github.com/NixOS/nixpkgs/commit/e4f405d002ba79e048d5bc582608d54629cd01c1) python3Packages.motor: 3.4.0 -> 3.5.1
* [`2fecb943`](https://github.com/NixOS/nixpkgs/commit/2fecb94326ee487375104a418bd33b72b72dfee1) python3Packages.pymongo: 4.7.3 -> 4.8.0
* [`d0dd8b9f`](https://github.com/NixOS/nixpkgs/commit/d0dd8b9ff24d707ede81c893fb96af9fbe673195) rPackages: migrate generated code to JSON
* [`7224c89e`](https://github.com/NixOS/nixpkgs/commit/7224c89e7282f549259726bdc3e4dc213f50faac) doc: update R section to mention .json files
* [`84c30688`](https://github.com/NixOS/nixpkgs/commit/84c30688a9effa65e8aeac962194c4618aa7e674) jdupes: 1.27.3 -> 1.28.0
* [`7a8913b2`](https://github.com/NixOS/nixpkgs/commit/7a8913b2d10174a8f17ce5b0925da0be77f1394e) jdupes: point to new homepage link, cleanup
* [`51df2b8f`](https://github.com/NixOS/nixpkgs/commit/51df2b8f014ecd030c4fa8422dc31673c6214188) pythonPackages.sure: fix eval
* [`20a58a02`](https://github.com/NixOS/nixpkgs/commit/20a58a024ea7fce459e35849bc8a23d8cbfc2dcf) python3Packages.rply: 0.7.7 -> 0.7.8
* [`12ed8307`](https://github.com/NixOS/nixpkgs/commit/12ed83072543d9477d983ee8eb3a15ea51064d24) python3Packages.uplc: 1.0.4 -> 1.0.6
* [`6a295ece`](https://github.com/NixOS/nixpkgs/commit/6a295ece91bdc591b5a71a371cc918e5fc464981) python3Packages.pluthon: 0.5.3 -> 1.0.0
* [`0764ddb0`](https://github.com/NixOS/nixpkgs/commit/0764ddb0a3052bc0d20afd264d0be357486ed3cb) opshin: 0.21.2 -> 0.22.0
* [`43e57e45`](https://github.com/NixOS/nixpkgs/commit/43e57e455edaafe99151f6c5ca892c72f1aaaa5b) cyberpunk-neon: init at 0-unstable-2024-02-23
* [`e8e29b13`](https://github.com/NixOS/nixpkgs/commit/e8e29b13a0365ae534929b09fea814fc414cd303) pgmoneta: 0.12.0 -> 0.13.0
* [`117d6362`](https://github.com/NixOS/nixpkgs/commit/117d6362c25e3a6f9fcd5ac45207f66dde51ad5c) zchunk: migrate to by-name
* [`86df4432`](https://github.com/NixOS/nixpkgs/commit/86df4432f403293805bebb1d8c1a827a28f8723f) zchunk: nixfmt-rfc-style
* [`bb5c5eb3`](https://github.com/NixOS/nixpkgs/commit/bb5c5eb3b021e3fdadbdfb4ac4404593866ae886) zchunk: rework
* [`8ee5cd86`](https://github.com/NixOS/nixpkgs/commit/8ee5cd86fa7e9c1d6ae37918513c9238238b8625) zchunk: add version test
* [`7b3df1d5`](https://github.com/NixOS/nixpkgs/commit/7b3df1d53b90330dc6d46b6bb8092bc5104cb5e8) zchunk: 1.4.0 -> 1.5.1
* [`1c26ee08`](https://github.com/NixOS/nixpkgs/commit/1c26ee085359196eb87a94823ae50f35868c9f4c) wabt: 1.0.35 -> 1.0.36
* [`6c8efe27`](https://github.com/NixOS/nixpkgs/commit/6c8efe27e448571e942deb7af960adf2e93811b4) router: 1.51.0 -> 1.52.0
* [`2f626825`](https://github.com/NixOS/nixpkgs/commit/2f62682564b8b8d402e7a54295323962ad0834b7) emacs: remove one unneeded line from genericBuild
* [`c7ce9ed4`](https://github.com/NixOS/nixpkgs/commit/c7ce9ed4733bf46569d9fed88730d869807996f4) emacs: remove unneeded code from genericBuild
* [`6b3965ed`](https://github.com/NixOS/nixpkgs/commit/6b3965ed806c849deddf162013396f3e294644b7) emacs: move emacs and texinfo to nativeBuildInputs in genericBuild
* [`0b51f54b`](https://github.com/NixOS/nixpkgs/commit/0b51f54b8f6b2c6fba77166390ff1cda657d4ca7) pipewire: 1.2.1 -> 1.2.2
* [`204bb970`](https://github.com/NixOS/nixpkgs/commit/204bb970670a4562e1b9960a6449777f35ba90b4) mesa: 24.1.4 -> 24.1.5
* [`00468e0f`](https://github.com/NixOS/nixpkgs/commit/00468e0fa02fa88bf2d6035aa48e745065fd94f7) prowlarr: 1.20.1.4603 -> 1.21.2.4649
* [`07531e79`](https://github.com/NixOS/nixpkgs/commit/07531e7941bdd7f77bad9d2bb2c9dd6e0ae02dca) oh-my-posh: 21.17.2 -> 22.4.0
* [`a76707e8`](https://github.com/NixOS/nixpkgs/commit/a76707e813b56ed367c0683ad7e2e4a06248c5d2) bash: 5.2p26 -> 5.2p32
* [`b62cfa99`](https://github.com/NixOS/nixpkgs/commit/b62cfa99c3583b5c77490b0875390d0d813706a5) bash: add upstream fix for `pop_var_context` error
* [`c47a1e70`](https://github.com/NixOS/nixpkgs/commit/c47a1e701df7f00352b8cf401fa79c0d2f5fcc59) stdenv: make sure the `env-vars` file created is not world readable
* [`2168c0df`](https://github.com/NixOS/nixpkgs/commit/2168c0df8da6878c1f338cc780132f7f961908f8) mercurial: 6.8 -> 6.8.1
* [`1085c876`](https://github.com/NixOS/nixpkgs/commit/1085c876681629f08939513ccab7b7f060d79a57) jitsi-meet-prosody: 1.0.8043 -> 1.0.8091
* [`b0b178fc`](https://github.com/NixOS/nixpkgs/commit/b0b178fc293ad71c35d3ac84e8ac856bd0d3492b) pahole: fix clang kernel build
* [`e53cf6ca`](https://github.com/NixOS/nixpkgs/commit/e53cf6ca74e8faaa5081137eb367cda363444c07) ffmpeg_4: 4.4.4 -> 4.4.5
* [`17eff57f`](https://github.com/NixOS/nixpkgs/commit/17eff57f75fc50d3117b544887f73523b086e5c1) mysql84: 8.4.1 -> 8.4.2
* [`e4bb50af`](https://github.com/NixOS/nixpkgs/commit/e4bb50afcbd3201eb9e2f9ffe398627e606b5040) abseil-cpp: 20240116.2 -> 20240722.0
* [`94e7951c`](https://github.com/NixOS/nixpkgs/commit/94e7951cba0b5d9c3aeb048e34e60773f056596f) glab: 1.41.0 -> 1.45.0
* [`1327403c`](https://github.com/NixOS/nixpkgs/commit/1327403cbe97566c648e22879850a5ed631c5a01) libtheora: migrate to by-name
* [`a8a6cb7a`](https://github.com/NixOS/nixpkgs/commit/a8a6cb7a0960ceb6599b1a09828402c1fc382336) libtheora: format with nixfmt
* [`b44d3ef4`](https://github.com/NixOS/nixpkgs/commit/b44d3ef41639ac3654207ea29fece05d9740f7bd) libtheora: modernize
* [`3a0ea49b`](https://github.com/NixOS/nixpkgs/commit/3a0ea49b6484b4074462ba884f441274942b1445) libtheora: add pkg-config test
* [`a654a5db`](https://github.com/NixOS/nixpkgs/commit/a654a5db5119bce50dfae0a77c3e7240dc58b56f) libtheora: add getchoo as maintainer
* [`5e48c437`](https://github.com/NixOS/nixpkgs/commit/5e48c4378570b4783b975fa6cb80a87ecf702159) libtheora: add validatePkgConfig hook
* [`c08f0003`](https://github.com/NixOS/nixpkgs/commit/c08f00030a5a1a6f8d80c175b856253c8d84f17e) ibus-engines.m17n: 1.4.30 -> 1.4.31
* [`1213f4e3`](https://github.com/NixOS/nixpkgs/commit/1213f4e3f2d61be86a0a8aaaeeaf669ead570d00) kallisto: 0.50.1 -> 0.51.0
* [`8a4db5b6`](https://github.com/NixOS/nixpkgs/commit/8a4db5b604dc0ddc3c3a690ec1c795110ca0ecca) aichat: 0.19.0 -> 0.20.0
* [`7166d524`](https://github.com/NixOS/nixpkgs/commit/7166d5242f80a0ea5aff8dbbe04e92946be79e25) nexusmods-app: reformat
* [`e54e9fac`](https://github.com/NixOS/nixpkgs/commit/e54e9fac95aed076ec5532a4a1b4f030cd4ad853) nexusmods-app: cleanup tests & `mainProgram` refs
* [`1148136d`](https://github.com/NixOS/nixpkgs/commit/1148136d367925d1e72c453eeb8aa95ff0bec8c4) nexusmods-app: refactor "unfree" variant
* [`c96bdd6d`](https://github.com/NixOS/nixpkgs/commit/c96bdd6d39e01d69badec83e7b80e6e593c5a8c7) ctpl: 0.3.4 -> 0.3.5
* [`d632bcd6`](https://github.com/NixOS/nixpkgs/commit/d632bcd61e9284e2ad378d9b1eb3f1366fb3ef6d) nph: init at 0.6.0
* [`8b204c1f`](https://github.com/NixOS/nixpkgs/commit/8b204c1fff72c0ad4c2df5feba4dc34622562a9b) sudo-font: 1.3 -> 1.4
* [`9b7f1a39`](https://github.com/NixOS/nixpkgs/commit/9b7f1a3913168bc9b9c070dbc9720dad1d06b49c) glslang: add dev and lib outputs to prevent cross comp issues
* [`e352a923`](https://github.com/NixOS/nixpkgs/commit/e352a923ef76017a7a4e7f4c8677295f04ae7eba) rPackages: refactor code generation to output JSON
* [`dc305dc6`](https://github.com/NixOS/nixpkgs/commit/dc305dc655a051083fe68bcb7696dfd59f011545) linuxPackages_6_10.zfs_unstable: unmark broken
* [`967b47b0`](https://github.com/NixOS/nixpkgs/commit/967b47b0065b1304aad4e3a016dec88fd8a500a3) lint-staged: 15.2.7 -> 15.2.8
* [`ba0d4952`](https://github.com/NixOS/nixpkgs/commit/ba0d495264c67cdb306a3aa7200e8ed7ebb548ae) linux_6_8,linux_6_9: remove
* [`b79c216d`](https://github.com/NixOS/nixpkgs/commit/b79c216dcfce8b55fdf1b4cf5df7d5a12bb9d271) calamares: 3.3.3 -> 3.3.8
* [`7d044a3d`](https://github.com/NixOS/nixpkgs/commit/7d044a3d41fdd3bc5afa8475ccdf5e945e32bf45) cmark: 0.31.0 -> 0.31.1
* [`95a721b5`](https://github.com/NixOS/nixpkgs/commit/95a721b533777eb4536c590f11477ce8e6cb3e0b) freeswitch: 1.10.11 -> 1.10.12
* [`a30c3615`](https://github.com/NixOS/nixpkgs/commit/a30c3615d340295be7f9f4bb0017f05c67db2725) inxi: 3.3.34-1 -> 3.3.35-1
* [`2c15c76d`](https://github.com/NixOS/nixpkgs/commit/2c15c76d47101962a6ca564a6eb048e9596edec9) pipewire: restore enableSystemd option
* [`ab783af3`](https://github.com/NixOS/nixpkgs/commit/ab783af38b189a73bcd455cfe9420ff934684464) pipewire: document enableSystemd maintainership
* [`a14c557f`](https://github.com/NixOS/nixpkgs/commit/a14c557f663f0c58844ca44226f3032513ee09c3) tlrc: fix build on darwin
* [`c97ce2ac`](https://github.com/NixOS/nixpkgs/commit/c97ce2ac54766517ef8c4eee796b4000220053ff) cbor-diag: 0.8.7 -> 0.8.8
* [`9f937f3f`](https://github.com/NixOS/nixpkgs/commit/9f937f3f985c4c8c0e8adbf6256c40d912e41706) cbor-diag: add amesgen as maintainer
* [`50118841`](https://github.com/NixOS/nixpkgs/commit/50118841a98e157bd8e186714f23853ffd82d24f) cbor-diag: move to by-name
* [`f91fb167`](https://github.com/NixOS/nixpkgs/commit/f91fb1678a4bdbb276ccb39927da059f9dfb4a14) gsl: 2.7.1 -> 2.8
* [`5bc5f138`](https://github.com/NixOS/nixpkgs/commit/5bc5f138bf15050eebabf80b6fa93178d47c3c69) python312Packages.pygsl: fix build with gsl 2.8
* [`64e18ca9`](https://github.com/NixOS/nixpkgs/commit/64e18ca9ffa1d4c4538c18118c105ebedb0fc5db) hyperv-daemons: fix fcopy build and nixfmt-rfc-style
* [`eeae44a1`](https://github.com/NixOS/nixpkgs/commit/eeae44a1edcaf5b6ecf8f564464ad9c3b173c799) haskellPackages.hledger_1_34: add overrides for dependencies and extra files
* [`c336215d`](https://github.com/NixOS/nixpkgs/commit/c336215d593891f72364b2746c673b5297bfb250) maintainers: add jhollowe
* [`28819016`](https://github.com/NixOS/nixpkgs/commit/28819016efe604ef8d93fddcdf49a4630ac84b9d) hamrs: init at 1.0.7
* [`89db3afb`](https://github.com/NixOS/nixpkgs/commit/89db3afb1fcea0ed49e8af537a9de331b2441878) jadx: fix linux build, remove native deps
* [`4650657f`](https://github.com/NixOS/nixpkgs/commit/4650657fbc3a73db9c207a42168f875fb8d2b787) rabbitmq-server: 3.13.3 -> 3.13.6
* [`3f190aaa`](https://github.com/NixOS/nixpkgs/commit/3f190aaad8bd2014bac2f2733ce763a6052edaec) rustic-rs: move to by-name
* [`564236b3`](https://github.com/NixOS/nixpkgs/commit/564236b384688774f71312f77229e11d98dc9a22) mariadb-galera: 26.4.19 -> 26.4.20
* [`ad4e9d57`](https://github.com/NixOS/nixpkgs/commit/ad4e9d57738e137736a14a5e263cb5d2647e609f) git-subrepo: 0.4.6 -> 0.4.9
* [`8db0f998`](https://github.com/NixOS/nixpkgs/commit/8db0f998a364fae68790149a0db14f41cc9e3566) vscode-extensions.streetsidesoftware.code-spell-checker: 4.0.5 -> 4.0.7
* [`f0b2a9d5`](https://github.com/NixOS/nixpkgs/commit/f0b2a9d5a90df42edf57f3db280cb336ce932bca) tinyemu: remove jhhuh from meta.maintainers [inactivity] [no orphans]
* [`dc7494cb`](https://github.com/NixOS/nixpkgs/commit/dc7494cb63a4308a5f09cf2833ed6ac01056487c) tinyemu: rework
* [`670188a7`](https://github.com/NixOS/nixpkgs/commit/670188a7742c96566859f87ae9a43818624c7000) tinyemu: nixfmt-rfc-style
* [`43a84add`](https://github.com/NixOS/nixpkgs/commit/43a84add2c037d1b54af66da09e8451133192cee) tinyemu: migrate to by-name
* [`6ade1c7f`](https://github.com/NixOS/nixpkgs/commit/6ade1c7f60efc5542ab82df39b39ec15c4722ddd) qcal: update 0.9.1 -> 0.9.2
* [`0d043a29`](https://github.com/NixOS/nixpkgs/commit/0d043a2918181b38433884e1bd30ef15858c4c6d) qcal: don't use deprecated substituteInPlace option
* [`dbb09784`](https://github.com/NixOS/nixpkgs/commit/dbb09784aacb13399e39466d4291d3ac7a9d8f69) zabbix-agent2: allow build on unix
* [`60016653`](https://github.com/NixOS/nixpkgs/commit/6001665347ba35644b1c73e04bbd3bc60377422f) gnote: 46.0 -> 46.1
* [`9f1d4ab0`](https://github.com/NixOS/nixpkgs/commit/9f1d4ab08d8fb6bacf7eb5c80972831612f80a8a) vscode-extensions.asvetliakov.vscode-neovim: 1.18.4 -> 1.18.7
* [`9725143e`](https://github.com/NixOS/nixpkgs/commit/9725143e606fb0655161c4b8da1beb23ed287a60) zabbix-agent: allow build on unix
* [`0bf368c8`](https://github.com/NixOS/nixpkgs/commit/0bf368c8aced8a8e399d5301db030def3e0178a0) nixos/mailman: allow setting relay domains with services.postfix.config.relay_domains
* [`d55d1d69`](https://github.com/NixOS/nixpkgs/commit/d55d1d69027dbad2bfb134721194c9514dc5cc02) nodejs_22: fix the eval
* [`33420502`](https://github.com/NixOS/nixpkgs/commit/3342050260fb83ad02a44dbdf49a7cc616d83fa0) glslang: fix symlink from dev to use bin
* [`5415c37e`](https://github.com/NixOS/nixpkgs/commit/5415c37e94479c0213eef5f562138c7ee2b4b952) gotree: 0.3.1 -> 1.2.0
* [`7d522267`](https://github.com/NixOS/nixpkgs/commit/7d522267b43d604d650a1401ecaae4096b279a51) cinny-unwrapped: 4.0.3 -> 4.1.0
* [`b153902d`](https://github.com/NixOS/nixpkgs/commit/b153902d9697ce534993805e063f2e7039711a2f) cloudflare-utils: 1.2.1 -> 1.3.0
* [`bbb9f2f1`](https://github.com/NixOS/nixpkgs/commit/bbb9f2f1c98768a1ff623fbe730c71d4871646b5) stdenv: set the phase in showPhaseHeader
* [`62446339`](https://github.com/NixOS/nixpkgs/commit/624463391d94d0fc505f50f26f02d95e3a72c60c) stdenv: introduce specific logging functions
* [`465dbd2d`](https://github.com/NixOS/nixpkgs/commit/465dbd2ddf6197f006411a9ff632d9ed2e9c5e38) stdenv: log hooks at nixTalkativeLog level
* [`e844424e`](https://github.com/NixOS/nixpkgs/commit/e844424e4f9b8107ca0055c8a67f8a003ee2b2a1) stdenv: replace other $NIX_DEBUG log statements
* [`d8fbb162`](https://github.com/NixOS/nixpkgs/commit/d8fbb162190086dbab5fb69adab3ae187f138672) stdenv: change the logging in _allFlags to talkative
* [`cc12ca44`](https://github.com/NixOS/nixpkgs/commit/cc12ca446db09384dd14ee0d95d8ed7b6e443ccd) live555: 2024.05.30 -> 2024.06.26
* [`437d3e57`](https://github.com/NixOS/nixpkgs/commit/437d3e574d63aa7bf5ffcebe92ca8effdb2c7ef4) logseq: add darwin support
* [`18cef614`](https://github.com/NixOS/nixpkgs/commit/18cef614613003df84de51521c03ea92ee1d7aed) maintainers: add geraldog
* [`e9211c21`](https://github.com/NixOS/nixpkgs/commit/e9211c2189973c9cba87cb1beaa7a307680f52c4) glibcLocales: fix building with llvm
* [`ead097db`](https://github.com/NixOS/nixpkgs/commit/ead097db7f84c48357a37d131d5fed3ae868db9e) glibcLocales: format
* [`111b49d1`](https://github.com/NixOS/nixpkgs/commit/111b49d11c032e6026671c87dbbe9c1562d98c1e) zoraxy: 3.0.7 -> 3.1.0
* [`6fbb0608`](https://github.com/NixOS/nixpkgs/commit/6fbb06080897ce3fbf58da4776fab7c0aa270d64) cargo-c: 0.9.32 -> 0.10.2
* [`8a4b60f7`](https://github.com/NixOS/nixpkgs/commit/8a4b60f702b6a6dad7d50746118b8a44ca79ece9) gst_all_1.gst-plugins-rs: 0.12.4 -> 0.12.8
* [`09d8b504`](https://github.com/NixOS/nixpkgs/commit/09d8b504e238cd196a7e24d818f2f57b2c235b3f) nsncd: unstable-2024-03-18 -> 1.4.1
* [`ae0d5d9c`](https://github.com/NixOS/nixpkgs/commit/ae0d5d9cc8dd82af36846bc3a4839ae16f98a6df) unixODBCDrivers.psql: merge with psqlodbc
* [`92d79ffc`](https://github.com/NixOS/nixpkgs/commit/92d79ffcb71708c3873da9f69f7d6fb191010ccc) mullvad-vpn: 2024.3 -> 2024.4
* [`f892146e`](https://github.com/NixOS/nixpkgs/commit/f892146ee50a65353de058addc8adcf479818b89) sentry-cli: 2.32.1 -> 2.33.1
* [`c45e7dff`](https://github.com/NixOS/nixpkgs/commit/c45e7dff861237f205eb5ef9ebf47fb107e2957e) infisical: 0.26.1 -> 0.27.0
* [`8da82625`](https://github.com/NixOS/nixpkgs/commit/8da82625e7b1d618c94cce34e965d45dbe35a1f4) amarok: 3.0.1 -> 3.1.0
* [`4a1b6d34`](https://github.com/NixOS/nixpkgs/commit/4a1b6d3442bf7ef7db3d7dda173b58a3ed25d4f6) Revert "nsncd: unstable-2024-03-18 -> 1.4.1"
* [`b335dfdd`](https://github.com/NixOS/nixpkgs/commit/b335dfdd9eef81afd1358e282bbf05f34fded772) mesa: cherry-pick patch to fix broken video decoding on AMD iGPUs
* [`d6de1821`](https://github.com/NixOS/nixpkgs/commit/d6de18216fdac1b1704fa57d51145b27fca379ee) lunarml: 0.1.0 → 0.2.0
* [`4eb01e33`](https://github.com/NixOS/nixpkgs/commit/4eb01e33819c7a9429b30d6c634b122683b4414f) python312Packages.django_5: 5.0.7 -> 5.0.8
* [`df74f34c`](https://github.com/NixOS/nixpkgs/commit/df74f34c6d96397fd8028901d5225bcb827938c4) python312Packages.glyphtools: disable tests
* [`471d1538`](https://github.com/NixOS/nixpkgs/commit/471d15382485e4ea6c2f2cdbd6377d37304c5228) whipper: test with pytest
* [`c4a5a7dd`](https://github.com/NixOS/nixpkgs/commit/c4a5a7dd972ed1e3e8ff4c210bae8584d844ca50) python312Packages.pycdio: fix tests on 3.12
* [`102305ea`](https://github.com/NixOS/nixpkgs/commit/102305ea0b353ad8c1b12670b60cc6ff839d91cb) python312Packages.apsw: test with pytest
* [`976cb96f`](https://github.com/NixOS/nixpkgs/commit/976cb96fe0e7a601f6ac322e9404bfa6466e7306) python312Packages.serpent: test with pytest
* [`0b0dd33e`](https://github.com/NixOS/nixpkgs/commit/0b0dd33e0ad51b5059008fdfdfdef1510bc049dd) python312Packages.setuptoolsCheckHook: remove
* [`92536533`](https://github.com/NixOS/nixpkgs/commit/9253653383e968abc638d54b3b9866d7c8355dca) python312Packages.setuptools: 70.0.0 -> 72.1.0
* [`a65d78dd`](https://github.com/NixOS/nixpkgs/commit/a65d78dd315e212219c1a7101beefcd73d363d6d) python312Packages.intervaltree: migrate to pytest and pep517 lingo
* [`ab0e2972`](https://github.com/NixOS/nixpkgs/commit/ab0e29728635f2c48cd5f3c7b75ee299528c8616) python312Packages.scikit-build: 0.17.6 -> 0.18.0
* [`1b87ff96`](https://github.com/NixOS/nixpkgs/commit/1b87ff961d8ff66f948735b3e975d170b89353a0) python312Packages.pytest-fixture-config: patch out tests_require
* [`b1156644`](https://github.com/NixOS/nixpkgs/commit/b1156644c8d663503ba0b0df276ce155eb755727) python312Packages.pystray: run tests with pytest
* [`7195f742`](https://github.com/NixOS/nixpkgs/commit/7195f7421f50886002064f4656733693a20bb213) python312Packages.myst-parser: disable failing tests
* [`ccd56ee7`](https://github.com/NixOS/nixpkgs/commit/ccd56ee7c3c92ea0ca97c692153409600a8dd019) python312Packages.pdm-backend: 2.3.1 -> 2.3.3
* [`e47d0b54`](https://github.com/NixOS/nixpkgs/commit/e47d0b5400d0e4c4aaf314db6cb833144bd1d11a) electrum-ltc: disable failing and stuck tests
* [`fddf1534`](https://github.com/NixOS/nixpkgs/commit/fddf1534d86f773604b2e178b0648b0894564723) python312Packages.datasette: ignore deprecation warnings
* [`cc2b171a`](https://github.com/NixOS/nixpkgs/commit/cc2b171ac7f140cf562a42eabfe1794ce94f10ba) python312Packages.python-daemon: fix build
* [`1bf8aa36`](https://github.com/NixOS/nixpkgs/commit/1bf8aa36647488b87e4f7fd8d534f3480d540bc9) python312Packages.liblarch: test with pytest
* [`0ab55a6c`](https://github.com/NixOS/nixpkgs/commit/0ab55a6ce8ba2b7bca3a4fd22c08c3b252bc6bb7) python312Packages.aiohttp: 3.9.5 -> 3.10.0
* [`b9a16acb`](https://github.com/NixOS/nixpkgs/commit/b9a16acbae51e84898f34cbc8a6ff9c4867861d2) python312Packages.uvloop: don't run aiohttp tests
* [`1957bde1`](https://github.com/NixOS/nixpkgs/commit/1957bde1fb62c161a0382d02d4480f5de8de9c43) python312Packages.aiohappyeyeballs: enable previously broken test
* [`6bd87a30`](https://github.com/NixOS/nixpkgs/commit/6bd87a30bfcf9435de577f15c200e656aac05366) python312Packages.aiohttp-fast-url-dispatcher: unpin aiohttp
* [`45fd62a5`](https://github.com/NixOS/nixpkgs/commit/45fd62a5392f87a7b7b98a2955315456ea323e26) python312Packages.aiohttp-fast-url-dispatcher: 0.3.0 -> 0.3.1
* [`9cce6b2c`](https://github.com/NixOS/nixpkgs/commit/9cce6b2c487fbd25ac90411fd4bda3d12d8f70d1) python312Packages.async-upnp-client: 0.39.0 -> 0.40.0
* [`7983e66e`](https://github.com/NixOS/nixpkgs/commit/7983e66e0e8fbdaffd4b5ee07746d0301988ac53) python312Packages.mocket: disable test failing due to DNS lookup
* [`c8dd37a2`](https://github.com/NixOS/nixpkgs/commit/c8dd37a2a79659a3d6d7890133d1f982d3bedc83) python312Packages.atpublic: 4.1.0 -> 5.0
* [`c3dacd86`](https://github.com/NixOS/nixpkgs/commit/c3dacd86f095e325888d6dc91b1beef5bc5eafe6) python312Packages.anyio: 4.3.0 -> 4.4.0
* [`003b0991`](https://github.com/NixOS/nixpkgs/commit/003b09912e7f931133afeede3544729fccb9a513) python312Packages.starlette: fix tests
* [`da270cd5`](https://github.com/NixOS/nixpkgs/commit/da270cd5759771ced8331f7a3b48d2d36e93145b) python312Packages.av: 12.2.0 -> 12.3.0
* [`e340c59f`](https://github.com/NixOS/nixpkgs/commit/e340c59f5eb3983e44a6a7aeed148ce80e3e1f25) python311Packages.python-ulid: 2.2.0 -> 2.7.0
* [`633d642f`](https://github.com/NixOS/nixpkgs/commit/633d642f4672e0c9451e761c32263d6ea6699fc0) python312Packages.requests: fix ca loading regression in 2.32.3
* [`717e520f`](https://github.com/NixOS/nixpkgs/commit/717e520fa0778701162c68add4969d7c0efdbe56) python312Packages.pytest: 8.2.2 -> 8.3.2
* [`287943d6`](https://github.com/NixOS/nixpkgs/commit/287943d6ddc23a04118bfb778475eeccf061cbcc) python312Packages.hypothesis: 6.103.0 -> 6.108.5
* [`26414d70`](https://github.com/NixOS/nixpkgs/commit/26414d70afde6fa0c7443b7f9c0641b47f21a9ae) python312Packages.pillow: 10.3.0 -> 10.4.0
* [`3c26a3a4`](https://github.com/NixOS/nixpkgs/commit/3c26a3a495680ffa496b836ed9f0baf884782565) python312Packages.fastapi: 0.111.0 -> 0.112.0
* [`96c7496c`](https://github.com/NixOS/nixpkgs/commit/96c7496c70637cc943b16c5ae9d2e9ecc68aa2f0) python312Packages.httpretty: fix build
* [`2ebc3e29`](https://github.com/NixOS/nixpkgs/commit/2ebc3e29129965f272dd5cad789783646bbc0b2a) python312Packages.sure: propagate mock
* [`73e44816`](https://github.com/NixOS/nixpkgs/commit/73e448164887d069e6586fc0c02f03885757f5af) python312Packages.proxy-py: disable failing test
* [`ae242787`](https://github.com/NixOS/nixpkgs/commit/ae24278745eda31a5960bc3a4a7ec151c6394168) python312Packages.aiohttp-fast-zlib: 0.1.1 -> 0.1.1
* [`f22f05aa`](https://github.com/NixOS/nixpkgs/commit/f22f05aa079a0944bbddb8092501cd6a0cc446d5) python312Packages.chacha20poly1305-reuseable: 0.12.2 -> 0.13.2
* [`06643a40`](https://github.com/NixOS/nixpkgs/commit/06643a404d92c7371e0aab4ff3d583c791154275) python312Packages.psycopg: 3.1.19 -> 3.2.1
* [`eb93fae7`](https://github.com/NixOS/nixpkgs/commit/eb93fae730190239110db07771f5d72699f8e17a) python312Packages.moto: 5.0.9 -> 5.0.12
* [`9d4242c7`](https://github.com/NixOS/nixpkgs/commit/9d4242c7599440bf1f8f0fa86b5d0bb62d63e048) python312Packages.sqlalchemy: 2.0.31 -> 2.0.32
* [`90f0d98c`](https://github.com/NixOS/nixpkgs/commit/90f0d98ccf279d47db6483292d6ddd98d74a86b0) python312Packages.sqlalchemy_1_4: 1.4.52 -> 1.4.53
* [`4529bd57`](https://github.com/NixOS/nixpkgs/commit/4529bd57273eafaa1dd78db0a8666f12b2ceca28) seq66: 0.99.12 -> 0.99.13
* [`f2316f95`](https://github.com/NixOS/nixpkgs/commit/f2316f95a6496c99933806f2abefbbb066b8e544) sqlc: 1.26.0 -> 1.27.0
* [`3fe9664e`](https://github.com/NixOS/nixpkgs/commit/3fe9664e2ab39752a300be06d2f283da7ab407d2) rustup: convert to cargoHash
* [`12dd2562`](https://github.com/NixOS/nixpkgs/commit/12dd2562179379ad7d4f7896672b901c4fd484e0) python312Packages.aiohttp: 3.10.0 -> 3.10.1
* [`30889c34`](https://github.com/NixOS/nixpkgs/commit/30889c3463e60d4090a45fa76a46d83398d5d1bb) cargo,clippy,rustc,rustfmt: 1.79.0 -> 1.80.0
* [`6938e9d2`](https://github.com/NixOS/nixpkgs/commit/6938e9d22fe8781d61fcb10c502b560e056f7cc3) mdbook-pdf: 0.1.8 -> 0.1.10
* [`5e12a4df`](https://github.com/NixOS/nixpkgs/commit/5e12a4df29d652aafd3df1e76aa1e9a0fa20eea0) python312Packages.django: 4.2.14 -> 4.2.15
* [`4c201bb4`](https://github.com/NixOS/nixpkgs/commit/4c201bb4e9a67f363114b73e389036906157ce2e) vnote: 3.18.1 -> 3.18.2
* [`a5c69440`](https://github.com/NixOS/nixpkgs/commit/a5c69440becd974027dd1ccbd3f383faa2d8de56) mongoc: 1.27.4 -> 1.27.5
* [`5f87351d`](https://github.com/NixOS/nixpkgs/commit/5f87351d42cf2b0940783466a68ab9b7e7949aa7) vscode-extensions.ms-python.vscode-pylance: 2024.7.1 -> 2024.8.1
* [`4d67dc7a`](https://github.com/NixOS/nixpkgs/commit/4d67dc7acceac0b46daea0985e367a32e061ae30) python3Packages.awscrt: remove pin of gcc version
* [`ce8459b7`](https://github.com/NixOS/nixpkgs/commit/ce8459b7bf7a089d1bd641996924f18205b50c38) ananicy-rules-cachyos: 0-unstable-2024-07-23 -> 0-unstable-2024-07-27
* [`faf1e170`](https://github.com/NixOS/nixpkgs/commit/faf1e1700a55d0eb60de04bac4caddc0171de54b) keepassxc-go: unbreak on darwin
* [`e1a55fe1`](https://github.com/NixOS/nixpkgs/commit/e1a55fe1b70243191088dcf9f645ae8871292f2a) mesa: use upstream version of patch
* [`ec6b205b`](https://github.com/NixOS/nixpkgs/commit/ec6b205b5ae905e487967604028381bc822076cc) usbguard: 1.1.2 -> 1.1.3
* [`83fa6dab`](https://github.com/NixOS/nixpkgs/commit/83fa6dab8e2f5ffb575d287d862beb5c47591bac) cosmic-comp: unstable-2023-11-13 -> 1.0.0-alpha.1
* [`89e00aec`](https://github.com/NixOS/nixpkgs/commit/89e00aec5cb0d3a8ef17246ea19de3c8b60d5f10) crun: 1.15 -> 1.16
* [`35d13051`](https://github.com/NixOS/nixpkgs/commit/35d1305130ff2904099cbd338f36865f5a333c9f) nixd: 2.3.0 -> 2.3.1
* [`c7129d13`](https://github.com/NixOS/nixpkgs/commit/c7129d13c73f3f6350686f153e8bb01da1d4e56d) nsncd: unstable-2024-03-18 -> 1.4.1-unstable-2024-04-10
* [`5da57013`](https://github.com/NixOS/nixpkgs/commit/5da570137e281b6168ab9b1d36a04cfb5858ba36) nsncd: nixfmt
* [`1b230484`](https://github.com/NixOS/nixpkgs/commit/1b230484c8c774ab92fb13d8b3aa48a7611f22fc) treewide: remove jhhuh from meta.maintainers [inactivity] [orphans]
* [`92ac5eeb`](https://github.com/NixOS/nixpkgs/commit/92ac5eebfb7ac4e2a43f9160ef86c6047821e3db) python312Packages.rapidfuzz: 3.9.5 -> 3.9.6
* [`75a10ed3`](https://github.com/NixOS/nixpkgs/commit/75a10ed3018c594e49b66d9821ec75f5329ca16c) picocrypt: 1.38 -> 1.39
* [`4e57d7f9`](https://github.com/NixOS/nixpkgs/commit/4e57d7f9b2e00f9297bbca162dea36e8bce6baa1) krane: 3.6.0 -> 3.6.1
* [`b7c13f00`](https://github.com/NixOS/nixpkgs/commit/b7c13f0006f68f41830c4b7733972eb915df73bf) python312Packages.bx-py-utils: 93 -> 94
* [`fadba002`](https://github.com/NixOS/nixpkgs/commit/fadba0028d99642ed3e188e1d2bc468b9c0f1483) ukmm: mark as broken on aarch64-linux
* [`8caad59a`](https://github.com/NixOS/nixpkgs/commit/8caad59a02a309f190aef40a5df07c78b01fb7ea) sherlock: 0-unstable-2024-06-09 -> 0.15.0
* [`f9b9b31c`](https://github.com/NixOS/nixpkgs/commit/f9b9b31c972d28ada6a2e3c0d7173c59c1c7359d) sherlock: format using nixfmt-rfc-style
* [`d0d10b0a`](https://github.com/NixOS/nixpkgs/commit/d0d10b0a445afd8b9c756cbfaeefb8a3e5d82cd1) sherlock: remove uses of with lib
* [`6ba7b012`](https://github.com/NixOS/nixpkgs/commit/6ba7b01271e0530a58c2e97c5b2aee1eef2bad8c) python312Packages.aiohappyeyeballs: 2.3.4 -> 2.3.5
* [`8a98528a`](https://github.com/NixOS/nixpkgs/commit/8a98528a8de4d6149fff1fc95e8a4eb789a09804) opensearch: 2.15.0 -> 2.16.0
* [`bfb9d182`](https://github.com/NixOS/nixpkgs/commit/bfb9d1825d545d96278db84d43e0b2a529775089) nixos/pgbouncer: add services.pgbouncer.settings option
* [`6008ed89`](https://github.com/NixOS/nixpkgs/commit/6008ed89f6163f0f58a80dbaf79ab6edf795d250) nixos/prometheus.exporters.pgbouncer: do not assume that pgbouncer runs on localhost
* [`63caf38e`](https://github.com/NixOS/nixpkgs/commit/63caf38e3378b444399180647233abb6e97d20f1) nixos/prometheus.exporters.pgbouncer: fix escaping connectionStringFile in shell arguments
* [`a87f5eb7`](https://github.com/NixOS/nixpkgs/commit/a87f5eb7d0afdc6c2f59cc33967ad4c770450d98) llvmPackages_{13,14,15,16,17,18,git}: add recurse into attrs
* [`d0e9693c`](https://github.com/NixOS/nixpkgs/commit/d0e9693c7d5398d630fbfaa95b8dd34720ebb9de) llvmPackages_git: remove recurse into attrs in call package
* [`f0c83432`](https://github.com/NixOS/nixpkgs/commit/f0c83432dbb6216798296cfebc830d612bad8e87) llvmPackagesSets: expose make package
* [`2bf2f493`](https://github.com/NixOS/nixpkgs/commit/2bf2f493a639cb2a2ba5c0d86531c54f55d7fa04) keymapper: 4.5.2 -> 4.6.0
* [`96eb942c`](https://github.com/NixOS/nixpkgs/commit/96eb942c2a62de7e04ec42112c788ee4f5fda226) pmix: use finalAttrs: pattern
* [`9c6f3ae8`](https://github.com/NixOS/nixpkgs/commit/9c6f3ae8ae1a8f0bf4fd8df5fb5c9c85460dd7a1) pmix: don't use with lib; in meta
* [`4a17df26`](https://github.com/NixOS/nixpkgs/commit/4a17df26e4f24130b31b63eef1c2ab1a65a2bdfd) pmix: add doronbehar to maintainers
* [`85e1c49c`](https://github.com/NixOS/nixpkgs/commit/85e1c49cdbe21472cbadfb81cb55938f19fce243) pmix: nixfmt
* [`97a89f6d`](https://github.com/NixOS/nixpkgs/commit/97a89f6d197f233115831ea1fe08894ffd55c8d9) pmix: use "''${!outputDev}" instead of $dev
* [`7c189828`](https://github.com/NixOS/nixpkgs/commit/7c189828223f55f7fc07a01bc6d860e44918f690) pmix: put substitution & wrapping in install & fixup respectively
* [`d6599a24`](https://github.com/NixOS/nixpkgs/commit/d6599a24f80b8ac51dac16dc201d154cf12b166a) eza: 0.18.24 -> 0.19.0
* [`f4035cfe`](https://github.com/NixOS/nixpkgs/commit/f4035cfe5878d699e668ebd79c1adbaaf44a8673) stackql: 0.5.699 -> 0.5.708
* [`4cd87f9b`](https://github.com/NixOS/nixpkgs/commit/4cd87f9ba96674cc5d3d25c4e08152eb214373d6) bcc: 0.30.0 -> 0.31.0
* [`d15083e9`](https://github.com/NixOS/nixpkgs/commit/d15083e985373113af8543e8e67ff3db9a5248fb) zed-editor: 0.146.5 -> 0.147.2
* [`300a4615`](https://github.com/NixOS/nixpkgs/commit/300a4615c00a1a4e7c3dd49197022cc3ad2f85b2) nixVersions.git: 2.24.0pre20240723 -> 2.25.0pre20240807
* [`661e32b4`](https://github.com/NixOS/nixpkgs/commit/661e32b447152b03d9ad3fff600a85c88af29988) dbgate: 5.3.1 -> 5.3.4
* [`63ac89e6`](https://github.com/NixOS/nixpkgs/commit/63ac89e63a8a6ec2607680aed33adc9aca699386) ardugotools: 0.6.0 -> 0.6.1
* [`d858bca6`](https://github.com/NixOS/nixpkgs/commit/d858bca61f9dd35dd2b4c7e0dd050f786b2173c7) python312Packages.asyncinotify: 4.0.6 -> 4.0.9
* [`a1d58d54`](https://github.com/NixOS/nixpkgs/commit/a1d58d54baa49216962af08f4522733a980c1c97) python312Packages.asyncinotify: fix license
* [`a41189a7`](https://github.com/NixOS/nixpkgs/commit/a41189a7461f77b4327658fad091ace1025bf1a0) home-assistant-cli: format using nixfmt-rfc-style
* [`66fd9c66`](https://github.com/NixOS/nixpkgs/commit/66fd9c663347f1c1e5cd72dabc19fdd827fa1ed6) home-assistant-cli: got rid of 'with lib' inside meta
* [`e92efd8a`](https://github.com/NixOS/nixpkgs/commit/e92efd8a53ba44743aa2c4af4fa0ba650093f1bf) Revert "ladybird: fix compilation by adding no longer propagated libraries"
* [`1a905d79`](https://github.com/NixOS/nixpkgs/commit/1a905d79fe1c1b8437d4b27e7fbcf0477dfc9b7f) okteto: move to by-name
* [`906598c9`](https://github.com/NixOS/nixpkgs/commit/906598c9145f13ed742e45b1440bf1f9232c58ce) testers: format inputs per RFC166
* [`64c49dcc`](https://github.com/NixOS/nixpkgs/commit/64c49dccb0e5411c8fce478cc3b9af8e6427fced) instawow: 4.4.0 -> 4.7.0
* [`3019956f`](https://github.com/NixOS/nixpkgs/commit/3019956f12fd4c2936e8e33ceb203909d52aa9b1) pmix: enable on all platforms
* [`511be509`](https://github.com/NixOS/nixpkgs/commit/511be509f295ab4d409e4b42478eb0ddcd6f9fb7) pmix: nixfmt
* [`06d68ea1`](https://github.com/NixOS/nixpkgs/commit/06d68ea13a421d5ebd9da352d40846d0875b3858) openmpi: add doronbehar to maintainers
* [`908ec599`](https://github.com/NixOS/nixpkgs/commit/908ec599a34b1f8c98717b67d38582f33384d876) openmpi: 5.0.3 -> 5.0.5
* [`af0df905`](https://github.com/NixOS/nixpkgs/commit/af0df905e6ca24d7bcc0dd2618e23e2eed7164e7) openmpi: fix configurePhase on darwin by always using our pmix
* [`8db6dc53`](https://github.com/NixOS/nixpkgs/commit/8db6dc53b0b03c7b6addea4cfd89b591678caa8d) openmpi: fix postInstall hook on Darwin
* [`94385486`](https://github.com/NixOS/nixpkgs/commit/9438548689f6a5ece83607312b75e513683fe031) emacs: fix missing ccache libary path
* [`a3e8676a`](https://github.com/NixOS/nixpkgs/commit/a3e8676a49bf04452b4956a1901f3839a6c276a7) cano: 0.1.0-alpha -> 0.2.0-alpha, modernize
* [`d0a96c6e`](https://github.com/NixOS/nixpkgs/commit/d0a96c6eda12b1209029f9f5b510dd0a834f34d5) testers.runCommand: add, document, and test
* [`244229a8`](https://github.com/NixOS/nixpkgs/commit/244229a8b6f29264cdd2efbcb64f945980b47871) python3Packages.bork: add test using `testers.runCommand`
* [`e0fc12cd`](https://github.com/NixOS/nixpkgs/commit/e0fc12cd1260c4196da1dc7189f70a6c56c43115) doc: add type signature of `testers.runCommand`
* [`5e9b327b`](https://github.com/NixOS/nixpkgs/commit/5e9b327be673e1a54d9aa1a29a0f6ccc15c23d3a) svu: 2.1.0 -> 2.1.1
* [`cdaccc25`](https://github.com/NixOS/nixpkgs/commit/cdaccc259a1759b70aad7bb6253434fa669822da) flameshot: 12.1.0-unstable-2024-07-02 -> 12.1.0-unstable-2024-08-02
* [`4be8e799`](https://github.com/NixOS/nixpkgs/commit/4be8e799dba7abfbfa902bf90ad5dab4c9f203f5) homebox: init at 0.13.0
* [`f8639ea0`](https://github.com/NixOS/nixpkgs/commit/f8639ea08de70e6dbfd859c8d84bde871f4b84db) nixos/homebox: init
* [`ea4107ab`](https://github.com/NixOS/nixpkgs/commit/ea4107aba089d07208e97390c478496e60ed2787) nixosTest.homebox: init
* [`8c4e58aa`](https://github.com/NixOS/nixpkgs/commit/8c4e58aa632034aeeb8bb71b0d35a92613fe6f74) angie: 1.6.0 -> 1.6.1
* [`61815891`](https://github.com/NixOS/nixpkgs/commit/61815891192dff31155da377422e35b36d93a9d8) angie-console-light: 1.2.1 -> 1.4.0
* [`be7c2ce5`](https://github.com/NixOS/nixpkgs/commit/be7c2ce57ef0b73c376d9b0b02bb5f53af4a029e) imgbrd-grabber: fix build
* [`c6711b87`](https://github.com/NixOS/nixpkgs/commit/c6711b873c9c4566c1b8ecfab19f5588c9ef1312) rustic: rename from rustic-rs
* [`18dd486b`](https://github.com/NixOS/nixpkgs/commit/18dd486bb9b5b19379c1c4c3bf78c04c239d032e) emptyFile: use SRI hash
* [`4252f65b`](https://github.com/NixOS/nixpkgs/commit/4252f65b9646a686d04214dfd362d7d593c775f1) reindeer: 2024.07.22.00 -> 2024.08.05.00
* [`809e8c7a`](https://github.com/NixOS/nixpkgs/commit/809e8c7ad8987604247e21cdd273b62dbc9e68e0) libpkgconf: 2.2.0 -> 2.3.0
* [`c87320ce`](https://github.com/NixOS/nixpkgs/commit/c87320cec746754b7cef39b8337a9d18dd680df9) libei: 1.2.1 -> 1.3.0
* [`149a1514`](https://github.com/NixOS/nixpkgs/commit/149a15141ad00c1b525ac02dacdb526b62c53e50) python312Packages.aiohttp: 3.10.1 -> 3.10.2
* [`2877a7ea`](https://github.com/NixOS/nixpkgs/commit/2877a7eaf07dcb06fe4018a98d0ff14d8ba77e0b) kubernetes-helmPlugins.helm-secrets: 4.6.0 -> 4.6.1
* [`86e91648`](https://github.com/NixOS/nixpkgs/commit/86e9164895041c917277fd0657e91a6939db7765) htcondor: 23.8.1 -> 23.9.6
* [`e388d591`](https://github.com/NixOS/nixpkgs/commit/e388d5919218e91a623f8fbceca16820f56e6676) metal-cli: 0.23.1 -> 0.24.0
* [`456330fb`](https://github.com/NixOS/nixpkgs/commit/456330fb727ff2a9d41a4ad64100844f28d07dd1) kubeone: 1.8.1 -> 1.8.2
* [`dfbc165d`](https://github.com/NixOS/nixpkgs/commit/dfbc165dc792605e1ca7d686a1ac0fce5cc03d28) treewide: remove nested let-in
* [`a3fe5ac2`](https://github.com/NixOS/nixpkgs/commit/a3fe5ac214a6f91f21eb2ee9fa690a8f8a644946) obs-studio-plugins.obs-vertical-canvas: 1.4.7 -> 1.4.8
* [`42fd05ca`](https://github.com/NixOS/nixpkgs/commit/42fd05ca76ef223585b24addd3f9f65c9e688194) python312Packages.asf-search: 7.1.4 -> 8.0.0
* [`53e8c6b9`](https://github.com/NixOS/nixpkgs/commit/53e8c6b9d95858d85ae9be8a00cb7258af77dcc0) python312Packages.okta: 2.9.7 -> 2.9.8
* [`55005c1b`](https://github.com/NixOS/nixpkgs/commit/55005c1b33df5402e0b7f4e2d9c71f4071b036b0) vscode-extensions.fill-labs.dependi: 0.7.5 -> 0.7.7
* [`d4fc396a`](https://github.com/NixOS/nixpkgs/commit/d4fc396ae80c3ddbdaab5197699562040d984ec4) linkerd_edge: 24.7.5 -> 24.8.2
* [`254e1349`](https://github.com/NixOS/nixpkgs/commit/254e1349c9c0913626b0d0bf0980444c323dd9ea) rpcs3: 0.0.32-16711-501e9260b -> 0.0.32-16784-03a612487
* [`fb5c061e`](https://github.com/NixOS/nixpkgs/commit/fb5c061ea79517ffce7bd3e699477e89b1719c57) noto-fonts-cjk-serif: 2.002 -> 2.003
* [`4ae5cf54`](https://github.com/NixOS/nixpkgs/commit/4ae5cf54142cfaeb63f3a75d687af6cc5ec587d1) sketchybar-app-font: 2.0.20 -> 2.0.23
* [`2e7b92d4`](https://github.com/NixOS/nixpkgs/commit/2e7b92d439682fe93e2cae4bd902668488b455d4) python312Packages.asf-search: update disabled
* [`354f95e1`](https://github.com/NixOS/nixpkgs/commit/354f95e168b56dfbcdb6b10cfab26f355e78c577) authelia: 4.38.9 -> 4.38.10
* [`27d4ae66`](https://github.com/NixOS/nixpkgs/commit/27d4ae6645e18bf5513af3bc2c24342c9a24bc18) rustc: 1.80.0 -> 1.80.1, add zlib dependency on Darwin
* [`03d46999`](https://github.com/NixOS/nixpkgs/commit/03d469996fa17783fef09966a561de81b10c39ab) python312Packages.pycoolmasternet-async: 0.2.0 -> 0.2.1
* [`f0c65051`](https://github.com/NixOS/nixpkgs/commit/f0c65051a7440c946d7458a595b2706df3189f04) emacsPackages.ligo-mode: 1.7.1-unstable-2024-07-17 -> 1.7.0-unstable-2024-08-01
* [`ec27795d`](https://github.com/NixOS/nixpkgs/commit/ec27795d712102c854af96b05c9b23044995b020) level-zero: 1.17.19 -> 1.17.25
* [`96790120`](https://github.com/NixOS/nixpkgs/commit/96790120dfd8633e10359bb193fea78d839e4fa9) nixos/pam: fix writeFile no longer taking null as an argument warning
* [`a71a5e3d`](https://github.com/NixOS/nixpkgs/commit/a71a5e3d0cf8852847970a78c021181a7a1b2bae) mystmd: 1.2.9 -> 1.3.2
* [`dc0e4f9e`](https://github.com/NixOS/nixpkgs/commit/dc0e4f9ec5f97e9516ec2877929c42c49caffd42) python312Packages.aioairzone: 0.7.7 -> 0.8.1
* [`d3b5c8d4`](https://github.com/NixOS/nixpkgs/commit/d3b5c8d43a885648d536c64e17a6c01516899c29) python312Packages.aioairzone-cloud: 0.5.5 -> 0.6.1
* [`004157a5`](https://github.com/NixOS/nixpkgs/commit/004157a551ff248f2d0cfce27279e1e906eaadb0) python312Packages.aioautomower: 2024.6.4 -> 2024.7.3
* [`b57ff914`](https://github.com/NixOS/nixpkgs/commit/b57ff914d875c677dfaedeeabe24094a34c92d9a) python312Packages.chacha20poly1305-reuseable: relax cryptogrpahy constraint
* [`a0e49d9d`](https://github.com/NixOS/nixpkgs/commit/a0e49d9d2ff843a295f7f47a6e54914c03e68b21) python312Packages.aioesphomeapi: 24.6.1 -> 25.0.0
* [`ab33b20d`](https://github.com/NixOS/nixpkgs/commit/ab33b20d07748adb49470583e9fd3d3cf2ddf3bf) python312Packages.aiohomekit: 3.1.5 -> 3.2.1
* [`4e9cb7b0`](https://github.com/NixOS/nixpkgs/commit/4e9cb7b071d5abccd1c287a0175e00b24473c5f1) python312Packages.aiolifx-themes: 0.4.27 -> 0.5.1
* [`f3785710`](https://github.com/NixOS/nixpkgs/commit/f3785710c87fa72efb5b32ce85e4140bd5c3b315) python312Packages.aioqsw: 0.3.5 -> 0.4.0
* [`82b1b33a`](https://github.com/NixOS/nixpkgs/commit/82b1b33a97d613e26cab9173ca02df7a75f53f61) python312Packages.bimmer-connected: 0.15.3 -> 0.16.1
* [`0af9ccec`](https://github.com/NixOS/nixpkgs/commit/0af9ccec78db5c28d8f1021cf9f24d2896b69658) python312Packages.bluetooth-data-tools: 1.19.3 -> 1.19.4
* [`645948e1`](https://github.com/NixOS/nixpkgs/commit/645948e10a12efece4fbc8dc4741bc6ae1d07980) python312Packages.deebot-client: 8.2.0 -> 8.3.0
* [`96e6c810`](https://github.com/NixOS/nixpkgs/commit/96e6c810531899bad25357591f33eb375cb19ebb) python312Packages.doorbirdpy: 2.2.2 -> 3.0.2
* [`c5394e00`](https://github.com/NixOS/nixpkgs/commit/c5394e00f53c270e0d60a7702c4f7d9a988b941a) python312Packages.dsmr-parser: 1.4.1 -> 1.4.2
* [`5256f72f`](https://github.com/NixOS/nixpkgs/commit/5256f72f25c030bed90186b7c4ee4c8d2fcf96b4) python312Packages.hassil: 1.7.1 -> 1.7.4
* [`68cfd3bb`](https://github.com/NixOS/nixpkgs/commit/68cfd3bbe47ce808ac1f68b88f7d5178ccedd1b2) home-assistant-intents: 2024.7.10 -> 2024.7.29
* [`8c441636`](https://github.com/NixOS/nixpkgs/commit/8c44163621eb8c8b454d0b23c663166be96e45e1) python312Packages.knx-frontend: 2024.7.25.204106 -> 2024.8.6.211307
* [`1b9248fb`](https://github.com/NixOS/nixpkgs/commit/1b9248fb525a267473bff4a774fabe3b16e448cb) python312Packages.laundrify-aio: 1.2.1 -> 1.2.2
* [`b670725d`](https://github.com/NixOS/nixpkgs/commit/b670725df91b3a609f891b1842652d9660509854) python312Packages.nettigo-air-monitor: 3.2.0 -> 3.3.0
* [`8e7f693f`](https://github.com/NixOS/nixpkgs/commit/8e7f693f681d5a7799381eca66d162bace9a0a23) python312Packages.pydaikin: 2.13.0 -> 2.13.1
* [`d65319e6`](https://github.com/NixOS/nixpkgs/commit/d65319e64ed989e587f8efa9b49f4e04560c8f26) python312Packages.pyhomeworks: 0.0.6 -> 1.1.0
* [`193a32d7`](https://github.com/NixOS/nixpkgs/commit/193a32d75decd5303010b4a461bf0880c28e7e8a) python312Packages.pylutron: 0.2.13 -> 0.2.15
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
