### PR TITLE
niv nixpkgs: update 867738f9 -> c1d50403

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "867738f9e61218e552398d2b9e2a4cddb88a5c4f",
-        "sha256": "1aycsks1ps4j8ga7s04w2yalas4ra5c4qapzsma4gdy9jy19mrrb",
+        "rev": "c1d50403531bc57f2d5ea109c747573d57d7342d",
+        "sha256": "0dq98vkx0p90p900h1d88y8f2gvx2daga4pjicl6iva6brcmp22v",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/867738f9e61218e552398d2b9e2a4cddb88a5c4f.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/c1d50403531bc57f2d5ea109c747573d57d7342d.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@867738f9...c1d50403](https://github.com/nixos/nixpkgs/compare/867738f9e61218e552398d2b9e2a4cddb88a5c4f...c1d50403531bc57f2d5ea109c747573d57d7342d)

* [`1182bd00`](https://github.com/NixOS/nixpkgs/commit/1182bd00bdf877f1c61f592790a1925a4610ccee) rmfakecloud: 0.0.21 -> 0.0.23
* [`de4a7667`](https://github.com/NixOS/nixpkgs/commit/de4a766794e72248d0c3ef23a2dab7843e564e15) rmfakecloud: build the webui together with the app
* [`940ff8f2`](https://github.com/NixOS/nixpkgs/commit/940ff8f2c73f4eb6958d316e419aa9afacc5e4cf) gocover-cobertura: 1.2.0 -> 1.3.0
* [`cb41be55`](https://github.com/NixOS/nixpkgs/commit/cb41be55860f68834868896f644270c372541185) timeshift: use substituteInPlace --replace-fail
* [`b201cc70`](https://github.com/NixOS/nixpkgs/commit/b201cc703f531a54d6e04552c6ed402753a8465c) timeshift: patch timeshift-launcher with escapeShellArg instead of a patch file
* [`8c5116e6`](https://github.com/NixOS/nixpkgs/commit/8c5116e6a52a2e6ea878d0ecdee4d5f3be58088f) timeshift: explain the timeshift-launcher string substitution
* [`c00b8000`](https://github.com/NixOS/nixpkgs/commit/c00b800033c21aa39e0e6e4842ebc3deb21ca61d) timeshift: timeshift-launcher: hard-code the timeshift-gtk path
* [`2a70e1ed`](https://github.com/NixOS/nixpkgs/commit/2a70e1ed3071bb258eedec7093802a3020cd8b36) prs: features: change select-skim-bin to select-skim
* [`9cc0aa17`](https://github.com/NixOS/nixpkgs/commit/9cc0aa17bfbedde8214c64a8d1a0bf1a21be89d6) prs: maintainers: remove dotlambda; add colemickens
* [`867b3a92`](https://github.com/NixOS/nixpkgs/commit/867b3a929834e0228fcba40f75283770576a7d12) taskserver: let description reflect support for taskwarrior 2 only
* [`95ebb0ea`](https://github.com/NixOS/nixpkgs/commit/95ebb0ea4b8a87d36382ac88a2c060cd246388ea) nixos/powerdns-admin: adapt for newer flask-session
* [`2cf1cfd3`](https://github.com/NixOS/nixpkgs/commit/2cf1cfd34d9b5db8c477c84a608354606f31fad9) cwtch: 0.1.3 -> 0.1.5
* [`3b1b9872`](https://github.com/NixOS/nixpkgs/commit/3b1b987285acaba03f6d13a23b79fcf2e49f02f6) cwtch-ui: 1.15.1 -> 1.15.4
* [`d69eac07`](https://github.com/NixOS/nixpkgs/commit/d69eac078539d2a95ba99f6249fa46d7f917dc93) choose-gui: fix x86_64-darwin build
* [`002513ae`](https://github.com/NixOS/nixpkgs/commit/002513aeea903d5517a80b096cbc68a477c1d51e) check_interfaces: use versionCheckHook
* [`c14b26ae`](https://github.com/NixOS/nixpkgs/commit/c14b26ae25b3270848767bbf4e9ffc19e101fcc7) blast: fix and enable strictDeps
* [`f0cae1e3`](https://github.com/NixOS/nixpkgs/commit/f0cae1e3c684960a590f6cc5feb2285c467f9f76) itk: fix contradictory ITK_USE_SYSTEM_EIGEN cmake flags
* [`d7b5992d`](https://github.com/NixOS/nixpkgs/commit/d7b5992d16a31c0845351c79ef4ffe257b37c97e) borgmatic: 1.8.14 -> 1.9.5
* [`cc08c29b`](https://github.com/NixOS/nixpkgs/commit/cc08c29bbb5051c3cea98361d5f8a97961017b41) gnome-extension-manager: 0.5.1 -> 0.6.0
* [`1ce7180d`](https://github.com/NixOS/nixpkgs/commit/1ce7180d601787f070986d1e3d199330de6492ff) nixos/wg-quick: add AmneziaWG support
* [`0240773f`](https://github.com/NixOS/nixpkgs/commit/0240773f490a097cd96dc3d7f171f36e717bf08b) nixos/wireguard: add AmneziaWG support
* [`d7a5f005`](https://github.com/NixOS/nixpkgs/commit/d7a5f005944c4e6f524665b2154c523d1c0de8d0) fetchutils: fix cross build
* [`eef5f3d0`](https://github.com/NixOS/nixpkgs/commit/eef5f3d0cacbbdad47b52f1b6f568a154f7fc829) maintainers: add wrvsrx
* [`a2b293e3`](https://github.com/NixOS/nixpkgs/commit/a2b293e3c950b40e5f5644031a715d9ccc128e77) stdenv: introduce nixLog and nixLogWithLevel
* [`38b33b8f`](https://github.com/NixOS/nixpkgs/commit/38b33b8f42a6508cc6d55b1d45666ce7b75bee29) tt-rss-plugin-data-migration: init at unstable-2023-11-01
* [`4273e2c3`](https://github.com/NixOS/nixpkgs/commit/4273e2c391fff635aba0ae7a91ef6b2f2d66bc69) the-powder-toy: 98.2.365 -> 99.0.377
* [`303b44de`](https://github.com/NixOS/nixpkgs/commit/303b44debd116cd91aebd4c03cd560d518c56872) glances: 4.2.1 -> 4.3.0.6
* [`54dfe363`](https://github.com/NixOS/nixpkgs/commit/54dfe363787bbe367250e9e12a2918471062a306) dosage-tracker: init at 1.8.0
* [`9c7d8351`](https://github.com/NixOS/nixpkgs/commit/9c7d8351f0b457ff073dc03a271fabab4ec60a75) legends-of-equestria: add darwin support
* [`591c6de7`](https://github.com/NixOS/nixpkgs/commit/591c6de7bc2aa7265e29a943d923d7e384230e25) e2fsprogs: 1.47.1 -> 1.47.2
* [`2a6ea1be`](https://github.com/NixOS/nixpkgs/commit/2a6ea1be572cbab04c870d7005c60679d0aabc01) flwrap: fix cross build
* [`172d46ee`](https://github.com/NixOS/nixpkgs/commit/172d46ee3c773fa212c13e71d73ded157dde2960) fastjet: fix cross build
* [`f01beefa`](https://github.com/NixOS/nixpkgs/commit/f01beefa3d3da9c1ea06947f0731166f9cda1ad9) fastjet-contrib: fix cross build
* [`045d5755`](https://github.com/NixOS/nixpkgs/commit/045d5755a2f05a585665d3ca13a8b869a5957bf8) flpsed: fix cross build
* [`b3b3fe03`](https://github.com/NixOS/nixpkgs/commit/b3b3fe03c458a4e929705f36cddcbf87d21149a7) SDL_gfx: fix cross build
* [`a0aefa46`](https://github.com/NixOS/nixpkgs/commit/a0aefa462bfe5401f51048a470183c83ae24f612) SDL_mixer: fix cross build
* [`70ffa2d7`](https://github.com/NixOS/nixpkgs/commit/70ffa2d78517310567ea2a5168f018cbd3d36f21) gtk2: fix cross / strictDeps build
* [`639b190d`](https://github.com/NixOS/nixpkgs/commit/639b190d8254478387b0116336897fd92bbcf331) freedroidrpg: fix cross build
* [`a7b52c47`](https://github.com/NixOS/nixpkgs/commit/a7b52c47963f68a4c8b7acf3bcc6e635ec68e240) fish-fillets-ng: fix cross / strictDeps build
* [`8a5f060b`](https://github.com/NixOS/nixpkgs/commit/8a5f060b32dad9ef86b783bca141e8aed8c70262) SDL_ttf: fix cross / strictDeps build
* [`3422fb58`](https://github.com/NixOS/nixpkgs/commit/3422fb581d03e075d741712357f02235883afc49) fllog: fix cross / strictDeps build
* [`ec1af801`](https://github.com/NixOS/nixpkgs/commit/ec1af801cb24f2d207f08ae794a08830ab26ecb3) lvtk: install includes in regular location
* [`943657de`](https://github.com/NixOS/nixpkgs/commit/943657de1c36d8a24932ff0b64a6980d8f6358f0) fcitx5-mcbopomofo: fix strictDeps build
* [`741bc47b`](https://github.com/NixOS/nixpkgs/commit/741bc47b4252055e7cea9e9ef1cbfc854220ce04) grpc: 1.69.0 -> 1.69.0
* [`6eea40ac`](https://github.com/NixOS/nixpkgs/commit/6eea40ac74dc04981a0a52904ba6b6ed0d27d9ef) python312Packages.grpcio: 1.68.1 -> 1.69.0
* [`cc0066da`](https://github.com/NixOS/nixpkgs/commit/cc0066dac2d6a80c9721ea3502731c5389a9a655) python312Packages.grpcio-channelz: 1.68.1 -> 1.69.0
* [`063befa5`](https://github.com/NixOS/nixpkgs/commit/063befa54a445035e1c1cca8a0e4b25affbcd759) python312Packages.grpcio-health-checking: 1.68.1 -> 1.69.0
* [`3efb8d5f`](https://github.com/NixOS/nixpkgs/commit/3efb8d5f9e8ac5afa18f38962f2c7b25d69217ca) python312Packages.grpcio-reflection: 1.68.1 -> 1.69.0
* [`e6061077`](https://github.com/NixOS/nixpkgs/commit/e6061077fbd7edab921043fd730a1f96c3cbf600) python312Packages.grpcio-status: 1.68.1 -> 1.69.0
* [`62db239a`](https://github.com/NixOS/nixpkgs/commit/62db239a007b1ef68028719e21794a3c690dedfe) python312Packages.grpcio-testing: 1.68.1 -> 1.69.0
* [`4edcae72`](https://github.com/NixOS/nixpkgs/commit/4edcae720740d977e6af7b78044887da6f9eaf38) python312Packages.grpcio-tools: 1.68.1 -> 1.69.0
* [`a2b5eb2e`](https://github.com/NixOS/nixpkgs/commit/a2b5eb2e969ab20fe548f3a89830b8554ff00623) postgresql: fix build on x86_64-darwin
* [`19633bd2`](https://github.com/NixOS/nixpkgs/commit/19633bd254579a5f0f7ebc44b5517847caa4f7a2) suitesparse: use effectiveStdenv pattern for cudaSupport
* [`914846db`](https://github.com/NixOS/nixpkgs/commit/914846dbe98f001a2aac86f9534041e9668b44fe) xterm: 396 -> 397
* [`2b807073`](https://github.com/NixOS/nixpkgs/commit/2b8070731ddeb85879e82c106a44bffa6cdd069c) lapack-reference: 3.12.0 -> 3.12.1
* [`45c19f2b`](https://github.com/NixOS/nixpkgs/commit/45c19f2b0674fb1345336cdde36fc71c7c1fb523) libavif: properly enable libsharpyuv support
* [`c0fbb868`](https://github.com/NixOS/nixpkgs/commit/c0fbb8684e6223a90779119a122b233164571d85) protobuf: 29.2 -> 29.3
* [`56a034bd`](https://github.com/NixOS/nixpkgs/commit/56a034bda41b01a088ee171de7c8787d1bcf5fb9) maintainers: add tris203
* [`26f09762`](https://github.com/NixOS/nixpkgs/commit/26f09762a84387d1891f2effeb6f5071ff921b4f) pytestCheckHook: support __structuredAttrs
* [`24729aa8`](https://github.com/NixOS/nixpkgs/commit/24729aa86386111b5af7e34f70f2f414c0411058) python3Packages.pytest-xdist: use pytestFlags
* [`9bf387aa`](https://github.com/NixOS/nixpkgs/commit/9bf387aa9d4bc4039accab9e301ae2cd9c98b0ca) python3Packages.pytest-forked: use pytestFlags
* [`ec6f585f`](https://github.com/NixOS/nixpkgs/commit/ec6f585f05963c59433fbbf6337d35c51fc475d1) pytestCheckHook: lint with ShellCheck
* [`d8c36cb2`](https://github.com/NixOS/nixpkgs/commit/d8c36cb25232bb661ccf373a8911910690aa7e92) setuptoolsBuildHook: support __structuredAttrs
* [`1c9b35c2`](https://github.com/NixOS/nixpkgs/commit/1c9b35c2483d4c2f8cc0f2416c8539d509f02274) python3packages.mysql-connector: specify setupPyBuildFlags directly without expecting Bash expansion
* [`71e47c95`](https://github.com/NixOS/nixpkgs/commit/71e47c958d46e4e7ac5a440754dad785904a944a) python3Packages.vowpalwabbit: specify setupPyBuildFlags without Bash-expanding expection
* [`76f6a3b2`](https://github.com/NixOS/nixpkgs/commit/76f6a3b292553fc95631fa54f90aed4ff87ffcbc) setuptoolsBuildHook: lint with ShellCheck
* [`1e8f3914`](https://github.com/NixOS/nixpkgs/commit/1e8f39148abbc0fc4d446b088019364d1995c689) unittestCheckHook: handle unittestFlagsArray `__structuredAttrs`-agnostically
* [`9b07602c`](https://github.com/NixOS/nixpkgs/commit/9b07602c8e09a97f030986052a7841e3e2bb9bc8) unittestCheckHook: lint with ShellCheck
* [`8be69aee`](https://github.com/NixOS/nixpkgs/commit/8be69aee9687540bda6f48e5bfdb8e01fb73de2d) doc: python: elaborate the makeWrapperArgs behaviour
* [`4fae2f59`](https://github.com/NixOS/nixpkgs/commit/4fae2f59eeb9128d4c9021a063d34e62a5592d3b) rl-2505.section.md: add entries about buildPython*'s __structuredAttrs support
* [`53da1217`](https://github.com/NixOS/nixpkgs/commit/53da12177e3e6674872f7890665636591eda05d7) python3Packages.conda: use __structuredAttrs = true
* [`625cf904`](https://github.com/NixOS/nixpkgs/commit/625cf90466022be8a17879224ff90daa6d38b5af) python3Packages.tensorflow: use __structuredAttrs = true
* [`80b2f9f1`](https://github.com/NixOS/nixpkgs/commit/80b2f9f1bbffe7d19a6ee879b322d8ac974b7aa3) python312Packages.scipy: 1.14.1 -> 1.15.0
* [`75dfe81c`](https://github.com/NixOS/nixpkgs/commit/75dfe81caf85265943e23070f98c1ddc8c69aa18) buildGoModule: fix GO_NO_VENDOR_CHECKS for v1.23+
* [`553d8989`](https://github.com/NixOS/nixpkgs/commit/553d898940b35a12c33fbc5596c69965e924c559) lpd8editor: replace `git` with `gitMinimal`
* [`676389b0`](https://github.com/NixOS/nixpkgs/commit/676389b044ad39df3febba0a9b35b93066af4d03) nano: replace `git` with `gitMinimal`
* [`5a408726`](https://github.com/NixOS/nixpkgs/commit/5a40872640be5414bbe26e737a242caeddc28055) zcash: replace `git` with `gitMinimal`
* [`31d83c33`](https://github.com/NixOS/nixpkgs/commit/31d83c33622ac109800cae8b16dc05f58628bada) visidata: replace `git` with `gitMinimal`
* [`c89ad207`](https://github.com/NixOS/nixpkgs/commit/c89ad2075009e81af1bf6db1644637dd9659e489) biome: replace `git` with `gitMinimal`
* [`17dabde5`](https://github.com/NixOS/nixpkgs/commit/17dabde5c6ff1ea6580abd80b195e625c1d944c3) cargo-llvm-cov: replace `git` with `gitMinimal`
* [`87516c65`](https://github.com/NixOS/nixpkgs/commit/87516c65d331a8802abbb641debb4dae369846c5) databricks-cli: replace `git` with `gitMinimal`
* [`b28a138a`](https://github.com/NixOS/nixpkgs/commit/b28a138a7733863dcd1249920a01c31662407d0d) github-runner: replace `git` with `gitMinimal`
* [`3c05d6b6`](https://github.com/NixOS/nixpkgs/commit/3c05d6b61bf6d21708590c0be2dc538c27bbfa72) gitstatus: replace `git` with `gitMinimal`
* [`fcf74752`](https://github.com/NixOS/nixpkgs/commit/fcf74752116b703d96fcb487597b0a9d70bade5c) glitter: replace `git` with `gitMinimal`
* [`ee9df0c5`](https://github.com/NixOS/nixpkgs/commit/ee9df0c5ae4a9671c960bb35c27949b823009896) ko: replace `git` with `gitMinimal`
* [`f5840d2b`](https://github.com/NixOS/nixpkgs/commit/f5840d2bb7919233f3af98f8bfaa47bedb705df2) log4j-sniffer: replace `git` with `gitMinimal`
* [`7d190c1e`](https://github.com/NixOS/nixpkgs/commit/7d190c1e944ea4f73334ca7a8bf9cbd32c0a4832) onefetch: replace `git` with `gitMinimal`
* [`fcff431b`](https://github.com/NixOS/nixpkgs/commit/fcff431ba53a2aec882993bfc95a96fd926b6fec) pre-commit: replace `git` with `gitMinimal`
* [`d3826bcd`](https://github.com/NixOS/nixpkgs/commit/d3826bcd89eb68be63e288b6dfae192353b4cab4) stellar-core: replace `git` with `gitMinimal`
* [`b2431972`](https://github.com/NixOS/nixpkgs/commit/b24319726a948e4707015eae2bfe8d096cd8b5ee) taler-wallet-core: replace `git` with `gitMinimal`
* [`49303166`](https://github.com/NixOS/nixpkgs/commit/4930316677b7f341c745e411fec7b7c2d1e2534c) flutter: replace `git` with `gitMinimal`
* [`dc3d1433`](https://github.com/NixOS/nixpkgs/commit/dc3d1433babf0f67aa9d3c9d5222fcf1c42f0bcf) julia-modules: replace `git` with `gitMinimal`
* [`a78aacee`](https://github.com/NixOS/nixpkgs/commit/a78aaceefcb7ab1297058699813e3611f3e006f4) python312Packages.commitizen: replace `git` with `gitMinimal`
* [`6c62a00e`](https://github.com/NixOS/nixpkgs/commit/6c62a00e47ebf1caec4bc6a2b1a2615e94a4676d) python312Packages.font-v: replace `git` with `gitMinimal`
* [`f309a89c`](https://github.com/NixOS/nixpkgs/commit/f309a89c5aafa7864cd71f1dcf4a48cb994b47c3) python312Packages.fontbakery: replace `git` with `gitMinimal`
* [`88129f58`](https://github.com/NixOS/nixpkgs/commit/88129f58679972030cf4f6dcdeb0e9825fbc7611) python312Packages.playwright: replace `git` with `gitMinimal`
* [`7d5bee9d`](https://github.com/NixOS/nixpkgs/commit/7d5bee9d1d013b54dd31ab06d27c5da9a3f05592) python312Packages.pre-commit-hooks: replace `git` with `gitMinimal`
* [`29748634`](https://github.com/NixOS/nixpkgs/commit/2974863439d344118c2b2d8e592eb015ebee09b6) build-support/make-hardcode-gsettings-patch: replace `git` with `gitMinimal`
* [`a9115b3a`](https://github.com/NixOS/nixpkgs/commit/a9115b3a83c938d794c5fda17e4ea05c9386fb57) nbstripout: replace `git` with `gitMinimal`
* [`f7e55fbc`](https://github.com/NixOS/nixpkgs/commit/f7e55fbcd058384a5ce15db2e6ac29f78c624431) cargo-generate: replace `git` with `gitMinimal`
* [`31d810e9`](https://github.com/NixOS/nixpkgs/commit/31d810e933e3b10ef82a5928e6d9269cd87fc76e) git-aggregator: replace `git` with `gitMinimal`
* [`7bb1650e`](https://github.com/NixOS/nixpkgs/commit/7bb1650eed96d116672a7e937f3af089eba94c6b) git-bug-migration: replace `git` with `gitMinimal`
* [`4a9c8f10`](https://github.com/NixOS/nixpkgs/commit/4a9c8f10573db1d2a15ce1f26bc045fd1702a59c) git-dive: replace `git` with `gitMinimal`
* [`cd48b304`](https://github.com/NixOS/nixpkgs/commit/cd48b3042c8b6dc8e8ad28ea423c066e9661d347) git-fast-export: replace `git` with `gitMinimal`
* [`375f9990`](https://github.com/NixOS/nixpkgs/commit/375f99903358a306b9ff61f65facad3817b5bba2) gst: replace `git` with `gitMinimal`
* [`ad0ad610`](https://github.com/NixOS/nixpkgs/commit/ad0ad610967810c0ce7650e1006020389c7f1130) zoekt: replace `git` with `gitMinimal`
* [`2705763c`](https://github.com/NixOS/nixpkgs/commit/2705763c5f61a2d4a2e07952e4523086c7cc82f7) python312Packages.dunamai: replace `git` with `gitMinimal`
* [`15b915cc`](https://github.com/NixOS/nixpkgs/commit/15b915cc8b851a543fc19dee26b38a7ab771485f) python312Packages.gto: replace `git` with `gitMinimal`
* [`170c8ab0`](https://github.com/NixOS/nixpkgs/commit/170c8ab0eb218636495de6f80d139852708d2c61) python312Packages.nbdime: replace `git` with `gitMinimal`
* [`6a187ef3`](https://github.com/NixOS/nixpkgs/commit/6a187ef35a4027c33c1eb87400e2e80835553c83) python312Packages.pdm-backend: replace `git` with `gitMinimal`
* [`67a5a288`](https://github.com/NixOS/nixpkgs/commit/67a5a288c9271234527ba400e3a87d705ba439d7) python312Packages.pdm-pep517: replace `git` with `gitMinimal`
* [`2a4bb2ea`](https://github.com/NixOS/nixpkgs/commit/2a4bb2ea5933144c609326335cf1420a6cf2e246) python312Packages.pypass: replace `git` with `gitMinimal`
* [`1a91e2f2`](https://github.com/NixOS/nixpkgs/commit/1a91e2f24b014f14e81fb56032a3b88521120902) dune-release: replace `git` with `gitMinimal`
* [`756d00cc`](https://github.com/NixOS/nixpkgs/commit/756d00ccfb963491c4eafd60882bc1b1af39860c) cargo-crev: replace `git` with `gitMinimal`
* [`90f8d2e2`](https://github.com/NixOS/nixpkgs/commit/90f8d2e2aa1eb1a120c9792d1a7b85edc8bf0625) flexget: 3.13.6 -> 3.13.10
* [`55442f68`](https://github.com/NixOS/nixpkgs/commit/55442f689a925f1a4d2efb4d4990d98cc9faca98) elixir: use env shebang only on Darwin
* [`5716880c`](https://github.com/NixOS/nixpkgs/commit/5716880c92498936b3bba2a27077270c54dd4eae) neovim-require-check-hook: fix ignore directories
* [`8d18f59f`](https://github.com/NixOS/nixpkgs/commit/8d18f59ff5bd747f789737f4136c8d46fda66c58) ed: 1.20.2 -> 1.21
* [`4aa50414`](https://github.com/NixOS/nixpkgs/commit/4aa504148c5e67f790c0b0b2ac73df68592b134a) python312Packages.zope-configuration: 5.0.1 -> 6.0
* [`ec57e55c`](https://github.com/NixOS/nixpkgs/commit/ec57e55c470688c43ad243b12951886f3bd2f73d) python312Packages.zope-i18nmessageid: 6.1.0 -> 7.0
* [`dbedf7e8`](https://github.com/NixOS/nixpkgs/commit/dbedf7e8fe6af735abb2d7d0eddefb170fbb0c4c) python312Packages.zope-interface: 6.4.post2 -> 7.2
* [`93dc9c63`](https://github.com/NixOS/nixpkgs/commit/93dc9c630e3aed9c1e3093112f143a2c0c6fb9c4) python312Packages.zope-security: init at 7.3
* [`270f14c0`](https://github.com/NixOS/nixpkgs/commit/270f14c060ed483b528b8e07c5152db468bb702b) python312Packages.zope-size: refactor
* [`fdc65b20`](https://github.com/NixOS/nixpkgs/commit/fdc65b20c155a16557e618d713b110fea5d820c2) python312Packages.zope-copy: 4.3 -> 5.0
* [`e5e38792`](https://github.com/NixOS/nixpkgs/commit/e5e387929b565f6b7e1e36c5f15aa7932dbd21ef) python312Packages.zope-event: 4.6 -> 5.0
* [`09aee680`](https://github.com/NixOS/nixpkgs/commit/09aee68012350575e577a84655bd274d158328f1) python312Packages.zope-proxy: 5.3 -> 6.1
* [`ac4d0ff3`](https://github.com/NixOS/nixpkgs/commit/ac4d0ff3b6e3508eb283bea178d2778ad715e848) python312Packages.zope-schema: refactor
* [`183b8f5a`](https://github.com/NixOS/nixpkgs/commit/183b8f5a441fa5491e0cebdb4047935597f625d6) python312Packages.zope-testing: refactor
* [`04622d27`](https://github.com/NixOS/nixpkgs/commit/04622d274f83c2b2412067ede3833922850745c4) python312Packages.zope-location: refactor
* [`b23cbd82`](https://github.com/NixOS/nixpkgs/commit/b23cbd820f174da25c6ff9a65f4593cdf89de521) python312Packages.zope-hookable: 6.0 -> 7.0
* [`72591df3`](https://github.com/NixOS/nixpkgs/commit/72591df33c690d08ac71b9719f5ddd6270b3d1ce) python312Packages.zope-component: refactor
* [`121c4520`](https://github.com/NixOS/nixpkgs/commit/121c452051bf32413be5e954a6b91be2bbc15bac) python312Packages.zope-testrunner: 6.4 -> 6.6.1
* [`9ff0763e`](https://github.com/NixOS/nixpkgs/commit/9ff0763eab781ce8926a8816dad6c635afd59071) python312Packages.zope-dottedname: refactor
* [`0026ea2a`](https://github.com/NixOS/nixpkgs/commit/0026ea2a19193d59f98d69c95b52220bf44471c5) python312Packages.zope-deprecation: refactor
* [`cc1e8fb2`](https://github.com/NixOS/nixpkgs/commit/cc1e8fb238f2d9f0e42b93eb894522075d5990f4) python312Packages.zope-contenttype: refactor
* [`35156fa6`](https://github.com/NixOS/nixpkgs/commit/35156fa65ca7e08833103e6c8cf207cd08e90ef9) python312Packages.zope-deferredimport: refactor
* [`b8bcb1f2`](https://github.com/NixOS/nixpkgs/commit/b8bcb1f21f387a76bce6885f737cb033b3ae36e1) python312Packages.zope-lifecycleevent: refactor
* [`50a847bb`](https://github.com/NixOS/nixpkgs/commit/50a847bbd2442f76536ef65f7131ad5be1c0743d) python312Packages.zope-cachedescriptors: refactor
* [`9f514393`](https://github.com/NixOS/nixpkgs/commit/9f5143931680937243771a209a9eaa096e2b4d83) python312Packages.zope-filerepresentation: refactor
* [`b2ce0ba3`](https://github.com/NixOS/nixpkgs/commit/b2ce0ba3816ee25ed24c3e9858a1975c53063848) python312Packages.zodbpickle: fix licenses
* [`6d0259c6`](https://github.com/NixOS/nixpkgs/commit/6d0259c66375b00afd661fa5f7a2013c580fefd7) python312Packages.zconfig: refactor
* [`2d90fabc`](https://github.com/NixOS/nixpkgs/commit/2d90fabc797281f3b2ca22d7e20a21cacc5d2f1e) python312Packages.zc-lockfile: refactor
* [`08c1723c`](https://github.com/NixOS/nixpkgs/commit/08c1723c1a9fa37402b548327ec2a5b1be7a2516) python312Packages.zdaemon: refactor
* [`0c5b457a`](https://github.com/NixOS/nixpkgs/commit/0c5b457a326f5a54d75c3a1f78a49b3e35086ff0) remmina: fix darwin build for newer clang
* [`f0204274`](https://github.com/NixOS/nixpkgs/commit/f0204274d3a7dd3153d99bf50f322ba5e75dc3a3) pre-commit.tests: fix the eval
* [`37e2a809`](https://github.com/NixOS/nixpkgs/commit/37e2a8099638c3da70ea2e51860d283433e8cace) nixos/nix-required-mounts: Fix outdated option hardware.opengl
* [`595caa6f`](https://github.com/NixOS/nixpkgs/commit/595caa6fdac4ec73997ecacc420096298b4d1bd4) python312Packages.scipy: 1.15.0 -> 1.15.1
* [`0246f92d`](https://github.com/NixOS/nixpkgs/commit/0246f92d6c79f604487cff07986a041bdcd2a7e6) vim: 9.1.0990 -> 9.1.1006
* [`2b1e87e1`](https://github.com/NixOS/nixpkgs/commit/2b1e87e1ecb829fa76c1a326eca16a1896788083) python313Packages.sqlalchemy: 2.0.36 -> 2.0.37
* [`64ec158e`](https://github.com/NixOS/nixpkgs/commit/64ec158ea86f53e3d4e5807e5e4d0b16d95a1b1a) libcap: remove runtime reference to `go`
* [`8ac4a94f`](https://github.com/NixOS/nixpkgs/commit/8ac4a94f1b25a84c8bb5498cb4204dc5c2dd27ab) sbcl: 2.4.11 -> 2.5.0
* [`0acbc191`](https://github.com/NixOS/nixpkgs/commit/0acbc1917df26a28a2739fc697e2b6706ffe7321) reposilite: add uku3lig to maintainers
* [`3fc7fdef`](https://github.com/NixOS/nixpkgs/commit/3fc7fdef3923f01a33667a35c7fce462b5e9cb85) gd: cleanup, modernize
* [`b17f43c5`](https://github.com/NixOS/nixpkgs/commit/b17f43c5d536a3f008d2f8f63b31aa39cbb65dbc) gd: move to pkgs/by-name
* [`6eeba57d`](https://github.com/NixOS/nixpkgs/commit/6eeba57d9a82dc0e6915b6ee5ca368e9feb55653) xorg.{utilmacros,xkeyboardconfig}: treat autotools as native inputs
* [`1c29d683`](https://github.com/NixOS/nixpkgs/commit/1c29d68344a8365367f9f01aa29af4641f89a2eb) aalib: cleanup, config.{sub,guess} updated by stdenv hook now
* [`4c3ed9d6`](https://github.com/NixOS/nixpkgs/commit/4c3ed9d61d495456aeb9ea74a2d77ef445868352) python312Packages.networkx: 3.3 -> 3.4.2
* [`833e0b19`](https://github.com/NixOS/nixpkgs/commit/833e0b1970936532dda4bd961c954499e1777fb0) python312Packages.aiohappyeyeballs: sphinx-autobuild is unneeded for build, replace with regular sphinx
* [`2435407d`](https://github.com/NixOS/nixpkgs/commit/2435407d78b00df53900335a3f1bba2fb2b104c1) spacedrive: fix darwin binary symlink
* [`cce6f178`](https://github.com/NixOS/nixpkgs/commit/cce6f178d2dd1f179a57b514d07280bb4d2a8164) python312Packages.fsspec: 2024.3.0 -> 2024.12.0
* [`e132c131`](https://github.com/NixOS/nixpkgs/commit/e132c131d966ee3abed7d614a7fe2e63186a24b8) python312Packages.fsspec: refactor
* [`1b21df1f`](https://github.com/NixOS/nixpkgs/commit/1b21df1f3390d0e04a7ff0d93fd3523f771b3421) python312Packages.s3fs: 2024.9.0 -> 2024.12.0
* [`18667eeb`](https://github.com/NixOS/nixpkgs/commit/18667eeb8c9435464f667ae1050dad071fd29ee4) python312Packages.s3fs: refactor
* [`da3c625f`](https://github.com/NixOS/nixpkgs/commit/da3c625f7c5bbaa52af4abc4965da8f82b7315ec) libcap: use correct cross golang cross compiler
* [`81806a92`](https://github.com/NixOS/nixpkgs/commit/81806a9294ea300a3e0161b9e0901b6a156361f4) ladspaPlugins: fix cross-compilation for aarch64
* [`e11fc0b9`](https://github.com/NixOS/nixpkgs/commit/e11fc0b96a534b4c1ee32c5bb1750674cd556fa7) bzip2: Embed autoconf patch
* [`3fde601c`](https://github.com/NixOS/nixpkgs/commit/3fde601cf079f640feacfd0d323420b013635f11) fertilizer: init at 0.3.0
* [`2df17d7c`](https://github.com/NixOS/nixpkgs/commit/2df17d7c9790b0fa0980bc4b4bc5f4e66c9faaf8) cmake: clean up obsolete Darwin patches
* [`4769d2ba`](https://github.com/NixOS/nixpkgs/commit/4769d2bad5adb7099185b1974546ef9a45abaaf5) vector: 0.43.1 -> 0.44.0
* [`b851789a`](https://github.com/NixOS/nixpkgs/commit/b851789ab0f7ae545da7292b04c8cd2aad12bff4) openjpeg: apply patches for CVE-2024-56826
* [`65aa905e`](https://github.com/NixOS/nixpkgs/commit/65aa905e470e4733523176b789fc39d6f8a11e10) python3Packages.pylance: 0.18.2 -> 0.22.0
* [`13d23dee`](https://github.com/NixOS/nixpkgs/commit/13d23deeac61fcf613d1a23db9929188b17b4703) maintainers: add ambossmann
* [`946c4ea1`](https://github.com/NixOS/nixpkgs/commit/946c4ea1ce6f6d589914b71a9a3483e9210d1ceb) python3Packages.lancedb: 0.14.0 -> 0.18.0
* [`d8c10f07`](https://github.com/NixOS/nixpkgs/commit/d8c10f07988449084d174abd2f31e314938a49b9) python313Packages.django_4: 4.2.17 -> 4.2.18
* [`00d14b8f`](https://github.com/NixOS/nixpkgs/commit/00d14b8fb7d129ba9b06307de50ddc194eab0e8c) libxcrypt: 4.4.36 -> 4.4.38
* [`7e92703f`](https://github.com/NixOS/nixpkgs/commit/7e92703f04b1096df66822ea227d8ffeeca3013d) git: 2.47.1 -> 2.47.2
* [`5e4ab19f`](https://github.com/NixOS/nixpkgs/commit/5e4ab19f509f38913b62f85ed40c01f757ca11ca) release-staging: init
* [`e30ba303`](https://github.com/NixOS/nixpkgs/commit/e30ba30304dbc49ec2e88e12840d0388c48dde48) apple-sdk: use llvm-readtapi instead of tapi
* [`25b03f7b`](https://github.com/NixOS/nixpkgs/commit/25b03f7b4482be660eebc88232ee0bebdf082d32) llvmPackages_19: 19.1.6 -> 19.1.7
* [`75716068`](https://github.com/NixOS/nixpkgs/commit/75716068845467b3d2ff87363c8052e3103a8fe5) libopenmpt: 0.7.12 -> 0.7.13
* [`42a45144`](https://github.com/NixOS/nixpkgs/commit/42a4514475d78b84ca77c32cc5896a8f0ad14d90) glslang: 15.0.0 -> 15.1.0
* [`cbb703b0`](https://github.com/NixOS/nixpkgs/commit/cbb703b0611f3b8277ddac3a975257166d447e15) vulkan-headers: 1.3.296.0 -> 1.4.304.0
* [`d9f8dc86`](https://github.com/NixOS/nixpkgs/commit/d9f8dc86db7a32ae00d92c691807487a2f9bbbb2) vulkan-loader: 1.3.296.0 -> 1.4.304.0
* [`30d3ed43`](https://github.com/NixOS/nixpkgs/commit/30d3ed43f63440639707037e00cf63bba61626a0) vulkan-validation-layers: 1.3.296.0 -> 1.4.304.0
* [`8349591a`](https://github.com/NixOS/nixpkgs/commit/8349591ac575799c044636b338a19d1bf7e70fff) vulkan-tools: 1.3.296.0 -> 1.4.304.0
* [`b93ab769`](https://github.com/NixOS/nixpkgs/commit/b93ab769f8518fec272643cd42bdf869a69c4299) vulkan-tools-lunarg: 1.3.296.0 -> 1.4.304.0
* [`c556c663`](https://github.com/NixOS/nixpkgs/commit/c556c6637504e4452fccdb595395dfcdc8bd1f67) vulkan-extension-layer: 1.3.296.0 -> 1.4.304.0
* [`5baf9d17`](https://github.com/NixOS/nixpkgs/commit/5baf9d17f281fde6217b2be67e9c6dd77447a064) vulkan-utility-libraries: 1.3.296.0 -> 1.4.304.0
* [`dfff72fd`](https://github.com/NixOS/nixpkgs/commit/dfff72fd969bc1cf9d2633da4c808119147e269d) vulkan-volk: 1.3.296.0 -> 1.4.304.0
* [`c28b09d3`](https://github.com/NixOS/nixpkgs/commit/c28b09d3eb76e31a955c6f486403f692ba4f1f91) spirv-headers: 1.3.296.0 -> 1.4.304.0
* [`863f9bc4`](https://github.com/NixOS/nixpkgs/commit/863f9bc40631822ff8137830ac5c3878e4c8f5da) spirv-cross: 1.3.296.0 -> 1.4.304.0
* [`872d8301`](https://github.com/NixOS/nixpkgs/commit/872d8301e3ee5f16de91841b95073e7b8548bb3f) spirv-tools: 1.3.296.0 -> 1.4.304.0
* [`80c35e34`](https://github.com/NixOS/nixpkgs/commit/80c35e346fe7c8d2adafbaeccb1820227a802993) godotpcktool: init at 2.1
* [`47ab1050`](https://github.com/NixOS/nixpkgs/commit/47ab1050fa9a97fa410f81696677cf353d7ffee3) libtapi: 1500.0.12.3 -> 1600.0.11.8
* [`ffd16f76`](https://github.com/NixOS/nixpkgs/commit/ffd16f7647dd7a7fda56106e05bc2b42d4eea0f6) zabbix70: 7.0.7 -> 7.0.8
* [`79a3e762`](https://github.com/NixOS/nixpkgs/commit/79a3e7628f72045946fb3cb40509fdaa4be8655d) rsync: 3.3.0 -> 3.4.1
* [`910c397c`](https://github.com/NixOS/nixpkgs/commit/910c397cad1a2e24c8af4eb0aea78b189cd0b7ff) libuv: 1.49.2 -> 1.50.0
* [`7f3e38ca`](https://github.com/NixOS/nixpkgs/commit/7f3e38ca45fd28c829c9c85bcfbd0a63eb3d9b14) rust-cbindgen: 0.27.0 -> 0.28.0
* [`5193dc33`](https://github.com/NixOS/nixpkgs/commit/5193dc335eafb561d719d3e91d94a8d5b3df629a) libsoup_3: 3.6.1 -> 3.6.3
* [`e0f3c630`](https://github.com/NixOS/nixpkgs/commit/e0f3c630ceba6b450413599b7e2f0fdab8ad54fe) mpvScripts.skipsilence: init at 0-unstable-2024-05-06
* [`878140ef`](https://github.com/NixOS/nixpkgs/commit/878140ef759691234403d6fd7cbe2b55c657366b) psqlodbc: adopt with NixOS/postgres team
* [`e9da71e0`](https://github.com/NixOS/nixpkgs/commit/e9da71e086951afc23af61cf86fd642d07ddf5ed) psqlodbc: 16.00.0000 -> 17.00.0002
* [`bead8471`](https://github.com/NixOS/nixpkgs/commit/bead84713d35f416f2789fedf8c2f4572ca5c54c) psqlodbc: add updateScript
* [`e1a79456`](https://github.com/NixOS/nixpkgs/commit/e1a79456eb22fcbe9c4a097366ea6ff2b3429977) hydra: postgresql is a check dependency only
* [`c0d940b2`](https://github.com/NixOS/nixpkgs/commit/c0d940b21b1aa7e466a86c17d0ba23b56baae6ed) opendht: 3.2.0 -> 3.2.0-unstable-2025-01-05
* [`d41c444e`](https://github.com/NixOS/nixpkgs/commit/d41c444e5b409738e133454ec56cf3e6fde4ffdd) opendht: format
* [`9bd20c90`](https://github.com/NixOS/nixpkgs/commit/9bd20c90a7c150e1909872dfd8e5922902c1d6dc) tzupdate: be resilient to network issues tzupdate experiences
* [`48e18343`](https://github.com/NixOS/nixpkgs/commit/48e18343ce808566a9f434c3613e5fc76b223a8f) go_1_23: 1.23.4 -> 1.23.5
* [`a058588d`](https://github.com/NixOS/nixpkgs/commit/a058588d6c65b4adadcd45bb384e876fa0d6eafc) rzls: init at 9.0.0-preview.25052.3
* [`5c8bd5c6`](https://github.com/NixOS/nixpkgs/commit/5c8bd5c69460b7b9c3174a6e907cfb5cfeabdc2f) abuild: set proper pkg-config name
* [`892f0edf`](https://github.com/NixOS/nixpkgs/commit/892f0edfb10f1b74bc2bf6fa2b49eef170819b0f) tzdata: 2024b -> 2025a
* [`0c912107`](https://github.com/NixOS/nixpkgs/commit/0c912107eee197ef22af405944df9146db008007) python312Packages.bash-kernel: 0.9.3 -> 0.10.0
* [`2d989c04`](https://github.com/NixOS/nixpkgs/commit/2d989c047998a0ecf2f8d9c75ba67a17c258aab7) python312Packages.jupysql: 0.10.16 -> 0.10.17
* [`8b7dd9cd`](https://github.com/NixOS/nixpkgs/commit/8b7dd9cdd94fc4531f3a110596a9cb34fdacee26) python312Packages.ckzg: init at 2.0.1
* [`fd02b0a1`](https://github.com/NixOS/nixpkgs/commit/fd02b0a1536370b875823bb58c5e17a6f6c75c8f) python312Packages.eth-abi: 4.1.0 -> 5.1.0
* [`63c77937`](https://github.com/NixOS/nixpkgs/commit/63c77937bbb9ee419094d14cdf7683578ee02d1b) redis: 7.2.6 -> 7.2.7
* [`65f44ca9`](https://github.com/NixOS/nixpkgs/commit/65f44ca919186dcaa1c1d18157a890714a97732b) python312Packages.jupyter-events: 0.10.0 -> 0.11.0
* [`be1859bf`](https://github.com/NixOS/nixpkgs/commit/be1859bf9613c124d50a7c5ee2be8bc38af56a7d) python312Packages.jupyter-server: 2.14.2 -> 2.15.0
* [`6d34e47c`](https://github.com/NixOS/nixpkgs/commit/6d34e47c40e8032942ff9baf5b0723e8330595e6) python312Packages.jupyterhub-ldapauthenticator: 2.0.1 -> 2.0.2
* [`1cf71b05`](https://github.com/NixOS/nixpkgs/commit/1cf71b0533be4cf57321fba81d333c38f5d47bdc) python312Packages.jupyterlab: 4.2.5 -> 4.3.4
* [`8cb5fba3`](https://github.com/NixOS/nixpkgs/commit/8cb5fba3d3e3ca26f21de6b34503d3406e503381) python312Packages.livelossplot: 0.5.5 -> 0.5.6
* [`160d2cb8`](https://github.com/NixOS/nixpkgs/commit/160d2cb80ab21f82bff97fa3f6d6d7bcfc74c8e5) python312Packages.marimo: 0.10.9 -> 0.10.14
* [`251026db`](https://github.com/NixOS/nixpkgs/commit/251026db0fa025aa15ca83638ee1370347d290ab) python312Packages.nbclassic: 1.1.0 -> 1.2.0
* [`52ce6c28`](https://github.com/NixOS/nixpkgs/commit/52ce6c2877317a88d4827c0c9b9b511d467b1f9b) python312Packages.nbclient: 0.10.0 -> 0.10.2
* [`fe79c96a`](https://github.com/NixOS/nixpkgs/commit/fe79c96ab486cb238eda4e928fcf04c84b91ef7a) python312Packages.nbconvert: 7.16.4 -> 7.16.5
* [`1552b610`](https://github.com/NixOS/nixpkgs/commit/1552b6104ef272ab47da591e213f42ddc1ffbf4d) python312Packages.notebook: 7.2.2 -> 7.3.2
* [`1967bc98`](https://github.com/NixOS/nixpkgs/commit/1967bc98d3ea2f8be7af49b8a65d7e7082549ca3) python312Packages.pycrdt-websocket: 0.15.1 -> 0.15.3
* [`23b95cf5`](https://github.com/NixOS/nixpkgs/commit/23b95cf5dfbc4794f5dff38ff6b868850bfbbd6f) python312Packages.jupyter-events: add teams.jupyter.members as maintainers
* [`57ab9a16`](https://github.com/NixOS/nixpkgs/commit/57ab9a16eb4baf741b17ee3301dd1a5743815244) python312Packages.livelossplot: refactor
* [`bee8b406`](https://github.com/NixOS/nixpkgs/commit/bee8b40675c1707b7996725d9d7c4efc6100d789) libsoup_3: 3.6.3 -> 3.6.4
* [`137980a2`](https://github.com/NixOS/nixpkgs/commit/137980a2a8d860c6e93478041d7aeccf5066f7dc) python312Packages.numpy: 2.2.0 -> 2.2.2
* [`fdfe5b94`](https://github.com/NixOS/nixpkgs/commit/fdfe5b9458a6e579879e254a0490b68502926523) xwayland: fix building with llvm
* [`6fd56f4d`](https://github.com/NixOS/nixpkgs/commit/6fd56f4dc8caebb05e777b530eccd96ef9a87a20) p11-kit: add meta.mainProgram
* [`8adce946`](https://github.com/NixOS/nixpkgs/commit/8adce9464c731d751863855c214ce5cd6617fbe7) python3Packages.contourpy: fix cross build
* [`ab5f7ea4`](https://github.com/NixOS/nixpkgs/commit/ab5f7ea487c5fe450955c31e8830514542d3c7d9) gdb: 15.2 -> 16.1
* [`f10143ec`](https://github.com/NixOS/nixpkgs/commit/f10143ec342c6d96ad925f6f31e5b07fdf1e4d95) nixos/wakapi: fix logical error in warning; minor grammatical improvements
* [`d179b9d9`](https://github.com/NixOS/nixpkgs/commit/d179b9d900e859925429c35385e3252019f1840f) lvm2: reformat by nixfmt
* [`9d54b779`](https://github.com/NixOS/nixpkgs/commit/9d54b7793cf0593f1fd4da28075b809ea08f9404) lvm2: place profile snippets into profile.d to avoid path conflicts
* [`546ece56`](https://github.com/NixOS/nixpkgs/commit/546ece569b66f3995839ffe87726177831aca72e) libpq: init at 17.2
* [`b12e9707`](https://github.com/NixOS/nixpkgs/commit/b12e9707e0bafae6f0c2d841caafc76bf9b4b16c) treewide: replace substituteAll with replaceVars (part 3)
* [`3f8254ef`](https://github.com/NixOS/nixpkgs/commit/3f8254ef7d477180f12dde9e0b96eda2a4258f43) lvm2: fix inclusion of nixosTests.lvm2 in tests
* [`c1e93aee`](https://github.com/NixOS/nixpkgs/commit/c1e93aee0a2c5dfc867f3418086f6783cb45efaf) rofi-unwrapped: 1.7.7 -> 1.7.8
* [`16b5545f`](https://github.com/NixOS/nixpkgs/commit/16b5545f9f5156548019edbbf6908cb147acbbcc) python312Packages.eth-typing: 5.0.1 -> 5.1.0
* [`4ee01994`](https://github.com/NixOS/nixpkgs/commit/4ee019941b6efe7e69c98dae0a7744a0afda6961) python312Packages.eth-utils: tidy code up
* [`63b42ea0`](https://github.com/NixOS/nixpkgs/commit/63b42ea0e745ec1066260cc7fecb54350da6158a) python312Packages.eth-account: 0.9.0 -> 0.13.4
* [`30acf4b8`](https://github.com/NixOS/nixpkgs/commit/30acf4b8f0db2e3bac5a37feab120152024c4eb1) python312Packages.eth-bloom: init at 3.1.0
* [`956ce9ad`](https://github.com/NixOS/nixpkgs/commit/956ce9ad733d507ada9fc4367ae47e1c1fbc18e8) python312Packages.trie: init at 3.0.1
* [`6c7026ad`](https://github.com/NixOS/nixpkgs/commit/6c7026adcaa00f24726d61df40317e7309ffe1ec) python312Packages.py-evm: init at 0.10.1-beta.2
* [`933ec314`](https://github.com/NixOS/nixpkgs/commit/933ec31443591e97c492232100478a8507deee3b) python312Packages.eth-tester: init at 0.12.0-beta.2
* [`563e494e`](https://github.com/NixOS/nixpkgs/commit/563e494e12e418e2e9f521450537491ba862c93e) python312Packages.pyunormalize: init at 16.0.0
* [`3224a886`](https://github.com/NixOS/nixpkgs/commit/3224a886d71c30fd43073b3cf45d6934b5efe485) python312Packages.eth-hash: 0.5.2 -> 0.7.1
* [`757f4e67`](https://github.com/NixOS/nixpkgs/commit/757f4e6755ba1bccea2146423461e4ef47caa3c6) python312Packages.eth-keys: 0.5.0 -> 0.6.0
* [`5950ae0f`](https://github.com/NixOS/nixpkgs/commit/5950ae0f2d7bbb6e7bfc53f83fd685e180b69f0b) python312Packages.eth-keyfile: 0.8.0 -> 0.8.1
* [`1a400c91`](https://github.com/NixOS/nixpkgs/commit/1a400c9182f9182426173c1b9c60c41d4137a03f) python312Packages.web3: 6.5.0 -> 7.6.1
* [`fe17c8b4`](https://github.com/NixOS/nixpkgs/commit/fe17c8b41d90399a8cb43ff645dd9a344cf81d19) vulkan-loader: remove outdated patch
* [`d9f6cedb`](https://github.com/NixOS/nixpkgs/commit/d9f6cedba0b51eee5532a6ccb85aa0bf64c9c6ab) publicsuffix-list: 0-unstable-2024-12-24 -> 0-unstable-2025-01-16
* [`5cdba8c3`](https://github.com/NixOS/nixpkgs/commit/5cdba8c37ce6e83f7d98e10f5dbb7841d947354b) pmbootstrap: 3.1.0 -> 3.2.0
* [`9a4a09be`](https://github.com/NixOS/nixpkgs/commit/9a4a09bef671cf93cae1769b9070bdd74a805cf0) mailutils: 3.17 -> 3.18
* [`af2aafc5`](https://github.com/NixOS/nixpkgs/commit/af2aafc5ccd8f9a9ebdbbe9cc7ecc42f2822eef2) maintainers: add jhahn
* [`1a5c9203`](https://github.com/NixOS/nixpkgs/commit/1a5c9203e174ee0c35e44bea7a3c6bf0715cf7f3) cyberduck: 9.0.0.41777 -> 9.1.2.42722
* [`11da6a16`](https://github.com/NixOS/nixpkgs/commit/11da6a16f395e73eff35db08fe66d5a53f0f6aa9) guile-mqtt: init at 0.2.1
* [`60a72c2a`](https://github.com/NixOS/nixpkgs/commit/60a72c2af1bd6d5ff139665785384b5da6b30d65) beanhub-extract: 0.1.3 -> 0.1.5
* [`21adffd6`](https://github.com/NixOS/nixpkgs/commit/21adffd6fcd0c6155be1b4b7f0518be2abbe032f) pyright: 1.1.391 -> 1.1.392
* [`5ff39028`](https://github.com/NixOS/nixpkgs/commit/5ff390289e135e883d93ba6c5e03ef159fe1db2c) cargo,clippy,rustfmt,rustc: 1.83.0 -> 1.84.0
* [`7ab1e888`](https://github.com/NixOS/nixpkgs/commit/7ab1e888334ddc2745b285e3df0b0efd5839d0f8) nixosTests.postgresql.*: fix eval
* [`6a5dff7a`](https://github.com/NixOS/nixpkgs/commit/6a5dff7af0e7dc22b357eaadd13929e19823710d) nixos/glpi-agent: init
* [`6f416e8c`](https://github.com/NixOS/nixpkgs/commit/6f416e8c9cf88cc097224f6388d297088310bb43) ibus-engines.m17n: 1.4.34 -> 1.4.35
* [`ca643b41`](https://github.com/NixOS/nixpkgs/commit/ca643b41490c2faf1a5b33a7d48f422f1d797e62) bpftune: add update script
* [`842fe953`](https://github.com/NixOS/nixpkgs/commit/842fe953f01eca82071fa0a7a23aa5f049f21832) bpftune: 0-unstable-2024-10-25 -> 0-unstable-2025-01-17
* [`402855c6`](https://github.com/NixOS/nixpkgs/commit/402855c6ca8542f92915c1c92517e97d180d57c9) ddev: 1.24.1 -> 1.24.2
* [`30db3141`](https://github.com/NixOS/nixpkgs/commit/30db3141525d551b80611fc8f908c87ec85e4c86) swayimg: 3.6 -> 3.8
* [`56b1e1c1`](https://github.com/NixOS/nixpkgs/commit/56b1e1c1b4db70c5cafc8cb1e687362f3ef3a62e) boost: Fix compilation to 32-bit ARM with clang in downstream packages ([nixos/nixpkgs⁠#375322](https://togithub.com/nixos/nixpkgs/issues/375322))
* [`497d17bf`](https://github.com/NixOS/nixpkgs/commit/497d17bffde144177b84e325ad7b3a07b6176de3) nextcloud-whiteboard-server: 1.0.4 -> 1.0.5
* [`be661baa`](https://github.com/NixOS/nixpkgs/commit/be661baa7d89d7c0fd80dcdcd68aac2d9eca8c8f) sockstat: init at 1.1.0
* [`a9eac745`](https://github.com/NixOS/nixpkgs/commit/a9eac74572da24c4c1d670e1d69055c5603870d1) nodejs_22: 22.12.0 -> 22.13.1
* [`54f6c33e`](https://github.com/NixOS/nixpkgs/commit/54f6c33e9b4a4e1351d79e1916573b647b20cb33) tzdata: add postgresql as passthru test
* [`0238f9cf`](https://github.com/NixOS/nixpkgs/commit/0238f9cf84e38af0ba9e6d6c5d7dee7f6088c559) postgresql: fix build
* [`df2cf0d1`](https://github.com/NixOS/nixpkgs/commit/df2cf0d18e8f93024731ca377fd65378e6a42d86) lvm2: add a test for buildsFHSEnv compatibility
* [`8d9f9f04`](https://github.com/NixOS/nixpkgs/commit/8d9f9f04ecd57806f5a627bd85889057ea3d1f61) httptoolkit: 1.19.0 -> 1.19.4
* [`b8f00683`](https://github.com/NixOS/nixpkgs/commit/b8f00683d39c59b0f075bc8cf7b0b63b4833494f) python312Packages.nptyping: fix for numpy 2.0
* [`d96772ae`](https://github.com/NixOS/nixpkgs/commit/d96772aef03e01676fc8779719b05807e809def2) python312Packages.nptyping: add pandapip1 to maintainers
* [`aa1405b6`](https://github.com/NixOS/nixpkgs/commit/aa1405b6e792e6cb110c46a732ae53e445fc0eaf) stdenv: add no-broken-symlinks hook
* [`0ad7c9ee`](https://github.com/NixOS/nixpkgs/commit/0ad7c9ee1e2a33a981f81ede385c2f0fc595c6e3) no-broken-symlinks: guard against double inclusions
* [`9b9badd9`](https://github.com/NixOS/nixpkgs/commit/9b9badd9578d7a2306177f51c629c5be4a68dcc1) no-broken-symlinks: check for reflexivity before dangling
* [`ba1297b0`](https://github.com/NixOS/nixpkgs/commit/ba1297b0d3ef7ba992e0d5ffe2712bca71a3b0c2) no-broken-symlinks: exit instead of returning 1 for cleaner log
* [`4e8e175c`](https://github.com/NixOS/nixpkgs/commit/4e8e175c7c8edf9218d1f6ed870ff097dd240cb4) doc: add stdenv entry for no-broken-symlinks.sh
* [`229fdf0c`](https://github.com/NixOS/nixpkgs/commit/229fdf0cf29b057503d2ba1c99d78650c209bd48) test.stdenv.hooks.no-broken-symlinks: init
* [`53f687f9`](https://github.com/NixOS/nixpkgs/commit/53f687f98be672edee65a33995ed074ad179dd76) verifast: 24.12 -> 25.01
* [`776952dd`](https://github.com/NixOS/nixpkgs/commit/776952dd888877b6991c251b846678664c48e9f7) alfaview: 9.19.0 -> 9.20.0
* [`7d9ee07c`](https://github.com/NixOS/nixpkgs/commit/7d9ee07cabf514b27b8ffef98e90542a25cbd2c2) flannel: 0.26.2 -> 0.26.3
* [`4fc79e67`](https://github.com/NixOS/nixpkgs/commit/4fc79e674c331edea85bd2209d56cdc7acb28859) emacs: make cairo optional
* [`4a96ba41`](https://github.com/NixOS/nixpkgs/commit/4a96ba41838750c2eebc8c581be5a99082fed823) apko: 0.22.6 -> 0.22.7
* [`2373f4c2`](https://github.com/NixOS/nixpkgs/commit/2373f4c21ca92c04375be651b1fbff40e9223758) rust-cbindgen: switch to useFetchCargoVendor
* [`93001650`](https://github.com/NixOS/nixpkgs/commit/930016505abdf85cf36f333909392831d80cd321) maintainers: add olemussmann
* [`8269ffb0`](https://github.com/NixOS/nixpkgs/commit/8269ffb01df6484e22dfa02097688eec4f305b82) vim: 9.1.1006 -> 9.1.1046
* [`8d1ab45e`](https://github.com/NixOS/nixpkgs/commit/8d1ab45e5bf88d2d1c0a4df892f9d3ee5b017114) ricochet-refresh: 3.0.25 -> 3.0.30
* [`51b2764e`](https://github.com/NixOS/nixpkgs/commit/51b2764e9fcd4ef768de7590ce796d619ef82cd2) no-broken-symlinks: provide only dontCheckForBrokenSymlinks and test against absolute symlinks
* [`34539b29`](https://github.com/NixOS/nixpkgs/commit/34539b291caac26d1c4f944682f54ea0affd37cf) no-broken-symlinks: actually interpolate relative paths
* [`28055501`](https://github.com/NixOS/nixpkgs/commit/28055501b3896ddce0de69c7ccd8858d16921f00) pdpmake: 2.0.1 -> 2.0.3
* [`c81bee51`](https://github.com/NixOS/nixpkgs/commit/c81bee5136d4ea2d1b5c1cbc3291022c809bd577) cozy-drive: 3.41.0 -> 3.42.0
* [`a47dd780`](https://github.com/NixOS/nixpkgs/commit/a47dd7800d4c00fd4ee71e874d071ee5a0f99042) ecs-agent: 1.89.2 -> 1.89.3
* [`60749f9c`](https://github.com/NixOS/nixpkgs/commit/60749f9cdc9204dbecaa7ea56ff1fa584baee566) stdenv: rename nixLogWithLevel to _nixLogWithLevel to indicate it is meant to be private
* [`8aa11323`](https://github.com/NixOS/nixpkgs/commit/8aa11323bb3b50e0cafba21511fd8d91158cffb3) stdenv: add note in nix logging functions about not cluttering nix-shell
* [`0f9034d8`](https://github.com/NixOS/nixpkgs/commit/0f9034d8b5c5c26f42a6b036d171044d4b11fb5d) lib: Discourage use of extend
* [`3e3c1f8f`](https://github.com/NixOS/nixpkgs/commit/3e3c1f8f39708ef71fed25bcf96a7a68e6884e3c) libgbm: 24.3.3 -> 24.3.4
* [`63bff8c1`](https://github.com/NixOS/nixpkgs/commit/63bff8c132d17b960f98d3878d10a410ec584472) treewide: migrate to fetchCargoVendor, batch 1
* [`c5977504`](https://github.com/NixOS/nixpkgs/commit/c597750454b1ff81f2a48b05b4e3b0d9d1ea3771) treewide: migrate to fetchCargoVendor, batch 2
* [`4b7e6799`](https://github.com/NixOS/nixpkgs/commit/4b7e67992cc0edd267853c4f93a36597690cc5f9) swtpm: fix cross build
* [`c368e3cb`](https://github.com/NixOS/nixpkgs/commit/c368e3cb07b0d6949085faca436b37e4f002e3ad) treewide: migrate to fetchCargoVendor, batch 3
* [`d3ca60f3`](https://github.com/NixOS/nixpkgs/commit/d3ca60f3661735cc42f2d27affcde8b36608f7b0) curl: patch netrc parsing bug for password-less entries
* [`9a3e4294`](https://github.com/NixOS/nixpkgs/commit/9a3e4294f74926a5c6c0ef2f0d7348988fb4dc51) curl: apply patches to darwin build
* [`2985b9a8`](https://github.com/NixOS/nixpkgs/commit/2985b9a8dae9c7fbc09351309cd564c02699410e) curl: fix typo in patch name
* [`4697fbbb`](https://github.com/NixOS/nixpkgs/commit/4697fbbba60937175be5ef1a91f8637176dddd14) bambu-studio: pin boost to 1.86
* [`5915be7a`](https://github.com/NixOS/nixpkgs/commit/5915be7ae831b0c77cbe1901d08a95711fc18c6d) abseil-cpp: 20240722.0 -> 20240722.1
* [`1da5a1c8`](https://github.com/NixOS/nixpkgs/commit/1da5a1c8ebe010f95bcb446e6133c76cd9959548) abseil-cpp_202401: 20240116.2 -> 20240116.3
* [`b8ab4574`](https://github.com/NixOS/nixpkgs/commit/b8ab4574dc8a37ea99d9507208b9036a21e94de5) application-title-bar: 0.7.7 -> 0.8.3
* [`6c0c36e1`](https://github.com/NixOS/nixpkgs/commit/6c0c36e18ab57ba6ae8bd86553d8cf2076ce4f6c) xdp-tools: 1.4.3 -> 1.5.1
* [`3b72265c`](https://github.com/NixOS/nixpkgs/commit/3b72265cb7915431cab661902bb06b8658a4aab1) cc-wrapper: set dontCheckForBrokenSymlinks
* [`9cdac5fc`](https://github.com/NixOS/nixpkgs/commit/9cdac5fc5225c9aa1df4e8a1480255e728d3f8d2) apple-sdk: set dontCheckForBrokenSymlinks
* [`ca851b6f`](https://github.com/NixOS/nixpkgs/commit/ca851b6f124ce5aabee2653afeeb31389245c608) glibc: 2.40-36 -> 2.40-66
* [`d3360812`](https://github.com/NixOS/nixpkgs/commit/d336081225fa8b32db26d39b83e5ed8041503da6) mirtk: unbreak by pinning boost
* [`b2416f44`](https://github.com/NixOS/nixpkgs/commit/b2416f44850769715167c68a7e5d28d756dc23d6) no-broken-symlinks: restrict checks to symlinks pointing inside the store
* [`c2df62d5`](https://github.com/NixOS/nixpkgs/commit/c2df62d50e280933c9fbc88528a078e3baebfe7f) libsecret: 0.21.4 → 0.21.6
* [`a311406e`](https://github.com/NixOS/nixpkgs/commit/a311406e18a5454d46db031c0155c14e8a28ff8f) gtk4: 4.16.7 → 4.16.12
* [`b59741c8`](https://github.com/NixOS/nixpkgs/commit/b59741c885d5ab95f7c981f61676acfb4c7623d0) at-spi2-core: 2.54.0 → 2.54.1
* [`50c8d8ae`](https://github.com/NixOS/nixpkgs/commit/50c8d8ae5fba89357b0c73777c9d39bb2eeba099) pango: 1.55.5 → 1.56.1
* [`dc5c49ec`](https://github.com/NixOS/nixpkgs/commit/dc5c49ec45b5cec5142a1b666f85c7aa7bc7dd2d) pangomm_2_48: 2.54.0 → 2.56.1
* [`b1031483`](https://github.com/NixOS/nixpkgs/commit/b1031483d5ec2415950e80365f8ffa39422a51d4) glib-networking: 2.80.0 → 2.80.1
* [`0c4953c7`](https://github.com/NixOS/nixpkgs/commit/0c4953c7dd4e9dbb959f5b4e042b440c6ef4f2aa) rauc: 1.11.3 -> 1.13
* [`7d069389`](https://github.com/NixOS/nixpkgs/commit/7d06938916ccf9c0db09a7733746efed2c3328bb) curl: fix line endings in patched test 2005
* [`2694413d`](https://github.com/NixOS/nixpkgs/commit/2694413d368f12ff117f5c4710c7874965f2939e) python313Packages.snakeviz: 2.2.0 -> 2.2.2
* [`d175d8a4`](https://github.com/NixOS/nixpkgs/commit/d175d8a4c55ce11c61e70f6d0d0458e7801441c8) llvmPackages.tblgen: add missing lldb-tblgen
* [`3670cc26`](https://github.com/NixOS/nixpkgs/commit/3670cc264ceb8f775319884e475f3d152ff7ae3d) apko: 0.22.7 -> 0.23.0
* [`7e51174b`](https://github.com/NixOS/nixpkgs/commit/7e51174be1178162826a12a6d255f5effd813544) python313Packages.snakeviz: modernize, add pbsds as maintainer
* [`1166b63c`](https://github.com/NixOS/nixpkgs/commit/1166b63c1d53a10322266ddbca000735ee0e90af) test.stdenv.hooks.no-broken-symlinks: correct inverted absolute path option
* [`4f833aa7`](https://github.com/NixOS/nixpkgs/commit/4f833aa7e7342498b241bdc75395ce6b0f9d45da) wealthfolio: 1.0.23 -> 1.0.24
* [`1ce07cfc`](https://github.com/NixOS/nixpkgs/commit/1ce07cfcbc31e1617fd93b17ceeff120600b5fed) androidenv fix extras;google;auto
* [`b10f5105`](https://github.com/NixOS/nixpkgs/commit/b10f51059783efb00af6d07800d5e196bd5c6554) volatility3: 2.8.0 -> 2.11.0
* [`9ac23506`](https://github.com/NixOS/nixpkgs/commit/9ac23506d5562f37733a26f7c534f770a1c2bc81) libgit2: 1.8.4 -> 1.9.0
* [`396775bc`](https://github.com/NixOS/nixpkgs/commit/396775bc8df7d6c9043009438928e6aa53b47d69) python3Packages.pygit2: 1.16.0 -> 1.17.0
* [`dbb58954`](https://github.com/NixOS/nixpkgs/commit/dbb5895438288b947d3989b5eb1563d0efc4c4df) libgit2-glib: add patch for libgit2 1.9.0
* [`8d1b72de`](https://github.com/NixOS/nixpkgs/commit/8d1b72de7e150e4acbcca0da4faed3ec4140f50e) libgit2: add upstream patch for case‐sensitive build directories
* [`5a47d957`](https://github.com/NixOS/nixpkgs/commit/5a47d957a54c8fd8758169a939a9ff35bb24888f) nixVersions.{nix_2_25,git}: remove obsolete `libgit2` patches
* [`a6ef617d`](https://github.com/NixOS/nixpkgs/commit/a6ef617de7a7b1514095bbf19e53e8ed80495c7a) jujutsu: add patch for libgit2 1.9.0
* [`3a051e39`](https://github.com/NixOS/nixpkgs/commit/3a051e393cb8cc9cc82c14c5ee8f67b39dfea14c) cargo-update: 16.0.0 -> 16.1.0
* [`6b2fda72`](https://github.com/NixOS/nixpkgs/commit/6b2fda72283edd3b593ea7baae0a7694ba66eae2) gex: bump version of libgit2
* [`e57355e0`](https://github.com/NixOS/nixpkgs/commit/e57355e04054979b1ee976c472a73cd87884e158) cargo-generate: add upstream patch to bump libgit2 version
* [`9ef4c288`](https://github.com/NixOS/nixpkgs/commit/9ef4c2889647ea36466c44b0d248011307f20b52) git-mit: add upstream patch for libgit2 version bump
* [`c868f57c`](https://github.com/NixOS/nixpkgs/commit/c868f57c9a71dea5bb905aacff9772622f5c0568) edopro: add patch from upstream to fix libgit2 version bump
* [`97975c25`](https://github.com/NixOS/nixpkgs/commit/97975c25ad1492f9d920959b014086a0af6467ca) git-warp-time: 0.8.4 -> 0.8.5
* [`a6e9cf8c`](https://github.com/NixOS/nixpkgs/commit/a6e9cf8cb3c8e27d9ccdea1f2268aed25f2acdf2) guile-git: add patches for `libgit2` 1.9.0
* [`a50178ff`](https://github.com/NixOS/nixpkgs/commit/a50178ff9bda96cbda4519321a0122f11e0b2fb9) guile-git: enable tests on Darwin
* [`e3ad49cb`](https://github.com/NixOS/nixpkgs/commit/e3ad49cbc42c2afcaa30de300e58d142effd03cc) python3Packages.uvloop: avoid test_dns
* [`a2e518fc`](https://github.com/NixOS/nixpkgs/commit/a2e518fc9193b5e99aaba517cb0f537c7c57ff6e) grpc: 1.69.0 -> 1.70.0
* [`b5b0f37c`](https://github.com/NixOS/nixpkgs/commit/b5b0f37c7f28c16d38bb2da1b9e7a747a13c2147) python312Packages.grpcio: 1.69.0 -> 1.70.0
* [`de352188`](https://github.com/NixOS/nixpkgs/commit/de3521888a3cd29d10d0526473b2b73d14793bc0) python312Packages.grpcio-channelz: 1.69.0 -> 1.70.0
* [`cd2eaccc`](https://github.com/NixOS/nixpkgs/commit/cd2eaccc3f48dc22004c0b29012968d5fd5bc850) python312Packages.grpcio-health-checking: 1.69.0 -> 1.70.0
* [`1865b26c`](https://github.com/NixOS/nixpkgs/commit/1865b26c156a12a655da610cddea59463236db8b) python312Packages.grpcio-reflection: 1.69.0 -> 1.70.0
* [`2d35fd37`](https://github.com/NixOS/nixpkgs/commit/2d35fd37468b646e28d67c02579ffc5f629f6a0e) python312Packages.grpcio-status: 1.69.0 -> 1.70.0
* [`cbb2cfb4`](https://github.com/NixOS/nixpkgs/commit/cbb2cfb4b8d66f442b1edd5858d203d3d1e84539) python312Packages.grpcio-testing: 1.69.0 -> 1.70.0
* [`139fecb1`](https://github.com/NixOS/nixpkgs/commit/139fecb15242f2e92c005f505106cb1e1c8a4441) python312Packages.grpcio-tools: 1.69.0 -> 1.70.0
* [`61e396f1`](https://github.com/NixOS/nixpkgs/commit/61e396f19da1e7ea4d5b2e01f8d7e628e18c05f7) qemu-utils: enable crypto support
* [`44bbc61a`](https://github.com/NixOS/nixpkgs/commit/44bbc61a12717710fb8478ab1285733bbd6350c9) qemu: drop unused inputs
* [`b891fd29`](https://github.com/NixOS/nixpkgs/commit/b891fd2983a798c3fec6895c913ce7f5e4a0ede4) cinelerra: 2.3-unstable-2024-03-20 -> 2.3-unstable-2025-01-25
* [`ceee3290`](https://github.com/NixOS/nixpkgs/commit/ceee3290708d5de52ffd4743afd01bffc17a74e8) libxisf: 0.2.12 -> 0.2.13
* [`ca060466`](https://github.com/NixOS/nixpkgs/commit/ca060466e87f6c2d7c74381d921353658b248aeb) varia: 2024.11.7-1 -> 2025.1.24
* [`ca99bf0a`](https://github.com/NixOS/nixpkgs/commit/ca99bf0a497013292a76b355549d3793169da25a) polkit: fix building with clang
* [`0ae0761c`](https://github.com/NixOS/nixpkgs/commit/0ae0761ca7a61613f5cbc61fc6435c8c2b04351c) jackett: 0.22.1177 -> 0.22.1310
* [`74544689`](https://github.com/NixOS/nixpkgs/commit/74544689e87d54e49421457416ee616c38750939) storm: 2.7.1 -> 2.8.0
* [`cace2b6e`](https://github.com/NixOS/nixpkgs/commit/cace2b6eae83f813290074bc572ade8dff09c4fe) treewide: migrate to fetchCargoVendor, batch 4
* [`745c9a50`](https://github.com/NixOS/nixpkgs/commit/745c9a501585235837dd6de6014230a41afaf93a) treewide: migrate to fetchCargoVendor, batch 5
* [`e2afb6a8`](https://github.com/NixOS/nixpkgs/commit/e2afb6a831940aba237b16cd33c9b595b1fcf911) treewide: migrate to fetchCargoVendor, batch 6
* [`1fea4dee`](https://github.com/NixOS/nixpkgs/commit/1fea4dee8b8fe2fde2a58f9fb175240da4f7db05) xpra: 6.2.2 -> 6.2.3
* [`82506de0`](https://github.com/NixOS/nixpkgs/commit/82506de0d72de67eeba6c6d123480d7f456b95a7) protobuf_25: 25.5 -> 25.6
* [`d16879f8`](https://github.com/NixOS/nixpkgs/commit/d16879f87cb0068a85b6ca2a4e0e14f4fd140bcf) librenms: 24.12.0 -> 25.1.0
* [`742e2d1f`](https://github.com/NixOS/nixpkgs/commit/742e2d1f52bc0ed9fe2b75e2617ccf103800a9cf) pony-corral: 0.8.1 -> 0.8.2
* [`0c5c626a`](https://github.com/NixOS/nixpkgs/commit/0c5c626a8149ad3d60eb1cb483daa7f6313f9576) cross-seed: 6.8.5 -> 6.9.1
* [`24652f62`](https://github.com/NixOS/nixpkgs/commit/24652f6279e3b291351e3a71b2f6058d26e6a518) netatalk: 3.1.19 -> 4.1.1
* [`d6ac5244`](https://github.com/NixOS/nixpkgs/commit/d6ac52440b527769081e27024bb0b4e8f55e9e54) netatalk4: add man pages to build
* [`da864ab3`](https://github.com/NixOS/nixpkgs/commit/da864ab387b3b5d1682dd96bca7f0ef0dcedaab8) swtpm: fixup darwin builds
* [`bba2501d`](https://github.com/NixOS/nixpkgs/commit/bba2501df87a9bf7cf9d864861876dfd2fce2d35) Revert "llvmPackages.tblgen: add missing lldb-tblgen"
* [`f259802a`](https://github.com/NixOS/nixpkgs/commit/f259802ac7a5c247d987681017169712d97a9f8d) nixos/fileSystems: link to mount(8) from `fileSystems.*.options`
* [`15391ccd`](https://github.com/NixOS/nixpkgs/commit/15391ccd3ee0aed22c13888d7feb68e93dd4f6d5) nixos/fileSystems: fix mount(8) manpage links
* [`cd81fa2a`](https://github.com/NixOS/nixpkgs/commit/cd81fa2ac99eda2370927ac721526f98ce9a778e) maintainers: add djds
* [`3fc45e16`](https://github.com/NixOS/nixpkgs/commit/3fc45e16ab9bf685ea92436ee0ae0e55ef1623f9) zig: commonify
* [`54dbd8ba`](https://github.com/NixOS/nixpkgs/commit/54dbd8ba51611c2b1d0b465cdd53740e91f00468) maintainers/teams: add RossComputerGuy to zig
* [`bccdfa1a`](https://github.com/NixOS/nixpkgs/commit/bccdfa1a5930fc430b40230fd5076b5223dec2b7) CODEOWNERS: add RossComputerGuy for Zig
* [`50e0d27a`](https://github.com/NixOS/nixpkgs/commit/50e0d27a0ef6cdfee6ade30c1a25583670271f13) zig.cc: add bintools
* [`2ca29c56`](https://github.com/NixOS/nixpkgs/commit/2ca29c56efb89d4b0af50e4feb0a681a6a7af2f9) zig: split cc and bintools wrappers
* [`2f34680a`](https://github.com/NixOS/nixpkgs/commit/2f34680a7db1188c34f0243ed7d0ded92e66cc17) traefik: add djds as maintainer
* [`bf629069`](https://github.com/NixOS/nixpkgs/commit/bf629069866e66e4e4c3aebf7ef1afe860a59fde) ngrok: 3.18.1 -> 3.19.1
* [`c8a67ecc`](https://github.com/NixOS/nixpkgs/commit/c8a67eccf353c426044a3f0207f6c152f17a46fc) python312Packages.kestra: 0.20.0 -> 0.21.0
* [`e27810b8`](https://github.com/NixOS/nixpkgs/commit/e27810b82379b2aea15ea436be123cd918169d54) nifskope: fix zlib build
* [`3a103771`](https://github.com/NixOS/nixpkgs/commit/3a10377185ae19a737a2021c72b6f14855d4f247) update-python-libraries: update version reference in changelog
* [`a3e777e8`](https://github.com/NixOS/nixpkgs/commit/a3e777e886ce3df5debf35a619e7cec06a451535) python313Packages.flit: 3.10.0 -> 3.10.1
* [`1893cea8`](https://github.com/NixOS/nixpkgs/commit/1893cea8a72cbc20e898dbd45340241d52130a7e) python313Packages.setuptools: 75.3.0 -> 75.8.0
* [`330384c7`](https://github.com/NixOS/nixpkgs/commit/330384c723326288422eaa334df018ae14855469) python313Packages.hypothesis: 6.112.2 -> 6.124.1
* [`92ccb994`](https://github.com/NixOS/nixpkgs/commit/92ccb994d3d43e3bd4260fc76e15704470466f9d) python313Packages.pytest: 8.3.3 -> 8.3.4
* [`7b6215bb`](https://github.com/NixOS/nixpkgs/commit/7b6215bb1c23a3f3002d90256acd7349084c720b) python313Packages.pytest: adopt by python maintainers
* [`2543fe5c`](https://github.com/NixOS/nixpkgs/commit/2543fe5c845b8dedda099632dec52a0f2768bf85) python313Packages.orjson: 3.10.11 -> 3.10.15
* [`4df3d477`](https://github.com/NixOS/nixpkgs/commit/4df3d477ab0c9fe8c04276be2929ee70267d6108) python313Packages.setuptools-rust: 1.10.1 -> 1.10.2
* [`d5515196`](https://github.com/NixOS/nixpkgs/commit/d5515196593ef220bd6a1c05aadf061a1246156c) python313Packages.bcrypt: 4.2.0 -> 4.2.1
* [`47a5c909`](https://github.com/NixOS/nixpkgs/commit/47a5c9091ea0ac16d87af1ff3d6baa927270d7d2) python313Packages.contourpy: 1.3.0 -> 1.3.1
* [`848299c8`](https://github.com/NixOS/nixpkgs/commit/848299c80d227d98ca16fea450eccae012fc6b04) python313Packages.eventlet: 0.37.0 -> 0.38.2
* [`372bd62e`](https://github.com/NixOS/nixpkgs/commit/372bd62eaee454aa158c5964063e30e688208757) python313Packages.attrs: 24.2.0 -> 24.3.0
* [`bb359061`](https://github.com/NixOS/nixpkgs/commit/bb359061b04cb9e6fe0738725ae4f98188d18e3b) python313Packages.matplotlib: 3.9.2 -> 3.10.0
* [`bda5d6d3`](https://github.com/NixOS/nixpkgs/commit/bda5d6d3b1ca44ff27e6e750bf7a69b2e2bfe9b3) python313Packages.executing: disable failing test
* [`3d3b3489`](https://github.com/NixOS/nixpkgs/commit/3d3b3489f50002fd562c2872df0a59351d6e05bd) python313Packages.httpcore: 1.0.6 -> 1.0.7
* [`14ec122e`](https://github.com/NixOS/nixpkgs/commit/14ec122efe642e29ead46f9d01f0f222b1336971) python313Packages.httpx: 0.27.2 -> 0.28.1
* [`0245dc90`](https://github.com/NixOS/nixpkgs/commit/0245dc906b65d2d892ecf8ab84f4c9517a4f3164) python313Packages.certifi: 2024.08.30 -> 2024.12.14
* [`5a6d9ebd`](https://github.com/NixOS/nixpkgs/commit/5a6d9ebdf102ee3288e9d9b299f9f86e7292dd7e) python312Packages.alabaster: 0.7.16 -> 1.0.0
* [`55e0fc6b`](https://github.com/NixOS/nixpkgs/commit/55e0fc6b2d63f1a44910f693a22c9d2e7c83efb9) python312Packages.sphinx: add breathe to passthru.tests
* [`0708c34a`](https://github.com/NixOS/nixpkgs/commit/0708c34ad7dc59517fcb47da86c088c55c6301e9) python313Packages.sphinx: 7.4.7 -> 8.1.3
* [`338783ee`](https://github.com/NixOS/nixpkgs/commit/338783ee64a7fdfbb2e4ad5ae19ea1916b5729e3) python313Packages.breathe: 4.35.0 -> 4.35.0-unstable-2025-01-16
* [`83ee3fda`](https://github.com/NixOS/nixpkgs/commit/83ee3fdab542cd58d16f3287d25d904d1dd13b25) python313Packages.pynacl: fix sphinx 8 compat
* [`ac0de38e`](https://github.com/NixOS/nixpkgs/commit/ac0de38eb3e9c2cec5988bc447702996672fcce7) python313Packages.myst-parser: fix sphinx 8.1 compat
* [`e7e5cb87`](https://github.com/NixOS/nixpkgs/commit/e7e5cb87912505e13a5aa0125ca13267d7ffeaa3) python313Packages.pytest-asyncio: 0.23.8 -> 0.25.2
* [`c6022df7`](https://github.com/NixOS/nixpkgs/commit/c6022df7f78b12cc2c06b3a02d6f3032f9ac234f) python313Packages.pytest-pook: init at 1.0.0
* [`f8e69d82`](https://github.com/NixOS/nixpkgs/commit/f8e69d826d1ed77b073064e749cd13832509ca31) python313Packages.pook: 1.4.3 -> 2.1.3
* [`3b349755`](https://github.com/NixOS/nixpkgs/commit/3b349755e4094ae0d49eee40539f61a749fa9808) python312Packages.jsonpath-ng: 1.6.1 -> 1.7.0 ([nixos/nixpkgs⁠#348869](https://togithub.com/nixos/nixpkgs/issues/348869))
* [`ef070f66`](https://github.com/NixOS/nixpkgs/commit/ef070f66626140a5d0610e41162bf872d8544380) python312Packages.xmltodict: 0.13.0 -> 0.14.2
* [`79200d4a`](https://github.com/NixOS/nixpkgs/commit/79200d4a14b111473803eeeb2902d2da004bd766) python312Packages.aio-georss-client: 0.13 -> 0.14
* [`722d7b91`](https://github.com/NixOS/nixpkgs/commit/722d7b91c8ec84ee2fae28f6b8e03f9061f3f0f1) python312Packages.frozenlist: 1.4.1 -> 1.5.0
* [`e9917a88`](https://github.com/NixOS/nixpkgs/commit/e9917a88056be085d5e42be722a27f9d006e8974) python312Packages.asttokens: 2.4.1 -> 3.0.0
* [`53bde90d`](https://github.com/NixOS/nixpkgs/commit/53bde90d3088e532b46ba1b8abc96e5404eb7d65) python312Packages.asttokens: refactor
* [`ca3c323e`](https://github.com/NixOS/nixpkgs/commit/ca3c323ea5f10fac5fe3fd58e9a5742caabb58df) trove-classifiers: 2024.9.12 -> 2024.10.21.16
* [`9268a790`](https://github.com/NixOS/nixpkgs/commit/9268a790a40d57af412c59eb16970fde92089c90) python312Packages.pikepdf: 9.4.2 -> 9.5.0
* [`aad33841`](https://github.com/NixOS/nixpkgs/commit/aad33841cc4c9777e34dd079e35fea4c665144c7) python312Packages.mistune: 3.0.2 -> 3.1.0
* [`04626c92`](https://github.com/NixOS/nixpkgs/commit/04626c927a0cb60e84525b0ee321a6512113f176) python313Packages.msgspec: 0.18.6 -> 0.19.0
* [`72a25df3`](https://github.com/NixOS/nixpkgs/commit/72a25df3281ebe5ad4c10e88457e5884e4763692) python312Packages.python-on-whales: 0.73.0 -> 0.74.0
* [`301872c8`](https://github.com/NixOS/nixpkgs/commit/301872c80455396c74440700117da5ccba319b7d) python312Packages.instructor: 1.6.4 -> 1.7.2
* [`123c5f30`](https://github.com/NixOS/nixpkgs/commit/123c5f30058b4019341e45d4cca5d8fb47f995bc) python313Packages.pathable: 0.4.3 -> 0.4.4
* [`ea38e93a`](https://github.com/NixOS/nixpkgs/commit/ea38e93aa933a71c876674ac863a6f0b359730f3) python313Packages.pytest-codspeed: 3.1.0 -> 3.1.1
* [`fceac78c`](https://github.com/NixOS/nixpkgs/commit/fceac78c35843b2cae674b9421b1546ff915af3b) python312Packages.deprecated: 1.2.14 -> 1.2.15
* [`7088e22d`](https://github.com/NixOS/nixpkgs/commit/7088e22d7f2557a07258bdf122b10b0f1d853ef8) python313Packages.pyvicare: 2.39.1 -> 2.40.0
* [`3fa1ec3f`](https://github.com/NixOS/nixpkgs/commit/3fa1ec3faf4595dfe287cdc22026f2fc2ac952b5) python312Packages.pytest-freezer: 0.4.8 -> 0.4.9
* [`11f054e0`](https://github.com/NixOS/nixpkgs/commit/11f054e0b676790b3745fbb095af865cc3c22fc8) python312Packages.aiosignal: 1.3.1 -> 1.3.2
* [`b3b5cd3a`](https://github.com/NixOS/nixpkgs/commit/b3b5cd3a7c8e0417c11e53f9c201b026b5003a7d) python312Packages.ciso8601: 2.3.1 -> 2.3.2
* [`123c6464`](https://github.com/NixOS/nixpkgs/commit/123c6464a8769415092f839dce19c97a1ed8303d) python312Packages.ciso8601: refactor
* [`885b3048`](https://github.com/NixOS/nixpkgs/commit/885b30484cea2d2772cc7360490b4b9be80f21e0) python312Packages.pycares: 4.4.0 -> 4.5.0
* [`929cf019`](https://github.com/NixOS/nixpkgs/commit/929cf019ce3616346080dd386e09e3d252bc7b7d) python312Packages.json5: 0.9.25 -> 0.9.28
* [`b358b3fb`](https://github.com/NixOS/nixpkgs/commit/b358b3fbe1e06700293a874cf182231882011a8b) python313Packages.types-python-dateutil: 2.9.0.20240906 -> 2.9.0.20241206
* [`eddfafbd`](https://github.com/NixOS/nixpkgs/commit/eddfafbd4b110ad4ee7c7ec3464a8c8c8c507440) python313Packages.typer: 0.12.5 -> 0.15.1
* [`59531cc1`](https://github.com/NixOS/nixpkgs/commit/59531cc1c59aa557ea183237e75672306e718f21) python3Packages.typogrify: 2.0.7 -> 2.1.0
* [`0b17b450`](https://github.com/NixOS/nixpkgs/commit/0b17b450bd4a2673c9c9d7b61094b99399f8e8e4) python3Packages.a2wsgi: 1.10.7 -> 1.10.8
* [`a471c7a3`](https://github.com/NixOS/nixpkgs/commit/a471c7a301fe5224c051172783a7aa9fc0028eb6) python3Packages.abjad: 3.19 -> 3.20
* [`e3e366a1`](https://github.com/NixOS/nixpkgs/commit/e3e366a1cd15cf8d463cc88c4e26e3aadc41ef1d) python3Packages.adafruit-board-toolkit: 1.1.1 -> 1.1.2
* [`a2c2dfaf`](https://github.com/NixOS/nixpkgs/commit/a2c2dfafbdbaa63a99c0dad1ceb9bd8a1533917b) python3Packages.aioairzone: 0.9.8 -> 0.9.9
* [`e505e4f2`](https://github.com/NixOS/nixpkgs/commit/e505e4f20c88570dd8936ea9ee5f5da0387d9628) python3Packages.aiobotocore: 2.15.1 -> 2.18.0
* [`e2ad06ea`](https://github.com/NixOS/nixpkgs/commit/e2ad06eaaa3680443364e10b2d5c722c87a3934f) python3Packages.aioesphomeapi: 28.0.0 -> 28.0.1
* [`8d8735fc`](https://github.com/NixOS/nixpkgs/commit/8d8735fcdb037aaf7f63df9000ea679ad82a6971) python3Packages.aiohttp-retry: 2.9.0 -> 2.9.1
* [`b79c07bd`](https://github.com/NixOS/nixpkgs/commit/b79c07bd904c5031776e2bb36cef96edd6539fee) python3Packages.aiojellyfin: 0.10.1 -> 0.13.0
* [`7ed4b718`](https://github.com/NixOS/nixpkgs/commit/7ed4b7184e1b8984e6ea00002075a83280f693e4) python3Packages.aiomqtt: 2.0.1 -> 2.3.0
* [`8caef729`](https://github.com/NixOS/nixpkgs/commit/8caef729276588528d4c6685802d458e82615290) python3Packages.aioresponses: 0.7.7 -> 0.7.8
* [`4bbf5300`](https://github.com/NixOS/nixpkgs/commit/4bbf5300d44ee9420a59650ba668f70e3f101bde) python3Packages.aiorpcx: 0.23.1 -> 0.24.0
* [`c5147ea2`](https://github.com/NixOS/nixpkgs/commit/c5147ea267393776511ae02426c3bfeaa26a5ec0) python3Packages.aioswitcher: 6.0.0 -> 6.0.1
* [`73a697c9`](https://github.com/NixOS/nixpkgs/commit/73a697c9e307dd3c96d8f6799ae6b62f38d20d8c) python3Packages.alembic: 1.13.3 -> 1.14.0
* [`f33311a0`](https://github.com/NixOS/nixpkgs/commit/f33311a0cf36bbec3d8bf5cfb4709d6a0269647e) python3Packages.altair: 5.4.1 -> 5.5.0
* [`8009c25b`](https://github.com/NixOS/nixpkgs/commit/8009c25b66b281facb9ecb732f59bdc747da967c) python3Packages.amazon-ion: 0.12.0 -> 0.13.0
* [`af6f4f66`](https://github.com/NixOS/nixpkgs/commit/af6f4f667a60b0a879a21cd6c28882f82523e51e) python3Packages.amazon-kclpy: 2.1.5 -> 3.0.1
* [`96ab7ef7`](https://github.com/NixOS/nixpkgs/commit/96ab7ef710c74c081abb9a986e5524260ea1b391) python3Packages.amshan: 2.1.1 -> 2021.12.1
* [`47c63624`](https://github.com/NixOS/nixpkgs/commit/47c63624b29bdecf74571d082ebb93d6f3de7767) python3Packages.androguard: 3.4.0a1 -> 4.1.2
* [`aff4a8b9`](https://github.com/NixOS/nixpkgs/commit/aff4a8b9f69e30311a62dd7629124ea4a9b80b4c) python3Packages.ansible-compat: 24.10.0 -> 25.0.0
* [`c1ea7be4`](https://github.com/NixOS/nixpkgs/commit/c1ea7be41fa656b1e8e20bb5dcaa12ea5db409ce) python3Packages.anthropic: 0.42.0 -> 0.43.1
* [`dcb5e93c`](https://github.com/NixOS/nixpkgs/commit/dcb5e93c9cc57410d7da9958cabb4e18c2afff91) python3Packages.anybadge: 1.14.0 -> 1.16.0
* [`a7e24ed5`](https://github.com/NixOS/nixpkgs/commit/a7e24ed5dd002f281b292f5d9fc2afb01a45e2b5) python3Packages.anyio: 4.6.2 -> 4.8.0
* [`6dce9c6e`](https://github.com/NixOS/nixpkgs/commit/6dce9c6e0427ec494945dc944c55706df2db9e72) python3Packages.aocd: 2.0.1 -> 2.1.0
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
