### PR TITLE
niv home-manager: update f1b1786e -> 10e99c43

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -41,10 +41,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f1b1786ea77739dcd181b920d430e30fb1608b8a",
-        "sha256": "129laifrjk48f5jz0j4ylya15s8wppiz3n8hx42iry6vqhf35mbz",
+        "rev": "10e99c43cdf4a0713b4e81d90691d22c6a58bdf2",
+        "sha256": "1vklmr0vzhplcjcqg19v66c1swg3xcgw96ry90dyd4hl2cb9j80b",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/f1b1786ea77739dcd181b920d430e30fb1608b8a.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/10e99c43cdf4a0713b4e81d90691d22c6a58bdf2.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@f1b1786e...10e99c43](https://github.com/nix-community/home-manager/compare/f1b1786ea77739dcd181b920d430e30fb1608b8a...10e99c43cdf4a0713b4e81d90691d22c6a58bdf2)

* [`aa8c3d7f`](https://github.com/nix-community/home-manager/commit/aa8c3d7f7d6b61d3273e943d4fb8bddf7a647431) tests: remove stray line
* [`64272584`](https://github.com/nix-community/home-manager/commit/64272584091a47e3762d1bfb40638fbe58dd756d) tests: change to wait for network.target
* [`afbf007b`](https://github.com/nix-community/home-manager/commit/afbf007bb5e05b7837be5485e221ea50c4fd4f1b) tests: add integration test for nh
* [`35b98d20`](https://github.com/nix-community/home-manager/commit/35b98d20ca8f4ca1f6a2c30b8a2c8bb305a36d84) treewide: change pacien to euxane
* [`19398e50`](https://github.com/nix-community/home-manager/commit/19398e505a80db1a1c41207ee89e1b1770c5dcf6) lesspipe: allow configuring package
* [`b7a7cd5d`](https://github.com/nix-community/home-manager/commit/b7a7cd5dd1a74a9fe86ed4e016f91c78483b527a) pqiv: fix condition for writing pqivrc file
* [`10e99c43`](https://github.com/nix-community/home-manager/commit/10e99c43cdf4a0713b4e81d90691d22c6a58bdf2) copyq: add option to disable XWayland
