### PR TITLE
niv nixpkgs: update e65e23b5 -> 88a55dff

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -231,7 +231,6 @@ rec {
     jc
     jless
     jq
-    loc
     lua
     moreutils
     mtr
@@ -249,6 +248,7 @@ rec {
     sd
     shellcheck
     shfmt
+    tokei
     tree
     unar
     uv

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e65e23b593f38f57b7076e1e025f904c07d7b848",
-        "sha256": "14l0pfn73miqap6grfvf4vg6c2ghcvzk5gbgsaf780md2b092jqb",
+        "rev": "88a55dffa4d44d294c74c298daf75824dc0aafb5",
+        "sha256": "05cjwc8lfgk8pz9qyb3gl097bwxqzblahcjs0adp0kr0226kyjph",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/e65e23b593f38f57b7076e1e025f904c07d7b848.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/88a55dffa4d44d294c74c298daf75824dc0aafb5.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@e65e23b5...88a55dff](https://github.com/nixos/nixpkgs/compare/e65e23b593f38f57b7076e1e025f904c07d7b848...88a55dffa4d44d294c74c298daf75824dc0aafb5)

* [`ca0bd350`](https://github.com/NixOS/nixpkgs/commit/ca0bd35097d7b7346a773d3349134b94aeb9f5d5) checkMeta: Expose checkValidity and add to all-packages
* [`8079c8bd`](https://github.com/NixOS/nixpkgs/commit/8079c8bd6dcdf9306be4a98b7bb452d5f63b84b2) idris2Packages.buildIdris: add retroactive support for building a whole dependency tree with source
* [`4d97c168`](https://github.com/NixOS/nixpkgs/commit/4d97c16871c5861581fa54c9317947f148252269) leptonica: format
* [`d653cc6b`](https://github.com/NixOS/nixpkgs/commit/d653cc6b877fa349121057635831eeedaea0ad0b) leptonica: 1.84.1 -> 1.85.0
* [`c4826155`](https://github.com/NixOS/nixpkgs/commit/c48261550c8fa7824dd643d5cbc66d11105df5eb) openbsd.mkDerivation: Set proper MACHINE variables
* [`212a268b`](https://github.com/NixOS/nixpkgs/commit/212a268bc14bed8109385bfddc7696a2c7e83007) maintainers: add jinser
* [`1259856b`](https://github.com/NixOS/nixpkgs/commit/1259856bac889331cf3bce2014651bb573d797db) llvmPackages.lldbPlugins: drop llvm/clang rebuild
* [`abe2d081`](https://github.com/NixOS/nixpkgs/commit/abe2d081c370a9c92e133d4a2410bcb23fe348ae) datasette: fix failing app on aarch64-darwin
* [`870974b0`](https://github.com/NixOS/nixpkgs/commit/870974b0260f95004d485847367391d8e24178ba) ack: 3.7.0 -> 3.8.0
* [`898f7b49`](https://github.com/NixOS/nixpkgs/commit/898f7b498b3dbc2eca495c5d6580f9c525b06630) bespokesynth: Modernise
* [`3a117af4`](https://github.com/NixOS/nixpkgs/commit/3a117af47d70c443f7c0bedda470d3f6106b21a6) bespokesynth: Modernise (with rebuilds)
* [`0a3fd92d`](https://github.com/NixOS/nixpkgs/commit/0a3fd92de049e5073d89cfaa8781f398179d633b) bespokesynth: Add passthru.updateScript
* [`5bc6acc8`](https://github.com/NixOS/nixpkgs/commit/5bc6acc80df0e98d17bba59f8f9d65905d1ba18f) bespokesynth: 1.2.1 -> 1.3.0
* [`e8ca293b`](https://github.com/NixOS/nixpkgs/commit/e8ca293bb3b569bee16ce071d38ea0140b88992f) bespokesynth: Use more system dependencies
* [`16267bf4`](https://github.com/NixOS/nixpkgs/commit/16267bf47023accd391750e66712722ec9826ec9) bespokesynth: Hardcode queried FQDN
* [`ebdf35c4`](https://github.com/NixOS/nixpkgs/commit/ebdf35c4363d50703b134d859ccf327b3dc7d031) bespokesynth: Move to by-name
* [`ac3cdad5`](https://github.com/NixOS/nixpkgs/commit/ac3cdad5391daa56a6030bede7b7cde8b791a145) python31{1,2}Packages.pysubs2: 1.7.3 -> 1.8.0
* [`37409b3b`](https://github.com/NixOS/nixpkgs/commit/37409b3b1a8d1a5f807dbd35c3e28cc32fa47a0e) llvmPackages_git: 20.0.0-unstable-2024-11-26 -> 20.0.0-unstable-2024-12-17
* [`f72b3415`](https://github.com/NixOS/nixpkgs/commit/f72b341556cf9438ecdc64de2973892387485531) llvmPackages_git.libc: init
* [`24a9528c`](https://github.com/NixOS/nixpkgs/commit/24a9528c83c5ee2a9e268135ee6dd7337f8a939c) spicetify-cli: 2.38.3 -> 2.38.7
* [`7f1e16d5`](https://github.com/NixOS/nixpkgs/commit/7f1e16d56d08b62c14198420f98776df174691a0) maintainers: add acuteaangle
* [`0996bcf2`](https://github.com/NixOS/nixpkgs/commit/0996bcf25b343a084d05106fd836916801e89276) rwpspread: 0.3.1 -> 0.4.0
* [`dc93e326`](https://github.com/NixOS/nixpkgs/commit/dc93e326f620705a830d6dec450eb160a532c4ad) mediawiki: 1.42.4 -> 1.43.0
* [`7df3b8d6`](https://github.com/NixOS/nixpkgs/commit/7df3b8d625c8c530b694aa6872cc6a4c08c85c66) cozette: 1.25.2 -> 1.26.0
* [`f83c3e6a`](https://github.com/NixOS/nixpkgs/commit/f83c3e6af111113bd50d31822ba609c423a706dc) hheretic: 0.2.3 -> 0.2.4
* [`a5af564f`](https://github.com/NixOS/nixpkgs/commit/a5af564f0be98522026e0253f320e865c2b5b952) ssdfs-utils: 4.46 -> 4.49
* [`b6f9dd79`](https://github.com/NixOS/nixpkgs/commit/b6f9dd796f5556a1c31e82d8ec415709e681572e) kokkos: 4.5.00 -> 4.5.01
* [`0fec56e5`](https://github.com/NixOS/nixpkgs/commit/0fec56e5229dc15a999c53555b01c8f854f13363) guile-hoot: init at 0.5.0
* [`a878bfd4`](https://github.com/NixOS/nixpkgs/commit/a878bfd443411e08928833dc0a4c7c611f135de0) dynamodb-local: 2.5.3 -> 2.5.4
* [`7ef5822a`](https://github.com/NixOS/nixpkgs/commit/7ef5822ac484039fa26f745af3ce011577434ae9) piknik: 0.10.1 -> 0.10.2
* [`55c251ae`](https://github.com/NixOS/nixpkgs/commit/55c251ae61da8b1749be997f7d2030139cd1efa5) cproto: 4.7w -> 4.7x
* [`1331a19b`](https://github.com/NixOS/nixpkgs/commit/1331a19b5aacbd5a156af57a93bdb6ca9c678e51) csound: 6.18.1 -> 6.18.1-unstable-2024-07-02
* [`70cef1dd`](https://github.com/NixOS/nixpkgs/commit/70cef1dd8cc0908ccaaa1eac514009a4e9f62986) sentry-cli: 2.39.1 -> 2.40.0
* [`9cf81429`](https://github.com/NixOS/nixpkgs/commit/9cf81429c3bd727db76ee3d032e349ccbf0d0d3f) armadillo: 14.2.1 -> 14.2.2
* [`eaa1c0a3`](https://github.com/NixOS/nixpkgs/commit/eaa1c0a3c349ef45f447dad2a44561a01ec8a9e0) positron-bin: add openssl as a dependency
* [`c9ddb6be`](https://github.com/NixOS/nixpkgs/commit/c9ddb6bef5f3760d3921969f241cb93b1162c32b) linuxPackages: 6.6 -> 6.12
* [`978c0461`](https://github.com/NixOS/nixpkgs/commit/978c0461ff041657bdcac4390e293f89ca8e1edd) mopidy: backport spotify access token auth
* [`bd2b24b7`](https://github.com/NixOS/nixpkgs/commit/bd2b24b72349e6fd3b4b4c91218780ec5b94fcac) mopidy-spotify: 5.0.0a2 -> 5.0.0a3
* [`ff0fe4e1`](https://github.com/NixOS/nixpkgs/commit/ff0fe4e1404d844ae87ee449ab2823b11adc956e) numcpp: 2.12.1 -> 2.13.0
* [`d69cdd2b`](https://github.com/NixOS/nixpkgs/commit/d69cdd2b578b1eae8616dcc0c98ed385d4c43eac) freeciv: 3.1.3 -> 3.1.4
* [`d10e413c`](https://github.com/NixOS/nixpkgs/commit/d10e413c2ced0b7d31dae3097d3ff9c170d78ca1) fswatch: 1.17.1 -> 1.18.0
* [`6da2bc74`](https://github.com/NixOS/nixpkgs/commit/6da2bc74dccaa843945f08fd65d8348a6ad9ef25) clojure: 1.12.0.1488 -> 1.12.0.1495
* [`c8e1cf73`](https://github.com/NixOS/nixpkgs/commit/c8e1cf73ec19f791eef6f0f9003fcc452d1faf68) ts_query_ls: 1.4.1 -> 1.4.2
* [`2ff25629`](https://github.com/NixOS/nixpkgs/commit/2ff256293ae082780e6f58167267f9bc81191b00) maintainers: add dbreyfogle
* [`d0c07d78`](https://github.com/NixOS/nixpkgs/commit/d0c07d78d12b9bece5e2b39f9318397fc5d7a46e) treedome: 0.5.1 -> 0.5.4
* [`c2900555`](https://github.com/NixOS/nixpkgs/commit/c290055571428a1015b135d89bce86ffe13837a9) nixos/simplesamlphp: don't configure empty options
* [`1a965b31`](https://github.com/NixOS/nixpkgs/commit/1a965b318d8298253f7b77f2d2737e7d7b2f1f18) cloud-nuke: 0.38.0 -> 0.38.1
* [`a18e283d`](https://github.com/NixOS/nixpkgs/commit/a18e283d7ff434cbd15319511b824834f8dfbaeb) pyrosimple: 2.14.1 -> 2.14.2
* [`1a55b6b7`](https://github.com/NixOS/nixpkgs/commit/1a55b6b75a4336ce89fea0194bdf0a9712ad7a1a) python312Packages.plugwise: 1.6.3 -> 1.6.4
* [`8cd0bb37`](https://github.com/NixOS/nixpkgs/commit/8cd0bb377eeb0bc42136ee28c9bacb461f135b7a) rgbds: 0.8.0 -> 0.9.0
* [`b4bcec16`](https://github.com/NixOS/nixpkgs/commit/b4bcec16a00756d79d9d1470d1a3894f0cc5015d) nixos/netdata: grant SUID to ndsudo
* [`e51eefa2`](https://github.com/NixOS/nixpkgs/commit/e51eefa29bfe025ba7fbd787679d038f48ded9a6) nng: 1.9.0 -> 1.10
* [`45f276b2`](https://github.com/NixOS/nixpkgs/commit/45f276b257bca8640ae35a7412932984a4b85f7a) ultrastardx: 2024.10.0 -> 2025.1.0
* [`cec9f303`](https://github.com/NixOS/nixpkgs/commit/cec9f3032be7547b18ea43fd16882691ffb6782f) paulstretch: update homepage
* [`bb5d69bb`](https://github.com/NixOS/nixpkgs/commit/bb5d69bba9f648a1a0897383327f1fb89858c53c) aragorn: update homepage
* [`0beaedac`](https://github.com/NixOS/nixpkgs/commit/0beaedaca95e04759bb1847d34b2f0988e08c5cc) netperf: update homepage
* [`f2e6d6ab`](https://github.com/NixOS/nixpkgs/commit/f2e6d6ab9cd59898adbdbf3e61bd4728813a6267) vengi-tools: update homepage
* [`3e071e12`](https://github.com/NixOS/nixpkgs/commit/3e071e122ab13da7c3b33e949fec2288b1c35b97) iwona: update homepage
* [`a3e60959`](https://github.com/NixOS/nixpkgs/commit/a3e6095949acaefb81ea348aced6a0ee22b91148) garden-of-coloured-lights: update homepage
* [`0f535409`](https://github.com/NixOS/nixpkgs/commit/0f53540942c196a86b03a161584f012b93ec4a2f) midori-unwrapped: update homepage
* [`80691778`](https://github.com/NixOS/nixpkgs/commit/8069177809b3d431f0362b306d72c9b0ce73d951) python312Packages.pylink-square: 1.3.0 -> 1.4.0
* [`c6ae8291`](https://github.com/NixOS/nixpkgs/commit/c6ae8291d2fac5e3195ac7af25d0bb2d25b28a75) pgmoneta: 0.15.0 -> 0.15.1
* [`53f806e0`](https://github.com/NixOS/nixpkgs/commit/53f806e02816c4129d40aa935f4a41ead5b8e217) stackql: 0.6.32 -> 0.6.50
* [`70414831`](https://github.com/NixOS/nixpkgs/commit/7041483103e1e2ab0a4742a3639b03029ad9d34f) qcad: 3.31.2.3 -> 3.31.2.7
* [`fb6736a9`](https://github.com/NixOS/nixpkgs/commit/fb6736a984779eb06491513fed13a8ebc293e9db) scala: drop scala 2.10 and 2.11
* [`e943fb22`](https://github.com/NixOS/nixpkgs/commit/e943fb22cc571fa29bca8db05542ef8097d4a951) elasticmq-server-bin: 1.6.10 -> 1.6.11
* [`9eccafa2`](https://github.com/NixOS/nixpkgs/commit/9eccafa200b6fd33c63d69d6eacacbfae7584985) todoist: 0.20.0 -> 0.22.0
* [`2bfeb890`](https://github.com/NixOS/nixpkgs/commit/2bfeb89021c53d15c52148a986fa607fade86bb6) mmex: move to pkgs/by-name
* [`405a6a53`](https://github.com/NixOS/nixpkgs/commit/405a6a53c511b6798af9dc61ad0bf2303b26000e) mmex: unvendor
* [`40a2ea84`](https://github.com/NixOS/nixpkgs/commit/40a2ea84338980d868f5ce2903bfc2c1b9353d05) dnsdist: 1.9.7 -> 1.9.8
* [`c5852659`](https://github.com/NixOS/nixpkgs/commit/c58526593f9881e45c48eee5f03536eff50d9d9c) sniffnet: 1.3.1 -> 1.3.2
* [`b88b5a80`](https://github.com/NixOS/nixpkgs/commit/b88b5a8066ef57dbfbb6b2ecdfc894c6b9fa8bdd) nbxplorer: 2.5.16 -> 2.5.17
* [`ce20e905`](https://github.com/NixOS/nixpkgs/commit/ce20e905bb8ec9bcbaddb5eefc8ea301264d4203) proton-pass: 1.27.0 -> 1.27.2
* [`a2e3b477`](https://github.com/NixOS/nixpkgs/commit/a2e3b4779ae570f57f56ddc3ab34ea61d767cd72) spicy-parser-generator: 1.11.3 -> 1.12.0
* [`b95d3858`](https://github.com/NixOS/nixpkgs/commit/b95d38587b5306f2fb8e5dc4191dd0617861fbda) coqPackages.MenhirLib: add maintainer
* [`d74aaeba`](https://github.com/NixOS/nixpkgs/commit/d74aaeba32ca61a783f234b05de73168ccd77ad2) namecoind: 25.0 -> 28.0
* [`5ede4649`](https://github.com/NixOS/nixpkgs/commit/5ede4649bacac6690a566928036b964830c03ee6) cobang: 0.14.1 -> 0.15.0
* [`9bcaf938`](https://github.com/NixOS/nixpkgs/commit/9bcaf938c1ca01360557c92bc3ea987bd22a17c2) chawan: 0-unstable-2024-12-27 -> 0-unstable-2025-01-06
* [`5ba5cf99`](https://github.com/NixOS/nixpkgs/commit/5ba5cf99817b6079fab6dddcab1712051230d53d) cubicsdr: fix Darwin build
* [`c7c174ca`](https://github.com/NixOS/nixpkgs/commit/c7c174caeff43ca3599d3d17f3ff5a253afacaa4) gnomeExtensions.pop-shell: 1.2.0-unstable-2024-10-09 -> 1.2.0-unstable-2024-12-31
* [`c080e6de`](https://github.com/NixOS/nixpkgs/commit/c080e6deb57326503347af5d7624245c959a9e8b) fw: 2.19.1 -> 2.20.0
* [`1c54c3f9`](https://github.com/NixOS/nixpkgs/commit/1c54c3f9845f71d7126539066c47867f20073970) livekit: 1.8.0 -> 1.8.3
* [`6ad6d3b2`](https://github.com/NixOS/nixpkgs/commit/6ad6d3b20966c3c52ba0a5f99e3b9665c11a46e8) sesh: 2.7.0 -> 2.8.0
* [`1e40ed64`](https://github.com/NixOS/nixpkgs/commit/1e40ed6494b0d3a0d6b379110baea26d0b12c65a) vttest: 20241204 -> 20241208
* [`f90c31df`](https://github.com/NixOS/nixpkgs/commit/f90c31df67079a89179c4037669fd6e4e591685c) zef: 0.22.6 -> 0.22.7
* [`bc966cb3`](https://github.com/NixOS/nixpkgs/commit/bc966cb3e318040876453732ea97500ce1b5aac6) dataexplorer: 3.9.0 -> 3.9.3
* [`e8d10db9`](https://github.com/NixOS/nixpkgs/commit/e8d10db92cad5e22290834a0c861cd6ab4a87455) livi: 0.2.0 -> 0.3.0
* [`7e18ed73`](https://github.com/NixOS/nixpkgs/commit/7e18ed7302675cd06c463d8f886baaa1037ae69a) gotify-desktop: 1.3.7 -> 1.4.0
* [`e9a00126`](https://github.com/NixOS/nixpkgs/commit/e9a00126f9d84d9e61d87e6238135245863a5cfa) openlibm: 0.8.4 -> 0.8.5
* [`0353128f`](https://github.com/NixOS/nixpkgs/commit/0353128f0217c957b1a52c2812b68b48a2bca33d) stevenblack-blocklist: 3.15.5 -> 3.15.8
* [`59e3191c`](https://github.com/NixOS/nixpkgs/commit/59e3191cadd9bdd874630d788af11856361fdecf) ols: 0-unstable-2024-12-28 -> 0-unstable-2025-01-04
* [`450fcb57`](https://github.com/NixOS/nixpkgs/commit/450fcb57101e6f80da321f45836bf70a00d8c9bf) bespokesynth: Fix compatibility with pipewire's JACK emulation
* [`f8db37f3`](https://github.com/NixOS/nixpkgs/commit/f8db37f3a1bbd05f8594b13d11228ca6f7fb3327) sdl3: init at 3.1.8
* [`6d9244a5`](https://github.com/NixOS/nixpkgs/commit/6d9244a526ad673435e3bf0b6d95c1fb3af9991e) makeDesktopItem: nixfmt
* [`318278aa`](https://github.com/NixOS/nixpkgs/commit/318278aaa4c14976766ba3ad2b7fa6c9dbde655b) makeDesktopItem: allow configuring output directory
* [`a93fdbaa`](https://github.com/NixOS/nixpkgs/commit/a93fdbaa77469431c3cc681f9f5d1b579ffb01b1) makeDesktopItem: add noogle-compatible documentation
* [`edad941e`](https://github.com/NixOS/nixpkgs/commit/edad941e03cd7273503a603d584748f9241948f3) cilium-cli: 0.16.22 -> 0.16.23
* [`a3a95981`](https://github.com/NixOS/nixpkgs/commit/a3a959813dadbd088fd8684daceedded38ae563e) llama-cpp: 4397 -> 4450
* [`2d42f784`](https://github.com/NixOS/nixpkgs/commit/2d42f784c6e032c40288615eb253f534acd34288) tabby: 0.22.0 -> 0.23.0
* [`b4d50c62`](https://github.com/NixOS/nixpkgs/commit/b4d50c6208e3b4d2dfaf3883fe17fb99790915e2) ocamlPackages.mccs: 1.1+18 -> 1.1+19
* [`19eb2823`](https://github.com/NixOS/nixpkgs/commit/19eb28239b179dd5a862d26f7095b3a6a8bf02e7) termius: 9.9.0 -> 9.12.0
* [`83928a4e`](https://github.com/NixOS/nixpkgs/commit/83928a4e42bfdc8ecd39fc3c5ee5340345af0d88) darktable: fix builds on macOS
* [`ebc7d18e`](https://github.com/NixOS/nixpkgs/commit/ebc7d18ebe7f9e703a4602f0dc3496c92fc5e47a) codeium: 1.30.18 -> 1.32.1
* [`81f18468`](https://github.com/NixOS/nixpkgs/commit/81f18468ae3e5a2d0612b5ab43ff74fa3a07f7f9) python312Packages.gattlib: use release tag
* [`493d7f0c`](https://github.com/NixOS/nixpkgs/commit/493d7f0cba1585b66e1e6f74334630d4a226fbd4) python312Packages.gattlib: switch to pyproject = true
* [`e9004165`](https://github.com/NixOS/nixpkgs/commit/e9004165ee77df1ee4b5676e4e5b41902c0fb726) python313Packages.gattlib: fix build against Python 3.13
* [`a343adb3`](https://github.com/NixOS/nixpkgs/commit/a343adb3ad251c6032df9c4828ef1ef8781c83f5) elkhound: add darwin support
* [`38f32ee4`](https://github.com/NixOS/nixpkgs/commit/38f32ee49ef9cf711bb97b110fca9379063b4b37) weidu: add darwin support
* [`41b14024`](https://github.com/NixOS/nixpkgs/commit/41b14024d24bd7488b58d7a252f8f16b194d57f9) pkgs/top-level/stage.nix: add pkgsLLVMLibc
* [`268410c7`](https://github.com/NixOS/nixpkgs/commit/268410c742b53f24ca96df2d7af7f1a2a8942d14) ares-cli: 3.1.3 -> 3.2.0
* [`32b0c77a`](https://github.com/NixOS/nixpkgs/commit/32b0c77a7e67ae0d5fc9a6741089e8075a496780) syzkaller: init at 0-unstable-2024-01-09
* [`e70ebc82`](https://github.com/NixOS/nixpkgs/commit/e70ebc824a25ef566e53a51c0336ec3be6188459) mongoose: 3.3.3 -> 3.3.4
* [`2058f5d0`](https://github.com/NixOS/nixpkgs/commit/2058f5d09c23caf693609212911d995c16bcf982) libwacom: Fix libwacom-show-stylus
* [`cef42e44`](https://github.com/NixOS/nixpkgs/commit/cef42e44b6c9ecc7b1789ed099d2406830a506f5) openfpgaloader: 0.12.1 -> 0.13.1
* [`2f4e7431`](https://github.com/NixOS/nixpkgs/commit/2f4e74311eae43ea23949a21e62a5b612bf65afc) seq66: 0.99.16 -> 0.99.17
* [`8cf2205b`](https://github.com/NixOS/nixpkgs/commit/8cf2205b43f0cd87b7b9e81c9d1ae3cb6a768c35) python312Packages.keras-applications: remove
* [`92371eb1`](https://github.com/NixOS/nixpkgs/commit/92371eb1be5e392cfeaa9054db7de1f9058a9033) awsume: install correct Zsh autocompletion
* [`795cbd1a`](https://github.com/NixOS/nixpkgs/commit/795cbd1a76100c637500289fd64c079feec70f9b) awsume: substitute path to awsume-autocomplete bin
* [`8aca148f`](https://github.com/NixOS/nixpkgs/commit/8aca148f4895d7b38c62050bfd0cd6d31e596e50) winetricks: 20240105 -> 20250102
* [`6a3e390d`](https://github.com/NixOS/nixpkgs/commit/6a3e390d2c735a4d1216d7b78e75ca358fb4d8b7) duckstation: Fix build on aarch64-linux
* [`c7098744`](https://github.com/NixOS/nixpkgs/commit/c7098744008164d3995f5208dadabbee5a6c63e9) abi-dumper: 1.2 -> 1.4
* [`b81b8539`](https://github.com/NixOS/nixpkgs/commit/b81b8539c048c3e98aff61a583acc475fc025feb) level-zero: 1.19.2 -> 1.20.0
* [`a4bea0f3`](https://github.com/NixOS/nixpkgs/commit/a4bea0f35f9619ac76a9887b714089221dde66c4) greetd.regreet: 0.1.3 -> 0.2.0
* [`2ea0fa87`](https://github.com/NixOS/nixpkgs/commit/2ea0fa877dcf8cf07492ac662ddc194b50c9d66e) calibre: 7.22.0 -> 7.24.0
* [`9802baf3`](https://github.com/NixOS/nixpkgs/commit/9802baf3f42dae79e2707eb5c78f2f78c3753d43) obs-cmd: 0.18.1 -> 0.18.2
* [`e9d0f59a`](https://github.com/NixOS/nixpkgs/commit/e9d0f59a5925a165677e9a7c620e419c3ee3ece3) python312Packages.highdicom: 0.22.0 -> 0.23.1
* [`35aa065d`](https://github.com/NixOS/nixpkgs/commit/35aa065d9b32b6858ad42f860e4dc43aa29a7143) paraview: 5.13.0 -> 5.13.2
* [`b6d9a73a`](https://github.com/NixOS/nixpkgs/commit/b6d9a73a5cbabdc18614a70c3f70f14022dea28a) enzyme: fix build for ClangEnzyme
* [`44ea839c`](https://github.com/NixOS/nixpkgs/commit/44ea839ccc22fb40f62275ff68613d30cf08400c) betterdisplay: 3.2.1 -> 3.3.0
* [`d88e6875`](https://github.com/NixOS/nixpkgs/commit/d88e68758a9edcb889541e731b0a0ed8402d7610) betterdisplay: version check
* [`0fceab91`](https://github.com/NixOS/nixpkgs/commit/0fceab9142454cac76d69e1f9f3bc026ce6adb45) zsh-prezto: 0-unstable-2024-12-12 -> 0-unstable-2025-01-10
* [`2ea3ad62`](https://github.com/NixOS/nixpkgs/commit/2ea3ad62c8808439d3e1f53b8630ded11d405042) heroku: 10.0.0 -> 10.0.2
* [`3ffda903`](https://github.com/NixOS/nixpkgs/commit/3ffda9033335d95338e1b80171327e2965f91dd7) svelte-language-server: 0.17.8 -> 0.17.10
* [`50046b45`](https://github.com/NixOS/nixpkgs/commit/50046b455f5c5a348b84902915715b76f8e6f6c9) rnr: 0.4.2 -> 0.5.0
* [`976679e1`](https://github.com/NixOS/nixpkgs/commit/976679e1647daa523b7eb48cd9a1b152716acad6) kubebuilder: 4.3.1 -> 4.4.0
* [`2ad21bce`](https://github.com/NixOS/nixpkgs/commit/2ad21bce4ea2aee9ec00aea73f77b17c5a105c5c) gnu-shepherd: 1.0.0 -> 1.0.1
* [`cc3615d6`](https://github.com/NixOS/nixpkgs/commit/cc3615d68ed4febbdf3580a58bb93988e6bacc3d) ugs: 2.1.9 -> 2.1.12
* [`81bc2811`](https://github.com/NixOS/nixpkgs/commit/81bc281190c4955903d546169453f16c39908d58) typescript: 5.7.2 -> 5.7.3
* [`6ab5c41d`](https://github.com/NixOS/nixpkgs/commit/6ab5c41d7ac12c8ee762a9324d7314b615b3d324) dovecot_fts_xapian: 1.8 -> 1.8.4
* [`f6135d7a`](https://github.com/NixOS/nixpkgs/commit/f6135d7a60c84523fe45b7c62d879f94be4ecb9c) debootstrap: 1.0.140 -> 1.0.140_bpo12+1
* [`9bb01785`](https://github.com/NixOS/nixpkgs/commit/9bb01785e1a473753de90a0418e7d90301a5e7cd) kicad: 8.0.7 -> 8.0.8
* [`651c20fc`](https://github.com/NixOS/nixpkgs/commit/651c20fc5db2f740a06b63e10103b4267f31b5c9) hw-probe: 1.6.5 -> 1.6.6
* [`f0d387a2`](https://github.com/NixOS/nixpkgs/commit/f0d387a2df7ca4b4a92d732f6f9787e2521ff293) badrobot: 0.1.3 -> 0.1.4
* [`9ab0448c`](https://github.com/NixOS/nixpkgs/commit/9ab0448cda981faa3193ff36fd2a0280a105b199) tex-fmt: 0.5.1 -> 0.5.2
* [`2e10c579`](https://github.com/NixOS/nixpkgs/commit/2e10c5793bcbc3ff07fbcea7a53936317ffff74f) goxel: 0.15.1 -> 0.15.1-unstable-2024-12-27
* [`6541a909`](https://github.com/NixOS/nixpkgs/commit/6541a909098f62c158aacdeb599425eeaa293c18) pcloud: use patchelfUnstable
* [`0c6c6ed0`](https://github.com/NixOS/nixpkgs/commit/0c6c6ed04922c2400ffc07661944e6447f5845b2) updatecli: 0.91.0 -> 0.92.0
* [`06bdc5a5`](https://github.com/NixOS/nixpkgs/commit/06bdc5a5737fd0da95d273cbe6637e40e69ea4b6) perlPackages.GnuPGInterface: use gnupg instead of gnupg1compat
* [`4efb8f08`](https://github.com/NixOS/nixpkgs/commit/4efb8f08d98f457ca6d1f4a0eefae0d6c6a05bb2) OVMF: add `passthru.mergedFirmware` parameter
* [`a35e5e53`](https://github.com/NixOS/nixpkgs/commit/a35e5e53753fb6722093a7c28a253221962fd6df) xen: use the merged OVMF blob
* [`349b7e66`](https://github.com/NixOS/nixpkgs/commit/349b7e661a1620f297f5ffa236b72f4dc6d4d218) tutanota-desktop: 259.241223.2 -> 259.250108.1
* [`9a2e8298`](https://github.com/NixOS/nixpkgs/commit/9a2e8298ed00690187840c05bb2643cf6ede3645) sql-formatter: 15.4.3 -> 15.4.9
* [`536293ee`](https://github.com/NixOS/nixpkgs/commit/536293ee470fc81c59b86c3a3488d9108e7690b9) gum: 0.14.5 -> 0.15.0
* [`77043634`](https://github.com/NixOS/nixpkgs/commit/77043634eddb13a973c2c9c97c4c1bf8b22df22b) activemq: 6.1.4 -> 6.1.5
* [`805a1897`](https://github.com/NixOS/nixpkgs/commit/805a18975a9b5879c64d8dad379ca0a534ccac35) glamoroustoolkit: 1.1.8 -> 1.1.9
* [`e188c1bd`](https://github.com/NixOS/nixpkgs/commit/e188c1bdd6e0d605074773a7304d9777c9b55df7) olvid: 2.2.0 -> 2.3.0
* [`c0d16425`](https://github.com/NixOS/nixpkgs/commit/c0d16425b27697c0f5c0d54fbef5dadb87bfe841) airshipper: 0.15.0 -> 0.16.0
* [`99f9f7cd`](https://github.com/NixOS/nixpkgs/commit/99f9f7cd89cddf8fbb4686c1d093256edd42872b) neo4j: 5.26.0 -> 5.26.1
* [`bef04e57`](https://github.com/NixOS/nixpkgs/commit/bef04e57aea66636c096aae4cf7c350e18bbf9f2) whistle: 2.9.92 -> 2.9.93
* [`4202351f`](https://github.com/NixOS/nixpkgs/commit/4202351fd613b6c3e09a814f8a1375cec5295f49) altair: 8.0.5 -> 8.1.3
* [`f321f74b`](https://github.com/NixOS/nixpkgs/commit/f321f74b733caee9231d403447141dcf5cefb979) youtrack: 2024.3.55417 -> 2024.3.56671
* [`2cea8d4a`](https://github.com/NixOS/nixpkgs/commit/2cea8d4ab24956f86fc71155e5c5d65445d87f8f) python312Packages.llama-cpp-python: 0.3.5 -> 0.3.6
* [`e55003d2`](https://github.com/NixOS/nixpkgs/commit/e55003d29d70e696ed6a266d05e7effd47887499) pipenv-poetry-migrate: move from python3Packages
* [`3c904888`](https://github.com/NixOS/nixpkgs/commit/3c9048889a3e573f3067989c246f203c43532bf9) pipenv-poetry-migrate: refactor
* [`11f9ec78`](https://github.com/NixOS/nixpkgs/commit/11f9ec78ff314d4c65aaeff1013ac1b80ca81c10) gensio: 2.8.10 -> 2.8.11
* [`2b492ee6`](https://github.com/NixOS/nixpkgs/commit/2b492ee652bbff957a4dbf4459bc4369968ff323) mpop: 1.4.20 -> 1.4.21
* [`0129b83a`](https://github.com/NixOS/nixpkgs/commit/0129b83a02516278fdcf123343034f6744767ad6) varnish76: init at 7.6.1
* [`75ad720f`](https://github.com/NixOS/nixpkgs/commit/75ad720f775dad2cef4697d3baef1acf4630ccd8) varnish: add flying circus as maintainer
* [`4d4cbee2`](https://github.com/NixOS/nixpkgs/commit/4d4cbee23d29b0f12a1f5c9cf0792f166a86352d) serfdom: 0.10.1 -> 0.10.2
* [`93a4d40e`](https://github.com/NixOS/nixpkgs/commit/93a4d40e735cefb0799165ffec0cd6b9d2ab2512) maintainers: add theredstonedev
* [`99df3b54`](https://github.com/NixOS/nixpkgs/commit/99df3b541cfadd5a65ad90fd5a53ec01643dd998) drumkv1: 0.9.23 -> 1.0.0 (+fix LV2 Qt UI issues)
* [`2357fa68`](https://github.com/NixOS/nixpkgs/commit/2357fa68eef0c861386de6aeb169ab4c3f5adf3f) feishu: 7.28.10 -> 7.32.11
* [`daf056cf`](https://github.com/NixOS/nixpkgs/commit/daf056cf9c3410e44562f53137b2a93a54c43f88) coursier: 2.1.22 -> 2.1.24
* [`879051dd`](https://github.com/NixOS/nixpkgs/commit/879051dda422f478324cb8234a3b25f837cb2374) gnome-podcasts: 0.7.1 -> 0.7.2
* [`de7025b3`](https://github.com/NixOS/nixpkgs/commit/de7025b325245ee6a31d54d1f9795f9b99862c5b) felix-fm: 2.14.0 -> 2.16.0
* [`8f4bc44f`](https://github.com/NixOS/nixpkgs/commit/8f4bc44f880f2251ac9cd7447ba7f02eaba10272) nixos/radicale: Allow AF_UNIX for systemd log
* [`8f0b7152`](https://github.com/NixOS/nixpkgs/commit/8f0b7152f3b937e716efd05cb8d8118bab524e21) micronaut: 4.7.3 -> 4.7.4
* [`36e15fb4`](https://github.com/NixOS/nixpkgs/commit/36e15fb41bc344765ace61d9254167e8d9774b16) jsvc: 1.4.0 -> 1.4.1
* [`327b3008`](https://github.com/NixOS/nixpkgs/commit/327b300831071ce5c47cf56e2f0ebc1f5c7e7ef9) apk-tools: 2.14.7 -> 2.14.9
* [`e9ebe4ed`](https://github.com/NixOS/nixpkgs/commit/e9ebe4edec9884171a4fe46bfdc0d5add2740387) iroh: 0.30.0 -> 0.31.0
* [`17f5f295`](https://github.com/NixOS/nixpkgs/commit/17f5f2958069306597eb0ddc4666ab41b9f81945) cunicu: 0.10.0 -> 0.12.0
* [`d8522d12`](https://github.com/NixOS/nixpkgs/commit/d8522d1248a82e0fbe535ca57b59f114a3dd8865) grml-zsh-config: 0.19.11 -> 0.19.12
* [`7f3bc71d`](https://github.com/NixOS/nixpkgs/commit/7f3bc71da99129ec635d5b0ec0c39194aa2ad8cc) latex2html: 2024.2 -> 2025
* [`0fe47395`](https://github.com/NixOS/nixpkgs/commit/0fe47395569c72f050f7cc4a59c78875eca3e58c) nixos/garage: add user-given path to ReadWritePaths
* [`97f27249`](https://github.com/NixOS/nixpkgs/commit/97f27249297bf5fbc563014ae9d4884dee27f1e0) nixos/garage: add cything as maintainer
* [`9ae82639`](https://github.com/NixOS/nixpkgs/commit/9ae82639dd42751909324b7d6090fb957a800ad3) immich-public-proxy: 1.5.6 -> 1.6.2
* [`6967de3b`](https://github.com/NixOS/nixpkgs/commit/6967de3b987d5803ee72ffd3d0facadedacdbd2e) stress-ng: 0.18.07 -> 0.18.09
* [`30538082`](https://github.com/NixOS/nixpkgs/commit/30538082b29abfe58c060e646169f48d9279cbb0) cosmic-workspaces-epoch: 1.0.0-alpha.2 -> 1.0.0-alpha.5.1
* [`6a8498eb`](https://github.com/NixOS/nixpkgs/commit/6a8498eb013957f50bb96b0f65491377eabcdde6) cosmic-edit: 1.0.0-alpha.4 -> 1.0.0-alpha.5.1
* [`c5c7595d`](https://github.com/NixOS/nixpkgs/commit/c5c7595dc93db1440cb10e09f9f8362338faa2d0) Make gradle update script runnable on macos
* [`82237781`](https://github.com/NixOS/nixpkgs/commit/822377815e4ec0384e1276dd18e417ceae5f6426) cosmic-term: 1.0.0-alpha.3 -> 1.0.0-alpha.5.1
* [`f5816b05`](https://github.com/NixOS/nixpkgs/commit/f5816b055d85986e40e5f82e45b1cfb6193c371c) perlPackages.Socket6: fix cross build
* [`273d98d9`](https://github.com/NixOS/nixpkgs/commit/273d98d9936f6e3073af4166a1cb35b67de23627) perlPackages.Tk: fix cross build
* [`d7ac52bd`](https://github.com/NixOS/nixpkgs/commit/d7ac52bd816b0f28a1070c4c90c2e24061ab34a0) matomo-beta: remove
* [`ddb143ae`](https://github.com/NixOS/nixpkgs/commit/ddb143ae14a07231b159b86e4e3dd356de91d08f) lomiri.lomiri-notifications: 1.3.0 -> 1.3.1
* [`057d0c76`](https://github.com/NixOS/nixpkgs/commit/057d0c76dcfe9110f40af33db83aabd0050fbd94) lomiri.lomiri-telephony-service: 0.5.3 -> 0.6.0, rename from lomiri.telephony-service
* [`501e3f0d`](https://github.com/NixOS/nixpkgs/commit/501e3f0dec99ea54c3e2c2e0a8b3041e9c0ca830) alpaca: 3.2.0 -> 3.5.0
* [`57718cbd`](https://github.com/NixOS/nixpkgs/commit/57718cbd821d3649158129978703c17ed9b7181f) alpaca: add nix-update-script
* [`27f6a180`](https://github.com/NixOS/nixpkgs/commit/27f6a1807f9de49b2507d20785523796d955f677) lomiri.lomiri-indicator-network: 1.0.2 -> 1.1.0
* [`2d8574f5`](https://github.com/NixOS/nixpkgs/commit/2d8574f5ed16d3d6bdfdcbba2d674a14961ccd26) traefik: 3.2.2 -> 3.3.2
* [`9b100cfb`](https://github.com/NixOS/nixpkgs/commit/9b100cfb67ccb2ff6e723b78d4ae2f9c88654a1c) kubernetes-helm: 3.16.4 -> 3.17.0
* [`9eb4351f`](https://github.com/NixOS/nixpkgs/commit/9eb4351feb5ce29ddc39c3f4b39781616bc2a586) clzip: 1.14 -> 1.15
* [`2cacb1e6`](https://github.com/NixOS/nixpkgs/commit/2cacb1e62680e3718a43577f5df36a3b600e0e11) openvpn: 2.6.12 -> 2.6.13
* [`1469c89e`](https://github.com/NixOS/nixpkgs/commit/1469c89eacb45651f550e1e5536541cc15587642) minisign: 0.11 -> 0.12
* [`7d527410`](https://github.com/NixOS/nixpkgs/commit/7d5274103b08ba1be2f5062dc4c05ae78f6bd19c) tellico: 4.0.1 -> 4.1
* [`96dc59ba`](https://github.com/NixOS/nixpkgs/commit/96dc59ba7ce5f25defa90f99829665156fe35056) libphonenumber: 8.13.52 -> 8.13.53
* [`0bfb3987`](https://github.com/NixOS/nixpkgs/commit/0bfb3987ba7e1b31ad2f5e44b679afbbd836ea6a) saucectl: 0.190.1 -> 0.191.0
* [`5698ccd0`](https://github.com/NixOS/nixpkgs/commit/5698ccd0fd66cb1817b133384bab6ebff5d77758) marp-cli: 4.0.4 -> 4.1.0
* [`83eb8d80`](https://github.com/NixOS/nixpkgs/commit/83eb8d8020d148cd151bbd5f93cd776ffef7dc7b) matomo: refactor into single package file
* [`252c0538`](https://github.com/NixOS/nixpkgs/commit/252c0538e5dfcb84e687719293e7c1b9a17b5d9d) matomo: move to pkgs/by-name
* [`1cc9c542`](https://github.com/NixOS/nixpkgs/commit/1cc9c542bc08bf7e1f0eb057e81067125a150f56) matomo: add updateScript
* [`e9750c60`](https://github.com/NixOS/nixpkgs/commit/e9750c60f30419dae1bc9af0d2b6a2ad2e45e1c7) matomo: add maintainer niklaskorz
* [`7c2e8f1b`](https://github.com/NixOS/nixpkgs/commit/7c2e8f1b55016a0a7145e46127db986737693ad5) nixos/matomo: migrate tests from handleTest to runTest
* [`545bf41e`](https://github.com/NixOS/nixpkgs/commit/545bf41ebdf45562d8bc78628b9e0dc5804c34ae) lomiri.lomiri-app-launch: 0.1.9 -> 0.1.11
* [`9aa9b9ba`](https://github.com/NixOS/nixpkgs/commit/9aa9b9ba7ae733e364d2e87bdc03a14cda5e3d9d) fcitx5-pinyin-moegirl: 20241211 -> 20250111
* [`b0ce3861`](https://github.com/NixOS/nixpkgs/commit/b0ce3861bb9c592adb1aaf03bf663cdd985836f1) xtermcontrol: 3.8 -> 3.10
* [`f4ae7af6`](https://github.com/NixOS/nixpkgs/commit/f4ae7af638f688db7c89120faed560c2cbea5b9e) ipv6calc: 4.2.1 -> 4.2.2
* [`2b954b5f`](https://github.com/NixOS/nixpkgs/commit/2b954b5f7d42232e5bf0e78162de4d13db0c6a55) freeipmi: 1.6.14 -> 1.6.15
* [`6d5b6935`](https://github.com/NixOS/nixpkgs/commit/6d5b6935662994444c737fd63c3d8887f1d8e6f9) clang-uml: 0.5.6 -> 0.6.0
* [`86005e91`](https://github.com/NixOS/nixpkgs/commit/86005e91e1d14b97594f1f0d71c7b6c2926066fc) xpipe: 13.4.4 -> 14.0
* [`bf337e45`](https://github.com/NixOS/nixpkgs/commit/bf337e4538de8a7b05584774fd2db6846e6f0080) c3c: 0.6.5 -> 0.6.6
* [`ba2d7f14`](https://github.com/NixOS/nixpkgs/commit/ba2d7f142d446d5353d50f0fa78f31bd5914887a) wootility: 4.7.2 -> 4.7.3
* [`dd97fe94`](https://github.com/NixOS/nixpkgs/commit/dd97fe94e0556f9e19b851b162871a28102e1434) vue-typescript-plugin: init at 2.2.0
* [`765478f5`](https://github.com/NixOS/nixpkgs/commit/765478f52fca03e545e3021d55e4d53dc0347c4d) cosmic-player: init at unstable-2025-01-14
* [`8a957c17`](https://github.com/NixOS/nixpkgs/commit/8a957c17d5fa0b9823618098b8734081c97771b3) kdePackages.qtkeychain: 0.14.3 -> 0.15.0
* [`8db76ca7`](https://github.com/NixOS/nixpkgs/commit/8db76ca7c3ea63ee43d05e317935196a565ff83e) json-sort-cli: init at 2.0.2
* [`0cbc155b`](https://github.com/NixOS/nixpkgs/commit/0cbc155bedd67bd9b75becf00b80e2179f58570e) libsForQt5.qtkeychain: 0.14.3 -> 0.15.0
* [`150cc9a7`](https://github.com/NixOS/nixpkgs/commit/150cc9a7ce570a86e52e6058a76542a25d2a8e3e) polypane: 22.1.1 -> 23.0.0
* [`a19575aa`](https://github.com/NixOS/nixpkgs/commit/a19575aa07d8142555e273969ec00ec7e3319806) openvas-scanner: 23.14.0 -> 23.15.0
* [`fbe603d8`](https://github.com/NixOS/nixpkgs/commit/fbe603d84404dec539748af830690be7b041c641) mcontrolcenter: 0.4.1 -> 0.5.0
* [`aff5150b`](https://github.com/NixOS/nixpkgs/commit/aff5150b3693ccf18d4f97a4e8c5291ba0ce18ed) lomiri.lomiri-thumbnailer: 3.0.3 -> 3.0.4
* [`ba79b6d6`](https://github.com/NixOS/nixpkgs/commit/ba79b6d68b191c8bb5b83dd6df1efc0834680c64) nixos/varnish: reduce overusage of `lib` ([nixos/nixpkgs⁠#208242](https://togithub.com/nixos/nixpkgs/issues/208242))
* [`0640622e`](https://github.com/NixOS/nixpkgs/commit/0640622eb1fb3ca4182e71aa3a48def88458ecec) nixos/varnish: fix stateDir to allow direct use of `varnishadm`
* [`76447ebd`](https://github.com/NixOS/nixpkgs/commit/76447ebd9e62bd1775a2f75699bf8477fa7b09a3) libretro.vice-*: init at 0-unstable-2025-01-11
* [`f941b532`](https://github.com/NixOS/nixpkgs/commit/f941b5323c65781cfe2d0c0ed3b25d9071a9cd85) mitama-cpp-result: 9.3.0 -> 10.0.4
* [`3aa13d8c`](https://github.com/NixOS/nixpkgs/commit/3aa13d8c44e8f44240beb03904c6d59ae624aefd) quill-log: 7.5.0 -> 8.0.0
* [`1a5827b3`](https://github.com/NixOS/nixpkgs/commit/1a5827b324c17b303d707551d876b34ddb62ddf3) clj-kondo: 2024.11.14 -> 2025.01.16
* [`4a5ef9b7`](https://github.com/NixOS/nixpkgs/commit/4a5ef9b782c8deca1785e8b5e87d831e29ec62d6) cargo-hack: 0.6.33 -> 0.6.34
* [`334a056d`](https://github.com/NixOS/nixpkgs/commit/334a056d6ddf0e2887e3c8e8ea9948021748f25d) bootstrap-studio: 7.0.2 -> 7.0.3
* [`08845d5e`](https://github.com/NixOS/nixpkgs/commit/08845d5eab463c0f64e69a3aa8910b8e2f1d62e8) flake-checker: 0.2.3 -> 0.2.4
* [`514d4725`](https://github.com/NixOS/nixpkgs/commit/514d472504780fc8cab55ffde03039267c5613a7) defaultCrateOverrides: remove obsolete darwin frameworks
* [`4748cfa7`](https://github.com/NixOS/nixpkgs/commit/4748cfa714e460dd68bc30c271d638a1a533089a) opensoundmeter: 1.4 -> 1.4.1
* [`9c090cbc`](https://github.com/NixOS/nixpkgs/commit/9c090cbce0bd7b848e461108bdda49f0c65a1a48) manga-tui: 0.4.0 -> 0.5.0
* [`804b6442`](https://github.com/NixOS/nixpkgs/commit/804b6442bdfd0a46e26fa9ef7b2cbd5cfefcad6b) talosctl: 1.9.1 -> 1.9.2
* [`1f678453`](https://github.com/NixOS/nixpkgs/commit/1f6784530daba470e01b3b96fc90dd970e81d8ae) cargo-tarpaulin: 0.31.4 -> 0.31.5
* [`666e3267`](https://github.com/NixOS/nixpkgs/commit/666e3267850998efd257c660d67a156c41c8ab10) alsa-lib: fix building with llvm
* [`c7b06f94`](https://github.com/NixOS/nixpkgs/commit/c7b06f94804af3bbb82e8be0f952cc5fbc0c06d7) libremidi: 4.4.0 -> 4.5.0
* [`0b707807`](https://github.com/NixOS/nixpkgs/commit/0b707807389a77e5f22c975a0a6104d0650c4d45) kitty: 0.38.1 → 0.39.0
* [`f2c38797`](https://github.com/NixOS/nixpkgs/commit/f2c3879717e22dcf371b766b587fa063853960e1) kitty: update description
* [`7f28294e`](https://github.com/NixOS/nixpkgs/commit/7f28294ee5a0cd102555bb665ece7b98528aa400) kitty: fix formatting
* [`bebf31e4`](https://github.com/NixOS/nixpkgs/commit/bebf31e4d4b09f5214aa7c8c1ecbdf4b6d28961c) lianad: 8.0 -> 9.0
* [`91956156`](https://github.com/NixOS/nixpkgs/commit/91956156120622fecc38947ca02d0d0eb20a3620) ode: 0.16.5 -> 0.16.6
* [`38dd37cd`](https://github.com/NixOS/nixpkgs/commit/38dd37cdc823e9520f06ee8f0219f4f205a66753) swiftlint: 0.58.0 -> 0.58.2
* [`97e3a655`](https://github.com/NixOS/nixpkgs/commit/97e3a655a08b329e61faf688b975ff6e62151346) commonsDaemon: 1.4.0 -> 1.4.1
* [`e706f49a`](https://github.com/NixOS/nixpkgs/commit/e706f49a8c287e50d9c05360dae2e4497bcff613) imsprog: 1.4.4 -> 1.4.5
* [`ab08ebc5`](https://github.com/NixOS/nixpkgs/commit/ab08ebc58d43fa79cd27f4fd432b8e619f8128cd) woof-doom: 15.0.1 -> 15.1.0
* [`9b660dff`](https://github.com/NixOS/nixpkgs/commit/9b660dff6d7771bae9e620ffa342794c4ff79842) incus: fix instance shutdown when softDaemonRestart enabled
* [`274e0fd9`](https://github.com/NixOS/nixpkgs/commit/274e0fd934df69ce630f40522ee4f7e9fee6d8ca) incus: support per-instance lxcfs
* [`f3a75905`](https://github.com/NixOS/nixpkgs/commit/f3a75905ab2f3ea3cd67f14fc5b132ff2df7f1e5) nixos/tests/incus: fix subtest names and add reboot check
* [`80e73d69`](https://github.com/NixOS/nixpkgs/commit/80e73d690ab2c68a0e82eb9f2cd939a2fc2a23d1) nixos/incus: add lxc hook path to service env
* [`b90638c6`](https://github.com/NixOS/nixpkgs/commit/b90638c68d93a23a06f0f0ad76f612c7be15c450) jetbrains: 2024.3.1 -> 2024.3.3
* [`8e22b77d`](https://github.com/NixOS/nixpkgs/commit/8e22b77d69a3ca83fc4c2defd60346f0694e1bff) jetbrains.plugins: update
* [`22ed62c1`](https://github.com/NixOS/nixpkgs/commit/22ed62c140c44ba2a4324cdee6688b716598be41) nixos/rippled: drop
* [`f0726244`](https://github.com/NixOS/nixpkgs/commit/f0726244095f3f0b1495561c37c59e7fc4f8819d) nixos/rippleDataApi: drop
* [`9a50cae3`](https://github.com/NixOS/nixpkgs/commit/9a50cae3bbc3d9c8650d01caeedfa9b8bad2d9f5) hawkthorne-journey: init at 1.1.0
* [`54224cf5`](https://github.com/NixOS/nixpkgs/commit/54224cf56a75e36551e7564e8e4c94c6d4ddf09f) tmx2lua: init at 1.0.1
* [`754146a3`](https://github.com/NixOS/nixpkgs/commit/754146a3c3b4ce52d6ef015219a53ee07542ad2b) python312Packages.robotframework-seleniumlibrary: 6.6.1 -> 6.7.0
* [`c01d4db0`](https://github.com/NixOS/nixpkgs/commit/c01d4db06471bc360b00b334518ac069b3c27ec0) nixos/wireless: remove patch warning from allowAuxiliaryImperativeNetworks option
* [`f1b468a5`](https://github.com/NixOS/nixpkgs/commit/f1b468a5667bac9518ae2e6ba9c40998b736710d) probe-rs-tools: 0.25.0 -> 0.26.0
* [`e5007e43`](https://github.com/NixOS/nixpkgs/commit/e5007e43b0733016f975bebce222f3918cf5131f) linuxKernel.kernels.linux_zen: fix update script
* [`43a7f605`](https://github.com/NixOS/nixpkgs/commit/43a7f6052924f235eab14b78d014e15cdcf20452) linuxKernel.kernels.linux_zen: 6.12.2 -> 6.12.10
* [`8859192d`](https://github.com/NixOS/nixpkgs/commit/8859192db359988dcfcdfcf71f233abb7571988c) linuxKernel.kernels.linux_lqx: 6.12.2 -> 6.12.10
* [`8acf8946`](https://github.com/NixOS/nixpkgs/commit/8acf8946722cac8e14a3074782e626015b5fbfe6) nixos/stirling-pdf: fix external dependencies and service permissions
* [`742b621a`](https://github.com/NixOS/nixpkgs/commit/742b621ab0502554a2aa3a2d0946954d11e6a4d4) libosmocore: 1.10.0 -> 1.10.1
* [`ccdceb51`](https://github.com/NixOS/nixpkgs/commit/ccdceb51e3064fde31180409171028e1d8284703) appgate-sdp: 6.4.0 -> 6.4.1
* [`04ca0033`](https://github.com/NixOS/nixpkgs/commit/04ca0033384d094bb0a9707e2452a4e5fb389fc3) fex: 2412 -> 2501
* [`0e1e7c17`](https://github.com/NixOS/nixpkgs/commit/0e1e7c177cbb04eaab9f449339510cbcdc81fbe3) hyprland-protocols: 0.5.0 -> 0.6.0
* [`5d3e652e`](https://github.com/NixOS/nixpkgs/commit/5d3e652ea5361094ee4051476119e2e2dac4cd0b) weaviate: 1.28.2 -> 1.28.3
* [`7f6ba9f7`](https://github.com/NixOS/nixpkgs/commit/7f6ba9f71c47053d94cecacca089b72d38156e74) python312Packages.genson: init at 1.3.0
* [`2439ead7`](https://github.com/NixOS/nixpkgs/commit/2439ead79150130e48f6c45409337125f4250685) lib.extendMkDerivation: init
* [`71d1ee92`](https://github.com/NixOS/nixpkgs/commit/71d1ee92de71061c36cac75283f45eb7b547fcba) clash-verge-rev: 2.0.2 -> 2.0.3
* [`5f422c56`](https://github.com/NixOS/nixpkgs/commit/5f422c56224b44156214bf2130735cec1c2ad9de) dbvisualizer: 24.3.2 -> 24.3.3
* [`83cbb264`](https://github.com/NixOS/nixpkgs/commit/83cbb264bec2f78debf749deb761edfa07e25e99) ankama-launcher: 3.12.28 -> 3.12.30
* [`76665e88`](https://github.com/NixOS/nixpkgs/commit/76665e882758672c497f20c10e8130273a4423ce) iosevka: 32.3.1 -> 32.4.0
* [`7c469273`](https://github.com/NixOS/nixpkgs/commit/7c469273d4b74b590257213738d2c1f1799d01e3) tidb: 8.5.0 -> 8.5.1
* [`bbdf8601`](https://github.com/NixOS/nixpkgs/commit/bbdf8601bcf2a7e733d5ef2552109a5d8d5a44ce) doc: add chapter Fixed-point arguments of build helpers
* [`4de0fe42`](https://github.com/NixOS/nixpkgs/commit/4de0fe420b54c6d9e2cc01211bf2cf0dc855a4ab) awscli2: 2.22.13 -> 2.23.2
* [`b331d661`](https://github.com/NixOS/nixpkgs/commit/b331d661de5d58572e44d388cd81895d1e645b94) maintainers: rename thinnerthinker -> boralg
* [`e4bdf35c`](https://github.com/NixOS/nixpkgs/commit/e4bdf35cc2b803019fa2e89462a411cac97a7392) krane: 3.6.2 -> 3.7.0
* [`7f175c12`](https://github.com/NixOS/nixpkgs/commit/7f175c12cdea410a6a4d42694fb11549551817be) oxlint: 0.15.3 -> 0.15.6
* [`bb327861`](https://github.com/NixOS/nixpkgs/commit/bb327861ef7ed0e75a7c00c64e30818ccafab52b) peazip: remove insecure and redundant dependency "archiver"
* [`3051b155`](https://github.com/NixOS/nixpkgs/commit/3051b1550a587c86bccf8b0ffef319862eeb4277) skrooge: 2.33.0 -> 25.1.0
* [`10fd8fa7`](https://github.com/NixOS/nixpkgs/commit/10fd8fa7c7f6bb65694bf2abca72707168a00fc3) bfs: 4.0.4 -> 4.0.5
* [`4924685d`](https://github.com/NixOS/nixpkgs/commit/4924685d4abef488aded8d51cfc301c400ba4f44) dillo: 3.1.1 -> 3.2.0
* [`9aa898f5`](https://github.com/NixOS/nixpkgs/commit/9aa898f52af4571a4cffad1d4ba704e9f58d637c) xcodegen: bundle included settings presets
* [`25e4bfda`](https://github.com/NixOS/nixpkgs/commit/25e4bfdaf1037c87de5dce51c12751d988944e4b) unrar: 7.1.2 -> 7.1.3
* [`411f7cdb`](https://github.com/NixOS/nixpkgs/commit/411f7cdb55e8e3055cca1bd5898cadc827d853b0) maintainers: update key for rytswd
* [`871979af`](https://github.com/NixOS/nixpkgs/commit/871979afbaa78553f96e716fe584d13f7cc3a704) civo: add rytswd as maintainer
* [`4bbd83f6`](https://github.com/NixOS/nixpkgs/commit/4bbd83f6d6456abcf2ec7e9d5bb6d44bbf676d7c) kodi: 21.1 -> 21.2
* [`c3c4be8f`](https://github.com/NixOS/nixpkgs/commit/c3c4be8f58d437e73c5ed03eeb30d3fc8c9c68ef) klayout: 0.29.10 -> 0.29.11
* [`2269ae37`](https://github.com/NixOS/nixpkgs/commit/2269ae37e860190c38b17826d5ca274e6a901c46) alvr: 20.11.1 -> 20.12.0
* [`b55a5291`](https://github.com/NixOS/nixpkgs/commit/b55a5291d1e2751e487bd9a9f8b6e81c5f339d46) dotnet-ef: 9.0.0 -> 9.0.1
* [`b96bce05`](https://github.com/NixOS/nixpkgs/commit/b96bce0598349bcf6210db7a5c9275400861843b) immich: 1.123.0 -> 1.124.2
* [`ab6060a6`](https://github.com/NixOS/nixpkgs/commit/ab6060a6c6db75f9998d6e864de596567d38a16e) phpExtensions.blackfire: 1.92.30 -> 1.92.32
* [`7d86dd09`](https://github.com/NixOS/nixpkgs/commit/7d86dd09e2233e7082ad957586d85f7bcdd28d8f) python312Packages.pynitrokey: 0.7.1 -> 0.7.3
* [`47a666c9`](https://github.com/NixOS/nixpkgs/commit/47a666c93348704beafe7eae3a63bf3cb13a52ad) tegola: 0.21.0 → 0.21.2
* [`44d75826`](https://github.com/NixOS/nixpkgs/commit/44d7582698a1b2c998a957e28558bf45e9c034fd) mmseqs2: 16-747c6 -> 17-b804f
* [`f430d897`](https://github.com/NixOS/nixpkgs/commit/f430d897ca2ffbfaa3cc7e688e5a745623cf7bfc) mmseqs2: add meta.changelog
* [`f575c248`](https://github.com/NixOS/nixpkgs/commit/f575c248410bfe8b0000222370a82eb9df53a9f5) libretrack: init at 1.7.0
* [`6ade29b7`](https://github.com/NixOS/nixpkgs/commit/6ade29b7831d5a0aaefc2053ea978c35ac000a26) kdocker: move to by-name/kd
* [`d8de57d5`](https://github.com/NixOS/nixpkgs/commit/d8de57d5432f61de705d01ee82f1e8d87fb54c94) nvidia-modprobe: 550.54.14 -> 565.77
* [`b16f9da3`](https://github.com/NixOS/nixpkgs/commit/b16f9da3b2daf09b59ec0305290fda4092024ae0) kdocker: 5.4 -> 6.2 ([nixos/nixpkgs⁠#374966](https://togithub.com/nixos/nixpkgs/issues/374966))
* [`dcfd4b07`](https://github.com/NixOS/nixpkgs/commit/dcfd4b07484c0b362d1b88f61ff2509c24c9b9f9) slackdump: 3.0.2 -> 3.0.3
* [`01e831ec`](https://github.com/NixOS/nixpkgs/commit/01e831ecd1566e78bae90cb6936e7d1877ad75d6) maintainers: add matrix to boralg
* [`a0472778`](https://github.com/NixOS/nixpkgs/commit/a0472778d37f67bbc28cb964129aa7e25b507ace) gmetronome: 0.4.1 -> 0.4.2
* [`7dcbeafe`](https://github.com/NixOS/nixpkgs/commit/7dcbeafeee879116f738040e40a8bc0d6f7a5594) hermitcli: 0.41.0 -> 0.42.1
* [`62973562`](https://github.com/NixOS/nixpkgs/commit/629735627a8fadeb42011ff5b5e185913e0f92db) grafana-image-renderer: 3.11.6 -> 3.12.0
* [`80d9c0da`](https://github.com/NixOS/nixpkgs/commit/80d9c0daf35233d48620783817aef0d224e64910) netbird: 0.35.2 -> 0.36.3
* [`d739078d`](https://github.com/NixOS/nixpkgs/commit/d739078de4b295db6344493e179c2053169e01f2) python312Packages.django-filingcabinet: disable tests with browser
* [`8f860dcd`](https://github.com/NixOS/nixpkgs/commit/8f860dcd1725794be7949019f1f7522c0f5c2f0b) netbird: fix formatting
* [`bc654111`](https://github.com/NixOS/nixpkgs/commit/bc6541114d2fa114f2bb171e0fa4d434a79190f9) vcprompt: move to pkgs/by-name
* [`c75811f8`](https://github.com/NixOS/nixpkgs/commit/c75811f8997dfe6a78929b7a279e8e6393aee764) vcprompt: 1.2.1 -> 1.3.0-unstable-2020-12-28
* [`1b73a3f8`](https://github.com/NixOS/nixpkgs/commit/1b73a3f88f91120959fd49864d8c823029e91192) sysstat: update homepage
* [`4e882515`](https://github.com/NixOS/nixpkgs/commit/4e88251557fb3a7d7942dcaed6e70890606e1b2f) perlPackages.Hailo: update homepage
* [`66028264`](https://github.com/NixOS/nixpkgs/commit/660282640d3f816bee07637e523c4646d5709e0f) python312Packages.pyparser: update homepage and src
* [`63ac80d7`](https://github.com/NixOS/nixpkgs/commit/63ac80d747ef77daa0559f55c53dd83149e7f900) perlPackages.maatkit: update homepage
* [`a0936b7b`](https://github.com/NixOS/nixpkgs/commit/a0936b7bfc0925fce1e306e87ab82bdc185ada0c) cvsps: update homepage
* [`3e7bfaf5`](https://github.com/NixOS/nixpkgs/commit/3e7bfaf54581c0861631da686cb291015945e325) torque: update homepage
* [`87c0ae4f`](https://github.com/NixOS/nixpkgs/commit/87c0ae4fc723813f3f86b67d447acc279e4bc4dc) procodile: update homepage
* [`e0420f93`](https://github.com/NixOS/nixpkgs/commit/e0420f93a59b0c65a12ec9497b70be58262a1123) cxxtest: update homepage
* [`d4e33cb8`](https://github.com/NixOS/nixpkgs/commit/d4e33cb80732510f4a262f621616c920a0cf6d87) transifex-cli: update homepage
* [`168e0b20`](https://github.com/NixOS/nixpkgs/commit/168e0b20e2cc44aeede1d2ed248f3822b8a5164f) keep-sorted: 0.5.1 -> 0.6.0
* [`2ee9c181`](https://github.com/NixOS/nixpkgs/commit/2ee9c181c53878896458b0a111945df6567565af) fider: init at 0.24.0
* [`54e48b64`](https://github.com/NixOS/nixpkgs/commit/54e48b64d144099a96e4a6a3c3a154c6cc111ffa) nixos/fider: init
* [`59fe6abb`](https://github.com/NixOS/nixpkgs/commit/59fe6abb331833df2deb560ff4a561dbe4b1afa3) python312Packages.keras-preprocessing: remove
* [`792640d7`](https://github.com/NixOS/nixpkgs/commit/792640d7a1345e5330644abc49145f32719b795b) meshcentral: 1.1.35 -> 1.1.38
* [`3c3982e2`](https://github.com/NixOS/nixpkgs/commit/3c3982e2231ddf98ceb82ace47b2951421e86fc1) python312Packages.pyexploitdb: 0.2.63 -> 0.2.64
* [`9035371b`](https://github.com/NixOS/nixpkgs/commit/9035371b3ed53b5a6530ad4d3c459c027c3b1a15) python312Packages.apispec: 6.8.0 -> 6.8.1
* [`23c1d61b`](https://github.com/NixOS/nixpkgs/commit/23c1d61b2b23d574805bfecebe8221eb561e2053) bitwarden-desktop: 2024.12.1 -> 2025.1.1
* [`69ace4da`](https://github.com/NixOS/nixpkgs/commit/69ace4daab664f6d9d48868c08aee8cd654d58f3) paperwork: fix evaluation warning
* [`d6d2987a`](https://github.com/NixOS/nixpkgs/commit/d6d2987afcad39e18077b6619f949f38ef30b1d2) universal-pidff: 0.0.10 -> 0.0.12
* [`f44907d2`](https://github.com/NixOS/nixpkgs/commit/f44907d245fcf7116db2b1be1b08bf12f037f0f3) cargo-deny: 0.16.3 -> 0.16.4
* [`51fcd275`](https://github.com/NixOS/nixpkgs/commit/51fcd2759e918214f3aa04d5f0970ce60a9650b2) doublecmd: 1.1.21 -> 1.1.22
* [`47cbb54c`](https://github.com/NixOS/nixpkgs/commit/47cbb54c07cd96eea506337783fcfb1c68b3c697) gawkextlib.{errno,gd,haru,lmdb,select}: fix (cross) build
* [`34f826a6`](https://github.com/NixOS/nixpkgs/commit/34f826a66c386477d9250b87a03051e2aafb6790) paperless-ngx: 2.13.5 -> 2.14.4
* [`bc6f6bf2`](https://github.com/NixOS/nixpkgs/commit/bc6f6bf2a99fcb6f6b7e6d83b7d59070b5d0dc22) f3d: 2.5.1 -> 3.0.0
* [`bd46f577`](https://github.com/NixOS/nixpkgs/commit/bd46f577401197229a3c52685ed10ab223f95c78) php8{1-3}Extensions.datadog_trace: use fetchCargoVendor
* [`0e27fa3c`](https://github.com/NixOS/nixpkgs/commit/0e27fa3cc156cd52e49f8b4526bbef5f324b6b3d) pay-respects: add ALameLlama to maintainers
* [`6b4c4cb9`](https://github.com/NixOS/nixpkgs/commit/6b4c4cb92805bcae5d5e3630dda9c6464a764ede) pay-respects: 0.6.10 -> 0.6.11
* [`22ee62f5`](https://github.com/NixOS/nixpkgs/commit/22ee62f58d745154964bd47bb0cf395584a78c54) php84Extensions.datadog_trace: mark broken
* [`4128ae7e`](https://github.com/NixOS/nixpkgs/commit/4128ae7e609a2dc057244e4dd3a633392b01f5db) nom: 2.7.2 -> 2.7.3
* [`257be01c`](https://github.com/NixOS/nixpkgs/commit/257be01ccfe1f9ab98e6e8ffb837c1bc7e4d045e) signal-desktop(darwin): fix hash
* [`fe637e02`](https://github.com/NixOS/nixpkgs/commit/fe637e0213e9c9a9ddbd21f7cf9f73940ecedb35) python312Packages.base64io: 1.0.3-unstable-2024-06-24 -> 1.0.3-unstable-2025-01-09
* [`1fa6b568`](https://github.com/NixOS/nixpkgs/commit/1fa6b568280c2e37418c33f0c9dcf325d8529b48) jfrog-cli: 2.72.5 -> 2.73.0
* [`b898dc0b`](https://github.com/NixOS/nixpkgs/commit/b898dc0b852159117cd9d93f273b41359bcae8b7) tailscale: build with tsidp
* [`1b328442`](https://github.com/NixOS/nixpkgs/commit/1b3284429f7c0c35f79619e7c21245546793c2fe) k3d: 5.7.4 -> 5.8.1
* [`897a9483`](https://github.com/NixOS/nixpkgs/commit/897a9483b83eb3d0f0780a5b264056df8c78f5e8) ugrep: 7.1.2 -> 7.1.3
* [`3fb5983a`](https://github.com/NixOS/nixpkgs/commit/3fb5983a82afd9b395dfd9af88d7e164ba4a66af) python312Packages.minio: 7.2.14 -> 7.2.15
* [`6a0c84f8`](https://github.com/NixOS/nixpkgs/commit/6a0c84f8c74770e0fc0f47a5925a91f5a5c781a6) maintainers: add GKHWB
* [`4e6dbf36`](https://github.com/NixOS/nixpkgs/commit/4e6dbf368da9a38f8ca33695caf2e179c8c72203) python312Packages.safety: 3.12.13 -> 3.2.14
* [`409845ed`](https://github.com/NixOS/nixpkgs/commit/409845ed08403a1761068f15f5e5d00e377f4917) python312Packages.license-expression: 30.4.0 -> 30.4.1
* [`8c01b4fa`](https://github.com/NixOS/nixpkgs/commit/8c01b4fa296c0bbd12854d129fc05689a18a1e94) youtube-music: 3.7.1 -> 3.7.2
* [`70f4e7b1`](https://github.com/NixOS/nixpkgs/commit/70f4e7b1ad7f2f49186a1de69c37fe50caeb41ce) lunar-client: 3.3.2 -> 3.3.3
* [`24750d9c`](https://github.com/NixOS/nixpkgs/commit/24750d9cadba28f89767aa28ada3a41a7bcb63ae) dbeaver-bin: 24.3.2 -> 24.3.3
* [`aa38588d`](https://github.com/NixOS/nixpkgs/commit/aa38588df261593d9249800f3cb6f0e9c9e93034) benthos: 4.42.0 -> 4.43.0
* [`952a2afa`](https://github.com/NixOS/nixpkgs/commit/952a2afab8a4a3cbd14fcd8474932fbfa1961aea) nixosTests.miriway: Update alacritty config format, switch to pkgs.formats
* [`d3e2f732`](https://github.com/NixOS/nixpkgs/commit/d3e2f73277c69a3bb0d4d1e086b4ee0fb53ea988) nixosTests.miracle-wm: Update alacritty config format, switch to pkgs.formats
* [`9b520ccb`](https://github.com/NixOS/nixpkgs/commit/9b520ccbfb2ee7c51f2ea7d4e059194397cc50ed) nixosTests.miriway: Switch back to commented-out code
* [`d777e99f`](https://github.com/NixOS/nixpkgs/commit/d777e99f6a48223cc5bfd4529d6608e5ba104ddb) nixosTests.miriway: Move the mouse to work around VM setup issues
* [`7c2becf7`](https://github.com/NixOS/nixpkgs/commit/7c2becf742a58b7ed60fe9cef0488d879add64bc) nixosTests.miracle-wm: Move the mouse to work around VM setup issues
* [`b7771dfb`](https://github.com/NixOS/nixpkgs/commit/b7771dfb4271620e6ccfbf3c4da77e32cf5c4836) mir,mir_2_15: Disable UdevWrapperTest.UdevMonitorDoesNotTriggerBeforeEnabling
* [`c7c6b372`](https://github.com/NixOS/nixpkgs/commit/c7c6b372e94ef613d98e76f1226d3fc63b65d6fb) hawkthorne-journey: Fix Desktop
* [`de80709d`](https://github.com/NixOS/nixpkgs/commit/de80709d152742aec5b724c4d9d45d069f69db54) sway-easyfocus: 2023-11-05 -> 0.2.0
* [`d1431a52`](https://github.com/NixOS/nixpkgs/commit/d1431a523caa47be8f67bcb6f17ac2badacbfbef) sunshine: fix updater package path
* [`d17d9b69`](https://github.com/NixOS/nixpkgs/commit/d17d9b69f4fc39222cc1ef551058ac75de280e27) osu-lazer: 2025.101.0 -> 2025.118.2
* [`bcec2d6b`](https://github.com/NixOS/nixpkgs/commit/bcec2d6bf1e460a5c0a5d21e41fe6c2bd161b722) osu-lazer-bin: 2025.101.0 -> 2025.118.2
* [`5eb7333f`](https://github.com/NixOS/nixpkgs/commit/5eb7333fcae1825a24d21a17e4c264359bf56464) google-cloud-sdk: 501.0.0 -> 506.0.0
* [`9590805f`](https://github.com/NixOS/nixpkgs/commit/9590805ff652428f1c168ae33addb6e49b7279f4) google-cloud-sdk: remove obsolete patch after gsutils bump
* [`610753a1`](https://github.com/NixOS/nixpkgs/commit/610753a12377a2c4b9f3793b69b77e7f136ed194) google-cloud-sdk: update update.sh to generate nixfmt valid data.nix
* [`ba62305e`](https://github.com/NixOS/nixpkgs/commit/ba62305ec9925e2a002ed08f1abac11f7202f419) liboqs: 0.11.0 -> 0.12.0, add nix-update-script
* [`bc25b631`](https://github.com/NixOS/nixpkgs/commit/bc25b631dcdff7736a82b4ffca8d22acebb12646) angular-language-server: 19.0.3 -> 19.0.4
* [`bbc45551`](https://github.com/NixOS/nixpkgs/commit/bbc455519f7c8a5c22fc903bc72042d4c24cf256) sunshine: 0.23.1 -> 2025.118.151840
* [`e28b7617`](https://github.com/NixOS/nixpkgs/commit/e28b761703108a58dcf7b10d9221213cbad2cdc9) zed-editor: add withGLES to passthru.tests
* [`62fb979c`](https://github.com/NixOS/nixpkgs/commit/62fb979cdd5bc4cb012bef20a2882dc4a99cde47) dsda-doom: 0.28.2 -> 0.28.3
* [`23dd5e85`](https://github.com/NixOS/nixpkgs/commit/23dd5e854f126927e88d3b8570a990e00b8f20e3) mpvScripts.mpv-playlistmanager: 0-unstable-2024-11-19 -> 0-unstable-2025-01-08
* [`4208161b`](https://github.com/NixOS/nixpkgs/commit/4208161bb1f3e74d493b3d050ba00d9c9401d4d7) gimp: move to openexr_3
* [`4bcf8859`](https://github.com/NixOS/nixpkgs/commit/4bcf8859f21b2a85a978abafdae1a3c29ad30562) linux_rpi: ignoreConfigErrors
* [`da5a0cfe`](https://github.com/NixOS/nixpkgs/commit/da5a0cfeba808bc82fb33ef07eccd350fca9956b) vips: move to openexr_3
* [`60cc35ab`](https://github.com/NixOS/nixpkgs/commit/60cc35abae02e10f84f981fe4031092d4a9c75b6) zfs: remove code for obsolete versions
* [`5094795c`](https://github.com/NixOS/nixpkgs/commit/5094795c607de240f689ff38787fe58d3b71ed55) zfs: 2.2.7 -> 2.3.0
* [`52d37690`](https://github.com/NixOS/nixpkgs/commit/52d376906d285583fca72b80573d30b758963237) uxn: 1.0-unstable-2025-01-04 -> 1.0-unstable-2025-01-19
* [`c1e831fb`](https://github.com/NixOS/nixpkgs/commit/c1e831fbb117cfa736f8387db2b44af9808b9c1b) monero-cli, monero-gui: pin boost 1.86
* [`aa07c2b9`](https://github.com/NixOS/nixpkgs/commit/aa07c2b9135ea32aaedf472feebb24e0f7b77c16) systemfd: 0.4.4 -> 0.4.6
* [`359726d9`](https://github.com/NixOS/nixpkgs/commit/359726d99ac7b9300a1df7b59ac15d7199d3d00e) sbcl.pkgs.stumpwm: use overrideLispAttrs not overrideAttrs
* [`543065d5`](https://github.com/NixOS/nixpkgs/commit/543065d5291a581a7d57a430142c6d49467ee52b) cnspec: 11.37.0 -> 11.37.1
* [`58855abb`](https://github.com/NixOS/nixpkgs/commit/58855abbc56fccad9f9bcc88ca9182be9f2dd1e4) cnquery: 11.36.0 -> 11.37.1
* [`11510054`](https://github.com/NixOS/nixpkgs/commit/115100541a0946a920afa05dfa152d0fd31aca3c) terragrunt: 0.71.2 -> 0.72.2
* [`d3c3aee4`](https://github.com/NixOS/nixpkgs/commit/d3c3aee40f46fea0e430423931ae8ecb6654131c) chiaki-ng: 1.9.4 -> 1.9.5
* [`a3548b05`](https://github.com/NixOS/nixpkgs/commit/a3548b05fef89baf7fec6a38d181f270e98925e4) gersemi: 0.17.1 -> 0.18.2
* [`f34f442a`](https://github.com/NixOS/nixpkgs/commit/f34f442aa4257f8d1a86ff147ee2d15ecae82048) maintainers: add ethancedwards8 matrix
* [`678af34d`](https://github.com/NixOS/nixpkgs/commit/678af34d5e4d198fcd948a7db8b89a618d8e62fa) air: 1.61.5 -> 1.61.7
* [`94adb9ef`](https://github.com/NixOS/nixpkgs/commit/94adb9efcd8705577331f0021c501db67ae091b7) dum: 0.1.19 -> 0.1.20
* [`30f769f6`](https://github.com/NixOS/nixpkgs/commit/30f769f69e0dd680001eeee97f6b62051f7926e9) guile-zlib: 0.2.1 -> 0.2.2
* [`3efc691b`](https://github.com/NixOS/nixpkgs/commit/3efc691be4709dbbcf79404122feb73cbea083f9) nsd: 4.11.0 -> 4.11.1
* [`095e7ca5`](https://github.com/NixOS/nixpkgs/commit/095e7ca5815067d37530ca3bbf1a774fb99c137c) pyenv: 2.5.0 -> 2.5.1
* [`dba84b21`](https://github.com/NixOS/nixpkgs/commit/dba84b21bf8958a418af6a691eb9f9d36e196d84) maintainers: update getchoo
* [`18e0dfbf`](https://github.com/NixOS/nixpkgs/commit/18e0dfbfe93c2d7d5ac4f53e9271aafb91705e7a) mint-artwork: Run {pre,post}Install hooks
* [`eac29814`](https://github.com/NixOS/nixpkgs/commit/eac29814d23d0df24588b1e328995959793e77c5) mlt: 7.28.0 -> 7.30.0
* [`fd39cdbf`](https://github.com/NixOS/nixpkgs/commit/fd39cdbfd823b2a53a6454687c73fbd41761b8aa) vimPlugins.git-conflict-nvim: 2024-12-27 -> 2.1.0
* [`7d0cbf1b`](https://github.com/NixOS/nixpkgs/commit/7d0cbf1b6ff7d13bc33e5ff9ebd1ac9830aa6c3a) nwg-panel: 0.9.59 -> 0.9.61
* [`a4677d48`](https://github.com/NixOS/nixpkgs/commit/a4677d48c1763423de84b92ed19c5050071fe0a0) simpleDBus: 0.8.1 -> 0.9.0
* [`3cef4905`](https://github.com/NixOS/nixpkgs/commit/3cef4905f08361e896c6567f9ce682240277d34b) cjson: fix building with clang
* [`eb453754`](https://github.com/NixOS/nixpkgs/commit/eb453754f44515407b2bc39c7c93ccda1cafcd86) spfft: 1.1.0 -> 1.1.1
* [`24d32f99`](https://github.com/NixOS/nixpkgs/commit/24d32f996c00317730e92f8fccdc6c070018889a) sq: 0.48.4 -> 0.48.5
* [`a8da7b01`](https://github.com/NixOS/nixpkgs/commit/a8da7b01f116ae3543a499487eabe8022ddf693f) python312Packages.python-linkplay: 0.1.2 -> 0.1.3
* [`f152a652`](https://github.com/NixOS/nixpkgs/commit/f152a652dd03830b568ba6e6dc5c3208a6317a77) terraform-providers.grafana: 3.15.3 -> 3.16.0
* [`586e657c`](https://github.com/NixOS/nixpkgs/commit/586e657c4a69362e206c3d405377afb6b3aa9bc9) pocketbase: 0.24.1 -> 0.24.4
* [`1a8f76c2`](https://github.com/NixOS/nixpkgs/commit/1a8f76c215c2965dc6f6b18a190edb61df209f3a) gerbera: 2.3.0 -> 2.4.1
* [`95dbf5b0`](https://github.com/NixOS/nixpkgs/commit/95dbf5b038a13db6062e407c757818b621f9b56f) changedetection-io: 0.48.05 -> 0.48.06
* [`e57f7990`](https://github.com/NixOS/nixpkgs/commit/e57f79900d837dd5c147d77c1b8dc72e5374ae26) flameshot: 12.1.0-unstable-2024-12-03 -> 12.1.0-unstable-2025-01-19
* [`360016ef`](https://github.com/NixOS/nixpkgs/commit/360016ef3f10021d63b7108307e62da896d43ce3) terraform-providers.artifactory: 12.7.1 -> 12.8.1
* [`e6305a33`](https://github.com/NixOS/nixpkgs/commit/e6305a33bf221476ad898a28e44cb9704cab51f1) v2rayn: 7.6.2 -> 7.7.0
* [`459806ae`](https://github.com/NixOS/nixpkgs/commit/459806aea2653e6a879fca7d9bc56c08635ceb36) nextcloud-notify_push: 0.7.0 -> 1.0.0
* [`a64584d9`](https://github.com/NixOS/nixpkgs/commit/a64584d9c022fe8baa83a216ae2d7e470009e412) ytdl-sub: 2025.01.15 -> 2025.01.17
* [`b2508634`](https://github.com/NixOS/nixpkgs/commit/b25086345bbcd124e9de4693a47fed5a44c8fbe4) clouddrive2: 0.8.5 -> 0.8.6
* [`0ca75b9e`](https://github.com/NixOS/nixpkgs/commit/0ca75b9e438455ebfccdda714ce20a9d715deb11) terraform-providers.huaweicloud: 1.72.0 -> 1.72.1
* [`5b7855d6`](https://github.com/NixOS/nixpkgs/commit/5b7855d61565abb15b230848086085b562c62011) python313Packages.hahomematic: 2025.1.7 -> 2025.1.10
* [`0ec2df46`](https://github.com/NixOS/nixpkgs/commit/0ec2df46bc4daab04b22113e9fd1b63de843ddee) home-assistant-custom-components.homematicip_local: 1.78.1 -> 1.79.0
* [`d7356a72`](https://github.com/NixOS/nixpkgs/commit/d7356a72a6ecb1bca16317402854c698e0a14ad5) linux_6_13: init
* [`e4d3693c`](https://github.com/NixOS/nixpkgs/commit/e4d3693cd8784f4eccee167a6d2722cec2c1f519) perf: don't apply dmesg patch on 6.13, remove 6.10 patches
* [`3a039b67`](https://github.com/NixOS/nixpkgs/commit/3a039b672d3e95264fe5a1c6ada9fa09eee11bdb) rust-analyzer-unwrapped: 2025-01-08 -> 2025-01-20
* [`6a580ab6`](https://github.com/NixOS/nixpkgs/commit/6a580ab6705f535dc83982f84eeb35413dec4f0b) nixos/release-small: add latestKernel test
* [`80093811`](https://github.com/NixOS/nixpkgs/commit/800938116f9ceecb921fec4d700e5ef5577521ca) mattermost: enable test suite, mmctl support, and plugin building
* [`8944a425`](https://github.com/NixOS/nixpkgs/commit/8944a4259cb5d8c54c81408527f600e3ff44c15e) mmctl: use correct Mattermost derivation
* [`f8eac009`](https://github.com/NixOS/nixpkgs/commit/f8eac009eed839d2d71f991f9c0df2e28da95a3d) nixos/mattermost: modernize, support MySQL and mmctl
* [`84c6d60c`](https://github.com/NixOS/nixpkgs/commit/84c6d60c263aa49c5430dec4ed9cefa9601f73e7) manual: add mattermost.chapter.md
* [`8c0035ae`](https://github.com/NixOS/nixpkgs/commit/8c0035ae8f57b65dd055802100044c298439b99d) release-notes/25.05: add Mattermost details
* [`33986ca1`](https://github.com/NixOS/nixpkgs/commit/33986ca158b28288e84a035d8dfe370afd571fa3) {mattermost,mattermostLatest}: fix string escapes
* [`d6530229`](https://github.com/NixOS/nixpkgs/commit/d65302292e05f00aa089980332ae6928041b3a9a) wesnoth: pin to boost-1.86.0
* [`3b6f6581`](https://github.com/NixOS/nixpkgs/commit/3b6f658130e5ed7a027593a6f24c1c1c700f2b89) init-script-builder: fix build ([nixos/nixpkgs⁠#375160](https://togithub.com/nixos/nixpkgs/issues/375160))
* [`45fc2a09`](https://github.com/NixOS/nixpkgs/commit/45fc2a0940521a6864cefdb7e415672b4825fe64) Revert "uhd: pin Boost 1.86"
* [`397e5bb5`](https://github.com/NixOS/nixpkgs/commit/397e5bb5a79f85c86a4f5dcd3382d205aff3bec3) rustc: mark broken for LLVM stdenv
* [`24a33d6b`](https://github.com/NixOS/nixpkgs/commit/24a33d6b3a328d7b723c4a06a071919d6a19844e) python312Packages.imageio: 2.36.1 -> 2.37.0
* [`86d4957f`](https://github.com/NixOS/nixpkgs/commit/86d4957f5de8f00709e971eb6ffcd828e8609782) python312Packages.jax: remove unneeded IOKit from buildInputs
* [`a0c6398b`](https://github.com/NixOS/nixpkgs/commit/a0c6398ba0c71dc26b393a71abda5772c12b96db) python312Packages.jax: remove unneeded cudaSupport in python-packages.nix
* [`8e56483d`](https://github.com/NixOS/nixpkgs/commit/8e56483d50032f842e3ac6c4e57c732b9638b261) python312Packages.timm: 1.0.13 -> 1.0.14
* [`36347091`](https://github.com/NixOS/nixpkgs/commit/363470919ed424ecb193c4d87e8be54a5f7f0a3d) wofi-power-menu: 0.2.5 -> 0.2.6
* [`65779f98`](https://github.com/NixOS/nixpkgs/commit/65779f98dcaa7053f93bec7c6be75adc0eb1b266) wofi-power-menu: add meta.changelog
* [`150f6f98`](https://github.com/NixOS/nixpkgs/commit/150f6f987e7ae15ce1514d4b41f44a27bd9e8f2f) rainfrog: 0.2.10 -> 0.2.11
* [`8e7b1073`](https://github.com/NixOS/nixpkgs/commit/8e7b1073fde774c48cb9d38076081a48d4ca7a58) ocamlPackages.elpi: use correct version information
* [`ec4b54f3`](https://github.com/NixOS/nixpkgs/commit/ec4b54f3d04a825d311c0b69926eaa8a3a213c02) nextcloud: Add britter as maintainer
* [`d4c0bd6d`](https://github.com/NixOS/nixpkgs/commit/d4c0bd6dc5b929133e33e21b096b9737cca58031) wf-config: fix and enable strictDeps
* [`db8996f0`](https://github.com/NixOS/nixpkgs/commit/db8996f0809493993a2ddb0f0000ba8af8597eaa) television: 0.9.2 -> 0.9.3
* [`7da0f0a1`](https://github.com/NixOS/nixpkgs/commit/7da0f0a12d56216fd3f0ee3b285268346c8e7f90) postgresqlPackages.postgis: 3.5.0 -> 3.5.2
* [`098d3e32`](https://github.com/NixOS/nixpkgs/commit/098d3e32a9087cebd06a6b736e498365253544e8) qgis-ltr: 3.34.14 -> 3.34.15
* [`78e54d4f`](https://github.com/NixOS/nixpkgs/commit/78e54d4f26e2cbc2c21bab645eb3569c44ccb954) qgis: 3.40.2 -> 3.40.3
* [`0e8c1544`](https://github.com/NixOS/nixpkgs/commit/0e8c154442d1d59dabbc729d100ca9a8d8243a7a) dino: remove tomfitzhenry@ as maintainer
* [`3e47905d`](https://github.com/NixOS/nixpkgs/commit/3e47905de2684f6046a8ecca1cd6898971259a4c) fzf: 0.57.0 -> 0.58.0
* [`34691a0b`](https://github.com/NixOS/nixpkgs/commit/34691a0b28eac4d160e885c8711533e18c09d87c) gurk-rs: move to pkgs/by-name
* [`5904143e`](https://github.com/NixOS/nixpkgs/commit/5904143e8589dc6f0aad6517e0935a185eec6543) gurk-rs: 0.6.0 -> 0.6.1
* [`a226f132`](https://github.com/NixOS/nixpkgs/commit/a226f13211ffedd597ac8bc44766ac8f4b8af946) ci/eval: support "10.rebuild-${kernel}: 1" labels
* [`167d6634`](https://github.com/NixOS/nixpkgs/commit/167d6634f8a4bad4e6a494cb47052d8dcaa29cac) services.xray: pass the settings file with systemd loadCredential
* [`f21517a1`](https://github.com/NixOS/nixpkgs/commit/f21517a167a73a6873d42a858734f598265d7b4e) nodejs_23: 23.5.0 -> 23.6.0
* [`80764733`](https://github.com/NixOS/nixpkgs/commit/8076473384121e1142748e92bdf7afd2d3a37c8f) phpPackages.composer: fix included patch
* [`80807847`](https://github.com/NixOS/nixpkgs/commit/80807847941a0393844d4684d949e2cc1a4024f1) fwupd: 2.0.3 -> 2.0.4
* [`00137105`](https://github.com/NixOS/nixpkgs/commit/0013710590e1e0c8087b12b2de476b8b63805158) manubulon-snmp-plugins: use versionCheckHook
* [`c39acbfa`](https://github.com/NixOS/nixpkgs/commit/c39acbfabae225c0f393b3fbc121466e6abef489) crusader: init at 0.3.2
* [`7b23fdcd`](https://github.com/NixOS/nixpkgs/commit/7b23fdcdd70e8d9e1dcf3ffaf9a8e154127f2f95) aws-nuke: 2.25.0 -> 3.44.0
* [`fa9aab7c`](https://github.com/NixOS/nixpkgs/commit/fa9aab7c731a34badcf0d94ba87ae93bac5a90f2) grafanaPlugins.marcusolsson-dynamictext-panel: 5.4.0 -> 5.6.0
* [`60520102`](https://github.com/NixOS/nixpkgs/commit/60520102f2ba74753b9aee92596f298c7aa9d52e) python313Packages.tencentcloud-sdk-python: 3.0.1305 -> 3.0.1306
* [`0d32e69a`](https://github.com/NixOS/nixpkgs/commit/0d32e69acecbbc71a684ad575b0a24569f57a96b) frankenphp: 1.4.0 -> 1.4.1
* [`94f9d8b7`](https://github.com/NixOS/nixpkgs/commit/94f9d8b7c22a97b616db1ca7d554d7436ca76213) jsoncons: 0.176.0 -> 1.1.0
* [`9466afac`](https://github.com/NixOS/nixpkgs/commit/9466afacfe1e5ce6c1af1eced501892cad8cfbde) bt-migrate: mark as broken
* [`30a77069`](https://github.com/NixOS/nixpkgs/commit/30a7706904f750fbeba4bef79e2217725de770e1) certstream-server-go: init at 1.7.0
* [`1eb41e58`](https://github.com/NixOS/nixpkgs/commit/1eb41e586b4cb5edf9a6a5d2649a5306aff29b2c) fstar: remove pnmadelaine as maintainer
* [`28d1c179`](https://github.com/NixOS/nixpkgs/commit/28d1c1799cdef16620b6c15cdccd1475ef8526ec) plex-desktop: fix and enable strictDeps
* [`eaff6da5`](https://github.com/NixOS/nixpkgs/commit/eaff6da586ba5cd7be487dcb6f542e85b03ac15f) minio: 2024-12-18T13-15-44Z -> 2025-01-18T00-31-37Z
* [`118ef08e`](https://github.com/NixOS/nixpkgs/commit/118ef08eb41716dc54874e4e5617042d5b845aa2) yutto: 2.0.0-rc.6 -> 2.0.0-rc.7
* [`d3fb754b`](https://github.com/NixOS/nixpkgs/commit/d3fb754b7897d6ba4c541bfa33235d8dfb06d44d) glab: 1.51.0 -> 1.52.0
* [`2d98f09b`](https://github.com/NixOS/nixpkgs/commit/2d98f09b17ae9235520c5060dcc7660f4805c9c8) phpdocumentor: fix vendorHash
* [`d9cf42ca`](https://github.com/NixOS/nixpkgs/commit/d9cf42ca11e07ae0a2d567f927048ac0ac8d8a3a) emulationstation-de: fix cross build
* [`38e021fa`](https://github.com/NixOS/nixpkgs/commit/38e021fa4443a30a43c36a39788c7cbbbdaf1a54) quirc: fix cross build
* [`7ba9030c`](https://github.com/NixOS/nixpkgs/commit/7ba9030c138f08f0a544a0f78fdfefeedae5e284) alvr: 20.12.0 -> 20.12.1
* [`06ee6116`](https://github.com/NixOS/nixpkgs/commit/06ee6116190af961b278f3830352ced4971e1a41) ci/request-reviews: Don't fail when there's too many reviewers
* [`0cd421fa`](https://github.com/NixOS/nixpkgs/commit/0cd421fa5f407d92ad56cd6b1d0dc92ae03b33bc) build-support/vm: don't depend on the "unix" module
* [`3cfe557b`](https://github.com/NixOS/nixpkgs/commit/3cfe557b10d764f8870b9e188ac492d143543bb6) lomiri.lomiri-download-manager: Fix compatibility with glog 0.7.x
* [`8dfd6a95`](https://github.com/NixOS/nixpkgs/commit/8dfd6a9537667a97e9d77c1d57a7ba01bebe65e6) terraform-providers.vultr: 2.21.0 -> 2.23.1
* [`110716db`](https://github.com/NixOS/nixpkgs/commit/110716db4f0dcdfcf6ada09de48d3865a2e15e6f) lomiri.trust-store: Fix compatibility with glog 0.7.x, pin Boost to 1.86
* [`632c3d4e`](https://github.com/NixOS/nixpkgs/commit/632c3d4eff60b4f2f602d8e58b744bc2aac423cc) clifm: 1.22 -> 1.23
* [`f8ad478e`](https://github.com/NixOS/nixpkgs/commit/f8ad478e12652aa5e561cf90adb415ecf3237c06) kryptor: 4.1.0 -> 4.1.1
* [`f6f924f1`](https://github.com/NixOS/nixpkgs/commit/f6f924f16877b80511ad470e84657e47415d2463) epson-escpr2: 1.2.24 - 1.2.25
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
