### PR TITLE
niv home-manager: update 5ec753a1 -> e8341405

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -41,10 +41,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5ec753a1fc4454df9285d8b3ec0809234defb975",
-        "sha256": "0jygm1vsfp10fylmxg8qfss01zfz72iwnxqaal75x5wpgmihdc7c",
+        "rev": "e83414058edd339148dc142a8437edb9450574c8",
+        "sha256": "0kg9iaixqygpncw7avgh1grwyjgnfc9i7k9pk8hc4xrvr8jv2l3c",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/5ec753a1fc4454df9285d8b3ec0809234defb975.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/e83414058edd339148dc142a8437edb9450574c8.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@5ec753a1...e8341405](https://github.com/nix-community/home-manager/compare/5ec753a1fc4454df9285d8b3ec0809234defb975...e83414058edd339148dc142a8437edb9450574c8)

* [`5765fe4f`](https://github.com/nix-community/home-manager/commit/5765fe4feb78092cf3cbe2aa5cd523513eea7769) accounts/calendar: fix defaultText rendering
* [`a4353cc4`](https://github.com/nix-community/home-manager/commit/a4353cc43d1b4dd6bdeacea90eb92a8b7b78a9d7) accounts/contacts: fix defaultText rendering
* [`0a0b1b18`](https://github.com/nix-community/home-manager/commit/0a0b1b18bdd16d3f810178c7aec9eca730699631) maintainers: remove omernaveedxyz
* [`454e8d6b`](https://github.com/nix-community/home-manager/commit/454e8d6b15aafb02fd22bba0edc4cc0b06dd0f41) granted: use assume directly
* [`eea1bc60`](https://github.com/nix-community/home-manager/commit/eea1bc607249f0b79fb437b5e9709aa6d2218bac) gpg-agent: use $TTY parameter in zsh integration
* [`c7cfdb38`](https://github.com/nix-community/home-manager/commit/c7cfdb386430b01fd9748139a0e9cfa40e36c265) spotify-player: add support for actions
* [`82378b3f`](https://github.com/nix-community/home-manager/commit/82378b3f7f8c12ecfab8539df780e495e6ba4cb6) htop: use attrsOf instead of attrs as settings type
* [`44629358`](https://github.com/nix-community/home-manager/commit/446293584f10d56b91368f500c022f7a93edbe2c) nixgl: add module
* [`bbd4254d`](https://github.com/nix-community/home-manager/commit/bbd4254d00e8c69c4c958ddb51fb18637ca7f9b8) nixgl: make desktop files point to wrapped exe
* [`b9fe7479`](https://github.com/nix-community/home-manager/commit/b9fe747915d95c3ea37539cccea67d3df39526a9) nixgl: use makeWrapper and update docs
* [`199cf563`](https://github.com/nix-community/home-manager/commit/199cf5634c2ed39fceae0da3b1d0a76f7d47e1b1) nixgl: use -q to silence grep
* [`d0c036ca`](https://github.com/nix-community/home-manager/commit/d0c036ca4904701289e0a779253f241feeacbf40) nixgl: ensure makeWrapper is present during build
* [`7dee0dc8`](https://github.com/nix-community/home-manager/commit/7dee0dc8f0c7d4f174c481f36d04b9edadba3b7e) nixgl: reference lib directly
* [`e61f8796`](https://github.com/nix-community/home-manager/commit/e61f87969ae179139164c7fb5e0bb76b791144e5) nixgl: Improve option documentation
* [`7a587970`](https://github.com/nix-community/home-manager/commit/7a5879707bb49c350aee7ab270c917584d430193) nixgl: API rework for flexibility and dual-GPU
* [`8bd6e0a1`](https://github.com/nix-community/home-manager/commit/8bd6e0a1a805c373686e21678bb07f23293d357b) nixgl: add support for channel-based configuration
* [`c77c3bb2`](https://github.com/nix-community/home-manager/commit/c77c3bb23390a9ba91860e721edde54856fc5f7a) yazi: enable shell integration values by default
* [`6cc03e33`](https://github.com/nix-community/home-manager/commit/6cc03e337aa1d0222e5942f58839d965075a9781) nix-gc: add `randomizedDelaySec` option
* [`c0e23159`](https://github.com/nix-community/home-manager/commit/c0e23159872e2e2135c7eb5cf96cd36cfe6ee1f4) git-credential-oauth: add extraFlags option
* [`0c0268a3`](https://github.com/nix-community/home-manager/commit/0c0268a3c80d30b989d0aadbd65f38d4fa27a9a0) eza: add color option
* [`93435d27`](https://github.com/nix-community/home-manager/commit/93435d27d250fa986bfec6b2ff263161ff8288cb) direnv: add support for mise integration
* [`05d9bee4`](https://github.com/nix-community/home-manager/commit/05d9bee4a5155758aec3c3807c0e342b9f253522) git-credential-oauth: fix use of mkIf and add tests
* [`e8341405`](https://github.com/nix-community/home-manager/commit/e83414058edd339148dc142a8437edb9450574c8) flake.lock: Update
