### PR TITLE
niv nixpkgs: update 6e17454c -> 1635ae0b

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "6e17454c31dde901565b848326de097b06dd0892",
-        "sha256": "0gnfk4fv2p87zmxhfwx48xri0b3bbfgqrsk2iiqhgi3rqv47v1a1",
+        "rev": "1635ae0b386ed5d63dc233d5881ad002b45a2db3",
+        "sha256": "1r5qmc61yvydyh8imh8flbyzkgjd3v3jk5vc9zds70h99mvr7gqj",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/6e17454c31dde901565b848326de097b06dd0892.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/1635ae0b386ed5d63dc233d5881ad002b45a2db3.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@6e17454c...1635ae0b](https://github.com/nixos/nixpkgs/compare/6e17454c31dde901565b848326de097b06dd0892...1635ae0b386ed5d63dc233d5881ad002b45a2db3)

* [`cf33426f`](https://github.com/NixOS/nixpkgs/commit/cf33426f95addae9a4b3b2aa1bdc775565bd0800) wl-crosshair: init at 0.1.0-unstable-2024-05-09
* [`7530892b`](https://github.com/NixOS/nixpkgs/commit/7530892b4ada154485962b6c376af6725c3ba638) apacheHttpdPackages.mod_tile: 0.7.1 -> 0.7.2
* [`31193fae`](https://github.com/NixOS/nixpkgs/commit/31193fae957745e6537d30ddaad2b3449942317c) maintainers: add lordmzte
* [`cff79374`](https://github.com/NixOS/nixpkgs/commit/cff7937495d8a37a2436a6b0cf31cd2cf28849bd) algia: init at 0.0.74
* [`dfd7c673`](https://github.com/NixOS/nixpkgs/commit/dfd7c673844567412dbcf2a9f9bb16e4e00c95a6) python3Packages.textblob: init at 0.18.0
* [`ff0cde38`](https://github.com/NixOS/nixpkgs/commit/ff0cde38b126fbc9f3e4ca5b14a55ba37159fa23) python312Packages.jianpu-ly: init at 1.801
* [`e19c4033`](https://github.com/NixOS/nixpkgs/commit/e19c4033d0a2275ae8d68363bf12d423bccb56c6) maintainers: add crimeminister
* [`9cd5ad85`](https://github.com/NixOS/nixpkgs/commit/9cd5ad85f5b77cfedadca5780add99095b940e89) overturemaps: init at 0.9.0
* [`801534d6`](https://github.com/NixOS/nixpkgs/commit/801534d649c6c947ed16bbd6013715af279ff619) maintainers: add shelvacu
* [`c78e6785`](https://github.com/NixOS/nixpkgs/commit/c78e67859b42fa52d5ad8b531caf1de8a9430c99) sm64ex: split out baserom derivation for easier reuse and nixfmt run
* [`6ddf796d`](https://github.com/NixOS/nixpkgs/commit/6ddf796d4c6a2866244c836724d1c26db6590cc1) sm64coopdx: init at 1.0.3
* [`e286b91e`](https://github.com/NixOS/nixpkgs/commit/e286b91ebca6f7de81cefb87492440582a565990) {nixos,nixosTests}/redlib: format with nixfmt
* [`a2a4c87c`](https://github.com/NixOS/nixpkgs/commit/a2a4c87cab75c0043b2241887ca1897634fc68eb) {,nixos/,nixosTests/}redlib: add Guanran928 as maintainer
* [`672d7efb`](https://github.com/NixOS/nixpkgs/commit/672d7efbd5ce0ab864d570b4f737d075850d4843) nixos/redlib: add cfg.settings
* [`4e6df6f8`](https://github.com/NixOS/nixpkgs/commit/4e6df6f865bf4b1b6fd94bfdcdb3e0b1a828d5a2) nixos/redlib: use upstream systemd service file
* [`743d0ff9`](https://github.com/NixOS/nixpkgs/commit/743d0ff90b27b632e30c1ac53ea702d98a0d15f9) fixup! nixos/redlib: use upstream systemd service file
* [`a6614061`](https://github.com/NixOS/nixpkgs/commit/a6614061b67983b29a987c3d5908cdbc9b535f23) akkuPackages.*: add an 'akku-' prefix to the package names
* [`08000db6`](https://github.com/NixOS/nixpkgs/commit/08000db65f4da68a95be072df79b79ef23062051) sweethome3d.application: 7.3 -> 7.5
* [`ad3a9e9c`](https://github.com/NixOS/nixpkgs/commit/ad3a9e9cab0ace359508393c5fb6461a6d201a3c) avdump3: init at 8293_stable
* [`13bc6b9f`](https://github.com/NixOS/nixpkgs/commit/13bc6b9fcc7a107e1dc6cb0b7b0c5f9e6365b08f) python312Packages.marisa-trie: 1.2.0 -> 1.2.1
* [`d794015a`](https://github.com/NixOS/nixpkgs/commit/d794015a06848629beb9e85dbe0ab15dcbe55cce) python3Packages.pdf2image: fix providing of `poppler_utils`
* [`6e9650ad`](https://github.com/NixOS/nixpkgs/commit/6e9650ad5000290fc439e072b022cf44dca341a7) koboldcpp: drop unused args
* [`466d4657`](https://github.com/NixOS/nixpkgs/commit/466d4657464a62b8da2df28715918c5f9e66f7ac) koboldcpp: migrate to `apple-sdk_12`
* [`942de9aa`](https://github.com/NixOS/nixpkgs/commit/942de9aafb51f31f63f9512d77208b3a76ad87bd) google-play: init at 1.5.8
* [`79b15754`](https://github.com/NixOS/nixpkgs/commit/79b157542cab5646831ca7208b5c7b2060f66c9d) decent-sampler: add chewblacka to maintainers
* [`ed6b181a`](https://github.com/NixOS/nixpkgs/commit/ed6b181a62ed4ba0bf37125b5cdc950ae0125412) decent-sampler: format with nixfmt
* [`51aced42`](https://github.com/NixOS/nixpkgs/commit/51aced42bec5a2761e104400a6113ec5e9090db0) decent-sampler: remove reliance on archive.org
* [`ccffb45b`](https://github.com/NixOS/nixpkgs/commit/ccffb45baea91141784a0758e585af077f0620ef) decent-sampler: 1.10.0 -> 1.12.1
* [`9e608d46`](https://github.com/NixOS/nixpkgs/commit/9e608d46a92cba517c6682090d06e1a9f83ad49b) nixos/suricata: add description fields for configuration
* [`f2de541d`](https://github.com/NixOS/nixpkgs/commit/f2de541dfd15c0ce2be09d255e4f0eaa3e32d1a4) nixos/suricata: add module to modules-list
* [`efb30c73`](https://github.com/NixOS/nixpkgs/commit/efb30c73fc33e601334882b3c81befd83b26e5fa) patchance: fix pipewire-jack compatibility
* [`157f77fc`](https://github.com/NixOS/nixpkgs/commit/157f77fc2861de89e890b2621db70c1f5cc9e77d) raysession: fix pipewire-jack compatibility
* [`87dfb08e`](https://github.com/NixOS/nixpkgs/commit/87dfb08e6686cc9dcef13f4583825f0c4ff5fb4a) python312Packages.boltons: 24.0.0 -> 24.1.0
* [`42a45d74`](https://github.com/NixOS/nixpkgs/commit/42a45d74bd197737559dd2a1452c6098ae182ade) tower-pixel-dungeon: init at 0.3.2
* [`ddc51f70`](https://github.com/NixOS/nixpkgs/commit/ddc51f709f0a84fa78231e56b5b15e98da620afa) home-assistant-custom-components.prometheus_sensor: 1.1.0 -> 1.1.2
* [`975ae5ec`](https://github.com/NixOS/nixpkgs/commit/975ae5ec7eb56363e35a60b7185053c9534b20b3) python312Packages.tldextract: 5.1.2 -> 5.1.3
* [`d19b53a5`](https://github.com/NixOS/nixpkgs/commit/d19b53a5719fad79842768a4322f79a67dd22e44) vidcutter: init at 6.0.5.3
* [`ff6d89ac`](https://github.com/NixOS/nixpkgs/commit/ff6d89ac694100ab5350cda97e46fdbd54a54e6c) nixos/netbox: clear old static files on upgrade
* [`fe58368d`](https://github.com/NixOS/nixpkgs/commit/fe58368de684b85915891352ef8bc3dd6e4d8ecc) nixos/netbox: switch to symlink to check for upgrades
* [`91309f47`](https://github.com/NixOS/nixpkgs/commit/91309f479121361bd01310caa57f8051680eac00) python3Packages.pyvex: fix cross
* [`5255c561`](https://github.com/NixOS/nixpkgs/commit/5255c5614d3fade61e2a978f538e6bfb954e5584) aaaaxy: 1.5.208 -> 1.5.220
* [`5d7e1d70`](https://github.com/NixOS/nixpkgs/commit/5d7e1d70fc6c702c4d29b6c6ba314fd979f6a4e4) qualisys-cpp-sdk: init at 2024.2
* [`1b93abe9`](https://github.com/NixOS/nixpkgs/commit/1b93abe91f4086e789e500d6aa14fc717c40b0f8) python312Packages.crc: 7.0.0 -> 7.1.0
* [`a2fbf260`](https://github.com/NixOS/nixpkgs/commit/a2fbf260c894a51e6633b03f02197a3d0129c09c) velero: 1.14.1 -> 1.15.0
* [`30a3b422`](https://github.com/NixOS/nixpkgs/commit/30a3b42239b001ec62ef6f5d97e44304543edb68) koboldcpp: drop `stdenv.hostPlatform.isAarch64` requirement
* [`bccff63b`](https://github.com/NixOS/nixpkgs/commit/bccff63bbbb1a7746120e2ecc211b4289ecfabd3) koboldcpp: drop `postPatch`
* [`d626241e`](https://github.com/NixOS/nixpkgs/commit/d626241e242fd883d0cd1e4da950479cf371ba0c) koboldcpp: `gitUpdater` -> `nix-update-script`
* [`23be0130`](https://github.com/NixOS/nixpkgs/commit/23be01302a945b6c37af5bd32d146e31f12aa016) flclash: libclash add meta
* [`e36c5927`](https://github.com/NixOS/nixpkgs/commit/e36c592733b2928e7b6d3d33782a383e1d49d173) vault-tasks: init at 0.4.0
* [`6b2d35ca`](https://github.com/NixOS/nixpkgs/commit/6b2d35caf253d99e0c16a8355dffe2033d99db1e) lcov: 2.1 -> 2.2
* [`56039172`](https://github.com/NixOS/nixpkgs/commit/560391729239bba7adadedcf7093120dae45f19b) libsecret: use python3Packages instead of python3.pkgs to fix cross compilation
* [`777bd013`](https://github.com/NixOS/nixpkgs/commit/777bd013ca8b3454d89225789b9bc868671f502b) fheroes2: 1.1.2 -> 1.1.3
* [`8ce2f147`](https://github.com/NixOS/nixpkgs/commit/8ce2f1475dc70e3f838ee9be02e286c2a37f8bf1) cbmc-viewer: init at 3.8
* [`e79dda5d`](https://github.com/NixOS/nixpkgs/commit/e79dda5d893f8abca1f0e368a0f919a4a08b186f) open62541pp: init at 0.15.0
* [`ecee72e2`](https://github.com/NixOS/nixpkgs/commit/ecee72e2475c5ca4ccce98d5b7e59fe30d2daa2c) pluginupdate.py: add support for adding/updating individual plugins
* [`18d93378`](https://github.com/NixOS/nixpkgs/commit/18d9337864ab7deb227590693b536303814ecd10) mdk-sdk: 0.29.1 -> 0.30.0
* [`ddc8ce08`](https://github.com/NixOS/nixpkgs/commit/ddc8ce08869ce35711f27c424e731a90e53ac23b) khronos-ocl-icd-loader: 2024.05.08 -> 2024.10.24
* [`206ebf24`](https://github.com/NixOS/nixpkgs/commit/206ebf249d58c202cd5abb2653bf84ab17b3483c) imewlconverter: init at 3.1.1
* [`8780a03d`](https://github.com/NixOS/nixpkgs/commit/8780a03d83dfdbb6131d5f3ca14f69837faf848b) astyle: 3.6.3 -> 3.6.4
* [`4abc781b`](https://github.com/NixOS/nixpkgs/commit/4abc781b6b5ce0d6d5f197be8edb88d32a10c2e1) vscode-extensions.ionic.ionic: init at 1.96.0
* [`5588cd1d`](https://github.com/NixOS/nixpkgs/commit/5588cd1dfeca91fb9369336b70362d554572a87d) wgnlpy: init at 0.1.5
* [`cf27301d`](https://github.com/NixOS/nixpkgs/commit/cf27301dc5f78cf80ba8d2f3ee37899576e31f16) monado: backport reproducibility fix
* [`e6bd72b3`](https://github.com/NixOS/nixpkgs/commit/e6bd72b39cf32da50a6767cb2402a1030e0f83aa) monado: nixfmt and refactor
* [`45dd1250`](https://github.com/NixOS/nixpkgs/commit/45dd125022f0b3a93cb429c5156b94a6ceef83d6) goldwarden: 0.3.4 -> 0.3.6
* [`3c2cc304`](https://github.com/NixOS/nixpkgs/commit/3c2cc3049dc3981c2bed06d2a9bda232543d70e7) pluginupdate.py: use newer syntax for types
* [`7fa4330c`](https://github.com/NixOS/nixpkgs/commit/7fa4330ceba9a65f01533885f670190571f15d28) azurite: 3.31.0 -> 3.33.0
* [`e8262828`](https://github.com/NixOS/nixpkgs/commit/e826282854ce2396cb9580789c5351d0d47a0ba3) python312Packages.sphinx-intl: 2.2.0 -> 2.3.0
* [`922b38af`](https://github.com/NixOS/nixpkgs/commit/922b38af875e055d178eaa2ef94cdfe96fa0ae9a) onefetch: migrate to by-name
* [`08151b58`](https://github.com/NixOS/nixpkgs/commit/08151b58b32b900ff8e5c0d3a12dae16d216eb89) libunicode: 0.4.0 -> 0.6.0
* [`37279cb3`](https://github.com/NixOS/nixpkgs/commit/37279cb3d66a5457280f975e3423abcdf0c88809) glaze: init at 4.0.0
* [`ac196039`](https://github.com/NixOS/nixpkgs/commit/ac196039ed84b22d9fd01267a9c11610e9d43b7f) termbench-pro: 2023-01-26 -> 2024-10-05
* [`25cbe490`](https://github.com/NixOS/nixpkgs/commit/25cbe49079c406fb8103bcfd4bd5c20e5ad00bbf) container2wasm: 0.6.5 -> 0.7.0
* [`6d26ed7b`](https://github.com/NixOS/nixpkgs/commit/6d26ed7b2922ad5a6f66a603fedb9402e7354184) fcitx5-mellow-themes: init at 0-unstable-2024-11-11
* [`a9a55a24`](https://github.com/NixOS/nixpkgs/commit/a9a55a246b2600ccd0b11b4cacd5817371d07977) tidb: 8.3.0 -> 8.4.0
* [`cdd8aa3f`](https://github.com/NixOS/nixpkgs/commit/cdd8aa3f28df64bec4bd814b5987ca12712179a9) python312Packages.rotary-embedding-torch: 0.8.4 -> 0.8.5
* [`7d3d959a`](https://github.com/NixOS/nixpkgs/commit/7d3d959aedb45d57c4a2d2b53d9b99152292cfe7) openxr-loader: 1.1.41 -> 1.1.42
* [`9bf261ef`](https://github.com/NixOS/nixpkgs/commit/9bf261eff8e5125e1be40cfcd7635cba8adc53a4) finamp: 0.9.11-beta -> 0.9.12-beta
* [`b8618314`](https://github.com/NixOS/nixpkgs/commit/b861831405b0799cd74e8f74a61c91368a228477) nixos/luksroot: make it harder to accidentially break cryptsetup
* [`b9124898`](https://github.com/NixOS/nixpkgs/commit/b9124898851a458f4cbb191bd6c99808cb8429a6) tplay: 0.5.0 -> 0.6.0
* [`baf20015`](https://github.com/NixOS/nixpkgs/commit/baf200156b02bd2d35136a4cab7c722fb53247b7) git-spice: 0.7.0 -> 0.8.1
* [`18fa0aba`](https://github.com/NixOS/nixpkgs/commit/18fa0aba0b75d57ec1e91ef96b3093f4e73ea100) flclash: 0.8.66 -> 0.8.67
* [`f7f3af6d`](https://github.com/NixOS/nixpkgs/commit/f7f3af6db6e24111653be3efbd79a47f6af18a4b) tomcat10: 10.1.30 -> 10.1.33
* [`58893dc7`](https://github.com/NixOS/nixpkgs/commit/58893dc7e136465be25bc2551a2359603cb677fa) btrfs-list: init at 2.3
* [`460fcd2e`](https://github.com/NixOS/nixpkgs/commit/460fcd2e230ae62d6a66fe89aaed47074823b65c) meshoptimizer: 0.21 -> 0.22
* [`3b8daca2`](https://github.com/NixOS/nixpkgs/commit/3b8daca28371ca875e0b796c3ff29e438a0c6b09) dezoomify-rs: migrate to new apple-sdk pattern
* [`8a6d3853`](https://github.com/NixOS/nixpkgs/commit/8a6d38531537205fd560234e4dd919094ea07db5) activemq: 6.1.3 -> 6.1.4
* [`6f1462c2`](https://github.com/NixOS/nixpkgs/commit/6f1462c28c22c9feb9a8fa069b96486135bcf90e) dcrwallet: 2.0.4 -> 2.0.5
* [`2528d14a`](https://github.com/NixOS/nixpkgs/commit/2528d14a3acd2f5692a5decf3c9a69cb1e15438e) xlights: 2024.16 -> 2024.17
* [`beebdd48`](https://github.com/NixOS/nixpkgs/commit/beebdd4863527ff6a979a9b005fd00cb7be2c0bc) mud: 1.0.1 -> 1.0.10
* [`db558c7c`](https://github.com/NixOS/nixpkgs/commit/db558c7c4a5dc4f90db9f8e8afd0ff8bd00ab091) backintime: 1.5.2 -> 1.5.3
* [`1b31d43b`](https://github.com/NixOS/nixpkgs/commit/1b31d43bdca9e5aefcc703518ca2e866a45d337d) twig-language-server: init at 0.5.1
* [`a74d8de7`](https://github.com/NixOS/nixpkgs/commit/a74d8de73dd0aaea063a3aa87b8f3d1f9408796d) tilt: 0.33.17 -> 0.33.21
* [`b1fa370d`](https://github.com/NixOS/nixpkgs/commit/b1fa370d51ae7090edb83a99da9effedcde436ed) contour: 0.4.3.6442 -> 0.5.1.7247
* [`df1d58c2`](https://github.com/NixOS/nixpkgs/commit/df1d58c214a254c3150e636969bc55ea70689d89) kubevirt: 1.3.1 -> 1.4.0
* [`c2e25700`](https://github.com/NixOS/nixpkgs/commit/c2e25700611299ea33f8303fe49ca96fea21a127) python312Packages.rich-click: 1.8.3 -> 1.8.4
* [`8a5d8a98`](https://github.com/NixOS/nixpkgs/commit/8a5d8a9818dc86eb4d93008c851bfbae23122b45) kubeshark: 52.3.82 -> 52.3.89
* [`014b3dfa`](https://github.com/NixOS/nixpkgs/commit/014b3dfae72e7ebf7c2b74d7b2f8baef03fb047d) python312Packages.unicorn: rename unicorn-emu input to unicorn
* [`443726e3`](https://github.com/NixOS/nixpkgs/commit/443726e33a0f5af03456d48a50cc60bef8b8615f) temporal-cli: 1.0.0 → 1.1.1
* [`09597867`](https://github.com/NixOS/nixpkgs/commit/095978677b619f12a4a26dad071df353b93e8837) flashgbx: 4.2 -> 4.3
* [`72843a15`](https://github.com/NixOS/nixpkgs/commit/72843a1519c19c05902b483d8ce9795dfd7a8409) python312Packages.tubeup: 2023.9.19 -> 2024.11.13
* [`7739493e`](https://github.com/NixOS/nixpkgs/commit/7739493e6f336d1bb3da61c01b0424ce0468abff) ast-grep: 0.28.1 -> 0.30.0
* [`6540042e`](https://github.com/NixOS/nixpkgs/commit/6540042e2767330be35a276315079618cce520e8) lzfse: modernize derivation
* [`6d0d288c`](https://github.com/NixOS/nixpkgs/commit/6d0d288cccb1be3aba5c7b05c971663a6306b70b) clanlib: add passthru.updateScript
* [`a4e49326`](https://github.com/NixOS/nixpkgs/commit/a4e49326e724949b9678eb467d623ee503260b78) clanlib: 4.1.0 -> 4.2.0
* [`53a761ab`](https://github.com/NixOS/nixpkgs/commit/53a761ab825cee8348aecc2be095fbd3f9d02a61) methane: nixfmt
* [`1bdfbcd3`](https://github.com/NixOS/nixpkgs/commit/1bdfbcd3e849900cb2b266f0e052a5c7ff65c24b) methane: add passthru.updateScript
* [`c327b0c6`](https://github.com/NixOS/nixpkgs/commit/c327b0c60d9b807e816c12e9f894244ed03558a3) methane: 2.0.1 -> 2.1.0
* [`7f0f95ae`](https://github.com/NixOS/nixpkgs/commit/7f0f95aec2c29a39213e1d371673f63ba3f762da) onefetch: darwin sdk fixup
* [`f4a848a2`](https://github.com/NixOS/nixpkgs/commit/f4a848a25d59208d2736754f06df2403dabaf48e) onefetch: 2.21.0 -> 2.22.0
* [`fe568fb6`](https://github.com/NixOS/nixpkgs/commit/fe568fb6c02629a47fed061f4cc2ffa69fb65e9b) ckan: 1.35.0 -> 1.35.2
* [`84eb15a5`](https://github.com/NixOS/nixpkgs/commit/84eb15a5b7be679d00b5c10f6009c115ef1bdb4a) kyverno: 1.12.6 -> 1.13.1
* [`6b1c3c97`](https://github.com/NixOS/nixpkgs/commit/6b1c3c97b5126ab22927cb15c8f221c7ff8d0826) textlint: 14.2.1 -> 14.3.0
* [`897a93e9`](https://github.com/NixOS/nixpkgs/commit/897a93e92e737dbbbc3c5cdb67f2c1d44a6c8d6b) duckdb: 1.1.2 -> 1.1.3
* [`d69fe736`](https://github.com/NixOS/nixpkgs/commit/d69fe7363932b7732dce7219da93edf30f229567) tryton: 7.2.6 -> 7.4.0
* [`57f9e0b5`](https://github.com/NixOS/nixpkgs/commit/57f9e0b54d108654dcb184e6049721a7f23f7cde) mopidy: make PipeWire a buildInput to add GStreamer dependency
* [`5c539079`](https://github.com/NixOS/nixpkgs/commit/5c5390796bc749b000e4ceb8a0f57beac8e0a2d3) matrix-sliding-sync: improve assertion/deprecation message
* [`12afb737`](https://github.com/NixOS/nixpkgs/commit/12afb737840b0e31972007203f9f72e40a5dde6e) nixos/virtualisation: fix rendering of example in diskSize
* [`152c4696`](https://github.com/NixOS/nixpkgs/commit/152c4696ee798110e3321f26ceebaa9c383d2472) bitwarden-desktop: 2024.9.0 -> 2024.11.1
* [`e90e1dcf`](https://github.com/NixOS/nixpkgs/commit/e90e1dcfb264055991685268ae92cacba1dd4d77) endless-sky: 0.10.8 -> 0.10.10
* [`a969802f`](https://github.com/NixOS/nixpkgs/commit/a969802fdf4d33dafa20189613562180d9ea1454) chez: 10.0.0 -> 10.1.0
* [`30d77e7f`](https://github.com/NixOS/nixpkgs/commit/30d77e7f89604f76a33c4023a237c136573cad2c) klog-rs: 0.1.0 -> 0.2.0
* [`d75835a5`](https://github.com/NixOS/nixpkgs/commit/d75835a5d41529f379209136b31dcb59694969ef) cli-tips: init at 0-unstable-2024-11-14
* [`2be2976b`](https://github.com/NixOS/nixpkgs/commit/2be2976bd2bee66a05ee96e5aa2e09fccc3793d2) tex-fmt: 0.4.6 -> 0.4.7
* [`82912474`](https://github.com/NixOS/nixpkgs/commit/82912474cbfafce39d84e95f805dd3db1cc79869) lunatask: 2.0.12 -> 2.0.13
* [`f70f1c7b`](https://github.com/NixOS/nixpkgs/commit/f70f1c7be0c7bc097ac0aac0f36e63fae32be609) python3Packages.brian2: fix build
* [`2c60aa20`](https://github.com/NixOS/nixpkgs/commit/2c60aa206cec9e67ab4c9f2e1aed3386dbd8b0f7) python312Packages.mlxtend: 0.23.1 -> 0.23.2
* [`80125b02`](https://github.com/NixOS/nixpkgs/commit/80125b026db0c2578deecaf2bf8f23c3a8d12a83) ox: 0.6.10 -> 0.7.1
* [`65db89a2`](https://github.com/NixOS/nixpkgs/commit/65db89a262695eb293456cd0627121a9cea1b4b0) emmet-language-server: 2.2.0 -> 2.6.0
* [`a06903ac`](https://github.com/NixOS/nixpkgs/commit/a06903acce4fc49b267dd0b00e95500172db38e2) glamoroustoolkit: 1.1.4 -> 1.1.7
* [`d80e2238`](https://github.com/NixOS/nixpkgs/commit/d80e223808012642c8a4532c402d5237d37d580c) libloragw-sx1301: init at 5.0.1r2
* [`194b5691`](https://github.com/NixOS/nixpkgs/commit/194b5691c67d2b39446896210995d800caa8bd6c) libloragw-sx1302: init at 2.1.0r7
* [`6bd22a91`](https://github.com/NixOS/nixpkgs/commit/6bd22a9174b1bad5ca4c0cc17fd2caf1ef0be34c) libloragw-2g4: init at 1.1.0
* [`500e7fcb`](https://github.com/NixOS/nixpkgs/commit/500e7fcb6f81ae3ac3c92478ec6d3413568ab33a) go-task: 3.39.2 -> 3.40.0
* [`88d11a00`](https://github.com/NixOS/nixpkgs/commit/88d11a001044f8129ccd037c396fe6670c7b3f43) polarity: 0-unstable-2024-06-28 -> 0-unstable-2024-11-15
* [`d0b60f93`](https://github.com/NixOS/nixpkgs/commit/d0b60f93984cde15be81276dc25dcfc808bba9ce) incus: 6.6.0 -> 6.7.0
* [`109721fb`](https://github.com/NixOS/nixpkgs/commit/109721fb52fc9dfd564852eed6d25b9922a06742) k9s: 0.32.5 -> 0.32.6
* [`95415a08`](https://github.com/NixOS/nixpkgs/commit/95415a086de488fab242b22981b99e62b851a267) ghq: 1.6.3 -> 1.7.1
* [`4d5b900c`](https://github.com/NixOS/nixpkgs/commit/4d5b900cce97a109df9db2ab2e6f228f5e202269) gdal: format
* [`7e41021c`](https://github.com/NixOS/nixpkgs/commit/7e41021c7b37d54dd3cad5de45aa2a20dc8398ef) gdal: disable failing darwin test
* [`15b9239b`](https://github.com/NixOS/nixpkgs/commit/15b9239b091307d0d319d46f7adf75e9153f179f) gdal: remove unnecessary disabled tests
* [`a413763d`](https://github.com/NixOS/nixpkgs/commit/a413763d8856a7a49ee777ac076b28c8502fba69) gdal: disable flaky tests
* [`980289d0`](https://github.com/NixOS/nixpkgs/commit/980289d071d76425fc2f908b01b458b988650a93) maintainers: add axertheaxe
* [`7d0395f7`](https://github.com/NixOS/nixpkgs/commit/7d0395f7e8f2fd518adaedd8a566876d3b3ca3bb) minify: 2.20.37 -> 2.21.1
* [`fcac268a`](https://github.com/NixOS/nixpkgs/commit/fcac268ae7e975613df0e1bdb63c8a0c2875d2c5) croc: 10.0.13 -> 10.1.0
* [`b80d0435`](https://github.com/NixOS/nixpkgs/commit/b80d0435e49f3c5b7c15e978208fb77781ce7ad6) nvtopPackages.apple: darwin support
* [`889eae69`](https://github.com/NixOS/nixpkgs/commit/889eae69e49e6d053a5a3d61fcaa7ff0fbe5dab0) gurk-rs: add passthru.tests.version
* [`cfef478f`](https://github.com/NixOS/nixpkgs/commit/cfef478f33054996f381c4bdc2244f2f3297100f) quill-log: 7.3.0 -> 7.5.0
* [`7550580e`](https://github.com/NixOS/nixpkgs/commit/7550580e19adfa3d4a93774bc9d039b9e2326b7a) technium-dns-server: 13.0.2 -> 13.2
* [`7872a84d`](https://github.com/NixOS/nixpkgs/commit/7872a84d4a08fe018438bd74e47500e034ef537c) pingvin-share: 1.2.4 -> 1.3.0
* [`6bbd4938`](https://github.com/NixOS/nixpkgs/commit/6bbd4938ee9afcc8ada32a442bc7bfd1fdc580d4) kpt: 0.39.3 -> 1.0.0-beta.55
* [`eef4b68d`](https://github.com/NixOS/nixpkgs/commit/eef4b68dd0406f1c2978ae565522ec9299e6c2ce) python3Packages.python-measurement: 3.2.2 -> 4.0a8
* [`b01b12dc`](https://github.com/NixOS/nixpkgs/commit/b01b12dcce52b29e67046f8b9d52266be03de0ac) python311Packages.myfitnesspal: fix build
* [`61f09a9e`](https://github.com/NixOS/nixpkgs/commit/61f09a9edc49d9f5231abcf038079c4e694705b6) perf_data_converter: fix fixed derivation hash.
* [`5bc1af95`](https://github.com/NixOS/nixpkgs/commit/5bc1af9524b400f9a374a3213b925747a69ec223) iotas: 0.2.10 -> 0.9.5
* [`e003a050`](https://github.com/NixOS/nixpkgs/commit/e003a0502da93a2dcd12857551efdfcb350540d6) streamcontroller: fix 1.5.0-beta.7 hash
* [`4a42682f`](https://github.com/NixOS/nixpkgs/commit/4a42682ff80ec666e6b0757d9d792dc51202d0ca) nixos/meilisearch: fix disabling analytics
* [`e287024e`](https://github.com/NixOS/nixpkgs/commit/e287024eb069a15e782229fffbe340cdcb65181e) f2: 1.9.1 -> 2.0.1
* [`8191db9d`](https://github.com/NixOS/nixpkgs/commit/8191db9d69edf03c4e4700a96288edacc4872ccb) snac2: 2.59 -> 2.63
* [`d1455f5b`](https://github.com/NixOS/nixpkgs/commit/d1455f5bce93f6f0343bc03bce3c58e2aaa42d2f) sydbox: format with nixfmt
* [`4f0861ca`](https://github.com/NixOS/nixpkgs/commit/4f0861ca1f9d58aff22a69a31e746e2ff8dc4c0d) telegram-desktop: 5.7.1 -> 5.8.0
* [`40b19627`](https://github.com/NixOS/nixpkgs/commit/40b196272f18c2b838595d25c7d97c36cb244b87) flclash: 0.8.67 -> 0.8.68
* [`eb80f0ba`](https://github.com/NixOS/nixpkgs/commit/eb80f0baa32c27483f1710e23529f860bfacafb7) wealthfolio: 1.0.18 -> 1.0.21
* [`6be7fb37`](https://github.com/NixOS/nixpkgs/commit/6be7fb37a63d254ba27e29c2732a6ada374723c0) python3Packages.django-ninja: 1.3.0 -> 1.3.0-unstable-2024-11-13
* [`62728931`](https://github.com/NixOS/nixpkgs/commit/6272893175fc2a09a1392a414e8f6822ef3f4195) sydbox: 2.2.0 -> 3.28.3
* [`4929c87f`](https://github.com/NixOS/nixpkgs/commit/4929c87fed3885435c076d403a28e7ad43d4ade6) sydbox: add meta.mainProgram & cleanup meta
* [`3fe4a6a9`](https://github.com/NixOS/nixpkgs/commit/3fe4a6a95caf9232f5c162eeeba70ae4de7f30db) sydbox: add updateScript
* [`d0243929`](https://github.com/NixOS/nixpkgs/commit/d02439295ca7d8c453d6e047cedfde1046c23913) sydbox: add version test
* [`bf6dafd1`](https://github.com/NixOS/nixpkgs/commit/bf6dafd182e0bca3ea81f80f9b99f29dacb84e04) sydbox: add getchoo to maintainers
* [`3b48d099`](https://github.com/NixOS/nixpkgs/commit/3b48d0996c2f3d3dbd8126e9a29903871e2c2afe) python3Packages.inject: init at 5.2.1
* [`5c7471db`](https://github.com/NixOS/nixpkgs/commit/5c7471db68057f695f7891a96fc915d99540deda) telegram-desktop: 5.8.0 -> 5.8.1
* [`542c7dc5`](https://github.com/NixOS/nixpkgs/commit/542c7dc5903288f9cdece6b0145eb911dd204d41) zrok: 0.4.39 -> 0.4.44
* [`6728211e`](https://github.com/NixOS/nixpkgs/commit/6728211ec862cd7c4865d4c87103abc7e2845a74) nixos/kanidm: allow origin url ending without slash
* [`c4b1d21e`](https://github.com/NixOS/nixpkgs/commit/c4b1d21e7be8807a55ef2f0a49d51deaa1a63988) rcp: 0.13.0 -> 0.15.0
* [`3835c5a3`](https://github.com/NixOS/nixpkgs/commit/3835c5a3f81305447e4ebe4e00340f12c6830b2f) bite: 0.2.1 -> 0.3, fix x86_64-darwin build
* [`f7ab39e5`](https://github.com/NixOS/nixpkgs/commit/f7ab39e5253c9a8dd54cef748228976ffd0a8319) php: support two- and zero-argument overrideAttrs forms
* [`9715e65d`](https://github.com/NixOS/nixpkgs/commit/9715e65d53e18f2ea4976d70172a18003c6766ae) python312Packages.asyncwhois: 1.1.5 -> 1.1.9
* [`484e8beb`](https://github.com/NixOS/nixpkgs/commit/484e8beb12ebfe4a9b4662dc4154bdc55e5f1a90) python312Packages.dbt-semantic-interfaces: 0.7.4 -> 0.8.1
* [`accaac8b`](https://github.com/NixOS/nixpkgs/commit/accaac8bb26fd7c1ed2e9a76fea588aa3f74050b) python312Packages.uarray: 0.9.0 -> 0.9.1
* [`1c8cc3b4`](https://github.com/NixOS/nixpkgs/commit/1c8cc3b4881090552e93d756d892d1529687b32c) databricks-cli: 0.229.0 -> 0.234.0
* [`b594649f`](https://github.com/NixOS/nixpkgs/commit/b594649f43fa3b01b77e98f2a58554b034a63583) python312Packages.dask-expr: 1.1.16 -> 1.1.19
* [`c5facb4c`](https://github.com/NixOS/nixpkgs/commit/c5facb4c7df92a6ca48c416b49a368503e7e2e93) python312Packages.distributed: 2024.10.0 -> 2024.11.2
* [`783f44cd`](https://github.com/NixOS/nixpkgs/commit/783f44cd4ebb1ed04fdd4a4bfc22adfdfb327fa6) python312Packages.dask: 2024.10.0 -> 2024.11.2
* [`d1cae02b`](https://github.com/NixOS/nixpkgs/commit/d1cae02bdf0a8c4d976ce834cc6918d653c13c69) python312Packages.dask-ml: fix darwin build
* [`927bf0fe`](https://github.com/NixOS/nixpkgs/commit/927bf0fee446a8c0574e013368fc6659ba7fc0e6) tetragon: 0.1.1 -> 1.2.0
* [`b15ed174`](https://github.com/NixOS/nixpkgs/commit/b15ed174fabbf583e69a2a1c64e8ff50efd6fa56) rmfakecloud: run nixfmt
* [`6059f5ad`](https://github.com/NixOS/nixpkgs/commit/6059f5ad4e78812050b091a42d350add624b0744) rfmakecloud: 0.0.18 -> 0.0.21
* [`64a13b76`](https://github.com/NixOS/nixpkgs/commit/64a13b7609c484677582f2758d6b4e44ddb50679) nixos/rmfakecloud: remove outdated note about webui not included
* [`f27f1e09`](https://github.com/NixOS/nixpkgs/commit/f27f1e09319237f5732c795c5132744d939412bc) nixos/tests/rmfakecloud: new test
* [`71936fca`](https://github.com/NixOS/nixpkgs/commit/71936fca9802aa6e0f500cd7f7050e2d70de8efb) corretto{11,17,21}: {11.0.24.8.1,17.0.12.7.1,21.0.4.7.1} -> {11.0.25.9.1,17.0.13.11.1,21.0.5.11.1}
* [`f6ce634c`](https://github.com/NixOS/nixpkgs/commit/f6ce634c1bb73e9748977b49a472bc65302c4025) python312Packages.accuweather: 3.0.0 -> 4.0.0
* [`822966ab`](https://github.com/NixOS/nixpkgs/commit/822966abb9caa1e4ae674d549240bd9a573f8818) rubyPackages.ncursesw: 1.4.10 -> 1.4.11
* [`f0119d67`](https://github.com/NixOS/nixpkgs/commit/f0119d67e47a75b4579ae707cebeec66f34de80b) kernelPackages.ivsc-driver: mark as broken on kernels >= 6.9
* [`27383769`](https://github.com/NixOS/nixpkgs/commit/273837695aa0668c16d13285131d196c9310b82d) pingvin-share: 1.3.0 -> 1.4.0
* [`b3676d1e`](https://github.com/NixOS/nixpkgs/commit/b3676d1ee144d34a58821d7584a5403eee9b780f) nixVersions.nix_2_25: add missing python build dep for mdbook
* [`b3d43231`](https://github.com/NixOS/nixpkgs/commit/b3d4323124a1dcbc1e7c611940e5e6d990000449) nix: remove unused paranthese/nixVersions variable
* [`23cd0388`](https://github.com/NixOS/nixpkgs/commit/23cd038879f9b5effb9ae9298037039808f55673) nixVersions.latest: set to nix 2.25
* [`130dc011`](https://github.com/NixOS/nixpkgs/commit/130dc0114e67e31be0f2c62e363cb0b861d3e02b) osquery: 5.13.1 -> 5.14.1
* [`59dc99c5`](https://github.com/NixOS/nixpkgs/commit/59dc99c57ee2c3ef2729098ff8c2772b056adeac) whitesur-gtk-theme: 2024.09.02 -> 2024-11-18
* [`002cd336`](https://github.com/NixOS/nixpkgs/commit/002cd3366ad60ccb0f5852abc731fb935f344e1c) hcloud: 1.48.0 -> 1.49.0
* [`c35f615a`](https://github.com/NixOS/nixpkgs/commit/c35f615aea0cbfcbed0cc7c0fde1fc46f7d3edd3) dragmap: init at 1.3.0
* [`cc0d0e84`](https://github.com/NixOS/nixpkgs/commit/cc0d0e84165bd2bcb438d7bae24d85f85a76eb5b) faircamp: 0.15.1 -> 0.21.0
* [`b515f281`](https://github.com/NixOS/nixpkgs/commit/b515f2811b677846cabebd14d8d2e7ad17949495) backblaze-b2: 4.0.1 -> 4.2.0
* [`7d2908b8`](https://github.com/NixOS/nixpkgs/commit/7d2908b81b65e7603cbc9ef0f3e11bb89996b3ab) sydbox: update meta.homepage
* [`bbedfbd0`](https://github.com/NixOS/nixpkgs/commit/bbedfbd065aaf48ae1a709010682e50aba56cefa) waveterm: fix hash mismatch
* [`ae6bb83a`](https://github.com/NixOS/nixpkgs/commit/ae6bb83a839b8cc688e4a1effe2c84519afd3a20) pdfium-binaries: fix updateScript
* [`f1244741`](https://github.com/NixOS/nixpkgs/commit/f124474196412865892dbc2402a966ee19bfb392) sea-orm-cli: 1.0.1 -> 1.1.1
* [`df5830d0`](https://github.com/NixOS/nixpkgs/commit/df5830d01308ba2e9801009d9df1c01a6f3d9a6c) gpauth: limit platforms to *-linux
* [`b978799f`](https://github.com/NixOS/nixpkgs/commit/b978799f716271a46b9d03a336e367e6ecadb7fb) lib.types.defaultTypeMerge: refactor functor.{payload,wrapped} merging
* [`27df1baa`](https://github.com/NixOS/nixpkgs/commit/27df1baaf14b8a0240b6c3df02074115342a4d8f) enscript: add meta.mainProgram
* [`704efbd9`](https://github.com/NixOS/nixpkgs/commit/704efbd9aa3494cf4f762737274c13e9e90ca393) opencomposite: add meta.platforms
* [`e65f4c7c`](https://github.com/NixOS/nixpkgs/commit/e65f4c7c1c5f12fca40bd82adc0a28246144d5fe) 2024.17 -> 2024.18
* [`b1182e54`](https://github.com/NixOS/nixpkgs/commit/b1182e548ab23fee1ab51b6e909f6a913452f462) luminance: init at 1.1.0
* [`32cb2b2a`](https://github.com/NixOS/nixpkgs/commit/32cb2b2abe5a4ed0419f0aa8e5f6ef55c5e7d2fe) check_interfaces: fix overuse of with lib
* [`af51a7fb`](https://github.com/NixOS/nixpkgs/commit/af51a7fb84ced3d514b359da91c37e5a1a05186b) manubulon-snmp-plugins: fix overuse of with lib
* [`30392773`](https://github.com/NixOS/nixpkgs/commit/30392773af69d096895a63b4988b5c8edb284333) openbsd_snmp3_check: fix overuse of with lib
* [`d8392c77`](https://github.com/NixOS/nixpkgs/commit/d8392c77b8f4869448c8f990d5e1de755caf8f08) wayclip: init at 0.4.2
* [`c3e90836`](https://github.com/NixOS/nixpkgs/commit/c3e908363d50c26907d38fcecfcfa37bbffa1425) python312Packages.tubeup: switch to pypa builder
* [`853d3489`](https://github.com/NixOS/nixpkgs/commit/853d34898d84b54977f24e5f1e13d1bcf6972cd8) nixos-containers: fix enableTun option
* [`7c1f2866`](https://github.com/NixOS/nixpkgs/commit/7c1f286645fc8908037a3c9da85175798e8b0878) telegram-desktop: 5.8.1 -> 5.8.2
* [`34845dd5`](https://github.com/NixOS/nixpkgs/commit/34845dd5f012d2de05b7e94a904c74542e489725) go9p: init at 0.25.0
* [`969ad19f`](https://github.com/NixOS/nixpkgs/commit/969ad19f9de5082630e706db37a838c04be138eb) nixos/monado: nixfmt
* [`e7e3755d`](https://github.com/NixOS/nixpkgs/commit/e7e3755d350284d9fd09c173e464ed56b4eed0e7) rabbitmq-server: migrate to the new macOS SDK
* [`dffdc710`](https://github.com/NixOS/nixpkgs/commit/dffdc71078d244f22f33b8849e73bc28b94b5c1e) python312Packages.language-data: 1.2.0 -> 1.3.0
* [`6b8507d7`](https://github.com/NixOS/nixpkgs/commit/6b8507d724ad51e0e80b85b2e454f682464869cb) hyprlauncher: 0.1.2 -> 0.2.2
* [`6c4d710b`](https://github.com/NixOS/nixpkgs/commit/6c4d710b94524c2b2c55adf79b571a8a42964a06) rustPlatform.buildRustPackage: allow specifying cargoDeps
* [`55a51905`](https://github.com/NixOS/nixpkgs/commit/55a51905434f3b52c729f6f9a38dab9313dfeb37) libdeltachat: use fetchCargoVendor
* [`4e75fe3d`](https://github.com/NixOS/nixpkgs/commit/4e75fe3db61cdf8a2bd70943dcb8fc0fb1334a0a) gitqlient: 1.6.2 -> 1.6.3
* [`db29b761`](https://github.com/NixOS/nixpkgs/commit/db29b761820cfde69a6f5a154ab3dc766bec608d) whitesur-kde: 2022-05-01-unstable-2024-11-01 -> 2024-11-18
* [`0082fde4`](https://github.com/NixOS/nixpkgs/commit/0082fde43de47be45a7b2daf7dcba9347f4f489c) notmuch: move the vim plugin to another output
* [`66d20ec1`](https://github.com/NixOS/nixpkgs/commit/66d20ec16fc69c477c2a6ca309a4ebe3fe72deb2) rubyPackages.ovirt-engine-sdk: set meta.broken
* [`daf33886`](https://github.com/NixOS/nixpkgs/commit/daf338866c371404efa98a33994942e55087afab) ams-lv2: Mark broken
* [`7cd5f8cd`](https://github.com/NixOS/nixpkgs/commit/7cd5f8cda00425cd4ed283642f9a297a17a8f6b6) texlive: 2023-final -> 2024.20241027
* [`9cae926b`](https://github.com/NixOS/nixpkgs/commit/9cae926b64e8bc770383adcb9976a75636ec7b87) python312Packages.manim: don't depend on texlive.ms
* [`a37d2451`](https://github.com/NixOS/nixpkgs/commit/a37d2451bc5922a908021bedd5950a94fd98d5f8) fossil: 2.24 -> 2.25
* [`b3f4b60d`](https://github.com/NixOS/nixpkgs/commit/b3f4b60d574415ef8863cce26f42a9d89fdf9481) grafana: 11.3.0+security-01 -> 11.3.1
* [`55883b6a`](https://github.com/NixOS/nixpkgs/commit/55883b6aaee9194792de7dde6162e3e78a74cf12) sarasa-gothic: 1.0.23 -> 1.0.24
* [`7de60082`](https://github.com/NixOS/nixpkgs/commit/7de6008292bc64753a115244ff8b8fab9809bcc5) python312Packages.bidsschematools: 0.11.3 -> 0.11.3.post3
* [`bcc8c9a3`](https://github.com/NixOS/nixpkgs/commit/bcc8c9a34366eda4d9263d2c65752a62ce821e86) intentrace: 0.2.5 -> 0.2.6
* [`dcfb0363`](https://github.com/NixOS/nixpkgs/commit/dcfb0363957378148c30f1c5f33b4994c52da5ae) python312Packages.gurobipy: 11.0.3 -> 12.0.0
* [`6e68add2`](https://github.com/NixOS/nixpkgs/commit/6e68add23712c0004b421d82c9a1e4e5f9e7d8d3) pugl: init at 0-unstable-2024-10-06
* [`f3f2f65e`](https://github.com/NixOS/nixpkgs/commit/f3f2f65e6343ba5e806733cc7e70750198bd799a) lvtk: 1.2.0 -> 1.2.0-unstable-2024-11-06
* [`54b5b8b0`](https://github.com/NixOS/nixpkgs/commit/54b5b8b06b87d931fbbaca410b6034e0e374d5a1) gurobi: reformat
* [`41cbe1fe`](https://github.com/NixOS/nixpkgs/commit/41cbe1fe27244a26567012f9aa367ff8c16f113e) gurobi: 11.0.3 -> 12.0.0
* [`b859583f`](https://github.com/NixOS/nixpkgs/commit/b859583f0019e72477f3e0e9b61b9cf25529c755) nostui: use upstream lock file
* [`229964fc`](https://github.com/NixOS/nixpkgs/commit/229964fc095c416054d0efd86d8678feb9adb239) python312Packages.forecast-solar: 3.1.0 -> 4.0.0
* [`1e44a426`](https://github.com/NixOS/nixpkgs/commit/1e44a426213f8b986493af7a002de9036c991353) gitify: init at 5.16.1
* [`e70f9703`](https://github.com/NixOS/nixpkgs/commit/e70f97033283b7d67b747835da7567f8917d18e3) cypress: add x86_64-darwin support
* [`f862225a`](https://github.com/NixOS/nixpkgs/commit/f862225a11680b8dbe2435ae8f13014c05181ee4) python314: 3.14.0a1 -> 3.14.0a2
* [`58dba3b4`](https://github.com/NixOS/nixpkgs/commit/58dba3b4da2aa68cfb55da18065616161f8637c2) cardinal: fix cross-compilation
* [`6a668a73`](https://github.com/NixOS/nixpkgs/commit/6a668a7390eef6d703c731922abccb102a81bdae) cardinal: nixfmt
* [`9e9e585c`](https://github.com/NixOS/nixpkgs/commit/9e9e585ca7c0806611c9868c97c118aa0e206c05) giada: format
* [`bd20b3a2`](https://github.com/NixOS/nixpkgs/commit/bd20b3a25f0b67854f14f4a40d765b6f23b7d356) giada: add missing fontconfig dependency
* [`df36d6b5`](https://github.com/NixOS/nixpkgs/commit/df36d6b5558cf9b5550d95348a6b135ef9801960) fltk: don't propagate fontconfig
* [`73acdf80`](https://github.com/NixOS/nixpkgs/commit/73acdf801667ffd0083b87258446e931361091e8) polyglot: init at version 3.5.1
* [`2a2670af`](https://github.com/NixOS/nixpkgs/commit/2a2670af0a628ddd91f8a80d217f4b33e2490605) util-linux: fix FreeBSD build
* [`2e46495e`](https://github.com/NixOS/nixpkgs/commit/2e46495ea8b46b22c983e3d3c6bff9a062451a2a) fishnet: 2.9.3 -> 2.9.4
* [`7d6d354a`](https://github.com/NixOS/nixpkgs/commit/7d6d354a153530d950acbe126809653a04963534) cinny-desktop: fix build failure
* [`68abfed4`](https://github.com/NixOS/nixpkgs/commit/68abfed4469dd0da9a060a69fbf0a80e5a94cdec) ferdium: 6.7.7 -> 7.0.0
* [`0179217f`](https://github.com/NixOS/nixpkgs/commit/0179217fb753adf1ebf21ff945fc7f7508861632) vscode-extensions.jetmartin.bats: init at 0.1.10
* [`80903fe4`](https://github.com/NixOS/nixpkgs/commit/80903fe41a5a724d953403ca0c389a8443a68e1d) qidi-slicer-bin: init at 1.2.0
* [`2d8bfa39`](https://github.com/NixOS/nixpkgs/commit/2d8bfa3908fb9ed5d3c405645e73e5c494d04d0b) hugo: 0.138.0 -> 0.139.0
* [`1dd96bb0`](https://github.com/NixOS/nixpkgs/commit/1dd96bb0f4ab4e539f6a1caf8941513c5bb12287) bambu-studio: 01.09.07.52 > 01.10.01.50
* [`89c0a160`](https://github.com/NixOS/nixpkgs/commit/89c0a1604a40a608fce404a86b416b3fac92308d) pnpm: 9.12.3 -> 9.14.2
* [`80386aad`](https://github.com/NixOS/nixpkgs/commit/80386aadf4ef787f6b01929f1af8007bce5f195f) dovecot_fts_xapian: 1.7.14 -> 1.8
* [`4dc27d25`](https://github.com/NixOS/nixpkgs/commit/4dc27d25a7e5661de4281993eeeef23fba56f1ec) python312Packages.ray: 2.38.0 -> 2.39.0
* [`44a747c3`](https://github.com/NixOS/nixpkgs/commit/44a747c34030ae38f51f61da5b930ec50a76c95c) katana: 1.1.0 -> 1.1.1
* [`be92b059`](https://github.com/NixOS/nixpkgs/commit/be92b059e929e63dcdf9342eab715dea5f6435b3) raycast: 1.85.2 -> 1.86.0
* [`f8c5ffa5`](https://github.com/NixOS/nixpkgs/commit/f8c5ffa59f340ae03b339e6db75262cd859edc9d) signal-desktop-beta: drop
* [`ea9b26a6`](https://github.com/NixOS/nixpkgs/commit/ea9b26a6ba703ebacbf0fd819d4f2e71a713c20f) gh-gei: 1.8.0 -> 1.9.0
* [`84e9fd9d`](https://github.com/NixOS/nixpkgs/commit/84e9fd9db5a9da04bde71b08e4553e96ea5c067d) nvtopPackages.full: mutually exclude gpus for darwin and linux
* [`37cf6e3e`](https://github.com/NixOS/nixpkgs/commit/37cf6e3ee61db025a21da52aa9121a1249b3153c) nvtopPackages: format
* [`088ac6b3`](https://github.com/NixOS/nixpkgs/commit/088ac6b39eae37775b5b6c34516017949ec8e756) nvtopPackages: set platform accordingly
* [`66644c73`](https://github.com/NixOS/nixpkgs/commit/66644c73b68734e3a7e5df748e6fd97a4624aa54) zoom-us: 6.2.5.* -> 6.2.10.*
* [`9afbaab2`](https://github.com/NixOS/nixpkgs/commit/9afbaab23f0861c64fd45e382e319ac6f9f9fb15) puncia: 0.15-unstable-2024-03-23 -> 0.24
* [`200c150a`](https://github.com/NixOS/nixpkgs/commit/200c150a5157b10f3204c4e1cff3d55654b9e8e8) python312Packages.archinfo: 9.2.128 -> 9.2.129
* [`7d677ba5`](https://github.com/NixOS/nixpkgs/commit/7d677ba5a162a8b676e884cd788755e304ebd05c) python312Packages.ailment: 9.2.128 -> 9.2.129
* [`d1ca2c77`](https://github.com/NixOS/nixpkgs/commit/d1ca2c779a52f4770ea33190c439fe9a2df54528) python312Packages.pyvex: 9.2.128 -> 9.2.129
* [`5ffafd6e`](https://github.com/NixOS/nixpkgs/commit/5ffafd6e202c53146cfbd38d9ae6194bcc776c0d) python312Packages.claripy: 9.2.128 -> 9.2.129
* [`f1bf4d74`](https://github.com/NixOS/nixpkgs/commit/f1bf4d74ef99397b15d17167656886d5a416586c) webdav: 5.4.2 -> 5.4.3
* [`4fba5287`](https://github.com/NixOS/nixpkgs/commit/4fba5287c3b2bb81da4ddd7718c54426fefbe98a) python312Packages.cle: 9.2.128 -> 9.2.129
* [`503dc93f`](https://github.com/NixOS/nixpkgs/commit/503dc93f1b99faedb2f20ff4eb6450f3cf44a854) python312Packages.angr: 9.2.128 -> 9.2.129
* [`4cecdc4c`](https://github.com/NixOS/nixpkgs/commit/4cecdc4c3310316baf443012ea093e13880abd3a) python312Packages.sudachipy: 0.6.8 -> 0.6.9
* [`2f620d4b`](https://github.com/NixOS/nixpkgs/commit/2f620d4b5a53140ed58798403e38e5d26051b5ba) python312Packages.aioopenexchangerates: 0.6.10 -> 0.6.13
* [`ee739016`](https://github.com/NixOS/nixpkgs/commit/ee73901639c3d23e29659fedc63c02ae7858e24d) python312Packages.pynina: 0.3.3 -> 0.3.4
* [`29e945ea`](https://github.com/NixOS/nixpkgs/commit/29e945ea362394a9f517ba5daa5af4766c1de29e) python312Packages.pynina: refactor
* [`ddb93970`](https://github.com/NixOS/nixpkgs/commit/ddb939709f59e67757b748ed03d4e6dda67888de) television: init at 0.5.0
* [`51a1c9ea`](https://github.com/NixOS/nixpkgs/commit/51a1c9eab08f8ec7f2fa1c327204f6076829e1f2) librewolf: 132.0.1-1 -> 132.0.2-1
* [`cba14f96`](https://github.com/NixOS/nixpkgs/commit/cba14f963eac3e9ec6fdb4850f8766b64d0f8f20) nextcloud: add news app
* [`dcbc753c`](https://github.com/NixOS/nixpkgs/commit/dcbc753c4fb5c51e93a6d1a277e2d57700779572) deskflow: 1.17.1 -> 1.17.2
* [`91fee431`](https://github.com/NixOS/nixpkgs/commit/91fee431005a26e238ecc6ed273eb3d413b0add6) nixos/monado: add forceDefaultRuntime option
* [`2f43c03c`](https://github.com/NixOS/nixpkgs/commit/2f43c03cc94e9edf071c27d11b0206b52dcf389e) python312Packages.hahomematic: 2024.10.17 -> 2024.11.7
* [`eb364e31`](https://github.com/NixOS/nixpkgs/commit/eb364e3146d29c91aab8871e071570d995acde29) home-assistant-custom-components.homematicip_local: 1.69.0 -> 1.71.0
* [`7a8b3506`](https://github.com/NixOS/nixpkgs/commit/7a8b3506edceed433a1aac74e24fe53772f735df) snis: update to the latest commit
* [`f5282620`](https://github.com/NixOS/nixpkgs/commit/f528262028f8a61c2c0d1cdb0e134b8279243169) uutils-coreutils: format
* [`1b7b747e`](https://github.com/NixOS/nixpkgs/commit/1b7b747e03104f2d22f71dd567a9aab2b8877c98) snis: add assets
* [`3b2787f1`](https://github.com/NixOS/nixpkgs/commit/3b2787f1aa804da7da1ddee6f148c3d9760f65a2) linuxKernel.packages.linux_6_11.evdi: autoformat with nixfmt
* [`7e6a6205`](https://github.com/NixOS/nixpkgs/commit/7e6a62051ed61a16904144f3593fe706bfad5999) linuxKernel.packages.linux_6_11.evdi: set broken for kernel >= 6.12
* [`63e45baa`](https://github.com/NixOS/nixpkgs/commit/63e45baa95b5300c3ee2463f1797a9dac3766931) linuxKernel.packages.linux_6_11.evdi: adopt maintenance
* [`31b9d154`](https://github.com/NixOS/nixpkgs/commit/31b9d15443de70e17e6cdd31b9b268c3bf7b77e4) postgresqlPackages.postgis: remove wolfgangwalther from maintainers
* [`1596e0aa`](https://github.com/NixOS/nixpkgs/commit/1596e0aa7dcfefa869eba720d3137154c29d97ed) OWNERS: add postgres team to own cargo-pgrx
* [`9e81eb84`](https://github.com/NixOS/nixpkgs/commit/9e81eb8444f62085e30f2ed5cad453b215b1c4ed) cargo-pgrx: 0.11.2 -> 0.12.6
* [`c8de5e8d`](https://github.com/NixOS/nixpkgs/commit/c8de5e8d85b10b19fa2cc1c08ebef979ff70ff8c) cargo-pgrx_0_10_2: remove
* [`7faa64b0`](https://github.com/NixOS/nixpkgs/commit/7faa64b0aa79fa16de9a983a0906de89ae0da097) cargo-pgrx_0_11_2: remove
* [`3903e189`](https://github.com/NixOS/nixpkgs/commit/3903e1897ab692d3d63f9bd33916a63d7e40935d) cargo-pgrx_0_11_3: remove
* [`7eac7962`](https://github.com/NixOS/nixpkgs/commit/7eac7962100ea534cf13211c6ba302542f596034) operator-sdk: 1.37.0 -> 1.38.0
* [`a5c5f98a`](https://github.com/NixOS/nixpkgs/commit/a5c5f98a5aeb0c59dc4b53b63c377577cfe28a6c) immich: 1.120.1 -> 1.121.0
* [`06c42637`](https://github.com/NixOS/nixpkgs/commit/06c42637cce311da42d842435881cbb34c2f3991) python312Packages.nbdev: 2.3.31 -> 2.3.32
* [`bdedbe34`](https://github.com/NixOS/nixpkgs/commit/bdedbe34dd3c0fe3f6eb2407a80e5433353eb31c) u3-tool: 0.3 -> 1.0
* [`0192be7d`](https://github.com/NixOS/nixpkgs/commit/0192be7d39a8ea16523093baf8caa7d683d865f1) u3-tool: use github mirror
* [`7496b4ce`](https://github.com/NixOS/nixpkgs/commit/7496b4ce2e63222b2bd164bc7967f4893097e958) u3-tool: fix style
* [`1563ad1a`](https://github.com/NixOS/nixpkgs/commit/1563ad1a619b7af35872c310adbaf8e6677c346f) python312Packages.pyhanko-certvalidator: 0.26.3 -> 0.26.5
* [`af517700`](https://github.com/NixOS/nixpkgs/commit/af5177004d0c765e40dc54bdaf9ffa587d515cb2) python312Packages.certomancer: 0.12.0 -> 0.12.3
* [`18ceb0aa`](https://github.com/NixOS/nixpkgs/commit/18ceb0aadbc18e6d93b423ee94d22d9fb0738c80) python312Packages.pyhanko: 0.25.1 -> 0.25.3
* [`d3b4ec2e`](https://github.com/NixOS/nixpkgs/commit/d3b4ec2ec0a1cb48c9970ae1bd986ec942bca687) openai-whisper-cpp: 1.7.1 -> 1.7.2
* [`618043c1`](https://github.com/NixOS/nixpkgs/commit/618043c125b0e9df59ec1fad1bde46877aa8a5a8) nph: fix build with nim-2.0
* [`32e0d3a3`](https://github.com/NixOS/nixpkgs/commit/32e0d3a3da7547ec0d6c8af04e95e51979c95c80) python312Packages.tensorly: unbreak (incorrect source hash)
* [`484eca6c`](https://github.com/NixOS/nixpkgs/commit/484eca6cecc8d6993f00bb9ca6e42991699302f2) llvmPackages.llvm-manpages: fix eval on Darwin
* [`95fc06c9`](https://github.com/NixOS/nixpkgs/commit/95fc06c959446938021835bd5054bdae64347611) ecapture: 0.8.9 -> 0.8.10
* [`2360e36d`](https://github.com/NixOS/nixpkgs/commit/2360e36da35814f5abd1d213ee6025ddf9bd7fd8) metacubexd: 1.168.0 -> 1.171.0
* [`5d844bc5`](https://github.com/NixOS/nixpkgs/commit/5d844bc5c66a9406a08ffb31b993da4644a4d1a2) waagent: 2.11.1.12 -> 2.12.0.2
* [`de907433`](https://github.com/NixOS/nixpkgs/commit/de9074338a5af6476cf7263a21b9cccb78d0edf6) ghstack: 0.9.3 -> 0.9.4
* [`0f18abcf`](https://github.com/NixOS/nixpkgs/commit/0f18abcf7ae515566122c4686fd287222f900e75) sqlitestudio: 3.4.4 -> 3.4.5
* [`bfc160a8`](https://github.com/NixOS/nixpkgs/commit/bfc160a84c63740ea4f82c8f1c7144dcc315836c) nixos/netbird: fix port conflict on metrics endpoint
* [`1bbcdc04`](https://github.com/NixOS/nixpkgs/commit/1bbcdc04144775a1390932de486deecb535fb552) tuxedo-drivers: 4.9.0 -> 4.11.3
* [`498c93d3`](https://github.com/NixOS/nixpkgs/commit/498c93d3dc6cdabc68c14dc543ba80adb06c9f5b) bambu-studio: move to by-name
* [`e90616da`](https://github.com/NixOS/nixpkgs/commit/e90616dafa1dd4599640f09369a73ca63bb59390) python312Packages.plugwise: 1.5.0 -> 1.5.2
* [`7cfd6b1d`](https://github.com/NixOS/nixpkgs/commit/7cfd6b1dca4450cbdfefc16667e05ab9d2deeb9b) python312Packages.mypy-boto3-autoscaling: 1.35.64 -> 1.35.66
* [`1ec61df3`](https://github.com/NixOS/nixpkgs/commit/1ec61df30bfbbe97557021e6228b77d0ee9c8000) python312Packages.mypy-boto3-cloudfront: 1.35.58 -> 1.35.66
* [`5605b660`](https://github.com/NixOS/nixpkgs/commit/5605b660a83ed9e391d13e9b6c44c2e8a93a1461) python312Packages.mypy-boto3-compute-optimizer: 1.35.0 -> 1.35.66
* [`b7e61c32`](https://github.com/NixOS/nixpkgs/commit/b7e61c323edc9668c3aae07d24c2a835c3e949d6) python312Packages.mypy-boto3-controltower: 1.35.59 -> 1.35.66
* [`6762af7a`](https://github.com/NixOS/nixpkgs/commit/6762af7afb3fb6ac93c960a6181e6d25dc706dc4) python312Packages.mypy-boto3-discovery: 1.35.0 -> 1.35.66
* [`2670b230`](https://github.com/NixOS/nixpkgs/commit/2670b230d328b1a3dd3cbad028337772e5f03a4c) python312Packages.mypy-boto3-ec2: 1.35.64 -> 1.35.66
* [`c05a6673`](https://github.com/NixOS/nixpkgs/commit/c05a66730e9ca37b0bfd9a70d045e55affbd41ab) python312Packages.mypy-boto3-ecs: 1.35.64 -> 1.35.66
* [`af615ff6`](https://github.com/NixOS/nixpkgs/commit/af615ff65ebcb9f816ce7449d6437a8fec080e0e) python312Packages.mypy-boto3-efs: 1.35.0 -> 1.35.65
* [`4a3e46a5`](https://github.com/NixOS/nixpkgs/commit/4a3e46a52a80c73199ab8d97dd00b329ad56344a) python312Packages.mypy-boto3-elbv2: 1.35.53 -> 1.35.66
* [`61da6627`](https://github.com/NixOS/nixpkgs/commit/61da662732f123673b780461d536ed466d39bbc7) python312Packages.mypy-boto3-glue: 1.35.53 -> 1.35.65
* [`b9daa5b1`](https://github.com/NixOS/nixpkgs/commit/b9daa5b17a1916ca121165decf4adacdfffd9628) python312Packages.mypy-boto3-keyspaces: 1.35.52 -> 1.35.65
* [`7e9d7c11`](https://github.com/NixOS/nixpkgs/commit/7e9d7c11cb21fdc69ff7ee1b41065175c39cbf3b) python312Packages.mypy-boto3-lambda: 1.35.58 -> 1.35.66
* [`2cdc0caa`](https://github.com/NixOS/nixpkgs/commit/2cdc0caa1b881001900f596fab3040baaefa1129) python312Packages.mypy-boto3-mediaconvert: 1.35.60 -> 1.35.66
* [`735e314e`](https://github.com/NixOS/nixpkgs/commit/735e314e2827e3ed52ae2ee4c68ffbfdc82b89b0) python312Packages.mypy-boto3-mediapackagev2: 1.35.50 -> 1.35.66
* [`14b1ca29`](https://github.com/NixOS/nixpkgs/commit/14b1ca29fde531eb73ce751dce690e26c23b79eb) python312Packages.mypy-boto3-mwaa: 1.35.0 -> 1.35.65
* [`0977439f`](https://github.com/NixOS/nixpkgs/commit/0977439f97eae4da36dfbd8d2251344ca281e29d) python312Packages.mypy-boto3-omics: 1.35.7 -> 1.35.66
* [`5211041f`](https://github.com/NixOS/nixpkgs/commit/5211041fcc1a1606c3ef930fdf5deb7ab367d07e) python312Packages.mypy-boto3-rbin: 1.35.0 -> 1.35.66
* [`ed158b37`](https://github.com/NixOS/nixpkgs/commit/ed158b375606c3cfd0b58a15f6b8812db8807b5c) python312Packages.mypy-boto3-rds: 1.35.64 -> 1.35.66
* [`b8afc350`](https://github.com/NixOS/nixpkgs/commit/b8afc3502b664fe1dac47ced61dff559e1af57ce) python312Packages.mypy-boto3-timestream-query: 1.35.46 -> 1.35.66
* [`ec2510ec`](https://github.com/NixOS/nixpkgs/commit/ec2510ecc93b0b8251ffc751ec7d9c545164d704) python312Packages.mypy-boto3-workspaces: 1.35.43 -> 1.35.66
* [`42aa7a08`](https://github.com/NixOS/nixpkgs/commit/42aa7a0817f265db2838f56429ec2f027df3ceaa) python312Packages.mypy-boto3-workspaces-web: 1.35.23 -> 1.35.66
* [`263f287c`](https://github.com/NixOS/nixpkgs/commit/263f287ccd1f2b8e926b27ec55655da8fe6ae783) python312Packages.aiortm: 0.9.25 -> 0.9.32
* [`1e5fa976`](https://github.com/NixOS/nixpkgs/commit/1e5fa97649f4f1fd9d260b9d39e69ffa82c361ef) python312Packages.publicsuffixlist: 1.0.2.20241108 -> 1.0.2.20241121
* [`bf4c8fc5`](https://github.com/NixOS/nixpkgs/commit/bf4c8fc53aa0a3c65a6930c0a411ba0f1a093f6c) python312Packages.pywerview: 0.7.0 -> 0.7.1
* [`d65d18f1`](https://github.com/NixOS/nixpkgs/commit/d65d18f1e48709dfdc7ca70b8945a1818aa870b5) ci: use nix 2.24
* [`aeb56c6e`](https://github.com/NixOS/nixpkgs/commit/aeb56c6e8d14c989bd634500a1701e71a3320c3d) trufflehog: 3.82.13 -> 3.84.0
* [`fffbbb85`](https://github.com/NixOS/nixpkgs/commit/fffbbb85bb255c97005ae4a94e0a754addf443f9) qtscrcpy: switch to latest ffmpeg
* [`85872d7f`](https://github.com/NixOS/nixpkgs/commit/85872d7fe6904c8e7b47107924f2877ce0f017cb) scilla: 1.3.0 -> 1.3.1
* [`a8ef375d`](https://github.com/NixOS/nixpkgs/commit/a8ef375d9cac66445698fb4ba88f2a7c7d9c084d) python312Packages.pylacus: 1.11.1 -> 1.12.0
* [`6f447d18`](https://github.com/NixOS/nixpkgs/commit/6f447d18a2e232d6e40656a3897dbaaea46f5df9) nuclei-templates: 10.0.3 -> 10.0.4
* [`d81d18c9`](https://github.com/NixOS/nixpkgs/commit/d81d18c9d59a123276685fdf0226c36725297e75) gnome: replace alias with throw
* [`4edaf66e`](https://github.com/NixOS/nixpkgs/commit/4edaf66e64724515be35a79d7eb0f97bc98f981c) python312Packages.language-data: update disabled
* [`ef1aab32`](https://github.com/NixOS/nixpkgs/commit/ef1aab32c9f6b507bff113ca142695b8e6191a58) kid3: 3.9.5 -> 3.9.6
* [`3fe9c65d`](https://github.com/NixOS/nixpkgs/commit/3fe9c65da3d4a702b94de3635a5796138f129c97) python312Packages.accuweather: 3.0.0 -> 4.0.0
* [`4d5c03fa`](https://github.com/NixOS/nixpkgs/commit/4d5c03fa7fec2b6d9a4d55fe7435d61db2d6ac00) omnom: 0-unstable-2024-08-29 -> 0-unstable-2024-10-01
* [`9e7cbd10`](https://github.com/NixOS/nixpkgs/commit/9e7cbd1095934de179850ec75ef44ed98bdb739a) omnom: package Firefox and Chrome addons
* [`f7729271`](https://github.com/NixOS/nixpkgs/commit/f7729271c847d3fd4b96fda10855aa46c8aa4721) omnom: don't wrap binary or patch config
* [`bb3bf678`](https://github.com/NixOS/nixpkgs/commit/bb3bf678201ff12abc2ffc516db77b0addb64487) omnom: 0-unstable-2024-10-01 -> 0-unstable-2024-11-20
* [`cc6c634b`](https://github.com/NixOS/nixpkgs/commit/cc6c634b45378708e9f39869cc9e7c38fa86c177) python312Packages.bluetooth-adapters: 0.20.0 -> 0.20.2
* [`0c94fb56`](https://github.com/NixOS/nixpkgs/commit/0c94fb56a695baa19f793ec4cf32825b5fb5f43c) cloak: move to by-name
* [`d6a60466`](https://github.com/NixOS/nixpkgs/commit/d6a60466acab0cebdde1b3b7eb9f3bce44414b4d) doing: move to by-name
* [`e43015af`](https://github.com/NixOS/nixpkgs/commit/e43015afa25b1d47e5ab2cd06a56aa14bbed759e) pt: move by-name
* [`3ed0997e`](https://github.com/NixOS/nixpkgs/commit/3ed0997e718588e04f974b42c0d8d5f607179380) xpadneo: fix build issues for kernel 6.12
* [`c44a31d3`](https://github.com/NixOS/nixpkgs/commit/c44a31d3eac2996fea66179440b76d8c1e45f5f6) gollum: move by-name
* [`339478c8`](https://github.com/NixOS/nixpkgs/commit/339478c850e90c0d86da082b0f731b3e1bd47563) cotp: move by-name
* [`22260d79`](https://github.com/NixOS/nixpkgs/commit/22260d7916e476d8a892554494776c8446a5fb76) acpic: move by-name
* [`2196a645`](https://github.com/NixOS/nixpkgs/commit/2196a645143a64b1886f68ba6147352ec70e5917) taskjuggler: move by-name
* [`f585591d`](https://github.com/NixOS/nixpkgs/commit/f585591dc65e5cfb5738180cbfb2ea9ca9f804c7) pdfposter: move by-name
* [`af205724`](https://github.com/NixOS/nixpkgs/commit/af2057249eacdb23c42e3b7ec83040afd791ef34) jekyll: move by-name
* [`d696a5a5`](https://github.com/NixOS/nixpkgs/commit/d696a5a53d7e195fa003ee5150fc40b9db7f7ab5) coltrane: move by-name
* [`eca7e4cc`](https://github.com/NixOS/nixpkgs/commit/eca7e4cc74c0021aa91f11a719391011145f158d) python312Packages.certbot-dns-ovh: ignore DeprecationWarning
* [`487e5351`](https://github.com/NixOS/nixpkgs/commit/487e53512283f9ccd20fe0e9888c32adff7e1442) python312Packages.certbot-dns-cloudflare: ignore DeprecationWarning
* [`3dcad335`](https://github.com/NixOS/nixpkgs/commit/3dcad335b14fee939b4c2ae5c51f47b91a78072a) python312Packages.certbot-dns-rfc2136: ignore DeprecationWarning
* [`4992f622`](https://github.com/NixOS/nixpkgs/commit/4992f62249954cb5e70666251b75f77645c94882) python312Packages.certbot-dns-route53: ignore DeprecationWarning
* [`4d874d59`](https://github.com/NixOS/nixpkgs/commit/4d874d59e2a06a255487d3a4ccff5a8e720de440) lib.systems.examples: set `rust.rustcTarget` for ucrtAarch64
* [`14a02190`](https://github.com/NixOS/nixpkgs/commit/14a02190a3a6bf51016f928adc9ec6d98ab56c53) python312Packages.certbot-dns-route53: refactor
* [`b79710e0`](https://github.com/NixOS/nixpkgs/commit/b79710e0affa31fb83a376801702acb6fb4906ab) go-musicfox: 4.5.3 -> 4.5.7
* [`aec5f24f`](https://github.com/NixOS/nixpkgs/commit/aec5f24fed9194acc1fe4789108db76ceea5393d) go-musicfox: format with nixfmt-rfc-style
* [`0f51db0c`](https://github.com/NixOS/nixpkgs/commit/0f51db0c72a4aad1bc2a71e17614d2af55eead61) python312Packages.aiosonic: 0.21.0 -> 0.22.0
* [`778a616b`](https://github.com/NixOS/nixpkgs/commit/778a616b69640491c39087c29467f64ecf1e5cf8) yandex-music: 5.23.2 -> 5.28.4
* [`c1452c0a`](https://github.com/NixOS/nixpkgs/commit/c1452c0a854ad0583839a0a670cbc2b854a1032a) python312Packages.azure-mgmt-extendedlocation: 1.1.0 -> 2.0.0
* [`7c52aa1e`](https://github.com/NixOS/nixpkgs/commit/7c52aa1efe9e3e41374bff013641b0057a162844) python312Packages.azure-mgmt-containerservice: 32.1.0 -> 33.0.0
* [`042a1e2c`](https://github.com/NixOS/nixpkgs/commit/042a1e2c7f5e043ae01d5cda998cc4a0efbd48fa) python312Packages.azure-mgmt-cosmosdb: 9.6.0 -> 9.7.0
* [`2d034292`](https://github.com/NixOS/nixpkgs/commit/2d0342923eb3f3746e7dd072339ab22c5351feed) denaro: move to by-name
* [`4057acc5`](https://github.com/NixOS/nixpkgs/commit/4057acc55bb961e8160b8232a46ee4c2cc772915) python312Packages.azure-keyvault-administration: 4.4.0 -> 4.5.0
* [`ad58af67`](https://github.com/NixOS/nixpkgs/commit/ad58af67b2f6e4c400346d76fe7deb0cdccbe366) python312Packages.azure-keyvault-certificates: 4.8.0 -> 4.9.0
* [`bdc85f48`](https://github.com/NixOS/nixpkgs/commit/bdc85f4819486792fb4029c859a5a76a50406049) python312Packages.azure-keyvault-keys: 4.9.0 -> 4.10.0
* [`32294d92`](https://github.com/NixOS/nixpkgs/commit/32294d92ef0df7d49d6c86488a2533baea6e90df) python312Packages.azure-keyvault-secrets: 4.8.0 -> 4.9.0
* [`ae0fb8ec`](https://github.com/NixOS/nixpkgs/commit/ae0fb8ecbabbcc7f2d12f9ab894db88498eb390c) python312Packages.azure-storage-file-share: 12.19.0 -> 12.20.0
* [`0ceb3a73`](https://github.com/NixOS/nixpkgs/commit/0ceb3a735b0a55dd657734759cb6602159fbe1d6) nixos-rebuild-ng: lazy import tabulate
* [`d55f8c84`](https://github.com/NixOS/nixpkgs/commit/d55f8c84a5af62834e028bc59c10f7daeb67d1de) nixos-rebuild-ng: reduce build closure by moving checks to passthru.tests
* [`4def1076`](https://github.com/NixOS/nixpkgs/commit/4def107627bcca82a66b1e88d9912b5acf131c0c) nixos-rebuild-ng: generate `.version-suffix` for classic Nix
* [`a8b2af2a`](https://github.com/NixOS/nixpkgs/commit/a8b2af2a12012158bac9d8fd6196855c24df3b17) nixos-rebuild-ng: add devShell
* [`c66e65cb`](https://github.com/NixOS/nixpkgs/commit/c66e65cb2ea8f37cd0f39cde2007f50e71f0f2bc) nixos-rebuild-ng: use python3Packages
* [`7183c4d4`](https://github.com/NixOS/nixpkgs/commit/7183c4d4cecde526bc1d825546c5598012850787) python312Packages.azure-mgmt-scheduler: 2.0.0 -> 7.0.0
* [`6049524d`](https://github.com/NixOS/nixpkgs/commit/6049524d7011541d091ffd73a8c9369566dd8f38) python312Packages.google-cloud-redis: 2.16.0 -> 2.16.1
* [`f4b2553b`](https://github.com/NixOS/nixpkgs/commit/f4b2553be7b3e17978f8bbcbe20827dd3dd6b792) python312Packages.restview: 3.0.1 -> 3.0.2
* [`6e7fc8cd`](https://github.com/NixOS/nixpkgs/commit/6e7fc8cdeb6742c30cb788828419ef77f235dd14) python312Packages.strawberry-graphql: 0.243.1 -> 0.251.0
* [`ebc7f539`](https://github.com/NixOS/nixpkgs/commit/ebc7f53961b371b84e3cf024bf56c14be2061a43) python312Packages.yfinance: 0.2.49 -> 0.2.50
* [`11284956`](https://github.com/NixOS/nixpkgs/commit/112849562033d30a725e0439dc89de64898e7ca6) font-awesome: 6.6.0 -> 6.7.1
* [`b97f7bee`](https://github.com/NixOS/nixpkgs/commit/b97f7beed1b260dd523bb22fcf410b5500418044) xxx-pe: move to by-name
* [`427ffbc9`](https://github.com/NixOS/nixpkgs/commit/427ffbc994f51b26922b47e25bf3c97bdedd7c55) botamusique: move to by-name
* [`fb61e646`](https://github.com/NixOS/nixpkgs/commit/fb61e646af0033d107b479e4952641fc1a7988b6) loudgain: move to by-name
* [`687fa135`](https://github.com/NixOS/nixpkgs/commit/687fa135815cda7e95c69fa81cf80d5f6325aa32) mpdcron: move to by-name
* [`76fe1041`](https://github.com/NixOS/nixpkgs/commit/76fe1041bea3c84e2984b588b581b2c870483516) pantheon.sideload: 6.2.2 -> 6.3.0
* [`7a36e6dd`](https://github.com/NixOS/nixpkgs/commit/7a36e6ddbdecaaf90e7412c8982e0c6b50d2cb2a) pantheon.elementary-gtk-theme: 8.1.0 -> 8.2.0
* [`2b331f34`](https://github.com/NixOS/nixpkgs/commit/2b331f344cca4c5460ea8d3844ea608754479148) castopod: move to by-name
* [`35d963f9`](https://github.com/NixOS/nixpkgs/commit/35d963f9c5c769a63510072cbeff6725925410e7) pantheon.switchboard-plug-about: Backport fwupd 2.0.0 support
* [`d8e54550`](https://github.com/NixOS/nixpkgs/commit/d8e545500a7adbf0a4c010dee1c055f33248c232) pantheon.elementary-settings-daemon: Backport fwupd 2.0.0 support
* [`cd04f10e`](https://github.com/NixOS/nixpkgs/commit/cd04f10e7e21a0dd354cd12b1f85e68bf4bb1b05) psst: move to by-name
* [`f742f884`](https://github.com/NixOS/nixpkgs/commit/f742f88460f78ac3219ae45bf4d86ecf7d438211) tsukimi: 0.16.9 -> 0.17.3
* [`aadaa13a`](https://github.com/NixOS/nixpkgs/commit/aadaa13a0ec05f1f571e59edb208d9af5d94a36c) lyra-cursors: init at 0-unstable-2021-12-04
* [`7c2fe325`](https://github.com/NixOS/nixpkgs/commit/7c2fe325787c0f1dd44c7618ab2f0ab8f8c8e7de) neovim: fix ruby provider warning
* [`68383498`](https://github.com/NixOS/nixpkgs/commit/6838349887e145166d798b55352aed9083e9a99a) php84: 8.4.0RC4 -> 8.4.1
* [`080b8f1f`](https://github.com/NixOS/nixpkgs/commit/080b8f1f576d278a58319cfa35a41813fbe4c244) php-packages: remove the merged soap patch
* [`be3a3ad0`](https://github.com/NixOS/nixpkgs/commit/be3a3ad0dafa586ee21d504226a02a357f867d40) opentelemetry-collector-builder: 0.112.0 -> 0.114.0
* [`b7f57e3b`](https://github.com/NixOS/nixpkgs/commit/b7f57e3b18ececeebe66c0f0e51fd28b5d217ceb) opentelemetry-collector-releases: init at 0.114.0
* [`f89fdc3f`](https://github.com/NixOS/nixpkgs/commit/f89fdc3f6c38670cb26759745d2a87e146db37d2) opentelemetry-collector: alias to opentelemetry-collector-releases.otelcol
* [`3b73cec2`](https://github.com/NixOS/nixpkgs/commit/3b73cec2ccb5193e51601d5b1b786bb2e1c7c29d) opentelemetry-collector-contrib: alias to opentelemetry-collector-releases.otelcol-contrib
* [`1f62f585`](https://github.com/NixOS/nixpkgs/commit/1f62f5853591f4586e4edcabc9648bcde1f1525e) opentelemetry-collector-builder: move to the package set
* [`bf180635`](https://github.com/NixOS/nixpkgs/commit/bf180635cffea564af79f0ef66146a602f8b706c) mdbook-alerts: 0.6.7 -> 0.6.10
* [`d37748d6`](https://github.com/NixOS/nixpkgs/commit/d37748d62e43511738576b27b2a11e0f067db81d) plfit: 0.9.6 -> 1.0.0
* [`c1e1a94f`](https://github.com/NixOS/nixpkgs/commit/c1e1a94f22ad2a4673bdc216ad91a36ef616fa36) python312Packages.plotnine: 0.14.1 -> 0.14.2
* [`b441ea9a`](https://github.com/NixOS/nixpkgs/commit/b441ea9a9f5bae4476ea5900d87deaa8e5aee5ea) linux/hardened/patches/5.10: v5.10.229-hardened1 -> v5.10.230-hardened1
* [`abb7a527`](https://github.com/NixOS/nixpkgs/commit/abb7a527f6be97f329507bfea16e8b38fdb9da0f) linux/hardened/patches/5.15: v5.15.171-hardened1 -> v5.15.173-hardened1
* [`6c769a79`](https://github.com/NixOS/nixpkgs/commit/6c769a79a9e5c4830d8165192a87704534da5580) linux/hardened/patches/5.4: v5.4.285-hardened1 -> v5.4.286-hardened1
* [`6fe36d8e`](https://github.com/NixOS/nixpkgs/commit/6fe36d8ed86a24521924f4c3aef2e8b1eeebd5a6) linux/hardened/patches/6.1: v6.1.116-hardened1 -> v6.1.118-hardened1
* [`3f0de246`](https://github.com/NixOS/nixpkgs/commit/3f0de246f44a2627312327f3e30c27d50748e979) linux/hardened/patches/6.11: v6.11.7-hardened1 -> v6.11.9-hardened1
* [`9590e322`](https://github.com/NixOS/nixpkgs/commit/9590e3221f7ad2e33d2f288e5d6555f8500bb47d) linux/hardened/patches/6.6: v6.6.60-hardened1 -> v6.6.62-hardened1
* [`932358f6`](https://github.com/NixOS/nixpkgs/commit/932358f69549688699ad8402b24ee77d68a3fb74) rabbit: 2.2.0 -> 2.3.1
* [`e7b85eac`](https://github.com/NixOS/nixpkgs/commit/e7b85eaca5c8426cfa2f19e96a93cccdca94f3f5) amazon-ssm-agent: skip additional flaky test
* [`519e0e44`](https://github.com/NixOS/nixpkgs/commit/519e0e44cfb5b94577cac42c96c44a25ee8bd4d0) python312Packages.aemet-opendata: 0.5.4 -> 0.5.5
* [`7019530d`](https://github.com/NixOS/nixpkgs/commit/7019530d14ef35645f04a9037cd21355a4661036) bisq-desktop: drop
* [`1ffc3bc1`](https://github.com/NixOS/nixpkgs/commit/1ffc3bc18c9cbcc134db29d59c0cc5f386327c07) oauth2c: 1.16.0 -> 1.17.0
* [`717e0a53`](https://github.com/NixOS/nixpkgs/commit/717e0a53ec2394aabb45b2d3ec2dfc471007d331) python3Packages.flask-allowed-hosts: init at 1.1.2
* [`ad869c8f`](https://github.com/NixOS/nixpkgs/commit/ad869c8f179b603ba093f5204804a106e86b5aec) open-web-calendar: init at 1.41
* [`897954b8`](https://github.com/NixOS/nixpkgs/commit/897954b8ae5c2cac7d61c9406aded112edc02750) nixos/open-web-calendar: init module
* [`6a24c125`](https://github.com/NixOS/nixpkgs/commit/6a24c125f8ca9ebd992cbde3e6016a4e6836dc25) python312Packages.msgraph-core: 1.1.6 -> 1.1.7
* [`d18faf4b`](https://github.com/NixOS/nixpkgs/commit/d18faf4b8fd0822e8d1367a1eeaefb6e0061a76f) ocamlPackages.typerep: 0.17.0 → 0.17.1
* [`01dbbb39`](https://github.com/NixOS/nixpkgs/commit/01dbbb39ec485d437fad2db25293f4a375a263ac) python312Packages.pygelf: init at 0.4.2
* [`df9a80ca`](https://github.com/NixOS/nixpkgs/commit/df9a80ca76d4db2aabc06bbc7a185c1374f39328) python312Packages.parsedmarc: add missing `pygelf` dependency
* [`2c6c67a6`](https://github.com/NixOS/nixpkgs/commit/2c6c67a61d8889e4ef2a9e6a354eb4e0c6d2b255) python312Packages.mail-parser: 4.0.0 -> 4.1.2
* [`c532371d`](https://github.com/NixOS/nixpkgs/commit/c532371d8423fb13baaa7c5a41790b7be0a0de17) python312Packages.mailsuite: 1.9.16 -> 1.9.18
* [`d60df245`](https://github.com/NixOS/nixpkgs/commit/d60df245ce98d22bb333abc09803ac8a4dd5a059) python312Packages.opensearch-py: fix build
* [`706ea6e2`](https://github.com/NixOS/nixpkgs/commit/706ea6e2e46d1d649ac7875156b1dae6502284b4) python312Packages.json-repair: 0.29.6 -> 0.30.2
* [`bcbc708e`](https://github.com/NixOS/nixpkgs/commit/bcbc708ec83462e62bc61a6cbcc2092cbf18dc83) soplex: 7.1.1 -> 712
* [`19713d84`](https://github.com/NixOS/nixpkgs/commit/19713d8414a636d0e2987f32f8f80aaa4c9cdace) infisical: 0.31.2 -> 0.31.8
* [`88a3df2d`](https://github.com/NixOS/nixpkgs/commit/88a3df2ded6091ce91c717ae1c32d903f627d71d) syshud: 0-unstable-2024-11-04 -> 0-unstable-2024-11-12
* [`edadf1c8`](https://github.com/NixOS/nixpkgs/commit/edadf1c80fc4047aa6d963b6f5488df1fe4f5072) supermariowar: 2023-unstable-2024-09-21 -> 2023-unstable-2024-10-17
* [`5742cb2a`](https://github.com/NixOS/nixpkgs/commit/5742cb2a483f90917eca2fc38a47cd7745a1495b) kubo: 0.29.0 -> 0.30.0
* [`fba84616`](https://github.com/NixOS/nixpkgs/commit/fba84616e53e619f1f5c95dfb4e01d4043f7b59e) kubo: 0.30.0 -> 0.32.1
* [`c824630f`](https://github.com/NixOS/nixpkgs/commit/c824630f080e5faaa7b45ba1893dfe12d5a1d3a1) stackblur-go: init at 1.1.0
* [`27a548c0`](https://github.com/NixOS/nixpkgs/commit/27a548c0322026a8d95a98297032584ee78a4e25) maintainers: add amadaluzia
* [`6c8ee2df`](https://github.com/NixOS/nixpkgs/commit/6c8ee2dfff97adc12d8ea95b6181855ed7ff0546) antimatter-dimensions: 0-unstable-2024-08-12 -> 0-unstable-2024-10-16
* [`db1a6859`](https://github.com/NixOS/nixpkgs/commit/db1a685947b2d2aba8859b38a28f0123daf12f3b) fix([nixos/nixpkgs⁠#356524](https://togithub.com/nixos/nixpkgs/issues/356524)): update nim mangling patch
* [`2e9c42e1`](https://github.com/NixOS/nixpkgs/commit/2e9c42e1c8a766fcefa869eee93dbb13d48a75ed) dnslink-std-go: init at 0.6.0
* [`50bbfb57`](https://github.com/NixOS/nixpkgs/commit/50bbfb5788f82535cdd5046cf1aa7c9da588a258) nixos/nncp: recursively merge configurations
* [`edc180ad`](https://github.com/NixOS/nixpkgs/commit/edc180ad4db9f47f8d949e2f880cfebb436a0378) remnote: 1.16.127 -> 1.17.21
* [`abbbd12e`](https://github.com/NixOS/nixpkgs/commit/abbbd12e01ff609c94ada6e95da5535338261fe0) drone-oss: 2.24.0 -> 2.25.0
* [`68dd66c6`](https://github.com/NixOS/nixpkgs/commit/68dd66c61e78417f4271144ac598ed78e79bce26) python312Packages.cftime: 1.6.4 -> 1.6.4.post1
* [`19db54ed`](https://github.com/NixOS/nixpkgs/commit/19db54eda1057089c1c64c2a06758c41a4ff67b1) workflows/eval: Minor fixes, ensure the correct commit is checked out
* [`bb19beaf`](https://github.com/NixOS/nixpkgs/commit/bb19beaf770f52ba83c3951fa10fa978c88d098a) OWNERS: Add myself to .github/workflows
* [`eb2872ea`](https://github.com/NixOS/nixpkgs/commit/eb2872ea67f6633d9681c511063b41303f908d9a) nixos-render-docs: don't validate redirects if none were given
* [`9597f362`](https://github.com/NixOS/nixpkgs/commit/9597f3627e5a88061ef5d34b266ec5dbf4c93832) vimPlugins.lspecho-nvim: init at 2024-10-06
* [`67000353`](https://github.com/NixOS/nixpkgs/commit/670003530c1b6b990ca06d373396a5a40f6a0901) python3Packages.pytest-smtpd: init at 0.1.0
* [`ea8280c3`](https://github.com/NixOS/nixpkgs/commit/ea8280c3a479734bd0c1023c15431e9a3b252d85) python3Packages.slapd: init at 0.1.5
* [`45cc7f41`](https://github.com/NixOS/nixpkgs/commit/45cc7f418109740a59d000a10b6490898e65be13) python3Packages.flask-webtest: init at 0.1.4
* [`e45e3313`](https://github.com/NixOS/nixpkgs/commit/e45e3313af1c07fc1c482566592b8c87d5d7f312) pythonPackages.sqlalchemy-json: init at 0.7.0
* [`d6f955ba`](https://github.com/NixOS/nixpkgs/commit/d6f955ba9b7207b53cd809d4b8394f464f954b0d) python3Packages.flask-themer: init at 2.0.0
* [`6849c636`](https://github.com/NixOS/nixpkgs/commit/6849c636b475e85e6450b53f6891e23079f16cd4) python3Packages.zxcvbn-rs-py: init at 0.1.1
* [`09c2d481`](https://github.com/NixOS/nixpkgs/commit/09c2d481c18d03ec0409b751c99ad048942bd175) canaille: init at 0.0.56
* [`ff2f00d4`](https://github.com/NixOS/nixpkgs/commit/ff2f00d425fc9e342582b8f69065f1584b63a369) nixos/canaille: init module
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
