### PR TITLE
niv nixpkgs: update 5083ec88 -> 6e17454c

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5083ec887760adfe12af64830a66807423a859a7",
-        "sha256": "0sr45csfh2ff8w7jpnkkgl22aa89sza4jlhs6wq0368dpmklsl8g",
+        "rev": "6e17454c31dde901565b848326de097b06dd0892",
+        "sha256": "0gnfk4fv2p87zmxhfwx48xri0b3bbfgqrsk2iiqhgi3rqv47v1a1",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/5083ec887760adfe12af64830a66807423a859a7.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/6e17454c31dde901565b848326de097b06dd0892.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@5083ec88...6e17454c](https://github.com/nixos/nixpkgs/compare/5083ec887760adfe12af64830a66807423a859a7...6e17454c31dde901565b848326de097b06dd0892)

* [`a9ce6eb9`](https://github.com/NixOS/nixpkgs/commit/a9ce6eb94b94bf8bb3983ca2875bdbe2ffbfeaad) hspell: remove build perl from runtime closure
* [`11f45c83`](https://github.com/NixOS/nixpkgs/commit/11f45c83621f8169f1c0dba8462196903697b0f1) nixos/alertmanager: add additional docs about envsubst
* [`158a3908`](https://github.com/NixOS/nixpkgs/commit/158a39089b46d587f73e049fde7dbf65b9b42af2) gh-copilot: add auto-updating
* [`8e415324`](https://github.com/NixOS/nixpkgs/commit/8e41532432774f9358d1e6e8b2e3939556e4097c) nixos/geoclue2: add package option
* [`3db022d0`](https://github.com/NixOS/nixpkgs/commit/3db022d0c2671728d334408f85f3fa088c2a3f1d) python312Packages.x-transformers: init at 1.32.2
* [`c38eb404`](https://github.com/NixOS/nixpkgs/commit/c38eb4045a5f1bc1ae7e41de2fa6bba06920b486) mongodb-6_0: 6.0.17 -> 6.0.18
* [`963b72c0`](https://github.com/NixOS/nixpkgs/commit/963b72c000a6d42bc4f81f49a3b86c8764eb0037) nanoboyadvance: use cmake flag instead of patch for glad source
* [`de7359b2`](https://github.com/NixOS/nixpkgs/commit/de7359b27a3d675a7e885fcdaeaf61bb6f974e32) maintainers: add venikx
* [`45f76ac0`](https://github.com/NixOS/nixpkgs/commit/45f76ac0ede907481a59e5527d40004708494939) excalidraw_export: init at v1.1.0
* [`37ffee83`](https://github.com/NixOS/nixpkgs/commit/37ffee83aeead19da0372ed721aba9b6dd1a4524) excalidraw_export: flag broken on darwin
* [`c2df671c`](https://github.com/NixOS/nixpkgs/commit/c2df671cfc78d21b7c8d3212a6c14ea4dda755ea) easyeffects: fix bug 'missing spectrum analyzer'
* [`63ba95cb`](https://github.com/NixOS/nixpkgs/commit/63ba95cb91d09a5ede7a57a2d9be6d06226d712c) stellarium: add passthru.updateScript
* [`547c086e`](https://github.com/NixOS/nixpkgs/commit/547c086e27cc943ffa06ff79aea402a4434fb01d) python-qt: 3.5.4 -> 3.5.6
* [`24597e94`](https://github.com/NixOS/nixpkgs/commit/24597e9460e8c9dda666b20843e54f3c44d5007e) nixos/network-interfaces-systemd: improve default ethernet network matching
* [`b6d57c6b`](https://github.com/NixOS/nixpkgs/commit/b6d57c6bf0238f386ab6170e118b610c7d542f9c) evdi: 1.14.6 -> 1.14.7
* [`64204e1d`](https://github.com/NixOS/nixpkgs/commit/64204e1dbbf261c61278d674e434ec852eb06bb2) n8n: drop maintainer freezeboy
* [`b4e9f423`](https://github.com/NixOS/nixpkgs/commit/b4e9f423f494dce9f506916cea13c885ae92e595) rl-2411.section.md: update to inform the removal of (buildPythonPackage { ... }).overrideDerivation
* [`3e8d53b9`](https://github.com/NixOS/nixpkgs/commit/3e8d53b9e8eebdbe1a33e9e8e76522ca3e2aa07e) python3Packages.pythonCatchConflictsHook: fix tests with lib.overrideDerivation
* [`38e77220`](https://github.com/NixOS/nixpkgs/commit/38e77220352ec445632cc862fd8987cbefa75225) python3Packages.scikit-image: fix tests with overridePythonAttrs
* [`4541db91`](https://github.com/NixOS/nixpkgs/commit/4541db911cca35a4c617746aaaeebf9beee3b504) n8n: remove `with lib;`
* [`cb08d30f`](https://github.com/NixOS/nixpkgs/commit/cb08d30fca28b835e5f03a9707bf8bec7340aeac) kdePackages.powerdevil: Add ddcutil as build input
* [`fcb041da`](https://github.com/NixOS/nixpkgs/commit/fcb041dad95d41fa4ca0c0a204fda06f93666cff) n8n: 1.61.0 -> 1.65.1
* [`47406c64`](https://github.com/NixOS/nixpkgs/commit/47406c64bc78a4dd75c551aa083224e70b79c56d) nixos-rebuild: fix --file with --build-host
* [`e7be2525`](https://github.com/NixOS/nixpkgs/commit/e7be25251399c8998665bf177459284bc7343279) stellarium: use lib.getExe in tests.version for xvfb-run
* [`880de994`](https://github.com/NixOS/nixpkgs/commit/880de9943e9467b5c7a214ebda4100fc261570ac) tideways-cli: init at 1.2.2
* [`b59b8fc0`](https://github.com/NixOS/nixpkgs/commit/b59b8fc07bf551f34dee194f57013e647108567a) tideways-daemon: init at 1.9.18
* [`c40002e9`](https://github.com/NixOS/nixpkgs/commit/c40002e9c86c462a42323cc8f2ae6804c0eca423) php82Extensions.tideways: init at 5.13.0
* [`b54a912d`](https://github.com/NixOS/nixpkgs/commit/b54a912d526aab0705861b5124c4a2d514be90f0) maintainers: add robbiebuxton
* [`37ce0679`](https://github.com/NixOS/nixpkgs/commit/37ce0679d9017e85eec0e688bd1792f781c3a64f) python312Packages.kalshi-python: init at 2.0.0
* [`1396ddce`](https://github.com/NixOS/nixpkgs/commit/1396ddce104b9e4300686fc123f60d4fb4f58f6a) python312Packages.narwhals: 1.9.1 -> 1.12.1
* [`8b88b3a2`](https://github.com/NixOS/nixpkgs/commit/8b88b3a235421861d84b13653852edf551b14215) arti: 1.2.8 -> 1.3.0
* [`c0c69179`](https://github.com/NixOS/nixpkgs/commit/c0c69179b51c32abac167349f055ce7449c99aa7) proxsuite-nlp: 0.8.0 -> 0.10.0
* [`2995821d`](https://github.com/NixOS/nixpkgs/commit/2995821d810146c4b5b3ba50f5a728ef6212786d) linux-rpi: 6.6.31-stable_20240529 -> 6.6.51-stable_20241008
* [`fb43b706`](https://github.com/NixOS/nixpkgs/commit/fb43b7067e14faa2dd7d982574a9b2a68c8fffbc) raspberrypifw: 1.20240926 -> 1.20241008
* [`08bed55e`](https://github.com/NixOS/nixpkgs/commit/08bed55e78daec2fb4cbdc78779cfcbd900c92ad) febio: darwin sdk refactor
* [`c970f0f7`](https://github.com/NixOS/nixpkgs/commit/c970f0f7cd60d9d98b11729e5a213711bdabff28) febio-studio: darwin sdk refactor
* [`179f1365`](https://github.com/NixOS/nixpkgs/commit/179f1365e022d5fb02144a2d3f4e7b4dbacbc990) rPackages.bgx: fix build
* [`aaacedff`](https://github.com/NixOS/nixpkgs/commit/aaacedffa4a42b75cbc71ec677b9e24b03a55685) sov: adopt and nixfmt-rfc-style
* [`d91203cd`](https://github.com/NixOS/nixpkgs/commit/d91203cd4ceb6e9f7ffbcda8ad09063e287c1231) sov: mark as broken on Darwin
* [`c6b04cb7`](https://github.com/NixOS/nixpkgs/commit/c6b04cb7feae79541e93840f1f6a48a0f6beb4b9) pinocchio: 3.2.0 -> 3.3.0
* [`426246f8`](https://github.com/NixOS/nixpkgs/commit/426246f849d8fa9468bf386d17e8280bbc7e7122) spotifyd: 0.3.5-unstable-2024-09-05 -> 0.3.5-unstable-2024-10-21
* [`45599a3b`](https://github.com/NixOS/nixpkgs/commit/45599a3be468204c76bd10751abd067bce4dbd0e) cbconvert: 1.0.4 -> 1.1.0
* [`e5391307`](https://github.com/NixOS/nixpkgs/commit/e5391307be12c765c9241dae93cab2a9f7694003) python312Packages.pygithub: 2.4.0 -> 2.5.0
* [`c04916cf`](https://github.com/NixOS/nixpkgs/commit/c04916cf323d4b092f201137f26dfb51518444a3) igraph: 0.10.13 -> 0.10.15
* [`a23620b2`](https://github.com/NixOS/nixpkgs/commit/a23620b20f3fc2db4c1f50804a6aa84d54190433) python312Packages.igraph: 0.11.6 -> 0.11.8
* [`3605e392`](https://github.com/NixOS/nixpkgs/commit/3605e392d9533e5b691d66faa8e655ff7351dcce) python312Packages.explorerscript: unpin igraph
* [`af5d97a9`](https://github.com/NixOS/nixpkgs/commit/af5d97a9305b792b7029add1d362b6851c8d5fac) python312Packages.explorerscript: modernize
* [`b43cf9aa`](https://github.com/NixOS/nixpkgs/commit/b43cf9aaba2834621999f74ea5b0794ad49cb43c) ant: add update script
* [`c2bc3a39`](https://github.com/NixOS/nixpkgs/commit/c2bc3a39f411cf9c3765862fa1044b08b94b18a0) ant: 1.10.11 -> 1.10.15
* [`f91f2508`](https://github.com/NixOS/nixpkgs/commit/f91f250870edc8dbc363879e441b181e3cf8a338) unrar: 7.0.9 -> 7.1.1, refactor
* [`7bb92df5`](https://github.com/NixOS/nixpkgs/commit/7bb92df5c855790c4f2c0c697e12096846d1f169) freefilesync: reformat
* [`0f8a593c`](https://github.com/NixOS/nixpkgs/commit/0f8a593cd2ac99af04ca1457ec0de9c6cbc5b4b6) imv: remove absolute path in desktop entry
* [`af971aa8`](https://github.com/NixOS/nixpkgs/commit/af971aa847ba1c0e7f7d8fc125e772db531736fe) imv: use replace-fail
* [`f7e15d3e`](https://github.com/NixOS/nixpkgs/commit/f7e15d3e5c3ad9e8b825c32dd7103dcb5d565fe7) signal-desktop: remove absolute path in desktop entry
* [`3b0e6194`](https://github.com/NixOS/nixpkgs/commit/3b0e6194fb3813468d23166dd2712660d036a231) ryujinx: remove absolute path in desktop entry
* [`4b11c8ab`](https://github.com/NixOS/nixpkgs/commit/4b11c8ab1df0438010b44df26bbbc0d1a176128d) qtcreator: remove absolute path in desktop entry
* [`9affc1b3`](https://github.com/NixOS/nixpkgs/commit/9affc1b3d88f9f69f4b87e88c7103c20365bdb32) entangle: remove absolute path in desktop entry
* [`dc278337`](https://github.com/NixOS/nixpkgs/commit/dc278337657dcdfdf632109b0769384109a7ec0e) gnome-weather: remove absolute path in desktop entry
* [`8816be7b`](https://github.com/NixOS/nixpkgs/commit/8816be7bdaa297e6b4448473f8e23e08b0ed1a0b) gnome-maps: remove absolute path in desktop entry
* [`d769a8de`](https://github.com/NixOS/nixpkgs/commit/d769a8defe586926b133efc4a73b62ee24e6002e) gnome-panel: remove absolute path in desktop entry
* [`58597460`](https://github.com/NixOS/nixpkgs/commit/585974607b263d2f6109531f2477c3eebea71499) imagej: remove absolute path in desktop entry
* [`52dc88de`](https://github.com/NixOS/nixpkgs/commit/52dc88dece9f74fbc3210bad54db45eaf4475c15) nmapsi4: remove absolute path in desktop entry
* [`cddcb797`](https://github.com/NixOS/nixpkgs/commit/cddcb797a3287aab52da11407f81dadaa08d9f79) fclones-gui: remove absolute path in desktop entry
* [`ac1e8835`](https://github.com/NixOS/nixpkgs/commit/ac1e883587fbeca09619b15217ed9fcbb1da345c) gnome-control-center: remove absolute path in desktop entry
* [`97ac49b0`](https://github.com/NixOS/nixpkgs/commit/97ac49b09c7477de806aa71fc39264deb112aa2d) gamepad-tool: remove absolute path in desktop entry
* [`79fccb50`](https://github.com/NixOS/nixpkgs/commit/79fccb5048611847344cdc8d15f99d3b36a89cc7) prowlarr: 1.24.3.4754 -> 1.25.4.4818
* [`98df2b0a`](https://github.com/NixOS/nixpkgs/commit/98df2b0a6703a56470754a21bcf07d6d5ff9aa2d) autofs5: enable NIS support
* [`1fd4bec5`](https://github.com/NixOS/nixpkgs/commit/1fd4bec599ea1eee1b6057c7c7fb1b31d4fba223) uhdm: 1.83 -> 1.84-unstable-2024-10-06
* [`5167a173`](https://github.com/NixOS/nixpkgs/commit/5167a173baf59294937d3b99aab4c454f6e29434) surelog: 1.83 -> 1.84-unstable-2024-11-09
* [`5281d7e6`](https://github.com/NixOS/nixpkgs/commit/5281d7e6fd5ee3229a0aa1bb75785fbfa11c372c) zsh-command-time: 2018-04-30 -> 2020-11-15
* [`1b81e76e`](https://github.com/NixOS/nixpkgs/commit/1b81e76e40b71a0d128fcbb9efb0ccdc12e55754) python311Packages.azure-mgmt-postgresqlflexibleservers: init at 1.0.0
* [`081a3877`](https://github.com/NixOS/nixpkgs/commit/081a3877f942082795ccf1f834f5a9f9693dabe2) python311Packages.azure-mgmt-mysqlflexibleservers: init at 1.0.0b2
* [`c1eb7328`](https://github.com/NixOS/nixpkgs/commit/c1eb73280b627fa5e3e2c667c198a082039000f9) azure-cli: 2.65.0 -> 2.66.0
* [`c9a2725a`](https://github.com/NixOS/nixpkgs/commit/c9a2725a061e0ac7e9c1756d93d9c4aa8343e05f) python311Packages.pyhanko: Unmark broken on darwin
* [`f21d3a0f`](https://github.com/NixOS/nixpkgs/commit/f21d3a0f07057bceb2816312233d3626493c3960) nixos/tabby: fix typo
* [`e0d0c393`](https://github.com/NixOS/nixpkgs/commit/e0d0c3932b807d332666600264dc165979b49213) dxvk_2: 2.4 -> 2.5
* [`48b99d02`](https://github.com/NixOS/nixpkgs/commit/48b99d0225bfaa968234b65b96058acdfed1a966) lomiri.history-service: 0.5 -> 0.6
* [`2fdce28d`](https://github.com/NixOS/nixpkgs/commit/2fdce28dabec3d656a2bb050c412cd389230bcfa) lomiri.history-service: Modernise
* [`4fd4d62c`](https://github.com/NixOS/nixpkgs/commit/4fd4d62c11c449a7425e65577942b87c407a7fe4) lomiri.history-service: nixfmt
* [`87d70198`](https://github.com/NixOS/nixpkgs/commit/87d70198eae37c3eb2c2666b79c9833eb7c1f07c) lomiri.lomiri-history-service: Rename from lomiri.history-service
* [`dfcc7021`](https://github.com/NixOS/nixpkgs/commit/dfcc70216ef4f6ac7a6eebd92365b52434749369) lomiri.suru-icon-theme: 2024.02.1 -> 2024.10.13
* [`4e91715e`](https://github.com/NixOS/nixpkgs/commit/4e91715e6491eba057c5644e7efcd9dc0983f295) lomiri.suru-icon-theme: Modernise
* [`72dd60d9`](https://github.com/NixOS/nixpkgs/commit/72dd60d9cf0b92b33d4899adc0979594dcaf6345) lomiri.suru-icon-theme: nixfmt
* [`3e599454`](https://github.com/NixOS/nixpkgs/commit/3e59945443b983a4ec39d2c95d52fdc19c7de4ee) lomiri.lomiri-clock-app: 4.0.4 -> 4.1.0
* [`132b5f59`](https://github.com/NixOS/nixpkgs/commit/132b5f592df2a16609270eb53153f86de630641e) ansible_2_15: drop
* [`70266f1d`](https://github.com/NixOS/nixpkgs/commit/70266f1d0be27ee4f2feeb63b041aaf3d42b7147) python312Packages.ansible-core: 2.17.5 -> 2.17.6
* [`dd0e1757`](https://github.com/NixOS/nixpkgs/commit/dd0e17573be7d8da13b168045f3b60fa2b4b580d) nix: switch to darwinMinVersionHook
* [`b44da01a`](https://github.com/NixOS/nixpkgs/commit/b44da01a3fe39289fccc2a2e15bc9d07217577cb) azure-cli-extensions.virtual-network-manager: 1.3.0 -> 1.3.1
* [`b3795313`](https://github.com/NixOS/nixpkgs/commit/b3795313b0968275c9baeb8f98619510e85cbaea) azure-cli-extensions.aks-preview: 9.0.0b8 -> 13.0.0b1
* [`c9483558`](https://github.com/NixOS/nixpkgs/commit/c948355850fc2c4258ac1bc17c86562059379768) azure-cli-extensions.amg: 2.5.0 -> 2.5.2
* [`9b564c94`](https://github.com/NixOS/nixpkgs/commit/9b564c943c28b6d4379acde449c0f32fccae6570) azure-cli-extensions.azure-firewall: 1.2.0 -> 1.2.1
* [`e30fe309`](https://github.com/NixOS/nixpkgs/commit/e30fe309971dbb7497f5cbb549f2716f366a3ea2) azure-cli-extensions.virtual-network-tap: 1.0.0b1 -> 1.0.0b2
* [`956eb496`](https://github.com/NixOS/nixpkgs/commit/956eb4968514dce25aceffae044859e12b953854) azure-cli-extensions.dataprotection: 1.5.4 -> 1.5.5
* [`7da024de`](https://github.com/NixOS/nixpkgs/commit/7da024de772f03a269a26a584771094bf15db857) azure-cli-extensions.image-copy-extension: 0.2.13 -> 1.0.0
* [`32976e69`](https://github.com/NixOS/nixpkgs/commit/32976e69fe7b36ea7a149d7a243f8e71e94c52b9) azure-cli-extensions.multicloud-connector: 1.0.0 -> 1.0.1
* [`677b5ff6`](https://github.com/NixOS/nixpkgs/commit/677b5ff62327e73be94540e9894bf78b3513d829) azure-cli-extensions.networkcloud: 2.0.0b5 -> 2.0.0b6
* [`c59b1c69`](https://github.com/NixOS/nixpkgs/commit/c59b1c69ad3c3966cf74c33aab07cdd047d2f47d) azure-cli-extensions.compute-diagnostic-rp: remove
* [`9d9f8205`](https://github.com/NixOS/nixpkgs/commit/9d9f820589ae6e565b1b1ae1f37681e128d0d933) azure-cli.generate-extensions: use writeShellScriptBin to fix missing shebang
* [`cb61b38f`](https://github.com/NixOS/nixpkgs/commit/cb61b38f6a523e1cbb782dcd9f65eda84f00da5a) python312Packages.backports-zoneinfo: remove
* [`d5448e23`](https://github.com/NixOS/nixpkgs/commit/d5448e23ebb833fae9167a8bd7a7b673d421828b) freefilesync: 13.7 -> 13.8
* [`fce91b52`](https://github.com/NixOS/nixpkgs/commit/fce91b527dcfa7bdd917fd98cace8777c368367b) python312Packages.optree: 0.13.0 -> 0.13.1
* [`64e9f97a`](https://github.com/NixOS/nixpkgs/commit/64e9f97a3a42db76c738236298cab6729cb74adc) maintainers: add luNeder
* [`d08191e8`](https://github.com/NixOS/nixpkgs/commit/d08191e8df8087bc9b0572d3226fa272191b0b8e) python312Packages.backports-shutil-which: remove
* [`9f4b11cc`](https://github.com/NixOS/nixpkgs/commit/9f4b11ccd225ece1b0842b31c1ac185930ab5844) python312Packages.backports-shutil-get-terminal-size: remove
* [`a45548f7`](https://github.com/NixOS/nixpkgs/commit/a45548f79e90ef35e68cae22471ebfb3e293f7b4) python312Packages.backports-cached-property: remove
* [`c4b7d21c`](https://github.com/NixOS/nixpkgs/commit/c4b7d21c6b0e03b5701dc5d61a887519ac3284aa) python312Packages.optuna: 4.0.0 -> 4.1.0
* [`60d453ca`](https://github.com/NixOS/nixpkgs/commit/60d453ca9153401f18808211d9e5de2ffbbc3219) libdeltachat: 1.142.12 -> 1.148.7
* [`517e7427`](https://github.com/NixOS/nixpkgs/commit/517e7427d46560f14ca924f228029c425941db17) adwsteamgtk: 0.6.11 -> 0.7.1
* [`49653722`](https://github.com/NixOS/nixpkgs/commit/49653722da965ac37239b4cccfdc9bf8aaf7bc92) zathura: add support for more image formats
* [`69606398`](https://github.com/NixOS/nixpkgs/commit/696063988ae188869f8c4a2a1491ab90156bd60c) qpwgraph: 0.7.8 -> 0.7.9
* [`809beefe`](https://github.com/NixOS/nixpkgs/commit/809beefe79653c50462de9737a5512e1d918daa3) bottles: 51.13 -> 51.15
* [`e024ba7b`](https://github.com/NixOS/nixpkgs/commit/e024ba7ba9fbb8259489785a14abaee2f177fcc8) bottles: avoid with libs;
* [`e87c4e37`](https://github.com/NixOS/nixpkgs/commit/e87c4e37493bf4bff74545a6e8f70726205f9c17) bottles: add Gliczy as maintainer
* [`d2cfb56c`](https://github.com/NixOS/nixpkgs/commit/d2cfb56cafd2aa7803e793413dd6622e565a3113) bottles: use nix-update-script
* [`b1a9ea36`](https://github.com/NixOS/nixpkgs/commit/b1a9ea361136e9207ab31320cd43a4c039a13385) bottles: move to pkgs/by-name
* [`a4117330`](https://github.com/NixOS/nixpkgs/commit/a41173303d0da0cfde13b58de6ba096b28923198) noto-fonts: 24.3.1 -> 2024.11.01
* [`01033be4`](https://github.com/NixOS/nixpkgs/commit/01033be4e0e4cf6bc3f26529177be42f217db8c1) backblaze-b2: remove tomhoule as maintainer
* [`e9f6aeb2`](https://github.com/NixOS/nixpkgs/commit/e9f6aeb2fd67bfe2dee9f0469b43072c3b5f7385) brave: 1.71.123 -> 1.73.89
* [`06ac81f6`](https://github.com/NixOS/nixpkgs/commit/06ac81f61c82ffa40d14ab48fe560bf7602033b4) fsautocomplete: format with nixfmt
* [`ca2a33df`](https://github.com/NixOS/nixpkgs/commit/ca2a33dfba1674e8f4278b24e78e16eea29c49b5) fsautocomplete: add version test
* [`6bed2477`](https://github.com/NixOS/nixpkgs/commit/6bed24773e134d7427a48cfdb856665f5f4b3c05) dotnet: use stdenvNoCC for runtime/sdk
* [`7d31a0ad`](https://github.com/NixOS/nixpkgs/commit/7d31a0adba02e7229f769c202508a80535d1e8da) sqldef: 0.17.20 -> 0.17.23
* [`8d0c0bea`](https://github.com/NixOS/nixpkgs/commit/8d0c0beaa30bc8de9ca6a7656b2f7c52dbb9bfc8) zapzap: 5.3.1 -> 5.3.8
* [`ce338e2d`](https://github.com/NixOS/nixpkgs/commit/ce338e2d6c7cdc809420372a9bd8b230d57ce894) python312Packages.edalize: 0.5.4 -> 0.6.0
* [`e2f22bac`](https://github.com/NixOS/nixpkgs/commit/e2f22bac524ded6691627dcdcd6ad0e044c76ab3) python312Packages.google-cloud-bigtable: 2.26.0 -> 2.27.0
* [`1830f828`](https://github.com/NixOS/nixpkgs/commit/1830f82831dd49ddfe3b323e60fe98cb90d00b7c) wget: 1.24.5 -> 1.25.0
* [`a9b6686b`](https://github.com/NixOS/nixpkgs/commit/a9b6686b4faa0a0b79b408bcaa67232344abab8b) wget: enable parallel building
* [`0d59db6c`](https://github.com/NixOS/nixpkgs/commit/0d59db6c85d9a142aacbe16816ecc611f7e41a14) wget: use nuke-refs to avoid runtime depeneds
* [`d4246a0c`](https://github.com/NixOS/nixpkgs/commit/d4246a0c9054898a6053d6e8d5a0e736646ca37c) python3Packages.hikari: format using nixfmt
* [`d81d437c`](https://github.com/NixOS/nixpkgs/commit/d81d437c5c9926ecf50933ee5191e54a58c4f88b) magic-wormhole-rs: 0.7.1 -> 0.7.3
* [`10a35620`](https://github.com/NixOS/nixpkgs/commit/10a35620c9a348a87af60316f17ede79fa55a84a) nixVersions.nix_2_25: init at 2.25.2
* [`81644d26`](https://github.com/NixOS/nixpkgs/commit/81644d2646eef8d4b37f28301ab7ceb165df7cdb) sile: 0.15.5 → 0.15.6
* [`1ef53f5f`](https://github.com/NixOS/nixpkgs/commit/1ef53f5fc09bd33b6c7f7f76372b92bf179b4336) nezha: init at 0.20.13
* [`4a6b7253`](https://github.com/NixOS/nixpkgs/commit/4a6b7253f8cec0cb3f37d039dad34b54f61a0ba3) python312Packages.instructor: 1.6.3 -> 1.6.4
* [`06b9024c`](https://github.com/NixOS/nixpkgs/commit/06b9024cc001fe8b1d4306808bc93432ba0a6cd8) nginx: upgrade pcre to pcre2
* [`2f7a44c9`](https://github.com/NixOS/nixpkgs/commit/2f7a44c93d4232c4c03b85fa5999bd5492f2d60f) emacsPackages.lsp-bridge: 0-unstable-2024-10-07 -> 0-unstable-2024-11-14
* [`be1e8072`](https://github.com/NixOS/nixpkgs/commit/be1e80726fd4f3283a3f37cd9ce9842a7d9c8317) chirp: 0.4.0-unstable-2024-10-03 -> 0.4.0-unstable-2024-11-11
* [`47adec44`](https://github.com/NixOS/nixpkgs/commit/47adec44dc620efa8e113360234ecba855075b05) glab: 1.48.0 -> 1.49.0
* [`8962e097`](https://github.com/NixOS/nixpkgs/commit/8962e0971ac5d8e90af41267ec4747c2dbe6f6a8) mealie: 1.12.0 -> 2.2.0 ([nixos/nixpkgs⁠#353395](https://togithub.com/nixos/nixpkgs/issues/353395))
* [`ecc59384`](https://github.com/NixOS/nixpkgs/commit/ecc593842b7e5e0cd83dbea08a0d7af67b720926) unison: 2.53.5 -> 2.53.7
* [`00d97b15`](https://github.com/NixOS/nixpkgs/commit/00d97b15f2a4138cfe94a8ecd460fe49fb434758) unison: remove with lib
* [`f9fdde59`](https://github.com/NixOS/nixpkgs/commit/f9fdde592d1dcea1b3b6deb16fe92d8c2f36a90a) unison: nixfmt
* [`c2797681`](https://github.com/NixOS/nixpkgs/commit/c2797681adf0e808ca5ad3a4838cd5425c5781f8) python312Packages.lxml-html-clean: 0.3.1 -> 0.4.1
* [`18c9dbc3`](https://github.com/NixOS/nixpkgs/commit/18c9dbc34f0546e7e6b61eaa6db5c9ac103262b4) pythonPackages.sphinx-multiversion: Fix homepage urls
* [`3cd38226`](https://github.com/NixOS/nixpkgs/commit/3cd382262c19cab764c8d31b70227fb742d63cdf) nixos/pay-respects: actually import the module
* [`c346fd51`](https://github.com/NixOS/nixpkgs/commit/c346fd5125298ddad629f1e38f86894a5c1a50e6) nixos/pay-respects: fix interactiveShellInit for fish and zsh
* [`dbfde9db`](https://github.com/NixOS/nixpkgs/commit/dbfde9db1c4f002ea7acc29433ab3bab291a561f) porn-vault: init at 0.30.0-rc.11
* [`88a16286`](https://github.com/NixOS/nixpkgs/commit/88a16286dfd5b33e24a775f0cfe175686932ca90) ocamlPackages.tls: 1.0.2 -> 1.0.4
* [`03b6ef2a`](https://github.com/NixOS/nixpkgs/commit/03b6ef2ae0ef082279294555b63097051cff4902) scalp: reformat
* [`1268974f`](https://github.com/NixOS/nixpkgs/commit/1268974f036a9c0f9635c9b94785a0da7312cd78) scalp: unstable-2022-03-15 -> 0-unstable-2024-08-28
* [`e8e8784f`](https://github.com/NixOS/nixpkgs/commit/e8e8784f34ea27a2157e93bdecd9b72479443213) pagsuite: reformat
* [`933b9203`](https://github.com/NixOS/nixpkgs/commit/933b920360feb7203866f66fcd515f8329d16010) pagsuite: fix build
* [`57339fd4`](https://github.com/NixOS/nixpkgs/commit/57339fd4250fd6a979fb9b5219c2878fbed07147) deepin-terminal: 6.0.14 -> 6.0.15
* [`c0ea1836`](https://github.com/NixOS/nixpkgs/commit/c0ea1836e0daa07ad04f36f02f6241543ae1cf85) libpqxx: nixfmt
* [`ca8cbf1c`](https://github.com/NixOS/nixpkgs/commit/ca8cbf1c825564c2479f10b25bfb61d8fb52a0d4) libpqxx: move to finalAttrs pattern, refactor
* [`34b8fc2f`](https://github.com/NixOS/nixpkgs/commit/34b8fc2f53272d4d4fcaecd49635f86d7fb5e223) libpqxx: add and order `meta` attrs
* [`68254e43`](https://github.com/NixOS/nixpkgs/commit/68254e438c9ae6eb29b32ee96809e0beef97a014) postgresqlPackages: enable update scripts by default
* [`0dbbc3c5`](https://github.com/NixOS/nixpkgs/commit/0dbbc3c5f933d439079fc802bb050abb1d4c2b62) postgresqlPackages.citus: 12.1.2 -> 12.1.6
* [`53b1df62`](https://github.com/NixOS/nixpkgs/commit/53b1df6254fcef640a3e1ad572fa64f6447c18a7) postgresqlPackages.h3-pg: 4.1.3 -> 4.1.4
* [`e87aa28b`](https://github.com/NixOS/nixpkgs/commit/e87aa28b9c3a6680cdb2756e8d352d5e2d4313bd) postgresqlPackages.lantern: 0.4.1 -> 0.5.0
* [`7c19e850`](https://github.com/NixOS/nixpkgs/commit/7c19e850655c1bf03ef0a31c4ab13b95ce9bbed3) postgresqlPackages.periods: 1.2.2 -> 1.2.3
* [`448763cd`](https://github.com/NixOS/nixpkgs/commit/448763cd4be54d2441f094af9ac28ce071c5bfef) postgresqlPackages.pg_bigm: 1.2-20200228 -> 1.2-20240606
* [`a65bd1ad`](https://github.com/NixOS/nixpkgs/commit/a65bd1adefe29f46a689d746ccb1257dcd61ec9f) postgresqlPackages.pg_net: 0.8.0 -> 0.13.0
* [`e7b11ef5`](https://github.com/NixOS/nixpkgs/commit/e7b11ef572b4f0c03e28dd93ac64e4e4432a72da) postgresqlPackages.pg_repack: 1.5.0 -> 1.5.1
* [`796e44d1`](https://github.com/NixOS/nixpkgs/commit/796e44d16836501ef62eb3633b57f0d149e02087) postgresqlPackages.pg_uuidv7: 1.5.0 -> 1.6.0
* [`b0187db3`](https://github.com/NixOS/nixpkgs/commit/b0187db3697bf74f00b2dc52af07236b6350abdb) postgresqlPackages.pgmq: 1.4.4 -> 1.4.5
* [`1f44f94a`](https://github.com/NixOS/nixpkgs/commit/1f44f94ad3864b9e4fc99e3574daa0904e4a3c42) postgresqlPackages.pgroonga: 3.2.3 -> 3.2.4
* [`34bcb530`](https://github.com/NixOS/nixpkgs/commit/34bcb530b12ce4131dc73f2a9682fe7477b5f8cb) postgresqlPackages.pgrouting: 3.6.3 -> 3.7.0
* [`2b9fc77f`](https://github.com/NixOS/nixpkgs/commit/2b9fc77f89f0c49280c203dd122b3d6d737e96b9) postgresqlPackages.pgsql-http: 1.6.0 -> 1.6.1
* [`1e8e3d00`](https://github.com/NixOS/nixpkgs/commit/1e8e3d000fda3a2ade333aaa02bb605d7463fb53) postgresqlPackages.pgvector: 0.6.2 -> 0.8.0
* [`12d32a59`](https://github.com/NixOS/nixpkgs/commit/12d32a594696556927b30485fcde006902fe6216) postgresqlPackages.plpgsql_check: 2.7.5 -> 2.7.12
* [`a7daa542`](https://github.com/NixOS/nixpkgs/commit/a7daa5426bef77245984ee24fd554d03c118ba16) postgresqlPackages.repmgr: 5.4.1 -> 5.5.0
* [`4d68d79b`](https://github.com/NixOS/nixpkgs/commit/4d68d79bd0a28b133b7aa7d7e40702652395e0f8) swayimg: 3.4 -> 3.5
* [`ce0eda58`](https://github.com/NixOS/nixpkgs/commit/ce0eda58da566b95d7bbc7388f45ab6ec1c2456e) python312Packages.twentemilieu: 2.0.1 -> 2.1.0
* [`6936e23b`](https://github.com/NixOS/nixpkgs/commit/6936e23b05cd015e9661ed0930cbf2fb18987409) swayimg: add nix-update-script
* [`585f64a1`](https://github.com/NixOS/nixpkgs/commit/585f64a15b5222a458b2e10e06baee64eb8417f6) swayimg: avoid `with lib;`
* [`ec6a62b7`](https://github.com/NixOS/nixpkgs/commit/ec6a62b74c0578cead6f89af59183e6f1a50ba64) libpqxx: 7.7.5 -> 7.9.2
* [`9b12a53e`](https://github.com/NixOS/nixpkgs/commit/9b12a53eb60ac0909fbb6264486bf9600ff7eb38) libpqxx: remove unnecessary CXXFLAGS, enable strictDeps
* [`038f8684`](https://github.com/NixOS/nixpkgs/commit/038f8684d00b9a54b23b6ea3348a9ef82193a9ce) libpqxx: split outputs
* [`fdc5d84e`](https://github.com/NixOS/nixpkgs/commit/fdc5d84e66a1c0a5b4db9e4af6fee35f8e42ee08) wipeout-rewrite: nixfmt
* [`fed528af`](https://github.com/NixOS/nixpkgs/commit/fed528af315000ebffd23b067bd3a408501302fc) wipeout-rewrite: Drop meta-wide "with lib"
* [`9bca23b0`](https://github.com/NixOS/nixpkgs/commit/9bca23b06b3241cf10656cd338e02063d5f1be93) wipeout-rewrite: Add passthru.updateScript
* [`211532d7`](https://github.com/NixOS/nixpkgs/commit/211532d7c9f2ae636b0a469f9b9d3016ec88dcaa) wipeout-rewrite: Migrate to by-name
* [`58b8cb66`](https://github.com/NixOS/nixpkgs/commit/58b8cb66b91d7bbd629832a65b5362c0857a620a) wipeout-rewrite: unstable-2023-08-13 -> 0-unstable-2024-07-07
* [`f4e9a21c`](https://github.com/NixOS/nixpkgs/commit/f4e9a21c0f5f5c3544b29c562d98c0d8842f8d0d) cosmic-packages: move to new cargo fetcher
* [`bf3050a2`](https://github.com/NixOS/nixpkgs/commit/bf3050a22a2858a42f4994b1ef8feb15d077b5b8) wtfis: 0.10.0 -> 0.10.1
* [`711b9bd4`](https://github.com/NixOS/nixpkgs/commit/711b9bd4c8307f67a32898cd788e58740acbcf1a) lima: fix cross
* [`1f690545`](https://github.com/NixOS/nixpkgs/commit/1f690545a1513ceb35ed07f5e4de0fdc6e63a580) fix-single-space-whitespace
* [`f56bbed2`](https://github.com/NixOS/nixpkgs/commit/f56bbed24be111f68983ca88c8cedbab8e6d237b) snipaste: add desktop entries
* [`7d5a9ce0`](https://github.com/NixOS/nixpkgs/commit/7d5a9ce0c7b997f1cf947995887e0e5f9e0074e6) nomad_1_9: 1.9.2 -> 1.9.3
* [`d783bfad`](https://github.com/NixOS/nixpkgs/commit/d783bfad2b676a8eb1ffbeb2f2f05cad8a52d009) deltachat-desktop: 1.46.8 -> 1.48.0
* [`27d5879a`](https://github.com/NixOS/nixpkgs/commit/27d5879adb0f11f9e4ee4302d97561bbfcd95ecb) forgejo: use major version to target upgrade stream
* [`cd813611`](https://github.com/NixOS/nixpkgs/commit/cd813611a445b6c7a46d9f473b69958ebe3c3bb9) firefox: enable darwin builds
* [`d72d4fa1`](https://github.com/NixOS/nixpkgs/commit/d72d4fa107a04cd708a9a819a4863046bc52d785) thunderbird: enable darwin builds
* [`2ef54886`](https://github.com/NixOS/nixpkgs/commit/2ef548869dfbd9ea4b9acd6cb22a6e3a3a9e0d4b) floorp: enable darwin builds
* [`de7585de`](https://github.com/NixOS/nixpkgs/commit/de7585dec87f2446b02642df347cd3c5c6208eeb) librewolf: enable darwin builds
* [`4248ace0`](https://github.com/NixOS/nixpkgs/commit/4248ace0609ba2aed84fba30742368ec8a736692) lact: 0.5.6 -> 0.6.0
* [`be8bf544`](https://github.com/NixOS/nixpkgs/commit/be8bf5440a476b3ee9187c42d9eddd8963e89a12) lact: refactor
* [`97a043ae`](https://github.com/NixOS/nixpkgs/commit/97a043ae9a355b7c3c64097276b230395e90b02f) lact: use --replace-fail
* [`6e1ec4b7`](https://github.com/NixOS/nixpkgs/commit/6e1ec4b79b541beb26bfdadb9192e07e9b840e05) lact: add libvulkan.so as NEEDED too
* [`bc2ad7fd`](https://github.com/NixOS/nixpkgs/commit/bc2ad7fd696cd6876fea4642b237cda6d8c52770) lact: add atemu to maintainers
* [`c353cd7f`](https://github.com/NixOS/nixpkgs/commit/c353cd7f4457d20b1dd8014ac20f4e9ede22f341) ponyc: 0.54.0 -> 0.58.6
* [`5fa4499d`](https://github.com/NixOS/nixpkgs/commit/5fa4499ddd9c9b8501f7326ae107ed6e5c00d69c) pony-corral: 0.8.0 -> 0.8.1
* [`f59267c1`](https://github.com/NixOS/nixpkgs/commit/f59267c1ccbdb8fa640371663a84c53b8fd61ef9) ponyc: run through nixfmt
* [`356d7a26`](https://github.com/NixOS/nixpkgs/commit/356d7a26263f2128787aa7adea8714deeba422b6) pony-corral: run through nixfmt
* [`debd6458`](https://github.com/NixOS/nixpkgs/commit/debd6458f7cc134c01b0fe612250068afb5b44f2) {ponyc,pony-corral}: add numinit as maintainer
* [`1d54f76d`](https://github.com/NixOS/nixpkgs/commit/1d54f76d6f84eed0c93bfd9189d352c50e5233d4) soapysdr: 0.8.1 -> 0.8.2-pre (fix python3.12 compat)
* [`2b8f2cc3`](https://github.com/NixOS/nixpkgs/commit/2b8f2cc34f72ee2ee136031b797140168b8621e8) androidStudioPackages.canary: 2024.2.2.5 -> 2024.3.1.2
* [`36a1705d`](https://github.com/NixOS/nixpkgs/commit/36a1705dcfc51977061cadd6f0ae1c38060bb37e) soapysdr: add numinit as maintainer
* [`159c8401`](https://github.com/NixOS/nixpkgs/commit/159c8401016a50fcbd6aece36eeb3e6a8948b039) neovim-node-client: init at 5.3.0
* [`6353656e`](https://github.com/NixOS/nixpkgs/commit/6353656e546c811969fc09444cfe7ab09b82642f) python3Packages.importmagic: fix build
* [`140939da`](https://github.com/NixOS/nixpkgs/commit/140939daca7439f7ecb2d698dbd4b81f2865fce7) emacsPackages.lspce: 1.1.0-unstable-2024-09-07 -> 1.1.0-unstable-2024-10-07
* [`01f7a056`](https://github.com/NixOS/nixpkgs/commit/01f7a056f45e474b670b24b19ab6b68369856481) python312Packages.pyexploitdb: 0.2.54 -> 0.2.55
* [`2c27dda8`](https://github.com/NixOS/nixpkgs/commit/2c27dda89b7dae9a4c36f23a18b71664b31fe547) python312Packages.pygithub: 2.4.0 -> 2.5.0
* [`54aee078`](https://github.com/NixOS/nixpkgs/commit/54aee078915c9cd00c9b0b3db9c06563cafc6dfd) docs/dotnet.section.md: fix accidentally localized example output
* [`1dd9c32b`](https://github.com/NixOS/nixpkgs/commit/1dd9c32b18e884b087488076983237c07372b9f8) docs: remove references before 22.11
* [`7076d32d`](https://github.com/NixOS/nixpkgs/commit/7076d32d233e3d05195509f9ec61abed422f637b) nixos/yabar: remove reference to nixos 18.03
* [`927846ee`](https://github.com/NixOS/nixpkgs/commit/927846eeff54dc0e489b607bc7ab5624e317f266) python3Packages.term-image: fix build
* [`67075b42`](https://github.com/NixOS/nixpkgs/commit/67075b4269b3c730345d458ef0fe950c342079fb) python3Packages.baize: init at 0.22.2
* [`12d53620`](https://github.com/NixOS/nixpkgs/commit/12d536207f37c5552374ea94c064b506915999ff) python3Packages.a2wsgi: fix build
* [`e8f8fd16`](https://github.com/NixOS/nixpkgs/commit/e8f8fd16e9849b0e2c60b5d8d83c645046dab17e) python3Packages.connexion: fix build
* [`050d8a38`](https://github.com/NixOS/nixpkgs/commit/050d8a38b81560700f284d55056409b3e495c026) keepmenu: 1.4.0 -> 1.4.2
* [`603b0136`](https://github.com/NixOS/nixpkgs/commit/603b0136a1475957677c4722d1e70954eae01a5d) python312Packages.whatthepatch: 1.0.6 -> 1.0.7
* [`6b4dfe71`](https://github.com/NixOS/nixpkgs/commit/6b4dfe719935f214eb1e6c2a1468e5f3daf0673a) jami: fix build with libgit2 1.8.4
* [`5705ab5b`](https://github.com/NixOS/nixpkgs/commit/5705ab5bc5014a1547533f811ef105f9bb478dae) wordpress: 6.6.2 -> 6.7
* [`d1da56f6`](https://github.com/NixOS/nixpkgs/commit/d1da56f629d7a2653886e3ed5bef2d3e7000af70) wordpressPackages: package and theme updates
* [`6fa830fc`](https://github.com/NixOS/nixpkgs/commit/6fa830fc0de2b532b6e54767a1239db1ebf700d5) libresprite: 1.0 -> 1.1
* [`66cb0f8f`](https://github.com/NixOS/nixpkgs/commit/66cb0f8ff52cba3282046081c4ce16dd4ee35fc3) tor-browser: 14.0.1 -> 14.0.2
* [`fcea615a`](https://github.com/NixOS/nixpkgs/commit/fcea615a3b9dea50ea149c93a0dff01e8b30b8fe) python3Packages.proton-vpn-api-core: 0.36.4 -> 0.36.6
* [`06dda4ba`](https://github.com/NixOS/nixpkgs/commit/06dda4babe70db4403b40128e893290d8dcb82f5) pferd: 3.6.0 -> 3.7.0
* [`be2aece1`](https://github.com/NixOS/nixpkgs/commit/be2aece13da4dec961ef25f91cdb4a0114a42915) python3Packages.proton-vpn-network-manager: 0.9.4 -> 0.9.7
* [`44155784`](https://github.com/NixOS/nixpkgs/commit/441557848e38ccf19bef3c5061fa4538a4eee9fb) protonvpn-gui: 4.7.3 -> 4.7.4
* [`0cad06d2`](https://github.com/NixOS/nixpkgs/commit/0cad06d22a6159d6692f1495ecddf3846e516a34) xtreemfs: fix build
* [`b9932292`](https://github.com/NixOS/nixpkgs/commit/b9932292ede742b1bb55d425fc229ad11f3197d6) xtreemfs: format
* [`796e83e9`](https://github.com/NixOS/nixpkgs/commit/796e83e99b2afa3d9ee88e97fbc8848ab1cacc99) ledfx: 2.0.104 -> 2.0.105
* [`13a26c51`](https://github.com/NixOS/nixpkgs/commit/13a26c516c2aa8535c88919ea80de1f99306c4cb) jami: 20240823 -> 20241031.0
* [`c877626b`](https://github.com/NixOS/nixpkgs/commit/c877626bf37d28f328b3fd3885f0c848cc438b80) podman: 5.2.3 -> 5.3.0
* [`b9f3beec`](https://github.com/NixOS/nixpkgs/commit/b9f3beec556f8f0cc0a759fa044453dc4d560e92) podman: fix patches
* [`b5003e74`](https://github.com/NixOS/nixpkgs/commit/b5003e741eb10921eb90dc8ded53c1a25715cadc) maintainers: add @⁠peat-psuwit to the maintainer list
* [`0d946aac`](https://github.com/NixOS/nixpkgs/commit/0d946aac1ee6aa2b3d2d527fae76c15edc6888c6) kimai: init at 2.24.0
* [`29e586e5`](https://github.com/NixOS/nixpkgs/commit/29e586e508e60e50a0dad49a36cecca968fe4728) nixos/kimai: init module & add test
* [`986a0381`](https://github.com/NixOS/nixpkgs/commit/986a0381df431ef4e0a9cdec2cda1fff0960a9d9) nixos/doc/rl: mention added module Kimai
* [`5dc49edf`](https://github.com/NixOS/nixpkgs/commit/5dc49edf82c0ef977ec451b4a6d0fc7baa0413ae) cdk-go: 1.5.3 -> 1.5.4
* [`2ca435a5`](https://github.com/NixOS/nixpkgs/commit/2ca435a5402d2659df532160562858d7bf549508) freebsd stdenv: be more principled about portioning out bootstrap libraries
* [`8330c77e`](https://github.com/NixOS/nixpkgs/commit/8330c77eab5d8aa4cc286e50e80db37febe463fa) ocamlPackages.luv: backport patch; fix clang build
* [`cacfa997`](https://github.com/NixOS/nixpkgs/commit/cacfa997c1940097e679fa89a127ff2680790aed) libuv: disable some tests on FreeBSD
* [`d796a88a`](https://github.com/NixOS/nixpkgs/commit/d796a88ab163c6399b868a8e0857d10a1663ddcc) ghostunnel: 1.8.1 -> 1.8.2
* [`0813984e`](https://github.com/NixOS/nixpkgs/commit/0813984e5473996bd02eac2e998c0eb7f92a1840) docker-compose: 2.30.0 -> 2.30.3
* [`6558e173`](https://github.com/NixOS/nixpkgs/commit/6558e173f9027f0a974c474d46dbce415daf3507) python312Packages.python-whois: 0.9.4 -> 0.9.5
* [`71810b3d`](https://github.com/NixOS/nixpkgs/commit/71810b3dfd2a4f9b410be9d4dc2404e846dff0e5) python312Packages.homematicip: 1.1.2 -> 1.1.3
* [`a2d6ea50`](https://github.com/NixOS/nixpkgs/commit/a2d6ea50f0e7cc650424d799cd8a51e897a3e792) python312Packages.cnvkit: 0.9.11 -> 0.9.12
* [`ddd08e40`](https://github.com/NixOS/nixpkgs/commit/ddd08e404f21d39ae6592ae359f416e7b0fd8462) dotnet: split setup hooks into wrapper for runtime/sdk
* [`42d69ab5`](https://github.com/NixOS/nixpkgs/commit/42d69ab59a80edf0c79b112f7a9b6dd86858c2cd) dotnet: move dotnet_root to $out/share/dotnet
* [`d2d56972`](https://github.com/NixOS/nixpkgs/commit/d2d56972fc89f280233f86184a69bc995866ae6a) dotnet: install man pages for source-built sdk
* [`003135da`](https://github.com/NixOS/nixpkgs/commit/003135da3224fc76cff37045891ef4b05712741d) dotnet: run postFixup based on hostPlatform
* [`f9cb431d`](https://github.com/NixOS/nixpkgs/commit/f9cb431d6d858665c2497eb58072d92e8eb871be) dotnet: fix missing targetPackages in source-built sdk packages
* [`97318b96`](https://github.com/NixOS/nixpkgs/commit/97318b96d6d093ba93b825b03b065fb3d07ad1c4) csharp-ls: fix updateScript
* [`193378ea`](https://github.com/NixOS/nixpkgs/commit/193378ead289f55648c17b84226827bfcc21e5e2) dotnet/update.sh: nix-hash -> nix hash convert
* [`4219a941`](https://github.com/NixOS/nixpkgs/commit/4219a941581cd45d1b86c6af974be51d041d10cd) buildDotnetModule: make dotnet-runtime optional
* [`aa0289ed`](https://github.com/NixOS/nixpkgs/commit/aa0289eda408174dc490a729ed77d6542ec2e49d) buildDotnetModule: respect self-contained setting in restore
* [`d9f506c5`](https://github.com/NixOS/nixpkgs/commit/d9f506c5c35456ea5e49a5ab91593e8c2caf0937) netcoredbg: explicitly disable dotnet-runtime
* [`bcd669f2`](https://github.com/NixOS/nixpkgs/commit/bcd669f23f863c223e8fabcf19c595cedcedf921) avalonia: remove unnecessary use of sdk_7_0
* [`5b462ef5`](https://github.com/NixOS/nixpkgs/commit/5b462ef57a789729df844667d5257044688c6686) buildDotnetModule: allow selfContainedBuild property to be omitted with null
* [`6e919bf9`](https://github.com/NixOS/nixpkgs/commit/6e919bf975ce6e43f2fcb1ef63a5ce565cfda50d) boogie: format with nixfmt
* [`112a4c48`](https://github.com/NixOS/nixpkgs/commit/112a4c48c609b7d1ba72c4d3f9000a2e8cba93e4) dotnet: add passthru.runtime/aspnetcore to sdk packages
* [`5f79bf7b`](https://github.com/NixOS/nixpkgs/commit/5f79bf7b7cc785103592dc93642a51f0054d33f0) scooter: 0.1.1 -> 0.1.2
* [`e7138f88`](https://github.com/NixOS/nixpkgs/commit/e7138f8854ca54985288af414022cf15dbabb0f2) pdftitle: 0.15 -> 0.16
* [`85900bc2`](https://github.com/NixOS/nixpkgs/commit/85900bc270cbbbf9f580aa4e7f0ae46291b93d8d) k3s: fix commit output of update script
* [`7c66fb1e`](https://github.com/NixOS/nixpkgs/commit/7c66fb1ec583f30a1c716d6bdfb44c480cd74472) migrate maintainership from luc65r to clevor
* [`0447221a`](https://github.com/NixOS/nixpkgs/commit/0447221af1005cddec962896604e2b26990936cb) supermodel: 0-unstable-2024-04-05 -> 0-unstable-2024-11-07
* [`adaf5f9b`](https://github.com/NixOS/nixpkgs/commit/adaf5f9b58aadbebb4ca12767e60f16f33ee1f5d) maintainers: drop luc65r
* [`a6e2c959`](https://github.com/NixOS/nixpkgs/commit/a6e2c9593113e45fab9e348f8987e3685270b503) jetbrains: 2024.2.2 -> 2024.3
* [`e321ffd9`](https://github.com/NixOS/nixpkgs/commit/e321ffd98a6c842dead2cf3b667a618e8e5eeb61) c-for-go: unstable-2023-09-06 -> 1.3.0
* [`e912c729`](https://github.com/NixOS/nixpkgs/commit/e912c72916c49134ac10eb6aaa9802deb501472a) c-for-go: format
* [`fcbba9b9`](https://github.com/NixOS/nixpkgs/commit/fcbba9b996fabd42ed3298df34e4a695538963a5) jetbrains.plugins: update
* [`e2df267f`](https://github.com/NixOS/nixpkgs/commit/e2df267f503681e7b05ca30c855871580dd41415) linux-wallpaperengine: fix hash mismatch
* [`44c83e33`](https://github.com/NixOS/nixpkgs/commit/44c83e338dce2f48398f5e68e0c36f79c0da7a0f) k3s_1_28: 1.28.14+k3s1 -> 1.28.15+k3s1
* [`1e62ea6e`](https://github.com/NixOS/nixpkgs/commit/1e62ea6e02861cbbe760facaad7fea67d968fb5e) k3s_1_29: 1.29.9+k3s1 -> 1.29.10+k3s1
* [`54737987`](https://github.com/NixOS/nixpkgs/commit/5473798787bcd6e4be1aa9603e9ebe5ef1533da0) root: adapt to new darwin SDK
* [`48bcebe3`](https://github.com/NixOS/nixpkgs/commit/48bcebe361325ad6d4e51f1df6733e61c00212b9) root: 6.32.06 -> 6.32.08
* [`adea5468`](https://github.com/NixOS/nixpkgs/commit/adea5468dc8025149584f76a7e322c153c520b18) root: move to by-name
* [`7bee6740`](https://github.com/NixOS/nixpkgs/commit/7bee67400f5f5ed7451a4fc73e91e075789b42bb) root: apply nixfmt
* [`263fcff3`](https://github.com/NixOS/nixpkgs/commit/263fcff3e9f7fec036ac9c7d20e8510f1d4cf250) alexandria: 0.12.0 -> 0.13.1
* [`06c4131f`](https://github.com/NixOS/nixpkgs/commit/06c4131f5bab42e12d992f091566f976866ac829) k8sgpt: 0.3.41 -> 0.3.46
* [`7c93b1ad`](https://github.com/NixOS/nixpkgs/commit/7c93b1ad10ca6694756c0542655bc4ae19545aa8) bodyclose: 0-unstable-2024-01-26 -> 0-unstable-2024-10-17
* [`a9646b14`](https://github.com/NixOS/nixpkgs/commit/a9646b1400b98f250eb975cc54519a1945fa7332) python312Packages.fakeredis: 2.25.1 -> 2.26.1
* [`d685a71d`](https://github.com/NixOS/nixpkgs/commit/d685a71db11d328764e280c9791e92422fab3943) matugen: 2.4.0 -> 2.4.1
* [`479610e7`](https://github.com/NixOS/nixpkgs/commit/479610e789a8c3bccf8ccc8595529fb55e6cfb17) qsv: 0.131.1 -> 0.138.0
* [`dfac70cb`](https://github.com/NixOS/nixpkgs/commit/dfac70cb1d3ae6d19d2dce79ec4710ad01ac3972) nixos/opendkim: modernize
* [`1414b222`](https://github.com/NixOS/nixpkgs/commit/1414b222f52ba757b6af721b9fba0d23c957dab2) nixos/opendkim: add expandable settings option
* [`f4971591`](https://github.com/NixOS/nixpkgs/commit/f497159195ef8c30849a8cd1df0719350ce8c5b4) nixos/opendkim: put config file under standard location
* [`ecfcfe0a`](https://github.com/NixOS/nixpkgs/commit/ecfcfe0a0edcbeff2de7ed71e4af58e7dd402990) objfw: fetch source from the original fossil instance
* [`d8061ae7`](https://github.com/NixOS/nixpkgs/commit/d8061ae7a3ad4895935699886163a006e7a00078) objfw: 1.2 -> 1.2.1
* [`9fd5a8d0`](https://github.com/NixOS/nixpkgs/commit/9fd5a8d09d881c23f056d4573ca8be8675b1b303) rustPlatform.fetchCargoVendor: decrease concurrency
* [`bfaca465`](https://github.com/NixOS/nixpkgs/commit/bfaca46529ff6590600e6df3b376e88cf7c0c9e3) dotnet-sdk/runtime/aspnetcore: 6.0 -> 8.0
* [`e3736259`](https://github.com/NixOS/nixpkgs/commit/e3736259f7c94971d95f975f720bcb47e3a18a14) maintainers/scripts/update: disable aliases
* [`9fb173da`](https://github.com/NixOS/nixpkgs/commit/9fb173da9421094875609cd6fd5ec98a7d48da05) maintainers/scripts/update-dotnet-lockfiles.nix: use update.nix
* [`3d38ecca`](https://github.com/NixOS/nixpkgs/commit/3d38ecca0ceadf29599b892ac556fb6602ca1892) maintainers/scripts/update: add dependencies to nativeBuildInputs
* [`845066f5`](https://github.com/NixOS/nixpkgs/commit/845066f50e082bf13ee122bb209bd24e332708c8) godot_4-mono: fix nuget dependencies
* [`aa319c6f`](https://github.com/NixOS/nixpkgs/commit/aa319c6f1e150efc6c21326979d40088c28564a1) dotnet-sdk: 8.0.403 -> 8.0.404
* [`0a5c33f8`](https://github.com/NixOS/nixpkgs/commit/0a5c33f88babc47401cf68042b4b2cc8102e561a) dotnet-sdk_6: 6.0.427 -> 6.0.428
* [`f2da78e1`](https://github.com/NixOS/nixpkgs/commit/f2da78e1be67b0c3915c5a84c96fbcf7e104227c) dotnetCorePackages.sdk_9_0: 9.0.100-rc.2.24474.11 -> 9.0.100
* [`df4effe4`](https://github.com/NixOS/nixpkgs/commit/df4effe419dc16d02329973f1db97e10e5394d6f) dotnetCorePackages.dotnet_8.vmr: 8.0.10 -> 8.0.11
* [`24570a33`](https://github.com/NixOS/nixpkgs/commit/24570a33b5021fe1f7df7a94502bd9865fb55b3f) dotnetCorePackages.dotnet_9: 9.0.0-rc.2 -> 9.0.0
* [`9c88243f`](https://github.com/NixOS/nixpkgs/commit/9c88243f6dc7615153202e6b7202c241563787c1) dotnet: fetch hash from nuget.org in update.sh
* [`70921740`](https://github.com/NixOS/nixpkgs/commit/709217401675050759f4cb17a589980cc42b086a) python312Packages.pylsp-rope: 0.1.16 -> 0.1.17
* [`db1d5cf7`](https://github.com/NixOS/nixpkgs/commit/db1d5cf76b0bf02854eb950abe3dc0642642162e) github-runner: 2.320.0 -> 2.321.0
* [`37f501b8`](https://github.com/NixOS/nixpkgs/commit/37f501b81dfc861f18ac2ef71bc6b6a33ccd83ba) python312Packages.pytensor: 2.25.5 -> 2.26.3
* [`5c96d47d`](https://github.com/NixOS/nixpkgs/commit/5c96d47ddd427528eed6bd09ca26fb9a4d610ef6) komikku: 1.62.0 -> 1.63.0
* [`e3b55d3c`](https://github.com/NixOS/nixpkgs/commit/e3b55d3c6af323e673d183995f8bc86f176d5c8f) perlPackages.Imager: 1.019 -> 1.025
* [`18b60a0b`](https://github.com/NixOS/nixpkgs/commit/18b60a0ba2988a477315c11ab4f522b8d23d0a83) graphite-cli: 1.4.6 -> 1.4.8
* [`998f3186`](https://github.com/NixOS/nixpkgs/commit/998f3186d5ddb18ffb052d0953350a89f759f671) jikken: 0.8.0 -> 0.8.1
* [`90b4bd37`](https://github.com/NixOS/nixpkgs/commit/90b4bd37890d04ddfbdb83bbd8de4b16cac18604) tanka: 0.28.2 -> 0.29.0
* [`fd3d60b2`](https://github.com/NixOS/nixpkgs/commit/fd3d60b2edbb0333c8ae925d053cf56d0438c379) certdump: mark broken on aarch64-darwin
* [`456d1f15`](https://github.com/NixOS/nixpkgs/commit/456d1f15efb5c3b5875be7d0447e6be66c145528) python312Packages.pymodbus: 3.7.2 -> 3.7.4
* [`e79c7ad4`](https://github.com/NixOS/nixpkgs/commit/e79c7ad4e58edfef56647c360ad0293b716e35e4) steampipePackages.steampipe-plugin-aws: 0.147.0 -> 1.3.0
* [`ee3fc4dd`](https://github.com/NixOS/nixpkgs/commit/ee3fc4dd353871742a07e201d72955c238aab330) steampipePackages.steampipe-plugin-github: 0.44.0 -> 1.0.0
* [`c855128e`](https://github.com/NixOS/nixpkgs/commit/c855128e2c38e17671a531ac8db499924ea2fcf8) python312Packages.aioruckus: 0.42 -> 0.42
* [`c7d2c63e`](https://github.com/NixOS/nixpkgs/commit/c7d2c63edcb0e2f10d0ab04c90fa2b3a97fbef25) python312Packages.aiostreammagic: 2.8.4 -> 2.8.5 ([nixos/nixpkgs⁠#355394](https://togithub.com/nixos/nixpkgs/issues/355394))
* [`ebcfdd33`](https://github.com/NixOS/nixpkgs/commit/ebcfdd33a881af5e31e27bebee1ce8f40668db92) python312Packages.go2rtc-client: 0.1.0 -> 0.1.1
* [`5df1fa7c`](https://github.com/NixOS/nixpkgs/commit/5df1fa7cf13b7dca4365ba4dfda8e99f4650f2eb) python312Packages.google-nest-sdm: 6.1.4 -> 6.1.5
* [`aea2b6e7`](https://github.com/NixOS/nixpkgs/commit/aea2b6e78b90aa211a81334f33b93c3546ce4981) python312Packages.python-linkplay: 0.0.17 -> 0.0.20
* [`7ca2b22e`](https://github.com/NixOS/nixpkgs/commit/7ca2b22e0304ac97b4f17a4ad096d71ac268ae3a) python312Packages.python-smarttub: modernize
* [`f6b0feb5`](https://github.com/NixOS/nixpkgs/commit/f6b0feb52a53e93f04aee6db2f97055af77bb3c9) python312Packages.pytibber: 0.30.4 -> 0.30.8
* [`2bc5df61`](https://github.com/NixOS/nixpkgs/commit/2bc5df61c98ad32b30dd182abc2f8efeafbaf648) python312Packages.reolink-aio: 0.11.0 -> 0.11.1
* [`1aa92a20`](https://github.com/NixOS/nixpkgs/commit/1aa92a20d3731a099065190f66eeb9f60cbc0b30) python312Packages.sense-energy: 0.13.3 -> 0.13.4
* [`dba35aad`](https://github.com/NixOS/nixpkgs/commit/dba35aad7da969e6614de58cfa7bb63d71e9ad33) python312Packages.zigpy: 0.71.0 -> 0.72.0
* [`ec253b77`](https://github.com/NixOS/nixpkgs/commit/ec253b77f760a470a8569a082a4cfab6171a1584) python312Packages.zha: 0.0.37 -> 0.0.39
* [`eb7011c5`](https://github.com/NixOS/nixpkgs/commit/eb7011c54a432fe8c5735e12c644a28c15ec3935) home-assistant: 2024.11.1 -> 2024.11.2
* [`b82d0265`](https://github.com/NixOS/nixpkgs/commit/b82d026543d51fe1443f758ced916ba88beef946) python312Packages.homeassistant-stubs: 2024.11.1 -> 2024.11.2
* [`ee595b70`](https://github.com/NixOS/nixpkgs/commit/ee595b709e18882162ef5e435ef5c9fe275bdf80) nixos/wyoming-faster-whisper: update CUDA device allowlist
* [`46119296`](https://github.com/NixOS/nixpkgs/commit/4611929638c97d42ac06beb753081da55c296766) xfce: remove commentary referencing AndersonTorres
* [`d1941512`](https://github.com/NixOS/nixpkgs/commit/d1941512c8f578a2dab84ebad6d93abba4bde9dc) boehmgc: remove AndersonTorres as maintainer
* [`2df2b3dc`](https://github.com/NixOS/nixpkgs/commit/2df2b3dc701f01f306aeb25ce593b6437d155677) grc: remove AndersonTorres
* [`cbc8441e`](https://github.com/NixOS/nixpkgs/commit/cbc8441e0fd70f4bdf92c52ec0712d2944516903) hax11: remove AndersonTorres as maintainer
* [`50b7aac0`](https://github.com/NixOS/nixpkgs/commit/50b7aac0abee23f3299653a1f5dedd372786fc99) jesec-rtorrent: remove AndersonTorres
* [`4cf85b6e`](https://github.com/NixOS/nixpkgs/commit/4cf85b6e2cb3ac01d7b86bf643e4c7639acca422) toml11: remove AndersonTorres as maintainer
* [`a32e0aa0`](https://github.com/NixOS/nixpkgs/commit/a32e0aa07ca206c9fd2fde021d4d6135b75211cc) root5: -fpermissive fix for new compiler, patch for python312
* [`bec6d615`](https://github.com/NixOS/nixpkgs/commit/bec6d615120287cbda343ca7f6cddf0678b9bbfa) impala: 0.2.3 -> 0.2.4
* [`9cd94925`](https://github.com/NixOS/nixpkgs/commit/9cd949255c7c5608fbb7eac2b36452fc79b87dbc) terraform-providers.auth0: 1.7.1 -> 1.7.3
* [`b674ed3c`](https://github.com/NixOS/nixpkgs/commit/b674ed3c19731c18257795883e5a567a80780cc3) python312Packages.py3langid: pyproject, relax numpy
* [`1c34da7d`](https://github.com/NixOS/nixpkgs/commit/1c34da7d34fbeb0652df6eecbdd7d387167d61b1) python312Packages.pygccxml: 2.5.0 -> 2.6.0
* [`cfa794fb`](https://github.com/NixOS/nixpkgs/commit/cfa794fb6898c4f24f9736c9df03f8f1101b147f) cloudflare-utils: 1.3.0 -> 1.3.3
* [`75a6be16`](https://github.com/NixOS/nixpkgs/commit/75a6be16843c6bb8e173d5be765b04c6f56f4537) flarum: fix 'mysql' has been renamed to/replaced by 'mariadb'
* [`cd1ee59b`](https://github.com/NixOS/nixpkgs/commit/cd1ee59b419b8c962fbc29150737f890420d9e64) vfkit: build from source
* [`0571bf83`](https://github.com/NixOS/nixpkgs/commit/0571bf83315df2d8870c0782c433b6d54ee1a6cd) manifold: 2.5.1-unstable-2024-11-08 -> 3.0.0
* [`a7c02923`](https://github.com/NixOS/nixpkgs/commit/a7c029235d39456ff4305dffcb91711af27520a3) linux_6_12: init at 6.12
* [`78450026`](https://github.com/NixOS/nixpkgs/commit/78450026fea2f4cf95dc9793ecc0c73865c8c49d) linux_6_11: 6.11.8 -> 6.11.9
* [`3471123c`](https://github.com/NixOS/nixpkgs/commit/3471123c6da3e01ce561e947724e68e9f9daba2d) linux_6_6: 6.6.61 -> 6.6.62
* [`3f7febe1`](https://github.com/NixOS/nixpkgs/commit/3f7febe1b4df8620cc2f479fcffa025c396606f5) linux_6_1: 6.1.117 -> 6.1.118
* [`17c934c9`](https://github.com/NixOS/nixpkgs/commit/17c934c9aa8143d75e3548a71393696331e87335) linux_5_15: 5.15.172 -> 5.15.173
* [`d5b803b0`](https://github.com/NixOS/nixpkgs/commit/d5b803b0675af4a84b2c90cd1addc1540f7c91ab) linux_5_10: 5.10.229 -> 5.10.230
* [`1386871d`](https://github.com/NixOS/nixpkgs/commit/1386871d141e254e4fbebd89fefcd4eb46ccf2d5) linux_5_4: 5.4.285 -> 5.4.286
* [`4ad10975`](https://github.com/NixOS/nixpkgs/commit/4ad10975ec3fcf8bf0060d8700f122fe0de7aef5) buildGoPackage: remove
* [`e698a7ee`](https://github.com/NixOS/nixpkgs/commit/e698a7eeb1babb42f19f678ba6df4f8cd894a15f) lsof: 4.99.3 -> 4.99.4
* [`e2048ac0`](https://github.com/NixOS/nixpkgs/commit/e2048ac05ba57ddddff9c6d91b288edf49a125ad) k3s: use nurl instead of nix-prefetch in update script
* [`0afba0d5`](https://github.com/NixOS/nixpkgs/commit/0afba0d517208e36cdef92eddbd4f24056bd72ea) python312Packages.magic-wormhole-mailbox-server: 0.4.1 -> 0.5.1
* [`1d43b457`](https://github.com/NixOS/nixpkgs/commit/1d43b4579938ca38e1005066069071165649dc21) python312Packages.pymc: 5.18.0 -> 5.18.2
* [`38106734`](https://github.com/NixOS/nixpkgs/commit/3810673409ce9bb375aff6a2bc6fd360173a5f5d) libretro.play: unstable-2024-09-23 -> unstable-2024-11-14
* [`c450d7b7`](https://github.com/NixOS/nixpkgs/commit/c450d7b798ffa1f42a4a0cf9b78f4f40b87eb871) libretro.mame2010: unstable-2022-06-14 -> unstable-2024-10-23
* [`20ba5b31`](https://github.com/NixOS/nixpkgs/commit/20ba5b31d2547af78ae94dd643a4f1daee317d0c) python312Packages.twentemilieu: refactor
* [`572d1086`](https://github.com/NixOS/nixpkgs/commit/572d10868806573ade8460d5578fae49ece5b87c) libretro.fbalpha2012: unstable-2023-11-01 -> unstable-2024-10-21
* [`448ca71b`](https://github.com/NixOS/nixpkgs/commit/448ca71b2d9588464c8d019a3114237bff5a859b) libretro.mgba: unstable-2024-09-24 -> unstable-2024-11-12
* [`bfa4e81d`](https://github.com/NixOS/nixpkgs/commit/bfa4e81dde47d4c48393d314f3a4e1447d2e815b) vale: 3.9.0 -> 3.9.1
* [`b289d2f3`](https://github.com/NixOS/nixpkgs/commit/b289d2f3187249cd7344389e0eea994a5f35bb4f) python312Packages.whenever: 0.6.12 -> 0.6.13
* [`b5849962`](https://github.com/NixOS/nixpkgs/commit/b5849962dfb4eae3a5bc192ed8e9e066d00e8bd4) python312Packages.manifold3d: 2.5.1 -> 3.0.0
* [`7dad6b2d`](https://github.com/NixOS/nixpkgs/commit/7dad6b2d9f724c35db277b88753ce3acd5744feb) qsv: use `useFetchCargoVendor` instead of vendoring Cargo.lock
* [`063fa684`](https://github.com/NixOS/nixpkgs/commit/063fa684a47f6d2aa31f2d2cd36f29af0606738e) freecad: take in account module-path argument
* [`d3c8c86a`](https://github.com/NixOS/nixpkgs/commit/d3c8c86ac4b5451d259ab19a380e5908dc53ff6f) freecad: make customizable
* [`71f8956e`](https://github.com/NixOS/nixpkgs/commit/71f8956ee40bb4e4bcf330570874926d69fc6488) freecad: add tests for modules
* [`a7ab6aa5`](https://github.com/NixOS/nixpkgs/commit/a7ab6aa51a148b481ab04fb98299c50c313f978f) doc: notice freecad customization an changelog
* [`0878d469`](https://github.com/NixOS/nixpkgs/commit/0878d469dca10655613acb6aae4f20b708f6c033) libretro.stella2014: unstable-2024-05-20 -> unstable-2024-10-21
* [`ca557eec`](https://github.com/NixOS/nixpkgs/commit/ca557eec87bcb1eb9d878221ae26b08d0ea25934) retroarch-assets: 1.19.0-unstable-2024-09-22 -> 1.19.0-unstable-2024-10-19
* [`8d9ac213`](https://github.com/NixOS/nixpkgs/commit/8d9ac2131da3f6938512912b874d0ff22cb1a48a) mpv: restore non‐obsolete Swift library path hack
* [`4b8c5f17`](https://github.com/NixOS/nixpkgs/commit/4b8c5f1731df1e4a9ec2aa643587251d3aa16aae) home-assistant-custom-components.solis-sensor: 3.7.0 -> 3.7.1
* [`008785dc`](https://github.com/NixOS/nixpkgs/commit/008785dc7e5df4b683eac93b5847a865856b6066) libretro.beetle-ngp: unstable-2024-06-28 -> unstable-2024-10-21
* [`80aefca4`](https://github.com/NixOS/nixpkgs/commit/80aefca49cf274460e1ab582b933a41e5fe7a1ad) libretro.snes9x2005: unstable-2024-06-28 -> unstable-2024-10-21
* [`18ad5961`](https://github.com/NixOS/nixpkgs/commit/18ad5961d2b8ad5ac71ab8ad200a873d12f4b8bb) ibm-plex: 6.4.0 -> 1.1.0
* [`da4a8059`](https://github.com/NixOS/nixpkgs/commit/da4a805906b506ae37643945a476ec1480770edb) ibm-plex: add @⁠ryanccn as maintainer
* [`8dd8ed68`](https://github.com/NixOS/nixpkgs/commit/8dd8ed68a1685a373361cc87a41beb1837b4d297) verifpal: 0.27.0 -> 0.27.4
* [`4a68949c`](https://github.com/NixOS/nixpkgs/commit/4a68949c7e080ad50010c3a56bd98c1f6b86b7d2) maintainers: add nadiaholmquist
* [`3246cfb7`](https://github.com/NixOS/nixpkgs/commit/3246cfb7bf3f9b6c48f40855ae8e79a90eae8a56) space-cadet-pinball: format with nixfmt-rfc-style
* [`eadef8f4`](https://github.com/NixOS/nixpkgs/commit/eadef8f4860c9eff7d45a5f87031bc1c416d759a) space-cadet-pinball: migrate to by-name
* [`347a3dd6`](https://github.com/NixOS/nixpkgs/commit/347a3dd6b4ad5d505d1d510d853cdf3c309c6f7f) showmethekey: 1.15.1 -> 1.16.0
* [`5ebcfc74`](https://github.com/NixOS/nixpkgs/commit/5ebcfc742d00e0dfbc529f3427648ba9da78e588) space-cadet-pinball: improve packaging
* [`5d56253d`](https://github.com/NixOS/nixpkgs/commit/5d56253de0ce091003e5f1d26ba3c82ce49ef20a) google-cloud-sdk: 494.0.0 -> 501.0.0
* [`ac35e924`](https://github.com/NixOS/nixpkgs/commit/ac35e924ac31ff9bac96f54e486fbb0967fc5268) libretro.opera: unstable-2024-05-06 -> unstable-2024-10-17
* [`d023b182`](https://github.com/NixOS/nixpkgs/commit/d023b182b389699adba6c94987fc47bdb60d8d31) critcl: 3.2 -> 3.3.1
* [`ecbe02d8`](https://github.com/NixOS/nixpkgs/commit/ecbe02d89665d5760470746c0077ea356a5a3a5e) tcllib: 1.21 -> 2.0
* [`7b1fc75b`](https://github.com/NixOS/nixpkgs/commit/7b1fc75bce56f5e8f2de62c10aaede4594db01ba) libretro.prboom: unstable-2024-09-07 -> unstable-2024-10-21
* [`95d07692`](https://github.com/NixOS/nixpkgs/commit/95d076927b34737991eefb7464adfc4351e09a55) fastfetch: 2.29.0 -> 2.30.1
* [`ed5098fd`](https://github.com/NixOS/nixpkgs/commit/ed5098fd7da20c419baaecee5a1fd465604dece3) libretro.beetle-lynx: unstable-2024-06-28 -> unstable-2024-10-21
* [`ec24d96a`](https://github.com/NixOS/nixpkgs/commit/ec24d96ad57a80ff9bc8d5f8a1d7d4ac0da271ec) libretro.mupen64plus: unstable-2024-08-21 -> unstable-2024-10-29
* [`6224134d`](https://github.com/NixOS/nixpkgs/commit/6224134d7fa37210978d13af96288628ea03445d) melodeon: 0.4.2 -> 0.4.3
* [`e0f9d195`](https://github.com/NixOS/nixpkgs/commit/e0f9d1953abf7648eeb37d989e1ea94211a1e0f7) python312Packages.usb-protocol: init at 0.9.1
* [`de6f807a`](https://github.com/NixOS/nixpkgs/commit/de6f807a09eec88ac89861d66fc924aa94862a7a) python312Packages.apollo-fpga: init at 1.1.0
* [`393495aa`](https://github.com/NixOS/nixpkgs/commit/393495aa442c8712876096a2ba5595b64f196802) python312Packages.luna-usb: init at 0.1.2
* [`ded0edc6`](https://github.com/NixOS/nixpkgs/commit/ded0edc6d918e711fcf131e3bc646e51a6ba98af) python312Packages.luna-soc: init at 0.2.0
* [`93b0565d`](https://github.com/NixOS/nixpkgs/commit/93b0565dd2230219f71b191334d5765ebc182680) python312Packages.cynthion: init at 0.1.7
* [`57fb63c9`](https://github.com/NixOS/nixpkgs/commit/57fb63c9314cf30e4c2b0abe5b0096fd73364007) cynthion: init at 0.1.7
* [`9dd1da74`](https://github.com/NixOS/nixpkgs/commit/9dd1da7475146cdc8937038b9341e8e19bcf5278) linuxManualConfig: don't leak rust-lib-src paths into the final binary
* [`bd9c7d02`](https://github.com/NixOS/nixpkgs/commit/bd9c7d0272597fa4475ad4485dc776acc6038b22) python312Packages.experiment-utilities: 0.3.6 -> 0.3.8
* [`c55b0f39`](https://github.com/NixOS/nixpkgs/commit/c55b0f39469fbb3a17bcbc8d424948b13b368a5b) python3Packages.django-filingcabinet: init at 0-unstable-2024-11-15
* [`73b6567c`](https://github.com/NixOS/nixpkgs/commit/73b6567c4122aa1d8d4e9fb602e954ea3d0fae73) doc: change allowInsecurePredicate example to a useful one
* [`81d54c13`](https://github.com/NixOS/nixpkgs/commit/81d54c130da1562af75534e8d3abb75df9bd7669) vaultwarden: 1.32.4 -> 1.32.5
* [`13097e3a`](https://github.com/NixOS/nixpkgs/commit/13097e3a4b125c82cabcc0477a676a5f8dae9263) libretro.bsnes-mercury-balanced: unstable-2023-11-01 -> unstable-2024-10-21
* [`efeab004`](https://github.com/NixOS/nixpkgs/commit/efeab00416ff61997379d42fdfdda84de1dfd926) libretro.beetle-gba: unstable-2021-09-18 -> unstable-2024-10-21
* [`03e9fb38`](https://github.com/NixOS/nixpkgs/commit/03e9fb3803d749d291af8f64fd0c67977ef05446) home-assistant-custom-components.xiaomi_miot: 0.7.21 -> 0.7.23
* [`21627452`](https://github.com/NixOS/nixpkgs/commit/216274522546630af9f24d220e77e9be4c03ef3d) yt-dlp: 2024.11.4 -> 2024.11.18
* [`58c785ae`](https://github.com/NixOS/nixpkgs/commit/58c785ae21b0f807850f75ac3fb001b8e7d14526) libretro.yabause: unstable-2023-01-03 -> unstable-2024-10-21
* [`f2ca8f1d`](https://github.com/NixOS/nixpkgs/commit/f2ca8f1d7a23607c615286d1e56a640b4c0219a8) libretro.picodrive: unstable-2024-10-01 -> unstable-2024-10-19
* [`ba407dd2`](https://github.com/NixOS/nixpkgs/commit/ba407dd26b3848de9c4a5931a0e3ccb11678107b) python312Packages.textual: 0.82.0 -> 0.86.1
* [`3c2d602c`](https://github.com/NixOS/nixpkgs/commit/3c2d602caa06d24bf0d404eb7d5a3d65e3e8c677) python312Packages.textual-fastdatatable: 0.9.0 -> 0.10.0
* [`da277264`](https://github.com/NixOS/nixpkgs/commit/da277264a1fafa51ca0952c52a463eaa15e60550) python312Packages.textual-textarea: 0.14.2 -> 0.14.4
* [`201985dc`](https://github.com/NixOS/nixpkgs/commit/201985dc663e4c0fd2e09d120c56c06608cc32be) python312Packages.textual-textarea: refactor
* [`08d2f9c6`](https://github.com/NixOS/nixpkgs/commit/08d2f9c665416cb5a4779eacf692fa5a6937a841) path-of-building.data: 2.48.2 -> 2.49.0
* [`06f50f4a`](https://github.com/NixOS/nixpkgs/commit/06f50f4adf5f96efc6926681ee7143c038e2abbc) nixos/networkd: warn about naively replacing IPForward
* [`2ac1f685`](https://github.com/NixOS/nixpkgs/commit/2ac1f685b699fe25bcb1dcb684ffc8b85fe4010e) docs: update Go section after buildGoPackage removal
* [`41d71362`](https://github.com/NixOS/nixpkgs/commit/41d71362538e39fcea05d3b6a431a597263dba76) buildGoModule: remove goPackagePath warning
* [`d6e26c4e`](https://github.com/NixOS/nixpkgs/commit/d6e26c4e7d7847dc448365bd92f22aac9c84b5d1) libretro.neocd: unstable-2024-06-22 -> unstable-2024-10-21
* [`e772508f`](https://github.com/NixOS/nixpkgs/commit/e772508fc9fe8bc3c28d3fe30b615a5ea5b0c2c2) libretro.beetle-pcfx: unstable-2024-08-07 -> unstable-2024-10-21
* [`4ba778e0`](https://github.com/NixOS/nixpkgs/commit/4ba778e088686cef915676c30aad104fbe16c054) libretro.nestopia: unstable-2024-06-28 -> unstable-2024-10-17
* [`2b410eeb`](https://github.com/NixOS/nixpkgs/commit/2b410eeb15f043a1290a9c24b07e94cfc5d2c09e) nix-init: fix build on x86_64-darwin
* [`3226e139`](https://github.com/NixOS/nixpkgs/commit/3226e1398841841400ca83bda480940b0c1127bf) libretro.tgbdual: unstable-2024-07-01 -> unstable-2024-10-21
* [`ebdcc360`](https://github.com/NixOS/nixpkgs/commit/ebdcc360f527e3807e9a291434e3fdfaa1da6bce) stm8flash: fix cross compilation
* [`ba0d80db`](https://github.com/NixOS/nixpkgs/commit/ba0d80db843c06d1c4247296516f4c60532ce47b) ip2unix: fix cross compilation
* [`48a8c0b2`](https://github.com/NixOS/nixpkgs/commit/48a8c0b281f4d9e0691d817fd1646eb560f2fae6) mblaze: 1.2 -> 1.3
* [`29d32706`](https://github.com/NixOS/nixpkgs/commit/29d327062dfaf2cfa75936dfc8b26089fdfdb284) wluma: 4.4.0 -> 4.5.1
* [`6b53949b`](https://github.com/NixOS/nixpkgs/commit/6b53949b0cbe3f6dadf4ea730558ac5f4eb56793) formats.ini: expose INI atom from all ini formats
* [`0f1b3297`](https://github.com/NixOS/nixpkgs/commit/0f1b3297c9a0cd68262108cd940c2d4bb27939f2) libretro.melonds: unstable-2023-04-13 -> unstable-2024-10-21
* [`9a2d0bf1`](https://github.com/NixOS/nixpkgs/commit/9a2d0bf15f9a6ce5be79b4fe19f347cff7b01931) libretro.beetle-vb: unstable-2024-06-28 -> unstable-2024-10-21
* [`859c76c5`](https://github.com/NixOS/nixpkgs/commit/859c76c505a4f2b80c32c64a22e51e139b6d68fa) nixos/tools: add enable options to manual
* [`28291813`](https://github.com/NixOS/nixpkgs/commit/28291813168bbcad28f5f695c84b9d3ae470c69d) nixos/arp-scan: init
* [`f278e7f4`](https://github.com/NixOS/nixpkgs/commit/f278e7f42c94fcd3944295699cea8307d5413f63) python3Packages.hikari: fix build
* [`add9ba09`](https://github.com/NixOS/nixpkgs/commit/add9ba09bbad5a947ac93d8315ca0d8e79fee806) python312Packages.textual-fastdatatable: refactor
* [`2702f06d`](https://github.com/NixOS/nixpkgs/commit/2702f06d51f9b84eae1e0fd2b627e22829e9cc3b) harlequin: 1.25.0 -> 1.25.2
* [`824cbe99`](https://github.com/NixOS/nixpkgs/commit/824cbe992255b202ac4d2005a0d4b739e14a7973) gamepad-tool: remove absolute icon path
* [`fb74ff8d`](https://github.com/NixOS/nixpkgs/commit/fb74ff8dd0d91eeb7e9c9251e03812a25ec5aeb9) tilix: remove absolute path in desktop entry
* [`b00728da`](https://github.com/NixOS/nixpkgs/commit/b00728da1090ce0dc8a3586f7d86f1a04122e605) electron-cash: remove absolute path in desktop entry
* [`eb42ef0c`](https://github.com/NixOS/nixpkgs/commit/eb42ef0c24564082056a5ae54cdf52902bda58fd) nixos/tcpdump: init
* [`4fae2896`](https://github.com/NixOS/nixpkgs/commit/4fae28967bbc2c04a48066891c01bfb1c798fc98) nixos/iftop: improve description, use lib.getExe
* [`a6ee554a`](https://github.com/NixOS/nixpkgs/commit/a6ee554a67d563c96134fd7b3797552c72113b68) nixos/traceroute: use lib.getExe
* [`b4d622fd`](https://github.com/NixOS/nixpkgs/commit/b4d622fd7acd3842ad6dc9b0580cc8299c98bf8c) nixos/{arp-scan,iftop,tcpdump,traceroute}: format
* [`e3b12254`](https://github.com/NixOS/nixpkgs/commit/e3b12254fbdcb9b9e28dbfff274e6478265b8c8c) python312Packages.sqlfmt: refactor
* [`f673b779`](https://github.com/NixOS/nixpkgs/commit/f673b779338786f6553c7118ed1703fa6072260e) harlequin: enable tests
* [`68fca281`](https://github.com/NixOS/nixpkgs/commit/68fca2812bca7d98829ef9813b54bdaa0d36b072) sketchybar: 2.21.0 -> 2.22.0
* [`7eb17a4e`](https://github.com/NixOS/nixpkgs/commit/7eb17a4ecc928e60fd142d5d4189a650797466cc) jankyborders: 1.6.0 -> 1.7.0
* [`5aa3f165`](https://github.com/NixOS/nixpkgs/commit/5aa3f1650c2ec6ee96f2962d1e271ff9e13c8ce7) python312Packages.pyro5: disable failing tests
* [`ae4e1dfb`](https://github.com/NixOS/nixpkgs/commit/ae4e1dfb3d030969d0ff00e3b43a8fc856cec2ab) wttrbar: 0.11.0 -> 0.11.2
* [`0ab169c6`](https://github.com/NixOS/nixpkgs/commit/0ab169c6ef599c41cdcbb2e122fdda11cd4ad5f9) dooit: 3.0.3 -> 3.0.4
* [`c71c783f`](https://github.com/NixOS/nixpkgs/commit/c71c783fa90a24d7c9ae4c1226544053c473c138) xst: 0.9.0 -> 0.10.0
* [`d14392ea`](https://github.com/NixOS/nixpkgs/commit/d14392eaf6c6402eacbdf71ef7854d5a535f3601) nixos/obs-studio: nullable package
* [`2e61f323`](https://github.com/NixOS/nixpkgs/commit/2e61f3236def89fc736995fd52555fe952cf5ac5) febio-studio: fix qt 6.8 build
* [`3bacf66e`](https://github.com/NixOS/nixpkgs/commit/3bacf66e418fb80d803304d46dbf5fa8c8aeed4a) python312Packages.dissect-archive: 1.2 -> 1.4
* [`cfc679cb`](https://github.com/NixOS/nixpkgs/commit/cfc679cb948062908e90d65e8c395ca7f1ed3e2a) python312Packages.dissect-xfs: 3.10 -> 3.11
* [`3066d8b9`](https://github.com/NixOS/nixpkgs/commit/3066d8b9830bf1ab1df95a44011ad9e58097ef43) vscode-extensions.visualjj.visualjj: 0.12.3 -> 0.12.5
* [`a16a1449`](https://github.com/NixOS/nixpkgs/commit/a16a1449a0e833bb153f82f366d00b4ddf68ade9) prrte: 3.0.5 -> 3.0.6
* [`ee22085a`](https://github.com/NixOS/nixpkgs/commit/ee22085aeb514e6f095861d50f5edfcbcb72263c) openmpi: 5.0.5 -> 5.0.6
* [`39e09b16`](https://github.com/NixOS/nixpkgs/commit/39e09b167374dbc3c4e002c5a6630f7fec1390fb) python312Packages.jaxtyping: 0.2.34 -> 0.2.36
* [`02cc2a7b`](https://github.com/NixOS/nixpkgs/commit/02cc2a7b0370097a36db783509eed21387843d77) legcord: 1.0.2 -> 1.0.4
* [`31b53417`](https://github.com/NixOS/nixpkgs/commit/31b53417f3cd891d97b4ae6cab5afe5486809d09) obsidian: 1.7.6 -> 1.7.7
* [`e89aa1c1`](https://github.com/NixOS/nixpkgs/commit/e89aa1c16663a98408c1ba0d22890949ff14adaf) python312Packages.dissect-extfs: 3.11 -> 3.12
* [`9afde02c`](https://github.com/NixOS/nixpkgs/commit/9afde02c5a1a5d46fcefe7d35a839da20caf13bb) cardinal: use suffix instead of prefix in wrapProgram
* [`10f85c7f`](https://github.com/NixOS/nixpkgs/commit/10f85c7f70b1acf472d947bab3c914ccb667f37c) python312Packages.dissect-fat: 3.10 -> 3.11
* [`5d171bb6`](https://github.com/NixOS/nixpkgs/commit/5d171bb64731a9bf7e25452e776c77902ccce37e) openapi-generator-cli: 7.9.0 -> 7.10.0
* [`8bd9aca9`](https://github.com/NixOS/nixpkgs/commit/8bd9aca92eba8bad1efbee9bfb87462dc8941502) python312Packages.dissect-vmfs: 3.9 -> 3.10
* [`ca3abfe7`](https://github.com/NixOS/nixpkgs/commit/ca3abfe7941f854fe358b09d41b5b9653065e9f6) python312Packages.dissect-ffs: 3.9 -> 3.10
* [`36f09e35`](https://github.com/NixOS/nixpkgs/commit/36f09e35b6bb08f130effca9d7b044f1673f0767) linux_xanmod: 6.6.60 -> 6.6.62
* [`8e03d427`](https://github.com/NixOS/nixpkgs/commit/8e03d427e07c0ab13e78b3c255126719672b5a4d) linux_xanmod_latest: 6.11.7 -> 6.11.9
* [`2a8b6e97`](https://github.com/NixOS/nixpkgs/commit/2a8b6e9721c00ff20e6ac190d0b3054c62c6bf15) fishPlugins.spark: init at 1.2.0
* [`fe0d4782`](https://github.com/NixOS/nixpkgs/commit/fe0d4782250b5aeaa552586466c0d65598f79ba6) walker: 0.7.7 -> 0.8.12
* [`392b7a87`](https://github.com/NixOS/nixpkgs/commit/392b7a8718e3549b4e80820cf5a1ec58dc5bc5a7) xtreemfs: move `which` to `nativeBuildInputs`
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
