### PR TITLE
niv home-manager: update 21c02186 -> ffe2d07e

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -41,10 +41,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "21c021862fa696c8199934e2153214ab57150cb6",
-        "sha256": "1ihdc17198yzjprvs8mbqgrp7ya261n870vvzd1nng8k38ayz0hi",
+        "rev": "ffe2d07e771580a005e675108212597e5b367d2d",
+        "sha256": "1avcr63sjidf83f69xdlsdi0dszhrppy257z7nld3hf2kmrdmyz3",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/21c021862fa696c8199934e2153214ab57150cb6.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/ffe2d07e771580a005e675108212597e5b367d2d.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@21c02186...ffe2d07e](https://github.com/nix-community/home-manager/compare/21c021862fa696c8199934e2153214ab57150cb6...ffe2d07e771580a005e675108212597e5b367d2d)

* [`1e22ef15`](https://github.com/nix-community/home-manager/commit/1e22ef1518fb175d762006f9cae7f6312b8caedb) direnv: update for new nushell behavior ([nix-community/home-manager⁠#5880](https://togithub.com/nix-community/home-manager/issues/5880))
* [`c124568e`](https://github.com/nix-community/home-manager/commit/c124568e1054a62c20fbe036155cc99237633327) flake.lock: Update
* [`57e6b30d`](https://github.com/nix-community/home-manager/commit/57e6b30d181ae6baff0909a61544ecbe1f642936) direnv: work around nushell bug
* [`853e7bd2`](https://github.com/nix-community/home-manager/commit/853e7bd24f875bac2e3a0cf72f993e917d0f8cf5) direnv: even better nushell fix
* [`0afc2f0f`](https://github.com/nix-community/home-manager/commit/0afc2f0f19470e45a3941926a330f2db55ac2fbf) river: reduce risk of large rebuilds in test
* [`ffe2d07e`](https://github.com/nix-community/home-manager/commit/ffe2d07e771580a005e675108212597e5b367d2d) direnv: hopefully final nushell fix
