### PR TITLE
niv nixpkgs: update ecd810c4 -> 09858bf7

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ecd810c4cc90890229ef353a12fb384c47ee75c3",
-        "sha256": "0rdrixmxjinvrw2f1aa40fxy8q7nxlqa33g3rxvyv40nay3izpyx",
+        "rev": "09858bf78bf7d367dd95f08a703b404351ef5b3a",
+        "sha256": "06jbpf1d6i7d354alrsrc17f6bllfzky7myc8fl8ms4x6302cyjw",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/ecd810c4cc90890229ef353a12fb384c47ee75c3.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/09858bf78bf7d367dd95f08a703b404351ef5b3a.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@ecd810c4...09858bf7](https://github.com/nixos/nixpkgs/compare/ecd810c4cc90890229ef353a12fb384c47ee75c3...09858bf78bf7d367dd95f08a703b404351ef5b3a)

* [`227c0926`](https://github.com/NixOS/nixpkgs/commit/227c0926cf9d31c531d49c068f54fb36c16854cc) Add devcontainer config
* [`4a1714ef`](https://github.com/NixOS/nixpkgs/commit/4a1714ef2d28e4ff1b98c5076b176402ec941936) octavePackages.matgeom: 1.2.3 -> 1.2.4
* [`a9edd099`](https://github.com/NixOS/nixpkgs/commit/a9edd0998786316de77d6c64eb233f4d28e18995) cc-wrapper hardeningFlags tests: add tests for pacret & shadowstack
* [`b8fd64f2`](https://github.com/NixOS/nixpkgs/commit/b8fd64f2e627db2c03fdd3f38a301020ec33be29) maintainers: add nathanregner
* [`e238f91c`](https://github.com/NixOS/nixpkgs/commit/e238f91c60da631d0e9481488d5aa7120722da31) flaresolverr: mark as broken
* [`d64c6bdc`](https://github.com/NixOS/nixpkgs/commit/d64c6bdc876c58e9494eed06f2d7c22a9640bfd5) mvnd: init at 1.0.2
* [`36c99b2c`](https://github.com/NixOS/nixpkgs/commit/36c99b2c6eafc2feed071904cc6439df7c4103a9) howard-hinnant-date: 3.0.1 -> 3.0.3
* [`8e44a9c4`](https://github.com/NixOS/nixpkgs/commit/8e44a9c450b1d702c0172a6712d33294b2b94c3e) maintainers: add ftsimas
* [`d3aff108`](https://github.com/NixOS/nixpkgs/commit/d3aff108c8c3d88f847347477a4fdff6801753b7) mptcpd: init at 0.13
* [`39e22be2`](https://github.com/NixOS/nixpkgs/commit/39e22be2994aaa0f275422112986373e2d80bdd0) nixos/mptcpd: init
* [`13f86a9b`](https://github.com/NixOS/nixpkgs/commit/13f86a9b26296a90521c758951e6ecb9db2563e6) python3Packages.flake8-class-newline: init at 1.6.0
* [`3bb46832`](https://github.com/NixOS/nixpkgs/commit/3bb468326cd3abcc225321f7099c95b2281027c1) python3Packages.flake8-deprecated: init at 2.2.1
* [`fe6dd4bf`](https://github.com/NixOS/nixpkgs/commit/fe6dd4bf7c1582d38209383fe3eae742ebeec5da) python3Packages.sqlcipher3: init at 0.5.4
* [`0f731eb8`](https://github.com/NixOS/nixpkgs/commit/0f731eb8d1e3a63d841ddb9d64292c1d73e794fc) signal-export: increase version to 3.2.0
* [`7694ae25`](https://github.com/NixOS/nixpkgs/commit/7694ae25b68107a8c8f1650116704f316486665c) narsil: 1.3.0-350-ga51756908 -> 1.4.0
* [`e7d05a5f`](https://github.com/NixOS/nixpkgs/commit/e7d05a5f9c85a1e670c72c32ce735545f0609c7b) narsil: nixfmt pass
* [`6efe1e4f`](https://github.com/NixOS/nixpkgs/commit/6efe1e4f7c0b3e70e82c6300a4da512d6fa4609a) vscode-extensions.yoavbls.pretty-ts-errors: 0.5.4 -> 0.6.1
* [`ffe685b3`](https://github.com/NixOS/nixpkgs/commit/ffe685b3e0187a60c792ab942600b349735fd6d9) pkgs/stdenv/linux: update armv5tel-unknown-linux-gnueabi bootstrap-files
* [`a2d3d00f`](https://github.com/NixOS/nixpkgs/commit/a2d3d00fb0acdb9bfc7b115f0bfd05528fb6678b) pkgs/stdenv/linux: update armv6l-unknown-linux-gnueabihf bootstrap-files
* [`59ebd721`](https://github.com/NixOS/nixpkgs/commit/59ebd721189d8181f0d749eee13804c030dcc345) nixos/neo4j: add advertisedAddress options
* [`e18e2779`](https://github.com/NixOS/nixpkgs/commit/e18e2779343bc7f4ed7e7520cd6d50ed5b02da55) s3ql: remove dugong dependency
* [`e4d990c8`](https://github.com/NixOS/nixpkgs/commit/e4d990c80aa297a2be2ff80c3180f798b850f824) python3Packages.dugong: deprecate
* [`8f267e81`](https://github.com/NixOS/nixpkgs/commit/8f267e81fa30dabcfa08d1c5c1238e0a473772c9) vscode-extensions.ms-dotnettools.csdevkit: 1.8.14 -> 1.14.14
* [`620b6a06`](https://github.com/NixOS/nixpkgs/commit/620b6a067933435bd080ce6b566ce52b7d89f123) vscode-extensions.ms-dotnettools.csharp: 2.39.29 -> 2.55.29
* [`c8a84a01`](https://github.com/NixOS/nixpkgs/commit/c8a84a01d57ea72a5e560f69cdd8596b7f7421b2) nixos/alsa: rebirth from the ashes
* [`0b5ca42f`](https://github.com/NixOS/nixpkgs/commit/0b5ca42f3136c25c90bd27dc65aa9fdf941ee462) nixos/tests/firefox: use hardware.alsa
* [`b0ee1095`](https://github.com/NixOS/nixpkgs/commit/b0ee1095295db1defd7f493f14697c77d17d3088) nixos/alsa: add rnhmjoj as maintainer
* [`4bda7a6e`](https://github.com/NixOS/nixpkgs/commit/4bda7a6e17636333023ea2fb144369562db3f9d5) tangara-companion: init at 0.4.3
* [`7b9726f1`](https://github.com/NixOS/nixpkgs/commit/7b9726f12c6f457416df47f069149b8eec37d273) pkgs/tools/text/diffutils: Disabled test-c-stack2 test-sigsegv-catch-stackoverflow1 and 2 on Aarch32
* [`34d7324b`](https://github.com/NixOS/nixpkgs/commit/34d7324bcd66d1f8fd3e84ba25d33a6509d4c208) pkgs/tools/text/gnugrep: Disabled tests for Aarch32
* [`b99ec6e0`](https://github.com/NixOS/nixpkgs/commit/b99ec6e0191261869deec9e7a4d7186c02182e39) skrooge: 2.31.0 -> 2.33.0
* [`2187d197`](https://github.com/NixOS/nixpkgs/commit/2187d1970e627656bf3a2ed7d23d579bc66874be) nixos/etc-overlay: make the etc overlay compatible with nixos-enter and nixos-install
* [`df7c405f`](https://github.com/NixOS/nixpkgs/commit/df7c405f3201216f7be5301848f5af91c6136988) nixos/etc-overlay: always create the metadata mountpoints in /run
* [`4f86994b`](https://github.com/NixOS/nixpkgs/commit/4f86994b739c33588d8c1c1649dd0d4139c5266b) matrix-commander: 7.6.2 -> 8.0.4
* [`b3d48503`](https://github.com/NixOS/nixpkgs/commit/b3d48503cb8b8fc788d4f59af9262e57b3283f5f) bigloo: 4.4b -> 4.5b
* [`dbf1e4c9`](https://github.com/NixOS/nixpkgs/commit/dbf1e4c95d8c36a58d0f3b57b60ab7a2c17bf59d) dendrite: 0.13.8 -> 0.14.0
* [`63e98269`](https://github.com/NixOS/nixpkgs/commit/63e9826972d0912573acd3e35b9d6bd8a36e8804) jetbrains.plugins: extend update script for source builds
* [`07bc712b`](https://github.com/NixOS/nixpkgs/commit/07bc712b0f13819d31532b30c4118284979a51a2) jetbrains.plugins: update
* [`7fe89a85`](https://github.com/NixOS/nixpkgs/commit/7fe89a853a1704952d784a961c9be485a46b24cc) jetbrains.plugins: lint fixes
* [`e19ce2cf`](https://github.com/NixOS/nixpkgs/commit/e19ce2cf9555cc860a9e5b72116a26f83719f235) wsjtx: fix and enable strictDeps
* [`697c6678`](https://github.com/NixOS/nixpkgs/commit/697c667818b26f76b9013730f6a1ba96d54f0eea) python312Packages.pickpack: init at 2.0.0
* [`4ba0f10e`](https://github.com/NixOS/nixpkgs/commit/4ba0f10e1b9c2a0b1041c41ab6cd161f53fbedc6) lean4: 4.11.0 -> 4.12.0
* [`c8b45756`](https://github.com/NixOS/nixpkgs/commit/c8b457564aee5330a08dfad3f25563f5ca4937d0) lua-language-server: 3.13.4 -> 3.13.5
* [`f46af671`](https://github.com/NixOS/nixpkgs/commit/f46af671f1780d0fe49f490fc88eaf3a5ea9f693) home-assistant-custom-components.solis-sensor: add update script to package
* [`abab77f9`](https://github.com/NixOS/nixpkgs/commit/abab77f99363b777dbdeec9764c7741d60039095) home-assistant-custom-components.solis-sensor: 3.7.2 -> 3.8.0
* [`72b219d8`](https://github.com/NixOS/nixpkgs/commit/72b219d8eacaefcf956844bcfec67674b0b4a1cb) update to 18.8.2
* [`10f6d55b`](https://github.com/NixOS/nixpkgs/commit/10f6d55b84ecd1c0475a00138bdc45dde5e8ee62) signal-export: 3.2.0 -> 3.2.2
* [`65778e04`](https://github.com/NixOS/nixpkgs/commit/65778e040c2932b5d379c419de57611547b7e809) hugin: move to openexr_3
* [`d9f13296`](https://github.com/NixOS/nixpkgs/commit/d9f13296df6d164d66088186f056fe12904f1c4f) maintainers: add tombert
* [`2f9ab041`](https://github.com/NixOS/nixpkgs/commit/2f9ab0414f3e7672037306095ea0db078749e5ba) bigpemu: init at 1.17
* [`aba1241f`](https://github.com/NixOS/nixpkgs/commit/aba1241f7fba0d455b231b19266a4fdd0af58747) dict: 1.13.1 → 1.13.3
* [`388a09e8`](https://github.com/NixOS/nixpkgs/commit/388a09e8c171eaec732a5c264d6ea9a4eb267d9c) weechat: 4.4.4 -> 4.5.0
* [`bd8d7d94`](https://github.com/NixOS/nixpkgs/commit/bd8d7d941b79acd49fb0fd941d7683155a75cc9a) weechat: 4.5.0 -> 4.5.1
* [`f2128f80`](https://github.com/NixOS/nixpkgs/commit/f2128f80350855a6d9ef68dfe579b4cd072689d0) netdata: fix absolute path to lm_sensors binary
* [`113ccac4`](https://github.com/NixOS/nixpkgs/commit/113ccac44f7ec2b44874cab4c4ac373d966531bb) maintainers: add lu1a
* [`f25b22df`](https://github.com/NixOS/nixpkgs/commit/f25b22df56b6272c3e71d82ed01db6121bccfa5c) dropbear: 2022.83 -> 2024.86
* [`190c2a91`](https://github.com/NixOS/nixpkgs/commit/190c2a91fa2fe4a0f63ffc683b567cc6a4cede9a) librenms: use --replace-fail instead of --replace
* [`0d4fc994`](https://github.com/NixOS/nixpkgs/commit/0d4fc994169a386e661be434c93b83060925f16b) librenms: generate i18n files
* [`1d3639ad`](https://github.com/NixOS/nixpkgs/commit/1d3639ad9b1e1bf0a7679a1940d9685c09520727) xtris: fix build by including time.h
* [`a2aa8955`](https://github.com/NixOS/nixpkgs/commit/a2aa8955b5c34a55254b13e1fe10714832ab4d82) soapyplutosdr: init at 0.2.2
* [`f7938fb5`](https://github.com/NixOS/nixpkgs/commit/f7938fb595a8f339670685f6d7c0fd94981d1ec1) soapysdr-with-plugins: add soapyplutosdr
* [`6ac2b4a2`](https://github.com/NixOS/nixpkgs/commit/6ac2b4a240387ea435022c11ad30d0010962fd3f) pinact: prefer versionCheckHook rather than testers.testVersion
* [`c6a2750e`](https://github.com/NixOS/nixpkgs/commit/c6a2750e4117341344cda6a82d228d77e82c9f91) pinact: set CGO_ENABLED=0
* [`1750892a`](https://github.com/NixOS/nixpkgs/commit/1750892a928fe72f01c1cff33e051a8f1f39b0a8) pinact: prefer tag rather than rev for fetchFromGitHub
* [`5d50bc8e`](https://github.com/NixOS/nixpkgs/commit/5d50bc8e162d5a8172f9c10aa3cf27715d516e97) pinact: reduce scope of with in meta
* [`3b8fc626`](https://github.com/NixOS/nixpkgs/commit/3b8fc626560eb0cc2187436d1bdc932df170a62d) pinact: 1.0.0 -> 1.1.0
* [`bf58353b`](https://github.com/NixOS/nixpkgs/commit/bf58353bc480d031412c225ecb268aaa7593cb56) python312Packages.mozart-api: 4.1.1.116.3 -> 4.1.1.116.4
* [`54b5803e`](https://github.com/NixOS/nixpkgs/commit/54b5803ecbd5b3988b461adc3c5cc106d14747c1) linuxPackages.system76: 1.0.16 -> 1.0.17
* [`6975dea4`](https://github.com/NixOS/nixpkgs/commit/6975dea4d3c862cf71f61eed9ef8d1e126b8db61) nixos/fcitx5: fix quickphrase
* [`2316da97`](https://github.com/NixOS/nixpkgs/commit/2316da9798ef5eba2b2a494f95c507710489d661) pinact: 1.1.0 -> 1.1.1
* [`872f6c46`](https://github.com/NixOS/nixpkgs/commit/872f6c46b9461e924719b89f129b863bd9fe1fbd) nyxt: drop dependency on notify-osd
* [`c978a5d5`](https://github.com/NixOS/nixpkgs/commit/c978a5d55c888b1eab23376673f2d472b9bf2c7d) maintainers: add scd31
* [`d49a887c`](https://github.com/NixOS/nixpkgs/commit/d49a887c164a5754caf3d33773849eb62c5ac676) pinact: 1.1.1 -> 1.1.2
* [`f7a1f01c`](https://github.com/NixOS/nixpkgs/commit/f7a1f01cbc14ebe3a97bea2a899c030929a2c20f) python312Packages.editorconfig: 0.12.4 -> 0.17.0
* [`e5e134e8`](https://github.com/NixOS/nixpkgs/commit/e5e134e8ec3c63d91b3ef2d80679fa8721d428eb) zcfan: 1.3.0 -> 1.4.0
* [`fb4c1a91`](https://github.com/NixOS/nixpkgs/commit/fb4c1a919cdabe4f6765a49ed24ea4897a02dc51) zcfan: refactor
* [`b74ffd6c`](https://github.com/NixOS/nixpkgs/commit/b74ffd6cbcd9edb92149277f436dd021749b8b9a) zcfan: add luftmensch-luftmensch to maintainers
* [`d71d18f1`](https://github.com/NixOS/nixpkgs/commit/d71d18f195530d304cee4c2c49b213d0053e1819) wire-desktop: linux 3.36.3462 -> 3.37.3607
* [`d0c19f24`](https://github.com/NixOS/nixpkgs/commit/d0c19f24a10f30c4cd266df8f9151d12df8d0596) wire-desktop: mac 3.35.4861 -> 3.37.5164
* [`7220c452`](https://github.com/NixOS/nixpkgs/commit/7220c45241e6399d355c63a40e43e64910740b49) wire-desktop: Both versions updated to Electron unaffected by CVE-2024-6775
* [`60661932`](https://github.com/NixOS/nixpkgs/commit/60661932d84b4c2debad46422df585e2cdcceffd) python312Packages.booleanoperations: refactor
* [`5bff874f`](https://github.com/NixOS/nixpkgs/commit/5bff874fd63b4c972c289a4f3ca30a7f90d17420) authentik: Fix ak script for systemd units
* [`4bff4585`](https://github.com/NixOS/nixpkgs/commit/4bff45851f45b6e40bb1e51dc396be1b1bdc0d7e) calibre: add fonttools dependency
* [`c0286526`](https://github.com/NixOS/nixpkgs/commit/c0286526ec34b81b11e04e0240b335c0dade7672) tsocks: fix ./configure error
* [`73750c2c`](https://github.com/NixOS/nixpkgs/commit/73750c2c08dc222fda30b90927965dcb0fb4617b) lomiri.lomiri-ui-toolkit: Add mesa.llvmpipeHook, re-allow many tests
* [`d1cd9058`](https://github.com/NixOS/nixpkgs/commit/d1cd9058fc6597e8783ae1013f78c2bb6391306c) mysql-workbench: 8.0.38 -> 8.0.40
* [`03ca0252`](https://github.com/NixOS/nixpkgs/commit/03ca0252182609385650cf6e66d680d20d221f7b) lomiri.lomiri-ui-extras: Add mesa.llvmpipeHook, re-allow affected test(s)
* [`3609c77c`](https://github.com/NixOS/nixpkgs/commit/3609c77cec51db4d34b01f6edfa33bad0886e619) lomiri.lomiri-system-settings-unwrapped: Add mesa.llvmpipeHook, re-allow affected test(s)
* [`198305bf`](https://github.com/NixOS/nixpkgs/commit/198305bfacb62317333646d63a5a00f8b72c04d0) lomiri.lomiri-clock-app: Add mesa.llvmpipeHook, re-allow affected test(s)
* [`610ec2c7`](https://github.com/NixOS/nixpkgs/commit/610ec2c78b0473065628ee36feec9c63425ea2ec) lomiri.morph-browser: Add mesa.llvmpipeHook, re-allow affected test(s)
* [`b27dc05a`](https://github.com/NixOS/nixpkgs/commit/b27dc05a63cbce52db5efa7c412415d1c775b3ac) uacme: 1.7.5 -> 1.7.6
* [`66131a35`](https://github.com/NixOS/nixpkgs/commit/66131a35629075ceec7272f5c7a1a1ed7109973b) vscode-extensions.signageos.signageos-vscode-sops: change to mit license
* [`4181c498`](https://github.com/NixOS/nixpkgs/commit/4181c49850831375b829c08433bc1637a5a8ab2b) criticality-score: migrate from python3Packages
* [`a5cc2d09`](https://github.com/NixOS/nixpkgs/commit/a5cc2d090e0d8b62e843f955c9148d54895fa415) nixos/luksroot: Check if the device was opened while reading password
* [`af397f4a`](https://github.com/NixOS/nixpkgs/commit/af397f4a337dcdea43583ab12ef31c0fcdbdcb31) qt6.qtwebengine: make the `AppleClang` substitution unconditional
* [`c725c10d`](https://github.com/NixOS/nixpkgs/commit/c725c10d451f8e7731c5345279027f99c089c38f) librespot: add optional support for Avahi
* [`2c20f93c`](https://github.com/NixOS/nixpkgs/commit/2c20f93c8ed233ad7daa842e8524d68dcda5f0b0) i2pd: 2.54.0 -> 2.55.0
* [`5e901b66`](https://github.com/NixOS/nixpkgs/commit/5e901b66e157ff41b1370592df527c0585f42271) jreleaser-cli: 1.15.0 -> 1.16.0
* [`e6179050`](https://github.com/NixOS/nixpkgs/commit/e6179050ae7ff461a2ebf1c1f74f0921654a57a6) criticality-score: 1.0.8 -> 2.0.4
* [`8e7104fd`](https://github.com/NixOS/nixpkgs/commit/8e7104fd7fd1a65f727c9e4e4774524db1a9a57e) python312Packages.dash-renderer: remove
* [`398c3b0f`](https://github.com/NixOS/nixpkgs/commit/398c3b0fd69c627a2e53d528de27914cc1d30c9f) python312Packages.delegator-py: refactor
* [`c62ac197`](https://github.com/NixOS/nixpkgs/commit/c62ac197df55ed119b1d9b6b12bfe4202222d205) python312Packages.pygithub3: refactor
* [`18479b84`](https://github.com/NixOS/nixpkgs/commit/18479b84b3e035899b20390105f3494d8f5ca506) dict: use flex_2_5_35
* [`78cc36af`](https://github.com/NixOS/nixpkgs/commit/78cc36af16f536b3532f527ed564ad05b6c4a0a6) mpack: fix gcc-14 and add Debian patches
* [`d6891b32`](https://github.com/NixOS/nixpkgs/commit/d6891b326ed2c30ca3704aee27bc6968bf620617) gnome-robots: 40.0 → 41.1
* [`4875bab7`](https://github.com/NixOS/nixpkgs/commit/4875bab70521b8bba347b3ee2500080d07033c8a) gxml: 0.20.3 → 0.20.4
* [`eb77e057`](https://github.com/NixOS/nixpkgs/commit/eb77e057322f01494c4c77e5da565b679faf25ec) gom: 0.4 → 0.5.3
* [`66f5709c`](https://github.com/NixOS/nixpkgs/commit/66f5709c424e09c20692d5f0bade44f24b40e865) libmikmod: 3.3.11.1 -> 3.3.12
* [`d47b905d`](https://github.com/NixOS/nixpkgs/commit/d47b905de6cecb436f411f1124a9f7ceff956271) gimpPlugins.bimp: fix gcc-14 build
* [`712cb46f`](https://github.com/NixOS/nixpkgs/commit/712cb46f88696bfcf316b6b06b0654c14f07efd3) libpointmatcher: 1.4.3 -> 1.4.4
* [`c7814ab4`](https://github.com/NixOS/nixpkgs/commit/c7814ab4d0d254c091f336f50bf9cc448cf34e15) xc: tweak, add update script, add sanity tests
* [`53062875`](https://github.com/NixOS/nixpkgs/commit/530628753825a4188d9ca92bec712cad4bdc13da) xc: 0.8.0 -> 0.8.5
* [`5ab8a81f`](https://github.com/NixOS/nixpkgs/commit/5ab8a81f724b381a1c745dbda36e0017064cc122) gimpPlugins.gap: drop
* [`41728e06`](https://github.com/NixOS/nixpkgs/commit/41728e065f81581ccbf5007006a20809f3c9e307) python312Packages.matrix-client: refactor
* [`13384429`](https://github.com/NixOS/nixpkgs/commit/13384429ea872f579cb514f7cde54b050b4003b2) python312Packages.matrix-api-async: remove
* [`517eb689`](https://github.com/NixOS/nixpkgs/commit/517eb6898aaad862174349c4ca8119997456cfaa) gimpPlugins.gimplensfun: fix clang build
* [`7b04cae6`](https://github.com/NixOS/nixpkgs/commit/7b04cae6c62506ad680279042dbde534f4394ae2) python312Packages.scikits-odes-core: init at 3.1.0
* [`ade6b8da`](https://github.com/NixOS/nixpkgs/commit/ade6b8dae63804e823bebdbc961cb657392f145a) python312Packages.scikits-odes-daepack: init at 3.1.0
* [`2f6cfef5`](https://github.com/NixOS/nixpkgs/commit/2f6cfef5fbe298ac699025421db0d61253d2b821) python312Packages.scikits-odes-sundials: init at 3.1.0
* [`122e9e82`](https://github.com/NixOS/nixpkgs/commit/122e9e824678d17d9a771f3acebe2f2c829c5d1c) python312Packages.scikits-odes: 2.7.0 -> 3.1.0
* [`391bca84`](https://github.com/NixOS/nixpkgs/commit/391bca848ab824999d110b230ff89003a2c5e49f) xlights: 2024.19 -> 2024.20
* [`71b1e045`](https://github.com/NixOS/nixpkgs/commit/71b1e045ee910b8e6410bb264a07910424ab8804) python312Packages.keyrings-google-artifactregistry-auth: refactor
* [`ab29b89f`](https://github.com/NixOS/nixpkgs/commit/ab29b89f860ea77cc75b4368eb29737f3583ab6a) python312Packages.log-symbols: refactor
* [`1b03c5a4`](https://github.com/NixOS/nixpkgs/commit/1b03c5a4e329efd30fad919889e6dc21324d0166) python312Packages.mdx-truly-sane-lists: refactor
* [`5c1cbe1b`](https://github.com/NixOS/nixpkgs/commit/5c1cbe1bd9ce4ff8cfafb72d45143cabfb1a1250) python312Packages.pygments-better-html: refactor
* [`90ca6cce`](https://github.com/NixOS/nixpkgs/commit/90ca6cce4a68ff51e1d17b76c95aad1a9ae7c726) python312Packages.scrap-engine: refactor
* [`4bd75eab`](https://github.com/NixOS/nixpkgs/commit/4bd75eabc31b3ea50a11e14d348562dd2a222f71) python312Packages.jupyter-telemetry: refactor
* [`e9cde7f1`](https://github.com/NixOS/nixpkgs/commit/e9cde7f1ed35162fb1efe55e6c067e969e8ec052) realm: 2.6.0 -> 2.7.0
* [`20688174`](https://github.com/NixOS/nixpkgs/commit/2068817458e74e76bb15fc491089eef52e5fbab3) oqs-provider: 0.7.0 -> 0.8.0
* [`66582900`](https://github.com/NixOS/nixpkgs/commit/66582900adfaa33c7e8e9cec80dcf9d2e4372352) netbird: 0.35.1 -> 0.35.2
* [`fedbda3a`](https://github.com/NixOS/nixpkgs/commit/fedbda3a39357eb675e44599b6f73f5b8bc6f2f3) glaze: 4.2.2 -> 4.2.3
* [`7c8e4226`](https://github.com/NixOS/nixpkgs/commit/7c8e422689beadafc548101ad7d33ac956971101) nixos-option: rewrite as a nix script
* [`2ceb1dbe`](https://github.com/NixOS/nixpkgs/commit/2ceb1dbe60cbc3d0edb23358e3e85a0f7f6fdd7a) nixos-option: update manpage
* [`b8842b8b`](https://github.com/NixOS/nixpkgs/commit/b8842b8bea555ad1d8ceaf36be528922ebf31636) nixos/doc/rl-2505: mention nixos-option rewrite
* [`f6c458df`](https://github.com/NixOS/nixpkgs/commit/f6c458dfc1d8767995b4eb2cf80070561ae6a9dc) nixos-option: add warn when Flake is used
* [`9875c579`](https://github.com/NixOS/nixpkgs/commit/9875c5795a3f6ef6428acc756f0a7a9fe80d8d84) nixos-option: move to pkgs/by-name
* [`aded7584`](https://github.com/NixOS/nixpkgs/commit/aded75844f7f1b564780d394f2d71f4a9a5ad27c) nixos-option: move default nixos argument to shell script
* [`44ca3686`](https://github.com/NixOS/nixpkgs/commit/44ca368667b72c6b8719647aca29f0e43a71241c) nixos-option: format
* [`f2d7d55c`](https://github.com/NixOS/nixpkgs/commit/f2d7d55c1164601083034777074bb8410d2ac6a5) nixos-option: link to nixos test
* [`8710aa0a`](https://github.com/NixOS/nixpkgs/commit/8710aa0a55abca3a4769882f643c455ea8807634) nixos-option: use `git rev-parse --show-toplevel` to check for Git repo
* [`9ce02093`](https://github.com/NixOS/nixpkgs/commit/9ce020936f2188a29ea470786d1494623a943b0a) input-leap: Backport fix for crash on qt6.8
* [`a2061cd3`](https://github.com/NixOS/nixpkgs/commit/a2061cd37ae9bb769738e12fadbe093619eed04b) python312Packages.cjkwrap: refactor
* [`52ca8635`](https://github.com/NixOS/nixpkgs/commit/52ca86359248573a9f84edeecf7e74523870ce4e) newlib: 4.4.0.20231231 -> 4.5.0.20241231
* [`2422a31b`](https://github.com/NixOS/nixpkgs/commit/2422a31beb3da52ea11337847cd196357cdf997b) amdvlk: use nix-update-script
* [`03b22700`](https://github.com/NixOS/nixpkgs/commit/03b22700496bab13ee8f8010a16ed227ebc2f1e0) amdvlk: 2024.Q4.2 -> 2024.Q4.3
* [`c9385b46`](https://github.com/NixOS/nixpkgs/commit/c9385b464b9b4be279ce4d47cd76bb0446b17085) vrc-get: 1.8.2 -> 1.9.0
* [`a4175381`](https://github.com/NixOS/nixpkgs/commit/a4175381e77291c8896ff390c7c5f275142ec066) nixos/ytdl-sub: init module
* [`1bae375e`](https://github.com/NixOS/nixpkgs/commit/1bae375e38b8f6a0a0da953d2b48ecf2bc629b20) signal-export: use built-system key
* [`6b9fe1cd`](https://github.com/NixOS/nixpkgs/commit/6b9fe1cd61ac2916be220e8cbae4b5d7167ba59c) haskellPackages.cabal-install: suppress error of missing local index
* [`c645ff1e`](https://github.com/NixOS/nixpkgs/commit/c645ff1e650ef78d3ca7b732b069c296c268b021) debootstrap: 1.0.138 -> 1.0.140
* [`a9dc181f`](https://github.com/NixOS/nixpkgs/commit/a9dc181f359d4eaf14872361e4cb19dcdbe6cf3c) kubectl-cnpg: 1.24.2 -> 1.25.0
* [`8736508e`](https://github.com/NixOS/nixpkgs/commit/8736508e49afd1b5b6f4dc6f5ada72cf750f2c7e) cosmic-ext-ctl: init at 1.1.0
* [`31a9dc1b`](https://github.com/NixOS/nixpkgs/commit/31a9dc1bc7098cea97550ba78ec24f06003c912f) build-bazel-package: added rm of extra local folders for toolchain configuration in latest bazel versions.
* [`8927e56a`](https://github.com/NixOS/nixpkgs/commit/8927e56a346df47d41a9f8f9746c4dd4b9ef5fb6) xh: 0.23.0 -> 0.23.1
* [`eef74a13`](https://github.com/NixOS/nixpkgs/commit/eef74a139b437531b81296927754cada5207c39e) ceph: add upstream patch for GCC 14
* [`047670d1`](https://github.com/NixOS/nixpkgs/commit/047670d138533b04114312f44cdc8e46ed872cad) ceph: add patches for Boost 1.86
* [`f474afb5`](https://github.com/NixOS/nixpkgs/commit/f474afb53fa312fadddae17911b02050e922e300) linux_xanmod: 6.6.68 -> 6.6.69
* [`7ad67193`](https://github.com/NixOS/nixpkgs/commit/7ad67193d9a0b1d5dfa9ea2a8feb36d2600ccc2e) linux_xanmod_latest: 6.12.7 -> 6.12.8
* [`d2717272`](https://github.com/NixOS/nixpkgs/commit/d2717272348966a6ec8344f04780a80622ce9bda) elfutils: rebase cxx-header-collision.patch
* [`6d3e783d`](https://github.com/NixOS/nixpkgs/commit/6d3e783d0136c86872ab73ee7a4e5d0b8aae5886) diodon: init at 1.13.0
* [`5812c8fb`](https://github.com/NixOS/nixpkgs/commit/5812c8fb3d5ae8d1169b5bf3134737cb3160a319) owmods-gui: init at 0.15.0
* [`d399b903`](https://github.com/NixOS/nixpkgs/commit/d399b903e91fd604e17db0530c225b3b99120388) mypaint: remove with lib
* [`a7579f37`](https://github.com/NixOS/nixpkgs/commit/a7579f374f5923b67d36cf293b045aece77fcd97) mypaint: fetchFromGitHub rev -> tag
* [`fcfea6f8`](https://github.com/NixOS/nixpkgs/commit/fcfea6f887f17783c311b4c7635326ad668f9f60) mypaint: disable tests
* [`f66a3333`](https://github.com/NixOS/nixpkgs/commit/f66a3333437af080883fe7073f1e2991b37646e9) cp2k: 2024.3 -> 2025.1
* [`0af77380`](https://github.com/NixOS/nixpkgs/commit/0af77380e5875ab39d30b4a51b390f5de8c66b37) tabiew: 0.8.0 -> 0.8.1
* [`891adb43`](https://github.com/NixOS/nixpkgs/commit/891adb43721c743fec3ccce3bf7ea082e64d0b68) python313Packages.pysaml2: mark as broken
* [`f2fcce79`](https://github.com/NixOS/nixpkgs/commit/f2fcce79636e8749a261c778aabe843d903759e3) phosh: 0.41.1 -> 0.44.0
* [`0bec5b45`](https://github.com/NixOS/nixpkgs/commit/0bec5b455c2571c380dc45c2a3215adf97f08544) phoc: 0.41.0 -> 0.44.0
* [`29f117d9`](https://github.com/NixOS/nixpkgs/commit/29f117d90a44811134d6450a73884bfb598480d4) mactop: 0.1.9 -> 0.2.3
* [`471bff0b`](https://github.com/NixOS/nixpkgs/commit/471bff0b46a6d43a1a7d0f87252cd42802f2076b) mactop: enable version check
* [`da290cff`](https://github.com/NixOS/nixpkgs/commit/da290cffc5f41da170516191e1f84ef0d5efbd3c) fheroes2: 1.1.4 -> 1.1.5
* [`85b9eb95`](https://github.com/NixOS/nixpkgs/commit/85b9eb95e20896cdfff0ce6edb0701538988d09f) onefetch: 2.22.0 -> 2.23.1
* [`4e67cff7`](https://github.com/NixOS/nixpkgs/commit/4e67cff74c392503a12fa03ef411f2094d0bea00) flrig: fix cross / strictDeps build
* [`30ae86f3`](https://github.com/NixOS/nixpkgs/commit/30ae86f315db4e543afdbd58da92d4fd1dd422b6) markdownlint-cli2: 0.16.0 -> 0.17.1
* [`cd76d925`](https://github.com/NixOS/nixpkgs/commit/cd76d9256b68d91770af16240ff09a67a94a4ce8) mago: 0.0.9 -> 0.0.18
* [`eff5c482`](https://github.com/NixOS/nixpkgs/commit/eff5c482de5975af132a4103fee5ab21af239c84) tk-8_5: fix build with GCC 14
* [`98f7e5a8`](https://github.com/NixOS/nixpkgs/commit/98f7e5a8b051e9cf60efa94ed0d30a16a1394d8c) pypy27: 7.3.12 -> 7.3.17
* [`a104720c`](https://github.com/NixOS/nixpkgs/commit/a104720c3e73b8ffbe9f992ac0477a252b8561a2) pypy310: 7.3.12 -> 7.3.17
* [`61f48149`](https://github.com/NixOS/nixpkgs/commit/61f481492906b2d386d562a48b1318bdfdc34943) cargo-valgrind: 2.1.1 -> 2.2.1
* [`da415351`](https://github.com/NixOS/nixpkgs/commit/da415351f2e6c7c36abb795820d05095879b24eb) faust2: fix cross / strictDeps build
* [`54662081`](https://github.com/NixOS/nixpkgs/commit/546620819efe0188e97ea2375816d5577e8eb5e8) faust2jaqt: fix strictDeps build
* [`249322d5`](https://github.com/NixOS/nixpkgs/commit/249322d5a40474f47c78d49488ed3b6932bed6f7) faust2lv2: fix cross / strictDeps build
* [`787fa53e`](https://github.com/NixOS/nixpkgs/commit/787fa53e45a7757821b4744511e7b422323931c1) faustPhysicalModeling: fix strictDeps build, disable PIE
* [`686dd255`](https://github.com/NixOS/nixpkgs/commit/686dd255ea19290cc3b02b899ff301b0bd429423) kitex: 0.12.0 -> 0.12.1
* [`59e900c8`](https://github.com/NixOS/nixpkgs/commit/59e900c824b952391915c240cdb01442137eea4f) matrix-synapse: filter out broken packages in nativeCheckInputs
* [`e7008f03`](https://github.com/NixOS/nixpkgs/commit/e7008f03e78b7a68fc402e1abe0d4d632c465b95) xylib: fix cross / strictDeps build
* [`2715ad4b`](https://github.com/NixOS/nixpkgs/commit/2715ad4bcfd507767ebb3dcc7b4af92dad63e872) xsane: fix build failure
* [`1bf4dd81`](https://github.com/NixOS/nixpkgs/commit/1bf4dd81ff5e356a2c1c1e819d14f9adf0b09e83) hhexen: 1.6.3 -> 1.6.4
* [`31627c7c`](https://github.com/NixOS/nixpkgs/commit/31627c7c0222fdcbe540e970607765d591d074ff) git-cinnabar: disable version check
* [`3d5cf811`](https://github.com/NixOS/nixpkgs/commit/3d5cf8110d9fba048ee4909fd9629484f14f732e) galene: 0.9.1 -> 0.96
* [`56d83477`](https://github.com/NixOS/nixpkgs/commit/56d83477b10dcf77473e52bf9c686782db86f24d) scala_2_13: 2.13.12 -> 2.13.15
* [`af029e26`](https://github.com/NixOS/nixpkgs/commit/af029e268dff50e271f7c8dd1d6633f57fbfb243) conduwuit: remove code for macOS < 11
* [`6945ed91`](https://github.com/NixOS/nixpkgs/commit/6945ed91ddb878785b8f6b165fd592a4b0a3f630) golem: remove code for macOS < 11
* [`41c903a7`](https://github.com/NixOS/nixpkgs/commit/41c903a7dd1cffdc33bffe6f5e431154baf228c1) moltenvk: remove code for macOS < 11
* [`eb7ca3b1`](https://github.com/NixOS/nixpkgs/commit/eb7ca3b17aeb95d57740fc426aba3772aeb33c41) vfkit: remove code for macOS < 11
* [`9a69c709`](https://github.com/NixOS/nixpkgs/commit/9a69c7090c126ef07afcdf6adf6342e88f40c946) python312Packages.materialx: remove code for macOS < 11
* [`cd670972`](https://github.com/NixOS/nixpkgs/commit/cd670972bec82054e8dd8997c530e15564336c88) dosbox-staging: remove code for macOS < 11
* [`e05898e3`](https://github.com/NixOS/nixpkgs/commit/e05898e313547e4b7a0cc65add68b91dec565801) swift: remove code for macOS < 11
* [`6240f6c3`](https://github.com/NixOS/nixpkgs/commit/6240f6c3e33c453e22c8c9497ba586bd5969a23c) swiftpm: remove code for macOS < 11
* [`793706e9`](https://github.com/NixOS/nixpkgs/commit/793706e9e674766afa395656dffc918bc1469501) swiftpm: remove old Darwin SDK pattern detritus
* [`40576b59`](https://github.com/NixOS/nixpkgs/commit/40576b59d4331e4fe0f52ed2cb039d0c55affed2) television: 0.8.5 -> 0.8.6
* [`ab8c28b8`](https://github.com/NixOS/nixpkgs/commit/ab8c28b891f4981c0b53562559c279f7fb6134d0) immich-public-proxy: 1.5.4 -> 1.5.6
* [`afbf117b`](https://github.com/NixOS/nixpkgs/commit/afbf117bf4ba97d166858de668f91d4efdaf9e05) butterfly: add update script
* [`004985c7`](https://github.com/NixOS/nixpkgs/commit/004985c7d9a238eb2abb0b763f1786cbe5b019cf) python312Packages.pysam: remove with lib
* [`24a09c62`](https://github.com/NixOS/nixpkgs/commit/24a09c620f3dd5743ab48eb43ed8f45061917e4e) python312Packages.pysam: 0.22.1 -> 0.22.1-unstable-2024-10-30
* [`2def2f25`](https://github.com/NixOS/nixpkgs/commit/2def2f2591a3f3b6e3c68ec9492145abc1287139) ayugram-desktop: init at 5.8.3
* [`aed5dea5`](https://github.com/NixOS/nixpkgs/commit/aed5dea534181786ff133b07fca7eafedefb3089) pilipalax: add update script
* [`438effdc`](https://github.com/NixOS/nixpkgs/commit/438effdc7ab5a25248697fa014f1825d4256c948) maintainers: add clemjvdm
* [`37c6d52c`](https://github.com/NixOS/nixpkgs/commit/37c6d52c4a19a602a44e21448f363035b9f0a177) openshot-qt: 3.2.1 -> 3.3.0
* [`88d1dc0d`](https://github.com/NixOS/nixpkgs/commit/88d1dc0d49012ed290bb95c715e7e2b50a737b0d) daisydisk: init at 4.30
* [`e6f803f5`](https://github.com/NixOS/nixpkgs/commit/e6f803f58c8bebd51752750b11a201ad01b02b9a) lips: init at 1.0.0-beta.20
* [`d5ab5f92`](https://github.com/NixOS/nixpkgs/commit/d5ab5f922e9a8bdbf05ad67425d9e976981afbe0) houdini: make houdini run again
* [`daaf4732`](https://github.com/NixOS/nixpkgs/commit/daaf47328543d3786147649a37a34ab5c426a1f5) limo: 1.0.10 -> 1.0.11
* [`ee611d1c`](https://github.com/NixOS/nixpkgs/commit/ee611d1c87045b66933d610896a68097f0ab9c13) python312Packages.pytest-lsp: init at 0.4.3
* [`086a28df`](https://github.com/NixOS/nixpkgs/commit/086a28df527f27670877faa1632dc9367d45914d) taterclient-ddnet: 9.0.2 -> 10.0.1
* [`30f9e4bf`](https://github.com/NixOS/nixpkgs/commit/30f9e4bf57a166aa3f42165d781ed2919944ba94) maintainers: add sigmike
* [`21a5a0a0`](https://github.com/NixOS/nixpkgs/commit/21a5a0a030720777bbf2ba6af98bd79f7b96b154) flexget: 3.13.5 -> 3.13.6
* [`7d782269`](https://github.com/NixOS/nixpkgs/commit/7d7822699bb80d883e3a9f8ed4d91b1602441a79) uim: use gcc13
* [`72a3f360`](https://github.com/NixOS/nixpkgs/commit/72a3f36080cc001c1454801492d4acb85f68a231) uim: enableParallelBuilding = false
* [`f106f709`](https://github.com/NixOS/nixpkgs/commit/f106f7099527e16b9bb8221106340f012c2e6986) mlterm: use gcc13
* [`ace318f7`](https://github.com/NixOS/nixpkgs/commit/ace318f71a1a3533130fbe1a133590b83674feea) uim: 1.8.8 -> 1.8.9
* [`18d7d0a4`](https://github.com/NixOS/nixpkgs/commit/18d7d0a431c15ee89fa13fa8358bd409739ed26e) python312Packages.pyroute2: 0.7.12 -> 0.8.1
* [`75f5ce89`](https://github.com/NixOS/nixpkgs/commit/75f5ce8906b8711379574cd84c8ef669d4d4269a) uim: 1.8.8 -> 1.8.9
* [`dff02106`](https://github.com/NixOS/nixpkgs/commit/dff0210660e443ecb21e2e4ff934c99ad179b59c) marmite: init at 0.2.3
* [`020ed677`](https://github.com/NixOS/nixpkgs/commit/020ed67754875d1735120c9b14ae2a53c6be8a71) yamale: 5.2.1 -> 5.3.0
* [`13beb493`](https://github.com/NixOS/nixpkgs/commit/13beb4934686483f6f9ed89d8c78f7ea6e696c02) butterfly: 2.2.2 -> 2.2.3
* [`779d0063`](https://github.com/NixOS/nixpkgs/commit/779d0063f62f561eaa83b978f51ad252c4e4c030) ecl: passthru clang when stdenv.cc.isClang
* [`c503f8d5`](https://github.com/NixOS/nixpkgs/commit/c503f8d5f308af09616a0e8b0a66b8d879eb8f71) gobgpd: 3.32.0 -> 3.33.0
* [`e8ba8fba`](https://github.com/NixOS/nixpkgs/commit/e8ba8fba97fd7100e89a4a62f986442855b74920) checkov: 3.2.344 -> 3.2.346
* [`d9013ff1`](https://github.com/NixOS/nixpkgs/commit/d9013ff1bb51e1b5bb11ad324ba9ae055fa44d6d) python312Packages.craft-application: 4.6.0 -> 4.7.0
* [`44eeece0`](https://github.com/NixOS/nixpkgs/commit/44eeece08a330a2b2a68797a75fcfb9df307e654) python312Packages.lacuscore: 1.12.6 -> 1.12.7
* [`66cd762f`](https://github.com/NixOS/nixpkgs/commit/66cd762fedf827ea26cd89ccbd75ac9eae62531e) python312Packages.pyliblo: Fix build
* [`7d6edd14`](https://github.com/NixOS/nixpkgs/commit/7d6edd1442c6226f1128ee5529600b580b8b22ee) python312Packages.mkdocstrings-python: 1.12.2 -> 1.13.0
* [`dcc3061f`](https://github.com/NixOS/nixpkgs/commit/dcc3061f77004de7c046127bae725f46c49371f6) immich-public-proxy: add changelog
* [`4e33ebef`](https://github.com/NixOS/nixpkgs/commit/4e33ebef2247762897e803b57e03188d35a5eee7) winePackages.{staging,unstable}: 9.22 -> 10.0-rc4
* [`62168d3a`](https://github.com/NixOS/nixpkgs/commit/62168d3ae622c6e2d02d0dd212936325d4358591) python312Packages.astroid-filterbanks: 0.4.0 -> 0.4.0-unstable-2024-12-02
* [`5d0859bb`](https://github.com/NixOS/nixpkgs/commit/5d0859bba22c03f8b8a84acee5fae4df34a9be09) tintin: 2.02.41 -> 2.02.42
* [`313b8790`](https://github.com/NixOS/nixpkgs/commit/313b8790f09ce350e6234d38385163127a85fe82) dnscontrol: 4.15.2 -> 4.15.3
* [`36759ee1`](https://github.com/NixOS/nixpkgs/commit/36759ee1de5560862bdbb01ba28c5d2a1db7f3d4) jellyseerr: 2.1.0 -> 2.2.3
* [`531f6549`](https://github.com/NixOS/nixpkgs/commit/531f6549efe9474f266268e2035011fc29895812) ianny: 1.0.0 -> 2.0.0
* [`5593ab92`](https://github.com/NixOS/nixpkgs/commit/5593ab92056742ea7f67fb0120e5800f793c3151) bookstack: 24.12 -> 24.12.1
* [`0d95bdb7`](https://github.com/NixOS/nixpkgs/commit/0d95bdb72cae59d8e77bbf83f5118913ce1e3b0f) uiua{,-unstable}: refactor
* [`e75958d0`](https://github.com/NixOS/nixpkgs/commit/e75958d0b2c57213bb4955388cc9c0b81217751a) uiua{,-unstable}: add windowSupport option
* [`1ebba613`](https://github.com/NixOS/nixpkgs/commit/1ebba6131b4558087d93eb5004003d8082c1b4b4) rabbitmq-server: Fix building on Darwin
* [`9ce6259f`](https://github.com/NixOS/nixpkgs/commit/9ce6259fd13ec7ce0e9eeec214e9d0f626a913a1) postgresqlPackages.pg_partman: 5.2.2 -> 5.2.4
* [`e4fe2484`](https://github.com/NixOS/nixpkgs/commit/e4fe2484b31fb29b0ef6d8bfe2f45e0f490bd368) python312Packages.simplesqlite: 1.5.2 -> 1.5.3
* [`9308a1c1`](https://github.com/NixOS/nixpkgs/commit/9308a1c1deb0a8d67588055f3ab4318855f1105e) nchat: enable whatsapp module (requires building go module 'whatsmeow')
* [`62fe46d4`](https://github.com/NixOS/nixpkgs/commit/62fe46d448adc98f250b161f89152a6da91e77a1) python312Packages.openwebifpy: 4.3.0 -> 4.3.1
* [`07679c4c`](https://github.com/NixOS/nixpkgs/commit/07679c4cc1909da9a0709382e4f48caa0904c360) mactracker: add update script
* [`fef34957`](https://github.com/NixOS/nixpkgs/commit/fef34957c967257e7b5790f6df80e64629e22a60) mactracker: 7.13 -> 7.13.2
* [`ec998e4b`](https://github.com/NixOS/nixpkgs/commit/ec998e4b391acabca133b174573190d79a89c23e) reaper: 7.28 -> 7.29
* [`2b2be7f8`](https://github.com/NixOS/nixpkgs/commit/2b2be7f8a892e2de458b342a8551a11b954b323b) mactracker: add version check
* [`e857f96d`](https://github.com/NixOS/nixpkgs/commit/e857f96d2b0963e82b894805f699f572d3ccfa93) python312Packages.kivy: 2.3.0 -> 2.3.1
* [`88dfa61c`](https://github.com/NixOS/nixpkgs/commit/88dfa61caa91502153287ef7a6edace02c225ce4) vanillatd: init vanillatd and vanillara
* [`ab4228f5`](https://github.com/NixOS/nixpkgs/commit/ab4228f5008f6dbc94c96f82512591f6c5b0dd62) hyfetch: add nullcube to maintainers
* [`595fc886`](https://github.com/NixOS/nixpkgs/commit/595fc886d6b905fffe12109d43efbe6ddf85178a) hyfetch: install man pages
* [`846644b2`](https://github.com/NixOS/nixpkgs/commit/846644b25b75b0bd3c2cc8291ff5b168f6b783ba) python312Packages.spacy: 3.8.2 -> 3.8.3
* [`be7b92e9`](https://github.com/NixOS/nixpkgs/commit/be7b92e97dac09dc9c8910b82e723bf1690c6aa3) ollama: 0.5.1 -> 0.5.4
* [`a6e3802b`](https://github.com/NixOS/nixpkgs/commit/a6e3802b11a08983b6023cea0a59ad5d3d2660c3) libplctag: fix build
* [`7746c557`](https://github.com/NixOS/nixpkgs/commit/7746c557e021f62a5a2534a5898697b2562a6a40) uim: switch to finalAttrs pattern
* [`1eaa2ce7`](https://github.com/NixOS/nixpkgs/commit/1eaa2ce74763b265bcf3d20287c6809f4b5550ba) python312Packages.pyemd: refactor
* [`b540a801`](https://github.com/NixOS/nixpkgs/commit/b540a80105b5a72be64b8ca58f55a056e7baebe7) hashes: 1.1.0 -> 1.1.1
* [`d391ef67`](https://github.com/NixOS/nixpkgs/commit/d391ef6798fd4383ef22602a33df4c0b4efd1b92) uim: 1.8.9 -> 1.8.9-unstable-2024-12-09
* [`45d1190f`](https://github.com/NixOS/nixpkgs/commit/45d1190f0885e6173f5a0e5f217f44ada241e605) uim: use --replace-fail for substitution in postPatch
* [`ce82a3b4`](https://github.com/NixOS/nixpkgs/commit/ce82a3b448115bf134554806b9eab8cb197b1e26) mlterm: fix build with GCC 14
* [`125dd5bd`](https://github.com/NixOS/nixpkgs/commit/125dd5bd42a6cfd81160afc4c8fa9366060845e2) usbkvm: 0.1.0 -> 0.2.0
* [`db0be3a5`](https://github.com/NixOS/nixpkgs/commit/db0be3a5588322fb1cde9d0fd666a4cf08949abb) poetry: 1.8.5 -> 2.0.0
* [`b7c362f8`](https://github.com/NixOS/nixpkgs/commit/b7c362f87cf042f3dcf69e368cd3dca4279c4bc5) usbkvm: remove udev rules hack, use udevrulesdir meson option
* [`ce63b69e`](https://github.com/NixOS/nixpkgs/commit/ce63b69e482449eeb7238b329546a83346c2522e) nixos-rebuild-ng: implement build-image
* [`fbb00d30`](https://github.com/NixOS/nixpkgs/commit/fbb00d3034c1bb3bd96ba050baeadc159280c6e1) nixos-rebuild-ng: document build-image in manpage
* [`f2031a5d`](https://github.com/NixOS/nixpkgs/commit/f2031a5d5271c6c834ec87f300927c5b669dec27) trealla: 2.63.10 -> 2.63.11
* [`58b4599c`](https://github.com/NixOS/nixpkgs/commit/58b4599c6bc684291eb54d08e95453ea2c4ec174) posy-cursors: update license
* [`98b446e1`](https://github.com/NixOS/nixpkgs/commit/98b446e16609566b0237963240a3094e5af52149) python312Packages.pymunk: 6.9.0 -> 6.10.0
* [`cc635406`](https://github.com/NixOS/nixpkgs/commit/cc6354069e2618137f98279743f33a0a53f4c791) senpai: update homepage
* [`d7bfa332`](https://github.com/NixOS/nixpkgs/commit/d7bfa3326cae92e595879cf3c5f27bb0bf90938c) maintainers: add bretek
* [`7402afc6`](https://github.com/NixOS/nixpkgs/commit/7402afc67705ba96b1343f8426921efb282c3bc8) zizmor: 0.10.0 -> 1.0.0
* [`b747c677`](https://github.com/NixOS/nixpkgs/commit/b747c677eccb89c31a65a05e26e8d622b3ef2e1c) nixos-rebuild-ng: refactor using match
* [`94a55561`](https://github.com/NixOS/nixpkgs/commit/94a555610950f3d5010020a6f43b31d7a4ed7467) vkdevicechooser: init at 1.1
* [`77b2788d`](https://github.com/NixOS/nixpkgs/commit/77b2788d0a2a8e89a858c4c5437f828d6917dde0) python313Packages.gpgme: fix build
* [`85c1c3ca`](https://github.com/NixOS/nixpkgs/commit/85c1c3ca3f214ee465a63bd6a5a41a7a9ebe191b) qt6.qtwebengine: fix build on darwin
* [`89cd194e`](https://github.com/NixOS/nixpkgs/commit/89cd194eb3e5d0414ae0144c634f8048da776707) itgmania: init at 0.9.0
* [`4b487410`](https://github.com/NixOS/nixpkgs/commit/4b487410b65093fdb9de269b0b86aeee1ca481d3) lesspipe: 2.14 -> 2.17
* [`7233b53e`](https://github.com/NixOS/nixpkgs/commit/7233b53e3c3d484f7f29eca9073135dbf1a871b3) lesspipe: reformat
* [`c9979c45`](https://github.com/NixOS/nixpkgs/commit/c9979c459b9e8e68df4e780269a4e3438f11a329) tsukimi: 0.18.0 -> 0.18.1
* [`836e2c3a`](https://github.com/NixOS/nixpkgs/commit/836e2c3afdecb91acd0f036d3fd436f1cc16502c) rabbitmq-server: Allow local networking on Darwin
* [`95e1340a`](https://github.com/NixOS/nixpkgs/commit/95e1340aedca3bbab30cf0448b4314ba49a214f5) hdrop: 0.6.0 -> 0.7.2
* [`d12bdcdf`](https://github.com/NixOS/nixpkgs/commit/d12bdcdfa69cd877d795c736a09b723638c400ab) fastcap: fix GCC 14 build
* [`e1786d99`](https://github.com/NixOS/nixpkgs/commit/e1786d996e34c93a73757e19c50fdd2f1cf96527) clisp: disable PIE hardening, fix strictDeps build
* [`09652a62`](https://github.com/NixOS/nixpkgs/commit/09652a628e63bcc16bdd6d1e83d58c26542e49dc) python312Packages.python-homewizard-energy: 7.0.0 -> 7.0.1
* [`a32e3d6e`](https://github.com/NixOS/nixpkgs/commit/a32e3d6e7055cfddbf878e000248010b96ab22fe) python312Packages.aranet4: 2.4.0 -> 2.5.0
* [`9bc077e5`](https://github.com/NixOS/nixpkgs/commit/9bc077e5beee1bc071eb4aa52eca1df5c1e93ff2) python312Packages.pyathena: 3.12.0 -> 3.12.2
* [`f2318ecf`](https://github.com/NixOS/nixpkgs/commit/f2318ecfb622402364fdff5a4e8f66c1cb0cfb51) rqbit: expose the webui as passthru
* [`08e3fd17`](https://github.com/NixOS/nixpkgs/commit/08e3fd17ac87147b965bd97988929ce07de2a2f6) git-aggregator: 2.1.0 -> 4.0.2
* [`d60afbe3`](https://github.com/NixOS/nixpkgs/commit/d60afbe3b18d318c249f73386d876def42eb32e0) webkitgtk_{4_0,4_1,6_0}: remove code for macOS < 11
* [`3fcf59e8`](https://github.com/NixOS/nixpkgs/commit/3fcf59e875905a7dc2ea7ef00b8a65fa23661e19) pam-reattach: remove code for macOS < 11
* [`1960f507`](https://github.com/NixOS/nixpkgs/commit/1960f5077efdd49a5227946e86f7591de94f4eeb) gtksourceview5: remove code for macOS < 11
* [`c10bb4c2`](https://github.com/NixOS/nixpkgs/commit/c10bb4c2a6a6a878df48772cee59421137357655) mmex: remove code for macOS < 11
* [`f84d6275`](https://github.com/NixOS/nixpkgs/commit/f84d6275fee2301f052b2bde665496d736d0953c) kitty: remove code for macOS < 11
* [`17193dd6`](https://github.com/NixOS/nixpkgs/commit/17193dd6d939b6d9433c669e79c89106765e15b9) bitcoin: remove code for macOS < 11
* [`34d052e6`](https://github.com/NixOS/nixpkgs/commit/34d052e696715b3ad4cda73f2bd7f823a8b7a85a) groestlcoin: remove code for macOS < 11
* [`027d53c0`](https://github.com/NixOS/nixpkgs/commit/027d53c0e4bf4486c4267a5152f23c0679295fd9) filezilla: remove code for macOS < 11
* [`d0d3a071`](https://github.com/NixOS/nixpkgs/commit/d0d3a07101bf8e1d0c502326e88a2582d88b56a1) libfilezilla: remove code for macOS < 11
* [`40abf9f7`](https://github.com/NixOS/nixpkgs/commit/40abf9f7dbd41155d4f721f84591b0bd7ce0c8ac) fluent-bit: remove code for macOS < 11
* [`0e742321`](https://github.com/NixOS/nixpkgs/commit/0e742321a1463ff2190def03e8baa29d52681b23) gdlv: remove code for macOS < 11
* [`2d9216fa`](https://github.com/NixOS/nixpkgs/commit/2d9216fa8a47018b3fb618cbf33bd19ec09942aa) junkie: remove code for macOS < 11
* [`8c4e57cf`](https://github.com/NixOS/nixpkgs/commit/8c4e57cf821d1b2d422b7bca82ee1ecaba66431e) dark-mode-notify: remove code for macOS < 11
* [`bb698ad4`](https://github.com/NixOS/nixpkgs/commit/bb698ad42ac3a9a949e5ec8a13c948545edcb8dd) freedv: remove code for macOS < 11
* [`e375360a`](https://github.com/NixOS/nixpkgs/commit/e375360a4bd0ff2aaef439fb4b0ac6db8cc99970) py-spy: remove code for macOS < 11
* [`2931f3f2`](https://github.com/NixOS/nixpkgs/commit/2931f3f2512deb2366289ff2793f3596fa3c8aae) rs: remove code for macOS < 11
* [`1f83d810`](https://github.com/NixOS/nixpkgs/commit/1f83d810b629339e66e6615ac43cd3897cd94473) tup: remove code for macOS < 11
* [`bb3ca4c2`](https://github.com/NixOS/nixpkgs/commit/bb3ca4c2e19f5796e1a1ca6b4288726ae231b101) python312Packages.intake: remove code for macOS < 11
* [`85f2404c`](https://github.com/NixOS/nixpkgs/commit/85f2404cc2fdf4028745600f51bd8d3dc1748c4a) python312Packages.torch: remove code for macOS < 11
* [`53d15ba5`](https://github.com/NixOS/nixpkgs/commit/53d15ba54f32cb88b2a685f1c282137606b41ef9) python312Packages.sentence-transformers: remove code for macOS < 11
* [`d3eee9a8`](https://github.com/NixOS/nixpkgs/commit/d3eee9a814fbcca9f6ed2dbd1c2e2db218722786) python311Packages.tensorflow: remove code for macOS < 11
* [`6d0b606f`](https://github.com/NixOS/nixpkgs/commit/6d0b606f19f609319743bd5ac77ad54bd1b3c4fd) trippy: 0.12.1 -> 0.12.2
* [`c447792f`](https://github.com/NixOS/nixpkgs/commit/c447792f28bd3bf3c2c8af2eef99539bb3acb65e) jwt-cli: refactor
* [`fc6fd61b`](https://github.com/NixOS/nixpkgs/commit/fc6fd61b00e0061f5c3a9dc9083612d73ee455f9) zsh-history-to-fish: fix runtime error via patch
* [`85c6ec2f`](https://github.com/NixOS/nixpkgs/commit/85c6ec2fe3163678134d22c8d77dacd9e7608782) keyscope: 1.3.0 -> 1.4.0
* [`affab2b1`](https://github.com/NixOS/nixpkgs/commit/affab2b149b1d78fbd4b7297ffeff62d89e68e34) python312Packages.lsp-tree-sitter: 0.0.16 -> 0.0.17
* [`e38e6f05`](https://github.com/NixOS/nixpkgs/commit/e38e6f054c6c99990bc224af487b96240a6c4a99) python312Packages.wikipedia-api: 0.7.1 -> 0.7.3
* [`86aeb6fd`](https://github.com/NixOS/nixpkgs/commit/86aeb6fd6551171470babb287309d56ebe4fb33a) python312Packages.adafruit-platformdetect: 3.75.0 -> 3.76.1
* [`53d915d8`](https://github.com/NixOS/nixpkgs/commit/53d915d81fd74d2ae8bd3eebcaa03958d684afba) atuin: make cargoHash the same on Linux and Darwin
* [`2e6c0a7f`](https://github.com/NixOS/nixpkgs/commit/2e6c0a7f58999e30801e9f3ce06571fa4bd91ab7) python312Packages.tree-sitter-make: init at 1.1.1
* [`66db139e`](https://github.com/NixOS/nixpkgs/commit/66db139ea38910591e7185672b6df43e3c067233) autotools-language-server: 0.0.19 -> 0.0.22
* [`a7929335`](https://github.com/NixOS/nixpkgs/commit/a79293357501f9233b5de25ce77370da78f7d16e) python312Packages.fastavro: 1.9.7 -> 1.10.0
* [`dfe1c248`](https://github.com/NixOS/nixpkgs/commit/dfe1c24809767a74b64f92c82638c1dd3452f1df) pgx_ulid: init at 0.2.0
* [`e72a1919`](https://github.com/NixOS/nixpkgs/commit/e72a19192c752c1b7831a6b1f21de514a26915ea) python312Packages.backports-datetime-fromisoformat: 2.0.2 -> 2.0.3
* [`c745ca00`](https://github.com/NixOS/nixpkgs/commit/c745ca0083b2e4f2d1d3746a0df9d6d73e873ca0) lomiri.lomiri-content-hub: Fix example moving after project rename
* [`eab23545`](https://github.com/NixOS/nixpkgs/commit/eab2354554c8886c39a8c05d7d5410798ab7d3aa) python312Packages.stanza: 1.9.2 -> 1.10.1
* [`23a675ee`](https://github.com/NixOS/nixpkgs/commit/23a675ee8313427610cf129dd2b52a69bf6a2a26) tree-sitter-grammars: add kdl
* [`8df39dce`](https://github.com/NixOS/nixpkgs/commit/8df39dce4f34276ebba6062665e4b4608414c797) python312Packages.pdfplumber: 0.11.4 -> 0.11.5
* [`2fe3a386`](https://github.com/NixOS/nixpkgs/commit/2fe3a38643334868aea20979d8850deb431b7266) python312Packages.django-vite: 3.0.5 -> 3.0.6
* [`e0ae3c26`](https://github.com/NixOS/nixpkgs/commit/e0ae3c2616172b3ffb6ee591ef0bddbb640b969a) bant: fixed hash post-buildBazelPackage fix.
* [`2567fe09`](https://github.com/NixOS/nixpkgs/commit/2567fe09866ae355fa33014a1fcbe2ca90918524) perf_data_converter: fixed hash post-buildBazelPackage fix.
* [`24ccd397`](https://github.com/NixOS/nixpkgs/commit/24ccd397b7aa2af9f189147707294ea2655c0f37) mpvScripts.modernz: 0.2.2 -> 0.2.3
* [`3ef6e71e`](https://github.com/NixOS/nixpkgs/commit/3ef6e71ead82afa094eeb4680e4c30570eafe111) vtk: fix libGL include dir
* [`792197c4`](https://github.com/NixOS/nixpkgs/commit/792197c433a0bf2af13667627b106afcd475e4b4) code-cursor: 0.44.9 -> 0.44.11
* [`a102717c`](https://github.com/NixOS/nixpkgs/commit/a102717ccc03ba29c5c20ace0fc63349eb6ddfcb) josm: 19253 -> 19265
* [`fa3ad81d`](https://github.com/NixOS/nixpkgs/commit/fa3ad81df3c80ce07d1908dba9335680c55d595e) josm: 19265 -> 19277
* [`50b6e2b8`](https://github.com/NixOS/nixpkgs/commit/50b6e2b80b767cd7ab50c4563db0cb45a963b468) python312Packages.dep-logic: 0.4.9 -> 0.4.10
* [`3171f8d3`](https://github.com/NixOS/nixpkgs/commit/3171f8d35f369a54411ec8fbc47a573f221b4c13) metasploit: 6.4.42 -> 6.4.43
* [`22ee4ea4`](https://github.com/NixOS/nixpkgs/commit/22ee4ea4c3e35edad321d35b09b8bec3a8859a0c) broot: 1.44.4 -> 1.44.5
* [`fc3ac053`](https://github.com/NixOS/nixpkgs/commit/fc3ac053dd4b9eb35a8386111330c719cc0fac2a) ddrescue: 1.28 -> 1.29
* [`05949196`](https://github.com/NixOS/nixpkgs/commit/05949196edfa4ea1fab0541543077fe0f206de96) protonup-qt: 2.10.2 -> 2.11.1
* [`ba80a00d`](https://github.com/NixOS/nixpkgs/commit/ba80a00d18ae379228d28882a349c8cf7eb87cd0) cyclonedx-gomod: 1.8.0 -> 1.9.0
* [`7a4d9674`](https://github.com/NixOS/nixpkgs/commit/7a4d9674143b2135cbb9091c4a5a46b0d2450110) pnpm_9: 9.15.2 -> 9.15.3
* [`589d42d0`](https://github.com/NixOS/nixpkgs/commit/589d42d0fd2015aae4ce1165da649d2cc6a4c47d) superfile: 1.1.6 -> 1.1.7
* [`6f62ff22`](https://github.com/NixOS/nixpkgs/commit/6f62ff2261e1f750e4c0b4bb38fbdeef82aa5fc7) libtommath: remove obsolete `TARGET_OS_*` workaround
* [`69c435e7`](https://github.com/NixOS/nixpkgs/commit/69c435e77a2833f47a11afa09198c2a588a5798a) libtomcrypt: remove obsolete `TARGET_OS_*` workaround
* [`f342be86`](https://github.com/NixOS/nixpkgs/commit/f342be8615e1177c3755c356ac4dcb3ab95bd376) clangbuildanalyzer: 1.5.0 -> 1.6.0
* [`6cdd3139`](https://github.com/NixOS/nixpkgs/commit/6cdd31392ae4e1f156f40b51e60d58eff5d54b43) grandorgue: remove obsolete `TARGET_OS_*` workaround
* [`b0e22909`](https://github.com/NixOS/nixpkgs/commit/b0e229092a554ca127f26f738c1c995026628eb3) gtk-frdp: remove obsolete `TARGET_OS_*` workaround
* [`26e9e065`](https://github.com/NixOS/nixpkgs/commit/26e9e065fa7f501ec7693b39634036182a69eae9) alac: remove obsolete `TARGET_OS_*` workaround
* [`110cca62`](https://github.com/NixOS/nixpkgs/commit/110cca6232e13741bcf3e2f65faa14c11697225b) gotop: remove obsolete `TARGET_OS_*` workaround
* [`4ba8d995`](https://github.com/NixOS/nixpkgs/commit/4ba8d9956e1b89be0544258996decafd172c3066) freerdp{,3}: remove obsolete `TARGET_OS_*` workaround
* [`07464c4d`](https://github.com/NixOS/nixpkgs/commit/07464c4dca6f10b8f3197552eb9b76bd59cc5797) remmina: remove obsolete `TARGET_OS_*` workaround
* [`873cc4bf`](https://github.com/NixOS/nixpkgs/commit/873cc4bf0faf539e3d05109996258cedd72ccfd5) fluent-bit: remove obsolete `TARGET_OS_*` workaround
* [`7d9c19c0`](https://github.com/NixOS/nixpkgs/commit/7d9c19c00d5f0a36dfd8b97baaf5d98c31114c08) mynewt-newt: remove obsolete `TARGET_OS_*` workaround
* [`2dfb2974`](https://github.com/NixOS/nixpkgs/commit/2dfb2974314c1150b3de806a871f9bad7c7e0b6d) cdo: remove obsolete `TARGET_OS_*` workaround
* [`e28dd23e`](https://github.com/NixOS/nixpkgs/commit/e28dd23eed8b0265b3bae12369cabf6e3e498914) icoutils: remove obsolete `TARGET_OS_*` workaround
* [`cb73dab5`](https://github.com/NixOS/nixpkgs/commit/cb73dab54d14b352bde5b43e96b4ac88fbc609a7) jwhois: remove obsolete `TARGET_OS_*` workaround
* [`99947385`](https://github.com/NixOS/nixpkgs/commit/99947385e7c2a9dc9e5b2870958f1267738b3646) mattermost: build webapp from source
* [`8e44bd9c`](https://github.com/NixOS/nixpkgs/commit/8e44bd9c6668e9f69593acfae351b24ee25baff7) nixos/netbird: fix state directory mode
* [`06760e7e`](https://github.com/NixOS/nixpkgs/commit/06760e7ea0500532764c9d8ebdcbcc11ab63dc47) hyprland-qtutils: 0.1.1 -> 0.1.2
* [`71b080a8`](https://github.com/NixOS/nixpkgs/commit/71b080a8e5175b175be0fc9f65e7d5c29919b521) hoppscotch: 24.11.0-0 -> 24.12.0-0
* [`0a72d910`](https://github.com/NixOS/nixpkgs/commit/0a72d910ec56046bf77f8b16b1f8560540dfa127) botan3: remove code for macOS < 11
* [`35f6c3bf`](https://github.com/NixOS/nixpkgs/commit/35f6c3bfed7b31b548559fed3f122489fa7964d9) memento: 1.4.1 -> 1.5.0
* [`828d940d`](https://github.com/NixOS/nixpkgs/commit/828d940d2f1d096fe42ac56b21f381efcbd1998b) matcha-rss-digest: 0.6.1 -> 0.7.0
* [`51291dec`](https://github.com/NixOS/nixpkgs/commit/51291dec17f40e5ded25be40d2a4729d46b308ec) python312Packages.httpx-ws: 0.7.0 -> 0.7.1
* [`17035a6e`](https://github.com/NixOS/nixpkgs/commit/17035a6ec5621cd586769b36749b83cbe6973183) tmuxPlugins.dracula: v2.3.0 -> v3.0.0
* [`001bc723`](https://github.com/NixOS/nixpkgs/commit/001bc723506017321d9b27d85d8bb3263969e6c7) snapraid: run tests on `x86_64-darwin`
* [`d9e107a3`](https://github.com/NixOS/nixpkgs/commit/d9e107a39aec4ae3d24a1335e856f67cf0c4e911) komga: 1.15.1 -> 1.16.0
* [`db3a3f7c`](https://github.com/NixOS/nixpkgs/commit/db3a3f7c1ba4ed53aa1944912d4b609dd3cd24e0) candy-icons: add passthru.updateScript
* [`7aca12ca`](https://github.com/NixOS/nixpkgs/commit/7aca12ca72a9d7ab3cb822edd9ba218bf2c7389f) bant: 0.1.9 -> 0.1.11
* [`fecea367`](https://github.com/NixOS/nixpkgs/commit/fecea3678f756aae2be1cb170918f443254270f3) python312Packages.imgw-pib: 1.0.8 -> 1.0.9
* [`1cedae1f`](https://github.com/NixOS/nixpkgs/commit/1cedae1f6ae49c0101c88e3bfd8891be72001598) python312Packages.pynmeagps: 1.0.43 -> 1.0.44
* [`bd3b4307`](https://github.com/NixOS/nixpkgs/commit/bd3b43076dc83619ee873f471400bd1d59d0a341) verible: 0.0.3836 -> 0.0.3894
* [`9ffa81f5`](https://github.com/NixOS/nixpkgs/commit/9ffa81f5e990f8d25c00a44b2c2e122627eb9f7a) notion-app: init at 4.2.0
* [`e0a0949c`](https://github.com/NixOS/nixpkgs/commit/e0a0949cf5fb641315ab0b37465cba4ce9c21398) consul: 1.20.1 -> 1.20.2
* [`e57e5836`](https://github.com/NixOS/nixpkgs/commit/e57e583636e60344d83f9e2877f4e323e54685d9) qidi-slicer-bin: 1.2.0 -> 1.2.1
* [`b5b41d49`](https://github.com/NixOS/nixpkgs/commit/b5b41d499ef8b1564644aeeec2f58ac624c0219e) ocamlPackages.odds: small fixes
* [`c89d90c0`](https://github.com/NixOS/nixpkgs/commit/c89d90c026587ffcdf3839595fe0f62fd3272adf) maintainers: add additional key for ethancedwards8 ([nixos/nixpkgs⁠#371344](https://togithub.com/nixos/nixpkgs/issues/371344))
* [`a7fe2946`](https://github.com/NixOS/nixpkgs/commit/a7fe29461e9de1447b5a328689b8a66b6574cddf) morewaita-icon-theme: 47.2 -> 47.3 ([nixos/nixpkgs⁠#371324](https://togithub.com/nixos/nixpkgs/issues/371324))
* [`c4ee24fe`](https://github.com/NixOS/nixpkgs/commit/c4ee24fe1bdfccb1bae1b42af54696ce57eb0c0a) mdbook-mermaid: 0.14.0 -> 0.14.1 ([nixos/nixpkgs⁠#371325](https://togithub.com/nixos/nixpkgs/issues/371325))
* [`f5986329`](https://github.com/NixOS/nixpkgs/commit/f598632917d43ced54a11df04f1de33532497bd4) envoy: fix build
* [`a220c0ff`](https://github.com/NixOS/nixpkgs/commit/a220c0ff59c3551ceb63e7c3df097ad32f63d313) qidi-slicer-bin: remove unused argument
* [`b550b4f9`](https://github.com/NixOS/nixpkgs/commit/b550b4f94e4c8908bd3982ab201aaea1753b123b) csharpier: 0.30.3 -> 0.30.5
* [`865ab911`](https://github.com/NixOS/nixpkgs/commit/865ab911551b42939d994c9274b8926ede1bdc4e) nixos/paperless: add module options for automated exports
* [`af7e0297`](https://github.com/NixOS/nixpkgs/commit/af7e02973a4b6efc7a66d9a7a3c6247b7648eea1) python312Packages.tencentcloud-sdk-python: 3.0.1295 -> 3.0.1296
* [`7b32c640`](https://github.com/NixOS/nixpkgs/commit/7b32c640f8fdb79afa4db5f499e980b9ac4b33b0) ocamlPackages.merlin: fix build
* [`dc72483b`](https://github.com/NixOS/nixpkgs/commit/dc72483b0aa3dd85001ad60047bd64d05f42b2bd) filebeat8: init at 8.16.1
* [`f744c156`](https://github.com/NixOS/nixpkgs/commit/f744c156d887c99c6642a3887d40e7309137a06e) xrizer: init at 0.1
* [`66abdfbf`](https://github.com/NixOS/nixpkgs/commit/66abdfbfc468ab0bdf8d5f555d84b77d11a65a7a) perlPackages.CryptDES: fix build for gcc14
* [`eccb8552`](https://github.com/NixOS/nixpkgs/commit/eccb8552c0b27b6c70b71e1584246808b14940f9) nixos-rebuild-ng: fix addopts in pytest
* [`460a5213`](https://github.com/NixOS/nixpkgs/commit/460a5213f146055d13448e939283f741f59f7800) ocamlPackages.ocamlmerlin-mlx: init at 0.9
* [`28988d08`](https://github.com/NixOS/nixpkgs/commit/28988d08f4312c0b43ed901d2403c0168a62e0ca) R: fix and enable strictDeps
* [`78c9ec6e`](https://github.com/NixOS/nixpkgs/commit/78c9ec6e7933748bd9ab4e6a6da05cc2ff93d2d5) home-assistant-custom-components.solis-sensor: 3.8.0 -> 3.8.1
* [`f7fa9290`](https://github.com/NixOS/nixpkgs/commit/f7fa929055ba0668856af788d2704451c1798699) icloudpd: 1.25.0 -> 1.25.1
* [`533042a9`](https://github.com/NixOS/nixpkgs/commit/533042a9c673d517be78c5e504233553bf17b532) homepage-dashboard: 0.10.6 -> 0.10.8
* [`53d7ab79`](https://github.com/NixOS/nixpkgs/commit/53d7ab796538e94c187e85719aa976c7b357ef06) ihaskell: Fix package dataset path
* [`0fde2d3a`](https://github.com/NixOS/nixpkgs/commit/0fde2d3a978ab6202c1561dde366356307833f32) walker: 0.9.0 → 0.11.16
* [`3783a0f2`](https://github.com/NixOS/nixpkgs/commit/3783a0f250d17fccac59b12d0b80457be96af930) charmcraft: disable two failing tests; broken upstream
* [`ab4fe049`](https://github.com/NixOS/nixpkgs/commit/ab4fe0490b0dec8fb473e863329f0e50a7b8cf09) snapcraft: disable broken test due to dependency difference in nixpkgs
* [`78ef63e5`](https://github.com/NixOS/nixpkgs/commit/78ef63e579e96da1bc293056d9b237983c18576f) rockcraft: disable broken test due to dependency difference in nixpkgs
* [`b2697bec`](https://github.com/NixOS/nixpkgs/commit/b2697bec57278fec8e02a766c2b94dbd6412b4e7) python3Packages.pygit2: import upstream patch to fix Python 3.13 tests
* [`aac38613`](https://github.com/NixOS/nixpkgs/commit/aac3861371b34948a07e3f6e7821b021cf4c36d6) python3Packages.craft-grammar: temporarily disable broken tests in Python 3.13
* [`05fdade3`](https://github.com/NixOS/nixpkgs/commit/05fdade30155608975003902b670d4f54b180571) python3Packages.craft-application: temporarily disable broken tests in Python 3.13
* [`7036d98c`](https://github.com/NixOS/nixpkgs/commit/7036d98c47f0f46e0fa4dbf747e470242b8ec525) python312Packages.scs: 3.2.7 -> 3.2.7.post2
* [`6ade0b3f`](https://github.com/NixOS/nixpkgs/commit/6ade0b3f81ba6190b9adf7550684e189c7428840) descent3-unwrapped: 1.5.0-beta-unstable-2024-12-20 -> 1.5.0-beta-unstable-2025-01-01
* [`909dc015`](https://github.com/NixOS/nixpkgs/commit/909dc0158a9366e01321319fa7ac064ceb39fc7f) chatterino2: generalize expression
* [`5154c6c3`](https://github.com/NixOS/nixpkgs/commit/5154c6c36ca4cafaa5e700cac4e1e2346156e210) ddccontrol-db: 20240920 -> 20250106
* [`9c35a835`](https://github.com/NixOS/nixpkgs/commit/9c35a835f6ed2b3db4d65c4c236c8d5a7c729287) dockle: 0.4.14 -> 0.4.15
* [`127ea1b5`](https://github.com/NixOS/nixpkgs/commit/127ea1b5a85c61097976b5aaa1a3682672bed172) json2cdn: init at 0.1.0
* [`0018055b`](https://github.com/NixOS/nixpkgs/commit/0018055bc1a013f5e39281a1ea7c26bbf88bf534) coqPackages.smtcoq: don't build currently-broken specific veriT
* [`141f581d`](https://github.com/NixOS/nixpkgs/commit/141f581d6f6416fa4af72093e0c837b36de27089) pkgs.formats: add cdn
* [`644fffcd`](https://github.com/NixOS/nixpkgs/commit/644fffcd8b3642bc6bcb7dfff589caa7b6488b35) maintainers: update github account for yuka
* [`4c8505b4`](https://github.com/NixOS/nixpkgs/commit/4c8505b430d65a78d50ed4c2089c0e3af94d4323) python312Packages.aioasuswrt: migrate to pytest-cov-stub
* [`22375dae`](https://github.com/NixOS/nixpkgs/commit/22375daedfb8d709097e5f9539945f213906734c) chatterino7: init at 7.5.2
* [`861bc667`](https://github.com/NixOS/nixpkgs/commit/861bc667a86c13dee1b2677b741423fc510b5bf5) chatterino2: add marie as a maintainer
* [`0c2c4283`](https://github.com/NixOS/nixpkgs/commit/0c2c428391ebf61fae127240a189440cc6e1280d) chatterino2: 2.5.1 -> 2.5.2
* [`b6f118ba`](https://github.com/NixOS/nixpkgs/commit/b6f118ba5b1a286b12ad1d82c9ac66fe6362ba93) python312Packages.aiosyncthing: migrate to pytest-cov-stub
* [`f9210b5f`](https://github.com/NixOS/nixpkgs/commit/f9210b5fb1fafd918d56a33065aa177c3509c67e) quickemu: don't depend on qemu_full
* [`f3fe1478`](https://github.com/NixOS/nixpkgs/commit/f3fe1478712c25d6729a21f9187112bad0575916) python312Packages.aiosyncthing: refactor
* [`742c4b07`](https://github.com/NixOS/nixpkgs/commit/742c4b07746acb52693b0d74e6b04428b79827dd) entropy: init at 1.0.7
* [`3bc7f6ab`](https://github.com/NixOS/nixpkgs/commit/3bc7f6ab37f6a768aee43bc571ee6e1fb3fa2871) python312Packages.fe25519: refactor
* [`699ce167`](https://github.com/NixOS/nixpkgs/commit/699ce1676cb43bf908415410b904848e1fa545e1) python312Packages.ge25519: refactor
* [`b3c14316`](https://github.com/NixOS/nixpkgs/commit/b3c1431629dd12d44e3e0b5a290df5b6addef2da) python312Packages.fe25519: migrate to pytest-cov-stub
* [`d98510f4`](https://github.com/NixOS/nixpkgs/commit/d98510f4c69b986eeb0eb2eb610fcfd9a77240b4) python312Packages.ge25519: migrate to pytest-cov-stub
* [`ca487651`](https://github.com/NixOS/nixpkgs/commit/ca48765135a4817e7e2d36e55e7b9255a14b3ed4) minio-warp: 1.0.6 -> 1.0.7
* [`484824ce`](https://github.com/NixOS/nixpkgs/commit/484824ce22dfe297bd6bb351b560ed92a1b69139) mediawriter: 5.2.2 -> 5.2.3
* [`faa8c806`](https://github.com/NixOS/nixpkgs/commit/faa8c806fdafa3207303965781801e324599a1cc) python312Packages.aiovodafone: migrate to pytest-cov-stub
* [`55418d87`](https://github.com/NixOS/nixpkgs/commit/55418d875ec98ecc4448a2b7aaec9cfce63f4042) quickemu: explicitly enable Samba support in QEMU
* [`28c826e1`](https://github.com/NixOS/nixpkgs/commit/28c826e18de846321a506e1b78dae28dba12f0dd) python312Packages.pymodbus: migrate to pytest-cov-stub
* [`a84a96f6`](https://github.com/NixOS/nixpkgs/commit/a84a96f6830066eacacffc0c91d1869dca6bd07c) luaPackages.papis-nvim: init at 0.7.0-1
* [`1684104d`](https://github.com/NixOS/nixpkgs/commit/1684104daeeab411ed926d54347d31c4b45f35f7) vimPlugins.papis-nvim: init at 2024-10-30
* [`41a722f7`](https://github.com/NixOS/nixpkgs/commit/41a722f7c0d0bb5db0a5868301b920cce9cb41b0) python312Packages.pyrainbird: migrate to pytest-cov-stub
* [`62a1b7ff`](https://github.com/NixOS/nixpkgs/commit/62a1b7ff616e60b06dcc5b9cd8a7903899253e3a) python312Packages.pywaze: migrate to pytest-cov-stub
* [`5bcdf4a7`](https://github.com/NixOS/nixpkgs/commit/5bcdf4a78119e1ebbf485a964f965daf0ce00bea) arpack-mpi: append `-mpi` to pname
* [`a8d88191`](https://github.com/NixOS/nixpkgs/commit/a8d881915b7689a72c0e9569a1685be1d6a2cdb3) alpine-make-rootfs: 0.7.0 -> 0.7.1
* [`c9e60c58`](https://github.com/NixOS/nixpkgs/commit/c9e60c588e1a4e3949b3d86f47ba703d8c9c9a19) alpine-make-vm-image: 0.13.0 -> 0.13.1
* [`48e1f116`](https://github.com/NixOS/nixpkgs/commit/48e1f11634a60559a755dafe75e5e788ce46007e) unifi: 8.6.9 -> 9.0.108
* [`8c40a322`](https://github.com/NixOS/nixpkgs/commit/8c40a322b357d882e1f98c783d6709f624e968f9) fityk: fix cross / strictDeps build
* [`ed627141`](https://github.com/NixOS/nixpkgs/commit/ed62714176e5dbb52ba80977f4b8e6a81bd11dc5) python312Packages.jaxopt: disable failing tests
* [`dd7d2c20`](https://github.com/NixOS/nixpkgs/commit/dd7d2c203af5a1676ecd5bc7d4556360a6922073) python312Packages.subarulink: refactor
* [`90109087`](https://github.com/NixOS/nixpkgs/commit/901090877fbfc56c2aedead1d4e15537ba1c5a33) python312Packages.subarulink: migrate to pytest-cov-stub
* [`b5fe94c6`](https://github.com/NixOS/nixpkgs/commit/b5fe94c6c4062428205c658c71fa251c50365433) clipcat: 0.19.0 -> 0.20.0
* [`e20d5738`](https://github.com/NixOS/nixpkgs/commit/e20d57385a767a1fc05504456c74dd43bfbb6180) arpack-mpi: workaround `ld: file not found: @⁠rpath/libquadmath.0.dylib`
* [`fa8055ec`](https://github.com/NixOS/nixpkgs/commit/fa8055ec155e03479ec9e967388f7acc21d4fdca) wxGTK32: reformat with nixfmt
* [`ea385c7f`](https://github.com/NixOS/nixpkgs/commit/ea385c7f9ffada227c7cef343fa2b1f69ad70e7a) wxGTK31, wxGTK32: move to pkgs/by-name
* [`aa120342`](https://github.com/NixOS/nixpkgs/commit/aa1203429f56d2e816a77fda34f069705e975f97) orca-slicer: fix gcc14
* [`ab07c002`](https://github.com/NixOS/nixpkgs/commit/ab07c0025d965b042fed751eead70ae18bcd0761) wxGTK31, wxGTK32: drop setfile stub
* [`f0b0f900`](https://github.com/NixOS/nixpkgs/commit/f0b0f90063fc33714a2ecf323d3b47c919eb45f2) openlinkhub: 0.4.4 -> 0.4.5
* [`e57dd565`](https://github.com/NixOS/nixpkgs/commit/e57dd5657e23fb03a1d9540d997a2dd1301df252) bilibili: 1.16.1-2 -> 1.16.1-3
* [`76872bac`](https://github.com/NixOS/nixpkgs/commit/76872bacbb0ae14ea771816ac50cd702f07bc0d8) mkKdeDerivation: provide proper stdenv when asked for
* [`47f1abca`](https://github.com/NixOS/nixpkgs/commit/47f1abca7cbf459dc5fa984a464a99577d448e3a) nvidia-system-monitor-qt: 1.5 -> 1.6
* [`41ab77f3`](https://github.com/NixOS/nixpkgs/commit/41ab77f3147b315ef10c0fcd8c68540ac03a829b) gtk-sharp-3_0: fix compile error on gcc 14
* [`c84a2088`](https://github.com/NixOS/nixpkgs/commit/c84a2088ee08f980f9e2fb15f9d6605a84a0e864) gtk-sharp-2_0: fix compile error on gcc 14
* [`eb69d60f`](https://github.com/NixOS/nixpkgs/commit/eb69d60f11495b2f139fab64b9b0b368ec0f4f46) playwright: refer to the core project instead of the python test launcher
* [`ebdb307d`](https://github.com/NixOS/nixpkgs/commit/ebdb307d51e998a7755bf02731dafd230d27ddd6) build(deps): bump actions/create-github-app-token from 1.11.0 to 1.11.1 ([nixos/nixpkgs⁠#371397](https://togithub.com/nixos/nixpkgs/issues/371397))
* [`3d92f38f`](https://github.com/NixOS/nixpkgs/commit/3d92f38fbd9d0aed8eee617f1b8730c5727a2b50) lib/types: refactor elemTypeFunctor for types.attrsWith
* [`8523f61f`](https://github.com/NixOS/nixpkgs/commit/8523f61f935486217e2ba4ec5bdd9c11abaf21ee) release-notes: add deprecation note: funtor.wrapped for lib.types.attrsWith
* [`5782ef8d`](https://github.com/NixOS/nixpkgs/commit/5782ef8dc37f8451339dea316a1ef40d5d68540b) lib/types: deprecate functor.wrapped in types.listOf
* [`a0fea4f1`](https://github.com/NixOS/nixpkgs/commit/a0fea4f1bd227945bfd1e7771ee4a2976cb2e5bc) poetryPlugins.poetry-plugin-shell: init at 1.0.0
* [`0a29203c`](https://github.com/NixOS/nixpkgs/commit/0a29203c56873eb959d40e067b1ec502cab3e6a5) python312Packages.safety-schemas: unpin pydantic
* [`da16b33b`](https://github.com/NixOS/nixpkgs/commit/da16b33bc91e5f6766df936326ad56d34162ea70) poetryPlugins.poetry-audit-plugin: unpin poetry
* [`4a6768d4`](https://github.com/NixOS/nixpkgs/commit/4a6768d4f9cb49cce78dca5f73ddfff04969d982) poetryPlugins.poetry-plugin-export: run tests
* [`c518e587`](https://github.com/NixOS/nixpkgs/commit/c518e58752d508ca28bc660cba85bc720f1d2cdf) maintainers: add yechielw
* [`fff647bf`](https://github.com/NixOS/nixpkgs/commit/fff647bfd5b61fb6e59afce7c85eba1acbb60711) smap: init at 0.1.12
* [`7dd39d20`](https://github.com/NixOS/nixpkgs/commit/7dd39d2082524ba19dc9be0df438fd9cbd62b57d) qdmr: 0.12.0 -> 0.12.1 ([nixos/nixpkgs⁠#370767](https://togithub.com/nixos/nixpkgs/issues/370767))
* [`d7f2f1a3`](https://github.com/NixOS/nixpkgs/commit/d7f2f1a3e33633da14ee88602b5ab127b6c868b6) ginac: 1.8.7 -> 1.8.8 ([nixos/nixpkgs⁠#370579](https://togithub.com/nixos/nixpkgs/issues/370579))
* [`f5bd23e7`](https://github.com/NixOS/nixpkgs/commit/f5bd23e78a8eddcbf41417a5376f0fa53de1fbd1) hentai-at-home: 1.6.3 -> 1.6.4
* [`ebbe9f39`](https://github.com/NixOS/nixpkgs/commit/ebbe9f39848cf93a1ca5e36eb50292fa36f6711c) python312Packages.anthropic: 0.39.0 -> 0.42.0
* [`99e1037b`](https://github.com/NixOS/nixpkgs/commit/99e1037b351d7736bd72d29813fd195e1df26ba8) notify-osd: use finalAttrs w/ mkDerivation
* [`fbae2ec8`](https://github.com/NixOS/nixpkgs/commit/fbae2ec8ad52874c85666ee5f301d8e34496dfca) notify-osd: remove fat `with lib`
* [`5f7c8194`](https://github.com/NixOS/nixpkgs/commit/5f7c8194f5b4d0f904ad40af7476d0fb0a587d15) notify-osd: 0.9.24 → 0.9.35+20.04.20191129
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
