### PR TITLE
niv zsh-syntax-highlighting: update e0165eaa -> 5eb677bb

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -197,10 +197,10 @@
         "homepage": "github.com/zsh-users/zsh-syntax-highlighting",
         "owner": "zsh-users",
         "repo": "zsh-syntax-highlighting",
-        "rev": "e0165eaa730dd0fa321a6a6de74f092fe87630b0",
-        "sha256": "016adxfxk29akcmkhn9v11sar0plmfcnp4hfn3w03457wqvvddg2",
+        "rev": "5eb677bb0fa9a3e60f0eff031dc13926e093df92",
+        "sha256": "1x33gk7hhp07jqq7yjvrsp2vmdbxmadlv3335ixx29bc6h8106r9",
         "type": "tarball",
-        "url": "https://github.com/zsh-users/zsh-syntax-highlighting/archive/e0165eaa730dd0fa321a6a6de74f092fe87630b0.tar.gz",
+        "url": "https://github.com/zsh-users/zsh-syntax-highlighting/archive/5eb677bb0fa9a3e60f0eff031dc13926e093df92.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "zsh-you-should-use": {


### PR DESCRIPTION
## Changelog for zsh-syntax-highlighting:
Branch: master
Commits: [zsh-users/zsh-syntax-highlighting@e0165eaa...5eb677bb](https://github.com/zsh-users/zsh-syntax-highlighting/compare/e0165eaa730dd0fa321a6a6de74f092fe87630b0...5eb677bb0fa9a3e60f0eff031dc13926e093df92)

* [`5eb677bb`](https://github.com/zsh-users/zsh-syntax-highlighting/commit/5eb677bb0fa9a3e60f0eff031dc13926e093df92) 'main' tests: Don't assume ps(1) is available.
