### PR TITLE
niv nixpkgs: update 88a55dff -> 867738f9

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "88a55dffa4d44d294c74c298daf75824dc0aafb5",
-        "sha256": "05cjwc8lfgk8pz9qyb3gl097bwxqzblahcjs0adp0kr0226kyjph",
+        "rev": "867738f9e61218e552398d2b9e2a4cddb88a5c4f",
+        "sha256": "1aycsks1ps4j8ga7s04w2yalas4ra5c4qapzsma4gdy9jy19mrrb",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/88a55dffa4d44d294c74c298daf75824dc0aafb5.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/867738f9e61218e552398d2b9e2a4cddb88a5c4f.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@88a55dff...867738f9](https://github.com/nixos/nixpkgs/compare/88a55dffa4d44d294c74c298daf75824dc0aafb5...867738f9e61218e552398d2b9e2a4cddb88a5c4f)

* [`cbac4e9b`](https://github.com/NixOS/nixpkgs/commit/cbac4e9b893a7aa06762905c1fd7acb4441720ea) nixos/grub: Remove `>` from submenu title, unbreak grub-reboot
* [`3e663c9e`](https://github.com/NixOS/nixpkgs/commit/3e663c9e90643e10c1bbcaf895233cbbe54925a2) maintainers: add huggy
* [`4d7a4fbd`](https://github.com/NixOS/nixpkgs/commit/4d7a4fbd9f634d0c2f1e660d3981e965b3513466) improve error handling flags to curl
* [`91103e7d`](https://github.com/NixOS/nixpkgs/commit/91103e7d7c7efe349834c44abf5d6f3e7496e4d7) nixos/perlless: disable NixOS documentation
* [`b43f31e5`](https://github.com/NixOS/nixpkgs/commit/b43f31e53ad9a5295e700ef7f5ccb759b3ecfd0f) nixos/nextcloud-notify_push: turn off keepalive_timeout, proxy_buffering
* [`4919e4cd`](https://github.com/NixOS/nixpkgs/commit/4919e4cd1c5d40e66697e8ecc5a21770e2d8add7) nixos/userborn: create passwordFilesLocation before userborn run if not /etc
* [`fdc1faed`](https://github.com/NixOS/nixpkgs/commit/fdc1faed2944c04a2ef39a3789738c5a53544ce1) conjure-tor: init at 0-unstable-2024-11-11
* [`f3da7ae5`](https://github.com/NixOS/nixpkgs/commit/f3da7ae5b8a5c4dbca404d0a8732faeee04b8722) clang-tidy-sarif: 0.6.6 -> 0.7.0
* [`74e9d007`](https://github.com/NixOS/nixpkgs/commit/74e9d007839867a3f4e052fd9629bde0d44baafd) jbig2enc: 0.29.0 -> 0.30.0
* [`8dffec1e`](https://github.com/NixOS/nixpkgs/commit/8dffec1ef809400df9bfce16c9ff14ea86899a9a) tesseract: remove explicit phases
* [`e2c6cba2`](https://github.com/NixOS/nixpkgs/commit/e2c6cba2e715d20608212c945516e1784f55941f) libxls: 1.6.2 -> 1.6.3
* [`91cab001`](https://github.com/NixOS/nixpkgs/commit/91cab001ddb32f19cef57c970bdee04bab564d7b) ut1999: replace gog source with original ISO from archive.org
* [`24b50ecb`](https://github.com/NixOS/nixpkgs/commit/24b50ecbc52d41be591d00ab082a2914d4227bde) add note about Epic Games permission to distribute the ISO
* [`2aaa8668`](https://github.com/NixOS/nixpkgs/commit/2aaa86686b547a8c4e74a5973fc55c58978968b7) purpur: 1.19.2r1763 -> 1.21.3r2358
* [`a2faa154`](https://github.com/NixOS/nixpkgs/commit/a2faa154b2d8f05ba4feca70b428a0c527e6382d) mp4fpsmod: init at 0.27
* [`2c522ade`](https://github.com/NixOS/nixpkgs/commit/2c522aded1e153fc32a1efe2a4d0f8f82d8c2bc4) linuxPackages.nvidia_x11_latest{,open}: alias to nvidiaPackages.latest
* [`289d2ed2`](https://github.com/NixOS/nixpkgs/commit/289d2ed27603ce3ff42718994fea2c7a8a166661) maintainers: add MasterEvarior
* [`5ecf371f`](https://github.com/NixOS/nixpkgs/commit/5ecf371f8dad1c87397a20fd89d51af29177dab1) flex-launcher: init at 2.2
* [`11d1b744`](https://github.com/NixOS/nixpkgs/commit/11d1b74488b0558a82d5d496ed387b83d33b2225) python312Packages.altair: disable flaky tests
* [`c7d4a8e2`](https://github.com/NixOS/nixpkgs/commit/c7d4a8e231555d22ce7d6347cdeb761ee638705f) maintainers: add vji
* [`d0bef132`](https://github.com/NixOS/nixpkgs/commit/d0bef1320c442abb6393688689eae431f006fd46) highlight: 4.14 -> 4.15
* [`0e3fb02a`](https://github.com/NixOS/nixpkgs/commit/0e3fb02a34258371d27e5804db57992e1d16df10) python3Packages.diffusers: 0.30.3 -> 0.31.0
* [`85b57d81`](https://github.com/NixOS/nixpkgs/commit/85b57d811631490d7b58bd4ceab0b1da30dd69f7) terraform-providers.gridscale: 1.27.0 -> 2.0.2
* [`5749d2bb`](https://github.com/NixOS/nixpkgs/commit/5749d2bb902f9e0237b2faced5105f37c56bae6b) element-call: add dist to output
* [`3ee5dbcd`](https://github.com/NixOS/nixpkgs/commit/3ee5dbcd66bd6c64c17eb167c111336459d2c8cb) parseable: init at 1.7.1
* [`6b9a7776`](https://github.com/NixOS/nixpkgs/commit/6b9a77767abaa07847b2353344ca9b07b2c3231a) nixos/azure: move image specific config out of azure-common
* [`0a0f6543`](https://github.com/NixOS/nixpkgs/commit/0a0f6543ad671e7435fdb131590a2d5bccd9140a) azure-image: set font & splashImage to null to force text mode, so console for Gen 2 VM could work
* [`538efe32`](https://github.com/NixOS/nixpkgs/commit/538efe32631b54a44b5eef7a829d9189abb32454) nixos/azure: improve documentation
* [`2249c085`](https://github.com/NixOS/nixpkgs/commit/2249c0859e81d94b4167d966a6e17ca23c9d8d7c) nixos/waagent: specify OS.OpensslPath by default
* [`d3d6adec`](https://github.com/NixOS/nixpkgs/commit/d3d6adec3691b85a548b9b563bba6a107474b144) waagent: fix typo
* [`c198f97a`](https://github.com/NixOS/nixpkgs/commit/c198f97a75a6c5461a0b20c886e3e672c7e1e29b) waagent: remove passthru.updateScript as it is not needed for nixpkgs-update
* [`6c443658`](https://github.com/NixOS/nixpkgs/commit/6c443658e6ed54bbe0ddb5f07dca91ca4db7ef8f) nixos/azure: improve code readability
* [`b5592e11`](https://github.com/NixOS/nixpkgs/commit/b5592e11652930dd8ce1ddcd91086967ec7b306b) nixos/azure: enable networking.useNetworkd
* [`181f1c08`](https://github.com/NixOS/nixpkgs/commit/181f1c08186a9841270cdf7f1818e7c7b98c13c1) dotenv-cli: 7.4.3 -> 8.0.0
* [`1121de4d`](https://github.com/NixOS/nixpkgs/commit/1121de4deaf326f5725e8bef325af6f11d6064c3) terraform-providers.scaleway: 2.48.0 -> 2.49.0
* [`a22671fa`](https://github.com/NixOS/nixpkgs/commit/a22671fab0d478c9e3fb61119a4ea659593efeb8) python312Packages.cffi: disable checks for pkgsLLVM build
* [`721c6ab2`](https://github.com/NixOS/nixpkgs/commit/721c6ab29e70fdc8a0e245ac6d11d712445bf876) python312Packages.json-stream: 2.3.2 -> 2.3.3
* [`1e9aeb9c`](https://github.com/NixOS/nixpkgs/commit/1e9aeb9c61037ba844ed026030ac12a8e1b7e50b) rerun: support web_viewer feature
* [`21b51135`](https://github.com/NixOS/nixpkgs/commit/21b5113509a4701926a229b1c7cd6b79d6b3ec47) workflows/eval: no maintainer reviews in draft mode
* [`8ab70837`](https://github.com/NixOS/nixpkgs/commit/8ab70837ff5b7406c9e57a5e81b22fc8d8b08330) git-lfs: 3.6.0 -> 3.6.1
* [`e7d2436e`](https://github.com/NixOS/nixpkgs/commit/e7d2436eeb0db5a7b427b943dfe2df001f39f221) systemd-netlogd: 1.4.3 -> 1.4.4
* [`69632d2b`](https://github.com/NixOS/nixpkgs/commit/69632d2b2968de7e3f3e20e726a70a6250ed3a23) systemd-netlogd: add version test
* [`6aacfc1b`](https://github.com/NixOS/nixpkgs/commit/6aacfc1bc9a1d3b76824fc54539e8ce74aad4f3c) lsp-plugins: 1.2.16 -> 1.2.20
* [`6f56a9ce`](https://github.com/NixOS/nixpkgs/commit/6f56a9ceee45a202eb6b9ef4438feafa4b1a123b) lsp-plugins: modernize
* [`aa112c87`](https://github.com/NixOS/nixpkgs/commit/aa112c87575509a4ec72bdbeea4e854eed5907da) lsp-plugins: migrate to by-name
* [`273dcbd9`](https://github.com/NixOS/nixpkgs/commit/273dcbd96f493b7b56177e5eb6cc0524c00791de) easyeffects: 7.1.9 -> 7.2.3
* [`5ce29df6`](https://github.com/NixOS/nixpkgs/commit/5ce29df66386f25f8946fc2fda543cb8c8fa04ae) recordbox: fix updateScript
* [`5b66268f`](https://github.com/NixOS/nixpkgs/commit/5b66268ff04e83c3e138c08a481fe148ac095b11) recordbox: 0.9.0 -> 0.9.2
* [`370ac8df`](https://github.com/NixOS/nixpkgs/commit/370ac8df3ec3bbd5321b27ad3e217ec7f203ab2b) nixos/guix: set proxy env vars for guix-daemon
* [`bcacbf28`](https://github.com/NixOS/nixpkgs/commit/bcacbf28c4b68dc377d915ec6719475ec1b7c7da) lunacy: 10.10 -> 10.11
* [`225dfc07`](https://github.com/NixOS/nixpkgs/commit/225dfc07511000ebfd7c70b2248b52f90468ebee) sleuthkit: enable on darwin
* [`3aadd305`](https://github.com/NixOS/nixpkgs/commit/3aadd30566e21de2e9ecf6e179a35be7ae5dab2f) makeBinaryWrapper: fix compiling with clang
* [`aa112238`](https://github.com/NixOS/nixpkgs/commit/aa112238de828de98ac8de59b3f3655e99ca63c6) gradle: fix cross builds
* [`d0db877f`](https://github.com/NixOS/nixpkgs/commit/d0db877f36a70b356e415763de3c22ba7ee8c9ee) maintainers: add mtpham99
* [`05542676`](https://github.com/NixOS/nixpkgs/commit/055426762bbaf8d3a950610f20b96314efb6880f) minizip-ng: fix darwin build
* [`e356d318`](https://github.com/NixOS/nixpkgs/commit/e356d3187c68516306baaee890308e246166e83b) nanobench: init at 4.3.11
* [`56589355`](https://github.com/NixOS/nixpkgs/commit/565893559c26748b059c7987b51d83503cd54ac0) uchmviewer: init at 8.4
* [`b8706b05`](https://github.com/NixOS/nixpkgs/commit/b8706b05875b427294f36d83eafd1edaa4c07475) sea-orm-cli: 1.1.3 -> 1.1.4
* [`a9c7c4c5`](https://github.com/NixOS/nixpkgs/commit/a9c7c4c52da181e7c66156c61b65c39f567efb41) gollum: 6.0.1 -> 6.1.0
* [`55400f8d`](https://github.com/NixOS/nixpkgs/commit/55400f8d3c63ad443fc434c578582bc15a5eaa89) deepsearch-glm: init at 1.0.0
* [`ee0eae58`](https://github.com/NixOS/nixpkgs/commit/ee0eae58c039cde0afd11a7a87e72772dd80629d) openvpn: fix sandboxed darwin build
* [`cb91cf6f`](https://github.com/NixOS/nixpkgs/commit/cb91cf6f4e95f6a35a14a0875a340d5e7f1b8271) tree-sitter-grammars.tree-sitter-tera: init
* [`5860af2f`](https://github.com/NixOS/nixpkgs/commit/5860af2f68b2d318ae3b12bf6a9f39a784e5aea0) maintainer: add arexon
* [`39c15b35`](https://github.com/NixOS/nixpkgs/commit/39c15b35c591b5e9e1b6cebb9a13db78d81b8d4a) mbrola: 3.3 -> 3.3-unstable-2024-01-29
* [`e48e51ee`](https://github.com/NixOS/nixpkgs/commit/e48e51ee81b3d359a61b9835a75eaa84f6332596) regolith: init at 1.5.1
* [`d0c25349`](https://github.com/NixOS/nixpkgs/commit/d0c25349a983a6bf4acd8ea2ed9cb51d5104524f) emacsPackages.el-easydraw: 1.2.0-unstable-2025-01-06 -> 1.2.0-unstable-2025-01-16
* [`6641525d`](https://github.com/NixOS/nixpkgs/commit/6641525d8b66c03fb9d210e139af31ee11b9c9eb) lldap-cli: 0-unstable-2024-02-24 -> 0-unstable-2024-11-11
* [`5c2a4073`](https://github.com/NixOS/nixpkgs/commit/5c2a4073f532fc91fc5121eac6ff00fd7118804d) distrobox: 1.8.0 -> 1.8.1
* [`df6cd8a7`](https://github.com/NixOS/nixpkgs/commit/df6cd8a78e1fc060474b65262a51cc76f44dd6ad) terraform-providers.aiven: 4.31.1 -> 4.33.0
* [`d8e490f5`](https://github.com/NixOS/nixpkgs/commit/d8e490f5af7a96de358830ae98433b0a69bbff8a) dhcpm: init at 0.2.3
* [`d962c9f9`](https://github.com/NixOS/nixpkgs/commit/d962c9f9275d912c3b6fe682458f3167613ea22f) terraform-providers.migadu: 2024.12.26 -> 2025.1.16
* [`2b456e47`](https://github.com/NixOS/nixpkgs/commit/2b456e47238ca94ea00fa5707bc1eb75d118bcf8) terraform-providers.opentelekomcloud: 1.36.28 -> 1.36.29
* [`3beb501f`](https://github.com/NixOS/nixpkgs/commit/3beb501f4a54ed0c3956e89b0758e3f06a7e32c5) terraform-providers.datadog: 3.50.0 -> 3.52.1
* [`189200a1`](https://github.com/NixOS/nixpkgs/commit/189200a18d14b7be31eebee7fe82399456b7aaa3) nixos/tests: add boot-stage2 tests
* [`2f3a80c9`](https://github.com/NixOS/nixpkgs/commit/2f3a80c96f694fea70e0d501fb8a17dd25c81ccb) stage-2-init: fix false positives for RO Nix store mounts
* [`8ed4f7b5`](https://github.com/NixOS/nixpkgs/commit/8ed4f7b5a62b2e41606eb66b4c5f6d142f46370b) workflows/labels: add a `sync-labels: false` step, migrate some rules
* [`15b3e2d0`](https://github.com/NixOS/nixpkgs/commit/15b3e2d0fed93b8659fc2f05003cc1ecebe5c7a6) .github/labeler-no-sync.yml: automatically add backport label for PRs touching `ci/`
* [`17a9ec6c`](https://github.com/NixOS/nixpkgs/commit/17a9ec6ca28b8b9905c8df328ac6983005925051) pythonPackages.pycapnp: 1.1.0 -> 2.0.0
* [`ba542a01`](https://github.com/NixOS/nixpkgs/commit/ba542a018e441172ea3abc45b1bf2e8a4f66bfb2) oxipng: re-enable tests
* [`1f7b32cc`](https://github.com/NixOS/nixpkgs/commit/1f7b32cce34e4302aaf078e3785719cb495daf5f) vpnc: unstable-2021-11-04 -> unstable-2024-12-20
* [`ba509e58`](https://github.com/NixOS/nixpkgs/commit/ba509e583a9c3d77d54fe8c430de37e11f045d5a) libpostal: fix build with GCC14
* [`7f5e8c93`](https://github.com/NixOS/nixpkgs/commit/7f5e8c93019c850cfd0f70e130323bc7c5d96001) jellyseerr: 2.2.3 -> 2.3.0
* [`81186b50`](https://github.com/NixOS/nixpkgs/commit/81186b50bf3d159398b0a37d12774e7681d9754c) jellyseerr: update conventions
* [`4fb87126`](https://github.com/NixOS/nixpkgs/commit/4fb8712629ca552ab696da28a16b9d7c7c5c3b4b) buf: 1.49.0 -> 1.50.0
* [`b5a03db8`](https://github.com/NixOS/nixpkgs/commit/b5a03db80725b5f798468f9badbac6dbf5da7f8a) waagent: patch openssl path
* [`d1f4d27b`](https://github.com/NixOS/nixpkgs/commit/d1f4d27b335d25163ccca61331e6d26d04fd4fa7) nixos/calibre-web: restore compatibility with old dataDir values
* [`8f91cddf`](https://github.com/NixOS/nixpkgs/commit/8f91cddf511eb25370738bfbf6a7e2b48084f267) xe: modernize
* [`edc39f12`](https://github.com/NixOS/nixpkgs/commit/edc39f12c5883c49bf44878c9e846676a5c478c9) xe: add maintainer pbsds
* [`5c583290`](https://github.com/NixOS/nixpkgs/commit/5c583290655ba8ccbe67dc6b9583bde1c2fba51c) plumed: 2.9.2 -> 2.9.3
* [`0be1c4a9`](https://github.com/NixOS/nixpkgs/commit/0be1c4a91b883367b9e2659a2172b5761f7e3296) nodejs_20: 20.18.1 -> 20.18.2
* [`ece1ffd8`](https://github.com/NixOS/nixpkgs/commit/ece1ffd894d994d79dacc50cd872787d72933d7f) fourmolu: init at 0.14.0.0
* [`562406b6`](https://github.com/NixOS/nixpkgs/commit/562406b68484c9798ac46fce81b3a7b43ec9420f) dotnet: set sandbox profile in source-built sdk/runtime
* [`3afb9cfa`](https://github.com/NixOS/nixpkgs/commit/3afb9cfa7d9a3ce10b7f279c749fcafd715a953a) dotnet: make native binaries executable in packages
* [`77dd43a1`](https://github.com/NixOS/nixpkgs/commit/77dd43a1e2da5494b28c6dd5da32a188886b68fe) dotnet/wrapper: add ready-to-run sdk test
* [`691f0c0f`](https://github.com/NixOS/nixpkgs/commit/691f0c0f0af67bae33eb57829664d0f8a6ce43aa) dotnetCorePackages.dotnet_{8,9}.vmr: mark broken on x86_64-darwin
* [`19542fb4`](https://github.com/NixOS/nixpkgs/commit/19542fb4f7cb653963dd1977219cd2cad9dca58a) gitlab: 17.7.1 -> 17.8.0
* [`94431037`](https://github.com/NixOS/nixpkgs/commit/94431037e1e50581b2251f51ab58518ab985c604) gitkraken: remove inactive maintainers
* [`3d0eeff1`](https://github.com/NixOS/nixpkgs/commit/3d0eeff147d13807a2e2f680d004df7e479be332) python313Packages.dlinfo: 1.2.1 -> 2.0.0
* [`68ca2d01`](https://github.com/NixOS/nixpkgs/commit/68ca2d019ac60b7c23bbf9ce752931d52332bca2) ansible-navigator: 24.12.0 -> 25.1.0
* [`d68b25f4`](https://github.com/NixOS/nixpkgs/commit/d68b25f43b3baa09c5253c2d5f87d3bb3708c7f5) mitra: 3.13.1 -> 3.14.0
* [`09f13162`](https://github.com/NixOS/nixpkgs/commit/09f13162ced91855a57f3df6b7a8611acaa82141) parallel: 20241222 -> 20250122
* [`8de6f7a8`](https://github.com/NixOS/nixpkgs/commit/8de6f7a8a9fad2d4ca40db678e8ca784c698c62b) nixVersions.nix_2_24: 2.24.11 -> 2.24.12
* [`94efb461`](https://github.com/NixOS/nixpkgs/commit/94efb4613c87f42337d96cad1771637d8edfb21a) nixos/nix-fallback-paths: 2.24.11 -> 2.24.12
* [`50610df9`](https://github.com/NixOS/nixpkgs/commit/50610df9b7bb9cf707972261520464f2a49a056f) nixVersions.nix_2_25: 2.25.4 -> 2.25.5
* [`d9b701bc`](https://github.com/NixOS/nixpkgs/commit/d9b701bca34d298277163c6183d65905a74558c9) packer: 1.11.2 -> 1.12.0
* [`49a28694`](https://github.com/NixOS/nixpkgs/commit/49a28694b75b9c2600ffd4e94a04cb26ffd74dce) miracle-wm: 0.4.0 -> 0.4.1
* [`53553b3c`](https://github.com/NixOS/nixpkgs/commit/53553b3cd71bbcbe224b6451cf03fd98e993ced2) python313Packages.whey: follow contributing guidelines
* [`a0059ad8`](https://github.com/NixOS/nixpkgs/commit/a0059ad85216503244ee58e07f92796efa6e7ab0) python313Packages.whey-pth: follow contributing guidelines
* [`3b863ac0`](https://github.com/NixOS/nixpkgs/commit/3b863ac0e19cc305789d169ebb0f451136e3159a) ols: do not set -microarch:native
* [`a370b2c8`](https://github.com/NixOS/nixpkgs/commit/a370b2c86fa5c808a57323e3b63a4e022b15670b) bun: 1.1.43 -> 1.2.0
* [`9c454953`](https://github.com/NixOS/nixpkgs/commit/9c4549534bb868c5bc4e613f0467c1d857faa7fc) docker: 27.5.0 -> 27.5.1
* [`1e4b1317`](https://github.com/NixOS/nixpkgs/commit/1e4b1317973170dfec0e6fc010e1528ba6120acb) maintainers: add bashsu
* [`1d049a42`](https://github.com/NixOS/nixpkgs/commit/1d049a42f1d28a983cf1a408677b4f3f442d0e4f) ipbus-uhal: init at 2.8.16
* [`389fedd8`](https://github.com/NixOS/nixpkgs/commit/389fedd879b8d767a55afe4e3014814c57e5679a) python312Packages.llm: 0.19.1 -> 0.20
* [`3fcbbcf4`](https://github.com/NixOS/nixpkgs/commit/3fcbbcf40473429cd33b0b95c8ea08ce97d83e82) notion-app: 4.2.0 -> 4.3.0
* [`14d92af6`](https://github.com/NixOS/nixpkgs/commit/14d92af69e0aa8e0cedaa0bcf61899150c371f00) virtualbox: 7.1.4 -> 7.1.6a
* [`4fd304c5`](https://github.com/NixOS/nixpkgs/commit/4fd304c580d3704b4f3a9955b354148b4f1d73b1) screen: 4.9.1 -> 5.0.0
* [`1a7820b2`](https://github.com/NixOS/nixpkgs/commit/1a7820b227be5a2595f67c6eb0485e65ea798651) pds: init at 0.4.74
* [`a0bc52cf`](https://github.com/NixOS/nixpkgs/commit/a0bc52cfa9adcbfb7f7cb75fd9048d757929a5e5) pdsadmin: init at 0.4.74
* [`6091da47`](https://github.com/NixOS/nixpkgs/commit/6091da47e56b3fabed1e19488524adc356c427e1) nixos/pds: init module
* [`6d0241eb`](https://github.com/NixOS/nixpkgs/commit/6d0241ebb0d98e9562554b66be10c893fb269bfb) pds: add NixOS test
* [`87b73658`](https://github.com/NixOS/nixpkgs/commit/87b736585afc6011683b31d6d5cd927761e3bf74) harper: 0.16.0 -> 0.17.0
* [`13a1b39d`](https://github.com/NixOS/nixpkgs/commit/13a1b39da68b9881bb24412f66968a151bf9f1b7) netrw: Fix including {stdlib,stdio,string}.h
* [`e22dd4d3`](https://github.com/NixOS/nixpkgs/commit/e22dd4d3165d5eb9f8a16208ea86fa11e183a9df) enlightenment.efl: 1.27.0 -> 1.28.0
* [`b199b4c9`](https://github.com/NixOS/nixpkgs/commit/b199b4c997a0a9f5d453be8bed6556d339012129) enlightenment.enlightenment: 0.26.0 -> 0.27.0
* [`814e95f1`](https://github.com/NixOS/nixpkgs/commit/814e95f1f5902a4eb513b2a13d8797a884a19f5c) mysql80: 8.0.40 -> 8.0.41
* [`a60170ab`](https://github.com/NixOS/nixpkgs/commit/a60170ab043a71919758155d8066e59f486759c5) mysql84: 8.4.3 -> 8.4.4
* [`7a095000`](https://github.com/NixOS/nixpkgs/commit/7a095000f2b074715117b676d1d5e40718c6afc0) mmex: 1.8.0 -> 1.8.1
* [`0fbb0557`](https://github.com/NixOS/nixpkgs/commit/0fbb055729fe507aebd71716e9f30632e8a65fef) db-rest: 6.0.5 -> 6.0.6
* [`7386ced3`](https://github.com/NixOS/nixpkgs/commit/7386ced30152caf6982562acf6d125c5984a0340) winePackages.{stable,unstable,staging,wayland}: * -> 10.0
* [`b93f6247`](https://github.com/NixOS/nixpkgs/commit/b93f6247337b311a9072e7e6f37e0b58d4cadab7) bitwarden-directory-connector: 2024.10.0 -> 2025.1.0
* [`5b381194`](https://github.com/NixOS/nixpkgs/commit/5b3811944d78f987779772fd866defe13c3af390) dune_3: 3.17.1 -> 3.17.2
* [`41ae5429`](https://github.com/NixOS/nixpkgs/commit/41ae5429cf1668b93c1c61edf56c8aab54ed8081) brave: 1.74.48 -> 1.74.50
* [`a074fbe8`](https://github.com/NixOS/nixpkgs/commit/a074fbe8729b77ea1d4a841fe35b910923e52e60) jdt-language-server: 1.43.0 -> 1.44.0
* [`cfd91265`](https://github.com/NixOS/nixpkgs/commit/cfd91265a6ee9c94a90e03fc30de4c8a091453e9) tre: fix cross build
* [`d91e1d5b`](https://github.com/NixOS/nixpkgs/commit/d91e1d5b9a660213d97668ed7f39e42c20e8fae5) coroot-node-agent: 1.23.3 -> 1.23.6
* [`17c37a6f`](https://github.com/NixOS/nixpkgs/commit/17c37a6fd6bf6ed83399809971d1974181568bb3) gdlauncher-carbon: 2.0.20 -> 2.0.22
* [`ab224822`](https://github.com/NixOS/nixpkgs/commit/ab224822391f803e3b58c65f753162361e769075) factorio, factorio-experimental: 2.0.28 -> 2.0.32
* [`da83b17f`](https://github.com/NixOS/nixpkgs/commit/da83b17f8bbb9ad80056ba3fca0e266d8682cf0f) rerun: add nasm feature
* [`4d0503e2`](https://github.com/NixOS/nixpkgs/commit/4d0503e2af4219a0d5517462fcf15732d1cbc220) rerun: move wasm app build to `preBuild` hook instead of `configurePhase`
* [`ff2495ce`](https://github.com/NixOS/nixpkgs/commit/ff2495ce6df5abc2e22c056b5a189e95c6125add) percona-xtrabackup: 8.0.35-31 -> 8.0.35-32
* [`e6a29549`](https://github.com/NixOS/nixpkgs/commit/e6a295495d974587b7afbdcedcaa2fa6fdba8fd6) SDL_ttf: mark insecure
* [`00130be6`](https://github.com/NixOS/nixpkgs/commit/00130be6fd3dfdc1715f64293251b7837d8c4688) appimageTools: drop SDL1 from fhs environment
* [`d6a757bb`](https://github.com/NixOS/nixpkgs/commit/d6a757bb01b6eaa28ee5fb100b7d9fd2bc29c3f2) buildPython*: prioritize user-specified passthru attrs
* [`617bc744`](https://github.com/NixOS/nixpkgs/commit/617bc74413bb92c9b06446e78da1b7897a64885b) buildPython*: move the format'-related assertion down to its value
* [`cbd527c8`](https://github.com/NixOS/nixpkgs/commit/cbd527c8adbf01920250a8e2681ae93eaa7dd5d4) buildPython*: use finalAttrs.finalPackage for passthru attribute values
* [`64aa1fa0`](https://github.com/NixOS/nixpkgs/commit/64aa1fa04ce8d287ba3619526c21121d2fa83271) proxsuite-nlp: 0.10.0 -> 0.10.1
* [`3deb5dc8`](https://github.com/NixOS/nixpkgs/commit/3deb5dc895973b62d7ee1f675e5969b19f7b2c98) github-runner: 2.321.0 -> 2.322.0
* [`fa4fc332`](https://github.com/NixOS/nixpkgs/commit/fa4fc3321e2361f973f7a3949105374e6e829bb9) lxqt.lxqt-panel: 2.1.3 -> 2.1.4
* [`ebdff461`](https://github.com/NixOS/nixpkgs/commit/ebdff4610caeaeac7e1aa408c438f2d288aac3a3) python312Packages.pythonqwt: 0.14.2 -> 0.14.4
* [`7327b47e`](https://github.com/NixOS/nixpkgs/commit/7327b47e938f9ce5d16a9166c7b80c78b70ced1d) moralerspace: init at 1.1.0
* [`2d5c9fa7`](https://github.com/NixOS/nixpkgs/commit/2d5c9fa7ff7ea4c6eae219ae38457a8e571c466e) moralerspace-hw: init at 1.1.0
* [`de2e4df8`](https://github.com/NixOS/nixpkgs/commit/de2e4df834474c30aa05a75e91d2d7914add62b1) moralerspace-hwjpdoc: init at 1.1.0
* [`b91152ca`](https://github.com/NixOS/nixpkgs/commit/b91152caf299987a47b2034ea71eb3fbbb707a4d) moralerspace-hwnf: init at 1.1.0
* [`4f28426f`](https://github.com/NixOS/nixpkgs/commit/4f28426f5e4ff1ebe6f660f0d38650f7dc083572) moralerspace-jpdoc: init at 1.1.0
* [`3ce3d3c8`](https://github.com/NixOS/nixpkgs/commit/3ce3d3c86267002444752660da33e2fbd5e5ca07) moralerspace-nf: init at 1.1.0
* [`5542e504`](https://github.com/NixOS/nixpkgs/commit/5542e5046e8177500b04431591b2f4f1e9124980) uclibc-ng: 1.0.50 -> 1.0.51
* [`aed9c00b`](https://github.com/NixOS/nixpkgs/commit/aed9c00b67e81cdb19222639454bf81af0ca54fb) python312Packages.cyclopts: 3.3.0 -> 3.3.1
* [`e2288917`](https://github.com/NixOS/nixpkgs/commit/e22889171fe4b6cf0ec120286972e5e902217ced) mumble: 1.5.634 -> 1.5.735
* [`b0fc09c0`](https://github.com/NixOS/nixpkgs/commit/b0fc09c000ab828c792b67b48a7f7afb00b7913a) byedpi: 0.15 -> 0.16
* [`3c843ae5`](https://github.com/NixOS/nixpkgs/commit/3c843ae5179da90ea9e8b901ec2450a74081abd1) libloot: useFetchCargoVendor
* [`0124dd08`](https://github.com/NixOS/nixpkgs/commit/0124dd08d8b574e3de79b4548018573ec0b046aa) adguardhome: 0.107.55 -> 0.107.56
* [`c80e3b8f`](https://github.com/NixOS/nixpkgs/commit/c80e3b8fa40104bcd63b4ac1627e41ae497506e0) python313Packages.rocketchat-api: 1.34.0 -> 1.35.0
* [`e573e232`](https://github.com/NixOS/nixpkgs/commit/e573e232ff92d342556d13596cbafa415177becf) maintainers: add EstebanMacanek
* [`4cf578c5`](https://github.com/NixOS/nixpkgs/commit/4cf578c57bc18b6edb1ac1b79c2cc5b2b6518a23) git-cliff: 2.7.0 -> 2.8.0
* [`3792c41d`](https://github.com/NixOS/nixpkgs/commit/3792c41da804209b4f3fb0eff400d83decae0b83) python3Packages.manga-ocr: 0.1.13 -> 0.1.14
* [`3adc86b8`](https://github.com/NixOS/nixpkgs/commit/3adc86b87d1cde8e1d7e0a927019456283769aa0) lomiri.morph-browser: 1.1.1 -> 1.1.2
* [`7d27803a`](https://github.com/NixOS/nixpkgs/commit/7d27803a689d6e664f7e350d21cbf2ae705baf46) lomiri.lomiri-ui-toolkit: Mark tst_slotslayout.13.qml borked
* [`57739b2e`](https://github.com/NixOS/nixpkgs/commit/57739b2ee0b29d233f3e04a060d6674d9070d024) amazon-cloudwatch-agent: 1.300051.0 -> 1.300052.0
* [`20775195`](https://github.com/NixOS/nixpkgs/commit/20775195500f784d1f2b6a5945e166446769acf0) vmpk: move to pkgs/by-name
* [`f7f9e973`](https://github.com/NixOS/nixpkgs/commit/f7f9e973fd3356fc8eb110090155e46585136bfe) vmpk: 0.8.8 -> 0.9.1
* [`0825d5fb`](https://github.com/NixOS/nixpkgs/commit/0825d5fba1064a252d97edd6f30a7802ade3c543) pnpm_10.fetchDeps: fix reproducibility
* [`cbf92309`](https://github.com/NixOS/nixpkgs/commit/cbf92309a90dc0b7cdff8810277853f66bb46a69) pax-rs: remove
* [`ab24e87a`](https://github.com/NixOS/nixpkgs/commit/ab24e87aa87dabb5abbbc0ba57a80a07ae6566dc) timelens: remove
* [`c6b2a26f`](https://github.com/NixOS/nixpkgs/commit/c6b2a26f28fa61b429a6e498eba9aa92765eec02) fwts: reformat with nixfmt
* [`f3785b42`](https://github.com/NixOS/nixpkgs/commit/f3785b42e8ee7dc6e9a9bcced86d13188c4fbfc4) fwts: refactor
* [`e2a5fad6`](https://github.com/NixOS/nixpkgs/commit/e2a5fad6673e76c26b4a1946bad066df8350860c) yabasic: 2.90.5 -> 2.91.0
* [`ebda6e8a`](https://github.com/NixOS/nixpkgs/commit/ebda6e8a125392fec8f90f358c82e0bbb553cde9) toybox: 0.8.11 -> 0.8.12
* [`d9e07d80`](https://github.com/NixOS/nixpkgs/commit/d9e07d80e174822ba115d44e43175e2207f455ef) networkmanager-l2tp: fix cross compilation
* [`9d1a41f6`](https://github.com/NixOS/nixpkgs/commit/9d1a41f61c8c9765ac6fc0f8b7d45f7eafb17ada) networkmanager-sstp: fix cross compilation
* [`83d20f41`](https://github.com/NixOS/nixpkgs/commit/83d20f415b183013a9fbcda726fcb1939f08a720) networkmanager-openvpn: fix cross compilation
* [`6ff2f955`](https://github.com/NixOS/nixpkgs/commit/6ff2f9550f551ee9a27715982a06c552a18a9115) networkmanager-openconnect: fix cross compilation
* [`6835eb27`](https://github.com/NixOS/nixpkgs/commit/6835eb27d5ba1c36a01179ee11ae36969656c88b) naabu: 2.3.3 -> 2.3.4
* [`e99b9eb8`](https://github.com/NixOS/nixpkgs/commit/e99b9eb8b31bd6b8ade67609c2eb7ec8ea71eb29) grafana-kiosk: 1.0.8 -> 1.0.9
* [`4b76da72`](https://github.com/NixOS/nixpkgs/commit/4b76da72ff10ea86a1ee44dcc4db98b4a26e2f8c) photoqt: 4.7 -> 4.8
* [`d0488230`](https://github.com/NixOS/nixpkgs/commit/d0488230df51980b5617db6e10e5b6f84c9afbc1) stella: 7.0b -> 7.0c
* [`fd4c02e6`](https://github.com/NixOS/nixpkgs/commit/fd4c02e6d99f2dcb49a9a7cd946bca7d23a1e8b3) gh-gei: 1.11.0 -> 1.12.0
* [`2fa8d3cc`](https://github.com/NixOS/nixpkgs/commit/2fa8d3ccf9efb131deda5d6531d5917050c9a763) python312Packages.plotpy: 2.6.3 -> 2.7.1
* [`01c4268e`](https://github.com/NixOS/nixpkgs/commit/01c4268ee218db48014707f828ce1277638aeca8) jruby: 9.4.9.0 -> 9.4.10.0
* [`ae02b6ea`](https://github.com/NixOS/nixpkgs/commit/ae02b6eae86f264a5abd24c41187036057c596cc) amnezia-vpn: 4.8.2.3 -> 4.8.3.1
* [`a1823898`](https://github.com/NixOS/nixpkgs/commit/a18238984e9f667a3491e7e88477d13aafc8b10f) python313Packages.moto: fix typo
* [`3045853c`](https://github.com/NixOS/nixpkgs/commit/3045853cb07f039c9ad9bfa0c7461f18426fd3c1) fwts: unpin gnumake42
* [`23569f5a`](https://github.com/NixOS/nixpkgs/commit/23569f5a30f44d1b69d8b006d11eb53cbfe33844) flatcam: drop
* [`11b32d1e`](https://github.com/NixOS/nixpkgs/commit/11b32d1ef3e55566bd0e9360c9dab5d00c75b9ef) cpuinfo: 0-unstable-2024-12-09 -> 0-unstable-2025-01-10
* [`ed91d70e`](https://github.com/NixOS/nixpkgs/commit/ed91d70e7bd5de901a3fd487179222675f786ee5) plasma5Packages.kdev-python: use current python3
* [`6918e71b`](https://github.com/NixOS/nixpkgs/commit/6918e71b3e97e56cdd2cb7d911de65e962e960c4) sedutil: add meta.mainProgram
* [`9f8f0531`](https://github.com/NixOS/nixpkgs/commit/9f8f053137668e607a15930d0db1a3d827ec93d5) julia_110-bin: 1.10.4 -> 1.10.7
* [`d9fa300f`](https://github.com/NixOS/nixpkgs/commit/d9fa300f8be0455d4fa4d5afaf0577593561a062) julia_110: 1.10.4 -> 1.10.7
* [`79f1080f`](https://github.com/NixOS/nixpkgs/commit/79f1080f280cfd4ace4ff698652173fcb54916a5) julia_110-bin: 1.10.7 -> 1.10.8
* [`c8062335`](https://github.com/NixOS/nixpkgs/commit/c806233552497c41cd4010f4820a31eccfc1ac40) julia_110: 1.10.7 -> 1.10.8
* [`237c8688`](https://github.com/NixOS/nixpkgs/commit/237c868837e6a57e378b9f07630385194fb93c79) julia_110: revert upstream commit breaking build
* [`bfc192c1`](https://github.com/NixOS/nixpkgs/commit/bfc192c114e38051fc20a5563f677438287a1919) poedit: move to pkgs/by-name
* [`91e51121`](https://github.com/NixOS/nixpkgs/commit/91e5112184970e5b452da2b38a75582a7a54de68) poedit: 3.4.4 -> 3.5.2
* [`0c9b6b37`](https://github.com/NixOS/nixpkgs/commit/0c9b6b37cc510e768088b5a73852e0246d8069cb) mediamtx: 1.11.1 -> 1.11.2
* [`551ffeca`](https://github.com/NixOS/nixpkgs/commit/551ffeca1785ae80638f3d1eb845078da9f15547) mattermostLatest: 10.4.1 -> 10.4.2
* [`a2247e78`](https://github.com/NixOS/nixpkgs/commit/a2247e78d5dda1ac0f1f5840d58f84b26395e84f) lpac: init at 2.2.1
* [`5ddb1465`](https://github.com/NixOS/nixpkgs/commit/5ddb146554ec5f0f2abec9efe6ec9a787bdb26bf) apt: 2.9.18 -> 2.9.21
* [`a4c008fc`](https://github.com/NixOS/nixpkgs/commit/a4c008fc9ec46324a36a6897dbfb2aad26606e2e) apt: 2.9.21 -> 2.9.25
* [`c961b3c2`](https://github.com/NixOS/nixpkgs/commit/c961b3c26cd299eab762b3b13a4bb3f6ec6b1c01) golden-cheetah: update to qt6, add darwin
* [`4c249aaf`](https://github.com/NixOS/nixpkgs/commit/4c249aafbf2bf305b38d85da01881a1c5a1cee75) boost: fix cross build if enablePython
* [`0819c6f2`](https://github.com/NixOS/nixpkgs/commit/0819c6f293470e0297de870da1fda81e38a4c3d1) unityhub: 3.10.0 -> 3.11.0
* [`3aba73a2`](https://github.com/NixOS/nixpkgs/commit/3aba73a291a923c7aa0d78ca9f4f1e221030b8ec) vpnc: support cross compilation
* [`6d668a97`](https://github.com/NixOS/nixpkgs/commit/6d668a9717af70c0bc95cb062da24be7d5c4e54f) networkmanager-vpnc: fix cross compilation
* [`fb5d5c81`](https://github.com/NixOS/nixpkgs/commit/fb5d5c81ea09871c2dd6fddc4052bf0748880068)  libtirpc: fix undefined reference in version script with llvm bintools
* [`4518a0d7`](https://github.com/NixOS/nixpkgs/commit/4518a0d7ff60e0a2a4b590f782bfd2daa597436a) gnome-bluetooth_1_0: fix cross compilation
* [`41198d5f`](https://github.com/NixOS/nixpkgs/commit/41198d5f4a53bd18f574805710ec053fb3c5e70b) tootik: 0.15.0 -> 0.15.1
* [`3bdb1ca6`](https://github.com/NixOS/nixpkgs/commit/3bdb1ca6ba7e368c8db1b846d85819e899cc17f2) flashrom: fix building with clang
* [`5926d582`](https://github.com/NixOS/nixpkgs/commit/5926d5826fbaacae269585d510df88794d054af2) blueberry: use substituteInPlace --replace-fail instead of deprecated --replace
* [`6ed902f1`](https://github.com/NixOS/nixpkgs/commit/6ed902f18cfcc9faa580e11172a5e6d9e9571497) blueberry: use `python3.buildPythonApplication` instead of manual wrapping
* [`f7ae72b6`](https://github.com/NixOS/nixpkgs/commit/f7ae72b6cc5aae4f88b678a1372d9a58d8414c50) terraform-providers.baiducloud: 1.21.10 -> 1.21.12
* [`73a34ab5`](https://github.com/NixOS/nixpkgs/commit/73a34ab5aa5d347a57b101bc8e30c7266d1d4b84) terraform-providers.okta: 4.12.0 -> 4.13.1
* [`b957e464`](https://github.com/NixOS/nixpkgs/commit/b957e464407cae9db6fe65d9d17b90e0e8ba764d) python312Packages.icalendar: 6.1.0 -> 6.1.1
* [`f5944a9f`](https://github.com/NixOS/nixpkgs/commit/f5944a9fc7db15113747f4ee92cac51b0c05c859) git-credential-manager: 2.6.0 -> 2.6.1
* [`bd1a0ee7`](https://github.com/NixOS/nixpkgs/commit/bd1a0ee7920971b0b6113bd3cc53f8a8dd54c8ac) tpm2-openssl: 1.2.0 -> 1.3.0
* [`53c5798e`](https://github.com/NixOS/nixpkgs/commit/53c5798ee958876d41606d2db9b86a69f725a8aa) python313Packages.ete3: fix build
* [`b3fb6bc2`](https://github.com/NixOS/nixpkgs/commit/b3fb6bc28b674786af06682d28f8ed5128a8343f) chirpstack-rest-api: 4.10.2 -> 4.11.0
* [`987ccd53`](https://github.com/NixOS/nixpkgs/commit/987ccd5387f61ffcf3cf9ad19b4545d03b21a966) python312Packages.altair: 5.4.1 -> 5.5.0
* [`29b2f8e3`](https://github.com/NixOS/nixpkgs/commit/29b2f8e32a919b314f737213517d3fb105cf784c) rerun: overwritable buildWebViewerFeatures without `analytics`
* [`ed0cd3b1`](https://github.com/NixOS/nixpkgs/commit/ed0cd3b127452046075a7b5262a7c91bf58e00b7) checkov: 3.2.355 -> 3.2.357
* [`ad0ec024`](https://github.com/NixOS/nixpkgs/commit/ad0ec0244c7058ea52882fc107aa9f96bcfe93de) katawa-shoujo-re-engineered: 1.4.9 -> 2.0.0
* [`3d713dce`](https://github.com/NixOS/nixpkgs/commit/3d713dce977f2907c626f0eb78ad670107042b08) python3Packages.elevenlabs: 1.9.0 -> 1.50.5
* [`982d4b54`](https://github.com/NixOS/nixpkgs/commit/982d4b545cb26449a9b5330226690a923bb3ee5b) davinci-resolve-studio: 19.1.2 -> 19.1.3
* [`72236ea2`](https://github.com/NixOS/nixpkgs/commit/72236ea284168ef5d3f79ded41a2d187b3aeef10) aerc: refactor
* [`34729d13`](https://github.com/NixOS/nixpkgs/commit/34729d135fdf1df3dd32d5127dd1603223613271) terraform-providers.buildkite: 1.15.2 -> 1.15.5
* [`1612db3c`](https://github.com/NixOS/nixpkgs/commit/1612db3c80286cfe09c0a5572a272df12c65d33a) ergochat: 2.14.0 -> 2.15.0
* [`18493e29`](https://github.com/NixOS/nixpkgs/commit/18493e297be88b6c3f8888c7a9dedc75cd69414b) slurm-spank-x11: fix build with gcc-14
* [`f13bfcae`](https://github.com/NixOS/nixpkgs/commit/f13bfcaeef13bd3f277e89a2c5a9e2ece8ef70e2) ansible-later: 3.3.1 -> 4.0.8
* [`9bb655a2`](https://github.com/NixOS/nixpkgs/commit/9bb655a235e9d374f442c7a1a3551054df37ca39) python3Packages.datafusion: fetchCargoTarball -> fetchCargoVendor
* [`aa3c1afa`](https://github.com/NixOS/nixpkgs/commit/aa3c1afabf9dd445d3f1884e3525c55040b5e476) python3Packages.typst: fetchCargoTarball -> fetchCargoVendor
* [`f3e22706`](https://github.com/NixOS/nixpkgs/commit/f3e2270660940b07aa378d1a6c56adf70957b288) clickhouse: fetchCargoTarball -> fetchCargoVendor
* [`8965df85`](https://github.com/NixOS/nixpkgs/commit/8965df8599001dcbbb737443a793d1a859706dee) librespot: useFetchCargoVendor
* [`c93dd741`](https://github.com/NixOS/nixpkgs/commit/c93dd741e1f6ad9a216d4e780dedb09a8fcb21db) mieru: 3.11.0 -> 3.11.1
* [`edb5006d`](https://github.com/NixOS/nixpkgs/commit/edb5006db95e7dcac2491a753e5e061053a9f4d5) jetbrains: useFetchCargoVendor
* [`e4531713`](https://github.com/NixOS/nixpkgs/commit/e45317132ed0e9b536b74b614352ac81bde4fbf3) microsoft-edge: 131.0.2903.112 -> 132.0.2957.127
* [`4762d9ba`](https://github.com/NixOS/nixpkgs/commit/4762d9ba6e8c623932dbecad224351bf8d092ea7) doc: emphasize trade-off between versionCheckHook and testers.testVersion
* [`1c6126f7`](https://github.com/NixOS/nixpkgs/commit/1c6126f7091988a345684098d0d21940e0e1a92e) various: replace substituteAll with replaceVars
* [`479ec7c3`](https://github.com/NixOS/nixpkgs/commit/479ec7c3ad6e081396a9e8dfc49696590c66ef5a) vimPlugins.lze: 0.4.5 -> 0.6.3
* [`fe24b14a`](https://github.com/NixOS/nixpkgs/commit/fe24b14a04bb2872408de3a1ca572e962c6a891b) tuifimanager: 5.0.9 -> 5.1.5
* [`6cbf845d`](https://github.com/NixOS/nixpkgs/commit/6cbf845dcb3e4bb42e53963095d8a00163a09a32) oh-my-fish: fix omf-install script
* [`3c4a42f4`](https://github.com/NixOS/nixpkgs/commit/3c4a42f4e76899fb35b8e0af7e4e02c741d8f11f) rbspy: 0.28.0 -> 0.29.0
* [`82ffb11a`](https://github.com/NixOS/nixpkgs/commit/82ffb11a67fbf00176cbba1ff4e76cec0d9369c0) python3Packages.pypdfium2: init at 4.30.1
* [`8114a813`](https://github.com/NixOS/nixpkgs/commit/8114a813dc6ecf46a2ff3a4308e99d82cb34fcd4) python311Packages.jax: fix build on Darwin
* [`77d19d14`](https://github.com/NixOS/nixpkgs/commit/77d19d14b4a09f27c2c05c07f17c9000b5e9621a)  spectra: init at 0.0.11.
* [`919ece96`](https://github.com/NixOS/nixpkgs/commit/919ece9608bbeea5aedf552eaed3264750a8038c) rustfilt: remove
* [`8ca6fefe`](https://github.com/NixOS/nixpkgs/commit/8ca6fefe3b349ce8e52b761846c7af5c68f16987) nixt: 2.5.1 -> 2.6.0
* [`27b777df`](https://github.com/NixOS/nixpkgs/commit/27b777df7515d8cb77cdc3551de489ee37402261) python312Packages.pycm: 4.0 -> 4.2
* [`0b73be72`](https://github.com/NixOS/nixpkgs/commit/0b73be72826763cf13160c250e83568363b031c1) immich: 1.125.2 -> 1.125.3
* [`2752c624`](https://github.com/NixOS/nixpkgs/commit/2752c62485ff33d6c3ddd759e80adc1f457133af) nextcloud-notify_push: useFetchCargoVendor
* [`78aa4155`](https://github.com/NixOS/nixpkgs/commit/78aa415507469aa388e0c008c7a00e6ba5eb2a7a) influxdb: useFetchCargoVendor
* [`2b4cec3d`](https://github.com/NixOS/nixpkgs/commit/2b4cec3db053c532422a2bb398808908bb33bcb2) influxdb2: useFetchCargoVendor
* [`42817d63`](https://github.com/NixOS/nixpkgs/commit/42817d63560d159921870f39bbadb8d4b7ddf37e) plausible: useFetchCargoVendor
* [`145fe791`](https://github.com/NixOS/nixpkgs/commit/145fe791fed482c508fe95adc9fdc9a2dc7ebdec) nix-index: useFetchCargoVendor
* [`c4017485`](https://github.com/NixOS/nixpkgs/commit/c4017485fe051c2cf4e60d54d2955278623e58fe) sourcegit: init at 2025.1
* [`d33a8e9c`](https://github.com/NixOS/nixpkgs/commit/d33a8e9ccc7f16a3b054bb33856693e35baaef5e) wireguard-vanity-address: remove
* [`e233cae7`](https://github.com/NixOS/nixpkgs/commit/e233cae76072a772008b9062f12f0d1f2d98a940) anevicon: remove
* [`6ecc829c`](https://github.com/NixOS/nixpkgs/commit/6ecc829cf2afecd6776fbf91a0d4ceff971b7952) sheesy-cli: remove
* [`5e6a566c`](https://github.com/NixOS/nixpkgs/commit/5e6a566c696a03df6fb623bc3fcf06c3704f5806) home-assistant-custom-components.versatile_thermostat: init at 7.1.5
* [`78c5938e`](https://github.com/NixOS/nixpkgs/commit/78c5938ece7ddaae24bbf8691003bd2ed032e89b) genpass: useFetchCargoVendor
* [`cebf6f33`](https://github.com/NixOS/nixpkgs/commit/cebf6f338e63c6afaec422ea9c67eb9ec661bd8d) smartgithg: 23.1.3 -> 24.1.1
* [`2bc17cc7`](https://github.com/NixOS/nixpkgs/commit/2bc17cc789194f79e91e33bafce095cc867b5a8e) smartgithg: refactor
* [`1e3febf5`](https://github.com/NixOS/nixpkgs/commit/1e3febf55347a94b7e0b490353c9a061b13a19d1) readarr: 0.4.8.2726 -> 0.4.10.2734
* [`5419f859`](https://github.com/NixOS/nixpkgs/commit/5419f859dd9b17cd0c48fe2a89e4d9be826da27a) xsv: remove
* [`e4fd5b5b`](https://github.com/NixOS/nixpkgs/commit/e4fd5b5b9c5e6772649cc6dd9057c8636a79d1ad) v2ray: 5.24.0 -> 5.25.1
* [`1bcaa8f2`](https://github.com/NixOS/nixpkgs/commit/1bcaa8f27a757f50689a0059f62f8182ba3468a8) nixpkgs-hammering: unstable-2024-03-25 -> 0-unstable-2024-12-22
* [`e0bfcf38`](https://github.com/NixOS/nixpkgs/commit/e0bfcf387a1593a28da428bc586c3c959eab36a1) cargo-inspect: remove
* [`00bff58d`](https://github.com/NixOS/nixpkgs/commit/00bff58da4b283e7671c1d20ac2039e64c2d611a) getmail6: 6.19.06 -> 6.19.07
* [`c61cc618`](https://github.com/NixOS/nixpkgs/commit/c61cc61897be26226cfb43c794e72c76cf4f9106) radicale: 3.4.0 -> 3.4.1
* [`837dca01`](https://github.com/NixOS/nixpkgs/commit/837dca01acd115562b323be1ff62bafe2d961b14) cargo-aoc: use versionCheckHook
* [`cf6d2208`](https://github.com/NixOS/nixpkgs/commit/cf6d220869850b4df31a4ac5d87e6b9e9f56c09c) jx: 3.11.4 -> 3.11.27
* [`21580426`](https://github.com/NixOS/nixpkgs/commit/21580426b4927574cdb1c95c12db11ed4cc4e0af) libdeltachat: 1.155.0 -> 1.155.1
* [`8284224e`](https://github.com/NixOS/nixpkgs/commit/8284224ee718e859a228f2993f4bd0a07f5e1494) mutter: fix cross compilation
* [`a4642280`](https://github.com/NixOS/nixpkgs/commit/a4642280f2b956025ee86b7e8ba3bfee78907a92) astal.io: 0-unstable-2025-01-13 -> 0-unstable-2025-01-23
* [`bc8cf258`](https://github.com/NixOS/nixpkgs/commit/bc8cf25835ef9371dccdbc997f9af40fd5d53801) cntr: 1.6.0 -> 1.6.1
* [`88234d3a`](https://github.com/NixOS/nixpkgs/commit/88234d3a4f58e7248af755a08049638860fea7a0) nixos/freshrss: add caddy support
* [`53cf4ff8`](https://github.com/NixOS/nixpkgs/commit/53cf4ff891064070d289bbe80b7b1e41c1db0601) seafile-server: fix cross build
* [`9572cfe7`](https://github.com/NixOS/nixpkgs/commit/9572cfe77e02eeb53d29b6b96cd349dfe6fac169) pika-backup: use fetchCargoVendor
* [`a8f1685c`](https://github.com/NixOS/nixpkgs/commit/a8f1685cca731083615484183678fec6507feeb9) sysdig: enable aarch64-linux back
* [`01697957`](https://github.com/NixOS/nixpkgs/commit/016979574e373891d0bfe8954213b0d08ed93c8e) renode-dts2repl: 0-unstable-2025-01-13 -> 0-unstable-2025-01-14
* [`e382d500`](https://github.com/NixOS/nixpkgs/commit/e382d5008e05b2318deabd922eaa2da56b984bbf) forgejo-runner: 6.0.1 -> 6.2.0
* [`303859ef`](https://github.com/NixOS/nixpkgs/commit/303859efd64e734df61666085e5e89757b4f652e) forgejo-runner: drop `kranzes` from maintainer list
* [`efb7e4f9`](https://github.com/NixOS/nixpkgs/commit/efb7e4f93593883cb30f7a903087d452486f0e91) terraform-providers.tencentcloud: 1.81.152 -> 1.81.164
* [`c466e665`](https://github.com/NixOS/nixpkgs/commit/c466e6659ebb766c68d2e7a93822127cd515cb80) factoriolab: 3.9.2 -> 3.10.0
* [`6d57cfc4`](https://github.com/NixOS/nixpkgs/commit/6d57cfc4d70b991c7d94c5d0ef0f9c54a6aede23) python312Packages.flask-limiter: 3.10.0 -> 3.10.1
* [`664464a5`](https://github.com/NixOS/nixpkgs/commit/664464a5dd9e603944943543506e16a0d80349aa) libburn: backport upstream C23 fix
* [`14fb968a`](https://github.com/NixOS/nixpkgs/commit/14fb968a10fd436c8ae3fd818f3dc844c42f1145) python312Packages.conda-libmamba-solver: 24.11.1 -> 25.1.1
* [`66708165`](https://github.com/NixOS/nixpkgs/commit/66708165f9ec311b039301eef5425c367f70d2a4) mongodb-ce: only enable version install check on darwin
* [`10b633fe`](https://github.com/NixOS/nixpkgs/commit/10b633fe824bbefeaa05f2ef60fefdd6765cf018) jetbrains-runner: 3.0.4 -> 3.0.5
* [`628d3c42`](https://github.com/NixOS/nixpkgs/commit/628d3c423cf3b5a3828f11aabddf80290809d899) heptabase: 1.50.1 -> 1.51.1
* [`67ead92f`](https://github.com/NixOS/nixpkgs/commit/67ead92f4a53625a8afbead0107a6139c4f668b6) prowlarr: 1.29.2.4915 -> 1.30.2.4939
* [`864b5371`](https://github.com/NixOS/nixpkgs/commit/864b5371754cafaa4a704a10e7684b2f7f24bd78) librewolf-bin:  134.0.0-1 -> 134.0.1-1
* [`1d81f9d0`](https://github.com/NixOS/nixpkgs/commit/1d81f9d0067f2b16bf87bf51f964f498cb286efe) treesheets: 0-unstable-2025-01-13 -> 0-unstable-2025-01-16
* [`3e21a686`](https://github.com/NixOS/nixpkgs/commit/3e21a686e76f8c984cf2230a04823a42f3c22ee1) maintainers: add c4thebomb
* [`8d732213`](https://github.com/NixOS/nixpkgs/commit/8d732213c20e051943366aabef6b3ce3638bad95) asn: 0.78.0 -> 0.78.3
* [`0eb9c322`](https://github.com/NixOS/nixpkgs/commit/0eb9c3225baadc40ea28df4eea6369806d0f81a1) clipper2: 1.4.0 -> 1.5.2
* [`82c3e3cd`](https://github.com/NixOS/nixpkgs/commit/82c3e3cdee326f41d4d925bba1c16671029fde5d) nsxiv: 32 -> 33
* [`db13a24e`](https://github.com/NixOS/nixpkgs/commit/db13a24e446d66448e56c88588037412bc959e1b) commandergenius: 3.5.1 -> 3.5.2
* [`893b69c8`](https://github.com/NixOS/nixpkgs/commit/893b69c8499b1c7506764500d1e93048d09ea8d5) cloudflare-utils: 1.3.3 -> 1.3.4
* [`0bbf2d4b`](https://github.com/NixOS/nixpkgs/commit/0bbf2d4b3b5b7518d6aa003c67f9513b75172ee2) checkstyle: 10.21.1 -> 10.21.2
* [`0d668d78`](https://github.com/NixOS/nixpkgs/commit/0d668d78a09c3bbbb8e7725f9942f3ccb2ebc801) voicevox-engine: fix with poetry-core >=2.0
* [`d89be71e`](https://github.com/NixOS/nixpkgs/commit/d89be71e9fc0ef097dbf88c02f29d264cb949d2a) voicevox: 0.22.3 -> 0.22.4
* [`13f65008`](https://github.com/NixOS/nixpkgs/commit/13f650083cf28dae5de21ae6633dceb0f6dc23ba) stgit: 2.5.0 -> 2.5.1
* [`4aa399df`](https://github.com/NixOS/nixpkgs/commit/4aa399dff0dc98b651f307de22b85d06dbc7d2ab) marmite: 0.2.3 -> 0.2.4
* [`953f72e7`](https://github.com/NixOS/nixpkgs/commit/953f72e76ec2379b28894a2457a372666c4d1acc) nixos/*: tag manpage references
* [`75b2b7e9`](https://github.com/NixOS/nixpkgs/commit/75b2b7e946b403d2d379129584250d7d5a84d7c8) nixos/*: undo manual linking to known manpage urls
* [`fd60375c`](https://github.com/NixOS/nixpkgs/commit/fd60375c7acaa1117b593a55e697668340ba8081) nixos/timesyncd: strip man: prefix from manpage links
* [`5e6998ae`](https://github.com/NixOS/nixpkgs/commit/5e6998ae80c1638765adcb307a93539564b34b71) nixos/autofs: fix manpage link
* [`a619c149`](https://github.com/NixOS/nixpkgs/commit/a619c149929a8cf4d6a46aa57482a4c381ec0f1e) python312Packages.python-gvm: 24.12.0 -> 25.1.1
* [`5f91d453`](https://github.com/NixOS/nixpkgs/commit/5f91d453d0ed6f14d2e6aa0efbb7375f212032ed) rpm: fixup %_var macro
* [`e3c1d205`](https://github.com/NixOS/nixpkgs/commit/e3c1d205f349d7f8beb434891cf7cc00ba636121) waveterm: 0.10.4 -> 0.11.0
* [`2e4911a4`](https://github.com/NixOS/nixpkgs/commit/2e4911a42cba4f15e57b2bd0de6fe3f87d70e662) vacuum-go: 0.15.3 -> 0.16.1
* [`975fb8eb`](https://github.com/NixOS/nixpkgs/commit/975fb8eb47e15b77ebbc102577204becf79bf249) jenkins: 2.479.2 -> 2.479.3
* [`13069f6a`](https://github.com/NixOS/nixpkgs/commit/13069f6a43f2ee5c74e40cf6a90548a38d6946a9) impression: use fetchCargoVendor
* [`048932df`](https://github.com/NixOS/nixpkgs/commit/048932dfaa4f127832a0b0630e62b4aa61ef728c) mousai: use fetchCargoVendor
* [`48919f56`](https://github.com/NixOS/nixpkgs/commit/48919f56745884cc738a1659ce323a468c34f275) adminer-pematon: 4.12 -> 4.13 ([nixos/nixpkgs⁠#377142](https://togithub.com/nixos/nixpkgs/issues/377142))
* [`51169532`](https://github.com/NixOS/nixpkgs/commit/51169532ba6ff8cc5a8520a442459dc900535927) scx.rustscheds: useFetchCargoVendor ([nixos/nixpkgs⁠#377086](https://togithub.com/nixos/nixpkgs/issues/377086))
* [`7f92be44`](https://github.com/NixOS/nixpkgs/commit/7f92be44ef2d48a19476b6eabedc06862f1c5913) maintainers: add EstebanMacanek
* [`a55f1907`](https://github.com/NixOS/nixpkgs/commit/a55f19076909ffd0befcfb4c79235ae1bd0a5e31) whatsapp-chat-exporter: fix missing dependency
* [`30c8a4f5`](https://github.com/NixOS/nixpkgs/commit/30c8a4f5eddd740e5ef6318530f85eea03554452) siyuan: 3.1.19 -> 3.1.20
* [`40ee6335`](https://github.com/NixOS/nixpkgs/commit/40ee633534477426e4d4823fcdf00e10791599a5) melonDS: 1.0rc-unstable-2024-12-26 -> 1.0rc-unstable-2025-01-17
* [`4b31ae1f`](https://github.com/NixOS/nixpkgs/commit/4b31ae1f151c49dcb6f310d4c7728391763ef3a4) python312Packages.unstructured: 0.16.13 -> 0.16.15
* [`2c1eeaf2`](https://github.com/NixOS/nixpkgs/commit/2c1eeaf29e3bf0cbc783774cba2871af8ea0b8f1) baddns: 1.6.68 -> 1.7.86
* [`eba96f6e`](https://github.com/NixOS/nixpkgs/commit/eba96f6e8c1bb40956d35192712825696672fb3d) legcord: 1.0.6 -> 1.0.8
* [`729d9ec4`](https://github.com/NixOS/nixpkgs/commit/729d9ec466c3084aee447db17ff90bb6cd0bed55) pdi: 1.8.0 -> 1.8.1
* [`f104c8ec`](https://github.com/NixOS/nixpkgs/commit/f104c8eca09a5affe9fa1de5d98d33affb31ade3) fpart: 1.6.0 -> 1.7.0
* [`3980a821`](https://github.com/NixOS/nixpkgs/commit/3980a8216e669bbd46fbf389d439fce182b4dbc3) tdlib: 1.8.42 -> 1.8.44
* [`5ecccb2e`](https://github.com/NixOS/nixpkgs/commit/5ecccb2ecde32c837615e3c62242468881cf538a) spring-boot-cli: 3.4.1 -> 3.4.2
* [`28467ff8`](https://github.com/NixOS/nixpkgs/commit/28467ff83d4d18db90c7f58d36f497c6010469c4) Revert "vue-typescript-plugin: init at 2.2.0"
* [`67b05da3`](https://github.com/NixOS/nixpkgs/commit/67b05da39d11a2114f8d916de33d43bd5281b8c6) python312Packages.llama-cpp-python: mark as broken on aarch64-linux
* [`16cda93b`](https://github.com/NixOS/nixpkgs/commit/16cda93bd61ba6b2e8e1f2f106bc9c40a988d4aa) ArchiSteamFarm: 6.1.0.3 -> 6.1.1.3
* [`22bd6330`](https://github.com/NixOS/nixpkgs/commit/22bd6330c05b780e8ac841285780ae60a1b12b72) snipaste: 2.10.3 -> 2.10.5
* [`20c13980`](https://github.com/NixOS/nixpkgs/commit/20c13980309051d6ec858340307985c9174796ec) gfn-electron: 2.1.2 -> 2.1.3
* [`f5e15c03`](https://github.com/NixOS/nixpkgs/commit/f5e15c0360aa825cd55f44f644d11f3150afddcd) gitxray: 1.0.16.4 -> 1.0.17
* [`506f4f14`](https://github.com/NixOS/nixpkgs/commit/506f4f1416cb753ffaf6ff30889281249a7a7c73) novelwriter: 2.5.3 -> 2.6
* [`b5ffed93`](https://github.com/NixOS/nixpkgs/commit/b5ffed93f1c5dc532fc74dcf15ca6a95ed2c06ae) steam-unwrapped: 1.0.0.81 -> 1.0.0.82
* [`c40d9b20`](https://github.com/NixOS/nixpkgs/commit/c40d9b20b07cdafe03913e260edd9e44184e2fba) plasma-panel-colorizer: 1.2.0 -> 2.1.0
* [`4787ad39`](https://github.com/NixOS/nixpkgs/commit/4787ad39a9a275ea74544012b055fd8c059b34b6) pnpm_10: 10.0.0 -> 10.1.0
* [`053ca458`](https://github.com/NixOS/nixpkgs/commit/053ca4580a33090ccda4c4090ab0b3c1b4a086ba) netbird-ui: fix meta.mainProgram
* [`2f809f78`](https://github.com/NixOS/nixpkgs/commit/2f809f78ca6fcc1626f365ccd450ba3c4abf827e) sql-formatter: 15.4.9 -> 15.4.10
* [`e31b0dab`](https://github.com/NixOS/nixpkgs/commit/e31b0dabea5b234a5f08a1e23e7784e43b0f380e) filebeat8: pin updateScript to major v8
* [`295b5212`](https://github.com/NixOS/nixpkgs/commit/295b5212fe02dcabf79d00b48aef4abf63deea93) ocamlPackages.ppx_irmin: 3.9.0 -> 3.10.0
* [`27367854`](https://github.com/NixOS/nixpkgs/commit/27367854f86d48b8a8acffacd549cf43f2f36049) refine: 0.4.0 -> 0.4.2
* [`36c51396`](https://github.com/NixOS/nixpkgs/commit/36c513967eedacf59cafe6b60d90ec9dbf274037) netbird: 0.35.2 -> 0.36.3
* [`fc3f7c17`](https://github.com/NixOS/nixpkgs/commit/fc3f7c17e27920d1a56ba4eb1120dfdb1adf18ca) nixos/mattermost: disable telemetry by default
* [`672f423d`](https://github.com/NixOS/nixpkgs/commit/672f423d0c0285db48b9da5459a0f2eaf5b2e24f) nixos/mattermost: default preferNixConfig to true
* [`26c0cc56`](https://github.com/NixOS/nixpkgs/commit/26c0cc56a55a5fa004bb68adfe2103ee5c00c53d) release-notes/25.05: add details about disabled Mattermost telemetry
* [`fffc7781`](https://github.com/NixOS/nixpkgs/commit/fffc77810e7549ab04c0e07c58eb0479cc19c08b) portfolio: 0.73.0 -> 0.74.0
* [`4ccbe977`](https://github.com/NixOS/nixpkgs/commit/4ccbe97736155d21546cc566d949e75f06e8b39b) gum: 0.15.0 -> 0.15.1
* [`d079b9b3`](https://github.com/NixOS/nixpkgs/commit/d079b9b3316c13fe3f4d0c429404e1feaa442843) glamoroustoolkit: 1.1.9 -> 1.1.11
* [`d57b75b9`](https://github.com/NixOS/nixpkgs/commit/d57b75b995b9ef23ad4be2b84092b588e5fd9043) regal: 0.30.0 -> 0.30.2
* [`e855c916`](https://github.com/NixOS/nixpkgs/commit/e855c9164802bc2e28f022959cf89c7a4bdd1821) cargo-leptos: 0.2.25 -> 0.2.26
* [`55f5dffc`](https://github.com/NixOS/nixpkgs/commit/55f5dffc7e08c87003793fc330d658c06fc76aa2) nextcloudPackages.apps.collectives: init at 2.16.0
* [`97210852`](https://github.com/NixOS/nixpkgs/commit/9721085275b30ae75cd7e63c848591e3a7e578b6) home-assistant-custom-lovelace-modules.hourly-weather: 6.6.0 -> 6.6.1
* [`6814f53c`](https://github.com/NixOS/nixpkgs/commit/6814f53cc04273c167d44e7b5a6d7a3527c75c12) kubedb-cli: fix hash after tag was moved
* [`1ce79c9d`](https://github.com/NixOS/nixpkgs/commit/1ce79c9d5867fce621e3bf5c3f1910f1cfa290ef) nomino: 1.5.0 -> 1.6.0
* [`9aa6e4e0`](https://github.com/NixOS/nixpkgs/commit/9aa6e4e059a67773efa293263838513afbdd2b11) n98-magerun: switch to buildComposerProject2 and tag ([nixos/nixpkgs⁠#377265](https://togithub.com/nixos/nixpkgs/issues/377265))
* [`d42f4d5f`](https://github.com/NixOS/nixpkgs/commit/d42f4d5f45d0da88832818a06d9123942381c7d5) mdbook-graphviz: update source hash
* [`58efc57c`](https://github.com/NixOS/nixpkgs/commit/58efc57ceb2db7ac4e01ffde0a313fb2560033a7) python312Packages.databricks-sdk: 0.40.0 -> 0.41.0
* [`433006b8`](https://github.com/NixOS/nixpkgs/commit/433006b863378c1c67d6a76951f4c5c3c840369e) squid: add test
* [`7db3b7c2`](https://github.com/NixOS/nixpkgs/commit/7db3b7c28bd5e0b530b2675265fcb6adbd1b0026) nixosTests.mate-wayland: Check for more text
* [`40ab1be0`](https://github.com/NixOS/nixpkgs/commit/40ab1be07c27edf96321b83e775239e207193e7f) python3Packages.openusd: 24.08 -> 24.11
* [`6f7b06b6`](https://github.com/NixOS/nixpkgs/commit/6f7b06b66c951f699c06f865c8b7f1dcd51df843) glooctl: 1.18.5 -> 1.18.6
* [`c2f5a1aa`](https://github.com/NixOS/nixpkgs/commit/c2f5a1aa35ae2adf1eb0ed866b556f9efdd01fd6) terraform-providers.tfe: 0.62.0 -> 0.63.0
* [`e45245cd`](https://github.com/NixOS/nixpkgs/commit/e45245cdcd04848fae174597d990aa8557e329d3) python313Packages.compliance-trestle: init at 3.7.0
* [`837da5af`](https://github.com/NixOS/nixpkgs/commit/837da5afc86e5988c12bfb56caebfbb7c0497fbf) colorstorm: 2.0.0 -> 2.0.0-unstable-2025-01-17
* [`da43c1e3`](https://github.com/NixOS/nixpkgs/commit/da43c1e3f1efe9bb9eec68ba8023e950944c4db1) python312Packages.pyedflib: 0.1.38 -> 0.1.39
* [`871c57e5`](https://github.com/NixOS/nixpkgs/commit/871c57e5f8bf527e0b81c448aaae908c383f5df1) sqldef: 0.17.27 -> 0.17.28
* [`28af2a6e`](https://github.com/NixOS/nixpkgs/commit/28af2a6ec46cb3343592edaff3cb396ab68b936b) lazysql: 0.3.3 -> 0.3.4
* [`d65ff674`](https://github.com/NixOS/nixpkgs/commit/d65ff67488a71153f9e60e60a6a4159a773e8919) rastertoezpl: init at 1.1.12
* [`e7b63155`](https://github.com/NixOS/nixpkgs/commit/e7b631559b45750e4eb9c8f5022d5b2590afe4c7) tfswitch: 1.2.4 -> 1.3.0
* [`f8be14da`](https://github.com/NixOS/nixpkgs/commit/f8be14da32825272964e0b48f21d518fdbc1cb00) python313Packages.python-swiftclient: switch to pyproject, drop unnecessary propagated pbr, drop old postPatch
* [`52daba4f`](https://github.com/NixOS/nixpkgs/commit/52daba4fddd2754047faa6a1d1b5b521429ed1db) python313Packages.keystoneauth1: don't propagate test dependency
* [`83e3baa4`](https://github.com/NixOS/nixpkgs/commit/83e3baa4a41da3d4580ce39d9a1bad5dc1e0fd3a) flutter_rust_bridge_codegen: 2.7.0 -> 2.7.1
* [`bf211cf6`](https://github.com/NixOS/nixpkgs/commit/bf211cf6c305dcc6bdc8b026c345cf59142b19db) localsend: refactor
* [`8bd04ce7`](https://github.com/NixOS/nixpkgs/commit/8bd04ce7b565c9d84834842db0a3a906c9eb787c) localsend: fix autostart
* [`ff5c2056`](https://github.com/NixOS/nixpkgs/commit/ff5c205639765907e1328c35f31cf5398917dcc9) python312Packages.wadler-lindig: init at 0.1.3
* [`4a6ee7e0`](https://github.com/NixOS/nixpkgs/commit/4a6ee7e08b839b51f0c164dbb8489f8feb22a11f) python312Packages.jaxtyping: 0.2.36 -> 0.2.37
* [`d9bde042`](https://github.com/NixOS/nixpkgs/commit/d9bde042b1f15c7cfddaae99d081b474189ecf71) wownero: pin boost 1.86
* [`4e279b9d`](https://github.com/NixOS/nixpkgs/commit/4e279b9ded9cba7f11731bc3e27e40fac93f11b2) vimPlugins.blink-copilot: init at 2025-01-27
* [`7075f9ea`](https://github.com/NixOS/nixpkgs/commit/7075f9eaa37c3606ee5327f10e4b0883dad038d2) simdutf: 6.0.3 -> 6.1.1
* [`cad725be`](https://github.com/NixOS/nixpkgs/commit/cad725befac932fc986063bb8b0201cc597a3614) lime3ds: fix build
* [`a8b2a4db`](https://github.com/NixOS/nixpkgs/commit/a8b2a4dbbdc4d27dbabedcefb147fb51f02810cb) python312Packages.llama-cpp-python: respect NIX_BUILD_CORES
* [`9dbe664d`](https://github.com/NixOS/nixpkgs/commit/9dbe664d61eccf47737264918ff608d168cc9fb2) aerc: add maintainers
* [`ae255878`](https://github.com/NixOS/nixpkgs/commit/ae255878c3cd6304bb2e09604965ad59a565fa19) mailpit: 1.21.8 -> 1.22.0
* [`2fa5a892`](https://github.com/NixOS/nixpkgs/commit/2fa5a892d9270fa8328c97c692e28f3b41c8c922) halide: 18.0.0 -> 19.0.0
* [`5645cd22`](https://github.com/NixOS/nixpkgs/commit/5645cd22d4a4ed66449986cd96f49ebc043cb5d6) linux: expose make flags for modules in `linuxKernel.packages.linux_X_Y`
* [`c10e0eb4`](https://github.com/NixOS/nixpkgs/commit/c10e0eb43ff335c8b0ecddceca288e7551461498) teamviewer: adding auto-update script
* [`64631fa5`](https://github.com/NixOS/nixpkgs/commit/64631fa56e1e7d7d3d7441717ad0f5fa26f8f4d8) teamviewer: 15.54.3 -> 15.61.3
* [`7b5ed412`](https://github.com/NixOS/nixpkgs/commit/7b5ed4120d1e3652a7be0da3dc2eed809de70d8d) victoriametrics: 1.109.0 -> 1.110.0
* [`80223d5e`](https://github.com/NixOS/nixpkgs/commit/80223d5e0c5bef1b22bfce1721b9a54839b965d2) stretchly: 1.16.0 -> 1.17.2
* [`d8748785`](https://github.com/NixOS/nixpkgs/commit/d87487856861e41585033d31c452c01e85bc3cb8) python312Packages.jaxopt: disable flaky test
* [`62fff963`](https://github.com/NixOS/nixpkgs/commit/62fff9635ca22fd9aa9bc33ab7ac0e1b5ebe7332) amazon-ssm-agent: 3.3.1345.0 -> 3.3.1611.0
* [`e49163e2`](https://github.com/NixOS/nixpkgs/commit/e49163e2aaad0d78499f739d941505c55d173d3a) basicswap: init at 0.14.3
* [`5b1b7838`](https://github.com/NixOS/nixpkgs/commit/5b1b7838b63129f7e5c67e11d3c1b8a6bf1fdc0e) phpmd: switch to buildComposerProject2, tag and versionCheckHook ([nixos/nixpkgs⁠#377325](https://togithub.com/nixos/nixpkgs/issues/377325))
* [`a0762f43`](https://github.com/NixOS/nixpkgs/commit/a0762f435f946020709d752200ddf4b3a5b3dd69) narsil: bbc8fc5efd779ec885045f9b8d903d0df1bec1b2 -> f5ec6bd6b8013f2a2b74fc45b6f4c53744590ec5
* [`f0dae932`](https://github.com/NixOS/nixpkgs/commit/f0dae93284ea4753be3591773134ce2b1962f583) tree-sitter: fix cross build
* [`2c537622`](https://github.com/NixOS/nixpkgs/commit/2c537622d5d9ee83679e4d5c5b8b4d66b0bfe658) capslock: 0.2.6 -> 0.2.7
* [`3a988939`](https://github.com/NixOS/nixpkgs/commit/3a988939227fe1b3c7510d18a547c42e86019c1b) python312Packages.stable-baselines3: 2.4.1-unstable-2025-01-07 -> 2.5.0
* [`69222d17`](https://github.com/NixOS/nixpkgs/commit/69222d1718d37b2bb228c1c0ad002a349f7782fd) kodiPackages.urllib3: 2.1.0 -> 2.2.3
* [`67015516`](https://github.com/NixOS/nixpkgs/commit/67015516a99843b1c56d933a21ef5af1471217bf) alist: add updateScript
* [`255a75ad`](https://github.com/NixOS/nixpkgs/commit/255a75ad74c543748a4ec1ca4cf3f07d2c66e737) roslyn-ls: 4.13.0-3.25051.1 -> 4.14.0-1.25060.2
* [`bb1ec268`](https://github.com/NixOS/nixpkgs/commit/bb1ec26890918e907432184ae0b73f3e94e05701) n8n: 1.73.1 -> 1.75.2
* [`b5f82750`](https://github.com/NixOS/nixpkgs/commit/b5f82750ab072b0c89f1424b96abf36ff380c965) python312Packages.blackjax: disable failing tests
* [`d2f6ea50`](https://github.com/NixOS/nixpkgs/commit/d2f6ea506b3a5a0b4f19e84400715df3e7c4a552) alist: 3.41.0 -> 3.42.0
* [`dc0f1b37`](https://github.com/NixOS/nixpkgs/commit/dc0f1b37085e9a216077b0b6e086e69c47fd1ce3) python313Packages.libknot: 3.4.3 -> 3.4.4
* [`9551a1cc`](https://github.com/NixOS/nixpkgs/commit/9551a1cc289637abc7ff4c3cf41e9e344f883911) prometheus-knot-exporter: 3.4.3 -> 3.4.4
* [`77efc486`](https://github.com/NixOS/nixpkgs/commit/77efc48642865afdd057ba4a0ffe9650490aa46b) php.packages.box: switch to buildComposerProject2, tag and add versionCheckHook ([nixos/nixpkgs⁠#377342](https://togithub.com/nixos/nixpkgs/issues/377342))
* [`89422528`](https://github.com/NixOS/nixpkgs/commit/8942252818ee878c4008c914ff6318d7a30ef30a) scaleway-cli: 2.35.0 -> 2.36.0
* [`7c6ece7a`](https://github.com/NixOS/nixpkgs/commit/7c6ece7a87ff3c7e4cd4cc7d572aacc7f75867bc) pdm: 2.22.2 -> 2.22.3
* [`b7ad3c77`](https://github.com/NixOS/nixpkgs/commit/b7ad3c77fa63c18dd99d7a82b3a46e7fe3cb8896) sploitscan: 0.11.0 -> 0.12.0
* [`0fe2e3f0`](https://github.com/NixOS/nixpkgs/commit/0fe2e3f0e3d89f4412940ebff28afea7dfd08390) maintainers.nix: Remove unused code
* [`6fa05399`](https://github.com/NixOS/nixpkgs/commit/6fa05399767b9e420e80839516a275bcd8ad9943) home-assistant-custom-lovelace-modules.clock-weather-card: init at 2.8.7
* [`8945c063`](https://github.com/NixOS/nixpkgs/commit/8945c06304624c5981796adf622e5e83beeb8689) oauth2-proxy: 7.8.0 -> 7.8.1
* [`2ede59bd`](https://github.com/NixOS/nixpkgs/commit/2ede59bdbd4e28b63d2a79441c17b667bfaf1ddd) php.packages.phive: switch to buildComposerProject2 and tag ([nixos/nixpkgs⁠#377352](https://togithub.com/nixos/nixpkgs/issues/377352))
* [`98a48804`](https://github.com/NixOS/nixpkgs/commit/98a488043d017970ff9949b9ae7ca7b9addbac3f) thunderbird-bin-unwrapped: 128.6.0esr -> 128.6.1esr
* [`07271da9`](https://github.com/NixOS/nixpkgs/commit/07271da986a0a0d71aff4f178b8b68ff25533796) dotnet: default to source-built sdk/runtimes
* [`7145669c`](https://github.com/NixOS/nixpkgs/commit/7145669ca849c1c52b728e0a7edc1ff434de82f7) python313Packages.playwrightcapture: 1.27.5 -> 1.27.6
* [`9b8bea38`](https://github.com/NixOS/nixpkgs/commit/9b8bea388ddc180d2386a50d5d402a61a6430081) python312Packages.lacuscore: 1.12.8 -> 1.12.8
* [`87521c59`](https://github.com/NixOS/nixpkgs/commit/87521c59b636ae9073c58bd549b4cdc334a3dc28) build-support: add `addBinToPathHook` hook
* [`f8110737`](https://github.com/NixOS/nixpkgs/commit/f8110737aeedf8ba92ea46a0b1d2d298843d7c06) build-support: add `writableTmpDirAsHomeHook` hook
* [`e09d88a5`](https://github.com/NixOS/nixpkgs/commit/e09d88a50988bb516aa24f5e468f5ac85ef19e56) python312Packages.ldfparser: 0.25.0 -> 0.26.0
* [`026ee7fa`](https://github.com/NixOS/nixpkgs/commit/026ee7faf4892c0f65b275480393b617530a09d9) python312Packages.aiohomeconnect: 0.11.2 -> 0.11.4
* [`1270d614`](https://github.com/NixOS/nixpkgs/commit/1270d6147d4a892d77c428205e6bf43e1f156bbc) sploitscan: update changelog URL
* [`7aa553db`](https://github.com/NixOS/nixpkgs/commit/7aa553db3a3e674b5c78fb7518b9b4eba7e8242f) netlify-cli: 18.0.0 -> 18.0.2
* [`795a518c`](https://github.com/NixOS/nixpkgs/commit/795a518ce93849dadbf5246cbb2e2f003cec4252) signalbackup-tools: 20250122 -> 20250127-1
* [`2f848591`](https://github.com/NixOS/nixpkgs/commit/2f848591a5604f5beca59ad7b58fe46b443fb3e2) deltachat-desktop: 1.52.0 -> 1.52.1
* [`c2504d23`](https://github.com/NixOS/nixpkgs/commit/c2504d232a73f86b1b43342329f2743371b2660d) vimPlugins.lua-async-await: fix deprecation
* [`b1d65ad6`](https://github.com/NixOS/nixpkgs/commit/b1d65ad64d1bb852960dc36a4cc41bb053143a4a) labwc-tweaks-gtk: 0-unstable-2025-01-11 -> 0-unstable-2025-01-26
* [`ef88b417`](https://github.com/NixOS/nixpkgs/commit/ef88b4174a3f20932c217bd3da9a3f51d7801b79) python313Packages.archinfo: 9.2.137 -> 9.2.138
* [`25098f69`](https://github.com/NixOS/nixpkgs/commit/25098f69105799ec9ef5af2d9828146e58bd3968) python313Packages.ailment: 9.2.137 -> 9.2.138
* [`2907ebd1`](https://github.com/NixOS/nixpkgs/commit/2907ebd1dda89c8b0d36a344a01c95d915df9c38) python313Packages.pyvex: 9.2.137 -> 9.2.138
* [`7d80f491`](https://github.com/NixOS/nixpkgs/commit/7d80f49136b89db31848fb9b507818c8e2dc7acb) python313Packages.claripy: 9.2.137 -> 9.2.138
* [`f0a86fd9`](https://github.com/NixOS/nixpkgs/commit/f0a86fd930cad28189ce0459999189ece16f9439) python313Packages.letpot: init at 0.3.0
* [`172cbe7e`](https://github.com/NixOS/nixpkgs/commit/172cbe7e03e411ff9cf71e34ce1881b78e2adf55) zed-editor: 0.170.2 -> 0.170.4 ([nixos/nixpkgs⁠#377358](https://togithub.com/nixos/nixpkgs/issues/377358))
* [`04e51a6c`](https://github.com/NixOS/nixpkgs/commit/04e51a6c3d51eee62e7e78e53cde56d884996a3c) iosevka-bin: 32.3.1 -> 32.4.0 ([nixos/nixpkgs⁠#377380](https://togithub.com/nixos/nixpkgs/issues/377380))
* [`40cf14fd`](https://github.com/NixOS/nixpkgs/commit/40cf14fdbdce3833475e2535409244eddd67bbe0) home-manager: 0-unstable-2025-01-13 -> 0-unstable-2025-01-27 ([nixos/nixpkgs⁠#377348](https://togithub.com/nixos/nixpkgs/issues/377348))
* [`215b4179`](https://github.com/NixOS/nixpkgs/commit/215b417971827591b88f0e74e7d8e25a1134303d) linuxPackages.nvidia_x11.open: don't include date for reproducibility ([nixos/nixpkgs⁠#377335](https://togithub.com/nixos/nixpkgs/issues/377335))
* [`b1b4dba5`](https://github.com/NixOS/nixpkgs/commit/b1b4dba528d88d9af11a49fc93ebf5597ec410fc) openlinkhub: 0.4.8 -> 0.5.0
* [`b2ef8ebf`](https://github.com/NixOS/nixpkgs/commit/b2ef8ebfd6f7c6c30ffeab226128196f2689b3d4) aerospike: 7.2.0.6 -> 8.0.0.1
* [`327028ba`](https://github.com/NixOS/nixpkgs/commit/327028baa0e7a7efebebaa266651fe7221baa00a) nixos/pixelfed: fix typo in nginx submodule description
* [`6de7de04`](https://github.com/NixOS/nixpkgs/commit/6de7de04a886d2857df3ce130558f194283609b7) gtuber: 0-unstable-2024-10-11 -> 0-unstable-2025-01-19
* [`876605aa`](https://github.com/NixOS/nixpkgs/commit/876605aadb7599f222e6b2492e9718ec4a80078c) fswatch: 1.18.0 -> 1.18.2
* [`d177ad4a`](https://github.com/NixOS/nixpkgs/commit/d177ad4a037cc2e5daa47c9bc1262144923196f7) vscode-extensions.hirse.vscode-ungit: init at 2.5.2 ([nixos/nixpkgs⁠#377322](https://togithub.com/nixos/nixpkgs/issues/377322))
* [`ce99e2aa`](https://github.com/NixOS/nixpkgs/commit/ce99e2aa18b5f2f86ffd7150dc417dad891eae70) amazon: make fileSystems option disko-compatible
* [`0a1747fc`](https://github.com/NixOS/nixpkgs/commit/0a1747fc1429cf676b3e702115c6e82f59797731) geoserver: 2.26.1 -> 2.26.2
* [`e7354817`](https://github.com/NixOS/nixpkgs/commit/e7354817c72ec55d66e912013f194ed83feac852) clisp: 2.50pre20230112 -> 2.49.95-unstable-2024-12-28
* [`1c008e8e`](https://github.com/NixOS/nixpkgs/commit/1c008e8e76e196a9fce3a5e36bf06b5dbc56bd51) rakudo: 2024.12 -> 2025.01
* [`26a572cf`](https://github.com/NixOS/nixpkgs/commit/26a572cff701de94d09a2bdf798088a728a32335) lomiri.lomiri-indicator-network: Disable parallel testing
* [`d671f0ef`](https://github.com/NixOS/nixpkgs/commit/d671f0ef4242429b26c8923515e1a1a2cc98db7f) discordo: 0-unstable-2025-01-12 -> 0-unstable-2025-01-27
* [`314320ac`](https://github.com/NixOS/nixpkgs/commit/314320ac638a2db0f86110fa2b7855c50e04c2b5) terraform-providers.spotinst: 1.207.0 -> 1.208.0
* [`0f2e751a`](https://github.com/NixOS/nixpkgs/commit/0f2e751aa4fb7bb6cf543cf958e5c2f63fdbfb75) harper: 0.17.0 -> 0.18.0
* [`48c81b90`](https://github.com/NixOS/nixpkgs/commit/48c81b909c659e82f6bf2afa7e5f273738f5530c) hyprutils: 0.3.3 -> 0.5.0
* [`960e673a`](https://github.com/NixOS/nixpkgs/commit/960e673a0b9b70cce86b5db349853572559dce72) aquamarine: 0.5.1 -> 0.7.1
* [`7d0870fb`](https://github.com/NixOS/nixpkgs/commit/7d0870fbb974b1c405447fd3a5e6800c143cc82a) hyprland: 0.46.2 -> 0.47.0
* [`dd5a0868`](https://github.com/NixOS/nixpkgs/commit/dd5a08689fabed50eeb874979dc2aaa3b3afbb27) openrgb: move to by-name
* [`e0a8ac83`](https://github.com/NixOS/nixpkgs/commit/e0a8ac83764881fcd788d9248db98eab9a50ff93) renovate: 39.107.0 -> 39.137.1
* [`5d845598`](https://github.com/NixOS/nixpkgs/commit/5d8455982373697ca3ef963f78a01763a9cbb2e2) rc-9front: 0-unstable-2022-11-01 -> 0-unstable-2025-01-19
* [`00e12b12`](https://github.com/NixOS/nixpkgs/commit/00e12b12b2e75d3cdaa8e305410373bc60c86f2a) poetryPlugins.poetry-plugin-up: 0.8.0 -> 0.9.0
* [`e7b90458`](https://github.com/NixOS/nixpkgs/commit/e7b90458b25486d70445b9e3322caae0e9af1c05) firefox-devedition-unwrapped: 135.0b4 -> 135.0b9
* [`3ae3a0f4`](https://github.com/NixOS/nixpkgs/commit/3ae3a0f4884440320c5fcec3d31fd3a153aef540) python312Packages.es-client: 8.15.2 -> 8.17.1
* [`6bd57802`](https://github.com/NixOS/nixpkgs/commit/6bd5780275b2a6acc0bdbbecabea98e23c9964c4) mallard-ducktype: init at 1.0.2
* [`3475b40d`](https://github.com/NixOS/nixpkgs/commit/3475b40d8901d1c939855342a76d7a8a96bbb1b1) aerc: 0.20.0 -> 0.20.1
* [`3c0e72bb`](https://github.com/NixOS/nixpkgs/commit/3c0e72bb3d5c3f0905026ca6b07ce574c3e61f5e) terraform-providers.sumologic: 3.0.0 -> 3.0.1
* [`753c0028`](https://github.com/NixOS/nixpkgs/commit/753c00280353005f9d856d4509535f29f9980aea) python3Packages.mdtraj: 1.10.0 -> 1.10.2
* [`be00d358`](https://github.com/NixOS/nixpkgs/commit/be00d3580a264bf786b84ba82f3a7f91a18055be) svgbob: 0.7.4 -> 0.7.6
* [`3ff56bf6`](https://github.com/NixOS/nixpkgs/commit/3ff56bf6c63a1bc5851f08284ac3cd4232ca1ae3) shairport-sync: 4.3.5 -> 4.3.6
* [`e8ae415d`](https://github.com/NixOS/nixpkgs/commit/e8ae415db8e8ae738b177b471b248af9e17fa34c) azure-storage-azcopy: 10.27.1 -> 10.28.0
* [`6179a579`](https://github.com/NixOS/nixpkgs/commit/6179a5793e6673991cb221c69981d8ce957b8c5b) gnmic: 0.39.1 -> 0.40.0
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
