### PR TITLE
niv doomemacs: update c9acdb72 -> c8a5e6ec

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "doomemacs",
         "repo": "doomemacs",
-        "rev": "c9acdb72a4bd95d7ac38d62e92aa79f395c1dccd",
-        "sha256": "1vsrhb98dqnyk8dh8kczm4bk4778mpcrxrq7g06jhz9pq774pmhy",
+        "rev": "c8a5e6ec1ca85a35f94d6c820c2fd8888373c2ae",
+        "sha256": "08cwhfwg4apm7rxfhkadlif79maklmx4k1il4rixwlc9gdy422lb",
         "type": "tarball",
-        "url": "https://github.com/doomemacs/doomemacs/archive/c9acdb72a4bd95d7ac38d62e92aa79f395c1dccd.tar.gz",
+        "url": "https://github.com/doomemacs/doomemacs/archive/c8a5e6ec1ca85a35f94d6c820c2fd8888373c2ae.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "emacs-overlay": {


### PR DESCRIPTION
## Changelog for doomemacs:
Branch: master
Commits: [doomemacs/doomemacs@c9acdb72...c8a5e6ec](https://github.com/doomemacs/doomemacs/compare/c9acdb72a4bd95d7ac38d62e92aa79f395c1dccd...c8a5e6ec1ca85a35f94d6c820c2fd8888373c2ae)

* [`dd18fa16`](https://github.com/doomemacs/doomemacs/commit/dd18fa16be2348feb6c64d6bf5e7838bd0deeae0) feat(corfu): `both` option for RET behavior
* [`97690184`](https://github.com/doomemacs/doomemacs/commit/97690184afde83a7a0d4a28a688457208893b156) docs(corfu): `both` option for RET behavior
* [`affaa7ec`](https://github.com/doomemacs/doomemacs/commit/affaa7ec9ccb2e7f7ccb9ee77a7785728a650840) docs(ligature): use correct obsoleted-in version
* [`069ea9e0`](https://github.com/doomemacs/doomemacs/commit/069ea9e02fc9834b8ddcb5245bd5a087ad3caa21) fix(cli): straight: highlight 'Reset "*" to "*"' option
* [`a8f116bb`](https://github.com/doomemacs/doomemacs/commit/a8f116bb6b663dd3c19443486cf805148527ce84) bump: magit forge orgit orgit-forge
* [`b2ce4f0a`](https://github.com/doomemacs/doomemacs/commit/b2ce4f0afc8c6d672878c546c0f98723b116ea7c) refactor(org): +org-exclude-agenda-buffers-from-workspace-h
* [`d8157d8c`](https://github.com/doomemacs/doomemacs/commit/d8157d8cc669c1a1c766c305e84f497766664853) tweak(org): move RET keybinds from normal to motion state
* [`086aed32`](https://github.com/doomemacs/doomemacs/commit/086aed32b2b1f0c9da5bfbaeaa849c4d9c448658) release(modules): 24.10.0-dev
* [`2bc6dd2a`](https://github.com/doomemacs/doomemacs/commit/2bc6dd2a96fca93202404726a2c24c67418fcf8b) fix(cli): don't load subdirs.el again
* [`515f6129`](https://github.com/doomemacs/doomemacs/commit/515f61295bb36e076e3366f735773dcc44132d44) nit(cli): revise comments wrt site-run-file loading
* [`8475d29f`](https://github.com/doomemacs/doomemacs/commit/8475d29f3c3a8cab39f599a4c644f09ac199f3d3) refactor: remove redundant set-default-toplevel-value call
* [`d6db8816`](https://github.com/doomemacs/doomemacs/commit/d6db88162e5ff515d6daa73d1a8896a26e31fd70) refactor(lib): doom-load
* [`3bced4db`](https://github.com/doomemacs/doomemacs/commit/3bced4dbbe783767e10a47f9a4b57f32616f94bc) refactor(cli): separate cli bootstrap from lib
* [`1ec4bac7`](https://github.com/doomemacs/doomemacs/commit/1ec4bac75e01ddcc896b8c00d8264a3306a9149e) bump: :completion
* [`63e9b112`](https://github.com/doomemacs/doomemacs/commit/63e9b112803b697a67261b3fd17d9401444acf93) feat(corfu): introduce +corfu-inhibit-auto-functions
* [`fb2f7903`](https://github.com/doomemacs/doomemacs/commit/fb2f79033c0572863a346e2e94bba608929cfba9) fix(corfu): disable corfu-auto in evil replace mode
* [`76f73846`](https://github.com/doomemacs/doomemacs/commit/76f738462184f6b0dbabe6eb5774ec46d41afcad) fix(cli): "void-function: doom-modules-initialize" error
* [`308444d6`](https://github.com/doomemacs/doomemacs/commit/308444d6128bac88e851c4d6fd86f1f4dce6e2e1) fix(literate): detect symlinked literate config files
* [`682f1511`](https://github.com/doomemacs/doomemacs/commit/682f15117679920d2b4bd45ae4e6bb93c3170397) feat(vc): integrate smerge-mode
* [`0d405329`](https://github.com/doomemacs/doomemacs/commit/0d405329fed6a46b28a9d5d0adebba2ae97e6e56) fix(literate): improve error handling while tangling
* [`295ab7ed`](https://github.com/doomemacs/doomemacs/commit/295ab7ed3a20ba4619a142be15f5f2ef08d2adcf) feat(org): add "doom +org tangle" command
* [`70fd17eb`](https://github.com/doomemacs/doomemacs/commit/70fd17ebfdde0a429e280429652fb23acafba8bb) fix(vc): smerge localleader keybinds
* [`86ee1537`](https://github.com/doomemacs/doomemacs/commit/86ee1537860ed4125d3f23d2985f863236820156) refactor(default): move +*-bindings.el loaders into config.el
* [`816db4a6`](https://github.com/doomemacs/doomemacs/commit/816db4a62addf7ac5e658123ba081069d224d310) refactor!(default): drag-stuff: make non-evil only
* [`8f60a1bc`](https://github.com/doomemacs/doomemacs/commit/8f60a1bc46b3b1ef7987aa85764f35ee2249721d) fix(python): type error on loading conda.el
* [`d6bc2b0f`](https://github.com/doomemacs/doomemacs/commit/d6bc2b0f19e51fa57e57c38f622b8c91fdddf0c0) fix(python): respect $ANACONDA_HOME
* [`f81798eb`](https://github.com/doomemacs/doomemacs/commit/f81798eb0a55cee1ef70ef0280813aa2c055bccf) module: undeprecate :editor god
* [`84230a43`](https://github.com/doomemacs/doomemacs/commit/84230a437dfca913ba94c39f7a61c41d24a7cfbd) fix(corfu): `global-corfu-minibuffer` predicate not respected
* [`8083d398`](https://github.com/doomemacs/doomemacs/commit/8083d398c5bff2759b651cfa020a684492c42e4f) refactor(tabs): remove unused variable
* [`5c7f6f5c`](https://github.com/doomemacs/doomemacs/commit/5c7f6f5c41bc2a2fa0cf8c7f55ccfe8041f90d80) fix(cli): don't native-comp site-files without --aot
* [`559e5b6a`](https://github.com/doomemacs/doomemacs/commit/559e5b6a966fa82bf8322f89d78a00ef4181812a) docs(cli): doom gc: corrections
* [`bd71e16c`](https://github.com/doomemacs/doomemacs/commit/bd71e16cf441a8d0ab4ccd6ce28913adccb69140) bump: :completion corfu
* [`2d3f0039`](https://github.com/doomemacs/doomemacs/commit/2d3f00396948ec309ba8e9b6188085c0c42acc79) fix(default): removal vestigial drag-stuff config
* [`52c91cc5`](https://github.com/doomemacs/doomemacs/commit/52c91cc51cb49886380bd85a3d0d01fc27d16f62) fix(tabs): workspace-scoped buffer lists
* [`42df7cb9`](https://github.com/doomemacs/doomemacs/commit/42df7cb9fd08cc6c34e8b3e4c7619e1e372a79f9) docs(cli): doom install: reformat output
* [`1a5ff08d`](https://github.com/doomemacs/doomemacs/commit/1a5ff08da4a1f011e6ec0697f672373517d224d6) fix(cli): doom install: bootstrap other profiles if present
* [`a940ac56`](https://github.com/doomemacs/doomemacs/commit/a940ac5614c0bb34358682e42e9d7791f56d135a) fix(cli): doom install: load $DOOMDIR/cli.el too
* [`0c8dff66`](https://github.com/doomemacs/doomemacs/commit/0c8dff66de394f94f4f1b2225aa9575319db926e) docs(mu4e): update NixOS installation instructions
* [`200c9083`](https://github.com/doomemacs/doomemacs/commit/200c9083152184e26b6a1c9f8a14581729ba5f02) bump: :email mu4e
* [`f3ad08c4`](https://github.com/doomemacs/doomemacs/commit/f3ad08c4cd2c6d57cf0a49618324f5d06690a35c) refactor(mu4e): org-msg config
* [`48a6b30f`](https://github.com/doomemacs/doomemacs/commit/48a6b30f4868b04a1564ebff1c6a4c775ebabd31) refactor(mu4e): replace +mu4e-backend w/ +offlineimap/+mbsync flags
* [`60e94479`](https://github.com/doomemacs/doomemacs/commit/60e94479a7952a9939b349dc478378ea47289fa9) feat(mu4e): add mu4e-compat package
* [`5c0211d6`](https://github.com/doomemacs/doomemacs/commit/5c0211d635daedbd31fc69f64f6712d930170ce5) refactor(mu4e): mu4e config
* [`13959117`](https://github.com/doomemacs/doomemacs/commit/139591172e1838c9a9a6712ace5aa7511ab96594) fix(mu4e): add mu4e-debug to doom-debug-variables
* [`c6479574`](https://github.com/doomemacs/doomemacs/commit/c6479574e6d324d788e3bc2f6240440010373956) feat(mu4e): respect XDG for mbsync config file
* [`424b7af4`](https://github.com/doomemacs/doomemacs/commit/424b7af45fa2c96bbee9b06f33c6cd0fc13412ac) fix(mu4e): duplicate "view in browser" actions
* [`1fa1eba5`](https://github.com/doomemacs/doomemacs/commit/1fa1eba5ac38d654a0763282f3ddd631e873c273) bump: :lang python
* [`03e5f133`](https://github.com/doomemacs/doomemacs/commit/03e5f1333ccd183939a62cf9b7999030553d67aa) fix(latex): reorder viewers wrt +latex-viewers
* [`45310f1c`](https://github.com/doomemacs/doomemacs/commit/45310f1c3ecbd8a652312bf950e6f43149afcee1) fix(mu4e): "no such file or directory: ~/.mbsyncrc"
* [`6d9a7e9a`](https://github.com/doomemacs/doomemacs/commit/6d9a7e9a8fa061634f6a3008a999f2b2d1172287) fix: over-aggressive deactivation of hl-line-mode
* [`fe54aa43`](https://github.com/doomemacs/doomemacs/commit/fe54aa436c39f0e6f948791b8956b7b93fdf36ed) fix(latex): modes not remapped to auctex modes
* [`79684ade`](https://github.com/doomemacs/doomemacs/commit/79684ade71dd573f8d90c85edc8a9091f51fbfba) fix(latex): run after-compilation-finished hook after Tex-Tex-sentinel
* [`e0a926dc`](https://github.com/doomemacs/doomemacs/commit/e0a926dc1ec9e1fa66f31751d33b3e4f41b6801a) tweak(indent-guides): default to character method
* [`9753bfb7`](https://github.com/doomemacs/doomemacs/commit/9753bfb775d04cedaa955a92b3e2256ceb28b0cc) fix: {back,fore}ground-color in subsequent frames
* [`8d2cf32f`](https://github.com/doomemacs/doomemacs/commit/8d2cf32fef9a82e1b929dc22adec3235181d7b54) feat(cli): add doom.ps1 for Windows users
* [`f644c4fa`](https://github.com/doomemacs/doomemacs/commit/f644c4fa6c23ba2820f102d74318b0f721b070a0) feat: add basic android support
* [`61dc1da6`](https://github.com/doomemacs/doomemacs/commit/61dc1da645b452943097c6b9dbbdb7eca2e7c469) fix(cli): doom.ps1: interpolated variable in error message
* [`4c7aec35`](https://github.com/doomemacs/doomemacs/commit/4c7aec35bac6ff77ab70337ba1b748638d9dd9be) fix(cli): envvar injection into bin/doom post-script
* [`94a291a7`](https://github.com/doomemacs/doomemacs/commit/94a291a7f8f3425a33a8326077cfb0c9964f1631) fix(cli): doom.ps1: path to post-script
* [`73ab5545`](https://github.com/doomemacs/doomemacs/commit/73ab554566c6f05d8a3bb523e293fcaec9b6ef20) fix(cli): don't auto-invoke pager under powershell
* [`2981aec4`](https://github.com/doomemacs/doomemacs/commit/2981aec4dd571f96ebb405289b12728b21c1aef5) fix(lib): doom/{reload,upgrade}: double-escaped %s in command
* [`2d382174`](https://github.com/doomemacs/doomemacs/commit/2d3821741a3a47b5410372bd16c1c813d97e7329) refactor(cli): introduce doom-cli-shell
* [`1ff37f9f`](https://github.com/doomemacs/doomemacs/commit/1ff37f9fa42b751342552ef42ef403dc41f50896) fix(dired): preserve buffers on dirvish-find-entry-a
* [`4fc11b69`](https://github.com/doomemacs/doomemacs/commit/4fc11b696e109db27321850203ce897be438b512) tweak: projectile: don't follow symlinks by default
* [`de1ffbca`](https://github.com/doomemacs/doomemacs/commit/de1ffbca11d0d759234eef266ded0053dfc113ba) feat: distinguish [C-m] key from RET
* [`765f3174`](https://github.com/doomemacs/doomemacs/commit/765f3174277905db531d6f17c771fe7fc376b1b2) docs(magit): remove magit-todos from the README
* [`ed05e4c0`](https://github.com/doomemacs/doomemacs/commit/ed05e4c088df608dce088d1dc8ab10b230649ca0) feat(nav-flash): blink on workspace change
* [`ac1122ae`](https://github.com/doomemacs/doomemacs/commit/ac1122ae67d762e09fc6684945b52adff96cf1dc) tweak(erlang): format w/ erlfmt instead of efmt
* [`0d9e188b`](https://github.com/doomemacs/doomemacs/commit/0d9e188b26ca1d01a57598e37171e5333272cad7) refactor!(indent-guides): use indent-bars instead
* [`6025e141`](https://github.com/doomemacs/doomemacs/commit/6025e141aae3bbe10b9a867e3a33eadd6b99671f) perf(lib): minor optimizations
* [`871efdce`](https://github.com/doomemacs/doomemacs/commit/871efdce08eaa36c5163335e45442e1a5e68d907) refactor: windows: move doom dirs to %LOCALAPPDATA%
* [`737f9124`](https://github.com/doomemacs/doomemacs/commit/737f91242a6b4486dc0a8ae6b7f00b622b0e6904) bump: :editor evil
* [`2fa4faa6`](https://github.com/doomemacs/doomemacs/commit/2fa4faa6cdfbdf5e675f25bbbca5a39724af191e) bump: :tools
* [`0dc1084e`](https://github.com/doomemacs/doomemacs/commit/0dc1084e8a915d778af7cc5774477ffb3daa0b0a) bump: :lang
* [`0461c5de`](https://github.com/doomemacs/doomemacs/commit/0461c5de5fa34d6b374f27eff1965f171049f987) tweak(indent-guides): subtle bars & bitmaps (almost) by default
* [`af814ff8`](https://github.com/doomemacs/doomemacs/commit/af814ff86a3961d38e1fc741fa840461ded4bd82) fix(indent-guides): interop with lsp-ui-peek
* [`bcdb9454`](https://github.com/doomemacs/doomemacs/commit/bcdb945465854c315c2a90e8f2465cf0beddbe53) fix(indent-guides): interop with magit-blame
* [`632a091a`](https://github.com/doomemacs/doomemacs/commit/632a091abbd61e11f0b5b5736dcb9ebd0d3cbbba) refactor: remove unneeded optimizations
* [`01c19094`](https://github.com/doomemacs/doomemacs/commit/01c19094e8c963bcdebc218c569e51a2685c3c4d) fix(python): type error if conda-anaconda-home is unset
* [`1a338384`](https://github.com/doomemacs/doomemacs/commit/1a33838423a07d270b11835717f43eaabff52c7e) refactor!(cc): remove irony and rtags
* [`cc8cf810`](https://github.com/doomemacs/doomemacs/commit/cc8cf810f58eee7762af364546d57bf56b640380) tweak(cc): prioritize clangd over ccls
* [`374c28ce`](https://github.com/doomemacs/doomemacs/commit/374c28cedd5386622e61b6e8779ef0dda9fe2bb7) refactor(cc): only bind ccls keys if ccls is present
* [`005831bf`](https://github.com/doomemacs/doomemacs/commit/005831bfcc1301e62d9a939cb905767b466200e5) refactor(lsp): let lsp-mode load lsp client packages
* [`bbb2cc1c`](https://github.com/doomemacs/doomemacs/commit/bbb2cc1cb35972766b6839baf004fb111edd576d) fix(indent-guides): disable indent-bars in tree-sitter-mode
* [`07eae645`](https://github.com/doomemacs/doomemacs/commit/07eae6450934cac13b1b625116be4e7cd0bfa3c1) refactor(vc): move git-commit to magit module
* [`47c8c905`](https://github.com/doomemacs/doomemacs/commit/47c8c905b8d5e455a935b4b16288449751f748cc) feat(dired): open dirvish sidebar w/ '<leader> o {p,P}'
* [`9d172f8c`](https://github.com/doomemacs/doomemacs/commit/9d172f8c25bc3d7c8970c8ee9bfc31acbbed5141) feat(default): bind '<leader> o /' to dirvish
* [`b03e7891`](https://github.com/doomemacs/doomemacs/commit/b03e78918bd458cd4d32d2e16a6663c2dddb1002) bump: org-contacts ob-php
* [`98e28d80`](https://github.com/doomemacs/doomemacs/commit/98e28d801e8acf0047cd9859dc2448a5cee66c21) fix(indent-guides): don't activate in noninteractive sessions
* [`49896617`](https://github.com/doomemacs/doomemacs/commit/498966179f2ee88e13e8cd765e52f7f5143b101c) perf(cli): doom: reduce init time
* [`08abc7d6`](https://github.com/doomemacs/doomemacs/commit/08abc7d6989066fe611180e0af58b9af59630018) refactor(cli): doom.ps1: simplify
* [`dd5ae257`](https://github.com/doomemacs/doomemacs/commit/dd5ae257f13a2fad44d967297634e8b24312136f) nit(indent-guides): reformat config.el & proofread comments
* [`ad5e3dcc`](https://github.com/doomemacs/doomemacs/commit/ad5e3dcce8e6a4f3779db4bdf9b19a7ce9b3e648) fix(emacs-lisp): byte-compiling missing function
* [`e02d3c79`](https://github.com/doomemacs/doomemacs/commit/e02d3c79a94065ba9f25728d98bef65a79521b2a) feat: backport safe-local-variable-directories from Emacs 30
* [`0ee89cbb`](https://github.com/doomemacs/doomemacs/commit/0ee89cbb5cad96c458b1f4df1b73e56b3c411006) tweak(idris): add popup rules
* [`75763ae7`](https://github.com/doomemacs/doomemacs/commit/75763ae786bc314c9f7865526460c4c2a2f97123) feat(idris): add flycheck support
* [`08f5eef3`](https://github.com/doomemacs/doomemacs/commit/08f5eef3ce05dc271c9a260a174993471cdd35d5) fix(idris): add ".ibc" to completion-ignored-extensions
* [`e6514cdf`](https://github.com/doomemacs/doomemacs/commit/e6514cdf4747c9bdd7ecad1418d807326c592b60) docs(idris): +lsp and idris2 compatibility
* [`86b7bef5`](https://github.com/doomemacs/doomemacs/commit/86b7bef5127c48e94df1c4f515f517383913d368) fix: type error if default returns nil :foreground/:background
* [`60083a26`](https://github.com/doomemacs/doomemacs/commit/60083a2626dc5f5e91c39d85b65259d838e06a69) fix(lib): doom/sandbox
* [`a022e55c`](https://github.com/doomemacs/doomemacs/commit/a022e55c08a18cfed97c0695da45553f7f73ab82) fix(lib): doom/sandbox: vanilla-doom+ target
* [`4790db64`](https://github.com/doomemacs/doomemacs/commit/4790db6448cad4886725f456e920392bf66b18c2) fix(dired): typo in command name
* [`28d0d4c2`](https://github.com/doomemacs/doomemacs/commit/28d0d4c2e9c72f821a33a55e06ff9c9f6686e00e) fix(indent-guides): bars on blank lines breaking line motions
* [`fcf8b0f8`](https://github.com/doomemacs/doomemacs/commit/fcf8b0f8a10e4b8435a831dcdf8758d7ede47059) fix(mu4e): treat *mu4e-main* as real
* [`40d67ab5`](https://github.com/doomemacs/doomemacs/commit/40d67ab5734d881240fd6ae5db4b1e62af6bb51f) fix(spell): fail gracefully on missing ispell-program-name
* [`88a39614`](https://github.com/doomemacs/doomemacs/commit/88a396148922a2cb5d1e1a731f741e02aada691a) fix(company): company-backends not set in some buffers
* [`30988a97`](https://github.com/doomemacs/doomemacs/commit/30988a9720daea55b31e4587e00ca65f5a78e4ad) fix(lsp): lsp-terraform removal condition
* [`29c661aa`](https://github.com/doomemacs/doomemacs/commit/29c661aa3e10114c8787fa49333d5bb5c5d90934) fix(cli): doom: improve shebang portability
* [`5a4aa916`](https://github.com/doomemacs/doomemacs/commit/5a4aa916bc0470ce63e57855eb1483e87414a21a) fix: adding newly created project to known-projects
* [`5ad99220`](https://github.com/doomemacs/doomemacs/commit/5ad99220b86ae1bf421861dfad24492d768ac4d9) fix(ligatures): no prettify-symbols-mode w/o +extra
* [`fc35b3cf`](https://github.com/doomemacs/doomemacs/commit/fc35b3cf37d983b7cee13d523fb3f5072abbeed5) feat(ruby): add rails-{routes,i18n} & ruby-json-to-hash
* [`f6b7e8ae`](https://github.com/doomemacs/doomemacs/commit/f6b7e8ae48076b517acef96159409460357417d2) module: add :lang graphviz
* [`1baebdaf`](https://github.com/doomemacs/doomemacs/commit/1baebdafb3b14e05351090d04e46bfcf33c36bf3) feat(racket): add +hash-lang
* [`240493ae`](https://github.com/doomemacs/doomemacs/commit/240493ae9235d2b1b2ffc1d98cd829b7d2bbb236) fix: face-* calls crashing new emacsclient frames
* [`a8515034`](https://github.com/doomemacs/doomemacs/commit/a8515034deb4495c32657a94d09bcdee30b7ff0b) refactor: rename childframe predicate function
* [`546e56f1`](https://github.com/doomemacs/doomemacs/commit/546e56f1fa484e26ca368a350edba58c6c4c0439) fix: suppress visual startup optimizations in debug mode
* [`6d7a39c4`](https://github.com/doomemacs/doomemacs/commit/6d7a39c482e02d6ca160f67653df44a6df70dd9f) tweak: load site-lisp verbosely in debug mode
* [`771fccc5`](https://github.com/doomemacs/doomemacs/commit/771fccc52bdc56c1816d104a90034c9fe8231ffd) nit: minor reformatting & revision
* [`f8f2b285`](https://github.com/doomemacs/doomemacs/commit/f8f2b2858014d10b18d8fcf082013b70aa580ea8) feat: add doom-log-level
* [`4ca58195`](https://github.com/doomemacs/doomemacs/commit/4ca5819532a440575411462f986b3844d987f549) fix(lib): file!: lower current-load-list priority
* [`a9742106`](https://github.com/doomemacs/doomemacs/commit/a974210605e21451eab1af5ad9ee6bf3bcec8e64) refactor(lib): letf!: use define-advice & split defun/defun*
* [`70bfb9f0`](https://github.com/doomemacs/doomemacs/commit/70bfb9f0e92c853d72f5614a1a2a67474c97b8fa) docs: letf!: add demo & rewrite docstring
* [`19d68887`](https://github.com/doomemacs/doomemacs/commit/19d68887b10e47d7e9f7c87c2f6e65c8db372dbc) refactor: remove redundant auto-mode-alist entries
* [`de6a0776`](https://github.com/doomemacs/doomemacs/commit/de6a077669450b937909d003718441170f91c43c) fix: early-init.el: don't suppress legit file errors
* [`3256fc7f`](https://github.com/doomemacs/doomemacs/commit/3256fc7fca470f5ea3b9cbe4684c5a168b907e83) fix: trigger defcustom setters in files opened from command-line
* [`9bd9d553`](https://github.com/doomemacs/doomemacs/commit/9bd9d5535416946d9d7adb07e2d55d5fb85a1f30) fix(lib): define doom-context-error
* [`1dc606bb`](https://github.com/doomemacs/doomemacs/commit/1dc606bb279146ac32aa8dfbe86dc839fa6f8b3e) fix(file-templates): __doom-readme: use doom-modules-version
* [`f27a85ed`](https://github.com/doomemacs/doomemacs/commit/f27a85ed354fa146a218fc2d26604317c9cc4723) module: add :emacs eww
* [`5880348a`](https://github.com/doomemacs/doomemacs/commit/5880348a6c668ca0846289dcff80f7d67cfb3bce) perf(cli): doomscript: reduce init time
* [`b853c410`](https://github.com/doomemacs/doomemacs/commit/b853c4106a44c4be8f31b72023428e04c79c1f03) fix(default): SPC g r: revert without prompting to save
* [`bd140955`](https://github.com/doomemacs/doomemacs/commit/bd140955164ca854450c52f4b5c4ca9e0f5c878b) fix(ligatures): lisp modes disobeying null +ligatures-extra-symbols
* [`288b6dc9`](https://github.com/doomemacs/doomemacs/commit/288b6dc962d76412a2c7db825d7dadc829945460) fix(cli): doom run: symlinks to XDG dirs beyond $HOME
* [`37dbc997`](https://github.com/doomemacs/doomemacs/commit/37dbc9977878a30ac57031dbe164d8aad545e701) fix(fold): truncate-string-to-width: type errors
* [`be422c45`](https://github.com/doomemacs/doomemacs/commit/be422c451602a6bde61244932cd8043563cc7629) fix(graphviz): org babel integration
* [`9359a81e`](https://github.com/doomemacs/doomemacs/commit/9359a81e8103aa19dba40eff4be802ec55a38e97) fix: gui frames fail to open from emacsclient
* [`73460f42`](https://github.com/doomemacs/doomemacs/commit/73460f42fd9a7bca76b7b5be47c4d3b6f8aa1040) fix(dired): require needed for `dirvish-side'
* [`d735c9be`](https://github.com/doomemacs/doomemacs/commit/d735c9be3d92da2754336c37ff593a321fe50ae5) fix(graphviz): don't eagerly load flycheck at startup
* [`14189be7`](https://github.com/doomemacs/doomemacs/commit/14189be77c18bb079f2f37da4147fba192f3efe1) fix: out-of-bounds error if this-single-command-raw-keys is empty
* [`0e5935f0`](https://github.com/doomemacs/doomemacs/commit/0e5935f0f701803bf9b9647d72c687ea2de1a954) fix(cli): "Argument list too long" error from after-scripts
* [`41987bb0`](https://github.com/doomemacs/doomemacs/commit/41987bb00fc58626b5147ab36487e8eb882f9648) fix(cli): persist correct doom-log-level to after-scripts
* [`b9eb6623`](https://github.com/doomemacs/doomemacs/commit/b9eb6623347a0cbbb721bd1175fc2d5479d01657) feat(vertico): allow affixes to be escaped
* [`fa6893ee`](https://github.com/doomemacs/doomemacs/commit/fa6893eeea7bb91b567522dffe445b8769044330) tweak(lib): doom-debug-variables: add doom-log-level
* [`59de0ec1`](https://github.com/doomemacs/doomemacs/commit/59de0ec15e14b16fbb14b3019cc2d85b17e64008) perf(default): eagerly loading yasnippet at startup
* [`c07f359d`](https://github.com/doomemacs/doomemacs/commit/c07f359d648a447ebeaaa3a89a69a3a25c3d0366) fix(ligatures): activate prettify-symbols-mode conditionally
* [`f452677c`](https://github.com/doomemacs/doomemacs/commit/f452677c555693e354f69ebd4b8b3f074f0e616e) docs(ligatures): revise docstrings
* [`07afef64`](https://github.com/doomemacs/doomemacs/commit/07afef645a24a663a822fe398d1bdab26f54d63e) tweak(company): company-idle-delay = 0.26
* [`faeab956`](https://github.com/doomemacs/doomemacs/commit/faeab956e5bfc1dfba87f8e788eb5175b083ea47) fix(vertico): consult-register: make evil-aware
* [`b6815045`](https://github.com/doomemacs/doomemacs/commit/b6815045828e80e1e301b11b900673593d61e419) fix(fold): avoid Hideshow-not-supported error
* [`d3477040`](https://github.com/doomemacs/doomemacs/commit/d34770407ce092501aeca0aee879d0f6ee6f2029) fix(emacs-lisp): unremap describe-symbol to helpful-symbol
* [`66a2972e`](https://github.com/doomemacs/doomemacs/commit/66a2972ebf5fd18cd8adb6eb71a48ec08ce418b8) fix(lib): doom/set-indent-width on Emacs >=30
* [`a78237cc`](https://github.com/doomemacs/doomemacs/commit/a78237cc01adeabe0fd4a83ff8b8aca7cb269482) fix(mu4e): org-msg: type error w/ prefix arg
* [`c82e7d9e`](https://github.com/doomemacs/doomemacs/commit/c82e7d9ea27ff1994a1891a7d162a9943ad7c897) fix(ligatures): avoid invalid `prettify-symbols-alist`
* [`2e5307e4`](https://github.com/doomemacs/doomemacs/commit/2e5307e4259281d1a233fb1bc99975d528650d53) fix(emacs-lisp): always try Helpful for doc lookup
* [`d633c150`](https://github.com/doomemacs/doomemacs/commit/d633c15042351766171912aab6fdaabbf1922037) perf(cc): lsp-clangd: halve core count for indexing
* [`7ec570fd`](https://github.com/doomemacs/doomemacs/commit/7ec570fdf5a43a81dca985eae7eb1bb7bda4bc75) fix(format): clang-format: respect c-basic-offset
* [`037b018c`](https://github.com/doomemacs/doomemacs/commit/037b018cdd579f981cfa1cfd55971eedd0dfc165) feat: add .doommodule files
* [`22d5e305`](https://github.com/doomemacs/doomemacs/commit/22d5e3059f5502df314b9df75e34f2d821f01d78) feat(emacs-lisp): extend config to lisp-{data,interaction}-mode
* [`0b2ccac0`](https://github.com/doomemacs/doomemacs/commit/0b2ccac00751dfc2f7628b1a2496727633cc3db5) fix(emacs-lisp): lookup docs backend w/o helpful
* [`a2b1c4da`](https://github.com/doomemacs/doomemacs/commit/a2b1c4da7864e1cf5270c1aa08ee31cc551cc4ce) feat(emacs-lisp): extend fontification to lisp-{data,interaction}-mode
* [`c8a5e6ec`](https://github.com/doomemacs/doomemacs/commit/c8a5e6ec1ca85a35f94d6c820c2fd8888373c2ae) fix: map!: allow :map values to be interpolated
