### PR TITLE
niv home-manager: update 03863036 -> 5ec753a1

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -41,10 +41,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "038630363e7de57c36c417fd2f5d7c14773403e4",
-        "sha256": "1xxnsylkjdkpjhx4zs58ykrcm623ns054zxnacyq9avjj6657m2m",
+        "rev": "5ec753a1fc4454df9285d8b3ec0809234defb975",
+        "sha256": "0jygm1vsfp10fylmxg8qfss01zfz72iwnxqaal75x5wpgmihdc7c",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/038630363e7de57c36c417fd2f5d7c14773403e4.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/5ec753a1fc4454df9285d8b3ec0809234defb975.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@03863036...5ec753a1](https://github.com/nix-community/home-manager/compare/038630363e7de57c36c417fd2f5d7c14773403e4...5ec753a1fc4454df9285d8b3ec0809234defb975)

* [`d3ee25c0`](https://github.com/nix-community/home-manager/commit/d3ee25c07848725e924a74a4813de2ad0f5d0878) Translate using Weblate (Hindi)
* [`d47d3325`](https://github.com/nix-community/home-manager/commit/d47d33254fbf4fdbdee9f1f14095f689662e479d) home-manager-manual: expose options.json
* [`8bb5d53c`](https://github.com/nix-community/home-manager/commit/8bb5d53c5847d9a9b2ad1bda49f9aa9df0de282a) docs: add XDG_*_HOME mentions to xdg.*Home options
* [`03f8e0b3`](https://github.com/nix-community/home-manager/commit/03f8e0b3b3ca4f49d11bf0264dbff465d6ae9aae) snixembed: add module
* [`342a1d68`](https://github.com/nix-community/home-manager/commit/342a1d682386d3a1d74f9555cb327f2f311dda6e) flake.lock: Update
* [`58283095`](https://github.com/nix-community/home-manager/commit/582830954264080aae93f751c3cdc58df600d2d1) vifm: add module
* [`65ae9c14`](https://github.com/nix-community/home-manager/commit/65ae9c147349829d3df0222151f53f79821c5134) git: add module for `git maintenance` ([nix-community/home-manager⁠#5772](https://togithub.com/nix-community/home-manager/issues/5772))
* [`2b13611e`](https://github.com/nix-community/home-manager/commit/2b13611eaed8326789f76f70d21d06fbb14e3e47) floorp: add module
* [`d57112db`](https://github.com/nix-community/home-manager/commit/d57112db877f07387ce7104b5ac346ede556d2d7) pls: fixed perm argument to pass via pls
* [`64c6325b`](https://github.com/nix-community/home-manager/commit/64c6325b28ebd708653dd41d88f306023f296184) flake.lock: Update
* [`e1aec543`](https://github.com/nix-community/home-manager/commit/e1aec543f5caf643ca0d94b6a633101942fd065f) thunderbird: support setting search engines ([nix-community/home-manager⁠#5697](https://togithub.com/nix-community/home-manager/issues/5697))
* [`2a4fd1cf`](https://github.com/nix-community/home-manager/commit/2a4fd1cfd8ed5648583dadef86966a8231024221) eza: fix icons option
* [`994a0baf`](https://github.com/nix-community/home-manager/commit/994a0baf7be821c6c1487ffb3ab2884a5581a293) nushell: add joaquintrinanes as maintainer
* [`edf15f15`](https://github.com/nix-community/home-manager/commit/edf15f1549a2f4e65d704f7d6ab6be715d932976) nushell: create generator helpers
* [`628b15d2`](https://github.com/nix-community/home-manager/commit/628b15d275a536fd4d4b9ab4405dd1f0eb34fe18) nushell: allow arbitrary environment variables
* [`b5342765`](https://github.com/nix-community/home-manager/commit/b53427656655174c50c050b50c497d0e91405ab7) Translate using Weblate (Romanian)
* [`f81be125`](https://github.com/nix-community/home-manager/commit/f81be125ff5a47b2f0a2289ccb6d4c752083659b) Translate using Weblate (German)
* [`5bb057a7`](https://github.com/nix-community/home-manager/commit/5bb057a7b527f8061f5b3dfaaf06650a23034f18) Translate using Weblate (Lithuanian)
* [`1d9b4a3e`](https://github.com/nix-community/home-manager/commit/1d9b4a3e60398572f4a760bc93f89ebeebbdb3e2) fish: make generation of completions optional
* [`800a191f`](https://github.com/nix-community/home-manager/commit/800a191f33ce7311e5070ff10d6fb5030b55fdde) broot: allow multiple keyboard keys per verb
* [`e43902a7`](https://github.com/nix-community/home-manager/commit/e43902a7d6df1ce25063d59fa35ab786fa9f7704) broot: fix minor documentation bug
* [`78a7a070`](https://github.com/nix-community/home-manager/commit/78a7a070bbcc3b37cc36080c2a3514207d427b3b) flake.lock: Update
* [`9c1a1c7d`](https://github.com/nix-community/home-manager/commit/9c1a1c7df49a9b28539ccb509b36d0b81e41391c) activitywatch: reduce test closure
* [`e78cbb20`](https://github.com/nix-community/home-manager/commit/e78cbb20276f09c1802e62d2f77fc93ec32da268) zed-editor: add module
* [`1834304b`](https://github.com/nix-community/home-manager/commit/1834304bc3849bfec635cab408e6090d536a549f) direnv: simplify, work around nushell/nushell[nix-community/home-manager⁠#14112](https://togithub.com/nix-community/home-manager/issues/14112)
* [`cb93ab1c`](https://github.com/nix-community/home-manager/commit/cb93ab1c990c5719ec199e8c397e688de06cb46d) direnv: remove nushell hack
* [`d4a3186d`](https://github.com/nix-community/home-manager/commit/d4a3186de0eeb37d1e43ed65791b0af677e440a1) firefox: conditional search file
* [`2ffb68e2`](https://github.com/nix-community/home-manager/commit/2ffb68e20981d78bfcc73b2271f2dfa003df182c) thunderbird: conditional search file
* [`346973b3`](https://github.com/nix-community/home-manager/commit/346973b338365240090eded0de62f7edce4ce3d1) tests/firefox: add shared path test
* [`09a0c0c0`](https://github.com/nix-community/home-manager/commit/09a0c0c02953318bf94425738c7061ffdc4cba75) cmus: add module
* [`802b3cb2`](https://github.com/nix-community/home-manager/commit/802b3cb2d45ad66619ea8ad19b280baa460556d2) espanso: use `launcher` command on Linux
* [`122f7054`](https://github.com/nix-community/home-manager/commit/122f70545b29ccb922e655b08acfe05bfb44ec68) firefox: change container.json version to 5
* [`892a6443`](https://github.com/nix-community/home-manager/commit/892a6443b7676207490c83d181367ba3abcb1f23) nh: add module
* [`fe563023`](https://github.com/nix-community/home-manager/commit/fe56302339bb28e3471632379d733547caec8103) zoxide: fix fzf bash-completion conflict
* [`1e27f213`](https://github.com/nix-community/home-manager/commit/1e27f213d77fc842603628bcf2df6681d7d08f7e) flake.lock: Update
* [`5ec753a1`](https://github.com/nix-community/home-manager/commit/5ec753a1fc4454df9285d8b3ec0809234defb975) modules/neovim: fix config generation ([nix-community/home-manager⁠#5976](https://togithub.com/nix-community/home-manager/issues/5976))
