### PR TITLE
niv nixpkgs: update fe21dd5a -> 5c1e2db5

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "fe21dd5ab593b2cd974161e462b2e2b0c8e24bae",
-        "sha256": "161ywnnqrafn16r8i9w6ipdsrrqr2q24h3y62slkvnnjwji60m87",
+        "rev": "5c1e2db52711ebee5df2c6bb7e04a52a13e2f73d",
+        "sha256": "018j2ahbqrbmi4kb3xaihck6y11dzrhx9ix53f51qdcz3mj2ax94",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/fe21dd5ab593b2cd974161e462b2e2b0c8e24bae.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/5c1e2db52711ebee5df2c6bb7e04a52a13e2f73d.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@fe21dd5a...5c1e2db5](https://github.com/nixos/nixpkgs/compare/fe21dd5ab593b2cd974161e462b2e2b0c8e24bae...5c1e2db52711ebee5df2c6bb7e04a52a13e2f73d)

* [`4851b2be`](https://github.com/NixOS/nixpkgs/commit/4851b2be0184a0aed976fcced4c1e7b6d7eae82c) nixos/tests/prometheus-exporters: add exportarr-sonarr test
* [`10ac9199`](https://github.com/NixOS/nixpkgs/commit/10ac9199553f17ad22e5f92e37e329126d6de951) ecwolf: add passthru.updateScript
* [`e8a9775a`](https://github.com/NixOS/nixpkgs/commit/e8a9775a6167736009a3bd255c8db7a56cfadb70) nixos/nzbget: add option to override package
* [`34bdc3a4`](https://github.com/NixOS/nixpkgs/commit/34bdc3a46a5591dc82c08dc64e9a7b608973cd89) libchewing: move Nix expression under pkgs/by-name
* [`222c7ca7`](https://github.com/NixOS/nixpkgs/commit/222c7ca7a9d0102232f0ed8b9be7ace0f04175a5) libchewing: canonicalise unstable version naming
* [`b4a64193`](https://github.com/NixOS/nixpkgs/commit/b4a64193b1865659360e29bdb8ffed100e98c7c7) libchewing: use fixed-point arguments
* [`e3b4dd81`](https://github.com/NixOS/nixpkgs/commit/e3b4dd81b174bc891be7b9ef6a32a51c060dc5b2) libchewing: format .override set pattern
* [`f193ae7b`](https://github.com/NixOS/nixpkgs/commit/f193ae7b67325dc19da147f78d2a5db3c7254807) libchewing: 0.5.1-unstable-2020-06-27 -> 0.6.0
* [`d680a8ae`](https://github.com/NixOS/nixpkgs/commit/d680a8aeb0eff0a891f5dde1eb1a603d37697047) libchewing: add ShamrockLee as a maintainer
* [`a7e4ae9c`](https://github.com/NixOS/nixpkgs/commit/a7e4ae9c8c483e57c87d99efb526ecd5f6cf2826) added linux_{default,latest} to linuxKernel.kernels
* [`e3835b2a`](https://github.com/NixOS/nixpkgs/commit/e3835b2a2eb4b4452b6156074875ce46db4b31df) libchewing: build on all platforms
* [`410ae87b`](https://github.com/NixOS/nixpkgs/commit/410ae87bf5e27aa37044c204b7add6bb18d364f3) nixos/boinc: use exec to start the payload binary
* [`5d49d4cf`](https://github.com/NixOS/nixpkgs/commit/5d49d4cfa1a4ceb5cfaad343c436c2e9e48de913) nixos/guix: use exec to start the payload binary
* [`a3843a7e`](https://github.com/NixOS/nixpkgs/commit/a3843a7ee5641cff16acf9a716f361b291e093f7) chiptrack: init at 0.3.1
* [`9ac4777d`](https://github.com/NixOS/nixpkgs/commit/9ac4777d98d04fc2cc0604a0fc04830c3be431b9) nixos/localsend: add package option
* [`0b097987`](https://github.com/NixOS/nixpkgs/commit/0b097987fe34e0f93216679b1c222f1b3fe88787) nixos/localsend: allow udp port
* [`cb10fe8a`](https://github.com/NixOS/nixpkgs/commit/cb10fe8aaf430862537f0ae807146995fc05c946) treewide: Remove ineffective capability grants.
* [`f4279308`](https://github.com/NixOS/nixpkgs/commit/f4279308f0410e3af441100b2748cc9a61f71295) erlang-language-platform: init at 2024-07-16
* [`0bde84a2`](https://github.com/NixOS/nixpkgs/commit/0bde84a250e62b422b2a23595a054d9ecf3445c3) maintainers: add alex-nt
* [`503bea43`](https://github.com/NixOS/nixpkgs/commit/503bea4333cf5c6613d41e89a28ad05d6afd1a2e) python312Packages.better-exceptions: init at 0.3.3
* [`29014765`](https://github.com/NixOS/nixpkgs/commit/29014765300b3d03ceb7885859e10fd46fa18468) gaphor: 2.8.2 -> 2.26.0
* [`a44e0fe3`](https://github.com/NixOS/nixpkgs/commit/a44e0fe3dc9f51fbd384bb367b72754d1a4a8234) pyton312Packages.sphinx-autodoc2: init at 0.5.0
* [`43f2c108`](https://github.com/NixOS/nixpkgs/commit/43f2c10893557733ebcc83dc4f070495541c4775) python3Packages.django-tenants: move out of authentik
* [`0792a843`](https://github.com/NixOS/nixpkgs/commit/0792a8433348cdec10a5d30c075a07ee3b01089c) python3Packages.django-cte: move out of authentik
* [`e1ac4f7d`](https://github.com/NixOS/nixpkgs/commit/e1ac4f7d43e9e599365b1a1fd228b373bbba3b1b) python3Packages.django-pgactivity: move out of authentik
* [`50b83177`](https://github.com/NixOS/nixpkgs/commit/50b83177ad4e5c0fc27ebf372f7195e392ce4389) python3Packages.django-pglock: move out of authentik
* [`13da3f33`](https://github.com/NixOS/nixpkgs/commit/13da3f3368935906924d710c78b69e2f437ed332) python3Packages.tenant-schemas-celery: move out of authentik
* [`75ff1566`](https://github.com/NixOS/nixpkgs/commit/75ff156698cabcf90608b06ec558f0d840204251) authentik: use packaged scim2-filter-parser
* [`d6f44b23`](https://github.com/NixOS/nixpkgs/commit/d6f44b2349191eaca586322cf65ef994d619b673) libspnav: 0.2.3 -> 1.1
* [`b2e9fff1`](https://github.com/NixOS/nixpkgs/commit/b2e9fff168ca23a8ce7469a5c3b782c4d954767d) spacenavd: 0.8 -> 1.2
* [`3e4235b7`](https://github.com/NixOS/nixpkgs/commit/3e4235b74feaad6bb9082e0c7697702f541b49b7) spacenavd: install upstream systemd unit
* [`b60d3f62`](https://github.com/NixOS/nixpkgs/commit/b60d3f6270168bd3560637931a9c42eb320d760b) fetchgithub: support fetchLFS
* [`8a763046`](https://github.com/NixOS/nixpkgs/commit/8a7630460dcef91b7e84f688b450aa74b04b7c44) spnavcfg: 0.3.1 -> 1.1
* [`896663ce`](https://github.com/NixOS/nixpkgs/commit/896663ce96858d7c54e12762cc29b90f0ad104d5) nixos/spacenavd: Use upstream module
* [`d909e89b`](https://github.com/NixOS/nixpkgs/commit/d909e89b6d6c04b8ef8b88504d5a1484aa31bb0f) spaacenavd: 1.2 -> 1.3
* [`30034ed5`](https://github.com/NixOS/nixpkgs/commit/30034ed5a09c612d1be25a2835f22499b47605d2) imapsync: 2.229 -> 2.290
* [`3275f1af`](https://github.com/NixOS/nixpkgs/commit/3275f1af7dd221f49a9c186e34ceb5a6549fe25a) docs: rust: Improve wording about adding Cargo.lock to src
* [`9c3540c0`](https://github.com/NixOS/nixpkgs/commit/9c3540c0ed9ceed7ade932a0856e7d362609e427) perlPackages.mimeConstruct: add passthru.binlore
* [`239c623a`](https://github.com/NixOS/nixpkgs/commit/239c623a204c5b7e7d1ced179d7d6cb7a48ea2f7) maintainers: add corbinwunderlich
* [`92d35561`](https://github.com/NixOS/nixpkgs/commit/92d355610cf8121962a70a57cf7aa5eec90866d9) lavalauncher: nixfmt-rfc-style
* [`9ddee15c`](https://github.com/NixOS/nixpkgs/commit/9ddee15c101db98ed581a10bc192a02f18e5ffa4) lavalauncher: finalAttrs
* [`0121c9a1`](https://github.com/NixOS/nixpkgs/commit/0121c9a1a5b1c9ff577b3eb50216a01369120d32) lavalauncher: use fetchFromSourcehut
* [`08573721`](https://github.com/NixOS/nixpkgs/commit/08573721b88bd93a35506fedd71672c3be68586a) lavalauncher: set strictDeps
* [`edfe0738`](https://github.com/NixOS/nixpkgs/commit/edfe07384d687f33e8caf05c7c070331d4d2ac1a) lavalauncher: mark as broken for Darwin
* [`2a15702b`](https://github.com/NixOS/nixpkgs/commit/2a15702bc8761ae7e0cdbf30ed180f96a8607023) nixos/openvpn: don't fail to restart stopped units
* [`5146c143`](https://github.com/NixOS/nixpkgs/commit/5146c143bbf1781007323df6fac8fa0fbaddd51d) gifski: 1.14.4 -> 1.32.0
* [`89ecd031`](https://github.com/NixOS/nixpkgs/commit/89ecd03131603978784cd28bb531e5d727f7cda8) teamviewer: format file
* [`2928912a`](https://github.com/NixOS/nixpkgs/commit/2928912a7c743763ac790aa69f3759b70f20b5cc) teamviewer: remove "with lib;"
* [`04dbbd43`](https://github.com/NixOS/nixpkgs/commit/04dbbd4365155613fbacd3c9f1ef79230c7e721a) teamviewer: introduce services.teamviewer.package option
* [`823adf6a`](https://github.com/NixOS/nixpkgs/commit/823adf6a2eb8428593b3594bb7068ad6250ea968) hof: 0.6.9-beta.1 -> 0.6.9
* [`b4e73ca4`](https://github.com/NixOS/nixpkgs/commit/b4e73ca4cf2da7f9f9657c98b59df02cf08807c8) python312Packages.humanize: 4.10.0 -> 4.11.0
* [`1b592cde`](https://github.com/NixOS/nixpkgs/commit/1b592cdeb46e83635461cb930daa221e9f24859f) nixos/image/repart: unsafeDiscardReferences.out = true
* [`f579c189`](https://github.com/NixOS/nixpkgs/commit/f579c189a761139aacb2ca34d8a2d655046a0cfd) nixos/buildbot-master: allow merging extraConfig and extraImports
* [`e7f53bf0`](https://github.com/NixOS/nixpkgs/commit/e7f53bf02fe9e58ff52051d35a1adc1d61901fff) nixos/tests/redmine: Limit architectures to supported ones
* [`6e6fc7ca`](https://github.com/NixOS/nixpkgs/commit/6e6fc7ca26581b916483d6de35cd1425ee3aa764) nixos/acme: do not limit credentials functionality to DNS/S3 config
* [`c02e1552`](https://github.com/NixOS/nixpkgs/commit/c02e155285efbee398686a37b270232a135055fa) vscode-extensions.esbenp.prettier-vscode: 10.4.0 -> 11.0.0
* [`eafd968b`](https://github.com/NixOS/nixpkgs/commit/eafd968bfd2b25a5d38076c39ee5f267ce2a03a1) nixos/systemd: fix enableStrictShellChecks description
* [`521b04f3`](https://github.com/NixOS/nixpkgs/commit/521b04f3c86a64d7d18c9226d0c17b06edf5abc0) hdf4: format with nixfmt
* [`6f6d588e`](https://github.com/NixOS/nixpkgs/commit/6f6d588e1f416282cbfee5ed0c7f389822d8b3db) hdf4: modernize
* [`c446f2bc`](https://github.com/NixOS/nixpkgs/commit/c446f2bc4d6f39f44a5a248e1cac3e6506fd241b) hdf4: fix cross
* [`013fb489`](https://github.com/NixOS/nixpkgs/commit/013fb489b8a0332f69369d58d0b9d186c3a88bf3) highlight: 4.12 -> 4.14
* [`71874199`](https://github.com/NixOS/nixpkgs/commit/718741995339d9814255734e134156ff8e2a66de) rpm: fix build on Darwin
* [`5900b644`](https://github.com/NixOS/nixpkgs/commit/5900b644bb5ed65d162e76a8d084e60197453275) nixos/docker: move live-restore option into daemon.settings
* [`77a65d18`](https://github.com/NixOS/nixpkgs/commit/77a65d189a85c18420d74bad3bc7d1598e2cb331) nixos/docker: keep live-restore disabled by default
* [`5c30edb4`](https://github.com/NixOS/nixpkgs/commit/5c30edb481c1b419a154eb4383d388c528813803) cemu-ti: Fix build failure
* [`1a48ff70`](https://github.com/NixOS/nixpkgs/commit/1a48ff70729306a4ce39f0bb69fcf2b25902dd91) python312Packages.morecantile: 5.4.2 -> 6.0.0
* [`a2d4cea9`](https://github.com/NixOS/nixpkgs/commit/a2d4cea96ec766ef1df9484888f14e59576ec825) etc: rename the temporary dirs so that they are recognisable
* [`0f786baf`](https://github.com/NixOS/nixpkgs/commit/0f786baf5db22e7eaa0e356b9ad595d9ee000eeb) etc: remove unneeded temporary directions after putting in place the new etc
* [`65f375d1`](https://github.com/NixOS/nixpkgs/commit/65f375d172e1088c6f412ac009f550e4b0b188eb) etc: extend tests to ensure that temporary dirs are cleaned up
* [`4d47e059`](https://github.com/NixOS/nixpkgs/commit/4d47e0592a4a69eb5843e2b33988627564974905) nomad_1_9: init at 1.9.0
* [`5336a876`](https://github.com/NixOS/nixpkgs/commit/5336a876984c63b10411cf9d151ec00442dc0b0d) nomad: nomad_1_7 -> nomad_1_8
* [`41bf8eb2`](https://github.com/NixOS/nixpkgs/commit/41bf8eb2e89e7c0314bac9df6847e3c7b8c7c78a) add changelog notes for breaking nomad changes
* [`c7a381c9`](https://github.com/NixOS/nixpkgs/commit/c7a381c92a79de9523a6adb23bfc5aba62c0cda1) mysql-shell: 8.4.1 -> 8.4.3
* [`cbcee246`](https://github.com/NixOS/nixpkgs/commit/cbcee246078791c6831999bf54b6815929e6589b) mysql-shell-innovation: 9.0.1 -> 9.1.0
* [`dd21919e`](https://github.com/NixOS/nixpkgs/commit/dd21919e9f6507b84a8a5e6d44f70c41bd5396a2) trace-cmd: Add updateScript
* [`28603d0f`](https://github.com/NixOS/nixpkgs/commit/28603d0f8d15b3056f54e63610bfda38cef9798e) trace-cmd: 3.2 -> 3.3.1
* [`c3ceedea`](https://github.com/NixOS/nixpkgs/commit/c3ceedeac1ac9cbf8f0f99d96ff87b56e5dd3df8) obs-studio-plugins.obs-hyperion: patch stateChanged deprecation
* [`926fb033`](https://github.com/NixOS/nixpkgs/commit/926fb03392796effcf68010f70a5a7af2e4c12dc) culvert: init at 0.4.0.unstable-2024-10-16
* [`408a0a97`](https://github.com/NixOS/nixpkgs/commit/408a0a97c02c2e019d83b8634aef80822ecff40a) jellyfin-rpc: init at 1.3.0
* [`ba5b7e3e`](https://github.com/NixOS/nixpkgs/commit/ba5b7e3e45d459620a26336b07184ff9541ecbd5) calamares: improve unfree check box description
* [`40a4559a`](https://github.com/NixOS/nixpkgs/commit/40a4559adbfedd3fc906881a5ea7c2debbe50241) rime-japanese: init at 0-unstable-2023-08-02
* [`516682d4`](https://github.com/NixOS/nixpkgs/commit/516682d47fa439dc87c68b05a36d5b629f208f08) glab: fix formatting
* [`6fb2d94d`](https://github.com/NixOS/nixpkgs/commit/6fb2d94d980916b734353537d71a70e51d113429) glab: 1.47.0 -> 1.48.0
* [`8a82b78f`](https://github.com/NixOS/nixpkgs/commit/8a82b78f5872d9704dd3f4763c7061cba1ea28de) fahrplan: init at 1.1.2
* [`5a9860d7`](https://github.com/NixOS/nixpkgs/commit/5a9860d7ad24ef05b537c3ea832a53577b9c430d) alice-lg: reformat according to RFC166
* [`a2498052`](https://github.com/NixOS/nixpkgs/commit/a24980521229f4e53a746bbfd526ea4af30cdc49) alice-lg: avoid 'with lib' usage
* [`d8ca7f6f`](https://github.com/NixOS/nixpkgs/commit/d8ca7f6f4aa94d282f36a601e9188121434733e1) alice-lg: migrate to by-name
* [`c93e4474`](https://github.com/NixOS/nixpkgs/commit/c93e44748e4de384a39c6811f176808eadb6d423) birdwatcher: adopt by stv0g
* [`663deaba`](https://github.com/NixOS/nixpkgs/commit/663deaba005111a3c4a5f4ec21b4a15d1cbcbbfb) birdwatcher: reformat according to RFC166
* [`fe4ca038`](https://github.com/NixOS/nixpkgs/commit/fe4ca0386582e3bdb5762ef28108c1d29bc9f699) birdwatcher: avoid 'with lib' usage
* [`694efe2c`](https://github.com/NixOS/nixpkgs/commit/694efe2c615641cebe73506d0d0ebab0a8340236) birdwatcher: migrate to by-name
* [`07c81867`](https://github.com/NixOS/nixpkgs/commit/07c81867c90727082b8fa1c25b0e60a49ecb00fd) dolphin-emu-primehack: 1.0.6a -> 1.0.7a, qt5 -> qt6, unpin fmt
* [`7c0a5039`](https://github.com/NixOS/nixpkgs/commit/7c0a50390e45978af693dbcb4a917a9c73b6c0a1) trunk-recorder: init at 5.0.1
* [`7e38e7d4`](https://github.com/NixOS/nixpkgs/commit/7e38e7d4a903077d9cec737655c8d26616a277b6) ispc: 1.24.0 -> 1.25.0
* [`742169ba`](https://github.com/NixOS/nixpkgs/commit/742169ba7fd31523a312155ed4142febe7da22fa) calamares: explain what unfree means
* [`b150635f`](https://github.com/NixOS/nixpkgs/commit/b150635f94721162855ba385171cab088e20cff6) dart: 3.5.3 -> 3.5.4
* [`727427cd`](https://github.com/NixOS/nixpkgs/commit/727427cdf541c16bda558cc9494104ca0995c47b) python3Packages.clickclick: update upstream location
* [`6c32de78`](https://github.com/NixOS/nixpkgs/commit/6c32de78405a8ca693eaa281cee5bc9a6062ac3b) vscode-extensions.streetsidesoftware.code-spell-checker: 4.0.7 -> 4.0.14
* [`c50fa568`](https://github.com/NixOS/nixpkgs/commit/c50fa5688015c3057902ce17446cc9e29d14b4ce) python3Packages.clickclick: 1.2.2 -> 20.10.2
* [`d931f342`](https://github.com/NixOS/nixpkgs/commit/d931f342a4292796f93efff82fca8580f6d53a9c) mysql80: 8.0.39 -> 8.0.40
* [`7e59ed7f`](https://github.com/NixOS/nixpkgs/commit/7e59ed7f3200e890764c1ff43e88f6da2706d8a5) pik: init at 0.9.0
* [`cc7dc586`](https://github.com/NixOS/nixpkgs/commit/cc7dc58696654b1e4a74444049569e6d50d9373f) cloneit: init at 0-unstable-2024-06-28
* [`846d5534`](https://github.com/NixOS/nixpkgs/commit/846d5534053903f601df5e6ce79d2807bcfa16d1) morgen: bump electron version to electron_32
* [`7d96814b`](https://github.com/NixOS/nixpkgs/commit/7d96814b2907cd77705faecc928625fc64936533) timidity: add enableVorbis option
* [`7518588d`](https://github.com/NixOS/nixpkgs/commit/7518588df677c260eb2fdf10541ef17c9b096492) Add basic NixOS tests for TiMidity++
* [`7713ac82`](https://github.com/NixOS/nixpkgs/commit/7713ac827e4556876c26e5b59d6f6df1ce6d5c55) Link TiMIDIty++ tests to the package
* [`f52c685f`](https://github.com/NixOS/nixpkgs/commit/f52c685f972760eb1db2b61b0c098cb69baa0958) buildNpmPackage: pass down patchFlags to fetchNpmDeps
* [`1caf4217`](https://github.com/NixOS/nixpkgs/commit/1caf42170d5ace8b3e7ee8b5e31bfad3f0c3e31c) vscode-extensions.continue.continue: 0.8.44 -> 0.8.54
* [`bb9c4334`](https://github.com/NixOS/nixpkgs/commit/bb9c433426faafe913d3f21ba33ff6d675568a5f) Update nixos/tests/all-tests.nix
* [`090c42e9`](https://github.com/NixOS/nixpkgs/commit/090c42e9928a334570d02da7352a33064a6473fd) openrazer: 3.8.0 -> 3.9.0
* [`44cb9e29`](https://github.com/NixOS/nixpkgs/commit/44cb9e293721c59ada40019feb25eff168df7010) schemamap: 0.4.0 -> 0.4.3
* [`aa796106`](https://github.com/NixOS/nixpkgs/commit/aa796106695843d7e3d44aff4550ca0dc71c7708) zabbix70: 7.0.2 -> 7.0.5
* [`bb814ee6`](https://github.com/NixOS/nixpkgs/commit/bb814ee6497958aa6c69449a6a7d9f0f862452a1) all-cabal-hashes: 2024-10-05T14:46:54Z -> 2024-10-25T11:10:52Z
* [`e790d59f`](https://github.com/NixOS/nixpkgs/commit/e790d59f98e8032c2d933d2539e782851cee1220) haskellPackages: stackage LTS 22.36 -> LTS 22.39
* [`7ae9e346`](https://github.com/NixOS/nixpkgs/commit/7ae9e346a4aa709476e3de6d01ffc99413721775) haskellPackages: regenerate package set based on current config
* [`dd766b62`](https://github.com/NixOS/nixpkgs/commit/dd766b62553a5d86caeb7c71bd280dbf4b082b1f) snyk: 1.1293.1 -> 1.1294.0
* [`31e0477d`](https://github.com/NixOS/nixpkgs/commit/31e0477d2b29433c3d89d144884d75e8738ec2ad) haskellPackages.mpi-hs: 0.7.3.0 -> 0.7.3.1
* [`1277fb61`](https://github.com/NixOS/nixpkgs/commit/1277fb618e323764021e1fb3c93bf6f63ed75b2e) yi: re-init at 0.19.2
* [`a62d4fe4`](https://github.com/NixOS/nixpkgs/commit/a62d4fe4996720888784d5b90f112cc088911143) haskell.packages.ghc98*.ghc-lib{,-parser}: use 9.8.3 versions
* [`365bef98`](https://github.com/NixOS/nixpkgs/commit/365bef989f014784dfb855e5aafad4f76ea6be92) python312Packages.cgal: 6.0.post202410011635 -> 6.0.1.post202410241521
* [`9ce86487`](https://github.com/NixOS/nixpkgs/commit/9ce864871fdce601ec366f7956f61056feddff83) python312Packages.rio-tiler: 6.7.0 → 7.0.1
* [`a3532c95`](https://github.com/NixOS/nixpkgs/commit/a3532c957dcd5e75894302a3a4d1170713d8769b) haskell.packages.ghc983.generic-arbitrary: disable broken test suite
* [`169b24df`](https://github.com/NixOS/nixpkgs/commit/169b24df4179a8ebc96258756e1dfe064da3ef1c) haskellPackages.password: use crypton, disable scrypt on non-x86
* [`c10dfd6b`](https://github.com/NixOS/nixpkgs/commit/c10dfd6bb79e6f44e065446e943d3e749ba6672d) cmus: 2.11.0 -> 2.12.0
* [`a751b1ac`](https://github.com/NixOS/nixpkgs/commit/a751b1ac82b80e5c466d033b58c5d03729f72555) fim: unpin from gcc-9
* [`fc489f37`](https://github.com/NixOS/nixpkgs/commit/fc489f378960496f31ffbf2716bcca9e4c9bbba2) rpiboot: add updateScript
* [`e69a5a04`](https://github.com/NixOS/nixpkgs/commit/e69a5a04b80b7d342c6900129c0900a97fbf98e9) birdwatcher: add updateScript
* [`a7dfd9f1`](https://github.com/NixOS/nixpkgs/commit/a7dfd9f1dc018dc5126fbb0690ee8f64686d79dc) alice-lg: add updateScript
* [`acefd3eb`](https://github.com/NixOS/nixpkgs/commit/acefd3eb3e2c45aa78ba6b8f0550d1203346f0be) gortr: adopt package by stv0g
* [`1b5b0110`](https://github.com/NixOS/nixpkgs/commit/1b5b01103aa3a88c70e624144aa8c94c4215aa54) gortr: format with nixfmt according to RFC166
* [`fbc0b893`](https://github.com/NixOS/nixpkgs/commit/fbc0b893e64fa55c3373326fdfa129b6b51abfb3) gortr: migrate to by-name
* [`038bdcf5`](https://github.com/NixOS/nixpkgs/commit/038bdcf50ca4ef0acd69a154c31791c510df2d1d) gortr: use 'hash' instead of 'sha256' attribute
* [`4cbb3cb2`](https://github.com/NixOS/nixpkgs/commit/4cbb3cb26073aed0d548111901ba621ee517fedb) intel-vaapi-driver: Format using nixfmt-rfc-style
* [`b657bae7`](https://github.com/NixOS/nixpkgs/commit/b657bae709c80552f6fb343d2232bcea8d88dd6e) intel-vaapi-driver: Move to pkgs/by-name
* [`410f5d58`](https://github.com/NixOS/nixpkgs/commit/410f5d583eb826f98a295f4df9806cf7a5f18eb2) intel-vaapi-driver: 2.4.1 -> 2.4.1-unstable-2024-10-27
* [`00269b87`](https://github.com/NixOS/nixpkgs/commit/00269b87c3c1722e1baa6275a3488a778b9dd82b) intel-vaapi-driver: Add passthru.updateScript
* [`be2a110f`](https://github.com/NixOS/nixpkgs/commit/be2a110f7a19ade845167d27d51630ad31ce26c7) libphonenumber: 8.13.45 -> 8.13.48
* [`67c5c8ea`](https://github.com/NixOS/nixpkgs/commit/67c5c8ea15bc3005b2c45d6a96965b0599938e15) babl: 0.1.108 -> 0.1.110
* [`0d6cba9f`](https://github.com/NixOS/nixpkgs/commit/0d6cba9f6571c92c9f895bb222fc2b763fa82c87) maintainers: add griffi-gh
* [`04f2513a`](https://github.com/NixOS/nixpkgs/commit/04f2513a229955a44397155086aa4aafec946cb2) fdroidserver: Add libvirt
* [`1f3d7250`](https://github.com/NixOS/nixpkgs/commit/1f3d725015646281577e906bc4b1ce4de533e675) python312Packages.umap-learn: 0.5.6 -> 0.5.7
* [`9ee170b5`](https://github.com/NixOS/nixpkgs/commit/9ee170b5a3f52de17bfc6b8a1d1497af14d3d387) sensu: drop it as it is no longer maintained
* [`f39d1ded`](https://github.com/NixOS/nixpkgs/commit/f39d1dedc84cf527279f7a0601f99a25ee44761d) melange: 0.11.3 -> 0.14.10
* [`b2870244`](https://github.com/NixOS/nixpkgs/commit/b287024481cf6a152b0654bc1e2c82e039ca8f7e) popeye: 0.21.3 -> 0.21.5
* [`546e8aed`](https://github.com/NixOS/nixpkgs/commit/546e8aedaa355ab694c2b249e3d9fcd857dd661a) go-ios: 1.0.143 -> 1.0.150
* [`ed71f142`](https://github.com/NixOS/nixpkgs/commit/ed71f1425175a41d9f474062b7d3468793f494ad) nyxt: remove old workaround
* [`7c4fc35d`](https://github.com/NixOS/nixpkgs/commit/7c4fc35d7426d35b5734b0f23626b17604a92c09) roon-server: 2.0-1462 -> 2.0-1470
* [`339eb4e6`](https://github.com/NixOS/nixpkgs/commit/339eb4e65bf196fa6062fc7388afdb6541509b61) manicode: init at 1.0.94
* [`1feb1934`](https://github.com/NixOS/nixpkgs/commit/1feb1934ccc3bfad04c0bd2f291b75193b2d232d) seafile-client: 9.0.8 -> 9.0.9
* [`0f4ede25`](https://github.com/NixOS/nixpkgs/commit/0f4ede258d2bd5bd7944d1113ae4cc49ac4f41a9) junest: fix --version flag
* [`fb64cad3`](https://github.com/NixOS/nixpkgs/commit/fb64cad3c9589e6b1139a9cf18aca6425cfd5bf4) byedpi: 0.14.1 -> 0.15
* [`2280b9bf`](https://github.com/NixOS/nixpkgs/commit/2280b9bf4a98a9c3fd0e29ced17494e774b1e87f) python312Packages.bsdiff4: 1.2.4 -> 1.2.5
* [`cc262c89`](https://github.com/NixOS/nixpkgs/commit/cc262c899f10c0a4d5d0d47b10211c48f4027bc8) linkerd_edge: 24.10.3 -> 24.10.4
* [`4d25fa4f`](https://github.com/NixOS/nixpkgs/commit/4d25fa4f987a3c68783183c6edca547e9c54122b) python312Packages.tableauserverclient: 0.33 -> 0.34
* [`c6fd7c90`](https://github.com/NixOS/nixpkgs/commit/c6fd7c90a7cf5c373626e1ed23c35594a051600a) apk-tools: 2.14.4 -> 2.14.5
* [`54313e99`](https://github.com/NixOS/nixpkgs/commit/54313e993e22b302539582f992aff63be5049a06) ocamlPackages.theora: 0.4.0 -> 0.4.1
* [`4935b06f`](https://github.com/NixOS/nixpkgs/commit/4935b06f4f8bb490ab2dfe4f280eab25164894f1) ocamlPackages.mm: 0.8.5 -> 0.8.6
* [`070cc6e1`](https://github.com/NixOS/nixpkgs/commit/070cc6e1d25a98307aa3cf32106a609648a6831a) wasm-pack: 0.13.0 -> 0.13.1
* [`a002b473`](https://github.com/NixOS/nixpkgs/commit/a002b473a20430323c770cf620aa8e0bd072c153) calicoctl: 3.28.2 -> 3.29.0
* [`eb24f0d6`](https://github.com/NixOS/nixpkgs/commit/eb24f0d65dc2e49ae6af0be9af00b506c25ffd74) rqbit: 6.0.0 -> 7.0.1
* [`70ad3289`](https://github.com/NixOS/nixpkgs/commit/70ad3289543b37637a4bdd9c9a81291f3f4188c8) _389_ds_base: move to by-name
* [`41769b4f`](https://github.com/NixOS/nixpkgs/commit/41769b4f0d3d459249f8239b21fa9fce2b3c69b3) _389_ds_base: nixfmt
* [`5ac19f84`](https://github.com/NixOS/nixpkgs/commit/5ac19f8437327468c8cb92ec5749d68feb6a4c03) _389_ds_base: add passthru.updateScript
* [`a8405a6a`](https://github.com/NixOS/nixpkgs/commit/a8405a6ad54f3b54a70c2c9375e25abb6a45851e) _389_ds_base: 2.4.6 -> 3.1.1
* [`e4eab5f5`](https://github.com/NixOS/nixpkgs/commit/e4eab5f5e60a8dd3ad02d43794b7db33904b75b9) duckstation-bin: 0.1-7294 -> 0.1-7371
* [`359c9d25`](https://github.com/NixOS/nixpkgs/commit/359c9d25550b92414380d959c0cccbeafa6dab71) stevenblack-blocklist: 3.14.115 -> 3.14.127
* [`0e1d05a2`](https://github.com/NixOS/nixpkgs/commit/0e1d05a286fdeb82070ed9451bbfe3d2ac9c747e) qdrant: 1.11.5 -> 1.12.1
* [`4805c0a4`](https://github.com/NixOS/nixpkgs/commit/4805c0a4f4764f2db25029fa7a352eb2eccfa05e) argc: 1.20.1 -> 1.21.0
* [`80ea320f`](https://github.com/NixOS/nixpkgs/commit/80ea320fe72bd16d9add8a34a6b6aa3880bb9f58) nixos/swapspace: init module
* [`e4c898c8`](https://github.com/NixOS/nixpkgs/commit/e4c898c8071c5333cc283620dd14a5638a09957e) nixos/swapspace: add tests
* [`47370df2`](https://github.com/NixOS/nixpkgs/commit/47370df25cd00902720a3edc85c70da0dc85c7af) argo: 3.5.11 -> 3.5.12
* [`5e526681`](https://github.com/NixOS/nixpkgs/commit/5e526681a7dfb7e66a22e04676bc89f27df9e5e3) tpm-fido: init at 0-unstable-2024-10-30
* [`fa62a405`](https://github.com/NixOS/nixpkgs/commit/fa62a40582a0344246a71967dddccec8020331f7) gitopper: init at 0.0.16
* [`603e07da`](https://github.com/NixOS/nixpkgs/commit/603e07da4187d3a47c202e68c177491ddccf37db) minizincide: 2.8.6 -> 2.8.7
* [`34b0ac8a`](https://github.com/NixOS/nixpkgs/commit/34b0ac8ad43af06fc5c670814ce5c33a7c428c02) coroot: 1.5.9 -> 1.5.11
* [`845a8b68`](https://github.com/NixOS/nixpkgs/commit/845a8b68d13fad6b6146168aa3fd49e094d98334) wavebox: 10.129.29-2 -> 10.129.32-2
* [`b560dc5f`](https://github.com/NixOS/nixpkgs/commit/b560dc5fe43e8b9ea1a6f289fb36cf52d4273d83) linuxPackages.nvidiaPackages.legacy_535: 535.154.05 -> 535.216.01
* [`12e303d1`](https://github.com/NixOS/nixpkgs/commit/12e303d121a64b5aba71550e95191c24198d96c3) veryl: 0.13.1 -> 0.13.2
* [`f5485c40`](https://github.com/NixOS/nixpkgs/commit/f5485c406b08c757831a5a0065a904db5e17821e) suil: build documentation using sphinxygen and sphinx-lv2-theme
* [`98492c5e`](https://github.com/NixOS/nixpkgs/commit/98492c5e589e2b6cbfe0198d3df4ee409420cbe3) evcc: 0.131.3 -> 0.131.4
* [`9dd1f943`](https://github.com/NixOS/nixpkgs/commit/9dd1f943ecd198a720605724700d9c1292c8c980) nixos/nextcloud-notify_push: fix defaultText rendering
* [`f5fc59f9`](https://github.com/NixOS/nixpkgs/commit/f5fc59f9954f32a1330e0422e1e4cb489190f14b) lime3ds: 2118.2 -> 2119
* [`4442e5ac`](https://github.com/NixOS/nixpkgs/commit/4442e5ac9161ba2379297fb39bd8b56ef3855bd8) libsForQt5.accounts-qml-module: Enable qdoc docs
* [`ea158ab9`](https://github.com/NixOS/nixpkgs/commit/ea158ab99a20ba26880f375c8f0fe8e4ae8f7f85) orca-slicer: 2.1.1 -> 2.2.0
* [`eeea8d64`](https://github.com/NixOS/nixpkgs/commit/eeea8d648db2f1bf64daf3efda503c56d673fd12) lomiri.u1db-qt: Enable qdoc docs
* [`8f74b6cd`](https://github.com/NixOS/nixpkgs/commit/8f74b6cdaf783aae29e998aaba69861277712320) lomiri.lomiri-action-api: Enable qdoc docs
* [`970ee76e`](https://github.com/NixOS/nixpkgs/commit/970ee76e3f587f74d9dafb15da0b04e350e2edc4) space-station-14-launcher: 0.29.0 -> 0.29.1
* [`ac976c91`](https://github.com/NixOS/nixpkgs/commit/ac976c912dfb054039f2589fa6d3b291a323001f) jasp-desktop: add patch to fix crash when using qt 6.8
* [`907c7931`](https://github.com/NixOS/nixpkgs/commit/907c79314b6be75ca717c980c03d4d8f3f436363) nixos/mobilizon: change psql socket dir to none symlinked directory
* [`5fdcf448`](https://github.com/NixOS/nixpkgs/commit/5fdcf448eb643e3dec751cf297698c8b8d0f8d0e) aldente: 1.28.5 -> 1.28.6
* [`588e404c`](https://github.com/NixOS/nixpkgs/commit/588e404caab338505995a08d14003d243716af6e) buildkit: 0.16.0 -> 0.17.0
* [`e902bd27`](https://github.com/NixOS/nixpkgs/commit/e902bd273774a9d399f7842a63be095a6480253e) ols: 0-unstable-2024-10-12 -> 0-unstable-2024-10-27
* [`55026717`](https://github.com/NixOS/nixpkgs/commit/550267174faf001f3dce24b90de44185adeee879) python311Packages.numcodecs: order inputs & no with lib; in meta
* [`d7fb5d01`](https://github.com/NixOS/nixpkgs/commit/d7fb5d0185c012a240c2400d2713b78da55a897f) python311Packages.numcodecs: simplify DISABLE_NUMCODECS_AVX2
* [`3438b4f4`](https://github.com/NixOS/nixpkgs/commit/3438b4f44c10d277355e55ab021cba0144a5f0bc) python311Packages.numcodecs: adopt
* [`a61172f7`](https://github.com/NixOS/nixpkgs/commit/a61172f7341a39d944171b7ee1dc39e56e810f9d) python312Packages.numcodecs: 0.13.0 -> 0.13.1
* [`d04843ce`](https://github.com/NixOS/nixpkgs/commit/d04843ce6096f2128fdd996bae44b257f9f32550) lomiri.lomiri-ui-toolkit: Enable qdoc docs
* [`e0d5bd98`](https://github.com/NixOS/nixpkgs/commit/e0d5bd98ffbcead17660720baa782ceead262455) lomiri.lomiri-download-manager: Enable qdoc docs
* [`03b310e9`](https://github.com/NixOS/nixpkgs/commit/03b310e94cbcaedecc1524f2597c8c990bcf2b60) lomiri.lomiri-indicator-network: Enable qdoc docs
* [`8a5f8623`](https://github.com/NixOS/nixpkgs/commit/8a5f86237dbad261bd629c8bc391536b7194f1e5) lomiri.lomiri-content-hub: Enable qdoc docs
* [`b8c432b5`](https://github.com/NixOS/nixpkgs/commit/b8c432b54a5a219964b53763caab57378e3aabcc) libsForQt5.accounts-qml-module: nixfmt, modernise
* [`bafb3749`](https://github.com/NixOS/nixpkgs/commit/bafb37491e96a52be0f7aeaedfe97722bf55e153) libsForQt5.accounts-qml-module: Fix version
* [`95c0233e`](https://github.com/NixOS/nixpkgs/commit/95c0233ed9624a7748fa76d4ee29777e1ca0f83e) lomiri.lomiri-action-api: nixfmt, modernise
* [`ba59f61a`](https://github.com/NixOS/nixpkgs/commit/ba59f61a725a46e2d2348929b60eac263a4b6dee) lomiri.u1db-qt: Add meta.changelog
* [`5cc3c54a`](https://github.com/NixOS/nixpkgs/commit/5cc3c54a642596d2b15666fd0ccb11590448c92d) lomiri.lomiri-ui-toolkit: nixfmt, modernise
* [`4ce2e1df`](https://github.com/NixOS/nixpkgs/commit/4ce2e1df58eca6a7e0358a8efc5b0ebb4373760c) lomiri.lomiri-download-manager: nixfmt, modernise
* [`4d808176`](https://github.com/NixOS/nixpkgs/commit/4d8081767bc55754d1321d9d10b0ff2d333178c8) lomiri.lomiri-content-hub: nixfmt, modernise
* [`33940445`](https://github.com/NixOS/nixpkgs/commit/339404456dd62837886034d44340409d14f7859e) blueutil: use the new apple-sdk
* [`2fe2ceb0`](https://github.com/NixOS/nixpkgs/commit/2fe2ceb07ea6ca336e77840e2a3fdddb9038d8f3) moonlight-qt: refactor darwin support
* [`3d794b1d`](https://github.com/NixOS/nixpkgs/commit/3d794b1dfe66ec8a555361687d0c15afb4581374) gnuk: convert into a saner derivation
* [`ae010bdd`](https://github.com/NixOS/nixpkgs/commit/ae010bdd4f80a28a7467274d93dad61e2bbb726e) step-cli: 0.27.5 -> 0.28.0
* [`4e63264c`](https://github.com/NixOS/nixpkgs/commit/4e63264c5427e2e09db6f4252dd2f8d7aa5792d0) gnuk: format with nixfmt-rfc-style
* [`89b4cb72`](https://github.com/NixOS/nixpkgs/commit/89b4cb7299c6e12b83e2bf807e85eb93a9e27984) nixos/victoriametrics: harden systemd unit, add more options.
* [`ac2bd873`](https://github.com/NixOS/nixpkgs/commit/ac2bd873a34bad238808ff94f0a8592ff4780ea3) gnuk: replace configurePhase with configureFlags and sourceRoot
* [`cab0d917`](https://github.com/NixOS/nixpkgs/commit/cab0d917f430d0608e39e1f097f5f00c36232b5d) gnuk: 1.2.14 -> 2.2
* [`ec8cc3e7`](https://github.com/NixOS/nixpkgs/commit/ec8cc3e7175aa57d0edd2fb5a6e6e8cd319da183) gnuk: set as broken, use correct homepage in meta and remove nested with expression
* [`a1f55920`](https://github.com/NixOS/nixpkgs/commit/a1f559204f5fea01167a9a0bb2e9afaad8e52d1b) onedrivegui: 1.1.0 -> 1.1.1a
* [`2de6b491`](https://github.com/NixOS/nixpkgs/commit/2de6b491698033736fd9e6d10fcfb4e1c751db4d) valeronoi: 0.2.1 -> 0.2.2
* [`ab66ef85`](https://github.com/NixOS/nixpkgs/commit/ab66ef85c42229920604eda2232caf92bd944514) vultr-cli: 3.3.1 -> 3.4.0
* [`145c5d03`](https://github.com/NixOS/nixpkgs/commit/145c5d03ad22dcd887e4da49c679976972f56a55) virtualisation.vmware.guest: allow the user to override the open-vm-tools package
* [`c756281b`](https://github.com/NixOS/nixpkgs/commit/c756281b2e98b4b689997b7b94f766b546e7d03c) Add kjeremy as a maintainer
* [`515d8061`](https://github.com/NixOS/nixpkgs/commit/515d8061f0e3c6fa1086c5bb3b739c7026c884b9) python3Packages.sphinx-sitemap: 2.5.1 -> 2.6.0
* [`7eae33bc`](https://github.com/NixOS/nixpkgs/commit/7eae33bc747672057ddcc4a18bb3a49cffed2127) haskellPackages.large-hashable: unstable-2022-06-10 -> 0.1.1.0
* [`001ff866`](https://github.com/NixOS/nixpkgs/commit/001ff8665b8b08dd8e3a681c624fd8495e8b6a4b) haskellPackages.vivid: drop obsolete overrides
* [`178464a9`](https://github.com/NixOS/nixpkgs/commit/178464a927e2261a66e6ca0e1af8d8fd9515ecc2) buffer: 0.9.5 -> 0.9.7
* [`16fe7448`](https://github.com/NixOS/nixpkgs/commit/16fe74480dc826483bd346e7d67bd0e2f2e75231) scraper: 0.20.0 -> 0.21.0
* [`4b2812e4`](https://github.com/NixOS/nixpkgs/commit/4b2812e4841347341e8de94bef6897f5ba3301cc) clairvoyant: 3.1.7 -> 3.1.8
* [`305fda40`](https://github.com/NixOS/nixpkgs/commit/305fda40862b892b58e368b514fa04b64dd654a1) srm-cuarzo: 0.7.2-1 -> 0.8.0-1
* [`ef3f2487`](https://github.com/NixOS/nixpkgs/commit/ef3f248740845fb118392d36a92326aa34653db7) haskellPackages.Cabal_*: use process 1.6.25.0 for GHC < 9.2.5
* [`2296b478`](https://github.com/NixOS/nixpkgs/commit/2296b47832546627d65012a5a5a8db479b37137e) kando: use apple-sdk_11
* [`dc043f86`](https://github.com/NixOS/nixpkgs/commit/dc043f86c77f1fa3ad81494316f1e95997192829) zizmor: init at 0.1.4
* [`83de7ef5`](https://github.com/NixOS/nixpkgs/commit/83de7ef5ef62151f9650cd290106a8a8d3cf958f) calamares: 3.3.9 -> 3.3.10
* [`7a69a74c`](https://github.com/NixOS/nixpkgs/commit/7a69a74c92c3273601272d7e57f5362fc46c79fe) calamares-nixos-extensions: 3.3.18 -> 3.3.19
* [`c7af6b76`](https://github.com/NixOS/nixpkgs/commit/c7af6b765b7bf822d288096f9824af9ca0f02396) ride: use apple-sdk_11
* [`f0a0f60e`](https://github.com/NixOS/nixpkgs/commit/f0a0f60e2597140c6933fb150925004d4b103237) en-croissant: use apple-sdk_11
* [`4fbd79e5`](https://github.com/NixOS/nixpkgs/commit/4fbd79e56f346a8848ba618017d14c875c8c7994) gcs: use apple-sdk_11, use lib.optionals for linux deps
* [`d4ca0a47`](https://github.com/NixOS/nixpkgs/commit/d4ca0a4783d13c851ce62852a83c08b142bca50d) pyxel: remove stuff already included by apple-sdk
* [`f09703e0`](https://github.com/NixOS/nixpkgs/commit/f09703e02b453e1ca80fb951e685a2691c44197d) pls: remove stuff already included by apple-sdk
* [`3d7142eb`](https://github.com/NixOS/nixpkgs/commit/3d7142eb1fc7af467583d9ae27832de03e85f4c4) hieroglyphic: remove stuff already included by apple-sdk
* [`fb26e7f3`](https://github.com/NixOS/nixpkgs/commit/fb26e7f3cb811bf9a4851bea64db8c4bee1efda5) mlx42: remove stuff already included by apple-sdk
* [`fcec676c`](https://github.com/NixOS/nixpkgs/commit/fcec676cedaed050c049cb02211ab7c1c87fd984) comet-gog: remove stuff already included by apple-sdk
* [`ca448b27`](https://github.com/NixOS/nixpkgs/commit/ca448b27882edf1095df91551ab45218e251d50c) thunderbird: add -latest and -esr flavors
* [`8daeea96`](https://github.com/NixOS/nixpkgs/commit/8daeea96b1eda5902d192df515bec94af43db54d) firefox-beta-bin-unwrapped: 133.0b1 -> 133.0b2
* [`a445fb0f`](https://github.com/NixOS/nixpkgs/commit/a445fb0fc2f64d79ede52afba09260349d3113d5) _86Box: update to apple-sdk pattern
* [`799fd411`](https://github.com/NixOS/nixpkgs/commit/799fd4111c48a55718ec679bd28dcd4dc1717600) augustus: update to apple-sdk pattern
* [`20851477`](https://github.com/NixOS/nixpkgs/commit/20851477dc079363e5ee86af048226d3bfbdc6e3) mir.passthru.updateScript: Look at tags instead of releases
* [`aa4e7ee3`](https://github.com/NixOS/nixpkgs/commit/aa4e7ee3ba9486f6c915cb0d596873c29948ac8c) mir: 2.18.2 -> 2.18.3
* [`96424cbf`](https://github.com/NixOS/nixpkgs/commit/96424cbf209464282ee554163d5856ee25539576) corsix-th: update to apple-sdk pattern
* [`3ff8deb4`](https://github.com/NixOS/nixpkgs/commit/3ff8deb4c15c6ab74f814cbc87e0d8121178915f) julius: update to apple-sdk pattern
* [`ea3ce94e`](https://github.com/NixOS/nixpkgs/commit/ea3ce94e3aa2f46a85c0151d0902abc8774cda48) awscli2: 2.18.15 -> 2.19.0
* [`b6cf7b27`](https://github.com/NixOS/nixpkgs/commit/b6cf7b27b7c097620339c72971d43f99adfd6f4e) qogir-kde: 0-unstable-2024-09-21 -> 0-unstable-2024-10-30
* [`f3f4455d`](https://github.com/NixOS/nixpkgs/commit/f3f4455df939ff3075555a033387b3524314cea6) gnomeExtensions: auto-update
* [`e2f176cf`](https://github.com/NixOS/nixpkgs/commit/e2f176cf4a4f2badcc5bb1b226f87f2fd011d100) gnomeExtensions.gsconnect: 57 -> 58
* [`0924dfae`](https://github.com/NixOS/nixpkgs/commit/0924dfae805a4f18646a72b20842cedfe472c856) nixos/home-assistant: escape yaml functions in lovelace config
* [`2f300bf6`](https://github.com/NixOS/nixpkgs/commit/2f300bf6e16270def6ded6e19f174e0a26ee4050) apacheHttpdPackages.mod_wsgi3: 5.0.0 -> 5.0.1
* [`6117e4b0`](https://github.com/NixOS/nixpkgs/commit/6117e4b0a4ab0a0defab6c219441156244fe0b8f) astc-encoder: 4.8.0 -> 5.0.0
* [`88931243`](https://github.com/NixOS/nixpkgs/commit/88931243df3a42273ec865104841e7f4f5ba4c29) antimicrox: 3.4.1 -> 3.5.0
* [`67ba2ae7`](https://github.com/NixOS/nixpkgs/commit/67ba2ae7457d86f2af909088936b9ee40123aaf5) shadps4: 0.3.0-unstable-2024-10-14 -> 0.4.0
* [`ae24a867`](https://github.com/NixOS/nixpkgs/commit/ae24a867db9d45346db3a0249e71fc12d0becf0e) ejabberd: add updateScript
* [`0d9742d6`](https://github.com/NixOS/nixpkgs/commit/0d9742d65773b7653d6ab7ce3bc6754651431f7f) ejabberd: 24.07 -> 24.10
* [`c2a1eed1`](https://github.com/NixOS/nixpkgs/commit/c2a1eed128dfa9e0c44ad5926b6035a13d473dd8) pacemaker: 2.1.8 -> 2.1.9
* [`839921d8`](https://github.com/NixOS/nixpkgs/commit/839921d80508e30fac0da15a803ade758a0595fa) zeekscript: mark as broken
* [`209ba0bd`](https://github.com/NixOS/nixpkgs/commit/209ba0bd185c50735adc73f5ff0428eb4a451203) kube-score: 1.18.0 -> 1.19.0
* [`78d93a94`](https://github.com/NixOS/nixpkgs/commit/78d93a94cbc7414de609bbdf9c5176eb798c57c8) crun: 1.18 -> 1.18.2
* [`e951dd2e`](https://github.com/NixOS/nixpkgs/commit/e951dd2eb00d34996b63d7d8094fd969d231b498) alienarena: 7.71.6 -> 7.71.7
* [`04136354`](https://github.com/NixOS/nixpkgs/commit/04136354eed10cdbaef13372c0e1177b6e507c89) shipwright: update to apple-sdk pattern
* [`f6d0c1a5`](https://github.com/NixOS/nixpkgs/commit/f6d0c1a59c3700d58aecf5f99cda7f2c0cfd4d16) mommy: 1.5.0 -> 1.5.1
* [`a36a5d71`](https://github.com/NixOS/nixpkgs/commit/a36a5d717e182d80a16b5756c14dca26227ce9d6) hayagriva: 0.6.0 -> 0.8.0
* [`82da1548`](https://github.com/NixOS/nixpkgs/commit/82da15486006dbd437bc215e8b6acd1011b8863c) fcitx5: add meta.mainProgram
* [`7f5fafc9`](https://github.com/NixOS/nixpkgs/commit/7f5fafc9009446a633573f48b73fdf10ff21f771) haskellPackages.http-semantics: restrict to < 0.3.0
* [`ae929641`](https://github.com/NixOS/nixpkgs/commit/ae929641efde1f5826b9c202a5686bc18df94978) haskell.packages.ghc9101.warp: 3.4.2 -> 3.4.3
* [`fbdd1192`](https://github.com/NixOS/nixpkgs/commit/fbdd1192a8f08717a8dc03a90c15d0b906896edd) lldap: 0.5.1-unstable-2024-08-09 -> 0.5.1-unstable-2024-10-30
* [`7261decc`](https://github.com/NixOS/nixpkgs/commit/7261decc5929425d51287c02f1967b89cad0c9df) stack: provide requested static-bytes >= 0.1.1
* [`a721517d`](https://github.com/NixOS/nixpkgs/commit/a721517d5e05f0ea87ea1b71eb31269158584867) top-level/release-haskell.nix: remove ineffectual Cabal-syntax jobs
* [`71b09ef3`](https://github.com/NixOS/nixpkgs/commit/71b09ef3316bc0423a906d3960fb5454a753d0ab) haskellPackages.Cabal_3_14_0_0: build against matching Cabal-syntax
* [`c409770d`](https://github.com/NixOS/nixpkgs/commit/c409770da864bb27b263845e2740aea753444651) haskell.compiler.ghcHEAD: 9.11.20240423 -> 9.13.20241031
* [`b3727e43`](https://github.com/NixOS/nixpkgs/commit/b3727e4302bc9e34a266665a5a8155951265bdd9) buf: 1.45.0 -> 1.46.0
* [`30bae674`](https://github.com/NixOS/nixpkgs/commit/30bae674b0e0c56c7bdc65a45a20313ed228d621) haskell.packages.*.Cabal_3_1*: never supply non corepkg process
* [`c6f9db47`](https://github.com/NixOS/nixpkgs/commit/c6f9db47340726f296050a4c492e2896c9bf6915) fish-lsp: init at 1.0.8-1
* [`51489400`](https://github.com/NixOS/nixpkgs/commit/51489400b5803054b717632896b278ac4110b4e0) checkstyle: 10.18.2 -> 10.20.0
* [`af56ed7d`](https://github.com/NixOS/nixpkgs/commit/af56ed7d7dc6da0a19a6fe74bc27f98430ce6c4a) epiphany: 47.1 → 47.2
* [`476c3e8a`](https://github.com/NixOS/nixpkgs/commit/476c3e8a90c197525bd4b0567f70c9f66de8d652) evolution: 3.54.0 → 3.54.1
* [`3b6a1ea1`](https://github.com/NixOS/nixpkgs/commit/3b6a1ea1d4abdffad8735b8274c1fa91d1e2527e) evolution-data-server: 3.54.0 → 3.54.1
* [`47e37a28`](https://github.com/NixOS/nixpkgs/commit/47e37a285a9fced10dbdf67db8c771ffacfa86b8) evolution-ews: 3.54.0 → 3.54.1
* [`e81d0169`](https://github.com/NixOS/nixpkgs/commit/e81d01698ff8ccaed9c2df67bb75b6c51294cc7f) angular-language-server: init at 18.2.0
* [`633b86fa`](https://github.com/NixOS/nixpkgs/commit/633b86fab657dcd4715a1b08be9268a826cbe8d0) openvdb: 11.0.0 -> 12.0.0
* [`d9cd17de`](https://github.com/NixOS/nixpkgs/commit/d9cd17de1a3b6194aef4eada2ff5145ddab58479) kdePackages.pulseaudio-qt: 1.6.0 -> 1.6.1
* [`4769a34d`](https://github.com/NixOS/nixpkgs/commit/4769a34dacd2c357a80856cd62d3184dd40d75ae) kdePackages.oxygen-icons: 6.0.0 -> 6.1.0
* [`0b63579b`](https://github.com/NixOS/nixpkgs/commit/0b63579b5384487d204b963f840f2a5a8514e074) maintainers: add istudyatuni
* [`4e0dbd3f`](https://github.com/NixOS/nixpkgs/commit/4e0dbd3f396aba5f980aea5d13c2b4f45a11441e) gruvbox-kvantum: init at 1.1
* [`d2b766c1`](https://github.com/NixOS/nixpkgs/commit/d2b766c1b10f3fae7f1aacf63ef3eb9ccfcaddbe) haskellPackages.snap: fix tests on darwin with sandbox
* [`cc000338`](https://github.com/NixOS/nixpkgs/commit/cc000338e6cde364faf0651b8c262ab66b1f6104) conan: 2.5.0 -> 2.9.1
* [`340c988c`](https://github.com/NixOS/nixpkgs/commit/340c988c24a0df481e8fb48e9e6900303b1bde8a) fractal: 8 -> 9
* [`42412a0d`](https://github.com/NixOS/nixpkgs/commit/42412a0dba7c06b8da215fbd8b657b2f47ad997d) jellyfin-web: switch to apple-sdk_11
* [`a851ff9f`](https://github.com/NixOS/nixpkgs/commit/a851ff9f0f8acc1c6705b533f07692cbb8e83d16) forgejo-runner: 3.5.1 -> 4.0.1
* [`cd86b058`](https://github.com/NixOS/nixpkgs/commit/cd86b058199342194fb994366a44daea4f69786a) gh-contribs: init at 0.9.0
* [`e1385bd5`](https://github.com/NixOS/nixpkgs/commit/e1385bd56eecf4db00aa7625fc045c21b1f01cb6) cosmic-wallpapers: 1.0.0-alpha.2 -> 1.0.0-alpha.3
* [`68d26617`](https://github.com/NixOS/nixpkgs/commit/68d2661782302af165a001ea077b48baa21b0418) lua-language-server: 3.11.1 -> 3.12.0
* [`18331b24`](https://github.com/NixOS/nixpkgs/commit/18331b243985af35bad029a88ea012fbf42e1588) akkoma-frontends: use finalAttrs pattern
* [`d4e2d6e0`](https://github.com/NixOS/nixpkgs/commit/d4e2d6e00c84682296396966a654f8deb01aa4f2) maintainers: add thtrf
* [`c952a4bf`](https://github.com/NixOS/nixpkgs/commit/c952a4bfdbecdc6f82d4352f86ba7221358c8567) vscode-extensions.sainnhe.gruvbox-material: init at 6.5.2
* [`4eceb5ba`](https://github.com/NixOS/nixpkgs/commit/4eceb5ba2fefb816cc6e03970a28d07d646df7e6) maintainers: add deadbaed
* [`b52119ac`](https://github.com/NixOS/nixpkgs/commit/b52119ac185a4515d62effc93923cd98c65ebe53) proto: 0.41.3 -> 0.42.0
* [`03a99cd3`](https://github.com/NixOS/nixpkgs/commit/03a99cd38cbd0d5446b2218ba0214e5621fd640c) maintainers: add erooke
* [`aef583fa`](https://github.com/NixOS/nixpkgs/commit/aef583fa260ca9a8b043ef321b317c5172a04f29) python3Packages.pytask: init at 0.5.1
* [`12dea281`](https://github.com/NixOS/nixpkgs/commit/12dea28165ea4bcb7a31689c3675887d612229c8) nixos/snipe-it: fix secure flag for cookies
* [`c12e8152`](https://github.com/NixOS/nixpkgs/commit/c12e8152ea2a8677d3436916a1b575b3526497cb) pdfsam-basic: 5.2.8 -> 5.2.9
* [`7d797d8b`](https://github.com/NixOS/nixpkgs/commit/7d797d8b678b4437132051492f42dda9f85b9ff2) python312Packages.wtforms-sqlalchemy: init at 0.4.1
* [`3442e32b`](https://github.com/NixOS/nixpkgs/commit/3442e32b1be95228e4606125062446e530c76b0a) mediagoblin: init at 0.14.0
* [`ff9dd57d`](https://github.com/NixOS/nixpkgs/commit/ff9dd57d3dda785fbe842d3d324df2a44a54d9e8) nixos/mediagoblin: init
* [`b9e3b9db`](https://github.com/NixOS/nixpkgs/commit/b9e3b9dbb22b94bfc880ab5f6bcca69f9255d8ce) ssh-tools: 1.8-unstable-2024-03-18 -> 1.9
* [`445de757`](https://github.com/NixOS/nixpkgs/commit/445de7572ca23929176cf673bc327adf750ac148) localstack: meta.mainProgram name
* [`3e403e12`](https://github.com/NixOS/nixpkgs/commit/3e403e1256f0e6e1755e7faa885d33b4e183846d) maintainers: add youwen5
* [`fc430914`](https://github.com/NixOS/nixpkgs/commit/fc43091447f91f867badfcb3f82663817712dda1) manga-tui: add youwen5 as maintainer
* [`60d18ed7`](https://github.com/NixOS/nixpkgs/commit/60d18ed756989537dfcc95f203bfe4e4ed6cbb06) python312Packages.xarray: 2024.09.0 -> 2024.10.0
* [`7a35c1a0`](https://github.com/NixOS/nixpkgs/commit/7a35c1a09d7ce09cc0a893c29757778fccc116f3) circt: move to pkgs/by-name
* [`28bd698b`](https://github.com/NixOS/nixpkgs/commit/28bd698b948953029100cd7bf33df44fb71dbe7b) circt: format files
* [`d24b9111`](https://github.com/NixOS/nixpkgs/commit/d24b911161eee648457643546beaa1e1cbf74e0a) circt: fix build failure on darwin platforms
* [`e252ddbb`](https://github.com/NixOS/nixpkgs/commit/e252ddbbe812e813da1a76049ba23490285629e3) vte: 0.78.0 → 0.78.1
* [`70c69b19`](https://github.com/NixOS/nixpkgs/commit/70c69b19f8df471706bb8c6e0581a0865c835054) gnome-terminal: 3.52.2 → 3.54.1
* [`8e6c10ce`](https://github.com/NixOS/nixpkgs/commit/8e6c10ce8b44091b001b4e33785fa410c58e1ae0) libdex: 0.8.0 → 0.8.1
* [`c1713b8a`](https://github.com/NixOS/nixpkgs/commit/c1713b8aeb41462e80d2fdb71c55ba207c87c53f) libpanel: 1.8.0 → 1.8.1
* [`66ae8b7d`](https://github.com/NixOS/nixpkgs/commit/66ae8b7d52f5ba4bd3e07ca458e161f99a7a741b) gnome-builder: 47.1 → 47.2
* [`17618f45`](https://github.com/NixOS/nixpkgs/commit/17618f4547ac26d8c668f6e309702669082b8f71) orca: 47.0 → 47.1
* [`f908b35d`](https://github.com/NixOS/nixpkgs/commit/f908b35d9e873f26fc3702faedf5266852c2f7a7) yi: Fix formatting
* [`11159f89`](https://github.com/NixOS/nixpkgs/commit/11159f893f256e22a15f266fc4a365c2b1d0e0fb) postmoogle: 0.9.21 -> 0.9.24
* [`cfc3ac4d`](https://github.com/NixOS/nixpkgs/commit/cfc3ac4d4e1f91605bd990ab6a3fa2581450303a) azure-cli.extensions-tool: commit removals last
* [`b934fc9e`](https://github.com/NixOS/nixpkgs/commit/b934fc9ec1505fff14aae8c08dfa391ee899c85c) azure-cli-extensions.adp: remove
* [`6d15c9df`](https://github.com/NixOS/nixpkgs/commit/6d15c9df9550a7a6f033119eb3e10efaea82c7f9) azure-cli-extensions.connection-monitor-preview: remove
* [`9d4aedff`](https://github.com/NixOS/nixpkgs/commit/9d4aedff0167973f672cb1d7bb1f5461cd2a9504) azure-cli-extensions.vm-repair: re-init at 2.0.0
* [`5139634e`](https://github.com/NixOS/nixpkgs/commit/5139634ead71d83baa899c2f04426e8ddc9e1543) azure-cli.extensions-tool: workaround for commit authorship bug in gitpython
* [`c63210f6`](https://github.com/NixOS/nixpkgs/commit/c63210f6e4d7d3a59eadf62f5a4d76fc01fc2652) azure-cli: add extensions-tool to tests
* [`3c1249c5`](https://github.com/NixOS/nixpkgs/commit/3c1249c5d3490b2886ed45db6c8d3ae9ee2bfa93) azure-cli.extensions-tool: add final newline when writing json
* [`69c04ee3`](https://github.com/NixOS/nixpkgs/commit/69c04ee31869b54e1b76defc7847e5e8f4c7e074) azure-cli.extensions-tool: fix typo in commit message
* [`28a8b311`](https://github.com/NixOS/nixpkgs/commit/28a8b311d407117ec5eee15c97a0ef50fd90e315) azure-cli-extensions.neon: init at 1.0.0b1
* [`8869d9b7`](https://github.com/NixOS/nixpkgs/commit/8869d9b72a5daddc8cb894bba880976e85a6ab57) azure-cli-extensions.mcc: init at 1.0.0b1
* [`2036403f`](https://github.com/NixOS/nixpkgs/commit/2036403fdb8b5928825653dc066669d7850c1a3c) azure-cli-extensions.arcgateway: init at 1.0.0b1
* [`c0eb4b67`](https://github.com/NixOS/nixpkgs/commit/c0eb4b679409ca44b9a38f3ebe77adcb05511f8f) azure-cli-extensions.deidservice: init at 1.0.0b1
* [`e2d832ee`](https://github.com/NixOS/nixpkgs/commit/e2d832ee427ee59d848aa4293c9308af25ce32de) azure-cli-extensions.quantum: init at 1.0.0b4
* [`d68e79cd`](https://github.com/NixOS/nixpkgs/commit/d68e79cd8f07d083cd68c643b8b2df0e300362b2) azure-cli-extensions.express-route-cross-connection: 0.1.1 -> 1.0.0
* [`6eca72a9`](https://github.com/NixOS/nixpkgs/commit/6eca72a9643bab6f2fe370fb5447df0c3aa19c12) azure-cli-extensions.scvmm: 1.1.1 -> 1.1.2
* [`76de7c0b`](https://github.com/NixOS/nixpkgs/commit/76de7c0b23277be5da2111122360b368914f1658) azure-cli-extensions.maintenance: 1.6.0 -> 1.7.0b1
* [`ca98256a`](https://github.com/NixOS/nixpkgs/commit/ca98256acbc6332ccb89372d7c99a00313668eae) azure-cli-extensions.apic-extension: 1.0.0b5 -> 1.1.0
* [`01a93ea8`](https://github.com/NixOS/nixpkgs/commit/01a93ea8faea26c2f04b8a2f3afdbc4259e4966c) azure-cli-extensions.stack-hci-vm: 1.3.0 -> 1.4.3
* [`7b51dd7d`](https://github.com/NixOS/nixpkgs/commit/7b51dd7de86ad80c093ce0e54d8d892af8b3b42d) azure-cli-extensions.multicloud-connector: 1.0.0b1 -> 1.0.0
* [`be2e4972`](https://github.com/NixOS/nixpkgs/commit/be2e4972bb558eab2a3f8c107563ad3037742ebc) azure-cli-extensions.redisenterprise: 1.2.0 -> 1.2.1b1
* [`ca921dea`](https://github.com/NixOS/nixpkgs/commit/ca921dea99bcde1cf12a340fbb48840fcbff1d47) azure-cli-extensions.connectedmachine: 1.0.0b2 -> 1.0.0
* [`834bd5ab`](https://github.com/NixOS/nixpkgs/commit/834bd5aba56cfb33275bb4ce92ace46bdb7043ed) azure-cli-extensions.standbypool: 1.0.0b1 -> 1.0.0
* [`c2fa0a08`](https://github.com/NixOS/nixpkgs/commit/c2fa0a082f978815febe12ca2271250e87951fcd) azure-cli-extensions.dataprotection: 1.5.3 -> 1.5.4
* [`fefd810c`](https://github.com/NixOS/nixpkgs/commit/fefd810ce1c55bf49207aa9691ceccb89a6da427) azure-cli-extensions.managementpartner: 0.1.3 -> 1.0.0
* [`1c8b1b36`](https://github.com/NixOS/nixpkgs/commit/1c8b1b3663381bf3746161eb920f5b661497ac48) azure-cli-extensions.cosmosdb-preview: 1.0.1 -> 1.1.0b1
* [`298f842a`](https://github.com/NixOS/nixpkgs/commit/298f842a8aa22faeb33ddc78ed23cb466c6069a2) azure-cli-extensions.mdp: 1.0.0b2 -> 1.0.0
* [`654e48a8`](https://github.com/NixOS/nixpkgs/commit/654e48a8043c1c970f6340d37fb954a25bbf96a4) azure-cli-extensions.new-relic: 1.0.0b1 -> 1.0.0
* [`751ee7a2`](https://github.com/NixOS/nixpkgs/commit/751ee7a2b97ce7fa9d73b4c40fba18e1b0b1231c) azure-cli-extensions.amg: 2.4.0 -> 2.5.0
* [`b078ecaa`](https://github.com/NixOS/nixpkgs/commit/b078ecaab2f16efb555235faabc0aa1fb6dd7e86) azure-cli-extensions.networkcloud: 2.0.0b4 -> 2.0.0b5
* [`bc06a2ab`](https://github.com/NixOS/nixpkgs/commit/bc06a2ab87e0fcef57f593c2c78d878efc6f3670) azure-cli-extensions.elastic-san: 1.0.0b2 -> 1.2.0b1
* [`45a8237a`](https://github.com/NixOS/nixpkgs/commit/45a8237acb5971465d2179d0ad3b5e151b82aa24) azure-cli-extensions.dynatrace: 0.1.0 -> 1.1.0
* [`488c3b55`](https://github.com/NixOS/nixpkgs/commit/488c3b55556df8a5c5c160cd84a3c51b1231b640) azure-cli-extensions.subscription: 0.1.5 -> 1.0.0b1
* [`5f8e2186`](https://github.com/NixOS/nixpkgs/commit/5f8e218696bec6f4e608c7832fd2f99e6c847e77) azure-cli-extensions.spring: 1.25.1 -> 1.26.0
* [`e5f0c98e`](https://github.com/NixOS/nixpkgs/commit/e5f0c98ec1a48b7788348d1374afea80094e4ec6) azure-cli-extensions.aks-preview: 9.0.0b6 -> 9.0.0b8
* [`33830c6e`](https://github.com/NixOS/nixpkgs/commit/33830c6eadfd4cb2735f4a8c59bce4b3def1b0da) azure-cli-extensions.traffic-collector: 0.1.3 -> 1.0.0
* [`c7a8bd05`](https://github.com/NixOS/nixpkgs/commit/c7a8bd05d4351c346d54ae9393267e484920c2c5) azure-cli-extensions.bastion: 1.3.0 -> 1.3.1
* [`b536aa3e`](https://github.com/NixOS/nixpkgs/commit/b536aa3e96e5b324d35750828bd1b5db149a9c21) azure-cli-extensions.support: 2.0.0 -> 2.0.1
* [`4cbd5a1a`](https://github.com/NixOS/nixpkgs/commit/4cbd5a1ab7fe9354f3519e411a90f10c43a731c7) azure-cli-extensions.k8s-extension: 1.6.1 -> 1.6.2
* [`d55d16b9`](https://github.com/NixOS/nixpkgs/commit/d55d16b96d71d7f513faf7e87f064e6003c4acee) azure-cli-extensions.monitor-pipeline-group: 1.0.0b1 -> 1.0.0b2
* [`2fb100c0`](https://github.com/NixOS/nixpkgs/commit/2fb100c0b33e9e968b389a2869f611d3bcc6cf0d) azure-cli-extensions.oracle-database: 1.0.0b1 -> 1.0.0
* [`57f60e97`](https://github.com/NixOS/nixpkgs/commit/57f60e978be7a341b1ef921571d5a04c49f470b5) python312Packages.plugwise: 1.4.3 -> 1.5.0
* [`98226361`](https://github.com/NixOS/nixpkgs/commit/9822636119106f24287fefdb992cbced4cec7076) python3.pkgs.pygmt: fix build by replacing invalid call to `env.get`
* [`9c9b745e`](https://github.com/NixOS/nixpkgs/commit/9c9b745ed712383c4eddebfa05ab4ea9c4744bc2) python3.pkgs.duckdb-engine: 0.13.2 -> 0.13.4
* [`e7998d1f`](https://github.com/NixOS/nixpkgs/commit/e7998d1f1f6bb91386e6fa95cac0d13304b48e6e) python3.pkgs.jupysql: disable broken tests due to duckdb>=1.1.0
* [`7abbb28c`](https://github.com/NixOS/nixpkgs/commit/7abbb28c59b9b9df44b60e8a28c784a87cb273d1) whitesur-kde: 2022-05-01-unstable-2024-09-26 -> 2022-05-01-unstable-2024-11-01
* [`682d4d76`](https://github.com/NixOS/nixpkgs/commit/682d4d76aa8c7b2894c10f25fc6502fd4ab08583) containerlab: 0.58.0 -> 0.59.0
* [`b6fdcfcb`](https://github.com/NixOS/nixpkgs/commit/b6fdcfcb59334b0cbca57e01db3b2f7a76514203) opentelemetry-collector-builder: 0.101.0 -> 0.112.0
* [`47d3c21a`](https://github.com/NixOS/nixpkgs/commit/47d3c21a3205e29db781ce56dd29ff515e7401f3) arc-browser: 1.66.0-55166 -> 1.67.0-55463
* [`fed8a828`](https://github.com/NixOS/nixpkgs/commit/fed8a82862ee5397147c4493f7e6259f28ecaaae) python312Packages.west: 1.2.0 -> 1.3.0
* [`a41f2a9b`](https://github.com/NixOS/nixpkgs/commit/a41f2a9ba2bf2d8e33c9da919b8a31933de342ed) goku: format with `nixfmt-rfc-style`
* [`00baf600`](https://github.com/NixOS/nixpkgs/commit/00baf6001ca54c985f17288383fccca957fcd5b0) goku: use `finalAttrs` pattern
* [`855ce12c`](https://github.com/NixOS/nixpkgs/commit/855ce12c2a9f08307010f3f66deadf37101e0de6) goku: remove `with lib;` from `meta`
* [`ca41496d`](https://github.com/NixOS/nixpkgs/commit/ca41496d7e0563ef8e530b80b99323bd85795aa4) python312Packages.west: switch to pypa builder
* [`2ba3e897`](https://github.com/NixOS/nixpkgs/commit/2ba3e897135ae2fdb16ec37972ad3ea80ad73fe8) goku: add `passthru.updateScript`
* [`027352dc`](https://github.com/NixOS/nixpkgs/commit/027352dc05195333ab8319a0b7a5ff133722609c) goku: 0.6.0 -> 0.7.2
* [`7d40d31a`](https://github.com/NixOS/nixpkgs/commit/7d40d31ade82071440671121fcf31adf50517b8f) rapidjson: move to by-name, reformat
* [`2490a405`](https://github.com/NixOS/nixpkgs/commit/2490a405c2edfbb3b8b57124710403728c93f584) goku: `stdenv` -> `stdenvNoCC`
* [`e68e39d9`](https://github.com/NixOS/nixpkgs/commit/e68e39d98812c16625326f8acb077ae3ec7c803a) goku: refactor `installPhase`
* [`c6570594`](https://github.com/NixOS/nixpkgs/commit/c65705940af72d626bb625732630aac1649552cd) postgresql: use team
* [`184cda2b`](https://github.com/NixOS/nixpkgs/commit/184cda2b9420ac04e2e4c7bf80c80bf900f8b50f) postgresql: remove danbst from maintainer list
* [`68944efe`](https://github.com/NixOS/nixpkgs/commit/68944efe43235009b6791f7c450c76b637c7a745) symengine: 0.12.0 -> 0.13.0
* [`79770473`](https://github.com/NixOS/nixpkgs/commit/79770473911a4c8874d80494934b4f3093897dfd) python312Packages.symengine: drop upstreamed patch
* [`21a4b4cd`](https://github.com/NixOS/nixpkgs/commit/21a4b4cddca798576dce4ea61eec985308df762b) whatsie: 4.16.2 -> 4.16.3
* [`1a774a95`](https://github.com/NixOS/nixpkgs/commit/1a774a95d219b2c42af4d4731da27cf4dfb8f99e) python312Packages.wtforms: 3.1.2 -> 3.2.1
* [`3b8c814f`](https://github.com/NixOS/nixpkgs/commit/3b8c814fdc9a6054b400aa1262f1e18584fe8229) buildbot: fix setting `package` to a drv from a different nixpkgs
* [`c0aaeb7f`](https://github.com/NixOS/nixpkgs/commit/c0aaeb7ff3e0a707e4fd966c1c121cb8f4c6f97b) nixos/release{,-combined}: drop the VirtualBox OVA
* [`8b2577c7`](https://github.com/NixOS/nixpkgs/commit/8b2577c7d5ad9ba71782110ea7e72e757825f16e) nixos/tools: Make the tools derivations overridable
* [`81db8787`](https://github.com/NixOS/nixpkgs/commit/81db8787ae21fa0cfa53a826afd9327267a55e3a) atlauncher: 3.4.37.3 -> 3.4.37.4
* [`7e8a5d5e`](https://github.com/NixOS/nixpkgs/commit/7e8a5d5e08fc2db9c6ae7087c7ae5e0de2309089) ArchiSteamFarm: 6.0.7.5 -> 6.0.8.7
* [`45d7127c`](https://github.com/NixOS/nixpkgs/commit/45d7127c77df7e6fbb61939dc76f466c66c6700a) mesonlsp: 4.3.5 -> 4.3.7
* [`12caeb35`](https://github.com/NixOS/nixpkgs/commit/12caeb3596122765aa083c1c40ce594dae15de42) openttd-jgrpp: Set meta.mainProgram
* [`3ed37b77`](https://github.com/NixOS/nixpkgs/commit/3ed37b77a5917beac417f49f7e72ec55c9c96fb9) gui-for-singbox: init at 1.8.9
* [`f321425b`](https://github.com/NixOS/nixpkgs/commit/f321425bf9e68e3d22672c96e1d2645dbe68361c) kazumi: init at 1.4.1
* [`12ba522d`](https://github.com/NixOS/nixpkgs/commit/12ba522dfdedde6dc36282ca22d15ac4e1b15649) nixos/docker: move imports
* [`339bd97d`](https://github.com/NixOS/nixpkgs/commit/339bd97d09426682713de53ccb8de70ae2c5698d) python312Packages.xarray-datatree: remove
* [`b8afe11d`](https://github.com/NixOS/nixpkgs/commit/b8afe11d836703c8d4fe91474baea1d7f4792b15) trippy: generate shell completions
* [`17c51d69`](https://github.com/NixOS/nixpkgs/commit/17c51d69065ab8fc438e23b049ccfa968eb70c9a) reckon: add missing runtime dependency
* [`0e3338f1`](https://github.com/NixOS/nixpkgs/commit/0e3338f16f0abfd0d4c0b4221fb89722bb18a2dc) python312Packages.zarr: modernize
* [`6f9d95f6`](https://github.com/NixOS/nixpkgs/commit/6f9d95f616e8b69c0baa43a1e539ff4e7d4cdc2d) hydrus: 591 -> 595
* [`b47334c4`](https://github.com/NixOS/nixpkgs/commit/b47334c435f79b303e2f474c6de73da20b48bf9e) berglas: fix version test
* [`18a1033f`](https://github.com/NixOS/nixpkgs/commit/18a1033fc8fa4f4905c7807d178e50135b8b3c99) python312Packages.humanize: drop support for Python 3.8
* [`b8142912`](https://github.com/NixOS/nixpkgs/commit/b814291287e1d561306d0da6d550e8022c1f3cdb) youtube-music: 3.5.1 -> 3.6.2
* [`5407a105`](https://github.com/NixOS/nixpkgs/commit/5407a105c84268382dbdf76f020ca9be1d4f9b6a) shell.nix: Support nix-shell -A
* [`ef615a42`](https://github.com/NixOS/nixpkgs/commit/ef615a42b013638e25143b0f731186f5f8c0a618) godot_4: add godot_4-mono
* [`f73d108d`](https://github.com/NixOS/nixpkgs/commit/f73d108d2ead48284c1677a24c1d8a85d9299ca8) godot_4: add corngood as maintainer
* [`ca644d38`](https://github.com/NixOS/nixpkgs/commit/ca644d386a24e551ec506e1de5efcada3010f042) clerk: 4.0.5-unstable-2023-10-07 -> 0-unstable-2024-02-20
* [`102ce717`](https://github.com/NixOS/nixpkgs/commit/102ce7177c375e74c1c064c844fcf3c5a559ec85) obs-studio-plugins.obs-move-transition: 3.1.0 -> 3.1.1
* [`a9255964`](https://github.com/NixOS/nixpkgs/commit/a9255964224afc416cbfcff584403b06553cfefc) python312Packages.sipyco: 1.4 -> 1.8
* [`98252b90`](https://github.com/NixOS/nixpkgs/commit/98252b90ddf7a4463aa3ba071c6cbd8fe9d46443) python312Packages.sipyco: switch to pypa builder
* [`5edbe2f6`](https://github.com/NixOS/nixpkgs/commit/5edbe2f6da2f6fef64eb1d93f1de056eb8ae5e3a) python312Packages.sipyco: fix darwin tests
* [`7cb3d249`](https://github.com/NixOS/nixpkgs/commit/7cb3d249b3cee3b2b8d15c700c2d686442fbbaa4) python312Packages.repocheck: 2015-08-05 -> 1.0.0
* [`be9227af`](https://github.com/NixOS/nixpkgs/commit/be9227afa70018684fd7f7ba88341c676b76b038) repocheck: move from python3Packages and refactor
* [`f7db0706`](https://github.com/NixOS/nixpkgs/commit/f7db07068e77b8c6fe1094b11fa31d8d5880105d) python312Packages.pydsdl: 1.18.0 -> 1.22.0
* [`e0d5144a`](https://github.com/NixOS/nixpkgs/commit/e0d5144abc203c7b17925910f81c7c8d354bb23e) python312Packages.pydsdl: refactor
* [`c0162158`](https://github.com/NixOS/nixpkgs/commit/c01621586cb27a845bc6a41f856037588bdab894) python312Packages.httpie: 3.2.3 -> 3.2.4
* [`a0909d29`](https://github.com/NixOS/nixpkgs/commit/a0909d29beb089b54ac7e3eec7f8f3ebc2114a4e) python312Packages.umap-learn: switch to pypa builder
* [`efa2aeeb`](https://github.com/NixOS/nixpkgs/commit/efa2aeebb8ff4452ffad09b4f328370f2612eebf) python312Packages.trx-python: init at 0.3
* [`c394b551`](https://github.com/NixOS/nixpkgs/commit/c394b551b0dc790d57bfa1666e90009a4c808fb0) nuclei-templates: 10.0.2 -> 10.0.3
* [`d371bd12`](https://github.com/NixOS/nixpkgs/commit/d371bd12884e3945732cf178198f94f1c98f3ae4) light: nixfmt
* [`7edefa55`](https://github.com/NixOS/nixpkgs/commit/7edefa55310801f15b8a4dcb9529883c8563f5cc) light: fetch source from gitlab; move to by-name
* [`fe0c7366`](https://github.com/NixOS/nixpkgs/commit/fe0c7366d562837285d5425ed97ec5da4b6a2d18) netease-cloud-music-gtk: 2.4.1 -> 2.5.0
* [`4462ce11`](https://github.com/NixOS/nixpkgs/commit/4462ce11b3ea4c61ed9447772fa5c26d3f33744b) netease-cloud-music-gtk: format with nixfmt-rfc-style
* [`dc561f04`](https://github.com/NixOS/nixpkgs/commit/dc561f040a8e3885d3ed346ac637999950cc3539) chiaki-ng: 1.9.0 -> 1.9.1
* [`95992965`](https://github.com/NixOS/nixpkgs/commit/9599296566c88826a42398af0981fe065d577aa0) lua-language-server: disable flaky tests
* [`114ef67c`](https://github.com/NixOS/nixpkgs/commit/114ef67cbb6ba6db805eadfc55ac8225ed4b7f6e) Don't run hwclock if /etc/ is not writable
* [`39c8fd64`](https://github.com/NixOS/nixpkgs/commit/39c8fd647f2976d022cf01fac2d64a2136e0ac8e) apostrophe: 3.1 -> 3.2
* [`d90f320e`](https://github.com/NixOS/nixpkgs/commit/d90f320eb26dd0f744e060b594175b7ff5479cc5) bootterm: init at 0.5
* [`e299dffa`](https://github.com/NixOS/nixpkgs/commit/e299dffa9e25acef8b6b28e5402348b825de4128) browsers: 0.5.8 -> 0.6.0
* [`db15554b`](https://github.com/NixOS/nixpkgs/commit/db15554b695453cfae1b1811b84c7df8b783b04f) htcondor: 23.10.1 -> 24.1.1
* [`b5ee5415`](https://github.com/NixOS/nixpkgs/commit/b5ee5415240d2b903b763fae04f4278ac9c07010) doc/haskell: update default GHC version
* [`799ae392`](https://github.com/NixOS/nixpkgs/commit/799ae392daa7a111bc29df7a707c7f387b4006e7) rtorrent: Format using nixfmt-rfc-style
* [`0adffe3f`](https://github.com/NixOS/nixpkgs/commit/0adffe3ffd2993f9a4c6cf49ee842d792699c6d8) kapacitor: move to by-name; nixfmt
* [`d1b84151`](https://github.com/NixOS/nixpkgs/commit/d1b841519ccf25cdd322b8cd08d88563031c0e57) kapacitor: 1.7.0 -> 1.7.5
* [`93f86800`](https://github.com/NixOS/nixpkgs/commit/93f868007bfabc7e7f730ffd7ee69985954cfcdd) rtorrent: Fix build on darwin
* [`b84e8228`](https://github.com/NixOS/nixpkgs/commit/b84e822858af980539ffc70556bb97a2969e0df7) mailctl: delete unused source files
* [`92ce1123`](https://github.com/NixOS/nixpkgs/commit/92ce112366294e58ae099eeb5b289873238ea443) haskellPackages.twain: build with up to date dependencies
* [`bb0fdf2d`](https://github.com/NixOS/nixpkgs/commit/bb0fdf2dfa3fa2b242eae5c39de6200c246588e8) solana: 1.17.31 -> 1.18.26
* [`cebf6fb8`](https://github.com/NixOS/nixpkgs/commit/cebf6fb82576f051484a4a0cdd694052fe6f922d) steghide: Format using nixfmt-rfc-style
* [`128f06e7`](https://github.com/NixOS/nixpkgs/commit/128f06e74e9726e9e75f50f0829d82261ca25953) ecapture: 0.8.8 -> 0.8.9
* [`4d458768`](https://github.com/NixOS/nixpkgs/commit/4d45876878f2fa7e25150ff50317c5e2d04dc53c) grim: Limit meta.platforms to linux
* [`38a1f61c`](https://github.com/NixOS/nixpkgs/commit/38a1f61cded9f20b9f497be8960f8ad642ba4aac) steghide: Fix build on clang 16
* [`73e30152`](https://github.com/NixOS/nixpkgs/commit/73e301522dd29beed7cfb6d5bb1bc69ffccb5c80) lxqt.obconf-qt: 0.16.4 -> 0.16.5
* [`f9310ec1`](https://github.com/NixOS/nixpkgs/commit/f9310ec1a92a072f2d267b73a423ad18cfa1f07c) trunk: fix build on darwin; move to by-name
* [`7249e6c5`](https://github.com/NixOS/nixpkgs/commit/7249e6c5614196b7cbcd81a7b837748df4a9f8b8) wf-recorder: fix compile for ffmpeg_7
* [`aebe9a35`](https://github.com/NixOS/nixpkgs/commit/aebe9a354b7b5783ec1130ff24ea98b6b2e4ad8a) regripper: update-2023-07-23 -> 0-unstable-2024-11-02
* [`7335bc5d`](https://github.com/NixOS/nixpkgs/commit/7335bc5d6a6c74f813aac870a2a5006726733375) dissent: fix build by pinning libspelling 0.2.1
* [`07a7c37d`](https://github.com/NixOS/nixpkgs/commit/07a7c37dad323aa20b45dde1f92171d1f3e37995) cosmic-icons: 1.0.0-alpha.2 -> 1.0.0-alpha.3
* [`ae888456`](https://github.com/NixOS/nixpkgs/commit/ae8884563baeab5a4c3f757e3c7ae306919e4e72) python312Packages.aiohttp-remotes: 1.2.0 -> 1.3.0
* [`104eb099`](https://github.com/NixOS/nixpkgs/commit/104eb099512cd403eca6ba77641c945cf814ab75) alsa-plugins: add more dependencies, make existing dependencies unconditional
* [`ab9d5220`](https://github.com/NixOS/nixpkgs/commit/ab9d5220d8a75f6752927dc6b232750ea64c2b81) stalwart-mail.webadmin: pin wasm-bindgen-cli version
* [`53377482`](https://github.com/NixOS/nixpkgs/commit/53377482004e6041af2d4e215fda0a86741b6b69) bpfmon: 2.52 -> 2.53
* [`d298e7fd`](https://github.com/NixOS/nixpkgs/commit/d298e7fde13a113c1ca6ac7c6f71ecc222da191d) dua: 2.29.2 -> 2.29.3
* [`91abaf6c`](https://github.com/NixOS/nixpkgs/commit/91abaf6cf27ce3c083d63f7d0b91f83301075e9d) python3.pkgs.vega: remove unnecessary patch that breaks the build
* [`de88955b`](https://github.com/NixOS/nixpkgs/commit/de88955be618163fab1e4151e91df3d0eb3610f0) sqruff: 0.17.0 → 0.20.2
* [`1ab2fa31`](https://github.com/NixOS/nixpkgs/commit/1ab2fa31a387fa2127588bd6e4c470909cd0981c) xurls: 2.5.0 -> 2.5.0-unstable-2024-11-03
* [`3e0a1fb7`](https://github.com/NixOS/nixpkgs/commit/3e0a1fb7cc6a3a7fdb607e25d7fd4dc3e2a2ba96) gn: nixfmt
* [`bfca4e1e`](https://github.com/NixOS/nixpkgs/commit/bfca4e1e736757cccb4110d7d04d88c6ba770ae6) gn1924: drop
* [`3f479feb`](https://github.com/NixOS/nixpkgs/commit/3f479febfe8b1e27456d6154a321c3a0f979ae82) kamp: 0.2.1 -> 0.2.2
* [`332e4e07`](https://github.com/NixOS/nixpkgs/commit/332e4e07a332119c679647d1c14a17b728cb3768) python312Packages.hap-python: 4.9.1 -> 4.9.2
* [`e674bbe9`](https://github.com/NixOS/nixpkgs/commit/e674bbe9fe18a82b3e3064f6dbad93f81f3f3f57) ppsspp: 1.17.1 -> 1.18
* [`77057c0c`](https://github.com/NixOS/nixpkgs/commit/77057c0c61db62e7c6177b0e78c0952b32472676) timoni: 0.22.0 -> 0.22.1
* [`ad751c9e`](https://github.com/NixOS/nixpkgs/commit/ad751c9e58484910041fbe2b98a133f8bbd6d1e1) pkgs/stdenv/linux: update armv7l-unknown-linux-gnueabihf bootstrap-files
* [`c2034a8f`](https://github.com/NixOS/nixpkgs/commit/c2034a8f620803cd31a60cb7976e1f8b183a54ab) Remove mcaju as maintainer
* [`a51f3224`](https://github.com/NixOS/nixpkgs/commit/a51f3224762eb27ac7ab3b39a17211e83c4ece67) ppsspp-sdl: 1.17.1 -> 1.18
* [`4682fff1`](https://github.com/NixOS/nixpkgs/commit/4682fff1edc2e638ac4405130a059fd64aaac0ba) rage: 0.10.0 -> 0.11.0
* [`acb1661f`](https://github.com/NixOS/nixpkgs/commit/acb1661f74d53d44585e36ebcc1a32fe73384e96) aggregate6: init at 1.0.12
* [`9ec16015`](https://github.com/NixOS/nixpkgs/commit/9ec16015fe94550ed45e09b80afa058f4e2324d6) go-jet: 2.11.1 -> 2.12.0
* [`89ab9552`](https://github.com/NixOS/nixpkgs/commit/89ab9552e246e65861c61079bc1d9e1f45b468c3) arouteserver: init at 1.23.1
* [`31d5e148`](https://github.com/NixOS/nixpkgs/commit/31d5e148149e1fc4e6047cca5dc8d4f46c9cd6c2) lunar-client: 3.2.24 -> 3.2.26
* [`5a2d2310`](https://github.com/NixOS/nixpkgs/commit/5a2d23108f4c724623b16c27f78bdde63b17d73b) connectome-workbench: 2.0.0 -> 2.0.1; unbreak
* [`75929c2e`](https://github.com/NixOS/nixpkgs/commit/75929c2eef3b490e76f6db0305d8a5a793ba60d0) usql: 0.19.3 -> 0.19.12
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
