### PR TITLE
niv niv: update 55422d6f -> e2f66fe5

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -89,10 +89,10 @@
         "homepage": "https://github.com/nmattia/niv",
         "owner": "nmattia",
         "repo": "niv",
-        "rev": "55422d6f2618cd2195eeafa3f16ae63fde723c15",
-        "sha256": "1s6m41hhsydf3lw6ihksc904vcpyd5agwiqq8hb8plyqvsyn74ba",
+        "rev": "e2f66fe558481d6b569358d27db06f7e972ed71b",
+        "sha256": "1xn822jajags6bigdr1ssxvfiyd7d3adhnmmrr9x3maphchkr0x0",
         "type": "tarball",
-        "url": "https://github.com/nmattia/niv/archive/55422d6f2618cd2195eeafa3f16ae63fde723c15.tar.gz",
+        "url": "https://github.com/nmattia/niv/archive/e2f66fe558481d6b569358d27db06f7e972ed71b.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {


### PR DESCRIPTION
## Changelog for niv:
Branch: master
Commits: [nmattia/niv@55422d6f...e2f66fe5](https://github.com/nmattia/niv/compare/55422d6f2618cd2195eeafa3f16ae63fde723c15...e2f66fe558481d6b569358d27db06f7e972ed71b)

* [`e2f66fe5`](https://github.com/nmattia/niv/commit/e2f66fe558481d6b569358d27db06f7e972ed71b) Fix spacing in error output ([nmattia/niv⁠#413](https://togithub.com/nmattia/niv/issues/413))
