### PR TITLE
niv home-manager: update 60bb1109 -> a42fa14b

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -41,10 +41,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "60bb110917844d354f3c18e05450606a435d2d10",
-        "sha256": "1jxrzlgc0xzad5hrjixab4brhir1hyf6cvq0zhgb7z9x06kaydin",
+        "rev": "a42fa14b53ceab66274a21da480c9f8e06204173",
+        "sha256": "0hdc0dh1ax3zlk1p5cqndz7ikmfdi1gnih44pryd64yf8k0c457s",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/60bb110917844d354f3c18e05450606a435d2d10.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/a42fa14b53ceab66274a21da480c9f8e06204173.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@60bb1109...a42fa14b](https://github.com/nix-community/home-manager/compare/60bb110917844d354f3c18e05450606a435d2d10...a42fa14b53ceab66274a21da480c9f8e06204173)

* [`149a48da`](https://github.com/nix-community/home-manager/commit/149a48da315988e36a6e12a82c49667a90d8031f) flake.lock: Update
* [`40746b5c`](https://github.com/nix-community/home-manager/commit/40746b5c77e9ab3fc2196802b637676574aaeb48) alacritty: fix test for nixpkgs update
* [`7e42a37b`](https://github.com/nix-community/home-manager/commit/7e42a37bf7dffd7fe4c2b14e42161433d7182d66) spotify-player: fix test for nixpkgs update
* [`ee8ff6d5`](https://github.com/nix-community/home-manager/commit/ee8ff6d53fca9adec60238f63eb632300d0dffa0) espanso: fix test for nixpkgs update
* [`cd21d2e6`](https://github.com/nix-community/home-manager/commit/cd21d2e61b2da9cc5b96f848ac6fd3c4dc377a1b) git-sync: fix crash when whitespace in path
* [`3c044aef`](https://github.com/nix-community/home-manager/commit/3c044aefe610ceeec9cf3e83e55fa62715df27e2) git-sync: add example to repository option
* [`35b05500`](https://github.com/nix-community/home-manager/commit/35b055009afd0107b69c286fca34d2ad98940d57) kanshi: add package to home.packages
* [`1d0862ee`](https://github.com/nix-community/home-manager/commit/1d0862ee2d7c6f6cd720d6f32213fa425004be10) feh: add themes option ([nix-community/home-manager⁠#6074](https://togithub.com/nix-community/home-manager/issues/6074))
* [`400e3c01`](https://github.com/nix-community/home-manager/commit/400e3c0152793ece616081870f979a2081a04f63) nixos: always run home-manager on NixOS activation ([nix-community/home-manager⁠#5780](https://togithub.com/nix-community/home-manager/issues/5780))
* [`192f123e`](https://github.com/nix-community/home-manager/commit/192f123e4b5a4605c30566409ccacffc416e45c4) nixos: add `key` to shared module to allow disabling it ([nix-community/home-manager⁠#6017](https://togithub.com/nix-community/home-manager/issues/6017))
* [`d154a557`](https://github.com/nix-community/home-manager/commit/d154a557da07645aaea3b3375317c234cf2eed82) aerc: add support of account gpg config ([nix-community/home-manager⁠#5298](https://togithub.com/nix-community/home-manager/issues/5298))
* [`c7c25176`](https://github.com/nix-community/home-manager/commit/c7c251761235282acfc681accf8d3deea6681cc0) {gtk, dunst}: replace `pkgs.gnome.adwaita-icon-theme` with `pkgs.adwaita-icon-theme` in the examples ([nix-community/home-manager⁠#5712](https://togithub.com/nix-community/home-manager/issues/5712))
* [`1bd5616e`](https://github.com/nix-community/home-manager/commit/1bd5616e33c0c54d7a5b37db94160635a9b27aeb) lib/file-type: Make `force` option visible ([nix-community/home-manager⁠#6003](https://togithub.com/nix-community/home-manager/issues/6003))
* [`5056a1cf`](https://github.com/nix-community/home-manager/commit/5056a1cf0ce7c2a08ab50713b6c4af77975f6111) version: allow 25.05 as state version
* [`aecd341d`](https://github.com/nix-community/home-manager/commit/aecd341dfead1c3ef7a3c15468ecd71e8343b7c6) firefox: improve search engine disclaimer generation
* [`0918bb02`](https://github.com/nix-community/home-manager/commit/0918bb02385a6897e7a0180d23ee4587491eb0d4) ci: make dependabot consider release-24.11
* [`05d3b621`](https://github.com/nix-community/home-manager/commit/05d3b6215afa733fed6f025a59a562f98330acc3) home-manager: prepare 25.05-pre
* [`f3a2ff69`](https://github.com/nix-community/home-manager/commit/f3a2ff69586f3a54b461526e5702b1a2f81e740a) zsh-abbr: update source path ([nix-community/home-manager⁠#6084](https://togithub.com/nix-community/home-manager/issues/6084))
* [`18462998`](https://github.com/nix-community/home-manager/commit/18462998b126c8e32bc34c56156690052d1b46c2) librewolf: use mkFirefoxModule
* [`0bd5e9c7`](https://github.com/nix-community/home-manager/commit/0bd5e9c76c9f2f486f4bec0524e16026547df414) librewolf: hide bookmarks option
* [`094265fc`](https://github.com/nix-community/home-manager/commit/094265fca0e000f8af3c38e4dde0e459f91d59f0) Translate using Weblate (Italian)
* [`705cf376`](https://github.com/nix-community/home-manager/commit/705cf3763a6d6074c1b7edb3ff0bb44efa7f091b) Translate using Weblate (Ukrainian)
* [`a42fa14b`](https://github.com/nix-community/home-manager/commit/a42fa14b53ceab66274a21da480c9f8e06204173) syncthing: expand declarative configuration
