### PR TITLE
niv nixpkgs: update 5c1e2db5 -> 5083ec88

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5c1e2db52711ebee5df2c6bb7e04a52a13e2f73d",
-        "sha256": "018j2ahbqrbmi4kb3xaihck6y11dzrhx9ix53f51qdcz3mj2ax94",
+        "rev": "5083ec887760adfe12af64830a66807423a859a7",
+        "sha256": "0sr45csfh2ff8w7jpnkkgl22aa89sza4jlhs6wq0368dpmklsl8g",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/5c1e2db52711ebee5df2c6bb7e04a52a13e2f73d.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/5083ec887760adfe12af64830a66807423a859a7.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@5c1e2db5...5083ec88](https://github.com/nixos/nixpkgs/compare/5c1e2db52711ebee5df2c6bb7e04a52a13e2f73d...5083ec887760adfe12af64830a66807423a859a7)

* [`4c55d256`](https://github.com/NixOS/nixpkgs/commit/4c55d256cdc3eec67ef0f5775d22da72b92c993e) README: use relative links to CONTRIBUTING.md
* [`7f78cd20`](https://github.com/NixOS/nixpkgs/commit/7f78cd20fd376c33952de2f4b6df7b501e1c10bc) nixos/changedetection-io: fix creation of data dir
* [`24b73ab4`](https://github.com/NixOS/nixpkgs/commit/24b73ab429998e7b9227001a0605054d66d3fff4) python3Packages.sphinx-multiversion: init at version 0.2.4
* [`56195a6a`](https://github.com/NixOS/nixpkgs/commit/56195a6a386366f02f73e5d122c3be80c8fc137b) maintainers: add danbulant
* [`10538b82`](https://github.com/NixOS/nixpkgs/commit/10538b82df08bf719c388bd937ec550c9ec8ddf7) nixos/mysql: fix permission error during first startup
* [`9ac50cec`](https://github.com/NixOS/nixpkgs/commit/9ac50cec5033b9c35fb29909624726b8c62d4bb9) udev-block-notify: init at 0.7.11
* [`40a81539`](https://github.com/NixOS/nixpkgs/commit/40a81539739d7be0048d57d42822a04a95ef98e1) maintainers: add snaki
* [`78e61aae`](https://github.com/NixOS/nixpkgs/commit/78e61aaed0ca9413ae94c889dc24d75bf346a48b) vapoursynth-eedi3: init at unstable-2019-09-30
* [`298aa2a7`](https://github.com/NixOS/nixpkgs/commit/298aa2a75e058473a2026b8536c50f2dd73013c7) vapoursynth-nnedi3cl: init at r8
* [`3fa182e7`](https://github.com/NixOS/nixpkgs/commit/3fa182e7ec85d325e9b5a3636f5dec86c983095a) nixos/teleport: add required utils to path
* [`78b5722e`](https://github.com/NixOS/nixpkgs/commit/78b5722e3e3b9ad077f24a6bc962daa2aaf273d4) vapoursynth-nnedi3: init at v12
* [`c15cc069`](https://github.com/NixOS/nixpkgs/commit/c15cc06900fd451b46fd2e6ae548ca0722ae466f) vapoursynth-znedi3: init at unstable-2023-07-09
* [`0d1057ac`](https://github.com/NixOS/nixpkgs/commit/0d1057ac2bde1f31229a0800348f5f4ba0813a95) kallisto: Add updateScript
* [`bdade1b8`](https://github.com/NixOS/nixpkgs/commit/bdade1b81eb00a74beade2add657c5258a0f65a9) passt: support cross compilation
* [`58176c67`](https://github.com/NixOS/nixpkgs/commit/58176c67da14c249601baa905a4791e4347e15d6) maintainers: add marnym
* [`0f589144`](https://github.com/NixOS/nixpkgs/commit/0f589144a1ac500d4b24a598fed8074851b15c57) rust-bindgen-unwrapped: 0.69.4 -> 0.70.1
* [`be50cd8e`](https://github.com/NixOS/nixpkgs/commit/be50cd8e6ca4d07d81c0a624aaef8fc5ab8dcfff) ffsubsync: fix
* [`d990a4de`](https://github.com/NixOS/nixpkgs/commit/d990a4de512cd503d42571d01130dc81922b0d8c) uglify-js: add meta.changelog
* [`fbf90240`](https://github.com/NixOS/nixpkgs/commit/fbf9024093e06badb3a6e6f2b143e06b4053408c) uglify-js: fix update script
* [`b829051e`](https://github.com/NixOS/nixpkgs/commit/b829051ea4976b8558cc0a41b596b273d8df5311) uglify-js: 3.18.0 -> 3.19.3
* [`a9421be2`](https://github.com/NixOS/nixpkgs/commit/a9421be2926f1790e53db4ed877ed09dad4c3674) gdtoolkit_4: 4.2.2 -> 4.3.1
* [`45c4b954`](https://github.com/NixOS/nixpkgs/commit/45c4b954aff0024890dbb5355667d398053dedd4) linuxPackages.amneziawg: init at 1.0.20240711
* [`3571c72f`](https://github.com/NixOS/nixpkgs/commit/3571c72f41c47a6261c189182c4854e7be955aa0) boehmgc: 8.2.6 -> 8.2.8
* [`3b12ef2f`](https://github.com/NixOS/nixpkgs/commit/3b12ef2f6fdf1822e403a26737c2c229cb7571d7) nixos/udisks2: add package option
* [`ac1c862a`](https://github.com/NixOS/nixpkgs/commit/ac1c862a3b74130b7a70ca2a4cd385505bb2c8c2) directx-headers: 1.614.0 -> 1.614.1
* [`5bd3d7b2`](https://github.com/NixOS/nixpkgs/commit/5bd3d7b231488cca6ea0570048b7ca9b579c745c) imath: 3.1.11 -> 3.1.12
* [`ca6df3d2`](https://github.com/NixOS/nixpkgs/commit/ca6df3d236ac289f418004273b860759ea5ff3e1) libjpeg: 3.0.3 -> 3.0.4
* [`879738c4`](https://github.com/NixOS/nixpkgs/commit/879738c42d4961b160848b7069c72243be3d53f8) ghstack: init at 0.9.3
* [`7c2572e5`](https://github.com/NixOS/nixpkgs/commit/7c2572e5cf4329ad9fa50d33015aa7be394b4026) alvr: build from source
* [`5970720f`](https://github.com/NixOS/nixpkgs/commit/5970720f1cadf2d0c6ef665ad7f673c2e919bce3) nixos/minidlna: add package option
* [`4d84cf29`](https://github.com/NixOS/nixpkgs/commit/4d84cf2982004b9a36aee24fff78ebf156cc42d2) harfbuzz: 9.0.0 -> 10.0.1
* [`cfae44ae`](https://github.com/NixOS/nixpkgs/commit/cfae44ae9c90dc070dba9702140b9e3f24043bc5) bazel: 7.1.2 -> 7.3.1
* [`95a4a50c`](https://github.com/NixOS/nixpkgs/commit/95a4a50c0907d37a39672e0884e2a8ffa3192732) make bazel bootstrap multi-platform
* [`8e8d4a6c`](https://github.com/NixOS/nixpkgs/commit/8e8d4a6c365d752d4b1601817cc5a7e97bb96b26) set meta.sourceProvenance for bazel bootstrap
* [`76bf576d`](https://github.com/NixOS/nixpkgs/commit/76bf576d03c5187f3c57335c3222d665ba2e0123) use camelCase for FODs, fix deps FOD
* [`3de687a6`](https://github.com/NixOS/nixpkgs/commit/3de687a6b6faaed2ecbde08b3de5e63262b7ead3) get linux/aarch64-darwin builds working
* [`bee45a2c`](https://github.com/NixOS/nixpkgs/commit/bee45a2c281a40246b2993b4c03c20f2a5e937bc) correct x86_64-linux deps sha
* [`77c941be`](https://github.com/NixOS/nixpkgs/commit/77c941be7f5a88d0bbf8f65fd17bb3c361a8b43a) fix deps and hashes for darwin
* [`bd5023c4`](https://github.com/NixOS/nixpkgs/commit/bd5023c4ea26c08d8e702ae9099e421e2f1e3654) fix deps hashes for linux
* [`46016bad`](https://github.com/NixOS/nixpkgs/commit/46016bada3730c22055eb010818024ff46fd96e6) fix whitespace
* [`6aae06b8`](https://github.com/NixOS/nixpkgs/commit/6aae06b8ce27bc07bd62de7e20d8da44af521295) use mktemp instead of TMP for deps
* [`2668d660`](https://github.com/NixOS/nixpkgs/commit/2668d660b6ce897f5322686a12ad2b7e8b3ac5c9) neovimUtils: make installing queries in treesitter grammars optional
* [`8cc8689d`](https://github.com/NixOS/nixpkgs/commit/8cc8689d873177e8b45b4f41150ca1baf6092437) Revert "vimPlugins.nvim-treesitter: add workaround for [nixos/nixpkgs⁠#332580](https://togithub.com/nixos/nixpkgs/issues/332580)"
* [`7153c097`](https://github.com/NixOS/nixpkgs/commit/7153c0975acb31ba2d01f2b660259a498aeb2bc4) libsForQt5.qcoro: 0.10.0 -> 0.11.0
* [`c31e8384`](https://github.com/NixOS/nixpkgs/commit/c31e8384dd91864330b19105e932be0fc8e9673c) lilv: add meson options to include Nix and NixOS specific paths for the default lv2 plugin search
* [`4cc4fd6f`](https://github.com/NixOS/nixpkgs/commit/4cc4fd6ff1b9f32f519c3ed7acc3b8b98b410bec) bitwarden-desktop: fix system authentication
* [`ba3ad022`](https://github.com/NixOS/nixpkgs/commit/ba3ad022bad53bc1d1ca75c63f5981f98700b732) lilv: remove unnecessary search path for LV2 plugins
* [`4f9f7f80`](https://github.com/NixOS/nixpkgs/commit/4f9f7f80a3e13935d9d309bcf1bdc64bdfd30eb1) python3Packages.sip: 6.8.3 -> 6.8.6
* [`52069f4f`](https://github.com/NixOS/nixpkgs/commit/52069f4fe5337ae48a722d286f67fc0734be51a1) eclipses: fix update script to avoid extra escapes in url output
* [`2def23d7`](https://github.com/NixOS/nixpkgs/commit/2def23d712cafc49dec09c445fb988d6472545a4) eclipses: 2024-06 -> 2024-09
* [`63d46aaa`](https://github.com/NixOS/nixpkgs/commit/63d46aaac49a7d439ee33a4526b3470d88c9b3b1) dconf: fix building without emulation available
* [`d195900a`](https://github.com/NixOS/nixpkgs/commit/d195900a0ecf0d4ae6863212ebaf60f32964f5f0) valkey: 7.2.7 -> 8.0.1
* [`cc4a29d8`](https://github.com/NixOS/nixpkgs/commit/cc4a29d84b22889a27d875df42eb35fb8d0123eb) monolith: 2.8.1 -> 2.8.3
* [`d604acb1`](https://github.com/NixOS/nixpkgs/commit/d604acb13610ca2564677f24adbdf47eee741c70) texinfo: fix reference to build platform coreutils
* [`a6704661`](https://github.com/NixOS/nixpkgs/commit/a670466186cf20c68265f0e9fa40a1ba596467be) texinfo: use substituteInPlace --replace-fail
* [`7467f7d5`](https://github.com/NixOS/nixpkgs/commit/7467f7d59f136ebe0771212e3e80b581fdb95d5b) nixos/roundcube: add example for `database.passwordFile`
* [`88bfd2e8`](https://github.com/NixOS/nixpkgs/commit/88bfd2e8242a219f956d01ec08ee99ff2325a3bc) libation: 11.3.14.2 -> 11.4.1
* [`49040214`](https://github.com/NixOS/nixpkgs/commit/4904021426ba51c49fb7ec81f8bec88919059f82) protobuf_25: 25.4 -> 25.5
* [`b9a41bcb`](https://github.com/NixOS/nixpkgs/commit/b9a41bcbac86c37b936b41a889fa0be5a28b3e1e) libarchive: 3.7.6 -> 3.7.7
* [`f6588327`](https://github.com/NixOS/nixpkgs/commit/f6588327a25dd0eb0a06013a904fe2c7c9c737f7) libxmlb: 0.3.19 -> 0.3.20
* [`84b9dfea`](https://github.com/NixOS/nixpkgs/commit/84b9dfea419dc96fc9d4925fb8b02b2740baf60b) osquery: 5.12.2 -> 5.13.1
* [`8044c0cc`](https://github.com/NixOS/nixpkgs/commit/8044c0cc0aec2509b33dd088294f69648061b632) python314: init at 3.14.0a1
* [`835a9710`](https://github.com/NixOS/nixpkgs/commit/835a9710c1373bdb8f9f7943cc394e16b7bf2768) python314Packages.flit-core: backport 3.14 compat patch
* [`b21033f8`](https://github.com/NixOS/nixpkgs/commit/b21033f825b20c663921d8f081c93cc4caf09802) OWNERS: extend my python code ownership
* [`062bd17d`](https://github.com/NixOS/nixpkgs/commit/062bd17d71320463b3986b5de2dc3b9b33417e86) execline-man-pages: 2.9.6.0.1 -> 2.9.6.1.1
* [`c58c2052`](https://github.com/NixOS/nixpkgs/commit/c58c2052cd53953f574580551237af62cfc2af16) maintainers: add kuglimon
* [`48f7655d`](https://github.com/NixOS/nixpkgs/commit/48f7655db81ccc8ced593f015b6b5605be3bce3f) libssh2: 1.11.0 -> 1.11.1
* [`933ccc51`](https://github.com/NixOS/nixpkgs/commit/933ccc51f4a539ad731c062fd347c7235531eb80) maintainers: add rksm
* [`59b91bae`](https://github.com/NixOS/nixpkgs/commit/59b91bae8c9f855411d9f4cb847a6d17e73284b5) autoconf-archive: 2023.02.20 -> 2024.10.16
* [`e2e74de0`](https://github.com/NixOS/nixpkgs/commit/e2e74de075a3d06facde5e2c67b66bdf4340577c) vim: 9.1.0765 -> 9.1.0787
* [`68da0b94`](https://github.com/NixOS/nixpkgs/commit/68da0b94729bfcccfb7944f26b192f739b565cd8) memcached: 1.6.29 -> 1.6.31
* [`58b590d9`](https://github.com/NixOS/nixpkgs/commit/58b590d966e4f2aefcd6271b6ae63a9a8b1b3c1a) darwin.libiconv: unconditionalize static patch
* [`11cced65`](https://github.com/NixOS/nixpkgs/commit/11cced659e5ae12645b4542c12527d6c09d74066) python312Packages.clickclick: pytest-cov -> pytest-cov-stub
* [`195c9123`](https://github.com/NixOS/nixpkgs/commit/195c9123542cd2489685a0a5273516fe3d622a2e) python312Packages.dbus-next: pytest-cov -> pytest-cov-stub
* [`6244788e`](https://github.com/NixOS/nixpkgs/commit/6244788e1e21fc20525fb2403978ce2461127494) python312Packages.echo: pytest-cov -> pytest-cov-stub
* [`df2eef0d`](https://github.com/NixOS/nixpkgs/commit/df2eef0dedc3aeb49a2158f4dd57a2bed9b49875) python312Packages.fairscale: pytest-cov -> pytest-cov-stub
* [`7d76cd70`](https://github.com/NixOS/nixpkgs/commit/7d76cd700d7be8724ce472845fed933faa159484) python312Packages.fast-histogram: pytest-cov -> pytest-cov-stub
* [`bbfbfa07`](https://github.com/NixOS/nixpkgs/commit/bbfbfa07bdf92e82f0685b616badc13c82332f20) python312Packages.flufl-lock: pytest-cov -> pytest-cov-stub
* [`4c0dbf16`](https://github.com/NixOS/nixpkgs/commit/4c0dbf162baf31e47df038392db84ce5f487931e) python312Packages.googlemaps: pytest-cov -> pytest-cov-stub
* [`c97526af`](https://github.com/NixOS/nixpkgs/commit/c97526afed386b049106a40ba6888d401bde011c) python312Packages.gunicorn: pytest-cov -> pytest-cov-stub
* [`a07ff3b1`](https://github.com/NixOS/nixpkgs/commit/a07ff3b1bbebdcac1ee3d1317c47aff100c308c2) python312Packages.haystack-ai: pytest-cov -> pytest-cov-stub
* [`788d11f4`](https://github.com/NixOS/nixpkgs/commit/788d11f457aada708de6c5f167d25d730d7355ec) python312Packages.injector: pytest-cov -> pytest-cov-stub
* [`8ebf13b4`](https://github.com/NixOS/nixpkgs/commit/8ebf13b49711009445948a328ce3d61fb78226eb) python312Packages.iocapture: pytest-cov -> pytest-cov-stub
* [`2d53d379`](https://github.com/NixOS/nixpkgs/commit/2d53d3790721b8a67b31fe92caddb3a210e2a27d) python312Packages.ipfshttpclient: pytest-cov -> pytest-cov-stub
* [`3d7a2e91`](https://github.com/NixOS/nixpkgs/commit/3d7a2e91743dd7e3bb1e80736db6d63423d8507a) python312Packages.isbnlib: pytest-cov -> pytest-cov-stub
* [`e198a602`](https://github.com/NixOS/nixpkgs/commit/e198a6026839ed6d451add6eafd1c622278b0b22) python312Packages.jwt: pytest-cov -> pytest-cov-stub
* [`6d73eaa6`](https://github.com/NixOS/nixpkgs/commit/6d73eaa60dfabbead35a7b1781c077f9d9c613ba) python312Packages.monero: pytest-cov -> pytest-cov-stub
* [`87135622`](https://github.com/NixOS/nixpkgs/commit/87135622104d51fd84f3ff91c1369ebe77206ab0) python312Packages.pettingzoo: pytest-cov -> pytest-cov-stub
* [`afadc6f9`](https://github.com/NixOS/nixpkgs/commit/afadc6f9260e3120cc427a7c13865c8023b2160a) python312Packages.pgmpy: pytest-cov -> pytest-cov-stub
* [`c56d950f`](https://github.com/NixOS/nixpkgs/commit/c56d950ff3b558bdc9c8677d8ae00b3ca5ac171b) python312Packages.plaster: pytest-cov -> pytest-cov-stub
* [`e197c36e`](https://github.com/NixOS/nixpkgs/commit/e197c36efdc7ecde34f36cb7de8f88c1d399d0bb) python312Packages.property-manager: pytest-cov -> pytest-cov-stub
* [`b703f4d0`](https://github.com/NixOS/nixpkgs/commit/b703f4d0ce9e6a5b573ca81d8c7311b47869270c) python312Packages.psautohint: pytest-cov -> pytest-cov-stub
* [`112a7efe`](https://github.com/NixOS/nixpkgs/commit/112a7efe154309cbcb1ec584134d116d9dcbf079) python312Packages.pyevtk: pytest-cov -> pytest-cov-stub
* [`c4a2c16c`](https://github.com/NixOS/nixpkgs/commit/c4a2c16c76b3a7bff32edf69630d3d6a8c3350a6) python312Packages.pyexcel-xls: pytest-cov -> pytest-cov-stub
* [`da9a4b0b`](https://github.com/NixOS/nixpkgs/commit/da9a4b0b6404960833cb6691ccd4429658aa8e97) python312Packages.pymaven-patch: pytest-cov -> pytest-cov-stub
* [`5db834e1`](https://github.com/NixOS/nixpkgs/commit/5db834e1729ab3dda998cdf5feb2fdc3676e2174) python312Packages.pyscaffold*: pytest-cov -> pytest-cov-stub
* [`d5886a2e`](https://github.com/NixOS/nixpkgs/commit/d5886a2e3166ed668a4581182b1d6647c46fcf5e) python312Packages.pystac: pytest-cov -> pytest-cov-stub
* [`73cf5262`](https://github.com/NixOS/nixpkgs/commit/73cf526286a09a8a43bf34ffe4018cdc731ffb77) python312Packages.pytest-*: pytest-cov -> pytest-cov-stub
* [`202b4b5c`](https://github.com/NixOS/nixpkgs/commit/202b4b5c7ca9221a831d3680f2a5805c5e14a532) python312Packages.rdflib: pytest-cov -> pytest-cov-stub
* [`7f7c3242`](https://github.com/NixOS/nixpkgs/commit/7f7c3242afa2afb51b547e30c4c9417d1366f666) python312Packages.reikna: pytest-cov -> pytest-cov-stub
* [`419db747`](https://github.com/NixOS/nixpkgs/commit/419db747e45e713fdb08019d595366d81495b16f) python312Packages.schwifty: pytest-cov -> pytest-cov-stub
* [`9e2dc791`](https://github.com/NixOS/nixpkgs/commit/9e2dc7918b3434081593933dc8505a48ff6c1a4d) python312Packages.sentence-transformers: pytest-cov -> pytest-cov-stub
* [`59d1cfb2`](https://github.com/NixOS/nixpkgs/commit/59d1cfb2350a2340037d0cc90184c6c62cdcf1ae) python312Packages.snapshottest: pytest-cov -> pytest-cov-stub
* [`48887a60`](https://github.com/NixOS/nixpkgs/commit/48887a6046f6449fc6308505c4f4783854509f2b) python312Packages.sortedcollections: pytest-cov -> pytest-cov-stub
* [`2b8b58d8`](https://github.com/NixOS/nixpkgs/commit/2b8b58d8de5552a4b0d4f34e1c54a3d22f780229) python312Packages.stups-fullstop: pytest-cov -> pytest-cov-stub
* [`e208ff10`](https://github.com/NixOS/nixpkgs/commit/e208ff1087bdfd2a31b40929609f9dbe22487e06) python312Packages.subliminal: pytest-cov -> pytest-cov-stub
* [`5391f72c`](https://github.com/NixOS/nixpkgs/commit/5391f72c5604c645ca770481027c60b2ba0e9618) python312Packages.tf2onnx: pytest-cov -> pytest-cov-stub
* [`6372046e`](https://github.com/NixOS/nixpkgs/commit/6372046ee5e290c252edca127ab05632974d9e16) python312Packages.torch-geometric: pytest-cov -> pytest-cov-stub
* [`c4407814`](https://github.com/NixOS/nixpkgs/commit/c4407814cc915fc191422855ae4b65ab5e65d48b) python312Packages.uarray: pytest-cov -> pytest-cov-stub
* [`edc1dfd1`](https://github.com/NixOS/nixpkgs/commit/edc1dfd1c4124182e005a719b6699036636f551a) python312Packages.unstructured*: pytest-cov -> pytest-cov-stub
* [`0684b2b0`](https://github.com/NixOS/nixpkgs/commit/0684b2b042c2ef352b9a1d137908cdad9802ad5b) python312Packages.venusian: pytest-cov -> pytest-cov-stub
* [`bf595a91`](https://github.com/NixOS/nixpkgs/commit/bf595a9173bc473c9cea43b6a08b98dddadf6545) python312Packages.xformers: pytest-cov -> pytest-cov-stub
* [`dd98f9d8`](https://github.com/NixOS/nixpkgs/commit/dd98f9d88f83f4d049db95e295150f8eb72a9599) stac-validator: init at 3.4.0
* [`16cbbf66`](https://github.com/NixOS/nixpkgs/commit/16cbbf66510f4fc496e313ae7e11ce28ea225464) cmake: 3.30.4 -> 3.30.5
* [`a59a4507`](https://github.com/NixOS/nixpkgs/commit/a59a45073da523548ba0ffd59a936ba4bb29b6d1) dav1d: 1.4.3 -> 1.5.0
* [`d4bc528d`](https://github.com/NixOS/nixpkgs/commit/d4bc528d44713970bca18c97ba23c01337885978) libogg: build  shared library
* [`77d256a1`](https://github.com/NixOS/nixpkgs/commit/77d256a1e18af8107bb8e08731969880c42f3900) python312Packages.markupsafe: 3.0.1 -> 3.0.2
* [`840af567`](https://github.com/NixOS/nixpkgs/commit/840af567fb08f9bd3e05f1daa951b89340709e77) nixos/libvirt: fix shellcheck findings with enableStrictShellChecks enabled
* [`15e4102a`](https://github.com/NixOS/nixpkgs/commit/15e4102a6a0a006df68a97ddad275e7d7f63c075) vvenc: init at 1.12.0
* [`cb2ef37a`](https://github.com/NixOS/nixpkgs/commit/cb2ef37af34beee3624db963653a8a36e1170006) lcevcdec: init at 3.2.1
* [`46c01233`](https://github.com/NixOS/nixpkgs/commit/46c012331f624423e3ac968c252eb54ce4558b67) ffmpeg: add vvenc option
* [`22faf0ac`](https://github.com/NixOS/nixpkgs/commit/22faf0ac9e16a5a2457944be5a42543591addb0c) ffmpeg: add lc3 option
* [`fdf2cbdc`](https://github.com/NixOS/nixpkgs/commit/fdf2cbdc1c13df3c62d1ff2e48d1e6fbf5384f8f) ffmpeg: add lcevcdec option
* [`e57d35f9`](https://github.com/NixOS/nixpkgs/commit/e57d35f922858f91dd327b66d2633feb683534fd) gptscript: 0.9.4 -> 0.9.5
* [`585e8543`](https://github.com/NixOS/nixpkgs/commit/585e85438de22dded709cb60645043ef2e47aba6) fmt: 11.0.1 -> 11.0.2, change sha256 -> hash
* [`90abf6e0`](https://github.com/NixOS/nixpkgs/commit/90abf6e0dbe4f59eca9cfc2c7b539ca643d68ccc) monolith: mark darwin as broken and fix license
* [`097532a3`](https://github.com/NixOS/nixpkgs/commit/097532a3ccd20a41bb3dd5bc76013a7d9be0ad2f) add libtool to darwin bazel deps
* [`e266fb9a`](https://github.com/NixOS/nixpkgs/commit/e266fb9a509e4651b3604bf4009e495c03c2f022) iwd: 2.22 -> 3.0
* [`9767bb9b`](https://github.com/NixOS/nixpkgs/commit/9767bb9bf1e6beaf4169e55963d7f44c637d4d22) stdenv/setup: make substituteInPlace require actual files
* [`ba99a7b1`](https://github.com/NixOS/nixpkgs/commit/ba99a7b1efacfe5d2549bdc67e6ba0561860fbbd) numactl: Fix memory corruption in set_nodemask_size
* [`3576b958`](https://github.com/NixOS/nixpkgs/commit/3576b958e4397bcfbf8d664286fca8f418c906be) Reapply "bmake: 20240808 -> 20240921" (PR [nixos/nixpkgs⁠#349649](https://togithub.com/nixos/nixpkgs/issues/349649))
* [`52dc9272`](https://github.com/NixOS/nixpkgs/commit/52dc9272a140389f392b109b0b171bd6cba1297f) meson: 1.5.2 -> 1.6.0
* [`1ceba936`](https://github.com/NixOS/nixpkgs/commit/1ceba9367c27ec3586766df242081ef55ba56f66) meson/setup-hook.sh: make build directory configurable
* [`e6f4812d`](https://github.com/NixOS/nixpkgs/commit/e6f4812da2d393f7446b3f91fae69a7d85894d42) tinyxxd: 1.3.5 -> 1.3.6
* [`72413bfe`](https://github.com/NixOS/nixpkgs/commit/72413bfe89d7499f0b9aa1b9e5cb6a93485a6c7d) binutils: make patches unconditional
* [`985072e2`](https://github.com/NixOS/nixpkgs/commit/985072e2ce4afa4201b49a20154fcc888aaccec5) cc-wrapper: Hardcode path to `mktemp` and `rm` if possible
* [`62f2fc1a`](https://github.com/NixOS/nixpkgs/commit/62f2fc1ae5f6e99d5aa5ae2829730c73a65cf7ed) tests.cc-wrapper: Add `NIX_CC_USE_RESPONSE_FILE` check
* [`ca81d85c`](https://github.com/NixOS/nixpkgs/commit/ca81d85c856c1d9435ac1a5c5a2f38fa5b443a2d) grpc: 1.62.1 -> 1.67.0
* [`f922c45f`](https://github.com/NixOS/nixpkgs/commit/f922c45fded80b7371a637203afd7bdd7dad5cbe) nspr: 4.35 -> 4.36
* [`19ac92c6`](https://github.com/NixOS/nixpkgs/commit/19ac92c619b942bf4a8bb3b236c82fdff0adc895) python312Packages.grpcio-channelz: 1.66.2 -> 1.67.0
* [`e1b88807`](https://github.com/NixOS/nixpkgs/commit/e1b88807433c5abbd98b829abf5283f67596370f) python312Packages.grpcio-health-checking: 1.66.2 -> 1.67.0
* [`2853e86d`](https://github.com/NixOS/nixpkgs/commit/2853e86dfd45652cd1f5dbdd1e77c759c1e661c9) python312Packages.grpcio-reflection: 1.66.2 -> 1.67.0
* [`0bddc716`](https://github.com/NixOS/nixpkgs/commit/0bddc71698b5594a58b342bf55abe141929ff4a6) python312Packages.grpcio-status: 1.64.1 -> 1.67.0
* [`2a4535cc`](https://github.com/NixOS/nixpkgs/commit/2a4535cc10bc7a06db9fa06a40f43445da7f4ef5) python312Packages.grpcio-testing: 1.66.2 -> 1.67.0
* [`6b5a8cb3`](https://github.com/NixOS/nixpkgs/commit/6b5a8cb3f462b163674ab883bdffcda9c24f4940) python312Packages.grpcio-tools: 1.65.1 -> 1.67.0
* [`da16a24f`](https://github.com/NixOS/nixpkgs/commit/da16a24f0aff890f114d545b7d5fee89f458dc8b) python312Packages.grpcio: 1.64.1 -> 1.67.0
* [`07aa0b86`](https://github.com/NixOS/nixpkgs/commit/07aa0b864b9e3852006aad9f75cafdcc3ac9ab21) nghttp2: 1.63.0 -> 1.64.0
* [`9b175cff`](https://github.com/NixOS/nixpkgs/commit/9b175cffd7ad8c6434f03f2c3cfc3222b38e4b43) swaytools: 0.1.1 -> 0.1.2
* [`5f6c78c3`](https://github.com/NixOS/nixpkgs/commit/5f6c78c303e281fbd13ff75d5d32ef39b71333d3) protobuf: 28.2 -> 28.3
* [`2c59da55`](https://github.com/NixOS/nixpkgs/commit/2c59da55cb1a4c9f30d7f88e4ea6835b71691237) python312Packages.protobuf: 5.28.2 -> 5.28.3
* [`70e3fbac`](https://github.com/NixOS/nixpkgs/commit/70e3fbac841d1b3434e572ee5ea00f96f6f475ea) scc: 3.3.5 -> 3.4.0
* [`5b4cc3f8`](https://github.com/NixOS/nixpkgs/commit/5b4cc3f8048a9f1c35862fe132fca5242b027344) pipewire: 1.2.5 -> 1.2.6
* [`5aa080a4`](https://github.com/NixOS/nixpkgs/commit/5aa080a4906bac66c70a67b940269dab503b1746) upower: Fix a race condition in test_sibling_priority_no_overwrite
* [`d0c7f81a`](https://github.com/NixOS/nixpkgs/commit/d0c7f81ae80bc05ecfd16e84e31404b334665a76) biliass: 2.1.0 -> 2.1.1
* [`56ad9c0e`](https://github.com/NixOS/nixpkgs/commit/56ad9c0e01a01cfa03656522c495d139c054b330) yutto: 2.0.0-rc.4 -> 2.0.0-rc.5
* [`ae207af8`](https://github.com/NixOS/nixpkgs/commit/ae207af82b4c38b878a8928d2d54454a6f6bf387) treewide: More string indentation fixes
* [`74d8a923`](https://github.com/NixOS/nixpkgs/commit/74d8a923cb7947cc12cee722d75d5d3fd7d26c6b) tinyxxd: 1.3.6 -> 1.3.7
* [`7869ffb0`](https://github.com/NixOS/nixpkgs/commit/7869ffb010560c83fa5476fb3a49f66469488eed) maintainers: add greg
* [`5e29fe35`](https://github.com/NixOS/nixpkgs/commit/5e29fe353405fea970eec69ae76638c606886886) kvazaar: init at 2.3.1
* [`77a6293b`](https://github.com/NixOS/nixpkgs/commit/77a6293b4ff3d241c37204ece7e141c491249b6b) ffmpeg: add kvazaar option
* [`13f2e602`](https://github.com/NixOS/nixpkgs/commit/13f2e60293758a7c1f8277d0e85c66b6e41d19d1) hifile: 0.9.9.13 -> 0.9.9.15
* [`3ff2adbb`](https://github.com/NixOS/nixpkgs/commit/3ff2adbb80da6648ce46b1122ebe02c68c5c57e4) hifile: add update script
* [`99dba147`](https://github.com/NixOS/nixpkgs/commit/99dba1471d8ac2528b6c72db9dc46735adbb4f82) maintainers/ymstnt: update name
* [`1971cea5`](https://github.com/NixOS/nixpkgs/commit/1971cea5492516371f36931c5b2793074d7815cc) python312Packages.pillow-simd: drop
* [`fa3075a2`](https://github.com/NixOS/nixpkgs/commit/fa3075a22d795d1a55e50e811cecb483aed5b474) lib/licenses: introduce MIT-CMU license
* [`477d7f77`](https://github.com/NixOS/nixpkgs/commit/477d7f77483665a57d06c0962189dde3a9395034) python312Packages.pillow: 10.4.0 -> 11.0
* [`2713abab`](https://github.com/NixOS/nixpkgs/commit/2713abab68939a23b13d2add48a527167eb277da) python312Packages.pillow-heif: 0.18.0 -> 0.20.0
* [`46434415`](https://github.com/NixOS/nixpkgs/commit/464344156d32f320beafc520288df2e1ba6cdff6) python312Packages.imageio: disable failing test
* [`000c1bad`](https://github.com/NixOS/nixpkgs/commit/000c1bad0d8a0fba6b7c3753ed25a80cef707643) python312Packages.starlette: 0.39.2 -> 0.40.0
* [`427db194`](https://github.com/NixOS/nixpkgs/commit/427db1945c38561784df1d88bae6694f0491d2a0) python312Packages.anyio: 4.6.0 -> 4.6.2
* [`fc8e85ad`](https://github.com/NixOS/nixpkgs/commit/fc8e85adff2680adda0c88772d914a948ea88d0a) python312Packages.uvicorn: 0.31.0 -> 0.32.0
* [`d38c5beb`](https://github.com/NixOS/nixpkgs/commit/d38c5bebc6a9db57ec77303ef7c3c952512507d0) python312Packages.fastapi: 0.115.0 -> 0.115.3
* [`a92ce87e`](https://github.com/NixOS/nixpkgs/commit/a92ce87eb3d50d91a947a8ab89baab37436e8743) python312Packages.aiohttp: 3.10.8 -> 3.10.10
* [`2ff66deb`](https://github.com/NixOS/nixpkgs/commit/2ff66debd8c849f2a2b788f2ea0dedd31e379d28) python312Packages.pdm-backend: 2.4.1 -> 2.4.3
* [`514b00cf`](https://github.com/NixOS/nixpkgs/commit/514b00cf08702b31cdf873a798f1ff100d4f2cf7) clang: skip the `-nostdlibinc` patch on Darwin
* [`5036d222`](https://github.com/NixOS/nixpkgs/commit/5036d2221600877719fef7c86b4223222d37dee8) python312Packages.build: 1.2.2 -> 1.2.2.post1
* [`b75c7028`](https://github.com/NixOS/nixpkgs/commit/b75c70282f91276908adf0f286437eadbb638119) ld64: search standard library locations
* [`d831e4c1`](https://github.com/NixOS/nixpkgs/commit/d831e4c17ba9568973a3e0a2cd8ce14343e7f335) openjdk8: 8u422-ga -> 8u432-b06
* [`afa5f909`](https://github.com/NixOS/nixpkgs/commit/afa5f909846cd0f80d38d0a50e7b2aa770d65eb0) openjdk11: 11.0.24+8 -> 11.0.25+9
* [`10ba3b43`](https://github.com/NixOS/nixpkgs/commit/10ba3b431ac58117e1a2254279b9ac538040d71a) nss_latest: 3.105 -> 3.106
* [`5807d3ad`](https://github.com/NixOS/nixpkgs/commit/5807d3ad698cb746e094c229e2f747f3643ed159) ngrok 3.16.0 -> 3.18.1
* [`fe4e4a1a`](https://github.com/NixOS/nixpkgs/commit/fe4e4a1ae23b5f96df2de7399e857c8762fc5fba) openjdk17: 17.0.12+7 -> 17.0.13+11
* [`fc8beb4a`](https://github.com/NixOS/nixpkgs/commit/fc8beb4a6a025b7fceea8c2a597543c0cfcbac92) openjdk21: 21.0.4+7 -> 21.0.5+11
* [`860924d7`](https://github.com/NixOS/nixpkgs/commit/860924d70406ee12fb85edf08871c285a7a228ea) openjdk23: 23-ga -> 23.0.1+11
* [`7bc545f5`](https://github.com/NixOS/nixpkgs/commit/7bc545f5a811d2835b7b2ded7f74434439a197fe) openjdk{8,11,17,21,23}: remove obsolete version logic
* [`09adc5dc`](https://github.com/NixOS/nixpkgs/commit/09adc5dc965bb9edfb69b258876727b06f018553) openjfx17: 17.0.11-ga -> 17.0.11+3
* [`2c50b625`](https://github.com/NixOS/nixpkgs/commit/2c50b625cf3e496ce5a600486553908f79b13121) openjfx21: 21.0.3-ga -> 21.0.3+2
* [`f95c2f68`](https://github.com/NixOS/nixpkgs/commit/f95c2f68da044de1766fa6a6655085422e7346ee) openjfx23: 23-ga -> 23.0.1+4
* [`1b0dadd1`](https://github.com/NixOS/nixpkgs/commit/1b0dadd10238de0c60ed27d36cd500b8210111f2) nixpkgs-openjdk-updater.openjdkSource: enforce `source.json` schema
* [`c1f644cd`](https://github.com/NixOS/nixpkgs/commit/c1f644cdccfc5b555ef90abd1536057eea7f572d) ethtool: 6.9 -> 6.11
* [`d29d7043`](https://github.com/NixOS/nixpkgs/commit/d29d7043a7c3dae0371a35676ba5b5192ef32b0e) tinysparql: upstream patch to fix a test that is broken on some platforms
* [`49e79fb6`](https://github.com/NixOS/nixpkgs/commit/49e79fb61529569688fd51af1c22a7ba805cbf9c) ffmpeg_{4,6,7}: clean up old Darwin SDK pattern
* [`151d5da2`](https://github.com/NixOS/nixpkgs/commit/151d5da2e624159658d90e563e325b0c3844dfa2) ffmpeg_{4,6,7}: remove redundant Darwin framework feature flags
* [`927d45ec`](https://github.com/NixOS/nixpkgs/commit/927d45eccfd8e5f922d7a35c273bad359f035b73) ffmpeg_{4,6,7}: build with `apple-sdk_15`
* [`f108380d`](https://github.com/NixOS/nixpkgs/commit/f108380db7a157daf23e0fe957bda5690c58d2b6) openssh, openssh_hpn, openssh_gssapi: 9.8p1 -> 9.9p1 ([nixos/nixpkgs⁠#350699](https://togithub.com/nixos/nixpkgs/issues/350699))
* [`3157d712`](https://github.com/NixOS/nixpkgs/commit/3157d712e141272f48f7e93dc03afe84d018c35a) ruby.rubygems: 3.5.21 -> 3.5.22
* [`0855ae2c`](https://github.com/NixOS/nixpkgs/commit/0855ae2c46caa7787bc1d0825e8795011b6f8560) bundler: 2.5.21 -> 2.5.22
* [`a95abfd5`](https://github.com/NixOS/nixpkgs/commit/a95abfd5e49f4c6c6ca5336470e91bb88768ea0c) publicsuffix-list: 0-unstable-2024-09-10 -> 0-unstable-2024-10-25
* [`7fe6b335`](https://github.com/NixOS/nixpkgs/commit/7fe6b3351aff3129406e9ea057873497e3612f51) sword: enable Windows building
* [`9142a070`](https://github.com/NixOS/nixpkgs/commit/9142a070307ca6f18eb6e02aa2bca4855406680e) {bintools-wrapper,cc-wrapper}: factor out Darwin SDK logic
* [`b50611e7`](https://github.com/NixOS/nixpkgs/commit/b50611e7496742b3d83f955ef019f2bb3dfa2892) python312Packages.ipython: 8.27.0 -> 8.29.0
* [`48e5645c`](https://github.com/NixOS/nixpkgs/commit/48e5645c753744e8c956f14a5c836ea682abfbbd) liburing: 2.7 -> 2.8
* [`2f31fd06`](https://github.com/NixOS/nixpkgs/commit/2f31fd064f926b1f6534fe9d1ac134fc243ec591) ffmpeg_7: remove obsolete macOS 10.12 SDK patch
* [`e047c69e`](https://github.com/NixOS/nixpkgs/commit/e047c69ed406c834722b6ed7bb1bdd39d3e5eef0) {bintools-wrapper,cc-wrapper}: allow paths relative to the Darwin SDK
* [`9e49cb2a`](https://github.com/NixOS/nixpkgs/commit/9e49cb2ad9d1c0d58837ad757a3c5a4af2b401ca) stereotool: 10.30 -> 10.41
* [`53765b0f`](https://github.com/NixOS/nixpkgs/commit/53765b0fb33db341bd67a4d97a2fed3863457c80) darwin.stdenv: avoid building a second Python just for locales
* [`04ba4d1a`](https://github.com/NixOS/nixpkgs/commit/04ba4d1a3bbde89a862a5cfd03277aba7a51ff0b) bintools-wrapper: fix late‐bound command references
* [`eb4f33e1`](https://github.com/NixOS/nixpkgs/commit/eb4f33e14c9710f445963ec7698c0395273ee37d) cmake: Fix the FindCURL module
* [`1472acd7`](https://github.com/NixOS/nixpkgs/commit/1472acd79c091d5f481b039867c450e74e4224af) mpg123: 1.32.7 -> 1.32.8
* [`11aee2d2`](https://github.com/NixOS/nixpkgs/commit/11aee2d2258ac116368cd662df490e2553237dea) libgit2: 1.8.1 -> 1.8.3
* [`8817c2be`](https://github.com/NixOS/nixpkgs/commit/8817c2bed1b323adc1614be63fa731fbdcfe3810) opentelemetry-collector-contrib: 0.110.0 -> 0.112.0
* [`8fbfbf55`](https://github.com/NixOS/nixpkgs/commit/8fbfbf557a7aae568bf492710c34c9e75def8bf3) python312Packages.grpcio: fix src hash
* [`55dfed83`](https://github.com/NixOS/nixpkgs/commit/55dfed83c07faaa7aa9d279af787ec41b8baed9a) {bintools-wrapper,cc-wrapper}: export Darwin SDK variables
* [`fe04acd9`](https://github.com/NixOS/nixpkgs/commit/fe04acd93b8cdb6aed211bdce9b164b39b6fe03d) python312Packages.passlib: modernize and adopt
* [`714b0306`](https://github.com/NixOS/nixpkgs/commit/714b0306e33aa057e3f8a617644a05342053b03c) gjs: 1.82.0 -> 1.82.1
* [`0b96d8b9`](https://github.com/NixOS/nixpkgs/commit/0b96d8b9a46a67429bdd757b99431f0378691632) python312Packages.werkzeug: 3.0.4 -> 3.0.6
* [`a98b8f61`](https://github.com/NixOS/nixpkgs/commit/a98b8f618bd6fb8385c968cf64af814043bc8790) druid: 30.0.0 -> 31.0.0
* [`7876de73`](https://github.com/NixOS/nixpkgs/commit/7876de730fab6765086b8bc5cc6ad3f956f8ffed) druid: use mysql_jdbc directly
* [`e7744477`](https://github.com/NixOS/nixpkgs/commit/e774447767e998ae66203d2fceb5a326038e015e) python312Packages.scipy: 1.14.0 -> 1.14.1
* [`1f8bb94b`](https://github.com/NixOS/nixpkgs/commit/1f8bb94bcab905561b7e7e28fa9ff833ef77652c) pythonOutputDistHook: append *Phases with appendToVar
* [`c4bc1a8b`](https://github.com/NixOS/nixpkgs/commit/c4bc1a8bb6038a26ac3d18a84841428bdedbd711) pipBuildHook: handle pipBuildFlags `__structuredAttrs`-agnostically
* [`3a0f6fab`](https://github.com/NixOS/nixpkgs/commit/3a0f6fabff15e2e59847bfc6c9563cc37b21de0c) pipInstallHook: handle pipInstallFlags `__structuredAttrs`-agnostically
* [`8ccc5fb5`](https://github.com/NixOS/nixpkgs/commit/8ccc5fb53a766cb7e475505ea54227351a1f6d6e) smlfut: 1.3.0 -> 1.6.2
* [`cbcd37e2`](https://github.com/NixOS/nixpkgs/commit/cbcd37e27b5634cab6f787964d43a7ff0f33fc3e) maintainers: add whtsht
* [`7aa21ca5`](https://github.com/NixOS/nixpkgs/commit/7aa21ca5d32f9f0ac1d7f2053ed1d7f03ec564a5) bleep: 0.0.7 -> 0.0.9
* [`1f39bb65`](https://github.com/NixOS/nixpkgs/commit/1f39bb6586ec2e89076f8f8f562bfd388e749903) pypaBuildHook: handle pypaBuildFlags `__structuredAttrs`-agnostically
* [`69f48715`](https://github.com/NixOS/nixpkgs/commit/69f4871514c06e92dc4ead9491e4581efa9898f9) pypaBuildHook: lint with ShellCheck
* [`967e5b43`](https://github.com/NixOS/nixpkgs/commit/967e5b43ed61d2a2bf7b2d194aa2e51c2cfc1904) pythonImportsCheckHook: support __structuredAttrs = true
* [`34ebbd65`](https://github.com/NixOS/nixpkgs/commit/34ebbd650cbae6a973dc08bf91b230e0093507ce) pkgs/stdenv/generic/setup.sh: lint with ShellCheck
* [`6684bba9`](https://github.com/NixOS/nixpkgs/commit/6684bba9c262f0d0b3cc039d3f17b4ade2c81475) onlyoffice-desktopeditors: 8.1.1 -> 8.2.0
* [`e31f6269`](https://github.com/NixOS/nixpkgs/commit/e31f62694877434a58d79c95af82c2b4619a713b) onlyoffice-desktopeditors: cleanup
* [`7451482d`](https://github.com/NixOS/nixpkgs/commit/7451482dbe2fc2108b65b554d2a27047c4292e11) python311Packages.tesnsorflow: fix evaulation error
* [`593d7718`](https://github.com/NixOS/nixpkgs/commit/593d771826649ec9a41b37315e9ef0ae1cb6c53b) xterm: 394 -> 395 ([nixos/nixpkgs⁠#351129](https://togithub.com/nixos/nixpkgs/issues/351129))
* [`87fe6550`](https://github.com/NixOS/nixpkgs/commit/87fe6550bb0daa75864e6028d04c9c9d0efb3592) zed-editor: remove darwin workaround for isysroot
* [`d85a1e50`](https://github.com/NixOS/nixpkgs/commit/d85a1e50fea67aa559cb578efc4415cd6adc22ef) libsForQt5.qtbase: fix Darwin build by removing obsolete patches
* [`3be309ef`](https://github.com/NixOS/nixpkgs/commit/3be309eff11e2eb677199997cb653b1358ccd5fd) libsForQt5.qtbase: use the macOS 13 SDK
* [`38316856`](https://github.com/NixOS/nixpkgs/commit/38316856843f2d95aea429faec9357f0a5f122bb) libsForQt5.qtbase: override the Darwin deployment target correctly
* [`593334fa`](https://github.com/NixOS/nixpkgs/commit/593334fad2e0fbf90ea90562b705e1829cd70a7e) shadowenv: 2.1.2 -> 3.0.1
* [`951e05b4`](https://github.com/NixOS/nixpkgs/commit/951e05b4b794511edc00cae63f5a6f03d2b6f831) serd: set license as ISC instead of MIT
* [`de26abe6`](https://github.com/NixOS/nixpkgs/commit/de26abe63b3401b943aa7003a31177a8caadc054) serd: set myself as maintainer
* [`607282c1`](https://github.com/NixOS/nixpkgs/commit/607282c12a5d8b1db0da9ef35f5bb25f50e05f2b) serd: 0.30.16 → 0.32.2
* [`3cd9ca4e`](https://github.com/NixOS/nixpkgs/commit/3cd9ca4ee169ec1f0fecbaf1e332e189ad4afc4c) serd: reformat file
* [`47dc341f`](https://github.com/NixOS/nixpkgs/commit/47dc341f33e3a654f21c6467ae013eac5d088b80) mercurial: 6.8.1 -> 6.8.2
* [`7e8b51b0`](https://github.com/NixOS/nixpkgs/commit/7e8b51b0971b93b409a7384b9b2a8a19a62300ba) libopenmpt: 0.7.10 -> 0.7.11
* [`d08e6075`](https://github.com/NixOS/nixpkgs/commit/d08e607506d41a59fa49bcca7c6e870f5e330f14) libimobiledevice-glue: 1.3.0 -> 1.3.1
* [`975bf7a1`](https://github.com/NixOS/nixpkgs/commit/975bf7a1f5049eea9014f3d0e35b5aa024d9155f) alexandria: init at 0.12
* [`e24121ec`](https://github.com/NixOS/nixpkgs/commit/e24121ec205cef4cf69c15408ef57f95559f6f15) postgresqlPackages: replace custom installPhase with buildPostgresqlExtension helper
* [`f0e85b34`](https://github.com/NixOS/nixpkgs/commit/f0e85b34b8aaaec497401cf7767714b02da42725) stirling-pdf: 0.29.0 -> 0.30.1
* [`629cfe1d`](https://github.com/NixOS/nixpkgs/commit/629cfe1d2de0a9895dbb1ff09d3c6a34a1d196cb) sqlite: split man into man output, add documentation as doc
* [`0b45a711`](https://github.com/NixOS/nixpkgs/commit/0b45a711edaa0ae734facff6094df875500b7de6) clojure-lsp: 2024.04.22-11.50.26 -> 2024.08.05-18.16.00
* [`19ff2dc8`](https://github.com/NixOS/nixpkgs/commit/19ff2dc86ffae4f31d00a3030a9a506d881576bb) zitadel.console: remove mkYarnPackage usage
* [`17b0581c`](https://github.com/NixOS/nixpkgs/commit/17b0581c26f6ee1cfee771af1ffa83f5ea84d9d9) prometheus-graphite-exporter: 0.15.2 -> 0.16.0
* [`bca5688b`](https://github.com/NixOS/nixpkgs/commit/bca5688b013f19d8f3fa73979d0cd2039070863c) ecsk: init at 0.9.3
* [`389290be`](https://github.com/NixOS/nixpkgs/commit/389290becc535ae4f3b88f7c457cefec2a5febfe) k3s_1_31: 1.31.1+k3s1 -> 1.31.2+k3s1
* [`6fbdb9bc`](https://github.com/NixOS/nixpkgs/commit/6fbdb9bcf61e71204b4ed3e038dcc95ce3c5cc78) k3s_1_30: 1.30.5+k3s1 -> 1.30.6+k3s1
* [`5e5aa9dd`](https://github.com/NixOS/nixpkgs/commit/5e5aa9dd40d4d59d3245c66a1070172164a6f4a2) qt6Packages.qtbase: remove obsolete Darwin patch
* [`2b2e4d03`](https://github.com/NixOS/nixpkgs/commit/2b2e4d03e3a1f5ab568e741e78cae179cbebd01d) qt6Packages.qtbase: remove obsolete Darwin flags
* [`05054bce`](https://github.com/NixOS/nixpkgs/commit/05054bce8a1081fdb2ff9cc957e542d05dde7f59) cdparanoia: fix darwin; add security patches
* [`b3f04cd5`](https://github.com/NixOS/nixpkgs/commit/b3f04cd54216082f2e6742c6cc7fa8bced5b8eb0) xorg.xorgserver: 21.1.13 -> 21.1.14
* [`8ffcca7f`](https://github.com/NixOS/nixpkgs/commit/8ffcca7fd0a026abd76db0a113dc4633a863e415) maintainers: add robinkrahl
* [`d43f004d`](https://github.com/NixOS/nixpkgs/commit/d43f004d1fe473a5e039c222ef25aaadeff98633) nitrokey-udev-rules: init at 1.0.0
* [`1527445c`](https://github.com/NixOS/nixpkgs/commit/1527445c79f230d15b6a0e60ae0b53eaff44408c) calico-apiserver: 3.28.2 -> 3.29.0
* [`38ec993a`](https://github.com/NixOS/nixpkgs/commit/38ec993a582f85ed1a792d31dd162f24c21b5311) nixos/hardware.nitrokey: replace libnitrokey with nitrokey-udev-rules
* [`80c32496`](https://github.com/NixOS/nixpkgs/commit/80c324967361f32a5cf52376958069d10f716fc3) docker-compose: 2.29.7 -> 2.30.0
* [`0e190616`](https://github.com/NixOS/nixpkgs/commit/0e190616fa810e84b59539db4ca025222c1234d0) libbpf: 1.4.6 -> 1.4.7
* [`90263425`](https://github.com/NixOS/nixpkgs/commit/90263425c535c8b22aba636d933393af31bc805c) fava: 1.28 -> 1.29
* [`50e230c4`](https://github.com/NixOS/nixpkgs/commit/50e230c417c3925725c022e64d2907157918af8e) nixos/lomiri: nixfmt
* [`04a90ffd`](https://github.com/NixOS/nixpkgs/commit/04a90ffde20f9d1dccd074382d2a2d17c26908b9) ruby: fix cross build ([nixos/nixpkgs⁠#348566](https://togithub.com/nixos/nixpkgs/issues/348566))
* [`b363747a`](https://github.com/NixOS/nixpkgs/commit/b363747ac6d7edbb9f6ba9838731b04b821f4da9) pkgsStatic.dtc: fix build
* [`0b145d93`](https://github.com/NixOS/nixpkgs/commit/0b145d934850ec5e39f3fd911a2e5fa5f64b1994) nixos/lomiri: Add internal basics option for shared shell/greeter things
* [`de4db8a6`](https://github.com/NixOS/nixpkgs/commit/de4db8a6b0fcdc381f06fa4be26be42d9755d538) nixos/lightdm-greeters/lomiri: nixfmt
* [`d14f6e59`](https://github.com/NixOS/nixpkgs/commit/d14f6e598623f22ddc47427fa68a2013faae27a8) nixos/lightdm-greeters/lomiri: Enable lomiri.basics option for shared settings
* [`23e40c0c`](https://github.com/NixOS/nixpkgs/commit/23e40c0ca47b29ef2850a8ef7962e8ee06f7254b) tests/lomiri: Only enable greeter in greeter test
* [`8bd87707`](https://github.com/NixOS/nixpkgs/commit/8bd877070573af794906b3e101327dc60c493ec0) cargo-audit: 0.20.1 -> 0.21.0
* [`6cdaa970`](https://github.com/NixOS/nixpkgs/commit/6cdaa970796abda50fb7bc07e9f3c2c7cde7b13b) cargo-audit: nixfmt
* [`f7ee49ed`](https://github.com/NixOS/nixpkgs/commit/f7ee49edba4622d86dc8d24884e1399df9d75632) python312Packages.image-go-nord: add missing dependencies
* [`a7ea63b0`](https://github.com/NixOS/nixpkgs/commit/a7ea63b055915050fc95d282e9509f8f112ba9b7) python312Packages.image-go-nord: modernize
* [`11769efa`](https://github.com/NixOS/nixpkgs/commit/11769efa2ca56ccb29bd0c306d19c79e124be10f) python312Packages.image-go-nord: 1.1.0 -> 1.2.0
* [`267cbff4`](https://github.com/NixOS/nixpkgs/commit/267cbff491b8181132723bd29b56c2d4b5030ab3) typst-live: 0.7.0 -> 0.8.0
* [`11d7d33e`](https://github.com/NixOS/nixpkgs/commit/11d7d33ef05b4c7c66cce78130ae49ac2c83e6e1) typst-live: nixfmt
* [`bed43b44`](https://github.com/NixOS/nixpkgs/commit/bed43b44613d2c4b130c1a66ee9a5e0c6ac6f60a) nixos/hardware.nitrokey: update documentation
* [`df73f7de`](https://github.com/NixOS/nixpkgs/commit/df73f7de42be5cdc3e90bc035a5e7ab88d06c63e) pghero: 3.5.0 -> 3.6.1
* [`af521fac`](https://github.com/NixOS/nixpkgs/commit/af521fac004ff958995d9b854839ba3516507623) vault: 1.18.0 -> 1.18.1
* [`9e3959fb`](https://github.com/NixOS/nixpkgs/commit/9e3959fbe5dfd40e872c1c15baee6371073289e8) vault-bin: 1.18.0 -> 1.18.1
* [`beda4661`](https://github.com/NixOS/nixpkgs/commit/beda46612acfdff1ca6bd2c2bf20b21290c43136) serd: move to pkgs/by-name
* [`4026e886`](https://github.com/NixOS/nixpkgs/commit/4026e88664f772ce81584390588e149dd6871ad4) rustc: use 1.82.0 binary to bootstrap rustc 1.82.0
* [`7011a66b`](https://github.com/NixOS/nixpkgs/commit/7011a66b4d498f1e68788ba74948c8b5f36126bc) nixos/tests/k3s/etcd: add etcd health check
* [`96d76639`](https://github.com/NixOS/nixpkgs/commit/96d76639f1ae781f9621c2ec35f46ded0c231d35) anytype: 0.43.1 -> 0.43.4
* [`171d2191`](https://github.com/NixOS/nixpkgs/commit/171d219159ca09d153bac48dc24ee40534e2f4b2) caneda: 0.3.1 -> 0.4.0
* [`c73d5f09`](https://github.com/NixOS/nixpkgs/commit/c73d5f09c5bcb9603d90a25af1088fa234e014fe) duckscript: 0.9.3 -> 0.11.1
* [`6030ff06`](https://github.com/NixOS/nixpkgs/commit/6030ff068ad72c6fe0671a113fa19eb7d48816c1) gnuplot: fix build with `withTeXLive = true`
* [`343d3333`](https://github.com/NixOS/nixpkgs/commit/343d3333ef172794deba624658bcac961f417550) maintainers: add bhasherbel
* [`1301e4f0`](https://github.com/NixOS/nixpkgs/commit/1301e4f0b024dfe7f11b921c798a35dab2d339d5) pyamlboot.tests: fix the eval
* [`3c433c91`](https://github.com/NixOS/nixpkgs/commit/3c433c914456d4bca2eaf5b0a3e71bd20f20a6c5) elpa2nix: inline string-empty-p to support Emacs 26
* [`214c684c`](https://github.com/NixOS/nixpkgs/commit/214c684c831233466676894e7a043523a370bbeb) composefs: 1.0.6 -> 1.0.7
* [`933687c9`](https://github.com/NixOS/nixpkgs/commit/933687c9a28a2525153dc24e04544035bff63aa0) tdb: 1.4.10 -> 1.4.11
* [`2167c83d`](https://github.com/NixOS/nixpkgs/commit/2167c83d18f176f516dbb9e96f5952fb3571b6a6) gcs: 5.27.0 -> 5.28.1
* [`507c5dd2`](https://github.com/NixOS/nixpkgs/commit/507c5dd2327ef9f5dd583ef83f37f9d8f638e74b) neovim: remove uneffective substituteInPlace patches ([nixos/nixpkgs⁠#352855](https://togithub.com/nixos/nixpkgs/issues/352855))
* [`2d0e1f80`](https://github.com/NixOS/nixpkgs/commit/2d0e1f80465c3d7e4d5acfbbe0e1a538944a81e5) sgx-psw: 2.24 -> 2.25
* [`6524b078`](https://github.com/NixOS/nixpkgs/commit/6524b07894a4e4377c258a536a301e4199f68b2c) aesmd: allow overriding sgx-psw package manually
* [`bf4d9cd7`](https://github.com/NixOS/nixpkgs/commit/bf4d9cd72342e25a1c2b7f299fc0bbdf20bae29c) libgit2: 1.8.3 -> 1.8.4
* [`12b06705`](https://github.com/NixOS/nixpkgs/commit/12b06705433588471ab7d3eaa3ac5232d9f735fb) maintainers: add arminius-smh
* [`e918946e`](https://github.com/NixOS/nixpkgs/commit/e918946e67fe5a1e41ffea6b92910c47feb04eb9) python312Packages.vulcan-api: 2.4.0 -> 2.4.1
* [`5162b70d`](https://github.com/NixOS/nixpkgs/commit/5162b70d6ef9ac3910f572d4bb536bbe3211c11a) python312Packages.vulcan-api: switch to pypa builder
* [`d4997d08`](https://github.com/NixOS/nixpkgs/commit/d4997d0868243c612344b06cb086556e68e543ae) xivlauncher 1.1.0 -> 1.1.1
* [`965d43f2`](https://github.com/NixOS/nixpkgs/commit/965d43f2041c3572d915238ffe81130791cc2f8e) clevis: 20 -> 21
* [`a13ba9b3`](https://github.com/NixOS/nixpkgs/commit/a13ba9b3667c3d8187339dbe4eabe3082e5e212b) libusb1: fix Android build
* [`7642cf2b`](https://github.com/NixOS/nixpkgs/commit/7642cf2bdcb5d7e14ec9bcf939a81c1490b76e96) kangaru: init at 4.3.2
* [`00911fc4`](https://github.com/NixOS/nixpkgs/commit/00911fc4d83b72bc0ce8b5de275c9e69c9d55e57) devbox: 0.13.4 -> 0.13.6
* [`7e7dce44`](https://github.com/NixOS/nixpkgs/commit/7e7dce448e687f84aa1628ecc812adb919aaa072) sphinx: disable racy test
* [`26b46c0c`](https://github.com/NixOS/nixpkgs/commit/26b46c0cf611e79655d7a65b03105326e98bd76f) python312Packages.mlflow: 2.16.2 -> 2.17.2
* [`aaeeef5b`](https://github.com/NixOS/nixpkgs/commit/aaeeef5b6c7848a7569cb7a1f651550d0e5f8327) stdenv: fix custom hardening settings when using `__structuredAttrs = true;`
* [`ed28ebdb`](https://github.com/NixOS/nixpkgs/commit/ed28ebdbb4de2cd110c7641716b140cd5522107b) qt6Packages.*: don’t propagate Darwin version inputs
* [`4e3c8f45`](https://github.com/NixOS/nixpkgs/commit/4e3c8f45a53fdbcccaf7bc250a7da50a14a21149) libsForQt5.*: consistently build with the macOS 13 SDK
* [`8aaea378`](https://github.com/NixOS/nixpkgs/commit/8aaea3781cca59530315eafe70f3d65a03d72657) libsForQt5.*: don’t propagate Darwin version inputs
* [`fa8ce61a`](https://github.com/NixOS/nixpkgs/commit/fa8ce61acd0d057dd3859f9518d2545ecd1d52e8) llvmPackages_19.compiler_rt: don't codesign
* [`0efe75ec`](https://github.com/NixOS/nixpkgs/commit/0efe75ec20e0275a4b8de31aabd713613f56bfe7) libffi: move label before .cfi_starproc
* [`f91487fa`](https://github.com/NixOS/nixpkgs/commit/f91487fa13dd5d5cd5ff95982e7c00cebb744f02) ld64: fix build with llvm19
* [`0fc97876`](https://github.com/NixOS/nixpkgs/commit/0fc9787683e6fef5eaf1b6de5f1f2592c2ab0b19) darwin.stdenv: add file to early stdenv stages
* [`1fb8dbc6`](https://github.com/NixOS/nixpkgs/commit/1fb8dbc65a97ce88f6a23c09a8101fea41d0f2c6) libjpeg: drop freeimage from passthru tests
* [`687371ab`](https://github.com/NixOS/nixpkgs/commit/687371ab28358ca878a93f4ef4884bfecf0ac40c) auto-patchelf: Don't use buildPythonApplication
* [`285f0932`](https://github.com/NixOS/nixpkgs/commit/285f0932e74da3f0536c7bf3f3673ec800d74857) bubblewrap: 0.10.0 -> 0.11.0
* [`d81b4fe1`](https://github.com/NixOS/nixpkgs/commit/d81b4fe176b1297e1d5aa75496fdcd6a52d235d1) portaudio: use implicit apple-sdk pattern
* [`da336797`](https://github.com/NixOS/nixpkgs/commit/da33679726fcef7d3f224956113eeab47db3e285) python312Packages.aiohttp-retry: 2.8.3 -> 2.9.0
* [`93f02acd`](https://github.com/NixOS/nixpkgs/commit/93f02acdb4df2f571e6d105374aeff4d0879f7a2) python312Packages.aiohttp-retry: refactor
* [`510f48f0`](https://github.com/NixOS/nixpkgs/commit/510f48f0b9280c33863c0a0c032a7df60405490f) python311Packages.langchain-openai: disable failing test
* [`2d6343f7`](https://github.com/NixOS/nixpkgs/commit/2d6343f7b79246493151caaad2c439d6a5de6abf) python312Packages.twilio: aiounittest is not supported oyn Python 3.12
* [`73d9296e`](https://github.com/NixOS/nixpkgs/commit/73d9296e98f3542f693aa7f3fcea87302320a411) python312Packages.sagemaker: relax attrs
* [`bd112af1`](https://github.com/NixOS/nixpkgs/commit/bd112af16a933ac573b2e97eb1932e6769a13511) hyprlauncher: init at 0.1.2
* [`9b7877aa`](https://github.com/NixOS/nixpkgs/commit/9b7877aa1fc7b61d4803d995eed207f54af10a5a) kubectl-graph: init at 0.7.0
* [`e166c9bb`](https://github.com/NixOS/nixpkgs/commit/e166c9bb94431551b3ac4c0674261144171e5775) apple-sdk: only rewrite old SDK paths
* [`19fd3f03`](https://github.com/NixOS/nixpkgs/commit/19fd3f030da2876f86ffbd3d99f0b24b4a81ee14) waf: 2.1.2 -> 2.1.3
* [`1e49cbef`](https://github.com/NixOS/nixpkgs/commit/1e49cbefaca3da759c56fce4f0e9f0d460bd5e93) jazz2: 2.9.0 -> 2.9.1
* [`03524a85`](https://github.com/NixOS/nixpkgs/commit/03524a85944df4da965439214cdde665cdf0ac0c) gssdp: fix cross compilation
* [`a99d2b7d`](https://github.com/NixOS/nixpkgs/commit/a99d2b7d4fe9c5f12bd7d21f61aaa4f228bbc894) python312Packages.paste: use `pyproject = true`
* [`f9954062`](https://github.com/NixOS/nixpkgs/commit/f9954062369e7426938a1bcb97ddaa354bbe47f1) python312Packages.pastedeploy: 3.0.1 -> 3.1
* [`775052b0`](https://github.com/NixOS/nixpkgs/commit/775052b00985257dbfc82af26156350be0a07b59) chafa: 1.14.4 -> 1.14.5
* [`42f60c5c`](https://github.com/NixOS/nixpkgs/commit/42f60c5c2a69f10b5be379ca1dd4b847020f16ef) python3Packages.moto: add onny as maintainer
* [`eb9cde0d`](https://github.com/NixOS/nixpkgs/commit/eb9cde0d3a9d5598459d77903da58c54ebfb9cf0) python3Packages.moto: reformat
* [`583c82b1`](https://github.com/NixOS/nixpkgs/commit/583c82b1211b46c2e382cfcfd2d7d3940130d78c) python3Packages.moto: 5.0.15 -> 5.0.18
* [`e1e75e69`](https://github.com/NixOS/nixpkgs/commit/e1e75e691ef2699139d309edcac88aaca48eec30) python312Packages.cassandra-driver: 3.29.1 -> 3.29.2
* [`18d48aa7`](https://github.com/NixOS/nixpkgs/commit/18d48aa758d1109490e78139df7e6acc85bdc203) ffmpeg: add librist
* [`ff546ee4`](https://github.com/NixOS/nixpkgs/commit/ff546ee4f31c357117eb4741e41f355fe476f951) tetrio-plus: split tpsecore into seperate package
* [`5a10946c`](https://github.com/NixOS/nixpkgs/commit/5a10946c77cdf0395f2bff82347a80199250fda0) libvpx: 1.14.1 -> 1.15.0
* [`9a023e53`](https://github.com/NixOS/nixpkgs/commit/9a023e536d952be7d83df05075a83abc4d0ec93b) graphviz: 12.1.2 -> 12.2.0
* [`baa84c3c`](https://github.com/NixOS/nixpkgs/commit/baa84c3c68321678857d6a0627a8c6b814492b86) nim-2_0: 2.0.10 -> 2.0.12
* [`1fe651e7`](https://github.com/NixOS/nixpkgs/commit/1fe651e76ca98dee8fb10f715cb2c9312d8f4714) monolith: add nix update script
* [`26c3a41f`](https://github.com/NixOS/nixpkgs/commit/26c3a41f6bbcd14e0e94da776d7f07ebfef62bea) python312Packages.moto: add (trivial) `sns` optional dependency
* [`37226af6`](https://github.com/NixOS/nixpkgs/commit/37226af6e86f5046ae4d11d959dfc0b51be9a32a) python312Packages.great-expectations: init at 1.2.1
* [`e2210c0e`](https://github.com/NixOS/nixpkgs/commit/e2210c0ebc861bd60710ea4008316297411d3d6a) dhcpcd:  10.0.6 -> 10.1.0
* [`0a4aaa9d`](https://github.com/NixOS/nixpkgs/commit/0a4aaa9d9a73735890cc7dca8db14c1aea0cb189) pkgs/stdenv/freebsd: update x86_64-unknown-freebsd bootstrap-files
* [`5b136316`](https://github.com/NixOS/nixpkgs/commit/5b136316aacadd0447dc24ba04c449d287ca8cea) pkgsi686Linux.swtpm: pull upstream 64-bit file api fix
* [`bab7ef30`](https://github.com/NixOS/nixpkgs/commit/bab7ef307cb11e2d2dc9b9ddf2d1de68f220ed45) pythonImportsCheckHook: lint with ShellCheck
* [`ccb418b6`](https://github.com/NixOS/nixpkgs/commit/ccb418b69938ebdac9337baa9cdceeb43b3497cd) pythonNamespacesHook: lint with ShellCheck
* [`e4f2f9dd`](https://github.com/NixOS/nixpkgs/commit/e4f2f9dd22db433d54c9c3e25fc6cee6c3471d09) pythonOutputDistHook: lint with ShellCheck
* [`3a79bc3a`](https://github.com/NixOS/nixpkgs/commit/3a79bc3aee323c79b534cb5ca80d85daf60b4182) pythonRelaxDepsHook: handle attributes `__structuredAttrs`-agnostically
* [`29c08ada`](https://github.com/NixOS/nixpkgs/commit/29c08adae171f1c273a0a15c00068205a9965bf2) pythonRelaxDepsHook: lint with ShellCheck
* [`65293f42`](https://github.com/NixOS/nixpkgs/commit/65293f424779e4df5d892e955dd03cf8d0ed84b0) pythonRemoveTestDirHook: lint with ShellCheck
* [`e32457af`](https://github.com/NixOS/nixpkgs/commit/e32457af0c9de65a4d3f57afd8b4c238da65d07a) setuptoolsRustHook: lint with ShellCheck
* [`6597b74f`](https://github.com/NixOS/nixpkgs/commit/6597b74fea10a79f09ef3fbcf02620e238992845) pypaBuildHook.tests: modernize
* [`b048be05`](https://github.com/NixOS/nixpkgs/commit/b048be052ccff215e125b9fbef825f296dcbe599) Reapply "less: Fix withSecure regression"
* [`e510e227`](https://github.com/NixOS/nixpkgs/commit/e510e227beafdd3bcb5b4a3c0f6feefcb0d40c21) kitty: Binary wrap kitty, and sign on darwin
* [`7d1abc0f`](https://github.com/NixOS/nixpkgs/commit/7d1abc0fc5a6c07c1b8942f92c377a016be34174) musescore: apple-sdk migration, removed portaudio override
* [`31fd3a6f`](https://github.com/NixOS/nixpkgs/commit/31fd3a6fe95deee382055dcc4244c2cfa20ef17b) cocoapods: 1.15.1 -> 1.16.2
* [`920eac09`](https://github.com/NixOS/nixpkgs/commit/920eac097f5c355adc0321d44f24032b1faa38a7) gfie: init at 4.2
* [`2a276628`](https://github.com/NixOS/nixpkgs/commit/2a27662845330f07c481baf066053b6b53f5afd8) maintainers: add jhol
* [`c2a6507f`](https://github.com/NixOS/nixpkgs/commit/c2a6507f0591367017d46574884f92493fb01a29) sphinxcontrib-moderncmakedomain init at 3.29.0
* [`c8df6697`](https://github.com/NixOS/nixpkgs/commit/c8df66973b396186ced7e81f0dd3e475bf77d3b8) xcbuild: look in system toolchain for binaries on `/usr/bin`
* [`7ae8a1e5`](https://github.com/NixOS/nixpkgs/commit/7ae8a1e519de8d316830a73f119c2e19234d7a58) xcbuild: suppress warnings for unknown keys
* [`d65243dc`](https://github.com/NixOS/nixpkgs/commit/d65243dcef837233696bedb61e323ca2fd007ecf) nixos/gotosocial: fix failing tests
* [`17cc7a6f`](https://github.com/NixOS/nixpkgs/commit/17cc7a6f16065d96d3352aea749154ee401b53e3) darwin.libutil: use bootstrap SDK
* [`877e3454`](https://github.com/NixOS/nixpkgs/commit/877e3454bb9ffa10287f068742d05159c14b4574) apple-sdk: propagate the `darwin.libutil` library
* [`ee802060`](https://github.com/NixOS/nixpkgs/commit/ee802060b85f8e7d82af36de60a21320c9ec50a9) neovim-unwrapped: drop `darwin.libutil` dependency
* [`22f2052c`](https://github.com/NixOS/nixpkgs/commit/22f2052ca1e7b7cfb4b090faa2d924c3e27e4742) python{27,39,310,311,312,313,314}: drop Darwin `libutil` patch
* [`70f47b08`](https://github.com/NixOS/nixpkgs/commit/70f47b08a068ddbf48e580fe0cdd176ef36b961d) python312Packages.caldav: 1.3.9 -> 1.4.0
* [`a70af477`](https://github.com/NixOS/nixpkgs/commit/a70af477b19cf3874dc8ddfe80dd01cdfe21e5db) libfmvoice: 0-unstable-2024-06-06 -> 0-unstable-2024-11-03
* [`ecff2204`](https://github.com/NixOS/nixpkgs/commit/ecff2204449afc1ced32878fc673808451e61000) libfmvoice: nixfmt
* [`e90e71b3`](https://github.com/NixOS/nixpkgs/commit/e90e71b3069d4f05b3dd3221f3f2cc5090a9d45e) libfmvoice: Drop meta-wide "with lib;"
* [`833eebc0`](https://github.com/NixOS/nixpkgs/commit/833eebc021af388fd917d74bb68bb6c76c6caa96) python312Packages.bidsschematools: init at 0.11.3
* [`cd2d4944`](https://github.com/NixOS/nixpkgs/commit/cd2d4944bedfac8de96e70844c25cc3719219fb7) python312Packages.bids-validator: fix build
* [`221b2afe`](https://github.com/NixOS/nixpkgs/commit/221b2afe734658cc09f2b9fdec0cc1783990b0f0) python312Packages.pybids: fix build
* [`c55530f9`](https://github.com/NixOS/nixpkgs/commit/c55530f978aaa224bc6d64f2f134f7fdbbedc42e) curl: 8.10.1 -> 8.11.0
* [`63def528`](https://github.com/NixOS/nixpkgs/commit/63def5281884dd422797668e7de9eda0c507dccf) pinact: 0.2.1 -> 1.0.0
* [`2d79445d`](https://github.com/NixOS/nixpkgs/commit/2d79445d164f68a558f8e349861dc1ef2f3f03aa) libsForQt5.pix: nixfmt
* [`3ea10f99`](https://github.com/NixOS/nixpkgs/commit/3ea10f99b7cb0c6fa7ab56f082030c7cfea97ae2) libsForQt5.pix: fix build
* [`3e646301`](https://github.com/NixOS/nixpkgs/commit/3e646301a07eb30da02f8c7775f6b3865c0ebac2) smartcat: 1.7.1 -> 2.1.0
* [`ef7e5af4`](https://github.com/NixOS/nixpkgs/commit/ef7e5af4a45e36a69286663f06314179bf2949c8) cosmic-settings-daemon: use make install
* [`cee9a79a`](https://github.com/NixOS/nixpkgs/commit/cee9a79a82a71cdd042b472b069ed1950ec11939) mtm: drop `darwin.libutil` dependency
* [`6c32a119`](https://github.com/NixOS/nixpkgs/commit/6c32a119a5f768a8678c0b9a2ff6433f8b879e0c) eternal-terminal: drop `darwin.libutil` dependency
* [`c87f921f`](https://github.com/NixOS/nixpkgs/commit/c87f921f5066cc6d2bd4aa04688ab9ad2c47de09) mg: drop `darwin.libutil` dependency
* [`ec62a8ee`](https://github.com/NixOS/nixpkgs/commit/ec62a8ee9dd48f29e3982b14eba72e5f0a9b61f1) chibi: drop `darwin.libutil` dependency
* [`3602fc32`](https://github.com/NixOS/nixpkgs/commit/3602fc321de115df5d441cb2d2bc3bec2a84ef04) abduco: drop `darwin.libutil` dependency
* [`45b28d97`](https://github.com/NixOS/nixpkgs/commit/45b28d976f0d217e42a0173e61a21d0ec04a42ab) nixos/mopidy: fix Python dependency collisions between extensions
* [`181f4aec`](https://github.com/NixOS/nixpkgs/commit/181f4aec8990d59b13be0efcd20d15975e398f24) ft2-clone: 1.86 -> 1.88
* [`bafae5bf`](https://github.com/NixOS/nixpkgs/commit/bafae5bf436a988527a79273c19058cd9e4a4a65) lib/licenses: set spdx for Ubuntu font license
* [`568bb8c2`](https://github.com/NixOS/nixpkgs/commit/568bb8c275e0460888c805fbddfcc991ac898dbe) lib/licenses: remove urls from licenses that have a spdxId
* [`8ec09813`](https://github.com/NixOS/nixpkgs/commit/8ec0981318b393e644f6967db0be5f5e7765a90f) pingvin-share: 1.1.3 -> 1.2.4
* [`ad6564b0`](https://github.com/NixOS/nixpkgs/commit/ad6564b0c33fda65c92544f18e67e3c8da25147d) nixos/pingvin-share: update env variable name
* [`0a785f6f`](https://github.com/NixOS/nixpkgs/commit/0a785f6f426b3bf4e9cae68613c5e1c27bcd4191) nixos/gdm: automatically enable services.displayManager
* [`7eb77986`](https://github.com/NixOS/nixpkgs/commit/7eb779860dafba203b048a56c0ee29ed5fb4303b) llvmPackages_19.libclc: use unwrapped clang only
* [`1ab5205f`](https://github.com/NixOS/nixpkgs/commit/1ab5205fbbfa29497a53b71f2fdf8ba12e0fe641) llvmPackages_19.bolt: upstream patch to fix darwin build
* [`3cd45d08`](https://github.com/NixOS/nixpkgs/commit/3cd45d08ee502f9de7391f59d60fa13c106c5838) llvmPackages_19: 19.1.1 -> 19.1.3
* [`65835ab8`](https://github.com/NixOS/nixpkgs/commit/65835ab8d2a4339d9a7404b28ab1ea6e536a3531) python312Packages.templateflow: fix build
* [`10a2c9d7`](https://github.com/NixOS/nixpkgs/commit/10a2c9d7b8fad0ed4f3f869281ffb1778bf9aec6) superhtml: 0.5.0 -> 0.5.1
* [`67cf25d7`](https://github.com/NixOS/nixpkgs/commit/67cf25d7f4a5f7e234fed3dd273d4d21641de3a0) apbs: drop unnecessary Darwin dependencies
* [`1b080335`](https://github.com/NixOS/nixpkgs/commit/1b080335df4b69cd23231aae445897759787faff) uhdm: drop `darwin.libutil` dependency
* [`81a67492`](https://github.com/NixOS/nixpkgs/commit/81a67492e9ee7e46028823f8b8fcc703373197c6) surelog: drop `darwin.libutil` dependency
* [`d1e72625`](https://github.com/NixOS/nixpkgs/commit/d1e72625646d84fd1781ef818e5619ccfddcfafb) pypy{27,39,310}: drop `darwin.libutil` dependency
* [`7863b8cf`](https://github.com/NixOS/nixpkgs/commit/7863b8cf18a5a895c85d3b22cc2e8b6007596380) netbsd.install: drop `darwin.libutil` dependency
* [`6bcccb6a`](https://github.com/NixOS/nixpkgs/commit/6bcccb6a8d8c3d0072ac4e166abb52c73fbd3643) fnc: drop `darwin.libutil` dependency
* [`5af01c33`](https://github.com/NixOS/nixpkgs/commit/5af01c33cd74f9d5fb4781025f9befd7a95ff451) fnc: set minimum version for Darwin
* [`59da82bf`](https://github.com/NixOS/nixpkgs/commit/59da82bf02fa2adc654482e464b0aaf79d4d5d6b) macvim: drop `darwin.libutil` dependency
* [`9bf6e339`](https://github.com/NixOS/nixpkgs/commit/9bf6e33999fd2409b443f1a5ba85b36a880dcc15) libuv: clarify `darwin.libutil` dependency
* [`b67fdd50`](https://github.com/NixOS/nixpkgs/commit/b67fdd5017e36c31b4925afe42d90c447bb1aedb) slumber: 2.1.0 -> 2.2.0
* [`514bd9d7`](https://github.com/NixOS/nixpkgs/commit/514bd9d7401af2e744d1cee8d41a410d1d5fda3f) go_1_23: 1.23.2 -> 1.23.3
* [`f144fc5b`](https://github.com/NixOS/nixpkgs/commit/f144fc5b96af309f1c50f540be0208568e33bf1f) mpdecimal: use absolute library install names on Darwin
* [`cb37e29e`](https://github.com/NixOS/nixpkgs/commit/cb37e29e3c52e3473770cadb1a241cb190b908e9) expat: 2.6.3 -> 2.6.4
* [`dc697d61`](https://github.com/NixOS/nixpkgs/commit/dc697d618e81a7667a759c1b8362c8e5179ffeb2) mesa: 24.2.5 -> 24.2.6
* [`2a61b919`](https://github.com/NixOS/nixpkgs/commit/2a61b919d2d3f397f6878eee8091a2459757cc1d) darwin.copyfile: use a bootstrap SDK
* [`074f9340`](https://github.com/NixOS/nixpkgs/commit/074f93408e5a6dc579d6d01f44f49d63c4bbfb2b) proton-vpn-local-agent: 0-unstable-2024-10-10 -> 1.0.0
* [`f4485f7c`](https://github.com/NixOS/nixpkgs/commit/f4485f7c41af12264a842741a20f975d742250c5) python3Packages.proton-vpn-api-core: 0.35.5 -> 0.36.4
* [`0e174ba6`](https://github.com/NixOS/nixpkgs/commit/0e174ba654b787fc2d4694ecdb336b1933ef31c5) python3Packages.proton-vpn-network-manager: 0.9.1 -> 0.9.4
* [`b32690dd`](https://github.com/NixOS/nixpkgs/commit/b32690dd8b1aec230452544ced44818f70aea53f) audiobookshelf: 2.16.1 -> 2.16.2
* [`b83ad8ea`](https://github.com/NixOS/nixpkgs/commit/b83ad8ea1e52f482e0bab4e4215a775ab9004a54) fyi: init at 1.0.4
* [`d56656e4`](https://github.com/NixOS/nixpkgs/commit/d56656e48729aa407f43dbf97020c1380d93d8a2) yosys: 0.46 -> 0.47
* [`b45392ec`](https://github.com/NixOS/nixpkgs/commit/b45392ecb998cf3d2aea426ac629f52af986dc2c) metadata: Update ffmpeg-next dependency
* [`345b20f1`](https://github.com/NixOS/nixpkgs/commit/345b20f15fcc1a0544ceb06fbd3d5c23e5533d5d) python312Packages.pygreat: 2019.5.1.dev0 -> 2024.0.2
* [`c455166b`](https://github.com/NixOS/nixpkgs/commit/c455166b5f3e62357fd0c40be2721dd78c36cfca) python{27,39,310,311,312,313,314}: use a bootstrap SDK on Darwin
* [`ad625dd1`](https://github.com/NixOS/nixpkgs/commit/ad625dd17211a42d6e19513e61bdf1382bb89602) stdenv/darwin: fix SDK overlays for macOS SDK < 11
* [`38835c82`](https://github.com/NixOS/nixpkgs/commit/38835c82566164a08de5b95531a65ca4a261ec1b) stdenv/darwin: add `darwin.{libutil,copyfile}` to SDK packages
* [`a061b02a`](https://github.com/NixOS/nixpkgs/commit/a061b02a6fc13985524e3fb5bf1da25b950d42ef) Revert "python{27,39,310,311,312,313,314}: use a bootstrap SDK on Darwin"
* [`b79f5f98`](https://github.com/NixOS/nixpkgs/commit/b79f5f98fc3e3c698012ed4ccedf9a6bc4fcb777) yabridge: 5.1.0 -> 5.1.1
* [`cf166c43`](https://github.com/NixOS/nixpkgs/commit/cf166c43d9e6ef512b8c23f783c68348682d7099) binary: 5.0 -> 5.1
* [`9c8c11f5`](https://github.com/NixOS/nixpkgs/commit/9c8c11f5c2d1dc232f26335c3e5a98805ce7458b) binary: run meson checks
* [`ae4fd669`](https://github.com/NixOS/nixpkgs/commit/ae4fd669e4a5be2038fde3519dce1d79f450be0c) qt6.wrapQtAppsHook: add `qtwayland` to `propagatedBuildInputs`
* [`b7cd0d3c`](https://github.com/NixOS/nixpkgs/commit/b7cd0d3c885afc3e087ea54ed568baaee0bee7ce) qt6.wrapQtAppsNoGuiHook: init
* [`f542c493`](https://github.com/NixOS/nixpkgs/commit/f542c493ada97abfc785a33bf2eb61b7516f2b52) qt6.qtwayland: set meta.{platforms,badPlatforms}
* [`ff6a0848`](https://github.com/NixOS/nixpkgs/commit/ff6a0848ca8066e21fd2a64167cf3a002ea39a13) qt6.wrapQtAppsHook: Only propagate plugins,qml of `qtwayland`
* [`9501a205`](https://github.com/NixOS/nixpkgs/commit/9501a2053937d1783e69d29d968014ceb388df12) qtbase-setup-hook: add wrapQtAppsNoGuiHook to error message
* [`a2d3be9d`](https://github.com/NixOS/nixpkgs/commit/a2d3be9d042eecca5eb45a40cf148c62613dcee9) deepin.dde-application-manager: use wrapQtAppsNoGuiHook to avoid propagating qtwayland
* [`89fd7716`](https://github.com/NixOS/nixpkgs/commit/89fd77165500d7488a89a84a78a1b7b1507d8e3e) pineapple-pictures: let wrapQtAppsHook propagate qtwayland
* [`98774a34`](https://github.com/NixOS/nixpkgs/commit/98774a34c85a160386f0b8419364b8eb4867fcba) doc/qt: Mention propagates and wrapQtAppsNoGuiHook
* [`c8aec3b2`](https://github.com/NixOS/nixpkgs/commit/c8aec3b28a36121fce3a8ee71c7c64535e7f45e5) qt: editing pass on docs
* [`9823494b`](https://github.com/NixOS/nixpkgs/commit/9823494bcf4ecbabef763cae9175bd782d473a8a) commit: 4.1 -> 4.2
* [`9341dc94`](https://github.com/NixOS/nixpkgs/commit/9341dc94dd3364112badb26f8ed2cd099db43c38) commit: run meson checks & cleanup
* [`86bce4ea`](https://github.com/NixOS/nixpkgs/commit/86bce4eacfe6eadd7fce771cb8d68d7f50e4de34) nextcloud28Packages: update
* [`1b3e6846`](https://github.com/NixOS/nixpkgs/commit/1b3e684650619779fb06d0259a8d5d724199d049) nextcloud29Packages: update
* [`eeed6404`](https://github.com/NixOS/nixpkgs/commit/eeed6404193897f90a17be00465e6a004a8830f9) nextcloud30Packages: update
* [`fe896ca8`](https://github.com/NixOS/nixpkgs/commit/fe896ca861eb2431863d25f9f8da7b4bd980c012) nextcloud28: 28.0.11 -> 28.0.12
* [`a8eba43f`](https://github.com/NixOS/nixpkgs/commit/a8eba43f1103efeac998dcbd790cd921900d2053) nextcloud29: 29.0.8 -> 29.0.9
* [`19a8336a`](https://github.com/NixOS/nixpkgs/commit/19a8336a3a05e8cb4216abf404cec9b15bbeaf9c) nextcloud30: 30.0.1 -> 30.0.2
* [`f81a2c15`](https://github.com/NixOS/nixpkgs/commit/f81a2c1514a05bb864698ee620cee9f80d759b9e) fix: use selected package instead of pkgs.vector
* [`95f26049`](https://github.com/NixOS/nixpkgs/commit/95f260494a9b649769140bf759ab537ed8c9acd2) identity: 0.6.0 -> 0.7.0
* [`e0784fad`](https://github.com/NixOS/nixpkgs/commit/e0784fad5f822b4665c26b8e4eeadf29f57fb9aa) identity: run checks
* [`fbcf9627`](https://github.com/NixOS/nixpkgs/commit/fbcf962708ba159bbb7c3b80a0e73ce4dc21424d) identity: use best practices & cleanup
* [`6952de9c`](https://github.com/NixOS/nixpkgs/commit/6952de9ce100bc4231b6d610b76ff409e8b60df8) identity: use versionCheckHook
* [`6e91bba9`](https://github.com/NixOS/nixpkgs/commit/6e91bba94d11159626d5ab6eb23fdc619ee93adb) identity: add meta.changelog
* [`182f3d07`](https://github.com/NixOS/nixpkgs/commit/182f3d0737ede9acaa15aa28da6c5f6712b1e4f8) garnet: 1.0.18 -> 1.0.36
* [`277a2669`](https://github.com/NixOS/nixpkgs/commit/277a2669d2a5600435c4f0a4c29b93cd3833cea9) gobject-introspection: Conditionalize `depsTargetTargetPropagated`
* [`1a118d8c`](https://github.com/NixOS/nixpkgs/commit/1a118d8c4af04e90cc855fcbabe31448ce424f77) evremap: init at 0-unstable-2024-06-17
* [`5106cce9`](https://github.com/NixOS/nixpkgs/commit/5106cce978472c09277608cc88f444486fa9acd5) maintainers: add schrobingus
* [`831c38e3`](https://github.com/NixOS/nixpkgs/commit/831c38e319870f202d00a607c10b299573080ad6) python3Packages.fastcrc: init at 0.3.2
* [`ffdc305e`](https://github.com/NixOS/nixpkgs/commit/ffdc305e978d3c563f395102d814758baa1c69b2) cargo-lambda: 1.4.0 -> 1.5.0
* [`d1f74248`](https://github.com/NixOS/nixpkgs/commit/d1f742488815333bbad3c8728f54025d2038424b) nixos/grafana: fix evaluation when no settings is defined
* [`6c359f48`](https://github.com/NixOS/nixpkgs/commit/6c359f48f312d8ce42d805572fd4fe3d30fe6349) fuse: move env vars to `env.*`
* [`2fdfc103`](https://github.com/NixOS/nixpkgs/commit/2fdfc1032b269d3088024c01c98703f41795a344) prometheus-collectd-exporter: 0.6.0 -> 0.7.0
* [`5bcd7350`](https://github.com/NixOS/nixpkgs/commit/5bcd7350a4ae728d558f2bc244b8b20bcb01842b) fcitx5-rime: allow empty `rimeDataPkgs`
* [`51fc0761`](https://github.com/NixOS/nixpkgs/commit/51fc0761d20831aed4a05c2f6916d90fefdcc87f) syshud: 0-unstable-2024-09-26 -> 0-unstable-2024-11-04
* [`41e907f8`](https://github.com/NixOS/nixpkgs/commit/41e907f884b5a2da94dae41e6195469359b09f5c) nixos/evremap: init module
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
