### PR TITLE
niv nixpkgs: update 1a53b400 -> b4802f74

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1a53b400e59d0c0c5b287231e4cc65195a0660c4",
-        "sha256": "11csqs0hgzvdzy0zcnxyz3kzgfasv2d66v23lhicjvqb83v9gvxg",
+        "rev": "b4802f749d77b8d35f101d4a386e87da4e9409c8",
+        "sha256": "12fhkjqrgc3m2di0qn8birz6g617l79haz4hnam30bzlz17gpxbh",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/1a53b400e59d0c0c5b287231e4cc65195a0660c4.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/b4802f749d77b8d35f101d4a386e87da4e9409c8.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@1a53b400...b4802f74](https://github.com/nixos/nixpkgs/compare/1a53b400e59d0c0c5b287231e4cc65195a0660c4...b4802f749d77b8d35f101d4a386e87da4e9409c8)

* [`2e8b6320`](https://github.com/NixOS/nixpkgs/commit/2e8b63203b69c1bd17b417dd4b1d1d37a8fb4675) pythonPackages.pyroute2: include version with package
* [`923d79c8`](https://github.com/NixOS/nixpkgs/commit/923d79c8e239033b6cd78a344e46e577e2cb00bf) python3Packages.dbf: Fix not running hooks in checkPhase
* [`4fdfab04`](https://github.com/NixOS/nixpkgs/commit/4fdfab04387758a0e91e54073c5f5536883045ca) python3Packages.dbf: Workaround broken build on Darwin
* [`3c74fe65`](https://github.com/NixOS/nixpkgs/commit/3c74fe653520687d13cf60602c3dbb36d6e3148e) memcached: 1.6.27 -> 1.6.29
* [`2e2f1881`](https://github.com/NixOS/nixpkgs/commit/2e2f18813c2417cae4accd759b0a2e3bb0f3e476) mk-python-derivation: don't expose check args when doCheck = false
* [`e8308ffe`](https://github.com/NixOS/nixpkgs/commit/e8308ffeacbf4bb2ed6ef91794f81ab913e7bc33) libnl: 3.8.0 -> 3.10.0
* [`3f799fa8`](https://github.com/NixOS/nixpkgs/commit/3f799fa8d85294f2934eb3537c6d4465b064a1d6) fluidsynth: 2.3.5 -> 2.3.6
* [`b5556cf2`](https://github.com/NixOS/nixpkgs/commit/b5556cf267b702de189c2f932ff4fbccb167a371) libavif: 1.1.0 -> 1.1.1
* [`b1ae8aa3`](https://github.com/NixOS/nixpkgs/commit/b1ae8aa3fbf7a98d815422c2768c805b197f42f8) readline: 8.2p10 -> 8.2p13
* [`57a5072e`](https://github.com/NixOS/nixpkgs/commit/57a5072e1061b469ff4a17118e41bee575c9f112) m17n_db: 1.8.5 -> 1.8.7
* [`cee585ad`](https://github.com/NixOS/nixpkgs/commit/cee585ad0e417f12a8abe4e63a00f34e5f1e465e) xorg.libXfont2: 2.0.6 -> 2.0.7
* [`1228c180`](https://github.com/NixOS/nixpkgs/commit/1228c180a0f13483e57dbeab3253774c39d08fbe) xorg.libXtst: 1.2.4 -> 1.2.5
* [`fa1ed6e8`](https://github.com/NixOS/nixpkgs/commit/fa1ed6e8b62e684d680297ea36724584a1635e10) libdeflate: 1.20 -> 1.21
* [`ac375e1e`](https://github.com/NixOS/nixpkgs/commit/ac375e1ed5641786e6a95736bc31cfc563231673) alsa-lib: 1.2.11 -> 1.2.12
* [`27e56c9b`](https://github.com/NixOS/nixpkgs/commit/27e56c9b6f46561d9bdda49a8771da8c2bbb6002) libsForQt5.qttools: Move QT_HOST_DATA from sed calls to a patch
* [`df8c7eaf`](https://github.com/NixOS/nixpkgs/commit/df8c7eaf8ecd035b041c5679c411fc74e5efc772) libsForQt5.qttools: nixfmt
* [`dc6555f0`](https://github.com/NixOS/nixpkgs/commit/dc6555f0d87bd28dd7c155e8b6cfb44617063a0c) mpg123: 1.32.6 -> 1.32.7
* [`62934e6b`](https://github.com/NixOS/nixpkgs/commit/62934e6beda42c01a5cbfe512babe34c722bb517) libsForQt5.qttools: Reorder outputs vs propagatedBuildInputs
* [`6d237d89`](https://github.com/NixOS/nixpkgs/commit/6d237d891cca996abfa684ad45b5a9eb986b82ef) libmpg123: 1.32.6 -> 1.32.7
* [`925c2dc6`](https://github.com/NixOS/nixpkgs/commit/925c2dc6723bc3a9251b5f8fdae92cdfc6c3309a) lksctp-tools: 1.0.19 -> 1.0.20
* [`f80f5263`](https://github.com/NixOS/nixpkgs/commit/f80f5263194ca2d7fc1735ff5080869ae130e268) man-db: use libiconvReal on FreeBSD
* [`e9940f7c`](https://github.com/NixOS/nixpkgs/commit/e9940f7cf34ea15e9fa564ca57b91ac2c7ed9a22) man-db: Use unspecified/all manual directly layout on FreeBSD
* [`37976256`](https://github.com/NixOS/nixpkgs/commit/37976256c89959b32792bdd27968659b168c1c8e) sqlite, sqlite-analyzer: 3.46.0 -> 3.46.1
* [`dcb8a6f5`](https://github.com/NixOS/nixpkgs/commit/dcb8a6f5e7bf0c31ffe0422638bee799dd36063f) lsof: Fix build on FreeBSD
* [`a1e47e38`](https://github.com/NixOS/nixpkgs/commit/a1e47e382f912cdde6ebccb8a886eb7311a2fbb5) python312Packages.markdown: 3.6 -> 3.7
* [`5c05007e`](https://github.com/NixOS/nixpkgs/commit/5c05007e39ac79a88980d7d86ab6ea9c1eaf29bf) librsvg: 2.58.2 -> 2.58.3
* [`3e508761`](https://github.com/NixOS/nixpkgs/commit/3e508761b4a87f30409a1447abef8269a54f906b) binutils-unwrapped: 2.42 -> 2.43.1
* [`8ce5fdc4`](https://github.com/NixOS/nixpkgs/commit/8ce5fdc45aed68b688233df9584255783bde0525) python3Packages.parselmouth: init at 0.4.4
* [`cac05cae`](https://github.com/NixOS/nixpkgs/commit/cac05caee918edcd60929d1b6b7ad1389dc7e757) python312Packages.pyopenssl: 24.1.0 -> 24.2.1
* [`88b08cbc`](https://github.com/NixOS/nixpkgs/commit/88b08cbccfc4deba9846aa662ec9062af3014a36) media-player-info: 24 -> 26
* [`a551cfdc`](https://github.com/NixOS/nixpkgs/commit/a551cfdc3e3381211ff060093a9977c6d3935032) androidenv: updates for Android API 35
* [`9ce6da76`](https://github.com/NixOS/nixpkgs/commit/9ce6da76e70c5a08a1f5ef4ec18de29cda2df2c0) androidenv: add maintainers
* [`4ac3fe32`](https://github.com/NixOS/nixpkgs/commit/4ac3fe32a0e250db2f615f65507abd8e632d9cb0) freetype: 2.13.2 -> 2.13.3
* [`e739636d`](https://github.com/NixOS/nixpkgs/commit/e739636d81c3557b3fa48d27f1a6ab54bb577e6d) libmaxminddb: 1.10.0 -> 1.11.0
* [`16f3c7eb`](https://github.com/NixOS/nixpkgs/commit/16f3c7ebcbf08cfdab815c225f3858fbb7eef545) rustPlatform.buildRustPackage: provide debug symbols on darwin
* [`b232187b`](https://github.com/NixOS/nixpkgs/commit/b232187bd35144521d52e5905c6a0652b41cb1a8) bluez: substitute --replace with --replace-fail
* [`76289d6e`](https://github.com/NixOS/nixpkgs/commit/76289d6e29b1b3f0da47e4256aebd52f235ee920) cryptsetup: 2.7.3 -> 2.7.4
* [`690fbfaf`](https://github.com/NixOS/nixpkgs/commit/690fbfaf335ced358faf059f9844f485fc01e7c6) svt-av1: 2.2.0 -> 2.2.1
* [`b3dd92e2`](https://github.com/NixOS/nixpkgs/commit/b3dd92e2139a75c79d996f6758681eee83da6672) nodejs: fix libv8 object files list
* [`123aa0e8`](https://github.com/NixOS/nixpkgs/commit/123aa0e8179c3bbc36da894b6183d39983fd30c7) libdrm: 2.4.122 -> 2.4.123
* [`a816544a`](https://github.com/NixOS/nixpkgs/commit/a816544a3d78c67889d5f41e5a2bc0d8c0178667) nghttp2: 1.62.1 -> 1.63.0
* [`b6c50255`](https://github.com/NixOS/nixpkgs/commit/b6c502550997f700e267b9ea7290a5adc2016d00) libpipeline: 1.5.7 -> 1.5.8
* [`8e91c6b7`](https://github.com/NixOS/nixpkgs/commit/8e91c6b7b30154b060f43f3e3bb5a481cdf603a3) nixos/services.mysql: remove `with lib;`
* [`48d2e61a`](https://github.com/NixOS/nixpkgs/commit/48d2e61a94dadce25aacd58d169c7c7fd4bc47bf) zeromq: modernize
* [`774ed199`](https://github.com/NixOS/nixpkgs/commit/774ed19961843d91316b9020e925e390b3caeeef) zeromq: create and install man pages
* [`d35a5323`](https://github.com/NixOS/nixpkgs/commit/d35a532382bd4a0134b0a0ebd7fa2994b5bd0ff4) python312Packages.lxml: 5.2.2 -> 5.3.0
* [`d4dbbff7`](https://github.com/NixOS/nixpkgs/commit/d4dbbff784ae584366ea0238f435d901ef2005b3) selenium-manager: 4.22.0 -> 4.24.0
* [`f9c61918`](https://github.com/NixOS/nixpkgs/commit/f9c61918596e60ad1ab9f6d625c47543039bc527) python3Packages.selenium: 4.22.0 -> 4.24.0
* [`9987b44d`](https://github.com/NixOS/nixpkgs/commit/9987b44d937d4169a3e4c0180912e7e99556f48b) tcpdump: 4.99.4 -> 4.99.5
* [`daafc70f`](https://github.com/NixOS/nixpkgs/commit/daafc70f711124dcd71add0d5bdfefba15e079ed) tmuxPlugins.extrakto: unstable-2021-04-04 -> 0-unstable-2024-08-26
* [`7cdaa0b8`](https://github.com/NixOS/nixpkgs/commit/7cdaa0b80c9da64b2acb6cc8e8f73d2f4489aaeb) protobuf: protobuf_25 -> protobuf_28
* [`7f39165c`](https://github.com/NixOS/nixpkgs/commit/7f39165cca05d34ac547b179a58f311d4f46440c) grpc: 1.62.1 -> 1.66.1
* [`c3a791bf`](https://github.com/NixOS/nixpkgs/commit/c3a791bf5ea492b83b4b0ba0e89ea1166f2f78f8) python3Packages.grpcio-status: 1.64.1 -> 1.66.1
* [`cf29a07f`](https://github.com/NixOS/nixpkgs/commit/cf29a07f09f8bdb46198265a2a995cb750194b54) python3Packages.grpcio-tools: 1.64.1 -> 1.66.1
* [`a0eb4584`](https://github.com/NixOS/nixpkgs/commit/a0eb45841d2b9fb312968a5a8f31be3c7e43c55e) zeromq: add passthru.tests
* [`e597af55`](https://github.com/NixOS/nixpkgs/commit/e597af558361ee4a917eb1ad4b2809204ca244f2) zeromq: enable curve support
* [`187b315b`](https://github.com/NixOS/nixpkgs/commit/187b315b0f640649efefdf52084b6c15cd0a45f2) protobuf: add GaetanLepage as maintainer
* [`818996ed`](https://github.com/NixOS/nixpkgs/commit/818996edf8d5a61e97ef37357a88d1c59a6ebeb5) libwacom,libwacom-surface: 2.12.2 -> 2.13.0
* [`b26982f9`](https://github.com/NixOS/nixpkgs/commit/b26982f96ab46d8c9111dfa92f93868b3ae9ff20) protobuf: add testVersion check
* [`391c3320`](https://github.com/NixOS/nixpkgs/commit/391c332090fd49bee0d702c5ba3b25615b96d27a) python311Packages.tensorflow: pin protobuf python to python311Packages.protobuf4
* [`4c41bfc1`](https://github.com/NixOS/nixpkgs/commit/4c41bfc129701046b6929079860c4f3cc308d7aa) or-tools: pin protobuf python to python312Packages.protobuf4
* [`8f4eb776`](https://github.com/NixOS/nixpkgs/commit/8f4eb776fbbf9b5ae48ef5c696d4cd5aee7a7e6f) ola: pin protobuf python to python312Packages.protobuf4
* [`b64a75b7`](https://github.com/NixOS/nixpkgs/commit/b64a75b72f87050fd986038d17af18ade92af688) gst_all_1.gst-plugins-base: disable introspection if unavailable
* [`611ad1cb`](https://github.com/NixOS/nixpkgs/commit/611ad1cb6f46fa2e3358cc98d441ca524b030ba1) nss_latest: 3.103 -> 3.104
* [`4fd0cbfb`](https://github.com/NixOS/nixpkgs/commit/4fd0cbfb5bf2c664d5bf845cd125975dbafc0427) cacert: 3.101.1 -> 3.104
* [`2f7222d3`](https://github.com/NixOS/nixpkgs/commit/2f7222d34d9bd99616cc4ab190475e31e59ff4db) gst_all_1.gstreamer: 1.24.3 -> 1.24.7
* [`830fd9c4`](https://github.com/NixOS/nixpkgs/commit/830fd9c48bf4a5fc00e8fbdf940730998c41d5af) gst_all_1.gst-plugins-base: 1.24.3 -> 1.24.7
* [`4f18a0a9`](https://github.com/NixOS/nixpkgs/commit/4f18a0a9feae87fda6035b127579075608d9eadb) gst_all_1.gst-plugins-good: 1.24.3 -> 1.24.7
* [`376d22b7`](https://github.com/NixOS/nixpkgs/commit/376d22b787a4c0593d363fa0ab9488120809598a) gst_all_1.gst-plugins-bad: 1.24.3 -> 1.24.7
* [`12eaa68d`](https://github.com/NixOS/nixpkgs/commit/12eaa68d405a8bdedc1833d20dec9514492682cd) gst_all_1.gst-plugins-ugly: 1.24.3 -> 1.24.7
* [`d8e8d256`](https://github.com/NixOS/nixpkgs/commit/d8e8d2560e1a870f3fae85eea5855728e66c1619) gst_all_1.gst-libav: 1.24.3 -> 1.24.7
* [`e21f9ba0`](https://github.com/NixOS/nixpkgs/commit/e21f9ba00e7d37e74bf2a89bc0f4fa1799ae7c9d) gst_all_1.gst-vaapi: 1.24.3 -> 1.24.7
* [`3f2e9f2e`](https://github.com/NixOS/nixpkgs/commit/3f2e9f2ee84030cce0e5a82524b0c59f5c336db6) gst_all_1.gst-rtsp-server: 1.24.3 -> 1.24.7
* [`aa1c0501`](https://github.com/NixOS/nixpkgs/commit/aa1c0501b91f2e93d332f56c71092bc1ffbe7f87) gst_all_1.gst-devtools: 1.24.3 -> 1.24.7
* [`afacb078`](https://github.com/NixOS/nixpkgs/commit/afacb0789d35e2ef591bf5e48b5164c6f704df28) gst_all_1.gst-editing-services: 1.24.3 -> 1.24.7
* [`c129df75`](https://github.com/NixOS/nixpkgs/commit/c129df75b68338d3b3b3b0892d5d78133ed850a4) python3Packages.gst-python: 1.24.3 -> 1.24.7
* [`69b18ff3`](https://github.com/NixOS/nixpkgs/commit/69b18ff3ea8b8df4b85b0ce58ff2ce26f0e38163) gst_all_1.gst-plugins-bad: add patch for macOS < 12 SDK
* [`21c01298`](https://github.com/NixOS/nixpkgs/commit/21c0129841005c2887037d3e2468944cd92b977e) treewide: handle prePhases __structuredAttrs-agnostically
* [`5d42a8b3`](https://github.com/NixOS/nixpkgs/commit/5d42a8b38c1ae022307a9eed02d655720bca7481) treewide: handle preConfigurePhases __structuredAttrs-agnostically
* [`385d523a`](https://github.com/NixOS/nixpkgs/commit/385d523a8e578dbd046b2345c8b034ddc164e12d) treewide: handle preInstallPhases __structuredAttrs-agnostically
* [`054c5f0e`](https://github.com/NixOS/nixpkgs/commit/054c5f0e106d8a0169582fed4c1b2ba86647f73d) treewide: handle preDistPhases __structuredAttrs-agnostically
* [`758056da`](https://github.com/NixOS/nixpkgs/commit/758056dac763e5368470673ae63c6fa637ba93d1) treewide: handle postPhases __structuredAttrs-agnostically
* [`5ec4f676`](https://github.com/NixOS/nixpkgs/commit/5ec4f676b47936aa3ccf7122ead2002ab67a5008) doc/stdenv: document the format of *Phases
* [`4776a9cb`](https://github.com/NixOS/nixpkgs/commit/4776a9cb746c7ad81f1cd9e97030351793ee2917) xterm: 393 -> 394
* [`dc629a75`](https://github.com/NixOS/nixpkgs/commit/dc629a75abe995ff0734bcbe769755cb7985bfd6) libpcap: 1.10.4 -> 1.10.5
* [`e4bf5a79`](https://github.com/NixOS/nixpkgs/commit/e4bf5a79e903aeba8b25db6deb31af52aca14b84) ell: 0.67 -> 0.68, iwd: 2.19 -> 2.20
* [`b1742202`](https://github.com/NixOS/nixpkgs/commit/b174220283d1011e40b360db043154f9de8d7bda) python3Packages.sphinxcontrib-jquery: fix build with doCheck=false
* [`0852f8eb`](https://github.com/NixOS/nixpkgs/commit/0852f8eb8481cfa310a131017a0e73f2333c8bba) rustc: expose platform lists
* [`28adcaa9`](https://github.com/NixOS/nixpkgs/commit/28adcaa9b9e7069a0eeb22fc47c52eb2d5587d27) gst_all_1.gstreamer: disable Rust if unavailable
* [`da19f27b`](https://github.com/NixOS/nixpkgs/commit/da19f27bd463b3e76a40f18a2076927a90840589) geocode-glib.tests.installed-tests: Fix
* [`a93d6723`](https://github.com/NixOS/nixpkgs/commit/a93d6723672cd2ea229778ff5361fd656f6f9f57) gjs.tests.installedTests: Fix
* [`c596592e`](https://github.com/NixOS/nixpkgs/commit/c596592e731fd1775b08d16dd6a5d254123b4b80) nixos-rebuild: add --no-ssh-tty flag
* [`6ed699e2`](https://github.com/NixOS/nixpkgs/commit/6ed699e2d9381731bec9761dcd9d5279dff42711) cairo: 1.18.0 -> 1.18.2
* [`3500e97c`](https://github.com/NixOS/nixpkgs/commit/3500e97c8efc9fd28c44059e2a5b0acbbe469236) hwdata: 0.385 -> 0.386
* [`ccff8b60`](https://github.com/NixOS/nixpkgs/commit/ccff8b60ace758f7deb58767429249b7ee06666c) python312Packages.sqlalchemy: 2.0.32 -> 2.0.33
* [`22813e91`](https://github.com/NixOS/nixpkgs/commit/22813e9165f4d104d0af6b7e615807553856fc31) libbpf: 1.4.5 -> 1.4.6
* [`e8e964f4`](https://github.com/NixOS/nixpkgs/commit/e8e964f492020e2823bc194a4c235396aeb0e9d7) qt5: 5.15.14 -> 5.15.15
* [`e6d3c8bf`](https://github.com/NixOS/nixpkgs/commit/e6d3c8bf32122bebff96929232372149ddaf28c8) gn: 2020-03-09 -> 2024-05-13
* [`23ed77af`](https://github.com/NixOS/nixpkgs/commit/23ed77af70a8239d66c6bfd6e20283f2cc6d59d1) wayland-protocols: 1.36 -> 1.37
* [`cb5552c7`](https://github.com/NixOS/nixpkgs/commit/cb5552c7a5f70618343bb6d3dcd01cf685c09349) umockdev: 0.18.3 -> 0.18.4
* [`3a41bcd6`](https://github.com/NixOS/nixpkgs/commit/3a41bcd617109a6161d702f7458d4a508a499a5a) mongodb-ce: remove custom `curl` override
* [`0c77b5d3`](https://github.com/NixOS/nixpkgs/commit/0c77b5d3741c726f1ccb9891dab456f9e2ff885f) python312Packages.sqlalchemy: 2.0.33 -> 2.0.34
* [`121787aa`](https://github.com/NixOS/nixpkgs/commit/121787aa4da29d2c337780c91453d002b3bc553b) python312Packages.pythran: 0.15.0 -> 0.16.1
* [`3695d3e3`](https://github.com/NixOS/nixpkgs/commit/3695d3e3b0decd7fdc0774dc0c998065821449f3) libaom: 3.9.1 -> 3.10.0
* [`897b3162`](https://github.com/NixOS/nixpkgs/commit/897b3162c511dee343f7896ca3aa33a2f0b4a418) python312Packages.pikepdf: 9.1.1 -> 9.2.1
* [`d71d9e86`](https://github.com/NixOS/nixpkgs/commit/d71d9e86b1f9ff0e979276f0a9afa3774db48d39) tzdata: 2024a -> 2024b
* [`6a2b4457`](https://github.com/NixOS/nixpkgs/commit/6a2b44571d592f155fbcbb30bb6956383bac36ee) hwdata: 0.386 -> 0.387
* [`954cea57`](https://github.com/NixOS/nixpkgs/commit/954cea5708a7a197fba7dc3a8068876c7edbe4d5) libsForQt5.qttools: Add LLVM for qdoc
* [`ef83d631`](https://github.com/NixOS/nixpkgs/commit/ef83d631b1541a31a218fe77611c240fc0476fcf) python312Packages.cffi: 1.17.0 -> 1.17.1
* [`7557a74c`](https://github.com/NixOS/nixpkgs/commit/7557a74c6a6ae7ef0849e32adcfc077046a34ae2) liburcu: 0.14.0 -> 0.14.1
* [`1ed22ba8`](https://github.com/NixOS/nixpkgs/commit/1ed22ba8937e29608a5bab9e76d054a753643aae) ffmpeg: remove withOgg
* [`9550eb89`](https://github.com/NixOS/nixpkgs/commit/9550eb8922a4ff28fcdc14b32bd28553d050dd8c) python312: 3.12.5 -> 3.12.6
* [`a161af2d`](https://github.com/NixOS/nixpkgs/commit/a161af2daadfd38583ee45ed4b200ca21617fb74) python311: 3.11.9 -> 3.11.10
* [`41723c52`](https://github.com/NixOS/nixpkgs/commit/41723c52fa412d1c3fdb16ffc413fd6205014119) expat: 2.6.2 -> 2.6.3
* [`a4870442`](https://github.com/NixOS/nixpkgs/commit/a48704428792db4901fd41bc940f4e610a4edd00) ruby: 3.3.4 -> 3.3.5 ([nixos/nixpkgs⁠#340137](https://togithub.com/nixos/nixpkgs/issues/340137))
* [`384f9f83`](https://github.com/NixOS/nixpkgs/commit/384f9f83363bce439aba5b345dcdc43e0ac95533) perl: 5.38.2 -> 5.40.0
* [`95434d51`](https://github.com/NixOS/nixpkgs/commit/95434d510b1383a834f240cb545d1cccd36603ff) top-level/release-perl.nix: init Hydra job set for perlPackages
* [`fb4a1867`](https://github.com/NixOS/nixpkgs/commit/fb4a18673377f7f4014e16f8d3d50a0f311ca86a) perlPackages.BKeywords: 1.26 -> 1.27
* [`d6d704d3`](https://github.com/NixOS/nixpkgs/commit/d6d704d3ed2253e2726075dcef5e4d6ccba824a0) perlPackages.GetoptLongDescriptive: 0.111 -> 0.114
* [`b5f4b26c`](https://github.com/NixOS/nixpkgs/commit/b5f4b26cdad19eb7e0b7d0f224f75456ea8edea8) perlPackages.po4a: 0.71 -> 0.73
* [`35efbc90`](https://github.com/NixOS/nixpkgs/commit/35efbc9044b69bdb9bc5f835a0caee5a2f905585) perlPackages.AppMusicChordPro: 6.030 -> 6.050.7
* [`2d5ed902`](https://github.com/NixOS/nixpkgs/commit/2d5ed902b29bc7e918e878db88fa3d9a99fd439c) perlPackages.CodeTidyAll: 0.83 -> 0.84
* [`204ef75e`](https://github.com/NixOS/nixpkgs/commit/204ef75e033157f52b83052210270132b2d3e649) perlPackages.DevelSize: 0.83 -> 0.84
* [`aec989ad`](https://github.com/NixOS/nixpkgs/commit/aec989ad30d4c9bd4275a949e4e5bcd9355350dd) perlPackages.MooseXGetopt: 0.75 -> 0.76
* [`78ec617b`](https://github.com/NixOS/nixpkgs/commit/78ec617b3aa8dd85d401c1e872d70cac89206b51) perlPackages.FileLoadLines: 1.021 -> 1.046
* [`66c5dc33`](https://github.com/NixOS/nixpkgs/commit/66c5dc33cc6e1c70c337a3fb25cbba0d85a7407f) perlPackages.TextLayout: 0.031 -> 0.037
* [`9e51c8eb`](https://github.com/NixOS/nixpkgs/commit/9e51c8eb8f7520e00eaec94075fb7ea498fa091c) perlPackages.ObjectPad: 0.804 -> 0.809
* [`0671159d`](https://github.com/NixOS/nixpkgs/commit/0671159daebe5dd5b75b06cb11040dba1fc6c134) perlPackages.XSParseKeyword: 0.38 -> 0.44
* [`2a1179cc`](https://github.com/NixOS/nixpkgs/commit/2a1179ccb838f11b596f5f8029ca30f06e27f2f4) perlPackages.EncodeIMAPUTF7: patch to fix build with 540
* [`7f567ed7`](https://github.com/NixOS/nixpkgs/commit/7f567ed707640f2ef83e353daa327bea919c557a) perlPackages.MouseXGetOpt: remove failing tests to fix build
* [`8df266da`](https://github.com/NixOS/nixpkgs/commit/8df266da79c83c40f5aceacace6d838878f61b2d) pkgsStatic.perl: fix build
* [`f6c80f8f`](https://github.com/NixOS/nixpkgs/commit/f6c80f8fc7fd57835ddecd1ed4d252cdf92b1f9b) perl536: remove
* [`097e28b0`](https://github.com/NixOS/nixpkgs/commit/097e28b021759fe1e829769c0d23438b9d725b13) unit: perl536 -> perl540
* [`0724f3cc`](https://github.com/NixOS/nixpkgs/commit/0724f3cc5673a91e4d68c47ae1d0ef8cdb11510e) macvim: 178 -> 179, perl536 -> perl540
* [`c01953da`](https://github.com/NixOS/nixpkgs/commit/c01953dae814229bde0f724c01c2d51ba65640e0) perlPackages.ApacheDB: mark as broken
* [`f5413cd9`](https://github.com/NixOS/nixpkgs/commit/f5413cd9d49fbb148f23017bf24db8aa0f4314cd) perlPackages.CGICompile: disable unstable test
* [`816958c8`](https://github.com/NixOS/nixpkgs/commit/816958c88efed3305b1fcdf686ddccdb9c57a93f) perlPackages.AuthenModAuthPubTkt: disable unstable test
* [`92b0f7cb`](https://github.com/NixOS/nixpkgs/commit/92b0f7cb13eb6d28cc5f929a32d7a294da2896c4) ffmpeg: ffmpeg_6 -> ffmpeg_7
* [`342fb8a1`](https://github.com/NixOS/nixpkgs/commit/342fb8a152c05354a2c9dc455fcbc1fc394a2912) ffmpeg: adjust update and pinning advice
* [`61922738`](https://github.com/NixOS/nixpkgs/commit/61922738bbdfee7c34dffb8ab6facc04b015011e) treewide: optimistically unpin FFmpeg 7 dependencies
* [`5ad11f7f`](https://github.com/NixOS/nixpkgs/commit/5ad11f7f8d3fca93bd926fb0cae43819305b88bd) python3Packages.av: 12.3.0 -> 13.0.0
* [`7732e956`](https://github.com/NixOS/nixpkgs/commit/7732e956a82f0ab9211d317f23e80aa044d5a420) libphidget22: init at 0-unstable-2024-04-11
* [`845e8ef8`](https://github.com/NixOS/nixpkgs/commit/845e8ef8a391db0c564534b3483e8ea457a0bba7) ffmpeg: Enable vid-stab by default
* [`3ca95fad`](https://github.com/NixOS/nixpkgs/commit/3ca95fad40371179821d3a5f37b5c6f0287cc916) libarchive: inherit badPlatforms from acl
* [`ad28bfd5`](https://github.com/NixOS/nixpkgs/commit/ad28bfd5ec47f873b7b789b46f668a470fffa665) elfutils: fix building for Microblaze
* [`808d4738`](https://github.com/NixOS/nixpkgs/commit/808d4738b9846095868d850c877b865221de9c2c) shadow: disable libbsd when unavailable
* [`b3c1bb17`](https://github.com/NixOS/nixpkgs/commit/b3c1bb1762fceefe9520ae0e442fdd2cce0fca31) protobufc: fix compatibility with new protobuf
* [`8e325b50`](https://github.com/NixOS/nixpkgs/commit/8e325b5086df6e045f92dac68d31037da3fbbcdb) ec2: shellcheck fixes
* [`5097974f`](https://github.com/NixOS/nixpkgs/commit/5097974f8e231d14862ed2def077cc7c775f608e) python312Packages.webob: 1.8.7 -> 1.8.8
* [`1a171ee7`](https://github.com/NixOS/nixpkgs/commit/1a171ee732761a15ed743b9fe36b0e387c74f79b) python312Packages.webob: add some key reverse dependencies to passthru.tests
* [`762d2c19`](https://github.com/NixOS/nixpkgs/commit/762d2c1971be733238f05d0dd17aeb7954972f0f) unit: clean up withPerl arguments
* [`67ecdcbb`](https://github.com/NixOS/nixpkgs/commit/67ecdcbb971c8a807dd6837af9bb78864b996318) unit: add nixos tests for perl
* [`9df84d4c`](https://github.com/NixOS/nixpkgs/commit/9df84d4c9a57dfc0e34874816b96e3a8e995516b) swiftpm: support structuredAttrs in setup hook
* [`fc37487a`](https://github.com/NixOS/nixpkgs/commit/fc37487ab215e7df8e73f9b2a07cb455c1071b1c) swiftpm: shellcheck setup hook
* [`e6ca54fd`](https://github.com/NixOS/nixpkgs/commit/e6ca54fdedb1b3b8a72fd9fb9adc7cf4ecb1d447) gradle: support structuredAttrs in setup hook
* [`3d22a726`](https://github.com/NixOS/nixpkgs/commit/3d22a726812072354c4a4046018b2a302946d72a) xcbuild: support structuredAttrs in setup hook
* [`96ddeee4`](https://github.com/NixOS/nixpkgs/commit/96ddeee42a4c2b373dfe3235da427e3b93463838) extra-cmake-modules: support structuredAttrs in hooks
* [`4153e8f0`](https://github.com/NixOS/nixpkgs/commit/4153e8f02f3f8490f209f9276e667ccbd8797397) cuda-modules: refactor appending cmakeFlags in setup hook
* [`01126ae1`](https://github.com/NixOS/nixpkgs/commit/01126ae1e7026b2f2690579c55fdc65fa93897b2) netbsd: use env. to pass RENAME environment variable
* [`c0e25035`](https://github.com/NixOS/nixpkgs/commit/c0e250354a8e25c8755fa6b0a1cb09a7325505eb) bsd: support structuredAttrs in setup hook
* [`88a44bc8`](https://github.com/NixOS/nixpkgs/commit/88a44bc843212804c01545e621d18f52a6bdfe00) bsd: shellcheck setup hook
* [`c3470fdf`](https://github.com/NixOS/nixpkgs/commit/c3470fdfb7c4730cc79cf9bd0e8bee99ced3758d) netbsd: support structuredAttrs in setup hook
* [`9e836fdd`](https://github.com/NixOS/nixpkgs/commit/9e836fddfe89e7a06e2094cbc64858c4cd9b2f1f) openbsd: support structuredAttrs in setup hook
* [`202bfa48`](https://github.com/NixOS/nixpkgs/commit/202bfa48fd04d3714345e8ed90a33f82befdaf62) freebsd: support structuredAttrs in setup hook
* [`7912e83a`](https://github.com/NixOS/nixpkgs/commit/7912e83adeef3bc5788ba857ca019cba9a168f1c) treewide: fix typos of enableParallelBuilding
* [`50b34650`](https://github.com/NixOS/nixpkgs/commit/50b34650c9dfa5500c0ba65a264d5de694a230a6) maintainers: add jacobkoziej
* [`c51ca826`](https://github.com/NixOS/nixpkgs/commit/c51ca826cecee4b78d0334bff0cb2007461c3f40) melpa2nix: update to work with current MELPA recipes
* [`799d0c8a`](https://github.com/NixOS/nixpkgs/commit/799d0c8a7da358ac05323922c87d149376549672) stdenv: bump required Bash version from 4 to 5
* [`56a20986`](https://github.com/NixOS/nixpkgs/commit/56a2098698688a02f8be6a43f52570afa5fcda89) ocamlPackages.ffmpeg*: pin FFmpeg 6 for now
* [`a149bd47`](https://github.com/NixOS/nixpkgs/commit/a149bd4768f8a4d1eb600302bc31ef8e4da7a0be) liquidsoap: pin FFmpeg 6 for now
* [`685864af`](https://github.com/NixOS/nixpkgs/commit/685864af83d81b4c1a8cfa912df10974c5360eb7) emacs.pkgs.melpaPackages.ttl-mode: update recipe
* [`d45c5ab2`](https://github.com/NixOS/nixpkgs/commit/d45c5ab2951fe02aabfe2b7bfce5c80ba4138a1b) ffmpeg: add npp option
* [`18d3b57f`](https://github.com/NixOS/nixpkgs/commit/18d3b57fa0b3ef18a7b10fe021d8d0f26d43641d) ffmpeg: add CudaNVCC option
* [`b965ede9`](https://github.com/NixOS/nixpkgs/commit/b965ede9638b21e9d0ac0b9b36f763f3686dec40) rust-analyzer: use env. to pass CFG_RELEASE environment variable
* [`9220a19a`](https://github.com/NixOS/nixpkgs/commit/9220a19a4dee6cea4270a4be4855b7de4ac6bf60) rust: support structuredAttrs in setup hooks
* [`d5013e94`](https://github.com/NixOS/nixpkgs/commit/d5013e942e3ae3655f5537ba32792c5c20e73106) rust: shellcheck setup hooks
* [`155fb5be`](https://github.com/NixOS/nixpkgs/commit/155fb5be701345e2ae36ff022a9a78bcfdb2e58f) openssl: use makeBinaryWrapper instead of makeShellWrapper
* [`64bbfed5`](https://github.com/NixOS/nixpkgs/commit/64bbfed55e056ce168e3f2f8df01bb600e8ee034) publicsuffix-list: 0-unstable-2024-08-21 -> 0-unstable-2024-09-10
* [`5f125d57`](https://github.com/NixOS/nixpkgs/commit/5f125d57c34ca17e713c70c96b7a825fa408f18b) cargo,clippy,rustc,rustfmt: 1.80.1 -> 1.81.0
* [`b1a93bb5`](https://github.com/NixOS/nixpkgs/commit/b1a93bb5c45a955dccdae4b70e6e4f85968a4933) {telegram-desktop,kotatogram-desktop}.tg_owt: add patch for FFmpeg 7
* [`11b562f3`](https://github.com/NixOS/nixpkgs/commit/11b562f3bfea35d7802cd7bf3968445cc8567d60) python312Packages.build: 1.2.1 -> 1.2.2
* [`b2f01b88`](https://github.com/NixOS/nixpkgs/commit/b2f01b886128a93ec7e9b9d7ac5f071cca08a63b) python3: get the triple from the build system
* [`a89244a3`](https://github.com/NixOS/nixpkgs/commit/a89244a391f69ebf3c31f7cffef4452c5c57c07d) keyutils: backport .pc file for static builds
* [`bfbe0e92`](https://github.com/NixOS/nixpkgs/commit/bfbe0e92723ed30bf3511383e7a7a734b29921fa) python312Packages.multidict: 6.0.5 -> 6.1.0
* [`e9cdb227`](https://github.com/NixOS/nixpkgs/commit/e9cdb2274152ab7e7646406cebec791a47a48c7d) gcc: gcc_13 → gcc_14
* [`a4145a81`](https://github.com/NixOS/nixpkgs/commit/a4145a81d1fdd70a0ac8459a6c5db3786753804e) treewide: add `-Wno-error=` due to compilation error with gcc_14
* [`438ed81a`](https://github.com/NixOS/nixpkgs/commit/438ed81a348890b52bf5bf93de50e04406a532d4) treewide: add `-fpermissive` due to configuration error with gcc_14
* [`a55b0ea0`](https://github.com/NixOS/nixpkgs/commit/a55b0ea0b170e31b2430ae9680eab435e2c5e9f1) jam: broaden `-std=c89` due to compilation error with gcc_14
* [`0aa06e6e`](https://github.com/NixOS/nixpkgs/commit/0aa06e6e1ca8677a87284720f417b19d1e2978a6) vulkan-headers: build using ninja to fix `gcc-14` compatibility
* [`67222d41`](https://github.com/NixOS/nixpkgs/commit/67222d4174abad58b8821e8d274bbb1d9da5dd6e) afdko: disable failing tests on gcc_14
* [`b1e9a039`](https://github.com/NixOS/nixpkgs/commit/b1e9a03960c5f5d83b1e9c955b22ed210f5925f7) zsh: add backported gcc_14 patch
* [`1bd53510`](https://github.com/NixOS/nixpkgs/commit/1bd53510127c76f26fc064d62776796aae56038c) range-v3: use `-std=c++17` due to compilation error with gcc_13
* [`246624dd`](https://github.com/NixOS/nixpkgs/commit/246624ddf266c0a27e07d00ac6ca0df50741e828) apparmorRulesFromClosure: include more directories
* [`4fef1bd3`](https://github.com/NixOS/nixpkgs/commit/4fef1bd39a67ef5251a26ba0d1be4c6d88a5ac3b) python312Packages.mypy: 1.10.1 -> 1.11.2
* [`616ab8b0`](https://github.com/NixOS/nixpkgs/commit/616ab8b0058d049ba6e2f469fe7cf64832f819be) msgpack-c: 6.0.2 -> 6.1.0
* [`5cd6d4ec`](https://github.com/NixOS/nixpkgs/commit/5cd6d4ec03bf439f9826c783341b3c93c4570a10) systemd: 256.4 -> 256.6
* [`70f48395`](https://github.com/NixOS/nixpkgs/commit/70f48395b9f51661b03e42db9cc373c0e6c3d1b1) svt-av1: 2.2.0 -> 2.2.1
* [`2a2b88eb`](https://github.com/NixOS/nixpkgs/commit/2a2b88eb557c655c2b4960a8d8f3e23a05a3472c) auto-patchelf: fix test for hook
* [`bc0395ee`](https://github.com/NixOS/nixpkgs/commit/bc0395ee6f9964065665adf3d365a2f93c3b4ca5) auto-patchelf: refactor structuredAttrs support
* [`349dd99a`](https://github.com/NixOS/nixpkgs/commit/349dd99ac7fbeb8d60721412a65206951324a227) protobuf: 28.0 -> 28.1
* [`d72ee974`](https://github.com/NixOS/nixpkgs/commit/d72ee974ef5cf3e8551ba733acc484bd543895f2) python312Packages.protobuf: 5.28.0 -> 5.28.1
* [`15f9d09c`](https://github.com/NixOS/nixpkgs/commit/15f9d09c26267c391b79a1be98e257a888731c03) python312Packages.pytz: 2024.1 -> 2024.2
* [`7124b06a`](https://github.com/NixOS/nixpkgs/commit/7124b06aeaa2a4aab5be6a4dfce08493cc0b88d4) deterministic-host-uname: fix use in nativeBuildInputs
* [`7e4ac86a`](https://github.com/NixOS/nixpkgs/commit/7e4ac86aa71e437c52f9848e660a492b9eae8612) python3Packages.cython: reorder input set
* [`54a55ac5`](https://github.com/NixOS/nixpkgs/commit/54a55ac5294fd55991a0c28d1056efd544b26f05) python3Packages.cython: rework checkPhase
* [`eddadbf8`](https://github.com/NixOS/nixpkgs/commit/eddadbf80f9464fc317030006452c11d3df96208) python3Packages.cython: use fetchFromGitHub instead of fetchPypi
* [`769509f2`](https://github.com/NixOS/nixpkgs/commit/769509f2e3f065e390c17dadc42fe83d59c944a0) python3Packages.cython: set strictDeps to true
* [`2bd250be`](https://github.com/NixOS/nixpkgs/commit/2bd250be2e3fbc5518d6fe31ba8429c47d739088) python3Packages.cython: add pygame-ce to passthru.tests
* [`0ce53ae9`](https://github.com/NixOS/nixpkgs/commit/0ce53ae927693ec58b06b864b92c411fff35fa2f) python3Packages.cython: reword comment
* [`b51f863d`](https://github.com/NixOS/nixpkgs/commit/b51f863da949ce763b9a8a7db5311c7e64d5c6d2) python3Packages.cython: add meta.mainProgram
* [`d85ab646`](https://github.com/NixOS/nixpkgs/commit/d85ab646413b11c713f7f6ffc28c8c5b0e64feb9) python3Packages.cython: add AndersonTorres to meta.maintainers
* [`17b3df28`](https://github.com/NixOS/nixpkgs/commit/17b3df2861d0ced01ddefa58b6d6fc2571b1c415) rust: Write to .cargo/config.toml instead of .cargo/config
* [`adde4b71`](https://github.com/NixOS/nixpkgs/commit/adde4b71d336d7e3eb7ae64c29030ff27cb3c832) lz4: 1.9.4 -> 1.10.0
* [`4fdc3b2c`](https://github.com/NixOS/nixpkgs/commit/4fdc3b2ca0313ee8acf9fcd488f3218646e30c27) boundary: fix update script
* [`9d06beb1`](https://github.com/NixOS/nixpkgs/commit/9d06beb162a3d0f4853a1ed0427994b39aaa9dcc) boundary: 0.15.4 -> 0.17.1
* [`9c116ffa`](https://github.com/NixOS/nixpkgs/commit/9c116ffab332dcc1c7b6e1d5072816289f30f6b0) boundary: nixfmt
* [`f131e4ff`](https://github.com/NixOS/nixpkgs/commit/f131e4ffd10a54420dbe7b2d0f7c812704074c61) boundary: move to pkgs/by-name
* [`eff4e923`](https://github.com/NixOS/nixpkgs/commit/eff4e9238203d8621b0aa5a3d3275de22b2c7a3c) tzdata: disable network access
* [`4654ea4c`](https://github.com/NixOS/nixpkgs/commit/4654ea4cc01154007f3521066f1b4ed429244c0a) buildEnv: support pulling in closures of paths
* [`db091453`](https://github.com/NixOS/nixpkgs/commit/db0914534a691d0d20139f31c7d3c98f9b7365db) buildFHSEnv: force overwriting ld-linux.so.2
* [`617a1a6e`](https://github.com/NixOS/nixpkgs/commit/617a1a6e5778df81efceffa656988e38bd293b1c) nixos-rebuild.sh: pass flags to nix-copy-closure whenever possible
* [`5165991c`](https://github.com/NixOS/nixpkgs/commit/5165991c4ee2bfcbfe15fa334207da3a74207b55) libsForQt5.plasma-wayland-protocols: 1.13.0 -> 1.14.0
* [`f34b9f5e`](https://github.com/NixOS/nixpkgs/commit/f34b9f5e60799e80576f7bfeca310f4631c4a443) nixos/netboot: Compress squashfs with zstd 19
* [`b79305df`](https://github.com/NixOS/nixpkgs/commit/b79305dfdd1205b4acabdca07df5a5f8cfab52c9) treewide: fix typos
* [`871a8481`](https://github.com/NixOS/nixpkgs/commit/871a8481f3f41c634211878e45e4cfcb6428efe6) jackline: fix nativeBuildInputs typo
* [`ad291eff`](https://github.com/NixOS/nixpkgs/commit/ad291eff6e725ab8ef4dc1fd64939df239328052) raspa-data: remove gzip
* [`496d66c8`](https://github.com/NixOS/nixpkgs/commit/496d66c83695d1759cdd285dba9beac6433e944b) tezos-rust-libs: fix pythonImportsCheck typo
* [`731a66d1`](https://github.com/NixOS/nixpkgs/commit/731a66d13bdefb5aac8e17514b3c13978af06d5d) tezos-rust-libs: set meta
* [`f9ba61be`](https://github.com/NixOS/nixpkgs/commit/f9ba61be40698cdf16478c2a92a46f10ed6a8a7e) python311Packages.django-pwa: fix pythonImportsCheck typo
* [`71b3a52b`](https://github.com/NixOS/nixpkgs/commit/71b3a52bb7717100f19564a493e32659352bded3) python311Packages.ipyniivue: fix nativeCheckInputs typo, build js from source
* [`d6330239`](https://github.com/NixOS/nixpkgs/commit/d633023973ee35097a50cc4f8988b5048fb92cad) ldns: 1.8.3 -> 1.8.4
* [`0dee053e`](https://github.com/NixOS/nixpkgs/commit/0dee053eb228a901be9bdc55237246cf90478a86) python311Packages.openapi3: fix nativeCheckInputs typo, fix checkPhase
* [`2d244d98`](https://github.com/NixOS/nixpkgs/commit/2d244d98c51981cb13e6a8707e076ee7ed8ea948) python311Packages.pycodestyle: fix nativeCheckInputs typo, fetch from github
* [`d2f22a8e`](https://github.com/NixOS/nixpkgs/commit/d2f22a8e8cc6768f3395eee22bba862963ac9975) python311Packages.pyogg: fix propagatedBuildInputs typo
* [`f993429d`](https://github.com/NixOS/nixpkgs/commit/f993429d0c4e17e6f949cfb0bf5e3d890cf76f01) python311Packages.summarytools: remove pytestCheckHook
* [`10ba0eba`](https://github.com/NixOS/nixpkgs/commit/10ba0eba327678d5d29869cf14d20e7370980633) python311Packages.symengine: fix nativeBuildInputs typo
* [`5c7c9ed4`](https://github.com/NixOS/nixpkgs/commit/5c7c9ed4a7db36552d03664e1a038370df2b8693) python311Packages.trimesh: update meta.homepage
* [`93f7772e`](https://github.com/NixOS/nixpkgs/commit/93f7772ee6e79955d4777372c216c0f5bac81807) libogg: modernize
* [`04bf3a5a`](https://github.com/NixOS/nixpkgs/commit/04bf3a5a24294b530a985b95ec8aa984c7d339ae) libogg: allow dependents to find it with cmake
* [`73e038d5`](https://github.com/NixOS/nixpkgs/commit/73e038d5fa61d5b42b1c55298dc4164e906d75c9) jsoncpp: 1.9.5 -> 1.9.6
* [`a1f9051d`](https://github.com/NixOS/nixpkgs/commit/a1f9051d07bc97519322a54b6cba8839c77ee81b) aws-c-mqtt: 0.10.4 -> 0.10.5
* [`fdbe69f2`](https://github.com/NixOS/nixpkgs/commit/fdbe69f2bf3c03e919ef0b4129b44d294b83d7a0) gn: backport LFS64 cleanup
* [`972976d9`](https://github.com/NixOS/nixpkgs/commit/972976d903bbb9bcc5d406397b11e5cf284139c0) nixos/pam: add pam_rssh support
* [`ba2b9186`](https://github.com/NixOS/nixpkgs/commit/ba2b91866b7097c9f6aa6983387dce625ed8d24c) chore: typos and comment fixups in Go build-support function
* [`f15ac020`](https://github.com/NixOS/nixpkgs/commit/f15ac02068f9951e906a366ac56dfe3f61234b10) python3Packages.poetry-core: backport test fix for Python 3.12.6
* [`82af94db`](https://github.com/NixOS/nixpkgs/commit/82af94db4c991933cf68816dc3f16bcbf1ba0a77) python311Packages.pbr: 6.0.0 -> 6.1.0
* [`87efc7da`](https://github.com/NixOS/nixpkgs/commit/87efc7da45b540967293d4b1486efd89f7d50f31) libndp: fix build for musl with GCC 14
* [`17648a4f`](https://github.com/NixOS/nixpkgs/commit/17648a4f578c72d29f838e1986320b985756ecf1) openssh: fix building for musl with GCC 14
* [`f761b0ab`](https://github.com/NixOS/nixpkgs/commit/f761b0abc4d983c289a595e9584bb60efe1efbe3) libaom: fix building for musl with GCC 14
* [`b8cccde6`](https://github.com/NixOS/nixpkgs/commit/b8cccde6f7260e81ec64dc7ac7a1f34ec7d33563) Revert "libselinux: fix build with musl ([nixos/nixpkgs⁠#119472](https://togithub.com/nixos/nixpkgs/issues/119472))"
* [`db8baf8c`](https://github.com/NixOS/nixpkgs/commit/db8baf8cc2dc38ab7a05803d8cfa34ba3b26f7db) bfs: add missing attr dependency
* [`98b8a936`](https://github.com/NixOS/nixpkgs/commit/98b8a9369be3cac7d5e7e746c8a2651901d8cc5b) libcap: remove attr dependency
* [`4c41851f`](https://github.com/NixOS/nixpkgs/commit/4c41851f239037ffd58a0655c7a0ad26c192fc2f) python3Packages.pyzmq: fix build
* [`7b6139f4`](https://github.com/NixOS/nixpkgs/commit/7b6139f4725e9920d9586fb5ffde4d90beaff11d) compiler-rt: apply armv6l patches to llvm >= 15 where applicable
* [`153f1186`](https://github.com/NixOS/nixpkgs/commit/153f118639858771457df4ff56278d668a501f69) perlPackages.BC: fix build with gcc 14
* [`1b8563bc`](https://github.com/NixOS/nixpkgs/commit/1b8563bc93d546b46bd53e658e8cacf1d599b3cc) libpwquality: fix building for musl with GCC 14
* [`9cd64ac3`](https://github.com/NixOS/nixpkgs/commit/9cd64ac30aa25b7ad8610b49d8d03d9e82ca1b0c) python3Packages.beautifulsoup4: fix tests
* [`a97420b2`](https://github.com/NixOS/nixpkgs/commit/a97420b26d3302913e5393e1cd888a069bd46089) python3Packages.paramiko: 3.4.0 -> 3.4.1
* [`a41bb2c3`](https://github.com/NixOS/nixpkgs/commit/a41bb2c31e2a1705c9ca7ab3179fd1623ed61d05) perlInterpreters.perl536: drop the attribute
* [`478bc3b4`](https://github.com/NixOS/nixpkgs/commit/478bc3b40ccdb9e92c045326cc0f9f2113f89a7b) bluez: python3.pkgs -> python3Packages
* [`c4ba2c64`](https://github.com/NixOS/nixpkgs/commit/c4ba2c64b4d875b3e98ff2e0311f6521ca668ff2) bluez: 5.76 -> 5.78
* [`14eeeb30`](https://github.com/NixOS/nixpkgs/commit/14eeeb307c3ac1bd2411587a31786ad770f1dac9) libapparmor: 4.0.1 -> 4.0.3
* [`4d0ae3fa`](https://github.com/NixOS/nixpkgs/commit/4d0ae3fa06ed23be487119d389b7d48981676bc4) libpcap: enable parallel building
* [`a9e319e2`](https://github.com/NixOS/nixpkgs/commit/a9e319e296f63de89248b2e24cdf7a10a6e321bd) python312Packages.ipython: 8.26.0 -> 8.27.0
* [`0d10cf98`](https://github.com/NixOS/nixpkgs/commit/0d10cf983204627e27a2478c8665f3eb819959a5) kexec-tools: 2.0.28 -> 2.0.29
* [`0e02f3d2`](https://github.com/NixOS/nixpkgs/commit/0e02f3d26306c4d0a339df8a534ea26d178ea86b) attr: backport patch for musl 1.2.5
* [`f8cc30d1`](https://github.com/NixOS/nixpkgs/commit/f8cc30d10268a2bda0dbdbb1d9ad95b2860fbecb) libapparmor: backport patch for musl 1.2.5
* [`0acc58ad`](https://github.com/NixOS/nixpkgs/commit/0acc58ad636a7292ad920622853a05f76d3d6c61) util-linux: backport patch for musl 1.2.5
* [`5f04a666`](https://github.com/NixOS/nixpkgs/commit/5f04a666d3c39b2c13293c2e025722809917ad9f) glibc: 2.39-52 -> 2.40-36
* [`35d12c9c`](https://github.com/NixOS/nixpkgs/commit/35d12c9cfc94fc00ab27df7c6732efeef310cf55) gcc: remove "fixed" pthread.h
* [`df3df617`](https://github.com/NixOS/nixpkgs/commit/df3df617f06623fbc132741f419a817828232b76) libselinux: 3.6 -> 3.7
* [`92f4286c`](https://github.com/NixOS/nixpkgs/commit/92f4286cd892b29b594c76193e76e8e3f3583da3) llvm{17,18}: fix build w/ glibc-2.40
* [`52bb840e`](https://github.com/NixOS/nixpkgs/commit/52bb840eafa02c719f641d20f67028cc2189ad70) postgresql: fix regress tests after tzdata update
* [`a6d156bb`](https://github.com/NixOS/nixpkgs/commit/a6d156bb3a524bd74f3c28a809f83c89865f1fab) linuxHeaders: 6.9 -> 6.10
* [`19a49413`](https://github.com/NixOS/nixpkgs/commit/19a494135aef450171149a6c328375fb3d96947a) nixos/resolvconf: add a resolvconf group
* [`a432668a`](https://github.com/NixOS/nixpkgs/commit/a432668acf9db69fb9123034a56f81eb4d437b53) dhcpcd: disable privsep by default
* [`05d12386`](https://github.com/NixOS/nixpkgs/commit/05d1238642a4e58c9eef41d7422f18bf1bb4dae1) emacs: do not do native compilation for .dir-locals.el
* [`13e80707`](https://github.com/NixOS/nixpkgs/commit/13e80707b2e8f0f707f81791b06e4a5e0cdf246d) emacs: make sure native compilation output dir is in $out
* [`aff5d1d5`](https://github.com/NixOS/nixpkgs/commit/aff5d1d523225d86027dbebfb95c321d7760a1fa) nixos/dhcpcd: remove ntpd workaround
* [`bad5251e`](https://github.com/NixOS/nixpkgs/commit/bad5251e874bec27438cb8a613ec87e845ed437e) nixos/tests/networking: test nameservers via DHCP
* [`b447fd58`](https://github.com/NixOS/nixpkgs/commit/b447fd58c7921b4c331760c6eebfad8d8188a19c) nixos/dhcpcd: harden and run as unprivileged user
* [`234b7541`](https://github.com/NixOS/nixpkgs/commit/234b7541be87635c14c358c7a254633f5d9e3af4) dhcpcd: move database to /var/lib
* [`67700c52`](https://github.com/NixOS/nixpkgs/commit/67700c521eb7f65b734e70e5509056f46973b92d) nixos/release-notes: mention dhcpcd changes
* [`50120404`](https://github.com/NixOS/nixpkgs/commit/5012040459a636fa1613edd7c49a000e578b3efb) orc: 0.4.39 -> 0.4.40
* [`38f10f91`](https://github.com/NixOS/nixpkgs/commit/38f10f915a4bed4dd392d4fe411106e5842f4013) openssl: switch to new download URL scheme (Github releases)
* [`7932bf56`](https://github.com/NixOS/nixpkgs/commit/7932bf565673e9192a18dcc4f23ad1c69644e437) openssl: set default to openssl_3_3
* [`64ab3059`](https://github.com/NixOS/nixpkgs/commit/64ab30598cd4ad0dc54f56dcc6d40ff4c5929e1a) openssl_3_3: 3.3.1 -> 3.3.2
* [`6fef5775`](https://github.com/NixOS/nixpkgs/commit/6fef5775cc1b70729e1526086c72c8fbaf584002) openssl_3: 3.0.14 -> 3.0.15
* [`2cd1c935`](https://github.com/NixOS/nixpkgs/commit/2cd1c935bbf5542d1be812be0ae9d3d1a36eb5ab) openssl_3_2: 3.2.2 -> 3.2.3
* [`7eb51a71`](https://github.com/NixOS/nixpkgs/commit/7eb51a716e4d1f29287db5e49d6fb79da28f5847) ibm-sw-tpm2: 1682 -> 1682-unstable-2024-08-02
* [`7ceece97`](https://github.com/NixOS/nixpkgs/commit/7ceece975d6ac4115f2c6a915a6ac8ccd11d9070) tpm2-tss: test with better maintained swtpm
* [`5b19e716`](https://github.com/NixOS/nixpkgs/commit/5b19e716f3751c4cbd783416c443cb05e7c0269a) mention new OpenSSL default version in release notes
* [`b8581496`](https://github.com/NixOS/nixpkgs/commit/b8581496dfb668d839e879c8e17393d44b726887) neovimRequireCheckHook: Fix dependency list
* [`259cc054`](https://github.com/NixOS/nixpkgs/commit/259cc0548e5386ebb2da139d6f461ededd53b070) iproute2: fix building for musl with GCC 14
* [`98d8c299`](https://github.com/NixOS/nixpkgs/commit/98d8c29972cfa69ab4c095af6b2634ea2bc629b8) iproute2: apply patch for musl 1.2.5
* [`8f1e2b14`](https://github.com/NixOS/nixpkgs/commit/8f1e2b148f8fcce2f7dd1a5cd0a8dfbdef3e1572) icu: set pname+version
* [`4a16af92`](https://github.com/NixOS/nixpkgs/commit/4a16af92feaed55170b20daff45e369c78237b66) xorg.libXpm: provide gzip path for cross
* [`248579e4`](https://github.com/NixOS/nixpkgs/commit/248579e4c73e489fd25af408d098942a26bb6cd2) python3Packages.twisted: backport Python 3.12.6 fix
* [`3052d8e2`](https://github.com/NixOS/nixpkgs/commit/3052d8e23003c1bb16e5b875ba952079ac34bf54) bluez: add patch for musl 1.2.5
* [`b45e06c5`](https://github.com/NixOS/nixpkgs/commit/b45e06c521df4e665bc90ef385aacf3c8ceced0b) gst_all_1.*: build with the macOS 12.3 SDK
* [`e623501b`](https://github.com/NixOS/nixpkgs/commit/e623501bd1434334c124812557a35ac737105513) emacs: add elisp package override helper mkHome
* [`eb709dd1`](https://github.com/NixOS/nixpkgs/commit/eb709dd1833f55d9b66ea57ac12b1ec6ce318132) timescaledb: use replace-fail instead of replace for substituteInPlace
* [`565a9417`](https://github.com/NixOS/nixpkgs/commit/565a94174fb0eb25f13830e2163bc72dbd7e9251) Re-Revert [nixos/nixpkgs⁠#342349](https://togithub.com/nixos/nixpkgs/issues/342349): "tree-sitter: 0.22.6 -> 0.23.0"
* [`eea613cf`](https://github.com/NixOS/nixpkgs/commit/eea613cf623404fd6e1ca14cbcd8fea500c69434) zlib-ng: 2.2.1 -> 2.2.2
* [`ad0706b2`](https://github.com/NixOS/nixpkgs/commit/ad0706b2981ca163bbc5f5cb8f1141fb612c8c1a) python312Packages.app-model: 0.2.8 -> 0.3.0
* [`c0d5c6f4`](https://github.com/NixOS/nixpkgs/commit/c0d5c6f407b7e99b3553739d4326c1e449bf880a) sassc: enable parallel building
* [`21b4e45e`](https://github.com/NixOS/nixpkgs/commit/21b4e45ef80bdb1da2f55c2f12e67f7c42db4cea) wayprompt: fix the wayprompt-ssh-askpass script
* [`18459ab7`](https://github.com/NixOS/nixpkgs/commit/18459ab73c27e94f326bd79295e25da1e6d341c1) ghostscript: 10.03.1 -> 10.04.0
* [`91960250`](https://github.com/NixOS/nixpkgs/commit/919602500b571eea23fe580c62e9bad7a6d94447) libtiff: 4.6.0 -> 4.7.0
* [`b1b4a97d`](https://github.com/NixOS/nixpkgs/commit/b1b4a97dc9eb522a901f16157e00872decfdf4b7) hylafaxplus: use newest libtiff instead of libtiff 4.6.0t
* [`86d7a802`](https://github.com/NixOS/nixpkgs/commit/86d7a802cb310b4aea78a6fbd2f0e9907a0429c3) gscan2pdf: use newest libtiff instead of libtiff 4.6.0t
* [`97e17374`](https://github.com/NixOS/nixpkgs/commit/97e1737419ded3af33ed32e7305efe0901be0ace) libtiff_t (fork of libtiff): drop
* [`6099db12`](https://github.com/NixOS/nixpkgs/commit/6099db12925ab88280a52ce607a6d4089d3b38e9) hylafaxplus: migrate to `pkgs/by-name` overlay
* [`e2c2aae2`](https://github.com/NixOS/nixpkgs/commit/e2c2aae222d423938f0925360d65ab4f1f467c73) gscan2pdf: migrate to `pkgs/by-name` overlay
* [`6a6a191d`](https://github.com/NixOS/nixpkgs/commit/6a6a191d00ef20a836be34ac5a8ce6fbe1dbb640) libtiff: migrate to `pkgs/by-name` overlay
* [`7228a714`](https://github.com/NixOS/nixpkgs/commit/7228a7147b534df444305556718c1bfd17951cf1) mesa: 24.2.2 -> 24.2.3
* [`408795e2`](https://github.com/NixOS/nixpkgs/commit/408795e2c1fd811e2b250373a2790f3bfdc62bad) open-webui: import missing googleapis-common-protos dep
* [`d2e7601d`](https://github.com/NixOS/nixpkgs/commit/d2e7601de772705bdbd80ec56482b4ed9539914e) protobuf_28: 28.1 -> 28.2
* [`17730866`](https://github.com/NixOS/nixpkgs/commit/17730866059c01b03b49839dd666b1ba44cfd6f3) libxml2: 2.13.3 → 2.13.4
* [`f7dc168c`](https://github.com/NixOS/nixpkgs/commit/f7dc168c825d6e595c8e14e4917e4d9c1a1d2291) python312Packages.trove-classifiers: 2024.7.2 -> 2024.9.12
* [`40dc82c7`](https://github.com/NixOS/nixpkgs/commit/40dc82c7cd7d1350d65a68c504ddff30a51fa690) mupdf: fix cxx build on darwin
* [`41f9b572`](https://github.com/NixOS/nixpkgs/commit/41f9b5724bed9d4f5423e98087997523aa32f021) mupdf: fix soname hell and python bindings import
* [`53313da4`](https://github.com/NixOS/nixpkgs/commit/53313da4ea166c63d11639d6e5666a3db6bc282c) mupdf: 1.24.8 -> 1.24.9
* [`9c4bcdc5`](https://github.com/NixOS/nixpkgs/commit/9c4bcdc56c13051de642165e2cf6f470d7d03e12) python3Packages.pymupdf: 1.24.8 -> 1.24.10
* [`3d0c8d96`](https://github.com/NixOS/nixpkgs/commit/3d0c8d963a228c03ef6d0e621013ed1c69fc6aa3) pymupdf-fonts: init at 1.0.5
* [`65564f03`](https://github.com/NixOS/nixpkgs/commit/65564f03966f09c0f05d47d586474a83b1082916) python3Packages.pymupdf: clean up checks and testing exceptions
* [`1fd4a81e`](https://github.com/NixOS/nixpkgs/commit/1fd4a81e1b21a0eb80f051be4415a383dd10ea06) libssh: 0.10.6 -> 0.11.1
* [`0b338201`](https://github.com/NixOS/nixpkgs/commit/0b3382016aede0ef95359478eb11b5c8d85423b7) libssh: split outputs
* [`350a819a`](https://github.com/NixOS/nixpkgs/commit/350a819a36b585257d7ed19f07ab6169e4a0cd35) go, buildGoModule, buildGoPackage: default to 1.23
* [`afe5a481`](https://github.com/NixOS/nixpkgs/commit/afe5a481155c2a4e384315b198d796969f4f46be) python312Packages.protobuf: 5.28.1 -> 5.28.2
* [`e06e75df`](https://github.com/NixOS/nixpkgs/commit/e06e75df0e6a7f286fc14487b72a81e485f818fa) graphviz: 12.1.0 -> 12.1.1
* [`892b7e93`](https://github.com/NixOS/nixpkgs/commit/892b7e93c849a214efb4a689ed1aa310b0bfa95e) git: 2.46.0 -> 2.46.1
* [`94198d05`](https://github.com/NixOS/nixpkgs/commit/94198d052ddb316218cf0bf14648454e3e871323) pipewire: 1.2.3 -> 1.2.4
* [`0c477676`](https://github.com/NixOS/nixpkgs/commit/0c477676412564bd2d5dadc37cf245fe4259f4d9) postgresql: improve fake pg_config in default output
* [`f32ec5e6`](https://github.com/NixOS/nixpkgs/commit/f32ec5e6d71f435ec47ad62cf275727a46c092a6) buildenv: don't pass null paths to writeClosure
* [`9acca21f`](https://github.com/NixOS/nixpkgs/commit/9acca21fb54894ae2975d0bf2f8054f36853c877) default-gcc-version: Remove conditional for vc4 and relibc
* [`c3948c21`](https://github.com/NixOS/nixpkgs/commit/c3948c21ef00fbf8ef02f3c2922e84ba72e8a62b) glslang: build shared libraries
* [`588b1f8d`](https://github.com/NixOS/nixpkgs/commit/588b1f8df600318b425200e3adf93c4d4fc15215) nixos/github-runners: make enable functional
* [`4092c0d8`](https://github.com/NixOS/nixpkgs/commit/4092c0d8507cea3068cf7ad2c58e8d1d2a3cb676) emacs: make trivialBuild know its elisp dependencies in another way
* [`49a9fd3f`](https://github.com/NixOS/nixpkgs/commit/49a9fd3f168f836cee7f9cba43a5d841608f9d39) emacs: make sure the pinned package-build is used
* [`014bc465`](https://github.com/NixOS/nixpkgs/commit/014bc46560aea4bb749ada242e7dde1df874f918) libsass: enable parallel building
* [`3a0c099e`](https://github.com/NixOS/nixpkgs/commit/3a0c099ef46aaeb79dbe2fd8d2bc955fc2cec4a4) kexec-tools: enable parallel building
* [`345bbd89`](https://github.com/NixOS/nixpkgs/commit/345bbd89a6d50d3188f062d8c203d808d55b5da9) python3Packages.executing: 2.0.1 -> 2.1.0; fix Python 3.12.6
* [`5fe39508`](https://github.com/NixOS/nixpkgs/commit/5fe395084ad57583cd5d5feaa9fa7d1a7038cfc8) burpsuite: 2024.6.6 -> 2024.7.6, add missing dependency for built-in browser
* [`c52c06de`](https://github.com/NixOS/nixpkgs/commit/c52c06de3ba853458f844523c75fabedf8ee80ad) gtest: 1.14.0 -> 1.15.2
* [`8760862c`](https://github.com/NixOS/nixpkgs/commit/8760862cbdebbe64dd0420ec9dd835c27776645f) python3Packages.automat: 22.10.0 -> 24.8.1
* [`47b62f57`](https://github.com/NixOS/nixpkgs/commit/47b62f5785fef1c72e1116e9b62d8383a2f24470) emacs: fix elisp native compilation errors caused by load-path
* [`697ece44`](https://github.com/NixOS/nixpkgs/commit/697ece4455a59b7dc686e04edcd4e000697e4f18) musl: 1.2.3 -> 1.2.5
* [`dffd2269`](https://github.com/NixOS/nixpkgs/commit/dffd22695990a6887733b1c8ecdb9cf8b681d480) Revert "pkgsStatic.gsasl: fix build"
* [`efcd97fd`](https://github.com/NixOS/nixpkgs/commit/efcd97fd88a1846530be897127fe70bf4513a71d) Revert "pkgsMusl.ostree: fix build"
* [`9bb7cacd`](https://github.com/NixOS/nixpkgs/commit/9bb7cacd8b63ad99281870d17f2deba9a2efc9c0) Revert "python3Packages.dulwich: skip problematic tests"
* [`77292c4f`](https://github.com/NixOS/nixpkgs/commit/77292c4f5b0ba8a5ef0581194325151132a3d503) buildDartApplication: include dart SDK builder by default
* [`47f16e4b`](https://github.com/NixOS/nixpkgs/commit/47f16e4b747d6889d04565ae084bb8b1064da569) meson: 1.5.1 -> 1.5.2
* [`78f30b83`](https://github.com/NixOS/nixpkgs/commit/78f30b83c64448f58fedb469b273539f64c1f121) emacs: respect native compilation errors by default
* [`1dea6d44`](https://github.com/NixOS/nixpkgs/commit/1dea6d4497b05743d3ae8a7014a22f66f525f6f4) boringssl: unstable-2024-02-15 → unstable-2024-09-20
* [`52cd0dbd`](https://github.com/NixOS/nixpkgs/commit/52cd0dbdf0bc06671c18c38160cd2d177bd3e5a4) davix: unvendor rapidjson
* [`e29d735e`](https://github.com/NixOS/nixpkgs/commit/e29d735e792d8893eae0a85cad09b4a439183583) librdf_raptor2: unstable-2022-06-06 -> 2.0.16 ([nixos/nixpkgs⁠#280822](https://togithub.com/nixos/nixpkgs/issues/280822))
* [`2cab2f6c`](https://github.com/NixOS/nixpkgs/commit/2cab2f6c426008a232deacb2c7c78c470f68b8d8) gle: format
* [`3c28377e`](https://github.com/NixOS/nixpkgs/commit/3c28377e51cf5af8fb9166443711e7305f2861bf) gle: 3.1.0 → 3.1.2
* [`dd115b34`](https://github.com/NixOS/nixpkgs/commit/dd115b346000967a5602fefa7b1bea6c5f310664) perlPackages.GetoptLong: 2.54 -> 2.58
* [`bc4e63e7`](https://github.com/NixOS/nixpkgs/commit/bc4e63e71af6115f25def6bc69935cdd0292183a) perlPackages.GetoptLongDescriptive: fix deps
* [`2d8cc6df`](https://github.com/NixOS/nixpkgs/commit/2d8cc6df922a09f2d29f4270a0e9653b2d007a5e) webdav: 5.1.0 -> 5.3.0
* [`b37957f4`](https://github.com/NixOS/nixpkgs/commit/b37957f41e53cb0c5aaff4aebb92853167945636) nodejs: disable failing network tests
* [`d88ea29d`](https://github.com/NixOS/nixpkgs/commit/d88ea29d11fbd49d2155446cd51afa245322ce34) minivmac: init at 2024.06.08
* [`c7670643`](https://github.com/NixOS/nixpkgs/commit/c767064338232907c168a3ef3ec4ba508a724ab0) vlc: pin FFmpeg 6 for now
* [`e1ac53d9`](https://github.com/NixOS/nixpkgs/commit/e1ac53d9d64f481d72c93e3d840a07a6a8e1b727) {gyroflow,openjfx{11,17,21,22}}: unpin FFmpeg 7
* [`600ce2f4`](https://github.com/NixOS/nixpkgs/commit/600ce2f45f1a6fe611b8add89f15f74beec0db60) python3Packages.protobuf4: pin to protobuf_25
* [`9a94e073`](https://github.com/NixOS/nixpkgs/commit/9a94e073bfc38ad5dcb1d5f35e9c6fbb3886ead4) Reapply "nix: nix_2_18 -> nix_2_24"
* [`af7bcfae`](https://github.com/NixOS/nixpkgs/commit/af7bcfae7844484d50ea54dbee8b42dab6b5200e) nix: update fallback-paths
* [`0e6dfaf0`](https://github.com/NixOS/nixpkgs/commit/0e6dfaf02482c9c2a4a9ecff31c3fa7c5bbdc606) gnome-graphs: 1.8.1 -> 1.8.2
* [`53856949`](https://github.com/NixOS/nixpkgs/commit/53856949160838e6cf5736d09be44b2b5d4eecdf) Reapply "nix-plugins: 14.0.0 -> 15.0.0"
* [`829636f4`](https://github.com/NixOS/nixpkgs/commit/829636f4173acb044ee430037762e2b30a03cb1e) nix-plugin-pijul: fix plugins to 2.18
* [`3f90386b`](https://github.com/NixOS/nixpkgs/commit/3f90386b24b02118f386a44ffbd9d8a40f289981) nixos/lvm: enable lvm when using systemd in stage 1 initrd
* [`468a6cbb`](https://github.com/NixOS/nixpkgs/commit/468a6cbbbef5a3d621e0deac86324e2bd69307a3) nixos/bcache: enable bcache when using systemd in stage 1 initrd
* [`59777cc5`](https://github.com/NixOS/nixpkgs/commit/59777cc5479f86834ce1c541e38abc3535860368) nodejs: fix tests for OpenSSL 3.2
* [`4686df86`](https://github.com/NixOS/nixpkgs/commit/4686df865c86e308a771c5a19d3284957cab022d) Revert "emacs: let nix build for manualPackages fail if native-comp fails"
* [`35ff4b6a`](https://github.com/NixOS/nixpkgs/commit/35ff4b6a6491017fe84da69d99594392fac0477b) emacsPackages.tsc: stop setting ignoreCompilationError
* [`d3e9e03e`](https://github.com/NixOS/nixpkgs/commit/d3e9e03e54839f757cd998597ae118515f4d512d) emacsPackages.cask: stop setting ignoreCompilationError
* [`84d59c02`](https://github.com/NixOS/nixpkgs/commit/84d59c02ec3cc07845273542b0031b104b9c28fb) emacsPackages.consult-gh: stop setting ignoreCompilationError
* [`5176727b`](https://github.com/NixOS/nixpkgs/commit/5176727b63774e1a9f801657cf4433de62df196f) emacsPackages.gn-mode-from-sources: stop setting ignoreCompilationError
* [`98ac76b7`](https://github.com/NixOS/nixpkgs/commit/98ac76b79c404e42dbf8085c3f57ba93e0b7be32) emacsPackages.color-theme-solarized: ignore native compilation error
* [`466727b8`](https://github.com/NixOS/nixpkgs/commit/466727b8217a9d96204884f2720ba8c895050a01) emacsPackages.session-management-for-emacs: ignore compilation error
* [`656c68d6`](https://github.com/NixOS/nixpkgs/commit/656c68d6547819064837ebbd1a4f6e8fc218c8a5) emacsPackages: add more override helpers
* [`e48a0365`](https://github.com/NixOS/nixpkgs/commit/e48a0365d2d67410cb701b028d2a70c271d2ea3d) emacsPackages: fix build for nongnu packages
* [`fc9502ff`](https://github.com/NixOS/nixpkgs/commit/fc9502ff295c22cc8114ecc6b550c3b0db41c267) emacsPackages: fix build for elpa packages
* [`bc2ab9c4`](https://github.com/NixOS/nixpkgs/commit/bc2ab9c42cede4e35e4d80f117e73ef3717fcb84) emacsPackages: fix build for melpa packages
* [`37575b30`](https://github.com/NixOS/nixpkgs/commit/37575b30229ad6a819b759b4f702a734bf219f34) buildVimPlugin: deprecate addRtp
* [`e9f4eb97`](https://github.com/NixOS/nixpkgs/commit/e9f4eb9728aa3851196bb964975195d120d11d5c) buildVimPlugin: enable structuredAttrs
* [`2f7cc5a7`](https://github.com/NixOS/nixpkgs/commit/2f7cc5a7812bd4b4758312051a72b0a618072cd4) emacsPackages: respect turnCompilationWarningToError and ignoreCompilationError at bytecompile time
* [`8ae08e01`](https://github.com/NixOS/nixpkgs/commit/8ae08e01c2c6593908848b74bec670eca5b9cb43) emacsPackages.psgml: fix build
* [`13b28dc4`](https://github.com/NixOS/nixpkgs/commit/13b28dc48716edb2bcb2ac36ca29e779356e28a8) python3.pkgs.paramiko: 3.4.1 -> 3.5.0
* [`a9c68ea8`](https://github.com/NixOS/nixpkgs/commit/a9c68ea85747ee9cab28b354bd47ae56808d29d1) python3Packages.werkzeug: 3.0.3 -> 3.0.4
* [`2bd38b4f`](https://github.com/NixOS/nixpkgs/commit/2bd38b4f38fa04b443769fbfecac12525c055631) emacsPackages.bbdb: fix build
* [`a2be9025`](https://github.com/NixOS/nixpkgs/commit/a2be9025372e05229d32e1a4cb9d050c5ca86a22) libaom: skip `_POSIX_C_SOURCE` patch on Darwin
* [`fd1745b8`](https://github.com/NixOS/nixpkgs/commit/fd1745b8607349440ff33b113a8b5eb2c5d96c15) openssl_3_3: hotfix for cmake builds
* [`36fed72b`](https://github.com/NixOS/nixpkgs/commit/36fed72b3bb7015751af5d06e519a2f55873116b) opencc: use system rapidjson to fix gcc 14 error
* [`42960d74`](https://github.com/NixOS/nixpkgs/commit/42960d743a87684313e56251bcd97225e60a712d) opencc: add passthru.updateScript
* [`1c953b1d`](https://github.com/NixOS/nixpkgs/commit/1c953b1def0291551328199d430029bbea8cd10a) Revert "llvmPackages.clangUseLLVM: add --undefined-version by default"
* [`72cc50b6`](https://github.com/NixOS/nixpkgs/commit/72cc50b66202fc872735d7276f39fea3e4809aa8) openssl_3_3: hotfix for cmake builds
* [`207d89c1`](https://github.com/NixOS/nixpkgs/commit/207d89c1e7f072496c242f15290ed3422eb8bf25) emacsPackages."@": fix build
* [`949c7e6a`](https://github.com/NixOS/nixpkgs/commit/949c7e6aee4d918cd259408860da1df13e1718cf) bazel-gazelle: 0.38.0 -> 0.39.0
* [`12b97a40`](https://github.com/NixOS/nixpkgs/commit/12b97a409bac470b2d6e53e09e512a723e836266) openssl_3_3: move cmake rm to correct phase
* [`82459a8d`](https://github.com/NixOS/nixpkgs/commit/82459a8dc1f97f9e4a3e96e7b0964b624409de5b) tex-match: remove
* [`71155764`](https://github.com/NixOS/nixpkgs/commit/71155764076b97ac27fa30bbbc739fc13150b0c1) docs: update the CUDA section with how to use the `nvidia-container-toolkit`
* [`1ec3f1db`](https://github.com/NixOS/nixpkgs/commit/1ec3f1dbbf81c413948f72de17b47347f253444b) Revert "gcc: gcc_13 → gcc_14"
* [`0d3c3735`](https://github.com/NixOS/nixpkgs/commit/0d3c3735e57706f8f5640f7f62c572c92adc3d2d) nvidia-container-toolkit: add "nvidia" to services.xserver.videoDrivers
* [`e480154f`](https://github.com/NixOS/nixpkgs/commit/e480154f61b12abb27f057b21db9f87becbf6e61) Revert "libaom,libvmaf: pin to GCC 13 on aarch64"
* [`a44cd70b`](https://github.com/NixOS/nixpkgs/commit/a44cd70b303ea41200f94e6ccb73c73597eadea6) hydra: 0-unstable-2024-09-20 -> 0-unstable-2024-09-24
* [`3e84f7c9`](https://github.com/NixOS/nixpkgs/commit/3e84f7c96cb40bb521220bb8c9c89dae6463c646) lksctp-tools: change hash after retag
* [`8f92904d`](https://github.com/NixOS/nixpkgs/commit/8f92904d89d15a699a24a9747e33d3e29e4bfa3d) ra-multiplex: 0.2.2 -> 0.2.5
* [`ec1bfdc3`](https://github.com/NixOS/nixpkgs/commit/ec1bfdc3f9ed181282a01703b597c6e0598213ab) cosmic-comp: 1.0.0-alpha.1 -> 1.0.0-alpha.2
* [`9eef14c6`](https://github.com/NixOS/nixpkgs/commit/9eef14c6781ab15b9fd6cb84a7699dabcc9efd6a) rPackages.sf: fix build on darwin
* [`39fd7e26`](https://github.com/NixOS/nixpkgs/commit/39fd7e26f03fc126b4d0c85ee885aa8ef3999085) rPackages.terra: fix build on darwin
* [`3b2590ee`](https://github.com/NixOS/nixpkgs/commit/3b2590eee2b057ada39066e536c3a0ebe66d2f8d) rPackages.vapour: fix build on darwin
* [`db9b9f9a`](https://github.com/NixOS/nixpkgs/commit/db9b9f9a49ca787caad81db239d2663a953b8248) ra-multiplex: fix typo on wrapProgram --suffix PATH
* [`90f529dd`](https://github.com/NixOS/nixpkgs/commit/90f529dd449b63a0c6cf530769ccbc6f144bfcbc) xdg-desktop-portal-cosmic: 1.0.0-alpha.1 -> 1.0.0-alpha.2
* [`ad2bf67e`](https://github.com/NixOS/nixpkgs/commit/ad2bf67e8f879112a61b6279a6277978df9cd54c) xdg-desktop-portal-cosmic: copy icons, portal.conf to $out/share
* [`1bae06c4`](https://github.com/NixOS/nixpkgs/commit/1bae06c49df9e7d2e160b7dc291c9c0c07ed3ec5) cosmic-settings-daemon: unstable-2023-12-29 -> 1.0.0-alpha.2
* [`102e9867`](https://github.com/NixOS/nixpkgs/commit/102e9867c1aa68ef4ad15ba3ae5145b581531ffb) cosmic-settings-daemon: inline pname repo
* [`d046f3e3`](https://github.com/NixOS/nixpkgs/commit/d046f3e3d9f5ca4819916aff585af0dc93e0e94d) cosmic-settings-daemon: install polkit rules
* [`e005e5d9`](https://github.com/NixOS/nixpkgs/commit/e005e5d99f413d27a9426f5c1019c071638b3f4e) nodejs: add missing patches and skip some TLS tests on 20.x and 18.x
* [`ab5bad33`](https://github.com/NixOS/nixpkgs/commit/ab5bad33c63d632997224c66d7c7685874482009) Reapply "closure-info: switch to stdenvNoCC ([nixos/nixpkgs⁠#344456](https://togithub.com/nixos/nixpkgs/issues/344456))"
* [`d70d6450`](https://github.com/NixOS/nixpkgs/commit/d70d6450a4625deafe4860433a477546827d1f1b) nwg-hello: 0.2.2 -> 0.2.4
* [`ba0df011`](https://github.com/NixOS/nixpkgs/commit/ba0df0111ff87a2721a945246f46e9a6e5363973) Revert "protobufc: fix compatibility with new protobuf"
* [`92ecfb16`](https://github.com/NixOS/nixpkgs/commit/92ecfb167e8035dd8806d01d0b5ed4d4ddf608f0) protobufc: pin to protobuf_25
* [`cc0e679a`](https://github.com/NixOS/nixpkgs/commit/cc0e679aafec63a998010143d0c8b9c043f1e0f0) maintainers/team-list: add ngi team
* [`0303ea1f`](https://github.com/NixOS/nixpkgs/commit/0303ea1f2e77478a9c36935c3a5809ff2ef22a22) naja, omnom, taler-depolymerization, taler-wallet-core: update maintainers
* [`e5a08c88`](https://github.com/NixOS/nixpkgs/commit/e5a08c88596139e9267cc57abde51bc4cbecb20b) nix-fallback-paths: 2.24.7 -> 2.24.8
* [`226b0bf8`](https://github.com/NixOS/nixpkgs/commit/226b0bf800d99f9664cf8a1d9fa317b626381497) adcskiller: init at 0-unstable-2024-05-19
* [`045a98f8`](https://github.com/NixOS/nixpkgs/commit/045a98f88caa7b9e9be4bd685912181276d4ca2c) mbedtls: make `-Wno-error conditional` on gcc version
* [`7c84a256`](https://github.com/NixOS/nixpkgs/commit/7c84a256ea52142648add5369ad02fc7ff987bad) mattermost: 9.5.9 -> 9.5.10
* [`9f92114f`](https://github.com/NixOS/nixpkgs/commit/9f92114fc85e96f8c208fc92642205cee3a053bc) libtiff: avoid parallel checking (partially)
* [`222d7063`](https://github.com/NixOS/nixpkgs/commit/222d7063940ddf7d60b86ad81d54663b4357254a) python311Packages.furl: disable test for all python versions
* [`8f280f4c`](https://github.com/NixOS/nixpkgs/commit/8f280f4cb8edc5f41305ca9221a8320eafff7f33) python3Packages.furl: add link to upstream issue
* [`e79c35f0`](https://github.com/NixOS/nixpkgs/commit/e79c35f00355e37b51b15d33fe7d69b34ef83f60) pipewire: 1.2.4 -> 1.2.5
* [`40799fc0`](https://github.com/NixOS/nixpkgs/commit/40799fc06d3ec4c2d7f6cd4953d09c8af0b4be3d) treewide: replace `stdenv.is` in non nix files
* [`8f3e6557`](https://github.com/NixOS/nixpkgs/commit/8f3e65575083b0deac2b6f04de4af47d408cda16) doc/python: correct platform conditional
* [`93ed3c31`](https://github.com/NixOS/nixpkgs/commit/93ed3c31668cf514611b0df752726332277d54f4) git-blame-ignore-revs: add formatting treewide
* [`0c0e48b0`](https://github.com/NixOS/nixpkgs/commit/0c0e48b0ec1af2d7f7de70f839de1569927fe4c8) qt6: 6.7.2 -> 6.7.3
* [`0be1e662`](https://github.com/NixOS/nixpkgs/commit/0be1e6623c3f9ed6e33fba5340f5d6a7c16dc7c8) emplace: move to by-name; nixfmt
* [`504189a0`](https://github.com/NixOS/nixpkgs/commit/504189a0f8cafe10cbc624d7a9dbe3b7a0e0c023) emplace: fix build
* [`4912d0b7`](https://github.com/NixOS/nixpkgs/commit/4912d0b79be1f6bebbee44788e3582465df8ce4a) yofi: fix build
* [`15d355a6`](https://github.com/NixOS/nixpkgs/commit/15d355a6ee47890424969f4778f71785710d8158) fcp: move to by-name; nixfmt
* [`88a0de19`](https://github.com/NixOS/nixpkgs/commit/88a0de19432ed1dd5ac372e761801f73079cfa47) fcp: fix build
* [`8e9a6862`](https://github.com/NixOS/nixpkgs/commit/8e9a6862d73568a7de5c7a87b32bba22610fdf00) protobuf_28: fix cross compilation by only building tests when necessary
* [`fa1996d6`](https://github.com/NixOS/nixpkgs/commit/fa1996d6bccaa6d547ddabd897f02bf5418f75d8) emacsPackages.lspce: 1.1.0-unstable-2024-07-29 -> 1.1.0-unstable-2024-09-07
* [`76aeca82`](https://github.com/NixOS/nixpkgs/commit/76aeca8297c18213c7eab8ab721c38d6de77d576) cdrtools: remove -fpermissive due to revert of gcc_14 as default
* [`3bd454d3`](https://github.com/NixOS/nixpkgs/commit/3bd454d384bc98193567d000666314875528c061) python312Packages.docker: fix tests
* [`67cdc348`](https://github.com/NixOS/nixpkgs/commit/67cdc348c09653b73a111e12e2d2a16a3db79b70) python312Packages.josepy: backport test fix
* [`d507a0ac`](https://github.com/NixOS/nixpkgs/commit/d507a0ac7753a82aa5f6d053bd466a4e1d51c008) python312Packages.proto-plus: 1.23.0 -> 1.24.0
* [`3baaaacc`](https://github.com/NixOS/nixpkgs/commit/3baaaaccee260cd3a7f41664a1fc803ff00c6d51) level-zero: 1.17.42 -> 1.17.45
* [`a28eb118`](https://github.com/NixOS/nixpkgs/commit/a28eb11846566990e895acd574a266ffbf7ec4c7) python312Packages.grpc-google-iam-v1: 0.13.0 -> 0.13.1
* [`d46eefef`](https://github.com/NixOS/nixpkgs/commit/d46eefeffd5d77babaf82a5741297af166bedc81) google-cloud-cpp: 2.14.0 -> 2.29.0
* [`8b540b5f`](https://github.com/NixOS/nixpkgs/commit/8b540b5f7197e68c96e4824b6c1be58c18484a2a) python312Packages.botocore: 1.34.131 -> 1.35.29
* [`afb688c2`](https://github.com/NixOS/nixpkgs/commit/afb688c2265eb0c4ee5709f8885ceecca797c80c) python312Packages.boto3: 1.34.131 -> 1.35.29
* [`48d02fb9`](https://github.com/NixOS/nixpkgs/commit/48d02fb9ac57627a62389985e6abb48f8bcdd456) awscli: 1.33.13 -> 1.34.29
* [`5d8390a8`](https://github.com/NixOS/nixpkgs/commit/5d8390a8c4473579044fcc48225e9db6b9afae60) python312Packages.py-partiql-parser: 0.5.4 -> 0.5.6
* [`110123ae`](https://github.com/NixOS/nixpkgs/commit/110123ae4d1b1d174c3436c131cc0e8fef7a6766) python312Packages.moto: 5.0.12 -> 5.0.15
* [`85e63d05`](https://github.com/NixOS/nixpkgs/commit/85e63d05409521bd6dcdb5e7f9ead72259f44f90) lomiri.lomiri: Replace NIXOS_XKB_LAYOUTS envvar with file
* [`c2a5dcf5`](https://github.com/NixOS/nixpkgs/commit/c2a5dcf5a04c895ab9a7b7443e11ee8799b5bd09) accountservice: condition gcc_14 specific `-Wno-error` flags
* [`d67a90a4`](https://github.com/NixOS/nixpkgs/commit/d67a90a413e9b56769e6fb6212604fb0da60ec79) seahorse: condition gcc_14 specific `-Wno-error` flags
* [`1ccf0c3c`](https://github.com/NixOS/nixpkgs/commit/1ccf0c3c68edeb5993966f5f7addfc615b33ad7e) python312Packages.chromadb: 0.5.7 -> 0.5.11
* [`e7062a6b`](https://github.com/NixOS/nixpkgs/commit/e7062a6b066d07a358978487c2509f2b75122f90) mise: fix shell completion
* [`7fbdbc68`](https://github.com/NixOS/nixpkgs/commit/7fbdbc6850aba5a953ffadd66eaaac64fea04603) grafanaPlugins.marcusolsson-dynamictext-panel: init at 5.4.0
* [`6471602f`](https://github.com/NixOS/nixpkgs/commit/6471602fa451057e055d034315bca53a1fa48574) python312Packages.google-api-core: 2.19.0 -> 2.20.0
* [`66eee3ad`](https://github.com/NixOS/nixpkgs/commit/66eee3addaed3dc8ba104f80c961737bee1d075d) ftgl: fix build, clean up
* [`fa49cf15`](https://github.com/NixOS/nixpkgs/commit/fa49cf159d1130325ac15a191b96e68c2bbc9154) python312Packages.icalendar: 5.0.13 -> 6.0.0
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
