### PR TITLE
niv home-manager: update 20665c6e -> fc52a210

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -41,10 +41,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "20665c6efa83d71020c8730f26706258ba5c6b2a",
-        "sha256": "0avq6bhyk0ad63k461yx75158m84pww4p1marx41yyql1534z00a",
+        "rev": "fc52a210b60f2f52c74eac41a8647c1573d2071d",
+        "sha256": "0883pphgnap6kfvscqvvhs3vlp01rh2yf5rdklgns4bp0i9j73ad",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/20665c6efa83d71020c8730f26706258ba5c6b2a.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/fc52a210b60f2f52c74eac41a8647c1573d2071d.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@20665c6e...fc52a210](https://github.com/nix-community/home-manager/compare/20665c6efa83d71020c8730f26706258ba5c6b2a...fc52a210b60f2f52c74eac41a8647c1573d2071d)

* [`5c430231`](https://github.com/nix-community/home-manager/commit/5c4302313d9207f7ec0886d68f8ff4a3c71209a1) neomutt: added missing sort options ([nix-community/home-manager⁠#6283](https://togithub.com/nix-community/home-manager/issues/6283))
* [`45bcdbc9`](https://github.com/nix-community/home-manager/commit/45bcdbc910dc5131943bb6f7edb156617898fd1a) gpg-agent: fix compatibility with sh when enableSshSupport ([nix-community/home-manager⁠#6287](https://togithub.com/nix-community/home-manager/issues/6287))
* [`456e599f`](https://github.com/nix-community/home-manager/commit/456e599f9101ed153dde268b4401c5d294ba6c8c) wayfire: add module ([nix-community/home-manager⁠#6066](https://togithub.com/nix-community/home-manager/issues/6066))
* [`fcc4259c`](https://github.com/nix-community/home-manager/commit/fcc4259cdbcb76138b48ed36b4f41c521910db0d) treewide: stub tests ([nix-community/home-manager⁠#6275](https://togithub.com/nix-community/home-manager/issues/6275))
* [`54b330ac`](https://github.com/nix-community/home-manager/commit/54b330ac067e74314f8ca6b38af6fcfbd17f3e9e) go: add telemetry options
* [`7e008565`](https://github.com/nix-community/home-manager/commit/7e00856596891850ba5ad4c5ecd2ed74468c08c5) flake.lock: Update
* [`01f40d52`](https://github.com/nix-community/home-manager/commit/01f40d52d65318463d71aa485fe9ad6f26357b45) zsh/prezto: add `package` option ([nix-community/home-manager⁠#5938](https://togithub.com/nix-community/home-manager/issues/5938))
* [`d4aebb94`](https://github.com/nix-community/home-manager/commit/d4aebb947a301b8da8654a804979a738c5c5da50) todoman: add todoman module ([nix-community/home-manager⁠#5252](https://togithub.com/nix-community/home-manager/issues/5252))
* [`2532b500`](https://github.com/nix-community/home-manager/commit/2532b500c3ed2b8940e831039dcec5a5ea093afc) ollama: add module ([nix-community/home-manager⁠#5735](https://togithub.com/nix-community/home-manager/issues/5735))
* [`9616d81f`](https://github.com/nix-community/home-manager/commit/9616d81f98032d1ee9bec68ab4b6a8c833add88c) mangohud: make `false` values actually disable ([nix-community/home-manager⁠#6299](https://togithub.com/nix-community/home-manager/issues/6299))
* [`0da8b6ba`](https://github.com/nix-community/home-manager/commit/0da8b6bae9b3179af68c72827541ef88cad413fc) sway: allow sway specific hideEdgeBorders options ([nix-community/home-manager⁠#6304](https://togithub.com/nix-community/home-manager/issues/6304))
* [`fc52a210`](https://github.com/nix-community/home-manager/commit/fc52a210b60f2f52c74eac41a8647c1573d2071d) network-manager-applet: changed nm-applet description ([nix-community/home-manager⁠#6311](https://togithub.com/nix-community/home-manager/issues/6311))
