### PR TITLE
niv doomemacs: update 8be1ef49 -> c9acdb72

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "doomemacs",
         "repo": "doomemacs",
-        "rev": "8be1ef498b81628214ab5e78739661faaf9d950f",
-        "sha256": "0cfn8i5322bm2v2cywpgw4fr64q8s6ibwkdhgr93f4a8xhqam93h",
+        "rev": "c9acdb72a4bd95d7ac38d62e92aa79f395c1dccd",
+        "sha256": "1vsrhb98dqnyk8dh8kczm4bk4778mpcrxrq7g06jhz9pq774pmhy",
         "type": "tarball",
-        "url": "https://github.com/doomemacs/doomemacs/archive/8be1ef498b81628214ab5e78739661faaf9d950f.tar.gz",
+        "url": "https://github.com/doomemacs/doomemacs/archive/c9acdb72a4bd95d7ac38d62e92aa79f395c1dccd.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "emacs-overlay": {


### PR DESCRIPTION
## Changelog for doomemacs:
Branch: master
Commits: [doomemacs/doomemacs@8be1ef49...c9acdb72](https://github.com/doomemacs/doomemacs/compare/8be1ef498b81628214ab5e78739661faaf9d950f...c9acdb72a4bd95d7ac38d62e92aa79f395c1dccd)

* [`07f88f94`](https://github.com/doomemacs/doomemacs/commit/07f88f94eab66ac84a1a82d685845534ea4ce310) fix: improve startup error message
* [`cf709852`](https://github.com/doomemacs/doomemacs/commit/cf7098528d2a21c29d497cd810faa0a77ecaf4cc) release(modules): 24.09.0-dev
* [`2c17f719`](https://github.com/doomemacs/doomemacs/commit/2c17f719657c46ea37e4846289e951c83409a514) fix(cli): don't prompt to rebuild if --rebuild is given
* [`e3fdfee1`](https://github.com/doomemacs/doomemacs/commit/e3fdfee1c54b10d84c4cd87dab6c9eb8beab87e3) feat(cli): add --aot option
* [`b1b40754`](https://github.com/doomemacs/doomemacs/commit/b1b40754fe613e45d67e1295dd89f9f980de8152) fix(org): don't optimize already-open agenda buffers
* [`a6df88a5`](https://github.com/doomemacs/doomemacs/commit/a6df88a56a3fccf483ee992dc4801f5d9a1983c4) feat(lib): doom-org-docs-mode: bind q to kill-current-buffer
* [`7f3412e3`](https://github.com/doomemacs/doomemacs/commit/7f3412e3174d3f5bb721a140f67be3a5a055e31d) bump: :ui
* [`b3bea233`](https://github.com/doomemacs/doomemacs/commit/b3bea23331f548b02682fda1170c439560a5fb64) fix(workspaces): "none" workspace
* [`334157d7`](https://github.com/doomemacs/doomemacs/commit/334157d7410dfe13ec6b9cba0f16d526c07d6f85) fix(popup,org): popup management for org-mode
* [`877008a0`](https://github.com/doomemacs/doomemacs/commit/877008a00e6e88f4029b81df0139377ddc173d49) fix(evil): set evil-want-keybinding sooner
* [`c93b7023`](https://github.com/doomemacs/doomemacs/commit/c93b70237cf20a6c0e456dd8686fb393d99614e2) fix(evil): defer evil-collection-kmacro
* [`511c8af3`](https://github.com/doomemacs/doomemacs/commit/511c8af36537992fd60ff970e19e5638207546ed) bump: :editor
* [`d3124c49`](https://github.com/doomemacs/doomemacs/commit/d3124c49718b3729c20b310870ae95e28db1b17b) nit: add deprecation comments for projectile config
* [`939fc0d3`](https://github.com/doomemacs/doomemacs/commit/939fc0d3227706459e7ba74d53e2c0fd3d07ccba) feat: add project-vc config
* [`4fcf3327`](https://github.com/doomemacs/doomemacs/commit/4fcf3327491551b022ac4ad94d342bc05f0fdd69) refactor: generalize fd/ripgrep vars & options
* [`d04e1404`](https://github.com/doomemacs/doomemacs/commit/d04e1404c285275239295cf8b6793a722ab36b64) fix: projectile: ignore more vc directories in file listings
* [`d9d1737d`](https://github.com/doomemacs/doomemacs/commit/d9d1737deb1106c75f33dd14088e37f4ff9bf1fe) docs(cc): future-proof Debian/Ubuntu install instructions
* [`ab1d396c`](https://github.com/doomemacs/doomemacs/commit/ab1d396c2dd319ef84a4064aeb83cec942d32803) docs(org): update install docs for Ubuntu/Debian & Arch
* [`52aadcd0`](https://github.com/doomemacs/doomemacs/commit/52aadcd01fec8040338900d020fadf063501fe2c) docs(:lang): correct grammar
* [`6e1bfe97`](https://github.com/doomemacs/doomemacs/commit/6e1bfe97c04e58a4573b8ff1e945d2b6bd5bae19) docs(markdown): expand proselint install docs
* [`f5020a4f`](https://github.com/doomemacs/doomemacs/commit/f5020a4f7f228a84a51039a57fbf67107a0f2d74) refactor: simplify projectile config
* [`95e0b430`](https://github.com/doomemacs/doomemacs/commit/95e0b43012f39959ec291ab4448e127088285147) fix: "Malformed pattern in custom ignore file .project" error
* [`fa153d5b`](https://github.com/doomemacs/doomemacs/commit/fa153d5b914d5480f384d62548cca9dbce22c2c7) refactor(ocaml): use apheleia instead of ocamlformat.el
* [`8519f6fe`](https://github.com/doomemacs/doomemacs/commit/8519f6fed249f12d177fdeda08255471683b9b00) refactor(ocaml): entry points into ocp-indent & opam-switch-mode
* [`29fcd474`](https://github.com/doomemacs/doomemacs/commit/29fcd474e201c5ce2e605fc9dcd08b2510234c48) bump: :lang ocaml
* [`84f7eb2a`](https://github.com/doomemacs/doomemacs/commit/84f7eb2affeae9bb5f85379dd8677f2c0a372c83) feat(cc): set eglot client for cuda-mode to clangd
* [`88666b19`](https://github.com/doomemacs/doomemacs/commit/88666b19139aa345f83028711bf306aa0aad1b65) bump: :lang cc
* [`173842cc`](https://github.com/doomemacs/doomemacs/commit/173842cceaefdb175dd0163ceb11bedd22093bf8) fix(lsp): eglot-ensure advice nooping in some major modes
* [`916180a6`](https://github.com/doomemacs/doomemacs/commit/916180a6bfddc9e7ba4c945141d63205af6774a1) fix: better-jumper evil integration
* [`e66a863e`](https://github.com/doomemacs/doomemacs/commit/e66a863e073f13d4aafb93b453b53ef2713f78ab) fix(magit): don't recursively open process buffers
* [`dc035a65`](https://github.com/doomemacs/doomemacs/commit/dc035a652f211573951b30b6ba7939086eea0f9e) fix: reset inhibit-* vars a mote more aggressively
* [`3a2c234b`](https://github.com/doomemacs/doomemacs/commit/3a2c234b1c57d0e8eea1f8780f6465254af442a4) fix(cli): don't AOT native-comp if disabled
* [`e7a51648`](https://github.com/doomemacs/doomemacs/commit/e7a51648936c635434bf47ac185c48492c655838) refactor(syntax): remove popen package! statement
* [`5e2e886b`](https://github.com/doomemacs/doomemacs/commit/5e2e886b351bccf34f96d3cf224868c4ee0ba016) nit: comment revision & reformatting
* [`0f432805`](https://github.com/doomemacs/doomemacs/commit/0f4328058cb51f4ace7864e19a7bc589bdeca022) fix: restrict find-function-search-for-symbol advice to Emacs 29
* [`e8a44474`](https://github.com/doomemacs/doomemacs/commit/e8a444749a140411618c4ee73d10f4e9ef4123a9) refactor: use eval-when! less
* [`1912571c`](https://github.com/doomemacs/doomemacs/commit/1912571c9cec35d06f869637573e75ec529f6c7c) docs: minor revisions of docstrings across core+cli
* [`74999956`](https://github.com/doomemacs/doomemacs/commit/74999956438ae0461f89569b7abb00205635ce93) fix: better-jumper evil integration (part 2)
* [`f6040832`](https://github.com/doomemacs/doomemacs/commit/f6040832e53d0837b55a9b1db4ad36c929fbab54) nit(format): move formatter configs to bottom
* [`1977b3df`](https://github.com/doomemacs/doomemacs/commit/1977b3dfbadddbba794ef7434a23a69e1b0047f1) refactor(lib): generalize ripgrep executables
* [`a8ed6c9f`](https://github.com/doomemacs/doomemacs/commit/a8ed6c9f7d83e168cca345a933dbf03ea566fdfd) fix(vc-gutter): inhibit diff-hl-dired-mode in dirvish
* [`e82dab32`](https://github.com/doomemacs/doomemacs/commit/e82dab325727476799c5a7655ce1feadd376a95c) refactor!(dired): use dirvish, drop +ranger
* [`c0a1b9ef`](https://github.com/doomemacs/doomemacs/commit/c0a1b9efc9a89c240fb8a76424c4d227dcbfc2d8) fix(format): prettier: don't override prettier indent config
* [`9913acbd`](https://github.com/doomemacs/doomemacs/commit/9913acbdc4f22b2d208ea59ce5aec1e3cd722788) fix: opening tramp paths from command line args
* [`967586fc`](https://github.com/doomemacs/doomemacs/commit/967586fcae6260ba25da26ca4d0a4daaf85c4188) fix(dired): dirvish-{mode,header}-line-height = doom-modeline-height
* [`d4ad14b7`](https://github.com/doomemacs/doomemacs/commit/d4ad14b75d090649c0783c41082ebc4d745b76a8) fix(dired): fallback to default if dirvish-use-mode-line == nil
* [`ddfb0cc3`](https://github.com/doomemacs/doomemacs/commit/ddfb0cc3cc4326e72efb6db84c95eeb1401c7fc2) refactor(dired): dirvish-hide-details
* [`50adaa9e`](https://github.com/doomemacs/doomemacs/commit/50adaa9e48964a54fa4acdde8ac363869b32419f) fix(format): prettier-*: 'void-variable unless' error
* [`109aa2c1`](https://github.com/doomemacs/doomemacs/commit/109aa2c1596316f9416261a7b27b9a2e595ffc42) bump: :tools
* [`22f37e84`](https://github.com/doomemacs/doomemacs/commit/22f37e84dc6fba6fc66443723259fc179c8cd7df) bump: :emacs
* [`1c6288e2`](https://github.com/doomemacs/doomemacs/commit/1c6288e2b714fff541dd130f201eae2cae4b2ef1) perf(dired): suppress mode hooks when previewing files
* [`0893edef`](https://github.com/doomemacs/doomemacs/commit/0893edefae1fe548c7e1112038c6e50b9e35bd26) refactor!(magit): remove magit-todos
* [`6e8f5818`](https://github.com/doomemacs/doomemacs/commit/6e8f581897e00aa0bea5660abd09958dd8576383) feat(default): add `SPC t d` toggle for diff-hl-mode
* [`dff6c36a`](https://github.com/doomemacs/doomemacs/commit/dff6c36ab54f153aaba3b975f41705665a1304b4) docs(ligatures): use set-font-ligatures!
* [`ef142fc9`](https://github.com/doomemacs/doomemacs/commit/ef142fc913d0ef1f37b4e73c8d155434537cbf00) refactor(ligatures): defer ligature.el & combine variables
* [`0ce403d0`](https://github.com/doomemacs/doomemacs/commit/0ce403d069fea2ac5d299dd1422176a5acfa4eee) refactor(ligatures): set-font-ligatures!: unsetting multiple modes
* [`bf330b40`](https://github.com/doomemacs/doomemacs/commit/bf330b405d73757b314cc70e16ce991d2bbd9cc5) refactor(ligatures): use (featurep 'harfbuzz)
* [`67e5dda5`](https://github.com/doomemacs/doomemacs/commit/67e5dda526597c2797bec632d92a3577edc92133) fix(format): void-function +javascript-npm-conf error
* [`abf19aa6`](https://github.com/doomemacs/doomemacs/commit/abf19aa63e67ca92b2caa94d947cfb59d7a4ee4e) tweak(format): +format/region: emit message on success
* [`d1e5a285`](https://github.com/doomemacs/doomemacs/commit/d1e5a285fe6a53200f354c0c46c5315075db5f05) fix(vc): git-timemachine: enable font-lock-mode
* [`c1c3b521`](https://github.com/doomemacs/doomemacs/commit/c1c3b521d6c9af240f6841a0994f95149811ffea) bump: :editor evil
* [`41dab49c`](https://github.com/doomemacs/doomemacs/commit/41dab49c17041aab84bb667c4caee19661a17d9b) fix(biblio): s/+roam/+roam2
* [`5e70fe16`](https://github.com/doomemacs/doomemacs/commit/5e70fe169764bd272e73adbe56d67251fe9a886a) bump: :tools magit
* [`c78e49e8`](https://github.com/doomemacs/doomemacs/commit/c78e49e862d4f3b5351968709a099eaf6d557cc6) tweak(corfu): corfu-auto-delay = 0.24
* [`f3e9920e`](https://github.com/doomemacs/doomemacs/commit/f3e9920e802bb19cd77a463af944dd3fabe3ef90) bump: magit
* [`a6c3c684`](https://github.com/doomemacs/doomemacs/commit/a6c3c6842a4cd282c2a23d3ff1bc3d6fd98cdb96) refactor(dired): use dirvish-preview-environment
* [`4ed3e75f`](https://github.com/doomemacs/doomemacs/commit/4ed3e75f5f89b2907d7e78b6701bb0ad7acef273) fix(dired): fail gracefully if pdf-tools isn't installed
* [`fe15b1da`](https://github.com/doomemacs/doomemacs/commit/fe15b1daf335544d3c85d84746394a4711325c4c) fix(dired): remove keybind to nonexistent command
* [`ded3f5ec`](https://github.com/doomemacs/doomemacs/commit/ded3f5ec834942044b5caae6ca220270660b466b) fix(vc-gutter): runaway diff-hl threads & immortal buffers
* [`ff9c59df`](https://github.com/doomemacs/doomemacs/commit/ff9c59df468bcba569067f3c72c5c05b26c0d00a) tweak(vc-gutter): disable diff-hl-mode in pdf-view-mode
* [`aa8c31cf`](https://github.com/doomemacs/doomemacs/commit/aa8c31cf080692ca27960cd9a880ff9faf09e8c8) fix(vc-gutter): wrong-number-of-args error
* [`122e3732`](https://github.com/doomemacs/doomemacs/commit/122e3732f70f21ff9bd6f5e263642fd1793e08b1) fix(markdown): disable meta keybinds if evil-disable-insert-state-bindings
* [`dbcd3082`](https://github.com/doomemacs/doomemacs/commit/dbcd30820bccc79680ad83f8a09cdc1614027c5a) fix(eshell): eshell-did-you-mean: sequencep 771 error
* [`b835e7b6`](https://github.com/doomemacs/doomemacs/commit/b835e7b6ec29f06a7dc0b68b4c539eea4c5bcb1f) fix(workspaces): don't overwrite previously workspaces on save
* [`c27387ce`](https://github.com/doomemacs/doomemacs/commit/c27387ce762aa76c1fc33a747b8b33f913cc9368) fix(latex): enable LSP on LaTeX-mode-local-vars-hook too
* [`879c0b06`](https://github.com/doomemacs/doomemacs/commit/879c0b06a4b65058758d84c694ac6f327c5adc4b) refactor!(go): remove go-guru
* [`a0c901cc`](https://github.com/doomemacs/doomemacs/commit/a0c901cca7607965e771f4d8fe50604d80a34bb6) fix(format): lsp-mode/eglot formatters
* [`d941078e`](https://github.com/doomemacs/doomemacs/commit/d941078e666fc86ca99c0d0b548347c80a50d5fa) tweak(ligatures): +ligatures-extra-alist: affect derived modes
* [`1b336d05`](https://github.com/doomemacs/doomemacs/commit/1b336d05491e1559de3e27e88b23c49f78ae0eec) bump: forge
* [`1e73754d`](https://github.com/doomemacs/doomemacs/commit/1e73754dad967f83fa015a73ae18a4d7d22c2921) refactor(dired): dirvish-hide-cursor
* [`804da585`](https://github.com/doomemacs/doomemacs/commit/804da58540401f2ffc5467efff8bf444bc330592) fix(format): disable on-save for LaTeX-mode
* [`0d363045`](https://github.com/doomemacs/doomemacs/commit/0d363045c58081cc4efe3d1665d2faaceecaeb1f) tweak(dart): open flutter output in popup
* [`9ebd9cb7`](https://github.com/doomemacs/doomemacs/commit/9ebd9cb734fa9d610bfd7112ce17764d64e6e5f9) fix(go): remove bind to deprecated function
* [`d309dcad`](https://github.com/doomemacs/doomemacs/commit/d309dcad27aaaed0d7b81a4a90abf4cf535b8907) fix(plantuml): {org-,}plantuml-jar-path resolution
* [`e59023b8`](https://github.com/doomemacs/doomemacs/commit/e59023b843cace269ad3aab0948673deae500d77) fix(vc-gutter): toggle diff-hl-margin-mode in tty frames
* [`32d93690`](https://github.com/doomemacs/doomemacs/commit/32d9369091d59cb83fd2f9b74b77d565ae1ee3b1) fix(lsp): disable lsp-terraform
* [`b521492b`](https://github.com/doomemacs/doomemacs/commit/b521492bf445887181860b626ee94be45a8b227e) fix(default): feature-gate deft keybinds
* [`93c5f98e`](https://github.com/doomemacs/doomemacs/commit/93c5f98ee28de5d24c66274fc92773f245b00b4c) fix(vc-gutter): resist errors in kill-buffer advice
* [`d4357c17`](https://github.com/doomemacs/doomemacs/commit/d4357c173a33ee1d9dc449c7ea892956aa6adea2) fix(lsp): void-variable lsp-client-packages error
* [`bc634eac`](https://github.com/doomemacs/doomemacs/commit/bc634eaca0ae57870e92678a4aa59e64abf092ca) fix: straight-built-in-pseudo-packages: add seq
* [`1e358cae`](https://github.com/doomemacs/doomemacs/commit/1e358caea1793c51dffde5eeb8e98034ce47621b) bump: ob-clojure-literate
* [`ad1507ae`](https://github.com/doomemacs/doomemacs/commit/ad1507ae8d708f06363e74ea46a3b4a60e9cb69d) docs(org): mention Jupyter packages for Arch Linux
* [`b69e7d17`](https://github.com/doomemacs/doomemacs/commit/b69e7d1780b1c9a47a30cd36b05d4fe5c9417bef) tweak(dired): bind gl, h, l, & arrows to directory nav
* [`fbfed241`](https://github.com/doomemacs/doomemacs/commit/fbfed2416706f811d519dfdd1350efb9b4be45f9) refactor!(php): remove phpactor.el
* [`ad26fcdb`](https://github.com/doomemacs/doomemacs/commit/ad26fcdbddeb2f5c9d9090adf1745a5b1b58bd68) perf(emacs-lisp): elisp-demos: inhibit local-vars hooks
* [`ba014186`](https://github.com/doomemacs/doomemacs/commit/ba01418652ac434345f4075c6daa15412e1edfed) revert: fix: straight-built-in-pseudo-packages: add seq
* [`c901f580`](https://github.com/doomemacs/doomemacs/commit/c901f5806e4b5d28ca7f93a5dfd4daffa6771593) fix(cli): straight ignoring native-comp-jit-compilation-deny-list
* [`e21e01d4`](https://github.com/doomemacs/doomemacs/commit/e21e01d4c27e357ce3588d46c5bb681277b320c1) fix(cli): doom env: blacklist $WAYLAND_DISPLAY
* [`7eb61896`](https://github.com/doomemacs/doomemacs/commit/7eb61896f455e17daf84948ad722a94cb4197afb) fix(org): jupyter-org-mime-types: restore :text/html
* [`e750d84a`](https://github.com/doomemacs/doomemacs/commit/e750d84a476721e42312297b4925dbd16d8fd8ad) bump: code-review
* [`9df815a4`](https://github.com/doomemacs/doomemacs/commit/9df815a450d7026b2f6d503edeead846d0f67f68) fix(plantuml): ref to incorrect jar path variable
* [`8e76097d`](https://github.com/doomemacs/doomemacs/commit/8e76097d49549f845736e234d10b8bcd85be6fc7) fix(org): respect evil-disable-insert-state-bindings
* [`07dff991`](https://github.com/doomemacs/doomemacs/commit/07dff9918464578be3136a786969d274a0c44d40) feat(tty): add kitty keyboard protocol support
* [`f90f1c21`](https://github.com/doomemacs/doomemacs/commit/f90f1c212eeb9effdf5908fc2a0360980382588f) refactor(tty): noop evil-terminal-cursor-changer if disabled
* [`a2814629`](https://github.com/doomemacs/doomemacs/commit/a2814629a0f0a21214c532698dbd2e774012c0b4) feat(bidi): add +bidi-*-font-scale vars
* [`db48f767`](https://github.com/doomemacs/doomemacs/commit/db48f767b0c87fa75981f3aac29e2d1cab5a5104) fix(bidi): fail gracefully if font is missing
* [`3ad8ecc0`](https://github.com/doomemacs/doomemacs/commit/3ad8ecc063679b01032516a7315a32ca8f91fa41) fix(vertico): orderless filtering
* [`0c1c37ad`](https://github.com/doomemacs/doomemacs/commit/0c1c37ad875a15ce8dae628856770af15701a0cf) bump: evil-textobj-tree-sitter
* [`9dfd7ebc`](https://github.com/doomemacs/doomemacs/commit/9dfd7ebc7833242824326e18f05fcabc8014196a) feat(ocaml): set formatter for dune-mode
* [`62f9b2ec`](https://github.com/doomemacs/doomemacs/commit/62f9b2ec9467408f131996537d4d21c43e535f72) feat(parinfer): enable for dune-mode
* [`4bc4b54e`](https://github.com/doomemacs/doomemacs/commit/4bc4b54eb9971ff0abf5884bc0e5360c3d0f70a3) bump: :lang php
* [`a8ba8fee`](https://github.com/doomemacs/doomemacs/commit/a8ba8feecb1e2166ccd08edef4d655463ef591d1) refactor(lib): doom/{reload,upgrade}: customizable commands
* [`9c6a5e93`](https://github.com/doomemacs/doomemacs/commit/9c6a5e93234103311ea69f70ac491ab711eb257d) fix(lib): doom/{reload,upgrade}: ensure env matches session
* [`1fad466c`](https://github.com/doomemacs/doomemacs/commit/1fad466c12f92864c141325eeed29e111f1ceaf0) fix(dired): "Attempt to delete minibuffer or sole ordinary window"
* [`ebf91a13`](https://github.com/doomemacs/doomemacs/commit/ebf91a136343031a0e5220615621431bfe3b953c) refactor: use true eos regex in auto-mode-alist entries
* [`b9e460bc`](https://github.com/doomemacs/doomemacs/commit/b9e460bc6451ef333b4ffb76c6f4a604d0142b63) refactor(vertico): remove redundant quoting
* [`fac979c6`](https://github.com/doomemacs/doomemacs/commit/fac979c6d876f4956ee2f32e8217d32eee63f5c5) fix: package!: unpinning with `:pin nil`
* [`ea97adf9`](https://github.com/doomemacs/doomemacs/commit/ea97adf9c7272cd5b6dc783d07d020c38d13da0a) fix: set jump points on more kill-buffer functions
* [`02ab7f3a`](https://github.com/doomemacs/doomemacs/commit/02ab7f3a79a13c5a2ced16b6e929b0d528b2b16e) feat(rss): add elfeed-tube behind +youtube
* [`9fe9f893`](https://github.com/doomemacs/doomemacs/commit/9fe9f89333de6922ba393b97b95f4283aafde14d) tweak(vterm): vterm-send-next-key mapped to C-q
* [`c862968f`](https://github.com/doomemacs/doomemacs/commit/c862968f4843fa7c30b9dbca688d8e400729196b) fix(clojure): leverage evil-collection-cider
* [`80e9263b`](https://github.com/doomemacs/doomemacs/commit/80e9263b85c204f63518496ec6cabe09741daccd) fix(cli): doom sync: heuristic for total rebuilds
* [`d6f5fed4`](https://github.com/doomemacs/doomemacs/commit/d6f5fed4a4a0fb7a73fa4e6345e66f42df0aa791) refactor(vertico): dabbrev-ignored-buffer-regexps: simplify
* [`67a516cf`](https://github.com/doomemacs/doomemacs/commit/67a516cf0dbc15bff66359031a724f1d60e5f0c6) perf(org): call yas-reload-all on TAB only once
* [`4f5f9d60`](https://github.com/doomemacs/doomemacs/commit/4f5f9d606555de2f645cb9c6e8367d359ff6bfa9) refactor(evil): remove unused +evil-repeat-keys variable
* [`6077b6f0`](https://github.com/doomemacs/doomemacs/commit/6077b6f0d8a679ab94baf75a3978c916d68ed978) fix: correct version string in obsoletion calls
* [`9a6bcc31`](https://github.com/doomemacs/doomemacs/commit/9a6bcc31f96308bc1659d90e6b7f4fcf7b1e3138) feat(fold): add +fold-ellipsis var
* [`89f5af81`](https://github.com/doomemacs/doomemacs/commit/89f5af81041138e208d0257b4750bfae67dc2920) refactor(fold): move +fold-hideshow-folded-face & unstyle +ts-fold-replacement-face
* [`1430e9c7`](https://github.com/doomemacs/doomemacs/commit/1430e9c70053e604cf05e73b8eb2822d0ab14b20) fix(rust): ensure order of modes in auto-mode-alist
* [`a5039c43`](https://github.com/doomemacs/doomemacs/commit/a5039c4333aac4d90ae0b4d17f3ff504e26ba4a1) fix(lib): doom/{reload,upgrade}: expand path to bin/doom
* [`c99e9b86`](https://github.com/doomemacs/doomemacs/commit/c99e9b8654e1ec2ddaae405c6e58654dfb41ffe9) fix(dired): initial pop-in for vc-state
* [`c352bd0d`](https://github.com/doomemacs/doomemacs/commit/c352bd0dcdd628b266a90a59beb1b669f3ec5c72) refactor: remove redundant doom-bin{,-dir} decls
* [`5e3c794d`](https://github.com/doomemacs/doomemacs/commit/5e3c794d313a5821aaae913e1942697cd7cddf1d) tweak(org): remap imenu to consult-imenu
* [`35dd2bb3`](https://github.com/doomemacs/doomemacs/commit/35dd2bb33ced07983e30c03cc7f4b3061089a563) bump: :lang rust
* [`c53f63b9`](https://github.com/doomemacs/doomemacs/commit/c53f63b96edfae1b064c44c225b12872891a62e1) fix: trigger doom-first-{file,buffer}-hook at startup
* [`14478064`](https://github.com/doomemacs/doomemacs/commit/14478064af0fc36603ce16fa7dd6c93044816ef9) refactor(dired,vc-gutter): setup for tty frames
* [`cea17bbe`](https://github.com/doomemacs/doomemacs/commit/cea17bbea336f4e48eeb9b6f554cd1810ed75b2b) refactor(org): remove redundant key remapping
* [`4a4a9a1a`](https://github.com/doomemacs/doomemacs/commit/4a4a9a1ada52c3f79c9fb1b79f5e74204821afd5) feat(corfu): add +corfu/toggle-auto-complete command
* [`08f8f57e`](https://github.com/doomemacs/doomemacs/commit/08f8f57e2f78bd832ad8ee961174cd15c38085cc) feat(corfu): vim-like C-n/C-p keybinds
* [`3c4921cc`](https://github.com/doomemacs/doomemacs/commit/3c4921cc57cdf25c8de6a556a0df6f9bc170859b) fix(popup): only remap quit-window in popup buffers
* [`786dae5a`](https://github.com/doomemacs/doomemacs/commit/786dae5a5d95d7d9f137bd2f86eb71c856b7a5ba) fix(lsp): don't warn about npm without +eglot
* [`d6a2e24a`](https://github.com/doomemacs/doomemacs/commit/d6a2e24a3ec37bf9819460b3d9c3d21b85c63b84) fix(dired,vc-gutter): don't inhibit diff-hl-dired-mode
* [`5311214f`](https://github.com/doomemacs/doomemacs/commit/5311214f9097e1a8336e5b2a22d8a778cfa23053) tweak(corfu): don't invert evil-complete-all-buffers
* [`1c16b846`](https://github.com/doomemacs/doomemacs/commit/1c16b84691adc9d8bff31a25eb28ae070f5913ce) refactor: remove unneeded/magic in add-hook! calls
* [`d1c2c8c3`](https://github.com/doomemacs/doomemacs/commit/d1c2c8c35bc9143d3ffd073a3acde1b0e95300f3) fix(popup): don't disable hide-mode-line if enabled globally
* [`c1b5f48f`](https://github.com/doomemacs/doomemacs/commit/c1b5f48f07e41604024bdcbe030ed0fc9abedcb7) bump: :core
* [`83fedf1f`](https://github.com/doomemacs/doomemacs/commit/83fedf1fffcf8d1cceec59029f6531a57248c47d) fix: recursive load errors on lib/projects.el
* [`7f175ab6`](https://github.com/doomemacs/doomemacs/commit/7f175ab6d9a0648eac5c8b404f3005eeda829a4d) fix(cli): inconsistent system hash between sessions
* [`bf9e6195`](https://github.com/doomemacs/doomemacs/commit/bf9e619533eff0cfd44a3d23c0a2e25ea9bee23d) refactor: remove redundant projectile-track-known-projects hook
* [`6671adc6`](https://github.com/doomemacs/doomemacs/commit/6671adc6879d3a2b77d49b288d8272963f9b1095) refactor!: move helpful from :core to :lang emacs-lisp
* [`7197ee65`](https://github.com/doomemacs/doomemacs/commit/7197ee65c7cd1a8291266a3514583406e1ab1f18) fix: help(ful) reporting symbol's source as init.*.el
* [`8c4d871f`](https://github.com/doomemacs/doomemacs/commit/8c4d871f7c14d62042f2ea0954cda2bb39846763) fix(evil): respect evil-disable-insert-state-bindings
* [`79910fba`](https://github.com/doomemacs/doomemacs/commit/79910fba42d8ec45c2960d855377af0f7a8d09d9) fix(cli): wrong-number-of-args error from mapconcat
* [`78f80266`](https://github.com/doomemacs/doomemacs/commit/78f8026620a7045014f6d42e5851b8370b6d92b2) fix(latex): auto-reveal folded regions at point
* [`34cc0c9d`](https://github.com/doomemacs/doomemacs/commit/34cc0c9d8658ba0906f77bb1b87bce13ed6f9bf4) tweak(dired): ESC to exit wdired-mode
* [`0a38eeef`](https://github.com/doomemacs/doomemacs/commit/0a38eeef4cbf27bf3f98a39f48f752e0dd3a1a72) fix(tty): meta keybinds in KKP supported terminals
* [`538ddf5e`](https://github.com/doomemacs/doomemacs/commit/538ddf5e66afb20f2dba6e4e06b134572c020c7d) fix: C-i in KKP supported terminals
* [`22fc36db`](https://github.com/doomemacs/doomemacs/commit/22fc36dba7078f1b6938b2c06abc82e073ff3688) fix(lib): doom/add-directory-as-project
* [`be8a1244`](https://github.com/doomemacs/doomemacs/commit/be8a1244f21ec22efaeab8bb7ff3fef5e4f3e880) bump: flymake-popon
* [`8c6ee0ed`](https://github.com/doomemacs/doomemacs/commit/8c6ee0ed4bc76e46f04043217e3629f41a44e583) fix: associate .doom(project|module|profile) w/ lisp-data-mode
* [`ed02241c`](https://github.com/doomemacs/doomemacs/commit/ed02241cb88bd2069641b4c08557648d0cbb479e) fix(default): respect evil-disable-insert-state-bindings
* [`c9acdb72`](https://github.com/doomemacs/doomemacs/commit/c9acdb72a4bd95d7ac38d62e92aa79f395c1dccd) refactor(cli): remove bin/doom.cmd
