### PR TITLE
niv nixpkgs: update 07b88919 -> c29a8c6a

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "07b889196841399386c384461586b52901b68439",
-        "sha256": "1qcds1zy8c4gfcbnk0paxpyjq3yyczcm86c0hayq4y7aagpraz37",
+        "rev": "c29a8c6aa5208fbafa857098a7cdbf4c4ea41a07",
+        "sha256": "03pg2qs1bh1i37ncc2pmry9np55sngmzh9jq5anlcnf7z1zpr079",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/07b889196841399386c384461586b52901b68439.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/c29a8c6aa5208fbafa857098a7cdbf4c4ea41a07.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@07b88919...c29a8c6a](https://github.com/nixos/nixpkgs/compare/07b889196841399386c384461586b52901b68439...c29a8c6aa5208fbafa857098a7cdbf4c4ea41a07)

* [`b4e403f9`](https://github.com/NixOS/nixpkgs/commit/b4e403f9e08f2ddfe79c4dbf66f9921afbd57eb6) nixos/doc: Split `mkdir` mode into `chmod` command for clarity
* [`eda01063`](https://github.com/NixOS/nixpkgs/commit/eda01063e7173446b0fa4baf5c9fb2ee4063a612) r128gain: 1.0.3 -> 1.0.7
* [`165c6e30`](https://github.com/NixOS/nixpkgs/commit/165c6e3067f0d3114823f15058182c7da75a510c) sauce-connect: use update script
* [`6b3b48cb`](https://github.com/NixOS/nixpkgs/commit/6b3b48cb7cc072c3213b7ef51d126bf84231d6e8) lighthouse: add `package` option to service
* [`c81b9995`](https://github.com/NixOS/nixpkgs/commit/c81b99951d81d3a3673a865a2904ce40b73aa00a) cargo-pio: init at 0.25.6
* [`2c72efd1`](https://github.com/NixOS/nixpkgs/commit/2c72efd1311450c62723bfd8639e67a06a004c73) github-markdown-toc-go: init at 1.4.0
* [`e608384d`](https://github.com/NixOS/nixpkgs/commit/e608384d5330440876e3860e6ffc0c6808263dc5) vendor-reset: unstable-2021-02-16 -> unstable-2024-04-16
* [`2ec46d71`](https://github.com/NixOS/nixpkgs/commit/2ec46d71212e0b74c9616f13c9482d9093cc2b65) pdfstudio: added 2024.0.0
* [`8ac5effc`](https://github.com/NixOS/nixpkgs/commit/8ac5effc2f4a56febe7a9cd5213094ec98b07875) opencl-headers: 2023.12.14 -> 2024.05.08
* [`ffb76687`](https://github.com/NixOS/nixpkgs/commit/ffb76687038465052847e1919245a9a339b52427) nixos/ibus: document ibus-engine for Chinese input
* [`700ebb76`](https://github.com/NixOS/nixpkgs/commit/700ebb76d82940b508e6477e9b0a7711d328177f) minizip-ng: 4.0.3 -> 4.0.7
* [`5ac05029`](https://github.com/NixOS/nixpkgs/commit/5ac050295d497919b82cb6eda143d1d5534ecf0b) iterm2: Indicate sourceProvenance
* [`5d1063c4`](https://github.com/NixOS/nixpkgs/commit/5d1063c439fe925ea6db0e03557a5a1c7c5da576) nixos/jack: Fix jack-session init script
* [`05fb63fe`](https://github.com/NixOS/nixpkgs/commit/05fb63fea32984597dd3ab6511294a0c9be5d6c7) keyspersecond: init at 8.9
* [`2cbada22`](https://github.com/NixOS/nixpkgs/commit/2cbada22bfa6ab73113425cb2934c5588c4c7c8d) maintainers: add diamond-deluxe
* [`3e64d490`](https://github.com/NixOS/nixpkgs/commit/3e64d490f6245f1ac96e7ec0e381ed4b68fc5c3f) pyevtk: 1.2.0 -> 1.6.0; change upstream url
* [`d0084f94`](https://github.com/NixOS/nixpkgs/commit/d0084f94a09dc3b97999cdc26416d17cdc31f0cd) maintainers: add alex
* [`e4eea837`](https://github.com/NixOS/nixpkgs/commit/e4eea8374c31d5e8fff223bd6e2881a3a0e8f51e) pkgsStatic.openssh: fix build
* [`a9fb62f1`](https://github.com/NixOS/nixpkgs/commit/a9fb62f1e3f582fc2118670bd9dc45281ba5d6b7) luminous-ttv: init at 0.5.7
* [`75775507`](https://github.com/NixOS/nixpkgs/commit/75775507721e12796782900eff29ab71f01cb37b) amneziawg-go: init at 0.2.12
* [`cec81c6d`](https://github.com/NixOS/nixpkgs/commit/cec81c6d537490ecce379441a1a0ecd4879442ff) tkey-ssh-agent: add updateScript
* [`9a9bc426`](https://github.com/NixOS/nixpkgs/commit/9a9bc42675e485b4112f6a22c1ab905828259ede) tkey-ssh-agent: add testVersion test
* [`99179cdd`](https://github.com/NixOS/nixpkgs/commit/99179cddcc95bab5ab1cb21b1638ef3203a0b5da) kopia: add updateScript and testVersion
* [`a9a9833f`](https://github.com/NixOS/nixpkgs/commit/a9a9833f0178b9f799de6fab9e3b236a25496296) libwebp: format
* [`909c4914`](https://github.com/NixOS/nixpkgs/commit/909c4914937137a5b19a42a78eb9252e7ce2b3b6) libwebp: build with CMake
* [`d7fda424`](https://github.com/NixOS/nixpkgs/commit/d7fda424a65c2c0f407e59cc126c2f3360e38a26) ladybird: remove workaround for missing libwebp CMake targets
* [`d594ccbf`](https://github.com/NixOS/nixpkgs/commit/d594ccbfd3b63e485b6cc32088ad8b8ee898e7e1) nixos/frigate: Clear cache directory before start
* [`b1863411`](https://github.com/NixOS/nixpkgs/commit/b1863411fdffe8bdeac6feafb011c05015de6c01) duckstation-bin: init at 0.1-7294
* [`ccd8cd8b`](https://github.com/NixOS/nixpkgs/commit/ccd8cd8bd85ec5fab368a0f1d87eae73230ff973) maintainers: add florensie
* [`930f82ea`](https://github.com/NixOS/nixpkgs/commit/930f82eaf3bc9263729a9bf874343ec6b4f94d3c) nixos/soju: use message-store instead of deprecated log in config
* [`bc7a9700`](https://github.com/NixOS/nixpkgs/commit/bc7a9700e943b5df3bc04e667e4ee0e4728a0d76) dotnet-repl: init at 0.1.216
* [`ca5dd27a`](https://github.com/NixOS/nixpkgs/commit/ca5dd27a4d858735de131c6c99d1aebf35dae528) simple64: init at 2024.09.1
* [`80aa9b21`](https://github.com/NixOS/nixpkgs/commit/80aa9b2146c128cd8e3c4fc975f1c19cd53e131c) simple64-netplay-server: init at 2024.06.1
* [`45c386ca`](https://github.com/NixOS/nixpkgs/commit/45c386ca9bf64e68da2b6edc1555a57219782a5c) libevdev: 1.13.2 -> 1.13.3
* [`505e078f`](https://github.com/NixOS/nixpkgs/commit/505e078f737869743a2d127695fc6404fb15c75e) iputils: 20240117 -> 20240905
* [`b3ee3dcf`](https://github.com/NixOS/nixpkgs/commit/b3ee3dcf43b0e6b173df7cf3266d1f80c66e65f6) repak: init at 0.2.2
* [`c2b0b19d`](https://github.com/NixOS/nixpkgs/commit/c2b0b19d1cf2b2dc35f9e5a435c13a489e92e1c2) xorg.libXi: 1.8.1 -> 1.8.2
* [`97f1e5df`](https://github.com/NixOS/nixpkgs/commit/97f1e5df091ae29f0f6e3f0e345e236af9e20090) nixos/rustdesk-server: suppport enable rustdesk's signal server and relay server seperately and rename an option
* [`ef28bf93`](https://github.com/NixOS/nixpkgs/commit/ef28bf932986c4a074ca5d56af6470cc64e18880) ocaml-ng: remove __attrsFailEvaluation
* [`bae4966c`](https://github.com/NixOS/nixpkgs/commit/bae4966c75cdc8db3235274b639f094bb4e22dea) xrgears: move to by-name
* [`eb06dadf`](https://github.com/NixOS/nixpkgs/commit/eb06dadfa09babd09f9b6ae56b75797225cd8962) xrgears: add update script
* [`f6a2e5ad`](https://github.com/NixOS/nixpkgs/commit/f6a2e5adf17667f7afb192890d71f4001e8c30b1) xrgears: unstable-2021-06-19 -> 1.0.1-unstable-2024-07-09
* [`58a31f09`](https://github.com/NixOS/nixpkgs/commit/58a31f09b8d2b25035f9deb0face05890381daf3) xrgears: format
* [`b13221ac`](https://github.com/NixOS/nixpkgs/commit/b13221acbcae6ebc9c88cdf2e2461bf9764e2759) cryptsetup: 2.7.4 -> 2.7.5
* [`567bd7c6`](https://github.com/NixOS/nixpkgs/commit/567bd7c6a61c0673cbc8e16a70a0b36f19dc8cbf) autoPatchelfHook: expose script as top level package
* [`c8e45153`](https://github.com/NixOS/nixpkgs/commit/c8e45153f6838025b4830a9b7f63a010a02567d2) eglexternalplatform: 1.1 -> 1.2
* [`dba4f38d`](https://github.com/NixOS/nixpkgs/commit/dba4f38d34c801052143c71fe772cde4e17b2330) nixos/renovate: set service type to simple
* [`468475a8`](https://github.com/NixOS/nixpkgs/commit/468475a8919c18ce142c40ee0b94e617896b99e3) pstoedit: 3.78 -> 4.01
* [`d832ccf9`](https://github.com/NixOS/nixpkgs/commit/d832ccf98e0b46c5565c5f8785356915c7a0263e) xorg.luit: 20240102 -> 20240910
* [`6eae42e7`](https://github.com/NixOS/nixpkgs/commit/6eae42e744331df1a8a1268589b35522a91e70ab) shadcn: init at 2.0.3
* [`dea1d488`](https://github.com/NixOS/nixpkgs/commit/dea1d488da5d3dca83e1f1ca6780cb22e45ba4f9) comodoro: update homepage
* [`754ce5ca`](https://github.com/NixOS/nixpkgs/commit/754ce5caaafeaf47951a0a27b4c2a64136829716) python3Packages.pycparser: change to pyproject
* [`9bd50dac`](https://github.com/NixOS/nixpkgs/commit/9bd50dacb431d0188759d2c0b8e046e8610b89b2) texinfo7: 7.1 -> 7.1.1
* [`85367ef2`](https://github.com/NixOS/nixpkgs/commit/85367ef231744a6fdcd948492a086fcfa8028801) inkscape-extensions.silhouette: 1.28 -> 1.29
* [`7984c1d0`](https://github.com/NixOS/nixpkgs/commit/7984c1d03bb87548ca8565dee2889e610e55d40a) unibilium: 2.1.1 -> 2.1.2
* [`ee5127c6`](https://github.com/NixOS/nixpkgs/commit/ee5127c6df7e5316a175e0bf9becc6156435a996) iproute2: 6.10.0 -> 6.11.0
* [`509f5d09`](https://github.com/NixOS/nixpkgs/commit/509f5d09f493c1dc36f33c5d5b659626d832f17f) vapoursynth: 69 -> 70
* [`229c15a7`](https://github.com/NixOS/nixpkgs/commit/229c15a739a7ebe0ef17528b2cd5d674a24b14ce) sql-studio: init at 0.1.27
* [`e3da86c9`](https://github.com/NixOS/nixpkgs/commit/e3da86c954387b2e2b25bcb621608ebaf24be423) isocodes: 4.16.0 -> 4.17.0
* [`602a8585`](https://github.com/NixOS/nixpkgs/commit/602a8585576f1506790d28b9e6466b4032739f5f) peertube-viewer: clean up package a bit
* [`e86b46d6`](https://github.com/NixOS/nixpkgs/commit/e86b46d61b1e31422e34ee18d37133d92b5c16d8) libraw: 0.21.2 -> 0.21.3
* [`a25f777e`](https://github.com/NixOS/nixpkgs/commit/a25f777e1a81a3ba90c1152a79fc3f84b41a452e) ember-cli: remove mkYarnPackage usage
* [`eec7d19b`](https://github.com/NixOS/nixpkgs/commit/eec7d19b98e5c89ba08710442a308c4defac38d8) curl: 8.9.1 -> 8.10.1
* [`073cb139`](https://github.com/NixOS/nixpkgs/commit/073cb13917ed4568f7c98c0829d50ca886006bdf) vscode-extensions.usernamehw.errorlens: 3.16.0 -> 3.20.0
* [`70f1b1bb`](https://github.com/NixOS/nixpkgs/commit/70f1b1bb77f50e86400cb931f8b2997d74f03dc9) kuro: unlock electron version
* [`b6567e0a`](https://github.com/NixOS/nixpkgs/commit/b6567e0a544f493c012b0a76b5255ea599bd373b) postgresqlPackages.lantern.tests.extension: fix test
* [`2b9fa464`](https://github.com/NixOS/nixpkgs/commit/2b9fa464cf6c2a1189dc4cd5d796cb132a9a257b) postgresqlPackages: refactor extension checks
* [`37ac1256`](https://github.com/NixOS/nixpkgs/commit/37ac1256c4e33c13f8634cd22da3136f76718b10) postgresqlPackages.pgjwt: add simple create extension check
* [`d7c610e6`](https://github.com/NixOS/nixpkgs/commit/d7c610e6edf8f636d915c65fe6bf9a7f2cf44d56) mpvScripts.uosc: 5.5.0 -> 5.6.0
* [`f1ea3915`](https://github.com/NixOS/nixpkgs/commit/f1ea391568911c59f9e52e9b3cd77f3860e6bd96) gromit-mpx: format
* [`72856321`](https://github.com/NixOS/nixpkgs/commit/72856321d7b1e810d679067cf5ce1c39e200eb4b) gromit-mpx: use specific dependencies directly in package definition
* [`e12990f3`](https://github.com/NixOS/nixpkgs/commit/e12990f31e931f27156189db90d439e477eb9fe6) gromit-mpx: move to pkgs/by-name
* [`0809e356`](https://github.com/NixOS/nixpkgs/commit/0809e3567c1230b7e1af3228c071e0d313e46539) gromit-mpx: move to finalAttrs
* [`e4104ba2`](https://github.com/NixOS/nixpkgs/commit/e4104ba247b588eca8af04c1717796e6bc7e5788) gromit-mpx: 1.6.0 -> 1.7.0
* [`0beb348e`](https://github.com/NixOS/nixpkgs/commit/0beb348e82c1e7c80c21ec3ea861591c28e24f52) gromit-mpx: add changelog to meta
* [`2b37673f`](https://github.com/NixOS/nixpkgs/commit/2b37673f319d8b0f9254769df2e3567e9bbee4f8) gromit-mpx: add maintainer gepbird
* [`eed66c37`](https://github.com/NixOS/nixpkgs/commit/eed66c3754fd55864498db78be15f0866aac04c3) gromit-mpx: move to hash from sha256
* [`23f433fb`](https://github.com/NixOS/nixpkgs/commit/23f433fbf11d531eb29ef0544d5e7be10c4c778c) libjxl: 0.10.3 -> 0.11.0
* [`c9a67838`](https://github.com/NixOS/nixpkgs/commit/c9a67838b375d438dfba83b7194a785c8560e49e) man-db: 2.12.1 -> 2.13.0
* [`9d13605f`](https://github.com/NixOS/nixpkgs/commit/9d13605f1c9e3de4864429fead360516f9bbbb56) omnisharp-roslyn: format
* [`f9d3af6f`](https://github.com/NixOS/nixpkgs/commit/f9d3af6fce11ee199e65f8fc8c9bbc2945682113) omnisharp-roslyn: move to pkgs/by-name
* [`18542a7b`](https://github.com/NixOS/nixpkgs/commit/18542a7bff212cf15815530be088d3f86d5ee4a8) omnisharp-roslyn: drop test for .NET 7
* [`ac2f7cf2`](https://github.com/NixOS/nixpkgs/commit/ac2f7cf25a11216f157a709f83724ae00220fc2d) omnisharp-roslyn: set passthru.updateScript
* [`218f0f9c`](https://github.com/NixOS/nixpkgs/commit/218f0f9c40d79b059db0762b43d22fa485f7691b) omnisharp-roslyn: ignore beta releases for update script
* [`1e56561c`](https://github.com/NixOS/nixpkgs/commit/1e56561c12fb90d1e861e2cf5547622de6c5ce68) omnisharp-roslyn: add maintainer gepbird
* [`f7e7cd2f`](https://github.com/NixOS/nixpkgs/commit/f7e7cd2ff6841eb50604a3bd7554ec18d68e8b98) nix-serve: mark as broken on darwin
* [`6af9c5c3`](https://github.com/NixOS/nixpkgs/commit/6af9c5c3c02457f248d60f97e2c161e219575568) maintainers: add frenetic00
* [`cf5eb488`](https://github.com/NixOS/nixpkgs/commit/cf5eb4882e1ec2f45d3dbfdabfb41ee0582c3de3) swapspace: add passthru.binlore
* [`2e8eda24`](https://github.com/NixOS/nixpkgs/commit/2e8eda249d7871a83177e931cc5c710ac863d60c) ffmpeg: add withCdio option
* [`8cd3989e`](https://github.com/NixOS/nixpkgs/commit/8cd3989e4d47ef3745f7554fc9f2c4bf36f2b008) gawk: 5.2.2 -> 5.3.1
* [`3cd51572`](https://github.com/NixOS/nixpkgs/commit/3cd51572e3de79080e6ab7da2f6bafd66681f5e5) libarchive: 3.7.4 -> 3.7.6
* [`e9a92dee`](https://github.com/NixOS/nixpkgs/commit/e9a92dee5338f7c98633a24848f906446abab850) scons: add patch to fix builds on sandboxed Darwin
* [`32ca1483`](https://github.com/NixOS/nixpkgs/commit/32ca1483b4236d498d40c966666aa7abfc645ccb) catch2_3: 3.7.0 -> 3.7.1
* [`7efb2db2`](https://github.com/NixOS/nixpkgs/commit/7efb2db213f2085ca1ef8bfdfe82d56c26d3081e) sonivox: 3.6.12 -> 3.6.13
* [`01dfed9e`](https://github.com/NixOS/nixpkgs/commit/01dfed9e82fa59a477f925cc5dfa29553ae08992) libopenmpt: 0.7.9 -> 0.7.10
* [`cdc116c0`](https://github.com/NixOS/nixpkgs/commit/cdc116c038fe743285f9d6ff4c67cbfb7e86b855) maintainers: add ailsa-sun
* [`80482213`](https://github.com/NixOS/nixpkgs/commit/80482213924e7ede0f1ca4aa889e9686908aec9a) bambootracker-qt6: 0.6.3 -> 0.6.4
* [`69948ad6`](https://github.com/NixOS/nixpkgs/commit/69948ad6029a04746f761e06a50728488c6133ee) systemd: Disable shadowstack
* [`bc21f77f`](https://github.com/NixOS/nixpkgs/commit/bc21f77ff67bd37fdd52bf243efe030b09b146d0) nixos/pgjwt: fix test
* [`fad6537e`](https://github.com/NixOS/nixpkgs/commit/fad6537e12235dfa4e8bb028e3574c0e758555ed) maintainers: add ailsa-sun; fixed lack of github ID
* [`8dcd5b47`](https://github.com/NixOS/nixpkgs/commit/8dcd5b47818c65d813a42479eebee0938b1f5b00) ocamlPackages.semaphore-compat: 1.0.1 -> 1.0.2
* [`ab19ce9f`](https://github.com/NixOS/nixpkgs/commit/ab19ce9f8d4a35d72ffe493915f27420a91c6d92) git: 2.46.1 -> 2.46.2
* [`c49774ff`](https://github.com/NixOS/nixpkgs/commit/c49774ff46f04794705d3472c3bf774e7b19efc1) perl540: fix build in stage1, add C locale patch
* [`540d99b6`](https://github.com/NixOS/nixpkgs/commit/540d99b6ca13081a872d5aa4a40f3eb128e45e9f) portaudio: Correct `alsa-lib` conditional
* [`7130bf30`](https://github.com/NixOS/nixpkgs/commit/7130bf3097c75ef852b9a8faec11794351d1b0aa) jackaudio: only add `makeWrapper` when needed
* [`1578a2d4`](https://github.com/NixOS/nixpkgs/commit/1578a2d4e1855696ab5cdd744f58027ce955bec0) fribidi: 1.0.15 -> 1.0.16
* [`b0976a60`](https://github.com/NixOS/nixpkgs/commit/b0976a6035bf944245b5c649ddaf0453598ac8c8) maturin: 1.7.1 -> 1.7.4
* [`fad9dabf`](https://github.com/NixOS/nixpkgs/commit/fad9dabf9f041ba61c410876e2743b53435261dc) pkgsMusl.postgresql: disable "locale -a" properly
* [`149aa98c`](https://github.com/NixOS/nixpkgs/commit/149aa98ce4396b972e85bb6953c8c7ccc959c6cd) postgresql: run full test-suite during checkPhase
* [`197de6a9`](https://github.com/NixOS/nixpkgs/commit/197de6a90d7889dfa53925dbead6b8f52fa162c5) libedgetpu: init at 0-unstable-2024-03-14
* [`ff4d69be`](https://github.com/NixOS/nixpkgs/commit/ff4d69becb912b5a1fed401fbc92698b36b9af27) temurin-{,jre-}bin: temurin-{,jre-}bin-22 -> temurin{,jre-}bin-21
* [`6da99f23`](https://github.com/NixOS/nixpkgs/commit/6da99f23d511c371b83814a3067c638b861b7207) temurin-{,jre-}bin-{8,11,17,21,22}: update
* [`3da3ed01`](https://github.com/NixOS/nixpkgs/commit/3da3ed012b059851d6f7b57cdde54e2ad0a6f351) temurin-{,jre-}bin-23: init at 23.0.0
* [`44cdf2fe`](https://github.com/NixOS/nixpkgs/commit/44cdf2fe1c1f40fd1a453e41248a4e9f605619ac) zulu8: 8.0.{392,402} -> 8.0.422
* [`72f2e946`](https://github.com/NixOS/nixpkgs/commit/72f2e946d74f7c7559ea359789373d99eb163389) zulu11: 11.0.22 -> 11.0.24
* [`3afd5ff6`](https://github.com/NixOS/nixpkgs/commit/3afd5ff68b65f4bb01439e3c4a64678a2e03147b) zulu17: 17.0.10 -> 17.0.12
* [`c12e8ac2`](https://github.com/NixOS/nixpkgs/commit/c12e8ac25f00ec34961c04ac7e5d35cc7bceb606) zulu21: 21.0.2 -> 21.0.4
* [`309cfa50`](https://github.com/NixOS/nixpkgs/commit/309cfa50b6b7ce1bae1105326c7f02c362a48965) zulu23: init at 23.0.0
* [`adf04590`](https://github.com/NixOS/nixpkgs/commit/adf045901d3448b3d36503628d5ae8c933cef836) openjdk: remove unused bootstrap files
* [`45bb4023`](https://github.com/NixOS/nixpkgs/commit/45bb40231383a4488b459c2cca664980b3b63ef0) openjdk21: remove from `info.json`
* [`bc12b04d`](https://github.com/NixOS/nixpkgs/commit/bc12b04da7b2cdc7a88be388f7d1ab3d4068dd81) openjdk8: 8u412-ga -> 8u422-ga
* [`22b0b36c`](https://github.com/NixOS/nixpkgs/commit/22b0b36c8cf5a8ae8353930b5125e0efe7d093e6) gupnp_1_6: 1.6.6 -> 1.6.7
* [`35487162`](https://github.com/NixOS/nixpkgs/commit/354871626361e04796b68eb9fb6b100f1e2a6a37) optifine: 1.20.4_HD_U_I7 -> 1.21.1_HD_U_J1
* [`90221a63`](https://github.com/NixOS/nixpkgs/commit/90221a63e4deb14c8f34767b205e9eb96399da22) crawlTiles: 0.32.0 -> 0.32.1
* [`0a94520c`](https://github.com/NixOS/nixpkgs/commit/0a94520cc7d810b443d3c337e46c67466c1b9c47) openjdk11: 11.0.23+9 -> 11.0.24+8
* [`64e24d18`](https://github.com/NixOS/nixpkgs/commit/64e24d184d3ba17d6bdbc2d107d6bf363cd46837) openjdk17: 17.0.11+9 -> 17.0.12+7
* [`fac90a74`](https://github.com/NixOS/nixpkgs/commit/fac90a74ac58646dd48ab72878cdbf6d19c26cf0) openjdk21: 21.0.3+9 -> 21.0.4+7
* [`00a8a1c7`](https://github.com/NixOS/nixpkgs/commit/00a8a1c7f3c34996fab82bb8e9848af40830a4f7) {openjdk,openjfx}23: init at 23-ga
* [`81c3d76c`](https://github.com/NixOS/nixpkgs/commit/81c3d76c5e0ce4dd9114201fde504798d96da685) jextract: pin JDK 23, mark as broken
* [`092c108f`](https://github.com/NixOS/nixpkgs/commit/092c108f77a9ef8f7ed4bb86ebe3396646b04268) cryptomator: pin JDK 23, mark as broken
* [`56d6fe11`](https://github.com/NixOS/nixpkgs/commit/56d6fe119194cce6ff0e63553bf0af82e7e51879) moneydance: pin OpenJDK 23
* [`b32d2c0a`](https://github.com/NixOS/nixpkgs/commit/b32d2c0ae73ac15f91966a1665ddede4a95bdcec) jabref: pin JDK 21 and OpenJFX 23
* [`35cc1474`](https://github.com/NixOS/nixpkgs/commit/35cc1474efc9464798a6aaeacbf65466f6769c33) zulu22: drop
* [`732642b8`](https://github.com/NixOS/nixpkgs/commit/732642b891b5ea2981e2d487c3a0dab0a3b9855f) {openjdk,openjfx}22: drop
* [`d19c7e8b`](https://github.com/NixOS/nixpkgs/commit/d19c7e8b164b2803ab5ad6efdb5fb45973c7d4a2) temurin-{,jre-}bin-22: drop
* [`de4ad2a6`](https://github.com/NixOS/nixpkgs/commit/de4ad2a6ace9f2428804cf515bbc5600aa340981) postgresql: use newer libuuid instead of ossp-uuid
* [`a7fdf225`](https://github.com/NixOS/nixpkgs/commit/a7fdf2256ae643876035c863dc9bbd3fd95101da) postgresql: simplify systemdSupport default value
* [`6178e9bd`](https://github.com/NixOS/nixpkgs/commit/6178e9bd3c37f1398f92ee433fb76e32e50ed874) postgresql: remove deprecated enableSystemd override
* [`a8edfd4e`](https://github.com/NixOS/nixpkgs/commit/a8edfd4e24871ffd1b8308826fa041b68407e54c) rofi-games: init at 1.10.2
* [`e791a35b`](https://github.com/NixOS/nixpkgs/commit/e791a35b58b1324be6adbb2d1444a416f6986073) cc-wrapper: Use `getExe` for `expand-response-params`
* [`8d8a065c`](https://github.com/NixOS/nixpkgs/commit/8d8a065cdc8ea78ed88b9ec8364595bbf6b821c2) libcamera: 0.3.1 -> 0.3.2
* [`06c4b0d0`](https://github.com/NixOS/nixpkgs/commit/06c4b0d0ede93b9695b7dae0b4f464a12bb820fb) unicode-emoji: 15.1 -> 16.0
* [`bdf7e63b`](https://github.com/NixOS/nixpkgs/commit/bdf7e63b54d6b332db2ad700fb5856b654171d15) super-productivity: 9.0.5 -> 10.0.11
* [`222485bb`](https://github.com/NixOS/nixpkgs/commit/222485bb0c51df935629c464df206396434e746e) libtiff: avoid parallel checking (completely)
* [`7c4e9bca`](https://github.com/NixOS/nixpkgs/commit/7c4e9bcab46957f073c2d433722fb1d4571234a6) bash: 5.2p32 -> 5.2p37
* [`442c6f36`](https://github.com/NixOS/nixpkgs/commit/442c6f36cbab6be27d1f848531f06885824c258a) ckan: 1.34.4 -> 1.35.0
* [`32f23f36`](https://github.com/NixOS/nixpkgs/commit/32f23f364ff9ed6044ee350e812d953e24f8573d) tryton: 7.2.5 -> 7.2.6
* [`053e3fe1`](https://github.com/NixOS/nixpkgs/commit/053e3fe1f4b5602f05084dba63be651592069231) cups: apply patches for CVE-2024-47175
* [`65007222`](https://github.com/NixOS/nixpkgs/commit/650072229d789b6c83ef110b9e665a9680ace842) curlpp: remove deprecated curl flag
* [`52deb99a`](https://github.com/NixOS/nixpkgs/commit/52deb99a18b2c653421cc32898b3e08606ee39c8) boogie: 3.2.4 -> 3.2.5
* [`11cdf8d9`](https://github.com/NixOS/nixpkgs/commit/11cdf8d9e50f1633495bb331e52f77475552d27a) python312Packages.pdm-backend: 2.3.3 -> 2.4.1
* [`2c2d7198`](https://github.com/NixOS/nixpkgs/commit/2c2d71985767f75fed36ac259aa574c49ad348a6) python312Packages.yarl: 1.9.4 -> 1.13.1
* [`78e1585d`](https://github.com/NixOS/nixpkgs/commit/78e1585d771727881df3f4453d9c07c8585f11c9) python312Packages.aiohttp: 3.10.5 -> 3.10.7
* [`bb52842d`](https://github.com/NixOS/nixpkgs/commit/bb52842d62976b9cb402a0d7e5a9188d82ae056c) python312Packages.aiohappyeyeballs: 2.3.6 -> 2.4.2
* [`c4a12396`](https://github.com/NixOS/nixpkgs/commit/c4a12396e52640f43076ce6f1e0781b60427f7bb) python312Packages.hass-nabucasa: backport aiohttp 3.10.6 compat patch
* [`dd15cc9b`](https://github.com/NixOS/nixpkgs/commit/dd15cc9baa31d902bd281cdbe6d06b24c0e633af) grilo-plugins: fix cross compilation, set strictDeps
* [`a25c0ed8`](https://github.com/NixOS/nixpkgs/commit/a25c0ed8f270de723aa72f6c7259880275c6081d) nc4nix: 0-unstable-2024-09-18 -> 0-unstable-2024-09-28
* [`dc0a818d`](https://github.com/NixOS/nixpkgs/commit/dc0a818dcb956dc1b637790af77aadbf0a2c342d) plattenalbum: 2.1.1 -> 2.2.0
* [`61c636a5`](https://github.com/NixOS/nixpkgs/commit/61c636a5ce0746866340eaa64087303b3e5879c1) gdb: 15.1 -> 15.2
* [`40b974d7`](https://github.com/NixOS/nixpkgs/commit/40b974d78ec24cd662c77cf5ad140b23ee908b08) lksctp-tools: 1.0.20 -> 1.0.21
* [`2e588d4e`](https://github.com/NixOS/nixpkgs/commit/2e588d4ecfe222567507bf1d59812e56b68efba6) ansel: 0-unstable-2024-08-13 -> 0-unstable-2024-09-29
* [`0b77f4ad`](https://github.com/NixOS/nixpkgs/commit/0b77f4ad4f3e5b3ed90cd95fc62d88c95910b414) srcOnly: some readability improvements
* [`13f0f6e5`](https://github.com/NixOS/nixpkgs/commit/13f0f6e596873df7209590308dedce8166b8c9b6) srcOnly: Add warning if dontUnpack is set
* [`1463fe69`](https://github.com/NixOS/nixpkgs/commit/1463fe69c656747c75a8f34547bc0877aa5eceb4) srcOnly: use derivation's stdenv and default to stdenvNoCC
* [`28ee6e79`](https://github.com/NixOS/nixpkgs/commit/28ee6e7979405feb704d8715ece9749e57277456) (WIP) srcOnly: Add noogle-compatible documentation
* [`2402f64f`](https://github.com/NixOS/nixpkgs/commit/2402f64fe9498708192b77b445ab2e5d121bb1ac) doc/rl-2411: Document srcOnly changes
* [`fbcfd581`](https://github.com/NixOS/nixpkgs/commit/fbcfd5812569148bac57d79ff27225b0afd3c205) treewide: specify stdenv in srcOnly calls
* [`75b62fe2`](https://github.com/NixOS/nixpkgs/commit/75b62fe23d0255cb9930d786c9c23d1f827f5c12) nicotine-plus: 3.3.4 -> 3.3.5
* [`75000c10`](https://github.com/NixOS/nixpkgs/commit/75000c10a64a8cb4d641fd8e3bf4981606ef355e) jq: migrate to by-name
* [`75406713`](https://github.com/NixOS/nixpkgs/commit/75406713eb7daef7f4c9755c24638b7fec7be0a7) jq: nuke references from "bin" to "man" and "doc"
* [`899a790d`](https://github.com/NixOS/nixpkgs/commit/899a790d808e447bdf686009fd16386e21f0beb2) jq: merge output "lib" into "out"
* [`f0591af9`](https://github.com/NixOS/nixpkgs/commit/f0591af948ba067d10ff69aaa05e2bdccce7f88d) python312Packages.annexremote: 1.6.5 -> 1.6.6
* [`51935745`](https://github.com/NixOS/nixpkgs/commit/519357453bdf2b417398059a5c00ad7081b3a671) cups: 2.4.10 -> 2.4.11
* [`1873dac3`](https://github.com/NixOS/nixpkgs/commit/1873dac3aab8706760685b614782c09582931aff) rubyPackages.puma: 6.4.2 -> 6.4.3
* [`32ddebd1`](https://github.com/NixOS/nixpkgs/commit/32ddebd1e382a54464b82f9c19e9dae3bd229a68) fuse: split outputs and clean up
* [`bd5910e3`](https://github.com/NixOS/nixpkgs/commit/bd5910e375a1d3aa45e53ad3b61015059078a74b) xtreemfs: fix fuse path
* [`eeb94ed4`](https://github.com/NixOS/nixpkgs/commit/eeb94ed42c4133f62f3faa98992c4240a190e284) unionfs-fuse: fix fuse path
* [`84acfec6`](https://github.com/NixOS/nixpkgs/commit/84acfec68b9a41e0dcc6989dafacc7827cd5e781) pythonPackages.fusepy: fix fuse path
* [`c7c65ef0`](https://github.com/NixOS/nixpkgs/commit/c7c65ef049521b8f0ba3780f0ea51a272490b896) acd_cli: fix fuse path
* [`f534f742`](https://github.com/NixOS/nixpkgs/commit/f534f74249e9e182dbf783891adcce1a0b51a865) nixos/security/wrappers: fix fuse path
* [`f978ecc4`](https://github.com/NixOS/nixpkgs/commit/f978ecc43e7748b22014ee4db63dce5c16dbb7d5) procps: 3.3.17 -> 4.0.4
* [`8878d5a6`](https://github.com/NixOS/nixpkgs/commit/8878d5a6826c6458c2f85e3d62506dd36017d26f) procps: remove typeteris from the maintainers
* [`84395979`](https://github.com/NixOS/nixpkgs/commit/84395979f64b240a0cb9fa0b598745d08f85a7bb) libnetfilter_conntrack: 1.0.9 -> 1.1.0
* [`2a01c405`](https://github.com/NixOS/nixpkgs/commit/2a01c405f52b765e7f54bf4e06d66c3cfd9f54c1) ascii-draw: 0.4.0 -> 1.0.0
* [`2ebffcc4`](https://github.com/NixOS/nixpkgs/commit/2ebffcc4c7e7b807d4e92c44f4037c4f3b4bee81) nixos/postgresql: set up sandboxing
* [`f800d8e4`](https://github.com/NixOS/nixpkgs/commit/f800d8e42b974b1a1e9408da4e96accfd6f26acf) nixos/postgresql: enable private /tmp & private mounts; fix wal-receiver test
* [`0771a6e1`](https://github.com/NixOS/nixpkgs/commit/0771a6e1dcd6e7133b7fe84507ba8163a810f750) xz: 5.6.2 -> 5.6.3
* [`12061e0e`](https://github.com/NixOS/nixpkgs/commit/12061e0e5be689bc3231cf0dc89c3f716b9d7525) xkeyboard_config: 2.42 -> 2.43
* [`9f1bc42e`](https://github.com/NixOS/nixpkgs/commit/9f1bc42ec8c3ea566fd9ccdffaa653b4135ff091) ugit: init at 5.8
* [`16478834`](https://github.com/NixOS/nixpkgs/commit/16478834f4c19c2b3df99b7e130f7df89215ef0e) hdf5: 1.14.4.3 -> 1.14.5
* [`983258c7`](https://github.com/NixOS/nixpkgs/commit/983258c7da8c36cfdf106db87613be4577c0ad0a) lvm2: 2.03.26 -> 2.03.27
* [`42df4680`](https://github.com/NixOS/nixpkgs/commit/42df4680dea29d0c6a1dafa8f1b2271eeabac4ca) berglas: 2.0.2 -> 2.0.6
* [`6f7657be`](https://github.com/NixOS/nixpkgs/commit/6f7657be4c73074053d7ba31cd1b05e076190ef9) openexr_3: 3.2.4 -> 3.3.0
* [`5ae5bd1c`](https://github.com/NixOS/nixpkgs/commit/5ae5bd1c9a47be0ec6553fb10f13e007c3ee6886) amf-headers: 1.4.34 -> 1.4.35
* [`2bd2e146`](https://github.com/NixOS/nixpkgs/commit/2bd2e1469028c47646a5cfed681057ea55dca086) dolibarr: 19.0.3 -> 20.0.0
* [`6d24a9cf`](https://github.com/NixOS/nixpkgs/commit/6d24a9cf8384b08625e721c5a288b15a09abf7c8) xmlto: Use non-namespaced stylesheets
* [`a9bc8ede`](https://github.com/NixOS/nixpkgs/commit/a9bc8ede3453e4fdcecf10a601e5660c4bd580b3) ocamlPackages.ocaml-version: 3.6.8 -> 3.6.9
* [`c4b80b75`](https://github.com/NixOS/nixpkgs/commit/c4b80b75429053d1929c45708ea40ecfb53cca2d) openimageio: 2.5.15.0 -> 2.5.16.0
* [`e804d4ea`](https://github.com/NixOS/nixpkgs/commit/e804d4eac8cbb11b71439efbe898c445052b1d4e) pdfsam-basic: 5.2.6 -> 5.2.8
* [`e40c8a0d`](https://github.com/NixOS/nixpkgs/commit/e40c8a0d7d958a11751e1ee5ced16ace2540c271) python312Packages.ropgadget: 7.4 -> 7.5
* [`74aa519b`](https://github.com/NixOS/nixpkgs/commit/74aa519ba2d5a49a17fe2667884975df7cc75726) redis: 7.2.5 -> 7.2.6
* [`0789f534`](https://github.com/NixOS/nixpkgs/commit/0789f53499110776ec56bd980c429b88d332dc7e) nodejs_20: 20.17.0 -> 20.18.0
* [`e3ce727a`](https://github.com/NixOS/nixpkgs/commit/e3ce727a588807dfb2a7186317d4e03fdcf8b509) python312Packages.itemloaders: 1.3.1 -> 1.3.2
* [`c88016ee`](https://github.com/NixOS/nixpkgs/commit/c88016eec80963d98761790173dd5a2f4b565a85) rmg-wayland: 0.6.5 -> 0.6.6
* [`8891a773`](https://github.com/NixOS/nixpkgs/commit/8891a773e4665dcef1a0f48ab2ea0b6ed5bb3356) sameboy: 0.16.6 -> 0.16.7
* [`1e8ac191`](https://github.com/NixOS/nixpkgs/commit/1e8ac19152fbe4454b4d2bfd885e136668de6d76) libnftnl: 1.2.7 -> 1.2.8, nftables: 1.1.0 -> 1.1.1
* [`32b9a244`](https://github.com/NixOS/nixpkgs/commit/32b9a2444b53fb31cdb9350982c018936898b27e) nftables: enable parallel building
* [`df1f47e6`](https://github.com/NixOS/nixpkgs/commit/df1f47e61434091b6c10b2a8b911717c154e3583) hwdata: 0.387 -> 0.388
* [`dc06d59f`](https://github.com/NixOS/nixpkgs/commit/dc06d59feaf277a864a8bb4b6b4a39109801da26) s2n-tls: 1.5.1 -> 1.5.4
* [`8444c325`](https://github.com/NixOS/nixpkgs/commit/8444c325121c8b5625ddd5afbaed6c70c9a4bde8) stress-ng: 0.18.04 -> 0.18.05
* [`eaf33ea6`](https://github.com/NixOS/nixpkgs/commit/eaf33ea63a5bfeda80556b8e01fb29993f3776fc) bosh-cli: 7.7.2 -> 7.8.0
* [`a8cf6284`](https://github.com/NixOS/nixpkgs/commit/a8cf6284831e7f26105ae6f39aa6f856a4d42514) python3Packages.furl: disable failing test for all python version
* [`68307063`](https://github.com/NixOS/nixpkgs/commit/68307063be1b2fce2ac5fbd41cae21d60d889599) python312Packages.ropgadget: switch to pypa builder
* [`f12cb459`](https://github.com/NixOS/nixpkgs/commit/f12cb459ba90740c4e7d30daf3624c2d600a2a8a) linux-router: 0.7.3 -> 0.7.6
* [`326c1be1`](https://github.com/NixOS/nixpkgs/commit/326c1be15a549a3613380e7b1fbe0f6779622e59) ell: enable debug info
* [`8a4f0041`](https://github.com/NixOS/nixpkgs/commit/8a4f00414d494130fbf37022225bb451008f9a0b) python312Packages.botocore: 1.35.29 -> 1.35.30
* [`acecfb93`](https://github.com/NixOS/nixpkgs/commit/acecfb937c6150fd392898ec723e77f76ee9e85c) python312Packages.boto3: 1.35.29 -> 1.35.30
* [`140cfc11`](https://github.com/NixOS/nixpkgs/commit/140cfc11549639158aff91bc2edaec049fc68830) awscli: 1.34.29 -> 1.34.30
* [`e6248182`](https://github.com/NixOS/nixpkgs/commit/e62481829335973537e3527c66af98c7adaa7e30) xeve: 0.5.0 -> 0.5.1
* [`7ad7e69a`](https://github.com/NixOS/nixpkgs/commit/7ad7e69aa8d26e2abaa7c4d4317dea956bf704f8) ffmpeg_7: 7.0.2 -> 7.1
* [`57b452a0`](https://github.com/NixOS/nixpkgs/commit/57b452a0fe550d9bb7b093ddedf74d62c872281b) unbound: 1.21.0 -> 1.21.1
* [`b7b1c183`](https://github.com/NixOS/nixpkgs/commit/b7b1c183e30a47280e62ea4a84702d13eb63ae2f) python3Packages.matplotlib: 3.9.1 -> 3.9.2 ([nixos/nixpkgs⁠#345336](https://togithub.com/nixos/nixpkgs/issues/345336))
* [`8a8912c1`](https://github.com/NixOS/nixpkgs/commit/8a8912c1b780d45646c12e0b1c89913d37368ffa) diffnav: init at 0.2.8
* [`d4cb98bd`](https://github.com/NixOS/nixpkgs/commit/d4cb98bd4ff0896db581116524501e55a89c99f2) qlog: 0.38.0 -> 0.39.0
* [`300c9216`](https://github.com/NixOS/nixpkgs/commit/300c9216b5f09c7fabf9ba0d9455654c76db04d7) ell: 0.68 -> 0.69, iwd: 2.20 -> 2.22
* [`6d800e29`](https://github.com/NixOS/nixpkgs/commit/6d800e294e8602bb979ee065bf77aed815e664e2) pcsclite: 2.2.3 -> 2.3.0
* [`41ffdf94`](https://github.com/NixOS/nixpkgs/commit/41ffdf94002c38a2540a7d88dd2b7e57746627c1) haskellPackages: stackage LTS 22.33 -> LTS 22.36
* [`7e74a964`](https://github.com/NixOS/nixpkgs/commit/7e74a964e4873bccf96fb5dc36cf34fae894f26e) all-cabal-hashes: 2024-09-03T10:29:19Z -> 2024-10-05T14:46:54Z
* [`a82b1d5a`](https://github.com/NixOS/nixpkgs/commit/a82b1d5ab866b8e80066c86a12c37c7268d3d523) haskellPackages: regenerate package set based on current config
* [`79698c98`](https://github.com/NixOS/nixpkgs/commit/79698c98e6907c89eeddc85b15bfb6bc5729ecd7) zxtune: 5072 -> 5075
* [`aaa845a2`](https://github.com/NixOS/nixpkgs/commit/aaa845a24abb03dc6955295c0712d840ab14d801) yourkit-java: 2024.3-b161 -> 2024.9-b158
* [`f9338ae2`](https://github.com/NixOS/nixpkgs/commit/f9338ae23ddb1d2bab9ea0048e5ff919c9f41d76) irpf: 2024-1.4 -> 2024-1.5
* [`d0882a79`](https://github.com/NixOS/nixpkgs/commit/d0882a7937c97067b788bef3b6e9e32c29635485) libdeflate: 1.21 -> 1.22
* [`aca9ff23`](https://github.com/NixOS/nixpkgs/commit/aca9ff2310744434766e242ac7eed0e2395af4ad) colmena: pin to nix 2.18
* [`cc0b8b46`](https://github.com/NixOS/nixpkgs/commit/cc0b8b466d2fdaad70f8959fcf1d6c557d04a277) emiluaPlugins.beast: 1.1.0 -> 1.1.1
* [`1e59c44a`](https://github.com/NixOS/nixpkgs/commit/1e59c44a7b545092da69d669d1ea7b2fde553a80) kaldi: 0-unstable-2024-09-16 -> 0-unstable-2024-10-04
* [`0a21dc7f`](https://github.com/NixOS/nixpkgs/commit/0a21dc7ff269d1f30078e10656c38bd84dc6ba54) iio-hyprland: 0-unstable-2024-07-24 -> 0-unstable-2024-09-29
* [`8d082b97`](https://github.com/NixOS/nixpkgs/commit/8d082b97abfb0fd54dfe1193f34601030215ae8a) blobdrop: init at 2.1
* [`adc68507`](https://github.com/NixOS/nixpkgs/commit/adc685078e82d9eff2d5e0cdb994313f6ae37654) cmake: 3.29.6 -> 3.30.4
* [`b3238d53`](https://github.com/NixOS/nixpkgs/commit/b3238d53569ec9ca2217f488b6782d79e9d85e4a) cmake-minimal: fix patch on darwin
* [`0dfbe6f1`](https://github.com/NixOS/nixpkgs/commit/0dfbe6f19cb6a6a586d66057a95e262dc72487c2) sparrow: pin JDK 23
* [`8e9ae867`](https://github.com/NixOS/nixpkgs/commit/8e9ae86774f4ad14315d6e496aa863088a1ac594) tailscaled: Add option to disable Taildrop
* [`5709115a`](https://github.com/NixOS/nixpkgs/commit/5709115ac9231cab456a11d13a70f0e768c640e2) memstream: cross-compilation fixes
* [`38d39e6d`](https://github.com/NixOS/nixpkgs/commit/38d39e6d6e94294cca62bbfc05d5bab36c36a795) librsvg: link libobjc on Darwin independent of CPU architecture
* [`ba7af302`](https://github.com/NixOS/nixpkgs/commit/ba7af302dc9a9f27f56178de10efbf0d75df8c4a) man-db: fix test failure when using Darwin’s libiconv
* [`646d4d5a`](https://github.com/NixOS/nixpkgs/commit/646d4d5a2d448615d518b5ba5ff85de275a7d7ed) gst_all_1.gstreamer: only try to link libdw if it is available
* [`bc23fc41`](https://github.com/NixOS/nixpkgs/commit/bc23fc41e477654dc25e6faa8dea7a26105aa15e) pdi: fix HDF5 version detection
* [`4949d0bc`](https://github.com/NixOS/nixpkgs/commit/4949d0bc84ca86a031de99246bda1c4af45d0a21) python312Packages.h5netcdf: 1.3.0 -> 1.4.0
* [`8b30d996`](https://github.com/NixOS/nixpkgs/commit/8b30d996bfbdae6f93ab1d250c818d2b2e9e8bf3) python312Packages.dnspython: 2.6.1 -> 2.7.0
* [`9328eb7b`](https://github.com/NixOS/nixpkgs/commit/9328eb7b4bcad274de24dc0b194011025f4f4b20) rss-bridge: Run update checker on it
* [`57c2e568`](https://github.com/NixOS/nixpkgs/commit/57c2e5683de7cd80ce44702b56fb22c614407a7e) buildPython hooks: format with shfmt
* [`4bd38954`](https://github.com/NixOS/nixpkgs/commit/4bd389541ef50a26a7ae54d137e3a99b5f33c101) haskellPackages.cloudy: add myself as maintainer
* [`81a10eaf`](https://github.com/NixOS/nixpkgs/commit/81a10eaf1b90a7f3eb60412b72252e2a553f2c56) haskellPackages.cloudy: generate optparse-applicative completions
* [`8f41b751`](https://github.com/NixOS/nixpkgs/commit/8f41b75149f6f6d19f8fa50a6707c281d197d480) python3Packages.elastic-transport: disable async httpbin test
* [`4552414d`](https://github.com/NixOS/nixpkgs/commit/4552414df11c4d1ceec30ba3a6b590ddc61382dc) microsoft-security-utilities-secret-masker: init at 1.0.0b3
* [`bf480e41`](https://github.com/NixOS/nixpkgs/commit/bf480e41d2f872c641b6743b0da009c0dfc7d081) azure-cli: 2.64.0 -> 2.65.0
* [`0fdffb80`](https://github.com/NixOS/nixpkgs/commit/0fdffb806c9ffc54dd77889fe205715328ee040e) azure-cli-extensions.alertsmanagement: 0.2.3 -> 1.0.0b1
* [`d9e74eef`](https://github.com/NixOS/nixpkgs/commit/d9e74eef0dd418eb2470fe7218b7e93cef065193) azure-cli-extensions.baremetal-infrastructure: 3.0.0b1 -> 3.0.0b2
* [`ae98dba2`](https://github.com/NixOS/nixpkgs/commit/ae98dba2ab29111af7c7766c9c09ade19d6a7af8) azure-cli-extensions.durabletask: init at 1.0.0.b1
* [`eb14449e`](https://github.com/NixOS/nixpkgs/commit/eb14449e8f394edc7f9a57e376fa73592b843afa) azure-cli-extensions.log-analytics: 0.2.2 -> 1.0.0b1
* [`20fa9179`](https://github.com/NixOS/nixpkgs/commit/20fa917956c60c9dc7e9e88905760ac9f5bfbc50) azure-cli-extensions.microsoft-fabric: init at 1.0.0b1
* [`2b2b2254`](https://github.com/NixOS/nixpkgs/commit/2b2b2254aa26c2b5b26d72363bdb7b44a54b9945) azure-cli-extensions.monitor-pipeline-group: init at 1.0.0b1
* [`04f2f61a`](https://github.com/NixOS/nixpkgs/commit/04f2f61a53bd83529b7cefe151951f7902addfff) azure-cli-extensions.multicloud-connector: init at 1.0.0b1
* [`a0b604cc`](https://github.com/NixOS/nixpkgs/commit/a0b604cc4d5fe16ba1a88134ca9ee5e20473a6da) azure-cli-extensions.terraform: init at 1.0.0b1
* [`0f67dc7e`](https://github.com/NixOS/nixpkgs/commit/0f67dc7e4ff5a3062d31da014895f11897399573) azure-cli-extensions.virtual-network-tap: 0.1.0 -> 1.0.0b1
* [`2b365b3f`](https://github.com/NixOS/nixpkgs/commit/2b365b3fda41b528bced944d747d82b1f16b9acd) azure-cli-extensions.virtual-wan: 1.0.0 -> 1.0.1
* [`31ad874f`](https://github.com/NixOS/nixpkgs/commit/31ad874f20cea674a9a26047fa8530833689e8bf) azure-cli-extensions.aks-preview: 8.0.0b1 -> 9.0.0b6
* [`55daed0f`](https://github.com/NixOS/nixpkgs/commit/55daed0ff98e37344380edc76ab5d299e2285c09) azure-cli-extensions.amg: 2.2.0 -> 2.4.0
* [`381ac8f5`](https://github.com/NixOS/nixpkgs/commit/381ac8f5f3e21f22e07ac6aaf430548724c868a6) azure-cli-extensions.azurelargeinstance: 1.0.0b3 -> 1.0.0b4
* [`49a25fb7`](https://github.com/NixOS/nixpkgs/commit/49a25fb766d60b24b0cd7a1855f7fb4593d6b337) azure-cli-extensions.bastion: 1.1.0 -> 1.3.0
* [`ea726bb9`](https://github.com/NixOS/nixpkgs/commit/ea726bb97778a197f05d1137e861a905a7bbdd52) azure-cli-extensions.connectedvmware: 1.1.1 -> 1.2.0
* [`20418116`](https://github.com/NixOS/nixpkgs/commit/204181167aed4853848aa17a4ee610c4d031402f) azure-cli-extensions.costmanagement: 0.3.0 -> 1.0.0
* [`6911ffff`](https://github.com/NixOS/nixpkgs/commit/6911ffff92be9c832cf4124c4916206b82b78ee7) azure-cli-extensions.databricks: 1.0.0 -> 1.0.1
* [`c573227c`](https://github.com/NixOS/nixpkgs/commit/c573227cd382297472c33ce43fde7d221a4ff445) azure-cli-extensions.datamigration: 1.0.0b1 -> 1.0.0b2
* [`dc4ca76f`](https://github.com/NixOS/nixpkgs/commit/dc4ca76f506ee0784b744f32b639ee53c5358241) azure-cli-extensions.elastic: 1.0.0b2 -> 1.0.0b3
* [`b1a12ff6`](https://github.com/NixOS/nixpkgs/commit/b1a12ff6f42523ccf2eaf63254cc7ea65f45a4ff) azure-cli-extensions.fleet: 1.2.1 -> 1.4.0
* [`104f42e2`](https://github.com/NixOS/nixpkgs/commit/104f42e2aed047c5ad590a3c59901309d774304d) azure-cli-extensions.import-export: 0.1.1 -> 1.0.0b1
* [`eab3e718`](https://github.com/NixOS/nixpkgs/commit/eab3e7186ecf9d3bc35a5161deb6c13486832d34) azure-cli-extensions.internet-analyzer: 0.1.0rc6 -> 1.0.0b1
* [`faa6e552`](https://github.com/NixOS/nixpkgs/commit/faa6e55232e2bf06013072513a456a3ed820030f) azure-cli-extensions.k8s-runtime: 1.0.3 -> 1.0.4
* [`96344e2b`](https://github.com/NixOS/nixpkgs/commit/96344e2bfa446adbb2896dcaec87dbd3874f4a44) azure-cli-extensions.log-analytics-solution: 1.0.0 -> 1.0.1
* [`670c535a`](https://github.com/NixOS/nixpkgs/commit/670c535a2d84d3472665b3fd8dc35fe00a6dcd96) azure-cli-extensions.networkcloud: 2.0.0b2 -> 2.0.0b4
* [`0d776e91`](https://github.com/NixOS/nixpkgs/commit/0d776e9138e6c9245ef8e03ef348e550a1ad9a58) azure-cli-extensions.nginx: 2.0.0b5 -> 2.0.0b6
* [`b2d25a15`](https://github.com/NixOS/nixpkgs/commit/b2d25a15a41b29c0e0a52c9a7e7c67497284028b) azure-cli-extensions.peering: 0.2.1 -> 1.0.0
* [`0fb3dae5`](https://github.com/NixOS/nixpkgs/commit/0fb3dae51e4baa144354557b738353b12647592f) azure-cli-extensions.redisenterprise: 1.0.0 -> 1.2.0
* [`001066ee`](https://github.com/NixOS/nixpkgs/commit/001066ee9cca296ef7c38a063d68551268b039ed) azure-cli-extensions.spring: 1.25.0 -> 1.25.1
* [`98886e06`](https://github.com/NixOS/nixpkgs/commit/98886e06a36c7f16c166dfe3e9812c735a403791) azure-cli-extensions.stack-hci-vm: 1.1.20 -> 1.3.0
* [`9c8159a0`](https://github.com/NixOS/nixpkgs/commit/9c8159a0fff46c1b96adb7df837d4090d3b3d07d) azure-cli-extensions.storage-blob-preview: 0.7.2 -> 1.0.0b1
* [`6995a60d`](https://github.com/NixOS/nixpkgs/commit/6995a60d4107dcac93462d2fb5c1a4450484f403) azure-cli-extensions.storagesync: 1.0.0 -> 1.0.1
* [`ca4f272e`](https://github.com/NixOS/nixpkgs/commit/ca4f272ed4bd3f415c0d4883dd833ff364555d46) azure-cli-extensions.virtual-network-manager: 1.2.0 -> 1.3.0
* [`0085947b`](https://github.com/NixOS/nixpkgs/commit/0085947b51a9f4d453750ea348271641010622a5) azure-cli-extensions.vmware: 7.0.0 -> 7.1.0
* [`4d30e3ca`](https://github.com/NixOS/nixpkgs/commit/4d30e3caa053bbdb925c3f39382b252344dbf0c4) azure-cli-extensions.workloads: 1.1.0b2 -> 1.1.0b3
* [`fef047eb`](https://github.com/NixOS/nixpkgs/commit/fef047eba57cf8b334cab3ac9bf37e7f7ff57c9d) nginx: Use placeholders which play nicely with Bash
* [`7d3b47a0`](https://github.com/NixOS/nixpkgs/commit/7d3b47a0fa5828525144522f053e7b2edca0cdb4) nginx: Create cryptographically secure htpasswd file
* [`43a17592`](https://github.com/NixOS/nixpkgs/commit/43a175926f9c884a64355cf733b65ebbaf90a824) maintainers: add naho
* [`3108e45c`](https://github.com/NixOS/nixpkgs/commit/3108e45ca898acec9e4e0b6b10e953b895631343) antora: move package into pkgs/by-name directory
* [`efc32987`](https://github.com/NixOS/nixpkgs/commit/efc3298775da2b9c6c26c729b6c8217a24460477) antora: reformat with nixfmt
* [`915e1b9a`](https://github.com/NixOS/nixpkgs/commit/915e1b9a5d6bc7f7643b86ebb90f8182d823d2d5) antora: sort entries
* [`c7b93d24`](https://github.com/NixOS/nixpkgs/commit/c7b93d24a77ae95d5f77b849936c7cf2f7cf063f) antora: declare meta.platforms
* [`8d93801d`](https://github.com/NixOS/nixpkgs/commit/8d93801da996336296d382433c9c9edfddb7061b) antora: declare passthru.updateScript
* [`93e0ab3c`](https://github.com/NixOS/nixpkgs/commit/93e0ab3c24282ed1e3430a5303ee281bc8458375) proxmox-auto-install-assistant: init at 8.2.6
* [`29150b9a`](https://github.com/NixOS/nixpkgs/commit/29150b9a1cf2036381798f90268df6c56392d0d5) podlet: init at 0.3.0
* [`1c01774e`](https://github.com/NixOS/nixpkgs/commit/1c01774e614ddf637ee6e50e0708e8042a2c5db0) nixos/oauth2-proxy: fix display-htpasswd-form flag name
* [`66f78a93`](https://github.com/NixOS/nixpkgs/commit/66f78a930360b52e5d3ac6db9112eea3fcfbbc32) systemd: 256.6 -> 256.7
* [`dc8b17f4`](https://github.com/NixOS/nixpkgs/commit/dc8b17f4029f7c41ee016fe69b0c218b792b3879) cbqn: 0.7.0 -> 0.8.0
* [`cbabc687`](https://github.com/NixOS/nixpkgs/commit/cbabc6874d1bfd0d8851318787771606e6cb271a) srcOnly: Fix bug introduced by rewrite
* [`d0b808a4`](https://github.com/NixOS/nixpkgs/commit/d0b808a4a33e01d005db50629db611729d3cef59) glslang: 14.3.0 -> 15.0.0
* [`b03d75a9`](https://github.com/NixOS/nixpkgs/commit/b03d75a91d7430995d35c4967dc33087e9c4f753) vulkan-headers: 1.3.290.0 -> 1.3.296.0
* [`5130e124`](https://github.com/NixOS/nixpkgs/commit/5130e124c32eb28e117947590aabf9c1f1729fa9) vulkan-loader: 1.3.290.0 -> 1.3.296.0
* [`810f4a8c`](https://github.com/NixOS/nixpkgs/commit/810f4a8c308bda5faba5f8f63d8aff56fbd94fbd) vulkan-validation-layers: 1.3.290.0 -> 1.3.296.0
* [`6ab2027f`](https://github.com/NixOS/nixpkgs/commit/6ab2027f6a57069f64f7438ef60f0441295acd1c) vulkan-tools: 1.3.290.0 -> 1.3.296.0
* [`46dcb46f`](https://github.com/NixOS/nixpkgs/commit/46dcb46fbc90f96c58e651105ae5f2d6499bdd0f) vulkan-tools-lunarg: 1.3.290.0 -> 1.3.296.0
* [`47ed9b95`](https://github.com/NixOS/nixpkgs/commit/47ed9b9577eaec120147aa43586fa1a28f48ba62) vulkan-extension-layer: 1.3.290.0 -> 1.3.296.0
* [`369d5b9a`](https://github.com/NixOS/nixpkgs/commit/369d5b9ad4d975c23d70f476e212f66246a695c0) vulkan-utility-libraries: 1.3.290.0 -> 1.3.296.0
* [`7301c569`](https://github.com/NixOS/nixpkgs/commit/7301c569e0d635d28299a8559bb1c326fd9e6535) vulkan-volk: 1.3.290.0 -> 1.3.296.0
* [`30de3661`](https://github.com/NixOS/nixpkgs/commit/30de3661d885fa485192f0b46de88344d00d5070) spirv-headers: 1.3.290.0 -> 1.3.296.0
* [`90a6594e`](https://github.com/NixOS/nixpkgs/commit/90a6594eba8ad04fd6d781809e78d067425c3bb3) spirv-cross: 1.3.290.0 -> 1.3.296.0
* [`8631b597`](https://github.com/NixOS/nixpkgs/commit/8631b597902219f0a429785a6fa96192243f9c65) ruby.rubygems: 3.5.16 -> 3.5.21
* [`4dd40b15`](https://github.com/NixOS/nixpkgs/commit/4dd40b15d8b5eac7870930f574669560b0630519) bundler: 2.5.16 -> 2.5.21
* [`d4232f33`](https://github.com/NixOS/nixpkgs/commit/d4232f33f48ecdd65c84e9c5016c769cff95aac6) spirv-tools: 1.3.290.0 -> 1.3.296.0
* [`b41deedb`](https://github.com/NixOS/nixpkgs/commit/b41deedb6242acd17582ae41d4c87defe55cb618) unzip: apply patch for CVE-2021-4217
* [`04ba2591`](https://github.com/NixOS/nixpkgs/commit/04ba25913fd800d5ff7b373e4fe9583dc00cbc84) dgraph: 24.0.2 -> 24.0.4
* [`ff855314`](https://github.com/NixOS/nixpkgs/commit/ff855314546e43536f8b103a0412e6f998ff361c) CODEOWNERS: Fix auto-patchelf path
* [`d1ae9bf1`](https://github.com/NixOS/nixpkgs/commit/d1ae9bf152e4e14a12a968a2719e09899aafc5ad) ibus-engines.typing-booster-unwrapped: 2.25.16 -> 2.25.17
* [`2f3deb25`](https://github.com/NixOS/nixpkgs/commit/2f3deb25eb3db0f90c100af4e8df0201e3f00397) questdb: 8.1.1 -> 8.1.2
* [`42b7876a`](https://github.com/NixOS/nixpkgs/commit/42b7876ab556e738bb1f31b10d6fb8fee05bd65a) vscode-extensions.ms-python.vscode-pylance: 2024.8.2 -> 2024.10.1
* [`683f97e3`](https://github.com/NixOS/nixpkgs/commit/683f97e3781356b3e8251d0ab5e5906c4cdd4ded) rustPlatform: cargo test is now called with the same environment variables as cargo build
* [`bab8ba01`](https://github.com/NixOS/nixpkgs/commit/bab8ba019fe98cf6632f2bb9b70ea95c2e65eb5a) audible-cli: Specify version regex
* [`bf60cac8`](https://github.com/NixOS/nixpkgs/commit/bf60cac802409f1171ef07a5998e6d811d7dc041) xone: added fix for kernel version 6.12
* [`a226c17c`](https://github.com/NixOS/nixpkgs/commit/a226c17c853f8b537a1bf67448749f37673896c6) alsa-ucm-conf: 1.2.11 -> 1.2.12
* [`874f6d21`](https://github.com/NixOS/nixpkgs/commit/874f6d21721b2be225d198177821b0c6b5547b5f) clair: 4.7.4 -> 4.8.0
* [`b0e2c787`](https://github.com/NixOS/nixpkgs/commit/b0e2c787ba58b6a1f1955b772040e312aeca4139) moltenvk: use xcbuildHook
* [`0cabb33e`](https://github.com/NixOS/nixpkgs/commit/0cabb33e1d57069bfd3b16857d57fb24b09ce4a4) moltenvk: build with the 14.4 SDK
* [`329fa34d`](https://github.com/NixOS/nixpkgs/commit/329fa34d6237e3da654707de0d55195ee25b7c8e) moltenvk: 1.2.9 -> 1.2.10
* [`f9e5f129`](https://github.com/NixOS/nixpkgs/commit/f9e5f1290d88e94c4004e1d49d418f4f7983c734) moltenvk: move to pkgs/by-name
* [`d8906e48`](https://github.com/NixOS/nixpkgs/commit/d8906e4851d8a307726a2a10f12b2962dd545a24) treewide: switch to moltenvk from darwin.moltenvk
* [`1f0a0ab9`](https://github.com/NixOS/nixpkgs/commit/1f0a0ab94d769e66967e098dbb0e589f2ff1d86a) darwin.moltenvk: add to darwin-aliases.nix
* [`578b04cd`](https://github.com/NixOS/nixpkgs/commit/578b04cd1da289b03feb9d3cd7f2b87baf53759b) qt5.qtbase: build with the 14.4 SDK
* [`4bb131ec`](https://github.com/NixOS/nixpkgs/commit/4bb131ec6b9a2ba58d51973ffb3622b56ed24767) qt5: build Qt 5 modules with the 14.4 SDK
* [`ab80059a`](https://github.com/NixOS/nixpkgs/commit/ab80059a1b36a2578471b5df16b6fc32ed95f4fb) qt5.qtwebengine: drop overrideSDK
* [`61d0e51c`](https://github.com/NixOS/nixpkgs/commit/61d0e51c9c9ea8c8a7a9fa0a5d21e71ed825bb12) qt5.qtwebengine: use the 13.3 SDK because the 14.4 SDK does not work
* [`830b9fe5`](https://github.com/NixOS/nixpkgs/commit/830b9fe572fa374c4b7c31aac506003f1d8dfd5c) qt6.qtbase: build with the 14.4 SDK
* [`2573d499`](https://github.com/NixOS/nixpkgs/commit/2573d499bd7cfb3d1d1f52e20c5b8bf49eb5f7d8) haskellPackages.network: fix build on x86_64-darwin
* [`088dce91`](https://github.com/NixOS/nixpkgs/commit/088dce914530e9f8df086805eb5a935ad2aac811) python3Packages.materialx: enable MSL support on x86_64-darwin
* [`bed55153`](https://github.com/NixOS/nixpkgs/commit/bed551533cef8e811bf40858fad45597e8f1c685) neovim-unwrapped: update build inputs for new Darwin SDK
* [`2ab1817d`](https://github.com/NixOS/nixpkgs/commit/2ab1817d71b577320ac4d80fdb49e74cc2f4eabe) curl: allow static builds on x86_64-darwin
* [`fbf56c14`](https://github.com/NixOS/nixpkgs/commit/fbf56c14a808ed3b016d44061489388e3e35dd0d) curl: link libiconv in static builds on Darwin
* [`c90b0830`](https://github.com/NixOS/nixpkgs/commit/c90b0830e54a373327239773df315d9ddc1422ab) boost-build: drop Darwin compiler substitution
* [`90df0c3e`](https://github.com/NixOS/nixpkgs/commit/90df0c3ed8794b60e95bb105674dd3f6d7f81972) boost-build: fix aarch64 clang cross-compilation
* [`6bda1a3e`](https://github.com/NixOS/nixpkgs/commit/6bda1a3ef42875b101bc178fc09b85836fb6514f) boost: fix Darwin cross-compilation
* [`ebd24041`](https://github.com/NixOS/nixpkgs/commit/ebd240410fbd0102a75e4fd6983e7209a59b934f) libpsl: fix Darwin cross-compilation
* [`86412523`](https://github.com/NixOS/nixpkgs/commit/86412523f5fa23646f82647bd6e2b9f3d72d4863) dotnetCorePackages.dotnet_{8,9}: ensure build can find the Swift overlay
* [`ff25858f`](https://github.com/NixOS/nixpkgs/commit/ff25858fa013538520a332d8b322931756e7abe5) xdg-user-dirs: make sure libiconv is linked
* [`80fdf7d3`](https://github.com/NixOS/nixpkgs/commit/80fdf7d31f47bfdd212c4531272e42e9f0378dbc) espanso: fix build on Darwin
* [`7d5f19a3`](https://github.com/NixOS/nixpkgs/commit/7d5f19a3545d88a4d8df9c588451f4fdac65339f) swift-wrapper: set up Darwin SDK paths for Swift
* [`cf0003e5`](https://github.com/NixOS/nixpkgs/commit/cf0003e56fcf182ad36bacd2bcbe2763969d0be7) swift: fix build with the new Darwin SDK
* [`1ad3206a`](https://github.com/NixOS/nixpkgs/commit/1ad3206aeaa53bf5bcf1d076a797cee16738a03a) swift: clean up ncurses and libedit references
* [`4d080bdf`](https://github.com/NixOS/nixpkgs/commit/4d080bdf16341da07fe2e4b0df933afdad9c4db7) swift: add cctools.libtool as a native build input on Darwin
* [`083d02ff`](https://github.com/NixOS/nixpkgs/commit/083d02ffc42ca477a36379ee20f1ad8a3b023875) swift: drop libarclite
* [`7c0c8fd7`](https://github.com/NixOS/nixpkgs/commit/7c0c8fd74afa2812dc2131a5450e6160bc31f00d) swift: build Swift with associated SDK version
* [`15331b1c`](https://github.com/NixOS/nixpkgs/commit/15331b1c32b7cab75031df0c4325d845c0bdb9f4) swift: use cctools.libtool directly
* [`5d128a9e`](https://github.com/NixOS/nixpkgs/commit/5d128a9edc7420154d5f4cf30d8d3ec86a67d70b) netbsd.install: fix build with new Darwin SDK
* [`86c05253`](https://github.com/NixOS/nixpkgs/commit/86c05253a1ce17d312e820af9b66986f7754516b) python3Packages.skia-pathops: fix build on Darwin
* [`4ebdf044`](https://github.com/NixOS/nixpkgs/commit/4ebdf0442f00a12b12f989fe86ef25b02c4ae1a3) libredirect: fix install name on aarch64-darwin
* [`9167e4fb`](https://github.com/NixOS/nixpkgs/commit/9167e4fbcddedf5738a5441ed7bbd310f01cdbe1) libredirect: update for new Darwin SDK on aarch64-darwin
* [`ac31fb75`](https://github.com/NixOS/nixpkgs/commit/ac31fb750578c31122d71ba739421fc8ce1d34d1) gcc: remove staging-next workaround
* [`0421ee2d`](https://github.com/NixOS/nixpkgs/commit/0421ee2dd8b823e940659b4ad51fce968d036b20) wine64Packages.{stable,unstable,staging}: use the 14.4 SDK
* [`22369efb`](https://github.com/NixOS/nixpkgs/commit/22369efb1ca9f2df5d56097588cfc12a2d2f715f) maintainers/team-list.nix: add reckenrode to darwin
* [`08ad8828`](https://github.com/NixOS/nixpkgs/commit/08ad88285dd5f058d8ddc606150f753be7f9f493) darwin: add bootstrapStdenv
* [`40d415f4`](https://github.com/NixOS/nixpkgs/commit/40d415f4df5548679dcb47331c83a2d4e7741ae8) darwin: add darwinMinVersionHook
* [`5721c4fa`](https://github.com/NixOS/nixpkgs/commit/5721c4fa47f6aa99c039bbceab40392d5110794e) darwin: add libSystem
* [`12114983`](https://github.com/NixOS/nixpkgs/commit/121149836ef2c33bb62abd323eb95780ac7d59a2) darwin: add xcodeProjectCheckHook
* [`42a6b873`](https://github.com/NixOS/nixpkgs/commit/42a6b873a601f5069a9cd7c153c200534e41bd23) hello: make sure libiconv is linked
* [`4ad6c7f1`](https://github.com/NixOS/nixpkgs/commit/4ad6c7f19d682a8e26930e94f1e5f01428753909) qt6: build Qt 6 modules with the 14.4 SDK
* [`4ec83510`](https://github.com/NixOS/nixpkgs/commit/4ec83510956bb7e1304516dee74854cfc4d889ea) qt6.qtmultimedia: drop old SDK compatibility patch
* [`0725c33a`](https://github.com/NixOS/nixpkgs/commit/0725c33a50ad2df7fe87e75a0e6dd3aeb37c3301) qt6.stdenv: drop overrideSDK
* [`cdb46a57`](https://github.com/NixOS/nixpkgs/commit/cdb46a574be24c435b036c1da6669e2c97f86a3c) skalibs: 2.14.2.0 -> 2.14.3.0
* [`d17b829d`](https://github.com/NixOS/nixpkgs/commit/d17b829d6d23d2c15c17430837750144f364a544) git: 2.46.2 -> 2.47.0
* [`e4659cb5`](https://github.com/NixOS/nixpkgs/commit/e4659cb5e546ef56cfe5fc6ba8462e320a29c277) pkgsStatic.gusb: fix build
* [`e178cc0d`](https://github.com/NixOS/nixpkgs/commit/e178cc0dcd5d052d7b8061e673e44dd19bfca28b) gsm: fix cross with Clang
* [`b6747f4e`](https://github.com/NixOS/nixpkgs/commit/b6747f4e6f01bab4fc2c3523e44079a51b22d4d8) zvbi: init at 0.2.42
* [`09e56a61`](https://github.com/NixOS/nixpkgs/commit/09e56a61f697c82f41a9f4083e927d76f82aeff9) ffmpeg: add withZvbi options
* [`c4fe4811`](https://github.com/NixOS/nixpkgs/commit/c4fe4811fef633980e03c7ccfbae9abc5351f2bc) ffmpeg: add withAribb24 options
* [`5dec8acb`](https://github.com/NixOS/nixpkgs/commit/5dec8acb8caa15777f8b3ab7ece592838070e78c) gepetto-viewer: 5.2.0 -> 5.2.0
* [`73e2bf78`](https://github.com/NixOS/nixpkgs/commit/73e2bf788b5a863f45a1ac0b2e5390a58794d4fd) gepetto-viewer-corba: 5.8.1 -> 5.8.1
* [`25ce4805`](https://github.com/NixOS/nixpkgs/commit/25ce4805249a158c6ea45a8abf27420b55f5c39b) usrsctp: backport build fix for FreeBSD 14
* [`8f8e2409`](https://github.com/NixOS/nixpkgs/commit/8f8e240965a71cea585b60a7f09281737d6849cf) darwin.apple-source-releases: add mkAppleDerivation
* [`6a54c7f6`](https://github.com/NixOS/nixpkgs/commit/6a54c7f6c92da33bbf330624313551f4a8b3c503) darwin.apple-source-releases: add update-source-releases.sh
* [`639108ea`](https://github.com/NixOS/nixpkgs/commit/639108ea70bc0541440bc14c375def19b592a48b) darwin.libsbuf: init at 14.1
* [`55679024`](https://github.com/NixOS/nixpkgs/commit/556790248f75fbd60ba60bb55418a830b2f98945) apple-sdk: init at 10.12.2 and 11.3
* [`3fb982d0`](https://github.com/NixOS/nixpkgs/commit/3fb982d0e2aab9b17591099caf53331e535295a3) apple-sdk_10_13: init at 10.13.2
* [`a447cba8`](https://github.com/NixOS/nixpkgs/commit/a447cba849ac70a51e636ea7fb0d3585c6730a6d) apple-sdk_10_14: init at 10.14.6
* [`d10c85b1`](https://github.com/NixOS/nixpkgs/commit/d10c85b19b251fd6405618ad4e4b45266fa9efc3) apple-sdk_10_15: init at 10.15.6
* [`689e8980`](https://github.com/NixOS/nixpkgs/commit/689e8980bc987d54fd441338aeda1649a20a4506) apple-sdk_12: init at 12.3
* [`4283b8f0`](https://github.com/NixOS/nixpkgs/commit/4283b8f00a2d4cb6cd36a77017f78c8bb8b2e056) apple-sdk_13: init at 13.3
* [`8fae2855`](https://github.com/NixOS/nixpkgs/commit/8fae28553af6e18d7e15fff32f3981e6affa5bff) apple-sdk_14: init at 14.4
* [`d1c25395`](https://github.com/NixOS/nixpkgs/commit/d1c25395231689272144d9903d18a42f7ed6564f) darwin: add mkStub for deprecating frameworks
* [`17aeace4`](https://github.com/NixOS/nixpkgs/commit/17aeace4d9a6632fcf0092ff95d7fcb9ab1b1507) darwin: prepare for adding stub packages
* [`fcd9dc8a`](https://github.com/NixOS/nixpkgs/commit/fcd9dc8ac61c2c11be5b9b0b9fa730b9827a14af) darwin.apple_sdk_11_0: convert frameworks and libs to stubs
* [`48022777`](https://github.com/NixOS/nixpkgs/commit/480227777b6217686ed7def88549dc0a46d968ff) darwin.apple_sdk_12_3: convert frameworks and libs to stubs
* [`0a3c4875`](https://github.com/NixOS/nixpkgs/commit/0a3c487571ac6ad4ceef83562cbb15c3c1c7a6bd) darwin.apple_sdk: convert frameworks and libs to stubs
* [`9ecb69c8`](https://github.com/NixOS/nixpkgs/commit/9ecb69c827e608f916b161431d90b7f34009145b) darwin.apple_sdk: drop gen-frameworks.py (replaced by new SDK pattern)
* [`c218ce1e`](https://github.com/NixOS/nixpkgs/commit/c218ce1e4de9ff13ff0ae58385c78e9c055367b0) darwin: replace framework chooser with stubs
* [`97d75cb6`](https://github.com/NixOS/nixpkgs/commit/97d75cb619e2bd83547ac6a7c899784d97af4401) {bintools,cc}-wrapper: set up Darwin SDK paths
* [`51755b0c`](https://github.com/NixOS/nixpkgs/commit/51755b0c00881bfe1602db0eb689efd2c66bcc20) {bintools,cc}-wrapper: use a fallback SDK when `DEVELOPER_DIR` is not set
* [`826edbf7`](https://github.com/NixOS/nixpkgs/commit/826edbf7190c7249394f9180652bc8969aa8198a) {bintools,cc}-wrapper: fix static builds on Darwin
* [`a556a81f`](https://github.com/NixOS/nixpkgs/commit/a556a81f121a852a423159422ca619bc82d31e52) atf: build with the bootstrap stdenv on Darwin
* [`54d591b2`](https://github.com/NixOS/nixpkgs/commit/54d591b2b4a7b29479e04ffde0f1338d208a4171) cmake: undo `/var/empty` workaround for Darwin SDK paths
* [`472d10b7`](https://github.com/NixOS/nixpkgs/commit/472d10b75bd462bb1e94625d23f9da5f15457d24) cmake: do in fact use the Darwin SDK in the setup hook
* [`a79ed0da`](https://github.com/NixOS/nixpkgs/commit/a79ed0daec90cfe0e053fd3f5be8c84fca865e48) gnutar: make sure libiconv is linked
* [`f1480a23`](https://github.com/NixOS/nixpkgs/commit/f1480a23ece3d3ae7596235cc3626444e4a62c36) libpng: build with the bootstrap stdenv on Darwin
* [`1ebcfd57`](https://github.com/NixOS/nixpkgs/commit/1ebcfd5758083575ecaf172aace1afd3d3d1b8d5) libuv: Use darwin.libutil on Darwin
* [`5a60ff83`](https://github.com/NixOS/nixpkgs/commit/5a60ff8315b67c0d95540329deb207b75c58cfbd) libxml2: build with the bootstrap stdenv on Darwin
* [`25c6fe1d`](https://github.com/NixOS/nixpkgs/commit/25c6fe1dc384173795d50ddbe701f0d87d5049b1) llvmPackages.clang: backport __ENVIRONMENT_OS_VERSION_MIN_REQUIRED__
* [`4dc3227d`](https://github.com/NixOS/nixpkgs/commit/4dc3227d4c4646bec09e13c11087b5f89682c0fe) llvmPackages.clang: use the system libunwind on Darwin
* [`d3114e05`](https://github.com/NixOS/nixpkgs/commit/d3114e05d777039ae04a9c39ce798140ccb81ed9) llvmPackages.compiler-rt: align Darwin bootstrap with other platforms
* [`654e19fb`](https://github.com/NixOS/nixpkgs/commit/654e19fb8311738c9112dce9409ca37ef4d2103f) llvmPackages.compiler-rt: always build sanitizers on Darwin
* [`7647c683`](https://github.com/NixOS/nixpkgs/commit/7647c6834a3b1390634842d8097dfa839cab0c89) llvmPackages.compiler-rt: avoid propagating the SDK in static builds
* [`2fd9a1ab`](https://github.com/NixOS/nixpkgs/commit/2fd9a1abeb51a0cc5a43d07151752f4e40908ff1) llvmPackages.compiler-rt: drop use of xcbuild
* [`e6a4c83d`](https://github.com/NixOS/nixpkgs/commit/e6a4c83d20d7e8ae3866f751becb1f40ec7916b3) llvmPackages.compiler-rt: fix compiler-rt bootstrap on Darwin
* [`3e5acdac`](https://github.com/NixOS/nixpkgs/commit/3e5acdacdd54b1c8d9c254d6cc722cef7b01aef8) llvmPackages.compiler-rt: fix cross-compilation on Darwin
* [`18211adc`](https://github.com/NixOS/nixpkgs/commit/18211adceb903a2efc9cf99e36c87718ba3846c3) llvmPackages.libcxx: use a bootstrap stdenv on Darwin
* [`34ce30c3`](https://github.com/NixOS/nixpkgs/commit/34ce30c35aa9c0da664b7afebddf66c71131d54a) llvmPackages.libllvm: disable tests when built in the Darwin bootstrap
* [`bf454029`](https://github.com/NixOS/nixpkgs/commit/bf45402971c5773a7c07eb8000a2d84395fd4294) ncurses: build with the bootstrap stdenv on Darwin
* [`aef46144`](https://github.com/NixOS/nixpkgs/commit/aef4614421f4d8142d627bb3dcdbb013549fc573) xar: add xarMinimal
* [`45e65c16`](https://github.com/NixOS/nixpkgs/commit/45e65c16d24be282fab4d7a5138fb087b5fa3bda) xcbuild: move to pkgs/by-name
* [`f51c62a7`](https://github.com/NixOS/nixpkgs/commit/f51c62a7f8bedf65e819b428b8948f861e3c4072) xcbuild: format with nixfmt-rfc-style
* [`15ac6579`](https://github.com/NixOS/nixpkgs/commit/15ac6579425fe3bf65604d806c9d5711db3c85d5) xcbuild: refactor to support the new SDKs
* [`118a214a`](https://github.com/NixOS/nixpkgs/commit/118a214ac5f31abe7491d371f5153292fbcb939a) xcbuild: warn when someone tries to override `sdkVer`
* [`49834c30`](https://github.com/NixOS/nixpkgs/commit/49834c3000ad469d560f73256d1e8133a8793a5f) xcbuild: suppress warning for now
* [`fee84be7`](https://github.com/NixOS/nixpkgs/commit/fee84be7523bee59232f3e86fa74e4ed7e55dcb8) xcbuild: suppress xcbuild passthru warning for now
* [`dd569d89`](https://github.com/NixOS/nixpkgs/commit/dd569d89133b9157011be854d1f3af0d8ca6c3b5) xcbuild: avoid `xcrun` invoking itself via `/usr/bin` stubs
* [`75bc428c`](https://github.com/NixOS/nixpkgs/commit/75bc428cf2428e275d36daba7e9aea85a6edceba) xcbuild: 0.1.2-pre -> 0.1.1-unstable-2019-11-20
* [`1fd1796e`](https://github.com/NixOS/nixpkgs/commit/1fd1796e65ddb690e7697d84b2e93904e59dcc53) zlib: build with the bootstrap stdenv on Darwin
* [`76a5ef68`](https://github.com/NixOS/nixpkgs/commit/76a5ef680e010ef1ce0ebea2e2fadacf401acefc) darwin.stdenv: rework for the new SDK
* [`9c004ef3`](https://github.com/NixOS/nixpkgs/commit/9c004ef367a7a3bfaba340453d821be66dfbafcf) darwin.stdenv: use xarMinimal
* [`b7442b90`](https://github.com/NixOS/nixpkgs/commit/b7442b90668d49ac5c3717a5b1cfae0dda4bb334) darwin.stdenv: provide an SDK when cross-compiling
* [`4624bd79`](https://github.com/NixOS/nixpkgs/commit/4624bd7959a6d1edac44cdca27a91d48065c7319) darwin.adv_cmds: convert to Meson and use mkAppleDerivation
* [`78076b3c`](https://github.com/NixOS/nixpkgs/commit/78076b3c12fa8f8520325d9e5cb4c2734bae03e7) darwin.AvailabilityVersions: use mkAppleDerivation
* [`129a959f`](https://github.com/NixOS/nixpkgs/commit/129a959fad9f305f3e3019b7a428067a3b4cf18d) darwin.AvailabilityVersions: also generate _symbol_aliasing.h
* [`8e7056cc`](https://github.com/NixOS/nixpkgs/commit/8e7056cc0762ed21cadebfad9d2c27aae91d8fa9) darwin.AvailabilityVersions: remove workaround
* [`94b14746`](https://github.com/NixOS/nixpkgs/commit/94b14746e0bc79dc0457175523761514acb9af8a) darwin.basic_cmds: convert to Meson and use mkAppleDerivation
* [`c5c276b6`](https://github.com/NixOS/nixpkgs/commit/c5c276b6cbfac1a913f58a2684661d71170864f0) darwin.bootstrap_cmds: convert to Meson and use mkAppleDerivation
* [`b878c444`](https://github.com/NixOS/nixpkgs/commit/b878c4440414d66dadb67320332cdf6b0c3e2478) darwin.bsdmake: add to darwin-aliases.nix
* [`8574626d`](https://github.com/NixOS/nixpkgs/commit/8574626dbbab96b8895bdb12bd9353eba07e5563) darwin.copyfile: convert to Meson and use mkAppleDerivation
* [`b8dbc16f`](https://github.com/NixOS/nixpkgs/commit/b8dbc16f1b625a6fd171e0a56e2b796aa4c66222) darwin.Csu: use mkAppleDerivation
* [`83807dc4`](https://github.com/NixOS/nixpkgs/commit/83807dc4e9657fa5b5969c3cd1f1668ed77a6d0e) darwin.developer_cmds: convert to Meson and use mkAppleDerivation
* [`97454b46`](https://github.com/NixOS/nixpkgs/commit/97454b46d525c45f0ad21d630ff180866711232c) darwin.diskdev_cmds: convert to Meson and use mkAppleDerivation
* [`eed715ac`](https://github.com/NixOS/nixpkgs/commit/eed715ac43fc2dba16ef55a6317dd8f71f0518d4) darwin.file_cmds: convert to Meson and use mkAppleDerivation
* [`0335ce09`](https://github.com/NixOS/nixpkgs/commit/0335ce09c091a04d4f7e5346391e94c0fed849c2) darwin.ICU: convert to upstream build system and use mkAppleDerivation
* [`ca4dd243`](https://github.com/NixOS/nixpkgs/commit/ca4dd24306946b5357036b96f2c323b4e2ffcfde) darwin.libiconv: move back to darwin attrset and use mkAppleDerivation
* [`b0884d52`](https://github.com/NixOS/nixpkgs/commit/b0884d52f2acc0de777b783e429a086917fb392c) darwin.libiconv: use finalPackage when referencing doInstallCheck
* [`9af3511f`](https://github.com/NixOS/nixpkgs/commit/9af3511fb213ebefa1536845b4ad5028f0fe31ca) darwin.libiconv: use `EOF` instead of `-header` for the herdoc
* [`375057b9`](https://github.com/NixOS/nixpkgs/commit/375057b9f51530b0be3c17b17bfd54fc9e5b0999) darwin.libresolv: convert to Meson and use mkAppleDerivation
* [`dac3f1f2`](https://github.com/NixOS/nixpkgs/commit/dac3f1f224e238f17f84ff2e96b4a08e990a73c7) macfuse-stubs: use top-level libtapi
* [`b8be4c4e`](https://github.com/NixOS/nixpkgs/commit/b8be4c4e6de535811cd47bffa139f2161d681cc0) darwin.libtapi: add to darwin-aliases.nix
* [`4b4270cc`](https://github.com/NixOS/nixpkgs/commit/4b4270cca333a91590e2a4d6eeda280563cb83e4) darwin.libutil: convert to Meson and use mkAppleDerivation
* [`822a8652`](https://github.com/NixOS/nixpkgs/commit/822a8652093ddd695ad11a3db33e4b2f98d9e37a) darwin.network_cmds: convert to Meson and use mkAppleDerivation
* [`6fca3b4a`](https://github.com/NixOS/nixpkgs/commit/6fca3b4a7072a16293c853a9f0f8cf859f88278a) darwin.PowerManagement: convert to Meson and use mkAppleDerivation
* [`149eb5ae`](https://github.com/NixOS/nixpkgs/commit/149eb5aef4687e70625eedd10a11c5670775952a) darwin.removefile: convert to Meson and use mkAppleDerivation
* [`a19b0a73`](https://github.com/NixOS/nixpkgs/commit/a19b0a7345a7a2c985a79697d4e89611e251c7fc) darwin.shell_cmds: convert to Meson and use mkAppleDerivation
* [`9ea9221a`](https://github.com/NixOS/nixpkgs/commit/9ea9221a1ef4a952c8e20d413cd80bf64a56f0c6) darwin.system_cmds: use mkAppleDerivation
* [`97da1bdf`](https://github.com/NixOS/nixpkgs/commit/97da1bdf095366aa338df005d49e2583a7bd29cc) darwin.text_cmds: convert to Meson and use mkAppleDerivation
* [`29a87d67`](https://github.com/NixOS/nixpkgs/commit/29a87d67513417fa50fe9c5eb63fd2c797153a97) darwin.top: convert to Meson and use mkAppleDerivation
* [`9d376e2c`](https://github.com/NixOS/nixpkgs/commit/9d376e2c537e30ddc40522e27bbbdd0300a73eb8) cctools: drop darwin.objc4 from build inputs
* [`39041627`](https://github.com/NixOS/nixpkgs/commit/39041627fe5dea0a0c6a0b8ad23617d68b45314b) cctools: move libtool to its own output
* [`2bf9c22e`](https://github.com/NixOS/nixpkgs/commit/2bf9c22eb1fae77ab538d42aada1f55635f781af) ld64: ensure ld64 checks pass with the new SDK
* [`1c177480`](https://github.com/NixOS/nixpkgs/commit/1c1774806d50fd444c67ff65d6cacd6171c7b992) ld64: drop libunwind as a dependency
* [`f90d4d5e`](https://github.com/NixOS/nixpkgs/commit/f90d4d5e5b57662e294cabca995e1e5841591c72) ld64: adopt source release private headers pattern
* [`84f8fcfc`](https://github.com/NixOS/nixpkgs/commit/84f8fcfc3e6a9da08e01e2c45603891abd35393d) libcCross: use darwin.libSystem unconditionally
* [`6986cab6`](https://github.com/NixOS/nixpkgs/commit/6986cab64be7fa54b59ae5a55a5e2a92c009925f) libunwind: add a comment explaining the package situation
* [`8a0d8844`](https://github.com/NixOS/nixpkgs/commit/8a0d8844058659ee01071edb4ed231e6321b882f) libxo: init at 1.7.5
* [`66fcbb94`](https://github.com/NixOS/nixpkgs/commit/66fcbb94e7af111946c50e9778fe01ef423df87f) makeStaticDarwin: drop darwin-portable-libSystem-hook
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
