### PR TITLE
niv home-manager: update 9ebaa80a -> 83ecd509

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -41,10 +41,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "9ebaa80a227eaca9c87c53ed515ade013bc2bca9",
-        "sha256": "0xm172djksf09x1p4pviyq9a95x2f3983bsr67i2iqxricib74nw",
+        "rev": "83ecd50915a09dca928971139d3a102377a8d242",
+        "sha256": "1q1sqnd8gjrglihgb56hmznj4had0jyg73k355m3ga4wqj3ggmf0",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/9ebaa80a227eaca9c87c53ed515ade013bc2bca9.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/83ecd50915a09dca928971139d3a102377a8d242.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@9ebaa80a...83ecd509](https://github.com/nix-community/home-manager/compare/9ebaa80a227eaca9c87c53ed515ade013bc2bca9...83ecd50915a09dca928971139d3a102377a8d242)

* [`77a792a0`](https://github.com/nix-community/home-manager/commit/77a792a0418227e69a2ba26728b47f2b8cf3b6ec) atuin: Do not hard code prefix for daemon socket path
* [`e952e949`](https://github.com/nix-community/home-manager/commit/e952e94955dcc6fa2120c1430789fc41363f5237) atuin: Prepare for daemon socket path in 18.4.0
* [`8772bae5`](https://github.com/nix-community/home-manager/commit/8772bae58c0a1390727aaf13802debfa29757d67) nushell: allow installing plugins
* [`c6a5fbfd`](https://github.com/nix-community/home-manager/commit/c6a5fbfd99bccfafbe99a6bb87b351c8fb7de70a) qt: install kio when qt.platformTheme = "kde"
* [`f26aa4b7`](https://github.com/nix-community/home-manager/commit/f26aa4b76fb7606127032d33ac73d7d507d82758) gpg-agent: fix GCR DBus package note
* [`6e5b2d9e`](https://github.com/nix-community/home-manager/commit/6e5b2d9e8014b5572e3367937a329e7053458d34) home-manager: support username with special chars ([nix-community/home-manager⁠#5609](https://togithub.com/nix-community/home-manager/issues/5609))
* [`15151bb5`](https://github.com/nix-community/home-manager/commit/15151bb5e7d6e352247ecaeeeefc34d0f306b287) gpg: fix hash of test ([nix-community/home-manager⁠#6200](https://togithub.com/nix-community/home-manager/issues/6200))
* [`e526fd2b`](https://github.com/nix-community/home-manager/commit/e526fd2b1a40e4ca0b5e07e87b8c960281c67412) gnome-shell: fix extensions' default ([nix-community/home-manager⁠#6199](https://togithub.com/nix-community/home-manager/issues/6199))
* [`3066cc58`](https://github.com/nix-community/home-manager/commit/3066cc58f552421a2c5414e78407fa5603405b1e) kanshi: dont write config in absence of nix settings ([nix-community/home-manager⁠#6198](https://togithub.com/nix-community/home-manager/issues/6198))
* [`66c5d8b6`](https://github.com/nix-community/home-manager/commit/66c5d8b62818ec4c1edb3e941f55ef78df8141a8) zed-editor: fix always generating settings.json
* [`83ecd509`](https://github.com/nix-community/home-manager/commit/83ecd50915a09dca928971139d3a102377a8d242) docs: fix typo in 24.11 release notes
