### PR TITLE
niv emacs-overlay: update 445662a3 -> 6bbe8973

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "445662a366f5360a8a1b1cf1dbf21df483cd5a5b",
-        "sha256": "14pd2rkbyj1fdfzdz0g6j0wyjphzmrp23sp30f7zsqw7ml5yv81p",
+        "rev": "6bbe8973c0a99ebb54175310f20a0d255f688f90",
+        "sha256": "0ilppv5p05pw8jfs8lxggyy65vfh39bvsixvq8k9fd3md4flw1jl",
         "type": "tarball",
-        "url": "https://github.com/nix-community/emacs-overlay/archive/445662a366f5360a8a1b1cf1dbf21df483cd5a5b.tar.gz",
+        "url": "https://github.com/nix-community/emacs-overlay/archive/6bbe8973c0a99ebb54175310f20a0d255f688f90.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "fast-syntax-highlighting": {


### PR DESCRIPTION
## Changelog for emacs-overlay:
Branch: master
Commits: [nix-community/emacs-overlay@445662a3...6bbe8973](https://github.com/nix-community/emacs-overlay/compare/445662a366f5360a8a1b1cf1dbf21df483cd5a5b...6bbe8973c0a99ebb54175310f20a0d255f688f90)

* [`b90aef58`](https://github.com/nix-community/emacs-overlay/commit/b90aef5849fe0bcdedecb67d8b406b49bd939046) Updated elpa
* [`ca701f81`](https://github.com/nix-community/emacs-overlay/commit/ca701f81056cd3f6111aef668827a77051fb0199) Updated melpa
* [`aac3291a`](https://github.com/nix-community/emacs-overlay/commit/aac3291a78bbaef28fda1b2c1bd8f6e3a60c722f) Updated emacs
* [`5a51bdfd`](https://github.com/nix-community/emacs-overlay/commit/5a51bdfd8dae135ce6ab3e47890900d1d2a44357) Updated melpa
* [`835be326`](https://github.com/nix-community/emacs-overlay/commit/835be326735bff3737320bf61cb2ae1b54a26cbd) Updated emacs
* [`8aa773e2`](https://github.com/nix-community/emacs-overlay/commit/8aa773e243343887d1e0f0c2a8236d2ae8a3b355) Updated flake inputs
* [`bae494ad`](https://github.com/nix-community/emacs-overlay/commit/bae494adba1b6b449e795922a1b20dfd1ef3df3e) Updated nongnu
* [`804d1213`](https://github.com/nix-community/emacs-overlay/commit/804d1213abe4d865c8f4377d6a94e91d2a86b24e) Updated elpa
* [`cf319a3e`](https://github.com/nix-community/emacs-overlay/commit/cf319a3e4f482b7b86434591ba6bc41b1f26389f) Updated melpa
* [`4d9907b7`](https://github.com/nix-community/emacs-overlay/commit/4d9907b7f96392f949a263d0fccd8ba2a7a0d8d2) Updated emacs
* [`31445d65`](https://github.com/nix-community/emacs-overlay/commit/31445d65f59be65c9c3fe5ca753583f7557ef312) Updated elpa
* [`3165cb46`](https://github.com/nix-community/emacs-overlay/commit/3165cb4686b6631dfba983d4bd4cffd1e2e714bf) Updated melpa
* [`452daa6a`](https://github.com/nix-community/emacs-overlay/commit/452daa6ae6b49c84676abf57f3a0720d78193afd) Updated emacs
* [`723d1acc`](https://github.com/nix-community/emacs-overlay/commit/723d1acc1d512677ea1592c9fabbe7bb85d4c9fc) Updated melpa
* [`c1d57dfc`](https://github.com/nix-community/emacs-overlay/commit/c1d57dfc41323f39f16ec7fe1c9d85402e6ec12d) Updated emacs
* [`2ad0059c`](https://github.com/nix-community/emacs-overlay/commit/2ad0059c7b080bcf8aee35ef5119968f6e1f7160) Updated elpa
* [`69f9e0a5`](https://github.com/nix-community/emacs-overlay/commit/69f9e0a57cdc3aad8dd564c0ffce7ac210018b7c) Updated melpa
* [`ccf777d7`](https://github.com/nix-community/emacs-overlay/commit/ccf777d7dcaf160ea3a6125e33ab281963173ce7) Updated emacs
* [`4e00488e`](https://github.com/nix-community/emacs-overlay/commit/4e00488efa01c743bbd338e245e399d9fb3d5c58) Updated flake inputs
* [`0ef25dc0`](https://github.com/nix-community/emacs-overlay/commit/0ef25dc00bf9ee0e2905b24dda6f83fc43053e44) Updated elpa
* [`4159dd18`](https://github.com/nix-community/emacs-overlay/commit/4159dd1801bfac89336648f294b0fca2be906f86) Updated melpa
* [`1114419e`](https://github.com/nix-community/emacs-overlay/commit/1114419e691c8d89c35182e123643c94c915f158) Updated melpa
* [`e67c0cec`](https://github.com/nix-community/emacs-overlay/commit/e67c0cec68f7df91c79ab06b97e2cc24023665cf) Updated emacs
* [`966ce440`](https://github.com/nix-community/emacs-overlay/commit/966ce44017c95df1112466fb9d3fcedc5caff6d1) Updated elpa
* [`d203881a`](https://github.com/nix-community/emacs-overlay/commit/d203881a857d4cd40d50876b1e3637d5eeb81889) Updated melpa
* [`4dd596a5`](https://github.com/nix-community/emacs-overlay/commit/4dd596a5638a325f9d253d69ac35182d3388114f) Updated emacs
* [`dc8dcea0`](https://github.com/nix-community/emacs-overlay/commit/dc8dcea003994cabed49d84e448cab3a781527ec) Updated melpa
* [`77049b6a`](https://github.com/nix-community/emacs-overlay/commit/77049b6a510629cedbab9ceaa3057e8cfee9a47c) Updated flake inputs
* [`8e7378f0`](https://github.com/nix-community/emacs-overlay/commit/8e7378f0e954d5b8f8d102cb692030cbb51f86f9) Updated elpa
* [`60aa595e`](https://github.com/nix-community/emacs-overlay/commit/60aa595e8124ac7ecc00b56b5a1de38596c2a456) Updated melpa
* [`c4f6796e`](https://github.com/nix-community/emacs-overlay/commit/c4f6796e5c499cf6370a45fff08a03e848b9abad) Updated emacs
* [`0f340014`](https://github.com/nix-community/emacs-overlay/commit/0f3400143e82f2dc4df3e7370c8d4a1a08dede36) Add nongnuDevelPackages
* [`e2155e7e`](https://github.com/nix-community/emacs-overlay/commit/e2155e7ec578386985d726f193251ad6e326234e) Updated nongnu
* [`c217f519`](https://github.com/nix-community/emacs-overlay/commit/c217f5191c2d09b5f638dddb1e25f5f3091c39bf) Updated elpa
* [`3244696b`](https://github.com/nix-community/emacs-overlay/commit/3244696b590895d81fca834984afe6019b386aaf) Updated melpa
* [`2bc3e071`](https://github.com/nix-community/emacs-overlay/commit/2bc3e07187f2a800be5bc35e9938a477e6bc6b98) Updated emacs
* [`98dbb7af`](https://github.com/nix-community/emacs-overlay/commit/98dbb7afc846b67efdb5761e4d6efcd4a4882396) Updated melpa
* [`e171f7ac`](https://github.com/nix-community/emacs-overlay/commit/e171f7ac85c6aba2463fee6f22288d6d249c9c7a) Updated emacs
* [`cd006b0c`](https://github.com/nix-community/emacs-overlay/commit/cd006b0c4505ce610b8d6b67f6b4e92e9bd794e9) Updated elpa
* [`81e2180f`](https://github.com/nix-community/emacs-overlay/commit/81e2180f4a1c669ff96b084953010c73a028f2fc) Updated melpa
* [`753eca1c`](https://github.com/nix-community/emacs-overlay/commit/753eca1ca6316fdeecf81811ca4611cfbcc82758) Updated emacs
* [`5192fb12`](https://github.com/nix-community/emacs-overlay/commit/5192fb127c3eec5ed54178aacdc127a22681d256) Updated flake inputs
* [`2fe70a73`](https://github.com/nix-community/emacs-overlay/commit/2fe70a73dc88db5a07ea2032ce6d2c179ccd37dc) Updated nongnu
* [`92d8f0cb`](https://github.com/nix-community/emacs-overlay/commit/92d8f0cb018def3ab20d5f9946dfc3526ef391da) Updated elpa
* [`f03780e6`](https://github.com/nix-community/emacs-overlay/commit/f03780e6cbd9801445b7b9ae62e4a66782b00c39) Updated melpa
* [`c051c42e`](https://github.com/nix-community/emacs-overlay/commit/c051c42e3325ac62e9bf83e72e3868db1e5f2e64) Updated emacs
* [`991746cb`](https://github.com/nix-community/emacs-overlay/commit/991746cb534d11cab851c1902a4206f8007361a4) Updated flake inputs
* [`c64683db`](https://github.com/nix-community/emacs-overlay/commit/c64683db9939ee81ad836528d77d366498c66c92) Updated melpa
* [`68aae509`](https://github.com/nix-community/emacs-overlay/commit/68aae5094b61dad45fb75d67e4a8adcc90c54b55) Updated emacs
* [`d9c36fe0`](https://github.com/nix-community/emacs-overlay/commit/d9c36fe040d003915246c2c1708e12d2c19fe8d6) Updated flake inputs
* [`729001bd`](https://github.com/nix-community/emacs-overlay/commit/729001bdfa6be842db28371833d1aecb93324cf8) Updated elpa
* [`4d209acb`](https://github.com/nix-community/emacs-overlay/commit/4d209acba3b48dd6b549a34f7a7850e479e9a1f5) Updated melpa
* [`1a0e4480`](https://github.com/nix-community/emacs-overlay/commit/1a0e4480b35557950f3f427888da596d85fbdbf1) Updated emacs
* [`8dcb52e5`](https://github.com/nix-community/emacs-overlay/commit/8dcb52e51154802065d574ef74e9baeaa356a66b) Updated nongnu
* [`06a06134`](https://github.com/nix-community/emacs-overlay/commit/06a061346d80c189652b5e0cc934c7d8daccec01) Updated elpa
* [`48fbdaaa`](https://github.com/nix-community/emacs-overlay/commit/48fbdaaa312e0fcbfcf2230ba3067777da5cfb0c) Updated melpa
* [`247f06a1`](https://github.com/nix-community/emacs-overlay/commit/247f06a15fb5bb3d3ff8890d76bd45b924dc707b) Updated melpa
* [`f148a612`](https://github.com/nix-community/emacs-overlay/commit/f148a612dbb4c29162fd61558ca10bc1b6fdc669) Updated emacs
* [`c53e6b75`](https://github.com/nix-community/emacs-overlay/commit/c53e6b75705941f539f77b24488ca2c6000e3198) Updated nongnu
* [`7e3e428d`](https://github.com/nix-community/emacs-overlay/commit/7e3e428d40015b89e7a529911663195394535882) Updated elpa
* [`e048cf67`](https://github.com/nix-community/emacs-overlay/commit/e048cf6775cd7e0d0f4cd17709e90d630ea7988e) Updated melpa
* [`fe8d3b87`](https://github.com/nix-community/emacs-overlay/commit/fe8d3b87057c262e2b4aaa0ec0eb6c3bb6bacf31) Updated emacs
* [`9e64aabf`](https://github.com/nix-community/emacs-overlay/commit/9e64aabf90258a2ee0c3feb20a69236433d83017) Updated nongnu
* [`c76660e7`](https://github.com/nix-community/emacs-overlay/commit/c76660e716c458ee4b4f117fad99fafd25007edb) Updated elpa
* [`0d603cf5`](https://github.com/nix-community/emacs-overlay/commit/0d603cf53ecdac90f54e546e160876251f4f2c5e) Updated melpa
* [`a25c804e`](https://github.com/nix-community/emacs-overlay/commit/a25c804e62e9eb6f79dd2f412e90141b0aa8bfcb) Updated melpa
* [`8937306d`](https://github.com/nix-community/emacs-overlay/commit/8937306d2635d87bd83d472ab617ea3fad75f227) Updated emacs
* [`88aa0b90`](https://github.com/nix-community/emacs-overlay/commit/88aa0b90f3d27721ec0fac83ce836fecdccccaad) Updated nongnu
* [`dd824a8d`](https://github.com/nix-community/emacs-overlay/commit/dd824a8da6c3ed4d0a5a9ce494a6ef14d649646d) Updated elpa
* [`df0173fa`](https://github.com/nix-community/emacs-overlay/commit/df0173fad06b6db686dab80ea97cb6c698e8f115) Updated melpa
* [`719fcbc0`](https://github.com/nix-community/emacs-overlay/commit/719fcbc0392e846cdd37f230f5cd82bdda58f71c) Updated emacs
* [`c59e8963`](https://github.com/nix-community/emacs-overlay/commit/c59e8963e74586a72bb0822884943622d72abd45) Updated nongnu
* [`4915c4a1`](https://github.com/nix-community/emacs-overlay/commit/4915c4a157dd6aaac62ede10ea59a4179cb26d14) Updated elpa
* [`59682436`](https://github.com/nix-community/emacs-overlay/commit/59682436402b2e69e2f88285485a4b40c1211067) Updated melpa
* [`8d37c93c`](https://github.com/nix-community/emacs-overlay/commit/8d37c93c501ff1e3502ce1cb756d2abf502f3940) Updated melpa
* [`efbdeccc`](https://github.com/nix-community/emacs-overlay/commit/efbdeccca60da278c7a52c8d5f386c6cc7655c95) Updated emacs
* [`d496f638`](https://github.com/nix-community/emacs-overlay/commit/d496f6383cf42653c2ce8bafe1fc22c9d0a59b9f) Updated flake inputs
* [`52d4cb2d`](https://github.com/nix-community/emacs-overlay/commit/52d4cb2d128a3ebf06dfc8d9c539bfd8515cd4a4) Updated elpa
* [`9084d428`](https://github.com/nix-community/emacs-overlay/commit/9084d428228b56b48f84313d6ef04b980aca0077) Updated melpa
* [`3bdfc90a`](https://github.com/nix-community/emacs-overlay/commit/3bdfc90a8b8b6358dda446e317d3b9c53e247c89) Updated emacs
* [`797ea8b8`](https://github.com/nix-community/emacs-overlay/commit/797ea8b86092a931faa26a72331b63b3c6c47883) Updated nongnu
* [`1375d60f`](https://github.com/nix-community/emacs-overlay/commit/1375d60faaa14d70c30e83e723297fb0ba01418c) Updated emacs
* [`a930980f`](https://github.com/nix-community/emacs-overlay/commit/a930980f1685668425e0c0a39532051b6a5f1119) Updated elpa
* [`2568557a`](https://github.com/nix-community/emacs-overlay/commit/2568557a13c8437acfe70164f664c9c0e6d1bb94) Updated melpa
* [`1528fd2d`](https://github.com/nix-community/emacs-overlay/commit/1528fd2d8b6f51e6cf1d367da718570d61c48460) Updated flake inputs
* [`e3c2692a`](https://github.com/nix-community/emacs-overlay/commit/e3c2692ae5e299dcb27dcb192ba68bab4dc86ab1) Updated melpa
* [`97e2af44`](https://github.com/nix-community/emacs-overlay/commit/97e2af44f9f4a786996ead0e82e65fea23369609) Updated emacs
* [`eb6c1c44`](https://github.com/nix-community/emacs-overlay/commit/eb6c1c44a0b90d68dadc2f0dc4c9307d8175280a) Updated nongnu
* [`8dddc681`](https://github.com/nix-community/emacs-overlay/commit/8dddc6818dce33b9d97d51508c964ca25e845ff7) Updated elpa
* [`5d6e7617`](https://github.com/nix-community/emacs-overlay/commit/5d6e7617e382a1e5e60103df9164a05e7351be83) Updated melpa
* [`6b3fd267`](https://github.com/nix-community/emacs-overlay/commit/6b3fd267d5f4d54b1498f5dee2c32661f3f90613) Updated nongnu
* [`548db807`](https://github.com/nix-community/emacs-overlay/commit/548db80761853bba29fb6289727a6319b27cc0eb) Updated elpa
* [`66441ad0`](https://github.com/nix-community/emacs-overlay/commit/66441ad02b196243f2e910ce5f03f1dda03fb61c) Updated melpa
* [`516c4425`](https://github.com/nix-community/emacs-overlay/commit/516c442503ca7f744d46d30b77b2ca11f35f1e3e) Updated emacs
* [`8be02a3d`](https://github.com/nix-community/emacs-overlay/commit/8be02a3d75b06dd38b1e5765a4a2418abcfe9ad0) Updated melpa
* [`6b6c7d8a`](https://github.com/nix-community/emacs-overlay/commit/6b6c7d8a021e2a313af8e7fe77f2078f937fe5a9) Updated flake inputs
* [`2436406b`](https://github.com/nix-community/emacs-overlay/commit/2436406b4efbb9414d92088b4c3a08246db74d7e) Updated nongnu
* [`fba162a8`](https://github.com/nix-community/emacs-overlay/commit/fba162a809315d84f1221de9de24ff2ac00187a0) Updated elpa
* [`0f2c4cb3`](https://github.com/nix-community/emacs-overlay/commit/0f2c4cb31745058644f044fb4976dd41a8307db7) Updated melpa
* [`73ae2320`](https://github.com/nix-community/emacs-overlay/commit/73ae2320be79ca277fa5b1c60afe0c6fd1a08519) Updated emacs
* [`141a020f`](https://github.com/nix-community/emacs-overlay/commit/141a020f73221ba3fc5edf2c0437949827276064) Updated nongnu
* [`f0bcef64`](https://github.com/nix-community/emacs-overlay/commit/f0bcef64b9a27f1de8dbb35d53dda9d4cd7464d2) Updated elpa
* [`51650f60`](https://github.com/nix-community/emacs-overlay/commit/51650f605cdc8e73fa1573d64127ec6f1619ba18) Updated emacs
* [`406b85d2`](https://github.com/nix-community/emacs-overlay/commit/406b85d2b06b4cfab0f0f31b08758fac8e02a691) Updated melpa
* [`d4cae4d9`](https://github.com/nix-community/emacs-overlay/commit/d4cae4d9ac38b0d7d5ccd61d57bed8aad9c752f0) Updated melpa
* [`aad34633`](https://github.com/nix-community/emacs-overlay/commit/aad34633f2b567583651ff6b7614026a4b7b58a3) Updated emacs
* [`3fb3c163`](https://github.com/nix-community/emacs-overlay/commit/3fb3c1632623136fad3cae2d2e5c73e0bca04766) Updated nongnu
* [`9b24a1af`](https://github.com/nix-community/emacs-overlay/commit/9b24a1af7659f8597b57ee7c28f87404826ad9f8) Updated elpa
* [`e8c9c507`](https://github.com/nix-community/emacs-overlay/commit/e8c9c50731314d192806c46277be0bcac97a4b1e) Updated melpa
* [`463ee3b4`](https://github.com/nix-community/emacs-overlay/commit/463ee3b4d1c63385c58d7742d33dbe6bdc8fd2a1) Updated emacs
* [`34aa99ed`](https://github.com/nix-community/emacs-overlay/commit/34aa99ed7c4cf36c93de4966850afc814ab5664e) Updated nongnu
* [`83f1d71d`](https://github.com/nix-community/emacs-overlay/commit/83f1d71d1486e4af3e84483293da9b37b0402964) Updated elpa
* [`e1c2845a`](https://github.com/nix-community/emacs-overlay/commit/e1c2845a53ec1f7a76c31da7d5dbc6422b61ff07) Updated melpa
* [`83e4a39e`](https://github.com/nix-community/emacs-overlay/commit/83e4a39e06f903236ad8595be5d8770284186d2e) Updated emacs
* [`e8be6f79`](https://github.com/nix-community/emacs-overlay/commit/e8be6f791bcd48f2ddb180793499013bfb92def5) Updated flake inputs
* [`f53d50f3`](https://github.com/nix-community/emacs-overlay/commit/f53d50f33151273cdb8cdd899f8de947c6018b06) Updated melpa
* [`aa3997dd`](https://github.com/nix-community/emacs-overlay/commit/aa3997dd78a00dec18e4d22f6073f78778c75301) Updated emacs
* [`e66167c0`](https://github.com/nix-community/emacs-overlay/commit/e66167c05e56e79750446cfcd5d1237da7f55a02) Updated flake inputs
* [`5b945043`](https://github.com/nix-community/emacs-overlay/commit/5b9450433aff68564c2e7c11bb4de967a7cbdf20) Updated nongnu
* [`2455e57b`](https://github.com/nix-community/emacs-overlay/commit/2455e57b0cf3242cc495d9831044529a50936722) Updated elpa
* [`92c05dd6`](https://github.com/nix-community/emacs-overlay/commit/92c05dd6f84856ef9b434ce876c62eea2ac5c03f) Updated melpa
* [`381e4aa2`](https://github.com/nix-community/emacs-overlay/commit/381e4aa28c0ecf265ed207ea14b0d10275eb651f) Updated emacs
* [`8dd2e6a5`](https://github.com/nix-community/emacs-overlay/commit/8dd2e6a5281ec2be00c2115ad0b2483be8db9d4b) Updated flake inputs
* [`442e4090`](https://github.com/nix-community/emacs-overlay/commit/442e4090a2f155ff5e7b3cce66a2f2245797034c) Updated nongnu
* [`c71cb74c`](https://github.com/nix-community/emacs-overlay/commit/c71cb74ccd98d6b9987822cd8e52c80a2aa0e8f1) Updated elpa
* [`0547cd35`](https://github.com/nix-community/emacs-overlay/commit/0547cd35dec4cbe988eb83bf6c2f676dced94fe5) Updated melpa
* [`a2e01edc`](https://github.com/nix-community/emacs-overlay/commit/a2e01edc18fdc0c31dfe8c3a1796902a4644575a) Updated emacs
* [`3c335bf8`](https://github.com/nix-community/emacs-overlay/commit/3c335bf80689107105ec6810b43be722fdd186c4) Updated emacs
* [`3922fa2c`](https://github.com/nix-community/emacs-overlay/commit/3922fa2cdbf5bf55f874d76167f70f7338f7b603) Updated nongnu
* [`928cbbb5`](https://github.com/nix-community/emacs-overlay/commit/928cbbb5a7d0346c861875eb7d2ca57925e3a16b) Updated elpa
* [`12e62600`](https://github.com/nix-community/emacs-overlay/commit/12e6260034f96c64e612efca1482984047fafe5f) Updated melpa
* [`09f34c88`](https://github.com/nix-community/emacs-overlay/commit/09f34c88fcb8ea60f8802ffa0efbaa382cad75e5) Updated nongnu
* [`84744bd9`](https://github.com/nix-community/emacs-overlay/commit/84744bd9868534b8d01acca4f464ef8e46758434) Updated elpa
* [`f396ad6b`](https://github.com/nix-community/emacs-overlay/commit/f396ad6b3ce6bfa2f3282cba4660df17391fd2a0) Updated melpa
* [`0c527c80`](https://github.com/nix-community/emacs-overlay/commit/0c527c80b18d24ad5b53aae362eac5d9c90f73a8) Updated flake inputs
* [`7e7a29fc`](https://github.com/nix-community/emacs-overlay/commit/7e7a29fc4ca7bbd50ad62c7ac4da3cce79ba1ac2) Updated melpa
* [`bfd58e3c`](https://github.com/nix-community/emacs-overlay/commit/bfd58e3ccc600bf01bc02d3d7844eb77a1547808) Updated emacs
* [`589ea56b`](https://github.com/nix-community/emacs-overlay/commit/589ea56ba7845ebd18aa5d52a0e565542a267653) Updated nongnu
* [`d2632c3a`](https://github.com/nix-community/emacs-overlay/commit/d2632c3a229d05790ca574640aae9bdeab939bc0) Updated elpa
* [`31cf722c`](https://github.com/nix-community/emacs-overlay/commit/31cf722c0181c0642a3d39761eead54749cd2fe6) Updated melpa
* [`45ea19bb`](https://github.com/nix-community/emacs-overlay/commit/45ea19bb0b9b7cbc6ca190ebbb5cff014ca32e1a) Updated emacs
* [`3c5042ab`](https://github.com/nix-community/emacs-overlay/commit/3c5042ab4050d4d708faa853c88b65d2c91d34d5) Updated nongnu
* [`b6ecd5a2`](https://github.com/nix-community/emacs-overlay/commit/b6ecd5a2e7b95232b7ae62a31db15246a6906e5a) Updated elpa
* [`517c6c93`](https://github.com/nix-community/emacs-overlay/commit/517c6c9344d1e3f24e5e3a322870092a126d8dc4) Updated melpa
* [`535e21a9`](https://github.com/nix-community/emacs-overlay/commit/535e21a91760db70f655492c6dc696a806726470) Updated emacs
* [`bcb0bbba`](https://github.com/nix-community/emacs-overlay/commit/bcb0bbba64286cdf35be2a975efaeb10ab274dee) Updated flake inputs
* [`747634bb`](https://github.com/nix-community/emacs-overlay/commit/747634bb5f7f6cdc2f76b037707c7b6779f4b5d8) Updated melpa
* [`3b4f8179`](https://github.com/nix-community/emacs-overlay/commit/3b4f8179de2b4950540d70161854e43fe1010eae) Updated emacs
* [`857cc166`](https://github.com/nix-community/emacs-overlay/commit/857cc166e4e91a1fd5b0db388505898c26785304) Updated nongnu
* [`c8dbec6a`](https://github.com/nix-community/emacs-overlay/commit/c8dbec6a0b96c0c32134d85e9165e746b68ddee4) Updated elpa
* [`88948124`](https://github.com/nix-community/emacs-overlay/commit/8894812488e2c1f34e6e1dbcda726b5bc040e6d1) Updated melpa
* [`083d5626`](https://github.com/nix-community/emacs-overlay/commit/083d562644c3efa57b0e11b9bf902d2bb70bfbd0) Updated emacs
* [`2fe43aca`](https://github.com/nix-community/emacs-overlay/commit/2fe43aca0a7b2c4bc395bde028173ca37a6b6904) Updated nongnu
* [`812df766`](https://github.com/nix-community/emacs-overlay/commit/812df766a75b6e3b6a6b0852c86bb6def40d205b) Updated elpa
* [`fa52ed43`](https://github.com/nix-community/emacs-overlay/commit/fa52ed43781e7174f69e4072f37dec3730c01f3e) Updated emacs
* [`5b263d57`](https://github.com/nix-community/emacs-overlay/commit/5b263d5788c503a83399c2b54ba87e46fb96b418) Updated melpa
* [`ddc032f7`](https://github.com/nix-community/emacs-overlay/commit/ddc032f721d44930b325faa0414bf60f29f87ae3) Updated melpa
* [`2dc18fd0`](https://github.com/nix-community/emacs-overlay/commit/2dc18fd0621276a03b36e509d9271155d6e5ee19) Updated emacs
* [`1eb41e1b`](https://github.com/nix-community/emacs-overlay/commit/1eb41e1bd466beb7611cddadb8378e602cc24945) Updated nongnu
* [`a1d264a4`](https://github.com/nix-community/emacs-overlay/commit/a1d264a46c1f782adb72fb7c4996d0cde2570223) Updated elpa
* [`bde8f177`](https://github.com/nix-community/emacs-overlay/commit/bde8f17728d51394fa78605cf3cd2493b8e6475b) Updated melpa
* [`cd1f4c41`](https://github.com/nix-community/emacs-overlay/commit/cd1f4c419ab3f3dd981de94fd1dda5a450dbcadf) Updated emacs
* [`d23e2b1d`](https://github.com/nix-community/emacs-overlay/commit/d23e2b1d13f65ada504e7662cbbfd964124f6384) Updated nongnu
* [`f560efb1`](https://github.com/nix-community/emacs-overlay/commit/f560efb1e208748c2bbccce0459a860b2ef62bdc) Updated elpa
* [`47c6dc70`](https://github.com/nix-community/emacs-overlay/commit/47c6dc70ea802686fcb513928be6465ec6400839) Updated melpa
* [`c34c8d77`](https://github.com/nix-community/emacs-overlay/commit/c34c8d77f326f42d43d5912c33e8802a96d29cd0) Updated emacs
* [`eda7ebd2`](https://github.com/nix-community/emacs-overlay/commit/eda7ebd2ea4134dd2b428e9e25f30239c7194f66) Updated fromElisp
* [`ad08090d`](https://github.com/nix-community/emacs-overlay/commit/ad08090d3f0ef28bcbb7b989d0491402cff4f745) Updated nongnu
* [`ed21ef42`](https://github.com/nix-community/emacs-overlay/commit/ed21ef421c345eafbaf656dffeb44bbb6e891154) Updated elpa
* [`3db40512`](https://github.com/nix-community/emacs-overlay/commit/3db405127bfaea6458d5d8efdab0f97a72377a0d) Updated melpa
* [`baf55697`](https://github.com/nix-community/emacs-overlay/commit/baf55697c9e11c207789cf841cf286f7c1099568) Updated emacs
* [`4f69ba89`](https://github.com/nix-community/emacs-overlay/commit/4f69ba89ee0da7783724694207b71cdfbbc0c34c) Updated nongnu
* [`b607b449`](https://github.com/nix-community/emacs-overlay/commit/b607b449257a0df8d1362bd998874cd2f30a432b) Updated elpa
* [`5102183b`](https://github.com/nix-community/emacs-overlay/commit/5102183b47bb2cf6699915a1e0a5ea0cc7f140d1) Updated melpa
* [`ac6e2462`](https://github.com/nix-community/emacs-overlay/commit/ac6e2462978c50ddf8c297d95dd1adca7e58d1e1) Updated emacs
* [`b5a54319`](https://github.com/nix-community/emacs-overlay/commit/b5a543194c6156e121a974a8710c52476c0e30d4) Updated flake inputs
* [`da6dff8b`](https://github.com/nix-community/emacs-overlay/commit/da6dff8bff20b1e11a84b98cb7d57ebc4fbe94b0) Updated nongnu
* [`c38ab8ab`](https://github.com/nix-community/emacs-overlay/commit/c38ab8ab3a08f09f2e4b35c792f70a70159f72f0) Updated elpa
* [`d153d9f1`](https://github.com/nix-community/emacs-overlay/commit/d153d9f118d71fa8f4d3204639b4fd32d793ab57) Updated melpa
* [`f364a854`](https://github.com/nix-community/emacs-overlay/commit/f364a8542a98343e54b5e2598f2479ba06b5ea5c) Updated flake inputs
* [`3e4af547`](https://github.com/nix-community/emacs-overlay/commit/3e4af547dc749364760bb5a45ec1b2a0a8be8037) Updated nongnu
* [`ceedca8a`](https://github.com/nix-community/emacs-overlay/commit/ceedca8a2911251076c33b52464850646173d401) Updated elpa
* [`cd29768a`](https://github.com/nix-community/emacs-overlay/commit/cd29768a858f5d860777147da43431df5d27291e) Updated melpa
* [`e197771f`](https://github.com/nix-community/emacs-overlay/commit/e197771f35c8c330324256c5f306614f273ffd9d) Updated emacs
* [`083cb4ec`](https://github.com/nix-community/emacs-overlay/commit/083cb4ec5e6801bb54f0776fff5229ab72f75bc2) Updated flake inputs
* [`cc137dec`](https://github.com/nix-community/emacs-overlay/commit/cc137decdd01d0fc54f6eae302a4b2773c26ca79) Updated nongnu
* [`37db8016`](https://github.com/nix-community/emacs-overlay/commit/37db8016026a43b5f3d16ec4b949792d6b6bce4a) Updated elpa
* [`c45a8b15`](https://github.com/nix-community/emacs-overlay/commit/c45a8b1599105dd5bbc2af9c57dbef26d5a42b72) Updated melpa
* [`758aa1de`](https://github.com/nix-community/emacs-overlay/commit/758aa1deb09d8d2dce7bd3a016434e8fcedfab89) Updated emacs
* [`e1b00b53`](https://github.com/nix-community/emacs-overlay/commit/e1b00b5328ecb8fbb1f91b1054453783a54058ad) Updated nongnu
* [`6c6dada1`](https://github.com/nix-community/emacs-overlay/commit/6c6dada1dbf833f9134399527925f094bb42914f) Updated elpa
* [`daae91b8`](https://github.com/nix-community/emacs-overlay/commit/daae91b88ac87312bdb27a52ac220043c63ef17e) Updated melpa
* [`9d8307d8`](https://github.com/nix-community/emacs-overlay/commit/9d8307d88a60bc4d6223a391b2fb41cc37e6714c) Updated emacs
* [`515ea143`](https://github.com/nix-community/emacs-overlay/commit/515ea143c92981cc699470a18b1150e4ebb5e4d6) Updated nongnu
* [`6d6e4169`](https://github.com/nix-community/emacs-overlay/commit/6d6e416939c4866ba29029eb130c669d586be9bd) Updated elpa
* [`c07434ea`](https://github.com/nix-community/emacs-overlay/commit/c07434ea1126b09684566c89843c5132bc9a67dd) Updated melpa
* [`618b258c`](https://github.com/nix-community/emacs-overlay/commit/618b258c4f0eb823e9d1feabac6ae9d164b77c19) Updated emacs
* [`75c12ab0`](https://github.com/nix-community/emacs-overlay/commit/75c12ab00289f28750067608de1dd8e3022cffaf) Updated flake inputs
* [`c0edc9c7`](https://github.com/nix-community/emacs-overlay/commit/c0edc9c7d97c85344fcecfccd115e8b3c87b5d0b) Updated melpa
* [`f97fc32d`](https://github.com/nix-community/emacs-overlay/commit/f97fc32d98cd25d40830543e95dc7cd66ef9ac63) Updated emacs
* [`11677931`](https://github.com/nix-community/emacs-overlay/commit/11677931e3ee57dfd557d0e6cc44343f8d2608e8) Updated flake inputs
* [`c4de0daa`](https://github.com/nix-community/emacs-overlay/commit/c4de0daa8d91f44418332e2b57c9219339003296) Updated nongnu
* [`74f02299`](https://github.com/nix-community/emacs-overlay/commit/74f022991e5310eeb5179e8eb969591714f0b24a) Updated elpa
* [`3387f280`](https://github.com/nix-community/emacs-overlay/commit/3387f28077f6891063b2428eb71858974546aa13) Updated melpa
* [`a3d82240`](https://github.com/nix-community/emacs-overlay/commit/a3d82240ba51c3bf319f7d6ec9970ba264947847) Updated emacs
* [`beddb777`](https://github.com/nix-community/emacs-overlay/commit/beddb77769c16762d860748251464262c3b98508) Updated nongnu
* [`e2d49049`](https://github.com/nix-community/emacs-overlay/commit/e2d49049193da5825545ba8c720f02a4eb64e8dc) Updated elpa
* [`46d9f51c`](https://github.com/nix-community/emacs-overlay/commit/46d9f51c7d5dd347d5bb000f0bbb00177b2f25da) Updated melpa
* [`e519d6ce`](https://github.com/nix-community/emacs-overlay/commit/e519d6ceb1aa9635e87db20789602589c7a781e0) Updated emacs
* [`be236af2`](https://github.com/nix-community/emacs-overlay/commit/be236af247cc01fb743af02d2ddf95eee37e038c) Updated flake inputs
* [`011e5ec2`](https://github.com/nix-community/emacs-overlay/commit/011e5ec2d7d83934c8ecfcb4043553d71afe8580) Updated elpa
* [`06145d70`](https://github.com/nix-community/emacs-overlay/commit/06145d70ae2aad67e0ab8fe7b86f71c3f1fe6e52) Updated melpa
* [`b569d3ae`](https://github.com/nix-community/emacs-overlay/commit/b569d3ae7d60c901a19944b00440c3a11e4da48a) Updated emacs
* [`ad0373d0`](https://github.com/nix-community/emacs-overlay/commit/ad0373d03bd3f3e9e88332628cf258ca65983e57) Updated elpa
* [`ae062765`](https://github.com/nix-community/emacs-overlay/commit/ae06276558dc3500804032c7d5457095f17561b7) Updated melpa
* [`b9785eef`](https://github.com/nix-community/emacs-overlay/commit/b9785eef40edb93ed3e353f63ad69f25a320557c) Updated melpa
* [`0780b827`](https://github.com/nix-community/emacs-overlay/commit/0780b82798307b08982e766e039f7a1680fadfe8) Updated emacs
* [`a1a70d50`](https://github.com/nix-community/emacs-overlay/commit/a1a70d5067afaf9167850efc62b124f5da9b5b64) Updated nongnu
* [`943df04c`](https://github.com/nix-community/emacs-overlay/commit/943df04c834c0e0ff07565fc3eaab51fd881d81f) Updated elpa
* [`12d91d19`](https://github.com/nix-community/emacs-overlay/commit/12d91d1951ee5541436a6970556d21a8e5f4f3ca) Updated melpa
* [`db56604e`](https://github.com/nix-community/emacs-overlay/commit/db56604e96bbc4de959c85b749d26a96dbe45a56) Updated emacs
* [`b07ef0c4`](https://github.com/nix-community/emacs-overlay/commit/b07ef0c4ed9352499d1b1c2831034c9979c93bfe) Updated nongnu
* [`1fc04d6b`](https://github.com/nix-community/emacs-overlay/commit/1fc04d6b751b73efb1409df9fd9c374529b7db58) Updated elpa
* [`b8d09be3`](https://github.com/nix-community/emacs-overlay/commit/b8d09be3670725b8b19082b1f89a4a140714f917) Updated melpa
* [`ff4dfde6`](https://github.com/nix-community/emacs-overlay/commit/ff4dfde6920d352fa016a1315b5f4259f54fef6d) Updated emacs
* [`512b17de`](https://github.com/nix-community/emacs-overlay/commit/512b17de7e3f6f150f6d39b8d23a7d1e391cb078) Updated melpa
* [`d945c2ba`](https://github.com/nix-community/emacs-overlay/commit/d945c2ba0421e0c1b239b5882f2c0725fe8cfba1) Updated emacs
* [`f04e49f5`](https://github.com/nix-community/emacs-overlay/commit/f04e49f576af07b1093d9889e1215ab9f0eaca48) Updated nongnu
* [`f95296dc`](https://github.com/nix-community/emacs-overlay/commit/f95296dceac522efc2f9ad2b0f14b602210e55a8) Updated elpa
* [`f15cba42`](https://github.com/nix-community/emacs-overlay/commit/f15cba422c1f3dba4f388c8a042e92afe9be824a) Updated melpa
* [`86e302cd`](https://github.com/nix-community/emacs-overlay/commit/86e302cd5f144f7bc4bb7a4d52536c92831c4c57) Updated emacs
* [`1852ff42`](https://github.com/nix-community/emacs-overlay/commit/1852ff42eaa15648376a480750e3194d57ead9c3) Updated nongnu
* [`54f25978`](https://github.com/nix-community/emacs-overlay/commit/54f25978c01029a03e2163a6d928cb8de09f1e1b) Updated elpa
* [`915783ed`](https://github.com/nix-community/emacs-overlay/commit/915783ed540951d87bd320b1e2f2d8ec930be375) Updated melpa
* [`e3e088ef`](https://github.com/nix-community/emacs-overlay/commit/e3e088ef4b4b187a54445f5767047a8257893093) Updated emacs
* [`3052bb01`](https://github.com/nix-community/emacs-overlay/commit/3052bb01d404ee9bd03b040c9ae898febca05b81) Updated melpa
* [`899069ba`](https://github.com/nix-community/emacs-overlay/commit/899069bad48b633d0da92e2e0d64add207283ed8) Updated flake inputs
* [`2c166e27`](https://github.com/nix-community/emacs-overlay/commit/2c166e2729fa6e7907abe9d309a58fff67295183) Updated nongnu
* [`d282abe5`](https://github.com/nix-community/emacs-overlay/commit/d282abe57699b13cc8da18fadb0900f6592fc0ab) Updated elpa
* [`a633f437`](https://github.com/nix-community/emacs-overlay/commit/a633f4375024504d2a5d485f971ce7c9af987248) Updated melpa
* [`709f6f16`](https://github.com/nix-community/emacs-overlay/commit/709f6f16db78e31d37f1db7f2a3f58715d3c1746) Updated emacs
* [`8539263e`](https://github.com/nix-community/emacs-overlay/commit/8539263eabed1ad0b18aff9e6ed516cfccc63ada) Updated nongnu
* [`b2cb3623`](https://github.com/nix-community/emacs-overlay/commit/b2cb3623d2e56d7da2e17ca695b61b895da53100) Updated elpa
* [`f7a3d86f`](https://github.com/nix-community/emacs-overlay/commit/f7a3d86f3ac31d662e9363050a81ae4dbcc7501e) Updated melpa
* [`28c1c399`](https://github.com/nix-community/emacs-overlay/commit/28c1c399c3139a964124b7afef191b83c5b694ec) Updated emacs
* [`277861c3`](https://github.com/nix-community/emacs-overlay/commit/277861c302ef06cc912c86dd790990c6a14b105d) Updated flake inputs
* [`b19075bb`](https://github.com/nix-community/emacs-overlay/commit/b19075bb87c0fec472dc9b4720096ce1735da1aa) Updated nongnu
* [`50010ea7`](https://github.com/nix-community/emacs-overlay/commit/50010ea7cd65efdf1ee448ae8c0791402ffd47c5) Updated elpa
* [`e614da0a`](https://github.com/nix-community/emacs-overlay/commit/e614da0a87240a3d88ea5ae3f4c75e0e10f41373) Updated melpa
* [`40712629`](https://github.com/nix-community/emacs-overlay/commit/40712629565969dd9b8eec73d3b733a437f0bef7) Updated emacs
* [`3b671ddf`](https://github.com/nix-community/emacs-overlay/commit/3b671ddf947fd8708b4cff886daf22a79466c850) Updated nongnu
* [`76e83593`](https://github.com/nix-community/emacs-overlay/commit/76e83593ca1b584f181900b8bc8b95dc163f380c) Updated elpa
* [`6c5563a2`](https://github.com/nix-community/emacs-overlay/commit/6c5563a26bd1369d05f0d9da0d0348ca9f41a643) Updated melpa
* [`0cc5d42f`](https://github.com/nix-community/emacs-overlay/commit/0cc5d42f055fa0f6dd7cad4e8c84650434378bcc) Updated melpa
* [`bd223a42`](https://github.com/nix-community/emacs-overlay/commit/bd223a4218c70d9ea00ca970c3a02390316e3f42) Updated nongnu
* [`fa49f2ee`](https://github.com/nix-community/emacs-overlay/commit/fa49f2ee0f6b1567b03643f6378ec18e3c4aed8d) Updated melpa
* [`a30d0976`](https://github.com/nix-community/emacs-overlay/commit/a30d097694a490feee5571750d05be1ef75fae40) Updated flake inputs
* [`48cf78a0`](https://github.com/nix-community/emacs-overlay/commit/48cf78a0672a449c949fcc6f0023e28b46fabe7b) Updated nongnu
* [`9973a0ae`](https://github.com/nix-community/emacs-overlay/commit/9973a0ae63b26b38b682ef0b5673a320f4fe5a1a) Updated elpa
* [`190dc7b1`](https://github.com/nix-community/emacs-overlay/commit/190dc7b1aaf9b168d7ea2a3d0d3dd962f32d3967) Updated melpa
* [`011e730e`](https://github.com/nix-community/emacs-overlay/commit/011e730ea976aeb70a730cf5b01b79643d8da092) Updated emacs
* [`3b0a0983`](https://github.com/nix-community/emacs-overlay/commit/3b0a0983dfc4565c6f5809c9ba708b36f44d7e0b) Updated flake inputs
* [`199ade88`](https://github.com/nix-community/emacs-overlay/commit/199ade88c899e69f1089454675f2514161951724) Updated melpa
* [`9fc815e2`](https://github.com/nix-community/emacs-overlay/commit/9fc815e216d4891aec42035e0008a0e2908938e4) Updated emacs
* [`8e818a7e`](https://github.com/nix-community/emacs-overlay/commit/8e818a7e8773aad8dc2f53efe8a5ab5365bb569c) Updated elpa
* [`6976012f`](https://github.com/nix-community/emacs-overlay/commit/6976012f1243153747f0051c54dc3179d1418f00) Updated melpa
* [`33812cad`](https://github.com/nix-community/emacs-overlay/commit/33812cad36ad7826d7eb9bd72eb11995be20cff6) Updated emacs
* [`49261a89`](https://github.com/nix-community/emacs-overlay/commit/49261a899cc9c11a465c243d9dcebc54d3b91fdb) Updated flake inputs
* [`4d3bcfc2`](https://github.com/nix-community/emacs-overlay/commit/4d3bcfc264afcd04617945191cdca0c13becc463) Updated elpa
* [`92709054`](https://github.com/nix-community/emacs-overlay/commit/92709054be3ef3aeddc7a37f1c59b6959530dfac) Updated melpa
* [`45405f34`](https://github.com/nix-community/emacs-overlay/commit/45405f34d10260753298ff244a9b9c36e04b2e11) Updated emacs
* [`6e8515fc`](https://github.com/nix-community/emacs-overlay/commit/6e8515fc55c2dc7f65b79aa7c647d318cc7ae760) Updated nongnu
* [`72077e4b`](https://github.com/nix-community/emacs-overlay/commit/72077e4bba07910b106ec099ec2ece8e5b5736f3) Updated elpa
* [`3169e5e6`](https://github.com/nix-community/emacs-overlay/commit/3169e5e682432a38e768b68e2557dc610ca0a426) Updated melpa
* [`8963f64e`](https://github.com/nix-community/emacs-overlay/commit/8963f64ec61eec13f39b1aa425a2e79543a995ba) Updated melpa
* [`8aca32cd`](https://github.com/nix-community/emacs-overlay/commit/8aca32cde9523f58a2cd3733b891c3c8b494b26f) Updated emacs
* [`b220a30f`](https://github.com/nix-community/emacs-overlay/commit/b220a30f2a7eedbc3ac50a1c9f8853fd4a9787f9) Updated flake inputs
* [`acc702af`](https://github.com/nix-community/emacs-overlay/commit/acc702af5ae924db7557bb36074a373e194dc949) Updated nongnu
* [`faae1b85`](https://github.com/nix-community/emacs-overlay/commit/faae1b85f955e2cc3dd4943d9d747151b8fec05a) Updated elpa
* [`ca954064`](https://github.com/nix-community/emacs-overlay/commit/ca9540642850913ce39b90c905f4bdd579660910) Updated melpa
* [`6bbe8973`](https://github.com/nix-community/emacs-overlay/commit/6bbe8973c0a99ebb54175310f20a0d255f688f90) Updated emacs
