### PR TITLE
niv emacs-overlay: update 964a44f6 -> 49b92479

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "964a44f6585f8cae26c228409676d92822f78de0",
-        "sha256": "0lmwqhkailgs4n4gvc7578bnqm0gdkzzw3jqd9g75dxjvbk3yy3a",
+        "rev": "49b92479d543bfc85fc7935a390e32fa023bc08c",
+        "sha256": "0disk7fvs0v5782jl7frry295c1dv8ma965w78lyr6swsbyjav30",
         "type": "tarball",
-        "url": "https://github.com/nix-community/emacs-overlay/archive/964a44f6585f8cae26c228409676d92822f78de0.tar.gz",
+        "url": "https://github.com/nix-community/emacs-overlay/archive/49b92479d543bfc85fc7935a390e32fa023bc08c.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "fast-syntax-highlighting": {


### PR DESCRIPTION
## Changelog for emacs-overlay:
Branch: master
Commits: [nix-community/emacs-overlay@964a44f6...49b92479](https://github.com/nix-community/emacs-overlay/compare/964a44f6585f8cae26c228409676d92822f78de0...49b92479d543bfc85fc7935a390e32fa023bc08c)

* [`d79f6fe2`](https://github.com/nix-community/emacs-overlay/commit/d79f6fe2b6f6d4bcffdebf4aa0515873d557e2b8) Updated elpa
* [`adb0c271`](https://github.com/nix-community/emacs-overlay/commit/adb0c271770161a17c66414a9828ed1ae01a2acb) Updated melpa
* [`f018d916`](https://github.com/nix-community/emacs-overlay/commit/f018d91651195552f17c5b922644b353179ba7a6) Updated emacs
* [`a93c1ab3`](https://github.com/nix-community/emacs-overlay/commit/a93c1ab37851e8dc49e087b3f440e1ccd34f19fd) Updated melpa
* [`665b9fb1`](https://github.com/nix-community/emacs-overlay/commit/665b9fb1235c5cca2125623bd2078d19c8093d2e) Updated emacs
* [`f6a19756`](https://github.com/nix-community/emacs-overlay/commit/f6a19756445da13b78e969ca786fa888954bbb54) Updated nongnu
* [`9652bd62`](https://github.com/nix-community/emacs-overlay/commit/9652bd6277e776b009b0c54594365c118cfa76ad) Updated elpa
* [`df789667`](https://github.com/nix-community/emacs-overlay/commit/df789667dc9cd738953b63ca29a461ea9157bd15) Updated melpa
* [`a4dc7719`](https://github.com/nix-community/emacs-overlay/commit/a4dc77197ec7249cceeaa43cca56a1c217fd440d) Updated emacs
* [`999df25f`](https://github.com/nix-community/emacs-overlay/commit/999df25f371933effadb7627c892e82472df7a37) Updated flake inputs
* [`a420c116`](https://github.com/nix-community/emacs-overlay/commit/a420c116d74abc72a5418ceb92151aca14954d75) Updated nongnu
* [`8feb373d`](https://github.com/nix-community/emacs-overlay/commit/8feb373dfedff3868730877af282afd864a68a16) Updated elpa
* [`2bbdfe5a`](https://github.com/nix-community/emacs-overlay/commit/2bbdfe5a0b234c29453fe62aed8e15a3a51b3e0f) Updated melpa
* [`b563467d`](https://github.com/nix-community/emacs-overlay/commit/b563467d6856629839995ff6d8699fb59d960ca9) Updated emacs
* [`6fd177f9`](https://github.com/nix-community/emacs-overlay/commit/6fd177f931b7eb5cde38b6850c8040ed8f488959) Updated melpa
* [`d4670235`](https://github.com/nix-community/emacs-overlay/commit/d467023596c548b43277215365020906697c00a2) Updated emacs
* [`21536dec`](https://github.com/nix-community/emacs-overlay/commit/21536dec00ea82d855bb6a725583518ae362f8ae) Updated nongnu
* [`b9644e3a`](https://github.com/nix-community/emacs-overlay/commit/b9644e3a7d83e77aac2bb579bb79e25b02f3a63c) Updated elpa
* [`74ed3538`](https://github.com/nix-community/emacs-overlay/commit/74ed3538299fef83c01c2efd7cb89360d3a764bb) Updated melpa
* [`e978e83b`](https://github.com/nix-community/emacs-overlay/commit/e978e83b07462ed833dab3de4544d27da2c03167) Updated emacs
* [`796d9fe5`](https://github.com/nix-community/emacs-overlay/commit/796d9fe5e39152db8ebbd26a8e9b0c043635322d) Updated nongnu
* [`d3db6e75`](https://github.com/nix-community/emacs-overlay/commit/d3db6e753d0b8f93326888e894fed2dd318e2fc0) Updated elpa
* [`2b2c0dd0`](https://github.com/nix-community/emacs-overlay/commit/2b2c0dd03b9fcf46a83fb62e99248fd3f56f942f) Updated melpa
* [`57ad4a6c`](https://github.com/nix-community/emacs-overlay/commit/57ad4a6cfaf4666c9ce71b81bd7243e4ed2d8b01) Updated emacs
* [`e6bad48f`](https://github.com/nix-community/emacs-overlay/commit/e6bad48f56fc003e96e6332f98397d5c7c5d3b84) Updated melpa
* [`f056a3b8`](https://github.com/nix-community/emacs-overlay/commit/f056a3b82aa523aa3b3a033fe8ffe77d29461079) Updated emacs
* [`0ed1de47`](https://github.com/nix-community/emacs-overlay/commit/0ed1de4793a553ed0f6c71f329d23e95a972e318) Updated nongnu
* [`3df7c4ba`](https://github.com/nix-community/emacs-overlay/commit/3df7c4ba924734ffc24b2175f84e36b6fe8e3334) Updated elpa
* [`4181b289`](https://github.com/nix-community/emacs-overlay/commit/4181b289bec9d2121ec741f675383d6c781c353b) Updated melpa
* [`99dd69ce`](https://github.com/nix-community/emacs-overlay/commit/99dd69ceab2be2310bc580094e5327252b40ec84) Updated flake inputs
* [`9ebb4a84`](https://github.com/nix-community/emacs-overlay/commit/9ebb4a8413496a056c1caa76e82d9fdd4a973c54) Updated nongnu
* [`2def670c`](https://github.com/nix-community/emacs-overlay/commit/2def670c4baedab0b94906a319824c160d0ddc74) Updated elpa
* [`f2a57f15`](https://github.com/nix-community/emacs-overlay/commit/f2a57f15aad9299d93c3eac02228b5c3d3eb2ba4) Updated melpa
* [`96dab5ac`](https://github.com/nix-community/emacs-overlay/commit/96dab5ac0c8d83fd5e53760efbc1632ea40d07a5) Updated emacs
* [`fc0f054a`](https://github.com/nix-community/emacs-overlay/commit/fc0f054a008209f1c8c0318b7576e7429b90a0d1) Updated melpa
* [`57861eb2`](https://github.com/nix-community/emacs-overlay/commit/57861eb230aba3a64cb7bed7772ca842793aedc5) Updated emacs
* [`d8ea9cc7`](https://github.com/nix-community/emacs-overlay/commit/d8ea9cc75f250d9024a0c2ae0322229de26cb332) Updated flake inputs
* [`51677928`](https://github.com/nix-community/emacs-overlay/commit/516779287a52f18496077b767be332f6c9798e6c) Updated nongnu
* [`dc287387`](https://github.com/nix-community/emacs-overlay/commit/dc287387996ca412f45f7b6cacb3e5a4b5b6eaf2) Updated elpa
* [`62b2e27b`](https://github.com/nix-community/emacs-overlay/commit/62b2e27b3be160622cac6611723b2659ea78a01a) Updated melpa
* [`cd0b5744`](https://github.com/nix-community/emacs-overlay/commit/cd0b5744ec96eaf43b1094c512fa8451c2a26f41) Updated emacs
* [`ed41473a`](https://github.com/nix-community/emacs-overlay/commit/ed41473a2a86d84d75c422764d65af78bf88df42) Updated nongnu
* [`239656a4`](https://github.com/nix-community/emacs-overlay/commit/239656a47b9685527d9f9028c3896c71e43722e9) Updated elpa
* [`5adf2046`](https://github.com/nix-community/emacs-overlay/commit/5adf20469a74beb33943e1743c6343ae704b33e6) Updated melpa
* [`37b07e43`](https://github.com/nix-community/emacs-overlay/commit/37b07e4331db0102655ce8e18d846894751a33b4) Updated emacs
* [`933b6a78`](https://github.com/nix-community/emacs-overlay/commit/933b6a78a634701896aa7c7a583949d7d571ace8) Updated melpa
* [`fac7acba`](https://github.com/nix-community/emacs-overlay/commit/fac7acbab55f1dbbf078c99d7dbce94c9590b073) Updated emacs
* [`1d6dbe8b`](https://github.com/nix-community/emacs-overlay/commit/1d6dbe8bf8efa7c9b090fbb10c80e9325759df38) Updated nongnu
* [`41f11652`](https://github.com/nix-community/emacs-overlay/commit/41f11652d609a69e8df552bed0fcecd23d01162a) Updated elpa
* [`7d2a19dc`](https://github.com/nix-community/emacs-overlay/commit/7d2a19dc77c19086c4b38fea66aca73b58040d76) Updated melpa
* [`d7e0c936`](https://github.com/nix-community/emacs-overlay/commit/d7e0c9362bd6030e79712036b22404f585fa2919) Updated emacs
* [`f8871380`](https://github.com/nix-community/emacs-overlay/commit/f88713807ad8aecdab95f040e60a8e2aaf04930d) Updated flake inputs
* [`5f9c5a08`](https://github.com/nix-community/emacs-overlay/commit/5f9c5a089ee4a7b121f11d0102d75a93b171a405) Updated nongnu
* [`acdb1320`](https://github.com/nix-community/emacs-overlay/commit/acdb132005b34dd45b5939f8112b192c8ad288ef) Updated elpa
* [`4238b864`](https://github.com/nix-community/emacs-overlay/commit/4238b86452a28b1832078548407e9c84afa9b11b) Updated melpa
* [`694acaa1`](https://github.com/nix-community/emacs-overlay/commit/694acaa144f0e88f6a5e7d406e26d5b8a7e51198) Updated emacs
* [`a757dd11`](https://github.com/nix-community/emacs-overlay/commit/a757dd117b066d5ee1527ce77c5e3d3ff6014b44) Updated flake inputs
* [`9cadda73`](https://github.com/nix-community/emacs-overlay/commit/9cadda7363575ba2df862b2ddccca08a2d3a9267) Updated melpa
* [`472f671a`](https://github.com/nix-community/emacs-overlay/commit/472f671ae934fc94384ebea0ad9419ef35240afe) Updated emacs
* [`94f9472c`](https://github.com/nix-community/emacs-overlay/commit/94f9472c4efc9678cc12c06400d1220d9b083bea) Updated nongnu
* [`5cde00c7`](https://github.com/nix-community/emacs-overlay/commit/5cde00c74d2b8ba4ed1ab1d4efabc3f3caca8f72) Updated elpa
* [`6cc2cb46`](https://github.com/nix-community/emacs-overlay/commit/6cc2cb466c04376fd6d323b911d3c9c208ed7cfb) Updated melpa
* [`6fbd3dab`](https://github.com/nix-community/emacs-overlay/commit/6fbd3dabc666841af3240c1f3f3aa52c037eb80d) Updated emacs
* [`9e158991`](https://github.com/nix-community/emacs-overlay/commit/9e158991cad34a9536a93f90f7c33e61e8b50c18) Updated nongnu
* [`8ad5c671`](https://github.com/nix-community/emacs-overlay/commit/8ad5c6717131c70aa7f61ffaf23b7bd59a2a2859) Updated elpa
* [`4fc88777`](https://github.com/nix-community/emacs-overlay/commit/4fc887777894174eb09978c65a7c6889607d6f3c) Updated melpa
* [`c4b02b4b`](https://github.com/nix-community/emacs-overlay/commit/c4b02b4be54b35b6bf0cd6b33ef01e33b5a041af) Updated emacs
* [`fd556776`](https://github.com/nix-community/emacs-overlay/commit/fd5567768f46b85f08b54e22576971b9bce185a4) Updated nongnu
* [`b4b2a4db`](https://github.com/nix-community/emacs-overlay/commit/b4b2a4db69e021d5c528a9515071f545b6438c1d) Updated elpa
* [`34df90b2`](https://github.com/nix-community/emacs-overlay/commit/34df90b253c0b01f25ea6930f968a92eb0b9ddff) Updated melpa
* [`ad6b500e`](https://github.com/nix-community/emacs-overlay/commit/ad6b500e038fcfea7ea26ce5f667e98bcad17c63) Updated emacs
* [`d51ac7f3`](https://github.com/nix-community/emacs-overlay/commit/d51ac7f37e4f338fb4f7c5e769af8d0d41de0a99) Updated flake inputs
* [`aa9035cb`](https://github.com/nix-community/emacs-overlay/commit/aa9035cb983c70fe87e1f7323fad23537b83a59a) Updated nongnu
* [`e42614ed`](https://github.com/nix-community/emacs-overlay/commit/e42614ed1bf6c342f351b32c3edbe2772df03133) Updated elpa
* [`487029bb`](https://github.com/nix-community/emacs-overlay/commit/487029bb8f8aa828f26f19b8d399cce79bf0248a) Updated melpa
* [`20239fd0`](https://github.com/nix-community/emacs-overlay/commit/20239fd0674b2895adcc8dfeacaffe3337dac94b) Updated emacs
* [`7e803198`](https://github.com/nix-community/emacs-overlay/commit/7e803198a2fdb48b2a260c0da948668d397f72c7) Updated melpa
* [`42b7368d`](https://github.com/nix-community/emacs-overlay/commit/42b7368d193ad1939c32e87b48e970423f22f242) Updated emacs
* [`6007ea80`](https://github.com/nix-community/emacs-overlay/commit/6007ea80bdb1b4321dd09427709e1d80fae5efbe) Updated elpa
* [`b9bce28f`](https://github.com/nix-community/emacs-overlay/commit/b9bce28f228f3a73da311ddf3d44b2a6a7bc56d9) Updated melpa
* [`7beb5f1e`](https://github.com/nix-community/emacs-overlay/commit/7beb5f1e34fb652bb68aa5d33247f92a1718f781) Updated emacs
* [`c0c5f2d3`](https://github.com/nix-community/emacs-overlay/commit/c0c5f2d3b04f251d3036432e6473af08eb394beb) Updated nongnu
* [`b8a53ec5`](https://github.com/nix-community/emacs-overlay/commit/b8a53ec5e21526aff929faa711dd22b3d9c5d49b) Updated elpa
* [`f15d1123`](https://github.com/nix-community/emacs-overlay/commit/f15d1123688272b19b761a16e42b20218e6ae3a8) Updated melpa
* [`0924fcda`](https://github.com/nix-community/emacs-overlay/commit/0924fcda6ea2ff09c857663d965a6d01e5d13ea6) Updated emacs
* [`50a7bc59`](https://github.com/nix-community/emacs-overlay/commit/50a7bc59d4cf844dc07e3c54b025b73f8319daed) Updated flake inputs
* [`aaf6d144`](https://github.com/nix-community/emacs-overlay/commit/aaf6d1443de5e2bf18231f4c1e435c5ff0cb667c) Updated nongnu
* [`69ecdf68`](https://github.com/nix-community/emacs-overlay/commit/69ecdf68894d67c91724838d3ef2d35db1a9ea78) Updated melpa
* [`f919d765`](https://github.com/nix-community/emacs-overlay/commit/f919d7650380b43fd27d271e1e096ac1b8fdd7ba) Updated emacs
* [`7d2087d8`](https://github.com/nix-community/emacs-overlay/commit/7d2087d88404112cb79a202ad004e078fd2ff35d) Updated nongnu
* [`5ef946d9`](https://github.com/nix-community/emacs-overlay/commit/5ef946d9eba9892b8400ec6717289a14ca3838b1) Updated elpa
* [`4c2faae7`](https://github.com/nix-community/emacs-overlay/commit/4c2faae7ac7d7400ea73e1ac327211b31f51fad0) Updated melpa
* [`49e8a084`](https://github.com/nix-community/emacs-overlay/commit/49e8a08498d157af476dfacf3ddec0f14dc4e512) Updated emacs
* [`2830c0d7`](https://github.com/nix-community/emacs-overlay/commit/2830c0d7b99849d2a163f25d14d2004ebb86bfd3) Updated melpa
* [`a543218e`](https://github.com/nix-community/emacs-overlay/commit/a543218ec15d1c97f3735c2698bf91003f470cd2) Updated emacs
* [`ed1abfef`](https://github.com/nix-community/emacs-overlay/commit/ed1abfef0a4e87c0731f91d8d1b160e3e261a3a8) Updated nongnu
* [`edab7e49`](https://github.com/nix-community/emacs-overlay/commit/edab7e49e85690e361700cf1613fb5afc22e1e50) Updated elpa
* [`6bd5f512`](https://github.com/nix-community/emacs-overlay/commit/6bd5f512b30ec3f1b1539757a6f18c1d73b9a799) Updated melpa
* [`43393ea4`](https://github.com/nix-community/emacs-overlay/commit/43393ea424f1d8ad6ed2a1053cbf67f5bab1a524) Updated emacs
* [`ccfe4a79`](https://github.com/nix-community/emacs-overlay/commit/ccfe4a79aa99f1f79dbafa3f6009c0438a8d760c) Updated elpa
* [`4dc3f1bd`](https://github.com/nix-community/emacs-overlay/commit/4dc3f1bddb275435e5d5ce99fd921d9eb74a9132) Updated melpa
* [`f776f828`](https://github.com/nix-community/emacs-overlay/commit/f776f828fe9de155a4b1139266e5aa557e8d2d22) Updated emacs
* [`e150cf4d`](https://github.com/nix-community/emacs-overlay/commit/e150cf4d4d3d2f90322e8c26eb6d72e246c9d634) Updated melpa
* [`8e1fd211`](https://github.com/nix-community/emacs-overlay/commit/8e1fd211d50232c3227a6e7a555515e5b3d3e333) Updated emacs
* [`a431a78d`](https://github.com/nix-community/emacs-overlay/commit/a431a78dd09b2903c9f7f2b0bd78f53d0bb9161b) Updated nongnu
* [`d25badb8`](https://github.com/nix-community/emacs-overlay/commit/d25badb857fd7e1ef13c31354fb1e5b47ed4591c) Updated elpa
* [`4954635f`](https://github.com/nix-community/emacs-overlay/commit/4954635f98b8ef2ff9ce469f82beee958ec6d783) Updated melpa
* [`38789ef3`](https://github.com/nix-community/emacs-overlay/commit/38789ef3dafe7a3a8927ccc874ddc90d0d5ef3b2) Updated emacs
* [`cb9f3553`](https://github.com/nix-community/emacs-overlay/commit/cb9f3553b34e1670e4c5b12cfc2757aa830652cd) Updated flake inputs
* [`58c89a99`](https://github.com/nix-community/emacs-overlay/commit/58c89a9912aed6ca10e120589ae67eba50e23d61) Updated nongnu
* [`4c1a300f`](https://github.com/nix-community/emacs-overlay/commit/4c1a300fedccf11194c39f26204f77d9e82ff728) Updated elpa
* [`9d57f70c`](https://github.com/nix-community/emacs-overlay/commit/9d57f70c9a98c0dc27c32a4c0e7625dfe8d97c42) Updated melpa
* [`05465c0b`](https://github.com/nix-community/emacs-overlay/commit/05465c0bbbbfa3db409e477e0a85bd161d27953e) Updated emacs
* [`c8f7c0c1`](https://github.com/nix-community/emacs-overlay/commit/c8f7c0c1e8f31e7ce8915b4f3aa3a1e4381c00b0) Updated melpa
* [`d376d6c0`](https://github.com/nix-community/emacs-overlay/commit/d376d6c0d09b7c5f4c5c026ae1a0ab53fb09fc77) Updated emacs
* [`01e159d8`](https://github.com/nix-community/emacs-overlay/commit/01e159d8218d6c83a71f69fe8270be0fb392afcb) Updated flake inputs
* [`44e18529`](https://github.com/nix-community/emacs-overlay/commit/44e185298bbaec0900fd82b2e4c850b70acd5006) Updated nongnu
* [`cd60643e`](https://github.com/nix-community/emacs-overlay/commit/cd60643e2e3d99ab124aa139cef97f5dedc0dca1) Updated elpa
* [`991921ad`](https://github.com/nix-community/emacs-overlay/commit/991921add940cb233df4105cec652cfeb1bd5151) Updated melpa
* [`2790653e`](https://github.com/nix-community/emacs-overlay/commit/2790653e250744d46d9fe501b6152d9f18e4d80d) Updated emacs
* [`fc17611c`](https://github.com/nix-community/emacs-overlay/commit/fc17611c29123274cfd5b3db9c5c16bd2f66ca05) Updated nongnu
* [`4225cc71`](https://github.com/nix-community/emacs-overlay/commit/4225cc71329095bf78e801fd08b996af366a3c98) Updated elpa
* [`28f2a6ef`](https://github.com/nix-community/emacs-overlay/commit/28f2a6efe28d4dadf0409ab122511f4e228f0cbb) Updated melpa
* [`d16ad9dd`](https://github.com/nix-community/emacs-overlay/commit/d16ad9dd4e4a5c591d818d2f2eb73189fb362d82) Updated emacs
* [`dbc158b2`](https://github.com/nix-community/emacs-overlay/commit/dbc158b2f694240cccd610441e9773f49ca317e2) Updated melpa
* [`244a2ab1`](https://github.com/nix-community/emacs-overlay/commit/244a2ab1459c72bac32a2db088549f8bc6d7a836) Updated emacs
* [`b2971f26`](https://github.com/nix-community/emacs-overlay/commit/b2971f26c272b3117758f0e011c45ab193755c2e) Updated flake inputs
* [`56084260`](https://github.com/nix-community/emacs-overlay/commit/56084260f7b977ae09ac1957d8b00dcc5abecc56) Updated elpa
* [`2126f883`](https://github.com/nix-community/emacs-overlay/commit/2126f88367e999c4ec9b50cd3966b32f7a27c66e) Updated melpa
* [`89ae60bb`](https://github.com/nix-community/emacs-overlay/commit/89ae60bbc93755f0c55606afd152e5e7493fe1b6) Updated nongnu
* [`70657d4f`](https://github.com/nix-community/emacs-overlay/commit/70657d4feb3b715b985705d545a08af76f134aae) Updated elpa
* [`633641c3`](https://github.com/nix-community/emacs-overlay/commit/633641c3b7f21669b7297bb93154b5ae6d34d1c9) Updated melpa
* [`28804bb2`](https://github.com/nix-community/emacs-overlay/commit/28804bb2080aa833d486b93717b0b0f0aefd9963) Updated emacs
* [`eed32b4f`](https://github.com/nix-community/emacs-overlay/commit/eed32b4f6a988c6715a83a1ce52aa12778abcd0a) Updated flake inputs
* [`2a8f8ec5`](https://github.com/nix-community/emacs-overlay/commit/2a8f8ec5a9393fcfff0d6735bd5c3b674d730198) Updated melpa
* [`c7c0186c`](https://github.com/nix-community/emacs-overlay/commit/c7c0186cfe9f14317c4c319788283389d5567f96) Updated emacs
* [`e0f1993b`](https://github.com/nix-community/emacs-overlay/commit/e0f1993bb6b406587decb6f39ed48ae3bbbfcf5a) Updated flake inputs
* [`076042e3`](https://github.com/nix-community/emacs-overlay/commit/076042e36869734fd37c415d4feeb95d7c3dd4d3) Updated nongnu
* [`f7927397`](https://github.com/nix-community/emacs-overlay/commit/f79273970a0ea83936d7e940bd6d03309f173eeb) Updated elpa
* [`682f2a54`](https://github.com/nix-community/emacs-overlay/commit/682f2a545cd336810993845195df8cfca5aa3b77) Updated melpa
* [`7a1e649a`](https://github.com/nix-community/emacs-overlay/commit/7a1e649ab6a73e0b8b728530318142f784b47054) Updated emacs
* [`b3538c3a`](https://github.com/nix-community/emacs-overlay/commit/b3538c3ac928177c0512e590fd6932fca3678db2) Updated flake inputs
* [`b02e8e26`](https://github.com/nix-community/emacs-overlay/commit/b02e8e26a4b08e9e28474df6b2a8d607e94215ce) Updated elpa
* [`19dcd36d`](https://github.com/nix-community/emacs-overlay/commit/19dcd36db0ab413236f985ab3a882ca3c16419f3) Updated melpa
* [`33fcdafe`](https://github.com/nix-community/emacs-overlay/commit/33fcdafefd56847a1095050262aa89863fade3d2) Updated emacs
* [`4fad2714`](https://github.com/nix-community/emacs-overlay/commit/4fad271473a3c52568acf39ae3c2e9b9364124dd) Updated melpa
* [`2a6761cc`](https://github.com/nix-community/emacs-overlay/commit/2a6761cc467f51556fee475e09dd01030b20837d) Updated nongnu
* [`22523b38`](https://github.com/nix-community/emacs-overlay/commit/22523b38cba1536cb25bcd7a3a997f64b5b10a0f) Updated elpa
* [`0b1bd916`](https://github.com/nix-community/emacs-overlay/commit/0b1bd916e2dcb4adcd655c5095ab3b14092ed610) Updated melpa
* [`599fff1f`](https://github.com/nix-community/emacs-overlay/commit/599fff1f414c35032984d18882c7e17af79bfad3) Updated flake inputs
* [`9473b6f7`](https://github.com/nix-community/emacs-overlay/commit/9473b6f71daf9b4029e624335a1badf6f7842fc2) Updated nongnu
* [`1c7713a0`](https://github.com/nix-community/emacs-overlay/commit/1c7713a0f64941e71be26752421ec8b9499179c7) Updated elpa
* [`1ab6ff64`](https://github.com/nix-community/emacs-overlay/commit/1ab6ff64227db4405bde3c833d4aac91f8767057) Updated melpa
* [`3e570631`](https://github.com/nix-community/emacs-overlay/commit/3e57063190e331f241b6887d00c043b8012dbb42) Updated emacs
* [`2fb96818`](https://github.com/nix-community/emacs-overlay/commit/2fb96818d6c36102fcdcd59d545cb603b0bdfd0e) Updated melpa
* [`8e8d2ab3`](https://github.com/nix-community/emacs-overlay/commit/8e8d2ab30c3c2d8b3d149f527eccb572f48b5a89) Updated emacs
* [`f381c91e`](https://github.com/nix-community/emacs-overlay/commit/f381c91e1cc2376124925040f63b15bdd21e9f63) Updated flake inputs
* [`a38ad400`](https://github.com/nix-community/emacs-overlay/commit/a38ad40058d2a96db68fa6672b28ed5dc5f2d2d5) Updated nongnu
* [`1efa8d1b`](https://github.com/nix-community/emacs-overlay/commit/1efa8d1b4f7bd4103d2301370b296871d525fbe3) Updated elpa
* [`c89ccf1b`](https://github.com/nix-community/emacs-overlay/commit/c89ccf1b095845e378bf5acb29877f4e88beac3f) Updated melpa
* [`e2b40104`](https://github.com/nix-community/emacs-overlay/commit/e2b4010417bfa8bd2decc03397e3652dfb0dcc61) Updated emacs
* [`32a4e779`](https://github.com/nix-community/emacs-overlay/commit/32a4e779b4f8ddba468eee482448f4e5294e29c0) Updated nongnu
* [`b52f152e`](https://github.com/nix-community/emacs-overlay/commit/b52f152e7e29e8e790dd289a1d2cbf4208592ac8) Updated elpa
* [`231dbcf0`](https://github.com/nix-community/emacs-overlay/commit/231dbcf0a7c45069e290cef5a5f4d52d67d48f52) Updated melpa
* [`51a7e15c`](https://github.com/nix-community/emacs-overlay/commit/51a7e15c6125e8166bdffd4b9f6b9f66961bbc94) Updated emacs
* [`2e2ef265`](https://github.com/nix-community/emacs-overlay/commit/2e2ef265a0dc2e1de5db1e5b384c8cbe4e4f316a) Updated melpa
* [`c7efde70`](https://github.com/nix-community/emacs-overlay/commit/c7efde709bbcd3a207abe763c11922fda4358a6d) Updated emacs
* [`ac3dfdca`](https://github.com/nix-community/emacs-overlay/commit/ac3dfdca835c5b8f7c27d5dcec2b9c4580299a7c) Updated flake inputs
* [`9071d5f5`](https://github.com/nix-community/emacs-overlay/commit/9071d5f50ce03d1f872973516d0e5dd13179cb93) Updated flake inputs
* [`d822359d`](https://github.com/nix-community/emacs-overlay/commit/d822359de7f0f4b42dafb37991b18488bd229b65) Updated flake inputs
* [`163a7407`](https://github.com/nix-community/emacs-overlay/commit/163a74072c6e31ef7a95820c0f21e8f5f24221e9) Disable emacs-unstable update
* [`23c1d800`](https://github.com/nix-community/emacs-overlay/commit/23c1d800e2b27c80de2cab5d4466c2d15b56d0b9) repos/emacs: Also disable update_release job
* [`7ff454d4`](https://github.com/nix-community/emacs-overlay/commit/7ff454d433725e251ceb5251ea0101402b11c319) Updated nongnu
* [`e99d68b8`](https://github.com/nix-community/emacs-overlay/commit/e99d68b803981b9c220e0ddbb2c96448e85c2f4d) Updated elpa
* [`9643840b`](https://github.com/nix-community/emacs-overlay/commit/9643840b8e9a5332a6921dc3e1884010a0561b60) Updated melpa
* [`565cab2a`](https://github.com/nix-community/emacs-overlay/commit/565cab2a16c16dffb7a043a8c748a1b082ec53f1) Updated melpa
* [`0a5780c7`](https://github.com/nix-community/emacs-overlay/commit/0a5780c7ffb75e3e29a31500c1cfb829c5dae838) Updated nongnu
* [`d477cba9`](https://github.com/nix-community/emacs-overlay/commit/d477cba9abceed91b0848a7df630f4d9ab206318) Updated elpa
* [`e2e852d2`](https://github.com/nix-community/emacs-overlay/commit/e2e852d21398ad0a2b5ccf4924b96c2af5d5f0f9) Updated melpa
* [`0b955b7e`](https://github.com/nix-community/emacs-overlay/commit/0b955b7e32e0bf5e9fd6237f716b0e37186ecdb6) Updated nongnu
* [`0a7e90dd`](https://github.com/nix-community/emacs-overlay/commit/0a7e90ddccf0b3b4c102b150b0a7ab512701ea38) Updated elpa
* [`c3a1033f`](https://github.com/nix-community/emacs-overlay/commit/c3a1033fe299dea7efdc3dce3de77ebba574bc4e) Updated melpa
* [`92864bdb`](https://github.com/nix-community/emacs-overlay/commit/92864bdb1faa821eee11c341fb4b4dde7384f05a) Updated melpa
* [`4d3c5acd`](https://github.com/nix-community/emacs-overlay/commit/4d3c5acd23395729d0c4e4caf64f6675982f9ad6) Updated nongnu
* [`547c1b31`](https://github.com/nix-community/emacs-overlay/commit/547c1b31a8ac5e94c73dfa0cbfa1839c8a1edddd) Updated elpa
* [`3d9c3f57`](https://github.com/nix-community/emacs-overlay/commit/3d9c3f57344e9b247287ab702380251d4f95875c) Updated melpa
* [`042ad644`](https://github.com/nix-community/emacs-overlay/commit/042ad6446d9037d9c73d4263ff3f10d9a80415dd) Updated nongnu
* [`12caee7f`](https://github.com/nix-community/emacs-overlay/commit/12caee7f15c68186ad30e9a441bd48f80b9b1168) Updated elpa
* [`0efb6004`](https://github.com/nix-community/emacs-overlay/commit/0efb6004354e5c6761d0c2a01bcbb9f3e57721b8) Updated melpa
* [`ebd77d29`](https://github.com/nix-community/emacs-overlay/commit/ebd77d296e02754318aae98802440aea456bdfdc) Updated flake inputs
* [`48dd30cb`](https://github.com/nix-community/emacs-overlay/commit/48dd30cb0e8569b6aac98e8d206227fc15a89468) Updated melpa
* [`1c25aaca`](https://github.com/nix-community/emacs-overlay/commit/1c25aaca3c5059ecc45f42657ed6fd998661a1c5) Updated flake inputs
* [`134ad77e`](https://github.com/nix-community/emacs-overlay/commit/134ad77e9e82aed947bc51bd030157e21bd77071) Updated nongnu
* [`4dd153b7`](https://github.com/nix-community/emacs-overlay/commit/4dd153b7f9c57795f22e0b5b184a546cd21257df) Updated elpa
* [`3e609462`](https://github.com/nix-community/emacs-overlay/commit/3e609462bf6a53a163a74818f8082dc1bd77fd31) Updated melpa
* [`c686340e`](https://github.com/nix-community/emacs-overlay/commit/c686340e9752462adb466a5bf6d1248fba35ff93) Updated nongnu
* [`aaa88a76`](https://github.com/nix-community/emacs-overlay/commit/aaa88a76657b629979b7461cefe48152f7d389b1) Updated elpa
* [`49cbf87f`](https://github.com/nix-community/emacs-overlay/commit/49cbf87fc39989cfaa69cae5e06f3e8e18474cd9) Updated melpa
* [`e2c7b1cd`](https://github.com/nix-community/emacs-overlay/commit/e2c7b1cdaa973f5bb3c905f4d236f598949a727d) Updated melpa
* [`3326b6ca`](https://github.com/nix-community/emacs-overlay/commit/3326b6cae6e89e85326ca3127a50bbc10e9ea07c) Updated flake inputs
* [`aa0c220b`](https://github.com/nix-community/emacs-overlay/commit/aa0c220bda30d546c6e9717a4119613cb7a6c1d0) Updated nongnu
* [`4c8b8c66`](https://github.com/nix-community/emacs-overlay/commit/4c8b8c6623070862403dfc486dee60b4188b7b40) Updated elpa
* [`fb11a305`](https://github.com/nix-community/emacs-overlay/commit/fb11a30501d1344d9c40f5bf85f486cb9f979b96) Updated melpa
* [`05f7b37b`](https://github.com/nix-community/emacs-overlay/commit/05f7b37b8cf15188625bb3138c83204c39ba892f) Updated nongnu
* [`fa2454e8`](https://github.com/nix-community/emacs-overlay/commit/fa2454e8edf8d1ac7baf5adac59c0f2c1208a4f2) Updated elpa
* [`53ed498b`](https://github.com/nix-community/emacs-overlay/commit/53ed498b85c8e047d13ffa435e05b79c9aaca04b) Updated melpa
* [`93d351a5`](https://github.com/nix-community/emacs-overlay/commit/93d351a5010799656026bb4ff253b0e68eab4de5) Updated melpa
* [`181790dd`](https://github.com/nix-community/emacs-overlay/commit/181790dde36acf253c5c57dcb55e726ed7ac5dd9) Revert "repos/emacs: Also disable update_release job"
* [`605078be`](https://github.com/nix-community/emacs-overlay/commit/605078be5d4edac9af115f844e22c200d597aa9b) Revert "Disable emacs-unstable update"
* [`9c3103d7`](https://github.com/nix-community/emacs-overlay/commit/9c3103d786d248b1defc68ef6c604af66bf5d0c1) Updated flake inputs
* [`0b1fe984`](https://github.com/nix-community/emacs-overlay/commit/0b1fe9841d127671046113c274aad58bf37bedcd) Updated nongnu
* [`cbba792c`](https://github.com/nix-community/emacs-overlay/commit/cbba792c7f4538997b494f0fc9e8122119a84655) Updated elpa
* [`171ac4f0`](https://github.com/nix-community/emacs-overlay/commit/171ac4f02f32f1b2953efca4d00b45a4bef97910) Updated melpa
* [`a7bef17c`](https://github.com/nix-community/emacs-overlay/commit/a7bef17c9ba6724411ca445fbbbc66f05bd40ef0) Updated emacs
* [`72034af7`](https://github.com/nix-community/emacs-overlay/commit/72034af7a2790ad074c864ac4ba1494b5147a430) Updated melpa
* [`d4f89622`](https://github.com/nix-community/emacs-overlay/commit/d4f89622cb2f68467b574dc0eb412583f947a130) Updated flake inputs
* [`03c78021`](https://github.com/nix-community/emacs-overlay/commit/03c78021ae6cd6b2c91ae5c179918186667b3c49) Updated nongnu
* [`8522e5da`](https://github.com/nix-community/emacs-overlay/commit/8522e5daf378cd5e7c7cfef31d501a252e56a6f0) Updated melpa
* [`1daea5dd`](https://github.com/nix-community/emacs-overlay/commit/1daea5ddf4cebd26c500f265edbeb62d679c7ff7) Updated emacs
* [`1a34d6be`](https://github.com/nix-community/emacs-overlay/commit/1a34d6be1f8b1f4f5ab11bc74d64c472c442094a) Updated nongnu
* [`20492c75`](https://github.com/nix-community/emacs-overlay/commit/20492c753b4f3b30fda02056f507e29ef38d3fa6) Updated elpa
* [`c20a5eb3`](https://github.com/nix-community/emacs-overlay/commit/c20a5eb334931573788c1f9d70743964397d375e) Updated melpa
* [`4ebe4c89`](https://github.com/nix-community/emacs-overlay/commit/4ebe4c890e7c8662ae31192359a56b0505cf10ba) Updated emacs
* [`6e33a4eb`](https://github.com/nix-community/emacs-overlay/commit/6e33a4eb8a77201138c17e6da664f5adfe6ae633) Updated flake inputs
* [`01d02e46`](https://github.com/nix-community/emacs-overlay/commit/01d02e46b9ee80a62c75e2f7bfecb87d1bba7c8a) Updated nongnu
* [`32f47ddd`](https://github.com/nix-community/emacs-overlay/commit/32f47dddc4d9b3a56b9bdc30ff981b698479a0bf) Updated elpa
* [`86d525f8`](https://github.com/nix-community/emacs-overlay/commit/86d525f88fcfc1355520a7be177231a88c5590ba) Add emacs-igc and emacs-igc-pgtk
* [`289bb67c`](https://github.com/nix-community/emacs-overlay/commit/289bb67c6d068e5af0cb4ee7223e9ef7c29a55b3) Updated melpa
* [`e1a127d2`](https://github.com/nix-community/emacs-overlay/commit/e1a127d279c42a3d935db6ab8771d5967b85c499) Updated emacs
* [`cda2a038`](https://github.com/nix-community/emacs-overlay/commit/cda2a0386cc568f2b5f22bb554fbe9f2e0b4b3b5) Updated emacs
* [`da7d94da`](https://github.com/nix-community/emacs-overlay/commit/da7d94da6f050424aba1f75d698bb9cc92abbf14) Updated melpa
* [`b6b40f5d`](https://github.com/nix-community/emacs-overlay/commit/b6b40f5d7ef0dc1c4a542ec5c819861701688552) Updated nongnu
* [`01d3541a`](https://github.com/nix-community/emacs-overlay/commit/01d3541ae87abe1a366c91642a518589d173946a) Updated elpa
* [`1a7f8823`](https://github.com/nix-community/emacs-overlay/commit/1a7f882361bd552a05f33d35d0fdcec2a9dbb930) Updated melpa
* [`b8e32860`](https://github.com/nix-community/emacs-overlay/commit/b8e32860b5c94c75e9efb1779b9b5a4bd4a7d655) Updated emacs
* [`fb473005`](https://github.com/nix-community/emacs-overlay/commit/fb47300576e3471c6b0cfa04e45b26bd59d2d27a) Updated flake inputs
* [`acdfe55f`](https://github.com/nix-community/emacs-overlay/commit/acdfe55fc39ee5a37fd397cc525108378d6be9c0) Updated nongnu
* [`3bb526c2`](https://github.com/nix-community/emacs-overlay/commit/3bb526c2056bbcbc8fa0cd9cf8da4ad7e6257aa5) Updated elpa
* [`19e889d4`](https://github.com/nix-community/emacs-overlay/commit/19e889d43bb6e5cdb4568af9f432afdebde47e8c) Updated melpa
* [`c78232a1`](https://github.com/nix-community/emacs-overlay/commit/c78232a115e112a366e7a087c9db4657876cb87c) Updated emacs
* [`5684de38`](https://github.com/nix-community/emacs-overlay/commit/5684de38908c100f4588ee1dc7eb89962052295b) Updated flake inputs
* [`ac838c63`](https://github.com/nix-community/emacs-overlay/commit/ac838c634493191fbe70a96b93d86378a7ad8cc4) Updated melpa
* [`48779394`](https://github.com/nix-community/emacs-overlay/commit/48779394ffa6cab042b3ae9b894e3cf2d4f86e2d) Updated emacs
* [`637f7754`](https://github.com/nix-community/emacs-overlay/commit/637f775460733493ed9f6d7b87e7a44777f51118) Updated nongnu
* [`ffb60eaf`](https://github.com/nix-community/emacs-overlay/commit/ffb60eaf3a77e32133340de5298b35beef3b0c09) Updated elpa
* [`ed3bfdeb`](https://github.com/nix-community/emacs-overlay/commit/ed3bfdeb3186d836366d4b9d4ff28527cca9b541) Updated melpa
* [`2251b6ce`](https://github.com/nix-community/emacs-overlay/commit/2251b6ce66de3f27aaf26779f2dc8c7b99402014) Updated emacs
* [`0d9f55d2`](https://github.com/nix-community/emacs-overlay/commit/0d9f55d26372c847d822f17421eaeb1f470dc9e0) Fix src hash for timu-macos-theme
* [`76c3d04c`](https://github.com/nix-community/emacs-overlay/commit/76c3d04c25e5fe40c54011317f696173454def08) Updated nongnu
* [`e0f7a48b`](https://github.com/nix-community/emacs-overlay/commit/e0f7a48bb47646cb4d134085c2a4351b06786bbf) Updated elpa
* [`87fe07e0`](https://github.com/nix-community/emacs-overlay/commit/87fe07e0d861d4161152f753cbf1bedfa8b39569) Updated melpa
* [`1ea7ab3b`](https://github.com/nix-community/emacs-overlay/commit/1ea7ab3b2f3555765d73ccbc2271ed4c45e50155) Updated emacs
* [`9caa7acd`](https://github.com/nix-community/emacs-overlay/commit/9caa7acdd6434064bb0ff899f7b87fc955399553) Updated melpa
* [`3c3d53a6`](https://github.com/nix-community/emacs-overlay/commit/3c3d53a6a1d65959bcfd3045fa7411da9c1f3ead) Updated emacs
* [`9995fbcd`](https://github.com/nix-community/emacs-overlay/commit/9995fbcdd1cdf0864524ce716087e0dafa5ce8a9) Updated nongnu
* [`593e672c`](https://github.com/nix-community/emacs-overlay/commit/593e672c83daa6791775de9457125cf6a5468db8) Updated elpa
* [`ff85c55a`](https://github.com/nix-community/emacs-overlay/commit/ff85c55a42b1fc68931f2091eff261942f893ded) Updated melpa
* [`7ec38a36`](https://github.com/nix-community/emacs-overlay/commit/7ec38a3697c36f10e8a821dec4ad4e21763e6421) Updated emacs
* [`7aa72a6f`](https://github.com/nix-community/emacs-overlay/commit/7aa72a6f74d275f0941b6eb07527c41d17db467e) Updated nongnu
* [`7d96066f`](https://github.com/nix-community/emacs-overlay/commit/7d96066f80c93ecc62620e925d1fb8edfa6dbbc6) Updated elpa
* [`e728886e`](https://github.com/nix-community/emacs-overlay/commit/e728886ee1aeb0b7bb5766656e05161d672c6b8c) Updated melpa
* [`497be68b`](https://github.com/nix-community/emacs-overlay/commit/497be68b191fb8e35dfb015a3ded3b00b82da144) Updated emacs
* [`5b88577d`](https://github.com/nix-community/emacs-overlay/commit/5b88577d054c2bf3ccefc65474daa0aa74d2507c) Updated melpa
* [`0f163b9e`](https://github.com/nix-community/emacs-overlay/commit/0f163b9ed898d12dfc5c5eafc4d4555f92c7b0e8) Updated flake inputs
* [`df053c8f`](https://github.com/nix-community/emacs-overlay/commit/df053c8fcf35c4da7beede9e3602bd6403fe8cb2) Updated nongnu
* [`73bb0adf`](https://github.com/nix-community/emacs-overlay/commit/73bb0adf1b38b8b75fe7701f71938857f629f6b8) Updated elpa
* [`8b23f27b`](https://github.com/nix-community/emacs-overlay/commit/8b23f27bc4e80b3b9e29aea6cdb64b651cf28076) Updated melpa
* [`32a95da7`](https://github.com/nix-community/emacs-overlay/commit/32a95da7a2c59af7c3cc899e7f4659d15f9e703d) Updated emacs
* [`3b0a54b3`](https://github.com/nix-community/emacs-overlay/commit/3b0a54b3b5f721ac34ae3c7aae892c4124b71e03) Updated flake inputs
* [`1ea14c73`](https://github.com/nix-community/emacs-overlay/commit/1ea14c733f3ac4969dbcf9d4a6371de5df9f9824) Updated nongnu
* [`1647b845`](https://github.com/nix-community/emacs-overlay/commit/1647b8455c375d8beffab1bde467789b96923e5b) Updated elpa
* [`48b0cc35`](https://github.com/nix-community/emacs-overlay/commit/48b0cc35316cb0c07ef56e98e428ca28c667f88e) Updated melpa
* [`a8f67a6a`](https://github.com/nix-community/emacs-overlay/commit/a8f67a6a631761a897cb40a69782e00e8677e9e5) Updated emacs
* [`78979aea`](https://github.com/nix-community/emacs-overlay/commit/78979aeab724d4a9a6c4c31194cf947c0397d69b) Updated melpa
* [`bf817bb8`](https://github.com/nix-community/emacs-overlay/commit/bf817bb80b020ffdeee5769867b8862026bd5312) Updated emacs
* [`1e3650ba`](https://github.com/nix-community/emacs-overlay/commit/1e3650ba7abda10b95625c63aa7f8a13dffc49a3) Updated flake inputs
* [`2c1e575c`](https://github.com/nix-community/emacs-overlay/commit/2c1e575cf906a8caffbcb2637e22b354194cf6ef) Updated nongnu
* [`13d1a6c6`](https://github.com/nix-community/emacs-overlay/commit/13d1a6c633b44096f6e01f8d866eeefce029efc5) Updated elpa
* [`36c166e4`](https://github.com/nix-community/emacs-overlay/commit/36c166e434efe7be41c195f625167d5b029cd21b) Updated melpa
* [`65eacdb3`](https://github.com/nix-community/emacs-overlay/commit/65eacdb31336e6af536e4be8c37b8fc462b9d206) Updated emacs
* [`c27a3c54`](https://github.com/nix-community/emacs-overlay/commit/c27a3c5433fcab75e9eb66cc81d7ce1503905526) Updated nongnu
* [`373c03bb`](https://github.com/nix-community/emacs-overlay/commit/373c03bb4cda176516b304ccb4481e0101c964ee) Updated elpa
* [`8094f314`](https://github.com/nix-community/emacs-overlay/commit/8094f3145d551c7b99bf5b749d4525be0a9d0cce) Updated melpa
* [`84447d57`](https://github.com/nix-community/emacs-overlay/commit/84447d574a9a21f6e3b04fce7c7279afb15f24c3) Updated emacs
* [`1300f8d7`](https://github.com/nix-community/emacs-overlay/commit/1300f8d7b20f3d0df0be8a0e0132b6abc1b1c576) Updated melpa
* [`393224b4`](https://github.com/nix-community/emacs-overlay/commit/393224b463dab363543ac2b6c96f41777516221c) Updated emacs
* [`b4a599b9`](https://github.com/nix-community/emacs-overlay/commit/b4a599b9b780571fbe60be00e85e83307cdb66f4) Updated nongnu
* [`6bca7e49`](https://github.com/nix-community/emacs-overlay/commit/6bca7e496460a9cd4c2956579c57aae43328f4fd) Updated elpa
* [`54930bbf`](https://github.com/nix-community/emacs-overlay/commit/54930bbffe2cf9f14e057d1825b7195b0301c152) Updated melpa
* [`49b92479`](https://github.com/nix-community/emacs-overlay/commit/49b92479d543bfc85fc7935a390e32fa023bc08c) Updated emacs
