### PR TITLE
niv nixpkgs: update d1618650 -> 59c3aa2d

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d161865045aa63ba6b02f549892a9d5f55a07d5d",
-        "sha256": "0r15d0yf9z08zy72k5k7ccvwpdwwk1sb9mpfvs1vl0sr66gqd5ih",
+        "rev": "59c3aa2d4de4b69b3e21742fd1d7222756cf5d91",
+        "sha256": "1irj7rjh7wjq74yr1s9g9zi44d8vcp7ig160a11mjn09vhj83rw0",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/d161865045aa63ba6b02f549892a9d5f55a07d5d.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/59c3aa2d4de4b69b3e21742fd1d7222756cf5d91.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@d1618650...59c3aa2d](https://github.com/nixos/nixpkgs/compare/d161865045aa63ba6b02f549892a9d5f55a07d5d...59c3aa2d4de4b69b3e21742fd1d7222756cf5d91)

* [`7c55eed5`](https://github.com/NixOS/nixpkgs/commit/7c55eed58963b98c86d4330039433570c7ba489e) updated rutorrent version
* [`ef37a35c`](https://github.com/NixOS/nixpkgs/commit/ef37a35c745c66e48e4f51f2c7668719e259eb3a) typo
* [`c784691d`](https://github.com/NixOS/nixpkgs/commit/c784691d6e2b4d8b5dae3739867c18c3671cbdf7) updated + working
* [`2cf7ffd7`](https://github.com/NixOS/nixpkgs/commit/2cf7ffd71d8e5fd29b0a5c7073b677182dc925f1) yaml-ccp: allow overriding static build
* [`ca5b44fb`](https://github.com/NixOS/nixpkgs/commit/ca5b44fbd011933618be66ad9bd40decf0aa9192) dcgm: fix build by using static yaml-cpp
* [`f7b4ce1c`](https://github.com/NixOS/nixpkgs/commit/f7b4ce1cfe07acb31191fed323e306afa0fe5799) dcgm: 3.2.5 -> 3.3.5
* [`d1e7e929`](https://github.com/NixOS/nixpkgs/commit/d1e7e92949ad9f0eb7f2756bb08c392366d200a1) prometheus-dcgm-exporter: 3.2.5-3.1.7 -> 3.3.5-3.4.0
* [`a9e897c9`](https://github.com/NixOS/nixpkgs/commit/a9e897c9474e7e3016c11067588857fe4791cd8b) libevent: add static build option
* [`d86fc14f`](https://github.com/NixOS/nixpkgs/commit/d86fc14f8bb7ab11985d43c0129169c4129f56ba) dcgm: add static build option
* [`20b99b97`](https://github.com/NixOS/nixpkgs/commit/20b99b975998eb39a9aa8ca2cecd088db1901f23) fallout-ce: Fix broken game load/save due to case sensitive filesystem
* [`431c3afb`](https://github.com/NixOS/nixpkgs/commit/431c3afbf2893d478fed68e9930041e99b00cc8b) khronos-ocl-icd-loader: 2023.12.14 -> 2024.05.08
* [`a100f1be`](https://github.com/NixOS/nixpkgs/commit/a100f1beb40bd05dfd3cce7eaebdbb0e83832489) darwin.xcode: add 15.2, 15.3 and 15.4
* [`0725e430`](https://github.com/NixOS/nixpkgs/commit/0725e430e245ff3ca8a28b4131a030638b564921) maintainers: add uku3lig
* [`6e14231e`](https://github.com/NixOS/nixpkgs/commit/6e14231e83f1d6da831c0007b3d59c34cdb8ba1c) nixos/prowlarr: set HOME for the service
* [`d66d7578`](https://github.com/NixOS/nixpkgs/commit/d66d7578a7977894abc6a04d8e5d509ec4ebdc36) ardour: add to vst plugin search path
* [`f18149d2`](https://github.com/NixOS/nixpkgs/commit/f18149d25164294eda76f75d5cf90388194e3f2a) autocorrect: 2.9.0 -> 2.11.1
* [`3cd09aea`](https://github.com/NixOS/nixpkgs/commit/3cd09aea9144812a8c782975e1749f3d31ad9db3) switching to pkgs/by-name/ru/rutorrent/package.nix
* [`9abeee7a`](https://github.com/NixOS/nixpkgs/commit/9abeee7aab52788f4c06c3558835ed5f7bfaed47) fixed doc
* [`aca603a8`](https://github.com/NixOS/nixpkgs/commit/aca603a8e4dae1f448815dcd3ba48c27a2767a49) redshift: Fix missing "vidmode" support
* [`a58ad455`](https://github.com/NixOS/nixpkgs/commit/a58ad4550c0fae84bfbea96d5abdcbc23e2948da) cc-wrapper: fix guessing mainProgram
* [`97f90494`](https://github.com/NixOS/nixpkgs/commit/97f90494c8ced5f9902ee05ad281c9324f159f0c) gitlab-ci-local: add version test
* [`bb0c512b`](https://github.com/NixOS/nixpkgs/commit/bb0c512b5436e9ef6670ea753ec91b815487d161) nixos/vmware.guest: disable xf86inputvmmouse on aarch64
* [`4236969a`](https://github.com/NixOS/nixpkgs/commit/4236969a5f4d82aab502bbbbeebc3a39c11df876) zinit: add installation of doc files
* [`36590a42`](https://github.com/NixOS/nixpkgs/commit/36590a42fec5d406b470878e019eb5e9a54cc91d) dotnet: expose stage0 vmr derivations
* [`6a4c47dd`](https://github.com/NixOS/nixpkgs/commit/6a4c47ddbf5351f79ad0ea89b3e0bf2795c35e0f) python312Packages.pytest-playwright: 0.5.0 -> 0.5.1
* [`33f3b01c`](https://github.com/NixOS/nixpkgs/commit/33f3b01c76e781931a7111a739c33d81e4034d80) python312Packages.getmac: 0.9.4 -> 0.9.5
* [`08522864`](https://github.com/NixOS/nixpkgs/commit/08522864db0e9dbeca16316eb80fa0fc4e225e14) python312Packages.qdldl: 0.1.7.post3 -> 0.1.7.post4
* [`b1f795e6`](https://github.com/NixOS/nixpkgs/commit/b1f795e6a60a8d5addbc01b59073ca84141a58d7) python312Packages.ansible-pylibssh: 1.2.0.post4 -> 1.2.2
* [`44585d34`](https://github.com/NixOS/nixpkgs/commit/44585d346f88d53166048fa6a03c6e1cab69d57c) apacheHttpdPackages.mod_auth_mellon: 0.19.0 -> 0.19.1
* [`6b7ddbe0`](https://github.com/NixOS/nixpkgs/commit/6b7ddbe0233850e412b6fe586730c884351a231c) python312Packages.troposphere: 4.8.0 -> 4.8.1
* [`d4c04bb2`](https://github.com/NixOS/nixpkgs/commit/d4c04bb278fbdd7730a257a8e157756dcd50795e) python312Packages.ntc-templates: 5.1.0 -> 6.0.0
* [`0dfc820f`](https://github.com/NixOS/nixpkgs/commit/0dfc820f4a915a979ccb4ba420a8fcad48345170) e2fsprogs: build fuse2fs on darwin
* [`d85827e4`](https://github.com/NixOS/nixpkgs/commit/d85827e40ccc8a4c4e20f0c8fa7cf2f82591861a) sof-firmware: 2024.03 -> 2024.06
* [`3b3cf819`](https://github.com/NixOS/nixpkgs/commit/3b3cf8194cf2e8f0eca3c14e1699ae276d172c36) bundlerUpdateScript: force bundler to use ruby platform
* [`3acaae95`](https://github.com/NixOS/nixpkgs/commit/3acaae9509ef628c4f5a9357542a1326503784dc) bundlerUpdateScript: remove old gemset.nix and Gemfile.lock before updating
* [`2b99603e`](https://github.com/NixOS/nixpkgs/commit/2b99603e3188a4f2a84515bb92c9695c3879ecb9) opentelemetry-cpp: fix CMake target include dirs
* [`4257ab06`](https://github.com/NixOS/nixpkgs/commit/4257ab0696d02be3ead719fa7903ab374a74fcb2) boxed-cpp: 1.3.0 -> 1.4.2
* [`b33e220f`](https://github.com/NixOS/nixpkgs/commit/b33e220ff0e28d4f3698b3eccddf7df1bebb1c72) nixos/samba: add mount.cifs +s wrapper
* [`4575922a`](https://github.com/NixOS/nixpkgs/commit/4575922a1fece39afd9fd6430c84ed3f55cadad6) removed rtorrent group as fixed in [nixos/nixpkgs⁠#285299](https://togithub.com/nixos/nixpkgs/issues/285299)
* [`7c131562`](https://github.com/NixOS/nixpkgs/commit/7c1315628b7a93652583e373a40035ede8a0046b) fix exposeInsecureRPC2mount rtorrent group
* [`80ea66d5`](https://github.com/NixOS/nixpkgs/commit/80ea66d5870bb1e27522563921b920fb6b183d52) flat-remix-gnome: 20240526 -> 20240721
* [`d297a177`](https://github.com/NixOS/nixpkgs/commit/d297a17708f9379402be13d8e5a9ce01858595bb) erlang_27: 27.0 -> 27.0.1
* [`7bea0cc7`](https://github.com/NixOS/nixpkgs/commit/7bea0cc7215b98f48de946d27b347551dd6f2323) libtraceevent: 1.8.2 -> 1.8.3
* [`d34d5280`](https://github.com/NixOS/nixpkgs/commit/d34d5280d16cadd203685497c7a5f5aeb992fce1) python2Packages.wcwidth: fix build
* [`5ebb67ec`](https://github.com/NixOS/nixpkgs/commit/5ebb67ecc9c23648876c092224ea2f4702730bdc) python2Packages.wcwidth: @⁠bryango in maintainers
* [`215f4a36`](https://github.com/NixOS/nixpkgs/commit/215f4a36108d72926db3df916689bb61afc93753) super-productivity: 8.0.10 -> 9.0.5
* [`5a22d11c`](https://github.com/NixOS/nixpkgs/commit/5a22d11caca3c16d880e60a18f0f1176f30cfc02) mouse-actions-gui: init at 0.4.4
* [`1899cb0f`](https://github.com/NixOS/nixpkgs/commit/1899cb0f36b7db56ec57e43a69d126eab576f751) nixos/mouse-actions: add user service, allow different package
* [`3dd0bf16`](https://github.com/NixOS/nixpkgs/commit/3dd0bf16db0e5c7e10f01da147ddfb87eb3c155e) nomachine-client: 8.4.2 -> 8.13.1
* [`6a9525ea`](https://github.com/NixOS/nixpkgs/commit/6a9525eac08442f2d2b0fbea8ba55270e013104d) commafeed: 4.3.3 -> 4.6.0
* [`84f66910`](https://github.com/NixOS/nixpkgs/commit/84f6691006f744dd8825309df40e81300d2a9a85) python312Packages.pytest-playwright: refactor
* [`67e47411`](https://github.com/NixOS/nixpkgs/commit/67e4741194dfe6f6680c21ed028d40fdbdaa2806) python3Packages.discordpy: add getpsyched as maintainer
* [`4a938f04`](https://github.com/NixOS/nixpkgs/commit/4a938f0428699b46a421ee973ce996acd01abb1b) coc-clangd: migrate from nodePackages
* [`9377b40c`](https://github.com/NixOS/nixpkgs/commit/9377b40c509bddf7ad2c1ee7ae51fcf4a76501af) containerlab: move to by-name
* [`8d34d0e6`](https://github.com/NixOS/nixpkgs/commit/8d34d0e6a7b0a3fb7485828e9d01d14c65d48c2a) libtracefs: add updateScript
* [`619b92b2`](https://github.com/NixOS/nixpkgs/commit/619b92b24cc4c6efd5a2673637d2d3ce1d0f3c94) libtracefs: 1.7.0 -> 1.8.1
* [`bf0bf519`](https://github.com/NixOS/nixpkgs/commit/bf0bf51934fe869f6a3d5693de81d04fcdba00f0) libtracefs: remove unused argument
* [`7de6d04e`](https://github.com/NixOS/nixpkgs/commit/7de6d04e7ac629a118101667acae2b5e9fe20c9d) libtracefs: Add patch to compile all documentation
* [`aed48962`](https://github.com/NixOS/nixpkgs/commit/aed489629d565e4a6c87e8676a342ffc55012ab6) techmino: add update script
* [`ac33384e`](https://github.com/NixOS/nixpkgs/commit/ac33384e6ba5623f59c8ad509da604ca4a9e7def) libcutl: move to by-name
* [`e27beb11`](https://github.com/NixOS/nixpkgs/commit/e27beb11bb75d45689b449bf7bddc6b157a3f530) libcutl: modernize
* [`7021d076`](https://github.com/NixOS/nixpkgs/commit/7021d076502c5dd4402e3343d6a05dea64873c4c) libcutl: 1.10.0 -> 1.11.0
* [`e4bd479a`](https://github.com/NixOS/nixpkgs/commit/e4bd479a7f167ecf90459e9d97c4cc11563cc61f) libcutl: adopt
* [`252b66e1`](https://github.com/NixOS/nixpkgs/commit/252b66e1875476f6ce3eea413511f435f87a5abb) bmap-tools: Replace with bmaptool
* [`afd564a3`](https://github.com/NixOS/nixpkgs/commit/afd564a3e65554591d47456c3bd064421a2f8389) bmaptool: 3.6 -> 3.8.0
* [`613cb4e8`](https://github.com/NixOS/nixpkgs/commit/613cb4e8a5536dc0234d99c01dbd96c84a2e70b2) crystal-dock: init at 2.2
* [`39c64aad`](https://github.com/NixOS/nixpkgs/commit/39c64aad2115864d26f6fd892fd7afd8af7a0a89) nixosTests.sourcehut: regenerate expired PGP key
* [`3489a438`](https://github.com/NixOS/nixpkgs/commit/3489a438d48b73ae87dd1549e662cc188ea106da) ut1999: fix library search paths on x86_64-linux
* [`a14312cb`](https://github.com/NixOS/nixpkgs/commit/a14312cbedf13eabd6884cc73668dad7dfe5e251) nixos-rebuild: Fix repl with channels
* [`1ed6ea67`](https://github.com/NixOS/nixpkgs/commit/1ed6ea6793788f3b6dfa661926345922d93dc15d) sndio: 1.9.0 -> 1.10.0
* [`34503040`](https://github.com/NixOS/nixpkgs/commit/345030401cf8ae6c3ab181eeddfdd44aca66685a) maintainers: add tbwanderer
* [`ef9ba5e6`](https://github.com/NixOS/nixpkgs/commit/ef9ba5e62a0e0b4fc4ed02892e6d64da229f7a83) kubernetes-helmPlugins.helm-s3: 0.16.0 -> 0.16.2
* [`d390ce7d`](https://github.com/NixOS/nixpkgs/commit/d390ce7dfa453024d16ce47b998b3a4d38d158d2) llvmPackages_git.compiler-rt: disable building `ctx_profile` when build sanitizers are disabled
* [`0912bbf3`](https://github.com/NixOS/nixpkgs/commit/0912bbf38662d1209dd47eaea6ea939516652a2e) wlr-which-key: 0.1.3 -> 1.0.1
* [`9c984efb`](https://github.com/NixOS/nixpkgs/commit/9c984efbec2cbbc7ee0baf0c2b41a12cbe817915) techmino: 0.17.17 -> 0.17.21
* [`5b72cfbb`](https://github.com/NixOS/nixpkgs/commit/5b72cfbb3df20a2c7775e8b819452cb814ee423a) python3Packages.discord.py: refactor
* [`7dce6034`](https://github.com/NixOS/nixpkgs/commit/7dce60342b4795365d10c569676efb5fc8671d5d) smc-fuzzer: init at 0-unstable-2020-12-23
* [`5a04de28`](https://github.com/NixOS/nixpkgs/commit/5a04de283e3d3c00d4aabd8122678b0e46f3e4d2) python3Packages.ziafont: 0.8 -> 0.9
* [`b8ea3d2b`](https://github.com/NixOS/nixpkgs/commit/b8ea3d2bd61eaf309e6fa7902476fe89c99fceac) python3Packages.ziamath: 0.10 -> 0.11
* [`09850cda`](https://github.com/NixOS/nixpkgs/commit/09850cda27f7bd43647f63bf776556075883446f) av1an: vapoursynth support
* [`bd20a788`](https://github.com/NixOS/nixpkgs/commit/bd20a788d6443621635a5901b3ccbea8ed17989f) opendht: 3.1.11 -> 3.2.0
* [`c6ede05a`](https://github.com/NixOS/nixpkgs/commit/c6ede05a87d84a2a5a3589e2d75b0123faf17061) atlauncher: build from source
* [`bb9591b7`](https://github.com/NixOS/nixpkgs/commit/bb9591b7bc3461f37c5e60745e07d5976e0f2292) python3Packages.dbus-next: add missing preCheck/postCheck hooks
* [`f7dccea6`](https://github.com/NixOS/nixpkgs/commit/f7dccea6d9e4844fac7fa4aef7b5ed706c04e362) lanraragi: 0.9.10 -> 0.9.21
* [`0606bc57`](https://github.com/NixOS/nixpkgs/commit/0606bc57509649f9cb335e78a3a1ed9d7b0d9aac) termius: 8.12.9 -> 9.3.1
* [`bbd14a62`](https://github.com/NixOS/nixpkgs/commit/bbd14a62d092bdd32b2335fd63bc9d082fa9d65e) termius: fix desktop icon not found
* [`a7735432`](https://github.com/NixOS/nixpkgs/commit/a7735432d9c6e62636f6b3e7cb5e2789f11b79b7) termius: add update script
* [`c206b4a2`](https://github.com/NixOS/nixpkgs/commit/c206b4a28be2d18de12609f2f840bace1bf6ad57) sdrpp: Fix SoapySDR dependency
* [`d0bc8f58`](https://github.com/NixOS/nixpkgs/commit/d0bc8f58fdf82ea7c149e7b2936bfea0ef5f9267) syncthing-relay: 1.27.9 -> 1.27.10
* [`ba654492`](https://github.com/NixOS/nixpkgs/commit/ba654492e57f31043e49a4b60cbdc1231540bee1) sublime-merge-dev: 2095 -> 2099
* [`e03a930d`](https://github.com/NixOS/nixpkgs/commit/e03a930dc3747085123a1043b99995852b79b08f) appflowy: 0.6.6 -> 0.6.7
* [`c2db29dc`](https://github.com/NixOS/nixpkgs/commit/c2db29dcad48cefc8bb14f1c88b7266b53cb0b98) coqPackages.ITree: add 3.2.0 hash
* [`be244015`](https://github.com/NixOS/nixpkgs/commit/be244015d3915f59182d2eb4186f72591de7401a) coqPackages.ITree: 5.1.2 -> 5.2.0
* [`0b76fa46`](https://github.com/NixOS/nixpkgs/commit/0b76fa46e5f907345f2393ba88ab92f78d2f665c) shadowsocks-rust: 1.20.3 -> 1.20.4
* [`5beec28d`](https://github.com/NixOS/nixpkgs/commit/5beec28db8d7f54798de14ee61d6e3df85d28986) vfkit: init at 0.5.1
* [`eeed74ef`](https://github.com/NixOS/nixpkgs/commit/eeed74efe3330459c77313f220b10e4bfc55f45d) podman: add vfkit to PATH for darwin
* [`f6484997`](https://github.com/NixOS/nixpkgs/commit/f64849977d80eecb0eda825f75041bad7b86d297) magma: fix missing libgfortran.so dependency
* [`6435628c`](https://github.com/NixOS/nixpkgs/commit/6435628c2d5b4f5aac69c83d922da30c94b39742) termius: 9.3.1 -> 9.3.2
* [`9d984bee`](https://github.com/NixOS/nixpkgs/commit/9d984beeca298a1c27957d4d3b0fe8cec830fb33) SpiderOAK: update download url
* [`a51b013a`](https://github.com/NixOS/nixpkgs/commit/a51b013a10a86228686be70c43fea44e813ae227) streamlink: 6.8.3 -> 6.9.0
* [`81260312`](https://github.com/NixOS/nixpkgs/commit/812603129177b051617eb943b95085c568844723) esbuild: 0.23.0 -> 0.23.1
* [`67eb12c0`](https://github.com/NixOS/nixpkgs/commit/67eb12c0ed95b9cd8f98948d6c9bc7cdbf92660f) open-webui: Add `environmentFile` option
* [`3887cb35`](https://github.com/NixOS/nixpkgs/commit/3887cb35500376e54a65aa76f6448a336f3fd71b) appflowy: 0.6.7 -> 0.6.7.1
* [`8a849838`](https://github.com/NixOS/nixpkgs/commit/8a84983814466a9f1f13d509fc58441a70c2e1af) python312Packages.seabreeze: 2.6.0 -> 2.9.2
* [`77430d38`](https://github.com/NixOS/nixpkgs/commit/77430d388d03dea21c65813b4c48a346a9c7b79f) nixos/stargazer: add allowCgiUser to make cgi-user option work
* [`be1336d8`](https://github.com/NixOS/nixpkgs/commit/be1336d8b84ba89607268bedcd6f5ed0c4030c5c) nixos/stargazer: harden systemd service
* [`82e87efc`](https://github.com/NixOS/nixpkgs/commit/82e87efc98676844a975a906bb66c06b8a9b9a57) cpu-x: nixfmt
* [`d4436a5f`](https://github.com/NixOS/nixpkgs/commit/d4436a5fad20d3dec03fa536db8d0434b14044f9) cpu-x: avoid double-wrapping
* [`392c09c8`](https://github.com/NixOS/nixpkgs/commit/392c09c842886831f1456ebac4623e27c03988cc) cpu-x: fix gtk support
* [`6a23789f`](https://github.com/NixOS/nixpkgs/commit/6a23789fdac6a7579c2b0680791b3624e67a8e38) cpu-x: modernise
* [`9cd5d118`](https://github.com/NixOS/nixpkgs/commit/9cd5d1183c001d9766b4189d1ccc370efd742d49) cpu-x: add version test
* [`62e7bdb1`](https://github.com/NixOS/nixpkgs/commit/62e7bdb1dcdc3286a124e863e2399c43cd20bb5c) gate: 0.39.2 -> 0.39.3
* [`775776cd`](https://github.com/NixOS/nixpkgs/commit/775776cd9b0ee2eb326d7d3ddf182a5718e5b141) python312Packages.ignite: refactor
* [`7e0e927e`](https://github.com/NixOS/nixpkgs/commit/7e0e927e858c24d1b9a868e066dc0b93c690771c) backintime: use --replace-fail and set mainProgram
* [`c85528c1`](https://github.com/NixOS/nixpkgs/commit/c85528c1acf698fd5edd5f7aa4349a78748b0a85) backintime: 1.4.3 -> 1.5.2
* [`162dd80f`](https://github.com/NixOS/nixpkgs/commit/162dd80fe94e6fbce85e351f8a1a14b74d8b8bc7) backintime: fix backintime-askpass
* [`13dc2d79`](https://github.com/NixOS/nixpkgs/commit/13dc2d792d5dc380cd47fe3bd9fddab1198d7c7b) rPackages: CRAN and BioC update
* [`cebbbf33`](https://github.com/NixOS/nixpkgs/commit/cebbbf33c4a4bb90932f7f1fae0fa12ece9b95d2) azure-static-sites-client: 1.0.026911 -> 19449a00c0269fefc8f29a6d01801c4b19308181
* [`01e04f8d`](https://github.com/NixOS/nixpkgs/commit/01e04f8d812426639c2be5d9d5ce7f5a0ab8b63c) bees: flatten derivation
* [`99e93489`](https://github.com/NixOS/nixpkgs/commit/99e93489ae27439e23004b2f6ec7f560f4b6576d) bees: substituteAll → makeWrapper
* [`07494f99`](https://github.com/NixOS/nixpkgs/commit/07494f99f6093a65a9110896151407b89a7df996) haskellPackages: stackage LTS 22.31 -> LTS 22.33
* [`299d0e8c`](https://github.com/NixOS/nixpkgs/commit/299d0e8ce55897cf14d128cea2f3d07570ea20ba) all-cabal-hashes: 2024-07-31T18:11:52Z -> 2024-08-19T17:17:03Z
* [`fbb895e2`](https://github.com/NixOS/nixpkgs/commit/fbb895e278eb1cefee09bb67d078c245f217057b) haskellPackages: regenerate package set based on current config
* [`396211ac`](https://github.com/NixOS/nixpkgs/commit/396211acc0c7379bc3e59e65879febf15e2fdf0d) maintainers: add xeals
* [`d801ea08`](https://github.com/NixOS/nixpkgs/commit/d801ea089d4a4467c2593069e3ccdce26edc3d1c) python3Packages.numpy-groupies: refactor
* [`fb3b6cd7`](https://github.com/NixOS/nixpkgs/commit/fb3b6cd77b202cad1042876671705736851217f7) update caddy service
* [`cd833e70`](https://github.com/NixOS/nixpkgs/commit/cd833e70dc45e5117fa751d77a1a7dbf04b176f2) hextazy: 0.4 -> 0.6
* [`29125560`](https://github.com/NixOS/nixpkgs/commit/291255600b608b470f6f6e2fd966bf5126b090ed) agdaPackages._1lab: unstable-2024-03-07 -> unstable-2024-08-05
* [`1816263f`](https://github.com/NixOS/nixpkgs/commit/1816263f05c550874f22dae8ce996f1815f1abca) haskellPackages.Cabal_3_{10_3,12_1}_0: use process 1.6.22.0
* [`9aacff10`](https://github.com/NixOS/nixpkgs/commit/9aacff10553b648240b25c203875cdd7e6c7cfe3) haskellPackages.feedback: use safe-coloured-text-layout 0.2.0.1
* [`88d7f8a4`](https://github.com/NixOS/nixpkgs/commit/88d7f8a482c45cec110f6310337f5e35a083d1de) gallia: 1.8.0 -> 1.9.0
* [`a750f6c5`](https://github.com/NixOS/nixpkgs/commit/a750f6c5886bcd1b838c1d82ea1d54a7242166b4) changelog-d: 1.0 -> 1.0.1
* [`9c79955b`](https://github.com/NixOS/nixpkgs/commit/9c79955b9fb55f28f0064d726fb372e98e4428ea) shortcat: 0.11.0 -> 0.11.4
* [`36de652d`](https://github.com/NixOS/nixpkgs/commit/36de652d39c11fe4fe70024c38ed1b13a2309941) postcss-cli: fix darwin hashes
* [`7ce990f1`](https://github.com/NixOS/nixpkgs/commit/7ce990f1d22cbe89f71155026e26f758b3f18499) haskellPackages.ffmpeg-light: remove override
* [`5cce43be`](https://github.com/NixOS/nixpkgs/commit/5cce43be8f9e280261dc7c7dacb5201a2c6de9e4) cloudflare-warp: 2024.4.133 -> 2024.6.497
* [`0bd853aa`](https://github.com/NixOS/nixpkgs/commit/0bd853aab8d458590c98f02d9f3e8fb57a97a49f) nixos/tests/vscode-remote-ssh: fix ocr, add timeout
* [`6acc9bef`](https://github.com/NixOS/nixpkgs/commit/6acc9befeffa6bbef01e2d8e3681e1506702c84d) nixos/tests/atop: fix version regex, add timeout
* [`bddd01e4`](https://github.com/NixOS/nixpkgs/commit/bddd01e49fd4745b86a28e38d5aa7ff982a016e0) nixos/tests/pleroma: fix timeout
* [`4fde325b`](https://github.com/NixOS/nixpkgs/commit/4fde325bdb1820f69028117574991d5be604dda2) nimlangserver: 1.2.0 -> 1.4.0
* [`0aa968f1`](https://github.com/NixOS/nixpkgs/commit/0aa968f1b699bcd5e92651f90743b79238987ee3) haskellPackages.entropy: build with js backend
* [`58d3b54d`](https://github.com/NixOS/nixpkgs/commit/58d3b54da2174108a80b3f3d484d2df5a7381e9d) rancher: 2.7.7 → 2.9.0
* [`0ff655ba`](https://github.com/NixOS/nixpkgs/commit/0ff655ba54ec608cd236b07f7eec6e313353d098) pifpaf: 3.1.5 -> 3.2.1
* [`bf1bd6d4`](https://github.com/NixOS/nixpkgs/commit/bf1bd6d4e737a07e89911ba6d52e168cb0f279cd) agdaPackages.standard-library: 2.1 -> 2.1.1-rc2
* [`c28db0ac`](https://github.com/NixOS/nixpkgs/commit/c28db0ac88719171d22d46dd8269a10c00914adf) maintainers: add BarrOff
* [`a62ec9ed`](https://github.com/NixOS/nixpkgs/commit/a62ec9ed4870270039364f11d3a9fb94a4b7f775) ypbind-mt: init at 2.7.2
* [`e9d0064b`](https://github.com/NixOS/nixpkgs/commit/e9d0064b02c2d03b95ad73c1387f3d2a2c2ba1b1) murex: make package a shellPackage
* [`4af7798d`](https://github.com/NixOS/nixpkgs/commit/4af7798d407302085fcca331ff01160997741568) iroh: 0.21.0 -> 0.23.0
* [`c7b97f15`](https://github.com/NixOS/nixpkgs/commit/c7b97f1538b2b5c6f88371a516fba7ab594faec7) gersemi: init at 0.15.1
* [`8ba6d915`](https://github.com/NixOS/nixpkgs/commit/8ba6d9159fa00a14d9b464e4f8aeac99568625f4) python3Packages.sqids: 0.4.1 -> 0.5.0
* [`606a1663`](https://github.com/NixOS/nixpkgs/commit/606a1663e55845c8c5d95d18644c15bd904a26b2) agdaPackages.agda-prelude: unstable-2023-10-04 -> unstable-2024-08-22
* [`409627b3`](https://github.com/NixOS/nixpkgs/commit/409627b390ce390f2a9859c0ca2f7a78c81944e5) erg: 0.6.41 -> 0.6.42
* [`3362afae`](https://github.com/NixOS/nixpkgs/commit/3362afaee0d57477b147fc438cf399980ac3ef9b) libkazv: init at 0.7.0
* [`cd79c54b`](https://github.com/NixOS/nixpkgs/commit/cd79c54b93e96280f63cb139c6ff3ccea357f22b) kazv: init at 0.5.0
* [`ed1fbb69`](https://github.com/NixOS/nixpkgs/commit/ed1fbb695abbe6ccf4adaa4773f3623dda52a265) python3Packages.array-api-compat: refactor
* [`79872e05`](https://github.com/NixOS/nixpkgs/commit/79872e05394ca417d45ab1cd75eed4e2e09101d9) haskellPackages.opencv{,-extra}: remove overrides
* [`14fa0288`](https://github.com/NixOS/nixpkgs/commit/14fa0288267a95c9f1978506fa43c959a15cb165) mlc: bump src
* [`089e5165`](https://github.com/NixOS/nixpkgs/commit/089e516511b68238010272ad15fff42c4b3c6a05) opensplatWithCuda: 1.1.3 -> 1.1.4
* [`05b20e02`](https://github.com/NixOS/nixpkgs/commit/05b20e0227aa32e8f3f37a57d133c2e9e07168b3) clipqr: 1.2.0 -> 1.3.0
* [`1c379e3a`](https://github.com/NixOS/nixpkgs/commit/1c379e3a57241166b103c5c886104c2316840b7c) buildDotnetModule: add `testFilters` arg
* [`a177c637`](https://github.com/NixOS/nixpkgs/commit/a177c637b91c7d40531327a04dfdc3e1035d293b) nexusmods-app: use `testFilters` & `disabledTests` args
* [`3a142756`](https://github.com/NixOS/nixpkgs/commit/3a1427563a4da776d2e7e4580cc265effc4fd81e) nwjs-ffmpeg-prebuilt: 0.90.0 -> 0.91.0
* [`3971d8f9`](https://github.com/NixOS/nixpkgs/commit/3971d8f97c98d697868cf6525c339e7ec6ca2bcd) haskell.ghc910: overrides for cabal-install and haskell-language-server.
* [`dd2b338d`](https://github.com/NixOS/nixpkgs/commit/dd2b338d7a5e24f18c5a2d59bf4ccf7f3084fa5e) dezoomify-rs: fix build on Darwin
* [`3c9d0c6c`](https://github.com/NixOS/nixpkgs/commit/3c9d0c6cbfb811d9bc868b7ee36b61f2377a1a08) containerlab: 0.56.0 -> 0.57.0
* [`5c4430d9`](https://github.com/NixOS/nixpkgs/commit/5c4430d9afb8f4a98a91fcafd4e7b90421e813fa) Override Cabal for cabal-install < 9.10.2.
* [`d956ce06`](https://github.com/NixOS/nixpkgs/commit/d956ce0645a6ba98df1500d3c67c9a564729988d) bwbasic: fixed darwin build
* [`9c9405d8`](https://github.com/NixOS/nixpkgs/commit/9c9405d81a6aa7c927b540c26fd8b69c3ebcd5ec) dbeaver-bin: add webkitgkt and glib-networking for webbrowser support
* [`bb696818`](https://github.com/NixOS/nixpkgs/commit/bb696818ef375fe6ce13c2af2b02a5fe884c6f16) cosmic-icons: 0-unstable-2024-08-04 -> 1.0.0-alpha.1-unstable2024-08-06
* [`5b910ae5`](https://github.com/NixOS/nixpkgs/commit/5b910ae5391ddd23cf2897871963d1d31f24cc89) smatch: clang build fix
* [`ac2b5954`](https://github.com/NixOS/nixpkgs/commit/ac2b5954c35a6b7a429d518cc8a906158532ee9d) ntfy-alertmanager: init at 0.3.0
* [`656a7235`](https://github.com/NixOS/nixpkgs/commit/656a7235d67be089c3e14bed737d9040da5b69b8) vimPlugins.ddc-vim: init at 2024-02-09
* [`14cefb10`](https://github.com/NixOS/nixpkgs/commit/14cefb10280a5c1c7d43fa39431e20bc622a0d58) vimPlugins.ddc-source-lsp: init at 2024-01-15
* [`64e3bc78`](https://github.com/NixOS/nixpkgs/commit/64e3bc78e9fee96f5e00ba48541946c95254fe45) vimPlugins.ddc-filter-matcher_head: init at 2023-12-25
* [`fde6c037`](https://github.com/NixOS/nixpkgs/commit/fde6c03762f7362fd28068e540c8cebf2549a183) vimPlugins.ddc-filter-sorter_rank: init at 2023-09-11
* [`ebdf5e91`](https://github.com/NixOS/nixpkgs/commit/ebdf5e9126f13f67a8fc9e48a6b42627ec2db109) vimPlugins.ddc-ui-native: init at 2024-01-10
* [`067065d5`](https://github.com/NixOS/nixpkgs/commit/067065d5fb56b0e5aff196d9506e7149d5dc7c6f) vimPlugins.ddc-ui-pum: init at 2023-10-07
* [`31958e50`](https://github.com/NixOS/nixpkgs/commit/31958e50af05fd3febd8249c0ef394f541917726) vimPlugins: update ddc-* plugins
* [`c7834641`](https://github.com/NixOS/nixpkgs/commit/c783464146e8adae6624840ac61d0fb8a94af3d1) filebot: migrate to pkgs/by-name
* [`59355062`](https://github.com/NixOS/nixpkgs/commit/59355062302530b787b3af49595052af00c7ab18) filebot: reformat with nixfmt-rfc-style
* [`12dda437`](https://github.com/NixOS/nixpkgs/commit/12dda437e27ff620546760f3dfba7e29159f113f) filebot: 5.1.4 -> 5.1.5
* [`515d3439`](https://github.com/NixOS/nixpkgs/commit/515d3439b3a8369241d62a7952e67d85159644c4) pixelorama: 1.0.1 -> 1.0.2
* [`4271b753`](https://github.com/NixOS/nixpkgs/commit/4271b753b2c65d9e943ff3a1c9b5fc826f4750f3) pixelorama: add aarch64-linux support
* [`ae09f9d3`](https://github.com/NixOS/nixpkgs/commit/ae09f9d3c393aa50619021c98037e79b2b813320) rPackages.rlas: fix build
* [`b1106158`](https://github.com/NixOS/nixpkgs/commit/b11061581dba23674d65789b737816cc53017d38) apple-cursor: 2.0.0 -> 2.0.1
* [`a20c12ad`](https://github.com/NixOS/nixpkgs/commit/a20c12ad89b45e3585fcbfe1eed767cf252c0766) maintainers: add dxwil
* [`05440aa7`](https://github.com/NixOS/nixpkgs/commit/05440aa73b5add33e2871a63269d42fe2a43b09d) zulip: 5.11.0 → 5.11.1
* [`e96dc9af`](https://github.com/NixOS/nixpkgs/commit/e96dc9afa16a8d2e84b0078e4bde752999e1d550) maintainers: add qaidvoid
* [`d15cef1e`](https://github.com/NixOS/nixpkgs/commit/d15cef1e2f8578936493798e2af5cda42972ede0) dropbox: 185.4.6054 -> 206.3.6386
* [`af1a940b`](https://github.com/NixOS/nixpkgs/commit/af1a940b2734d3ee638ca262c7d818560709f5d6) k8s-manifest-sigstore: init at 0.5.4
* [`46da6473`](https://github.com/NixOS/nixpkgs/commit/46da6473780f2b3914a5ad258be2595dd3451ef9) playwright: apply nixfmt
* [`2c5d3195`](https://github.com/NixOS/nixpkgs/commit/2c5d31957364ab18abcd0ac7b51a09a66401f8a2) tinygo: repair hydra build
* [`a6dd104e`](https://github.com/NixOS/nixpkgs/commit/a6dd104efedc4ee9568136b5d0a8435e2e3de941) flat-remix-gtk: 20220627 -> 20240730
* [`03faf8f3`](https://github.com/NixOS/nixpkgs/commit/03faf8f3bbd781438b0554ece1aca83b7adec782) nixos/version: validate system.stateVersion
* [`9d8b60c6`](https://github.com/NixOS/nixpkgs/commit/9d8b60c697b7245d477984ab06f1a8943b65232a) schemaspy: add passthru.updateScript
* [`4519015f`](https://github.com/NixOS/nixpkgs/commit/4519015fd06f5c2dda1a7bfe0b632fc8f5a9656b) playwright: build from source
* [`14e3e952`](https://github.com/NixOS/nixpkgs/commit/14e3e9520c4a525a52389b1c6a7f74fb66245a74) nexus: 3.69.0-02 -> 3.70.1-02
* [`eed465da`](https://github.com/NixOS/nixpkgs/commit/eed465da4251973c72cd0bb2aa9fddfec86704c7) schemaspy: 6.1.0-SNAPSHOT -> 6.2.4
* [`54eab359`](https://github.com/NixOS/nixpkgs/commit/54eab3591479cafb28f17bf9abe99ce964578b0c) schemaspy: add anthonyroussel to maintainers
* [`79eeb500`](https://github.com/NixOS/nixpkgs/commit/79eeb500d69231144d5ac3a65ce2c808e74cae0a) schemaspy: reformat and migrate to pkgs/by-name
* [`079282d0`](https://github.com/NixOS/nixpkgs/commit/079282d04a8fd36c5f49537f7f0148f3ba7385b9) git-cliff: 2.4.0 -> 2.5.0
* [`e1cbc500`](https://github.com/NixOS/nixpkgs/commit/e1cbc50048ce455d260556bfaf3e9f0d43be6a20) tpnote: 1.24.7 -> 1.24.8
* [`b2978adf`](https://github.com/NixOS/nixpkgs/commit/b2978adff4486e5ec2d4fa34fb650a8b95f71dc6) quisk: 4.2.35 -> 4.2.37
* [`35e5fab9`](https://github.com/NixOS/nixpkgs/commit/35e5fab91dbcd98df3d319e9ba1d88807285a2e8) lxtask: fetch from the github repository
* [`d881cf7d`](https://github.com/NixOS/nixpkgs/commit/d881cf7d62ded69b494df997b522e4801dccee12) lxtask: add update script
* [`576d12cf`](https://github.com/NixOS/nixpkgs/commit/576d12cf79ddde36df6fcc338f7d670bb99a4617) lxtask: 0.1.10 -> 0.1.11
* [`1b37b276`](https://github.com/NixOS/nixpkgs/commit/1b37b276b52972c015ef7f10c758870ad72c7dba) swayimg: 2.3 -> 3.2
* [`bf28f849`](https://github.com/NixOS/nixpkgs/commit/bf28f8492d3f02f1d71ed85181c0356763d62a19) moon: 1.27.6 -> 1.27.10
* [`37ee699f`](https://github.com/NixOS/nixpkgs/commit/37ee699f5659b5bd65519522485ca9eb387e3df2) glow: 1.5.1 -> 2.0.0
* [`9b89ce40`](https://github.com/NixOS/nixpkgs/commit/9b89ce40e594d080d46bce8c4e473708a60b42aa) oama: add to haskell-updates Hydra jobset
* [`fd7cfbba`](https://github.com/NixOS/nixpkgs/commit/fd7cfbba484950f9ad8bf854a028ca5e439fc72d) cpupower-gui: fix crash when freq is set
* [`6022147e`](https://github.com/NixOS/nixpkgs/commit/6022147eefb8265c6a4ca3f5b1fb139f353089a2) stirling-pdf: 0.26.1 -> 0.28.3
* [`290b0fa1`](https://github.com/NixOS/nixpkgs/commit/290b0fa1f624db6965b0f20d9db3cb2b57ebbaa5) stirling-pdf: add updateScript
* [`787b1ebf`](https://github.com/NixOS/nixpkgs/commit/787b1ebf040be1962f93deb5b324547bcadc5e92) swiftshader: fix build on hydra
* [`3501da99`](https://github.com/NixOS/nixpkgs/commit/3501da99986c8cd1ba2342c49cae9bb81b70e8e7) srgn: 0.12.0 -> 0.13.1
* [`c575666c`](https://github.com/NixOS/nixpkgs/commit/c575666ce42f3d5c33608cade1c567b726ec2071) facter: 4.6.1 -> 4.8.0
* [`ef7577e0`](https://github.com/NixOS/nixpkgs/commit/ef7577e015eb242a71ab19742d8e90e356f89046) puppet-bolt: 3.28.0 -> 3.30.0
* [`0a8012c8`](https://github.com/NixOS/nixpkgs/commit/0a8012c84abb9a73db59c54a73273247d8e1006b) r10k: 4.0.1 -> 4.1.0
* [`f08553d2`](https://github.com/NixOS/nixpkgs/commit/f08553d2f90e1aa80408579afa52ad8ab04bcb83) jetty_11: 11.0.22 -> 11.0.23
* [`b409a1c3`](https://github.com/NixOS/nixpkgs/commit/b409a1c3bd334bb8940e024a611abe1f823ae9c7) jetty_12: 12.0.11 -> 12.0.12
* [`7de56ac5`](https://github.com/NixOS/nixpkgs/commit/7de56ac5c4422700bf2322a492323cea8c4a3a70) x16: substitute --replace with --replace-fail
* [`948c196e`](https://github.com/NixOS/nixpkgs/commit/948c196ec7558895553be4b7f69d8043dc6d3124) qqwing: fix cross compilation and pkgconfig generation
* [`0fca1292`](https://github.com/NixOS/nixpkgs/commit/0fca1292718eeba3c1d4a8ada6f98e3069063653) amazon-ssm-agent: substitute --replace with --replace-fail
* [`85852fa6`](https://github.com/NixOS/nixpkgs/commit/85852fa6617abe4d107cbcef72183f032cf3c35d) apfsprogs: substitute --replace with --replace-fail
* [`ecf6cfcb`](https://github.com/NixOS/nixpkgs/commit/ecf6cfcbc188e20a8461c9498a20d1b7811f5be6) apt-offline: substitute --replace with --replace-fail
* [`31ae1b3e`](https://github.com/NixOS/nixpkgs/commit/31ae1b3e04aa47e7be889b5dad75ada5c4e52d3e) armitage: substitute --replace with --replace-fail
* [`f4c63df3`](https://github.com/NixOS/nixpkgs/commit/f4c63df33c8e8e7ca5df9a6b1185400a1fcb0c8b) backgroundremover: substitute --replace with --replace-fail
* [`eaff6e79`](https://github.com/NixOS/nixpkgs/commit/eaff6e79d4131635b4b1e500fc135b044c418cd3) coc-pyright: migrate from nodePackages
* [`bfa81186`](https://github.com/NixOS/nixpkgs/commit/bfa811869d389f13b8d2ba0c72322bd29f962998) ibus-engines.table: 1.17.6 -> 1.17.7
* [`693f9402`](https://github.com/NixOS/nixpkgs/commit/693f9402ddbc721d09cf258afe54781f693dda5c) aerc: import a patch fix a bug with gpg signed messages
* [`8125b9f8`](https://github.com/NixOS/nixpkgs/commit/8125b9f8dceb06325916cfc4cc187c98d1ec67ab) mqttx: 1.9.9 -> 1.10.1
* [`1bce2914`](https://github.com/NixOS/nixpkgs/commit/1bce2914b3a814febcf9089fe88cfa11203709a1) licenses: Update databricks metadata
* [`c8e37dbf`](https://github.com/NixOS/nixpkgs/commit/c8e37dbf521f57e6273d4d1ff93537cdaa3878a6) databricks-cli: init at 0.227.0
* [`2e36dcbc`](https://github.com/NixOS/nixpkgs/commit/2e36dcbcadad1f722eb74ebd777f56ff291a13b9) jd-diff-patch: 1.7.1 -> 1.9.1
* [`134eef34`](https://github.com/NixOS/nixpkgs/commit/134eef34ebd558ac6808b6c3a8084317c1c20849) haskellPackages.weeder: restrict to < 2.9
* [`ad56f28d`](https://github.com/NixOS/nixpkgs/commit/ad56f28d301073ecf5a5948555176fb9b4f1e22e) emptty: 0.12.1 -> 0.13.0
* [`9496aef1`](https://github.com/NixOS/nixpkgs/commit/9496aef133a55ecb9a6d9464e16e43234291926a) eiquadprog: init at v1.2.9
* [`9d53c1f8`](https://github.com/NixOS/nixpkgs/commit/9d53c1f86b2fb2569acd571cc968c5dd79ab9f15) libphonenumber: 8.13.43 -> 8.13.44
* [`308b6c6e`](https://github.com/NixOS/nixpkgs/commit/308b6c6e8294b66922596ef4e436e5f0a9abdfcf) gvproxy: 0.7.4 -> 0.7.5
* [`0a977497`](https://github.com/NixOS/nixpkgs/commit/0a9774970be2429ea86c9c778230ebacf3a3f597) fragments: 3.0.0 -> 3.0.1
* [`62c8d162`](https://github.com/NixOS/nixpkgs/commit/62c8d16271afe3ede9e13a3c48750c5234ae8f5a) maintainers: add zebradil
* [`67cb78ed`](https://github.com/NixOS/nixpkgs/commit/67cb78ed56b0ebe532c89034330154e7268bc222) portfolio: 0.70.3 -> 0.70.4
* [`d8c52fa2`](https://github.com/NixOS/nixpkgs/commit/d8c52fa28235936faf257f65d980b2757dd52b42) haskellPackages.shakespeare: 2.1.1 -> 2.1.0.1
* [`177ccd9b`](https://github.com/NixOS/nixpkgs/commit/177ccd9be746acc9daee7779d6a51bac7e8a63f2) git-annex: update sha256 for 10.20240808
* [`8894a160`](https://github.com/NixOS/nixpkgs/commit/8894a160fe9b855b8d3a15981e24cd1bec49e232) haskellPackages.eventlog2html: drop upstreamed patches
* [`c780b33c`](https://github.com/NixOS/nixpkgs/commit/c780b33c0f955fc64ab697d2246db7121cc60702) python312Packages.sphinxcontrib-confluencebuilder: 2.6.1 -> 2.7.1
* [`e6730d69`](https://github.com/NixOS/nixpkgs/commit/e6730d699e9b729d729fc9f77db2ff1e9c10d3f2) ani-cli: 4.8 -> 4.9
* [`ee544db3`](https://github.com/NixOS/nixpkgs/commit/ee544db326ce1355f4807485a19f9265a8ed39a3) temporal-cli: tctl-next: 0.13.1 -> 1.0.0
* [`2994633e`](https://github.com/NixOS/nixpkgs/commit/2994633e8b4434e5d347b9ef2844857337a460fa) indilib: 2.0.8 -> 2.0.9
* [`e441308c`](https://github.com/NixOS/nixpkgs/commit/e441308cac22af98cf6fdd9c275b551268008579) indi-full: 2.0.8 -> 2.0.9, small cleanup
* [`4fd353c0`](https://github.com/NixOS/nixpkgs/commit/4fd353c08facc5b04a883a37c63e0de88e1db4eb) yarg: init at 0.12.6
* [`c72bd64b`](https://github.com/NixOS/nixpkgs/commit/c72bd64bb02f17677453fbf4a076235be13c890d) cloudflare-dynamic-dns: init at 4.3.0
* [`b21149a5`](https://github.com/NixOS/nixpkgs/commit/b21149a547a04e53c969c078862a590b3cb19e2e) python312Packages.parse-type: 0.6.2 -> 0.6.3
* [`1d5acdc4`](https://github.com/NixOS/nixpkgs/commit/1d5acdc4f4268607ced81c111a5383b9f38003ac) python312Packages.pefile: 2023.2.7 -> 2024.8.26
* [`689d25d9`](https://github.com/NixOS/nixpkgs/commit/689d25d9638a45644ba5ad24e075a6e39e293ca4) osqp-eigen: init at 0.8.1
* [`396d1f10`](https://github.com/NixOS/nixpkgs/commit/396d1f10e642cafbdff950321dcb0b817a71b873) tsid: init at 1.7.1
* [`8b7eaaef`](https://github.com/NixOS/nixpkgs/commit/8b7eaaefd0ce4ce7eb7849afcbc7237b48699f95) simdjson: 3.10.0 -> 3.10.1
* [`46de9050`](https://github.com/NixOS/nixpkgs/commit/46de905013997861f3477e3a4e887ac8cb409ac1) containerd: 1.7.20 -> 1.7.21
* [`5ab41fbc`](https://github.com/NixOS/nixpkgs/commit/5ab41fbc81f9e154cdc36def5420e079e89b72c8) unciv: 4.13.0-patch1 -> 4.13.2-redo
* [`ea13ffa8`](https://github.com/NixOS/nixpkgs/commit/ea13ffa819b733d6cadcd14ffdeb10883680c7b4) python312Packages.univers: 30.12.0 -> 30.12.1
* [`045f6925`](https://github.com/NixOS/nixpkgs/commit/045f6925423ff98ce43c669fc8145db3e5cdcf97) lms: 3.51.1 -> 3.56.0
* [`29bc58a3`](https://github.com/NixOS/nixpkgs/commit/29bc58a302a9e50b91adb3207a7f0cabdc2fdb92) vencord: refactor to use pnpm.fetchDeps
* [`09e917c6`](https://github.com/NixOS/nixpkgs/commit/09e917c6d465244db41b6f245fd28654bace4c96) vencord: reformat using nixfmt
* [`1401c610`](https://github.com/NixOS/nixpkgs/commit/1401c61030765c9ee5ddd9e6eedbf81bd16ac041) vencord: 1.9.5 -> 1.9.7
* [`4e205841`](https://github.com/NixOS/nixpkgs/commit/4e205841fbd52e5a496538f644ec5527f77e5225) vencord: fix installPhase hooks
* [`a76791c8`](https://github.com/NixOS/nixpkgs/commit/a76791c8b30cea5f0879c27bea4f0d51294005ef) vencord: sort inputs
* [`9e7fcb7e`](https://github.com/NixOS/nixpkgs/commit/9e7fcb7e19f09729ca790f4f1431c6d9c4f4d95e) treesheets: 0-unstable-2024-06-29 -> 0-unstable-2024-08-25
* [`877d23c6`](https://github.com/NixOS/nixpkgs/commit/877d23c6b2fa0c29e1c22a5e064cefb886457b34) vencord: fix update script
* [`43092196`](https://github.com/NixOS/nixpkgs/commit/4309219691d2f14934238cc9b31e368a8b7e74e2) vencord: 1.9.7 -> 1.9.8
* [`6b0fbdd0`](https://github.com/NixOS/nixpkgs/commit/6b0fbdd01c541a6cb5b5515a00a8e1e44b29e4e8) python312Packages.xdoctest: 1.1.6 -> 1.2.0
* [`35409608`](https://github.com/NixOS/nixpkgs/commit/35409608ea3dd64e7cb4abecee8ebf8b5167cfbb) google-amber: 2023-09-02 -> 2024-08-21
* [`7c00ac89`](https://github.com/NixOS/nixpkgs/commit/7c00ac89dceca60c0441d75b868c2813a7ef3133) python312Packages.nbdev: 2.3.27 -> 2.3.28
* [`b0a59de1`](https://github.com/NixOS/nixpkgs/commit/b0a59de1746ada067f545abe733a2d973d75b68b) rgp: 2.1 -> 2.2
* [`6b407a0f`](https://github.com/NixOS/nixpkgs/commit/6b407a0fba5118049b527579cc6f9bcef7057a7f) python312Packages.pulumi-aws: 6.49.1 -> 6.50.1
* [`8f082113`](https://github.com/NixOS/nixpkgs/commit/8f082113a8b8f1301c2313614cd0c4a36042e970) changedetection-io: add python dependency elementpath
* [`f001cee1`](https://github.com/NixOS/nixpkgs/commit/f001cee1cfc91f013daa6dc50bebfd656f3ef285) python312Packages.bucketstore: fix build and update
* [`3b7343c7`](https://github.com/NixOS/nixpkgs/commit/3b7343c7e74181ef2028c7396eba64b315c7c3f2) python312Packages.rns: unvendor esptool
* [`8e9857bb`](https://github.com/NixOS/nixpkgs/commit/8e9857bb7ee2a519d12799fafa4a3459c5d620f7) python312Packages.pysqueezebox: 0.7.1 -> 0.8.1
* [`c9b90a1d`](https://github.com/NixOS/nixpkgs/commit/c9b90a1de3729bb07c40c5212a297cbe5de070ee) python312Packages.stamina: 24.2.0 -> 24.3.0
* [`4a7b3001`](https://github.com/NixOS/nixpkgs/commit/4a7b3001ab418d5bab8e7dadf5ba8ddc36469535) atlas: move to by-name
* [`23cd1324`](https://github.com/NixOS/nixpkgs/commit/23cd1324dcd384b245ec6107844a646433f0f5a7) pcsx2-bin: 2.1.17 -> 2.1.116
* [`ebaf3f00`](https://github.com/NixOS/nixpkgs/commit/ebaf3f00acf638862db61cf1852eddf53e476adb) pcsx2-bin: simplified updateScript
* [`230fed8a`](https://github.com/NixOS/nixpkgs/commit/230fed8ac54b6f7a385361777f90d26f01c639be) openblas: Enable s390x-linux
* [`80c970d6`](https://github.com/NixOS/nixpkgs/commit/80c970d69db621a1094e61aea122adcd53a74a76) nomacs: support more formats
* [`78e1247f`](https://github.com/NixOS/nixpkgs/commit/78e1247f1bcd3740f742adc5ced9380586c9deb7) cosmic-bg: subtituteInPlace use --replace-fail
* [`5a8609b1`](https://github.com/NixOS/nixpkgs/commit/5a8609b1c97115bec86d5d9682a8bc344225c15c) python312Packages.linode-api: fix dependencies and tests
* [`a28e50c4`](https://github.com/NixOS/nixpkgs/commit/a28e50c46a170a777d168a889d1f4bd132db8c0b) libxnd: unstable-2019-08-01 -> 0.2.0-unstable-2023-11-17
* [`933bc04d`](https://github.com/NixOS/nixpkgs/commit/933bc04d7a4179755e00ac7148af8fa241729e6a) python311Packages.xnd: remove patch
* [`8e567281`](https://github.com/NixOS/nixpkgs/commit/8e567281727dbc90a1d844554a90f55b7ba84160) zoom-us: 6.1.10.1400 -> 6.1.11.1545
* [`7ba2551d`](https://github.com/NixOS/nixpkgs/commit/7ba2551d0f5ffc3053f61338d5e21a98972732d7) python312Packages.oci: 2.128.2 -> 2.133.0
* [`e3e9b974`](https://github.com/NixOS/nixpkgs/commit/e3e9b9744192ae2ae5db6569d08cad94b8caed82) pinocchio: 3.1.0 -> 3.2.0
* [`497b0b95`](https://github.com/NixOS/nixpkgs/commit/497b0b952b4958be286cbd093238cbc37b2f576d) pinocchio: ease use from upstream flake
* [`b2c270d4`](https://github.com/NixOS/nixpkgs/commit/b2c270d4046cb9725a86c6ad28fe35eebde98a26) python312Packages.pytest-check: 2.3.1 -> 2.4.1
* [`0f8ef96f`](https://github.com/NixOS/nixpkgs/commit/0f8ef96fa1041214f732fb47782593e72f1f40c2) CODEOWNERS: add mattpolzin for idris2Packages
* [`f3336bb4`](https://github.com/NixOS/nixpkgs/commit/f3336bb4221a2ab85c5d679f94d8abb32c8dd3a0) stretchly: 1.15.1 -> 1.16.0
* [`9a1c987c`](https://github.com/NixOS/nixpkgs/commit/9a1c987cc6fcec2bab379478b1ca37aa53ed16d0) sesh: 1.2.0 -> 2.0.2
* [`c71e6eec`](https://github.com/NixOS/nixpkgs/commit/c71e6eecc6ab73c96e4efa04726a229ad3b45287) kubectl-cnpg: 1.23.3 -> 1.24.0
* [`66ca7e87`](https://github.com/NixOS/nixpkgs/commit/66ca7e87cba7b330a0bf78365e344b26962d2224) doclifter: modernize
* [`b16581f0`](https://github.com/NixOS/nixpkgs/commit/b16581f094e8bb0f924544db104cd776b81a6985) nixos/services.zammad: remove `with lib;`
* [`60fbd9b7`](https://github.com/NixOS/nixpkgs/commit/60fbd9b7d9b5d369dbe510344ddde1c06186685e) haskellPackages: regenerate package set based on current config
* [`9ac9aadd`](https://github.com/NixOS/nixpkgs/commit/9ac9aaddf04b3a371450bb8bca60b52854b4755e) haskellPackages.opencv-extra: Mark broken
* [`6cd5fa6f`](https://github.com/NixOS/nixpkgs/commit/6cd5fa6f0656ad90623186a711ff1c6a53b22fcb) codeql: 2.18.2 -> 2.18.3
* [`94db5b23`](https://github.com/NixOS/nixpkgs/commit/94db5b237d66742bbe2fd510d3a03852d15366fb) pinit: init at 2.1.1
* [`0a84ba4c`](https://github.com/NixOS/nixpkgs/commit/0a84ba4c3123f60023d29c4af5c755696a9718d5) texstudio: 4.8.1 -> 4.8.2
* [`74797080`](https://github.com/NixOS/nixpkgs/commit/747970800ed2623933f81ce3ad2a4fa879386567) jbrowse: 2.13.1 -> 2.14.0
* [`f50034b1`](https://github.com/NixOS/nixpkgs/commit/f50034b1bb304341f1e8dd85d2e0f4988de24ea1) vcpkg: 2024.07.12 -> 2024.08.23
* [`a69b64ac`](https://github.com/NixOS/nixpkgs/commit/a69b64acdc2b0d7b8a64eaba18cd2e10d87cd15c) metal-cli: 0.24.0 -> 0.25.0
* [`d931a1be`](https://github.com/NixOS/nixpkgs/commit/d931a1bebc8128781495afb51672d35b647aad57) notation: move to by-name
* [`12fbf240`](https://github.com/NixOS/nixpkgs/commit/12fbf2405837420ea2a83e3952825f9f2e6adb43) notation: 1.1.1 -> 1.2.0
* [`ae38d0c7`](https://github.com/NixOS/nixpkgs/commit/ae38d0c729d7df9d062dab14c9d0a1b678b37103) lunacy: 9.6.2 -> 10.0.1
* [`bbc4d99f`](https://github.com/NixOS/nixpkgs/commit/bbc4d99f2e7dfcfcd76fa5c40cfd2b144f4ae809) retrospy: 6.5 -> 6.6
* [`d603c386`](https://github.com/NixOS/nixpkgs/commit/d603c386f939a30c45205fbcdda550e4be14770b) prow: unstable-2020-04-01 -> 0-unstable-2024-08-27
* [`13419f08`](https://github.com/NixOS/nixpkgs/commit/13419f08762836e22952968c82a10ff59176b72c) prow: move to by-name
* [`f25def23`](https://github.com/NixOS/nixpkgs/commit/f25def232a0f6b3e8c35ac342189adec4c5c4bd2) nixos/tests/ec2-nixops: fix build
* [`d98f6da9`](https://github.com/NixOS/nixpkgs/commit/d98f6da9f8db747e2bd3fcd51edf14056739ba65) pythonPackages.whey, pythonPackages.whey-pth: init at 0.1.1
* [`40664f76`](https://github.com/NixOS/nixpkgs/commit/40664f7655f8d25fba681fe8a5e1c92a4999c63f) surrealist: 2.0.6 -> 2.1.6
* [`c4f8cd1a`](https://github.com/NixOS/nixpkgs/commit/c4f8cd1a4498e9803ef00b77ba9a6ea8e7884a4a) haskell.packages.ghc910.haskell-language-server: fix package
* [`2d28732c`](https://github.com/NixOS/nixpkgs/commit/2d28732c2a797deed0a7cb53b6dfd03352f53b0f) glooctl: 1.16.17 -> 1.17.6
* [`e57c43ea`](https://github.com/NixOS/nixpkgs/commit/e57c43ea71ffbd2931d508b4b5b67978ba7eed41) python312Packages.mktestdocs: init at 0.2.1
* [`94092f98`](https://github.com/NixOS/nixpkgs/commit/94092f98a242d6b5793571338de47b8604717ac5) python312Packages.albucore: 0.0.13 -> 0.0.14
* [`702ae3e7`](https://github.com/NixOS/nixpkgs/commit/702ae3e748131bd87381f384985ecea66fa629ad) blockbook: 0.3.6 -> 0.4.0
* [`8feccc55`](https://github.com/NixOS/nixpkgs/commit/8feccc5533575bdb0a168525c5e54d42fcf6170a) inshellisense: 0.0.1-rc.15 -> 0.0.1-rc.16
* [`908c5df9`](https://github.com/NixOS/nixpkgs/commit/908c5df932dc4ab5aeeb0052e56d53fd81e1a379) open-webui: test `environmentFile` option
* [`393040a1`](https://github.com/NixOS/nixpkgs/commit/393040a17657f7f43d6a30d2f9fcdb2304739113) stackit-cli: 0.11.0 -> 0.14.0
* [`66824a24`](https://github.com/NixOS/nixpkgs/commit/66824a24da7a6d5cd92450b96b6279860da6c3c2) python312Packages.vector: 1.4.1 -> 1.5.1
* [`6b6892db`](https://github.com/NixOS/nixpkgs/commit/6b6892dbed2ad08d613c738fafe12ba86dfd66af) brainflow: 5.12.1 -> 5.13.2
* [`5ad2d0ac`](https://github.com/NixOS/nixpkgs/commit/5ad2d0ac3bde8371d87856ec4e39ddb62d0c234d) clj-kondo: 2024.08.01 -> 2024.08.29
* [`1b9bd8dd`](https://github.com/NixOS/nixpkgs/commit/1b9bd8dd0fd5b8be7fc3435f7446272354624b01) factorio: 1.1.109 -> 1.1.110
* [`d7ec977f`](https://github.com/NixOS/nixpkgs/commit/d7ec977f86e140b118864e5956f19d544ee28d72) stdenv: Allow user to supply their bootstrapFiles set of tools
* [`04130d9b`](https://github.com/NixOS/nixpkgs/commit/04130d9b5e0e585b3c8aa500ae7ebaeee018cc6c) vault: 1.17.3 -> 1.17.4
* [`d6b8983c`](https://github.com/NixOS/nixpkgs/commit/d6b8983cab9bff0d4587a15bc1586dcbca269a45) reaper: 7.20 -> 7.22
* [`9eac00d1`](https://github.com/NixOS/nixpkgs/commit/9eac00d1737a164798d8e84d891538846ad06eb0) borgmatic: 1.8.13 -> 1.8.14
* [`71334dce`](https://github.com/NixOS/nixpkgs/commit/71334dce17bdee772c2863275cd249ee67155404) pantheon.elementary-settings-daemon: 8.0.0 -> 8.1.0
* [`c3d6f516`](https://github.com/NixOS/nixpkgs/commit/c3d6f5163e9c65eb7d31145b6926196d92911403) freedroidrpg: 0.16.1 -> 1.0
* [`5d19a9ed`](https://github.com/NixOS/nixpkgs/commit/5d19a9ed868a734d6e20a24d60ace0b9bb403373) Only replace actual java commands with the full path
* [`ab7c92ca`](https://github.com/NixOS/nixpkgs/commit/ab7c92ca382e14773dc16b4fcc317992caf35ed3) ibmcloud-cli: 2.17.0 -> 2.27.0
* [`6cc8c10f`](https://github.com/NixOS/nixpkgs/commit/6cc8c10fe01947a2c6d59b3a4c8b176953fc5941) oama: ignore erroneous references on aarch64-darwin
* [`ffb13b56`](https://github.com/NixOS/nixpkgs/commit/ffb13b56cadac2f571d18bc592290a76cf840ea3) haskellPackages.{spdx,puresat}: relax lower bounds in new releases
* [`b1cad710`](https://github.com/NixOS/nixpkgs/commit/b1cad710043cd6e213da71ee84dd405e71daa658) python312Packages.pytest-twisted: 1.14.2 -> 1.14.2-unstable-2024-08-22
* [`d7c97a26`](https://github.com/NixOS/nixpkgs/commit/d7c97a26b2130b1cb81c29caca655a7df08a04a4) roslyn-ls: 4.12.0-1.24359.11 -> 4.12.0-2.24422.6
* [`abafc3b3`](https://github.com/NixOS/nixpkgs/commit/abafc3b3cf9b6422a8e583932b6398ddfa8d21e2) kubernetes-controller-tools: 0.14.0 -> 0.16.1
* [`6b6a7fbc`](https://github.com/NixOS/nixpkgs/commit/6b6a7fbc3aef95cddbc9661a986f42607cb58878) virtualisation/azure-images: drop outdated list...
* [`6986c209`](https://github.com/NixOS/nixpkgs/commit/6986c2091f6ecde550279353f6847e7b5b1cfb58) neard: 0.18 -> 0.19-unstable-2024-07-02
* [`e972a34a`](https://github.com/NixOS/nixpkgs/commit/e972a34acb84f2c594b999485edd5f7905560cc8) nixos/neard: expose settings option
* [`5115bc51`](https://github.com/NixOS/nixpkgs/commit/5115bc51cf523ef4a43c479c976124249548e834) dolt: 1.42.14 -> 1.42.17
* [`6d3fa005`](https://github.com/NixOS/nixpkgs/commit/6d3fa00589dc8d7233591d0aba7b6bb82dbe7cf0) librewolf-bin: init at 129.0.2.1
* [`1be278fb`](https://github.com/NixOS/nixpkgs/commit/1be278fba1e6b66f3b8bf0be831e5cfcf37b67d7) colima: 0.7.0 -> 0.7.5
* [`90b7e23e`](https://github.com/NixOS/nixpkgs/commit/90b7e23ea292b6a4ebbfe1b0c85a0f6878e04551) vivaldi: 6.8.3381.57 -> 6.9.3447.37
* [`311bc407`](https://github.com/NixOS/nixpkgs/commit/311bc40751698ed7c32d549e4c0484d560eb78a4) apr: 1.7.4 -> 1.7.5
* [`2a8e58b7`](https://github.com/NixOS/nixpkgs/commit/2a8e58b799b88a25be51053c72d8f79b403af5df) wasm-pack: 0.12.1 -> 0.13.0
* [`cb2ec9cf`](https://github.com/NixOS/nixpkgs/commit/cb2ec9cfa19fcdc98f20bc4c4081937d5ee7ad8b) pandoc-include: 1.3.3 -> 1.4.0
* [`c62dfc3a`](https://github.com/NixOS/nixpkgs/commit/c62dfc3ad90014a4284ebcf3cc1e719f41cbfe99) nixpacks: 1.26.1 -> 1.27.0
* [`5a03aa5a`](https://github.com/NixOS/nixpkgs/commit/5a03aa5a453e737b2dbc098781040e30d30c23f3) nixos/kubernetes: add extraConfig to kubelet config
* [`df3fe1dd`](https://github.com/NixOS/nixpkgs/commit/df3fe1dd131d549b390e1ccfc9399cf2c3c38560) python312Packages.trimesh: 4.4.7 -> 4.4.8
* [`b95d8992`](https://github.com/NixOS/nixpkgs/commit/b95d89928d07ca81144e726131dabe2a69a61649) flameshot: format with nixfmt-rfc-style
* [`f9787502`](https://github.com/NixOS/nixpkgs/commit/f97875026ab7e727f88644c77ad7df8858681a58) flameshot: update cmake options
* [`0174d4a3`](https://github.com/NixOS/nixpkgs/commit/0174d4a34cbdb0406796669d2553c3d5e46c9ea1) flameshot: fix build on Darwin
* [`14b7ee1e`](https://github.com/NixOS/nixpkgs/commit/14b7ee1e0728fb18b2e2a424c5c0d54d415919bb) python312Packages.distributed: 2024.8.1 -> 2024.8.2
* [`1ee08192`](https://github.com/NixOS/nixpkgs/commit/1ee08192eb3f769f43d35ae8987ec28993860443) python312Packages.etils: 1.9.2 -> 1.9.3
* [`a606bee9`](https://github.com/NixOS/nixpkgs/commit/a606bee95505f55e5ee0f5b864eae2f0eda040d7) svt-av1-psy: init at 2.2.1
* [`b5d838af`](https://github.com/NixOS/nixpkgs/commit/b5d838aff647259a8d1a6c1265025b9115409e51) qt6Packages.drumstick: format with nixfmt
* [`f8bca491`](https://github.com/NixOS/nixpkgs/commit/f8bca49147e4d8f897097e1af21efd6c3ddb33af) qt6Packages.drumstick: 2.9.0 -> 2.9.1
* [`407c4855`](https://github.com/NixOS/nixpkgs/commit/407c48557100f1b8a685605d805f8f5fdc7ea8cb) elixir: 1.16 -> 1.17 update default
* [`f1705382`](https://github.com/NixOS/nixpkgs/commit/f1705382585bb9d6fde673a6ce0d243b528127ca) appflowy: 0.6.7.1 -> 0.6.7.2
* [`be008eb9`](https://github.com/NixOS/nixpkgs/commit/be008eb9ee585ccd5324919c375d48f4f285f094) eintopf: 0.13.16 -> 0.14.1
* [`2137cfed`](https://github.com/NixOS/nixpkgs/commit/2137cfedcb572b8613ea03f979134ec87383468c) koboldcpp-1.73.1 -> koboldcpp-1.74
* [`2b7b439e`](https://github.com/NixOS/nixpkgs/commit/2b7b439e9f756f6fedb75ffa69cd890b089366dd) vue-language-server: 2.0.29 -> 2.1.2
* [`4516a96d`](https://github.com/NixOS/nixpkgs/commit/4516a96db487c004c6e547140372f90c428b79b8) treewide: remove some unreferenced patches
* [`4eae74ad`](https://github.com/NixOS/nixpkgs/commit/4eae74adfe8c054957fb780803465af771b135e6) python312Packages.eigenpy: 3.8.1 -> 3.9.0
* [`9bd70468`](https://github.com/NixOS/nixpkgs/commit/9bd70468baf00273e9178f8c76d612ca74ba2e3d) cargo-update: 14.0.2 -> 14.1.1
* [`976da724`](https://github.com/NixOS/nixpkgs/commit/976da7242c8aecf984bb3fb6f8011df96eab01be) vimPlugins.nvim-various-textobjs: init at 2024-08-17
* [`2e41a59b`](https://github.com/NixOS/nixpkgs/commit/2e41a59bbb4f79def51b9540ed51058fa457fead) cdrtools: fix riscv64-linux build
* [`13413a72`](https://github.com/NixOS/nixpkgs/commit/13413a728126be4cdb5357bd7de30f2978344b1b) cf-tool: init at 202405140250
* [`3af51583`](https://github.com/NixOS/nixpkgs/commit/3af5158353847323fe2f17484d8849af9a93f198) devilutionx: 1.5.2 -> 1.5.3
* [`7ffc5523`](https://github.com/NixOS/nixpkgs/commit/7ffc5523d613e40bed10679a2a32c326e7db7b3d) reveal-md: 6.1.2 -> 6.1.3
* [`5a603783`](https://github.com/NixOS/nixpkgs/commit/5a60378393d76d640b6865493408993c145df351) tuir: 1.29.0 -> 1.31.0
* [`d36980f0`](https://github.com/NixOS/nixpkgs/commit/d36980f098518a66a7cf732a7f6b1a30eefa9368) bats.libraries.bats-detik: 1.3.0 -> 1.3.2
* [`0a4d37ae`](https://github.com/NixOS/nixpkgs/commit/0a4d37aea281ec1ece4e4dad1eb7d2a42d457810) gnome-monitor-config: fix cross compilation, set strictDeps
* [`584e028d`](https://github.com/NixOS/nixpkgs/commit/584e028d6fb8632c01cf5b52301f2cbd30f0919d) iotools: Move package definition into by-name directory
* [`5fc67c2a`](https://github.com/NixOS/nixpkgs/commit/5fc67c2ab7b68e9bc58e6feee6a941163471e2e2) libjaylink: Move package definition into by-name directory
* [`29c0b3c3`](https://github.com/NixOS/nixpkgs/commit/29c0b3c35314147486d08bc1d7a898833363f917) mapnik: 4.0.0 -> 4.0.2
* [`3f1e3e5c`](https://github.com/NixOS/nixpkgs/commit/3f1e3e5ccd312d41634867d371ccf24e9a8db4fb) giza: init at 1.4.1
* [`30fc5dbe`](https://github.com/NixOS/nixpkgs/commit/30fc5dbebd2a42a28cf8716f396a5bdf57f78eac) splash: init at 3.10.3
* [`f1c3597d`](https://github.com/NixOS/nixpkgs/commit/f1c3597d95027fdd8f786716e02c0ed4167842d9) nixos/doc/rl-2411: warn about upcoming macOS version requirement
* [`4fd2357f`](https://github.com/NixOS/nixpkgs/commit/4fd2357f088c7683f3672363cf070001eb2eded1) python312Packages.raylib-python-cffi: 5.0.0.2 -> 5.0.0.3
* [`4bbb8428`](https://github.com/NixOS/nixpkgs/commit/4bbb84280b5f69e2e364726cb741cdbe30ee153e) pianobar: 2022.04.01 -> 2022.04.01-unstable-2024-08-16
* [`f1f27be0`](https://github.com/NixOS/nixpkgs/commit/f1f27be07d4fb0cd208ae444d8561d0747faab9e) libcyaml: 1.4.1 -> 1.4.2
* [`0bdbc60c`](https://github.com/NixOS/nixpkgs/commit/0bdbc60cdf15a4a99c085004be352d60eac13535) harper: 0.9.5 -> 0.10.0
* [`8be51a78`](https://github.com/NixOS/nixpkgs/commit/8be51a78a90d3625cf8ad520af867d25acfd6269) libkeyfinder: 2.2.6 -> 2.2.8
* [`fa2686d9`](https://github.com/NixOS/nixpkgs/commit/fa2686d939241cdfe8dbcd493c91eb34c7c5cf36) keyfinder-cli: 1.1.1 -> 1.1.2
* [`e84c5104`](https://github.com/NixOS/nixpkgs/commit/e84c5104d5052ceda551cf850842e8bee800c32e) groovy: add completion,desktop support
* [`e9941fba`](https://github.com/NixOS/nixpkgs/commit/e9941fbadd8470895aa1d85f0bc8ec7c604f352e) python312Packages.ghapi: 1.0.3 -> 1.0.6
* [`5319e124`](https://github.com/NixOS/nixpkgs/commit/5319e12489319ec313e2d5ab8c94cb2a3a11d7a9) sonarr: 4.0.8.1874 -> 4.0.9.2244
* [`2cf7c7fd`](https://github.com/NixOS/nixpkgs/commit/2cf7c7fd9ea044cb25d4cd73c73d10a44dde0347) python312Packages.ipywidgets: 8.1.3 -> 8.1.5
* [`601e1bf8`](https://github.com/NixOS/nixpkgs/commit/601e1bf83e25b69c25e52e5e9140c7c7ab51c5c9) python312Packages.jupyter: 1.0.0 -> 1.1.1
* [`371ecc2e`](https://github.com/NixOS/nixpkgs/commit/371ecc2e5f657965902a571774064b286e88dc0a) python312Packages.jupyterlab: 4.2.4 -> 4.2.5
* [`a4e2f20b`](https://github.com/NixOS/nixpkgs/commit/a4e2f20b166d53ae669a5d4c0f3b4cf9d47309bf) python312Packages.jupyterlab-widgets: 3.0.11 -> 3.0.13
* [`c09fbe38`](https://github.com/NixOS/nixpkgs/commit/c09fbe38a8b0badbcb957219d67fb4d835549349) python312Packages.marimo: 0.8.3 -> 0.8.7
* [`f66332b0`](https://github.com/NixOS/nixpkgs/commit/f66332b008b76b21246d29df5550cc5f0d040133) python312Packages.nbdev: 2.3.27 -> 2.3.28
* [`50f1bb80`](https://github.com/NixOS/nixpkgs/commit/50f1bb8008e325ddf35f5d47d988a6ef7ec43110) python312Packages.nbsphinx: 0.9.4 -> 0.9.5
* [`68e35943`](https://github.com/NixOS/nixpkgs/commit/68e35943525d897e36dccfe5c4a342a842b10771) python312Packages.notebook: 7.2.1 -> 7.2.2
* [`3ed98a38`](https://github.com/NixOS/nixpkgs/commit/3ed98a38f1b6a55a719a90b410810192496057e9) mapproxy: 2.2.0 -> 3.0.1
* [`6bc1fe6e`](https://github.com/NixOS/nixpkgs/commit/6bc1fe6eb8da147d34ae73bee65e7154a6885fac) deno: 1.45.5 -> 1.46.2
* [`dc4cf9eb`](https://github.com/NixOS/nixpkgs/commit/dc4cf9eb9d1d84523da0bff6d4033b19212a8263) chirp: 0.4.0-unstable-2024-08-06 -> 0.4.0-unstable-2024-08-31
* [`e6e452ff`](https://github.com/NixOS/nixpkgs/commit/e6e452ff00e9d6219cdcc9c8aa7abac6882ff315) microsoft-edge: 128.0.2739.42 -> 128.0.2739.54
* [`3b5e411a`](https://github.com/NixOS/nixpkgs/commit/3b5e411a5faafb30fd8c65e2620572f9cbe669f9) bats.libraries: Add brokenpip3 as maintainer
* [`c98ab14e`](https://github.com/NixOS/nixpkgs/commit/c98ab14e32d8e43c7dad7dcc14425307e892afd9) tuir: Add brokenpip3 as maintainer
* [`0223b738`](https://github.com/NixOS/nixpkgs/commit/0223b738382e899fe644e905022cc0a93a99cda8) haskellPackages.sequence-formats: disable tests due to missing files
* [`9e95a875`](https://github.com/NixOS/nixpkgs/commit/9e95a875b0316829cadfd281e84dd1be92b3a8b4) haskellPackages.streamly-zip: provide correct package for libzip
* [`b385174f`](https://github.com/NixOS/nixpkgs/commit/b385174fedd55d8a8c42d8aa354ef02a1314a1fd) haskellPackages: mark builds failing on hydra as broken
* [`fb6458be`](https://github.com/NixOS/nixpkgs/commit/fb6458be9e440fb3b046f9e92726279e27af5c60) mautrix-meta: add eyjhb as maintainer
* [`569f3e8c`](https://github.com/NixOS/nixpkgs/commit/569f3e8c5bb3cf6fe0aec295099a6c1a41973e28) haskellPackages.postgresql-libpq: >= 0.10.2 and deps are broken
* [`1ea32d4f`](https://github.com/NixOS/nixpkgs/commit/1ea32d4f698230e2c1e765d857c44b17daa377b4) nixos/grub: fix value precendence with optional -> mkIf
* [`6bf5e091`](https://github.com/NixOS/nixpkgs/commit/6bf5e0917ef0c68a1e85c409b12bd689cc0817b2) haskellPackages.sdl2-ttf: move pkg-config override to proper place
* [`38778097`](https://github.com/NixOS/nixpkgs/commit/38778097cafeb87a1e0479b0b8802ff9a73c453b) haskellPackages.gi-gtk_4_0_9: ensure override is applied correctly
* [`0c924ab2`](https://github.com/NixOS/nixpkgs/commit/0c924ab22aa8818c701ad9d94be34dc7934d692c) haskellPackages.sdl2: work around argv limit
* [`87bc034f`](https://github.com/NixOS/nixpkgs/commit/87bc034f9bf40043a7bcfde1c50a1888947d8d07) qq: add update-date into version
* [`48f8b025`](https://github.com/NixOS/nixpkgs/commit/48f8b025284af069a7d35bbfd33cdfb543eb9d59) pgcat: 1.1.1 -> 1.2.0
* [`03f4b385`](https://github.com/NixOS/nixpkgs/commit/03f4b385f7e85d1c3a1f9523c3d9f4982ab223b9) qq: 3.2.12 -> 3.2.12-2024.8.19
* [`e236658b`](https://github.com/NixOS/nixpkgs/commit/e236658b95508edb3dffe8a7b6ab3f6a1340630c) _1password-gui: 8.10.36 -> 8.10.40, _1password-gui-beta: 8.10.38-13.BETA -> 8.10.44-21.BETA
* [`cc2ad05f`](https://github.com/NixOS/nixpkgs/commit/cc2ad05f411f36e61071776ec2751a1f01baaa09) maintainers: add cheesecake
* [`b0381962`](https://github.com/NixOS/nixpkgs/commit/b0381962830e1cb1dffe12df1966edeedeb1fcc1) logseq: add maintainer cheesecake
* [`0e298141`](https://github.com/NixOS/nixpkgs/commit/0e2981418504d581f45983af29cd1b2a585cc019) faudio: 24.08 -> 24.09
* [`aa4fea2c`](https://github.com/NixOS/nixpkgs/commit/aa4fea2c087e022db3c89a05b61512992f06c320) linux_xanmod: 6.6.47 -> 6.6.48
* [`f7947da1`](https://github.com/NixOS/nixpkgs/commit/f7947da16c628b0cee43547d2af803ff443b0241) pantheon.switchboard-plug-sound: fix cross compilation
* [`8dce7daf`](https://github.com/NixOS/nixpkgs/commit/8dce7dafcf0368f8007393f555a432ae5b373271) glfw-minecraft: merge glfw-wayland-minecraft into glfw
* [`2a5017a5`](https://github.com/NixOS/nixpkgs/commit/2a5017a5550a32dfdf4000bd8fa2fea89e6a0f95) prismlauncher: deprecate withWaylandGLFW option
* [`a1863c87`](https://github.com/NixOS/nixpkgs/commit/a1863c871e3fc1a317f8d671a113f13dc3d0a9c2) nixos/kubernetes: amend dns addon clusterDns list
* [`697d24d5`](https://github.com/NixOS/nixpkgs/commit/697d24d5de386b27ca0214519788cbe28ad6e945) prismlauncher: use top level X11 packages
* [`78bac42c`](https://github.com/NixOS/nixpkgs/commit/78bac42cb3c3d67275935829193a58a4f2b75e01) linux_xanmod_latest: 6.10.6 -> 6.10.7
* [`be3e301b`](https://github.com/NixOS/nixpkgs/commit/be3e301b9a80423e467014da6533a41dda01c1a7) luaPackages.lsp-progress-nvim: init at 1.0.13-1
* [`34161008`](https://github.com/NixOS/nixpkgs/commit/341610082b118a83b6eaf524e178fa0f879d3005) vimPlugins.lsp-progress-nvim: init at 1.0.13-1
* [`436aff26`](https://github.com/NixOS/nixpkgs/commit/436aff262d00b6bcf2311c10e8f2a255e1c550a6) feather: 2.6.7 -> 2.6.8
* [`cba3c283`](https://github.com/NixOS/nixpkgs/commit/cba3c2834c404f0c60322eafb7e4c6ea3bde0605) lunar-client: 3.2.16 -> 3.2.17
* [`89967da1`](https://github.com/NixOS/nixpkgs/commit/89967da19531aa1a97dd1796504439be02d875fe) kotatogram-desktop: 0-unstable-2024-07-01 -> 0-unstable-2024-09-01
* [`48723b7d`](https://github.com/NixOS/nixpkgs/commit/48723b7df38541ca31e20c7c44d4a99640ea9533) coreboot-toolchain: 24.05 -> 24.08
* [`29c84f4a`](https://github.com/NixOS/nixpkgs/commit/29c84f4a192e897ab0d6ba65b463bd6bfb5057c4) haskellPackages.kqueue: apply patch for GHC 9.6 core libs
* [`9bd6b9c0`](https://github.com/NixOS/nixpkgs/commit/9bd6b9c0e9a41cdde3203a1c37bb1dd530339cee) coreboot-utils: 24.05 -> 24.08
* [`dfd6da90`](https://github.com/NixOS/nixpkgs/commit/dfd6da9083c87123287d3a0b60cd7287ceeb0479) coreboot-toolchain: format nix files
* [`381643e8`](https://github.com/NixOS/nixpkgs/commit/381643e81789111660f6877148cee6f2f5b23ee2) coreboot-utils: format nix files
* [`56b92e14`](https://github.com/NixOS/nixpkgs/commit/56b92e141a610b8b40595a673396a38d93ccfa4c) libcyaml: migrate to by-name
* [`735662bf`](https://github.com/NixOS/nixpkgs/commit/735662bf16490b20d7b5206a633bed14c1d50b1c) prometheus-openldap-exporter: remove
* [`bea97cf1`](https://github.com/NixOS/nixpkgs/commit/bea97cf13d56c17412c1d17347b72c8076061243) awscli2: 2.17.18 -> 2.17.42
* [`3524ada1`](https://github.com/NixOS/nixpkgs/commit/3524ada1634aff5892d20527d863faf9ca08c809) maintainers: add cageyv
* [`3f5602bf`](https://github.com/NixOS/nixpkgs/commit/3f5602bf9752f024ba541cdc73894dca76d1b003) lprobe: init at 0.1.3
* [`8719eb45`](https://github.com/NixOS/nixpkgs/commit/8719eb45524dc38d0324b730e87edb4cb45c44ad) python312Packages.blis: 0.7.11 -> 1.0.0
* [`e5bec360`](https://github.com/NixOS/nixpkgs/commit/e5bec360ca7e1838a2e2dad528dd977ff0666536) dep-scan: 5.3.4 -> 5.4.3
* [`88bee160`](https://github.com/NixOS/nixpkgs/commit/88bee160aa5a026ae384e94e10f551afa41765ea) mapproxy: migrate to by-name
* [`21604f73`](https://github.com/NixOS/nixpkgs/commit/21604f73f238d1cccb128d6e9d7a851cebebc7cd) python312Packages.pyheif: 0.7.1 -> 0.8.0
* [`44b73d21`](https://github.com/NixOS/nixpkgs/commit/44b73d2160110b054c998d3ff93913a6154b556c) tui-journal: 0.9.1 -> 0.10.0
* [`12c4e7bc`](https://github.com/NixOS/nixpkgs/commit/12c4e7bc4abf11d118f1298e77287badb4c93e1d) python312Packages.pipenv-poetry-migrate: 0.5.8 -> 0.5.9
* [`b04f9599`](https://github.com/NixOS/nixpkgs/commit/b04f959916523361e56b51b645fcedcdcbc11207) python312Packages.libcst: move tests to passthru.tests
* [`05d6ab07`](https://github.com/NixOS/nixpkgs/commit/05d6ab0713ddace728b727bcd53618999ca126d3) python312Packages.libcst: modernize
* [`e08e458f`](https://github.com/NixOS/nixpkgs/commit/e08e458fb8b686703e7122852aa7bfa3164496e0) python312Packages.libcst: add dotlambda to maintainers
* [`0e0552e7`](https://github.com/NixOS/nixpkgs/commit/0e0552e789bd6f8da243096cb12bb60fe2ad9f37) python312Packages.hypothesmith: modernize
* [`4fbb84dd`](https://github.com/NixOS/nixpkgs/commit/4fbb84dd8b542aa26dceccfc5e88c843e6c4f335) buck: pin python3 to python311
* [`ad464a4f`](https://github.com/NixOS/nixpkgs/commit/ad464a4f531cb0d3dad7ab65d75689aea75d18ee) gdb: use meta.badPlatforms instead of assert iff aarch64-darwin
* [`dbdf66b1`](https://github.com/NixOS/nixpkgs/commit/dbdf66b130bc6f0e51b15333a3fcf0043b06559a) python312Packages.webdataset: 0.2.96 -> 0.2.100
* [`62fe2904`](https://github.com/NixOS/nixpkgs/commit/62fe2904d777d3683896adb314ca2fe284ddb24a) python312Packages.quantile-forest: 1.3.9 -> 1.3.10
* [`9762339a`](https://github.com/NixOS/nixpkgs/commit/9762339aaab340e350527492929c65809a5a9232) mapproxy: add geospatial team to maintainers
* [`f242ac49`](https://github.com/NixOS/nixpkgs/commit/f242ac49c810a5cd408f1008ef75eabe5ae59923) cwe-client-cli: init at 0.3.2
* [`c01f00fc`](https://github.com/NixOS/nixpkgs/commit/c01f00fc9cafe90f735525a67a81e7a4de80cb66) python312Packages.langfuse: 2.44.1 -> 2.45.1
* [`a21545d6`](https://github.com/NixOS/nixpkgs/commit/a21545d6a53e899788b115d3a3e3b3084bec8c4b) quarkus: 3.13.2 -> 3.14.1
* [`15b6250d`](https://github.com/NixOS/nixpkgs/commit/15b6250dc3c75998ee7136f52adb689b7c349197) stargazer: 1.3.0 -> 1.3.1
* [`21064e22`](https://github.com/NixOS/nixpkgs/commit/21064e22609186814935ce49e5f226bdb0ba7142) ollama: 0.3.5 -> 0.3.9
* [`3b927135`](https://github.com/NixOS/nixpkgs/commit/3b9271352c8fbef68a9ad46d8e6d2489b39d4e86) python312Packages.matrix-nio: 0.24.0 -> 0.25.0
* [`6ddbfade`](https://github.com/NixOS/nixpkgs/commit/6ddbfadefcc01e57209baaf88e1f31c265325ad0) chirp: migrate to by-name
* [`cbfa64a5`](https://github.com/NixOS/nixpkgs/commit/cbfa64a5777ef758210b2130c756c875ced5dd04) cairo-lang: 2.5.4 -> 2.8.0
* [`6dd315e8`](https://github.com/NixOS/nixpkgs/commit/6dd315e82b36cf1ee5f9f2e83835dfa023a65c04) roc-toolkit: fix build on darwin
* [`ce1d083c`](https://github.com/NixOS/nixpkgs/commit/ce1d083cc91a4e411b4f8b9aa6b72bc5d2a98e61) crossplane-cli: 1.16.0 -> 1.16.1
* [`7fc4e0e7`](https://github.com/NixOS/nixpkgs/commit/7fc4e0e7c6ba59580b413492374e7525fd7e3073) liberasurecode: format with nixfmt-rfc-style
* [`c3bda7eb`](https://github.com/NixOS/nixpkgs/commit/c3bda7ebcb79fabc637461755654b3451878c39c) liberasurecode: migrate to pkgs/by-name
* [`5eeb2442`](https://github.com/NixOS/nixpkgs/commit/5eeb24425935bb2422910ca2627960004a3ee48b) liberasurecode: 1.6.3 -> 1.6.4
* [`d68b3e05`](https://github.com/NixOS/nixpkgs/commit/d68b3e05c277ad874a6fd74df4113791ff54291d) maubot: 0.4.2 -> 0.5.0
* [`ec45a5b9`](https://github.com/NixOS/nixpkgs/commit/ec45a5b98e9f3c146d04c8aa024c85fc413cd979) maubot: update plugins
* [`f510a49e`](https://github.com/NixOS/nixpkgs/commit/f510a49e54ed793cbe7a258e19b7ae5595c326b8) liberasurecode: add passthru.tests.pkg-config, meta.pkgConfigModules
* [`1284004b`](https://github.com/NixOS/nixpkgs/commit/1284004bf6c6e50d8592b6efe83708931e75aec7) xdg-desktop-portal-hyprland: fix build
* [`9d60285f`](https://github.com/NixOS/nixpkgs/commit/9d60285f79704e3aaa1565ef2202fee001926673) python311Packages.pyeclib: unstable-2022-03-11 -> 1.6.1
* [`62d36959`](https://github.com/NixOS/nixpkgs/commit/62d3695980f8e358bd7a92c754d8fb43025e6e47) maintainers: add oakenshield
* [`ca8ebb9d`](https://github.com/NixOS/nixpkgs/commit/ca8ebb9de33d4a417ea91dd70c6800245a229cbe) renode-dts2repl: 0-unstable-2024-08-20 -> 0-unstable-2024-08-30
* [`dad5a626`](https://github.com/NixOS/nixpkgs/commit/dad5a626744be3c22915df72631277b83f803c3e) mesa.meta.platforms: broaden
* [`2163a45c`](https://github.com/NixOS/nixpkgs/commit/2163a45ca7d635b42241de7ed49dfccd2492222c) gamin, fileschanged: remove
* [`bc4dad0d`](https://github.com/NixOS/nixpkgs/commit/bc4dad0dcf9194061f8782698a93e9e9b83ee2ba) codeblocks: remove optional gamin dependency
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
