### PR TITLE
niv home-manager: update 471e3eb0 -> 10541f19

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -41,10 +41,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "471e3eb0a114265bcd62d11d58ba8d3421ee68eb",
-        "sha256": "1smfj6fb3jc80gbavdf603nz782fb96d9k5w36g61zliw5g2qfvz",
+        "rev": "10541f19c584fe9633c921903d8c095d5411e041",
+        "sha256": "1z0ccdgrkr7d19njqipgf38wxdwwnmvvaswkngzw57a06v2qngby",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/471e3eb0a114265bcd62d11d58ba8d3421ee68eb.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/10541f19c584fe9633c921903d8c095d5411e041.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@471e3eb0...10541f19](https://github.com/nix-community/home-manager/compare/471e3eb0a114265bcd62d11d58ba8d3421ee68eb...10541f19c584fe9633c921903d8c095d5411e041)

* [`5130249a`](https://github.com/nix-community/home-manager/commit/5130249ab20229480aa732942c9c555a38fb910a) taskwarrior-sync: add package option
* [`03b49187`](https://github.com/nix-community/home-manager/commit/03b49187a2e41f042896a26761ca86ce90cb7f2c) sway: indent sway configuration options
* [`b00bdf59`](https://github.com/nix-community/home-manager/commit/b00bdf59c0aa5515a0a8e1773fa19128e7efa181) xdg: add option 'xdg.stateFile'
* [`5b95e061`](https://github.com/nix-community/home-manager/commit/5b95e0611b498fac7c8425d1b1bc4cacfd64e7f0) Translate using Weblate (Hungarian)
* [`7d569851`](https://github.com/nix-community/home-manager/commit/7d569851e95e8b360a3d7a2f52c5fc6a597a7657) flake.lock: Update
* [`127ccc3e`](https://github.com/nix-community/home-manager/commit/127ccc3eb7e36fa75e8c3fbd8a343154f66cc1c6) i3/sway: support str type for font size
* [`aaebdea7`](https://github.com/nix-community/home-manager/commit/aaebdea769a5c10f1c6e50ebdf5924c1a13f0cda) taskwarrior: support taskwarrior3 migration
* [`ec4c6928`](https://github.com/nix-community/home-manager/commit/ec4c6928bbacc89cf10e9c959a7a47cbaad95344) firefox: fix selection of lastUserContextId
* [`8a175a89`](https://github.com/nix-community/home-manager/commit/8a175a89137fe798b33c476d4dae17dba5fb3fd3) tests: change quoting to match new Nixpkgs behavior
* [`77c94148`](https://github.com/nix-community/home-manager/commit/77c94148285563113246eaf9f8df5488e00c81d0) k9s: allow defining custom theme file
* [`be47a2bd`](https://github.com/nix-community/home-manager/commit/be47a2bdf278c57c2d05e747a13ed31cef54a037) k9s: remove katexochen as maintainer
* [`10541f19`](https://github.com/nix-community/home-manager/commit/10541f19c584fe9633c921903d8c095d5411e041) pqiv: add boolean support
