### PR TITLE
niv home-manager: update 8f6ca785 -> 60bb1109

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -41,10 +41,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "8f6ca7855d409aeebe2a582c6fd6b6a8d0bf5661",
-        "sha256": "1zdrga86vdc8d47n2xlqw6iq13688ga5hjji77rsnm3gg8hnllk4",
+        "rev": "60bb110917844d354f3c18e05450606a435d2d10",
+        "sha256": "1jxrzlgc0xzad5hrjixab4brhir1hyf6cvq0zhgb7z9x06kaydin",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/8f6ca7855d409aeebe2a582c6fd6b6a8d0bf5661.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/60bb110917844d354f3c18e05450606a435d2d10.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@8f6ca785...60bb1109](https://github.com/nix-community/home-manager/compare/8f6ca7855d409aeebe2a582c6fd6b6a8d0bf5661...60bb110917844d354f3c18e05450606a435d2d10)

* [`2f607e07`](https://github.com/nix-community/home-manager/commit/2f607e07f3ac7e53541120536708e824acccfaa8) docs: home.sessionVariable clarification
* [`73090072`](https://github.com/nix-community/home-manager/commit/73090072715c823dd19478a58ba4f241d27a577f) news: fix typo
* [`60bb1109`](https://github.com/nix-community/home-manager/commit/60bb110917844d354f3c18e05450606a435d2d10) helix: fix wrapping of extraPackages
