### PR TITLE
niv emacs-overlay: update cedccfff -> d902534f

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "cedccfff0d6e1fb9c62f77fb4e05169256219eca",
-        "sha256": "10v2b8ids65injk724zkgc5dag86yi4ilw2dgbnsp195dpd8jqw3",
+        "rev": "d902534f27fea8439422e55c435d4b4bbf8a2472",
+        "sha256": "10pmagj761vpmg3mvjwg1yfidxhcmpyjwgyswbbwg5g1sb21avcs",
         "type": "tarball",
-        "url": "https://github.com/nix-community/emacs-overlay/archive/cedccfff0d6e1fb9c62f77fb4e05169256219eca.tar.gz",
+        "url": "https://github.com/nix-community/emacs-overlay/archive/d902534f27fea8439422e55c435d4b4bbf8a2472.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "fast-syntax-highlighting": {


### PR DESCRIPTION
## Changelog for emacs-overlay:
Branch: master
Commits: [nix-community/emacs-overlay@cedccfff...d902534f](https://github.com/nix-community/emacs-overlay/compare/cedccfff0d6e1fb9c62f77fb4e05169256219eca...d902534f27fea8439422e55c435d4b4bbf8a2472)

* [`c03f4449`](https://github.com/nix-community/emacs-overlay/commit/c03f4449e43800db63e6a909575e40837a982b8a) Updated nongnu
* [`a0196e4a`](https://github.com/nix-community/emacs-overlay/commit/a0196e4a9da85a7f06d9f79110e70d97e57cfbed) Updated elpa
* [`fc37a2fa`](https://github.com/nix-community/emacs-overlay/commit/fc37a2fa36fce96e3e3bc44f79db2cecf57343f4) Updated emacs
* [`ceebeec9`](https://github.com/nix-community/emacs-overlay/commit/ceebeec902a34e822ed0b1c29d3e5a8f5da72c39) Updated flake inputs
* [`90c653ab`](https://github.com/nix-community/emacs-overlay/commit/90c653abf42ea0189ef9fe3a31eed6ffee4dcec2) Updated emacs
* [`79547cb5`](https://github.com/nix-community/emacs-overlay/commit/79547cb5e8968bd1540f01609c1273fe5fb9b53e) Updated nongnu
* [`d5528e6d`](https://github.com/nix-community/emacs-overlay/commit/d5528e6d32cddac7e8a3db292d4c00fd2c947443) Updated nongnu
* [`d00ada52`](https://github.com/nix-community/emacs-overlay/commit/d00ada520498c78e500fb02a45d4a9364f1e5de7) Updated elpa
* [`6afb2183`](https://github.com/nix-community/emacs-overlay/commit/6afb2183cef03dcfce47c3bf22b2d44ded54ace0) Updated emacs
* [`77836f64`](https://github.com/nix-community/emacs-overlay/commit/77836f645ce80b186a337bce9793a870aa38f1bc) Updated elpa
* [`5020b902`](https://github.com/nix-community/emacs-overlay/commit/5020b902f155be44b3bd0b5a394ba97f5c83690f) Updated nongnu
* [`5201f36d`](https://github.com/nix-community/emacs-overlay/commit/5201f36d19505bc1cb8c253ea8e6379cdeb33252) Updated emacs
* [`693875f2`](https://github.com/nix-community/emacs-overlay/commit/693875f2cf5cf94e520dbd0bca4711e4540b864c) Updated nongnu
* [`7a0f9b6c`](https://github.com/nix-community/emacs-overlay/commit/7a0f9b6cd046e4f35bf5d5fb59e25fa486594cb4) Updated flake inputs
* [`c1235165`](https://github.com/nix-community/emacs-overlay/commit/c12351656d70d7a52ddfdf760d062e98da933845) Updated elpa
* [`7cd35bfb`](https://github.com/nix-community/emacs-overlay/commit/7cd35bfbe2fbb2906bc85803eab0bdc499b6f253) Updated emacs
* [`711566e1`](https://github.com/nix-community/emacs-overlay/commit/711566e17e7b414a24973dfd00a63eb62efb3836) flake: Remove flake-utils
* [`7ea718bb`](https://github.com/nix-community/emacs-overlay/commit/7ea718bb35f0ed66ea9cc53a7621ed38ec2696ae) Updated nongnu
* [`82ff4a70`](https://github.com/nix-community/emacs-overlay/commit/82ff4a7080a4407c0a7d1f22bed606139ae8c3b7) Updated elpa
* [`0cfc0c58`](https://github.com/nix-community/emacs-overlay/commit/0cfc0c58951dba55ad311ebc8bc5b29cda76eb47) Updated emacs
* [`c9f00a77`](https://github.com/nix-community/emacs-overlay/commit/c9f00a771906077a8c41272a6c38af7a2ed7df41) ci: Pin Nix to 2.18.9
* [`b6133350`](https://github.com/nix-community/emacs-overlay/commit/b613335061c4e924ac6aa2704e9af5a001f19b55) Updated nongnu
* [`9251d6e1`](https://github.com/nix-community/emacs-overlay/commit/9251d6e1366dfa5f9efebb3d4dc62fbb964b7e29) Updated elpa
* [`8aa36a59`](https://github.com/nix-community/emacs-overlay/commit/8aa36a5940db29645a01036dbaedfef785b04524) melpa: Hack update script not to use broken nix
* [`adb0aaf9`](https://github.com/nix-community/emacs-overlay/commit/adb0aaf917ad499dcce27eb90a207e2f19a4cc4c) Updated melpa
* [`3cbb5319`](https://github.com/nix-community/emacs-overlay/commit/3cbb531951b8abd4413ebc04a4e06d214de3cf04) Updated emacs
* [`bf948fae`](https://github.com/nix-community/emacs-overlay/commit/bf948fae8c5d4dc7839621c6acf1662f6ab78135) Updated melpa
* [`ca2129b1`](https://github.com/nix-community/emacs-overlay/commit/ca2129b1d5afb32e46299dc48e03467522352bd5) Updated emacs
* [`14649cb9`](https://github.com/nix-community/emacs-overlay/commit/14649cb9b85ff80801214c8fe080009bbd8dc383) Updated nongnu
* [`71531b9b`](https://github.com/nix-community/emacs-overlay/commit/71531b9ba1ca6eb5ae812c5f85c0c932d2fd8de4) Updated elpa
* [`8d1826ba`](https://github.com/nix-community/emacs-overlay/commit/8d1826ba7648bd2704c6beed35a9e9e3327178d1) Updated melpa
* [`7d5f5d41`](https://github.com/nix-community/emacs-overlay/commit/7d5f5d41bf8eaf301b845ea056cba808573bee98) Updated flake inputs
* [`d063bcd7`](https://github.com/nix-community/emacs-overlay/commit/d063bcd7962998e302fcf567ac50376d1d0646a2) Updated nongnu
* [`b704abc3`](https://github.com/nix-community/emacs-overlay/commit/b704abc3cd77700ae76d7e50b518d36231113649) Updated elpa
* [`426cb9df`](https://github.com/nix-community/emacs-overlay/commit/426cb9df18290e06fe1820da6cb716a2599839f3) Updated melpa
* [`3a071974`](https://github.com/nix-community/emacs-overlay/commit/3a071974344ba47573382596d91bd7a94beeac20) Updated flake inputs
* [`88e5ed4c`](https://github.com/nix-community/emacs-overlay/commit/88e5ed4cdb2d504a79cd4300b2d936318cee7de7) Updated melpa
* [`0c0c0dba`](https://github.com/nix-community/emacs-overlay/commit/0c0c0dba05690c02ea7d508fd59389052c5f6438) Updated emacs
* [`a05b1f74`](https://github.com/nix-community/emacs-overlay/commit/a05b1f74147d1b4d9997c58f802bcfe50c007e38) Updated nongnu
* [`f283ea8e`](https://github.com/nix-community/emacs-overlay/commit/f283ea8ea3c82e0ffc29a12615a947a9a410f213) Updated elpa
* [`fdbf7efb`](https://github.com/nix-community/emacs-overlay/commit/fdbf7efbc9f7cfefd3f8429120f60d9ae78708e3) Updated melpa
* [`1febd5c1`](https://github.com/nix-community/emacs-overlay/commit/1febd5c1ad7e798543c886756c598e0fb8d473fd) Updated emacs
* [`b6d15803`](https://github.com/nix-community/emacs-overlay/commit/b6d15803858d416007c812c4b32441153326ef43) Updated nongnu
* [`c2ca6f64`](https://github.com/nix-community/emacs-overlay/commit/c2ca6f6453cf8422198ec3209c6fba7cde448516) Updated elpa
* [`c626c28c`](https://github.com/nix-community/emacs-overlay/commit/c626c28c864722e20b7e9b507ccb1ca48d4328af) Updated melpa
* [`3f4a91fb`](https://github.com/nix-community/emacs-overlay/commit/3f4a91fb88fbfca216c74a10edbde6ad93684474) Updated flake inputs
* [`92793983`](https://github.com/nix-community/emacs-overlay/commit/92793983cce95f76479982fdd2f4f27979854cc2) Updated melpa
* [`4635854f`](https://github.com/nix-community/emacs-overlay/commit/4635854f5ebe3f201346a80731d1cc8775d7e3ee) Updated nongnu
* [`7f59c301`](https://github.com/nix-community/emacs-overlay/commit/7f59c301454d2a3908819f16e2d6bcfd3667e9b7) Updated elpa
* [`cbd63433`](https://github.com/nix-community/emacs-overlay/commit/cbd63433a850b999169dd08f8b6ac34e91629d75) Updated melpa
* [`881e7b58`](https://github.com/nix-community/emacs-overlay/commit/881e7b588330736320f2a6496225e729156cbcde) Updated emacs
* [`0b79f991`](https://github.com/nix-community/emacs-overlay/commit/0b79f99128badd14e5ab525c44b3052bdb91d38b) Updated nongnu
* [`79d50f29`](https://github.com/nix-community/emacs-overlay/commit/79d50f29766d521dff062b038efd15c1fd4a9739) Updated elpa
* [`89ca3331`](https://github.com/nix-community/emacs-overlay/commit/89ca3331d0faf728c6f169b85d07e1589c8e7048) Updated melpa
* [`b83a78c6`](https://github.com/nix-community/emacs-overlay/commit/b83a78c62a3d9be32671dae83b7cb8b2cce52725) Updated emacs
* [`30579c1a`](https://github.com/nix-community/emacs-overlay/commit/30579c1a1476cf681104a3434531791f5557ca44) Updated flake inputs
* [`599de1ca`](https://github.com/nix-community/emacs-overlay/commit/599de1cac7b84cd2d0abbc3ad897e2791328a499) Updated melpa
* [`83b6f973`](https://github.com/nix-community/emacs-overlay/commit/83b6f9732eaf48f94d8ad6baa5cc2bf82bc3d3ff) Updated emacs
* [`c0ec1dce`](https://github.com/nix-community/emacs-overlay/commit/c0ec1dce37be9bf3f4972fcad1191be29848bb75) Updated nongnu
* [`b6ad1cf5`](https://github.com/nix-community/emacs-overlay/commit/b6ad1cf5ce77aa5073af5d1d7c77e11e2a3005cb) Updated elpa
* [`18264d45`](https://github.com/nix-community/emacs-overlay/commit/18264d45da2a551a74b282198dd785a4829d1889) Updated melpa
* [`48f6fcd3`](https://github.com/nix-community/emacs-overlay/commit/48f6fcd3e11fec064374d7a9df8dc026fd711094) Updated emacs
* [`9412f6c4`](https://github.com/nix-community/emacs-overlay/commit/9412f6c45cf35b18a51cb713d836088d4a3157f0) Updated nongnu
* [`7feb51a8`](https://github.com/nix-community/emacs-overlay/commit/7feb51a8215d1d1004dd8ce5b780d64cc236d78d) Updated elpa
* [`750392b4`](https://github.com/nix-community/emacs-overlay/commit/750392b45b88f96f3a14a7ad164c26ab27e2c710) Updated melpa
* [`9596809f`](https://github.com/nix-community/emacs-overlay/commit/9596809f1b6bd55dcf3d7c4e3f7c26ebfe88ef22) Updated emacs
* [`2a681ddb`](https://github.com/nix-community/emacs-overlay/commit/2a681ddb9e0b74ab6680b20f1672a5f5fd532dad) Updated melpa
* [`2313c418`](https://github.com/nix-community/emacs-overlay/commit/2313c4189eaef014d01fb260313f58554ddb5e31) Updated emacs
* [`9eb5c6ce`](https://github.com/nix-community/emacs-overlay/commit/9eb5c6ced87b3980adbcca7bd3cc3728f2c2084e) Updated nongnu
* [`e5c5d15a`](https://github.com/nix-community/emacs-overlay/commit/e5c5d15a48d76466ef9fa4e199e753b9dd6e5e2a) Updated elpa
* [`9e1d2018`](https://github.com/nix-community/emacs-overlay/commit/9e1d20187d64422248198b21347703f98c218c3e) Updated melpa
* [`d066ff0e`](https://github.com/nix-community/emacs-overlay/commit/d066ff0e61cfb9819514d124a7d256d6d05e33ac) Updated emacs
* [`565547e7`](https://github.com/nix-community/emacs-overlay/commit/565547e79ce1c07dbac337c86bf6962ae3e69e04) Updated nongnu
* [`fe2312ed`](https://github.com/nix-community/emacs-overlay/commit/fe2312ed21dca3e2b9a28916988eaae5e03af943) Updated elpa
* [`82aa1d60`](https://github.com/nix-community/emacs-overlay/commit/82aa1d607458ba59b426ac627804e9215e012761) Updated melpa
* [`17d58785`](https://github.com/nix-community/emacs-overlay/commit/17d58785e7a094bf329bd20c1632d6fd34a7af35) Updated emacs
* [`071670e5`](https://github.com/nix-community/emacs-overlay/commit/071670e5bfad91f90647c0961bdc38deee2219fb) Updated melpa
* [`3370eff9`](https://github.com/nix-community/emacs-overlay/commit/3370eff942378b11c41da200b3e7225869920491) Updated flake inputs
* [`79bc2328`](https://github.com/nix-community/emacs-overlay/commit/79bc2328f605ece415cb4c27e000eaa9e224aed2) Updated elpa
* [`a03932a7`](https://github.com/nix-community/emacs-overlay/commit/a03932a70e735e9ca27097043105f32debd2c617) Updated melpa
* [`0c62adbb`](https://github.com/nix-community/emacs-overlay/commit/0c62adbb149571711cea2dbadb4c2a0652dfc266) Updated emacs
* [`616e686e`](https://github.com/nix-community/emacs-overlay/commit/616e686ed2dfd52003b92adadd72163db2636f37) Updated nongnu
* [`0c8598df`](https://github.com/nix-community/emacs-overlay/commit/0c8598df24a3877662d3374da33bfe4591442298) Updated elpa
* [`146c531a`](https://github.com/nix-community/emacs-overlay/commit/146c531addc9ad05d74a7310ddd9ad5a5cedb72a) Updated melpa
* [`207f6791`](https://github.com/nix-community/emacs-overlay/commit/207f6791278638301f7783cff08d8c1e00e6703b) Updated emacs
* [`95821bb1`](https://github.com/nix-community/emacs-overlay/commit/95821bb1f52bac1f268a77898cc863ebdf3249b8) Updated melpa
* [`21d609ea`](https://github.com/nix-community/emacs-overlay/commit/21d609eadcc0ec5ad9a7b3ac3ce8f41fa0466877) Updated nongnu
* [`01a97b7d`](https://github.com/nix-community/emacs-overlay/commit/01a97b7d62e0a1063e98e042b9c5db5e04d37888) Updated elpa
* [`10001900`](https://github.com/nix-community/emacs-overlay/commit/10001900f78be46ab8642edde7455aa5f0d54a6a) Updated melpa
* [`9c43c3f7`](https://github.com/nix-community/emacs-overlay/commit/9c43c3f77c7c46fb4b15dd4a3274f7979a94439c) Updated flake inputs
* [`dc4dc7d3`](https://github.com/nix-community/emacs-overlay/commit/dc4dc7d31acb43b66ff2a5f001936e7ba541de9f) Updated nongnu
* [`39ef0684`](https://github.com/nix-community/emacs-overlay/commit/39ef0684eb1fb83060e4badca01352ea904c7e89) Updated elpa
* [`e94b9aef`](https://github.com/nix-community/emacs-overlay/commit/e94b9aef9633ffb9ea2bebe8c9b999618ec15109) Updated melpa
* [`8bb826ff`](https://github.com/nix-community/emacs-overlay/commit/8bb826ff3ad7dd473f69c518272ae56d5f917a52) Updated melpa
* [`cfc32faf`](https://github.com/nix-community/emacs-overlay/commit/cfc32faff41ea05592a0425be92bf33d40744a42) Updated flake inputs
* [`84fd4cdf`](https://github.com/nix-community/emacs-overlay/commit/84fd4cdfe15eee56c4f42043829ef6e6b7da3312) Updated nongnu
* [`5d6ad034`](https://github.com/nix-community/emacs-overlay/commit/5d6ad034c85e9647f1d6dc2bf0b214014b844411) Updated elpa
* [`1cfaed17`](https://github.com/nix-community/emacs-overlay/commit/1cfaed170f85e2b31e0c5b9e1459dfa9d43e7db6) Updated melpa
* [`914e8cd4`](https://github.com/nix-community/emacs-overlay/commit/914e8cd43c10d41f6bba21abaf0d8b29554d69c9) Updated emacs
* [`bc39ae24`](https://github.com/nix-community/emacs-overlay/commit/bc39ae24a1fe1762896d1ac235e519cf5d69e58b) Updated nongnu
* [`44d601ba`](https://github.com/nix-community/emacs-overlay/commit/44d601ba4d251251e342d14ba3663a073c1b4aa4) Updated elpa
* [`adc9a8ca`](https://github.com/nix-community/emacs-overlay/commit/adc9a8ca1ef06c1786f2a18dbd5e999b4e115e74) Updated melpa
* [`7a8b2d88`](https://github.com/nix-community/emacs-overlay/commit/7a8b2d8879986e79d9271f85f6559e8a74f5b6cf) Updated melpa
* [`96fb09e8`](https://github.com/nix-community/emacs-overlay/commit/96fb09e8711fbe18347cb44290e2082d7bb8f6fa) Updated nongnu
* [`cf308e1c`](https://github.com/nix-community/emacs-overlay/commit/cf308e1caa9533a9c01cc28020d0dea5134b546a) Updated elpa
* [`dfa8f663`](https://github.com/nix-community/emacs-overlay/commit/dfa8f663d2b95fd9ad891b9363e7d41bad0cd05a) Updated melpa
* [`af086b3e`](https://github.com/nix-community/emacs-overlay/commit/af086b3eaccec54cb18c6d3cf376d8f94b81d482) Updated emacs
* [`6ebb442c`](https://github.com/nix-community/emacs-overlay/commit/6ebb442c2cea78c10319ca00569c963ab52a888d) Updated nongnu
* [`4f2af1a9`](https://github.com/nix-community/emacs-overlay/commit/4f2af1a9f2ad8cedcced602fd0ef30c7a496aa2d) Updated elpa
* [`8c899159`](https://github.com/nix-community/emacs-overlay/commit/8c8991591e48d03735b488fe0ad72a69fe00d188) Updated melpa
* [`395675b2`](https://github.com/nix-community/emacs-overlay/commit/395675b281ab1aea12ab75a6296b83e3b3152f13) Updated emacs
* [`feaebd62`](https://github.com/nix-community/emacs-overlay/commit/feaebd62bd3960aa559413470986ca0b15d2ddf5) Updated melpa
* [`98672e89`](https://github.com/nix-community/emacs-overlay/commit/98672e8948813f132851fb6768fa1265a8cab324) Updated emacs
* [`3debd608`](https://github.com/nix-community/emacs-overlay/commit/3debd608803681bfab013d6eb2a8095dec8b1b95) Updated elpa
* [`a81df221`](https://github.com/nix-community/emacs-overlay/commit/a81df221fef98954bba1869e7648ec650928a584) Updated nongnu
* [`8905d10a`](https://github.com/nix-community/emacs-overlay/commit/8905d10ac833fbebaefbeeb012f7af3cb147c391) Updated melpa
* [`e074a4f5`](https://github.com/nix-community/emacs-overlay/commit/e074a4f54d88af0db5284d77e0b80bb1a8d2c80f) Updated emacs
* [`865dd92d`](https://github.com/nix-community/emacs-overlay/commit/865dd92d2c7f46190b2063ffc6ec6af605d097bd) Updated elpa
* [`f5913f18`](https://github.com/nix-community/emacs-overlay/commit/f5913f1890a0cd11684666a77e363cc3b473d069) Updated melpa
* [`5264b3b1`](https://github.com/nix-community/emacs-overlay/commit/5264b3b1bc09532a103ea69a0747ae56fdb3a5ec) Updated emacs
* [`45023e64`](https://github.com/nix-community/emacs-overlay/commit/45023e6456ddc236499178ac9914d43d478bb499) Updated flake inputs
* [`4639038b`](https://github.com/nix-community/emacs-overlay/commit/4639038b0f5e66e7d0f3d103b8e44ded3ab7e337) Updated melpa
* [`e599f2aa`](https://github.com/nix-community/emacs-overlay/commit/e599f2aa6d4d9c706506aaae12e3d7a1d82fa2be) Updated elpa
* [`2edb10c7`](https://github.com/nix-community/emacs-overlay/commit/2edb10c787461d3514475230bb83238752aacbff) Updated melpa
* [`f6c94b95`](https://github.com/nix-community/emacs-overlay/commit/f6c94b95f529cfbd29848c12816111a2471a5293) Updated emacs
* [`dfda8a5b`](https://github.com/nix-community/emacs-overlay/commit/dfda8a5b8586c88309f7efa1cfe85b735be1cd0b) Updated nongnu
* [`188269c4`](https://github.com/nix-community/emacs-overlay/commit/188269c44cde3363a8b8afd04565bc079b989d95) Updated elpa
* [`35ae580c`](https://github.com/nix-community/emacs-overlay/commit/35ae580c2592be7467285353d27fb5ae684c7816) Updated melpa
* [`aad0ad26`](https://github.com/nix-community/emacs-overlay/commit/aad0ad26e710b4b1f575ed5895592ba8835e2c9e) Updated emacs
* [`ed670c72`](https://github.com/nix-community/emacs-overlay/commit/ed670c7246dd4bfd24e50939eb5d9bcaa95e638b) Updated melpa
* [`d7618a5f`](https://github.com/nix-community/emacs-overlay/commit/d7618a5f8b29ca9c573df4532631b621b2a763fa) Updated emacs
* [`9689a1f9`](https://github.com/nix-community/emacs-overlay/commit/9689a1f90e9dc315f460a626dec4d7f27e4e623b) Updated nongnu
* [`6d296e5f`](https://github.com/nix-community/emacs-overlay/commit/6d296e5f93348504d669a2a377fb16c7548239c2) Updated elpa
* [`e242de3c`](https://github.com/nix-community/emacs-overlay/commit/e242de3cdffc62319a3caba2ab9f491c4b8f51c1) Updated melpa
* [`d0ff8cfc`](https://github.com/nix-community/emacs-overlay/commit/d0ff8cfc00bed7ae7a9f9e4cacea031443d295bb) Updated emacs
* [`489d5749`](https://github.com/nix-community/emacs-overlay/commit/489d5749b9782320f89e628e9e9caa515150e1e1) Updated nongnu
* [`9c2da4a0`](https://github.com/nix-community/emacs-overlay/commit/9c2da4a0bf2e6bd0ce99c37b60c19cfe38e99dcb) Updated elpa
* [`1475817e`](https://github.com/nix-community/emacs-overlay/commit/1475817ef069bde0ff30ec538cee3dbdd970f0ce) Updated melpa
* [`6b6b7f28`](https://github.com/nix-community/emacs-overlay/commit/6b6b7f2861316ed7157cd50ae76a69fe97af2956) Updated emacs
* [`f85aea57`](https://github.com/nix-community/emacs-overlay/commit/f85aea570502f146063045f284ae1a580732e122) Updated flake inputs
* [`4a704b93`](https://github.com/nix-community/emacs-overlay/commit/4a704b933bbfefbdeebfd5b5376675854ef690d5) Updated melpa
* [`1057a540`](https://github.com/nix-community/emacs-overlay/commit/1057a540b471891bd77ec474e3a6c06cff9ef4c0) Updated nongnu
* [`f6d0e3fc`](https://github.com/nix-community/emacs-overlay/commit/f6d0e3fca9097209f44dcfba704cda5d2c4be957) Updated elpa
* [`23d3e508`](https://github.com/nix-community/emacs-overlay/commit/23d3e50846476ae7d6b0ab0f521addc3e1d2d595) Updated melpa
* [`cfbfcbbd`](https://github.com/nix-community/emacs-overlay/commit/cfbfcbbd057e695106ab9a7871a66834ee8d1b41) Updated emacs
* [`82a2f1d0`](https://github.com/nix-community/emacs-overlay/commit/82a2f1d035df1b10ec00005e18512bce3168032e) Updated flake inputs
* [`54332f10`](https://github.com/nix-community/emacs-overlay/commit/54332f105503c95a3b390a25318a797182d73e88) Updated nongnu
* [`3faab99e`](https://github.com/nix-community/emacs-overlay/commit/3faab99e6e21a170c140ac347a3c688f81480028) Updated elpa
* [`f9275300`](https://github.com/nix-community/emacs-overlay/commit/f92753004a1ebaebe62cdb71e53e78c5e805c3f0) Updated melpa
* [`e39c7cf3`](https://github.com/nix-community/emacs-overlay/commit/e39c7cf39e1d2c31f8cce19ab3ecbb1e02d3bb65) Updated emacs
* [`5ea724c6`](https://github.com/nix-community/emacs-overlay/commit/5ea724c6d8d0ee672b613c27db6a8022e1ba468d) Updated melpa
* [`bec72cac`](https://github.com/nix-community/emacs-overlay/commit/bec72cac63eda987283722b1cf8d11a9eb38cad5) Updated nongnu
* [`d22ba0e4`](https://github.com/nix-community/emacs-overlay/commit/d22ba0e43c8e4bfe1ed5bc2294434a329f67bdc5) Updated elpa
* [`12f96fc5`](https://github.com/nix-community/emacs-overlay/commit/12f96fc5689b22e7695886ece1e79632e3c6941f) Updated melpa
* [`7ea05ee7`](https://github.com/nix-community/emacs-overlay/commit/7ea05ee738796f89473a282568d333d7dff31b4c) Updated emacs
* [`68d3f191`](https://github.com/nix-community/emacs-overlay/commit/68d3f19123c4170d41e9e26f8d62d1516bcf9497) Updated flake inputs
* [`d264137b`](https://github.com/nix-community/emacs-overlay/commit/d264137b077b103fb94bff3cf091281e6521b473) Updated nongnu
* [`39cd49eb`](https://github.com/nix-community/emacs-overlay/commit/39cd49ebe145484f70cd517abb27376c0dc63c9b) Updated elpa
* [`9814f442`](https://github.com/nix-community/emacs-overlay/commit/9814f4421d27465c2af4e2b639a11b95959b6734) Updated melpa
* [`9cdfbd67`](https://github.com/nix-community/emacs-overlay/commit/9cdfbd6780b1c3c3d1eadebfb8a6848cd32a5861) Updated emacs
* [`63aaa4ea`](https://github.com/nix-community/emacs-overlay/commit/63aaa4eafdaa7055b305b80d705b8a3787d66153) Updated nongnu
* [`356cde15`](https://github.com/nix-community/emacs-overlay/commit/356cde15331d5d0707fde9b1f3e9d75dcf39eca4) Updated elpa
* [`9d98277b`](https://github.com/nix-community/emacs-overlay/commit/9d98277bf20a8b143f32e8ee11cc2b6fc92c20f6) Updated melpa
* [`35e28f1f`](https://github.com/nix-community/emacs-overlay/commit/35e28f1f2b9c7c67aad83c26e6a8ddf54ce447f6) Updated nongnu
* [`1074d4d6`](https://github.com/nix-community/emacs-overlay/commit/1074d4d6fcb706878789163061f96dac95cbb7a4) Updated elpa
* [`7c339668`](https://github.com/nix-community/emacs-overlay/commit/7c339668cfab03071117e7d80fb7a5ba85f21ac0) Updated emacs
* [`e0427ea8`](https://github.com/nix-community/emacs-overlay/commit/e0427ea80cbbda144b5014fbe1facd9d49f6f49d) Updated melpa
* [`4da1f1d1`](https://github.com/nix-community/emacs-overlay/commit/4da1f1d1eee6dc6858724b4e4b8792fc6a528f69) Updated emacs
* [`dd653236`](https://github.com/nix-community/emacs-overlay/commit/dd65323687af4ac2a99646382763f8690e900973) Updated melpa
* [`ddeedc5e`](https://github.com/nix-community/emacs-overlay/commit/ddeedc5e6c93d151a2ece9bc76267d75a123771a) Updated nongnu
* [`cbdeef5c`](https://github.com/nix-community/emacs-overlay/commit/cbdeef5cc5557a4d64ff211caad6dfe987618c1a) Updated elpa
* [`2672f82e`](https://github.com/nix-community/emacs-overlay/commit/2672f82eb7fad6a6781d038efc159f3713818da0) Updated melpa
* [`0e4b27fa`](https://github.com/nix-community/emacs-overlay/commit/0e4b27fa676e558e904ec022117867ae89e7d874) Updated nongnu
* [`8fd8189d`](https://github.com/nix-community/emacs-overlay/commit/8fd8189d01ac5a3b69e23d8fde90f45b27d6ec5b) Updated elpa
* [`27ab826f`](https://github.com/nix-community/emacs-overlay/commit/27ab826fc02fbfebed47b93272ab4d754f1a915e) Updated emacs
* [`887c9c66`](https://github.com/nix-community/emacs-overlay/commit/887c9c6651450ad0ae6120a77963bd5630b478ba) Updated melpa
* [`79d8dd31`](https://github.com/nix-community/emacs-overlay/commit/79d8dd3148860718bc78b73c7e4972f850b19541) Updated melpa
* [`32b7d5d6`](https://github.com/nix-community/emacs-overlay/commit/32b7d5d6d0d6e21c0d61080ff958165246bfd686) Updated nongnu
* [`8f3888a3`](https://github.com/nix-community/emacs-overlay/commit/8f3888a3100bed16eead048df1f79ad46bbaf916) Updated elpa
* [`a5792e6b`](https://github.com/nix-community/emacs-overlay/commit/a5792e6b5612dff780ee1155a415847f6d792204) Updated melpa
* [`bd7288e0`](https://github.com/nix-community/emacs-overlay/commit/bd7288e0a45c76a26e3d71dd77a3fc5a527ba06c) Updated flake inputs
* [`69e3de74`](https://github.com/nix-community/emacs-overlay/commit/69e3de744446371edeeb9a38119b1fbb985e263f) Updated elpa
* [`4393d7fa`](https://github.com/nix-community/emacs-overlay/commit/4393d7fa938ad16ad5fab9054f73da87fecff8c4) Updated melpa
* [`46cbce8b`](https://github.com/nix-community/emacs-overlay/commit/46cbce8bc96c36a83a2cae9312026b3028bdcb87) Updated melpa
* [`e1c705ac`](https://github.com/nix-community/emacs-overlay/commit/e1c705acd767f3ef201b13a490e61c3b14509504) Updated nongnu
* [`2458d7ef`](https://github.com/nix-community/emacs-overlay/commit/2458d7ef90e929d418950b8fb77a1be92d88e70d) Updated elpa
* [`aa036203`](https://github.com/nix-community/emacs-overlay/commit/aa036203ab87d6c73dc3aaa9349e301a34817e25) Updated melpa
* [`c9edf2ee`](https://github.com/nix-community/emacs-overlay/commit/c9edf2eef08adc100644b6e5757ce2c7c34e7784) Updated emacs
* [`86765ada`](https://github.com/nix-community/emacs-overlay/commit/86765ada8c91167f2f704956535bc11443daf451) Updated nongnu
* [`b0f8c6d8`](https://github.com/nix-community/emacs-overlay/commit/b0f8c6d8c52dea574f289766447b7c1177642eef) Updated elpa
* [`43d71dd3`](https://github.com/nix-community/emacs-overlay/commit/43d71dd3a63f9eb614faff2333e9ce03e21f73d3) Updated melpa
* [`a7244fcd`](https://github.com/nix-community/emacs-overlay/commit/a7244fcd51654b1a28240deb01e175b86c797ac4) Updated emacs
* [`2bbf361a`](https://github.com/nix-community/emacs-overlay/commit/2bbf361a5d58fd97f31bd871e334f0682b98c905) Updated melpa
* [`18509ea5`](https://github.com/nix-community/emacs-overlay/commit/18509ea5a25718f1001cce73ebda00e66a03cb62) Updated elpa
* [`a9340c47`](https://github.com/nix-community/emacs-overlay/commit/a9340c4718112611efd5693c78bd4d673cdb429e) Updated nongnu
* [`23ccc0cf`](https://github.com/nix-community/emacs-overlay/commit/23ccc0cf07428c86a611f21898c7eb8d7bc7876a) Updated melpa
* [`550cfdf5`](https://github.com/nix-community/emacs-overlay/commit/550cfdf5570aa09457a9e4f3c878cee535e1d7e2) Updated emacs
* [`22e268fd`](https://github.com/nix-community/emacs-overlay/commit/22e268fd97f9ed4c5027e8645691e042f24f7d04) Updated nongnu
* [`a926998a`](https://github.com/nix-community/emacs-overlay/commit/a926998aab69dcd1bb2e5ec4b023535703696d1d) Updated elpa
* [`dd386453`](https://github.com/nix-community/emacs-overlay/commit/dd38645351b6f14cda47c81456131c86b11386db) Updated melpa
* [`bb0acd64`](https://github.com/nix-community/emacs-overlay/commit/bb0acd64336552d7ed16bc7e2cd0ddfec65fdcbe) Updated melpa
* [`0b8f7a55`](https://github.com/nix-community/emacs-overlay/commit/0b8f7a55f7d78ff2ccd1fada970a2a908e60b1c5) Updated nongnu
* [`0bea1f7d`](https://github.com/nix-community/emacs-overlay/commit/0bea1f7d5263bde0180e322b5685ddd0b9654801) Updated elpa
* [`4fdad73e`](https://github.com/nix-community/emacs-overlay/commit/4fdad73ee36c957ad345efdd85d0d2af9c2e9b38) Updated melpa
* [`61af138b`](https://github.com/nix-community/emacs-overlay/commit/61af138b0b7ffc19b1221b5d6d28f164a8c0d919) Updated emacs
* [`92a61732`](https://github.com/nix-community/emacs-overlay/commit/92a61732661ded9e496c3b63c49e35533215f115) Updated elpa
* [`c4fac579`](https://github.com/nix-community/emacs-overlay/commit/c4fac57997b75108a9815ce80081551e1ab7ed69) Updated nongnu
* [`e4795901`](https://github.com/nix-community/emacs-overlay/commit/e47959010683ae6af028d9e18cb94f20c5dee237) Updated melpa
* [`a0935df2`](https://github.com/nix-community/emacs-overlay/commit/a0935df2077f0a9b227a38f08600d17d0029feed) Updated emacs
* [`e4a4e427`](https://github.com/nix-community/emacs-overlay/commit/e4a4e427b998522b16cf033319678c6cb9f9861e) Updated melpa
* [`87de50e4`](https://github.com/nix-community/emacs-overlay/commit/87de50e44afcc4d819f9c65e9ab46222bf15f742) Updated emacs
* [`22929f38`](https://github.com/nix-community/emacs-overlay/commit/22929f381a27012d3897700427d09b344810b72a) Updated nongnu
* [`ede64e0c`](https://github.com/nix-community/emacs-overlay/commit/ede64e0cbd549e1fe13d89d2a81e161ad2c5af15) Updated elpa
* [`f2a47b38`](https://github.com/nix-community/emacs-overlay/commit/f2a47b3827ec18f2c72446b31279c3a64bfa1f5d) Updated melpa
* [`72c506de`](https://github.com/nix-community/emacs-overlay/commit/72c506de74f90bc47bfe62627844b973b493a377) Updated emacs
* [`e5f8205e`](https://github.com/nix-community/emacs-overlay/commit/e5f8205e44e676fbd182dac5484fc843a3c81f56) Updated nongnu
* [`11cfcdb5`](https://github.com/nix-community/emacs-overlay/commit/11cfcdb5c90289fda42fe7088981f35c4fb75dfb) Updated elpa
* [`a84dc7f9`](https://github.com/nix-community/emacs-overlay/commit/a84dc7f9b8a43f089d094a7d9af8340d21f0d5f0) Updated melpa
* [`94734b1b`](https://github.com/nix-community/emacs-overlay/commit/94734b1bf571b12202fa1298f6bf200372b40170) Updated melpa
* [`4c13a6fc`](https://github.com/nix-community/emacs-overlay/commit/4c13a6fcbabc424b48ab3a5e8a30119ecf33df7d) Updated nongnu
* [`74b9722e`](https://github.com/nix-community/emacs-overlay/commit/74b9722ee2ff0a5dce45a5f45acf97a4aa6d5b42) Updated melpa
* [`6fcec249`](https://github.com/nix-community/emacs-overlay/commit/6fcec24914230d0fd047cfe2b4428fe03d779f99) Updated emacs
* [`c401d6e4`](https://github.com/nix-community/emacs-overlay/commit/c401d6e4170885d110ecbf0322ecaa7fe9d59f6c) Updated nongnu
* [`b537c6ad`](https://github.com/nix-community/emacs-overlay/commit/b537c6adc150f4517eb9025c4101cf9ab15f4902) Updated elpa
* [`174d1ea0`](https://github.com/nix-community/emacs-overlay/commit/174d1ea0c1d96834c18fe615274adad8a00705f2) Updated nongnu
* [`31dd8e84`](https://github.com/nix-community/emacs-overlay/commit/31dd8e842483b14a334409530b966a196c52f254) Updated elpa
* [`68655ab2`](https://github.com/nix-community/emacs-overlay/commit/68655ab2998b748db2691c8bbead41051a4862b9) Updated flake inputs
* [`76b9b210`](https://github.com/nix-community/emacs-overlay/commit/76b9b210ee8d6012b464e23a56123bfca902d2a2) Updated nongnu
* [`c459524b`](https://github.com/nix-community/emacs-overlay/commit/c459524b98ca355ef06f272034267cbe8f3e28f0) Updated elpa
* [`c9e52f40`](https://github.com/nix-community/emacs-overlay/commit/c9e52f40222b7dd7084b06ade6907a2a8f8196bb) Updated flake inputs
* [`96e0bac0`](https://github.com/nix-community/emacs-overlay/commit/96e0bac0682868c890d4d36168024853e8dee174) Updated elpa
* [`5b1b438a`](https://github.com/nix-community/emacs-overlay/commit/5b1b438a780878b506e9a49d877ce27ab7c3a98b) Updated nongnu
* [`09e0f5d0`](https://github.com/nix-community/emacs-overlay/commit/09e0f5d0a4d0eae261ca598ad9a11c73c12d61ae) Updated elpa
* [`ef4afd4f`](https://github.com/nix-community/emacs-overlay/commit/ef4afd4f603d68b83160107108123b0555295af1) Updated melpa
* [`f704f6f1`](https://github.com/nix-community/emacs-overlay/commit/f704f6f113bef121c7e38f807e3397f7dbe1aee0) Updated emacs
* [`fb81e751`](https://github.com/nix-community/emacs-overlay/commit/fb81e75180369a888db920df8f6097fbf2f603e9) Updated melpa
* [`af0bb4d6`](https://github.com/nix-community/emacs-overlay/commit/af0bb4d679641b1d96ee366c0198642e4666f044) Updated flake inputs
* [`bda2c918`](https://github.com/nix-community/emacs-overlay/commit/bda2c918fa6366cbdfc29c5307de9cecfa142bbe) Updated elpa
* [`07a864eb`](https://github.com/nix-community/emacs-overlay/commit/07a864eb40960450d6fa07aca8947f048a5eee4e) Updated melpa
* [`ceb935b7`](https://github.com/nix-community/emacs-overlay/commit/ceb935b70d456dffe6a8a2b7ffefc5b5be5a1818) Updated emacs
* [`62fe29fb`](https://github.com/nix-community/emacs-overlay/commit/62fe29fb26c5e5e375a9f3a5c8bed246ba2f65e7) Updated nongnu
* [`48849491`](https://github.com/nix-community/emacs-overlay/commit/48849491de34805d5802910c7f538cea7c378967) Updated elpa
* [`6b78552e`](https://github.com/nix-community/emacs-overlay/commit/6b78552e35d0a1b050091401ee9959070383ac36) Updated melpa
* [`4ab3a4f1`](https://github.com/nix-community/emacs-overlay/commit/4ab3a4f16671bdc5c61afa563a80b94a22e289f0) Updated melpa
* [`ca218dbd`](https://github.com/nix-community/emacs-overlay/commit/ca218dbd42ae4b16bc4378a06f5f1310b69a32af) Updated emacs
* [`c038049f`](https://github.com/nix-community/emacs-overlay/commit/c038049f688ee3da6d4d2f7557c274a52ffaac9d) Updated nongnu
* [`88d1137e`](https://github.com/nix-community/emacs-overlay/commit/88d1137e1b2b93dd6f65b47a61fc47a49a242b4f) Updated elpa
* [`d1b497b5`](https://github.com/nix-community/emacs-overlay/commit/d1b497b5b8b38353e749911a857b5c3c6da336b7) Updated melpa
* [`200afe61`](https://github.com/nix-community/emacs-overlay/commit/200afe61d314ab169ed46241560d20d2df09f7c6) Updated nongnu
* [`90c48f72`](https://github.com/nix-community/emacs-overlay/commit/90c48f727fee87c31a442bb6cd7e68960c86e0be) Updated elpa
* [`60b9979f`](https://github.com/nix-community/emacs-overlay/commit/60b9979ff5649312fb41f1971f5def47373379c5) Updated melpa
* [`7c0720d6`](https://github.com/nix-community/emacs-overlay/commit/7c0720d624aae2b9ab356e3e858a2490bce1b822) Updated emacs
* [`ba91b440`](https://github.com/nix-community/emacs-overlay/commit/ba91b440d752de20c11371b661b4fe395d65ef06) Updated flake inputs
* [`9538b0c1`](https://github.com/nix-community/emacs-overlay/commit/9538b0c14fad28b9a9edf69d34916f476699ad45) Updated melpa
* [`e1345151`](https://github.com/nix-community/emacs-overlay/commit/e13451512d7ad3adad894c39299748f024c0e884) Updated nongnu
* [`2c93365b`](https://github.com/nix-community/emacs-overlay/commit/2c93365bf4a9c1a02da39db93a5c693112904bef) Updated elpa
* [`a7757632`](https://github.com/nix-community/emacs-overlay/commit/a7757632e104a3164d194809924187cd0d06f868) Updated melpa
* [`d902534f`](https://github.com/nix-community/emacs-overlay/commit/d902534f27fea8439422e55c435d4b4bbf8a2472) Updated emacs
