### PR TITLE
niv nixpkgs: update 395d3350 -> 154e2c9d

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "395d3350e4628550d067d713f514361f916df1e6",
-        "sha256": "1fkbjsapyj80sxn31nvq8addwaq7r4xgyjps2qa2xyp16gp7fg0p",
+        "rev": "154e2c9da04847ca8090dde074b20d1aaae955c4",
+        "sha256": "0ymgmlrjadff7r7kdayzhv1px1c1ihg58s0pclg1pjc9mh3s28yi",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/395d3350e4628550d067d713f514361f916df1e6.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/154e2c9da04847ca8090dde074b20d1aaae955c4.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@395d3350...154e2c9d](https://github.com/nixos/nixpkgs/compare/395d3350e4628550d067d713f514361f916df1e6...154e2c9da04847ca8090dde074b20d1aaae955c4)

* [`4fe25c8e`](https://github.com/NixOS/nixpkgs/commit/4fe25c8e18e3569d3807771ed3d06b05557ef0af) ikos: 3.1 -> 3.2
* [`cbdd1eaf`](https://github.com/NixOS/nixpkgs/commit/cbdd1eaf88040e9da1db708e87e6bb54648158c1) kramdown-asciidoc: 1.0.1 -> 2.1.0
* [`75222b16`](https://github.com/NixOS/nixpkgs/commit/75222b1674de180a074864115f2fc2821118f068) mpd-notification: add systemd to buildInputs
* [`e40e7034`](https://github.com/NixOS/nixpkgs/commit/e40e703411690d4072bba2afb9eba892b126f67a) dwarf-fortress-packages.themes: set license to unfree
* [`0407dd70`](https://github.com/NixOS/nixpkgs/commit/0407dd70a52da26d8ba5bb9600c7be1da1f9c8bd) inhibridge: init at 0.3.0
* [`609f8e05`](https://github.com/NixOS/nixpkgs/commit/609f8e0590dfe0114ad2139cc331c3e870fefaa9) muscle: compile with GCC for Darwin
* [`caa9cf13`](https://github.com/NixOS/nixpkgs/commit/caa9cf136bcd9043641e24b3a571cac3a3988186) jekyll: Join `set` commands
* [`9b78c376`](https://github.com/NixOS/nixpkgs/commit/9b78c3760a564141e9f8d836748db9db3975cad2) jekyll: Quote variable dereferencing
* [`235bacee`](https://github.com/NixOS/nixpkgs/commit/235bacee2e99f2fea9ee9576bef76cec062038b3) jekyll: Remove unnecessary `readonly`
* [`27312ae2`](https://github.com/NixOS/nixpkgs/commit/27312ae230117c8525fc602d2f854d352664a46f) jekyll: Use an idiomatic way to get script directory
* [`df7a3621`](https://github.com/NixOS/nixpkgs/commit/df7a3621699f3c29c658d0a9fc098b115b6b6d4f) jekyll: Use idiomatic lowercase un-exported variable
* [`544ae25b`](https://github.com/NixOS/nixpkgs/commit/544ae25b98ec349360f9f2c2015bd658985c8c3e) jekyll: Re-lock dependencies
* [`cf9e5835`](https://github.com/NixOS/nixpkgs/commit/cf9e5835e92c6fa6a57215207c62e1908b5b2103) jekyll: Add jekyll-compose to full dependencies
* [`73b12e75`](https://github.com/NixOS/nixpkgs/commit/73b12e75e7b4e34ba1a77dd6dca1663465665bc6) yubikey-touch-detector: correct license
* [`121127d2`](https://github.com/NixOS/nixpkgs/commit/121127d295eee0acdb99e7fe9c8d4f6ec63ed9e3) gomplate: 3.11.8 -> 4.0.1
* [`798a8249`](https://github.com/NixOS/nixpkgs/commit/798a82495277766b3f4a52067a7c4f9975f5f8d6) gomplate: 4.0.1 -> 4.1.0
* [`ab9d8b8a`](https://github.com/NixOS/nixpkgs/commit/ab9d8b8a7c651c63c1dcd023839c31c7091f4ad0) bottles: 51.11 -> 51.13
* [`0eff84bc`](https://github.com/NixOS/nixpkgs/commit/0eff84bc006626b986437ae72dae22de601e0f23) efibootmgr: add updateScript
* [`c003cbeb`](https://github.com/NixOS/nixpkgs/commit/c003cbebe391f56230e169af5a5b532850d29ecd) efibootmgr: add meta.mainProgram
* [`5b71d6c0`](https://github.com/NixOS/nixpkgs/commit/5b71d6c0d083c969ce9660f3be0c0dc57d4995ac) efibootmgr: add version test
* [`612f242c`](https://github.com/NixOS/nixpkgs/commit/612f242c1d2d7299b96269fad951e2cef3d417c6) efibootmgr: split man output
* [`57b0f80b`](https://github.com/NixOS/nixpkgs/commit/57b0f80b637ffc890532c00242a205e26a12f8c1) python3Packages.pyqt3d: 5.15.6 -> 5.15.7
* [`2958b7e3`](https://github.com/NixOS/nixpkgs/commit/2958b7e3e463eb13afb7dace1cc85e7be9463ba4) python3Packages.pyqtchart: 5.15.6 -> 5.15.7
* [`8a6a68ec`](https://github.com/NixOS/nixpkgs/commit/8a6a68ec60f1a7e50a9d549eb7edefb059566339) python3Packages.pyqtdatavisualization: 5.15.5 -> 5.15.6
* [`d8008dee`](https://github.com/NixOS/nixpkgs/commit/d8008dee9f9cc9faffda122bf17cbb7531021889) sanjuuni: add run-on-nixos-artwork test
* [`1a75a7df`](https://github.com/NixOS/nixpkgs/commit/1a75a7df554ee51a45f9e08f38b333cfd0c98c6d) python312Packages.roadlib: 0.24.1 -> 0.26.0
* [`f772ed2c`](https://github.com/NixOS/nixpkgs/commit/f772ed2cace0b1e47ea510a4e0c34639548af68a) maintainers/team-list: add cyberus team
* [`7237f14f`](https://github.com/NixOS/nixpkgs/commit/7237f14f6cd2ef389d3c0d9f570c66201f94af33) cyclonedx-python: add cyberus team as maintainer
* [`31b9891d`](https://github.com/NixOS/nixpkgs/commit/31b9891df87c10fb16972ad2a4c8d5134eb2a4ca) tailscale-gitops-pusher: add cyberus team as maintainer
* [`38c7d204`](https://github.com/NixOS/nixpkgs/commit/38c7d204e63f07d86b43a020404faaecb201af4f) gitlab-container-registry: add cyberus team as maintainer
* [`682bee28`](https://github.com/NixOS/nixpkgs/commit/682bee28da45bfc3f441673e3060ba55b4e7f723) gitlab-elasticsearch-indexer: add cyberus team as maintainer
* [`20b3a545`](https://github.com/NixOS/nixpkgs/commit/20b3a5458d7d1edcd39ff14c90400a11e3f37f76) nixos/outline: add cyberus team as maintainer
* [`06b7e949`](https://github.com/NixOS/nixpkgs/commit/06b7e94988f32fbb31594d56ed612a6400a6bba1) outline: add cyberus team as maintainer
* [`6b129e29`](https://github.com/NixOS/nixpkgs/commit/6b129e29421627031526bbf068a888f6c0620d46) plausible: add cyberus team as maintainer
* [`f4905f3a`](https://github.com/NixOS/nixpkgs/commit/f4905f3a284546ef90e858a1986204ec56dfb8cd) tigervnc: 0.13.1 -> 0.14.0
* [`065aa24d`](https://github.com/NixOS/nixpkgs/commit/065aa24d39a6287513287dbd340479d7bc5703ec) libmatroska: migrate to by-name
* [`f9d30dcf`](https://github.com/NixOS/nixpkgs/commit/f9d30dcf8a084bc7cf6331b6f733aba1f83a4cff) libmatroska: format with nixfmt
* [`08fa5d73`](https://github.com/NixOS/nixpkgs/commit/08fa5d730303ecd17364198ef6feb18e3744215b) libmatroska: add getchoo as maintainer
* [`9f208ba0`](https://github.com/NixOS/nixpkgs/commit/9f208ba029abfc35a91882f48ffb5db6fe87dcd5) libmatroska: modernize
* [`5a476aa1`](https://github.com/NixOS/nixpkgs/commit/5a476aa11c5ba360d49b4779314792bd83580f44) libmatroska: remove unnecessary cmake flag
* [`eea88013`](https://github.com/NixOS/nixpkgs/commit/eea880137fbc30df8b1eb91ddcfb3d326cc3d7bb) libmatroska: split outputs
* [`f28b426a`](https://github.com/NixOS/nixpkgs/commit/f28b426a21dc19e81402c9bce8966370206d65c7) libmatroska: add validatePkgConfig hook
* [`6d9d1fa6`](https://github.com/NixOS/nixpkgs/commit/6d9d1fa6f2e345dd1e1a1cb97cee2cf4eb30fb23) libmatroska: add pkg-config test
* [`c8fbf33c`](https://github.com/NixOS/nixpkgs/commit/c8fbf33c873af6fdcea138fa4f013346eda5d0f4) libmatroska: add updateScript
* [`9132a2c6`](https://github.com/NixOS/nixpkgs/commit/9132a2c6bd628dcb07067767731a988b49876304) gns3-gui: 2.2.47 -> 2.2.49
* [`8fac7d92`](https://github.com/NixOS/nixpkgs/commit/8fac7d922ec14b6f7136f5d92a38d8e6e471155b) gns3-server: 2.2.47 -> 2.2.49
* [`a3c8723d`](https://github.com/NixOS/nixpkgs/commit/a3c8723d2b63450414935297992be420e208fc58) gns3-gui,gns3-server: format with nixfmt-rfc-style
* [`76940007`](https://github.com/NixOS/nixpkgs/commit/7694000762c2b64ebdeea157ce533a9a11c7e925) gns3-gui,gns3-server: remove `with lib;` notation
* [`65286b23`](https://github.com/NixOS/nixpkgs/commit/65286b2326bde909c7a3b80b0e49ba5d2aad03b1) python3Packages.awslambdaric: 2.0.11 -> 2.1.0
* [`c2699a99`](https://github.com/NixOS/nixpkgs/commit/c2699a996a0b455d01fb76374eb65da8aa8cd434) steam-run: mark as free (only the dependencies are unfree)
* [`bb926b3a`](https://github.com/NixOS/nixpkgs/commit/bb926b3af94737085b54bec8f2610d46c832b5ab) steam-run-free: add alias from steamPackages.steam-fhsenv-without-steam.run
* [`059696a8`](https://github.com/NixOS/nixpkgs/commit/059696a890221d2a5b1c71c744d9bbf711d12252) python310Packages.tensorflow-bin: Add Jetson source
* [`3aa42474`](https://github.com/NixOS/nixpkgs/commit/3aa424743f6824bcdfe4b6d469e3342d6c03563d) python310Packages.tensorflow-bin: Allow building for Jetsons
* [`a5fcc930`](https://github.com/NixOS/nixpkgs/commit/a5fcc930b44cb11589ed4995aede3082f641d249) python310Packages.geoip2: Disable TestAsyncClient for Python 3.10 as well
* [`4aa67c95`](https://github.com/NixOS/nixpkgs/commit/4aa67c9517ceada7f94e531ecec6899f938f12f4) python311Packages.tensorflow-bin: Use CUDA 12
* [`90b1b8d6`](https://github.com/NixOS/nixpkgs/commit/90b1b8d60c65d253bc5e373ffd9657c032aaf913) python311Packages.tensorflow-bin: Remove redundant rec
* [`cc47f003`](https://github.com/NixOS/nixpkgs/commit/cc47f00391200ee643a28fb3c91dfec20f213063) python3Packages.tensorflow-bin: Use cuda_compat on Jetsons
* [`3876bf52`](https://github.com/NixOS/nixpkgs/commit/3876bf529f9fa6c0a9e0c4ad294c635da195eb97) cassandra: fix cqlsh not working
* [`9e9a1f73`](https://github.com/NixOS/nixpkgs/commit/9e9a1f737d0252a1a51424749c3949be832f47df) freebsd: Add upstream patch fixing obscure c++98 interaction
* [`2c66c45c`](https://github.com/NixOS/nixpkgs/commit/2c66c45cf39a298971a6237bd818eeeec46beb97) gbenchmark: mark support for FreeBSD
* [`363ab2fe`](https://github.com/NixOS/nixpkgs/commit/363ab2fe36c47410ecb81cf05d23292c774db78b) upsun: add updateScript
* [`12656c3d`](https://github.com/NixOS/nixpkgs/commit/12656c3d83adeabd41cfc592480711bd43728e7a) psqlodbc: Point to src URL that exists
* [`d45b39bb`](https://github.com/NixOS/nixpkgs/commit/d45b39bb89c0f67b9ef9e4d335fc3bd1b2a33f1c) llvmPackages.compiler-rt: Use FreeBSD headers during noLibc build
* [`d8d49bea`](https://github.com/NixOS/nixpkgs/commit/d8d49bea89b5fcb3a8d6826e7bc8611b0b87db21) python312Packages.rx: update disable test reason
* [`7970d394`](https://github.com/NixOS/nixpkgs/commit/7970d394fefa42ddf2d75d14f2a3d50b41b1534c) python312Packages.rx: drop nose dependency
* [`cca50359`](https://github.com/NixOS/nixpkgs/commit/cca503598d7170dff2dea80cc3a6e3f815ade0b8) python3Packages.tensorflow-bin: Explain wheel rename on Jetsons
* [`f2a4ee0a`](https://github.com/NixOS/nixpkgs/commit/f2a4ee0a3e437e9a63b9699221b8f2bc7d573a35) python3Packages.tensorflow-bin: Simplify CUDA platform branching
* [`04db3f04`](https://github.com/NixOS/nixpkgs/commit/04db3f04485c5e99e103bed2116b8cb0f4e66791) python312Packages.rx: enable pyproject
* [`8d1de5a4`](https://github.com/NixOS/nixpkgs/commit/8d1de5a49464fe93087e7126626fde60d5561dab) lensfun: remove CMAKE_BUILD_TYPE from cmakeFlags
* [`c9a5df08`](https://github.com/NixOS/nixpkgs/commit/c9a5df08f56e96d8b1467dc1423998db94542b3e) widelands: remove CMAKE_BUILD_TYPE from cmakeFlags
* [`688649de`](https://github.com/NixOS/nixpkgs/commit/688649def33bd686f86bcaf9c1053e41b69b5e61) xeus-cling: remove CMAKE_BUILD_TYPE from cmakeFlags
* [`c847ef8d`](https://github.com/NixOS/nixpkgs/commit/c847ef8d75e35f476fde3f994e5cd8a251e6ce82) qgis: remove CMAKE_BUILD_TYPE from cmakeFlags
* [`1271a3b6`](https://github.com/NixOS/nixpkgs/commit/1271a3b6d5550d191a049727f55c5649b7988ffc) qgis-ltr: remove CMAKE_BUILD_TYPE from cmakeFlags
* [`ee4483f1`](https://github.com/NixOS/nixpkgs/commit/ee4483f188bcb71b9ccbf56139d32b892bcdaa56) maa-assistant-arknights: remove CMAKE_BUILD_TYPE from cmakeFlags
* [`72734ed7`](https://github.com/NixOS/nixpkgs/commit/72734ed79359bcb3f985960bce89ecba0ee55a90) manifold: remove CMAKE_BUILD_TYPE from cmakeFlags
* [`42f5757e`](https://github.com/NixOS/nixpkgs/commit/42f5757eed89f6c940150f12d6b3e91b599bacee) opengv: remove CMAKE_BUILD_TYPE from cmakeFlags
* [`1a2360f0`](https://github.com/NixOS/nixpkgs/commit/1a2360f0b4bce5e8aed9a03deda413f0208b3ba8) cro-mag-rally: remove CMAKE_BUILD_TYPE from cmakeFlags
* [`e5cfcd2b`](https://github.com/NixOS/nixpkgs/commit/e5cfcd2b3ec33acac46fb6fb767c05f3cfa2266f) httping: remove CMAKE_BUILD_TYPE from cmakeFlags
* [`4b84d3df`](https://github.com/NixOS/nixpkgs/commit/4b84d3dfec38506162973c0f318d5a407d9ef101) ricochet-refresh: remove CMAKE_BUILD_TYPE from cmakeFlags
* [`53f550bb`](https://github.com/NixOS/nixpkgs/commit/53f550bbfd8f116027c97dc17876cce903fb21f9) protonmail-bridge-gui: use cmakeFlags instead of preConfigure
* [`81cd98b0`](https://github.com/NixOS/nixpkgs/commit/81cd98b0b50d16a210cf3b7e119ea939c2f7c128) clang-uml: remove CMAKE_BUILD_TYPE from cmakeFlags
* [`71402a67`](https://github.com/NixOS/nixpkgs/commit/71402a672f19385ad9cb2eb22c6a5834a9ca770a) rsgain: remove CMAKE_BUILD_TYPE from cmakeFlags
* [`07654aeb`](https://github.com/NixOS/nixpkgs/commit/07654aeb367723490443858e33bfc698936cbc83) raze: remove CMAKE_BUILD_TYPE from cmakeFlags
* [`2277260e`](https://github.com/NixOS/nixpkgs/commit/2277260e75b4eedf25c062ce8e655444c52b7382) lms: remove CMAKE_BUILD_TYPE from cmakeFlags
* [`2ab92557`](https://github.com/NixOS/nixpkgs/commit/2ab92557c1b0bb84e22b3dccd288fef41dd65180) libvpl: remove CMAKE_BUILD_TYPE from cmakeFlags
* [`e41451fe`](https://github.com/NixOS/nixpkgs/commit/e41451febf8662e36e70180a78708558e4d1e438) qdiskinfo: remove CMAKE_BUILD_TYPE from cmakeFlags
* [`7194cfcb`](https://github.com/NixOS/nixpkgs/commit/7194cfcbc69e2dd38c05b1eba5ac7e6ea0be508e) _2ship2harkinian: remove CMAKE_BUILD_TYPE from cmakeFlags
* [`6db07cb0`](https://github.com/NixOS/nixpkgs/commit/6db07cb07a0eab1c7f2cabc2371a90a950f358da) python312Packages.blessings: drop nose dependency
* [`59147201`](https://github.com/NixOS/nixpkgs/commit/59147201a76a2aa7379f6c537e00303dc154ea62) python312Packages.pytest-relaxed drop invocation dependency
* [`6bdf93be`](https://github.com/NixOS/nixpkgs/commit/6bdf93beb49fcf85aeaa827b2952f699a1b17ece) python312Packages.invocation: enable tests with pytest
* [`0305bd86`](https://github.com/NixOS/nixpkgs/commit/0305bd86005e18bbf68361e3b32f2ef914ebefaa) cbeams: replaced blessings with blessed
* [`e414edaa`](https://github.com/NixOS/nixpkgs/commit/e414edaa0d145f6207d17bad98f51b66e78b3854) cbeams: migrate to pkgs/by-name, modernize
* [`7a58572d`](https://github.com/NixOS/nixpkgs/commit/7a58572d131d0d8f36f37af05d1d51ee4aaed464) cbeams: modernize, add sigmanificient to maintainers
* [`5f0ccb48`](https://github.com/NixOS/nixpkgs/commit/5f0ccb483fab5881c26985fece03a90d6eb23cc9) python3Packages.ronin: drop
* [`12858cfa`](https://github.com/NixOS/nixpkgs/commit/12858cfae4b39bf4800b08dc31550fff21ba196e) python3Packages.reportengine: drop
* [`83d7278d`](https://github.com/NixOS/nixpkgs/commit/83d7278d8f044cba3a42093ddc0f93e6ade1c804) python3Packages.validphys2: drop
* [`b02dc5f5`](https://github.com/NixOS/nixpkgs/commit/b02dc5f58a4b3c8eea54d7584ce70b9162fc68ad) python3Packages.n3fit: drop
* [`ad79eb47`](https://github.com/NixOS/nixpkgs/commit/ad79eb47c2793cc23196db57bf78d5cc0dde8752) python312Packages.pydy: drop nose dependency
* [`5e6cc7bd`](https://github.com/NixOS/nixpkgs/commit/5e6cc7bd5a064d3b421a1b14c83300a8d11aa7c3) python312Packages.clustershell: drop nose dependency
* [`76c3e5c1`](https://github.com/NixOS/nixpkgs/commit/76c3e5c1abf316d941e92dc050e3629e8346f16d) thunderbird-bin-unwrapped: 115.13.0 → 128.1.0esr
* [`492ae30d`](https://github.com/NixOS/nixpkgs/commit/492ae30d9d8df09998200c2243d0ad52cc9d6336) suricata: enable tests
* [`88ca9cc9`](https://github.com/NixOS/nixpkgs/commit/88ca9cc9ad4b85027e93626716a438217c628d61) thunderbird-bin: migrated to autoPatchelfHook
* [`9cf57d47`](https://github.com/NixOS/nixpkgs/commit/9cf57d47d5791953809d6ce84b42bd9dd34174ea) maintainers: add lucastso10
* [`ee6fa102`](https://github.com/NixOS/nixpkgs/commit/ee6fa1027f98496a6d38024d0f0f3fbde4ca6799) programs/yubikey-touch-detector: expose configuration variables
* [`814cecf7`](https://github.com/NixOS/nixpkgs/commit/814cecf7451a6c28e469b09894b70e3a8d5f017e) bump2version: move to python-modules
* [`9c17b9b0`](https://github.com/NixOS/nixpkgs/commit/9c17b9b05f575a9f45d72426c39433a75b830512) nanoemoji: move to python-modules
* [`bcd82a2c`](https://github.com/NixOS/nixpkgs/commit/bcd82a2c121fba395e55be2e82100a607d4b9ca5) python3Packages.ufomerge: init at 1.7.0
* [`4bd73755`](https://github.com/NixOS/nixpkgs/commit/4bd737554e672ee3e357a1ed0d17ff3a1203fda0) python3Packages.opentype-feature-freezer: init at 0-unstable-2022-07-09
* [`9dc55ca4`](https://github.com/NixOS/nixpkgs/commit/9dc55ca46c8a04c334a5e49a9ec5f3f185d0b9b1) python3Packages.paintcompiler: init 0.3.4
* [`3185dca3`](https://github.com/NixOS/nixpkgs/commit/3185dca35e6c33cb49993d5a14472e3724884bc0) python3Packages.blackrenderer: init at 0.6.0
* [`185f7f40`](https://github.com/NixOS/nixpkgs/commit/185f7f400830b1f056c23aeecd103a2b74ecb23c) python3Packages.diffenator2: init at 0.4.3
* [`dc997637`](https://github.com/NixOS/nixpkgs/commit/dc997637aebe7f9da5dda1219187c3926223ff9e) python3Packages.vttlib: init at 0.12.0
* [`1b3f672a`](https://github.com/NixOS/nixpkgs/commit/1b3f672a3f7bd691b0c5c52820e9bf9aae7ad5a8) python3Packages.bumpfontversion: init at 0.4.0
* [`9264afd8`](https://github.com/NixOS/nixpkgs/commit/9264afd8f0f96c69d4479cf136c81aa39066a356) python3Packages.gftools: init at 0.9.68
* [`185948bd`](https://github.com/NixOS/nixpkgs/commit/185948bd01dd80e856a27788b2b6cf787410279f) tailscale: only autoconnect after backend is up
* [`337bd8c3`](https://github.com/NixOS/nixpkgs/commit/337bd8c31c26c152b1cb88b10cf4b600ef158a99) fscryptctl: 1.0.0 -> 1.2.0
* [`4e49df05`](https://github.com/NixOS/nixpkgs/commit/4e49df05ed42a11de3fb0313d466ebb32cea09cf) fscryptctl: move to by-name
* [`5cdc4888`](https://github.com/NixOS/nixpkgs/commit/5cdc4888b4ea4492313dbf5c750b85d88faa6598) sirius: Add option to build python bindings
* [`c2f9a2c4`](https://github.com/NixOS/nixpkgs/commit/c2f9a2c471a7c372597b4e0b93740b56d2f849e3) python3Packages.sirius: init at 7.6.0
* [`585af9ec`](https://github.com/NixOS/nixpkgs/commit/585af9ec70b6048639bfc492163875aed3c11e55) umpire: Add cuda support
* [`ea0225ee`](https://github.com/NixOS/nixpkgs/commit/ea0225eebfa7df6f66061bcd8c71d9ed4a2b608a) opera: 111.0.5168.61 -> 113.0.5230.47
* [`2ae28348`](https://github.com/NixOS/nixpkgs/commit/2ae2834863b579bdaba1f843a497d91566d30ba7) nixos/ups: add system-ups.slice
* [`50afd1e1`](https://github.com/NixOS/nixpkgs/commit/50afd1e1d3a057a1a4bd91afefeed8a5d14ffc13) nixos/bacula: add system-bacula.slice
* [`fdc712da`](https://github.com/NixOS/nixpkgs/commit/fdc712da63a5c70013810098572dec54c705be05) betterbird: 115.9.0-bb26-build2 -> 115.14.0-bb31
* [`c9360770`](https://github.com/NixOS/nixpkgs/commit/c9360770fea142a33ef7c9131aee8d2b0c4b0f3f) ArchiSteamFarm: 6.0.4.4 -> 6.0.6.4
* [`9a047da6`](https://github.com/NixOS/nixpkgs/commit/9a047da69b72055b438da0a8af597915fa0d9ad0) cudaPackages.tensorrt: 8.6 -> 10.3
* [`ca7cb5d6`](https://github.com/NixOS/nixpkgs/commit/ca7cb5d6ea1dde0f3fb050cb4e086cbfb136d7a4) openjfx22: 22.0.1-ga -> 22.0.2-ga
* [`19d7a635`](https://github.com/NixOS/nixpkgs/commit/19d7a635e878846a7d4d1c586884bb8245924484) openjfx{11,17,21,22}: add upstream patch for FFmpeg 7
* [`93fb96ec`](https://github.com/NixOS/nixpkgs/commit/93fb96ecdead26092b8425383fffb0422bf52182) nixos/generic-extlinux-compatible: add mirroredBoots option
* [`57737e22`](https://github.com/NixOS/nixpkgs/commit/57737e22bd80c08ebc53cc204f4abd3a2e7108ee) oidc-agent: reformat code, fix wrong man page location
* [`33422585`](https://github.com/NixOS/nixpkgs/commit/3342258555640322a18589c549828d5c374d614f) home-assistant-custom-components.xiaomi_gateway3: 4.0.5 -> 4.0.6
* [`53f3f689`](https://github.com/NixOS/nixpkgs/commit/53f3f689bea6a05c8aa1c04ab5177c2f5488913a) alot: v0.10 -> v0.11
* [`0aa5a025`](https://github.com/NixOS/nixpkgs/commit/0aa5a025908680f2e25071afef74d6bf03dcc3ab) python312Packages.xarray: 2024.6.0 -> 2024.07.0
* [`ecc89624`](https://github.com/NixOS/nixpkgs/commit/ecc89624769f0183cf34f921cd7e8b9d8b44358d) bitwarden-directory-connector: 2024.3.2 -> 2024.9.0
* [`1b52ef11`](https://github.com/NixOS/nixpkgs/commit/1b52ef11fe8822a19d1257f9b49fa5632f585002) lean4: 4.9.0 -> 4.9.1
* [`99d63649`](https://github.com/NixOS/nixpkgs/commit/99d636490f81e5024077b7e234871a06f5fe7451) zsh-forgit: 24.02.0 -> 24.09.0
* [`9706ea61`](https://github.com/NixOS/nixpkgs/commit/9706ea618a983552f5c7d103b07c82592a2f5a78) duplicati: move to by-name
* [`0374204e`](https://github.com/NixOS/nixpkgs/commit/0374204eccb1ee66fc5c445673259b02204b32bc) duplicati: 2.0.7.1 -> 2.0.8.1
* [`cb36b6c2`](https://github.com/NixOS/nixpkgs/commit/cb36b6c228e2109677d4239e0f779cb18f1b7fc5) dump_syms: 2.3.3 -> 2.3.4
* [`e5e69b74`](https://github.com/NixOS/nixpkgs/commit/e5e69b748f3049680c418854930c2f2b792d4a82) lib.types.anything: remove custom logic for lists (default to 'mergeEqualOption')
* [`e1c10225`](https://github.com/NixOS/nixpkgs/commit/e1c102250e4dcf828d50514ceb8f8c969fd501ca) soupault: 4.10.0 → 4.11.0
* [`8b8a20d1`](https://github.com/NixOS/nixpkgs/commit/8b8a20d1b4e15f1740aa04ac72bd72e8a3242364) lms: 3.56.0 -> 3.57.0
* [`c27e90ce`](https://github.com/NixOS/nixpkgs/commit/c27e90ce58df36fd047b86a8b73109626fdf215f) lime3ds: 2117.1 -> 2118
* [`b15edf44`](https://github.com/NixOS/nixpkgs/commit/b15edf445b05791315a39c0e333ab6461150d908) stockfish: 16.1 -> 17
* [`b4cc9898`](https://github.com/NixOS/nixpkgs/commit/b4cc989874b7bc35e98458c66eaae7a50bc06867) spl: init at v0.3.2
* [`83d27c38`](https://github.com/NixOS/nixpkgs/commit/83d27c3878f875d96fbcbe738f3731be3cd88ddb) duplicati: add bot-wxt1221 as maintainers
* [`45d49fec`](https://github.com/NixOS/nixpkgs/commit/45d49fecefbfc06fd238a100a3223da957a0ac06) duplicati: add sourceProvenance patern
* [`4175200f`](https://github.com/NixOS/nixpkgs/commit/4175200f2c40528b5fa3f116745244ad9b91eb36)   spoofdpi: 0.11.1 -> 0.12.0
* [`89795ca2`](https://github.com/NixOS/nixpkgs/commit/89795ca29333a90d3c52ee3a14bbe3418a2d9060) vimPlugins.nvim-rip-substitute: init at 2024-08-30
* [`a02d9427`](https://github.com/NixOS/nixpkgs/commit/a02d94279bf26791132820a9266c4173c63fc69d) nixos/ttyd: allow `caFile=null` when `enableSSL=true`
* [`b7bb0f21`](https://github.com/NixOS/nixpkgs/commit/b7bb0f2190aa06db278f4375c13f1c9980e7a2ac) nixos/ttyd: reduce `inherit (lib)`
* [`c5e664b7`](https://github.com/NixOS/nixpkgs/commit/c5e664b7f23fa19bd07560b08dbc4ed45c2ad435) vimPlugins.syntax-tree-surfer: init at 2023-10-06
* [`bde8bfd1`](https://github.com/NixOS/nixpkgs/commit/bde8bfd131bbb61f5339fd5898099afbb2f88c73) hoppscotch: 24.3.3-1 -> 24.8.1-0
* [`519741ae`](https://github.com/NixOS/nixpkgs/commit/519741ae32ee35e16360c7b985ba68ac0acc8fe5) sums: init at 0.11
* [`ae9471fd`](https://github.com/NixOS/nixpkgs/commit/ae9471fd64ee1dae1bfbbbe3780999962cbb1a19) granian: init at 1.5.2
* [`57077bc4`](https://github.com/NixOS/nixpkgs/commit/57077bc43431ca294f4ee9cd600ab0b29a3814bd) waybar: include the systemd user unit
* [`0de0b9d7`](https://github.com/NixOS/nixpkgs/commit/0de0b9d7a27cb113d1e7d8dbfdb24d9631ce5418) pmtiles: 1.20.0 -> 1.21.0
* [`c6546911`](https://github.com/NixOS/nixpkgs/commit/c654691181464e798c0d5bc1403427f6c6554ed2) python311Packages.llama-cloud: 0.0.15 -> 0.0.17
* [`8d811438`](https://github.com/NixOS/nixpkgs/commit/8d811438a9be4fca37dba706ebfeb0a4ccd00c6f) python311Packages.llama-index-core: 0.11.7 -> 0.11.8
* [`25862e1a`](https://github.com/NixOS/nixpkgs/commit/25862e1a2b4b2c80aa418b9f3acb116b4730ab38) python311Packages.llama-index-cli: 0.3.0 -> 0.3.1
* [`90a45d8c`](https://github.com/NixOS/nixpkgs/commit/90a45d8cb1d940ad6dd860f3c09ea719bdd766f2) python311Packages.llama-index-vector-stores-postgres: 0.2.1 -> 0.2.2
* [`110af40a`](https://github.com/NixOS/nixpkgs/commit/110af40a829afee7f05c439ef921cbc564031450) python311Packages.llama-parse: 0.5.2 -> 0.5.3
* [`a03d5e6f`](https://github.com/NixOS/nixpkgs/commit/a03d5e6f56fc83152d17a05226d230f143942da5) waybar: the systemd unit is coming from the package now
* [`ce10ce52`](https://github.com/NixOS/nixpkgs/commit/ce10ce52b94f4e8dd48ac13fee7563b951b2c27c) plasticity: 24.1.8 -> 24.2.0
* [`e2ff45f9`](https://github.com/NixOS/nixpkgs/commit/e2ff45f9b30827df9686b597e1b8da0a352d2123) syslogng: add option to enable grpc module
* [`9b6222cb`](https://github.com/NixOS/nixpkgs/commit/9b6222cb716912d52103b4f7ef4c43112c54906d) dyalog: 19.0.49960 -> 19.0.50027
* [`4584a58c`](https://github.com/NixOS/nixpkgs/commit/4584a58c0dfd965946be5b2f079f464ae0ee3632) nix.stable.tests.nix-fallback-paths: Allow cross-compiled store path name
* [`2e702d07`](https://github.com/NixOS/nixpkgs/commit/2e702d07bbf4fc97d97a25a180431e826b38ac30) nix: nix_2_18 -> nix_2_24
* [`131b8e5f`](https://github.com/NixOS/nixpkgs/commit/131b8e5fe6eafcc10d96e3d81d7a3841e099657f) nixVersions.*: Add tests.nixpkgs-lib
* [`556d5d47`](https://github.com/NixOS/nixpkgs/commit/556d5d4789f3333c780c5734882452eed33e1376) nixos/rl-2411: Add Nix update
* [`12829a17`](https://github.com/NixOS/nixpkgs/commit/12829a17fdadb32ec8351103c633bacdb0ed6fd0) nix-doc: disable nix-doc
* [`02911673`](https://github.com/NixOS/nixpkgs/commit/029116732305987878ffc9714829cc770e786a6c) nix-plugins: 14.0.0 -> 15.0.0
* [`19618599`](https://github.com/NixOS/nixpkgs/commit/19618599793f8fe0428d5843b667c7c89767e1e5) overlayed: init at 0.5.0
* [`4e32fc40`](https://github.com/NixOS/nixpkgs/commit/4e32fc40570e7afb8fb23923671cf36b3efe0481) pico-sdk: 1.5.1 -> 2.0.0
* [`ff8b2d51`](https://github.com/NixOS/nixpkgs/commit/ff8b2d5162558d80646b2f4f393e239414071f5e) nixos/iso-image: mount squashfs with threads=multi
* [`d308cfcb`](https://github.com/NixOS/nixpkgs/commit/d308cfcb3865c6411dabde5f8c2d8f30463efee7) nixos/netboot: mount squashfs with threads=multi
* [`951afba3`](https://github.com/NixOS/nixpkgs/commit/951afba3ae436be3e170951b2ff3993186740b1f) scorecard: 4.13.1 -> 5.0.0
* [`a9335092`](https://github.com/NixOS/nixpkgs/commit/a933509293a2ee24b7f34945fd5fbe47253e2726) firefoxpwa: 2.12.1 -> 2.12.3
* [`cefa2035`](https://github.com/NixOS/nixpkgs/commit/cefa2035dd7d26ee1016f6c3b90fb97209bf6f5e) gllvm: 1.3.1 -> 1.3.1-unstable-2024-04-28, fix build
* [`317a52a7`](https://github.com/NixOS/nixpkgs/commit/317a52a7570617ec89d733f8e4dd5865fb653f8a) flarum: fix installation and migration logic
* [`e2c6cd34`](https://github.com/NixOS/nixpkgs/commit/e2c6cd349d8417c0da36ad38b2519869686f46fd) pureref: 2.0.2 -> 2.0.3
* [`d4766c39`](https://github.com/NixOS/nixpkgs/commit/d4766c399a62b9c6a941b9e7571119feb5cec1e7) (python3Packages.)pwndbg: 2024.02.14 -> 2024.08.29
* [`5877cd8c`](https://github.com/NixOS/nixpkgs/commit/5877cd8c9f47ca7315389054b00e056cd6294536) gen-license: 0.1.2 -> 0.1.4
* [`f747eba8`](https://github.com/NixOS/nixpkgs/commit/f747eba81f8487ef5e01f9a69e40f478888effac) librealsense: 2.55.1 -> 2.56.1
* [`d25d241e`](https://github.com/NixOS/nixpkgs/commit/d25d241e3819fbeded149f6e2cd4d89d0887cdb0) Update nixos/modules/services/networking/tailscale.nix
* [`0f973955`](https://github.com/NixOS/nixpkgs/commit/0f9739557845c46aad9a18bc7fe424eecd0f2074) fastddsgen: 4.0.0 -> 4.0.1
* [`061641ea`](https://github.com/NixOS/nixpkgs/commit/061641eacf6f58f37b2ff3e944e436b3fa25cf0a) wireguard-ui: init at 0.6.2
* [`86df4f6a`](https://github.com/NixOS/nixpkgs/commit/86df4f6a364bbbe2df52c80030ac34ddc3f0ddb3) flexget: 3.11.43 -> 3.11.45
* [`e2594868`](https://github.com/NixOS/nixpkgs/commit/e2594868c9e5a0c5dc54545388d7d3467df36d1a) pokemmo-installer: init at 1.4.8
* [`0c4c9798`](https://github.com/NixOS/nixpkgs/commit/0c4c9798243c384894a86cff58529a02302b0b6d) libdatachannel: format and allow building on darwin
* [`457e4096`](https://github.com/NixOS/nixpkgs/commit/457e409607d806c8de78aeda885af901d3aa1c4f) httptoolkit-server: init at 1.19.0
* [`7b9fb850`](https://github.com/NixOS/nixpkgs/commit/7b9fb850e79a0345d29d388f5b420dc661bd0e89) httptoolkit: init at 1.19.0
* [`918e8d7b`](https://github.com/NixOS/nixpkgs/commit/918e8d7bbbc56465f54e0b59eafc0150cf72d1bd) kara: init at 0.7.1
* [`826a9ba8`](https://github.com/NixOS/nixpkgs/commit/826a9ba899c6a2517678ecc716ce9a8f2ef52507) tomcat9: 9.0.93 -> 9.0.94
* [`e7354e83`](https://github.com/NixOS/nixpkgs/commit/e7354e83da0752096a84fe8c54497f24071b8209) tomcat10: 10.1.28 -> 10.1.29
* [`633055a2`](https://github.com/NixOS/nixpkgs/commit/633055a2bd74b4ed53e6130e32dead37db7ff7bf) jp-zip-codes: init at 0-unstable-2024-08-01
* [`392ec6ad`](https://github.com/NixOS/nixpkgs/commit/392ec6ad7aa1d0036e0996785d5922a0924a6f96) jawiki-all-titles-in-ns0: init at 0-unstable-2024-09-11
* [`78b3a6b4`](https://github.com/NixOS/nixpkgs/commit/78b3a6b434348703379e54705a938fd7804846be) mozcdic-ut-alt-cannadic: init at 0-unstable-2024-07-28
* [`d148df37`](https://github.com/NixOS/nixpkgs/commit/d148df37bbe4348c4bfab2ceeb19f905fc4e1d99) mozcdic-ut-edict2: init at 0-unstable-2024-07-28
* [`6d471318`](https://github.com/NixOS/nixpkgs/commit/6d471318dd50db95726484e7b9772ac45f7fc2e1) mozcdic-ut-jawiki: init at 0-unstable-2024-08-23
* [`57f2fc98`](https://github.com/NixOS/nixpkgs/commit/57f2fc98888af0070f57cde65789cec6fcff931c) mozcdic-ut-neologd: init at 0-unstable-2024-07-28
* [`ee06c044`](https://github.com/NixOS/nixpkgs/commit/ee06c044df50df174b74a492125b74ad878e9c9b) mozcdic-ut-personal-names: init at 0-unstable-2024-08-06
* [`6201a276`](https://github.com/NixOS/nixpkgs/commit/6201a2761c04a6e3e6e04bc15fa22cb4c3fada7e) mozcdic-ut-place-names: init at 0-unstable-2024-08-06
* [`58a342c6`](https://github.com/NixOS/nixpkgs/commit/58a342c6375eae7531d05b87b53aff9ccf83ef9b) mozcdic-ut-skk-jisyo: init at 0-unstable-2024-07-27
* [`4441c635`](https://github.com/NixOS/nixpkgs/commit/4441c635e4fa7ba4ae959febaa2d204bfd20ae10) mozcdic-ut-sudachidict: init at 0-unstable-2024-07-28
* [`bbb9b4bb`](https://github.com/NixOS/nixpkgs/commit/bbb9b4bb379b0284a4d7e1a071072e9db5263ef5) merge-ut-dictionaries: init at 0-unstable-2024-08-28
* [`c99947bd`](https://github.com/NixOS/nixpkgs/commit/c99947bd69f932d6a3c7f93745be0ccef0e5e551) ibus-engines.mozc-ut: init at 2.30.5544.102
* [`e2d17e90`](https://github.com/NixOS/nixpkgs/commit/e2d17e900880e624808df0cbce421a8ebe2e8b7d) podofo010: 0.10.3 -> 0.10.4
* [`2f95b266`](https://github.com/NixOS/nixpkgs/commit/2f95b266775689a2e3e2cf7df05fcda8762c0656) ipget: 0.10.0 -> 0.11.0
* [`47b0dfe7`](https://github.com/NixOS/nixpkgs/commit/47b0dfe793b66241cacca50d722783425986c7a7) trexio: 2.4.2 -> 2.5.0
* [`99ef3d51`](https://github.com/NixOS/nixpkgs/commit/99ef3d51e8df28b11567fefb8523e6d3452a5443) itk: unvendor eigen
* [`483b8847`](https://github.com/NixOS/nixpkgs/commit/483b8847c2d766d60189438aee547b14236b8276) last-resort: 15.100 -> 16.000
* [`67a611c2`](https://github.com/NixOS/nixpkgs/commit/67a611c2f6fde3a4213be2890a71dd265232287a) python312Packages.stanza: 1.8.2 -> 1.9.2
* [`0b134745`](https://github.com/NixOS/nixpkgs/commit/0b134745fbae93afc3e0751fe1429e10bb6656e1) docker-buildx: 0.16.2 -> 0.17.0
* [`56b263c7`](https://github.com/NixOS/nixpkgs/commit/56b263c7d48616bd2de97bbd4e4a9a5a0cd00224) experienced-pixel-dungeon: 2.18 -> 2.18.2
* [`0957c779`](https://github.com/NixOS/nixpkgs/commit/0957c77918358adbb2f6062001d03895c77c93eb) nosql-workbench: lint
* [`ef95cc15`](https://github.com/NixOS/nixpkgs/commit/ef95cc157bd16b2a504d127c8d3c2f2499fb5c35) granted: 0.32.0 -> 0.33.0
* [`a9507301`](https://github.com/NixOS/nixpkgs/commit/a95073010f19fae349fa135799398d07129900ef) nosql-workbench: 3.11.0 -> 3.13.0
* [`be83fcde`](https://github.com/NixOS/nixpkgs/commit/be83fcde7dae676ac077b352153a93af0df71d49) nix.tests.nixStatic: init
* [`14f8c145`](https://github.com/NixOS/nixpkgs/commit/14f8c145e64e8ec544d9243cbad7bc3f53e99657) buildkit: 0.15.2 -> 0.16.0
* [`3e49c026`](https://github.com/NixOS/nixpkgs/commit/3e49c02689024c19ebed7f7b562df0bbd2ebb469) grafana-agent: 0.42.0 -> 0.43.0
* [`ac849e56`](https://github.com/NixOS/nixpkgs/commit/ac849e565872034155ccaaa0bf736a75f1073a6e) nixos/nix-fallback-paths: 2.24.2 -> 2.24.6
* [`adc9eb14`](https://github.com/NixOS/nixpkgs/commit/adc9eb141c144a06c3673563336fd9abc804e2b1) home-assistant-custom-components.average: init at 2.3.4
* [`89bc5a22`](https://github.com/NixOS/nixpkgs/commit/89bc5a229aff2d61239ed300f891a006d0ade0be) docker-compose: 2.29.2 -> 2.29.3
* [`df8c8b2e`](https://github.com/NixOS/nixpkgs/commit/df8c8b2e624495f3038346c6f16995fa7f07f2a9) aider-chat: skip version check in tests
* [`be3cef9e`](https://github.com/NixOS/nixpkgs/commit/be3cef9ecc55178922f972ca2c61434eb31fed81) krane: 3.6.1 -> 3.6.2
* [`d5b29d1e`](https://github.com/NixOS/nixpkgs/commit/d5b29d1ea167ba26cbd6ee64b12801b720e704cb) python312Packages.radian: 0.6.12 -> 0.6.13
* [`d1e5bbc7`](https://github.com/NixOS/nixpkgs/commit/d1e5bbc756535966e3047e61c45b65137d0ffe9a) python312Packages.rchitect: 0.4.6 -> 0.4.7
* [`01153a9c`](https://github.com/NixOS/nixpkgs/commit/01153a9c4ff7d2388254417121bc7384e7ea87f8) semantic-release: 24.1.0 -> 24.1.1
* [`3f2eafc1`](https://github.com/NixOS/nixpkgs/commit/3f2eafc16933172c083e75b2d2e6ce2433c8ca5d) harper: 0.10.0 -> 0.11.0
* [`36671a03`](https://github.com/NixOS/nixpkgs/commit/36671a03acbae2a55391a4d2669775396fd99ccd) vitess: 20.0.1 -> 20.0.2
* [`62da6fc9`](https://github.com/NixOS/nixpkgs/commit/62da6fc9174ddc7857210d07f9f7d250baa1abe6) tektoncd-cli: 0.38.0 -> 0.38.1
* [`c7b2d3b1`](https://github.com/NixOS/nixpkgs/commit/c7b2d3b1a704898fec88546c99f17176fea7ab04) glibtool: init
* [`8bb3c5af`](https://github.com/NixOS/nixpkgs/commit/8bb3c5af95bad56de011d0990b3ffd71ae23b672) opengrok: 1.13.20 -> 1.13.21
* [`c1cfad42`](https://github.com/NixOS/nixpkgs/commit/c1cfad4217c33ad71958c69b18d59e5af1eee50c) python312Packages.gradio: 4.41.0 -> 4.44.0
* [`57e1568a`](https://github.com/NixOS/nixpkgs/commit/57e1568a7ba45e2360441474faf012a4d7dcfe7b) python312Packages.gradio-pdf: 0.0.13 -> 0.0.15
* [`496ca405`](https://github.com/NixOS/nixpkgs/commit/496ca405d84176d310bcc4f3dd08884675b34717) python312Packages.manifestoo-core: 1.7 -> 1.8
* [`c014be4e`](https://github.com/NixOS/nixpkgs/commit/c014be4eba12f7e618576c84c8e2721c34f63baf) sqlite-vec: 0.1.1 -> 0.1.2
* [`335adbae`](https://github.com/NixOS/nixpkgs/commit/335adbaecd773d3d44e600889df6fb624fe86131) yubico-piv-tool: 2.6.0 -> 2.6.1
* [`abe503e2`](https://github.com/NixOS/nixpkgs/commit/abe503e2b326f4c222591de58f1ddc8c36425d1b) python312Packages.huggingface-hub: 0.24.6 -> 0.24.7
* [`d09dbe2d`](https://github.com/NixOS/nixpkgs/commit/d09dbe2d7f31aa865bd2e6b963d52df0dc231323) ipxe: move to by-name
* [`0ed7e745`](https://github.com/NixOS/nixpkgs/commit/0ed7e74523d93bf14823f8d097db1e3e35521fc0) ipxe: format with nixfmt-rfc-style
* [`01770b43`](https://github.com/NixOS/nixpkgs/commit/01770b4374c21fa854d2937d3be1664bd02a5e23) ipxe: modernise
* [`345f1f93`](https://github.com/NixOS/nixpkgs/commit/345f1f93c297606513481562261a492b36599cc4) ipxe: 1.12.1-unstable-2024-08-15 -> 1.21.1-unstable-2024-09-13
* [`892944ff`](https://github.com/NixOS/nixpkgs/commit/892944ffa7bc20447f0e04ada7cdd8496a699eaf) vimPlugins.tssorter-nvim: init at 2024-08-16
* [`5c59c2a2`](https://github.com/NixOS/nixpkgs/commit/5c59c2a2cb1596e1d1df510506fb0bbd35c7b913) python312Packages.playwright: 1.46.0 -> 1.47.0
* [`fa023952`](https://github.com/NixOS/nixpkgs/commit/fa023952c69f1d152d75e28ce022d8e7519e64f5) signalbackup-tools: 20240910 -> 20240913
* [`5821bf91`](https://github.com/NixOS/nixpkgs/commit/5821bf91fffdd58a463c6af2ffcf8eab80f846e9) easyrsa: 3.2.0 -> 3.2.1
* [`064bee57`](https://github.com/NixOS/nixpkgs/commit/064bee57239a9a4c7da46f2e686d9a26e3da6d87) jacktrip: 2.3.1 -> 2.4.0
* [`4b5dd706`](https://github.com/NixOS/nixpkgs/commit/4b5dd70639f13628744b32239b37f990cf8b4eb4) codeium: 1.14.15 -> 1.16.11
* [`9bdd5a12`](https://github.com/NixOS/nixpkgs/commit/9bdd5a1298e0c2963c118f1f0714505927867f38) easyeffects: 7.1.8 -> 7.1.9
* [`12ab22bb`](https://github.com/NixOS/nixpkgs/commit/12ab22bbb28a43381570b63a0c2494059158b6c1) unbook: format with nixfmt-rfc-style
* [`3c5896e3`](https://github.com/NixOS/nixpkgs/commit/3c5896e3bffbf2d46a850586cff414a24ada76f3) unbook: 0.8.2 -> 0.9.1
* [`97e08eb0`](https://github.com/NixOS/nixpkgs/commit/97e08eb079a9d7bb33e5a815ad5e3dc8b680d74e) unbook: add git updater
* [`054b14e6`](https://github.com/NixOS/nixpkgs/commit/054b14e67631e16406ef8418f5e9488f23b94e72) ansible-lint: 24.7.0 -> 24.9.0
* [`554ec1c0`](https://github.com/NixOS/nixpkgs/commit/554ec1c0f0444d649f7e94c4ebe67e61d74a0f8f) nixos/tests: add postgresql wal2json test
* [`29a684b0`](https://github.com/NixOS/nixpkgs/commit/29a684b0a0051ff18ce0f81820a62ba5f01f9bd2) hackgregator: init at 0.5.0-unstable-2023-12-05
* [`dca4e119`](https://github.com/NixOS/nixpkgs/commit/dca4e1190697c0144edd32fe460071a112919850) osv-scanner: 1.8.4 -> 1.8.5
* [`521c3daf`](https://github.com/NixOS/nixpkgs/commit/521c3dafeec138f7bb4c244925160383441c279d) polyphone: 2.3.0 -> 2.4.0
* [`9ad9d8f6`](https://github.com/NixOS/nixpkgs/commit/9ad9d8f628df42a3557312c40719140dc8848726) libmanette: 0.2.7 -> 0.2.9
* [`f8afc980`](https://github.com/NixOS/nixpkgs/commit/f8afc980039d347679f3d93b5382d9c9c85f7be9) obs-studio-plugins.obs-text-pthread: 2.0.4 -> 2.0.5
* [`6749b1c4`](https://github.com/NixOS/nixpkgs/commit/6749b1c4bcfe88bdcfdea480ecda17a61e70ecbc) lib/tests/misc.nix: move testFix into new category FIXED-POINTS
* [`11c20cd3`](https://github.com/NixOS/nixpkgs/commit/11c20cd39099033adec0688aa44cf2f95f28b1ff) lib.toExtension: init
* [`30809cce`](https://github.com/NixOS/nixpkgs/commit/30809ccecd64b3274e029af552a6f89512c9f624) stdenv.mkDerivation: simplify overrideAttrs with extends and toOverlay
* [`2937899b`](https://github.com/NixOS/nixpkgs/commit/2937899befc968859611cb721c8fd958b65ee18f) lib.fixedPoints.toExtension: Improve type
* [`53a24f4a`](https://github.com/NixOS/nixpkgs/commit/53a24f4a7c6e39153d26d107da52392620e932a5) lib.fixedPoints.toExtension: improve documentation
* [`779b124c`](https://github.com/NixOS/nixpkgs/commit/779b124cdf94f962d80cc73ea9b22a82d0cfac3b) aerospike: 7.1.0.5 -> 7.1.0.6
* [`767fcbb7`](https://github.com/NixOS/nixpkgs/commit/767fcbb7381ae188001baea5d30586f5b3ba0ef1) cdecl: 18.3 -> 18.4.1
* [`e31ace5c`](https://github.com/NixOS/nixpkgs/commit/e31ace5cd4bd50e773604deca5939d49985d11e6) buildGoModule: use lib.toExtension
* [`016f6f9f`](https://github.com/NixOS/nixpkgs/commit/016f6f9f58b7bc9ac2e599f66a79cec4823f8b7f) dnscrypt-wrapper: remove package and NixOS modules
* [`41b5974c`](https://github.com/NixOS/nixpkgs/commit/41b5974cb2469cdfc794160e6a6c9825b07b5bd8) doc/hooks/just: add documentation
* [`3f9c2167`](https://github.com/NixOS/nixpkgs/commit/3f9c21679b7173755a546bbd5f893b2641b0afac) pcloud: 1.14.6 -> 1.14.7
* [`7478ee57`](https://github.com/NixOS/nixpkgs/commit/7478ee57973cfa7f58612cd1f57d5e2f11a48921) python312Packages.ndspy: 4.1.0 -> 4.2.0
* [`170f770b`](https://github.com/NixOS/nixpkgs/commit/170f770b03bff4df3c94acf239e46bc8e47bca78) python312Packages.pyttsx3: 2.91 -> 2.97
* [`ac1ae971`](https://github.com/NixOS/nixpkgs/commit/ac1ae97199658434938e48850635d725ac9f1b2b) cinny-unwrapped, cinny-desktop: 4.1.0 -> 4.2.1
* [`dcebfc2f`](https://github.com/NixOS/nixpkgs/commit/dcebfc2f25ce769f8ed69908d6bdb7edb8758ec7) haunt: 0.2.6 -> 0.3.0
* [`d2cf5dda`](https://github.com/NixOS/nixpkgs/commit/d2cf5dda65bbf2cdacbcf652fee527e5987d39d9) nixosTests.terminal-emulators: Disable lomiri-terminal-app colour test
* [`34fb7a52`](https://github.com/NixOS/nixpkgs/commit/34fb7a52313996cdeb15dca40a156781a70fdfd8) r2modman: switch to nix-update
* [`ca139acf`](https://github.com/NixOS/nixpkgs/commit/ca139acf0ea5c63c9cd756b35d51bcb2e5de7cc8) nixos/ly: unlock gnome-keyring on login when enabled
* [`00915de6`](https://github.com/NixOS/nixpkgs/commit/00915de65840e09a941419578d3cea4adefb6fc6) v2raya: remove mkYarnPackage usage
* [`8d3fa8f5`](https://github.com/NixOS/nixpkgs/commit/8d3fa8f5180cb26eb782396b73c59b7499e3d0e9) aiken: 1.0.29-alpha -> 1.1.2
* [`248a877d`](https://github.com/NixOS/nixpkgs/commit/248a877d1328f98a18adff36c966bfb20415fb37) r2modman: 3.1.49 -> 3.1.50
* [`074fd203`](https://github.com/NixOS/nixpkgs/commit/074fd2032c1a49a5ede6b49cacf49a5ff9c9c763) cypress: use lowercase executable
* [`1389dc96`](https://github.com/NixOS/nixpkgs/commit/1389dc968b663a1c10550e5f9955f8deb1d3cf3b) dendrite: 0.13.7 -> 0.13.8
* [`d919e8bf`](https://github.com/NixOS/nixpkgs/commit/d919e8bfe401ea8bf306e1eb3ff881c7e5e0a05f) fable: 4.19.3 -> 4.20.0
* [`091353d7`](https://github.com/NixOS/nixpkgs/commit/091353d722a14745dc3ec7ac594ceeb93b565841) circt: 1.84.0 -> 1.86.0
* [`58802a68`](https://github.com/NixOS/nixpkgs/commit/58802a68fcf2e403d83c7e6e547e19a916462844) python312Packages.django-model-utils: 4.5.1 -> 5.0.0
* [`259f670e`](https://github.com/NixOS/nixpkgs/commit/259f670ec58d5cb4fe8f248594918a724d576896) kitex: 0.11.0 -> 0.11.3
* [`e717b3f4`](https://github.com/NixOS/nixpkgs/commit/e717b3f49a786e0ea66ac10746a8d619b7ed09cc) iptsd: 2 -> 3
* [`c0111a90`](https://github.com/NixOS/nixpkgs/commit/c0111a90bbaadf53926b803e41d6dca49dff4763) kubernetes-helm: 3.15.4 -> 3.16.1
* [`c3d27bc2`](https://github.com/NixOS/nixpkgs/commit/c3d27bc28d9e5d82f86b13d890ec4a81a0f84e3f) delfin: 0.4.5 -> 0.4.6
* [`5567f3ac`](https://github.com/NixOS/nixpkgs/commit/5567f3ace542430b99023bb5363f13db1b7b3302) deviceTree.applyOverlays: rewrite in Python/libfdt
* [`cb13eac2`](https://github.com/NixOS/nixpkgs/commit/cb13eac2d061d6121947ba566543a0048440f905) python3Packages.nodriver 0.36 -> 0.37
* [`c73fab3d`](https://github.com/NixOS/nixpkgs/commit/c73fab3d8bd36ac982f509908fe56916863d9f54) dnf5: 5.2.5.0 -> 5.2.6.0
* [`500d8592`](https://github.com/NixOS/nixpkgs/commit/500d8592e3534bb681db444c2004d5a80b4b264f) nextcloud-client: 3.13.4 -> 3.14.0
* [`066125b6`](https://github.com/NixOS/nixpkgs/commit/066125b6632f0f81791a91856d3a56246eee2ccf) doc/stdenv/stdenv: document runHook function
* [`4620fbd2`](https://github.com/NixOS/nixpkgs/commit/4620fbd2d497ff0d9b9e69a6310e5da3254a1152) era: init at 0.1.3
* [`276333a8`](https://github.com/NixOS/nixpkgs/commit/276333a8d658f3f9440a0332a8cf86ef43c284ea) wavebox: 10.128.5-2 -> 10.128.7-2
* [`183a9637`](https://github.com/NixOS/nixpkgs/commit/183a96374e9df0f38ed5a4d5931dcbfea6c29112) teams-for-linux: 1.9.6 -> 1.10.2
* [`5abd5977`](https://github.com/NixOS/nixpkgs/commit/5abd5977243abca519f1abc6a1f598011bf632bc) python312Packages.datafusion: 38.0.1 -> 40.1.0
* [`684c0e50`](https://github.com/NixOS/nixpkgs/commit/684c0e50607a1180b828a193bb1bfee5248ba0ee) pdf-parser: add updateScript
* [`f23cdfed`](https://github.com/NixOS/nixpkgs/commit/f23cdfedfa6ce783fa97edfa88f63bb49e4a8cb3) pdf-parser: 0.7.4 -> 0.7.9
* [`4af71f27`](https://github.com/NixOS/nixpkgs/commit/4af71f27b60894d6408c8f3dde01803e59ca6a0f) python312Packages.django-appconf: 1.0.5 -> 1.0.6
* [`fc384517`](https://github.com/NixOS/nixpkgs/commit/fc384517f18073666e8fb70c86c84a188e1b4512) python312Packages.django-celery-beat: 2.6.0 -> 2.7.0
* [`ddafd4b1`](https://github.com/NixOS/nixpkgs/commit/ddafd4b14a91dc510524247fd266f85cdb740d1a) llvmPackages: Reinstate overriding across whole package set
* [`8c1b12f8`](https://github.com/NixOS/nixpkgs/commit/8c1b12f8b7025d4cff4eca9e308870ad74c06266) libcdr: enable parallel building
* [`114ae8cd`](https://github.com/NixOS/nixpkgs/commit/114ae8cd1b3f362d042d8c32d921fccb9f0062ac) libvisio: enable parallel building
* [`d1bad83b`](https://github.com/NixOS/nixpkgs/commit/d1bad83b436c9a0a97d115ddeddf93d9cf5001b7) rocketchat-desktop: 4.0.2 -> 4.1.0
* [`cf71c1df`](https://github.com/NixOS/nixpkgs/commit/cf71c1dfcdee7ef0fa9f150cc556e6d4e3f1f3fa) linux_xanmod: 6.6.50 -> 6.6.51
* [`14dec03c`](https://github.com/NixOS/nixpkgs/commit/14dec03c8760e74f220b5f1a4fcc88b64a7e63ae) linux_xanmod_latest: 6.10.9 -> 6.10.10
* [`290ec4e7`](https://github.com/NixOS/nixpkgs/commit/290ec4e775b7ebb6ff2a882ef0b836171a761bc3) llvmPackages.*: Add devExtraCmakeFlags parameter
* [`b993f628`](https://github.com/NixOS/nixpkgs/commit/b993f628a8ff54abf1f339ac8fdce33577d3238d) handheld-daemon: 3.3.12 -> 3.3.15
* [`b92e287f`](https://github.com/NixOS/nixpkgs/commit/b92e287f3943e6a4aa1459c8eeaad14e0f95eef9) python311Packages.llama-index-vector-stores-postgres: 0.2.2 -> 0.2.5
* [`726668fb`](https://github.com/NixOS/nixpkgs/commit/726668fb7a6d57ed9fd4a9971833c000abd1d030) python311Packages.llama-index-graph-stores-neo4j: 0.3.1 -> 0.3.2
* [`129e7b2f`](https://github.com/NixOS/nixpkgs/commit/129e7b2f93ec65c37e03d82930237846880b110c) python311Packages.llama-index-indices-managed-llama-cloud: 0.3.0 -> 0.3.1
* [`284899bc`](https://github.com/NixOS/nixpkgs/commit/284899bc1e5214c9dee0601229b2cc9262d53de4) python311Packages.llama-index-embeddings-ollama: 0.3.0 -> 0.3.1
* [`4948c577`](https://github.com/NixOS/nixpkgs/commit/4948c5778d0b9a0b51d5194b3f86eb0b7b190229) python311Packages.llama-index-embeddings-openai: 0.2.4 -> 0.2.5
* [`fabf9da6`](https://github.com/NixOS/nixpkgs/commit/fabf9da67096f6111feeb3f79cac83564e4dfecb) python311Packages.llama-index-llms-ollama: 0.3.1 -> 0.3.2
* [`c295aba0`](https://github.com/NixOS/nixpkgs/commit/c295aba037f75e103689d5561992fd3bdba04397) python311Packages.llama-index-llms-openai: 0.2.3 -> 0.2.7
* [`672b82d3`](https://github.com/NixOS/nixpkgs/commit/672b82d38b803dde115e1f095d81ab703770f70e) python311Packages.llama-index-multi-modal-llms-openai: 0.2.0 -> 0.2.1
* [`e74dff45`](https://github.com/NixOS/nixpkgs/commit/e74dff45e1d2504f8e79c6d9caff76f5e2f0ea75) python311Packages.llama-parse: 0.5.3 -> 0.5.5
* [`cb6ec7a2`](https://github.com/NixOS/nixpkgs/commit/cb6ec7a2a03a3c04071c631ba2aa1ab74f95f074) python311Packages.llama-index-core: 0.11.8 -> 0.11.9
* [`17d63d3a`](https://github.com/NixOS/nixpkgs/commit/17d63d3a3726e42110c9f72a23feb82f859ffd1b) python312Packages.opower: 0.7.0 -> 0.8.0
* [`bec7b80e`](https://github.com/NixOS/nixpkgs/commit/bec7b80e56095ada44ff27a87258e96aaba830ba) python312Packages.publicsuffixlist: 1.0.2.20240913 -> 1.0.2.20240915
* [`38b17d67`](https://github.com/NixOS/nixpkgs/commit/38b17d6753e8d9fe51b903635a8406736cdba177) python312Packages.pyexploitdb: 0.2.34 -> 0.2.35
* [`2da68035`](https://github.com/NixOS/nixpkgs/commit/2da68035ff2cb894a6c98afc2e5cd0d596edf783) gosec: 2.21.1 -> 2.21.2
* [`8b5f6df8`](https://github.com/NixOS/nixpkgs/commit/8b5f6df8605afbe903dfa0e776bb19076f6e1fa6) vyper: drop useless pytest-runner
* [`3bb5ba4b`](https://github.com/NixOS/nixpkgs/commit/3bb5ba4b34ce56b404ce950985e85d25696723d9) python312Packages.hikari: drop useless pytest-runner, use pytest-cov-sub
* [`fb9a787b`](https://github.com/NixOS/nixpkgs/commit/fb9a787bc2eef3b63550b53147ab6762de4a2798) python312Packages.pytest-harvest: drop useless pytest-runner, remove distutils usage
* [`6cd83646`](https://github.com/NixOS/nixpkgs/commit/6cd8364602515754488ba81cbb94b1d69c8d0b7c) python312Packages.tf2onnx: remove useless pytest-runner
* [`b9d46514`](https://github.com/NixOS/nixpkgs/commit/b9d465144a8e6637c0057162dfdff9309a3ad2cb) nsc: 2.8.8 -> 2.8.9
* [`31dc862e`](https://github.com/NixOS/nixpkgs/commit/31dc862eb0fc327d592fc93aa255b9b550caf8e2) python312Packages.catppuccin: 2.3.1 -> 2.3.4
* [`61fcdd9c`](https://github.com/NixOS/nixpkgs/commit/61fcdd9ca1607e4b47cd3ed77e84e00c60a709c5) hugo: 0.134.0 -> 0.134.2
* [`768db400`](https://github.com/NixOS/nixpkgs/commit/768db4009ed0a6744304dbd44de90c20ad3409ca) nixos: remove environment.noXlibs
* [`07b4ece5`](https://github.com/NixOS/nixpkgs/commit/07b4ece5c88c5cd45533a57c83c5fe8ad600a5ce) devpod: 0.5.19 -> 0.5.20
* [`8f175c4b`](https://github.com/NixOS/nixpkgs/commit/8f175c4bf3827a7b10fbb023ce2d926bfcd7bf9b) google-cloud-sdk: 485.0.0 -> 492.0.0
* [`35e48f01`](https://github.com/NixOS/nixpkgs/commit/35e48f01ead0f6a68905b0b9be60ae60d94e79eb) netbird: 0.29.0 -> 0.29.2
* [`c607f9fb`](https://github.com/NixOS/nixpkgs/commit/c607f9fbcc7952a6dd0e92d6d470aa4647425e19) musescore: Switch to the more minimalist wrapGAppsNoGuiHook
* [`78c9f7a8`](https://github.com/NixOS/nixpkgs/commit/78c9f7a866c3a647ef017a03a7f6145104053764) python312Packages.pick: 2.3.2 -> 2.4.0
* [`2608b399`](https://github.com/NixOS/nixpkgs/commit/2608b3990cc7280eccff2be50d9fab9a05d4d8bb) onlyoffice-documentserver: enable aarch64-linux support
* [`de18194d`](https://github.com/NixOS/nixpkgs/commit/de18194d1ec5abd5f1186da885200ebbfabc998a) beets: make the autobpm plugin depend on librosa
* [`90aee059`](https://github.com/NixOS/nixpkgs/commit/90aee059a22a7e003147f13adb4fa9bf596c4108) sn0int: 0.26.0 -> 0.26.1
* [`90914ee7`](https://github.com/NixOS/nixpkgs/commit/90914ee74f4fa0faf7b13adf063497d019c037cb) qpdfview: fix build
* [`1f01aa70`](https://github.com/NixOS/nixpkgs/commit/1f01aa701c01636b1e29c32342cb25f88a266820) python312Packages.pynmeagps: 1.0.39 -> 1.0.41
* [`34ca65ef`](https://github.com/NixOS/nixpkgs/commit/34ca65ef1d859d771d7b0a2a41be7d6d761c077d) termsonic: 0-unstable-2024-02-02 -> 0-unstable-2024-09-15
* [`16923867`](https://github.com/NixOS/nixpkgs/commit/16923867291060d6aeeb6b65e616845817c73859) waylock: 1.1.0 -> 1.2.1
* [`b21aa656`](https://github.com/NixOS/nixpkgs/commit/b21aa65653f771d614bf79c510c674d203f49ae8) sus-compiler: init at 0.0.2
* [`44a20134`](https://github.com/NixOS/nixpkgs/commit/44a2013436290f6ac442f07c76111402748d7a98) vulkan-caps-viewer: 3.41 -> 3.42
* [`7e7813b8`](https://github.com/NixOS/nixpkgs/commit/7e7813b835a6502977b8ed2449674f51077e1fa8) python312Packages.plugwise: 1.3.1 -> 1.4.0
* [`823ad293`](https://github.com/NixOS/nixpkgs/commit/823ad293421c2944fd3de2a1e448f1a6a2a3e687) python312Packages.django-modeltranslation: 0.19.8 -> 0.19.9
* [`986eb22a`](https://github.com/NixOS/nixpkgs/commit/986eb22a8ab683c5da7bd4c27f1debf0818abf67) silverbullet: 0.9.2 -> 0.9.4
* [`7d430f6a`](https://github.com/NixOS/nixpkgs/commit/7d430f6ae78e85d554bab7fa49750c67422b3f5b) maintainers: add ttrei
* [`52175e64`](https://github.com/NixOS/nixpkgs/commit/52175e6441a404d8783c1b04e436a5660ecfdde5) pachyderm: 2.11.1 -> 2.11.2
* [`a6a8bdf0`](https://github.com/NixOS/nixpkgs/commit/a6a8bdf09c1eb14b25a9b1efb8c67e30a2a07200) nfs-utils: optional LDAP support
* [`17f88666`](https://github.com/NixOS/nixpkgs/commit/17f8866661943b04d0ee68d234cba6f15da7cd97) screenly-cli: 1.0.0 -> 1.0.1
* [`202c06da`](https://github.com/NixOS/nixpkgs/commit/202c06daedf31d088f556ce3e6e8cfb5047b753c) maintainers: add interdependence
* [`acff7907`](https://github.com/NixOS/nixpkgs/commit/acff7907ed35a1aa418f3a849544e894b5dd1b72) SDL1: fix building for musl with GCC 14
* [`13240037`](https://github.com/NixOS/nixpkgs/commit/132400377c8b6bea76f649ee26aac2f35d703e40) fantomas: 6.3.13 -> 6.3.15
* [`1acbc708`](https://github.com/NixOS/nixpkgs/commit/1acbc708787e8dbc2c1a4421c7b90c57059d6a7b) scrcpy: 2.6.1 -> 2.7
* [`f5cb564f`](https://github.com/NixOS/nixpkgs/commit/f5cb564fa13253d24b993f2556bdc44ce27736b7) gimp: add libxslt for rebuilding menus XML files
* [`496c416b`](https://github.com/NixOS/nixpkgs/commit/496c416b6650b4d2b66df245361d40fe30689ef6) gimp: Fix AVIF/HEIC support
* [`8605bedf`](https://github.com/NixOS/nixpkgs/commit/8605bedf8684fe74b82ca2a98dca1b6672576025) maintainers: add arrnphm
* [`7830f27e`](https://github.com/NixOS/nixpkgs/commit/7830f27e1f22db771606993ca7dbc259d1ba9c3a) python312Packages.expecttest: 0.1.4 → 0.2.1
* [`678de7fd`](https://github.com/NixOS/nixpkgs/commit/678de7fd6a35904429ee8c511a2f7f2b218d0add) python312Packages.python-bidi: add missing dependency libiconv to fix darwin build
* [`6afd91d6`](https://github.com/NixOS/nixpkgs/commit/6afd91d69de42349b86e326f358a8686d6219bd4) aws-encryption-sdk-cli: 4.1.0 -> 4.2.0
* [`49ba09a9`](https://github.com/NixOS/nixpkgs/commit/49ba09a9276d0fa34a388067d0421af9b3d064ff) micronaut: 4.6.1 -> 4.6.2
* [`df27c10b`](https://github.com/NixOS/nixpkgs/commit/df27c10bc7e4cbc4d53b29ed3bc0568330694c7f) tere: 1.5.1-unstable-2024-04-01 -> v1.6.0
* [`1521f967`](https://github.com/NixOS/nixpkgs/commit/1521f967829e0ae11e63750bd8c0671f0385ee07) rcu: 2024.001p -> 2024.001q
* [`ea61eda1`](https://github.com/NixOS/nixpkgs/commit/ea61eda12fd99227347c7c58258bb20c2fa4ce0f) rectangle: 0.82 -> 0.83
* [`39e923ed`](https://github.com/NixOS/nixpkgs/commit/39e923ed0bc0084ae0e2e22cb7a9e4ffa1963ac1) coder: 2.14.2 -> 2.14.3
* [`0586b3d4`](https://github.com/NixOS/nixpkgs/commit/0586b3d42408529f1a86305f9edc8bb3bce19499) qownnotes: 24.9.1 -> 24.9.6
* [`47d79939`](https://github.com/NixOS/nixpkgs/commit/47d79939962694aabe0c178751a0bd490f639a44) yamlscript: 0.1.74 -> 0.1.75
* [`23387d86`](https://github.com/NixOS/nixpkgs/commit/23387d86b905d1d990167f774fc7c25b7ac951cf) python312Packages.psycopg: 3.2.1 -> 3.2.2
* [`445c2764`](https://github.com/NixOS/nixpkgs/commit/445c2764867ba413cb2ad9650c752b647a8e8a79) altair: 7.3.5 -> 7.3.6
* [`0592e2c9`](https://github.com/NixOS/nixpkgs/commit/0592e2c9ad10433d908639e9c8f7bedaeb4bc0f9) nzbhydra2: 7.5.0 -> 7.6.0
* [`13cdb077`](https://github.com/NixOS/nixpkgs/commit/13cdb0775b87afce1a70d95f75200cb1cdac2751) emacsPackages.eglot: only build info manual when needed
* [`93424a6c`](https://github.com/NixOS/nixpkgs/commit/93424a6ca57b33f118a9f46f3ec6683f4f998c34) emacs.pkgs.gn-mode-from-sources: init
* [`18a45a61`](https://github.com/NixOS/nixpkgs/commit/18a45a613d89f993a355fe4f7f58323e2e6603d1) mubeng: 0.17.0 -> 0.18.0
* [`b247b043`](https://github.com/NixOS/nixpkgs/commit/b247b04351921e86bda3f30a4edfd6859a78cab7) mediamtx: 1.9.0 -> 1.9.1
* [`18754779`](https://github.com/NixOS/nixpkgs/commit/18754779c8c1fe1537c4fc86bdb37b8d34f5796e) python312Packages.command-runner: 1.6.0 -> 1.7.0
* [`e3a1d7b5`](https://github.com/NixOS/nixpkgs/commit/e3a1d7b51d70edd2805d6f96d03cb56a12b874c1) quick-lookup: init at 2.1.1
* [`4d0986e5`](https://github.com/NixOS/nixpkgs/commit/4d0986e5ffa56ec4705db6d9aa4509dbaec32d4a) hydra: add unstableGitUpdater
* [`f5507819`](https://github.com/NixOS/nixpkgs/commit/f5507819243685adf72372b37d7e37bb032bc85b) hydra: 0-unstable-2024-08-27 -> 0-unstable-2024-09-15
* [`f15b9956`](https://github.com/NixOS/nixpkgs/commit/f15b995651e06bdc2730368856659dabdeee6ae7) spacectl: 1.0.1 -> 1.5.0
* [`d0b62bda`](https://github.com/NixOS/nixpkgs/commit/d0b62bdafb2488801d169c1156f493faa8fc0aff) python312Packages.tesla-fleet-api: 0.7.4 -> 0.7.5
* [`fe05a75a`](https://github.com/NixOS/nixpkgs/commit/fe05a75ac72863863a1de9fe9ed35126bd92ddb5) nu_scripts: 0-unstable-2024-08-30 -> 0-unstable-2024-09-11
* [`a780c7a1`](https://github.com/NixOS/nixpkgs/commit/a780c7a12287934bfeeb24811b69d45fe08ca8d6) nb-cli: 1.4.1 -> 1.4.2
* [`1eff8639`](https://github.com/NixOS/nixpkgs/commit/1eff86395c900dd17a5899a3eb325b81d9744f98) thunderbird-bin-unwrapped: 128.1.0esr -> 128.2.0esr
* [`67c15305`](https://github.com/NixOS/nixpkgs/commit/67c153055962db5808c447f1ddaa37d0160ab178) libvmi: 0.14.0-unstable-2024-08-06 -> 0.14.0-unstable-2024-09-04
* [`8edd2ff6`](https://github.com/NixOS/nixpkgs/commit/8edd2ff640aed11f69fbe267498487158c6038d9) bant: 0.1.6 -> 0.1.7
* [`467e802f`](https://github.com/NixOS/nixpkgs/commit/467e802f223b7d13d12c9a7ae3495eef8a31b11a) python312Packages.pyhanko: mark as broken on darwin
* [`1a26606a`](https://github.com/NixOS/nixpkgs/commit/1a26606a23ca152309d689f77b2c45c47678e37a) python312Packages.pyhanko: minor cleaning
* [`f7ea4548`](https://github.com/NixOS/nixpkgs/commit/f7ea454899506cb9f8fe432c80edc41669aa7354) mupdf: mark as broken when using python
* [`1cdbe4dd`](https://github.com/NixOS/nixpkgs/commit/1cdbe4dd988324faf63fb3625880abd2b53ec7d7) python312Packages.pdfplumber: 0.11.1 -> 0.11.4
* [`9cc1be68`](https://github.com/NixOS/nixpkgs/commit/9cc1be682a445f40cc28d7746b3e36beba5ada1c) maa-assistant-arknights: 5.5.11452 -> 5.6.1
* [`8a23ff48`](https://github.com/NixOS/nixpkgs/commit/8a23ff488f1abbc88a940a82a0faa91d1fb01c60) ceph-csi: 3.12.1 -> 3.12.2
* [`a37bd24e`](https://github.com/NixOS/nixpkgs/commit/a37bd24e4450158db255e91e3f644f4d986b893a) coin3d: fix hash 4.0.3
* [`c9a24933`](https://github.com/NixOS/nixpkgs/commit/c9a24933acf7df12208de23d036b3f86ae5edaa3) fcitx5-pinyin-moegirl: 20240809 -> 20240909
* [`ed902352`](https://github.com/NixOS/nixpkgs/commit/ed9023524d014a71102203a139b4aa47da5a4fc9) rtorrent: 0.9.8-unstable-2024-08-31 -> 0.9.8-unstable-2024-09-07
* [`0dd1d6c7`](https://github.com/NixOS/nixpkgs/commit/0dd1d6c79bd41fdecb2c5b69ea78bc7dcd833988) fcitx5-pinyin-zhwiki: 20240509 -> 20240909
* [`aee7fc23`](https://github.com/NixOS/nixpkgs/commit/aee7fc23795ae796a43224109828781cc2b722a1) smbmap: 1.10.4 -> 1.10.5
* [`c6ab3b3a`](https://github.com/NixOS/nixpkgs/commit/c6ab3b3ae800e0aed84301a4e825c0ea73698e9a) llm-ls: fix build with rust 1.80 and on darwin
* [`71b1f2d9`](https://github.com/NixOS/nixpkgs/commit/71b1f2d98dcd732df2832da97d86015eeebfd016) coqPackages.mtac2: init at 1.4-coq8.19
* [`26e9f443`](https://github.com/NixOS/nixpkgs/commit/26e9f44340cb52473e1f02edc4d7d02fdfb7d4cd) mubeng: refactor
* [`68784b40`](https://github.com/NixOS/nixpkgs/commit/68784b40efddab24a7119776ad85ade7c6fccf31) warzone2100: 4.5.2 -> 4.5.3
* [`3d75de3f`](https://github.com/NixOS/nixpkgs/commit/3d75de3f2582e3fcb7ac050a038cb542da7c1dbd) cargo-nextest: 0.9.77 -> 0.9.78
* [`a7510257`](https://github.com/NixOS/nixpkgs/commit/a751025715dbeab372cdbbfb9d19f6d261ed957a) maintainers: update SomeoneSerge
* [`ae1991a9`](https://github.com/NixOS/nixpkgs/commit/ae1991a95b25269a8cee13ff5785b7a10501075d) blackmagic-desktop-video: use `gcc`, not `gcc7`
* [`01c2deb2`](https://github.com/NixOS/nixpkgs/commit/01c2deb27bfefc4dd01451f4f7c6d3b0e0ba5971) protoc-gen-connect-es: 1.4.0 -> 1.5.0
* [`1d3e242f`](https://github.com/NixOS/nixpkgs/commit/1d3e242fc8d3d04b4fa85b448fc41667df06c4b9) musescore: 4.4.1 -> 4.4.2
* [`be9c2734`](https://github.com/NixOS/nixpkgs/commit/be9c27343cab29e82806e10380e010ed2b790452) emacsPackages.lsp-bridge: 0-unstable-2024-09-05 -> 0-unstable-2024-09-11
* [`97f0874c`](https://github.com/NixOS/nixpkgs/commit/97f0874c1f0278a864d32ec7972abe439d949abf) sentry-cli: 2.35.0 -> 2.36.1
* [`2f227e4f`](https://github.com/NixOS/nixpkgs/commit/2f227e4ff5f7ebd5223952c611492f9ace76bf7e) vimPlugins.avante-nvim: Init at 2024-09-15
* [`577fe7c8`](https://github.com/NixOS/nixpkgs/commit/577fe7c8939d2c04ed879a29120535a871414e29) checkov: 3.2.253 -> 3.2.254
* [`418ba673`](https://github.com/NixOS/nixpkgs/commit/418ba6732619211f09a0158347861db5a1f5e5ac) qgis: 3.38.2 -> 3.38.3
* [`02d0336f`](https://github.com/NixOS/nixpkgs/commit/02d0336f35c5e76275b3516293a80d876b0f550d) python312Packages.tencentcloud-sdk-python: 3.0.1231 -> 3.0.1232
* [`85c1a1f3`](https://github.com/NixOS/nixpkgs/commit/85c1a1f3abad88a31caf9df40b73d98f09bfb2f5) maintainers: add rennsax
* [`dfc771e0`](https://github.com/NixOS/nixpkgs/commit/dfc771e0b2c5cb64441b954952e0cb5fb5f74717) qgis: drop redundant CMAKE_BUILD_TYPE setting
* [`69b6ec08`](https://github.com/NixOS/nixpkgs/commit/69b6ec0894d056627a8e074178d39b5e917477d3) waybar: 0.10.4 -> 0.11.0
* [`06c5b53c`](https://github.com/NixOS/nixpkgs/commit/06c5b53ca56092bc65c2f6f30e31c8eeb87cbb7e) gpt4all-cuda: fix CUDA initialization
* [`b39d88e6`](https://github.com/NixOS/nixpkgs/commit/b39d88e69d43eb4b146765bbc52354c16c7ae413) frr: 10.0.1 -> 10.1
* [`120a0059`](https://github.com/NixOS/nixpkgs/commit/120a0059f1d6fa92e42cb2b9bacd7f809c573b44) python312Packages.aiostreammagic: 2.3.0 -> 2.3.1
* [`8facd833`](https://github.com/NixOS/nixpkgs/commit/8facd83341f5e8aab9b29f254a13fbe0eeda8308) python312Packages.weatherflow4py: 1.0.4 -> 1.0.6
* [`e32ed381`](https://github.com/NixOS/nixpkgs/commit/e32ed381ecf07fac29d2d89aa59755ffc6c33f4c) uwsm: 0.18.2 -> 0.19.0
* [`e21aecdc`](https://github.com/NixOS/nixpkgs/commit/e21aecdc354b406d6de6428badbfff98414dad63) qgis-ltr: 3.34.10 -> 3.34.11
* [`5c771e30`](https://github.com/NixOS/nixpkgs/commit/5c771e30e33e2fd9fc4ca035ed389976dbf63e4e) qgis-ltr: drop redundant CMAKE_BUILD_TYPE setting
* [`04e88717`](https://github.com/NixOS/nixpkgs/commit/04e88717732460acb7ef1cce758b8a63f0cce3ec) uwsm: pass python-bin meson option
* [`7784c973`](https://github.com/NixOS/nixpkgs/commit/7784c973e614ef6c5e101486e703b6c396fa05ce) lowdown: patch to fix macOS and UTF-8 bugs
* [`b3cc247b`](https://github.com/NixOS/nixpkgs/commit/b3cc247b6f70de000c188eb656480e2af46722ec) python312Packages.policy-sentry: 0.12.12 -> 0.13.1
* [`6d93973f`](https://github.com/NixOS/nixpkgs/commit/6d93973f2a80d98f92a4a028beea69934624104d) python312Packages.cloudsplaining: 0.6.3 -> 0.7.0
* [`8d123c1f`](https://github.com/NixOS/nixpkgs/commit/8d123c1f2232ba8aa40ec0c44e008e45c1dce6b1) python312Packages.cloudsplaining: update disabled
* [`0d683ad8`](https://github.com/NixOS/nixpkgs/commit/0d683ad8790d8ad37275054a25e7e14ddded7144) duplicity: drop useless pytest-runner, run pytest explicitly trough pytestCheckHook
* [`20f77642`](https://github.com/NixOS/nixpkgs/commit/20f7764221304edf05fdafad375c80c723ea547f) udocker: remove useless pytest-runner
* [`cbd46bcb`](https://github.com/NixOS/nixpkgs/commit/cbd46bcbc2896dfe15d86ae058c3cc37b4cfdaf3) terminator: drop useless pytest-runner
* [`12b31a74`](https://github.com/NixOS/nixpkgs/commit/12b31a7434ba00e1b6db78aa5d503232be646452) cpplint: drop useless pytest-runner
* [`39374875`](https://github.com/NixOS/nixpkgs/commit/39374875a0814c725f1e442520ec87791399c770) python312Packages.pytest-runner: drop
* [`83cdec2e`](https://github.com/NixOS/nixpkgs/commit/83cdec2e165cc20610f5fae569bd499a002c5175) nixos/tests/frr: fix ping command
* [`5aed162d`](https://github.com/NixOS/nixpkgs/commit/5aed162d67bccdf1cb1d31c69d21f4cfec249799) python312Packages.pytorch-pfn-extras: 0.7.6 -> 0.7.7
* [`44c96683`](https://github.com/NixOS/nixpkgs/commit/44c966831ea8d3571295587fdca708dec0d46d32) python312Packages.ffcv: mark as broken on darwin
* [`f388ebdb`](https://github.com/NixOS/nixpkgs/commit/f388ebdb19c6e0dda3e2860d76addda00a791bf4) framework-laptop-kmod: 0-unstable-2024-01-02 -> 0-unstable-2024-09-15
* [`3f9ddaae`](https://github.com/NixOS/nixpkgs/commit/3f9ddaae3e407874f9ef028fd7924275962b62a3) meshcentral: 1.1.29 -> 1.1.30
* [`026662eb`](https://github.com/NixOS/nixpkgs/commit/026662eb8e2f721082fd07c4f51c8cf2e9d64752) muse-sounds-manager: init at 1.1.0.587
* [`366e1bf1`](https://github.com/NixOS/nixpkgs/commit/366e1bf1dce07a8bc291e7a8979b1df829abeaf0) checkov: relax cloudsplaining
* [`6078e0e1`](https://github.com/NixOS/nixpkgs/commit/6078e0e1cb65ab044d0b2b9e955a3e3f7fe39912) imgui: add pkgsCross.mingwW64 support
* [`a9269351`](https://github.com/NixOS/nixpkgs/commit/a92693519fd4da631334ea7eb7029ac74f4c136d) onedrivegui: 1.1.0rc3 -> 1.1.0
* [`e1b20bea`](https://github.com/NixOS/nixpkgs/commit/e1b20bea893044ea22241024e0662bd75e0540a4) libcdio-paranoia: 10.2+2.0.1 -> 10.2+2.0.2
* [`840e9ca1`](https://github.com/NixOS/nixpkgs/commit/840e9ca127fe6f6ef70a30d98772ea9603049175) fscryptctl: replace rec with finalAttrs
* [`f78e6b88`](https://github.com/NixOS/nixpkgs/commit/f78e6b8839bc908849a385ed05a8ed536194ab85) nautilus-open-any-terminal: add required config from project README so module functions intuitively
* [`d8f97305`](https://github.com/NixOS/nixpkgs/commit/d8f973058ba5d4adc5053b78d5c6de089279ee5c) build(deps): bump peter-evans/create-pull-request from 7.0.1 to 7.0.3
* [`8d742758`](https://github.com/NixOS/nixpkgs/commit/8d742758de79717be57b6049bc4087e6f94cb8d8) symmetrica: compile for c99
* [`00a082f9`](https://github.com/NixOS/nixpkgs/commit/00a082f90932fcc73f9a4b5195c93d58443f0548) musescore: fix crash accessing uninitialized properties
* [`960b838a`](https://github.com/NixOS/nixpkgs/commit/960b838a5f114e252546bdc20171b4a4ca7c1d35) CONTRIBUTING: offer clearer guidelines about blocker vs. non-blocker issues ([nixos/nixpkgs⁠#264651](https://togithub.com/nixos/nixpkgs/issues/264651))
* [`53eac0b4`](https://github.com/NixOS/nixpkgs/commit/53eac0b4de531381f7ae119ae61689b4e94e71bf) nixos/buildbot: fix usage of escapeStr
* [`cf0de14f`](https://github.com/NixOS/nixpkgs/commit/cf0de14f590ef351751177d33df775b797ef0547) onedrive: 2.5.0-rc3 -> 2.5.0
* [`ed4a1c24`](https://github.com/NixOS/nixpkgs/commit/ed4a1c2451deb8199317803d6668d575d0513681) cassandra: try using python311 packages to fix failing tests
* [`8e572a79`](https://github.com/NixOS/nixpkgs/commit/8e572a79583e9d1c2099a4c46963ec51b78389ca) gtk4-layer-shell: add `wayland-protocols` as a dependency to fix segfault
* [`5ec7e325`](https://github.com/NixOS/nixpkgs/commit/5ec7e325fbcb1aa6fbaaf226129a2c2694224822) hdr10plus_tool: 1.6.0 -> 1.6.1
* [`a015ebb4`](https://github.com/NixOS/nixpkgs/commit/a015ebb48b86f3a9b4103eeb9787cb8918c30ffe) minetest: 5.9.0 -> 5.9.1 ([nixos/nixpkgs⁠#342183](https://togithub.com/nixos/nixpkgs/issues/342183))
* [`95bccd3a`](https://github.com/NixOS/nixpkgs/commit/95bccd3af30b43b37789f698553fe74faf64353c) warp-terminal: 0.2024.09.03.08.02.stable_03 -> 0.2024.09.10.08.02.stable_01
* [`5805b962`](https://github.com/NixOS/nixpkgs/commit/5805b9622549c1c6cd47e2f72d68a822274b5c37) gruvbox-gtk-theme: 0-unstable-2024-07-22 -> 0-unstable-2024-09-12
* [`bcc99eb1`](https://github.com/NixOS/nixpkgs/commit/bcc99eb1974db40f4f2662cfae76f04de7d8c55c) dotnet: 9.0.0-preview.7 -> 9.0.0-rc.1
* [`89217d3c`](https://github.com/NixOS/nixpkgs/commit/89217d3cf56ef1297bddd8861e7978693d263c27) undocker: 1.2.2 -> 1.2.3 ([nixos/nixpkgs⁠#341364](https://togithub.com/nixos/nixpkgs/issues/341364))
* [`75d3a0f1`](https://github.com/NixOS/nixpkgs/commit/75d3a0f1ff492c5e76da1d50d455ab1c53fe70e5) syn2mas: 0.10.0 -> 0.12.0
* [`f6982dc3`](https://github.com/NixOS/nixpkgs/commit/f6982dc31ca295fd659d2cfa6e987ffa694476a4) metacubexd: 1.147.0 -> 1.149.0
* [`24677dd2`](https://github.com/NixOS/nixpkgs/commit/24677dd25788e8c56a33e6b93180fb94654428a2) matrix-authentication-service: 0.10.0 -> 0.12.0
* [`16f21778`](https://github.com/NixOS/nixpkgs/commit/16f21778c9fea9f331000bdb5af28a8c2638a8f9) python312Packages.textual: 0.72.0 -> 0.79.0
* [`cbdb699d`](https://github.com/NixOS/nixpkgs/commit/cbdb699d7a1e7425168a7e97193d79639f260bc7) python312Packages.graphrag: 0.3.2 -> 0.3.3
* [`fe677565`](https://github.com/NixOS/nixpkgs/commit/fe67756521268220f0801d05c376010af3ff86e4) power-profiles-daemon: update homepage url
* [`e60dfa04`](https://github.com/NixOS/nixpkgs/commit/e60dfa04148a5d5a5fcc93c3ec573d019546522e) rsshub: 0-unstable-2024-07-08 -> 0-unstable-2024-09-16
* [`761b04f5`](https://github.com/NixOS/nixpkgs/commit/761b04f506348243b3c57bfdb77c1cc9705d112a) element-desktop: 1.11.76 -> 1.11.77
* [`5dcc1253`](https://github.com/NixOS/nixpkgs/commit/5dcc1253d4b39247ea2560c46de8659f3f06cf32) libsForQt5.qwt: 6.2.0 -> 6.3.0
* [`cf893a47`](https://github.com/NixOS/nixpkgs/commit/cf893a47d2ae3d2702631353b511101d62a3a292) gplates: fix build with qwt 6.3
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
