### PR TITLE
niv home-manager: update e1ae908b -> 066ba0c5

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -41,10 +41,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e1ae908bcc30af792b0bb0a52e53b03d2577255e",
-        "sha256": "1bwnmhb7brayfamljr4rl3ks07gs4awgx57zns6cd8dhc92c08y6",
+        "rev": "066ba0c5cfddbc9e0dddaec73b1561ad38aa8abe",
+        "sha256": "14sryxr51hya2hqlpl7qpmi6l70wfv9p2vzdrlqyzmf0wzjrmgn9",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/e1ae908bcc30af792b0bb0a52e53b03d2577255e.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/066ba0c5cfddbc9e0dddaec73b1561ad38aa8abe.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@e1ae908b...066ba0c5](https://github.com/nix-community/home-manager/compare/e1ae908bcc30af792b0bb0a52e53b03d2577255e...066ba0c5cfddbc9e0dddaec73b1561ad38aa8abe)

* [`0a64a209`](https://github.com/nix-community/home-manager/commit/0a64a209aa3c0e5ae528b9f25c3c5e9bb735dbb3) flake.lock: Update
* [`1b4f2a48`](https://github.com/nix-community/home-manager/commit/1b4f2a48168b3d90e11365552d1e7e601a4be6b6) zed-editor: add installRemoteServer option
* [`a1df6c4c`](https://github.com/nix-community/home-manager/commit/a1df6c4c76a839661207105daa519e3de3b5fe15) nushell: slight refactor
* [`46c83c07`](https://github.com/nix-community/home-manager/commit/46c83c07b9a97a8f7633dd162dd9a3bbe511195b) nushell: add settings option
* [`709aaab1`](https://github.com/nix-community/home-manager/commit/709aaab1a5c35a8d1f1e7546efa226e09f3316fb) nushell: set env in config.nu file
* [`82455a84`](https://github.com/nix-community/home-manager/commit/82455a84e32af01c66e326e5a188795f324975a1) nushell: allow multi-word aliases
* [`bd530df4`](https://github.com/nix-community/home-manager/commit/bd530df4e284310fee0fada3562de908009e1236) firefox: avoid unnecessarily overriding package
* [`0ee8bfdd`](https://github.com/nix-community/home-manager/commit/0ee8bfdd04de611a93cf57dda01686b613cc587d) firefox: add preConfig
* [`5dc1c2e4`](https://github.com/nix-community/home-manager/commit/5dc1c2e40410f7dabef3ba8bf4fdb3145eae3ceb) hyprland: add xdg.portal configuration ([nix-community/home-manager⁠#5707](https://togithub.com/nix-community/home-manager/issues/5707))
* [`c4650fb9`](https://github.com/nix-community/home-manager/commit/c4650fb9c0c4c8f7e1a43e6d72378246a4b50f3b) cliphist: support multiple systemdTargets properly ([nix-community/home-manager⁠#5669](https://togithub.com/nix-community/home-manager/issues/5669))
* [`d71828a7`](https://github.com/nix-community/home-manager/commit/d71828a7dd0dc53cf3994e8737c84b4180cc6dfa) ghostty: allow darwin users to manager their config ([nix-community/home-manager⁠#6300](https://togithub.com/nix-community/home-manager/issues/6300))
* [`d5e5c0d0`](https://github.com/nix-community/home-manager/commit/d5e5c0d051d8d4f293d8c7550c167597427e058b) aerospace: add module ([nix-community/home-manager⁠#6279](https://togithub.com/nix-community/home-manager/issues/6279))
* [`608b26d1`](https://github.com/nix-community/home-manager/commit/608b26d16ee69384580b1b14ac947d81d0240beb) thunderbird: add native host support ([nix-community/home-manager⁠#6292](https://togithub.com/nix-community/home-manager/issues/6292))
* [`6aa38ffd`](https://github.com/nix-community/home-manager/commit/6aa38ffdf77fb4250f5d832fd5a09eb99226fba7) atuin: set socket path for darwin ([nix-community/home-manager⁠#6248](https://togithub.com/nix-community/home-manager/issues/6248))
* [`79eff1f6`](https://github.com/nix-community/home-manager/commit/79eff1f6b95c059ed0f9dfae9fd16689c1dda5ca) zsh: added HIST_SAVE_NO_DUPS and HIST_FIND_NO_DUPS options to zsh for history configuration. ([nix-community/home-manager⁠#6227](https://togithub.com/nix-community/home-manager/issues/6227))
* [`6fbbfb92`](https://github.com/nix-community/home-manager/commit/6fbbfb92409bf999fd80b78c7f7bc145d2d36f39) Revert "thunderbird: add native host support ([nix-community/home-manager⁠#6292](https://togithub.com/nix-community/home-manager/issues/6292))" ([nix-community/home-manager⁠#6371](https://togithub.com/nix-community/home-manager/issues/6371))
* [`697ba131`](https://github.com/nix-community/home-manager/commit/697ba1319fdc58c94dc94cd7908df554dc48d970) waybar: allow setting systemd.target to null ([nix-community/home-manager⁠#6241](https://togithub.com/nix-community/home-manager/issues/6241))
* [`ba3338ab`](https://github.com/nix-community/home-manager/commit/ba3338ab990e4348a4e57fc4fdac758524cf7029) waybar: allow setting layer to overlay ([nix-community/home-manager⁠#5729](https://togithub.com/nix-community/home-manager/issues/5729))
* [`7636b248`](https://github.com/nix-community/home-manager/commit/7636b248675e00d887ec0e6932c316d87f36dbf3) hyprland: make package nullable ([nix-community/home-manager⁠#5742](https://togithub.com/nix-community/home-manager/issues/5742))
* [`9ce5d0b8`](https://github.com/nix-community/home-manager/commit/9ce5d0b888a054945121394297ad34173d135547) xdg-autostart: add module ([nix-community/home-manager⁠#5251](https://togithub.com/nix-community/home-manager/issues/5251))
* [`86a0d627`](https://github.com/nix-community/home-manager/commit/86a0d627cae02e8cc5d29eeb03de97f8c652a4bb) home-manger: fix runtime closure ([nix-community/home-manager⁠#5174](https://togithub.com/nix-community/home-manager/issues/5174))
* [`41f3dbd7`](https://github.com/nix-community/home-manager/commit/41f3dbd795fd89017232c1a6a90dc9d760334ef8) linux-wallpaperengine: add ckgxrg as maintainer
* [`d963ed33`](https://github.com/nix-community/home-manager/commit/d963ed335b890a70ed53eecf14cdb21528eda9b8) linux-wallpaperengine: add module
* [`c621c26c`](https://github.com/nix-community/home-manager/commit/c621c26c4c1ea6e0a9a01c3ca33ef62da5ee155d) aerospace: cleanup
* [`7a457746`](https://github.com/nix-community/home-manager/commit/7a457746847c9cb3a1e46e5bc86b205fbadf5da8) aerospace: enable option desc fix ([nix-community/home-manager⁠#6375](https://togithub.com/nix-community/home-manager/issues/6375))
* [`a5e196d6`](https://github.com/nix-community/home-manager/commit/a5e196d61f6e564f7fdeeb4a92cef92e1785d3f5) flake-module: add flake-parts module ([nix-community/home-manager⁠#5229](https://togithub.com/nix-community/home-manager/issues/5229))
* [`9ee99be0`](https://github.com/nix-community/home-manager/commit/9ee99be0c03f30cf3351917402216d256181c4c1) cliphist: add khaneliman maintainer
* [`9a97ac43`](https://github.com/nix-community/home-manager/commit/9a97ac435e3da2a2abf465a0ddd22ce022418495) swaync: add khaneliman maintainer
* [`c3031a0e`](https://github.com/nix-community/home-manager/commit/c3031a0e8c988fdf2880c98ce5fbab7ee637e8ad) waybar: add khaneliman maintainer
* [`06bc3541`](https://github.com/nix-community/home-manager/commit/06bc354189e5a7d94b691779f9cb3ac00bab8bce) neovim: add khaneliman maintainer
* [`ebdbb381`](https://github.com/nix-community/home-manager/commit/ebdbb381034f4af008aed45cd3bdf873b1443792) wezterm: add khaneliman maintainer
* [`178f8265`](https://github.com/nix-community/home-manager/commit/178f8265cbbe72415dcc3759debebf15f308f0bc) kitty: add khaneliman maintainer
* [`05c64fa7`](https://github.com/nix-community/home-manager/commit/05c64fa76b2dfbf4a3f5fbca916bcc7f434739d7) ghostty: add khaneliman maintainer
* [`34e28fc6`](https://github.com/nix-community/home-manager/commit/34e28fc6ddeab63f4c9aa1262b24e8bd1197d613) bat: add khaneliman maintainer
* [`c72b699e`](https://github.com/nix-community/home-manager/commit/c72b699ec6d16f449a34b980d6d4898f231ada6b) btop: add khaneliman maintainer
* [`6a988979`](https://github.com/nix-community/home-manager/commit/6a988979464c3ca13d146ab16bb6996ad86d9b37) nix-index: add khaneliman maintainer
* [`5a3f7c6d`](https://github.com/nix-community/home-manager/commit/5a3f7c6d078557ada97938a41adb05c27f52325e) direnv: add khaneliman maintainer
* [`a77b2c18`](https://github.com/nix-community/home-manager/commit/a77b2c186a0ab3d50abc547a18842340d8a84d10) fastfetch: add khaneliman maintainer
* [`90b7acd9`](https://github.com/nix-community/home-manager/commit/90b7acd9880ff1809807f5c78af869d4dd5969b5) fzf: add khaneliman maintainer
* [`cb985acc`](https://github.com/nix-community/home-manager/commit/cb985acc3ca1cc7d44de0f165b89098f9752f737) git: add khaneliman maintainer
* [`9cb98f31`](https://github.com/nix-community/home-manager/commit/9cb98f3140c02e59d70262a0d0b8e8275ff3b6be) lazygit: add khaneliman maintainer
* [`d62027e4`](https://github.com/nix-community/home-manager/commit/d62027e44d8ff7adc3306482d3c3b195f21f0004) ripgrep: add khaneliman maintainer
* [`bf2a029b`](https://github.com/nix-community/home-manager/commit/bf2a029bcde2e223db10a0a3fb9a94dc9e833d75) yazi: add khaneliman maintainer
* [`20fd9686`](https://github.com/nix-community/home-manager/commit/20fd9686b85dc64657a176466e23d0f3a5e1f760) btop: remove with lib;
* [`2d731a33`](https://github.com/nix-community/home-manager/commit/2d731a33b193209cb88b874e508ea912765f7d99) wezterm: remove with lib
* [`c90cd85b`](https://github.com/nix-community/home-manager/commit/c90cd85b04ff3348978b05ba73ffc8e1b74b9fce) kitty: remove with lib
* [`e3baf274`](https://github.com/nix-community/home-manager/commit/e3baf274f47678df6289c7482353cb6d38b7be5d) bat: remove with lib
* [`fee01c93`](https://github.com/nix-community/home-manager/commit/fee01c9351638a67ec8605a43f2e535c1c66266f) hyprland: fix null package conditions
* [`86b0f304`](https://github.com/nix-community/home-manager/commit/86b0f3049c3a5f3e8ec13a54a323ed3e2587ed93) hyprland: add null package tests
* [`234613d7`](https://github.com/nix-community/home-manager/commit/234613d77c939ff2e2c0f2c476a56d80930e5b8b) neovim: remove with lib
* [`a8159195`](https://github.com/nix-community/home-manager/commit/a8159195bfaef3c64df75d3b1e6a68d49d392be9) flake-module: fix naming
* [`64455251`](https://github.com/nix-community/home-manager/commit/644552519e74bde9c21ea7ec473d5eee67915d25) sway-stubs: add more stubs
* [`e0a2df31`](https://github.com/nix-community/home-manager/commit/e0a2df319302e975a6c8f7fc940315f425b337e8) i3-stubs: add more stubs
* [`02dc2e82`](https://github.com/nix-community/home-manager/commit/02dc2e827f7c677cad1a4cbfcb7ad01728424351) river-stubs: add stubs for river tests
* [`c4f4b1e2`](https://github.com/nix-community/home-manager/commit/c4f4b1e2fa335844aaa98d65066a5a434fa9ce22) bspwm-stubs: add stubs for bspwm tests
* [`e17bdf31`](https://github.com/nix-community/home-manager/commit/e17bdf3191ad5f94c4037117f5635c8b1138c730) herbstluftwm-stubs: add stubs for herbstluftwm tests
* [`c4f28f28`](https://github.com/nix-community/home-manager/commit/c4f28f282f54fc15a60a3b258ecce77a44327958) spectrwm-stubs: add stubs for spectrwm tests
* [`9afd0220`](https://github.com/nix-community/home-manager/commit/9afd02201332756d4bbad273202ecc96049c53b2) wayfire-stubs: add stubs for wayfire tests
* [`801ddd86`](https://github.com/nix-community/home-manager/commit/801ddd8693481866c2cfb1efd44ddbae778ea572) hyprland: use package stubs
* [`055c6705`](https://github.com/nix-community/home-manager/commit/055c67056d87577a39af4144ad5eadb093cfb97d) fcitx5: add waylandFrontend option to not set env vars ([nix-community/home-manager⁠#5431](https://togithub.com/nix-community/home-manager/issues/5431))
* [`8544cd09`](https://github.com/nix-community/home-manager/commit/8544cd092047a7e92d0dce011108a563de7fc0f2) lapce: add module ([nix-community/home-manager⁠#5752](https://togithub.com/nix-community/home-manager/issues/5752))
* [`dae6d346`](https://github.com/nix-community/home-manager/commit/dae6d3460c8bab3ac9f38a86affe45b32818e764) git: add default value null to programs.git.signing.key ([nix-community/home-manager⁠#6032](https://togithub.com/nix-community/home-manager/issues/6032))
* [`18fa9f32`](https://github.com/nix-community/home-manager/commit/18fa9f323d8adbb0b7b8b98a8488db308210ed93) yazi: add main.lua support to plugins ([nix-community/home-manager⁠#6394](https://togithub.com/nix-community/home-manager/issues/6394))
* [`066ba0c5`](https://github.com/nix-community/home-manager/commit/066ba0c5cfddbc9e0dddaec73b1561ad38aa8abe) flake-module: rename `homeModules` to `homeManagerModules` ([nix-community/home-manager⁠#6392](https://togithub.com/nix-community/home-manager/issues/6392))
