### PR TITLE
niv nixpkgs: update 6d97d419 -> ecd810c4

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "6d97d419e5a9b36e6293887a89a078cf85f5a61b",
-        "sha256": "10y6ply5jhg9pwq13zldmipxh8dscmawx5syi1i6rb773xnnr452",
+        "rev": "ecd810c4cc90890229ef353a12fb384c47ee75c3",
+        "sha256": "0rdrixmxjinvrw2f1aa40fxy8q7nxlqa33g3rxvyv40nay3izpyx",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/6d97d419e5a9b36e6293887a89a078cf85f5a61b.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/ecd810c4cc90890229ef353a12fb384c47ee75c3.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@6d97d419...ecd810c4](https://github.com/nixos/nixpkgs/compare/6d97d419e5a9b36e6293887a89a078cf85f5a61b...ecd810c4cc90890229ef353a12fb384c47ee75c3)

* [`66a4cdc7`](https://github.com/NixOS/nixpkgs/commit/66a4cdc74217b10188cbee4ff472e59290a7ce25) cupsd: Allow major upgrades of gutenprint with cups-genppdupdate.
* [`501faf79`](https://github.com/NixOS/nixpkgs/commit/501faf79fac647947bcbca6d9b0ae55c232c70d8) maintainers: add willow_ch
* [`43d8f47d`](https://github.com/NixOS/nixpkgs/commit/43d8f47df35d34e1aa21db98dce801318e5c0f24) nixos/fileSystems: add enable option
* [`5afa8d15`](https://github.com/NixOS/nixpkgs/commit/5afa8d15cb8621ec9d9cf08a3634c0e6dc6b10ea) plantuml-server: remove unnecessary systemd option path
* [`d40983ba`](https://github.com/NixOS/nixpkgs/commit/d40983ba34488f05bbb4194f574bc84c39925cf1) dwm: add extraSessionCommands option
* [`0274fc22`](https://github.com/NixOS/nixpkgs/commit/0274fc2212161c451b9c03fcbc2e1dbb3ace779c) nixos/zfs: Set scrub default IOSchedulingClass to idle
* [`385a87c5`](https://github.com/NixOS/nixpkgs/commit/385a87c5f8f0a99b318f4fe469fe7f8032776181) dwm: format module with nixfmt
* [`afd04454`](https://github.com/NixOS/nixpkgs/commit/afd044548fe0312d5f49df730115645256829ed8) Disable compiler runtime-test for cmake when cross-compiling to None platform.
* [`3d9f7e0c`](https://github.com/NixOS/nixpkgs/commit/3d9f7e0ca0accf52101ab3b48bab629f4dbc2e3f) i3status-rust: add optional support for pipewire driver
* [`25baa10f`](https://github.com/NixOS/nixpkgs/commit/25baa10f8c60f364122226285b44ec507ae932b0) gnomeExtensions.velent: unstable-2023-11-10 -> 1.0.0.alpha.46
* [`24aabe7a`](https://github.com/NixOS/nixpkgs/commit/24aabe7a1560faf7766c2b545efeab612d9ba881) beanprice: init at 20240619
* [`4e5de4ef`](https://github.com/NixOS/nixpkgs/commit/4e5de4ef9598e9777aac542ee83bb4f34bc4d6fa) nixos/dwm-status: don't disable upower
* [`e445971f`](https://github.com/NixOS/nixpkgs/commit/e445971f487b50f9ed3f4bd77df8b77c64405990) physfs: don't set CMAKE_SKIP_RPATH
* [`a4008da2`](https://github.com/NixOS/nixpkgs/commit/a4008da2d49de77e0da4391db1ae681a143233a3) nixos/systemd-boot: Don't write to /etc/machine-id
* [`627221c2`](https://github.com/NixOS/nixpkgs/commit/627221c26208d7ed3db88bb4b07cf4e40e4e7a7f) nixos/make-disk-image: Remove hack that cleans up machine-id
* [`5f197bf5`](https://github.com/NixOS/nixpkgs/commit/5f197bf5d0eaee359dc5c3eb4deabf1654c81b72) nixos/eval-config: Deprecate NIXOS_EXTRA_MODULE_PATH
* [`77650561`](https://github.com/NixOS/nixpkgs/commit/77650561723637cce4e1ae3eeb784825828792ab) playonlinux: add python dependency pyasyncore
* [`6896c88c`](https://github.com/NixOS/nixpkgs/commit/6896c88c1b6ae2b68d30e32b03d2c5c63b2d8a90) lib25519: add update script
* [`c258e18f`](https://github.com/NixOS/nixpkgs/commit/c258e18f67a5d39d4d2902f84201af4b6dac40b8) nixos/auto-cpufreq: init vm test
* [`c574adec`](https://github.com/NixOS/nixpkgs/commit/c574adecc908290bbe53437e6c7f2ae19bb29548) auto-cpufreq: add passthru.tests
* [`4b6daa0e`](https://github.com/NixOS/nixpkgs/commit/4b6daa0e158c57d5489070568e28402310a52f13) megasync: 4.9.1.0 -> 5.5.0.0
* [`745f78a6`](https://github.com/NixOS/nixpkgs/commit/745f78a683e893579e19540b2571693c06799026) nixos/komga: introduce 'settings' option
* [`3f182f39`](https://github.com/NixOS/nixpkgs/commit/3f182f399fc9667a23aac32bc1108002f1ccbae2) nixos/tests/komga: fix renamed 'port' option
* [`e380a8f3`](https://github.com/NixOS/nixpkgs/commit/e380a8f3e0dc87b546a8bff1c41113220435ec7e) nwjs: change license to MIT
* [`06d1364d`](https://github.com/NixOS/nixpkgs/commit/06d1364d1d2931d50b2143243859a34a92cd18d2) nwjs: simplify the bits variable assignment
* [`96a7448a`](https://github.com/NixOS/nixpkgs/commit/96a7448a4ea5fd45d9ae1070dd5bce3e2b55113a) nixos/overlayfs: add a switch to disable prefixing with `/sysroot` for initrd mounts
* [`cba277a1`](https://github.com/NixOS/nixpkgs/commit/cba277a1dcd82e872c75794e4b593dea84520575) nixos/overlayfs: format
* [`fbaa0f52`](https://github.com/NixOS/nixpkgs/commit/fbaa0f529b53e62f56d5e406994b332f4d3ac272) nixos/tests/filesystems-overlayfs: format
* [`341179bf`](https://github.com/NixOS/nixpkgs/commit/341179bfa2da981051fb9bffe6f4ed90f878eff7) nixos/tests/filesystems-overlayfs: add test for initrd -> userspace overlays
* [`97eb7072`](https://github.com/NixOS/nixpkgs/commit/97eb707293a83aacf7a0d88b26c037e1baf0facb) ceptre: format via nixfmt
* [`1bca079d`](https://github.com/NixOS/nixpkgs/commit/1bca079dcae044c505b121f26328ca78103c2b6c) ceptre: bump to 0-unstable-2024-8-26
* [`43f4d40e`](https://github.com/NixOS/nixpkgs/commit/43f4d40e99b8cce8ff454705b71f324903be89a3) ceptre: cleanup
* [`b412d42a`](https://github.com/NixOS/nixpkgs/commit/b412d42add9de6d58d8839093d1a3ac61ca581fc) yakut: fix dependencies
* [`a141face`](https://github.com/NixOS/nixpkgs/commit/a141face92ff0b03c8d9613178399089b7483aed) helmsman: nixfmt-rfc-style
* [`44604fac`](https://github.com/NixOS/nixpkgs/commit/44604face4a01084f1bd17e3852e0accb2377fbe) manta: fix build
* [`19c58a0f`](https://github.com/NixOS/nixpkgs/commit/19c58a0fa8e13fa72c6ccba1a8d446c2a7de68ba) helmsman: only build helsman subPackage
* [`5cc43997`](https://github.com/NixOS/nixpkgs/commit/5cc4399755f29a7ecb31810d77d02f4db2baa257) helmsman: add sarcasticadmin as maintainer
* [`fad94949`](https://github.com/NixOS/nixpkgs/commit/fad94949b18d7ee62a2f5c9127624176ce82670d) megasync: remove freeimage
* [`197e68c0`](https://github.com/NixOS/nixpkgs/commit/197e68c0d34ae1ae91e50dbf57918d13a681d7ed) dmg2img: 1.6.7 -> 1.6.7-unstable-2020-12-27
* [`7853e732`](https://github.com/NixOS/nixpkgs/commit/7853e73254778e131376ecd8829987adee04c33c) rush: look for rush.rc in /etc
* [`1714b4c1`](https://github.com/NixOS/nixpkgs/commit/1714b4c1755f57b57299e7ead398b74d74e34206) kaufkauflist: 4.0.0 -> 4.0.2
* [`adf1393c`](https://github.com/NixOS/nixpkgs/commit/adf1393ce30d22fcf3745b49bd24cb9226febd0d) libvisio: 0.1.7 -> 0.1.8
* [`fe4fac1f`](https://github.com/NixOS/nixpkgs/commit/fe4fac1fe40a2939e6025347cc1776b5d7313f21) megasync: use fetchpatch
* [`55fdc8ea`](https://github.com/NixOS/nixpkgs/commit/55fdc8ea50647ffe51fa5a116fbed8b105aa9f25) megasync: version fetchpatch urls so they don't magically break
* [`55a2b3eb`](https://github.com/NixOS/nixpkgs/commit/55a2b3eb0c016c3a450dec784a9d1a70051d6df8) sc-im: fix aligning selection of cells cause crash
* [`5403a688`](https://github.com/NixOS/nixpkgs/commit/5403a688978aae4613055646683d77ba46ffacba) gnome-pass-search-provider: init at 1.4.0
* [`449c9e76`](https://github.com/NixOS/nixpkgs/commit/449c9e769584f4535468c7a6fbabd004b256a2d4) invoiceplane: nixfmt
* [`34943efb`](https://github.com/NixOS/nixpkgs/commit/34943efbbd34db017dd0982f0b6294279965083a) invoiceplane: reformat
* [`48a820f9`](https://github.com/NixOS/nixpkgs/commit/48a820f96602c406b4fb8d8e458fdedb9cd75dce) invoiceplane: Add changelog
* [`19ce591f`](https://github.com/NixOS/nixpkgs/commit/19ce591f4e3c76f36aeaa83801a935d33c85d335) invoiceplane: Build from source
* [`5378b5f6`](https://github.com/NixOS/nixpkgs/commit/5378b5f6f408a15ffe19d7e80a0275571f031eb9) python312Packages.mkdocs-material: 9.5.39 -> 9.5.45
* [`bee089e0`](https://github.com/NixOS/nixpkgs/commit/bee089e0e10f2d1c81f941c36d818cb6e870c800) python312Packages.langcodes: 3.4.1 -> 3.5.0
* [`cbead292`](https://github.com/NixOS/nixpkgs/commit/cbead292e4aafd2ff4a384cfead3fb824d3d0657) ani-cli: only add the player to the PATH as a fallback, format
* [`c3d2d3e3`](https://github.com/NixOS/nixpkgs/commit/c3d2d3e3148d9fb50554799c379ece36238f7ba3) ani-cli: add diniamo as a maintainer
* [`80ab465c`](https://github.com/NixOS/nixpkgs/commit/80ab465c94ee609d5629bb97a4043465f0d5661f) ani-cli: avoid `with lib;`
* [`0ac27f49`](https://github.com/NixOS/nixpkgs/commit/0ac27f49bfd68f9fdcbb46d271b691bc7458543d) ani-cli: avoid `rec`
* [`6982710b`](https://github.com/NixOS/nixpkgs/commit/6982710bb21a84d9b37ea5760050245950a64d95) megasync: 5.5.0.0 -> 5.6.1.0
* [`27f7066b`](https://github.com/NixOS/nixpkgs/commit/27f7066b00a532383b28a7090d185833eae3be12) codecrafters-cli: 34 -> 35
* [`4689b8cd`](https://github.com/NixOS/nixpkgs/commit/4689b8cd078db110d0811e663ee762a136b39b3b) licensed: init at 5.0.0
* [`83149d48`](https://github.com/NixOS/nixpkgs/commit/83149d48fd418792b7d3aeb9a3809fe49f83afae) python312Packages.openturns: 1.23 -> 1.24
* [`bfc5706c`](https://github.com/NixOS/nixpkgs/commit/bfc5706cf4cb50255453ea2ef9bd476ce3e7ebcf) maintainers: add mahtaran
* [`c61fc34b`](https://github.com/NixOS/nixpkgs/commit/c61fc34b47d71894d4514e1440de5e1929db4b75) python3Packages.mkdocs-git-committers-plugin-2: init at 2.4.1
* [`68622ebc`](https://github.com/NixOS/nixpkgs/commit/68622ebcc7e151effd254a86bc704af37ee04ff2) nomacs-qt6: init (master + plugins)
* [`a85eeff3`](https://github.com/NixOS/nixpkgs/commit/a85eeff36e6280d019c1f7d31806eca2d0ac4298) typescript: 5.6.3 -> 5.7.2
* [`623d6fbb`](https://github.com/NixOS/nixpkgs/commit/623d6fbbca58104cf5167ce9433812296e86f207) netbox: 4.1.3 -> 4.1.7
* [`046286d6`](https://github.com/NixOS/nixpkgs/commit/046286d6b95930b01a5118844169794cce52e33a) diffoscope: add additional tools
* [`bf9c6c98`](https://github.com/NixOS/nixpkgs/commit/bf9c6c9861b86e566b1bf22f251194a489b8f97c) switch-to-configuration-ng: Better handling of socket-activated units
* [`82c0b6fd`](https://github.com/NixOS/nixpkgs/commit/82c0b6fd09a84f3520a46b380043770d01db4262) lldap: 0.5.1-unstable-2024-10-30 -> 0.6.1
* [`dea5930f`](https://github.com/NixOS/nixpkgs/commit/dea5930f0ed8c29d3758d5ade9898b4e99d80b74) wine64Packages.{unstable,staging}: 9.20 -> 9.22
* [`a0f0eafe`](https://github.com/NixOS/nixpkgs/commit/a0f0eafede8a035794f41dbd509937738e832e11) megasync: don't cp clang-format
* [`0941dc79`](https://github.com/NixOS/nixpkgs/commit/0941dc795a2f8f70e8682c9f74362bf9649b1669) nostr-rs-relay: 0.8.13-unstable -> 0.9.0
* [`482ff494`](https://github.com/NixOS/nixpkgs/commit/482ff494b881aac44f64c0ca045e2fe973050de3) windows.mcfgthreads: 1.6.1 -> 1.9.2
* [`1fed2312`](https://github.com/NixOS/nixpkgs/commit/1fed2312e7a3735c87e8a6570ae734bbcecb4180) Add X-NotSocketActivated logic to switch-to-configuration.pl, as well
* [`f2b47bff`](https://github.com/NixOS/nixpkgs/commit/f2b47bffd00ba103eea3bcc62b3926892d14805d) ciscoPacketTracer8: nixfmt
* [`b5047459`](https://github.com/NixOS/nixpkgs/commit/b5047459f9ccb75c513e2b06014711333f501dd0) ciscoPacketTracer8: remove `with lib;`, order `meta` attrs
* [`aeb72d95`](https://github.com/NixOS/nixpkgs/commit/aeb72d953458ca682d8dacf93545bcad4343d0ec) ciscoPacketTracer8: add maintainer gepbird
* [`46041f4f`](https://github.com/NixOS/nixpkgs/commit/46041f4f37a762e533a70bb897c27f13c24edd59) ciscoPacketTracer8: add version parameter
* [`f8e91e90`](https://github.com/NixOS/nixpkgs/commit/f8e91e908e33ceb61418cc75e9bee24af93d4948) ciscoPacketTracer8: revert to fhsEnv
* [`a67194f9`](https://github.com/NixOS/nixpkgs/commit/a67194f905f0b41d072e0485a2574feb44df5ba9) ciscoPacketTracer8: allow overriding src
* [`e94e7536`](https://github.com/NixOS/nixpkgs/commit/e94e7536ead97e24fe6e36d9a1e5046e4af93334) python312Packages.peewee: 3.17.7 -> 3.17.8
* [`516a2a36`](https://github.com/NixOS/nixpkgs/commit/516a2a3674201858f026325a18a0ab083cb11a76) firewalld: 2.2.3 -> 2.3.0
* [`836ba536`](https://github.com/NixOS/nixpkgs/commit/836ba536d1ed68d75fbe2bf8329982c4115705f3) firewalld-gui: 2.2.3 -> 2.3.0
* [`0794fe04`](https://github.com/NixOS/nixpkgs/commit/0794fe0425b1e7dfb1a7d344e334d6f10748f4a0) python312Packages.etils: 1.10.0 -> 1.11.0
* [`bfa5fe24`](https://github.com/NixOS/nixpkgs/commit/bfa5fe24d7416e56e6e04132b805205bc76a248d) python312Packages.viv-utils: 0.7.11 -> 0.7.13
* [`3f94adc3`](https://github.com/NixOS/nixpkgs/commit/3f94adc343621f8c2913a38499e7813976229aba) youplot: 0.4.5 -> 0.4.6
* [`2995a17c`](https://github.com/NixOS/nixpkgs/commit/2995a17c25fe44cf04f0857b2eeee98950e317a5) xsnow: 3.4.4 -> 3.7.9
* [`c0fd43c6`](https://github.com/NixOS/nixpkgs/commit/c0fd43c6d156cb006c64db51cba989f0fcc03902) ttysvr: 0.3.3 -> 0.3.4
* [`7a66174f`](https://github.com/NixOS/nixpkgs/commit/7a66174fcf4b5ff722b944f902a708ceeda31e64) python312Packages.wheel-inspect: 1.7.1 -> 1.7.2
* [`a1b3091d`](https://github.com/NixOS/nixpkgs/commit/a1b3091db87edbf8dc76b07a04e45d813c515395) nixos/kimai: fix incorrect service name for PHP-FPM service mixin
* [`106bef06`](https://github.com/NixOS/nixpkgs/commit/106bef066f18b25ebefde3f2a75e8582ad22eb35) nixos/kimai: set PHP package for PHP-FPM pool to Kimai's PHP package
* [`39c3f09f`](https://github.com/NixOS/nixpkgs/commit/39c3f09f30db0c65828df02e3012568286ca48c0) ocamlPackages.reason: 3.13.0 -> 3.14.0
* [`118327ee`](https://github.com/NixOS/nixpkgs/commit/118327ee921198191db5681115aab67d35bf47fb) python312Packages.influxdb-client: 1.47.0 -> 1.48.0
* [`e77fad20`](https://github.com/NixOS/nixpkgs/commit/e77fad204986754611f5ce95e4f315d0f8a0d8c8) python312Packages.cheetah3: 3.3.3.post1 -> 3.4.0
* [`f3e76532`](https://github.com/NixOS/nixpkgs/commit/f3e7653291e02f35d42b4fe7fd9be15877ac6590) python312Packages.zope-testrunner: 6.4 -> 6.6
* [`e7d28503`](https://github.com/NixOS/nixpkgs/commit/e7d285032a4cd5a3fa7c9c2b497b1f60d97672e5) python312Packages.roombapy: 1.8.1 -> 1.8.2
* [`e3919fff`](https://github.com/NixOS/nixpkgs/commit/e3919fff86708bd0ac47f799c78c4b893b0aa413) latex2html: 2024 -> 2024.2
* [`14584f5e`](https://github.com/NixOS/nixpkgs/commit/14584f5e68431b4c0c691bacad26a7df4dd3bcda) python312Packages.glom: 23.5.0 -> 24.11.0
* [`b67dd357`](https://github.com/NixOS/nixpkgs/commit/b67dd357d718b2ee7395990bff055bf052395fb6) python312Packages.python-sql: 1.5.1 -> 1.5.2
* [`92d11056`](https://github.com/NixOS/nixpkgs/commit/92d110561b29131122be665248daba2bda5bf4e8) python312Packages.libusbsio: 2.1.12 -> 2.1.13
* [`8f132b64`](https://github.com/NixOS/nixpkgs/commit/8f132b64862eb60f32d3237f930c97791aeb8f32) python312Packages.osqp: 0.6.7.post1 -> 0.6.7.post3
* [`5eee2fa2`](https://github.com/NixOS/nixpkgs/commit/5eee2fa2b081e5c39a0b0af8ba969d63e748aa0c) python312Packages.pyexcel: 0.7.0 -> 0.7.1
* [`cf887a6a`](https://github.com/NixOS/nixpkgs/commit/cf887a6a6373354275178bf358184883a5c83b97) nomacs: add nomad-qt6; enable plugins by default
* [`2553f4b7`](https://github.com/NixOS/nixpkgs/commit/2553f4b738d63dede25a2a1abf14ed9f77988633) python312Packages.py-scrypt: 0.8.24 -> 0.8.27
* [`c45c6e5d`](https://github.com/NixOS/nixpkgs/commit/c45c6e5de3632f77cb94c2c9bcb7af88d06d7e2b) python312Packages.rcssmin: 1.1.2 -> 1.2.0
* [`8e5455e9`](https://github.com/NixOS/nixpkgs/commit/8e5455e9a199d42453aec2e91ed382686323b2c3) python312Packages.rjsmin: 1.2.2 -> 1.2.3
* [`31c61b19`](https://github.com/NixOS/nixpkgs/commit/31c61b198472ab806447fd755fed04802a7672b3) python312Packages.mecab-python3: 1.0.9 -> 1.0.10
* [`b393f7cd`](https://github.com/NixOS/nixpkgs/commit/b393f7cd617dba07d547b4abf453a09d570c51d7) python312Packages.pymssql: 2.3.1 -> 2.3.2
* [`48d275c3`](https://github.com/NixOS/nixpkgs/commit/48d275c3de4e2aece7d26179fd6e33a47daff39d) colorls: 1.4.6 -> 1.5.0
* [`84d991d3`](https://github.com/NixOS/nixpkgs/commit/84d991d304360cc2e70a72b2a50eae1a898738ac) python3Packages.prosemirror: 0.5.0 -> 0.5.1
* [`3c999ebf`](https://github.com/NixOS/nixpkgs/commit/3c999ebf694f3b5d7571b60efd2445a6f7cd900a) python3Packages.prosemirror: add changelog
* [`7d23946c`](https://github.com/NixOS/nixpkgs/commit/7d23946c14235d2ae91ceadcc32e1e258f0fc965) python3Packages.prosemirror: nixfmt
* [`9a8e0740`](https://github.com/NixOS/nixpkgs/commit/9a8e0740f1c89b4c65886e20eda6e025496a7a0b) net-news-wire: 6.1.4 -> 6.1.5
* [`d5a0ed5e`](https://github.com/NixOS/nixpkgs/commit/d5a0ed5e016a142ec3e071d57595ac2c1e7ce4be) python312Packages.sopel: 8.0.0 -> 8.0.1
* [`63b17a2c`](https://github.com/NixOS/nixpkgs/commit/63b17a2c79f45c995ec934b69031afcc2aa542af) python312Packages.pylibftdi: 0.22.0 -> 0.23.0
* [`915fdc4c`](https://github.com/NixOS/nixpkgs/commit/915fdc4ca710bce29aa6eea30a0466bf59232826) python312Packages.pyvcd: 0.4.0 -> 0.4.1
* [`b1f01488`](https://github.com/NixOS/nixpkgs/commit/b1f0148854a4a9d67a9e155d902ade7d7d895e8d) python312Packages.types-dateutil: 2.9.0.20240906 -> 2.9.0.20241003
* [`5e8a956b`](https://github.com/NixOS/nixpkgs/commit/5e8a956b37219c196f460ae3e1ecfbea0d3e292e) python312Packages.sphinxawesome-theme: 5.2.0 -> 5.3.2
* [`85af7106`](https://github.com/NixOS/nixpkgs/commit/85af71061185bd0b4570eec2ff2ab1772ecd9f52) python312Packages.gnureadline: 8.2.10 -> 8.2.13
* [`bedca36b`](https://github.com/NixOS/nixpkgs/commit/bedca36b94bcd80b363049c67b6e67e656a8fc6c) python312Packages.manuel: 1.12.4 -> 1.13.0
* [`38c44c5f`](https://github.com/NixOS/nixpkgs/commit/38c44c5ffcb2460ddbd540eff819ae1e2a17489e) python312Packages.fabio: 2024.4.0 -> 2024.9.0
* [`75b51039`](https://github.com/NixOS/nixpkgs/commit/75b51039a3e97e22ec37839822ca00798f60c76f) python312Packages.hg-evolve: 11.1.4 -> 11.1.6
* [`22f07059`](https://github.com/NixOS/nixpkgs/commit/22f07059a53844e6e6f6767f05281d4a0612e29f) python312Packages.virtualenvwrapper: 6.1.0 -> 6.1.1
* [`8ff98614`](https://github.com/NixOS/nixpkgs/commit/8ff986142986ef85283839d59e5b2fb76733ad52) python312Packages.tablib: 3.6.1 -> 3.7.0
* [`6eceecf5`](https://github.com/NixOS/nixpkgs/commit/6eceecf590a2a896b0349b7503668bc946dcac49) python312Packages.line-profiler: 4.1.3 -> 4.2.0
* [`9b92e9d2`](https://github.com/NixOS/nixpkgs/commit/9b92e9d2afec93cb53ddc5f897a2fc6f6c636ac5) python312Packages.torchdiffeq: 0.2.4 -> 0.2.5
* [`6c907c5e`](https://github.com/NixOS/nixpkgs/commit/6c907c5e7daa44fce69d104837c467c24226db75) python312Packages.dploot: 3.0.0 -> 3.0.3
* [`0b6f4a29`](https://github.com/NixOS/nixpkgs/commit/0b6f4a29df29c083c41418f4809f14eea3fae9b7) unifi-controller: patchelf unifi's sdnotify
* [`e5b5cf80`](https://github.com/NixOS/nixpkgs/commit/e5b5cf80c5d78dc7c4921dc4725cddb2c1c3b8b7) nixos/unifi: enable sd_notify
* [`5d10e2be`](https://github.com/NixOS/nixpkgs/commit/5d10e2bedb74e11d69acafa5823538114c346a2e) nixos/unifi: always restart service
* [`7de8722d`](https://github.com/NixOS/nixpkgs/commit/7de8722dc3d9bde0fed3fb066967b66d58f398cb) ipe: optional support for qvoronoi
* [`0bc6a534`](https://github.com/NixOS/nixpkgs/commit/0bc6a534e8105ffa3a6e9762b711eeee3b20a5f9) python312Packages.consolekit: 1.7.1 -> 1.7.2
* [`e461d525`](https://github.com/NixOS/nixpkgs/commit/e461d525e289493804cfb8a6edc61ccbb2e1f5a3) python312Packages.azure-servicebus: 7.12.3 -> 7.13.0
* [`49f13ed2`](https://github.com/NixOS/nixpkgs/commit/49f13ed21c39e56ecccc43cb05dedfc18c180972) python312Packages.pywebpush: 2.0.1 -> 2.0.3
* [`b3cdb788`](https://github.com/NixOS/nixpkgs/commit/b3cdb788b9f68d7c888849485a90b947f2e77ebd) xdg-terminal-exec: 0.10.1 -> 0.12.0
* [`58d5f8ee`](https://github.com/NixOS/nixpkgs/commit/58d5f8eee7c054589b581912506da057f3f16166) python312Packages.pyinstaller: 6.11.0 -> 6.11.1
* [`f317e28d`](https://github.com/NixOS/nixpkgs/commit/f317e28d813ba09d0165e251211e98ccc58110ca) elan: fix for Lean >= 4.16.0
* [`db6be866`](https://github.com/NixOS/nixpkgs/commit/db6be866d53a65f0081792b05cb37c2a21e5ef89) gossip: supply correct libsdl2
* [`b1b3d683`](https://github.com/NixOS/nixpkgs/commit/b1b3d683d9b71d75994b9200c4b450c7304566f5) python312Packages.pyside2: 5.15.15 -> 5.15.16
* [`e34631a0`](https://github.com/NixOS/nixpkgs/commit/e34631a0695b7bb875a3748edd0cff7d7486d547) bazel_7: cleanup dead files
* [`3b413092`](https://github.com/NixOS/nixpkgs/commit/3b413092b5b6d6f842e679f55384bd5770205487) megacmd: format; better coding style (avoid rec; avoid with lib)
* [`9e21c00c`](https://github.com/NixOS/nixpkgs/commit/9e21c00cf1dfbe33371864b5d7d573088d1fada0) duo-unix: 2.0.2 -> 2.0.4
* [`4211063d`](https://github.com/NixOS/nixpkgs/commit/4211063dc86534794842e8dfb88c597d774d4d62) megacmd: fix build with ffmpeg; add option to build with freeimage
* [`8f261372`](https://github.com/NixOS/nixpkgs/commit/8f2613724084a3d843db76ebced1941946215f19) python312Packages.reportlab: 4.2.4 -> 4.2.5
* [`1599f470`](https://github.com/NixOS/nixpkgs/commit/1599f470b99a43cdb235bd5571f1e6df47b37e65) python312Packages.pyperf: 2.7.0 -> 2.8.1
* [`ae11e320`](https://github.com/NixOS/nixpkgs/commit/ae11e32041c69ff01b248851f88479ed080225de) python312Packages.apispec: 6.6.1 -> 6.8.0
* [`ab208326`](https://github.com/NixOS/nixpkgs/commit/ab20832614cb9332e92f8305309cdc4a80dfbed5) python312Packages.bottleneck: 1.4.0 -> 1.4.2
* [`7f7f18a1`](https://github.com/NixOS/nixpkgs/commit/7f7f18a16a129e0c530bcdbe3269b2fa85fcc536) python312Packages.pyipv8: 2.13.0 -> 3.0.0
* [`c2681f24`](https://github.com/NixOS/nixpkgs/commit/c2681f24852a34c46d86082bbd0a9f5c08244fb1) aws-sso-util: init at 4.33.0
* [`23aca92f`](https://github.com/NixOS/nixpkgs/commit/23aca92fa2d41cc3eca4ea010c1cbef970c2d1e9) bitwarden-menu: 0.4.3 -> 0.4.5
* [`fbe94803`](https://github.com/NixOS/nixpkgs/commit/fbe948038821c9309c724b9a82da41e2d586bded) python312Packages.mkdocs-git-authors-plugin: 0.9.0 -> 0.9.2
* [`0be5b527`](https://github.com/NixOS/nixpkgs/commit/0be5b527df50ddb32636b9281f0311ec6fdcce4f) python312Packages.cx-freeze: 7.2.2 -> 7.2.7
* [`277733f9`](https://github.com/NixOS/nixpkgs/commit/277733f91c36aac932685835a24f39bc838e44c8) python312Packages.pywebview: 5.2 -> 5.3.2
* [`cb90cde2`](https://github.com/NixOS/nixpkgs/commit/cb90cde22ba6db17630dd151b59b78ab9e58c7a0) python312Packages.pypiserver: 2.2.0 -> 2.3.2
* [`a333cf53`](https://github.com/NixOS/nixpkgs/commit/a333cf53c7c33eaf3fff2454f5617d601efc211c) python312Packages.rasterio: 1.4.2 -> 1.4.3
* [`fb04c1e4`](https://github.com/NixOS/nixpkgs/commit/fb04c1e4b029560ec7233398cfc1df5d90cd9e4a) parsedmarc: 8.15.4 -> 8.16.0
* [`bf8aad39`](https://github.com/NixOS/nixpkgs/commit/bf8aad392c498ca4fb122c00c5eb7814cb9ed1a1) yafc-ce: 2.3.1 -> 2.4.0
* [`687be0d9`](https://github.com/NixOS/nixpkgs/commit/687be0d94e92ed3a6eeeafa15963922d68c02a78) python312Packages.awswrangler: 3.9.1 -> 3.10.1
* [`20847c0e`](https://github.com/NixOS/nixpkgs/commit/20847c0e357524a3252865ab34acd3b0e0737252) Revert "jellyfin-media-player: 1.10.1 -> 1.11.1"
* [`61cc7a31`](https://github.com/NixOS/nixpkgs/commit/61cc7a311a3fc5323e149b941bf08987818ad65f) xml2rfc: 3.24.0 -> 3.25.0
* [`7f07e847`](https://github.com/NixOS/nixpkgs/commit/7f07e847b3d18327e386d0d9d6cf262a10825709) python312Packages.mkdocs-drawio-exporter: 0.9.1 -> 0.10.1
* [`340016f9`](https://github.com/NixOS/nixpkgs/commit/340016f92aae2012c9b2bae783702bce6ba7c8e9) python312Packages.rotary-embedding-torch: 0.8.5 -> 0.8.6
* [`d62793a2`](https://github.com/NixOS/nixpkgs/commit/d62793a21854df347652d086be7512addbb33da2) python312Packages.meraki: 1.52.0 -> 1.53.0
* [`d15991ac`](https://github.com/NixOS/nixpkgs/commit/d15991ac20a4a3c7b2b796a18f318efc954fd4a1) python312Packages.amqp: 5.3.0 -> 5.3.1
* [`de9443a6`](https://github.com/NixOS/nixpkgs/commit/de9443a6ac753977cf69e87d253de424850275ad) python312Packages.logbook: 1.7.0.post0 -> 1.8.0
* [`fcea1379`](https://github.com/NixOS/nixpkgs/commit/fcea1379ec3e05f67e7d09da5a563b08aca0d667) xapian: 1.4.26 -> 1.4.27
* [`d95a8f5a`](https://github.com/NixOS/nixpkgs/commit/d95a8f5a13dda838574cd1cb6196b767cf596a3f) Document the logic around X-NotSocketActivated in the manual
* [`43300fe7`](https://github.com/NixOS/nixpkgs/commit/43300fe72a15df8c6199b1c7c93ca7cdbea39daa) nixos/qemu-vm: set permissions for tmpfs root
* [`7ca4fd40`](https://github.com/NixOS/nixpkgs/commit/7ca4fd4014f6fec2eef90dbb9ed5c7acca6ca02d) kubernetes-helmPlugins.helm-unittest: 0.6.3 -> 0.7.0
* [`e5caf0f8`](https://github.com/NixOS/nixpkgs/commit/e5caf0f862284c00c0cc58bc63fb379391ea4e8b) primitive: init 0-unstable-2020-05-04
* [`eb6ea54d`](https://github.com/NixOS/nixpkgs/commit/eb6ea54db50b5f381779c6edb806e251b1768aa6) zsh-you-should-use: modernize
* [`842c83c0`](https://github.com/NixOS/nixpkgs/commit/842c83c040f3620854bc094e7b186965149f19cd) zsh-you-should-use: adopt
* [`da186a65`](https://github.com/NixOS/nixpkgs/commit/da186a6585ca1d24abf1bf94daf8deb15686fb11) zsh-you-should-use: add update script
* [`98738252`](https://github.com/NixOS/nixpkgs/commit/98738252fb9cbf19354bab16793c43b56a791cb8) zsh-you-should-use: hardcode tput dependency
* [`22b6ee88`](https://github.com/NixOS/nixpkgs/commit/22b6ee8848bca70e6ceb81dd2c81e5db81c58aeb) jellyfin-media-player: 1.10.1 -> 1.11.1
* [`afa059a1`](https://github.com/NixOS/nixpkgs/commit/afa059a15ba28b5524399861d114909c35490cfc) jellyfin-media-player: added paumr as maintainer
* [`f8068598`](https://github.com/NixOS/nixpkgs/commit/f80685980500d9fa840cbf25a6e46e61845a808d) python3Packages.zephyr-python-api: modernize code
* [`640ef780`](https://github.com/NixOS/nixpkgs/commit/640ef7805e2a18bac4dce853860659a8120518c3) caper: init at 0.9
* [`f1bdc121`](https://github.com/NixOS/nixpkgs/commit/f1bdc1213bf0b68e2e5349c02e5a2450093fc757) headscale: backport BaseDomain and ServerURL checks
* [`e2ee66b9`](https://github.com/NixOS/nixpkgs/commit/e2ee66b98dfc32d846d2c9d5fe7d7bd0db156fea) kicad: 8.0.6 -> 8.0.7
* [`3cc811b0`](https://github.com/NixOS/nixpkgs/commit/3cc811b0ae6791341e50fe6154687ab155c7ea37) python312Packages.confluent-kafka: 2.5.3 -> 2.6.1
* [`aa36c775`](https://github.com/NixOS/nixpkgs/commit/aa36c7759ddb65fb8a39cc252b362e913038e432) maintainers: add kpcyrd
* [`c48576ab`](https://github.com/NixOS/nixpkgs/commit/c48576abb25aa008c68f783d2fdb4aa0ba25dcb1) python312Packages.numpy-stl: 3.1.2 -> 3.2.0
* [`afb2a27b`](https://github.com/NixOS/nixpkgs/commit/afb2a27b571cf3e9f2f1f18ef140a25766af9212) elastix: update homepage
* [`04998b35`](https://github.com/NixOS/nixpkgs/commit/04998b35c7c1182d818f171bf67372895514a801) python312Packages.python-utils: 3.9.0 -> 3.9.1
* [`aec3c5b2`](https://github.com/NixOS/nixpkgs/commit/aec3c5b26d18ce96a684077e7d22f2bc809899cf) python312Packages.aiosomecomfort: 0.0.26 -> 0.0.28
* [`2b6ab4d8`](https://github.com/NixOS/nixpkgs/commit/2b6ab4d819e8ecd13e64dcc2b3439297144b7fe5) mlflow-server: 2.18.0 -> 2.19.0
* [`fc202c4d`](https://github.com/NixOS/nixpkgs/commit/fc202c4d1be3d85eeb28b552eb5ea09bc2bc3a61) commitizen: 4.0.0 -> 4.1.0
* [`39ab44a5`](https://github.com/NixOS/nixpkgs/commit/39ab44a5666c67b06e9f42802cda6bc80dc77f51) extra-container: 0.12 -> 0.13
* [`c5fccf85`](https://github.com/NixOS/nixpkgs/commit/c5fccf85ab08a400ccec2bd8bd2848184bf64f6b) python312Packages.flask-limiter: 3.8.0 -> 3.9.2
* [`70cf61d8`](https://github.com/NixOS/nixpkgs/commit/70cf61d858ba1824e276914bfae0be8df8127d11) waydroid: fix 1.4.3
* [`7d4abac4`](https://github.com/NixOS/nixpkgs/commit/7d4abac4b50fa60e8239365965723d418b16a63b) vmware-guest: Don't use lib directly for maintainers
* [`178a1242`](https://github.com/NixOS/nixpkgs/commit/178a1242f7f8966c4c1d47c3892fe4026c119415) snowflake-cli: 3.1.0 -> 3.2.1
* [`f7a62ae1`](https://github.com/NixOS/nixpkgs/commit/f7a62ae15a735fe09446e6b23d0d73dbf212e341) mongoc: 1.29.0 -> 1.29.1
* [`2f453455`](https://github.com/NixOS/nixpkgs/commit/2f453455b74c34a6d9391f733faf1576c79ec37d) fluidd: 1.31.0 -> 1.31.2
* [`34e13b3a`](https://github.com/NixOS/nixpkgs/commit/34e13b3ace62cd2c2d1986ec1270a9f804bc9559) ocamlPackages.lacaml: 11.1.0 -> 11.1.1
* [`7484dc8f`](https://github.com/NixOS/nixpkgs/commit/7484dc8f19d63fe931f919bca969b5b30b18e9d9) python312Packages.aiolimiter: 1.1.0 -> 1.2.1
* [`bf2f6de3`](https://github.com/NixOS/nixpkgs/commit/bf2f6de39ded3be2c9e929f1081503dc936730a6) nixos/etc-activation: only assert for 6.6 kernel in switchable systems
* [`a1fde467`](https://github.com/NixOS/nixpkgs/commit/a1fde467e2f84bc6181f75eda866f51c6350507e) gcsfuse: 2.5.1 -> 2.6.0
* [`d8e0f79b`](https://github.com/NixOS/nixpkgs/commit/d8e0f79b4942fc6e70370dc90c18265d9fc933a5) python312Packages.elasticsearchdsl: 8.16.0 -> 8.17.0
* [`7c87ea18`](https://github.com/NixOS/nixpkgs/commit/7c87ea18820bfa3b65e9d883cc843206e2c53e60) megacmd: add darwin support
* [`33d4a53b`](https://github.com/NixOS/nixpkgs/commit/33d4a53bcbe432bdb4e9c160cf06af124a59ffbc) tsm-client: update support URLs
* [`2f85e967`](https://github.com/NixOS/nixpkgs/commit/2f85e9679c8c8974f85e4db9be9138134d539637) tsm-client: 8.1.24.0 -> 8.1.25.0
* [`db18211d`](https://github.com/NixOS/nixpkgs/commit/db18211d0f59b8c93412ff8dac0e4a448acc69f4) maintainers: add srv6d
* [`b0a3a9a5`](https://github.com/NixOS/nixpkgs/commit/b0a3a9a52f0ac9bef834a3e45d511776afe95aad) nixos/lib/eval-config: Add warning when masking pkgs
* [`7adae4d8`](https://github.com/NixOS/nixpkgs/commit/7adae4d89df03d9ba9b644cc5f8fa8c94d3a573e) python312Packages.py3status: 3.60 -> 3.61
* [`88a70296`](https://github.com/NixOS/nixpkgs/commit/88a702963c3788ec12c6d714b86a5d561c0cca59) python312Packages.pytapo: 3.3.32 -> 3.3.37
* [`1fdf59c3`](https://github.com/NixOS/nixpkgs/commit/1fdf59c3db6cf3fab7df2ec8bd3e37db351cd081) python312Packages.srsly: 2.4.8 -> 2.5.0
* [`6ce2a344`](https://github.com/NixOS/nixpkgs/commit/6ce2a3445a3262c1f59bb4c174e8b80d80072508) nixos-firewall-tool: cleanup script
* [`47bdb26b`](https://github.com/NixOS/nixpkgs/commit/47bdb26b653ed309251fb85a78c61174dc5f8dab) maintainers: add baongoc124
* [`26e66c53`](https://github.com/NixOS/nixpkgs/commit/26e66c536c5b223c8489c24af19245f7a3b8aa1b) Remove with lib from minimal profile; group config
* [`a8f9a8d1`](https://github.com/NixOS/nixpkgs/commit/a8f9a8d18febe4179defb145a7d426f4051e7694) python312Packages.netcdf4: 1.7.1.post2 -> 1.7.2
* [`67605d59`](https://github.com/NixOS/nixpkgs/commit/67605d59a035c573863b64184853ecd1a6bdea25) python312Packages.datalad: 1.1.4 -> 1.1.5
* [`bdbcc39e`](https://github.com/NixOS/nixpkgs/commit/bdbcc39e80562e850c0e59362d89f6f90ee95880) python312Packages.relatorio: 0.10.2 -> 0.11.1
* [`7ba86f50`](https://github.com/NixOS/nixpkgs/commit/7ba86f50b53a98f4795309f5e9189d7b726d902f) sunvox: 2.1.2 -> 2.1.2b
* [`cc9658d1`](https://github.com/NixOS/nixpkgs/commit/cc9658d1b5fc244e3b687fef9975ac560c1919c8) python312Packages.fake-useragent: 1.5.1 -> 2.0.3
* [`99d0b95e`](https://github.com/NixOS/nixpkgs/commit/99d0b95e66701ccf5197f355ee7d767fc348bc46) google-lighthouse: init at 12.3.0
* [`ad6ab5dc`](https://github.com/NixOS/nixpkgs/commit/ad6ab5dc3151c8c05a042e0f89c575f0ec406219) python312Packages.branca: 0.8.0 -> 0.8.1
* [`3fce2fee`](https://github.com/NixOS/nixpkgs/commit/3fce2feebedd74aae04a40aa16b88b2ddac6643c) python312Packages.superqt: 0.6.7 -> 0.7.0
* [`88e6208a`](https://github.com/NixOS/nixpkgs/commit/88e6208a0cc6e61e20db25a007c71fb407b25132) python312Packages.commoncode: 32.0.0 -> 32.1.0
* [`fdbfc823`](https://github.com/NixOS/nixpkgs/commit/fdbfc8232d795a2aa1e8bce5695c41b504561ec1) biboumi: add optional libraries (including PostgreSQL)
* [`62c70656`](https://github.com/NixOS/nixpkgs/commit/62c70656de9d776e093e2dbfdb7e39093ef96d8f) python312Packages.diff-cover: 9.2.0 -> 9.2.1
* [`3303ee19`](https://github.com/NixOS/nixpkgs/commit/3303ee196ec0685315d125a54afdf467da39d7a3) python312Packages.universal-pathlib: 0.2.5 -> 0.2.6
* [`762bd525`](https://github.com/NixOS/nixpkgs/commit/762bd5254795cc4a31a49e67ec1099dc85aa385d) python312Packages.djangorestframework-stubs: 3.15.1 -> 3.15.2
* [`7a8261d4`](https://github.com/NixOS/nixpkgs/commit/7a8261d47e8ed3dba12cdf20fd31167a0fb64e5d) python312Packages.pywikibot: 9.5.0 -> 9.6.1
* [`d2d7c27a`](https://github.com/NixOS/nixpkgs/commit/d2d7c27ae8f777467f2da16fd70d7a2239b399ff) maintainers: add hlad
* [`f831bafd`](https://github.com/NixOS/nixpkgs/commit/f831bafd7313465bbd85a32a8a140f88b070f799) obs-studio-plugins.obs-color-monitor: init at 0.8.2
* [`bc496012`](https://github.com/NixOS/nixpkgs/commit/bc49601256b5b07877ae4be1b26a5c2af53cbb26) python312Packages.fpdf2: 2.8.1 -> 2.8.2
* [`f507643f`](https://github.com/NixOS/nixpkgs/commit/f507643f36a391e5e713a1f00b35dda80188673a) python312Packages.httpx-ws: 0.6.2 -> 0.7.0
* [`54f369fa`](https://github.com/NixOS/nixpkgs/commit/54f369fab9768dca493a6a61e49a8136b8794608) maintainers: add dopplerian
* [`8758992d`](https://github.com/NixOS/nixpkgs/commit/8758992d5e231709b4a9e54f24c68090172f7d40) python312Packages.bitsandbytes: 0.44.1 -> 0.45.0
* [`891c3be9`](https://github.com/NixOS/nixpkgs/commit/891c3be903d1640b3efae4f4712280c7c9b2f4df) virtualisation/lxc: use system.build.image
* [`22255dde`](https://github.com/NixOS/nixpkgs/commit/22255ddec41b459f7f480ab6422ad10d0c4a98b7) installer/sd-image: use system.build.image...
* [`a582fba7`](https://github.com/NixOS/nixpkgs/commit/a582fba754216b8ae6cfc95a260fc5feefa6e20d) installer/iso-image: use system.build.image
* [`fdb144fb`](https://github.com/NixOS/nixpkgs/commit/fdb144fb411b31aa2829d00ccfc9ddafe3ccd0f6) ec2/amazon-image: use system.build.image
* [`e04d4cc0`](https://github.com/NixOS/nixpkgs/commit/e04d4cc0ea3b9ab403b3e5adfc17b8159fa496a8) openstack-image: use system.build.image
* [`53e68e04`](https://github.com/NixOS/nixpkgs/commit/53e68e04f271802fd98e509b284231eed6614a8d) openstack-image-zfs: use system.build.image
* [`63d0a4ea`](https://github.com/NixOS/nixpkgs/commit/63d0a4ea61bc694fa1607473ebafffb4025cc7a8) modules/netboot: add system.build.image for new kexecTarball
* [`48ec455a`](https://github.com/NixOS/nixpkgs/commit/48ec455ae83f6255b312d71918b3434bcd4609b2) virtualisation/disk-image: init
* [`e3347c19`](https://github.com/NixOS/nixpkgs/commit/e3347c19b376a7942ae19c4f219964776bb6e871) image/images: Add remaining image modules
* [`7eeb17d3`](https://github.com/NixOS/nixpkgs/commit/7eeb17d3eeeb135a6654f2d850ffb0a01ea90787) sympa: 6.2.72 -> 6.2.74
* [`7c81e1d5`](https://github.com/NixOS/nixpkgs/commit/7c81e1d58761b599cf2e39fc59cff5c855d7b08e) open-vm-tools: substituteInPlace use --replace-fail
* [`23ddc7b6`](https://github.com/NixOS/nixpkgs/commit/23ddc7b6e5e19e785b5936d98e7a966d0707868e) python312Packages.django-soft-delete: 1.0.14 -> 1.0.16
* [`463adcff`](https://github.com/NixOS/nixpkgs/commit/463adcffd4d4047e1dc21e9cab2cbbf9a2fd183c) nicotine-plus: 3.3.6 -> 3.3.7
* [`e5988ce1`](https://github.com/NixOS/nixpkgs/commit/e5988ce17bbaaa3886c380ceb6741ca9f7c381be) python312Packages.magicgui: 0.9.1 -> 0.10.0
* [`fb04895b`](https://github.com/NixOS/nixpkgs/commit/fb04895bee114cc25541e5b25b8aa4fd00953d6a) open-vm-tools: remove with lib
* [`fa24aa68`](https://github.com/NixOS/nixpkgs/commit/fa24aa68b98c7d577ab2467b3090786b19c03c9d) open-vm-tools: add missing license
* [`f6bb4417`](https://github.com/NixOS/nixpkgs/commit/f6bb4417aa9b86f4239666c3f16b02d16fb0c3a1) megasync: Wrap xorg.xrdb
* [`ddde8c0f`](https://github.com/NixOS/nixpkgs/commit/ddde8c0f6887dd443945b250fe3a4e252ccf25fa) sm64ex: unstable-2022-12-19 -> 0-unstable-2024-07-04
* [`739cd63a`](https://github.com/NixOS/nixpkgs/commit/739cd63aa626dd9bce65fc76bc1974e317346621) sm64ex: enable 60fps patch by default
* [`41d52682`](https://github.com/NixOS/nixpkgs/commit/41d526828f23ca7769e32d66d435bf6bd7a1b58f) sm64ex-coop: drop
* [`8248382f`](https://github.com/NixOS/nixpkgs/commit/8248382fdd6a43d36f4ae75a0c8d0521cc9f818c) sm64ex: migrate to pkgs/by-name
* [`1ea74e68`](https://github.com/NixOS/nixpkgs/commit/1ea74e68c8024ac8a316164e2991c0a1dd99cf5f) tor-browser: fix desktop icon
* [`75299a63`](https://github.com/NixOS/nixpkgs/commit/75299a638b82f877634a08bcc2f8b8cab392b2c8) usbredir: 0.13.0 -> 0.14.0
* [`f6f318be`](https://github.com/NixOS/nixpkgs/commit/f6f318bea594c8e814086c67078b33dc61dca9ee) python312Packages.google-cloud-dataproc: 5.12.0 -> 5.16.0
* [`c297586d`](https://github.com/NixOS/nixpkgs/commit/c297586d7cc3269c05970af3a5a38ca73d384fb3) python312Packages.pynitrokey: 0.6.0 -> 0.7.1
* [`ed5141d4`](https://github.com/NixOS/nixpkgs/commit/ed5141d4972872bdc39509106173cd9a3e63b0d1) python312Packages.ansitable: 0.11.3 -> 0.11.4
* [`fda14c3d`](https://github.com/NixOS/nixpkgs/commit/fda14c3dc025a18557d04feda75071dcae484795) pstoedit: 4.01 -> 4.02
* [`a01cab51`](https://github.com/NixOS/nixpkgs/commit/a01cab513a00540e688e97f887853f7af382222f) liblo: 0.31 -> 0.32
* [`7322145b`](https://github.com/NixOS/nixpkgs/commit/7322145b03415901e7bae78f770b141ec8c533b8) matio: avoid ac_cv_av_copy check to fix cross building
* [`6900d0cf`](https://github.com/NixOS/nixpkgs/commit/6900d0cf3eae266b3dc1dc2e88f09de3f3eb3f4a) nixos/biboumi: expose package for overriding
* [`a7e3b6a1`](https://github.com/NixOS/nixpkgs/commit/a7e3b6a1ae356b05ea80dea730f9b0887f2b2083) nixos/biboumi: update docs version
* [`3284305e`](https://github.com/NixOS/nixpkgs/commit/3284305eb31c89291fee4a1e17e97df7cbe820a3) allow the ability to skip the database
* [`bbc3d889`](https://github.com/NixOS/nixpkgs/commit/bbc3d88974b5afd99362c652fd2e58fb0d8949b4) last: 1592 -> 1607
* [`11c826d5`](https://github.com/NixOS/nixpkgs/commit/11c826d556b9881adfce377b5c5b06e6a417743a) python312Packages.google-cloud-dlp: 3.25.1 -> 3.26.0
* [`2b3bcc2b`](https://github.com/NixOS/nixpkgs/commit/2b3bcc2bbae375a60b21220a1d6e9b6a444ca47a) netmaker: 0.26.0 -> 0.30.0
* [`16152c78`](https://github.com/NixOS/nixpkgs/commit/16152c7848aaad2b316c377737d6abf098d14c77) netmaker-full: 0.26.0 -> 0.30.0
* [`53bcab7e`](https://github.com/NixOS/nixpkgs/commit/53bcab7eb37febc5ac9cc1a442d1451104a5f1b6) python312Packages.pydata-sphinx-theme: 0.16.0 -> 0.16.1
* [`15b41de2`](https://github.com/NixOS/nixpkgs/commit/15b41de20802563ec650a2010e5a36a8671de08c) libdeltachat: 1.151.6 -> 1.152.0
* [`7898b22e`](https://github.com/NixOS/nixpkgs/commit/7898b22eb6f8aeb48b73a261e91ebfc751f64ece) deltachat-desktop: 1.48.0 -> 1.50.0
* [`ab27e24a`](https://github.com/NixOS/nixpkgs/commit/ab27e24a78b47fafa4ea8f5db3d4d76526bab2eb) lug-helper: fix missing dependencies
* [`792b24aa`](https://github.com/NixOS/nixpkgs/commit/792b24aafeaefd7e6be6513da95ee4bc93f30a9a) hanko: init at 0.5.2
* [`40805f17`](https://github.com/NixOS/nixpkgs/commit/40805f17b405c02d83135bf3de15e8336990c45c) pdns: 4.9.2 -> 4.9.3
* [`d05d12c3`](https://github.com/NixOS/nixpkgs/commit/d05d12c3b1beba58e61e6ee96b4d97af9966ef7f) python312Packages.jianpu-ly: 1.801 -> 1.826
* [`bda27514`](https://github.com/NixOS/nixpkgs/commit/bda27514741adacab583711c7f209ce1e479d1ab) python312Packages.types-s3transfer: 0.10.2 -> 0.10.4
* [`2a2527f5`](https://github.com/NixOS/nixpkgs/commit/2a2527f59b6e3da964d7823c9ed40977a49fbe2b) python312Packages.cloudsmith-api: 2.0.13 -> 2.0.16
* [`18df25f7`](https://github.com/NixOS/nixpkgs/commit/18df25f754e6f2484107ced9424cf9da130db778) python312Packages.yark: 1.2.10 -> 1.2.12
* [`7512c886`](https://github.com/NixOS/nixpkgs/commit/7512c886a1b67be48a427d5f8eeb5a08f2373b96) xml-tooling-c: 3.2.4 -> 3.3.0
* [`a288bb9c`](https://github.com/NixOS/nixpkgs/commit/a288bb9c3e60c1d9cdaae530fd52fd826b414fe7) python312Packages.bandit: 1.7.10 -> 1.8.0
* [`a8e93c7e`](https://github.com/NixOS/nixpkgs/commit/a8e93c7ed85ecea310832af1e4a11072bfbc7a8b) spicedb: 1.38.1 -> 1.39.1
* [`304aca53`](https://github.com/NixOS/nixpkgs/commit/304aca53888f4d5a22de1c304f8210892657e929) python312Packages.linode-api: 5.22.0 -> 5.25.0
* [`526e858b`](https://github.com/NixOS/nixpkgs/commit/526e858b7221dad86780ee2b06b95b06cd3dd12f) gridtracker: 1.24.0104 -> 1.24.0922
* [`e8cf4d17`](https://github.com/NixOS/nixpkgs/commit/e8cf4d17e628aab86a6f898850b3885182c845f9) lhapdf: 6.5.4 -> 6.5.5
* [`712bb5b9`](https://github.com/NixOS/nixpkgs/commit/712bb5b97575c83d084aaaaa251ff64c0629921f) scite: 5.5.3 -> 5.5.4
* [`878be9c2`](https://github.com/NixOS/nixpkgs/commit/878be9c20b2876cc364534dead058c09a46225a7) Address review feedback: Attempt to fix wonky indentation
* [`bc1cfec9`](https://github.com/NixOS/nixpkgs/commit/bc1cfec92030da8d95deb0e46fcf095b7a3e3918) Address review feedback: It's "configuration switch"
* [`ac77cf7e`](https://github.com/NixOS/nixpkgs/commit/ac77cf7e6aae9215b902213d4da442efef4d89b8) kclvm_cli: 0.10.8 -> 0.11.0
* [`63c1ea97`](https://github.com/NixOS/nixpkgs/commit/63c1ea97a19f189387cc0056ef24b4c4e76a8002) ndpi: 4.10 -> 4.12
* [`d9434769`](https://github.com/NixOS/nixpkgs/commit/d9434769daf66288f834042bcffbe6148d6c6dcc) pt2-clone: 1.71 -> 1.72
* [`d9abdb3b`](https://github.com/NixOS/nixpkgs/commit/d9abdb3bb0e9cbce418bc1a70691d60901501050) sentry-native: 0.7.16 -> 0.7.17
* [`a7bee591`](https://github.com/NixOS/nixpkgs/commit/a7bee5911ccdbf0bce2cf21296e43a3694642ff1) jellyseerr: migrate to by-name
* [`17f32f37`](https://github.com/NixOS/nixpkgs/commit/17f32f37425f7bbe6719f3c8c36320c5483178fb) pinentry-rofi: add rofi and coreutils to runtime PATH
* [`28765958`](https://github.com/NixOS/nixpkgs/commit/28765958d2d4aeb14a6687b60d2ffa735b816e6f) nextcloudXXPackages.apps.recognize: use lib.{getExe,getDev},
* [`361a9f0f`](https://github.com/NixOS/nixpkgs/commit/361a9f0f94b592f9a764a92aa58c72c3db28599c) cli11: 2.3.2 -> 2.4.2
* [`802a0aca`](https://github.com/NixOS/nixpkgs/commit/802a0aca8d7fdec58710cf0cdc55d83ccc2707f6) regripper: fix perl libs not in path
* [`5613d83b`](https://github.com/NixOS/nixpkgs/commit/5613d83ba6753d6a50a641dcb894b5b2d01f9dfa) regripper: 0-unstable-2024-11-02 -> 0-unstable-2024-12-12
* [`0bcffe70`](https://github.com/NixOS/nixpkgs/commit/0bcffe70b7d7b5662f8e8b748cfcafd054c2758f) apk-tools: 2.14.5 -> 2.14.7
* [`b9d800d4`](https://github.com/NixOS/nixpkgs/commit/b9d800d46814e44db4d0a0104141aeb54e0c3c9a) workflows/eval: Request reviews from changed package maintainers
* [`b844cba4`](https://github.com/NixOS/nixpkgs/commit/b844cba4e6fcac4c4ceef81e481a5f93a01e4631) workflows/eval: Use maintainer GitHub IDs for review requests of changed packages
* [`47095676`](https://github.com/NixOS/nixpkgs/commit/470956763783e67a2c24130bcb1dfa34b6284f68) cairo-lang: 2.8.5 -> 2.9.2
* [`9289b2b9`](https://github.com/NixOS/nixpkgs/commit/9289b2b9ffc447590a796241074df8364d95a905) dune_3: 3.17.0 -> 3.17.1
* [`b20ab0c3`](https://github.com/NixOS/nixpkgs/commit/b20ab0c38e043b8590e973582cad1c9c086082f1) gi-crystal: 0.22.2 -> 0.24.0
* [`f3ffbef1`](https://github.com/NixOS/nixpkgs/commit/f3ffbef1da7bcdebdbd9e4170618de451336ce5f) asdf-vm: 0.14.1 -> 0.15.0
* [`4680d11d`](https://github.com/NixOS/nixpkgs/commit/4680d11d112fbce66bab5ab893b0177c5e005c48) clightning: 24.11 -> 24.11.1
* [`03feacca`](https://github.com/NixOS/nixpkgs/commit/03feaccae82ae21f91beaa41222958979b4fd90c) soapui: 5.7.2 -> 5.8.0
* [`31666700`](https://github.com/NixOS/nixpkgs/commit/31666700b5545aa98a23dbc70bd3e43bc3576e4d) flowblade: 2.16.3 -> 2.18
* [`941c3b20`](https://github.com/NixOS/nixpkgs/commit/941c3b20ba257c3092afd04c5b9dfd40e7f257e5) imgproxy: 3.26.1 -> 3.27.0
* [`dcf68b3b`](https://github.com/NixOS/nixpkgs/commit/dcf68b3b5d9367dc335e7e4ce7a74bd9eee55d88) flirt: Add update script using nix-update
* [`3aa17d16`](https://github.com/NixOS/nixpkgs/commit/3aa17d16b9b307357c320c1b7f53b4a2fc1ac8f2) telepresence2: 2.20.3 -> 2.21.1
* [`749a30e1`](https://github.com/NixOS/nixpkgs/commit/749a30e19a15750306362eaf3b8d97bd038f69fe) vscode-extensions.sourcery.sourcery: 1.25.0 -> 1.27.0
* [`5cc5a003`](https://github.com/NixOS/nixpkgs/commit/5cc5a0037431b8441923f89c7b1bc033d34495e7) databricks-cli: 0.236.0 -> 0.237.0
* [`2ab54fcb`](https://github.com/NixOS/nixpkgs/commit/2ab54fcb48c044c8238225a02505b93c22835601) marimo: 0.9.27 -> 0.10.5
* [`0bcf3d7e`](https://github.com/NixOS/nixpkgs/commit/0bcf3d7e2f98d5d08ad7af44cd49bff2d5f519f8) argc: 1.21.1 -> 1.22.0
* [`3d0bc79b`](https://github.com/NixOS/nixpkgs/commit/3d0bc79b383e29399bc3b49596e797166ca94017) trezor-suite: 24.11.3 -> 24.12.3
* [`75a9c0da`](https://github.com/NixOS/nixpkgs/commit/75a9c0daaec9dfa68d2fd8885bc95283f377d366) python3Packages.rioxarray: fix tests with rasterio 1.4.3
* [`9067d72e`](https://github.com/NixOS/nixpkgs/commit/9067d72efde7e849db51737475490ec53ca9a242) kitsas: 5.7 -> 5.8
* [`597310d6`](https://github.com/NixOS/nixpkgs/commit/597310d63f9985791ae8ad532aaf6d326e1c4df7) nghttp3: 1.6.0 -> 1.7.0
* [`1e23b095`](https://github.com/NixOS/nixpkgs/commit/1e23b095f9ea771e4d08e93d48c607fd1aa78fcf) sfcgal: update patch to build process
* [`7d908a04`](https://github.com/NixOS/nixpkgs/commit/7d908a042e908f1aeca65916212a886040c11479) sfcgal: add geospatial team to the maintainers
* [`f1262d55`](https://github.com/NixOS/nixpkgs/commit/f1262d559522a2dd91185c85036a230127706eb1) carapace: 1.1.0 -> 1.1.1
* [`5ade7d90`](https://github.com/NixOS/nixpkgs/commit/5ade7d90224094fd0bc1457ffc6cdfd703c40f57) pvs-studio: disable automatic updates
* [`10ad08d0`](https://github.com/NixOS/nixpkgs/commit/10ad08d0772271aa5f0b34407e53f67e44ae467a) docker: 27.4.0 -> 27.4.1
* [`dc95f035`](https://github.com/NixOS/nixpkgs/commit/dc95f0356bbd8250f9ce4936f6952b26a6ba76da) cloudflared: 2024.11.1 -> 2024.12.2
* [`54d0eb38`](https://github.com/NixOS/nixpkgs/commit/54d0eb383b8d09693c871d75477e371cd80cec5a) python312Packages.awscrt: 0.23.0 -> 0.23.6
* [`5d4e2e5d`](https://github.com/NixOS/nixpkgs/commit/5d4e2e5d2c864a2db001651b6b379a8151ec9b1b) jbang: 0.121.0 -> 0.122.0
* [`5736cebc`](https://github.com/NixOS/nixpkgs/commit/5736cebc5c14b9596a6be0cdd586ae4b8a32f036) prowlarr: 1.26.1.4844 -> 1.28.2.4885
* [`edde5545`](https://github.com/NixOS/nixpkgs/commit/edde55453f3aa5d98eef33fc9f07f8ce960abfb8) rednotebook: 2.36 -> 2.37
* [`099cca9d`](https://github.com/NixOS/nixpkgs/commit/099cca9d2dc55797ca0380d52df46dbe592fc05c) remmina: 1.4.36 -> 1.4.37
* [`a79e449d`](https://github.com/NixOS/nixpkgs/commit/a79e449d58fe1edf854dbe731aceccdc98e83814) eslint_d: 14.2.2 -> 14.3.0
* [`4acd290b`](https://github.com/NixOS/nixpkgs/commit/4acd290bdcd1ca7a20c431d89d83b85778f68e50) kicad-small: 8.0.6 -> 8.0.7
* [`e9b1c813`](https://github.com/NixOS/nixpkgs/commit/e9b1c813e3a78437d8c9f133e9ce11f300aa7d39) lilypond-unstable: 2.25.21 -> 2.25.22
* [`c89fcd0e`](https://github.com/NixOS/nixpkgs/commit/c89fcd0e45ffc142c4f32f428a4ec5267b817203) maintainers: add l1npengtul
* [`ac0da457`](https://github.com/NixOS/nixpkgs/commit/ac0da457b49e3cf199d3aec63e0590f09aec1162) jitsi-meet-prosody: 1.0.8242 -> 1.0.8302
* [`0d83cbce`](https://github.com/NixOS/nixpkgs/commit/0d83cbce808e840b1ef15a33e89892135d24ee79) tanka: 0.30.2 -> 0.31.0
* [`22658738`](https://github.com/NixOS/nixpkgs/commit/226587381bac07f7d518b5f6c313fdce7ed7794b) jjui: Add update script using nix-update
* [`c951613d`](https://github.com/NixOS/nixpkgs/commit/c951613d3cb3d61b14c890238017d0685ff359f9) jjui: 0-unstable-2024-12-10 -> 0.1
* [`a07e0e87`](https://github.com/NixOS/nixpkgs/commit/a07e0e87bad14a95e3d262f419a6e5c24a6a08d6) cargo-binstall: 1.10.16 -> 1.10.17
* [`0fc37050`](https://github.com/NixOS/nixpkgs/commit/0fc370504fd21c2866551ce8d7f31fb80d61422d) python312Packages.panel: 1.5.1 -> 1.5.5
* [`7c9c25ed`](https://github.com/NixOS/nixpkgs/commit/7c9c25edc1aaa9481a5f0e47f82ff6c8c51b6baf) python312Packages.strawberry-graphql: 0.253.1 -> 0.254.0
* [`db3e62b1`](https://github.com/NixOS/nixpkgs/commit/db3e62b1f2f351bd31478fc3067a9de415d58a40) python312Packages.num2words: 0.5.13 -> 0.5.14
* [`ae97e961`](https://github.com/NixOS/nixpkgs/commit/ae97e9612f8faf83bb727da66e87ca2a1f8c7e6b) famistudio: move to finalAttrs
* [`f68400f3`](https://github.com/NixOS/nixpkgs/commit/f68400f3daf459304d0af6ed62641cb3e1e3207e) ocamlPackages.higlo: 0.9 -> 0.10.0
* [`2c640658`](https://github.com/NixOS/nixpkgs/commit/2c640658308eda0bf18a9cfebb0b79ba58d4cbe8) taproot-assets: 0.4.1 -> 0.5.0
* [`40086fb0`](https://github.com/NixOS/nixpkgs/commit/40086fb0ea36cb4917cf3fbf0449bd8896ad6aa3) nixos/networkd: add RequestAddress to network sectionDHCPv4
* [`21e85783`](https://github.com/NixOS/nixpkgs/commit/21e85783e0732486f9052b18b4124d511680804e) louvre: 2.9.0-1 -> 2.13.0-1
* [`0a5de06f`](https://github.com/NixOS/nixpkgs/commit/0a5de06f6ff57c4937fed7dff2b8ca4fe65305aa) gfold: 4.5.1 -> 4.6.0
* [`0360d59d`](https://github.com/NixOS/nixpkgs/commit/0360d59d0f4596509bfe3ea9abefcceae0dcf926) healthchecks: 3.8 -> 3.9
* [`a7b23c8d`](https://github.com/NixOS/nixpkgs/commit/a7b23c8dc4efae88aba9cd972aa30ee21fc5f62a) subtitlecomposer: ffmpeg_6 as dependency
* [`5f0d21d9`](https://github.com/NixOS/nixpkgs/commit/5f0d21d9e7ed72fd6ce29042fcec637ecbbdf5f8) firefox: extend compile flag "--enable-lto=cross" with parameter "full"
* [`976ec244`](https://github.com/NixOS/nixpkgs/commit/976ec244339e39e63b3297ae7941f55de281a948) matomo: 5.2.0 -> 5.2.1
* [`cf37a496`](https://github.com/NixOS/nixpkgs/commit/cf37a496573ba6590f580702580e8d17b7531c43) zoekt: 3.7.2-2-unstable-2024-12-09 -> 3.7.2-2-unstable-2024-12-18
* [`15eafd03`](https://github.com/NixOS/nixpkgs/commit/15eafd036bae7c7fa19f322bd55a014f8c06e586) Fixed the Monica email configuration bug
* [`a21e4fa9`](https://github.com/NixOS/nixpkgs/commit/a21e4fa9e0773cdb937a492a60a3207eb231f0cc) restic: fixed handling of arguments with spaces in restic wrappers
* [`62659a8c`](https://github.com/NixOS/nixpkgs/commit/62659a8ca7bba5d151365ff641b74439181725c0) jdt-language-server: 1.42.0 -> 1.43.0
* [`e9e1d145`](https://github.com/NixOS/nixpkgs/commit/e9e1d145f6e6da36d743619704aa8e1eed14704b) nixos/fontdir: fix X11-fonts cross compilation
* [`e344f839`](https://github.com/NixOS/nixpkgs/commit/e344f839716f022bb48c68789c6bff327307e5ae) tinygo: 0.34.0 -> 0.35.0
* [`7e80b735`](https://github.com/NixOS/nixpkgs/commit/7e80b7355b8698e522383dff6710c7d51aab12c4) noseyparker: 0.21.0 -> 0.22.0
* [`02e0722c`](https://github.com/NixOS/nixpkgs/commit/02e0722c208a36b81796f8e3e27c1e6f2ddd45f8) ostree-full: 2024.8 -> 2024.10
* [`42df0b49`](https://github.com/NixOS/nixpkgs/commit/42df0b494b2e4d60a755488a6b7a333235c29458) {itk_5_2, python312Packages.itk}: unbreak by disabling RTK cmake module
* [`c3a2bcbd`](https://github.com/NixOS/nixpkgs/commit/c3a2bcbdc866113228687c175ea99c6be2779c6e) numbat: unbreak on darwin
* [`a693796e`](https://github.com/NixOS/nixpkgs/commit/a693796eb0c2bf350a2c5932d4d7361a8f001a6e) python312Packages.meshtastic: 2.5.5 -> 2.5.6post1
* [`f14218fa`](https://github.com/NixOS/nixpkgs/commit/f14218fa9056e57f01f7113fbe0b9215aceb6e88) kaidan: 0.9.2 -> 0.10.1
* [`73888229`](https://github.com/NixOS/nixpkgs/commit/73888229b960e47d3d44b25df4ec713b974ea034) kak-tree-sitter-unwrapped: 1.1.2 -> 1.1.3
* [`91fa1ae9`](https://github.com/NixOS/nixpkgs/commit/91fa1ae9f21d8914801e0f7fcff228d0d47cf612) gnuplot: 6.0.1 -> 6.0.2
* [`41fe8d27`](https://github.com/NixOS/nixpkgs/commit/41fe8d27061c9d0ac3db30dcfe59ec6ac762bb28) peergos: 0.21.0 -> 0.22.0
* [`3e4c8d33`](https://github.com/NixOS/nixpkgs/commit/3e4c8d33b5a0d00f61637c65dcb7bb671559015e) jitsi-videobridge: 2.3-174-gd011ddf7 -> 2.3-187-gc7ef8e66
* [`b431444b`](https://github.com/NixOS/nixpkgs/commit/b431444b9c3dd754fd88783dc4ab0977657f624c) python312Packages.sumo: 2.3.9 -> 2.3.10
* [`4083d721`](https://github.com/NixOS/nixpkgs/commit/4083d721929d5594a0633bb417469aab47cd2e08) itk: 5.4.0 -> 5.4.1
* [`1987668c`](https://github.com/NixOS/nixpkgs/commit/1987668c4b06162d5fb751bf1fbd2751db90eef7) cargo-lambda: 1.5.0 -> 1.6.1
* [`334a9bd0`](https://github.com/NixOS/nixpkgs/commit/334a9bd0b269b616fbc33a6f7c02470ebc4b8efd) rwalk: init at 0.8.7
* [`ab94430a`](https://github.com/NixOS/nixpkgs/commit/ab94430a32417f36104660412d2e7742847b1303) kickstart: 0.4.0 -> 0.5.0
* [`1ad7b8d1`](https://github.com/NixOS/nixpkgs/commit/1ad7b8d1293fa3fe9ed89bcb6c19374622bfc293) zxtune: 5080 -> 5081
* [`226fc838`](https://github.com/NixOS/nixpkgs/commit/226fc8388b008f660cc94351a3c2c5236689ace4) yourkit-java: 2024.9-b160 -> 2024.9-b161
* [`efe29687`](https://github.com/NixOS/nixpkgs/commit/efe29687afdb726ace952caf9a015427da9afea6) maintainers: add stevestreza
* [`fe0501f4`](https://github.com/NixOS/nixpkgs/commit/fe0501f48683d0377028f2abfa744bf713c8d9a5) python312Packages.fakeredis: 2.26.1 -> 2.26.2
* [`4d4e9f6a`](https://github.com/NixOS/nixpkgs/commit/4d4e9f6ae91194849aecb191e1954b25fd54ce78) zrok: 0.4.44 -> 0.4.45
* [`73feb781`](https://github.com/NixOS/nixpkgs/commit/73feb7813e3754b07aa0fe0ca6100783de97db8e) graphite-cli: 1.4.8 -> 1.4.11
* [`cb0f1faf`](https://github.com/NixOS/nixpkgs/commit/cb0f1fafa83dd30199cbeb6e58a7de4904b8dce2) wrangler: add updateScript
* [`2de7b67e`](https://github.com/NixOS/nixpkgs/commit/2de7b67eec963916a26d369d987d55983d85458e) lens-desktop: 2024.3.191333 -> 2024.11.261604
* [`c781dc91`](https://github.com/NixOS/nixpkgs/commit/c781dc915a88ed79a18be9aacbd249fa3ee4e4be) fix: formatting
* [`a1454eb2`](https://github.com/NixOS/nixpkgs/commit/a1454eb28ccee7619a33da83ea35b5109e0319ba) archivemount: 1 -> 1a
* [`8d2e6511`](https://github.com/NixOS/nixpkgs/commit/8d2e6511ca280087619e8692fc2eb5ce9b353d2a) overturemaps: 0.11.0 -> 0.12.0
* [`7f12e53e`](https://github.com/NixOS/nixpkgs/commit/7f12e53e88ed2c31f59fbde03722dcc6fb9c0d96) protonmail-desktop: 1.6.0 -> 1.6.1
* [`3fd20a94`](https://github.com/NixOS/nixpkgs/commit/3fd20a94c0f21d9de73f4c58e10badb27e8ea296) python312Packages.pytorch: just disable -Werror; fix darwin x64 build
* [`57c9e834`](https://github.com/NixOS/nixpkgs/commit/57c9e83452f99bd823d971351197406303a5e8ff) rocmPackages_5.rocm-docs-core: 1.8.2 -> 1.12.0
* [`7aea8294`](https://github.com/NixOS/nixpkgs/commit/7aea8294a56a0c593d85703bdcacdad9aee3dead) rocmPackages.rocm-docs-core: 1.11.0 -> 1.12.0
* [`f0030485`](https://github.com/NixOS/nixpkgs/commit/f0030485c0675f29330df96914e37f6c4f65849a) emacsPackages.voicemacs: 0-unstable-2024-10-11 -> 0-unstable-2024-12-11
* [`16f79979`](https://github.com/NixOS/nixpkgs/commit/16f7997902bade385fc3928c9b377552c7940e1b) papermc: 1.21.4-12 -> 1.21.4-15
* [`729a6c72`](https://github.com/NixOS/nixpkgs/commit/729a6c72f9e74a162f063b95626eee3ba5229d6d) libdwarf-lite: 0.11.0 -> 0.11.1
* [`4f6c1008`](https://github.com/NixOS/nixpkgs/commit/4f6c1008f34237bb1c33af6be17ee23ec6d0ad92) ansel: 0-unstable-2024-10-28 -> 0-unstable-2024-12-19
* [`ee0612a9`](https://github.com/NixOS/nixpkgs/commit/ee0612a9fa08674e9f779f9fb2150fcbd2f8f9ec) maintainers: add cything
* [`4a0e3ff8`](https://github.com/NixOS/nixpkgs/commit/4a0e3ff8447026a78fb0c67a20f4557351c7173e) zsh-prezto: 0-unstable-2024-06-03 -> 0-unstable-2024-12-12
* [`aa32a2b5`](https://github.com/NixOS/nixpkgs/commit/aa32a2b58bb8c14c72be2221e9f246a05687fd14) python312Packages.cantools: 39.4.13 -> 40.0.0
* [`38ce7109`](https://github.com/NixOS/nixpkgs/commit/38ce7109ae94c4d32b6a010a9cc743a9682f667d) jicofo: 1.0-1104 -> 1.0-1117
* [`8f16c8fc`](https://github.com/NixOS/nixpkgs/commit/8f16c8fc389ffd59a2a90e0784da135fbfc7632f) jackett: 0.22.1064 -> 0.22.1109
* [`03589ed5`](https://github.com/NixOS/nixpkgs/commit/03589ed5bf9f8db99fd9d705c9aeabdab24af6f0) etesync-dav: 0.33.4 -> 0.33.6
* [`8616d6d6`](https://github.com/NixOS/nixpkgs/commit/8616d6d65ce3e1ba450aad60f25952895e8b35b1) lxd-ui: 0.14 -> 0.15
* [`e94b558c`](https://github.com/NixOS/nixpkgs/commit/e94b558c5c775df08af57edaa66e2e2e26e8feb6) python3Packages.tinytag: 1.10.4 -> 2.0.0
* [`69dcf863`](https://github.com/NixOS/nixpkgs/commit/69dcf863ba341e3e0af1b7c48c082469cfd744d7) sundials: 7.2.0 -> 7.2.1
* [`39a3cf0b`](https://github.com/NixOS/nixpkgs/commit/39a3cf0bab47848e7d70dbf7ae68e36c97a86f22) weaviate: 1.28.0 -> 1.28.2
* [`317967e3`](https://github.com/NixOS/nixpkgs/commit/317967e32f7b824739d5b7191792fc4ee0aa0138) bngblaster: 0.9.13 -> 0.9.14
* [`63148938`](https://github.com/NixOS/nixpkgs/commit/6314893899dea79c294fe312c94867ed265a1170) clusterctl: 1.9.0 -> 1.9.2
* [`26f16670`](https://github.com/NixOS/nixpkgs/commit/26f1667071631ec68a994418fbfa386f95bca484) ibus-engines.typing-booster-unwrapped: 2.26.12 -> 2.27.1
* [`5fd0c7d2`](https://github.com/NixOS/nixpkgs/commit/5fd0c7d23f25c9478a7e7bcc1446d07c75172192) xpra: 6.2.1 -> 6.2.2
* [`ca31e178`](https://github.com/NixOS/nixpkgs/commit/ca31e178104800e1364f1df79932e187c5f1ff0a) lgogdownloader: 3.15 -> 3.16
* [`340e51e1`](https://github.com/NixOS/nixpkgs/commit/340e51e1e7cd8407053fc4c22ffe3e3df9b478a1) prometheus-nextcloud-exporter: 0.7.0 -> 0.8.0
* [`2c0b8428`](https://github.com/NixOS/nixpkgs/commit/2c0b84284157dd15073500dd73316b7299502030) package-project-cmake: 1.12.0 -> 1.13.0
* [`5e0eaf68`](https://github.com/NixOS/nixpkgs/commit/5e0eaf68ab71432fb5e567f2cba1a6e7e2261c53) pgmodeler: 1.1.5 -> 1.1.6
* [`4bdb7481`](https://github.com/NixOS/nixpkgs/commit/4bdb74811ea2b24688e5995e004c47444a905d0b) nextcloudXXPackages.apps.recognize: add meta.description
* [`9468b63e`](https://github.com/NixOS/nixpkgs/commit/9468b63e4c0129a1a95b061a996a6994b6469a22) adms: enable on darwin
* [`0bd44ede`](https://github.com/NixOS/nixpkgs/commit/0bd44ede0a2235afaacefbd63fe56670e1654fe8) qucs-s: enable on darwin
* [`256577c3`](https://github.com/NixOS/nixpkgs/commit/256577c3605c4e7e46af3c8f62b333b0038298ce) qucsator-rf: enable on darwin
* [`6a28bdc3`](https://github.com/NixOS/nixpkgs/commit/6a28bdc3519072a587513fa92de50ef2dde9ce25) linuxPackages_latest.prl-tools: 20.1.2-55742 -> 20.1.3-55743
* [`854f0111`](https://github.com/NixOS/nixpkgs/commit/854f0111d37e93dd870035c5512d3d2fbaee6e5e) rquickshare: fix opening
* [`b7c1e20c`](https://github.com/NixOS/nixpkgs/commit/b7c1e20c24f27e228cf283c92460285cfd6276cd) bookstack: 24.10.3 -> 24.12
* [`9264594e`](https://github.com/NixOS/nixpkgs/commit/9264594e44466d7aa8fb40838b7aa3bb176875ca) ayatana-indicator-sound: 24.5.0 -> 24.5.1
* [`d0c1c288`](https://github.com/NixOS/nixpkgs/commit/d0c1c2885b980cec2fb4f1e66e258949b39c1a22) gotrue-supabase: 2.165.1 -> 2.166.0
* [`57ed908d`](https://github.com/NixOS/nixpkgs/commit/57ed908d011454a845340df81cde77027fd02bf0) treesheets: 0-unstable-2024-12-11 -> 0-unstable-2024-12-22
* [`5c5fab76`](https://github.com/NixOS/nixpkgs/commit/5c5fab76c211ed71132cd71657cc69f260e8b0c0) qbittorrent-enhanced-nox: 5.0.2.10 -> 5.0.3.10
* [`59020cac`](https://github.com/NixOS/nixpkgs/commit/59020cac7545401603f906b1a2809c080d280426) python312Packages.scikit-posthocs: 0.11.1 -> 0.11.2
* [`2723f906`](https://github.com/NixOS/nixpkgs/commit/2723f90663031476cc02126b8ea3239c14e6e725) gren: 0.4.5 -> 0.5.2
* [`ab13e834`](https://github.com/NixOS/nixpkgs/commit/ab13e8340b1be2c34050424b58120f6b2ad1d346) ox: 0.7.2 -> 0.7.5
* [`62558150`](https://github.com/NixOS/nixpkgs/commit/62558150fc964871d9d443455220ad1371479c03) vgm2x: 0-unstable-2024-12-11 -> 0-unstable-2024-12-13
* [`41d38a5a`](https://github.com/NixOS/nixpkgs/commit/41d38a5aa5629562a424717665f3349c5fc1f27a) alsa-utils: 1.2.12 -> 1.2.13
* [`1680fa9a`](https://github.com/NixOS/nixpkgs/commit/1680fa9aef299f44597799dda410556ae1b3d7eb) tegola: 0.20.0 → 0.21.0
* [`baaca5dd`](https://github.com/NixOS/nixpkgs/commit/baaca5ddd85ad58c04322364a2be0ac532f47667) kube-bench: 0.9.3 -> 0.9.4
* [`1aa29a64`](https://github.com/NixOS/nixpkgs/commit/1aa29a6462e19b1b24b902de306cb5b82d3deacf) shadps4: 0.4.0-unstable-2024-12-08 -> 0.4.0-unstable-2024-12-23
* [`09332bf9`](https://github.com/NixOS/nixpkgs/commit/09332bf97c98e1da7f9e1313b8739257934df701) spring-boot-cli: 3.4.0 -> 3.4.1
* [`5b4ea980`](https://github.com/NixOS/nixpkgs/commit/5b4ea980e508a0bb6ad2b122f16142d97f44644f) tutanota-desktop: 253.241203.1 -> 259.241223.0
* [`b48c91db`](https://github.com/NixOS/nixpkgs/commit/b48c91dbe89484470a75f62db2e3d96ed095f4c3) ejabberd: 24.10 -> 24.12
* [`3517b02d`](https://github.com/NixOS/nixpkgs/commit/3517b02dcef6a2c6912b3f10948759740d28dfaf) ltex-ls-plus: 18.3.0 -> 18.4.0
* [`8cd53510`](https://github.com/NixOS/nixpkgs/commit/8cd53510161e46a0c15e1352013c3263fcda1164) pluto: 5.20.3 -> 5.21.0
* [`2390145e`](https://github.com/NixOS/nixpkgs/commit/2390145ef5177b24d65d1afa32c52b18265d593a) xq-xml: 1.2.5 -> 1.3.0
* [`f8dca931`](https://github.com/NixOS/nixpkgs/commit/f8dca9319b78cb6973734b659e1febac1e7e6f47) lcm: 1.5.0 -> 1.5.1
* [`2c8cda52`](https://github.com/NixOS/nixpkgs/commit/2c8cda529a4789648c086d3210a48ebd7673e62f) grails: 6.2.2 -> 7.0.0-M1
* [`4780e19c`](https://github.com/NixOS/nixpkgs/commit/4780e19ce0c2e4980ec50c78d0f531dd25f4384a) intel-gpu-tools: 1.29 -> 1.30
* [`ed0277da`](https://github.com/NixOS/nixpkgs/commit/ed0277da033d319596b4a3431532741b0def4c02) bosh-cli: 7.8.2 -> 7.8.5
* [`f9be289a`](https://github.com/NixOS/nixpkgs/commit/f9be289a7645ff3b73666197de0e82454813a384) glooctl: 1.18.0 -> 1.18.2
* [`2f50751f`](https://github.com/NixOS/nixpkgs/commit/2f50751f439a46a0096e6cf5175a79888ef1caa7) tangara-cli: init at 0.4.3
* [`d8476da2`](https://github.com/NixOS/nixpkgs/commit/d8476da2c795dc495581c9b9978272957c68bbf7) goose: 3.23.1 -> 3.24.0
* [`5c5d7df9`](https://github.com/NixOS/nixpkgs/commit/5c5d7df9cfc6cf6ecffe2c847fead30aa7b87cc0) tenv: 3.2.11 -> 4.0.3
* [`aa1d45dc`](https://github.com/NixOS/nixpkgs/commit/aa1d45dc665330c7647aede5684f34a6497ecfaa) turnon: 1.6.2 -> 2.0.0
* [`e52ed6ee`](https://github.com/NixOS/nixpkgs/commit/e52ed6eeb1b7ba147d5bbc1db64393128ce32218) rattler-build: 0.32.1 -> 0.33.1
* [`e19c22f9`](https://github.com/NixOS/nixpkgs/commit/e19c22f9f71b4307d9564883323b8281ede226aa) python312Packages.pyinstaller-hooks-contrib: 2024.10 -> 2024.11
* [`c1eba5ed`](https://github.com/NixOS/nixpkgs/commit/c1eba5edbbc7d4044b04b6090efa85b76d58453e) trunk: 0.21.4 -> 0.21.5
* [`67bfb722`](https://github.com/NixOS/nixpkgs/commit/67bfb72264075930841bfe7c7060659a81bf5daa) terraform-ls: 0.36.2 -> 0.36.3
* [`0f03ddbd`](https://github.com/NixOS/nixpkgs/commit/0f03ddbdf04d2848f833dea0fd2a1f26f36b312f) istioctl: 1.24.1 -> 1.24.2
* [`7d992547`](https://github.com/NixOS/nixpkgs/commit/7d9925471fa1574c75ca5311d98504ca31f6120a) grafana-loki: 3.3.1 -> 3.3.2
* [`a9db27f0`](https://github.com/NixOS/nixpkgs/commit/a9db27f07c8e6c2222009aacbe047a18dc5d4b09) prometheus-mongodb-exporter: 0.43.0 -> 0.43.1
* [`0bf195b4`](https://github.com/NixOS/nixpkgs/commit/0bf195b49d90eb1da873705abb15024bc22cca9a) dust: unpin apple-sdk
* [`155d71f7`](https://github.com/NixOS/nixpkgs/commit/155d71f72093127195b28971c5941e3ff6b82454) weaver: unpin apple-sdk
* [`df1929fb`](https://github.com/NixOS/nixpkgs/commit/df1929fb16c1ef91150c393f4080c9af341fcae7) stats: 2.11.21 -> 2.11.22
* [`1a5d3324`](https://github.com/NixOS/nixpkgs/commit/1a5d332428e41701cd0c5d544815190b6c48a2ac) python312Packages.databricks-sql-connector: 3.6.0 -> 3.7.0
* [`30465699`](https://github.com/NixOS/nixpkgs/commit/3046569950964ead1ad865c0c44e6f26a26978c0) rocksndiamonds: 4.3.8.2 -> 4.4.0.0
* [`20722013`](https://github.com/NixOS/nixpkgs/commit/20722013573dd7643b745e5c6c44cc479338d174) parallel: 20241122 -> 20241222
* [`540870a4`](https://github.com/NixOS/nixpkgs/commit/540870a4d0b9d4ded6109d85d20a727170cecd70) linuxkit: 1.5.2 -> 1.5.3
* [`e24aa49b`](https://github.com/NixOS/nixpkgs/commit/e24aa49b5d5feffbf6946b523a7e63594d852d74) iosevka-bin: 32.2.1 -> 32.3.0
* [`665ceb9d`](https://github.com/NixOS/nixpkgs/commit/665ceb9d68e5ab66fde2a48f9c172a81abbcc80c) ox: 0.7.5 -> 0.7.6
* [`ac5b74c4`](https://github.com/NixOS/nixpkgs/commit/ac5b74c44f2d26ec6b27f6ef429833d83b81a9ac) bkcrack: 1.7.0 -> 1.7.1
* [`b3eb30da`](https://github.com/NixOS/nixpkgs/commit/b3eb30da65321a835af823ddfea46bae9bb72b7f) wgcf: 2.2.23 -> 2.2.24
* [`e7751bce`](https://github.com/NixOS/nixpkgs/commit/e7751bceade3e506e0c4aa8ad55b264b5659caaa) kube-router: 2.3.0 -> 2.4.1
* [`672efea1`](https://github.com/NixOS/nixpkgs/commit/672efea1738a1ce6a71fb9837b9bc28d14f84db1) python312Packages.duckdb-engine: 0.13.4 -> 0.14.0
* [`c4ca3376`](https://github.com/NixOS/nixpkgs/commit/c4ca3376f4d6b855444459cde218e79edbafa063) sendme: 0.20.0 -> 0.21.0
* [`a9baae61`](https://github.com/NixOS/nixpkgs/commit/a9baae6151da9503b3ab0425107374714066be4e) dumbpipe: 0.21.0 -> 0.22.0
* [`d61d8386`](https://github.com/NixOS/nixpkgs/commit/d61d838689010f121913753782abdbfe02b0eb6d) gr-framework: 0.73.8 -> 0.73.10
* [`d59e60c4`](https://github.com/NixOS/nixpkgs/commit/d59e60c4ac54d8a8fd301ebed0e79d8f7bfc31f1) coursier: 2.1.19 -> 2.1.22
* [`c62f9479`](https://github.com/NixOS/nixpkgs/commit/c62f9479d92e717e4eab0e35e8f67c6fc01b1049) discordo: 0-unstable-2024-12-12 -> 0-unstable-2024-12-22
* [`01a77de3`](https://github.com/NixOS/nixpkgs/commit/01a77de3d2e266abeab83a3ca6da66ca91e5de1b) python312Packages.clarifai-grpc: 10.9.10 -> 10.11.2
* [`807024af`](https://github.com/NixOS/nixpkgs/commit/807024af2d631cd98816dacd90a16a7a483d44c1) zfs-autobackup: 3.2 -> 3.3
* [`20fbe9ec`](https://github.com/NixOS/nixpkgs/commit/20fbe9ecfdbdef1648bc3e9ba0b80aea0ea0b882) bitwuzla: 0.6.1 -> 0.7.0
* [`d345aa9c`](https://github.com/NixOS/nixpkgs/commit/d345aa9c88bf1409b550721720fdcd94d1c2dd14) openafs: 1.8.13 → 1.8.13.1
* [`27c0af47`](https://github.com/NixOS/nixpkgs/commit/27c0af47745bb5fd30e6df7a4b17a700a7b99ec7) proxmox-backup-client: 3.2.2 -> 3.3.2
* [`1c5316a0`](https://github.com/NixOS/nixpkgs/commit/1c5316a00d6a62dbdca0d34e81abf90a6db15d7d) micronaut: 4.7.2 -> 4.7.3
* [`83c72c73`](https://github.com/NixOS/nixpkgs/commit/83c72c7305c29d6ea6d023568484e8a51d77ecdf) nsc: 2.10.1 -> 2.10.2
* [`870d5825`](https://github.com/NixOS/nixpkgs/commit/870d582592bcfe4a33dbe42d3480a0fa51d77c5f) likwid: 5.4.0 -> 5.4.1
* [`422e761b`](https://github.com/NixOS/nixpkgs/commit/422e761b67dce6bffded934153c5cc6f99ce9987) proxmox-backup-client: switch to versionCheckHook
* [`20a6e0c6`](https://github.com/NixOS/nixpkgs/commit/20a6e0c6ca89acea7f5208969e8515060dc52d25) newlib: 4.3.0.20230120 -> 4.4.0.20231231
* [`247d4790`](https://github.com/NixOS/nixpkgs/commit/247d47909ab1e7790a613a66712a654d0cc55aaf) grml-zsh-config: 0.19.8 -> 0.19.11
* [`1ed6811f`](https://github.com/NixOS/nixpkgs/commit/1ed6811f3a508ef4b827a5f754b8ee13a9052a03) python312Packages.berkeleydb: 18.1.10 -> 18.1.12
* [`89e79d58`](https://github.com/NixOS/nixpkgs/commit/89e79d58769436a8cfd0d80ae28012d51134f2f3) bazarr: 1.4.5 -> 1.5.0
* [`1b310209`](https://github.com/NixOS/nixpkgs/commit/1b31020925da44ba144d78bef648d18e7400e286) sil-padauk: 5.001 -> 5.100
* [`7f0546fa`](https://github.com/NixOS/nixpkgs/commit/7f0546faee1c556ebda8987f58017c4f07fc353c) sil-abyssinica: 2.201 -> 2.300
* [`73a527ae`](https://github.com/NixOS/nixpkgs/commit/73a527ae79c8450aa9b29b7235874d672837590d) eclint: 0.5.0 -> 0.5.1
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
