### PR TITLE
niv doomemacs: update 9c8cfaad -> ba1dca32

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "doomemacs",
         "repo": "doomemacs",
-        "rev": "9c8cfaadde1ccc96a780d713d2a096f0440b9483",
-        "sha256": "1bwd3b1myadarqksmg5ld1f19k2nvi0bsm4l869vjxprbri5vswi",
+        "rev": "ba1dca322f9a07bc2b7bec6a98f2c3c55c0bbd77",
+        "sha256": "1y8ar78fwr8fkw1h9zfc6g565k8phqwcl5zc9f61bg2m1s7yxrmi",
         "type": "tarball",
-        "url": "https://github.com/doomemacs/doomemacs/archive/9c8cfaadde1ccc96a780d713d2a096f0440b9483.tar.gz",
+        "url": "https://github.com/doomemacs/doomemacs/archive/ba1dca322f9a07bc2b7bec6a98f2c3c55c0bbd77.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "emacs-overlay": {


### PR DESCRIPTION
## Changelog for doomemacs:
Branch: master
Commits: [doomemacs/doomemacs@9c8cfaad...ba1dca32](https://github.com/doomemacs/doomemacs/compare/9c8cfaadde1ccc96a780d713d2a096f0440b9483...ba1dca322f9a07bc2b7bec6a98f2c3c55c0bbd77)

* [`169540ad`](https://github.com/doomemacs/doomemacs/commit/169540ad3b19e611a125297cdfb87618f1418746) feat(lib): add doom-copy
* [`97387b89`](https://github.com/doomemacs/doomemacs/commit/97387b89fb5668755415af71f2998f8b50857798) fix(lib): with-doom-module: nil -> empty doom-module-context
* [`bbbfb853`](https://github.com/doomemacs/doomemacs/commit/bbbfb85393aea09692349915e4dba5f9ca50eeb5) fix: ignore profile load file extension
* [`bf9249d0`](https://github.com/doomemacs/doomemacs/commit/bf9249d002e2e4bd797b76f2140e712399359d3b) docs: don't recommend doom/reload
* [`94d96749`](https://github.com/doomemacs/doomemacs/commit/94d967490f708bf1333cd54fc6918c9dc39c936d) fix(sh): don't set mode-name in sh-mode derivatives
* [`bdc35faf`](https://github.com/doomemacs/doomemacs/commit/bdc35faff28cadf1dc2ffbe99801550808a13023) tweak(sh): auto-mode-alist: generalize /*rc rule
* [`3b6e46ef`](https://github.com/doomemacs/doomemacs/commit/3b6e46ef00d0195ec6f6bbb9f257fc1460d2c414) feat(lib): move backports to doom-compat.el
* [`da08aa2d`](https://github.com/doomemacs/doomemacs/commit/da08aa2d7d9ca9197896e7988dc8785006796336) feat(lib): backport major-mode-remap{,-alist}
* [`201321c9`](https://github.com/doomemacs/doomemacs/commit/201321c92911c6cf8464fb96943e5c858066ec44) feat(lib): backport safe-local-variable-directories
* [`a39dd36e`](https://github.com/doomemacs/doomemacs/commit/a39dd36e97076459e6155158d3593dfd0ce78fc5) refactor: move templates/ to static/
* [`3401492c`](https://github.com/doomemacs/doomemacs/commit/3401492c84713facf63563c0def734d2d269e639) refactor: deprecate letenv!
* [`9aaefbe4`](https://github.com/doomemacs/doomemacs/commit/9aaefbe4aebc8105e9ecfbe5f1b46243b7b1169a) refactor: remove redundant straight hacks
* [`9c8ea37a`](https://github.com/doomemacs/doomemacs/commit/9c8ea37a2dadcbc5e502664d3ef690bb91b3891f) refactor(cli): remove cli/packages.el
* [`ec656162`](https://github.com/doomemacs/doomemacs/commit/ec6561628487893090b86a8ae5ba8521af960d95) refactor(cli): add stubs for v3 commands
* [`be6fcece`](https://github.com/doomemacs/doomemacs/commit/be6fcece3a37bb4abc199f847732cfb5359edc43) fix(cli): doom gc
* [`87a0d9d2`](https://github.com/doomemacs/doomemacs/commit/87a0d9d2e1e14d1ffc344076c4fc9ca10e3da1b6) fix: void-variable native-comp-deferred-compilation-deny-list
* [`abedb71f`](https://github.com/doomemacs/doomemacs/commit/abedb71f9689c41242fcf35381116e335da6831b) refactor(cli): restructure doom profile commands
* [`b9e43666`](https://github.com/doomemacs/doomemacs/commit/b9e436663bc33161e354f217c8face3ab7228993) fix(cli): defcli-obsolete!: don't rely on lexical-binding
* [`7dddbcf7`](https://github.com/doomemacs/doomemacs/commit/7dddbcf793964f893ea672f1e58c6642fdc76e37) fix(lib): native-comp-deferred-compilation-deny-list in sandbox
* [`05e34351`](https://github.com/doomemacs/doomemacs/commit/05e34351ea5abf4828a305a970d6555e1290cd8b) fix(eval): double prompt when region sent to repl
* [`52d1c208`](https://github.com/doomemacs/doomemacs/commit/52d1c208d431c3f2f190d1171820a2db07de6165) feat(file-templates): add apply method
* [`4a8f3bf0`](https://github.com/doomemacs/doomemacs/commit/4a8f3bf03303890cdcec2a323887555d93d0b93a) fix(python): +python-executable-find ipython
* [`fca69c98`](https://github.com/doomemacs/doomemacs/commit/fca69c9849d3abcab0e8e1b1a17cf09298472715) release(modules): 25.01.0-dev
* [`8072d62b`](https://github.com/doomemacs/doomemacs/commit/8072d62b4fb7c6212d70257420a7bdb791dd879c) refactor(cli): remove redundant setq
* [`ec645b83`](https://github.com/doomemacs/doomemacs/commit/ec645b83818d0d691493b944b03ffeab70b112bb) fix(lib): 'unknown specializer record' error on Emacs <30
* [`4418c80c`](https://github.com/doomemacs/doomemacs/commit/4418c80c9519f3af6bc4cc894c5292aa4ab3c852) fix(syntax): disable checker in non-project elisp files
* [`637f70f5`](https://github.com/doomemacs/doomemacs/commit/637f70f53be1f4c30ea3dd40875780e67cf5ac19) fix(emacs-lisp): duplicate entries in flycheck-disabled-checkers
* [`82cfe98c`](https://github.com/doomemacs/doomemacs/commit/82cfe98ccc0c759c15ac9f87008b1ed4128ed416) fix(lib): doom-copy: copy first level of records
* [`ea616ebd`](https://github.com/doomemacs/doomemacs/commit/ea616ebd5bcc98d342ab89bbe02f99dd8c0cd673) fix(lib): cmd!: remove superfluous macro declarations
* [`c7887694`](https://github.com/doomemacs/doomemacs/commit/c7887694694de996c017c3ff6e202cec1cdca299) refactor: move GPG defaults to :config default
* [`440b8be3`](https://github.com/doomemacs/doomemacs/commit/440b8be3aa55eab2dfcf1e507986d1cf47a11fed) fix(emacs-lisp): false positives from syntax checkers
* [`ba1dca32`](https://github.com/doomemacs/doomemacs/commit/ba1dca322f9a07bc2b7bec6a98f2c3c55c0bbd77) revert: tweak(sh): auto-mode-alist: generalize /*rc rule
