### PR TITLE
niv doomemacs: update ba1dca32 -> 2bc05242

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "doomemacs",
         "repo": "doomemacs",
-        "rev": "ba1dca322f9a07bc2b7bec6a98f2c3c55c0bbd77",
-        "sha256": "1y8ar78fwr8fkw1h9zfc6g565k8phqwcl5zc9f61bg2m1s7yxrmi",
+        "rev": "2bc052425ca45a41532be0648ebd976d1bd2e6c1",
+        "sha256": "0a1px0igzhzl7mjl0wkp9jnb3sjggpbi2rnj0w2kga08d8frahcb",
         "type": "tarball",
-        "url": "https://github.com/doomemacs/doomemacs/archive/ba1dca322f9a07bc2b7bec6a98f2c3c55c0bbd77.tar.gz",
+        "url": "https://github.com/doomemacs/doomemacs/archive/2bc052425ca45a41532be0648ebd976d1bd2e6c1.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "emacs-overlay": {


### PR DESCRIPTION
## Changelog for doomemacs:
Branch: master
Commits: [doomemacs/doomemacs@ba1dca32...2bc05242](https://github.com/doomemacs/doomemacs/compare/ba1dca322f9a07bc2b7bec6a98f2c3c55c0bbd77...2bc052425ca45a41532be0648ebd976d1bd2e6c1)

* [`ecd079f6`](https://github.com/doomemacs/doomemacs/commit/ecd079f6daa92946938c009f663e84cec63dd433) feat(lib): backport {enable,disable}-theme-functions
* [`50b9afbb`](https://github.com/doomemacs/doomemacs/commit/50b9afbb2d80da579e45f93c0733f0443f358344) refactor: swap load-theme advice for enable-theme-functions
* [`cc182188`](https://github.com/doomemacs/doomemacs/commit/cc1821888924933788f2759874ab7d6b0d8b1aea) refactor: nconc -> add-to-list
* [`ad4eee6f`](https://github.com/doomemacs/doomemacs/commit/ad4eee6f6694f49424e0d796971c90860c9c6555) refactor: remove redundant backport
* [`2f8b49ea`](https://github.com/doomemacs/doomemacs/commit/2f8b49ea7a868760c9154960bca8cf4908398526) fix: reset gc-cons-threshold if not already
* [`80566503`](https://github.com/doomemacs/doomemacs/commit/80566503646dd80c7604220f184076e190144675) perf: gcmh-high-cons-threshold = 64mb
* [`e3bc367b`](https://github.com/doomemacs/doomemacs/commit/e3bc367ba2f6571f2cfa47e6ba23fc92dd4d0961) nit: minor comment revision
* [`0a715cc3`](https://github.com/doomemacs/doomemacs/commit/0a715cc3f233497417dc7baae67ee97f5300d246) refactor: (if|when)-let -> (if|when)-let*
* [`68edae42`](https://github.com/doomemacs/doomemacs/commit/68edae421fa60a1b5fc8fb53022caf165ff9f6b5) refactor: doom-profile-generate: remove defunct build step
* [`a06287cc`](https://github.com/doomemacs/doomemacs/commit/a06287cc23cbf151b2cb67eba69cf5ff9e230534) fix: only check for major emacs version changes
* [`881eea13`](https://github.com/doomemacs/doomemacs/commit/881eea137fffe7bfdafdb2a72a359576210ae08a) refactor: remove doom-bin-dir
* [`b0256453`](https://github.com/doomemacs/doomemacs/commit/b02564535e228b7fa1ff583e0c77e1e977ae3714) fix: "Invalid key: nil" errors in some eval contexts
* [`ad3da32c`](https://github.com/doomemacs/doomemacs/commit/ad3da32c5ff33cae22cf75551bbb5d1351d3e99e) refactor: comp: s/after!/with-eval-after-load
* [`254a8d38`](https://github.com/doomemacs/doomemacs/commit/254a8d38a7a2752b1f49620308fa4d0e217fdf70) feat(lib): prepend DOOMPROFILELOADPATH to doom-profile-load-path
* [`7de97233`](https://github.com/doomemacs/doomemacs/commit/7de9723334b8c6cd8baabc9392b1186f2dcaa410) feat(cli): defcli-obsolete!: allow arbitrary obsolescence message
* [`3f1a4711`](https://github.com/doomemacs/doomemacs/commit/3f1a47112713fe17ba0aec426a7fef0a1947e314) refactor: replace point-at-{b,e}ol
* [`d51fffed`](https://github.com/doomemacs/doomemacs/commit/d51fffeda5ee077958bb687a3b1007d0050cbe39) fix(cli): appease byte-compiler sama
* [`d6037a24`](https://github.com/doomemacs/doomemacs/commit/d6037a24d4eb9663f239c47db1733b3df72a4f44) refactor: load doom-compat.el from doom.el
* [`9111d9b7`](https://github.com/doomemacs/doomemacs/commit/9111d9b74c0c846ba69c81bd317d1ae7d3a5152f) fix(emacs-lisp): only set mode-name in elisp buffers
* [`ea098dcc`](https://github.com/doomemacs/doomemacs/commit/ea098dcc1fbfb545451e5940896d6da4568bad71) fix(cc): replace opencl-mode with opencl-c-mode
* [`cc98bdd1`](https://github.com/doomemacs/doomemacs/commit/cc98bdd14bfcf3042f6e5e23e95e5ee72d58eec7) fix(modeline): change macOS default EOL type to LF
* [`c1f5d611`](https://github.com/doomemacs/doomemacs/commit/c1f5d6111fc682e746d8cd30ef9497616101ac95) fix(notmuch): afew: process only new mail
* [`8f57069d`](https://github.com/doomemacs/doomemacs/commit/8f57069dd50e66b97a3fe7b1d9676e423787c08c) feat(workspaces): add count arg to switch-{left,right} commands
* [`eaf26b83`](https://github.com/doomemacs/doomemacs/commit/eaf26b83ad9eda33a6d44d83b362a9c29a3c3346) fix: file-missing doom-compat error
* [`a830b0e4`](https://github.com/doomemacs/doomemacs/commit/a830b0e41adb07e3e808298a12919de988ab351c) fix: doom-compat: end-of-file error
* [`6a7251bc`](https://github.com/doomemacs/doomemacs/commit/6a7251bcfad05de5a68f0ba7be213e4d98738b50) docs(lsp): replace support table w/ links
* [`754e0f79`](https://github.com/doomemacs/doomemacs/commit/754e0f79821a2215d660941facec42f30ba51a5d) bump: :tools
* [`50de0332`](https://github.com/doomemacs/doomemacs/commit/50de03321c94b0a3d8c0baa661d6476c557f9367) bump: :ui
* [`4f8a8e05`](https://github.com/doomemacs/doomemacs/commit/4f8a8e05e920936fbcecdd415773bba2d4ac9897) fix(doom-dashboard): vanishing right-hand mode-line
* [`0ef4a3f9`](https://github.com/doomemacs/doomemacs/commit/0ef4a3f9e1338848fc49cfab82b9ff606bc82969) tweak(vertico): remove consult-man remapping
* [`fcf72672`](https://github.com/doomemacs/doomemacs/commit/fcf726726b0d94f4207d69770b175d39fae509f9) fix(fold): fix recursive unfolding
* [`96f5fcc6`](https://github.com/doomemacs/doomemacs/commit/96f5fcc6a0520ca3631b25ff0a7f77acf095cb7f) fix(ansible): check for metadata file
* [`8a064ffa`](https://github.com/doomemacs/doomemacs/commit/8a064ffaeccb4d05d9bb12ef4405226a4500c71f) fix(ansible): check for config file
* [`5aed9baa`](https://github.com/doomemacs/doomemacs/commit/5aed9baa29f52bdaf0ae440bb38ee91e41ce4be5) fix: auto-mode-alist: make /*rc rule low-priority
* [`cfb93b2a`](https://github.com/doomemacs/doomemacs/commit/cfb93b2a32a09e82e8579dab6ed575127682da90) feat(terraform): add validate, fmt, & destroy keybinds
* [`1fc41d71`](https://github.com/doomemacs/doomemacs/commit/1fc41d719c19973c8f45fc93c8e5ffcfa4ff2477) fix: project-current-directory-override takes a directory
* [`2b4f762b`](https://github.com/doomemacs/doomemacs/commit/2b4f762b1e6a366cfcd9ffb3e17f127c64df2657) release(modules): 25.02.0-dev
* [`295cee7c`](https://github.com/doomemacs/doomemacs/commit/295cee7c7858f002a791b0e4638118108e71d6d9) refactor(cli): s/doom-cli-sync-info-file/doom-sync-info-file
* [`eccd7292`](https://github.com/doomemacs/doomemacs/commit/eccd72922b010d88f4800482860ca8222bd44bb3) fix(cli): show "restart Emacs" advice only if Emacs is running
* [`9b4f7ead`](https://github.com/doomemacs/doomemacs/commit/9b4f7ead886fc3964ac7f60c420e5ac322683481) fix(lib): doom-profiles-bootloadable-p: respect XDG_CONFIG_HOME
* [`b31eef93`](https://github.com/doomemacs/doomemacs/commit/b31eef9336ae416c45b4141a35371ca88a465aac) revert: fix(lib): doom-copy: copy first level of records
* [`7032e579`](https://github.com/doomemacs/doomemacs/commit/7032e5797fc69f2300ca6383ea8eb5649c49ecd2) bump: :editor
* [`6b3b656e`](https://github.com/doomemacs/doomemacs/commit/6b3b656ed7c1a0f8071351237358b952b2d7e5b6) bump: :app
* [`6f281806`](https://github.com/doomemacs/doomemacs/commit/6f28180686d5f5aa73017ac9c064c034bfc26a63) bump: :term
* [`47ef79b3`](https://github.com/doomemacs/doomemacs/commit/47ef79b3b3a2379b147bc51a403d29703a0c671a) bump: :config
* [`8951de19`](https://github.com/doomemacs/doomemacs/commit/8951de19d8a2494079f862b5e4f7e706baef9aa7) bump: :lang
* [`a55e4a5a`](https://github.com/doomemacs/doomemacs/commit/a55e4a5aaccb75e453fe98a68df0780ebdf1178a) docs(vertico): suppress grep warnings if ripgrep is available
* [`1a863605`](https://github.com/doomemacs/doomemacs/commit/1a8636056051ad52c8df33adc898699451c425a7) docs: warn users about nushell issues
* [`75a995f6`](https://github.com/doomemacs/doomemacs/commit/75a995f66f3f611c26c495db0c0351acdbb464f5) docs: detect nushell on windows too
* [`c21c6c0a`](https://github.com/doomemacs/doomemacs/commit/c21c6c0aa88a9391c6424ee55c3a9c04e8fb3ddf) refactor!(ruby): remove robe
* [`a7aa65ee`](https://github.com/doomemacs/doomemacs/commit/a7aa65eee432ae72abf850a4d308ee4bb936898e) bump: :ui doom
* [`d4d44f3a`](https://github.com/doomemacs/doomemacs/commit/d4d44f3aa071991f5355f8cf360857f095b5649d) bump: :emacs
* [`40b9ad7b`](https://github.com/doomemacs/doomemacs/commit/40b9ad7b7c5aa3d501f974088d44532cae6f0422) docs: remove link to blank issue in project readme
* [`01666572`](https://github.com/doomemacs/doomemacs/commit/01666572d7c342cde52a7a95087c322a3505057d) fix(lean): remove company-lean
* [`311ad23f`](https://github.com/doomemacs/doomemacs/commit/311ad23fd410f976f66c40f98e26aa7ee2dda8c3) fix: void-function (setf plist-get) error
* [`93ef81bf`](https://github.com/doomemacs/doomemacs/commit/93ef81bfd42187697e50281fb531d127c0acb888) fix: don't prompt to save non-file buffers
* [`373b7aa9`](https://github.com/doomemacs/doomemacs/commit/373b7aa97651ce0ea2ec6d9a314b4e76f78be4f4) fix: rename {b,e}ol functions to pos-{b,e}ol
* [`2bc05242`](https://github.com/doomemacs/doomemacs/commit/2bc052425ca45a41532be0648ebd976d1bd2e6c1) bump: :tools magit
