### PR TITLE
niv home-manager: update 066ba0c5 -> ba4a1a11

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -41,10 +41,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "066ba0c5cfddbc9e0dddaec73b1561ad38aa8abe",
-        "sha256": "14sryxr51hya2hqlpl7qpmi6l70wfv9p2vzdrlqyzmf0wzjrmgn9",
+        "rev": "ba4a1a110204c27805d1a1b5c8b24b3a0da4d063",
+        "sha256": "13ky419aycilw37w6rv1nyq8vxd5adihvk00zirdgx6gf70lamvy",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/066ba0c5cfddbc9e0dddaec73b1561ad38aa8abe.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/ba4a1a110204c27805d1a1b5c8b24b3a0da4d063.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@066ba0c5...ba4a1a11](https://github.com/nix-community/home-manager/compare/066ba0c5cfddbc9e0dddaec73b1561ad38aa8abe...ba4a1a110204c27805d1a1b5c8b24b3a0da4d063)

* [`7abcf59a`](https://github.com/nix-community/home-manager/commit/7abcf59a365430b36f84eaa452a466b11e469e33) mpv: support includes directives ([nix-community/home-manager⁠#6391](https://togithub.com/nix-community/home-manager/issues/6391))
* [`78576b81`](https://github.com/nix-community/home-manager/commit/78576b817fdd88a75c6adf512e9ba20551662cef) home-manager: add lib support for non-flake users ([nix-community/home-manager⁠#5429](https://togithub.com/nix-community/home-manager/issues/5429))
* [`1e47f710`](https://github.com/nix-community/home-manager/commit/1e47f7101fedd857e561782d00d4cb1f6b69e7df) gpg-agent: no-allow-external-cache option ([nix-community/home-manager⁠#6387](https://togithub.com/nix-community/home-manager/issues/6387))
* [`24bb01ea`](https://github.com/nix-community/home-manager/commit/24bb01ea170a6705c6700be3fa7438b394523ea4) tests: avoid unnecessary test script interpolation
* [`c5c2cbc8`](https://github.com/nix-community/home-manager/commit/c5c2cbc866fecc75175259bcda02c4c0e00c00ee) ci: tweak test command slightly
* [`7a3f0b3b`](https://github.com/nix-community/home-manager/commit/7a3f0b3b8df1b913890f5fad04d34f2af91da858) tests: rework derivation stubbing
* [`f2d32e46`](https://github.com/nix-community/home-manager/commit/f2d32e46fac9d51da6912948ae1156044c71774b) broot: use hjson-go
* [`59971126`](https://github.com/nix-community/home-manager/commit/5997112695f3b02d3992764760fc6ddfef51fba3) flake.lock: Update
* [`d092f0a4`](https://github.com/nix-community/home-manager/commit/d092f0a4c07fea79f14886da83c9ee7249c6a84f) Translate using Weblate (Spanish)
* [`39602525`](https://github.com/nix-community/home-manager/commit/396025251ae173da389133ed3aa7a3f18d333ea3) Translate using Weblate (Bulgarian)
* [`987f622c`](https://github.com/nix-community/home-manager/commit/987f622cc4368626d8b041ea495edf0d243714ba) Add translation using Weblate (Bulgarian)
* [`3b6fde96`](https://github.com/nix-community/home-manager/commit/3b6fde96d8b41a4a21cbacba8de7debf7ea78021) Translate using Weblate (Russian)
* [`f20b7a8a`](https://github.com/nix-community/home-manager/commit/f20b7a8ab527a2482f13754dc00b2deaddc34599) firefox: fix referencing firefox fork name in profile-specific docs ([nix-community/home-manager⁠#6407](https://togithub.com/nix-community/home-manager/issues/6407))
* [`30ea6fed`](https://github.com/nix-community/home-manager/commit/30ea6fed4e4b41693cebc2263373dd810de4de49) firefox: fix referencing name in profile-specific docs
* [`15bd6736`](https://github.com/nix-community/home-manager/commit/15bd673658c189491cd896f06b3dd8f09bb0dfe4) firefox: remove old unused test file ([nix-community/home-manager⁠#6403](https://togithub.com/nix-community/home-manager/issues/6403))
* [`f99c704f`](https://github.com/nix-community/home-manager/commit/f99c704fe3a4cf8d72b2d568ec80bc38be1a9407) bash: Make sure HISTFILE's directory exists
* [`43379927`](https://github.com/nix-community/home-manager/commit/433799271274c9f2ab520a49527ebfe2992dcfbd) wayland: create tray.target if xsession is not enabled ([nix-community/home-manager⁠#6332](https://togithub.com/nix-community/home-manager/issues/6332))
* [`947eef9e`](https://github.com/nix-community/home-manager/commit/947eef9e99c42346cf0aac2bebe1cd94924c173b) neovim: disable neovim-coc-config test
* [`90a4374b`](https://github.com/nix-community/home-manager/commit/90a4374b174edb88a2e36889ee39ce45a186c7f6) Translate using Weblate (Portuguese)
* [`bf9a1a06`](https://github.com/nix-community/home-manager/commit/bf9a1a068919ccdfa7d130873936c5fd4c826e85) Translate using Weblate (Swedish)
* [`5af1b9a0`](https://github.com/nix-community/home-manager/commit/5af1b9a0f193ab6138b89a8e0af8763c21bbf491) treewide: standardize shell integration options
* [`b0bd29bb`](https://github.com/nix-community/home-manager/commit/b0bd29bb4b8df265b13bbb4a6639afa74faaa831) tldr-update: init ([nix-community/home-manager⁠#6401](https://togithub.com/nix-community/home-manager/issues/6401))
* [`cf2ea71e`](https://github.com/nix-community/home-manager/commit/cf2ea71e6877dddd9b94812fcb21a19f21f3d351) flake.lock: Update
* [`0f9e9230`](https://github.com/nix-community/home-manager/commit/0f9e92302a6bd86087e8b6f1a539d1d1f0ccbe62) neovim: re-enable test
* [`a3c9e881`](https://github.com/nix-community/home-manager/commit/a3c9e88177f0dc4a2662b5324572425f59129f11) nushell: temporarily disable test
* [`fc3cd1e4`](https://github.com/nix-community/home-manager/commit/fc3cd1e40870cb40692d1272468fa5e187d07591) kitty: allow not setting shell_integration
* [`c0d06189`](https://github.com/nix-community/home-manager/commit/c0d06189f27f9cd0f97c13a0e75c4fd12c7e9d61) kitty: assert can't enable shell integrations when mode is null
* [`b34b5668`](https://github.com/nix-community/home-manager/commit/b34b56689dcc75294e14e8c95db4e054a4e9573f) yazi: remove with lib
* [`5795f792`](https://github.com/nix-community/home-manager/commit/5795f792abf38e4f2701b4f7454deeb8e2575ae4) yazi: organization tweak
* [`e5854b98`](https://github.com/nix-community/home-manager/commit/e5854b98cd759b91c83ba5caa5ff32f274f1dc78) flake-module: change type from lazyAttrsOf raw to lazyAttrsOf deferredModule ([nix-community/home-manager⁠#6408](https://togithub.com/nix-community/home-manager/issues/6408))
* [`ba4a1a11`](https://github.com/nix-community/home-manager/commit/ba4a1a110204c27805d1a1b5c8b24b3a0da4d063) ludusavi: create Ludusavi module ([nix-community/home-manager⁠#5626](https://togithub.com/nix-community/home-manager/issues/5626))
