### PR TITLE
niv home-manager: update 25988610 -> c2cd2a52

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -41,10 +41,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2598861031b78aadb4da7269df7ca9ddfc3e1671",
-        "sha256": "0ihczivbf80rngg9ylywd4kmjy3rlpgdw5chjhy7gy6hy098lbqp",
+        "rev": "c2cd2a52e02f1dfa1c88f95abeb89298d46023be",
+        "sha256": "1wq1cn8r4igs5bb3fgcn8ima65rk427kkxkl25a0n6adabg35nah",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/2598861031b78aadb4da7269df7ca9ddfc3e1671.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/c2cd2a52e02f1dfa1c88f95abeb89298d46023be.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@25988610...c2cd2a52](https://github.com/nix-community/home-manager/compare/2598861031b78aadb4da7269df7ca9ddfc3e1671...c2cd2a52e02f1dfa1c88f95abeb89298d46023be)

* [`40ddec2f`](https://github.com/nix-community/home-manager/commit/40ddec2f8a71d9fb92735f0553dc81a8825596c4) zsh: add option: history.append
* [`25c12f07`](https://github.com/nix-community/home-manager/commit/25c12f07366fb98008326cc3910d4231ccf889e9) tests: fix escaping of wait command
* [`b18f3ebc`](https://github.com/nix-community/home-manager/commit/b18f3ebc4029c22d437e3424014c8597a8b459a0) systemd: fully deprecate legacy switcher
* [`5dc25356`](https://github.com/nix-community/home-manager/commit/5dc25356567119127f046b347c3060a8dd607365) Translate using Weblate (Hungarian)
* [`c2cd2a52`](https://github.com/nix-community/home-manager/commit/c2cd2a52e02f1dfa1c88f95abeb89298d46023be) submodule-support: add default values for top-level configs
