### PR TITLE
niv home-manager: update fc52a210 -> 9786661d

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -41,10 +41,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "fc52a210b60f2f52c74eac41a8647c1573d2071d",
-        "sha256": "0883pphgnap6kfvscqvvhs3vlp01rh2yf5rdklgns4bp0i9j73ad",
+        "rev": "9786661d57c476021c8a0c3e53bf9fa2b4f3328b",
+        "sha256": "15v18m57025npf3awdvgcnnnij7pn9psljfg6in0wz77qxf2hvhi",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/fc52a210b60f2f52c74eac41a8647c1573d2071d.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/9786661d57c476021c8a0c3e53bf9fa2b4f3328b.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@fc52a210...9786661d](https://github.com/nix-community/home-manager/compare/fc52a210b60f2f52c74eac41a8647c1573d2071d...9786661d57c476021c8a0c3e53bf9fa2b4f3328b)

* [`a1f180af`](https://github.com/nix-community/home-manager/commit/a1f180af1710c2b4a2b9e1a8f6d8871840497393) hyprlock: add bezier to importantPrefixes
* [`0dfec9de`](https://github.com/nix-community/home-manager/commit/0dfec9deb275854a56c97c356c40ef72e3a2e632) hyprlock: remove with lib;
* [`12851ae7`](https://github.com/nix-community/home-manager/commit/12851ae7467bad8ef422b20806ab4d6d81e12d29) thunderbird: Enable tests for Darwin ([nix-community/home-manager⁠#6324](https://togithub.com/nix-community/home-manager/issues/6324))
* [`a0046af1`](https://github.com/nix-community/home-manager/commit/a0046af169ce7b1da503974e1b22c48ef4d71887) Translations update from Hosted Weblate
* [`495de1e1`](https://github.com/nix-community/home-manager/commit/495de1e197e7e113ad8877dad4c29a66482a093c) Translate using Weblate (Danish)
* [`1e364297`](https://github.com/nix-community/home-manager/commit/1e36429705f9af2d00a517ba46a4f21ef8a8194f) sbt: allow irregular plugins to be configured
* [`1c75a4c1`](https://github.com/nix-community/home-manager/commit/1c75a4c151dfe417c73ae3f87a6eba0b009c438c) syncthing: have tray wait for bar to load ([nix-community/home-manager⁠#6290](https://togithub.com/nix-community/home-manager/issues/6290))
* [`97d7946b`](https://github.com/nix-community/home-manager/commit/97d7946b5e107dd03cc82f21165251d4e0159655) {hypridle, hyrpaper}: remove with lib; ([nix-community/home-manager⁠#6318](https://togithub.com/nix-community/home-manager/issues/6318))
* [`f8ef4541`](https://github.com/nix-community/home-manager/commit/f8ef4541bb8a54a8b52f19b52912119e689529b3) nixpkgs: lib.isFunction replaces builtins.isFunction in check for overlayType ([nix-community/home-manager⁠#6338](https://togithub.com/nix-community/home-manager/issues/6338))
* [`9786661d`](https://github.com/nix-community/home-manager/commit/9786661d57c476021c8a0c3e53bf9fa2b4f3328b) fcitx5: allow to set fcitx5-with-addons ([nix-community/home-manager⁠#5770](https://togithub.com/nix-community/home-manager/issues/5770))
