### PR TITLE
niv home-manager: update e8341405 -> 8f6ca785

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -41,10 +41,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e83414058edd339148dc142a8437edb9450574c8",
-        "sha256": "0kg9iaixqygpncw7avgh1grwyjgnfc9i7k9pk8hc4xrvr8jv2l3c",
+        "rev": "8f6ca7855d409aeebe2a582c6fd6b6a8d0bf5661",
+        "sha256": "1zdrga86vdc8d47n2xlqw6iq13688ga5hjji77rsnm3gg8hnllk4",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/e83414058edd339148dc142a8437edb9450574c8.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/8f6ca7855d409aeebe2a582c6fd6b6a8d0bf5661.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@e8341405...8f6ca785](https://github.com/nix-community/home-manager/compare/e83414058edd339148dc142a8437edb9450574c8...8f6ca7855d409aeebe2a582c6fd6b6a8d0bf5661)

* [`8ca921e5`](https://github.com/nix-community/home-manager/commit/8ca921e5a806b5b6171add542defe7bdac79d189) git-credential-oauth: fix ordering of git extraConfig
* [`1743615b`](https://github.com/nix-community/home-manager/commit/1743615b61c7285976f85b303a36cdf88a556503) podman: add module
* [`2c6a9b3c`](https://github.com/nix-community/home-manager/commit/2c6a9b3ccf1bb0930befadfed13195c2168d1287) git: fix maintenance service
* [`8f6ca785`](https://github.com/nix-community/home-manager/commit/8f6ca7855d409aeebe2a582c6fd6b6a8d0bf5661) flake.lock: Update
