### PR TITLE
niv home-manager: update 10541f19 -> a9c9cc6e

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -41,10 +41,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "10541f19c584fe9633c921903d8c095d5411e041",
-        "sha256": "1z0ccdgrkr7d19njqipgf38wxdwwnmvvaswkngzw57a06v2qngby",
+        "rev": "a9c9cc6e50f7cbd2d58ccb1cd46a1e06e9e445ff",
+        "sha256": "1cxp9rgczr4rhhx1klwcr7a61khizq8hv63gvmy9gfsx7fp4h60a",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/10541f19c584fe9633c921903d8c095d5411e041.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/a9c9cc6e50f7cbd2d58ccb1cd46a1e06e9e445ff.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@10541f19...a9c9cc6e](https://github.com/nix-community/home-manager/compare/10541f19c584fe9633c921903d8c095d5411e041...a9c9cc6e50f7cbd2d58ccb1cd46a1e06e9e445ff)

* [`e5fa72ba`](https://github.com/nix-community/home-manager/commit/e5fa72bad0c6f533e8d558182529ee2acc9454fe) Translate using Weblate (Romanian)
* [`8a167164`](https://github.com/nix-community/home-manager/commit/8a1671642826633586d12ac3158e463c7a50a112) flake.lock: Update
* [`51e46643`](https://github.com/nix-community/home-manager/commit/51e46643429b3dc96dadf3014757582eca6adf28) treewide: use non-deprecated substitute arguments
* [`e1c60940`](https://github.com/nix-community/home-manager/commit/e1c6094075d28d496a1b0db208afd31e0b213d67) systemd: unify handling of switch environment
* [`da8406a6`](https://github.com/nix-community/home-manager/commit/da8406a6ff556b86dc368e96ca8bd81b2704a91a) systemd: use getExe for sd-switch
* [`2b1957a0`](https://github.com/nix-community/home-manager/commit/2b1957a0a3db7d63c1844abb84223655c30a7eb0) home-manager: fix early exit due to FQDN error
* [`c82fc8cf`](https://github.com/nix-community/home-manager/commit/c82fc8cf3f75e667ad9dd3e5df721119b63723b3) home-manager: use `hostname` from GNU inetutils
* [`ef506124`](https://github.com/nix-community/home-manager/commit/ef506124579ff6280a43a9596bb2a5049872bf8e) gpg-agent: add launchd service agent and sockets
* [`433e6866`](https://github.com/nix-community/home-manager/commit/433e686675ba24176fe3383916a4bd1c9799c676) autorandr: configModule.extraConfig
* [`ea244c5a`](https://github.com/nix-community/home-manager/commit/ea244c5ae2205f0fced24dde2e555440303d63bc) helix: remove outdated language-server comment
* [`cb3ab592`](https://github.com/nix-community/home-manager/commit/cb3ab5928cbe8ac3cfee7010ccad4c31dbc1fb5f) helix: add example for use with evil-helix
* [`daaf0c2f`](https://github.com/nix-community/home-manager/commit/daaf0c2f8da6c7b5dc04dd62a3d98422f259551b) kanshi: add support for output aliases
* [`4c8647b1`](https://github.com/nix-community/home-manager/commit/4c8647b1ed35d0e1822c7997172786dfa18cd7da) trayscale: add module
* [`7923c691`](https://github.com/nix-community/home-manager/commit/7923c691527d2ee85fe028c6e780ac3bf8606f06) neovide: add module
* [`076c78ed`](https://github.com/nix-community/home-manager/commit/076c78edede4e7abc71af0b1610fb1fc1c0fac29) fish: add `preferAbbrs` option
* [`503af483`](https://github.com/nix-community/home-manager/commit/503af483e1b328691ea3a434d331995595fb2e3d) eza: add support for fish abbreviations
* [`43845d04`](https://github.com/nix-community/home-manager/commit/43845d04f83d44d744206ea9884b8206e7640633) git: add diff-highlight diff pager option
* [`f084d653`](https://github.com/nix-community/home-manager/commit/f084d653199345ad294abca921a0e25872bd75c0) swaync: fix example configuration
* [`898eaef7`](https://github.com/nix-community/home-manager/commit/898eaef7ea906ddc8e86d57957f2a701878bfb05) Translate using Weblate (Russian)
* [`e94bee95`](https://github.com/nix-community/home-manager/commit/e94bee957400c8f871d9b9ea54308e15d664242c) Translate using Weblate (Hindi)
* [`7edf6cca`](https://github.com/nix-community/home-manager/commit/7edf6ccaec8001cb20368bf1bf6a677178cae07b) Add translation using Weblate (Hindi)
* [`f69e61a2`](https://github.com/nix-community/home-manager/commit/f69e61a2d77b721f28868b6fdc55706ca1bad49c) pls: add support for fish abbreviations
* [`0d118885`](https://github.com/nix-community/home-manager/commit/0d118885b2840447b5b7f2b6097b4511ed3d02e9) lsd: add support for fish abbreviations
* [`c6e4ec39`](https://github.com/nix-community/home-manager/commit/c6e4ec39df78245f7ce678476ff068515763345b) z-lua: add support for fish abbreviations
* [`6c1a461a`](https://github.com/nix-community/home-manager/commit/6c1a461a444e6ccb3f3e42bb627b510c3a722a57) mopidy: reduce test closure size
* [`e524c57b`](https://github.com/nix-community/home-manager/commit/e524c57b1fa55d6ca9d8354c6ce1e538d2a1f47f) mopidy: fix formatting
* [`9c5f16d7`](https://github.com/nix-community/home-manager/commit/9c5f16d7034500ef11d4d6d787728878b4522874) borgmatic: fix service permissions
* [`25479e29`](https://github.com/nix-community/home-manager/commit/25479e29d1aefc72a3d031f2703530d6112818a3) flake.lock: Update
* [`76bf7798`](https://github.com/nix-community/home-manager/commit/76bf779881934ab476962b904a771378278290ad) sway: un-extract single-use variable
* [`a9c9cc6e`](https://github.com/nix-community/home-manager/commit/a9c9cc6e50f7cbd2d58ccb1cd46a1e06e9e445ff) sway: do not use `pkgs.sway` when `cfg.package = null`
