### PR TITLE
niv zsh-autosuggestions: update c3d4e576 -> e52ee8ca

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -149,10 +149,10 @@
         "homepage": null,
         "owner": "zsh-users",
         "repo": "zsh-autosuggestions",
-        "rev": "c3d4e576c9c86eac62884bd47c01f6faed043fc5",
-        "sha256": "1m8yawj7skbjw0c5ym59r1y88klhjl6abvbwzy6b1xyx3vfb7qh7",
+        "rev": "e52ee8ca55bcc56a17c828767a3f98f22a68d4eb",
+        "sha256": "02p5wq93i12w41cw6b00hcgmkc8k80aqzcy51qfzi0armxig555y",
         "type": "tarball",
-        "url": "https://github.com/zsh-users/zsh-autosuggestions/archive/c3d4e576c9c86eac62884bd47c01f6faed043fc5.tar.gz",
+        "url": "https://github.com/zsh-users/zsh-autosuggestions/archive/e52ee8ca55bcc56a17c828767a3f98f22a68d4eb.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "zsh-histdb": {


### PR DESCRIPTION
## Changelog for zsh-autosuggestions:
Branch: master
Commits: [zsh-users/zsh-autosuggestions@c3d4e576...e52ee8ca](https://github.com/zsh-users/zsh-autosuggestions/compare/c3d4e576c9c86eac62884bd47c01f6faed043fc5...e52ee8ca55bcc56a17c828767a3f98f22a68d4eb)

* [`69bf058c`](https://github.com/zsh-users/zsh-autosuggestions/commit/69bf058c231ec94006c0c31c96343ce6a60d4ac9) Ensure we're using the builtin exec
* [`8072e52d`](https://github.com/zsh-users/zsh-autosuggestions/commit/8072e52d969409f3a9d5b6e977443e69bc6fe568) Run: make
* [`56f10c3b`](https://github.com/zsh-users/zsh-autosuggestions/commit/56f10c3b5dac558a7fcc7aa47459e4ac0eec3dc7) Always reset file descriptor after consuming it
* [`2cc34c01`](https://github.com/zsh-users/zsh-autosuggestions/commit/2cc34c015e581534e631b37d353b5fb7d34ed151) Switch from Circle CI to GitHub Actions
* [`c5044edd`](https://github.com/zsh-users/zsh-autosuggestions/commit/c5044edd48a63166926861ec793759a6d985197c) Support latest minor version of 5.8
* [`9b027294`](https://github.com/zsh-users/zsh-autosuggestions/commit/9b0272944fc31af2f5a940ac07acc9054ab14e02) Add support for 5.9
* [`23f29434`](https://github.com/zsh-users/zsh-autosuggestions/commit/23f294345584162a73f43e9616556fcca4bd9ce0) Add more common widgets to list of clear widgets
* [`11d17e7f`](https://github.com/zsh-users/zsh-autosuggestions/commit/11d17e7fea9fba8067f992b3d95e884c20a4069c) Clear POSTDISPLAY instead of unsetting
* [`9aceef96`](https://github.com/zsh-users/zsh-autosuggestions/commit/9aceef9646995c478e40c57a81a1ddbbaf9741b9) Remove circle ci reference left over from switch to github actions
* [`a50468ef`](https://github.com/zsh-users/zsh-autosuggestions/commit/a50468ef4bf8301231a9db0cb5b8b5896b95c9ac) Update changelog for v0.7.1 release
* [`f8907cf3`](https://github.com/zsh-users/zsh-autosuggestions/commit/f8907cf32b1aefc6868c4f0d1fb77286d1a0f9b3) v0.7.1
