### PR TITLE
niv powerlevel10k: update 3e2053a9 -> 05b11d8b

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -113,10 +113,10 @@
         "homepage": "",
         "owner": "romkatv",
         "repo": "powerlevel10k",
-        "rev": "3e2053a9341fe4cf5ab69909d3f39d53b1dfe772",
-        "sha256": "1gvbgw38wa0z1jvs3xqr5108aqsaajlw9xxha9lxyhb04rmsxmga",
+        "rev": "05b11d8b92f39ad109c5944fecad249dfe166088",
+        "sha256": "150jxkqbsk63vagqi8p9i0061f51hypzpvbhsymlqwj83ylwlvid",
         "type": "tarball",
-        "url": "https://github.com/romkatv/powerlevel10k/archive/3e2053a9341fe4cf5ab69909d3f39d53b1dfe772.tar.gz",
+        "url": "https://github.com/romkatv/powerlevel10k/archive/05b11d8b92f39ad109c5944fecad249dfe166088.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "rh": {


### PR DESCRIPTION
## Changelog for powerlevel10k:
Branch: master
Commits: [romkatv/powerlevel10k@3e2053a9...05b11d8b](https://github.com/romkatv/powerlevel10k/compare/3e2053a9341fe4cf5ab69909d3f39d53b1dfe772...05b11d8b92f39ad109c5944fecad249dfe166088)

* [`f3b05b44`](https://github.com/romkatv/powerlevel10k/commit/f3b05b4448799cfc960da7c664207bb08a10067f) Fix word splitting issues in README.md
* [`eb487f83`](https://github.com/romkatv/powerlevel10k/commit/eb487f836a9738aeef282e74fcc5bdc38c712ee5) Fix word splitting issues in README.md
