### PR TITLE
niv nixpkgs: update 154e2c9d -> a7d1437d

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "154e2c9da04847ca8090dde074b20d1aaae955c4",
-        "sha256": "0ymgmlrjadff7r7kdayzhv1px1c1ihg58s0pclg1pjc9mh3s28yi",
+        "rev": "a7d1437dc8c97361cbb036e98264764fc6221d89",
+        "sha256": "1zw12r5jaxl14ivgx2iw327d51ff4idqw1b7k0n9fdv1p4sll45b",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/154e2c9da04847ca8090dde074b20d1aaae955c4.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/a7d1437dc8c97361cbb036e98264764fc6221d89.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@154e2c9d...a7d1437d](https://github.com/nixos/nixpkgs/compare/154e2c9da04847ca8090dde074b20d1aaae955c4...a7d1437dc8c97361cbb036e98264764fc6221d89)

* [`8c79e599`](https://github.com/NixOS/nixpkgs/commit/8c79e5994e286d521c6a37ee86a35e8bd469037d) dropbox: make dropboxd outlive `dropbox-cli start`
* [`6e8f91da`](https://github.com/NixOS/nixpkgs/commit/6e8f91da32c7c57bbf0b4260277ce5baf9c2610e) nixos/auto-upgrade: correct typo in assertion message
* [`a3184ef2`](https://github.com/NixOS/nixpkgs/commit/a3184ef2bfd74597e656519b4199833ba27b7898) doc: use initdbArgs in example postgresql upgrade script
* [`39acb107`](https://github.com/NixOS/nixpkgs/commit/39acb107ecc319861ef0753bac9356bd0cdb1987) maintainers: add jacekpoz
* [`c9eaf04a`](https://github.com/NixOS/nixpkgs/commit/c9eaf04a688ee66d7da3c02235a5c0b6dab365fc) libbass: 2.4.15 -> 2.4.17
* [`b036cf99`](https://github.com/NixOS/nixpkgs/commit/b036cf99ad13ba47c89760dbf4faf08a3e5ca946) maintainers: add jigglycrumb
* [`63cdc15d`](https://github.com/NixOS/nixpkgs/commit/63cdc15d0b915be94f050c0970a8c6ab36358aa3) python3Packages.dash-bootstrap-components: change src location
* [`c59ec5c2`](https://github.com/NixOS/nixpkgs/commit/c59ec5c27a6912fe0ed8ef6cd9039d0e64de694e) znapzend: 0.21.0 -> 0.23.2
* [`88967044`](https://github.com/NixOS/nixpkgs/commit/889670444ba8e209214652636ca55defe5eb551e) ubootOrangePi5Plus: init
* [`0d557cc2`](https://github.com/NixOS/nixpkgs/commit/0d557cc212e1dca9c0a64a409088d7f8a563e255) itch: implement NIXOS_OZONE_WL
* [`0d6250a6`](https://github.com/NixOS/nixpkgs/commit/0d6250a604ecbb0637c4d1d8e3b90a489af73899) rana: init at 0.5.4
* [`69c6e335`](https://github.com/NixOS/nixpkgs/commit/69c6e3352dbf417738453e3bad560cd4327d9f52) nixos/veilid: Add veilid service module
* [`c321004b`](https://github.com/NixOS/nixpkgs/commit/c321004b56ad5916f54edc7a863af45907c01164) Add figboy9 to maintainers
* [`67b152a0`](https://github.com/NixOS/nixpkgs/commit/67b152a087a28cfab0191229af4626b432a6762a) Add figboy9 to module maintainers
* [`fa96a417`](https://github.com/NixOS/nixpkgs/commit/fa96a417fa9ad08ad3a0b4a2416d0996ca7867d8) nixos/cupsd: typo
* [`da5ae1bd`](https://github.com/NixOS/nixpkgs/commit/da5ae1bd60b4c4a9398f38b457b2b15774f1a0d3) postgresqlPackages.pgvecto-rs: 0.2.1 -> 0.3.0
* [`b444a0e0`](https://github.com/NixOS/nixpkgs/commit/b444a0e0285386f27b5305e411d132a8dbfbdd07) rss-bridge: Add simple NixOS test
* [`b87850d1`](https://github.com/NixOS/nixpkgs/commit/b87850d1d5dab3a0cd7c5e69073570ab4507778a) nixos/etc: remove assertion
* [`447c12c4`](https://github.com/NixOS/nixpkgs/commit/447c12c4f0d22f889961e232ab25c6523f161e51) nixos/system-sysusers: include username in assertion
* [`57e7129b`](https://github.com/NixOS/nixpkgs/commit/57e7129b3a156858a37c94b2af3fda2634d9aaac) nixos/systemd-sysusers: remove assertion
* [`b84ff32c`](https://github.com/NixOS/nixpkgs/commit/b84ff32c5c911ec34ccb36049499243ae924122a) klayout: 0.28.12 -> 0.29.5
* [`8bffd5f0`](https://github.com/NixOS/nixpkgs/commit/8bffd5f04b360f94d5ad0b7cef41ccffe2a24d32) nixos/mailman: configure web frontend with postfix when enablePostfix is turned on
* [`5e9ef74b`](https://github.com/NixOS/nixpkgs/commit/5e9ef74b02404b931ad31e63dfd2db0f953b2828) elfutils: fix header colliding with binary in llvm
* [`f421ff38`](https://github.com/NixOS/nixpkgs/commit/f421ff388cecce40ae20209b4261bc6b67f17971) python312Packages.contextlib2: 21.6.0 -> 21.6.0-unstable-2024-05-23
* [`18ce9a75`](https://github.com/NixOS/nixpkgs/commit/18ce9a750306396b455994310bcedd1376bf7c39) resticprofile: 0.27.1 -> 0.28.0
* [`098f35ed`](https://github.com/NixOS/nixpkgs/commit/098f35edefee4050bec9496053b1ade67bdc59a9) smtp4dev: init at 3.3.4
* [`addbb0ed`](https://github.com/NixOS/nixpkgs/commit/addbb0edd29c948ffebfc7f1636b975c0e39b6e7) python312Packages.llama-index-core: use nltk-data from nix package
* [`6205e30a`](https://github.com/NixOS/nixpkgs/commit/6205e30a7badab5b38158e2d239bf7c0b59e5e88) maintainers: add camerondugan
* [`80f3d367`](https://github.com/NixOS/nixpkgs/commit/80f3d367db4026e545489915b488bb45e11d4744) fastcompmgr: init at 0.3
* [`03efb61d`](https://github.com/NixOS/nixpkgs/commit/03efb61d1d2938e5dbf40df0c622d92e7a8c8185) neomutt: apply nixfmt-rfc-style
* [`083bcedf`](https://github.com/NixOS/nixpkgs/commit/083bcedfa91b6a2d3e0065d94ae4c00f14a36169) bilibili: allow more arguments
* [`964d6c6f`](https://github.com/NixOS/nixpkgs/commit/964d6c6fe0efa1c6fde66cf49dc78d1598d05314) bilibili: 1.14.0-1 -> 1.14.0-2; bilibili: unpack with dpkg
* [`8f0bfe09`](https://github.com/NixOS/nixpkgs/commit/8f0bfe093a30dbfd181759f85f4299eb1bfed21b) bilibili: support aarch64-linux
* [`6498cc6c`](https://github.com/NixOS/nixpkgs/commit/6498cc6cf5d270fc5cc80fb23848f6b572c83caf) bilibili: add bot-wxt1221 as maintainer
* [`c671a808`](https://github.com/NixOS/nixpkgs/commit/c671a808fedf18c4fac6f4057547ffc1ce765517) bilibili: switch to electron_30
* [`0a1b0540`](https://github.com/NixOS/nixpkgs/commit/0a1b05400f5434685db03b16f2f525101f001b29) gh-eco: 0.1.3 -> 0.1.5
* [`4e57ff32`](https://github.com/NixOS/nixpkgs/commit/4e57ff32d99eb2aa633580de27c10b21ecba794b) python312Packages.latexrestricted: init at 0.4.0
* [`9433700e`](https://github.com/NixOS/nixpkgs/commit/9433700e46d7c8dc3b5434319187c87c119d5216) latexminted: 0.1.0b9 -> 0.1.0b16
* [`864bf237`](https://github.com/NixOS/nixpkgs/commit/864bf237e759da917245edb26dbb77d23b00cbb6) aliae: init at 0.22.1
* [`a5be4af4`](https://github.com/NixOS/nixpkgs/commit/a5be4af4f15f17f43b38d6c77d3cb2dca0f419f0) omnom: init at 0-unstable-2024-08-29
* [`c790be2e`](https://github.com/NixOS/nixpkgs/commit/c790be2e0ee49b4960b46030c386fe974742098a) maintainers: add ltrump
* [`989ec1af`](https://github.com/NixOS/nixpkgs/commit/989ec1afaaf8604493e4b651dc0c02c229e2c1a6) git-annex-remote-googledrive: modernise
* [`8ce786ec`](https://github.com/NixOS/nixpkgs/commit/8ce786ec86be946643567fbfeff9fb44251d77b3) git-annex-remote-googledrive: add missing distutils dependency
* [`9c0df812`](https://github.com/NixOS/nixpkgs/commit/9c0df8127788454f49e3641e724842efc40cf194) level-zero: 1.17.28 -> 1.17.42
* [`2e951824`](https://github.com/NixOS/nixpkgs/commit/2e951824d909ba2c0625650879c279fcb5f0b861) swi-prolog: rename from swiProlog
* [`52057458`](https://github.com/NixOS/nixpkgs/commit/52057458d2ea325e79a3b84941a98d640d7961e4) swi-prolog: 9.2.6 -> 9.2.7
* [`f6c72271`](https://github.com/NixOS/nixpkgs/commit/f6c72271415dc39f6044e57c65b8c0c7e3fe8bf9) swi-prolog: prevent git from running during extraPacks install
* [`6840ba25`](https://github.com/NixOS/nixpkgs/commit/6840ba251c4943c5e41a317232d71eb1ae58dbbc) nixos/networkmanager: set up /etc/ipsec.secrets as required by the L2TP plugin
* [`6c1b8188`](https://github.com/NixOS/nixpkgs/commit/6c1b8188384769f174c948c662c439897f64c6c6) bazarr: Add missing dependency for PostgreSQL DB
* [`342b5a8b`](https://github.com/NixOS/nixpkgs/commit/342b5a8b854633fe32d09837d4105d640138a235) sshd: fix shellcheck warnings in prestart script
* [`a236941a`](https://github.com/NixOS/nixpkgs/commit/a236941ad0379faf5436305643ad46bc3312a893) systemd/initrd: fix shellcheck issues
* [`7d664c0a`](https://github.com/NixOS/nixpkgs/commit/7d664c0ac14df7ed4223d04fe0579662bd88c53a) growpart: shellcheck fixes
* [`b471c7e9`](https://github.com/NixOS/nixpkgs/commit/b471c7e91105ad3c306c08b22b9a3b846d760143) amber-lang: 0.3.3-alpha -> 0.3.5-alpha
* [`0dc30d7f`](https://github.com/NixOS/nixpkgs/commit/0dc30d7f8f300bbd31737315a93257fbce12cc29) amber-lang: add `passthru.updateScript`
* [`3217f4af`](https://github.com/NixOS/nixpkgs/commit/3217f4aff0797d0a4283fac484bf67a711272f68) collabora-online: init at 24.04.6-1
* [`b160372b`](https://github.com/NixOS/nixpkgs/commit/b160372b34d72a1297c5e017ff9678e1cfa08338) texmacs: 2.1.2 -> 2.1.4
* [`01d0b0b6`](https://github.com/NixOS/nixpkgs/commit/01d0b0b6834022a5d61a09c0013715c7aeb6be9f) nixos/logrotate: harden systemd unit
* [`5ccb0b42`](https://github.com/NixOS/nixpkgs/commit/5ccb0b428cf773155ce205cc97b9974ada17673b) nixos/doc/rl-2411: add logrotate breaking change
* [`0b51a4ed`](https://github.com/NixOS/nixpkgs/commit/0b51a4ed23d182fe641a7a4483468b8d860bb108) whatsapp-for-linux: add arm64 support
* [`0c3a2265`](https://github.com/NixOS/nixpkgs/commit/0c3a2265b186d7ca7bec93c99d1e683bc0b51d6f) wakapi: move to by name
* [`c2e39567`](https://github.com/NixOS/nixpkgs/commit/c2e3956797ac0d2aa9128f36ff722890a29a5880) wakapi: 2.11.2 -> 2.12.0
* [`7bee8c8c`](https://github.com/NixOS/nixpkgs/commit/7bee8c8cd9a6e8fde8a0fac18c571ab7c08d16ec) wakapi: modernize
* [`21aac957`](https://github.com/NixOS/nixpkgs/commit/21aac957689fd8daaf4ad98f1a633d95468eeb63) temporal: 1.24.2 -> 1.25.0
* [`8336f9d9`](https://github.com/NixOS/nixpkgs/commit/8336f9d9b69a5a8fadc30d34ea5e9ec2bdcb45d5) floorp-unwrapped: 11.17.8 -> 11.18.1
* [`12d52cd3`](https://github.com/NixOS/nixpkgs/commit/12d52cd3e0be7edb5e66e9db72dfa98d367fb3ef) airgorah: init at 0.7.3
* [`83bd47a8`](https://github.com/NixOS/nixpkgs/commit/83bd47a835f90e8488c7ef1234ae1d876789abcb) jupyter: respect JUPYTER_PATH
* [`90126a73`](https://github.com/NixOS/nixpkgs/commit/90126a732d73b42b14f7e465ca6dcb445f4ea4b6) bbin: 0.2.3 -> 0.2.4
* [`13995fbc`](https://github.com/NixOS/nixpkgs/commit/13995fbc6868909bb0fc3a1312b32ba69a7acac7) aces-container: init at 1.0.2
* [`99ee5b80`](https://github.com/NixOS/nixpkgs/commit/99ee5b80d5b9ca6ce2f9359f371bf96321cc4cb1) color-transformation-language: init at 1.5.3
* [`4539588d`](https://github.com/NixOS/nixpkgs/commit/4539588dd5b28ddcae1f39544b9a000abf475e94) art: update dependencies.
* [`52bb3ddb`](https://github.com/NixOS/nixpkgs/commit/52bb3ddb86a6bbeb94b6661ec914e999bf662c5a) fix bug where sdImage.expandOnBoot=false would prevent nix-store from loading DB
* [`08afe032`](https://github.com/NixOS/nixpkgs/commit/08afe03265c29b9617e1bb713049d9ef3ffb9366) fix bug where nix store DB would not be loadable if root was not mounted on /
* [`c8ca37a1`](https://github.com/NixOS/nixpkgs/commit/c8ca37a12df79bbbe5732db43bf508c294413cd1) agdaPackages.standard-library: 2.1.1-rc2 -> 2.1.1
* [`492e603e`](https://github.com/NixOS/nixpkgs/commit/492e603ecd14f51a61b9683181418e981267e5cc) flutter: fix iOS build error
* [`8ab57cea`](https://github.com/NixOS/nixpkgs/commit/8ab57cea8a2ce8b8f0ba12932980cba8b5be21a0) flutter: prevent built iOS/macOS apps from containing links to nix store
* [`9c9a126b`](https://github.com/NixOS/nixpkgs/commit/9c9a126bc25111795de654712c47fc5669cfae95) system76-keyboard-configurator: 1.3.10 -> 1.3.12
* [`45419ce9`](https://github.com/NixOS/nixpkgs/commit/45419ce9036f19cdb67158993a52fb553716c01e) proxmark3: 4.18589 -> 4.18994
* [`272b51ed`](https://github.com/NixOS/nixpkgs/commit/272b51ed0f5ece8adba60eb90fdec86015401f86) python312Packages.evaluate: 0.4.2 -> 0.4.3
* [`c85fe0ea`](https://github.com/NixOS/nixpkgs/commit/c85fe0eaadec613045446280c7067ddc24ab1cf5) jbang: 0.117.1 -> 0.118.0
* [`2dfd0954`](https://github.com/NixOS/nixpkgs/commit/2dfd0954c78a6cfadea445b802c2dbe668a686fc) pgmoneta: 0.13.0 -> 0.14.0
* [`b4d63fb6`](https://github.com/NixOS/nixpkgs/commit/b4d63fb6c0834412957c57bee452a7144207e5c6) goa: 3.18.2 -> 3.19.0
* [`8ec41e51`](https://github.com/NixOS/nixpkgs/commit/8ec41e5185f6512aee778a4d53011040c580603c) k3d: 5.7.3 -> 5.7.4
* [`a3b3308d`](https://github.com/NixOS/nixpkgs/commit/a3b3308d237157d4c0ff0bbfdbae8528e1097040) zoekt: 0-unstable-2024-09-05 -> 3.7.2-2-unstable-2024-09-10
* [`104ab2bd`](https://github.com/NixOS/nixpkgs/commit/104ab2bdcb2f80721a7f1ec5234b378edbd20c80) ocamlPackages.unisim_archisec: 0.0.8 -> 0.0.9
* [`6c149a3e`](https://github.com/NixOS/nixpkgs/commit/6c149a3e9ede976c8c640718170267f66730f70f) questdb: 8.1.0 -> 8.1.1
* [`29872359`](https://github.com/NixOS/nixpkgs/commit/2987235936eefde5f5400325d69ed8d0b2e42ca1) ocamlPackages.lambdasoup: 1.1.0 -> 1.1.1
* [`84020335`](https://github.com/NixOS/nixpkgs/commit/84020335537864f0f12951c4568b84aaa93936e1) python312Packages.wagtail-localize: 1.9 -> 1.10
* [`e181e1b5`](https://github.com/NixOS/nixpkgs/commit/e181e1b5f7389b6df63931324d0229b2c0516162) fluidd: 1.30.3 -> 1.30.4
* [`3771c772`](https://github.com/NixOS/nixpkgs/commit/3771c772f493dc10f297c4bf8129577e967c63ad) klayout: 0.29.5 -> 0.29.6
* [`31111104`](https://github.com/NixOS/nixpkgs/commit/311111045908f68de06512a9fdc11fde6ea402e0) istioctl: 1.22.4 -> 1.23.1
* [`23ccb14f`](https://github.com/NixOS/nixpkgs/commit/23ccb14f2c35265ccc91d3630cceb197f423e15c) python312Packages.wagtail-localize: refactor
* [`31801403`](https://github.com/NixOS/nixpkgs/commit/318014034a856b09da9bbe23c101a2d99d897b3b) reduce options
* [`0ea2046b`](https://github.com/NixOS/nixpkgs/commit/0ea2046bc50aac2f4abf37952898e51392eb27c5) make opening the firewall optional
* [`55a59446`](https://github.com/NixOS/nixpkgs/commit/55a594468a7a224dfe2a8485bf51ff24d4d90fec) change dataDir
* [`16002b16`](https://github.com/NixOS/nixpkgs/commit/16002b1628ed7a3accd743a6bd462f6bac3e8238) fix systemd service based on veilid package
* [`108f4bc5`](https://github.com/NixOS/nixpkgs/commit/108f4bc58109f3029ae2e134d23c8bb2edec5bb7) osl: 1.13.10.0 -> 1.13.11.0
* [`c2b462c9`](https://github.com/NixOS/nixpkgs/commit/c2b462c9f554156f8a942391288efdddbf2aef10) maintainers: add wgunderwood
* [`86df9cf1`](https://github.com/NixOS/nixpkgs/commit/86df9cf159a8564d414f1d062ce8db2304d2c214) tex-fmt: init at 0.4.3
* [`5f7af5b9`](https://github.com/NixOS/nixpkgs/commit/5f7af5b99f19e416059ff242fd8f6197f586223f) crystalline: 0.13.1 -> 0.14.0
* [`a43a9089`](https://github.com/NixOS/nixpkgs/commit/a43a90895abfdc780a3543b1c5e968f49566ead7) python312Packages.ml-dtypes: 0.4.0 -> 0.5.0
* [`3c884af7`](https://github.com/NixOS/nixpkgs/commit/3c884af75c45b9099f51e42ef57326235733a272) vulkan-memory-allocator: Apply fix to allow specifying version constraints on CMake module
* [`27d64130`](https://github.com/NixOS/nixpkgs/commit/27d64130bc43e8e3779d0bce4f20299718d673d4) mongodb-compass: 1.44.0 -> 1.44.3
* [`afb0b0ee`](https://github.com/NixOS/nixpkgs/commit/afb0b0ee5821302180070c1edbd43dc7c73ec762) nixos/collabora-online: init
* [`be13e1b4`](https://github.com/NixOS/nixpkgs/commit/be13e1b4043e79649cadfb58540fed3806c6506f) expand-response-params: Fix windows build and add `mainProgram`
* [`3532e00b`](https://github.com/NixOS/nixpkgs/commit/3532e00b82663bef5b7c3e0cf0bf03d34bf1982b) terramate: 0.10.2 -> 0.10.4
* [`36c91ba5`](https://github.com/NixOS/nixpkgs/commit/36c91ba5d090923d6696eaef1a3581e14cab415e) deck: 1.39.6 -> 1.40.1
* [`9ecb30a5`](https://github.com/NixOS/nixpkgs/commit/9ecb30a5337b9852be377b575e0d4a15a9f74075) janet: 1.35.2 -> 1.36.0
* [`db5f567b`](https://github.com/NixOS/nixpkgs/commit/db5f567b7944fef85d4c5f0e7a009681dd2442d4) jbrowse: 2.15.0 -> 2.15.1
* [`a01561ab`](https://github.com/NixOS/nixpkgs/commit/a01561ab26fd18602577f5d5d38a40b36929eb06) nixos/veilid: add a description of options
* [`ca5cb00a`](https://github.com/NixOS/nixpkgs/commit/ca5cb00a4cfc8505a637527b7ebc8f342a4c7eeb) nixos/veilid: format with nixfmt-rfc-style
* [`1dba027a`](https://github.com/NixOS/nixpkgs/commit/1dba027ae97a0ec3d19826f913c7235546c19442) nixos/veilid: format module-list with nixfmt-rfc-style
* [`d0ea0aef`](https://github.com/NixOS/nixpkgs/commit/d0ea0aef6950970a54cbe97e152468408886138a) pe-bear: 0.6.7.3 -> 0.7.0
* [`7f935f56`](https://github.com/NixOS/nixpkgs/commit/7f935f56eb0d632f730f15fe61142d42180ef518) rpm-ostree: 2024.7 -> 2024.8
* [`1e4c10ff`](https://github.com/NixOS/nixpkgs/commit/1e4c10ff428911fd429d4d2472f64a03ea562231) stirling-pdf: 0.28.3 -> 0.29.0
* [`3c15c230`](https://github.com/NixOS/nixpkgs/commit/3c15c230287161be3e0c191f51c0b1fad352bc37) linkerd_edge: 24.8.3 -> 24.9.2
* [`13c8f955`](https://github.com/NixOS/nixpkgs/commit/13c8f955df1610810c0b74c13518d83abfcc2816) space-station-14-launcher: 0.28.1 -> 0.29.0
* [`bb7c0499`](https://github.com/NixOS/nixpkgs/commit/bb7c0499c8525816819d6636f67723c45c97ed08) python312Packages.txtorcon: 23.11.0 -> 24.8.0
* [`3134d8e0`](https://github.com/NixOS/nixpkgs/commit/3134d8e0f9d43c53208b2f6fc1204f771a16be0f) python312Packages.txtorcon: switch to pypa builder
* [`aee15e11`](https://github.com/NixOS/nixpkgs/commit/aee15e113f1ac8157a5fc1f92540fa181ac8c69a) python312Packages.aioitertools: 0.11.0 -> 0.12.0
* [`498bfee8`](https://github.com/NixOS/nixpkgs/commit/498bfee8f6befdf52a0ee40dd55c078acb4393ab) python312Packages.aioitertools: refactor
* [`8157ccb9`](https://github.com/NixOS/nixpkgs/commit/8157ccb9bb42eec9f2e56d1742e4894905b4754b) python312Packages.albucore: 0.0.14 -> 0.0.15
* [`b3d9c9af`](https://github.com/NixOS/nixpkgs/commit/b3d9c9af37559ec28d541758b057b299a50cec0f) python3Packages.cffi: use build-system/dependencies
* [`7e9221a5`](https://github.com/NixOS/nixpkgs/commit/7e9221a57b1bccf8a601a15ac10ea47a7e1f4dcf) acme-sh: 3.0.7 -> 3.0.8
* [`73520885`](https://github.com/NixOS/nixpkgs/commit/735208853bce9832f9c3f04ae18b6466eea05843) muffet: 2.10.2 -> 2.10.3
* [`226cac0b`](https://github.com/NixOS/nixpkgs/commit/226cac0b001d5d0893e43b5641c8cda04281339b) python312Packages.dash: 2.18.0 -> 2.18.1
* [`e15e5e8d`](https://github.com/NixOS/nixpkgs/commit/e15e5e8d95f4642311cabe711d74cd3deab66fd4) scion: make vmTest handle failured nodes
* [`a49a45f8`](https://github.com/NixOS/nixpkgs/commit/a49a45f85e9fac710754810fb0c0185892c078f7) scion: individually verify certs in vmTest
* [`8dd43e73`](https://github.com/NixOS/nixpkgs/commit/8dd43e731ef83b8a65b063c2b78aed224a5b312d) veryl: init at 0.13.0
* [`d24f0136`](https://github.com/NixOS/nixpkgs/commit/d24f0136ee8e0707b5026f0face1772cfa44ae43) halloy: 2024.08 -> 2024.11
* [`d59950d0`](https://github.com/NixOS/nixpkgs/commit/d59950d0f2170076b63bcd25fd7a177a4cea12f7) bazarr: 1.4.3 -> 1.4.4
* [`63b3ad69`](https://github.com/NixOS/nixpkgs/commit/63b3ad69aa9051311ed0abee2bc9fbc33d5e4d97) mystmd: 1.3.6 -> 1.3.8
* [`1982d0c8`](https://github.com/NixOS/nixpkgs/commit/1982d0c8fa8efbdedd9d748bc5ada91d500c5a88) stackql: 0.5.724 -> 0.5.740
* [`9273f809`](https://github.com/NixOS/nixpkgs/commit/9273f809959ec564e8f5766b55b2309c81c592e2) kubeshark: 52.3.79 -> 52.3.82
* [`b1e918e4`](https://github.com/NixOS/nixpkgs/commit/b1e918e4306d6fc07202395dd00b61de36c91ffa) etcd: 3.5.15 -> 3.5.16
* [`a2f44f16`](https://github.com/NixOS/nixpkgs/commit/a2f44f1625bbfe12c2b628828502f46e93b1cf6f) blackmagic-desktop-video: 14.1a1 -> 14.2a1
* [`97c23f31`](https://github.com/NixOS/nixpkgs/commit/97c23f31f8292397e34f8ca420a9f02856f5df82) devpi-client: 7.0.3 -> 7.1.0
* [`4a37f254`](https://github.com/NixOS/nixpkgs/commit/4a37f2542fb2a61dc5de36bb8c7f1dc92929a1bb) passt: 2024_08_21.1d6142f -> 2024_09_06.6b38f07
* [`b040dfb0`](https://github.com/NixOS/nixpkgs/commit/b040dfb0a091c362e99228a4010f68c9a575f4b8) renode-unstable: 1.15.2+20240905git62115c2c3 -> 1.15.2+20240914gitcb658f346
* [`878e9746`](https://github.com/NixOS/nixpkgs/commit/878e97464cffa05140ec9937e5624a31d78e93bc) dbmate: 2.20.0 -> 2.21.0
* [`ff806fc7`](https://github.com/NixOS/nixpkgs/commit/ff806fc7df051489f41beff99f70b8523cb02499) python312Packages.ibm-cloud-sdk-core: drop pythonRelaxDepsHook
* [`caba9f89`](https://github.com/NixOS/nixpkgs/commit/caba9f893a290fddbfa75c0ffdb95a1905398b92) python312Packages.samarium: drop pythonRelaxDepsHook and pythonRelaxDeps
* [`76beea9e`](https://github.com/NixOS/nixpkgs/commit/76beea9e05eba9b33b02e94a6e5a080d2c9ea430) python312Packages.discum: drop pythonRelaxDepsHook
* [`6e1523e3`](https://github.com/NixOS/nixpkgs/commit/6e1523e3a0516d41896e7ec8afe12ad2eaf6a558) python312Packages.datashaper: drop pythonRelaxDepsHook
* [`cf96f76c`](https://github.com/NixOS/nixpkgs/commit/cf96f76cf4e0992ea39f468c767ed64e22dacf0c) python312Packages.pyzx: drop pythonRelaxDepsHook
* [`0a5dd928`](https://github.com/NixOS/nixpkgs/commit/0a5dd928b81bc0d51c158c4a0cb0e3daba045198) python312Packages.spatialmath-python: drop pythonRelaxDepsHook
* [`ae4c5b2e`](https://github.com/NixOS/nixpkgs/commit/ae4c5b2eced656e77102b5e1d3bc64064b42dd04) python312Packages.h5py: drop pythonRelaxDepsHook
* [`ea52205e`](https://github.com/NixOS/nixpkgs/commit/ea52205ebd47e8ea6ebe3991702c16acd4a20fc9) cewler: drop pythonRelaxDepsHook
* [`acc67601`](https://github.com/NixOS/nixpkgs/commit/acc67601d91d0af571f887f2371ec35aeaa4bb0d) zotify: drop pythonRelaxDepsHook
* [`0106a3ce`](https://github.com/NixOS/nixpkgs/commit/0106a3ce4c9e9eb196c648a68bba7679f243a49c) sherlock: drop pythonRelaxDepsHook
* [`903906ce`](https://github.com/NixOS/nixpkgs/commit/903906cea4d00e21957ef38b31aeb400a2670467) openboard: replace -> replace-fail
* [`7e45c9e1`](https://github.com/NixOS/nixpkgs/commit/7e45c9e19035e8459b9c961ce5a48300b858925b) openboard: disable software updates by default
* [`7cad243b`](https://github.com/NixOS/nixpkgs/commit/7cad243b71619174fd6d102b498d0d8932a3a884) openboard: 1.7.0 -> 1.7.1
* [`459587ea`](https://github.com/NixOS/nixpkgs/commit/459587eaa3092e8c44b85e3b71cc2cf40886112d) imgproxy: 3.25.0 -> 3.26.0
* [`c998f879`](https://github.com/NixOS/nixpkgs/commit/c998f87904b718a4be63400c6916f4e2c41e41ed) octoscan: 0-unstable-2024-08-25 -> 0.1.0
* [`0436ec6b`](https://github.com/NixOS/nixpkgs/commit/0436ec6bafaaf50c1233bb688b307f67e6281e9b) octoscan: add changelog to meta
* [`ac0aabb2`](https://github.com/NixOS/nixpkgs/commit/ac0aabb2577aaf0d3fc35e3306c7ab14104bc315) glooctl: 1.17.6 -> 1.17.8
* [`4dfe60d5`](https://github.com/NixOS/nixpkgs/commit/4dfe60d586a0bf284e834d27fbce6ffd78f5ee76) vscode-extensions.ms-toolsai.jupyter: 2024.8.0 -> 2024.8.1
* [`3fc34aa9`](https://github.com/NixOS/nixpkgs/commit/3fc34aa9115281c14c80d09a77ad8985e256461a) tzupdate: use less with lib; make src rev accurate
* [`94892f8f`](https://github.com/NixOS/nixpkgs/commit/94892f8f20c1312589ca59426a042642e563af45) tzupdate: add doronbehar to maintainers
* [`8efaf0d2`](https://github.com/NixOS/nixpkgs/commit/8efaf0d2d6ae01cdafe9de714ab803d9eaec2aca) nixos/tzupdate: use timedatectl to actually set the timezone
* [`5ffb0264`](https://github.com/NixOS/nixpkgs/commit/5ffb02646bcb72f4a1cde8879e54775a92c998d6) python312Packages.pyunifiprotect: remove
* [`fff94ade`](https://github.com/NixOS/nixpkgs/commit/fff94ade56edb4266944109e61e39a100f0b5792) unifi-protect-backup: switch to uiprotect
* [`e34a564d`](https://github.com/NixOS/nixpkgs/commit/e34a564dd17882bfca0d5398e40fc8365dc4d32b) unifi-protect-backup: format with nixfmt
* [`ab0db3f4`](https://github.com/NixOS/nixpkgs/commit/ab0db3f40d023ae59dcc9ce056a288128708cc5f) llama-cpp: 3672 -> 3772
* [`a68c23c6`](https://github.com/NixOS/nixpkgs/commit/a68c23c65f13f91303ececf5b9c30f252616703b) touchosc: 1.3.4.209 -> 1.3.5.212
* [`629a2c9a`](https://github.com/NixOS/nixpkgs/commit/629a2c9a12fc4d8cc60cf26c0a35cd8c21d91391) rednotebook: 2.33 -> 2.34
* [`c7834224`](https://github.com/NixOS/nixpkgs/commit/c7834224bb8c0a18dd049272b17d1100d2f2accc) prometheus-pve-exporter: 3.4.4 -> 3.4.5
* [`ef28df46`](https://github.com/NixOS/nixpkgs/commit/ef28df465b0ebe63583af330d662da5485bf49a7) dolt: 1.42.18 -> 1.42.20
* [`38ba7cfb`](https://github.com/NixOS/nixpkgs/commit/38ba7cfb0660a8664a5a9877e9a1dd8c7028d4d2) whitesur-kde: 2022-05-01-unstable-2024-08-26 -> 2022-05-01-unstable-2024-09-10
* [`a35b73ba`](https://github.com/NixOS/nixpkgs/commit/a35b73baee1eedbc8f03e49a5ae99ded6b5751ff) proto: 0.40.4 -> 0.41.1
* [`ab1cdd44`](https://github.com/NixOS/nixpkgs/commit/ab1cdd44fa792d745adfedc998eb7e3ea358d29d) phrase-cli: 2.31.2 -> 2.32.0
* [`8d8bbda5`](https://github.com/NixOS/nixpkgs/commit/8d8bbda5f649a9c0574c4a6953ab4670ad99c6fc) prometheus-mongodb-exporter: 0.40.0 -> 0.41.0
* [`166330d2`](https://github.com/NixOS/nixpkgs/commit/166330d2b1819fe808d176dd749db54762b481eb) jitterentropy: 3.5.0 -> 3.6.0
* [`387b6266`](https://github.com/NixOS/nixpkgs/commit/387b6266f1182247f123d3ea6060f878fb20b62f) platformsh: 5.0.19 -> 5.0.20
* [`55a4028b`](https://github.com/NixOS/nixpkgs/commit/55a4028b53b6a71b68bb8c6dde3736e95c668777) zarf: 0.38.3 -> 0.39.0
* [`41461284`](https://github.com/NixOS/nixpkgs/commit/4146128418dcc9520ad02124eecda9622825b2b8) web-ext: 8.2.0 -> 8.3.0
* [`9296a38e`](https://github.com/NixOS/nixpkgs/commit/9296a38e38d1ef607e3f794ab22786f956612334) awsebcli: 3.20.10 -> 3.21
* [`4ee79f4f`](https://github.com/NixOS/nixpkgs/commit/4ee79f4f1c6c02a4e07251d3af1ae921537b06dd) limine: reformat
* [`1e85a6ab`](https://github.com/NixOS/nixpkgs/commit/1e85a6ab16551ed124119645266b04651117dd54) limine: add surfaceflinger as maintainer
* [`7c3d1d6c`](https://github.com/NixOS/nixpkgs/commit/7c3d1d6ccf0a88197bc249194ede3c4344f48544) maintainers: add sanana
* [`67ff8244`](https://github.com/NixOS/nixpkgs/commit/67ff8244c3175b510b53b89eaaf671fc2c6fa2c6) limine: add sanana as maintainer
* [`eb4fbff6`](https://github.com/NixOS/nixpkgs/commit/eb4fbff60a82011599d9db5729fbb8538dbf9bde) xdg-desktop-portal: support cross compilation
* [`a3bb1324`](https://github.com/NixOS/nixpkgs/commit/a3bb1324ffa2d9c9929e5b4e3903aae1ccb6a5be) visualvm: 2.1.9 -> 2.1.10
* [`cb73b5d5`](https://github.com/NixOS/nixpkgs/commit/cb73b5d5f8f4f93d311becf206594ae42c381d3c) nomad_1_8: 1.8.3 -> 1.8.4
* [`9784dc0a`](https://github.com/NixOS/nixpkgs/commit/9784dc0a1d3918073132349070e39799fdc6a517) anytype: add commandLineArgs
* [`b1c583e4`](https://github.com/NixOS/nixpkgs/commit/b1c583e4542094731be66fe3350b81d4480b1339) ocamlPackages.qcheck-multicoretests-util: 0.3 -> 0.4
* [`9774e5bf`](https://github.com/NixOS/nixpkgs/commit/9774e5bf4fb189b5d5f0d415bb3e9cbfedf86eab) opensearch: 2.16.0 -> 2.17.0
* [`c3a384ac`](https://github.com/NixOS/nixpkgs/commit/c3a384aca1ac6f01f846834848b0dcad2775124f) clash-nyanpasu: 1.6.0 -> 1.6.1
* [`4f1cc094`](https://github.com/NixOS/nixpkgs/commit/4f1cc0947de9ed9f874e7c6eb71c0f10f51f528c) nightfox-gtk-theme: 0-unstable-2024-07-22 -> 0-unstable-2024-09-12
* [`08448801`](https://github.com/NixOS/nixpkgs/commit/08448801a5b59d118e6853b022a536a111935bbf) rofimoji: 6.4.0 -> 6.5.0
* [`7baed2d5`](https://github.com/NixOS/nixpkgs/commit/7baed2d5110aa4092286daffa39ea1a0057e0898) nc4nix: 0-unstable-2024-09-07 -> 0-unstable-2024-09-18
* [`cadeeaa5`](https://github.com/NixOS/nixpkgs/commit/cadeeaa525cba69c99387779ed05cbd672a254c3) buildDunePackage: allow overriding `stdenv`
* [`d5a12712`](https://github.com/NixOS/nixpkgs/commit/d5a1271205311f5823861e578373bf3d65bc4f98) messer-slim: 4.2.2 -> 4.3
* [`883b7bd0`](https://github.com/NixOS/nixpkgs/commit/883b7bd08366536fa19b22be80cc5b1acbe3d7c6) litmusctl: 1.9.0 -> 1.10.0
* [`83954c70`](https://github.com/NixOS/nixpkgs/commit/83954c7034aaa83a73030df48c7d61c09a218164) protonmail-bridge: 3.12.0 -> 3.13.0
* [`1762811e`](https://github.com/NixOS/nixpkgs/commit/1762811ec3ee01eeb31255ffb4b018db7048d428) pyenv: 2.4.12 -> 2.4.13
* [`357c9d9f`](https://github.com/NixOS/nixpkgs/commit/357c9d9ff1279dc888874f229924b2c212cd3e6d) spaceship-prompt: 4.16.0 -> 4.16.1
* [`6ea05288`](https://github.com/NixOS/nixpkgs/commit/6ea05288cb7aea0a03a0a6216995c0a012493454) python312Packages.keyrings-cryptfile: 1.3.9 -> 1.4.1
* [`0a7b1339`](https://github.com/NixOS/nixpkgs/commit/0a7b133937771556fc330bf7fb2c2d8d52f01ae2) bloop: 2.0.0 -> 2.0.2 and aarch64-apple-darwin support
* [`0611a6bf`](https://github.com/NixOS/nixpkgs/commit/0611a6bf49d86a8fc403b8704bb978752c6a2462) grim: migrate to by-name
* [`4994bd1a`](https://github.com/NixOS/nixpkgs/commit/4994bd1a2bac2733d9af50eee3fda03ca519f4ef) grim: refactor and adopt
* [`c488f494`](https://github.com/NixOS/nixpkgs/commit/c488f494232da5a80bc2b2a7fff679e941af0aa7) novelwriter: 2.5.1 -> 2.5.2
* [`0a3ef518`](https://github.com/NixOS/nixpkgs/commit/0a3ef518c4a80cc21de1ab958f8cb4ce935708c9) ibus-engines.typing-booster-unwrapped: 2.25.15 -> 2.25.16
* [`d74bb82c`](https://github.com/NixOS/nixpkgs/commit/d74bb82cca02f9af3c70b7ac34f35df1b9d784ca) tailscale: 1.74.0 -> 1.74.1
* [`c017a22a`](https://github.com/NixOS/nixpkgs/commit/c017a22aadaddc4df5e034567dad70fa5440b73a) libsForQt5.mlt: 7.26.0 -> 7.28.0
* [`94b8def8`](https://github.com/NixOS/nixpkgs/commit/94b8def8b108e66fef93a771e21cd5a6d8b4e202) esptool: 4.7.0 -> 4.8.0
* [`593490e8`](https://github.com/NixOS/nixpkgs/commit/593490e84f5cb936b8cec52ee632123110d0d5b0) python312Packages.foolscap: 23.3.0 -> 24.9.0
* [`4849e629`](https://github.com/NixOS/nixpkgs/commit/4849e629186ced43547b56819b3b1db96f624962) python312Packages.openapi-core: 0.19.3 -> 0.19.4
* [`245b2a5e`](https://github.com/NixOS/nixpkgs/commit/245b2a5ebe242681a5012a192d6712a50649d80d) python312Packages.twitchapi: 4.2.1 -> 4.3.1
* [`adf48a9c`](https://github.com/NixOS/nixpkgs/commit/adf48a9c60aac7248af300d05320d02f1b0f8968) afterburn: 5.6.0 -> 5.7.0
* [`19b5a9a9`](https://github.com/NixOS/nixpkgs/commit/19b5a9a9adfd0dedace563e595364a424db8fdf7) calicoctl: 3.28.1 -> 3.28.2
* [`85af4230`](https://github.com/NixOS/nixpkgs/commit/85af423058de1f2e847ca57c78956ffcb91d6807) coreth: 0.13.7 -> 0.13.8
* [`09fb2fef`](https://github.com/NixOS/nixpkgs/commit/09fb2fef88f987f7e5a3972b80ecaae7d82d4c7b) murex: 6.2.4000 -> 6.3.4225
* [`db4adb16`](https://github.com/NixOS/nixpkgs/commit/db4adb16e92ed3d95c77ccf67130187b948d3de8) tunwg: 24.01.15+9f04d73 -> 24.09.18+760ee81
* [`af8da0fa`](https://github.com/NixOS/nixpkgs/commit/af8da0fab9f34982a988e44d4dedab0de197ddc0) wasmedge: 0.14.0 -> 0.14.1
* [`de59208b`](https://github.com/NixOS/nixpkgs/commit/de59208b3bf57015166f716023493b5d546955ac) python312Packages.shiboken2: use python.pkgs.distutils
* [`abd8708c`](https://github.com/NixOS/nixpkgs/commit/abd8708ccc945c1c6c2d6fbd20f4cb07f8124097) python312Packages.pyside2: use python.pkgs.distutils
* [`6a3cf885`](https://github.com/NixOS/nixpkgs/commit/6a3cf885c013c9aa1d52c00fc14379076bb7827f) i3bar-river: 0.1.10 -> 1.0.0
* [`ac7e26a5`](https://github.com/NixOS/nixpkgs/commit/ac7e26a5db2f21cee071b1194b6204056bdada9d) bartender: 5.1.2 -> 5.1.5
* [`bf818853`](https://github.com/NixOS/nixpkgs/commit/bf8188532bf3dc09cea0ebbc57d63fa79e693750) rqlite: 8.30.0 -> 8.30.3
* [`e63faf81`](https://github.com/NixOS/nixpkgs/commit/e63faf81989408d91fe6013adc6f8f680a4ba74f) cpuinfo: 0-unstable-2024-08-30 -> 0-unstable-2024-09-11
* [`4a0793d0`](https://github.com/NixOS/nixpkgs/commit/4a0793d075b79ef32456070c790aa37e689bbe80) kokkos: 4.4.00 -> 4.4.01
* [`acf722e1`](https://github.com/NixOS/nixpkgs/commit/acf722e191cbf89d9f9e43b53b46548b26efabb3) qbittorrent: 4.6.5 -> 4.6.7
* [`4b10cd5b`](https://github.com/NixOS/nixpkgs/commit/4b10cd5baa04826970e1cb8cd6b86311c585df20) bazecor: 1.4.5 -> 1.5.0
* [`8250da44`](https://github.com/NixOS/nixpkgs/commit/8250da44e4d4b578131bc1e44daf10bcb4a4036b) simple-dftd3: 1.1.0 -> 1.1.1
* [`e5b4bd06`](https://github.com/NixOS/nixpkgs/commit/e5b4bd06190770b3d8393601323c96e4b878634c) rtz: 0.7.0 → 0.7.1
* [`e6784a66`](https://github.com/NixOS/nixpkgs/commit/e6784a660e4f6d5a5f848d24cb5800408aec2556) sequoia-sq: 0.37.0 -> 0.38.0
* [`1c0e78c9`](https://github.com/NixOS/nixpkgs/commit/1c0e78c92b1d03232e00f40ecb41c5725f5543ac) python312Packages.vdf: add patch to support appinfo.vdf v29
* [`5a9adeb2`](https://github.com/NixOS/nixpkgs/commit/5a9adeb2c9dd078f87b3b9ad3113671b7697d06d) python312Packages.vdf: avoid using pname for src.repo
* [`41ea5543`](https://github.com/NixOS/nixpkgs/commit/41ea55435a70dd7d65b37c4cfdfac3bfeb136d3a) python312Packages.vdf: explicitly use tag for rev
* [`90effb99`](https://github.com/NixOS/nixpkgs/commit/90effb99edf82b41a082c3cf6e8726585f4b59c6) electron_32-bin: init at 32.1.1
* [`483e68aa`](https://github.com/NixOS/nixpkgs/commit/483e68aa6c6ad60b8ee283dac8eb3252ed2325a4) bitwarden-desktop: 2024.8.2 -> 2024.9.0
* [`a4eb2ac4`](https://github.com/NixOS/nixpkgs/commit/a4eb2ac49f1fda386fc69d6c775d4bfd06e669dc) linux_xanmod: 6.6.51 -> 6.6.52
* [`a371dc45`](https://github.com/NixOS/nixpkgs/commit/a371dc4593c22cb633e7475cb423375856892ab2) linux_xanmod_latest: 6.9.10 -> 6.9.10
* [`9e4edca1`](https://github.com/NixOS/nixpkgs/commit/9e4edca155dbc29551f46bb6ebccc3948999753d) electron-source.electron_32: init at 32.1.1
* [`b075f7d8`](https://github.com/NixOS/nixpkgs/commit/b075f7d893fcc0c05a80714354598067ff6ccd13) electron: 31 -> 32
* [`bac1f691`](https://github.com/NixOS/nixpkgs/commit/bac1f69114aace9b58a5eeb68c15ba9c7f1ae575) electron-chromedriver_32: 32.1.0 -> 32.1.1
* [`3c3e6d15`](https://github.com/NixOS/nixpkgs/commit/3c3e6d155d601d7f4f6f1c95dbac4b36ee8e4478) sshx: unstable-2023-11-23 -> 0.2.4
* [`11e81a04`](https://github.com/NixOS/nixpkgs/commit/11e81a047e30d5b72550d15a17623609172bcc03) papermc: 1.21.1-69 -> 1.21.1-85
* [`92226003`](https://github.com/NixOS/nixpkgs/commit/922260030165b119e39eb281953ebeb2f2d63536) gapcast: init at 1.0.3
* [`7b393d87`](https://github.com/NixOS/nixpkgs/commit/7b393d87a8fc7f007e8ce874092a014e25d27de0) python3Packages.proton-core: 0.2.0 -> 0.3.3
* [`f01b6740`](https://github.com/NixOS/nixpkgs/commit/f01b67406414907f2c95cd132003ae46590c757c) chromium: remove superfluous patch
* [`e9359ec5`](https://github.com/NixOS/nixpkgs/commit/e9359ec5f8cd856973b2e56ddc9ca6e1def40980) sbt-extras: 2024-07-10 -> 2024-09-13
* [`5fc52158`](https://github.com/NixOS/nixpkgs/commit/5fc5215870622fddf2f86de7eeab4987fdabe0c3) pragtical: 3.4.4 -> 3.5.0
* [`7b89ad82`](https://github.com/NixOS/nixpkgs/commit/7b89ad82bec383ecaf6e063216793d031be0aa75) devspace: 6.3.12 -> 6.3.13
* [`5312ad97`](https://github.com/NixOS/nixpkgs/commit/5312ad970c947865c9b92391dca13876896000e3) git-quick-stats: 2.5.6 -> 2.5.7
* [`6c3b1a64`](https://github.com/NixOS/nixpkgs/commit/6c3b1a64c5e5bebbcf4e6437bedf7de20f5fc53f) bicep: 0.29.47 -> 0.30.3
* [`b675b26e`](https://github.com/NixOS/nixpkgs/commit/b675b26ead5f2cc8e0617b069e9e4e2f46af1bfd) terragrunt: 0.67.3 -> 0.67.9
* [`1db3e753`](https://github.com/NixOS/nixpkgs/commit/1db3e7534b8d17a770d06d2fb50a3f2ba54a024f) openjfx17: fix build with Ruby 3
* [`29a1bcb9`](https://github.com/NixOS/nixpkgs/commit/29a1bcb9ec9660f5bee962b1e8682850c4a5f5be) doc: 24.11: fix taskwarrior typo
* [`a3492a8f`](https://github.com/NixOS/nixpkgs/commit/a3492a8f1185cc1a2a6145ff4c9bf5d36c1d212f) awscli2: unpin python
* [`d359326c`](https://github.com/NixOS/nixpkgs/commit/d359326c5877da2bcdfcb3f661600113fed81e0b) vwsfriend: 0.24.5 -> 0.24.7
* [`5c4f3956`](https://github.com/NixOS/nixpkgs/commit/5c4f395609c98d042c69953dbe84ee98c2eb8d74) deepin.dtk6core: 6.0.18 -> 6.0.19
* [`001d69e7`](https://github.com/NixOS/nixpkgs/commit/001d69e7f7279c63a5b48a826a6b0c6d30c1bddc) deepin.dtk6gui: 6.0.18 -> 6.0.19
* [`a086c9f8`](https://github.com/NixOS/nixpkgs/commit/a086c9f89335ba4f109de9d2f4dc47bf4ae2d4f2) deepin.dtk6widget: 6.0.18 -> 6.0.19
* [`48dd5fa2`](https://github.com/NixOS/nixpkgs/commit/48dd5fa246042664a7075bc1ed9e5cf14c0a54a9) deepin.dtk6declarative: 6.0.18 -> 6.0.19
* [`a60418cc`](https://github.com/NixOS/nixpkgs/commit/a60418cc6612fcbcd7e51f89fb4ff46641eb4326) drawterm: 0-unstable-2024-09-08 -> 0-unstable-2024-09-09
* [`e7f2c184`](https://github.com/NixOS/nixpkgs/commit/e7f2c184675395c5274955f219540314bce2c13f) deepin.dde-tray-loader: 0.0.11 -> 1.0.1
* [`c60f9823`](https://github.com/NixOS/nixpkgs/commit/c60f9823162a4dfa2b363ad01bacf8bb281343ff) deepin.qt6integration: 6.0.18 -> 6.0.19
* [`b4b96bec`](https://github.com/NixOS/nixpkgs/commit/b4b96bec9dea7feb253c591bae0e0ae4295cb109) praat: 6.4.19 -> 6.4.20
* [`6e9cede9`](https://github.com/NixOS/nixpkgs/commit/6e9cede90cb8bfe7f986def52f2385fa80af94c9) deepin.qt6platform-plugins: 6.0.18 -> 6.0.19
* [`13f79201`](https://github.com/NixOS/nixpkgs/commit/13f79201796625cb6e987a24b8be78b631ead665) deepin.dde-shell: 0.0.43 -> 1.0.2
* [`80539ddd`](https://github.com/NixOS/nixpkgs/commit/80539ddd5065c8aeaed0f2005fe690f5559d1d80) python3Packages.assay: 2022-01-19 -> 2024-05-09
* [`05e13bff`](https://github.com/NixOS/nixpkgs/commit/05e13bffe19c8ccd425761798fba120242bac5f3) nixosTests.k3s.{single-node,multi-node}: enable check-config for aarch64
* [`e9002b6b`](https://github.com/NixOS/nixpkgs/commit/e9002b6b547e171d943c2c1b0b78ce3e8ad1b207) nixosTests.k3s.{single-node,multi-node}: nixfmt
* [`c9b35b9a`](https://github.com/NixOS/nixpkgs/commit/c9b35b9a1867ada44880bff1627c0a296b48ab66) argo: 3.5.10 -> 3.5.11
* [`486633e3`](https://github.com/NixOS/nixpkgs/commit/486633e3f40d7f60e35238340dcb8a5ccb0c5871) postgresqlPackages.system_stats: 3.0 -> 3.2
* [`5a952cfc`](https://github.com/NixOS/nixpkgs/commit/5a952cfc5e9ba9f508c9045796ad42f87e0442c3) vscode-extensions.ocamllabs.ocaml-platform: 1.12.2 -> 1.20.0
* [`50344500`](https://github.com/NixOS/nixpkgs/commit/5034450095548401f47f1a55c44cb2ecdae6b77f) nixos/systemd: Factor out tpm2 support into separate module
* [`a0165bd5`](https://github.com/NixOS/nixpkgs/commit/a0165bd5afa5f7c2c045fcc6988810cc85e1d8f1) nixos/systemd/tpm2: Enable tpm2-setup and tpm2.target
* [`74fc8505`](https://github.com/NixOS/nixpkgs/commit/74fc8505cd85c354a7a45e9d2e665f998c4667e3) vscode-extensions.fill-labs.dependi: 0.7.9 -> 0.7.10
* [`2d2e2089`](https://github.com/NixOS/nixpkgs/commit/2d2e208956f4363a36691d0d5e0d1131f3b3f3ce) wlroots: 0.18.0 -> 0.18.1
* [`297f1bc1`](https://github.com/NixOS/nixpkgs/commit/297f1bc1727a6c8ce490df633d4e03862c381b85) python312Packages.dask-awkward: 2024.7.0 -> 2024.9.0
* [`d52a7b2b`](https://github.com/NixOS/nixpkgs/commit/d52a7b2b5a49246ab54fcb9f9d20d013e6e494c8) python312Packages.emoji: 2.12.1 -> 2.13.0
* [`58f8d27e`](https://github.com/NixOS/nixpkgs/commit/58f8d27e0af7ab886a333bd194fc1a383c7fe21a) python312Packages.art: 6.2 -> 6.3
* [`c8b28996`](https://github.com/NixOS/nixpkgs/commit/c8b289962d14c9df9be0279bf9b7eaf1727830dd) python312Packages.dask-histogram: 2024.3.0 -> 2024.9.1
* [`91fc27de`](https://github.com/NixOS/nixpkgs/commit/91fc27ded9173103a0b910aaf9fae7722b624dba) emacs28-gtk2: remove
* [`fc16ae75`](https://github.com/NixOS/nixpkgs/commit/fc16ae75ec645650df14e93504d5f57fdfcfb123) dub-to-nix: update recommended regen command
* [`f9f65a7b`](https://github.com/NixOS/nixpkgs/commit/f9f65a7b294be3398341e850f081de981a948ba2) heroic: Set updateScript
* [`0ffc21b1`](https://github.com/NixOS/nixpkgs/commit/0ffc21b1004d06179b9f190b44b5fc8d7fdd9c8c) heroic: 2.15.1 -> 2.15.2
* [`7747aa9b`](https://github.com/NixOS/nixpkgs/commit/7747aa9b1739d57b9c15b1d9f4231ba72d124537) heroic: reformat to follow RFC style
* [`bded1f52`](https://github.com/NixOS/nixpkgs/commit/bded1f52cadbcb9ec8187772fcde39997b2b200f) awscli2: 2.17.42 -> 2.17.56
* [`f9c3ec68`](https://github.com/NixOS/nixpkgs/commit/f9c3ec68e1b4b1b57ea2e2ff150e83ab7bbd73fe) awscli2: nixfmt-rfc-style
* [`f5061b9f`](https://github.com/NixOS/nixpkgs/commit/f5061b9fb6e8188f279da0ca7841cb2775adaf8b) wasmtime: 24.0.0 -> 25.0.0
* [`b4feff6a`](https://github.com/NixOS/nixpkgs/commit/b4feff6a7046441417f89d703dc9b275e9421a26) qbittorrent-enhanced: 4.6.6.10 -> 4.6.7.10
* [`fa9140e5`](https://github.com/NixOS/nixpkgs/commit/fa9140e51116668941846052b77dbd82ec1fed2a) texstudio: 4.8.2 -> 4.8.3
* [`295f2e94`](https://github.com/NixOS/nixpkgs/commit/295f2e949a9d9e6eec96e3cd0643cc6190d47b2b) pg_checksums: 1.1 -> 1.2
* [`522a30a2`](https://github.com/NixOS/nixpkgs/commit/522a30a293209d16b22e66842ef080a32c33c7e6) oapi-codegen: 2.3.0 -> 2.4.0
* [`402eb1dd`](https://github.com/NixOS/nixpkgs/commit/402eb1ddcbd907fbc8207446f63b0b0584c99d40) quickjs-ng: 0.5.0 -> 0.6.0
* [`62c5d3fd`](https://github.com/NixOS/nixpkgs/commit/62c5d3fd0f0b7c1992c41be132ccc47f869f73a6) python312Packages.watermark: 2.4.0 -> 2.5.0
* [`33825c7a`](https://github.com/NixOS/nixpkgs/commit/33825c7ae708fe71571ee78ea7acd061be48cb8b) quarkus: 3.14.2 -> 3.14.4
* [`fb74f8c3`](https://github.com/NixOS/nixpkgs/commit/fb74f8c3d7db360c8961565f067aae2e3e06e4e6) gancio: 1.19.0 -> 1.19.1
* [`e6d5fe50`](https://github.com/NixOS/nixpkgs/commit/e6d5fe503b6cb401f67bb1b99a60b1e06afb80d0) python312Packages.langfuse: 2.45.1 -> 2.50.2
* [`197ca79a`](https://github.com/NixOS/nixpkgs/commit/197ca79a3cc9a85033efba153ea1786dc0a3e892) python312Packages.marimo: 0.8.15 -> 0.8.18
* [`bf310f7f`](https://github.com/NixOS/nixpkgs/commit/bf310f7fcb6b8ff8153e3493e169be3784b1427a) astro-language-server: 2.10.0 -> 2.14.2
* [`728126dc`](https://github.com/NixOS/nixpkgs/commit/728126dcd1e6568ad9f7621865c546e1b05f7141) renode-dts2repl: 0-unstable-2024-09-05 -> 0-unstable-2024-09-20
* [`608bd15c`](https://github.com/NixOS/nixpkgs/commit/608bd15ce5fbb82a39cea2a9fb5b0ac4f7d23306) nixos/i2pd: remove `with lib;`
* [`32f34d13`](https://github.com/NixOS/nixpkgs/commit/32f34d13c2ed93a7c382007af2614eaa824e784a) bluemap: 3.21 -> 5.3
* [`e9c29892`](https://github.com/NixOS/nixpkgs/commit/e9c2989220a87fab05090b9c799f2582524d942a) bluemap: 5.3 -> 5.4
* [`d1af071b`](https://github.com/NixOS/nixpkgs/commit/d1af071bc991195ff9654b069bbd4846c6c80f26) misconfig-mapper: 1.8.4 -> 1.9.0
* [`9bdb19be`](https://github.com/NixOS/nixpkgs/commit/9bdb19be9a4f830f138a4821cc39d38cf85df093) LAStools: add Wno-narrowing on aarch64
* [`fdf01997`](https://github.com/NixOS/nixpkgs/commit/fdf019979ebe923d0393765f08975d33e557842e) nixos/jenkinsSlave: remove `with lib;`
* [`c59b120d`](https://github.com/NixOS/nixpkgs/commit/c59b120d008ac7632dfc678b058335b51197fefe) python312Packages.billiard: 4.2.0 -> 4.2.1
* [`8d780794`](https://github.com/NixOS/nixpkgs/commit/8d780794fa6bd9cebc2b3917f545c47e61caf30f) python312Packages.datasalad: 0.2.1 -> 0.3.0
* [`148c0ec3`](https://github.com/NixOS/nixpkgs/commit/148c0ec36ef03d2c9d12676fa4560d09821d01ea) python312Packages.numpyro: 0.15.2 -> 0.15.3
* [`29a41744`](https://github.com/NixOS/nixpkgs/commit/29a41744f6edef5dd8cc44132861e74134cc3272) vimPlugins.render-markdown-nvim: fix broken alias
* [`1011fb02`](https://github.com/NixOS/nixpkgs/commit/1011fb027003ea62bb6ef73a5853680450c4b317) terraform-local: 0.19.0 -> 0.20.0
* [`ea736101`](https://github.com/NixOS/nixpkgs/commit/ea736101cdd2436d9abedd0b1884ce1c1962873f) shotcut: 24.08.29 -> 24.09.13
* [`f0d7076c`](https://github.com/NixOS/nixpkgs/commit/f0d7076c6a935cfcc8792a6019cd566e3411ce79) nixos/systemd-stage-1: Include modprobe@.service
* [`c645046b`](https://github.com/NixOS/nixpkgs/commit/c645046b6a480aedade8f066ffd9bb93c087f233) python3.pkgs.textual-slider: init at 0.1.2
* [`16f1a1b1`](https://github.com/NixOS/nixpkgs/commit/16f1a1b12c5873498de11b5677ae3a3b61195bec) python3.pkgs.pyytlounge: init at 2.1.1
* [`3d2e6103`](https://github.com/NixOS/nixpkgs/commit/3d2e6103c8b74038996c905844a6eb048c2cd78c) python3.pkgs.async-cache: init at 1.1.1
* [`5892f519`](https://github.com/NixOS/nixpkgs/commit/5892f519c149c227cd4522cc5779de48a48e75d2) isponsorblocktv: init at 2.2.1
* [`13d19ef4`](https://github.com/NixOS/nixpkgs/commit/13d19ef4d5e5a5d7bf239a75fdf023fd11906c7d) plex-desktop: 1.96.0 -> 1.101.0
* [`f0b6425d`](https://github.com/NixOS/nixpkgs/commit/f0b6425d738288f85381488cc3e25c30a441235c) doc/build-helpers: fix wrong invokations of writeTextFile with destination
* [`523e5df5`](https://github.com/NixOS/nixpkgs/commit/523e5df5147e15dd63262506aca6698466758bc7) storj-uplink: 1.111.4 -> 1.113.4
* [`3f954af9`](https://github.com/NixOS/nixpkgs/commit/3f954af976afb25fc22fd41299b5a198a5d4803d) dpp: 10.0.30 -> 10.0.31
* [`ac4a4cb8`](https://github.com/NixOS/nixpkgs/commit/ac4a4cb83ca6e63d3d0ea0cda64f8c3aa69b312f) router: 1.52.1 -> 1.54.0
* [`8a242099`](https://github.com/NixOS/nixpkgs/commit/8a242099b8601f5c0c11a45bcf935fac3276f685) python312Packages.blacken-docs: move from top-level
* [`26bfa2c7`](https://github.com/NixOS/nixpkgs/commit/26bfa2c7f2a3801a17a13986105842f42ea90172) nbqa: update dependencies
* [`c52e8e94`](https://github.com/NixOS/nixpkgs/commit/c52e8e94297adf2e179062486c65f40fdd7a2cbd) gensio: 2.8.5 -> 2.8.9
* [`4b0564d9`](https://github.com/NixOS/nixpkgs/commit/4b0564d94a098013b30058003e5c969d87caded4) redlib: 0.35.1 -> 0.35.1-unstable-2024-09-22
* [`de654eed`](https://github.com/NixOS/nixpkgs/commit/de654eed30048b6c74df251b03569bcfc149e6c9) python312Packages.pulumi-aws: 6.51.0 -> 6.52.0
* [`6c1e1d05`](https://github.com/NixOS/nixpkgs/commit/6c1e1d053c1b38aa144061631d35fa5f10051f90) onthespot: add async-timeout
* [`364a8c30`](https://github.com/NixOS/nixpkgs/commit/364a8c30fd18cfb89fe9f24d57e5d8a88ecbc03b) onthespot: format with nixfmt
* [`a620edff`](https://github.com/NixOS/nixpkgs/commit/a620edff970d716ebb1aa37d445569780fa7fb42) maestro: refactor prefer finalAttrs instead of rec
* [`d0f192a5`](https://github.com/NixOS/nixpkgs/commit/d0f192a58336d56170698b24fb807da3d87e53a5) maestro: add script to auto update to the latest stable version
* [`011eee0c`](https://github.com/NixOS/nixpkgs/commit/011eee0c557963d0e46bf7729cb573f31d4ed4a2) maestro: 1.37.9 -> 1.38.1
* [`23a7d90d`](https://github.com/NixOS/nixpkgs/commit/23a7d90d468d8dd03c2ffa96ee15f8d4de0b5785) mathematica: add chewblacka to maintainers
* [`78b5960d`](https://github.com/NixOS/nixpkgs/commit/78b5960d77303de3993f6c86fb2c9b35bc8cbd59) mathematica: 14.0.0 -> 14.1.0
* [`83077472`](https://github.com/NixOS/nixpkgs/commit/83077472b8dfbef2f549c640d7a148390ba146bf) python312Packages.tifffile: 2024.6.18 -> 2024.9.20
* [`b1b9fa4c`](https://github.com/NixOS/nixpkgs/commit/b1b9fa4c85a2c3a9769c7a8bbd9338ef63d0dd48) python312Packages.billiard: modernize, fetch source from github
* [`7d392af7`](https://github.com/NixOS/nixpkgs/commit/7d392af757cb523b072497acb255d06918d53148) python312Packages.billiard: drop outdated disabledTests
* [`128a7c7f`](https://github.com/NixOS/nixpkgs/commit/128a7c7fe5c721e9535799346e0d20c8f1d15261) python312Packages.billiard: add nickcao to maintainers
* [`8cb31b03`](https://github.com/NixOS/nixpkgs/commit/8cb31b035e15f70ed0ff38a6b439fc24ef4dde08) python312Packages.mmengine: disable outdated (failing) tests
* [`b5b94409`](https://github.com/NixOS/nixpkgs/commit/b5b94409797cb27e9c01e87b5a04882376111d9a) tuxpaint: add mainProgram
* [`62030f7b`](https://github.com/NixOS/nixpkgs/commit/62030f7bdd6f395ebd8b999da4d743ce4654f7ca) previewqt: adopt and modernize
* [`843be87f`](https://github.com/NixOS/nixpkgs/commit/843be87f63b2b8208bb63cdf66950d70bf95a2da) python312Packages.hy: 0.29.0 -> 1.0.0
* [`644f6061`](https://github.com/NixOS/nixpkgs/commit/644f6061be4b4a7c76c3a879061c37179e41d80d) ratchet: 0.9.2 -> 0.10.0
* [`30f11e43`](https://github.com/NixOS/nixpkgs/commit/30f11e43df52131ece66d62470ffe23c111eefcf) nix: add installer test and adapt passthru tests based on the platform
* [`1136ea81`](https://github.com/NixOS/nixpkgs/commit/1136ea818720becd1b1c6e67008d1273ba251469) neovim.tests.nvim_with_ftplugin: fix the test
* [`5f6015bb`](https://github.com/NixOS/nixpkgs/commit/5f6015bb9c2e7f152949c9cf2f7c43dfe89498e4) livebook: 0.14.0 -> 0.14.2
* [`e9e4cd93`](https://github.com/NixOS/nixpkgs/commit/e9e4cd93917d58a954a36fa5eb084fc34d3a88a8) neovim.tests.can_require_transitive_deps: fix running
* [`66635912`](https://github.com/NixOS/nixpkgs/commit/6663591207ae050bfa8421923b981369be4cad48) linuxPackages.nvidia_x11: install libraries with correct sonames
* [`eb75d79b`](https://github.com/NixOS/nixpkgs/commit/eb75d79b27e2cbbe3506c88b14ecbcd614fb119d) infisical: 0.30.0 -> 0.31.0
* [`bc4914bc`](https://github.com/NixOS/nixpkgs/commit/bc4914bcf114da6eb5da46f6cb1f2be3e0fb917a) google-chrome: fix update script
* [`22d84922`](https://github.com/NixOS/nixpkgs/commit/22d8492295fc3c7f06d9d862bd0fad5e18d8122b) google-chrome: 128.0.6613.138 -> 129.0.6668.59 (Darwin)
* [`6215daa5`](https://github.com/NixOS/nixpkgs/commit/6215daa52004e2e36117fa204db95fce46598945) writeTextFile: assert destination starting with a /
* [`cf9945af`](https://github.com/NixOS/nixpkgs/commit/cf9945af444050478e518f2d55ed5ebe96475353) caffe: drop nose dependency
* [`69ed950c`](https://github.com/NixOS/nixpkgs/commit/69ed950c468f808e1b5ed3326d592d77ca625f02) ubridge: migrate to pkgs/by-name, format with nixfmt-rfc-style
* [`f04bdba5`](https://github.com/NixOS/nixpkgs/commit/f04bdba5275f734e02ad988e582483364e48e114) ubridge: add passthru.updateScript
* [`bab6df35`](https://github.com/NixOS/nixpkgs/commit/bab6df353c7342e18e56dcba14edf53d1789e4c5) ubridge: 0.9.18 -> 0.9.19
* [`f29ed88f`](https://github.com/NixOS/nixpkgs/commit/f29ed88f30c7310913ca58294681044b56844bcd) ubridge: add anthonyroussel to maintainers
* [`370458d7`](https://github.com/NixOS/nixpkgs/commit/370458d7f179323121eb77a9157a0398c4104174) wine64Packages.{unstable,staging}: 9.17 -> 9.18
* [`c7827815`](https://github.com/NixOS/nixpkgs/commit/c782781566c601701e710f2bba0288d523011de6) onboard: remove unused nose dependency
* [`bcb2ba85`](https://github.com/NixOS/nixpkgs/commit/bcb2ba85b2f45f82ec446bdf47cd116fd8a13ab0) autosuspend: 7.0.0 -> 7.0.1
* [`82978a85`](https://github.com/NixOS/nixpkgs/commit/82978a85c6731eb072a916cbfb8d6d807dd88fcb) Revert "nixos/profiles/base: install vim w/nix-syntax plugin"
* [`4324cd5e`](https://github.com/NixOS/nixpkgs/commit/4324cd5e8e0597813f20d29e4b64954936aeddd6) pixelorama: 1.0.2 -> 1.0.3
* [`2e229394`](https://github.com/NixOS/nixpkgs/commit/2e229394f61b1da67522cc56692cb4ef78775b5a) maintainers: add attila
* [`5d0e7f1e`](https://github.com/NixOS/nixpkgs/commit/5d0e7f1e3b954d5c6ca0ba40013b694945f82728) ton: 2024.08 -> 2024.09
* [`627e241f`](https://github.com/NixOS/nixpkgs/commit/627e241f5c2f5cbfedf7b943fd394a1b8de1d433) python3{11,12}Packages.jupyter-contrib-nbextensions: drop
* [`90b88c48`](https://github.com/NixOS/nixpkgs/commit/90b88c48a7bcab4c4d880a2f1c358338d37ae1a7) perlPackages.HTTPDaemon: fix build on Darwin with sandboxing
* [`5e1c6815`](https://github.com/NixOS/nixpkgs/commit/5e1c681551d5cf92e20ac7f817013dba8a5c76e0) python312Packages.cirq-*: refactor
* [`100eefb9`](https://github.com/NixOS/nixpkgs/commit/100eefb99c640ea73432fc5bbc816e379d269182) dopamine: 3.0.0-preview.33 -> 3.0.0-preview.34
* [`3872fa98`](https://github.com/NixOS/nixpkgs/commit/3872fa981452040e37564a056deb311641998a55) iwqr: init at 0.1.1
* [`57861b15`](https://github.com/NixOS/nixpkgs/commit/57861b1528791b060812eac6dd62cd916c2bf33b) wget: fix build on sandboxed Darwin
* [`50b9f412`](https://github.com/NixOS/nixpkgs/commit/50b9f412af62e081ed95150b9831f1d65bfcbaf7) hydrus: use the native test runner
* [`5c558d31`](https://github.com/NixOS/nixpkgs/commit/5c558d31ec081ae70be3bd96efae84580feee954) ogre: 14.2.6 -> 14.3.0
* [`b0b4b0e1`](https://github.com/NixOS/nixpkgs/commit/b0b4b0e15f150a988c0932c887cb9e456064d696) ncmpcpp: 0.9.2 -> 0.10
* [`0fc790f4`](https://github.com/NixOS/nixpkgs/commit/0fc790f4ccd227e67ad2b8df9ecd53e54ce48957) neovim.tests: minor improvements
* [`c4639f8c`](https://github.com/NixOS/nixpkgs/commit/c4639f8cbc4e4a1852a2d462ce949fab9bf66d7e) python27Packages.more-itertools: use `unittestCheckHook`
* [`6ae535b3`](https://github.com/NixOS/nixpkgs/commit/6ae535b3a6972d7b37a7878dd9adb98125fcd51e) astartectl: 24.5.0 -> 24.5.2
* [`17ddf8b3`](https://github.com/NixOS/nixpkgs/commit/17ddf8b3fc50386a26bab5e1ff33c55c605a46af) arkade: 0.11.24 -> 0.11.26
* [`d4c147cb`](https://github.com/NixOS/nixpkgs/commit/d4c147cb9747c5b1801f2bd3a6b30f6855d1197e) yandex-music: 5.15.0 -> 5.18.2
* [`dfb203e2`](https://github.com/NixOS/nixpkgs/commit/dfb203e2cd5c06bf50fbf310de62649c81cdc9e1) balena-cli: 19.0.3 -> 19.0.12
* [`bc843a95`](https://github.com/NixOS/nixpkgs/commit/bc843a95dd0d77c846e86e4eb2d22f03f2aa3aec) spicy-parser-generator: 1.11.1 -> 1.11.2
* [`f80a5b1d`](https://github.com/NixOS/nixpkgs/commit/f80a5b1d94fa1874acbf5b94acd73f7128151252) git-town: 16.1.1 -> 16.2.1
* [`08981710`](https://github.com/NixOS/nixpkgs/commit/089817100165a606256570a87feb1401ee7d0f4b) blockbench: 4.10.4 -> 4.11.0
* [`c2393231`](https://github.com/NixOS/nixpkgs/commit/c2393231eb9d0d8aadc6dc5a18147f396526b39b) cargo-temp: 0.2.21 -> 0.2.22
* [`17a50105`](https://github.com/NixOS/nixpkgs/commit/17a50105fb0541ae9bfa77efa2557a3b6977aab8) compose2nix: 0.2.2 -> 0.2.3
* [`64063ac4`](https://github.com/NixOS/nixpkgs/commit/64063ac42f7251f286c65364d68504adf5b5bd1f) maintainers: add beviu
* [`d8eefe56`](https://github.com/NixOS/nixpkgs/commit/d8eefe56554757212964be878e5568d6d33aca1b) autologin: init at 1.0.0
* [`124c7e94`](https://github.com/NixOS/nixpkgs/commit/124c7e945bf378487b9bc08751b65b5f113d9a18) xpipe: 11.2 -> 11.3
* [`7d7b6622`](https://github.com/NixOS/nixpkgs/commit/7d7b6622fd63418bf4791a9815c29192fb60bedc) gitlab-ci-ls: 0.21.1 -> 0.21.2
* [`2fcf8787`](https://github.com/NixOS/nixpkgs/commit/2fcf878726c627ec8d487c0cf5f432167156648d) libraqm: 0.10.1 -> 0.10.2
* [`b050d149`](https://github.com/NixOS/nixpkgs/commit/b050d14946c0de493562f9bde8dc19995591e89e) noson: 5.6.7 -> 5.6.8
* [`162631be`](https://github.com/NixOS/nixpkgs/commit/162631be2b7a5cd8a2d1d54cc1f0e51d49074ab5) uiua: 0.12.3 -> 0.13.0-dev.1
* [`ef9fc985`](https://github.com/NixOS/nixpkgs/commit/ef9fc9852789b388ff79b161fd180539c923c639) ananicy-rules-cachyos: 0-unstable-2024-08-26 -> 0-unstable-2024-09-18
* [`bacc816c`](https://github.com/NixOS/nixpkgs/commit/bacc816cb0100c304b285b43d6cab0bd62a6bd6d) mailmap: remap cafkafk
* [`3a9977f9`](https://github.com/NixOS/nixpkgs/commit/3a9977f9ac7d93673bb9bdd8578a6f72ea3a97b6) maintainers: add mithicspirit
* [`f11759d4`](https://github.com/NixOS/nixpkgs/commit/f11759d46f187f89c046dc478fccc04782071e83) autotrash: include manpage
* [`afeb3ec1`](https://github.com/NixOS/nixpkgs/commit/afeb3ec1dba10c9cf3c63d80c09bb1199804e778) rabtap: 1.42 -> 1.43
* [`4820dbad`](https://github.com/NixOS/nixpkgs/commit/4820dbad9c089c8c7a14b4346ca3df1c3d762f6a) revive: 1.3.9 -> 1.4.0
* [`e69b0ef6`](https://github.com/NixOS/nixpkgs/commit/e69b0ef60eacae43e8d8963561057798a0b44d2e) qrtool: 0.11.4 -> 0.11.5
* [`491e455c`](https://github.com/NixOS/nixpkgs/commit/491e455c5173ed2ffface5e2d8a1c6398e5a13d1) shadowsocks-rust: 1.20.4 -> 1.21.0
* [`4032dfb9`](https://github.com/NixOS/nixpkgs/commit/4032dfb9355e639165fce999dd878ed379e0074c) tagparser: 12.3.0 -> 12.3.1
* [`88635b9e`](https://github.com/NixOS/nixpkgs/commit/88635b9e19bced2e2d0a678b7808fb04bce84fea) kubernetes-helmPlugins.helm-diff: 3.9.10 -> 3.9.11
* [`a13a8072`](https://github.com/NixOS/nixpkgs/commit/a13a80723e5cc52e0731ae3d625d17b642c404c5) deepin.dde-launchpad; 0.8.4 -> 1.0.2
* [`3fb1abdf`](https://github.com/NixOS/nixpkgs/commit/3fb1abdf84cf7f4c9ffcfea50151e9807368276d) deepin.deepin-editor: 6.5.0 -> 6.5.2
* [`01a5ae81`](https://github.com/NixOS/nixpkgs/commit/01a5ae814a7415b6250ee31724b303da8ea13c40) deepin.dde-control-center: 6.0.59 -> 6.0.65
* [`3a0cc443`](https://github.com/NixOS/nixpkgs/commit/3a0cc443ac9ff34b3b7a5d2b2ea02dfefa20495a) deepin.dde-network-core: 2.0.32 -> 2.0.34
* [`82d54806`](https://github.com/NixOS/nixpkgs/commit/82d54806df5ae0ff3f3eed435658b79968a67b0c) avro-tools: modernized derivation and formatted via nixfmt-rfc-style
* [`f4c57be8`](https://github.com/NixOS/nixpkgs/commit/f4c57be80a911fdcd98f9dc823d93fc06c9deb7a) httpie-desktop: add missing desktop entry
* [`cc07df2d`](https://github.com/NixOS/nixpkgs/commit/cc07df2d282e4565a94bf14d4c4351151250a704) avro-tools: moved to by-name
* [`74104294`](https://github.com/NixOS/nixpkgs/commit/74104294d028556bb3866425a603a0c2a732ad3d) dbeaver-bin: 24.2.0 -> 24.2.1
* [`f5d0813b`](https://github.com/NixOS/nixpkgs/commit/f5d0813bbd62fdaa99e7bdca76efe2d64a42d4d3) oh-my-posh: 23.12.0 -> 23.14.1
* [`647e5c3a`](https://github.com/NixOS/nixpkgs/commit/647e5c3a3a45f4932d1f244b070510c49a040e5b) renpy: 8.2.1 -> 8.3.2
* [`8658b1b6`](https://github.com/NixOS/nixpkgs/commit/8658b1b6481baa7eda843cfd6d48d65327d3330d) appimage-run: Add libsecret for bitwarden
* [`4ed45e09`](https://github.com/NixOS/nixpkgs/commit/4ed45e0921f8abefaacae58cbb6f9bb0667320be) aliae: remove static_build
* [`5f7485a9`](https://github.com/NixOS/nixpkgs/commit/5f7485a989f9f763f1ccdc2f4fa07c9261a4be21) zsh-wd: 0.8.0 -> 0.9.0
* [`f53c6bee`](https://github.com/NixOS/nixpkgs/commit/f53c6bee84870ce5c47bf9789a71ff93f8655981) saunafs: 4.5.0 -> 4.5.1
* [`e4a3cac4`](https://github.com/NixOS/nixpkgs/commit/e4a3cac40c16be2cb6926443811ce15ce66919dd) bloaty: 1.1-unstable-2023-11-06 -> 1.1-unstable-2024-09-23
* [`dc4a4b2a`](https://github.com/NixOS/nixpkgs/commit/dc4a4b2ad0e7ad11a4a969d65ce9ced5f1fa2b03) bloaty: moved to by-name
* [`c58dd962`](https://github.com/NixOS/nixpkgs/commit/c58dd96276b0c99c6b426aaa7820799d5fc4bb13) python312Packages.aioautomower: 2024.9.0 -> 2024.9.1
* [`56f8f810`](https://github.com/NixOS/nixpkgs/commit/56f8f810aeedd2b03c4bc390f714875fe522e93a) nixos/veilid: fix description link
* [`77c46bd1`](https://github.com/NixOS/nixpkgs/commit/77c46bd124aae84880fcd5a56e0cc9b86547cc95) python312Packages.unstructured: 0.15.10 -> 0.15.13
* [`7a3290b8`](https://github.com/NixOS/nixpkgs/commit/7a3290b85e5cb13adfc56679ed5b9b1e82003c89) ejs: 3.1.9 -> 3.1.10
* [`5e6bd6eb`](https://github.com/NixOS/nixpkgs/commit/5e6bd6eb1d3e3075942f3a0973245a821c98b2bb) ocamlPackages.angstrom: 0.16.0 → 0.16.1
* [`fa12063f`](https://github.com/NixOS/nixpkgs/commit/fa12063f122652e90bb617ce3c84d4762e342152) ocamlPackages.ocamlbuild: use version 0.14.3 with OCaml 4.07
* [`8c7e7bed`](https://github.com/NixOS/nixpkgs/commit/8c7e7bed25939ce429920ecbfa835a7483680063) vscode-extensions.RoweWilsonFrederiskHolme.wikitext: 3.8.1 -> 3.8.2
* [`f55aee66`](https://github.com/NixOS/nixpkgs/commit/f55aee66316a6215d7ae8cda7ae325d6783e2aaf) python312Packages.meteoswiss-async: init at 0.1.1
* [`b0da153b`](https://github.com/NixOS/nixpkgs/commit/b0da153b6cf1d8dddf4a63d6ad0f353c78071dd2) python312Packages.weheat: 2024.09.10 -> 2024.09.23
* [`7198878c`](https://github.com/NixOS/nixpkgs/commit/7198878c8064fff05f8fe7132d0da470057b67f4) ldeep: 1.0.65 -> 1.0.66
* [`c0d12c19`](https://github.com/NixOS/nixpkgs/commit/c0d12c19cb8aaef9c9a99a69995a919426472fcc) python312Packages.publicsuffixlist: 1.0.2.20240918 -> 1.0.2.20240920
* [`51fe0368`](https://github.com/NixOS/nixpkgs/commit/51fe0368e9ab6cf7cf0a017c012896f27ada0ab6) python312Packages.ufmt: 2.7.2 -> 2.7.3
* [`3e98e7e2`](https://github.com/NixOS/nixpkgs/commit/3e98e7e2ae99592b2f3f147c10c9bc3648c61e4e) python312Packages.slack-sdk: 3.33.0 -> 3.33.1
* [`92613243`](https://github.com/NixOS/nixpkgs/commit/926132437254bc44c56c9b2eee1d129876c537f7) python312Packages.restfly: 1.4.7 -> 1.5.0
* [`0010d951`](https://github.com/NixOS/nixpkgs/commit/0010d951740bc74e6ab4c2f8a26c87ea9f2dd786) boilr: run nixfmt
* [`58923b79`](https://github.com/NixOS/nixpkgs/commit/58923b792c967ee1f738f2bdfbd346d03fa3f1f0) minio-client: 2024-09-09T07-53-10Z -> 2024-09-16T17-43-14Z
* [`15d09a0b`](https://github.com/NixOS/nixpkgs/commit/15d09a0b05dd7be4f9817c785bf4566e7bcbfe68) aws-sam-cli: disable flaky test and add missing input
* [`59d2f50a`](https://github.com/NixOS/nixpkgs/commit/59d2f50afc1d3f30560587dc1894137bdc51f445) aws-sam-cli: update formatting
* [`be138083`](https://github.com/NixOS/nixpkgs/commit/be138083315257507575b68b3941bc6b70e5a832) uwsm: 0.19.0 -> 0.19.1
* [`a0a0b4d6`](https://github.com/NixOS/nixpkgs/commit/a0a0b4d63bdc89990c7009dc6b0beb5ee36efe6b) rustdesk-flutter: add missing libayatana-appindicator patch ([nixos/nixpkgs⁠#343742](https://togithub.com/nixos/nixpkgs/issues/343742))
* [`bcc5fe1d`](https://github.com/NixOS/nixpkgs/commit/bcc5fe1d8ca688534183e5030f8a96eaa391ac17) nixos/firefox: add autoConfigFiles
* [`4360c170`](https://github.com/NixOS/nixpkgs/commit/4360c170f39a0db9d5819c48a7cc08966b95dae0) nixos/firefox: add linsui as maintainer
* [`ac3e0dba`](https://github.com/NixOS/nixpkgs/commit/ac3e0dba12443934b0ae18333dfd1aac25145de3) nixos/firefox: format
* [`5a44a67c`](https://github.com/NixOS/nixpkgs/commit/5a44a67c873775af1a37ad1edf3d9e9397e65568) boilr: fix build
* [`d533a821`](https://github.com/NixOS/nixpkgs/commit/d533a821bccde13307dadb97e2987a2447669b6f) gpxsee: 13.24 -> 13.26
* [`3bcaabbb`](https://github.com/NixOS/nixpkgs/commit/3bcaabbb7119cb06f7f79770baf2e11ad293955c) build-support/php: fix comments in multi-lines command
* [`07e6929c`](https://github.com/NixOS/nixpkgs/commit/07e6929c812d6df226b0f326178f15e93aba1a33) build-support/php: fix environment variables for Composer
* [`de112a50`](https://github.com/NixOS/nixpkgs/commit/de112a504fd76ce0783ef4da54efb92a0970f57b) python3Packages.morecantile: 5.3.0 -> 5.4.2
* [`55c48074`](https://github.com/NixOS/nixpkgs/commit/55c480745bb93b67792eeeb5669935e15c6999f3) python3Packages.morecantile: disable one failing test for darwin
* [`94d0d228`](https://github.com/NixOS/nixpkgs/commit/94d0d228173faff39670bc1157ddba8e56012a8d) ocamlPackages.elpi: use release tarball ([nixos/nixpkgs⁠#343266](https://togithub.com/nixos/nixpkgs/issues/343266))
* [`5ca6aa40`](https://github.com/NixOS/nixpkgs/commit/5ca6aa4004d944387e7580060342d4954e1bfddf) python312Packages.numpyro: switch to fetchFromGitHub
* [`33278de0`](https://github.com/NixOS/nixpkgs/commit/33278de087b75243bd6e7480bcd622a2c5279201) python312Packages.numpyro: disable failing test on darwin
* [`809f17bc`](https://github.com/NixOS/nixpkgs/commit/809f17bc7660ff411dbe12ee4855eeb6155b9d14) mpvScripts.dynamic-crop: 0-unstable-2024-06-22 -> 0-unstable-2024-09-14
* [`02b5f869`](https://github.com/NixOS/nixpkgs/commit/02b5f869e28b7f179f2fcecc12b1896ab978f090) cargo-show-asm: 0.2.38 -> 0.2.39
* [`72afec8d`](https://github.com/NixOS/nixpkgs/commit/72afec8da6ab11989823073f01261a445fc5b2ec) plplot: nixfmt
* [`a50b031b`](https://github.com/NixOS/nixpkgs/commit/a50b031b1e1d04f9a73ed3ffe99a1dd48c4eb416) plplot: compile optional png support
* [`15bc2e3a`](https://github.com/NixOS/nixpkgs/commit/15bc2e3a26b078525ffae17ce90f16d9fe651288) gaugePlugins.dotnet: 0.6.0 -> 0.7.0
* [`76d0095d`](https://github.com/NixOS/nixpkgs/commit/76d0095d769058f4c4f5ff422013ba856a21ac18) vscode-extensions.apollographql.vscode-apollo: 2.2.0 -> 2.3.2
* [`c52ee7dc`](https://github.com/NixOS/nixpkgs/commit/c52ee7dcd06117cfc8f8e964fdc31ad30a0bd2bc) vscode-extensions.davidanson.vscode-markdownlint: 0.55.0 -> 0.56.0
* [`0556c426`](https://github.com/NixOS/nixpkgs/commit/0556c426ff33a3c26bafcf68291a1a9f09e4090b) nixos/pretix: fix database.host option type ([nixos/nixpkgs⁠#343917](https://togithub.com/nixos/nixpkgs/issues/343917))
* [`bdc85ba4`](https://github.com/NixOS/nixpkgs/commit/bdc85ba41a58091ce5e6d3349bb8f37104ff3457) git-repo: 2.46 -> 2.47
* [`97c17485`](https://github.com/NixOS/nixpkgs/commit/97c17485d96fbb391f693f9d0029ca33f35c19c7) flexget: 3.11.45 -> 3.11.46
* [`95f5cf75`](https://github.com/NixOS/nixpkgs/commit/95f5cf75d37fd6b437df35b6a48c5cd04053fbf0) build-support/php: fix typo
* [`40084740`](https://github.com/NixOS/nixpkgs/commit/40084740564879baf7b65db5297074a91769fc08) thunderbird-unwrapped: 128.1.1esr -> 128.2.3esr
* [`d03e2a74`](https://github.com/NixOS/nixpkgs/commit/d03e2a74e3c68c31aa4b5fba31455aedf9f6c0fe) backdown: 1.1.1 -> 1.1.2
* [`6e4d0242`](https://github.com/NixOS/nixpkgs/commit/6e4d0242b0e79797bfaacd79d962bdb36ef3194f) mdbook-mermaid: 0.13.0 -> 0.14.0
* [`a133f3bc`](https://github.com/NixOS/nixpkgs/commit/a133f3bcb5d18840ff9fa09bf8636f719e8919b8) swift-quit: init at 1.5
* [`0c241853`](https://github.com/NixOS/nixpkgs/commit/0c24185366f374fcf805844857127c2867c32c56) nixos: set system.stateVersion from the nixpkgs release, not version
* [`0d4bfb52`](https://github.com/NixOS/nixpkgs/commit/0d4bfb52fb9eb80b1c762dac9037655626b00877) macchina: 6.1.8 -> 6.2.1
* [`c65e2f7d`](https://github.com/NixOS/nixpkgs/commit/c65e2f7d280cd3ba934bb899a4869f31d7426fa6) easytier: init at 1.2.3
* [`87c0458c`](https://github.com/NixOS/nixpkgs/commit/87c0458c4aabb6ff1c18162be0e16f5c42a2b3cb) python312Packages.xmlschema: 3.4.1 -> 3.4.2
* [`ed9eb1f2`](https://github.com/NixOS/nixpkgs/commit/ed9eb1f244e7ab72707e4ff9b690008cff19bf2a) docker-buildx: 0.17.0 -> 0.17.1
* [`4513ea8c`](https://github.com/NixOS/nixpkgs/commit/4513ea8cb0dd96b4d1b79f01963a5f76c8da51d2) ignite-cli: 28.5.2 -> 28.5.3
* [`c02bc173`](https://github.com/NixOS/nixpkgs/commit/c02bc17349cdde0cde05bedd30e631249203e6a0) coqPackages.simple-io: 1.8.0 → 1.10.0
* [`79d3272c`](https://github.com/NixOS/nixpkgs/commit/79d3272c536a6f9c9ce7c85383e917db1030be7e) coqPackages.QuickChick: 2.0.2 → 2.0.4
* [`93d8ee1b`](https://github.com/NixOS/nixpkgs/commit/93d8ee1b678d696130c55b6763514aa7c30b35c3) credhub-cli: 2.9.37 -> 2.9.38
* [`13935f9f`](https://github.com/NixOS/nixpkgs/commit/13935f9ffd328a6399de738ef7ad2d044ef68cec) moar: 1.27.0 -> 1.27.2
* [`0699fe69`](https://github.com/NixOS/nixpkgs/commit/0699fe6957b4e74b6f5dd98e709efc4db0ad2c94) pokeget-rs: 1.6.2 -> 1.6.3
* [`52779a7b`](https://github.com/NixOS/nixpkgs/commit/52779a7b780c562d2c4483d5220de0398a593009) firefly-iii-data-importer: 1.5.5 -> 1.5.6
* [`28306a72`](https://github.com/NixOS/nixpkgs/commit/28306a729a1e99e7f5c41772a371e865917297e0) snipe-it: 7.0.11 -> 7.0.12
* [`9601fce1`](https://github.com/NixOS/nixpkgs/commit/9601fce1d14317e3767453c3296516f95e67900f) python312Packages.asteval: 1.0.3 -> 1.0.4
* [`31ce1ce9`](https://github.com/NixOS/nixpkgs/commit/31ce1ce97f73495185c5cdeca6dcf1a4e3c7d725) docker-compose: 2.29.3 -> 2.29.7
* [`28b2fdd2`](https://github.com/NixOS/nixpkgs/commit/28b2fdd261e8071e24f90e21361f8ba508ef3617) mountpoint-s3: 1.9.0 -> 1.9.1
* [`f533b790`](https://github.com/NixOS/nixpkgs/commit/f533b790e7d3110258c39d113ee2b17193d8a4fd) gqlgenc: 0.25.0 -> 0.25.1
* [`0ed28543`](https://github.com/NixOS/nixpkgs/commit/0ed2854362b7a593fa7c6ece69c12fde392b2a32) vimPlugins.render-markdown-nvim: add nvim-treesitter dependency
* [`0fb7a292`](https://github.com/NixOS/nixpkgs/commit/0fb7a292e3567887410a5968b5ab2cc8ecaf9524) minio: 2024-09-09T16-59-28Z -> 2024-09-13T20-26-02Z
* [`400a39ab`](https://github.com/NixOS/nixpkgs/commit/400a39abec93a886d66da3db8e59145b65582a85) thumbdrives: add Luflosi as maintainer
* [`f2000aea`](https://github.com/NixOS/nixpkgs/commit/f2000aea8588a109e76efdec26e1ec51bee3417a) thumbdrives: migrate to pkgs/by-name, format with nixfmt-rfc-style
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
