### PR TITLE
niv home-manager: update 83ecd509 -> f1b1786e

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -41,10 +41,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "83ecd50915a09dca928971139d3a102377a8d242",
-        "sha256": "1q1sqnd8gjrglihgb56hmznj4had0jyg73k355m3ga4wqj3ggmf0",
+        "rev": "f1b1786ea77739dcd181b920d430e30fb1608b8a",
+        "sha256": "129laifrjk48f5jz0j4ylya15s8wppiz3n8hx42iry6vqhf35mbz",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/83ecd50915a09dca928971139d3a102377a8d242.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/f1b1786ea77739dcd181b920d430e30fb1608b8a.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@83ecd509...f1b1786e](https://github.com/nix-community/home-manager/compare/83ecd50915a09dca928971139d3a102377a8d242...f1b1786ea77739dcd181b920d430e30fb1608b8a)

* [`832920a6`](https://github.com/nix-community/home-manager/commit/832920a60833533eaabcc93ab729801bf586fa0c) thunderbird: add profileVersion
* [`1395379a`](https://github.com/nix-community/home-manager/commit/1395379a7a36e40f2a76e7b9936cc52950baa1be) home-manager: improve path handling when building news
* [`99f54cdf`](https://github.com/nix-community/home-manager/commit/99f54cdfef395bb3de1c7b8dd422412de65b038d) yazi: fix example option for settings
* [`db9a98e1`](https://github.com/nix-community/home-manager/commit/db9a98e178b57a8aff46b3482dfccb3f4d8d4ce3) pay-respects: add module
* [`f342df3a`](https://github.com/nix-community/home-manager/commit/f342df3ad938f205a913973b832f52c12546aac6) flake.lock: Update
* [`51160a09`](https://github.com/nix-community/home-manager/commit/51160a097a850839b7eae7ef08d0d3e7e353dfc3) thunderbird: implement `extensions` for profiles
* [`c903b1f6`](https://github.com/nix-community/home-manager/commit/c903b1f6fbfc2039963806df896f698331b77aa8) flake.lock: Update
* [`f47b6c15`](https://github.com/nix-community/home-manager/commit/f47b6c153ad31187a519bd569ccbcb20acb16ce0) cavalier: add module
* [`cb27edb5`](https://github.com/nix-community/home-manager/commit/cb27edb5221d2f2920a03155f8becc502cf60e35) waybar: add systemd restart triggers
* [`1f74238a`](https://github.com/nix-community/home-manager/commit/1f74238a4c8e534a1b6be72cb5153043071ffd17) xresources: allow floating point values
* [`edb8b00e`](https://github.com/nix-community/home-manager/commit/edb8b00e4d17b2116b60eca50f38ac68f12b9ab4) Translate using Weblate (Czech)
* [`8bea1a20`](https://github.com/nix-community/home-manager/commit/8bea1a2005c64a8c9c430d0dddb6b2e5db5f6f12) nixgl: forward override calls to wrapped package
* [`7349b015`](https://github.com/nix-community/home-manager/commit/7349b01505d18cd60ba0e573e78c234b742056ef) mu: reinitialize when personal addresses change
* [`8264bfe3`](https://github.com/nix-community/home-manager/commit/8264bfe3a064d704c57df91e34b795b6ac7bad9e) mu: add integration tests
* [`f1b1786e`](https://github.com/nix-community/home-manager/commit/f1b1786ea77739dcd181b920d430e30fb1608b8a) swayr: avoid IFD
