### PR TITLE
niv zsh-autosuggestions: update e52ee8ca -> 0e810e5a

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -149,10 +149,10 @@
         "homepage": null,
         "owner": "zsh-users",
         "repo": "zsh-autosuggestions",
-        "rev": "e52ee8ca55bcc56a17c828767a3f98f22a68d4eb",
-        "sha256": "02p5wq93i12w41cw6b00hcgmkc8k80aqzcy51qfzi0armxig555y",
+        "rev": "0e810e5afa27acbd074398eefbe28d13005dbc15",
+        "sha256": "0y866dsm8l164afbyd9cafbl97yf9viqwms9bbn0799nwgsb15pk",
         "type": "tarball",
-        "url": "https://github.com/zsh-users/zsh-autosuggestions/archive/e52ee8ca55bcc56a17c828767a3f98f22a68d4eb.tar.gz",
+        "url": "https://github.com/zsh-users/zsh-autosuggestions/archive/0e810e5afa27acbd074398eefbe28d13005dbc15.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "zsh-histdb": {


### PR DESCRIPTION
## Changelog for zsh-autosuggestions:
Branch: master
Commits: [zsh-users/zsh-autosuggestions@e52ee8ca...0e810e5a](https://github.com/zsh-users/zsh-autosuggestions/compare/e52ee8ca55bcc56a17c828767a3f98f22a68d4eb...0e810e5afa27acbd074398eefbe28d13005dbc15)

* [`f9526195`](https://github.com/zsh-users/zsh-autosuggestions/commit/f9526195c50ddf2cec64e0ce6310bc5a68d4c340) Fixes link for nixos package
