### PR TITLE
niv home-manager: update a9953635 -> bf23fe41

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -41,10 +41,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a9953635d7f34e7358d5189751110f87e3ac17da",
-        "sha256": "1h2pxnm66id786xy3b29n0ggzjggl1h6kmjp8mb3xhys1hpxyiqr",
+        "rev": "bf23fe41082aa0289c209169302afd3397092f22",
+        "sha256": "1f5lih3cmmipwhm21km35zgszk7jpl5rpdf96b7rgkd3m8wsslyc",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/a9953635d7f34e7358d5189751110f87e3ac17da.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/bf23fe41082aa0289c209169302afd3397092f22.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@a9953635...bf23fe41](https://github.com/nix-community/home-manager/compare/a9953635d7f34e7358d5189751110f87e3ac17da...bf23fe41082aa0289c209169302afd3397092f22)

* [`0941a2e1`](https://github.com/nix-community/home-manager/commit/0941a2e14486ee30e2088afa1d2869f2486dd3b8) flake.lock: Update
* [`f83dc9f2`](https://github.com/nix-community/home-manager/commit/f83dc9f25a5915c70b013102e30f3ee2a72ba633) tmux: set `sensibleOnTop = false` as a default
* [`21396857`](https://github.com/nix-community/home-manager/commit/21396857fdceb61239a7ae67b9be4dbfd90c12c1) kdeconnect: upgrade default version
* [`de7d67b8`](https://github.com/nix-community/home-manager/commit/de7d67b8bae8aa2ac920fa10918c89ce44b66d00) mopidy: make makeWrapper a native build input
* [`b7219652`](https://github.com/nix-community/home-manager/commit/b7219652387ce4331ae49ddac8b0286f50e0ed68) mopidy: ignore collisions between extensions
* [`2f7739d0`](https://github.com/nix-community/home-manager/commit/2f7739d01080feb4549524e8f6927669b61c6ee3) kakoune: add colorSchemePackage option
* [`819f6822`](https://github.com/nix-community/home-manager/commit/819f682269f4e002884702b87e445c82840c68f2) lorri: fix ReadWritePaths for new gcroots behavior
* [`8eeda281`](https://github.com/nix-community/home-manager/commit/8eeda281e70cbadabb7f0095c5f34e354e85f307) flake.lock: Update
* [`4964f3c6`](https://github.com/nix-community/home-manager/commit/4964f3c6fc17ae4578e762d3dc86b10fe890860e) home-manager: prepare 24.11 release
* [`441fae84`](https://github.com/nix-community/home-manager/commit/441fae847ddfe20f9f9a4c47345691a205bb772c) zsh-abbr: add package option
* [`7f78e2d1`](https://github.com/nix-community/home-manager/commit/7f78e2d1c6a9db76444e02a73f0669ebb79f8833) yazi: update keymap config
* [`e71e678d`](https://github.com/nix-community/home-manager/commit/e71e678d18d1a24e01d823ccb72df13f9e82f65b) nix-your-shell: add module
* [`86327350`](https://github.com/nix-community/home-manager/commit/863273505016a1e88e4ffaec48d1b767104c5652) kubecolor: add module
* [`c1fee8d4`](https://github.com/nix-community/home-manager/commit/c1fee8d4a60b89cae12b288ba9dbc608ff298163) alot: make package used by module configurable
* [`d2e2bda6`](https://github.com/nix-community/home-manager/commit/d2e2bda6c050a61d51b8e395ad66b8fa48318e07) nix-your-shell: fix creating required directory
* [`873e39d5`](https://github.com/nix-community/home-manager/commit/873e39d5f4437d2f3ab06881fea8e63e45e1d011) podman-container: fix tests and failing podman 5.3.0 service
* [`bf23fe41`](https://github.com/nix-community/home-manager/commit/bf23fe41082aa0289c209169302afd3397092f22) tmux: add 'focusEvents'
