### PR TITLE
niv emacs-overlay: update d902534f -> 964a44f6

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "d902534f27fea8439422e55c435d4b4bbf8a2472",
-        "sha256": "10pmagj761vpmg3mvjwg1yfidxhcmpyjwgyswbbwg5g1sb21avcs",
+        "rev": "964a44f6585f8cae26c228409676d92822f78de0",
+        "sha256": "0lmwqhkailgs4n4gvc7578bnqm0gdkzzw3jqd9g75dxjvbk3yy3a",
         "type": "tarball",
-        "url": "https://github.com/nix-community/emacs-overlay/archive/d902534f27fea8439422e55c435d4b4bbf8a2472.tar.gz",
+        "url": "https://github.com/nix-community/emacs-overlay/archive/964a44f6585f8cae26c228409676d92822f78de0.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "fast-syntax-highlighting": {


### PR DESCRIPTION
## Changelog for emacs-overlay:
Branch: master
Commits: [nix-community/emacs-overlay@d902534f...964a44f6](https://github.com/nix-community/emacs-overlay/compare/d902534f27fea8439422e55c435d4b4bbf8a2472...964a44f6585f8cae26c228409676d92822f78de0)

* [`dcff3ac1`](https://github.com/nix-community/emacs-overlay/commit/dcff3ac1d9e6ad316c917d2425f1b3067f64f8a5) Updated flake inputs
* [`9354adf6`](https://github.com/nix-community/emacs-overlay/commit/9354adf670b5f5a787f32e7d1b1476e85015a44b) Updated nongnu
* [`dfe29ae7`](https://github.com/nix-community/emacs-overlay/commit/dfe29ae7ac4a8bb5f1b993e32cfea336f78a0d82) Updated elpa
* [`7a58ace1`](https://github.com/nix-community/emacs-overlay/commit/7a58ace151bf1939308680f37db100b00769c318) flake: bump nixpkgs-stable from 24.05 to 24.11
* [`1603799a`](https://github.com/nix-community/emacs-overlay/commit/1603799aa3105e4b737358710d88ea8078c0ebb7) Updated melpa
* [`483548ff`](https://github.com/nix-community/emacs-overlay/commit/483548ffef958bed56302a2d7938ec31dac8ddb1) Updated flake inputs
* [`4ebaf4d0`](https://github.com/nix-community/emacs-overlay/commit/4ebaf4d0b6b8ab9bacd57f5db199da2d76eea8da) Updated melpa
* [`951ef3b9`](https://github.com/nix-community/emacs-overlay/commit/951ef3b904d452654ee8049440f628bca5dc1ff2) Updated flake inputs
* [`d620cb05`](https://github.com/nix-community/emacs-overlay/commit/d620cb053183a0150d85b423d8ecbf37b7636416) Updated nongnu
* [`e4632fae`](https://github.com/nix-community/emacs-overlay/commit/e4632fae7ef03a3cca85363a11a171e20f7a643d) Updated elpa
* [`75b7551f`](https://github.com/nix-community/emacs-overlay/commit/75b7551fea3c131628fdba2bc03d0a398f07c75a) Updated melpa
* [`dda85b36`](https://github.com/nix-community/emacs-overlay/commit/dda85b369ea696041ce1ac4fe923fe2be6b666cb) Updated nongnu
* [`a0720262`](https://github.com/nix-community/emacs-overlay/commit/a0720262d8eae367c90d08e510eddfb7049455fa) Updated elpa
* [`fe46c999`](https://github.com/nix-community/emacs-overlay/commit/fe46c9992f9a8e7302afe92af6b5c8b0838e00ab) Updated melpa
* [`9a75ee95`](https://github.com/nix-community/emacs-overlay/commit/9a75ee9552e74f9652920cf2bbf8f1c9270876bf) Updated emacs
* [`51d6aafb`](https://github.com/nix-community/emacs-overlay/commit/51d6aafb5e3bbf10a29bd8ff417b617e35b14d0e) Updated flake inputs
* [`6decb306`](https://github.com/nix-community/emacs-overlay/commit/6decb306abb5d5051d833243253d0927578c4209) Updated nongnu
* [`54d10269`](https://github.com/nix-community/emacs-overlay/commit/54d102696b787b0baf144fd71a377172b561af62) Updated elpa
* [`fe0cac73`](https://github.com/nix-community/emacs-overlay/commit/fe0cac736304960d31d88e364f59582246f5cc17) Updated nongnu
* [`2118e282`](https://github.com/nix-community/emacs-overlay/commit/2118e2829ef4b6dd969684cf9a4e0e771c943761) Updated elpa
* [`2e9c7537`](https://github.com/nix-community/emacs-overlay/commit/2e9c753771e4b5b78f5e11e942a53c776e775e91) Updated flake inputs
* [`e6e14304`](https://github.com/nix-community/emacs-overlay/commit/e6e143046bbb81dc05b07de319cc23337d691929) Updated nongnu
* [`92abfe9a`](https://github.com/nix-community/emacs-overlay/commit/92abfe9a334c215d4e14cabe1593a0189610ce90) Updated elpa
* [`2719cb2f`](https://github.com/nix-community/emacs-overlay/commit/2719cb2f8b84ea33a5acf5c81e2fd2dd377b0753) Updated flake inputs
* [`6e20ff5e`](https://github.com/nix-community/emacs-overlay/commit/6e20ff5e256610574701bc290b8fbae0762a1bdd) Updated nongnu
* [`82784e1b`](https://github.com/nix-community/emacs-overlay/commit/82784e1b39d7bdfc247823e01d93efda67cb2a94) Updated elpa
* [`3318e42d`](https://github.com/nix-community/emacs-overlay/commit/3318e42dd57a365b8831b4bab2b9c1d131898b1d) Updated flake inputs
* [`29369e97`](https://github.com/nix-community/emacs-overlay/commit/29369e97a3396831f60da64a09c0009dd667a8a7) Updated nongnu
* [`27b7329a`](https://github.com/nix-community/emacs-overlay/commit/27b7329a78fa554cef7c0fd7b972d4dd82cbb0a1) Updated elpa
* [`d3342b2b`](https://github.com/nix-community/emacs-overlay/commit/d3342b2b1be90527b9cd54494e1c063613c6454c) nativeComp: darwin: Allow emacs to find the path for libSystem
* [`f4ffb367`](https://github.com/nix-community/emacs-overlay/commit/f4ffb3671dac9e298f329f97664c90a76259b569) Updated nongnu
* [`2e6e7801`](https://github.com/nix-community/emacs-overlay/commit/2e6e7801a515f8dbece2d888244a6a2604e36e86) Updated elpa
* [`e2a6b004`](https://github.com/nix-community/emacs-overlay/commit/e2a6b0046e00fede39cf8c84d7636f20f3f07256) Updated nongnu
* [`2f6e00e6`](https://github.com/nix-community/emacs-overlay/commit/2f6e00e690fd83b9c24eef9a026a5d6d8c34c5a0) Updated elpa
* [`7b2066e3`](https://github.com/nix-community/emacs-overlay/commit/7b2066e3d3714fda877edcc6713ae81c5cc320a0) Updated nongnu
* [`315894ec`](https://github.com/nix-community/emacs-overlay/commit/315894eca1fcb961f21ace3f32e022768f2e6405) Updated elpa
* [`e3ac055c`](https://github.com/nix-community/emacs-overlay/commit/e3ac055c27f9268a294c911578c7cb04c087c7ab) Updated flake inputs
* [`fe3384fe`](https://github.com/nix-community/emacs-overlay/commit/fe3384fe7e2047fa055005a99c43dca830bc7508) Updated nongnu
* [`b5d8ba00`](https://github.com/nix-community/emacs-overlay/commit/b5d8ba006311a92e22d93e59086f888b24a17508) Updated elpa
* [`2250b03d`](https://github.com/nix-community/emacs-overlay/commit/2250b03dfd3485d1f6bb4de11a042baa8bc3ec9c) Updated flake inputs
* [`7508ed01`](https://github.com/nix-community/emacs-overlay/commit/7508ed019d2cd89d49e4ff4547e4e640bc81c344) Updated nongnu
* [`a10b59f7`](https://github.com/nix-community/emacs-overlay/commit/a10b59f755abef2a8b2c9f077f109764bb4b208b) Updated elpa
* [`81fe8f6c`](https://github.com/nix-community/emacs-overlay/commit/81fe8f6c2ac036290e7c37f6a96a9e4a3b730ce9) Updated nongnu
* [`8668b468`](https://github.com/nix-community/emacs-overlay/commit/8668b46808a0117cda69acf9d61d17ac2ab374b5) Updated elpa
* [`f75bb35a`](https://github.com/nix-community/emacs-overlay/commit/f75bb35a27b207eed7c1430d21995fabf68ea190) Updated melpa
* [`f583e369`](https://github.com/nix-community/emacs-overlay/commit/f583e3691e30db811c8a5b9d45cdf433dba1bccd) Updated emacs
* [`7d21d337`](https://github.com/nix-community/emacs-overlay/commit/7d21d337e27c51435bb1d55f7b14aa6358303f66) Updated nongnu
* [`d3f55c97`](https://github.com/nix-community/emacs-overlay/commit/d3f55c978e1faef8940ab52b580bb8a2c3f68cef) Updated elpa
* [`c5cad68c`](https://github.com/nix-community/emacs-overlay/commit/c5cad68c66a0e4eb2f98c91f5aa356acd8ef3200) Updated flake inputs
* [`b2882beb`](https://github.com/nix-community/emacs-overlay/commit/b2882bebd48a348f17873aaddf9b0a8ecf573bbf) Updated nongnu
* [`af0d3635`](https://github.com/nix-community/emacs-overlay/commit/af0d36350388a62326d8dd78952bd99767a32fb3) Updated elpa
* [`fadb2265`](https://github.com/nix-community/emacs-overlay/commit/fadb2265e02959662db0cb34872846f1e6f998ae) Updated nongnu
* [`004d589f`](https://github.com/nix-community/emacs-overlay/commit/004d589f0433676c2e044729435486ac8ba5fe06) Updated elpa
* [`37481613`](https://github.com/nix-community/emacs-overlay/commit/37481613849f600a38307e29ea25184ec889ea4f) Updated melpa
* [`9df047f0`](https://github.com/nix-community/emacs-overlay/commit/9df047f0cd70ac7a2c0fa4750394f07677ca3860) Updated emacs
* [`59141957`](https://github.com/nix-community/emacs-overlay/commit/591419570c52573c2285ccb083cb916f0ad7d95f) Updated melpa
* [`5801bf52`](https://github.com/nix-community/emacs-overlay/commit/5801bf5202cd0fea8637d3891040669f46813a95) Updated emacs
* [`c4ff56a2`](https://github.com/nix-community/emacs-overlay/commit/c4ff56a2fe6f0e36fe84dcdf137c4a67fcaaf9ca) Updated flake inputs
* [`e76d3a74`](https://github.com/nix-community/emacs-overlay/commit/e76d3a7447ebc92942769a9ec5d2cdfa34190af4) Updated nongnu
* [`68fddf69`](https://github.com/nix-community/emacs-overlay/commit/68fddf69137e3d5354765401d86e071ee1b97849) Updated elpa
* [`ca3a1267`](https://github.com/nix-community/emacs-overlay/commit/ca3a12671632965263c18e19a84ff2cb094ebffb) Updated melpa
* [`4f8045e9`](https://github.com/nix-community/emacs-overlay/commit/4f8045e953c68f261e2b870507f2a9e6c35a5629) Updated emacs
* [`10234b60`](https://github.com/nix-community/emacs-overlay/commit/10234b60c7ea22a618f936b0545675982163f1dd) Updated nongnu
* [`c4de2fd2`](https://github.com/nix-community/emacs-overlay/commit/c4de2fd2fe16d3cfff15d2db0e2b684972a82012) Updated elpa
* [`2b6ca8fe`](https://github.com/nix-community/emacs-overlay/commit/2b6ca8fe3eba9719f15964adc43df27e17f6cfbb) Updated flake inputs
* [`51ea85eb`](https://github.com/nix-community/emacs-overlay/commit/51ea85eb1864d5492248794cdfaf675c2c91382f) Updated nongnu
* [`af7f5d0e`](https://github.com/nix-community/emacs-overlay/commit/af7f5d0e6d69bc40777e56c86f568ae997aee9e2) Updated elpa
* [`5177ee9d`](https://github.com/nix-community/emacs-overlay/commit/5177ee9d0c33b0f91b97ece0cdfd855c06f8734c) Updated nongnu
* [`f8ae6558`](https://github.com/nix-community/emacs-overlay/commit/f8ae6558b7d7fb3493937cab280b6869a9195621) Updated elpa
* [`0dddcfd8`](https://github.com/nix-community/emacs-overlay/commit/0dddcfd81e140abb46d5b11cffe9007fb2ed120a) Updated flake inputs
* [`752aba94`](https://github.com/nix-community/emacs-overlay/commit/752aba94340a2bd08547fdbd35828b4deb65a916) Updated nongnu
* [`f8f3d406`](https://github.com/nix-community/emacs-overlay/commit/f8f3d40658939bffde17781dbfbc97757780d26f) Updated elpa
* [`efe61b09`](https://github.com/nix-community/emacs-overlay/commit/efe61b09c9e49fefcb2694f651711b7d29ef6734) Updated nongnu
* [`07a18388`](https://github.com/nix-community/emacs-overlay/commit/07a183880b1f5bc1c18bbf3583fab17b94b2a110) Updated elpa
* [`e6acfb11`](https://github.com/nix-community/emacs-overlay/commit/e6acfb11cd0cf9737c0f7947e3866712a60defc1) Updated nongnu
* [`3ec49386`](https://github.com/nix-community/emacs-overlay/commit/3ec49386133fb02408d458d7946ca41c7016fba3) Updated elpa
* [`ac344c63`](https://github.com/nix-community/emacs-overlay/commit/ac344c63516bb3d8bf2b54f523b34fe09abc1aea) Updated nongnu
* [`be04ea9c`](https://github.com/nix-community/emacs-overlay/commit/be04ea9ce6b2bfdddcfb1871dc4a983abc73e690) Updated flake inputs
* [`29923fea`](https://github.com/nix-community/emacs-overlay/commit/29923fea47e5a6067ba52d02607c3806fb1c28c8) Updated nongnu
* [`f51080de`](https://github.com/nix-community/emacs-overlay/commit/f51080decb05dfc8cda1138ad9bfe87c6d0310ff) Updated elpa
* [`9404f94f`](https://github.com/nix-community/emacs-overlay/commit/9404f94f50ab55f0ce075ad06719cfff90e93c16) Updated nongnu
* [`91734080`](https://github.com/nix-community/emacs-overlay/commit/91734080b60643d2c9cca288d0dcec77a1e0fce7) Updated elpa
* [`91394111`](https://github.com/nix-community/emacs-overlay/commit/91394111f9fad62bd7c909dcdb149d4cf4594487) Updated melpa
* [`4310724e`](https://github.com/nix-community/emacs-overlay/commit/4310724e208e868521b0f34795d42668bd8f9cdb) Updated emacs
* [`7b68c5b0`](https://github.com/nix-community/emacs-overlay/commit/7b68c5b041f0dc12d45470e66418a706464bf79d) README: clarify `emacsExtraPackages` usage
* [`c335c009`](https://github.com/nix-community/emacs-overlay/commit/c335c0094b99e8fd6ab1dcd29efe3bcc88b7da6b) Updated melpa
* [`6c65dad3`](https://github.com/nix-community/emacs-overlay/commit/6c65dad3a545b08c9d5cc4632f6ce6442aa3d33f) Updated emacs
* [`a960c044`](https://github.com/nix-community/emacs-overlay/commit/a960c04475a6eebdec1f6057e27224aa4c0c7842) Updated nongnu
* [`e465cb34`](https://github.com/nix-community/emacs-overlay/commit/e465cb34d54fc7c637af703f6adb50ec2ade3245) Updated elpa
* [`399d8b3e`](https://github.com/nix-community/emacs-overlay/commit/399d8b3e2121615993b09636d421733b30dcc0ba) Updated melpa
* [`e621b262`](https://github.com/nix-community/emacs-overlay/commit/e621b2624bed4ada7b997845de10537152ba522b) Updated emacs
* [`917e9c73`](https://github.com/nix-community/emacs-overlay/commit/917e9c735316551eaac9bc47d1cf0de18540da87) Updated flake inputs
* [`b44c20e8`](https://github.com/nix-community/emacs-overlay/commit/b44c20e8fe4d20222d26d4b54e17b955052b363a) Updated nongnu
* [`5b94691f`](https://github.com/nix-community/emacs-overlay/commit/5b94691f623a763ffd48f9784e00293656586d0f) Updated elpa
* [`3409e86b`](https://github.com/nix-community/emacs-overlay/commit/3409e86b5731cfa81321b30de003aab27e20c6c2) Updated melpa
* [`76e6bf04`](https://github.com/nix-community/emacs-overlay/commit/76e6bf04179ade0b79079f395d642a41348eb78e) Updated emacs
* [`d6353ce8`](https://github.com/nix-community/emacs-overlay/commit/d6353ce807b7845ffec114d234c90ece44c39122) Updated melpa
* [`5822823c`](https://github.com/nix-community/emacs-overlay/commit/5822823cf2fbead676f26629d8f3ad0f907f574d) Updated flake inputs
* [`fd8a73c6`](https://github.com/nix-community/emacs-overlay/commit/fd8a73c6082986dcbe32f91a9e8bb16fb4639a9c) Updated nongnu
* [`2ce90473`](https://github.com/nix-community/emacs-overlay/commit/2ce904731649301654f34f2f638daf6a4473857a) Updated elpa
* [`f44e9866`](https://github.com/nix-community/emacs-overlay/commit/f44e986695256fa0fde8ef7198c5633e8adfba5f) Updated melpa
* [`25858d10`](https://github.com/nix-community/emacs-overlay/commit/25858d10419fdc307aa562695fd5bf3c8c2ec80d) Updated emacs
* [`1836c396`](https://github.com/nix-community/emacs-overlay/commit/1836c396d3b2b051e1cef8fad3d23bdc7cd939f0) Updated nongnu
* [`41d1f2ae`](https://github.com/nix-community/emacs-overlay/commit/41d1f2ae395516cd6024d573716a40168fd2377e) Updated elpa
* [`c4a9ede6`](https://github.com/nix-community/emacs-overlay/commit/c4a9ede6cd03cbb2e3530f9b0aea5d2ec001c13d) Updated melpa
* [`fce2b622`](https://github.com/nix-community/emacs-overlay/commit/fce2b6224adae5f9b6d43d74ecb996a3133a63f4) Updated emacs
* [`cdd908f4`](https://github.com/nix-community/emacs-overlay/commit/cdd908f4c350b85a43a277d6a0916fd26a458d4e) Updated melpa
* [`3eb85a97`](https://github.com/nix-community/emacs-overlay/commit/3eb85a97f21d14e125364b022acf7f0d197859a9) Updated emacs
* [`8823d476`](https://github.com/nix-community/emacs-overlay/commit/8823d476190cdaebc8d6c8bcf664b0179935e20d) Revert "Disable webkit2gtk integration"
* [`fe83961a`](https://github.com/nix-community/emacs-overlay/commit/fe83961a65b4ed4cd76ddd22653a8fe5a0039041) Updated nongnu
* [`2ecfec26`](https://github.com/nix-community/emacs-overlay/commit/2ecfec265881bf624527e5e25e7bd6fdd5be86ca) Updated elpa
* [`519b67fa`](https://github.com/nix-community/emacs-overlay/commit/519b67faa4da472a390c579a7310d296994b62f1) Reapply "Disable webkit2gtk integration"
* [`28e282ca`](https://github.com/nix-community/emacs-overlay/commit/28e282ca970d1ee9f946a032af5feb1ad88c9267) Updated nongnu
* [`36387a83`](https://github.com/nix-community/emacs-overlay/commit/36387a83305573dcb2c9e63272247f0124742e8a) Updated elpa
* [`291e2700`](https://github.com/nix-community/emacs-overlay/commit/291e270067fe4bd4f375ac253c90ecc33df7fab1) Updated melpa
* [`c098c637`](https://github.com/nix-community/emacs-overlay/commit/c098c63704be5ebcaba15d0f1273395c44482417) Updated emacs
* [`840a2fa3`](https://github.com/nix-community/emacs-overlay/commit/840a2fa3e9d546ecbcc080ee13bf6aa0e8697b10) Updated flake inputs
* [`3b18975e`](https://github.com/nix-community/emacs-overlay/commit/3b18975e9d8bcef2e44bddd063f6edc829f7db86) Updated melpa
* [`08c065bf`](https://github.com/nix-community/emacs-overlay/commit/08c065bf80654e214e8ded2d27b0dea39c66f452) Updated emacs
* [`1c9b6dc2`](https://github.com/nix-community/emacs-overlay/commit/1c9b6dc2d30a073658e7dafc69a3c26ce3d2de02) Updated nongnu
* [`8714a74f`](https://github.com/nix-community/emacs-overlay/commit/8714a74fbec707661f7fadf573e68e79722a3476) Updated elpa
* [`9254eba9`](https://github.com/nix-community/emacs-overlay/commit/9254eba974b1e099d97fe91eed0075c785da588e) Updated melpa
* [`7932d8e1`](https://github.com/nix-community/emacs-overlay/commit/7932d8e1fa38eb94ab264469e915c5f04393f7a1) Updated emacs
* [`1f75789b`](https://github.com/nix-community/emacs-overlay/commit/1f75789b2f199e398e1c6e7c64a8e50c48a27677) Updated nongnu
* [`6b727713`](https://github.com/nix-community/emacs-overlay/commit/6b72771305f2fdd691844ca7c29d93d6511afcde) Updated elpa
* [`150225c0`](https://github.com/nix-community/emacs-overlay/commit/150225c0e793dc783835bff826b8375344241154) Updated melpa
* [`c52319c9`](https://github.com/nix-community/emacs-overlay/commit/c52319c9046fdc812035dae70ce0a238eaab71dd) Updated emacs
* [`d01d3ee3`](https://github.com/nix-community/emacs-overlay/commit/d01d3ee3253454934b08ca4cc801baa81ade8e8a) Updated melpa
* [`d7697bf2`](https://github.com/nix-community/emacs-overlay/commit/d7697bf2004fcb6508d3bf146e94fff59ecb2db9) Updated emacs
* [`324c3785`](https://github.com/nix-community/emacs-overlay/commit/324c3785c467ceeafc8bf7b14ad4149534120ba0) Updated flake inputs
* [`9534c782`](https://github.com/nix-community/emacs-overlay/commit/9534c782c0ca964660f8bdb05a6363e687a804e8) Updated nongnu
* [`695c3f28`](https://github.com/nix-community/emacs-overlay/commit/695c3f283df1fac966f8c7a2e53476d75d72be14) Updated elpa
* [`52c1aa91`](https://github.com/nix-community/emacs-overlay/commit/52c1aa9113ab656c8cf0dc59259ae3c31d2f701c) Updated melpa
* [`b501185a`](https://github.com/nix-community/emacs-overlay/commit/b501185a01bca853da21a1d35c058bb48a9a84eb) Updated emacs
* [`003885cb`](https://github.com/nix-community/emacs-overlay/commit/003885cb5fa02bd2f4bc66a6406a7dbf6f36e361) Updated nongnu
* [`4915a556`](https://github.com/nix-community/emacs-overlay/commit/4915a55645571f8edfaaf598e05e94f3d287de0c) Updated elpa
* [`b2ee9e08`](https://github.com/nix-community/emacs-overlay/commit/b2ee9e086fc9c22a19c0e2c1843d626d8e1d4e27) Updated melpa
* [`7fe6fa39`](https://github.com/nix-community/emacs-overlay/commit/7fe6fa395b9faa227071788bf01297a95d502fb6) Updated emacs
* [`b132f0d1`](https://github.com/nix-community/emacs-overlay/commit/b132f0d1c8d2f8fdbc842cd5057fab7b39462c74) Updated melpa
* [`df40078d`](https://github.com/nix-community/emacs-overlay/commit/df40078d8d4f3f0439e52a3f3e44af0005e6072e) Updated emacs
* [`39a1541d`](https://github.com/nix-community/emacs-overlay/commit/39a1541dcde50dec42e11c127a35fd3251f74bb6) Updated nongnu
* [`580f3763`](https://github.com/nix-community/emacs-overlay/commit/580f376388cd7050fe08db49066501d494a0cbc9) Updated elpa
* [`1ac689f2`](https://github.com/nix-community/emacs-overlay/commit/1ac689f2dde2b5e6f1b82a82bf82e48377269830) Updated melpa
* [`05ed54de`](https://github.com/nix-community/emacs-overlay/commit/05ed54de2ec7875b97a2a33d810997e00e6ea699) Updated emacs
* [`bb6dce92`](https://github.com/nix-community/emacs-overlay/commit/bb6dce92b187d44e11e74a8e8f70e925024a8b42) Updated nongnu
* [`c264b783`](https://github.com/nix-community/emacs-overlay/commit/c264b783a2d1ffbf9bea7ae4c0ed2639ff811224) Updated elpa
* [`701b5841`](https://github.com/nix-community/emacs-overlay/commit/701b5841ea2667e19b2a49640db174969c3ea573) Updated melpa
* [`03bdf32e`](https://github.com/nix-community/emacs-overlay/commit/03bdf32edf7ef2a8f5fa4c6cd2fac32fbf43bb4c) Updated emacs
* [`0164b013`](https://github.com/nix-community/emacs-overlay/commit/0164b013076cc9549e4a694cf3fdecf411427e2d) Updated flake inputs
* [`d04fdd1b`](https://github.com/nix-community/emacs-overlay/commit/d04fdd1bd2cb85a4005d7203fbc68325e39ca799) Updated melpa
* [`fc45166e`](https://github.com/nix-community/emacs-overlay/commit/fc45166e48995bc14d800c4ddcdf97d52799cce1) Updated emacs
* [`86857229`](https://github.com/nix-community/emacs-overlay/commit/868572293f0a3276d074b62ddb09b2b84abce0e6) Updated nongnu
* [`f529e106`](https://github.com/nix-community/emacs-overlay/commit/f529e106317e87227f005fb39e470be358754081) Updated elpa
* [`ba5ce567`](https://github.com/nix-community/emacs-overlay/commit/ba5ce5679a3e5167ed119fece4437d2a5314c9d8) Updated melpa
* [`c712f393`](https://github.com/nix-community/emacs-overlay/commit/c712f393aa716377f358ca34ac66f9b8efbcc7ff) Updated emacs
* [`e42e8b8f`](https://github.com/nix-community/emacs-overlay/commit/e42e8b8f2338e989a15e25ed6b9215460b9e3233) Updated nongnu
* [`63781cfc`](https://github.com/nix-community/emacs-overlay/commit/63781cfcc11e9998a407651ce73c63de385b5a7c) Updated elpa
* [`c55bcda9`](https://github.com/nix-community/emacs-overlay/commit/c55bcda95d90ef94d781ce9c3d711aa998083df3) Updated melpa
* [`87d2f5f8`](https://github.com/nix-community/emacs-overlay/commit/87d2f5f8d77f119be56ed7a52243378f25c1f946) Updated emacs
* [`d714e233`](https://github.com/nix-community/emacs-overlay/commit/d714e233bc77b18e3b5af4b5bcff2407303338ef) Updated melpa
* [`8521536b`](https://github.com/nix-community/emacs-overlay/commit/8521536b77195b89b7c6ed51fc8643ae65fff26f) Updated emacs
* [`431b888f`](https://github.com/nix-community/emacs-overlay/commit/431b888f1cf0d23a52137884761ded259f5660bb) Updated flake inputs
* [`47cc51eb`](https://github.com/nix-community/emacs-overlay/commit/47cc51eb2affa7468c3941ce9057c3fac1fa040c) Updated nongnu
* [`786143cc`](https://github.com/nix-community/emacs-overlay/commit/786143cc220afd5336c5db8fdf264b38f50fb2de) Updated elpa
* [`bc958ac4`](https://github.com/nix-community/emacs-overlay/commit/bc958ac44c7f595c25bf9e32e9f0debc920a6663) Updated melpa
* [`1d3ff271`](https://github.com/nix-community/emacs-overlay/commit/1d3ff271d875b7bfacafbc1f4a5dff7ce54ef95d) Updated emacs
* [`3c66cd81`](https://github.com/nix-community/emacs-overlay/commit/3c66cd813a126cea5fcb9782563ab50797f65b1f) Updated elpa
* [`2d9f8378`](https://github.com/nix-community/emacs-overlay/commit/2d9f83781449facf15b488cff5e6297bdd227bd8) Updated melpa
* [`3c24690a`](https://github.com/nix-community/emacs-overlay/commit/3c24690ab6fe48f82675b13cd6addb9a8dadfb92) Updated emacs
* [`6e615f22`](https://github.com/nix-community/emacs-overlay/commit/6e615f2298f3738547ccfc9bd6cacee3b9a323e6) Updated flake inputs
* [`89be1569`](https://github.com/nix-community/emacs-overlay/commit/89be1569ffe3dbe9022a50e973b6c9e7285a4654) Updated melpa
* [`f1941db6`](https://github.com/nix-community/emacs-overlay/commit/f1941db6f24f6a1ca138b373dd7c25ffd48530c3) Updated emacs
* [`4542eb16`](https://github.com/nix-community/emacs-overlay/commit/4542eb16105ebbd8b771af4304796ef3ed8c2c98) Updated nongnu
* [`2129f15e`](https://github.com/nix-community/emacs-overlay/commit/2129f15e6c9fd12ce0ccd4a2d6fbe173cc59370d) Updated elpa
* [`6166691a`](https://github.com/nix-community/emacs-overlay/commit/6166691a52ee0d63f548483c24331d8210186111) Updated melpa
* [`141bcbc8`](https://github.com/nix-community/emacs-overlay/commit/141bcbc88cc068b7715db45b0d10aab43c236ca0) Updated emacs
* [`b2fa7512`](https://github.com/nix-community/emacs-overlay/commit/b2fa75129123c0bf657a9a05109fc77204dfa085) Updated nongnu
* [`adbb7320`](https://github.com/nix-community/emacs-overlay/commit/adbb7320b9996af5757c35e7c405a6b27e372159) Updated elpa
* [`1f724402`](https://github.com/nix-community/emacs-overlay/commit/1f7244023359387ef58be70452fed030b4364efc) Updated melpa
* [`fd87d27a`](https://github.com/nix-community/emacs-overlay/commit/fd87d27a2bd726ef4ea161ee43fc9b1738a6fdb3) Updated emacs
* [`49bd3fd7`](https://github.com/nix-community/emacs-overlay/commit/49bd3fd75db9c063076c4b572778be5c96899570) Updated melpa
* [`f4d610ef`](https://github.com/nix-community/emacs-overlay/commit/f4d610ef67e8a50051075d7030803b94351f8b76) Updated flake inputs
* [`8deaf5b4`](https://github.com/nix-community/emacs-overlay/commit/8deaf5b42fcbc1ef3d9dc54c4f2bcbee5e4c41ca) Updated nongnu
* [`27c4e58c`](https://github.com/nix-community/emacs-overlay/commit/27c4e58c0397dead26fdadcec7cb654c3bda4103) Updated elpa
* [`b16d3eb7`](https://github.com/nix-community/emacs-overlay/commit/b16d3eb7e7df1b8d859d2983746fde844c17db7b) Updated melpa
* [`f4952c0e`](https://github.com/nix-community/emacs-overlay/commit/f4952c0ec0e9ce358188cc81a17008ee99be3c99) Updated emacs
* [`aa0db286`](https://github.com/nix-community/emacs-overlay/commit/aa0db28624312e885f91a78146c6e368e007f20b) Updated nongnu
* [`e7662cf1`](https://github.com/nix-community/emacs-overlay/commit/e7662cf1911f9a09488a52aed79eac70deb25f5d) Updated elpa
* [`2c3d5a13`](https://github.com/nix-community/emacs-overlay/commit/2c3d5a1304e2775c4496f29f942c326140427bfb) Updated melpa
* [`4ad82df6`](https://github.com/nix-community/emacs-overlay/commit/4ad82df68a6a5cf1aaee49fae0a1047e0422face) Updated emacs
* [`18921dbe`](https://github.com/nix-community/emacs-overlay/commit/18921dbeab3d835a42c5bd081a0629f86897b2e4) Updated melpa
* [`0657c6e5`](https://github.com/nix-community/emacs-overlay/commit/0657c6e51b025e4b569c413d28ad4a5f4e64e93c) Updated emacs
* [`ccb19b4e`](https://github.com/nix-community/emacs-overlay/commit/ccb19b4ecc1a59ac282bab397c605ba13cd2c76c) Updated elpa
* [`80b84fa7`](https://github.com/nix-community/emacs-overlay/commit/80b84fa77a5c34245c30242f4c5f6320d877a9f6) Updated melpa
* [`d8157b24`](https://github.com/nix-community/emacs-overlay/commit/d8157b244fc20164c39d2844294105ecb55bdc4c) Updated nongnu
* [`970c8bf0`](https://github.com/nix-community/emacs-overlay/commit/970c8bf0e3a129b8b8000d71b7c6154a7a3c808c) Updated elpa
* [`1b886826`](https://github.com/nix-community/emacs-overlay/commit/1b886826db1b9f3ed1b4c056ad5fe614350dfd2d) Updated melpa
* [`52eb809a`](https://github.com/nix-community/emacs-overlay/commit/52eb809a3a5ab12954afa3b85b9e52de570237f0) Updated emacs
* [`6aa87f47`](https://github.com/nix-community/emacs-overlay/commit/6aa87f47a18a1e38f30e8d2c98c269df6e155113) Updated melpa
* [`0a583fe7`](https://github.com/nix-community/emacs-overlay/commit/0a583fe7317026fbc456209e28718b3a85abbca9) Updated emacs
* [`c8e9f6ae`](https://github.com/nix-community/emacs-overlay/commit/c8e9f6ae15da11936055e7aadde9c62a533d6329) Updated flake inputs
* [`94f45001`](https://github.com/nix-community/emacs-overlay/commit/94f450015b545452363a3dce9bfd5edb6b99bd2c) Updated nongnu
* [`2d3f780c`](https://github.com/nix-community/emacs-overlay/commit/2d3f780ce2b3be68bc58af55013c004e672a0841) Updated elpa
* [`91de3363`](https://github.com/nix-community/emacs-overlay/commit/91de336375fff7c672d4d0b816a03c8fdfbc92de) Updated melpa
* [`a7bf96d8`](https://github.com/nix-community/emacs-overlay/commit/a7bf96d88990c00f169ec0f766a4a5c04fbd11a6) Updated nongnu
* [`407cd9bf`](https://github.com/nix-community/emacs-overlay/commit/407cd9bfb013941f0e2578a373e3895d2bf023ee) Updated elpa
* [`33dc2582`](https://github.com/nix-community/emacs-overlay/commit/33dc25822d9ca3e5339ed437208c36e9771c2ac0) Updated melpa
* [`85d4073e`](https://github.com/nix-community/emacs-overlay/commit/85d4073e0b45f7a6444dabe02fd30cd0676954be) Updated emacs
* [`4170b763`](https://github.com/nix-community/emacs-overlay/commit/4170b763345d7c5658b1be2d80ddcbce87d4d88f) Updated melpa
* [`fbd938f1`](https://github.com/nix-community/emacs-overlay/commit/fbd938f1f77da260f283b736e1b46b43efcb9961) Updated emacs
* [`66c82eb7`](https://github.com/nix-community/emacs-overlay/commit/66c82eb7ba0569aafad4f6e349f376a4271f6297) Updated nongnu
* [`48f87c7b`](https://github.com/nix-community/emacs-overlay/commit/48f87c7b174fd54c0446fc4c2f393475ecbe7525) Updated elpa
* [`07d721df`](https://github.com/nix-community/emacs-overlay/commit/07d721dfecdded7ed8f208554bdbd65f16fe46cb) Updated melpa
* [`644713bf`](https://github.com/nix-community/emacs-overlay/commit/644713bfd86acb4198fc416f9452eb6d25775a03) Updated emacs
* [`e1688860`](https://github.com/nix-community/emacs-overlay/commit/e16888608049ca2c4508ec8567a9be40c09f5d8f) Updated flake inputs
* [`3b800785`](https://github.com/nix-community/emacs-overlay/commit/3b800785083b9cf6002560e85135ec195b962c06) Updated nongnu
* [`5f215d06`](https://github.com/nix-community/emacs-overlay/commit/5f215d06c8a5f0c6043fa851f05701e31961cfa1) Updated elpa
* [`da154a26`](https://github.com/nix-community/emacs-overlay/commit/da154a268947f8dc003c2c896310afb5531a33df) Updated melpa
* [`4b0e7b77`](https://github.com/nix-community/emacs-overlay/commit/4b0e7b77b538ee7a012404c62dad556c1fdf26a2) Updated emacs
* [`9f501537`](https://github.com/nix-community/emacs-overlay/commit/9f5015375befaa23ee4269babbfb8ff7f60fdbf9) Updated melpa
* [`8bc91082`](https://github.com/nix-community/emacs-overlay/commit/8bc910823b5594e669812d55fcd62c50d37759bb) Updated emacs
* [`58e0e1b7`](https://github.com/nix-community/emacs-overlay/commit/58e0e1b766896cacd34d6183d4f272a21c4605e0) Updated nongnu
* [`b8ea105a`](https://github.com/nix-community/emacs-overlay/commit/b8ea105a3920e385287261739a9944b93914ede7) Updated melpa
* [`5fb1f4fb`](https://github.com/nix-community/emacs-overlay/commit/5fb1f4fbdd31fd047dc92eb4c06e2a1349d96437) Updated emacs
* [`4a63bf83`](https://github.com/nix-community/emacs-overlay/commit/4a63bf83a190feaf033928530b46fb3942529fdc) Updated flake inputs
* [`0a0b4415`](https://github.com/nix-community/emacs-overlay/commit/0a0b4415e39287c9f398d77180c17a58bdc88d6e) Updated nongnu
* [`8c93b259`](https://github.com/nix-community/emacs-overlay/commit/8c93b2599001d56a59fc175d9585932b3de7ac3b) Updated elpa
* [`fb70a5df`](https://github.com/nix-community/emacs-overlay/commit/fb70a5dfc5ce9e7e6bbc364d593247f2cbfd17d3) Updated melpa
* [`b25255c4`](https://github.com/nix-community/emacs-overlay/commit/b25255c4ff136938d16c1972f27840094e627b6b) Updated emacs
* [`97678931`](https://github.com/nix-community/emacs-overlay/commit/97678931872b1bad445ed341e083c09025b4f0e7) Updated melpa
* [`968f0ff0`](https://github.com/nix-community/emacs-overlay/commit/968f0ff01de11ab6f74101bb27008a70ab726632) Updated flake inputs
* [`b19c34a7`](https://github.com/nix-community/emacs-overlay/commit/b19c34a7c9e19f02f2e1fd690c04cb4ec232de3d) Updated nongnu
* [`5ae8c408`](https://github.com/nix-community/emacs-overlay/commit/5ae8c40812e57097cb0d38b89d833d722c3a3589) Updated elpa
* [`27642084`](https://github.com/nix-community/emacs-overlay/commit/27642084fcad18551771d5cb8a8af457c969436a) Updated melpa
* [`74388037`](https://github.com/nix-community/emacs-overlay/commit/74388037057110eb4b64dc94c75395ddf4d0f940) Updated emacs
* [`84e0ee59`](https://github.com/nix-community/emacs-overlay/commit/84e0ee5985e6d5c039849b5ef47993aeb1689468) Updated nongnu
* [`3d382964`](https://github.com/nix-community/emacs-overlay/commit/3d382964be308d4446b445ece8f951e7e5c36496) Updated elpa
* [`6b3d624e`](https://github.com/nix-community/emacs-overlay/commit/6b3d624e57119b658ef8b5b0616825d86353bef3) Updated melpa
* [`4c344936`](https://github.com/nix-community/emacs-overlay/commit/4c344936ab4e21146d4fbe5806005a2e1b5c4844) Updated emacs
* [`3f0d0e1e`](https://github.com/nix-community/emacs-overlay/commit/3f0d0e1e5905cd4359aa2e4ed039c710cf047c99) Updated melpa
* [`8a291cec`](https://github.com/nix-community/emacs-overlay/commit/8a291cec04f546542bf4d594d0c192ef93157624) Updated nongnu
* [`4335244d`](https://github.com/nix-community/emacs-overlay/commit/4335244def5e78c6d0d4b67861e398337e40b422) Updated elpa
* [`01498098`](https://github.com/nix-community/emacs-overlay/commit/01498098ee08512e6fd22c4fdab37f1c18006b52) Updated melpa
* [`0ee304f9`](https://github.com/nix-community/emacs-overlay/commit/0ee304f9c74150022a618ecc42bfe565ee5e254c) Updated emacs
* [`71426c53`](https://github.com/nix-community/emacs-overlay/commit/71426c53c0a829c425d73dfd4a51b22b8d90a4ba) Updated nongnu
* [`7a8e98ca`](https://github.com/nix-community/emacs-overlay/commit/7a8e98caa27bf77212b3986aa92a05184f67a070) Updated elpa
* [`d39ef672`](https://github.com/nix-community/emacs-overlay/commit/d39ef67248e265591b8ce2080653582c735a3ea0) Updated melpa
* [`8532ee52`](https://github.com/nix-community/emacs-overlay/commit/8532ee52b538571d93e8fc7b83d76039e25e1fbf) Updated emacs
* [`467b69d2`](https://github.com/nix-community/emacs-overlay/commit/467b69d2d152d1b8df3e216cf0aaccd5aa59bfae) Updated flake inputs
* [`19bd95e4`](https://github.com/nix-community/emacs-overlay/commit/19bd95e4f5cc0677fac4e501ba68f3ec7d1da2c3) Updated melpa
* [`bc19dc80`](https://github.com/nix-community/emacs-overlay/commit/bc19dc80cd2987406a19b5c644e0400c4cf67e33) Updated emacs
* [`3c8333b6`](https://github.com/nix-community/emacs-overlay/commit/3c8333b60023af1d1a83e528df09aec0e0acf1a9) Updated flake inputs
* [`d2080e24`](https://github.com/nix-community/emacs-overlay/commit/d2080e24be22a0df2d9faeeb193f60e92ae08a08) Updated nongnu
* [`eab2ed35`](https://github.com/nix-community/emacs-overlay/commit/eab2ed354a88a6870ffca4980abb470bba0e4452) Updated elpa
* [`dc669001`](https://github.com/nix-community/emacs-overlay/commit/dc66900102152af56b9594875aae3525f43991e3) Updated melpa
* [`d7aadd31`](https://github.com/nix-community/emacs-overlay/commit/d7aadd31e28779d86de9134ff7d356f948f0933b) Updated emacs
* [`9eaf2014`](https://github.com/nix-community/emacs-overlay/commit/9eaf2014c36b1081ef2c5d597d9203830687a399) Updated nongnu
* [`91fc19de`](https://github.com/nix-community/emacs-overlay/commit/91fc19dee8e4c85047381f51bd8ce8116e56e217) Updated elpa
* [`a2ba4f7c`](https://github.com/nix-community/emacs-overlay/commit/a2ba4f7cd6196263a7af10b4d2c9a46c479b9522) Updated melpa
* [`54484c89`](https://github.com/nix-community/emacs-overlay/commit/54484c89441501961a1e1e7449389b81fffa1c68) Updated emacs
* [`7dc139df`](https://github.com/nix-community/emacs-overlay/commit/7dc139dffc4ad8301c639210a00d993e1c158069) Updated melpa
* [`b678938b`](https://github.com/nix-community/emacs-overlay/commit/b678938bf435d410fb7056b95fb1fdbd601b03ab) Updated nongnu
* [`24de0683`](https://github.com/nix-community/emacs-overlay/commit/24de06834be49839d0754b7fca56d0ce16e79935) Updated elpa
* [`964a44f6`](https://github.com/nix-community/emacs-overlay/commit/964a44f6585f8cae26c228409676d92822f78de0) Updated melpa
