### PR TITLE
niv home-manager: update bf23fe41 -> 9ebaa80a

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -41,10 +41,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "bf23fe41082aa0289c209169302afd3397092f22",
-        "sha256": "1f5lih3cmmipwhm21km35zgszk7jpl5rpdf96b7rgkd3m8wsslyc",
+        "rev": "9ebaa80a227eaca9c87c53ed515ade013bc2bca9",
+        "sha256": "0xm172djksf09x1p4pviyq9a95x2f3983bsr67i2iqxricib74nw",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/bf23fe41082aa0289c209169302afd3397092f22.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/9ebaa80a227eaca9c87c53ed515ade013bc2bca9.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@bf23fe41...9ebaa80a](https://github.com/nix-community/home-manager/compare/bf23fe41082aa0289c209169302afd3397092f22...9ebaa80a227eaca9c87c53ed515ade013bc2bca9)

* [`092b81b9`](https://github.com/nix-community/home-manager/commit/092b81b95615919b36cbb0e690dda8583b31013e) atuin: configure daemon using systemd and launchd
* [`33c236f1`](https://github.com/nix-community/home-manager/commit/33c236f1d5eb3d1a3df202540794d590c2fe0a2f) atuin: add water-sucks as maintainer
* [`c56aa0f5`](https://github.com/nix-community/home-manager/commit/c56aa0f51d058f41a7ba0c45bd3b6d9d244c0396) atuin: assert version >= 18.2.0 when daemon is enabled
* [`f8bc330a`](https://github.com/nix-community/home-manager/commit/f8bc330a13f80e13e70967bca0e674f711218ea2) atuin: capitalize mentions of "atuin"
* [`dfdf59b2`](https://github.com/nix-community/home-manager/commit/dfdf59b2d539941aea5c26666c9ab809c1dc34df) atuin: make daemon log level configurable
* [`256ec265`](https://github.com/nix-community/home-manager/commit/256ec2653e79363022a6042285dde3935816cea4) flake.lock: Update
* [`5b5de433`](https://github.com/nix-community/home-manager/commit/5b5de4338fad32dc709c900b4dcbbcd98b20dc4c) kakoune: fix color scheme package XDG file
* [`70803283`](https://github.com/nix-community/home-manager/commit/70803283187c8f775ff561be4117e5b1a11b296e) Translate using Weblate (Finnish)
* [`8f4f57f9`](https://github.com/nix-community/home-manager/commit/8f4f57f9a67367881b1a36f93856ffef8646d428) qt: update tooling for Plasma 6
* [`6c3a7a0b`](https://github.com/nix-community/home-manager/commit/6c3a7a0b72c19ec994b85c57a1712d177bd809b2) qt: reduce test closure
* [`30f66eaa`](https://github.com/nix-community/home-manager/commit/30f66eaa3209e13f32f98df5a150542baf2d72af) xresources: use `profileExtra` instead of `initExtra`
* [`b1c19f1d`](https://github.com/nix-community/home-manager/commit/b1c19f1dcbc2429c16d5e6259dbff4f12dd8a89d) home-cursor: use `profileExtra` instead of `initExtra`
* [`ad48eb25`](https://github.com/nix-community/home-manager/commit/ad48eb25cd0b00ce730da00fa1f8e6e6c27b397d) etesync-dav: update default server URL
* [`3a7fc9cd`](https://github.com/nix-community/home-manager/commit/3a7fc9cd71a844aae9c6b6bb44700cea9539bc13) zsh: make autosuggest strategy accept more options
* [`1cd17a2f`](https://github.com/nix-community/home-manager/commit/1cd17a2f76f7711b06d5d59f1746cef602974498) mangohud: fix a non-working example
* [`86ee1290`](https://github.com/nix-community/home-manager/commit/86ee1290d76bcd5f7ee6c80f181288a28ab0dca0) starship: add `enableInteractive` option for fish
* [`0daaded6`](https://github.com/nix-community/home-manager/commit/0daaded612b0e6eaed0a63fc9d0778d8f05940fe) starship: replace `eval` with `source` for fish
* [`65912bc6`](https://github.com/nix-community/home-manager/commit/65912bc6841cf420eb8c0a20e03df7cbbff5963f) imapnotify: provide an option for setting PATH
* [`953521f7`](https://github.com/nix-community/home-manager/commit/953521f759fd746190ae2d2d052183296425b27b) fcitx5: fix package reference in test
* [`0b42cc1b`](https://github.com/nix-community/home-manager/commit/0b42cc1b1c7a38f32334f217eadbc7b83b3ef44c) cmus: reduce test closure
* [`63eb786e`](https://github.com/nix-community/home-manager/commit/63eb786e047fbb101041103f86162cd72d105d79) xresources: simplify tests
* [`d00c6f6d`](https://github.com/nix-community/home-manager/commit/d00c6f6d0ad16d598bf7e2956f52c1d9d5de3c3a) nix: simplify tests
* [`f63c15c1`](https://github.com/nix-community/home-manager/commit/f63c15c137f9e446af897c15218c1af9f06d91ad) isync/mbsync: update module for 1.5.0 changes ([nix-community/home-manager⁠#5918](https://togithub.com/nix-community/home-manager/issues/5918))
* [`9ebaa80a`](https://github.com/nix-community/home-manager/commit/9ebaa80a227eaca9c87c53ed515ade013bc2bca9) thunderbird: set the correct SMTP server for aliases ([nix-community/home-manager⁠#6177](https://togithub.com/nix-community/home-manager/issues/6177))
