### PR TITLE
niv nixpkgs: update b4802f74 -> aca8144f

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b4802f749d77b8d35f101d4a386e87da4e9409c8",
-        "sha256": "12fhkjqrgc3m2di0qn8birz6g617l79haz4hnam30bzlz17gpxbh",
+        "rev": "aca8144f8aeca1044ad6bc29ad9cae0bd12dfb19",
+        "sha256": "0570fhmvyxhzzbyxjab1sbjdvl6k580q26n885rpf114macqb2aj",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/b4802f749d77b8d35f101d4a386e87da4e9409c8.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/aca8144f8aeca1044ad6bc29ad9cae0bd12dfb19.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@b4802f74...aca8144f](https://github.com/nixos/nixpkgs/compare/b4802f749d77b8d35f101d4a386e87da4e9409c8...aca8144f8aeca1044ad6bc29ad9cae0bd12dfb19)

* [`94847c97`](https://github.com/NixOS/nixpkgs/commit/94847c9734c654abd493546e3643c6fb86c0eb11) fftwQuad: Mark unsupported on aarch64
* [`33c81414`](https://github.com/NixOS/nixpkgs/commit/33c81414f70fbc5a4aeb24da5c90b080ca77a961) maintainers: add luna_1024
* [`e2bfd6e9`](https://github.com/NixOS/nixpkgs/commit/e2bfd6e9c38764eb7161b936124575b5c4ce12f5) nixos/kresd: add link to upstream doc
* [`a2a19c21`](https://github.com/NixOS/nixpkgs/commit/a2a19c2144df4594071b109a95f8765035cd7fcb) cups-brother-hl3170cdw: init at 1.1.4-0
* [`d99c367e`](https://github.com/NixOS/nixpkgs/commit/d99c367e1ecb1229b3c53bd65b66b07801e6288e) dra-cla: unstable-2024-02-07 -> 0-unstable-2024-06-07
* [`94b71765`](https://github.com/NixOS/nixpkgs/commit/94b71765fc45f726163720c3d7261348082c986a) pocket-casts: 0.7.0 -> 0.8.0
* [`1d750cd8`](https://github.com/NixOS/nixpkgs/commit/1d750cd8a267326f777d6b6552977bd4f74eed55) pocket-casts: add yayayayaka to maintainers
* [`fe4acbaa`](https://github.com/NixOS/nixpkgs/commit/fe4acbaaa8a1abb96c2ce87006f9e849574b4cf3) maintainers: Add gileri
* [`1afb6314`](https://github.com/NixOS/nixpkgs/commit/1afb6314f6341224c989ab02f8a878a289399e11) nixos/bitmagnet: init module
* [`ceec1c3d`](https://github.com/NixOS/nixpkgs/commit/ceec1c3d3369608d4f897b49f606ecdd7be35528) miru: 5.5.0 -> 5.5.6
* [`53db73d6`](https://github.com/NixOS/nixpkgs/commit/53db73d61ea02112aa19477efcee46595a9971b9) nixos/netdata: remove changefinder
* [`58157652`](https://github.com/NixOS/nixpkgs/commit/58157652bcbf2380ed392298eb0ef963d8d417da) fasmg: j27m -> kd3c
* [`85d13569`](https://github.com/NixOS/nixpkgs/commit/85d135690de4e5029203c6acde48991b1d51087f) wxGTK32: 3.2.5 -> 3.2.6
* [`c1c9a14b`](https://github.com/NixOS/nixpkgs/commit/c1c9a14be7113c4e9422732fcd344eeed969b72d) microsoft-identity-broker: use hash from upstream Packages file
* [`caee0feb`](https://github.com/NixOS/nixpkgs/commit/caee0feb9ffe39364d39c54cd9c07bf477b64bff) microsoft-identity-broker: fix package hash
* [`b4878419`](https://github.com/NixOS/nixpkgs/commit/b4878419ee2ca05c740505bacd7eb3e2b4beab24) nixos/wakapi: add database options; gate db creation behind database.createLocally
* [`53596231`](https://github.com/NixOS/nixpkgs/commit/53596231c8c7253dee4ef8f8df6aa1293727c0b1) gramma: remove mkYarnPackage usage
* [`c1cb18cd`](https://github.com/NixOS/nixpkgs/commit/c1cb18cd9e20b4166e48a30b752e7e9e6f53303e) wivrn: init at 0.19
* [`6e9e75f7`](https://github.com/NixOS/nixpkgs/commit/6e9e75f7f22174291aeea4d465ed5a89f5619ec1) nixos/wivrn: init module
* [`5bf02d69`](https://github.com/NixOS/nixpkgs/commit/5bf02d69a3bb124c27f5f49d1d6b0c7dc6fb35f6) httpie-desktop: add aarch64-linux support
* [`c4045a54`](https://github.com/NixOS/nixpkgs/commit/c4045a54b42d02e16dd3f1f6761a13b920dcd2f0) waycorner: move to by-name overlay; format via nixfmt
* [`68c7d64d`](https://github.com/NixOS/nixpkgs/commit/68c7d64d1a3e01266645f0d9a5266fc8df7052c9) waycorner: modernize derivation
* [`4f959fdb`](https://github.com/NixOS/nixpkgs/commit/4f959fdb30615232c3417b0ebc9c525a2ff04c0a) raspberrypi-eeprom: Add flashrom to path
* [`19c568f3`](https://github.com/NixOS/nixpkgs/commit/19c568f3871fd91cbef1fd89f37de6dd2c772634) imhex: add support for darwin
* [`03aa7e6e`](https://github.com/NixOS/nixpkgs/commit/03aa7e6efeffa6dd4c4db530d8bd57c29186e747) wezterm: sort passthru
* [`8ed82c62`](https://github.com/NixOS/nixpkgs/commit/8ed82c62be739f166c32512dc2b84e496f2d2855) idris2Packages.pack: init at 2024-02-07
* [`dd37c180`](https://github.com/NixOS/nixpkgs/commit/dd37c18048ec7d56b8449b5075755029c733021b) cosmic-edit: 1.0.0-alpha.1 -> 1.0.0-alpha.2
* [`55b2896c`](https://github.com/NixOS/nixpkgs/commit/55b2896c69ebb00a3f359d4d1f89cbd94051875a) reader: init at 0.4.5
* [`90ba2b10`](https://github.com/NixOS/nixpkgs/commit/90ba2b10c91303f76391c92b2936260adb843a1c) vivictpp: move to pkgs/by-name
* [`58494bfe`](https://github.com/NixOS/nixpkgs/commit/58494bfe4617939610d76a59e49943cb0a5c5e95) vivictpp: 1.0.0 -> 1.1.0
* [`64ac27b9`](https://github.com/NixOS/nixpkgs/commit/64ac27b97fcd94a098e4cb979f49c6ead538a6b6) frog-protocols: init at 0.01-unstable-2024-09-25
* [`0fbfad40`](https://github.com/NixOS/nixpkgs/commit/0fbfad403a76651f41739a410597aec659e3f0bf) unicode-character-database: 15.1.0 -> 16.0.0
* [`8039b13d`](https://github.com/NixOS/nixpkgs/commit/8039b13d00fd1910ea706591086ca88e80c45ddb) gucharmap: 15.1.5 -> 16.0.1
* [`b0887160`](https://github.com/NixOS/nixpkgs/commit/b0887160e48a2d83eadc949e6af60cdc92f57f97) eduke32: migrate to pkgs/by-name
* [`adabe50d`](https://github.com/NixOS/nixpkgs/commit/adabe50db8a31303534bc44a105f69e7e89986a9) eduke32: format with nixfmt-rfc-style
* [`28519824`](https://github.com/NixOS/nixpkgs/commit/28519824242bfed738ffb7cd35b4eb180f1f7018) eduke32: 0-unstable-2024-02-17 -> 0-unstable-2024-07-26
* [`daf926d0`](https://github.com/NixOS/nixpkgs/commit/daf926d0e34044f4cad7cb193dd7c83593937cca) eduke32: add ion fury and fix wrappers
* [`435828e3`](https://github.com/NixOS/nixpkgs/commit/435828e33ce7a77d542fd58ff45e4cb961acff15) eduke32: remove mikroskeem, add qubitnano to maintainers
* [`8dac4539`](https://github.com/NixOS/nixpkgs/commit/8dac453957b77331a01af3b47a8169e2e9119150) qogir-kde: 0-unstable-2024-09-01 -> 0-unstable-2024-09-21
* [`256d33ba`](https://github.com/NixOS/nixpkgs/commit/256d33ba46d12c16deb55eca6b989be69138ce45) archivemount: Migrate to `by-name`
* [`2d19e4a7`](https://github.com/NixOS/nixpkgs/commit/2d19e4a770ae7843085eae36c2dc06933d2dc03d) archivemount: 0.9.1 -> 1
* [`99f0cc93`](https://github.com/NixOS/nixpkgs/commit/99f0cc9344467a3f6ac7d9c5215b7a1f9f2c4939) xrdp: 0.9.25.1 -> 0.10.1, xorgxrdp: 0.9.20 -> 0.10.2
* [`06390e19`](https://github.com/NixOS/nixpkgs/commit/06390e19bba888e85d44f50bf9faa0ef420c99b8) Add libdrm dependency
* [`4c786688`](https://github.com/NixOS/nixpkgs/commit/4c786688739c7122cb7d957c91455e25006a782a) xauth path changed
* [`2f5a9ad9`](https://github.com/NixOS/nixpkgs/commit/2f5a9ad9b43021d1baf31d3f9d0a38d7297ffcbb) Add SessionSockdirGroup=xrdp to sesman config
* [`aca69fd6`](https://github.com/NixOS/nixpkgs/commit/aca69fd697e3c3c7688f5ab0b25d6563b56e7fed) foxotron: 2023-07-16 -> 2024-09-23
* [`9e6c9ad0`](https://github.com/NixOS/nixpkgs/commit/9e6c9ad0fe59dd0d7a185bc7d13613fd9d517c6f) live555: 2024.08.01 -> 2024.09.20
* [`ed72e91d`](https://github.com/NixOS/nixpkgs/commit/ed72e91db150f2e3778dee5fa13f5802e14fd2e5) nixos/mihomo: fix option type
* [`93da11de`](https://github.com/NixOS/nixpkgs/commit/93da11def19632826d95ee7b148f20bf6baccc00) nixos/tests/mihomo: implement check correctly, fix target value
* [`81818095`](https://github.com/NixOS/nixpkgs/commit/818180957da96bc6f358591a123157a9e36f6cdf) maintainers: add melon
* [`aa788352`](https://github.com/NixOS/nixpkgs/commit/aa788352f8f0ce6fffe4749b83eb27ad8e5a20fa) maintainers: add kototama
* [`8c80c2bd`](https://github.com/NixOS/nixpkgs/commit/8c80c2bd128f41a2a7bfbcd18588552bdcaa8ed0) octoprint.python.pkgs.OctoPrint-FileCheck-2021.2.23 -> 2024.3.27
* [`c2621cb7`](https://github.com/NixOS/nixpkgs/commit/c2621cb78a2cb347961bba8a7a4be8872138797b) nixosTests.nix-upgrade: fix failing test
* [`9e012ecb`](https://github.com/NixOS/nixpkgs/commit/9e012ecbf272fb46b60a4a7fd97cf7c28aa39ecd) nixos/sing-box: generate config file into RuntimeDirectory
* [`dd53928d`](https://github.com/NixOS/nixpkgs/commit/dd53928de81cda8c2fe8f1acdf9f0f0c02ee91f1) freecad: work around https://github.com/FreeCAD/FreeCAD/issues/10514
* [`2f36cbcd`](https://github.com/NixOS/nixpkgs/commit/2f36cbcdda1c49a599ce0a1d25f3c1d32a395b05) zoom-us: add conditional webview fix
* [`1dd45da8`](https://github.com/NixOS/nixpkgs/commit/1dd45da83f7eb852855729c9ee15d5168d5a2cfc) cargo-hakari: 0.9.30 -> 0.9.33
* [`83e6cbda`](https://github.com/NixOS/nixpkgs/commit/83e6cbda1ab5942982f7c64496c2c672ac8a1d2c) cargo-hakari: refactor meta
* [`dd8b2cc9`](https://github.com/NixOS/nixpkgs/commit/dd8b2cc974c5b6dfdec4fe1a79d633671b619648) ruby_3_4: init at 3.4.0.preview2
* [`1bcd4549`](https://github.com/NixOS/nixpkgs/commit/1bcd4549ffd3c81c217e604824526b0614706c24) maintainers: add erikeah
* [`4fa2c2b5`](https://github.com/NixOS/nixpkgs/commit/4fa2c2b5aa9ec73b0abcc3b458cfed0e29e9fd5a) kamp: init at 0.2.1
* [`1d760331`](https://github.com/NixOS/nixpkgs/commit/1d76033154a0b7498c423244f90fb5ecfa62ca38) Rename nixos/modules/profiles/{macos-builder.nix -> nix-builder-vm.nix}
* [`46878205`](https://github.com/NixOS/nixpkgs/commit/4687820524450e9ef6ad896cdf5c1fe7c29539bd) Document nixos/modules/profiles/nix-builder-vm.nix
* [`00355648`](https://github.com/NixOS/nixpkgs/commit/00355648f01d146250564d7756b06fd638bf9c30) nixos/modules/profiles/macos-builder.nix: Restore as alias
* [`a034fb50`](https://github.com/NixOS/nixpkgs/commit/a034fb50f79816c6738fb48b48503b09ea3b0132) Format
* [`6a50f540`](https://github.com/NixOS/nixpkgs/commit/6a50f540270b150aa80afe2774bd9849c7b66d24) writefreely: 0.15.0 -> 0.15.1
* [`852a489a`](https://github.com/NixOS/nixpkgs/commit/852a489ac7c45f12f0caf477214ef9cd8ef6c0a4) writefreely: move to pkgs/by-name
* [`85848e7d`](https://github.com/NixOS/nixpkgs/commit/85848e7d8bae32e63d13eb02abca687d12a10cf3) writefreely: format with nixfmt
* [`49c56d30`](https://github.com/NixOS/nixpkgs/commit/49c56d3057619e07870d88f84169b126292ceac7) Pin electron 27 until upstream is updated
* [`723c4a67`](https://github.com/NixOS/nixpkgs/commit/723c4a673591de18ef1d7915881de9077ffca6de) xlockmore: set mainprogram to xlock
* [`fa186ab1`](https://github.com/NixOS/nixpkgs/commit/fa186ab175425c130332d4fff19793fdb4c88162) osc-cli: unpin defusedxml
* [`9f8d9fb7`](https://github.com/NixOS/nixpkgs/commit/9f8d9fb7e6eac4c7c30401d6644ec72b16e693f4) fastcdr: 2.2.4 -> 2.2.5
* [`62922959`](https://github.com/NixOS/nixpkgs/commit/62922959f68591eb74f10708d9ad36639bb87e0e) bustools: init at 0.44.0
* [`dbcff5dc`](https://github.com/NixOS/nixpkgs/commit/dbcff5dc7462649ba001bbb99a1add2a3a2beea6) python312Packages.tensorstore: add aarch64-linux support
* [`6f115a07`](https://github.com/NixOS/nixpkgs/commit/6f115a07ce3ff2530dd1479310cdaae9a6edec79) netbeans: 22 -> 23
* [`ff935a11`](https://github.com/NixOS/nixpkgs/commit/ff935a11a9317108dc75e59db0d59e47737fa068) git-spice: 0.6.0 -> 0.7.0
* [`67f6d7ec`](https://github.com/NixOS/nixpkgs/commit/67f6d7ec53f4a7d602b0102a277b81e9e9b90afa) Add patch to disable PCRE2 JIT.
* [`042afa60`](https://github.com/NixOS/nixpkgs/commit/042afa604cfd90f5386ad25cfc90cb12442e43ec) gpclient: add gio-networking for embedded browser
* [`b00742f5`](https://github.com/NixOS/nixpkgs/commit/b00742f5fb462caac9f3768dc157f78df8dca3b2) maintainers: add petrkozorezov
* [`b6785a0d`](https://github.com/NixOS/nixpkgs/commit/b6785a0df67ca3ff01f7cbb0355ccbe1fd5f296d) Add note about the issue this patch works around.
* [`7b3261b5`](https://github.com/NixOS/nixpkgs/commit/7b3261b5a60a7721249abc01a1fbb0cad552ff5e) nixos/pam: Strip config in documentation and messages
* [`70c36136`](https://github.com/NixOS/nixpkgs/commit/70c36136dae134796a902de9ece4e9dadabf2d1a) bazecor: 1.5.1 -> 1.5.2
* [`5db5954b`](https://github.com/NixOS/nixpkgs/commit/5db5954bb2648b067cf73fe19243d65941873d0c) technitium-dns-server: 13.0.1 --> 13.0.2
* [`34254e38`](https://github.com/NixOS/nixpkgs/commit/34254e38eaf8deef928a5c614a8bfd7a79e0c0c1) jfrog-cli: 2.56.1 -> 2.70.0, update go version
* [`25bea19c`](https://github.com/NixOS/nixpkgs/commit/25bea19c7130240c2ce607238c0fb92360c5179c) jfrog-cli: set proxyVendor due to case sensitivity issues
* [`762a9d42`](https://github.com/NixOS/nixpkgs/commit/762a9d42a10f6dd135b39af68f817c4ab140b743) bazarr: allow overriding package in module
* [`3a26957d`](https://github.com/NixOS/nixpkgs/commit/3a26957d8ecd4d4a5b00939fa80f10e857488911) doc/README: More anchors to link to
* [`cf648c09`](https://github.com/NixOS/nixpkgs/commit/cf648c09cc2029aba1599816386f02456b212cb3) xen: make the EFI build mandatory
* [`233d4228`](https://github.com/NixOS/nixpkgs/commit/233d422887dd66530e2b6234f1ee39f0aec79ee1) nixos/tailscale: document tailscale-autoconnect
* [`2fc61b16`](https://github.com/NixOS/nixpkgs/commit/2fc61b161dfaddc4455fce44749e391934ce58e1) granted: fix wrapping of assume script
* [`aaa4953b`](https://github.com/NixOS/nixpkgs/commit/aaa4953b20f41352a18e602cfb6270076452db79) xen: fix XSA 462 description formatting
* [`85e42e60`](https://github.com/NixOS/nixpkgs/commit/85e42e600dd52713bfe947eec6ab11ccc1e857c6) openai-whisper-cpp: fix cuda build
* [`89dcf5ff`](https://github.com/NixOS/nixpkgs/commit/89dcf5ffc4d1591fd227ebb8f87cdde7fd463c26) julia_111-bin: init at 1.11.0
* [`e957f43d`](https://github.com/NixOS/nixpkgs/commit/e957f43d114397c9ceb96d6def782b6e0b145198) julia_111: init at 1.11.0
* [`0c4b516b`](https://github.com/NixOS/nixpkgs/commit/0c4b516b28eeca9148da4d80d4682ac3c29c76c4) julia_16-bin: drop
* [`27b4d529`](https://github.com/NixOS/nixpkgs/commit/27b4d5291fac22a71bf72409fed29c0d0c4c9ad2) julia-stable{,-bin}: use julia_111{,-bin}
* [`4cbccd49`](https://github.com/NixOS/nixpkgs/commit/4cbccd4923dce6b1725482049d8ac3b71c3c1d4d) veryl: 0.13.0 -> 0.13.1
* [`35325ece`](https://github.com/NixOS/nixpkgs/commit/35325ecea96a18eea55566f55107dd01910967dc) veryl: add shell completions
* [`4d70ac23`](https://github.com/NixOS/nixpkgs/commit/4d70ac234b07c7e9bcd597a11ca5b40c3d48cd1a) mavproxy: 1.80.70 -> 1.8.71
* [`cd11e6c7`](https://github.com/NixOS/nixpkgs/commit/cd11e6c7ed68a96445fd7e24fa82aeb7ae88be6d) Revert "curl: disable fetchpatch passthru test on darwin"
* [`77d670ed`](https://github.com/NixOS/nixpkgs/commit/77d670ed72eef1928b6c954978a92dca0c5da751) errands: 46.2.5 -> 46.2.6
* [`1feb53c2`](https://github.com/NixOS/nixpkgs/commit/1feb53c231ad5f5d4da71642262a1582727287f2) appflowy: 0.6.8 -> 0.7.1
* [`f99d1ecb`](https://github.com/NixOS/nixpkgs/commit/f99d1ecba1850b9a8e0f1a3f001aef9191675627) noseyparker: 0.18.1 -> 0.20.0
* [`7d52f9c7`](https://github.com/NixOS/nixpkgs/commit/7d52f9c721aacb96f4ea14bf611f9a1d1b79ad5a) depotdownloader: 2.5.0 -> 2.7.2
* [`490cb91e`](https://github.com/NixOS/nixpkgs/commit/490cb91ec4b5027c245961b63655f063a6cd1b40) halloy: 2024.11 -> 2024.12
* [`db7dd707`](https://github.com/NixOS/nixpkgs/commit/db7dd707e17ac5d317ef4fd7924ce8820532952c) aldente: 1.28.4 -> 1.28.5
* [`885ec4f5`](https://github.com/NixOS/nixpkgs/commit/885ec4f591c5046baf9fe42f79d2603ef0133451) opencpn: 5.8.4 -> 5.10.2
* [`44d4e4f6`](https://github.com/NixOS/nixpkgs/commit/44d4e4f60a5f03c0e1b220692b7bcb01dcf7bed4) qutebrowser: 3.2.1 -> 3.3.1
* [`73056028`](https://github.com/NixOS/nixpkgs/commit/73056028755cb9e482e7e0501a84789d7b3a728e) pkgsStatic.krb5: fix build
* [`f7246430`](https://github.com/NixOS/nixpkgs/commit/f72464305ffd9a5cf7f7502a53bf7b79e984923e) binsider: 0.1.0 -> 0.2.0
* [`f87eb089`](https://github.com/NixOS/nixpkgs/commit/f87eb089bc41362ebaa87f90a033d0a45dd9f45c) build: no default features for all non-linux
* [`f294f05b`](https://github.com/NixOS/nixpkgs/commit/f294f05bd9b7b62a44195dc22a364ba596d614b1) xlog: 2.0.24 -> 2.0.25
* [`fc25b66d`](https://github.com/NixOS/nixpkgs/commit/fc25b66dce7b4e5d0d7f28ea30ddf52d82b1c892) xlockmore: 5.78 → 5.80
* [`69ff55d1`](https://github.com/NixOS/nixpkgs/commit/69ff55d18810ee2266f85a8995009c4ce36fa7b3) kid3: use regular callPackage instead of customized one
* [`9cdf7540`](https://github.com/NixOS/nixpkgs/commit/9cdf75404de6f498fe5ecb84a71f01647d2a700b) kid3: migrate to by-name
* [`0fe83f8c`](https://github.com/NixOS/nixpkgs/commit/0fe83f8cb116581319a513de7d064e98bd84ce59) tautulli: 2.14.5 -> 2.14.6
* [`17592f3f`](https://github.com/NixOS/nixpkgs/commit/17592f3f01ec3250ad735b8089483c534f688c7d) vym: use standard callPackage
* [`1236eb79`](https://github.com/NixOS/nixpkgs/commit/1236eb79b30e5789dd71f97c6739af876ab5ffd6) vym: nixfmt-rfc-style and hammer
* [`fbd723ff`](https://github.com/NixOS/nixpkgs/commit/fbd723ff804ed99058982559012a8ebcd637cda4) vym: migrate to by-name
* [`0f7e7b68`](https://github.com/NixOS/nixpkgs/commit/0f7e7b687eebdb9d4a482f1594290cf9e9e58d69) dbeaver-bin: don't depend on swt (not needed at all)
* [`7c16395c`](https://github.com/NixOS/nixpkgs/commit/7c16395c9f1ce5b300a8a80625bc5d98b7102f99) portfolio: don't depend on swt (not needed at all)
* [`271e05bb`](https://github.com/NixOS/nixpkgs/commit/271e05bbfb2f3d08e548f4d5efc24a76ff705807) ipscan: mark as broken (doesn't really launch)
* [`c582a1e5`](https://github.com/NixOS/nixpkgs/commit/c582a1e5e650173bc3abb7b19e6af90c61cbb578) vuze: mark as broken
* [`729a27a9`](https://github.com/NixOS/nixpkgs/commit/729a27a947a50e38589d520c2604c2d0191db7a9) tuxguitar: nixfmt & don't use 'with lib;' in meta
* [`e72eb225`](https://github.com/NixOS/nixpkgs/commit/e72eb22590baf1d1cfae0d8ed7b721242eb3e9e7) tuxguitar: use finalAttrs pattern
* [`dd12b437`](https://github.com/NixOS/nixpkgs/commit/dd12b437a6f6fd2b7d778ba7aad6c37dd841dbb6) tuxguitar: rename passthru nixos test attribute
* [`b76ff913`](https://github.com/NixOS/nixpkgs/commit/b76ff9137f97509dff1ae18271ac6c8fa4697e80) swt: 4.5 -> 4.33
* [`51475bd9`](https://github.com/NixOS/nixpkgs/commit/51475bd9d35a0f7b9cb40c7dce573996b0bbe9d7) tuxguitar: 1.5.5 -> 1.6.4; move to pkgs/by-name
* [`16216c69`](https://github.com/NixOS/nixpkgs/commit/16216c69c02e0ce76ea538418b6aa7cb19fa6230) libtraceevent: 1.8.3 -> 1.8.4
* [`01a9ca4f`](https://github.com/NixOS/nixpkgs/commit/01a9ca4f12856d786e70c9107dbd5836748fe377) blueprint-compiler: 0.12.0 -> 0.14.0
* [`329e459d`](https://github.com/NixOS/nixpkgs/commit/329e459dab229ffcade78fe2ab30a0690eddafb6) swt: make it actually useful
* [`c70579b0`](https://github.com/NixOS/nixpkgs/commit/c70579b0a564176e2aa9d9e042d13f6d9f8bd023) dataexplorer: make it launch by using swt built with jdk17
* [`2f6e0c8d`](https://github.com/NixOS/nixpkgs/commit/2f6e0c8de3120add9fc81a3671a20e577931564c) nixos/systemd-initrd: add missing kmod-blacklist src
* [`5b9b4784`](https://github.com/NixOS/nixpkgs/commit/5b9b47844ccf76d84a933b546264cbdd0e4eff40) input-leap: unstable-2023-12-27 -> 3.0.2
* [`b9ca8498`](https://github.com/NixOS/nixpkgs/commit/b9ca8498aa357e371790a134d7fcca715d332d46) nixos/nextcloud-notify_push: fix connecting to mysql via socket
* [`1ce8d342`](https://github.com/NixOS/nixpkgs/commit/1ce8d3420813d567dc141d2fb161a4c8850a0ec7) corsix-th: 0.67 -> 0.68
* [`1747c62f`](https://github.com/NixOS/nixpkgs/commit/1747c62f4b3d164e8c2915a803ae39a91aea453f) crystfel: 0.11.0 -> 0.11.1
* [`3806b888`](https://github.com/NixOS/nixpkgs/commit/3806b88822fd0550e82f7c9c0b839af4e561f95e) telepresence2: 2.19.1 -> 2.20.1
* [`fe9ef3a1`](https://github.com/NixOS/nixpkgs/commit/fe9ef3a10bdaa6a830abf5147bd947c2b2bd1aae) vaultwarden: 1.32.1 -> 1.32.2
* [`14684ed5`](https://github.com/NixOS/nixpkgs/commit/14684ed595a30ce6288bd11b8af999bc8ecbc63d) vuls: init at 0.27.0
* [`5aa5a319`](https://github.com/NixOS/nixpkgs/commit/5aa5a319b7d6d2e1bf36967c9ead67be740dde5a) xwayland-satellite: format with nixfmt
* [`ed3a3b00`](https://github.com/NixOS/nixpkgs/commit/ed3a3b00721774bbb6514fa8fa79e298d54b9fe5) xwayland-satellite: 0.4 -> 0.4-unstable-2024-09-15
* [`44a9fdce`](https://github.com/NixOS/nixpkgs/commit/44a9fdce36be4e6265bd0a88f5330155a1b15328) stern: 1.30.0 -> 1.31.0
* [`049ee041`](https://github.com/NixOS/nixpkgs/commit/049ee0417517497be8537edf77c488c01932cc32) stern: move to pkgs/by-name
* [`2b41b2c7`](https://github.com/NixOS/nixpkgs/commit/2b41b2c756bc5e52f90077e85d3866467e82f5fc) kubent: 0.7.2 -> 0.7.3
* [`32695b36`](https://github.com/NixOS/nixpkgs/commit/32695b36869b14ac2cf04f8fb4f48f9709e84fc1) kubent: migrate to pkgs/by-name
* [`9ec4be8c`](https://github.com/NixOS/nixpkgs/commit/9ec4be8cea81d31b57d97f221364e342d67a9dd5) kubent: add meta.changelog
* [`1ada7c1d`](https://github.com/NixOS/nixpkgs/commit/1ada7c1d363765eb4be76eedec5be6c8c8e281ad) nixos/nextcloud: fix shellcheck findings with enableStrictShellChecks enabled
* [`db122798`](https://github.com/NixOS/nixpkgs/commit/db122798908d1a6d9adf210b9b3f5e4eb1cf014a) nixos/go-camo: fix shellcheck findings with enableStrictShellChecks enabled
* [`8248bb94`](https://github.com/NixOS/nixpkgs/commit/8248bb94fa6335c5f0cd1314380a0f0b133efb3c) catppuccin-kvantum: unstable-2022-07-04 -> 0-unstable-2024-10-10
* [`113c82de`](https://github.com/NixOS/nixpkgs/commit/113c82de3388a7926f4efc5caa3c7b5cd7862a1f) hubstaff: symlink HubstaffCLI binary
* [`5e629ac8`](https://github.com/NixOS/nixpkgs/commit/5e629ac8de1a047b6fcb86968889624c133766ba) pcsx2-bin: 2.1.136 -> 2.1.205
* [`daf88706`](https://github.com/NixOS/nixpkgs/commit/daf88706ecaff34e9babbd724ee55ae405b067e0) seq-cli: init at 2024.3.922
* [`6a8ff458`](https://github.com/NixOS/nixpkgs/commit/6a8ff458813a5e76368499cae220d80b5b3dc5a6) poetry: 1.8.3 -> 1.8.4
* [`19201917`](https://github.com/NixOS/nixpkgs/commit/1920191784a097ea1ce2edbeb7d073a04fdd26d4) monit: 5.34.0 -> 5.34.2
* [`88ae9f3a`](https://github.com/NixOS/nixpkgs/commit/88ae9f3ab2e574fce290282d02c3b48cb1bb1222) fceux: use standard callPackage
* [`3edaf1f0`](https://github.com/NixOS/nixpkgs/commit/3edaf1f09b53d59572061b156bcd0a574933cbdd) fceux: nixfmt-rfc-style
* [`7bb6a043`](https://github.com/NixOS/nixpkgs/commit/7bb6a0437b19df281da6128d5224ba1f289401ee) fceux: migrate to by-name
* [`d9de98d7`](https://github.com/NixOS/nixpkgs/commit/d9de98d7e9fd8e189c67cfea415ecdde32fb7322) fceux: fix missing dependencies
* [`1f2b8bb2`](https://github.com/NixOS/nixpkgs/commit/1f2b8bb21f1daf0b85abe894da1ca864dd4046b3) fceux: select Qt version
* [`34ab01c6`](https://github.com/NixOS/nixpkgs/commit/34ab01c663ad9918e68e73b53e8e047e813c37ce) fceux: 2.6.6-unstable-2024-01-19 -> 2.6.6-unstable-2024-06-09
* [`4d8c2734`](https://github.com/NixOS/nixpkgs/commit/4d8c2734f8ad1ad8a0e7ec2c7782983e8c6e7681) radare2: 5.9.2 -> 5.9.6
* [`9f6d95af`](https://github.com/NixOS/nixpkgs/commit/9f6d95afb4414e3f549c0f9916d9804f3854341b) catppuccin-cursors: 0.3.1 -> 0.4.0
* [`bf3c22db`](https://github.com/NixOS/nixpkgs/commit/bf3c22db390d65825600556752c825086d2519dc) taskflow: 3.7.0 -> 3.8.0
* [`866ecd3d`](https://github.com/NixOS/nixpkgs/commit/866ecd3def487d5b923f1b6c61451783b92387b8) taskflow: modernize
* [`4631e519`](https://github.com/NixOS/nixpkgs/commit/4631e519a8d18c2ee67650c9ec2af6bcdb00cc59) taskflow: move to pkgs/by-name
* [`f25e1d1f`](https://github.com/NixOS/nixpkgs/commit/f25e1d1fb791e7ed1df05f5a3e1cd565b9c20d72) python312Packages.rapidfuzz: support Taskflow 3.8.0
* [`44c0faf5`](https://github.com/NixOS/nixpkgs/commit/44c0faf56bfa57f75436fff815586fe5bbd94eb9) zine: fix build with rust 1.80+
* [`a3a32f3b`](https://github.com/NixOS/nixpkgs/commit/a3a32f3b92bc301ec7f1ea1c664c5616470b98e2) ncdu: 2.5 -> 2.6
* [`7c692619`](https://github.com/NixOS/nixpkgs/commit/7c69261980bd5589ad1e50a610bfbdd950a03058) qdirstat: use stdenv.mkDerivation
* [`1513db9e`](https://github.com/NixOS/nixpkgs/commit/1513db9ef98b2b3cb3fbf9daf66691747809dab2) kgeotag: use stdenv.mkDerivation
* [`9f0e002e`](https://github.com/NixOS/nixpkgs/commit/9f0e002ec1bfbd5b41d52fb72c91d5bc3b8c4562) r3ctl: use stdenv.mkDerivation
* [`99a939f4`](https://github.com/NixOS/nixpkgs/commit/99a939f44252149263531ade3584d3fc700a4396) oscar: use stdenv.mkDerivation
* [`989f10b0`](https://github.com/NixOS/nixpkgs/commit/989f10b02d3d96f649802be47a048cb7e7ec4ae5) synology-drive-client: use stdenv.mkDerivation
* [`828accc0`](https://github.com/NixOS/nixpkgs/commit/828accc0e369a21f8ede7b77e98dd93150dfca2c) neovim-qt: use stdenvNoCC.mkDerivation
* [`03fae2ef`](https://github.com/NixOS/nixpkgs/commit/03fae2ef6911194c83509636fdc7f8b7867a7c33) x2goclient: use stdenv.mkDerivation
* [`043347c0`](https://github.com/NixOS/nixpkgs/commit/043347c00cf62f9362cac1550b8b2ae7ccdff613) soundwireserver: use stdenvNoCC.mkDerivation and wrapQtAppsHook
* [`47a74774`](https://github.com/NixOS/nixpkgs/commit/47a747747bfc12f59bdc4c2615bea2387033fb7a) vt323: init at 2.0
* [`302cc71c`](https://github.com/NixOS/nixpkgs/commit/302cc71c7a8869198af98f816c061c959a6d3478) magic-vlsi: 8.3.486 -> 8.3.497
* [`d337b4e2`](https://github.com/NixOS/nixpkgs/commit/d337b4e2f5da5eb711eb414d5feb99fe49be4066) swayimg: 3.2 -> 3.4
* [`3a23b88c`](https://github.com/NixOS/nixpkgs/commit/3a23b88c5b664a4677fdb412004e8b5d6e8eb7ea) swayimg: reformat
* [`a1b287f8`](https://github.com/NixOS/nixpkgs/commit/a1b287f88d9555b5abb136552c61a985c0409a62) gotosocial: 0.16.0 -> 0.17.0
* [`5da8c6df`](https://github.com/NixOS/nixpkgs/commit/5da8c6df9c044ae8216c58b259acd8c94e9b5f69) gotosocial: run nixfmt
* [`b036dc5b`](https://github.com/NixOS/nixpkgs/commit/b036dc5b8e1ddc0e00d332f4c74444ce18606cf2) dclib: fix build after libxml2 update
* [`8ed2026e`](https://github.com/NixOS/nixpkgs/commit/8ed2026e4b83d40d11fbb39d6cd23b88ca2e1fe5) monkeysAudio: 10.74 -> 10.76
* [`5089e82d`](https://github.com/NixOS/nixpkgs/commit/5089e82de8c457a311e2af912ef2e616dd142132) anchor: drop xrelkd from maintainer
* [`b84f5e00`](https://github.com/NixOS/nixpkgs/commit/b84f5e005bb677114328be7307280c8611373b46) terranix: 2.7.0 -> 2.8.0
* [`5e98b259`](https://github.com/NixOS/nixpkgs/commit/5e98b259ca44be14710a8a7301b497bfe485b818) svix-server: 1.30.0 -> 1.38.0
* [`2b5cd64f`](https://github.com/NixOS/nixpkgs/commit/2b5cd64f800ee5e7c2f799a34a147d5a1fe17921) osquery: remove workaround for autoPatchelfHook problem
* [`1b8384bd`](https://github.com/NixOS/nixpkgs/commit/1b8384bdcf20f662350558bb4f5ef04e207770c1) nomacs: 3.19.0 -> 3.19.1
* [`74d20416`](https://github.com/NixOS/nixpkgs/commit/74d20416532003953467222683f6f020cf6b1c6d) openpgp-card-tools: 0.11.3 -> 0.11.4
* [`da3311fb`](https://github.com/NixOS/nixpkgs/commit/da3311fba0913fccb70c412a9f8bd701b9c8a7fb) python312Packages.flask-restx: disable broken tests
* [`b54e66bf`](https://github.com/NixOS/nixpkgs/commit/b54e66bf39e5604764a19134ab21b29171c00fec) python312Packages.frozendict: 2.4.5 -> 2.4.6
* [`c424307a`](https://github.com/NixOS/nixpkgs/commit/c424307a7e0f2c4730633458f33837fe38689320) libressl: 3.9.2 -> 4.0.0
* [`3f97d8bb`](https://github.com/NixOS/nixpkgs/commit/3f97d8bba281ff8362d258b26d23b784f7c16331) opencomposite: use vendored OpenXR
* [`cc0f98cc`](https://github.com/NixOS/nixpkgs/commit/cc0f98cca79314c6eb00d3fe019f1a1544d75de9) heimdal: fix build on darwin
* [`08296892`](https://github.com/NixOS/nixpkgs/commit/082968923081a72a04db3adab29d8f55e5ef0a31) pappl: 1.4.6 -> 1.4.7
* [`91d64e11`](https://github.com/NixOS/nixpkgs/commit/91d64e1154010426cfce7d73de0ec099b5c47ac9) pappl: modernize derivation; add changelog
* [`740ad128`](https://github.com/NixOS/nixpkgs/commit/740ad128e263394fba709b23685f723dd289a948) pappl: format via nixfmt
* [`d8039594`](https://github.com/NixOS/nixpkgs/commit/d8039594c5852606fddd11e47b62a3026d91177c) anyk: use OpenJDK with JavaFX
* [`18196014`](https://github.com/NixOS/nixpkgs/commit/18196014aaca193f2ca7a04511f41655ca112dee) gitleaks: Add `nix-update-script`
* [`96e708de`](https://github.com/NixOS/nixpkgs/commit/96e708de7f9ed6f96ee11c36ddc5e48852d27ecc) gitleaks: 8.20.1 -> 8.21.0
* [`b16ded58`](https://github.com/NixOS/nixpkgs/commit/b16ded58a0def1289c3f948edc5347a5b441eb76) openpgp-card-tools: 0.11.4 -> 0.11.6
* [`1b89990e`](https://github.com/NixOS/nixpkgs/commit/1b89990e784d5723b3e6ec54b6f24c932d16751c) podman-desktop: 0.12.0 -> 1.12.0
* [`46719faa`](https://github.com/NixOS/nixpkgs/commit/46719faa3c5d02efb5d893670182c86fef196d63) feishin: 0.10.1 -> 0.11.0
* [`0b65b5ed`](https://github.com/NixOS/nixpkgs/commit/0b65b5ed47f954cd913f7a9a073ef5ce2ced826d) feishin: 0.11.0 -> 0.11.1
* [`8dbc7a26`](https://github.com/NixOS/nixpkgs/commit/8dbc7a26966bc93bf8ed5c41317e57ba046453e4) librespot: 0.4.2 -> 0.5.0
* [`ff29338a`](https://github.com/NixOS/nixpkgs/commit/ff29338aa9a9278bf05552808c04491b15e7fd27) julia.withPackages: remove handling for julia_16
* [`c61ac9e1`](https://github.com/NixOS/nixpkgs/commit/c61ac9e1ea49ca6054ae2220fcb934772b40ea1a) julia.withPackages: move julia resolve code to its own file
* [`d51280ff`](https://github.com/NixOS/nixpkgs/commit/d51280ffba060cd9eef1f211ffd4f6dcf35e18f9) julia.withPackages: pass extra args to update_package_add for julia 1.11+
* [`f94050dd`](https://github.com/NixOS/nixpkgs/commit/f94050dd247799478ef2c52d7178448cb2e1e17f) julia.withPackages: use 4-space indentation for consistency
* [`d4e06ddc`](https://github.com/NixOS/nixpkgs/commit/d4e06ddc97cc67876cef4d21b3b58186482046d8) podman-desktop: 0.12.0 -> 1.13.2
* [`9f7fc2bd`](https://github.com/NixOS/nixpkgs/commit/9f7fc2bdd7bc19a2ded3030a7e03913d422460d9) maintainers: add booxter
* [`f40a7a80`](https://github.com/NixOS/nixpkgs/commit/f40a7a80c46993f6e7888e8fdf3589af9a8de4b9) komac: remove `with lib` from meta
* [`6c2ee694`](https://github.com/NixOS/nixpkgs/commit/6c2ee694512055358ff39b3a96c7730116f38a1c) komac: format with nixfmt-rfc-style
* [`91abcc04`](https://github.com/NixOS/nixpkgs/commit/91abcc044641b7aa3616a9ec9beddb59040ba395) komac: add version check
* [`96562536`](https://github.com/NixOS/nixpkgs/commit/96562536ca9a60ad69b1fe3cc6bc8a9208f31110) komac: add updateScript
* [`d1893e8c`](https://github.com/NixOS/nixpkgs/commit/d1893e8cde1cc389fb22a988e7b0a97072379793) komac: ensure that source is a tag
* [`2ec2f2a6`](https://github.com/NixOS/nixpkgs/commit/2ec2f2a6eea879bcea296bb902e412d9c881b985) podman-desktop: don't disable signing for electron config
* [`c1afccdb`](https://github.com/NixOS/nixpkgs/commit/c1afccdb826f4f2ddcf05ffafd43cda1a4dc153b) podman-desktop: use --replace-fail instead of --replace
* [`af71af6e`](https://github.com/NixOS/nixpkgs/commit/af71af6e870edc17b7ecd31761d8808fa75afcd8) podman-desktop: remove xcrun dependency
* [`a444ff29`](https://github.com/NixOS/nixpkgs/commit/a444ff29796c5ff9bcfaa6d473ca347bf6342989) python312Packages.dbt-semantic-interfaces: 0.6.2 -> 0.7.4
* [`0ab87eba`](https://github.com/NixOS/nixpkgs/commit/0ab87eba08f542929ead7ac0071042b5497398dc) apache-jena: 5.1.0 -> 5.2.0
* [`8ed9892a`](https://github.com/NixOS/nixpkgs/commit/8ed9892aacfed2da8d7c9ee132b8461044ee9362) zziplib: 0.13.74 -> 0.13.78
* [`27ca005e`](https://github.com/NixOS/nixpkgs/commit/27ca005e9762a215d15311df70bc5db7e70d22e4) python312Packages.aiostreammagic: 2.5.0 -> 2.6.0
* [`393388db`](https://github.com/NixOS/nixpkgs/commit/393388db3261bdf68d46f4155eaa6ab3e3c037b6) displaycal: 3.9.12 → 3.9.14
* [`d566d792`](https://github.com/NixOS/nixpkgs/commit/d566d7927c0892c3b780866e3d803a4e97210c93) linuxPackages.ena: 2.12.3->2.13.0
* [`294db84c`](https://github.com/NixOS/nixpkgs/commit/294db84cc769355e196969192104efa52798a1b4) vimPlugins.hunk-nvim: init at 2024-09-19
* [`53b37c99`](https://github.com/NixOS/nixpkgs/commit/53b37c99b41dbcbf9ddedc509f92776b055d08b4) virtualbox: nixfmt
* [`b6ce4710`](https://github.com/NixOS/nixpkgs/commit/b6ce4710c6022e0c3276132af7b3746f32b4991e) agedu: 20211129 -> 20241013
* [`3e27a932`](https://github.com/NixOS/nixpkgs/commit/3e27a93247be041e0740f2e353c58a942191074b) python312Packages.jupyter-collaboration: 2.1.2 -> 2.1.3
* [`1eee78fe`](https://github.com/NixOS/nixpkgs/commit/1eee78feeb14691bf478b1ccab9eedc2ecfc6484) nexusmods-app: 0.6.1 -> 0.6.2
* [`d0c9c5dc`](https://github.com/NixOS/nixpkgs/commit/d0c9c5dc40c2c2a95a4bcfbf3536d3b9e0855249) bwidget: 1.9.16 -> 1.10.0
* [`72adb59e`](https://github.com/NixOS/nixpkgs/commit/72adb59e9b9386c42030ca061786996097d6d6b4) gersemi: 0.15.1 -> 0.16.2
* [`3560ef60`](https://github.com/NixOS/nixpkgs/commit/3560ef60c04fb3c6c70f42fc55c7b50d72091a68) roswell: 23.10.14.114 -> 24.10.115
* [`a63367cf`](https://github.com/NixOS/nixpkgs/commit/a63367cfcdb886bee208f50db8b069f61158861d) obs-studio: enable debug info
* [`83e0aed0`](https://github.com/NixOS/nixpkgs/commit/83e0aed01ebe77a0dc88c3d920e51ae139631199) vimPlugins.kdl-vim: init at 2023-02-20
* [`ca31d3e8`](https://github.com/NixOS/nixpkgs/commit/ca31d3e869dc6f692d9fca54e27f028247331028) release-plz: 0.3.79 -> 0.3.98
* [`41c74c8b`](https://github.com/NixOS/nixpkgs/commit/41c74c8bc21988f81dbaa2127d63867e379372bf) release-plz: add changelog to meta
* [`53702892`](https://github.com/NixOS/nixpkgs/commit/537028927ae347b6a9995728a5c2e83db601870d) envision: Fix WMR build
* [`a1c3173e`](https://github.com/NixOS/nixpkgs/commit/a1c3173e7e1909448f1bcc11807c828f3edd5f87) bartender: 5.1.8 -> 5.2.3
* [`4291736a`](https://github.com/NixOS/nixpkgs/commit/4291736a50b2cfccd45e5ffca9d66e46e989b513) matrix-synapse: 1.116.0 -> 1.117.0
* [`7f9b9e5e`](https://github.com/NixOS/nixpkgs/commit/7f9b9e5eddc018e565ae510c6f8dea9dc556484b) open-policy-agent: 0.66.0 -> 0.69.0
* [`d41ca97d`](https://github.com/NixOS/nixpkgs/commit/d41ca97ddc1e3e47c12e9fa25b06d0cf67095635) firefox-bin: fix `webgpu` support
* [`9212e492`](https://github.com/NixOS/nixpkgs/commit/9212e492411e8d49a92154379c62e3a53cd90ccf) keymapp: 1.3.2 -> 1.3.3
* [`b748370e`](https://github.com/NixOS/nixpkgs/commit/b748370e899135672dfb4eb4495e9b599ae8f53c) wasmer: 4.3.5 -> 4.3.6
* [`f4f4b8d7`](https://github.com/NixOS/nixpkgs/commit/f4f4b8d7b51380c71b103739c6e2e596ece6e355) wasmer: 4.3.6 -> 4.3.7
* [`c58210f2`](https://github.com/NixOS/nixpkgs/commit/c58210f2b13bf5a22220a104bcadafdba7fa8af6) wasmer: 4.3.7 -> 4.4.0
* [`cffc04f3`](https://github.com/NixOS/nixpkgs/commit/cffc04f3b2cc68ee77728bf3eb31880c004b8e2c) wasmer: mark withLLVM broken
* [`dc55dab2`](https://github.com/NixOS/nixpkgs/commit/dc55dab2ae3daa16df7bfc143760006922c0a65e) stylelint-lsp: fix script launch issue on macOS
* [`666d3bd3`](https://github.com/NixOS/nixpkgs/commit/666d3bd33d4f978ba8ea1ca34ae6756606721f58) {nodePackages,vimPlugins}.coc-metals: drop
* [`9c9b5188`](https://github.com/NixOS/nixpkgs/commit/9c9b5188ee898e9a9cdbd860a681e125bee09806) dbt: relax protobuf
* [`9d0575a0`](https://github.com/NixOS/nixpkgs/commit/9d0575a00263159b84e3cffae41ade98fcac7d70) python312Packages.dbt-adapters: relax protobuf
* [`dd9cebba`](https://github.com/NixOS/nixpkgs/commit/dd9cebba8151d983b2638fde8f65f17eb9c110be) python312Packages.dbt-common: relax protobuf
* [`611373fe`](https://github.com/NixOS/nixpkgs/commit/611373fe1c9ab801cad408edd2087de274d6565c) python312Packages.triton: 3.0.0 -> 3.1.0
* [`1b5cd03b`](https://github.com/NixOS/nixpkgs/commit/1b5cd03b92296272e37dd169b6aaf3e5cb553f6f) julia_111-bin: 1.11.0 -> 1.11.1
* [`bc84d24e`](https://github.com/NixOS/nixpkgs/commit/bc84d24ec913af5f32236cedb25f6adfa2b61115) julia_111: 1.11.0 -> 1.11.1
* [`56d03d86`](https://github.com/NixOS/nixpkgs/commit/56d03d86ed5f60465b721cfdadf9dfdde660416d) nix-output-monitor: 2.1.3 -> 2.1.4
* [`8a4a23f0`](https://github.com/NixOS/nixpkgs/commit/8a4a23f066f28fe6f6a41bf31be149e76b144a97) ncspot: format with nixfmt
* [`429b0b4b`](https://github.com/NixOS/nixpkgs/commit/429b0b4b9004648218b4109454138245bfd9d7d8) ncspot: migrate to by-name
* [`0eef1f68`](https://github.com/NixOS/nixpkgs/commit/0eef1f6829c59e45433f2bb8653dd60ffdc020b3) ncspot: cleanup
* [`2ab52ba9`](https://github.com/NixOS/nixpkgs/commit/2ab52ba9f13524cf8214a6227fb90c6cab7ffb5f) ncspot: 1.1.2 -> 1.2.0
* [`dc2097df`](https://github.com/NixOS/nixpkgs/commit/dc2097df2eeea2b20494dd017b963e56cd855318) ncspot: expose all feature flags
* [`1bf991d3`](https://github.com/NixOS/nixpkgs/commit/1bf991d3ee637940ab0e0b269d918ffad56bfe35) ncspot: add getchoo as maintainer
* [`fa3ab236`](https://github.com/NixOS/nixpkgs/commit/fa3ab236c6a5e31d9e1926cfd76f6ea3e32f1af7) pdftitle: 0.11 -> 0.14
* [`fcb6fce9`](https://github.com/NixOS/nixpkgs/commit/fcb6fce9be039b144fb285165ff179a5a7206b9d) xwayland-satellite: cleanup meta
* [`9d53ad1f`](https://github.com/NixOS/nixpkgs/commit/9d53ad1f97072648259f2db9c14c9d62dfc42934) xwayland-satellite: add getchoo as maintainer
* [`c6dc8004`](https://github.com/NixOS/nixpkgs/commit/c6dc80048dd660b145afb1eb8d351714841700e6) xwayland-satellite: use binary wrapper
* [`492050c0`](https://github.com/NixOS/nixpkgs/commit/492050c0d3de26da271439a95d90d4a4faab2b18) discourse: mark as known vulnerable
* [`aca1f582`](https://github.com/NixOS/nixpkgs/commit/aca1f582a55b78c0ac8e52ac3b8629469d00e610) pdpmake: 1.4.3 -> 2.0.1
* [`684df029`](https://github.com/NixOS/nixpkgs/commit/684df0290ea2e1f8e51670eb6190a26b0eb840b7) gpt4all: 3.3.0 -> 3.4.2
* [`c9d0bdb9`](https://github.com/NixOS/nixpkgs/commit/c9d0bdb9ca0943462a7ed0ae3bf2f47fc5b8c7be) python3Packages.taskw: fix failing build
* [`778ade01`](https://github.com/NixOS/nixpkgs/commit/778ade01d99365ef2123f30c742b41e1d181b036) python3Packages.bugzilla: update 3.2.0 -> 3.3.0
* [`6dd3f84e`](https://github.com/NixOS/nixpkgs/commit/6dd3f84e628a17c704bd1d960c98f1353fd4a307) kubecfg: 0.34.3 -> 0.35.0
* [`a544ca23`](https://github.com/NixOS/nixpkgs/commit/a544ca239200cfa478f1645f4c035c05ad284cb8) kiwitalk: drop
* [`e0c40623`](https://github.com/NixOS/nixpkgs/commit/e0c406232aac14c7bd49ed2345618b534414d57e) pgroll: 0.6.0 -> 0.7.0
* [`c9ee9d80`](https://github.com/NixOS/nixpkgs/commit/c9ee9d80d6fa20b34d23a2954eaa64f7dfec6077) tailscale: 1.76.0 -> 1.76.1
* [`32bfb814`](https://github.com/NixOS/nixpkgs/commit/32bfb8144402363b4d18813c72724f2f3db0e222) coz: 0.2.1 -> 0.2.2
* [`f8299f4b`](https://github.com/NixOS/nixpkgs/commit/f8299f4b1838ed7d316b6ce34bf3237a52d271b6) coz: add aleksana to maintainers
* [`6c147b9b`](https://github.com/NixOS/nixpkgs/commit/6c147b9bdb630310c6682780851859ae16c5cb11) python312Packages.timm: 1.0.10 -> 1.0.11
* [`6496096e`](https://github.com/NixOS/nixpkgs/commit/6496096ed1304ea537222dbed047d5c9f6b8e5c7) vscode-extensions.visualjj.visualjj: init at 0.11.8
* [`7e432843`](https://github.com/NixOS/nixpkgs/commit/7e432843249c17870079bde86937242e8ed7215a) tellico: 3.5.5 -> 4.0.1
* [`9728b040`](https://github.com/NixOS/nixpkgs/commit/9728b040962b3d650cdbda8a6e412eb07cfcef59) python3Packages.biliass: 2.0.0-beta.1 -> 2.0.0-rc4
* [`266d4c22`](https://github.com/NixOS/nixpkgs/commit/266d4c22f778e3a973cbeb7040205b99ee37905d) yutto: 2.0.0-beta.43 -> 2.0.0-rc.4
* [`844301ec`](https://github.com/NixOS/nixpkgs/commit/844301ec743a42b8b2b077b4de222c0e87708304) biliass: fix darwin build
* [`020268ed`](https://github.com/NixOS/nixpkgs/commit/020268edd288f64f6808b2764cb7e50573585210) mujoco: 3.2.3 -> 3.2.4
* [`db737d13`](https://github.com/NixOS/nixpkgs/commit/db737d13aea135e795512e051d78a159f69ea8ad) links2: 2.29 -> 2.30
* [`b941b041`](https://github.com/NixOS/nixpkgs/commit/b941b04105a3882198552d6601de3a29aaf9f736) python312Packages.coffea: 2024.9.0 -> 2024.10.0
* [`151bfc61`](https://github.com/NixOS/nixpkgs/commit/151bfc6195cc58b967858b8582420980e8f2c73b) checkov: 3.2.266 -> 3.2.267
* [`f66995e8`](https://github.com/NixOS/nixpkgs/commit/f66995e80287bcfb967f168e9181ba30be892fe6) python312Packages.aiostream: switch to pytest-cov-stub
* [`5ece10ef`](https://github.com/NixOS/nixpkgs/commit/5ece10ef7bdce536c640dca4cae6b8b7a5b49c2c) python312Packages.aiostreammagic: 2.6.0 -> 2.8.1
* [`bbb15eb5`](https://github.com/NixOS/nixpkgs/commit/bbb15eb5d5292470e6973bb6d7ea618e650e58b0) python312Packages.asynccmd: refactor
* [`c9f9be35`](https://github.com/NixOS/nixpkgs/commit/c9f9be35123172a3e3da442429e99cf864635c8d) gobusybox: init at 0.2.0-unstable-2024-03-05
* [`cfbfcdf1`](https://github.com/NixOS/nixpkgs/commit/cfbfcdf185295648d1f0abb6ece617f967cbd49b) u-root{,-cmds}: init at 0.14.0-unstable-2024-09-26
* [`4cda75d2`](https://github.com/NixOS/nixpkgs/commit/4cda75d2ed9559d2f8ae7782f29ead2031a6bc89) vscode-extensions.elixir-lsp.vscode-elixir-ls: 0.24.1 -> 0.24.2
* [`285787a4`](https://github.com/NixOS/nixpkgs/commit/285787a445d4a1df0e405f10a63062fbfdf66409) megatools: 1.11.0 -> 1.11.1
* [`4a5efcea`](https://github.com/NixOS/nixpkgs/commit/4a5efceaf791f31f26fd65233f3bc2b66d908567) opera: 113.0.5230.47 -> 114.0.5282.102
* [`b48b48ac`](https://github.com/NixOS/nixpkgs/commit/b48b48ac58e4d58d72af55949459bd62e7fd1b31) mosquitto: use `hash` attribute for SRI hashes
* [`92562a9d`](https://github.com/NixOS/nixpkgs/commit/92562a9d483f6cb243333fd798ef3ea65a6097cd) yaydl: 0.14.1 -> 0.15.5
* [`e1544d54`](https://github.com/NixOS/nixpkgs/commit/e1544d54e6a927640be0618752758f3042ddbda3) qc: 0.6.0 -> 0.6.1
* [`43012a81`](https://github.com/NixOS/nixpkgs/commit/43012a8149bf42b97fdde20f356009e53a209ef1) qgis: re-export unwrapped parameters
* [`90f4a481`](https://github.com/NixOS/nixpkgs/commit/90f4a481725fec496232284c2e6c48dc41907c5e) mosquitto: stop using `with` expression
* [`348d9d04`](https://github.com/NixOS/nixpkgs/commit/348d9d0414457fb0e0bb7634a15d6ce0a71e0271) mosquitto: fetch repo with its explicit name
* [`0c764c58`](https://github.com/NixOS/nixpkgs/commit/0c764c58a46e6ded56e956ae2016b849a2d84aad) mosquitto: add `meta.changelog` attribute
* [`9549f7ad`](https://github.com/NixOS/nixpkgs/commit/9549f7ad3023cb99880fac61966b7ee76430af86) mosquitto: add `meta.mainProgram` attribute
* [`64d0b8b7`](https://github.com/NixOS/nixpkgs/commit/64d0b8b7013c31cc63d5f75ce985227c3802d9f2) amdvlk: workaround glslang 14 issue
* [`55cabd03`](https://github.com/NixOS/nixpkgs/commit/55cabd03a04ffca1f07edc66d0154f1439687e30) present: fix crash caused by dependency
* [`a5262ae9`](https://github.com/NixOS/nixpkgs/commit/a5262ae9365d288f4352997b2220c117713a7a4c) av-98: mark as broken
* [`b628bd00`](https://github.com/NixOS/nixpkgs/commit/b628bd00fbf8e2c5916a648ddc6e72a955af4e11) ansiwrap: mark as broken
* [`2ffd202e`](https://github.com/NixOS/nixpkgs/commit/2ffd202e4569df67ed19bbaebe3808ae9561a3af) dependency-track: 4.11.7 -> 4.12.0
* [`9b8aa25e`](https://github.com/NixOS/nixpkgs/commit/9b8aa25e9ccd8ac911c38c3ad8123eef4d382dce) CONTRIBUTING: add section on getting your PR merged
* [`0a0c9e56`](https://github.com/NixOS/nixpkgs/commit/0a0c9e56cd7cfe1b18745fd5c6c741a3d1b6a0ca) CONTRIBUTING: add section on getting the PR over the finish line
* [`e758ca25`](https://github.com/NixOS/nixpkgs/commit/e758ca25b37816a463c06c57dcd07c26a86a25f3) bear: 3.1.3 -> 3.1.5
* [`8de11d32`](https://github.com/NixOS/nixpkgs/commit/8de11d32de14d96e3a33c74dca59793801595bad) maintainers: add chn
* [`f9d8517d`](https://github.com/NixOS/nixpkgs/commit/f9d8517d5d23305d82ef2ec7dd7659603b9812c5) lenovo-legion: 0.0.12 -> 0.0.18 with patches in master
* [`ddbd7b7c`](https://github.com/NixOS/nixpkgs/commit/ddbd7b7c58b2c1340905ab142206159bfc49f179) python312Packages.portion: 2.5.0 -> 2.6.0
* [`6a6de4b8`](https://github.com/NixOS/nixpkgs/commit/6a6de4b8e4b302e9bd961a74b5df44c56dd3b025) jna: 5.14.0 -> 5.15.0
* [`e1a60202`](https://github.com/NixOS/nixpkgs/commit/e1a60202156a760444347f514926388a8814dd5f) forgejo: add marie to maintainers
* [`ec4f809c`](https://github.com/NixOS/nixpkgs/commit/ec4f809cd5c718b9334459d32e940e02a3cdb9c8) forgejo: 8.0.3 -> 9.0.0
* [`76ae387f`](https://github.com/NixOS/nixpkgs/commit/76ae387ff3c75f4629f2b8643ce114be71699d6b) sing-box: 1.10.0 -> 1.10.1
* [`82c53234`](https://github.com/NixOS/nixpkgs/commit/82c532349e08e30874e601674b8d24b80338fc91) kdePackages.mpvqt: 1.0.0 -> 1.0.1
* [`43da9988`](https://github.com/NixOS/nixpkgs/commit/43da99888c0d82825b868e5091467f0d7a286f8a) bear: re-enable tests
* [`7281ff8a`](https://github.com/NixOS/nixpkgs/commit/7281ff8a09af2cc30b8c648c8dff843934026812) bear: move to pkgs/by-name
* [`25c4c172`](https://github.com/NixOS/nixpkgs/commit/25c4c17206af0b03da60e0652489f40d5caa9838) signal-desktop(linux): 7.28.0 -> 7.29.0
* [`2287e63e`](https://github.com/NixOS/nixpkgs/commit/2287e63efddd08de4c0fa7c44a75768344286f0e) signal-desktop(darwin): 7.28.0 -> 7.29.0
* [`cdae25b0`](https://github.com/NixOS/nixpkgs/commit/cdae25b080b3abcf41c85441d304fe853ea4c336) signal-desktop-beta: 7.29.0-beta.1 -> 7.30.0-beta.1
* [`bf82581f`](https://github.com/NixOS/nixpkgs/commit/bf82581fda887d54447a4456f1d6915ab7602b14) moonlight-qt: 6.0.1 -> 6.1.0
* [`66f3134f`](https://github.com/NixOS/nixpkgs/commit/66f3134f2e541373c1327aa0377cd2dd577a208e) python3.pkgs.ibis-framework: remove dask input
* [`84768649`](https://github.com/NixOS/nixpkgs/commit/84768649a29a394bf5fd45c3f417ee4b9c66616f) nextcloud30: 30.0.0 -> 30.0.1
* [`c6b5faca`](https://github.com/NixOS/nixpkgs/commit/c6b5facae8e69c1d2de54e0a57cfbd3305e64919) maintainers: add cholli
* [`65c965f0`](https://github.com/NixOS/nixpkgs/commit/65c965f047b699a9ebd51afa95031c5b33f2a40a) pyfa: init at 2.60.1
* [`62b23983`](https://github.com/NixOS/nixpkgs/commit/62b23983870e46df67778514ac0641d9e37a8e4a) apt: 2.9.7 -> 2.9.8
* [`04e39de6`](https://github.com/NixOS/nixpkgs/commit/04e39de6eb236b086e486193510069ffe683062b) nixos/immich: do not set services.redis.servers.immich.user
* [`0551f61f`](https://github.com/NixOS/nixpkgs/commit/0551f61f0cc0608d56117f4d8b97d88dc0e233e2) multipass: 1.14.0 -> 1.14.1
* [`055d124b`](https://github.com/NixOS/nixpkgs/commit/055d124b37a6c5f8d2c4dc454a64e449ac6c5560) linux_testing: 6.12-rc2 -> 6.12-rc3
* [`0910e4bb`](https://github.com/NixOS/nixpkgs/commit/0910e4bbbb6dfb2b8a33b0dc09171ae53561d485) linux_6_11: 6.11.3 -> 6.11.4
* [`0e4c64ff`](https://github.com/NixOS/nixpkgs/commit/0e4c64ff9cef5800c6a3f4838c66a918ceb61398) linux_6_6: 6.6.56 -> 6.6.57
* [`d0227f7d`](https://github.com/NixOS/nixpkgs/commit/d0227f7da53cc7d3088eafaf67282fd3d85cd6c7) linux_6_1: 6.1.112 -> 6.1.113
* [`e3aaef14`](https://github.com/NixOS/nixpkgs/commit/e3aaef1472ccdd9568187b7f0cb909b96864d482) linux_5_15: 5.15.167 -> 5.15.168
* [`2a1497e9`](https://github.com/NixOS/nixpkgs/commit/2a1497e916a4feae70ae495f22bac3c32408c9dd) linux_5_10: 5.10.226 -> 5.10.227
* [`3fd22459`](https://github.com/NixOS/nixpkgs/commit/3fd22459cd4ecc74250e30583dc4efff041563ad) flexget: 3.11.46 -> 3.11.48
* [`31f217fb`](https://github.com/NixOS/nixpkgs/commit/31f217fbfe4431dda1ca96209d30b9bdbe33f4f4) coroot: 1.5.8 -> 1.5.9
* [`1b212b8a`](https://github.com/NixOS/nixpkgs/commit/1b212b8a10a5d2c73c6f8aa64cb4500c3944c981) pyflyby: init at 1.9.6
* [`71c64f8e`](https://github.com/NixOS/nixpkgs/commit/71c64f8ecc52879a5de35a920a57898331d483cb) initrd: drop effectless modification of kmod-blacklist
* [`fbef14a1`](https://github.com/NixOS/nixpkgs/commit/fbef14a19edfb564c2da2e933a06842e7af4da86) errcheck: 1.7.0 -> 1.8.0
* [`7f110cfc`](https://github.com/NixOS/nixpkgs/commit/7f110cfc7de92ca5f0af3ee368d29caca531fa74) sql-formatter: 15.4.2 -> 15.4.3, migrate from nodePackages ([nixos/nixpkgs⁠#323304](https://togithub.com/nixos/nixpkgs/issues/323304))
* [`f0dce5f0`](https://github.com/NixOS/nixpkgs/commit/f0dce5f0ba4611c8e65a64ff060d7a72699213ef) mkvtoolnix: fix build by backporting patch
* [`beb7aeec`](https://github.com/NixOS/nixpkgs/commit/beb7aeeca17873a52b00252ec07d89da7423f4e7) linux-firmware: 20240909 -> 20241017
* [`1d3c4e43`](https://github.com/NixOS/nixpkgs/commit/1d3c4e4324d3aeb6cf5b950e6175b5512fe0ce1a) maintainers: add Hasnep
* [`1a5b596d`](https://github.com/NixOS/nixpkgs/commit/1a5b596d5aa4594b9923a35bbfa1a09322143cd2) sqruff: init at 0.17.0
* [`139cb739`](https://github.com/NixOS/nixpkgs/commit/139cb739fd98f62245c2c9ca45d1c0fb33ed47e3) Use recommended version check
* [`bc6e6d98`](https://github.com/NixOS/nixpkgs/commit/bc6e6d9847423d78dcc25d507e5108d9a6e30351) cosmic-icons: use nix-update-script instead of unstableGitUpdater
* [`7c7ae6a3`](https://github.com/NixOS/nixpkgs/commit/7c7ae6a334944343385eceda1c2b8e089d3a48a4) cosmic-icons: inline pname
* [`e4087112`](https://github.com/NixOS/nixpkgs/commit/e40871126a7dfb6257aa13eb164a6598a507701c) python312Packages.drf-yasg: 1.21.7 -> 1.21.8
* [`76d85375`](https://github.com/NixOS/nixpkgs/commit/76d85375cb1642f9525fbcc75b83ea6f5755470e) python312Packages.pytensor: set version to 2.25.5
* [`75e9810d`](https://github.com/NixOS/nixpkgs/commit/75e9810da8a272e23eb81bb08d21c6d2e64a4ccb) linux: enable FF support for hid-nvidia-shield
* [`6de674c9`](https://github.com/NixOS/nixpkgs/commit/6de674c9ccaf90e1c7678bc6255549e7fa721f48) prometheus-redis-exporter: 1.63.0 -> 1.65.0
* [`27ed4c52`](https://github.com/NixOS/nixpkgs/commit/27ed4c52c1802c543624988b845920e799ee6062) python312Packages.pycrdt: 0.9.16 -> 0.10.3
* [`aec0a90d`](https://github.com/NixOS/nixpkgs/commit/aec0a90d2fc567712c79d1bbb7f986469ce31a4e) python312Packages.pycrdt-websocket: 0.14.2 -> 0.15.1
* [`5ee46b6e`](https://github.com/NixOS/nixpkgs/commit/5ee46b6e75417fcdf441226e00d2a020ebbffddc) python312Packages.jupyter-ydoc: 2.1.1 -> 2.1.2
* [`77f43fed`](https://github.com/NixOS/nixpkgs/commit/77f43fedfa3fc1d1b70d70f3d44628e05e845cef) python312Packages.tabula-py: 2.9.3 -> 2.10.0
* [`30297417`](https://github.com/NixOS/nixpkgs/commit/3029741718f4c765fbc5ebf76bea3d6c8ff15fe5) buck2: unstable-2024-05-15 -> unstable-2024-10-15
* [`73009026`](https://github.com/NixOS/nixpkgs/commit/73009026b09cb1b9c3be089a89674c117df79c60) libzbc: 6.1.0 -> 6.2.0
* [`81b010c1`](https://github.com/NixOS/nixpkgs/commit/81b010c18a25d50e4c49b9f6fcf74b0fb3ffc70b) prometheus-process-exporter: 0.8.3 -> 0.8.4
* [`a1c03ab0`](https://github.com/NixOS/nixpkgs/commit/a1c03ab062da59936e7cc46e9ea7b204f864dea5) system76-power: Move out of kernel category
* [`1d4df7ad`](https://github.com/NixOS/nixpkgs/commit/1d4df7adcc918f23c9c8fb357dd3bb7861270fed) system76-scheduler: Move out of kernel category
* [`969102bd`](https://github.com/NixOS/nixpkgs/commit/969102bd1172bb00b0e0b694356ccdaa9224ada8) system76-scheduler: migrate to pkgs/by-name format
* [`76e0284e`](https://github.com/NixOS/nixpkgs/commit/76e0284e88749dcf441819fd6dd0c3fd9b710219) system76-power: migrate to pkgs/by-name format
* [`a084c7f0`](https://github.com/NixOS/nixpkgs/commit/a084c7f0150164ca305e3a1c3429669aa4f89e9b) csvlens: 0.10.0 -> 0.10.1
* [`2fe3912f`](https://github.com/NixOS/nixpkgs/commit/2fe3912fdb9210a8ef64bbe26a4399ec52202f03) quictls: 3.1.5 -> 3.3.0
* [`15fe493d`](https://github.com/NixOS/nixpkgs/commit/15fe493d6fcc60d2f5668db422621b57e245e0d7) cosmic-icons: nixfmt-rfc-style
* [`403604ca`](https://github.com/NixOS/nixpkgs/commit/403604ca66e87e0886f179cba63699073a10fe3b) resolvconf: use correct output files when used with dnsmasq
* [`05172055`](https://github.com/NixOS/nixpkgs/commit/05172055a181b78e4d2a85f65a8ebdc9883b6521) lxqt.libqtxdg: 4.0.0 -> 4.0.1
* [`abca0a57`](https://github.com/NixOS/nixpkgs/commit/abca0a57ac2c1c69808fef2e8031c9c5701b75a5) biome: 1.9.2 -> 1.9.3
* [`c4aecf31`](https://github.com/NixOS/nixpkgs/commit/c4aecf316040e164c0ab49e974847932d90d2a5a) aaphoto: fix src
* [`795e2dd8`](https://github.com/NixOS/nixpkgs/commit/795e2dd8e7d06fd604f04b11630ce907a3501757) sttr: 0.2.23 -> 0.2.24
* [`9c4158a9`](https://github.com/NixOS/nixpkgs/commit/9c4158a9b3e1cef2c7409501b9d4c0f609c72212) pkarr: init at v2.0.0
* [`8e650135`](https://github.com/NixOS/nixpkgs/commit/8e6501351cd4857cdff2d38a0e6304e8ed5955a7) devenv: 1.3 -> 1.3.1
* [`70737f27`](https://github.com/NixOS/nixpkgs/commit/70737f27973618b50480f98dffd655b62dacceff) tdf: 0-unstable-2024-05-29 -> 0-unstable-2024-10-09
* [`539c6f76`](https://github.com/NixOS/nixpkgs/commit/539c6f765492ab6e11d99e500347eb7eff5fc3fe) vimPlugins.telekasten-nvim: add missing dependencies
* [`2dd171d3`](https://github.com/NixOS/nixpkgs/commit/2dd171d32108ea09ebbe861f3c4d6f692889c1cd) maintainers: add smonson
* [`6652ec3d`](https://github.com/NixOS/nixpkgs/commit/6652ec3ddbf1e621b5e8c3731c4ad32ded28fcb3) system76-power: 1.1.23 -> 1.2.1
* [`44b57e5e`](https://github.com/NixOS/nixpkgs/commit/44b57e5e902411b636aa0e2d5eee366d473defce) python312Packages.wxpython: 4.2.1 -> 4.2.2
* [`fe23a392`](https://github.com/NixOS/nixpkgs/commit/fe23a39256bd0c441c4867660bc522f2a01c50df) ruff: 0.6.9 -> 0.7.0
* [`6f45e688`](https://github.com/NixOS/nixpkgs/commit/6f45e688f8f4be8424ea8ef5d50d583efc6da376) python312Packages.jupyter-collaboration: 2.1.3 -> 2.1.4
* [`3e1b768e`](https://github.com/NixOS/nixpkgs/commit/3e1b768ec7a37ea0e0dec24242080586703dc720) python312Packages.ruff-lsp: 0.0.57 -> 0.0.58
* [`351899cd`](https://github.com/NixOS/nixpkgs/commit/351899cd4b3d03cc6c038597c0f0610cca321b7b) Revert "rust: use lld on pkgsStatic aarch64"
* [`88c41d8a`](https://github.com/NixOS/nixpkgs/commit/88c41d8a918925f5ccc915734bb8095833496d82) Revert "rust: allow linker to be different from compiler"
* [`c4c95cac`](https://github.com/NixOS/nixpkgs/commit/c4c95cac8161486a52f901a27ccdb5f8e80380b1) Revert "buildRustPackage: disable cargo-auditable on pkgsStatic aarch64"
* [`e9ddacf2`](https://github.com/NixOS/nixpkgs/commit/e9ddacf236687203430818c49a3eff17e0be3517) grafana: 11.2.2 -> 11.2.2+security-01, fix CVE-2024-9264
* [`bf3053df`](https://github.com/NixOS/nixpkgs/commit/bf3053dfc117a5e5f7c7d4e06e1fe7ffcd531504) python3Packages.bugzilla: use fetchPypi.hash instead of sha256
* [`1b376df9`](https://github.com/NixOS/nixpkgs/commit/1b376df9cfafc8f3246663617105493ac91d324d) python3Packages.bugzilla: switch to buildPythonPackage:pyproject
* [`5160edc3`](https://github.com/NixOS/nixpkgs/commit/5160edc348fa0fcf7980b53f14891c1fca305948) virtscreen: drop
* [`0fbe6fec`](https://github.com/NixOS/nixpkgs/commit/0fbe6fec88ff2c8bd633147ce2677f624b98aaf2) python312Packages.quamash: drop
* [`128e6ccc`](https://github.com/NixOS/nixpkgs/commit/128e6ccc67ab3392202b2cea18ab34dda375b9e8) cloudfox: 1.14.2 -> 1.15.0
* [`e4d5f5cf`](https://github.com/NixOS/nixpkgs/commit/e4d5f5cfe503d38e8510321c45bc82e430c33126) ldeep: 1.0.70 -> 1.0.72
* [`54e338b5`](https://github.com/NixOS/nixpkgs/commit/54e338b51d1ac5e163c42ef3e76fa5dd225fc883) ggshield: 1.32.1 -> 1.32.2
* [`88d93cef`](https://github.com/NixOS/nixpkgs/commit/88d93cef1aa82c9ee8e9b801f7f4d3340d231d62) skypeforlinux: 8.129.0.202 -> 8.130.0.205
* [`ba62342a`](https://github.com/NixOS/nixpkgs/commit/ba62342af9b6e8d3535e80d733ef8f742b8acf2a) prowler: 4.3.7 -> 4.4.1
* [`7f5a6e88`](https://github.com/NixOS/nixpkgs/commit/7f5a6e887e3c2431087064834a8dca74a6312def) python312Packages.aioopenexchangerates: 0.6.6 -> 0.6.7
* [`1313f9e8`](https://github.com/NixOS/nixpkgs/commit/1313f9e8f834cb34531e21007140c3a4ef841941) python312Packages.aliyun-python-sdk-core: 2.15.2 -> 2.16.0
* [`bc103338`](https://github.com/NixOS/nixpkgs/commit/bc1033387cdf29459829c0018b9f821bbc3cb334) python312Packages.appthreat-vulnerability-db: 6.0.14 -> 6.1.0
* [`094125f7`](https://github.com/NixOS/nixpkgs/commit/094125f7508c16be29e092bf009feb5c7aa4ec6f) python312Packages.dirigera: 1.2.0 -> 1.2.1
* [`ad3e6628`](https://github.com/NixOS/nixpkgs/commit/ad3e6628a0268047e3d0d414f199a119be3fe91c) junest: 7.4.9 -> 7.4.10
* [`a7c13860`](https://github.com/NixOS/nixpkgs/commit/a7c13860366df9ba74067a1535837d5245591b9b) plasma-panel-colorizer: 0.5.2 -> 1.0.0
* [`626bc994`](https://github.com/NixOS/nixpkgs/commit/626bc994f02ebaae1f8293702826eebe65a92233) python312Packages.censys: 2.2.14 -> 2.2.15
* [`c42012a3`](https://github.com/NixOS/nixpkgs/commit/c42012a35184940f66d1194add73e77f0e71b043) python312Packages.fastcore: 1.7.11 -> 1.7.17
* [`12ca43ae`](https://github.com/NixOS/nixpkgs/commit/12ca43ae1ec5c28ef997ee7132b3b3aa4d1599ef) python312Packages.ipwhois: 1.2.0 -> 1.3.0
* [`ebf552be`](https://github.com/NixOS/nixpkgs/commit/ebf552be094282be6646104ffab6eee7bca68521) python312Packages.lxmf: 0.5.6 -> 0.5.7
* [`a24e412f`](https://github.com/NixOS/nixpkgs/commit/a24e412f3256fbf9fe73558ecbbdcbf7b29448d9) python312Packages.mitogen: 0.3.13 -> 0.3.14
* [`6476dee8`](https://github.com/NixOS/nixpkgs/commit/6476dee80dfc937925f1dd89a0da893484aa9b4b) plasma-panel-colorizer: add updateScript
* [`25deb1ee`](https://github.com/NixOS/nixpkgs/commit/25deb1eec3237ae5675bfb2ab5082102c3372260) python312Packages.msgraph-sdk: 1.9.0 -> 1.11.0
* [`67a6f34c`](https://github.com/NixOS/nixpkgs/commit/67a6f34ca0281aaa7397738aeadf828fe654b3a3) basex: 11.1 -> 11.4
* [`46678b17`](https://github.com/NixOS/nixpkgs/commit/46678b17c5cc2c3fc91ebd94c32c5711a42ded9f) python312Packages.plugwise: 1.4.1 -> 1.4.2
* [`d6c72582`](https://github.com/NixOS/nixpkgs/commit/d6c72582bb7d51d14947809f323a62557e26ed76) python312Packages.publicsuffixlist: 1.0.2.20241010 -> 1.0.2.20241017
* [`b11b9a19`](https://github.com/NixOS/nixpkgs/commit/b11b9a19bf8a6e4e33224ab498030d105d37d3db) python312Packages.pyotgw: 2.2.1 -> 2.2.2
* [`70d1b8a3`](https://github.com/NixOS/nixpkgs/commit/70d1b8a33eb1de39a8605d175e04b72226bf8134) python312Packages.pyrisco: 0.6.4 -> 0.6.5
* [`79e27211`](https://github.com/NixOS/nixpkgs/commit/79e27211a61a9b6aff12f8cc894e11ace9baa741) python312Packages.pysmi: 1.5.0 -> 1.5.4
* [`8855536b`](https://github.com/NixOS/nixpkgs/commit/8855536bbb86a17f50c6dbe0920646e2893adf63) python312Packages.reolink-aio: 0.9.11 -> 0.10.0
* [`655c7b0e`](https://github.com/NixOS/nixpkgs/commit/655c7b0e425c264a8699cbcf3e5c51d7bf2447d9) python312Packages.pyjson5: 1.6.6 -> 1.6.7
* [`7cb2e9d3`](https://github.com/NixOS/nixpkgs/commit/7cb2e9d3b758e1745ef180dc5a07f8c5686b3275) python312Packages.pyexploitdb: 0.2.38 -> 0.2.39
* [`8bfb3120`](https://github.com/NixOS/nixpkgs/commit/8bfb31201e9f1dc44a64d10d8768bc6b967426f8) python312Packages.pwkit: 1.2.1 -> 1.2.2
* [`b07dfc31`](https://github.com/NixOS/nixpkgs/commit/b07dfc312038a7d83bc5873f876d57e03b97a937) python312Packages.twilio: 9.3.3 -> 9.3.4
* [`f7adc837`](https://github.com/NixOS/nixpkgs/commit/f7adc837bce0cf296dcd525188fc8fed68b75a09) python312Packages.typer-shell: 0.1.11 -> 0.1.12
* [`9c4b6a30`](https://github.com/NixOS/nixpkgs/commit/9c4b6a30b93cbeaa332f3e5721f79c09713b7240) trufflehog: 3.82.8 -> 3.82.11
* [`c4e6c85d`](https://github.com/NixOS/nixpkgs/commit/c4e6c85dc35222e23d69bc0066044778cc9e1a70) python312Packages.tabula-py: update disabled
* [`dcba7d34`](https://github.com/NixOS/nixpkgs/commit/dcba7d34c53234ddb2e4a027b5ff27f92a7587a7) metasploit: 6.4.30 -> 6.4.31
* [`a25a0562`](https://github.com/NixOS/nixpkgs/commit/a25a056294fd911badbfb0ec96245543a72851d0) plasma-panel-colorizer: enable strictDeps
* [`65752282`](https://github.com/NixOS/nixpkgs/commit/657522822cb6167c9569b6e4616193b69e8c5a44) python312Packages.mypy-boto3-amplify: 1.35.19 -> 1.35.41
* [`45f6521d`](https://github.com/NixOS/nixpkgs/commit/45f6521d641b442fee34729b00d31c3de45e95da) python312Packages.mypy-boto3-cloudformation: 1.35.0 -> 1.35.41
* [`f3663724`](https://github.com/NixOS/nixpkgs/commit/f36637246da91722f037ba95d0a4b247091cb41d) python312Packages.mypy-boto3-codebuild: 1.35.21 -> 1.35.41
* [`5bf5d422`](https://github.com/NixOS/nixpkgs/commit/5bf5d42248e59b665442f5001ce140356701a3f5) python312Packages.mypy-boto3-codepipeline: 1.35.37 -> 1.35.40
* [`6423f9bf`](https://github.com/NixOS/nixpkgs/commit/6423f9bf125805fe89af1cc532d8f6c6b11a64b9) python312Packages.mypy-boto3-dataexchange: 1.35.0 -> 1.35.43
* [`f86b185f`](https://github.com/NixOS/nixpkgs/commit/f86b185fcf78fa65662b8d2b925a053f693aadc1) python312Packages.mypy-boto3-ecs: 1.35.38 -> 1.35.43
* [`be92ca8a`](https://github.com/NixOS/nixpkgs/commit/be92ca8a81c2f70ce8332c279465e2de5e7a55d4) outguess: nixfmt
* [`90aa716c`](https://github.com/NixOS/nixpkgs/commit/90aa716c0e1e516f0bea51507a368220f59b3975) python312Packages.mypy-boto3-ivs: 1.35.19 -> 1.35.41
* [`6840f27e`](https://github.com/NixOS/nixpkgs/commit/6840f27e74d04fe138d221e1c541308ea4ffd008) python312Packages.mypy-boto3-pinpoint-sms-voice-v2: 1.35.26 -> 1.35.43
* [`bbc54ff1`](https://github.com/NixOS/nixpkgs/commit/bbc54ff10ec6c8d485ef754b43e0518b11c400a0) python312Packages.mypy-boto3-pipes: 1.35.16 -> 1.35.43
* [`52f29b5f`](https://github.com/NixOS/nixpkgs/commit/52f29b5fb48b374f3e1db4faa64ea79bc0adc748) python312Packages.mypy-boto3-quicksight: 1.35.33 -> 1.35.43
* [`7b2e267a`](https://github.com/NixOS/nixpkgs/commit/7b2e267acedb96fdd172109d4c8eec862ee139ad) python312Packages.mypy-boto3-rds: 1.35.31 -> 1.35.43
* [`088600fc`](https://github.com/NixOS/nixpkgs/commit/088600fcd3c5c48c705cb95284c87b0f2321f032) python312Packages.mypy-boto3-redshift: 1.35.35 -> 1.35.41
* [`6f1ca6db`](https://github.com/NixOS/nixpkgs/commit/6f1ca6db12b4627006349c222236697ac1b22758) python312Packages.mypy-boto3-resiliencehub: 1.35.0 -> 1.35.41
* [`3bc56c63`](https://github.com/NixOS/nixpkgs/commit/3bc56c638e6be7728ceac9b9ace3328ee80c9ffa) python312Packages.mypy-boto3-s3: 1.35.32 -> 1.35.42
* [`8550114c`](https://github.com/NixOS/nixpkgs/commit/8550114ceee5ed9823031ca3600f55c4ef285ae2) python312Packages.mypy-boto3-securitylake: 1.35.0 -> 1.35.40
* [`acf12909`](https://github.com/NixOS/nixpkgs/commit/acf1290922d7da5f89197c55d143419bfc3adeb8) python312Packages.mypy-boto3-sesv2: 1.35.29 -> 1.35.41
* [`bcf38da5`](https://github.com/NixOS/nixpkgs/commit/bcf38da5ce342909e1a4a5e990dcead6241bbfc6) python312Packages.mypy-boto3-transfer: 1.35.0 -> 1.35.40
* [`5de63922`](https://github.com/NixOS/nixpkgs/commit/5de6392267081edbbd2ec0c2f507dd451dceb3c9) outguess: enable strictDeps
* [`532871af`](https://github.com/NixOS/nixpkgs/commit/532871af725896be1891b5b58897823231fcdd6e) python312Packages.mypy-boto3-workspaces: 1.35.32 -> 1.35.43
* [`669c7a8d`](https://github.com/NixOS/nixpkgs/commit/669c7a8d6d4a82529cf2a5c59e462731c8d85dff) application-title-bar: nixfmt
* [`3f5a08f3`](https://github.com/NixOS/nixpkgs/commit/3f5a08f36da63e38f47dba4e1c572047362bc325) clipboard-jh: 0.9.0.1 -> 0.9.1
* [`0d9ec510`](https://github.com/NixOS/nixpkgs/commit/0d9ec5106270e3596f6fd93fa87d4d42c1598f42) python312Packages.swisshydrodata: 0.1.0 -> 0.2.1
* [`2dbb5d67`](https://github.com/NixOS/nixpkgs/commit/2dbb5d677ba2fcc441ef67f3fe0423f12e10dde9) application-title-bar: modernize
* [`df03b322`](https://github.com/NixOS/nixpkgs/commit/df03b32278b211d2398c8cb1bc693a70ca8f3d73) nixos/jupyter: set user primary group
* [`a50f6833`](https://github.com/NixOS/nixpkgs/commit/a50f68331620a7ac1566a3fed7d39fa30a23780b) valuta: 1.2.0 -> 1.3.2
* [`c5d1d88d`](https://github.com/NixOS/nixpkgs/commit/c5d1d88d5faa688d5f801684f904519d2e978e78) python312Packages.aiortm: 0.9.12 -> 0.9.17
* [`d581fdf0`](https://github.com/NixOS/nixpkgs/commit/d581fdf015c40ec5c418fb1ca05f1ac980bde35c) warp-terminal: 0.2024.10.08.08.02.stable_02 -> 0.2024.10.15.08.02.stable_02
* [`387380b9`](https://github.com/NixOS/nixpkgs/commit/387380b96182c6e3244d7ba27bbd7e85fe148a5b) outguess: modernize
* [`ff5ebf9e`](https://github.com/NixOS/nixpkgs/commit/ff5ebf9e583d1588c5318a196940db8846076388) python312Packages.cymruwhois: init at 1.6
* [`a6ce630f`](https://github.com/NixOS/nixpkgs/commit/a6ce630fd796bcff08bfbc166a5c96a154d36dd0) dnsdiag: init at 2.5.0
* [`e6e229dc`](https://github.com/NixOS/nixpkgs/commit/e6e229dc20b3492c2f2b7789f61b6fb8adf43ee3) wezterm: add headless package for mux server
* [`b71ae2d9`](https://github.com/NixOS/nixpkgs/commit/b71ae2d9501c687ab40e784d209e813df2259f2d) chromium,chromedriver: 129.0.6668.100 -> 130.0.6723.58
* [`601fc502`](https://github.com/NixOS/nixpkgs/commit/601fc502a9331f09411b289a2489dc4eb6c51d47) hyprdim: 2.2.6 -> 3.0.0
* [`76386048`](https://github.com/NixOS/nixpkgs/commit/7638604838de6e1e2dad2b90844f73151a29952d) simpleini: init at 4.22
* [`a9e1f4e0`](https://github.com/NixOS/nixpkgs/commit/a9e1f4e0abe8f8b5f6b6169323d990a0954280e4) aliases.nix: throw aliases before 2022
* [`2dc3caa0`](https://github.com/NixOS/nixpkgs/commit/2dc3caa083b72b3f5d2fea1a08e3460eb96989d4) python3Packages.bugzilla: renamed into python-bugzilla
* [`6b3d803d`](https://github.com/NixOS/nixpkgs/commit/6b3d803ddddc6ad7612e16986aaee95fdd243859) ida-free: fix hash mismatchin of icon
* [`512fa854`](https://github.com/NixOS/nixpkgs/commit/512fa85477d84da18516f69056975f140a025710) python312Packages.pdf2docx: fix build
* [`cd44a4ad`](https://github.com/NixOS/nixpkgs/commit/cd44a4ad1e1dea6ea9042e0b3de72f84588bcc84) python312Packages.pdf2docx: modernize
* [`06b34fe3`](https://github.com/NixOS/nixpkgs/commit/06b34fe320590301917300e1e5621ffaca007610) python312Packages.pdf2docx: fix license
* [`7f2652e7`](https://github.com/NixOS/nixpkgs/commit/7f2652e77c442f71774bf929acd7ab138e88d1d9) php82Extensions.memcached: 3.2.0 -> 3.3.0
* [`489ccd84`](https://github.com/NixOS/nixpkgs/commit/489ccd84df4303db7f80b200c67504a7945e4ded) cosmic-wallpapers: init at 1.0.0-alpha.2
* [`b9776d2c`](https://github.com/NixOS/nixpkgs/commit/b9776d2cf128e8cc59e6936f4ab942ceb3b2f1ce) ursadb: 1.5.1 -> 1.5.2
* [`bbc4efa5`](https://github.com/NixOS/nixpkgs/commit/bbc4efa5dec763979308a85b02cf2498447ea566) rospo: 0.12.1 -> 0.13.0
* [`3b7432ff`](https://github.com/NixOS/nixpkgs/commit/3b7432ff22aa31eeffdd5df29d47feb78a336c21) system76-scheduler: 2.0.1 -> 2.0.2
* [`41fc9db2`](https://github.com/NixOS/nixpkgs/commit/41fc9db2408c8d3e4d4c40eb9031327f1612f263) python312Packages.herepy: 3.6.3 -> 3.6.4
* [`28a2199b`](https://github.com/NixOS/nixpkgs/commit/28a2199ba645d8a4ccb1205bd9ace4fb8922c566) mockgen: 0.4.0 -> 0.5.0
* [`8f9d4a06`](https://github.com/NixOS/nixpkgs/commit/8f9d4a06acae4c7366caa1907abaadd731755d91) prometheus-ipmi-exporter: 1.8.0 -> 1.9.0
* [`890d1ec4`](https://github.com/NixOS/nixpkgs/commit/890d1ec4bafb9b4d1145b5ed19c6b6eecc33e52c) tdom: 0.9.4 -> 0.9.5
* [`08c4968a`](https://github.com/NixOS/nixpkgs/commit/08c4968a3ddcaa03d82cfdc5d281ab8e3d3cd8e6) highs: 1.7.2 -> 1.8.0
* [`c858402c`](https://github.com/NixOS/nixpkgs/commit/c858402c2a629211153137fb8d39be9fde4694ff) libcpr: 1.10.5 -> 1.11.0
* [`1bb473ae`](https://github.com/NixOS/nixpkgs/commit/1bb473ae6235e5e0f02b674f4e72c1e791e6cdc7) mkuimage: init at 0-unstable-2024-02-28
* [`7273516f`](https://github.com/NixOS/nixpkgs/commit/7273516ff448f97de563725d065fe7ea68b747e4) u-root: add minimal kernel in passthru for local testing
* [`58d3118e`](https://github.com/NixOS/nixpkgs/commit/58d3118e612e65d7a19ad7dd76132b9ed0a20767) couchbase-shell: init at 1.0.0
* [`313e196d`](https://github.com/NixOS/nixpkgs/commit/313e196dbd1f9e17cd9d2874d9782f180f9f7ff2) python3Packages.click-aliases: 1.0.4 -> 1.0.5
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
