### PR TITLE
niv nixpkgs: update aca8144f -> 07b88919

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "aca8144f8aeca1044ad6bc29ad9cae0bd12dfb19",
-        "sha256": "0570fhmvyxhzzbyxjab1sbjdvl6k580q26n885rpf114macqb2aj",
+        "rev": "07b889196841399386c384461586b52901b68439",
+        "sha256": "1qcds1zy8c4gfcbnk0paxpyjq3yyczcm86c0hayq4y7aagpraz37",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/aca8144f8aeca1044ad6bc29ad9cae0bd12dfb19.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/07b889196841399386c384461586b52901b68439.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@aca8144f...07b88919](https://github.com/nixos/nixpkgs/compare/aca8144f8aeca1044ad6bc29ad9cae0bd12dfb19...07b889196841399386c384461586b52901b68439)

* [`25e8a273`](https://github.com/NixOS/nixpkgs/commit/25e8a273af4099fdb8886b7b3ad554fb318ca9ed) nixos/xl2tpd: prefer 'install' over 'chmod/chown'
* [`39dfdad5`](https://github.com/NixOS/nixpkgs/commit/39dfdad529771f2454d3374a50bb46b067866db8) pptpd: prefer 'install' over 'chmod/chown'
* [`736d58b9`](https://github.com/NixOS/nixpkgs/commit/736d58b90e13c684744e8d98d1c563fd962701bd) nixos/sftpgo: fix upstream docs links
* [`3a66bd1d`](https://github.com/NixOS/nixpkgs/commit/3a66bd1dc716393a5c1531ac1efa7d80f7ed4825) nixos/sftpgo: change type of dataDir option to path
* [`e8885aba`](https://github.com/NixOS/nixpkgs/commit/e8885abab973a6a58afbbda010f2392d00b5daa6) nixos/sftpgo: add extraReadWriteDirs option
* [`5b25b69c`](https://github.com/NixOS/nixpkgs/commit/5b25b69ce60504cc45ba263e06b98cb483325c49) nginxModules.njs: 0.8.1 -> 0.8.4
* [`893e0f37`](https://github.com/NixOS/nixpkgs/commit/893e0f3733edbf1d1e7e04970644e60a23ffc551) rebuild-amount: Fix 'SC2155 (warning): Declare and assign separately to avoid masking return values.'
* [`89ea599a`](https://github.com/NixOS/nixpkgs/commit/89ea599a5478f0d4a7c025ae6c4ab2ce3666e6ae) ejabberd: 23.10 -> 24.02
* [`6f551028`](https://github.com/NixOS/nixpkgs/commit/6f5510289ed010967cb9e684ed09fd6cdf841f8c) nixos/tests/ejabberd: fix tests
* [`90484c7f`](https://github.com/NixOS/nixpkgs/commit/90484c7f6813e1d98eac231647fa3d31059005a0) ejabberd: handle optional deps
* [`845ef604`](https://github.com/NixOS/nixpkgs/commit/845ef6049853b4d483ef85efed25ae50444e4549) ejabberd: 24.02 -> 24.06
* [`8fefd4d6`](https://github.com/NixOS/nixpkgs/commit/8fefd4d617366c10d5653516dd9a87b2910aa0ba) ejabberd: 24.06 -> 24.07
* [`954eaa9a`](https://github.com/NixOS/nixpkgs/commit/954eaa9a7259eb9e551b8eea658002a507fa765e) btop: add rocm version
* [`96d13837`](https://github.com/NixOS/nixpkgs/commit/96d13837d14c6a9ccc8c681f206cbc7a574fdbb5) protoc-gen-go-grpc: mark as unmaintained
* [`1a66c5bf`](https://github.com/NixOS/nixpkgs/commit/1a66c5bf282b9e6435b9e136c1d0cf2988bbbfdf) vapoursynth: Simplify plugin loading
* [`189fc6cf`](https://github.com/NixOS/nixpkgs/commit/189fc6cfbfd2bd955f42a6fffe7a70033cf9cc1c) nixos/bazarr: set systemd config KillSignal to SIGINT to fix timeout
* [`5c9a9fed`](https://github.com/NixOS/nixpkgs/commit/5c9a9fed37700c071cd14c64430f761ff201ea35) flac: set meta.mainProgramm
* [`adc03577`](https://github.com/NixOS/nixpkgs/commit/adc03577327067ebd028ce75a5826d4707c9bd9f) pocketsphinx: init at 5.0.3
* [`9eea4935`](https://github.com/NixOS/nixpkgs/commit/9eea49356ed20f9efbe27b21540a0c95ffa640da) python3Packages.speechrecognition: devendor dependencies
* [`b488ef74`](https://github.com/NixOS/nixpkgs/commit/b488ef7483a6faec70a629cd02c630d83eb6dc9b) gup: 0.9.1 -> 0.9.2
* [`06c80107`](https://github.com/NixOS/nixpkgs/commit/06c801075527868dd888dc89cd91e1145f76ab57) uboot: missing perl dependency
* [`8f66f0bc`](https://github.com/NixOS/nixpkgs/commit/8f66f0bcf94e11f6c67459dbe8f3ff4aa9abbbae) php81: replace local patch with an official commit
* [`9a04e8dc`](https://github.com/NixOS/nixpkgs/commit/9a04e8dc45ef677a096cc5f14672c14fe79b066c) php81: replace a patch from a fork with an official commit
* [`80f6b177`](https://github.com/NixOS/nixpkgs/commit/80f6b177348351f531ea9fd4ed615c8f4d4dfd08) ayatana-indicator-messages: substitute --replace with --replace-fail
* [`f3d06382`](https://github.com/NixOS/nixpkgs/commit/f3d063820018405efbf3806dfd133f2264e83f3d) basalt-monado: init at 0-unstable-2024-06-21
* [`4cfe15f9`](https://github.com/NixOS/nixpkgs/commit/4cfe15f91343cd89aa01b0c68f85987ac2a158b6) root: workaround upsteam issue 14778
* [`07544dd4`](https://github.com/NixOS/nixpkgs/commit/07544dd438dab566adaa5d60bc3de20be126e156) python3Packages.speechrecognition: add optional dependencies
* [`873fe01d`](https://github.com/NixOS/nixpkgs/commit/873fe01d6e9d02a33d2a698b2cf3078eb1158287) angryipscanner: Fix to patch swt error
* [`1cf3c6b6`](https://github.com/NixOS/nixpkgs/commit/1cf3c6b671e5ee3fc0f4b031199c1410afb00e39) fatrop: 0.0.1 -> 0.0.3
* [`697e3017`](https://github.com/NixOS/nixpkgs/commit/697e301788c0d890324030880d1fc2f8b14bd3a8) casadi: build with fatrop
* [`b9df781c`](https://github.com/NixOS/nixpkgs/commit/b9df781c54d091195ce35ddbd3c5fe167e7c35b9) gup: use SRI hash and fix updateScript
* [`268db320`](https://github.com/NixOS/nixpkgs/commit/268db320794c93e632614a88d77955085c823007) ani-skip: init at 1.0.1
* [`5ac6c526`](https://github.com/NixOS/nixpkgs/commit/5ac6c5261dfcf80a295f2e41ebf7d6919d5f0c46) doc: Add missing debian12 attribute names
* [`db25e397`](https://github.com/NixOS/nixpkgs/commit/db25e39716296306ddb3176a8bab300abdfb43c1) gradle: inherit `tests` attribute through the wrapper
* [`2cb73cfd`](https://github.com/NixOS/nixpkgs/commit/2cb73cfd624598ec729f50593fe18ba50a041e23) gradle: add an `updateScript`
* [`e9f663ca`](https://github.com/NixOS/nixpkgs/commit/e9f663ca7cec55509cdc866c43c537540ac750d4) go-md2man: 2.0.4 -> 2.0.5
* [`28f2f2a4`](https://github.com/NixOS/nixpkgs/commit/28f2f2a4f9723cf730e427952922755c2d552dfc) darwin.xcode: add 15.0.1 and 16
* [`2f34e5e9`](https://github.com/NixOS/nixpkgs/commit/2f34e5e90969a39fd1c492c22383120e46ea9015) fatrop: 0.0.3 -> 0.0.4
* [`0769507d`](https://github.com/NixOS/nixpkgs/commit/0769507dfd160d94f9af3e115d43ff03e4c12e82) libzip: 1.10.1 -> 1.11.1
* [`95c13a1d`](https://github.com/NixOS/nixpkgs/commit/95c13a1dc1afccf6620ada5e6ec3e7ff80512ccc) pax-utils: 1.3.7 -> 1.3.8
* [`5280effa`](https://github.com/NixOS/nixpkgs/commit/5280effa98ac07eae7d3ded1197d65c1a6608ff2) tflint: modernized derivation and formatted via nixfmt-rfc-style
* [`373cbc31`](https://github.com/NixOS/nixpkgs/commit/373cbc318a4156578e70d1b6135c6f3cb772d696) tflint: moved to by-name
* [`372ab6c4`](https://github.com/NixOS/nixpkgs/commit/372ab6c4ab4dc02bd1c0d2a97ddda0f084a06bf5) opentelemetry-collector-contrib: 0.109.0 -> 0.110.0
* [`58473a3c`](https://github.com/NixOS/nixpkgs/commit/58473a3c1a7e424fca88eb1f954e153deb51a2d8)  nixos/anki-sync-server: add setting
* [`6fd39905`](https://github.com/NixOS/nixpkgs/commit/6fd3990534fa4d69c945217a8faa948e1e742e53) trivial: make symlinkJoin support pname+version alone
* [`c70a1b2f`](https://github.com/NixOS/nixpkgs/commit/c70a1b2fafaae045e7ce37a0c59c26a19bf957c1) freerdp3: fix cross compilation
* [`14dedbaa`](https://github.com/NixOS/nixpkgs/commit/14dedbaa92dce20c6e342e1e763821da9381c68d) libjxl: build plugins/loaders unconditionally
* [`b713d143`](https://github.com/NixOS/nixpkgs/commit/b713d143b17f869a18cad59fbe8fe2d54dc07f8f) librenms: 24.8.0 -> 24.9.1
* [`23d2b40c`](https://github.com/NixOS/nixpkgs/commit/23d2b40cae5f2d21601e950b8bb576b0487590d0) python3Packages.protobuf3: remove
* [`2cc1c9ef`](https://github.com/NixOS/nixpkgs/commit/2cc1c9efd81ef0411bf00f932773a40c36c07504) protobuf3_20: remove
* [`fd65959f`](https://github.com/NixOS/nixpkgs/commit/fd65959f5fc8d3f5b2beda543b0b3e9f9226521b) casadi: 3.6.6 -> 3.6.7
* [`8e6e68bb`](https://github.com/NixOS/nixpkgs/commit/8e6e68bb608b03dfdf37271889cd32d63458e8e2) buildpack: modernized derivation and formatted via nixfmt-rfc-style
* [`b5b06a23`](https://github.com/NixOS/nixpkgs/commit/b5b06a23ec63f12ad68914bff7b977be9bedf087) buildpack: moved to by-name
* [`f49c7fec`](https://github.com/NixOS/nixpkgs/commit/f49c7fec76c6a0786f6d8136601f855744cc8d08) libscfg: format, add updateScript
* [`803d2e92`](https://github.com/NixOS/nixpkgs/commit/803d2e92b2e015f13564bebcfd080eaf8fe57e13) proj: 9.4.1 -> 9.5.0
* [`49450230`](https://github.com/NixOS/nixpkgs/commit/494502306d4eb9c264d638bd53b43f6554468802) python3Packages.pyproj: 3.6.1 -> 3.7.0
* [`c0f03388`](https://github.com/NixOS/nixpkgs/commit/c0f03388ef332178a95b6cb807d37ee6ff9c5694) gdal: disable test failing with proj 9.5
* [`f9e0e497`](https://github.com/NixOS/nixpkgs/commit/f9e0e4973769d10b264398c013bb5d144392eef0) beekeeper-studio: 4.6.2 -> 4.6.8
* [`a27ca817`](https://github.com/NixOS/nixpkgs/commit/a27ca817c830e42dadb3bf3defc6b8b32dfe5edc) hyprcursor: 0.1.9 -> 0.1.10
* [`565c8557`](https://github.com/NixOS/nixpkgs/commit/565c85576bcac014cabddf1221551998e629fc75) python312Packages.pythonqwt: init at 0.12.7
* [`fbfa8e21`](https://github.com/NixOS/nixpkgs/commit/fbfa8e21e6e5600ed6f4ebec2bfdabd5321cd5db) python312Packages.guidata: init at 3.6.3
* [`97fb6ff0`](https://github.com/NixOS/nixpkgs/commit/97fb6ff0a6572b4ca9ca926565310cc74197c1eb) python312Packages.plotpy: init at 2.6.3
* [`96cbd5b4`](https://github.com/NixOS/nixpkgs/commit/96cbd5b453989e162ebdb806714a0b0100f9db9b) tests.pkg-config.defaultPkgConfigPackages.wayland-scanner: fix the test
* [`b57d9966`](https://github.com/NixOS/nixpkgs/commit/b57d9966875009058d01613da91f906533b38352) python3Packages.libpwquality: fix build
* [`faf6d685`](https://github.com/NixOS/nixpkgs/commit/faf6d685fd9a75f30799099f1519fda4d7ad8c4a) xcodes: 1.4.1 -> 1.5.0
* [`1c88e6d3`](https://github.com/NixOS/nixpkgs/commit/1c88e6d36de04fe93aa6baedffa77c6ffd91a597) 1password-gui: 8.10.40 -> 8.10.46 (beta 8.10.44-21 -> 8.10.48-17)
* [`c46f9d2a`](https://github.com/NixOS/nixpkgs/commit/c46f9d2a3c94f18671f1a2367161aa06a49bbf79) mozc: rename ibus-mozc -> mozc
* [`309fe2dd`](https://github.com/NixOS/nixpkgs/commit/309fe2dd49d6197abb6907cc7d0de5dfb2433cc8) mozc-ut: move to the top-level namespace
* [`08278f16`](https://github.com/NixOS/nixpkgs/commit/08278f16f8ed00d78ec3e549fa1e936cfcc77cf2) licenses: add naist-2003
* [`96df1422`](https://github.com/NixOS/nixpkgs/commit/96df1422108321d7b202dfbf5c476840eff20a1f) maintainers: add musjj
* [`85d7a2ab`](https://github.com/NixOS/nixpkgs/commit/85d7a2abf0332256d84977025f868c2f01d3c96a) fcitx5-mozc: 2.26.4220.102 -> 2.30.5544.102
* [`70724bf1`](https://github.com/NixOS/nixpkgs/commit/70724bf1c266250f547793945d6cc45d83dd1aa3) maintainers: add ElliottSullingeFarrall
* [`8aea7153`](https://github.com/NixOS/nixpkgs/commit/8aea7153f3f290e5d8ab45c483e428d81423078d) fcitx5-mozc: coalesce inherit statements
* [`f2095203`](https://github.com/NixOS/nixpkgs/commit/f2095203e66f1cf4d2fefcac4281ff9da5315a89) ddnet: 18.4 -> 18.6
* [`dd94c734`](https://github.com/NixOS/nixpkgs/commit/dd94c734bf9f9312e3913ca6bccae21ddb99a721) maintainers: add JulianFP
* [`1070635c`](https://github.com/NixOS/nixpkgs/commit/1070635c99b31871a60f367186a32ca28d71e09e) python312Packages.sphinx-mdinclude: fix build
* [`6ffc520d`](https://github.com/NixOS/nixpkgs/commit/6ffc520d0d6238340e097753b7f83273689c1430) python312Packages.sphinx-mdinclude: 0.6.1 -> 0.6.2
* [`750afb72`](https://github.com/NixOS/nixpkgs/commit/750afb7250756e56deddc15fff3754ba3642f3a8) lowdown: 1.1.0 -> 1.1.2
* [`936e9a7d`](https://github.com/NixOS/nixpkgs/commit/936e9a7d54554e32d72f2f3c5bf77fdeb1bf88d9) {fcitx5-mozc,fcitx5-mozc-ut}: move to by-name
* [`b8c08600`](https://github.com/NixOS/nixpkgs/commit/b8c086008602dcac53875e89c8aa0e3b46a65d20) mozc-ut: move to by-name
* [`ba0f4f4f`](https://github.com/NixOS/nixpkgs/commit/ba0f4f4fbec72cf638a6c5281607e5089941fc40) fcitx5-mozc: use cd instead of sourceRoot
* [`51742564`](https://github.com/NixOS/nixpkgs/commit/517425649e70b87be93da2acc62210f3c1251c34) zpaqfranz: 60.6 -> 60.7
* [`ca07e930`](https://github.com/NixOS/nixpkgs/commit/ca07e930b67652eb03efb9f0c8fdbf9f1d36efcb) nushellPlugins.query: fix homepage
* [`8c78777b`](https://github.com/NixOS/nixpkgs/commit/8c78777bac4d62bedb8905a6c6e527b2aebe7087) python312Packages.imgtool: remove
* [`f01b0b54`](https://github.com/NixOS/nixpkgs/commit/f01b0b546874dc34f1f0c98bbf595134946d9efa) python312Packages.urwid: fix build on Darwin
* [`981689dc`](https://github.com/NixOS/nixpkgs/commit/981689dc770aee144f4ffa5482a5b0547a2e73b7) ocamlPackages.printbox: 0.11 -> 0.12
* [`59ab5b9c`](https://github.com/NixOS/nixpkgs/commit/59ab5b9c5316a43369dfe3c5407bc267ffe2cf8b) rsop: init at 0.3.9
* [`8d26e1da`](https://github.com/NixOS/nixpkgs/commit/8d26e1dafc2cba4e98856575524309e493cdfe21) git-branchless: improve for cross compiling
* [`1f09ed79`](https://github.com/NixOS/nixpkgs/commit/1f09ed79a4fe5530880a9c6aa2f0ceba45bfbd36) libspatialite: added patch to wrap call to xmlNanoHTTPCleanup()
* [`fedeefb4`](https://github.com/NixOS/nixpkgs/commit/fedeefb48a62bd36f69ff7a0ed219ffa8c2d6356) libnvidia-container: move to pkgs/by-name
* [`b1380d98`](https://github.com/NixOS/nixpkgs/commit/b1380d98288e7f4d9e0293c0fae902b49d855b72) crystal: 1.11 -> 1.12
* [`1b2de2cb`](https://github.com/NixOS/nixpkgs/commit/1b2de2cbcf46b4953ebc60104e9f34781e98fdf7) crystalline: use llvm18 to match crystal 1.12
* [`cf6ea4f7`](https://github.com/NixOS/nixpkgs/commit/cf6ea4f75ec6eeecd1dcd805c0cb42bbeaee3e79) invidious: add patch to fix compile error
* [`90a79047`](https://github.com/NixOS/nixpkgs/commit/90a79047cdc5417de4d2fa6d39d14d47c391a65f) crystal: add missing versions to all-packages.nix
* [`0491852c`](https://github.com/NixOS/nixpkgs/commit/0491852c1a344b6117abffe3fabda45764b801fd) collision: mark as broken
* [`3bdb1b15`](https://github.com/NixOS/nixpkgs/commit/3bdb1b157ecb6f0985c28bdcfdff7a344946fbdf) crystal: 1.12.0 -> 1.12.1
* [`47c7b064`](https://github.com/NixOS/nixpkgs/commit/47c7b064069e30a43c8ee3845fbf19c48177c965) crystal: add llvmPackages passthru and use it for crystalline
* [`032dbc02`](https://github.com/NixOS/nixpkgs/commit/032dbc02dea0ed06777fdc28236cc5f9178979db) crystal: 1.12.1 -> 1.14.0
* [`e054656a`](https://github.com/NixOS/nixpkgs/commit/e054656aedf18c10ec63db9b2d7c1c6ebdd31ec9) daed: init at 0.8.0
* [`cafef48c`](https://github.com/NixOS/nixpkgs/commit/cafef48cf6bdcbbb64823f2b93ea06686e812fcc) tijolo: mark as broken
* [`b8b67383`](https://github.com/NixOS/nixpkgs/commit/b8b67383867765ec2317d920c6285379da494164) OWNERS: make the LLVM team own all of LLVM
* [`8bf94514`](https://github.com/NixOS/nixpkgs/commit/8bf9451413b020440e936e18215fb42ae0e4eb5a) python312Packages.llm: remove unused arguments
* [`5b04c7ae`](https://github.com/NixOS/nixpkgs/commit/5b04c7aec8a65ac828b5d32534168943336429b8) leetcode-cli: fix build failure on macOS
* [`fa5b1dad`](https://github.com/NixOS/nixpkgs/commit/fa5b1dad9f8842f4f4129506be696eea11e0726a) surfer: add darwin support
* [`3c8cbd83`](https://github.com/NixOS/nixpkgs/commit/3c8cbd830f2ae9e66257aa0c24773be241f0d273) babashka: 1.4.192 -> 1.12.194
* [`0eb7e098`](https://github.com/NixOS/nixpkgs/commit/0eb7e098fe24dade07604ad44a48c3a13f958000) turbo: don't redefine `name`
* [`565f972d`](https://github.com/NixOS/nixpkgs/commit/565f972dede14b6e68151503c3933034f5a41ac2) nixos/getty: add option to autologin once per boot, take 2
* [`ee1e5de4`](https://github.com/NixOS/nixpkgs/commit/ee1e5de4fa5a33b2451a816bd6ad27c762c5cc54) ocamlPackages.mlbdd: 0.7.2 -> 0.7.3
* [`2e1e7a11`](https://github.com/NixOS/nixpkgs/commit/2e1e7a11928d8e3ef39a4aab4a01f19bdc7c1ccf) ciano: remove arguments in top-level
* [`9799316c`](https://github.com/NixOS/nixpkgs/commit/9799316c9a2f56d7054285a541f4a2dc3b842da6) ciano: migrate to by-name
* [`476c490f`](https://github.com/NixOS/nixpkgs/commit/476c490fb2d4acaa199d2faf8e0f96a5db3b1e3b) ciano: refactor
* [`85236bb1`](https://github.com/NixOS/nixpkgs/commit/85236bb1736738911eea880b7526e2892c3a7b3f) linuxdoc-tools: 0.9.83 -> 0.9.85
* [`05347383`](https://github.com/NixOS/nixpkgs/commit/053473838f47d06c366db4c6aa9f0449b29b53b0) webdav: 5.3.0 -> 5.4.0
* [`4aa8864c`](https://github.com/NixOS/nixpkgs/commit/4aa8864c1ef8f715794c2685522fd41e7f980ebf) teams: create the stdenv team
* [`2d1fda71`](https://github.com/NixOS/nixpkgs/commit/2d1fda710cc2d76b6b3c8c1ff3a44419230ba46f) swayrbar: 0.3.8 -> 0.4.0
* [`60b56abc`](https://github.com/NixOS/nixpkgs/commit/60b56abc6df0c712626ac21f3f5ccbfaa5cff3c9) libnvidia-container: 1.9.0 -> 1.16.2
* [`3991c08b`](https://github.com/NixOS/nixpkgs/commit/3991c08bba40f3dabbe687c7198b15c95b59caba) ocamlPackages.gen_js_api: 1.1.2 -> 1.1.3
* [`c0678ef0`](https://github.com/NixOS/nixpkgs/commit/c0678ef0abe11b3e24b6b2b109cad156c654defa) guile-goblins: 0.13.0 -> 0.14.0
* [`280d1ac6`](https://github.com/NixOS/nixpkgs/commit/280d1ac6f9e9e79a1437926a923389e1408d41f6) libreswan: 5.0 -> 5.1
* [`797ff48e`](https://github.com/NixOS/nixpkgs/commit/797ff48ef55efc010647e017105e302ea83cb82d) libjcat: 0.2.1 -> 0.2.2
* [`73100244`](https://github.com/NixOS/nixpkgs/commit/731002442edb554b9c8874e3652758a5d12679fe) risor: 1.6.0 -> 1.7.0
* [`01a21114`](https://github.com/NixOS/nixpkgs/commit/01a21114cf4afa3a5269e8960f8ee2255c099272) polymake: 4.12 -> 4.13
* [`bd035939`](https://github.com/NixOS/nixpkgs/commit/bd0359397108fa4e5cce3053f7609de0204f4aa7) python3Packages.libarchive-c: apply patch fixing a test with recent `libarchive` versions
* [`56698b56`](https://github.com/NixOS/nixpkgs/commit/56698b568306357793c932dee01ee4b3d0e22aa6) git-branchless: 0.9.0 -> 0.10.0 & fix build
* [`64ec9ae3`](https://github.com/NixOS/nixpkgs/commit/64ec9ae3dcd9d1daaf9e7470343056ac09ecb577) switch-to-configuration-ng: remove unnecessary loop
* [`7c828e9e`](https://github.com/NixOS/nixpkgs/commit/7c828e9e1a2e6cc35813223839f582e9c7f2fe92) nixosTests.amazon-init-shell: test switching during amazon-init
* [`f30714a3`](https://github.com/NixOS/nixpkgs/commit/f30714a30e7dd0ab53f0735c82a316fa3355f979) maintainers: add shiphan
* [`d30181d9`](https://github.com/NixOS/nixpkgs/commit/d30181d974bad639f90a222d31791880caf0b090) halide: format using nixfmt
* [`19c1507d`](https://github.com/NixOS/nixpkgs/commit/19c1507d6db6b9a4ffd38bf2852df6afd8796c5b) halide: 16.0.0 -> 18.0.0
* [`a90f538e`](https://github.com/NixOS/nixpkgs/commit/a90f538e38bcb322b9a2b90ff0c43156d61b97ab) python3Packages.halide: init at 18.0.0
* [`79c77ab3`](https://github.com/NixOS/nixpkgs/commit/79c77ab335a8651c95797e3f5823e0c4ce9600d3) copilot-node-server: init at 1.41.0
* [`8d7be6e3`](https://github.com/NixOS/nixpkgs/commit/8d7be6e3d03e3fae0ec597a312681ab61f16b0a7) git-branchless: disable tests for now
* [`101d1229`](https://github.com/NixOS/nixpkgs/commit/101d12296da24436eaf2de7514c4693d11b86851) coturn: make setgroups conditional on privdrop codepath
* [`6d9089c6`](https://github.com/NixOS/nixpkgs/commit/6d9089c67dec1c62750f21b8fb2862e0e601f189) nixos/coturn: set up sandboxing
* [`72dd22a0`](https://github.com/NixOS/nixpkgs/commit/72dd22a02df88371c04216781acff3d55d2c2c03) nixos/coturn: reindent, unclutter
* [`4387ff61`](https://github.com/NixOS/nixpkgs/commit/4387ff6109e0bb0f966bd9645536a878c6277397) todoist-electron: 8.10.1 -> 9.8.0
* [`60b743d7`](https://github.com/NixOS/nixpkgs/commit/60b743d7430bc07b23634b3b27fbdcfc267a9b4b) linuxPackages.vmware: workstation-17.5.1-unstable-2024-01-12 -> workstation-17.6.1-unstable-2024-10-12
* [`aa642633`](https://github.com/NixOS/nixpkgs/commit/aa6426334a06196a50a50e76d5a871940f521c3c) vmware-workstation: 17.5.2 -> 17.6.1
* [`29a10b38`](https://github.com/NixOS/nixpkgs/commit/29a10b382139b954a65def44ff1091ebd3e37c9b) vmware-workstation: remove bundled guest tools
* [`af32e9af`](https://github.com/NixOS/nixpkgs/commit/af32e9affa26d9542464dd79de5338267a27add7) vmware-workstation: use system X11 libraries
* [`cf17e1ba`](https://github.com/NixOS/nixpkgs/commit/cf17e1ba7ddaff988a4da7907a693d8fa4c8e57c) mozillavpn: Fix build errors from Qt deprecations
* [`1d4fc452`](https://github.com/NixOS/nixpkgs/commit/1d4fc45269ca8fc86a0e479ff8b1434b246154b1) refurb: Disable another failing test
* [`41e2795f`](https://github.com/NixOS/nixpkgs/commit/41e2795fc758fdae1c8c4f0b122dc623cc9973cf) i2p: 2.6.1 -> 2.7.0
* [`3ac13c9f`](https://github.com/NixOS/nixpkgs/commit/3ac13c9fc7c60f55844d2c9fa030c34272bfa67b) psst: 2024-08-19 -> 2024-10-07
* [`d98c0dae`](https://github.com/NixOS/nixpkgs/commit/d98c0dae15b907be59110a80efeef1aca2a31b06) geonkick: 3.4.0 -> 3.5.0
* [`3048009d`](https://github.com/NixOS/nixpkgs/commit/3048009dd5342a7d00d35fb294d5d1abefd6c49f) python312Packages.weasel: 0.3.4 -> 0.4.1
* [`db1b484d`](https://github.com/NixOS/nixpkgs/commit/db1b484d986440256b32c898dd44985bf98401c0) flake.nix: exclude armv6-linux and riscv64-linux from checks
* [`ccb77978`](https://github.com/NixOS/nixpkgs/commit/ccb779782ccb471954971697fcdf1c2331cd906b) flake.nix: exclude armv6-linux, riscv64-linux, and FreeBSD from devShells
* [`705fdd9c`](https://github.com/NixOS/nixpkgs/commit/705fdd9ccc0f8dccade08344cdfb75593b7f91d0) ci/basic-eval: check that flake outputs are valid
* [`42b355a9`](https://github.com/NixOS/nixpkgs/commit/42b355a90833c1706076a03f5b263bd6141958da) artalk: 2.9.0 -> 2.9.1
* [`41e9182e`](https://github.com/NixOS/nixpkgs/commit/41e9182e5ae32322040ba4399d9a6e7621fd463d) python312Packages.pykcs11: 1.5.16 -> 1.5.17
* [`ffd457a5`](https://github.com/NixOS/nixpkgs/commit/ffd457a522bc492d66449833a82d6062e5df5e07) tensorrt: fix cudnn version
* [`675e3bc1`](https://github.com/NixOS/nixpkgs/commit/675e3bc1e66fd90b5d0fb30b9e6abf9ee559d82c) mise: move to by-name
* [`46be6039`](https://github.com/NixOS/nixpkgs/commit/46be6039f5e225645f1aedd39806ea05f88a22ff) cog: add missing meta attributes
* [`0f4f56b4`](https://github.com/NixOS/nixpkgs/commit/0f4f56b43f3aefb378d5c65802171a59d0d3515e) patch-package: migrate from nodePackages
* [`73b46d8e`](https://github.com/NixOS/nixpkgs/commit/73b46d8e7ff4fdf7bc5fcdd6011827c7da98f9f1) nltk-data: add wordnet
* [`3ffe79b4`](https://github.com/NixOS/nixpkgs/commit/3ffe79b4f21e0eb451626c4dc92ef5c4e8a94935) codeberg-cli: 0.4.2 -> 0.4.3
* [`34b7d209`](https://github.com/NixOS/nixpkgs/commit/34b7d209bb3c5431971722f9617a246a7061f3c0) nodejs/importNpmLock: init source overrides option
* [`9f766d18`](https://github.com/NixOS/nixpkgs/commit/9f766d186d83d390acc1eaf8d9685143588362bf) fcitx5-mcbopomofo: init at 2.7
* [`04f01018`](https://github.com/NixOS/nixpkgs/commit/04f0101890c827877f4c1922dd56ec68809ba78f) keycloak: 26.0.0 -> 26.0.1
* [`804e3cb3`](https://github.com/NixOS/nixpkgs/commit/804e3cb3099bdea7886888f3f6cb5cfa7f4abfef) python312Packages.dask-expr: 1.1.15 -> 1.1.16
* [`4c053e52`](https://github.com/NixOS/nixpkgs/commit/4c053e522f112bb34fa8890b7d5243f927d1b896) python312Packages.dask: 2024.9.1 -> 2024.10.0
* [`25b14c63`](https://github.com/NixOS/nixpkgs/commit/25b14c631711e0ae9564aaf49cea6d178e5dba14) python312Packages.distributed: 2024.9.1 -> 2024.10.0
* [`a76c4c2e`](https://github.com/NixOS/nixpkgs/commit/a76c4c2efbbf7663505f43bb5c281467753ab0cb) perlPackages.meta: init at 0.012
* [`dc5a8706`](https://github.com/NixOS/nixpkgs/commit/dc5a8706200d94f37e39648f02f2a5d5740a06b5) keycloak: remove kc.sh.orig
* [`fc6f12b9`](https://github.com/NixOS/nixpkgs/commit/fc6f12b97848aec765ee84f0dfdc110851024316) greetd.tuigreet: add man page
* [`b7bf99ac`](https://github.com/NixOS/nixpkgs/commit/b7bf99ac5030fe6bd6c33bf5a4616bbafc4f6b12) abiword: use a live src
* [`da95559c`](https://github.com/NixOS/nixpkgs/commit/da95559c54ba2477224764e0444a228d8b222842) python312Packages.databricks-sdk: 0.34.0 -> 0.35.0
* [`e076ca33`](https://github.com/NixOS/nixpkgs/commit/e076ca3343d8c870c30174a2ce80f005633c3679) python312Packages.pysigma: 0.11.14 -> 0.11.17
* [`b1f1ea0e`](https://github.com/NixOS/nixpkgs/commit/b1f1ea0ed4a2ffe35b89419ec085f173606c9365) gaucheBootstrap: fix darwin build
* [`79d29ca7`](https://github.com/NixOS/nixpkgs/commit/79d29ca79e068aa4cebd148aa03814ca84a23735) gshogi: fix double wrapping
* [`8b2c339c`](https://github.com/NixOS/nixpkgs/commit/8b2c339cbceb2375abc8dbdbad4fe8e0f2110794) erlang: 25.3.2.13 -> 25.3.2.15
* [`b66c26bd`](https://github.com/NixOS/nixpkgs/commit/b66c26bd3ebc4e36012b5f73632f15f013295542) erlang_26: 26.2.5.1 -> 26.2.5.4
* [`e7d44d66`](https://github.com/NixOS/nixpkgs/commit/e7d44d664c11f8baec82a1251b523de2467c50c3) erlang_27: 27.0.1 -> 27.1.2
* [`0b7becdc`](https://github.com/NixOS/nixpkgs/commit/0b7becdccbc9f2b2b47ca49ac73932062ba28877) appgate-sdp: 6.3.2 -> 6.4.0
* [`8dac8f7b`](https://github.com/NixOS/nixpkgs/commit/8dac8f7bb297c4c0cd37e9837a37dbf3445a31a2) CONTRIBUTING: add practical advice section heading
* [`9e0e8837`](https://github.com/NixOS/nixpkgs/commit/9e0e8837de55759c8ac77bab28c66b7380bef2d2) bitwig-studio: 5.2.4 -> 5.2.5
* [`0b970852`](https://github.com/NixOS/nixpkgs/commit/0b970852975e2d79216f747107d370823fab7134) python3Packages.proton-core: 0.2.0 -> 0.3.3
* [`20792493`](https://github.com/NixOS/nixpkgs/commit/20792493c79ecc91d1bca8330377e5a27cd37718) python3Packages.proton-vpn-api-core: 0.32.2 -> 0.35.5
* [`ef3b0b0b`](https://github.com/NixOS/nixpkgs/commit/ef3b0b0b7e4ed28d17fbab27f497d352dc4d6ec2) python3Packages.proton-vpn-network-manager: 0.5.2 -> 0.9.1
* [`e26315c7`](https://github.com/NixOS/nixpkgs/commit/e26315c72a9fa7d3bcb24110c4c054c4b9d08a7b) python3Packages.proton-keyring-linux: 0.0.2 -> 0.1.0
* [`74cdad8a`](https://github.com/NixOS/nixpkgs/commit/74cdad8aa811a70dc782b87991bfb874b2b50e20) protonvpn-gui: 4.4.4 -> 4.6.0, deprecate obsolete dependencies
* [`ef18a2aa`](https://github.com/NixOS/nixpkgs/commit/ef18a2aa00a556f84121697511925745b4fe82f4) atlas: 0.28.0 -> 0.28.1
* [`ad9a406b`](https://github.com/NixOS/nixpkgs/commit/ad9a406b92b3dd052efcbab6fa2101ee44fa66d0) clang-analyzer: use current LLVM version
* [`00e1112f`](https://github.com/NixOS/nixpkgs/commit/00e1112f9b7b14bc1b10fdbf7e9b6e6b080dc4d6) nixos/docker-registry: fix extraConfig docs
* [`7e45a0e6`](https://github.com/NixOS/nixpkgs/commit/7e45a0e6d86d06548d69489d20b702b28979dbd9) uiua: add webcamSupport option
* [`df4ed58e`](https://github.com/NixOS/nixpkgs/commit/df4ed58e097d344751b8ac6da547135fdde8c1fb) jmol: 16.2.21 -> 16.3.1
* [`88b285c0`](https://github.com/NixOS/nixpkgs/commit/88b285c01d84de82c0b2b052fd28eaf6709c2d26) nixos/virtualisation: format image-related files
* [`6071ee8e`](https://github.com/NixOS/nixpkgs/commit/6071ee8e31ae3c51dee1204efa14ae0b1999f40d) .git-blame-ignore-revs: add image files formatting
* [`096186d8`](https://github.com/NixOS/nixpkgs/commit/096186d8744c8c69d4b9f71374ca76ac4e97ab88) glycin-loaders: 1.0.1 -> 1.1.1
* [`60d00382`](https://github.com/NixOS/nixpkgs/commit/60d00382ce034aeadbf87ecd826605afd2328826) erlang_27: 27.0.1 -> 27.1.2
* [`e87d07a5`](https://github.com/NixOS/nixpkgs/commit/e87d07a533c368653802762555a9879759b21640) linux_xanmod: 6.6.56 -> 6.6.57
* [`8b38a2bc`](https://github.com/NixOS/nixpkgs/commit/8b38a2bc3c4d66008f7fc3fd81b1c5f26b656052) linux_xanmod_latest: 6.11.3 -> 6.11.4
* [`2406a9f8`](https://github.com/NixOS/nixpkgs/commit/2406a9f8441f569c24e88c89eadeddbf747d8cb5) librealsense-gui: 2.56.1 -> 2.56.2
* [`bd4bd872`](https://github.com/NixOS/nixpkgs/commit/bd4bd87293adbd04bbd89a7a09086e03388000b1) mbedtls: 3.6.1 -> 3.6.2
* [`292e87f3`](https://github.com/NixOS/nixpkgs/commit/292e87f32de220c9629b71db6fbe4a00e8fcf258) talosctl: 1.8.0 -> 1.8.1
* [`00434af5`](https://github.com/NixOS/nixpkgs/commit/00434af50777422d9225f1eccbb33b1ff3dd82e5) fasmg: add updateScript
* [`8639e252`](https://github.com/NixOS/nixpkgs/commit/8639e25284fa4b45cb7c115ee82aa7b171b64b5b) fasmg: kd3c -> kl0e
* [`4d9b9d26`](https://github.com/NixOS/nixpkgs/commit/4d9b9d26f46d63484364964defcf0d2ad4a471f9) gpu-screen-recorder: 4.2.1 -> 4.2.3
* [`4b6c6a8d`](https://github.com/NixOS/nixpkgs/commit/4b6c6a8df53db4b5de58ebb27e1ffa5b145e1ca9) gpu-screen-recorder-gtk: 4.2.1 -> 4.2.3
* [`21b5e29b`](https://github.com/NixOS/nixpkgs/commit/21b5e29b6e88bf30530c1dd45867d493851dd61e) signal-desktop-beta: 7.30.0-beta.1 -> 7.30.0-beta.2
* [`d8720e0f`](https://github.com/NixOS/nixpkgs/commit/d8720e0fa84ee55091551a6897a828acb49ea25d) python312Packages.pdoc: 14.7.0 -> 15.0.0
* [`2e4867bd`](https://github.com/NixOS/nixpkgs/commit/2e4867bddf4f75a09ddb75f8af7bf9af070477ea) ovn: 24.09.0 -> 24.09.1
* [`56ec5e83`](https://github.com/NixOS/nixpkgs/commit/56ec5e83a4c55f5be5ded75640106b736d1444cf) audiobookshelf: 2.15.0 -> 2.15.1
* [`67f3b2a2`](https://github.com/NixOS/nixpkgs/commit/67f3b2a27a8b358baf093a459cd77ddf0d97a974) kakoune-lsp: 17.1.2 -> 18.0.2
* [`46e450fc`](https://github.com/NixOS/nixpkgs/commit/46e450fce8b99fed1397db6b1840059c791143ac) tailspin: 3.0.2 -> 4.0.0
* [`b7069ab4`](https://github.com/NixOS/nixpkgs/commit/b7069ab41620814f6260ebdf9e428f81d17d3d23) watchexec: 2.1.2 -> 2.2.0
* [`2c7dcb08`](https://github.com/NixOS/nixpkgs/commit/2c7dcb08142717a936d9eb03e78a726df3631608) kubectl-cnpg: 1.24.0 -> 1.24.1
* [`e4b96adc`](https://github.com/NixOS/nixpkgs/commit/e4b96adcc66ee33364c07fe3e1f032355a09416b) novops: 0.16.0 -> 0.17.0
* [`297f21e3`](https://github.com/NixOS/nixpkgs/commit/297f21e357b63ca45814467824e61c48e1d610fa) nixos/ntpd: format with nixfmt-rfc-style
* [`b4e0067f`](https://github.com/NixOS/nixpkgs/commit/b4e0067f779db39a9369deea35da84e76f0928e1) broot: 1.44.0 -> 1.44.1
* [`a9796586`](https://github.com/NixOS/nixpkgs/commit/a97965860486b2b8e5846b80a73b11af3256bcab) msedgedriver: init at 130.0.2849.1
* [`2b591c18`](https://github.com/NixOS/nixpkgs/commit/2b591c18e82b8807c69bfaefe0c9d5e514f79bbf) opnborg: init at v0.1.2
* [`191301f1`](https://github.com/NixOS/nixpkgs/commit/191301f12196ae3d424f40712e635c70f760c332) python312Packages.ydata-profiling: 4.10.0 -> 4.11.0
* [`105d59fd`](https://github.com/NixOS/nixpkgs/commit/105d59fd6a3a62975648f1a68800b7876e75cc95) open-watcom-v2: 0-unstable-2024-05-14 -> 0-unstable-2024-10-13
* [`56f3a518`](https://github.com/NixOS/nixpkgs/commit/56f3a51846e0cca0baea2755267770c59b743f53) gbenchmark: fix cross compilation
* [`ad01adae`](https://github.com/NixOS/nixpkgs/commit/ad01adae67f8e5f2111ffb6f15288c0e8468d18d) tuifimanager: 4.1.7 -> 5.0.0
* [`65dc12ea`](https://github.com/NixOS/nixpkgs/commit/65dc12ea22599727459e121b7a0741be3a2392e8) visidata: 3.0.2 -> 3.1.1
* [`8c64772d`](https://github.com/NixOS/nixpkgs/commit/8c64772d13ce2b36997412dc421f634e9af5a827) visidata: newScope -> python3Packages.callPackage
* [`461cc3b8`](https://github.com/NixOS/nixpkgs/commit/461cc3b854da17cb8c6bc8c8b4cfc844b1b1ef68) python312Packages.smbus2: 0.4.3 -> 0.5.0
* [`98b70abd`](https://github.com/NixOS/nixpkgs/commit/98b70abd0b12662a2ff64ddc2beec9b6f924d6a4) waveterm: 0.8.10 -> 0.8.12
* [`ed5bbede`](https://github.com/NixOS/nixpkgs/commit/ed5bbede063e2e5322aca1e2b177e4030622cdfa) livekit: 1.7.2 -> 1.8.0
* [`64ef9469`](https://github.com/NixOS/nixpkgs/commit/64ef94693a590877987f4752b2b7dc59fdd1714c) guile-ssh: 0.16.3 -> 0.17.0-unstable-2024-10-15
* [`27a3bf03`](https://github.com/NixOS/nixpkgs/commit/27a3bf032506f24054d422b81673257cae56bccd) keyguard: 1.6.2 -> 1.6.3
* [`1f1b1ba8`](https://github.com/NixOS/nixpkgs/commit/1f1b1ba8cfd1a4bfbfead420986da465c8657355) pop-launcher: 1.2.1 -> 1.2.4
* [`53bc9450`](https://github.com/NixOS/nixpkgs/commit/53bc9450bceb1252177997e1f88e1b4087271a7e) nixos/ntpd: Use StateDirectory instead of a preStart script
* [`d98f11e9`](https://github.com/NixOS/nixpkgs/commit/d98f11e96f78d4249212656994d4c48cd6ea31ad) switch-to-configuration-ng: improve user experience
* [`4e632e9c`](https://github.com/NixOS/nixpkgs/commit/4e632e9c3fe0b3a09eb9e8506df911583ab845df) nixos/ntpd: Add hardening
* [`19c40f0e`](https://github.com/NixOS/nixpkgs/commit/19c40f0e11f39b8a5abb0eeb53415932474e00ae) nixos/tests/ntpd: init
* [`4b93fe87`](https://github.com/NixOS/nixpkgs/commit/4b93fe87b34dc59995084db0284d9e5dfbbb4d6f) openjump: 2.2.1 → 2.3.0
* [`286a40b2`](https://github.com/NixOS/nixpkgs/commit/286a40b27cdd1e220984701361aa07f6a17168ed) viewnior: switch to a pr which combines other PRs
* [`ff4392fd`](https://github.com/NixOS/nixpkgs/commit/ff4392fdb80babd44342ddadcc26fd57c49d338c) hyprshot: include hyprpicker optional dependency
* [`8becdcf6`](https://github.com/NixOS/nixpkgs/commit/8becdcf6cc94892310f11b0e26caa5fb36b546b8) quantlib: 1.35 -> 1.36
* [`863d9730`](https://github.com/NixOS/nixpkgs/commit/863d9730607e9773b96d55da9e73bcd44e552dc9) libkrunfw: 4.4.1 -> 4.4.2
* [`3f514ca3`](https://github.com/NixOS/nixpkgs/commit/3f514ca30871c30d059d611398a2a16de3776cef) maintainers: add ivyfanchiang
* [`6be8cf55`](https://github.com/NixOS/nixpkgs/commit/6be8cf551ba6abb97d1c2c7c00b8e7786df41429) python312Packages.cryptg: 0.4 -> 0.5
* [`239b78ef`](https://github.com/NixOS/nixpkgs/commit/239b78ef5d673b1e039fcbeffa9c482b9851f988) python312Packages.edk2-pytool-library: 0.21.12 -> 0.22.2
* [`2d852e6c`](https://github.com/NixOS/nixpkgs/commit/2d852e6c0a390b843871869ae8f0277968d5cfad) vscode-extensions.biomejs.biome: 2024.5.251958 -> 2024.10.131712
* [`f18df6b1`](https://github.com/NixOS/nixpkgs/commit/f18df6b1e96b3d5fb2fcf66cc5d83e617390dc8e) libvgm: 0-unstable-2024-06-08 -> 0-unstable-2024-10-17
* [`e07c407e`](https://github.com/NixOS/nixpkgs/commit/e07c407e6b835c40be7b10dc384680041dedb086) libvgm: Modernise
* [`e1e4c0f4`](https://github.com/NixOS/nixpkgs/commit/e1e4c0f4743c5c3ddc9eb0d78a0075a1664ecc39) shpool: 0.7.1 -> 0.8.0
* [`ed18fab6`](https://github.com/NixOS/nixpkgs/commit/ed18fab640e343bbee1afe81569e5e6d83fcf15a) corefreq: init at 1.98.4
* [`dcc8b99d`](https://github.com/NixOS/nixpkgs/commit/dcc8b99d856d77d373cd4c0ec88329e5bfb042b6) nixos/corefreq: add program defining both the daemon service and its kernel module
* [`9711acd3`](https://github.com/NixOS/nixpkgs/commit/9711acd3dc611ba139f625a82bee58179d9aaae0) obfs4: 0.1.0 -> 0.4.0
* [`bd514933`](https://github.com/NixOS/nixpkgs/commit/bd5149334f8208b463f4070a94fbd60fe9c865cf) altair: 7.3.6 -> 8.0.0
* [`0e711c55`](https://github.com/NixOS/nixpkgs/commit/0e711c555fe4893a7d68f1d61a694d8036ee9d53) python312Packages.google-nest-sdm: 5.0.1 -> 6.1.0
* [`28512828`](https://github.com/NixOS/nixpkgs/commit/28512828bb6a4acf098d6bb94b985c7e088b44df) zef: 0.22.2 -> 0.22.4
* [`275032b7`](https://github.com/NixOS/nixpkgs/commit/275032b756da76d67809c21892d6ff651f94d282) step-kms-plugin: 0.11.5 -> 0.11.6
* [`99f3585b`](https://github.com/NixOS/nixpkgs/commit/99f3585b04b4b6794660c081eaadb0c32d7ff1d2) nexttrace: 1.3.4 -> 1.3.5
* [`3db4a167`](https://github.com/NixOS/nixpkgs/commit/3db4a167080bf3b393f5c21934cd01b863a98bf4) misconfig-mapper: 1.9.0 -> 1.10.0
* [`c1a2fb1e`](https://github.com/NixOS/nixpkgs/commit/c1a2fb1eb220c4bf5f7e887453c7bf3221fe4f1d) halo: 2.19.3 -> 2.20.5
* [`0c066a94`](https://github.com/NixOS/nixpkgs/commit/0c066a943d083a766531ea56c7747d501a34e6d5) zsh-wd: 0.9.0 -> 0.9.1
* [`a2f7f46b`](https://github.com/NixOS/nixpkgs/commit/a2f7f46b671bca91d656391b5e7b4d4cd7511e50) dpp: 10.0.31 -> 10.0.32
* [`d17b5e24`](https://github.com/NixOS/nixpkgs/commit/d17b5e240e5eb3075abfa8d694a87a33f5a97d76) fluidd: 1.30.4 -> 1.30.5
* [`55dc8a5a`](https://github.com/NixOS/nixpkgs/commit/55dc8a5a78c11700a9be8bd2c420a25c3f943dc6) opengrok: 1.13.22 -> 1.13.23
* [`5dbcb9e7`](https://github.com/NixOS/nixpkgs/commit/5dbcb9e762a3e5e56282401772f55ef51617eced) flix: 0.51.0 -> 0.52.0
* [`bdf394a9`](https://github.com/NixOS/nixpkgs/commit/bdf394a90441cbe2508c681b471c2cd89c7e458b) nats-server: 2.10.21 -> 2.10.22
* [`c687c5fe`](https://github.com/NixOS/nixpkgs/commit/c687c5fe4c5d6bf0de94a3c16cfe6c1d79ffba4a) journalist: 1.0.0-unstable-2024-06-15 -> 1.0.1
* [`5534d77d`](https://github.com/NixOS/nixpkgs/commit/5534d77dbce128519dc1a8c56bd840432a744395) orchard: 0.24.0 -> 0.24.1
* [`45e21d7f`](https://github.com/NixOS/nixpkgs/commit/45e21d7f2cfae7353f1c15e9f9e1c9a48f1e9f60) pupdate: 3.18.0 -> 3.19.0
* [`9e8b94af`](https://github.com/NixOS/nixpkgs/commit/9e8b94af3dd62fdd48dcc4523859de75ea3dd31e) youtrack: 2024.2.41254 -> 2024.3.47197
* [`ae7f1f62`](https://github.com/NixOS/nixpkgs/commit/ae7f1f629256543e082d99aa610f0d65d27b7445) paper-clip: 5.5 -> 5.5.1
* [`e29134d8`](https://github.com/NixOS/nixpkgs/commit/e29134d8f6a5f9ff2e4264e42b12abd64d38baeb) python312Packages.basemap-data-hires: init at 1.4.1
* [`7cce8cc2`](https://github.com/NixOS/nixpkgs/commit/7cce8cc2a2a6f1cdf00dd45762beaf0d5b1c61ea) vimPlugins.nvim-gomove: init at 2024-10-20
* [`c922656d`](https://github.com/NixOS/nixpkgs/commit/c922656df46209719c88d80a9efe40370896e568) python312Packages.lcd-i2c: refactor
* [`a7ad1c18`](https://github.com/NixOS/nixpkgs/commit/a7ad1c182b0452bdb62dda9994a9562ec0cc6119) tlsinfo: init at 0.1.41
* [`e656ac40`](https://github.com/NixOS/nixpkgs/commit/e656ac409b8e8ea58f27f5c009c0a1358c6bba86) graphpython: init at 1.0-unstable-2024-07-28
* [`c1be8ddb`](https://github.com/NixOS/nixpkgs/commit/c1be8ddb34c5bdb2adda4e3f9dff2f8b5fe43c08) live-chart: init at 1.10.0
* [`048692c8`](https://github.com/NixOS/nixpkgs/commit/048692c8c01d9dfe8380e36796a43fabda063f94) ryokucha: init at 0.3.1
* [`19524b4d`](https://github.com/NixOS/nixpkgs/commit/19524b4d3586ab6600463a92a1f5bfbe65e70e50) reco: init at 5.0.2
* [`97c0dab6`](https://github.com/NixOS/nixpkgs/commit/97c0dab613b453358267bd2786dfb8baa37552ee) gearlever: 2.0.7 -> 2.1.0
* [`0b1caae8`](https://github.com/NixOS/nixpkgs/commit/0b1caae80afd7f34e38a2546b09fa7b7e09e3516) vimPlugins.align-nvim: init at 2024-10-20
* [`6d3f0573`](https://github.com/NixOS/nixpkgs/commit/6d3f057365a40895b22c9b5eff5be34b8fb89d8b) tomlplusplus: format code
* [`7556940b`](https://github.com/NixOS/nixpkgs/commit/7556940b5e194df737127401df7710f68a106720) tomlplusplus: add pkg-config test
* [`2d09cfe3`](https://github.com/NixOS/nixpkgs/commit/2d09cfe396252cdde960e3e484dcd0b442b2e3a4) tomlplusplus: add update script
* [`40100a58`](https://github.com/NixOS/nixpkgs/commit/40100a5851e4cdc4c0ab593a514a6505ab1e3308) tomlplusplus: enable checks
* [`dea4c289`](https://github.com/NixOS/nixpkgs/commit/dea4c28928fd9ffe665788b9484869a92cfe2c86) tomlplusplus: build example programs
* [`4af69f9c`](https://github.com/NixOS/nixpkgs/commit/4af69f9c3a037ea8816ca28a9c3085578ce855d1) tomlplusplus: move to by-name
* [`d642ec93`](https://github.com/NixOS/nixpkgs/commit/d642ec93cfddfbc7cfb5d8e021470c2e8aad4f63) vimPlugins.focus-nvim: init at 2024-10-20
* [`b0cf086e`](https://github.com/NixOS/nixpkgs/commit/b0cf086efe870b26963e916a5e0afcadfc8a44ff) zsync2: init at 2.0.0-alpha-1-20230304
* [`5577994e`](https://github.com/NixOS/nixpkgs/commit/5577994ed4b1ea4dc9b2e48dabd5a86af3e62af1) nhost-cli: 1.24.0 -> 1.24.5
* [`5ab59cff`](https://github.com/NixOS/nixpkgs/commit/5ab59cff363f8cada0024d274b950c55549fbca7) appimageupdate: init at 2.0.0-alpha-1-20230526
* [`e63282de`](https://github.com/NixOS/nixpkgs/commit/e63282de01db7f71182b25992b128f8d634165f1) fluidd: update src.url
* [`ff9e913d`](https://github.com/NixOS/nixpkgs/commit/ff9e913d0b44689d5acbca871fdc2c6fcf0beade) vscode-extensions.vscode-icons-team.vscode-icons: 12.8.0 -> 12.9.0
* [`936ac723`](https://github.com/NixOS/nixpkgs/commit/936ac723b490185ce89b3db0f809b5a3cfe9d184) rshim-user-space: 2.0.32 -> 2.1.5
* [`f00ef5e5`](https://github.com/NixOS/nixpkgs/commit/f00ef5e5b8262693be331fe59000e66b146c8501) makehuman: 1.2.0 -> 1.3.0
* [`93df0d6b`](https://github.com/NixOS/nixpkgs/commit/93df0d6b308a821cfd3a433364f441224f48f0f4) maintainers: add PapayaJackal
* [`9ed7d6f6`](https://github.com/NixOS/nixpkgs/commit/9ed7d6f6eb02b5e3c4a67e8b3954d2b0dceded3c) pleroma: support darwin
* [`fe60e66a`](https://github.com/NixOS/nixpkgs/commit/fe60e66a65a67d44b5118e21af72d938efcb9d70) air: 1.52.3 -> 1.61.1
* [`1ff2ed56`](https://github.com/NixOS/nixpkgs/commit/1ff2ed566f43bf4d75a019c1a9bf0daed6bc9276) vscode-extensions: remove `uncenter` from maintaining extensions
* [`41673e40`](https://github.com/NixOS/nixpkgs/commit/41673e40a80e47953b0f78903e45928df6c5cecc) router: 1.55.0 -> 1.56.0
* [`2370c67b`](https://github.com/NixOS/nixpkgs/commit/2370c67b409da4f80db0701611db134d3a2afd46) sioyek: add qtwayland to buildInputs
* [`33283c8e`](https://github.com/NixOS/nixpkgs/commit/33283c8e665b2ddf9184f5a3f53358015dd28485) coyim: add maintainer
* [`877334ef`](https://github.com/NixOS/nixpkgs/commit/877334ef365a950747056e0c520e26b66be3bb79) coyim: nixfmt
* [`891a68c7`](https://github.com/NixOS/nixpkgs/commit/891a68c792c39a94649621e9b4c49a82b2d7b5ee) fcitx5-pinyin-moegirl: 20240909 -> 20241009
* [`245e5da5`](https://github.com/NixOS/nixpkgs/commit/245e5da5ec2a40e97628a552723ccfd2b7ad44e0) icu: add opt-in support to build icu release candidates
* [`2ac5b1b4`](https://github.com/NixOS/nixpkgs/commit/2ac5b1b494d61465d8a5b0c9f48278cc26745fb1) icu76: init at 76.1rc
* [`e0605c03`](https://github.com/NixOS/nixpkgs/commit/e0605c03698f978e8b67ed899e5920e3787c1be8) bcache-tools: fix udev patch to use bash from explicit path
* [`ade8ce43`](https://github.com/NixOS/nixpkgs/commit/ade8ce43697cf9088e4d5fbfa38b714eae499051) ice-bar: 0.11.9 -> 0.11.11
* [`2cdd2796`](https://github.com/NixOS/nixpkgs/commit/2cdd2796cb8a2c705eed65662ddeecda631cf777) git-extras: 7.2.0 -> 7.3.0
* [`f6ccf622`](https://github.com/NixOS/nixpkgs/commit/f6ccf622b5a1ab9d36d1bd960fb72c28e0a47abd) pulsar: 1.121.0 -> 1.122.0
* [`ca733c42`](https://github.com/NixOS/nixpkgs/commit/ca733c424fd556bb4650a32b85352d66f9eee84d) ovito: 3.7.11 -> 3.11.0
* [`ff43d55f`](https://github.com/NixOS/nixpkgs/commit/ff43d55fd4033ba0ef57ffceffd5497cf5456ba5) immich: 1.118.1 -> 1.118.2
* [`1efb386d`](https://github.com/NixOS/nixpkgs/commit/1efb386d68a53cff7dddae20b3aaba69547dc422) python312Packages.albumentations: don't check for updates
* [`080adc46`](https://github.com/NixOS/nixpkgs/commit/080adc466f1cf4fe279cfc03e6e2cc0b40f7c6a2) imhex: unpin fmt
* [`eb4dfb90`](https://github.com/NixOS/nixpkgs/commit/eb4dfb90a602c5d353a0123f4d1c4c1705c59be0) furnace: unpin fmt
* [`5cdff541`](https://github.com/NixOS/nixpkgs/commit/5cdff541c3fdb0a0888693254bebd6524e757db8) zig: fix cache folder handling
* [`4592e9f5`](https://github.com/NixOS/nixpkgs/commit/4592e9f5c16110bee7f6d020abda5240532ca127) README.md: mention that → can be used to signal version upgrades
* [`98297f0b`](https://github.com/NixOS/nixpkgs/commit/98297f0bf45c6cbbe622bca819d3639935d76dba) archi: bugfix - added missing glib
* [`c3a8a2ad`](https://github.com/NixOS/nixpkgs/commit/c3a8a2ad62f19366ae8d8f04cb8d4c8a03413f77) python311Packages.pyct: modernize
* [`b453927e`](https://github.com/NixOS/nixpkgs/commit/b453927e0134dc50daaeb359a39416ae43a63566) python312Packages.pyct: enable
* [`ef4756a5`](https://github.com/NixOS/nixpkgs/commit/ef4756a52a748cec5eedf944497f3e19a0bd1cfd) python312Packages.pyvex: 9.2.122 -> 9.2.123
* [`3a424b8d`](https://github.com/NixOS/nixpkgs/commit/3a424b8d3d7473298f84f57b77d0bed2c92a1e06) python312Packages.albumentations: 1.4.17 -> 1.4.18
* [`40a4bd08`](https://github.com/NixOS/nixpkgs/commit/40a4bd08fe59dd3c24807b28b19cecbcd48d5bc4) viewnior: add webp support
* [`e547a1fe`](https://github.com/NixOS/nixpkgs/commit/e547a1fe90d236401b1cbd98f1948a46caaab255) viewnior: Use x11
* [`e0490b14`](https://github.com/NixOS/nixpkgs/commit/e0490b14aebb8cbd64dca91d291551269241f675) python312Packages.hvplot: 0.10.0 -> 0.11.1
* [`6e6fc8e9`](https://github.com/NixOS/nixpkgs/commit/6e6fc8e967a85d32f09ba4e9c49c7e3346719668) tomlplusplus: fix nits
* [`1fc1fb51`](https://github.com/NixOS/nixpkgs/commit/1fc1fb51e7a78a276d53f77c0eb9816999d236ad) python312Packages.hiyapyco: 0.6.1 -> 0.7.0
* [`d586a185`](https://github.com/NixOS/nixpkgs/commit/d586a185ffd5f0810c166ae1961bb4f4d0c04316) wyoming-fastper-whisper: 2.1.0 -> 2.2.0
* [`97b7c11d`](https://github.com/NixOS/nixpkgs/commit/97b7c11d88610721a346913aecc3a26cbdf30eb4) python312Modules.faster-whisper: 1.0.3 -> unstable-2024-07-26
* [`b6cb0d1d`](https://github.com/NixOS/nixpkgs/commit/b6cb0d1d07b82a4cad0ba3e1d866a3ad20b158b9) release-notes-24.11/zapret: fix path to option
* [`1cd19c7a`](https://github.com/NixOS/nixpkgs/commit/1cd19c7ac46711ba34c33a9417b8d536c093c792) python312Packages.holoview: order inputs; no with lib; in meta
* [`45d55e1d`](https://github.com/NixOS/nixpkgs/commit/45d55e1d2086536191acb4c7005b1011b7f948fd) python312Packages.holoview: enable tests
* [`84cdacd3`](https://github.com/NixOS/nixpkgs/commit/84cdacd319e469aa7db108c092c3b78adddaa4a7) python312Packages.hvplot: order inputs; no with lib; in meta
* [`72ddbd5c`](https://github.com/NixOS/nixpkgs/commit/72ddbd5caeb228e53a7c0018aee828c594139f60) python31{1,2}Packages.bokeh-sampledata: init at 2024.2
* [`3b43bfd3`](https://github.com/NixOS/nixpkgs/commit/3b43bfd340ad531bcc14b60cf3ae1321c252cf5c) python31{1,2}Packages.hvplot: enable (most) tests
* [`f44371fc`](https://github.com/NixOS/nixpkgs/commit/f44371fc15d2733d63e78c009b4f905523525bc4) home-assistant-custom-lovelace-modules.universal-remote-card: 4.1.0 -> 4.1.1
* [`0b0cbe18`](https://github.com/NixOS/nixpkgs/commit/0b0cbe18c613ae96f0947eaad7166ea42f5a4e02) home-assistant-custom-components.smartthinq-sensors: 0.40.1 -> 0.40.3
* [`0e349d6a`](https://github.com/NixOS/nixpkgs/commit/0e349d6abd74c2c66b4e4034a506da8c10ae1a80) webdav: 5.4.0 -> 5.4.1
* [`1ef1cac1`](https://github.com/NixOS/nixpkgs/commit/1ef1cac17cb1c06a05370cdbe4e656bbb34d6267) webdav: add pbsds to maintainers
* [`4400a3b9`](https://github.com/NixOS/nixpkgs/commit/4400a3b902f2f34cc3fdd5830e8cde77ff6a4824) ananicy-cpp: add patch to fix detect cgroups
* [`562ccf68`](https://github.com/NixOS/nixpkgs/commit/562ccf681464215a6237aa504d746bec99ddbfa6) xournalpp: 1.2.3 -> 1.2.4
* [`49769d85`](https://github.com/NixOS/nixpkgs/commit/49769d859555ad417828e4d277b13e42b501d03f) xournalpp: format using nixfmt-rfc-style
* [`bd72d520`](https://github.com/NixOS/nixpkgs/commit/bd72d520133cbeefbbcc45cc96168d347f9c0b2f) tmuxPlugins.nord: 0.3.0 -> 0.3.0-unstable-2023-03-03
* [`b51e2591`](https://github.com/NixOS/nixpkgs/commit/b51e2591bcbf94f92ec2643d7ac7961a442aaa60) bun: fix cross-compilation
* [`4d649ff2`](https://github.com/NixOS/nixpkgs/commit/4d649ff22a55d332ab2960c1efa19fb683e2b632) prismlauncher: 8.4 -> 9.0
* [`af86ff66`](https://github.com/NixOS/nixpkgs/commit/af86ff668fc6f38326785c3631ebba5360dc7b4a) prismlauncher: enable checks
* [`d5262c26`](https://github.com/NixOS/nixpkgs/commit/d5262c269ee23bd70d7ef61ab43bc9eda0d80bef) electron_33-bin: init at 33.0.0
* [`34c5e9c9`](https://github.com/NixOS/nixpkgs/commit/34c5e9c983b61b8ccaf54f7ce11c5885a84cf61a) electron-chromedriver_33: init at 33.0.0
* [`1463bbcc`](https://github.com/NixOS/nixpkgs/commit/1463bbcc8c5195b7305b991da8f13fa018f68002) electron_32-bin: 32.1.2 -> 32.2.1
* [`b01aa67a`](https://github.com/NixOS/nixpkgs/commit/b01aa67a3855198ec983ec0ec5951abef4489abb) electron-chromedriver_32: 32.1.2 -> 32.2.1
* [`1d212462`](https://github.com/NixOS/nixpkgs/commit/1d2124626cd75a5b4e48abe649fac7bf48ca6288) lisp-modules: skip broken systems that don't evaluate from import
* [`0c5883bb`](https://github.com/NixOS/nixpkgs/commit/0c5883bbce990809800106eaad2512f9a6d1b7eb) mpiCheckPhaseHook: add parameters to bypass errors in sandbox
* [`161892e9`](https://github.com/NixOS/nixpkgs/commit/161892e932643c769117d621a70e014f3b2d1563) petsc: use mpiCheckPhaseHook to bypass check in sandbox
* [`3aeaac6b`](https://github.com/NixOS/nixpkgs/commit/3aeaac6b8e65aa1561b32067c6946b052d633eed) nwchem: replace nativeCheckInputs with nativeInstallCheckInputs
* [`3e08945b`](https://github.com/NixOS/nixpkgs/commit/3e08945b40e08fc0a36cf24dc73e5022c58df1d1) nwchem: mark supported on aarch64
* [`baefd488`](https://github.com/NixOS/nixpkgs/commit/baefd488bce8f243a95168f540b75c2c814d52ba) mate.mate-panel: 1.28.2 -> 1.28.4
* [`69006508`](https://github.com/NixOS/nixpkgs/commit/6900650847809fe479d6f4518fb83b1072e92878) electron-source.electron_32: 32.1.2 -> 32.2.1
* [`65d98a73`](https://github.com/NixOS/nixpkgs/commit/65d98a731911414a69d52319aca74b2fb2b14d1d) legcord: 1.0.1 -> 1.0.2
* [`6ade66ee`](https://github.com/NixOS/nixpkgs/commit/6ade66eec3f373c9c994d8e2d2454f9e13199b82) legcord: add updateScript
* [`200961e8`](https://github.com/NixOS/nixpkgs/commit/200961e8f28974b89bdb218139e1bc3e4395b5d5) coyim: fix build on aarch64
* [`f7388bc3`](https://github.com/NixOS/nixpkgs/commit/f7388bc3a8ee43147ac99ede06162b846fb38b9b) oscar: 1.5.1 -> 1.5.3
* [`a3670a29`](https://github.com/NixOS/nixpkgs/commit/a3670a2940c20629609fdb913ee639f3acb9e639) thunderbird-bin-unwrapped: 128.3.1esr -> 128.3.2esr
* [`4161ea40`](https://github.com/NixOS/nixpkgs/commit/4161ea40cfbc5f876e787b694ee9b703aa0fa2d2) iosevka-bin: 31.7.1 -> 31.9.1
* [`9f3d02d5`](https://github.com/NixOS/nixpkgs/commit/9f3d02d510042068aee542cf27e66c1dc919e711) harlequin: 1.24.1 -> 1.25.0
* [`fbe78043`](https://github.com/NixOS/nixpkgs/commit/fbe78043e0ddaa5d228312e1b9580a41d489ae43) nushellPlugins.skim: init at 0.7.0
* [`c6df108b`](https://github.com/NixOS/nixpkgs/commit/c6df108b6a1a3fdcbe605d2f23d6f1832da0ec10) equicord: init at 1.10.4
* [`50d67ba2`](https://github.com/NixOS/nixpkgs/commit/50d67ba2689f24cdeb7e5490e107663eba2b7312) equibop: init at 2.0.9
* [`18db6738`](https://github.com/NixOS/nixpkgs/commit/18db67388e7052fb08d6b1fbc4114421c069095e) oscavmgr: 0.4.1 -> 0.4.2
* [`4575253c`](https://github.com/NixOS/nixpkgs/commit/4575253c0c91aabd3bde5b05e9a13ce37880e6e5) camunda-modeler: 5.26.0 -> 5.28.0
* [`3fb71380`](https://github.com/NixOS/nixpkgs/commit/3fb71380330bcb254b16ac394c111a0f15b5a73d) ocamlPackages.cohttp_async_websocket: add missing dependency
* [`6d59693e`](https://github.com/NixOS/nixpkgs/commit/6d59693e05691383a82cabc1ac34863bbb98a978) comby: do not depend on opium
* [`33546d99`](https://github.com/NixOS/nixpkgs/commit/33546d99d4db50d1656f2e98f9dad40a25f0a302) ocamlPackages.ohex: init at 0.2.0
* [`5ea573ca`](https://github.com/NixOS/nixpkgs/commit/5ea573ca476915e0ccefb99be5687e4150fa049b) ocamlPackages.mirage-crypto: 0.11.3 → 1.1.0
* [`74f38d71`](https://github.com/NixOS/nixpkgs/commit/74f38d71ddbad5744618b1e10c871213fb241266) bun: 1.1.29 -> 1.1.31
* [`53cb15aa`](https://github.com/NixOS/nixpkgs/commit/53cb15aadcad2b805c04e897675d7a95de91ee21) mark: 10.0.1 -> 11.2.0
* [`a34f2157`](https://github.com/NixOS/nixpkgs/commit/a34f21576968d0d68aaed40106a3e9a7d7f5bcc3) granted: format using nixfmt
* [`b7b77c5f`](https://github.com/NixOS/nixpkgs/commit/b7b77c5f955b5dbb478b40048e64a6c954136114) granted: set updateScript
* [`b74384f6`](https://github.com/NixOS/nixpkgs/commit/b74384f636cd115242916f0690bf028d6065ddb1) granted: add versionCheckHook
* [`a40bac7f`](https://github.com/NixOS/nixpkgs/commit/a40bac7fd1d7ef1285adb625e54c32ced5794207) granted: add jlbribeiro as maintainer
* [`32656bcd`](https://github.com/NixOS/nixpkgs/commit/32656bcd29c062773b7740e3d576308aa1300a02) granted: 0.34.1 -> 0.35.0
* [`9d47ed15`](https://github.com/NixOS/nixpkgs/commit/9d47ed157cb0ff2bc81cd34759348529f014cb6e) granted: 0.35.0 -> 0.35.1
* [`bff96234`](https://github.com/NixOS/nixpkgs/commit/bff96234a226ba495083176ebc3edded0698728b) mosquitto: 2.0.18 -> 2.0.20
* [`b58c8efa`](https://github.com/NixOS/nixpkgs/commit/b58c8efae874164a5aba08b238d014acd474db44) mozcdic-ut-sudachidict: 0-unstable-2024-07-28 -> 0-unstable-2024-10-12
* [`19742067`](https://github.com/NixOS/nixpkgs/commit/19742067f4694a18c827aceaebdb0221bb7ab818) mozcdic-ut-personal-names: 0-unstable-2024-09-21 -> 0-unstable-2024-10-14
* [`1e1a6c16`](https://github.com/NixOS/nixpkgs/commit/1e1a6c16476e3610331149aace6150c0a4f3d6ed) cargo-public-api: 0.38.0 -> 0.40.0
* [`1276b88d`](https://github.com/NixOS/nixpkgs/commit/1276b88d5c577097e8972f69816fc39ed090737c) mozcdic-ut-alt-cannadic: 0-unstable-2024-07-28 -> 0-unstable-2024-10-13
* [`66463e22`](https://github.com/NixOS/nixpkgs/commit/66463e22244e41ae4b4112af04dcafca189927a2) kara: 0.7.1 -> 0.7.3
* [`fc4c4be8`](https://github.com/NixOS/nixpkgs/commit/fc4c4be8046c94999bdd17be1b11168292e23203) mozcdic-ut-place-names: 0-unstable-2024-09-03 -> 0-unstable-2024-10-12
* [`0fb71517`](https://github.com/NixOS/nixpkgs/commit/0fb7151745f150b036d28364d5356cd5dee79bb5) xcrawl3r: 0.1.0 -> 0.2.0
* [`d977b908`](https://github.com/NixOS/nixpkgs/commit/d977b90826b58a8f9b4ca37659e3c36c11cfcae8) fnlfmt: 0.3.1 -> 0.3.2
* [`439625a0`](https://github.com/NixOS/nixpkgs/commit/439625a0f6c69c84c74dd1e32512e6e11cfb0872) python312Packages.praw: 7.7.1 -> 7.8.0
* [`ee6e8448`](https://github.com/NixOS/nixpkgs/commit/ee6e844811304df2ce073cf5f690c0c891afbf74) gweled: move to pkgs/by-name
* [`17f0d2ac`](https://github.com/NixOS/nixpkgs/commit/17f0d2ac4035fdd8be36711a8bd85fa5bd7ac639) gweled: format with nixfmt-rfc-style
* [`01bc8773`](https://github.com/NixOS/nixpkgs/commit/01bc8773ea6ec77c4466c0785ec70f32954c6cf5) gweled: unstable-2021-02-11 -> 1.0-beta1
* [`04185d60`](https://github.com/NixOS/nixpkgs/commit/04185d60a4dd4746786b8dee3da87c287830132a) python3Packages.qtile: 0.28.1 -> 0.29.0
* [`9e5bae47`](https://github.com/NixOS/nixpkgs/commit/9e5bae47fa156390c0d94b77dadb1ff03da2dd17) python3Packages.qtile-extras: 0.28.1 -> 0.29.0
* [`f6bdbd16`](https://github.com/NixOS/nixpkgs/commit/f6bdbd1605b17cfbd8af51ba68db779e130d54b3) shfmt: 3.9.0 -> 3.10.0
* [`ab3e98d6`](https://github.com/NixOS/nixpkgs/commit/ab3e98d6b72ccf09802804ee85387fdbb3db14a6) icu: temporary change to test rc version
* [`ad22c750`](https://github.com/NixOS/nixpkgs/commit/ad22c7506d4444ceee1a3c741027dda5af839ee4) gmrun: move to pkgs/by-name
* [`e7d4c70b`](https://github.com/NixOS/nixpkgs/commit/e7d4c70bebd6ed25075bf9c8d8d4f77802765a19) gmrun: format with nixfmt-rfc-style
* [`860eea03`](https://github.com/NixOS/nixpkgs/commit/860eea03372b8fe77f4a450953974b9f290be263) gmrun: 0.9.2 -> 1.4w
* [`9455dd1c`](https://github.com/NixOS/nixpkgs/commit/9455dd1c9d043b2f111716d94a18905d0f74e14d) nushell: 0.99.0 -> 0.99.1
* [`fa25edac`](https://github.com/NixOS/nixpkgs/commit/fa25edac5b9a0621890ee927d532a2cc99bad878) nushell: fix build on darwin
* [`a3396560`](https://github.com/NixOS/nixpkgs/commit/a33965600a4d58ba10e4060fdcd86792e2047e3a) nushellPlugins.net: consistent naming
* [`7214c817`](https://github.com/NixOS/nixpkgs/commit/7214c817dd7692aefc29dcafff57b84615f738fe) merge-ut-dictionaries: 0-unstable-2024-09-09 -> 0-unstable-2024-10-13
* [`4112fd7a`](https://github.com/NixOS/nixpkgs/commit/4112fd7ab9bc4b4f8015df87a7c1bbab7af2d0ba) mozcdic-ut-neologd: 0-unstable-2024-07-28 -> 0-unstable-2024-10-12
* [`2534d1c5`](https://github.com/NixOS/nixpkgs/commit/2534d1c5295d3f6fd2c95092f369974e540f5b0c) mozcdic-ut-edict2: 0-unstable-2024-07-28 -> 0-unstable-2024-10-12
* [`7eb09a20`](https://github.com/NixOS/nixpkgs/commit/7eb09a2082c07f2f3e388f3abe785ba157a9d286) mozcdic-ut-skk-jisyo: 0-unstable-2024-07-27 -> 0-unstable-2024-10-12
* [`3f826e90`](https://github.com/NixOS/nixpkgs/commit/3f826e900cf2f5c34f35d5b9bbb176bcf4296435) python3Packages.djangorestframework-csv: init at 3.0.2
* [`df56fd90`](https://github.com/NixOS/nixpkgs/commit/df56fd90bfd678cb596245317c71043de5e16887) lazpaint: move to pkgs/by-name
* [`028da5a7`](https://github.com/NixOS/nixpkgs/commit/028da5a73bab6f2a7d3097d187581e9c12ebb671) lazpaint: format with nixfmt-rfc-style
* [`863fb6de`](https://github.com/NixOS/nixpkgs/commit/863fb6de5ea88c079ee196951ac660da7eeffd95) mozcdic-ut-jawiki: 0-unstable-2024-09-27 -> 0-unstable-2024-10-12
* [`d7b0a7f5`](https://github.com/NixOS/nixpkgs/commit/d7b0a7f5017f3a4f3d79e1f90aeb14537372dee0) eiwd: use stdenv.buildPlatform.canExecute
* [`a6f72e58`](https://github.com/NixOS/nixpkgs/commit/a6f72e581fb6f0b7d55173f4249410edb2971a32) ffmpeg_7-full: use stdenv.buildPlatform.canExecute
* [`80a7af37`](https://github.com/NixOS/nixpkgs/commit/80a7af371531699e25539f73b7e8ac92e1c39b71) flatbuffers_23: use stdenv.buildPlatform.canExecute
* [`59dd05ed`](https://github.com/NixOS/nixpkgs/commit/59dd05ed24bd5c764e9e3abff8463bcd44b364d8) flatbuffers_2_0: use stdenv.buildPlatform.canExecute
* [`9109a87f`](https://github.com/NixOS/nixpkgs/commit/9109a87f53f549b740716bc8d3cea1632dd5e44e) fossil: use stdenv.buildPlatform.canExecute
* [`2e685bba`](https://github.com/NixOS/nixpkgs/commit/2e685bbac17ea8e283912f8f8782bf9d6636ee38) glab: use stdenv.buildPlatform.canExecute
* [`1ea118d8`](https://github.com/NixOS/nixpkgs/commit/1ea118d88f03b65924e1fb95c18bc81bca8807f4) k6: use stdenv.buildPlatform.canExecute
* [`4d672b25`](https://github.com/NixOS/nixpkgs/commit/4d672b2560f529eab0ce8410580c24572da3824f) kaniko: use stdenv.buildPlatform.canExecute
* [`7ef881b7`](https://github.com/NixOS/nixpkgs/commit/7ef881b7efa3f465d372d23ad211a0c4c02a2d22) kmymoney: use stdenv.buildPlatform.canExecute
* [`a9142755`](https://github.com/NixOS/nixpkgs/commit/a91427558d68cb30c8beeb6d734824956cf650ba) kubeshark: use stdenv.buildPlatform.canExecute
* [`fe7e01bd`](https://github.com/NixOS/nixpkgs/commit/fe7e01bda1bc8a0ae1c6c211f234eda0d4aae1df) kubevela: use stdenv.buildPlatform.canExecute
* [`b80f0edf`](https://github.com/NixOS/nixpkgs/commit/b80f0edf72c4966e4b04f65e508cd3053f1977c0) mangal: use stdenv.buildPlatform.canExecute
* [`faa7f0f8`](https://github.com/NixOS/nixpkgs/commit/faa7f0f8b7991acdee82ac5e2bde4fb420242c2e) mtdutils: use stdenv.buildPlatform.canExecute
* [`8a3a11c3`](https://github.com/NixOS/nixpkgs/commit/8a3a11c3267b14f97086332bdba03ea211cbc692) nlohmann_json: use stdenv.buildPlatform.canExecute
* [`60c99f1a`](https://github.com/NixOS/nixpkgs/commit/60c99f1abd322a70e04b5ee8613146b4afb8095f) pidgin: use stdenv.buildPlatform.canExecute
* [`2d992c6f`](https://github.com/NixOS/nixpkgs/commit/2d992c6fdde9ce4b4803e5e68b64ef899f64b948) utox: use stdenv.buildPlatform.canExecute
* [`56783f82`](https://github.com/NixOS/nixpkgs/commit/56783f8200b0c883b0ecf23b2eb69127e98b8327) velero: use stdenv.buildPlatform.canExecute
* [`66c524ac`](https://github.com/NixOS/nixpkgs/commit/66c524ac401505651b180c5ab82ab0bb2bf5f60e) zerotierone: use stdenv.buildPlatform.canExecute
* [`b2d525e1`](https://github.com/NixOS/nixpkgs/commit/b2d525e17244a61c674ae17a858901f69a8b5276) python312Packages.optimistix: 0.0.8 -> 0.0.9
* [`191df780`](https://github.com/NixOS/nixpkgs/commit/191df7805ef768162ad63e42509a6339ce3ad6c8) bencodetools: use stdenv.buildPlatform.canExecute
* [`bb16748e`](https://github.com/NixOS/nixpkgs/commit/bb16748e8cfd5d74905f451e4d65be4a0737dcc4) minizip2: use stdenv.buildPlatform.canExecute
* [`4b43b3c1`](https://github.com/NixOS/nixpkgs/commit/4b43b3c102f66d4074fa24a9467a5f6230ff074b) tpm2-tss: use stdenv.buildPlatform.canExecute
* [`22c69ed6`](https://github.com/NixOS/nixpkgs/commit/22c69ed6b271b2c1504fdebc7e9e2b2a7438ada1) uriparser: use stdenv.buildPlatform.canExecute
* [`e77269f1`](https://github.com/NixOS/nixpkgs/commit/e77269f1f1efc749b90f04b958385b1b7344cd49) visidata: use stdenv.buildPlatform.canExecute
* [`34395aeb`](https://github.com/NixOS/nixpkgs/commit/34395aeb9f0e88c44443c7d5040b23d73d6ef871) python312Packages.torch-geometric: skip failing test on darwin
* [`e3acda6a`](https://github.com/NixOS/nixpkgs/commit/e3acda6ad2a499a0b678140fd1956bc0401925d4) iosevka-comfy: 2.0.0 -> 2.1.0
* [`076162ab`](https://github.com/NixOS/nixpkgs/commit/076162abbeaead46ffa88bd1b92a2c02ecf9bae7) python3Packages.survey: 5.4.0 -> 5.4.2
* [`3d8ab12a`](https://github.com/NixOS/nixpkgs/commit/3d8ab12ae1e6035c61ec86185fa205ae5399a607) lazpaint: 7.2.2-unstable-2024-01-20 -> 7.2.2-unstable-2024-01-23; switch to qt5
* [`4a6b6e7e`](https://github.com/NixOS/nixpkgs/commit/4a6b6e7e0559b888ed6ba6348619141bf324eb7b) lunatask: 2.0.9 -> 2.0.11
* [`d1e6b445`](https://github.com/NixOS/nixpkgs/commit/d1e6b4455683ffc2dfdf5a0cf56a337004e4db36) exo: 0-unstable-2024-10-09 -> 0-unstable-2024-10-21
* [`1051d82f`](https://github.com/NixOS/nixpkgs/commit/1051d82fa8fd02c440ddb9b91749e82c3b5b3ab2) python312Packages.lineax: 0.0.6 -> 0.0.7
* [`12baf0a2`](https://github.com/NixOS/nixpkgs/commit/12baf0a297387ebf78f257fcd00e83cf94f4c13f) labwc-tweaks-gtk: 0-unstable-2024-09-30 -> 0-unstable-2024-10-20
* [`56444f5f`](https://github.com/NixOS/nixpkgs/commit/56444f5f6a71400d7e34ca983ff7af0ef2765e4a) factorio: 1.1.110 -> 2.0.7
* [`5579fe35`](https://github.com/NixOS/nixpkgs/commit/5579fe359c6969b6587d68a66f2c42dab46d5f20) factorio-space-age: init at 2.0.7
* [`1d572416`](https://github.com/NixOS/nixpkgs/commit/1d5724166863085691b1a95dac4cd1e817bf71ef) pdftitle: 0.14 -> 0.15
* [`19865ae5`](https://github.com/NixOS/nixpkgs/commit/19865ae53ac2266dcfe5dc3a079c87329b858fb0) tflint-plugins.tflint-ruleset-aws: 0.32.0 -> 0.34.0
* [`b93bbf64`](https://github.com/NixOS/nixpkgs/commit/b93bbf6406ab5cb00b5e0bf0ceb321462c8266bd) nixos/nginx: remove rejectSSL assertion
* [`b75088e1`](https://github.com/NixOS/nixpkgs/commit/b75088e1c4a2a9c44b299e0925407d8b2f860779) python312Packages.docker-pycreds: fix and clean
* [`66a89777`](https://github.com/NixOS/nixpkgs/commit/66a897777cf42f10e2cf684aaecde36964541a70) python312Packages.docker-pycreds: add GaetanLepage as maintainer
* [`77514565`](https://github.com/NixOS/nixpkgs/commit/77514565aef4cc2bd8fab96949c34317f2c687a6) snipaste: 2.9.2-Beta -> 2.10.2
* [`117bafd4`](https://github.com/NixOS/nixpkgs/commit/117bafd4d2e40cbfe0ce863bf5dec4e18c3fa379) snipaste: add updateScript
* [`b32fbba3`](https://github.com/NixOS/nixpkgs/commit/b32fbba3f6260aaa9f6b05eb17e792ef3819e8fe) fireplace: nix-darwin bugfix
* [`cfac9c18`](https://github.com/NixOS/nixpkgs/commit/cfac9c18427ca5ea0cb1d5fcfb8335f361bf90c1) immersed: Fix runtime error with libgpg-error
* [`bbc84b1f`](https://github.com/NixOS/nixpkgs/commit/bbc84b1f56e21b383db415ae03b7581ab3a971cf) libjodycode: set meta.platforms
* [`cdaedcb0`](https://github.com/NixOS/nixpkgs/commit/cdaedcb0ddd6c0fc00bb7c14d0257015fdb84ef9) xfce.mousepad: 0.6.2 -> 0.6.3
* [`bc6ca210`](https://github.com/NixOS/nixpkgs/commit/bc6ca21020cb222bd7467f8b09649751edf0eea3) pythonPackages.mpi4py: 3.1.6-unstable-2024-07-08 -> 4.0.1
* [`f32ef08b`](https://github.com/NixOS/nixpkgs/commit/f32ef08b48bf3faf504c57d1588139cf9fbf7ded) gnome-commander: init at 1.18.1-unstable-2024-10-18
* [`7fad2c2e`](https://github.com/NixOS/nixpkgs/commit/7fad2c2e395784739c2ced5f9e3836583bb17f30) nixos/wrappers: add enable switch
* [`ef1bae27`](https://github.com/NixOS/nixpkgs/commit/ef1bae277eb79b35ce0ec227718af0908ad3c131) python3Packages.ducc0: 0.34.0 -> 0.35.0
* [`b01da391`](https://github.com/NixOS/nixpkgs/commit/b01da391b7e51feeca65d428ff16570f1249fc29) inspector: init at 0.2.0
* [`08eee7bd`](https://github.com/NixOS/nixpkgs/commit/08eee7bd7ae2eb1278d08416740c709bd796f26c) home-assistant-custom-components.*: make use of lib.packagesFromDirectoryRecursive
* [`1cf977ba`](https://github.com/NixOS/nixpkgs/commit/1cf977bad5975ed81c59b18c78dae15a67fab83e) granted: 0.35.1 -> 0.35.2
* [`1c2e39c9`](https://github.com/NixOS/nixpkgs/commit/1c2e39c9556659ddd4c7ff3b230fe798ec67b109) arc-browser: 1.63.1-54714 -> 1.65.0-54911
* [`ceef7db0`](https://github.com/NixOS/nixpkgs/commit/ceef7db08594f060070bbe58ac2a89262acc6d89) mastodon: 4.3.0 -> 4.3.1
* [`cba4ebe2`](https://github.com/NixOS/nixpkgs/commit/cba4ebe2b528d05cded39e6c26b2f4b7c81d46f9) pdm: 2.19.2 -> 2.19.3
* [`ef9880fd`](https://github.com/NixOS/nixpkgs/commit/ef9880fdd6ab7d5532062029c2551472f263aed1) arc-browser: format with nixfmt-rfc-style
* [`bbf17bf3`](https://github.com/NixOS/nixpkgs/commit/bbf17bf314b8fe916c257513ccc946b8dd441472) arc-browser: quote paths
* [`42fbc7de`](https://github.com/NixOS/nixpkgs/commit/42fbc7de66bc45e49113cef963402fd5463bbafd) arc-browser: remove `set -euo pipefail`
* [`377d600f`](https://github.com/NixOS/nixpkgs/commit/377d600fe1eee63480e88246fc6875917c424d4c) polkadot: stable2409 -> stable2409-1
* [`6f021cbe`](https://github.com/NixOS/nixpkgs/commit/6f021cbe0163fd40581e9b5542fd03f6350ccd58) polkadot: format with nixfmt-rfc-style
* [`045c2d21`](https://github.com/NixOS/nixpkgs/commit/045c2d219ddbfde49420900ade5cf7cfffaad3db) binutils-unwrapped: remove broken iOS patch
* [`76cc1fd9`](https://github.com/NixOS/nixpkgs/commit/76cc1fd92379a39b24612ef7ba4e88c3bdc88f83) spiped: format with nixfmt
* [`6b8c4f11`](https://github.com/NixOS/nixpkgs/commit/6b8c4f116cd0d4e2990d8d02829de9d62037f38e) spiped: small fixes, e.g. sha256 -> hash
* [`692b12ce`](https://github.com/NixOS/nixpkgs/commit/692b12ceeacab7f81b3e1d698d9f2181acf44a46) nixos/tests/spiped: init
* [`76842a45`](https://github.com/NixOS/nixpkgs/commit/76842a453c96360eeeac94a469e5bd0560491fdc) gitlab-release-cli: 0.18.0 -> 0.19.0
* [`4225f640`](https://github.com/NixOS/nixpkgs/commit/4225f640ef7a92272a9bf3ca7f264651ce512123) remctl: init at 3.18
* [`b34590be`](https://github.com/NixOS/nixpkgs/commit/b34590bec59d39e3bb4421dfbdca7addde290988) perlPackages.NetRemctl: init at 3.18
* [`100bad6a`](https://github.com/NixOS/nixpkgs/commit/100bad6ad37495d85c69b2b1e8cba48a8a16d16e) python312Packages.remctl: init at 3.18
* [`4955cb9a`](https://github.com/NixOS/nixpkgs/commit/4955cb9a09db723b52cda7f641244be62366c335) binutils-unwrapped: remove broken vc4 sources
* [`4b09bd0f`](https://github.com/NixOS/nixpkgs/commit/4b09bd0fec888c3cdb3f7c6ae196298b349a3fe5) gotestwaf: 0.5.5 -> 0.5.6
* [`99d0e499`](https://github.com/NixOS/nixpkgs/commit/99d0e4996d3a7a247df0546775a48506c84220b7) binutils: remove autoreconfHook on iOS
* [`89acd969`](https://github.com/NixOS/nixpkgs/commit/89acd969efae30e7ea420cfaed48b212da6644bd) python311Packages.oslo-utils: use only qemu-utils
* [`e07090c4`](https://github.com/NixOS/nixpkgs/commit/e07090c4101ec2bb09dca3bce24d82b05ffa4120) bustools: 0.44.0 -> 0.44.1
* [`40d92943`](https://github.com/NixOS/nixpkgs/commit/40d929432526971c1455c7f36cea2f528a815b01) python312Packages.xdis: support new python minor versions
* [`27d3ece6`](https://github.com/NixOS/nixpkgs/commit/27d3ece652409bc0d53dc2c50ae80060f1ba534d) python312Packages.huggingface-hub: 0.25.2 -> 0.26.1
* [`394a7326`](https://github.com/NixOS/nixpkgs/commit/394a7326067ca557f0d0f401247b1956a789cd8f) python312Packages.xdis: switch to pyproject and dependencies
* [`2e1dd3a8`](https://github.com/NixOS/nixpkgs/commit/2e1dd3a8c016215e74aeb60e1bd4435f0dab29f4) godot_4: use separateDebugInfo
* [`d6cd2901`](https://github.com/NixOS/nixpkgs/commit/d6cd2901a282140c77751b20d37cea1f036b0da7) detect-it-easy: init at 3.09
* [`661a05d1`](https://github.com/NixOS/nixpkgs/commit/661a05d10ea42cc9a3f5e8f4e4d0b334d6c591ed) Revert "bmake: 20240808 -> 20240921"
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
