### PR TITLE
niv powerlevel10k: update 0996a941 -> 8a331b82

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -113,10 +113,10 @@
         "homepage": "",
         "owner": "romkatv",
         "repo": "powerlevel10k",
-        "rev": "0996a9411824cbfe8fdd8cb17448c94ef891be34",
-        "sha256": "141vrzbspnca8vs979vsyx2ynnj4gbm80x46pkswr5z6ks69lkfa",
+        "rev": "8a331b82108dd5c5834cebdc0abbe778cc1a2735",
+        "sha256": "0iwjyizmw2lyf80q5cyqabvgbnav31ynfbjwsgv1insjqd04pzwx",
         "type": "tarball",
-        "url": "https://github.com/romkatv/powerlevel10k/archive/0996a9411824cbfe8fdd8cb17448c94ef891be34.tar.gz",
+        "url": "https://github.com/romkatv/powerlevel10k/archive/8a331b82108dd5c5834cebdc0abbe778cc1a2735.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "rh": {


### PR DESCRIPTION
## Changelog for powerlevel10k:
Branch: master
Commits: [romkatv/powerlevel10k@0996a941...8a331b82](https://github.com/romkatv/powerlevel10k/compare/0996a9411824cbfe8fdd8cb17448c94ef891be34...8a331b82108dd5c5834cebdc0abbe778cc1a2735)

* [`3483f230`](https://github.com/romkatv/powerlevel10k/commit/3483f230a72a0cf2078f4874acb38b74d61dbecd) Updated README.md to include instructions to enable MesloLGS Terminal Font
* [`67a365b9`](https://github.com/romkatv/powerlevel10k/commit/67a365b9dbf2c784ca8e655d681df10ef2d4a1a4) Let mise-configured ancestors be anchors ([romkatv/powerlevel10k⁠#2782](https://togithub.com/romkatv/powerlevel10k/issues/2782))
* [`5e264734`](https://github.com/romkatv/powerlevel10k/commit/5e26473457d819fe148f7fff32db1082dae72012) support cpu_arch on linux ([romkatv/powerlevel10k⁠#2776](https://togithub.com/romkatv/powerlevel10k/issues/2776))
* [`8a331b82`](https://github.com/romkatv/powerlevel10k/commit/8a331b82108dd5c5834cebdc0abbe778cc1a2735) copy warp font instructions to font.md
