### PR TITLE
niv doomemacs: update c8a5e6ec -> dea6552e

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "doomemacs",
         "repo": "doomemacs",
-        "rev": "c8a5e6ec1ca85a35f94d6c820c2fd8888373c2ae",
-        "sha256": "08cwhfwg4apm7rxfhkadlif79maklmx4k1il4rixwlc9gdy422lb",
+        "rev": "dea6552ef97d8d1b731bef17548d492e8b15566c",
+        "sha256": "1dll7ya5l62fdn6gixqacyrh244jqskj66g0byw2iij26r1zkm16",
         "type": "tarball",
-        "url": "https://github.com/doomemacs/doomemacs/archive/c8a5e6ec1ca85a35f94d6c820c2fd8888373c2ae.tar.gz",
+        "url": "https://github.com/doomemacs/doomemacs/archive/dea6552ef97d8d1b731bef17548d492e8b15566c.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "emacs-overlay": {


### PR DESCRIPTION
## Changelog for doomemacs:
Branch: master
Commits: [doomemacs/doomemacs@c8a5e6ec...dea6552e](https://github.com/doomemacs/doomemacs/compare/c8a5e6ec1ca85a35f94d6c820c2fd8888373c2ae...dea6552ef97d8d1b731bef17548d492e8b15566c)

* [`92c06445`](https://github.com/doomemacs/doomemacs/commit/92c064459f3f48af9880f51617bef02ac73b9cec) fix(default): search-project: don't escape selection
* [`8c771192`](https://github.com/doomemacs/doomemacs/commit/8c7711920e6dfc2996200fde786bf1b09f58730f) fix(lib): doom/{reload,upgrade} on Windows
* [`0b3800fb`](https://github.com/doomemacs/doomemacs/commit/0b3800fbe4735b48dda1b581410fca162b1c6c22) feat(cli): add doom.sh for Android users
* [`fe7b8496`](https://github.com/doomemacs/doomemacs/commit/fe7b84966a5ec3b6e2f4e0a4a3094bd2f6490cf9) bump: straight
* [`ad29be39`](https://github.com/doomemacs/doomemacs/commit/ad29be39f6fd5778ba7e8651dd3a1b1f5d3a66ae) refactor(lib): add provide lines
* [`c88516d6`](https://github.com/doomemacs/doomemacs/commit/c88516d6bbd7e8e651f7b74bd8ee0e867cf1207f) docs: revise Emacs version warnings
* [`9df3787b`](https://github.com/doomemacs/doomemacs/commit/9df3787bc7ed70687af5ce81c7e62332298814e8) docs: warn about segfaults on Emacs 29.4 + PGTK
* [`c75e1b91`](https://github.com/doomemacs/doomemacs/commit/c75e1b915bf7de28ae057aaa7b74221ec943bd74) docs(cc): treat clangd as default/better option
* [`896204c8`](https://github.com/doomemacs/doomemacs/commit/896204c8f7942f18ce72628533790f3e87e42729) docs: more robust nerd-icon doctor check
* [`df651377`](https://github.com/doomemacs/doomemacs/commit/df65137730bff3cc8a6c78d34e28d3a56adb632c) docs: warn Windows users about symlinks
* [`9d859f62`](https://github.com/doomemacs/doomemacs/commit/9d859f62e4f762988ba87ef84723e1ac7df695ca) fix(clojure): type error evilifying cider-debug keys
* [`397d1493`](https://github.com/doomemacs/doomemacs/commit/397d1493131812dae6c8d2099c40125e36a6f815) fix(python): renamed python-pytest commands
* [`a35992a9`](https://github.com/doomemacs/doomemacs/commit/a35992a97d17e98e9dab08006eb78d0a79f44bbf) bump: :email wanderlust
* [`68b3cc86`](https://github.com/doomemacs/doomemacs/commit/68b3cc86c581408495e2837920555630a15ee47b) fix(ruby): replace the obsolete macro `featurep!` with `modulep!`
* [`dc387bc4`](https://github.com/doomemacs/doomemacs/commit/dc387bc48666fd911425f9c15ece1702840ea46d) fix(mu4e): org-msg: toggle behavior
* [`03fbb00e`](https://github.com/doomemacs/doomemacs/commit/03fbb00e3c1f71070386de6bab101d452189b5b3) bump: :ui doom
* [`8b9168de`](https://github.com/doomemacs/doomemacs/commit/8b9168de6e6a9cabf13d1c92558e2ef71aa37a72) release(modules): 24.11.0-dev
* [`a5538209`](https://github.com/doomemacs/doomemacs/commit/a5538209d82e54bf67a45248f6d3505c8451e54f) fix(fold): autoload `+fold--ensure-hideshow-mode`
* [`b9deb35a`](https://github.com/doomemacs/doomemacs/commit/b9deb35aabf99d71d25cd44fff579dac102f6a94) bump: :lang factor
* [`15904349`](https://github.com/doomemacs/doomemacs/commit/15904349cfb1fb920a0b275850859dda701186bc) refactor!: module API
* [`448bc5ca`](https://github.com/doomemacs/doomemacs/commit/448bc5cae2ce6f6b8533d1975c6601e4072207d7) refactor: use negated flags
* [`49f4bf68`](https://github.com/doomemacs/doomemacs/commit/49f4bf6819dc0016f569383e1a7c5ffb5ef0854f) fix(lib): letf!: defun* indentation
* [`fafdb25d`](https://github.com/doomemacs/doomemacs/commit/fafdb25dd8a6ecd21ba82ffc0e92be3816d063ba) feat(lib): introduce doom-error & error functions
* [`dea6552e`](https://github.com/doomemacs/doomemacs/commit/dea6552ef97d8d1b731bef17548d492e8b15566c) fix(agda): agda2-auto-maybe-all -> agda2-mimer-maybe-all
