### PR TITLE
niv niv: update f7c53883 -> f9760c0a

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -89,10 +89,10 @@
         "homepage": "https://github.com/nmattia/niv",
         "owner": "nmattia",
         "repo": "niv",
-        "rev": "f7c538837892dd2eb83567c9f380a11efb59b53f",
-        "sha256": "0xl33k24vfc29cg9lnp95kvcq69qbq5fzb7jk9ig4lgrhaarh651",
+        "rev": "f9760c0aaebc24c47f350d2e580b2c56716b0410",
+        "sha256": "0i12f1yszmnxlm3as8yd3jlc84mknp3n1r3njzhsznvkk7y2pzcn",
         "type": "tarball",
-        "url": "https://github.com/nmattia/niv/archive/f7c538837892dd2eb83567c9f380a11efb59b53f.tar.gz",
+        "url": "https://github.com/nmattia/niv/archive/f9760c0aaebc24c47f350d2e580b2c56716b0410.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {


### PR DESCRIPTION
## Changelog for niv:
Branch: master
Commits: [nmattia/niv@f7c53883...f9760c0a](https://github.com/nmattia/niv/compare/f7c538837892dd2eb83567c9f380a11efb59b53f...f9760c0aaebc24c47f350d2e580b2c56716b0410)

* [`f9760c0a`](https://github.com/nmattia/niv/commit/f9760c0aaebc24c47f350d2e580b2c56716b0410) Bump cachix/install-nix-action from V27 to 28 ([nmattia/niv⁠#408](https://togithub.com/nmattia/niv/issues/408))
