### PR TITLE
niv nixpkgs: update 89f8fd07 -> 7495def0

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "89f8fd07fb125f182ad5652eff777940e09aa5c2",
-        "sha256": "0skkkykgli6ajliy6w4ia393pswjfv8m0c2nc9p9qpkb6mslzqwv",
+        "rev": "7495def0bb63385f6dddd5e2ea9dfe764de14ee9",
+        "sha256": "0zdx2q5f3dmvi9hv9981gf6k8wzydkf5cfk25n0dqp4xm1ai8bxp",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/89f8fd07fb125f182ad5652eff777940e09aa5c2.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/7495def0bb63385f6dddd5e2ea9dfe764de14ee9.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@89f8fd07...7495def0](https://github.com/nixos/nixpkgs/compare/89f8fd07fb125f182ad5652eff777940e09aa5c2...7495def0bb63385f6dddd5e2ea9dfe764de14ee9)

* [`00387a18`](https://github.com/NixOS/nixpkgs/commit/00387a1825fdadc307dde2e51c31d6d51ef5e001) vimPlugins.netrw-nvim: init at 2024-03-12
* [`51f84765`](https://github.com/NixOS/nixpkgs/commit/51f847654a10bba73931d12012d24d2dc88878be) nixos/xserver: add option enableTearFree
* [`3c12ef3f`](https://github.com/NixOS/nixpkgs/commit/3c12ef3f219c1a0f458d72e7b460782287974bbd) nixos/firewall: fix reverse path check failures with IPsec
* [`fa5ae18c`](https://github.com/NixOS/nixpkgs/commit/fa5ae18c143c299ad080be109d39cb2a29f906bb) nixos/tests/firewall: fix deprecation warning
* [`54f33c58`](https://github.com/NixOS/nixpkgs/commit/54f33c58c45e4677699162dbd864adfd363377e1) vimPlugins.nvim-treesitter: collate grammars
* [`24deb859`](https://github.com/NixOS/nixpkgs/commit/24deb859ebc654df7d6737104c9c661e29981534) nanomq: 0.20.8 → 0.21.8
* [`b8f4ef4f`](https://github.com/NixOS/nixpkgs/commit/b8f4ef4f25bf4dd1c1689f069ec619f98bc37e16) nanomq: migrate to by-name
* [`d145c1d3`](https://github.com/NixOS/nixpkgs/commit/d145c1d32c7a51e2ff3d2cb0b98d9b9feaf2e3d6) commonsLang: 3.14.0 -> 3.15.0
* [`d0065cf5`](https://github.com/NixOS/nixpkgs/commit/d0065cf5f43648b301983a7a9e4b79e45ee2985f) jetbrains-toolbox: 2.4.0.32175 -> 2.4.1.32573
* [`10dc80b1`](https://github.com/NixOS/nixpkgs/commit/10dc80b1f802f955552f3e12e3601f675c78876d) ckbcomp: 1.229 -> 1.230
* [`d473784f`](https://github.com/NixOS/nixpkgs/commit/d473784f5c6bfa391d49703f2f9c5ee6ff1fa1eb) python312Packages.ufal-chu-liu-edmonds: init at 1.0.3
* [`f78ebd9c`](https://github.com/NixOS/nixpkgs/commit/f78ebd9c12abb9c9c44e15be46d6a272639ff674) jetbrains: fix webstorm vmoptions
* [`97d56a33`](https://github.com/NixOS/nixpkgs/commit/97d56a33653ad1ed78a36c92f9509756f8940ea1) SDL_image: fix build with clang 16
* [`2a7fc4b6`](https://github.com/NixOS/nixpkgs/commit/2a7fc4b6ef7a47d906659f5dda252bd2abf42b33) freesasa: init at 2.1.2
* [`21872e30`](https://github.com/NixOS/nixpkgs/commit/21872e303b091b6a3c8d1faa1bca63613de44e5f) python312Packages.freesasa: init at 2.2.1
* [`25544b7c`](https://github.com/NixOS/nixpkgs/commit/25544b7c981d22ac3ab8facad4204dce0740096b) jetbrains: verify download urls
* [`7a0b34fa`](https://github.com/NixOS/nixpkgs/commit/7a0b34fa71dabd645beeba4c9f16047ec5a74b4d) kontroll: init at 1.0.1
* [`d4db678f`](https://github.com/NixOS/nixpkgs/commit/d4db678fa4a9ada88939bd06ddb537c5cddc93c7) kops: 1.29.0 -> 1.29.2
* [`8b0e9cec`](https://github.com/NixOS/nixpkgs/commit/8b0e9cecce44bf0395af2d31caf4464f96644a51) python3Packages.xsser: drop
* [`e7fce8c4`](https://github.com/NixOS/nixpkgs/commit/e7fce8c43489d9d8cd7ef9bc736928adabc2a92a) oculante: 0.8.22 -> 0.8.23
* [`3d3bccaf`](https://github.com/NixOS/nixpkgs/commit/3d3bccafad038ef43b3330a6877c32bee6c08bce) meshcentral: 1.1.26 -> 1.1.27
* [`5f59cd75`](https://github.com/NixOS/nixpkgs/commit/5f59cd75a2da4b707589473de2ea3e8aa1047ecf) style: remove overuse of `with lib;`
* [`38d28a39`](https://github.com/NixOS/nixpkgs/commit/38d28a391c83ae39a576748496d3d25f97b8d8f5) stress-ng: 0.18.01 -> 0.18.02
* [`ce713951`](https://github.com/NixOS/nixpkgs/commit/ce713951674f6f628b67d44b27cccc373d356bef) clj-kondo: 2024.05.24 -> 2024.08.01
* [`1e7e4dec`](https://github.com/NixOS/nixpkgs/commit/1e7e4dec3f748336c850a273d213894214fc575d) flink: 1.19.1 -> 1.20.0
* [`867c994c`](https://github.com/NixOS/nixpkgs/commit/867c994c3bfe792ab59711c33da283e6ba80994e) gfal2: 2.22.2 -> 2.23.0
* [`2e24c5cd`](https://github.com/NixOS/nixpkgs/commit/2e24c5cde4dd01b03ca737a84d8c5e384328421a) python312Packages.recipe-scrapers: 14.56.0 -> 15.0.0
* [`1a57e19c`](https://github.com/NixOS/nixpkgs/commit/1a57e19c5fe1f8eebd19534be63d61acf8c7eac7) papermc: 1.21-108 -> 1.21-124
* [`58e72de2`](https://github.com/NixOS/nixpkgs/commit/58e72de215c10426b2a925ca9b5cb184193dbfd7) mapproxy: 2.0.2 -> 2.2.0
* [`2632d9f4`](https://github.com/NixOS/nixpkgs/commit/2632d9f483e7079a4a14643f322f29ee09af8ac3) grass-sass: 0.13.3 -> 0.13.4
* [`ecf45c76`](https://github.com/NixOS/nixpkgs/commit/ecf45c7639b4c865d814a13de559358d39efad67) kitex: 0.10.2 -> 0.10.3
* [`2ac5ea77`](https://github.com/NixOS/nixpkgs/commit/2ac5ea7729f433c9b698381c2bafe251dd9c7631) git-autoshare: init at 1.0.0b6
* [`179b7a7d`](https://github.com/NixOS/nixpkgs/commit/179b7a7d4582afc864a6f12ae885f67883d7aa63) commonsBcel: 6.8.2 -> 6.10.0
* [`286152cf`](https://github.com/NixOS/nixpkgs/commit/286152cfa1d5a84abeff944a518a8e24443daa8d) maintainers: add i-al-istannen
* [`b450e893`](https://github.com/NixOS/nixpkgs/commit/b450e893b88375e1a348bf81e20097fae87065dc) jreleaser-cli: init at 1.13.1
* [`d5c411a4`](https://github.com/NixOS/nixpkgs/commit/d5c411a42bae9a0c3796cd88cf507a17000a3650) python312Packages.keyring: 25.2.1 -> 25.3.0
* [`311f44ac`](https://github.com/NixOS/nixpkgs/commit/311f44ac80f5c711eda43101870c357ef1a47bc4) cosign: 2.2.4 -> 2.4.0
* [`41d745cc`](https://github.com/NixOS/nixpkgs/commit/41d745ccfb06d24d67876b036b064bc4aec7ee28) python312Packages.django-anymail: 11.0.1 -> 11.1
* [`dbb01194`](https://github.com/NixOS/nixpkgs/commit/dbb011943ddf1b63b680087057fa74a40d72629a) hilbish: 2.2.3 -> 2.3.2
* [`bccb2f7c`](https://github.com/NixOS/nixpkgs/commit/bccb2f7c8435daad2fda86a204bc1fdd0125a485) buildkite-agent: 3.76.2 -> 3.77.0
* [`b07f0229`](https://github.com/NixOS/nixpkgs/commit/b07f02293892dbca7784ce4a5a7e73839e9a2121) freerdp3: 3.6.3 -> 3.7.0
* [`42903be7`](https://github.com/NixOS/nixpkgs/commit/42903be7da6a9043aea0e73df8ff97a5bee7ed5e) ArmTrustedFirmwareRK3588: Don't include unused HDCP blob
* [`a2ee9683`](https://github.com/NixOS/nixpkgs/commit/a2ee9683141c91835454adc949c3c29bd886c4ee) vimPlugins.stay-centered-nvim: init at 2024-04-13
* [`7387f57b`](https://github.com/NixOS/nixpkgs/commit/7387f57b52ba5f18904538c08e5f09a5af4c6930) devpod: 0.5.16 -> 0.5.19
* [`d6150339`](https://github.com/NixOS/nixpkgs/commit/d6150339fcf26a17b80797a79132938d9c8e1ac9) nixos/gdm: refactor file-global `with`
* [`c178b444`](https://github.com/NixOS/nixpkgs/commit/c178b444fa707858f14c2eb48a9157e8b515b2d4) lib/licenses: busl add spdxid
* [`0984590b`](https://github.com/NixOS/nixpkgs/commit/0984590b4ebc9a7af88df52ed80fe755fbe86544) lib/licenses: correct zsh to mit-modern
* [`67327ada`](https://github.com/NixOS/nixpkgs/commit/67327ada9b39b906d1c712102ab36e23f83d5e8c) lib/licenses: remove libssh2 equivalent to bsd3
* [`fddb874f`](https://github.com/NixOS/nixpkgs/commit/fddb874f91c21833f0e76fa9fbc43beaf8bcb733) lib/licenses: remove incorrect comment about mit and x11
* [`ef660a9c`](https://github.com/NixOS/nixpkgs/commit/ef660a9c864227c377674b991ce33c153fd0c9b5) gnome.gnome-online-miners: Remove
* [`079379cf`](https://github.com/NixOS/nixpkgs/commit/079379cfeffc00cb183248b612cc4754253cf10d) gnome-connections: Format with nixfmt
* [`78863094`](https://github.com/NixOS/nixpkgs/commit/788630942d1592e575224eddc02b9dd8acc356cc) gnome-connections: Move to by-name
* [`f6245d22`](https://github.com/NixOS/nixpkgs/commit/f6245d22dc133c5ce612170830cc19704433b667) gnome.gnome-boxes: Format with nixfmt
* [`16b58860`](https://github.com/NixOS/nixpkgs/commit/16b5886034c9ede11fe81bc00d17031a1b7a311d) gnome-boxes: Move from gnome scope to top-level
* [`19a51d23`](https://github.com/NixOS/nixpkgs/commit/19a51d23df27887b57998cff9f702ebf80784041) gnome.gnome-characters: Format with nixfmt
* [`c9550b70`](https://github.com/NixOS/nixpkgs/commit/c9550b704d5308f6e6262da362c69f0a6b785f3e) gnome-characters: Move from gnome scope to top-level
* [`dcfb1248`](https://github.com/NixOS/nixpkgs/commit/dcfb124855c8e0dc1316b675c4c36d1251867125) gnome-clocks: Move from gnome scope to top-level
* [`ebfe4df5`](https://github.com/NixOS/nixpkgs/commit/ebfe4df5bc3ce15b83611ed6ef45ff2c8ef43f83) gnome.gnome-logs: Format with nixfmt
* [`2d62b2f9`](https://github.com/NixOS/nixpkgs/commit/2d62b2f940486e5d1f3eaeb95522a9d8b738b94a) gnome-logs: Move from gnome scope to top-level
* [`10192d93`](https://github.com/NixOS/nixpkgs/commit/10192d932c9a2f712b557efa2b7965f9d129ca0e) gnome.gnome-maps: Format with nixfmt
* [`a6cc36c2`](https://github.com/NixOS/nixpkgs/commit/a6cc36c2354cb8a2109812983ee25d54dc2e34ba) gnome-maps: Move from gnome scope to top-level
* [`49e50ece`](https://github.com/NixOS/nixpkgs/commit/49e50ecedad5828e1466e91642aa3988311bed91) gnome.gnome-music: Format with nixfmt
* [`9ec24b9c`](https://github.com/NixOS/nixpkgs/commit/9ec24b9c32b29465ce9bb9a82bbeeda86987f393) gnome-music: Move from gnome scope to top-level
* [`57662bfb`](https://github.com/NixOS/nixpkgs/commit/57662bfbd2685e0771f061280ff2dadf753bbd99) gnome.gnome-nettool: Format with nixfmt
* [`80ebfdbd`](https://github.com/NixOS/nixpkgs/commit/80ebfdbdd38a74f25031f18d6be18f39b60c040e) gnome-nettool: Move from gnome scope to top-level
* [`3ed98103`](https://github.com/NixOS/nixpkgs/commit/3ed981036c9002a828efbaa101434893db00f3ea) gnome.gnome-notes: Format with nixfmt
* [`c809e050`](https://github.com/NixOS/nixpkgs/commit/c809e050bb98793669896452b81c42752ab7fa32) gnome-notes: Move from gnome scope to top-level
* [`329d59cb`](https://github.com/NixOS/nixpkgs/commit/329d59cb9e211ea8897f7e5270b1f80716f6820e) gnome.gnome-power-manager: Format with nixfmt
* [`5331a0c1`](https://github.com/NixOS/nixpkgs/commit/5331a0c15cf3deed2967da388fd897bb83bb6b21) gnome-power-manager: Move from gnome scope to top-level
* [`b7e102ce`](https://github.com/NixOS/nixpkgs/commit/b7e102ce3c693bfdb812daa1ff5e7811bde88880) gnome.gnome-sound-recorder: Format with nixfmt
* [`30b3caaa`](https://github.com/NixOS/nixpkgs/commit/30b3caaa5e6113d79f29c61f58a4e7c89dfe5c66) gnome-sound-recorder: Move from gnome scope to top-level
* [`7388144c`](https://github.com/NixOS/nixpkgs/commit/7388144cf296d3dc9399a1acaef1b3b806963fd6) gnome.gnome-weather: Format with nixfmt
* [`bb4d62ac`](https://github.com/NixOS/nixpkgs/commit/bb4d62ac72a3c8256d46bc02f6b274ce519cfd73) gnome-weather: Move from gnome scope to top-level
* [`5efca33a`](https://github.com/NixOS/nixpkgs/commit/5efca33abd5b076624013abb99b31c8f87468c3b) gnome.polari: Format with nixfmt
* [`1e2a2205`](https://github.com/NixOS/nixpkgs/commit/1e2a2205f01123ca13d16ca8c7ac2b9a6bc20ebe) polari: Move from gnome scope to top-level
* [`1da4f864`](https://github.com/NixOS/nixpkgs/commit/1da4f864b63e4dd20f1355453a87687356c0cb08) gnome.vinagre: Format with nixfmt
* [`885eab59`](https://github.com/NixOS/nixpkgs/commit/885eab59d568b88f8a018fe496f41ee6897e0c51) vinagre: Move from gnome scope to top-level
* [`a95a3350`](https://github.com/NixOS/nixpkgs/commit/a95a3350d8898839e7feecdd19929c45f9bbd438) gnome.gnome-contacts: Format with nixfmt
* [`572d0e44`](https://github.com/NixOS/nixpkgs/commit/572d0e4403c3b4c091d19cd4325cd2b15220857b) gnome-contacts: Move from gnome scope to top-level
* [`0c660db4`](https://github.com/NixOS/nixpkgs/commit/0c660db41c9004ed0b54db6346581cd09257188d) gnome.gnome-backgrounds: Format with nixfmt
* [`6e8760f7`](https://github.com/NixOS/nixpkgs/commit/6e8760f7f7121128e2037db44915a4a5450b6e67) gnome-backgrounds: Move from gnome scope to top-level
* [`fa14462b`](https://github.com/NixOS/nixpkgs/commit/fa14462bbb32901befe241436a6883aec793908e) gnome.gnome-bluetooth: Format with nixfmt
* [`3839d978`](https://github.com/NixOS/nixpkgs/commit/3839d9787be953b9f5bbe7b2e2ba1bc7fac44801) gnome.gnome-color-manager: Format with nixfmt
* [`138941d6`](https://github.com/NixOS/nixpkgs/commit/138941d672ee443281aec00f52a892abb96438ff) gnome-color-manager: Move from gnome scope to top-level
* [`4f1ded69`](https://github.com/NixOS/nixpkgs/commit/4f1ded697ab711d758d574972a9ed1be6027b392) gnome.gnome-software: Format with nixfmt
* [`967bb64c`](https://github.com/NixOS/nixpkgs/commit/967bb64c16724a1c37698d8ca59aaba9bd9ca6ba) gnome-software: Move from gnome scope to top-level
* [`591060cf`](https://github.com/NixOS/nixpkgs/commit/591060cf881adea044a03b1e28f1d8fdd6b3f8cb) gnome.gnome-remote-desktop: Format with nixfmt
* [`18859a6b`](https://github.com/NixOS/nixpkgs/commit/18859a6bad65a309ef7bdd844da020e7cd572aa7) gnome-remote-desktop: Move from gnome scope to top-level
* [`82d86ea4`](https://github.com/NixOS/nixpkgs/commit/82d86ea422fd8e0c31cf21ea84660e31a8459d40) gnome.aisleriot: Format with nixfmt
* [`659c2ac8`](https://github.com/NixOS/nixpkgs/commit/659c2ac87ead9e08cb2517f9e32b2b1b8b3c7a73) aisleriot: Move from gnome scope to top-level
* [`005b9b54`](https://github.com/NixOS/nixpkgs/commit/005b9b545b95cb888b3930a31d368154a2e7e6af) gnome.atomix: Format with nixfmt
* [`fcd5e77e`](https://github.com/NixOS/nixpkgs/commit/fcd5e77e535545f08d5cd598ba2c3f850dddf887) atomix: Move from gnome scope to top-level
* [`4401fd2a`](https://github.com/NixOS/nixpkgs/commit/4401fd2a058035fa999c10115a8eb5abfb772e92) gnome.five-or-more: Format with nixfmt
* [`31b95b82`](https://github.com/NixOS/nixpkgs/commit/31b95b8251e7b3ed8723f39ec3b35eb1701b9746) five-or-more: Move from gnome scope to top-level
* [`cc3c481a`](https://github.com/NixOS/nixpkgs/commit/cc3c481aa3553fb5d7e149dd56cd3de1028d486f) gnome.four-in-a-row: Format with nixfmt
* [`076fe09e`](https://github.com/NixOS/nixpkgs/commit/076fe09eebc88d01901f2359281520abd7b1670f) four-in-a-row: Move from gnome scope to top-level
* [`6b1e3037`](https://github.com/NixOS/nixpkgs/commit/6b1e30370b62bab5372e0fbf4c742937762850eb) gnome.gnome-chess: Format with nixfmt
* [`fa58a27b`](https://github.com/NixOS/nixpkgs/commit/fa58a27b35321608a576260953fd4750f53ba376) gnome-chess: Move from gnome scope to top-level
* [`fc0c1ea4`](https://github.com/NixOS/nixpkgs/commit/fc0c1ea497cd136ecc8a7092636d0bb49fa56da5) gnome.gnome-klotski: Format with nixfmt
* [`b4e480f9`](https://github.com/NixOS/nixpkgs/commit/b4e480f919774e078422b6cd6cf3ed4d23011e5c) gnome-klotski: Move from gnome scope to top-level
* [`6ab301db`](https://github.com/NixOS/nixpkgs/commit/6ab301dbe244e69373fc96bf6e0571b75358ea68) gnome.gnome-mahjongg: Format with nixfmt
* [`828635c7`](https://github.com/NixOS/nixpkgs/commit/828635c72508386c5a73de11046708bd6ea37631) gnome-mahjongg: Move from gnome scope to top-level
* [`cf621377`](https://github.com/NixOS/nixpkgs/commit/cf621377cc2ae5d2a78b066fbcb8c751cc3d0ba5) gnome.gnome-mines: Format with nixfmt
* [`38115466`](https://github.com/NixOS/nixpkgs/commit/38115466395a739e39a57a15f7574947e18e284c) gnome-mines: Move from gnome scope to top-level
* [`798db4f7`](https://github.com/NixOS/nixpkgs/commit/798db4f748a53d38d4f1d13655fc8af1c7423866) gnome.gnome-nibbles: Format with nixfmt
* [`b76db173`](https://github.com/NixOS/nixpkgs/commit/b76db173dfccbe78f82bf2c242e1aef83a916254) gnome-nibbles: Move from gnome scope to top-level
* [`9588b7c1`](https://github.com/NixOS/nixpkgs/commit/9588b7c15972e2af80dc37212c8be97208dce2b1) gnome.gnome-robots: Format with nixfmt
* [`82a1d2ed`](https://github.com/NixOS/nixpkgs/commit/82a1d2ed24f4c24553877273368ae2e43b19422b) gnome-robots: Move from gnome scope to top-level
* [`10a82e5f`](https://github.com/NixOS/nixpkgs/commit/10a82e5f278c1f73106841a62c16b158e619bec4) gnome.gnome-sudoku: Format with nixfmt
* [`d988332c`](https://github.com/NixOS/nixpkgs/commit/d988332cd44ca1cdb0914204dbff26188d880b04) gnome-sudoku: Move from gnome scope to top-level
* [`80545812`](https://github.com/NixOS/nixpkgs/commit/80545812574a69b036cbe66f0cbc772b724c3e07) gnome.gnome-taquin: Format with nixfmt
* [`f26fb6ac`](https://github.com/NixOS/nixpkgs/commit/f26fb6acad656a7d6654f97f0362be10d6958941) gnome-taquin: Move from gnome scope to top-level
* [`1843392c`](https://github.com/NixOS/nixpkgs/commit/1843392c64eab3f649c5fda932af5fc249413dc7) gnome.gnome-tetravex: Format with nixfmt
* [`e0795cb2`](https://github.com/NixOS/nixpkgs/commit/e0795cb2de6b8461710dc03e98992e310fdc4959) gnome-tetravex: Move from gnome scope to top-level
* [`b0f25844`](https://github.com/NixOS/nixpkgs/commit/b0f258443f172aef285b4c387dd1de5c2711e35a) gnome.hitori: Format with nixfmt
* [`8c4f0fc7`](https://github.com/NixOS/nixpkgs/commit/8c4f0fc73e485f763459aa0aa286b816a12586d9) hitori: Move from gnome scope to top-level
* [`8cef7515`](https://github.com/NixOS/nixpkgs/commit/8cef7515916f35f42d4c6135527f120ac0e49069) gnome.iagno: Format with nixfmt
* [`31a54e03`](https://github.com/NixOS/nixpkgs/commit/31a54e038cd86ea779e9fb094f5462f10ffb4172) iagno: Move from gnome scope to top-level
* [`2ef7b97c`](https://github.com/NixOS/nixpkgs/commit/2ef7b97c0e914028417f1f5989843bab71b0e7b9) gnome.lightsoff: Format with nixfmt
* [`5db162af`](https://github.com/NixOS/nixpkgs/commit/5db162af3a35a925231cc8bdf07014721e783a0a) lightsoff: Move from gnome scope to top-level
* [`5341a2e3`](https://github.com/NixOS/nixpkgs/commit/5341a2e3caffb42364f5b3b17d897038c077a5a2) gnome.swell-foop: Format with nixfmt
* [`077dd2b9`](https://github.com/NixOS/nixpkgs/commit/077dd2b94ca428c15cdbc9e1687748d183194618) swell-foop: Move from gnome scope to top-level
* [`0f038882`](https://github.com/NixOS/nixpkgs/commit/0f0388822a7f9cbd5a62753aad91829d7049f9cc) gnome.tali: Format with nixfmt
* [`1f3f0c2e`](https://github.com/NixOS/nixpkgs/commit/1f3f0c2e4b53593ca4d778d2b7d2a1fcfb560648) tali: Move from gnome scope to top-level
* [`d430528d`](https://github.com/NixOS/nixpkgs/commit/d430528dae600401bd68fab31061b594ec6f4c94) gnome.quadrapassel: Format with nixfmt
* [`d364738c`](https://github.com/NixOS/nixpkgs/commit/d364738c7622c8f1286023ac9112e814c29a36e3) quadrapassel: Move from gnome scope to top-level
* [`5f5c3a54`](https://github.com/NixOS/nixpkgs/commit/5f5c3a54d4595c2400b5b97a686470555f4dc7e8) gnome.gnome-initial-setup: Format with nixfmt
* [`db9ae25d`](https://github.com/NixOS/nixpkgs/commit/db9ae25dca40580497b79d6a638e62647e50ec53) gnome-initial-setup: Move from gnome scope to top-level
* [`214a26c5`](https://github.com/NixOS/nixpkgs/commit/214a26c550d5edc19cec7227baf12e3f5787c87e) gnome.gdm: Format with nixfmt
* [`a0d15e0d`](https://github.com/NixOS/nixpkgs/commit/a0d15e0d04e8e8d3ac5a5ce21d19ba5e4ff15c7c) gdm: Move from gnome scope to top-level
* [`64438363`](https://github.com/NixOS/nixpkgs/commit/64438363f5c45363759b6c298249643aedbca5bf) gnome-shell-extensions: Move from gnome scope to top-level
* [`c1f4b333`](https://github.com/NixOS/nixpkgs/commit/c1f4b33309306217ad1067cd32904d444ccc013a) gnome.libchamplain: Remove
* [`b8d83d9a`](https://github.com/NixOS/nixpkgs/commit/b8d83d9ac3bf308440da0df30174804c3012aef1) gnome.libsoup: Remove
* [`e186593e`](https://github.com/NixOS/nixpkgs/commit/e186593ede4eb4900fe81d1365f225ca48ae9825) gnome.caribou: Format with nixfmt
* [`81237a9e`](https://github.com/NixOS/nixpkgs/commit/81237a9e871ab2f335c589b31cee3366d512f39b) caribou: Move from gnome scope to top-level
* [`6dd20f8a`](https://github.com/NixOS/nixpkgs/commit/6dd20f8a64541aaeb4da464bd8827783db0fbb5c) gnome.metacity: Format with nixfmt
* [`f192bd9e`](https://github.com/NixOS/nixpkgs/commit/f192bd9e5cc9bd42783c1b5e7f8b8538c1285cd6) metacity: Move from gnome scope to top-level
* [`bd70d321`](https://github.com/NixOS/nixpkgs/commit/bd70d3211c2f7c29c35e613ebc10b0abe8df41ed) gnome.gtkhtml: Format with nixfmt
* [`e61da57b`](https://github.com/NixOS/nixpkgs/commit/e61da57bbfae48898af470ffba5c1e26f9352046) gtkhtml: Move from gnome scope to top-level
* [`369e2d97`](https://github.com/NixOS/nixpkgs/commit/369e2d976d862491dbe525744b1c9c5ad4660d55) gtkhtml: Unmaintain
* [`54b056a9`](https://github.com/NixOS/nixpkgs/commit/54b056a950ff5fa1df8d0b2fc3db76b75e0c3189) nixos/metacity: Avoid top-level with
* [`cfa338f7`](https://github.com/NixOS/nixpkgs/commit/cfa338f7580952c4d766610273022c6ffc488cda) livekit: 1.7.0 -> 1.7.2
* [`4c9c4d55`](https://github.com/NixOS/nixpkgs/commit/4c9c4d55192092b29ff606a5e1af85dce095c65e) cdo: 2.2.2 -> 2.4.2
* [`0599045c`](https://github.com/NixOS/nixpkgs/commit/0599045c7c0eee3a8fe047d1c9cb03e419e8c5e5) ceph-csi: migrate to pkgs/by-name
* [`06f1086c`](https://github.com/NixOS/nixpkgs/commit/06f1086c5b78e438dc4772c35abaeaf7840ad8ef) ceph-csi: refactor
* [`861d2d66`](https://github.com/NixOS/nixpkgs/commit/861d2d667fd725e2b673732cd4df6aa76dda4e52) ceph-csi: nixfmt format
* [`bf907e87`](https://github.com/NixOS/nixpkgs/commit/bf907e87eb2e077990215b3c94a9a5717405f5c5) moosefs: 3.0.117 -> 3.0.118
* [`9d628e39`](https://github.com/NixOS/nixpkgs/commit/9d628e393320be48553be8177aeab75024a4ac5b) youtrack: 2024.2.37269 -> 2024.2.40106
* [`c2808920`](https://github.com/NixOS/nixpkgs/commit/c2808920d05cabb43c71610a5467289f9851d3e7) ssh-tpm-agent: 0.3.1 -> 0.6.0
* [`a385b83d`](https://github.com/NixOS/nixpkgs/commit/a385b83d1e31382213c999398513f18d6ab1252d) bacon: 2.19.0 -> 2.20.0
* [`2cb40bfb`](https://github.com/NixOS/nixpkgs/commit/2cb40bfb32b9ced3e68d8be9f01f47d69ff1ac80) vt-cli: 0.10.2 -> 1.0.1
* [`329ab81c`](https://github.com/NixOS/nixpkgs/commit/329ab81c77c782f3ddac34613f1d4aa0db3de3d2) gql: 0.9.0 -> 0.25.0
* [`e0b73075`](https://github.com/NixOS/nixpkgs/commit/e0b73075709900cb60e012e7b2bd2cbcb3c34064) libs3: fix cross compilation
* [`d04697ae`](https://github.com/NixOS/nixpkgs/commit/d04697aee8fff61578cf3480506f13a4747892d3) lib.meta.licensesSpdx: mapping from SPDX ID to licenses
* [`70f7377a`](https://github.com/NixOS/nixpkgs/commit/70f7377a57b589c0f772c18c7d3e8c4132a42d9e) analog: 6.0.17 -> 6.0.18
* [`dfa6f475`](https://github.com/NixOS/nixpkgs/commit/dfa6f4753f8898fddfe7669fd48a26ccf2c1c7f2) libsidplayfp: 2.8.0 -> 2.9.0
* [`a289e52c`](https://github.com/NixOS/nixpkgs/commit/a289e52ce19dc0b314cdc1d1d33685e8afe687ed) apacheKafka: init 3.8.0
* [`46469d01`](https://github.com/NixOS/nixpkgs/commit/46469d01b3b627f9bf0f4799eda089bc0dc79fb9) wazero: 1.7.3 -> 1.8.0
* [`4403f7f6`](https://github.com/NixOS/nixpkgs/commit/4403f7f6c30d37e7d8553908c90fb19ff7aeaed7) nixos/ayatana-indicators: Support new passthru.ayatana-indicators format
* [`06d1ee2b`](https://github.com/NixOS/nixpkgs/commit/06d1ee2b4453557a5048931ae142f4c964ab39fb) ayatana-indicator-datetime: nixfmt, modernise
* [`24014e19`](https://github.com/NixOS/nixpkgs/commit/24014e1975ee0a0e3ab896062411b962861c3310) ayatana-indicator-datetime: Update to new passthru.ayatana-indicators format
* [`a6bb6760`](https://github.com/NixOS/nixpkgs/commit/a6bb6760accddd31d417f19abfad2bb4d2c2d383) ayatana-indicator-display: nixfmt, modernise
* [`a2507a00`](https://github.com/NixOS/nixpkgs/commit/a2507a005c31fa765c8c74db37f140952efa968f) ayatana-indicator-display: Update to new passthru.ayatana-indicators format
* [`c0b9c8b2`](https://github.com/NixOS/nixpkgs/commit/c0b9c8b273a1a571a3d44c7b996bea931e9ef56b) ayatana-indicator-messages: nixfmt, modernise
* [`9d469d94`](https://github.com/NixOS/nixpkgs/commit/9d469d94bbc021d77533430407c077f94bc31477) ayatana-indicator-messages: Update to new passthru.ayatana-indicators format
* [`753daf1a`](https://github.com/NixOS/nixpkgs/commit/753daf1a9ad1f0b54a39d5a8bfa05e7a9838af9a) ayatana-indicator-power: nixfmt, modernise
* [`63d590f3`](https://github.com/NixOS/nixpkgs/commit/63d590f366d24bf885ce9ac88b2075a57bfcacee) ayatana-indicator-power: Update to new passthru.ayatana-indicators format
* [`ca545c06`](https://github.com/NixOS/nixpkgs/commit/ca545c062e987987fc0bebfd8c1c0c8604dc9bb3) ayatana-indicator-session: nixfmt, modernise
* [`6d1aa155`](https://github.com/NixOS/nixpkgs/commit/6d1aa1550658981606b0fef5c79249cae10521e4) ayatana-indicator-session: Update to new passthru.ayatana-indicators format
* [`de0703d5`](https://github.com/NixOS/nixpkgs/commit/de0703d599cb4be000f884e255a638b164c384e3) ayatana-indicator-sound: nixfmt, modernise
* [`16217606`](https://github.com/NixOS/nixpkgs/commit/162176068159676918e82d05e2b7ae4a795c8ebf) ayatana-indicator-sound: Update to new passthru.ayatana-indicators format
* [`cc01673c`](https://github.com/NixOS/nixpkgs/commit/cc01673c2306b109f775b455d04dd1c91217748c) tests/ayatana-indicators: nixfmt, modernise
* [`712439f9`](https://github.com/NixOS/nixpkgs/commit/712439f971d3ce5cce6e878d0fbd2b983968d305) tests/ayatana-indicators: Prepare for differences in ayatana vs lomiri indicators
* [`363e6d2d`](https://github.com/NixOS/nixpkgs/commit/363e6d2d986cbb27b91a6855d3bfccc8c21c68c1) lomiri.lomiri-indicator-network: nixfmt, modernise
* [`58265b00`](https://github.com/NixOS/nixpkgs/commit/58265b002d0129d86c76e50e4f94e2dcdb5d5047) lomiri.lomiri-indicator-network: Update to new passthru.ayatana-indicators format
* [`c07e19d8`](https://github.com/NixOS/nixpkgs/commit/c07e19d8d0932c2a4737503ad71276bdc08a39c3) lomiri.telephony-service: nixfmt, modernise
* [`491a3b1a`](https://github.com/NixOS/nixpkgs/commit/491a3b1a9d9ff013d0938fdfdd1c6113fd9efa02) lomiri.telephony-service: Update to new passthru.ayatana-indicators format
* [`95461ff6`](https://github.com/NixOS/nixpkgs/commit/95461ff6c68da807d4fc6722e1cf83908738e8a8) tests/ayatana-indicators: Finalise for differences in ayatana vs lomiri indicators
* [`c834ad68`](https://github.com/NixOS/nixpkgs/commit/c834ad683c1055bb1053508b8ee0acdee2fad1d7) cargo-binstall: 1.6.9 -> 1.10.2
* [`3ef6ee8f`](https://github.com/NixOS/nixpkgs/commit/3ef6ee8fa92d974cad7cce19765b83e1b78ce575) pwntools: 4.12.0 -> 4.13.0
* [`7e0b386a`](https://github.com/NixOS/nixpkgs/commit/7e0b386abdf1d51c7fad5943dcff8071f18f2439) httm: 0.40.4 -> 0.42.0
* [`5feacc45`](https://github.com/NixOS/nixpkgs/commit/5feacc455c201e40a2d82d2eef8f6716e43bcee5) jami: 20240627.0 -> 20240813.0
* [`6d5f08d6`](https://github.com/NixOS/nixpkgs/commit/6d5f08d6425816d6c00dfc4593f746083f9be61b) manga-tui: init at 0.2.0
* [`953fda00`](https://github.com/NixOS/nixpkgs/commit/953fda002e2e2849b9560ebd9b69ffadc3702bca) vimPlugins.comment-box-nvim: init at v1.0.2
* [`5f17f87a`](https://github.com/NixOS/nixpkgs/commit/5f17f87a7f52dfa9f5c116f68549eef38efdff75) nixos/ollama: move `loadModels` script into a separate service
* [`d37e698d`](https://github.com/NixOS/nixpkgs/commit/d37e698de42773d284535fbc3bffb32ba5467f5d) ipxe: 1.21.1-unstable-2024-06-27 -> 1.21.1-unstable-2024-08-15
* [`cde041e6`](https://github.com/NixOS/nixpkgs/commit/cde041e681c68e2d1481abcd9929342a776ccea9) pulldown-cmark: 0.11.0 -> 0.11.2
* [`7f18de02`](https://github.com/NixOS/nixpkgs/commit/7f18de02f3a8d7917d0ea857020ea21ee75825b3) jetbrains.jdk: 21.0.3b465.3 -> 21.0.3b509.11
* [`411a92de`](https://github.com/NixOS/nixpkgs/commit/411a92de1cba0c38aed2e7a2dc8447e652c4e2bf) renode-unstable: 1.15.1+20240808git7a138330e -> 1.15.1+20240816gitb8fc56b69
* [`a1576ffe`](https://github.com/NixOS/nixpkgs/commit/a1576ffea5059e24d80248e3528b20c8190bdc8f) cosmic-launcher: unstable-2023-12-13 -> 1.0.0-alpha.1
* [`4ffaf692`](https://github.com/NixOS/nixpkgs/commit/4ffaf69204fc6d05bc15ce679a472280d4b6e218) pwntools: adopt pypa build
* [`a4698592`](https://github.com/NixOS/nixpkgs/commit/a469859267f9068125a1d81f54787ec65432d648) pwntools: add pythonImportsCheck
* [`0eb50abb`](https://github.com/NixOS/nixpkgs/commit/0eb50abb66b4612f2a404c6c29c2ec5f98f67f19) composefs: 1.0.4 -> 1.0.5
* [`57e0c2c5`](https://github.com/NixOS/nixpkgs/commit/57e0c2c588899a2261b042e8e98076c122b3ff63) composefs: build with meson
* [`8aaa39a2`](https://github.com/NixOS/nixpkgs/commit/8aaa39a2f2640a47a29e1d17547940122b1cb878) maintainers: add returntoreality
* [`787fa4de`](https://github.com/NixOS/nixpkgs/commit/787fa4de88999f3a426a7dc2b797ec1424a0de40) python312Packages.ilcli: init at 0.3.2
* [`52cd02ea`](https://github.com/NixOS/nixpkgs/commit/52cd02eabd390464cd6b4d24281a1025e74aabb9) level-zero: 1.17.25 -> 1.17.28
* [`aa182b1d`](https://github.com/NixOS/nixpkgs/commit/aa182b1dc5774946744bcd7d7a767c6cb3efcbce) stargazer: 1.2.1 -> 1.3.0
* [`d2367c3f`](https://github.com/NixOS/nixpkgs/commit/d2367c3f7e85566f6cd5c7dab111d042191f9f64) indi-full: refactor 3rdparty drivers
* [`fa29eae2`](https://github.com/NixOS/nixpkgs/commit/fa29eae245b7ea65a411c2ebd0b0ce36a69c615e) python312Packages.django-anymail: refactor
* [`b4fbaae2`](https://github.com/NixOS/nixpkgs/commit/b4fbaae278aab14ed2c69d4f96d2f6a35af1b3e3) andi: init at 0.14
* [`b73ddc74`](https://github.com/NixOS/nixpkgs/commit/b73ddc74b2d128b738f657a49bfbaf69a244078d) dolt: 1.42.10 -> 1.42.13
* [`c42b3ab7`](https://github.com/NixOS/nixpkgs/commit/c42b3ab736328706909b96eb1ae04020168c3b15) adif-multitool: 0.1.12-rc1 -> 0.1.15
* [`cde5405d`](https://github.com/NixOS/nixpkgs/commit/cde5405d2e33d08d88e3925bca3651d547b26d77) cvc5: enable tests
* [`eca81c39`](https://github.com/NixOS/nixpkgs/commit/eca81c39b5a9ce14b54bc2363b3aab3552a0ab3e) python312Packages.pyinfra: 3.0.2 -> 3.1
* [`54d75a19`](https://github.com/NixOS/nixpkgs/commit/54d75a194fe684e2a762a61cb9f64abf40681707) clickhouse-backup: 2.5.27 -> 2.5.29
* [`de83fcb2`](https://github.com/NixOS/nixpkgs/commit/de83fcb2df588530c8e7257d62537adab0b325fd) containers.*.config: reuse host `nixpkgs.pkgs` if defined
* [`06002550`](https://github.com/NixOS/nixpkgs/commit/0600255046b085870a44a6385bd66dd9f171661b) Use `host.pkgs.stdenv.hostPlatform`
* [`79e5dbb2`](https://github.com/NixOS/nixpkgs/commit/79e5dbb2626735cffaff1c660425e8ce3927b399) Restore check for container not defining `nixpkgs.hostPlatform` option
* [`2ba4ccdf`](https://github.com/NixOS/nixpkgs/commit/2ba4ccdfcfabab0bc44c16687f13bcc1d5c13996) python312Packages.plexapi: 4.15.15 -> 4.15.16
* [`49a22c7d`](https://github.com/NixOS/nixpkgs/commit/49a22c7d3eaa9e8a5545c8ae656f53f0666025d3) easyeffects: 7.1.7 -> 7.1.8
* [`b5af21d5`](https://github.com/NixOS/nixpkgs/commit/b5af21d50f0c01f97c27c25d7bf605ce3ccefb0e) bosh-cli: 7.6.1 -> 7.7.0
* [`4e8b1b96`](https://github.com/NixOS/nixpkgs/commit/4e8b1b96ef6f8207517316b80e75dccc17c65594) koboldcpp: 1.72 -> 1.73
* [`3ab95873`](https://github.com/NixOS/nixpkgs/commit/3ab95873a8e7137e194f9bf36f8f5acd2cd92be8) koboldcpp: sort meta and add changelog
* [`b0691b65`](https://github.com/NixOS/nixpkgs/commit/b0691b65a40120ee33f5b2564339c1dabb19c6aa) python312Packages.gsd: 3.3.0 -> 3.3.1
* [`7e1ddd1a`](https://github.com/NixOS/nixpkgs/commit/7e1ddd1a4a3668a51845741cd368e22c1bc91cc5) guile-sqlite3: migrate to by-name
* [`fa36e4bd`](https://github.com/NixOS/nixpkgs/commit/fa36e4bd1aecfa5c70969786623ab27c091698b0) guile-sqlite3: adopt and rewrite
* [`2bd64765`](https://github.com/NixOS/nixpkgs/commit/2bd647656316561fced7d66ebe117fc4c18d051e) swayest-workstyle: remove maintainer miangraham
* [`f2d1e835`](https://github.com/NixOS/nixpkgs/commit/f2d1e8350416fc56240aa02645676b70379bc1fb) swayest-workstyle: adopt by AndersonTorres
* [`6002d45a`](https://github.com/NixOS/nixpkgs/commit/6002d45a9622accea71cdcbd1be17c465c5ae756) swayest-workstyle: get rid of rec
* [`db2751a7`](https://github.com/NixOS/nixpkgs/commit/db2751a7bbde921e2cd4c4447476b31554973de1) i3status: 2.14 -> 2.15
* [`e6692003`](https://github.com/NixOS/nixpkgs/commit/e66920030fa8f6e008923b610ca5b9a211b3c821) dotnet: 6.0.32 -> 6.0.33
* [`c3420ea8`](https://github.com/NixOS/nixpkgs/commit/c3420ea8cf09c0dbdf7a3ed256fd58dee242a5a8) python312Packages.fhir-py: 1.4.2 -> 2.0.4
* [`6d206633`](https://github.com/NixOS/nixpkgs/commit/6d206633f6dd631b57935aec3b0f553fd975163a) eintopf: fix frontend build
* [`01483d6a`](https://github.com/NixOS/nixpkgs/commit/01483d6aaa4c6fc9a1e0fb48f46e73287b094b4f) python312Packages.mdtraj: fix build
* [`f5cb52f5`](https://github.com/NixOS/nixpkgs/commit/f5cb52f553ac98a5c665a7de176ca9cc5e40d58c) dotnet: 8.0.7 -> 8.0.8
* [`62c58293`](https://github.com/NixOS/nixpkgs/commit/62c582939e00de17b87a11b88ac0f48274bae5a2) python312Packages.bx-py-utils: 95 -> 96
* [`59e2925f`](https://github.com/NixOS/nixpkgs/commit/59e2925fab6b4c8f0b8d0f29c94b962ec79dead9) python312Packages.prayer-times-calculator-offline: use fetchFromGitHub
* [`2a7e6416`](https://github.com/NixOS/nixpkgs/commit/2a7e6416bbecac27a7d058c426e1582383686e57) python312Packages.pygame-ce: 2.5.0 -> 2.5.1
* [`ac814421`](https://github.com/NixOS/nixpkgs/commit/ac8144214b3586a807841599d68394b76d852222) python312Packages.labgrid: 24.0 -> 24.0.1
* [`92d32f4b`](https://github.com/NixOS/nixpkgs/commit/92d32f4b23aa65a8baafa1df33fea151462864fa) python3Packages.shapely: 2.0.5 -> 2.0.6
* [`ef03964b`](https://github.com/NixOS/nixpkgs/commit/ef03964b9274afcc858ffbed0e50e55ee8c1226c) ifm-web: init at 4.0.2
* [`75ebbdb6`](https://github.com/NixOS/nixpkgs/commit/75ebbdb6db0c6549e03a7a77f382435ee487b805) live555: 2024.06.26 -> 2024.08.01
* [`dc62e561`](https://github.com/NixOS/nixpkgs/commit/dc62e56150ee6015cf067a02ba944cfe778ef43a) ncnn: 20240410 -> 20240820
* [`964499d5`](https://github.com/NixOS/nixpkgs/commit/964499d5acd1495b3217f87cad1b4c01621cf2f6) lsd: 1.1.2 -> 1.1.3
* [`dac90ca0`](https://github.com/NixOS/nixpkgs/commit/dac90ca0f0e525b0edb1974fc9ccea8fa227a1f1) lsd: move to pkgs/by-name
* [`c326c795`](https://github.com/NixOS/nixpkgs/commit/c326c7959f4e0ec8d33ba43e1af477f777b52424) lsd: format with nixfmt
* [`77e7f017`](https://github.com/NixOS/nixpkgs/commit/77e7f01746d43d853a5194139b35821186f190bd) lsd: remove `with lib;`
* [`99e73021`](https://github.com/NixOS/nixpkgs/commit/99e73021ef9bf1383e2183a5c64b0f469dd2894d) azuredatastudio: 1.48.1 -> 1.49.1
* [`043c629d`](https://github.com/NixOS/nixpkgs/commit/043c629da2fd268724dc4a1d37aef8c7580cdb2a) nom: 2.5.1 -> 2.6.0
* [`224f2dc0`](https://github.com/NixOS/nixpkgs/commit/224f2dc0bdd2c22e1b7d65564c523f6eac60efec) evcc: 0.130.1 -> 0.130.2
* [`2d60d8c8`](https://github.com/NixOS/nixpkgs/commit/2d60d8c861fa3c5cbc527a5bee6a44536995dbcf) nextcloud28: 28.0.8 -> 28.0.9
* [`29765062`](https://github.com/NixOS/nixpkgs/commit/29765062e4876ba7b029ffc6aed95ef7b3093f82) nextcloud29: 29.0.4 -> 29.0.5
* [`ea713fbd`](https://github.com/NixOS/nixpkgs/commit/ea713fbdd028949a28976d1cf12b984584deafe6) nextcloudPackages: update
* [`9a6b7222`](https://github.com/NixOS/nixpkgs/commit/9a6b722284a5a0e667b0f23bac1b28be147bf902) openrw: unstable-2021-10-14 -> 0-unstable-2024-04-20
* [`39db5024`](https://github.com/NixOS/nixpkgs/commit/39db502492c6f151ee9e637f13d9ab1e538545af) dotnet: 9.0.0-preview.6 -> 9.0.0-preview.7
* [`2c993d51`](https://github.com/NixOS/nixpkgs/commit/2c993d51734bdcb6f48f07c1d628c9a781600a97) loudgain: add patches for FFmpeg 7 and GCC 14
* [`76ea10b4`](https://github.com/NixOS/nixpkgs/commit/76ea10b4a20e7ef68197b3fc302af460067dce95) mediastreamer: add Debian patch for FFmpeg ≥ 5
* [`694653c2`](https://github.com/NixOS/nixpkgs/commit/694653c221e13507701e454d601da5edf9ab8dcc) python312Packages.trimesh: 4.4.6 -> 4.4.7
* [`5f2a4392`](https://github.com/NixOS/nixpkgs/commit/5f2a43928f45fc1553d916148acee0d4f08be286) python312Packages.whenever: 0.6.1 -> 0.6.7
* [`edfb47e9`](https://github.com/NixOS/nixpkgs/commit/edfb47e9f9968245616d5e24cb650504c2b70fbc) ppsspp: add upstream patch for FFmpeg 6
* [`4cd0a71e`](https://github.com/NixOS/nixpkgs/commit/4cd0a71e02eca78e0f1e04809a960e4340ff6753) python312Packages.exiv2: 0.16.3 -> 0.17.0
* [`19f4ad9b`](https://github.com/NixOS/nixpkgs/commit/19f4ad9b9a0ab3d3a279d6c73bcd78e8055f57ad) python312Packages.exiv2: fix build
* [`c73d65ff`](https://github.com/NixOS/nixpkgs/commit/c73d65ff10d763db67ba427e1424a76f6d32b592) itk: remove spurious mainProgram
* [`c3eede95`](https://github.com/NixOS/nixpkgs/commit/c3eede953f205c0d208fe6f0308cd946b68e8c31) itk: add myself as maintainer
* [`b4b81837`](https://github.com/NixOS/nixpkgs/commit/b4b818370c1f81ffd0f6448b99ee08f3aac7b448) itk: apply nixfmt
* [`7c6344a3`](https://github.com/NixOS/nixpkgs/commit/7c6344a39ab5d6a4af574eb875db8dbf24c23809) bottom: add desktop file
* [`83fdb904`](https://github.com/NixOS/nixpkgs/commit/83fdb9041c2fef310a6b4e0bc49b2346ddce629b) python312Packages.django-silk: 5.1.0 -> 5.2.0
* [`4a3bd441`](https://github.com/NixOS/nixpkgs/commit/4a3bd44183359ab892622a005179f9ae5eed6a8c) llvmPackages_19: 19.1.0-rc2 -> 19.1.0-rc3
* [`b067dc0a`](https://github.com/NixOS/nixpkgs/commit/b067dc0a68b581d12a388d9ba7cf1f4ae84ea4f6) python312Packages.gaphas: 4.0.0 -> 4.1.1
* [`d204078d`](https://github.com/NixOS/nixpkgs/commit/d204078d53a3816c3e05477da3fc3beff41a0d3d) python312Packages.mkdocs-autorefs: 1.0.1 -> 1.1.0
* [`3c9b9859`](https://github.com/NixOS/nixpkgs/commit/3c9b9859b302ca19f19b31097ee2b00380c3a44d) nix-perl: fix build for 2.24
* [`0dfd4ac7`](https://github.com/NixOS/nixpkgs/commit/0dfd4ac792328376bb32a41584c1481fbb81d437) python312Packages.pyproject-api: 1.6.1 -> 1.7.1
* [`b7ca9dc1`](https://github.com/NixOS/nixpkgs/commit/b7ca9dc149bd90728891695d6365a59ce1a5d8ab) surrealdb: fix build
* [`95b620c9`](https://github.com/NixOS/nixpkgs/commit/95b620c9ac7adcda96442a75a314d0f49d933d26) dae: 0.7.0 -> 0.7.1
* [`712e0395`](https://github.com/NixOS/nixpkgs/commit/712e039585209b13b878ec72573af766d81e5de2) nixos/networkd: add IPv6SendRA options added in systemd 255
* [`b68e126c`](https://github.com/NixOS/nixpkgs/commit/b68e126c85a479f942cf13461017ae07fee745bf) immich-go: 0.21.1 -> 1.21.3
* [`48a9a6a9`](https://github.com/NixOS/nixpkgs/commit/48a9a6a9b3de23f3025d0489dc8adba24bd33460) morgen: 3.5.1 -> 3.5.5
* [`d33349ca`](https://github.com/NixOS/nixpkgs/commit/d33349ca85075250cbc7a951bd169ba17a75ddf8) gotree: 1.2.0 -> 1.4.1
* [`88c331f0`](https://github.com/NixOS/nixpkgs/commit/88c331f003305220ac27ed77b8e95ba90f138c3f) python312Packages.aioesphomeapi: 25.0.0 -> 25.1.0
* [`71438e65`](https://github.com/NixOS/nixpkgs/commit/71438e6528dd45fcbb2c5436ff857bff9eb93819) librewolf-unwrapped: use nvidia wayland vendored patches, format using nixfmt-rfc-style
* [`dd9f7afb`](https://github.com/NixOS/nixpkgs/commit/dd9f7afbb31ba922fea71d7ae8505f80a70b1677) taskchampion-sync-server: 0.4.1-unstable-2024-04-08 -> 0.4.1-unstable-2024-08-20
* [`5c57962a`](https://github.com/NixOS/nixpkgs/commit/5c57962a128064c8b86857995e3a1372f476498c) matrix-authentication-service: 0.9.0 -> 0.10.0
* [`fdd524aa`](https://github.com/NixOS/nixpkgs/commit/fdd524aa1ea724fa3aac26ed4ff6ba3aebcafa70) dart: 3.4.4 -> 3.5.1
* [`7042d94f`](https://github.com/NixOS/nixpkgs/commit/7042d94f640520d444b7a81da1543cea1a5273c2) python3Packages.pcbnewtransition: fix Python 3.12 build
* [`5c493ae9`](https://github.com/NixOS/nixpkgs/commit/5c493ae9edbc67a40c8dd48f783274c5f8807d8d) python3Packages.shapely_1_8: remove
* [`3fc66073`](https://github.com/NixOS/nixpkgs/commit/3fc660733babd8a600c83be0daa4dc29faf584a7) kikit: 1.5.0 -> 1.6.0
* [`d045216e`](https://github.com/NixOS/nixpkgs/commit/d045216e9c0595cc44be18e7cc79372062e0448f) kicad: use python 3.12
* [`f098bd1f`](https://github.com/NixOS/nixpkgs/commit/f098bd1f4c1f7aa93cd5bad06f764332d9756d55) roslyn-ls: update dependencies for dotnet 9.0-preview.7
* [`858f0456`](https://github.com/NixOS/nixpkgs/commit/858f0456cf96377c4e0c9e27fb32cfb8433dfba0) dotnet-sdk: disable msbuild terminal logger
* [`b4df9190`](https://github.com/NixOS/nixpkgs/commit/b4df919002467b242994f432d54078f45d94a2c8) teleport_16: 16.0.4 -> 16.1.4
* [`9dadc1dc`](https://github.com/NixOS/nixpkgs/commit/9dadc1dc124a942150ac7e053253fdd18bac7181) xemu: 0.7.131 -> 0.7.132
* [`796f1441`](https://github.com/NixOS/nixpkgs/commit/796f14415042e6771690899cbb3db98d64018cde) polkadot: stable2407 -> stable2407-1
* [`23bc068c`](https://github.com/NixOS/nixpkgs/commit/23bc068ce89aad3797e944f3b452694c6265d5dd) python312Packages.pulumi-aws: 6.49.0 -> 6.49.1
* [`59ff74f3`](https://github.com/NixOS/nixpkgs/commit/59ff74f36d5ff9e235d4a7022fd2f620b3fcb513) wasmtime: 23.0.1 -> 24.0.0
* [`85189bee`](https://github.com/NixOS/nixpkgs/commit/85189bee5b53b2f81f78a22c33cf4f298bffcfb3) attic-client: 0-unstable-2024-08-01 -> 0-unstable-2024-08-19
* [`1b4795b3`](https://github.com/NixOS/nixpkgs/commit/1b4795b3e26cbb064727e674fd8051043e1dcb24) tests/lomiri: Optimise further
* [`7331ccef`](https://github.com/NixOS/nixpkgs/commit/7331ccefb3441d8079585ad727f30cd222b6c873) infisical: 0.28.4 -> 0.28.5
* [`8d4d182a`](https://github.com/NixOS/nixpkgs/commit/8d4d182a3e0acab0cdf19c104938e40eae8cb09e) python312Packages.aioairzone: 0.8.1 -> 0.8.2
* [`fe3bdcfc`](https://github.com/NixOS/nixpkgs/commit/fe3bdcfc934bc5632ec06df71f6578322e0f5f6f) elan: 3.1.1 -> 3.1.1-unstable-2024-08-02
* [`3da6b7e7`](https://github.com/NixOS/nixpkgs/commit/3da6b7e7d45a5199dd5c301742e8b60a0f1a3233) pcsx2: 2.1.17 -> 2.1.102
* [`6bcfc6e4`](https://github.com/NixOS/nixpkgs/commit/6bcfc6e440a46890c009de3abf4e2299075bba0e) python312Packages.emborg: 1.39 -> 1.40
* [`96bbd89c`](https://github.com/NixOS/nixpkgs/commit/96bbd89cf30651eb84105c09ebbd0447a7188be5) python312Packages.pylance: set buildAndTestSubdir instead of sourceRoot
* [`a9e93571`](https://github.com/NixOS/nixpkgs/commit/a9e9357187381c6cb5514674ed8db9227d528066) python312Packages.pylance: add updateScript
* [`62a1bf6b`](https://github.com/NixOS/nixpkgs/commit/62a1bf6b8d19d83b18b3075823e67f5c5f379328) python312Packages.pylance: 0.15.0 -> 0.16.0
* [`6dc177f1`](https://github.com/NixOS/nixpkgs/commit/6dc177f1039449fb81f4ae15f99fe90a0057d856) python312Packages.lancedb: add updateScript
* [`ddf9cf97`](https://github.com/NixOS/nixpkgs/commit/ddf9cf976a6d1838b929f16640bc203a9dc9c1d3) python312Packages.lancedb: 0.11.0 -> 0.12.0
* [`2fd6f266`](https://github.com/NixOS/nixpkgs/commit/2fd6f266041c95ecf691fd97ce91981abf5597c1) aws-sso-cli: skip broken TestServerWithSSL
* [`239a4209`](https://github.com/NixOS/nixpkgs/commit/239a4209d7aa8db5a5c08559d692a4ed3f43d1ce) pulumi-bin: disable build on hydra
* [`aaea04e9`](https://github.com/NixOS/nixpkgs/commit/aaea04e9fd5c2b3baca0514622ba6532de6ad186) kubeaudit: 0.22.1 -> 0.22.2
* [`08d13b30`](https://github.com/NixOS/nixpkgs/commit/08d13b304e14741d03f5dd1d69f174936d0ecaab) python312Packages.microsoft-kiota-serialization-form: 0.1.0 -> 0.1.1
* [`20ff5f20`](https://github.com/NixOS/nixpkgs/commit/20ff5f2021c25c1ac6ef60e6faddfae4f7b37ad2) python312Packages.microsoft-kiota-authentication-azure: 1.0.0 -> 1.1.0
* [`26d737c3`](https://github.com/NixOS/nixpkgs/commit/26d737c3483d4e15258f38750b87f5e684a1cfc7) llvmPackages_19.openmp: fix patches
* [`7e623c1a`](https://github.com/NixOS/nixpkgs/commit/7e623c1abd958b13c1fc6a6afa8108da9c47cad7) llvmPackages_19.lldb-manpages: copy llvm docs for python llvm_slug module
* [`297ca08c`](https://github.com/NixOS/nixpkgs/commit/297ca08c8e146704723488d475ac014fd8693182) jwt-cli: 6.1.0 -> 6.1.1
* [`af3af2e2`](https://github.com/NixOS/nixpkgs/commit/af3af2e2948028bc8fba6ae51bf520f834404e91) kubedb-cli: 0.46.0 -> 0.47.0
* [`425a9e02`](https://github.com/NixOS/nixpkgs/commit/425a9e028b9315af6fefbcce916bbd867d2df2cd) hermitcli: 0.39.3 -> 0.40.0
* [`ad608df0`](https://github.com/NixOS/nixpkgs/commit/ad608df0ba8efa13b0cd99b21e7fc84c4da7e95b) orchard: 0.22.0 -> 0.22.1
* [`d084f513`](https://github.com/NixOS/nixpkgs/commit/d084f51342c4d9f59504f0a61c9debbef0d6260c) python312Packages.ttn-client: 1.1.0 -> 1.2.0
* [`efb74e41`](https://github.com/NixOS/nixpkgs/commit/efb74e410a79416c5acc9f26b202b02df2158e7a) qxmpp: 1.8.0 -> 1.8.1
* [`175b5fb9`](https://github.com/NixOS/nixpkgs/commit/175b5fb947745ccae54e2fe7649b22c88634a8fd) rocksdb: 9.4.0 -> 9.5.2
* [`ab091709`](https://github.com/NixOS/nixpkgs/commit/ab0917099550d8b4dc43f0d377a11d30d924ca0b) lunar-client: 3.2.15 -> 3.2.16
* [`233df41a`](https://github.com/NixOS/nixpkgs/commit/233df41a7ff60ec32a2d7a7ff08d1126a44abef1) git-mit: 5.13.11 -> 5.13.22
* [`2269c90d`](https://github.com/NixOS/nixpkgs/commit/2269c90d7a7cec0e474810017e568ffb753425b5) checkov: 3.2.234 -> 3.2.235
* [`8ea510ff`](https://github.com/NixOS/nixpkgs/commit/8ea510ff94a06c40ca60b9addd14d5e2d4b07676) python312Packages.tencentcloud-sdk-python: 3.0.1215 -> 3.0.1216
* [`91bc28ff`](https://github.com/NixOS/nixpkgs/commit/91bc28ff78796333931c4f285675efd6b68ce797) python312Packages.aranet4: 2.3.4 -> 2.4.0
* [`2fa7d04b`](https://github.com/NixOS/nixpkgs/commit/2fa7d04b22c054a73bafee585777f2590808c025) sshs: 4.4.1 -> 4.5.1
* [`c7b8a6d6`](https://github.com/NixOS/nixpkgs/commit/c7b8a6d6576c8e8de16e8add5d8c1342f71a4f8a) automatic-timezoned: 2.0.29 -> 2.0.30
* [`4b3bdda0`](https://github.com/NixOS/nixpkgs/commit/4b3bdda0f8684b52400f923b3e8f9016084643da) python312Packages.ttn-client: refactor
* [`65ac9a4b`](https://github.com/NixOS/nixpkgs/commit/65ac9a4bff6131231abc73d4b2d8d9f7b36c2b09) python312Packages.microsoft-kiota-authentication-azure: update changelog URL
* [`ce560da5`](https://github.com/NixOS/nixpkgs/commit/ce560da5a718e1f583ee28e262d3801f7e256d36) python312Packages.microsoft-kiota-serialization-form: update changelog URL
* [`90bf0c51`](https://github.com/NixOS/nixpkgs/commit/90bf0c5119bd27b436ec8ab2dab8d689528547be) stdenv/freebsd: rsync with --safe-links
* [`ed069fab`](https://github.com/NixOS/nixpkgs/commit/ed069fab0819fbf43a6b38ebd61a760fe5f7bc38) kubeaudit: refactor
* [`f3a104c1`](https://github.com/NixOS/nixpkgs/commit/f3a104c11a29d6b3bdc90fcce5cf172aa5f22d5a) stdenv/freebsd: do not require recursive-nix
* [`a8e93d40`](https://github.com/NixOS/nixpkgs/commit/a8e93d404a6b4b9a1ce3a32f6b5656cf8bd7545c) mpvScripts.mpv-playlistmanager: 0-unstable-2024-07-28 -> 0-unstable-2024-08-17
* [`acbb7430`](https://github.com/NixOS/nixpkgs/commit/acbb7430f34d545e7fbeaed2141d97cdd3471368) python312Packages.ruff-api: 0.0.7 -> 0.0.8
* [`a06aaa8e`](https://github.com/NixOS/nixpkgs/commit/a06aaa8e3f72a9c50a08722de706ada11a1c1c1d) signal-desktop: 7.19.0 -> 7.21.0
* [`6c22d084`](https://github.com/NixOS/nixpkgs/commit/6c22d08406c232a8591443d8053facae6cffcc5c) nixos/test/dae: disable waiting network
* [`9e2357e0`](https://github.com/NixOS/nixpkgs/commit/9e2357e0dfc40f560375632875955fa9db4deb71) materialgram: init at 5.4.1.1
* [`a80d1619`](https://github.com/NixOS/nixpkgs/commit/a80d1619dd3e48003346526eebc786ebeba3d541) fwupd: 1.9.23 -> 1.9.24
* [`44e0bdf0`](https://github.com/NixOS/nixpkgs/commit/44e0bdf03ac9faf3ed52fee6b3403a8f5bf069f2) deck: 1.39.4 -> 1.39.5
* [`a6ee5cc5`](https://github.com/NixOS/nixpkgs/commit/a6ee5cc53b909e15211dd054269e9a8da04393bb) libplctag: 2.6.1 -> 2.6.2
* [`1a9be389`](https://github.com/NixOS/nixpkgs/commit/1a9be38901373ae498f0f29dc7a4a2ca303c1e18) libvncserver: fix generated pkg-config file
* [`f8cc61f1`](https://github.com/NixOS/nixpkgs/commit/f8cc61f19400326e1b58fc8af8fba3105dccdd25) iaito: 5.9.2 -> 5.9.4
* [`c879f274`](https://github.com/NixOS/nixpkgs/commit/c879f27429cf08e23a3aa59c0dc74a0128f43c47) vengi-tools: 0.0.32 -> 0.0.33
* [`1e5d59a4`](https://github.com/NixOS/nixpkgs/commit/1e5d59a44f08338cf8cded36bdcce239d079fee9) python312Packages.pyeapi: fix re-tag
* [`8242d315`](https://github.com/NixOS/nixpkgs/commit/8242d3154615766ad6890abc3d35ca0c6770fdb1) astyle: support building as a library
* [`65f5cbb5`](https://github.com/NixOS/nixpkgs/commit/65f5cbb5f29450dc32a2835aeb8cabfca2fedc09) kdePackages: Gear 24.05.2 -> 24.08.0
* [`abe192b6`](https://github.com/NixOS/nixpkgs/commit/abe192b6321a80dfbc792bd0fe7dafa49249e59d) python312Packages.oschmod: run tests and check import
* [`31321be1`](https://github.com/NixOS/nixpkgs/commit/31321be124c9c3889b5b5f0f80fd6825e60c8d2d) kubernetes: 1.30.2 -> 1.31.0
* [`71299db3`](https://github.com/NixOS/nixpkgs/commit/71299db32fa045850a761841beb33bc166e1914f) libndctl: 71.1 -> 79
* [`7aa5bc80`](https://github.com/NixOS/nixpkgs/commit/7aa5bc8043036bf53c6cd3dbca7ceadb987a80da) ci: Update pinned Nixpkgs
* [`fa2aacff`](https://github.com/NixOS/nixpkgs/commit/fa2aacff8ca15903f33fba6290bd7c7baa92ecf9) pantheon.appcenter: 7.4.0-unstable-2024-02-07 -> 8.0.0
* [`bab6f05d`](https://github.com/NixOS/nixpkgs/commit/bab6f05d19494b04d57f5cb5a13e57a63807eff2) nyxt: 3.11.6 -> 3.11.8
* [`0875a51b`](https://github.com/NixOS/nixpkgs/commit/0875a51bda41592cd560792c8c34a4260a65def1) sbclPackages.nyxt: remove
* [`3e74d14b`](https://github.com/NixOS/nixpkgs/commit/3e74d14b0a990ea21d04b14f417e2f11396d8da1) pantheon.wingpanel-indicator-datetime: 2.4.1 -> 2.4.2
* [`551735b1`](https://github.com/NixOS/nixpkgs/commit/551735b16e9ae4d779c9a1e24a512137b51888dd) pantheon.wingpanel-indicator-keyboard: 2.4.1 -> 2.4.2
* [`22df8305`](https://github.com/NixOS/nixpkgs/commit/22df830519635d3503dce5e030306a6ac65529b4) pantheon.wingpanel-indicator-nightlight: 2.1.2 -> 2.1.3
* [`fb105c39`](https://github.com/NixOS/nixpkgs/commit/fb105c395e0e3265bb6be276c1fb5a73a1ab8d57) pantheon.wingpanel-indicator-network: 7.1.0 -> 7.1.1
* [`dc94eaa8`](https://github.com/NixOS/nixpkgs/commit/dc94eaa89394b8ff9c01269b7d62ca777d881938) python312Packages.graphrag: 0.3.0 -> 0.3.1
* [`cca708d7`](https://github.com/NixOS/nixpkgs/commit/cca708d7c46d093d479fe70c789de2c145241560) deepin.deepin-movie-reborn: 6.0.5 -> 6.0.10
* [`347ad13f`](https://github.com/NixOS/nixpkgs/commit/347ad13fa47d38c4ec8097d6ad17a97afbe6cde8) deepin.deepin-terminal: 6.0.13 -> 6.0.14
* [`deb2f07f`](https://github.com/NixOS/nixpkgs/commit/deb2f07f229052312a4445f2f96a4b6731312bfe) tauon: format with nixfmt
* [`c9de427c`](https://github.com/NixOS/nixpkgs/commit/c9de427c1936bd7afabbc5c89edc79a87d0049c7) vimPlugins.pum-vim: init at 2024-08-17
* [`558293e2`](https://github.com/NixOS/nixpkgs/commit/558293e2095a5b716aa1347971627d0c7a3af6c9) ruff: 0.6.1 -> 0.6.2
* [`c7e761e0`](https://github.com/NixOS/nixpkgs/commit/c7e761e07577340be5d8c009162681917ed10fb9) ruff: format
* [`e70b0d2b`](https://github.com/NixOS/nixpkgs/commit/e70b0d2b944e9f72da2c6ea6ba4d19b6f2c69eb3) python312Packages.transformers: 4.44.1 -> 4.44.2
* [`fe0d323a`](https://github.com/NixOS/nixpkgs/commit/fe0d323af527b8d222312d251dc876b44bf05d29) nixos/engelsystem: prune template cache on version changes
* [`c6b519f5`](https://github.com/NixOS/nixpkgs/commit/c6b519f519b8a7c50ea035ad03f9c8befd418293) tektoncd-cli: 0.37.0 -> 0.38.0
* [`760b2b55`](https://github.com/NixOS/nixpkgs/commit/760b2b55621bdbfb9cade9a012760f945525ac6c) nixos/engelsystem: refactor option setup
* [`4269da11`](https://github.com/NixOS/nixpkgs/commit/4269da11188c633051e165eea4f858c109350de1) veilid: set mainProgram
* [`195f0709`](https://github.com/NixOS/nixpkgs/commit/195f0709532ee75fae5ee525bd9e56dacfb13f19) ledger-autosync: 1.0.3 -> 1.2.0
* [`a83efd27`](https://github.com/NixOS/nixpkgs/commit/a83efd2793a781240730f2f2310b27d9631446cc) python312Packages.pytibber: 0.29.3 -> 0.30.0
* [`6acda483`](https://github.com/NixOS/nixpkgs/commit/6acda483ec088d42d5b1d86563a5fea9d28f1ff4) veilid: add a version passthru.tests
* [`f39ae568`](https://github.com/NixOS/nixpkgs/commit/f39ae56808527e651e1df4f0c8f25ef8fec3897a) vimPlugins.vim-emacs-bindings: init at 2016-10-07
* [`bb9c3eec`](https://github.com/NixOS/nixpkgs/commit/bb9c3eec4827eb43cb4e1a24b3ce99257bf18918) CODEOWNERS: add myself to ACME
* [`b1fc96bb`](https://github.com/NixOS/nixpkgs/commit/b1fc96bb2b33bd8b994ed19fea3a0a9a1bc50697) python311Packages.openai: 1.40.8 -> 1.42.0
* [`3238b16e`](https://github.com/NixOS/nixpkgs/commit/3238b16ece23573e77b00221e7982ceea0e786bb) racket: 8.13 -> 8.14
* [`6dfc3d03`](https://github.com/NixOS/nixpkgs/commit/6dfc3d037a468d27190a2fa73647b731648bb7d2) skaffold: 2.13.1 -> 2.13.2
* [`eb19b36e`](https://github.com/NixOS/nixpkgs/commit/eb19b36ec45caf14e9fe5026d3970d89c03ced69) tailscale: 1.72.0 -> 1.72.1
* [`33f43c50`](https://github.com/NixOS/nixpkgs/commit/33f43c502df06dc4b6ef3a0d0ff57f8d18a900f3) python3Packages.sopel: fix
* [`e5d85ebc`](https://github.com/NixOS/nixpkgs/commit/e5d85ebcc3b50a979a996914fa3d618b50495a33) python3Packages.pygeoip: drop
* [`1edbc4fa`](https://github.com/NixOS/nixpkgs/commit/1edbc4fa0dc6ea6b09201c731b4759ee91af32b5) nixos/ups: change upsmon option type from str to enum
* [`8caa2633`](https://github.com/NixOS/nixpkgs/commit/8caa26332d9291d1facfa987c4cd54b4c82b9f20) tightvnc: drop, marked insecure 3 years ago
* [`7646e629`](https://github.com/NixOS/nixpkgs/commit/7646e629d0b1b0e43f6cce331fe942295bfea075) mupdf_1_17: drop
* [`00b14ffd`](https://github.com/NixOS/nixpkgs/commit/00b14ffd84d4a4e674c8a149471ae4ff95e40173) ferdi: drop
* [`2907ec25`](https://github.com/NixOS/nixpkgs/commit/2907ec251c1098e0960f40462b32313dd1ab5ae3) aider-chat: 0.50.0 -> 0.51.0
* [`e57b3fa5`](https://github.com/NixOS/nixpkgs/commit/e57b3fa5593c7059ce1ee23b58ef64143cf389b8) google-chrome: 127.0.6533.119 -> 128.0.6613.84/128.0.6613.85
* [`623c29b0`](https://github.com/NixOS/nixpkgs/commit/623c29b0af46b613e2fe04e1e5b3fd5f7cf171c3) fastly: 10.13.1 -> 10.13.3
* [`e5607c9d`](https://github.com/NixOS/nixpkgs/commit/e5607c9d796fe6f9b89a21efb4e7737f0cfc3446) podman: 5.2.1 -> 5.2.2
* [`e7a096d2`](https://github.com/NixOS/nixpkgs/commit/e7a096d2734e1a5787a57b43a93a68d7f124bdb3) stackql: 0.5.708 -> 0.5.724
* [`c6996e86`](https://github.com/NixOS/nixpkgs/commit/c6996e869b714c3cb47ffc2d959750cfc32ce089) zed-editor: 0.149.3 -> 0.149.5
* [`6de81bad`](https://github.com/NixOS/nixpkgs/commit/6de81bad4a71063126c7f434578880f52e7db6fb) wasm-tools: 1.215.0 -> 1.216.0
* [`e197edf9`](https://github.com/NixOS/nixpkgs/commit/e197edf9ed72ec3bce5d64c5a3479033a6a02798) qsv: init at 0.131.1
* [`0ba32dbe`](https://github.com/NixOS/nixpkgs/commit/0ba32dbe8426b11ae026d2d7a8783f7193b2f0ca) bitwarden-cli: 2024.7.2 -> 2024.8.0
* [`53227486`](https://github.com/NixOS/nixpkgs/commit/53227486a66aba739cd242481d607a243e03bc48) python312Packages.cookiecutter: run tests
* [`f539a50f`](https://github.com/NixOS/nixpkgs/commit/f539a50f5697d52d6321389d2fe7df1ab1727ec5) python312Packages.cookiecutter: add meta.changelog
* [`7b03c4fa`](https://github.com/NixOS/nixpkgs/commit/7b03c4faab04ccfb87dc934f842898d422102910) tippecanoe: 2.58.0 -> 2.60.0
* [`e290252d`](https://github.com/NixOS/nixpkgs/commit/e290252db8a78f2cd608955429094d65ebb6f168) python311Packages.trfl: drop
* [`8f3f5dae`](https://github.com/NixOS/nixpkgs/commit/8f3f5daedddee095b8c1dca269bfd55b575a85f4) python312Pacakges.bsuite: drop trfl dependency
* [`611b6073`](https://github.com/NixOS/nixpkgs/commit/611b6073823c188932a2b20f90237adc1d39923e) btor2tools: run update-nix-fetchgit. Remove unnecessary patch
* [`5bcc4ada`](https://github.com/NixOS/nixpkgs/commit/5bcc4ada6307f2db1c013006dd80e6a11c7b9800) treewide: remove maintainer joelkoen
* [`3d159512`](https://github.com/NixOS/nixpkgs/commit/3d159512d943d3868b393c2050776c01b828daa6) feishin: use electron_31
* [`f15ff50c`](https://github.com/NixOS/nixpkgs/commit/f15ff50c71ed588f0d233124c564ea501b4bcf32) python312Packages.google-cloud-network-connectivity: init at 2.4.5
* [`7dee8510`](https://github.com/NixOS/nixpkgs/commit/7dee8510a83a73c9e4a3d2f93c3eb3afb490ad58) python3Packages.matrix-nio: relax dependency aiohttp-socks
* [`2a22780b`](https://github.com/NixOS/nixpkgs/commit/2a22780b9dfeb394234077e53d6bc21a876e1114) balena-cli: 18.2.34 -> 19.0.0
* [`83730350`](https://github.com/NixOS/nixpkgs/commit/837303500cea4e43ec3bf6c38eae3f537bc74530) egl-wayland: 1.1.15 -> 1.1.16
* [`9f880ff8`](https://github.com/NixOS/nixpkgs/commit/9f880ff8e354dd22677a2e8d0c356299b177264a) clever-tools: 3.8.1 -> 3.8.2
* [`fb9e9029`](https://github.com/NixOS/nixpkgs/commit/fb9e9029b2b574c50ee6c89765f2c612c6937033) nats-top: 0.6.1 -> 0.6.2
* [`160b35ad`](https://github.com/NixOS/nixpkgs/commit/160b35ad7ffb3a89ec4a151d2b95f7b613fd3758) php82Packages.phive: 0.15.2 -> 0.15.3
* [`5ab545c3`](https://github.com/NixOS/nixpkgs/commit/5ab545c33a671f7988e9c0539c000e98d386c773) home-assistant-custom-components.mass: 2024.6.2 -> 2024.8.1
* [`557958e0`](https://github.com/NixOS/nixpkgs/commit/557958e097fd63ed18d6bffa0f95c8e437f2be42) home-assistant.python.pkgs.pytest-homeassistant-custom-component: 0.13.147 -> 0.13.154
* [`34c4a5c4`](https://github.com/NixOS/nixpkgs/commit/34c4a5c4ebe4269fc6e1017bb6ceb0f7f8c0c6f3) python312Packages.pynmeagps: 1.0.38 -> 1.0.39
* [`f3754a77`](https://github.com/NixOS/nixpkgs/commit/f3754a7737f8d0859f97212339fcd07af8ee0cea) wowup-cf: 2.12.0 -> 2.20.0
* [`d221e816`](https://github.com/NixOS/nixpkgs/commit/d221e816c772b381ee0a8356abd562d31fe680e3) python312Packages.pipx: 1.6.0 -> 1.7.0
* [`673c665d`](https://github.com/NixOS/nixpkgs/commit/673c665d93efa7331d4b39b083a8135324aa3e26) python312Packages.pyswitchbot: 0.48.1 -> 0.48.2
* [`f9019d51`](https://github.com/NixOS/nixpkgs/commit/f9019d51ef584ad7315d7242a3a639430af79723) python312Packages.cron-descriptor: 1.4.3 -> 1.4.4
* [`1c607f63`](https://github.com/NixOS/nixpkgs/commit/1c607f63ca279bc70709a4a0271de56ab536c12b) haskellPackages.ffmpeg-light: remove override
* [`5c05bac4`](https://github.com/NixOS/nixpkgs/commit/5c05bac47f2495cf0d5e5205cb1cf3a73701c23c) haskellPackages.opencv{,-extra}: remove overrides
* [`c757d40d`](https://github.com/NixOS/nixpkgs/commit/c757d40d0872f0fb714619fca82dea2cb4cccba8) python312Packages.yfinance: 0.2.41 -> 0.2.42
* [`8fc33b55`](https://github.com/NixOS/nixpkgs/commit/8fc33b55f160e0652aab8f98330b3cafeaa1d54d) typos: 1.23.6 -> 1.23.7
* [`e9fc3f6c`](https://github.com/NixOS/nixpkgs/commit/e9fc3f6cb919f7a91695a5b42fe97dd7e72aae7f) skopeo: 1.16.0 -> 1.16.1
* [`deeb1924`](https://github.com/NixOS/nixpkgs/commit/deeb1924bfa5fd581d69795c6e45311470f5b758) rojo: 7.4.3 -> 7.4.4
* [`361510d4`](https://github.com/NixOS/nixpkgs/commit/361510d4f237936672f227f7acf6b1527680fc5d) python312Packages.asana: 5.0.8 -> 5.0.9
* [`8ae196f7`](https://github.com/NixOS/nixpkgs/commit/8ae196f7c50cb5412420a8ed6e01dd404c5a9c02) lune: 0.8.7 -> 0.8.8
* [`12bee5d5`](https://github.com/NixOS/nixpkgs/commit/12bee5d5c6a219e3733eb2b6191bb1901b2a2477) home-assistant-custom-components.xiaomi_miot: 0.7.19 -> 0.7.20
* [`aebb91e7`](https://github.com/NixOS/nixpkgs/commit/aebb91e709e6cb261b85af18e4523b7f48fa7219) brave: 1.68.141 -> 1.69.153
* [`d3b2b6e3`](https://github.com/NixOS/nixpkgs/commit/d3b2b6e38029ab39049541b64d656c08b4341b9c) yandex-cloud: 0.131.0 -> 0.131.1
* [`d888bdee`](https://github.com/NixOS/nixpkgs/commit/d888bdee8d164b9811114de8903ed7d04863f0dd) opengrok: 1.13.19 -> 1.13.20
* [`a9b6abeb`](https://github.com/NixOS/nixpkgs/commit/a9b6abebd368d0a0473afd057b9f634e145a8c60) cloudlist: 1.0.9 -> 1.1.0
* [`90c48db8`](https://github.com/NixOS/nixpkgs/commit/90c48db8534420fc6171b95a3b88811e96b767b9) metasploit: 6.4.22 -> 6.4.23
* [`7081728e`](https://github.com/NixOS/nixpkgs/commit/7081728e6958d1face38c357730ce0cb079d9c20) python312Packages.cron-descriptor: add changelog
* [`9b6d74f5`](https://github.com/NixOS/nixpkgs/commit/9b6d74f5d188f80707cae4d5c5509948e584208d) python312Packages.pyeapi: update changelog URL
* [`bbb42450`](https://github.com/NixOS/nixpkgs/commit/bbb42450c52d5db817b5011aea2212dc270f2154) default-crate-overrides: proc-macro-crate assumes env::var("CARGO")
* [`69ad06ba`](https://github.com/NixOS/nixpkgs/commit/69ad06ba6c63bb59e71fb0078436789c11237c7e) python312Packages.archinfo: 9.2.115 -> 9.2.116
* [`14ce3389`](https://github.com/NixOS/nixpkgs/commit/14ce3389c4a24af1452d4008f12743abc601769e) python312Packages.ailment: 9.2.115 -> 9.2.116
* [`49f8cfc5`](https://github.com/NixOS/nixpkgs/commit/49f8cfc5553bc1cb4c56620c1785b9421e450e92) python312Packages.pyvex: 9.2.115 -> 9.2.116
* [`5267d428`](https://github.com/NixOS/nixpkgs/commit/5267d42868c75b53c89d6714a7383c70a4cc30e6) python312Packages.claripy: 9.2.115 -> 9.2.116
* [`b4479989`](https://github.com/NixOS/nixpkgs/commit/b4479989b9344f659a520757412ffa5dc87af664) python312Packages.cle: 9.2.115 -> 9.2.116
* [`9bc16299`](https://github.com/NixOS/nixpkgs/commit/9bc162997f4b257c7e2d98ad0e671c39a362969d) python311Packages.angr: 9.2.115 -> 9.2.116
* [`29031302`](https://github.com/NixOS/nixpkgs/commit/290313026e5850df61c79f5127d7e823cb2b9673) python312Packages.meshtastic: 2.3.15 -> 2.4.0
* [`bfc9cdc0`](https://github.com/NixOS/nixpkgs/commit/bfc9cdc0efadf398566670a73d1f4d6e9af7cc54) python312Packages.iso4217: 1.11 -> 1.12
* [`de1555c8`](https://github.com/NixOS/nixpkgs/commit/de1555c8bfd6bc6626711f35eb1414a078357af7) python312Packages.iso4217: refactor
* [`4d277b21`](https://github.com/NixOS/nixpkgs/commit/4d277b2183137cc794c4326211251e66c164ef3e) eigenlayer: 0.10.0 -> 0.10.2
* [`6ff6b317`](https://github.com/NixOS/nixpkgs/commit/6ff6b31721e0e3d43e1f1f510d940de6ed2ac541) sqlfluff: 3.1.0 -> 3.1.1
* [`fc0f323d`](https://github.com/NixOS/nixpkgs/commit/fc0f323d8cf0e6b18c5844c078718eb99c5c6ecc) dxx-rebirth: 0-unstable-2024-01-13 -> 0.60.0-beta2-unstable-2024-08-11
* [`25628691`](https://github.com/NixOS/nixpkgs/commit/25628691a0a0c3dd04aa779ce5887f18035301d6) luaPackages.tree-sitter-norg: update + unbreak on darwin
* [`7a408828`](https://github.com/NixOS/nixpkgs/commit/7a40882888294732cbc0455348e1325da6da7222) luaPackages.lz.n: 2.0.0 -> 2.2.0
* [`1633ace9`](https://github.com/NixOS/nixpkgs/commit/1633ace98bc88c9073b1ee966f73b434bdb76bd0) pgadmin: 8.10 -> 8.11
* [`f81d55a0`](https://github.com/NixOS/nixpkgs/commit/f81d55a089540b680e3b5f98ef93bf36c68fbf39) vimPlugins.middleclass: build neovim plugin from lua package
* [`3fe6cc6e`](https://github.com/NixOS/nixpkgs/commit/3fe6cc6e18b607946b80fb9ffba489eebbeeb332) barman: 3.10.1 -> 3.11.1
* [`6687a981`](https://github.com/NixOS/nixpkgs/commit/6687a981a168c19230b083fbb03e7ff9747350f1) nixStatic: use git and man in installCheckInputs
* [`ee143910`](https://github.com/NixOS/nixpkgs/commit/ee143910b71697136c021dba70fffea8f7f133ed) vimPlugins.animation-nvim: add middleclass dependency and check
* [`cba879ba`](https://github.com/NixOS/nixpkgs/commit/cba879ba22fc15212d0ef8f9b0e9c444d426dfda) vimPlugins.windows-nvim: fix middleclass dependency and check
* [`c4dffb65`](https://github.com/NixOS/nixpkgs/commit/c4dffb6513d88afac521dd2b009b3adbca3e215f) nixosTest.nix-upgrade: init
* [`19f85e26`](https://github.com/NixOS/nixpkgs/commit/19f85e265083bd70960d0dda0f64218177455491) nix: reference upgrade test
* [`d01abc56`](https://github.com/NixOS/nixpkgs/commit/d01abc5602a42a3dc0045518b7d6ab46cb7cf8ff) nixosTest.nix-upgrade: actually use nix-daemon for build
* [`33b5aab8`](https://github.com/NixOS/nixpkgs/commit/33b5aab88f6084ca14b3884ef533f54fdb043796) nixosTest.nix-upgrade: try to garbage collect with old nix
* [`fd86aae9`](https://github.com/NixOS/nixpkgs/commit/fd86aae9a5e71407c6e849722b72ebf1e07f79da) golangci-lint: 1.60.2 -> 1.60.3 ([nixos/nixpkgs⁠#336690](https://togithub.com/nixos/nixpkgs/issues/336690))
* [`39f026a8`](https://github.com/NixOS/nixpkgs/commit/39f026a8c7a499f898c7ad0253a273ccb3b94786) alephone: 1.8.1 -> 1.10
* [`28a05523`](https://github.com/NixOS/nixpkgs/commit/28a05523b3fa22f4d322da01ef83d06374f1f671) fulcio: 1.6.1 -> 1.6.2
* [`9427e069`](https://github.com/NixOS/nixpkgs/commit/9427e0699e4209ab51ecd42c8933dbeb2718ae9b) licensure: 0.5.0 -> 0.5.1
* [`51d99d2f`](https://github.com/NixOS/nixpkgs/commit/51d99d2f8252363dc1434b100d341b49f152d795) obs-studio-plugins.advanced-scene-switcher: 1.27.0 -> 1.27.1
* [`c5e8f89f`](https://github.com/NixOS/nixpkgs/commit/c5e8f89f3aacae0fd763fdcab1de71b387c96e19) autoPatchelfHook: fix tests
* [`8f53ab35`](https://github.com/NixOS/nixpkgs/commit/8f53ab35b1b0976d1f769d011e3853f4068c4ac0) python312Packages.pypck: 0.7.20 -> 0.7.21
* [`3fa807ef`](https://github.com/NixOS/nixpkgs/commit/3fa807ef33d98298da710c45ab5426f98ebb43bb) vimPlugins.lzn-auto-require: init at 0.1.0
* [`79b94593`](https://github.com/NixOS/nixpkgs/commit/79b94593704a4f4deaeb170d12a5566ba87a9a84) vimPlugins.helpview-nvim: init at 2024-08-12
* [`63c88c4e`](https://github.com/NixOS/nixpkgs/commit/63c88c4e8a037a6e273820c91a089764a67dda8f) treewide: `buildPhase="true"` -> `dontBuild=true`
* [`2c16fd04`](https://github.com/NixOS/nixpkgs/commit/2c16fd044911cd3c2450f4b17dc9d7152f4a9da3) vimPlugins.ranger-nvim: init at 2024-02-09
* [`c2034b94`](https://github.com/NixOS/nixpkgs/commit/c2034b9495909d667152262cea494920e930e2bd) luaPackages.rtp-nvim: 1.0.0 -> 1.1.0
* [`b45eb827`](https://github.com/NixOS/nixpkgs/commit/b45eb82718a03409c190515304d0f3d66dfb7f33) luaPackages.rtp-nvim: enable tests
* [`b370d4cb`](https://github.com/NixOS/nixpkgs/commit/b370d4cb93f0a24d9a2d415231c56d482c7d5a31) vimPlugins.rtp-nvim: init at 1.1.0
* [`7d71f22b`](https://github.com/NixOS/nixpkgs/commit/7d71f22b5f7254453641e8d8e288281eeaa45d48) python312Packages.unearth: 0.17.0 -> 0.17.1
* [`0a1f4c46`](https://github.com/NixOS/nixpkgs/commit/0a1f4c46f4545433fa92d57c43254793908475bd) jsonnet-bundler: 0.5.1 -> 0.6.0
* [`86cf5022`](https://github.com/NixOS/nixpkgs/commit/86cf5022c44a0760ef3278ea2f3967a472369d26) please: 0.5.4 -> 0.5.5
* [`26c89d06`](https://github.com/NixOS/nixpkgs/commit/26c89d068edd79499173442edddccd30ae72cdfc) python3Packages.cpyparsing: 2.4.7.2.3.3 -> 2.4.7.2.4.0
* [`5b36ae93`](https://github.com/NixOS/nixpkgs/commit/5b36ae93b0aac5c84e367aa29b1c65ae8d56e197) vimPlugins.nvim-dap-rr: init at 2024-07-10
* [`2c61ec85`](https://github.com/NixOS/nixpkgs/commit/2c61ec858716cbe025a1b37268efba307ad05bd7) cosmic-randr: remove env substituteInPlace
* [`91098b26`](https://github.com/NixOS/nixpkgs/commit/91098b26e25aa35eb893e49bb9a54948737a2dfa) vimPlugins.smart-open-nvim: init at 2024-08-18
* [`64ee32d0`](https://github.com/NixOS/nixpkgs/commit/64ee32d0b2406d4658410b51898211519de0cd2c) python312Packages.mkdocs-material: 9.5.31 -> 9.5.33
* [`5e6a89a3`](https://github.com/NixOS/nixpkgs/commit/5e6a89a3a3ac5856372f539d36fdf12b7bf07fff) glanceclient: 4.6.0 -> 4.7.0
* [`4b0b32e5`](https://github.com/NixOS/nixpkgs/commit/4b0b32e5f5dded9fdfbc3a7578690c8643d62c7f) mongodb-ce: fix darwin build
* [`c4bd4f44`](https://github.com/NixOS/nixpkgs/commit/c4bd4f447142fbd6ebdebb0c036288710465832d) deepin.deepin-clone: remove
* [`29c13e2d`](https://github.com/NixOS/nixpkgs/commit/29c13e2d0c49541ed01d6c373bfbc6654a7ae57b) viber: fix fetchurl hash
* [`ec85ff93`](https://github.com/NixOS/nixpkgs/commit/ec85ff9346731bdb47705ac2067a7488c3de3923) compose2nix: 0.2.1 -> 0.2.2
* [`d01560ac`](https://github.com/NixOS/nixpkgs/commit/d01560ac29c32a2bfe3cf3284cc3a6569f75c855) cshatag: 2.1.0 -> 2.2.0
* [`b833f7bd`](https://github.com/NixOS/nixpkgs/commit/b833f7bd61530c0685bf204cfa0555e74a493497) fd: 10.1.0 -> 10.2.0
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
