### PR TITLE
niv nixpkgs: update 7495def0 -> d1618650

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "7495def0bb63385f6dddd5e2ea9dfe764de14ee9",
-        "sha256": "0zdx2q5f3dmvi9hv9981gf6k8wzydkf5cfk25n0dqp4xm1ai8bxp",
+        "rev": "d161865045aa63ba6b02f549892a9d5f55a07d5d",
+        "sha256": "0r15d0yf9z08zy72k5k7ccvwpdwwk1sb9mpfvs1vl0sr66gqd5ih",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/7495def0bb63385f6dddd5e2ea9dfe764de14ee9.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/d161865045aa63ba6b02f549892a9d5f55a07d5d.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@7495def0...d1618650](https://github.com/nixos/nixpkgs/compare/7495def0bb63385f6dddd5e2ea9dfe764de14ee9...d161865045aa63ba6b02f549892a9d5f55a07d5d)

* [`98cb07dc`](https://github.com/NixOS/nixpkgs/commit/98cb07dc5e6ddc8ff1897593495c1a0d875aa7e5) openfst: 1.8.2 -> 1.8.3
* [`22993741`](https://github.com/NixOS/nixpkgs/commit/2299374130709a0ff627c95652a03412330583c8) libshout: add ssl/tls support
* [`54119287`](https://github.com/NixOS/nixpkgs/commit/54119287379b17ad7d77cd322890635e13996fa7) ruby: make 3.3 the default
* [`3b7de9db`](https://github.com/NixOS/nixpkgs/commit/3b7de9db844fb8f31fdd288c9a9d9b2c880439ae) maintainers: add tri-ler
* [`6b44d5c5`](https://github.com/NixOS/nixpkgs/commit/6b44d5c58a7ab2c93c6dc05db45be5885cb6db4a) octoprint.plugins.printtimegenius: 2.3.1 -> 2.3.3
* [`a422af9f`](https://github.com/NixOS/nixpkgs/commit/a422af9fc314330b13555f584e66151f9feba96e) octoprint.python.pkgs.firmwareupdater: init at 1.14.0
* [`d4f7f2ec`](https://github.com/NixOS/nixpkgs/commit/d4f7f2ec8af42361cbbe10d3154c2c5ce21bec12) octoprint.python.pkgs.fullscreen: init at 0.0.6
* [`8cdb09fe`](https://github.com/NixOS/nixpkgs/commit/8cdb09fe99e013f5f96f59368809d876a5087ac9) seventeenlands: init at 0.1.42
* [`3306e56e`](https://github.com/NixOS/nixpkgs/commit/3306e56e00fe35c8725dd520b2c3fb7a00ad50ce) fmtoy: 0-unstable-2024-06-07 -> 0-unstable-2024-06-11
* [`8a83a53b`](https://github.com/NixOS/nixpkgs/commit/8a83a53b81fffb3a25dd37e07d20a3f656dea042) fmtoy: Reformat, drop meta-wide with lib
* [`f90cdb6f`](https://github.com/NixOS/nixpkgs/commit/f90cdb6f372fe7b4c4957d2c00d5ec5925e5d67d) vgm2x: 0.0.0-unstable-2023-08-27 -> 0-unstable-2024-06-18
* [`6b1baf6a`](https://github.com/NixOS/nixpkgs/commit/6b1baf6a6c914c95ca04caf32d0ff4aa0e1d3f73) vgm2x: Reformat, drop meta-wide with lib
* [`b9906ed5`](https://github.com/NixOS/nixpkgs/commit/b9906ed5c6ec88323f40505d9484c968a3470d17) box64: 0.2.8 -> 0.3.0
* [`9466b5ff`](https://github.com/NixOS/nixpkgs/commit/9466b5ff59f3f08eb8858d74e060cae0f6a34779) xterm: 392 -> 393
* [`8306b7b7`](https://github.com/NixOS/nixpkgs/commit/8306b7b7d53c2e6611f413555323ef5e9e6fa88a) imlib2: 1.12.2 -> 1.12.3
* [`9e1bb632`](https://github.com/NixOS/nixpkgs/commit/9e1bb6323faf82f482ee8bc39609ff6de10af6d2) tuptime: 5.2.3 -> 5.2.4
* [`7e390c81`](https://github.com/NixOS/nixpkgs/commit/7e390c813e4a4937f53ecbfdbaf7ddd58cd2efe2) ethabi: remove
* [`cae9a627`](https://github.com/NixOS/nixpkgs/commit/cae9a627ca2b18ea8b59af0c64c2a1f498defe22) rkboot: switch to qemu-x86_64
* [`5b68c653`](https://github.com/NixOS/nixpkgs/commit/5b68c6533d18205bd9fc8774f58e92d47563a61a) prox: 0.5.2 -> 1.1.0
* [`41b3cc4a`](https://github.com/NixOS/nixpkgs/commit/41b3cc4addc489a5633cc99c042ea4749057d8b4) onlyoffice-documentserver: 7.5.1 -> 8.1.1
* [`69ba3f70`](https://github.com/NixOS/nixpkgs/commit/69ba3f70eb4ed48e21fa5ef0ea90133e7b7c0d0f) lua5_4: 5.4.6 -> 5.4.7
* [`4a1a64b2`](https://github.com/NixOS/nixpkgs/commit/4a1a64b2d43a96c4ffdc0d7fe5f0c476bddb8614) gbenchmark: 1.8.4 -> 1.8.5
* [`253cee14`](https://github.com/NixOS/nixpkgs/commit/253cee1452e651773b5fa9b05cbc09f3db481fc9) automake117x: init 1.17
* [`f2932726`](https://github.com/NixOS/nixpkgs/commit/f293272682bbfef8d5ef6e6a1544845eae907970) perl: add cc in addition to makeBinaryWrapper. see NixOS[nixos/nixpkgs⁠#311794](https://togithub.com/nixos/nixpkgs/issues/311794)
* [`34b3dd9c`](https://github.com/NixOS/nixpkgs/commit/34b3dd9cb7ede6b2db747d0049a54aea19b33d71) libtirpc: 1.3.4 -> 1.3.5
* [`f47e3afc`](https://github.com/NixOS/nixpkgs/commit/f47e3afc1e73dfa589bd2bc9c085b377fd304b40) boost-build: fix overriding target when llvm
* [`3e6180e9`](https://github.com/NixOS/nixpkgs/commit/3e6180e98430359ded36ebc4a0341e1bd6608ef8) boost: fix building with llvm
* [`e5906ddf`](https://github.com/NixOS/nixpkgs/commit/e5906ddfd42a74354981e535fb9e4dfc1e05905b) nodejs: fix cross compilation for armv7l
* [`d162d8e5`](https://github.com/NixOS/nixpkgs/commit/d162d8e50de274431d97bcf28c70751481e2ca82) nodejs: use ninja for build
* [`3cf3f6ae`](https://github.com/NixOS/nixpkgs/commit/3cf3f6ae23b0173acaa37bc3ba23031f9a60c0c6) nodejs: allow building for vfpv2
* [`63930d48`](https://github.com/NixOS/nixpkgs/commit/63930d484ca2c1f351704cbf2e780d1c8ad00417) libcamera: 0.3.0 -> 0.3.1
* [`09fefcd7`](https://github.com/NixOS/nixpkgs/commit/09fefcd76b2c8ad614f2be71ff60d18690e10a87) nftables: 1.0.9 -> 1.1.0
* [`3bc32efb`](https://github.com/NixOS/nixpkgs/commit/3bc32efbc8f9f90d65629da38cef406c06de4be1) buildFHSEnv: use relative symlinks
* [`d7f46fbb`](https://github.com/NixOS/nixpkgs/commit/d7f46fbb5c40e7e9a165adf4f82669ae35c5b055) nodejs: fix tests and disable parallel checking
* [`010277de`](https://github.com/NixOS/nixpkgs/commit/010277de84ba988922adf23e8cb1ad3890c5ff62) buildGoModule: respect user-specified passthru
* [`a6e1fc62`](https://github.com/NixOS/nixpkgs/commit/a6e1fc62617390cd784a65dcf044382988fb0494) maintainers: add progrm_jarvis
* [`b07c4419`](https://github.com/NixOS/nixpkgs/commit/b07c44198798fdd9f51c9ba34dc4811b857e56d4) shell.nix: Enable e.g. --arg nixpkgs ./.
* [`83851c6b`](https://github.com/NixOS/nixpkgs/commit/83851c6b244444d7ce4fc855ccbe5d2300095ba1) cataclysm-dda-git: remove incompatible patches, bump git.
* [`7b6fa3f3`](https://github.com/NixOS/nixpkgs/commit/7b6fa3f33e15a9951293d8379b93c44032099f34) maintainers: add laalsaas to FC team
* [`cf642a11`](https://github.com/NixOS/nixpkgs/commit/cf642a11d355754053ecd990cfd6c72f8d6e60e2) matomo_5: 5.0.2 -> 5.1.0
* [`eec69b59`](https://github.com/NixOS/nixpkgs/commit/eec69b590bab22bf0bcb0944627600916f1954a8) wp-cli: fix wrapper environment
* [`9bea4168`](https://github.com/NixOS/nixpkgs/commit/9bea4168bc46e1ebff1fdb7959f74b1f0f2453cb) libspatialindex: 1.9.3 -> 2.0.0
* [`dd0e6df0`](https://github.com/NixOS/nixpkgs/commit/dd0e6df0ff5446523b5a6473077550b978d32662) git: 2.45.2 -> 2.46.0
* [`cdb2f297`](https://github.com/NixOS/nixpkgs/commit/cdb2f2971c9a94a4fc15cf505015053ddff0ba1a) stdenv: refactor appendToVar and prependToVar
* [`ebbc481f`](https://github.com/NixOS/nixpkgs/commit/ebbc481ff5664533e7f0a6e9ef58851a1d2a4891) emacsPackages.lspce: 1.1.0-unstable-2024-07-14 -> 1.1.0-unstable-2024-07-29
* [`fd56a80f`](https://github.com/NixOS/nixpkgs/commit/fd56a80fbeef53f3465dbdb7189ecba07c3a9905) showtime: init at 46.3
* [`1094ca55`](https://github.com/NixOS/nixpkgs/commit/1094ca551be1d7d3ab91b666b2944cccddd6875a) python3Packages.djangorestframework: disable pytz when django >= 5
* [`d07eb6be`](https://github.com/NixOS/nixpkgs/commit/d07eb6be1d0ef8515ddbf8d5f9c6fb6f62e605a6) djangorestframework: 3.15.1 -> 3.15.2
* [`aedaa16a`](https://github.com/NixOS/nixpkgs/commit/aedaa16a243234dba42b51bdcb741ddf79e8d8f1) curl: fix rustls ca-certificates detection
* [`79581b82`](https://github.com/NixOS/nixpkgs/commit/79581b82793b3e1baf5aaa78de34fc09f9164a98) tpm2-tss: remove shadow dependency
* [`929db7bc`](https://github.com/NixOS/nixpkgs/commit/929db7bc228eac527c80658905e4afaf19765c3e) tests.stdenv: fix spelling
* [`bfd97a69`](https://github.com/NixOS/nixpkgs/commit/bfd97a691f165c2a160d5c86a7dbfd89fcbdb33c) stdenv: make _accumFlagsArray independent of structuredAttrs
* [`6bdfef9d`](https://github.com/NixOS/nixpkgs/commit/6bdfef9d2de252bec22a5c4b5859ad578b60b004) stdenv: generalize _accumFlagsArray to concatTo
* [`8cb51ec3`](https://github.com/NixOS/nixpkgs/commit/8cb51ec38e4579b62ee26d31bcdcdbc61f37f42d) stdenv: refactor default flags without __structuredAttrs use
* [`471cbdd0`](https://github.com/NixOS/nixpkgs/commit/471cbdd062bceda5a9761f65f0dddffbd72683db) stdenv: add concatStringsSep helper
* [`afc35531`](https://github.com/NixOS/nixpkgs/commit/afc35531ae9f2f5bbf9ea4064999f99021360b8b) bonnmotion: remove hardcoded /build
* [`a4eeebb0`](https://github.com/NixOS/nixpkgs/commit/a4eeebb0f6d762396a7a8352532a90512e2a6fa1) dictu: remove hardcoded /build
* [`eca98a63`](https://github.com/NixOS/nixpkgs/commit/eca98a63015f9d7c217cc38e4ab59c9121ec36a0) home-assistant-component-tests.abode: remove hardcoded /build
* [`692e4c92`](https://github.com/NixOS/nixpkgs/commit/692e4c9207c60e326722016857ed85eccf9a602e) hydrapaper: remove hardcoded /build
* [`211b0f55`](https://github.com/NixOS/nixpkgs/commit/211b0f55b63ed4bf6fea89f4b4a6fff043b0cc4c) kodiPackages.jellycon: remove hardcoded /build
* [`61242375`](https://github.com/NixOS/nixpkgs/commit/61242375c1ff6b5df5faeef26f4e625269d69481) kodiPackages.jellyfin: remove hardcoded /build
* [`8a29b0a2`](https://github.com/NixOS/nixpkgs/commit/8a29b0a2559d55fcf558ab67d1a9bac691882fdc) lc0: remove hardcoded /build
* [`2bec472b`](https://github.com/NixOS/nixpkgs/commit/2bec472be92021842423c3e55118d6b13b9f411b) python311Packages.naked: remove hardcoded /build
* [`51a8c236`](https://github.com/NixOS/nixpkgs/commit/51a8c236fee9caac68eb80b4f0d8f244696658bf) python311Packages.openai-triton-cuda: remove hardcoded /build
* [`58df299b`](https://github.com/NixOS/nixpkgs/commit/58df299b0de456c0019c3fd465eca1556f2045fe) swaysettings: remove hardcoded /build
* [`5a1fe0ad`](https://github.com/NixOS/nixpkgs/commit/5a1fe0ad139595687d2c1b869e0f2a87cf05425f) nest-mpi: 3.7 -> 3.8
* [`9dddba49`](https://github.com/NixOS/nixpkgs/commit/9dddba492ed60eeaa3c7dbde8f06e361fbfa2989) chromaprint: add patch for FFmpeg 7
* [`55933d9b`](https://github.com/NixOS/nixpkgs/commit/55933d9bf6e62232eb48cbf08620f22cb7658b61) meson: support structuredAttrs in setup hook
* [`7c732de6`](https://github.com/NixOS/nixpkgs/commit/7c732de6e3b35497f14a70888fe48b492f0f3cac) meson: remove unused crossMesonFlags from setup hook
* [`7752cea6`](https://github.com/NixOS/nixpkgs/commit/7752cea66c18f1651a14b4a64074188b142d3a6c) ninja: support structuredAttrs in setup hook
* [`4b45acf5`](https://github.com/NixOS/nixpkgs/commit/4b45acf52990ba892151928070d385657ebd51b9) ninja: shellcheck setup hook
* [`34a2b7ae`](https://github.com/NixOS/nixpkgs/commit/34a2b7ae9f77ca1c39b871b1165c0aec44928227) cmake: support structuredAttrs in setup hook
* [`d7c25703`](https://github.com/NixOS/nixpkgs/commit/d7c257035d5ffc0bf5d70fa85796aa238e4f4a73) setup-hooks/autoreconf: support structuredAttrs
* [`10c5c6b5`](https://github.com/NixOS/nixpkgs/commit/10c5c6b506321e1bb8931245fd6254255762a9b1) SDL2: 2.30.5 -> 2.30.6
* [`f1eb2f78`](https://github.com/NixOS/nixpkgs/commit/f1eb2f7892ff2d4254560563e1428562ce30b39a) tproxy: init at 0.8.1
* [`1bca03df`](https://github.com/NixOS/nixpkgs/commit/1bca03dfe35b3a9a2b9442ba7c04d521abc9d055) python312Packages.mdformat-gfm-alerts: init at 1.0.1
* [`4ae7723c`](https://github.com/NixOS/nixpkgs/commit/4ae7723c9bb74ba98f890ed6504ac989c8142aab) nixos/mediawiki: add resetUserEmail script
* [`6e774779`](https://github.com/NixOS/nixpkgs/commit/6e7747792622ca7fcbcb16d262aa91d17542b3bd) chiaki4deck: rename to chiaki-ng
* [`3b82c96f`](https://github.com/NixOS/nixpkgs/commit/3b82c96f7e3a872714ef0702cd186f65c28a7a6c) emacs: fix name when pname is overridden
* [`675dcef3`](https://github.com/NixOS/nixpkgs/commit/675dcef30ad23f3b17066c7b11722f581b90798c) emacs: remove redundant doCheck from genericBuild
* [`cdf4aef5`](https://github.com/NixOS/nixpkgs/commit/cdf4aef5e2ad2c50872f8948656f21df9e8325f4) emacs: handle propagatedBuildInputs correctly for genericBuild
* [`84c2e009`](https://github.com/NixOS/nixpkgs/commit/84c2e0096d0c365e3f2a81ad8533c5b8910e7a73) emacs: stop generating autoload file for trivialBuild
* [`37df73d3`](https://github.com/NixOS/nixpkgs/commit/37df73d3d8314e6b96cb1ccb7cd91ed796bdfa3a) emacs: teach elisp builders the finalAttrs pattern
* [`5248f6f8`](https://github.com/NixOS/nixpkgs/commit/5248f6f8ef5bae4f848adf9865ee1cd792707f0e) emacs: stop vendoring PR [nixos/nixpkgs⁠#234651](https://togithub.com/nixos/nixpkgs/issues/234651)
* [`5805cf21`](https://github.com/NixOS/nixpkgs/commit/5805cf21a8b24491b5d50bb4afb6740bbfe129a8) emacs: remove unused parameters to make nixf-tidy-review bot happy
* [`e64ccec7`](https://github.com/NixOS/nixpkgs/commit/e64ccec7e762e326a0b8f042762abb5a3b7d53df) emacs: make elpa2nix of elpaBuild consistent with melpaBuild
* [`bdd77341`](https://github.com/NixOS/nixpkgs/commit/bdd77341419276125dbae522fa4a8a16cc895ecf) emacs: inherit files in melpaBuild to make nixf-tidy CI happy
* [`3f7abb4e`](https://github.com/NixOS/nixpkgs/commit/3f7abb4eaf794d913faec6c92939e677a0ac2dd3) mupdf: 1.23.6 -> 1.24.8
* [`565ef086`](https://github.com/NixOS/nixpkgs/commit/565ef086232bcabf4542c01b0bc7324653b7da65) python312Packages.pymupdf: 1.23.6 -> 1.24.8
* [`5eb83260`](https://github.com/NixOS/nixpkgs/commit/5eb832604afb1ae550ac927133be65b7c2f06eb0) python312Packages.textual-universal-directorytree: 1.1.0 -> 1.5.0
* [`fe95d699`](https://github.com/NixOS/nixpkgs/commit/fe95d699290779aa33c34cae8f8abb8e530af87d) browsr: 1.19.0 -> 1.21.0
* [`6c159d50`](https://github.com/NixOS/nixpkgs/commit/6c159d50340a3fa28cb28dacdce2b225ddba40e6) mesa: fix building with llvm
* [`513074bb`](https://github.com/NixOS/nixpkgs/commit/513074bb9b4d8f5c1f025300a9cbfaeba79efa92) python312Packages.matplotlib: 3.9.0 -> 3.9.1
* [`19eba8fe`](https://github.com/NixOS/nixpkgs/commit/19eba8feb8f31af052f847fcec52069dba89be8f) ffmpeg_6: 6.1.1 -> 6.1.2
* [`7f972523`](https://github.com/NixOS/nixpkgs/commit/7f972523f363485afc6154f7ec195bc532316ce7) steam: fix 32bit driver check
* [`52cf1248`](https://github.com/NixOS/nixpkgs/commit/52cf1248c12866f2f58c03c7aedb3b4c0b1dec8d) git-blame-ignore-revs: add steam formatting commit
* [`ca0c4a60`](https://github.com/NixOS/nixpkgs/commit/ca0c4a606025fb749a4d5e0c5e5d4df2db6503a8) steam: drop game specific libraries now duplicated with steam own
* [`dc8cfc56`](https://github.com/NixOS/nixpkgs/commit/dc8cfc565e66c9d95293836fade61dbc6f97497e) steam: use 32bit compatible ldd
* [`58997957`](https://github.com/NixOS/nixpkgs/commit/589979573f16c25da1f7fc3ade63395beb36cae1) chatzone-desktop: init at 5.2.1
* [`fd7b1400`](https://github.com/NixOS/nixpkgs/commit/fd7b1400a09bcf72cd1bda3d0dc308d28f32b776) dnsproxy: 0.72.1 -> 0.72.3
* [`517cc0d7`](https://github.com/NixOS/nixpkgs/commit/517cc0d7351778954829f533645688c855aebcea) dnsproxy: rfc format style
* [`60e705e3`](https://github.com/NixOS/nixpkgs/commit/60e705e365e79123f9738d4b11b7c4c8a6aed693) spasm-ng: unstable-2020-08-03 -> unstable-2022-07-03
* [`2bb8283a`](https://github.com/NixOS/nixpkgs/commit/2bb8283a53f2dc2cba86bf827f251cd1bec3f8e4) python3Packages.gradio: fix pydantic's `nativeCheckInputs`.
* [`355e6e60`](https://github.com/NixOS/nixpkgs/commit/355e6e60d0b1ac5cea6b2d5157cf22e4b31d262a) pypy27Packages.kserve.dependencies: fix the eval
* [`f143061b`](https://github.com/NixOS/nixpkgs/commit/f143061b219df61796aeb5af7169b9605ea55c7c) rospo: init at 0.12.1
* [`41c2a080`](https://github.com/NixOS/nixpkgs/commit/41c2a080d04d2af50200be3658fa65548c212889) ffmpeg_7: 7.0.1 -> 7.0.2
* [`ff0cc848`](https://github.com/NixOS/nixpkgs/commit/ff0cc8483388b88b37e65c132346049bb043b2f4) go_1_22: 1.22.5 -> 1.22.6
* [`cb22276c`](https://github.com/NixOS/nixpkgs/commit/cb22276cc7e24a3801203b0bd3920b2ae6e55083) python312Packages.cffi: 1.16.0 -> 1.17.0
* [`b05d5bc8`](https://github.com/NixOS/nixpkgs/commit/b05d5bc8902801044a7d313c92486c1ddd534c35) hwdata: 0.384 -> 0.385
* [`ce5afb2b`](https://github.com/NixOS/nixpkgs/commit/ce5afb2bb616d959f121a5135cfe7b5f53414139) cp2k: 24.1 -> 24.2
* [`75d3833a`](https://github.com/NixOS/nixpkgs/commit/75d3833ab100d625e001aaf8ee976358819fa10b) dftd4: fix installation path of Fortran headers
* [`e7b76920`](https://github.com/NixOS/nixpkgs/commit/e7b76920075109ddfa6a7a4097a524be95a89f5c) cp2k: add support for dftd4 dispersion corrections
* [`c55536c5`](https://github.com/NixOS/nixpkgs/commit/c55536c53c35746e38fc9ab6040993a795cea9db) makeFontsConf: accept 'includes'
* [`a6b7762d`](https://github.com/NixOS/nixpkgs/commit/a6b7762d34248ba7e6f6c18d0371cbd7525a9e39) python312Packages.platformdirs: refactor
* [`b2c2b557`](https://github.com/NixOS/nixpkgs/commit/b2c2b557cd94a93d3baa7aa5021a454cdcb2db91) SDL2: switch `maintainers` from `cpages` to `teams.sdl.members`
* [`1a03e743`](https://github.com/NixOS/nixpkgs/commit/1a03e743f4bcb9f7f9d84f2ba1b2e8b894b7082d) python312Packages.cython: 3.0.10 -> 3.0.11
* [`06666ea6`](https://github.com/NixOS/nixpkgs/commit/06666ea69042efeb33c579c23adbf9362ab6c26f) python3Packages.fonttools: 4.53.0 -> 4.53.1
* [`655ba11c`](https://github.com/NixOS/nixpkgs/commit/655ba11ce8588f7cb4ea3478ebd54e10f53433ef) python3Packages.fonttools: don't use pname in fetcher
* [`0e8454e9`](https://github.com/NixOS/nixpkgs/commit/0e8454e9926249156e739e69a8bc21e3880ce1c7) openimageio: 2.5.5.0 -> 2.5.14.0
* [`8878d8af`](https://github.com/NixOS/nixpkgs/commit/8878d8afcd31cfdcd363d323cf3dabaed6929845) python312: 3.12.4 -> 3.12.5
* [`176cbe2d`](https://github.com/NixOS/nixpkgs/commit/176cbe2ddaf9643d8ae28a56ae8ce9f84ec720e7) python311Packages.debugpy: 1.8.2 -> 1.8.5
* [`0799550a`](https://github.com/NixOS/nixpkgs/commit/0799550a95c11510ef864ea40f68916db9f3d49d) azure-agent: remove x86 assertion
* [`f6fe3b3b`](https://github.com/NixOS/nixpkgs/commit/f6fe3b3bffa2c012b014e608953ea15076b72b21) azure-common: add accelerated networking configs
* [`63827efb`](https://github.com/NixOS/nixpkgs/commit/63827efb6c924cb184b0db7b92e42f3d24b22429) amdenc: init at 1.0-1787253
* [`999df503`](https://github.com/NixOS/nixpkgs/commit/999df5035f41ae462d488a8832feb2f89ce91938) amf: init at 1.4.34-1787253
* [`0769bb8a`](https://github.com/NixOS/nixpkgs/commit/0769bb8aac006c6cdc9a3e21ec3fcb292395068d) azure-image: support creating v2 image
* [`85fcdad6`](https://github.com/NixOS/nixpkgs/commit/85fcdad66cf53a416426660ed47ab2979c85828c) azure-common: fix unsupported attribute
* [`5b4f446d`](https://github.com/NixOS/nixpkgs/commit/5b4f446d6a1ab09b2295212e5d31f3cdea104369) azure-common: improve code style
* [`b5fe6cc7`](https://github.com/NixOS/nixpkgs/commit/b5fe6cc72ffd64859806f93c996ab69ac49b285a) crispy-doom: 6.0 -> 7.0
* [`01542212`](https://github.com/NixOS/nixpkgs/commit/01542212601a14e00e322bab19552db8cdd60ad2) freerdp: 3.6.3 -> 3.7.0
* [`a6d6b96a`](https://github.com/NixOS/nixpkgs/commit/a6d6b96a0839de8f144a33104395d5bf06dc2b96) freerdp: remove useless parenthesis
* [`9b83914b`](https://github.com/NixOS/nixpkgs/commit/9b83914b1a6ecf8a2612f88b21d8f5cd7f191198) freerdp: add some key programs to passthru.tests
* [`a68c330c`](https://github.com/NixOS/nixpkgs/commit/a68c330cd8d29c5e07549cd6bb811866b3ba1bc5) nixos/automx2: init
* [`1f265758`](https://github.com/NixOS/nixpkgs/commit/1f26575842dd1d30bfd742910bba1713f899e705) azure-common: rm trailing whitespace
* [`03bdfbb4`](https://github.com/NixOS/nixpkgs/commit/03bdfbb4ab4909399945521bce83343410f8d054) ffmpeg: add amf support
* [`bd046906`](https://github.com/NixOS/nixpkgs/commit/bd046906766161a33c6d7fc393deab687b0fe8bc) curl: 8.9.0 -> 8.9.1
* [`20806901`](https://github.com/NixOS/nixpkgs/commit/208069013eea2c989a0b7d70701cff36443ca5e3) curl: rm unused patch file
* [`00e4f263`](https://github.com/NixOS/nixpkgs/commit/00e4f26329e8b1896af79aaa75c6e471ae9c39f3) curl: fix SIGPIPE regression in 8.9.1
* [`028138f2`](https://github.com/NixOS/nixpkgs/commit/028138f20147703bf4a466f77f0f66bb895ad7d5) azure-common: put mlx drivers into availableKernelModules
* [`31d23811`](https://github.com/NixOS/nixpkgs/commit/31d238110c720ab467cbd7adb715ebca76f9e09d) nodejs: disable failing tests on x86_64-darwin
* [`d728271f`](https://github.com/NixOS/nixpkgs/commit/d728271fcf97727163b35f645ee8739ba059dd21) ffmpeg: add snappy option
* [`911869fe`](https://github.com/NixOS/nixpkgs/commit/911869feaf621141647213c90f33ed76a3035e12) ffmpeg: add shine option
* [`7dda5634`](https://github.com/NixOS/nixpkgs/commit/7dda5634bcd0086d3d72ea24d213e47299a05f4c) maintainers: add frectonz
* [`471089ae`](https://github.com/NixOS/nixpkgs/commit/471089ae27093626bc36fe0c1ef6d7ebfcaa9147) mekuteriya: init at 0.1.5
* [`0e022141`](https://github.com/NixOS/nixpkgs/commit/0e022141f4b2ad06753148d82876ec2b11677cb1) tidal-hifi: 5.15.0 -> 5.16.0
* [`8d00b653`](https://github.com/NixOS/nixpkgs/commit/8d00b653a55a38dba05017d34f4447f8b95020d7) cagebreak: depend on wayland-scanner
* [`ec9e0c6d`](https://github.com/NixOS/nixpkgs/commit/ec9e0c6dc8debea603d612a3b76586d2a2750faf) cardboard: depend on wayland-scanner
* [`b8baf82e`](https://github.com/NixOS/nixpkgs/commit/b8baf82e243c9ac07cc6dc066a6ee63bae310823) clightd: depend on wayland-scanner
* [`4eb2f9c1`](https://github.com/NixOS/nixpkgs/commit/4eb2f9c1ce974220323e719f33f693428a0d5580) deepin.dwayland: depend on wayland-scanner
* [`279f8445`](https://github.com/NixOS/nixpkgs/commit/279f84453e1ab3bcf6429e40d32f63f423a4fd5e) ffmpeg: add rubberband option
* [`05f55a6c`](https://github.com/NixOS/nixpkgs/commit/05f55a6c133090254746463445ec95e6962ae00a) openblas: 0.3.27 -> 0.3.28
* [`64eaa631`](https://github.com/NixOS/nixpkgs/commit/64eaa6318185fe0c3e54b0e4e0f2d5b12ebe34ab) stdenv: concatStringsSep: quote ${sep}
* [`eed069a5`](https://github.com/NixOS/nixpkgs/commit/eed069a5bc40ba4d871de7700c7eb8d592e98cb6) buildGoModule: fix overrideAttrs overriding
* [`a9377954`](https://github.com/NixOS/nixpkgs/commit/a93779544568a96f6432d98ac0b2220c4d774dab) enlightenment.efl: depend on wayland-scanner
* [`5670ef01`](https://github.com/NixOS/nixpkgs/commit/5670ef01c1185bb17bf6fc08b775cb6d8d5bcca3) fcitx5: depend on wayland-scanner
* [`6e512236`](https://github.com/NixOS/nixpkgs/commit/6e512236236e8ef963661ce75d4e99d570d2affc) gamescope: depend on wayland-scanner
* [`f0779eca`](https://github.com/NixOS/nixpkgs/commit/f0779ecaf277ee9c9764b1cc3f53dfdf516fbfde) gnome3.mutter43: depend on wayland-scanner
* [`b29d12cf`](https://github.com/NixOS/nixpkgs/commit/b29d12cf4c0b2a16a337397d351810853a48024d) gnome3.mutter: depend on wayland-scanner
* [`4fb55bca`](https://github.com/NixOS/nixpkgs/commit/4fb55bca32fdca0ff086f06c10c0cf99dea58c13) gst_all_1.gst-plugins-bad: depend on wayland-scanner
* [`b97d2b7e`](https://github.com/NixOS/nixpkgs/commit/b97d2b7eb1172ec4c45494737f36726f7bb7199f) gst_all_1.gst-plugins-base: depend on wayland-scanner
* [`7850b566`](https://github.com/NixOS/nixpkgs/commit/7850b56683987e454a1c7083059bfe78a485ea71) gtk-layer-shell: depend on wayland-scanner
* [`e6fb535a`](https://github.com/NixOS/nixpkgs/commit/e6fb535aa564ca8ea8649107461c8f679155d2c5) hello-wayland: depend on wayland-scanner
* [`c2b34fed`](https://github.com/NixOS/nixpkgs/commit/c2b34fed8fecfa03824fd25dff177045d98a23b4) kitty: depend on wayland-scanner
* [`ded50228`](https://github.com/NixOS/nixpkgs/commit/ded502285367aeffca7acb9d02688280aad149ff) labwc: depend on wayland-scanner
* [`c18e0463`](https://github.com/NixOS/nixpkgs/commit/c18e0463fb591cfbd603697f172d40585511332b) latte-dock: depend on wayland-scanner
* [`8714155d`](https://github.com/NixOS/nixpkgs/commit/8714155dd0abb9555d463106f2004fff7f02f709) libwpe-fdo: depend on wayland-scanner
* [`158cce9f`](https://github.com/NixOS/nixpkgs/commit/158cce9f41d6ef5e4ea2685939f44a84bcc70039) looking-glass-client: depend on wayland-scanner
* [`2bc82869`](https://github.com/NixOS/nixpkgs/commit/2bc828695e40156109eda0ec20f8a4d163f64677) maliit-framework: depend on wayland-scanner
* [`95d91005`](https://github.com/NixOS/nixpkgs/commit/95d91005a926712f29492ebaae158802fd742e98) phoc: depend on wayland-scanner
* [`11554519`](https://github.com/NixOS/nixpkgs/commit/115545192f45ce6b1a1f6e83e3e57a2384badda5) phosh: depend on wayland-scanner
* [`9f692804`](https://github.com/NixOS/nixpkgs/commit/9f692804dbde24d21c6b397f733c1e622ac46231) phosh-mobile-settings: depend on wayland-scanner
* [`abea49c9`](https://github.com/NixOS/nixpkgs/commit/abea49c97730cac3a38e0bb23d814503a9dd1642) plasma5Packages.kguiaddons: depend on wayland-scanner
* [`3040aa61`](https://github.com/NixOS/nixpkgs/commit/3040aa615c1b8f69bf52313ccdba40712799b35a) plasma5Packages.kidletime: depend on wayland-scanner
* [`b96f111a`](https://github.com/NixOS/nixpkgs/commit/b96f111a718915eea17ad57f194bc1ff8a2cf252) plasma5Packages.krfb: depend on wayland-scanner
* [`cec8d1fd`](https://github.com/NixOS/nixpkgs/commit/cec8d1fd0e3072fd598281c3e3d9970fd168c9e6) plasma5Packages.kscreenlocker: depend on wayland-scanner
* [`5f7c8fe1`](https://github.com/NixOS/nixpkgs/commit/5f7c8fe1fddbf32343d1b1b3f8d108720092d4f4) plasma5Packages.kwayland: depend on wayland-scanner
* [`d23c5a44`](https://github.com/NixOS/nixpkgs/commit/d23c5a444e5f3727bb73e14398c0e46d4e519e01) plasma5Packages.kwin: depend on wayland-scanner
* [`505c8b2a`](https://github.com/NixOS/nixpkgs/commit/505c8b2adb53eb2d2dd32704a858c02e0d2ea86e) plasma5Packages.plasma-integration: depend on wayland-scanner
* [`8a5862be`](https://github.com/NixOS/nixpkgs/commit/8a5862be27ee81e4826b9bc97c5fe48ef6c1df5d) plasma5Packages.plasma-remotecontrollers: depend on wayland-scanner
* [`11ed329b`](https://github.com/NixOS/nixpkgs/commit/11ed329b6d7e702105e4f5a6ee59e14b957910c2) plasma5Packages.plasma-workspace: depend on wayland-scanner
* [`75ea55bd`](https://github.com/NixOS/nixpkgs/commit/75ea55bdfe5ff3c0da716df76b5b75ad04d7bd85) plasma5Packages.xdg-desktop-portal-kde: depend on wayland-scanner
* [`bc10b426`](https://github.com/NixOS/nixpkgs/commit/bc10b4260d0f4826f553b967ad87712ba6d85921) python3.pkgs.pywayland: depend on wayland-scanner
* [`e2c13522`](https://github.com/NixOS/nixpkgs/commit/e2c1352232b6c076b0008c99f5c8712ab4f529a2) river: depend on wayland-scanner
* [`4fad1505`](https://github.com/NixOS/nixpkgs/commit/4fad15058d88b9bd77159829ae6667f2f4ac1b77) river-tag-overlay: depend on wayland-scanner
* [`07faca9b`](https://github.com/NixOS/nixpkgs/commit/07faca9bcbbd86b74158073b64d512bba61bd8ff) rofi-wayland: depend on wayland-scanner
* [`c9492d8f`](https://github.com/NixOS/nixpkgs/commit/c9492d8f34f56ab7b85990d4f05fbbbcb1eab42f) squeekboard: depend on wayland-scanner
* [`b21621aa`](https://github.com/NixOS/nixpkgs/commit/b21621aab578ffc344772f25336adef8cffc4dcf) tofi: depend on wayland-scanner
* [`aaafc000`](https://github.com/NixOS/nixpkgs/commit/aaafc00079e09f47e38bc25874e9535c4233f485) vaapiIntel: depend on wayland-scanner
* [`c5287193`](https://github.com/NixOS/nixpkgs/commit/c5287193127ee57cd81a09803bdff40d08bc25b7) vlc: depend on wayland-scanner
* [`2e7aab88`](https://github.com/NixOS/nixpkgs/commit/2e7aab8885807a40479e5d392fe399c7fee9cc2d) vulkan-cts: depend on wayland-scanner
* [`05f18e12`](https://github.com/NixOS/nixpkgs/commit/05f18e12098768b1b777617304dcd433c1fb5adc) vulkan-tools: depend on wayland-scanner
* [`649aa599`](https://github.com/NixOS/nixpkgs/commit/649aa5999b819d2f1a5928f829ea7852065e4f3e) python312Packages.versioningit: migrate to pytest-cov-stub
* [`3d856e4c`](https://github.com/NixOS/nixpkgs/commit/3d856e4c3b978e7dbc0ed7c7035a4aa6df665c71) python312Packages.versioningit: 3.1.1 -> 3.1.2
* [`75004795`](https://github.com/NixOS/nixpkgs/commit/750047954598fb7f4a89c922be2d4451a64a238a) python312Packages.isal: 1.7.0 -> 1.7.0
* [`73af18ee`](https://github.com/NixOS/nixpkgs/commit/73af18ee3dfec4f4927dc8f8c33199c73b21a8b7) python312Packages.zlib-ng: 0.5.0 -> 0.5.0
* [`f61999af`](https://github.com/NixOS/nixpkgs/commit/f61999af9c8f176bbf963ebcb0d53aa55c911c96) python312Packages.aiohttp-isal: drop
* [`d474d6ef`](https://github.com/NixOS/nixpkgs/commit/d474d6efe28a0805f9b63a5deeb1f5177f13207c) waffle: depend on wayland-scanner
* [`f043fe4a`](https://github.com/NixOS/nixpkgs/commit/f043fe4abb790c9ecaed3e784304b3f8fab78b17) way-displays: depend on wayland-scanner
* [`e2292818`](https://github.com/NixOS/nixpkgs/commit/e22928181e64383ee4fa45d5436dd3998419dd60) waylock: depend on wayland-scanner
* [`b46f93f0`](https://github.com/NixOS/nixpkgs/commit/b46f93f04b8eaca6f5171bf005ce6df0e3145efa) webkitgtk: depend on wayland-scanner
* [`2aa25051`](https://github.com/NixOS/nixpkgs/commit/2aa25051f757220e2433a8a7660f219bc895f405) wio: depend on wayland-scanner
* [`9876c2fe`](https://github.com/NixOS/nixpkgs/commit/9876c2fe9e90b49f693da628e8b8b696ec5f63a4) stdenv: concatStringsSep: test sep="&"
* [`7536a7fe`](https://github.com/NixOS/nixpkgs/commit/7536a7fec9ec2809c6c1ec4b42495d8caf288f7b) python312Packages.aiohttp: 3.10.2 -> 3.10.3
* [`84e2939d`](https://github.com/NixOS/nixpkgs/commit/84e2939d825b11505f4f3cdc8722e1444004ac46) rust-cbindgen: 0.26.0 -> 0.27.0
* [`c791dc61`](https://github.com/NixOS/nixpkgs/commit/c791dc612605cfa5d2a000a77a0db6d9fe9b1c60) buildMozillaMach: prune patches
* [`ec0a59d4`](https://github.com/NixOS/nixpkgs/commit/ec0a59d44c8fc1c5bfa36c7d833f0287085b1824) buildMozillaMach: backport cbindgen 0.27.0 compat
* [`46fac414`](https://github.com/NixOS/nixpkgs/commit/46fac414355bca03e226a4c0d4717ee04a242ccd) rust-cbindgen: test firefox and mesa in passthru
* [`f5846d25`](https://github.com/NixOS/nixpkgs/commit/f5846d25a1335267bc8bad633ffcbdf2109b18dc) nodejs: skip tests failing in sandbox in all platforms
* [`35b556d3`](https://github.com/NixOS/nixpkgs/commit/35b556d314ff99940619f4f16920542fd5b8f972) nodejs_20: 20.15.1 -> 20.16.0
* [`921bd99f`](https://github.com/NixOS/nixpkgs/commit/921bd99f8de553bd45be0ed298619589f2b7fee4) wayland-scanner: split from wayland
* [`26a4a052`](https://github.com/NixOS/nixpkgs/commit/26a4a052bae1fb8eb83f5078442bb3eb963eabec) clightd: fix cross
* [`dbffd9be`](https://github.com/NixOS/nixpkgs/commit/dbffd9be779fb4257e58f837e1cd05c660b5999d) freerdp: don't set WAYLAND_SCANNER explicitly
* [`45092159`](https://github.com/NixOS/nixpkgs/commit/4509215980a0ddd025b04a5667e9b67802de1bb4) freerdp3: don't set WAYLAND_SCANNER explicitly
* [`0b16a47c`](https://github.com/NixOS/nixpkgs/commit/0b16a47cd2031b6433c6e2dc733c565049cd433a) gamescope: fix cross
* [`efaee7c9`](https://github.com/NixOS/nixpkgs/commit/efaee7c99bfef7b6d35b86a560a22685e9c47454) wayland-scanner: set mainProgram
* [`1120942b`](https://github.com/NixOS/nixpkgs/commit/1120942b912c00c3e2ba606bec5315bb29fe7371) vulkan-tools: use lib.getExe
* [`f5b3dd7a`](https://github.com/NixOS/nixpkgs/commit/f5b3dd7ab2d2850da6e95ec4a0b9c7d14a30380b) libheif: 1.18.0 -> 1.18.2
* [`f2811442`](https://github.com/NixOS/nixpkgs/commit/f28114421f4d0e6fd3a1b7ea5417b3f92877a07f) libwacom: nixfmt
* [`1bab8637`](https://github.com/NixOS/nixpkgs/commit/1bab863789dafb7bc5fb149d1f4fbb70319f3ddb) libwacom-surface: nixfmt
* [`20b9ff56`](https://github.com/NixOS/nixpkgs/commit/20b9ff566a8839f0968324e062e1149bc7213e61) libwacom: move to by-name
* [`f5402ed7`](https://github.com/NixOS/nixpkgs/commit/f5402ed76a8ffb27cf426f36a717d01569a6e7f1) libwacom-surface: move to by-name
* [`16324f69`](https://github.com/NixOS/nixpkgs/commit/16324f699aacf14595fc9c40f9080de192d2fc10) libwacom: use finalAttrs style
* [`09ce1650`](https://github.com/NixOS/nixpkgs/commit/09ce1650e906d6ed5e6f09789c6e36fc0c97b771) libwacom-surface: v2.12.0-1 -> v2.12.2-1
* [`1bf99ab6`](https://github.com/NixOS/nixpkgs/commit/1bf99ab6f56481f0fe4032695009ccd3123c8980) libwacom: move tests to passthru.tests
* [`bf6088c5`](https://github.com/NixOS/nixpkgs/commit/bf6088c5bcb0578183b36def937c55e76c377906) libwacom: simplify tests enablement
* [`976209e9`](https://github.com/NixOS/nixpkgs/commit/976209e971d28e70d9cb5d3f5701e835656a4dcd) libwacom: remove ambiguous with statement
* [`dbdbd72f`](https://github.com/NixOS/nixpkgs/commit/dbdbd72fc67facb72fe0e028c1bec23d5c6a2105) libwacom: use lib.mesonOption
* [`ddddc574`](https://github.com/NixOS/nixpkgs/commit/ddddc574a016f9d73ebdf4b238f3133e87025d55) x265: apply darwin patch unconditionally
* [`3f6f0c80`](https://github.com/NixOS/nixpkgs/commit/3f6f0c80f1a8804b0b91bbed6165e4257f0f46d7) graphviz: 10.0.1 -> 12.1.0
* [`f32f54b8`](https://github.com/NixOS/nixpkgs/commit/f32f54b8606c32304f12b0da946a31454c2587c7) pkgs/stdenv/linux: update s390x-unknown-linux-gnu bootstrap-files
* [`88c52425`](https://github.com/NixOS/nixpkgs/commit/88c5242599db9fe3e4c50466a58b972a2c339e5d) azure-common: remove bootloader timeout since we can access serial console now
* [`7de2fd46`](https://github.com/NixOS/nixpkgs/commit/7de2fd4688786e7e1fd3e9f91c48a795554c4a50) maintainers: add sith-lord-vader
* [`5ccaa56a`](https://github.com/NixOS/nixpkgs/commit/5ccaa56a46444ee8512dcf6ab64fbfd3fc9889c0) python3Packages.stravalib: 1.6 → 2.0
* [`31f0b048`](https://github.com/NixOS/nixpkgs/commit/31f0b048a2105ccb7f4d8e86a14874afc9af0ffe) kodiPackages.youtube: 7.0.8 -> 7.0.9
* [`cb68f11d`](https://github.com/NixOS/nixpkgs/commit/cb68f11dc57b21f8cdef69afd39c4c4f108fea51) zabbix: add 7.0 LTS version
* [`72cc239f`](https://github.com/NixOS/nixpkgs/commit/72cc239f964e5b39f775e4305ba94230edc80c87) zabbix-agent2-plugin-postgresql: 6.4.15 -> 7.0.2
* [`7c05cf6b`](https://github.com/NixOS/nixpkgs/commit/7c05cf6b0eaf5bfff82c9ac22debcdf23224bc42) zabbix-agent2-plugin-postgresql: format
* [`2da0ddc8`](https://github.com/NixOS/nixpkgs/commit/2da0ddc8973b485fd4bf5c52d644a74e6179f9b9) zabbix: format
* [`129eace2`](https://github.com/NixOS/nixpkgs/commit/129eace28d9ffdba9280242c2582044853fbe4bb) python312Packages.gast: modernize
* [`20ba6d16`](https://github.com/NixOS/nixpkgs/commit/20ba6d165ed587d229aee9b7324d362704dffa04) python312Packages.gast: 0.5.3 -> 0.6.0
* [`8c63be6c`](https://github.com/NixOS/nixpkgs/commit/8c63be6c613467ebde11be70400bfe56fcc7d48a) python312Packages.beniget: modernize
* [`7828a0d8`](https://github.com/NixOS/nixpkgs/commit/7828a0d8ac3bbacb1112e2a1d290f5d556e7661a) python312Packages.beniget: 0.4.1 -> 0.4.2.post1
* [`d1c78884`](https://github.com/NixOS/nixpkgs/commit/d1c788840ecc51990c249f24d63abd183666c580) python312Packages.pythran: bump gast to 0.6.0
* [`c338237e`](https://github.com/NixOS/nixpkgs/commit/c338237e0e328c0ca6ddf0b9248645564282078f) python312Packages.pythran: modernize
* [`f236d96d`](https://github.com/NixOS/nixpkgs/commit/f236d96d3bc15b0c86efdb1beaae30203ceacdcf) libilbc: init at 3.0.4
* [`d91ad22d`](https://github.com/NixOS/nixpkgs/commit/d91ad22d821e0406b34f250a8ed361fb781009e2) ffmpeg: add ilbc options
* [`94683f9e`](https://github.com/NixOS/nixpkgs/commit/94683f9e55d47996b7403791863143f7afad8a51) azure-common: take networkmanager users into account for accelerated networking
* [`501b80e6`](https://github.com/NixOS/nixpkgs/commit/501b80e6f5244cd0f50be87a826a3303b71843cd) zathura: useMupdf on Darwin
* [`bba26b6d`](https://github.com/NixOS/nixpkgs/commit/bba26b6dfc45cb739439d7bd5269f41f2baf9e92) x265: move both `arm` `CROSS_COMPILE_*` under isCross
* [`0a3ed67f`](https://github.com/NixOS/nixpkgs/commit/0a3ed67ff66fe992ea08636d6518efbe22d2d3ac) autoPatchelfHook: add keep_libc flag ([nixos/nixpkgs⁠#332617](https://togithub.com/nixos/nixpkgs/issues/332617))
* [`0ec3712f`](https://github.com/NixOS/nixpkgs/commit/0ec3712f8a3d65f366c167159a5cd9d526889598) mupdf: fix review suggestions
* [`f0e142a4`](https://github.com/NixOS/nixpkgs/commit/f0e142a4cde80c58487a9960bc5a7ce08b91a796) gawk: move gawkbug to gawkInteractive
* [`edce18da`](https://github.com/NixOS/nixpkgs/commit/edce18da936b15d17452da8aa6d784dadc30c241) emacs.pkgs.libgit: remove fix because it has been removed from MELPA
* [`9f592a28`](https://github.com/NixOS/nixpkgs/commit/9f592a2829394095421491b5127af0a681642342) emacsPackages.osx-dictionary: remove unneeded dontUnpack
* [`997df6b9`](https://github.com/NixOS/nixpkgs/commit/997df6b9aa287073ae54bee8cb72a2f5e303982d) emacs: replace cd with pushd/popd in buildPhase of melpaBuild
* [`9f8b4031`](https://github.com/NixOS/nixpkgs/commit/9f8b4031ad9e328c96c62cba450ce1ebc093295c) openfec: 1.4.2.9 -> 1.4.2.11
* [`0dda8896`](https://github.com/NixOS/nixpkgs/commit/0dda88967287cf6aafc8c07dd71e43c9bebeb1a0) libedit: 20240517-3.1 -> 20240808-3.1
* [`1227cabe`](https://github.com/NixOS/nixpkgs/commit/1227cabed742abfa313ebae435aab55a5199ac26) xorg.libFS: 1.0.9 -> 1.0.10
* [`4405fd10`](https://github.com/NixOS/nixpkgs/commit/4405fd10d7cf2d77c38e235e8c48479e778e4374) mesa: 24.1.5 -> 24.1.6
* [`9fa6d793`](https://github.com/NixOS/nixpkgs/commit/9fa6d793dd061878784be4c3fa2ad7cb12c5cdab) python312Packages.pikepdf: 9.1.0 -> 9.1.1
* [`69addf43`](https://github.com/NixOS/nixpkgs/commit/69addf43928b4c377613832043fb7dbec01c620f) wasm-bindgen-cli: 0.2.92 -> 0.2.93
* [`fca63549`](https://github.com/NixOS/nixpkgs/commit/fca63549ac4dcd414225889b3fc025e93baedac3) python312Packages.uvloop: 0.19.0 -> 0.20.0
* [`571e1a82`](https://github.com/NixOS/nixpkgs/commit/571e1a8251ee7d617445d910a93326076a770d45) iproute2: fix static build again
* [`80609a72`](https://github.com/NixOS/nixpkgs/commit/80609a726d455b4880e10296c147bb73ace8cc19) gaugePlugins.makeGaugePlugin: fix updateScript
* [`66839cb7`](https://github.com/NixOS/nixpkgs/commit/66839cb7d27e631637ea645dcb16847ecb39d7e9) gaugePlugins.screenshot: 0.2.0 -> 0.3.0
* [`6cf198e1`](https://github.com/NixOS/nixpkgs/commit/6cf198e132c2be18df48559c9b6cbb9d38dbde63) gaugePlugins.ruby: 0.8.0 -> 0.9.2
* [`c30eb0c5`](https://github.com/NixOS/nixpkgs/commit/c30eb0c5e69fd8cca33b5adf283ce7025bbc4d97) gaugePlugins.java: 0.10.3 -> 0.11.0
* [`8b3a4a61`](https://github.com/NixOS/nixpkgs/commit/8b3a4a617e545284622226cc10b32f0e82a571f0) bluez: fix when gobject-introspection unsupported
* [`73c318b0`](https://github.com/NixOS/nixpkgs/commit/73c318b001fdb5549217fe9e2e759de096fae5ae) gauge: add plugin loading tests
* [`ebf6790c`](https://github.com/NixOS/nixpkgs/commit/ebf6790c393f4e89eede6d8049c95dc738734bea) stdenv: concatTo: fall back to old behaviour for "*Array" variables
* [`f974fa11`](https://github.com/NixOS/nixpkgs/commit/f974fa11e7e55f7e419492d472e1522d25ebdaf7) sudo: amend the concatTo warning (configureFlagsArray)
* [`75c12269`](https://github.com/NixOS/nixpkgs/commit/75c122699aa9b111b20124af29873762479c6cff) lib.cli.escapeShellArg{,s}: Only escape when necessary ([nixos/nixpkgs⁠#333744](https://togithub.com/nixos/nixpkgs/issues/333744))
* [`31127720`](https://github.com/NixOS/nixpkgs/commit/311277204d035558b2eb965a5fd58113d905e4aa) krb5: merge krb5 and libkrb5 with krb5.lib output
* [`b485499d`](https://github.com/NixOS/nixpkgs/commit/b485499dd713c0599c57c937be518e66eac91f07) rl-2411.section.md: fix typo
* [`ee1d2385`](https://github.com/NixOS/nixpkgs/commit/ee1d23853f5fd73ddeb48091346b4e700a26d10e) vim: 9.1.0595 -> 9.1.0679
* [`d9780a8b`](https://github.com/NixOS/nixpkgs/commit/d9780a8b8fda54f96eb2a58a0526235d18a08a39) python312Packages.aiohappyeyeballs: 2.3.5 -> 2.3.6
* [`3257fa48`](https://github.com/NixOS/nixpkgs/commit/3257fa4884945f9f64dd2be49ab4e696188eb14f) unbound: 1.20.0 -> 1.21.0
* [`31a6e138`](https://github.com/NixOS/nixpkgs/commit/31a6e1387f69eaaf01638764cd2fa3903d2d621d) python312Packages.exceptiongroup: refactor
* [`ff69a598`](https://github.com/NixOS/nixpkgs/commit/ff69a5986077327ec04ad7b5e1a8a15191babf5c) python312Packages.freezegun: refactor
* [`e6f8f04f`](https://github.com/NixOS/nixpkgs/commit/e6f8f04f9e0e03fe13c61fc3c38f76eabc8f2ca9) openssh: use krb5 dev output
* [`5f5c2e1f`](https://github.com/NixOS/nixpkgs/commit/5f5c2e1f038f795accf9e712951f3ef1169712c2) libgssglue: use krb5 lib output
* [`28290731`](https://github.com/NixOS/nixpkgs/commit/28290731fb94876aa1a9fa7c0efbc3373ab41e70) dotnet: use krb5 lib output
* [`cfe0e8e8`](https://github.com/NixOS/nixpkgs/commit/cfe0e8e874f609c71d8511eb6a8c9d53f884aee0) liburing: 2.6 -> 2.7
* [`3a55d6d0`](https://github.com/NixOS/nixpkgs/commit/3a55d6d070f293e3a4d08713b6baacf51e4e7412) mackup: 0.8.40 -> 0.8.41
* [`4f24561b`](https://github.com/NixOS/nixpkgs/commit/4f24561b0692e0df41c9367a4a5b22aa5daf7c0f) cosmic-screenshot: unstable-2023-11-08 -> 1.0.0-alpha.1
* [`ebb172b7`](https://github.com/NixOS/nixpkgs/commit/ebb172b7319bd1983a9033f70883dfd1f4989d91) cosmic-protocols: 0-unstable-2024-01-11 -> 0-unstable-2024-07-31
* [`40e3a2d6`](https://github.com/NixOS/nixpkgs/commit/40e3a2d6d4039cbb438b3f7e9418f3e47a30905f) cosmic-protocols: fix typo in description
* [`9c0d5a27`](https://github.com/NixOS/nixpkgs/commit/9c0d5a279f3cceaa69be0125dca85025930fb033) cosmic-notifications: unstable-2024-01-05 -> 1.0.0-alpha.1
* [`653035c6`](https://github.com/NixOS/nixpkgs/commit/653035c6503aa2e7d5e45a8d3acb397bf199ae23) cosmic-notifications: inline pname
* [`7baf5b34`](https://github.com/NixOS/nixpkgs/commit/7baf5b3497c7594029a783d5c78baf6f8a06b3b7) opencl-clhpp: 2.0.15 -> 2024.05.08
* [`d62cf4c9`](https://github.com/NixOS/nixpkgs/commit/d62cf4c9fd63aae24b849d1da6eec6c16ae36f60) arrayfire: apply patch for newer opencl-clhpp
* [`4c38d8a8`](https://github.com/NixOS/nixpkgs/commit/4c38d8a84621ed8c0a4f133ba167cb37f2ab0c9d) nodejs: 22.5.1 -> 22.6.0 ([nixos/nixpkgs⁠#333210](https://togithub.com/nixos/nixpkgs/issues/333210))
* [`9b9d7041`](https://github.com/NixOS/nixpkgs/commit/9b9d7041a4dba3ffbd8a484d90a171765327d818) Reapply "gss: re-enable tests"
* [`51ef0911`](https://github.com/NixOS/nixpkgs/commit/51ef09110bf8fd18aac9885ec746552ce69a3c42) singularity-tools: make runscript modifiable
* [`b9096d0d`](https://github.com/NixOS/nixpkgs/commit/b9096d0d865f7e0fb202490f9c554dc1b34eb06d) versionCheckHook: small indentation improvement
* [`393e9661`](https://github.com/NixOS/nixpkgs/commit/393e966194039c3655bd75570e74ae8696640461) versionCheckHook: ignore echoed store paths
* [`2ecfdda4`](https://github.com/NixOS/nixpkgs/commit/2ecfdda4cd6c2dabe7377a5a3e667f7b1e0637d8) c3c: switch from testVersion to versionCheckHook
* [`8479c602`](https://github.com/NixOS/nixpkgs/commit/8479c602282de6f6b3130fc2ab1763d3cdd740ae) pacman: fix scripts
* [`3f648e28`](https://github.com/NixOS/nixpkgs/commit/3f648e2891cfc8f37086bb20248cb0bada556616) gnumake: do not use MAKE_CXX
* [`31d78137`](https://github.com/NixOS/nixpkgs/commit/31d78137d577f5205690083510512ff61895cf5c) iterm2: 3.5.2 -> 3.5.4
* [`5fec2348`](https://github.com/NixOS/nixpkgs/commit/5fec23489572200c8da12dc7efecf4530afeaeb4) gnumake: recreate patch set and move to patches directory
* [`effb4473`](https://github.com/NixOS/nixpkgs/commit/effb44737251e30809e1a0c32f4cc194238687b1) p2pool: 4.0 -> 4.1
* [`5e7780a2`](https://github.com/NixOS/nixpkgs/commit/5e7780a26ef8434cc856a5ef32ac5d9ccb434f92) getoptions: 3.3.1 -> 3.3.2
* [`98588514`](https://github.com/NixOS/nixpkgs/commit/98588514bd38fc99f73da116309cf57a793df6e0) mongodb-5_0: 5.0.27 -> 5.0.28
* [`c6f9c6c3`](https://github.com/NixOS/nixpkgs/commit/c6f9c6c37758bf3e748436142d8fc89fa127db90) mongodb-6_0: 6.0.16 -> 6.0.17
* [`6f4426f8`](https://github.com/NixOS/nixpkgs/commit/6f4426f80fc454cc7454d6b395562f787b9bda83) neovim-unwrapped: use outputChecks
* [`cb0d3e9d`](https://github.com/NixOS/nixpkgs/commit/cb0d3e9d0a55214858bad221a838c3c4ce107241) xdg-desktop-portal-shana: 0.3.11 -> 0.3.12
* [`cd15dea2`](https://github.com/NixOS/nixpkgs/commit/cd15dea2e2a7f6f724a6bebccd63ef2507960e97) harper: init at 0.9.5
* [`468cfccb`](https://github.com/NixOS/nixpkgs/commit/468cfccb0cd92f9a48dac88cfea5c0168664a7fa) cmake: setup-hook.sh: unify indentation
* [`237b25b5`](https://github.com/NixOS/nixpkgs/commit/237b25b55629f4bf0c5a87a1330fcf7f64e9a7e3) cinny-desktop: migrate to pkgs/by-name, add ryand56 to maintainers
* [`ce84b361`](https://github.com/NixOS/nixpkgs/commit/ce84b361b57c90788904cc954a4df27481083b96) cinny-desktop: override cinny dependency with hashRouter
* [`9f136138`](https://github.com/NixOS/nixpkgs/commit/9f136138197b9f0e85f9bd9594b234774ff4fbf8) cinny-desktop: format using nixfmt-rfc-style
* [`b26ca1d0`](https://github.com/NixOS/nixpkgs/commit/b26ca1d0713d21b9c6448a7a6a724dd0ce3e9660) cinny-desktop: 4.0.3 -> 4.1.0
* [`3f255f7f`](https://github.com/NixOS/nixpkgs/commit/3f255f7f288f0105a993edd778c0f8d5a7e406ed) catch2_3: 3.5.2 -> 3.7.0
* [`3f2b634b`](https://github.com/NixOS/nixpkgs/commit/3f2b634b998a3eb2e27aaf9d0f2d60215bd319b0) cudaPackages_12_4: init at 12.4.0
* [`65e73f4d`](https://github.com/NixOS/nixpkgs/commit/65e73f4d7aedaf94189f6eba4f43f5f7be2a1d39) python312Packages.gunicorn: 22.0.0 -> 23.0.0
* [`0b136159`](https://github.com/NixOS/nixpkgs/commit/0b136159899e31b0eb9598f5965447ff45f23b04) python312Packages.mlflow: relax gunicorn dependency
* [`79b28e83`](https://github.com/NixOS/nixpkgs/commit/79b28e837273286eb3c22ca0c0d886bfc3af3288) lib.licenses: add CockroachDB Community License Agreement
* [`855b8f7f`](https://github.com/NixOS/nixpkgs/commit/855b8f7f4957f893a822d89025bf4349e0909ce2) cockroach-bin: Update licenses
* [`45089df0`](https://github.com/NixOS/nixpkgs/commit/45089df0cf12db54756284793f6aaa507fd70936) pacemaker: 2.1.7 -> 2.1.8
* [`6b25e188`](https://github.com/NixOS/nixpkgs/commit/6b25e1888763d7a5ef6414f26961ca2988ffd19a) aquamarine: fix build
* [`f3c2be2a`](https://github.com/NixOS/nixpkgs/commit/f3c2be2a80cadf50efef4f14b26462a55017be37) nixos/wakapi: init module
* [`31227b24`](https://github.com/NixOS/nixpkgs/commit/31227b2491fd41a8e350e28931926c8771a2dc3e) lomiri.libusermetrics: 1.3.2 -> 1.3.3
* [`19d9cb7c`](https://github.com/NixOS/nixpkgs/commit/19d9cb7ca1d49c387e2c0191bdb9e74718d25e67) lomiri.libusermetrics: nixfmt
* [`2b883410`](https://github.com/NixOS/nixpkgs/commit/2b883410d4a31cbbd033c0ea92ce2e192193d3f0) nvidia-container-toolkit: only mount existing paths in the host
* [`d665ca4f`](https://github.com/NixOS/nixpkgs/commit/d665ca4fb2c6c5814a763fa0cd861730d89ef609) nvidia-container-toolkit: add initial set of tests to check closures
* [`e86a7c59`](https://github.com/NixOS/nixpkgs/commit/e86a7c5986650d4ac621ebf2592ea85947b48c60) thanos: 0.35.1 -> 0.36.1
* [`51930e03`](https://github.com/NixOS/nixpkgs/commit/51930e034347bb25bff50346086c65cc089fb2f0) git: re-enable a few tests that are fixed upstream
* [`e3244e9f`](https://github.com/NixOS/nixpkgs/commit/e3244e9ff008312235d213cc1066eaa8d2602ce1) treewide: replace xxxFlagsArray with non-Array variant in nix code
* [`755c316f`](https://github.com/NixOS/nixpkgs/commit/755c316f384eb6da4e95c24472dd7466b74112ee) php-packages: remove unused checkXXX options from buildPecl derivations
* [`6dce5aaf`](https://github.com/NixOS/nixpkgs/commit/6dce5aafd3553d75d4879b6bbe89efb6676d7c31) python312Packages.sqlalchemy-file: init at 0.6.0
* [`23c20c44`](https://github.com/NixOS/nixpkgs/commit/23c20c44cf3ddbb552111c80ac2576b42bf6e5b0) python312Packages.starlette-admin: init at 0.14.1
* [`71f977f8`](https://github.com/NixOS/nixpkgs/commit/71f977f8a70b9a84a3a20fccdc2417720a2e3bb0) python312Packages.reflex-hosting-cli: init at 0.1.13
* [`bc0a29f0`](https://github.com/NixOS/nixpkgs/commit/bc0a29f049300020a8e91239d647d9a9a16838c3) python312Packages.reflex: init at 0.5.9
* [`12439209`](https://github.com/NixOS/nixpkgs/commit/124392093c923021bde48c2ac54938ba87a2eb0f) wine64Packages.wayland: add missing `wayland-scanner` build input
* [`425ff51a`](https://github.com/NixOS/nixpkgs/commit/425ff51abc39a7e9d47b50f0245307d5ee50e228) gtk4: 4.14.4 -> 4.14.5
* [`ad16a8d0`](https://github.com/NixOS/nixpkgs/commit/ad16a8d0524fee884fa38a5b7e145d2fa9827f9c) gaugePlugins.makeGaugePlugin: fix darwin build
* [`e85f5305`](https://github.com/NixOS/nixpkgs/commit/e85f5305f058ba73e3eb614fd668679104086be5) blastem 0.6.2-unstable-2024-03-31 -> 0.6.2-unstable-2024-08-14
* [`a58bfa11`](https://github.com/NixOS/nixpkgs/commit/a58bfa1150d1675664747c70b2d5677e2fa32ce7) lima-bin: Fix completion generation
* [`198af78c`](https://github.com/NixOS/nixpkgs/commit/198af78cb6bf6fb4e195e390bb79fa05926a85ce) nixpkgs-manual: fix build
* [`ed48acbc`](https://github.com/NixOS/nixpkgs/commit/ed48acbc06b1c71063b665c8ac5e3d2b690d4b4f) matomo_5: 5.1.0 -> 5.1.1
* [`f5b3a9cd`](https://github.com/NixOS/nixpkgs/commit/f5b3a9cd32d98a3cbcd318592fa468052dfb0c87) elpa-packages: updated 2024-08-20 (from overlay)
* [`d2e6659b`](https://github.com/NixOS/nixpkgs/commit/d2e6659b0ebddcfc49513b7d0d2bc37f8d8b7a41) elpa-devel-packages: updated 2024-08-20 (from overlay)
* [`b6939189`](https://github.com/NixOS/nixpkgs/commit/b69391897e0a31d193064d34b73fa189d2d6f4a2) melpa-packages: updated 2024-08-20 (from overlay)
* [`1b04022e`](https://github.com/NixOS/nixpkgs/commit/1b04022ea7cfe7ddd2488f4d5ecda78dc97f317d) nongnu-packages: updated 2024-08-20 (from overlay)
* [`de35646e`](https://github.com/NixOS/nixpkgs/commit/de35646e516fd72d875c51c01975b67e92a10beb) nongnu-devel-packages: updated 2024-08-20 (from overlay)
* [`d00775c1`](https://github.com/NixOS/nixpkgs/commit/d00775c1d9a3acbff2d121fbae54691a7f07d18a) stdenv: create `env-vars` file before writing data to it
* [`60dad75a`](https://github.com/NixOS/nixpkgs/commit/60dad75a8d81e58c866083498da5f3ed516fc21e) rubyPackages.standard: init at 1.40.0
* [`8df36bb6`](https://github.com/NixOS/nixpkgs/commit/8df36bb6c49dfaabc45355fc1919b0c0626c105a) cgl: 0.60.8 -> 0.60.9
* [`0091b8b7`](https://github.com/NixOS/nixpkgs/commit/0091b8b7598477f968a7ee0bd58e0f7d791032e1) svix-server: 1.28.0 -> 1.30.0
* [`70c79190`](https://github.com/NixOS/nixpkgs/commit/70c79190d93afcbf9f2ec40417a45802a1015ee4) flashprog: 1.1 -> 1.2
* [`62dcf47a`](https://github.com/NixOS/nixpkgs/commit/62dcf47ab471bb6e0883f156ab10d2b5e97477bd) fflogs: 8.12.19 -> 8.13.1
* [`81bc42c9`](https://github.com/NixOS/nixpkgs/commit/81bc42c9b8010726dd5bbb05a90534b6edce4f16) u-config: init at 0.33.1
* [`631d41a7`](https://github.com/NixOS/nixpkgs/commit/631d41a767b47205d53f38d198d591308fed48e9) python312Packages.numpy_2: 2.0.1 -> 2.1.0
* [`5dfdb095`](https://github.com/NixOS/nixpkgs/commit/5dfdb0956172c6a5fc3a3c44d8b949e7e8cccc17) tree-wide: remove eelco as maintainer from things he no longer maintains
* [`099f709d`](https://github.com/NixOS/nixpkgs/commit/099f709d9ec2024222db5f33bdc3e08ef1ebfad2) go-task: fix shell completion for command alias
* [`6cac9e40`](https://github.com/NixOS/nixpkgs/commit/6cac9e409cec6b65f2980b0dd90e1290310c7ac4) wstunnel: reformat with nixfmt
* [`bbcc6a0f`](https://github.com/NixOS/nixpkgs/commit/bbcc6a0f6c4d5b5d2cd1cc4e45982adc71513324) wstunnel: add updateScript
* [`035abb86`](https://github.com/NixOS/nixpkgs/commit/035abb86ca5deb96ce98511d221fccdd7699d37e) python3Packages.gguf: 0.6.0 -> 0.9.1
* [`e29d1bfc`](https://github.com/NixOS/nixpkgs/commit/e29d1bfc3e39ae23284503e26a6280e813acb7a3) wstunnel: 9.7.4 -> 10.0.1
* [`c85887e5`](https://github.com/NixOS/nixpkgs/commit/c85887e5180cea00b60879b252f13d7e8265831c) wstunnel: use versionCheckHook instead of testVersion
* [`93343775`](https://github.com/NixOS/nixpkgs/commit/93343775bd2c4a4afc573e842f24ef08bf350895) nixos/uwsm: init
* [`be55458d`](https://github.com/NixOS/nixpkgs/commit/be55458d12afc09f38f8ace6cd3bbc3014de70c6) rustdesk-flutter: 1.2.7 -> 1.3.0
* [`5c1ed3ad`](https://github.com/NixOS/nixpkgs/commit/5c1ed3ad5a60913877eea7713b645703526b4f51) kasmweb: 1.12.0 -> 1.15.0
* [`e1abf9bf`](https://github.com/NixOS/nixpkgs/commit/e1abf9bfed8933d977d25b234999ae48a6dba632) rustdesk-flutter: Make build reproducible
* [`b3d96378`](https://github.com/NixOS/nixpkgs/commit/b3d96378e1c6fb89d3dfd41b32f5f4ec9e4f424e) molsketch: fix cmakeFlags for __structuredAttrs
* [`f4c1b6f2`](https://github.com/NixOS/nixpkgs/commit/f4c1b6f205aa4bff93199e283575d24158bb151b) python3Packages.pymeshlab: fix cmakeFlags
* [`1e8290ea`](https://github.com/NixOS/nixpkgs/commit/1e8290ea5f4e9cfd6d4a6bbc427394e15a4e1f6d) yarp: fix cmakeFlags for __structuredAttrs
* [`8fa3649f`](https://github.com/NixOS/nixpkgs/commit/8fa3649f99a3438d9236020fe761d22eae893d51) aws-c-common: fix setup hook cmakeFlags for __structuredAttrs
* [`8b93d36e`](https://github.com/NixOS/nixpkgs/commit/8b93d36ef7a879368a6c64c5db090883ee3654f4) openwsman: fix cmakeFlags for __structuredAttrs
* [`13d2eec8`](https://github.com/NixOS/nixpkgs/commit/13d2eec8108c8854438ccdedfe0ddc486c2c70a8) vigra: format with nixfmt-rfc-style
* [`80dd13fb`](https://github.com/NixOS/nixpkgs/commit/80dd13fbc1681f84eb72910fb2897af071f06fcd) vigra: fix cmakeFlags for __structuredAttrs
* [`c0d35f87`](https://github.com/NixOS/nixpkgs/commit/c0d35f87337d9bfb33af08d910fda5f4a564afa4) python3Packages.hoomd-blue: fix cmakeFlags for __structuredAttrs
* [`263be5c8`](https://github.com/NixOS/nixpkgs/commit/263be5c8519ba553abbe5e0bde08c4c772907793) python3Packages.rdkit: fix cmakeFlags for __structuredAttrs
* [`2d66a0bf`](https://github.com/NixOS/nixpkgs/commit/2d66a0bf73a0dd3d54d2da4cc5a6c7fc5e703f55) commandergenius: fix cmakeFlags and makeFlags for __structuredAttrs
* [`e44a479b`](https://github.com/NixOS/nixpkgs/commit/e44a479b1a5c9865dbb6ed0c56440b61c3450724) irods: fix cmakeFlags for __structuredAttrs
* [`87f3fbad`](https://github.com/NixOS/nixpkgs/commit/87f3fbade567e21d023651d82f8454a2de209ddc) python312Packages.ipython: 8.25.0 -> 8.26.0
* [`881fc844`](https://github.com/NixOS/nixpkgs/commit/881fc844c4170099862054f0d5a854a081d275dd) python312Packages.ipython: add teams.jupyter.members as maintainer
* [`33d8eabc`](https://github.com/NixOS/nixpkgs/commit/33d8eabcbeb03702566c625572b4a6b84d51160d) wlx-overlay-s: add required libraries
* [`5c23bebf`](https://github.com/NixOS/nixpkgs/commit/5c23bebf2a9beb6710f7b30b36904ca0cbd957ca) sirius: 7.5.2 -> 7.6.0
* [`244ed365`](https://github.com/NixOS/nixpkgs/commit/244ed365b998cd2b19c224f1210f498da31dc49b) scalingo: 1.32.0 -> 1.33.0
* [`00708835`](https://github.com/NixOS/nixpkgs/commit/007088359e7a0b438f42387cb59c0479ba81df83) python3: break infinite recursion
* [`699c3201`](https://github.com/NixOS/nixpkgs/commit/699c320171c1f0b34dff44ba8b83e617b8b48603) libsndfile: enable on all platforms
* [`2543d158`](https://github.com/NixOS/nixpkgs/commit/2543d1581728b37c4f35e2dfef1c7ecf2a68fb5a) libsamplerate: mark broken on MinGW
* [`d7988eb8`](https://github.com/NixOS/nixpkgs/commit/d7988eb8266e0d3020c37bd9b7e3435075ef22c2) libresample: move to `pkgs/by-name`
* [`1e0e30ab`](https://github.com/NixOS/nixpkgs/commit/1e0e30ab0ba3779033115ac34893e543e363beda) libresample: format with `nixfmt-rfc-style`
* [`7ca429f2`](https://github.com/NixOS/nixpkgs/commit/7ca429f26f93fff0b2387ac30707f0bbccdd1a80) libresample: add myself to maintainers
* [`a35a9a31`](https://github.com/NixOS/nixpkgs/commit/a35a9a314a58e28e4fd64effe3f7c199d47a7c60) feishu: 7.18.11 -> 7.22.9
* [`c88cfcb0`](https://github.com/NixOS/nixpkgs/commit/c88cfcb0122571e7b5ebdc16392000195ed2185b) powershell: 7.4.4 -> 7.4.5
* [`2ae3a0f5`](https://github.com/NixOS/nixpkgs/commit/2ae3a0f50d19a1fc57f59a584592031922e13725) xjadeo: unpin FFmpeg 4
* [`ff64007b`](https://github.com/NixOS/nixpkgs/commit/ff64007b3ad05f570cce6232e610077efe5ec402) pangolin: unpin FFmpeg 4
* [`5e13c419`](https://github.com/NixOS/nixpkgs/commit/5e13c4193be5ab072049d2923994a2c59e167602) vulkan-cts: unpin FFmpeg 4
* [`f96d0986`](https://github.com/NixOS/nixpkgs/commit/f96d09865aaea3913a626674d191130b0b311a9f) sumo: unpin FFmpeg 4
* [`4d77d90c`](https://github.com/NixOS/nixpkgs/commit/4d77d90c23cb64bde3b0cbc4d287f3589e2c755c) ultrastardx: unpin FFmpeg 4
* [`6f17a88b`](https://github.com/NixOS/nixpkgs/commit/6f17a88bb19c940d9f4e0e4b4496adbf3ad096d7) frida-tools: 12.3.0 -> 12.5.0
* [`5ea4f918`](https://github.com/NixOS/nixpkgs/commit/5ea4f918417b7ad9e6536cc9560af7888537f7af) httplib: 0.16.2 -> 0.16.3
* [`420875f6`](https://github.com/NixOS/nixpkgs/commit/420875f69ad52e857860e053d885d2253c43f7ef) iroh: 0.21.0 -> 0.23.0
* [`98f36e5c`](https://github.com/NixOS/nixpkgs/commit/98f36e5c989ea57386a4e1f945bbe8318b0f736a) picosnitch: mark as vulnerable
* [`774a38ed`](https://github.com/NixOS/nixpkgs/commit/774a38edb7d0092665576215e4af4f9b36d3a00b) nagios: 4.5.3 -> 4.5.4
* [`5d5a33a8`](https://github.com/NixOS/nixpkgs/commit/5d5a33a8e3c8ca92cbf4b1dfb6a8930fe87803c5) loopwm: added updateScript
* [`36e6203f`](https://github.com/NixOS/nixpkgs/commit/36e6203fb7b1f46fb5fa604e27d5ae1d52140ab9) thunderbird-unwrapped: 128.1.0esr -> 128.1.1esr
* [`a805299f`](https://github.com/NixOS/nixpkgs/commit/a805299f6234608b064787f979f573c45738979e) pipewire: 1.2.2 -> 1.2.3
* [`3c3626cc`](https://github.com/NixOS/nixpkgs/commit/3c3626cc2c0b9cc7b785a0ea52ef5103338d2cbb) python312Packages.fastapi: disable flaky test
* [`73288a2c`](https://github.com/NixOS/nixpkgs/commit/73288a2c8a5702cfac95ab1690274f520266bbd5) hyprland: fix build
* [`2a2d3cb4`](https://github.com/NixOS/nixpkgs/commit/2a2d3cb4abb872c9dc7a43d012f6be15b28285ff) pgraphs: 0.6.13 -> 0.6.17
* [`6988ee21`](https://github.com/NixOS/nixpkgs/commit/6988ee218c8e8576464f2a896819383486bda0c4) whitesur-kde: change update script
* [`633b5b3d`](https://github.com/NixOS/nixpkgs/commit/633b5b3dcfd5b383c99251716b079d5b1caa9400) mealie: v1.11.0 -> v1.12.0
* [`8525a690`](https://github.com/NixOS/nixpkgs/commit/8525a69076805a540b2a7652f77f4ab78d320f29) python3Packages.array-api-strict: refactor
* [`1d43162c`](https://github.com/NixOS/nixpkgs/commit/1d43162c4b7f7816814cab5de9b1a70c5a1aaee1) esphome: 2024.7.3 -> 2024.8.0
* [`d62b72d4`](https://github.com/NixOS/nixpkgs/commit/d62b72d4ee9db68ee9a1f358af8fffa956ea0813) libsForQt5.ffmpegthumbs: unpin FFmpeg 4
* [`a3d72290`](https://github.com/NixOS/nixpkgs/commit/a3d72290fbd80476cf9fcc326dc30fe287c260b8) megasync: unpin FFmpeg 4
* [`426ea95c`](https://github.com/NixOS/nixpkgs/commit/426ea95c184c07a98b364f00aef40e869ba86abe) alephone: pin FFmpeg 6
* [`8c533c35`](https://github.com/NixOS/nixpkgs/commit/8c533c3550cb5694365b1b7a980680d859e83566) olive-editor: pin FFmpeg 6
* [`2f5176c2`](https://github.com/NixOS/nixpkgs/commit/2f5176c2b44c8026d40aefdfc431afc4578b61d1) guvcview: 2.0.6 -> 2.1.0
* [`b2b7066b`](https://github.com/NixOS/nixpkgs/commit/b2b7066b25b7765815bc118bb2a29079872c8142) octavePackages.video: 2.0.2 -> 2.1.1
* [`e1c2ff51`](https://github.com/NixOS/nixpkgs/commit/e1c2ff514c505ac29c3d5fd1d7193223cb66551c) rustplayer: unstable-2022-12-04 -> 1.1.2-unstable-2024-07-14
* [`44a26807`](https://github.com/NixOS/nixpkgs/commit/44a26807b5212ad61d2df0831785a01c06cf9da2) electricsheep: 3.0.2-2019-10-05 -> 3.0.2-unstable-2024-02-13
* [`f7d69fba`](https://github.com/NixOS/nixpkgs/commit/f7d69fbac6e23a46a0799285b7fcad87007706be) untrunc-anthowlock: 0-unstable-2021-11-21 -> 0-unstable-2024-08-14
* [`2a75dd13`](https://github.com/NixOS/nixpkgs/commit/2a75dd13a543d93a888505a0a0ea3bbda2dad3f4) webcamoid: add upstream patch for FFmpeg 7
* [`bc8cde20`](https://github.com/NixOS/nixpkgs/commit/bc8cde207e71a62005b5ad0c560d3fe9b5d62e66) guacamole-server: add upstream patch for FFmpeg 7
* [`778806c4`](https://github.com/NixOS/nixpkgs/commit/778806c4a726c27d8cb631a4df1c74769a4c1a6a) ffmpeg_4: discourage further use
* [`7b1f1f77`](https://github.com/NixOS/nixpkgs/commit/7b1f1f77ebaf3e9d8e39512f8c3f6b26a60db483) chiaki-ng: 1.7.4 -> 1.8.1
* [`6fa5767e`](https://github.com/NixOS/nixpkgs/commit/6fa5767e07221bbc6fdfda24904b994becc10e7f) tvheadend: drop
* [`a565cfea`](https://github.com/NixOS/nixpkgs/commit/a565cfeac35939ec55cb0bd20d1414ffd10e0685) antennas: drop
* [`46e093c9`](https://github.com/NixOS/nixpkgs/commit/46e093c98e4c027e725c37af63489a36884d83ec) whitesur-kde: unstable-2023-10-06 -> 2022-05-01-unstable-2024-08-07
* [`e0ffe42f`](https://github.com/NixOS/nixpkgs/commit/e0ffe42febb6bde8d3e551d938c8f1b73c8a566f) cudaPackages.cudnn_9_3: add sbsa and jetson
* [`1b7f2fe8`](https://github.com/NixOS/nixpkgs/commit/1b7f2fe883b0846b7cc99f0da81d50054d175860) tests/nvidia-container-toolkit: more getExe
* [`1e571aea`](https://github.com/NixOS/nixpkgs/commit/1e571aeab4c10daa086f1a8a78bb562b8e8ed245) tests/nvidia-container-toolkit: less nesting
* [`0780a3eb`](https://github.com/NixOS/nixpkgs/commit/0780a3ebc81069648e4ab57d3f5603d1d59d953c) tests/nvidia-container-toolkit: strip {no,one}-nvidia prefix as obvious from the context
* [`d970b4d6`](https://github.com/NixOS/nixpkgs/commit/d970b4d6cd3c297865b4d2b083cd4b3f523ed973) tests/nvidia-container-toolkit: hardware.opengl -> graphics
* [`096a5c44`](https://github.com/NixOS/nixpkgs/commit/096a5c44505765a35eefe8b40ec3b8bfa5efce30) komac: add HeitorAugustoLN as a maintainer
* [`f72b7b56`](https://github.com/NixOS/nixpkgs/commit/f72b7b56fb6f8d6c1839c0dc70477ad4c8193e10) tests/nvidia-container-toolkit: mv shared config to `defaults`
* [`521380e5`](https://github.com/NixOS/nixpkgs/commit/521380e506fe2190ad9e112548306a1f90d4e041) ghidra-extensions.ghidra-delinker-extension: 0.4.0 -> 0.5.0
* [`cc390828`](https://github.com/NixOS/nixpkgs/commit/cc390828efcd16cb1c32899471cafc53c0821662) vim: 9.1.0679 -> 9.1.0689
* [`aa0e6bba`](https://github.com/NixOS/nixpkgs/commit/aa0e6bba5ea3238db1605b48e7038bf24e8e4b50) lime3ds: 2116 -> 2117.1
* [`92c116b4`](https://github.com/NixOS/nixpkgs/commit/92c116b4395c67060e3a191e6b851ef9df1e173b) flutterPackages.v3_24: init
* [`a2b56cd6`](https://github.com/NixOS/nixpkgs/commit/a2b56cd6e0995d2ec9ca3e4d20286d9201cd6281) flutterPackages.v3_24: fix patches
* [`ca5230ce`](https://github.com/NixOS/nixpkgs/commit/ca5230ce0b5a0b75f11aeec9c61103c477b5ea6e) python3Packages.certifi: 2024.02.02 -> 2024.07.04 ([nixos/nixpkgs⁠#329697](https://togithub.com/nixos/nixpkgs/issues/329697))
* [`768be845`](https://github.com/NixOS/nixpkgs/commit/768be845b82f1c235c43f623370be79194ce40a3) pscale: 0.207.0 -> 0.208.0
* [`0f3b632c`](https://github.com/NixOS/nixpkgs/commit/0f3b632cb183c2d13a21e571e09418d7d08ed736) rquickshare: 0.10.2 -> 0.11.2
* [`32ee8434`](https://github.com/NixOS/nixpkgs/commit/32ee8434dd3f07cd1b14a14001977e1cf4f0ee75) radarr: 5.8.3.8933 -> 5.9.1.9070
* [`55a29528`](https://github.com/NixOS/nixpkgs/commit/55a295282250200cd92ceade860b297a6e3042b0) maintainers: add vinylen
* [`16ba8c91`](https://github.com/NixOS/nixpkgs/commit/16ba8c917915b9ff0004276931c19be73f060cd3) lastpass-cli: v1.3.6 -> v1.6.0
* [`7d687638`](https://github.com/NixOS/nixpkgs/commit/7d687638c5e0b09632fd70ba466ab1e544228436) aquamarine: drop upstreamed patch
* [`fec851ff`](https://github.com/NixOS/nixpkgs/commit/fec851ff9eed5ff5060db0b7c20bfc7a67a544d4) maintainers: add lutzberger
* [`30fe276d`](https://github.com/NixOS/nixpkgs/commit/30fe276d69fe0fd3e319281d1133c90bd433f10d) newsboat: add mainProgram
* [`39f4f087`](https://github.com/NixOS/nixpkgs/commit/39f4f0877bcbd5c7ad569e203e1b8d6feaa683d6) electron_29-bin: mark as insecure because it's EOL
* [`fd911150`](https://github.com/NixOS/nixpkgs/commit/fd911150a24ccb9ec4594bba2f9c4062bc23d990) electron-source.electron_29: remove as it's EOL
* [`01cf1d5f`](https://github.com/NixOS/nixpkgs/commit/01cf1d5fb6f6a9c6c82af8ba775c5262f81661db) davinci-resolve: improve updateScript functionality
* [`03a80c7a`](https://github.com/NixOS/nixpkgs/commit/03a80c7ac291d932e24fc67a6f80a7a673a01f9c) davinci-resolve: refactor use downloadTitle instead of name
* [`dc9a240a`](https://github.com/NixOS/nixpkgs/commit/dc9a240a0c499399abe91d742599cca8fb25258e) davinci-resolve: 18.6.6 -> 19.0
* [`e236ff11`](https://github.com/NixOS/nixpkgs/commit/e236ff11c26bb3f4e93acc677f80a1fdfca4be3b) catppuccin-cursors: 0.3.0 -> 0.3.1
* [`54a619ce`](https://github.com/NixOS/nixpkgs/commit/54a619ce17d34fe38f623335d2c994bd47b7494c) templ: 0.2.747 -> 0.2.771
* [`377e315d`](https://github.com/NixOS/nixpkgs/commit/377e315d7205ae4d14216b8599b9785d4ea597b8) swig1: remove at 1.3.40
* [`a0fb3d0a`](https://github.com/NixOS/nixpkgs/commit/a0fb3d0aeb6376f3e688dff5bf495890f11dde19) soapysdr: swig2 -> swig3
* [`6cd0594a`](https://github.com/NixOS/nixpkgs/commit/6cd0594a59c33d176c8f48a23506110083bfac02) soapysdr: apply nixfmt
* [`9811da4c`](https://github.com/NixOS/nixpkgs/commit/9811da4c78118f94d51b08d1a866efcb856397e6) babeltrace: swig2 -> swig4
* [`1a92b120`](https://github.com/NixOS/nixpkgs/commit/1a92b1205d31863be2df0b4f70c70afdf3d4c952) gpgme: swig2 -> swig4
* [`49ab3050`](https://github.com/NixOS/nixpkgs/commit/49ab3050950c69d385bd82a40c3d57950bc23c00) gpgme: apply nixfmt
* [`3c4d7327`](https://github.com/NixOS/nixpkgs/commit/3c4d7327e92be407c400f0992c76cef8f8fe5d69) python312Packages.lttng: swig2 -> swig4
* [`46eee3f7`](https://github.com/NixOS/nixpkgs/commit/46eee3f793ddd3108552d8bd278606429fa4f4a1) swig2: remove at 2.0.12
* [`9e5316a1`](https://github.com/NixOS/nixpkgs/commit/9e5316a1c58cd34dbcf1a51d80137d98aeacd906) nixos/varnish: change default stateDir to /run
* [`9490a5f3`](https://github.com/NixOS/nixpkgs/commit/9490a5f310f4b4fc83c149b7bbbf9012ce03671e) Discord updates
* [`1c7b9e2c`](https://github.com/NixOS/nixpkgs/commit/1c7b9e2cddd6a4ae4dd1221d04b68844f2745997) emacsPackages.notdeft: fix build
* [`a04b802d`](https://github.com/NixOS/nixpkgs/commit/a04b802dde5b75186f5366305bbab9aa4f7c2c76) emacsPackages.pod-mode: fix build
* [`d17985f4`](https://github.com/NixOS/nixpkgs/commit/d17985f4e8acae94eb78435b43a877db65fa0247) so: migrate to by-name
* [`3fafb7e3`](https://github.com/NixOS/nixpkgs/commit/3fafb7e306415c69a92431ee50d6ef2dcf691c73) so: remove mredaelli from meta.maintainers
* [`0fde3185`](https://github.com/NixOS/nixpkgs/commit/0fde31852888cd24aaece756797cbe9b13f0c58f) so: adopt and rework
* [`59f7d71c`](https://github.com/NixOS/nixpkgs/commit/59f7d71c0a3d84f16727e317597a60304431f7e4) so: use self pattern
* [`77debe79`](https://github.com/NixOS/nixpkgs/commit/77debe793e5ce257c309da0daaf2c67d3c04d687) so: 0.4.9 -> 0.4.10
* [`3975369a`](https://github.com/NixOS/nixpkgs/commit/3975369a6b373bdf9e0a233348ac95cadbfb5fe4) python312Packages.apricot-select: drop nose dependency
* [`ecd4a41e`](https://github.com/NixOS/nixpkgs/commit/ecd4a41e6906528794f4119a4763d0f0a7c0d927) spasm-ng: Add ASM header files
* [`f990b5a9`](https://github.com/NixOS/nixpkgs/commit/f990b5a9c13485feb2eb2163246694eea1495fce) python311Packages.pyopencl: 2024.2.6 -> 2024.2.7
* [`a4120fcd`](https://github.com/NixOS/nixpkgs/commit/a4120fcd056a6962c409cdc5272444af016c30d7) mesonEmulatorHook: don’t use `lib.escapeShellArg`
* [`fd724b46`](https://github.com/NixOS/nixpkgs/commit/fd724b4641d78c7d64c5d50a19648c54f030699e) emacsPackages.ligo-mode: 1.7.0-unstable-2024-08-14 -> 1.7.0-unstable-2024-08-22
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
