### PR TITLE
niv nixpkgs: update 4b2b2d5c -> 89f8fd07

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4b2b2d5c8cbf659337c0d781b763def0c2da461f",
-        "sha256": "1aj6ylnzcsbxxbsifi9wyaz3fx72mz38gvk80bxcpvxg5vxm4qmf",
+        "rev": "89f8fd07fb125f182ad5652eff777940e09aa5c2",
+        "sha256": "0skkkykgli6ajliy6w4ia393pswjfv8m0c2nc9p9qpkb6mslzqwv",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/4b2b2d5c8cbf659337c0d781b763def0c2da461f.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/89f8fd07fb125f182ad5652eff777940e09aa5c2.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@4b2b2d5c...89f8fd07](https://github.com/nixos/nixpkgs/compare/4b2b2d5c8cbf659337c0d781b763def0c2da461f...89f8fd07fb125f182ad5652eff777940e09aa5c2)

* [`5183bab0`](https://github.com/NixOS/nixpkgs/commit/5183bab0c6f65c430d12b380c43a3dca508e098f) vimPlugins.themed-tabs-nvim: init at 2023-11-09
* [`807edcce`](https://github.com/NixOS/nixpkgs/commit/807edcce8c9904e8d06fdbeb075b0a005bbab8f9) git-radar: add coreutils-prefixed to PATH on darwin
* [`ea8378fb`](https://github.com/NixOS/nixpkgs/commit/ea8378fb8e5c5989b9d0980d89bc978ae6db2d87) thorium-browser: init at 120.0.6099.235
* [`589ea911`](https://github.com/NixOS/nixpkgs/commit/589ea9114aac366fbea7d5fed4b967ac44c18ca3) vimPlugins.vim-habamax: init at 2024-01-22
* [`5112fbdb`](https://github.com/NixOS/nixpkgs/commit/5112fbdb82596120a34f41fbf88cb3db97092a42) vcv-rack: 2.4.1 -> 2.5.1
* [`7749696f`](https://github.com/NixOS/nixpkgs/commit/7749696f61275cbd02aa753560b30e5ff0dfe1f3) docs: fix Nvidia casing to be consistent across different places
* [`aa915382`](https://github.com/NixOS/nixpkgs/commit/aa915382e9bf8564b75de46079b4c94907de6445) (ponysay): Add missing pre and post install hooks
* [`bcb0c9e3`](https://github.com/NixOS/nixpkgs/commit/bcb0c9e3d5d53719c828365946a6b271dbe2d438) framework-tool: unstable-2023-11-14 -> 0.1.0-unstable-2024-06-14
* [`f99e5032`](https://github.com/NixOS/nixpkgs/commit/f99e50320e9f4d947f22afc48f534803fe17a820) nixos/wordpress: update .htaccess for httpd
* [`121ad0d1`](https://github.com/NixOS/nixpkgs/commit/121ad0d115295571f00d5cc6af3ae800948dc334) maintainers: add Celibistrial
* [`ba10aace`](https://github.com/NixOS/nixpkgs/commit/ba10aacec83edb0acf6f176a8041e09326ebaaf3) nbfc-linux: init at 0.1.15
* [`9f51e910`](https://github.com/NixOS/nixpkgs/commit/9f51e9102db8af97b0d7cb030000df35db52be62) convmv: add Darwin support, reformat & migrate to pkgs/by-name
* [`d44cc3b6`](https://github.com/NixOS/nixpkgs/commit/d44cc3b616862d6f1ac872bc447b110a55a0ea07) convmv: add al3xtjames to maintainers
* [`fc2b1fb8`](https://github.com/NixOS/nixpkgs/commit/fc2b1fb8f6e7cf2c289d686d1a775b2c97a777d7) maintainers: add rcmlz
* [`79fea538`](https://github.com/NixOS/nixpkgs/commit/79fea538ea5112e72210a6eea686b7c7e6429235) tigerjython: init at 2.39
* [`64ba49b8`](https://github.com/NixOS/nixpkgs/commit/64ba49b8e5b55c6ce224292adc4cd3c5c230c1cf) libjwt: 1.17.1 -> 1.17.2
* [`452a0757`](https://github.com/NixOS/nixpkgs/commit/452a0757309134f9c02937941ffb0d7e025e4d3e) openvpn: 2.6.11 -> 2.6.12
* [`2c8f78ed`](https://github.com/NixOS/nixpkgs/commit/2c8f78edb200c3f527720605c606cae0e7e30bfa) portablemc: 4.3.0 -> 4.4.0
* [`1eb0abae`](https://github.com/NixOS/nixpkgs/commit/1eb0abaed0d8a5180473f0a25f0ed9e74309c840) linux-wallpaperengine: drop
* [`db2396c7`](https://github.com/NixOS/nixpkgs/commit/db2396c7f9af99da25daf2a8e6baa05d75f6501a) parmetis: Move to pkgs/by-name/pa/parmetis
* [`6c6fb148`](https://github.com/NixOS/nixpkgs/commit/6c6fb1480cf786d0c28f38b6cbf20a72ab2a6d5d) k9s: Use native DNS resolver
* [`31d5e3e2`](https://github.com/NixOS/nixpkgs/commit/31d5e3e2c5c930ed82227dda229b5a45c831468f) python312Packages.numpy_2: 2.0.0 -> 2.0.1
* [`f7ead05e`](https://github.com/NixOS/nixpkgs/commit/f7ead05e978e616a5951e4ddd70a9de66a02a15e) melange: 0.10.0 -> 0.11.2
* [`895c222e`](https://github.com/NixOS/nixpkgs/commit/895c222ef4e2c2bdae3c68e1a4495f3ae9f9dc89) libndp: 1.8 -> 1.9
* [`dbad97cf`](https://github.com/NixOS/nixpkgs/commit/dbad97cfa1f1b5c714a1d5b93f2536dfd96551e7) szyszka: Add desktop icon
* [`b2d3c481`](https://github.com/NixOS/nixpkgs/commit/b2d3c481e64f7dcd0e0e5df08ed9b57036d50a7d) gnomeExtensions.unite: 78 -> 79
* [`076390a4`](https://github.com/NixOS/nixpkgs/commit/076390a47eb815acae05900d76e5dc7d3dbecaf1) resticprofile: 0.27.0 -> 0.27.1
* [`8646b99d`](https://github.com/NixOS/nixpkgs/commit/8646b99d692a95f2ed489dbeda1dabb41b711188) coolercontrol.*: 1.3.0 -> 1.4.0
* [`86576d96`](https://github.com/NixOS/nixpkgs/commit/86576d96a894b7c605c2b5266a1b6777d3d84a47) flashprint: 5.8.4 -> 5.8.6
* [`4d5cacee`](https://github.com/NixOS/nixpkgs/commit/4d5cacee9323ad3808f99f17d71964c63985ff3f) maintainers: add AlexSKaye
* [`0305851d`](https://github.com/NixOS/nixpkgs/commit/0305851dbc79f7f2f513d5b8855edf6392f8e09e) juniper: 2.3.0 -> 4.0.0, use buildDotnetModule
* [`f435d213`](https://github.com/NixOS/nixpkgs/commit/f435d213981efdc35d7b4678527d10bac4b5b650) pythonPackages.clickhouse-driver: drop nose dependency
* [`e240e87e`](https://github.com/NixOS/nixpkgs/commit/e240e87ef04aedfddf56c3ff3ff356373258750b) tclvfs: init at 1.4-unstable-2023-11-23
* [`25affda0`](https://github.com/NixOS/nixpkgs/commit/25affda0543f68a168f4f2da4359aa38b3c0ce87) haskellPackages: stackage LTS 22.29 -> LTS 22.31
* [`89004f50`](https://github.com/NixOS/nixpkgs/commit/89004f509476f93ab57c39c61138fc1f9c23eeab) all-cabal-hashes: 2024-07-14T21:17:20Z -> 2024-07-31T18:11:52Z
* [`7ab80daf`](https://github.com/NixOS/nixpkgs/commit/7ab80dafd997629ff0b4b4b42767dc45fd1bbf9f) haskellPackages: regenerate package set based on current config
* [`b94eb919`](https://github.com/NixOS/nixpkgs/commit/b94eb919c6419948188aee67f8366733b0974efb) azure-storage-azcopy: 10.25.1 -> 10.26.0
* [`50ee8e36`](https://github.com/NixOS/nixpkgs/commit/50ee8e365b90916278c4a62a6d0f37cdb330a80d) coqPackages.gaia: 1.17 -> 2.2
* [`a06a5415`](https://github.com/NixOS/nixpkgs/commit/a06a5415bb107bb400d5887ab9a63a9d1f37bf10) coqPackages.mathcomp: 1 -> 2
* [`83b327fd`](https://github.com/NixOS/nixpkgs/commit/83b327fd220ae7e506954672754fc91dfbb628ad) ccextractor: move to `pkgs/by-name`
* [`c3a8cb1e`](https://github.com/NixOS/nixpkgs/commit/c3a8cb1e7b6f40aa8603569cb80cc416df07b038) ccextractor: format with `nixfmt-rfc-style`
* [`b546361c`](https://github.com/NixOS/nixpkgs/commit/b546361c0024f925c6691adaa063366f78515db3) ccextractor: modernize
* [`98002580`](https://github.com/NixOS/nixpkgs/commit/98002580a9da497482cd644f45d1563d23bdf5d7) ccextractor: adopt
* [`fc83b7ab`](https://github.com/NixOS/nixpkgs/commit/fc83b7abbdca87ca2d934e24fb49736abf1afc79) dezoomify-rs: init at 2.12.4
* [`69aeeff2`](https://github.com/NixOS/nixpkgs/commit/69aeeff2de8126bc18aae5cb2d9322dc9bb177be) amd-ucodegen: init at 0-unstable-2017-06-07
* [`bd9880a4`](https://github.com/NixOS/nixpkgs/commit/bd9880a4d5755217c19278968b83212a191932a1) webdav: 4.2.0 -> 5.1.0
* [`0bfff19d`](https://github.com/NixOS/nixpkgs/commit/0bfff19dc027f296372342b9374d8969e20fe9a2) aws-c-io: 0.14.9 -> 0.14.18
* [`c790b114`](https://github.com/NixOS/nixpkgs/commit/c790b114e6acf17b188f769a3a964ca9a3395edd) tcludp: init at 1.0.11
* [`3fe77df3`](https://github.com/NixOS/nixpkgs/commit/3fe77df3a76582235fb4608a1afb8d2a33933a7f) pdf4tcl: init at 0.9.4
* [`658fff5f`](https://github.com/NixOS/nixpkgs/commit/658fff5fabf2998fbcde8c022744a294d7299979) tdom: init at 0.9.4
* [`f59c6447`](https://github.com/NixOS/nixpkgs/commit/f59c64470d8091b21c0190cfcf9508c5ceda5af1) haskellPackages.patch: fix build on js backend
* [`f2f3deae`](https://github.com/NixOS/nixpkgs/commit/f2f3deae5e912a5d108b2bec0b99f3c298d5716f) haskellPackages.gi-gtk: fix build on ghc > 9.6
* [`90e293d1`](https://github.com/NixOS/nixpkgs/commit/90e293d12208fbd97c6eec6e200d4cf526b602cc) pingvin-share: init at 0.29.0
* [`924437f5`](https://github.com/NixOS/nixpkgs/commit/924437f5de26032fed5b22491e267a28d05f1fce) nixos/pingvin-share: init at 0.29.0
* [`712a04c6`](https://github.com/NixOS/nixpkgs/commit/712a04c693f202b1d7e7ea61e6926d4d4a7b3280) nixos/pingvin-share: add nixos test
* [`109219f3`](https://github.com/NixOS/nixpkgs/commit/109219f36987ddaf83640a9660126a4e43a7a727) nixos/pingvin-share: add release note
* [`edf938b9`](https://github.com/NixOS/nixpkgs/commit/edf938b9aa059c2c9307072817d52377f11cb9de) maintainers: update RatCornu infos
* [`05ad3979`](https://github.com/NixOS/nixpkgs/commit/05ad3979d3a621a9cdff168dff8f1397909b04fc) yarn-berry: 4.3.1 -> 4.4.0
* [`c20da5db`](https://github.com/NixOS/nixpkgs/commit/c20da5db54d25bbdfc2ab49471d9c91e24fbc082) haskellPackages.os-string: mark os-string as GHC-9.10 Core library
* [`1e8936bd`](https://github.com/NixOS/nixpkgs/commit/1e8936bd6221a4e76196033f04d392770b8f4a26) zlint: 3.6.2 -> 3.6.3
* [`a59858e0`](https://github.com/NixOS/nixpkgs/commit/a59858e045cc765d2a7dc11695d5d650f7a8bc5b) zlint: refactor
* [`01a2d2e4`](https://github.com/NixOS/nixpkgs/commit/01a2d2e402ec593397637379df8906e04c9b6596) garnet: 1.0.16 -> 1.0.18
* [`d91504af`](https://github.com/NixOS/nixpkgs/commit/d91504af503edc6c35bef8ae2c41addbf9aefe71) liquibase: 4.28.0 -> 4.29.1
* [`350f9983`](https://github.com/NixOS/nixpkgs/commit/350f99833a394e101ba7afe9fe1c99fd43efd13e) nawk: 20240422 -> 20240728
* [`074ab265`](https://github.com/NixOS/nixpkgs/commit/074ab2651a9aece7473413a793b525f2dd976a8c) vitess: 19.0.4 -> 20.0.1
* [`25f283f3`](https://github.com/NixOS/nixpkgs/commit/25f283f361f860c6f09b361bd1b33398b4993fa8) nawk: reformat using nixfmt
* [`391a2d4b`](https://github.com/NixOS/nixpkgs/commit/391a2d4bfd3ebf677c7547ee0440c3df852ad2d9) edl: unstable-2022-09-07 -> 3.52.1-unstable-2024-07-05
* [`da43e5ae`](https://github.com/NixOS/nixpkgs/commit/da43e5aec909eda35b2a91953575cee168e9d607) fastddsgen: 3.3.0 -> 4.0.0
* [`2c0b45de`](https://github.com/NixOS/nixpkgs/commit/2c0b45de6bd922b0f50948321e7dce62c5c0f733) ndpi: 4.8 -> 4.10
* [`9df63d3f`](https://github.com/NixOS/nixpkgs/commit/9df63d3f612caaf06cccad0ca1d1b9a3f6f2855e) dockbarx: 1.0-beta2 -> 1.0-beta4
* [`0ed130ac`](https://github.com/NixOS/nixpkgs/commit/0ed130acf60fd8244b530c7f7857311f4a61adc7) linuxkit: 1.4.0 -> 1.5.0
* [`6e6831c8`](https://github.com/NixOS/nixpkgs/commit/6e6831c85a6bcc81ee9b5a735aacd47d888be797) python312Packages.pytest-subprocess: 1.5.0 -> 1.5.2
* [`4dbec937`](https://github.com/NixOS/nixpkgs/commit/4dbec93707bd859a52bc71808c6202bf0ebed223) kubectl-gadget: 0.30.0 -> 0.31.0
* [`459f120b`](https://github.com/NixOS/nixpkgs/commit/459f120b6884f27248e49758d28ca42f1660c5ea) ghidra-extensions.ghidra-delinker-extension: init at 0.4.0
* [`29baf5ff`](https://github.com/NixOS/nixpkgs/commit/29baf5ff293f0246e4a11492d50692ff5d1f21ae) rkbin: Update license to unfreeRedistributableFirmware
* [`f5a22a2d`](https://github.com/NixOS/nixpkgs/commit/f5a22a2dba1ebb26f7a74470f1042c96f537c49e) libdovi: 3.3.0 → 3.3.1
* [`fc62a673`](https://github.com/NixOS/nixpkgs/commit/fc62a67397e8e16df29f9cf50c63dc8a4d018eeb) rkbin: Include license in docs
* [`d5e5482f`](https://github.com/NixOS/nixpkgs/commit/d5e5482fb4ead0861c524fb5f559dd4a00616551) python3Packages.somweb: init at 1.2.1
* [`a503b3af`](https://github.com/NixOS/nixpkgs/commit/a503b3afa17b50a9a12421964285e46eaffa92b6) haskellPackages.dunai: unbreak
* [`19123316`](https://github.com/NixOS/nixpkgs/commit/19123316e852e17a683664d40334cc83b1469b43) python312Packages.diffusers: 0.29.2 -> 0.30.0
* [`33fc5a84`](https://github.com/NixOS/nixpkgs/commit/33fc5a846d144e9abd3f153bf39d520ff67acc33) mov-cli: 4.4.7 -> 4.4.8
* [`319cc068`](https://github.com/NixOS/nixpkgs/commit/319cc0680108b51cfd4a4cb956bab8f0cd76bcdc) jsonnet-language-server: 0.13.1 -> 0.14.0
* [`83786bec`](https://github.com/NixOS/nixpkgs/commit/83786becd070652880717c38c9b9af8d9d8b27db) prometheus-lnd-exporter: 0.2.7 -> 0.2.8
* [`abb863c3`](https://github.com/NixOS/nixpkgs/commit/abb863c3ccd003914f1ee90125d01d0bb59943b3) xml-security-c: retired from Apache
* [`fd5c8c3e`](https://github.com/NixOS/nixpkgs/commit/fd5c8c3ebf0c00e811a59fb814c3f3df823f9551) maintainers: add aksiksi
* [`2c8f5042`](https://github.com/NixOS/nixpkgs/commit/2c8f504254fc59045b76b01b0940a464b8945cad) haskellPackages: disable tests on aarch64-darwin that require postgresql
* [`53974919`](https://github.com/NixOS/nixpkgs/commit/539749190aead2b267dcf5c37e3c4c8dfd3fa399) haskellPackages.bytezap: unbreak
* [`4c3e46cc`](https://github.com/NixOS/nixpkgs/commit/4c3e46cc11104a4a64adf6aa302ec13ecaae798a) haskellPackages: edit raehik package maintainership
* [`a4b65383`](https://github.com/NixOS/nixpkgs/commit/a4b65383b1fedc1866ecb36b1a65c82e98260d1e) haskellPackages.tasty: Drop overrides for 1.5.1
* [`4bb43471`](https://github.com/NixOS/nixpkgs/commit/4bb434715bd81b16d54f805c4434e4e68500c022) haskellPackages.monad-schedule: Fix eval
* [`8eb1b3b8`](https://github.com/NixOS/nixpkgs/commit/8eb1b3b862867b40570accd899e4d730ab605225) hareThirdParty.hare-ev: 0-unstable-2024-07-11 -> 0-unstable-2024-08-06
* [`be715731`](https://github.com/NixOS/nixpkgs/commit/be7157314120f0134686bad20df14d5b8305f5e2) haskellPackages.doctest: Skip failing cabal-doctest tests
* [`cc49d6c0`](https://github.com/NixOS/nixpkgs/commit/cc49d6c0e57d9db1d20b7b4c92379dcca7c317c7) haskellPackages: regenerate package set based on current config
* [`a33ef724`](https://github.com/NixOS/nixpkgs/commit/a33ef7243a4924597ac515a4f5512f85b4c7dd13) python311Packages.sqlite-utils: 3.36 -> 3.37
* [`d8a2d632`](https://github.com/NixOS/nixpkgs/commit/d8a2d6328edf64c081951854d179e700278bf8ac) python311Packages.llm: 0.14 -> 0.15
* [`2bca85a8`](https://github.com/NixOS/nixpkgs/commit/2bca85a8d31191761b1285a0a1d44ef13eed4f15) qt5.qtwebengine: fix darwin build for system ffmpeg 7
* [`d5db6d7d`](https://github.com/NixOS/nixpkgs/commit/d5db6d7d46a30cbeb0184ea5c56c26f2d80d6285) compose2nix: init at 0.2.1
* [`f262891d`](https://github.com/NixOS/nixpkgs/commit/f262891dad98a4bcc94b6eb4c7c0eba2179eea84) treewide: remove ralith from meta.maintainers [inactivity] [orphans]
* [`ed734e5e`](https://github.com/NixOS/nixpkgs/commit/ed734e5eba251f8f6de9b15dbfebdc05f9cfd7d1) python3Packages.scikit-fuzzy: unstable-2022-11-07 -> unstable-2023-09-14
* [`09005f3b`](https://github.com/NixOS/nixpkgs/commit/09005f3bb2c15854d4820ae19315447c2feef75f) maintainers: add ofalvai
* [`c8fd4604`](https://github.com/NixOS/nixpkgs/commit/c8fd4604a3a38da444165d947dea2c525c904cb4) local-ai: Switch test to llama 3.1
* [`c875450f`](https://github.com/NixOS/nixpkgs/commit/c875450f5242a59fa258cbb2cf0d18633bb36e54) local-ai: 2.18.1 -> 2.19.4
* [`5793fb5b`](https://github.com/NixOS/nixpkgs/commit/5793fb5b9e2e6031a090649911e540597cf194de) osquery: fix build
* [`fd1f078f`](https://github.com/NixOS/nixpkgs/commit/fd1f078fea05b1b197a3ede8d0c832f2359aa6cd) nixos-rebuild: remove list-generations piping into $PAGER
* [`e0d4ac27`](https://github.com/NixOS/nixpkgs/commit/e0d4ac275b1f1a8b7ebc765c0ff845a574824cb0) nzbget: move to by-name
* [`392f3c93`](https://github.com/NixOS/nixpkgs/commit/392f3c9396c7b6329f8190253a3581a58fc85c8e) nzbget: 24.1 -> 24.2
* [`3ecdf25e`](https://github.com/NixOS/nixpkgs/commit/3ecdf25e37efb32ec0ebc72ee9e511028eb4816a) pachyderm: 2.10.6 -> 2.11.0
* [`08bc3e37`](https://github.com/NixOS/nixpkgs/commit/08bc3e37361739fc53a6930a18786a5078c7cbd9) trippy: 0.10.0 -> 0.11.0
* [`038c94d1`](https://github.com/NixOS/nixpkgs/commit/038c94d189741f74ce7fbbd729fe4042230d62d3) recyclarr: refactor - build from source
* [`f68084c3`](https://github.com/NixOS/nixpkgs/commit/f68084c37825289bd357ebf3348912349f3eb4b1) recyclarr: 7.1.1 -> 7.2.1
* [`18ebd72b`](https://github.com/NixOS/nixpkgs/commit/18ebd72b859b00475c4f201979caf87696e0ffd3) recyclarr: move to pkgs/by-name
* [`aaba7b83`](https://github.com/NixOS/nixpkgs/commit/aaba7b83709eacf862cf36449d9d33428fed505b) recyclarr: use finalAttrs for buildDotnetModule
* [`bdbda65d`](https://github.com/NixOS/nixpkgs/commit/bdbda65d25b86e8c616cccf66cac17906e3ab037) h2: 2.3.230 -> 2.3.232
* [`46c3afb2`](https://github.com/NixOS/nixpkgs/commit/46c3afb271ffe9b73f6d2b75e4b7243618280a7e) cassandra: add meta.sourceProvenance information
* [`7db4805e`](https://github.com/NixOS/nixpkgs/commit/7db4805efb6c1002b3fed61e97ff859a4370cfa9) urbit: 3.0 -> 3.1
* [`d74d1829`](https://github.com/NixOS/nixpkgs/commit/d74d1829916fa421faee82fe7d46922cc5617f5a) Revert "systemd-stage-1: Use common bin for /sbin"
* [`208e9533`](https://github.com/NixOS/nixpkgs/commit/208e953381d3677962af934bdae2014236f60f01) systemd-stage-1: Fully merge `/bin` and `/sbin`
* [`67fd96e2`](https://github.com/NixOS/nixpkgs/commit/67fd96e28b45e57fd587ac70dec42d1bc847516b) haskellPackages.feedback: Fix build
* [`30e07f1e`](https://github.com/NixOS/nixpkgs/commit/30e07f1ecd762aaf8255c9a97713379eb1f478ed) pyenv: 2.4.8 -> 2.4.10
* [`8dd369f5`](https://github.com/NixOS/nixpkgs/commit/8dd369f524411d971e03d8bc5e1abcb73c55f3db) nixos/systemd-tmpfiles: add initrd support
* [`10c46625`](https://github.com/NixOS/nixpkgs/commit/10c46625fe2d0f5bd95a90e97cf4f2c5ee8fcd6e) rPackages.DGP4LCF: add dependencies
* [`20e16537`](https://github.com/NixOS/nixpkgs/commit/20e16537470cfbe45290e061284b5e7665acd707) python312Packages.wirerope: init at 0.4.7
* [`be71cac4`](https://github.com/NixOS/nixpkgs/commit/be71cac470b002d988ce5b3d945cf8809b2fcb9e) python312Packages.methodtools: init at 0.4.7
* [`eecbc8d2`](https://github.com/NixOS/nixpkgs/commit/eecbc8d2407910420ab04fe47713dd55fa338614) haskellPackages.xnobar: Disable on darwin
* [`aca87162`](https://github.com/NixOS/nixpkgs/commit/aca871629f4b32304c00aad39d79e4064eec1df6) haskellPackages: regenerate package set based on current config
* [`5867cdce`](https://github.com/NixOS/nixpkgs/commit/5867cdce3a9fafc856050d2225e642808135eebf) mstflint: 4.28.0-1 -> 4.29.0-1
* [`4621cc2c`](https://github.com/NixOS/nixpkgs/commit/4621cc2cd466103dfd4ac31ef71d1fd6e2c5f71e) sdrangel: 7.21.4 -> 7.22.0
* [`4845c345`](https://github.com/NixOS/nixpkgs/commit/4845c345c1eb64e0d97157b738d6f143353c71c9) python312Packages.wsme: drop nose dependency, modernize, adopt
* [`ab3c41d6`](https://github.com/NixOS/nixpkgs/commit/ab3c41d6d3daf8b015ca527116deab85b1fd188c) icu75: init at 75.1
* [`487396af`](https://github.com/NixOS/nixpkgs/commit/487396af3c3ffe28764b30e88612346d386e25a3) viu: 1.4.0 -> 1.5.0
* [`cdd7496f`](https://github.com/NixOS/nixpkgs/commit/cdd7496ff394f4970312ea019f45dca2a8b7b4c8) foomatic-db: unstable-2024-05-04 -> unstable-2024-08-13
* [`bc76800b`](https://github.com/NixOS/nixpkgs/commit/bc76800bba4095be2c6d34deb482e5d258e85f1c) simpleitk: 2.3.1 -> 2.4.0
* [`b5edded2`](https://github.com/NixOS/nixpkgs/commit/b5edded29125b9786fd696538a79df69281637d5) elastix: 5.1.0 -> 5.2.0
* [`97ad266c`](https://github.com/NixOS/nixpkgs/commit/97ad266c07bb553f9c2da14bf6c7d8448ac2ab0e) samba: 4.20.1 -> 4.20.4
* [`b33bf6b9`](https://github.com/NixOS/nixpkgs/commit/b33bf6b99a4b3d6771013cb99ed230f9a8682e95) nixos/systemd/initrd: Fix emergencyAccess to work with `null`.
* [`0008b4c6`](https://github.com/NixOS/nixpkgs/commit/0008b4c66b3597502861cfd843714b5e6249394e) moar: 1.25.1 -> 1.26.0
* [`7364d718`](https://github.com/NixOS/nixpkgs/commit/7364d718e172893301bb87d3c2d47d6d7c29067a) git-annex: update sha256 for 10.20240731
* [`f831be35`](https://github.com/NixOS/nixpkgs/commit/f831be35496da6495b55486462e8740e8fa44f5f) python3Packages.qtile: 0.28.0 -> 0.28.1
* [`dd2acdf7`](https://github.com/NixOS/nixpkgs/commit/dd2acdf7286d02ae4bade198fabd666629f3e0af) python3Packages.qtile-extras: 0.28.0 -> 0.28.1
* [`8ef8e7fd`](https://github.com/NixOS/nixpkgs/commit/8ef8e7fd8abadc05e92f7869541e2a03bbeaa96d) lomiri.lomiri-gallery-app: init at 3.0.2
* [`cb0faa48`](https://github.com/NixOS/nixpkgs/commit/cb0faa488a8cb204203bee71b6d96d3c504826ff) tests/lomiri-gallery-app: init
* [`8c1cb414`](https://github.com/NixOS/nixpkgs/commit/8c1cb41408c4c6381646aea834c0b8350bdc370e) nixos/lomiri: Add gallery app
* [`fc95088f`](https://github.com/NixOS/nixpkgs/commit/fc95088f1188b5584d54093b54b6d628446333cb) poptop: init at 0.1.8
* [`d43eae54`](https://github.com/NixOS/nixpkgs/commit/d43eae54d3e1b64e67dcd4806962cd4a7e6c33c6) nut: 2.8.0 -> 2.8.2
* [`2546a4c7`](https://github.com/NixOS/nixpkgs/commit/2546a4c70df3a6d57468d692d97ae6295f408baf) stack: get latest version building
* [`86f32f10`](https://github.com/NixOS/nixpkgs/commit/86f32f104ac2c5225be27a9c3ab86e4da700cc2d) kime: 3.0.2 -> 3.1.1
* [`5b5e7b07`](https://github.com/NixOS/nixpkgs/commit/5b5e7b07febd4dda47e945ced8a5c6551c1323f6) maintainers: update goatastronaut0212's email
* [`7c5f71ba`](https://github.com/NixOS/nixpkgs/commit/7c5f71bad4416c3d4bd5721b5ef180f6ad0bdce2) opengrok: 1.13.9 -> 1.13.19
* [`3d2d84cc`](https://github.com/NixOS/nixpkgs/commit/3d2d84cc33667208cafaae457b11429e61fc1fd1) boost186: init at 1.86.0
* [`eaa6a1ef`](https://github.com/NixOS/nixpkgs/commit/eaa6a1ef0dc126f47066e921cd226f9833873e74) gotenberg: 8.8.1 -> 8.9.1
* [`f10b598e`](https://github.com/NixOS/nixpkgs/commit/f10b598eaf88f5af44ba069014723449669ea9c3) chatblade: 0.4.0 -> 0.6.2
* [`b356a808`](https://github.com/NixOS/nixpkgs/commit/b356a808fdd5f2b891e3711f5324079d8e738ff3) build-support/php: copy v1 into v2
* [`65c0e4eb`](https://github.com/NixOS/nixpkgs/commit/65c0e4ebf6907c7382b60d087a69805b139193f4) build-support/php: implement v2
* [`9734fe62`](https://github.com/NixOS/nixpkgs/commit/9734fe62434afe7b73bc13b6d618de23e7915d75) phpunit: switch to `buildComposerProject2`
* [`8890dd5f`](https://github.com/NixOS/nixpkgs/commit/8890dd5fb5db143944d96f55125d5afedf5663a9) php.packages.psalm: switch to `buildComposerProject2`
* [`012319af`](https://github.com/NixOS/nixpkgs/commit/012319af4650f44ad5230be9ff709d8e3ba2fe7d) php.packages.psalm: 5.22.2 -> 5.25.0
* [`56ab77b1`](https://github.com/NixOS/nixpkgs/commit/56ab77b1c4de33c65c9907b342064b318c89c13b) php.packages.psysh: 0.11.21 -> 0.12.4
* [`a9585caf`](https://github.com/NixOS/nixpkgs/commit/a9585cafb96fcb21cee4c2e7a8321c63be0253fc) n98-magerun2: switch to `buildComposerProject2`
* [`35ab61e8`](https://github.com/NixOS/nixpkgs/commit/35ab61e8e8969c240cd1fbf7476c433f6146202c) php.packages.phpstan: switch to `buildComposerProject2`
* [`d90ff2a8`](https://github.com/NixOS/nixpkgs/commit/d90ff2a850124a19a0df6ce87f9b7feaa2bf930a) php.packages.grumphp: switch to `buildComposerProject2`
* [`40dc65f5`](https://github.com/NixOS/nixpkgs/commit/40dc65f56d8586a6bfb40f04ecf13dfff952a4b6) release-cuda: allow passing `system` to release-lib
* [`3dbc5f2f`](https://github.com/NixOS/nixpkgs/commit/3dbc5f2ff0e080add208d71046a3d12c129d538b) nfpm: 2.38.0 -> 2.39.0
* [`914797c4`](https://github.com/NixOS/nixpkgs/commit/914797c4f146c30b6cc928e6116d588c8bd6add1) bun: 1.1.20 -> 1.1.24
* [`75265168`](https://github.com/NixOS/nixpkgs/commit/75265168f77f4d8795eb653149a685ab0c3a6231) wolfram-engine: 13.3.0 -> 14.1.0
* [`4df65bd9`](https://github.com/NixOS/nixpkgs/commit/4df65bd968372e15f072f810d5c27270d87ec102) haskellPackages.avro: drop unnecessary patch
* [`9a0fdb1e`](https://github.com/NixOS/nixpkgs/commit/9a0fdb1eb7fd16a02e6ca1025f344bdc147fb10e) haskellPackages.stan: remove override
* [`a3671063`](https://github.com/NixOS/nixpkgs/commit/a3671063679af637ca0ad34848128e42e3bf145f) haskellPackages.hakyll-filestore: remove override
* [`f7de034e`](https://github.com/NixOS/nixpkgs/commit/f7de034e531b5d9d3c913b77002bc808036874b1) haskellPackages.streamly-bytestring: remove override
* [`9649c7eb`](https://github.com/NixOS/nixpkgs/commit/9649c7eba2df426e35358b167d49101ea34d44ca) haskellPackages.blucontrol: remove override
* [`cfc80471`](https://github.com/NixOS/nixpkgs/commit/cfc804712446a00edfef48fc798edc7508a39166) haskellPackages.bench: remove override
* [`473989a5`](https://github.com/NixOS/nixpkgs/commit/473989a5652a7cbe7c1e20057063cb053f39b590) haskellPackages.comfort-blas: remove override
* [`d1c7660c`](https://github.com/NixOS/nixpkgs/commit/d1c7660c96caa8f6b10d34ffab03f9e562fac1fb) haskellPackages.storablevector: remove override
* [`c11def25`](https://github.com/NixOS/nixpkgs/commit/c11def254ea225b51feea2e94b306c6ed1673b48) haskellPackages.shh-extras: remove override
* [`8b9a958c`](https://github.com/NixOS/nixpkgs/commit/8b9a958cda4c553e952a63f99cd7155d8a549c4c) haskellPackages.diagrams-gtk: remove override
* [`468486a6`](https://github.com/NixOS/nixpkgs/commit/468486a64bae109fc7961bb96a7396cdaffe074f) haskellPackages.haskell-ci: remove jailbreak
* [`352af3c1`](https://github.com/NixOS/nixpkgs/commit/352af3c131ab6c020efb11293af28fffb0c649bd) haskellPackages.math-functions: remove override
* [`74311469`](https://github.com/NixOS/nixpkgs/commit/74311469928d06072d116330401572bd4ad073c7) haskellPackages.vector-hashtables: remove override
* [`c6aa022e`](https://github.com/NixOS/nixpkgs/commit/c6aa022e6a8840a275ab427cca7714eeb48f7dab) haskellPackages.posix-api: jailbreak to unbreak
* [`4de66399`](https://github.com/NixOS/nixpkgs/commit/4de6639906ca9b08f49b21b2a8bbf3b805a4e200) cdecl: 18.2 -> 18.3
* [`79dd2d35`](https://github.com/NixOS/nixpkgs/commit/79dd2d35fcda86733d8a9a7a42edf620d34859cb) mesos-dns: move to by-name
* [`add437eb`](https://github.com/NixOS/nixpkgs/commit/add437ebb7de9848df285e492b8415c1300ef370) mesos-dns: 0.9.0 -> 0.9.2
* [`15643603`](https://github.com/NixOS/nixpkgs/commit/15643603076f9ac640a71a394626037381119477) libiec61850: 1.5.3 -> 1.6.0
* [`e9709b1b`](https://github.com/NixOS/nixpkgs/commit/e9709b1bb1eeae14ed8ccb571234334074ece9cc) leo-editor: use pyqt6
* [`7ab199ac`](https://github.com/NixOS/nixpkgs/commit/7ab199ac2b39ea84a8632c9330219ec55cbdd7fd) haskellPackages: fix formatting
* [`e4f09ba9`](https://github.com/NixOS/nixpkgs/commit/e4f09ba9e2f16ee0670a91d2b6bcab6246026191) python312Packages.pyblu: 0.4.0 -> 0.5.2
* [`34d9244a`](https://github.com/NixOS/nixpkgs/commit/34d9244a4a1bb3c4cd599a178ab7c6794176da4e) python312Packages.pycoolmasternet-async: 0.2.1 -> 0.2.2
* [`0a4d6516`](https://github.com/NixOS/nixpkgs/commit/0a4d6516d43960b17566d79ca0b5ecc1ba92367f) python312Packages.python-linkplay: run tests
* [`df2df4c3`](https://github.com/NixOS/nixpkgs/commit/df2df4c3a61bb110694e00cde38d871c7761bc08) nvidia-container-toolkit: do not shadow docker executable
* [`f7b4d574`](https://github.com/NixOS/nixpkgs/commit/f7b4d57421d67baf096e0b46168699e774067812) virtualisation/docker: fix nvidia wrapper
* [`f1cd097b`](https://github.com/NixOS/nixpkgs/commit/f1cd097be2344bf6e1602ed304b3df12d96dc9ae) lib/types: update reference to docs
* [`9e0678b5`](https://github.com/NixOS/nixpkgs/commit/9e0678b571a0cb5e71b20328dcd40f82a67fd3df) picard: switch back to Python 3.12
* [`db8fd4c3`](https://github.com/NixOS/nixpkgs/commit/db8fd4c34f0a746a429aea8554dbaaa5e033b53e) picard: 2.12 -> 2.12.1
* [`43033473`](https://github.com/NixOS/nixpkgs/commit/43033473541b26a3c569512d2d7d826fd81e489d) picard: run tests
* [`1d5e59ac`](https://github.com/NixOS/nixpkgs/commit/1d5e59acffd9723cdb28d692582b126a7600da83) picard: don't use with lib in meta
* [`1decf9f4`](https://github.com/NixOS/nixpkgs/commit/1decf9f446ef9755608ed090a7a28cf07111b055) picard: add doronbehar to maintainers
* [`058e8f5e`](https://github.com/NixOS/nixpkgs/commit/058e8f5ef11cd5291cf03aa4a886e475cf7bdd71) nvidia-podman: remove nvidia wrapper
* [`835b2f88`](https://github.com/NixOS/nixpkgs/commit/835b2f88220cfbf3e4110592e2940df7df126965) nixos/chromadb: init
* [`e2f89ee1`](https://github.com/NixOS/nixpkgs/commit/e2f89ee150db512614619f4ba55f1ef0c72d5536) python312Packages.chromadb: enable `nixosTests`
* [`1d65e264`](https://github.com/NixOS/nixpkgs/commit/1d65e2645d7426bdf04a0748744436c3a8f0c074) cargo-outdated: fix build against Rust 1.80 due to outdated time dependency
* [`2baf32a4`](https://github.com/NixOS/nixpkgs/commit/2baf32a43e6b115d76cd402dc9511d6897e9e902) vacuum-go: 0.12.0 -> 0.12.1
* [`36b15460`](https://github.com/NixOS/nixpkgs/commit/36b15460c9428f29835fbf3475ade9937b1e2e6f) python3Packages.jsonslicer: add tests and changelogs
* [`f53c9cfd`](https://github.com/NixOS/nixpkgs/commit/f53c9cfd9e4dd4761bd6a9535057847963ac88bc) libkrunfw: 4.2.0 -> 4.3.0
* [`064edbf5`](https://github.com/NixOS/nixpkgs/commit/064edbf5874587571a0dc816e1695703775e25d4) cargo-audit: 0.20.0 -> 0.20.1
* [`51d0ec5f`](https://github.com/NixOS/nixpkgs/commit/51d0ec5f05b574ac66ae4abb6bba66b66fbda870) python312Packages.msal: 1.29.0 -> 1.30.0
* [`d4ddd147`](https://github.com/NixOS/nixpkgs/commit/d4ddd14755d8e8282a18a603854710e6b12f4382) python312Packages.msal: refactor
* [`0bebb66d`](https://github.com/NixOS/nixpkgs/commit/0bebb66dbf75a5c4a552aa2737c6b75e2f208495) python312Packages.msal-extensions: 1.1.0 -> 1.2.0
* [`b3fd6814`](https://github.com/NixOS/nixpkgs/commit/b3fd68140a4d5d5f83c996690c141768e4112827) python312Packages.msal-extensions: refactor
* [`a6be7eaa`](https://github.com/NixOS/nixpkgs/commit/a6be7eaae37b677d3026e2f41d13443103385cb3) maintainers: add ilaumjd
* [`d9bfa1a3`](https://github.com/NixOS/nixpkgs/commit/d9bfa1a33fd7a6319a3475b26877db0a1e9c7df7) ferdium: 6.7.4 -> 6.7.6
* [`1c8a87ee`](https://github.com/NixOS/nixpkgs/commit/1c8a87ee18b458f11cee246933c8d0a791cc7d97) mmsd-tng: cleanup
* [`910e535c`](https://github.com/NixOS/nixpkgs/commit/910e535cde54dc9bdee1af4c65853caf4231d0f3) caprine: init at 2.60.1
* [`d0a6063a`](https://github.com/NixOS/nixpkgs/commit/d0a6063a651206ef337e57b280bac81d3dc74186) aws-c-event-stream: 0.4.2 -> 0.4.3
* [`f9708577`](https://github.com/NixOS/nixpkgs/commit/f9708577690f78362ef76a89fae0a25ac466cdeb) grpc-gateway: 2.21.0 -> 2.22.0
* [`44d500c6`](https://github.com/NixOS/nixpkgs/commit/44d500c6cccd92214a5aed4f2c223ff2702dd47e) python312Packages.incremental: 22.10.0 -> 24.7.2
* [`b5660f32`](https://github.com/NixOS/nixpkgs/commit/b5660f3256d196afd5f82c5746acf34aa27511ad) python312Packages.aiolyric: unpin incremental
* [`bc31f8c6`](https://github.com/NixOS/nixpkgs/commit/bc31f8c667c14455457f863fdeae5844ea408f0b) python312Packages.klein: unstable-2023-09-05 -> 24.8.0
* [`74a3e13b`](https://github.com/NixOS/nixpkgs/commit/74a3e13be1d0fdb3ccd83d4db2afe8285a3e832b) python312Packages.aiolyric: run all tests
* [`2a310c2e`](https://github.com/NixOS/nixpkgs/commit/2a310c2ef1c2ad2a21f275eb6ce7209fc8fa0e4b) python312Packages.aioazuredevops: unpin incremental
* [`a4b24887`](https://github.com/NixOS/nixpkgs/commit/a4b24887d95ec108c43246db189a9b6b16b21ea3) python312Packages.ovoenergy: unpin incremental
* [`5413b8f8`](https://github.com/NixOS/nixpkgs/commit/5413b8f8eed4baea242b5cfc3430f9f634420697) python312Packages.twisted: 24.3.0 -> 24.7.0
* [`720fee1b`](https://github.com/NixOS/nixpkgs/commit/720fee1bd5f84b087c6745734a1b8d79d31f8f92) python312Packages.txtorcon: fix tests
* [`5580883b`](https://github.com/NixOS/nixpkgs/commit/5580883b26cdba7540b6f84318f904d4182913e4) haskellPackages.hnix-store-remote: restrict to 0.6.*
* [`aa994dd2`](https://github.com/NixOS/nixpkgs/commit/aa994dd296be218c8f3ecc902929008530960010) harmonia: switch to non-deprecated SIGN_KEY_PATHS
* [`506773fb`](https://github.com/NixOS/nixpkgs/commit/506773fb175bb928d9aa597368dc80784eea1f6b) python312Packages.chromadb: 0.5.4 -> 0.5.5
* [`e0af6003`](https://github.com/NixOS/nixpkgs/commit/e0af60030b0775d97ad90bdc4dece34ef669c569) beeper-bridge-manager: 0.12.0 -> 0.12.1
* [`0c4e5c66`](https://github.com/NixOS/nixpkgs/commit/0c4e5c66a1f1203f7b3e50b136b0d289a3e1ed0a) python312Packages.aiortm: 0.8.17 -> 0.8.18
* [`db928e65`](https://github.com/NixOS/nixpkgs/commit/db928e65220d1f428a7678bd0f31ac6d2faf145c) aws-c-auth: 0.7.23 -> 0.7.25
* [`34863ee3`](https://github.com/NixOS/nixpkgs/commit/34863ee342fea822e5951882d1f3ffe1b125d42a) flutterPackages-source.v3_{13,16,19}.engine.release.src: fix output size
* [`82ddfe16`](https://github.com/NixOS/nixpkgs/commit/82ddfe16620c582c5ae0f68973771290f7bbd840) udev-gothic: 1.3.1 -> 2.0.0
* [`8b9ca438`](https://github.com/NixOS/nixpkgs/commit/8b9ca438650a5ab1d5d4f5853332286bc873d328) udev-gothic-nf: 1.3.1 -> 2.0.0
* [`71de7c7e`](https://github.com/NixOS/nixpkgs/commit/71de7c7e2b6214d17a970dbcd12176674f8c87c3) amdvlk: cleanup
* [`04d72f3b`](https://github.com/NixOS/nixpkgs/commit/04d72f3b80beda40daf35fd4a2ba85fad2bcb77d) _86Box: darwin support
* [`4aae1e48`](https://github.com/NixOS/nixpkgs/commit/4aae1e48fada2ece20fa64b71a101f79ed9e1e72) _86Box: remove 'with lib;'
* [`579ba840`](https://github.com/NixOS/nixpkgs/commit/579ba84089f0756e78411a4f2cc2ada7ce4871b6) _86Box: format with nixfmt-rfc-style
* [`a878e02e`](https://github.com/NixOS/nixpkgs/commit/a878e02e3775a2cd2e280e1e147cd619b92a933c) _86Box: add matteopacini as darwin maintainer
* [`a72194fa`](https://github.com/NixOS/nixpkgs/commit/a72194fa1a08c5daa027c74a0cfb53a7d3e5e1ba) amdvlk: move to pkgs/by-name
* [`45e20816`](https://github.com/NixOS/nixpkgs/commit/45e20816054abcb2f5556645ea7d89476dc401b6) semantic-release: 24.0.0 -> 24.1.0
* [`9a7636d9`](https://github.com/NixOS/nixpkgs/commit/9a7636d98930c205c595dd0e02305e90acb7ec29) python312Packages.aiohttp-socks: 0.8.4 -> 0.9.0
* [`422d8530`](https://github.com/NixOS/nixpkgs/commit/422d853079c4a33223444e990c4842e87ce2165c) liboop: drop
* [`bab27735`](https://github.com/NixOS/nixpkgs/commit/bab27735f692d6de2d98a3d620b0956c698f05a6) emacsPackages.prisma-mode: add missing dependency lsp-mode
* [`43303ab4`](https://github.com/NixOS/nixpkgs/commit/43303ab4bde05c1e5ba15f87e3f36851b63e3f2e) emacsPackages.voicemacs: add missing dependency el-patch
* [`b9073bef`](https://github.com/NixOS/nixpkgs/commit/b9073bef290c5e31b0513abba120b1fc5ad3613c) emacs.pkgs.matrix-client: delete
* [`2421239d`](https://github.com/NixOS/nixpkgs/commit/2421239d668e84349a94a72fe21c2eefba4c8121) emacs: let nix build for manualPackages fail if native-comp fails
* [`6fd0909c`](https://github.com/NixOS/nixpkgs/commit/6fd0909cd795066a340de701499c446e16f47d17) bartender: 5.0.52 -> 5.1.0
* [`94bd5958`](https://github.com/NixOS/nixpkgs/commit/94bd59582d1408348dfcb15fcc6709fd4af16e14) telegram-desktop.tg_owt: 0-unstable-2024-08-02 -> 0-unstable-2024-08-04
* [`05f5d395`](https://github.com/NixOS/nixpkgs/commit/05f5d395cbf275f05a02a1ce7f8d874a81982628) telegram-desktop: 5.3.2 -> 5.4.0
* [`fd5f2f5e`](https://github.com/NixOS/nixpkgs/commit/fd5f2f5eb22c7d04cf88838ea232d0a7d6791e36) telegram-desktop: 5.4.0 -> 5.4.1
* [`087869a9`](https://github.com/NixOS/nixpkgs/commit/087869a945c96289c96bd5a1985e8d173efd54a1)  python312Packages.aiohttp-socks: refactor
* [`d903b254`](https://github.com/NixOS/nixpkgs/commit/d903b254cd454749a3701ff27f8152939f9fc9d5) python3Packages.pixelmatch: drop
* [`891e6fd7`](https://github.com/NixOS/nixpkgs/commit/891e6fd75a10cc029141a62e92e0061975ca4585) librealsense: 2.54.2 -> 2.55.1
* [`98a6160a`](https://github.com/NixOS/nixpkgs/commit/98a6160ab97959600ef689176eea572f348c54c1) librealsense: unbreak cuda
* [`8b47eab3`](https://github.com/NixOS/nixpkgs/commit/8b47eab338d90b334ed41373ca423e066651d5e8) python312Packages.manim-slides: add missing build dependency
* [`adfc1349`](https://github.com/NixOS/nixpkgs/commit/adfc13497d6ed67c5888cdf2838fbc9eaf7f7c01) stgit: 2.4.9 -> 2.4.10
* [`fb046fbc`](https://github.com/NixOS/nixpkgs/commit/fb046fbc20753ed28d26c3ec98732b8c883dbc6b) zxtune: 5061 -> 5071
* [`50f5dd89`](https://github.com/NixOS/nixpkgs/commit/50f5dd8917ff8e2e2aebc59e0e74bed35c78e7eb) mate.engrampa: 1.28.1 -> 1.28.2
* [`fecc4a26`](https://github.com/NixOS/nixpkgs/commit/fecc4a2679213932f26f0103451b668c8200eecd) lapce: 0.4.0 -> 0.4.1
* [`bd226efd`](https://github.com/NixOS/nixpkgs/commit/bd226efd48bb924dd2a2385fef72cac711e5eddd) gvm-libs: 22.8.0 -> 22.10.0
* [`b1379365`](https://github.com/NixOS/nixpkgs/commit/b1379365c0b8c3fe9d2c43c304a2c04287d2386b) haskellPackages.quickspec: Unmark broken
* [`9ec7f4bb`](https://github.com/NixOS/nixpkgs/commit/9ec7f4bb640344b01105769c9f1c0ab4a25cb392) python312Packages.daphne: fix tests with Twisted 24.7.0
* [`cd3a7f51`](https://github.com/NixOS/nixpkgs/commit/cd3a7f51ad760cae72d64956feccf22f1a900c15) haskellPackages.quickcheck-state-machine: Fix build failure in tests
* [`f18afac3`](https://github.com/NixOS/nixpkgs/commit/f18afac329341e1445b455d4f60ccf8b6d830ae4) haskellPackages: regenerate package set based on current config
* [`6dccc1a4`](https://github.com/NixOS/nixpkgs/commit/6dccc1a420a5bb5a5414ba98401add07e6a57151) rust-parallel: init 1.18.1
* [`47c7db93`](https://github.com/NixOS/nixpkgs/commit/47c7db93d320571afd62173c2dfac159650bfa0c) maintainers: add sedlund
* [`498d6626`](https://github.com/NixOS/nixpkgs/commit/498d66266280db0ecee88a11c36666e3838c8065) make-startupitem: fix {prepend,append}ExtraArgs for Exec without arguments
* [`df2bfebf`](https://github.com/NixOS/nixpkgs/commit/df2bfebf33a8f467585d640d2c6f74e09ed64523) lammps: don't use with lib in meta
* [`03d44579`](https://github.com/NixOS/nixpkgs/commit/03d44579fba974e35f694e4c34242024e3900e7d) lammps: build shared libs
* [`f573aaed`](https://github.com/NixOS/nixpkgs/commit/f573aaedbb11e60be8483ba468d19dbf85fefd88) lammps: use lib.cmakeBool for packages cmakeFlags
* [`8da4899d`](https://github.com/NixOS/nixpkgs/commit/8da4899d248c4dce63e92ce65f8d7612bd9a156d) maintainers: add nebunebu
* [`2a01c732`](https://github.com/NixOS/nixpkgs/commit/2a01c732f5253d5f38c6a7d983d195097972609b) _7zz: 24.07 -> 24.08
* [`c5bc9942`](https://github.com/NixOS/nixpkgs/commit/c5bc9942ad9bbb56604cbe585ff12af3908e1e58) python31{2,1}Packages.lammps: init at 2Aug2023_update3
* [`2a1b95d6`](https://github.com/NixOS/nixpkgs/commit/2a1b95d6e33a869d52889154b6a814bc5b2e5cd9) wire-desktop: add ozone platform hint for wayland
* [`401a54f0`](https://github.com/NixOS/nixpkgs/commit/401a54f03c34cc80c1911afa4ce44d7094754915) qgis: 3.38.1 -> 3.38.2
* [`19f6a13e`](https://github.com/NixOS/nixpkgs/commit/19f6a13e7852d15ab2dde836621abea9ed0bb21f) qgis-ltr: 3.34.9 -> 3.34.10
* [`45887b09`](https://github.com/NixOS/nixpkgs/commit/45887b09cd56c2e90adf756b2d0c9a360a315982) gtfocli: 0.0.4 -> 0.0.5
* [`8e98705b`](https://github.com/NixOS/nixpkgs/commit/8e98705b81096aa22321780b13a5b1112b429167) textlint: fix build on aarch64-linux
* [`119712f2`](https://github.com/NixOS/nixpkgs/commit/119712f21ef9887bcc0afa53f60dcbeb2354480c) gmobile: init at 0.2.1
* [`fffa43b0`](https://github.com/NixOS/nixpkgs/commit/fffa43b03e4f1ddb2ad11151af7209709c804da6) phoc: 0.38.0 -> 0.41.0
* [`f8fceac2`](https://github.com/NixOS/nixpkgs/commit/f8fceac2de6fa57e8ae5fbff827f84511941cc7d) phosh: 0.39.0 -> 0.41.0
* [`ef947512`](https://github.com/NixOS/nixpkgs/commit/ef947512dd91692cef3e5e3e19dcb669a82f76c2) phosh-mobile-settings: 0.39.0 -> 0.41.0
* [`07dac017`](https://github.com/NixOS/nixpkgs/commit/07dac017ce4f374fa41846402db015eea00a62fe) mmsd-tng: 1.12.1 -> 2.6.1
* [`f6f5249a`](https://github.com/NixOS/nixpkgs/commit/f6f5249ab30d3a8cd68ed6335913842a5b9b7bb4) _64gram: 1.1.31 -> 1.1.34 and disable self update
* [`da69826d`](https://github.com/NixOS/nixpkgs/commit/da69826d745bdad0f2d9fc00830403387c6f3eb7) dbeaver-bin: fix crash at startup
* [`d4d4fcc3`](https://github.com/NixOS/nixpkgs/commit/d4d4fcc35fbc56b3981407296196368273e3d7a9) cups-idprt-tspl: init at 1.4.7
* [`bf988847`](https://github.com/NixOS/nixpkgs/commit/bf98884720bd2641e28cbbb6e1df009a355b7286) cups-idprt-barcode: init at 1.2.1
* [`d298a664`](https://github.com/NixOS/nixpkgs/commit/d298a6648887ab60a5932e2ceac62571ad0859c6) cups-idprt-mt888: init at 1.2.0
* [`e173852a`](https://github.com/NixOS/nixpkgs/commit/e173852abfed19f4af528889af40fe0047926bf1) cups-idprt-mt890: init at 1.2.0
* [`5b479c99`](https://github.com/NixOS/nixpkgs/commit/5b479c99b3a61ae19c10c76b8a5b8838f0e974e2) cups-idprt-sp900: init at 1.4.0
* [`9ba89a14`](https://github.com/NixOS/nixpkgs/commit/9ba89a14d9ef50588779b133cc19da83b6753ca7) sway-scratch: init at 0.2.1
* [`6c2e19d0`](https://github.com/NixOS/nixpkgs/commit/6c2e19d099480c659467a7005796c10432e04046) libdeltachat: 1.142.1 -> 1.142.7
* [`7a7b9e09`](https://github.com/NixOS/nixpkgs/commit/7a7b9e09b26d4a9c2eeeeb2b8df7beac0690edff) libdeltachat: move to pkgs/by-name
* [`3680e49d`](https://github.com/NixOS/nixpkgs/commit/3680e49de49c83a610ca9e33241fb343271ae70d) maintainers: add jovandeginste
* [`5be6d620`](https://github.com/NixOS/nixpkgs/commit/5be6d6203bc660afa475cb86b1417b764d721990) mollysocket: 1.4.0 -> 1.4.1
* [`0a1ac778`](https://github.com/NixOS/nixpkgs/commit/0a1ac7786829ee041106d21a6cccbc2edf15940f) diffoscope: 275 -> 276
* [`a8b4b275`](https://github.com/NixOS/nixpkgs/commit/a8b4b275e858375b86d2f0a0e7ce98372d36a787) webex: 44.5.0.29672 -> 44.8.0.30404
* [`85bcb27f`](https://github.com/NixOS/nixpkgs/commit/85bcb27f4eec367f6716aaacf717868948408d3f) bloop: 1.6.0 -> 2.0.0
* [`539f2e72`](https://github.com/NixOS/nixpkgs/commit/539f2e72919c36649dcc6480581291fce71e178c) wechat-uos: fix crashing issue caused by zerocallusedregs hardening
* [`bdfc9f7a`](https://github.com/NixOS/nixpkgs/commit/bdfc9f7a981d5566d2ae76bf8d58dd995920a2a8) python312Packages.equinox: 0.11.4 -> 0.11.5
* [`718275f8`](https://github.com/NixOS/nixpkgs/commit/718275f83c549cf8e80333b92ef1964af8ee172b) portfolio: fix crash at startup
* [`27d67275`](https://github.com/NixOS/nixpkgs/commit/27d67275a1f671e9ba90e216b4d3638bb1705dba) hubstaff: 1.6.24-094b0af9 -> 1.6.26-95441346
* [`b54552aa`](https://github.com/NixOS/nixpkgs/commit/b54552aa3fa533e8f1b92b9f23bc791352da0e43) meteor-git: init at 0.22.0
* [`4c059d48`](https://github.com/NixOS/nixpkgs/commit/4c059d484ed368b9aa232753d68d3faf45883fa7) miniflux: 2.1.4 -> 2.2.0
* [`37e90282`](https://github.com/NixOS/nixpkgs/commit/37e90282540c5728fed6b81d3dedd29b3b2a9c6e) google-chrome: 127.0.6533.99 -> 127.0.6533.119
* [`0c44eb67`](https://github.com/NixOS/nixpkgs/commit/0c44eb676097c49f208d41c01faf977e841ec72b) python312Packages.flask-limiter: specify optional dependencies
* [`b7abe4e2`](https://github.com/NixOS/nixpkgs/commit/b7abe4e26b54eae98d5d45592c74b56ee81f1e9d) fit-trackee: 0.8.5 -> 0.8.6
* [`3001940a`](https://github.com/NixOS/nixpkgs/commit/3001940a906587b63c1b83ec8ea78c0a9b847e1f) gcc14: 14.1.0 -> 14.2.0
* [`660a8b1c`](https://github.com/NixOS/nixpkgs/commit/660a8b1c81beee976c452f0ab7e8e9586c1e25cc) irrd: unbreak
* [`cb0b3482`](https://github.com/NixOS/nixpkgs/commit/cb0b3482892dbc53c649c607cb3dc1c664297fe4) hatch: clean, format and fix build
* [`a6fc8b8b`](https://github.com/NixOS/nixpkgs/commit/a6fc8b8bf570257e4cdb37c0b4a440c2272ce1dd) lefthook: 1.7.12 -> 1.7.14
* [`4f33aca4`](https://github.com/NixOS/nixpkgs/commit/4f33aca4e48580408489587f97e7b387296328b6) python312Packages.opower: 0.6.0 -> 0.7.0
* [`d3cfed5f`](https://github.com/NixOS/nixpkgs/commit/d3cfed5f7ba9422bf87e2e15070bacaef218d050) python312Packages.aiohomekit: 3.2.2 -> 3.2.3
* [`e8443c16`](https://github.com/NixOS/nixpkgs/commit/e8443c1626246761ddf555c7c0b27f3322e06bec) troubadix: 24.7.4 -> 24.8.0
* [`85579079`](https://github.com/NixOS/nixpkgs/commit/8557907904bbca99d73e794201dd5950d058656f) python312Packages.google-nest-sdm: 4.0.6 -> 4.0.7
* [`2493523b`](https://github.com/NixOS/nixpkgs/commit/2493523bae4479f75018e767cada38b72fe0147b) python312Packages.yalesmartalarmclient: 0.3.9 -> 0.4.0
* [`86aef8ef`](https://github.com/NixOS/nixpkgs/commit/86aef8eff3e0b7a2f5c98690bca3848fdb459f83) python312Packages.python-homewizard-energy: 6.3.0 -> 6.3.0
* [`13871642`](https://github.com/NixOS/nixpkgs/commit/1387164291d1d442f38fde97b9ff861837628ec4) trufflehog: 3.81.8 -> 3.81.9
* [`8152fcd2`](https://github.com/NixOS/nixpkgs/commit/8152fcd22a31949429e4f3d91b8c57687bbdf2db) quickfix: format
* [`98c68a8b`](https://github.com/NixOS/nixpkgs/commit/98c68a8b3bd39886988a9e56467b95b33cf0a608) quickfix: fix build on Darwin
* [`f88424f5`](https://github.com/NixOS/nixpkgs/commit/f88424f5d8ae28bc589a005a83ddcadd596ab5ec) karabiner-elements: format with nixfmt-rfc-style
* [`fa35b059`](https://github.com/NixOS/nixpkgs/commit/fa35b059552c02693c57321383eb9f3673a5feec) karabiner-elements: refactor meta
* [`b941404a`](https://github.com/NixOS/nixpkgs/commit/b941404ab94f4a96545957c2655caaf5b1ce591b) karabiner-elements: simplify updateScript
* [`e4d93e7f`](https://github.com/NixOS/nixpkgs/commit/e4d93e7f56c71d667a7261fd331f9aa95fc30409) cbtemulator: 1.22.0 -> 1.29.0
* [`e5aa8e21`](https://github.com/NixOS/nixpkgs/commit/e5aa8e21821e0591434db3ab6281569d86ebef30) karabiner-elements: switch to finalAttrs pattern
* [`ea09687d`](https://github.com/NixOS/nixpkgs/commit/ea09687d5fa113ff6bdaba5e79850d99334664bd) karabiner-elements: 14.13.0 -> 15.0.0
* [`f7fbcb84`](https://github.com/NixOS/nixpkgs/commit/f7fbcb8427f1d3f4f17c12deef044cd0b42bc344) emacsPackages.tsc: refactor
* [`28505bd0`](https://github.com/NixOS/nixpkgs/commit/28505bd0025e8757259664cfec4d5913fdfe3832) python312Packages.anthropic: 0.33.0 -> 0.34.0
* [`9562b3d2`](https://github.com/NixOS/nixpkgs/commit/9562b3d2af281ad1786d854caa68458ff0459fba) ccextractor: 0.93 -> 0.94-unstable-2024-08-12
* [`9c1be92c`](https://github.com/NixOS/nixpkgs/commit/9c1be92c509a4f7fac2d8fbd036fcbe56a3bed99) openfga: 1.5.8 -> 1.5.9
* [`d0c8907a`](https://github.com/NixOS/nixpkgs/commit/d0c8907aeaf87226b69ba4e06974f68e5ac67f4a) qovery-cli: 1.2.0 -> 1.2.4
* [`2d095db6`](https://github.com/NixOS/nixpkgs/commit/2d095db6e1bc9f72c1188f6dfc1abe9135824021) walker: 0.6.7 -> 0.7.6
* [`800c7426`](https://github.com/NixOS/nixpkgs/commit/800c7426a07048a6541651cd0aac32f2e5e7d485) cargo-shear: 1.1.1 -> 1.1.2
* [`295604c6`](https://github.com/NixOS/nixpkgs/commit/295604c68c23ca07fce718d70f1bee982848ab35) cpufetch: 1.05 -> 1.06
* [`a2b8e09f`](https://github.com/NixOS/nixpkgs/commit/a2b8e09fea044bccdbd471d9aab98ccc9f801ff9) xdg-desktop-portal: disable bad test
* [`8ab167a8`](https://github.com/NixOS/nixpkgs/commit/8ab167a8c8edf631638920a91071337951663bca) prometheus-influxdb-exporter: 0.11.5 -> 0.11.7
* [`dd3c115d`](https://github.com/NixOS/nixpkgs/commit/dd3c115d03553b62dd060d71a9f579470d9780b5) maskromtool: 2024-07-14 -> 2024-08-18
* [`3ce5bb51`](https://github.com/NixOS/nixpkgs/commit/3ce5bb51f2f9e4ad979e0e45fab857be72e1d657) ocamlPackages.ezjsonm-encoding: 2.0.0 -> 2.1.0
* [`c364b166`](https://github.com/NixOS/nixpkgs/commit/c364b16672a250486fd60969c809115af0998ec4) libdwarf-lite: 0.10.1 -> 0.11.0
* [`b9e65c80`](https://github.com/NixOS/nixpkgs/commit/b9e65c8006da809356ee93b14490b2dffd4173af) prometheus-statsd-exporter: 0.26.1 -> 0.27.1
* [`a9ae7e68`](https://github.com/NixOS/nixpkgs/commit/a9ae7e6838e069012e39af6e2470ccbf62836377) prometheus-graphite-exporter: 0.15.1 -> 0.15.2
* [`c2d1d138`](https://github.com/NixOS/nixpkgs/commit/c2d1d1383af67190f41f78fe9686ef8ba4ce7ddb) manifold: init at 2.5.1-unstable-2024-08-18
* [`0b77dbce`](https://github.com/NixOS/nixpkgs/commit/0b77dbce92b08bf447d5ceeaca73eb7dda664a52) python312Packages.dio-chacon-wifi-api: 1.2.0 -> 1.2.1
* [`952a596a`](https://github.com/NixOS/nixpkgs/commit/952a596ab833312231c5ff3b88c424ed85efe31b) add maintainer: bleetube
* [`a4e933bd`](https://github.com/NixOS/nixpkgs/commit/a4e933bdee2f456fb523649cc972b47547645ef0) sarasa-gothic: 1.0.18 -> 1.0.19
* [`2f681f12`](https://github.com/NixOS/nixpkgs/commit/2f681f12303cb7656401f574e6151a463977eee7) tenv: 3.0.0 -> 3.1.0
* [`bf2e74ff`](https://github.com/NixOS/nixpkgs/commit/bf2e74ff7880ffc2ad1b1e45c27ac735d75414c3) antimatter-dimensions: 0-unstable-2024-06-28 -> 0-unstable-2024-08-12
* [`3f8bcb8b`](https://github.com/NixOS/nixpkgs/commit/3f8bcb8b01f345ee6ab2a880f872837f821f80d5) miru: 5.2.14 -> 5.3.1
* [`25a8ee78`](https://github.com/NixOS/nixpkgs/commit/25a8ee78fe0a9b2cb8919ec62f83abf242147de8) sing-box: 1.9.3 -> 1.9.4
* [`e591b806`](https://github.com/NixOS/nixpkgs/commit/e591b806c74a9b3bd2d344bbd8dbbbcbec7ae96a) fluent-bit: 3.1.5 -> 3.1.6
* [`5a4d3453`](https://github.com/NixOS/nixpkgs/commit/5a4d34533876fa3658c5dacdd7c7f7b70b2d43f2) python312Packages.imageio: 2.35.0 -> 2.35.1
* [`cf6b5469`](https://github.com/NixOS/nixpkgs/commit/cf6b546936516192d5c1d9a7b7d731af211942ad) ocamlPackages.cohttp-mirage: remove at 5.3.1
* [`19878eaf`](https://github.com/NixOS/nixpkgs/commit/19878eaf162c0a35805cd86d55a236b29fea3fbb) ocamlPackages.mirage-channel: remove at 4.1.0
* [`8bcc5c9e`](https://github.com/NixOS/nixpkgs/commit/8bcc5c9e2551d9b8e5d6599862139da449b9ad11) ocamlPackages.mirage-console-unix: remove at 5.1.0
* [`1f92ee7a`](https://github.com/NixOS/nixpkgs/commit/1f92ee7ad719bb6d24d4053cfbd152791c2ac733) ocamlPackages.tls: 0.17.3 → 0.17.5
* [`7f907528`](https://github.com/NixOS/nixpkgs/commit/7f907528a811316c9637bde923e2ba2af0fb0706) fh: 0.1.10 -> 0.1.16, fix build
* [`17681155`](https://github.com/NixOS/nixpkgs/commit/1768115589e38369ec3517c18160588b7a36a2f7) nixos/cgit: handle list setting type
* [`d8c7f812`](https://github.com/NixOS/nixpkgs/commit/d8c7f812795b6fbebd13da629fc3ac19777ed85d) nixos/cgit: test list settings type
* [`69f24c55`](https://github.com/NixOS/nixpkgs/commit/69f24c557531de864424b50da59d7e7fefc99b93) linux_testing: 6.11-rc3 -> 6.11-rc4
* [`ada73e57`](https://github.com/NixOS/nixpkgs/commit/ada73e57e749d3b65799ceccdf5f1fa98c1e4fe7) linux_6_10: 6.10.5 -> 6.10.6
* [`97a2b970`](https://github.com/NixOS/nixpkgs/commit/97a2b970d9eff924f5dc3e50599ecd51eec7b33f) linux_6_6: 6.6.46 -> 6.6.47
* [`61e71859`](https://github.com/NixOS/nixpkgs/commit/61e71859f47919f58022096dd97c05539a5c76e9) linux_6_1: 6.1.105 -> 6.1.106
* [`b073b434`](https://github.com/NixOS/nixpkgs/commit/b073b43445fdd414b5d82814236d4f9f6db5d972) linux_5_15: 5.15.164 -> 5.15.165
* [`f407a437`](https://github.com/NixOS/nixpkgs/commit/f407a437954e5abd30dc6adb1d4c6fd0a8dbb5fb) linux_5_10: 5.10.223 -> 5.10.224
* [`14aadc32`](https://github.com/NixOS/nixpkgs/commit/14aadc321b4dc9e104fc13ec195de96af06c91ab) linux_5_4: 5.4.281 -> 5.4.282
* [`764392dc`](https://github.com/NixOS/nixpkgs/commit/764392dcfcc6d6e3dc19697daa447c6e2a5e6e71) linux_4_19: 4.19.319 -> 4.19.320
* [`dba2363a`](https://github.com/NixOS/nixpkgs/commit/dba2363a18c27bb20a55b91d3a57472ab09f2169) linux-rt_6_1: 6.1.102-rt37 -> 6.1.105-rt38
* [`1d11eba6`](https://github.com/NixOS/nixpkgs/commit/1d11eba657623a14e752975539d2a69b1d5039ff) xen-guest-agent: remove libclang environment variable
* [`bd4c69da`](https://github.com/NixOS/nixpkgs/commit/bd4c69da51be8319f0b7fe25e98abab5b6a30fa9) xen-guest-agent: install systemd service
* [`aac35007`](https://github.com/NixOS/nixpkgs/commit/aac35007254b1e84d387a78e31f2fefd6dd59e52) pods: 2.0.0 -> 2.0.1-unstable-2024-08-11
* [`b7928590`](https://github.com/NixOS/nixpkgs/commit/b79285900b76077d2af1d77f4e9ae0938c73e1f5) gofumpt: 0.6.0 -> 0.7.0
* [`5a558cc1`](https://github.com/NixOS/nixpkgs/commit/5a558cc13f11f4648ca52d6e10d77dfe2b40f32a) bitrise: init at 2.19.0
* [`7d38b25f`](https://github.com/NixOS/nixpkgs/commit/7d38b25f44ad4b365603e665ecdbc65a85340699) libsignal-ffi: fix darwin build
* [`6d985278`](https://github.com/NixOS/nixpkgs/commit/6d9852786929e026b7aff9dd10367f1e190545ab) python312Packages.limits: modernize
* [`13aed30c`](https://github.com/NixOS/nixpkgs/commit/13aed30cd138c9445396cb0ce02b7311280d594a) python312Packages.limits: 3.12.0 -> 3.13.0
* [`a047cce7`](https://github.com/NixOS/nixpkgs/commit/a047cce7049f2f82a0c07d6b252961aa4a398538) python312Packages.flask-limiter: modernize
* [`a9d8bdc3`](https://github.com/NixOS/nixpkgs/commit/a9d8bdc3cee22929e8dd863bf9b4b993cae335a6) python312Packages.flask-limiter: 3.7.0 -> 3.8.0
* [`815d5589`](https://github.com/NixOS/nixpkgs/commit/815d5589d958531af840d7e29424c8525aeff441) zerotierone: fix build with Rust 1.80 ([nixos/nixpkgs⁠#335676](https://togithub.com/nixos/nixpkgs/issues/335676))
* [`7ba5c23a`](https://github.com/NixOS/nixpkgs/commit/7ba5c23a8ced44b6ee2e28dc407876872117b8bb) lint-staged: 15.2.8 -> 15.2.9
* [`4ea76a39`](https://github.com/NixOS/nixpkgs/commit/4ea76a39c891adf8657676392c03283e9d8de9c7) element-web: don't inherit jitsi-meet's knownVulnerabilities
* [`eab75cbf`](https://github.com/NixOS/nixpkgs/commit/eab75cbf0e885ff9e86bf2a23ee2c32c3efe0814) graphite-cli: 1.4.1 -> 1.4.2
* [`e2cad224`](https://github.com/NixOS/nixpkgs/commit/e2cad22427c25164d308803f0f20c4508939a9e3) dsda-doom: 0.28.0 -> 0.28.1
* [`cf3b2b97`](https://github.com/NixOS/nixpkgs/commit/cf3b2b972c4da04ebe64d392f8a846afba3d692b) python312Packages.green: remove failing test
* [`c5317861`](https://github.com/NixOS/nixpkgs/commit/c53178613a94bc833e7006435d388603a022d42b) hwinfo: fix runtime dependencies
* [`d9139cea`](https://github.com/NixOS/nixpkgs/commit/d9139cea92ce7a060b5e9ee1a497b164e56c3837) ryujinx: 1.1.1373 -> 1.1.1376
* [`4fd2c198`](https://github.com/NixOS/nixpkgs/commit/4fd2c198e34abc687f969f2bc52a10866812f1bb) dsda-doom: cleanup
* [`44f802c7`](https://github.com/NixOS/nixpkgs/commit/44f802c761fef68bf7892431764e6338c967252a) azure-cli-extensions.storage-preview: init at 1.0.0b2
* [`66c27851`](https://github.com/NixOS/nixpkgs/commit/66c27851b83f1bfa553f003324722d0ede0b8127) zeal: fix build against Qt 6.7.2
* [`d6058c6d`](https://github.com/NixOS/nixpkgs/commit/d6058c6de42595ae48935eb9879598fcceb6dd61) proton-pass: 1.20.2 -> 1.22.0
* [`2d421238`](https://github.com/NixOS/nixpkgs/commit/2d421238d7166948a33708bcfb42fbae9b790c38) duplicity: 2.2.3 -> 3.0.2
* [`cd077fee`](https://github.com/NixOS/nixpkgs/commit/cd077fee963272681ed549f3313789b9983a2690) python312Packages.openai: 1.39.0 -> 1.40.8
* [`5ae44432`](https://github.com/NixOS/nixpkgs/commit/5ae444326911f1f3d555d3ca7280d5975164ddb8) python312Packages.langchain-community: 0.2.7 -> 0.2.12
* [`cc288762`](https://github.com/NixOS/nixpkgs/commit/cc2887629977ddd961f78294ae7d509ccc3885d9) python312Packages.tencentcloud-sdk-python: 3.0.1213 -> 3.0.1214
* [`14fbed4b`](https://github.com/NixOS/nixpkgs/commit/14fbed4b701648a5ec5536ff51945f44cde1767c) nixos/mastodon: don't pin postgresql version for test
* [`1592790b`](https://github.com/NixOS/nixpkgs/commit/1592790b039acaf4820a76f203434808d395a3b2) nixos/mastodon: use correct postgresql package
* [`3376e300`](https://github.com/NixOS/nixpkgs/commit/3376e3000d9047901015f281de5917f94c787d46) checkov: 3.2.228 -> 3.2.231
* [`ca17c446`](https://github.com/NixOS/nixpkgs/commit/ca17c446da9fca6379364f408edd66949e1058f5) simgrid: use `lib.cmakeBool/cmakeFeature`
* [`35342f72`](https://github.com/NixOS/nixpkgs/commit/35342f72d701b095e017857e2eeca5af98d2a535) heptabase: init at 1.35.3
* [`af6af513`](https://github.com/NixOS/nixpkgs/commit/af6af513b996b69165059dfe4fef9a4f1561a9a6) python312Packages.python-linkplay: 0.0.6 -> 0.0.8
* [`bbf93c95`](https://github.com/NixOS/nixpkgs/commit/bbf93c95bd88ee7e6f64a678fd316f6fb792f49a) duplicity: add meta.changelog
* [`2da4dee9`](https://github.com/NixOS/nixpkgs/commit/2da4dee9139215e42855a2a66eb62a66e0c758c2) xmrig-mo: 6.22.0-mo1 -> 6.22.0-mo3
* [`e0794de5`](https://github.com/NixOS/nixpkgs/commit/e0794de53a4ccb7112c6d427c392515ac483b659) silverbullet: 0.9.0 -> 0.9.2
* [`fecc6af4`](https://github.com/NixOS/nixpkgs/commit/fecc6af462655f2f061957b2b12bf6fe62dd768f) miracle-wm: 0.3.0 -> 0.3.2, fix build
* [`3fe58db7`](https://github.com/NixOS/nixpkgs/commit/3fe58db7d007670758a45273183ee7f4e9b5a500) mastodon: 4.2.11 -> 4.2.12
* [`25549408`](https://github.com/NixOS/nixpkgs/commit/25549408ab22177c1772b06e1e14915a642630ae) palemoon-bin: 33.2.1 -> 33.3.0
* [`b2306ddc`](https://github.com/NixOS/nixpkgs/commit/b2306ddcb8e2cf8d052f5cc57177203727d940d0) process-cpp: 3.0.1-unstable-2024-03-14 -> 3.0.2
* [`29058a4b`](https://github.com/NixOS/nixpkgs/commit/29058a4be2bb175873e86c5c8451de079c7d966c) process-cpp: nixfmt
* [`85f5b431`](https://github.com/NixOS/nixpkgs/commit/85f5b4310cee5404cd7bf86caf1454b487c223b7) cockroachdb-bin: remove neosimsim from meta.maintainers
* [`a5e5d66a`](https://github.com/NixOS/nixpkgs/commit/a5e5d66a4c41593b0f1d2e00c789d025b07e3490) vimPlugins: introduce passthru.initLua for some plugins ([nixos/nixpkgs⁠#334913](https://togithub.com/nixos/nixpkgs/issues/334913))
* [`74bda36a`](https://github.com/NixOS/nixpkgs/commit/74bda36a0a393897a623ceaa7d4c865341220b42) python312Packages.glean-parser: 14.5.1 -> 14.5.2
* [`dc9fccd6`](https://github.com/NixOS/nixpkgs/commit/dc9fccd6c7319179461ae4d97b923c0197480512) fastfetch: 2.21.2 -> 2.21.3
* [`cbd09efd`](https://github.com/NixOS/nixpkgs/commit/cbd09efda26506844dbf4e72a9b8a2d250d8c5a7) zopfli: set meta.mainProgram
* [`d3a139bf`](https://github.com/NixOS/nixpkgs/commit/d3a139bf97854d493821f5390dd8da6c034cac2b) zstd: set meta.mainProgram
* [`7ebbf278`](https://github.com/NixOS/nixpkgs/commit/7ebbf278326dd25d5ba921cbb705da6c11ff5984) compress-drv: sort formats
* [`6449d32b`](https://github.com/NixOS/nixpkgs/commit/6449d32b0a0f94bd6e6bc057acecb16ce00a0ffc) compress-drv: add htm, otf formats to default
* [`9581a2bd`](https://github.com/NixOS/nixpkgs/commit/9581a2bdcaa97a17f1147deab25e12c3e6d6ccf5) compress-drv: misc cleanup
* [`0ca4bfa7`](https://github.com/NixOS/nixpkgs/commit/0ca4bfa7002996b2207431d791dd66a8dd9acd84) compress-drv: add zstd
* [`4cc5dee0`](https://github.com/NixOS/nixpkgs/commit/4cc5dee048cb5e5e61db4fe74bf21812add9e028) compress-drv: allow passing extra arguments to find
* [`0654f81d`](https://github.com/NixOS/nixpkgs/commit/0654f81d56c56b455274be2553e374df2ca7a458) compress-drv: carry pname, version forward
* [`a1d5c9d1`](https://github.com/NixOS/nixpkgs/commit/a1d5c9d11af37c06a1bda4894699c3e5dceeb2b4) paperless-ngx: change symlink to work with compressDrvWeb
* [`0505523e`](https://github.com/NixOS/nixpkgs/commit/0505523e987e9c2e2ad4a7690583f86c5485cabf) compress-drv: correct comment
* [`a63fc233`](https://github.com/NixOS/nixpkgs/commit/a63fc233cc7413bf86dd5dcc161c80acc3b0dd3a) python312Packages.quil: 0.10.0 -> 0.11.2
* [`2fd8d299`](https://github.com/NixOS/nixpkgs/commit/2fd8d2999e02a2d3283f7d7f03f3a307963a60f7) Revert [nixos/nixpkgs⁠#314299](https://togithub.com/nixos/nixpkgs/issues/314299): dhcpcd: 10.0.6 -> 10.0.8
* [`a419f4ca`](https://github.com/NixOS/nixpkgs/commit/a419f4caccd860643aecf5976acb46f94ea68adf) maa-cli: 0.4.10 -> 0.4.11
* [`a2de5ef8`](https://github.com/NixOS/nixpkgs/commit/a2de5ef85eee3b9406385829ef6b7ba4a7a85e3d) python312Packages.qcs-sdk-python: 0.19.0 -> 0.19.2
* [`a619cf04`](https://github.com/NixOS/nixpkgs/commit/a619cf04a7696a6a4e73d21bfd0ff824d0ebd52c) lua-language-server: 3.10.4 -> 3.10.5
* [`cf4ffe3d`](https://github.com/NixOS/nixpkgs/commit/cf4ffe3dcbf31b1e66d2fdba1edc8b5fa71c6ffc) neocmakelsp: 0.7.9 -> 0.8.1
* [`cfc80acb`](https://github.com/NixOS/nixpkgs/commit/cfc80acb81380920d04aec1fab6c2093fe1e728f) eksctl: 0.188.0 -> 0.189.0
* [`f3c94988`](https://github.com/NixOS/nixpkgs/commit/f3c94988cd60d8bba9b442bbee22f269263c4802) labctl: 0.0.22 -> 0.0.22-unstable-2024-05-10
* [`e52c5647`](https://github.com/NixOS/nixpkgs/commit/e52c5647d4c474f3e37f93cff30df9df5ae63bdd) frp: 0.59.0 -> 0.60.0
* [`6270475c`](https://github.com/NixOS/nixpkgs/commit/6270475c59b886df354ed73a6ef942ed3d14c5f5) goflow2: 2.1.5 -> 2.2.0
* [`85562feb`](https://github.com/NixOS/nixpkgs/commit/85562feb5c228bfa56d6b6a786721d308528b294) hishtory: 0.303 -> 0.304
* [`ae5bd14a`](https://github.com/NixOS/nixpkgs/commit/ae5bd14abe720cc25e626ee42fcd2074843be691) clamav: 1.3.1 -> 1.4.0
* [`dac849b1`](https://github.com/NixOS/nixpkgs/commit/dac849b163f22f5d1fe6587fb5fd5e9f36562648) faiss: unbreak pythonless build
* [`3b4f6ef9`](https://github.com/NixOS/nixpkgs/commit/3b4f6ef9686d462fc8986d835ee6fad5604e3c48) beidconnect: init at 2.10
* [`94d2af64`](https://github.com/NixOS/nixpkgs/commit/94d2af6419455e685e5aaaa72c87335d64e2e273) kiwitalk: fix builds with Rust 1.80
* [`168e66ac`](https://github.com/NixOS/nixpkgs/commit/168e66ac8154c0b529cf48f701117d0c1de41e41) github/PULL_REQUEST_TEMPLATE: fix link to linking tests
* [`09735040`](https://github.com/NixOS/nixpkgs/commit/097350409e37e6fd7d6f93610107fa15f6d82911) minio-client: 2024-07-31T15-58-33Z -> 2024-08-17T11-33-50Z
* [`abd5b2bb`](https://github.com/NixOS/nixpkgs/commit/abd5b2bb1422ea03f15d5afb72d011cb97534aa4) mlkit: add tests
* [`a2e3831d`](https://github.com/NixOS/nixpkgs/commit/a2e3831d1d7c613c2afe639f35d8483edaa619a6) swc: 0.91.69 -> 0.91.369
* [`9e157550`](https://github.com/NixOS/nixpkgs/commit/9e157550d03d6e49e90f54d3570d22caa46a49ae) python3Packages.cyrtranslit: init at 1.1.1
* [`960cd985`](https://github.com/NixOS/nixpkgs/commit/960cd9850b859e2d30c631cb8a83f8a9306a7330) python3Packages.django-otp: 1.5.0 -> 1.5.1
* [`59e82ebc`](https://github.com/NixOS/nixpkgs/commit/59e82ebc7df3412a0ecd73f58745fa2a46df40fa) python3Packages.django-otp-webauthn: init at 0.3.0
* [`f5bb4b80`](https://github.com/NixOS/nixpkgs/commit/f5bb4b807c2f1ca1f37ae0ff3c10e87686d35c3e) weblate: 5.6.2 -> 5.7
* [`ab18d221`](https://github.com/NixOS/nixpkgs/commit/ab18d221afe3e52c3335bf48c1fe09fa3492d96b) python312Packages.coffea: 2024.8.0 -> 2024.8.1
* [`2aaf2162`](https://github.com/NixOS/nixpkgs/commit/2aaf216245ec8b776e8df9931632bd2be74d3bb6) nixfmt with rfc style
* [`aada64be`](https://github.com/NixOS/nixpkgs/commit/aada64be54fe6e8af0ea92fe22eede4d27f49e4f) deltachat-desktop: 1.46.2 -> 1.46.5
* [`491f5ebe`](https://github.com/NixOS/nixpkgs/commit/491f5ebe713a44ecd16373cd8b6233fe0f052a5e) deltachat-desktop: move to pkgs/by-name
* [`d832568b`](https://github.com/NixOS/nixpkgs/commit/d832568bbc2571e42817009fd95b2646392c7c44) python312Packages.deltachat-rpc-client: init
* [`91add64d`](https://github.com/NixOS/nixpkgs/commit/91add64d006858d6c0522c7db93096e268cdfbf1) workflows/check-nix-format: Better `nix-shell` message
* [`a468bfc9`](https://github.com/NixOS/nixpkgs/commit/a468bfc94288627df0c8c5b6c804e4d318d34dc1) parmetis: Use KarypisLab GitHub mirror instead of glaros source
* [`84c49afa`](https://github.com/NixOS/nixpkgs/commit/84c49afaaaa997662d819fbf998475803db4bbcf) keycloak: 25.0.2 -> 25.0.4
* [`42fdc711`](https://github.com/NixOS/nixpkgs/commit/42fdc711cc3b453693d8dc3b794fb259e1ca043c) ludusavi: 0.24.3 -> 0.25.0
* [`5dd91651`](https://github.com/NixOS/nixpkgs/commit/5dd916512a0140d7cdaa5c3347d377eb60a841ab) python312Packages.mkdocs-git-revision-date-localized-plugin: 1.2.6 -> 1.2.7
* [`ebb3cf3b`](https://github.com/NixOS/nixpkgs/commit/ebb3cf3ba916f819cecccc9a83a12a8a00813f07) swiftlint: 0.55.1 -> 0.56.1
* [`2a545449`](https://github.com/NixOS/nixpkgs/commit/2a5454490e7596e4ac2e7b24498ccd59e3d8a06a) nixosTests.systemd-boot.memtest86: only run when `memtest86plus` is available ([nixos/nixpkgs⁠#335825](https://togithub.com/nixos/nixpkgs/issues/335825))
* [`bea41b9a`](https://github.com/NixOS/nixpkgs/commit/bea41b9a25b85b77b453ed4046949970e04e90bc) buttermanager: 2.5.1 -> 2.5.2
* [`83c6f0d2`](https://github.com/NixOS/nixpkgs/commit/83c6f0d2f181e6bf95d4319625f36757b0ad1dcb) dbeaver-bin: 24.1.4 -> 24.1.5
* [`e26d0a24`](https://github.com/NixOS/nixpkgs/commit/e26d0a24b8cc69000f96ceb085b70b84f78b94c2) syn2mas: 0.9.0 -> 0.10.0
* [`365a578f`](https://github.com/NixOS/nixpkgs/commit/365a578fadb149da7c387f37b2e9ec75813c3123) python312Packages.ansible-compat: 24.7.0 -> 24.8.0
* [`a87ddf5f`](https://github.com/NixOS/nixpkgs/commit/a87ddf5f7d87d18af850ed3d015c4134a654e6ae) seaweedfs: 3.71 -> 3.72
* [`07b7048a`](https://github.com/NixOS/nixpkgs/commit/07b7048a306cfacb9bc32e9d69d3445e3ea41241) flyctl: 0.2.109 -> 0.2.114
* [`1bb54f39`](https://github.com/NixOS/nixpkgs/commit/1bb54f39c2a1730a47e4355891f443e74d46f6be) python312Packages.pyzx: init at 0.8.0
* [`e9690f62`](https://github.com/NixOS/nixpkgs/commit/e9690f6295300636a36f57498c197bf34b494307) widelands: darwin support
* [`3a5174a9`](https://github.com/NixOS/nixpkgs/commit/3a5174a922a57ac38297b30feb5ed7c736dda066) pgbackrest: 2.53 -> 2.53.1
* [`618c95b2`](https://github.com/NixOS/nixpkgs/commit/618c95b2aa9b7f491e9976db197228e38ba515aa) python312Packages.pyquil: 4.13.0 -> 4.14.1
* [`568b0cfe`](https://github.com/NixOS/nixpkgs/commit/568b0cfe1bbb44d527cfffe1ea6782756f8f6af0) storj-uplink: 1.109.2 -> 1.110.3
* [`01b9e4af`](https://github.com/NixOS/nixpkgs/commit/01b9e4af20fd6c508732e456010e037ff504fccf) openvas-scanner: 23.8.4 -> 23.8.5
* [`ef69e580`](https://github.com/NixOS/nixpkgs/commit/ef69e580f110b419b837040ac961bbc2b13cd2de) redisinsight: fix build
* [`8d974586`](https://github.com/NixOS/nixpkgs/commit/8d974586d7dcf01643dc999c6a9c56c83a3a0dd6) threema-desktop: fix build
* [`4ba32492`](https://github.com/NixOS/nixpkgs/commit/4ba32492acae23d4965d9c3d40e40db7f1ab3439) webcord-vencord: electron_29 -> electron_30
* [`f9fbeb4d`](https://github.com/NixOS/nixpkgs/commit/f9fbeb4d0d8c193ae570ea6f0597acca9ffd0ccc) python3Packages.homf: 1.0.0 → 1.1.1
* [`18c70e93`](https://github.com/NixOS/nixpkgs/commit/18c70e93783d44c667764c14dd91148c6e220f61) opencv4: fix build with enableCuda = true
* [`36a456f1`](https://github.com/NixOS/nixpkgs/commit/36a456f157f26e4be15070e4a8101e1da14e61bf) mealie: fix relative path in code handling backup
* [`d3a10194`](https://github.com/NixOS/nixpkgs/commit/d3a101940d317b4e2496249e2c790d17f8642373) rpl: 1.15.6 -> 1.15.7
* [`80e3fd91`](https://github.com/NixOS/nixpkgs/commit/80e3fd91a92149cb6b463ebe32d5859f89fa6cda) doc/build-helpers: document `runCommandWith`
* [`482d6eaa`](https://github.com/NixOS/nixpkgs/commit/482d6eaab2803e5d3be84124d0677d9dd5234a29) doc/build-helpers: refactor the paragraphs about `runCommand{,CC}`
* [`e3d7e7f2`](https://github.com/NixOS/nixpkgs/commit/e3d7e7f2a7e54978dfeccb95bb0fb9b6761fc0f7) doc/build-helpers: add note relating `runCommand` and `runCommandWith`
* [`2b8a6a7e`](https://github.com/NixOS/nixpkgs/commit/2b8a6a7e43e007f1bd40c515c1ecb84238638b6d) doc/build-helpers: refactor the paragraph about `runCommandLocal`
* [`9e5d56e8`](https://github.com/NixOS/nixpkgs/commit/9e5d56e8c64e00f6c69070952fbf76aae5f0497a) doc/build-helpers: forward-link `runCommand*` in `runCommandWith`
* [`73fb7b05`](https://github.com/NixOS/nixpkgs/commit/73fb7b0557f1b0d18c70022cfa660bb1bc78f295) python3Packages.homf: add checks
* [`4a06f12e`](https://github.com/NixOS/nixpkgs/commit/4a06f12e55dec9618488de5544db1faa0fff167a) python312Packages.dvc-data: 3.16.3 -> 3.16.4
* [`b706dea6`](https://github.com/NixOS/nixpkgs/commit/b706dea6a07d1b61adab36bacfb2f4b29e188439) dvc: 3.53.2 -> 3.54.0
* [`f80fe495`](https://github.com/NixOS/nixpkgs/commit/f80fe495344e9c3b49c3d2d0d57141016201ab3a) librewolf-unwrapped: 129.0.1 -> 129.0.1-1
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
