### PR TITLE
niv home-manager: update a9c9cc6e -> 21c02186

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -41,10 +41,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a9c9cc6e50f7cbd2d58ccb1cd46a1e06e9e445ff",
-        "sha256": "1cxp9rgczr4rhhx1klwcr7a61khizq8hv63gvmy9gfsx7fp4h60a",
+        "rev": "21c021862fa696c8199934e2153214ab57150cb6",
+        "sha256": "1ihdc17198yzjprvs8mbqgrp7ya261n870vvzd1nng8k38ayz0hi",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/a9c9cc6e50f7cbd2d58ccb1cd46a1e06e9e445ff.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/21c021862fa696c8199934e2153214ab57150cb6.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@a9c9cc6e...21c02186](https://github.com/nix-community/home-manager/compare/a9c9cc6e50f7cbd2d58ccb1cd46a1e06e9e445ff...21c021862fa696c8199934e2153214ab57150cb6)

* [`4a4a8b14`](https://github.com/nix-community/home-manager/commit/4a4a8b145463ccfef579bb0e26275c97bf0b5bf2) firefox: fix languagepacks policy
* [`4974dfb2`](https://github.com/nix-community/home-manager/commit/4974dfb26e1c84d22bfdf943d41a33c9e51209a8) thunderbird: change settings type to json
* [`d2493de5`](https://github.com/nix-community/home-manager/commit/d2493de5cd1da06b6a4c3e97f4e7d5dd791df457) ci: remove 23.11 from dependabot
* [`75781766`](https://github.com/nix-community/home-manager/commit/7578176649a08abb73dfbd2755a5988766952b53) flake.lock: Update
* [`b6204ff4`](https://github.com/nix-community/home-manager/commit/b6204ff489af6391eeb9feb43978fa3b81ac5d18) xscreensaver: fix type of systemd Service.Environment
* [`1d8296c4`](https://github.com/nix-community/home-manager/commit/1d8296c46f3b688bcdf7f68ba7cf92fa6203c192) flameshot: fix type of systemd Service.Environment
* [`ffc3a473`](https://github.com/nix-community/home-manager/commit/ffc3a473e62da754222a816ffe986b7fd0902da2) xembed-sni-proxy: fix type of systemd Service.Environment
* [`10fd27c2`](https://github.com/nix-community/home-manager/commit/10fd27c291479bb71e5debf40c28192bb14e978b) kdeconnect: fix type of systemd Service.Environment
* [`80092fae`](https://github.com/nix-community/home-manager/commit/80092fae03d42f41952ae9227b193674da22596e) mpd: fix type of systemd Service.Environment
* [`336c792b`](https://github.com/nix-community/home-manager/commit/336c792b1936cd228de505c1c239e90422dfba74) rsibreak: fix type of systemd Service.Environment
* [`397750d2`](https://github.com/nix-community/home-manager/commit/397750d269041f071bad5abffdfed7329e7e0166) xsettings: fix type of systemd Service.Environment
* [`cacf2d27`](https://github.com/nix-community/home-manager/commit/cacf2d27f6cd45ecc78a6a25404d4ed1ec8dd97d) kbfs: fix type of systemd Service.Environment
* [`3670a035`](https://github.com/nix-community/home-manager/commit/3670a035868a8b074892bb17ee7743188f449d06) hound: fix type of systemd Service.Environment
* [`06c6695c`](https://github.com/nix-community/home-manager/commit/06c6695c8caa012bb0c7d794127ef2f94ef3137a) grobi: fix type of systemd Service.Environment
* [`dcc1a9e6`](https://github.com/nix-community/home-manager/commit/dcc1a9e6599905fe348e061b1471d82aa0a6275b) nextcloud-client: fix type of systemd Service.Environment
* [`7540dcc7`](https://github.com/nix-community/home-manager/commit/7540dcc7899193ddef035b19d91eecd57dacf30c) opensnitch-ui: fix type of systemd Service.Environment
* [`480d589c`](https://github.com/nix-community/home-manager/commit/480d589cddf0057d7bac491bd9a08e5a083cf6cb) opensnitch-client: fix type of systemd Service.Environment
* [`451606f4`](https://github.com/nix-community/home-manager/commit/451606f4a843752fc18cdcc764c0e7373ede3e96) polybar: fix type of systemd Service.Environment
* [`87c7d4df`](https://github.com/nix-community/home-manager/commit/87c7d4df161d0eafc0c8fe93a98ba5247a83d969) firefox: fix policies availability
* [`1f7b8188`](https://github.com/nix-community/home-manager/commit/1f7b8188a9c9c5ba32f9a8351c55f42ecc22b77c) zoxide: replace outdated flag in "options" example
* [`b5e09b85`](https://github.com/nix-community/home-manager/commit/b5e09b85f22675923a61ef75e6e9188bd113a6e1) firefox: only add Version = 2 on non-darwin
* [`1786e2af`](https://github.com/nix-community/home-manager/commit/1786e2afdbc48e9038f7cff585069736e1d0ed44) firefox: fix incorrect condition
* [`2cf3abce`](https://github.com/nix-community/home-manager/commit/2cf3abce034432cb357c0a6a670481819c55f564) neovim: use `home.shellAliases`
* [`ecaed80b`](https://github.com/nix-community/home-manager/commit/ecaed80b18e1d179d728d862c96d2fe43699226b) kitty: remove IFD
* [`f48b181f`](https://github.com/nix-community/home-manager/commit/f48b181f0161db6246a1bd1b05d70a7b3a87ab41) ssh-agent: use POSIX conforming if condition
* [`6b191238`](https://github.com/nix-community/home-manager/commit/6b1912380e5577063401f58a2deb985fdc7cdc60) ci: bump DeterminateSystems/update-flake-lock from 23 to 24
* [`8d7e352a`](https://github.com/nix-community/home-manager/commit/8d7e352a4b25ac2d88a881ffa3472680af916ddc) poweralertd: Enable passing CLI args to the daemon
* [`4803bf55`](https://github.com/nix-community/home-manager/commit/4803bf558bdf20cb067aceb8830b7ad70113f4e3) swayidle: make -w optional
* [`0b052dd8`](https://github.com/nix-community/home-manager/commit/0b052dd8119005c6ba819db48bcc657e48f401b7) swayidle: minor cleanups
* [`dfe4d334`](https://github.com/nix-community/home-manager/commit/dfe4d334b172071e7189d971ddecd3a7f811b48d) wezterm: fix generated configuration
* [`51e1d69f`](https://github.com/nix-community/home-manager/commit/51e1d69f7a99446e5ef109ec5ed66b982e0434ca) poweralertd: fix regression
* [`14929f70`](https://github.com/nix-community/home-manager/commit/14929f7089268481d86b83ed31ffd88713dcd415) zoxide: clarify `options` option
* [`04213d1c`](https://github.com/nix-community/home-manager/commit/04213d1ce4221f5d9b40bcee30706ce9a91d148d) flake.lock: Update
* [`21c02186`](https://github.com/nix-community/home-manager/commit/21c021862fa696c8199934e2153214ab57150cb6) ci: disable the tests for macos
