### PR TITLE
niv nixpkgs: update 639295b1 -> 7d402f20

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "639295b1f6dc159631e7dec5a0b926ec2a2fdf9c",
-        "sha256": "1pz2z8fzrbhrms1v25444igmni8f6q72dwnyvnj9wyk7nrjav8j7",
+        "rev": "7d402f207f326eed0ad136d09ef6a65364daf894",
+        "sha256": "0k6k63k70vzv7kwjwa0zxz7c0j17kfgczjc68k8cia6ipn4y6hj6",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/639295b1f6dc159631e7dec5a0b926ec2a2fdf9c.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/7d402f207f326eed0ad136d09ef6a65364daf894.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@639295b1...7d402f20](https://github.com/nixos/nixpkgs/compare/639295b1f6dc159631e7dec5a0b926ec2a2fdf9c...7d402f207f326eed0ad136d09ef6a65364daf894)

* [`b3c825d1`](https://github.com/NixOS/nixpkgs/commit/b3c825d1eff82e1f9789d8ac620659f873956cf6) nixos/jackett: add Systemd sandboxing configuration
* [`036752a6`](https://github.com/NixOS/nixpkgs/commit/036752a6dc365faa61efa77b09a19b98c1d99c6f) moodle: add missing plugin types
* [`b1595ae6`](https://github.com/NixOS/nixpkgs/commit/b1595ae6d33b938cb856e34a9e941b77e7b1ad17) nixos/restic: test that `initialize = false` works correctly
* [`b9b5678e`](https://github.com/NixOS/nixpkgs/commit/b9b5678eacde92724f411a5836a21ea5c204e6e5) maintainers: add negatethis
* [`01bc4d1e`](https://github.com/NixOS/nixpkgs/commit/01bc4d1e857fa5a9954792564d6c939c7709dbdf) rescrobbled: init at 0.7.1
* [`2b0aab58`](https://github.com/NixOS/nixpkgs/commit/2b0aab5850b053dcab403f70e00dfc922ca8d569) linuxPackages.iio-utils: init
* [`9fa68648`](https://github.com/NixOS/nixpkgs/commit/9fa68648ea6044fa1303b05032ca4e47266e6497) rvz: init at 1.0.3
* [`873d6a92`](https://github.com/NixOS/nixpkgs/commit/873d6a92d6932d378d2bc11dd9699d7fdd9d6114) nixos/nginx-sso: use 'pkgs.formats'
* [`cf2b6c4e`](https://github.com/NixOS/nixpkgs/commit/cf2b6c4eb271c7e3b42696bc03956b3a184a422c) nixos/nginx-sso: use 'lib.getExe'
* [`e26c18db`](https://github.com/NixOS/nixpkgs/commit/e26c18db131d739d421832f69746a458fe204eea) mmg: init at 5.7.3-unstable-2024-05-31
* [`97f956f7`](https://github.com/NixOS/nixpkgs/commit/97f956f7ef1d597f1608e3db56bfe6098d5df394) scarlett2: init at 0-unstable-2024-04-06
* [`04851a97`](https://github.com/NixOS/nixpkgs/commit/04851a974b7187070dd5c3aa858fc80788296a1d) lilex: init at 2.530
* [`0e88eaba`](https://github.com/NixOS/nixpkgs/commit/0e88eabaaa1d7aaf655c0dbc85a08c8feba5e9eb) penguin-subtitle-player: init at 1.6.0
* [`695c4343`](https://github.com/NixOS/nixpkgs/commit/695c4343dab78e44ff99154ff22a9aa5c3a4ab4c) skrive: init at 0.10.0
* [`fce6f3ff`](https://github.com/NixOS/nixpkgs/commit/fce6f3ff6a080901bd0398b932d8ce3ed95d4968) cudaPackages.nccl-tests: 2.13.9 -> 2.13.10
* [`d304cba8`](https://github.com/NixOS/nixpkgs/commit/d304cba853264c2037cc3122bd36a99506cb2f52) maintainers: add automathis
* [`d5b20477`](https://github.com/NixOS/nixpkgs/commit/d5b20477d3018ba8651af021d4862e2af2119ff6) cpp-redis: init at 4.3.1
* [`b8393db2`](https://github.com/NixOS/nixpkgs/commit/b8393db284317016fe547fd713f7f5639af9e3f0) python3Packages.hebg: init at 0.2.4
* [`2399ceb9`](https://github.com/NixOS/nixpkgs/commit/2399ceb9c828dab7eeb501e30d02952fa73ba84b) maintainers: add kvik
* [`fc2d3db3`](https://github.com/NixOS/nixpkgs/commit/fc2d3db3d52ca2e601eaa8a9115e015919a2c540) python3Packages.cyclonedds-python: init at 0.10.5
* [`178a8c7c`](https://github.com/NixOS/nixpkgs/commit/178a8c7cd3ab5ee5eb1f14cfe2ceaa487214cd3f) cpu_features: init at 0.9.0
* [`20462988`](https://github.com/NixOS/nixpkgs/commit/204629887fc44df27908ebb914c2b1adebab09f0) python3Packages.piqp: init at 0.4.2
* [`47177c0e`](https://github.com/NixOS/nixpkgs/commit/47177c0ec92a6e6b73d1247f384ba6cc94a6ccfe) nixos/luksroot: Exit if EOF detected
* [`421c9a21`](https://github.com/NixOS/nixpkgs/commit/421c9a21aed2cf56c58f5c3bfdacf9690550118b) nixos/frigate: add rtmp nginx module
* [`06ce1d33`](https://github.com/NixOS/nixpkgs/commit/06ce1d333091a55bcace79117e213ad995bf8153) papilo: init at 2.3.0
* [`bda399c7`](https://github.com/NixOS/nixpkgs/commit/bda399c7e8427a9f3ebae43804f4b2e3107fa45c) prettierd: remove mkYarnPackage usage
* [`81ecc353`](https://github.com/NixOS/nixpkgs/commit/81ecc353064cdb4f71e676571e8f2d0a95ab34e0) maintainers: add eklairs
* [`c6e762d3`](https://github.com/NixOS/nixpkgs/commit/c6e762d37c9da443add2eaf99cc8b6f615ca6dde) tlock: init at 1.0.0
* [`9e3f655e`](https://github.com/NixOS/nixpkgs/commit/9e3f655e1403676aff8c46a797f13e5288d84c79) segger-jlink: v796 -> v810
* [`15119b82`](https://github.com/NixOS/nixpkgs/commit/15119b82443c3e4f4ad310fc0b351481a4e6247b) nixos/mullvad-vpn: remove unneeded hacks
* [`bed3fe7f`](https://github.com/NixOS/nixpkgs/commit/bed3fe7f63ec050f2da09ab7342c83988f9d30e5) maintainers: add kmogged
* [`d957526c`](https://github.com/NixOS/nixpkgs/commit/d957526c0651240658dbf004a5a3e29d68de2459) nixos/dbus: inline once used homeDir
* [`172f25b6`](https://github.com/NixOS/nixpkgs/commit/172f25b6ad962378d137eeaf4eecddc4aa63b647) makeDBusConf: make overrideable
* [`cfc0d6be`](https://github.com/NixOS/nixpkgs/commit/cfc0d6bee8e110f76f3d1ac8d99e3a669386f961) nixos/dbus: add package options
* [`608e8624`](https://github.com/NixOS/nixpkgs/commit/608e86249801477cd0486b3d8e792d6c4dec7997) calibre-web: Add LDAP dependency
* [`31ac1380`](https://github.com/NixOS/nixpkgs/commit/31ac1380013356a9985ab2b634f8c60f4eff88ea) coqPackages.coq-tactical: init at unstable-2022-02-15
* [`1cb6d223`](https://github.com/NixOS/nixpkgs/commit/1cb6d223867d1da42267bd6e748714a0c984ebc5) nixos/bind: harden systemd service
* [`4855723c`](https://github.com/NixOS/nixpkgs/commit/4855723c87be027e9ed9a3e6e6503d04f48f4b8a) nixos/bind: Make ProtectSystem strict, add missing SystemCallFilters
* [`63cd2b8e`](https://github.com/NixOS/nixpkgs/commit/63cd2b8e03e72332916a78b248f181c42213ae95) nixos/bind: rndc-confgen should not chown file
* [`f52a17ea`](https://github.com/NixOS/nixpkgs/commit/f52a17ea14146de31d711b47891296a34c59283b) coqPackages.vscoq-language-server: 2.1.7 -> 2.2.1
* [`5c08da1b`](https://github.com/NixOS/nixpkgs/commit/5c08da1bbfc1d438799a809c868831daf1e3c9df) apache-modules.mod_dnssd: fix path link
* [`6e439af3`](https://github.com/NixOS/nixpkgs/commit/6e439af37504904a275deef651d5a7ee7cea09f5) python3Packages.presenterm-export: init at 0.2.5
* [`5dd6467e`](https://github.com/NixOS/nixpkgs/commit/5dd6467e7bcd8a43078682dd947066016186a00e) gzip: use makeShellWrapper instead of makeWrapper
* [`6bc20484`](https://github.com/NixOS/nixpkgs/commit/6bc2048474553542e957635c66ef92e7f1293d2f) deviceTree: Allow applying dtoverlays for DT with no compatible string
* [`6f9c572a`](https://github.com/NixOS/nixpkgs/commit/6f9c572a0eaef2fe7e4bb73c6e11692d9f9b2a4b) nixos/gitlab: Fix registry port
* [`620dccb4`](https://github.com/NixOS/nixpkgs/commit/620dccb431316defe65f39a5a07da9dab2b81632) nixos/test/fcitx5: add assertion message
* [`da7b5ed4`](https://github.com/NixOS/nixpkgs/commit/da7b5ed4465162b4963515edc71de7719062e2c3) nixos/gancio: add gancio to nginx extraGroups only if nginx enabled
* [`5e83e20c`](https://github.com/NixOS/nixpkgs/commit/5e83e20cb78837d75c2c65624b9ca19c2ed55c79) nixos/mailhog: add setSendmail option for sendmail setuid wrapper.
* [`c6053a54`](https://github.com/NixOS/nixpkgs/commit/c6053a54bb517861ed8eabf45fa28d88f3297953) nixos/tests/mailhog: modify test to use system sendmail.
* [`194aa78b`](https://github.com/NixOS/nixpkgs/commit/194aa78bd74ef2c37ac004a469a414a0cb299046) maintainers: add lilioid
* [`f037bfbe`](https://github.com/NixOS/nixpkgs/commit/f037bfbe0bc7c29b68855aad6ade8c55688a4f04) fortanix-sgx-tools: init at 0.5.1
* [`3e332e4f`](https://github.com/NixOS/nixpkgs/commit/3e332e4f103526fc46ee77dbd3295195e249478b) sgxs-tools: init at version 0.8.6
* [`a00c1932`](https://github.com/NixOS/nixpkgs/commit/a00c1932aba9b6400e1595cd7e0ded3e76d509b1) nixos/akkoma: Provide cache directory via environment
* [`d0c8d732`](https://github.com/NixOS/nixpkgs/commit/d0c8d73266c0080f3a6b93fa18c769922a3c099c) aws-codeartifact-proxy: init at 0.5.1
* [`89fbc2b6`](https://github.com/NixOS/nixpkgs/commit/89fbc2b61b44016dec6cfb328fe6700958de678a) nixos/akkoma: Include ImageMagick by default
* [`83717a8d`](https://github.com/NixOS/nixpkgs/commit/83717a8dfed470ab1fa9ab6db9dcfbf91f81a495) visp: init at 3.6.0
* [`7e6a0edf`](https://github.com/NixOS/nixpkgs/commit/7e6a0edf647b2054b1e198f0921d91446b86f77e) nixos/tftpd: remove with lib
* [`8440f6cc`](https://github.com/NixOS/nixpkgs/commit/8440f6cc6f825d2ca85585f6fbcf3018d934f7da) nixos/tftpd: format with nixmft-rfc-style
* [`22fea14d`](https://github.com/NixOS/nixpkgs/commit/22fea14d1197342935c1e95aee2e1886092f2e74) nixos/tftpd: cleanup
* [`3e4830f6`](https://github.com/NixOS/nixpkgs/commit/3e4830f63647fcb30b4e614293b332513b07b264) dropbox: add missing libXmu to targetPkgs
* [`0c610470`](https://github.com/NixOS/nixpkgs/commit/0c61047055ee99123a9d382cb1fffe3180ad1d0a) imagemagick: include configure.xml ([nixos/nixpkgs⁠#353169](https://togithub.com/nixos/nixpkgs/issues/353169))
* [`3339bf30`](https://github.com/NixOS/nixpkgs/commit/3339bf30e854be9c700746ee5ee5feb2fec99c9a) virtualbox: 7.0.22 -> 7.1.4
* [`bc93e48b`](https://github.com/NixOS/nixpkgs/commit/bc93e48b3763afdb044615461e711481206cc8e5) tcptrace: init at 6.6.7
* [`eefa1c8f`](https://github.com/NixOS/nixpkgs/commit/eefa1c8fa74897b77a6acab2461206f6d52dd382) vscode-extensions.visualstudiotoolsforunity.vstuc: init at 1.0.4
* [`415acef9`](https://github.com/NixOS/nixpkgs/commit/415acef9c9085406dda5125fe7f854c0a7fd8d93) nixos/nginx-sso: allow using file-based secrets
* [`58a1a610`](https://github.com/NixOS/nixpkgs/commit/58a1a6107df682c4fd8ebfcd3fc91f2eee3c314e) nixos/tests/nginx-sso: use '_secret'
* [`92dd7dbb`](https://github.com/NixOS/nixpkgs/commit/92dd7dbb617bb5a75628725e1f9917122a239914) symcc: init at 1.0-unstable-2024-07-16
* [`cdefc40e`](https://github.com/NixOS/nixpkgs/commit/cdefc40e99a2a6781b7493135be58d8c6c418b19) llvmPackages.*: Expose git rev through pkg.src.rev
* [`6d18d5c2`](https://github.com/NixOS/nixpkgs/commit/6d18d5c27d454a0e604b2d1d76d2a3e9cf014cf1) nosql-booster: init at 8.1.9
* [`5cd68d33`](https://github.com/NixOS/nixpkgs/commit/5cd68d33bbcd73c7e2d852117a470addd2e8cf14) python3Packages.torch: enable vulkan support
* [`2fa74a49`](https://github.com/NixOS/nixpkgs/commit/2fa74a49bd417544399675c118f25ffd687c003a) unison-fsmonitor: 0.3.4 -> 0.3.8
* [`1fb1e700`](https://github.com/NixOS/nixpkgs/commit/1fb1e7007354afec3040651d210e8ba2ca81eccf) unison-fsmonitor: fmt
* [`98c25c9a`](https://github.com/NixOS/nixpkgs/commit/98c25c9a6e083d55968b166e4fe8dba82041422a) unison-fsmonitor: switch new darwin SDK pattern
* [`b5248572`](https://github.com/NixOS/nixpkgs/commit/b5248572c5e168a079f211b9cfe3da418bbc4fce) readsb: init at 3.14.1641
* [`89af2f73`](https://github.com/NixOS/nixpkgs/commit/89af2f738d961ad2fc1a1fea11c78c04b7f3a7ee) nordzy-cursor-theme: 0.6.0 -> 2.3.0
* [`0f46accc`](https://github.com/NixOS/nixpkgs/commit/0f46acccf0cb63963d212cd4e089d7f9bba9412f) libtorrent-rasterbar-1_2_x: 1.2.11 -> 1.2.19
* [`e1677d06`](https://github.com/NixOS/nixpkgs/commit/e1677d068f1cfa218968e1c9c542afd8539df7a6) awk-language-server: init at 0.10.6
* [`99bc8179`](https://github.com/NixOS/nixpkgs/commit/99bc8179e8fe2aa369d0d9a1965f57220eeaa533) hexapdf: init at 1.0.2
* [`0f63e08f`](https://github.com/NixOS/nixpkgs/commit/0f63e08fee53279b93cc7a8557170b993d74c57a) pcsc-safenet: 10.8.28 -> 10.8.1050
* [`66c0af5e`](https://github.com/NixOS/nixpkgs/commit/66c0af5e3b6ccf78e5d5ceef81a431bf78ab2f78) zap-chip-gui: actually provide a gui
* [`88787d55`](https://github.com/NixOS/nixpkgs/commit/88787d55b45dd6327cb29e76714a0e98b78ea5da) sportstracker: init at 8.0.1
* [`df001468`](https://github.com/NixOS/nixpkgs/commit/df001468e8928d622154cb3e82311861827c976b) pythonPackages.pytmx: 3.31 -> 3.32
* [`18457266`](https://github.com/NixOS/nixpkgs/commit/18457266102f9170c05dda46f9f90665be29c832) chars: add updateScript
* [`f6559fcb`](https://github.com/NixOS/nixpkgs/commit/f6559fcbae206a96dbe309c2edd2cf029c6d87a3) angle-grinder: add updateScript
* [`d6aa244e`](https://github.com/NixOS/nixpkgs/commit/d6aa244edf624e998ef76952eb34cd2510e0e183) okms-cli: init at 0.1.2
* [`bd0c863e`](https://github.com/NixOS/nixpkgs/commit/bd0c863eb4c27b20716022d51dc630f04b7d6384) lightworks: 2023.2 -> 2025.1
* [`2b71ca95`](https://github.com/NixOS/nixpkgs/commit/2b71ca95bac9f5bb1e7d51ec256473f7398b40b6) mqttx-cli: init at 1.11.0
* [`3564fb91`](https://github.com/NixOS/nixpkgs/commit/3564fb91c791ae273bac175dd4fb4111abadce5e) python312Packages.bson: enable tests
* [`cb2831b4`](https://github.com/NixOS/nixpkgs/commit/cb2831b4077ad6fea0808e7e75aed9a5fcbeaa40) jedit: 5.6.0-unstable-2023-11-19 -> 5.7.0
* [`9ffec75b`](https://github.com/NixOS/nixpkgs/commit/9ffec75b334e4b5dfaf028678a517dfd7fc55cb0) logisim-evolution: 3.8.0 -> 3.9.0
* [`12fae9cc`](https://github.com/NixOS/nixpkgs/commit/12fae9cc4dddd71ff00b1427dc3bcb811bdf2394) ahk_x11: init at 1.0.4
* [`810bc284`](https://github.com/NixOS/nixpkgs/commit/810bc2847463d3402f3ec54c3093582c3a1857f8) dumpifs: init at 0-unstable-2020-05-07
* [`1aa4ccf7`](https://github.com/NixOS/nixpkgs/commit/1aa4ccf7b33ab9fe0831dcc053f15cda130a9a53) exodus: 24.41.3 -> 24.41.6
* [`58542c2d`](https://github.com/NixOS/nixpkgs/commit/58542c2d7eee26541aba35745e2eec40a0ee22b6) descent3-unwrapped: init at 1.5.0-beta-unstable-2024-10-29
* [`4c5768f0`](https://github.com/NixOS/nixpkgs/commit/4c5768f0bcafe2975cbe4fa7c6c65c559018a54f) descent3: init at 1.5.0-beta-unstable-2024-10-29
* [`973542f8`](https://github.com/NixOS/nixpkgs/commit/973542f89a32734a6a48126ed35bf29a0321ec4d) firecracker: 1.9.0 -> 1.9.1, build from source
* [`d3d033a3`](https://github.com/NixOS/nixpkgs/commit/d3d033a38fc327bf97cfc7a99424a6cff3daa5c9) autosubst2: init at unstable-2022-07-04
* [`8199516b`](https://github.com/NixOS/nixpkgs/commit/8199516be8d5b1d23ecfc59dae8df9823a5b911b) bio-gappa: init at 0.8.4
* [`f5435651`](https://github.com/NixOS/nixpkgs/commit/f543565191f1e794ead1c0a4185febc6c544ea97) coroot-node-agent: init at 1.22.2
* [`af834d93`](https://github.com/NixOS/nixpkgs/commit/af834d939d2b64f9f9994557c4bf8b69dcbeb0ec) local-ai: 2.22.1 -> 2.23.0
* [`cc2afaa1`](https://github.com/NixOS/nixpkgs/commit/cc2afaa16f4b57809ad6c2519223175f116942ab) tt-rss: Add simple test
* [`33e2e0a6`](https://github.com/NixOS/nixpkgs/commit/33e2e0a61185ae9eb932e43432031d45ea002f92) tt-rss: Add updateScript
* [`ebf5be79`](https://github.com/NixOS/nixpkgs/commit/ebf5be79b71b619b5e9f896165a2fa6043e2c605) tt-rss: unstable-2023-04-13 -> 0-unstable-2024-11-04
* [`b652b301`](https://github.com/NixOS/nixpkgs/commit/b652b30119e9f6cfb9b61827a1ee7f75516cf428) tt-rss: Add updateDaemon.commandFlags parameter
* [`7baea176`](https://github.com/NixOS/nixpkgs/commit/7baea176a1a51aff0b3635850784fa4f7263e814) tt-rss: Add gileri as maintainer
* [`fd821d10`](https://github.com/NixOS/nixpkgs/commit/fd821d104c3dc2f4969c85b1340a133786b02c23) realcugan-ncnn-vulkan: init at 20220728
* [`3a064718`](https://github.com/NixOS/nixpkgs/commit/3a064718e595b9678bc0f63306f3349d24f96949) maintainers: add theoparis
* [`fe02fc11`](https://github.com/NixOS/nixpkgs/commit/fe02fc114dea033ea5031e22b046c84439a1bf1b) maintainers: add js6pak
* [`cf2e76fc`](https://github.com/NixOS/nixpkgs/commit/cf2e76fca3d9126bddd53bccde7e552236216dd9) llvmPackages: Fix update-git.py
* [`99be9899`](https://github.com/NixOS/nixpkgs/commit/99be9899faf0e4d7b59ec093400325243497ebe9) msbuild-structured-log-viewer: init at 2.2.383
* [`14dfe7b5`](https://github.com/NixOS/nixpkgs/commit/14dfe7b5335a00afcf1f48a62e779433fbe3594d) openfortivpn-webview-qt: init at 1.1.2
* [`a9763f63`](https://github.com/NixOS/nixpkgs/commit/a9763f63694d530ac7dbde20f0eca5d3318800ec) material-maker: init at 1.3
* [`f7593337`](https://github.com/NixOS/nixpkgs/commit/f75933378e0b3a0bfbe791a9c71f030546ea8220) plex-desktop: add libdrm to FHS environment
* [`20d91e05`](https://github.com/NixOS/nixpkgs/commit/20d91e0545716ed2b215f6be05a9a29d045c246f) misc-gitology: init at unstable-2024-08-26
* [`07cdea2a`](https://github.com/NixOS/nixpkgs/commit/07cdea2ae5005c6396eafd9d87e1cdec6c0c2a4b) arpack: add ISO C bindings
* [`93c1d0e0`](https://github.com/NixOS/nixpkgs/commit/93c1d0e0d950f368db01aff71f567a4c8588c09c) nanovna-qt: init at 20200403
* [`f97fc5fb`](https://github.com/NixOS/nixpkgs/commit/f97fc5fba175d7dde18aef108e997f3a67365d19) udpt: 3.1.1 -> 3.1.2
* [`4e17c3e5`](https://github.com/NixOS/nixpkgs/commit/4e17c3e53fda94d45b8703414fdf6d547febe4a9) ocis: init at 5.0.9
* [`4296417a`](https://github.com/NixOS/nixpkgs/commit/4296417ab7160508ad7bdb8fe0aa67d49677d432) mtools: 4.0.45 -> 4.0.46
* [`a840e0fe`](https://github.com/NixOS/nixpkgs/commit/a840e0fe64a05812f1d69f7ba38743b815cb2de6) elasticsearchPlugins.analysis-smartcn: init at 7.17.16
* [`f503b2e4`](https://github.com/NixOS/nixpkgs/commit/f503b2e4fe1bbe056de874cd8c6d753a1b20ee8d) elasticsearchPlugins.analysis-smartcn: inline reference to lib since there is only one in meta
* [`bf14b9fd`](https://github.com/NixOS/nixpkgs/commit/bf14b9fdbabca43697531ad6d983b972d189efdc) nextcloud: refactor path out of all-packages
* [`e8e69b17`](https://github.com/NixOS/nixpkgs/commit/e8e69b17b649a7de290b92f7896891666d5b7d17) nextcloud: add recognize app for nextcloud
* [`526e09ab`](https://github.com/NixOS/nixpkgs/commit/526e09ab5669b0ba469edef471df263b08de3960) nextcloud: add ffmpeg to recognize for recognizing video and audio
* [`9634c281`](https://github.com/NixOS/nixpkgs/commit/9634c2818b645c0408189731271c4ad50b0c48fd) nextcloud: remove useless ...
* [`e035b7bc`](https://github.com/NixOS/nixpkgs/commit/e035b7bc65fab96a0ca8e64b509d481e1ddfbede) nextcloud30Packages.apps.recognize: ensure node_binary is replaced
* [`20ddea25`](https://github.com/NixOS/nixpkgs/commit/20ddea255e64b64d4cba444f41eed48b10370a06) nextcloud30Packages.apps.recognize: simplify tar extractions
* [`7ca5d58e`](https://github.com/NixOS/nixpkgs/commit/7ca5d58e7e40f5631dd637ba6df4c143eecc6f60) nextcloud30Packages.apps.recognize: explain tensorflow version
* [`a4cf2ca6`](https://github.com/NixOS/nixpkgs/commit/a4cf2ca6743d06a1a78bab83e3fd54fce82e9f1c) nextcloud30Packages.apps.recognize: make tensorflow optional
* [`5e0c50ca`](https://github.com/NixOS/nixpkgs/commit/5e0c50ca956f902f1d0cd519c634a85d11cd2f40) Apppapersway: 1.001 -> 1.004
* [`e9f84d2f`](https://github.com/NixOS/nixpkgs/commit/e9f84d2f01bda29a373365d5ff4d9173c74fac37) discordchatexporter-desktop: init at 2.44
* [`8fb22f13`](https://github.com/NixOS/nixpkgs/commit/8fb22f131508ea58e6b1a5c3039796f036e92e9d) python312Packages.linuxpy: init at 0.20.0
* [`0eb4e5bf`](https://github.com/NixOS/nixpkgs/commit/0eb4e5bf71fe766ea329f47031d7c420b16fdc45) python311Packages.pixel-font-knife: init at 0.0.7
* [`813693b2`](https://github.com/NixOS/nixpkgs/commit/813693b29964dbbb1acb418d245518157418ab77) zsh-autosuggestions: 0.7.0 -> 0.7.1
* [`7eef9362`](https://github.com/NixOS/nixpkgs/commit/7eef936251d02ace3e39369297e249f833611d4f) temporal: 1.25.1 → 1.25.2
* [`258742f4`](https://github.com/NixOS/nixpkgs/commit/258742f45c6c50ff5b1568bcb684258f92b529f8) temporal: Assigned self as maintainer
* [`ce9f5acf`](https://github.com/NixOS/nixpkgs/commit/ce9f5acf5ea5f1c88d21462e2a9e2df0ae3380f1) fido2-manage: 0-unstable-2024-09-24 -> 0-unstable-2024-11-22
* [`7c4d31d3`](https://github.com/NixOS/nixpkgs/commit/7c4d31d327f88f88258e69beaed6aec3c35b5d61) misc-gitology: Versions start with a digit
* [`81909529`](https://github.com/NixOS/nixpkgs/commit/81909529585a906d6495376dc1d991a11c6a1db1) misc-gitology: Run preInstall/postInstall hooks
* [`83b92b30`](https://github.com/NixOS/nixpkgs/commit/83b92b30f6af9cd37d71a62f390a7a4d6b439af2) python312Packages.mygene: init at 3.2.2
* [`e366fef2`](https://github.com/NixOS/nixpkgs/commit/e366fef2f1e65ad488a0786c38c1061a8b6c58f8) esp-generate: init at 0.1.0
* [`ab97c856`](https://github.com/NixOS/nixpkgs/commit/ab97c856999eddc12221aaabd2ce7d3110e887e7) tcsh: 6.24.13 -> 6.24.14
* [`9af0a6c3`](https://github.com/NixOS/nixpkgs/commit/9af0a6c3a6da61012a0562efea198d7af34a88be) acpica-tools: nixfmt
* [`75235504`](https://github.com/NixOS/nixpkgs/commit/752355049b4551fe57651601338eb49abd596091) acpica-tools: 20240827 -> R09_27_24
* [`27f45403`](https://github.com/NixOS/nixpkgs/commit/27f4540379efd3d030bf2ce987e89fb0fc50283e) netpbm: 11.8.1 -> 11.8.2
* [`0971b5d8`](https://github.com/NixOS/nixpkgs/commit/0971b5d869b0ac59e709460fe53c38fdd90d7cd1) anytype: 0.43.4 -> 0.43.8
* [`28a8a3af`](https://github.com/NixOS/nixpkgs/commit/28a8a3af60f2af13fb5a420c83e128f1b4961d52) ovito: 3.11.0 -> 3.11.1
* [`dea9a622`](https://github.com/NixOS/nixpkgs/commit/dea9a6227b151069606e725aec653b18a0f64626) pulumi-bin: 3.138.0 -> 3.142.0
* [`54fb9997`](https://github.com/NixOS/nixpkgs/commit/54fb99975f2ab8c1eb472c5a595d083b737fd365) wasmtime: 26.0.1 -> 27.0.0
* [`114c0de3`](https://github.com/NixOS/nixpkgs/commit/114c0de3875c39d3647dfe253b52caa239417a4a) maintainers: add teczito
* [`bd7a4f18`](https://github.com/NixOS/nixpkgs/commit/bd7a4f185b68e956215e90d952929d6d6a6ce276) hosts-bl: init at 0-unstable-2024-11-17
* [`988cfb6f`](https://github.com/NixOS/nixpkgs/commit/988cfb6f25a14388c6e7d006406902383c49bf5f) zx: 8.2.2 -> 8.2.3
* [`b559566b`](https://github.com/NixOS/nixpkgs/commit/b559566b171a445f214a0c0ab99ff6c933aaf7ef) convfont: 1.0 -> 1.2
* [`4baf980b`](https://github.com/NixOS/nixpkgs/commit/4baf980b7bb8edad49ee1a195e6053f656faadfc) python312Packages.pynrrd: 1.0.0 -> 1.1.1
* [`fcf14b09`](https://github.com/NixOS/nixpkgs/commit/fcf14b0949220553a55fdf2d6ee0814eb280dbed) zx: 8.2.3 -> 8.2.4
* [`23ea20a0`](https://github.com/NixOS/nixpkgs/commit/23ea20a03fa210722383a47e2458bf771d4ab470) nginxModules.njs: 0.8.4 -> 0.8.7
* [`8e21c350`](https://github.com/NixOS/nixpkgs/commit/8e21c350c9321a863bbb5fbce05d1698bd9fadfa) cdxgen: 10.10.4 -> 11.0.3
* [`3c71f72e`](https://github.com/NixOS/nixpkgs/commit/3c71f72eed9b22e67e4aaf01355e02b8ed38b39a) sv-lang: 3.0 -> 7.0
* [`211edf1c`](https://github.com/NixOS/nixpkgs/commit/211edf1c0770b41d27d675d82d740459597023e7) python3Packages.nifty8: init at 8.5.2
* [`6e367c56`](https://github.com/NixOS/nixpkgs/commit/6e367c5670308f3e132a5a11644ca46d4529b12b) siketyan-ghr: init at 0.4.4
* [`f043602b`](https://github.com/NixOS/nixpkgs/commit/f043602b93f891234e299b212294933a75746558) littlegptracker: 0-unstable-2020-11-26 -> 1.4.2
* [`2b8a6852`](https://github.com/NixOS/nixpkgs/commit/2b8a68528b426e25d6caedc1cf093e8b6b1b6dff) storm: 2.6.4 -> 2.7.1
* [`95eee45d`](https://github.com/NixOS/nixpkgs/commit/95eee45da2f51bba91107a3f86aeefdffb4b8837) libcpuid: 0.7.0 -> 0.7.1
* [`a81f13db`](https://github.com/NixOS/nixpkgs/commit/a81f13db8d3e24f66e97724645833a178ddc3357) gnatPackages.xmlada: 24.0.0 -> 25.0.0
* [`96732513`](https://github.com/NixOS/nixpkgs/commit/967325133f8155825a00f169791814624aefd844) gnatPackages.gprbuild: 24.0.0 -> 25.0.0
* [`b5db2a40`](https://github.com/NixOS/nixpkgs/commit/b5db2a401a22bf1e8fa1798187351aa863c83a4c) gnatPackages.gnatcoll-core: 24.0.0 -> 25.0.0
* [`8bc7bcca`](https://github.com/NixOS/nixpkgs/commit/8bc7bcca4d6587e12302e76195ee8e72cb135d09) gnatPackages.gnatcoll-*(bindings): 24.0.0 -> 25.0.0
* [`0ccec7f0`](https://github.com/NixOS/nixpkgs/commit/0ccec7f0558bde4aa5cc1f42401afc9dcb7cf603) gnatPackages.gpr2: 24.0.0 -> 25.0.0
* [`b2020771`](https://github.com/NixOS/nixpkgs/commit/b2020771fc7184cca03ac17d5e48f0dcac7325ce) gnatPackages.gnatcoll-cpp: init at 25.0.0
* [`3fd273a5`](https://github.com/NixOS/nixpkgs/commit/3fd273a58ce56b104c39d5b8526576c58d713163) gnatPackages.gnatcoll-*(db): 24.0.0 -> 25.0.0
* [`89f4126e`](https://github.com/NixOS/nixpkgs/commit/89f4126ef6c65defa45ddf345731c2e5cbf3169a) linuxPackages.yt6801: init at 1.0.29
* [`cc709d78`](https://github.com/NixOS/nixpkgs/commit/cc709d780fff41eb7f701c39f8e45a4293c7e001) lxi-tools: 2.7 -> 2.8
* [`53a859c1`](https://github.com/NixOS/nixpkgs/commit/53a859c1123def71e1c5aeadae501e458e486aaf) mpvScripts.mpvacious: 0.36 -> 0.37
* [`92cf95af`](https://github.com/NixOS/nixpkgs/commit/92cf95af709ee88f4f4635dbf8027b16c367981e) tatl: init at 1.0
* [`b2f59cd8`](https://github.com/NixOS/nixpkgs/commit/b2f59cd8e0dd47472714fab587197d14c192978e) dafny: add basic test for auto-updates
* [`f9ae4a59`](https://github.com/NixOS/nixpkgs/commit/f9ae4a59aa90f0cfd0b8d4b8d473ad8ecc5f7cbf) rerun: 0.18.2 -> 0.20.2
* [`79f20d92`](https://github.com/NixOS/nixpkgs/commit/79f20d921e8562937a7742e91dc73323eb79848b) zbus-xmlgen: 4.1.0 -> 5.0.1
* [`43694a88`](https://github.com/NixOS/nixpkgs/commit/43694a88d5cdf9f9b5416ba3b2889b9219f1b59a) graphqurl: 1.0.3 -> 2.0.0
* [`f1b1f80d`](https://github.com/NixOS/nixpkgs/commit/f1b1f80d76cc6e2cb43ef710526ae77431b6da3f) coccinelle: 1.2 -> 1.3.0
* [`3296dbec`](https://github.com/NixOS/nixpkgs/commit/3296dbecf93aa9e53818bc7f6e3fdc45d196b29d) fetchmail: 6.4.39 -> 6.5.1
* [`495ddbdf`](https://github.com/NixOS/nixpkgs/commit/495ddbdf05282e098abc17cf259bd567addc147f) xmlsec: 1.3.5 -> 1.3.6
* [`3d50bbbc`](https://github.com/NixOS/nixpkgs/commit/3d50bbbc57c871410c21adb714f0876d33f0cabf) libsolv: 0.7.30 -> 0.7.31
* [`65dba705`](https://github.com/NixOS/nixpkgs/commit/65dba705fff86c179ea8fe22cd5ff8be36b6a5cb) ldb: 2.9.1 -> 2.9.2
* [`69c6d0f4`](https://github.com/NixOS/nixpkgs/commit/69c6d0f4a739b4d19de986e73ca0bf2467543000) libgpiod: 2.1.3 -> 2.2
* [`e533ee3a`](https://github.com/NixOS/nixpkgs/commit/e533ee3a5ee607053ac9843c424e237ba9576a89) libmysqlconnectorcpp: 9.0.0 -> 9.1.0
* [`46ac60f1`](https://github.com/NixOS/nixpkgs/commit/46ac60f1b0e7deacff900bdd81af561bc61e55f5) ocamlPackages.lwt: 5.8.0 -> 5.9.0
* [`de0d5b39`](https://github.com/NixOS/nixpkgs/commit/de0d5b399bd52fbb784876595a5b9bb2dc7b0249) ipmitool: fix hash
* [`36a73cab`](https://github.com/NixOS/nixpkgs/commit/36a73cab5004a795522cbfa2eaf28b6892eb5197) aws-lc: init at 1.39.0
* [`88ac0566`](https://github.com/NixOS/nixpkgs/commit/88ac05665bc6a85aabe78070b99fd23ad1675409) labelle: 1.2.3 --> 1.3.2
* [`5c2af8e3`](https://github.com/NixOS/nixpkgs/commit/5c2af8e353dd6d87fe5ae7e78546404f619f70d3) linuxPackages.cryptodev: 1.13 -> 1.14
* [`a0a03bc5`](https://github.com/NixOS/nixpkgs/commit/a0a03bc535a34a626ebe7e93a0a4f79ed4f8f1cf) windterm: init at 2.6.1
* [`898659b9`](https://github.com/NixOS/nixpkgs/commit/898659b94d54aa2da3150bc6ae17411a7758402b) trippy: 0.11.0 -> 0.12.0
* [`1c1cc8c0`](https://github.com/NixOS/nixpkgs/commit/1c1cc8c0c0563a0fc81bd0fc3a3f289a45b9ab1a) couchdb3: 3.4.1 -> 3.4.2
* [`ccf1ea95`](https://github.com/NixOS/nixpkgs/commit/ccf1ea953ad3c966d9a1609650a9837843421368) inferno: 0.11.21 -> 0.12.0
* [`2c8966ef`](https://github.com/NixOS/nixpkgs/commit/2c8966ef551a730212096188fe01bc3d78b002e6) miniaudicle: 1.5.3.0 -> 1.5.4.2
* [`d05a8387`](https://github.com/NixOS/nixpkgs/commit/d05a83872fabd3044691b1e90a0f444cf83947c2) libffcall: 2.4 -> 2.5
* [`259890a1`](https://github.com/NixOS/nixpkgs/commit/259890a12f0ffc9a2f113e53617cf17af913d3c6) guile-zlib: 0.1.0 -> 0.2.1
* [`142d9d8e`](https://github.com/NixOS/nixpkgs/commit/142d9d8ecf6747762ba9e2707f9fcc3055991cb5) groovy: 4.0.23 -> 4.0.24
* [`d275db64`](https://github.com/NixOS/nixpkgs/commit/d275db64814a9a4bf53aa1b5bd7ab4a46a6e2066) snd: 24.8 -> 24.9
* [`ae5c692c`](https://github.com/NixOS/nixpkgs/commit/ae5c692c9cf39cc717f5c0612f1ac9ee0370b0ca) qcad: 3.31.1.2 -> 3.31.2.3
* [`dfeab1d2`](https://github.com/NixOS/nixpkgs/commit/dfeab1d25457b1550c6f6fe31798fa19ddd7c14b) nzbget: 24.3 -> 24.5
* [`c52cded1`](https://github.com/NixOS/nixpkgs/commit/c52cded148f33cdce989a29015d0971283e46e8c) opam-publish: 2.4.0 -> 2.5.0
* [`51042af5`](https://github.com/NixOS/nixpkgs/commit/51042af598bf33b1709a91b9ed03830e6f3dc97d) guile-git: 0.8.0 -> 0.9.0
* [`12ed4047`](https://github.com/NixOS/nixpkgs/commit/12ed40470f1974521fe01b9df4cdc36e97251ee7) terser: 5.34.1 -> 5.36.0
* [`06297fe1`](https://github.com/NixOS/nixpkgs/commit/06297fe1cb787886607c457745ef44d08b36cf6f) yaydl: 0.15.5 -> 0.17.1
* [`7327a7b5`](https://github.com/NixOS/nixpkgs/commit/7327a7b5bda200f9f881172596b9832acc76856a) libation: 11.4.1 -> 11.5.5
* [`beca2bd9`](https://github.com/NixOS/nixpkgs/commit/beca2bd9b2bd48c2336d083fb3e7f8fd4b8e80f1) whistle: 2.9.86 -> 2.9.90
* [`c22957c7`](https://github.com/NixOS/nixpkgs/commit/c22957c77833972979791a3dc189f5504bd6363f) tdb: 1.4.11 -> 1.4.12
* [`b282ad16`](https://github.com/NixOS/nixpkgs/commit/b282ad165a8c4c433a8cefd9e237d4260d0bbc1a) nixos/evremap: extend key type
* [`d7ad16e5`](https://github.com/NixOS/nixpkgs/commit/d7ad16e525c18f36e2ca193194dfba8b25774722) nixos/evremap: add option phys
* [`1e8e314f`](https://github.com/NixOS/nixpkgs/commit/1e8e314fdb1e5841f40e0ba6810465d9b1d2255c) nixos/acme: fix cert ownership assert message
* [`d3bf1f6d`](https://github.com/NixOS/nixpkgs/commit/d3bf1f6db4fdcfcb53a6504674f73d531828e4c3) objconv: 2.54 -> 2.54.1
* [`a34d3ce6`](https://github.com/NixOS/nixpkgs/commit/a34d3ce69ffdf95dc935da9e700375249488332d) jmol: 16.3.1 -> 16.3.5
* [`9a98ab05`](https://github.com/NixOS/nixpkgs/commit/9a98ab0570c3b6d785be010be0dfde83d71532fc) bwbasic: 3.20 -> 3.30
* [`6dcd66e0`](https://github.com/NixOS/nixpkgs/commit/6dcd66e0d26f8e53fda45b0e0a4644738ac8f06f) flyway: 10.20.1 -> 11.0.1
* [`62601ddf`](https://github.com/NixOS/nixpkgs/commit/62601ddfc36eb1bc7674c586a49a92a4b243e08d) bmake: 20240921 -> 20241124
* [`5dfd070f`](https://github.com/NixOS/nixpkgs/commit/5dfd070f2b63f50362922120f24102a9a2427737) librealsense-gui: 2.56.2 -> 2.56.3
* [`9c1ac764`](https://github.com/NixOS/nixpkgs/commit/9c1ac764a23b24a2de59212f2d37e0881cf36380) python3Packages.hightime: init at 0.2.2
* [`2abceb3a`](https://github.com/NixOS/nixpkgs/commit/2abceb3ac64f22a1e8c0ae7532ed6986b0109bf3) python3Packages.nidaqmx: 0.5.7 -> 1.0.2
* [`77e81fd8`](https://github.com/NixOS/nixpkgs/commit/77e81fd8604b8bddc921244d56c42ef5aa70289a) nixos/podman: add systemd to extraPackages
* [`01238658`](https://github.com/NixOS/nixpkgs/commit/012386585546bc314563db23d7c2db9fe03d8641) cudaPackages.nccl-tests: 2.13.10 -> 2.13.11
* [`0b109d41`](https://github.com/NixOS/nixpkgs/commit/0b109d41efc9e2eb7f85b38683b1aac44259df05) ckbcomp: 1.231 -> 1.232
* [`4175383b`](https://github.com/NixOS/nixpkgs/commit/4175383bc7b3b74127d66ffd8e83c100e9d2d8d4) libdatachannel: 0.22.2 -> 0.22.3
* [`dcdf6442`](https://github.com/NixOS/nixpkgs/commit/dcdf644229f3a5b5b16be93525fc75df900396d7) git-mit: 5.13.30 -> 5.14.2
* [`217be60f`](https://github.com/NixOS/nixpkgs/commit/217be60f2842db5c0d36962e9547a1f6c48df832) xmrig: 6.22.0 -> 6.22.2
* [`457e98b6`](https://github.com/NixOS/nixpkgs/commit/457e98b611a616bfaa1632143bce1198ef43a45e) shadowsocks-rust: 1.21.1 -> 1.21.2
* [`ca9a6381`](https://github.com/NixOS/nixpkgs/commit/ca9a6381a7c038c75d84952c2764d98d92f8838b) mutagen-compose: 0.18.0 -> 0.18.0-1
* [`e530b7d4`](https://github.com/NixOS/nixpkgs/commit/e530b7d4c7af2330e7e4983a7e4c679de3e0bb84) gap: 4.13.1 -> 4.14.0
* [`5b138248`](https://github.com/NixOS/nixpkgs/commit/5b138248b820d51e71a91a5568cf91d25ee097ed) nagios: 4.5.4 -> 4.5.8
* [`3b3bd00e`](https://github.com/NixOS/nixpkgs/commit/3b3bd00e95bbbf6df9e3a99dc6c239a573ecbe3e) snipe-it: 7.0.13 -> 7.1.15
* [`c1a47f8e`](https://github.com/NixOS/nixpkgs/commit/c1a47f8e5afe12da4da05ac0c834427453c69429) diffoscope: 283 -> 284
* [`1648e197`](https://github.com/NixOS/nixpkgs/commit/1648e1973a1d5b7d737017a9de7bd40a523d98e7) libcifpp: 7.0.7 -> 7.0.8
* [`2a7ba9a5`](https://github.com/NixOS/nixpkgs/commit/2a7ba9a529197951f737a33263d73daa0f711f7c) benthos: 4.40.0 -> 4.42.0
* [`bc70bd62`](https://github.com/NixOS/nixpkgs/commit/bc70bd6290b6128b47ef458938ea838b5343dabc) glances: 4.2.0 -> 4.2.1
* [`70857bc3`](https://github.com/NixOS/nixpkgs/commit/70857bc325128fc74c6a15ab4f9173f9902b68dc) librepo: 1.18.1 -> 1.19.0
* [`c11b1569`](https://github.com/NixOS/nixpkgs/commit/c11b156913e1a03e25c29af375237d863fc9f047) glasgow: 0-unstable-2024-10-24 -> 0-unstable-2024-12-02
* [`2a75ecc5`](https://github.com/NixOS/nixpkgs/commit/2a75ecc52b6b01077b125b407d39262c5d4fad80) python312Packages.go2rtc-client: 0.1.1 -> 0.1.2
* [`d22eeb20`](https://github.com/NixOS/nixpkgs/commit/d22eeb20ea4c7a6561682a9757c6184870ab5020) nixos/evremap: fix toml config generation
* [`2e030327`](https://github.com/NixOS/nixpkgs/commit/2e030327a622c11372787d40c48b6c358d055429) grandorgue: 3.15.2-1 -> 3.15.3-1
* [`cee45b14`](https://github.com/NixOS/nixpkgs/commit/cee45b14e621b4acc76b5cc01681d84cf9e54c07) nixos/evremap: use nixfmt
* [`67bf4766`](https://github.com/NixOS/nixpkgs/commit/67bf4766e5eb722fec5ed072c804d3b70e4c550f) cloudfoundry-cli: 8.8.2 -> 8.9.0
* [`a71dd721`](https://github.com/NixOS/nixpkgs/commit/a71dd7213e998e0d85c36b7c3c8a824e515729a3) patchelfUnstable: 0.18.0-unstable-2024-06-15 -> 0.18.0-unstable-2024-11-18
* [`f4f8f7cf`](https://github.com/NixOS/nixpkgs/commit/f4f8f7cff026e5d1528704efb0684de6bbcd40a4) brev-cli: 0.6.295 -> 0.6.302
* [`0b0613a2`](https://github.com/NixOS/nixpkgs/commit/0b0613a2ebb3fa0772e5180826131d1bc1cf7066) nelua: 0-unstable-2024-10-18 -> 0-unstable-2024-12-05
* [`5284e69d`](https://github.com/NixOS/nixpkgs/commit/5284e69de285d721546b84898adcdbaa714a2b38) instaloader: 4.13.2 -> 4.14
* [`ea0ae55a`](https://github.com/NixOS/nixpkgs/commit/ea0ae55a1f566ef0e642f356a8561160d71cf560) cdogs-sdl: 2.1.0 -> 2.2.0
* [`e973c3ee`](https://github.com/NixOS/nixpkgs/commit/e973c3ee013bcf9aca94499bbc2c476084354f8d) oha: 1.4.7 -> 1.5.0
* [`bcf3cd83`](https://github.com/NixOS/nixpkgs/commit/bcf3cd8305666922bdce77bc4e7acb780abcbcf3) gigalixir: 1.12.1 -> 1.13.1
* [`96f44d4f`](https://github.com/NixOS/nixpkgs/commit/96f44d4fe6a5d6c08b2a064c69ddee9224f4589b) moodle-dl: 2.3.12 -> 2.3.13
* [`6628ffa7`](https://github.com/NixOS/nixpkgs/commit/6628ffa74c11a9c378206096bdb5b027046c8ab8) yandex-cloud: 0.136.0 -> 0.140.0
* [`3fb3dbe4`](https://github.com/NixOS/nixpkgs/commit/3fb3dbe4265dda734f1e39aaf187746500d4cf0a) cppcheck: 2.16.0 -> 2.16.1
* [`7380e2e0`](https://github.com/NixOS/nixpkgs/commit/7380e2e0ba0e447ef2f443f2a8245a2b9e06eb87) dblab: 0.26.0 -> 0.29.0
* [`80c02397`](https://github.com/NixOS/nixpkgs/commit/80c02397c25d60416e96dc69f68afc2e596a1341) lazysql: 0.3.0 -> 0.3.2
* [`38096ffd`](https://github.com/NixOS/nixpkgs/commit/38096ffd97529b9850dcedd76181a32d20af7fdc) katana: 1.1.1 -> 1.1.2
* [`a0fe7081`](https://github.com/NixOS/nixpkgs/commit/a0fe708135592f6a0acab794cfdd92445764ef8d) babashka-unwrapped: 1.12.194 -> 1.12.195
* [`1d041214`](https://github.com/NixOS/nixpkgs/commit/1d041214642d9913c8d3586e40b27ae15b625e8d) melange: 0.14.10 -> 0.17.3
* [`ad8830af`](https://github.com/NixOS/nixpkgs/commit/ad8830af00b07558136c963d9f15e159ca891299) go-ios: 1.0.155 -> 1.0.162
* [`855fcab0`](https://github.com/NixOS/nixpkgs/commit/855fcab0f0d1c072c6986e64f83d282cebd36e28) pdf-parser: 0.7.9 -> 0.7.10
* [`1a66083b`](https://github.com/NixOS/nixpkgs/commit/1a66083b27aaf508b0b761dbaf5c1e138de313b4) skypilot: 0.6.1 -> 0.7.0
* [`bece2962`](https://github.com/NixOS/nixpkgs/commit/bece2962dbec86c924447b65b3f24c4e0f82cf04) grizzly: 0.5.0 -> 0.6.1
* [`3906ab30`](https://github.com/NixOS/nixpkgs/commit/3906ab30d83504aa08ae0d57e3f5cfc5573fabd9) moq: 0.5.0 -> 0.5.1
* [`dc1c0287`](https://github.com/NixOS/nixpkgs/commit/dc1c0287d1ae7dcd87af13a5a63e137f5f31a599) fzf-make: 0.37.0 -> 0.42.0
* [`94c1dcc9`](https://github.com/NixOS/nixpkgs/commit/94c1dcc912ae654b21278ba7411298b224a3ad26) vitess: 21.0.0 -> 21.0.1
* [`37f921b4`](https://github.com/NixOS/nixpkgs/commit/37f921b419ae6a06f8bbd154631f26057e414afb) steampipePackages.steampipe-plugin-azure: 1.0.0 -> 1.1.0
* [`6822dabb`](https://github.com/NixOS/nixpkgs/commit/6822dabb7868a22c553600f02c5e2dc586ef9e27) re-flex: 5.0.1 -> 5.1.0
* [`5019f181`](https://github.com/NixOS/nixpkgs/commit/5019f181f976d36e7c678417d53264d379e8560a) python312Packages.mdformat-mkdocs: 3.0.1 -> 3.1.1
* [`4ef90206`](https://github.com/NixOS/nixpkgs/commit/4ef90206676e43c9c9378793591138be3dca3eea) relic: 8.1.0 -> 8.1.1
* [`a3a51aba`](https://github.com/NixOS/nixpkgs/commit/a3a51aba374f14a8f295f3757abf827852fc2082) docker-compose: 2.30.3 -> 2.31.0
* [`ec2bb3bd`](https://github.com/NixOS/nixpkgs/commit/ec2bb3bdc41a524c2a37e8e34246cc14f38b029e) argc: 1.21.0 -> 1.21.1
* [`c2167a60`](https://github.com/NixOS/nixpkgs/commit/c2167a60c901f97c12de62dfe61eacf845aca7f8) argo: 3.5.12 -> 3.6.2
* [`2712c412`](https://github.com/NixOS/nixpkgs/commit/2712c412007a41f33f8d15c57649018278fc2ff7) buildkit: 0.17.0 -> 0.18.1
* [`fcdc5ba4`](https://github.com/NixOS/nixpkgs/commit/fcdc5ba4805bfe46d9489310467c62419ab6bc1c) python312Packages.pallets-sphinx-themes: 2.1.3 -> 2.3.0
* [`186761aa`](https://github.com/NixOS/nixpkgs/commit/186761aafae442728e72824c36b8f75a1347f94e) python312Packages.hcs-utils: fix build
* [`4bce075e`](https://github.com/NixOS/nixpkgs/commit/4bce075e9618d4fc0070bc8a25b99abcb4287461) iroh: 0.26.0 -> 0.29.0
* [`17f6ab6d`](https://github.com/NixOS/nixpkgs/commit/17f6ab6d4a41177cc12f0cf1afd070b2ab34e471) stress-ng: 0.18.06 -> 0.18.07
* [`42e358e4`](https://github.com/NixOS/nixpkgs/commit/42e358e40912b3f283649bfa40ea6336d50a02ac) wallabag: 2.6.9 -> 2.6.10
* [`abf1b2d9`](https://github.com/NixOS/nixpkgs/commit/abf1b2d976231d59131ab3213a0059589c292937) jamulus: format
* [`3eb23b1f`](https://github.com/NixOS/nixpkgs/commit/3eb23b1f230300f14550dfcabe79b197297fffd1) schemacrawler: 16.22.3 -> 16.23.2
* [`a8d9bda3`](https://github.com/NixOS/nixpkgs/commit/a8d9bda30131edfc3629f6a26450adcb94f44f68) ft2-clone: 1.88 -> 1.89
* [`361a4743`](https://github.com/NixOS/nixpkgs/commit/361a47432c24db48ff87ccc74ce356da454fd161) revive: 1.4.0 -> 1.5.1
* [`4d51cb2b`](https://github.com/NixOS/nixpkgs/commit/4d51cb2b1be7a6704d3461e2d51f2e83ba7b092e) credhub-cli: 2.9.38 -> 2.9.39
* [`624e6797`](https://github.com/NixOS/nixpkgs/commit/624e679794a7ab49168017af4c654d142db7fc09) leo-editor: 6.8.2 -> 6.8.3
* [`377de3e1`](https://github.com/NixOS/nixpkgs/commit/377de3e1ff7cfb55da9d8ccbdb13856e980dfbd3) nest-cli: 10.4.7 -> 10.4.8
* [`1575ebf5`](https://github.com/NixOS/nixpkgs/commit/1575ebf5b29039a73ddb6fe4f02209444c77aff1) ab-av1: 0.7.19 -> 0.8.0
* [`72f2aa5b`](https://github.com/NixOS/nixpkgs/commit/72f2aa5b4275ca8ec17b2526e53e31af59efe2db) liblxi: 1.21 -> 1.22
* [`f66387d5`](https://github.com/NixOS/nixpkgs/commit/f66387d56b9dfd918b2dbbb6cc0635360a41f5f2) r2mod_cli: 1.3.3 -> 1.3.3.1
* [`c5c4e85a`](https://github.com/NixOS/nixpkgs/commit/c5c4e85aea71512427edfa87583e2b248a05a43b) shaarli: 0.13.0 -> 0.14.0
* [`2109df66`](https://github.com/NixOS/nixpkgs/commit/2109df66719aa8660e3baa336503773cb5516c79) typeshare: 1.11.0 -> 1.13.2
* [`8d1df57a`](https://github.com/NixOS/nixpkgs/commit/8d1df57af88836835b11967a4e7242f65706d922) openfga: 1.8.0 -> 1.8.1
* [`e1024e58`](https://github.com/NixOS/nixpkgs/commit/e1024e584599144a9c120c19c6e2f021c976ea98) erg: 0.6.47 -> 0.6.48
* [`b4201751`](https://github.com/NixOS/nixpkgs/commit/b4201751907e15de2ce291e3ce342632fa985638) dotenvx: 1.22.0 -> 1.28.0
* [`0b6183dd`](https://github.com/NixOS/nixpkgs/commit/0b6183dd697bc769a1f7ce0ce929060caa7e3006) go-mockery: 2.46.3 -> 2.50.0
* [`4a2da200`](https://github.com/NixOS/nixpkgs/commit/4a2da200dbf320d91e544c52693dcd32e8110544) typos-lsp: 0.1.30 -> 0.1.31
* [`5c635fc4`](https://github.com/NixOS/nixpkgs/commit/5c635fc4ff772b49c67c85c04e04bcac17072da9) dbmate: 2.22.0 -> 2.23.0
* [`a7bd4cf7`](https://github.com/NixOS/nixpkgs/commit/a7bd4cf78e6c019d97e57a560282e5c25697046e) python312Packages.sphinx-intl: 2.3.0 -> 2.3.1
* [`b63af16d`](https://github.com/NixOS/nixpkgs/commit/b63af16d500cc0c191b0d15f704ed9b16d976987) sqlboiler: 4.17.0 -> 4.17.1
* [`9db021f5`](https://github.com/NixOS/nixpkgs/commit/9db021f514d073cc526a50f08d147b7f46a8d38a) hwatch: 0.3.16 -> 0.3.18
* [`3d60714d`](https://github.com/NixOS/nixpkgs/commit/3d60714d15fe090fbfa4064c4b0c60b9b1f1489b) container2wasm: 0.7.0 -> 0.7.1
* [`42fb6945`](https://github.com/NixOS/nixpkgs/commit/42fb6945732973121b55f2b9021667503c1c5df5) function-runner: 6.3.0 -> 6.4.0
* [`93b894f2`](https://github.com/NixOS/nixpkgs/commit/93b894f2cd60a616886c466ae0c60e7cf67e0059) cargo-mutants: 24.11.0 -> 24.11.2
* [`323491f4`](https://github.com/NixOS/nixpkgs/commit/323491f4795dacefd58fed2a2f604ba6e220bed7) openxr-loader: 1.1.42 -> 1.1.43
* [`7bd33c31`](https://github.com/NixOS/nixpkgs/commit/7bd33c314fe8610db5f3645f552b76c70694d163) etesync-dav: format
* [`e8ee2d42`](https://github.com/NixOS/nixpkgs/commit/e8ee2d42c6da74575cc969be9e1be579a799bc32) etesync-dav: 0.32.1-unstable-2024-09-02 -> 0.33.4
* [`fdf93b50`](https://github.com/NixOS/nixpkgs/commit/fdf93b5022daee3dc2a4f844a39d3ad0483693be) testkube: 2.1.61 -> 2.1.72
* [`0f021198`](https://github.com/NixOS/nixpkgs/commit/0f02119852220556ad321b8b6d8dc4d3298cd33b) ansible-navigator: 24.9.0 -> 24.10.0
* [`fc948876`](https://github.com/NixOS/nixpkgs/commit/fc94887663a0aaa3d296d7f16aa7bbe15d36c5a6) centrifugo: 5.4.7 -> 5.4.8
* [`d55b3c0f`](https://github.com/NixOS/nixpkgs/commit/d55b3c0f1bf40b270682de6166d45df66b316218) hashlink: 1.13 -> 1.14
* [`782085a4`](https://github.com/NixOS/nixpkgs/commit/782085a4ad360daf04ef81e8ef52480807c947b2) mitra: 3.9.0 -> 3.11.0
* [`5d83ea3b`](https://github.com/NixOS/nixpkgs/commit/5d83ea3b9d4fe5226a9ac743ec0e5937db9d3835) dl-librescore: 0.35.17 -> 0.35.20
* [`ab8291d1`](https://github.com/NixOS/nixpkgs/commit/ab8291d1f08a6b06c6ff38ee3ec284972561ee4e) sentry-cli: 2.38.2 -> 2.39.1
* [`39fc6d4b`](https://github.com/NixOS/nixpkgs/commit/39fc6d4b92d0efdb994e62ba3d241dc389d31f13) luigi: 3.5.2 -> 3.6.0
* [`ed5608b8`](https://github.com/NixOS/nixpkgs/commit/ed5608b888bc4d312dd5c6374e74a4b656b1ecb3) nextcloud30Packages.apps.recognize: 8.1.1->8.2.0
* [`0feebd4a`](https://github.com/NixOS/nixpkgs/commit/0feebd4a76451724f434662b12d184345e77c341) ostree: add composefs support
* [`3534991c`](https://github.com/NixOS/nixpkgs/commit/3534991cf8db4988ddecc0b3a8e89b0f53f57179) bootc: add composefs support
* [`02044641`](https://github.com/NixOS/nixpkgs/commit/020446415171e24e171adb53b636b8330818c83e) python312Packages.oddsprout: fix test on darwin
* [`0479e6ee`](https://github.com/NixOS/nixpkgs/commit/0479e6ee96243861e13bd9343e59feeb621dd3c9) nextcloudXXPackages.apps.recognize: suport nextcloud 29 and 28
* [`4b799153`](https://github.com/NixOS/nixpkgs/commit/4b79915311883e9e6faab0bf3da464fc70bc6467) protoc-gen-es: 2.2.2 -> 2.2.3
* [`18a0cbaa`](https://github.com/NixOS/nixpkgs/commit/18a0cbaae4380439b1caf5e895485e3f88c5bb9a) dolt: 1.43.15 -> 1.44.0
* [`a0a016f9`](https://github.com/NixOS/nixpkgs/commit/a0a016f9e4f625fb317bfbe6ee05fc770860b7c4) tanka: 0.29.0 -> 0.30.2
* [`2c87ea37`](https://github.com/NixOS/nixpkgs/commit/2c87ea374c3818ddd1945a1da671a004f2881b4c) tonelib-metal: format
* [`75c8475e`](https://github.com/NixOS/nixpkgs/commit/75c8475e45600ff31d86b222696e5f78ed1f2c02) tonelib-metal: 1.2.6 -> 1.3.0
* [`cf49d14d`](https://github.com/NixOS/nixpkgs/commit/cf49d14dfa41465e3cebbe60b850896aaa856995) tonelib-noisereducer: format
* [`40d0e04c`](https://github.com/NixOS/nixpkgs/commit/40d0e04cd06280364e74473c8ebd60c10e827985) tonelib-noisereducer: 1.2.0 -> 2.0
* [`e68ea691`](https://github.com/NixOS/nixpkgs/commit/e68ea6914dea5b038412c429ee347e06aaa52bb0) nixos/evremap: incorporate changes from review
* [`030b9607`](https://github.com/NixOS/nixpkgs/commit/030b96073cc9c86fa4567818de564348aeb6068d) powertabeditor: init at 2.0.21
* [`6a5dc7cb`](https://github.com/NixOS/nixpkgs/commit/6a5dc7cbd5a711815eb72a9d2815bbc4d238153f) nixos/evremap: add option phys
* [`1310ec6f`](https://github.com/NixOS/nixpkgs/commit/1310ec6fd810226535bb7e94dcb5f136beec705a) hsd: 6.1.1 -> 7.0.0
* [`8feb14ce`](https://github.com/NixOS/nixpkgs/commit/8feb14ce118b7b01ea0c7af6f57c4048e42e64b5) kbld: 0.44.1 -> 0.45.0
* [`145fecbb`](https://github.com/NixOS/nixpkgs/commit/145fecbbe8bd4ac2999da7182b425381f023f0dc) soft-serve: 0.7.6 -> 0.8.0
* [`f30d7261`](https://github.com/NixOS/nixpkgs/commit/f30d726162e4c334aec58aa2ce48d054d8184cde) stackql: 0.5.748 -> 0.6.7
* [`d2db437c`](https://github.com/NixOS/nixpkgs/commit/d2db437c6f2e982e0344ada870c24c34871001fe) python3Packages.nox: Remove optional dependencies from testing
* [`8bf2474b`](https://github.com/NixOS/nixpkgs/commit/8bf2474b6414ab09bee64007b77c6aed33a6d927) arpack: add top arpack-mpi attribute
* [`21a0a5a4`](https://github.com/NixOS/nixpkgs/commit/21a0a5a406c43a096f8772a9e7018de96ff5b411) optifine: 1.21.1_HD_U_J1 -> 1.21.3_HD_U_J2
* [`86b469a7`](https://github.com/NixOS/nixpkgs/commit/86b469a7d0a44dc87e6870ffb40784ab3999c796) marp-cli: 3.4.0 -> 4.0.0
* [`98402f0f`](https://github.com/NixOS/nixpkgs/commit/98402f0f344d8c544cba129396f58034b9d3927e) marp-cli: 4.0.0 -> 4.0.3
* [`34cba6c3`](https://github.com/NixOS/nixpkgs/commit/34cba6c33ecb5c1ec55966d16e6f60aa3119d7d8) lief: 0.15.1 -> 0.16.0
* [`11ba3ebb`](https://github.com/NixOS/nixpkgs/commit/11ba3ebb737810449d96642e2e4a239a6bfda8c6) rshell: 0.0.33 -> 0.0.36
* [`25ddf18a`](https://github.com/NixOS/nixpkgs/commit/25ddf18a62efa7bb255a979909288cc54f4662b3) nu_scripts: 0-unstable-2024-11-10 -> 0-unstable-2024-12-08
* [`6670bc51`](https://github.com/NixOS/nixpkgs/commit/6670bc5197f636b5865f5cba218507f3315c6b18) scraper: 0.21.0 -> 0.22.0
* [`dfe822b9`](https://github.com/NixOS/nixpkgs/commit/dfe822b99bf691b53bc66a24c6bf80d2f7ea802f) python312Packages.rns: 0.8.6 -> 0.8.7
* [`c3bf5330`](https://github.com/NixOS/nixpkgs/commit/c3bf5330e34c438311186c6d7fed6ccb0cbb5d2f) python312Packages.nomadnet: 0.5.4 -> 0.5.5
* [`e0c9172e`](https://github.com/NixOS/nixpkgs/commit/e0c9172e54463410be876eb6338657456214c97e) kyverno: 1.13.1 -> 1.13.2
* [`269a4110`](https://github.com/NixOS/nixpkgs/commit/269a4110f394482418c895616df104b14bf6eba9) mmctl: 9.11.5 -> 9.11.6
* [`e212a541`](https://github.com/NixOS/nixpkgs/commit/e212a5419c63eed490e518557544dc47a5edc7dc) yourkit-java: 2024.9-b159 -> 2024.9-b160
* [`ca490fc0`](https://github.com/NixOS/nixpkgs/commit/ca490fc0b3a33b86c414774e8741826d54d5d79c) silice: 0-unstable-2024-07-22 -> 0-unstable-2024-12-02
* [`989e8364`](https://github.com/NixOS/nixpkgs/commit/989e83646c4d045919d0ef659e2027b08aa7246e) dbgate: Add support for aarch64-darwin
* [`bc84ae7b`](https://github.com/NixOS/nixpkgs/commit/bc84ae7bdf047f020e763aeabc6acf5d361e6049) codebuff: 1.0.99 -> 1.0.119 and rename from manicode
* [`c55d5fc3`](https://github.com/NixOS/nixpkgs/commit/c55d5fc3dc66d24ff719a3d31559bef1619e8ab1) dbgate: 5.3.4 -> 6.0.0
* [`0f4d1da0`](https://github.com/NixOS/nixpkgs/commit/0f4d1da02a97ef69862dc0dd61aa593b92fbffe7) kaldi: 0-unstable-2024-10-04 -> 0-unstable-2024-11-29
* [`207fd3a4`](https://github.com/NixOS/nixpkgs/commit/207fd3a40368f244d9b64a72295a4e40ac370817) freetds: 1.4.23 -> 1.4.24
* [`aaf03d7f`](https://github.com/NixOS/nixpkgs/commit/aaf03d7f0022f77ba1c2656ff0aec88ae7b36597) sunshine: move to by-name
* [`7b727784`](https://github.com/NixOS/nixpkgs/commit/7b72778438dbd2768c9da52123526d2cc1906e59) overturemaps: 0.10.0 -> 0.11.0
* [`edde220e`](https://github.com/NixOS/nixpkgs/commit/edde220e33472926173ab77fc402452e1e1bf8b0) jamulus: refactor
* [`a164ceb7`](https://github.com/NixOS/nixpkgs/commit/a164ceb7f37b42476879795aef86bc3d1afbf5b4) jamulus: 3.10.0 -> 3.11.0
* [`cdfe2245`](https://github.com/NixOS/nixpkgs/commit/cdfe22455a0eb0cc4833726585834b14b144e1e3) jamulus: move to by-name
* [`2ffd9dec`](https://github.com/NixOS/nixpkgs/commit/2ffd9decddeadc8b7883ec20fcda98df5f72ab7a) moodle: 4.4.4 -> 4.4.5
* [`7895f517`](https://github.com/NixOS/nixpkgs/commit/7895f51712a131d2928957e4e4fe742c855903bf) kyverno-chainsaw: 0.2.11 -> 0.2.12
* [`c648006f`](https://github.com/NixOS/nixpkgs/commit/c648006faf395679687f96f7f53e16f55d1b6421) murex: 6.3.4225 -> 6.4.1005
* [`eaa80072`](https://github.com/NixOS/nixpkgs/commit/eaa80072eac16d3b037c8a68534a456847037ecf) heisenbridge: 1.14.6 -> 1.15.0
* [`6456702e`](https://github.com/NixOS/nixpkgs/commit/6456702e1233c3606f7214fc92532b47fa63e0e9) htslib: 1.19.1 -> 1.21
* [`18f1813d`](https://github.com/NixOS/nixpkgs/commit/18f1813d7a867abcbbdf364328769d973a01df07) box64: 0.3.0 -> 0.3.2
* [`daa49dca`](https://github.com/NixOS/nixpkgs/commit/daa49dca79c7bffdf9f8bba45777f864ca87ae10) thanos: 0.36.1 -> 0.37.2
* [`06ad4b59`](https://github.com/NixOS/nixpkgs/commit/06ad4b594ac68be8304a805ef2abe8840d06b25e) gscreenshot: 3.7.0 -> 3.8.0
* [`d37af857`](https://github.com/NixOS/nixpkgs/commit/d37af857a484e9984c4c4c99db5bb540de574daa) kavita: 0.8.3.2 -> 0.8.4.2
* [`a94f0553`](https://github.com/NixOS/nixpkgs/commit/a94f055308dde40d94d0002a32ba528f8c33632a)  asciinema-agg: migrate to by-name
* [`b6cf4162`](https://github.com/NixOS/nixpkgs/commit/b6cf4162f9317e00541d8cdce0062f73ff52e177) kokkos: 4.4.01 -> 4.5.00
* [`4722e2b5`](https://github.com/NixOS/nixpkgs/commit/4722e2b5e9c2469bdf490e94cc8443f0d9353485) asciinema-agg: refactor
* [`4eee326d`](https://github.com/NixOS/nixpkgs/commit/4eee326d87cea93d0c44868d4b004085cd6a9157) asciinema-agg: 1.4.3 -> 1.5.0
* [`77e5f5a5`](https://github.com/NixOS/nixpkgs/commit/77e5f5a573b52854c62a1ae4cfd51b402c75bbe0) papermc: 1.21.3-53 -> 1.21.4-12
* [`361c900e`](https://github.com/NixOS/nixpkgs/commit/361c900e70e1e73513f82b7a721e567d970dc13f) global: 6.6.13 -> 6.6.14
* [`7e1f85a5`](https://github.com/NixOS/nixpkgs/commit/7e1f85a54350b979013dacda4e0d61a2823eb691) kapp: 0.63.3 -> 0.64.0
* [`b33ef4e8`](https://github.com/NixOS/nixpkgs/commit/b33ef4e86d8db35f9123423c83beb88abee04308) regbot: 0.7.2 -> 0.8.0
* [`9625d9bf`](https://github.com/NixOS/nixpkgs/commit/9625d9bf0c4c9dbbc355bedbb0e036a73a1de462) maintainers: add xiaoxiangmoe
* [`a17c823d`](https://github.com/NixOS/nixpkgs/commit/a17c823d401ea8acf7c4c1f65d3bec90a21e6f03) affine-bin: rename affine to affine-bin
* [`cb237b03`](https://github.com/NixOS/nixpkgs/commit/cb237b0342b66b4f33f87862fc3bfeb85313184b) affine-bin: add macos support
* [`e3f98e17`](https://github.com/NixOS/nixpkgs/commit/e3f98e17bfd443d826229f1b0f304634e5c14ad8) affine: add affine building from source
* [`dd0f9811`](https://github.com/NixOS/nixpkgs/commit/dd0f9811e0f5a797afb8b6701ad404c87bc63445) dart.metadata_god: init
* [`1b376d5f`](https://github.com/NixOS/nixpkgs/commit/1b376d5f67579a69e3868a0b50d80215f3dafb2b) bloomeetunes: init at 2.10.9
* [`4700e0ac`](https://github.com/NixOS/nixpkgs/commit/4700e0ac5781db1f45b35af5334f1e98457014b4) tone: format
* [`e385b096`](https://github.com/NixOS/nixpkgs/commit/e385b09605d91bb4bf761195b5cb5ae65a869768) simple-live-app: init at 1.7.5
* [`ca0c858a`](https://github.com/NixOS/nixpkgs/commit/ca0c858a92f5edbafb9b1085f27b99febb95910c) asterisk: 20.9.3 -> 20.11.0
* [`853a77c9`](https://github.com/NixOS/nixpkgs/commit/853a77c9b3c0c715fab7f2a3cf6b3002483a95cc) sabnzbd: 4.3.3 -> 4.4.0
* [`115d3a62`](https://github.com/NixOS/nixpkgs/commit/115d3a6238052e8fb9e2f4f71c192356a38f68f8) nextcloud30Packages.apps.recognize: patchPhase -> postPatch
* [`c45a9059`](https://github.com/NixOS/nixpkgs/commit/c45a9059b6374c077a456fb171c4ac140d80597a) vscode-js-debug: 1.95.3 -> 1.96.0
* [`5f21b9c3`](https://github.com/NixOS/nixpkgs/commit/5f21b9c395953cfbe925edd52574ccbca73e8117) terraform-providers.snowflake: 0.98.0 -> 0.99.0
* [`36c9793f`](https://github.com/NixOS/nixpkgs/commit/36c9793f008ad3c7cce637dd861133eeba75f8ad) marksman: 2024-11-20 -> 2024-12-04
* [`cf1909e4`](https://github.com/NixOS/nixpkgs/commit/cf1909e4b8230bc1c1fd478f4b8a78f2756a6f4a) coturn: 4.6.2 -> 4.6.3
* [`86ac5a91`](https://github.com/NixOS/nixpkgs/commit/86ac5a91e3332d956244f713fbfee65ddf8fef67) ibus-engines.table: 1.17.8 -> 1.17.9
* [`bbd051af`](https://github.com/NixOS/nixpkgs/commit/bbd051af56deff5de5d35f3aaacb93d49a2612ea) littlefs-fuse: 2.7.8 -> 2.7.9
* [`75aa1d11`](https://github.com/NixOS/nixpkgs/commit/75aa1d11ac3b0c98886be3c145ebcd9caa1a495f) ceph-csi: 3.12.3 -> 3.13.0
* [`35113df5`](https://github.com/NixOS/nixpkgs/commit/35113df5ec29f38c599c412d4364173078bfdc8b) trillian: 1.6.1 -> 1.7.0
* [`94d95004`](https://github.com/NixOS/nixpkgs/commit/94d9500402aec7778ad5841a80869765eb8d0d1b) quarto: 1.6.37 -> 1.6.39
* [`a6048a80`](https://github.com/NixOS/nixpkgs/commit/a6048a8058bd4e1254bc671f83a034616c0d0a24) sundials: 7.1.1 -> 7.2.0
* [`6d2bc5ae`](https://github.com/NixOS/nixpkgs/commit/6d2bc5ae3a0bf6143a74dda88e6ce9c3ac0c2274) weaviate: 1.27.5 -> 1.28.0
* [`04d175b5`](https://github.com/NixOS/nixpkgs/commit/04d175b54a0eb82c751ce9016930d496e9f4b492) nixos/ollama: add allowed device for WSL compatibility
* [`e88ba378`](https://github.com/NixOS/nixpkgs/commit/e88ba378f6a51cffb609747b2d404111986be81c) rancher: 2.9.0 -> 2.10.0
* [`20f6ff6c`](https://github.com/NixOS/nixpkgs/commit/20f6ff6ccd7d4a019e499e4f6fa5eb5b19525d81) twilio-cli: 5.22.6 -> 5.22.7
* [`8a0aa519`](https://github.com/NixOS/nixpkgs/commit/8a0aa519acb7b3b80bfa4bba83e1a0ec119f9d74) terraform-providers.google: 6.12.0 -> 6.13.0
* [`fa1f66b7`](https://github.com/NixOS/nixpkgs/commit/fa1f66b7040712b13e6af5627760aeb8ac3e56f3) kops_1_30: 1.30.2 -> 1.30.3
* [`43c40252`](https://github.com/NixOS/nixpkgs/commit/43c40252396d41cd496231e834a0440c10595283) terraform-providers.aws: 5.78.0 -> 5.80.0
* [`56bdda78`](https://github.com/NixOS/nixpkgs/commit/56bdda785521767e11f90367d0b5f16f8fc72aed) qbec: 0.16.2 -> 0.16.3
* [`252c7963`](https://github.com/NixOS/nixpkgs/commit/252c7963b1e9351a87656ac52d71b86e15d261fd) tartube-yt-dlp: 2.5.059 -> 2.5.062
* [`a7deef38`](https://github.com/NixOS/nixpkgs/commit/a7deef38b1f2f34278df8d10c9eec90742f47130) clojure-lsp: 2024.08.05-18.16.00 -> 2024.11.08-17.49.29
* [`67a6a597`](https://github.com/NixOS/nixpkgs/commit/67a6a597854aca0526882285f5d8bfde576b00db)  nextcloudXXPackages.apps.recognize: use node from path
* [`4a87aa2f`](https://github.com/NixOS/nixpkgs/commit/4a87aa2f91038aa1dc87363e5c51f43d1237fc1e) nextcloudXXPackages.apps.recognize: use python3 rather than 311
* [`1e3f613d`](https://github.com/NixOS/nixpkgs/commit/1e3f613dc1a405930c47ecd405171bd871e0317a) terraform-providers.rancher2: 5.1.0 -> 6.0.0
* [`cb80b1a1`](https://github.com/NixOS/nixpkgs/commit/cb80b1a199bf333c5957583de36234e3d2c9add0) terraform-providers.tencentcloud: 1.81.142 -> 1.81.147
* [`7956dbb8`](https://github.com/NixOS/nixpkgs/commit/7956dbb8bc3008f30eb33b0fd50434047ed7bcb5) carbon-now-cli: 2.0.0 -> 2.1.0
* [`b6498d18`](https://github.com/NixOS/nixpkgs/commit/b6498d18f9ebe95235ab038254ebc7adb6aea8d8) rt-tests: 2.7 -> 2.8
* [`68d4a7df`](https://github.com/NixOS/nixpkgs/commit/68d4a7df4998cc112d32f38c74bb6004070ee075) nixos/tabby: remove scheduler systemd service
* [`822c245d`](https://github.com/NixOS/nixpkgs/commit/822c245dbf7ad1fb99c6177b02c8e37554ef2d75) nixos/tabby: add host option
* [`1193c469`](https://github.com/NixOS/nixpkgs/commit/1193c46927163849462b659b9950e7bfa602b48f) partclone: 0.3.32 -> 0.3.33
* [`29cba182`](https://github.com/NixOS/nixpkgs/commit/29cba182abfc0b7dd04e7a44163780c47e25fbcb) terraform-providers.alicloud: 1.235.0 -> 1.237.0
* [`b6f4b380`](https://github.com/NixOS/nixpkgs/commit/b6f4b380a696787de56135c19e890a4d60a8ad99) matomo: default to 5.x, drop 4.x
* [`37ccca21`](https://github.com/NixOS/nixpkgs/commit/37ccca21163ade037b4e9fffa3dfe585f78535e7) matomo: 5.1.2 -> 5.2.0
* [`a9e6d7a1`](https://github.com/NixOS/nixpkgs/commit/a9e6d7a110d6930ec9d4d88836351ef91cc5d2c8) k3s_1_29: 1.29.10+k3s1 -> 1.29.11+k3s1
* [`3883a09d`](https://github.com/NixOS/nixpkgs/commit/3883a09df895e3ebf562d7822dc3a1a3cbd53ce3) git-quick-stats: 2.5.7 -> 2.5.8
* [`2385837a`](https://github.com/NixOS/nixpkgs/commit/2385837a12d09d583d099fea65dcb861333ef671) whatsapp-for-mac: 2.24.11.85 -> 2.24.23.82
* [`63b6db2e`](https://github.com/NixOS/nixpkgs/commit/63b6db2ed876970a917f8c51ed4ac1fa41433b49) mxt-app: 1.41 -> 1.42
* [`3519e37b`](https://github.com/NixOS/nixpkgs/commit/3519e37b431cf4339846b6f2cd87951cb2d0863c) coroot: 1.6.3 -> 1.6.7
* [`b83590c8`](https://github.com/NixOS/nixpkgs/commit/b83590c858cacf0f4d679ea3ec8f452da5740eb2) src-cli: 5.5.0 -> 5.10.0
* [`0488b87e`](https://github.com/NixOS/nixpkgs/commit/0488b87eb9e565738a1ab0c82a62fd192383f040) maintainers: add kmatasfp
* [`92123398`](https://github.com/NixOS/nixpkgs/commit/921233985c512efec8119b7de55b9958ad0110f9) pcaudiolib: 1.2 -> 1.3
* [`355c46fe`](https://github.com/NixOS/nixpkgs/commit/355c46fea4d45277a2c9ceb170405935886af28a) opencolorio: 2.4.0 -> 2.4.1
* [`2248d471`](https://github.com/NixOS/nixpkgs/commit/2248d4714d40bb5d5cf3b47e4bf8b5cf3c2cbff4) manifest-tool: 2.1.8 -> 2.1.9
* [`9f58354e`](https://github.com/NixOS/nixpkgs/commit/9f58354e35d906b441bb2c14896a135ea246abc5) glooctl: 1.17.16 -> 1.18.0
* [`802b3fce`](https://github.com/NixOS/nixpkgs/commit/802b3fcee0ba73548f89c5b4de658e139f276cb0) flannel: 0.26.1 -> 0.26.2
* [`a0cd3ea1`](https://github.com/NixOS/nixpkgs/commit/a0cd3ea137ad7b98abc03ad03a1b0c54ccb5dc46) spire: 1.11.0 -> 1.11.1
* [`8e3d6162`](https://github.com/NixOS/nixpkgs/commit/8e3d6162a9861fdb6d01244612f7738d18ca56ae) python312Packages.dbt-bigquery: 1.8.3 -> 1.9.0
* [`ff289578`](https://github.com/NixOS/nixpkgs/commit/ff2895786e9b2672a7c66c4049d9e875416ea0ea) pinniped: 0.35.0 -> 0.36.0
* [`b99f361c`](https://github.com/NixOS/nixpkgs/commit/b99f361cb2cf69690fa0a24613d53a904d5e78f1) obs-studio-plugins.obs-source-record: 0.4.1 -> 0.4.4
* [`d1287a0b`](https://github.com/NixOS/nixpkgs/commit/d1287a0b56fd282f70528635e486fd59c6bca849) altair: 8.0.4 -> 8.0.5
* [`af971f30`](https://github.com/NixOS/nixpkgs/commit/af971f3091c27e2e11f792d9578b5f935492ebcf) vals: 0.37.8 -> 0.38.0
* [`ebc87151`](https://github.com/NixOS/nixpkgs/commit/ebc87151bf5dcaae50d574a22a7263f902197062) halo: 2.20.10 -> 2.20.11
* [`187485e9`](https://github.com/NixOS/nixpkgs/commit/187485e9dd8f97094d0d080f7ab5b5c9b20335e1) grafana-loki: 3.2.1 -> 3.3.1
* [`6f85944a`](https://github.com/NixOS/nixpkgs/commit/6f85944a5efa3a775ea9cdd305630d47c2b84c44) prometheus-mongodb-exporter: 0.42.0 -> 0.43.0
* [`101e5a6b`](https://github.com/NixOS/nixpkgs/commit/101e5a6b26c985efeae65d30fdb169f29f43ecb4) buildkite-cli: 3.3.1 -> 3.4.1
* [`a0736073`](https://github.com/NixOS/nixpkgs/commit/a073607399e639a8e825a836bac2378c687e9f1a) youtrack: 2024.3.52635 -> 2024.3.53776
* [`8befa299`](https://github.com/NixOS/nixpkgs/commit/8befa299345079229504fb9a707ef583844dd71a) docker: 27.3.1 -> 27.4.0
* [`8fc2225e`](https://github.com/NixOS/nixpkgs/commit/8fc2225e131bcaf6a9bd0e353757f7f2783109e4) dxx-rebirth: 0.60.0-beta2-unstable-2024-11-16 -> 0.60.0-beta2-unstable-2024-12-07
* [`a04ba402`](https://github.com/NixOS/nixpkgs/commit/a04ba402ddf61b336295cd5621889d9873c285c1) coqPackages.compcert: 3.14 → 3.15
* [`c6980dc0`](https://github.com/NixOS/nixpkgs/commit/c6980dc01632dd824e8b3c4fdd7e4af67961cb86) aws-sam-cli: 1.131.0 -> 1.132.0
* [`ee4d933d`](https://github.com/NixOS/nixpkgs/commit/ee4d933d36ad2adfb9f45f3abbd396b2f074a0e0) vulnix: 1.10.1-unstable-2024-04-02 -> 1.10.2
* [`3d066cd2`](https://github.com/NixOS/nixpkgs/commit/3d066cd2676b8a9deba3dcd3dc5746550b25a2fe) lua-language-server: 3.13.3 -> 3.13.4
* [`fa8320d2`](https://github.com/NixOS/nixpkgs/commit/fa8320d2cc9ff5d329738c6e5f6c5481f237f9ca) python312Packages.django-q2: init at 1.7.4
* [`1b8f54d2`](https://github.com/NixOS/nixpkgs/commit/1b8f54d2a16c480f59968427d052af9b00e51d8f) mailmanPackages.hyperkitty: 1.3.9 -> 1.3.12
* [`0fb39c5a`](https://github.com/NixOS/nixpkgs/commit/0fb39c5abbe057f748c1447212edff4c2c77e316) mailmanPackages: use python 3.12
* [`b93e42b9`](https://github.com/NixOS/nixpkgs/commit/b93e42b9428e2af77cca07c90b994bc58fdd0d89) python3Packages.django-q: drop
* [`7c9903f4`](https://github.com/NixOS/nixpkgs/commit/7c9903f45348ac02db3f29271b882bd03b616701) nextcloud30Packages.apps.recognize: s/buildInputs/nativeBuildInputs/
* [`cf55aa87`](https://github.com/NixOS/nixpkgs/commit/cf55aa8701953603bc80b733bbb9f92a4d76adfe) python312Packages.pycrdt: 0.10.8 -> 0.10.9
* [`2d19bd0e`](https://github.com/NixOS/nixpkgs/commit/2d19bd0e0e82d185a37f625c82258149cb0a9605) goperf: 0-unstable-2024-11-18 -> 0-unstable-2024-12-04
* [`3fde1968`](https://github.com/NixOS/nixpkgs/commit/3fde1968606c78e4b58fc50ef18e69d1508d4d96) yt-dlp: 2024.12.6 -> 2024.12.13
* [`997e1559`](https://github.com/NixOS/nixpkgs/commit/997e1559dd35bba8be331faa2cc788ed1d0d8367) iosevka-bin: 31.9.1 -> 32.2.1
* [`07087e70`](https://github.com/NixOS/nixpkgs/commit/07087e708f07cb0552f3648a4129a78086eb3530) apache-modules.mod_dnssd: update path file link
* [`b924ef1d`](https://github.com/NixOS/nixpkgs/commit/b924ef1daf0bc5bb2619e4f91f955cadc26311c0) oatpp: 1.3.0 -> 1.3.1
* [`61dd3fda`](https://github.com/NixOS/nixpkgs/commit/61dd3fdae2528e2344f4c3a675883af0b5e547f7) nixos/hadoop: fix lib function calls
* [`bdd10c64`](https://github.com/NixOS/nixpkgs/commit/bdd10c641ebe9183c87c8d571ab0cfd50765be7f) nixos/hadoop: fix failing yarn tests
* [`b1e4a232`](https://github.com/NixOS/nixpkgs/commit/b1e4a232f4c59daed94234f41b847bb91afcb94a) nixos/hadoop: fix failing hdfs test
* [`5f96089d`](https://github.com/NixOS/nixpkgs/commit/5f96089dec6a8566f4e75193fec4d9b3c50f22c0) python312Packages.openai: 1.56.1 -> 1.57.4
* [`0d577921`](https://github.com/NixOS/nixpkgs/commit/0d57792151701b60b2a87966d9bbe0adf94aee6b) tflint-plugins.tflint-ruleset-aws: 0.34.0 -> 0.36.0
* [`999e8c7f`](https://github.com/NixOS/nixpkgs/commit/999e8c7ff06219593f337dff7e0f94a5fe4b1324) hadoop: 3.4.0 -> 3.4.1
* [`c62ec80d`](https://github.com/NixOS/nixpkgs/commit/c62ec80d1fc0cc4a665f3dca74a4d1292a8820e5) hadoop, nixos/hadoop, nixosTests/hadoop: nixfmt
* [`32d09a7f`](https://github.com/NixOS/nixpkgs/commit/32d09a7f4a8f330c241912be884001be7c870bc9) vrcadvert: add version checking
* [`58c0be8a`](https://github.com/NixOS/nixpkgs/commit/58c0be8a93a9092e8314c10d754cd51ecd6cbedd) vrcadvert: add update script
* [`3ff58f5e`](https://github.com/NixOS/nixpkgs/commit/3ff58f5e65c6a0eed2315d0b2bac3f85cec6de6d) vrcadvert: refactor
* [`de83a974`](https://github.com/NixOS/nixpkgs/commit/de83a9748c2cf7a3d6c29b718ea2bd64db2f9d6f) pyradio: 0.9.3.11.1 -> 0.9.3.11.3
* [`787ab904`](https://github.com/NixOS/nixpkgs/commit/787ab904c5d8932ee69ca03a1fbb9f4e7794d3fc) feishu: 7.22.9 -> 7.28.10
* [`b4bd73ce`](https://github.com/NixOS/nixpkgs/commit/b4bd73ceed445af90744883a45f315891d3811ef) tone: clean up
* [`dbffcefb`](https://github.com/NixOS/nixpkgs/commit/dbffcefb667bb345669081c305c5fe4f7f052dd0) tone: use versionCheckHook
* [`818d1c60`](https://github.com/NixOS/nixpkgs/commit/818d1c60b9d51547db79b4ac6a49c7d01adb3f36) tone: use update script
* [`4d0505cb`](https://github.com/NixOS/nixpkgs/commit/4d0505cb775cc431f8ff9bb9a2548ae8c930ac7a) tone: add changelog
* [`1a25e898`](https://github.com/NixOS/nixpkgs/commit/1a25e8981170d437a2b46841197af5260c945ea9) vscode-extensions.eamodio.gitlens: 15.6.0 -> 16.0.5
* [`16b2ede3`](https://github.com/NixOS/nixpkgs/commit/16b2ede3fc70be1740f41037a704df8be67a82ae) mongodb-7_0: 7.0.15 -> 7.0.16
* [`9275f7d9`](https://github.com/NixOS/nixpkgs/commit/9275f7d93ee34e5e7980b7013aea5960d056b086) pixelorama: 1.0.3 -> 1.0.5
* [`6bc4407d`](https://github.com/NixOS/nixpkgs/commit/6bc4407d3239a0eaa0993ca848c5fb8d36c0f577) frida-tools: 12.5.0 -> 13.6.0
* [`1044a518`](https://github.com/NixOS/nixpkgs/commit/1044a518e44f00d0b2da3807d250be77825e4f9b) atlauncher: 3.4.38.0 -> 3.4.38.1
* [`ffb32d8b`](https://github.com/NixOS/nixpkgs/commit/ffb32d8b96713fbd41dbbb0b4c74d6f320e9cd29) libfabric: 1.22.0 -> 2.0.0
* [`49c7bab2`](https://github.com/NixOS/nixpkgs/commit/49c7bab240966925ed5325c4d468e8c710a1fd58) stunnel: 5.73 -> 5.74
* [`719fc3af`](https://github.com/NixOS/nixpkgs/commit/719fc3afc22c7f149cde2ee1cd27d815ba5a36be) oathkeeper: 0.40.7 -> 0.40.8
* [`72fc5421`](https://github.com/NixOS/nixpkgs/commit/72fc542105eef9f4f7f30eee83d72464878646ae) starlark-rust: 0.12.0 -> 0.13.0
* [`eaac8c83`](https://github.com/NixOS/nixpkgs/commit/eaac8c8310675b162f8d52239351085dd2b8f574) yo: 5.0.0 -> 5.1.0
* [`6ae87d9a`](https://github.com/NixOS/nixpkgs/commit/6ae87d9af9dab792479a45440359dfde2e9dab21) pachyderm: 2.11.5 -> 2.11.6
* [`8726cf8a`](https://github.com/NixOS/nixpkgs/commit/8726cf8a7811218c89fa1d9c1a5e43f285b63d0e) findup: 1.1.1 -> 1.1.2
* [`c6623208`](https://github.com/NixOS/nixpkgs/commit/c66232084acb7077cd8730b03e471e2dbac28821) fcgi: 2.4.2 -> 2.4.3
* [`7745db24`](https://github.com/NixOS/nixpkgs/commit/7745db249bd0953efb39abc579ae6c3375fd7a43) dart.super_native_extensions: add 0.9.0-dev.5
* [`29b4c648`](https://github.com/NixOS/nixpkgs/commit/29b4c6487c268717e219109a808a5b2c4b86f2cc) saber: 0.25.2 -> 0.25.3
* [`cb34fe7c`](https://github.com/NixOS/nixpkgs/commit/cb34fe7ccb736c0763ead4bb9e83c983b733fce4) zon2nix: fix build on Darwin
* [`3898b1bb`](https://github.com/NixOS/nixpkgs/commit/3898b1bb6b5f112882aa7abde395c1916f704ae5) gopeed: init at 1.6.4
* [`d219a4f9`](https://github.com/NixOS/nixpkgs/commit/d219a4f9cf84366784a729be1f07087c18132d32) python312Packages.nodriver: 0.37 -> 0.38.post1
* [`50a4df38`](https://github.com/NixOS/nixpkgs/commit/50a4df38ee375da47eebe0dee8636c5c6ca0f4a1) matio: 1.5.27 -> 1.5.28
* [`6817299f`](https://github.com/NixOS/nixpkgs/commit/6817299f3834d825d99277c0536613a9a8107e3b) nixos/clash-verge: enable serviceModule by default
* [`6382ac75`](https://github.com/NixOS/nixpkgs/commit/6382ac757b42e16c9a1a593ecf9b94b2f48ffc4d) linuxwave: 0.1.5 -> 0.2.0
* [`56873ca8`](https://github.com/NixOS/nixpkgs/commit/56873ca8ae49f3df1ce89a4ba6de21d06457055f) python312Packages.llama-index-vector-stores-chroma: 0.4.0 -> 0.4.1
* [`bbfb9897`](https://github.com/NixOS/nixpkgs/commit/bbfb98976e0d370473a5ca54eb4947cff800b677) vttest: 20240708 -> 20241204
* [`899687ac`](https://github.com/NixOS/nixpkgs/commit/899687acd5e65ca160a346b8bcbccb8370120009) python312Packages.llama-index-vector-stores-postgres: 0.3.2 -> 0.4.0
* [`3f772e33`](https://github.com/NixOS/nixpkgs/commit/3f772e3323b2b749b955723c2bf8dabbb965eca2) saga: 9.6.0 -> 9.6.2
* [`904ffed7`](https://github.com/NixOS/nixpkgs/commit/904ffed79eccc1adb4d6ba3176a7ff08d2d86555) nm-file-secret-agent: init at v1.0.0
* [`98b7c502`](https://github.com/NixOS/nixpkgs/commit/98b7c502797c5769513e62b8a023c0e16d75a8d2) linuxKernels.linux_lqx: fix build by removing SCHED_CLASS_EXT option
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
