### PR TITLE
niv nixpkgs: update 7d402f20 -> 6d97d419

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "7d402f207f326eed0ad136d09ef6a65364daf894",
-        "sha256": "0k6k63k70vzv7kwjwa0zxz7c0j17kfgczjc68k8cia6ipn4y6hj6",
+        "rev": "6d97d419e5a9b36e6293887a89a078cf85f5a61b",
+        "sha256": "10y6ply5jhg9pwq13zldmipxh8dscmawx5syi1i6rb773xnnr452",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/7d402f207f326eed0ad136d09ef6a65364daf894.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/6d97d419e5a9b36e6293887a89a078cf85f5a61b.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@7d402f20...6d97d419](https://github.com/nixos/nixpkgs/compare/7d402f207f326eed0ad136d09ef6a65364daf894...6d97d419e5a9b36e6293887a89a078cf85f5a61b)

* [`b969657b`](https://github.com/NixOS/nixpkgs/commit/b969657bf9609e5ee5a90b1181e542359f998fd5) rustfmt: wrap cargo-fmt with cargo
* [`b0ed9f01`](https://github.com/NixOS/nixpkgs/commit/b0ed9f01c1b06fc8613b65d45ed72550e46f79f9) maintainers: add krovuxdev
* [`1ba8a1c5`](https://github.com/NixOS/nixpkgs/commit/1ba8a1c58360d10afa3bfe8cdeecc199a08d3c7b) maintainers: add lriesebos
* [`79f4ac27`](https://github.com/NixOS/nixpkgs/commit/79f4ac2747d39fb486753c7371d58d2ae9aa17ba) cpptrace: init at 0.6.2
* [`8e1442ad`](https://github.com/NixOS/nixpkgs/commit/8e1442adb28858e61d893f943f844d0ce688f2e6) Add return value to runPhase bash function in stdenv
* [`e93ca9b4`](https://github.com/NixOS/nixpkgs/commit/e93ca9b43cf5aa4e58c9557f561f7dbafbabe893) Change from status to retval
* [`a45a079b`](https://github.com/NixOS/nixpkgs/commit/a45a079bbc278cd6579f553db1fbadc7a59e9474) openfortivpn-webview: init at 1.2.0
* [`e619721c`](https://github.com/NixOS/nixpkgs/commit/e619721c9bd245b1817b073eab5c8a3250983ac0) wordpressPackages.plugins.wp-fail2ban: init at 5.3.2
* [`5793126b`](https://github.com/NixOS/nixpkgs/commit/5793126b31c3cbffb42c1aff1082e4e682848fc3) ffado: support cross compilation
* [`9e6e56d4`](https://github.com/NixOS/nixpkgs/commit/9e6e56d4f0728a53afd9855eb6c09644b2ddae8a) ffado: remove dead patch
* [`dd3e4b41`](https://github.com/NixOS/nixpkgs/commit/dd3e4b41b440ebcb56f4c01ddad12ca221e9260f) libiconv: update gnu config scripts
* [`2cb06bde`](https://github.com/NixOS/nixpkgs/commit/2cb06bdea2274f63d1364494148e9067e0e3e6f7) jwtinfo: init at 0.4.4
* [`437364b4`](https://github.com/NixOS/nixpkgs/commit/437364b43456d53e0903d4cdd2afbf1e6bc09196) pipewire: disable webrtc-audio-processing if unavailable
* [`fef4f7aa`](https://github.com/NixOS/nixpkgs/commit/fef4f7aa1780e1833b8c195608646816c0b7b62c) python312Packages.pikepdf: 9.2.1 -> 9.3.0
* [`26082d8a`](https://github.com/NixOS/nixpkgs/commit/26082d8aeaa926909d9570d046442877be7221b2) libunistring: 1.2 -> 1.3
* [`e872feae`](https://github.com/NixOS/nixpkgs/commit/e872feae7623c5b35f9a1c71c6482e47ef811a34) pydot: 2.0.0 -> 3.0.2
* [`bd565dc5`](https://github.com/NixOS/nixpkgs/commit/bd565dc53d4b16def65154d7beb2635cb63294bd) swig: 4.2.1 -> 4.3.0
* [`f451ce6d`](https://github.com/NixOS/nixpkgs/commit/f451ce6d1f862d14c0da41a27cc6e13acc4c2837) fluidsynth: 2.3.6 -> 2.3.7
* [`b8d86f57`](https://github.com/NixOS/nixpkgs/commit/b8d86f5728a8a4fdc832a88e78eba4aab29ef992) tcl: 8.6.13 -> 8.6.15
* [`e9ef95e5`](https://github.com/NixOS/nixpkgs/commit/e9ef95e543da2d911eaccad23ee673bde3caee4e) tk: 8.6.13 -> 8.6.15
* [`dd09ec94`](https://github.com/NixOS/nixpkgs/commit/dd09ec94c14451d50f56b1a23f3271036a97f903) nssTools: install man pages
* [`503016cf`](https://github.com/NixOS/nixpkgs/commit/503016cf18d55385175dc6fa03df3463488bd620) python312Packages.fs: clean-up
* [`17dd29c9`](https://github.com/NixOS/nixpkgs/commit/17dd29c92615ba405e5ceb3c3ff77ace2650d087) tpm2-tss: adds support for libtpms backend
* [`351ec8a9`](https://github.com/NixOS/nixpkgs/commit/351ec8a9223a78c9970502459f5cfd4cc03b0b36) normcap: fix on GNOME wayland when used via keybind or alt-f2
* [`d11baac0`](https://github.com/NixOS/nixpkgs/commit/d11baac0c2ba9a0df59fb08c6b790156300ed0b3) normcap: fix build when `doCheck=false;`
* [`718eb8ff`](https://github.com/NixOS/nixpkgs/commit/718eb8ff9548b7ff0de55759d9b6c72e63e59282) enchant: compile with Voikko support
* [`5ec3e7b3`](https://github.com/NixOS/nixpkgs/commit/5ec3e7b30e2c2a60f3571b85392c2fc3dcda74a1) nodejs_22: use shared SQLite
* [`ba231a8c`](https://github.com/NixOS/nixpkgs/commit/ba231a8c1c947382774639a04ed22775a1b0a42e) audit: format package
* [`40338db4`](https://github.com/NixOS/nixpkgs/commit/40338db4921b86c4c5f07514b925369408eb2e64) sqlite, sqlite-analyzer: 3.46.1 -> 3.47.0
* [`2e19720a`](https://github.com/NixOS/nixpkgs/commit/2e19720a20d2f05a11ac300fcb9e98d030043584) sqlite-rsync: init at 3.47.0
* [`05382c2f`](https://github.com/NixOS/nixpkgs/commit/05382c2f8c2725e29d9c7b1dec9ea89dfa04ddc7) svt-av1: 2.2.1 -> 2.3.0
* [`c1a3a2f3`](https://github.com/NixOS/nixpkgs/commit/c1a3a2f36e352e637fc193beb88d60b0e4f71802) tesseract: ensure fixupPhase is run, e.g. ensuring library codesigning on darwin
* [`52fa1933`](https://github.com/NixOS/nixpkgs/commit/52fa1933c05e373a38b2f3271c3d4890a9138e14) python312Packages.waitress: 3.0.0 -> 3.0.1
* [`6f1355e0`](https://github.com/NixOS/nixpkgs/commit/6f1355e00be64f6d829dcf7c1caaab6c3c7f80ff) python312Packages.waitress: refactor
* [`bd121768`](https://github.com/NixOS/nixpkgs/commit/bd121768887ec4d97a0245faaa0bf6eaba96e2b8) stdenvAdapters: set default_both_libraries for meson in makeStaticLibrary
* [`a1c1180a`](https://github.com/NixOS/nixpkgs/commit/a1c1180ac8e7f7201ec615e62653ec33aed7f0b6) libuv: 1.48.0 -> 1.49.2
* [`982e3fc3`](https://github.com/NixOS/nixpkgs/commit/982e3fc31d8f83e1f6792e5cfe0af21881a2c801) nodejs_23: drop reverts
* [`9cdde0bb`](https://github.com/NixOS/nixpkgs/commit/9cdde0bb6d5d44357a9a99a761e53478f59d2aea) valgrind: fix build on armv7l-linux
* [`87ba2ce0`](https://github.com/NixOS/nixpkgs/commit/87ba2ce02b0182c9571e448badef96301512a170) mpg123: 1.32.8 -> 1.32.9
* [`a40e3774`](https://github.com/NixOS/nixpkgs/commit/a40e3774a0103b989ed0e312e18731885b377f33) lvm2: 2.03.27 -> 2.03.28
* [`b6a12f84`](https://github.com/NixOS/nixpkgs/commit/b6a12f84c650c228837831709e82af985b0df1ca) chicken: remove hardening disable
* [`bfff86f9`](https://github.com/NixOS/nixpkgs/commit/bfff86f9a0d3312bb1c6e4f79ab19dd80f5682fd) python3Packages.pymunk: 6.5.2 -> 6.9.0
* [`c5e1b99b`](https://github.com/NixOS/nixpkgs/commit/c5e1b99ba9ec52800cdf300b7188914ddc843547) python3Packages.pymunk: convert to pyproject, fix cross
* [`f02bc548`](https://github.com/NixOS/nixpkgs/commit/f02bc548d1018721827cc8007fe01db095fdca94) xorg.libXcursor: 1.2.2 -> 1.2.3
* [`5f31855e`](https://github.com/NixOS/nixpkgs/commit/5f31855eeeb789bbc3594674520e577961c3d012) maintainers: add boldikoller
* [`47d5eeb5`](https://github.com/NixOS/nixpkgs/commit/47d5eeb56beb9ec5213c5fcc84b51215a123d998) mdbook: 0.4.40 -> 0.4.41
* [`2f9dcca3`](https://github.com/NixOS/nixpkgs/commit/2f9dcca3954d5eceaf3af6a611d96f265386e534) iwd: 3.0 -> 3.1
* [`1af2e423`](https://github.com/NixOS/nixpkgs/commit/1af2e4234cc67a66b98b8575be399212c14d4622) ell: 0.69 -> 0.70
* [`36223da9`](https://github.com/NixOS/nixpkgs/commit/36223da9c1947297cf10b92682e7be60a97a33e3) buildGoModule: remove `buildFlags`/`buildFlagsArray`
* [`4cd083a3`](https://github.com/NixOS/nixpkgs/commit/4cd083a3cdf25fce6d1c0bb232e241681fad34ca) postgresql: drop build-time dependency on GHC
* [`91664c8f`](https://github.com/NixOS/nixpkgs/commit/91664c8fb3b4b0f0fc559d48ad685e26cdc1f0df) rpm: fixup gpg path
* [`fc465864`](https://github.com/NixOS/nixpkgs/commit/fc465864227e4492ca9f889d6931fc6116497886) openjdk: Fix cross for most versions
* [`49245b83`](https://github.com/NixOS/nixpkgs/commit/49245b838c5417fb6fb5eca8d69cb22e2f3427e7) python312Packages.setuptools: 75.1.0 -> 75.1.1
* [`22ad67ee`](https://github.com/NixOS/nixpkgs/commit/22ad67eebbeb281dfdc2db434dc7840b6105d105) iptables: 1.8.10 -> 1.8.11
* [`ce6c31c3`](https://github.com/NixOS/nixpkgs/commit/ce6c31c312584ce8f5a32fd7bbfe5e89734524b4) llvmPackages_{12,13}.lldb: don't try to find nonexistent patch
* [`ee9eacf2`](https://github.com/NixOS/nixpkgs/commit/ee9eacf23ec7cf46c6ebbbb215e4ee26a3bc6fed) llvmPackages_12: build from monorepo source
* [`8408b91e`](https://github.com/NixOS/nixpkgs/commit/8408b91e8dae5b31807f43da351b3271316fb165) llvmPackages_12.compiler-rt: move codesign patch into versioned dir
* [`37437849`](https://github.com/NixOS/nixpkgs/commit/37437849deb116c22c01191f5ecbef2c7b30f1f7) llvmPackages_12.clang: use nostdlibinc patch instead of sed command
* [`82b28965`](https://github.com/NixOS/nixpkgs/commit/82b28965d4cce19bb41d4cf7a187596d47b3a23e) uv: 0.4.30 -> 0.5.1
* [`457241da`](https://github.com/NixOS/nixpkgs/commit/457241dab4b6e9423009d2bd9c1db6fbcaef209a) python3Packages.pytest-xdist: change pytestFlagsArray in preCheck hook
* [`49433de9`](https://github.com/NixOS/nixpkgs/commit/49433de9829074148bacd570bb0d45fa85a5f8dc) harfbuzz: 10.0.1 -> 10.1.0
* [`729a3efc`](https://github.com/NixOS/nixpkgs/commit/729a3efc568d7beb3a3aae3fb4055cd2d8dbc4d1) chipsec: pass --build-libs without relying on bash eval of setupPyBuildFlags
* [`3f9135d8`](https://github.com/NixOS/nixpkgs/commit/3f9135d88bbc9b26d81027d4e6977f796c255100) python3Packages: disable pytest cache
* [`6af5508c`](https://github.com/NixOS/nixpkgs/commit/6af5508cbc487e236b00384613ac54c81301daa5) python3Packages.numcodecs: avoid bash eval in pytestFlagsArray
* [`7b55da73`](https://github.com/NixOS/nixpkgs/commit/7b55da73c009b92caa741b28a0d1451792528b33) pkgsLLVM.tpm2-tss: fixup tests
* [`a2090197`](https://github.com/NixOS/nixpkgs/commit/a2090197fcb3c572cc8ab6e0be0833027a669a70) hwdata: 0.388 -> 0.389
* [`76132834`](https://github.com/NixOS/nixpkgs/commit/7613283480877b71b283594a5a6004d2110fdffe) desktop-file-utils: 27 -> 28
* [`3b863c6f`](https://github.com/NixOS/nixpkgs/commit/3b863c6ffb801e3ad003f592f12a470524109656) libzip: 1.11.1 -> 1.11.2
* [`e65ff18e`](https://github.com/NixOS/nixpkgs/commit/e65ff18e52b093cda46d922521778d1aea9e97c0) s2n-tls: 1.5.5 -> 1.5.7
* [`9637c2fe`](https://github.com/NixOS/nixpkgs/commit/9637c2fe2d8c0754611c400c1a18babfd91e41a9) json_c: 0.17 -> 0.18
* [`8acad423`](https://github.com/NixOS/nixpkgs/commit/8acad4230d0239388684c2beced2e6b8d9b3e28e) libmysofa: 1.3.2 -> 1.3.3
* [`adb92862`](https://github.com/NixOS/nixpkgs/commit/adb928625e143289174291c8ff00db6592c622e2) elfutils: 0.191 -> 0.192
* [`2c89bfca`](https://github.com/NixOS/nixpkgs/commit/2c89bfca9c6b7202ba933f6be7720e77aeadd1cc) libtirpc: 1.3.5 -> 1.3.6
* [`b386ef24`](https://github.com/NixOS/nixpkgs/commit/b386ef248fa182ad0a9641036ffe6028e6a6d85c) thin-provisioning-tools: 1.0.12 -> 1.1.0
* [`44b5d849`](https://github.com/NixOS/nixpkgs/commit/44b5d849aab9c99d947406f3c48e8eaad6a6eda3) libnats-c: 3.8.2 -> 3.9.1
* [`90b343e3`](https://github.com/NixOS/nixpkgs/commit/90b343e3e4d2971a36365bf0e3231c27094ab994) kanata-with-cmd: 1.7.0-prerelease-1 -> 1.7.0
* [`106ba639`](https://github.com/NixOS/nixpkgs/commit/106ba63900ed5d08c66c796b90f2d76d630625f3) tree-wide: Indent .bash files like .sh
* [`91817563`](https://github.com/NixOS/nixpkgs/commit/9181756339fc269cf350dd12d2f628cbe1ab7a60) .editorconfig: Format .bash files like .sh
* [`6ac7c0c4`](https://github.com/NixOS/nixpkgs/commit/6ac7c0c4d0e8f4fdae1f08f263f23c689f1ecb76) xorg.libX11: Fix spurious Xerror when running synchronized
* [`0a52fc94`](https://github.com/NixOS/nixpkgs/commit/0a52fc9410ce8b687f2f119dc8da727172a99a94) Revert "kanata-with-cmd: 1.7.0-prerelease-1 -> 1.7.0"
* [`dd78812a`](https://github.com/NixOS/nixpkgs/commit/dd78812a70f0f0950f1058f16db1686de705b024) ffmpeg-headless: enable vulkan
* [`3f601a92`](https://github.com/NixOS/nixpkgs/commit/3f601a9255f8c6c34f8cf68bfbed8c01b6dd20ad) ffmpeg-headless: enable fribidi
* [`34a88677`](https://github.com/NixOS/nixpkgs/commit/34a886774394d0bcfebb81bae427d92ecd1fe652) ffmpeg-headless: enable bluray
* [`610b0fd1`](https://github.com/NixOS/nixpkgs/commit/610b0fd1995945d6309feb36ee40912403766887) ffmpeg-headless: enable xml2
* [`2fa42d7b`](https://github.com/NixOS/nixpkgs/commit/2fa42d7b13c4b9c39aa19a5680b1ca81faed99a2) ffmpeg-headless: enable openmpt
* [`ca1689f4`](https://github.com/NixOS/nixpkgs/commit/ca1689f486da5fc2d8c9d14c48851db60e80cb1a) ffmpeg-headless: enable zvbi
* [`a4065db1`](https://github.com/NixOS/nixpkgs/commit/a4065db12315af754aa30a3a9d4fc710ab6f55b2) ffmpeg-headless: enable opencl
* [`e982db44`](https://github.com/NixOS/nixpkgs/commit/e982db441062bc0d6a91eeba6d20c92f7faf4a8b) man-db: Add `--with-col` to `configureFlags`
* [`a74f2b4f`](https://github.com/NixOS/nixpkgs/commit/a74f2b4f3bc9ba291dcab1ee9232b96b488b96e7) python3Packages.pendulum: fix on 32 bit platforms
* [`eaff3f22`](https://github.com/NixOS/nixpkgs/commit/eaff3f220765d87f7c3b18df4e3ca36cc6d38296) python312Packages.mypy: 1.11.2 -> 1.13.0
* [`92fc176b`](https://github.com/NixOS/nixpkgs/commit/92fc176ba64f7057e1b349e5824281737b557d40) libvisual: 0.4.1 -> 0.4.2
* [`ab5894f2`](https://github.com/NixOS/nixpkgs/commit/ab5894f22844628925edab137457678a3bb240e4) mdbook: 0.4.41 -> 0.4.42
* [`56ec4b7d`](https://github.com/NixOS/nixpkgs/commit/56ec4b7d1671aba5d77052225c758dbabfbe75fa) adns: format with `nixfmt-rfc-style`
* [`bf65989f`](https://github.com/NixOS/nixpkgs/commit/bf65989fe97f87f6ceb896a5384482566211891a) adns: use `finalAttrs`
* [`9a071c95`](https://github.com/NixOS/nixpkgs/commit/9a071c952059168b1d4b4a00f71de76012e0b64e) adns: remove `with lib;`
* [`cf3ff2dd`](https://github.com/NixOS/nixpkgs/commit/cf3ff2dd370b7371cb2f09ec3364b75cdfcbf635) adns: rearrange furniture
* [`3f94e7e6`](https://github.com/NixOS/nixpkgs/commit/3f94e7e68c682c9269f2d5a9857fe77d84657944) adns: update licence
* [`9bac1ec6`](https://github.com/NixOS/nixpkgs/commit/9bac1ec6850749fe691f0d617bc2a620566228b5) adns: use title case for `meta.description`
* [`6ae57a56`](https://github.com/NixOS/nixpkgs/commit/6ae57a56dcfb8603debae92111d0e35f23e8c7c5) adns: modernize `installCheckPhase`
* [`e7e4bcc6`](https://github.com/NixOS/nixpkgs/commit/e7e4bcc65b3fba6334b4d4b5f16573968d3c633e) adns: enable parallel building
* [`4f0ff90a`](https://github.com/NixOS/nixpkgs/commit/4f0ff90a95d69f9ba314f198c79454f95a3643f0) adns: fix Darwin properly
* [`4b712c8f`](https://github.com/NixOS/nixpkgs/commit/4b712c8f6fab7e98cb2742ed180b4c16fa0f0fc9) buildRustPackage: remove unused `patchRegistryDeps`
* [`63ce4665`](https://github.com/NixOS/nixpkgs/commit/63ce4665b2ce60fbe35d7cdf2b434dd10f1b4095) systemd: revert boot-breaking systemd-boot change
* [`34bfeba2`](https://github.com/NixOS/nixpkgs/commit/34bfeba24f24bcc63fa6a5edfbda15d1a7e4b45f) srt: 1.5.3 -> 1.5.4
* [`01fe6fb3`](https://github.com/NixOS/nixpkgs/commit/01fe6fb38d5d50180e322fab5d7bab6f4e764c1e) librist: fix build for musl
* [`bf92ca56`](https://github.com/NixOS/nixpkgs/commit/bf92ca56f46baec4f269552d6b0491fa3fb20576) tree-sitter: 0.24.3 → 0.24.4
* [`3427e995`](https://github.com/NixOS/nixpkgs/commit/3427e995dbd9644c18bca337e5b23db4eb70015c) tree-sitter: Update grammars
* [`b5ef6f67`](https://github.com/NixOS/nixpkgs/commit/b5ef6f670a95861bb1b0561882349dc06dcbac33) qt{5,6}.qtbase: build without libinput by default
* [`ea291e87`](https://github.com/NixOS/nixpkgs/commit/ea291e87e301058160d99126bf3d473220a0757e) alsa-lib: 1.2.12 -> 1.2.13
* [`1810b522`](https://github.com/NixOS/nixpkgs/commit/1810b522d7c69fbc67f05aed4183aa53afffecfd) Revert "stdenv: set NIX_DONT_SET_RPATH_FOR_TARGET on Darwin"
* [`5b35070c`](https://github.com/NixOS/nixpkgs/commit/5b35070c8bf58afcbd8fdd65b65c06b43f778093) python3Packages.asyncpg: 0.29.0 -> 0.30.0
* [`3d52077f`](https://github.com/NixOS/nixpkgs/commit/3d52077f5a6331c12eeb7b6a0723b49bea10d6fe) rpm: 4.18.1 -> 4.20.0
* [`841334f2`](https://github.com/NixOS/nixpkgs/commit/841334f22e6f69037f82ac1d9b21f8850a27f0b7) postgresql: 16.4 -> 17.0
* [`17a4a363`](https://github.com/NixOS/nixpkgs/commit/17a4a36321947c3c35d0eb1a1507cc836899025d) python3Packages.psutil: use placeholder "out" instead of $out
* [`1e99bcac`](https://github.com/NixOS/nixpkgs/commit/1e99bcac6f2b2bb2caee862c34976474280ea924) nodejs: 20.18.0 -> 22.11.0
* [`6c61c502`](https://github.com/NixOS/nixpkgs/commit/6c61c502464af20f9a9847fc76b07d0971fb5812) cargo-auditable: 0.6.2 -> 0.6.5
* [`9c44a425`](https://github.com/NixOS/nixpkgs/commit/9c44a42559f915c6d7a2b6377046ad7477beb274) python312Packages.scapy: 2.6.0 -> 2.6.1
* [`459a9250`](https://github.com/NixOS/nixpkgs/commit/459a925026a28f5a762d648108c4d21068d080e3) mesa: 24.2.6 -> 24.2.7
* [`7903d0b7`](https://github.com/NixOS/nixpkgs/commit/7903d0b711ec74509ca6ef36bd0d1d0c46f732a5) llvmPackages.llvm: Drop dependency on target through libbfd
* [`da9f1b68`](https://github.com/NixOS/nixpkgs/commit/da9f1b68935e210b27f6e1cfe194461359cf8743) libtpms: 0.9.6 -> 0.10.0
* [`0ddab62d`](https://github.com/NixOS/nixpkgs/commit/0ddab62d3d834015f0a89e249cc47e41e5b7cde2) qt6.qtdeclarative: backport more patches recommended by upstream
* [`bde88ba1`](https://github.com/NixOS/nixpkgs/commit/bde88ba1b721c906df9a621942d2ec90f04ba999) libxml2: 2.13.4 -> 2.13.5
* [`065a393a`](https://github.com/NixOS/nixpkgs/commit/065a393a8d0412ce1839cd8eaad476b923cf8a5e) libaom: 3.10.0 -> 3.11.0
* [`797b544b`](https://github.com/NixOS/nixpkgs/commit/797b544bda2f9b921c9757c422aa68a1de1b431b) postgresql_16: 16.4 -> 16.5
* [`3aeb9755`](https://github.com/NixOS/nixpkgs/commit/3aeb9755e933c27809782891cfbed1660894123e) boost: 1.81 -> 1.86
* [`9be3e110`](https://github.com/NixOS/nixpkgs/commit/9be3e110508ee6ad12d6b4935a9df4a82c29c4f2) curl: backport netrc regression fix
* [`54725195`](https://github.com/NixOS/nixpkgs/commit/547251956b2dad7de893eb09e876a8e79df6f9b9) nixos/minidlna: remove with lib
* [`93d38a29`](https://github.com/NixOS/nixpkgs/commit/93d38a29e0e473731b36e5d6f8e7ea12c3e58f3d) nixos/minidlna: add option
* [`3e0bc634`](https://github.com/NixOS/nixpkgs/commit/3e0bc63451ec9edae5d831f8cc10333be631f56b) folly: format with `nixfmt-rfc-style`
* [`89e64193`](https://github.com/NixOS/nixpkgs/commit/89e641930d8e38c22ace2459de9ed5d59e303b9c) folly: convert to new Darwin SDK pattern
* [`b22849fd`](https://github.com/NixOS/nixpkgs/commit/b22849fd64aeb41230f248fa7105279e31eb232c) folly: move to `pkgs/by-name`
* [`77300534`](https://github.com/NixOS/nixpkgs/commit/77300534286faf02ec5a6513399e8db928e8028a) folly: use `finalAttrs`
* [`fbb9ab50`](https://github.com/NixOS/nixpkgs/commit/fbb9ab5079a9269684c3d07edb355f992b462d77) folly: remove `with lib;`
* [`0d5cd2a3`](https://github.com/NixOS/nixpkgs/commit/0d5cd2a39d8ab7368a3fa03a7d08d32ea0dad4bc) folly: use `refs/tags/`
* [`b67cce14`](https://github.com/NixOS/nixpkgs/commit/b67cce1449a32fa94bf31e06218b0bbb23f2ba95) folly: use `hash`
* [`593f7888`](https://github.com/NixOS/nixpkgs/commit/593f78887a31e513b07aa0bd0a3edb2b74d4e3aa) folly: reorder attributes
* [`7ae3a8ad`](https://github.com/NixOS/nixpkgs/commit/7ae3a8ada67d2dff01b1d5e60c0333fd08c938a4) folly: reorder inputs to match upstream file
* [`5ee21f29`](https://github.com/NixOS/nixpkgs/commit/5ee21f2961c40dcd33d032c6b0fd0164098f1ea1) folly: refine `meta.platforms`
* [`eca60c84`](https://github.com/NixOS/nixpkgs/commit/eca60c841c4bd7e33ae89055f81ded06c059d2f1) folly: use Ninja
* [`7047ba9c`](https://github.com/NixOS/nixpkgs/commit/7047ba9ccbdf730d726c44de5e9182b4689b3f32) llvmPackages.clang: move add-nostdlibinc-flag.patch to cc-wrapper
* [`7d8f0801`](https://github.com/NixOS/nixpkgs/commit/7d8f0801a43b49d00ae0070032a7965191a806b9) uv: 0.5.1 -> 0.5.2
* [`18969950`](https://github.com/NixOS/nixpkgs/commit/1896995025743fdf79e607c613fc7e9fa6ad4c72) aws-c-auth: 0.7.26 -> 0.8.0
* [`b497dfa1`](https://github.com/NixOS/nixpkgs/commit/b497dfa184430d92f79ca1e41e80a1134f10020d) bundler-{app,env}: expose pname and version in derivation
* [`c114f3df`](https://github.com/NixOS/nixpkgs/commit/c114f3df83c20c0d51fb87c15ba658bea8c3107b) aws-c-common: 0.9.27 -> 0.10.3
* [`40e546a4`](https://github.com/NixOS/nixpkgs/commit/40e546a42ac4f0306d7b1fc77c38d94f9acd8fef) aws-c-event-stream: 0.4.3 -> 0.5.0
* [`ed412319`](https://github.com/NixOS/nixpkgs/commit/ed412319a27bc59cc9c69bca3500f7c72290acdf) aws-c-http: 0.8.2 -> 0.9.2
* [`00f5f8bc`](https://github.com/NixOS/nixpkgs/commit/00f5f8bc5d2660e027a33182760a4de001bc678b) aws-c-mqtt: 0.10.5 -> 0.11.0
* [`38d503d5`](https://github.com/NixOS/nixpkgs/commit/38d503d58d0ec7f986dfbec3edb77765371ae4a9) aws-c-s3: 0.6.0 -> 0.7.1
* [`4d26d412`](https://github.com/NixOS/nixpkgs/commit/4d26d412c3cf48d0ce9dd9f16eea31770fc01141) aws-c-compression: 0.2.19 -> 0.3.0
* [`be4d282c`](https://github.com/NixOS/nixpkgs/commit/be4d282cf9c355c605a41140a1399c2c581cd6d1) aws-c-io: 0.14.18 -> 0.15.3
* [`61f93320`](https://github.com/NixOS/nixpkgs/commit/61f93320e8d0950d563ae1bc0bd98a3808178d0e) aws-checksums: 0.1.18 -> 0.2.2
* [`c74b7e24`](https://github.com/NixOS/nixpkgs/commit/c74b7e24537bc95acb834286118cebba61c18208) aws-c-sdkutils: 0.1.16 -> 0.2.1
* [`efe4939e`](https://github.com/NixOS/nixpkgs/commit/efe4939ed8dde1ae4cd2d022e9907b8a014a4fa3) aws-c-cal: 0.6.15 -> 0.8.0
* [`03d3d603`](https://github.com/NixOS/nixpkgs/commit/03d3d6034b18e93052668fe7d712bcb57bd2621c) aws-crt-cpp: 0.29.4 -> 0.29.4
* [`437dca66`](https://github.com/NixOS/nixpkgs/commit/437dca6672ed19a04837a9f4589f5ac551b8183e) aws-sdk-cpp: 1.11.448 -> 1.11.448
* [`6fc6e7bc`](https://github.com/NixOS/nixpkgs/commit/6fc6e7bce851f59f61c3f96c62a014bedc40fbf0) systemd: 256.7 -> 256.8
* [`3e7fb955`](https://github.com/NixOS/nixpkgs/commit/3e7fb9550277f97b4113e10718da2078b39baeed) hid-tmff2: 0.81 -> 0.82
* [`e516bc35`](https://github.com/NixOS/nixpkgs/commit/e516bc35e78977f44b42b681a23b08e3712e8d22) xorg.utilmacros: 1.2.0.1 -> 1.20.2
* [`83e1ebb0`](https://github.com/NixOS/nixpkgs/commit/83e1ebb0c67cb310adeeabf6c4ab6218dbad403d) ruby_3_3: 3.3.5 -> 3.3.6
* [`83c4a9c3`](https://github.com/NixOS/nixpkgs/commit/83c4a9c338d8a972291737306848ab5628fd8515) aws-*: don't auto update
* [`719c731d`](https://github.com/NixOS/nixpkgs/commit/719c731df3f1b48570fc1e89d83e27d78ee26b23) stdenv: elaborate on nature of mass rebuilds
* [`da006946`](https://github.com/NixOS/nixpkgs/commit/da006946a927ecc5883b306ec4370fea0c7b6868) emacs: use `--replace-warn`
* [`bdd6ddd2`](https://github.com/NixOS/nixpkgs/commit/bdd6ddd20d7f5ff12ef5a8156603550516d9d5c2) autoconf-archive: fix quoting of m4_fatal
* [`583c2c58`](https://github.com/NixOS/nixpkgs/commit/583c2c58e9833e648fb17c1a98fdd379b243c9d9) openh264: 2.4.1 -> 2.5.0
* [`19853b79`](https://github.com/NixOS/nixpkgs/commit/19853b79530b5c99e5e1412aaf9721e0ec3b70bb) Revert "systemd: revert boot-breaking systemd-boot change"
* [`f87a1736`](https://github.com/NixOS/nixpkgs/commit/f87a1736cc5b7d4ffe31295e749f17a97b039fd3) waf: 2.1.3 -> 2.1.4
* [`894fb074`](https://github.com/NixOS/nixpkgs/commit/894fb0748dc16bac3d6fee704715e726759481eb) e2fsprogs: remove compat patch
* [`71306e6b`](https://github.com/NixOS/nixpkgs/commit/71306e6b36657f3987214611ec863a891334bf5a) nixos/lib/test-driver: remove legacy args handling
* [`e307440e`](https://github.com/NixOS/nixpkgs/commit/e307440e58d0ae7feeec3571c206cbdc29c73e91) juce: reformat
* [`a2f60bb5`](https://github.com/NixOS/nixpkgs/commit/a2f60bb52e86be09e79e7f2078f3c8972d7d8cfc) haskell: Don't use package-qualified and non-package-qualified grep
* [`31706d4a`](https://github.com/NixOS/nixpkgs/commit/31706d4a55d292678ab634b301347109e2dc9ea0) treewide: fix sed -ie and friends
* [`47a4caf4`](https://github.com/NixOS/nixpkgs/commit/47a4caf4839500e93fed4ada995ee40586038e9e) llvmPackages_12.compiler-rt: fix build race aarch64-darwin
* [`54522e10`](https://github.com/NixOS/nixpkgs/commit/54522e10d558fa88e032d24b426ec788d34a70ec) meson.setupHook: Add timeout-multiplier
* [`80f7c3dd`](https://github.com/NixOS/nixpkgs/commit/80f7c3ddbf0997e984a4990a36a48d3999dc9e45) nixos/doc/rl-2505: announce macOS version support policy
* [`0f9067f8`](https://github.com/NixOS/nixpkgs/commit/0f9067f865a22aa6c1fe94eed7f218287b3e9425) darwin: set the minimum version to macOS 11.3
* [`0757844d`](https://github.com/NixOS/nixpkgs/commit/0757844d03ccbff1142c4227d43a30513069583f) libsForQt5.qtbase: remove code for macOS < 11
* [`90c0ebfc`](https://github.com/NixOS/nixpkgs/commit/90c0ebfc8b49c8ab4215d0ffc5eca8bf7695106a) gtk4: remove code for macOS < 11
* [`995962f2`](https://github.com/NixOS/nixpkgs/commit/995962f25af49863609f92249668da1f1b840ac5) haskellPackages.network: remove code for macOS < 11
* [`f3c86387`](https://github.com/NixOS/nixpkgs/commit/f3c863877b175288ec45ea78c1e041610a9b135e) apple-sdk_{10_12,10_13,10_14,10_15}: drop
* [`685ed87e`](https://github.com/NixOS/nixpkgs/commit/685ed87eccd31e58eceac312a9053c7a5314cfa8) darwin.apple_sdk_10_12: drop
* [`fee73d8d`](https://github.com/NixOS/nixpkgs/commit/fee73d8d33805d4af6d676288e1387b60003b6b5) apple-sdk: remove code for old SDKs
* [`c00c40ba`](https://github.com/NixOS/nixpkgs/commit/c00c40ba8b994305961b1263255252b5194b588b) stdenv/darwin: remove code for old SDKs
* [`9af10047`](https://github.com/NixOS/nixpkgs/commit/9af100479c5948d0dd833a745f45c5c1f2c27d7d) nixos/chrony: fix memory locking issue with graphene-hardened-light
* [`98d5c93e`](https://github.com/NixOS/nixpkgs/commit/98d5c93e0afc2f03a768b7ff638e594b48a8f191) llvmPackages.compiler-rt: remove code for macOS < 11
* [`4963ea1e`](https://github.com/NixOS/nixpkgs/commit/4963ea1eaa2c25a56c05095eeaad245e1ca6e341) llvmPackages.lldb: remove code for macOS < 11
* [`b600d09a`](https://github.com/NixOS/nixpkgs/commit/b600d09aa151b20c481ce58d38e5109172009733) llvmPackages.libcxx: remove code for macOS < 11
* [`e3810681`](https://github.com/NixOS/nixpkgs/commit/e38106815e4e8177b196ddffe2f6dc639c446ea4) ld64: remove code for macOS < 11
* [`fa10b9c7`](https://github.com/NixOS/nixpkgs/commit/fa10b9c7f8ab7fba2f285fac32de362fb6924533) ld64: use the SDK source release packages
* [`af82e115`](https://github.com/NixOS/nixpkgs/commit/af82e115592a7290bdbf8c9fbfed3fa783f384d0) cctools: remove code for macOS < 11
* [`937529bb`](https://github.com/NixOS/nixpkgs/commit/937529bb5178df7221fc4cabcb5faee558bae31e) gcc: remove code for macOS < 11
* [`63a7b4f1`](https://github.com/NixOS/nixpkgs/commit/63a7b4f14364ba09933c38af0ec462e87d8482fa) python3: remove code for macOS < 11
* [`b937adc2`](https://github.com/NixOS/nixpkgs/commit/b937adc202be021c546a7095d77a9eb9eb0f5dd4) darwin.IOKitTools: remove code for macOS < 11
* [`7b3dd230`](https://github.com/NixOS/nixpkgs/commit/7b3dd230da3f734ec334bb3c638f766e86ce44cc) darwin.adv_cmds: remove code for macOS < 11
* [`c5790587`](https://github.com/NixOS/nixpkgs/commit/c579058789780f869e7377916a8688ceace8f2a2) darwin.copyfile: remove code for macOS < 11
* [`7dca5760`](https://github.com/NixOS/nixpkgs/commit/7dca57603c6ab0d706c38a5392a5306825b1c84b) darwin.diskdev_cmds: remove code for macOS < 11
* [`ab0a6abb`](https://github.com/NixOS/nixpkgs/commit/ab0a6abbf9b66573f1c58104272662b7a4a448e0) darwin.file_cmds: remove code for macOS < 11
* [`1b30d9b9`](https://github.com/NixOS/nixpkgs/commit/1b30d9b9f0eeacfda4e0984bf8603f78864867e6) darwin.libpcap: remove code for macOS < 11
* [`ba01760b`](https://github.com/NixOS/nixpkgs/commit/ba01760b21f9c9af04d3cd287c94992680ab8fce) darwin.libresolv: remove code for macOS < 11
* [`5cf94b53`](https://github.com/NixOS/nixpkgs/commit/5cf94b53c865ceaaf0c7a111c423cdce460fb6bd) darwin.mail_cmds: remove code for macOS < 11
* [`6ec624cb`](https://github.com/NixOS/nixpkgs/commit/6ec624cba0d218fa9e99a364fce7f8c2652c2357) darwin.network_cmds: remove code for macOS < 11
* [`da2128cb`](https://github.com/NixOS/nixpkgs/commit/da2128cb405f9f517e68a36973f4a92b08de35fb) darwin.patch_cmds: remove code for macOS < 11
* [`94bc3e47`](https://github.com/NixOS/nixpkgs/commit/94bc3e473a8bf61579908d5e00e1f6268b634709) darwin.removefile: remove code for macOS < 11
* [`bd002ebb`](https://github.com/NixOS/nixpkgs/commit/bd002ebb74ef301a8fabd89ea1a7ef5f821167f2) darwin.shell_cmds: remove code for macOS < 11
* [`1c0adeb5`](https://github.com/NixOS/nixpkgs/commit/1c0adeb5d45bb2afa4124ff464136fe6f9e2cf8d) darwin.system_cmds: remove code for macOS < 11
* [`377c3ff7`](https://github.com/NixOS/nixpkgs/commit/377c3ff76b3f7d24220d530646afc6928d4152b1) darwin.text_cmds: remove code for macOS < 11
* [`082b0535`](https://github.com/NixOS/nixpkgs/commit/082b0535df73f898344701a09010ee232c717e2c) darwin.top: remove code for macOS < 11
* [`c7a0002b`](https://github.com/NixOS/nixpkgs/commit/c7a0002b0b64c54ea0c28a7f75a3da263d0452b4) nixVersions.{nix_2_24,git}: remove code for macOS < 11
* [`726bfb7c`](https://github.com/NixOS/nixpkgs/commit/726bfb7ca487492ebd31a2a390986ff274e6feba) memstream{,Hook}: drop
* [`874d326a`](https://github.com/NixOS/nixpkgs/commit/874d326aca331ec8580fddba3e559ce15ba091c4) memorymapping{,Hook}: drop
* [`312737ea`](https://github.com/NixOS/nixpkgs/commit/312737ea68be42c32ffce0b355b3fb29b7cb52a2) libuv: disable test for darwin sandbox
* [`8c407207`](https://github.com/NixOS/nixpkgs/commit/8c4072073225b7dceaafc30086824e6e79e90460) python3Packages.cffi: remove some obsolete darwin patches
* [`77787905`](https://github.com/NixOS/nixpkgs/commit/77787905e73bf06917f61ace2414034ca7bb4cc6) python3Packages.cffi: disable a test on FreeBSD
* [`05a480c3`](https://github.com/NixOS/nixpkgs/commit/05a480c3af6fed341033979a2a69dbd46caa5ac2) libgit2: switch to pcre2
* [`61d19bc3`](https://github.com/NixOS/nixpkgs/commit/61d19bc34a00381740c9d83a03da85beee164a50) xorg.libXt: 1.3.0 -> 1.3.1
* [`a5c0f9ce`](https://github.com/NixOS/nixpkgs/commit/a5c0f9ce9bb0880def8b7e8864c31de7adc1d6a8) gns3-gui: update to 2.2.51
* [`a3f5de3a`](https://github.com/NixOS/nixpkgs/commit/a3f5de3a736f043a6b00f28a595a356a1a632f7b) python3Packages.ropper: 1.3.8 -> 1.3.10
* [`e8a6b9ef`](https://github.com/NixOS/nixpkgs/commit/e8a6b9eff5557491969ba4e7637b57b94be80557) bluez.updateScript: init
* [`83b7cf4a`](https://github.com/NixOS/nixpkgs/commit/83b7cf4a00c0052c3467896d333c45df1829a1fe) bluez: 5.78 -> 5.79
* [`920dbf9a`](https://github.com/NixOS/nixpkgs/commit/920dbf9a5618f4ae661a92860e0d0114e12c7b68) python311Packages: stop recursing into package set
* [`987b8043`](https://github.com/NixOS/nixpkgs/commit/987b804367b616e53f27800a4e32504e96623214) python313Packages: recurse into package set
* [`53a6655f`](https://github.com/NixOS/nixpkgs/commit/53a6655f7225bf5dbd9960251d72ce7223b60bf5) python313Packages.flit: 3.9.0 -> 3.10.0
* [`2c36c0c9`](https://github.com/NixOS/nixpkgs/commit/2c36c0c994f4c7db0d99d1fc1dce9e25d502a408) python313Packages.colorlog: fix build
* [`bf586e1e`](https://github.com/NixOS/nixpkgs/commit/bf586e1e6318c18d414b10740ee18c464f238c84) python313Packages.jedi: 0.19.1 -> 0.19.1-unstable-2024-10-17
* [`520e0ed2`](https://github.com/NixOS/nixpkgs/commit/520e0ed26d32ed01b5c00681cd33a121ef5f95f8) python313Packages.rpds-py: 0.18.1 -> 0.20.0
* [`d2751a94`](https://github.com/NixOS/nixpkgs/commit/d2751a94792cf7ee8538b3dfee8a86e6362125d0) python313Packages.wrapt: 1.16.0 > 1.17.0dev4
* [`78dd50f7`](https://github.com/NixOS/nixpkgs/commit/78dd50f7a23db0843be9a615e02c3ac127ae10d4) python313Packages.curio: 1.6 -> 1.6-unstable-2024-04-11
* [`d390c9ee`](https://github.com/NixOS/nixpkgs/commit/d390c9ee82cececccfee9f914e05eb83c80b0ebb) python313Packages.parameterized: fix tests
* [`fd30f279`](https://github.com/NixOS/nixpkgs/commit/fd30f2796b08596646c9a43fd439c4177f53c0ac) python313Packages.trustme: 1.1.0 -> 1.2.0
* [`e5fb68f6`](https://github.com/NixOS/nixpkgs/commit/e5fb68f685aa5f70cd578cc3c57eef79fbb0c231) python313Packages.watchdog: 4.0.2 -> 5.0.3
* [`e76fbe62`](https://github.com/NixOS/nixpkgs/commit/e76fbe62bef07f205ee03548adb079e3db0971ae) python313Packages.pure-eval: 0.2.2 -> 0.2.3
* [`cbe9b655`](https://github.com/NixOS/nixpkgs/commit/cbe9b6557f052148b275d46cadeb28cc4f967851) python313Packages.astroid: 3.3.4 -> 3.3.5
* [`d27de45c`](https://github.com/NixOS/nixpkgs/commit/d27de45c207035e85cce9f8079e831fc9fff843c) python313Packages.twisted: 24.7.0 -> 24.10.0
* [`a0c33425`](https://github.com/NixOS/nixpkgs/commit/a0c33425f12ecdfc3c456ff2d0d801a161e59eca) python313Packages.cython_0: disable
* [`9cd69975`](https://github.com/NixOS/nixpkgs/commit/9cd69975e3106a939c4513fdc4c3ce643f51ec9b) python313Packages.pyflakes: disable failing tests
* [`c6d7e26b`](https://github.com/NixOS/nixpkgs/commit/c6d7e26b9f24f8f9a71b0599def49fc8d535c407) python313Packages.oauthlib: disable failing test
* [`ddc3140a`](https://github.com/NixOS/nixpkgs/commit/ddc3140a998c002f9d20e12ccca1c65127d4626b) gpgme: add python3.13 support
* [`d6c1a5e4`](https://github.com/NixOS/nixpkgs/commit/d6c1a5e4e205045d549cba78f3df520f19a558cc) python3.pkgs.pythonRuntimeDepsCheckHook: allow prereleases
* [`e45ee06a`](https://github.com/NixOS/nixpkgs/commit/e45ee06a8731823a10f8d9fa860174ddd3b46fee) python313Packages.toolz: 0.12.1 -> 1.0.0
* [`35a944f3`](https://github.com/NixOS/nixpkgs/commit/35a944f30c5cac6a6160d746fbdacf1b3388faf1) python313Packages.pytest-doctestplus: fix tests
* [`6cad9267`](https://github.com/NixOS/nixpkgs/commit/6cad9267f80918f7e727ea20c70becf77c7f2076) python312Packages.cython_0: 0.29.36 -> 0.29.37.1
* [`26050b09`](https://github.com/NixOS/nixpkgs/commit/26050b09dc835be830b193d55b3bb9852621b515) python313Packages.psycopg2: 2.9.9 -> 2.9.10
* [`ff16ccea`](https://github.com/NixOS/nixpkgs/commit/ff16cceabe6f06a58403aab0a1b5fcfe2bc86fa5) python312Packages.redis: 5.1.1 -> 5.2.0
* [`92fbead4`](https://github.com/NixOS/nixpkgs/commit/92fbead477ae585c45e79131d79e7e3168ea0337) python312Packages.fakeredis: 2.25.1 -> 2.26.1
* [`26608c5e`](https://github.com/NixOS/nixpkgs/commit/26608c5e4a43987a69d843247a4aefda276a1d02) python313Packages.watchfiles: 0.22.0 -> 0.24.0
* [`d6298777`](https://github.com/NixOS/nixpkgs/commit/d629877745558b0f328308e561d41b79dd2d43fc) python313Packages.httptools: 0.6.1 -> 0.6.4
* [`024350e3`](https://github.com/NixOS/nixpkgs/commit/024350e33914f18840790b7644b2c029fc57b915) python313Packages.deprecated: disable failing tests
* [`6b9e3472`](https://github.com/NixOS/nixpkgs/commit/6b9e3472ae81f934e0aeb6919974dc1760ac11cf) python312Packages.setuptools: 75.1.0 -> 75.3.0
* [`5bfacde2`](https://github.com/NixOS/nixpkgs/commit/5bfacde24ba22c8dae9c28542232c68b26c3c321) python312Packages.numpy: 1.26.4 -> 2.1.2
* [`221b4c4d`](https://github.com/NixOS/nixpkgs/commit/221b4c4d4ead3274855a0bb88831639d77355cb3) python312Packages.seaborn: fix compatibility with numpy>=2
* [`b01b543f`](https://github.com/NixOS/nixpkgs/commit/b01b543f41ab31d3411bf54ff1933f22f7a45fb4) python312Packages.cirq-core: 1.4.1 -> 1.4.1-unstable-2024-09-21
* [`a31c91d2`](https://github.com/NixOS/nixpkgs/commit/a31c91d2e0451a43f66c658d1b30fc94a9cac619) python312Packages.ase: fix compatibility with numpy>=2
* [`b41a8367`](https://github.com/NixOS/nixpkgs/commit/b41a83676e3e199f508b2eb75b6c7348cd1206e7) python312Packages.einops: fix compatibility with numpy>=2
* [`c3f94cf5`](https://github.com/NixOS/nixpkgs/commit/c3f94cf57dc35772185b7a051f3e16a41944c343) python312Packages.patsy: fix compatibility with numpy>=2
* [`4a4e321f`](https://github.com/NixOS/nixpkgs/commit/4a4e321ffdc1378540f883b6c4ce632621e22a61) python312Packages.plotly: fix compatibility with numpy>=2
* [`40f89c6e`](https://github.com/NixOS/nixpkgs/commit/40f89c6e0d0cd9e47c14183d3bee21e815785151) python3.pkgs.pythonRuntimeDepsCheckHook: don't validate wheel metadata
* [`b1ac443c`](https://github.com/NixOS/nixpkgs/commit/b1ac443c554758b77f877dd5e3c1c0a7bf915b93) python313Packages.packaging: 24.1 -> 24.2
* [`925d0ecf`](https://github.com/NixOS/nixpkgs/commit/925d0ecf50e31c913cd968361c8b1944bb9a9147) python312Packages.starlette: 0.40.0 -> 0.41.2
* [`8722d610`](https://github.com/NixOS/nixpkgs/commit/8722d610babccd9c2335e4c2eb1f0908e07cd40e) python312Packages.python-multipart: 0.0.12 -> 0.0.17
* [`5c8e9946`](https://github.com/NixOS/nixpkgs/commit/5c8e9946fd5764947dda45d03ca3a4fe00192d90) python312Packages.fastapi: 0.115.3 -> 0.115.4
* [`7a635aa8`](https://github.com/NixOS/nixpkgs/commit/7a635aa8be7df6588bdf365609f26888c35572dc) python313Packages.eliot: patch for numpy2 compat
* [`fe14d581`](https://github.com/NixOS/nixpkgs/commit/fe14d581941980f402066cbc95c953254e6a3243) python313Packages.eventlet: apply patch for 3.13 compat
* [`61e3dc61`](https://github.com/NixOS/nixpkgs/commit/61e3dc616378b585ee950d6e61138221062b4101) python313Packages.msgspec: apply patch for 3.13 support
* [`bf963769`](https://github.com/NixOS/nixpkgs/commit/bf963769c5097e4d45041192156b9f4eceb40aa1) python312Packages.moto: 5.0.18 -> 5.0.20
* [`6ec63d56`](https://github.com/NixOS/nixpkgs/commit/6ec63d56ff76f28c22844ca6f9a21b8ae0de9d29) python313Packages.orjson: 3.10.7 -> 3.10.11
* [`b0a6dbef`](https://github.com/NixOS/nixpkgs/commit/b0a6dbeffc28da6ff44c72cfa964badb2a2678fc) python313Packages.numpy: 2.1.2 -> 2.1.3
* [`41b458bf`](https://github.com/NixOS/nixpkgs/commit/41b458bf839b2311617d78c86ff7f40b94e20d18) python313Packages.ipdb: disable failing tests
* [`59d77698`](https://github.com/NixOS/nixpkgs/commit/59d776981717f35ab70669b67f153a19fa7b8498) python313Packages.pkginfo: 1.11.1 -> 1.11.2
* [`e5c3b12b`](https://github.com/NixOS/nixpkgs/commit/e5c3b12b6a1896673c7928f38efe7286ce43813a) python313Packages.pyodbc: 5.1.0 -> 5.2.0
* [`052de9f5`](https://github.com/NixOS/nixpkgs/commit/052de9f5973b3a2014622465c33f6a207e5bdde6) python313Packagese.cattrs: disable failing tests, modernize
* [`0c2c3c8e`](https://github.com/NixOS/nixpkgs/commit/0c2c3c8ee9ba35cebdcf08e40301add651d5e15e) python313Packages.ml-dtypes: establish numpy2 compat
* [`99673388`](https://github.com/NixOS/nixpkgs/commit/99673388572ffc162e762fc6919259484dffcbc8) python312Packages.pytest-benchmark: 4.0.0 -> 5.1.0
* [`19908dd5`](https://github.com/NixOS/nixpkgs/commit/19908dd50f6e5eec156db7193032d99a0e3d776e) python313Packages.django_4: disable failing test
* [`ad54759c`](https://github.com/NixOS/nixpkgs/commit/ad54759c98a96596f11b88ad48d2e28b378c7a27) python313Packages.importlib-resources: backport 3.13 compat
* [`3b571083`](https://github.com/NixOS/nixpkgs/commit/3b5710835c31dbfc7048a3cf13e4647d5afae9c8) python313Packages.hatchling: 1.25.0 -> 1.26.1
* [`d4c26774`](https://github.com/NixOS/nixpkgs/commit/d4c26774d5eb78e3374a8131934ea1f51b533cff) folly: 2024.03.11.00 -> 2024.11.18.00
* [`2fc882c7`](https://github.com/NixOS/nixpkgs/commit/2fc882c70caf62e96b14996b7feff6f60ee8cbd9) folly: patch `pkg-config` file instead of CMake files
* [`fbdced9b`](https://github.com/NixOS/nixpkgs/commit/fbdced9bb35a7a9619bfeab7a0244fd603fa6b03) folly: fix split outputs
* [`ae0425bd`](https://github.com/NixOS/nixpkgs/commit/ae0425bd9a566411f8cd86de17985786f895bcb0) folly: refine `-fpermissive` flag
* [`3352d4f1`](https://github.com/NixOS/nixpkgs/commit/3352d4f1ab484923e31f86a2969e6c8442efd964) folly: remove obsolete AArch64 hack
* [`cad3e3ec`](https://github.com/NixOS/nixpkgs/commit/cad3e3ece680b4bab28d15c9626dd78b4d4db726) folly: condition shared libraries on platform setting
* [`fb3b4695`](https://github.com/NixOS/nixpkgs/commit/fb3b469558cc59f1c992d86264f1f193208d01aa) folly: propagate required dependencies
* [`bba7126b`](https://github.com/NixOS/nixpkgs/commit/bba7126b28441f19eace48cd842d31799473ee82) folly: bump to `fmt_11`
* [`a3afbe7c`](https://github.com/NixOS/nixpkgs/commit/a3afbe7ccf4d41df8c712f9eba76aa985c3a2e5b) folly: enable tests
* [`f86db487`](https://github.com/NixOS/nixpkgs/commit/f86db4874da1299fe7b09c470ae618c544eaa923) folly: add update script
* [`df175d62`](https://github.com/NixOS/nixpkgs/commit/df175d625e04e14a69fffbc186c3c69d52e825cf) folly: add emily to maintainers
* [`c71ed296`](https://github.com/NixOS/nixpkgs/commit/c71ed296d791941e67e108cc39eec4b13a32b705) folly: add techknowlogick to maintainers
* [`95d28ae6`](https://github.com/NixOS/nixpkgs/commit/95d28ae657e6cc9eb01abbfc1623138955c798ac) fizz: format with `nixfmt-rfc-style`
* [`91c31b10`](https://github.com/NixOS/nixpkgs/commit/91c31b10692ba26cdfeb9501e8eb5280fbb66220) fizz: convert to new Darwin SDK pattern
* [`eb19c30c`](https://github.com/NixOS/nixpkgs/commit/eb19c30c3ace43959738f0885b6c7f0f82a124a8) fizz: move to `pkgs/by-name`
* [`be386149`](https://github.com/NixOS/nixpkgs/commit/be3861494e77b389b2ee98beda99b533f7195f67) fizz: remove `with lib;`
* [`d68470e9`](https://github.com/NixOS/nixpkgs/commit/d68470e96bd21abbd8f28c3cba770c19f643ecb5) fizz: reorder attributes
* [`997d4ede`](https://github.com/NixOS/nixpkgs/commit/997d4edee5cc3d79b9530ee14e1ac913f928fc13) fizz: reorder inputs to match upstream file
* [`74e32917`](https://github.com/NixOS/nixpkgs/commit/74e329179b95b39fd04bb04c415d350c98488113) fizz: remove unnecessary input
* [`cb829657`](https://github.com/NixOS/nixpkgs/commit/cb829657b8992dee9d0781462718bd5a6498245b) fizz: remove unnecessary `NIX_LDFLAGS`
* [`ca280ee5`](https://github.com/NixOS/nixpkgs/commit/ca280ee51f8c404858fa2778889ec155cb5c2390) fizz: remove unnecessary CMake flag
* [`1c1d6a6b`](https://github.com/NixOS/nixpkgs/commit/1c1d6a6ba2943c6272ee865021b9ca4c02f7876c) fizz: use Ninja
* [`3f4e898d`](https://github.com/NixOS/nixpkgs/commit/3f4e898d0a359a2847aff3145bb81a8d4147f245) fizz: set `__darwinAllowLocalNetworking`
* [`67fd043f`](https://github.com/NixOS/nixpkgs/commit/67fd043f62962e02670b4a714ac375b40772e1e1) fizz: 2024.03.11.00 -> 2024.11.11.00
* [`136740de`](https://github.com/NixOS/nixpkgs/commit/136740dec662e1bc4e9560393fa568c3f9450b53) fizz: condition shared libraries on platform setting
* [`03b58e14`](https://github.com/NixOS/nixpkgs/commit/03b58e14f792db6acbed43439281561dcfe92d7f) fizz: propagate required dependencies
* [`f88b7334`](https://github.com/NixOS/nixpkgs/commit/f88b7334eaedf837cb81f08bd40e9d80543f7b61) fizz: enable more tests
* [`dbb5591b`](https://github.com/NixOS/nixpkgs/commit/dbb5591b5b267339ac46448b1096f0d457c237b6) fizz: split outputs
* [`0414a001`](https://github.com/NixOS/nixpkgs/commit/0414a001b6b80cbf81c84cbbe67fc418191f581d) fizz: add update script
* [`5115b618`](https://github.com/NixOS/nixpkgs/commit/5115b6186a5c3d6264964358022d27a2ce508702) fizz: add emily to maintainers
* [`4871d404`](https://github.com/NixOS/nixpkgs/commit/4871d40414226e48c89c411b56fc668dea1cb23a) fizz: add techknowlogick to maintainers
* [`ee8c1b19`](https://github.com/NixOS/nixpkgs/commit/ee8c1b1980f466183f36b473accf64b58de12aa4) mvfst: format with `nixfmt-rfc-style`
* [`5b60e96f`](https://github.com/NixOS/nixpkgs/commit/5b60e96f64c75a169768492ef30e125037242f66) mvfst: convert to new Darwin SDK pattern
* [`d76e1dc8`](https://github.com/NixOS/nixpkgs/commit/d76e1dc840eb0d018f11ec88d8808c71052e29cd) mvfst: move to `pkgs/by-name`
* [`e82a30f5`](https://github.com/NixOS/nixpkgs/commit/e82a30f577f4547eb29ed20f428813e1d0a363b2) mvfst: use `finalAttrs`
* [`5848ed9b`](https://github.com/NixOS/nixpkgs/commit/5848ed9bfbec76ed225ffb9519584c0d945851e2) mvfst: remove `with lib;`
* [`40d409e3`](https://github.com/NixOS/nixpkgs/commit/40d409e3dbd6da712dafe2ecf8c1f9d1ecbf138f) mvfst: use `refs/tags/`
* [`067a44e6`](https://github.com/NixOS/nixpkgs/commit/067a44e638003c206c9ec4826e727b7d31e25ce4) mvfst: use `hash`
* [`4f8f7221`](https://github.com/NixOS/nixpkgs/commit/4f8f722165e5f490327e4d5a65513846cd9bd309) mvfst: reorder inputs
* [`c647a831`](https://github.com/NixOS/nixpkgs/commit/c647a831203c3d51eef949e9cd60cdcc5a191fdc) mvfst: use Ninja
* [`5b08d098`](https://github.com/NixOS/nixpkgs/commit/5b08d0983422fc5cbe9502de2cc137aea3b7eb8f) mvfst: 2024.03.11.00 -> 2024.11.18.00
* [`ee1e828c`](https://github.com/NixOS/nixpkgs/commit/ee1e828c2731ec81cc11c03b7f7eb23c3d02b5e3) mvfst: condition shared libraries on platform setting
* [`e5709fe8`](https://github.com/NixOS/nixpkgs/commit/e5709fe8148e9af89d7eca372eda64d6fe7ab6a7) mvfst: propagate required dependencies
* [`ea635930`](https://github.com/NixOS/nixpkgs/commit/ea635930e783661d12ffd5a589981c89ee84b646) mvfst: enable tests
* [`49ad4789`](https://github.com/NixOS/nixpkgs/commit/49ad47893e80628afe3e08fc847929503da1de9b) mvfst: split outputs
* [`09315626`](https://github.com/NixOS/nixpkgs/commit/0931562600485a700fd8d3ed65af94495e13e3c2) mvfst: add update script
* [`fef1275d`](https://github.com/NixOS/nixpkgs/commit/fef1275d9bdb171b189364ad6e26f9f478ab7389) mvfst: add emily to maintainers
* [`01eddf68`](https://github.com/NixOS/nixpkgs/commit/01eddf68ddef3292efb478616a613e5adff45ad0) mvfst: add techknowlogick to maintainers
* [`6d542aed`](https://github.com/NixOS/nixpkgs/commit/6d542aedaf25d86a78a3ab58b9a574a972b8f785) wangle: format with `nixfmt-rfc-style`
* [`b21418c8`](https://github.com/NixOS/nixpkgs/commit/b21418c8d81f68502d196c4fcfaad1197413b2ce) wangle: convert to new Darwin SDK pattern
* [`1b7c0a5e`](https://github.com/NixOS/nixpkgs/commit/1b7c0a5eb09050f2ba618b00983e06255b813089) wangle: move to `pkgs/by-name`
* [`337f8966`](https://github.com/NixOS/nixpkgs/commit/337f896690b67e5b5a4950e24ee6b60f47944b54) wangle: remove `with lib;`
* [`355eae10`](https://github.com/NixOS/nixpkgs/commit/355eae10ef9909f6b69d203210680ce2c7d8e0e6) wangle: use `refs/tags/`
* [`34fa0315`](https://github.com/NixOS/nixpkgs/commit/34fa0315d46ca13086db80d38564dac1fc9cf720) wangle: use `hash`
* [`4a2ad773`](https://github.com/NixOS/nixpkgs/commit/4a2ad7732b9f179c0878a9978bcf142e183abdf7) wangle: reorder attributes
* [`c93b3ff5`](https://github.com/NixOS/nixpkgs/commit/c93b3ff59af12832f81deb4c191964dbd9009bcb) wangle: reorder inputs to match upstream file
* [`6ad10b9a`](https://github.com/NixOS/nixpkgs/commit/6ad10b9af58e9f1bcdde56ca4173595d33348ebc) wangle: remove unnecessary CMake flag
* [`2477b3ee`](https://github.com/NixOS/nixpkgs/commit/2477b3ee0172b87573f5610e06b6fd4169e34fa8) wangle: use Ninja
* [`ad8aa38b`](https://github.com/NixOS/nixpkgs/commit/ad8aa38bc71e64df8acfcf17d732e5a72bc2ad42) wangle: set `__darwinAllowLocalNetworking`
* [`6ff98c69`](https://github.com/NixOS/nixpkgs/commit/6ff98c69607f755a49773181761f0715aae8853d) wangle: 2024.03.11.00 -> 2024.11.18.00
* [`ade1eb00`](https://github.com/NixOS/nixpkgs/commit/ade1eb00f9af7780c3254e434d047d78ca45b3c5) wangle: condition shared libraries on platform setting
* [`5205f55d`](https://github.com/NixOS/nixpkgs/commit/5205f55d4d0a46e33956d9732c2185afe70932d0) wangle: split outputs
* [`762f4562`](https://github.com/NixOS/nixpkgs/commit/762f456228f1373a898c9997476e5a80082e694a) wangle: add update script
* [`82c87506`](https://github.com/NixOS/nixpkgs/commit/82c87506538ca969d57da9e18dec999edc8d3365) wangle: add emily to maintainers
* [`17fe5480`](https://github.com/NixOS/nixpkgs/commit/17fe5480a108d9a25756be5792e21fffe330c4f5) wangle: add techknowlogick to maintainers
* [`1848967c`](https://github.com/NixOS/nixpkgs/commit/1848967c016e020021deaf18efd54ca8ccbc5f20) fbthrift: format with `nixfmt-rfc-style`
* [`3a06e577`](https://github.com/NixOS/nixpkgs/commit/3a06e577d69e845ed472bd877955ad54e8be6bd7) fbthrift: convert to new Darwin SDK pattern
* [`dddd67fc`](https://github.com/NixOS/nixpkgs/commit/dddd67fced92a76eeed32bc47c7116df1fcac968) fbthrift: move to `pkgs/by-name`
* [`548f1f7c`](https://github.com/NixOS/nixpkgs/commit/548f1f7c35fa88b31ed1936395c04cc032a8f438) fbthrift: use `finalAttrs`
* [`9b67782a`](https://github.com/NixOS/nixpkgs/commit/9b67782a3fc04e4cfec4f51cfb8cc476a58771fc) fbthrift: remove `with lib;`
* [`cf3fde89`](https://github.com/NixOS/nixpkgs/commit/cf3fde892c97026d00eb23767f765fa157c4ed38) fbthrift: use `refs/tags/`
* [`33fe8a6a`](https://github.com/NixOS/nixpkgs/commit/33fe8a6aff7a8c3deaaa49af78859b5bc64a4197) fbthrift: use `hash`
* [`19f009b3`](https://github.com/NixOS/nixpkgs/commit/19f009b3aad9b68e968a02acfa30620db367a39b) fbthrift: reorder attributes
* [`26008b46`](https://github.com/NixOS/nixpkgs/commit/26008b4611d77bb9e3d3726f758604cfd9975365) fbthrift: reorder inputs to match upstream file
* [`c55b18d9`](https://github.com/NixOS/nixpkgs/commit/c55b18d9158c6c163e5e5df2499e2445bdd9cf46) fbthrift: remove unnecessary inputs
* [`fcf3d526`](https://github.com/NixOS/nixpkgs/commit/fcf3d5262ce1ae625bf374c6d2f64dfa77ecf087) fbthrift: use Ninja
* [`dc60c663`](https://github.com/NixOS/nixpkgs/commit/dc60c66359534f5f69ab126974b05d8b71f6271d) fbthrift: 2024.03.11.00 -> 2024.11.11.00
* [`3bdc6926`](https://github.com/NixOS/nixpkgs/commit/3bdc69269d392026f6c25ad136f709e12e8d1a8c) fbthrift: condition shared libraries on platform setting
* [`3dd6e0e7`](https://github.com/NixOS/nixpkgs/commit/3dd6e0e71a23a91aaf1f846ef487f6a0e59bc69e) fbthrift: propagate required dependencies
* [`acf1c72b`](https://github.com/NixOS/nixpkgs/commit/acf1c72bfceec7572b7043dd42abee0bf76dfa16) fbthrift: add note about tests
* [`7699884b`](https://github.com/NixOS/nixpkgs/commit/7699884b844f330209eccd18906f90e1b95405e8) fbthrift: split outputs
* [`814fc8dc`](https://github.com/NixOS/nixpkgs/commit/814fc8dcf101a837ea262631438075abcf4d575c) fbthrift: add update script
* [`0293bf6a`](https://github.com/NixOS/nixpkgs/commit/0293bf6af5f73272e792a07484a25453b0a7c68c) fbthrift: add emily to maintainers
* [`143f2537`](https://github.com/NixOS/nixpkgs/commit/143f253756ca08f80e47c3e411c38cc16606ce9c) fbthrift: add techknowlogick to maintainers
* [`6582129e`](https://github.com/NixOS/nixpkgs/commit/6582129eab3c3d58081106ca000bbbe96a2d4091) fb303: format with `nixfmt-rfc-style`
* [`87a7353f`](https://github.com/NixOS/nixpkgs/commit/87a7353f0c9ef56525c290ad50fe1d2b4e4bfa84) fb303: convert to new Darwin SDK pattern
* [`be97ac3f`](https://github.com/NixOS/nixpkgs/commit/be97ac3fe63710b41b15a95fb7aff75fb1627f00) fb303: move to `pkgs/by-name`
* [`3c20ddd6`](https://github.com/NixOS/nixpkgs/commit/3c20ddd66d335c2186a229d233c462d2c568435d) fb303: use `finalAttrs`
* [`fa9cad87`](https://github.com/NixOS/nixpkgs/commit/fa9cad876b6bfbfcf50974a9f5deafa267abf532) fb303: remove `with lib;`
* [`29125310`](https://github.com/NixOS/nixpkgs/commit/29125310cc32a1b10886559f7029f3e00e05317d) fb303: use `refs/tags/`
* [`5be8fbd1`](https://github.com/NixOS/nixpkgs/commit/5be8fbd184ebd0466e7de166ae8313508183bcad) fb303: use `hash`
* [`025d0edf`](https://github.com/NixOS/nixpkgs/commit/025d0edf867c5f33192977756dd49196cb66c7bb) fb303: reorder attributes
* [`ef6c8fc0`](https://github.com/NixOS/nixpkgs/commit/ef6c8fc06f3590ab7953776e3a36c39d492dde20) fb303: reorder inputs to match upstream file
* [`01b30ede`](https://github.com/NixOS/nixpkgs/commit/01b30ede829a6a794f164085a4974dc80bf2b5de) fb303: add explicit `gflags` input
* [`f7efb7b8`](https://github.com/NixOS/nixpkgs/commit/f7efb7b813c2d2a322b719783366d13c0b59dbaa) fb303: remove `python3` input
* [`068ceb04`](https://github.com/NixOS/nixpkgs/commit/068ceb04d027ed8bc84c9de23406c5dc4cb814e6) fb303: use `lib.cmakeBool`
* [`2801ca73`](https://github.com/NixOS/nixpkgs/commit/2801ca739a90ed2bda06bd43f9a0b9a88cd3b27b) fb303: use Ninja
* [`633f8f77`](https://github.com/NixOS/nixpkgs/commit/633f8f77b23351f1d19494f2f2cc56e79f5e4285) fb303: 2024.03.11.00 -> 2024.11.18.00
* [`72f24cc2`](https://github.com/NixOS/nixpkgs/commit/72f24cc2938db98b238d58c6445d61b3f2b65a67) fb303: condition shared libraries on platform setting
* [`79dc5a8b`](https://github.com/NixOS/nixpkgs/commit/79dc5a8b54c7e7149674fd1d4348c8dd412119f9) fb303: split outputs
* [`172efded`](https://github.com/NixOS/nixpkgs/commit/172efded7a0b48e6daf1ad0f3c7c1ec676b525ee) fb303: add update script
* [`d4b587f8`](https://github.com/NixOS/nixpkgs/commit/d4b587f878193665d7cb259559e85531f1d4c235) fb303: add emily to maintainers
* [`c9719114`](https://github.com/NixOS/nixpkgs/commit/c9719114fd9fc85f7123dc873140f43d08b45bab) fb303: add techknowlogick to maintainers
* [`c20f3875`](https://github.com/NixOS/nixpkgs/commit/c20f3875247fe88fc3a6f013688302b74197bef3) edencommon: format with `nixfmt-rfc-style`
* [`3c14c26a`](https://github.com/NixOS/nixpkgs/commit/3c14c26a35418f54f3ec3f1d767a92de8fdb5341) edencommon: convert to new Darwin SDK pattern
* [`aa5a90ed`](https://github.com/NixOS/nixpkgs/commit/aa5a90ed1d4a113bfd74e62685df4892dc6912db) edencommon: move to `pkgs/by-name`
* [`a8259641`](https://github.com/NixOS/nixpkgs/commit/a82596414267f3cba069337b2c8597b1547a53cd) edencommon: use `finalAttrs`
* [`171a5474`](https://github.com/NixOS/nixpkgs/commit/171a5474ac2c3b8e520be6b3c5fa2d1dcd0cd325) edencommon: remove `with lib;`
* [`eb863325`](https://github.com/NixOS/nixpkgs/commit/eb86332558fed372ff758b4466012a2fe6cb24a7) edencommon: use `refs/tags/`
* [`d26d7a19`](https://github.com/NixOS/nixpkgs/commit/d26d7a195ee0570b72f2e3267a9e8df5f4ee5be8) edencommon: use `hash`
* [`7e35f7f5`](https://github.com/NixOS/nixpkgs/commit/7e35f7f5bb495607c624b299d6d0c04f32471006) edencommon: reorder inputs to match upstream file
* [`2de2d0fa`](https://github.com/NixOS/nixpkgs/commit/2de2d0fad8f21742a342099420f999a519b1070e) edencommon: add explicit `gflags` dependency
* [`66a2ebb4`](https://github.com/NixOS/nixpkgs/commit/66a2ebb46d081620dc8ca55bf800136808ba4e62) edencommon: use Ninja
* [`509f33b9`](https://github.com/NixOS/nixpkgs/commit/509f33b9956bcd33db149b8e4a957a1d0bad9079) edencommon: 2024.03.11.00 -> 2024.11.18.00
* [`c8d4e11d`](https://github.com/NixOS/nixpkgs/commit/c8d4e11d1ce49ed6dcb5edb4ee2c583a38aff428) edencommon: condition shared libraries on platform setting
* [`d7df60e8`](https://github.com/NixOS/nixpkgs/commit/d7df60e8f45e7b8f4eb7fe31376b108def2ea888) edencommon: enable tests
* [`7da9ef3e`](https://github.com/NixOS/nixpkgs/commit/7da9ef3eb4db25e5082db30293a98b0a4dd3b9a3) edencommon: split outputs
* [`c7b019d5`](https://github.com/NixOS/nixpkgs/commit/c7b019d5f7ef6eb06d794e4357fc17f3a51034dc) edencommon: add update script
* [`cd48138e`](https://github.com/NixOS/nixpkgs/commit/cd48138e8dca0440999ccff34368159cb2c34dec) edencommon: add emily to maintainers
* [`b4b2ad6a`](https://github.com/NixOS/nixpkgs/commit/b4b2ad6a9e83f05a67773b8801a5ea9938fbbdd3) edencommon: add techknowlogick to maintainers
* [`fcb99bc1`](https://github.com/NixOS/nixpkgs/commit/fcb99bc19c648f7946bc9baf1fa143920ca69641) cpptoml: add patch for GCC 11
* [`ca944d62`](https://github.com/NixOS/nixpkgs/commit/ca944d626ba5cff1ecaddc0dda5cc2a59fa92522) watchman: format with `nixfmt-rfc-style`
* [`1c60ec77`](https://github.com/NixOS/nixpkgs/commit/1c60ec77f4081f5ff616f8b50a21b967e99c10eb) watchman: convert to new Darwin SDK pattern
* [`ba17205a`](https://github.com/NixOS/nixpkgs/commit/ba17205ae363ee665fbc7065b48ae3865d0384e4) watchman: move to `pkgs/by-name`
* [`4f864948`](https://github.com/NixOS/nixpkgs/commit/4f864948a8b40bbd964c521a433c972e67325330) watchman: use `finalAttrs`
* [`8a2efd91`](https://github.com/NixOS/nixpkgs/commit/8a2efd913300b7e6c6fd79a53962686cf9298383) watchman: remove `with lib;`
* [`14410cc8`](https://github.com/NixOS/nixpkgs/commit/14410cc8dca87ea0131afce4acce49c4a0d714eb) watchman: use `refs/tags/`
* [`033896e9`](https://github.com/NixOS/nixpkgs/commit/033896e98cf203107a6a751db4fe8f351371ea41) watchman: reorder attributes
* [`fe604367`](https://github.com/NixOS/nixpkgs/commit/fe60436739a0cd8aec4c7382249c2f5029dde64b) watchman: reorder inputs to match upstream file
* [`f7f5d1a9`](https://github.com/NixOS/nixpkgs/commit/f7f5d1a9473a3fafc5aa8f685e9e364d97548fc5) watchman: clean up inputs
* [`354913f3`](https://github.com/NixOS/nixpkgs/commit/354913f342e64e93c2a8384e52f17daf1d97b3bb) watchman: use Ninja
* [`13a571f5`](https://github.com/NixOS/nixpkgs/commit/13a571f5ee27e94c04140ae14e5bc74dc4917343) watchman: 2024.03.11.00 -> 2024.11.18.00
* [`d9ea8bbe`](https://github.com/NixOS/nixpkgs/commit/d9ea8bbebfe60895ac98640402a655e95149bcf1) watchman: use `lib.cmake{Bool,Feature}`
* [`33b5c76f`](https://github.com/NixOS/nixpkgs/commit/33b5c76f1492e5afca9a3c03d525f50891af42c1) watchman: set `CMAKE_INSTALL_RPATH_USE_LINK_PATH`
* [`e701eb3d`](https://github.com/NixOS/nixpkgs/commit/e701eb3d63fa3f4cae55d86dd935bcc117e4f174) watchman: use upstream default for `stateDir`
* [`10dbf1de`](https://github.com/NixOS/nixpkgs/commit/10dbf1de4b6864143707529c34ace520a46a7372) watchman: enable tests
* [`9a90e1cd`](https://github.com/NixOS/nixpkgs/commit/9a90e1cd80359c9dd5e7eaca80274ba9c96b5180) watchman: strip references to `folly.fmt.dev`
* [`ec166bb5`](https://github.com/NixOS/nixpkgs/commit/ec166bb5f0eb1af4fc706ea55c01cd886e81ea01) watchman: add update script
* [`df28dd1d`](https://github.com/NixOS/nixpkgs/commit/df28dd1d3c0915c071561a132d013badf3086c6d) watchman: add emily to maintainers
* [`041e7f43`](https://github.com/NixOS/nixpkgs/commit/041e7f435d6bb191f0e472763fc5f52df40c7b76) watchman: add techknowlogick to maintainers
* [`75d6e7b2`](https://github.com/NixOS/nixpkgs/commit/75d6e7b2428880e40987073674060376f9431db7) fishPlugins.bang-bang: init at 0-unstable-2023-07-23
* [`dde96067`](https://github.com/NixOS/nixpkgs/commit/dde9606751a89abc4cd05014b2ecc25e20848f6d) llvmPackages.compiler-rt: use `$SDKROOT` to fix Darwin static
* [`195c2b5a`](https://github.com/NixOS/nixpkgs/commit/195c2b5a51e75db4b7d5d70801bd8bbc9b2da003) python312Packages.baize: init at 0.22.2
* [`435f5fc0`](https://github.com/NixOS/nixpkgs/commit/435f5fc0a7990255acaf681c24528009414baa6a) python312Packages.a2wsgi: fix tests
* [`3c0f325d`](https://github.com/NixOS/nixpkgs/commit/3c0f325d73ffa9f89d95a7fc45b00828753f7183) python312Packages.connexion: skip failing test
* [`bc05229e`](https://github.com/NixOS/nixpkgs/commit/bc05229e2e5cea3fad6e717625a73889d9dbd84d) python313Packages.aiohappyeyeballs: 2.4.2 -> 2.4.3
* [`a8e22371`](https://github.com/NixOS/nixpkgs/commit/a8e2237172be5df5ad33b29fbc6a87a92875aba6) python313Packages.sphinx-autodoc-typehints: 2.4.4 -> 2.5.0
* [`9d7feef6`](https://github.com/NixOS/nixpkgs/commit/9d7feef61a8b76c522dfbc98ebb08b3c194d8d46) python312Packages.nbmake: create home for ipython tests
* [`e6dea5c4`](https://github.com/NixOS/nixpkgs/commit/e6dea5c44c142ec9ba50d3f6cb0cdec15889e07c) python312Packages.datalad: ignore deprecation warning in tests
* [`5690819d`](https://github.com/NixOS/nixpkgs/commit/5690819d8059acc22fce78029c11065703eeeffc) python313Packages.nbformat: disable failing tests
* [`7ae858a1`](https://github.com/NixOS/nixpkgs/commit/7ae858a18a71866f681ae7810f4f227abcd289ed) python312Packages.filterpy: disable failing test
* [`e4c5bb40`](https://github.com/NixOS/nixpkgs/commit/e4c5bb40963ad660df392839cd9e93494eabdd43) python312Packages.norfair: relax numpy constraint
* [`d08e1a3f`](https://github.com/NixOS/nixpkgs/commit/d08e1a3f61c2ea03c4435b9bbcbe5955a192c47c) python312Packages.graphql-core: 3.2.4 -> 3.2.5
* [`2300738a`](https://github.com/NixOS/nixpkgs/commit/2300738a41c486f687e5ae6901a3a79442b73fb3) python313Packages.css-inline: 0.14.1 -> 0.14.2
* [`c3f73ea9`](https://github.com/NixOS/nixpkgs/commit/c3f73ea908d82dba589a8b3ac2f7bb0737a2c49b) python313Packages.pycurl: 7.45.3 -> 7.45.3-unstable-2024-10-17
* [`bdfcd349`](https://github.com/NixOS/nixpkgs/commit/bdfcd349ba70632b2949e424c1c0563920aae408) python313Packages.pytest-benchmark: disable failing test
* [`1a671cd6`](https://github.com/NixOS/nixpkgs/commit/1a671cd65484955b85bc476e6e3c0f90f4881071) python313Packages.sqlalchemy-utils: disable failing test
* [`56053abb`](https://github.com/NixOS/nixpkgs/commit/56053abb61c94b17f0eeece7a02c93a4e18ca0d3) python312Packages.mxnet: relax numpy constraint
* [`256fa808`](https://github.com/NixOS/nixpkgs/commit/256fa808b50ef711a3ce7cb0c9a00ab56c46e963) python312Packages.pyvirtualdisplay: test without xdist
* [`bb6c4217`](https://github.com/NixOS/nixpkgs/commit/bb6c4217865f98b132ba927aee11a26ca5874c13) python313Packages.future: disable
* [`9e3e01e2`](https://github.com/NixOS/nixpkgs/commit/9e3e01e254df04d5fbd2e86ae5d4c5d9a31a9141) python313Packages.python-json-logger: disable failing test
* [`860bdf3a`](https://github.com/NixOS/nixpkgs/commit/860bdf3aba8fe2b9bd996bfd9a8de6fa3c533204) python313Packages.python-json-logger: migrate to PEP517 build
* [`407bf75a`](https://github.com/NixOS/nixpkgs/commit/407bf75ac5b8637a31f43c91eb5d47713f447c37) python313Packages.coreapi: disable
* [`635bae74`](https://github.com/NixOS/nixpkgs/commit/635bae7444c190b54b8c2bf4b7f90b21c8b79480) python313Packages.djangorestframework: fix build
* [`8fb80971`](https://github.com/NixOS/nixpkgs/commit/8fb80971fd5412cdfbae967a476e5d6a3282424a) python313Packages.pytest-codspeed: init at 3.0.0
* [`9ba1a70f`](https://github.com/NixOS/nixpkgs/commit/9ba1a70f7f49ed6651c0430387bc30e325de2039) python313Packages.yarl: 1.13.1 -> 1.17.1
* [`9d4db940`](https://github.com/NixOS/nixpkgs/commit/9d4db9409f97a4d6735c12eb7dc5000ede4d16f1) python313Packages.aiohttp: 3.10.10 -> 3.11.0
* [`707d3848`](https://github.com/NixOS/nixpkgs/commit/707d3848923b813b21a05c620b489dae636708e8) python313Packages.aiohttp-fast-zlib: disable tests
* [`dce41cc5`](https://github.com/NixOS/nixpkgs/commit/dce41cc5e8f1124a3f69d4a033ad7d3df9586c3a) python313Packages.aioresponses: fix compat with aiohttp 3.11.0
* [`6ad8b704`](https://github.com/NixOS/nixpkgs/commit/6ad8b70417795202a36742ecfd79a83563a87c18) python312Packages.elastic-transport: ignore deprecation warnings in tests
* [`e0575141`](https://github.com/NixOS/nixpkgs/commit/e057514118b1adff6dc81e1605047c8dea631d78) python313Packages.aiohttp-fast-zlib: 0.1.1 -> 0.2.0
* [`eb700290`](https://github.com/NixOS/nixpkgs/commit/eb700290d744268910286b4d2ebcdcaf96c68fc4) python313Packages.aiogram: 3.13.1 -> 3.14.0
* [`c107d8c9`](https://github.com/NixOS/nixpkgs/commit/c107d8c99b53bce661df17bf6fd6d66ebf1551bc) python313Packages.aiohttp-zlib-ng: drop
* [`8d171082`](https://github.com/NixOS/nixpkgs/commit/8d171082ff2c4b44330b4b693bcd75ec481a8e2e) python313Packages.coloredlogs: replace pipes module usage
* [`562de2dd`](https://github.com/NixOS/nixpkgs/commit/562de2dd84cf174721ff2cfb5129a5a84eb8cbae) python313Packages.coloredlogs: use pep517 builder
* [`9018643a`](https://github.com/NixOS/nixpkgs/commit/9018643afd8b7c8330b44e4d4cbfbc37f93b8da2) python3Packages.uvloop: use system libuv ([nixos/nixpkgs⁠#351870](https://togithub.com/nixos/nixpkgs/issues/351870))
* [`964bd997`](https://github.com/NixOS/nixpkgs/commit/964bd997f24210c26ea78d9502bf0d2e87bfb66b) python313Packages.pyarrow: use Cython 3
* [`73820257`](https://github.com/NixOS/nixpkgs/commit/738202573aaad4c4fa81bcd082f29df85ad4de31) python313Packages.testfixtures: fix tests
* [`92679494`](https://github.com/NixOS/nixpkgs/commit/926794941f92c8377edd9e5509c8e6db727387d3) python313Packages.patsy: 0.5.6 -> 1.0.1
* [`73db954b`](https://github.com/NixOS/nixpkgs/commit/73db954b5aeb29efe1cb3c362953937248fe5a28) python313Packages.venusian: fix tests
* [`56224891`](https://github.com/NixOS/nixpkgs/commit/56224891d28b0122c6b82ad74af4df20e3594ae6) python313Packages.compreffor: 0.5.5 -> 0.5.6
* [`7e6ea1b6`](https://github.com/NixOS/nixpkgs/commit/7e6ea1b67f4f22a6c8a817a8659c179710e5604c) python313Packages.falcon: 3.1.3 -> 4.0.2
* [`d0d62af6`](https://github.com/NixOS/nixpkgs/commit/d0d62af65371b61a72fd89ec01ff8bf738541a51) python313Packages.hug: drop
* [`6297a64a`](https://github.com/NixOS/nixpkgs/commit/6297a64a36e1c613cc7f2c40979c8e7ce8a73d34) python313Packages.audioop-lts: init at 0.2.1
* [`98d9ddb0`](https://github.com/NixOS/nixpkgs/commit/98d9ddb0efb62473c474fd5e34585c13461743cf) python313Packages.aiohttp: 3.11.0 -> 3.11.2
* [`b9733f28`](https://github.com/NixOS/nixpkgs/commit/b9733f28c3dee118741926c4f2936750482779e3) python313Packages.nbconvert: disable DeprecationWarning in tests
* [`481b33e7`](https://github.com/NixOS/nixpkgs/commit/481b33e79977eec487ed7bfcb2b092c23579b535) python313Packages.pyramid: fix build
* [`543e9ed9`](https://github.com/NixOS/nixpkgs/commit/543e9ed9e77f6fe139e8a74d0afc8c508dbec7b8) python313Packages.tiktoken: 0.7.0 -> 0.8.0
* [`b24fe59f`](https://github.com/NixOS/nixpkgs/commit/b24fe59fca27e5a57589d9ed1e4851a1a0358adb) python313Packages.objgraph: 3.6.1 -> 3.6.2
* [`c29d54a7`](https://github.com/NixOS/nixpkgs/commit/c29d54a7dc90fa2f3dda54b5c78f161894ecd398) python312Packages.python-lsp-server: disable failing test
* [`cbf267bd`](https://github.com/NixOS/nixpkgs/commit/cbf267bde4444b2665a635edb6f51a5a8406e1fc) python313Packages.sqlalchemy: 2.0.34 -> 2.0.36
* [`93e03a8b`](https://github.com/NixOS/nixpkgs/commit/93e03a8b597847edf436fe54d958d2e172437577) python312Packages.inkex: relax numpy constraint
* [`4516306d`](https://github.com/NixOS/nixpkgs/commit/4516306d19b29932dc168a376a2138325c89592a) python313Packages.quantities: 0.15.0 -> 0.16.1
* [`8b702dda`](https://github.com/NixOS/nixpkgs/commit/8b702dda352fa7d8f90407fb796daa5697dc76b7) python312Packages.pydevd: disable failing test
* [`420d7fc3`](https://github.com/NixOS/nixpkgs/commit/420d7fc3527aaae341690c3fd2afa138ada9b74f) python313Packages.flexparser: 0.3.1 -> 0.4
* [`a74f4fc3`](https://github.com/NixOS/nixpkgs/commit/a74f4fc335b567d3adb09bb5b939810265a86a3d) python313Packages.pint: 0.24.3 -> 0.24.4
* [`f472920c`](https://github.com/NixOS/nixpkgs/commit/f472920c8631ec8270391d13532b68a891576cf8) python313Packages.geojson: fix build
* [`e09e9897`](https://github.com/NixOS/nixpkgs/commit/e09e98971f91756b82d9ed4b595207e194cdd1a9) python313Packages.quart: 0.19.8 -> 0.19.9
* [`a8b611ba`](https://github.com/NixOS/nixpkgs/commit/a8b611ba8d03f9fe59b9643d9532e31f6136a002) python313Packages.werkzeug: 3.0.6 -> 3.1.3
* [`dc07d2e9`](https://github.com/NixOS/nixpkgs/commit/dc07d2e954cd28a74a8e554bd02fa4a934b3924a) python313Packages.blinker: 1.8.2 -> 1.9.0
* [`e5a791db`](https://github.com/NixOS/nixpkgs/commit/e5a791db2708b633b89bb2e02482d9398410e136) python313Packages.flask: 3.0.3 -> 3.1.0
* [`29b189a8`](https://github.com/NixOS/nixpkgs/commit/29b189a8218b03d7279269dc57c07562f4574627) octoprint: fix flask override
* [`95a11315`](https://github.com/NixOS/nixpkgs/commit/95a113156ebbe6504c5d96ee5b24a9d76885131d) python312Packages.flask-sqlalchemy: update disabled tests
* [`1735ffa2`](https://github.com/NixOS/nixpkgs/commit/1735ffa215bac6db6adf180095537aaece23571c) sourcehut: fix flask ecosystem overrides
* [`205cfb66`](https://github.com/NixOS/nixpkgs/commit/205cfb661773948db8cc78d2554b116ccf694549) python313Packages.asn1: fix build
* [`7e5fcf02`](https://github.com/NixOS/nixpkgs/commit/7e5fcf0250fee5ba0cfc625079151b3f8649adf7) python313Packages.yeelight: fix build
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
