### PR TITLE
niv nixpkgs: update 32cbecb2 -> d92224a3

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "32cbecb28fd80987dcea38b1d9c577db1259f0ad",
-        "sha256": "08slfkann4wr1qizjyfqbkhmb2lfcrak0d912b7k4pfx7rxrxj4b",
+        "rev": "d92224a31826a0b547560afea84c6a83a9d113f8",
+        "sha256": "06is3r7zgg5izas7cd71dvkyni1k8l3f5x388k6biagf7w2a1ycd",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/32cbecb28fd80987dcea38b1d9c577db1259f0ad.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/d92224a31826a0b547560afea84c6a83a9d113f8.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@32cbecb2...d92224a3](https://github.com/nixos/nixpkgs/compare/32cbecb28fd80987dcea38b1d9c577db1259f0ad...d92224a31826a0b547560afea84c6a83a9d113f8)

* [`dffd88e5`](https://github.com/NixOS/nixpkgs/commit/dffd88e5160038a2881c656b566745c2945d518d) nixos/zeronet: fix settings option
* [`5499e85c`](https://github.com/NixOS/nixpkgs/commit/5499e85c808caea18d8c875ef2a8ed3e7a390451) kustomize-sops: rename exec plugin to ksops
* [`6f68d4e4`](https://github.com/NixOS/nixpkgs/commit/6f68d4e447f4d952242790a107534a1a3065a8e8) nixos/signald: automatically migrate db
* [`e9ab2de5`](https://github.com/NixOS/nixpkgs/commit/e9ab2de5ed0d1ce725dbc8b6fe6161264f513416) nixos/vault-agent: make template value optional
* [`f7d21be1`](https://github.com/NixOS/nixpkgs/commit/f7d21be1d3aae0c4b1e32145b57cb50f4d965850) nixos/wrapper: pass trusted argv[0] to the privileged executable
* [`8f582b0e`](https://github.com/NixOS/nixpkgs/commit/8f582b0ebb792b1bba40acdf7e6217eaa52033a6) nsncd: 3 seconds is way too low for a default timeout
* [`4f1dc4bf`](https://github.com/NixOS/nixpkgs/commit/4f1dc4bfb7b5c7a6d5e77d331bc1a349e76d5808) nixos/modprobe: Added `boot.modprobeConfig.useUbuntuModuleBlacklist`.
* [`963f17c9`](https://github.com/NixOS/nixpkgs/commit/963f17c958855a2454bfaee7b600938373799012) nixos/connman: remove syslog.target
* [`c74e40fb`](https://github.com/NixOS/nixpkgs/commit/c74e40fb3e1efca3932bd4cbe6ea472764b6e1f2) nixos/aesmd: remove syslog.target
* [`2eb085d9`](https://github.com/NixOS/nixpkgs/commit/2eb085d9b5ced7ced94dd0d74b6d5c596d31ce0a) nixos/keepalived: remove syslog.target
* [`3d391389`](https://github.com/NixOS/nixpkgs/commit/3d3913890084f9847d4f2eb3f5a95de6a5fe25fa) nixos/cloud-init: remove syslog.target
* [`cb8d3762`](https://github.com/NixOS/nixpkgs/commit/cb8d3762a6b0f65e08dd848f54bc48bc8966e9a3) mlton: bootstrap with 20210117 version
* [`83280493`](https://github.com/NixOS/nixpkgs/commit/83280493512a550f3d44f226573c4c8da043faab) mlton: enable aarch64-darwin
* [`c151a5bd`](https://github.com/NixOS/nixpkgs/commit/c151a5bd4f78e7e2c0afe9deb790af0973c623d9) firefox_decrypt: 1.1.0 -> 1.1.1
* [`bd87a38b`](https://github.com/NixOS/nixpkgs/commit/bd87a38b86f889a6902a356ab415eeead881766b) nixos/lemmy: fix nginx backend to proxy needed headers
* [`a180a54d`](https://github.com/NixOS/nixpkgs/commit/a180a54daa5b2970b9e19e0900c347c36a50f778) nixos/dockerTools: fixup proot/fakeroot code - exclude also dev
* [`4ff2f4a1`](https://github.com/NixOS/nixpkgs/commit/4ff2f4a1f28c9f245f59cfb0732006112cfe6955) qjackctl: 0.9.13 -> 0.9.91
* [`8e02b5f4`](https://github.com/NixOS/nixpkgs/commit/8e02b5f478f6fb15cabfe943c4173c454792cf8d) nixos/loki: Start Loki after the network comes online
* [`831f9b60`](https://github.com/NixOS/nixpkgs/commit/831f9b6052383685fb2ab536b10b021405742d9d) languagetool: fix description on allowOrigin option
* [`dd1e48cc`](https://github.com/NixOS/nixpkgs/commit/dd1e48cc9e452c4ff1e4f26a255dd354b54169b7) .github/ISSUE_TEMPLATE: Add an issue template for tracking
* [`04c97333`](https://github.com/NixOS/nixpkgs/commit/04c973335eeea558f49aad967d26f28e0265a05a) filesender: FIX: missing format definition.
* [`50534c32`](https://github.com/NixOS/nixpkgs/commit/50534c32b80968004a89f851afebee2466fc71d6) python3Packages.pynput: Add `updateScript`
* [`3ea89d7b`](https://github.com/NixOS/nixpkgs/commit/3ea89d7b62138a17d1c7c1b839334d971bb610e5) maintainers: add @⁠daspk04
* [`3d44d5c2`](https://github.com/NixOS/nixpkgs/commit/3d44d5c2ce00d994f0ed02f5c472b330a1215802) visual-hexdiff: init at 0.0.53
* [`259db30f`](https://github.com/NixOS/nixpkgs/commit/259db30f0bac37121a01e7005483875f01e22a8c) nixos/lib/qemu-common: fix cross to x86_64
* [`e331c907`](https://github.com/NixOS/nixpkgs/commit/e331c90739f197cb02b2a1fd7a12d9905f12c53f) Fixup
* [`15ebd6c8`](https://github.com/NixOS/nixpkgs/commit/15ebd6c89502de8652e244fcffffe5788814f2f6) Fixup
* [`17555cad`](https://github.com/NixOS/nixpkgs/commit/17555cad7965ff70ee857463f69e8b2c696dbb64) Count hard links when sizing virtual disks
* [`60e499c1`](https://github.com/NixOS/nixpkgs/commit/60e499c17cefe0685c9ab42d7c8161c691d44bef) nixos/netboot: Fix netbootRamdisk build
* [`b0763a9a`](https://github.com/NixOS/nixpkgs/commit/b0763a9ab36d3935fc5e18263362a48e3dedba61) maintainers: add Achmad Fathoni
* [`c74c1d96`](https://github.com/NixOS/nixpkgs/commit/c74c1d96069d6b8c31c2175cfcb369da50d1601e) bpftrace: Source from "bpftrace" instead of "iovisor"
* [`a9b277d7`](https://github.com/NixOS/nixpkgs/commit/a9b277d7342693e97c6a591d1391b73da35c63ec) python3Packages.pycolorecho: init at 0.1.1
* [`1fb18e1e`](https://github.com/NixOS/nixpkgs/commit/1fb18e1e5fe29cf80cf42d2f8cdd21f52532d4e0) promptfoo: 0.57.1 -> 0.79.0
* [`437d92c6`](https://github.com/NixOS/nixpkgs/commit/437d92c6ade842199fb2befd476fa7d966b0a04a) prometheus-nats-exporter: add updateScript and testVersion
* [`0a58f692`](https://github.com/NixOS/nixpkgs/commit/0a58f69255f3d3e8f0b8e8dc83a7447939b234e1) nixos/pam: replace apparmor warnings with assertions
* [`249d4a97`](https://github.com/NixOS/nixpkgs/commit/249d4a97d51c33b94fb2653c3bfd2659d45f9889) workflows/check-nix-format: Improve error message
* [`3b9e993a`](https://github.com/NixOS/nixpkgs/commit/3b9e993adb4f3c463d1a8131d61f373d75d2a067) maintainers: add nezia
* [`6504eee8`](https://github.com/NixOS/nixpkgs/commit/6504eee8e06eaca10927f355d87c4ecb2dc25ddf) ecc: 1.0.12 -> 1.0.27
* [`526239b1`](https://github.com/NixOS/nixpkgs/commit/526239b118321e06811ac05848e4256f00fd6086) nixos/espanso: remove unused wayland option
* [`f40bcf1b`](https://github.com/NixOS/nixpkgs/commit/f40bcf1bd28cf8412c2469e4a8d349def652165a) inputstream-adaptive: add symlink to libcdm_aarch64_loader.so
* [`7acf6b2e`](https://github.com/NixOS/nixpkgs/commit/7acf6b2e9bfbe69b730fd708792f132d8d16ee2a) inputstream-adaptive: remove symlink for libssd_wv.so
* [`11c4e6b9`](https://github.com/NixOS/nixpkgs/commit/11c4e6b9dfe91e8ad99d82705e6f28cdb97cd055) inputstream-adaptive: only create symlink for libcdm_aarch64_loader.so on aarch64
* [`4147f4a4`](https://github.com/NixOS/nixpkgs/commit/4147f4a424d92d0d350e80eca4669ffa0755e26d) osmscout-server: 3.0.0 -> 3.1.0
* [`5619b33e`](https://github.com/NixOS/nixpkgs/commit/5619b33e5a378212a6689af8ca6882477b7de67f) maintainers: add eilvelia
* [`a60eddf7`](https://github.com/NixOS/nixpkgs/commit/a60eddf7211d15aff5ace9a87686ad6ad6eafccd) benzene: init at 0-unstable-2022-12-18
* [`25ff7301`](https://github.com/NixOS/nixpkgs/commit/25ff73017d9268a2034c92af2ffc7d2405e0be25) ogen: init at 1.4.1
* [`e4470046`](https://github.com/NixOS/nixpkgs/commit/e447004694c6f3397e1e04411fc8bcb42f74d385) cni-plugin-flannel: 1.2.0 -> 1.5.1-flannel3
* [`06791fce`](https://github.com/NixOS/nixpkgs/commit/06791fce8f9e5a461f1d3f67a6f7b3ac8303e090) nixos/nbd: remove `with lib;`
* [`2a8f3353`](https://github.com/NixOS/nixpkgs/commit/2a8f33535502cf5918a6636030a8d9ea17b311cd) nixos/postfix: add missing mkDefault for smtpd tls config
* [`aa6ef8e2`](https://github.com/NixOS/nixpkgs/commit/aa6ef8e22bab27416982a101ce5ce73f0bd03c89) nixos/gitlab-runner: let script options accept scripts as strings
* [`ac80f2cc`](https://github.com/NixOS/nixpkgs/commit/ac80f2cc333c8c8a73289199d0c21959a9d880b7) nixos/prometheus-restic-exporter: add repositoryFile option
* [`92121e43`](https://github.com/NixOS/nixpkgs/commit/92121e43ea9b5f4ec6d636098f2349ada91716e7) nixos/prometheus-exporters: add assertion for restic repository options to make them mutually exclusive
* [`4d339145`](https://github.com/NixOS/nixpkgs/commit/4d33914586370af1c739dc5645d127c2eae77653) rocmPackages_5.rocm-docs-core: 0.26.0 -> 1.8.2
* [`9264b0fd`](https://github.com/NixOS/nixpkgs/commit/9264b0fd2a3c5a38faef02ccbd33ab4ce5f3d992) ibus: fix cross compilation
* [`9ce0e1dc`](https://github.com/NixOS/nixpkgs/commit/9ce0e1dcaf106deec0d43cfb5b0ed8c9828fe7f5) eddy: 1.2.1 -> 3.6
* [`65664d6b`](https://github.com/NixOS/nixpkgs/commit/65664d6ba2909eb5a6d3ee260d659b89cccf73e6) nixos/gotenberg: fix service config for chromium
* [`3f6d80d3`](https://github.com/NixOS/nixpkgs/commit/3f6d80d322dd00052ccff6f4073779e74c6e2ba0) appimageTools: add libmpg123 to the environment
* [`666ed31e`](https://github.com/NixOS/nixpkgs/commit/666ed31e64111c86957c5392a48fd04ad71c4582) zydis: propagate zycore dependency
* [`4fe3724c`](https://github.com/NixOS/nixpkgs/commit/4fe3724ce401441e991f63a163e53f3b64883266) joypixels: Reflect redistributability in the license
* [`176d8671`](https://github.com/NixOS/nixpkgs/commit/176d86712b014681412ae2e89c70fdbb85086fab) beedii: init at 1.0.0
* [`9477947a`](https://github.com/NixOS/nixpkgs/commit/9477947a1a79967ffb6ac2e0d39b75185cf0c389) openseeface: init at 1.20.4-unstable-2024-09-21
* [`2367be91`](https://github.com/NixOS/nixpkgs/commit/2367be910aabbf30490ebcbbd98748702ff9607f) python3Packages.dirsearch: init at 0.4.3
* [`4b440818`](https://github.com/NixOS/nixpkgs/commit/4b440818278da8d54bbd6326ce5f10c116a68611) nixos/searxng: limiter.toml reference moved
* [`708a493c`](https://github.com/NixOS/nixpkgs/commit/708a493c1397937ac2c8dc1e18b655b455d69f70) python3: proper syntax for Windows patches
* [`c713db2b`](https://github.com/NixOS/nixpkgs/commit/c713db2b9fe7ec1d0e7641a6ef7471012279ec96) python3Packages.pyalsaaudio: init at 0.11.0
* [`39735e83`](https://github.com/NixOS/nixpkgs/commit/39735e83b2a6cb724b9e5dbc424d20b2ce4adeb8) rutorrent: 4.2.10 -> 4.3.8
* [`87df940a`](https://github.com/NixOS/nixpkgs/commit/87df940a6a1eb2348a6909bd332314b35b32fcdb) raspberrypifw: 1.20240926 -> 1.20241008
* [`4f2b5f37`](https://github.com/NixOS/nixpkgs/commit/4f2b5f3788566bc92b8e4daaaebee43c766dccc6) auto-editor: init at 25.3.0
* [`88b18841`](https://github.com/NixOS/nixpkgs/commit/88b18841422dcc4d56e63d592eafc2b5b4149b89) nixos/akkoma: Make imports explicit
* [`cebeec1b`](https://github.com/NixOS/nixpkgs/commit/cebeec1b8d67db1c02c38fbcf876bff6462fb413) nixos/transmission: improve permission handling and description
* [`89320d73`](https://github.com/NixOS/nixpkgs/commit/89320d7377d739c26d8a97a68fd26915eb9e4e85) nixos/transmission: improve code
* [`76fb46fd`](https://github.com/NixOS/nixpkgs/commit/76fb46fd8ada509ca81fb8d11bfc744d683a2a45) nixos/transmission: format with nixfmt-rfc-style
* [`38bc6ac8`](https://github.com/NixOS/nixpkgs/commit/38bc6ac8f9d1b49b35ca54ec0f4d727b513db363) nixos/transmission: fix the type of `settings.umask`
* [`2610a204`](https://github.com/NixOS/nixpkgs/commit/2610a20422b56ef4aaadad4d0d121cefb0d13d49) joypixels: 8.0.0 -> 9.0.0
* [`0ae7f47d`](https://github.com/NixOS/nixpkgs/commit/0ae7f47d5de073cb2de76b76b6617044cc5e5cd2) hunspellDicts.id_ID: init at 6.3.0.4
* [`75c3ed6d`](https://github.com/NixOS/nixpkgs/commit/75c3ed6d05d16d6fb705d12dbfa3737436ac32b2) python311Packages.fslpy: init at 3.21.1
* [`d84584ef`](https://github.com/NixOS/nixpkgs/commit/d84584efcec278d7451807f3f070f95db68aa009) filesender: 2.49 -> 2.50
* [`dbfb1a73`](https://github.com/NixOS/nixpkgs/commit/dbfb1a7338c1a12459cb0bc2775451eab12625a8) python3Packages.django: fix build on 32 bit platforms
* [`3b48a63a`](https://github.com/NixOS/nixpkgs/commit/3b48a63ac5d4b3c6fbd630d9b5c5958765a5d64d) polybar: remove references to cc before makeWrapper
* [`1ed59a4e`](https://github.com/NixOS/nixpkgs/commit/1ed59a4eb8a0d5694bc7f67b3770e664433730e7) lix: only use LTO with GCC
* [`7d7994a7`](https://github.com/NixOS/nixpkgs/commit/7d7994a7cbd127c4808e694495bb79cac12e8964) google-chat-linux: init at 5.29.23-1
* [`ad24e1ca`](https://github.com/NixOS/nixpkgs/commit/ad24e1ca55b34851f7e8cb312163e23e2367dc37) maintainers: add cterence
* [`b51666b2`](https://github.com/NixOS/nixpkgs/commit/b51666b2cc4e3cdc51c9bed4a0f07cf3b3d3e096) gnomeExtensions.pano: 22 -> v23-alpha3
* [`ef8c5ac5`](https://github.com/NixOS/nixpkgs/commit/ef8c5ac5a5242b0dc339fdeb7dcf4b2228d61605) eintopf: 0.14.1 -> 0.14.2
* [`b3edb98d`](https://github.com/NixOS/nixpkgs/commit/b3edb98d8c2d55901ee4c2de49b1aef54f38dbed) eintopf.frontend: 0.14.1 -> 0.14.2
* [`9f8d8481`](https://github.com/NixOS/nixpkgs/commit/9f8d8481a4555388a40620a2c00037122966e27e) eintopf.frontend: reformat
* [`1ca18373`](https://github.com/NixOS/nixpkgs/commit/1ca183731c4d0eb61b7b5cd4596cf856744c1d61) eintopf: reformat
* [`b6176b5f`](https://github.com/NixOS/nixpkgs/commit/b6176b5fd2941ddf40563bef9c1a4a7359b3102b) eintopf.frontend: cleanup and modernize
* [`3688e311`](https://github.com/NixOS/nixpkgs/commit/3688e311b4ce4692a8fbb9f2afc64996f0f03b28) flutter: Pass flutter_tools package_config.json to Dart runtime
* [`a5eaeab8`](https://github.com/NixOS/nixpkgs/commit/a5eaeab894dd2934675dbd951214ac671f5159d5) maintainers: add sako
* [`f3b448bf`](https://github.com/NixOS/nixpkgs/commit/f3b448bfe5b3d488d3f2efae6696811af6e29735) unnamed-sdvx-clone: init at 0.6.0
* [`2f9c81ff`](https://github.com/NixOS/nixpkgs/commit/2f9c81ffb1851e6d49f9157396aee8c12b3a1db5) ocamlPackages.sel: 0.4.0 -> 0.5.0
* [`7c99a7de`](https://github.com/NixOS/nixpkgs/commit/7c99a7de644babeffaded90d6931ea43f8192974) python310Packages.onlykey-solo-python: fix compatibility with fido2 1.1.3
* [`6bb49a52`](https://github.com/NixOS/nixpkgs/commit/6bb49a52f3d68917c28652263ae23348f9b92c2d) python3Packages.pywikibot: init at 9.5.0
* [`bac10f20`](https://github.com/NixOS/nixpkgs/commit/bac10f202ba3ac18070734b50a4cad58fd259895) maintainers: Add purpole
* [`fd8506f9`](https://github.com/NixOS/nixpkgs/commit/fd8506f99748a18b4f177e240c4782ea1918d097) sccmhunter: init at 1.0.6-unstable-2024-11-07
* [`bbbd6b71`](https://github.com/NixOS/nixpkgs/commit/bbbd6b711cda065023eb7caa0bf4462e8fdb2cdf) maintainers: add talhaHavadar
* [`d231c9ea`](https://github.com/NixOS/nixpkgs/commit/d231c9ea3a2f78fa15e9c58296128c11495ff263) ocamlPackages.cairo2: 0.6.4 -> 0.6.5
* [`ec1db0b7`](https://github.com/NixOS/nixpkgs/commit/ec1db0b7392121d89dbaa1cdb705ff1d1c7f3811) turbovnc: 3.1.2 -> 3.1.3
* [`815ec0c6`](https://github.com/NixOS/nixpkgs/commit/815ec0c6f29c01c209e731f599734dff28ca33e5) nodejs: fix build on 32 bit platforms
* [`56398710`](https://github.com/NixOS/nixpkgs/commit/563987104e9ce0088f140360edd02458b2266688) linux config: enable cp15 barrier emulation on aarch64
* [`49fec30e`](https://github.com/NixOS/nixpkgs/commit/49fec30e867199515dd5942e403797483ee49c4b) sbctl: 0.14 -> 0.16
* [`9cc2c5f0`](https://github.com/NixOS/nixpkgs/commit/9cc2c5f0fd022739a76f2bca0fb1156811bbc792) sbctl: don't generate completions when cross compiling
* [`fc30e169`](https://github.com/NixOS/nixpkgs/commit/fc30e169ac2363c0d7886dfed44c5333114fa06a) sbctl: nixfmt
* [`3a7bef85`](https://github.com/NixOS/nixpkgs/commit/3a7bef85cad99c5987e9412b8d38c31bde5a10c3) sbctl: don't use pname in src
* [`0c38fa28`](https://github.com/NixOS/nixpkgs/commit/0c38fa2802129a0b4dbded8b9812cafa8023e61d) libratbag: 0.17 -> 0.18
* [`71b8c39c`](https://github.com/NixOS/nixpkgs/commit/71b8c39ca813ceb9a566c2bcc46d93a2e1e4b265) libratbag: format with nixfmt
* [`3442068f`](https://github.com/NixOS/nixpkgs/commit/3442068f54253ab3624ad3b5b3cd4a04042c4da2) libratbag: refactor
* [`a6229420`](https://github.com/NixOS/nixpkgs/commit/a6229420a3d0382cbef7b7e90e0fd19658267b40) piper: 0.7 -> 0.8
* [`77ee7fc3`](https://github.com/NixOS/nixpkgs/commit/77ee7fc30af0f1534554b8e226bf588fbc2d79e3) piper: format with nixfmt
* [`016e5f24`](https://github.com/NixOS/nixpkgs/commit/016e5f240f44e926c882c90fb8f5e96efb7830c1) piper: refactor
* [`9cf5d33f`](https://github.com/NixOS/nixpkgs/commit/9cf5d33f09f0972c62dac03cb32a94b2c55ce8fa) sope: add jceb to maintainers
* [`81b0e3f7`](https://github.com/NixOS/nixpkgs/commit/81b0e3f7fa14dac6ac28c00966a171f5f2573055) sogo: 5.11.0 -> 5.11.2
* [`034aab10`](https://github.com/NixOS/nixpkgs/commit/034aab107d1940234ca35777ff419829fbcfd00c) criu: 3.19 -> 4.0
* [`7578f383`](https://github.com/NixOS/nixpkgs/commit/7578f3833bf6f4bfac41449444885ccd952345c0) plasma-panel-spacer-extended: init at 1.9.0
* [`c659022e`](https://github.com/NixOS/nixpkgs/commit/c659022ecb860175ee5464c8f0ad51e6d89bfc25) schemacrawler: 16.22.2 -> 16.22.3
* [`872d4bf3`](https://github.com/NixOS/nixpkgs/commit/872d4bf33ed0c7998c7726b295ba8c445cf25b3d) vkquake: 1.31.2 -> 1.31.3
* [`58c79d50`](https://github.com/NixOS/nixpkgs/commit/58c79d502fffe9482120bf49528ea44f92642795) godot_4: compile with BuildID
* [`bba005b8`](https://github.com/NixOS/nixpkgs/commit/bba005b8236787c3a42f8e8a0bd4bbb951d489f3) proton-ge-bin: Automate switching to new GE-Proton version after update
* [`41960fcd`](https://github.com/NixOS/nixpkgs/commit/41960fcdacbafa81ed5daf40d378b490fc5e81ca) splice.nix: make `pkgs` `splicedPackages` when required
* [`a27e48e1`](https://github.com/NixOS/nixpkgs/commit/a27e48e1b24504bc134ba05640c5663c7af0fd80) treewide: remove `= __splicedPackages`
* [`95be31c1`](https://github.com/NixOS/nixpkgs/commit/95be31c1bebf1741c16870b304ac10fbf16b67b7) proton-ge-bin: keep version information in `$steamcompattool/version`
* [`1c327386`](https://github.com/NixOS/nixpkgs/commit/1c327386b4934dd76d0deae5d7d350050553b23a) maintainers: add DictXiong
* [`ff0d3ad1`](https://github.com/NixOS/nixpkgs/commit/ff0d3ad153794f6244360b15da7b6ad0a3a9da3c) wl-clicker: init at v0.3.1
* [`0f3f5456`](https://github.com/NixOS/nixpkgs/commit/0f3f5456236487d3ad9d0565d45e5711cb031709) maintainers: add nateeag
* [`7fae9ae3`](https://github.com/NixOS/nixpkgs/commit/7fae9ae3c2a8a13fdcc158c3da96634ca5129192) pinentry-qt: fix caps lock warning
* [`899a7b24`](https://github.com/NixOS/nixpkgs/commit/899a7b2472bc386979824f6e6633f6d723c802a7) maintainers: add d4rk
* [`f28124f5`](https://github.com/NixOS/nixpkgs/commit/f28124f58a6db5068d5e85af5a340e396126384e) vulkan-hdr-layer-kwin6: init at 0-unstable-2024-10-19
* [`c6668dff`](https://github.com/NixOS/nixpkgs/commit/c6668dffc80c0acb0797f24886d8a2eb3d5b37e6) canon-cups-ufr2: 5.90 -> 6.00
* [`3ce3d5b2`](https://github.com/NixOS/nixpkgs/commit/3ce3d5b24093459af9ed1e9257e550fef224b6b9) canon-cups-ufr2: fix color printing issues
* [`fe7142ef`](https://github.com/NixOS/nixpkgs/commit/fe7142ef013aefec0375d34c250835d429672a22) aws-shell: init at 0.2.2
* [`39d93612`](https://github.com/NixOS/nixpkgs/commit/39d936127824eebc74c0ca2bc8c15825db6b7c7f) mydumper: 0.14.3-1 -> 0.16.9-1
* [`c443230c`](https://github.com/NixOS/nixpkgs/commit/c443230cc50d951fe552a2e7ae41581e5a181957) mydumper: fix darwin build
* [`c5610aa7`](https://github.com/NixOS/nixpkgs/commit/c5610aa78056cf6e3ee5a4b26ac1894ff1a816a2) mydumper: add michaelglass as maintainer
* [`be0619d3`](https://github.com/NixOS/nixpkgs/commit/be0619d3b78cfd02a10ea33982779be518f4ce3a) python312Packages.aiostreammagic: 2.8.4 -> 2.8.5
* [`f0cc69f4`](https://github.com/NixOS/nixpkgs/commit/f0cc69f4ab14b1caddd6bc55e912b61e221d60db) kind: 0.2.4 -> 0.2.5
* [`c567efd6`](https://github.com/NixOS/nixpkgs/commit/c567efd682d38e7fbdf19d1032cddfbd8c004628) pwsafe: 1.18.0 -> 1.20.0
* [`0c7055e9`](https://github.com/NixOS/nixpkgs/commit/0c7055e9a7daeb4b04e7a980f71ff292479471e6) mystmd: 1.3.8 -> 1.3.17
* [`833e1164`](https://github.com/NixOS/nixpkgs/commit/833e1164761bda7438dcaed1c82fe41859b42671) static-web-server: 2.33.0 -> 2.33.1
* [`69a605de`](https://github.com/NixOS/nixpkgs/commit/69a605dedd31d552a6d2df72017d2e8cc0c97e85) hyperrogue: 13.0r -> 13.0v
* [`e351a0b8`](https://github.com/NixOS/nixpkgs/commit/e351a0b8409dab9b6b7c6276347bf3a9b766d00e) maintainers: add pancaek
* [`4ec848d3`](https://github.com/NixOS/nixpkgs/commit/4ec848d3650e21a1efddfb4d4822d6dea6c0461c) komika-fonts: init at 0-unstable-2024-08-12
* [`e4e84b2b`](https://github.com/NixOS/nixpkgs/commit/e4e84b2b36b33b185b4693161200add7e4b9c483) dprint: format with nixfmt-rfc-style
* [`d76335d6`](https://github.com/NixOS/nixpkgs/commit/d76335d6343069e3455beb747055ac392c5bca0f) dprint: add passthru.tests.version
* [`ef9f08ed`](https://github.com/NixOS/nixpkgs/commit/ef9f08ed35e96b5354435f9535f463d8d5d1409e) dprint: add updateScript
* [`4155ccc1`](https://github.com/NixOS/nixpkgs/commit/4155ccc122bb63eddb310b279ad577b87046f081) dprint: 0.47.2 -> 0.47.5
* [`fe3ce419`](https://github.com/NixOS/nixpkgs/commit/fe3ce419eb0b647233f0ba3f86e59bddac18711a) dprint: switch to the new darwin sdk pattern
* [`ccfbd723`](https://github.com/NixOS/nixpkgs/commit/ccfbd723b367889f71eb4569d631ee90349dd650) passt: 2024_09_06.6b38f07 -> 2024_10_30.ee7d0b6
* [`1cdc18fb`](https://github.com/NixOS/nixpkgs/commit/1cdc18fbbfb05ad76df3c10dc8adddb9edbac210) jitsi-videobridge: 2.3-160-g97a1f15b -> 2.3-174-gd011ddf7
* [`33586ab6`](https://github.com/NixOS/nixpkgs/commit/33586ab6d6875a83333f8a165878d144475d537b) boogie: 3.2.5 -> 3.4.2
* [`4e842196`](https://github.com/NixOS/nixpkgs/commit/4e84219665352871e1335902977438d2984b865e) gcalcli: 4.4.0 -> 4.5.1
* [`934cf4cd`](https://github.com/NixOS/nixpkgs/commit/934cf4cdea4c8790f93278232027d9ebcfc5b0c7) rpPPPoE: 3.12 -> 4.0 and build kernel mode plugin
* [`82803318`](https://github.com/NixOS/nixpkgs/commit/82803318055e6dbf94e1d01db373cde0b7292f17) renode-unstable: 1.15.3+20241004git4b8a8f170 -> 1.15.3+20241112git6e850cb52
* [`e032def5`](https://github.com/NixOS/nixpkgs/commit/e032def5eaeb453a9eb6bd0b3763235b29cd84c6) rcodesign: 0.27.0 -> 0.28.0
* [`41f51511`](https://github.com/NixOS/nixpkgs/commit/41f5151102c622d8112ed8b803b4f9a614decb3a) maintainers: add BastianAsmussen
* [`90633c18`](https://github.com/NixOS/nixpkgs/commit/90633c1825085e8ba98495d0835cebf0e8b5a272) pcloud: 1.14.7 -> 1.14.8
* [`aef4e7d0`](https://github.com/NixOS/nixpkgs/commit/aef4e7d0bdad3e1ac2b02b8a68598572f7bb651a) glooctl: 1.17.14 -> 1.17.16
* [`5bdf0a48`](https://github.com/NixOS/nixpkgs/commit/5bdf0a48312158baa1e4c8dc1e1a67c5f4dc9cc1) healthchecks: 3.6 -> 3.7
* [`6cf58c53`](https://github.com/NixOS/nixpkgs/commit/6cf58c53e3ca09c4e95fb89271b004a8189362b5) keymapper: 4.8.2 -> 4.9.0
* [`66f4003f`](https://github.com/NixOS/nixpkgs/commit/66f4003f0ff82d2a7484ed90a45148933d0ebc5b) sftpgo: 2.6.2 -> 2.6.3
* [`ed0c00f8`](https://github.com/NixOS/nixpkgs/commit/ed0c00f8abc1482640398e26a59d3abea81c47da) wsysmon: remove procps dep and dynamically link spdlog
* [`1cd36341`](https://github.com/NixOS/nixpkgs/commit/1cd36341b2b21416d281d0fed2c3a9f4b4dbb361) ruby_3_2: 3.2.5 -> 3.2.6
* [`9f1665e1`](https://github.com/NixOS/nixpkgs/commit/9f1665e1f823d7a49182a4eb85beb873ee0e838f) jbang: 0.119.0 -> 0.120.4
* [`f9ede03b`](https://github.com/NixOS/nixpkgs/commit/f9ede03bf8dc759f0e7da65da0968d4285612e2f) maintainers: add tensor5
* [`3cb3f1a5`](https://github.com/NixOS/nixpkgs/commit/3cb3f1a51f97a1f68d9fbe607db488752775448f) hydrus: 595 -> 598
* [`cd96421e`](https://github.com/NixOS/nixpkgs/commit/cd96421ea908da82934385a213e54c3fe43f4d81) nixos/k3s: refactor multi-node test
* [`7a873035`](https://github.com/NixOS/nixpkgs/commit/7a87303563fa0b4906991f1a131a61489ca97866) pulsarctl: 2.11.1.3 -> 4.0.0.4
* [`5fbc2731`](https://github.com/NixOS/nixpkgs/commit/5fbc2731f4107f75bcd5bc5842dc16280d7ee5b3) digikam: add conditional cmake flag for cudaSupport
* [`b4fadb97`](https://github.com/NixOS/nixpkgs/commit/b4fadb9704898fdd49edb39cab8c0fd1f001ef8f) itk_4_13: init at 4.13.3
* [`1d366318`](https://github.com/NixOS/nixpkgs/commit/1d3663186c37011f7fddf817d62a279f03a086ca) shark: init at 4.0-unstable-2024-05-25
* [`5f047b8c`](https://github.com/NixOS/nixpkgs/commit/5f047b8cc62d67f3074fd1d935300f902347539f) otb: init at 9.0.0
* [`1f3975fc`](https://github.com/NixOS/nixpkgs/commit/1f3975fc27282c422d4e6b5e66cc51ee2d90f697) attic-client: 0-unstable-2024-10-06 -> 0-unstable-2024-11-10
* [`b8fa6e26`](https://github.com/NixOS/nixpkgs/commit/b8fa6e26eb7b485ba8c64f7059520cb039f9e071) yourkit-java: 2024.9-b158 -> 2024.9-b159
* [`f464a3ab`](https://github.com/NixOS/nixpkgs/commit/f464a3ab33f2801b4ad724496b0943e74bd63858) i3-rounded: unstable-2021-10-03 -> 4.21.1
* [`06d460db`](https://github.com/NixOS/nixpkgs/commit/06d460dbb27eb48dd24912e09867f16a92c8f492) maintainers: add gurjaka
* [`2926cde0`](https://github.com/NixOS/nixpkgs/commit/2926cde0ff737cf01acfede15b7198e4bc62bf00) tabby: 0.19.0 -> 0.20.0
* [`acae8e9c`](https://github.com/NixOS/nixpkgs/commit/acae8e9cc9bd65e99a4796c8ec4d4061235fe98d) python312Packages.readchar: 4.2.0 -> 4.2.1
* [`d91b4a9c`](https://github.com/NixOS/nixpkgs/commit/d91b4a9c047cbe8064e3c11bb179245d3e16636f) jitsi-meet-prosody: 1.0.8091 -> 1.0.8242
* [`4fc64027`](https://github.com/NixOS/nixpkgs/commit/4fc640279dd2c3890abc906bf1dcb920b1993e16) dolt: 1.43.1 -> 1.43.15
* [`bc6d8e18`](https://github.com/NixOS/nixpkgs/commit/bc6d8e18bb21e661ad0711c4fbc3427c8cbfbb3f) python3Packages.sopel: Added missing package and missing meta.MainProgram
* [`34049645`](https://github.com/NixOS/nixpkgs/commit/34049645be1def0eedae0f890f471765d88e694a) airshipper: 0.14.0 -> 0.15.0
* [`ee355521`](https://github.com/NixOS/nixpkgs/commit/ee355521d0d0ae2cdc7ae33cd193a3538274f3a9) video2midi: 0.4.8 -> 0.4.9
* [`cb9f9a1e`](https://github.com/NixOS/nixpkgs/commit/cb9f9a1e5a51a87d59b373db7016cee1608debd5) fetchgit{,hub}: add tag argument
* [`ae1d8fc4`](https://github.com/NixOS/nixpkgs/commit/ae1d8fc4da794246a3fec72346cbdea15f578566) msgraph-cli: init a 1.9.0
* [`d8872755`](https://github.com/NixOS/nixpkgs/commit/d887275508bb007eae55af93fa30a64a0ef4f1f3) pythonPackages.fabio: init at 24.4.0
* [`60065ac2`](https://github.com/NixOS/nixpkgs/commit/60065ac2e06cdfdb709ee53e5377c9894bf8670f) gifski: use `useFetchCargoVendor`
* [`baf8c5d3`](https://github.com/NixOS/nixpkgs/commit/baf8c5d3daaa240208326d49d27e3e0830577db8) gifski: format using nixfmt
* [`0cf736eb`](https://github.com/NixOS/nixpkgs/commit/0cf736ebdd17471a0ae354fa4e8d67ec7992b775) gifski: move to by-name
* [`38b07653`](https://github.com/NixOS/nixpkgs/commit/38b076534b831e216097a83d749537db6d9e1226) gifski: remove meta `with lib` use
* [`95d71aed`](https://github.com/NixOS/nixpkgs/commit/95d71aedd5a60ba0a02d5b5b96db0f98a864a9f5) initool: 0.18.0 -> 1.0.0
* [`bec44da8`](https://github.com/NixOS/nixpkgs/commit/bec44da823f7acda7b7b744036cd80ba58d14777) Use postPatch instead of prePatch to apply fix
* [`dd5fda8f`](https://github.com/NixOS/nixpkgs/commit/dd5fda8f0b8c3fae4bd3cf7898759e377f8f0fe5) use attribute instead of hardcoded version in package url
* [`06f8b75c`](https://github.com/NixOS/nixpkgs/commit/06f8b75c3c00f5344106b0d43a837fc052821994) use hash instead of sha256 attribute
* [`f6f1f031`](https://github.com/NixOS/nixpkgs/commit/f6f1f031038f646fc0ac4b3059621913ca102151) remove empty line
* [`7b7a0d94`](https://github.com/NixOS/nixpkgs/commit/7b7a0d946313d262bbac3273ca0353a290fc32d3) Add link to the changelogs associated with patch
* [`ac305d69`](https://github.com/NixOS/nixpkgs/commit/ac305d6920651ad456e0b17f25aa916012cad95a) Hardcode version in package url as version attribute doesn't work
* [`7caf0ad3`](https://github.com/NixOS/nixpkgs/commit/7caf0ad318a0005a4885d6fb8ee4e3edf0aac4e0) Fix indent style issue: use spaces not tabs
* [`415b0ea8`](https://github.com/NixOS/nixpkgs/commit/415b0ea85b2cb2dbd5f6ffaf769fa66dfe9b5630) python312Packages.datalad: 1.1.3 -> 1.1.4
* [`dd9f103c`](https://github.com/NixOS/nixpkgs/commit/dd9f103ceb9d791e736c6ab4c45ecddc7af6466a) pinact: format with nixfmt-rfc-style
* [`a058f359`](https://github.com/NixOS/nixpkgs/commit/a058f359f8d2387d67ef4db84df5ccdb6239147d) pinact: simplify testers.testVersion
* [`9476d9bf`](https://github.com/NixOS/nixpkgs/commit/9476d9bfc2667a8bd6f76b28329dd4c599d27337) pinact: add updateScript
* [`5b882376`](https://github.com/NixOS/nixpkgs/commit/5b88237651f4222ecf0d0c07865b050823c28fa8) silx: init at 2.1.1
* [`963a14be`](https://github.com/NixOS/nixpkgs/commit/963a14beaf3248297ad085035d6e223add6c1af7) mydumper: add version tests
* [`dde8ee11`](https://github.com/NixOS/nixpkgs/commit/dde8ee11792fcc2063146c15bb1c3e0976841879) nixos/shairport-sync: restart the systemd service on failure
* [`eea7e3a9`](https://github.com/NixOS/nixpkgs/commit/eea7e3a90dc96201c7329731617133ec77e9ae59) rygel: make gtk support optional
* [`386bc09b`](https://github.com/NixOS/nixpkgs/commit/386bc09b61ccecbe90d085c9ea5bc604217ee25d) maintainers: add jljox
* [`892b1f3a`](https://github.com/NixOS/nixpkgs/commit/892b1f3a1c74dfa80217510f653525ead76c02a1) kittycad-kcl-lsp: init at 0.1.61
* [`b2659e7a`](https://github.com/NixOS/nixpkgs/commit/b2659e7ad316b0974b75cb30685ae3eadcaec0f4) termius: 9.7.2 -> 9.8.5
* [`2e73f304`](https://github.com/NixOS/nixpkgs/commit/2e73f304b59a47a4a51ea109a519e27742ad3871) p2pool: 4.1.1 -> 4.2
* [`ea505ba4`](https://github.com/NixOS/nixpkgs/commit/ea505ba4cac5628c1dc8146f9418505c8486f9ce) kubernetes-helmPlugins.helm-unittest: 0.5.2 -> 0.6.3
* [`8de980f7`](https://github.com/NixOS/nixpkgs/commit/8de980f74866b64d4ba05f68052511bf71f00e28) atlantis: 0.28.5 -> 0.30.0
* [`13552fd8`](https://github.com/NixOS/nixpkgs/commit/13552fd8228fd0a4ea526836efb0189fec2bbd4e) fioctl: 0.42 -> 0.43
* [`9f6cfce9`](https://github.com/NixOS/nixpkgs/commit/9f6cfce9c5a2a33682a8fbdf966c181596fab52a) crowdsec: 1.6.3 -> 1.6.4
* [`095b8a3a`](https://github.com/NixOS/nixpkgs/commit/095b8a3af886ff9e8f9e1b04955b44163ddc031d) reuse: 4.0.3 -> 5.0.2
* [`ca01f3f1`](https://github.com/NixOS/nixpkgs/commit/ca01f3f15662121ce977cd695ae63f885fd81121) python312Packages.billiard: disable time sensitive tests
* [`063a83a7`](https://github.com/NixOS/nixpkgs/commit/063a83a71b09191e9a6ff13dd0d2df1e76c3d8f5) rabbitmq-c: 0.14.0 -> 0.15.0
* [`0fb01611`](https://github.com/NixOS/nixpkgs/commit/0fb01611f304e196dc58a2d42d18330584f73366) clusternet: init at 0.17.1
* [`0593c1fa`](https://github.com/NixOS/nixpkgs/commit/0593c1fab44ade355849b4d3efe570b49f99179c) git-cliff: 2.6.1 -> 2.7.0
* [`b3e39e3e`](https://github.com/NixOS/nixpkgs/commit/b3e39e3ee9b2ee2113d29ffb48377363131bc056) hubstaff: 1.6.26-95441346 -> 1.6.28-fafb0aba
* [`f6253960`](https://github.com/NixOS/nixpkgs/commit/f6253960d35467b963e30889495060e51de85bd6) sdrangel: 7.22.2 -> 7.22.4
* [`6b9033af`](https://github.com/NixOS/nixpkgs/commit/6b9033af806c25c83456dd5ad4a7e74a82b7f2b4) ocamlPackages.happy-eyeballs: 1.1.0 -> 1.2.2
* [`18ed1c4e`](https://github.com/NixOS/nixpkgs/commit/18ed1c4e972073f105aaff675cc5f96558e3e5ac) kopia: 0.17.0 -> 0.18.2
* [`88beeeb8`](https://github.com/NixOS/nixpkgs/commit/88beeeb88dedb7092d233d4e5374a64bc6523f64) ocamlPackages.asai: 0.3.0 -> 0.3.1
* [`e9bc776c`](https://github.com/NixOS/nixpkgs/commit/e9bc776c6b774006440cb57f5ea26a865cf041cb) paperjam: init at 1.2.1
* [`1c537cf0`](https://github.com/NixOS/nixpkgs/commit/1c537cf04ac89ffb85f45963d114d5463eae90e2) git-lfs: 3.5.1 -> 3.6.0
* [`453c0fbb`](https://github.com/NixOS/nixpkgs/commit/453c0fbb1e2876d5b54c48eea9843a8d3a48da3e) vue-language-server: 2.1.6 -> 2.1.10
* [`b1dc2491`](https://github.com/NixOS/nixpkgs/commit/b1dc24918a06d0b555cbbd87ce25bc372adee482) maintainers: add ShawnToubeau
* [`53b61e7a`](https://github.com/NixOS/nixpkgs/commit/53b61e7a0ea65e009f2135d6d3474dcadf8209db) python312Packages.datalad: refactor
* [`a997d6d8`](https://github.com/NixOS/nixpkgs/commit/a997d6d81cec1cde4678786624e14e6727555182) yubikey-touch-detector: 1.11.0 -> 1.12.0
* [`42efdd11`](https://github.com/NixOS/nixpkgs/commit/42efdd11c6d55c564c1633599892df59e61a2fc0) google-java-format: 1.24.0 -> 1.25.0
* [`ae8aa6f0`](https://github.com/NixOS/nixpkgs/commit/ae8aa6f04752ad50b1b651fd4505cb5f867fa853) kubeone: 1.8.3 -> 1.9.0
* [`73945d01`](https://github.com/NixOS/nixpkgs/commit/73945d013599d5508c52319b0ee5de176e901a14) organicmaps: 2024.09.08-7 -> 2024.11.12-7
* [`df0f5907`](https://github.com/NixOS/nixpkgs/commit/df0f5907470cdd54a24e1bfe0c1b0b283adea56b) rqlite: 8.31.2 -> 8.34.1
* [`9e9774ee`](https://github.com/NixOS/nixpkgs/commit/9e9774ee89f3e84794e8bdd3496d75f822fd4e2f) containerd: format with nixfmt
* [`d697b384`](https://github.com/NixOS/nixpkgs/commit/d697b384d57a5cb26ca5e600da02288a88f4cc9e) containerd: 1.7.23 -> 2.0.0
* [`5db7ee74`](https://github.com/NixOS/nixpkgs/commit/5db7ee7410228267ec448abe6413e98e901b813c) containerd: use standard attributes for make
* [`7d3a899c`](https://github.com/NixOS/nixpkgs/commit/7d3a899c10541faeb495d201f0e25dd99c8d5fc5) containerd: use best practices
* [`429c01ff`](https://github.com/NixOS/nixpkgs/commit/429c01fff2abe089924fa8ea24ef166e8d0ef873) containerd: add updateScript
* [`5fe62be1`](https://github.com/NixOS/nixpkgs/commit/5fe62be1168b9f885dd192fdb0e6dc68704bdb73) containerd: add override for btrfs support
* [`514c2e58`](https://github.com/NixOS/nixpkgs/commit/514c2e5835739e57326a0eb6172e182249d5824c) containerd: split outputs
* [`eb399ae2`](https://github.com/NixOS/nixpkgs/commit/eb399ae2b22273b93f2aa889f57ea61629f09ec4) containerd: add meta.mainProgram
* [`845831e7`](https://github.com/NixOS/nixpkgs/commit/845831e7822fa2ba8e964c8e9f0292ac11c2aac3) docker: only install containerd binaries
* [`0422fd66`](https://github.com/NixOS/nixpkgs/commit/0422fd66356ad4adcc9c53cd05deabd6bbd89f49) containerd: add getchoo to maintainers
* [`3f48f68e`](https://github.com/NixOS/nixpkgs/commit/3f48f68ef056e8163334ebb64721282e4a05c188) containerd: conditionally build manpages
* [`711aab6d`](https://github.com/NixOS/nixpkgs/commit/711aab6d45fc590c91d7b70eaf2e5f9bb31a4597) containerd: add cross compilation tests
* [`328ebf20`](https://github.com/NixOS/nixpkgs/commit/328ebf20943c882e6727d6f99061e31f8395f864) nixos/containerd: load after `local-fs.target` & `dbus.service`
* [`58a8067a`](https://github.com/NixOS/nixpkgs/commit/58a8067afbb0a25e973a737dfe12b8fd371ed90a) rustdesk-server: 1.1.11-1 -> 1.1.12
* [`37b61d4c`](https://github.com/NixOS/nixpkgs/commit/37b61d4c473468e8831b9c779588da14390ef999) istatmenus: init at 7.02.10
* [`2a8cac1d`](https://github.com/NixOS/nixpkgs/commit/2a8cac1d474f89fcbe2bb494863d7ecb7ffd6259) blender: use numpy 1.x
* [`045921d4`](https://github.com/NixOS/nixpkgs/commit/045921d4b05ff288b9af776d89b8ef77c9270f26) lilypond-unstable: 2.25.20 -> 2.25.21
* [`e51543ca`](https://github.com/NixOS/nixpkgs/commit/e51543cab8745fbc155e764e09623f3cafb1b256) graalvmCEPackages.graalnodejs: 24.0.1 -> 24.1.1
* [`1493059f`](https://github.com/NixOS/nixpkgs/commit/1493059fb9421291155f2049ed72cfe7f715c760) graalvmCEPackages.graalpy: 24.0.1 -> 24.1.1
* [`dd097781`](https://github.com/NixOS/nixpkgs/commit/dd0977818d69d3bcb6b7b191dc5983be4c9c563a) graalvmCEPackages.truffleruby: 24.0.1 -> 24.1.1
* [`650928dc`](https://github.com/NixOS/nixpkgs/commit/650928dc6759e3a87c8b8b17eb0052e9398317f1) tree-sitter: update webui fix-paths.patch
* [`0f8228bc`](https://github.com/NixOS/nixpkgs/commit/0f8228bc40652c48325b3445760be20cc6c97992) Try to fix issue on Darwin
* [`561232db`](https://github.com/NixOS/nixpkgs/commit/561232db155676bf6961358cfff4bf418e8d94cb) fix format
* [`9c3233af`](https://github.com/NixOS/nixpkgs/commit/9c3233afc41c2b6bd051934115acfe963bd720f0) graalvmCEPackages.graaljs: 24.0.1 -> 24.1.1
* [`c7fe0ba1`](https://github.com/NixOS/nixpkgs/commit/c7fe0ba1a142dcbb67d19c6d066b212662ec5741) qemu: fix strictDeps
* [`236e31de`](https://github.com/NixOS/nixpkgs/commit/236e31deb941bd675d3f333e4348e07820f99fb2) acme-sh: 3.0.9 -> 3.1.0
* [`2256f114`](https://github.com/NixOS/nixpkgs/commit/2256f11410db8cc57226948b61aaaf542659e0e6) networkd-dispatcher: don't patch conf file path
* [`3c7196f0`](https://github.com/NixOS/nixpkgs/commit/3c7196f05b3c9c0388b9fbe09ff4aad7c7a80678) nixos/networkd-dispatcher: add extraArgs option
* [`df13ffdf`](https://github.com/NixOS/nixpkgs/commit/df13ffdfb0df5c52273d507e2fd84c11f42c971c) papermc: 1.21.1-119 -> 1.21.3-53
* [`4b848193`](https://github.com/NixOS/nixpkgs/commit/4b848193daddaf3701c93a9b037f82ebfb507027) ansel: 0-unstable-2024-09-29 -> 0-unstable-2024-10-28
* [`6b6bbe1a`](https://github.com/NixOS/nixpkgs/commit/6b6bbe1aae8c423ff7ab2faedd24a9532b8d15f2) nano: add sigmasquadron as co-maintainer
* [`d890c3f8`](https://github.com/NixOS/nixpkgs/commit/d890c3f858939fb2c696d3cea0110e7f9830e5fc) keepassxc: add sigmasquadron as co-maintainer
* [`4a972e31`](https://github.com/NixOS/nixpkgs/commit/4a972e31157759d33a4651575d6c307e2117b6a8) OVMF: add sigmasquadron as co-maintainer
* [`aac54d9b`](https://github.com/NixOS/nixpkgs/commit/aac54d9b210f1e9b59911d9b10457ac4debfb890) asciiquarium: add sigmasquadron as co-maintainer
* [`f611da92`](https://github.com/NixOS/nixpkgs/commit/f611da92a7badc165c06938a106cb898ffd06a37) bat: add sigmasquadron as co-maintainer
* [`03b4c534`](https://github.com/NixOS/nixpkgs/commit/03b4c534849dd48914b93d2ba66b409915d8cc42) cntr: add sigmasquadron as co-maintainer
* [`8050a6bb`](https://github.com/NixOS/nixpkgs/commit/8050a6bbc3939540a2cdc36be983c87cade3bdec) cryfs: add sigmasquadron as co-maintainer
* [`9374b8b0`](https://github.com/NixOS/nixpkgs/commit/9374b8b083b2599191c4c993e9a1338f92f151ac) dev86: add sigmasquadron as co-maintainer
* [`817bda8d`](https://github.com/NixOS/nixpkgs/commit/817bda8d0556c94edebed004939cc0a0854d0ff4) duf: add sigmasquadron as co-maintainer
* [`ec3d4c6c`](https://github.com/NixOS/nixpkgs/commit/ec3d4c6c836a9dc8d85dd97a6a7cb5ac9bccb41d) er-patcher: adopt
* [`33cbff83`](https://github.com/NixOS/nixpkgs/commit/33cbff8371b8cdfc818762fd4457245e63afbe41) eza: add sigmasquadron as co-maintainer
* [`7fccd0fa`](https://github.com/NixOS/nixpkgs/commit/7fccd0fad5f654d338ed3be34b3a0ba06a1f20ce) freetube: add sigmasquadron as co-maintainer
* [`dca118b0`](https://github.com/NixOS/nixpkgs/commit/dca118b096a82bccd59bf4f1ea119d6ada3d6bd2) lazygit: add sigmasquadron as co-maintainer
* [`5b977243`](https://github.com/NixOS/nixpkgs/commit/5b97724312802db9609f281b83fc5daa38b6064e) mullvad-browser: add sigmasquadron as co-maintainer
* [`ab413c80`](https://github.com/NixOS/nixpkgs/commit/ab413c8047b155342d8f5c9d99dbeae942d4bf69) music-player: adopt
* [`4f41851f`](https://github.com/NixOS/nixpkgs/commit/4f41851f812e94128eec495f4cfd8f74dadf206d) steamguard-cli: add sigmasquadron as co-maintainer
* [`d4f3fe7d`](https://github.com/NixOS/nixpkgs/commit/d4f3fe7de3c08389160b9ed1c3b057b959d20fe3) fish: add sigmasquadron as co-maintainer
* [`ade41e6f`](https://github.com/NixOS/nixpkgs/commit/ade41e6fd7832b4696be7cae737a59d076cbae16) scarab: add sigmasquadron as co-maintainer
* [`2ed86e28`](https://github.com/NixOS/nixpkgs/commit/2ed86e28551d21963ce6f27b85ead00a133446be) seabios: adopt
* [`8808a76d`](https://github.com/NixOS/nixpkgs/commit/8808a76d0c4bef035861dd0d84ef743911697c65) flannel: 0.25.7 -> 0.26.1
* [`7353ca42`](https://github.com/NixOS/nixpkgs/commit/7353ca42e5be194d0cde4d2ebbcfbd57ef69c704) heroku: 9.3.0 -> 9.5.0
* [`b394dc14`](https://github.com/NixOS/nixpkgs/commit/b394dc14e86ef9d5ba9975f591635586b76f6f10) railway-wallet: 5.17.10 -> 5.19.4
* [`cbe0d672`](https://github.com/NixOS/nixpkgs/commit/cbe0d672272693bdec77f9930c6740e9a57a3be2) swayrbar: 0.4.0 -> 0.4.2
* [`dc5f9d7e`](https://github.com/NixOS/nixpkgs/commit/dc5f9d7ea9a8b6b114f89294de32432c869b8738) gpxlab: add symlink to binary on darwin
* [`bd4e8d28`](https://github.com/NixOS/nixpkgs/commit/bd4e8d2878d69676cecfc7b04fb9b651d5abde5d) gpxlab: migrate to by-name
* [`cfcccc73`](https://github.com/NixOS/nixpkgs/commit/cfcccc73e6b56d298c44968426f4aefe9750dd81) s2geometry: enable on unix
* [`c2a95086`](https://github.com/NixOS/nixpkgs/commit/c2a95086c52379eb97bd6096c657be69ccfec09c) micronaut: 4.6.3 -> 4.7.1
* [`fc3871aa`](https://github.com/NixOS/nixpkgs/commit/fc3871aa8ad6d9dbfff9bc3be5c131576e0fe8e5) linux/common-config: enable support for crashkernel dumps
* [`d8b5f031`](https://github.com/NixOS/nixpkgs/commit/d8b5f031dc448652ae800a7aa10bfd1313ffa0cc) nixos/crashdump: remove redundant kernel patch
* [`65dc95e5`](https://github.com/NixOS/nixpkgs/commit/65dc95e52f4919423834efbbbbc8a94d9aefd2c4) feat: Allow setting a password on cmdline for pxe boot
* [`ffc17f1a`](https://github.com/NixOS/nixpkgs/commit/ffc17f1a1bef9ba0b0a1789f21c78bd31d71dd90) archivebox: fix build
* [`018bd5d2`](https://github.com/NixOS/nixpkgs/commit/018bd5d268087e3baeb1d95e5a2ad03dc25770e2) archivebox: add SingleFile
* [`c2e4e74e`](https://github.com/NixOS/nixpkgs/commit/c2e4e74e95a68f2640cd7edddcf86b55061bba6f) sesh: 2.5.0 -> 2.6.0
* [`72b1eead`](https://github.com/NixOS/nixpkgs/commit/72b1eeadda7ba4d96de8d74ff364d864bf6779a6) jicofo: 1.0-1090 -> 1.0-1104
* [`88f51e41`](https://github.com/NixOS/nixpkgs/commit/88f51e4196afd79572376972044e509dc8fb9cf0) jackett: 0.22.893 -> 0.22.998
* [`9a524549`](https://github.com/NixOS/nixpkgs/commit/9a524549d64566b5f45107903a922d92511763a2) Add passwordHash option
* [`ca4419df`](https://github.com/NixOS/nixpkgs/commit/ca4419dfde56eddcea92982695ca5b6dcb34f132) zfs-replicate: 3.2.13 -> 4.0.0
* [`3f8bc3e4`](https://github.com/NixOS/nixpkgs/commit/3f8bc3e45a28e2ff4ec19e14d2629984bcae91d8) cubiomes-viewer: 4.1.0 -> 4.1.2
* [`216c6f28`](https://github.com/NixOS/nixpkgs/commit/216c6f28d9c896913511773c8e0f05432a5ae3b0) surrealist: 2.1.6 -> 3.0.8
* [`f014b0d4`](https://github.com/NixOS/nixpkgs/commit/f014b0d415208d69572452af15f0d98990059d75) nixos/frr: make runtime directory world-readable
* [`6a280523`](https://github.com/NixOS/nixpkgs/commit/6a2805234bbff2d37c1025983c7e29c4b6d54aad) apache-answer: init at 1.4.1
* [`2cded1ab`](https://github.com/NixOS/nixpkgs/commit/2cded1ab8dbbbdf27a448dbcac94a101662d279b) polarity: add nix-update updatescript
* [`b5442735`](https://github.com/NixOS/nixpkgs/commit/b5442735ff0f715f1d4ab1ca60905a721f23d98b) buffybox: init at 3.2.0-unstable-2024-11-10
* [`40f32aaf`](https://github.com/NixOS/nixpkgs/commit/40f32aaf16809c472eb2c1eaf4612fa699c6825c) vscode-js-debug: 1.94.0 -> 1.95.3
* [`51759e80`](https://github.com/NixOS/nixpkgs/commit/51759e8046caa67396f3d4d70b966ba697cd8b70) proxmox-auto-install-assistant: 8.2.6 -> 8.3.3
* [`97dd1a61`](https://github.com/NixOS/nixpkgs/commit/97dd1a61b7794e62260c46214a2ac2d5a870ab4d) proxmox-auto-install-assistant: switch to versionCheckHook
* [`2d59c247`](https://github.com/NixOS/nixpkgs/commit/2d59c247599f776355dc71159eb34d6bf7287c85) fend: 1.5.3 -> 1.5.5
* [`c4a95290`](https://github.com/NixOS/nixpkgs/commit/c4a9529071d5464d0c778690d8219f3548151b0b) lib/types: init {types.attrsWith}
* [`798d1b52`](https://github.com/NixOS/nixpkgs/commit/798d1b5285aac761baaddc9558b6c4b5670a0b38) ocamlPackages.gsl: 1.25.0 -> 1.25.1
* [`415d1932`](https://github.com/NixOS/nixpkgs/commit/415d1932eae07d9a64e1e21199a2b9c904ce3d5f) lib/types: Test attrsWith type merging
* [`39ecccc9`](https://github.com/NixOS/nixpkgs/commit/39ecccc962831a5cb1e755680a8f5da6aed52d3c) pioasm: 2.0.0 -> 2.1.0
* [`fd17f3cd`](https://github.com/NixOS/nixpkgs/commit/fd17f3cd76eb7299002798f142a2470dc6854aae) cplay-ng: 5.2.0 -> 5.3.1
* [`1ff7a913`](https://github.com/NixOS/nixpkgs/commit/1ff7a913595a024a37cb437bb63cf692a4bed26c) amdvlk: 2024.Q3.3 -> 2024.Q4.1
* [`d75d17e1`](https://github.com/NixOS/nixpkgs/commit/d75d17e1e84f63e58a49c8db075cf28200eb2c37) nixos/cage: add package option
* [`b5976528`](https://github.com/NixOS/nixpkgs/commit/b59765289c3993b0a7029cd7407c94c139488220) froide: init at 0-unstable-2024-11-22
* [`a488b52c`](https://github.com/NixOS/nixpkgs/commit/a488b52c8ff0db4f3a96c7dc1c64a0a42dcebd92) python3Packages.django-fsm: init at 3.0.0
* [`1dce7c5b`](https://github.com/NixOS/nixpkgs/commit/1dce7c5b2fda15dfe0a211994379bbe1ad382511) kuma: 2.8.3 -> 2.9.1
* [`09a7678c`](https://github.com/NixOS/nixpkgs/commit/09a7678c51686176a714982c5f431a7105632534) quarto: 1.6.33 -> 1.6.37
* [`01a0ebaf`](https://github.com/NixOS/nixpkgs/commit/01a0ebafcae437940376bb67ccab137bf4de50af) zimfw: 1.15.0 -> 1.16.0
* [`8d30d5b3`](https://github.com/NixOS/nixpkgs/commit/8d30d5b339bb28f779d68f5e02745a8ab9c13b06) weaviate: 1.26.6 -> 1.27.5
* [`6f32fcb8`](https://github.com/NixOS/nixpkgs/commit/6f32fcb8778d45a9af39629ba260319efa23e79c) qdrant-web-ui: 0.1.31 -> 0.1.33
* [`900bd0d8`](https://github.com/NixOS/nixpkgs/commit/900bd0d8e6203f51c25456e493a3b61cca59ac8b) nixos/buffyboard: init
* [`45f0035a`](https://github.com/NixOS/nixpkgs/commit/45f0035a83ed4016f5f4504b1810148143f980f3) lib/types: Add deprecation to attrsWith
* [`036b0bb4`](https://github.com/NixOS/nixpkgs/commit/036b0bb41dd6e070961e127c92a9f06d67e09abb) bngblaster: 0.9.8 -> 0.9.12
* [`617e1366`](https://github.com/NixOS/nixpkgs/commit/617e1366d53f7594860d2e3919fb4280c09d7edd) snappymail: 2.38.1 -> 2.38.2
* [`f2a0dc53`](https://github.com/NixOS/nixpkgs/commit/f2a0dc5399da4388068d615244ca9ac0e07c5516) lxqt.lxqt-wayland-session: 0.1.0 -> 0.1.1
* [`cc4a61e0`](https://github.com/NixOS/nixpkgs/commit/cc4a61e075442468698b87a628d488dcf833db00) ibus-engines.typing-booster-unwrapped: 2.25.17 -> 2.26.11
* [`5316344d`](https://github.com/NixOS/nixpkgs/commit/5316344dfd0b51e32c81e54ac74e24292ae9ba9a) questdb: 8.1.2 -> 8.2.0
* [`57b8861c`](https://github.com/NixOS/nixpkgs/commit/57b8861c473e62fd29523f9eb0480e4202135dc8) pachyderm: 2.11.4 -> 2.11.5
* [`40b3e9f1`](https://github.com/NixOS/nixpkgs/commit/40b3e9f1d39626c1bf38a315e78a1aafd3f378d4) handheld-daemon: 3.4.1 -> 3.5.7
* [`c826dbd6`](https://github.com/NixOS/nixpkgs/commit/c826dbd65f1955ff5e757d931159449824a3d782) python312Packages.tinydb: 4.8.0 -> 4.8.2
* [`5c182f85`](https://github.com/NixOS/nixpkgs/commit/5c182f857e5f877234f632414dd643f0846676a7) nickel: 1.8.1 -> 1.9.0
* [`efc13017`](https://github.com/NixOS/nixpkgs/commit/efc1301777818548a2f23f31248486e680502456) handheld-daemon: 3.5.7 -> 3.6.1
* [`666a4348`](https://github.com/NixOS/nixpkgs/commit/666a4348c2ec4ca2f62515a1d8bcac11a332610a) matrix-alertmanager: 0.7.2 -> 0.8.0
* [`f387cf1f`](https://github.com/NixOS/nixpkgs/commit/f387cf1f21845ec9b89ba6db2965c1a3c0e5c381) twilio-cli: 5.22.3 -> 5.22.6
* [`f9ba1e0f`](https://github.com/NixOS/nixpkgs/commit/f9ba1e0f76a8800c443d198a39f62ce5432a873e) funzzy: 1.2.0 -> 1.5.0
* [`4b53e94e`](https://github.com/NixOS/nixpkgs/commit/4b53e94e9cf1d0e61641d7fad59b210563916d1f) wikiman: init at 2.13.2
* [`9e6936a3`](https://github.com/NixOS/nixpkgs/commit/9e6936a3cee5bf551f8b9c22c3a2f0fed1f51c4b) svkbd: 0.4.1 -> 0.4.2
* [`1ad988e4`](https://github.com/NixOS/nixpkgs/commit/1ad988e405d06efb3080ddc368bc2ec650465456) svkbd: format with nixfmt-rfc-style
* [`81bfbe3d`](https://github.com/NixOS/nixpkgs/commit/81bfbe3d828a3e0a71a10562c4ec6516cdd5607d) ropebwt2: init at 0-unstable-2021-02-01
* [`60260523`](https://github.com/NixOS/nixpkgs/commit/602605237b42660be3b3deab3fef3a0576140a7a) fermi2: init at unstable-2021-05-21
* [`196f1419`](https://github.com/NixOS/nixpkgs/commit/196f141973be2bed412b7e8cc016afb65c2d7254) tiddit: init at 3.6.1
* [`74cb0ae1`](https://github.com/NixOS/nixpkgs/commit/74cb0ae183e48437d383e667ff80b3f977f4bfd6) dracula-theme: 4.0.0-unstable-2024-10-03 -> 4.0.0-unstable-2024-11-26
* [`797eb297`](https://github.com/NixOS/nixpkgs/commit/797eb297e4735d564264013143cd35d573435834) librenms: 24.10.1 -> 24.11.0
* [`f9b403d5`](https://github.com/NixOS/nixpkgs/commit/f9b403d5d350327e2003c1935aca442bbfc58a2d) mirrord: init at 3.125.0
* [`b99b7077`](https://github.com/NixOS/nixpkgs/commit/b99b707780016392b0150766b38bdacabddd9102) comet-gog: 0.1.2 -> 0.2.0
* [`b4bb0db8`](https://github.com/NixOS/nixpkgs/commit/b4bb0db86bf978a6ee74eb9ad25f3868d65c52e9) kops_1_30: 1.30.1 -> 1.30.2
* [`d1946291`](https://github.com/NixOS/nixpkgs/commit/d1946291d1bd00b25a4c0153351b768d95531cf1) tartube-yt-dlp: 2.5.040 -> 2.5.059
* [`c4a7f547`](https://github.com/NixOS/nixpkgs/commit/c4a7f5477b2baf2b37a944481e81c3888e0340a7) python312Packages.art: 6.3 -> 6.4
* [`95c563d5`](https://github.com/NixOS/nixpkgs/commit/95c563d5121d318fc3c284f8e81a26f5ebbcb3f0) sickgear: 3.32.10 -> 3.32.11
* [`f1f9a540`](https://github.com/NixOS/nixpkgs/commit/f1f9a54031dbc95b6e924772fddd125debb697bb) cups-filters: 1.28.17 -> 2.0.1
* [`dd90a1d9`](https://github.com/NixOS/nixpkgs/commit/dd90a1d99b28804a7590e2589fc8977c1651861b) mlflow-server: 2.17.2 -> 2.18.0
* [`34ae6ed3`](https://github.com/NixOS/nixpkgs/commit/34ae6ed370f62c76126bf79fbf6a3f3bd43781ec) simulide: don't use libsForQt5.callPackage
* [`1276771e`](https://github.com/NixOS/nixpkgs/commit/1276771ea7f1533be13af78089b7d94a4e7ed2c4) vulkan-cts: 1.3.9.0 -> 1.3.10.0
* [`17f173dd`](https://github.com/NixOS/nixpkgs/commit/17f173dd44bc2c2b03c7a304519ff38db3067790) simulide: migrate to pkgs/by-name
* [`09dbeb21`](https://github.com/NixOS/nixpkgs/commit/09dbeb21f149ae194f5149c47dc827ff6c6f58df) git-pw: 2.6.0 -> 2.7.0
* [`cfb25834`](https://github.com/NixOS/nixpkgs/commit/cfb258343f5e6e1807a242f513017a96cc8a3e61) alda: nixfmt
* [`9253eb0b`](https://github.com/NixOS/nixpkgs/commit/9253eb0baac6063e23b308537d9faab7bf7cf533) cilium-cli: 0.16.19 -> 0.16.20
* [`9f2c1211`](https://github.com/NixOS/nixpkgs/commit/9f2c121124ba78064edb4f8bdf01ebad48c6f498) alda: 2.2.3 -> 2.3.1
* [`1c1dfd06`](https://github.com/NixOS/nixpkgs/commit/1c1dfd06c28f720ad4b4191b33c229c0c99c655b) julia.withPackages: fix multiprocessing usage to work on macOS
* [`df6f4e28`](https://github.com/NixOS/nixpkgs/commit/df6f4e28682d21ce30ded83052e706b107431dad) xray: 24.9.30 -> 24.11.21
* [`270dc7bf`](https://github.com/NixOS/nixpkgs/commit/270dc7bf9287dd2f7d98a0e1d803cc2283beb731) python312Packages.aiosomecomfort: 0.0.25 -> 0.0.26
* [`ecc71601`](https://github.com/NixOS/nixpkgs/commit/ecc7160125abaff3a5adf8fb2d91cf75eb44bc38) python312Packages.notus-scanner: 22.6.4 -> 22.6.5
* [`8cf70f5f`](https://github.com/NixOS/nixpkgs/commit/8cf70f5ff0ab5c1e8c2134f996d1b2e8a67857d4) minio-warp: init at 1.0.6
* [`23abd3a8`](https://github.com/NixOS/nixpkgs/commit/23abd3a86673fdf3526cd7617380c68f8089e2eb) reveal-md: 6.1.3 -> 6.1.4
* [`4aa9f8fb`](https://github.com/NixOS/nixpkgs/commit/4aa9f8fb76823c495caf79fd6c3afb4c61f00d17) python312Packages.x-wr-timezone: 1.0.1 -> 2.0.0
* [`4f6eafbb`](https://github.com/NixOS/nixpkgs/commit/4f6eafbb37cb0434f9cf310d96509f04ba4f634b) tiny-cuda-nn: fix a couple of build issues
* [`7f6e867b`](https://github.com/NixOS/nixpkgs/commit/7f6e867bfe13ecc73a78ff53301e8300d1a73de8) commitizen: 3.30.0 -> 4.0.0
* [`faf72ed5`](https://github.com/NixOS/nixpkgs/commit/faf72ed584ce772f28e11cf728e9e624d2b4d5c1) mariadb-connector-java: 3.4.1 -> 3.5.1
* [`79fdb67f`](https://github.com/NixOS/nixpkgs/commit/79fdb67f884dfbeeb2538b667be23e35b27e92d7) python312Packages.marimo: 0.9.14 -> 0.9.27
* [`f01de68f`](https://github.com/NixOS/nixpkgs/commit/f01de68f50fcc16848cc076c6dc4407ffec37408) python312Packages.recurring-ical-events: unpin x-wr-timezone
* [`18a80ee4`](https://github.com/NixOS/nixpkgs/commit/18a80ee43c6b16754ce49ef18b82db8777553181) linuxPackages_latest.broadcom_sta: add patch to compile on Kernel 6.12
* [`5ff378b7`](https://github.com/NixOS/nixpkgs/commit/5ff378b7b8a84ea09446cb6a3d8be9fabd5b6926) mysql_jdbc: 9.0.0 -> 9.1.0
* [`884b5b4f`](https://github.com/NixOS/nixpkgs/commit/884b5b4f48d6f6a936a13bedec4bcd59f1bb3ca6) python312Packages.aiohttp-fast-zlib: 0.1.1 -> 0.2.0
* [`f5080d12`](https://github.com/NixOS/nixpkgs/commit/f5080d12b384b58f70047a35fdc67ff90ba8490a) Rebuild password update functionality, add tests
* [`dc8d9260`](https://github.com/NixOS/nixpkgs/commit/dc8d92608d407c7f80a3cba8d4195aa1a0b7c36c) Add tests
* [`e61f7d60`](https://github.com/NixOS/nixpkgs/commit/e61f7d60e176e1b523ef62b799c048101b6d537c) asahi-bless: 0.3.0 -> 0.4.1
* [`f8d32a00`](https://github.com/NixOS/nixpkgs/commit/f8d32a0023f4a030f8357402ba0c89e05676aa79) zram-generator: use latest tags instead of release in update script
* [`508d3d10`](https://github.com/NixOS/nixpkgs/commit/508d3d102289b53fda29d7da397baca88563969d) zram-generator: 1.1.2 -> 1.2.0
* [`08aab404`](https://github.com/NixOS/nixpkgs/commit/08aab4041b1943bfe1258088e75c3a9c94ffd86e) zram-generator: 1.2.0 -> 1.2.1
* [`ff3f176c`](https://github.com/NixOS/nixpkgs/commit/ff3f176cdd2bcdba3aa8bee3f0dc204347c765bc) zram-generator: move to by-name
* [`754f5fb9`](https://github.com/NixOS/nixpkgs/commit/754f5fb90dbc5b6bcfdc15e7b46cb8ac943a1ea0) zram-generator: format with nixfmt, use --replace-fail instead of --replace
* [`58bc2b25`](https://github.com/NixOS/nixpkgs/commit/58bc2b252dd6b6fc6cbe627085a5f005a76fa186) asahi-nvram: 0.2.1 -> 0.2.3
* [`b65739e0`](https://github.com/NixOS/nixpkgs/commit/b65739e061fbf58aed6ef6145685b154c65ddc97) zotero: 7.0.8 → 7.0.10
* [`3c9e7c7b`](https://github.com/NixOS/nixpkgs/commit/3c9e7c7bbfee5e78683864fe91e608715e2aae88) cocogitto: 6.1.0 -> 6.2.0
* [`1ec09830`](https://github.com/NixOS/nixpkgs/commit/1ec09830979b029c470cccfb184be4d25baf34e3) klog-time-tracker: 6.4 -> 6.5
* [`b6447bb4`](https://github.com/NixOS/nixpkgs/commit/b6447bb4a802779f1ed774e580c88047723c6da2) python3Packages.proton-core: 0.3.3 -> 0.4.0
* [`8edf7a33`](https://github.com/NixOS/nixpkgs/commit/8edf7a33c5cde4d89e9af128d5cea5c67943e452) kafkactl: 5.3.0 -> 5.4.0
* [`6ce5063d`](https://github.com/NixOS/nixpkgs/commit/6ce5063d82750ff4109d025d51a7b275dbddb178) feishin: 0.11.1 -> 0.12.0
* [`e50228f6`](https://github.com/NixOS/nixpkgs/commit/e50228f6d981184e913b39b537734e9f1efb0ef5) perlPackages.DBDMariaDB: fix strictDeps = true
* [`bf173b31`](https://github.com/NixOS/nixpkgs/commit/bf173b318479611003d7279884d4f41affe3fbd3) python312Packages.niaclass: 0.2.0 -> 0.2.1
* [`c85ddc48`](https://github.com/NixOS/nixpkgs/commit/c85ddc48b7fe732da1ce83d7f5fd5974abc4ea4e) botan{2,3}: always set --cpu, fix cross compilation
* [`beb6fe98`](https://github.com/NixOS/nixpkgs/commit/beb6fe987b2428126c435cefe41262dcf22aa1ca) cloudflare-warp: format with nixfmt-rfc-style
* [`13b953c8`](https://github.com/NixOS/nixpkgs/commit/13b953c8644e7457bf2b429ca14d7367f6eebf85) lib.packagesFromDirectoryRecursive: More precise type signature
* [`d35845f8`](https://github.com/NixOS/nixpkgs/commit/d35845f8f8ba8abaebe1011e8dbe882126606958) mihomo-party: 1.4.5 -> 1.5.12
* [`3df9613e`](https://github.com/NixOS/nixpkgs/commit/3df9613e1620d1043189ce0b30d6413ec5fe05b7) mihomo-party: add update script
* [`ff74a617`](https://github.com/NixOS/nixpkgs/commit/ff74a61763d70d933030e23e42a659cda749139e) sqldef: 0.17.23 -> 0.17.24
* [`8872fb10`](https://github.com/NixOS/nixpkgs/commit/8872fb10ac344b4f880e3a6ed7d59ee95c681aa8) davinci-resolve: 19.0.2 -> 19.1
* [`c3e14461`](https://github.com/NixOS/nixpkgs/commit/c3e14461e9f69461866941a944e217e897b424a7) cargo-bolero: 0.11.2 -> 0.12.0
* [`7a294f6f`](https://github.com/NixOS/nixpkgs/commit/7a294f6ffb7b95a0109cc2611e5703139e899427) warp-terminal: 0.2024.11.19.08.02.stable_01 -> 0.2024.11.19.08.02.stable_03
* [`cb20f06e`](https://github.com/NixOS/nixpkgs/commit/cb20f06e97f4603500cee5337708429b4238f59b) feishin: 0.12.0 -> 0.12.1
* [`4bdf760a`](https://github.com/NixOS/nixpkgs/commit/4bdf760ad3adda23210c11c45d160f844b48e715) python312Packages.langsmith: 0.1.137 -> 0.1.147
* [`a2e74766`](https://github.com/NixOS/nixpkgs/commit/a2e747664b7005a36a367c8acde256a3a4dfee65) strawberry: format with nixfmt
* [`7ae70a97`](https://github.com/NixOS/nixpkgs/commit/7ae70a97d5c9dc31070d814966e93896dad0614c) metasploit: update dependencies to fix runtime error
* [`58fa1639`](https://github.com/NixOS/nixpkgs/commit/58fa163946765f59a3d085cffcb1c4cc9c2f3a68) metasploit: add versionTest to detect runtime errors
* [`ff6e9748`](https://github.com/NixOS/nixpkgs/commit/ff6e974816517c6fef59c5d32ac47bb71b2243f0) lomiri.lomiri-mediaplayer-app: init at 1.1.0
* [`928dea90`](https://github.com/NixOS/nixpkgs/commit/928dea90c68f371bd8a81f003844c508114adc8f) nixos/lomiri: Add mediaplayer app
* [`00ee3ec7`](https://github.com/NixOS/nixpkgs/commit/00ee3ec75f498e8a7f6979241fa491b1c02abf14) tests/lomiri-mediaplayer-app: init
* [`5157f42d`](https://github.com/NixOS/nixpkgs/commit/5157f42ddeecb87a60794145e7fd10b8d9a28c61) vgm2x: 0-unstable-2024-06-18 -> 0-unstable-2024-11-17
* [`8ed9e1be`](https://github.com/NixOS/nixpkgs/commit/8ed9e1be0443d46e2f729ac963c0498790f86d8c) moonfire-nvr: 0.7.7 -> 0.7.17
* [`50153978`](https://github.com/NixOS/nixpkgs/commit/50153978426f2503261836ba1dcb31bdd48c5a27) cockpit: 328 -> 329.1
* [`a7ada678`](https://github.com/NixOS/nixpkgs/commit/a7ada678dda21022645fe0e0b383ba30919686dd) check-jsonschema: 0.29.2 -> 0.29.4
* [`9080387f`](https://github.com/NixOS/nixpkgs/commit/9080387f029a6a73f034cc7800266957fb52beb5) latexminted: 0.3.0 -> 0.3.2
* [`ed90cb9e`](https://github.com/NixOS/nixpkgs/commit/ed90cb9e2664c6527891716b394e60e48bac144f) grpcurl: 1.9.1 -> 1.9.2
* [`801174a2`](https://github.com/NixOS/nixpkgs/commit/801174a20057d252f7820298ba07543738b99f02) bash-completion: hack around a release bug impacting BSDs
* [`00ba22a1`](https://github.com/NixOS/nixpkgs/commit/00ba22a1c81dc7c072f1162e00221b8779d77c54) lite-xl: 2.1.5 -> 2.1.6
* [`f90d2f4a`](https://github.com/NixOS/nixpkgs/commit/f90d2f4a41da476c0a4405d96e4271b240bb0a7a) panicparse: 2.3.1 -> 2.4.0
* [`c31efe91`](https://github.com/NixOS/nixpkgs/commit/c31efe91504527031a5deb261cd606ccb0a38324) julia.withPackages: fix artifact fixupPhase on darwin
* [`23038522`](https://github.com/NixOS/nixpkgs/commit/23038522f11831d6a8c0232c3ba98bf322ef4102) julia.withPackages: set empty JULIA_SSL_CA_ROOTS_PATH on darwin
* [`ae165c04`](https://github.com/NixOS/nixpkgs/commit/ae165c04aeebb4a332d292c98a36fdcb8b2f2239) bitbox: init at 4.46.3
* [`bf97031d`](https://github.com/NixOS/nixpkgs/commit/bf97031d41221f0caad008de72be2dcfc8eed6c3) mob: 5.3.1 -> 5.3.3
* [`6252fe37`](https://github.com/NixOS/nixpkgs/commit/6252fe37ac71f3a8e6a4714d918a759ade830d47) rdkafka: 2.6.0 -> 2.6.1
* [`195e5ba5`](https://github.com/NixOS/nixpkgs/commit/195e5ba5a8c975e29f8b0ab4b3f7567b4e681b78) kubernetes-controller-tools: 0.16.4 -> 0.16.5
* [`79662325`](https://github.com/NixOS/nixpkgs/commit/79662325cb64c7effec13993aa0c322baa80bde3) python312Packages.optimum: 1.23.0 -> 1.23.3
* [`3b4d2f4c`](https://github.com/NixOS/nixpkgs/commit/3b4d2f4c5c9e352d89179fb5664582e30d676efd) phrase-cli: 2.33.1 -> 2.34.1
* [`4ea11c69`](https://github.com/NixOS/nixpkgs/commit/4ea11c695060658e190259f062490bc6463b1111) python312Packages.aioacaia: 0.1.9 -> 0.1.10
* [`747ce40f`](https://github.com/NixOS/nixpkgs/commit/747ce40fe2980f720e9745915984fb71a38a0b3d) cirrus-cli: 0.132.0 -> 0.133.0
* [`17dd96c4`](https://github.com/NixOS/nixpkgs/commit/17dd96c4deead1bc2334e62e8889283ccc521412) python312Packages.binance-connector: 3.9.0 -> 3.10.0
* [`fbbfa557`](https://github.com/NixOS/nixpkgs/commit/fbbfa557fd2cb266b10bad980fc610d834aa6d66) dbgate: add desktop entries
* [`93b806da`](https://github.com/NixOS/nixpkgs/commit/93b806da897ac4d96e01efbdb3ee6fa7929afaf9) gamescope: fix cross compilation
* [`cc90b03c`](https://github.com/NixOS/nixpkgs/commit/cc90b03c71a9988c0f87bc90479fa2dbfaa259d2) python312Packages.jupyterlab-server: remove jupyterlab_server.pytest_plugin from import checks
* [`1ddee49c`](https://github.com/NixOS/nixpkgs/commit/1ddee49c20c7b06314db1019bedb0e495241768c) python312Packages.uxsim: 1.7.0 -> 1.7.1
* [`85540a4a`](https://github.com/NixOS/nixpkgs/commit/85540a4af0ce0706162b43b880c455df8ab2aa12) libevdevc: fix cross compilation, format with nixfmt
* [`d2bdb08c`](https://github.com/NixOS/nixpkgs/commit/d2bdb08ccb202c23c48602c619b4165dc4a87979) apparmor: adopt
* [`ceaeeb47`](https://github.com/NixOS/nixpkgs/commit/ceaeeb47cb395996ccc531a7f7e6ff56e433690f) nixos/apparmor: adopt
* [`407bd6b3`](https://github.com/NixOS/nixpkgs/commit/407bd6b3446bb9c332031ddbf1effb3c10524919) nixos/tests/apparmor: adopt
* [`efa60da7`](https://github.com/NixOS/nixpkgs/commit/efa60da789205e265acf47aca8892df4534273c0) python3Packages.proton-vpn-api-core: 0.36.6 -> 0.38.2
* [`0e5cc7f0`](https://github.com/NixOS/nixpkgs/commit/0e5cc7f03299149843c410dec8b18d1076eb2baf) python3Packages.proton-keyring-linux: 0.1.0 -> 0.2.0
* [`dddeb779`](https://github.com/NixOS/nixpkgs/commit/dddeb779ac9895708bade50507a13c4a1d10e3a8) proton-vpn-local-agent: 1.0.0 -> 1.2.0
* [`c44e3594`](https://github.com/NixOS/nixpkgs/commit/c44e35947944993fa5c2d69c4e1948794f9a6b9b) python3Packages.proton-vpn-network-manager: 0.9.7 -> 0.10.1
* [`f11e9d4e`](https://github.com/NixOS/nixpkgs/commit/f11e9d4e1c648994503ac7d4829acce0a3fa333c) protonvpn-gui: 4.7.4 -> 4.8.0
* [`937d3c9f`](https://github.com/NixOS/nixpkgs/commit/937d3c9fa0a171040017af8b6eb3b2ef388fdd09) python312Packages.rmscene: 0.5.0 -> 0.6.0
* [`230b623a`](https://github.com/NixOS/nixpkgs/commit/230b623a470032d4b905add7ad801d1a51b889a9) snowflake: 2.9.2 -> 2.10.1
* [`f88894d1`](https://github.com/NixOS/nixpkgs/commit/f88894d14a76b7a3c9e488ad70d76bf67e78dcb2) pdfstudio: format
* [`e56d88b5`](https://github.com/NixOS/nixpkgs/commit/e56d88b500f507223e893d9de390981d013be801) rmapi: 0.0.27.1 -> 0.0.28
* [`63c36f81`](https://github.com/NixOS/nixpkgs/commit/63c36f819ca3d7b49ea7bc4dde01c4c61ee24e89) python312Packages.pynecil: 0.2.1 -> 1.0.1
* [`8f28ab10`](https://github.com/NixOS/nixpkgs/commit/8f28ab10cfe39674cffe01a939d1f21b0c34349d) to-html: 0.1.4 -> 0.1.6
* [`88f32cf6`](https://github.com/NixOS/nixpkgs/commit/88f32cf694a7f6fc16c2e5b80d615b8b317fa9c4) to-html: Add shell completions
* [`87ad190d`](https://github.com/NixOS/nixpkgs/commit/87ad190dceb5c4fee8dd5970e58782a7536302e1) pcsx2: 2.1.127 -> 2.3.39
* [`5459214b`](https://github.com/NixOS/nixpkgs/commit/5459214bcc07926d3312c0cf27f458c45b804618) z-lua: 1.8.19 -> 1.8.20
* [`4ebdf1ed`](https://github.com/NixOS/nixpkgs/commit/4ebdf1edaafe4367a10b081b72c83a870276b73b) python312Packages.replicate: 1.0.1 -> 1.0.4
* [`bdbbf3a8`](https://github.com/NixOS/nixpkgs/commit/bdbbf3a8a1648866f00b2f58493fedd911def12d) azpainter: 3.0.9a -> 3.0.10
* [`175d8c88`](https://github.com/NixOS/nixpkgs/commit/175d8c885446bf4a6dc6bc6f1b69b0c961f567cb) python312Packages.pyvo: 1.5.3 -> 1.6
* [`f31600fd`](https://github.com/NixOS/nixpkgs/commit/f31600fd0fc19fb3af357b140461c9afdc87af35) workflows/backport: Use GitHub App to create PRs to make GHA trigger on them
* [`07079b57`](https://github.com/NixOS/nixpkgs/commit/07079b57ec6960f35fb2b9957ac9539f0838bd6a) libdeltachat: 1.151.1 -> 1.151.2
* [`318dd618`](https://github.com/NixOS/nixpkgs/commit/318dd6182f7e4a645a0140af2b1ce9a2ba28fefc) x42-plugins: 20230315 -> 20240611
* [`f6b4c1a4`](https://github.com/NixOS/nixpkgs/commit/f6b4c1a4d75bee647c29104710c531398c1a8bab) obs-studio-plugins.input-overlay: 5.0.5 -> 5.0.6
* [`f35b3e9c`](https://github.com/NixOS/nixpkgs/commit/f35b3e9c240d56a31f6b37612bc86aabc263d9d9) spring-boot-cli: 3.3.4 -> 3.4.0
* [`a0bf1917`](https://github.com/NixOS/nixpkgs/commit/a0bf19172ca56af9ab3b93f2cb752d322b0488d8) wl-mirror: 0.16.5 -> 0.17.0
* [`ba9d401a`](https://github.com/NixOS/nixpkgs/commit/ba9d401ad62892e472bdf65f4df20cb7ff157796) python312Packages.ihcsdk: 2.8.7 -> 2.8.9
* [`69f0f79b`](https://github.com/NixOS/nixpkgs/commit/69f0f79b22e33fc89b3d01188144563b62fb6e88) cling: avoid dynamic linking against libLLVM.so to fix xeus-cling
* [`5d87db84`](https://github.com/NixOS/nixpkgs/commit/5d87db84aa4bbaede7b9b4455739c9b85815a71e) wireshark: 4.2.6 -> 4.4.2
* [`4ebd9725`](https://github.com/NixOS/nixpkgs/commit/4ebd9725e1aa051b4eb57fd1552027fcce7643a1) wireshark: switch to zlib-ng
* [`7214855e`](https://github.com/NixOS/nixpkgs/commit/7214855ea4221ef0194a1146312152a99c049199) pythonPackages.pyshark: fix capture test
* [`51c69383`](https://github.com/NixOS/nixpkgs/commit/51c693837f3c4bb751797c766cca5a0198f7dafc) raffi: 0.5.1 -> 0.6.0
* [`3f36a68d`](https://github.com/NixOS/nixpkgs/commit/3f36a68d94a57257ded223374de69adab74b5917) xeus-cling: wrap with library args and add smoke check
* [`0d48c50f`](https://github.com/NixOS/nixpkgs/commit/0d48c50f4b01ff434fa58900e62c02a078f62681) nixos/networkd: use upstream wait-online@ unit
* [`49d45711`](https://github.com/NixOS/nixpkgs/commit/49d45711a6bb75b142f5eb884b364e346777f0b7) btrfs-progs: 6.11 -> 6.12
* [`64fa76da`](https://github.com/NixOS/nixpkgs/commit/64fa76daa13ab0c17b9eddea82aceb0e0d48d21b) cozy-drive: 3.40.0 -> 3.41.0
* [`b9274aa7`](https://github.com/NixOS/nixpkgs/commit/b9274aa7a594d22b665c350b84a5ad0978caf36c) libcamera: re-sign IPA modules after fixup ([nixos/nixpkgs⁠#353336](https://togithub.com/nixos/nixpkgs/issues/353336))
* [`27e8e2f7`](https://github.com/NixOS/nixpkgs/commit/27e8e2f73c5c574f44b446f775f1e83d4247a02a) roxterm: 3.14.3 -> 3.15.3
* [`1441fa7f`](https://github.com/NixOS/nixpkgs/commit/1441fa7fbe5150c66a89bfae919bcfeb35867450) linuxPackages.ena: add updateScript
* [`fb56d1e4`](https://github.com/NixOS/nixpkgs/commit/fb56d1e4a7dac4486eaf7b302892cabd0cbf3c2f) linuxPackages.ena: bump 2.13.0 -> 2.13.1
* [`cdd61029`](https://github.com/NixOS/nixpkgs/commit/cdd6102925f3c802a5b5b2cc39e6e730af843f03) jprofiler: remove catap as maintainer
* [`5b9283c4`](https://github.com/NixOS/nixpkgs/commit/5b9283c4ef773e451aec6706fbb756a1b9dd2531) jprofiler: format
* [`be9066a7`](https://github.com/NixOS/nixpkgs/commit/be9066a7f3c12597302c9795732b447e109965f1) jprofiler: 13.0.6 -> 14.0.5
* [`fab56ca2`](https://github.com/NixOS/nixpkgs/commit/fab56ca285de3b7c2f41320bc94b5b26361f2826) tutanota-desktop: 250.241025.0 -> 253.241126.2
* [`e3a9c19e`](https://github.com/NixOS/nixpkgs/commit/e3a9c19e86661ce0d5799b20c91a5156eaf34db8) strawberry: drop strawberry-qt5 in favor of strawberry-qt6
* [`10ce0b2d`](https://github.com/NixOS/nixpkgs/commit/10ce0b2de85389ae66966eb2f947b94c23feb683) strawberry: 1.1.3 -> 1.2.2
* [`6f860d8e`](https://github.com/NixOS/nixpkgs/commit/6f860d8ef6d6d67ea4d82fb4458b7d50ab037d78) strawberry: drop PCRE dependency
* [`9a994b1f`](https://github.com/NixOS/nixpkgs/commit/9a994b1f5f130ead19a4e8a67d9c0f3978437b07) alfaview: 9.17.0 -> 9.18.1
* [`5d193551`](https://github.com/NixOS/nixpkgs/commit/5d193551cd32b0be2b462e712ca4e8fc277c35e0) gitxray: 1.0.16 -> 1.0.16.4
* [`e571f245`](https://github.com/NixOS/nixpkgs/commit/e571f2451ee6043bf261846d60baff811a4bd49c) nixVersions.nix_2_18: drop
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
