### PR TITLE
niv nixpkgs: update 09858bf7 -> e65e23b5

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "09858bf78bf7d367dd95f08a703b404351ef5b3a",
-        "sha256": "06jbpf1d6i7d354alrsrc17f6bllfzky7myc8fl8ms4x6302cyjw",
+        "rev": "e65e23b593f38f57b7076e1e025f904c07d7b848",
+        "sha256": "14l0pfn73miqap6grfvf4vg6c2ghcvzk5gbgsaf780md2b092jqb",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/09858bf78bf7d367dd95f08a703b404351ef5b3a.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/e65e23b593f38f57b7076e1e025f904c07d7b848.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@09858bf7...e65e23b5](https://github.com/nixos/nixpkgs/compare/09858bf78bf7d367dd95f08a703b404351ef5b3a...e65e23b593f38f57b7076e1e025f904c07d7b848)

* [`8db4537c`](https://github.com/NixOS/nixpkgs/commit/8db4537cdaf1334b66e62e2d2526f3e27e12d056) cc-wrapper: Unconditionally warn about skipped native flags
* [`98fea108`](https://github.com/NixOS/nixpkgs/commit/98fea10888ea511f5cc589a8fd980531abff88e0) lvm2: fix libdevmapper SONAME when onlyLib is on
* [`8feda1aa`](https://github.com/NixOS/nixpkgs/commit/8feda1aaac9dba0c739dcc42e1364fc62127e4f0) fetch-npm-deps: handle all git+ urls the same during fixup
* [`35691d23`](https://github.com/NixOS/nixpkgs/commit/35691d23f2c9e029965dcdbf81eda13ecf260347) webrtc-audio-processing: Fetch patch for big-endian support
* [`d989ce94`](https://github.com/NixOS/nixpkgs/commit/d989ce94fa10a81db90179c806861d44553733e5) webrtc-audio-processing: Enable parallel building
* [`0534fd7c`](https://github.com/NixOS/nixpkgs/commit/0534fd7c576409cab7a5af867b748812ab0cff75) git: re-enable test t1700-split-index "null sha1"
* [`fc590fdd`](https://github.com/NixOS/nixpkgs/commit/fc590fdd053b8eee03385d4cff4d71ead4c71547) cc-wrapper: warn if clang's --target option is used on a wrapped compiler
* [`e5226da3`](https://github.com/NixOS/nixpkgs/commit/e5226da3636c72f1bf1db438f39bb2a2c450557b) python312Packages.contourpy: fix cross compilation
* [`68fccae6`](https://github.com/NixOS/nixpkgs/commit/68fccae63d8f6d9bb6e482e1e0c5d7390a87553e) octavePackages.netcdf: 1.0.17 -> 1.0.18
* [`fcb8b742`](https://github.com/NixOS/nixpkgs/commit/fcb8b742109b844fd4c24645f3805c680672a924) octavePackages.netcdf: Propagate netcdf library to octave environment
* [`76f6b5ef`](https://github.com/NixOS/nixpkgs/commit/76f6b5efdf7d75fdc0ad7c82bee58cbad1692e1c) unrar-free: add setupHook
* [`8e6cc2f3`](https://github.com/NixOS/nixpkgs/commit/8e6cc2f3f6b2b8606dc3c521737bfe0677c56014) nixos/networking: fix shellcheck findings with enableStrictShellChecks enabled
* [`82399093`](https://github.com/NixOS/nixpkgs/commit/82399093160f5e37ade7c5539dcf89f0aa529550) perlPackages.XSParseKeyword: 0.44 -> 0.46
* [`ffe2c415`](https://github.com/NixOS/nixpkgs/commit/ffe2c415a7b3c3463287cef7e9f293b49c5aa7d8) xorg.luit: refactor & migrate to pkgs/by-name
* [`58e533ae`](https://github.com/NixOS/nixpkgs/commit/58e533ae328cdddbbe3e5cd956ea0cbf78871ff1) valgrind: 3.23.0 -> 3.24.0
* [`42a9eafa`](https://github.com/NixOS/nixpkgs/commit/42a9eafab012c34225cc732423acb38265be4742) python312Packages.widlparser: 1.0.12 -> 1.1.5
* [`5c96771a`](https://github.com/NixOS/nixpkgs/commit/5c96771a91b74fcdfb5143f50c13b03bd1450d68) python312Packages.widlparser: refactor
* [`ce691f53`](https://github.com/NixOS/nixpkgs/commit/ce691f536f5db321c972cd58218d17fa60708398) python312Packages.seekpath: 2.0.1 -> 2.1.0
* [`a9ea7b29`](https://github.com/NixOS/nixpkgs/commit/a9ea7b296f8df662307dc560dd410c1ba7cdb14c) python312Packages.seekpath: refactor
* [`fb8fdae7`](https://github.com/NixOS/nixpkgs/commit/fb8fdae775a876c9999b3b2ff06ca19dbd8a6388) swig: fix cross-compilation
* [`baecae58`](https://github.com/NixOS/nixpkgs/commit/baecae582fb0fc9aef015a0b1b2d171770887312) tclPackages.lexec: init at 0-unstable-2020-03-11
* [`68e7b65b`](https://github.com/NixOS/nixpkgs/commit/68e7b65bf3e0b348ab711e833d8712c6b4ad29f1) wesnoth: 1.18.2 -> 1.18.3
* [`06715a23`](https://github.com/NixOS/nixpkgs/commit/06715a236845a4891dd9614b764f5cfdc793646c) xmlto: use strictDeps
* [`d76be85c`](https://github.com/NixOS/nixpkgs/commit/d76be85c4151cf7734d4f9e5231a165758adaf6d) python312Packages.kdl-py: init at 1.2.0
* [`96a14dba`](https://github.com/NixOS/nixpkgs/commit/96a14dbad52ea895e31b053543530c4a2ed77237) bikeshed: 3.7.0 -> 4.2.7
* [`da270d49`](https://github.com/NixOS/nixpkgs/commit/da270d4934f0fe189723ef6450a0c15b48dbc365) bikeshed: refactor
* [`ac49606b`](https://github.com/NixOS/nixpkgs/commit/ac49606bdffce90d7ddd304f1e6cfa4b7ab16c9c) all-cabal-hashes: 2024-10-25T11:10:52Z -> 2024-11-07T13:09:31Z
* [`bc61ebc1`](https://github.com/NixOS/nixpkgs/commit/bc61ebc1f5e0b2e790a3800e1821d0a87d9310ff) haskellPackages: stackage LTS 22.39 -> LTS 22.40
* [`ca7e24d0`](https://github.com/NixOS/nixpkgs/commit/ca7e24d079ec3e0df14c2b6f120d0ea2d463ea6b) haskellPackages: regenerate package set based on current config
* [`ae2d745a`](https://github.com/NixOS/nixpkgs/commit/ae2d745af610347cb27bfa0125bfce399f463279) doc/stdenv: accurately describe propagatedNativeBuildInputs
* [`9c8d7408`](https://github.com/NixOS/nixpkgs/commit/9c8d7408c86fbe64b037ee4ef5eebae000508fe2) antlr4_13: 4.13.0 -> 4.13.2
* [`6f8ae8aa`](https://github.com/NixOS/nixpkgs/commit/6f8ae8aa2db1d9f6e822391dad71414e1dc564c0) haskellPackages: adjust to updates on Hackage
* [`a28a3dc7`](https://github.com/NixOS/nixpkgs/commit/a28a3dc721e58f50656d1f399c2bb790dc274753) haskellPackages.aws-spend-summary add maintainer
* [`0984a89f`](https://github.com/NixOS/nixpkgs/commit/0984a89fe289c1b0521e40dd9a913deb309fda48) haskellPackages.haskell-language-server: refactor override
* [`d7694077`](https://github.com/NixOS/nixpkgs/commit/d76940773adeff338d47b2d7c79a23da0d96e282) haskellPackages.ghcide: apply patch for GHC 9.8.3 compat
* [`c64e1dc1`](https://github.com/NixOS/nixpkgs/commit/c64e1dc196e2e5a419b496c70f960180f28ad47f) aws-spend-summary: init
* [`7e02be55`](https://github.com/NixOS/nixpkgs/commit/7e02be55000d8f88dcc0c6df186c457eb2dfe1d9) libnl: 3.10.0 -> 3.11.0
* [`6be30af3`](https://github.com/NixOS/nixpkgs/commit/6be30af34e46090d95dd8b81db38c9e18cd8ad89) obs-studio: don't use ffmpeg-full
* [`db847bf5`](https://github.com/NixOS/nixpkgs/commit/db847bf5ace41d6932b1dbeb38bc9551bc7610c0) xorg.xtrans: 1.5.1 -> 1.5.2
* [`3c2dc98f`](https://github.com/NixOS/nixpkgs/commit/3c2dc98f04400ea34d5c46fc24ec2ad210f00f01) spdlog: 1.14.1 -> 1.15.0
* [`70eff791`](https://github.com/NixOS/nixpkgs/commit/70eff7912f4de4a470f0d22b03f842e285c00134) haskellPackages.reflex: remove patches that were upstreamed
* [`cca2dab0`](https://github.com/NixOS/nixpkgs/commit/cca2dab0de7fec3095f8d6f165c84419173d1dda) aalib: update for ncurses-6.5
* [`0295dd76`](https://github.com/NixOS/nixpkgs/commit/0295dd76598ede3107076512e98b092cfc6b5813) haskellPackages.dependent-sum-template: build with ghc 9.10
* [`5ab3591a`](https://github.com/NixOS/nixpkgs/commit/5ab3591ad01f034048f5a43f8d611f7a0876bddf) haskellPackages.dependent-sum-template: remove jailbreak on 9.8
* [`17ce0ee1`](https://github.com/NixOS/nixpkgs/commit/17ce0ee12fb90e9874f6edfc4c90b357f6066883) rtmpdump: unstable-2021-02-19 -> 2.6
* [`3a7c4af8`](https://github.com/NixOS/nixpkgs/commit/3a7c4af86d476b6aa3fa0b43eea9b832617f3238) libvdpau: fix tracing feature
* [`ac02e474`](https://github.com/NixOS/nixpkgs/commit/ac02e47426e72d1f3e790ad0850d2a30f9e58eb4) opencl-headers: 2024.05.08 -> 2024.10.24
* [`ec3ec603`](https://github.com/NixOS/nixpkgs/commit/ec3ec6038a01c6e22637565976ed82e1625fa006) haskell.compiler.ghcHEAD: disable --hyperlinked-source on aarch64
* [`d4c94e35`](https://github.com/NixOS/nixpkgs/commit/d4c94e35f8162141b48d545080e055fc9eae26a1) fontforge: format with nixfmt
* [`06fc75a3`](https://github.com/NixOS/nixpkgs/commit/06fc75a3a4424d3748521a3c12e156845f336745) fontforge: fix error: Core python package 'pkg_resources' not found: Cannot discover plugins
* [`f2912243`](https://github.com/NixOS/nixpkgs/commit/f2912243332d54f2ee3df308b9f7b23e272d0270) libass: remove unused rasterizerSupport option
* [`8f891250`](https://github.com/NixOS/nixpkgs/commit/8f891250231002e5610e54d01fddf52e65bc7e14) vulkan-loader: format
* [`d4e9241a`](https://github.com/NixOS/nixpkgs/commit/d4e9241a58f63b6ec922434469452e00af7fa0f5) vulkan-loader: format, add option to enable or disable x11 support
* [`a3775eb5`](https://github.com/NixOS/nixpkgs/commit/a3775eb57d53a3113d226e5266b6f9df4971cfa3) haskellPackages: fix test suites on multiple stream libraries
* [`a9e49671`](https://github.com/NixOS/nixpkgs/commit/a9e49671459cc2cce0d078d6f4ac32d072c0bac2) haskellPackages.testcontainers: fix build
* [`ec31910f`](https://github.com/NixOS/nixpkgs/commit/ec31910fe727985c6f0fd8c14c91b12ed8c3c331) haskellPackages.beam-postgres: fix build
* [`56fec67e`](https://github.com/NixOS/nixpkgs/commit/56fec67eb1b8ac9fe3f35356d00d21a4aa72c655) haskellPackages: cleanup overrides after linked pulls made it to hackage
* [`fcb52416`](https://github.com/NixOS/nixpkgs/commit/fcb524165fd310eeb5d95d784425ddb7115f32f7) aws-spend-summary: add shell completions
* [`68f30040`](https://github.com/NixOS/nixpkgs/commit/68f3004020cbce11a102e367d79578297dbd2783) libmpc: use updateAutotoolsGnuConfigScriptsHook for FreeBSD native
* [`d77191f7`](https://github.com/NixOS/nixpkgs/commit/d77191f776ca1809609c98cf968b8e4ef2f8e0d3) libiberty: fix references to /usr/bin/uname for FreeBSD build system
* [`59c5439e`](https://github.com/NixOS/nixpkgs/commit/59c5439ea8f18a2c6fe37de3932e09d00af380ee) isl: use updateAutotoolsGnuConfigScriptsHook to fix build on FreeBSD native
* [`664360c4`](https://github.com/NixOS/nixpkgs/commit/664360c45895506b6e57ae89d345e9e04b62669f) xmpp-bridge: mark broken for Darwin
* [`eeb1a225`](https://github.com/NixOS/nixpkgs/commit/eeb1a225c6462c4160a0802ca1485a9779d8a259) tinyemu: mark broken on Darwin
* [`4d0e8b4e`](https://github.com/NixOS/nixpkgs/commit/4d0e8b4ebca1bf2ce64a312cbe98d994c9dc70fd) mindustry: mark broken on aarch64-linux as well
* [`e11db000`](https://github.com/NixOS/nixpkgs/commit/e11db000c5f0a857e9dd637e6fcb7a7618d9536a) glow-lang: mark broken, doesn't build since 2023-10-13
* [`b5364a27`](https://github.com/NixOS/nixpkgs/commit/b5364a27e3d3d790cc7efe17fb7612d792fdfac9) ibmcloud-cli: 2.27.0 -> 2.30.0
* [`665b3788`](https://github.com/NixOS/nixpkgs/commit/665b3788d3bcc132f1795d146a8ad782c4ac3a03) ibmcloud-cli: remove CF notices
* [`2fe42ec2`](https://github.com/NixOS/nixpkgs/commit/2fe42ec2da6fc604dc3a47f6f7c921c9431f01ad) python312Packages.dnspython: disable network
* [`c7047112`](https://github.com/NixOS/nixpkgs/commit/c7047112ab72b5a49722b297b7fd05808dfb5955) Revert "git-annex: work around corrupted store paths of dependencies"
* [`4fb0a4a4`](https://github.com/NixOS/nixpkgs/commit/4fb0a4a47c6b7fad61c3caaa3937a4e18afeee7e) haskell.compiler.ghcHEAD: bootstrap using GHC 9.10
* [`9c2ca55d`](https://github.com/NixOS/nixpkgs/commit/9c2ca55dd36db44b59c6993840679cbfab9206b9) haskell.packages.ghcHEAD: start compiler config for GHC 9.14
* [`05dc4b5a`](https://github.com/NixOS/nixpkgs/commit/05dc4b5ac8bb35cb2451075a0ba03df992fed6fe) libllvm: use updateAutotoolsGnuConfigScriptsHook to fix FreeBSD->other cross build
* [`1f787f65`](https://github.com/NixOS/nixpkgs/commit/1f787f659f44c9b9f805c3fca0ab3d0be4ef17cc) python312Packages.hypothesis: disable flaky test
* [`c8fa99e9`](https://github.com/NixOS/nixpkgs/commit/c8fa99e91eefc8b4ee84f30b9c00b8fe61045bf2) linode-cli: 5.50.0 -> 5.54.0
* [`26be2762`](https://github.com/NixOS/nixpkgs/commit/26be2762a08c2d4943b68d1b957b9381e65d8c3b) python312Packages.watchdog: disable flaky test everywhere
* [`676035e9`](https://github.com/NixOS/nixpkgs/commit/676035e961b65c1e0162c32d8ab8eb4e0f935572) sourcemapper: init at 0-unstable-2024-03-22
* [`8e3b8e08`](https://github.com/NixOS/nixpkgs/commit/8e3b8e080571ee2c8a2bf6c31a4f10b093547d93) pkgs/build-support: cc-wrapper.sh not detecting c++ files by extension
* [`029555ec`](https://github.com/NixOS/nixpkgs/commit/029555ec8d5802df415d530aa5a8962d5354f918) opencv4: restore sfm module
* [`3d2ec781`](https://github.com/NixOS/nixpkgs/commit/3d2ec781e77c39ef4e68b557408d11752d76f167) haskellPackages.hailgun: fix build
* [`5e104797`](https://github.com/NixOS/nixpkgs/commit/5e104797bad04e818d276669810bd4caa544c1b1) haskellPackages.servant-auth-server: unbreak
* [`380913f9`](https://github.com/NixOS/nixpkgs/commit/380913f9177e462e73bf98b09f1a15a7a511173a) gumbo: 0.12.1 -> 0.12.2
* [`0b109d02`](https://github.com/NixOS/nixpkgs/commit/0b109d021ffc82fb3630e07d76a37c7eb6474777) python312Packages.uvloop: disable flaky test
* [`d51b1767`](https://github.com/NixOS/nixpkgs/commit/d51b1767a3583e92962357fa0950a6b07a9ec6ca) haskellPackages.http-reverse-proxy: disable tests on darwin
* [`e01fa430`](https://github.com/NixOS/nixpkgs/commit/e01fa430c2b703f863fe0cee5d1e530280bdd4aa) libinput: 1.26.2 -> 1.27.0
* [`a81011bc`](https://github.com/NixOS/nixpkgs/commit/a81011bcc19db1982c28ae207fbc48ec68bcdea8) gradle: add udev to the JNA library path
* [`f077b3d5`](https://github.com/NixOS/nixpkgs/commit/f077b3d5e677d1b086901317ed2cd5f91223c19b) graylog-6_0: 6.0.4 -> 6.0.8
* [`e702d7d8`](https://github.com/NixOS/nixpkgs/commit/e702d7d82eff2b9b4587239cd30f5e0fae1d1128) graylog-5_2: 5.2.9 -> 5.2.12
* [`10562ef1`](https://github.com/NixOS/nixpkgs/commit/10562ef16a14b16d83b79c5b2597c31f12e1b2b7) python3Packages.pytest-rerunfailures: 14.0 -> 15.0
* [`8f3098ea`](https://github.com/NixOS/nixpkgs/commit/8f3098ead65532c758f29c65eb49fe0e59380111) s2n-tls: 1.5.7 -> 1.5.9
* [`87b01019`](https://github.com/NixOS/nixpkgs/commit/87b010196489f96e4acdcc804ed3d096476e46ad) rust: adjust env definition order
* [`29bbd1bc`](https://github.com/NixOS/nixpkgs/commit/29bbd1bc81024237b9f9b8be59e1d1b6bb75fc07) ghostscript: fix install names on Darwin
* [`67a5661a`](https://github.com/NixOS/nixpkgs/commit/67a5661a6a46f724aee29004fa3d9547d8eaabbb) octavePackages: Ensure locales are found and present in final env
* [`d34f5f6d`](https://github.com/NixOS/nixpkgs/commit/d34f5f6d916a093b5f8a407510d476f0607447d5) ell: 0.70 -> 0.71
* [`b4aaf6ac`](https://github.com/NixOS/nixpkgs/commit/b4aaf6accb7bb3cb5c8824efeb2988f2a1202b6e) sqlite, sqlite-analyzer: 3.47.0 -> 3.47.1
* [`63c55901`](https://github.com/NixOS/nixpkgs/commit/63c55901de1dea4194f4b53d0ccc3fa7b3c03ad3) git: 2.47.0 -> 2.47.1
* [`40638e5a`](https://github.com/NixOS/nixpkgs/commit/40638e5aaa4f86ecb35b344546d4ed5c2f8d7bdc) xcbuild: fix interactive applications run by xcrun
* [`5b2878e7`](https://github.com/NixOS/nixpkgs/commit/5b2878e771696e5f1b80b0f433578cd9177b82a2) xtreemfs: unpin Boost
* [`ef8ec3e6`](https://github.com/NixOS/nixpkgs/commit/ef8ec3e69b183e25c0286811fb1cbf472e38a372) python312Packages.charset-normalizer: 3.3.2 -> 3.4.0
* [`4d0ad83e`](https://github.com/NixOS/nixpkgs/commit/4d0ad83ee1a30bb275012aff4ea9c2054a9954c5) python312Packages.htmldate: 1.9.1 -> 1.9.2
* [`b9efad37`](https://github.com/NixOS/nixpkgs/commit/b9efad374e98cde9114f1054f0d97055b036091e) buildGoModule: handle ldflags and tags __structuredAttrs-agnostically
* [`22c6ae97`](https://github.com/NixOS/nixpkgs/commit/22c6ae979e4040218af23c31efb84940e72b46d6) buildGoModule: Use environment variable GOOS and GOARCH directly
* [`e1bbbad0`](https://github.com/NixOS/nixpkgs/commit/e1bbbad05dee2fa6d58364e77424f92f91c98e45) gbenchmark: 1.9.0 -> 1.9.1
* [`24929d6d`](https://github.com/NixOS/nixpkgs/commit/24929d6da2dad6de1c4513ae9adf785a93f4a15d) npm-check-updates: 16.14.12 -> 17.1.10
* [`6bf41de4`](https://github.com/NixOS/nixpkgs/commit/6bf41de4b5bec2eb908fa482b37cbe30d150c182) freebsd: improve overridability again
* [`622f566d`](https://github.com/NixOS/nixpkgs/commit/622f566d8cd531e932d9b566fa56ed09635c1190) freebsd: add upstream patches for clang 19 compatibility
* [`5a854b01`](https://github.com/NixOS/nixpkgs/commit/5a854b01b2a23d92840297c621d31fdf300bc5d0) libimagequant: 4.3.1 -> 4.3.3
* [`25247977`](https://github.com/NixOS/nixpkgs/commit/25247977a6b0c76094db80678918f97942518957) enpass: 6.9.2.1563 -> 6.10.1.1661
* [`d7a7b89e`](https://github.com/NixOS/nixpkgs/commit/d7a7b89edaeae85d932dc4d35710de4a7c185ef1) libopenmpt: 0.7.11 -> 0.7.12
* [`8bb6a928`](https://github.com/NixOS/nixpkgs/commit/8bb6a928b4f28ef1c60b206b237860008d5abbd3) desktop-file-utils: 0.27 -> 0.28
* [`4eb10206`](https://github.com/NixOS/nixpkgs/commit/4eb10206503ed38136269701ef4823ba401926a0) bash: define DEFAULT_LOADABLE_BUILTINS_PATH for non-FHS builds
* [`50b34d2f`](https://github.com/NixOS/nixpkgs/commit/50b34d2fffa46c11e4a488fd08edc7e82d8ba0dd) libgpg-error: 1.50 -> 1.51
* [`f1f383cc`](https://github.com/NixOS/nixpkgs/commit/f1f383cc5e2fc1406fc8cba27c16e9254f069b38) x265: format
* [`cd2a5352`](https://github.com/NixOS/nixpkgs/commit/cd2a5352360f70a2ddeb5cf1ab617efb3ea96f02) x265: 3.6 -> 4.1
* [`4a61ef63`](https://github.com/NixOS/nixpkgs/commit/4a61ef63764fbb80e8bbbd6c27ed91d58adbe75a) release-cross: replace x86_64-darwin with aarch64-darwin
* [`53860b80`](https://github.com/NixOS/nixpkgs/commit/53860b807f51bca88d34d5ea65c7aea5dde0c344) python312Packages.ipyniivue: 2.0.1 -> 2.1.0
* [`4d8234eb`](https://github.com/NixOS/nixpkgs/commit/4d8234ebad4e3296dd61cdcf58074c97645525ed) python312Packages.sqlparse: 0.5.1 -> 0.5.2
* [`60339704`](https://github.com/NixOS/nixpkgs/commit/603397045cad84eb1554b7cbc219cba078a2ec55) open62541: 1.4.6 -> 1.4.8
* [`38a888a1`](https://github.com/NixOS/nixpkgs/commit/38a888a13404272628e6b37fe6ec4af6fadc5a76) xterm: 395 -> 396
* [`ec2b9886`](https://github.com/NixOS/nixpkgs/commit/ec2b988672affc7db695c1aba96aca436d678826) unixtools: fix subpackages to include ALL relevant manpages
* [`32c575c0`](https://github.com/NixOS/nixpkgs/commit/32c575c04279cde337428fbc86b4cd6832dfe4be) m17n_db: 1.8.7 -> 1.8.9
* [`fc9ea42a`](https://github.com/NixOS/nixpkgs/commit/fc9ea42a0baab729a76ebd302ec68c1bab60dba0) libdrm: 2.4.123 -> 2.4.124
* [`7bfa443f`](https://github.com/NixOS/nixpkgs/commit/7bfa443f6a669d8513707484a23aee06e72bece3) libcap: 2.70 -> 2.73
* [`0c170c3a`](https://github.com/NixOS/nixpkgs/commit/0c170c3ab3c9b497af33d64710ec647f7cfc6684) python312Packages.argcomplete: 3.5.1 -> 3.5.2
* [`e5949f15`](https://github.com/NixOS/nixpkgs/commit/e5949f158f0c5abddd6f3a240a226d80f90b9cba) graphviz: 12.2.0 -> 12.2.1
* [`52cdd2a1`](https://github.com/NixOS/nixpkgs/commit/52cdd2a1dd6f120a94aacdad401582788aaff681) docbook2x: fix strictDeps
* [`95c179f9`](https://github.com/NixOS/nixpkgs/commit/95c179f9fbe0178a6d96cf0c1e3e06566d90aa29) haskell.compiler.ghc94{5,6}: remove at 9.4.5 and 9.4.6, respectively
* [`0ec04bb2`](https://github.com/NixOS/nixpkgs/commit/0ec04bb2ba713fdb9274ee6e0e3dd16a16e3e0c1) libbpf: 1.4.7 -> 1.5.0
* [`93368ac4`](https://github.com/NixOS/nixpkgs/commit/93368ac469925dba433c8e6a3b1772c5547f744f) ghostscript: fix cross for armv7l
* [`608357a5`](https://github.com/NixOS/nixpkgs/commit/608357a5a1dc7ea822dfde8e1f214dbc4b443dcc) setup-hooks/set-source-date-epoch-to-latest.sh: quote output path in updateSourceDateEpoch
* [`65576841`](https://github.com/NixOS/nixpkgs/commit/655768419e15811f2143941f98d35594f566e78a) nixos/trilium: add adjustable package
* [`d442876f`](https://github.com/NixOS/nixpkgs/commit/d442876f16e12af5628eb11191b3f09099cf886b) treewide: update openstack clis to python 3.12
* [`56491939`](https://github.com/NixOS/nixpkgs/commit/564919392a0818737c5333b6262f969c30674b53) python3Packages.ufoprocessor: 1.9.0 -> 1.13.3
* [`38b5b2b6`](https://github.com/NixOS/nixpkgs/commit/38b5b2b672f6a0d2fd806022188b7f442832cb05) python3Packages.fonttools: 4.54.1 -> 4.55.2
* [`0a41c15b`](https://github.com/NixOS/nixpkgs/commit/0a41c15b2e40db0070818bdee86cc90a22562c0a) python3Packages.afdko: 4.0.1 -> 4.0.2
* [`cc07d62b`](https://github.com/NixOS/nixpkgs/commit/cc07d62bc20ac9104c3130072475dcdaf95338cd) python3Packages.fontpens: 0.2.4 -> 0.3.0
* [`be53dfe6`](https://github.com/NixOS/nixpkgs/commit/be53dfe6b9011f0113f9820e89cb5e24b5f9350c) python312Packages.fontparts: 0.12.2 -> 0.12.3
* [`e7ed4bfa`](https://github.com/NixOS/nixpkgs/commit/e7ed4bfa74b8a19e004d253196546ddfb3302507) glib: setup-hook: glibPreFixupPhase -> glibPostInstallHook
* [`2a887396`](https://github.com/NixOS/nixpkgs/commit/2a887396513a5cd369d6913d15db5b7ccf56d54b) gobject-introspection: setup-hook: move giDiscoverSelf to postInstallHook
* [`54f04571`](https://github.com/NixOS/nixpkgs/commit/54f045716d34649a316b3d792b069f6529d7ecc9) python3Packages.pytest-forked: simplify setup hook
* [`0cd7dfa9`](https://github.com/NixOS/nixpkgs/commit/0cd7dfa96cebfa474b0670ad1810b620cbe7ff93) python3Packages.pytest-xdist: simplify setup hook
* [`f1518d36`](https://github.com/NixOS/nixpkgs/commit/f1518d36753d1497df2f8b4e82b46b8e6bafe8ed) systemd: 256.8 -> 256.9
* [`56f8d1e9`](https://github.com/NixOS/nixpkgs/commit/56f8d1e98ad21f0fe83412cab8443b4820f04831) appstream: 1.0.3 -> 1.0.4
* [`c1dc459b`](https://github.com/NixOS/nixpkgs/commit/c1dc459b310a61dc3dd3f8f6c16ae995743226c2) openjpeg: 2.5.2 -> 2.5.3
* [`2dab1113`](https://github.com/NixOS/nixpkgs/commit/2dab111331a71f3ba8f29e10b688009dabfc0b0a) SDL2: 2.30.6 -> 2.30.10
* [`4a880d24`](https://github.com/NixOS/nixpkgs/commit/4a880d2484c64fb87d8a210c9a7db9b91fa3cad1) llvmPackages.bolt: Use ninja, drop libclang dependency
* [`1d5d5314`](https://github.com/NixOS/nixpkgs/commit/1d5d531429ad92fd6fa8ddf3a9354100cb9faeff) sway-unwrapped: backport libinput-1.27 support
* [`d022ffba`](https://github.com/NixOS/nixpkgs/commit/d022ffbafd047180c3209c113a0280f0f28c3be5) gnupg: format with nixfmt
* [`563e111e`](https://github.com/NixOS/nixpkgs/commit/563e111e67438cbe1609615ae3c639602f2e00a8) gnupg: 2.4.5 -> 2.4.7
* [`820f3631`](https://github.com/NixOS/nixpkgs/commit/820f3631b9e945535f872341852802e70f2a66ab) python3Packages.moto: 5.0.20 -> 5.0.22
* [`14414ee6`](https://github.com/NixOS/nixpkgs/commit/14414ee678e71231a852942e202040f131188aa5) buildEnv: builder.pl: specify parameter ignoreSingleFileOutput after priority
* [`667d42c0`](https://github.com/NixOS/nixpkgs/commit/667d42c00d566e091e6b9a19b365099315d0e611) treewide: format all inactive Nix files
* [`a3d0d19b`](https://github.com/NixOS/nixpkgs/commit/a3d0d19bb8bf0364c525dd1270d0607612cff415) buildEnv: builedr.pl: use signatures
* [`f7b4d46f`](https://github.com/NixOS/nixpkgs/commit/f7b4d46f4829290b1407c5f5055047c7f3d94047) curl: 8.11.0 -> 8.11.1
* [`9a4428aa`](https://github.com/NixOS/nixpkgs/commit/9a4428aa46b07d65d8c92fe739f0d76414f5dc73) re2c: 4.0.1 -> 4.0.2
* [`b69edc44`](https://github.com/NixOS/nixpkgs/commit/b69edc44cc1cbbfaa85c5c6f067499409f46d51c) cataclysm-dda: clean up buildInputs
* [`59331c3a`](https://github.com/NixOS/nixpkgs/commit/59331c3a174455ff68cdaa959dd98a5fd13a6930) llvmPackages: Split tablegen into its own derivation
* [`15fd33d5`](https://github.com/NixOS/nixpkgs/commit/15fd33d586aab6f35bf2168b13aa2e2abb394398) socat: 1.8.0.1 -> 1.8.0.2
* [`5d3ea7b3`](https://github.com/NixOS/nixpkgs/commit/5d3ea7b3e4545b1105b29740fabec8326a303fee) python3Packages.typeguard: cleanup
* [`afa24188`](https://github.com/NixOS/nixpkgs/commit/afa24188ce18a0534ac76100df827e9c9e6a3834) python3Packages.typeguard: 4.3.0 -> 4.4.1
* [`928cd315`](https://github.com/NixOS/nixpkgs/commit/928cd3150334a91d3d9014398f3e00c8cc87d611) glog: 0.6.0 -> 0.7.1
* [`6e40f855`](https://github.com/NixOS/nixpkgs/commit/6e40f855105b0c458eeef2d64db6d21ae7fc2ccf) unbound: bison is required when cross-compiling
* [`41e34e0c`](https://github.com/NixOS/nixpkgs/commit/41e34e0c2e6a7e26d62634075fc4362d6e3bdc4c) pinentry_mac: fix strictDeps ([nixos/nixpkgs⁠#361859](https://togithub.com/nixos/nixpkgs/issues/361859))
* [`9b370cbc`](https://github.com/NixOS/nixpkgs/commit/9b370cbc0033f4b926c090a476f334c7cd839e13) json-glib: 1.10.0 -> 1.10.6
* [`5843a13d`](https://github.com/NixOS/nixpkgs/commit/5843a13d3897708caa0bce8b9a0e59529b442f02) nixos/tests/jenkins: increase disk size to 2 GiB
* [`fb3449bd`](https://github.com/NixOS/nixpkgs/commit/fb3449bd17db599056af6cf975edebd8730f3a49) jenkins-job-builder: add passthru.tests
* [`a7e9d552`](https://github.com/NixOS/nixpkgs/commit/a7e9d5524b2e5ecca81c41752907096b0f5c14fd) avahi: apply patch for CVE-2024-52616
* [`5ab79f98`](https://github.com/NixOS/nixpkgs/commit/5ab79f9898eb375b00f7624074dc87d92a091f17) stdenv/darwin: remove libunistring
* [`0182edcf`](https://github.com/NixOS/nixpkgs/commit/0182edcf58c8603704ec4a285e2ecf4733a9e5d1) libunistring: use gnu libiconv on darwin
* [`5587af11`](https://github.com/NixOS/nixpkgs/commit/5587af11e3446f6233c2486da9b5dcf8b8f7902b) Revert "guile: workaround for libunistring / darwin libiconv"
* [`6f1347b6`](https://github.com/NixOS/nixpkgs/commit/6f1347b6fd487452a9d75f13cd4b76d31b8079ec) tinysparql: 3.8.1 -> 3.8.2
* [`9ed03e6a`](https://github.com/NixOS/nixpkgs/commit/9ed03e6ab8326f7c260bba181506752af1c0e200) python3Packages.dirsearch: enable tests & misc fixes
* [`aa788a5f`](https://github.com/NixOS/nixpkgs/commit/aa788a5f1fc898f7081135c63aa29bff930741bd) python3Packages.pydantic-core: fix aarch64-linux cross compilation
* [`f4ee239a`](https://github.com/NixOS/nixpkgs/commit/f4ee239a9878c6ad9afb9880627af8a3f7c5ce8a) python3Packages.watchfiles: fix aarch64-linux cross compilation
* [`c0ce5813`](https://github.com/NixOS/nixpkgs/commit/c0ce5813c64a2a63f1d522e507ee5921895034fc) python312Packages.rpds-py: specify the interpreter version to maturin
* [`890829e2`](https://github.com/NixOS/nixpkgs/commit/890829e256a36a81292b79356082c22b7c7c3690) tpm2-tss: enable darwin builds
* [`4ce241c8`](https://github.com/NixOS/nixpkgs/commit/4ce241c88276a0892cc0907e805f2142b1f2b478) replaceVarsWith: init
* [`de0eb4cf`](https://github.com/NixOS/nixpkgs/commit/de0eb4cfbf2612489db75ec88332787ad205e10d) sbcl: git versions of SBCL use ps in checkPhase
* [`80cc159a`](https://github.com/NixOS/nixpkgs/commit/80cc159a7d5fad7e69c69932d3d5b4a6d96b46ee) sbcl: 2.4.10 -> 2.4.11
* [`42ea6796`](https://github.com/NixOS/nixpkgs/commit/42ea6796bf05358aaab4c47444fc1eca758cd504) stumpwm: pin to sbcl 2.4.10
* [`504c876e`](https://github.com/NixOS/nixpkgs/commit/504c876ec6e152569049838ad6d738e1d00deee3) doc/interoperability: add OpenXR doc
* [`62b63369`](https://github.com/NixOS/nixpkgs/commit/62b63369425bdede6d6f9a4092f39d8283dfcc46) auto-patchelf: Fix missing defaults and add --no-add-existing option
* [`cb45ad86`](https://github.com/NixOS/nixpkgs/commit/cb45ad8681f07c57ebff47a7b827cb9927f6d028) envision: autopatchelf after build
* [`a4667d93`](https://github.com/NixOS/nixpkgs/commit/a4667d9375230059ae728326e8cac8dcbc6fadf3) mpg123: 1.32.9 -> 1.32.10
* [`eab2c5a2`](https://github.com/NixOS/nixpkgs/commit/eab2c5a2ae820d1baa5973735455c38207e5da90) xorg.libXxf86vm: 1.1.5 -> 1.1.6
* [`321bd31b`](https://github.com/NixOS/nixpkgs/commit/321bd31b60641009ac87e1b934d6bfde1f4c1d9e) replaceVarsWith: fix checkPhase with dir set
* [`e58e0c15`](https://github.com/NixOS/nixpkgs/commit/e58e0c158ec5715b63e456b6c1c9cc0e327cc913) various: replace substituteAll with replaceVarsWith
* [`269fdda9`](https://github.com/NixOS/nixpkgs/commit/269fdda927b464efc5441c509d581ead6e18dcf6) llvmPackages: sed -i 's/--replace /--replace-fail /g'
* [`ca840832`](https://github.com/NixOS/nixpkgs/commit/ca840832cb5e17f218e67867b24893085d96361b) libdeflate: 1.22 -> 1.23
* [`7c9c5797`](https://github.com/NixOS/nixpkgs/commit/7c9c5797f825e1cb869d205714fff0b2d20a359b) haskellPackages.yi-language: drop obsolete patch
* [`9e4756b6`](https://github.com/NixOS/nixpkgs/commit/9e4756b6869d49b5443aa1c96e9b0e810f3fb7b1) wrapGAppsHook: append *Phases with appendToVar
* [`6f8448a1`](https://github.com/NixOS/nixpkgs/commit/6f8448a10c9eaa8df0e1e2cc856927bbe65a1c7e) gpr-project-darwin-rpath-hook.sh: append *Phases with appendToVar
* [`b8d4a65c`](https://github.com/NixOS/nixpkgs/commit/b8d4a65cb17eb3ddec8f742f424a6d195500f281) dotnetFixupHook: append *Phases with appendToVar
* [`3e7009de`](https://github.com/NixOS/nixpkgs/commit/3e7009dee38ccf8d188e5bbcc69df4fd656d5821) qt5.wrapQtAppsHook: append *Phases with appendToVar
* [`8bd6a783`](https://github.com/NixOS/nixpkgs/commit/8bd6a7839902fbd1c875bd1ef4cc09f2e8a48dd7) qt6.wrapQtAppsHook: append *Phases with appendToVar
* [`fd54a563`](https://github.com/NixOS/nixpkgs/commit/fd54a5636e57a4f498a006ef7a482c2415df14f3) drop-icon-theme-cache.sh: add to *Phases with appendToVar
* [`01dc95c6`](https://github.com/NixOS/nixpkgs/commit/01dc95c6d28b9a9cf0eb8da945d2f36349a5c281) desktop-file-utils: setup-hook.sh: add to *Phases __structuredAttrs-agnostically
* [`6a6d1d12`](https://github.com/NixOS/nixpkgs/commit/6a6d1d12845ba8abc3028902b96731d8dcbb6365) linux: enable CONFIG_MEMORY_HOTPLUG_DEFAULT_ONLINE
* [`a46ae72f`](https://github.com/NixOS/nixpkgs/commit/a46ae72feefdbfa10afc1122a072ff6c194db16b) granian: 1.6.1 -> 1.7.0
* [`0994918b`](https://github.com/NixOS/nixpkgs/commit/0994918b4cd1d4fc043bdc75173737c5371853ea) xorg.libXv: 1.0.12 -> 1.0.13
* [`82d4f699`](https://github.com/NixOS/nixpkgs/commit/82d4f699252a542b44e47e82524847165e4df6a5) zeromq: fix static, pkgConfigModules, move to by-name
* [`af3a9bcd`](https://github.com/NixOS/nixpkgs/commit/af3a9bcd2c1a19d162d0b328a0c8330423390e9e) treewide: zeromq4 -> zeromq
* [`a156555f`](https://github.com/NixOS/nixpkgs/commit/a156555f535fda047ab73f7ec58fb6f54be1998d) lib2geom: Disable tests on i686
* [`c48af16c`](https://github.com/NixOS/nixpkgs/commit/c48af16c0973b2a58d167df56f30daf22380809c) s2n-tls: 1.5.9 -> 1.5.10
* [`4e019c16`](https://github.com/NixOS/nixpkgs/commit/4e019c1689e1d8d427ce88d9e0bf109768ca4544) sqlite, sqlite-analyzer: 3.47.1 -> 3.47.2
* [`a047c632`](https://github.com/NixOS/nixpkgs/commit/a047c632be7c76144a99a8d23eb2655503ea311c) lvm2: 2.03.28 -> 2.03.29
* [`bbbe3d4d`](https://github.com/NixOS/nixpkgs/commit/bbbe3d4ddc67fab9d39d9dade898478de462ffea) llvmPackages: remove _IMPORT_PREFIX replacements
* [`98b12ee1`](https://github.com/NixOS/nixpkgs/commit/98b12ee1f43336c710da6340d9f3c5db802d1b04) rust-bindgen-unwrapped: 0.70.1 -> 0.71.1
* [`71d262c2`](https://github.com/NixOS/nixpkgs/commit/71d262c2e00fa014bca6b3e724aa4b0f7e0ab76a) llvmPackages_{12-19}.llvm: fix darwin build
* [`81bf89d5`](https://github.com/NixOS/nixpkgs/commit/81bf89d5e881cbe03770453d1ac5d92c56368348) llvmPackages_19: 19.1.5 -> 19.1.6
* [`f1ce2245`](https://github.com/NixOS/nixpkgs/commit/f1ce22458dd39fbd86d3f209ac7cba3a3e99e6c1) xorg.xorgserver: 21.1.14 -> 21.1.15
* [`ba274cf3`](https://github.com/NixOS/nixpkgs/commit/ba274cf3b95b642bbf731fe4cfef5070d2e88650) meson: 1.6.0 -> 1.6.1 ([nixos/nixpkgs⁠#365763](https://togithub.com/nixos/nixpkgs/issues/365763))
* [`c247ef1f`](https://github.com/NixOS/nixpkgs/commit/c247ef1ff52042750e76f1b4d43c12c869c9885b) libuv: disable flaky darwin test
* [`c08ee11f`](https://github.com/NixOS/nixpkgs/commit/c08ee11f8db831bd89dc862a53e8a2c70683c51f) libuv: enable x64 darwin tests
* [`69dd998d`](https://github.com/NixOS/nixpkgs/commit/69dd998de1bf49d766ee7669f5b18beb5510bfe8) libuv: remove redundant conditionally disabled tests
* [`822e728a`](https://github.com/NixOS/nixpkgs/commit/822e728ac3205dc478680d66bb5e85ab1f3bc0cb) bintools-wrapper: wrap LLVM strip as well
* [`48a0850c`](https://github.com/NixOS/nixpkgs/commit/48a0850c15b8123b506b4cc1d79079c518688140) linux: allow building with ld.lld
* [`70cc2515`](https://github.com/NixOS/nixpkgs/commit/70cc251554d883130ae1a94ffd3508c2d521db6a) linux: simplify toolchain selection
* [`870bd95d`](https://github.com/NixOS/nixpkgs/commit/870bd95d2b126f647fd28cd2b44201ae9c31a6c8) protobuf: 29.1 -> 29.2
* [`6c47e128`](https://github.com/NixOS/nixpkgs/commit/6c47e128a38087a6ee2bdcc3223a5fc86e359949) xorg.libxshmfence: 1.3.2 -> 1.3.3
* [`19988ff6`](https://github.com/NixOS/nixpkgs/commit/19988ff6f5afb51b6ea2154354e51be6e7fe5f35) xorg.libXrender: 0.9.11 -> 0.9.12
* [`002b5ce8`](https://github.com/NixOS/nixpkgs/commit/002b5ce885c6a382023af63d750a1156e236c2af) llvmPackages.llvm: Relax replace-fail in tests
* [`3fdf224d`](https://github.com/NixOS/nixpkgs/commit/3fdf224de26f559324cde0e0d38f0475fdb03359) llvmPackages.tblgen: Fix 12/13/14 build
* [`09f0e922`](https://github.com/NixOS/nixpkgs/commit/09f0e9226890fa0cb723a9de4112adc2dee86ae6) gnu-efi: fix hash
* [`9cc80fe1`](https://github.com/NixOS/nixpkgs/commit/9cc80fe1f62862e67e7d91ac41140c98282c0ae9) xorg.libxcvt: 0.1.2 -> 0.1.3
* [`662cf493`](https://github.com/NixOS/nixpkgs/commit/662cf493f0bbb6ceaaf32b96fea3636064e8d850) tests.overriding: format with nixfmt-rfc-style
* [`9e66d6ce`](https://github.com/NixOS/nixpkgs/commit/9e66d6ce585636cd243c91a54e09cb7faae5c021) tests.overriding: restructure and categorise by test targets
* [`cb945702`](https://github.com/NixOS/nixpkgs/commit/cb94570270f632fa83cad925e82b5253723ff1db) libtool: 2.4.7 -> 2.5.4 ([nixos/nixpkgs⁠#363684](https://togithub.com/nixos/nixpkgs/issues/363684))
* [`1c554f83`](https://github.com/NixOS/nixpkgs/commit/1c554f83acae5cc9dfa02a1bb459ae6ebf63cbb0) Reapply "netpbm: 11.8.1 -> 11.8.2" ([nixos/nixpkgs⁠#366656](https://togithub.com/nixos/nixpkgs/issues/366656))
* [`7ba4f731`](https://github.com/NixOS/nixpkgs/commit/7ba4f73152a55e914cb72fe6a02e692e1d10fd6b) folly: 2024.11.18.00 -> 2024.12.09.00
* [`0deb5cdf`](https://github.com/NixOS/nixpkgs/commit/0deb5cdffda7dbf4b69eb8bee17fb006db730731) fizz: 2024.11.18.00 -> 2024.12.09.00
* [`f924da6b`](https://github.com/NixOS/nixpkgs/commit/f924da6bd9a524e756175da2849563e42a17919c) mvfst: 2024.11.18.00 -> 2024.12.09.00
* [`a2f78fb7`](https://github.com/NixOS/nixpkgs/commit/a2f78fb7dd70657efa5d5a7ca54049f1d45bf6b1) wangle: 2024.11.18.00 -> 2024.12.09.00
* [`73b6872a`](https://github.com/NixOS/nixpkgs/commit/73b6872ab66e83b9d441f3cd3b5a1025b0cf0e8a) fbthrift: 2024.11.18.00 -> 2024.12.09.00
* [`5959b9f6`](https://github.com/NixOS/nixpkgs/commit/5959b9f6c940084aa10cc741eac30b4188c28a72) fb303: 2024.11.18.00 -> 2024.12.09.00
* [`2d19c9d3`](https://github.com/NixOS/nixpkgs/commit/2d19c9d3280ef4ae8389f1772462a1d1dee15bb6) edencommon: 2024.11.18.00 -> 2024.12.09.00
* [`748bb47e`](https://github.com/NixOS/nixpkgs/commit/748bb47e4eded2c620ff468124caef893641068e) watchman: 2024.11.18.00 -> 2024.12.09.00
* [`b1c5cd3e`](https://github.com/NixOS/nixpkgs/commit/b1c5cd3e794cdf89daa5e4f0086274a416a1cded) systemd: nixfmt
* [`9f2a4d0f`](https://github.com/NixOS/nixpkgs/commit/9f2a4d0f8efd23fb6aa5e4ba586c8580324e5b1e) systemd: 256.9 -> 257.1
* [`ee3031a0`](https://github.com/NixOS/nixpkgs/commit/ee3031a01faf03107932ffbf09454bdcb1cebc14) nixosTests.systemd: modify test to use new error output from systemd 257
* [`46add745`](https://github.com/NixOS/nixpkgs/commit/46add74525ed6f72eebffb14eeedbe1d85834672) nixosTests.systemd-journal-gateway: fix permissions on files under /run/secrets
* [`798aa80b`](https://github.com/NixOS/nixpkgs/commit/798aa80b7d5e38ec6bb1f5b0739eca2283e5dfac) nixos-enter: inherit parent PID namespace
* [`14add2bd`](https://github.com/NixOS/nixpkgs/commit/14add2bd69ecd41099e248c54aaad1d6baff0e1d) nixosTests.systemd-repart: don't access attributes from deprecated module argument
* [`97c9cb71`](https://github.com/NixOS/nixpkgs/commit/97c9cb713b681befd22ccc70484ebd3788923c3a) nixosTests.systemd-repart.create-root: fix node filesystem config
* [`95587053`](https://github.com/NixOS/nixpkgs/commit/95587053f7b879ac23108350edb5f30362ec4714) nixos/make-disk-image: nixfmt
* [`324189bc`](https://github.com/NixOS/nixpkgs/commit/324189bc828d57a3289a4335aaebe025e3976857) nixos/make-disk-image: ensure partitions are aligned to sector size
* [`0948c420`](https://github.com/NixOS/nixpkgs/commit/0948c420b60b1f710bcba677e12289cb1f0f9952) xorg.libXau: 1.0.11 -> 1.0.12
* [`45eee8dd`](https://github.com/NixOS/nixpkgs/commit/45eee8dd68a7f8b2f8018ee4a65ce9d4fbc04b19) libwebp: 1.4.0 -> 1.5.0
* [`26713f77`](https://github.com/NixOS/nixpkgs/commit/26713f779299cd4688ef2f35e7f19cbc2e207f79) pyright: 1.1.382 -> 1.1.391
* [`8b724434`](https://github.com/NixOS/nixpkgs/commit/8b724434c37a12ea5ed23ba55339e3dc72d86d7d) libtiff: switch back to CMake
* [`f72ee068`](https://github.com/NixOS/nixpkgs/commit/f72ee0686dfa37018d76669764fb8794a7d501e4) libtiff: fix static builds
* [`bae7a7ac`](https://github.com/NixOS/nixpkgs/commit/bae7a7ac67989104a71b865e3290ded20fb01499) nixos/make-disk-image: fix hybrid and legacy+gpt image generation
* [`831ccafa`](https://github.com/NixOS/nixpkgs/commit/831ccafadf3c18be16693a1845cae150c2fc34bb) nixosTests.grow-partition: fix test
* [`7872dc1d`](https://github.com/NixOS/nixpkgs/commit/7872dc1dada5cca1e4b1964fa496583776fdad01) python312Packages.psutil: 6.0.0 -> 6.1.1
* [`3fc1a007`](https://github.com/NixOS/nixpkgs/commit/3fc1a00773dc8f70ada5f62bc0eb13539a34190a) bintools-wrapper: introduce ld-wrapper-hook
* [`b5e504cc`](https://github.com/NixOS/nixpkgs/commit/b5e504cc4069cd75c2200fc09cd0ace33c5ead61) cc-wrapper: Move cc-wrapper-hook above NIX_DEBUG
* [`6e60452b`](https://github.com/NixOS/nixpkgs/commit/6e60452beb0d2419e4b98e09600c871c4004feb3) liburcu: 0.14.1 -> 0.15.0
* [`26896ed1`](https://github.com/NixOS/nixpkgs/commit/26896ed13ac93969fc8e0b24bb344f8ba8a61ba5) jacinda: fix build by providing happy >= 2.1
* [`c61c0e17`](https://github.com/NixOS/nixpkgs/commit/c61c0e171852c401fb9391b4990f6da2779283b4) stack: fix build by providing pantry >= 0.10
* [`7a84c154`](https://github.com/NixOS/nixpkgs/commit/7a84c154c93f24b63f932b26e09fa72fa437f6cc) git-annex: update sha256 for 10.20241031
* [`4343c985`](https://github.com/NixOS/nixpkgs/commit/4343c98599559b3b3e7a5beade8ca4a5b374ba21) xorg.libSM: 1.2.4 -> 1.2.5
* [`1e359c03`](https://github.com/NixOS/nixpkgs/commit/1e359c03f07e5972d9117c953cc978bf2b0d3f7a) python312Packages.rpds-py: 0.20.0 -> 0.22.3
* [`82ddcd88`](https://github.com/NixOS/nixpkgs/commit/82ddcd88fb946ca54bdc12476689c39cfd2f37f2) ppp: adopt
* [`6a03ad39`](https://github.com/NixOS/nixpkgs/commit/6a03ad39361bb7c2ca9cf90ecb17d40113efda67) ppp: remove 'with lib' usage
* [`89905314`](https://github.com/NixOS/nixpkgs/commit/899053142435b39cd76e8d030731cb5f6c268812) ppp: add systemd sd-notify support
* [`cb5e5e3c`](https://github.com/NixOS/nixpkgs/commit/cb5e5e3ca3abbe31fca50b4aca6855acd1b93b3f) ppp: add PAM support
* [`5705c90b`](https://github.com/NixOS/nixpkgs/commit/5705c90b8a4fe0cc53c4ad8a63e1bedc1c2a7210) darcs: build with tls < 2.0 again
* [`1a8d021e`](https://github.com/NixOS/nixpkgs/commit/1a8d021ea7052d3a727a22ee02e4ec8334281477) haskellPackages.espial: allow esqueleto >= 3.5.12
* [`494cb37f`](https://github.com/NixOS/nixpkgs/commit/494cb37f997100b0a6c340c1a51b384282e0c023) haskellPackages.relocant: add postgresql db to tests
* [`9c577069`](https://github.com/NixOS/nixpkgs/commit/9c577069d9cd254c955ed320e45887c5ac991f90) haskellPackages.HsSyck: implicit function decl may not fail build
* [`81c6edc0`](https://github.com/NixOS/nixpkgs/commit/81c6edc05ebf18326d50f57dcbe2571dbefd7e5f) haskell.packages.ghc910.http2: build with http-semantics >= 0.3
* [`dc097001`](https://github.com/NixOS/nixpkgs/commit/dc09700185c660171b7e9984fd50a4d2543f75d4) haskellPackages.{hd5-lite,bindings-libcddb}: disable gcc 14 -Werror
* [`eb452887`](https://github.com/NixOS/nixpkgs/commit/eb452887df6f29df976a1fe75a2f5a31bf19e587) python312Packages.fnllm: 0.0.12 -> 0.0.13
* [`e03546c4`](https://github.com/NixOS/nixpkgs/commit/e03546c4a1e51012b9922c540135ca0aae83fe09) Revert "python313Packages.dnspython: don't run tests that connect to internet"
* [`173de320`](https://github.com/NixOS/nixpkgs/commit/173de320197ba97f2daf46b7d229055cd3732df4) mkBinaryCache: fix FileHashes
* [`1269ed5a`](https://github.com/NixOS/nixpkgs/commit/1269ed5abebb837fc4b8c1b861d1c0e922bfa40c) libcap: ship the optional 'captree' component
* [`7c66004f`](https://github.com/NixOS/nixpkgs/commit/7c66004f908dca1cff2a2aca3839c1594fb37d3a) mercurial: 6.8.2 -> 6.9
* [`fb7fe3b3`](https://github.com/NixOS/nixpkgs/commit/fb7fe3b3a819bfebf7db1a873509bcd97d1e38c0) haskellPackages.termbox-bindings-c: disable implicit fun -Werror
* [`25e269c4`](https://github.com/NixOS/nixpkgs/commit/25e269c421a64620f3c90d1bcc697ab86e662db4) haskellPackages.libxml-sax: disable gcc14 implicit fun decl -Werror
* [`1ad0cb4d`](https://github.com/NixOS/nixpkgs/commit/1ad0cb4d35108af8de6f4648710cd5b0dec8c434) haskellPackages: link upstream issues for GCC 14 workarounds
* [`b3692b32`](https://github.com/NixOS/nixpkgs/commit/b3692b3250716532c7bc91860f396f1e00982942) haskellPackages.cabal2nix-unstable: 2024-12-04 -> 2024-12-22
* [`9676ba57`](https://github.com/NixOS/nixpkgs/commit/9676ba57565a4790431f11173114156d44fe5818) llvmPackages.clang: Drop failing substituteInPlace for CompletionModel.cmake
* [`a28951b8`](https://github.com/NixOS/nixpkgs/commit/a28951b857ba983ac2b55bb183858dfb179661f3) python312Packages.aiohttp: 3.11.9 -> 3.11.11
* [`143eb2ef`](https://github.com/NixOS/nixpkgs/commit/143eb2efc7b644bc8db4280da0d6582a6f1cd58f) python312Packages.jinja2: 3.1.4 -> 3.1.5
* [`76a8a362`](https://github.com/NixOS/nixpkgs/commit/76a8a3623dbe7e86d5f0aeb594bb2ffe5de3faed) libajantv2: 16.2-bugfix5 -> 17.1.0
* [`5f1d2105`](https://github.com/NixOS/nixpkgs/commit/5f1d21054605cfedc93d5a573fc61ad1b8a8a694) linuxPackages.ajantv2: init at 17.1.0
* [`270a8431`](https://github.com/NixOS/nixpkgs/commit/270a843127de7e0ff09049cf617b9acd16ce52e6) gst_all_1.gst-plugins-bad: fix aja support
* [`20e0e888`](https://github.com/NixOS/nixpkgs/commit/20e0e8885220aff6aa0ade35ed77497f9f5eda5a) wayland-protocols: 1.38 -> 1.39
* [`e9c5bf1c`](https://github.com/NixOS/nixpkgs/commit/e9c5bf1c021023c31f4f662209adbc4a6ef84dda) xorg.libICE: 1.1.1 -> 1.1.2
* [`24db2b71`](https://github.com/NixOS/nixpkgs/commit/24db2b71600ded70fca0b3655ea84f91ab6c0eb4) bpftools: fix cross
* [`5dce243b`](https://github.com/NixOS/nixpkgs/commit/5dce243bc8135fe2c934af23895740b2adb1f8bb) haskellPackages: mark builds failing on hydra as broken
* [`89914601`](https://github.com/NixOS/nixpkgs/commit/899146019f2864b205e82d857aab9082b55e172a) haskellPackages.diagrams-input: downgrade for Stackage LTS compat
* [`d43d9d17`](https://github.com/NixOS/nixpkgs/commit/d43d9d17fad427095dceb69e4a70677484f4a6a9) haskellPackages.unbound-generics: Unmark broken
* [`4b2408be`](https://github.com/NixOS/nixpkgs/commit/4b2408beac6b9cb39b591bdce41ad4c504b336c4) flatbuffers: 24.3.25 -> 24.12.23
* [`80b0f86b`](https://github.com/NixOS/nixpkgs/commit/80b0f86ba4e8891dc6916f3a2a11571dfa39acde) fontforge: move to by-name
* [`c7bb21f4`](https://github.com/NixOS/nixpkgs/commit/c7bb21f40e27e773b16d619882ea3db46d634fe3) fontforge: disable Python with a cmakeFlag
* [`e1213d79`](https://github.com/NixOS/nixpkgs/commit/e1213d79c0089a02633bbddf13ca1dec94784038) recordbox: 0.8.3 -> 0.9.0
* [`e8405906`](https://github.com/NixOS/nixpkgs/commit/e840590675ae3c6d3ab76c2c23a4cd7ee47388ce) haskellPackages.amqp-streamly: don't attempt to run docker tests
* [`f0629e1d`](https://github.com/NixOS/nixpkgs/commit/f0629e1d16c19698e91065ac12c6e89b315ad3b6) linux/common-config: add missing items for aarch64
* [`c4a1f9e4`](https://github.com/NixOS/nixpkgs/commit/c4a1f9e4bbdf2a87e7985b22999ab07b189b2a69) linux/common-config: conditionalize x86 specifics
* [`762e44ad`](https://github.com/NixOS/nixpkgs/commit/762e44ade3b55807fa9b5ad9feb597e4d85386ae) linux/common-config: don't set PM_TRACE
* [`bdebe049`](https://github.com/NixOS/nixpkgs/commit/bdebe0499515ee36bc90e61813b08d7e9cc4cbaf) linux/common-config: set NFS_FS=m
* [`73c466f7`](https://github.com/NixOS/nixpkgs/commit/73c466f7d5bd4c4ba6bc01aedfcc6e4cf791d1b7) linux/common-config: don't set DEVKMEM on aarch64
* [`b551567c`](https://github.com/NixOS/nixpkgs/commit/b551567c5944202359bfe417d262f3eb851d2740) linux/common-config: add CMA_SYSFS version bound
* [`37789d9e`](https://github.com/NixOS/nixpkgs/commit/37789d9eaa566f5d0bdeaaecd9cb3b0991dab6e9) linuxManualConfig: forbid config errors on aarch64
* [`e4307e63`](https://github.com/NixOS/nixpkgs/commit/e4307e63cd66655cdee85c6ec2c9f1133d47c281) haskellPackages: mark failing builds as broken
* [`1f3c32e4`](https://github.com/NixOS/nixpkgs/commit/1f3c32e43507fd8661bac1c05efe9be73b908b05) zvbi: fix building for musl on x86_64
* [`f826467a`](https://github.com/NixOS/nixpkgs/commit/f826467add3932fb246203b6a450dcae6b5fd918) gumbo: 0.12.2 -> 0.12.3
* [`3f124208`](https://github.com/NixOS/nixpkgs/commit/3f124208ee78cd9977af9d0b2a4cf211b3a2b5dc) glib: 2.82.1 -> 2.82.4
* [`672912aa`](https://github.com/NixOS/nixpkgs/commit/672912aa533a79ba971467e3448a8243f9fbaee5) libcamera: 0.3.2 -> 0.4.0
* [`a689ece7`](https://github.com/NixOS/nixpkgs/commit/a689ece741d27c8d00cfac5de4b917a12c7d7357) electrum-ltc: unbreak
* [`ec8e4b27`](https://github.com/NixOS/nixpkgs/commit/ec8e4b2704a5cb490c788985768e01925f23d484) fontforge: replace erictapen with philiptaron as maintainer
* [`4aa999bd`](https://github.com/NixOS/nixpkgs/commit/4aa999bdf7b91809aa1d8b3f03c1376e3417b186) sonarlint-ls: refactor to online build
* [`d7f26c35`](https://github.com/NixOS/nixpkgs/commit/d7f26c354831659cf91316966fc01ab7289a486c) sonarlint-ls: 3.5.1.75119 -> 3.14.1.75775
* [`2240543b`](https://github.com/NixOS/nixpkgs/commit/2240543b6a6d376c287807cd408d88a0e7e4516b) sonarlint-ls: fix update script
* [`cbc50da1`](https://github.com/NixOS/nixpkgs/commit/cbc50da11c2dfb45d3ddfe352f24d49c3be81822) zfs_2_1: remove
* [`e4f44407`](https://github.com/NixOS/nixpkgs/commit/e4f44407a7a9a5561cd6b589a6d27e7a8f91a720) nodejs_22: 22.11.0 -> 22.12.0 ([nixos/nixpkgs⁠#361565](https://togithub.com/nixos/nixpkgs/issues/361565))
* [`2b8df769`](https://github.com/NixOS/nixpkgs/commit/2b8df7696923fa204511df546be1256a8b9cfa1f) nodejs_23: 23.2.0 -> 23.5.0 ([nixos/nixpkgs⁠#357699](https://togithub.com/nixos/nixpkgs/issues/357699))
* [`e641337b`](https://github.com/NixOS/nixpkgs/commit/e641337b748029a03c213bb169fc9ffcf7ec7af7) nftables: fix build for musl
* [`4a5cddb1`](https://github.com/NixOS/nixpkgs/commit/4a5cddb1729fdcceaad1c36bb8f37681204010eb) python312Packages.hatchling: 1.26.1 -> 1.27.0
* [`3df81375`](https://github.com/NixOS/nixpkgs/commit/3df8137531efaa4d5b95cd95f359754d35c678ab) hatch: 1.13.0 -> 1.14.0
* [`ca32061f`](https://github.com/NixOS/nixpkgs/commit/ca32061f94342879ebdd59e54710aee7c48f9a1a) python312Packages.nbmake: 1.5.4 -> 1.5.5
* [`8a4badf7`](https://github.com/NixOS/nixpkgs/commit/8a4badf704a76d5b8943243b853a49e94daad697) bash-completion: 2.15.0 -> 2.16.0
* [`2d25f722`](https://github.com/NixOS/nixpkgs/commit/2d25f7224f2763e6d0bdc43c4b96b8110957bc27) libcava: init at 0.10.3
* [`2a2e1459`](https://github.com/NixOS/nixpkgs/commit/2a2e1459520e8067b9edd16dfd3b8fab46570d00) waybar: libcava moved to a separate package
* [`69e7105d`](https://github.com/NixOS/nixpkgs/commit/69e7105d5d8bff9e0cb1718d4a76a54aa9210f98) all-cabal-hashes: 2024-11-07T13:09:31Z -> 2024-12-23T18:27:47Z
* [`ca5dc07d`](https://github.com/NixOS/nixpkgs/commit/ca5dc07d37595696cdd6b28f7c59d48161b4f68f) haskellPackages: stackage LTS 22.40 -> LTS 22.43
* [`81ef1154`](https://github.com/NixOS/nixpkgs/commit/81ef1154335b000bc0a685a1b735eaa7c6ff5022) haskellPackages: regenerate package set based on current config
* [`87d2c80f`](https://github.com/NixOS/nixpkgs/commit/87d2c80f283480413a3602cbfc7bd5805ae6ab82) haskell.packages.ghc910: bump upgrades to their latest hackage rel.
* [`48d7ea88`](https://github.com/NixOS/nixpkgs/commit/48d7ea883c55610819ba736fe9f803a6e375e339) haskell.packages.ghc98: bump upgrades to their latest hackage rel.
* [`5dfa2d6f`](https://github.com/NixOS/nixpkgs/commit/5dfa2d6f55793aa9a2b397a4215e1e4e9037c934) pandoc_3_6: init at 3.6
* [`628a4031`](https://github.com/NixOS/nixpkgs/commit/628a40319abfb54a5041e6af7dfe947c0bccd2b8) jacinda: build with happy-2.1.3
* [`0bbb00e8`](https://github.com/NixOS/nixpkgs/commit/0bbb00e8ee21bcefbaa3ddee70da521020b4945e) haskellPackages: use Cabal 3.14.1.0 over 3.14.0.0
* [`fe2fe998`](https://github.com/NixOS/nixpkgs/commit/fe2fe9981ea6edb49d776c0ae554d8b10c25b85a) cabal-install: adjust overrides for 3.14.1.0
* [`d8d3d878`](https://github.com/NixOS/nixpkgs/commit/d8d3d878f7d0992d23b83a475077543e53b2ae8d) haskellPackages.gi-gtk_4: 4.0.9 -> 4.0.11
* [`3403ebc8`](https://github.com/NixOS/nixpkgs/commit/3403ebc8b70c52237ad832fc3b2ffbd31959d241) haskell.packages.ghc9101.ghc-lib-parser*: retain 9.10.* versions
* [`bc8861aa`](https://github.com/NixOS/nixpkgs/commit/bc8861aae15d46526fd27c5f74be51b19f0fbbdd) python312Packages.cbor2: 5.6.4 -> 5.6.5
* [`e0a58f2b`](https://github.com/NixOS/nixpkgs/commit/e0a58f2bf31b0e8f48f9cf5933d740602dfb41c5) python312Packages.webauthn: 2.2.0 -> 2.4.0
* [`afa1d22c`](https://github.com/NixOS/nixpkgs/commit/afa1d22c89adfc26f92e3433897deb29f511ba22) pretix: relax webauthn constraint
* [`f43f9987`](https://github.com/NixOS/nixpkgs/commit/f43f9987c5f60aca5c73cb316b7a01d028bae4ec) haskellPackages.repa*: drop obsolete patches
* [`bb7f5079`](https://github.com/NixOS/nixpkgs/commit/bb7f507906130920f96676e74b29645357a946ed) pkgsCross.*.haskellPackages.xhtml: 3000.3.0.0 -> 3000.4.0.0
* [`a20dc12b`](https://github.com/NixOS/nixpkgs/commit/a20dc12b5e7972bb80c25c5a51400bedb36c53c9) python312Packages.google-cloud-artifact-registry: 1.13.1 -> 1.14.0
* [`259a468b`](https://github.com/NixOS/nixpkgs/commit/259a468bb344c9c02c81453371f613efbc487c22) python3Packages.meson-python: honor mesonFlagsArray
* [`7b883835`](https://github.com/NixOS/nixpkgs/commit/7b8838356f11e8fcb64abcda33ada82fe4fa75e7) haskell.packages.ghc9121.splitmix: 0.1.0 -> 0.1.1
* [`e3a7759b`](https://github.com/NixOS/nixpkgs/commit/e3a7759b8f905d168c55f01595f9f675efd57381) haskell.packages.ghc9121.tagged: 0.8.8 -> 0.8.9
* [`7c67b060`](https://github.com/NixOS/nixpkgs/commit/7c67b0608c0119d9b480ba4b66383cb4c44a754f) haskell.packages.ghc912.primitive: 0.8.0.0 -> 0.9.0.0
* [`64ce0e31`](https://github.com/NixOS/nixpkgs/commit/64ce0e316cdf4218545db87e0cb2138524f46edd) haskell.packages.ghc9121.call-stack: disable test suite
* [`817e2aee`](https://github.com/NixOS/nixpkgs/commit/817e2aee9f6821c0b208ef9d145ccb800b95eafe) haskell.packages.ghc9121.tar: 0.5.1.1 -> 0.6.3.0
* [`581f185b`](https://github.com/NixOS/nixpkgs/commit/581f185b6c635cc825d9a1355689bf31c88f8ba1) git-annex: update sha256 for 10.20241202
* [`7016a8c3`](https://github.com/NixOS/nixpkgs/commit/7016a8c3847b1a04383f48c124c33da9f7f1829a) haskellPackages.opencascade-hs: provide non standard include dirs
* [`542c92b9`](https://github.com/NixOS/nixpkgs/commit/542c92b9a536350375e4ab63bced85fdc963736a) haskellPackages.hevm: drop obsolete patches
* [`32eb7980`](https://github.com/NixOS/nixpkgs/commit/32eb7980e105d4ed38f2a401787862e0920de2a7) ppp: add withSystemd option
* [`f16ddd92`](https://github.com/NixOS/nixpkgs/commit/f16ddd92f3da56b91781dbe16a7a64b6bcbb404c) wluma: 4.5.1 -> 4.6.0
* [`f6f7c1f5`](https://github.com/NixOS/nixpkgs/commit/f6f7c1f5b4e7fb660f8c3ba1d2e2a616e241b648) python312Packages.keystoneauth1: 5.8.0 -> 5.9.1, define optional-dependencies
* [`7c8db21c`](https://github.com/NixOS/nixpkgs/commit/7c8db21cad13dcc7d60acfea282ffc45194b9a6b) python312Packages.python-cinderclient: ignore failing tests
* [`4f4c91a5`](https://github.com/NixOS/nixpkgs/commit/4f4c91a57ceaf789d34420f961d4c629d888bb77) python312Packages.testtools: update homepage
* [`84d06d81`](https://github.com/NixOS/nixpkgs/commit/84d06d81ee35a08a9293a96bcec1e02f3b316355) memcached: 1.6.31 -> 1.6.34
* [`fce7ac39`](https://github.com/NixOS/nixpkgs/commit/fce7ac3978c8dfa895c1f4ea55d9c2c3a30131b3) ticktick: 6.0.10 -> 6.0.20
* [`6d0a7285`](https://github.com/NixOS/nixpkgs/commit/6d0a72859d3b122fb372bead94aa5785503dab13) Revert "folly: disable tests on Clang for now"
* [`380056ee`](https://github.com/NixOS/nixpkgs/commit/380056eeb5ddc2bb1b28829d656825a3067983b2) greetd-mini-wl-greeter: init at 0-unstable-2024-12-27
* [`2a7323bc`](https://github.com/NixOS/nixpkgs/commit/2a7323bcd326e52bf929ec8a5fbf0d6c0927c341) gnomeExtensions.guillotine: 24 -> 25
* [`2bf06b75`](https://github.com/NixOS/nixpkgs/commit/2bf06b7559413ec699071f89bf050a63b27ac87e) bmake: 20240921 -> 20241124
* [`44a18061`](https://github.com/NixOS/nixpkgs/commit/44a180612a7732d41c400a197b2c96a14a21df9b) umockdev: 0.18.4 -> 0.19.0
* [`4bafb2cb`](https://github.com/NixOS/nixpkgs/commit/4bafb2cb042801ab290dc818ef4b514da6124b15) publicsuffix-list: 0-unstable-2024-12-06 -> 0-unstable-2024-12-24
* [`e923d7eb`](https://github.com/NixOS/nixpkgs/commit/e923d7eb817ef6f96145f641dd015f8528085e8a) libdeflate: enable tests
* [`c00d7f39`](https://github.com/NixOS/nixpkgs/commit/c00d7f39d6d5117236a2bc919259a543c469f385) maintainers: add Rishik-Y
* [`960ff389`](https://github.com/NixOS/nixpkgs/commit/960ff3895f17718061a42dc3b8f029ca47397061) wluma: add Rishik-Y to maintainers
* [`af2be646`](https://github.com/NixOS/nixpkgs/commit/af2be6465f77b12ccc6d828dfb348ac766fc8b6b) pixman: fix build on armv7
* [`ce8c020d`](https://github.com/NixOS/nixpkgs/commit/ce8c020d974f854d49c70a207f9581c57bd485cd) git-annex: add missing symlinks to PATH in checkPhase
* [`0e2c82c3`](https://github.com/NixOS/nixpkgs/commit/0e2c82c3419be9f20e6742d036653cc8c58d6500) nixos/freshrss: fix empty extensions
* [`98245d66`](https://github.com/NixOS/nixpkgs/commit/98245d66c0fc6ee25ad2b58ff3d08a1468f4992a) doxygen: format
* [`81522c2e`](https://github.com/NixOS/nixpkgs/commit/81522c2e588b9f2942931e73e07f9ac7cdd4abab) python312Packages.fs: re-add setuptools dependency
* [`5922ada3`](https://github.com/NixOS/nixpkgs/commit/5922ada38dd89f2bd22b560120a251617d535b27) doxygen: 1.12.0 -> 1.13.0
* [`b6956c49`](https://github.com/NixOS/nixpkgs/commit/b6956c491f782902f890809012d99cfe0b2f8117) python3Packages.migen: unstable-2024-07-21 -> 0.9.2-unstable-2024-12-25
* [`59155b95`](https://github.com/NixOS/nixpkgs/commit/59155b95914eb41a4d4e3df0d1c064d449546195) devede: 4.17.0 -> 4.19.0
* [`93bd863f`](https://github.com/NixOS/nixpkgs/commit/93bd863fac9b5c0e9d8dd311baa0956836127e49) haskell.packages.ghcjs.exceptions: fix the eval
* [`595be476`](https://github.com/NixOS/nixpkgs/commit/595be4765cebe97c7b65e5eaf33f76d31ad9d0a0) haskell.packages.ghc865Binary.exceptions: fix the eval
* [`5530826d`](https://github.com/NixOS/nixpkgs/commit/5530826d219a247d4d1850728f3851a259010449) shadow: 4.16.0 -> 4.17.0
* [`caab23e8`](https://github.com/NixOS/nixpkgs/commit/caab23e84594ba7ff791194605f57d0a8c5fdf9c) kernelshark: fix build
* [`dca72f67`](https://github.com/NixOS/nixpkgs/commit/dca72f67e6376efb67c6262a9bf15c8f110b5093) tree-sitter: 0.24.4 -> 0.24.6
* [`9899af47`](https://github.com/NixOS/nixpkgs/commit/9899af479969b209bed8afae0a4c1ec5fcd01ef4) tree-sitter: format with nixfmt-rfc-style
* [`c2b5e7ba`](https://github.com/NixOS/nixpkgs/commit/c2b5e7ba67b25f2274c4335d89f3de61080b4ae9) tree-sitter: install shell completions
* [`2c963021`](https://github.com/NixOS/nixpkgs/commit/2c963021060bb5a16d7f494517010a15383387d5) netpbm: 11.8.2 -> 11.9.0
* [`c559662e`](https://github.com/NixOS/nixpkgs/commit/c559662e801f5dbdd83a63ae92e3ec62b5993af8) setup-hooks/strip: include darwin-specific paths
* [`30ee3a4e`](https://github.com/NixOS/nixpkgs/commit/30ee3a4eb86478ef02291eabc0b4e1e9d5015f13) perlPackages.CryptDES: fix build with gcc14
* [`5e06bab1`](https://github.com/NixOS/nixpkgs/commit/5e06bab1877380f9163467fe1828d6b6ddcfcdfa) rustPlatform.maturinBuildHook: specify the interpreter name
* [`daa4397b`](https://github.com/NixOS/nixpkgs/commit/daa4397bae9bc59563411886e4337782ed037d4e) python3Packages.orjson: the maturin fix is no longer needed
* [`5586b78a`](https://github.com/NixOS/nixpkgs/commit/5586b78aa520c6157371c1fa2f86bab08c625e61) python3Packages.tokenizers: the maturin fix is no longer needed
* [`c2242249`](https://github.com/NixOS/nixpkgs/commit/c2242249461634f3008f1a9a65cb8abbc352f743) python3Packages.rpds-py: the maturin fix is no longer needed
* [`9edda767`](https://github.com/NixOS/nixpkgs/commit/9edda767f9c23a261d9b6b80711d115d89931b61) python3Packages.pydantic-core: the maturin fix is no longer needed
* [`4ad0ed83`](https://github.com/NixOS/nixpkgs/commit/4ad0ed83488265290723aa1ec704af38a196df9a) python3Packages.watchfiles: the maturin fix is no longer needed
* [`cf127c9d`](https://github.com/NixOS/nixpkgs/commit/cf127c9dc389231b03bae610fec546e2017969ea) treewide: load structured attributes in all bash builders consistently
* [`b88f5151`](https://github.com/NixOS/nixpkgs/commit/b88f5151351e7a0a95d219580c3695539abd234b) dockerTools.streamLayeredImage: fix with structuredAttrs
* [`0fb0aa52`](https://github.com/NixOS/nixpkgs/commit/0fb0aa526a8fe313493db02c63ee42c7edd77194) various: remove useless "source stdenv/setup"
* [`d63aa1dd`](https://github.com/NixOS/nixpkgs/commit/d63aa1ddbebc3d9f533b63309d5ef8ce84b82b62) nixos/tasks: remove obsolete tty-backgrounds-combine.sh file
* [`255012c7`](https://github.com/NixOS/nixpkgs/commit/255012c708de45390ac5bb8d15122bb5cd58b63a) nixosTests.etc: fix with structuredAttrs
* [`0d7cdd82`](https://github.com/NixOS/nixpkgs/commit/0d7cdd823a3e85b5eb9e88ec46bb8dd7718b758e) gnupg24: add freepg patches
* [`7498f431`](https://github.com/NixOS/nixpkgs/commit/7498f431c8bd2869ec6b90a62b532b09268c24c0) glibc: avoid overriding makeFlags
* [`152d7e78`](https://github.com/NixOS/nixpkgs/commit/152d7e78818519b2c775dd4fc39747a96eb42520) cmake: 3.30.5 -> 3.31.3
* [`d8b97748`](https://github.com/NixOS/nixpkgs/commit/d8b9774868f2136001bf0c7b763c9fdf49b31600) tree-sitter: use new darwin SDK pattern
* [`e33a761e`](https://github.com/NixOS/nixpkgs/commit/e33a761efdec0ff79cf5ae2d309c95c62fc72c12) tree-sitter: use substitution and patches more appropriately
* [`c100a3fc`](https://github.com/NixOS/nixpkgs/commit/c100a3fc13113a881c7abfb04fe8ce43f5e750f5) tree-sitter: add uncenter to maintainers
* [`c91f3fb8`](https://github.com/NixOS/nixpkgs/commit/c91f3fb82cd62f221daf364b2c9a8dc25f7dd096) xxHash: 0.8.2 -> 0.8.3
* [`d4d5fa0f`](https://github.com/NixOS/nixpkgs/commit/d4d5fa0f0f6772ee06cfa311128c4a11fb1786dd) kbd: 2.6.4 -> 2.7.1
* [`255bcd6f`](https://github.com/NixOS/nixpkgs/commit/255bcd6fea77f6b9c46e9413004189ffeb19da3f) linuxHeaders: 6.12 -> 6.12.7
* [`a5027884`](https://github.com/NixOS/nixpkgs/commit/a50278845b4b44f89ff437801eb67dd53720f964) obs-studio-plugins.obs-transition-table: fix build failure
* [`3a08f5ea`](https://github.com/NixOS/nixpkgs/commit/3a08f5ea2c51f9ccf9e94c5ce6753d75aa542790) haskell.compiler.ghc98: 9.8.2 -> 9.8.4
* [`00dc1670`](https://github.com/NixOS/nixpkgs/commit/00dc16708cefde03a76dc200119c0c9ff12c6705) haskell.packages.ghc910.ghc-lib: match with compiler version
* [`feaddcab`](https://github.com/NixOS/nixpkgs/commit/feaddcabd1b9704dfb97441a027e88702444722e) haskell.packages.ghc9101: test pkgs that have been fixed on hydra
* [`3c6c9898`](https://github.com/NixOS/nixpkgs/commit/3c6c9898744da7aa3f14c19246e724a0b6c892c0) haskell.packages.ghc9121: don't test pkgs that don't support 9.12
* [`f5ffbb61`](https://github.com/NixOS/nixpkgs/commit/f5ffbb61db45bf01ba062eab1ed69c888a31ff3e) python312Packages.appdirs: fix typo
* [`a3af774b`](https://github.com/NixOS/nixpkgs/commit/a3af774b04bde67091382d1eb0477195625d5a25) metacubexd: 1.173.3 -> 1.176.1
* [`e2448ea1`](https://github.com/NixOS/nixpkgs/commit/e2448ea1b551599554610c74f697164f0ab2ccd7) maturin: 1.7.8 -> 1.8.1
* [`6a811e2e`](https://github.com/NixOS/nixpkgs/commit/6a811e2e8d0a8b3e40106b34747b9068ced0a6d4) poptracker: add update script
* [`2686a5a2`](https://github.com/NixOS/nixpkgs/commit/2686a5a2d983fd929feeca0ef3841dc8a97c9553) poptracker: 0.27.0 -> 0.29.0
* [`52917938`](https://github.com/NixOS/nixpkgs/commit/52917938b0d9c62be065ed076cb959eed5d0adfa) edencommon: skip flaky test on darwin
* [`56bf96d5`](https://github.com/NixOS/nixpkgs/commit/56bf96d5365c15957f1233d49b836f3d63488f84) bash-completion: Remove obsolete patch
* [`11bed26c`](https://github.com/NixOS/nixpkgs/commit/11bed26c582bcb724e20760d9a585489481ff859) python3Packages.basedmypy: init at 2.8.1
* [`110baa0b`](https://github.com/NixOS/nixpkgs/commit/110baa0bc13b89b12be56814b4a1895204c8d357) snowmachine: 2.0.1 -> 2.0.2
* [`a1436e54`](https://github.com/NixOS/nixpkgs/commit/a1436e5414bb84c75a11f498e4e8c8cae30c9574) epubcheck: 5.1.0 -> 5.2.0
* [`7a7e3775`](https://github.com/NixOS/nixpkgs/commit/7a7e377539f080e044c37d66cc3058b932d687ef) nettle: 3.10.0 -> 3.10.1
* [`bba38aef`](https://github.com/NixOS/nixpkgs/commit/bba38aef22a5f84dbc67166c99bb6803f29b2fa5) maintainers: add outfoxxed
* [`78e34063`](https://github.com/NixOS/nixpkgs/commit/78e340633e27249c9e6ca5701b2c62b9aba6f3e8) qt6.qtdeclarative: re-enable qml caching
* [`f68d5c76`](https://github.com/NixOS/nixpkgs/commit/f68d5c76fde4d28a78d0aee8012d6e981e01bbc1) mysql-workbench: 8.0.38 -> 8.0.40
* [`55b3d701`](https://github.com/NixOS/nixpkgs/commit/55b3d70162ee0644a8ea635984cf2801ddcd9ca6) qt6: don't treat absolute paths without known suffix as library
* [`164d44fc`](https://github.com/NixOS/nixpkgs/commit/164d44fcaf41ae3b54b2e911587416586492fabf) haskellPackages.libxml-sax: drop obsolete override
* [`31aab29b`](https://github.com/NixOS/nixpkgs/commit/31aab29bd8581757f053a94937ce0c463c52e723) haskellPackages.xz: make sure we are using pkgs.xz, allow tasty 1.4
* [`c7a72e43`](https://github.com/NixOS/nixpkgs/commit/c7a72e43b3167d7b96d72167a12160cdf24e943a) haskellPackages.pfile: allow hspec == 2.11.*
* [`3b4be0dc`](https://github.com/NixOS/nixpkgs/commit/3b4be0dc071c759bc4a0279cccd42d7505a0f00b) haskellPackages.provide: relax lower bound on lens
* [`a8f9a9f6`](https://github.com/NixOS/nixpkgs/commit/a8f9a9f6fe50d5f4e9209c071c45431168dbad7d) haskellPackages.lawful-conversions: relax lower bounds of test suite
* [`f16ebb86`](https://github.com/NixOS/nixpkgs/commit/f16ebb8654560e7e56015d6feed230c489f7e9d4) ultrastar-creator: specify mainProgram
* [`8609c05e`](https://github.com/NixOS/nixpkgs/commit/8609c05e152696318c6744a3bafa841829dd00f1) haskellPackages.alfred-margaret: remove stale broken flag
* [`b20733c8`](https://github.com/NixOS/nixpkgs/commit/b20733c8c797485c31dffe246a63997462e74ac1) haskellPackages.cabal2nix-unstable: 2024-12-22 -> 2024-12-31
* [`9bafcc25`](https://github.com/NixOS/nixpkgs/commit/9bafcc2507315bcdacaf3144cd18e041d2de3c7b) ultrastar-manager: specify mainProgram
* [`24fc6ed5`](https://github.com/NixOS/nixpkgs/commit/24fc6ed5fb597e49e0b9365c1e7b87a546ff0ac8) python312Packages.aiorun: 2024.5.1 -> 2024.8.1
* [`3ee5ecc9`](https://github.com/NixOS/nixpkgs/commit/3ee5ecc95bcb74d941a5206da2610168fe0302ef) python312Packages.colorlog: 6.8.2 -> 6.9.0
* [`ed081897`](https://github.com/NixOS/nixpkgs/commit/ed0818973867f0870d1bbf71289fb8675b7d981d) python312Packages.isodate: 0.6.1 -> 0.7.2
* [`41883de1`](https://github.com/NixOS/nixpkgs/commit/41883de1adbd9e7c4afbffec9ddf02a63ebd1bd4) python312Packages.tidalapi: 0.7.6 -> 0.8.3
* [`7a7e377c`](https://github.com/NixOS/nixpkgs/commit/7a7e377c9146597fd5e725693920d06e8792f7e9) python312Packages.pyblu: 1.0.4 -> 2.0.0
* [`dc7d134f`](https://github.com/NixOS/nixpkgs/commit/dc7d134fcaa0f4040998d45b3e0732326ba72bf6) python312Packages.music-assistant-models: 1.1.3 -> 1.1.4
* [`08cddd18`](https://github.com/NixOS/nixpkgs/commit/08cddd18fcaddc500cf41fa7a4d606beb0bb4170) python312Packages.music-assistant-client: fix version, relax deps
* [`a8fa25dd`](https://github.com/NixOS/nixpkgs/commit/a8fa25dd287e54c7a66550443696c4abca6e2434) home-assistant-custom-components.mass: 2024.9.1 -> 2024.12.1
* [`1ea56351`](https://github.com/NixOS/nixpkgs/commit/1ea5635176062eae09a5a8c29fb31038b46befb2) music-assistant: 2.3.2 -> 2.3.4
* [`483b1b39`](https://github.com/NixOS/nixpkgs/commit/483b1b399a381c6c3549e96acecdd4730ec4089a) dfcldd: 1.3.4-1 -> 1.9.2
* [`c0c964d8`](https://github.com/NixOS/nixpkgs/commit/c0c964d8ae68a87a9dd2af578f881f44137a8ddb) powershell-editor-services: init at 4.1.0
* [`e8284ebb`](https://github.com/NixOS/nixpkgs/commit/e8284ebb96d8cd7ee565507b3a0e0cca1e1cfe19) maintainers: add sharpchen
* [`bae109d5`](https://github.com/NixOS/nixpkgs/commit/bae109d55552be585d32b1892a79342f2b112983) python312Packages.python-hl7: fix pname
* [`048ee4d9`](https://github.com/NixOS/nixpkgs/commit/048ee4d97cb77cb6bfdbc86068ac57ba50ab6173) haskell.packages.ghc8107.ghc-source-gen: pin to 0.4.5.0
* [`ad3be326`](https://github.com/NixOS/nixpkgs/commit/ad3be3261e5f71d2e6755f845721d04f733a3c53) hspell: Add zlib
* [`a03cc600`](https://github.com/NixOS/nixpkgs/commit/a03cc600ddeb621653979429637053a8a537776c) lcms2: Stop propagating dependencies
* [`e73ff8c4`](https://github.com/NixOS/nixpkgs/commit/e73ff8c46094f86ebd23d2dfdc0485f3a2ecefae) haskellPackages.nspace: disable tests
* [`9e810e24`](https://github.com/NixOS/nixpkgs/commit/9e810e2480746ea12e006448ef62ba612981e8ab) gitlab-ci-ls: 0.22.2 -> 1.0.0
* [`e2c7e1cd`](https://github.com/NixOS/nixpkgs/commit/e2c7e1cd412948fe8cbc48cbdb6d7b97675b3857) haskellPackages: mark builds failing on hydra as broken
* [`e51cc8a2`](https://github.com/NixOS/nixpkgs/commit/e51cc8a2a6d3e8d1919ab6766b8ffd3d2a9ddbe2) lib.collectModules: improve readability by replacing implication
* [`4f7efec8`](https://github.com/NixOS/nixpkgs/commit/4f7efec8516720497bf2d004d7c62097bda2e8a1) haskell.packages.ghc96.htree: restrict to < 0.2
* [`852dc779`](https://github.com/NixOS/nixpkgs/commit/852dc77915d6310d97a3a359b6c5a0fbdf5d1610) hashlink: fix build with gcc-14
* [`608553f0`](https://github.com/NixOS/nixpkgs/commit/608553f0c7e31b2a0d3c618da0bb82a84d788aa3) calamares: 3.3.12 -> 3.3.13
* [`dc04d68a`](https://github.com/NixOS/nixpkgs/commit/dc04d68ac46e12cb35bc4e2c80537f6ae7f7dff3) dico: 2.11 -> 2.12
* [`7e31d112`](https://github.com/NixOS/nixpkgs/commit/7e31d112dc42d8d87cff0824b25347d9240130ac) swtpm: 0.9.0 -> 0.10.0
* [`a9886331`](https://github.com/NixOS/nixpkgs/commit/a9886331da834829ca2b322d76c5ad738d68e57a) zlib-ng: 2.2.2 -> 2.2.3
* [`2b05b25c`](https://github.com/NixOS/nixpkgs/commit/2b05b25c3d55e3b0352ae38f001f0993d595a228) pythonPackages.rope: fix 3.13 build
* [`59439ee4`](https://github.com/NixOS/nixpkgs/commit/59439ee4f490e13b7fb110b5e99983576161c7dc) pylint: 3.3.1 -> 3.3.3
* [`09d6a2f6`](https://github.com/NixOS/nixpkgs/commit/09d6a2f64f370527bc34ac21468fb364b86490ce) python312Packages.astroid: 3.3.5 -> 3.3.8
* [`3e51ea92`](https://github.com/NixOS/nixpkgs/commit/3e51ea9253014c989f4b6da2d49ea408fee6e51a) python313Packages.python-lsp-server: fix 3.13 tests
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
