### PR TITLE
niv nixpkgs: update 59c3aa2d -> 395d3350

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "59c3aa2d4de4b69b3e21742fd1d7222756cf5d91",
-        "sha256": "1irj7rjh7wjq74yr1s9g9zi44d8vcp7ig160a11mjn09vhj83rw0",
+        "rev": "395d3350e4628550d067d713f514361f916df1e6",
+        "sha256": "1fkbjsapyj80sxn31nvq8addwaq7r4xgyjps2qa2xyp16gp7fg0p",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/59c3aa2d4de4b69b3e21742fd1d7222756cf5d91.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/395d3350e4628550d067d713f514361f916df1e6.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@59c3aa2d...395d3350](https://github.com/nixos/nixpkgs/compare/59c3aa2d4de4b69b3e21742fd1d7222756cf5d91...395d3350e4628550d067d713f514361f916df1e6)

* [`39a5a0fd`](https://github.com/NixOS/nixpkgs/commit/39a5a0fd70120979e9dd72f9b20665525b2cdf79) leftwm-config: init at 0.1.0
* [`cf36cc3e`](https://github.com/NixOS/nixpkgs/commit/cf36cc3e54300c24de8f825b80f0a541b8856753) leftwm-theme: init at unstable-2022-12-24
* [`781987f9`](https://github.com/NixOS/nixpkgs/commit/781987f98387b741ca27ee7d8aa67555d6128c0a) yo: 4.3.1 -> 5.0.0
* [`bba237c1`](https://github.com/NixOS/nixpkgs/commit/bba237c12cb3dd25933ffe677616dd868bf97427) clj-kondo: Remove duplicate postInstall logic
* [`930addba`](https://github.com/NixOS/nixpkgs/commit/930addba50d1f5447499c4eb9af9a1b938fa7dff) python312Packages.textual-universal-directorytree: 1.1.0 -> 1.5.0
* [`16e24f64`](https://github.com/NixOS/nixpkgs/commit/16e24f645b60e0057936c350929d821aecdeb745) python3Packages.sev-snp-measure: add executable output
* [`d04e6c54`](https://github.com/NixOS/nixpkgs/commit/d04e6c548813a84e5adf22c74f636d579c5f4274) podman: drop slirp4netns which has been replaced by passt
* [`fb9ca468`](https://github.com/NixOS/nixpkgs/commit/fb9ca468ea9b554bc406353581128cbcfe0ea42a) hterm: init at 0.8.9
* [`f42dbd07`](https://github.com/NixOS/nixpkgs/commit/f42dbd07017fa2641051cd3bc9b86f7737a45e3a) maintainers: add denperidge
* [`e2e28f84`](https://github.com/NixOS/nixpkgs/commit/e2e28f84f31fd711ca035cee71468b408372a642) nixos/podman: add slirp4netns if configured
* [`4098898f`](https://github.com/NixOS/nixpkgs/commit/4098898ff6d545ae0827620f8e749a0bf229446c) tocpdf: init at 0.3.3
* [`89aaab56`](https://github.com/NixOS/nixpkgs/commit/89aaab565e830235f2026763cc13f1f33df27820) nixos/doc: add documentation for formats.hocon
* [`141a8a6c`](https://github.com/NixOS/nixpkgs/commit/141a8a6c86a4b14554add0457c864182c6fb6332) nixos/doc: move implementation notes for formats.hocon to docs
* [`a891526b`](https://github.com/NixOS/nixpkgs/commit/a891526b22a9cc741dcf5a070925c8a5ab7b452a) nixos/doc: add documentation for formats.libconfig
* [`bf2adb82`](https://github.com/NixOS/nixpkgs/commit/bf2adb82b7f1fd702ffd8a16b1c3f14b068874c6) nixos/doc: move implementation notes for formats.libconfig to docs
* [`2a5a7f39`](https://github.com/NixOS/nixpkgs/commit/2a5a7f398cea3643f6b7457b19deb3ff70874cb3) double-conversion: Allow static linking
* [`0613c3f1`](https://github.com/NixOS/nixpkgs/commit/0613c3f1cbafe410ff0ce6781e31baa58196ad2b) spacectl: init at 1.0.1
* [`2232311c`](https://github.com/NixOS/nixpkgs/commit/2232311c93ae0b23296445966f4e8b960a66142d) Update nixos/modules/virtualisation/podman/default.nix
* [`56e81065`](https://github.com/NixOS/nixpkgs/commit/56e8106538cab8bb506705853a5cbccf92f15a58) Remove trailing whitespace
* [`356aab4c`](https://github.com/NixOS/nixpkgs/commit/356aab4ceba7cafa5d374837b790573e822fcebd) php82Extensions.phalcon: 5.7.0 -> 5.8.0
* [`2d227405`](https://github.com/NixOS/nixpkgs/commit/2d227405686e608b7e4a75d9babc5abcd8732030) omekasy: init at 1.2.3
* [`a9f5850a`](https://github.com/NixOS/nixpkgs/commit/a9f5850ad3470d59f61518422962208590a64f82) gemrb: 0.9.2 -> 0.9.3
* [`efc04469`](https://github.com/NixOS/nixpkgs/commit/efc044691ceb1ad16f1c3530a6b985f5198264b6) elvis-erlang: 3.1.0 -> 3.2.5
* [`0c4ceee4`](https://github.com/NixOS/nixpkgs/commit/0c4ceee4e4ac4e28c6a4fdce2bdd770806d44b51) build2: 0.16.0 -> 0.17.0
* [`07524c2f`](https://github.com/NixOS/nixpkgs/commit/07524c2f27f8f3f13b42dc9b4e27e17fda447b5f) libbutl: 0.16.0 -> 0.17.0
* [`4fa15953`](https://github.com/NixOS/nixpkgs/commit/4fa15953375ca4dcafe76b4447ae50abfeec42d8) bpkg: 0.16.0 -> 0.17.0
* [`692a9415`](https://github.com/NixOS/nixpkgs/commit/692a94157c825ba69518aea04a972811664bf84c) bdep: 0.16.0 -> 0.17.0
* [`46d4396c`](https://github.com/NixOS/nixpkgs/commit/46d4396c678cb66e7f5bf1afa18b99a76045fd83) libodb: 2.5.0-b.25 -> 2.5.0-b.27
* [`428fd4f8`](https://github.com/NixOS/nixpkgs/commit/428fd4f85bd3e64b2f829b912517ceb2db544f58) libodb-sqlite: 2.5.0-b.25 -> 2.5.0-b.27
* [`f01d2608`](https://github.com/NixOS/nixpkgs/commit/f01d2608de02fb7d1213d386259b0e3332248c1a) libbpkg: 0.16.0 -> 0.17.0
* [`feb1211f`](https://github.com/NixOS/nixpkgs/commit/feb1211f0a3a68ef8254f064033417a9d6d11318) build2.bootstrap: 0.16.0 -> 0.17.0
* [`919e8886`](https://github.com/NixOS/nixpkgs/commit/919e8886b0ede648f21ea02b5212452bd8882cd9) convimg: 9.3 -> 9.4
* [`19e84ecb`](https://github.com/NixOS/nixpkgs/commit/19e84ecb3e0330c163871936014db8fcb4cda080) dk: 2.2 -> 2.3
* [`8d9d8816`](https://github.com/NixOS/nixpkgs/commit/8d9d881634f76bb80fff06ee73ede1fe75a2a690) nixosTests.hocker-fetchdocker: remove
* [`9c28d412`](https://github.com/NixOS/nixpkgs/commit/9c28d412460bb72d0040baadae220c7cdbfd3c85) python312Packages.pylint: 3.2.3 -> 3.2.5
* [`3cefe1eb`](https://github.com/NixOS/nixpkgs/commit/3cefe1ebcccb2e6d6cf73e0ec884a19595dc0bcd) coq2html: 1.3 -> 1.4
* [`2ca7d794`](https://github.com/NixOS/nixpkgs/commit/2ca7d794ac886276608bfab445be86ea9c746384) sayonara: 1.7.0-stable3 -> 1.10.0-stable1
* [`2d568684`](https://github.com/NixOS/nixpkgs/commit/2d5686847705bfe12e8ffc64127da7849831f048) alfaview: 9.13.0 -> 9.14.0
* [`bfcb5ecb`](https://github.com/NixOS/nixpkgs/commit/bfcb5ecb0ecff38631b01ae050fa6c4a6eadacb1) python312Packages.plux: 1.10.0 -> 1.11.0
* [`edeec132`](https://github.com/NixOS/nixpkgs/commit/edeec132050ecc6a25a8307abd2edad02960d659) python312Packages.ansible: 10.1.0 -> 10.2.0
* [`e465b641`](https://github.com/NixOS/nixpkgs/commit/e465b64108d4d3c9fd37fa6adc84fe981ddc67b8) pithos: cleanup propagations
* [`ea528313`](https://github.com/NixOS/nixpkgs/commit/ea52831349761ed5cbec2df679bb16c6d8f1e209) mautrix-googlechat: 0.5.1 -> 0.5.2
* [`6f3a459d`](https://github.com/NixOS/nixpkgs/commit/6f3a459d1cafc42dcb41c69d8438eee18a3993c7) python312Packages.pyqtwebengine: 5.15.6 -> 5.15.7
* [`52dc97ca`](https://github.com/NixOS/nixpkgs/commit/52dc97ca376b7decac3d9ab43dd4be1e7c859add) ocamlPackages.cryptokit: 1.19 -> 1.20.1
* [`4190957d`](https://github.com/NixOS/nixpkgs/commit/4190957df97bf02d791f8c172f6edaf41d316298) python312Packages.tinytuya: 1.14.0 -> 1.15.1
* [`66d41e75`](https://github.com/NixOS/nixpkgs/commit/66d41e75e89aa7cf3484c97b5c006c36da5fc56f) python{39,310,311,312,313}: Allow using cc to resolve dynamic libraries
* [`64c6e422`](https://github.com/NixOS/nixpkgs/commit/64c6e42213917d4cbaaf76188afcb76d6eb1b4ad) python312Packages.r2pipe: 1.9.2 -> 1.9.4
* [`e7e1dea3`](https://github.com/NixOS/nixpkgs/commit/e7e1dea32df4c65009943523821e6ce36f0bca5c) domoticz: 2024.4 -> 2024.7
* [`d78ff5d1`](https://github.com/NixOS/nixpkgs/commit/d78ff5d116e0fb3ee3dc60fd3ada6f0d35b6c77b) python312Packages.pyqt6-sip: 13.6.0 -> 13.8.0
* [`2e209e6f`](https://github.com/NixOS/nixpkgs/commit/2e209e6f7f6efbe676ffed5881ce8e649404ddb2) buildkite-agent-metrics: 5.9.7 -> 5.9.8
* [`272af6c5`](https://github.com/NixOS/nixpkgs/commit/272af6c543c2e868951e4b5d0107f6e3da284514) tutanota-desktop: 235.240712.0 -> 235.240718.0
* [`aa664147`](https://github.com/NixOS/nixpkgs/commit/aa664147ee3198a86d30afac33f8f70690fcc00f) bundletool: 1.17.0 -> 1.17.1
* [`29f0444f`](https://github.com/NixOS/nixpkgs/commit/29f0444f1b5cfa28755104c4027a3d26b6197f79) ocamlPackages.resto-cohttp-client: 1.0 -> 1.2
* [`e58be96f`](https://github.com/NixOS/nixpkgs/commit/e58be96f5a2a1853a10223a0a9465c5d6974510a) ocamlPackages.dates_calc: 0.0.4 -> 0.0.6
* [`11034aa6`](https://github.com/NixOS/nixpkgs/commit/11034aa69988696ef1f1b302d9f64c1e516440d4) ocamlPackages.timedesc: 2.0.0 -> 3.1.0
* [`c65ec3ff`](https://github.com/NixOS/nixpkgs/commit/c65ec3ffa0923847d21bf5536bc242e4d375c681) ocamlPackages.tsdl-mixer: 0.5 -> 0.6
* [`b356b7e8`](https://github.com/NixOS/nixpkgs/commit/b356b7e8a3a823e286130762ae6cf090a167b34b) ocamlPackages.tezt: 4.0.0 -> 4.1.0
* [`e90fae6a`](https://github.com/NixOS/nixpkgs/commit/e90fae6a96f77cb88ec3ff10e0e1eb80e081fee7) wine64Packages{stable,staging,unstable}.minimal: enable MinGW on Darwin
* [`64c6d5f1`](https://github.com/NixOS/nixpkgs/commit/64c6d5f183c59122c2ef53ccc81f24f9cc657163) usbutils: build and install usbreset
* [`3150b3bd`](https://github.com/NixOS/nixpkgs/commit/3150b3bd7551d8604cbff05bab981cf11f3c025b) usbutils: fix meta
* [`f3722c3f`](https://github.com/NixOS/nixpkgs/commit/f3722c3f9d1fd7487d1d1f9b0a814d205171ecd0) python312Packages.pytorch-metric-learning: 2.5.0 -> 2.6.0
* [`369e50d8`](https://github.com/NixOS/nixpkgs/commit/369e50d885301b80a0315c87379bfa5dd3da6612) python312Packages.grpcio-tools: 1.64.1 -> 1.65.1
* [`e10fa9b5`](https://github.com/NixOS/nixpkgs/commit/e10fa9b5e2879cf24f5f10294230aa1e5083b7c0) java-service-wrapper: 3.5.58 -> 3.5.59
* [`4945979e`](https://github.com/NixOS/nixpkgs/commit/4945979ed624e49d5cede0c7cb1161dba200900b) notmuch-bower: 1.0 -> 1.1
* [`2285ecde`](https://github.com/NixOS/nixpkgs/commit/2285ecdeb3a86a27dce4be43bdbed3c78d655478) roomeqwizard: 5.31.2 -> 5.31.3
* [`d2db417d`](https://github.com/NixOS/nixpkgs/commit/d2db417d1b44e15a4d219d0d94383bac374c32f3) python312Packages.tempora: 5.6.0 -> 5.7.0
* [`ad5c6904`](https://github.com/NixOS/nixpkgs/commit/ad5c6904973dbee6e0add6c896f711783ddf81cc) questdb: 8.0.1 -> 8.1.0
* [`2c5a1a10`](https://github.com/NixOS/nixpkgs/commit/2c5a1a1019569979923e09362821deae4533a938) python312Packages.grpcio-tools: refactor
* [`fc48ee30`](https://github.com/NixOS/nixpkgs/commit/fc48ee3027cf06f0d7b2152f93bafce3f61a5b3c) freenect: 0.7.0 -> 0.7.5
* [`137d5202`](https://github.com/NixOS/nixpkgs/commit/137d52020d61966f330f149dd4238241d75a8ca0) ocamlPackages.ppx_yojson_conv_lib: 0.16.0 -> 0.17.0
* [`3f059cf7`](https://github.com/NixOS/nixpkgs/commit/3f059cf73a6543ad19bbd7e234c868bc31d55c4f) httping: 3.6 -> 4.1.0
* [`cef4449c`](https://github.com/NixOS/nixpkgs/commit/cef4449cd1420d6cac34ffba25664d671bfcb1f3) neo4j: 5.21.0 -> 5.22.0
* [`0af83e77`](https://github.com/NixOS/nixpkgs/commit/0af83e770a3985067f105dc1294443e08fe0be53) meson: 1.5.0 -> 1.5.1
* [`7fa7304d`](https://github.com/NixOS/nixpkgs/commit/7fa7304d22b5c4b9dbfd7f3550d2704e8444724d) ocamlPackages.ppx_blob: 0.8.0 -> 0.9.0
* [`af58c6c6`](https://github.com/NixOS/nixpkgs/commit/af58c6c6210263a23a4f9d3bcae68f6263545fb4) nomad-driver-containerd: init at 0.9.4
* [`24655f78`](https://github.com/NixOS/nixpkgs/commit/24655f78040b420c6af6103c714f2c052a533592) patch-shebangs: don't patch shebangs with bash builtins
* [`4c6e132c`](https://github.com/NixOS/nixpkgs/commit/4c6e132c7ed1928d347e48dc1f2ea6013f48cd6d) lib/systems: use execline’s exec instead of runtimeShell
* [`7e3e4704`](https://github.com/NixOS/nixpkgs/commit/7e3e47048619efe9027bb494ff11e130c25ad717) fwts: 24.03.00 -> 24.07.00
* [`dd3fd182`](https://github.com/NixOS/nixpkgs/commit/dd3fd18213ac2f33fdd6e0a6a918112d777039d0) iqtree: 2.3.5 -> 2.3.6
* [`99ae138a`](https://github.com/NixOS/nixpkgs/commit/99ae138ab7ee9230999c4e515b663d445f2b69a0) kubecm: 0.30.0 -> 0.31.0
* [`aa2d1bf2`](https://github.com/NixOS/nixpkgs/commit/aa2d1bf23f06929b82b5b9a267f7410fc86377d9) ocamlPackages.ocaml_sqlite3: 5.1.0 -> 5.2.0
* [`48327e9b`](https://github.com/NixOS/nixpkgs/commit/48327e9ba08ec3e182bd9c7ea40007d0d90a3d53) secp256k1: 0.5.0 -> 0.5.1
* [`dd719848`](https://github.com/NixOS/nixpkgs/commit/dd7198480710369d130634662b8f93d59c2abef8) gtimelog: unstable-2023-10-05 -> 0.12.0
* [`f4de0b97`](https://github.com/NixOS/nixpkgs/commit/f4de0b978b60903277ec8cfe1bb4502b9b1bf691) kaldi: 0-unstable-2024-06-03 -> 0-unstable-2024-07-25
* [`6266094e`](https://github.com/NixOS/nixpkgs/commit/6266094e825c95395368331aa76d857909505a42) pythonPackages.mako: disable broken tests in llvm
* [`351e8e51`](https://github.com/NixOS/nixpkgs/commit/351e8e515314dbacb2b35a3f9b7f152297746de4) ec2-ami-tools: 1.5.7 -> 1.5.19
* [`349cf6ba`](https://github.com/NixOS/nixpkgs/commit/349cf6ba9cf3d02190f1c845421ed531ac47dd48) photini: fix build by using pyside6
* [`72198697`](https://github.com/NixOS/nixpkgs/commit/721986970def3ff39e43e795bfd567b87832d0d5) python312Packages.ptpython: 3.0.28 -> 3.0.29
* [`b824e677`](https://github.com/NixOS/nixpkgs/commit/b824e67750993aa6331c47b585d486bd2c420c4a) dhewm3: 1.5.3 -> 1.5.4
* [`b8fafeb0`](https://github.com/NixOS/nixpkgs/commit/b8fafeb09c18432cde8cdb1ef00a23d145a3418f) python312Packages.ptpython: refactor
* [`7cad420b`](https://github.com/NixOS/nixpkgs/commit/7cad420bb9f940171d7ed839b65e0fc816f880d3) checkpolicy: 3.6 -> 3.7
* [`f5338c65`](https://github.com/NixOS/nixpkgs/commit/f5338c6522ee6713edd7a729e356024675186ce4) ultrastardx: 2024.5.1 -> 2024.8.0
* [`b63f6251`](https://github.com/NixOS/nixpkgs/commit/b63f62510f7b573a6f712ce7df5e21921cd2cdc7) libmysqlconnectorcpp: 8.4.0 -> 9.0.0
* [`08583c57`](https://github.com/NixOS/nixpkgs/commit/08583c57fa6cbe6f1121cffe38391875dfce0ffa) qtractor: 1.0.0 -> 1.1.1
* [`821ed220`](https://github.com/NixOS/nixpkgs/commit/821ed220bb425d9eb41193ad3aa078d72bd2fc08) igir: 2.9.2 -> 2.11.0
* [`93ff87e4`](https://github.com/NixOS/nixpkgs/commit/93ff87e4ffa2178066dc11699b5d9f450ea0ec9b) python312Packages.flake8: 7.1.0 -> 7.1.1
* [`168ddc1d`](https://github.com/NixOS/nixpkgs/commit/168ddc1d8dbec60d0c8e9d31161d803e642cff3c) karate: 1.4.1 -> 1.5.0
* [`38189021`](https://github.com/NixOS/nixpkgs/commit/3818902133740330c9e4273cacb9ca07f1f18e8e) libzdb: 3.2.3 -> 3.4.0
* [`612ff0c5`](https://github.com/NixOS/nixpkgs/commit/612ff0c5d9dee3e00431879b344e989ab454858f) icingaweb2-ipl: 0.13.2 -> 0.14.1
* [`5f2b6c65`](https://github.com/NixOS/nixpkgs/commit/5f2b6c65b77c2f6c993ba1ce27c7721c58a690f8) mpvScripts.thumbfast: 0-unstable-2023-12-08 -> 0-unstable-2024-08-02
* [`8d7c0f47`](https://github.com/NixOS/nixpkgs/commit/8d7c0f47a6f154fc8836476f2bd078b540125a90) ddev: 1.23.3 -> 1.23.4
* [`d477ba6a`](https://github.com/NixOS/nixpkgs/commit/d477ba6a98f0a4c12ac3b3f4bff56048d5c7b7b1) python312Packages.ftfy: 6.2.0 -> 6.2.3
* [`b053e443`](https://github.com/NixOS/nixpkgs/commit/b053e443478b1a0632121d338e6928b0630232c8) exfatprogs: 1.2.4 -> 1.2.5
* [`52ce489c`](https://github.com/NixOS/nixpkgs/commit/52ce489ca7c52c117dc2c18ab0232e1dad1cc85b) cp2k: 2024.1 -> 2024.2
* [`e569e958`](https://github.com/NixOS/nixpkgs/commit/e569e95867771d1378f04d421aa24c40104c45b8) sacad: 2.7.5 -> 2.8.0
* [`2b43b3fa`](https://github.com/NixOS/nixpkgs/commit/2b43b3faa278a923af0c6012458d42a4b3301c6b) python312Packages.ftfy: fix license
* [`18614a25`](https://github.com/NixOS/nixpkgs/commit/18614a25c0db423ce61ebe38c32c2ba5640a2996) python312Packages.ftfy: modernize attribute names
* [`388bcf6e`](https://github.com/NixOS/nixpkgs/commit/388bcf6e3e56c4a376dfeecdec482fae2809930e) python312Packages.pyyaml: 6.0.1 -> 6.0.2
* [`1568b766`](https://github.com/NixOS/nixpkgs/commit/1568b766c49ed1c1edca86561fc145580008d96b) oneDNN: 3.5 -> 3.5.3
* [`9059a37d`](https://github.com/NixOS/nixpkgs/commit/9059a37d41fb5ffb2a0b7b1e01025a4761a175ef) python312Packages.pynetbox: 7.3.4 -> 7.4.0
* [`11026bcc`](https://github.com/NixOS/nixpkgs/commit/11026bcc424175bbdfaca6fbe1c687b1902ea340) polychromatic: 0.9.1 -> 0.9.2
* [`d64658d1`](https://github.com/NixOS/nixpkgs/commit/d64658d11a71109fc27cd7cdcec66dafd0383821) ts1-signatures: init at unstable-2024-08-10
* [`2939ad7b`](https://github.com/NixOS/nixpkgs/commit/2939ad7bd9383986a2b67e0820bf8f497d512d5b) curl-impersonate: 0.6.1 -> 0.7.0
* [`8f8d42c8`](https://github.com/NixOS/nixpkgs/commit/8f8d42c893e81157f4937719047f5013d3270dcb) leftwm-{config,theme}: update, migrate to by-name, refactor
* [`0e625c76`](https://github.com/NixOS/nixpkgs/commit/0e625c76086e662bcaf347d7c7873ccb2d6c1853) maintainers: add ajgon
* [`5f26c661`](https://github.com/NixOS/nixpkgs/commit/5f26c661bd2716e29f9f5164eecd02ae6ea61e9b) xmrig-proxy: 6.21.1 -> 6.22.0
* [`c19c741a`](https://github.com/NixOS/nixpkgs/commit/c19c741a98da62349ee05ad868d8489bfe9d2e2d) xmrig: 6.21.3 -> 6.22.0
* [`87480a33`](https://github.com/NixOS/nixpkgs/commit/87480a3334945a779f3665f434a09f263d4b379b) whatsie: init at 4.15.3
* [`f8378d59`](https://github.com/NixOS/nixpkgs/commit/f8378d5909058a4b9389cc36cd2c43ef317425fd) python312Packages.pyfwup: 0.5.0 -> 0.5.2
* [`c40e83f4`](https://github.com/NixOS/nixpkgs/commit/c40e83f4c56c8dc051eacf9ee9e93e154973e196) maintainers: add baksa
* [`d237d96f`](https://github.com/NixOS/nixpkgs/commit/d237d96f9370ab6bfc5a2f18313d0fabdb2b5a8a) python312Packages.pytest-examples: 0.0.12 -> 0.0.13
* [`90eda56f`](https://github.com/NixOS/nixpkgs/commit/90eda56fc83d3264418a506e285c8b03a2c28bae) vips: 8.15.2 -> 8.15.3
* [`982a4342`](https://github.com/NixOS/nixpkgs/commit/982a4342778517c7edc76d759240ffc63d7d66b0) elasticmq-server-bin: 1.6.5 -> 1.6.7
* [`6951bbad`](https://github.com/NixOS/nixpkgs/commit/6951bbad8f10f44e06bce9a99e4a52f51a5c4257) fluidd: 1.30.1 -> 1.30.3
* [`25fcab15`](https://github.com/NixOS/nixpkgs/commit/25fcab15545c5afb53724ed9021de71ae6d117fd) steam: fix bootstrap tarball with non-default steamroot
* [`b24de405`](https://github.com/NixOS/nixpkgs/commit/b24de4052b76d01d3db49c2b5ca13d96359a09ac) doc: refactor documentation for lib.{composeExtensions,composeManyExtensions}
* [`dea395bb`](https://github.com/NixOS/nixpkgs/commit/dea395bbad7239f25761b615fd24f0607c77f644) format: lib/fixed-points
* [`117e468d`](https://github.com/NixOS/nixpkgs/commit/117e468da4642bf43cffe0336bb9f8a22921645b) graphene: tighten withDocumentation default
* [`4249fa33`](https://github.com/NixOS/nixpkgs/commit/4249fa33f622eaf9ffebc3d7a01cb74d6bbf6704) gnutls: enable ktls support
* [`5be4ecc1`](https://github.com/NixOS/nixpkgs/commit/5be4ecc1c44eb566cd6a2dd537325cd891e9d2a9) emacs: make melpaBuild accept recipe content as a string
* [`f01c891a`](https://github.com/NixOS/nixpkgs/commit/f01c891a3fb8b91fa2573676b276352c613e096d) space-station-14-launcher: 0.28.0 -> 0.28.1
* [`9717a2f8`](https://github.com/NixOS/nixpkgs/commit/9717a2f8fa7c355c8cebc40c9a95103cda7938b8) llvmPackages_14.lldbPlugins.llef: 1.1.0 -> 1.2.0
* [`aec6f3a9`](https://github.com/NixOS/nixpkgs/commit/aec6f3a99c06da504de9eaad009c7b7f32368efe) summon: 0.10.0 -> 0.10.1
* [`941cc5b5`](https://github.com/NixOS/nixpkgs/commit/941cc5b522ca1229089ddf3a61cc0151530da311) boogie: 3.2.3 -> 3.2.4
* [`02396716`](https://github.com/NixOS/nixpkgs/commit/023967169b3524a16a9e967b9dbe7880bd335570) python3Packages.k5test: fix krb5-config paths
* [`bd8dec23`](https://github.com/NixOS/nixpkgs/commit/bd8dec23eb083175b37589c7517d83f9fb500c70) python312Packages.minio: 7.2.7 -> 7.2.8
* [`6efed403`](https://github.com/NixOS/nixpkgs/commit/6efed4036bd621fe4142fb9436393f1ad8159aab) python312Packages.cmaes: 0.11.0 -> 0.11.1
* [`3b9a5c74`](https://github.com/NixOS/nixpkgs/commit/3b9a5c7421ce8fb00803708d48c2a607eb8fce54) python312Packages.opentsne: 1.0.1 -> 1.0.2
* [`f235dda8`](https://github.com/NixOS/nixpkgs/commit/f235dda87f8c1efd01fe92eb8e26e9d1f7736eb2) nixos/wireless: reimplement secrets using ext_password_backend
* [`f951caf1`](https://github.com/NixOS/nixpkgs/commit/f951caf18620516590a11b4d891f4b97fa4a5963) nixos/release-notes: mention networking.wireless changes
* [`ef14f41c`](https://github.com/NixOS/nixpkgs/commit/ef14f41c38c7ec28c38418c80fea5d059e227a84) beetsPackages.alternatives: 0.11.1 -> 0.13.0
* [`cf2eaa54`](https://github.com/NixOS/nixpkgs/commit/cf2eaa548152f7d5a0fffdc2aecec821c67a4a0b) python312Packages.pyjwt: 2.8.0 -> 2.9.0
* [`0b9248aa`](https://github.com/NixOS/nixpkgs/commit/0b9248aa2586346e2d7d01bd6ba38fbbc26df76e) sickgear: 3.32.3 -> 3.32.7
* [`d7eb7d3c`](https://github.com/NixOS/nixpkgs/commit/d7eb7d3cb8db63465855204d0b1d59cb583e7479) mpvScripts.mpv-osc-tethys: init at 0-unstable-2024-08-19
* [`787b544f`](https://github.com/NixOS/nixpkgs/commit/787b544f2ae5ed42e5f8e5c673894f64ed66695c) netbird-dashboard: 2.3.0 -> 2.5.0
* [`89a8fc95`](https://github.com/NixOS/nixpkgs/commit/89a8fc9557f11dbaa2d35b3d8816de3fc58aa480) openapi-generator-cli: 7.7.0 -> 7.8.0
* [`84762ac4`](https://github.com/NixOS/nixpkgs/commit/84762ac4d0bd7a0da97aa8945020c39268d6155c) libinput: 1.26.1 -> 1.26.2
* [`f45aa7dd`](https://github.com/NixOS/nixpkgs/commit/f45aa7ddf7785fa3d3c3c73102184dd27c4bcf29) kokkos: 4.3.01 -> 4.4.00
* [`4c2e720a`](https://github.com/NixOS/nixpkgs/commit/4c2e720a58bc4c6903147a34d9fd9699276d5986) pbzx: fix build with musl libc
* [`4c74c839`](https://github.com/NixOS/nixpkgs/commit/4c74c8391fd29fe2183d7a9c165ae7e6b55ba836) kubebuilder: 4.1.1 -> 4.2.0
* [`68752480`](https://github.com/NixOS/nixpkgs/commit/687524806bd921549dfd9474523b8308ee016e2b) xsos: 0.7.19 -> 0.7.33
* [`0c2e6f18`](https://github.com/NixOS/nixpkgs/commit/0c2e6f18fdfcda215322f81f0dcbab7dd82803ed) python312Packages.pytest-textual-snapshot: 0.4.0 -> 1.0.0
* [`f000781f`](https://github.com/NixOS/nixpkgs/commit/f000781fce5d50469f514191931569464d9a383d) sqlcipher: 4.6.0 -> 4.6.1
* [`7e7b8af1`](https://github.com/NixOS/nixpkgs/commit/7e7b8af1e631b58441dc904f5fb1bfee683215dd) mercure: 0.16.2 -> 0.16.3
* [`7d380b30`](https://github.com/NixOS/nixpkgs/commit/7d380b3089644385b4b6084e6c8f75300da7a623) python312Packages.gemfileparser2: 0.9.3 -> 0.9.4
* [`12e96c77`](https://github.com/NixOS/nixpkgs/commit/12e96c77f163a15b978481a06cedcc9fc947a09b) python312Packages.datadog: 0.49.1 -> 0.50.0
* [`45a61d0e`](https://github.com/NixOS/nixpkgs/commit/45a61d0e3bcf21877a7a5dd80d1efc14a8869ad3) rootlesskit: 2.1.0 -> 2.3.1
* [`a40843fd`](https://github.com/NixOS/nixpkgs/commit/a40843fda22ac6f4e19472c3e507c1e83cb0f6f9) cloudfoundry-cli: 8.7.11 -> 8.8.0
* [`e81bb18a`](https://github.com/NixOS/nixpkgs/commit/e81bb18a0f23dc88f08ccd58d526be969934a01c) kak-tree-sitter: init at 1.1.2
* [`31cd26ea`](https://github.com/NixOS/nixpkgs/commit/31cd26eaced20dc2fa6de9571627879f4a58019d) keybase: 6.3.1 -> 6.4.0
* [`02e6cbc6`](https://github.com/NixOS/nixpkgs/commit/02e6cbc6cadc8cc1d24885eea2500ef0deba6fe1) snipe-it: 7.0.7 -> 7.0.11
* [`6c166ced`](https://github.com/NixOS/nixpkgs/commit/6c166ced421740ee6c108d546e350aa8899a623a) publicsuffix-list: 0-unstable-2024-06-19 -> 0-unstable-2024-08-21
* [`bea8c866`](https://github.com/NixOS/nixpkgs/commit/bea8c86677734dedd8e0b37cac6d32a5299898b4) vassal: 3.7.12 -> 3.7.14
* [`fd0cd7c9`](https://github.com/NixOS/nixpkgs/commit/fd0cd7c98f3a4beed3176df11a0aa462f263c349) librepo: 1.18.0 -> 1.18.1
* [`b0425259`](https://github.com/NixOS/nixpkgs/commit/b04252595536dd2c3c600fd33439e17097a4b382) maintainers: add asterismono
* [`1890efc3`](https://github.com/NixOS/nixpkgs/commit/1890efc3bf9d02a1bd6a3a6a02d6c0f2a3a3b7ad) gtk-pipe-viewer: 0.5.2 -> 0.5.3
* [`ed67b10a`](https://github.com/NixOS/nixpkgs/commit/ed67b10a8ccf169289548f4b70c8639226265a54) ocamlPackages.lambdasoup: 1.0.0 -> 1.1.0
* [`1d5fa251`](https://github.com/NixOS/nixpkgs/commit/1d5fa2511991aadd115c5d264ee2cd19a2b598f7) ocamlPackages.miou: 0.2.0 -> 0.3.0
* [`a3ad1532`](https://github.com/NixOS/nixpkgs/commit/a3ad1532fb875a24e713c2bc0692e09a8d6a01b9) osv-scanner: 1.8.3 -> 1.8.4
* [`97dd5614`](https://github.com/NixOS/nixpkgs/commit/97dd5614be83dcbded368ef567803e6e1ffd7f00) ungit: 1.5.26 -> 1.5.27
* [`4d0d7dfc`](https://github.com/NixOS/nixpkgs/commit/4d0d7dfcecd3570557a8b0fbb5551116b95b586b) nixos/tests/wpa_supplicant: use secretsFile and split subcases
* [`5bc31cf5`](https://github.com/NixOS/nixpkgs/commit/5bc31cf591df699233e3f41c51e4a7f20ef65cbe) tidb: 8.1.0 -> 8.3.0
* [`89eb93dc`](https://github.com/NixOS/nixpkgs/commit/89eb93dc3ffda68535d6ee51a7825f1de31ae658) nixos/wireless: link config to /etc by default
* [`f28182d4`](https://github.com/NixOS/nixpkgs/commit/f28182d44a7f9e42f9691221a2df0747b2df7ec5) libkvmi: init at 1.1.0-unstable-2023-12-13
* [`39fd9bbb`](https://github.com/NixOS/nixpkgs/commit/39fd9bbb58e4026995405a4f022bac8964a5118c) libvmi: move to pkgs/by-name
* [`0fae3ce9`](https://github.com/NixOS/nixpkgs/commit/0fae3ce9627e3281b56f18415a26229cbbce3aa1) libvmi: format with nixfmt-rfc-style
* [`5596ac58`](https://github.com/NixOS/nixpkgs/commit/5596ac5840346bf7e7873e9f91e51875385e1785) istioctl: 1.22.3 -> 1.22.4
* [`6b2530d2`](https://github.com/NixOS/nixpkgs/commit/6b2530d2416b7611a0200bc61ff7b499eb8369b9) python312Packages.aiohttp: 3.10.3 -> 3.10.5
* [`ed3f1962`](https://github.com/NixOS/nixpkgs/commit/ed3f196204c271820547e823e7c532234a0d5251) openxr-loader: 1.1.38 -> 1.1.40
* [`b98cad25`](https://github.com/NixOS/nixpkgs/commit/b98cad25a72deff0ad8b10adbe6f718f3f0fa39a) xlights: 2024.14 -> 2024.15
* [`733dcef8`](https://github.com/NixOS/nixpkgs/commit/733dcef8657cb49bf51b53f75afb83e5cc605935) mssql_jdbc: 12.8.0 -> 12.8.1
* [`caef6dd3`](https://github.com/NixOS/nixpkgs/commit/caef6dd355ad6cc584a5e316c545808e7636b185) curl: enable configure flag `--enable-versioned-symbols`
* [`45db1ff7`](https://github.com/NixOS/nixpkgs/commit/45db1ff7c1aa8219a83e3fd48034fdf58706fd00) nodejs_20: 20.16.0 -> 20.17.0 ([nixos/nixpkgs⁠#336388](https://togithub.com/nixos/nixpkgs/issues/336388))
* [`c455cc31`](https://github.com/NixOS/nixpkgs/commit/c455cc3170d68f05b4614c41883a7d417d1c16e0) nodejs_22: 22.6.0 -> 22.7.0 ([nixos/nixpkgs⁠#336556](https://togithub.com/nixos/nixpkgs/issues/336556))
* [`911aa144`](https://github.com/NixOS/nixpkgs/commit/911aa1440f40405f13f9252e2eb8ffc12f269090) treewide: support NIX_SSL_CERT_FILE as an impureEnvVar
* [`7eb5c099`](https://github.com/NixOS/nixpkgs/commit/7eb5c0991cc5e6ad7fcef92848157e83e23f5fe8) doc: add proxy usage to fetchers chapter
* [`1ea135a1`](https://github.com/NixOS/nixpkgs/commit/1ea135a1175a24bd44e65a3f333cc5e253087235) grizzly: 0.4.3 -> 0.4.5
* [`e76eb726`](https://github.com/NixOS/nixpkgs/commit/e76eb726088f65fd19cce0244b26e3d67c9a726c) ocamlPackages.ocaml-version: 3.6.7 -> 3.6.8
* [`2067f837`](https://github.com/NixOS/nixpkgs/commit/2067f837dc17e5bb1e102b605396560960f3ea14) scdl: 2.11.4 -> 2.12.1
* [`0a4fb986`](https://github.com/NixOS/nixpkgs/commit/0a4fb986558dd24ffa46088bbb991dc8c3198f49) lvm2: 2.03.23 -> 2.03.24
* [`ee6a0e37`](https://github.com/NixOS/nixpkgs/commit/ee6a0e376d4e6cb4d8c980eedff78cceeef18a1e) kvdo: drop
* [`f5fa4e0c`](https://github.com/NixOS/nixpkgs/commit/f5fa4e0cc890b1a6ccf8cce32944a7e7a49cae85) nixos/tests/lvm2/vdo: only build latest kernel
* [`9366ef0f`](https://github.com/NixOS/nixpkgs/commit/9366ef0fbd3e5ddb495b2c38ab861d66f569fdd7) vdo: 8.2.2.2 -> 8.3.0.71
* [`31f61f52`](https://github.com/NixOS/nixpkgs/commit/31f61f5254bf27f5e2a73dc058757c40ecf8aeed) lvm2: 2.03.24 -> 2.03.25
* [`bd0539cb`](https://github.com/NixOS/nixpkgs/commit/bd0539cb2086b948cb57cb2e9876efff3e47bfb8) nixos/tasks/lvm: assert kernel version for vdo
* [`eec2ebe8`](https://github.com/NixOS/nixpkgs/commit/eec2ebe81aae6523512ad5d78bcafcf8c5f58da5) lvm2: 2.03.25 -> 2.03.26
* [`222e4aba`](https://github.com/NixOS/nixpkgs/commit/222e4aba8981f75c6376948f15d7f3af65ed37a8) rocketchat-desktop: 4.0.1 -> 4.0.2
* [`8cc7bfe6`](https://github.com/NixOS/nixpkgs/commit/8cc7bfe625805ae412eb091bf08c457b527a46ee) maintainers: Add istoph and textshell
* [`5547322a`](https://github.com/NixOS/nixpkgs/commit/5547322a0c01dd30a7e0111adc1f02bafbbd6ebc) postgresql: move dynamic modules to default output
* [`77977286`](https://github.com/NixOS/nixpkgs/commit/77977286d80c9bfb77cbf80989d41c59d66dccf8) postgresql: move libecpq to lib output
* [`435f51c3`](https://github.com/NixOS/nixpkgs/commit/435f51c37faf74375134dfbd7c5a4560da2a9ea7) postgresql: split dev output
* [`94d432ce`](https://github.com/NixOS/nixpkgs/commit/94d432ce88b6dff272a17b4ed15dbefca14097fc) postgresql: remove references to llvm-dev on darwin as well
* [`dfde86f7`](https://github.com/NixOS/nixpkgs/commit/dfde86f73857f575ae79785c1da9496599b38b2c) postgresql: refactor removal of references in bitcode files
* [`73cb4036`](https://github.com/NixOS/nixpkgs/commit/73cb40366df17b3224970ae80e64527687bd5023) postgresql: refactor to simplify condition
* [`19770f00`](https://github.com/NixOS/nixpkgs/commit/19770f0097f4436c2b3147ad0f489ce08e84463a) maturin: 1.7.0 -> 1.7.1
* [`3721cfdc`](https://github.com/NixOS/nixpkgs/commit/3721cfdcafe8dabc8cf0115f69216cfd2c300466) indicator-sound-switcher: 2.3.9 -> 2.3.10.1
* [`ee075da7`](https://github.com/NixOS/nixpkgs/commit/ee075da75169ba8067d161dd31e180060fa82cb8) python312Packages.pybind11: 2.13.1 -> 2.13.5
* [`6e725d46`](https://github.com/NixOS/nixpkgs/commit/6e725d468c2bf2efcd732e2c1880bc32c4c3ee8c) libpsl: don't make first output conditional if build statically
* [`f2d6afbb`](https://github.com/NixOS/nixpkgs/commit/f2d6afbb926517e1101e17db1682d075da80745f) nwg-clipman: init at 0.2.3
* [`727a2402`](https://github.com/NixOS/nixpkgs/commit/727a2402f83e8eb3bc87cebc18c994d58fd143ea) python312Packages.gemfileparser2: update meta.homepage
* [`9d655d7c`](https://github.com/NixOS/nixpkgs/commit/9d655d7c6b2e9629c6991ff29953ca40f63cbb7c) python312Packages.gemfileparser2: refactor
* [`6f266f39`](https://github.com/NixOS/nixpkgs/commit/6f266f390dc4f390af01c9ffbe238a915472d449) haven-cli: 4.0.2 -> 4.1.0
* [`ab911931`](https://github.com/NixOS/nixpkgs/commit/ab91193111aeb9dd587fb4162ec69af048c470a5) swaylock: 1.7.2 -> 1.8.0
* [`17c9dc89`](https://github.com/NixOS/nixpkgs/commit/17c9dc89607b35948c2aa611ef5b638e543c6d5e) svt-av1: 2.1.2 -> 2.2.0
* [`143cc364`](https://github.com/NixOS/nixpkgs/commit/143cc364ea1e88fc86036ea55113b87e84cbb6de) webwormhole: unstable-2023-02-25 -> 0-unstable-2023-11-15
* [`2e73274b`](https://github.com/NixOS/nixpkgs/commit/2e73274b605341828eb1aae87087c694eb29ad18) veilid: add updateScript
* [`e3fb33ee`](https://github.com/NixOS/nixpkgs/commit/e3fb33ee11faa453465cf7da7e9a91a2b2205796) mc: 4.8.31 -> 4.8.32
* [`4152b7ed`](https://github.com/NixOS/nixpkgs/commit/4152b7ed06024ce36c3416024e48ab59ed746de1) sosreport: 4.7.2 -> 4.8.0
* [`33766569`](https://github.com/NixOS/nixpkgs/commit/337665691f15a90ac2491349fc930977d6fc914c) ceph-csi: 3.11.0 -> 3.12.1
* [`1efcffa7`](https://github.com/NixOS/nixpkgs/commit/1efcffa700a0650bfab2beb40b6e538d2bfb4bfc) stdenv: support default values in concatTo
* [`f96e2089`](https://github.com/NixOS/nixpkgs/commit/f96e20895fbbde870aec134d04352b55f6344865) bmake: support structuredAttrs in setup hook
* [`c3900d12`](https://github.com/NixOS/nixpkgs/commit/c3900d12c9805df2ad26b24c0475de4f951f25d2) just: support structuredAttrs in setup hook
* [`8affc6a0`](https://github.com/NixOS/nixpkgs/commit/8affc6a06fc1a21c8dd6007b24e35a1cdff23e56) just: shellcheck setup hook
* [`add9bca4`](https://github.com/NixOS/nixpkgs/commit/add9bca495a7f0679156e8b8869f96b433778a28) waf: support structuredAttrs in setup hook
* [`55640420`](https://github.com/NixOS/nixpkgs/commit/55640420313c92c988c543ae3022009f9bfb20d7) zig: support structuredAttrs in setup hook
* [`e3191276`](https://github.com/NixOS/nixpkgs/commit/e3191276d9e36fbffafa2c969b36c1569245510c) zig: improve shellcheck disable comments
* [`5d3e7203`](https://github.com/NixOS/nixpkgs/commit/5d3e7203cea89b8db01dc18e7b2447cc6c1f4c92) build2: support structuredAttrs in setup hook
* [`b42b6495`](https://github.com/NixOS/nixpkgs/commit/b42b649581b9f845173bc7c6727aa2536c30f350) build2: shellcheck setup hook
* [`4a48b924`](https://github.com/NixOS/nixpkgs/commit/4a48b9242cbe9bd8aaf3d630d78784c62ec461ce) scons: support structuredAttrs in setup hook
* [`5c740315`](https://github.com/NixOS/nixpkgs/commit/5c740315edaca42781cb0cf5a3b924d7cb61e965) scons: add missing checkTarget in setup hook
* [`bc0468d6`](https://github.com/NixOS/nixpkgs/commit/bc0468d6edfc769aefca04f0dd0ec953619ae2d9) premake: support structuredAttrs in setup hook
* [`b072c1f7`](https://github.com/NixOS/nixpkgs/commit/b072c1f723747ab7d98f344430e293cd17872449) premake: shellcheck setup hook
* [`544b981c`](https://github.com/NixOS/nixpkgs/commit/544b981c3eb5f65ed8d56e98ee7d526a1322c4ae) gn: support structuredAttrs in setup hook
* [`5b370227`](https://github.com/NixOS/nixpkgs/commit/5b370227d11ee87fc308fb9165813acb5626f9f2) gn: shellcheck setup hook
* [`1bcca7d6`](https://github.com/NixOS/nixpkgs/commit/1bcca7d66b0a052b703d029c4593434b84136455) qt: support structuredAttrs in qmake hook
* [`581aebcd`](https://github.com/NixOS/nixpkgs/commit/581aebcdad092b228b02ac068bb28d6b2a22b909) perl: support structuredAttrs in generic builder
* [`78463332`](https://github.com/NixOS/nixpkgs/commit/78463332d0722485b0f846754ea6d1c5d7227bf3) runelite: 2.7.1 -> 2.7.2
* [`38bc2c47`](https://github.com/NixOS/nixpkgs/commit/38bc2c471a017931009dbafbc4380a342b92810e) passt: 2024_07_26.57a21d2 -> 2024_08_21.1d6142f
* [`050689db`](https://github.com/NixOS/nixpkgs/commit/050689db307b54c180afd5a4320f57db947e0a7d) treewide: fix pg_config / postgresql headers moved to dev output
* [`cd81adf5`](https://github.com/NixOS/nixpkgs/commit/cd81adf5ae33007c3dd914831f98c8ff653c45a2) openh264: add patch enabling riscv64 support
* [`287e0d32`](https://github.com/NixOS/nixpkgs/commit/287e0d3288a84c595d83c1bed662b29c50cd7317) python3Packages.pytest-order: 1.2.1 -> 1.3.0
* [`b452c2cd`](https://github.com/NixOS/nixpkgs/commit/b452c2cd2ba17aaf4511d5fb584a1741cead0721) xtf: init at 0-unstable-2024-07-25
* [`199115ee`](https://github.com/NixOS/nixpkgs/commit/199115ee3cd36bf04190f57d75c5d0d6b7643616) xen: add xtf to README
* [`2d6ba540`](https://github.com/NixOS/nixpkgs/commit/2d6ba540503a8aca4924bf5f8b3c66bab5d59458) aws-c-auth: 0.7.25 -> 0.7.26
* [`2cbcebca`](https://github.com/NixOS/nixpkgs/commit/2cbcebca4f3777941fb083571f5fe717f93f34a2) zxtune: 5071 -> 5072
* [`013943f1`](https://github.com/NixOS/nixpkgs/commit/013943f1a996696eef91e68d4c48038349c8b483) lapce: 0.4.1 -> 0.4.2
* [`b47a27e7`](https://github.com/NixOS/nixpkgs/commit/b47a27e7f85c716d140c043281a9d0aa8ebe676a) zrok: 0.4.34 -> 0.4.39
* [`178dbecb`](https://github.com/NixOS/nixpkgs/commit/178dbecb442253c30ee52e4b5bb5df172046b09a) irpf: 2024-1.3 -> 2024-1.4
* [`e2f440f8`](https://github.com/NixOS/nixpkgs/commit/e2f440f8b0e148da4ba17801add2d129de3c8d22) seq66: 0.99.13 -> 0.99.14
* [`0835b9f6`](https://github.com/NixOS/nixpkgs/commit/0835b9f6deb1aeb59e68446a8c94a92c1c4bbff8) wayland: 1.23.0 -> 1.23.1
* [`1f5f7844`](https://github.com/NixOS/nixpkgs/commit/1f5f7844485e80928f947faa3a3cc580da0efc1b) mandelbulber: 2.31-1 -> 2.32
* [`5eee6cf4`](https://github.com/NixOS/nixpkgs/commit/5eee6cf40ad44fd4f21b76f26f54ca34a7f5e69e) xar: 1.6.1 -> 498
* [`f3ece349`](https://github.com/NixOS/nixpkgs/commit/f3ece34945e145358cd8c2604b37fb683393f510) nixos/postgresql: fix documentation markdown
* [`2f9c580c`](https://github.com/NixOS/nixpkgs/commit/2f9c580c6f48b8bdea941188b85389601c1ad867) postgresql: use systemdLibs
* [`0abb9f36`](https://github.com/NixOS/nixpkgs/commit/0abb9f36d078b07a3770dcecf2c301fc03a7ada7) mlt: 7.24.0 -> 7.26.0
* [`8abca493`](https://github.com/NixOS/nixpkgs/commit/8abca4935e004866b579532a32e5c0cfa160a483) asfa: 0.10.0 -> 0.10.0-1
* [`403ddc3b`](https://github.com/NixOS/nixpkgs/commit/403ddc3beee04ed0230413b36173690553c84f36) rain: 1.12.0 -> 1.15.0
* [`a0bda77e`](https://github.com/NixOS/nixpkgs/commit/a0bda77e6a849d393fb8765bd2b95f57f4cf1000) socat: 1.8.0.0 -> 1.8.0.1
* [`edb01013`](https://github.com/NixOS/nixpkgs/commit/edb0101339a0ed64d67df66af989e2ed89fad199) lilypond-unstable: 2.25.17 -> 2.25.19
* [`d65b3435`](https://github.com/NixOS/nixpkgs/commit/d65b3435632a8374c4dc2b35d392bee7b93a368e) libcpuid: 0.6.5 -> 0.7.0
* [`345b6687`](https://github.com/NixOS/nixpkgs/commit/345b6687f54861ad160c4f701a80393464a8dd0a) jsonnet-language-server: 0.14.0 -> 0.14.1
* [`23eacd40`](https://github.com/NixOS/nixpkgs/commit/23eacd40cf5907665262e0dbeb24dc4347c575d1) gnupatch: fix segfault on cleanup
* [`3bb9be40`](https://github.com/NixOS/nixpkgs/commit/3bb9be40b3b811fbda57aa83045dc81c1250f366) python312Packages.pygithub: 2.3.0 -> 2.4.0
* [`005b0d6e`](https://github.com/NixOS/nixpkgs/commit/005b0d6ef55ce26badb81883a7394893ae791e6c) graphene: fix `tests.installedTests`
* [`cf99b99f`](https://github.com/NixOS/nixpkgs/commit/cf99b99fe673c2861da33adfc6598de46ec01a67) rabbitmq-server: 3.13.6 -> 3.13.7
* [`29bf0700`](https://github.com/NixOS/nixpkgs/commit/29bf0700ed71295ddd4e960197e79501da8a6cff) qdrant-web-ui: 0.1.30 -> 0.1.31
* [`ad8b4f4e`](https://github.com/NixOS/nixpkgs/commit/ad8b4f4e4f604889cd9ba45f2d4640a7b7d3e26d) hpp-fcl: add missing dependency
* [`ab8a1f83`](https://github.com/NixOS/nixpkgs/commit/ab8a1f839c6ae8f06d8ff9b6d756b4e159471a75) scotch: 7.0.4 -> 7.0.5
* [`d791bfec`](https://github.com/NixOS/nixpkgs/commit/d791bfec05086daae182b284fd61d0d0cd9a2185) hpp-fcl: fix import check
* [`8fdec88d`](https://github.com/NixOS/nixpkgs/commit/8fdec88dd165f19f3d46f3a04d94a4a6416ae938) hpp-fcl: clean cmakeFlags
* [`ec841f6b`](https://github.com/NixOS/nixpkgs/commit/ec841f6b65496e3ed42fe907c8b9190a8ea6ae96) hpp-fcl: nixfmt
* [`4caafb45`](https://github.com/NixOS/nixpkgs/commit/4caafb45e0626a1a759e141626d1b5b8d4dbfa5a) hpp-fcl: move to by-name
* [`36b4ff05`](https://github.com/NixOS/nixpkgs/commit/36b4ff0515f93e15cff9a85bdd55fdefe7837b10) hpp-fcl: also available on other platforms than unix
* [`90a6f86d`](https://github.com/NixOS/nixpkgs/commit/90a6f86d47ed76ef4501bed8a9835c6ccbfb6f50) hpp-fcl: avoid use of meta = with lib;
* [`84defedf`](https://github.com/NixOS/nixpkgs/commit/84defedf7edec6803d632481cd9e0e2cd362350e) scotch: split outputs
* [`229f3bb6`](https://github.com/NixOS/nixpkgs/commit/229f3bb6d7f2688adc6295fd18fc1b522167c592) scotch: shared libs
* [`b363d5ae`](https://github.com/NixOS/nixpkgs/commit/b363d5ae78812d8083b487868f10b51b275df491) terminal-parrot: 1.1.1 -> 1.2.0
* [`60bd9fec`](https://github.com/NixOS/nixpkgs/commit/60bd9fec1eb137eda17ba0390a20059ef1ff012a) vscode-extensions.ms-python.vscode-pylance: 2024.8.1 -> 2024.8.2
* [`048c4cc3`](https://github.com/NixOS/nixpkgs/commit/048c4cc3e0a6e63d3b7c9710419da47e6ed956d0) diffsitter: add updateScript and versionCheckHook
* [`1feaea91`](https://github.com/NixOS/nixpkgs/commit/1feaea91067bd93947cba889f2479c1733908880) swig: swig3 -> swig4
* [`6dfc2e76`](https://github.com/NixOS/nixpkgs/commit/6dfc2e76826d150651f4299b1a8a15944ffdd436) pdfsam-basic: 5.2.4 -> 5.2.6
* [`93eacad9`](https://github.com/NixOS/nixpkgs/commit/93eacad925cd8c337d0041cea532f33c6974007b) bevelbar: 24.06 -> 24.07
* [`981629a0`](https://github.com/NixOS/nixpkgs/commit/981629a05b844bbfc775ac141c692e95fd6a61f7) mumps: update scotch include dir
* [`4075c526`](https://github.com/NixOS/nixpkgs/commit/4075c526ec619f32a946c2cb93f9e081cdc38014) python312Packages.scipy: don't use with lib in meta
* [`5d63abee`](https://github.com/NixOS/nixpkgs/commit/5d63abee89ac0afca31bf7e35be438194634ebc9) python312Packages.scipy: use modern deps Python attributes
* [`f22c6821`](https://github.com/NixOS/nixpkgs/commit/f22c682151b9332bc6b00e424199b40d880069ff) iosevka-bin: 30.3.3 -> 31.4.0
* [`0c8ccd6b`](https://github.com/NixOS/nixpkgs/commit/0c8ccd6b96b5c755f63a50822e5fd44f35b9ff4d) luaPackages.luarocks_bootstrap: Fix build
* [`a153ea8a`](https://github.com/NixOS/nixpkgs/commit/a153ea8a8d1e4f28f08cc298111681fbf50cb495) dopamine: 3.0.0-preview.31 -> 3.0.0-preview.32
* [`3b3cb4c2`](https://github.com/NixOS/nixpkgs/commit/3b3cb4c2d18cc0683009e3e44ca5a6cec745c7af) python312Packages.glyphslib: 6.7.2 -> 6.8.2
* [`8ebecaab`](https://github.com/NixOS/nixpkgs/commit/8ebecaab832dd72e1641bf7baacc7a11e1355ea7) bazel-buildtools: 7.1.2 -> 7.3.1
* [`34123fca`](https://github.com/NixOS/nixpkgs/commit/34123fcafb67ccc676fe5520f2ff1f31c8278ab7) python312Packages.scipy: cleaning + inputs sorting
* [`c45c1e45`](https://github.com/NixOS/nixpkgs/commit/c45c1e450c188cc81748d14b8ae869bbe01024a2) furnace: 0.6.5 -> 0.6.6
* [`981a40b5`](https://github.com/NixOS/nixpkgs/commit/981a40b5478fac4500b7d4a2826790957ca29e5b) steam-rom-manager: 2.5.17 -> 2.5.22
* [`8e6a2235`](https://github.com/NixOS/nixpkgs/commit/8e6a2235bedf56a92fcd7db08fbaf44e45d38f61) instaloader: 4.13 -> 4.13.1
* [`3c93795f`](https://github.com/NixOS/nixpkgs/commit/3c93795f92e6c2f32984db942d8fd702a7234bc1) maintainers: add KristianAN
* [`8f4200d1`](https://github.com/NixOS/nixpkgs/commit/8f4200d165b73db63dc277e9984a480984415593) installShellFiles: move setup script to the same directory
* [`f72e74d7`](https://github.com/NixOS/nixpkgs/commit/f72e74d7aef142ea16d0841fa4322fc1310bb913) installShellFiles: migrate tests to tests subdirectory
* [`8b674370`](https://github.com/NixOS/nixpkgs/commit/8b674370c42fd5312d53edd2002af0978ff3f2b9) installShellFiles: nixfmt-rfc-style
* [`e548b317`](https://github.com/NixOS/nixpkgs/commit/e548b3170836504cc2be8159c9aadccfbd63c469) installShellFiles: migrate to by-name
* [`98e9fbb5`](https://github.com/NixOS/nixpkgs/commit/98e9fbb530d572f057d1b9ea787a5a67a1d3a24c) installShellFiles: dismember tests into their own files
* [`1c9d4799`](https://github.com/NixOS/nixpkgs/commit/1c9d4799c297aa0a2c8292d8d4b97992aa7bdd7d) installShellFiles: add new function installBin
* [`507416c3`](https://github.com/NixOS/nixpkgs/commit/507416c3115ee4b2c26b49ad4c1f2b2f014ef7ae) installShellFiles: add new tests install-bin and install-bin-output
* [`bb5aa086`](https://github.com/NixOS/nixpkgs/commit/bb5aa086d69be1bfe5c3777210edb748d10e31d2) installShellFiles: rewrite functions
* [`56ff3983`](https://github.com/NixOS/nixpkgs/commit/56ff39832db97b06ab3abc658a4569a30c6449f6) installShellFiles: set passthru directly instead of overriding it
* [`1fc77a5c`](https://github.com/NixOS/nixpkgs/commit/1fc77a5ce2a6884e8cc69fc59986a08648f4eb83) doc: rewrite installShellFiles
* [`32897dce`](https://github.com/NixOS/nixpkgs/commit/32897dce904cb05328940293f289d82d9b413bcb) CODEOWNERS: update ownership for installShellFiles
* [`618cffa8`](https://github.com/NixOS/nixpkgs/commit/618cffa8e16a5c3182602841d848e7fcbc3c14ca) nawk: uses installBin to install the binary
* [`766b1bc0`](https://github.com/NixOS/nixpkgs/commit/766b1bc091deead980c5334e3fbf87b59e71ad07) clash-verge-rev: 1.7.5 -> 1.7.7; clash-verge-rev: build from source; clash-verge-rev: add bot-wxt1221 as maintainers
* [`162acc63`](https://github.com/NixOS/nixpkgs/commit/162acc638ece33175705e05efe0695499438cc76) debase: init at 2
* [`47bf0716`](https://github.com/NixOS/nixpkgs/commit/47bf0716f1c92d3717c5b26910c84acbd2ee4c81) openseachest: 23.12 -> 24.08
* [`5e454f92`](https://github.com/NixOS/nixpkgs/commit/5e454f926b2ce07553e9f6a6ed3d30a05a0d2d71) stylelint: 16.8.1 -> 16.9.0
* [`cb092b6e`](https://github.com/NixOS/nixpkgs/commit/cb092b6ef503ed32e0ae62c1bba2caf3b896076b) cronutils: add passthru.update-script
* [`ff236364`](https://github.com/NixOS/nixpkgs/commit/ff236364ef93ceea0b32f2ca03658058142c6f17) formatjson5: add passthru.update-script
* [`c6f02dd3`](https://github.com/NixOS/nixpkgs/commit/c6f02dd309085d4c9560b8ebca5ce2bce258d555) igvm-tooling: add passthru.update-script
* [`99265c72`](https://github.com/NixOS/nixpkgs/commit/99265c7248ee21918ffd45b573ec431c5c0c4e0d) uplosi: add passthru.update-script
* [`1eaba938`](https://github.com/NixOS/nixpkgs/commit/1eaba9381c007dcc71d372ec2dc15889935b0181) goat: unstable-2022-08-15 -> 0-unstable-2024-07-31
* [`665d088c`](https://github.com/NixOS/nixpkgs/commit/665d088c90fe1dc52dc90fb78c4cafbda6bb5e09) capslock: 0.1.1 -> 0.2.4
* [`73c1748c`](https://github.com/NixOS/nixpkgs/commit/73c1748c1e0827c996ae7c71034d3eb105a122a3) python312Packages.oauthlib: disable failing test with pyjwt 2.9.0
* [`1e9aab76`](https://github.com/NixOS/nixpkgs/commit/1e9aab76bb92b20e85b89cbd2c6beaaa6e31428c) furnace: 0.6.6 -> 0.6.7
* [`92134fa6`](https://github.com/NixOS/nixpkgs/commit/92134fa6c7417a28b326c4feb8d49988dc3929d9) python312Packages.pyjwt: test oauthlib in passthru
* [`e3b0aa3c`](https://github.com/NixOS/nixpkgs/commit/e3b0aa3cf132d4f078a94ccd7d7d16a31bf57803) matterbridge: 1.26.0 -> 1.26.0-unstable-2024-08-27
* [`6b82acb5`](https://github.com/NixOS/nixpkgs/commit/6b82acb5777839889fa63adcd23c788e14aa996b) matterbridge: move to by-name
* [`0ef332b8`](https://github.com/NixOS/nixpkgs/commit/0ef332b825591f33777e8797e3243379b61669d0) discover-overlay: 0.7.4 -> 0.7.8
* [`6bea9fec`](https://github.com/NixOS/nixpkgs/commit/6bea9fece4985067988abd589b9f6f9a2ead6e7e) dart: 3.5.1 -> 3.5.2
* [`a3da5801`](https://github.com/NixOS/nixpkgs/commit/a3da58019fe3a5d9e53084d7bcfb1831a4134006) easeprobe: 2.1.1 -> 2.2.1
* [`8881a63f`](https://github.com/NixOS/nixpkgs/commit/8881a63f8e94ad8d3c86f8d0858751e9561d5009) kubeshark: 52.3.78 -> 52.3.79
* [`387cdfaf`](https://github.com/NixOS/nixpkgs/commit/387cdfaf65ad7462cfa411f5d061c4ae75e56e28) crawl: 0.31.0 -> 0.32.0
* [`9efa491e`](https://github.com/NixOS/nixpkgs/commit/9efa491e9e35b433ead017b0a41adeff7816cfef) mev-boost: 1.7.1 -> 1.8
* [`dfa73af5`](https://github.com/NixOS/nixpkgs/commit/dfa73af57d60a40fc1dc7e65513e2928f811e819) temurin-bin: support riscv64-linux
* [`9729387a`](https://github.com/NixOS/nixpkgs/commit/9729387a99fcff79e06dfd631f74a2923a84d585) fontconfig: fix properly, remove NixOS module hack
* [`6b1d5b23`](https://github.com/NixOS/nixpkgs/commit/6b1d5b23d313a79a5b84f371e1002c7d5866e3fe) miracle-wm: 0.3.2 -> 0.3.4
* [`6be6702d`](https://github.com/NixOS/nixpkgs/commit/6be6702d45f339801a6a04a0d9414bfafafe2e43) openssl: expose 'enable-md2' option
* [`87971766`](https://github.com/NixOS/nixpkgs/commit/87971766e55daef11dc0499df25db4fd3ba7f56a) hydrus: 581 -> 588
* [`492500d6`](https://github.com/NixOS/nixpkgs/commit/492500d6c759862de612a8e99b5ad68f4d33f471) container2wasm: 0.6.4 -> 0.6.5
* [`74ec7d89`](https://github.com/NixOS/nixpkgs/commit/74ec7d89989335e69d7897baebb98514ee243d11) snabb: 2024.06 -> 2024.08
* [`9994e4df`](https://github.com/NixOS/nixpkgs/commit/9994e4df96fdedd44fba7f11d37ad8600467d494) tinyxxd: init at 1.3.5
* [`7118909e`](https://github.com/NixOS/nixpkgs/commit/7118909e8222d9d7dd4dbf8c153c8a0cae9a87a1) unixtools: use tinyxxd to serve up xxd
* [`04cf7c0c`](https://github.com/NixOS/nixpkgs/commit/04cf7c0cd4faa09e36f264bfb326c21e7d63a349) doc: add release note about `xxd` now being provided by `tinyxxd` instead of `vim.xxd`
* [`34587b9f`](https://github.com/NixOS/nixpkgs/commit/34587b9f7ee8c6f50a159039fecbdee9251ecc9b) paperwork: 2.2.3 -> 2.2.5
* [`91e707d8`](https://github.com/NixOS/nixpkgs/commit/91e707d8e47805fe5fb25233b3e3b9c94dc91846) clash-nyanpasu: 1.5.1 -> 1.6.0
* [`9a00adc7`](https://github.com/NixOS/nixpkgs/commit/9a00adc7e1c16aff9782ae006f04517f0602c348) assimp: 5.4.2 -> 5.4.3
* [`81c3d4cb`](https://github.com/NixOS/nixpkgs/commit/81c3d4cb13f7c104580c73cd859587756518d678) mdk-sdk: 0.29.0 -> 0.29.1
* [`386a1d5d`](https://github.com/NixOS/nixpkgs/commit/386a1d5d06e699212f7e123edce7826d34f6eca8) nixos/hydra: add system-hydra.slice
* [`d464996f`](https://github.com/NixOS/nixpkgs/commit/d464996f3f53d72cdd808407b20e2dc54f0c1842) nixos/hydra: fix typo
* [`2d8f095a`](https://github.com/NixOS/nixpkgs/commit/2d8f095ab1ebf755c34f8190636c5459b995292e) nixos/hydra: unset SSL_CERT_FILE
* [`af10a338`](https://github.com/NixOS/nixpkgs/commit/af10a338feb5c039ef2ae4a606697b7b5e769c1e) gst_all_1.gstreamer: disable libunwind if unavailable
* [`b5c88efb`](https://github.com/NixOS/nixpkgs/commit/b5c88efba7d7ce6ae830930613b40bd3b0a4aba9) gst_all_1.gstreamer: disable introspection if unavailable
* [`ac58a5e8`](https://github.com/NixOS/nixpkgs/commit/ac58a5e8b51e03b429b21f28afe7497bdd71126c) ibus-engines.typing-booster-unwrapped: 2.25.11 -> 2.25.15
* [`e347ebb7`](https://github.com/NixOS/nixpkgs/commit/e347ebb778b8cff8d4ce0474340ce97c08014d59) checkstyle: 10.17.0 -> 10.18.1
* [`22786dad`](https://github.com/NixOS/nixpkgs/commit/22786dadf499ddcfaada6c66eeef055752e62672) vulkan-headers: 1.3.283.0 -> 1.3.290.0
* [`44e1b298`](https://github.com/NixOS/nixpkgs/commit/44e1b2986d70210d4339c6d3f8207ab40db56b93) vulkan-loader: 1.3.283.0 -> 1.3.290.0
* [`83ee0939`](https://github.com/NixOS/nixpkgs/commit/83ee093947ea50e0f9ed688c865b485d1738747f) vulkan-validation-layers: 1.3.283.0 -> 1.3.290.0
* [`9a94f57d`](https://github.com/NixOS/nixpkgs/commit/9a94f57d73d101fe3bfdb7f93b3ba2f12c3da141) vulkan-tools: 1.3.283.0 -> 1.3.290.0
* [`2cf5c8b8`](https://github.com/NixOS/nixpkgs/commit/2cf5c8b852e31930a3866346f56841e67f4be17f) vulkan-tools-lunarg: 1.3.283.0 -> 1.3.290.0
* [`7b2ce523`](https://github.com/NixOS/nixpkgs/commit/7b2ce5236d94c79fbeea87ae815a3c8efd723aa6) vulkan-extension-layer: 1.3.283.0 -> 1.3.290.0
* [`0d6ff0dd`](https://github.com/NixOS/nixpkgs/commit/0d6ff0ddccbfb6285bb6811873c832172b1002d6) vulkan-utility-libraries: 1.3.283.0 -> 1.3.290.0
* [`2314a568`](https://github.com/NixOS/nixpkgs/commit/2314a5687b0a165dad261e465f20d36a3f30786a) vulkan-volk: 1.3.283.0 -> 1.3.290.0
* [`a919d00a`](https://github.com/NixOS/nixpkgs/commit/a919d00a29344642c0c0145c39008ff747a08f84) spirv-headers: 1.3.283.0 -> 1.3.290.0
* [`d4bd2a84`](https://github.com/NixOS/nixpkgs/commit/d4bd2a8446c36c4e06f55628a71a7e200e35f4bd) spirv-cross: 1.3.283.0 -> 1.3.290.0
* [`4441399c`](https://github.com/NixOS/nixpkgs/commit/4441399c6475e24c34fed6e979d86b00f12c326d) spirv-tools: 1.3.283.0 -> 1.3.290.0
* [`7bd29c7d`](https://github.com/NixOS/nixpkgs/commit/7bd29c7ddf2b6a14efe3a1c2432f2d38eb83b29b) notes: move to by-name
* [`34952062`](https://github.com/NixOS/nixpkgs/commit/3495206296cf624f37d300fd656d0098bf8b2b65) testlib: init at 0.9.41
* [`f51c8db4`](https://github.com/NixOS/nixpkgs/commit/f51c8db4727a3cac066988e1dcdff5868947e0e3) ecs-agent: 1.85.1 -> 1.86.3
* [`90534869`](https://github.com/NixOS/nixpkgs/commit/90534869fb973c7d8d49f343ff1c999d19f06e55) vim: 9.1.0689 -> 9.1.0707
* [`54719fed`](https://github.com/NixOS/nixpkgs/commit/54719fedf20eb62ae17446470bb8deb5d96fec76) octavePackages.image-acquisition: 0.2.2 -> 0.2.6
* [`a590718b`](https://github.com/NixOS/nixpkgs/commit/a590718bf97d0e46b238e14748e9be1e15543470) snyk: 1.1292.2 -> 1.1293.0
* [`96283678`](https://github.com/NixOS/nixpkgs/commit/96283678b647cd7b4d5d77f1176ffc52e269cde4) rke2_stable: 1.28.11+rke2r1 -> 1.30.4+rke2r1
* [`9cfe67a6`](https://github.com/NixOS/nixpkgs/commit/9cfe67a6cf266c565af1d46f50e79e07caa57598) vscode-js-debug: 1.91.0 -> 1.93.0
* [`0295652d`](https://github.com/NixOS/nixpkgs/commit/0295652d91b30980e534251734b94d249643bec7) todesk: init at 4.7.2.0
* [`1c77c14c`](https://github.com/NixOS/nixpkgs/commit/1c77c14c21d415c5b461c345aa340e63efe96159) nixos/todesk: init
* [`8d35d023`](https://github.com/NixOS/nixpkgs/commit/8d35d0239abfe3b6c5cf38fd543c841a9d80a5ee) kstars: 3.7.0 -> 3.7.2
* [`37e443af`](https://github.com/NixOS/nixpkgs/commit/37e443af61dcbd8939e873ff9ae775ef2e1febec) ayatana-ido: move to pkgs/by-name
* [`e272eb2f`](https://github.com/NixOS/nixpkgs/commit/e272eb2fd75c38299905032fb1d3086021f7bd47) ayatana-ido: fix cross compilation
* [`9baa4280`](https://github.com/NixOS/nixpkgs/commit/9baa4280ed94f4e169fa4718fe56e416d42c40e5) libayatana-indicator: move to pkgs/by-name
* [`8e2f23d6`](https://github.com/NixOS/nixpkgs/commit/8e2f23d65ad4231d7bf3b6764cd0408ff2cfa493) libayatana-indicator: fix cross compilation
* [`ad0aa8e3`](https://github.com/NixOS/nixpkgs/commit/ad0aa8e34d25f8f9263527a76ae26f3c28b00881) emacs: set foundMakefile in buildPhase of elisp builders
* [`e74bbbf4`](https://github.com/NixOS/nixpkgs/commit/e74bbbf47c4fa0c0ecb87e6c151ad07ded9b5608) xray: 1.8.16 -> 1.8.24
* [`e6c5bccf`](https://github.com/NixOS/nixpkgs/commit/e6c5bccff53e28fb8c6a916ada0339565e456af9) twitch-dl: 2.3.1 -> 2.5.0
* [`8edaa084`](https://github.com/NixOS/nixpkgs/commit/8edaa084143de2d9b58beafe21989d4d4688eb43) tartube-yt-dlp: 2.5.0 -> 2.5.040
* [`6b8ae8a3`](https://github.com/NixOS/nixpkgs/commit/6b8ae8a33c1338f8f9693b6fcb29578b27172af6) octavePackages.image-acquisition: propagate libv4l to runtime
* [`fd7c768d`](https://github.com/NixOS/nixpkgs/commit/fd7c768d3a74d04ee2cf8f2c1680bf86bf5b5775) calibre: enable tests
* [`e0ca236e`](https://github.com/NixOS/nixpkgs/commit/e0ca236e4023141cc48c372e11d5ea31af26d3c4) gnome-frog: 1.5.1 -> 1.5.2
* [`135d1802`](https://github.com/NixOS/nixpkgs/commit/135d18025393b9a9033d28ca72fd096799220045) ldid-procursus: Migrate to `by-name`
* [`97ceb876`](https://github.com/NixOS/nixpkgs/commit/97ceb876f0889e543129f9f6ccde03c20916063e) ldid-procursus: Fix (possible) memory issues
* [`fb707e89`](https://github.com/NixOS/nixpkgs/commit/fb707e891f6a106494d6489a4b6bbfc9f3c74989) maintainers: add alx
* [`7516e662`](https://github.com/NixOS/nixpkgs/commit/7516e662d2df6ee038fdeac513527b93e969193d) quake3e: 2022-04-01-dev -> 2024-09-02-dev
* [`ceece79d`](https://github.com/NixOS/nixpkgs/commit/ceece79d5592ed96375252dea70b9a7c0dce8b0a) rke2_testing: 1.30.3-rc5+rke2r1 -> 1.31.0-rc1+rke2r1
* [`755657b2`](https://github.com/NixOS/nixpkgs/commit/755657b2b4f81995ef049b677c745f92bd435c66) docker_27: 27.1.1 -> 27.2.0
* [`32fb2531`](https://github.com/NixOS/nixpkgs/commit/32fb25319b39196c015adef2a1c6d74cf86f4bbb) dufs: 0.41.0 -> 0.42.0
* [`949be238`](https://github.com/NixOS/nixpkgs/commit/949be2386cb6387d500d3bb4507627dbc3047de7) jan: 0.5.1 -> 0.5.3
* [`f87b978a`](https://github.com/NixOS/nixpkgs/commit/f87b978abed6a81c3c003174aed1b8f093190a8c) roc-toolkit: disable libunwind if unavailable
* [`f0a86e6d`](https://github.com/NixOS/nixpkgs/commit/f0a86e6d119877f47452a790157def800aef5a61) libunwind.meta.pkgConfigModules: init
* [`920cd662`](https://github.com/NixOS/nixpkgs/commit/920cd662b338eae1cc9956da028ebbff7c57702d) pazi: 0.4.1 -> 0.5.0
* [`52b0b4ef`](https://github.com/NixOS/nixpkgs/commit/52b0b4ef3d2b1b6a76f97d0c8c50def5640ab7c1) gst_all_1.gstreamer: use a better libunwind check
* [`5e8cc279`](https://github.com/NixOS/nixpkgs/commit/5e8cc2796282a951dc81d49efd15903de0a7f157) nixos/openvpn: add extraArgs option
* [`ea202b72`](https://github.com/NixOS/nixpkgs/commit/ea202b72633d88a5635ae8745a2ffec275f8f3c6) nuclei-templates: 9.9.3 -> 9.9.4
* [`97e4ebd0`](https://github.com/NixOS/nixpkgs/commit/97e4ebd0e8ecbcb877fc1c4ecb41e02cfe776ef4) intel-gmmlib: 22.4.1 -> 22.5.1
* [`2cdc4272`](https://github.com/NixOS/nixpkgs/commit/2cdc4272ee3e2d607a41bd88f83dd903de120216) workcraft: 3.5.0 -> 3.5.1
* [`c7188fe3`](https://github.com/NixOS/nixpkgs/commit/c7188fe301c79ba920869f27570e8bd77a17aefb) kubectl-gadget: move to by-name
* [`a4ffcf56`](https://github.com/NixOS/nixpkgs/commit/a4ffcf5664f1a90922f3572f60c2cc2457370446) kubectl-gadget: 0.31.0 -> 0.32.0
* [`7a41a8c7`](https://github.com/NixOS/nixpkgs/commit/7a41a8c71d466c3b1091da22aa6fb383194f24e3) kubectl-gadget: add version test
* [`0a5e4d16`](https://github.com/NixOS/nixpkgs/commit/0a5e4d16668017bb4a36781f04df2c6173251238) single-file-cli: remove chromedriver from nativeCheckInputs
* [`60e8c03c`](https://github.com/NixOS/nixpkgs/commit/60e8c03c9bb26c45763ac3f1e54ac46b0eed248a) nixos/services.snapserver: remove `with lib;`
* [`f51cd108`](https://github.com/NixOS/nixpkgs/commit/f51cd1081633c201e96f28cd73defbb231549fcd) nixos/services.borgbackup: remove `with lib;`
* [`cd7695ae`](https://github.com/NixOS/nixpkgs/commit/cd7695ae97b64354c6d1c75548f6cdfd6f6be94e) nixos/services.portunus: remove `with lib;`
* [`11dd437b`](https://github.com/NixOS/nixpkgs/commit/11dd437b6572f479d9d86c964f208ccf63e96b3f) nixos/services.radicle: remove `with lib;`
* [`9ed63429`](https://github.com/NixOS/nixpkgs/commit/9ed63429ab7c5afbeb7097e0354b1322c8824e6b) nixos/services.rippled: remove `with lib;`
* [`36872243`](https://github.com/NixOS/nixpkgs/commit/3687224301eae61e432e8ec53c29332c3ca195e1) nixos/services.snapper: remove `with lib;`
* [`d37789ce`](https://github.com/NixOS/nixpkgs/commit/d37789ce5dde15a74f7b5b45cc142b7329937da9) nixos/services.taskserver: remove `with lib;`
* [`4f6d325a`](https://github.com/NixOS/nixpkgs/commit/4f6d325a8ad337d97d443a22eeea376ddf8c4308) nixos/services.graphite: remove `with lib;`
* [`0d894a22`](https://github.com/NixOS/nixpkgs/commit/0d894a223ffb04694458fa5bc7133d641491c625) gotrue-supabase: 2.155.6 -> 2.159.2
* [`11b4b119`](https://github.com/NixOS/nixpkgs/commit/11b4b119cf2bdb9a2400f3095f49a0a1f21c8742) htpdate: 1.3.7 -> 2.0.0
* [`50fa8124`](https://github.com/NixOS/nixpkgs/commit/50fa8124b3e2ead2199998c13d32a298fbf42b7d) openimageio: 2.5.14.0 -> 2.5.15.0
* [`048ae520`](https://github.com/NixOS/nixpkgs/commit/048ae52060b238bc11c504a94ac0b7ae090b2131) iroh: 0.23.0 -> 0.24.0
* [`c7a2e833`](https://github.com/NixOS/nixpkgs/commit/c7a2e8332abefa853530e994ccf37a24a9667cd8) spicy-parser-generator: 1.11.0 -> 1.11.1
* [`2929e547`](https://github.com/NixOS/nixpkgs/commit/2929e5476b74bb1a9fcb95093e34131d7d6cc022) verifast: 21.04 -> 24.08.30
* [`db833142`](https://github.com/NixOS/nixpkgs/commit/db833142376599a48f277745c4a7f43406a82ee4) chawan: 0-unstable-2024-08-03 -> 0-unstable-2024-09-03
* [`3f56b1b1`](https://github.com/NixOS/nixpkgs/commit/3f56b1b1087e78e4cdf922fe43836c1678d183aa) gaugePlugins.dotnet: 0.5.7 -> 0.6.0
* [`1a4a2e77`](https://github.com/NixOS/nixpkgs/commit/1a4a2e7757c663c3cd10a31c6dde4d53e4f92144) json2ts: init at v15.0.2
* [`20291241`](https://github.com/NixOS/nixpkgs/commit/20291241fdb8fd44961d44f6df51929b507d1fe3) wstunnel: the ping frequency can now also be configured for the server
* [`1fcb80ec`](https://github.com/NixOS/nixpkgs/commit/1fcb80ec4876fd1cdcd63805540026cddf3ae727) polypane: 20.1.2 -> 21.1.0
* [`38a04a86`](https://github.com/NixOS/nixpkgs/commit/38a04a864da888d40894d318c4cfcff7ede82df7) kuma-cp: 2.8.2 -> 2.8.3
* [`906e5696`](https://github.com/NixOS/nixpkgs/commit/906e5696a6abab9a4863db07e204bbbf69c042c0) rustlings: add darwin support by adding CoreServices to buildInputs
* [`4710faec`](https://github.com/NixOS/nixpkgs/commit/4710faecac82708d2dd3e16ea674e2731b5e1cff) python311Packages.flask-compress: 1.14 -> 1.15
* [`eb7d2ec2`](https://github.com/NixOS/nixpkgs/commit/eb7d2ec2e9b33369a0d6ffef0bce6a40cb30923c) notes: 2.2.1 -> 2.3.0
* [`235ae9c7`](https://github.com/NixOS/nixpkgs/commit/235ae9c70fbb260384cb6497f45c443002c5fed0) nodejs_22: 22.7.0 -> 22.8.0
* [`0deda63f`](https://github.com/NixOS/nixpkgs/commit/0deda63f0609e0d2123e59763092b1e557359e94) shpool: 0.6.3 -> 0.7.0
* [`8c0e76ad`](https://github.com/NixOS/nixpkgs/commit/8c0e76ad140678fadb61bf566cb013f48744014a) gdlv: Reformat with official formatter
* [`3c841d74`](https://github.com/NixOS/nixpkgs/commit/3c841d740f9add1e89bb16d2a249cbf8c0b5a40e) gdlv: Convert to by-name
* [`251fcfba`](https://github.com/NixOS/nixpkgs/commit/251fcfba615529b2946e17fd1e68746f5245b74e) gdlv: Update 1.10.0 -> 1.12.0
* [`dbeb0769`](https://github.com/NixOS/nixpkgs/commit/dbeb07693d084746010d8f0247ef8baa967419ad) czkawka: refactor
* [`9cc5c5ec`](https://github.com/NixOS/nixpkgs/commit/9cc5c5ec1db3e1f67992afd34f82608f53917ef6) czkawka-full: "init"
* [`e2c69062`](https://github.com/NixOS/nixpkgs/commit/e2c6906277d41ee3c70142e0a53e0fd4575e5940) jdt-language-server: 1.38.0 -> 1.39.0
* [`d106812b`](https://github.com/NixOS/nixpkgs/commit/d106812bbf36f9ea7a6642b89d78c15cc78a0a3c) erlfmt: 1.3.0 -> 1.5.0
* [`dfefafb8`](https://github.com/NixOS/nixpkgs/commit/dfefafb8f66a9269882f60f72a3d27b695820c36) python312Packages.django_4: 4.2.15 -> 4.2.16
* [`c025b7fc`](https://github.com/NixOS/nixpkgs/commit/c025b7fc8175cf6a082de3bd134fbc8d242c93a4) typeshare: 1.9.2 -> 1.11.0
* [`b9aa424d`](https://github.com/NixOS/nixpkgs/commit/b9aa424d5790cc061ebe993cb7912aa52db03f16) plumed: 2.9.1 -> 2.9.2
* [`293ba2fc`](https://github.com/NixOS/nixpkgs/commit/293ba2fc3b5e255865e51716a7fbd9c3114f7c10) tempo: 2.5.0 -> 2.6.0
* [`1883f5d1`](https://github.com/NixOS/nixpkgs/commit/1883f5d1850de24ef7d8c443bbdaaf2ca0b44809) avalanchego: 1.11.10 -> 1.11.11
* [`29bc1320`](https://github.com/NixOS/nixpkgs/commit/29bc1320208295f630b169d8e9b0d1e8ab9844c3) trillian: 1.6.0 -> 1.6.1
* [`8f61973d`](https://github.com/NixOS/nixpkgs/commit/8f61973d92aee06e2e0854f13433940c5e169a35) Revert "e2fsprogs: build fuse2fs on darwin"
* [`df8f8331`](https://github.com/NixOS/nixpkgs/commit/df8f8331a73e56662b061c051c7af32816d4dd94) fcitx5-fluent: init at unstable-2024-03-30
* [`55c63e29`](https://github.com/NixOS/nixpkgs/commit/55c63e297cf4beeb362f7fa2ce0ada4ca907cae8) flameshot: 12.1.0-unstable-2024-08-02 -> 12.1.0-unstable-2024-09-01
* [`61fec7d0`](https://github.com/NixOS/nixpkgs/commit/61fec7d07ed50985d9f15c73a6980a164e3f4fc5) terramate: 0.10.0 -> 0.10.2
* [`2585dc64`](https://github.com/NixOS/nixpkgs/commit/2585dc64be69e2f9adfa0ac95b269c207400f3a3) python3Packages.ydata-profiling: 4.8.3 -> 4.9.0
* [`9827d943`](https://github.com/NixOS/nixpkgs/commit/9827d943d68b6e2e1f911c6e6ca1df49461240b4) deck: 1.39.5 -> 1.39.6
* [`d75fec0e`](https://github.com/NixOS/nixpkgs/commit/d75fec0e035f5ce02e8bd898a1be881f8741da6e) davinci-resolve: 19.0 -> 19.0.1
* [`17a622b9`](https://github.com/NixOS/nixpkgs/commit/17a622b98ea16b9ddaee530c39d831f1ad3dd321) jbrowse: 2.14.0 -> 2.15.0
* [`e61a242d`](https://github.com/NixOS/nixpkgs/commit/e61a242d06b8361b03c9ec1907b3a4dfe5fb22c6) intermodal: 0.1.13 -> 0.1.14
* [`6cbccdca`](https://github.com/NixOS/nixpkgs/commit/6cbccdca5a7bbbe45898d0dc85e6197ab8965b91) melange: 0.11.2 -> 0.11.3
* [`5fc29fc1`](https://github.com/NixOS/nixpkgs/commit/5fc29fc1bb21443842fa5397a03c409c678db0b0) libgrapheme: fix cross compilation
* [`28751986`](https://github.com/NixOS/nixpkgs/commit/2875198675619731d0e7b6720798be31e3653744) djlint: 1.34.1 -> 1.35.2
* [`7080574b`](https://github.com/NixOS/nixpkgs/commit/7080574bdd2da4e5f0721fe7bc23d2497d00e630) linkerd_edge: 24.8.2 -> 24.8.3
* [`93c1a2bd`](https://github.com/NixOS/nixpkgs/commit/93c1a2bd49f01c4ece3cd4560e07f03d3c9a1efc) httm: 0.42.0 -> 0.42.4
* [`d27dc73d`](https://github.com/NixOS/nixpkgs/commit/d27dc73da5ab21c186694d4efa090d54b6d6d5c3) qdrant: 1.11.2 -> 1.11.3
* [`5ffe217c`](https://github.com/NixOS/nixpkgs/commit/5ffe217cd9b3834cdd916720723d2a28be6cae50) mongodb-ce: remove custom `curl` override
* [`5a6b103c`](https://github.com/NixOS/nixpkgs/commit/5a6b103c46aa8f091eda0917b367fbd61ffe5776) kubecolor: 0.3.3 -> 0.4.0
* [`aa675a6c`](https://github.com/NixOS/nixpkgs/commit/aa675a6c32d494f163bf7f849626488eaf497fd8) kubecolor: only include root package
* [`fe9dddb3`](https://github.com/NixOS/nixpkgs/commit/fe9dddb3b9c80433314aa19a08bec7212e74d35c) bngblaster: 0.9.5 -> 0.9.6
* [`ccc257f6`](https://github.com/NixOS/nixpkgs/commit/ccc257f60d51880e6274d6215676c2d1cab4bd87) automatic-timezoned: 2.0.30 -> 2.0.31
* [`472f4b86`](https://github.com/NixOS/nixpkgs/commit/472f4b86d0a11d8c78c07388dd005d437446ca12) function-runner: 5.1.4 -> 6.0.0
* [`0a899446`](https://github.com/NixOS/nixpkgs/commit/0a899446e8050cd992e28fecb691a919101caf75) fulcio: 1.6.3 -> 1.6.4
* [`8aa2a80b`](https://github.com/NixOS/nixpkgs/commit/8aa2a80b3f1c68d8e0456a4db8cc7fd31c83a014) gosec: 2.20.0 -> 2.21.1
* [`ef077f08`](https://github.com/NixOS/nixpkgs/commit/ef077f0885c90d54dc80271d375365688837cfe1) prometheus-pgbouncer-exporter: 0.8.0 -> 0.9.0
* [`eafbfdd5`](https://github.com/NixOS/nixpkgs/commit/eafbfdd5bada6d7d51f6677baa6da7e627b09bb8) ocamlPackages.gluten: 0.5.1 -> 0.5.2
* [`7df7eb1b`](https://github.com/NixOS/nixpkgs/commit/7df7eb1b409d63f8282053556bf4bc298b83c591) pyenv: 2.4.10 -> 2.4.11
* [`05e1a418`](https://github.com/NixOS/nixpkgs/commit/05e1a4189f3c14c8f6a2e69eebe2f6694151b00a) onlyoffice-documentserver: 8.1.1 -> 8.1.3
* [`38de1942`](https://github.com/NixOS/nixpkgs/commit/38de19423f182ef9a0a1ad61d1643e5ce5ef6482) coder: 2.13.5 -> 2.14.2
* [`b14fef90`](https://github.com/NixOS/nixpkgs/commit/b14fef9063050510c37c272c850663bceed8b0e8) mystmd: 1.3.4 -> 1.3.6
* [`87989335`](https://github.com/NixOS/nixpkgs/commit/87989335b245b5bc12e0cf3d7c143be12f8e82da) twitch-dl: 2.5.0 -> 2.6.0
* [`085724ef`](https://github.com/NixOS/nixpkgs/commit/085724ef1725a58655ab3096c570508bc573437a) julia-modules: move makeWrapper to nativeBuildInputs
* [`02a4d9a7`](https://github.com/NixOS/nixpkgs/commit/02a4d9a728489f78a8265d84c6fd6c1057f449d1) mesa: cherry-pick fixes for software rendering fallback
* [`6aba98ae`](https://github.com/NixOS/nixpkgs/commit/6aba98aefdc3c6aa22913a042f7519447a684372) nixos/testing: Fix tty output
* [`b745b4f7`](https://github.com/NixOS/nixpkgs/commit/b745b4f77cf3d6ec227aed31302065b5f974a2c5) hyperion-ng: 2.0.14 -> 2.0.16
* [`94db46ec`](https://github.com/NixOS/nixpkgs/commit/94db46ecadfc053c0ea425476d21307fb0ec0806) nextcloudPackages.hmr_enabler: init at 0+unstable-2024-08-24
* [`26226abe`](https://github.com/NixOS/nixpkgs/commit/26226abeed56453a397e96c495a95fc177af234d) tryton: 7.2.4 -> 7.2.5
* [`28000247`](https://github.com/NixOS/nixpkgs/commit/28000247e4ca9bc61ac60c66ff9f228df4d94c8b) coin3d: 4.0.2 -> 4.0.3
* [`04fadac4`](https://github.com/NixOS/nixpkgs/commit/04fadac429ca7d6b92025188652376c230205730) run nixfmt-rfc-style
* [`39df221e`](https://github.com/NixOS/nixpkgs/commit/39df221e77df89edb01151ad413c251bd8d52830) virtualisation-options: init
* [`94634e82`](https://github.com/NixOS/nixpkgs/commit/94634e82f80535c068ffabb6b2388333a9a17978) macos-builder: use virtualisation.diskSize...
* [`564b6ce1`](https://github.com/NixOS/nixpkgs/commit/564b6ce153ec4fd089d006408fd9a524adc7419e) oci-{options,image}: use virtualisation.diskSize
* [`048599f0`](https://github.com/NixOS/nixpkgs/commit/048599f0d793913cf8d3822a0f8b5b3dc60b37fd) linode-image: use virtualisation.diskSize
* [`9e18e9fe`](https://github.com/NixOS/nixpkgs/commit/9e18e9fedc2bcaa8912fd68687477783e18eb171) google-compute-image: use virtualisation.diskSize
* [`d37a3ea1`](https://github.com/NixOS/nixpkgs/commit/d37a3ea1efddb9667bb308d43e81a06286fe696b) promox-image: use virtualisation.diskSize
* [`d223461d`](https://github.com/NixOS/nixpkgs/commit/d223461d54375b33221ee95f9361581d1fdd8fe3) digital-ocean-image: use virtualisation.diskSize
* [`759de4c5`](https://github.com/NixOS/nixpkgs/commit/759de4c54d3322146279b7393ffd1ba9434389d2) amazon-image: sizeMB -> virtualisation.diskSize
* [`a4b1638f`](https://github.com/NixOS/nixpkgs/commit/a4b1638f7fb936e3cf43b61bc98d1c30a3a97dda) azure-image: use virtualisation.diskSize
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
