### PR TITLE
niv nixpkgs: update c29a8c6a -> fe21dd5a

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c29a8c6aa5208fbafa857098a7cdbf4c4ea41a07",
-        "sha256": "03pg2qs1bh1i37ncc2pmry9np55sngmzh9jq5anlcnf7z1zpr079",
+        "rev": "fe21dd5ab593b2cd974161e462b2e2b0c8e24bae",
+        "sha256": "161ywnnqrafn16r8i9w6ipdsrrqr2q24h3y62slkvnnjwji60m87",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/c29a8c6aa5208fbafa857098a7cdbf4c4ea41a07.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/fe21dd5ab593b2cd974161e462b2e2b0c8e24bae.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@c29a8c6a...fe21dd5a](https://github.com/nixos/nixpkgs/compare/c29a8c6aa5208fbafa857098a7cdbf4c4ea41a07...fe21dd5ab593b2cd974161e462b2e2b0c8e24bae)

* [`05167f6e`](https://github.com/NixOS/nixpkgs/commit/05167f6ee7be0ce6dddd4bcffa2445d0bd7df34c) weechat 4.4.2 -> 4.4.3
* [`132cb2a9`](https://github.com/NixOS/nixpkgs/commit/132cb2a9571d70348ac7f3d4e1ae2305374d0324) varnish74: drop
* [`2223d54d`](https://github.com/NixOS/nixpkgs/commit/2223d54d907d5fd4175d4a6fdf884b2e260f440e) local-ai: 2.21.1 -> 2.22.1
* [`7ab046eb`](https://github.com/NixOS/nixpkgs/commit/7ab046eba505e862970cc84efae54f8a5806f873) dbus-map: drop
* [`709c7530`](https://github.com/NixOS/nixpkgs/commit/709c75309a5f7b94c1d97afdadb9ef2508859a21) vdr-markad: 3.6.0 -> 4.2.5
* [`4986f2e5`](https://github.com/NixOS/nixpkgs/commit/4986f2e594270b5cd6d6b84a9e859da4298d1b85) vdr-epgsearch: 2.4.2 -> 2.4.3
* [`68a437ea`](https://github.com/NixOS/nixpkgs/commit/68a437ea0f5fced96b24c8b352c429deaebc7d6b) vdr-skin-nopacity: 1.1.17 -> 1.1.18
* [`671e89b4`](https://github.com/NixOS/nixpkgs/commit/671e89b4db4c7755ef7f78e9bbafdbdaba830bcd) tbs: 20240506 -> 20241026
* [`5bfad8d9`](https://github.com/NixOS/nixpkgs/commit/5bfad8d9f6797b085dea3b00a641131e64b5969e) nixosModules.monado: format using nixfmt
* [`64a429e1`](https://github.com/NixOS/nixpkgs/commit/64a429e14a3fc7bb09e30a17f03515d4bdad3e56) nixosModules.monado: use hardware.graphics instead of hardware.opengl
* [`d375e8d1`](https://github.com/NixOS/nixpkgs/commit/d375e8d1be598ecbedc53cc0411f3e359a3628c6) ncurses: support termlib
* [`34b5fb26`](https://github.com/NixOS/nixpkgs/commit/34b5fb261d838ef4010efa6c5a4ad0882e1c49ac) libtinfo: init at 6.4
* [`c3b147d3`](https://github.com/NixOS/nixpkgs/commit/c3b147d34ae9eb7032c2bb644606be3d0dce7020) tests.buildFHSEnv.libtinfo: simplify using libtinfo
* [`5175000c`](https://github.com/NixOS/nixpkgs/commit/5175000c08d4f6ddaa8a81d6e7f5b9236620dbf9) libnixxml: fix darwin build
* [`1d632f0c`](https://github.com/NixOS/nixpkgs/commit/1d632f0c1ba16006d19d2de5713f914569ccafc2) caido: 0.42.0 -> 0.43.1
* [`614e5f94`](https://github.com/NixOS/nixpkgs/commit/614e5f946cb8058220a7a8daf64911702afc151d) python312Packages.opencv-python: init at 4.9.0
* [`3db8bbd4`](https://github.com/NixOS/nixpkgs/commit/3db8bbd41abcbcfaf12f3cd12bcf6b1d5c8484c2) mokuro: use opencv-python
* [`ca539544`](https://github.com/NixOS/nixpkgs/commit/ca5395442f9617ad8c2ab4b633d431cb1d0e2b74) python310Packages.paddleocr: use opencv-python
* [`83c8f23d`](https://github.com/NixOS/nixpkgs/commit/83c8f23dd7b071e33dcf51819f78a2275c44fc16) python312Packages.albucore: use opencv-python
* [`ceb628a5`](https://github.com/NixOS/nixpkgs/commit/ceb628a5667cfa7846db69a948af169ffc29eb97) python312Packages.qudida: use opencv-python
* [`902d5e51`](https://github.com/NixOS/nixpkgs/commit/902d5e51f095b9d866d206c2dad52e70aff749c4) python312Packages.manim: update dependencies
* [`7c2ed11f`](https://github.com/NixOS/nixpkgs/commit/7c2ed11f836f5d89cd8e050f1287446f5c466516) python312Packages.manim-slides: use opencv-python
* [`30732b37`](https://github.com/NixOS/nixpkgs/commit/30732b37b7b072ddce4648048772a29c07ecf1b0) python310Packages.unstructured-inference: use opencv-python
* [`ae8afe3c`](https://github.com/NixOS/nixpkgs/commit/ae8afe3cf4586e48c1cf80635287a49bf901bc5d) python311Packages.ffcv: use opencv-python
* [`fae4b49b`](https://github.com/NixOS/nixpkgs/commit/fae4b49b037988782febb40b88e592dc15378453) python312Packages.imantics: use opencv-python
* [`a6640c45`](https://github.com/NixOS/nixpkgs/commit/a6640c450c06a2a1b6f2bfdb445708af8ff4b63b) python310Packages.bpycv: use opencv-python
* [`542ca9b9`](https://github.com/NixOS/nixpkgs/commit/542ca9b9aba714a597a08c18b815b54710ec4e81) python312Packages.layoutparser: use opencv-python
* [`31d63d67`](https://github.com/NixOS/nixpkgs/commit/31d63d67a3479755412432c848959b60801bb5b6) python311Packages.mtcnn: use opencv-python
* [`c9bbb182`](https://github.com/NixOS/nixpkgs/commit/c9bbb182932eee10093dc0b0d94d387d72086f47) python312Packages.pdf2docx: use opencv-python-headless
* [`9d6fc536`](https://github.com/NixOS/nixpkgs/commit/9d6fc5360ce5e317077226c984098fefa11dec48) python312Packages.albumentations: use opencv-python
* [`4f81dd40`](https://github.com/NixOS/nixpkgs/commit/4f81dd4009c49dd43bd4f51657079a6b4f91375d) python312Packages.videocr: use opencv-python
* [`ea60f68a`](https://github.com/NixOS/nixpkgs/commit/ea60f68a878bf1b74aa4e874a779ecb60ba95341) mavproxy: use opencv-python
* [`e4467c1c`](https://github.com/NixOS/nixpkgs/commit/e4467c1cc8beaca9ed2435ee85f7c004b846add3) deface: use opencv-python
* [`9985ebb0`](https://github.com/NixOS/nixpkgs/commit/9985ebb02b805dabfc2ea12a734e0e1434d0bb04) python312Packages.rapidocr-onnxruntime: use opencv-python
* [`9e03a278`](https://github.com/NixOS/nixpkgs/commit/9e03a278f95ca4e02771e6ea92bf780fdf413229) python312Packages.invisible-watermark: use opencv-python
* [`6ed4e039`](https://github.com/NixOS/nixpkgs/commit/6ed4e0393eb8e42fb33b30742d3119346f315228) python312Packages.grad-cam: use opencv-python
* [`1be0b8ce`](https://github.com/NixOS/nixpkgs/commit/1be0b8ceee9af915697ae6d6424ebb3a72931c02) python312Packages.imagecorruptions: use opencv-python
* [`d718cf0d`](https://github.com/NixOS/nixpkgs/commit/d718cf0d0f30b6750ff0b115f28e2fc6163e84ce) video-trimmer: 0.8.2 -> 0.9.0
* [`d72b652f`](https://github.com/NixOS/nixpkgs/commit/d72b652fce9268ff5d199b934b4cb00218ec0726) dotbot: run nixfmt
* [`a36acd01`](https://github.com/NixOS/nixpkgs/commit/a36acd01512665335f7900e9f767b43f46251f19) dotbot: fix test
* [`ca7cf828`](https://github.com/NixOS/nixpkgs/commit/ca7cf8285336e094567d6d6332780b854e0c13a9) nix-search: init at 0.4.0
* [`1c508d40`](https://github.com/NixOS/nixpkgs/commit/1c508d4038eb38b8f8186ff22f098dad54404f8d) dvc: 3.55.2 -> 3.56.0
* [`00b55b13`](https://github.com/NixOS/nixpkgs/commit/00b55b130699c8b8054a7356eefa9b7736088ac2) python312Packages.dvc-data: 3.16.6 -> 3.16.7
* [`091790d8`](https://github.com/NixOS/nixpkgs/commit/091790d8341089fcbedfc589c72b1502f28be0d4) python312Packages.mypy-boto3-dynamodb: 1.35.24 -> 1.35.54
* [`e008de4c`](https://github.com/NixOS/nixpkgs/commit/e008de4ce7089166a654124ba9848fe24a50f0c5) python312Packages.mypy-boto3-stepfunctions: 1.35.46 -> 1.35.54
* [`6d8da5fe`](https://github.com/NixOS/nixpkgs/commit/6d8da5fe9d86d050f4538a2ad0800b83ca8bfd7f) python312Packages.mock-ssh-server: refactor
* [`17ab0e70`](https://github.com/NixOS/nixpkgs/commit/17ab0e70bb01dcdb445fdec7feaf26d4e3e1b06b) baddns: 1.1.869 -> 1.3.3
* [`3c29537e`](https://github.com/NixOS/nixpkgs/commit/3c29537eddcee0f8c2e3739826e10ecdff7a2e09) cargo-make: 0.37.20 -> 0.37.23
* [`c161f693`](https://github.com/NixOS/nixpkgs/commit/c161f69395749989a016a2abb726e579e394a96b) vimPlugins.cmp-vimtex: init at 2024-08-06
* [`630d2ec8`](https://github.com/NixOS/nixpkgs/commit/630d2ec83040b4d074c4cdebe6288d5a1536869f) vimPlugins.luasnip-latex-snippets-nvim: init at 2024-09-16
* [`cfb63cdd`](https://github.com/NixOS/nixpkgs/commit/cfb63cdd1a258d87ea5272f65a046fe7225a54d2) vimPlugins.typst-conceal-vim: init at 2023-10-13
* [`a8930258`](https://github.com/NixOS/nixpkgs/commit/a8930258f56eeabde984d522461f2c222850eb17) vimPlugins.typst-preview-nvim: init at 2024-10-24
* [`46a70efc`](https://github.com/NixOS/nixpkgs/commit/46a70efc8de28a4f63a7a9ab7a9b3361c3949403) vimPlugins.follow-md-links-nvim: init at 2024-09-29
* [`0cef8e3f`](https://github.com/NixOS/nixpkgs/commit/0cef8e3f953b877cf6dca550a30cd40d5571739a) ord: 0.20.1 -> 0.21.2
* [`f9511cb7`](https://github.com/NixOS/nixpkgs/commit/f9511cb7662cb36a8293219c1b7255b833099959) mediawriter: 5.1.3 -> 5.1.90
* [`c497d93d`](https://github.com/NixOS/nixpkgs/commit/c497d93d550aa4c2445b772dc488b41d56c840dc) ytermusic: format using nixfmt
* [`ba0315ba`](https://github.com/NixOS/nixpkgs/commit/ba0315ba61c85652180772a1e2ccc44dcff3ab3e) evtx: 0.8.3 -> 0.8.4
* [`81090db6`](https://github.com/NixOS/nixpkgs/commit/81090db682c5cad265dfe958c684defc6909ff34) ytermusic: fix build by updating dependencies
* [`01aab17a`](https://github.com/NixOS/nixpkgs/commit/01aab17a2eff47862eeb56e10ef0723d66bd7861) nixos/tests/prometheus-exporters/varnish: make state directory explicit
* [`00be4cf4`](https://github.com/NixOS/nixpkgs/commit/00be4cf4e82c6aa00ff5e2c73754ebed1823e4e3) Add override for typst-preview-nvim
* [`03401f02`](https://github.com/NixOS/nixpkgs/commit/03401f0200310afa450cd26efebe5891049972b6) git-lfs: fix cross compilation
* [`7f1c12b1`](https://github.com/NixOS/nixpkgs/commit/7f1c12b1170f974cc2fefd5ed45d588a3a090972) python312Packages.pysigma-backend-opensearch: 1.0.2 -> 1.0.3
* [`6ff04391`](https://github.com/NixOS/nixpkgs/commit/6ff04391d6c0abbdf90914f24278d844a89a7c00) python312Packages.mmengine: fix test
* [`ebbcbca1`](https://github.com/NixOS/nixpkgs/commit/ebbcbca198bc921e80e8eac4b00fbe7da3ac1255) python312Packages.bimmer-connected: 0.16.3 -> 0.16.4
* [`255d5e0d`](https://github.com/NixOS/nixpkgs/commit/255d5e0d43d6d156a325e69a94636df91786133c) Revert "woodpecker-server: 2.7.1 -> 2.7.2"
* [`e0b41a76`](https://github.com/NixOS/nixpkgs/commit/e0b41a76dda8a7788007fbb78e9600dcfffb8e03) SDL_ttf: fix sdltest configure flag
* [`20fff77f`](https://github.com/NixOS/nixpkgs/commit/20fff77fcc33876e4e897562d81b9c83d57769e6) vix: limit package to x86_64-linux ([nixos/nixpkgs⁠#353569](https://togithub.com/nixos/nixpkgs/issues/353569))
* [`e19b0195`](https://github.com/NixOS/nixpkgs/commit/e19b0195b43079bac31c27b911a4cd1da3d5944d) SDL_sound: fix sdltest flag
* [`4ddef40c`](https://github.com/NixOS/nixpkgs/commit/4ddef40cb938ec937c0082a2b82a8b3369361140) agg: disable sdltest on darwin
* [`eb2009ec`](https://github.com/NixOS/nixpkgs/commit/eb2009ec57598911cdfdb6e148abd092fbcb2d9f) dgen-sdl: fix darwin build
* [`15e07bd8`](https://github.com/NixOS/nixpkgs/commit/15e07bd8205e174b42acb8db510246be6fa738ed) emacsPackages: Don't add nix to melpa updater shell
