### PR TITLE
niv home-manager: update 9786661d -> e1ae908b

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -41,10 +41,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "9786661d57c476021c8a0c3e53bf9fa2b4f3328b",
-        "sha256": "15v18m57025npf3awdvgcnnnij7pn9psljfg6in0wz77qxf2hvhi",
+        "rev": "e1ae908bcc30af792b0bb0a52e53b03d2577255e",
+        "sha256": "1bwnmhb7brayfamljr4rl3ks07gs4awgx57zns6cd8dhc92c08y6",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/9786661d57c476021c8a0c3e53bf9fa2b4f3328b.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/e1ae908bcc30af792b0bb0a52e53b03d2577255e.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@9786661d...e1ae908b](https://github.com/nix-community/home-manager/compare/9786661d57c476021c8a0c3e53bf9fa2b4f3328b...e1ae908bcc30af792b0bb0a52e53b03d2577255e)

* [`0b8df9ee`](https://github.com/nix-community/home-manager/commit/0b8df9eeb66941ef32e5761ecf4cddff91e5c020) lsd: add support for icons.yaml
* [`bb14224f`](https://github.com/nix-community/home-manager/commit/bb14224f51ae4caed12a7b26f245d042c8cf8553) mu: allow option to set muhome
* [`96dee79b`](https://github.com/nix-community/home-manager/commit/96dee79b178d295b716052feca3ee46abc085abe) lsd: remove with lib;
* [`4481a16d`](https://github.com/nix-community/home-manager/commit/4481a16d1ac5bff4a77c608cefe08c9b9efe840d) yazi: improve fish integration
* [`cefb1889`](https://github.com/nix-community/home-manager/commit/cefb1889b96ddd1dac3dd4734e894f4cadab7802) Translate using Weblate (Czech)
* [`1757aca1`](https://github.com/nix-community/home-manager/commit/1757aca1640bebd7495f2784844f21a8dd712f8d) go: stub systemd dependency in test
* [`4806e9c0`](https://github.com/nix-community/home-manager/commit/4806e9c021e8f1d78b0bb7bc4ecc75d27a31a4bb) flake.lock: Update
* [`b17008a7`](https://github.com/nix-community/home-manager/commit/b17008a795066bd3b4da86d7614a3be0efb0092e) swayr: update expected test result
* [`01d01729`](https://github.com/nix-community/home-manager/commit/01d0172933845daaf3392f6b8c3953995e912f6e) wezterm: update expected test result
* [`0db5c8bf`](https://github.com/nix-community/home-manager/commit/0db5c8bfcce78583ebbde0b2abbc95ad93445f7c) ghostty: add keybinds to settings example
* [`7b9ece1b`](https://github.com/nix-community/home-manager/commit/7b9ece1bf3c8780cde9b975b28c2d9ccd7e9cdb9) tealdeer: update docs link
* [`a2362a64`](https://github.com/nix-community/home-manager/commit/a2362a64964c406ba3b289a474fbde573f4b7fc9) nh: check osConfig for null before accessing
* [`a0428685`](https://github.com/nix-community/home-manager/commit/a0428685572b134f6594e7d7f5db5e1febbab2d7) nh: remove PATH assignment in nh-clean systemd unit
* [`44ee9bc8`](https://github.com/nix-community/home-manager/commit/44ee9bc826770df1ab83c7e93f77fdaddd37523a) himalaya: improve service
* [`5f5a9d5c`](https://github.com/nix-community/home-manager/commit/5f5a9d5cd23e6ff7f877ec66b498bb02585a72b0) himalaya: make use of lib.getExe
* [`2ae3dd46`](https://github.com/nix-community/home-manager/commit/2ae3dd460f60822434959a92e8e19c9f9b7efce2) himalaya: add xdg desktop entry
* [`e9068fac`](https://github.com/nix-community/home-manager/commit/e9068facd7bcfb99405d0e5e3b938f5e5ddc38e0) himalaya: adjust package for released v1.0.0
* [`15f7f9bc`](https://github.com/nix-community/home-manager/commit/15f7f9bc4e7aedcdd26e2f20fc4b46220ead584d) himalaya: fix tests
* [`b93e17c7`](https://github.com/nix-community/home-manager/commit/b93e17c73cca670460d0604c00ba0571eb5d4cad) neovim: fix flaky test
* [`1b9fe46e`](https://github.com/nix-community/home-manager/commit/1b9fe46e9fc3575eeb63ef42d73144e397593904) home-manager: move tests into new test flake
* [`daf04c59`](https://github.com/nix-community/home-manager/commit/daf04c5950b676f47a794300657f1d3d14c1a120) ollama: add darwin support
* [`e1ae908b`](https://github.com/nix-community/home-manager/commit/e1ae908bcc30af792b0bb0a52e53b03d2577255e) flake.lock: Update
