### PR TITLE
niv emacs-overlay: update 6fa58edd -> cedccfff

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "6fa58edd58a554fb75fe1b430adefabf50ade53a",
-        "sha256": "06n1n5p54h06jjzfva3ksx97sk931m6q2czhswp386m1sg33capr",
+        "rev": "cedccfff0d6e1fb9c62f77fb4e05169256219eca",
+        "sha256": "10v2b8ids65injk724zkgc5dag86yi4ilw2dgbnsp195dpd8jqw3",
         "type": "tarball",
-        "url": "https://github.com/nix-community/emacs-overlay/archive/6fa58edd58a554fb75fe1b430adefabf50ade53a.tar.gz",
+        "url": "https://github.com/nix-community/emacs-overlay/archive/cedccfff0d6e1fb9c62f77fb4e05169256219eca.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "fast-syntax-highlighting": {


### PR DESCRIPTION
## Changelog for emacs-overlay:
Branch: master
Commits: [nix-community/emacs-overlay@6fa58edd...cedccfff](https://github.com/nix-community/emacs-overlay/compare/6fa58edd58a554fb75fe1b430adefabf50ade53a...cedccfff0d6e1fb9c62f77fb4e05169256219eca)

* [`414c3ef3`](https://github.com/nix-community/emacs-overlay/commit/414c3ef34d7d33fbed49ad21cf32c28f2f2572a5) Updated nongnu
* [`c87710c7`](https://github.com/nix-community/emacs-overlay/commit/c87710c7a3f03214467c2aef993f6f665af10d68) Updated elpa
* [`949ed15c`](https://github.com/nix-community/emacs-overlay/commit/949ed15c567ffd5599ef49c9cb96954a2d86dfdc) Updated melpa
* [`99c6c746`](https://github.com/nix-community/emacs-overlay/commit/99c6c746c5b8651e5993e5b9a649d0a961346299) Updated emacs
* [`5d61fa81`](https://github.com/nix-community/emacs-overlay/commit/5d61fa810490ef7b33fc6cea2042adaf70020887) Updated flake inputs
* [`ac76459e`](https://github.com/nix-community/emacs-overlay/commit/ac76459ea37692e696b4a5cb890df35df820b98c) Updated nongnu
* [`2bacfb48`](https://github.com/nix-community/emacs-overlay/commit/2bacfb4872b16be80bf91a0110771931a4243ce1) Updated elpa
* [`1cb4ecc5`](https://github.com/nix-community/emacs-overlay/commit/1cb4ecc50cd6c0cdd480709fe78255da17b77179) Updated melpa
* [`57f92101`](https://github.com/nix-community/emacs-overlay/commit/57f92101924dff3eb03689bf9ba0ce0c49a6d6e8) Updated emacs
* [`36dcfe7c`](https://github.com/nix-community/emacs-overlay/commit/36dcfe7c348ec4a492775c388265173ee5e0d5ff) Updated melpa
* [`7bdcd77e`](https://github.com/nix-community/emacs-overlay/commit/7bdcd77e2b8fd8e10d8d8bfae5ba7302dbd69d3e) Updated emacs
* [`a483757d`](https://github.com/nix-community/emacs-overlay/commit/a483757de48eba86f4ab373fd522341555aecfd7) Updated flake inputs
* [`5efcd2e6`](https://github.com/nix-community/emacs-overlay/commit/5efcd2e6e3bce767b94234a554d6c05dac8918bd) Adapt Emacs update script to chop off more extraneous info
* [`eb7cc658`](https://github.com/nix-community/emacs-overlay/commit/eb7cc658d453cdeb1d978a1f83ccf375ba42a095) Updated nongnu
* [`b84e0f98`](https://github.com/nix-community/emacs-overlay/commit/b84e0f98a6f3c8e232245871d4ac1d7aa05b8f51) Updated elpa
* [`c652df2b`](https://github.com/nix-community/emacs-overlay/commit/c652df2b2d75fcc0a08fc123f18321ea882f9e22) Updated melpa
* [`85f404eb`](https://github.com/nix-community/emacs-overlay/commit/85f404ebb7a17ed7c6e42b1e68aafb2ebaf023dc) Updated emacs
* [`ebb0bbfb`](https://github.com/nix-community/emacs-overlay/commit/ebb0bbfb5f8a13c4e64e26fd9f18439119064e39) Updated flake inputs
* [`0c1b170a`](https://github.com/nix-community/emacs-overlay/commit/0c1b170a30cad95a03798248caa427370b9fc504) Updated nongnu
* [`5a9afdef`](https://github.com/nix-community/emacs-overlay/commit/5a9afdefc4ce17c3bafeaefd4eb023e87d01dc6a) Updated elpa
* [`7ad60568`](https://github.com/nix-community/emacs-overlay/commit/7ad60568c11f84dc3dbc455d06cabd324c32e728) Updated melpa
* [`c51fe453`](https://github.com/nix-community/emacs-overlay/commit/c51fe4531ae40b08b61f7ea680f3df2a964cd936) Updated emacs
* [`31bf955b`](https://github.com/nix-community/emacs-overlay/commit/31bf955bfaaa8008795c1e8d26daf0401f1fa5e6) Updated melpa
* [`f5e7cbe0`](https://github.com/nix-community/emacs-overlay/commit/f5e7cbe08abc8c4fba75084efae5173540accb43) Updated emacs
* [`bb242817`](https://github.com/nix-community/emacs-overlay/commit/bb242817e911f656031a825f0c5679c5ed82552a) Updated elpa
* [`d6f8d789`](https://github.com/nix-community/emacs-overlay/commit/d6f8d7895aaa12d4017d684e1143c425c7812c8e) Updated nongnu
* [`4653a87d`](https://github.com/nix-community/emacs-overlay/commit/4653a87d2a0252deb57a8c50f67cec0af9e4b1d5) Updated elpa
* [`9a249ec8`](https://github.com/nix-community/emacs-overlay/commit/9a249ec8611cace71a5f4896a8a247672bc36f89) Updated melpa
* [`15484da3`](https://github.com/nix-community/emacs-overlay/commit/15484da3f9409ea034986671133c894b061e9df5) Updated emacs
* [`088b49a8`](https://github.com/nix-community/emacs-overlay/commit/088b49a8267b149ea3be1ec54e661d856a5e7e24) Updated flake inputs
* [`0e91d6cd`](https://github.com/nix-community/emacs-overlay/commit/0e91d6cde618114734b4830d14c3a4e8e4b26d86) Updated nongnu
* [`5b319994`](https://github.com/nix-community/emacs-overlay/commit/5b31999426138b11a73101e8124a51b73649e234) Updated melpa
* [`00859b19`](https://github.com/nix-community/emacs-overlay/commit/00859b191a98a4f08e7cffc639a5b9cd3be9cdf7) Updated emacs
* [`49d2e0b4`](https://github.com/nix-community/emacs-overlay/commit/49d2e0b4fcba6ed7516eccd168d4f734d0911bfd) Updated flake inputs
* [`fd6e4c36`](https://github.com/nix-community/emacs-overlay/commit/fd6e4c36fad10cff8d494add80c6adc86d6ae947) Updated nongnu
* [`dfa44d16`](https://github.com/nix-community/emacs-overlay/commit/dfa44d161338550df03000b535df2ffbaa815dcc) Updated elpa
* [`d520e1bc`](https://github.com/nix-community/emacs-overlay/commit/d520e1bc76016f5a82fc09e36891bd7f907b1226) Updated melpa
* [`125316ab`](https://github.com/nix-community/emacs-overlay/commit/125316ab852d4d9abd771be51471b52ead9aa0c8) Updated emacs
* [`13806d71`](https://github.com/nix-community/emacs-overlay/commit/13806d71fd499fd1300e0ae3420f9ed856adf961) Updated elpa
* [`4abe6300`](https://github.com/nix-community/emacs-overlay/commit/4abe6300515446deceb150312274b42a72bddf75) Updated melpa
* [`dd6d5acc`](https://github.com/nix-community/emacs-overlay/commit/dd6d5accb4d568022b843af5469abb82c08615a8) Updated emacs
* [`e18764f1`](https://github.com/nix-community/emacs-overlay/commit/e18764f12c308e67390924e2f7937fefb3e7f409) Updated melpa
* [`705b1d0b`](https://github.com/nix-community/emacs-overlay/commit/705b1d0be622b52a8b40d64a701e56b8924d8fb8) Updated emacs
* [`ab2e43c8`](https://github.com/nix-community/emacs-overlay/commit/ab2e43c8e24181de5265d2d49136fcce01f441fd) Updated flake inputs
* [`1349b3f4`](https://github.com/nix-community/emacs-overlay/commit/1349b3f4d839157ee6d21dc33110112d61acb8d3) Updated nongnu
* [`1758d4f7`](https://github.com/nix-community/emacs-overlay/commit/1758d4f7e4a2c60295c92946862a8786dbe9b0d8) Updated elpa
* [`2a623005`](https://github.com/nix-community/emacs-overlay/commit/2a6230052716ae60e46ef9c43121996de8819de7) Updated melpa
* [`d83373c6`](https://github.com/nix-community/emacs-overlay/commit/d83373c669b43b08219d63270662ab6585aeec6c) Updated emacs
* [`6c1d9191`](https://github.com/nix-community/emacs-overlay/commit/6c1d919107fb94c9968a3d3bedde40ad8433000a) Updated nongnu
* [`641f4fa6`](https://github.com/nix-community/emacs-overlay/commit/641f4fa6e16a8f61611409c3228d45071c80870c) Updated elpa
* [`aab83d8f`](https://github.com/nix-community/emacs-overlay/commit/aab83d8fe8b65054ffb82de177d6ef286e00a49b) Updated melpa
* [`3d41910d`](https://github.com/nix-community/emacs-overlay/commit/3d41910d37e4f1d447ab0ff34a69f9e13756f0bf) Updated emacs
* [`1c42ffa2`](https://github.com/nix-community/emacs-overlay/commit/1c42ffa2bbfe2b898a4cfc2c73edbfca77baf994) Bump cachix/install-nix-action from 29 to 30
* [`29af1ca6`](https://github.com/nix-community/emacs-overlay/commit/29af1ca608ec75e42c3d7a59459546a90c2ac417) Updated melpa
* [`0ed40004`](https://github.com/nix-community/emacs-overlay/commit/0ed4000480e3f21e67a99d30248d6768b9f2f6ee) Updated nongnu
* [`d9143db1`](https://github.com/nix-community/emacs-overlay/commit/d9143db19d5f770d3688ab8ecfabbce092bdd492) Updated elpa
* [`cc15718c`](https://github.com/nix-community/emacs-overlay/commit/cc15718cbc1ad62bd9ec488ae07a4ab82ff537e6) Updated melpa
* [`788bbc26`](https://github.com/nix-community/emacs-overlay/commit/788bbc26c24f3c9f42df59807ba4a557796a1441) Updated nongnu
* [`a46d730d`](https://github.com/nix-community/emacs-overlay/commit/a46d730d3d0626909bc638577a5a79f95afac09a) Updated elpa
* [`3bc032b7`](https://github.com/nix-community/emacs-overlay/commit/3bc032b75e8dc06c1a6fee592d86f3684869bb0b) Updated melpa
* [`8d737f3f`](https://github.com/nix-community/emacs-overlay/commit/8d737f3f4440f1f30e57fd213180062d6e3f04d8) Updated emacs
* [`a637a917`](https://github.com/nix-community/emacs-overlay/commit/a637a9177b12a8ba406bd9786827c4ba5c809264) Updated flake inputs
* [`c3bfafef`](https://github.com/nix-community/emacs-overlay/commit/c3bfafef9075c7f7367a0274b0de3c215ef18b2a) Updated melpa
* [`dc726e7c`](https://github.com/nix-community/emacs-overlay/commit/dc726e7c476bc262832391a0fd02f4cfc072dc25) Updated nongnu
* [`2f0acb10`](https://github.com/nix-community/emacs-overlay/commit/2f0acb10d4ca8535fc1c5186531d0dde19e8a947) Updated elpa
* [`e50af9e8`](https://github.com/nix-community/emacs-overlay/commit/e50af9e8275ef9dfd2ced7df52c796f13f1af6a1) Updated melpa
* [`14b82b95`](https://github.com/nix-community/emacs-overlay/commit/14b82b9590a9cfced6c702a184613b428ed676f3) Updated emacs
* [`617eaee2`](https://github.com/nix-community/emacs-overlay/commit/617eaee28a1802ae8d3740467590eefdf6a4c2bf) Updated flake inputs
* [`82b1c581`](https://github.com/nix-community/emacs-overlay/commit/82b1c581575c24ef8ef6724eb1072b2f8e26f279) Updated elpa
* [`c144308e`](https://github.com/nix-community/emacs-overlay/commit/c144308ef75b28ec3289c1ec7e34ee0ee80a3e3e) Updated melpa
* [`00e79db0`](https://github.com/nix-community/emacs-overlay/commit/00e79db0e791b9fd393eb98068135cb08d33684b) Updated emacs
* [`3dd4923b`](https://github.com/nix-community/emacs-overlay/commit/3dd4923bdd090186de32c11b1d6945fb8cc4eeea) Updated melpa
* [`c73112e1`](https://github.com/nix-community/emacs-overlay/commit/c73112e15bc9c784b4c6f4855ae4acb0a6cc480f) Updated emacs
* [`ba55c2fd`](https://github.com/nix-community/emacs-overlay/commit/ba55c2fd8703a7873347d7aebb69d3225401e70b) Updated elpa
* [`2740ccfe`](https://github.com/nix-community/emacs-overlay/commit/2740ccfee65e8483cdabd097d98feec9f3f089c8) Updated melpa
* [`db751b32`](https://github.com/nix-community/emacs-overlay/commit/db751b329a5927d928894c3232af6c70e04c32a9) Updated nongnu
* [`06a78be8`](https://github.com/nix-community/emacs-overlay/commit/06a78be871b652361acf2444388ec9b4257b2a12) Updated elpa
* [`1a666a67`](https://github.com/nix-community/emacs-overlay/commit/1a666a674ac0600b1c7339af84883addf25c8ad6) Updated melpa
* [`75650e84`](https://github.com/nix-community/emacs-overlay/commit/75650e84f17566e47b40ae75e21dff1e4f97fd3d) Updated emacs
* [`976544e1`](https://github.com/nix-community/emacs-overlay/commit/976544e11b9f3689f33c0cfd73431fe4bb23abd0) Updated flake inputs
* [`989dbd90`](https://github.com/nix-community/emacs-overlay/commit/989dbd909a25e01f91fb51bdb2bcf3777e5afc65) Updated melpa
* [`141d2669`](https://github.com/nix-community/emacs-overlay/commit/141d26694d12456d2012cbec704a979902ab6ccd) Updated emacs
* [`067e6295`](https://github.com/nix-community/emacs-overlay/commit/067e6295eac1f8ca7d7ce651ffda9e861cbc9e1a) Updated flake inputs
* [`56606545`](https://github.com/nix-community/emacs-overlay/commit/566065457b8c74ed951c19e145a2445a193bef9d) Updated nongnu
* [`a15dcfb3`](https://github.com/nix-community/emacs-overlay/commit/a15dcfb3f5c432983fb8fa9127f1b5a8d90fabaa) Updated elpa
* [`3748e4b7`](https://github.com/nix-community/emacs-overlay/commit/3748e4b786fb7582ef64555efb98a66cdad0d2fa) Updated melpa
* [`62aabfba`](https://github.com/nix-community/emacs-overlay/commit/62aabfbaa261598f019a1dc1fcf5ca15922ec598) Updated emacs
* [`3b3d5c27`](https://github.com/nix-community/emacs-overlay/commit/3b3d5c27983cc94a20b5adc1540f84f7980eb261) Updated nongnu
* [`a5e47657`](https://github.com/nix-community/emacs-overlay/commit/a5e47657c45e95fc5835e573a18722895e558e53) Updated elpa
* [`ee4a84b8`](https://github.com/nix-community/emacs-overlay/commit/ee4a84b86a72f85b3b69982e3555ec5ff0e5bfd0) Updated melpa
* [`4b3d8ab1`](https://github.com/nix-community/emacs-overlay/commit/4b3d8ab182d381b581de10a76754d453c0ae39dc) Updated emacs
* [`6ce6925b`](https://github.com/nix-community/emacs-overlay/commit/6ce6925b055a93cd747c4132bacaf6714b87bc1b) Updated melpa
* [`b3101a3a`](https://github.com/nix-community/emacs-overlay/commit/b3101a3a0f3883f97fa867ef56b0f29fa2b2b7f1) Updated emacs
* [`9b10be00`](https://github.com/nix-community/emacs-overlay/commit/9b10be0060eeda3029ee2da1676c142bdc2e689f) Updated nongnu
* [`650ebad7`](https://github.com/nix-community/emacs-overlay/commit/650ebad778616524c65c7556efe36df24ee76793) Updated elpa
* [`c3cecb35`](https://github.com/nix-community/emacs-overlay/commit/c3cecb35e0735f81b1b7cd1f928cd2225fe3bdf9) Updated melpa
* [`64e6dba5`](https://github.com/nix-community/emacs-overlay/commit/64e6dba516f22ccfa4eb4e8c6b881fa1e1ec80d4) Updated emacs
* [`8394b717`](https://github.com/nix-community/emacs-overlay/commit/8394b717055c5ef50756ae1e3fbca4749163e1bb) README.org: change to official nixos wiki link
* [`90541546`](https://github.com/nix-community/emacs-overlay/commit/90541546caac508094be72becb8e3ebb24f9c217) Updated elpa
* [`3c9143c3`](https://github.com/nix-community/emacs-overlay/commit/3c9143c30e06ea70c1ca87f50f84f72c6a79c787) Updated melpa
* [`eac5f274`](https://github.com/nix-community/emacs-overlay/commit/eac5f2748d0719b747e21b486c1686aa1e23a9ae) Updated emacs
* [`e3634be0`](https://github.com/nix-community/emacs-overlay/commit/e3634be032a23ea92c871afc57dc748d2c46623d) Updated flake inputs
* [`22e87ed5`](https://github.com/nix-community/emacs-overlay/commit/22e87ed52062b0732339ac5f13cd0c38dad62e28) Updated melpa
* [`d9fcbf59`](https://github.com/nix-community/emacs-overlay/commit/d9fcbf59e2675866e61c33985877a98f05b27df9) Updated nongnu
* [`7bc37ea4`](https://github.com/nix-community/emacs-overlay/commit/7bc37ea48b0ac6531b4cd260f742be94e8429f4f) Updated elpa
* [`5b749002`](https://github.com/nix-community/emacs-overlay/commit/5b749002dc81cbc503c10eee9bb8e0b129e805f1) Updated melpa
* [`5921ff72`](https://github.com/nix-community/emacs-overlay/commit/5921ff72aa8019353091f0e63b3e34db28fa757f) Updated emacs
* [`fe229612`](https://github.com/nix-community/emacs-overlay/commit/fe2296125d8cf1834bcf2f27278c3ba430ad1603) Updated nongnu
* [`98b4ec1b`](https://github.com/nix-community/emacs-overlay/commit/98b4ec1b834c278baec2dc17146c6ec026083670) Updated elpa
* [`30479b6f`](https://github.com/nix-community/emacs-overlay/commit/30479b6f2c3ea7a25be890276befd9272483e4d3) Updated melpa
* [`5fa07998`](https://github.com/nix-community/emacs-overlay/commit/5fa07998986f0adc6d6a96b3731097bad4e3304d) Updated emacs
* [`47150fd5`](https://github.com/nix-community/emacs-overlay/commit/47150fd5be494e65fc4d35ad51f30bd889f5f79f) Updated flake inputs
* [`4dd78ccd`](https://github.com/nix-community/emacs-overlay/commit/4dd78ccd4d4741710538fd0701b54831d1d58ce7) Updated melpa
* [`185ef369`](https://github.com/nix-community/emacs-overlay/commit/185ef369068c3d0e164730d855fb31444875b189) Updated emacs
* [`0646f852`](https://github.com/nix-community/emacs-overlay/commit/0646f852a92dcbac2cf8b03bc4bcef7752fef0b0) Updated nongnu
* [`eb7d824a`](https://github.com/nix-community/emacs-overlay/commit/eb7d824a6b3ac22a14328caeb6c34c08afc9eb88) Updated elpa
* [`2f19d976`](https://github.com/nix-community/emacs-overlay/commit/2f19d976990a992fbc67d353d97c21f46e8962f8) Updated melpa
* [`1ac99536`](https://github.com/nix-community/emacs-overlay/commit/1ac99536bb5eb9b2b4fc161bd0651bcbbb36c6d9) Updated emacs
* [`464ef9df`](https://github.com/nix-community/emacs-overlay/commit/464ef9dff2ba24da9f04909c60110b2dce23cb48) Updated nongnu
* [`3685aaa8`](https://github.com/nix-community/emacs-overlay/commit/3685aaa84c160c23b2ca7539ff03be50ba94587a) Updated elpa
* [`80b32011`](https://github.com/nix-community/emacs-overlay/commit/80b32011f432a98b91e0189eb764b93a34c4e90d) Updated melpa
* [`87e8ffcc`](https://github.com/nix-community/emacs-overlay/commit/87e8ffccb53aa67dfaab7bd4fd9f27b543e73cec) Bump actions/checkout from 4.2.0 to 4.2.1
* [`5875b25c`](https://github.com/nix-community/emacs-overlay/commit/5875b25cdcc87d39edf86534ca490e6c43ffb5e6) Updated melpa
* [`7b64ceb1`](https://github.com/nix-community/emacs-overlay/commit/7b64ceb1b9699dab4153e670bb146836466dfb23) Updated nongnu
* [`2c40c476`](https://github.com/nix-community/emacs-overlay/commit/2c40c4767fdf246fc4e8e63897b1f9ebb507a07c) Updated elpa
* [`b73795c2`](https://github.com/nix-community/emacs-overlay/commit/b73795c2481699e60ad9a331db4c7b8be3fee8b4) Updated melpa
* [`9af2d0c9`](https://github.com/nix-community/emacs-overlay/commit/9af2d0c9f70f686fc85bd78c631bced09ff2154c) recipes-archive-melpa.json: fix hashes for timu-*-theme
* [`ea207d97`](https://github.com/nix-community/emacs-overlay/commit/ea207d97f06fab220ba915daf40d6a27c6a066c5) Updated nongnu
* [`ad4b22bc`](https://github.com/nix-community/emacs-overlay/commit/ad4b22bcbca88199c9ac3a95a8ec99e0cd25a4c4) Updated elpa
* [`ae28e5b4`](https://github.com/nix-community/emacs-overlay/commit/ae28e5b42265fdc79965ec4f0958d591c3667d95) Updated melpa
* [`c5430682`](https://github.com/nix-community/emacs-overlay/commit/c5430682e61cd179555e3c8abb0785dd1c2c1a78) Updated emacs
* [`2189b8af`](https://github.com/nix-community/emacs-overlay/commit/2189b8afd568c8e2ae710adbc0a51251c36f9e06) Updated melpa
* [`74473259`](https://github.com/nix-community/emacs-overlay/commit/744732598481ac0b82b5fa0128b745f0db0d9116) Updated emacs
* [`41348c7e`](https://github.com/nix-community/emacs-overlay/commit/41348c7e347513795f210abcc158a7019fbdc6d3) Updated flake inputs
* [`9e2c73b9`](https://github.com/nix-community/emacs-overlay/commit/9e2c73b9c26597b750a18cbe8e7b9f998325b942) Updated elpa
* [`e4a692ef`](https://github.com/nix-community/emacs-overlay/commit/e4a692efda41fb5afdfd961bf36cd9c73cbd5307) Updated emacs
* [`6d0d0711`](https://github.com/nix-community/emacs-overlay/commit/6d0d071146d96b69d4ac57515946d2ef49c956b3) Updated flake inputs
* [`f6ee258a`](https://github.com/nix-community/emacs-overlay/commit/f6ee258af245cdaf54958dac5b482956dba237da) Updated nongnu
* [`ca95bd53`](https://github.com/nix-community/emacs-overlay/commit/ca95bd53a1c6077cb5169f15aab94fc38da477da) Updated elpa
* [`77cb2a48`](https://github.com/nix-community/emacs-overlay/commit/77cb2a48800525477ef5e34636ed848821760d6a) Updated emacs
* [`2b5a2ac7`](https://github.com/nix-community/emacs-overlay/commit/2b5a2ac70c95ece37e0d1bb1ad8814a13ea3e1c9) Updated nongnu
* [`3887df84`](https://github.com/nix-community/emacs-overlay/commit/3887df84b086e73986cffcb4c9c98297471f4afb) Updated elpa
* [`285f8d59`](https://github.com/nix-community/emacs-overlay/commit/285f8d59e8748a46035518ad906ac812893e9865) Updated emacs
* [`103a3b28`](https://github.com/nix-community/emacs-overlay/commit/103a3b289392d1d6b6335b5dd1b05e11e9d019db) Updated nongnu
* [`76f66a4f`](https://github.com/nix-community/emacs-overlay/commit/76f66a4f74341608e0f3c835f7b809a97f223219) Updated elpa
* [`3ff861b0`](https://github.com/nix-community/emacs-overlay/commit/3ff861b0b86704afa226b70312b584bfcdb46bd7) Updated emacs
* [`05a2608c`](https://github.com/nix-community/emacs-overlay/commit/05a2608c9e477d2cc83b081515d93276ed1f8c26) Updated emacs
* [`598437a0`](https://github.com/nix-community/emacs-overlay/commit/598437a0016e3891ae9e16032904673be4c77478) Updated nongnu
* [`b99fa8fd`](https://github.com/nix-community/emacs-overlay/commit/b99fa8fd7812f1d2a3114cff4a6a50ee1f604390) Updated elpa
* [`ae013c11`](https://github.com/nix-community/emacs-overlay/commit/ae013c110048505762b9458334094613b3ea6046) Updated emacs
* [`12492040`](https://github.com/nix-community/emacs-overlay/commit/1249204004e17f53a39a3afb1ef9a9c9881dcca6) Updated flake inputs
* [`f1915679`](https://github.com/nix-community/emacs-overlay/commit/f191567991033e00c9879147fb4de01465292282) Updated nongnu
* [`a882ebf2`](https://github.com/nix-community/emacs-overlay/commit/a882ebf2b169df3342b00f58fe1c719ec3f84d88) Updated elpa
* [`264b4e4a`](https://github.com/nix-community/emacs-overlay/commit/264b4e4a44a67a42bfc161ee48d9139f3abd8ab0) Updated emacs
* [`2a676710`](https://github.com/nix-community/emacs-overlay/commit/2a6767107654ef30e2b4568312308db13eea9a5d) Updated emacs
* [`9cc56167`](https://github.com/nix-community/emacs-overlay/commit/9cc5616723259cf3f69cf1499462077de2ead86f) Updated elpa
* [`426cc95e`](https://github.com/nix-community/emacs-overlay/commit/426cc95e354c1c53d296c5822e1a7a65f8b3ed06) Updated nongnu
* [`5300bc6e`](https://github.com/nix-community/emacs-overlay/commit/5300bc6e8734d18a08dec1b1f5d0b19b6ae585f5) Updated emacs
* [`82e6fb28`](https://github.com/nix-community/emacs-overlay/commit/82e6fb28615cfa454b3de5e40a8ef8df5fc374db) Updated flake inputs
* [`31e817d4`](https://github.com/nix-community/emacs-overlay/commit/31e817d4bb9e8a402c7898ec0d8c8290714b3a46) Updated nongnu
* [`6a395318`](https://github.com/nix-community/emacs-overlay/commit/6a395318b684197b6bc210d0c174c97034248a95) Updated elpa
* [`59b865f2`](https://github.com/nix-community/emacs-overlay/commit/59b865f2b0a7036fc7a03de1bfe81e0a810a81ca) Updated emacs
* [`bc42fc2a`](https://github.com/nix-community/emacs-overlay/commit/bc42fc2a962dd3e7321b4503fb534f3ab3a161e9) Updated emacs
* [`6357bea9`](https://github.com/nix-community/emacs-overlay/commit/6357bea9436dd7817681c7bc10412a63e3e818ef) Updated flake inputs
* [`aa5cc861`](https://github.com/nix-community/emacs-overlay/commit/aa5cc861152f1d7b28f00d2e1f0a3f926dcb1fec) Updated nongnu
* [`b2659787`](https://github.com/nix-community/emacs-overlay/commit/b2659787c20d75a71a092400932a34d2008baf26) Updated elpa
* [`3adba4b7`](https://github.com/nix-community/emacs-overlay/commit/3adba4b7d1db1d4eba3f682a956fcbb5de1bd7a1) Updated emacs
* [`2f73137d`](https://github.com/nix-community/emacs-overlay/commit/2f73137ddbe9068dfd9f81b8cbf0b0733627df45) Updated nongnu
* [`9c511a3c`](https://github.com/nix-community/emacs-overlay/commit/9c511a3c3068f69198a9f272b80c93c8a5853385) Updated elpa
* [`89860b1c`](https://github.com/nix-community/emacs-overlay/commit/89860b1c343648e8d71b6820e9311b98353ff14e) Updated emacs
* [`7938dbba`](https://github.com/nix-community/emacs-overlay/commit/7938dbba5b6ba17d90b86aa77e4e0f309225a6d3) Updated emacs
* [`fb0fa2bc`](https://github.com/nix-community/emacs-overlay/commit/fb0fa2bce785c4f304815beeaa39f260e7762042) Updated nongnu
* [`806a6630`](https://github.com/nix-community/emacs-overlay/commit/806a6630330b0c4441da0665397a27ccb2805c33) Updated elpa
* [`e622d87b`](https://github.com/nix-community/emacs-overlay/commit/e622d87bd6d6fa49c486ed32920dbacb15e67f2d) Updated emacs
* [`8703ee89`](https://github.com/nix-community/emacs-overlay/commit/8703ee8957c906474b524ba5b77d80f6d047a64b) Updated nongnu
* [`eda92813`](https://github.com/nix-community/emacs-overlay/commit/eda9281341686326991b2550780180064900777a) Updated elpa
* [`5d488eec`](https://github.com/nix-community/emacs-overlay/commit/5d488eec63742aca43fb57a6f805ef282294f3a4) Updated emacs
* [`4d31bc2c`](https://github.com/nix-community/emacs-overlay/commit/4d31bc2cd9a919f041e04eea272d1309bc056f0b) Updated flake inputs
* [`6304f986`](https://github.com/nix-community/emacs-overlay/commit/6304f986376e810d64c0939807a996a956e34d70) Updated emacs
* [`3545afef`](https://github.com/nix-community/emacs-overlay/commit/3545afef464c0fe128eefaffefabf6438c8bb9e3) Updated nongnu
* [`d4873799`](https://github.com/nix-community/emacs-overlay/commit/d487379952a58611b91047c5176bfb26289332f2) Updated elpa
* [`6025acb8`](https://github.com/nix-community/emacs-overlay/commit/6025acb8c873345197aae8cf9ff06cf11c61d5f8) Updated emacs
* [`948001c8`](https://github.com/nix-community/emacs-overlay/commit/948001c86697aaaa58bd5bc2cc82ce4552eb894e) Updated nongnu
* [`20e5bc49`](https://github.com/nix-community/emacs-overlay/commit/20e5bc499055ffb8c97acf13361450e02852153f) Updated elpa
* [`9d46b89a`](https://github.com/nix-community/emacs-overlay/commit/9d46b89a210d43f294374dc627e03f7164f3a470) Updated emacs
* [`dd66a43b`](https://github.com/nix-community/emacs-overlay/commit/dd66a43b14c37c5461bdc4324be3fd32e720c996) Updated emacs
* [`ccf9bb9a`](https://github.com/nix-community/emacs-overlay/commit/ccf9bb9a2b283904ba4763b30ac0730b358bcc88) Updated flake inputs
* [`c34975c1`](https://github.com/nix-community/emacs-overlay/commit/c34975c1b4669ff57aa4d9e03e91a0ea7ea62da7) Updated nongnu
* [`7c8d4c6b`](https://github.com/nix-community/emacs-overlay/commit/7c8d4c6bbe78794cd40b5a16adc14dba46f17a9a) Updated elpa
* [`d3881d1b`](https://github.com/nix-community/emacs-overlay/commit/d3881d1b6f01c5d01d4af9b61026315aeb2367fb) Updated emacs
* [`7a402fa1`](https://github.com/nix-community/emacs-overlay/commit/7a402fa16538d93765625fb06cd18364ca2c0be7) Updated nongnu
* [`04821886`](https://github.com/nix-community/emacs-overlay/commit/0482188677c67f1a95c21d580df61551bc8addef) Updated elpa
* [`cc8c7d43`](https://github.com/nix-community/emacs-overlay/commit/cc8c7d43b2bc0f2e3fa7433ce33fc49887245427) Updated emacs
* [`632463d5`](https://github.com/nix-community/emacs-overlay/commit/632463d5b3d99ed65d68921ce9302edc754a5daf) Updated emacs
* [`6fd1f939`](https://github.com/nix-community/emacs-overlay/commit/6fd1f939e4453206d131744aee904c019f216ecd) Updated elpa
* [`d9efc55f`](https://github.com/nix-community/emacs-overlay/commit/d9efc55f0843a251f45e32569348edaa8add061e) Updated nongnu
* [`ab0a7f5d`](https://github.com/nix-community/emacs-overlay/commit/ab0a7f5d3a957009c9396e6020c25a6e28c1fe21) Updated elpa
* [`4887992a`](https://github.com/nix-community/emacs-overlay/commit/4887992a11388734b4900f3d16892999b54849ff) Updated emacs
* [`3766c53b`](https://github.com/nix-community/emacs-overlay/commit/3766c53bf8c0e24ac5d3aed2b8f772d33f59f96a) Updated flake inputs
* [`6b8d885b`](https://github.com/nix-community/emacs-overlay/commit/6b8d885bbe788308c3c6cea8c1fe637660793424) Updated emacs
* [`2db30fcc`](https://github.com/nix-community/emacs-overlay/commit/2db30fccd45552347394b56b9a143db49ad0c8b3) Updated nongnu
* [`bff71020`](https://github.com/nix-community/emacs-overlay/commit/bff710200084114208d808f4125d19c804b9a382) Updated elpa
* [`185ee299`](https://github.com/nix-community/emacs-overlay/commit/185ee299bf80de2cfb21517cdff7d9f1a1f0dd9b) Updated emacs
* [`fad4f014`](https://github.com/nix-community/emacs-overlay/commit/fad4f0146ceb35b2d5c168417c9e19f15867697e) Updated flake inputs
* [`bc6c3609`](https://github.com/nix-community/emacs-overlay/commit/bc6c3609c65ad4683388e3705c03b04531e192fa) Updated nongnu
* [`dfbc5302`](https://github.com/nix-community/emacs-overlay/commit/dfbc53025ea2527fbf2aca46be92cf725360f4a9) Updated elpa
* [`8585c0d7`](https://github.com/nix-community/emacs-overlay/commit/8585c0d7f7b5efa704112bbfc6310cebacb94e69) Updated emacs
* [`eb6cc11e`](https://github.com/nix-community/emacs-overlay/commit/eb6cc11e49bbaac9de9a0c94a331fbe900c5384c) Updated elpa
* [`921c961c`](https://github.com/nix-community/emacs-overlay/commit/921c961c4b0754122a3897bb1d68a40f3f925ef0) Updated emacs
* [`42221c01`](https://github.com/nix-community/emacs-overlay/commit/42221c0108e81cc9f0b8219b8a3855eace7be53c) Updated nongnu
* [`c37eef2b`](https://github.com/nix-community/emacs-overlay/commit/c37eef2b98dcf0fb77f0d0457f14e4ae7a728050) Updated elpa
* [`825505b4`](https://github.com/nix-community/emacs-overlay/commit/825505b43c276d6efd41c69f9dd5ca3dfc522284) Updated emacs
* [`074f3bcc`](https://github.com/nix-community/emacs-overlay/commit/074f3bcc4b6744dcb9088c9197b8b1ac97f3df74) Updated emacs
* [`fc64298c`](https://github.com/nix-community/emacs-overlay/commit/fc64298c41b56fecff1e1b627e4c87ad1a0bffa9) Updated nongnu
* [`7f86b977`](https://github.com/nix-community/emacs-overlay/commit/7f86b977ad3e397c8cf37be53a6578ec5cd109c7) Updated elpa
* [`5f83b15a`](https://github.com/nix-community/emacs-overlay/commit/5f83b15a9fe67d4dd1edcd281194d4d30925125a) Updated emacs
* [`b911fe3b`](https://github.com/nix-community/emacs-overlay/commit/b911fe3bf813b7d1df1245ddd2d0f31592d48136) Updated nongnu
* [`d3072046`](https://github.com/nix-community/emacs-overlay/commit/d3072046c9b1c2a1313c8ccf9ce1d51fb83bc058) Updated elpa
* [`77d74dfc`](https://github.com/nix-community/emacs-overlay/commit/77d74dfc6c667e656c96aec2359477d0e8200890) Updated emacs
* [`d88dc995`](https://github.com/nix-community/emacs-overlay/commit/d88dc99503cd831388bef9c8deb06fc65b767478) Updated flake inputs
* [`5f1ab1d8`](https://github.com/nix-community/emacs-overlay/commit/5f1ab1d8d749dba6673786c5dda321f08fee07b2) Updated emacs
* [`45522b10`](https://github.com/nix-community/emacs-overlay/commit/45522b1053af4c3e82a3ba8c7c3ffc80ebb9faec) Updated flake inputs
* [`6914e276`](https://github.com/nix-community/emacs-overlay/commit/6914e2767a72dfc8b4b7624156f5eb02b65ce1d9) Updated nongnu
* [`bdc09531`](https://github.com/nix-community/emacs-overlay/commit/bdc09531a05831d3a450846997d6b1efcf662bb5) Updated elpa
* [`42247fb5`](https://github.com/nix-community/emacs-overlay/commit/42247fb5d6545d95f615538de8d4186006b68357) Updated emacs
* [`2a1bcc85`](https://github.com/nix-community/emacs-overlay/commit/2a1bcc85cf8ce76836948707d24a8c1f889f02b8) Updated nongnu
* [`7f4f073b`](https://github.com/nix-community/emacs-overlay/commit/7f4f073bbd80eba17bd1e585abe0e4271c63e485) Updated elpa
* [`a798b734`](https://github.com/nix-community/emacs-overlay/commit/a798b734eeea4177bc9359aa2b1bbb5e8b368acc) Updated emacs
* [`6cce90fc`](https://github.com/nix-community/emacs-overlay/commit/6cce90fcdcd89fd498850f3905eff3bc03c0e12d) Bump actions/checkout from 4.2.1 to 4.2.2
* [`b32650fe`](https://github.com/nix-community/emacs-overlay/commit/b32650fe39381fd539d5452962adb3e37d045c62) Updated emacs
* [`64c6af10`](https://github.com/nix-community/emacs-overlay/commit/64c6af10947cd17201570726eba26046e95ed58b) Updated nongnu
* [`714bc70d`](https://github.com/nix-community/emacs-overlay/commit/714bc70d0e19690f5b0c605223fd53874cd71280) Updated elpa
* [`d212b83f`](https://github.com/nix-community/emacs-overlay/commit/d212b83f4742843c6ef5c93d0ffb73b4d52a1f85) Updated emacs
* [`ccdc0418`](https://github.com/nix-community/emacs-overlay/commit/ccdc04185c596b78387aeabee053aad7e62060c4) Updated emacs
* [`65b0352a`](https://github.com/nix-community/emacs-overlay/commit/65b0352aa3c436b17fa4ab6adcf9b22bc67610cb) Updated flake inputs
* [`ab38e576`](https://github.com/nix-community/emacs-overlay/commit/ab38e5767457fd7bc0ef00962feeb4c4e5ddfeb8) Updated nongnu
* [`b2082080`](https://github.com/nix-community/emacs-overlay/commit/b208208055e10d9ff9c8036a77c4e5c1dbf8bba1) Updated nongnu
* [`67374cbd`](https://github.com/nix-community/emacs-overlay/commit/67374cbdb8400967ef6aba113e6d5815a13bf7bb) Updated elpa
* [`88aa67a2`](https://github.com/nix-community/emacs-overlay/commit/88aa67a24ebef4001b58945bdc2852f427f1abc9) Updated emacs
* [`36d8e10e`](https://github.com/nix-community/emacs-overlay/commit/36d8e10e11f55571860ec24910e0d0408ecef862) Updated nongnu
* [`7a941f6b`](https://github.com/nix-community/emacs-overlay/commit/7a941f6bf6fdd698830b1bef4cb98d2a8fa15f34) Updated elpa
* [`e380fa7e`](https://github.com/nix-community/emacs-overlay/commit/e380fa7ec3666a347d3d5bbcacbdd53dd9f89157) Updated emacs
* [`8bb49e9a`](https://github.com/nix-community/emacs-overlay/commit/8bb49e9a3d65294d63c69f7ddc217076fd29767b) Updated nongnu
* [`60db7647`](https://github.com/nix-community/emacs-overlay/commit/60db7647705e60bbc60eed8b8ebaf44036536440) Updated elpa
* [`200231b4`](https://github.com/nix-community/emacs-overlay/commit/200231b4367ea41169c472b256ba68b74ebe097f) Updated emacs
* [`620e6fc3`](https://github.com/nix-community/emacs-overlay/commit/620e6fc31925817272633f9f5a4245feac41e1f1) Updated flake inputs
* [`fd67937f`](https://github.com/nix-community/emacs-overlay/commit/fd67937f973307e63540990f568a288fcedb9d67) Updated nongnu
* [`cedccfff`](https://github.com/nix-community/emacs-overlay/commit/cedccfff0d6e1fb9c62f77fb4e05169256219eca) Updated emacs
