### PR TITLE
niv emacs-overlay: update 6bbe8973 -> 6fa58edd

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "6bbe8973c0a99ebb54175310f20a0d255f688f90",
-        "sha256": "0ilppv5p05pw8jfs8lxggyy65vfh39bvsixvq8k9fd3md4flw1jl",
+        "rev": "6fa58edd58a554fb75fe1b430adefabf50ade53a",
+        "sha256": "06n1n5p54h06jjzfva3ksx97sk931m6q2czhswp386m1sg33capr",
         "type": "tarball",
-        "url": "https://github.com/nix-community/emacs-overlay/archive/6bbe8973c0a99ebb54175310f20a0d255f688f90.tar.gz",
+        "url": "https://github.com/nix-community/emacs-overlay/archive/6fa58edd58a554fb75fe1b430adefabf50ade53a.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "fast-syntax-highlighting": {


### PR DESCRIPTION
## Changelog for emacs-overlay:
Branch: master
Commits: [nix-community/emacs-overlay@6bbe8973...6fa58edd](https://github.com/nix-community/emacs-overlay/compare/6bbe8973c0a99ebb54175310f20a0d255f688f90...6fa58edd58a554fb75fe1b430adefabf50ade53a)

* [`094a1aa7`](https://github.com/nix-community/emacs-overlay/commit/094a1aa79b08bfae06f5abfdaa5b126735b0f7a4) Updated nongnu
* [`22d7f296`](https://github.com/nix-community/emacs-overlay/commit/22d7f296028354d7b3d485940f90a6b2b94d8bdd) Updated elpa
* [`7281c8b0`](https://github.com/nix-community/emacs-overlay/commit/7281c8b0dd831fad24e4ee551e8d911dcad46a6d) Updated melpa
* [`d1f6dc57`](https://github.com/nix-community/emacs-overlay/commit/d1f6dc57f8ac04cafa2eb7926373a016b215e862) Updated emacs
* [`1ac2a8f8`](https://github.com/nix-community/emacs-overlay/commit/1ac2a8f8ba9d1cbe621d1890dce295716d603daf) Updated melpa
* [`2a601aa1`](https://github.com/nix-community/emacs-overlay/commit/2a601aa194ec5524490e682929e2be0949a127aa) Updated flake inputs
* [`c46c7af3`](https://github.com/nix-community/emacs-overlay/commit/c46c7af331e273e70e6cbd2874d965d1663c138d) Updated nongnu
* [`5bc13ad1`](https://github.com/nix-community/emacs-overlay/commit/5bc13ad142c177b92e4149e0ea00704aa239513e) Updated elpa
* [`ee905095`](https://github.com/nix-community/emacs-overlay/commit/ee9050954acd3cd7a0c7b5976f6645e43618c59d) Updated melpa
* [`71f5beaa`](https://github.com/nix-community/emacs-overlay/commit/71f5beaa73ce069d12da1c398ada6b31fc922978) Updated emacs
* [`69623562`](https://github.com/nix-community/emacs-overlay/commit/69623562bd8d8af6261775181609155032f52ab6) Updated nongnu
* [`cf12eee4`](https://github.com/nix-community/emacs-overlay/commit/cf12eee4a4a45b6a2e2af6dbf50963d7329c3a98) Updated elpa
* [`511d11f7`](https://github.com/nix-community/emacs-overlay/commit/511d11f7c95bf4576ad79879e7b3e71738f02d89) Updated melpa
* [`32f1e40c`](https://github.com/nix-community/emacs-overlay/commit/32f1e40cbf5c4866d2a2bf518b19fe0acf4c892e) Updated emacs
* [`2f7c7275`](https://github.com/nix-community/emacs-overlay/commit/2f7c7275d542f59760bd307e5805572cee65ae37) Updated melpa
* [`070df6b0`](https://github.com/nix-community/emacs-overlay/commit/070df6b044b05cd340491b0c088b3ebc27cd925b) Updated nongnu
* [`5a20ac36`](https://github.com/nix-community/emacs-overlay/commit/5a20ac36515bace80929c9246e69172359bfaca5) Updated elpa
* [`fa117fc7`](https://github.com/nix-community/emacs-overlay/commit/fa117fc7f6ad4f7466e305608c72688947da5b5d) Updated melpa
* [`f7376b27`](https://github.com/nix-community/emacs-overlay/commit/f7376b272eb8ec449942de8e16b9005a10eba2f2) Updated nongnu
* [`0df1b940`](https://github.com/nix-community/emacs-overlay/commit/0df1b9409ec2b9edd42493c9ce501d9ea065f666) Updated elpa
* [`dd0e413d`](https://github.com/nix-community/emacs-overlay/commit/dd0e413dfae595c2b7d328968ff016e6c71b1cea) Updated melpa
* [`dd2bea61`](https://github.com/nix-community/emacs-overlay/commit/dd2bea615a05ddba399f76115bd57037c38278a7) Updated emacs
* [`2ab55649`](https://github.com/nix-community/emacs-overlay/commit/2ab55649b8375215b978db50efc61064bd4efab8) Updated melpa
* [`3cd65b7f`](https://github.com/nix-community/emacs-overlay/commit/3cd65b7f3c1709933e1d01075108295304ac42bb) Updated elpa
* [`6b44e96a`](https://github.com/nix-community/emacs-overlay/commit/6b44e96a6506afd093cc60b39a2d98e6d74e3a2f) Updated melpa
* [`413638a2`](https://github.com/nix-community/emacs-overlay/commit/413638a23d44398a47a5d7a14245018913086791) Updated nongnu
* [`f97c7407`](https://github.com/nix-community/emacs-overlay/commit/f97c7407d4479ef281fa923d6f1bcbe71636eb3a) Updated elpa
* [`383c387b`](https://github.com/nix-community/emacs-overlay/commit/383c387b3c864d5d28e017c1e0ad6f5d47e53610) Updated melpa
* [`caa97943`](https://github.com/nix-community/emacs-overlay/commit/caa979438d279b0daf0e0aee38e5102f5d40ace2) Updated melpa
* [`d9a26422`](https://github.com/nix-community/emacs-overlay/commit/d9a2642269cf8a4b145d98906fb5b7a1b4bdeb41) Updated nongnu
* [`04c4b688`](https://github.com/nix-community/emacs-overlay/commit/04c4b6880dac53c766c3dd9c42f54d76171b7f93) Updated elpa
* [`8d081308`](https://github.com/nix-community/emacs-overlay/commit/8d081308bf9c1bc53e77be677e28767f7df7cdd0) Updated melpa
* [`8a94f9d5`](https://github.com/nix-community/emacs-overlay/commit/8a94f9d557f3f8b372f03f18b2e1be3820d7da7f) Updated emacs
* [`addae6a4`](https://github.com/nix-community/emacs-overlay/commit/addae6a4735e5312c0d23850a560749c19b6d40b) Updated nongnu
* [`321ab388`](https://github.com/nix-community/emacs-overlay/commit/321ab388f2bf1e9efc8fd729d96f270905addbfa) Updated elpa
* [`db23857d`](https://github.com/nix-community/emacs-overlay/commit/db23857d4148f49e20bbd76e01fe623564a8ccd2) Updated melpa
* [`355ea2b7`](https://github.com/nix-community/emacs-overlay/commit/355ea2b7b3a317f9082b30f4d43cc5bee63141f2) Updated emacs
* [`52dfbf0d`](https://github.com/nix-community/emacs-overlay/commit/52dfbf0d625cc1e2765fe2bd9ecc8602b8d36943) Updated flake inputs
* [`a59c0c3e`](https://github.com/nix-community/emacs-overlay/commit/a59c0c3e6b482b938b3b5b4a3116d308c40489a7) Updated melpa
* [`fd627331`](https://github.com/nix-community/emacs-overlay/commit/fd627331988189a021b2d766f8699c91a6eb79fa) Updated emacs
* [`9cec4279`](https://github.com/nix-community/emacs-overlay/commit/9cec427916653a42b96e1b81c642bc9cbee64ce6) Updated flake inputs
* [`317d03dc`](https://github.com/nix-community/emacs-overlay/commit/317d03dca082b3bf2d563e098454c077a19cc82a) Updated nongnu
* [`0f3c92cd`](https://github.com/nix-community/emacs-overlay/commit/0f3c92cdcfc668cbb77fd6295067b2d7c0c1aacf) Updated elpa
* [`30226406`](https://github.com/nix-community/emacs-overlay/commit/302264062ca73851e9306b70daeed6d9f1ae3ff9) Updated melpa
* [`cbaf1ccd`](https://github.com/nix-community/emacs-overlay/commit/cbaf1ccd4b174b668b02aba608784622148af851) Updated nongnu
* [`e2835191`](https://github.com/nix-community/emacs-overlay/commit/e283519130da7542a91b15200e216914399a578b) Updated elpa
* [`d2e8a913`](https://github.com/nix-community/emacs-overlay/commit/d2e8a913f490f0022b9fe9c54e419e3ab134687c) Updated melpa
* [`66dea328`](https://github.com/nix-community/emacs-overlay/commit/66dea328d8d93c607542662d0d110c6ccbd6dc3b) Updated melpa
* [`5d87c639`](https://github.com/nix-community/emacs-overlay/commit/5d87c6391f09134b214a85eb3b28ecbebbad7269) Updated emacs
* [`3120dc57`](https://github.com/nix-community/emacs-overlay/commit/3120dc5731726648881557bcf96c232ed7091c29) Updated elpa
* [`f5ad3310`](https://github.com/nix-community/emacs-overlay/commit/f5ad33100d118b07d9db1c52eeda075714cd3546) Updated melpa
* [`b4d9deeb`](https://github.com/nix-community/emacs-overlay/commit/b4d9deebfbb2010f14e854659f177a4b35e0a531) Updated emacs
* [`57727ef4`](https://github.com/nix-community/emacs-overlay/commit/57727ef448f4d57119a708b7d4efc43206620c27) Updated nongnu
* [`74354374`](https://github.com/nix-community/emacs-overlay/commit/7435437499a03d11725b35a2910088a75ad7cc54) Updated elpa
* [`127ea0a2`](https://github.com/nix-community/emacs-overlay/commit/127ea0a204ce87110d625a28c59a46708b6684e0) Updated melpa
* [`0442d57f`](https://github.com/nix-community/emacs-overlay/commit/0442d57ffa83985ec2ffaec95db9c0fe742f5182) Updated emacs
* [`50213f88`](https://github.com/nix-community/emacs-overlay/commit/50213f8850b2ffff1b55f1a76ccf5fb30cd6ceae) Updated melpa
* [`c30396ae`](https://github.com/nix-community/emacs-overlay/commit/c30396aea8788285d904c765682411267c28dba1) Updated emacs
* [`365c341f`](https://github.com/nix-community/emacs-overlay/commit/365c341febef0299a4b6eec28531a7b3fd8ab31e) Updated flake inputs
* [`8654269d`](https://github.com/nix-community/emacs-overlay/commit/8654269dae3d0da13b1dfd116ec95d4f18bb1dec) Updated nongnu
* [`577b9b17`](https://github.com/nix-community/emacs-overlay/commit/577b9b17e392a1c5bd3f544d2a998539983cd3e7) Updated elpa
* [`5f9116c5`](https://github.com/nix-community/emacs-overlay/commit/5f9116c581e526bc3dc8dcc2097f9d7ce7d9bacd) Updated melpa
* [`4a8f0b4e`](https://github.com/nix-community/emacs-overlay/commit/4a8f0b4eaeede7d01c23e1a835828ef8f2153121) Updated emacs
* [`251542d3`](https://github.com/nix-community/emacs-overlay/commit/251542d3366092c757fd893bd5acbfcd0c365f15) Updated nongnu
* [`59da11db`](https://github.com/nix-community/emacs-overlay/commit/59da11dbaf2fc340a0a55a5fd6eb958871d14741) Updated elpa
* [`65237d41`](https://github.com/nix-community/emacs-overlay/commit/65237d41a4d8c37c2f3f44755cf736e132e0e478) Updated melpa
* [`6b349a3d`](https://github.com/nix-community/emacs-overlay/commit/6b349a3db196fdbc93a541b7ffd5454db0a0770b) Updated melpa
* [`6ab2b1aa`](https://github.com/nix-community/emacs-overlay/commit/6ab2b1aa86b3cde735a33d3670b5d2e2f288c4da) Updated emacs
* [`45fa743e`](https://github.com/nix-community/emacs-overlay/commit/45fa743e4e05bd70336f1f5cc445e23fdfb91c9e) Updated flake inputs
* [`4d36b9d0`](https://github.com/nix-community/emacs-overlay/commit/4d36b9d03b55cf1803f226784431f17be98849ea) Updated nongnu
* [`2b3f8efb`](https://github.com/nix-community/emacs-overlay/commit/2b3f8efbc54e1332d21b931778c98910bf4563fe) Updated elpa
* [`1c9e73b2`](https://github.com/nix-community/emacs-overlay/commit/1c9e73b2d45cb8f9f4b1e5458ba90419bfdc1bef) Updated melpa
* [`618b2f83`](https://github.com/nix-community/emacs-overlay/commit/618b2f8393cc31d275d5373febf017dc38a0f72f) Updated emacs
* [`1cbbff0e`](https://github.com/nix-community/emacs-overlay/commit/1cbbff0e12b6e68f22f434f8b5f8c35488347b58) Updated nongnu
* [`c1ce92f4`](https://github.com/nix-community/emacs-overlay/commit/c1ce92f405c758f856d7d107116d792bea4f8c3e) Updated elpa
* [`0206e7da`](https://github.com/nix-community/emacs-overlay/commit/0206e7da91cd13d356738410d656a9ba229c9661) Updated melpa
* [`0b13bb57`](https://github.com/nix-community/emacs-overlay/commit/0b13bb572b5495a3c8ebfb86defd4d6c5b71f001) Updated melpa
* [`2ad56b7a`](https://github.com/nix-community/emacs-overlay/commit/2ad56b7a43dd27e83a0f23d65962383130e5c5ae) Updated nongnu
* [`83c11329`](https://github.com/nix-community/emacs-overlay/commit/83c1132976e743743e4b757923eb9d252dd44e69) Updated elpa
* [`3a3004a9`](https://github.com/nix-community/emacs-overlay/commit/3a3004a9c55c1b0e6d2086293b1229542dd42a8e) Updated melpa
* [`9b03793f`](https://github.com/nix-community/emacs-overlay/commit/9b03793f7d6a2475d0e052aa65a49bbd01ec43e0) Updated emacs
* [`a5a2beb7`](https://github.com/nix-community/emacs-overlay/commit/a5a2beb73da66873e03b15b4559042061ca1a67d) Updated flake inputs
* [`04be97b0`](https://github.com/nix-community/emacs-overlay/commit/04be97b0996837f6f286f83e3c419ef3d24253a2) Updated nongnu
* [`6e18850d`](https://github.com/nix-community/emacs-overlay/commit/6e18850db152c6787f51fc0491a8019f9ff2f506) Updated elpa
* [`53a42024`](https://github.com/nix-community/emacs-overlay/commit/53a420244b5c84bd7cfebe53583dbd8b484caecd) Updated melpa
* [`bf4ae226`](https://github.com/nix-community/emacs-overlay/commit/bf4ae226fc2ca4d264fe4688004ffc1d00d2e7d8) Updated emacs
* [`1755605c`](https://github.com/nix-community/emacs-overlay/commit/1755605cfb8c01588f967db63061b259719bb62d) Updated melpa
* [`9c64b595`](https://github.com/nix-community/emacs-overlay/commit/9c64b595f3ba6670c7ac89d57e6822c0fce7d46e) Updated emacs
* [`4ea95bb2`](https://github.com/nix-community/emacs-overlay/commit/4ea95bb27d9ece5762980c9d64e0d6062dbefb5c) Updated nongnu
* [`90b45415`](https://github.com/nix-community/emacs-overlay/commit/90b45415f65c9403559c1e119bd7bb0709a417b9) Updated elpa
* [`4c55fe25`](https://github.com/nix-community/emacs-overlay/commit/4c55fe25e71211cf8fcd5b00ae54dec7471ed839) Updated melpa
* [`54aca77d`](https://github.com/nix-community/emacs-overlay/commit/54aca77d6292f4ad6619a7c59da1423253a902fb) Updated elpa
* [`94f05bf3`](https://github.com/nix-community/emacs-overlay/commit/94f05bf3834c7929b512753dc73602a6df770cf8) Updated emacs
* [`e13b089f`](https://github.com/nix-community/emacs-overlay/commit/e13b089fe1f8bb7aa6c7ac0bb6bb0f6612cf9f12) Updated melpa
* [`aa788863`](https://github.com/nix-community/emacs-overlay/commit/aa788863a1cb7fa28d4869097d83cf37603e3ae2) recipes-archive-melpa: fix incorrect source hash of geiser
* [`a4447c19`](https://github.com/nix-community/emacs-overlay/commit/a4447c19bd3bbdf9f89a40d9585156d0f39ee8b6) Updated melpa
* [`12e60221`](https://github.com/nix-community/emacs-overlay/commit/12e602219fc2ca3ca0f9a0fc9a7701853b7e3998) Updated emacs
* [`b51b85f5`](https://github.com/nix-community/emacs-overlay/commit/b51b85f50a3a4a1881f70ecb686dab03d6c052fc) Updated flake inputs
* [`a2574010`](https://github.com/nix-community/emacs-overlay/commit/a25740102b9c0c479f5e75cb0d215cd47fedc817) Updated nongnu
* [`38425b82`](https://github.com/nix-community/emacs-overlay/commit/38425b825b768b5282c1e6e2c2c7e237d69274f9) Updated elpa
* [`4567080e`](https://github.com/nix-community/emacs-overlay/commit/4567080e119f5d5c1695451c5620761c1cb2d0fe) Updated melpa
* [`ba0b7636`](https://github.com/nix-community/emacs-overlay/commit/ba0b7636b47b5423ec09f89bcba06aadb68a607d) Updated emacs
* [`d96fb46b`](https://github.com/nix-community/emacs-overlay/commit/d96fb46b9753b420df45c90382825f761667c0b8) Updated elpa
* [`6560f39f`](https://github.com/nix-community/emacs-overlay/commit/6560f39fd828385e72a931e0d567d97e203781d8) Updated nongnu
* [`397195d6`](https://github.com/nix-community/emacs-overlay/commit/397195d6c2b3480cf62e681163661aa536d2f64d) Updated emacs
* [`2978f49c`](https://github.com/nix-community/emacs-overlay/commit/2978f49cc9c67844c7921a9330655078e127243f) Updated melpa
* [`ca87a80a`](https://github.com/nix-community/emacs-overlay/commit/ca87a80a345390779e7353364f0d3f248d394e64) Updated melpa
* [`5788c866`](https://github.com/nix-community/emacs-overlay/commit/5788c86646c42ebce3d8731fccd4f973b530240b) Updated emacs
* [`1c6fc32e`](https://github.com/nix-community/emacs-overlay/commit/1c6fc32e67d8c6d9db88ea5df6545bf036bab1cb) Updated nongnu
* [`9c76d8bc`](https://github.com/nix-community/emacs-overlay/commit/9c76d8bc60fa77ccc8e60b50e371601c8394b7bd) Updated elpa
* [`2ae0aa81`](https://github.com/nix-community/emacs-overlay/commit/2ae0aa813a98a274610c5d70c47ecb7797ee855b) Updated melpa
* [`f587d924`](https://github.com/nix-community/emacs-overlay/commit/f587d92456e827b660a308a0dd632d3f6378f8cb) Updated emacs
* [`af6604a1`](https://github.com/nix-community/emacs-overlay/commit/af6604a12d45cc3cab125c846b730012624dc096) Updated nongnu
* [`73ac4908`](https://github.com/nix-community/emacs-overlay/commit/73ac490814b8f603709bbf67c5cc293f33519d32) Updated elpa
* [`c64b7d86`](https://github.com/nix-community/emacs-overlay/commit/c64b7d861f5ac2988eddae245e5f5c659866551c) Updated melpa
* [`f91cf70a`](https://github.com/nix-community/emacs-overlay/commit/f91cf70ac3a0698db119789cf00e8882bd69aec0) Updated emacs
* [`a6cb07e5`](https://github.com/nix-community/emacs-overlay/commit/a6cb07e5f45014d7fd42a9775a352901952c48ad) Updated melpa
* [`905565ae`](https://github.com/nix-community/emacs-overlay/commit/905565ae69b6928505945420f896fc1fc87f1de7) Updated flake inputs
* [`2ba1eaca`](https://github.com/nix-community/emacs-overlay/commit/2ba1eaca5b45d42bf17064b7c1547c95841e7350) Updated nongnu
* [`2c810d17`](https://github.com/nix-community/emacs-overlay/commit/2c810d178a64313231350a9bdd432c48cc6b7ba4) Updated elpa
* [`c4a2b881`](https://github.com/nix-community/emacs-overlay/commit/c4a2b8812949d2296ae977f7551fc441af21d9fe) Updated melpa
* [`1ac33e4b`](https://github.com/nix-community/emacs-overlay/commit/1ac33e4bb48fac2c3857a4190770f15ec1410556) Updated emacs
* [`33c94620`](https://github.com/nix-community/emacs-overlay/commit/33c94620b7c7ff5d27da7194d7acb17c18ead0be) Updated nongnu
* [`51deae12`](https://github.com/nix-community/emacs-overlay/commit/51deae12009b565764890da456a216347b2e38b0) Updated melpa
* [`795d5dc7`](https://github.com/nix-community/emacs-overlay/commit/795d5dc72088bd6c758826c56284b0024b045194) Updated emacs
* [`b624be8c`](https://github.com/nix-community/emacs-overlay/commit/b624be8c3791e08e036cdd5a069b045c188a1f77) Updated melpa
* [`c8644c5d`](https://github.com/nix-community/emacs-overlay/commit/c8644c5d59fee9a24a1be146bb6ce5b41d23592e) Updated emacs
* [`49bd32d8`](https://github.com/nix-community/emacs-overlay/commit/49bd32d814722af04c44539099af2aa100292bd5) Updated flake inputs
* [`90141bc4`](https://github.com/nix-community/emacs-overlay/commit/90141bc45541e1fef29b7258406a1a8ef8b223fc) Updated nongnu
* [`306230b5`](https://github.com/nix-community/emacs-overlay/commit/306230b5859861149b9fa6dbd987d41418507a7f) Updated elpa
* [`909372e5`](https://github.com/nix-community/emacs-overlay/commit/909372e5e86533aac5210403253a01f7ac54fc64) Updated melpa
* [`fa3ce462`](https://github.com/nix-community/emacs-overlay/commit/fa3ce46208f452a6ae30adf8f98e868871f4b463) Updated emacs
* [`fae7498c`](https://github.com/nix-community/emacs-overlay/commit/fae7498cd0cfa1854562c765c1af3a77922e2d33) Updated nongnu
* [`eb47ae00`](https://github.com/nix-community/emacs-overlay/commit/eb47ae00752b779354a04603b7945493f1164e09) Updated elpa
* [`c8dc302d`](https://github.com/nix-community/emacs-overlay/commit/c8dc302d516e0c94af66b9a1504f9b4d2433fe6c) Updated melpa
* [`a8a34f45`](https://github.com/nix-community/emacs-overlay/commit/a8a34f45a3db87fd82f307228c587c0eadbd4045) Updated emacs
* [`b7619a35`](https://github.com/nix-community/emacs-overlay/commit/b7619a354ed5c8991f3ef2bb537fb3340d27b424) Updated flake inputs
* [`2b8a4aea`](https://github.com/nix-community/emacs-overlay/commit/2b8a4aeadf19c702355559b02a1593c9d09b1546) Updated melpa
* [`ba3ebd47`](https://github.com/nix-community/emacs-overlay/commit/ba3ebd4737b74a32922091adfd51f6bb8c103099) Updated flake inputs
* [`2fd3ce66`](https://github.com/nix-community/emacs-overlay/commit/2fd3ce66218235e65c492287e8750770639cdd64) Updated nongnu
* [`d23ef878`](https://github.com/nix-community/emacs-overlay/commit/d23ef8783b70a40938b0c08942206ca817bc54e5) Updated elpa
* [`8cb3e3ef`](https://github.com/nix-community/emacs-overlay/commit/8cb3e3ef669e599ee2b5e127d4f5bd52d833f695) Updated melpa
* [`8da0dcb0`](https://github.com/nix-community/emacs-overlay/commit/8da0dcb09e0f890d2a9fbc8c6bb947c6867a5b5f) Updated emacs
* [`f861548d`](https://github.com/nix-community/emacs-overlay/commit/f861548dfdd6825fa3309eb705dcbc97a33e0b11) Updated nongnu
* [`b7aec685`](https://github.com/nix-community/emacs-overlay/commit/b7aec685e9d3c6866a451dee1fd72c6b17229e1a) Updated elpa
* [`5968833b`](https://github.com/nix-community/emacs-overlay/commit/5968833ba4a68d6eb7be4b900f79438d7d271bcb) Updated melpa
* [`1cd7f441`](https://github.com/nix-community/emacs-overlay/commit/1cd7f441f2124bf8c16e08a44544a8212f401cdd) Bump cachix/install-nix-action from V27 to 28
* [`f4acc62c`](https://github.com/nix-community/emacs-overlay/commit/f4acc62c00a67e5b71ce11e0ee2c3e1b3928c681) Updated melpa
* [`dc6aea77`](https://github.com/nix-community/emacs-overlay/commit/dc6aea77064dfd891e4e6e81241aa44dd1c4a3d1) Updated nongnu
* [`fdbd7ee6`](https://github.com/nix-community/emacs-overlay/commit/fdbd7ee60f0a58087a18642fee030b9d7975878a) Updated elpa
* [`e7cba6c2`](https://github.com/nix-community/emacs-overlay/commit/e7cba6c2c8ed404862ed6ba8c48e3f0fa5110ae5) Updated melpa
* [`9d338902`](https://github.com/nix-community/emacs-overlay/commit/9d338902d478ffba6a7dd0d9c2fb6151cb4b970a) Updated emacs
* [`fc8a199c`](https://github.com/nix-community/emacs-overlay/commit/fc8a199c482ba2f82a4e0742a099ba66a1ef9a23) Updated flake inputs
* [`a0de883e`](https://github.com/nix-community/emacs-overlay/commit/a0de883eab6ef8829182cea26db33e875113d480) Updated melpa
* [`efdb0ad8`](https://github.com/nix-community/emacs-overlay/commit/efdb0ad85219e9be1f77aaa3ca3085be8b130603) Updated emacs
* [`d6bf6cdb`](https://github.com/nix-community/emacs-overlay/commit/d6bf6cdb34b7e1acd2c3be4cf19b3f4be9ae0957) Updated flake inputs
* [`22c0b943`](https://github.com/nix-community/emacs-overlay/commit/22c0b943fd284157ce5db4420054f459c2890746) Updated elpa
* [`316e070e`](https://github.com/nix-community/emacs-overlay/commit/316e070ed90ff047b22220b25fc88edcca04ac8a) Updated nongnu
* [`ca4df3dd`](https://github.com/nix-community/emacs-overlay/commit/ca4df3dd54a346149cd98e1a0769d48aeb4bc312) Updated melpa
* [`851b8bf5`](https://github.com/nix-community/emacs-overlay/commit/851b8bf523a5a9974239ceebde31d1f310919ae0) Updated emacs
* [`889ac367`](https://github.com/nix-community/emacs-overlay/commit/889ac367e4e2c9f75f67bd4d1fe7c8626e4ceb60) Updated melpa
* [`7dc1c795`](https://github.com/nix-community/emacs-overlay/commit/7dc1c795e919fb76fa481874928c90b882fcf19b) Updated emacs
* [`9ea515ad`](https://github.com/nix-community/emacs-overlay/commit/9ea515ade059e43bdde6bbc51e1751a6b151dc0d) Updated nongnu
* [`8b34903f`](https://github.com/nix-community/emacs-overlay/commit/8b34903f77faba399b183bea8b1aac617ba84577) Updated elpa
* [`8ec18ddc`](https://github.com/nix-community/emacs-overlay/commit/8ec18ddcc6030e32fa5ab456891519061587511a) Updated melpa
* [`e303aa1d`](https://github.com/nix-community/emacs-overlay/commit/e303aa1dc000c07ee38a865bccb6e216fb5c1018) Updated emacs
* [`31123e4a`](https://github.com/nix-community/emacs-overlay/commit/31123e4ac96153cc40b322525d329f0c243f0df6) Updated nongnu
* [`3525a483`](https://github.com/nix-community/emacs-overlay/commit/3525a48361d4239c95b84d1912830a8f9feca301) Updated elpa
* [`5dee28c8`](https://github.com/nix-community/emacs-overlay/commit/5dee28c8080e1282dc2240fea689254708fc815f) Updated melpa
* [`d10ed46c`](https://github.com/nix-community/emacs-overlay/commit/d10ed46cb14c2d6083b3174b52a0c1fbdebe6746) Updated emacs
* [`1ccb8215`](https://github.com/nix-community/emacs-overlay/commit/1ccb8215ba633ad53a80e755c5724048792a4bb5) Updated nongnu
* [`e02f5006`](https://github.com/nix-community/emacs-overlay/commit/e02f50066958e7f447895fd812778a2d821e71e0) Updated elpa
* [`a1ca2766`](https://github.com/nix-community/emacs-overlay/commit/a1ca2766ae9535f16bcac91f7001d24a6837178b) Updated melpa
* [`4be8ac59`](https://github.com/nix-community/emacs-overlay/commit/4be8ac597719efc769ceb72fb2bca5206a860968) Updated nongnu
* [`a5a21cdc`](https://github.com/nix-community/emacs-overlay/commit/a5a21cdc6d37644b5c68a42343a196d02a30079f) Updated elpa
* [`042c271d`](https://github.com/nix-community/emacs-overlay/commit/042c271deb8be852b2e46b090d85a704ed0fdd6d) Updated melpa
* [`20a30547`](https://github.com/nix-community/emacs-overlay/commit/20a30547db333f132a20aa327b40351d1187a8d4) Updated emacs
* [`c64436a2`](https://github.com/nix-community/emacs-overlay/commit/c64436a2941e042e63c5efb5eab94a11a12ca5de) Updated melpa
* [`afcea8fc`](https://github.com/nix-community/emacs-overlay/commit/afcea8fca5ae2937d7a6fc019185730c4b387285) Updated flake inputs
* [`1b4645b0`](https://github.com/nix-community/emacs-overlay/commit/1b4645b0532c6f465d622ca5327db74d6e846b65) Updated nongnu
* [`75f79c95`](https://github.com/nix-community/emacs-overlay/commit/75f79c95b616bd894562e22a7bb8a8a68dd5dd9b) Updated elpa
* [`fa856306`](https://github.com/nix-community/emacs-overlay/commit/fa856306db1e44f99d5b1aebd6d1298439419918) Updated melpa
* [`5dc958d2`](https://github.com/nix-community/emacs-overlay/commit/5dc958d29c79253341fec0e37130041444d57f0c) Updated emacs
* [`e588118d`](https://github.com/nix-community/emacs-overlay/commit/e588118d85745bfabfd58aaeb400e3fe6c66daf1) Updated flake inputs
* [`ca2f88f4`](https://github.com/nix-community/emacs-overlay/commit/ca2f88f41141cac4d39e9f0b1d819807d19fcfdc) Updated flake inputs
* [`545d43be`](https://github.com/nix-community/emacs-overlay/commit/545d43beb336e58918c2a2aaf253f2be888108c9) Updated nongnu
* [`0229bbe8`](https://github.com/nix-community/emacs-overlay/commit/0229bbe8b5e1d9c6d7ade2f90bab122d0c96e976) Updated elpa
* [`eafa9726`](https://github.com/nix-community/emacs-overlay/commit/eafa97260a15887a0b77d984f6c75143273622b6) Updated nongnu
* [`2c5171a3`](https://github.com/nix-community/emacs-overlay/commit/2c5171a36fcd616753b204c34ef38bf7729825e2) Updated elpa
* [`0f4b4ef3`](https://github.com/nix-community/emacs-overlay/commit/0f4b4ef3ca6a3c6b7559e8987898b88fd3689135) Updated nongnu
* [`6ae6f2b1`](https://github.com/nix-community/emacs-overlay/commit/6ae6f2b182f996c14df856ddb8ec68269d04f403) Updated elpa
* [`25566cb2`](https://github.com/nix-community/emacs-overlay/commit/25566cb2d874171a6572b0675e734bd5366f76a7) Updated elpa
* [`b8a1f6f9`](https://github.com/nix-community/emacs-overlay/commit/b8a1f6f94a8947b5601ab7302ad7dc5a3fc45c26) Updated nongnu
* [`df4d0f85`](https://github.com/nix-community/emacs-overlay/commit/df4d0f85da9ac732d96eba5f2b15dab86d25a3ad) Updated flake inputs
* [`217992fe`](https://github.com/nix-community/emacs-overlay/commit/217992fe3eadc4771948900f31b6ef878e83d948) Updated nongnu
* [`01e2bfd5`](https://github.com/nix-community/emacs-overlay/commit/01e2bfd559a1d47c1dbc3da6103acb1821a6dff3) Updated elpa
* [`81a008d2`](https://github.com/nix-community/emacs-overlay/commit/81a008d2801c1120fad55d035fd7712fd30e24ee) Updated nongnu
* [`b3512b3d`](https://github.com/nix-community/emacs-overlay/commit/b3512b3df5396e17d9e89cadcc3f57db0ea1fecc) Updated elpa
* [`de632958`](https://github.com/nix-community/emacs-overlay/commit/de632958e0b70e263e6fd66ac858f21209a3700e) Updated nongnu
* [`dad75975`](https://github.com/nix-community/emacs-overlay/commit/dad75975b68c048a06524d8de47affef0b0d91d1) Updated elpa
* [`cd6999f7`](https://github.com/nix-community/emacs-overlay/commit/cd6999f7c2cdd81cf8cc0fb6c84f0fae394fc184) Updated nongnu
* [`6df42c7b`](https://github.com/nix-community/emacs-overlay/commit/6df42c7be622892e86d553a6dc815c48f1ac970e) Updated elpa
* [`017a3747`](https://github.com/nix-community/emacs-overlay/commit/017a3747a3fdd8430debd4e137df1cfabe67c0b6) Updated flake inputs
* [`51127344`](https://github.com/nix-community/emacs-overlay/commit/51127344bccf7358142bc9a00df256b5bfcac65d) Updated nongnu
* [`e81b6546`](https://github.com/nix-community/emacs-overlay/commit/e81b6546fb597e6204bd6ef1bd0e6d35d498be20) Updated elpa
* [`454ee959`](https://github.com/nix-community/emacs-overlay/commit/454ee959f279d57a4e75e1fdf909b4aad5a7a9e9) Updated nongnu
* [`d995ae78`](https://github.com/nix-community/emacs-overlay/commit/d995ae782711bd65ee738198242f4450e5339995) Updated elpa
* [`ad40c4b8`](https://github.com/nix-community/emacs-overlay/commit/ad40c4b881309a5a96029636c35cc42419d55ce7) Updated flake inputs
* [`ce4ed6b6`](https://github.com/nix-community/emacs-overlay/commit/ce4ed6b670743b22ae3816b24cd3e72818246aad) Disable webkit2gtk integration
* [`7a44cef5`](https://github.com/nix-community/emacs-overlay/commit/7a44cef5ba5e5c62660d33c9ac241bdeceb312d9) Updated nongnu
* [`ecba1d6b`](https://github.com/nix-community/emacs-overlay/commit/ecba1d6b464597b7e8a61461c0645b8fa5657945) Updated elpa
* [`c691136b`](https://github.com/nix-community/emacs-overlay/commit/c691136bcb2dd7486e6dae9eeb3f30c9c3a4bf98) Use bytecomp-revert.patch for unstable Emacsen
* [`71b91b97`](https://github.com/nix-community/emacs-overlay/commit/71b91b970975957c52f0c71d3e779e8e774e7df9) Updated nongnu
* [`72a7fec6`](https://github.com/nix-community/emacs-overlay/commit/72a7fec67842b9f3ef2bd07e4a9229736ed40952) Updated elpa
* [`2f92a704`](https://github.com/nix-community/emacs-overlay/commit/2f92a7048fc397e2e7bbadce11209c0dcf49a70d) Updated melpa
* [`e86adaf7`](https://github.com/nix-community/emacs-overlay/commit/e86adaf7da0f0186c8f21ccb61ff10880434436b) Updated emacs
* [`368359d0`](https://github.com/nix-community/emacs-overlay/commit/368359d0f3c9f4ee6ec9bfec2932b49d77d6233f) Cosmetics: remove <= 23.11 handholding
* [`fb01b36e`](https://github.com/nix-community/emacs-overlay/commit/fb01b36edc9a01291b48c33f0786e9bcf6e76d0d) Cosmetics: don't use lib.makeOverridable anymore
* [`2933ca78`](https://github.com/nix-community/emacs-overlay/commit/2933ca78e41dc52a149d66c97b46deda985bdad6) Cosmetics: don't specify defaults prescribed by nixpkgs
* [`e417bd7c`](https://github.com/nix-community/emacs-overlay/commit/e417bd7c85cebf56e6f8b5846f92de9432e4c4b7) Reapply "Use --replace-warn instead of --replace in substituteInPlace"
* [`a4ee09a7`](https://github.com/nix-community/emacs-overlay/commit/a4ee09a79bdebef57ee7b1b74586c6d1f438541a) Fix typo in name prefix for emacs-unstable-pgtk
* [`971818ce`](https://github.com/nix-community/emacs-overlay/commit/971818ced1e07091530eafe2a0d324913dacfabf) Fix incomplete rebase
* [`050a8222`](https://github.com/nix-community/emacs-overlay/commit/050a822282e4a922c58bb44b60fb28a372b2841c) Updated melpa
* [`616bb077`](https://github.com/nix-community/emacs-overlay/commit/616bb0773b238f89120fa07a38d19a55f04db90a) Updated emacs
* [`ecc8dff5`](https://github.com/nix-community/emacs-overlay/commit/ecc8dff54ca08415a4dc21f10d37f6c9ac620adf) Updated nongnu
* [`cbd5ad1b`](https://github.com/nix-community/emacs-overlay/commit/cbd5ad1b0cd6b709c5089c5778b449dcf2281d28) Updated elpa
* [`2508d6b7`](https://github.com/nix-community/emacs-overlay/commit/2508d6b78c40293a1e271feeccabe5d6a0be6ea5) Updated melpa
* [`c164c3ca`](https://github.com/nix-community/emacs-overlay/commit/c164c3ca326870be7534bdbeacf045d55941fa2c) Updated emacs
* [`bdd33a96`](https://github.com/nix-community/emacs-overlay/commit/bdd33a96dfff44e15d75c1f7a3c9c214639f63f4) Updated flake inputs
* [`259a74fe`](https://github.com/nix-community/emacs-overlay/commit/259a74fe865f70531a40737ad7fd20af78a0bc32) Updated nongnu
* [`73bcee30`](https://github.com/nix-community/emacs-overlay/commit/73bcee308cb94aa4d81a053ead98e5ad3e5d2560) Updated elpa
* [`a2be0e7c`](https://github.com/nix-community/emacs-overlay/commit/a2be0e7ce6f18ef41d7a535c34595e0e7945cd1a) Updated melpa
* [`e1ea487e`](https://github.com/nix-community/emacs-overlay/commit/e1ea487ee539e6afe98cd4067a02a723eb549c88) Updated emacs
* [`ebe44681`](https://github.com/nix-community/emacs-overlay/commit/ebe446814ae4356f21637db24f2fba41b571cd8e) remove: withGTK2, see [nix-community/emacs-overlay⁠#431](https://togithub.com/nix-community/emacs-overlay/issues/431)
* [`c8f9c557`](https://github.com/nix-community/emacs-overlay/commit/c8f9c557cc398c64bc8a9d9f90d968c55421098b) Updated melpa
* [`18c1571f`](https://github.com/nix-community/emacs-overlay/commit/18c1571fcb0025a04e58a75a1eeb42c44c63b3f4) Updated flake inputs
* [`2a5f35a4`](https://github.com/nix-community/emacs-overlay/commit/2a5f35a40e256cbb6c978e1485d82791d80084e7) Updated nongnu
* [`38c23655`](https://github.com/nix-community/emacs-overlay/commit/38c2365595da317ce6050052e5c04361a41504db) Updated elpa
* [`7bdbf964`](https://github.com/nix-community/emacs-overlay/commit/7bdbf964a126bc3c75aec5a46e7cd516f5423f12) Updated melpa
* [`77557b52`](https://github.com/nix-community/emacs-overlay/commit/77557b526c0d2c57747e44c8de7789f7a6fb741d) Updated emacs
* [`8667d33b`](https://github.com/nix-community/emacs-overlay/commit/8667d33b7cc10e71ae6e397418492bf9f7f77937) Updated flake inputs
* [`3d4ededb`](https://github.com/nix-community/emacs-overlay/commit/3d4ededb77d0881b0f98da524d6a6139d31ac0da) Updated nongnu
* [`5e84637f`](https://github.com/nix-community/emacs-overlay/commit/5e84637f4a6db092a29a720a761a54d2444738d5) Updated elpa
* [`e2b94255`](https://github.com/nix-community/emacs-overlay/commit/e2b94255408a9dea82dbe8021c266cd63a9308bc) Updated melpa
* [`4c0f8af2`](https://github.com/nix-community/emacs-overlay/commit/4c0f8af2d094676ffc5db297ffd705817596625f) Updated emacs
* [`faafff38`](https://github.com/nix-community/emacs-overlay/commit/faafff3802ebcfbb8c3534819933e07f41f7c52a) Updated nongnu
* [`4f3f9d45`](https://github.com/nix-community/emacs-overlay/commit/4f3f9d457e18ed904199492a0bad63ec422dd409) Updated elpa
* [`311c0e81`](https://github.com/nix-community/emacs-overlay/commit/311c0e81965ecd4cdc368aa38f821f4ffd1e657d) Updated emacs
* [`64b47fb0`](https://github.com/nix-community/emacs-overlay/commit/64b47fb02afc62dfc4e257d2bd843be75b8cf796) Updated nongnu
* [`619e3ff8`](https://github.com/nix-community/emacs-overlay/commit/619e3ff8298c76f2036b59d48d2dc3dfea3a6388) Updated elpa
* [`3e8cb7b3`](https://github.com/nix-community/emacs-overlay/commit/3e8cb7b37da4a86a1f640ef676f41c107290ac4e) Updated melpa
* [`9deee9cc`](https://github.com/nix-community/emacs-overlay/commit/9deee9ccee19d5300bc366c7d28c479777886273) Updated emacs
* [`c3531746`](https://github.com/nix-community/emacs-overlay/commit/c353174633294a1fd1a87f0b9e6cb77a25eb255a) Bump cachix/install-nix-action from V28 to 29
* [`55855cd2`](https://github.com/nix-community/emacs-overlay/commit/55855cd25344644121a9692f4ba59a980d91484d) Bump actions/checkout from 4.1.7 to 4.2.0
* [`6fa58edd`](https://github.com/nix-community/emacs-overlay/commit/6fa58edd58a554fb75fe1b430adefabf50ade53a) Updated flake inputs
