### PR TITLE
niv nixpkgs: update a7d1437d -> 1a53b400

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a7d1437dc8c97361cbb036e98264764fc6221d89",
-        "sha256": "1zw12r5jaxl14ivgx2iw327d51ff4idqw1b7k0n9fdv1p4sll45b",
+        "rev": "1a53b400e59d0c0c5b287231e4cc65195a0660c4",
+        "sha256": "11csqs0hgzvdzy0zcnxyz3kzgfasv2d66v23lhicjvqb83v9gvxg",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/a7d1437dc8c97361cbb036e98264764fc6221d89.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/1a53b400e59d0c0c5b287231e4cc65195a0660c4.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@a7d1437d...1a53b400](https://github.com/nixos/nixpkgs/compare/a7d1437dc8c97361cbb036e98264764fc6221d89...1a53b400e59d0c0c5b287231e4cc65195a0660c4)

* [`bd146106`](https://github.com/NixOS/nixpkgs/commit/bd1461067cd8214912039ebe60b222c15483f357) ghc_filesystem: 1.5.12 -> 1.5.14
* [`50be5716`](https://github.com/NixOS/nixpkgs/commit/50be5716ca095d676499b19ce7ddb5ddd7dff49f) qemacs: 5.4.1c -> 6.1.1b
* [`22c0b321`](https://github.com/NixOS/nixpkgs/commit/22c0b3210b1d5aa9bc92c805f1226eab5e851aa7) intelli-shell: init at 0.2.7
* [`de4366e8`](https://github.com/NixOS/nixpkgs/commit/de4366e87574a7cafcf416ff7d4a1f07afcbc8a9) seilfahrt: init at 1.0.2
* [`0d669f4f`](https://github.com/NixOS/nixpkgs/commit/0d669f4f6f17f84ac2bb983fef54cc1af8041223) qmqtt: init at 1.0.3
* [`11c244ce`](https://github.com/NixOS/nixpkgs/commit/11c244ced9c3c91d722966f829ab1bd9992b64a1) mdns: init at 1.4.3
* [`5f795986`](https://github.com/NixOS/nixpkgs/commit/5f795986395e82bd6eb6b9ab1adc4e1383ebd785) hyperhdr: init at 20.0.0.0
* [`1d160e9c`](https://github.com/NixOS/nixpkgs/commit/1d160e9cc18d722144f4e859ef77d71f5fdee578) Remove the revCount attribute from the generated flake registry
* [`651cab9a`](https://github.com/NixOS/nixpkgs/commit/651cab9ae0bf2dfe76abb17f9cb9cd057e2964bc) rubyPackages.nokogiri: mark as broken for old libxml2
* [`2b982b99`](https://github.com/NixOS/nixpkgs/commit/2b982b99acda10816cb2d5aee617003024034c1d) nixos/systemd: let systemd setup /etc/machine-id
* [`115c1d69`](https://github.com/NixOS/nixpkgs/commit/115c1d69015de09f4211890477af05ba4fb873b9) nixos/systemd: add presets to ignore all other presets
* [`caacc202`](https://github.com/NixOS/nixpkgs/commit/caacc20216aac6653295c2ae1eef3b432a5d96f6) fishPlugins.plugin-sudope: init at 0-unstable-2021-04-11
* [`b85717ad`](https://github.com/NixOS/nixpkgs/commit/b85717adbea78ac456643c89a1ecd3a7629df121) fishPlugins.fish-bd: init at 1.3.3
* [`83da4f51`](https://github.com/NixOS/nixpkgs/commit/83da4f513d8880707ef3886523539340f12b9426) kvmfr: fix build for linux-6_10
* [`1b640cc0`](https://github.com/NixOS/nixpkgs/commit/1b640cc0e4468628d180f7911efae0ba7b3c8580) looking-glass-client: replace patch file with fetchpatch
* [`4e59adcc`](https://github.com/NixOS/nixpkgs/commit/4e59adccb6953213dce083ef0ed74aa5118d7943) azuki: init at 0-unstable-2021-07-02
* [`c70215a6`](https://github.com/NixOS/nixpkgs/commit/c70215a6ed3942e350174951ada5d4802050b10e) fprintd: disable flaky test
* [`0cdf53a5`](https://github.com/NixOS/nixpkgs/commit/0cdf53a57f8318cee86dd682fd1523b8aaa69d0f) nixos/datadog-agent: fix deprecated trace agent option
* [`ec325045`](https://github.com/NixOS/nixpkgs/commit/ec3250455404b8b7007067fb2bc7e9d3cfabb7ff) local-ai: format code
* [`e8f5d6f5`](https://github.com/NixOS/nixpkgs/commit/e8f5d6f53f3f29c75b97cd3f2121ed2733e6bdf6) local-ai: 2.19.4 -> 2.20.1
* [`dd663dbf`](https://github.com/NixOS/nixpkgs/commit/dd663dbf624821e30f9a763ab9631e5d83fcf543) apacheHttpdPackages.mod_jk: 1.2.49 -> 1.2.50
* [`51b27144`](https://github.com/NixOS/nixpkgs/commit/51b2714417a45f7682ae9aab354aec3cd53b34bb) apacheHttpdPackages.mod_jk: reformat with nixfmt-rfc-style
* [`2004f7c0`](https://github.com/NixOS/nixpkgs/commit/2004f7c00f346eca5917c3f1cacaeca347fa2498) xpra: 5.0.9 -> 6.1.2
* [`2d07b69b`](https://github.com/NixOS/nixpkgs/commit/2d07b69bf0ed5708768824ca07ed3da0ddff671e) maintainers: add noahgitsham
* [`72429bfb`](https://github.com/NixOS/nixpkgs/commit/72429bfb0a2047a0ee0e3b8c0b816cb305b015c4) python312Packages.blobfile: 2.1.0 -> 3.0.0
* [`9faaa276`](https://github.com/NixOS/nixpkgs/commit/9faaa27620c96e7e3e4384341b7f1d8c1b0c0abd) dnglab: 0.5.2 -> 0.6.3
* [`71142ee9`](https://github.com/NixOS/nixpkgs/commit/71142ee93bde866d7790552d6d4a4e07b4baf849) kvmfr: backport security fix for potential buffer overflow
* [`14aefbb1`](https://github.com/NixOS/nixpkgs/commit/14aefbb104ca572b267e0d3cf23a543f88871682) wike: fix cross compilation
* [`78552017`](https://github.com/NixOS/nixpkgs/commit/7855201741d7fac25d4458e448b1d63c3c8283d1) fragment-mono: init at 1.21
* [`5204cb90`](https://github.com/NixOS/nixpkgs/commit/5204cb90cddd28257dfcccd2a8ed9dc574bf69a5) maintainers: add amuckstot30
* [`728043e8`](https://github.com/NixOS/nixpkgs/commit/728043e8d709b134451018497f6f211d0e83b3cf) postmoogle: init at 0.9.21
* [`165e383a`](https://github.com/NixOS/nixpkgs/commit/165e383a1a83e17ae79811aa672d808f2b1056df) all-cabal-hashes: 2024-08-19T17:17:03Z -> 2024-09-03T10:29:19Z
* [`84d63aeb`](https://github.com/NixOS/nixpkgs/commit/84d63aeb6b1f48cfd94c650c19250ae7de790757) haskellPackages.diohsc: unbreak
* [`a4666899`](https://github.com/NixOS/nixpkgs/commit/a46668992ced17930e731494019155fb5e380ec2) haskell.packages.ghc910: fixed some packages
* [`556d821d`](https://github.com/NixOS/nixpkgs/commit/556d821d15f55319991921c11af38db893da305a) maintainers: add hustlerone
* [`04f0edfe`](https://github.com/NixOS/nixpkgs/commit/04f0edfeb5ae6ccd0a4e54e63c63bccb65695471) haskellPackages: regenerate package set based on current config
* [`ae3938ba`](https://github.com/NixOS/nixpkgs/commit/ae3938baff8c4b0177bfb5b876172b0fa56ced74) haskellPackages.clash-prelude: Unmark broken
* [`3a58705b`](https://github.com/NixOS/nixpkgs/commit/3a58705b09184cd410a1daa851f6f4b7919fc808) python312Packages.anthropic: 0.34.0 -> 0.34.2
* [`85fcc86a`](https://github.com/NixOS/nixpkgs/commit/85fcc86a724bd1548b6c2936174fa1e7782fcef0) Regenerate hackage-packages
* [`bfc503e1`](https://github.com/NixOS/nixpkgs/commit/bfc503e1bec3d68073831b54438207fa56431a28) Add info about override removal
* [`e2af344b`](https://github.com/NixOS/nixpkgs/commit/e2af344be55ec2e783a8dcdb63791c20c163a1c6) haskellPackages.system-fileio: disable checks
* [`67a00dc8`](https://github.com/NixOS/nixpkgs/commit/67a00dc8b4633cff6b374a1075ea232b97ae70f2) haskellPackages: regenerate package set based on current config
* [`cd31b044`](https://github.com/NixOS/nixpkgs/commit/cd31b044130aa79baf368c5c3adb799cf5e3f00b) haskell.compiler.ghc*: set stage 0 tools
* [`4b00fbf1`](https://github.com/NixOS/nixpkgs/commit/4b00fbf16307a1501bd57370cf334a905554ee90) haskell.compiler.ghc*: correctly account for ncurses in cross
* [`1261fe02`](https://github.com/NixOS/nixpkgs/commit/1261fe024fada592533a61a1f6ca1e03be50a4c6) haskell.compiler.ghc*: fall back to host libs for “cross native” ghc
* [`d5f666f5`](https://github.com/NixOS/nixpkgs/commit/d5f666f593f04e79750a2663703651f990942fc6) haskell.compiler.ghc*: don't configure --host
* [`bd331dc3`](https://github.com/NixOS/nixpkgs/commit/bd331dc379a1f3e6967d7e98e032a860ed30fccb) ghc-settings-edit: init at 0.1.0
* [`884a76c5`](https://github.com/NixOS/nixpkgs/commit/884a76c5e61c25d94695433101b9a9d46814193d) haskell.compiler.ghc*: use host->target CC and tools in settings
* [`f8650440`](https://github.com/NixOS/nixpkgs/commit/f8650440993dfbe139fe94d6c0c727f52c640b73) haskell.compiler.ghc*: don't cross-compile haddock
* [`35d77dde`](https://github.com/NixOS/nixpkgs/commit/35d77dde973460069f7a409268d7db93faab9309) haskell.compiler.ghc*: add enableUnregisterised
* [`d3bad452`](https://github.com/NixOS/nixpkgs/commit/d3bad452401c87015cf3a1ad754a6d14eb5e48fc) haskell.compiler.ghc*: assert cross is possible
* [`322bab82`](https://github.com/NixOS/nixpkgs/commit/322bab828488c44c434b2fab7fcb15b640970cc8) haskell.compiler.ghc*: allow all platforms
* [`bd373f03`](https://github.com/NixOS/nixpkgs/commit/bd373f03a0f4320df4f7ef42125ea27f6699353e) haskell.compiler.ghc*: use GHC from pkgsBuildBuild
* [`eeeeb555`](https://github.com/NixOS/nixpkgs/commit/eeeeb555e2ce5e767674a9275d218bbea843486a) tests.cross.sanity: Add GHC to catch regressions
* [`8b6009f8`](https://github.com/NixOS/nixpkgs/commit/8b6009f8526822e1e01c9428f99de4ef8983b816) haskell.compiler.ghc96: fix incorrect unlit path for cross compilers
* [`8c08fb10`](https://github.com/NixOS/nixpkgs/commit/8c08fb1090b4e24e22b1a5973557d0e322170d81) haskell.compiler.ghc9{6,8,10}: update comment about stage selection
* [`de13f8f4`](https://github.com/NixOS/nixpkgs/commit/de13f8f45475ca2d7c8a9baa378f92e835703939) haskell.compiler.*: set cctools tools in settings if applicable
* [`2dae2274`](https://github.com/NixOS/nixpkgs/commit/2dae22748f572b52002767e3fcf86b0f70d50cdc) haskell.compiler.*: set correct runtime LLVM tools in settings
* [`a259fd03`](https://github.com/NixOS/nixpkgs/commit/a259fd03ae7d6da289a58cd3569e8ef5c5092135) maintainers: update email for kinzoku
* [`ead87172`](https://github.com/NixOS/nixpkgs/commit/ead87172ebe275c72326a00a21417b854ee040e8) nixos/tests/non-default-filesystems: fix btrfs mount regex
* [`5cd41e16`](https://github.com/NixOS/nixpkgs/commit/5cd41e16a64f45e8688a0f028bd74f54b8cc6d80) release-haskell.nix: don't try to build pkgsMusl on non x86_64-linux
* [`7fff0433`](https://github.com/NixOS/nixpkgs/commit/7fff04332d2c70b64c6929e92aa5f90361dfff4e) haskell.compiler.ghc{96,98,910}: use emscripten installCC for ghcjs
* [`79474fd4`](https://github.com/NixOS/nixpkgs/commit/79474fd4c31d496bc51fa3ee80c96742527889e1) gmic: enable OpenCV, OpenMP (Clang) and X11
* [`cc0811a5`](https://github.com/NixOS/nixpkgs/commit/cc0811a5dad333cefde6d50fe8c1fa0942d19f74) gmic-qt: enable OpenMP (Clang)
* [`0cf9d699`](https://github.com/NixOS/nixpkgs/commit/0cf9d699790b8b03f319b85b5a2bb552f1c23776) dafny: 4.7.0 -> 4.8.0
* [`00ce4be9`](https://github.com/NixOS/nixpkgs/commit/00ce4be9e427ba08b6b702736c8c255d867ccc84) nixos/tests/pgjwt: fix test
* [`5ab2ff7a`](https://github.com/NixOS/nixpkgs/commit/5ab2ff7a7afd00d371e3a7af043baf955142778d) nixos/quorum: update geth flags
* [`7fb51e54`](https://github.com/NixOS/nixpkgs/commit/7fb51e54e81fba61c71a0f47252f08b0f03d82ee) nixos/tests/quorum: fix test
* [`4888c3cd`](https://github.com/NixOS/nixpkgs/commit/4888c3cd8b6e1eba35a5904bc0f71995f1393c4e) haskellPackages.ghc-settings-edit: build using Cabal
* [`30a4e6db`](https://github.com/NixOS/nixpkgs/commit/30a4e6db2a30994ce66c45599370b98eaed25f33) ffts: init at unstable-2019-03-19
* [`46460a75`](https://github.com/NixOS/nixpkgs/commit/46460a759d07e6922b179678c41f03bd27bb5a36) git-annex: update sha256 for 10.20240831
* [`dfb10eff`](https://github.com/NixOS/nixpkgs/commit/dfb10eff9edbd1c1ed771365463c1ac9875f8fd3) tetrio-desktop: format with nixfmt
* [`9baf2743`](https://github.com/NixOS/nixpkgs/commit/9baf2743ad56503631b11d0a1e4adfae4f44a159) doc/hooks/desktop-file-utils: document hook
* [`cc27161f`](https://github.com/NixOS/nixpkgs/commit/cc27161f1ce3a5f5526d0ff2aa61107fcfdce3fc) haskellPackages.weeder: 2.8.0 -> 2.9.0
* [`9d2a706a`](https://github.com/NixOS/nixpkgs/commit/9d2a706ae7b358268e77a281a86facbd271df515) haskellPackages.xmonad-contrib: restrict to < 0.18.1 to match xmonad
* [`43f616a7`](https://github.com/NixOS/nixpkgs/commit/43f616a7cc2ee6c755c2860b0e974c255c911a13) realvnc-vnc-viewer: 7.12.0 -> 7.12.1
* [`b039994d`](https://github.com/NixOS/nixpkgs/commit/b039994dad3a4288dfdffe388cf97faf39240c5a) haskell.compiler.ghc*: use matching CLANG & CC on Darwin with LLVM
* [`a40acaa2`](https://github.com/NixOS/nixpkgs/commit/a40acaa2b626cde67411b02799ce104a511808e6) canokey-usbip: init at unstable-2024-03-11
* [`e6fe1b9c`](https://github.com/NixOS/nixpkgs/commit/e6fe1b9ccd4917b270844fbd01358a36364dd09b) firefox: set better default for libName
* [`9ee18fb3`](https://github.com/NixOS/nixpkgs/commit/9ee18fb33e0679ffc83246c8d5890febdda32d3b) haskell.packages.ghc910.hoogle: Enable hydra job
* [`65feac83`](https://github.com/NixOS/nixpkgs/commit/65feac831199e1dd8075a825f85f01c83a6eaeb5) nixos/tests/tmate-ssh-server: fix test
* [`48276abd`](https://github.com/NixOS/nixpkgs/commit/48276abd93a8843748ae21e935785b1c53378cb9) maintainers: add mohe2015
* [`b5aefcd4`](https://github.com/NixOS/nixpkgs/commit/b5aefcd40a4c5a0db8275e72fd18018a9d94b77b) fetchgx: support `hash` attribute
* [`1ccd5ba5`](https://github.com/NixOS/nixpkgs/commit/1ccd5ba5405b90482518e9f76b6cecba850c3be3) fetchs3: support `hash` attribute
* [`fb8a85e2`](https://github.com/NixOS/nixpkgs/commit/fb8a85e2bb111e587211be819efa275854b2a6b2) fetchbzr: support `hash` attribute
* [`07d3b14c`](https://github.com/NixOS/nixpkgs/commit/07d3b14ce251db9c4c9ee59e72c489003f67df17) nix-prefetch-bzr: emit SRI hashes by default
* [`a7013f2f`](https://github.com/NixOS/nixpkgs/commit/a7013f2fc3520ba5f082576be22d1da14f240376) gweled: `sha256` → `hash`
* [`ef232d59`](https://github.com/NixOS/nixpkgs/commit/ef232d59ac5fc448714898783ff17603177a9c68) fetchcvs: support `hash` attribute
* [`3f7f5df3`](https://github.com/NixOS/nixpkgs/commit/3f7f5df38ab417d031632228fc3a7eb67d27905c) nix-prefetch-cvs: emit SRI hashes by default
* [`54209fcd`](https://github.com/NixOS/nixpkgs/commit/54209fcd9e50adfb7be203dd790e206dd8a11123) fetchmtn: support `hash` attribute
* [`8af38be3`](https://github.com/NixOS/nixpkgs/commit/8af38be358c39fc4413303539d41d9a652aaba58) netbsd: `sha256` → `hash`
* [`4b8644b7`](https://github.com/NixOS/nixpkgs/commit/4b8644b7a69821f5e0bd07ba6350087a3b08dcb3) fetchdarcs: support `hash` attribute
* [`f723aa0f`](https://github.com/NixOS/nixpkgs/commit/f723aa0f6620154e1d6f42588ed983e8aa4d9eac) fetchpijul: minor simplification
* [`c3691d77`](https://github.com/NixOS/nixpkgs/commit/c3691d772d954f14e8a93256faaaff0d3348af8f) fetchfossil: simplify and check that multiple hashes were not passed in
* [`a8c21f4c`](https://github.com/NixOS/nixpkgs/commit/a8c21f4c11e922da13b34f15cb2515fb5317c242) althttpd: `sha256` → `hash`
* [`30361c57`](https://github.com/NixOS/nixpkgs/commit/30361c578fb4ece9def77ed5f6f2083f58a80e54) fetchsvnssh: support `hash` attribute
* [`7c19bb37`](https://github.com/NixOS/nixpkgs/commit/7c19bb37a30e1601543b104f78ef6079a465e2c3) fetchipfs: simplify, error-out when given multiple hashes
* [`003a8a41`](https://github.com/NixOS/nixpkgs/commit/003a8a41e33f6bbd9350caa632b30a49c9f7895a) gitstatus: add prompt scripts and share helper
* [`d74187c8`](https://github.com/NixOS/nixpkgs/commit/d74187c8b4c768ee202406e2b4acaeb8b5263cf7) knossosnet: 1.2.0 -> 1.2.3
* [`fd13a803`](https://github.com/NixOS/nixpkgs/commit/fd13a803d4472e120a5bb5420cfc02fa5e91b46e) calamares-nixos: 3.3.8 -> 3.3.9
* [`a065b80b`](https://github.com/NixOS/nixpkgs/commit/a065b80b90b6d559c67b519b3fcd018d803cdd68) wpa_supplicant: add patch to fix ext_passwords_file bug
* [`98c67f66`](https://github.com/NixOS/nixpkgs/commit/98c67f661daa23112cef0bedffebf9f285f24dbe) nixos/wpa_supplicant: test a naughty passphrase
* [`e4fc65e0`](https://github.com/NixOS/nixpkgs/commit/e4fc65e079fcf2ea3d98ecde971912a7898ebc79) nixos/garage: reformat
* [`cb905a56`](https://github.com/NixOS/nixpkgs/commit/cb905a5649281058c61c0f0835222cd6bc7bc0fc) nixos/garage: add mjm as maintainer
* [`4d3d3e46`](https://github.com/NixOS/nixpkgs/commit/4d3d3e46fec7e9d12c8c01893818f238bfd3a8d9) nixos/garage: fix StateDirectory check to work with multiple data_dirs
* [`5f67a5f3`](https://github.com/NixOS/nixpkgs/commit/5f67a5f326e7addc00761bcc14b959c6d7cb575f) finamp: 0.9.9-beta -> 0.9.11-beta
* [`f716fa53`](https://github.com/NixOS/nixpkgs/commit/f716fa5303f16769af69b424ca0600cbc5877f1f) haskell.compiler.*: pass --with-curses-* flags again
* [`2c878dce`](https://github.com/NixOS/nixpkgs/commit/2c878dce6a6aa04d944f4a97f7e9291acee82545) top-level/release-haskell.nix: reflect removal of mailctl
* [`6c00c676`](https://github.com/NixOS/nixpkgs/commit/6c00c676f1cf0aa0aedd3c77e77d93b4c912356a) haskell.compiler.ghc96*: use patch for unlit workaround
* [`8bf0041d`](https://github.com/NixOS/nixpkgs/commit/8bf0041dc66713c90b626ed890138d87fa7c5555) haskell.compiler.ghc9*: fix rpath on aarch64-linux
* [`e04b9301`](https://github.com/NixOS/nixpkgs/commit/e04b930173c29ec175ef26bdf787945eb7460f1e) haskell.compiler.*: check that there are no references to stage0
* [`4903ac93`](https://github.com/NixOS/nixpkgs/commit/4903ac938b7d1c3dd1b40a0f8e97abcf904b30c3) haskell.compiler.*: remove perl from buildInputs
* [`097aff7a`](https://github.com/NixOS/nixpkgs/commit/097aff7affd0d4bc909797468a1455fcade840de) haskell.compiler.*: move bootPkgs.ghc to depsBuildBuild
* [`04fcf3c5`](https://github.com/NixOS/nixpkgs/commit/04fcf3c5bd7bc234123d980819714ec2879ad65d) maintainers: add pizzapim
* [`af068bf6`](https://github.com/NixOS/nixpkgs/commit/af068bf63a91abf1cb490e7557591c3ca0141d0d) maintainers: add scraptux
* [`650a1f2f`](https://github.com/NixOS/nixpkgs/commit/650a1f2f8be80125e51c2ce904257b8c4b9a6d77) vscode-extensions.sas.sas-lsp: init at 1.10.2
* [`f1daa46d`](https://github.com/NixOS/nixpkgs/commit/f1daa46d4547cd5c8c36ab6679bfe7932aa738a7) nixos/gatus: init module
* [`7d68a055`](https://github.com/NixOS/nixpkgs/commit/7d68a055b9ce74484d0de474ac6c44d0bfb25afe) gatus: add nixosTest
* [`bbc86951`](https://github.com/NixOS/nixpkgs/commit/bbc869511ecb6a153cf8f7d445dacdefbd3dbcc3) chiaki-ng: 1.8.1 -> 1.9.0
* [`f373abe6`](https://github.com/NixOS/nixpkgs/commit/f373abe60b11bf83c48a7fa84fc9f2c5c8d5151e) liquibase: Use `finalAttrs` for recursive fixpoint
* [`2e36424e`](https://github.com/NixOS/nixpkgs/commit/2e36424e03c0f42ee5a4c8d19a1ead5616cc8357) angie: 1.6.2 -> 1.7.0
* [`d0542fe3`](https://github.com/NixOS/nixpkgs/commit/d0542fe3cdc451328e917ee2b40ca776425e0cbc) flake.nix: Add doc comments
* [`dc7d86c5`](https://github.com/NixOS/nixpkgs/commit/dc7d86c51c69cb29be1f187948bd8e87e688d30a) chiaki-ng: remove pinned libplacebo version
* [`91e208ae`](https://github.com/NixOS/nixpkgs/commit/91e208ae023615d211135b81667089c15760822c) maintainers: add BonusPlay
* [`69830dad`](https://github.com/NixOS/nixpkgs/commit/69830dad8faab63c1c767ccfc3478c32a35e3510) top-level/release-haskell.nix: add jobs for cross compiled GHCs
* [`f3f40a16`](https://github.com/NixOS/nixpkgs/commit/f3f40a16c748534cead9acea568aac46b4005611) binutils: CoreServices depends on host, not build platform
* [`e51ed7ef`](https://github.com/NixOS/nixpkgs/commit/e51ed7ef17f0c9b53010a9acac9711981e8f1078) chickenPackages.chickenEggs.webview: repair
* [`fc4cdcfd`](https://github.com/NixOS/nixpkgs/commit/fc4cdcfdec4d9b55a3a039ffd56e7370dc6e1cab) python3Packages.proto-plus: 1.23.0 -> 1.24.0
* [`0e8c4663`](https://github.com/NixOS/nixpkgs/commit/0e8c4663aa40b2ff2ffb2b01936400c48f8bd628) intel-undervolt: init at 1.7
* [`342a47f9`](https://github.com/NixOS/nixpkgs/commit/342a47f9bcbdf636158bf7fed22f9d94af1189d9) nixos/networkd: add DHCPv4 - IPv6OnlyMode toggle
* [`2b38e1e0`](https://github.com/NixOS/nixpkgs/commit/2b38e1e0a933bef3bb7700afaad6081345a2dc3f) zenn-cli: 0.1.155 -> 0.1.157
* [`bf41830b`](https://github.com/NixOS/nixpkgs/commit/bf41830b1c584c19a71f2626ea2a39e398aad0df) gnomeExtensions.unite: 79 -> 80
* [`e852c133`](https://github.com/NixOS/nixpkgs/commit/e852c13342e78994300f1cb329fc146b17d93f6e) writers: disable broken test (fsharp)
* [`55903a2f`](https://github.com/NixOS/nixpkgs/commit/55903a2f8ed80146547744aeb72130466c89d975) writers: add babashka
* [`5ea164c8`](https://github.com/NixOS/nixpkgs/commit/5ea164c8db0fe96c3b365c1efd4dab5065b7c476) libspng: fix cross compile
* [`74a5f772`](https://github.com/NixOS/nixpkgs/commit/74a5f772749c7ccd9b4f111a6194598e4fc81de5) switch-to-configuration-ng: update rust-ini to support multi-line INI values
* [`f6fed8b8`](https://github.com/NixOS/nixpkgs/commit/f6fed8b8317bf6f8ee8101c211f5a44787f2d97d) nixos/switch-test: add test for multi-line unit values
* [`a8fe9a45`](https://github.com/NixOS/nixpkgs/commit/a8fe9a45aebcdaf1118b58016932306507ef629f) ghidra: add findcrypt extension
* [`eb2f0760`](https://github.com/NixOS/nixpkgs/commit/eb2f0760dd6dcfeae10363c90774735cd375b0d3) asusctl: 6.0.9 -> 6.0.12
* [`75d77524`](https://github.com/NixOS/nixpkgs/commit/75d77524ac02cbbdd0ac83cb3da109ee441ce045) nixos/usbStorage: apply upstream
* [`27fe8596`](https://github.com/NixOS/nixpkgs/commit/27fe8596dc73d031deb06f57dc8dbb3b76ac168d) Lamdera 1.3.0
* [`341442bd`](https://github.com/NixOS/nixpkgs/commit/341442bd7eda3dda19607f9fa232f3474c45f47d) esbuild: 0.23.1 -> 0.24.0
* [`2831842a`](https://github.com/NixOS/nixpkgs/commit/2831842ad1b114397907eb2ab7aad652f1df1d2b) jotdown: 0.5.0 -> 0.6.0
* [`a9dcd648`](https://github.com/NixOS/nixpkgs/commit/a9dcd648d59cc85d2cb1db4f694f48e2629d1213) flatpak: Don't propagate /etc/zoneinfo into sandbox
* [`5cb00643`](https://github.com/NixOS/nixpkgs/commit/5cb00643629e960e2a7c6c2aa96d94feff1ba666) c3-lsp: init at 0.3.2
* [`1f42ffa2`](https://github.com/NixOS/nixpkgs/commit/1f42ffa2b4ae9f2b8e088443ac39b29937f8636f) lact: 0.5.5 -> 0.5.6
* [`ada79bff`](https://github.com/NixOS/nixpkgs/commit/ada79bfff2aad6f4c09e14efeecfdbd1a4e767e4) plasticity: 24.2.0 -> 24.2.3
* [`5f7adcb3`](https://github.com/NixOS/nixpkgs/commit/5f7adcb34974e473bcf59541ff70fd9226815d86) lean4: 4.9.1 -> 4.10.0
* [`557846c5`](https://github.com/NixOS/nixpkgs/commit/557846c520706940dc520fe5d5ef7bb25beafb32) elasticmq-server-bin: 1.6.7 -> 1.6.8
* [`5d3c605f`](https://github.com/NixOS/nixpkgs/commit/5d3c605f5fa44f3e1d877402e5cd925a41d196ee) openjph: 0.15.0 -> 0.17.0
* [`cc7f81cd`](https://github.com/NixOS/nixpkgs/commit/cc7f81cdbd61dd6614e05126c60d8054d24f2730) stellarium: 24.2 -> 24.3
* [`e2d259eb`](https://github.com/NixOS/nixpkgs/commit/e2d259ebc05f57cf74677cb924febefe2c0b71e2) pkgs.haskell.lib: Add disableParallelBuilding function
* [`931fd13d`](https://github.com/NixOS/nixpkgs/commit/931fd13dd21ddb2940887709664e85908c47f533) haskellPackages.gi-gtk: Re-enable parallel building
* [`f46b2c2c`](https://github.com/NixOS/nixpkgs/commit/f46b2c2ca77368bacbc961d9b5ad82b820b2cff1) {ftjam,jam}: "remove"
* [`8c7c8ab8`](https://github.com/NixOS/nixpkgs/commit/8c7c8ab880ecf63b9bc5b9210f73abeb9b6e0dc7) ftjam: refactor
* [`98ac6851`](https://github.com/NixOS/nixpkgs/commit/98ac68511e49f455286dbc172f53a48616c6392d) jam: refactor
* [`cbb3d6d9`](https://github.com/NixOS/nixpkgs/commit/cbb3d6d9b716757243eb78bfdf943bfa7762d881) stats: 2.11.7 -> 2.11.11
* [`4fc7228b`](https://github.com/NixOS/nixpkgs/commit/4fc7228b7291d47e1be49b5598ade922b9e48378) ibus-engines.table-others: 1.3.17 -> 1.3.18
* [`ded7972d`](https://github.com/NixOS/nixpkgs/commit/ded7972d72649c85bf157fbac126a0ccde432c50) imsprog: 1.4.3 -> 1.4.4
* [`0553db55`](https://github.com/NixOS/nixpkgs/commit/0553db553f6b834fd305477f7f7155dbfcc5ef32) shopify-cli: 3.63.2 -> 3.67.1
* [`0cac1f10`](https://github.com/NixOS/nixpkgs/commit/0cac1f100d430a58733616e9fbe7010374b05112) haskell.compiler.*: don't declare stage0 ghc as dep to stdenv
* [`5ad0f9ac`](https://github.com/NixOS/nixpkgs/commit/5ad0f9ac30f8172da997fc9fc6804e34500a1d1b) haskell.compiler.*: let configure know about objdump
* [`5b15a1f5`](https://github.com/NixOS/nixpkgs/commit/5b15a1f577931e4685cab06cdf782538e0e1deff) haskell.compiler.*: use symlinks from bintool wrapper if possible
* [`e89d03ce`](https://github.com/NixOS/nixpkgs/commit/e89d03cef325b41d5b5e1778447fffd594de468b) vtm: 0.9.99.09 -> 0.9.99.13
* [`46044101`](https://github.com/NixOS/nixpkgs/commit/46044101f34f0f4ae04733a0a43b3f2e52c7a067) nixos/gns3-server: fix ubridge_path
* [`77edd2b0`](https://github.com/NixOS/nixpkgs/commit/77edd2b0666eaa21649212c88da4ac61a7d37a34) nixos/gns3-server: disable SystemD DisableUser
* [`c1104aee`](https://github.com/NixOS/nixpkgs/commit/c1104aee4de80d5df792c26a8d429baeed02c1ff) nixos/gns3-server: disable SystemD hardening
* [`e123625a`](https://github.com/NixOS/nixpkgs/commit/e123625aa94e98f5aadec07ba854762a99991bc1) markdown-anki-decks: fix build
* [`390728af`](https://github.com/NixOS/nixpkgs/commit/390728afda76f68029c3082fd441936e01d49872) crd2pulumi: 1.5.0 -> 1.5.2
* [`07f17240`](https://github.com/NixOS/nixpkgs/commit/07f17240f7ee86af5c39e5be5757a3c8353eb467) firebase-tools: 13.17.0 -> 13.18.0
* [`76f1ad84`](https://github.com/NixOS/nixpkgs/commit/76f1ad84c833a96091313739edee2d85a972c6cc) satellite: 0.4.3 -> 0.5.0
* [`b4a69dcb`](https://github.com/NixOS/nixpkgs/commit/b4a69dcb47db8026496ef128a2962dd17996f67f) thunderbird: expose icu patch in passthru
* [`febd2e6c`](https://github.com/NixOS/nixpkgs/commit/febd2e6c309275008c946c73d758398c84137844) betterbird: apply icu patch from thunderbird
* [`aef3e2c8`](https://github.com/NixOS/nixpkgs/commit/aef3e2c8cced2f98c1210c5db18a932c96f7b01b) codeium: 1.16.11 -> 1.16.18
* [`994311da`](https://github.com/NixOS/nixpkgs/commit/994311dad765d6facd2ca734364f8d25b162e1fa) esphome: 2024.9.0 -> 2024.9.1
* [`58fe27c6`](https://github.com/NixOS/nixpkgs/commit/58fe27c67d773e6d46ef3aa3a3f4eb2c9155b026) mov-cli: 4.4.12 -> 4.4.14
* [`1b42ad15`](https://github.com/NixOS/nixpkgs/commit/1b42ad1524c9cca9678e53cef7757e4d86e42d2b) abbaye-des-morts: 2.0.2 -> 2.0.4
* [`52fd714a`](https://github.com/NixOS/nixpkgs/commit/52fd714a84706f6a751e565a0009802e8bfa73e1) berkeleydb: skip tests on macOS to fix build
* [`607be34f`](https://github.com/NixOS/nixpkgs/commit/607be34fdd8c3393ef2fcbafccfa3f0d0613aea9) delve: 1.23.0 -> 1.23.1
* [`7471ddea`](https://github.com/NixOS/nixpkgs/commit/7471ddea304aa765179507054a752d3540384edb) snazy: 0.52.17 -> 0.53.0
* [`d95b15d1`](https://github.com/NixOS/nixpkgs/commit/d95b15d100c0be6151f4c35cf9d0668de32d161c) talosctl: 1.7.6 -> 1.8.0
* [`5e26dac4`](https://github.com/NixOS/nixpkgs/commit/5e26dac4a47732cfcad4cb28c71838f472305651) buildah-unwrapped: 1.37.2 -> 1.37.3
* [`3bd2e06a`](https://github.com/NixOS/nixpkgs/commit/3bd2e06a389158dde580d80f8a6a5f403886cc8a) stalwart-mail.webadmin: 0.1.13 -> 0.1.15
* [`d2300b89`](https://github.com/NixOS/nixpkgs/commit/d2300b891399d111c02b291c8b037904895324a0) cairosvg: add cli
* [`193cfe48`](https://github.com/NixOS/nixpkgs/commit/193cfe48d476ede39aa3399cf25263fbc1894639) activemq: migrate to pkgs/by-name, format with nixfmt-rfc-style
* [`d6f05e3a`](https://github.com/NixOS/nixpkgs/commit/d6f05e3a846768ecf9cafc2f69a68f5313cfbcd1) activemq: 6.1.2 -> 6.1.3
* [`b0a49957`](https://github.com/NixOS/nixpkgs/commit/b0a499578ca1afd075a1bf3597002b55f5416f47) activemq: add anthonyroussel to maintainers
* [`5aa44a45`](https://github.com/NixOS/nixpkgs/commit/5aa44a45a9205f43bf7cf6bccb409d5df7a232e7) gotrue-supabase: 2.160.0 -> 2.161.0
* [`e7e8be8c`](https://github.com/NixOS/nixpkgs/commit/e7e8be8c740f48ee13dc8a91169e7b529b07b68f) devbox: 0.12.0 -> 0.13.0
* [`0a522de2`](https://github.com/NixOS/nixpkgs/commit/0a522de24902f9bbdb9423c101038cab1e9c84b1) movim: 0.27.1 → 0.28
* [`b14d6d0e`](https://github.com/NixOS/nixpkgs/commit/b14d6d0e1c4a066556df7c3d78f6843d06bff029) fnc: 0.16 -> 0.18
* [`9bc6d231`](https://github.com/NixOS/nixpkgs/commit/9bc6d2311105f2b46653cb8d39bf4a4c45db1a3c) buildFHSEnvBubblewrap: extraPreBwrapCmds after variable initialisation
* [`c914c30b`](https://github.com/NixOS/nixpkgs/commit/c914c30b5b9f65577b83cf0b84a01e46fa1ddf96) fflogs: 8.13.5 -> 8.14.0
* [`4437f876`](https://github.com/NixOS/nixpkgs/commit/4437f8763376ac86cd7658f1997d8e85ebc375cc) arduino-ide: 2.3.2 -> 2.3.3
* [`386df84f`](https://github.com/NixOS/nixpkgs/commit/386df84fa286745c51a7a2f18c2395ec29285ef8) python312Packages.blake3: init at 0.4.1
* [`32e29a2d`](https://github.com/NixOS/nixpkgs/commit/32e29a2dd630d575d49acce80b6dda45e4c63346) nwjs-ffmpeg-prebuilt: 0.91.0 -> 0.92.0
* [`1351b9e0`](https://github.com/NixOS/nixpkgs/commit/1351b9e0e1a6639071e619e6929dd1e8fa516b2d) cosmic-term: 1.0.0-alpha.1 -> 1.0.0-alpha.2
* [`34eada36`](https://github.com/NixOS/nixpkgs/commit/34eada36cf3a85f34d48c690d3a1c2502ac9ee81) nova: 3.10.1 -> 3.10.2
* [`0698a5dd`](https://github.com/NixOS/nixpkgs/commit/0698a5ddba45bfacf5ad7325f0b59d2c56d2e195) cosmic-store: 1.0.0-alpha.1 -> 1.0.0-alpha.2
* [`5d5f6bf6`](https://github.com/NixOS/nixpkgs/commit/5d5f6bf693cd34617e8935aecf1d23cae564cab4) python312Packages.pysmb: 1.2.9.1 -> 1.2.10
* [`29449dea`](https://github.com/NixOS/nixpkgs/commit/29449deaf7812708d5921608f1a3197f39c3fda1) Add more options to unl0kr
* [`fba9cc15`](https://github.com/NixOS/nixpkgs/commit/fba9cc1544fb09f3b77608d84ff0d2321d55c570) mangl: init at 1.1.5-unstable-2024-07-10
* [`2e5c96e5`](https://github.com/NixOS/nixpkgs/commit/2e5c96e562f8bcfb5f18f8705564ad3c47a992af) cosmic-session: 1.0.0-alpha.1 -> 1.0.0-alpha.2
* [`d5a0c1e5`](https://github.com/NixOS/nixpkgs/commit/d5a0c1e5c779ddf8df924c805d4d00e1875efbc1) cosmic-session: remove unused argument
* [`051f75f1`](https://github.com/NixOS/nixpkgs/commit/051f75f1a9de50a16c2c26e62fb6edc2511ddbfe) veracrypt: 1.26.7 -> 1.26.14, move to pkgs/by-name
* [`a123b04f`](https://github.com/NixOS/nixpkgs/commit/a123b04fd799398ba8f0e5bc11269017429a21bb) cosmic-bg: 1.0.0-alpha.1 -> 1.0.0-alpha.2
* [`202021fa`](https://github.com/NixOS/nixpkgs/commit/202021faf6417a8da47b534538e9e753ddbdd8ac) veracrypt: format using nixfmt-rfc-style
* [`ef795629`](https://github.com/NixOS/nixpkgs/commit/ef7956291fd5ca30f7d5fdf66c1012e7ff1efb4b) veracrypt: remove `with lib;`, add myself as maintainer
* [`090269bd`](https://github.com/NixOS/nixpkgs/commit/090269bd7d57fba606ef7d5d96fc11ccd8fff2bb) radarr: 5.9.1.9070 -> 5.11.0.9244
* [`6bd5354f`](https://github.com/NixOS/nixpkgs/commit/6bd5354f0c39a658a5a01c7349f90898f13011ab) cosmic-greeter: 1.0.0-alpha.1 -> 1.0.0-alpha.2
* [`a09f3e76`](https://github.com/NixOS/nixpkgs/commit/a09f3e76f264bb5dd37b3cd767146cce2b844766) cosmic-greeter: remove unused argument
* [`49fd638a`](https://github.com/NixOS/nixpkgs/commit/49fd638a47bca86a5258ccb0d207cef9a47474b5) ncmpcpp: fix visualizer configure flag
* [`90b1b644`](https://github.com/NixOS/nixpkgs/commit/90b1b644700e3a69efaf593d65bbbdf38111a0f7) cosmic-workspaces-epoch: 1.0.0-alpha.1 -> 1.0.0-alpha.2
* [`0071dc62`](https://github.com/NixOS/nixpkgs/commit/0071dc629f7b2d455fbd691c7bdd6383a7545e0c) cosmic-workspaces-epoch: inline pname repo
* [`be5f3bd3`](https://github.com/NixOS/nixpkgs/commit/be5f3bd31e72a0e22cfae128f97bdc79eb32dd6c) bochs: use lib.* string functions
* [`a06a1a61`](https://github.com/NixOS/nixpkgs/commit/a06a1a61a1db22bd168e90226414cc35c4bcd0d9) galculator: migrate to by-name
* [`0a487d27`](https://github.com/NixOS/nixpkgs/commit/0a487d274f5dfc58c8449719620a3df9da064960) galculator: refactor
* [`0dcfe7e5`](https://github.com/NixOS/nixpkgs/commit/0dcfe7e565e2888a3178e2b735408bcafbec7421) nixos.mautrix-meta: Update config to 0.4 format
* [`d174c0fd`](https://github.com/NixOS/nixpkgs/commit/d174c0fda8697b808b380f2f44e27a3f0409ae86) nuclear: 0.6.31 -> 0.6.39
* [`2456a36c`](https://github.com/NixOS/nixpkgs/commit/2456a36c6ad4bb0739aac4098ac7b2ec085b23e2) klayout: 0.29.6 -> 0.29.7
* [`780aa237`](https://github.com/NixOS/nixpkgs/commit/780aa2379092d0f11ec55466170e7d90e9515196) bibletime: libsForQt5.callPackage -> callPackage
* [`b38bd063`](https://github.com/NixOS/nixpkgs/commit/b38bd06347fda29a5060d3e6a2dfae05f9f81d47) bibletime: migrate to by-name
* [`3a2b613e`](https://github.com/NixOS/nixpkgs/commit/3a2b613ecac020ba61ca5b2752b5f672ef578179) bibletime: refactor
* [`8d6e1018`](https://github.com/NixOS/nixpkgs/commit/8d6e1018936c4f9f7cd322a6dd08bef6a26d0435) tests.pkg-config: extend current Nixpkgs configuration
* [`77eb5dfe`](https://github.com/NixOS/nixpkgs/commit/77eb5dfe220b9ebee8a7b0274b8ceee939f34b07) cudaPackages_{10*,11*}: warn about upcoming removal
* [`306c5e55`](https://github.com/NixOS/nixpkgs/commit/306c5e55e7d05ff41756f28fd3b44c6fa1aee4bd) vault: 1.17.5 -> 1.17.6
* [`45f43614`](https://github.com/NixOS/nixpkgs/commit/45f4361477374da95de9279c19abfe8941757817) vault: move to pkgs/by-name
* [`0421579b`](https://github.com/NixOS/nixpkgs/commit/0421579b13c65d53caf75a686641716dd4a35440) vault: nixfmt
* [`74d6d7b3`](https://github.com/NixOS/nixpkgs/commit/74d6d7b3f4aa4940f3ba51a5a6402a78d5c77c02) vault-bin: 1.17.5 -> 1.17.6
* [`2460ec66`](https://github.com/NixOS/nixpkgs/commit/2460ec66bb6b5156b013aad306eba2b7cbbc780a) vault-bin: move to pkgs/by-name
* [`b99a01b7`](https://github.com/NixOS/nixpkgs/commit/b99a01b7113cfebb499864d89d0df560bfde9c58) vault-bin: nixfmt
* [`c076e341`](https://github.com/NixOS/nixpkgs/commit/c076e3418c81ad40f6fb57673fc185fe686a9ba6) openseachest: 24.08 -> 24.08.1
* [`8e2b735e`](https://github.com/NixOS/nixpkgs/commit/8e2b735ee0db2816961d73878dabab4663501394) alt-ergo: 2.5.4 → 2.6.0
* [`a0396049`](https://github.com/NixOS/nixpkgs/commit/a03960496e4c100f988fa523009c6e3182533f04) terramate: 0.10.4 -> 0.10.6
* [`6a1ce548`](https://github.com/NixOS/nixpkgs/commit/6a1ce54871ef03235b5756a8d4ac90154c73b384) nextflow: 22.10.6 -> 24.04.4 + remove buildFHSEnv
* [`e7dac85a`](https://github.com/NixOS/nixpkgs/commit/e7dac85a8173ded92b679c21c43ee051d3eac028) nextflow: add a passthru.tests.version
* [`8d15ee11`](https://github.com/NixOS/nixpkgs/commit/8d15ee11acca4b076a427362ea3f3097a4f2b6c0) tests/nextflow: init
* [`c20a2c9c`](https://github.com/NixOS/nixpkgs/commit/c20a2c9c32aaec742a2e21612e677d8e3f305b83) curl-impersonate-chrome: 0.7.0 -> 0.8.0
* [`1a133b17`](https://github.com/NixOS/nixpkgs/commit/1a133b175d6e62df40f8d2582a79cfdab79f48ba) jbrowse: 2.15.1 -> 2.15.4
* [`8ecc78e6`](https://github.com/NixOS/nixpkgs/commit/8ecc78e6462ab136a3c42801b84e8591b2a3093e) onioncircuits: 0.7 -> 0.8.1
* [`cea4885f`](https://github.com/NixOS/nixpkgs/commit/cea4885f8d6c356b48096919742839c76511cbae) corretto{11,17,21}: {11.0.23.9.1,17.0.11.9.1,21.0.3.9.1} -> {11.0.24.8.1,17.0.12.7.1,21.0.4.7.1}
* [`a0bec3f7`](https://github.com/NixOS/nixpkgs/commit/a0bec3f71e169f865bb300495c3ca93b91f36043) corretto{11,17,21}: apply nixfmt
* [`a55d8471`](https://github.com/NixOS/nixpkgs/commit/a55d847171ccdfbc6bf956657a8c0ca159ccda27) riseup-vpn: 0.21.11 -> 0.24.8
* [`23970016`](https://github.com/NixOS/nixpkgs/commit/23970016579f52e54f83f7ab3bf890db318c47c3) datadog-agent: unpin Go version
* [`3292bd5b`](https://github.com/NixOS/nixpkgs/commit/3292bd5b01f0115f7c8675cb2460bfaaef9a10e0) crawl: 0.32.0 -> 0.32.1
* [`9bd83ec2`](https://github.com/NixOS/nixpkgs/commit/9bd83ec263c44d9619325e99a7e33f256868dc24) gren: init at 0.4.5
* [`c846f1d0`](https://github.com/NixOS/nixpkgs/commit/c846f1d01a7cfa65b54cce180e13d43d42ec49dc) minizincide: 2.8.5 -> 2.8.6
* [`780a4929`](https://github.com/NixOS/nixpkgs/commit/780a49292920669e4afff1a029e23b8d3bc205c8) the-foundation: 1.8.1 → 1.9.0
* [`6f1d170f`](https://github.com/NixOS/nixpkgs/commit/6f1d170fe6c7d605e8331a002970e8e473962b1d) alt-ergo: split into multiple outputs
* [`91394156`](https://github.com/NixOS/nixpkgs/commit/9139415648b1d46fcf5df2620d4479a042057953) ocamlPackages.lsp: 1.18.0 → 1.19.0
* [`65eea038`](https://github.com/NixOS/nixpkgs/commit/65eea0383988286f43dc2bf8450fdd5d09021707) lib/modules: Improve error when loading a flake as a module
* [`9a3eba01`](https://github.com/NixOS/nixpkgs/commit/9a3eba01c50c3d1c4a5aa0438058943a1dc00e70) ollama: only set `updateScript` for `ollama`, not `ollama-{rocm,cuda}`
* [`76ea88d1`](https://github.com/NixOS/nixpkgs/commit/76ea88d11a221e8ea0f5fd3f1c7168894cfaee89) wavebox: 10.128.7-2 -> 10.129.27-2
* [`1c72f09b`](https://github.com/NixOS/nixpkgs/commit/1c72f09b0726e746b2c3c38fc42cba069ccac303) plexamp: 4.11.1 -> 4.11.2
* [`7301f5b7`](https://github.com/NixOS/nixpkgs/commit/7301f5b7d27c1ded589dfd743e071f42e1b89cfe) hpcg: cleanup, add runHooks to InstallPhase
* [`21377a28`](https://github.com/NixOS/nixpkgs/commit/21377a28765e05791188e72810aa672a695851d4) hpcg: move to pkgs/by-name
* [`077fedc9`](https://github.com/NixOS/nixpkgs/commit/077fedc902d0bb0d64f27ed278faa598289025b8) hpcg: apply nixfmt
* [`8e9cb69d`](https://github.com/NixOS/nixpkgs/commit/8e9cb69da9a391783b799f479c1c89537955a380) gcc11: update darwin support patch to 11.5.0
* [`58e115dc`](https://github.com/NixOS/nixpkgs/commit/58e115dc5324ce0c9ae81ec30c5cc33e17580cd7) gcc11: drop libgcc-aarch64-darwin-detection upstreamed patch
* [`a3340a9a`](https://github.com/NixOS/nixpkgs/commit/a3340a9a8cab63c51f6a5afa7e1b48d171a60f69) linuxPackages.nvidiaPackages.vulkan_beta: 550.40.71 -> 550.40.75
* [`0a221ab2`](https://github.com/NixOS/nixpkgs/commit/0a221ab2dedc11c89ed4e565b82155fe9cf0321b) dioxus-cli: 0.5.6 -> 0.5.7
* [`c2862ede`](https://github.com/NixOS/nixpkgs/commit/c2862ede74e9113d4ed6a922b6402fccab0f4d21) maintainers: add rayhem
* [`ad41323c`](https://github.com/NixOS/nixpkgs/commit/ad41323c9df3c55a9fa1598c4cb3a1daf9bfe735) lynis: 3.1.1 -> 3.1.2
* [`70a662d4`](https://github.com/NixOS/nixpkgs/commit/70a662d45b8d21a080a486a29db5665eaf1af8e4) freecad: 0.21.2 → 1.0rc1
* [`935e1d72`](https://github.com/NixOS/nixpkgs/commit/935e1d72db7458183ca4936a128f4ae947ae9a9a) freecad: 1.0rc1 → 1.0rc2
* [`1faf483a`](https://github.com/NixOS/nixpkgs/commit/1faf483a6d09b134d81104d3171e0ac9ae3d6ae5) staruml: moved to by-name
* [`2536bd78`](https://github.com/NixOS/nixpkgs/commit/2536bd783e82d22e9baada424a9918baf1e9a486) figma-linux: moved to by-name
* [`66ae511f`](https://github.com/NixOS/nixpkgs/commit/66ae511fb5b9c9bf00f2f8c93f3582de13dc23c1) infracost: moved to by-name
* [`41778ac4`](https://github.com/NixOS/nixpkgs/commit/41778ac4e94983d5cd8277988740012daa7daf71) obsidian: moved to by-name
* [`8283321d`](https://github.com/NixOS/nixpkgs/commit/8283321d14ec1f68064200953b4f47d201d7e0a9) scaleway-cli: moved to by-name
* [`3f286091`](https://github.com/NixOS/nixpkgs/commit/3f286091233c67bb53d816bc2a7d73a104497574) netbeans: moved to by-name
* [`28a7516c`](https://github.com/NixOS/nixpkgs/commit/28a7516cd23cf1ca8cbda046734d3b8341e9a4c7) openxr-loader: 1.1.40 -> 1.1.41
* [`6b835334`](https://github.com/NixOS/nixpkgs/commit/6b8353349cbb3b54de990370889f5854f8b38c6e) nixpacks: 1.28.1 -> 1.29.0
* [`1fa3315e`](https://github.com/NixOS/nixpkgs/commit/1fa3315ea1cf1113192474da151e16dcb5feaacf) pprof: 0-unstable-2024-07-10 -> 0-unstable-2024-09-25
* [`96abf503`](https://github.com/NixOS/nixpkgs/commit/96abf503155f9adc39dcfbf4ba627af2309ad8a0) ansible-navigator: 24.7.0 -> 24.9.0
* [`01525c4d`](https://github.com/NixOS/nixpkgs/commit/01525c4d9795e4f036f296163fe3aed834c91b6d) outline: 0.79.0 -> 0.80.2
* [`7b76bb2b`](https://github.com/NixOS/nixpkgs/commit/7b76bb2be13a60e6ed388b97522c4dcb43b2192a) hylafaxplus: 7.0.8 -> 7.0.9
* [`6bf2f158`](https://github.com/NixOS/nixpkgs/commit/6bf2f1589cf4d304fba849f4466ebd7a517bbb0d) sogo: 5.10.0 -> 5.11.0
* [`53733e14`](https://github.com/NixOS/nixpkgs/commit/53733e14ed712d0125e292b602ca91d51a8f5564) cassandra: 4.1.2 -> 4.1.7
* [`21ba7eff`](https://github.com/NixOS/nixpkgs/commit/21ba7effdca5353799f884ee0cc56be47af57973) dwlb: init at 0-unstable-2024-05-16
* [`3aa40fa3`](https://github.com/NixOS/nixpkgs/commit/3aa40fa3958bddcf225926b01645e7f72aeb672d) heimdal: 7.8.0-unstable-2023-11-29 -> 7.8.0-unstable-2024-09-10
* [`6358d987`](https://github.com/NixOS/nixpkgs/commit/6358d98704567a129314f700f1a35724c3358a0f) ulauncher: add mainProgram
* [`d5358688`](https://github.com/NixOS/nixpkgs/commit/d53586885c29681bfb05ee4867810ed8db95864d) cozette: 1.25.1 -> 1.25.2
* [`1962209f`](https://github.com/NixOS/nixpkgs/commit/1962209f7653968826702d8c4d1ec4c7671a92d6) nss_latest: 3.104 -> 3.105
* [`47c0dbd8`](https://github.com/NixOS/nixpkgs/commit/47c0dbd84e7afbeb1b2fc2114dda59d8ecada4be) fix elm-pages and elm-land builds
* [`fee3bfaa`](https://github.com/NixOS/nixpkgs/commit/fee3bfaa675fdcec8565860157779a0e4e2d9e1c) kyverno: 1.12.5 -> 1.12.6
* [`6ca8fb23`](https://github.com/NixOS/nixpkgs/commit/6ca8fb23fa1b116a89003f29d4f35e21d393cab8) pspg: 5.8.6 -> 5.8.7
* [`70be41ae`](https://github.com/NixOS/nixpkgs/commit/70be41ae3f950fe0a570ead53326e23dd5ebf66c) python312Packages.django-bootstrap4: 24.3 -> 24.4
* [`55367b38`](https://github.com/NixOS/nixpkgs/commit/55367b381af23045c93f7b85171db850e628ef7d) ghidra: 11.1.2 -> 11.2
* [`a2054f70`](https://github.com/NixOS/nixpkgs/commit/a2054f705bebb757a7bc1b5156eab063f7398117) airshipper 10.0 -> 14.0
* [`032bd1e2`](https://github.com/NixOS/nixpkgs/commit/032bd1e282919e3e2fe1d5159d4dbc2e9bc96914) immersed-vr: 9.10 -> 10.5.0
* [`f6882726`](https://github.com/NixOS/nixpkgs/commit/f6882726d8f62259668c1090ac3fe461b39c1185) luckybackup: libsForQt5.callPackage -> callPackage
* [`758ee913`](https://github.com/NixOS/nixpkgs/commit/758ee91317eafeaa1f3bbaf976af04e0efbe866c) luckybackup: migrate to by-name
* [`a689118a`](https://github.com/NixOS/nixpkgs/commit/a689118a3ff401667f3144f260764f5895b8f869) luckybackup: refactor
* [`6e567409`](https://github.com/NixOS/nixpkgs/commit/6e5674091b01c99d37437dfadd303d08d0d692d1) miracle-wm: 0.3.5 -> 0.3.6
* [`443e1337`](https://github.com/NixOS/nixpkgs/commit/443e1337c47caf46130c1cfd84994f64eefdab4b) mir*: nixfmt
* [`c1295e61`](https://github.com/NixOS/nixpkgs/commit/c1295e616427efbf1b7e85ad129a47693e3eaf1b) mir: 2.17.2 -> 2.18.0
* [`ea12c5d0`](https://github.com/NixOS/nixpkgs/commit/ea12c5d0aec9451310fb860c74e154b4af5f09e2) mir: Add miriway & miracle-wm as tests
* [`6dc52fe9`](https://github.com/NixOS/nixpkgs/commit/6dc52fe9a07686d456b39f8296fc57278f586185) uwsgi: 2.0.26 -> 2.0.27
* [`6474ec11`](https://github.com/NixOS/nixpkgs/commit/6474ec11bc438f7966cd112af847c03b6756e686) google-cloud-sdk: remove bundled python
* [`602fa25b`](https://github.com/NixOS/nixpkgs/commit/602fa25bef368e7949f74f7ac6ca3964d4ff1920) docs: fix links in "Automatic package updates"
* [`af4720c1`](https://github.com/NixOS/nixpkgs/commit/af4720c14d868d120d60a01aa178c98b57cb1675) lsp-ai: init at 0.7.1
* [`be396825`](https://github.com/NixOS/nixpkgs/commit/be39682588126e0270546398271f39d0e974ed49) renderdoc: libsForQt5.callPackage -> callPackage
* [`257ebd4d`](https://github.com/NixOS/nixpkgs/commit/257ebd4d0bd6354094e982548764dd16a4dcac78) renderdoc: migrate to by-name
* [`7ab97652`](https://github.com/NixOS/nixpkgs/commit/7ab9765219bfa618cf1ee9106b79e99be1cfc707) python312Packages.openai-whisper: 20231117 -> 20240927
* [`55a77e19`](https://github.com/NixOS/nixpkgs/commit/55a77e199391e2358cce831cb6e2cc5fe1f344f1) dae: add passthru.updateScript
* [`a14f9808`](https://github.com/NixOS/nixpkgs/commit/a14f9808a8f938e24ea1f80519f48dc290e9135d) dae: add luochen1990 to maintainers
* [`bc7ca673`](https://github.com/NixOS/nixpkgs/commit/bc7ca67350992e15b80e900f7d7cf9904339659a) dae: 0.7.1 -> 0.7.4
* [`31ebc7ef`](https://github.com/NixOS/nixpkgs/commit/31ebc7ef07ad3ccdbf1209133d63145661fafa10) goda: 0.5.9 -> 0.5.11
* [`f298abec`](https://github.com/NixOS/nixpkgs/commit/f298abec5a19d66fb304f0847a3b8e95389ee153) pagefind: 1.1.0 -> 1.1.1
* [`062aaf4d`](https://github.com/NixOS/nixpkgs/commit/062aaf4d907d6348e0f15c97e308b5fd909f9650) entangle: move to by-name; nixfmt
* [`7db7e2f7`](https://github.com/NixOS/nixpkgs/commit/7db7e2f7a73e2de2b59691d453eddf6c2c30e4a7) entangle: fix build
* [`75ca7c7c`](https://github.com/NixOS/nixpkgs/commit/75ca7c7c91c08870b08ae74e1707b2b9c181dc97) python312Packages.awslambdaric: 2.1.0 -> 2.2.1
* [`4e77373c`](https://github.com/NixOS/nixpkgs/commit/4e77373c08eed2b6734e29bec656aa74a141b848) renderdoc: refactor
* [`7451f5ed`](https://github.com/NixOS/nixpkgs/commit/7451f5ed7d304fa58b0459d3439f15b70d6e364b) renderdoc: 1.34 -> 1.35
* [`726d02f6`](https://github.com/NixOS/nixpkgs/commit/726d02f644e07887afc65e7227516f0758bf323c) quickjs: refactor
* [`e100ad4e`](https://github.com/NixOS/nixpkgs/commit/e100ad4eb7f4f7bba61efd967c1ddf28b9c109da) quickjs-ng: adopt and refactor
* [`2d7206bf`](https://github.com/NixOS/nixpkgs/commit/2d7206bfb4a5ae4720086a58aee1839dcf04fd25) quickjs-ng: 0.6.0 -> 0.6.1
* [`bc15896b`](https://github.com/NixOS/nixpkgs/commit/bc15896be2dfa30f2fb83a06835ac64f98ad327e) asm-lsp: add support for darwin
* [`e5d3aa87`](https://github.com/NixOS/nixpkgs/commit/e5d3aa87910ef3c98e63c32621d93aaaeb4306d0) maintainers: add CaiqueFigueiredo
* [`da26765f`](https://github.com/NixOS/nixpkgs/commit/da26765f7ae79bbad1049607d20993f6cecd6f8d) asm-lsp: add CaiqueFigueiredo to maintainers
* [`430ac742`](https://github.com/NixOS/nixpkgs/commit/430ac7426fe91240d7135d1e2c10a1659b8e610f) asm-lsp: format with nixfmt
* [`8ce015b9`](https://github.com/NixOS/nixpkgs/commit/8ce015b936bf9fc0787169e44d6c26af370c7fb6) python312Packages.labelbox: 4.0.0 -> 5.1.0
* [`d6c5ad26`](https://github.com/NixOS/nixpkgs/commit/d6c5ad2634acade16012552acbcb28245d683b90) fanficfare: 4.37.0 -> 4.38.0
* [`f748ccc3`](https://github.com/NixOS/nixpkgs/commit/f748ccc3182f6d51d84f2e9906123d991d474a9c) tsm-client: 8.1.23.0 -> 8.1.24.0
* [`347255a2`](https://github.com/NixOS/nixpkgs/commit/347255a29a2f420560647bfc55b912e8ddde47dd) github/PULL_REQUEST_TEMPLATE: replace first heading with comment
* [`f1abda94`](https://github.com/NixOS/nixpkgs/commit/f1abda9414533b67b072312486a6388774ac54bc) kodiPackages.radioparadise: 2.0.0 -> 2.0.1
* [`34238b6d`](https://github.com/NixOS/nixpkgs/commit/34238b6dc481b17298391f40f71b8fdb14b22d19) kodi.package.iagl: add missing infotagger package dependency
* [`0f94b8ea`](https://github.com/NixOS/nixpkgs/commit/0f94b8ea223594a0697e166c047662d16260eff5) cryptoverif: 2.10 -> 2.11
* [`28d09338`](https://github.com/NixOS/nixpkgs/commit/28d09338c496a12b8e17b2bb8ca7b88db62f60c9) prowlarr: 1.23.1.4708 -> 1.24.3.4754
* [`a03eab61`](https://github.com/NixOS/nixpkgs/commit/a03eab619f7861b7ca8db2a2fb1b45da6b26db51) scala-next: Init at 3.5.1
* [`657be5d7`](https://github.com/NixOS/nixpkgs/commit/657be5d7dbeb7686b2ddd7a03014b426eddaa3d1) maintainers: add natsukagami, hamzaremmal and dottybot
* [`4be06021`](https://github.com/NixOS/nixpkgs/commit/4be06021f3216e840a2452e94d65b2851c151832) yt-dlp: 2024.8.6 -> 2024.9.27
* [`24f34c60`](https://github.com/NixOS/nixpkgs/commit/24f34c60b110f8e8350a6ac82c1c9152a59ae73d) rednotebook: 2.34 -> 2.35
* [`c7ad3a76`](https://github.com/NixOS/nixpkgs/commit/c7ad3a761946476f2a7045ded7dc3885b3ebc9f9) gallery-dl: 1.27.4 -> 1.27.5
* [`e229318f`](https://github.com/NixOS/nixpkgs/commit/e229318f7d34f4988a815e6d10b8fb0f7e0e2974) alpaca: 2.0.3 -> 2.0.5
* [`dcc4fd6a`](https://github.com/NixOS/nixpkgs/commit/dcc4fd6a68f7f33a676543667007d77222e50b18) pass-git-helper: 2.0.0 -> 3.0.0
* [`60d3dac6`](https://github.com/NixOS/nixpkgs/commit/60d3dac6f27dd4892bef098879e32fdf0c2851b5) dolt: 1.42.20 -> 1.43.1
* [`ddbc429f`](https://github.com/NixOS/nixpkgs/commit/ddbc429f152020afef41b3530e7f27e6f792a12c) graphite-cli: 1.4.4 -> 1.4.5
* [`0ea58247`](https://github.com/NixOS/nixpkgs/commit/0ea582475dc48b834ce00bd38b0e64db5b7507fb) maintainers: add zimward
* [`abd1b315`](https://github.com/NixOS/nixpkgs/commit/abd1b3156a419d8bb03fd1b0c9de177c343e5286) gpredict: cleanup "with lib", remove let in for attribute set
* [`311706db`](https://github.com/NixOS/nixpkgs/commit/311706db9cf75a710a9e46556d9af19c943f3ae7) gpredict: switch to fetchFromGitHub
* [`d0360967`](https://github.com/NixOS/nixpkgs/commit/d036096765a17acaff011e5c36be7697c42b53f4) gpredict: add to update TLE download URLs
* [`ea824089`](https://github.com/NixOS/nixpkgs/commit/ea824089d6d9b0ec81f39a6ad8afa35c999fdbff) gpredict: apply nixfmt
* [`1b3e7256`](https://github.com/NixOS/nixpkgs/commit/1b3e725693353175f3f8751fe15a5fabb5a595c8) verapdf: init at 1.26.2
* [`c2fb683a`](https://github.com/NixOS/nixpkgs/commit/c2fb683ac8e68c5eb97ee5dcfd07b0cf11f65fc9) python312Packages.niaarm: 0.3.9 -> 0.3.12
* [`8bab23b2`](https://github.com/NixOS/nixpkgs/commit/8bab23b22dc269b32713690718ff2e92d22fa3b7) simplex-chat-desktop: 6.0.4 -> 6.0.5
* [`34a466eb`](https://github.com/NixOS/nixpkgs/commit/34a466eb413115e2c4aaf9e8c8d9b2c016b971b8) pietrasanta-traceroute: 0.0.5-unstable-2024-06-11 -> 0.0.5-unstable-2024-09-06
* [`cd42e582`](https://github.com/NixOS/nixpkgs/commit/cd42e582fb4bd4cdbbcf85466e1bc3d6d6ebfa4c) stu: 0.6.2 -> 0.6.3
* [`bb12bc9c`](https://github.com/NixOS/nixpkgs/commit/bb12bc9c790d731fd48508108fcb881385685745) python3Packages.xdis: 6.1.0 -> 6.1.1
* [`bacecfa3`](https://github.com/NixOS/nixpkgs/commit/bacecfa3b617eefe9e1391b935c98c0bc78efaaa) lighthouse: use OpenSSL from Nixpkgs
* [`fc93b376`](https://github.com/NixOS/nixpkgs/commit/fc93b376c228979a0fa92f53649ffe2d3bc54761) avml: use OpenSSL from Nixpkgs
* [`78247063`](https://github.com/NixOS/nixpkgs/commit/7824706368a469b63848f25d12664bc18e39b84a) rover: use OpenSSL from Nixpkgs
* [`335bd898`](https://github.com/NixOS/nixpkgs/commit/335bd898d6e63f1572b4ed9ed3a1fbf0ad416a80) deltachat-repl,deltachat-rpc-server: use OpenSSL from Nixpkgs
* [`bd9cd90d`](https://github.com/NixOS/nixpkgs/commit/bd9cd90d49558b91cbe96f6273f2a0efe008eed0) edgedb: use OpenSSL from Nixpkgs
* [`46850407`](https://github.com/NixOS/nixpkgs/commit/4685040762bf53e004e5e9674435d02fac12915b) python3Packages.uncompyle6: 3.9.1 -> 3.9.2
* [`e4eacffe`](https://github.com/NixOS/nixpkgs/commit/e4eacffe3463357961451a58dee47e2e6e988917) zarf: 0.39.0 -> 0.40.1
* [`f6c3b3e8`](https://github.com/NixOS/nixpkgs/commit/f6c3b3e8c94114801864f337c43cf94d45c4ad11) twm: 0.10.2 -> 0.11.0, move to pkgs/by-name
* [`987a83af`](https://github.com/NixOS/nixpkgs/commit/987a83afbbe6661b28a2ba030fec3b8c056a21b6) maintainers: add aucub
* [`27f1f466`](https://github.com/NixOS/nixpkgs/commit/27f1f466cb09710a31b6ccca1ae401e55c25d696) mir: 2.18.0 -> 2.18.2
* [`4bd55f26`](https://github.com/NixOS/nixpkgs/commit/4bd55f26ca28ef3afda2b5e5f491adce997c5c27) python3Packages.djangosaml2: init at 1.9.3
* [`d3b5dc8d`](https://github.com/NixOS/nixpkgs/commit/d3b5dc8da1cc30772ac50d17e0b605444a7ff6ee) nixos/seafile: add persistent user, configurable storage path, gc service
* [`e6e65f02`](https://github.com/NixOS/nixpkgs/commit/e6e65f022cec8774c55e4baebff93469eb55d8fa) seafile-server: 10.0.1 -> 11.0.12
* [`90e07d3e`](https://github.com/NixOS/nixpkgs/commit/90e07d3e559b80434d0875ce6f0474393f58bdad) seahub: 10.0.1 -> 11.0.12
* [`3f03d48c`](https://github.com/NixOS/nixpkgs/commit/3f03d48cd36cbfe568ad408bbd3ab4a0ce86c916) veracrypt: 1.26.14 -> 1.26.15
* [`073099d0`](https://github.com/NixOS/nixpkgs/commit/073099d0f7a1fe42490ba95f7295f78434004197) nixos/seafile: add persistent user, configurable storage path, gc service
* [`1b79e211`](https://github.com/NixOS/nixpkgs/commit/1b79e2110e3d7f78a09e5f6f277939263eae4e7f) waagent: 2.11.1.4 -> 2.11.1.12
* [`ab450e0f`](https://github.com/NixOS/nixpkgs/commit/ab450e0fd3cfddcbcce092d56d73fefb6816538d) deck: nixfmt
* [`41296abb`](https://github.com/NixOS/nixpkgs/commit/41296abb5b664237daa0d58d6ae568641632ad03) deck: add passthru.updateScript
* [`a9eaa7fc`](https://github.com/NixOS/nixpkgs/commit/a9eaa7fc75d66497d9bbca45b3754128b1f04b25) deck: add 1.40.2 -> 1.40.3
* [`7d3dae09`](https://github.com/NixOS/nixpkgs/commit/7d3dae09263c8ff09ea1eac3fda4b234e641ae5d) qrq: init at 0.3.5
* [`2095eae5`](https://github.com/NixOS/nixpkgs/commit/2095eae5ce6909d25c4593b356c20ee47faa198b) fan2go: 0.8.1 -> 0.9.0
* [`42bc5949`](https://github.com/NixOS/nixpkgs/commit/42bc59498d6a55d9ecc735a9581647f2106a0928) splitcode: init at 0.30.0
* [`39b9817d`](https://github.com/NixOS/nixpkgs/commit/39b9817d5efa5ce0d618e9eb480cf94915f5f864) buildkite-cli: 2.0.0 -> 3.1.0
* [`26fb54e2`](https://github.com/NixOS/nixpkgs/commit/26fb54e2e5365eab212a28124cc55046a0ec6016) python3Packages.xen: init
* [`7455c80a`](https://github.com/NixOS/nixpkgs/commit/7455c80a5f97a5fa9c4449a6c64c053232f6eca4) uwc: 1.0.5 -> 1.0.7 and fetch from GitHub
* [`935b9608`](https://github.com/NixOS/nixpkgs/commit/935b96082f8ebb3a349bc2e08c10bd0a6aa12a0a) uwc: disable tests
* [`25f4610b`](https://github.com/NixOS/nixpkgs/commit/25f4610b3eec8f2dd61f653c734f64ca96e1b828) python312Packages.pysmb: switch to pypa builder
* [`30547aa2`](https://github.com/NixOS/nixpkgs/commit/30547aa2693e77a48e8fb840cf670067185e8563) dooit: fix textual version
* [`511066d3`](https://github.com/NixOS/nixpkgs/commit/511066d37e57910a452dd60025fe32a01b777312) python312Packages.safety: 3.2.7 -> 3.2.8
* [`aa04240e`](https://github.com/NixOS/nixpkgs/commit/aa04240ed0f07be0012043969a17605fd4dac0cb) maintainers: add kraanzu
* [`bc01328c`](https://github.com/NixOS/nixpkgs/commit/bc01328c5754e59bbe88e6c8996a4464229a7910) dooit: add maintainer kraanzu
* [`094664f1`](https://github.com/NixOS/nixpkgs/commit/094664f121c2b698675eb3e92b7c45d6d4ed927d) cargo-zigbuild: 0.19.2 -> 0.19.3
* [`ca679554`](https://github.com/NixOS/nixpkgs/commit/ca6795545c1682a2e12bf12dea0216ce6b77239a) gmt: modernize
* [`b1f77009`](https://github.com/NixOS/nixpkgs/commit/b1f7700933ca3848548b1b460e9a3a3064e5db3f) python312Packages.treq: 23.11.0 -> 24.9.1
* [`fde40f47`](https://github.com/NixOS/nixpkgs/commit/fde40f4760af1b90daa5f36c98b8895028f41bed) darcs-to-git: move to by-name; nixfmt
* [`1896f994`](https://github.com/NixOS/nixpkgs/commit/1896f994ad4e9f617571eb7337647d6fd50eb3f9) darcs: add passthru.updateScript
* [`705db780`](https://github.com/NixOS/nixpkgs/commit/705db7803991a474a155aa51dcd8ddd6ef629cb7) darcs: 0-unstable-2015-06-04 -> 0-unstable-2024-02-20
* [`6b2c497f`](https://github.com/NixOS/nixpkgs/commit/6b2c497f83fce0f341ed2cbbc7307d0b37653522) vscode-extensions.asvetliakov.vscode-neovim: 1.18.11 -> 1.18.12
* [`921a21a2`](https://github.com/NixOS/nixpkgs/commit/921a21a26fc587f4306c6908e510abced6feace2) cpuinfo: 0-unstable-2024-09-11 -> 0-unstable-2024-09-26
* [`d179a5e5`](https://github.com/NixOS/nixpkgs/commit/d179a5e5ba4edac2b7d891020f324475947977c3) healthchecks: 3.4 -> 3.6
* [`c0f95a99`](https://github.com/NixOS/nixpkgs/commit/c0f95a993b45ee3a67be9d9b78b20c410812677a) google-cloud-sdk: 492.0.0 -> 494.0.0
* [`dba66f57`](https://github.com/NixOS/nixpkgs/commit/dba66f574552a4b80a561f6b65ce64bb3a2bcd02) vivaldi: 6.9.3447.46 -> 6.9.3447.48
* [`7d8f1572`](https://github.com/NixOS/nixpkgs/commit/7d8f1572d1d400100b75076c5c9e9924a0c88f92) nixos: enable fstrim by default
* [`ca579ba7`](https://github.com/NixOS/nixpkgs/commit/ca579ba7b0c9119009165eab5c4c947d15fb1cad) nomad_1_6: remove
* [`13aafe03`](https://github.com/NixOS/nixpkgs/commit/13aafe03ff4d7d62c7e0bee777559a579dc801ad) sensu-go: bump Go version to 1.22
* [`9d9980f1`](https://github.com/NixOS/nixpkgs/commit/9d9980f1bb1a22f22736880765182eb1c7267c54) resolve-march-native: 5.0.2 -> 5.1.0
* [`17c1e538`](https://github.com/NixOS/nixpkgs/commit/17c1e538d39309802b777b72743be70042d7409e) xdg-desktop-portal-hyprland: 1.3.5 -> 1.3.6
* [`c28b31df`](https://github.com/NixOS/nixpkgs/commit/c28b31df9376cfb09b7db7aaa2e97a740b4eb02a) misskey: fix darwin build
* [`4a5d6796`](https://github.com/NixOS/nixpkgs/commit/4a5d67962714f98472fc8ac77de24c7cc6fc5079) lunar-client: 3.2.17 -> 3.2.18
* [`bb89119e`](https://github.com/NixOS/nixpkgs/commit/bb89119ec78ac7db5e2577e4b5591da140bcc789) kitty: 0.36.1 -> 0.36.4
* [`a63e4cf4`](https://github.com/NixOS/nixpkgs/commit/a63e4cf4b383128bb12f95d9b3c2fdb97fbc47bd) lilypond-unstable: 2.25.19 -> 2.25.20
* [`2a5132e9`](https://github.com/NixOS/nixpkgs/commit/2a5132e9926129f24ec3b375f1347a0329abc78c) syshud: 0-unstable-2024-08-27 -> 0-unstable-2024-09-26
* [`05c82673`](https://github.com/NixOS/nixpkgs/commit/05c82673cae335c0c881f13a99e0a3bf8bec9a53) scopehal-apps: init at unstable-2024-08-22
* [`f020b7ac`](https://github.com/NixOS/nixpkgs/commit/f020b7ac7a11132e027ba400165f1ba55e882a54) vikunja: 0.24.3 -> 0.24.4
* [`df80b55a`](https://github.com/NixOS/nixpkgs/commit/df80b55ac584d04d96c4645b3eb19962c5451c99) elvis-erlang: 3.2.5 -> 3.2.6
* [`cc72c8cf`](https://github.com/NixOS/nixpkgs/commit/cc72c8cfd694b4f6f814dd5cafb8ca36a55cafff) lagrange: 1.17.6 → 1.18.1
* [`d4a3b76c`](https://github.com/NixOS/nixpkgs/commit/d4a3b76cc4cecf39c20813199ec521414c58973e) typesense: 27.0 -> 27.1
* [`7bb5e997`](https://github.com/NixOS/nixpkgs/commit/7bb5e997fe923b619b3c56b4dd1d264bea74457d) python312Packages.pyogrio: 0.9.0 → 0.10.0
* [`d924b523`](https://github.com/NixOS/nixpkgs/commit/d924b523e0bb70e7f4e07cdc431a3d30f4ac419d) golex: init at 1.1.0
* [`eac660eb`](https://github.com/NixOS/nixpkgs/commit/eac660eb4b5103cb89ea773b5fd907965401ef73) gmt: fix build by overriding netcdf
* [`6889e8ee`](https://github.com/NixOS/nixpkgs/commit/6889e8eeeec391ad7c0c2d08a04a474d62ba050f) gmt: 6.4.0 -> 6.5.0
* [`eccfe1c0`](https://github.com/NixOS/nixpkgs/commit/eccfe1c0ad400df7a7eb50aae7b7d8953900a050) gmt: let it find libraries automatically
* [`f0d7b6b8`](https://github.com/NixOS/nixpkgs/commit/f0d7b6b8e96c777b6b7823e8cfe85a76082f1cb8) xmlrpc_c: 1.51.07 -> 1.59.03, enable parallel building
* [`468b7e78`](https://github.com/NixOS/nixpkgs/commit/468b7e784e508e62974e389a94fbf082f3fe5213) maintainers: add mortenmunk
* [`11a96562`](https://github.com/NixOS/nixpkgs/commit/11a96562ba23dc9e6e669d7ab53d71405bc03292) privatebin: init at 1.7.4
* [`22e2e021`](https://github.com/NixOS/nixpkgs/commit/22e2e02118b2e84a5471edaadec6a1cfc34e477d) nixos/privatebin: init
* [`daf41d07`](https://github.com/NixOS/nixpkgs/commit/daf41d07f9d3130c6bee63c9e694e77e3666e338) python312Packages.eigenpy: 3.9.1 -> 3.10.0
* [`1acaef28`](https://github.com/NixOS/nixpkgs/commit/1acaef2804466e9fb0d6024c1796fd026827565d) python312Packages.qdrant-client: 1.11.2 -> 1.11.3
* [`ca4018eb`](https://github.com/NixOS/nixpkgs/commit/ca4018ebff1d6cdd7cbb59c631920333cffcb443) nextcloud-client: 1.14.0 -> 1.14.1
* [`cc4b9ba5`](https://github.com/NixOS/nixpkgs/commit/cc4b9ba546101741c3a54d6921788ddc48e1c200) papermc: 1.21.1-85 -> 1.21.1-110
* [`11d1f877`](https://github.com/NixOS/nixpkgs/commit/11d1f8776c7b9e34b0e21516b2cdbf6c7a8a0e3c) nixos/postgresql: escape initdbArgs
* [`ebc36a9d`](https://github.com/NixOS/nixpkgs/commit/ebc36a9dee03716949e97a6310a21199a8e6e9a0) python312Packages.pygmt: unbreak on Darwin
* [`dce718aa`](https://github.com/NixOS/nixpkgs/commit/dce718aa83a51aef01310366b101e367de9f8bf4) cloudlens: fix darwin build
* [`9de4b998`](https://github.com/NixOS/nixpkgs/commit/9de4b9989715dc901cf2fd7c69ae70e2646dc9f4) exhaustive: 0.10.0 -> 0.12.0
* [`c25213a9`](https://github.com/NixOS/nixpkgs/commit/c25213a9bd2387e4e870a3e6e94be4e02a9cb9a5) nixos/bluemap: move to `web-apps`
* [`48b7647c`](https://github.com/NixOS/nixpkgs/commit/48b7647cb6a328af7b85dd66bc4249ff6797a936) go-secdump: mark as Linux-only
* [`cacd1aa4`](https://github.com/NixOS/nixpkgs/commit/cacd1aa4e6fcc2855370d8ea4023d416eca09dcd) spl: 0.3.2 -> 0.4.0
* [`03a6842b`](https://github.com/NixOS/nixpkgs/commit/03a6842b0e6864fd5bfd99021d37a96fac185c95) sbt-extras: 2024-09-13 -> 2024-09-28
* [`41b5378f`](https://github.com/NixOS/nixpkgs/commit/41b5378f9af66f88c136fbe90c3f1c78bbafcfac) heroku: 9.2.1 -> 9.3.0
* [`2729ae75`](https://github.com/NixOS/nixpkgs/commit/2729ae7590ff7a47ec06aed86f5c9803713dc536) heptabase: 1.39.0 -> 1.40.0
* [`f95b3605`](https://github.com/NixOS/nixpkgs/commit/f95b3605e0d2d1cd0734b1c7dfb7c18c05909a1c) linux-pam.meta.homepage: update
* [`889b6cb4`](https://github.com/NixOS/nixpkgs/commit/889b6cb48ba23132548f028dc6d1a095aa5202c0) libtorrent: 0.13.8-unstable -> 0.14.0
* [`42931581`](https://github.com/NixOS/nixpkgs/commit/4293158115a47487e65e78caf7fc4a1bc211beb4) rtorrent: 0.9.8-unstable -> 0.10.0
* [`a3e3aa25`](https://github.com/NixOS/nixpkgs/commit/a3e3aa258345b39da49f9cd662e8af36654fe755) rainfrog: 0.2.5 -> 0.2.6
* [`c7620c55`](https://github.com/NixOS/nixpkgs/commit/c7620c55a7a028df265cbe841d5a12cf3717ee79) moosefs: 3.0.118 -> 4.56.6
* [`951665ca`](https://github.com/NixOS/nixpkgs/commit/951665ca4f935cc3983bc86e6b9bb57fc3aa245a) paru: 2.0.3 -> 2.0.4
* [`5d981c05`](https://github.com/NixOS/nixpkgs/commit/5d981c05758713e020105421fd06c57d3f8a43c6) python312Packages.ale-py: 0.10.0 -> 0.10.1
* [`52e47d17`](https://github.com/NixOS/nixpkgs/commit/52e47d17b6e4991301927ee45ab6a1ba0e91c647) feishin: 0.9.0 -> 0.10.0
* [`143b30a1`](https://github.com/NixOS/nixpkgs/commit/143b30a1532a37e4b6856f0fdebb507fdbc441bc) python312Packages.arviz: 0.19.0 -> 0.20.0
* [`63306af8`](https://github.com/NixOS/nixpkgs/commit/63306af816bc75c40d783fed2a948ea45fb18b20) python312Packages.py-ocsf-models: init at 0.1.1
* [`6300fc82`](https://github.com/NixOS/nixpkgs/commit/6300fc82bea0c920b02fbdf47749ebc7cf1e9c7c) python312Packages.dask: 2024.9.0 -> 2024.9.1
* [`f460d5b9`](https://github.com/NixOS/nixpkgs/commit/f460d5b97290055462544b0e252f593e7f4cfc82) python312Packages.distributed: 2024.9.0 -> 2024.9.1
* [`d35e33b2`](https://github.com/NixOS/nixpkgs/commit/d35e33b2b2ca4999067173e59d0139857526f32d) python312Packages.dask-expr: 1.1.14 -> 1.1.15
* [`f5b83b89`](https://github.com/NixOS/nixpkgs/commit/f5b83b899129c605b014bc84b14a43d841431774) python312Packages.corner: disable flaky tests
* [`5fd94c39`](https://github.com/NixOS/nixpkgs/commit/5fd94c39d46bf68843b0ba090e4ba0ff04afce74) mathmod: move to pkgs/by-name
* [`acec0550`](https://github.com/NixOS/nixpkgs/commit/acec05505d2dcb51ef7a8026d226d601ca5b1d8c) octavePackages.signal: 1.4.5 -> 1.4.6
* [`3bd63480`](https://github.com/NixOS/nixpkgs/commit/3bd63480277c0d53c1da3168863c3c855ef3ac31) mathmod: 11.1-unstable-2024-01-26 -> 12.0
* [`fdf1280a`](https://github.com/NixOS/nixpkgs/commit/fdf1280a9240545fbdb481447c6f9f4f537c7d28) flyctl: 0.3.6 -> 0.3.10
* [`2a6f4876`](https://github.com/NixOS/nixpkgs/commit/2a6f48769c9766c862e72f50eb2dd9ab78c224f0) miniflux: add updateScript
* [`1ff2dee6`](https://github.com/NixOS/nixpkgs/commit/1ff2dee679c55363ecec39392136f07cc6dca893) miniflux: 2.2.0 -> 2.2.1
* [`d7f0cdec`](https://github.com/NixOS/nixpkgs/commit/d7f0cdec396ef119fe287bf653f64c7f50f80d47) miniflux: move to by-name
* [`e08b1081`](https://github.com/NixOS/nixpkgs/commit/e08b1081c9c1899777bf5ccf806b873765c753f2) python312Packages.aiovlc: 0.5.0 -> 0.6.0
* [`ff903a01`](https://github.com/NixOS/nixpkgs/commit/ff903a01fd1f9f050680d7bba7e3e56b0c4a50f1) albert: 0.26.3 -> 0.26.4
* [`15f16852`](https://github.com/NixOS/nixpkgs/commit/15f168528abc70128bbb61f3ab0eec83d80deb57) bruno: 1.29.1 -> 1.30.1
* [`e4f84e3e`](https://github.com/NixOS/nixpkgs/commit/e4f84e3e6cdf15e92638697cae5fdefeb6363110) gleam: 1.5.0 -> 1.5.1
* [`c04f7ccc`](https://github.com/NixOS/nixpkgs/commit/c04f7ccc59590582a46312a388972318e0aa082b) glance: 0.6.1 -> 0.6.2
* [`66d8ae4c`](https://github.com/NixOS/nixpkgs/commit/66d8ae4cae1b4e1028afcfd99060bf85fb8ed58d) python312Packages.openai: 1.47.1 -> 1.50.2
* [`ec50ae00`](https://github.com/NixOS/nixpkgs/commit/ec50ae00b1ba4dc9f3f324cd8ada96bd261e1e5c) picom-pijulius: 8.2-unstable-2024-09-14 -> 8.2-unstable-2024-09-27
* [`c8da361b`](https://github.com/NixOS/nixpkgs/commit/c8da361b085e741c790f7ac2f65f9b6b60d007fa) signalbackup-tools: 20240924-2 -> 20240929
* [`18e87bbc`](https://github.com/NixOS/nixpkgs/commit/18e87bbcd8cb29dc64563677f014f2ef61e6e911) trealla: 2.56.15 -> 2.56.19
* [`9d99efd6`](https://github.com/NixOS/nixpkgs/commit/9d99efd61d66163f23b198d9326e95e762042177) python312Packages.ancp-bids: unbreak and minor refactor
* [`14d9618a`](https://github.com/NixOS/nixpkgs/commit/14d9618ae105b2948d58629abc60348637c475e6) chirp: 0.4.0-unstable-2024-09-19 -> 0.4.0-unstable-2024-09-28
* [`fafa8272`](https://github.com/NixOS/nixpkgs/commit/fafa8272c22caa0efa4000726af1deea4700c376) roddhjav-apparmor-rules: 0-unstable-2024-09-19 -> 0-unstable-2024-09-27
* [`55a058b2`](https://github.com/NixOS/nixpkgs/commit/55a058b26d6b2844b284b56e645daf09a4ea8c03) vscode-js-debug: 1.93.0 -> 1.94.0
* [`de1ef794`](https://github.com/NixOS/nixpkgs/commit/de1ef794a6c3224e0a6feb815f6e95b63ad6d683) tautulli: 2.14.4 -> 2.14.5
* [`5dcb4ae9`](https://github.com/NixOS/nixpkgs/commit/5dcb4ae9fd8663b5244536c2be76a30b991a3512) nvd: 0.2.3 -> 0.2.4, switch source repository to Sourcehut
* [`0d65cdb6`](https://github.com/NixOS/nixpkgs/commit/0d65cdb64bd38d37b45343cc4287684ae3b633ec) newsboat: migrate to pkgs/by-name
* [`f079da87`](https://github.com/NixOS/nixpkgs/commit/f079da8702ea59ba308286fec041f4296c4e394d) newsboat: reformat unix nixfmt-rfc-style
* [`4d4b7c20`](https://github.com/NixOS/nixpkgs/commit/4d4b7c205e5799acd79e71daac0ec1d3a4b4735c) praat: 6.4.20 -> 6.4.21
* [`ca09d7f2`](https://github.com/NixOS/nixpkgs/commit/ca09d7f2521a653eed3931c4b3c3c5f9168f12bc) mdcat: 2.4.0 -> 2.5.0
* [`f3a67ca6`](https://github.com/NixOS/nixpkgs/commit/f3a67ca61b2c25dcce930afbbb267581b60eda81) microsoft-edge: 129.0.2792.52 -> 129.0.2792.65
* [`e6d4785e`](https://github.com/NixOS/nixpkgs/commit/e6d4785ec0c2a9716f1383fcabff64ff86798d20) githooks: 3.0.3 -> 3.0.4
* [`f2da1493`](https://github.com/NixOS/nixpkgs/commit/f2da14933fe5c29a332d4dfd0e345981169e7b2c) newsboat: 2.36 -> 2.37
* [`65a629f0`](https://github.com/NixOS/nixpkgs/commit/65a629f03747f9d14d8497f52c66a5443415f35f) mob: 5.2.0 -> 5.3.1
* [`0a0e5200`](https://github.com/NixOS/nixpkgs/commit/0a0e5200f454a3ebb0f5151c09d8be00e5dd9eb5) twilio-cli: 5.22.1 -> 5.22.2
* [`3c9c8489`](https://github.com/NixOS/nixpkgs/commit/3c9c8489052d690b137759cd3ce76adc4ca36b05) sbcl: 2.4.8 -> 2.4.9
* [`54378108`](https://github.com/NixOS/nixpkgs/commit/543781083afffe71d6250862eb494c244355fa11) treewide: replace passthru.optional-dependencies with optional-dependencies
* [`8c76fcad`](https://github.com/NixOS/nixpkgs/commit/8c76fcad3790385abe05e5e0b46ea7e08b0e19ec) tigerbeetle: 0.16.2 -> 0.16.3
* [`fcc1b52f`](https://github.com/NixOS/nixpkgs/commit/fcc1b52f56595eb63bc22deb3858bad716c99d2e) dracula-theme: 4.0.0-unstable-2024-09-07 -> 4.0.0-unstable-2024-09-24
* [`9e9213e2`](https://github.com/NixOS/nixpkgs/commit/9e9213e2ef54c44c72a84d403cbedea8b360ec53) maintainers: add herschenglime
* [`76845618`](https://github.com/NixOS/nixpkgs/commit/768456183c5d9d1d5c089b4c57c73587132b7897) gnome-pomodoro: 0.24.1 -> 0.26.0
* [`b97588eb`](https://github.com/NixOS/nixpkgs/commit/b97588ebb20a82bfb752f2473c260b61c038e01f) matrix-hebbot: move to by-name; nixfmt
* [`404999a4`](https://github.com/NixOS/nixpkgs/commit/404999a461ef474e9c41e86193bb0af410f6cd2c) matrix-hebbot: 2.1 -> 2.1-unstable-2024-09-20
* [`b535ab6a`](https://github.com/NixOS/nixpkgs/commit/b535ab6ac32a6825ab4623e7c26a1efdb26c8e19) virt-manager: only add run time dependencies to PYTHONPATH
* [`5792062b`](https://github.com/NixOS/nixpkgs/commit/5792062b63862271dbe880408ff091e69358086e) llvmPackages_git: 20.0.0-git-2024-09-22 -> 20.0.0-git-2024-09-29
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
