### PR TITLE
niv nixpkgs: update d92224a3 -> 639295b1

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d92224a31826a0b547560afea84c6a83a9d113f8",
-        "sha256": "06is3r7zgg5izas7cd71dvkyni1k8l3f5x388k6biagf7w2a1ycd",
+        "rev": "639295b1f6dc159631e7dec5a0b926ec2a2fdf9c",
+        "sha256": "1pz2z8fzrbhrms1v25444igmni8f6q72dwnyvnj9wyk7nrjav8j7",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/d92224a31826a0b547560afea84c6a83a9d113f8.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/639295b1f6dc159631e7dec5a0b926ec2a2fdf9c.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@d92224a3...639295b1](https://github.com/nixos/nixpkgs/compare/d92224a31826a0b547560afea84c6a83a9d113f8...639295b1f6dc159631e7dec5a0b926ec2a2fdf9c)

* [`fc4e95e2`](https://github.com/NixOS/nixpkgs/commit/fc4e95e2e0966d641e985117674af67d10237a6f) nixos/v2ray: change the type of `config` field
* [`2d605e15`](https://github.com/NixOS/nixpkgs/commit/2d605e1557d1064c25ca121b11fb8ade4b60e0b2) appimage-env: remove xorg.libxshmfence
* [`f43fb79c`](https://github.com/NixOS/nixpkgs/commit/f43fb79c08b8627da6b10abbf73c64c9a910dc04) [nbstripout] Don't propagate ipython
* [`e3c0ba78`](https://github.com/NixOS/nixpkgs/commit/e3c0ba78dd50837d0b1edb4e923ace33220c504b) nixos/activation-script: check rmdir in usrbinenv
* [`8f519d86`](https://github.com/NixOS/nixpkgs/commit/8f519d86e07008e9fa7b64a62dc073ab7a0685d0) hotspot: build against Konsole
* [`09ebdf44`](https://github.com/NixOS/nixpkgs/commit/09ebdf44fabc0f4a11df971c52cbd041db425094) nixos/anki-sync-server: do not use unqualified 'cat' in execStart script
* [`8c270aea`](https://github.com/NixOS/nixpkgs/commit/8c270aea543b48ea4b913ecbeeaad800cd0d4218) ycmd: add rust completion support
* [`39eaf6e7`](https://github.com/NixOS/nixpkgs/commit/39eaf6e74658f3f23a95c03aa311c65a877491f8) nixos/plymouth: add support for logo in catppuccin (two-step) theme
* [`80f84365`](https://github.com/NixOS/nixpkgs/commit/80f8436552f74af3897b209a79d283f81ba17a42) meshlab: set QT_QPA_PLATFORM xcb
* [`f6ad69af`](https://github.com/NixOS/nixpkgs/commit/f6ad69af7ebaf72e03849cd3a3420b11ca5e3b71) nixos/sd-card: explicitly set core_freq for rpi 3
* [`1d261ca4`](https://github.com/NixOS/nixpkgs/commit/1d261ca49aa0efee846c660a01358d66fa2c12d1) hunspellDicts.et_EE: init at 20030606
* [`d67c1a4c`](https://github.com/NixOS/nixpkgs/commit/d67c1a4c6b0852bad6b361555f3b0522bb10cb36) pub2nix.generatePackageConfig: Use logical paths for pubspec.yaml
* [`66dce478`](https://github.com/NixOS/nixpkgs/commit/66dce47853fc352f05ee6481c231f79255c88b96) nixos/navidrome: support dns through systemd-resolved
* [`6853d8fd`](https://github.com/NixOS/nixpkgs/commit/6853d8fdb7ad1ca299ae9d13278b34423fccc8b8) llvmPackages: add `asl20-llvm` to licenses for v19+
* [`26b1c14e`](https://github.com/NixOS/nixpkgs/commit/26b1c14ebba41f0b1635b14f0262bb883c49aaf7) shoreline: init at 0-unstable-2021-08-21
* [`b9d30709`](https://github.com/NixOS/nixpkgs/commit/b9d30709a592a52a73c8f7aca2d4bbbfed08f828) extlinux-conf-builder: don't emit MENU when timeout is zero
* [`54bb89c6`](https://github.com/NixOS/nixpkgs/commit/54bb89c66f33f07ea61cef92e82b005163f8f34e) less: set default lessopen preprocessor to null
* [`78eb75ea`](https://github.com/NixOS/nixpkgs/commit/78eb75ea551783052fb45390f020aa4c939a60d7) kubernetes-helmPlugins.helm-dt: init at 0.4.1
* [`b5d50eae`](https://github.com/NixOS/nixpkgs/commit/b5d50eae88f4f071dbd2828ddd33f60283abd92f) quakespasm: 0.96.0 -> 0.96.3
* [`77f40974`](https://github.com/NixOS/nixpkgs/commit/77f4097425aedb26e3b55cc2bde13fc9e19e2e0c) unbound: support dynlib module
* [`16782bd5`](https://github.com/NixOS/nixpkgs/commit/16782bd5568bf7e34974e5b0cc5e5e042a4fb65c) v2raya: add cliPackage option
* [`16934a90`](https://github.com/NixOS/nixpkgs/commit/16934a90e6a85762bb1be20c1ecf8405ee84627f) maintainers: add justinrubek
* [`8ba96159`](https://github.com/NixOS/nixpkgs/commit/8ba961591c8591212d171b74a803ad89e9117c57) build(deps): bump korthout/backport-action from 3.0.2 to 3.1.0
* [`a7ef1254`](https://github.com/NixOS/nixpkgs/commit/a7ef1254e61d9cdccc6096778c8fcc640059aabd) tasks/network-interfaces: Disable network-local-commands service if unnecessary
* [`61fd315b`](https://github.com/NixOS/nixpkgs/commit/61fd315b420f8bb87bb1c867d556227b2fd46e17) nixos/manual: add hint to interactive testing about Internet access
* [`c73827fa`](https://github.com/NixOS/nixpkgs/commit/c73827fa29459043c1d3f8d29b04790dc9ac9f6e) markdown2html-converter: init at 1.1.12
* [`39821c35`](https://github.com/NixOS/nixpkgs/commit/39821c35675091d310f156514c21b2d5cb1fd198) octavePackages.statistics: 1.6.7 -> 1.7.0
* [`3e2e5daa`](https://github.com/NixOS/nixpkgs/commit/3e2e5daab49949fa069c477ad7b424b375ef42dd) doc/languages-frameworks/python: Reword section to make commit rules a bit clearer
* [`00a43d7d`](https://github.com/NixOS/nixpkgs/commit/00a43d7d03a4d64df7bf29d20738cd37537f2dbc) doc/languages-frameworks/python: update references to python 3.12
* [`96c1637f`](https://github.com/NixOS/nixpkgs/commit/96c1637f91e147c9f5b7e953c09d3a7898b38e7c) ts-warp: init 1.5.4
* [`ff1ae848`](https://github.com/NixOS/nixpkgs/commit/ff1ae848ec6c48b7cb479eda6f2fddd5fa88959c) akkuPackages.machine-code: remove all-a64.sps test
* [`1383f108`](https://github.com/NixOS/nixpkgs/commit/1383f108d244d22265a66994aeb2ee3c89491571) msmtp: add updateScript
* [`bb8884d3`](https://github.com/NixOS/nixpkgs/commit/bb8884d3b7a2e525c818a2f537774aa5f4edb677) msmtp: 1.8.25 -> 1.8.26
* [`1d3fd9f9`](https://github.com/NixOS/nixpkgs/commit/1d3fd9f92d7097459bcf84e6bd0e8a401bdd16f3) msmtp: specify that msmtpq is a wrapper
* [`b28bf421`](https://github.com/NixOS/nixpkgs/commit/b28bf4218a12f243ae20a04a5c01d6dfd5e4c04b) hunspellDicts.ko_KR: init at 0.7.94
* [`01f3292d`](https://github.com/NixOS/nixpkgs/commit/01f3292dcadbf5868d816332cd48b221f7bd5c9e) tacent: init at 0.8.18
* [`27a19594`](https://github.com/NixOS/nixpkgs/commit/27a19594dce7571ab7db6b536981a1c423d7e98a) tacentview: init at 1.0.46
* [`296632cf`](https://github.com/NixOS/nixpkgs/commit/296632cf5ea11612fd194dead75b3dfbeba53600) firefox-bin: link native-messaging-hosts to correct location
* [`14ef7f78`](https://github.com/NixOS/nixpkgs/commit/14ef7f785008728e99c2e7695ec618785e8a82ce) unar: 1.10.7 -> 1.10.8
* [`7afc19dd`](https://github.com/NixOS/nixpkgs/commit/7afc19ddfece81b7c5ed1ac8f9fe3f4f2cad6565) maintainers: add lactose
* [`7062afb2`](https://github.com/NixOS/nixpkgs/commit/7062afb2ff428fa0ee8b5635ae06d5adb6fbb396) libpeas2: fix cross compilation
* [`4807bfbf`](https://github.com/NixOS/nixpkgs/commit/4807bfbff5c4d7819cd701ce25b9e54ca46920f1) xcursor-pro: init at 2.0.2
* [`38035045`](https://github.com/NixOS/nixpkgs/commit/380350455a9e896ae0708afc779663c55d7b1c32) qgroundcontrol: Disable bad message
* [`765c9bf4`](https://github.com/NixOS/nixpkgs/commit/765c9bf44e30f623996de3bedfe3cf2495f2707f) nixos/qgroundcontrol: Add cfg.package option
* [`93c30427`](https://github.com/NixOS/nixpkgs/commit/93c30427d92025c7f3983bdfeb9add22198aed62) python312Packages.torchio: 0.19.6 -> 0.20.0
* [`9485a4d9`](https://github.com/NixOS/nixpkgs/commit/9485a4d94b5576556bd171826fd3cf2e8ef4635f) python312Packages.nitransforms: 23.0.1 -> 24.0.2
* [`b552249a`](https://github.com/NixOS/nixpkgs/commit/b552249a1884b239337d21d4f75d4d81a2251ace) procs: fix cross compilation
* [`11b62e65`](https://github.com/NixOS/nixpkgs/commit/11b62e658f142fa4ef15696226e01d2feb02095c) maintainers: update natsukagami
* [`26feb287`](https://github.com/NixOS/nixpkgs/commit/26feb287583eae5b9e6bf2b273f01811d878c7d3) common-updater-scripts,directoryListingUpdater: handle ${pname}_${version} file names
* [`e55e5f40`](https://github.com/NixOS/nixpkgs/commit/e55e5f40dd0c3492a77e3577672444a17bfb88a4) rubyPackages.pandocomatic: 1.1.2 -> 2.0.1
* [`633d6568`](https://github.com/NixOS/nixpkgs/commit/633d6568b0d6aa4c465c96db17df2c0d2b34d414) wlock: init at 0-unstable-2024-09-13
* [`45e10488`](https://github.com/NixOS/nixpkgs/commit/45e1048834cd1d8974e3fec4a09a329bd9f0a592) maintainers: add thomaslepoix
* [`787e3e6f`](https://github.com/NixOS/nixpkgs/commit/787e3e6fdbae411e40cb4c6b852faf488eb0006e) isync: add post-1.5.0 commits and build from git
* [`ba01c8ba`](https://github.com/NixOS/nixpkgs/commit/ba01c8bab3dc7832543f5e577c1832a78c26c8bf) nixos/resilio: set rslsync gid
* [`ad7b2f34`](https://github.com/NixOS/nixpkgs/commit/ad7b2f343896360eb8ac9fd8815304758356750a) lib/types: make pattern of strMatching accessible
* [`f45b52f3`](https://github.com/NixOS/nixpkgs/commit/f45b52f30f082f40bef75e18a9e17dec93657f47) maintainers: add shadows_withal and MarchCraft
* [`606b3a8c`](https://github.com/NixOS/nixpkgs/commit/606b3a8c1d11b8e3d29a548736baf3cbc4166683) easyroam-connect-desktop: init
* [`e5888c35`](https://github.com/NixOS/nixpkgs/commit/e5888c35ddf774f639f1c6dfc7a2bbf1d104e29c) mpsolve: switch to GitHub repository as source
* [`ce97cf12`](https://github.com/NixOS/nixpkgs/commit/ce97cf12501e420538ea15e758c6f6d086e6aeff) rain-bittorrent: init at 1.30.0
* [`bf6e2e97`](https://github.com/NixOS/nixpkgs/commit/bf6e2e97239b9950593d144dcce98f3aa4c834da) mfcl5750dw: init at 3.5.1-1
* [`2ef17476`](https://github.com/NixOS/nixpkgs/commit/2ef17476baedd1225d80120f45bd83ada1bb9702) cgt-calc: init at 1.13.0
* [`401069ce`](https://github.com/NixOS/nixpkgs/commit/401069cede88987ed4227c2dcaf3140215d2455a) granian: 1.6.1 -> 1.6.2
* [`0b09ff19`](https://github.com/NixOS/nixpkgs/commit/0b09ff1954bbe9bcb899ec796c1550e927902c51) python312Packages.vbuild: init at 0.8.2
* [`9b2793b6`](https://github.com/NixOS/nixpkgs/commit/9b2793b6ef23e0583af0ef10e16077067fd5c548) python312Packages.pytest-variables: init at 3.1.0
* [`d38743dc`](https://github.com/NixOS/nixpkgs/commit/d38743dce81eaf2b1777d82ca73429549e845422) stdenv: fix documentation for stripAllFlags and stripDebugFlags
* [`252a4a2e`](https://github.com/NixOS/nixpkgs/commit/252a4a2eae7857862107408269f32a395bf601b0) perlPackages.NetAsyncWebSocket: 0.13 -> 0.14
* [`1ce78627`](https://github.com/NixOS/nixpkgs/commit/1ce786273addfdb330bc791a3a7f20022a238dcc) niimath: init at 1.0.20240905
* [`f12daedb`](https://github.com/NixOS/nixpkgs/commit/f12daedb13ab9e895de79b6a83be33b6738d8f0b) python3Packages.databricks-sql-connector: drop bad patch, relax thrift dep
* [`20863d46`](https://github.com/NixOS/nixpkgs/commit/20863d46680149af58124e108d9f248cc312fb5c) darwin.libpcap: disable condition on PRIVATE to expose symbol
* [`2ff2261b`](https://github.com/NixOS/nixpkgs/commit/2ff2261bd1b01ccfb01740728145d861534d9516) mullvad: fix darwin build
* [`3d2755e0`](https://github.com/NixOS/nixpkgs/commit/3d2755e0a57a286f3834a94e36b8e52a7955ab04) Apply suggestions from code review
* [`562e8b68`](https://github.com/NixOS/nixpkgs/commit/562e8b6883227b92aacef3da29340a73dfb2aebd) maintainers: add inexcode
* [`1f24e9b5`](https://github.com/NixOS/nixpkgs/commit/1f24e9b5f5ac6b23b0024543c78abe0f9dca1013) minion: init at 3.0.12
* [`ad6f3fbe`](https://github.com/NixOS/nixpkgs/commit/ad6f3fbe3be32cf0112d2a05d104b3cd9a8f8dff) itk: Adds RTK remote crate
* [`048d8cce`](https://github.com/NixOS/nixpkgs/commit/048d8cceeec8d20b6267fde8dc55bb753706a4fd) nixos/qemu-vm: minor readability improvements
* [`1a749ea8`](https://github.com/NixOS/nixpkgs/commit/1a749ea80c06c937b85af6c8ec86a7c75e04c9b0) ios-safari-remote-debug: init at unstable-2024-09-09
* [`627542ea`](https://github.com/NixOS/nixpkgs/commit/627542ea2d292dd79151edaca5aea9bf6dd06f7d) cloudpan189-go: init at 0.1.3
* [`539e4e27`](https://github.com/NixOS/nixpkgs/commit/539e4e2733a8dcf43fb7c38eded1f79800dd9fce) git-lfs-transfer: init at unstable-2024-10-07
* [`2d365813`](https://github.com/NixOS/nixpkgs/commit/2d3658130b95416ed9bc5d4c106e3c1dbe9cd750) nixos/git: add lsf.enablePureSSHTransfer
* [`0512de25`](https://github.com/NixOS/nixpkgs/commit/0512de251218d4ad14a1ad8a73c374ac352d9d4e) nixos/galene: add turnAddress option and fix httpAddress
* [`e3f4aae3`](https://github.com/NixOS/nixpkgs/commit/e3f4aae37e1d9ba074e1a956a20c3f93103cf7eb) libnss_nis: init at 3.2
* [`c243f041`](https://github.com/NixOS/nixpkgs/commit/c243f041aa2b0b6a99f9a2828d83bb451e89cf2b) python312Packages.torch: unroll recursive git retrieval
* [`9a2dbfc2`](https://github.com/NixOS/nixpkgs/commit/9a2dbfc20945eee3e77b6c870c800151511c22c8) persepolis: 4.0.1 -> 5.0.1
* [`50924ca2`](https://github.com/NixOS/nixpkgs/commit/50924ca2b97e37e64d14f1ec35c39ab84d89d346) Apply suggestions from code review
* [`0f1b0e98`](https://github.com/NixOS/nixpkgs/commit/0f1b0e982e5cf25623b1ea9a27cfe1a45a1e898a) azure-artifacts-credprovider: init at 1.0.9
* [`8a3d2277`](https://github.com/NixOS/nixpkgs/commit/8a3d2277f5add78cbe8c51d6bb352fae44b5edc2) azure-artifacts-credprovider: 1.0.9 -> 1.3.0
* [`27ecc780`](https://github.com/NixOS/nixpkgs/commit/27ecc78052d39551bb142c678b91e04102a64b0b) azure-artifacts-credprovider: fix formating
* [`ffc5d082`](https://github.com/NixOS/nixpkgs/commit/ffc5d0827110d5426e1931c51b3125f3c4aded6a) streamlink-twitch-gui-bin: 2.4.1 -> 2.5.3
* [`b9fe3c3e`](https://github.com/NixOS/nixpkgs/commit/b9fe3c3e1f3d56699956a652d5b5dcaab8aa9e12) python3Packages.pre-commit-po-hooks: init at 1.7.3
* [`a3cc4986`](https://github.com/NixOS/nixpkgs/commit/a3cc4986c8eb877e6e5e67aba52442b8ca829f14) akkoma: update tzdata 1.1.1 -> 1.1.2
* [`db4f9004`](https://github.com/NixOS/nixpkgs/commit/db4f9004c8c40f79960c30b3afef2d7eb2f16586) whisparr: init at 2.0.0.548
* [`d6d7fe94`](https://github.com/NixOS/nixpkgs/commit/d6d7fe94d4465d8e507a36ae9a8f1cd58914a721) nixos/whisparr: initial commit
* [`65896252`](https://github.com/NixOS/nixpkgs/commit/6589625273010658818a00876012d3963dd27f63) arma3-unix-launcher: replace curlpp.src with srcOnly curlpp to ensure patches are applied
* [`3ab2140c`](https://github.com/NixOS/nixpkgs/commit/3ab2140c5798083f6436ee5887653137b4ad3490) arma3-unix-launcher: remove unused dependencies
* [`3a1817aa`](https://github.com/NixOS/nixpkgs/commit/3a1817aaa9bb4502d68a4d0494fdf0943e9c1a6d) libblockdev: add updateScript
* [`56197afc`](https://github.com/NixOS/nixpkgs/commit/56197afc1422dd0f227085b23d31bbf8becccf0d) libblockdev: 3.1.1 -> 3.2.1
* [`55817483`](https://github.com/NixOS/nixpkgs/commit/5581748393b2afe4f2ad329d04032255a72eae03) python312Packages.blivet: 3.10.1 -> 3.11.0
* [`a60bf9d8`](https://github.com/NixOS/nixpkgs/commit/a60bf9d8bcebbf3fc39fcdf69748b8e3811f47f6) python312Packages.graph-tool: 2.78 -> 2.79
* [`39e72496`](https://github.com/NixOS/nixpkgs/commit/39e724960e5e139e8dbb1c702449527589a73212) fopnu: init at 1.67
* [`b16b9e41`](https://github.com/NixOS/nixpkgs/commit/b16b9e417317390c2cb7ae7d81b464b66a55a065) maintainers: add jmir
* [`8f893215`](https://github.com/NixOS/nixpkgs/commit/8f8932152128fc939774a708f4c7bd04bdb93c23) leddy: init at 0.1.0-unstable-2024-04-05
* [`84549eeb`](https://github.com/NixOS/nixpkgs/commit/84549eeb5183373526abdbe2fde9d231e2005ff7) dpdk: 23.11 -> 24.07
* [`6995a813`](https://github.com/NixOS/nixpkgs/commit/6995a813cdc3839eef1e12c9ea5d98e063980585) iro: init at 0-unstable-2024-10-24
* [`f64a3cb8`](https://github.com/NixOS/nixpkgs/commit/f64a3cb81fa07ad62f7ff837a16b613b658b3a5a) libgnt: 2.14.3 -> 2.14.4-dev
* [`5d470b88`](https://github.com/NixOS/nixpkgs/commit/5d470b88351c1970b12849c251c899460415f656) nixos-install: clear executable cache after entering chroot
* [`9bfc41da`](https://github.com/NixOS/nixpkgs/commit/9bfc41da62af1cd000f93e038618125fc6e6521b) perlPackages.EmailOutlookMessage: add missing dep
* [`07ccfe68`](https://github.com/NixOS/nixpkgs/commit/07ccfe68437c7cd4fc368df73a9b50b646db9a6e) tree-sitter-grammars.tree-sitter-twig: init
* [`0f9bf051`](https://github.com/NixOS/nixpkgs/commit/0f9bf0515e65efdb60b01d86ee30e01a4d17219d) libloot: init at 0.24.5
* [`b5711fd0`](https://github.com/NixOS/nixpkgs/commit/b5711fd002a7dcb5b0c452602e4692d9028d9982) limo: init at 1.0.8.2
* [`00c3a3de`](https://github.com/NixOS/nixpkgs/commit/00c3a3defe134abf6c8d532ef5f99b9a960a14a2) nixos-option: add clang-tidy
* [`7e9e33e7`](https://github.com/NixOS/nixpkgs/commit/7e9e33e79c7003088af7bd7ee100d12df8c20017) nixos-option: add devShell
* [`22698149`](https://github.com/NixOS/nixpkgs/commit/226981490b9eb849ace075cb9a68ff0f5e1779a2) nixos-option: clean up includes based on clang-tidy suggestions
* [`553461ad`](https://github.com/NixOS/nixpkgs/commit/553461adc754ff9f7f5bf47c18f3f198261a8c28) nixos-option: use c++20 starts_with
* [`e8d76d62`](https://github.com/NixOS/nixpkgs/commit/e8d76d62a2871f14b6162c4f464bffd3c041f29e) nixos-option: explicitly cast to int from size_t
* [`2cfcb6f4`](https://github.com/NixOS/nixpkgs/commit/2cfcb6f44242c7789d481b57351ca5f9c2dc9b28) nixos-option: don't throw errors in main
* [`01580b19`](https://github.com/NixOS/nixpkgs/commit/01580b19ae9ae74688c499350922eda42fea7e3e) nixos-option: enable bugprone lints
* [`c3e48526`](https://github.com/NixOS/nixpkgs/commit/c3e48526e0a53207f6421838c89d099f5d711a42) nixos-option: enable performance lint
* [`59a152ad`](https://github.com/NixOS/nixpkgs/commit/59a152ad84b1a45d72fa31a779ab7d365cceb2f6) nfs-utils:
* [`09fa1c43`](https://github.com/NixOS/nixpkgs/commit/09fa1c430715479f5e4923f59d58a268aa126348) python312Packages.rclone-python: init at 0.1.12
* [`bfa51720`](https://github.com/NixOS/nixpkgs/commit/bfa517208efc8cc7a2034f6ed136a88680ee7d66) maintainers: add David-Kopczynski
* [`f640d057`](https://github.com/NixOS/nixpkgs/commit/f640d0570df9caca074823baef64f5be8fa6a62c) maintainers: add Jojo4GH
* [`8b8d1fca`](https://github.com/NixOS/nixpkgs/commit/8b8d1fca01dd77babb4bb9ba22b37fb7ef1bdb0d) octoprint.python.pkgs.OctoPrint-FileCheck: 2024.3.27 -> 2024.11.12
* [`a8ab49c7`](https://github.com/NixOS/nixpkgs/commit/a8ab49c7e73e4aacac907cc651ea4ac611ecfac9) octoprint.plugins.prusaslicerthumbnails: 1.0.7 -> 1.0.8
* [`1d149072`](https://github.com/NixOS/nixpkgs/commit/1d14907280d226f0118db24d3ead204555e87dbe) octoprint.plugins.mqtt: 0.8.10 -> 0.8.16
* [`6a0e9fed`](https://github.com/NixOS/nixpkgs/commit/6a0e9fede34c4a45461179ae8dfd8a83cca6a880) OpenBUGS: fixed build
* [`b82a9c37`](https://github.com/NixOS/nixpkgs/commit/b82a9c375278cd735ab85e12a5d7f9af4125667e) maintainers: add gale-username
* [`a78c3461`](https://github.com/NixOS/nixpkgs/commit/a78c34618838c3a904cbbd86008e72c3244e330c) maintainers: add ImUrX
* [`9c4e9405`](https://github.com/NixOS/nixpkgs/commit/9c4e940564af9aa61c3f57f309115cc0b874a3d8) nixos-option: enable modernize-* checks in clang-tidy
* [`e5705ba0`](https://github.com/NixOS/nixpkgs/commit/e5705ba07b6bdbbad63ae938cd170ad312589021) nixos-option: enable readability lint
* [`1e59fb41`](https://github.com/NixOS/nixpkgs/commit/1e59fb41f0a669621979161ea4857c9d32e979d9) nixos-option: enable more lints
* [`e7367a6e`](https://github.com/NixOS/nixpkgs/commit/e7367a6eabb559839a370dc82ecb22b237ab6515) nixos-option: enable misc lints
* [`6fe4fb2b`](https://github.com/NixOS/nixpkgs/commit/6fe4fb2b95a813c1dd86cedc383fe9e9dfa5530c) nixos-option: enable cppcoreguidelines lints
* [`7a8407e4`](https://github.com/NixOS/nixpkgs/commit/7a8407e477f5892104f9ccd00972e18245be8a82) nixos-option: fix potential memory leak in mapOptions
* [`cf117192`](https://github.com/NixOS/nixpkgs/commit/cf117192587887bfc3a9a68504887814845bf07f) nixos-option: disable modernize-use-trailing-return-type
* [`b7ea84f9`](https://github.com/NixOS/nixpkgs/commit/b7ea84f90078a065b5072434aa044caff0b17a42) nixos-options: don't use references for string_views
* [`8c9f891d`](https://github.com/NixOS/nixpkgs/commit/8c9f891dba7e5d941db3a7ab252aba0c56021066) openslide: expose build system compiler to meson to fix cross build
* [`3c923717`](https://github.com/NixOS/nixpkgs/commit/3c923717ed9481013bb22f8d21790caa0636e9f1) koodo-reader: 1.6.7 -> 1.7.2
* [`cb6290c2`](https://github.com/NixOS/nixpkgs/commit/cb6290c2cfe36e54121631c9812bb1b4759c7db0) plasma-panel-colorizer: 1.0.0 -> 1.2.0
* [`9586958e`](https://github.com/NixOS/nixpkgs/commit/9586958e380aee9fe8a354d61c244594bcc838d2) plasmusic-toolbar: 2.0.0 -> 2.1.1
* [`8037b0ad`](https://github.com/NixOS/nixpkgs/commit/8037b0ad198846dc16f30108f4ff109d22e6dd22) qemu: 9.1.1 -> 9.1.2
* [`83250cf4`](https://github.com/NixOS/nixpkgs/commit/83250cf4178bea091afd025a1fd5b7070f0402fb) maintainers: add FirelightFlagboy
* [`6bf3257e`](https://github.com/NixOS/nixpkgs/commit/6bf3257e0ff86ebd2ff233d27a8e62dad1415377) maintainers: add kiranshila
* [`ab96d452`](https://github.com/NixOS/nixpkgs/commit/ab96d4520cc7dd954d2f4a0157bcc69ca7acead3) enzyme: init at 0.0.165
* [`4a4ae35a`](https://github.com/NixOS/nixpkgs/commit/4a4ae35a62c909f0f4f6673fdc80cb064af6c87b) notesnook: add wayland support
* [`dc5239bd`](https://github.com/NixOS/nixpkgs/commit/dc5239bd1caf93f9df5295f6da7fd3fe487eb4c4) Update shntool to patch bugs
* [`8bddbe02`](https://github.com/NixOS/nixpkgs/commit/8bddbe02c5237627616ad997b54c66bd03694401) prism-model-checker: init at 4.8.1
* [`2c034c52`](https://github.com/NixOS/nixpkgs/commit/2c034c521677cf9429661f2565f58bda20f4ad50) haskellPackages.pandoc-cli_3_5: fix build
* [`7b368045`](https://github.com/NixOS/nixpkgs/commit/7b3680457aedee0736e78ae71518d5736aafacc2) openscap: 1.3.10 -> 1.4.0
* [`9e67608a`](https://github.com/NixOS/nixpkgs/commit/9e67608a3ee0b6b15ec31a0c3b2fdeab9a51ffa6) marktext: nixfmt
* [`68e8a6ef`](https://github.com/NixOS/nixpkgs/commit/68e8a6ef35c05106a48c60749bf3858e873c2d9a) marktext: build from source
* [`5c913007`](https://github.com/NixOS/nixpkgs/commit/5c913007c6234133035e64048cbdf42764b5f723) pandoc: add version 3.5
* [`093558f8`](https://github.com/NixOS/nixpkgs/commit/093558f82bdebddb4fa145a19fa6f3c56f1187d8) quarto: use pandoc 3.5
* [`b4815cca`](https://github.com/NixOS/nixpkgs/commit/b4815cca25ae4517a4d527dc65ff9f07fd6440cc) pvs-studio: init at 7.33.85330.89
* [`90694f80`](https://github.com/NixOS/nixpkgs/commit/90694f80102bd928ebca900ced8a796f37d52c14) ardour: 8.8 -> 8.10
* [`b51a681d`](https://github.com/NixOS/nixpkgs/commit/b51a681d3e8521fb0dc9d416f3e6d2701bc7b419) qemu: separate doc output
* [`45641b91`](https://github.com/NixOS/nixpkgs/commit/45641b9107849fb1617a6dd8ce6d4168f7e1f5cb) cups-brother-dcpt310: init at 1.0.1
* [`0c3d16a7`](https://github.com/NixOS/nixpkgs/commit/0c3d16a7d5ae010a7e76723ee578dd9df9205333) build-support: fix nix-prefetch-* on macOS
* [`6cb8c5ec`](https://github.com/NixOS/nixpkgs/commit/6cb8c5ec01dbd02c75a6fe396bfaea22405f99ab) build-support: Simplify tmpdir creation with coreutils
* [`b552aae1`](https://github.com/NixOS/nixpkgs/commit/b552aae1fb0633072f5f3422a2c593a6652e622b) bash-env-json: fix path issue
* [`31153e09`](https://github.com/NixOS/nixpkgs/commit/31153e09fce1a4e229216867cab5be477c33b1d8) moneydance: apply nixfmt
* [`b9ad3759`](https://github.com/NixOS/nixpkgs/commit/b9ad375933e3e523f0a9dd4f1f51e846014bab10) nav: init at 1.2.1
* [`2e942b48`](https://github.com/NixOS/nixpkgs/commit/2e942b4805bcfa7ce08fe65cf72dce3641e278b8) pixi: format with nixfmt
* [`a4522a90`](https://github.com/NixOS/nixpkgs/commit/a4522a90a74d22d38d088d6b13c4c6f2abd92f4e) maintainer: add 71rd
* [`19cc9e9a`](https://github.com/NixOS/nixpkgs/commit/19cc9e9ad205d9f5243f2693bae7826081649d72) outfly: init at v0.14.0
* [`70c2f444`](https://github.com/NixOS/nixpkgs/commit/70c2f444e35d0909e334a6e2be27bd4fead81e44) llvmPackages.bintuils: Hack ranlib to ignore `-t`
* [`66220586`](https://github.com/NixOS/nixpkgs/commit/662205865507cd7a4216f99ba08fd8619e78e7b9) rman: fix build with GCC 14
* [`e61435f2`](https://github.com/NixOS/nixpkgs/commit/e61435f2df6fdf88828699a4b49721841ddd34cb) pixi: 0.34.0 -> 0.38.0
* [`12b908e2`](https://github.com/NixOS/nixpkgs/commit/12b908e27f74c7dd8948a17a5f72a81069171f44) graphia: 4.2 -> 5.1
* [`114bfcc1`](https://github.com/NixOS/nixpkgs/commit/114bfcc157314976c95b25dcd8ff41e79216a699) v2ray: 5.20.0 -> 5.22.0
* [`ccd13f2b`](https://github.com/NixOS/nixpkgs/commit/ccd13f2bf611e7a980ab59c53e5aeff0e25f11e0) moneydance: fix GTK crash
* [`5ceee66a`](https://github.com/NixOS/nixpkgs/commit/5ceee66acce696e002cd4e8b23e7b27efc25a19b) grass: use default python version
* [`a2bbfcd3`](https://github.com/NixOS/nixpkgs/commit/a2bbfcd3f5a53033612e46d7abb1e25dd6ffd9a2) python312Packages.wagtail: 6.2.2 -> 6.3.1
* [`a4d88020`](https://github.com/NixOS/nixpkgs/commit/a4d88020d8341434a8e50a73ba254af4df8b0c4f) graalvm-ce: 23.0.0 -> 23.0.1
* [`02711f4d`](https://github.com/NixOS/nixpkgs/commit/02711f4db588a80e569699626f77b584e15f68ce) c-blosc2: 2.15.1 -> 2.15.2
* [`a4030984`](https://github.com/NixOS/nixpkgs/commit/a40309842dae555b691f7b4a491bb1b5eca617f9) navicat-premium: init at 17.1.6
* [`5f730803`](https://github.com/NixOS/nixpkgs/commit/5f730803f3976e8a077770f7af605454c2407513) keka: 1.3.2 -> 1.4.6
* [`996f9e4f`](https://github.com/NixOS/nixpkgs/commit/996f9e4f289d94e96551d4c07a1a88a29dcf15b9) nixos/nginx: don't disable IPC
* [`8b3e1a0d`](https://github.com/NixOS/nixpkgs/commit/8b3e1a0d6575b19e248b426ba3c866ca81df14a8) flarum: update core and packages
* [`44636db2`](https://github.com/NixOS/nixpkgs/commit/44636db274cb81d91d6970a531353adcf383ed39) nginxMainline: 1.27.2 -> 1.27.3
* [`0e42c120`](https://github.com/NixOS/nixpkgs/commit/0e42c12065bbfa5e3dd4d4a810f3e59221bd611e) vpl-gpu-rt: Set platforms to x86_64-linux only
* [`1825fc36`](https://github.com/NixOS/nixpkgs/commit/1825fc3612ed7e5c7ec7194e4fbca3f641a0c331) clever-tools: 3.9.0 -> 3.10.1
* [`7749d2c0`](https://github.com/NixOS/nixpkgs/commit/7749d2c01658c079e768b8c8b7a58092fedd6d39) maintainers: add fauxmight
* [`1dbd6f0f`](https://github.com/NixOS/nixpkgs/commit/1dbd6f0f0d49c21213802ff261633a542819297b) webull-desktop: init at 8.2.0
* [`3f24c10c`](https://github.com/NixOS/nixpkgs/commit/3f24c10cad293248813670221d9b50138273918d) snapmaker-luban: 4.10.2 -> 4.14.0
* [`608806ba`](https://github.com/NixOS/nixpkgs/commit/608806bad169f03bf49731742880f4a653313c79) ocamlPackages.ocsigen-toolkit: 3.3.4 -> 4.1.0
* [`f06e84ea`](https://github.com/NixOS/nixpkgs/commit/f06e84eadd8fe5bfb75091c0f0ab483e03447596) ssm-session-manager-plugin: 1.2.677.0 -> 1.2.694.0
* [`3408cb90`](https://github.com/NixOS/nixpkgs/commit/3408cb904abf4958c90a376b28e328b2bc0d9321) librespot: 0.5.0 -> 0.6.0
* [`2ecf39cb`](https://github.com/NixOS/nixpkgs/commit/2ecf39cb209c2ffd8409b6868db457a8293a56cf) moodle: 4.4.3 -> 4.4.4
* [`6596f4f3`](https://github.com/NixOS/nixpkgs/commit/6596f4f3fd03e9fbe95b94bdddb21197c70171a6) python3Packages.drawille: 0.1.0 -> 0.2.0
* [`34a4ddbb`](https://github.com/NixOS/nixpkgs/commit/34a4ddbbee279b512eecda0e48369493291dff52) amarok: 3.1.0 -> 3.1.1
* [`b41b63b9`](https://github.com/NixOS/nixpkgs/commit/b41b63b99277846e2e750f2f4d0b9bb7a88b4e7a) dunst: nixfmt
* [`acc53aaa`](https://github.com/NixOS/nixpkgs/commit/acc53aaa5574bc1be8377e3ea7d081534283c150) pinniped: 0.33.0 -> 0.35.0
* [`1d9f567a`](https://github.com/NixOS/nixpkgs/commit/1d9f567adaf2c542a309de20257930e524c09ffd) dunst: add update script
* [`4604b01e`](https://github.com/NixOS/nixpkgs/commit/4604b01e795b3eb0218fd97857bb7074f2b63786) trunk: 0.21.1 -> 0.21.4
* [`1ded47e2`](https://github.com/NixOS/nixpkgs/commit/1ded47e2f231bb92de8fe143fa0acc75d0dc5ae0) dunst: 1.11.0 -> 1.12.0, update completions
* [`e33b3db8`](https://github.com/NixOS/nixpkgs/commit/e33b3db86050308043c6d76a079fdf73212d3e2a) dunst: remove `with lib;` and order `meta` attrs
* [`ed34e762`](https://github.com/NixOS/nixpkgs/commit/ed34e762c14ec92325b47a1c3971f41e439418d8) terraform-ls: 0.34.3 -> 0.36.0
* [`a8146de9`](https://github.com/NixOS/nixpkgs/commit/a8146de927f1bf57013e7412b39c6f50ffd512bb) rocksdb: 9.7.3 -> 9.7.4
* [`97daa1b5`](https://github.com/NixOS/nixpkgs/commit/97daa1b55daf4e7bba90d634617e26ad58687fdb) ocamlPackages.eliom: 11.0.1 -> 11.1.0
* [`9a035ad1`](https://github.com/NixOS/nixpkgs/commit/9a035ad14a35b57c782e0b656c4f6090564a1800) srgn: 0.13.3 -> 0.13.4
* [`3b23ec6d`](https://github.com/NixOS/nixpkgs/commit/3b23ec6d6004e96e5b06b1496f8fa9c17490b239) istioctl: 1.23.2 -> 1.24.1
* [`35fd31cf`](https://github.com/NixOS/nixpkgs/commit/35fd31cfc5b37d48297dd6e9f301cee338996c2c) zef: 0.22.4 -> 0.22.6
* [`ceb975a7`](https://github.com/NixOS/nixpkgs/commit/ceb975a766fa7e28b362d48fc40477eceac8d7aa) fluidd: 1.30.5 -> 1.31.0
* [`3114309b`](https://github.com/NixOS/nixpkgs/commit/3114309b65106578e4d97f957e75dd68e4481020) argocd: 2.12.6 -> 2.13.1
* [`5d3907df`](https://github.com/NixOS/nixpkgs/commit/5d3907df24a15ac6aabd1e7654d5f47e959438fb) ocamlPackages.lacaml: 11.0.10 -> 11.1.0
* [`43afe45c`](https://github.com/NixOS/nixpkgs/commit/43afe45c4a8279a0e0df11ca17179987bc45c30e) skim: format with nixfmt
* [`38383e40`](https://github.com/NixOS/nixpkgs/commit/38383e40957f955e7fcb31a6a4b0f1063b98df9e) skim: modernize
* [`8e1248bd`](https://github.com/NixOS/nixpkgs/commit/8e1248bdd745f05c1e7b2b79efe9f7b116d37c2e) skim: 0.10.4 -> 0.15.0
* [`6f34fc5d`](https://github.com/NixOS/nixpkgs/commit/6f34fc5d4ecf8f57c2a2f573a34b71f188485513) skim: add getchoo to maintainers
* [`1e658170`](https://github.com/NixOS/nixpkgs/commit/1e658170c88fdf9ed9e6a4240874dad7aaf39a4d) skim: add version test
* [`6df5a2ea`](https://github.com/NixOS/nixpkgs/commit/6df5a2eade5d0bc10a99beafe24d0ec9af11b91b) nomnatong: 5.12 -> 5.13
* [`ca3f599c`](https://github.com/NixOS/nixpkgs/commit/ca3f599cc0483bf5ffa79fea371cc429856052fb) maintainers: add paschoal
* [`f05b34d3`](https://github.com/NixOS/nixpkgs/commit/f05b34d39c9706ca9af6d52a6a7ef7f9062be148) pyfa: 2.60.2 -> 2.61.0
* [`11455592`](https://github.com/NixOS/nixpkgs/commit/1145559288b88cb0180e0b1204752da9ee4b9dd9) sbt-with-scala-native: 1.10.2 -> 1.10.6
* [`755454e1`](https://github.com/NixOS/nixpkgs/commit/755454e1025bf8741726c052866df6da05aa48df) hermitcli: 0.40.0 -> 0.41.0
* [`9345d630`](https://github.com/NixOS/nixpkgs/commit/9345d630c5ed1f5ed7ea6e4b8d34ee7a4c3eaf30) pifpaf: 3.2.1 -> 3.2.3
* [`1ef196fd`](https://github.com/NixOS/nixpkgs/commit/1ef196fd22b92cc138e215aad48ce654d3597392) clipboard-jh: 0.9.1 -> 0.10.0
* [`7d6602e7`](https://github.com/NixOS/nixpkgs/commit/7d6602e7def39245fa868d1eb99f3a6fc05db149) etc-overlay: mount the metadata image read-only
* [`ce1f649c`](https://github.com/NixOS/nixpkgs/commit/ce1f649ca1857a2fb822ccd68beabf133c3c699b) mark: 11.2.0 -> 11.3.0
* [`8d2f5822`](https://github.com/NixOS/nixpkgs/commit/8d2f58226f558605bcefe3d601098529aa5acfaa) ruplacer: 0.9.0 -> 0.10.0
* [`b7fe3f43`](https://github.com/NixOS/nixpkgs/commit/b7fe3f437abd1ef367bcb0d5f419f7111ffe4f9f) procs: 0.14.7 -> 0.14.8
* [`2e396331`](https://github.com/NixOS/nixpkgs/commit/2e3963313561f38973436f0599e1ee871451eb3d) kubebuilder: 4.3.0 -> 4.3.1
* [`849a0f10`](https://github.com/NixOS/nixpkgs/commit/849a0f105f8cdf2086b3f68563e98d9b90716f3d) sendme: 0.18.0 -> 0.19.0
* [`62c8b993`](https://github.com/NixOS/nixpkgs/commit/62c8b9930df836a22ef7825210978845874d5d9b) dumbpipe: 0.18.0 -> 0.20.0
* [`6873a4d1`](https://github.com/NixOS/nixpkgs/commit/6873a4d1bfc3c8838a75f1c7637a0406bd13b487) fn-cli: 0.6.35 -> 0.6.36
* [`fb3b671d`](https://github.com/NixOS/nixpkgs/commit/fb3b671d0dedb721ec5e2073033a6ee3256165a4) dqlite: 1.16.7 -> 1.18.0
* [`ab4ab7b3`](https://github.com/NixOS/nixpkgs/commit/ab4ab7b35cbb208537b8b3f3c092cfefa0788472) cbconvert: use versionCheckHook
* [`3d1b701d`](https://github.com/NixOS/nixpkgs/commit/3d1b701d1177dc2fbe74e279118b52c92b981689) calamares-nixos: 3.3.10 -> 3.3.12
* [`1532d55f`](https://github.com/NixOS/nixpkgs/commit/1532d55fed2dfe95a6c07f2a8ed7d820e6742af0) calamares: 3.3.10 -> 3.3.12
* [`5c21bdb9`](https://github.com/NixOS/nixpkgs/commit/5c21bdb944e776bb8235faa00e556c497cd02de8) kubernetes-polaris: 9.5.0 -> 9.6.0
* [`5a5a45bb`](https://github.com/NixOS/nixpkgs/commit/5a5a45bbef404d919e3ba757c6adab8734660f20) converseen: 0.12.2.3 -> 0.12.2.4
* [`6645789a`](https://github.com/NixOS/nixpkgs/commit/6645789addf4ae7a2e89c384b003e4e8b8410ac2) coursier: 2.1.14 -> 2.1.19
* [`de9c3b95`](https://github.com/NixOS/nixpkgs/commit/de9c3b95581e9cc7bfd58f989eb27a04d6a3b0ed) openrefine: 3.8.5 -> 3.8.7
* [`11a186e0`](https://github.com/NixOS/nixpkgs/commit/11a186e0263cba6cf7d58dcd1aeb174c32f969e3) yadm: 3.2.2 -> 3.3.0
* [`a5046d85`](https://github.com/NixOS/nixpkgs/commit/a5046d85f78eb144522919b7e8da91f300865865) cadaver: 0.24 -> 0.26
* [`1bd6c312`](https://github.com/NixOS/nixpkgs/commit/1bd6c312a50fbb5432f87626e04753e57156efc1) libowfat: 0.33 -> 0.34
* [`edf7918e`](https://github.com/NixOS/nixpkgs/commit/edf7918e697ac031c9893658b2b11bce1cc25994) likwid: 5.3.0 -> 5.4.0
* [`0f43a759`](https://github.com/NixOS/nixpkgs/commit/0f43a759dd38ef96560c59c8a11273c8147014cd) booster: 0.11 -> 0.12
* [`e494b8a7`](https://github.com/NixOS/nixpkgs/commit/e494b8a7ea91d658cd22d7745e5603909f2f7a97) yabasic: 2.90.4 -> 2.90.5
* [`6f5bfa04`](https://github.com/NixOS/nixpkgs/commit/6f5bfa0416e68bb81b56f1b019c1a4b8200620b7) davfs2: 1.7.0 -> 1.7.1
* [`1751934f`](https://github.com/NixOS/nixpkgs/commit/1751934f580ef5fc06286095160f5d9b56ce303a) kaffeine: 2.0.18 -> 2.0.19
* [`dbbb288f`](https://github.com/NixOS/nixpkgs/commit/dbbb288fe155049552094c50fa9c9d1d62e792bd) throttled: 0.10.0 -> 0.11
* [`4230118f`](https://github.com/NixOS/nixpkgs/commit/4230118f13f6c7247a1b54a886aa7e5a2471d355) corosync: 3.1.8 -> 3.1.9
* [`244e595e`](https://github.com/NixOS/nixpkgs/commit/244e595e0bf0a6a1cdbc2e6e1caf4410d99cce9f) lnav: add prql support
* [`0111d0a2`](https://github.com/NixOS/nixpkgs/commit/0111d0a26494169b7ddb9550a9ead930ba441e7e) siege: 4.1.6 -> 4.1.7
* [`54d12a30`](https://github.com/NixOS/nixpkgs/commit/54d12a3009bd9f34c0e0669dae469dced0cbfbd1) valentina: 0.7.52 -> 0.7.53
* [`014764ff`](https://github.com/NixOS/nixpkgs/commit/014764ffc9935c91e0813553f13c649ab81b3363) cbconvert-gui: install icon to correct directory
* [`6f1a52d0`](https://github.com/NixOS/nixpkgs/commit/6f1a52d0bffb982f42e7aa0e5f3fdeae680c5996) hugin: 2023.0.0 -> 2024.0.1
* [`d9fa748b`](https://github.com/NixOS/nixpkgs/commit/d9fa748b6ed361f3b6dde160eca14775709d50b5) swaysome: 2.1.1 -> 2.1.2
* [`1a6c959a`](https://github.com/NixOS/nixpkgs/commit/1a6c959ae8d21fd6778b72023bdbecf289c71f65) tqsl: 2.7.3 -> 2.7.5
* [`d76b9ce3`](https://github.com/NixOS/nixpkgs/commit/d76b9ce33bee8953c8f395931f78fb4f488d928d) lnav: guard gpm behind isDarwin
* [`ea21ccf6`](https://github.com/NixOS/nixpkgs/commit/ea21ccf67c95ce01d9cb159d28d65d91077bd65b) lnav: add pcasaretto as mantainer
* [`345ee0e6`](https://github.com/NixOS/nixpkgs/commit/345ee0e6ca177e87866ea59bb06c205c9d90a5da) factorio: 2.0.22 -> 2.0.23
* [`60fd285f`](https://github.com/NixOS/nixpkgs/commit/60fd285fa927864f3bd32c3edea39ab07c65ac1c) wcslib: 8.3 -> 8.4
* [`32bc7979`](https://github.com/NixOS/nixpkgs/commit/32bc7979db9c6213cb52d2518a59da5c8161f80e) eid-mw: 5.1.19 -> 5.1.21
* [`72886718`](https://github.com/NixOS/nixpkgs/commit/72886718d423c0a5500783547af6453d35c8f95b) genymotion: 3.7.1 -> 3.8.0
* [`2b34cf87`](https://github.com/NixOS/nixpkgs/commit/2b34cf87ca90afcc25e1314dc54d180bb88689b1) uwsgi: 2.0.27 -> 2.0.28
* [`903e726b`](https://github.com/NixOS/nixpkgs/commit/903e726bccc1663f077944497e438de14cc86b72) xmedcon: 0.24.0 -> 0.24.1
* [`280444e1`](https://github.com/NixOS/nixpkgs/commit/280444e1a772e9ff9a938ec8dcbebb1915a0577f) gwyddion: 2.66 -> 2.67
* [`90a02412`](https://github.com/NixOS/nixpkgs/commit/90a02412dcfc9fdb5c0197597f8fea062d23dea1) keepalived: 2.3.1 -> 2.3.2
* [`328b7232`](https://github.com/NixOS/nixpkgs/commit/328b7232f8c0f73e2b6cd6b5e1e7aed8cb23441e) fiji: 20240614-2117 -> 20241114-1317
* [`773ad53e`](https://github.com/NixOS/nixpkgs/commit/773ad53e66fdf630e0e779255fe2b7a188e97874) debianutils: 5.20 -> 5.21
* [`2f73a222`](https://github.com/NixOS/nixpkgs/commit/2f73a2225a8b3d17ed2ee9b5ffe6a7670424fdf1) hsqldb: 2.7.3 -> 2.7.4
* [`8a70db7d`](https://github.com/NixOS/nixpkgs/commit/8a70db7dc9b8290b20c095107949acb19ea79004) mmsd-tng: 2.6.1 -> 2.6.2
* [`5de0ac5f`](https://github.com/NixOS/nixpkgs/commit/5de0ac5f3814155ad21ec5f316e11a12c009337a) inform6: 6.42-r4 -> 6.42-r6
* [`93f1d4bf`](https://github.com/NixOS/nixpkgs/commit/93f1d4bf602e05adbdc45e1b380eff83419d017a) java-service-wrapper: 3.5.59 -> 3.5.60
* [`c0efae75`](https://github.com/NixOS/nixpkgs/commit/c0efae7559d542575a40a3627e660679f5cb1c39) nixos/librenms: add default php_memory_limit and use it in cronjobs
* [`c59a8279`](https://github.com/NixOS/nixpkgs/commit/c59a8279ae97372f08400657ce174fa155a79437) nixos/librenms: add enableLocalBilling option
* [`4bac8c5d`](https://github.com/NixOS/nixpkgs/commit/4bac8c5de59aab1ddb5f6482a59f6b3d0d517e0c) nixos/librenms: fix links in docs
* [`7e2f76a1`](https://github.com/NixOS/nixpkgs/commit/7e2f76a187ee9193d1fe2917b780adeab736370e) nixos/librenms: add netali to maintainers
* [`2c1b3076`](https://github.com/NixOS/nixpkgs/commit/2c1b30762bda29c16002758485879f6713bfead9) keycloak: 26.0.6 -> 26.0.7
* [`95ffb22b`](https://github.com/NixOS/nixpkgs/commit/95ffb22b2660e311159f7243793c8216810770a1) shotcut: 24.10.13 -> 24.11.17
* [`3398fff9`](https://github.com/NixOS/nixpkgs/commit/3398fff9b8aee3baf962d195a21c91e89d37b6c3) linuxPackages.lkrg: use finalAttrs pattern
* [`5dca7395`](https://github.com/NixOS/nixpkgs/commit/5dca7395b70fc36491b5accf21159c62097060b1) linuxPackages.lkrg: 0.9.5 -> 0.9.9
* [`ba3f758e`](https://github.com/NixOS/nixpkgs/commit/ba3f758e65512abec53fd5dbe47e63bf0abc4d97) lutris: 0.5.17 -> 0.5.18
* [`f075ed99`](https://github.com/NixOS/nixpkgs/commit/f075ed9905be79061d9e75f66c80ebfe65817bdb) open-web-calendar: 1.41 -> 1.42
* [`3ee82eb5`](https://github.com/NixOS/nixpkgs/commit/3ee82eb5b43829fd7396a3712dfbdce67acef803) nifi: 1.28.0 -> 1.28.1
* [`ec381eaa`](https://github.com/NixOS/nixpkgs/commit/ec381eaaddbe7f1d3ed6c53698d4177ec856253d) linuxPackages.corefreq: 1.98.4 -> 1.98.7
* [`f6616c8d`](https://github.com/NixOS/nixpkgs/commit/f6616c8d8fda2d6528f3b1558ca0be3d88098ac0) rsyslog-light: 8.2408.0 -> 8.2412.0
* [`7bd66051`](https://github.com/NixOS/nixpkgs/commit/7bd66051d588ec5f188a07ecda0f7cdb55768437) cargonode: init at 0.1.2
* [`8d14b766`](https://github.com/NixOS/nixpkgs/commit/8d14b76691ffbb72aa0d74ca623686d994655e0c) maintainers: add xosnrdev
* [`c353ff94`](https://github.com/NixOS/nixpkgs/commit/c353ff94025bc23bd4a1124fbc36ec21ebaeee52) ch9344: 2.0 -> 0-unstable-2024-11-15
* [`131ac24c`](https://github.com/NixOS/nixpkgs/commit/131ac24ca77420c465ff60e67e29dbed3e5a5f4d) conda: format
* [`3b413d30`](https://github.com/NixOS/nixpkgs/commit/3b413d302ee8b4a293debde1e2a3ec9604accaae) conda: 4.11.0 -> 24.9.2
* [`9b5546a0`](https://github.com/NixOS/nixpkgs/commit/9b5546a02f0129eb03a1447f28ef1a307a1e93ac) systemd-netlogd: 1.4.2 -> 1.4.3
* [`f4cffd1e`](https://github.com/NixOS/nixpkgs/commit/f4cffd1e27a92b66434b0d740a45afcca8181f28) python312Packages.nskeyedunarchiver: 1.2 -> 1.5
* [`82747d8f`](https://github.com/NixOS/nixpkgs/commit/82747d8fa78daad064914006a855cc1dc9a85ab8) catppuccin-cursors: 1.0.1 -> 1.0.2
* [`610fbeeb`](https://github.com/NixOS/nixpkgs/commit/610fbeeb141fad3a7d5680b0ef37251c368f28ac) hmcl: 3.5.9 -> 3.6.11
* [`be22744b`](https://github.com/NixOS/nixpkgs/commit/be22744b029e39454216555a9eb409fcb2c1bebd) python312Packages.stevedore: 5.3.0 -> 5.4.0
* [`0462ffbc`](https://github.com/NixOS/nixpkgs/commit/0462ffbc3070ac9245189688feed9ded1100f6da) nexusmods-app: fix passthru tests
* [`a95c46c8`](https://github.com/NixOS/nixpkgs/commit/a95c46c801805ed49a1414ed350bab078e0f3637) emulationstation-de: 3.0.2 -> 3.1.0
* [`1c4e83df`](https://github.com/NixOS/nixpkgs/commit/1c4e83df052d1a3a8b31414a5bf9250a7973c924) telegram-desktop: 5.8.2 -> 5.9.0
* [`89b7c3c5`](https://github.com/NixOS/nixpkgs/commit/89b7c3c57a24b40cc4b3264228c8dc8582be606b) tonelib-gfx: 4.8.5 -> 4.8.7
* [`4467161b`](https://github.com/NixOS/nixpkgs/commit/4467161b8c744a6f9ab65208ff184d061063e529) ps3-disc-dumper: nixfmt
* [`5e5bb325`](https://github.com/NixOS/nixpkgs/commit/5e5bb325965c2905185a26decf1e41ddc4012403) tdf: add darwin support
* [`08d91861`](https://github.com/NixOS/nixpkgs/commit/08d9186163ff564e4520f25edda8ceb0d4610ac5) tdf: add DieracDelta as maintainer
* [`ad464e05`](https://github.com/NixOS/nixpkgs/commit/ad464e054a1940d8b5fa1a9e312d05226c3a576e) tdf: unstable-2024-10-09 -> 0.2.0
* [`dfea47c4`](https://github.com/NixOS/nixpkgs/commit/dfea47c4019100368972779f9e376043346b9e9e) tdf: formatting
* [`1a782781`](https://github.com/NixOS/nixpkgs/commit/1a7827817004f9e9daee8ede5561fb895e6a2c76) bitwig-studio: fix MIDI input
* [`f4be7b83`](https://github.com/NixOS/nixpkgs/commit/f4be7b83f15447ff536269e88baf5218d9ad6047) _010editor: init at 15.0.1
* [`e5bd86b7`](https://github.com/NixOS/nixpkgs/commit/e5bd86b7518c0cd40f82ae3cca4b131c4db053f7) maintainers: Add jiriks74
* [`b99d2547`](https://github.com/NixOS/nixpkgs/commit/b99d25476da519644a277d3315f8852dede83451) sydbox: 3.28.3 -> 3.29.4
* [`6a22a70f`](https://github.com/NixOS/nixpkgs/commit/6a22a70fb59dbbb6e3280b0e8ad1c573aa33af05) arduino-ide: 2.3.3 -> 2.3.4
* [`8675dc30`](https://github.com/NixOS/nixpkgs/commit/8675dc301fac038d7c95f89ecb9483b95fce61d5) slimevr-server: init at 0.13.2
* [`96091878`](https://github.com/NixOS/nixpkgs/commit/960918782887aee5c7ae1044cd4be134d509ddd9) vscode-extensions.wakatime.vscode-wakatime: 24.2.0 -> 24.7.2
* [`2bc4425f`](https://github.com/NixOS/nixpkgs/commit/2bc4425f7f991c3a134e1f9634c9d25e0b2625ef) libinput-gestures: 2.77 -> 2.78
* [`a8c245be`](https://github.com/NixOS/nixpkgs/commit/a8c245be4ffd44a0dbc43bbafaba16f24bb37df5) opensmtpd: 7.5.0p0 -> 7.6.0p1
* [`3ffe8911`](https://github.com/NixOS/nixpkgs/commit/3ffe8911e0b1c777f6f4794b89e820bec234d783) xlockmore: 5.80 -> 5.81
* [`8f55d7c9`](https://github.com/NixOS/nixpkgs/commit/8f55d7c961adfe8557363573c1365e477021c0b8) neo4j-desktop: 1.5.9 -> 1.6.0
* [`e0d8523b`](https://github.com/NixOS/nixpkgs/commit/e0d8523bec9cc49aac1f4a88dd404545ce41478c) gcompris: 4.2 -> 4.3
* [`7e5388a6`](https://github.com/NixOS/nixpkgs/commit/7e5388a61796aab6132d620fe444781817d16e4b) pgpool: 4.5.4 -> 4.5.5
* [`c14e5b2e`](https://github.com/NixOS/nixpkgs/commit/c14e5b2e9e82251aba588319635b0a9485b79cdf) vpl-gpu-rt: 24.3.3 -> 24.4.3
* [`b211fc88`](https://github.com/NixOS/nixpkgs/commit/b211fc881d22c15f8da8678e8e0e9128163978d3) deja-dup: 46.1 -> 47.0
* [`eb28ce3c`](https://github.com/NixOS/nixpkgs/commit/eb28ce3cdca462d0c03052c54982cb0030643ee1) zabbix-agent2-plugin-postgresql: 7.0.4 -> 7.0.6
* [`0d6139a4`](https://github.com/NixOS/nixpkgs/commit/0d6139a4bb2e40508debb11da88469ce9b49bcc9) apacheHttpd: fix shebangs in cross-compiled apxs output
* [`8352beba`](https://github.com/NixOS/nixpkgs/commit/8352beba6751169e8b11f987a06381adfd6eb065) apacheHttpdPackages.mod_dnssd: fix cross compilation
* [`0e9fa534`](https://github.com/NixOS/nixpkgs/commit/0e9fa53445b9eba390c0f8c3d855ee770482e41c) nixos/plasma5: fix shellcheck findings with enableStrictShellChecks enabled
* [`f6cdce03`](https://github.com/NixOS/nixpkgs/commit/f6cdce0397d0e3440e60ac2bc8ef745b9244b49e) bootstrap-studio: 6.7.3 -> 7.0.0
* [`b521c0c6`](https://github.com/NixOS/nixpkgs/commit/b521c0c6bd11e259fb52e6eee538c355f177d2f4) nixos-rebuild-ng: add --builders as common_build_flags
* [`916d65a2`](https://github.com/NixOS/nixpkgs/commit/916d65a2d022c739c0117f29d845243abbf6014d) nixos-rebuild-ng: add shell completion via shtab
* [`68a10822`](https://github.com/NixOS/nixpkgs/commit/68a1082234b117eed774134d77cb68752a3006ec) nixos-rebuild-ng: add proper manpage using scd format
* [`a987599a`](https://github.com/NixOS/nixpkgs/commit/a987599ac134668cdcf3664e4433d7c370b4e627) nixos-rebuild-ng: simplify build options
* [`da566994`](https://github.com/NixOS/nixpkgs/commit/da566994eac60d23e9be0c9dc3116722e9f0a5a8) nixos-rebuild-ng: enable shell files by default
* [`ae7292ec`](https://github.com/NixOS/nixpkgs/commit/ae7292ec50746f1fdfb4c27aee75034333ff6148) sqlcl: 24.3.0.285.0530 -> 24.3.2.330.1718
* [`22fefb30`](https://github.com/NixOS/nixpkgs/commit/22fefb3059510716e79ef10a80a879122fe85a97) dpkg: 1.22.10 -> 1.22.11
* [`9e049841`](https://github.com/NixOS/nixpkgs/commit/9e0498419864168b9ce8df973ff35f9dc25e939e) virtiofsd: 1.12.0 -> 1.13.0
* [`376975bd`](https://github.com/NixOS/nixpkgs/commit/376975bdf66459d5d6b9fb5a7fd97764a3de6a33) arrpc: format
* [`a611045f`](https://github.com/NixOS/nixpkgs/commit/a611045f3df0b851b4b02507605b0dde002434f6) arrpc: 3.4.0 -> 3.5.0; add systemd user service
* [`9dcb0c5d`](https://github.com/NixOS/nixpkgs/commit/9dcb0c5ddae42f90eaff1381b9131f71a462332c) drm_info: move to by-name, adopt, format
* [`54dcafdd`](https://github.com/NixOS/nixpkgs/commit/54dcafdd31156931b09e37765444410bc7e46a20) drm_info: 2.3.0 -> 2.7.0
* [`3a496888`](https://github.com/NixOS/nixpkgs/commit/3a4968884a2471d87096052554f1c16bf2bbe941) opera: 114.0.5282.102 -> 115.0.5322.77
* [`d7c4d4ac`](https://github.com/NixOS/nixpkgs/commit/d7c4d4acad13462f716579897006e3c0faeac6f6) isabelle: fix darwin build
* [`1ff76edc`](https://github.com/NixOS/nixpkgs/commit/1ff76edc0aeb17d602f156aa52ba3e7e98bf1592) datovka: 4.24.1 -> 4.24.2
* [`2843169b`](https://github.com/NixOS/nixpkgs/commit/2843169b006a16a0237f933369c9752d887b04be) cargo-modules: 0.19.1 -> 0.20.2
* [`2a6b716f`](https://github.com/NixOS/nixpkgs/commit/2a6b716fb4ec7d8ae07b9f40cd1cca6b7ec8b62f) ArchiSteamFarm: 6.0.8.7 -> 6.1.0.3
* [`0cd0e98d`](https://github.com/NixOS/nixpkgs/commit/0cd0e98df198949f7c12cd3e65a703a5d51d9aee) kikoplay: init at 0-unstable-2018-03-22
* [`e2139b90`](https://github.com/NixOS/nixpkgs/commit/e2139b903b78488b2857445545f655c7c818561d) nixos/rtkit: Add option for rtkit-daemon command-line args
* [`686c2c3d`](https://github.com/NixOS/nixpkgs/commit/686c2c3d0059f459861137829f5e50f3a954cf13) nixos/rtkit: Add tests
* [`f286fa79`](https://github.com/NixOS/nixpkgs/commit/f286fa79470c9af0ef0ae8e9905f9c6bdf56a224) ieda: init at 0-unstable-2024-10-11
* [`bdc67dec`](https://github.com/NixOS/nixpkgs/commit/bdc67dec2470d793cc021cb85c6b73f56a188f5c) spotlight-downloader: init at 1.5.0
* [`7da51622`](https://github.com/NixOS/nixpkgs/commit/7da5162201ba9efe46923806273da28ec0dc41d5) eccodes: 2.36.0 -> 2.39.0
* [`c933df87`](https://github.com/NixOS/nixpkgs/commit/c933df874ca07b89b9d0c6501dd895e181d8b8a3) grip-grab: init at 0.6.7
* [`8a693f4e`](https://github.com/NixOS/nixpkgs/commit/8a693f4e59afb129286c72d370c2b02afc5e3f7f) xfsprogs: 6.11.0 -> 6.12.0
* [`bd200697`](https://github.com/NixOS/nixpkgs/commit/bd200697e9d95ae0c0dacedaa4813ccde2e1d8db) nixos-rebuild-ng: show help when manpage is disabled
* [`f59f2dab`](https://github.com/NixOS/nixpkgs/commit/f59f2daba3d5b7f4e7dd00132a7e013864975d88) ocamlPackages.mirage-crypto-rng-eio: init at 1.1.0
* [`6bf2358f`](https://github.com/NixOS/nixpkgs/commit/6bf2358f4a11cc89563d79a55af75ac2b81ccf8d) simdjson: 3.10.1 -> 3.11.0
* [`4e2aca60`](https://github.com/NixOS/nixpkgs/commit/4e2aca60518270c3dc9a5e337fbcdfae061cf402) pulumi-esc: 0.11.0 -> 0.11.1
* [`0460a361`](https://github.com/NixOS/nixpkgs/commit/0460a36177109072b4d3278090bd736ca638ed6c) python312Packages.dbt-core: 1.8.8 -> 1.8.9
* [`0a0f73bb`](https://github.com/NixOS/nixpkgs/commit/0a0f73bbe90282740b51d9d5e9b2dee86859dc49) cargo-crev: 0.25.11 -> 0.26.2
* [`c71e8a26`](https://github.com/NixOS/nixpkgs/commit/c71e8a269d2e8dfc68137bcbe941a92ec065bb3b) linuxPackages.virtio_vmmci: 0.6.0 -> 0.6.2
* [`b7bf4060`](https://github.com/NixOS/nixpkgs/commit/b7bf4060216fe8bc200ee4f086b2fd600eaf2e53) zfs_2_1: 2.1.15 -> 2.1.16
* [`cda16d0f`](https://github.com/NixOS/nixpkgs/commit/cda16d0f128a106b04c84696dbce2aafe6a11dec) verifast: 24.08.30 -> 24.12
* [`d42959a3`](https://github.com/NixOS/nixpkgs/commit/d42959a3c60ee5b344709b2b2e68fb188ec99a11) nix-snapshotter: 0.2.0 -> 0.2.1
* [`0d7c5153`](https://github.com/NixOS/nixpkgs/commit/0d7c515332cac9439581da6ffd9f83919edf17d7) waagent: init module
* [`6a2505c7`](https://github.com/NixOS/nixpkgs/commit/6a2505c7f83a22a8e1e6c61541175d28d0c06985) ktlint: 1.4.0 -> 1.5.0
* [`39a2d79b`](https://github.com/NixOS/nixpkgs/commit/39a2d79b95bbaed04c9c125051dab1a686540739) calibre: 7.21.0 -> 7.22.0
* [`09652483`](https://github.com/NixOS/nixpkgs/commit/096524834163096b1df1149599afe0248b14a6b1) gvproxy: 0.8.0 -> 0.8.1
* [`ddf76258`](https://github.com/NixOS/nixpkgs/commit/ddf76258622ba9e4a1209b099702f9bf7ef7f40a) dra-cla: 0-unstable-2024-06-07 -> 3.0.5
* [`98863967`](https://github.com/NixOS/nixpkgs/commit/9886396715863e85f438952d20a69944e9ac0dcc) python312Packages.strawberry-graphql: 0.251.0 -> 0.253.1
* [`b107d298`](https://github.com/NixOS/nixpkgs/commit/b107d298872601fe35151dae442ace51b5a3a986) sby: 0.46 -> 0.47
* [`ab7512fb`](https://github.com/NixOS/nixpkgs/commit/ab7512fbba738ffdd75cc7d2f1fd99ef7ab07050) git-town: 16.4.1 -> 16.7.0
* [`e0431c7d`](https://github.com/NixOS/nixpkgs/commit/e0431c7d4f74d61eeb245f0a1f6bc946b6bf5173) tcount: init at 0-unstable-2023-04-20
* [`1c4001f9`](https://github.com/NixOS/nixpkgs/commit/1c4001f9cbb52de31412ab52b3951551a4ae007e) cplex: set meta.mainProgram
* [`1f75f5cd`](https://github.com/NixOS/nixpkgs/commit/1f75f5cd8092b6dd7216be9dd5d2793e99e5d0b5) cplex: fix phase hooks
* [`b4826414`](https://github.com/NixOS/nixpkgs/commit/b48264149acecc5b4e43679d0c758f70e874c387) cplex: move doc and license to share, remove uninstall dir
* [`e5e58788`](https://github.com/NixOS/nixpkgs/commit/e5e587880922d00fa025d5b1d13f3fd55577ba9c) cplex: install desktop entry
* [`9351aae4`](https://github.com/NixOS/nixpkgs/commit/9351aae45269f888708711d25e2fd8e60a7a7e7c) cplex: put openjdk in nativeBuildInputs
* [`a4f8586a`](https://github.com/NixOS/nixpkgs/commit/a4f8586a70208c5c579d80dea03910f91771bd86) cplex: use autoPatchelfHook
* [`7c3295ab`](https://github.com/NixOS/nixpkgs/commit/7c3295abd5bcce3fd9570d59dbd64898bbb5826c) cplex: use makeWrapper instead of wrapProgram
* [`2df4affe`](https://github.com/NixOS/nixpkgs/commit/2df4affe417a3a822fc7688f925c766a9aa1d7bc) cplex: fix oplide
* [`e7db63fb`](https://github.com/NixOS/nixpkgs/commit/e7db63fb2c1188bb0ad99040a28380662f185573) cplex: fix file permissions
* [`5627b82b`](https://github.com/NixOS/nixpkgs/commit/5627b82bfb402ce7cac79516f3ff26fb23f8f24f) pkgsite: init at 0-unstable-2024-12-06
* [`54c06b3a`](https://github.com/NixOS/nixpkgs/commit/54c06b3aa66af1dc87f9935bb1bef1fb075d5264) vtfedit: init at 1.3.3
* [`4b5e0204`](https://github.com/NixOS/nixpkgs/commit/4b5e02043f6963344b2aaa49796d8942628d5fed) nixos/archisteamfarm: add mincore to SystemCallFilter
* [`93a5e4a3`](https://github.com/NixOS/nixpkgs/commit/93a5e4a31a80af5c6f635181b70aadf9ff14ea96) sonarr: 4.0.10.2544 -> 4.0.11.2680
* [`23211d6b`](https://github.com/NixOS/nixpkgs/commit/23211d6b59d897f4d6686e139269de0a8c002848) python3Packages.django-mfa3: Enable failing test
* [`cc899859`](https://github.com/NixOS/nixpkgs/commit/cc899859d834a2ec990593b5472beb4a45d22ac0) pocketbase: 0.23.1 -> 0.23.4
* [`f06a63da`](https://github.com/NixOS/nixpkgs/commit/f06a63dac5adb11910b6d52e01fb628a7ed72435) eddie: init at 2.24.4
* [`ebbdb619`](https://github.com/NixOS/nixpkgs/commit/ebbdb619354b4cf23ddddb0410b311a38faf702e) fix dhcpcd when ipv6 is disabled
* [`a61c5e48`](https://github.com/NixOS/nixpkgs/commit/a61c5e4851f0b8cdf9a41e940b0f56bb4af8812f) rustic: 0.9.4 -> 0.9.5
* [`60ea1e34`](https://github.com/NixOS/nixpkgs/commit/60ea1e34e590b2e43696147f685e7c9864493c79) gnome-secrets: 9.6 -> 10.3
* [`29313f73`](https://github.com/NixOS/nixpkgs/commit/29313f73725ee1263ca0debb4643d44bf13045b3) openjph: 0.17.0 -> 0.18.1
* [`9df16629`](https://github.com/NixOS/nixpkgs/commit/9df16629a5bb221df59bb8d070076d6f8968a476) mpvScripts.mpv-playlistmanager: 0-unstable-2024-08-17 -> 0-unstable-2024-11-19
* [`ecbf38cf`](https://github.com/NixOS/nixpkgs/commit/ecbf38cf9a27da6ca2a3eacb579f1090fe3dc312) cargo-temp: 0.2.22 -> 0.3.0
* [`405afd3e`](https://github.com/NixOS/nixpkgs/commit/405afd3e1b7194927b0a741661c392a585547724) scotch: 7.0.5 -> 7.0.6
* [`e99f4a48`](https://github.com/NixOS/nixpkgs/commit/e99f4a48af9d309e6e0dec3d619649d4dd81d6b6) devbox: 0.13.6 -> 0.13.7
* [`448b2e3a`](https://github.com/NixOS/nixpkgs/commit/448b2e3a7518a221aacd9d27532f9da652dfed21) gimpPlugins.bimp: fix darwin build
* [`a7140ff3`](https://github.com/NixOS/nixpkgs/commit/a7140ff3f09450f41454b00b57e02ea30c0506e3) gimpPlugins.gap: fix aarch64-linux build
* [`a86e263b`](https://github.com/NixOS/nixpkgs/commit/a86e263b9538fac60fc0838506a08e6519fc5fc2) gimpPlugins.gap: mark as linux-only
* [`cc039e71`](https://github.com/NixOS/nixpkgs/commit/cc039e714bc41e995385be31a24f9c67c2168556) crun: 1.18.2 -> 1.19
* [`3073067b`](https://github.com/NixOS/nixpkgs/commit/3073067bd68c4ae54bbcd1103cd1b81629d68fd8) gaugePlugins.java: 0.11.1 -> 0.11.2
* [`a5314161`](https://github.com/NixOS/nixpkgs/commit/a53141618fba1baad5e7c40b8d67153a193cf6d7) gaugePlugins.dotnet: 0.7.2 -> 0.7.3
* [`6730b6f2`](https://github.com/NixOS/nixpkgs/commit/6730b6f273f4fa04eac7582504f86904af996741) formiko: 1.4.3 -> 1.5.0
* [`486f034b`](https://github.com/NixOS/nixpkgs/commit/486f034b93f3436aa6cc5c26fae87557fc274e78) lefthook: 1.8.1 -> 1.9.0
* [`45691701`](https://github.com/NixOS/nixpkgs/commit/45691701c3810953020ce2df2de8db03f726b6d3) pam: Use freebsd.pam on FreeBSD
* [`ce33e20a`](https://github.com/NixOS/nixpkgs/commit/ce33e20a03de383dea7d04ec5680d342a8345493) fetchFromGitHub: expose tag argument
* [`940b0e9a`](https://github.com/NixOS/nixpkgs/commit/940b0e9a7123da7f4eb71329be13958f7767ba88) uxn: 1.0-unstable-2024-10-19 -> 1.0-unstable-2024-11-30
* [`8d180bf8`](https://github.com/NixOS/nixpkgs/commit/8d180bf83cdb67549e5b5fdb911d3ad5fbb87a3b) opentelemetry-collector-builder: 0.114.0 -> 0.115.0
* [`8e58a347`](https://github.com/NixOS/nixpkgs/commit/8e58a34739caa629fd15e19c3d54c2fb4bc40d78) pyspread: 2.3 -> 2.3.1
* [`6b7dea8d`](https://github.com/NixOS/nixpkgs/commit/6b7dea8d871518447f2f613f622f0427cf98c179) peazip: 10.0.0 -> 10.1.0
* [`56091f1b`](https://github.com/NixOS/nixpkgs/commit/56091f1b7f6644ecb934ff6a5c4cc69ca64e3f5d) spicedb: 1.37.1 -> 1.38.1
* [`020924cb`](https://github.com/NixOS/nixpkgs/commit/020924cb8b423413a393238519452f84e03a2932) sopwith: 2.6.0 -> 2.7.0
* [`12fc3828`](https://github.com/NixOS/nixpkgs/commit/12fc38284352e4bad1cd6e0ecbcc6c30a92c6615) python312Packages.homematicip: 1.1.3 -> 1.1.4
* [`67ac4704`](https://github.com/NixOS/nixpkgs/commit/67ac470441d3137e7182d10f4923c5b2dc41dd71) alvr: 20.11.0 -> 20.11.1
* [`de031293`](https://github.com/NixOS/nixpkgs/commit/de031293aa0fa9042e2b643f8326e7fd4cd7f91b) flutter_rust_bridge_codegen: init a 2.6.0
* [`93c777ee`](https://github.com/NixOS/nixpkgs/commit/93c777ee940fe2a8b905ef6d7e86d8fc1864a39b) Fix zygote could not fork error
* [`1fe9bfe9`](https://github.com/NixOS/nixpkgs/commit/1fe9bfe98202e09bb83cba864bc231110954faa5) nixos-rebuild-ng: rename manual to nixos-rebuild
* [`556a52ac`](https://github.com/NixOS/nixpkgs/commit/556a52ac2718ba58bf27ed1ea89ebfd8b2508865) nixos-rebuild-ng: fix linter failures
* [`0f9ee1a6`](https://github.com/NixOS/nixpkgs/commit/0f9ee1a6519d51861a985152a9b737329d748f7a) jay: 1.5.0 -> 1.7.0
* [`ac689cc9`](https://github.com/NixOS/nixpkgs/commit/ac689cc9b23beeb61d52e232730fd658d5c6ba16) cargonode: refactor
* [`f389b242`](https://github.com/NixOS/nixpkgs/commit/f389b242fe58322cf5e45d77c062ec145687e6f9) nwjs-ffmpeg-prebuilt: 0.93.0 -> 0.94.0
* [`f90ef886`](https://github.com/NixOS/nixpkgs/commit/f90ef8864801fdf162309a9cc93015dc7c975ecb) python312Packages.peft: 0.13.2 -> 0.14.0
* [`6c19ad49`](https://github.com/NixOS/nixpkgs/commit/6c19ad4943c241225876a15cf343af6d69f27fec) calibre: add image optimization programs
* [`a33355be`](https://github.com/NixOS/nixpkgs/commit/a33355bee72d40afb90140fecf75ed6aff1939fe) calibre: format
* [`e7e2a798`](https://github.com/NixOS/nixpkgs/commit/e7e2a798acf7648022804146c3f36afcca52b929) changedetection-io: 0.47.06 -> 0.48.01
* [`94c4e90b`](https://github.com/NixOS/nixpkgs/commit/94c4e90bd48c36afaf92b5780143d62ab659cf64) instawow: 4.7.0 -> 4.8.0
* [`84a5d186`](https://github.com/NixOS/nixpkgs/commit/84a5d186bd6243360f31d3915cb1c4fd68618449) flameshot: 12.1.0-unstable-2024-09-01 -> 12.1.0-unstable-2024-12-03
* [`efe99b59`](https://github.com/NixOS/nixpkgs/commit/efe99b598c158f75b94a577579d01bdc73c66b0d) ytdl-sub: 2024.11.6 -> 2024.12.4
* [`20187268`](https://github.com/NixOS/nixpkgs/commit/20187268165785b479f593df04a7e057191660ca) klayout: 0.29.8 -> 0.29.10
* [`2e1477dd`](https://github.com/NixOS/nixpkgs/commit/2e1477ddc8dec66f198b5fbfc8cd3e5337cae49d) waagent: add passthru.tests
* [`adb17e6b`](https://github.com/NixOS/nixpkgs/commit/adb17e6bd7da7f9e8c4fd98249547862ca95ec2b) python312Packages.py-tes: 0.4.2 -> 1.1.0
* [`2952abf8`](https://github.com/NixOS/nixpkgs/commit/2952abf8b3acd7e7305e7a8c3ba0fba9abf0f083) octoscan: 0.1.2 -> 0.1.3
* [`9f4607c3`](https://github.com/NixOS/nixpkgs/commit/9f4607c3c212ec02ecacd43b90e77b97638c0519) atac: 0.18.0 -> 0.18.1
* [`1c43a553`](https://github.com/NixOS/nixpkgs/commit/1c43a5539fbee8e0415ab6c65ef0ec1dc92d646e) jql: 8.0.0 -> 8.0.2
* [`6f78b957`](https://github.com/NixOS/nixpkgs/commit/6f78b9574e29d3e3f766370903fcea01491f79b0) zed-open-capture: init at unstable-2023-24-19
* [`e7f4622d`](https://github.com/NixOS/nixpkgs/commit/e7f4622dae8bbdda34cd0f6952b39693db47d1d7) rtabmap: make use of zed-open-capture
* [`b73f6cf0`](https://github.com/NixOS/nixpkgs/commit/b73f6cf0fbd8cd377e9518949975cdf103ad4528) sentry-native: 0.7.11 -> 0.7.16
* [`68cec4ca`](https://github.com/NixOS/nixpkgs/commit/68cec4caf1378a2e6334195f263b7a99e4559c68) kubefirst: 2.7.3 -> 2.7.7
* [`2c46e12b`](https://github.com/NixOS/nixpkgs/commit/2c46e12b8db4a3eab6489d40bf08254d2a73e307) cargonode: refactor
* [`292bd59d`](https://github.com/NixOS/nixpkgs/commit/292bd59d3120b936cb0fe5842fe3955e4751cbc0) json-schema-for-humans: fix build and update
* [`de101f46`](https://github.com/NixOS/nixpkgs/commit/de101f46fe7c78a8eb2f95415964fa6bc30af51a) python312Packages.courlan: 1.3.1 -> 1.3.2
* [`579d328a`](https://github.com/NixOS/nixpkgs/commit/579d328a9f2fc34e345526fd6c9b4887ec9727b6) jetbrains.plugins: fix adding JAR plugins
* [`6c9cb915`](https://github.com/NixOS/nixpkgs/commit/6c9cb915b7c4ac44e15d02391857bddca0fd3fe0) nwg-hello: 0.2.4 -> 0.3.0
* [`bfe7ed8f`](https://github.com/NixOS/nixpkgs/commit/bfe7ed8ff4b2834e7b0fe452980ea1ce790ca832) traefik: 3.1.4 -> 3.2.1
* [`3a1877ce`](https://github.com/NixOS/nixpkgs/commit/3a1877ce56cf620303db1d219ba37b4c7ea2d343) maintainers: add axka
* [`c9fecf24`](https://github.com/NixOS/nixpkgs/commit/c9fecf240b2b3a68828ebfb355d122ea6fb29400) cve: 1.7.0 -> 1.7.1
* [`aeb43658`](https://github.com/NixOS/nixpkgs/commit/aeb4365816f6fcf9d7471e33ad2828f9acc734ca) tabby-agent: 0.18.0 -> 0.21.1
* [`6d896f68`](https://github.com/NixOS/nixpkgs/commit/6d896f680dc869cf273480f9fc6f747d53872e53) macchina: 6.2.1 -> 6.4.0
* [`3da9d80a`](https://github.com/NixOS/nixpkgs/commit/3da9d80a6b76425beeaa75bb989e3e317a8fe1d6) harmonia: 1.0.2 -> 2.0.0
* [`8c3258c1`](https://github.com/NixOS/nixpkgs/commit/8c3258c180319ee96341e17fc08ef966686abe1c) uiua: remove legacy darwin deps
* [`a00e463c`](https://github.com/NixOS/nixpkgs/commit/a00e463c988fc0dcba4a41a45bbcbda4214d8534) dotnetCorePackages.patchNupkgs: fix patchelf usage
* [`bd6a3a2a`](https://github.com/NixOS/nixpkgs/commit/bd6a3a2a4588d9394559e4884b30f2777172c09a) ocamlPackages.earlybird: 1.3.2 -> 1.3.3
* [`3c1facf9`](https://github.com/NixOS/nixpkgs/commit/3c1facf9a7a38bd5b3b1c2325a7da4bc47797a2d) uiua-unstable: init at 0.14.0-dev.6
* [`a40c58de`](https://github.com/NixOS/nixpkgs/commit/a40c58dea8a1058cd2a27e3d5bd1299229fde4cf) ginkgo: 2.21.0 -> 2.22.0
* [`301d0ec4`](https://github.com/NixOS/nixpkgs/commit/301d0ec420e5a7845fb29208ccc82cfb5b5601f0) openvas-scanner: 23.10.0 -> 23.13.1
* [`fd513031`](https://github.com/NixOS/nixpkgs/commit/fd5130310c55d195081d9b8839e741df1ae4ef38) calicoctl: 3.29.0 -> 3.29.1
* [`1fe526cc`](https://github.com/NixOS/nixpkgs/commit/1fe526ccb30e0f22bdc98f88a254a1c950181f9b) polychromatic: 0.9.2 -> 0.9.3
* [`4eaf80d5`](https://github.com/NixOS/nixpkgs/commit/4eaf80d58581c937a6b4310c33aea028962309e1) python312Packages.mrsqm: fix build
* [`a7dcd165`](https://github.com/NixOS/nixpkgs/commit/a7dcd165b8bbad3c4b8d938350b68ae6f5148fb9) wavebox: 10.129.32-2 -> 10.131.16-2
* [`e7cb26c6`](https://github.com/NixOS/nixpkgs/commit/e7cb26c6e0abd90e7dc0fd330bf66e33af5f5dae) bird: 2.15.1 -> 2.16
* [`d48876c9`](https://github.com/NixOS/nixpkgs/commit/d48876c9b8f67bbadbe927ad8d828a35ec723559) pkcs11-provider: 0.5 -> 0.6
* [`45f439bd`](https://github.com/NixOS/nixpkgs/commit/45f439bd7ef484820afa08e363c468619f924d3e) pkcs11-provider: nixfmt
* [`0faaecba`](https://github.com/NixOS/nixpkgs/commit/0faaecba01fdcf745fbef12562b0419d5cb9bf7b) magic-wormhole-rs: migrate to new apple-sdk pattern
* [`5d3fb630`](https://github.com/NixOS/nixpkgs/commit/5d3fb630fb588b4a4b20e19bcaa5caaf94b194f7) magic-wormhole-rs: skip libxcb dependency on Darwin
* [`980e2470`](https://github.com/NixOS/nixpkgs/commit/980e2470baea191ba779004bb3503fa35b030c44) magic-wormhole-rs: enable tests
* [`cbea40be`](https://github.com/NixOS/nixpkgs/commit/cbea40be36eb692d55d492bac349dccfa6c56e2e) magic-wormhole-rs: reformat with nixfmt-rfc-style
* [`ae031f19`](https://github.com/NixOS/nixpkgs/commit/ae031f193eaa05a4c6c0e3449e2a5bb25d361a1c) magic-wormhole-rs: migrate to pkgs/by-name
* [`3715bf4e`](https://github.com/NixOS/nixpkgs/commit/3715bf4e98a10ebfa9ab5a35fed112854fafd432) nixos/hickory-dns: give `settings.zone` a freeformType
* [`0d491345`](https://github.com/NixOS/nixpkgs/commit/0d491345a0747a2fb159b660cdbb171aa9c472de) hydrogen: 1.2.3 -> 1.2.4
* [`970a263f`](https://github.com/NixOS/nixpkgs/commit/970a263fabcd3c920b94e352d2bb1af3904cbd0b) netdata: 1.47.4 -> 1.47.5
* [`1ceb2dbd`](https://github.com/NixOS/nixpkgs/commit/1ceb2dbda1a5be9654caca7cbdf94a9332ce9bc2) mate.atril: 1.28.0 -> 1.28.1
* [`af4fad1f`](https://github.com/NixOS/nixpkgs/commit/af4fad1f21ee3f7d9d5ed61d1f2393a1d37b134c) nixos-rebuild-ng: remove --raw from nix-instantiate
* [`222515bd`](https://github.com/NixOS/nixpkgs/commit/222515bd499d948c68e377ba49d0129cb35fc116) filebot: 5.1.5 -> 5.1.6
* [`d07d8a55`](https://github.com/NixOS/nixpkgs/commit/d07d8a5589f80c1e93769e802ae60feb86d9ea44) waagent: improve code readability and doc
* [`d3097b77`](https://github.com/NixOS/nixpkgs/commit/d3097b77bf3535bc9b121727f96e08b6793b818d) ldapnomnom: 1.4.1 -> 1.5.1
* [`7946d711`](https://github.com/NixOS/nixpkgs/commit/7946d711304e82baa1077687ead8b63cdb51320f) galario: nixfmt
* [`a67dc5b1`](https://github.com/NixOS/nixpkgs/commit/a67dc5b123f66fa2c6038d81285d34154a7c9714) srm-cuarzo: 0.8.0-1 -> 0.10.0-1
* [`04565525`](https://github.com/NixOS/nixpkgs/commit/045655252364935ab1db76d177c46619c7016bb1) python312Packagesgalario: fix build
* [`a7f278d0`](https://github.com/NixOS/nixpkgs/commit/a7f278d01e472b726ede3c672e5c6715c3a1e5ba) marwaita: 22.2 -> 23
* [`88ed5890`](https://github.com/NixOS/nixpkgs/commit/88ed58906d136216e44450c9d08ed2fcb9b677d3) emiluaPlugins.this-thread: 1.0.0 -> 1.0.1
* [`d87d5c25`](https://github.com/NixOS/nixpkgs/commit/d87d5c25cd5128f0e0651542b5645bf9ece484c7) brave: 1.73.91 -> 1.73.97
* [`92ba75b2`](https://github.com/NixOS/nixpkgs/commit/92ba75b2ae79a0d4b4dcfa5006179a0ccdc14d23) minizign: unstable-2023-08-13 -> 0.1.4
* [`daec6491`](https://github.com/NixOS/nixpkgs/commit/daec649173fa3637cd25c79b83b84803ef5d35c8) golds: init at 0.7.1
* [`caa61788`](https://github.com/NixOS/nixpkgs/commit/caa61788635afc5164a1a75760dff38cc0ab93d6) gocovsh: init at 0.6.1
* [`97748fc9`](https://github.com/NixOS/nixpkgs/commit/97748fc9a517ab686b4867b7f36da07c3952d3f3) gama-tui: init at 1.1.4
* [`694d0083`](https://github.com/NixOS/nixpkgs/commit/694d008374017ed3daede51c2b001a81f7434eeb) ztags: unstable-2023-09-07 -> 1.0.1
* [`1600f8c4`](https://github.com/NixOS/nixpkgs/commit/1600f8c4647b339ecc81a657d299b800d4d28e27) python312Packages.flake8-bugbear: 24.8.19 -> 24.10.31
* [`21f74763`](https://github.com/NixOS/nixpkgs/commit/21f74763f21be2eceb64e0acba5a3cb8c81eeb36) mongocxx: 3.10.2 -> 4.0.0
* [`b44f3766`](https://github.com/NixOS/nixpkgs/commit/b44f376683e99ee0a8c87b2dce95be7a35cd1342) python312Packages.nimfa: fix build
* [`e07423c1`](https://github.com/NixOS/nixpkgs/commit/e07423c1c28c23561d88f03f7175fbb1b3dd0169) cargo-aoc: init at 0.3.8
* [`87860d17`](https://github.com/NixOS/nixpkgs/commit/87860d17da952823be00a2176172fc5d43c46d85) python312Packages.pysvn: 1.9.22 -> 1.9.23
* [`bf6767fa`](https://github.com/NixOS/nixpkgs/commit/bf6767fa2024aecd29e78d72a9d441be8f153759) checkstyle: 10.20.0 -> 10.20.2
* [`83d059dd`](https://github.com/NixOS/nixpkgs/commit/83d059ddf7ae5963fc2957a3baf5b5c1a51273f3) sbclPackages._3d-math: build fix
* [`a362eb0e`](https://github.com/NixOS/nixpkgs/commit/a362eb0e58beaf5b0b8fb6612753d1398e911046) arti: 1.3.0 -> 1.3.1
* [`14cf5ed4`](https://github.com/NixOS/nixpkgs/commit/14cf5ed4a75145cd80b40bb2df58b89b03f4a3eb) python312Packages.gflanguages: 0.6.5 -> 0.7.1
* [`a2aadfe8`](https://github.com/NixOS/nixpkgs/commit/a2aadfe89fdd57884812b3b59d2925dda72401a7) ecs-agent: 1.87.1 -> 1.88.0
* [`4ae6f5fe`](https://github.com/NixOS/nixpkgs/commit/4ae6f5fed4960ff3b10e18f63c61e9df5ac1d004) chezmoi: 2.53.1 -> 2.55.0
* [`36f6092a`](https://github.com/NixOS/nixpkgs/commit/36f6092a63f575c7f5414a59ef25859a58ea24e7) java-hamcrest: init at 3.0
* [`4a944c3c`](https://github.com/NixOS/nixpkgs/commit/4a944c3c81030021cc1706e215a651da448a1a39) nzbhydra2: 7.8.0 -> 7.10.2
* [`066e87dc`](https://github.com/NixOS/nixpkgs/commit/066e87dc5c2821cdb5ae3be34de8f7b6cad08580) wt: 4.10.4 -> 4.11.1
* [`e252f123`](https://github.com/NixOS/nixpkgs/commit/e252f12311b42e553ecd2195ff28a0701a11d9ac) chiaki-ng: 1.9.1 -> 1.9.2
* [`145339b5`](https://github.com/NixOS/nixpkgs/commit/145339b54775af2b103d4581b7ea394f77be2194) cri-o-unwrapped: 1.31.2 -> 1.31.3
* [`b912f71f`](https://github.com/NixOS/nixpkgs/commit/b912f71f23243ecf08a606d673a65d383dcdeeaa) htcondor: 24.1.1 -> 24.2.2
* [`6cb776b3`](https://github.com/NixOS/nixpkgs/commit/6cb776b31c7b46e23eefc34e3f575b55e4836f57) python312Packages.stevedore: update disabled
* [`ded2850b`](https://github.com/NixOS/nixpkgs/commit/ded2850bd2366cc5854ef7f141e2683648edd8fe) python312Packages.pytest-selenium: init at 4.1.0
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
