### PR TITLE
niv niv: update 9e0a8184 -> 55422d6f

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -89,10 +89,10 @@
         "homepage": "https://github.com/nmattia/niv",
         "owner": "nmattia",
         "repo": "niv",
-        "rev": "9e0a81847b67d11c4fab4c554a0dad0311ea8836",
-        "sha256": "01g7mfp9lif4nxbjk4a1b1mfgxrz6ji31ql4lcw2q3822d038vh2",
+        "rev": "55422d6f2618cd2195eeafa3f16ae63fde723c15",
+        "sha256": "1s6m41hhsydf3lw6ihksc904vcpyd5agwiqq8hb8plyqvsyn74ba",
         "type": "tarball",
-        "url": "https://github.com/nmattia/niv/archive/9e0a81847b67d11c4fab4c554a0dad0311ea8836.tar.gz",
+        "url": "https://github.com/nmattia/niv/archive/55422d6f2618cd2195eeafa3f16ae63fde723c15.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {


### PR DESCRIPTION
## Changelog for niv:
Branch: master
Commits: [nmattia/niv@9e0a8184...55422d6f](https://github.com/nmattia/niv/compare/9e0a81847b67d11c4fab4c554a0dad0311ea8836...55422d6f2618cd2195eeafa3f16ae63fde723c15)

* [`55422d6f`](https://github.com/nmattia/niv/commit/55422d6f2618cd2195eeafa3f16ae63fde723c15) Bump GHA runners ([nmattia/niv⁠#412](https://togithub.com/nmattia/niv/issues/412))
