### PR TITLE
niv powerlevel10k: update 087405df -> 0996a941

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -113,10 +113,10 @@
         "homepage": "",
         "owner": "romkatv",
         "repo": "powerlevel10k",
-        "rev": "087405df7838f4c3e835025699bd7b98b9731acc",
-        "sha256": "115b23nzndd93ixhh6mykfmyjxcxpqyfrqmsdbkignxlwmzwv3kh",
+        "rev": "0996a9411824cbfe8fdd8cb17448c94ef891be34",
+        "sha256": "141vrzbspnca8vs979vsyx2ynnj4gbm80x46pkswr5z6ks69lkfa",
         "type": "tarball",
-        "url": "https://github.com/romkatv/powerlevel10k/archive/087405df7838f4c3e835025699bd7b98b9731acc.tar.gz",
+        "url": "https://github.com/romkatv/powerlevel10k/archive/0996a9411824cbfe8fdd8cb17448c94ef891be34.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "rh": {


### PR DESCRIPTION
## Changelog for powerlevel10k:
Branch: master
Commits: [romkatv/powerlevel10k@087405df...0996a941](https://github.com/romkatv/powerlevel10k/compare/087405df7838f4c3e835025699bd7b98b9731acc...0996a9411824cbfe8fdd8cb17448c94ef891be34)

* [`140a6ade`](https://github.com/romkatv/powerlevel10k/commit/140a6ade4e9d7431df697de4dfff04b353e219e2) Squashed 'gitstatus/' changes from 62177e89..44504a24
* [`0996a941`](https://github.com/romkatv/powerlevel10k/commit/0996a9411824cbfe8fdd8cb17448c94ef891be34) Support aws-sso-cli on AWS prompt element ([romkatv/powerlevel10k⁠#2769](https://togithub.com/romkatv/powerlevel10k/issues/2769))
