### PR TITLE
niv home-manager: update ffe2d07e -> 03863036

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -41,10 +41,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "ffe2d07e771580a005e675108212597e5b367d2d",
-        "sha256": "1avcr63sjidf83f69xdlsdi0dszhrppy257z7nld3hf2kmrdmyz3",
+        "rev": "038630363e7de57c36c417fd2f5d7c14773403e4",
+        "sha256": "1xxnsylkjdkpjhx4zs58ykrcm623ns054zxnacyq9avjj6657m2m",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/ffe2d07e771580a005e675108212597e5b367d2d.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/038630363e7de57c36c417fd2f5d7c14773403e4.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@ffe2d07e...03863036](https://github.com/nix-community/home-manager/compare/ffe2d07e771580a005e675108212597e5b367d2d...038630363e7de57c36c417fd2f5d7c14773403e4)

* [`437ec620`](https://github.com/nix-community/home-manager/commit/437ec62009fa8ceb684eb447d455ffba25911cf9) borgmatic: note Darwin platform support
* [`30e04f3d`](https://github.com/nix-community/home-manager/commit/30e04f3d477256de3eb6a7cff608e220087537d4) pass-secret-service: add GNUPGHOME to service env vars
* [`509dbf8d`](https://github.com/nix-community/home-manager/commit/509dbf8d45606b618e9ec3bbe4e936b7c5bc6c1e) megasync: fix issue with service failing to launch
* [`bc623830`](https://github.com/nix-community/home-manager/commit/bc623830e619cef86a2d3750625ffe4e24ea7e64) ci: bump cachix/install-nix-action from 27 to 30
* [`fcf5e608`](https://github.com/nix-community/home-manager/commit/fcf5e608ac65f64463bc0ccc5ea86f2170f20689) kitty: allow float values in settings ([nix-community/home-manager⁠#5925](https://togithub.com/nix-community/home-manager/issues/5925))
* [`3ac39b2a`](https://github.com/nix-community/home-manager/commit/3ac39b2a8b7cbfc0f96628d8a84867c885bc988b) zathura: Fix the type for config options ([nix-community/home-manager⁠#5934](https://togithub.com/nix-community/home-manager/issues/5934))
* [`271c83e2`](https://github.com/nix-community/home-manager/commit/271c83e21ea81f39a42ad128384e0e6804956a88) firefox: organize tests by submodule ([nix-community/home-manager⁠#5698](https://togithub.com/nix-community/home-manager/issues/5698))
* [`03863036`](https://github.com/nix-community/home-manager/commit/038630363e7de57c36c417fd2f5d7c14773403e4) xdg-mime type package options ([nix-community/home-manager⁠#5920](https://togithub.com/nix-community/home-manager/issues/5920))
