### PR TITLE
niv doomemacs: update dea6552e -> 9c8cfaad

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "doomemacs",
         "repo": "doomemacs",
-        "rev": "dea6552ef97d8d1b731bef17548d492e8b15566c",
-        "sha256": "1dll7ya5l62fdn6gixqacyrh244jqskj66g0byw2iij26r1zkm16",
+        "rev": "9c8cfaadde1ccc96a780d713d2a096f0440b9483",
+        "sha256": "1bwd3b1myadarqksmg5ld1f19k2nvi0bsm4l869vjxprbri5vswi",
         "type": "tarball",
-        "url": "https://github.com/doomemacs/doomemacs/archive/dea6552ef97d8d1b731bef17548d492e8b15566c.tar.gz",
+        "url": "https://github.com/doomemacs/doomemacs/archive/9c8cfaadde1ccc96a780d713d2a096f0440b9483.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "emacs-overlay": {


### PR DESCRIPTION
## Changelog for doomemacs:
Branch: master
Commits: [doomemacs/doomemacs@dea6552e...9c8cfaad](https://github.com/doomemacs/doomemacs/compare/dea6552ef97d8d1b731bef17548d492e8b15566c...9c8cfaadde1ccc96a780d713d2a096f0440b9483)

* [`1f8c326d`](https://github.com/doomemacs/doomemacs/commit/1f8c326dfa8f7ab489d04acd3d2c440030173765) fix(eval): remove duplicate REPL entries
* [`7aed77c7`](https://github.com/doomemacs/doomemacs/commit/7aed77c702e53d82ecbf2b3e3f6d274ccb40d6b0) bump: :emacs undo
* [`5ff8561b`](https://github.com/doomemacs/doomemacs/commit/5ff8561b5eadfadeb3e02fa4bf64533b90fe4d83) fix(lsp): lsp!: make non-interactive
* [`9ae7aa11`](https://github.com/doomemacs/doomemacs/commit/9ae7aa1122781c8b4353fad049bc7b5cea1b0638) tweak: centralize profile loader script
* [`c23b6fa5`](https://github.com/doomemacs/doomemacs/commit/c23b6fa5db8aa6c7e4121b05ea17eecf2059cdfe) nit: reformat early-init
* [`25201a40`](https://github.com/doomemacs/doomemacs/commit/25201a40f3d909337d93be3591960e6d12f54ffe) refactor: rename :core module group to :doom
* [`db76813c`](https://github.com/doomemacs/doomemacs/commit/db76813c26fcb1343dab39d99b47fdf86b9016e2) refactor: rename doom-features to doom-system
* [`fca61870`](https://github.com/doomemacs/doomemacs/commit/fca6187021833c1c81a70f7c7ed4a9731ce3c301) refactor: with-doom-module: context constructor
* [`9aa44706`](https://github.com/doomemacs/doomemacs/commit/9aa44706831fe87000a1d49a0d53c5493bb0ebe5) refactor: declare doom-module->context side-effect-free
* [`4d83719e`](https://github.com/doomemacs/doomemacs/commit/4d83719e58992237d185990644217f0647c838ca) fix: doom-module-context: make error free
* [`ffac5ea4`](https://github.com/doomemacs/doomemacs/commit/ffac5ea4fa620d08d77e0c63b46f79a0ead50529) fix: doom-module-from-path: doom-{core,user}-dir detection
* [`0d8b6bdf`](https://github.com/doomemacs/doomemacs/commit/0d8b6bdfbdb2fbaaba8be65fd9797d2ab24e3df6) bump: :tools
* [`138fa6c9`](https://github.com/doomemacs/doomemacs/commit/138fa6c995c4c21b9e622f3c1c9cece940c6df5b) bump: :os
* [`89b087a2`](https://github.com/doomemacs/doomemacs/commit/89b087a2839e0007fa814804c979bf06e1cbcfa7) bump: :editor
* [`d80c5e51`](https://github.com/doomemacs/doomemacs/commit/d80c5e51159fade5d15e09bd3c87fb9dd8b60c50) bump: :doom
* [`8a7b20c4`](https://github.com/doomemacs/doomemacs/commit/8a7b20c43d0b26288dcc08440406b540cc122bd7) release(modules): 24.12.0-dev
* [`bbf733c5`](https://github.com/doomemacs/doomemacs/commit/bbf733c5e07b70628867e91452f12f6e309e848a) fix: profile loader file path
* [`5dcba2f8`](https://github.com/doomemacs/doomemacs/commit/5dcba2f89fa5a20c6535e15f859aaef466ce4b90) fix: permissions for local dirs
* [`97c0dcc2`](https://github.com/doomemacs/doomemacs/commit/97c0dcc2c328fcc791333e149418c26096043758) fix: early-init with DOOMPROFILE set
* [`8cafbe44`](https://github.com/doomemacs/doomemacs/commit/8cafbe4408e7d6c68947a2066e5837379d0983c1) refactor!: restructure Doom core
* [`7c89699e`](https://github.com/doomemacs/doomemacs/commit/7c89699e3fa3c3a06092c6bdb7f88fe1d33192b5) fix: silence (if|when)-let deprecation warnings
* [`aab15950`](https://github.com/doomemacs/doomemacs/commit/aab1595011c2bb52e0df0c67f122f3f3d3647793) fix: void-variable straight-base-dir errors
* [`f425f2ff`](https://github.com/doomemacs/doomemacs/commit/f425f2ff3da584cfe2676f6b9cf1d81a690a75e5) fix: more void-variable errors
* [`0b934258`](https://github.com/doomemacs/doomemacs/commit/0b9342589b8286ce3be0e6dc0078da1b96ed2592) fix(cli): doom upgrade: void-variable straight-repository-branch
* [`1f45e9e7`](https://github.com/doomemacs/doomemacs/commit/1f45e9e79edf00d77726fb80662061b769a33b40) refactor: remove redundant require calls
* [`5649e1ac`](https://github.com/doomemacs/doomemacs/commit/5649e1acc414babf1a95bfd5663e07f1b56165fe) fix: incorrect value for user-init-file
* [`114f9968`](https://github.com/doomemacs/doomemacs/commit/114f99688cdf1b389a74173d8eefd8bc661c94d0) fix: nil load-file-name in package autoloads
* [`9e6c46a3`](https://github.com/doomemacs/doomemacs/commit/9e6c46a332682b6026e7b8138c7de49c8efa2253) fix: indexing packages' Info documents
* [`b3aa41fd`](https://github.com/doomemacs/doomemacs/commit/b3aa41fd74241459bf1298b50bc3f39840236c1c) refactor: profile generators
* [`b26980a4`](https://github.com/doomemacs/doomemacs/commit/b26980a4a4ee3853d0a811001d7ad45fa67d02a1) fix: reversed autoloads
* [`7531c429`](https://github.com/doomemacs/doomemacs/commit/7531c4298e5decb891d6b48921b320aad18effc2) fix: indexing packages' Info documents (part 2)
* [`1d3c2db2`](https://github.com/doomemacs/doomemacs/commit/1d3c2db274a23756a6abca69f74dc4a63016efff) fix: doom-autoloads--scan: s/pfile/file
* [`e2c1801e`](https://github.com/doomemacs/doomemacs/commit/e2c1801e6a2d24ad7e9937cd60023a5b80db0812) fix: doom/reload: void-variable doom-module-init-file
* [`e1a2f94e`](https://github.com/doomemacs/doomemacs/commit/e1a2f94ec1534907ee36e9e0e6adc546eea9ae3e) fix: void-variable doom-module-load-path error
* [`0b79fd33`](https://github.com/doomemacs/doomemacs/commit/0b79fd3391812cac0289b6ab2714b605287f2229) fix: doom-autoloads--scan: set load-true-file-name too
* [`48d04330`](https://github.com/doomemacs/doomemacs/commit/48d043301ef86a7603bbf9e230e839db4112f6ca) fix: void symbol doom-module-packages-file
* [`0f556345`](https://github.com/doomemacs/doomemacs/commit/0f556345fdfdc4e5bcc6bb023877bf9a0f203dae) fix: remove custom-dont-initialize hack
* [`1b826fa8`](https://github.com/doomemacs/doomemacs/commit/1b826fa80f6d5a1bf01477a1cebd44c2c5bace89) refactor: remove load suffix hacks
* [`bcd399d1`](https://github.com/doomemacs/doomemacs/commit/bcd399d1c35941990f5da8e593a3464409bc2425) fix: more void-variable doom-module-*-file errors
* [`6a8c09f0`](https://github.com/doomemacs/doomemacs/commit/6a8c09f01288f1ed00a7cc2b7f5887e8f2b4be77) fix: package autoload order
* [`eea00f5d`](https://github.com/doomemacs/doomemacs/commit/eea00f5d455a4db980bf5ede7bf9d82ebfdc320d) refactor: remove doom/goto-private-*-file commands
* [`fdcab58a`](https://github.com/doomemacs/doomemacs/commit/fdcab58a1b28a3b2bde23789e2a4c9c1391070b6) fix: raise compile errors from profile init files
* [`68ace9c1`](https://github.com/doomemacs/doomemacs/commit/68ace9c1f1b60f4145aa2af6ff63ee179f460372) docs(cli): report full command in command-based errors
* [`989e7a00`](https://github.com/doomemacs/doomemacs/commit/989e7a0034a0c69b65d363d3206c814f0e9d930d) fix(cli): decli-group!: indentation
* [`1af6fe85`](https://github.com/doomemacs/doomemacs/commit/1af6fe85024d1ea3ae1bb54b039377c55a050d8f) fix(cli): cull empty let-forms in autoloads
* [`cb557319`](https://github.com/doomemacs/doomemacs/commit/cb557319a9750c13432550dda99bd0053a9ac52f) fix(lib): silence deprecation notice from autoload.el
* [`5e847095`](https://github.com/doomemacs/doomemacs/commit/5e84709577b2c28752eb78af2f9b02befdfd9877) nit(cli): fix print-group! indentation
* [`87833005`](https://github.com/doomemacs/doomemacs/commit/87833005fd9f6b5d4835d800c0e7923aae359a1d) tweak(cli): remove 'doom i' alias
* [`1ee4a0a6`](https://github.com/doomemacs/doomemacs/commit/1ee4a0a6ec43cb79f142716206e7177c7c5fb93c) tweak(cli): move doom {version,doctor,info} to top-level
* [`7bc39f2c`](https://github.com/doomemacs/doomemacs/commit/7bc39f2c1402794e76ea10b781dfe586fed7253b) fix: restore noninteractive init settings
* [`fa0a83ff`](https://github.com/doomemacs/doomemacs/commit/fa0a83ff2fbe3e13932d539d17855054582a31e7) feat(lib): add doom-plist-{map,map*}
* [`2373511d`](https://github.com/doomemacs/doomemacs/commit/2373511daf49f5b6686567e893ccf79e4c605bd4) refactor(lib): deprecate doom-plist-get
* [`caab7f92`](https://github.com/doomemacs/doomemacs/commit/caab7f92637b3737b0d876cd657861ba9e9011fd) nit: move obsolete aliases
* [`04c7cf51`](https://github.com/doomemacs/doomemacs/commit/04c7cf51b4f312d322aed88097777211e64e94d0) tweak(emacs-lisp): imenu: rearrange groups & fix nested cl types
* [`87a024ee`](https://github.com/doomemacs/doomemacs/commit/87a024ee9070dbfaf39322e1bd45eac4c9597a26) fix: don't byte-compile profile init file
* [`90ede316`](https://github.com/doomemacs/doomemacs/commit/90ede316983966b5c5f584bba679f65b3549b2d3) fix(org): org-roam: remove emacsql-sqlite hacks
* [`16543b6c`](https://github.com/doomemacs/doomemacs/commit/16543b6c2bf8f7fb3d9c77f7aed80d70b766d131) bump: :tools debugger lsp
* [`ef33cb3b`](https://github.com/doomemacs/doomemacs/commit/ef33cb3b63b0c8a1cf669110706175b07c33af0c) bump: :config use-package
* [`2b0013db`](https://github.com/doomemacs/doomemacs/commit/2b0013db1c7e834976a72d9c0c97977ad3ab438b) bump: emacsql
* [`9423f6bf`](https://github.com/doomemacs/doomemacs/commit/9423f6bf95e0bb5e797a94b53a0b50a84680b440) fix(default): woman: ignore stderr from manpath
* [`7533707e`](https://github.com/doomemacs/doomemacs/commit/7533707e0057fec56d04681eb327541c4163ab92) fix(coq): file-missing generic/proof-site error
* [`a2113327`](https://github.com/doomemacs/doomemacs/commit/a211332796de25225784c71908c5e97be22dfa15) fix(python): invalid command for basedpyright
* [`b126c385`](https://github.com/doomemacs/doomemacs/commit/b126c3857d6687de04e40f0c632da45f4ab15ebc) bump: :lang
* [`be4fb85d`](https://github.com/doomemacs/doomemacs/commit/be4fb85dd93810e495d5f4a793d620f82508cb7e) bump: :ui
* [`9c8cfaad`](https://github.com/doomemacs/doomemacs/commit/9c8cfaadde1ccc96a780d713d2a096f0440b9483) fix(cli): doom sync: void-variable envvars error
