### PR TITLE
niv nixpkgs: update 1635ae0b -> 32cbecb2

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1635ae0b386ed5d63dc233d5881ad002b45a2db3",
-        "sha256": "1r5qmc61yvydyh8imh8flbyzkgjd3v3jk5vc9zds70h99mvr7gqj",
+        "rev": "32cbecb28fd80987dcea38b1d9c577db1259f0ad",
+        "sha256": "08slfkann4wr1qizjyfqbkhmb2lfcrak0d912b7k4pfx7rxrxj4b",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/1635ae0b386ed5d63dc233d5881ad002b45a2db3.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/32cbecb28fd80987dcea38b1d9c577db1259f0ad.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@1635ae0b...32cbecb2](https://github.com/nixos/nixpkgs/compare/1635ae0b386ed5d63dc233d5881ad002b45a2db3...32cbecb28fd80987dcea38b1d9c577db1259f0ad)

* [`6f0523e4`](https://github.com/NixOS/nixpkgs/commit/6f0523e4847da9a801d96d698bf331f48863e444) nixos/documentation: Link Devhelp files
* [`8e1ad9ba`](https://github.com/NixOS/nixpkgs/commit/8e1ad9ba9270df6bb4ea7dddeeb9a3a1b33b75a5) gnome: check for package exclusions by name for default program modules
* [`541afcbc`](https://github.com/NixOS/nixpkgs/commit/541afcbc9b16d4d63391f85d21d920de9f247dba) cinnamon: check for package exclusions by name for themes
* [`9711af05`](https://github.com/NixOS/nixpkgs/commit/9711af0579b007dc9a301c70b6469c09b58d4d3d) nixos/iso-image: fix isoImage.grubTheme = null; logic
* [`cd75ec21`](https://github.com/NixOS/nixpkgs/commit/cd75ec216aadbcec5b3b9a96897d2a1247b24713) nixos/networkd: allow configuring RTTSec for CAKE qdisc
* [`9692e2e8`](https://github.com/NixOS/nixpkgs/commit/9692e2e81987410ed51af3b7733d1f1bbabc31bd) nixos/java: No bashisms in `environment.shellInit` script
* [`610e8be8`](https://github.com/NixOS/nixpkgs/commit/610e8be8387cfd96e5016c258f5a6748e7ab2ef0) maintainers: add tholo
* [`063943c2`](https://github.com/NixOS/nixpkgs/commit/063943c214aed7e583d9ec026a56e5b5b806b53d) emulationstation-de: 2.2.1 -> 3.0.2
* [`63924a70`](https://github.com/NixOS/nixpkgs/commit/63924a70b188a2dc3aa8717aeba25ad473ef3569) ammonite: add ammonite for Scala 3.3
* [`e9a119ea`](https://github.com/NixOS/nixpkgs/commit/e9a119ead4272db6f3b9f44355251418abed8c60) nixos/installation-cd-base: add git & rsync
* [`3bdb9637`](https://github.com/NixOS/nixpkgs/commit/3bdb9637ecd2cf126f329fa34367857a9dff11a6) maintainers: add evris99
* [`402699d0`](https://github.com/NixOS/nixpkgs/commit/402699d00e98907f7922986fdcd50c875a6a48fc) nixos/networkd: add IPv6RetransmissionTimeSec option to [Network] section
* [`38d02e4e`](https://github.com/NixOS/nixpkgs/commit/38d02e4ecd886cac339786baac7fe87ba9f0f61d) nixos/networkd add IPv4ProxyARPPrivateVLAN option to [Network] section
* [`ee051d65`](https://github.com/NixOS/nixpkgs/commit/ee051d65f316cce2ede70383d18ffd5b2f3f9edc) nixos/networkd: add L3MasterDevice option to [RoutingPolicyRule] section
* [`c4f70c3c`](https://github.com/NixOS/nixpkgs/commit/c4f70c3c275cc6ede5e190f8b3ad2a7817c5ef9c) moodle: 4.4.1 -> 4.4.3
* [`55e7c615`](https://github.com/NixOS/nixpkgs/commit/55e7c6155a91eb6b3a9f400cbc830c7271da5983) nixos/moodle: update to php83
* [`c945e4db`](https://github.com/NixOS/nixpkgs/commit/c945e4db53337a0bb71b593bf9a2f2689669fce3) nixos/installation-device: make openssh settings a default
* [`71b36a1b`](https://github.com/NixOS/nixpkgs/commit/71b36a1b261c7802c9b94e7dcc99b9e765a7249e) openutau: bump dotnet version 7 -> 8
* [`722137f9`](https://github.com/NixOS/nixpkgs/commit/722137f9eacae1027a62c70c825b2543bdc8261c) shadershark: simplify update script
* [`005fca65`](https://github.com/NixOS/nixpkgs/commit/005fca65323f3c7016e7a05c37978c156649731c) ciscoPacketTracer7: disown
* [`e383d676`](https://github.com/NixOS/nixpkgs/commit/e383d67656d91670469df4ba678f83882ae0b10b) ciscoPacketTracer8: disown
* [`0b3aa5bd`](https://github.com/NixOS/nixpkgs/commit/0b3aa5bd5ccde47da9d59fee4b3d2c11fa3137d0) electron: fix "Incomplete regular expression for hostnames" in update script
* [`a9c94419`](https://github.com/NixOS/nixpkgs/commit/a9c9441997fcb49f7d6ee5e03a0bc79b3a9e0bc8) fetch-yarn-deps: fix "Incomplete URL substring sanitization"
* [`60550330`](https://github.com/NixOS/nixpkgs/commit/60550330ceaf6457c8a243d0e3bfc4048ec37805) yarn2nix: fix "Incomplete URL substring sanitization"
* [`1c4d950b`](https://github.com/NixOS/nixpkgs/commit/1c4d950be62611eef1634f90695f52d576abc1ad) maubot: fix "Incomplete URL substring sanitization" in plugins update script
* [`1c79bffa`](https://github.com/NixOS/nixpkgs/commit/1c79bffa2911c65014d0fc0470527c46bc4d115e) ciscoPacketTracer{7,8}: re-add `with maintainers`
* [`f6c2abe7`](https://github.com/NixOS/nixpkgs/commit/f6c2abe75144bb5dd814c7757b137a46434fdbe9) python3Packages.pyflipper: init at 0.18-unstable-2024-04-15
* [`8b8fd74b`](https://github.com/NixOS/nixpkgs/commit/8b8fd74b2329c919d60a75aa6167b0e5b077f507) vokoscreen-ng: 4.0.0 -> 4.2.0
* [`fb13561a`](https://github.com/NixOS/nixpkgs/commit/fb13561ac91671eb10016aa97a3c5762aeeab615) python312Packages.tensorflow: use tensorflow-bin by default
* [`804211c4`](https://github.com/NixOS/nixpkgs/commit/804211c4c43ee5da01af307d9cf503d2f95f290a) python312Packages.tf-keras: clean derivation
* [`a076a881`](https://github.com/NixOS/nixpkgs/commit/a076a88139452237749062581ce27704d6677b91) python312Packages.keras: add missing dependency distutils
* [`f7d992d6`](https://github.com/NixOS/nixpkgs/commit/f7d992d6dde3a51a8dfea1486c3e56f59ea26ec0) sysdig-cli-scanner: do not use --dbpath arg when --iac is set
* [`4d040761`](https://github.com/NixOS/nixpkgs/commit/4d0407614dfd25a235d3b2ec533c524d03186591) rider: add avalonia libs needed for dotMemory
* [`1b510687`](https://github.com/NixOS/nixpkgs/commit/1b510687b4f54c14490f941a7f66312df94d2788) nixos/mailman: wrap mailman cli to start as mailman user
* [`5f6dd365`](https://github.com/NixOS/nixpkgs/commit/5f6dd3654ce8bb2dd7f6b7f8a8f8dc0950343c11) python3.pkgs.geoarrow-types: init at 0.2.0
* [`0f949a0b`](https://github.com/NixOS/nixpkgs/commit/0f949a0bffabfa6f77fd76ae23ad149792e7c8e2) python3.pkgs.geoarrow-c: init at 0.1.3
* [`a06ca42c`](https://github.com/NixOS/nixpkgs/commit/a06ca42c14d0de662cf970e713d174dcd66af608) python3.pkgs.geoarrow-pyarrow: init at 0.1.2
* [`17b05c63`](https://github.com/NixOS/nixpkgs/commit/17b05c63e87ad3061fe3f7bf3b12461d43190f4c) python3.pkgs.geoarrow-pandas: init at 0.1.2
* [`0d2187f1`](https://github.com/NixOS/nixpkgs/commit/0d2187f1b24c43c9515bba4756728735327133f0) halloy: fix add halloy url scheme handler
* [`0e68835e`](https://github.com/NixOS/nixpkgs/commit/0e68835e06e3cd5fdee34f0ef7076cc2120e7848) python312Packages.azure-mgmt-resource: 23.1.1 -> 23.2.0
* [`f9d0de7f`](https://github.com/NixOS/nixpkgs/commit/f9d0de7fccd2eae95ddcdb099aca4e3938b21bef) python312Packages.docstring-parser: 0.15 -> 0.16
* [`f9efbc90`](https://github.com/NixOS/nixpkgs/commit/f9efbc90b4c85e49949da97fea81ede49885d14f) python312Packages.pytest-celery: 0.1.0 -> 1.1.1
* [`a58c8fee`](https://github.com/NixOS/nixpkgs/commit/a58c8fee1e265904132803d4d4d8c1d9c56dee71) nixos/wg-access-server: bugfix dns.enabled (yaml)
* [`162a6c2b`](https://github.com/NixOS/nixpkgs/commit/162a6c2bbf034af25739222dd28f89b7de0de7fb) python312Packages.python-engineio: 4.9.1 -> 4.10.1
* [`f1e8d2b3`](https://github.com/NixOS/nixpkgs/commit/f1e8d2b37f3df1be97defdb22aaf31aef43936ea) python312Packages.simple-websocket: 1.0.0 -> 1.1.0
* [`5b260ab8`](https://github.com/NixOS/nixpkgs/commit/5b260ab83d67b08d561f3191971efa57f6df87c0) python312Packages.vobject: 0.9.7 -> 0.9.8
* [`21d6e5c7`](https://github.com/NixOS/nixpkgs/commit/21d6e5c776852852fda897b0b33a4b137fed2f20) python312Packages.vobject: refactor
* [`42ac7b24`](https://github.com/NixOS/nixpkgs/commit/42ac7b2428fc0895ebf1809d62b9ef47a2686258) nixos/networkd: add dhcpServerConfig.PersistLeases option
* [`17c58cde`](https://github.com/NixOS/nixpkgs/commit/17c58cde1623229a7f34973ca49fb9204badddda) python312Packages.llama-cpp-python: init at 0.3.1
* [`cc1ac71d`](https://github.com/NixOS/nixpkgs/commit/cc1ac71df5506424d9a6f27969515bc930e08d74) python312Packages.llama-cpp-python: add passthru.test to build with CUDA
* [`f4e43ac2`](https://github.com/NixOS/nixpkgs/commit/f4e43ac273943bedb957d13fcdcf0cba4203e9bc) python312Packages.llama-cpp-python: use stdenv from cudaPackages
* [`ed534e09`](https://github.com/NixOS/nixpkgs/commit/ed534e09d00f3a0f440f46db5e9fe5e67c663466) python312Packages.asyncstdlib: 3.12.5 -> 3.13.0
* [`97c5b688`](https://github.com/NixOS/nixpkgs/commit/97c5b6880867accc8e968559ee6a2b7f4fec068b) python312Packages.meteoswiss-async: relax aiohttp and asyncstdlib
* [`04c89f98`](https://github.com/NixOS/nixpkgs/commit/04c89f9811c39959be724a7b12db844d42eded35) python312Packages.weheat: 2024.09.23 -> 2024.11.2
* [`3c21a5c9`](https://github.com/NixOS/nixpkgs/commit/3c21a5c9d6c87860a9abeb9f3ef753496de9c809) lib/systems: elaborate properly with non-matching system / config / parsed args
* [`64a6e829`](https://github.com/NixOS/nixpkgs/commit/64a6e8292aa39a664743d20b520173320dcea6bc) nixos/acme: Set /var/lib/acme permissions to 755
* [`706960ce`](https://github.com/NixOS/nixpkgs/commit/706960ceec6ea5c16260fa3f21e75b8163259b5b) parlay: init at 0.6.0
* [`e9d417cd`](https://github.com/NixOS/nixpkgs/commit/e9d417cdd14b2bf9dcd09d0a396d6489f898958b) limesctl: drop
* [`6bd3ff78`](https://github.com/NixOS/nixpkgs/commit/6bd3ff78381dbb38887574e7c587336768f8f5bb) gancio: remove mkYarnPackage usage
* [`10959a82`](https://github.com/NixOS/nixpkgs/commit/10959a82889bc2a8d50bf8e13144f64a20ae6d86) gancioPlugins.telegram-bridge: remove mkYarnPackage usage
* [`25be6b0c`](https://github.com/NixOS/nixpkgs/commit/25be6b0c86a0d80f9756dc205a7a7c5f75bf97e6) angular-language-server: remove overjealous templating
* [`2c147282`](https://github.com/NixOS/nixpkgs/commit/2c147282024849856d24cd3cfe892a4f639c2e9b) llvmPackages.compiler_rt: Fix compiler_rt version tests for git
* [`bbb6e83f`](https://github.com/NixOS/nixpkgs/commit/bbb6e83f5191eec81ee7d4e1d73a72396a626f96) nixos/binfmt: add option `addEmulatedSystemsToNixSandbox`
* [`5b4a8db4`](https://github.com/NixOS/nixpkgs/commit/5b4a8db4d9ae791a4d2a1f205806ef95c3efc853) build-support/docker: customisable layering strategy
* [`205e5a55`](https://github.com/NixOS/nixpkgs/commit/205e5a55fd18f30a3a1e6ec4b4f0b80ef123fd5f) R: patchelf libraries missing libR.so
* [`09b4aa1d`](https://github.com/NixOS/nixpkgs/commit/09b4aa1dce9ada503a06ae8bb20682a70000c199) eyedropper: 1.0.0 -> 2.0.1
* [`9af38b4e`](https://github.com/NixOS/nixpkgs/commit/9af38b4ee1bc9a412bf4d14318e1be7b98ebe4d3) caf: apply formatting
* [`51ba14b1`](https://github.com/NixOS/nixpkgs/commit/51ba14b167e2e222fbc866485b8ea0d7f8fe2bfd) llvmPackages: Make targetLlvmLibraries overridable
* [`d581c42d`](https://github.com/NixOS/nixpkgs/commit/d581c42d5d55c612a687cb22db8f748c4f608c7b) nixos/paperless: add secretsFile option
* [`0dff4975`](https://github.com/NixOS/nixpkgs/commit/0dff4975e883f6e18d0e8adf4eab295c33200c0a) adguardhome: 0.107.53 -> 0.107.54
* [`d65d45c6`](https://github.com/NixOS/nixpkgs/commit/d65d45c669bd548f0cdfb7cacba808b1d40410be) maintainers: add r17x
* [`c304abf7`](https://github.com/NixOS/nixpkgs/commit/c304abf7cf0e60b8af36777a279e2f474a7da896) xbar: init at 2.1.7-beta
* [`d954930a`](https://github.com/NixOS/nixpkgs/commit/d954930a4fc417aedf0201f32bd7df2a70eea525) stdenv: add Silvermont support, remove incorrect AES support
* [`6cecfd8a`](https://github.com/NixOS/nixpkgs/commit/6cecfd8ad7236806a710ccbb291f0f863336f2bf) docker-tool: fix maxLayers assert
* [`6b3108af`](https://github.com/NixOS/nixpkgs/commit/6b3108af8521e9e1f446a4161605acee61508c4f) streamlink: 6.11.0 -> 7.0.0
* [`c2713e9c`](https://github.com/NixOS/nixpkgs/commit/c2713e9c7b5efb6f4ac2043501394a4aa56698ef) normcap: 0.5.8 -> 0.5.9
* [`40e8ef4a`](https://github.com/NixOS/nixpkgs/commit/40e8ef4a2a096f7c001221d6a2f67e9515a586d5) exegol: 4.3.1 -> 4.3.8
* [`ac8286a5`](https://github.com/NixOS/nixpkgs/commit/ac8286a5ed6b6544f13a9016f79bc78f91f356c5) maintainers: add charB66
* [`0a1effab`](https://github.com/NixOS/nixpkgs/commit/0a1effab9e6caa99b520b2f60c1a5870a09beb45) exegol: add charB66 as maintainer
* [`f621753b`](https://github.com/NixOS/nixpkgs/commit/f621753b76bfda3524d0a95c3c78d67b297c0ced) flatten_references_graph: remove unused fixture and all real /nix/store paths from tests
* [`a9f3a296`](https://github.com/NixOS/nixpkgs/commit/a9f3a296d311b1a08fffafad4f53fbd240d5b9e7) nixos/lvm: expand enable description to better inform users about their actions
* [`b5a3634e`](https://github.com/NixOS/nixpkgs/commit/b5a3634ea1fc968c2ff31ef4333bb6008e24197f) sd-image: fix raspberry pi 0 boot
* [`625c8e4c`](https://github.com/NixOS/nixpkgs/commit/625c8e4ce8c221a0e1267f60da9d01767d316da0) pmbootstrap: 2.3.1 > 3.0.0
* [`95fe499c`](https://github.com/NixOS/nixpkgs/commit/95fe499c1dd6f74a0632ab6dfe9feaa5e79664a5) youki: add systemd build flag
* [`479359d5`](https://github.com/NixOS/nixpkgs/commit/479359d5b60fe1c420409e3f1b213a560d073896) kcl: 0.10.0 -> 0.10.9
* [`e98441f1`](https://github.com/NixOS/nixpkgs/commit/e98441f15fdb883b4d36765a7399c19e826bcc27) sudo: 1.9.16 -> 1.9.16p2
* [`5647888f`](https://github.com/NixOS/nixpkgs/commit/5647888ffb2277294992e073c857120c0eb964fb) python3Packages.python-mapnik: mark broken
* [`609794c5`](https://github.com/NixOS/nixpkgs/commit/609794c5183a9aed7f3c837133a0c41cabd027a7) xcp: 0.21.3 -> 0.22.0
* [`cb14281e`](https://github.com/NixOS/nixpkgs/commit/cb14281e112718ca7b05060bc540684f2d5f82f7) archi: 5.3.0 -> 5.4.3
* [`780c0bbd`](https://github.com/NixOS/nixpkgs/commit/780c0bbdeaedec7976ccdd73083f57d174dc3e73) bluej: move to pkgs/by-name
* [`8bc4908f`](https://github.com/NixOS/nixpkgs/commit/8bc4908f5c36bb62c23e12906fd5f3af4750454c) bluej: with lib; cleanup
* [`74458684`](https://github.com/NixOS/nixpkgs/commit/74458684bdc16dfbfb9e1091cba0b83bf227f3ea) bluej: nixfmt-rfc-style
* [`79acebfa`](https://github.com/NixOS/nixpkgs/commit/79acebfa44002f53bb92bc37fd9fc565e3f581c9) svix-server: 1.38.0 -> 1.40.0
* [`9a9707a8`](https://github.com/NixOS/nixpkgs/commit/9a9707a8b795ad8a312d13a2207620c525449edb) maintainers: add anugrahn1
* [`b2e7be76`](https://github.com/NixOS/nixpkgs/commit/b2e7be76ba71822327db9fa2cbc75c447abaa04c) nixos/acme: fix cert ownership assert for string `SupplementaryGroups`
* [`1555c004`](https://github.com/NixOS/nixpkgs/commit/1555c004881637a1c6973a3a244ac42f9a4badce) texlive.combine: fix requiredTexPackages
* [`041fc2c6`](https://github.com/NixOS/nixpkgs/commit/041fc2c6f58ee02fbc235e7a62cd8528f108a0a5) tana: 1.0.16 -> 1.0.17
* [`d69c5a4a`](https://github.com/NixOS/nixpkgs/commit/d69c5a4ad3d5d45b6aa189b60f1d2d47dc4c04cb) python3Packages.netbox-plugin-prometheus-sd: init at 1.1.1
* [`4b8fee22`](https://github.com/NixOS/nixpkgs/commit/4b8fee227424154cb455ca745e633303ab6405d8) nixos/netbird: fix coturn configuration
* [`7a0ebd3a`](https://github.com/NixOS/nixpkgs/commit/7a0ebd3abc3d614977ea029186a311a32f3e8d1b) aspellDicts: expose pname and version
* [`4de62b4c`](https://github.com/NixOS/nixpkgs/commit/4de62b4c0fc4a24e5efae581c440a5196773bd5a) nb: add passthru.tests.version
* [`30610d3d`](https://github.com/NixOS/nixpkgs/commit/30610d3d1ff09f8c78fad930c832b485a374efd9) nb: add updateScript
* [`850c40d4`](https://github.com/NixOS/nixpkgs/commit/850c40d402bd292899dcd08852ea2bd993f628e3) 7z2hashcat: init at 2.0
* [`500c708b`](https://github.com/NixOS/nixpkgs/commit/500c708ba6c745cc3929f44f4fc82c92aad5b44d) act: add passthru.tests.version
* [`7b47ad2d`](https://github.com/NixOS/nixpkgs/commit/7b47ad2dfd84863fb3a8d4f83e8b93ddd892fa16) vscode-extensions: set pname
* [`4a5fbe74`](https://github.com/NixOS/nixpkgs/commit/4a5fbe7489c1a7efada93a34401b880841235f4b) maintainers: add ribru17
* [`b143a809`](https://github.com/NixOS/nixpkgs/commit/b143a809ea1d6ef1a7deb0c3cef895256fc91171) gping: 1.17.3 -> 1.18.0
* [`640a6391`](https://github.com/NixOS/nixpkgs/commit/640a6391c7cf5117d4cad5b1f0dcd8321c36541a) netbird-dashboard: 2.5.0 -> 2.7.0
* [`572e6233`](https://github.com/NixOS/nixpkgs/commit/572e623305c039e3af896d10d73d4e8597ff21dc) glib: disable sysprof feature on FreeBSD
* [`027e7777`](https://github.com/NixOS/nixpkgs/commit/027e77778c87d6599dd485c15801283c6e5962b6) nixos/hostapd: allow octothorpe characters in SAE password
* [`088f1e64`](https://github.com/NixOS/nixpkgs/commit/088f1e641b8c14eb451591ce6d0ae29c3d8fd666) workflows/check-nix-format: reminder to rebase
* [`d753a00a`](https://github.com/NixOS/nixpkgs/commit/d753a00a5a84b436881a1d6a861d7c0dbd81ad24) mullvad-vpn: 2024.6 -> 2024.7
* [`934079c6`](https://github.com/NixOS/nixpkgs/commit/934079c635cd130b556dc2af7e8176f29681f6db) fetchsvn: add system certificate authorities bundle
* [`c8145a30`](https://github.com/NixOS/nixpkgs/commit/c8145a308cf97a2d890a0062f3273b9988127bd7) prometheus-aruba-exporter: init at unstable-2023-01-18
* [`623ecef9`](https://github.com/NixOS/nixpkgs/commit/623ecef987c4dc0fc4682244fb4e3489fbf8f94e) freebsd: set `BOOTSTRAPPING` when building for Linux
* [`337b2fd9`](https://github.com/NixOS/nixpkgs/commit/337b2fd99d138e750551473347311c848205fd5d) freebsd.localedef: Fix formatting
* [`df1ec7d0`](https://github.com/NixOS/nixpkgs/commit/df1ec7d0937fdcfad12500f6f23584ce477fd5df) freebsd.mkDerivation: move all environment variable declarations into env attrset
* [`3d728b1d`](https://github.com/NixOS/nixpkgs/commit/3d728b1d9af87fea4b663af7ef5f07bc98497e7b) quill: format using nixfmt
* [`16ec17e6`](https://github.com/NixOS/nixpkgs/commit/16ec17e630064b10f52d14224e9e53bb60f5420d) quill: use `useFetchCargoVendor`
* [`b5938e6b`](https://github.com/NixOS/nixpkgs/commit/b5938e6b8c3c69ded5922c478e38c77f87faea51) quill: 0.2.17 -> 0.5.1
* [`97954a85`](https://github.com/NixOS/nixpkgs/commit/97954a8515b033fa03c2e2d02b51aa998bd9170e) quill: remove `with lib` from meta
* [`306de5ac`](https://github.com/NixOS/nixpkgs/commit/306de5acc38c342add3bb94406598814f94db722) maintainers: add octvs as maintainer
* [`8a8e3493`](https://github.com/NixOS/nixpkgs/commit/8a8e349342057864bd714488f42899b56f9874b7) mpvScripts.autosub: init at 2021-06-29
* [`692c9fdb`](https://github.com/NixOS/nixpkgs/commit/692c9fdbfaf55522114dd930cd205037b652947f) vivaldi: use coreutils from nixpkgs
* [`05a28af5`](https://github.com/NixOS/nixpkgs/commit/05a28af51bc4aadb820b75df01075b11efece23a) .github/labeler.yml: add ruby label for gem changes
* [`1a03c1d3`](https://github.com/NixOS/nixpkgs/commit/1a03c1d3835c615da27a367ca5455a5f956b3910) git-prole: 0.5.1 -> 0.5.3
* [`b5c19b4c`](https://github.com/NixOS/nixpkgs/commit/b5c19b4cb003f63674669203db7254ec5f480e56) fuzzel: support building with librsvg backend
* [`272ae239`](https://github.com/NixOS/nixpkgs/commit/272ae2396694327ec269ef244be0a9099974d5b0) railway: 3.17.10 -> 3.18.0
* [`34941a6a`](https://github.com/NixOS/nixpkgs/commit/34941a6aa430580d3ebda1f6cb17f58fa13d9ae8) step-ca: 0.27.5 -> 0.28.0
* [`21dea591`](https://github.com/NixOS/nixpkgs/commit/21dea5914a26d212c263da3620db79e47dd4646b) waypipe: 0.9.1 -> 0.9.2
* [`4545329a`](https://github.com/NixOS/nixpkgs/commit/4545329a81e401f4eafc40336712b8be37b26cf3) jellyfin{,-web}: 10.10.1 → 10.10.2
* [`1110e5fe`](https://github.com/NixOS/nixpkgs/commit/1110e5fe642a5120c74066d53ed0cb23cceef43c) haskell-modules: Add replacements-by-name
* [`e62e4c5d`](https://github.com/NixOS/nixpkgs/commit/e62e4c5dd8c2608ddfecb7fe4a4690784d91899d) haskellPackages.hercules-ci-cnix-store: 0.3.6.0 -> 0.3.6.1
* [`5092b77f`](https://github.com/NixOS/nixpkgs/commit/5092b77f735380542a919fe99f3d14ad11fee047) haskellPackages.hercules-ci-cnix-expr: 0.3.6.4 -> 0.3.6.5
* [`ee93a4f5`](https://github.com/NixOS/nixpkgs/commit/ee93a4f541cd0e931ec4e1ed7c8c36ad4594f120) haskellPackages.hercules-ci-agent: 0.10.4 -> 0.10.5
* [`19b4b39d`](https://github.com/NixOS/nixpkgs/commit/19b4b39db4b02959e59e7975f64518d05c5e998f) hercules-ci-cnix-store/nix: 2.18 -> 2.24
* [`9314da7e`](https://github.com/NixOS/nixpkgs/commit/9314da7ee8d2aedfb15193b8c489da51efe52bb5) Format
* [`240d44bc`](https://github.com/NixOS/nixpkgs/commit/240d44bc7475f47a88d0b4cdcb1da341dcf2716d) gjs: assign meta.mainProgram
* [`7a9a2d8f`](https://github.com/NixOS/nixpkgs/commit/7a9a2d8f34e19b1002b12f8cbd5fe962843fa4c8) gnome-maps: fix cross compilation
* [`b2aa67fb`](https://github.com/NixOS/nixpkgs/commit/b2aa67fb819036d3c796fd5c2e343733356a522d) iio-oscilloscope: init at 0.17
* [`4f681fdc`](https://github.com/NixOS/nixpkgs/commit/4f681fdcdddbf722c7362146656181091bd3641d) amiri: 1.000 -> 1.001
* [`05baf008`](https://github.com/NixOS/nixpkgs/commit/05baf008998374c75c87a880d30ef7c62a92319d) ponysay: fix SyntaxWarning
* [`4167057b`](https://github.com/NixOS/nixpkgs/commit/4167057b32b5de3dff33cef2dcfa08c3f38f0fe4) ghidra: add wasm extension
* [`c565ccd3`](https://github.com/NixOS/nixpkgs/commit/c565ccd3264ff3ca59d7d43515af0f8415f729bf) freebsd: improve overridability of entire package set
* [`73da8726`](https://github.com/NixOS/nixpkgs/commit/73da8726b34bc4489f86e4418c45ad8c5910850c) hqplayer-desktop: 4.22.0-65 -> 5.8.2-25
* [`2a1f893b`](https://github.com/NixOS/nixpkgs/commit/2a1f893b6ac8f8c4a6524b3abe86172364c78b3f) perlPackages.ModuleScanDeps: 1.34 -> 1.37
* [`6e397f45`](https://github.com/NixOS/nixpkgs/commit/6e397f45c204e2b713ed063966287dc9144d28a1) rainfrog: 0.2.9 -> 0.2.10
* [`ad430b1b`](https://github.com/NixOS/nixpkgs/commit/ad430b1b0999fb8cb9efe088789ce009e2607047) rainfrog: add passthru.tests.version
* [`bbeed35f`](https://github.com/NixOS/nixpkgs/commit/bbeed35f79aa254d20f9657d47c0b2f600cd0599) cue: format with nixfmt
* [`f995dcd4`](https://github.com/NixOS/nixpkgs/commit/f995dcd4d7c86b002ba0bb7ae662338d911f8fc8) cue: 0.10.1 -> 0.11.0
* [`d028ee00`](https://github.com/NixOS/nixpkgs/commit/d028ee002899753157579ef60d0e58531b7effd0) python312Packages.python-socks: 2.5.2 -> 2.5.3
* [`009bee2d`](https://github.com/NixOS/nixpkgs/commit/009bee2d92ae7204fff2056b105472c3ddf4db4d) ncdu: 2.6 -> 2.7
* [`20a29cb9`](https://github.com/NixOS/nixpkgs/commit/20a29cb94fbca9648260ac4016c8991aeef881ae) bfg-repo-cleaner: 1.13.0 -> 1.14.0
* [`8ad7b50b`](https://github.com/NixOS/nixpkgs/commit/8ad7b50bf8369a965cc6ddad5253c9f9335269de) bfg-repo-cleaner: format with nixfmt-rfc-style
* [`5a4df0c1`](https://github.com/NixOS/nixpkgs/commit/5a4df0c14f9445c297fbb52db6cb065e25469ff9) bfg-repo-cleaner: add passthru.tests.version
* [`21eb9f18`](https://github.com/NixOS/nixpkgs/commit/21eb9f187e9ac0558ccab12de6fb31e06019df19) fishnet: format with nixfmt-rfc-style
* [`bbaf0abf`](https://github.com/NixOS/nixpkgs/commit/bbaf0abf9ce813abc09697349c73feb2cb62e453) fishnet: add passthru.tests.version
* [`511ae6d1`](https://github.com/NixOS/nixpkgs/commit/511ae6d1787e96c0c89e0d73380bd35717d35d26) pomerium: 0.27.2 -> 0.28.0
* [`c1ce95d1`](https://github.com/NixOS/nixpkgs/commit/c1ce95d1223812140bacfc5a6d330878d37923df) firefox-beta-unwrapped: 133.0b1 -> 133.0b9
* [`703ad4e4`](https://github.com/NixOS/nixpkgs/commit/703ad4e4621ee3c145009f0c3b02c5ccaab81525) kando: 1.4.0 -> 1.5.1
* [`71e5e9cd`](https://github.com/NixOS/nixpkgs/commit/71e5e9cd17f8a2b1bf86fb5145128097fdcb9f1e) qspeakers: 1.6.9 -> 1.6.10
* [`fc3800db`](https://github.com/NixOS/nixpkgs/commit/fc3800db5100e29f90f24cb6c11f355c957dd791) timew-sync-client: init at 1.0.1-unstable-2024-08-05
* [`d5150853`](https://github.com/NixOS/nixpkgs/commit/d51508538c2aef713c79a3d8bc0b2541388c0c09) singular: 4.3.2p16 -> 4.4.0p6
* [`58600bbc`](https://github.com/NixOS/nixpkgs/commit/58600bbcf92de75d1820c7713cecf500910b4148) notepad-next: 0.8 -> 0.9
* [`5f4f6718`](https://github.com/NixOS/nixpkgs/commit/5f4f6718627fde799586b4b17d73ea745cacf603) tesh: fix build
* [`4814bb47`](https://github.com/NixOS/nixpkgs/commit/4814bb478f7cf133b9b596927eaec9c8bb68d850) seclists: 2024.3 -> 2024.4
* [`09064248`](https://github.com/NixOS/nixpkgs/commit/090642487838f62463577f64dbdc6304bccaa2e1) chiptrack: 0.3.1 -> 0.5
* [`afa66f47`](https://github.com/NixOS/nixpkgs/commit/afa66f475581570610d399839623f125f7e5bad8) factorio: fix `updateScript` definition
* [`4ae2d4df`](https://github.com/NixOS/nixpkgs/commit/4ae2d4df2ca3dc74fecbcf396be4c916f4d208c3) k2pdfopt: format
* [`8657f42d`](https://github.com/NixOS/nixpkgs/commit/8657f42dcc3835baf84d593716c1104eba03de64) k2pdfopt: pin tesseract version
* [`4a43f36f`](https://github.com/NixOS/nixpkgs/commit/4a43f36f2677276f13143b8d0a7046f4e5631623) sunvox: Add back wayback machine fallback src
* [`87c189e2`](https://github.com/NixOS/nixpkgs/commit/87c189e26bdeacbd7070658c06fa60f7d7f1e215) logdy: 0.13.0 -> 0.13.1
* [`36c71c53`](https://github.com/NixOS/nixpkgs/commit/36c71c53a03721afcc181c2623e3b9802a9949e2) suitesparse-graphblas: 9.3.1 -> 9.4.2
* [`5f830be0`](https://github.com/NixOS/nixpkgs/commit/5f830be0e81d008f7fd8cde6753f64ee2db770c0) lua-language-server: 3.13.0 -> 3.13.2
* [`73bf44ce`](https://github.com/NixOS/nixpkgs/commit/73bf44ceb684d6f8e528dd70a3633471db703a1a) python312Packages.cached-property: 1.5.2 -> 2.0.1
* [`d8741973`](https://github.com/NixOS/nixpkgs/commit/d87419737d1eaf75f20f39c124309a4038443d7a) python312Packages.libcst: 1.5.0 -> 1.5.1
* [`144d01dd`](https://github.com/NixOS/nixpkgs/commit/144d01dd49fd77ad9d88e4ea21b5f00a64c20ad9) zabbix70: 7.0.5 -> 7.0.6
* [`6f88eaab`](https://github.com/NixOS/nixpkgs/commit/6f88eaab1bc294ce147608a9b5043a275b8c6c56) beets: allow darwin builds
* [`abc5566a`](https://github.com/NixOS/nixpkgs/commit/abc5566af957882d429b89ca50dff961656541b6) amazon-cloudwatch-agent: 1.300049.1 -> 1.300050.0
* [`e4c37a63`](https://github.com/NixOS/nixpkgs/commit/e4c37a6375a2dfc6fc39be08b6ab6097c4ab1e62) jetbrains.clion: 2024.2.3 -> 2024.3
* [`d37c1931`](https://github.com/NixOS/nixpkgs/commit/d37c1931259e0d35d284627ab2168629361338bf) jetbrains.plugins: update
* [`1bdff917`](https://github.com/NixOS/nixpkgs/commit/1bdff917553098af6788022cbc9c3da0e47cdd59) flutter: revert remove usages of aliases {build,host,target}Platform
* [`898c9e3c`](https://github.com/NixOS/nixpkgs/commit/898c9e3c91fa9ce29e8de21c8365653d1af74db9) nixos/activation: prevent error during NIXOS_LUSTRATE install
* [`2c1a608b`](https://github.com/NixOS/nixpkgs/commit/2c1a608bf7ab1cdf3055afd1f452d1dce6da1b78) apfsprogs: format with nixfmt-rfc-style
* [`7b77b4ab`](https://github.com/NixOS/nixpkgs/commit/7b77b4ab6cf7b48faab962f88a1166423c7f249f) apfsprogs: 0-unstable-2024-09-27 -> 0.2.0
* [`af48b9b1`](https://github.com/NixOS/nixpkgs/commit/af48b9b14a9e28741daeba5d1b069708b5729e53) python3Packages.stable-baselines3: init at 2.3.2
* [`9662edb8`](https://github.com/NixOS/nixpkgs/commit/9662edb82b4d4b0ae6156457301b7c0184fc2ece) python312Packages.openai: 1.52.1 -> 1.54.5
* [`c3c14a99`](https://github.com/NixOS/nixpkgs/commit/c3c14a9947d6c725d54290a735b64dc2160badd3) ladybird: 0-unstable-2024-11-06 -> 0-unstable-2024-11-21
* [`410c68d8`](https://github.com/NixOS/nixpkgs/commit/410c68d8f5f8f676bc1d8504514d3f01c6210e48) vault: 1.18.1 -> 1.18.2
* [`8ff76bc0`](https://github.com/NixOS/nixpkgs/commit/8ff76bc039d321f47b13822a72135a08ed35beba) vault-bin: 1.18.1 -> 1.18.2
* [`1aa5a568`](https://github.com/NixOS/nixpkgs/commit/1aa5a568a6a86acb70126fbecda22e58b64855a3) telegram-bot-api: 7.11 -> 8.0
* [`250ac961`](https://github.com/NixOS/nixpkgs/commit/250ac961c138aa67757a20d517f8d0c9a99b49d1) nagstamon: move to by-name
* [`697286bf`](https://github.com/NixOS/nixpkgs/commit/697286bf4dd701fb2e55ac51251f9561c6b8cbf2) nagstamon: format
* [`2dd36e98`](https://github.com/NixOS/nixpkgs/commit/2dd36e9886dbca73e59d1a913e1a0e3620edab81) limine: 8.0.14 -> 8.4.0
* [`3890e029`](https://github.com/NixOS/nixpkgs/commit/3890e029e31014e95cd53c483dce07aff2605c77) nixos/zapret: extra features
* [`fb3a557a`](https://github.com/NixOS/nixpkgs/commit/fb3a557a4bea131a5e3eda3861811deb70545381) htmldoc: 1.9.18 -> 1.9.19
* [`98393161`](https://github.com/NixOS/nixpkgs/commit/983931612864cb44f567aaed7190c3a6ef28ddc2) python312Packages.jsonformatter: 0.3.2 -> 0.3.4
* [`d35dd741`](https://github.com/NixOS/nixpkgs/commit/d35dd741908a2de37a1895fd9a9063f53afb9fd0) deno: 2.0.6 -> 2.1.1
* [`4b05e36c`](https://github.com/NixOS/nixpkgs/commit/4b05e36cf3c36a614ab64b96dd50aac618898ae0) mitimasu: init at 0-unstable-2023-10-24
* [`bc7da810`](https://github.com/NixOS/nixpkgs/commit/bc7da8107fc8c2527b1680e82b512c9a5be21f78) vscode-extensions.chanhx.crabviz: init at 0.4.0
* [`e8c9fa5b`](https://github.com/NixOS/nixpkgs/commit/e8c9fa5bc83aeaa2c6382a95bb56a94598cf2354) plausible: 2.0.0 -> 2.1.4
* [`ea103a02`](https://github.com/NixOS/nixpkgs/commit/ea103a02af2bdd57a9ee4e54fd4d83ee15bd0578) libstroke: fix build with gcc14
* [`ff51f58e`](https://github.com/NixOS/nixpkgs/commit/ff51f58e1d14f6a66c37e2d523e77ab9a55144d3) tesseract: format
* [`936c762b`](https://github.com/NixOS/nixpkgs/commit/936c762b8e8c3907109af8e9203896baefaa8c58) tesseract: add patrickdag as maintainer
* [`32a6049a`](https://github.com/NixOS/nixpkgs/commit/32a6049ad5fc6d418a1b193310078b3ab25993de) ocamlPackages.menhir: support --suggest-menhirLib
* [`c8318492`](https://github.com/NixOS/nixpkgs/commit/c8318492ca92940e77c68a5eedd1fd9e9222352d) arduino-cli: 1.0.4 -> 1.1.0
* [`0b43f970`](https://github.com/NixOS/nixpkgs/commit/0b43f970ec55c5138ad8035b1dd8bd33ccfd1cf3) arduino-cli: 1.1.0 -> 1.1.1
* [`d45cc1f9`](https://github.com/NixOS/nixpkgs/commit/d45cc1f9005e0914dff060305a686d2c46077491) gcsan2pdf: pin tesseract version
* [`8bb356dd`](https://github.com/NixOS/nixpkgs/commit/8bb356dda9938e520b803e06aa0b49923577d994) gscan2pdf: 2.13.3 -> 2.13.4
* [`3f8bf41b`](https://github.com/NixOS/nixpkgs/commit/3f8bf41b9378129f1cc9a6c2ac5edb08ffeadfc9) dexed: unstable-2022-07-09 -> 0.9.8
* [`4ffa9883`](https://github.com/NixOS/nixpkgs/commit/4ffa98835d06b9f52a405c6dc48c924a7ce34c04) dexed: Modernise, nixfmt
* [`fbc630fc`](https://github.com/NixOS/nixpkgs/commit/fbc630fc15b1efa9e78e0c77542efb45ae63eb88) dexed: Move to pkgs/by-name
* [`f6d43fcf`](https://github.com/NixOS/nixpkgs/commit/f6d43fcff88a41a158e3f11af364d7d3cadbddc8) proxmark3: 4.18994 -> 4.19552
* [`6ed14b40`](https://github.com/NixOS/nixpkgs/commit/6ed14b40743fd6a18e618128ebfaa01844841409) nodePackages.jsonlint: add meta.mainProgram
* [`f3ea13c8`](https://github.com/NixOS/nixpkgs/commit/f3ea13c87991252d2b3dc19d86fca5a4f7e2a4ab) jetbrains.rider: Use unwrapped location of sdk
* [`b8c9d52b`](https://github.com/NixOS/nixpkgs/commit/b8c9d52b8465cb716a12536fd5e5af16d38d1a36) fire: 1.0.0.3 -> 1.0.1-unstable-2024-10-22
* [`f5afe5b4`](https://github.com/NixOS/nixpkgs/commit/f5afe5b4525496503251e0ce51d2eb25f8c001b2) fire: Modernise, nixfmt
* [`652d9def`](https://github.com/NixOS/nixpkgs/commit/652d9def63a53e4e195ae1825bee5afa1f3706a5) fire: Move to pkgs/by-name
* [`f9f571f5`](https://github.com/NixOS/nixpkgs/commit/f9f571f5d10759f9749bb41bd6d987cfda834abe) samba: resurrect cross compilation patch
* [`d0459540`](https://github.com/NixOS/nixpkgs/commit/d04595402d1ecf7974feaddd206ae9d1bcaabdfc) samba: set correct pythondir
* [`07a431c6`](https://github.com/NixOS/nixpkgs/commit/07a431c62f30da45b92df914489dd9497c05402e) bun: fix hanging build on x86_64-darwin
* [`25bd3f09`](https://github.com/NixOS/nixpkgs/commit/25bd3f09719570e02c33f834a4e71f7a102b9d01) bun: fix missing symbol crash on macOS 12
* [`832aeacb`](https://github.com/NixOS/nixpkgs/commit/832aeacb18514f58a711072587b8d1e7a6af01f2) bililiverecorder: 2.12.0 -> 2.13.0
* [`a5d52b7a`](https://github.com/NixOS/nixpkgs/commit/a5d52b7a45dfa3a1ef20b5edfd5c92a1f7fbfc33) bun: run post hooks after patchelf
* [`2d31028c`](https://github.com/NixOS/nixpkgs/commit/2d31028ce6e3993fdace9155069909469becced3) jetbrains.clion: fix .NET version for Clion 2024.3
* [`1967d5fd`](https://github.com/NixOS/nixpkgs/commit/1967d5fdcf47272c00ba3c60cb7aa84d9d58c5e7) azure-static-sites-client: 19449a00c0269fefc8f29a6d01801c4b19308181 -> 53b7d0e07fe5c34bf68929fab92f87ce910288dc
* [`5aa904b6`](https://github.com/NixOS/nixpkgs/commit/5aa904b61e7c60ba043a797e88245c4926b33142) nixos/mautrix-telegram: use ffmpeg-headless instead of ffmpeg-full
* [`81711286`](https://github.com/NixOS/nixpkgs/commit/8171128674e35241c9e8d97054a1547b31c08e38) jellyfin{,-web}: 10.10.2 → 10.10.3
* [`41ee6d01`](https://github.com/NixOS/nixpkgs/commit/41ee6d013b5493724fdeaff08e150c0a3ee3debe) ugrep: 7.0.3 -> 7.1.0
* [`daccfd63`](https://github.com/NixOS/nixpkgs/commit/daccfd63916beb68294c91dffd704535ced8904d) mollysocket: 1.5.2 -> 1.5.3
* [`494d5c19`](https://github.com/NixOS/nixpkgs/commit/494d5c1958a9e27043bf3c3341fea01b107cd91b) pytesseract: disable tests broken on tesseract 5.5.0
* [`efad6261`](https://github.com/NixOS/nixpkgs/commit/efad6261977a853c42bc262e695fa11f6c56b900) tesseract: 5.3.4 -> 5.5.0
* [`9e5d4b3b`](https://github.com/NixOS/nixpkgs/commit/9e5d4b3b17dada804f25c518b2df437f0ec1256e) python312Packages.qt5reactor: disable
* [`53b69fd4`](https://github.com/NixOS/nixpkgs/commit/53b69fd41c15ac2beb548d011ba8d7842ac4f7f4) samba: add pkgsCross.aarch64-multiplatform.samba to passthru.tests
* [`82bb9f42`](https://github.com/NixOS/nixpkgs/commit/82bb9f42b9d9fbfc07a10b64b6b8a273dc43105d) bitwarden-cli: 2024.9.0 -> 2024.11.0
* [`3650335d`](https://github.com/NixOS/nixpkgs/commit/3650335dcb40bff0da9a004990a9d59f5f6585fc) coolercontrol.*: 1.4.0 -> 1.4.4
* [`029b8c50`](https://github.com/NixOS/nixpkgs/commit/029b8c50ea3fc4fa2dc1ce8495c36faf1d7b5578) coolercontrol.*: nixfmt, drop meta-wide "with lib"
* [`9f4511da`](https://github.com/NixOS/nixpkgs/commit/9f4511da1a65ca98c1ac112f65f6474a59d4ba4b) trunk-io: format with nixfmt
* [`92222beb`](https://github.com/NixOS/nixpkgs/commit/92222bebc30c3cbdf1ae70c6e8dc5eeae8824d03) trunk-io: 1.3.2 -> 1.3.4
* [`a695a618`](https://github.com/NixOS/nixpkgs/commit/a695a6183f561ca34b6bac9a9e95d597b0b54488) magnetic-catppuccin-gtk: 0-unstable-2024-06-27 -> 0-unstable-2024-11-06
* [`12cb286d`](https://github.com/NixOS/nixpkgs/commit/12cb286d9a4064f90507403d4a11321ebdfbfbd8) impression: 3.2.0 -> 3.3.0
* [`9dfbe512`](https://github.com/NixOS/nixpkgs/commit/9dfbe512437e052b62ba6d6fa6d2e43200e2fbc1) python312Packages.ocrmypdf: 16.5.0 -> 16.6.2
* [`8b81bddc`](https://github.com/NixOS/nixpkgs/commit/8b81bddc76ddcb6ef510fbfbd816e4678558e499) paperless-ngx: fix tests with OCRmyPDF 16.6
* [`d25befdb`](https://github.com/NixOS/nixpkgs/commit/d25befdbcf8f8e27c6318b7c966c7105583eea8d) unciv: 4.14.5-patch1 -> 4.14.9
* [`b03d0eda`](https://github.com/NixOS/nixpkgs/commit/b03d0eda20ab8e7bcaeaa2fca92092978a5c207e) libadwaita: 1.6.1 -> 1.6.2
* [`cb0240ee`](https://github.com/NixOS/nixpkgs/commit/cb0240eec72ab1472eeaf000a9d95ef190864eb1) vivaldi: 7.0.3495.6 -> 7.0.3495.18
* [`0b8b1b52`](https://github.com/NixOS/nixpkgs/commit/0b8b1b5273706c6a2fca4c554dfdbd5ed183c6c6) python312Packages.click-odoo-contrib: 1.19 -> 1.20
* [`6eda86c0`](https://github.com/NixOS/nixpkgs/commit/6eda86c02fa7108b63de26aa19212ea77bdd7730) python312Packages.docstring-parser: refactor
* [`05e5594e`](https://github.com/NixOS/nixpkgs/commit/05e5594ea36fe35075e1f39540a886d1e488a26c) reposilite: 3.5.18 -> 3.5.19
* [`9492bc8f`](https://github.com/NixOS/nixpkgs/commit/9492bc8f7aa8176d61918d6300d14e99c9f523f5) buildMavenPackage: add overrideMavenAttrs function
* [`ee25f370`](https://github.com/NixOS/nixpkgs/commit/ee25f3700313deb3c508c0f9d0f78e54c867e2f4) gkraken,nixos/gkraken: Drop
* [`75621e67`](https://github.com/NixOS/nixpkgs/commit/75621e67f950af748a595d8a04748e6d7c9690a9) python312Packages.netbox-reorder-rack: 1.1.2 -> 1.1.3
* [`cbb3cec8`](https://github.com/NixOS/nixpkgs/commit/cbb3cec851be63f45a18b26e058288757739736a) doc/maven: document how to override maven attrs
* [`059ac828`](https://github.com/NixOS/nixpkgs/commit/059ac8281d2c088794b41db74072393ac2b0bae5) icnsutil: include pillow dependency
* [`3b52cd4c`](https://github.com/NixOS/nixpkgs/commit/3b52cd4c1bded09d5a4d9b2dc17ff1736ea89b3d) desktopToDarwinBundle: fix 16x, 32x app icons
* [`6e391940`](https://github.com/NixOS/nixpkgs/commit/6e391940966fae752ed2aa0b6e0ec85428d46c62) glaze: 4.0.0 -> 4.0.1
* [`198e6f21`](https://github.com/NixOS/nixpkgs/commit/198e6f212ed49974f8eed1d9e36caf9bcee1f629) python312Packages.inform: 1.31 -> 1.32
* [`3cf742a0`](https://github.com/NixOS/nixpkgs/commit/3cf742a06ba4087635796ed613282b24aea7bae5) python312Packages.mypy-boto3-autoscaling: 1.35.66 -> 1.35.68
* [`9dda8887`](https://github.com/NixOS/nixpkgs/commit/9dda8887d695358a946bd0dc1aec72085d03f3f9) python312Packages.mypy-boto3-ce: 1.35.67 -> 1.35.68
* [`1f048282`](https://github.com/NixOS/nixpkgs/commit/1f048282cf78ce070ed62f67468d0b7decda99e4) python312Packages.mypy-boto3-codepipeline: 1.35.40 -> 1.35.68
* [`38de9d65`](https://github.com/NixOS/nixpkgs/commit/38de9d652171f50453f75319dc1d75e34ee7e2c8) python312Packages.mypy-boto3-cognito-idp: 1.35.18 -> 1.35.68
* [`65aa1313`](https://github.com/NixOS/nixpkgs/commit/65aa13131c9ad6a894c27a92395ab9ef13dea49c) python312Packages.mypy-boto3-connect: 1.35.64 -> 1.35.68
* [`2a29b401`](https://github.com/NixOS/nixpkgs/commit/2a29b401f3b1ff805b125668ee9abd62d8bf2250) python312Packages.mypy-boto3-elbv2: 1.35.67 -> 1.35.68
* [`a9ecec22`](https://github.com/NixOS/nixpkgs/commit/a9ecec220fcc7ada9e227d6d729694a925b44ba3) python312Packages.mypy-boto3-emr: 1.35.39 -> 1.35.68
* [`2f17043f`](https://github.com/NixOS/nixpkgs/commit/2f17043f208dbb9292043e4ddb43244a9cf1485d) python312Packages.mypy-boto3-inspector2: 1.35.58 -> 1.35.68
* [`9d96720f`](https://github.com/NixOS/nixpkgs/commit/9d96720f57338527eeaf61a40fa6957f8a792fd5) python312Packages.mypy-boto3-lambda: 1.35.67 -> 1.35.68
* [`7e2ab090`](https://github.com/NixOS/nixpkgs/commit/7e2ab09055a3b3267523210fd631dd4ab4786c5e) python312Packages.mypy-boto3-omics: 1.35.66 -> 1.35.68
* [`421ac247`](https://github.com/NixOS/nixpkgs/commit/421ac24759b4fa7cc5ebce961f541c0df87e1de0) python312Packages.mypy-boto3-quicksight: 1.35.61 -> 1.35.68
* [`3b64a4ea`](https://github.com/NixOS/nixpkgs/commit/3b64a4eabff159129845a9eb7fc32c54f40077a9) python312Packages.mypy-boto3-sagemaker: 1.35.61 -> 1.35.68
* [`04200acd`](https://github.com/NixOS/nixpkgs/commit/04200acdbe478bda7318926f372068aeba4e1756) python312Packages.mypy-boto3-ses: 1.35.3 -> 1.35.68
* [`9ad5b78f`](https://github.com/NixOS/nixpkgs/commit/9ad5b78f4bb8d38fb8c41e0eb112990996649e2e) python312Packages.mypy-boto3-sns: 1.35.0 -> 1.35.68
* [`fcd38562`](https://github.com/NixOS/nixpkgs/commit/fcd38562d36c5d28c48e891f3d607bc7ee32d42c) python312Packages.mypy-boto3-stepfunctions: 1.35.54 -> 1.35.68
* [`64db9966`](https://github.com/NixOS/nixpkgs/commit/64db9966f762d097c6bd07abf446857ec34d34b5) python312Packages.mypy-boto3-workspaces: 1.35.66 -> 1.35.68
* [`f176d9b7`](https://github.com/NixOS/nixpkgs/commit/f176d9b7b6c8b2775d101f24e41a6ded5145a614) luaPackages.luacheck: add meta.mainProgram
* [`3561b1dd`](https://github.com/NixOS/nixpkgs/commit/3561b1dd74cc672a43c4cc9b59a2ccc196dc8d21) dotnet-{sdk,runtime,aspnetcore}_{6,7}: mark as EOL
* [`2342cc1a`](https://github.com/NixOS/nixpkgs/commit/2342cc1a4062cec75a46d62efc908f4d180c8b98) .github/labeler.yml: add more paths to Java
* [`5bd3eeba`](https://github.com/NixOS/nixpkgs/commit/5bd3eeba769d782905a28df3b5e6ef625d0c6e71) python3Packages.hydrogram: init at 0.1.4
* [`99d697b8`](https://github.com/NixOS/nixpkgs/commit/99d697b87b118231962a0da12754ffe36d5a8ead) iterm2: 3.5.4 -> 3.5.10
* [`63613a73`](https://github.com/NixOS/nixpkgs/commit/63613a7326328f6c71123d44ec5d3b272dfa13eb) pulsar: 1.122.0 -> 1.123.0
* [`919d4b8e`](https://github.com/NixOS/nixpkgs/commit/919d4b8e15fe62928c4df309c533ea250ee9ccd4) maintainers: add rytswd
* [`0d7512f7`](https://github.com/NixOS/nixpkgs/commit/0d7512f7d6161c63c3acc550eae3303499063869) woof-doom: 14.5.0 -> 15.0.0
* [`6585cbd0`](https://github.com/NixOS/nixpkgs/commit/6585cbd0e00091e945d37e014276ec8b6afc0e68) stirling-pdf: 0.30.1 -> 0.33.1
* [`2b585512`](https://github.com/NixOS/nixpkgs/commit/2b585512cd1d2c01e50a678522dd531cfdf3fd19) cairo-lang: 2.8.4 -> 2.8.5
* [`5b9e7d16`](https://github.com/NixOS/nixpkgs/commit/5b9e7d16ec0ae6e1e55027371a72d69d44864a19) circom: 2.2.0 -> 2.2.1
* [`14571a9f`](https://github.com/NixOS/nixpkgs/commit/14571a9f9686d566971055b9dab9429677d2ba72) r2modman: 3.1.50 -> 3.1.54
* [`cd5b40ab`](https://github.com/NixOS/nixpkgs/commit/cd5b40ab2b03b97a5d7e40a10fc411f83192f643) gdal: 3.9.3 -> 3.10.0
* [`1677c4a3`](https://github.com/NixOS/nixpkgs/commit/1677c4a3d57554aaa69fc0a299a5f8d46acb1aa3) gdal: add libavif optional dependency
* [`3e8d408a`](https://github.com/NixOS/nixpkgs/commit/3e8d408a5e789f3feefc6424026bc5eb70f71892) mysql-shell{,_8,-innovation}: format with nixfmt
* [`2b02a18e`](https://github.com/NixOS/nixpkgs/commit/2b02a18ef7996f772355ca83227af99b80c46685) freebsd: Add support for aarch64
* [`6d0fee0f`](https://github.com/NixOS/nixpkgs/commit/6d0fee0f6c02fe96c5068e567915906107daff4f) streamcontroller: Use commit hash to fetch releases
* [`8ae2932d`](https://github.com/NixOS/nixpkgs/commit/8ae2932d567cbe792ddfebd537be6fd66f594179) add `--enable-wayland-ime` flag to all Electron packages that uses `NIXOS_OZONE_WL`
* [`efb43451`](https://github.com/NixOS/nixpkgs/commit/efb434511a0add0ba8eb47fddbab52a8e68817d6) python312Packages.icalendar: 6.0.1 -> 6.1.0
* [`159f059a`](https://github.com/NixOS/nixpkgs/commit/159f059ad606c9ff4e7f81d45d6591fa791fe9dc) python312Packages.syrupy: 4.7.2 -> 4.8.0
* [`13981dc9`](https://github.com/NixOS/nixpkgs/commit/13981dc98c5d6e020db03c408cb751637222bcb3) python312Packages.skops: disable flaky test
* [`5991ed35`](https://github.com/NixOS/nixpkgs/commit/5991ed35dad1fa95a450f0c6ed31e34e53612966) nixos/open-webui: update doc link url
* [`fb3ba5ec`](https://github.com/NixOS/nixpkgs/commit/fb3ba5ec5b19f6729e68483f0baa8211fb51ed50) python312Packages.pyftdi: 0.55.4 -> 0.56.0
* [`ba1b15be`](https://github.com/NixOS/nixpkgs/commit/ba1b15be08b15e1b8368fb0e7a392b4fc7c88697) squeak: fix build
* [`13b508e9`](https://github.com/NixOS/nixpkgs/commit/13b508e96868e385c480ac5fc2f8c247ba3e4601) rabbitmq-server: 4.0.2 → 4.0.4
* [`ec7e6174`](https://github.com/NixOS/nixpkgs/commit/ec7e61744071273adc8f3c6bcfe1c56c9320b9bd) rabbitmq-server: use the latest compatible Erlang version
* [`d1761537`](https://github.com/NixOS/nixpkgs/commit/d1761537ac54922496276856531bf1921f0f59bf) rabbitmq-server: move to by-name hierarchy
* [`3f34ba46`](https://github.com/NixOS/nixpkgs/commit/3f34ba46d6e6aba733af0e3392a964f3bfa0e409) nezha-agent: add updateScript
* [`78c80ec3`](https://github.com/NixOS/nixpkgs/commit/78c80ec3842f9ba71dae7e383709a4d57f0f7165) nezha-agent: 0.20.3 -> 0.20.5
* [`83aba607`](https://github.com/NixOS/nixpkgs/commit/83aba607464119744f3a4e248b14084f9d0ae922) wordpress: 6.7 -> 6.7.1
* [`3469a7c9`](https://github.com/NixOS/nixpkgs/commit/3469a7c92fcab3cea7b84062935c1e0927b35c1c) kubectl-gadget: 0.33.0 -> 0.34.0
* [`c73e275b`](https://github.com/NixOS/nixpkgs/commit/c73e275bfa481a79298a554c134554cc9c536618) pg_top: 3.7.0 -> 4.1.0
* [`e36b87dc`](https://github.com/NixOS/nixpkgs/commit/e36b87dce3d8e49c41c21613ae73b05b2b4b1f85) pg_top: nixfmt
* [`9a795338`](https://github.com/NixOS/nixpkgs/commit/9a795338a416e9a5074ec12f4fd9d8a871819083) rectangle: 0.84 -> 0.85
* [`78824546`](https://github.com/NixOS/nixpkgs/commit/78824546545f2c506d32eb0a2ea25aabb9ab9e3d) nixos/manticore: fix mkKeyValueDefault
* [`65f013da`](https://github.com/NixOS/nixpkgs/commit/65f013da3a2d4491232b9a04c6b206c4e1813a85) treewide: add mainProgram attribute to lisp compilers
* [`7c5948b7`](https://github.com/NixOS/nixpkgs/commit/7c5948b7f99f1cd23e9c074976653e20baa0da45) nvc: move to pkgs/by-name
* [`4f1da3ec`](https://github.com/NixOS/nixpkgs/commit/4f1da3ec5e74be151e62a3a748e392f6d4b80c71) nvc: reformat
* [`2acfd434`](https://github.com/NixOS/nixpkgs/commit/2acfd434f46f1d81c7adcabd53ecf21148e4ee40) nvc: 1.14.1 -> 1.14.2
* [`62447aca`](https://github.com/NixOS/nixpkgs/commit/62447acaf42430c3644777cb685442421ce58936) python312Packages.elasticsearchdsl: 8.15.3 -> 8.16.0
* [`beee8b63`](https://github.com/NixOS/nixpkgs/commit/beee8b63c9f9ffad7c210f23fd46422c69914693) yggdrasil: 0.5.9 -> 0.5.10
* [`9d34f3ce`](https://github.com/NixOS/nixpkgs/commit/9d34f3ceb56e49b69df16afffd0384caa2b4e31e) wlvncc: unstable-2023-01-05 -> unstable-2024-11-24
* [`b98f05ae`](https://github.com/NixOS/nixpkgs/commit/b98f05ae319e17eccb24a403c795738b27ef141c) lock: 1.1.3 -> 1.2.0
* [`f5a4dd81`](https://github.com/NixOS/nixpkgs/commit/f5a4dd81d64c85ff18731a400230b6657f5c0a88) prometheus-statsd-exporter: 0.27.2 -> 0.28.0
* [`54d9129d`](https://github.com/NixOS/nixpkgs/commit/54d9129de60e14b11943c07d6c3cd9b5892c3c79) notmuch-mailmover: 0.4.0 -> 0.5.0
* [`b84c7c21`](https://github.com/NixOS/nixpkgs/commit/b84c7c214ee16d46d41ce0097455d26a2eb222a6) nixos/nezha-agent: add options for new features
* [`3298b542`](https://github.com/NixOS/nixpkgs/commit/3298b5421728029205136b3b259316911053a67c) python312Packages.pymeteireann: 2021.8.0 -> 2024.11.0
* [`79facd2b`](https://github.com/NixOS/nixpkgs/commit/79facd2bb62349c1a818ba563fdf267dc806c9fd) zammad: refactor package
* [`f41f218e`](https://github.com/NixOS/nixpkgs/commit/f41f218e0df5119c8c4e610185123bc1ded08233) nixos/zammad: refactor module
* [`4ad703d6`](https://github.com/NixOS/nixpkgs/commit/4ad703d62e7c1a1817262c31c09494864aea8d9c) nixos/tests/zammad: refactor test
* [`4f60875e`](https://github.com/NixOS/nixpkgs/commit/4f60875ee6fb67680b75eb3e63245beca6a4224b) wasmer: 5.0.1 -> 5.0.2
* [`edfc76c5`](https://github.com/NixOS/nixpkgs/commit/edfc76c52e8a2f4e3fc887d65c95c1b80a493e37) radicle-{explorer,httpd}: 0.17.0 -> 0.17.1
* [`eff53a21`](https://github.com/NixOS/nixpkgs/commit/eff53a213598dae44cc92a1b82359eed44c69628) singularity-tools: enable __structuredAttrs and pass contents directly
* [`73450ebc`](https://github.com/NixOS/nixpkgs/commit/73450ebccf101dc7263106057af6fa90b8737e7a) lan-mouse: reformat
* [`ea8ced0c`](https://github.com/NixOS/nixpkgs/commit/ea8ced0c4c4c538e7e2c624cc6957c6969ffffbf) sublime-merge: set meta.mainProgram
* [`b2508395`](https://github.com/NixOS/nixpkgs/commit/b2508395f1c3d4c3da446c77bfe802e069236835) taterclient-ddnet: 8.6.1 -> 9.0.0
* [`0fd49999`](https://github.com/NixOS/nixpkgs/commit/0fd499992dccd6286352610aee4cad7427a6a70b) python312Packages.pinocchio: Disable test that fails on darwin
* [`955dff85`](https://github.com/NixOS/nixpkgs/commit/955dff85b36109b555645dd6efc2b59f3f23612e) discord: bump all versions
* [`a149b3de`](https://github.com/NixOS/nixpkgs/commit/a149b3de32b72ba44d66064426dfe388cf7468ac) hishtory: 0.304 -> 0.318
* [`a53505b4`](https://github.com/NixOS/nixpkgs/commit/a53505b4523bc844f0aac012a2088e90ef18d2c0) cwtch: init at 0.1.3
* [`73307b55`](https://github.com/NixOS/nixpkgs/commit/73307b55a1e581445c624ef538af66732153891e) cwtch-ui: init at 1.15.1
* [`aaffe251`](https://github.com/NixOS/nixpkgs/commit/aaffe2513c83cf008c21de060043d4c0806e1af9) bicep: 0.30.23 -> 0.31.92
* [`029bc6ad`](https://github.com/NixOS/nixpkgs/commit/029bc6ad7ec6ebd750c94f19908ce64b1dd85395) skypeforlinux: 8.132.0.201 -> 8.133.0.202
* [`f19e0f76`](https://github.com/NixOS/nixpkgs/commit/f19e0f76f469784ce8800898327799abd183c3cc) xfce.xfce4-settings: Fix screen locked but lockscreen invisible after suspend
* [`91878b74`](https://github.com/NixOS/nixpkgs/commit/91878b746f680a9fee18bb925babfce41a8bd0a9) epson-escpr2: 1.2.20 -> 1.2.21
* [`bbffc418`](https://github.com/NixOS/nixpkgs/commit/bbffc418d29a8e8e4d77c3b8fa053fb135bde0b5) vimPlugins.gitlab-vim: init at 2024-11-22
* [`628a933c`](https://github.com/NixOS/nixpkgs/commit/628a933c8a4d9157ec4f36f005c3340cc182a3ad) python312Packages.rns: 0.8.5 -> 0.8.6
* [`6ac9416b`](https://github.com/NixOS/nixpkgs/commit/6ac9416b744ba1ff1e0e4380f3d65edfce5f2880) python3Packages.radio-beam: 0.3.7 -> 0.3.8
* [`3a2ff8ac`](https://github.com/NixOS/nixpkgs/commit/3a2ff8ac13d610b9f6a6bcabac85cf7356cc8d5b) sql-studio: 0.1.27 -> 0.1.32
* [`b32389d7`](https://github.com/NixOS/nixpkgs/commit/b32389d78cdb74b4cc7442999aefba56def5aedd) qlog: 0.39.0 -> 0.40.0
* [`2c8074df`](https://github.com/NixOS/nixpkgs/commit/2c8074dfa79e56e04ce18528d7e3c07f23c5d26c) binwalk: 2.4.3 -> 3.1.0
* [`bef3f40f`](https://github.com/NixOS/nixpkgs/commit/bef3f40f05fbea6154967ff638d4e194f1a7d251) edk2: 202408.01 -> 202411
* [`fc827af1`](https://github.com/NixOS/nixpkgs/commit/fc827af1dcce0b608fb05ab670cf9296e67ee74a) decent-sampler: 1.12.1 -> 1.12.5
* [`9d969303`](https://github.com/NixOS/nixpkgs/commit/9d9693035c1f088bf3e3b9798662dbd4b1ecebe6) python312Packages.craft-parts: 2.1.2 -> 2.1.3
* [`df694054`](https://github.com/NixOS/nixpkgs/commit/df694054ab4eaa298550176d17ecf8e84ca7a071) floorp: 11.20.0 -> 11.21.0
* [`ee2bb9be`](https://github.com/NixOS/nixpkgs/commit/ee2bb9be3e7910877c16bda01136c2086074949f) nerdfonts: separate into packages under nerd-fonts
* [`536dc87d`](https://github.com/NixOS/nixpkgs/commit/536dc87db6ea8ac6cd3c5ea08e8bc8bf59ccfa2f) nerd-fonts: 3.2.1 -> 3.3.0
* [`d7831a0f`](https://github.com/NixOS/nixpkgs/commit/d7831a0f3f023990ee59796d53d302de244914f1) python312Packages.h5netcdf: 1.4.0 -> 1.4.1
* [`71f6103e`](https://github.com/NixOS/nixpkgs/commit/71f6103e6b8c9f5ca989f9bb016d7053bb4074c6) vscode-extensions.ms-python.python: Add aarch64-linux support
* [`f663b145`](https://github.com/NixOS/nixpkgs/commit/f663b14524ef529a41b0b8fb17461e0deb655030) Revert "singularity-tools: don't preserve store content ownership"
* [`91cbd96f`](https://github.com/NixOS/nixpkgs/commit/91cbd96ffe01664663dfc807999e124b396895f0) kanidm: allow hydra to cache alternative build with secret provisioning
* [`576701ee`](https://github.com/NixOS/nixpkgs/commit/576701eebceed7402943fa82e02bbce136d2d61a) libsignal-ffi: 0.58.3 -> 0.62.0
* [`705ae9b9`](https://github.com/NixOS/nixpkgs/commit/705ae9b92e70c3abd0668c58ecee298127db188c) mautrix-signal: 0.7.2 -> 0.7.3
* [`cfc067b5`](https://github.com/NixOS/nixpkgs/commit/cfc067b5c9fb00b02bf9bb68f395c9d8671ace3c) python312Packages.python-hcl2: 5.0.0 -> 5.1.1
* [`be27f036`](https://github.com/NixOS/nixpkgs/commit/be27f0361a484afb7f1bbebe11cf0d708f4716a2) regal: 0.28.0 -> 0.29.2
* [`d7705cc9`](https://github.com/NixOS/nixpkgs/commit/d7705cc9211ddb55f832fedfe1fc8a4784351918) zizmor: 0.2.1 -> 0.5.0
* [`7f37b926`](https://github.com/NixOS/nixpkgs/commit/7f37b926d86ef7aad80438c0321d7f78c45e7d1f) python312Packages.compressai: disable flaky test
* [`af10dd20`](https://github.com/NixOS/nixpkgs/commit/af10dd201409ca9ba396507544f35d9dbaea2e98) lib/customisation: remove overrideScope'
* [`2425e26e`](https://github.com/NixOS/nixpkgs/commit/2425e26e4f6788e29eb601cf840a78b4b9e0dc56) addOpenGLRunpath: covert to throw
* [`8893429f`](https://github.com/NixOS/nixpkgs/commit/8893429fc5b957d4df71e494ce99edb1d4f2163d) avahi: drop assert
* [`8ac98691`](https://github.com/NixOS/nixpkgs/commit/8ac9869133eca3fbf8e8bba0f8686ec6c6cf5d1f) python: remove pythonForBuild passthru
* [`c4461bbe`](https://github.com/NixOS/nixpkgs/commit/c4461bbe1ceeaacca183847655672244e6d3d5f5) singularity-tools: remove deprecated shellScript and mkLayer
* [`6626e361`](https://github.com/NixOS/nixpkgs/commit/6626e36190fe408328eb46e9d0815300552eb1a0) mdcat: 2.6.1 -> 2.7.0
* [`356af207`](https://github.com/NixOS/nixpkgs/commit/356af207229bf6f14eac9058ab90df9b905a1de4) terragrunt: 0.68.7 -> 0.69.1
* [`d9b684cd`](https://github.com/NixOS/nixpkgs/commit/d9b684cda479a18325f40c51006838dd00f79ea3) rucola: init at 0.4.1
* [`6c1474ba`](https://github.com/NixOS/nixpkgs/commit/6c1474baf0f5d1eee31599c08e08f179e01a4896) radicale: 3.3.0 -> 3.3.1
* [`f32fd441`](https://github.com/NixOS/nixpkgs/commit/f32fd441276e55a901a21a35fb21c4bfacbe47be) dynamodb-local: 2.5.2 -> 2.5.3
* [`2fe2ad56`](https://github.com/NixOS/nixpkgs/commit/2fe2ad56a458ce26027ca86a2f66b615022827be) lan-mouse: 0.9.1 → 0.10.0
* [`8dca2766`](https://github.com/NixOS/nixpkgs/commit/8dca27661f8035c09a7b26978e9b558d08bd2f24) radicale: format with nixfmt-rfc-style
* [`31fb039b`](https://github.com/NixOS/nixpkgs/commit/31fb039bd455c9855733f244099f7b6961f57402) vimPlugins: Remove the nvim-cmp dependency on cmp-sources
* [`077802d9`](https://github.com/NixOS/nixpkgs/commit/077802d97425a0608a352bdf4a9e5de6ea2bf046) python312Packages.radicale-infcloud: modernize
* [`1c6dea27`](https://github.com/NixOS/nixpkgs/commit/1c6dea27f7209d9ab0cd5ed93aad478ec6a66c32) scrcpy: 2.7 -> 3.0
* [`1d220ad5`](https://github.com/NixOS/nixpkgs/commit/1d220ad5523b9cb137b67a8e70deef30da1e12ce) penelope: init at 0.12.4-unstable-2024-10-21
* [`e34cd11e`](https://github.com/NixOS/nixpkgs/commit/e34cd11e1dce71f9f5696e261ffdd6aafb44d804) libretro-core-info: move to pkgs/by-name, format with nixfmt-rfc-style
* [`1a6115af`](https://github.com/NixOS/nixpkgs/commit/1a6115afb56189cc573bfbb2b1c9ed87551529ea) retroarch-assets: move to pkgs/by-name, format with nixfmt-rfc-style
* [`859926a5`](https://github.com/NixOS/nixpkgs/commit/859926a5b57eb00669a344b6a59c56853cdd2d87) retroarch-joypad-autoconfig: move to pkgs/by-name, format by nixfmt-rfc-style
* [`b65ca14e`](https://github.com/NixOS/nixpkgs/commit/b65ca14edeb3375f2ed97b3217c5952d71b161da) kodi-retroarch-advanced-launchers: move to pkgs/by-name, format with nixfmt-rfc-style
* [`7ae7e0df`](https://github.com/NixOS/nixpkgs/commit/7ae7e0df8611b2f3d86ffa4f333a0a7a91d037fd) retroarch: format with nixfmt-rfc-style
* [`006b13c5`](https://github.com/NixOS/nixpkgs/commit/006b13c56c744ba6ea7d867bcc67c7726e7bf335) retroarch-{bare,full}: renamed from retroarch{Bare,Full}
* [`bc078e1e`](https://github.com/NixOS/nixpkgs/commit/bc078e1e31f041f3a43985a0d9352d128eba0421) retroarch-bare: add passthru.wrapper, refactor derivation to use it
* [`3c11d3ed`](https://github.com/NixOS/nixpkgs/commit/3c11d3ede137f702d28424ff2460c7497fa0e9e6) retroarch-bare: move to pkgs/by-name
* [`3aa0725c`](https://github.com/NixOS/nixpkgs/commit/3aa0725cb3576f6ef4b53fe79f7769e50a331aa7) retroarch: add withCores helper
* [`61d8a91f`](https://github.com/NixOS/nixpkgs/commit/61d8a91f52e9e6cb0a82ac66ac878ce00f5c9c1a) libretro: renamed from retroarch
* [`b3cc74f3`](https://github.com/NixOS/nixpkgs/commit/b3cc74f3f8ea790dba2a7c8a8c15a1efc955b5e6) libretro: update README.md
* [`e981e0a2`](https://github.com/NixOS/nixpkgs/commit/e981e0a249b35f5a49b16a506505673c93b484c4) retroarch-free: init
* [`2d0d7ee5`](https://github.com/NixOS/nixpkgs/commit/2d0d7ee55aca25cc6fef074fa27e1c762af4fd40) retroarch-bare: remove top-level `with lib` in meta
* [`60d1565d`](https://github.com/NixOS/nixpkgs/commit/60d1565d29c9751be1b53d89450da48d349e6d27) retroarch: define it using wrapRetroArch instead retroarch-bare.wrapper
* [`3d616665`](https://github.com/NixOS/nixpkgs/commit/3d616665d6df74d912b1a2a099f782e104bf03a9) retroarch-{bare,free}: use lib instead of builtins
* [`50c7be19`](https://github.com/NixOS/nixpkgs/commit/50c7be19f3caca384afc45317fb75bf71369339e) retroarch-bare: add missing . in longDescription
* [`600ffd15`](https://github.com/NixOS/nixpkgs/commit/600ffd15b2141a19341b23b28cdd579fc63122f0) retroarch: use makeBinaryWrapper
* [`8d8d408c`](https://github.com/NixOS/nixpkgs/commit/8d8d408cb7b9f2cea28e29954d3b09b46e0c6749) spl: 0.4.0 -> 0.4.1
* [`579f606e`](https://github.com/NixOS/nixpkgs/commit/579f606e7104fe6afeac6716b8fe6c86aa57cd92) python312Packages.tencentcloud-sdk-python: 3.0.1270 -> 3.0.1271
* [`81ff7b56`](https://github.com/NixOS/nixpkgs/commit/81ff7b56ac1dbfa2a7afc19314c1b5912bb1cd8d) flyctl: 0.3.37 -> 0.3.40
* [`2faaf8f4`](https://github.com/NixOS/nixpkgs/commit/2faaf8f4289e291302b4f546d0ca8c40ba1035a8) virtualbox: Fix UI language selection in virtualbox
* [`2a6bf99e`](https://github.com/NixOS/nixpkgs/commit/2a6bf99e788af5397f6fca43359002685e6d8a30) linuxPackages.openafs: Patch for Linux kernel 6.12.
* [`880c2da8`](https://github.com/NixOS/nixpkgs/commit/880c2da8d07356a87bf9500a55585ff8652f9fe5) convbin: 3.7 -> 5.1
* [`142020d5`](https://github.com/NixOS/nixpkgs/commit/142020d5ace85bf7234cca1e4b1c18df97fcfa5d) maintainers: add octvs as maintainer
* [`89281cba`](https://github.com/NixOS/nixpkgs/commit/89281cba811ddd2f18cabe1b11bb21d8c19b82b5) python312Packages.arxiv: init at 2.1.0
* [`bfec9ac8`](https://github.com/NixOS/nixpkgs/commit/bfec9ac865899a6d6f86b3e9bd9c0b773f51f3dc) python312Packages.papis: 0.13 -> 0.14
* [`54571608`](https://github.com/NixOS/nixpkgs/commit/545716083af3d1b486205cd1cd3143a56af3146b) python312Packages.dask-ml: disable broken tests
* [`ffe06317`](https://github.com/NixOS/nixpkgs/commit/ffe0631728b99ffeb57bb0eeacc43b3bfc113524) libdeltachat: 1.150.0 -> 1.151.1
* [`551bea64`](https://github.com/NixOS/nixpkgs/commit/551bea6443dcc09229c49c9e6222a181c5e8c6be) mapproxy: 3.1.0 -> 3.1.2
* [`2d04db6e`](https://github.com/NixOS/nixpkgs/commit/2d04db6ed96192877a84903498d41326cfe65030) kubernetes-kcp: init at 0.26.0
* [`b2c3907f`](https://github.com/NixOS/nixpkgs/commit/b2c3907f9b8f46b90d51cd5dd0faa49e9cd4a735) vscodium: fix update script to work with longer hashes
* [`aac60d6a`](https://github.com/NixOS/nixpkgs/commit/aac60d6a8742e87fa82c28946b8201b99015d935) vscodium: 1.95.2 -> 1.95.3
* [`64445967`](https://github.com/NixOS/nixpkgs/commit/644459679a5b2388d3eb65a05bde1e37715976f2) lxqt.lxqt-panel: 2.1.1 -> 2.1.2
* [`b15e5b00`](https://github.com/NixOS/nixpkgs/commit/b15e5b006343734ff9bbd54e92146fb9868c8974) godns: 3.1.8 -> 3.1.9
* [`5bf97cd7`](https://github.com/NixOS/nixpkgs/commit/5bf97cd7f860193b9814e33cfbc26cee6efa80e0) prometheus: 2.55.0 -> 3.0.0
* [`c983d7bc`](https://github.com/NixOS/nixpkgs/commit/c983d7bc802f0112aa644b90b8215ad6142c91c2) libbitcoin{,-client,-explorer,-network,-protocol}: drop
* [`8d3e3da1`](https://github.com/NixOS/nixpkgs/commit/8d3e3da1863a35a77e93bb74163e4b05b26daf37) sumokoin: drop
* [`2b1c7203`](https://github.com/NixOS/nixpkgs/commit/2b1c7203dfb01abfec5252ef43ed03a59caa68cb) gopass-hibp: 1.15.14 -> 1.15.15
* [`03675716`](https://github.com/NixOS/nixpkgs/commit/03675716cf607867764e30c3a643dc009c762655) litecoin{,d}: drop
* [`fb2dd4ae`](https://github.com/NixOS/nixpkgs/commit/fb2dd4aed7c3e95fc31473f540fa07355cd7ac73) boost175: drop
* [`f1dd207d`](https://github.com/NixOS/nixpkgs/commit/f1dd207da75d4e4f97f64bacaada182f06438a89) rippled{,-validator-keys-tool}: drop
* [`532ae122`](https://github.com/NixOS/nixpkgs/commit/532ae122a70a731dc8ef8b271049475d64c5af07) tracexec: 0.5.2 -> 0.8.0
* [`7c1b6a3a`](https://github.com/NixOS/nixpkgs/commit/7c1b6a3abce38e51958eef6242ef949e255a98e8) codon: LLVM-14 unpin
* [`c90e5ad0`](https://github.com/NixOS/nixpkgs/commit/c90e5ad038b43e7b6c09876a67d6e65ffc70bec4) clazy: unpin LLVM-14
* [`ec11f1cc`](https://github.com/NixOS/nixpkgs/commit/ec11f1cc9705de9db8bb07b0a877bdc61ab950ef) ccls: unpin LLVM-14
* [`f02f5157`](https://github.com/NixOS/nixpkgs/commit/f02f51572567cbc6dbaa14b169433941375059a6) cvise: unpin LLVM-14
* [`c5a0fff8`](https://github.com/NixOS/nixpkgs/commit/c5a0fff8793b750e48da11f14ae9c085c3edc6e9) zcash: unpin LLVM-14
* [`d6493987`](https://github.com/NixOS/nixpkgs/commit/d649398796126aa444e008ea7d07a21d2bcc605e) xdp-tools: unpin LLVM-14
* [`6960c3ba`](https://github.com/NixOS/nixpkgs/commit/6960c3bacccbf1a1cd223c4e42bafcffda7417ce) cemu-ti: add aarch64-linux platform
* [`6b92b09f`](https://github.com/NixOS/nixpkgs/commit/6b92b09f0354864c344883019a3689d0f3443f69) cemu-ti: mark x86_64-linux broken
* [`1fcc0e15`](https://github.com/NixOS/nixpkgs/commit/1fcc0e1569e147ec9de64a92bbfbb12520f50433) melody: 0.19.0 -> 0.20.0
* [`31c6a65e`](https://github.com/NixOS/nixpkgs/commit/31c6a65ecad402b4bb69e55a4e42abd1a187ec1a) python312Packages.cachecontrol: 0.14.0 -> 0.14.1
* [`5c6f35fe`](https://github.com/NixOS/nixpkgs/commit/5c6f35fe6b6fa56fbfe7b28e233c3180c216a2d1) Revert "limesctl: drop"
* [`b5af449a`](https://github.com/NixOS/nixpkgs/commit/b5af449a6f4e305a2bc814c5aa5c82ab5c9cd753) git-credential-gopass: 1.15.14 -> 1.15.15
* [`f5ed2b60`](https://github.com/NixOS/nixpkgs/commit/f5ed2b6041363505e9169043fb0636989041bc3d) python3Packages.globus-sdk: 3.45.0 -> 3.48.0
* [`a0ffe5ae`](https://github.com/NixOS/nixpkgs/commit/a0ffe5aefaac2284671cc4dad20f05d62e93bdc0) vimPlugins.spaceman-nvim: init at 2024-11-03
* [`6d404af7`](https://github.com/NixOS/nixpkgs/commit/6d404af7beee626c3c4c517b6485184eecbf933e) glsl_analyzer: fix on x86_64-darwin
* [`6239ac5d`](https://github.com/NixOS/nixpkgs/commit/6239ac5d0615dd5f055734edf5bc5046c538cd2d) uwsm: prefer user env binaries
* [`a20bd2cc`](https://github.com/NixOS/nixpkgs/commit/a20bd2cca935ff6bd5dee07722e78d8a3174bf56) uwsm: add missing systemd dependency
* [`814a5c02`](https://github.com/NixOS/nixpkgs/commit/814a5c0285b8411356782f561f12f43757db357d) firefly-iii: 6.1.21 -> 6.1.24
* [`0c7f7224`](https://github.com/NixOS/nixpkgs/commit/0c7f7224aa3e28e5a32db1bc2aecac8877ea86ca) nixos/firefly-iii: Changes to clear cache more consistently upon updates
* [`fcc06517`](https://github.com/NixOS/nixpkgs/commit/fcc06517a0702cd0e1404e5f88e85f0ab85ccf15) firefly-iii-data-importer: 1.5.6 -> 1.5.7
* [`167c90ca`](https://github.com/NixOS/nixpkgs/commit/167c90ca01bafc3df57011ef099d3779f2ab6478) nixos/firefly-iii-data-importer: Changes to clear cache more consistently upon updates
* [`33f90436`](https://github.com/NixOS/nixpkgs/commit/33f90436f53627299d550fc1df4a71742d6d5ca1) adminer-pematon: init at 4.12
* [`83719075`](https://github.com/NixOS/nixpkgs/commit/837190757566b6e7ca79a112da6ae56a266d60b5) tidal-hifi: 5.16.0 -> 5.17.0
* [`bb102da5`](https://github.com/NixOS/nixpkgs/commit/bb102da5dece3e3ab5f3c57bf3a36101e3351f59) gleam: 1.6.1 -> 1.6.2
* [`58e31a24`](https://github.com/NixOS/nixpkgs/commit/58e31a2445b00738a6e032448ba8dd63a21c8303) globalping-cli: 1.4.0 -> 1.4.3
* [`a77a60f8`](https://github.com/NixOS/nixpkgs/commit/a77a60f882cc2b9dbbe280480da95094cd2c4ddb) picom-pijulius: 8.2-unstable-2024-11-12 -> 8.2-unstable-2024-11-15
* [`e18aee47`](https://github.com/NixOS/nixpkgs/commit/e18aee47b356f621c9dac8fdbd8c66b56f7ef222) rbw: nix-fmt rfc style
* [`68eacce4`](https://github.com/NixOS/nixpkgs/commit/68eacce4f7a58a4de6e1b7b843c25a29f0df91c1) rbw: fix darwin build
* [`a18fac9e`](https://github.com/NixOS/nixpkgs/commit/a18fac9e1a0f010c2756408041a293d600d216a2) vte: 0.78.1 -> 0.78.2
* [`52158e94`](https://github.com/NixOS/nixpkgs/commit/52158e94532a5d368368c23380776136892858a1) trealla: 2.57.1 -> 2.60.18
* [`422e9c14`](https://github.com/NixOS/nixpkgs/commit/422e9c14e3c93c58ac81aaed50809409809b4600) python311Packages.pyoverkiz: 1.14.2 -> 1.15.0
* [`09445326`](https://github.com/NixOS/nixpkgs/commit/094453260dd22caa611a00839379180e02f7d304) cinnamon: remove
* [`23ed5b9d`](https://github.com/NixOS/nixpkgs/commit/23ed5b9d553854ed18004c77b6a717ab5323140e) python312Packages.pyftdi: update disabled
* [`4ae22ca1`](https://github.com/NixOS/nixpkgs/commit/4ae22ca15cddac78d28a92e051a9ea6368cdb4ce) ldeep: 1.0.73 -> 1.0.75
* [`c76b79b7`](https://github.com/NixOS/nixpkgs/commit/c76b79b7d2f74d07932bce178e6fb2ca070903a4) libstdcxx5: remove
* [`95f9d5d2`](https://github.com/NixOS/nixpkgs/commit/95f9d5d2b3bf29ea720a870e68b5c20b475afb3e) vimPlugins.codecompanion-nvim: init at 2024-11-24
* [`2de18b37`](https://github.com/NixOS/nixpkgs/commit/2de18b37cfacf7481b81239d44c20848a8d8dafd) aerospike: 7.2.0.1 -> 7.2.0.4
* [`37c985d2`](https://github.com/NixOS/nixpkgs/commit/37c985d24185f9a69dba0f9b0d53de4a92d1d477) katawa-shoujo-re-engineered: 1.4.8 -> 1.4.9
* [`cd7b8f7f`](https://github.com/NixOS/nixpkgs/commit/cd7b8f7f5cc8d81d957992199a124aef93243522) seclists: 2024.3 -> 2024.4
* [`1e7b94da`](https://github.com/NixOS/nixpkgs/commit/1e7b94dac5c7eb2ae2c0062adb44549378d51a8e) digikam: 8.4.0 → 8.5.0
* [`1d2443c3`](https://github.com/NixOS/nixpkgs/commit/1d2443c3d7b13c4eb47b29edf0a3dbf5934b7f39) cbmc: nixfmt
* [`0d713207`](https://github.com/NixOS/nixpkgs/commit/0d71320797007c58d408dfc991e21ef236843de6) cbmc: 6.0.1 -> 6.4.0
* [`1f772d56`](https://github.com/NixOS/nixpkgs/commit/1f772d5684d8e0b0d3a3f277af9872895a4a5c53) triptych.nvim: add plenary-nvim as required dependency
* [`1d64cd96`](https://github.com/NixOS/nixpkgs/commit/1d64cd968a5b4482e3ba347214f49beb9de3f65d) lightningcss: 1.28.0 → 1.28.2
* [`90474914`](https://github.com/NixOS/nixpkgs/commit/90474914ee2c8f592342d3e3cc16e0e7693479f8) gcc: do not allow version skew when cross-building gcc
* [`69624427`](https://github.com/NixOS/nixpkgs/commit/696244274815dc389745da532f809174605957ce) tinymist: 0.12.0 -> 0.12.4
* [`da8eea70`](https://github.com/NixOS/nixpkgs/commit/da8eea70a5bc61bb4b979e3e242bfefe4ad2174b) taco: nixfmt
* [`c2678467`](https://github.com/NixOS/nixpkgs/commit/c2678467d98ce3d96a447a80e69235b37fd6e65b) terraform-providers.digitalocean: 2.42.0 -> 2.44.1
* [`853bcb85`](https://github.com/NixOS/nixpkgs/commit/853bcb8549cbd1f488673a215d221a5726d73d85) eigenmath: 3.27-unstable-2024-10-18 -> 3.33-unstable-2024-11-22
* [`4842516f`](https://github.com/NixOS/nixpkgs/commit/4842516f6afd93a376cfad8575cc355c64d3cacc) terraform-providers.dnsimple: 1.7.0 -> 1.8.0
* [`b45fe742`](https://github.com/NixOS/nixpkgs/commit/b45fe742d31451e8b6bb5de52e93a62af3558e72) ncmpc: 0.49 -> 0.51
* [`d73bbaae`](https://github.com/NixOS/nixpkgs/commit/d73bbaaebdda8b4948ed3d8fa4e6c00899698144) ncmpc: reformat with nixfmt-rfc-style
* [`e999a6f5`](https://github.com/NixOS/nixpkgs/commit/e999a6f576ed0af4cb57302b8f15c4548cf71e93) ncmpc: build manpage and enable regex
* [`8a8bce8b`](https://github.com/NixOS/nixpkgs/commit/8a8bce8b04a5ba76c7666e0da334366492165523) ncmpc: fails on darwin
* [`8bf50d01`](https://github.com/NixOS/nixpkgs/commit/8bf50d016a83f10c89dd0809e6d86af2d1da22ad) govc: 0.44.0 -> 0.46.2
* [`160facf7`](https://github.com/NixOS/nixpkgs/commit/160facf7c1614c5bfaebfbb3c04785de51828cac) python312Packages.qcodes: 0.49.0 -> 0.50.0
* [`6bb61e56`](https://github.com/NixOS/nixpkgs/commit/6bb61e56d5616474a47675adbaa39e777fc901f1) gitkraken: 10.4.1 -> 10.5.0
* [`31efc3ee`](https://github.com/NixOS/nixpkgs/commit/31efc3ee347f57ff5363581dedb933d0020faf6d) python312Packages.taco: fix build
* [`a5b22ac2`](https://github.com/NixOS/nixpkgs/commit/a5b22ac2b0cc5b9dc4d91d36aa0c1a6d1764777f) abracadabra: 2.7.0 -> 2.7.1
* [`85e03f3c`](https://github.com/NixOS/nixpkgs/commit/85e03f3c0b8e2d928363ee9f97c84ca7b1d980e4) pocketbase: 0.22.22 -> 0.23.1
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
