### PR TITLE
niv nixpkgs: update c1d50403 -> 23c19d9c

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c1d50403531bc57f2d5ea109c747573d57d7342d",
-        "sha256": "0dq98vkx0p90p900h1d88y8f2gvx2daga4pjicl6iva6brcmp22v",
+        "rev": "23c19d9c503a55631cb25c6c008692316e91521e",
+        "sha256": "1rjam0s7gx330irqgv52kfhzljqhdiyffd7jrhglc183zrz639pn",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/c1d50403531bc57f2d5ea109c747573d57d7342d.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/23c19d9c503a55631cb25c6c008692316e91521e.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@c1d50403...23c19d9c](https://github.com/nixos/nixpkgs/compare/c1d50403531bc57f2d5ea109c747573d57d7342d...23c19d9c503a55631cb25c6c008692316e91521e)

* [`a009d2b7`](https://github.com/NixOS/nixpkgs/commit/a009d2b73f072a09781e2b0397628ecb9df142a9) nixos-container: do not touch os-release if it is a symlink
* [`5302d519`](https://github.com/NixOS/nixpkgs/commit/5302d519f98fdb78d387165b278a127158fe342a) ubports-pdk: init at 0-unstable-2024-08-28
* [`db0a0b11`](https://github.com/NixOS/nixpkgs/commit/db0a0b11739ce4da69266a8358892fcd60effd16) nixos/users-groups: split isSystemUser/isNormalUser and uid check into two
* [`2021b9b8`](https://github.com/NixOS/nixpkgs/commit/2021b9b81570abcdc6499666156b695b1696b152) maintainers: add renpenguin
* [`648c8933`](https://github.com/NixOS/nixpkgs/commit/648c8933d33ac726ba65e744ee69deb4e6c0eabc) python3Packages.curated-tokenizers: init at 0.0.8
* [`cc51d500`](https://github.com/NixOS/nixpkgs/commit/cc51d5006fa31d20f3b5a02cfd59ffd21be75692) python3Packages.curated-transformers: init at 0.1.1
* [`a1accfb8`](https://github.com/NixOS/nixpkgs/commit/a1accfb8f5040bd28cd0a36d05ee61e219f10175) python3Packages.spacy-curated-transformers: init at 0.3.0
* [`95b84e94`](https://github.com/NixOS/nixpkgs/commit/95b84e949e50f484d5c1a569909ea09a29c13f41) python3Packages.spacy-models: fix model builds
* [`447999e1`](https://github.com/NixOS/nixpkgs/commit/447999e1ae0f6e9db4a8694a7105bdec49573e69) widevine-cdm: move to by-name
* [`971457ce`](https://github.com/NixOS/nixpkgs/commit/971457ce05d22325aa048b09f9a5e3bf929a4651) pysolfc: fix desktop entry
* [`673076b0`](https://github.com/NixOS/nixpkgs/commit/673076b0a89ce4f1638650e97a44b38061c384e6) python2Packages.pygtk: fix build w/ `-fpermissive`
* [`033bec6c`](https://github.com/NixOS/nixpkgs/commit/033bec6c96bb9709d5d34ff0a729c953d4efb388) fishPlugins.exercism-cli-fish-wrapper: init at 0-unstable-2024-11-29
* [`7ba35e30`](https://github.com/NixOS/nixpkgs/commit/7ba35e3012da188742007866b710c6ddb91e5e46) maintainers: update x123 email
* [`1f52ec9f`](https://github.com/NixOS/nixpkgs/commit/1f52ec9f95614d616ab29254d62a375aa152dcb6) prometheus-node-cert-exporter: init at 1.1.7-unstable-2024-12-26
* [`682e3b71`](https://github.com/NixOS/nixpkgs/commit/682e3b71a0c53d9aad6af1f51bc577a67b913c0f) playwright-test: Add PLAYWRIGHT_BROWSERS_PATH to build environment
* [`a1952a60`](https://github.com/NixOS/nixpkgs/commit/a1952a6083d1f4d66c24dd813083e2530d2d7611) python3Packages.playwright: Add PLAYWRIGHT_BROWSERS_PATH to build environment
* [`ae1430ed`](https://github.com/NixOS/nixpkgs/commit/ae1430edcace78833f8c3d4915bfa0d48182b53e) pythonPackages.jsonpath-python: init at 1.0.6
* [`cedcbe01`](https://github.com/NixOS/nixpkgs/commit/cedcbe01b570f007db5d9ea21d11f2848f3057ae) xar: fix build on GCC14
* [`cd90665c`](https://github.com/NixOS/nixpkgs/commit/cd90665c656a1c1527ee68284cac09519ab36794) vcsi: relax python deps, run tests
* [`c1a7fc76`](https://github.com/NixOS/nixpkgs/commit/c1a7fc76e7387c5c44305778cfd4661999fe6e1f) facetimehd-calibration: fix strictDeps build
* [`789c30f7`](https://github.com/NixOS/nixpkgs/commit/789c30f7e23f8f1427f2e8244945d0bfca281f45) binaryen: fix strictDeps build
* [`bb868d76`](https://github.com/NixOS/nixpkgs/commit/bb868d767431519d8b9133226dd55b359adaccdf) frr: 10.1 -> 10.2.1
* [`4dd7ca03`](https://github.com/NixOS/nixpkgs/commit/4dd7ca03a3a63c5848f8f60e9ddd0e7ce0b2f961) libyang: 2.1.148 -> 3.4.2
* [`a5f24af6`](https://github.com/NixOS/nixpkgs/commit/a5f24af6da0f2a5ae04024d297a882abe2719bca) buildkite-agent: 3.87.1 -> 3.89.0
* [`9478b2f3`](https://github.com/NixOS/nixpkgs/commit/9478b2f3e8d7be47bbd0691afde74592d9b8cb82) nixos/tests/frr: Adjust hello-interval and dead-interval
* [`56aa5498`](https://github.com/NixOS/nixpkgs/commit/56aa5498d3f4727059403dd0efea97f6bfe70fb5) adalanche: remove obsolete `TARGET_OS_*` workaround
* [`db53f14a`](https://github.com/NixOS/nixpkgs/commit/db53f14a1163551d0137a3acc74cbd52151f0761) nray: remove obsolete `TARGET_OS_*` workaround
* [`13e8cecd`](https://github.com/NixOS/nixpkgs/commit/13e8cecd5d99b1d48baa88c8a81f25a4c178fc26) thc-hydra: remove obsolete `TARGET_OS_*` workaround
* [`5042c058`](https://github.com/NixOS/nixpkgs/commit/5042c058bdd3695795d532b5a965f22201eb5f0a) plasmusic-toolbar: 2.1.1 -> 2.2.0
* [`ff3c5a71`](https://github.com/NixOS/nixpkgs/commit/ff3c5a7172afb99d4294ed7bbe0e6abe3f3e22e8) maintainers: add jorikvanveen
* [`c30d1290`](https://github.com/NixOS/nixpkgs/commit/c30d129071627882d058bd6cb1e91137f6c2dcb5) discord: add `startupWMClass`
* [`fb6a7bfe`](https://github.com/NixOS/nixpkgs/commit/fb6a7bfe74ebeca9a86a96ece73242a11d34352c) openbsd.{fsck,fsck_ffs,fsck_msdos}: init
* [`55d65381`](https://github.com/NixOS/nixpkgs/commit/55d65381bbda9ca9a614d86d54a836897d49a755) openbsd.fsck: Override paths
* [`52f3e97e`](https://github.com/NixOS/nixpkgs/commit/52f3e97ee46c0cdd3511ddaa3882e764fe14c62f) openbsd.fsck: unveil /nix/store too
* [`63bbbe8a`](https://github.com/NixOS/nixpkgs/commit/63bbbe8a6ca560e007925a1203789349413eebcb) freebsd.compat: don't claim to work outside of Linux
* [`3244da6d`](https://github.com/NixOS/nixpkgs/commit/3244da6d13200f7a9bfbf744f9139dcfdc41994e) nixos/tabby: fix invalid mkRemovedOptionModule import
* [`e32fb0b0`](https://github.com/NixOS/nixpkgs/commit/e32fb0b0f2571eb991941944db54701ef7efd345) soft-serve: 0.8.1 -> 0.8.2
* [`65580eea`](https://github.com/NixOS/nixpkgs/commit/65580eea00b47b4171b68dba52ade898d139dd85) nginx: Fix cross-OS build
* [`9d2d70be`](https://github.com/NixOS/nixpkgs/commit/9d2d70bea2f9ff86ce655dcf2a148509c5b7871d) nixos/docs: fix typo
* [`6d73ef8b`](https://github.com/NixOS/nixpkgs/commit/6d73ef8b9dec22e06a315930d24010c6c93b30bb) cldr-annotations: 46.0 -> 46.1
* [`69e14e43`](https://github.com/NixOS/nixpkgs/commit/69e14e43b5a6afceaa75dce9d24407ba3ca35d77) ocamlPackages.lablgtk: unpin gnumake42
* [`c262d2ca`](https://github.com/NixOS/nixpkgs/commit/c262d2ca8d15f2ec508b6984eb3b89a16ca20a35) itk: 5.4.1 -> 5.4.2
* [`ea9594ba`](https://github.com/NixOS/nixpkgs/commit/ea9594ba15fcbb787b9abe9d587e0e5c8fcafd4d) nixos/nix: restructure default for system-features
* [`d2cadf48`](https://github.com/NixOS/nixpkgs/commit/d2cadf484c319f19272d4f11a07c4d192069f1d9) repart: Enable custom --empty flags in initrd
* [`6ea4c4c1`](https://github.com/NixOS/nixpkgs/commit/6ea4c4c1e84b163c1dbf828a53fd0b5d42a0ddfd) pocket-casts: 0.8.0 -> 0.9.0
* [`10274ff5`](https://github.com/NixOS/nixpkgs/commit/10274ff528a3de5ecea67a340093ae88945c900a) sonic-lineup: fix strictDeps build
* [`e1cadf82`](https://github.com/NixOS/nixpkgs/commit/e1cadf8259db663093e8efb9b1ce93f0d3f4f5ec) perlPackages.GraphicsTIFF: fix strictDeps build
* [`51f6a82f`](https://github.com/NixOS/nixpkgs/commit/51f6a82f6d50208f3c1f53028338536fc7962c2e) libcryptui: fix strictDeps build
* [`e96980a1`](https://github.com/NixOS/nixpkgs/commit/e96980a1ee8d8f276acfbd5b6b66d50557dc1991) inconsolata: install variable font
* [`9d321ab3`](https://github.com/NixOS/nixpkgs/commit/9d321ab3f82e52b3d5b3f4b4d380ea47b5184575) firefox: Remove unused makeBinaryWrapper argument
* [`4545eb3e`](https://github.com/NixOS/nixpkgs/commit/4545eb3e01b7d9448a4c8bb24cfb85daf4f384da) firefox: Remove obsolete native host configurations
* [`990e7a5f`](https://github.com/NixOS/nixpkgs/commit/990e7a5fa219dc4fdae74cd23c7043722736e33e) pachyderm: 2.11.6 -> 2.12.2
* [`879813b5`](https://github.com/NixOS/nixpkgs/commit/879813b5ede6c54f281819e02f07e1e0aac94a37) grafana-dash-n-grab: 0.7.1 -> 0.7.2
* [`9a903fd7`](https://github.com/NixOS/nixpkgs/commit/9a903fd7b09487d0552457665b94b95ffb1da862) xxgdb: fix build failure
* [`aff75d6a`](https://github.com/NixOS/nixpkgs/commit/aff75d6ae09c95b5e3f3e15b484e61ebdb1626f1) pam_u2f: 1.3.1 -> 1.3.2
* [`fdf0d3c7`](https://github.com/NixOS/nixpkgs/commit/fdf0d3c72eadcfefc3cf92e5ca2f54e1fda32c06) redict.tests: fix the eval
* [`f6b4f881`](https://github.com/NixOS/nixpkgs/commit/f6b4f8810fc98f5fc5e9f8d883ed95d5f51a3dbd) google-alloydb-auth-proxy: 1.12.0 -> 1.12.1
* [`dfc72531`](https://github.com/NixOS/nixpkgs/commit/dfc725314dd9195773f6791560caf0d4eaa51289) kubevpn: 2.2.10 -> 2.3.9
* [`83e55ef3`](https://github.com/NixOS/nixpkgs/commit/83e55ef36bbef061bf30da830703cfa19022be30) nixos/webdav: add package option
* [`b370e7f1`](https://github.com/NixOS/nixpkgs/commit/b370e7f14a0b865a99e4a45578c0a1f0f3926177) pkgs/build-support/php/builders/v2: copy installer-paths to the output
* [`bca58127`](https://github.com/NixOS/nixpkgs/commit/bca581271636675d7c741d44ec5f4f3b2f479d1e) androidenv.emulateApp: add meta.mainProgram
* [`f6354126`](https://github.com/NixOS/nixpkgs/commit/f63541262b4060be14d0d6d38b85273aed687534) ibus-engines.table: 1.17.9 -> 1.17.10
* [`21548b63`](https://github.com/NixOS/nixpkgs/commit/21548b6325511256de280abad14ea957cb8f832e) rquickshare: 0.11.3 -> 0.11.4
* [`9f7e3c9d`](https://github.com/NixOS/nixpkgs/commit/9f7e3c9d1faf2a45245826580883ce70f2dd3b2e) rquickshare-legacy: don't set `updateScript`
* [`c1094176`](https://github.com/NixOS/nixpkgs/commit/c1094176e863f8ab9518942fe04324a5241ca6b3) pyquaternion: Patch for numpy2 support
* [`2d67d1e7`](https://github.com/NixOS/nixpkgs/commit/2d67d1e7926e40e0503c9321d3cc777e2a30b514) python312Packages.py2bit: 0.3.0 -> 0.3.3
* [`de25b6a9`](https://github.com/NixOS/nixpkgs/commit/de25b6a94bbb593763d7be3b1ded151720addf2a) juju: 3.6.1 -> 3.6.2
* [`193c83ee`](https://github.com/NixOS/nixpkgs/commit/193c83ee8d410be9955891a79f73058a2f518bf7) httptoolkit-server: 1.19.0 -> 1.19.3
* [`3c32e26f`](https://github.com/NixOS/nixpkgs/commit/3c32e26fee045916726c93206856580930149acd) gtk-pipe-viewer: 0.5.3 -> 0.5.4
* [`c3f637d8`](https://github.com/NixOS/nixpkgs/commit/c3f637d84cb68c037d0c7415361a3182cc7d25b6) unionfs-fuse: 2.2 -> 3.6
* [`f835a25c`](https://github.com/NixOS/nixpkgs/commit/f835a25c46a5c4d64e2e2dc25a63e4429bf93fe0) unionfs-fuse: add update script
* [`07f17232`](https://github.com/NixOS/nixpkgs/commit/07f172320af3bfcf6a574b0a1e3e80e0bce46c60) rke: 1.7.1 -> 1.7.2
* [`9305c76f`](https://github.com/NixOS/nixpkgs/commit/9305c76f0611489e0fb894f0fd927ee8cd0e8c2e) python312Packages.textual-autocomplete: init at 3.0.0a13
* [`82a9574d`](https://github.com/NixOS/nixpkgs/commit/82a9574d100a132cef784036833a302b82cd59d5) bee: 2.3.2 -> 2.4.0
* [`4b2abf40`](https://github.com/NixOS/nixpkgs/commit/4b2abf40c55821bada2664aff7474a77812a9bce) tailscale: add lsof dependency on darwin
* [`c1dd2007`](https://github.com/NixOS/nixpkgs/commit/c1dd20073671a9a9d4441a927efd9253052df944) kics: 2.1.3 -> 2.1.4
* [`c3702284`](https://github.com/NixOS/nixpkgs/commit/c370228401e61475b5dbf31d9403929cf22dbcf5) protoc-gen-validate: 1.1.0 -> 1.2.1
* [`823e1c08`](https://github.com/NixOS/nixpkgs/commit/823e1c0800b2e382fe196ad2cb64763cd8ccae4e) jan: 0.5.13 -> 0.5.14
* [`d267ea87`](https://github.com/NixOS/nixpkgs/commit/d267ea8717977a757b705250205bb8801568dd63) nixos/wrappers: add per-wrapper enable option
* [`5db6786f`](https://github.com/NixOS/nixpkgs/commit/5db6786f743af2003666820fd1e164f400c54e9e) mc: 4.8.32 -> 4.8.33
* [`7c6be4bc`](https://github.com/NixOS/nixpkgs/commit/7c6be4bcb5b8f4c4797439d850d715094bc0423e) micromdm: 1.12.1 -> 1.13.0
* [`10b3543c`](https://github.com/NixOS/nixpkgs/commit/10b3543c05cf10ecf5fdda72db0e4af981522ace) revive: 1.5.1 -> 1.6.0
* [`80ae1ba9`](https://github.com/NixOS/nixpkgs/commit/80ae1ba91339bbc4b260ddb8f0f57b1efd3e72f9) yewtube: 2.12.0 -> 2.12.1
* [`b90a52b4`](https://github.com/NixOS/nixpkgs/commit/b90a52b475aad5c7c46f2878623e462e68c6361c) passes: 0.9 -> 0.10
* [`35ff9ddc`](https://github.com/NixOS/nixpkgs/commit/35ff9ddce1346004ee2fba191afb27697357501a) pineflash: fix start on wayland
* [`d62ea22c`](https://github.com/NixOS/nixpkgs/commit/d62ea22c2b8512fbf620234fa13963934d263a2b) docs: removed internal `security.wrapperDir`
* [`d409bd14`](https://github.com/NixOS/nixpkgs/commit/d409bd141f39d4c480cc4db9070ff3c06cd4d3b9) level-zero: 1.20.0 -> 1.20.2
* [`4615c564`](https://github.com/NixOS/nixpkgs/commit/4615c564a256367024cd66d5a2de12bb736d500b) python312Packages.crc32c: 2.4 -> 2.7.1
* [`b845aa35`](https://github.com/NixOS/nixpkgs/commit/b845aa355f4653624621529347d6d167e71f0178) ruffle: remove govanify from `meta.maintainers`
* [`ff76ffdb`](https://github.com/NixOS/nixpkgs/commit/ff76ffdb3ac128f060b25a1d636b0d2500a5c62c) carapace: 1.1.1 -> 1.2.1
* [`2363cc10`](https://github.com/NixOS/nixpkgs/commit/2363cc101e923e5cf7696f95a3dc3d49a2e3db33) avidemux: fix build against x265 4.1
* [`f7c14661`](https://github.com/NixOS/nixpkgs/commit/f7c14661350a4ee047b690e83e11958acf610af0) kubebuilder: 4.4.0 -> 4.5.0
* [`9683835f`](https://github.com/NixOS/nixpkgs/commit/9683835f04a0c1784ab2e7667ff8bedd5b084da6) nixos/nextcloud: Update logreader warning description
* [`ced568bf`](https://github.com/NixOS/nixpkgs/commit/ced568bf30daea79411d4638bc5c5d4a2a80b951) geogram: 1.8.6 -> 1.9.2
* [`dcc7199c`](https://github.com/NixOS/nixpkgs/commit/dcc7199c4e2c84bf0ff00732f398ef741f2e969e) nixos/tlp: expose package
* [`14c471b1`](https://github.com/NixOS/nixpkgs/commit/14c471b127039f67eaed970d4b4f6da8f1d6a375) maintainers: add ntbbloodbath
* [`d1ed2945`](https://github.com/NixOS/nixpkgs/commit/d1ed29454badb696c5133ecd7d4515f7ed6b17bf) ruffle: nightly-2025-01-04 -> nightly-2025-01-25
* [`5d57a90e`](https://github.com/NixOS/nixpkgs/commit/5d57a90e2abf555de084876009bffba7dc40f0f2) rstudio: fix build
* [`a3a1c578`](https://github.com/NixOS/nixpkgs/commit/a3a1c578ed462e7c7e7d959059a82d5fff2cccde) pngout: 20200115 -> 20230322
* [`df880616`](https://github.com/NixOS/nixpkgs/commit/df88061665aa5bb8bada79466e12721daa91d7dc) jwasm: 2.18 -> 2.19
* [`25a5185f`](https://github.com/NixOS/nixpkgs/commit/25a5185f4a9b9e9cb08dad79f1e0cd3356cd208d) mackerel-agent: 0.83.0 -> 0.84.0
* [`92e0e9e5`](https://github.com/NixOS/nixpkgs/commit/92e0e9e5168fdd1db2ca68a420dd0dc73401f89d) nextdns: 1.44.3 -> 1.44.4
* [`dba233a0`](https://github.com/NixOS/nixpkgs/commit/dba233a016e710f6f2ae4bfd14bb7e8659743987) python312Packages.highdicom: 0.23.1 -> 0.24.0
* [`3379ddaa`](https://github.com/NixOS/nixpkgs/commit/3379ddaa64b02d84fe13d264cb3fa5c772b6f1ac) python312Packages.pylibjpeg-openjpeg: unbreak by lifting poetry-core version bounds
* [`63a37dd5`](https://github.com/NixOS/nixpkgs/commit/63a37dd5ed6093fe1e3a4fdf3823b5996cadc69f) python312Packages.highdicom: restore pylibjpeg-openjpeg optional dependency
* [`88d9c7ff`](https://github.com/NixOS/nixpkgs/commit/88d9c7ffb7b9b5cbd83c2f841b6d5048b34c87e4) dprint-plugin-toml: 0.6.3 -> 0.6.4
* [`7aa016f9`](https://github.com/NixOS/nixpkgs/commit/7aa016f96a27aec33ab3180fbc51b35ca516f402) libtorrent-rasterbar: 2.0.10 -> 2.0.11
* [`1d706ae8`](https://github.com/NixOS/nixpkgs/commit/1d706ae8086e983e95df64db5c496b64488c6ec1) mmtui: init at 0.1.1
* [`06b47bf4`](https://github.com/NixOS/nixpkgs/commit/06b47bf4d00d45ec6da1bf4c8a7394896d71ea4f) crowdsec: Correctly add upstream systemd service to outputs
* [`426a7afc`](https://github.com/NixOS/nixpkgs/commit/426a7afc9a6ecfdac544bda4022acef31e36df34) crowdsec: Set tag version as expected by upstream
* [`ab9d0650`](https://github.com/NixOS/nixpkgs/commit/ab9d0650b09329d4ef81ed1fa53b941f65fb5b90) python313Packages.arelle: disable for now
* [`001ba37d`](https://github.com/NixOS/nixpkgs/commit/001ba37df7fe527b68d23d78ed5ff5d7f174ad7d) dotnet-repl: 0.1.216 -> 0.3.230
* [`f04cda16`](https://github.com/NixOS/nixpkgs/commit/f04cda16d6f2b6b622440d9eae3d6f0276bb9bea) libmpcdec: fix cross build
* [`684ddcb6`](https://github.com/NixOS/nixpkgs/commit/684ddcb6c22100f6d1ab73b3f40020d70076c69e) Update ltc.nix
* [`6483e949`](https://github.com/NixOS/nixpkgs/commit/6483e949bddca7079547ad2f2c1ea64b666face7) maintainers: add niraethm
* [`a6786b1e`](https://github.com/NixOS/nixpkgs/commit/a6786b1e06edf3af40c644ece739eb760621086c) vintagestory: add niraethm as maintainer
* [`1203351f`](https://github.com/NixOS/nixpkgs/commit/1203351f3d84c8a4bd5d9067b5be414d4f2a02be) maintainers: add andrewgazelka
* [`635db320`](https://github.com/NixOS/nixpkgs/commit/635db320d080fc5decff99abf0d1689e846a18f5) change sha256 to hash
* [`bc14c84d`](https://github.com/NixOS/nixpkgs/commit/bc14c84db6907f2ca9339af9564c2e48ee708e93) python312Packages.pulsar: 3.5.0 -> 3.6.0
* [`475dfe1b`](https://github.com/NixOS/nixpkgs/commit/475dfe1b552eb5fd9d965f7d6db9bdd7a5f3dd28) mkbootimage: install exbootimage tool
* [`6d8fc203`](https://github.com/NixOS/nixpkgs/commit/6d8fc203e222a905329a4e6d5b68e1f11eea9f1e) container2wasm: 0.7.1 -> 0.8.0
* [`e35a65a2`](https://github.com/NixOS/nixpkgs/commit/e35a65a2f8a32f63c78a9d41cf993a5cf8a323c0) nixos: Fix timesyncd test for systemd >= 257.1
* [`545cc3f1`](https://github.com/NixOS/nixpkgs/commit/545cc3f18563bb9c33ba1fca5b4a8d2615d3a8f6) stackql: 0.6.50 -> 0.6.65
* [`a34e2101`](https://github.com/NixOS/nixpkgs/commit/a34e2101ec8135c1220f80179c865129a6442591) mdbook: 0.4.43 -> 0.4.44
* [`a4e9fb56`](https://github.com/NixOS/nixpkgs/commit/a4e9fb56ad4ef38b3c882a308ee9ed065e564249) rundeck: add mainProgram
* [`794dbd79`](https://github.com/NixOS/nixpkgs/commit/794dbd79bb30041fcc1b2f03e74880df2456694f) rundeck: remove unnecessary option
* [`e7588bdc`](https://github.com/NixOS/nixpkgs/commit/e7588bdcf3d006f2550ee3da4829813789faa147) cue: 0.11.2 -> 0.12.0
* [`31f4103c`](https://github.com/NixOS/nixpkgs/commit/31f4103cb430fb55b3d4f853ed3f5b8059837432) iotas: add gnome-circle team to maintainers
* [`5f9e5f8a`](https://github.com/NixOS/nixpkgs/commit/5f9e5f8a9876a92282e5e86cdc63f48c32b67536) soplex: 712 -> 713
* [`5678e06c`](https://github.com/NixOS/nixpkgs/commit/5678e06cfbe5948355b9925b3416f0553c410a35) aws-sso-util: builds on darwin
* [`66bd09fb`](https://github.com/NixOS/nixpkgs/commit/66bd09fb952a708aee6cc21062a1d98e10a6db70) sesh: 2.8.0 -> 2.10.0
* [`75c4f247`](https://github.com/NixOS/nixpkgs/commit/75c4f247cd4100ba6fd1477734dd3adf01a81f63) melange: 0.18.3 -> 0.19.3
* [`c6919aa5`](https://github.com/NixOS/nixpkgs/commit/c6919aa5616f9ac93fb9e7e848fc2d7097a76260) grizzly: 0.6.1 -> 0.7.1
* [`eeb348ef`](https://github.com/NixOS/nixpkgs/commit/eeb348ef5adde18b432188bc54ed550233b1bb38) anyk: 3.33.0 -> 3.39.0
* [`7401d8c7`](https://github.com/NixOS/nixpkgs/commit/7401d8c7b2d31b63da03d8071494f8a7f245fb5a) python312Packages.pytrends: drop
* [`ff23b19e`](https://github.com/NixOS/nixpkgs/commit/ff23b19e01dd7bcdea59844155e684506471e95a) python313Packages.inform: fix tests
* [`82c62d13`](https://github.com/NixOS/nixpkgs/commit/82c62d132e3f8a087bdaa6941800fcd157dffa99) nixosTests.terminal-emulators.lomiri-terminal-app: Drop
* [`d250c32b`](https://github.com/NixOS/nixpkgs/commit/d250c32be71d2d757db32a1b22d4cabba55c95b4) services.mysqlBackup: make singleTransaction configurable per database
* [`00f0c5cf`](https://github.com/NixOS/nixpkgs/commit/00f0c5cf3264189205230d6a383432940cafad82) services.mysqlBackup: use new path of mariadb-dump if mysql service package is a modern mariadb
* [`16553f2c`](https://github.com/NixOS/nixpkgs/commit/16553f2c836371d3fab643be15549bceab93da85) services.mysqlBackup: add assertion that all databases in singleTransaction must be included in the databases option
* [`657c6898`](https://github.com/NixOS/nixpkgs/commit/657c689842d9c57d9e3ce7a81d24cabf2e46445b) ci/eval: make eval for non-native platforms less incorrect
* [`e8a255c0`](https://github.com/NixOS/nixpkgs/commit/e8a255c09a299398efb99cb98a53330edfe5f9fc) xtrlock-pam: drop
* [`a0cdf6f1`](https://github.com/NixOS/nixpkgs/commit/a0cdf6f14ae84237dcea65a3bd964db79ecd938b) fittrackee: 0.8.12 -> 0.9.1
* [`bdd4e9d7`](https://github.com/NixOS/nixpkgs/commit/bdd4e9d74045d35226e6b8efd02fd37a96595a80) tezos-rust-libs: bump llvm
* [`4dea13e8`](https://github.com/NixOS/nixpkgs/commit/4dea13e848ceacbc48d82cf8ddff746f0736ad24) mirrord: add support for aarch64-darwin and x86_64-darwin
* [`33c07e77`](https://github.com/NixOS/nixpkgs/commit/33c07e7725294425774255ddfb57d78d8bb789eb) renpy: 8.3.1.24090601 -> 8.3.4.24120703
* [`bfcf7a7a`](https://github.com/NixOS/nixpkgs/commit/bfcf7a7a9207c56ac7c5ec6f29b4c5531986f797) galaxy-buds-client: format
* [`9bc53e1f`](https://github.com/NixOS/nixpkgs/commit/9bc53e1f217c271a47928cf6ab730223a8304e33) galaxy-buds-client: cleanup
* [`30d3f9ef`](https://github.com/NixOS/nixpkgs/commit/30d3f9efff0a0ca2b47acabdb21ff1bf71f34c8d) maintainers: add nekitdev
* [`3ad21240`](https://github.com/NixOS/nixpkgs/commit/3ad21240eb23b6b87e2f809dd2d32874b588dc32) changelogging: init at 0.7.0
* [`17b41f0f`](https://github.com/NixOS/nixpkgs/commit/17b41f0f2428a720cd0f73e6ed4859f101d7beac) dolt: 1.45.4 -> 1.48.0
* [`8a4b47d7`](https://github.com/NixOS/nixpkgs/commit/8a4b47d7cac5c0dbfd76771e07727d5be3623dc4) python3Packages.pyobjc-core: init at 11.0
* [`a2431394`](https://github.com/NixOS/nixpkgs/commit/a24313946ddb04b76c4070c9221aa1e13ff97d80) python3Packages.pyobjc-framework-Cocoa: init at 11.0
* [`f4305e60`](https://github.com/NixOS/nixpkgs/commit/f4305e605c8a4cd812907ab96944a9eafd9d4c3b) python3Packages.rumps: init at unstable-2025-02-02
* [`83f30e8a`](https://github.com/NixOS/nixpkgs/commit/83f30e8ab718a8ba6fa3728838e31baac845a79d) doomrunner: move to by-name
* [`9779a3e4`](https://github.com/NixOS/nixpkgs/commit/9779a3e4ad55bc21f9273737535433c37c92b48f) doomrunner: 1.8.3 -> 1.9.0, cleanup
* [`39ef5285`](https://github.com/NixOS/nixpkgs/commit/39ef52856bb824d8248f6f13dbe5ea11abb0094c) sympa: 6.2.74 -> 6.2.76
* [`4c3a095d`](https://github.com/NixOS/nixpkgs/commit/4c3a095d576eacb252002e81b94a2fea2933e135) lubelogger: 1.4.3 -> 1.4.4
* [`5da19e6c`](https://github.com/NixOS/nixpkgs/commit/5da19e6cada34f2c7653769feb317adb15953b7e) citrix-workspace: bump llvm
* [`e927eba0`](https://github.com/NixOS/nixpkgs/commit/e927eba03b4161ce9ca8ec1a495ff1431daf0d64) racket and racket-minimal: separate recipes
* [`9f953c13`](https://github.com/NixOS/nixpkgs/commit/9f953c133d4ba0608f9b0bee2b5b1aa66a67d258) racket-minimal: fix docs failure for lack of SQLite
* [`3a8ef07d`](https://github.com/NixOS/nixpkgs/commit/3a8ef07df70750437bf783c1448379369f7d9d25) racket: fix failure to find executable
* [`bae3d399`](https://github.com/NixOS/nixpkgs/commit/bae3d399e4eac8ef6ab9816d79f37355f62f73eb) cue: Switch to using `tag` inside of `fetchFromGitHub`
* [`c569f990`](https://github.com/NixOS/nixpkgs/commit/c569f990dfabc6cec3a8979fdee4d1b8fa24b2a3) display3d: init at 0.2.1
* [`07e08a7a`](https://github.com/NixOS/nixpkgs/commit/07e08a7a91e5c920097d97e8d6deacd41ee5cc16) rss-bridge: 2025-01-02 -> 2025-01-26
* [`7a856fcb`](https://github.com/NixOS/nixpkgs/commit/7a856fcb9c6498d7bcacf66ebf8aaf13ca2eaa01) sonar-scanner-cli: 6.2.1.4610 -> 7.0.1.4817
* [`d4549901`](https://github.com/NixOS/nixpkgs/commit/d4549901c87c62b2a3c9002b91fafbf378551dea) nixos/nats: make config validation friendly to cross compilation
* [`27b4c1f7`](https://github.com/NixOS/nixpkgs/commit/27b4c1f70e11a98d801bdf1b644cdd4c1c3bd80c) nixops_unstable_{minimal,full}: fix missing nix after poetry update
* [`3048cdc6`](https://github.com/NixOS/nixpkgs/commit/3048cdc6db45d44dc33852175dffb71959bfb3fc) vcmi: 1.6.4 -> 1.6.5
* [`b6ed862e`](https://github.com/NixOS/nixpkgs/commit/b6ed862e65772fab57f460f5670a518b5bae0ef5) grafanaPlugins.victoriametrics-logs-datasource: init at 0.14.3
* [`d4f5d01b`](https://github.com/NixOS/nixpkgs/commit/d4f5d01becc2af7f4e96e84ed3e20f302510f9b2) cargo-shuttle: 0.51.0 -> 0.52.0
* [`65c24be2`](https://github.com/NixOS/nixpkgs/commit/65c24be2bdf0ba1ec97d7bff0b3b825b74e4feb3) vale: 3.9.4 -> 3.9.5
* [`9fc6a9ba`](https://github.com/NixOS/nixpkgs/commit/9fc6a9ba5bf6fddf90489962b7c4c8822e85027d) fanficfare: 4.41.0 -> 4.42.0
* [`e499f37d`](https://github.com/NixOS/nixpkgs/commit/e499f37df93149dce44b74834cfe37f5ab32114c) mantainers: add phrmendes
* [`b5c4a09d`](https://github.com/NixOS/nixpkgs/commit/b5c4a09dc84255d4e4c958d25a4e598ab4856108) dart.flutter_discord_rpc: init
* [`da7074e3`](https://github.com/NixOS/nixpkgs/commit/da7074e3496c8770da38fa4deb95f940f2325bb5) cudaPackages.cuda_sanitizer_api: add override
* [`594abb41`](https://github.com/NixOS/nixpkgs/commit/594abb417db1a338ef7618f8543c6727b75d49a3) gdtoolkit_4: 4.3.1 -> 4.3.3
* [`6adcba97`](https://github.com/NixOS/nixpkgs/commit/6adcba9704a299587128fa05a6e11e8db6b445fa) mbuffer: fix and enable strictDeps
* [`1cd03986`](https://github.com/NixOS/nixpkgs/commit/1cd039866ff4728d85430ba66af60ba790a4789b) roslyn-ls:  4.14.0-1.25060.2 -> 4.14.0-1.25074.7
* [`1c699b89`](https://github.com/NixOS/nixpkgs/commit/1c699b8921e759f147668ad10be3e436ab9e4032) shark: fix build with boost187
* [`8e5a2b1a`](https://github.com/NixOS/nixpkgs/commit/8e5a2b1af2fcb4e2e06b49d4b81cf3f3136b4ee9) git-machete: 3.31.1 -> 3.32.1
* [`01a9a85b`](https://github.com/NixOS/nixpkgs/commit/01a9a85bbe9928b7fa6954662942244bbef243d7) maintainers: add remyvv
* [`c9e03a8e`](https://github.com/NixOS/nixpkgs/commit/c9e03a8eda110dcae3a70af88533f3ff949f72ee) ddev: add remyvv as maintainer
* [`13d80f9a`](https://github.com/NixOS/nixpkgs/commit/13d80f9a1d1cb20146a2718bc21f61f9a5de627d) nim-unwrapped: 2.2.0 -> 2.2.2
* [`238bc884`](https://github.com/NixOS/nixpkgs/commit/238bc88476ac11fe14fee424abce25aa0ab95439) copycat: 002 -> 003
* [`a179629c`](https://github.com/NixOS/nixpkgs/commit/a179629c24919e364111d3703c80152d8be1aee1) aws-iam-authenticator: 0.6.29 -> 0.6.30
* [`3d86ed3a`](https://github.com/NixOS/nixpkgs/commit/3d86ed3ac6cf3d421d10522b77f09eb702515118) certificate-ripper: 2.3.0 -> 2.4.0
* [`f05513f3`](https://github.com/NixOS/nixpkgs/commit/f05513f3af282cdbb7c79fbce78dfcd6a1b2334e) nixos/xonsh: support extra packages
* [`f6706283`](https://github.com/NixOS/nixpkgs/commit/f6706283e81d05a907d5ca00539f8bd454a66a84) xonsh: format
* [`a2295206`](https://github.com/NixOS/nixpkgs/commit/a229520681acc90fd74805598fb64a698c1b2702) xonsh: rewrite with callPackage and new buildPythonPackage
* [`c922aecb`](https://github.com/NixOS/nixpkgs/commit/c922aecbc36187a48b82a57316c56c1f6e16f5f5) xonsh.xontribs: init empty package set
* [`92a755c0`](https://github.com/NixOS/nixpkgs/commit/92a755c010899f094f3140cae1bc5e3a5d0d17d8) xonsh.xontribs.xonsh-direnv: init at 1.6.5
* [`e23facf8`](https://github.com/NixOS/nixpkgs/commit/e23facf8739d9738c6904e0475b08ef735714bb5) xonsh.xontribs.xontrib-abbrevs: init at 0.1.0
* [`9c6b94bb`](https://github.com/NixOS/nixpkgs/commit/9c6b94bb313be8c4ce4c7ce7bb19cb916aa3e0f7) xonsh.xontribs.xontrib-bashisms: init at 0.0.5
* [`bc10963f`](https://github.com/NixOS/nixpkgs/commit/bc10963f94090f17eaa1400d61087842dfd0fefb) xonsh.xontribs.xontrib-debug-tools: init at 0.0.1
* [`d508833e`](https://github.com/NixOS/nixpkgs/commit/d508833e365603020eafd4265b90c6b8bf3b5b8e) xonsh.xontribs.xontrib-distributed: init at 0.0.4
* [`cb781057`](https://github.com/NixOS/nixpkgs/commit/cb78105719eabede7c07206e6c8ac8fca3539e88) xonsh.xontribs.xontrib-fish-completer: init at 0.0.1
* [`afeae083`](https://github.com/NixOS/nixpkgs/commit/afeae08331f80ee83959223803bea28ae6bc0b72) xonsh.xontribs.xontrib-jedi: init at 0.1.1
* [`6453547e`](https://github.com/NixOS/nixpkgs/commit/6453547e820676c7eb0d3d7debdd4f2bb7093bd4) xonsh.xontribs.xontrib-jupyter: init at 0.3.2
* [`a09d941a`](https://github.com/NixOS/nixpkgs/commit/a09d941ad719afe76c1924dcd95127d1dafc777b) xonsh.xontribs.xontrib-vox: init at 0.0.1
* [`65fa4335`](https://github.com/NixOS/nixpkgs/commit/65fa4335a0c93be788831b30cf0b161e3c46cc21) xonsh.xontribs.xontrib-whole-word-jumping: init at 0.0.1
* [`ab315b1b`](https://github.com/NixOS/nixpkgs/commit/ab315b1b0cb329b14417acb5972c74d7056a978c) spotify-player: 0.20.3 -> 0.20.4
* [`6c28f61e`](https://github.com/NixOS/nixpkgs/commit/6c28f61e895b4ee0e10d8cb1c5607faa38a8370f) lock: 1.3.9 -> 1.4.1
* [`aad97fda`](https://github.com/NixOS/nixpkgs/commit/aad97fda3ed9c3f07efbff33119776710b621873) libreoffice-fresh-unwrapped: 24.8.3.2 -> 25.2.0.3
* [`5fdddf2e`](https://github.com/NixOS/nixpkgs/commit/5fdddf2e7a5b302b031b263a7f7f4b8120ce7f7c) libreoffice-still-unwrapped: 24.2.7.2 -> 24.8.4.2
* [`cc2fac10`](https://github.com/NixOS/nixpkgs/commit/cc2fac109ffc5a0841cd7acc474caa22003e0261) dioxus-cli: 0.6.0 -> 0.6.2
* [`4081b09e`](https://github.com/NixOS/nixpkgs/commit/4081b09e7af48f2c40af054fc4090e6c3100999e) resticprofile: 0.28.0 -> 0.29.1
* [`8b67f2a8`](https://github.com/NixOS/nixpkgs/commit/8b67f2a80351c42014021235b28f782c663d569d) Revert "python3Packages.zarr: 2.18.3 -> 3.0.1"
* [`14a9b932`](https://github.com/NixOS/nixpkgs/commit/14a9b932cd0e871d559086c8dd674d3e045df289) diesel-cli: 2.2.6 -> 2.2.7
* [`178845f8`](https://github.com/NixOS/nixpkgs/commit/178845f8e455576b13c6c4185adc71c631fc04b9) ghidra-with-extensions: add ivyfanchiang as maintainer
* [`e3e51b26`](https://github.com/NixOS/nixpkgs/commit/e3e51b26ccad3aa405826a7c8bd1b0c5e2d74dbf) ghidra-extensions.kaiju: init at 241204
* [`cddf3efb`](https://github.com/NixOS/nixpkgs/commit/cddf3efbe92e4a17a99aa7bab3e1fb71eadb670e) liborcus: fix and enable strictDeps
* [`ee6ca62b`](https://github.com/NixOS/nixpkgs/commit/ee6ca62b12becac9ae0fff31689a889c92ea7885) liborcus: enable tests and parallel builds
* [`1ede86c7`](https://github.com/NixOS/nixpkgs/commit/1ede86c7a31444c37ac89271a7870cb023b24e44) anytype: build from source
* [`2280309e`](https://github.com/NixOS/nixpkgs/commit/2280309e1c07295b72f3ffea672cd9667ceea324) ephemeralpg: 3.3 -> 3.4
* [`18ceb047`](https://github.com/NixOS/nixpkgs/commit/18ceb0473147aa7e3e3cf461270ad29dff4be2b7) Update flutter327: 3.27.1 -> 3.27.4
* [`2687d35e`](https://github.com/NixOS/nixpkgs/commit/2687d35ecae8e0b974c46972509d07adb7639f0a) erlang: 27.2.1 -> 27.2.2
* [`13b10627`](https://github.com/NixOS/nixpkgs/commit/13b10627307dcd9f5fee0a54a9d571132f1effa1) services/journald: re-enable systemd-journald-audit.socket
* [`745feb58`](https://github.com/NixOS/nixpkgs/commit/745feb584b527d0df785a9509aee8858c28dc7d9) ghidra: 11.2.1 -> 11.3
* [`e7fc8937`](https://github.com/NixOS/nixpkgs/commit/e7fc893774f31a52d95d5fb50d319af84471f7ca) ghidra-bin: 11.2.1 -> 11.3
* [`ff78e34e`](https://github.com/NixOS/nixpkgs/commit/ff78e34e0b63972761db8a5b02a357d6ac5494d3) services/journald: introduce audit option
* [`bf3a7002`](https://github.com/NixOS/nixpkgs/commit/bf3a70020c624e8f4aec631c4a22f58666b735e1) nixos/tests/systemd-journal: test audit behaviour
* [`30898cd8`](https://github.com/NixOS/nixpkgs/commit/30898cd8b7b2a797dfa68a4ce1f597ff218b8ab3) python313Packages.gurobipy: 12.0.0 -> 12.0.1
* [`f87f5893`](https://github.com/NixOS/nixpkgs/commit/f87f5893ab4bf8da5d49ef867e0148857ff6cce4) metals: 1.5.0 -> 1.5.1
* [`a7cb5b1b`](https://github.com/NixOS/nixpkgs/commit/a7cb5b1ba5746d3f3e84a77a730d750a1ecb831d) nixos/home-assistant: use full path for option in description
* [`ff585410`](https://github.com/NixOS/nixpkgs/commit/ff585410544889b6f864c04f10c4619f3193689e) committed: 1.1.2 -> 1.1.5
* [`5ee577c1`](https://github.com/NixOS/nixpkgs/commit/5ee577c1df6a15bebc47e0a708227bdfbd7c10af) python313Packages.dataproperty: refactor, use setuptools-scm
* [`87ba9a0f`](https://github.com/NixOS/nixpkgs/commit/87ba9a0fc0a51f29674bb71bf05afa7b332ddff1) python313Packages.pytablewriter: refactor, use setuptools-scm
* [`e024f6f2`](https://github.com/NixOS/nixpkgs/commit/e024f6f2935c4c58974c01d13c216a4af2826002) python313Packages.tabledata: refactor, use setuptools-scm
* [`1b092ec7`](https://github.com/NixOS/nixpkgs/commit/1b092ec7710b17cd2609a30fb80e2654d4a33b42) python313Packages.typepy: refactor, use setuptools-scm
* [`53f87ad4`](https://github.com/NixOS/nixpkgs/commit/53f87ad49044225133e30695fb2c3bdf08f68281) blackfire: 2.28.22 -> 2.28.23
* [`7654daca`](https://github.com/NixOS/nixpkgs/commit/7654daca5128adb49c067758d27fa131036f87e4) yaml-language-server: fix strictDeps
* [`1012d54b`](https://github.com/NixOS/nixpkgs/commit/1012d54b3ae5acc1423d4e6da9a43750ffb0ca1b) factoriolab: 3.10.0 -> 3.11.4
* [`108d1379`](https://github.com/NixOS/nixpkgs/commit/108d1379650bfca60d5d53715bac7a993c7a1518) chroma: 2.8.0 -> 2.15.0
* [`7539f8d1`](https://github.com/NixOS/nixpkgs/commit/7539f8d17e3ae1b967503dcbd3f418ff9cf7d6e0) licensee: 9.16.1 -> 9.18.0
* [`af3198dd`](https://github.com/NixOS/nixpkgs/commit/af3198dd1c85f7bfde40abf92c1b2dfe3a70a13e) lxqt-panel-profiles: fix paths
* [`84cd89f0`](https://github.com/NixOS/nixpkgs/commit/84cd89f0d794fd0b7f4397bab74c1382899191ab) amdvlk: 2024.Q4.3 -> 2025.Q1.1
* [`3af1bb5f`](https://github.com/NixOS/nixpkgs/commit/3af1bb5f9f1780397c204edcbc206437240a090d) tailwindcss_4: init at 4.0.4
* [`ca3ef3c8`](https://github.com/NixOS/nixpkgs/commit/ca3ef3c8af500df055460d3439911d11e65eba7d) add maintainer
* [`3dea7372`](https://github.com/NixOS/nixpkgs/commit/3dea7372a434c93bb6eab3e51ca9fd1bb4db0a86) python312Packages.langsmith: 0.3.4 -> 0.3.6
* [`00eabcdf`](https://github.com/NixOS/nixpkgs/commit/00eabcdf1806ecf97882619577d2c9b30c59e77a) linux_xanmod, linux_xanmod_latest: 2025-02-08 updates
* [`ff1741e2`](https://github.com/NixOS/nixpkgs/commit/ff1741e20dc77f83e5f2ad0f5564fd271a01965e) argo: 3.6.2 -> 3.6.3
* [`3f0b3d00`](https://github.com/NixOS/nixpkgs/commit/3f0b3d009c044f8ddf2f6fd8e2e7a77fe97a9ada) slsa-verifier: 2.6.0 -> 2.7.0
* [`c28495a1`](https://github.com/NixOS/nixpkgs/commit/c28495a152a3bac20bf4110bb2f1cf72ff6cbc73) unciv: 4.15.8 -> 4.15.9-patch1
* [`d46c14d6`](https://github.com/NixOS/nixpkgs/commit/d46c14d61709ca827c98f19c5114b6f59820ed78) sftpgo: 2.6.4 -> 2.6.5
* [`1a7364db`](https://github.com/NixOS/nixpkgs/commit/1a7364dbbf24d748f9b6658f3a45cc5425e2ce99) feishu: fix broken symlink to curl
* [`974db0c4`](https://github.com/NixOS/nixpkgs/commit/974db0c4f84c1e94e71689ca135a3896714fdf44) python312Packages.certbot-dns-cloudflare: refactor
* [`7e475903`](https://github.com/NixOS/nixpkgs/commit/7e4759039d1ad13c45ebbfefb56dbee203e8a4ef) python312Packages.certbot-dns-cloudflare: mark as broken
* [`06ef4c9f`](https://github.com/NixOS/nixpkgs/commit/06ef4c9f6002afdcc26825c630a045d0683cec3b) coroot: 1.6.8 -> 1.8.2
* [`a89985fd`](https://github.com/NixOS/nixpkgs/commit/a89985fde98ee472efe700afd9fa452da728bf89) rcu: 2024.001q -> 2025.001r
* [`a58d8081`](https://github.com/NixOS/nixpkgs/commit/a58d808136a25cd71312c0b888d7d24a6c0ee90d) epiphany: 47.2 → 47.3.1
* [`fcb50b76`](https://github.com/NixOS/nixpkgs/commit/fcb50b7659701aeb2cacfb708a0a096b1b992cc9) nexusmods-app: add release-note for resetting before upgrading
* [`00704a39`](https://github.com/NixOS/nixpkgs/commit/00704a3957f2a8f430592be0d1b58ddc3217aee8) gcr_4: 4.3.0 → 4.3.1
* [`12da928b`](https://github.com/NixOS/nixpkgs/commit/12da928bf305686acdc08bfbeab6db134ba0dc8f) ghex: 46.1 → 46.2
* [`144de796`](https://github.com/NixOS/nixpkgs/commit/144de796364af4571a80973fc8098528927b9f4e) gnome-connections: 47.0 → 47.2.1
* [`ec932cfa`](https://github.com/NixOS/nixpkgs/commit/ec932cfa7f18396592255f5e250276a564591c3b) gnome-control-center: 47.3 → 47.4
* [`fa8150e7`](https://github.com/NixOS/nixpkgs/commit/fa8150e7b2ba0cfe8a334c72d286905eff7a2d21) gnome-initial-setup: 47.2 → 47.4
* [`a580d16a`](https://github.com/NixOS/nixpkgs/commit/a580d16a3c4cfb4a682ff7b851339fbe226a3813) gnome-mahjongg: 47.0 → 47.1
* [`2622b719`](https://github.com/NixOS/nixpkgs/commit/2622b719333007e2b51653ac908c126bc352ca09) gnome-maps: 47.3 → 47.4
* [`773541af`](https://github.com/NixOS/nixpkgs/commit/773541af0507cd4aa7ce4a7559898dc6e8214b9a) gnome-shell: 47.3 → 47.4
* [`1f66b19b`](https://github.com/NixOS/nixpkgs/commit/1f66b19bb013998a64ee32cb36e761721a0d459c) gnome-system-monitor: 47.0 → 47.1
* [`37119594`](https://github.com/NixOS/nixpkgs/commit/371195947ffbab0904d975b5725e3dfa9ae5c88d) gnome-text-editor: 47.2 → 47.3
* [`45ec1969`](https://github.com/NixOS/nixpkgs/commit/45ec196909ee6d05b863db92bea0de3d0e540be7) gtk-vnc: 1.4.0 → 1.5.0
* [`a4cef2e0`](https://github.com/NixOS/nixpkgs/commit/a4cef2e0faae0bfc7f96e12aa22c96dd504467e8) libshumate: 1.3.1 → 1.3.2
* [`a97da365`](https://github.com/NixOS/nixpkgs/commit/a97da3657f3f6e9ee111e02e5011bfa92fb282b9) nautilus: 47.1 → 47.2
* [`3605057c`](https://github.com/NixOS/nixpkgs/commit/3605057cf21fd9f7d5ca248a3e44bbc689b7242b) mutter: 47.4 → 47.5
* [`0e784173`](https://github.com/NixOS/nixpkgs/commit/0e7841732545cd0c2781090a6b702876025ee7fc) zenity.updateScript: Fix version policy
* [`8f6ed757`](https://github.com/NixOS/nixpkgs/commit/8f6ed7577e24fa85328be5c7aeab8c3b8d01af6b) libpanel: Fix version policy
* [`33e8007d`](https://github.com/NixOS/nixpkgs/commit/33e8007dc1f2a3ba5c8340965bc8543414aac665) python312Packages.stravalib: 2.1 → 2.2
* [`7bf55a1a`](https://github.com/NixOS/nixpkgs/commit/7bf55a1a383ab2db1497bee8f932e335831dfe99) python313Packages.sdjson: init at 0.5.0
* [`1f2234d6`](https://github.com/NixOS/nixpkgs/commit/1f2234d6c8684c6a57e146807a1cf4bc49365ef5) python313Packages.pyproject-parser: specify optional-dependencies
* [`c10ad6ec`](https://github.com/NixOS/nixpkgs/commit/c10ad6ec5a2f706ce64274742f7802a76f038f34) python312Packages.plyara: 2.2.7 -> 2.2.8
* [`2f4fb407`](https://github.com/NixOS/nixpkgs/commit/2f4fb407cf51d59a942ed535de79e1157d2e78a4) gcsfuse: 2.6.0 -> 2.9.0
* [`21e5c178`](https://github.com/NixOS/nixpkgs/commit/21e5c1788795f3367db161ad5151d0d4dfb5c267) fq: 0.13.0 -> 0.14.0
* [`f4288c28`](https://github.com/NixOS/nixpkgs/commit/f4288c287800e96b08730d1d92875fe33209eee7) python313Packages.traits: 6.4.3 -> 7.0.2
* [`65f3e6c9`](https://github.com/NixOS/nixpkgs/commit/65f3e6c9b368ea1754fdcb925b9bb102e90639a7) sdl2-compat: init at 2.30.52
* [`ec1f1e1b`](https://github.com/NixOS/nixpkgs/commit/ec1f1e1b319eb34816e7636bef8add723a7e58f9) python312Packages.gpytorch: 1.13 -> 1.14
* [`216003af`](https://github.com/NixOS/nixpkgs/commit/216003af31308b4601386aaec169b5261eba5d02) python312Packages.botorch: 0.12.0 -> 0.13.0
* [`8c493c32`](https://github.com/NixOS/nixpkgs/commit/8c493c32a1498bc777905c79fe10b69697304aed) python312Packages.optuna: 4.1.0 -> 4.2.0
* [`228d4def`](https://github.com/NixOS/nixpkgs/commit/228d4def8a0f1ed52c6a3c3d113cfd9e0d35bf65) python312Packages.pyannote-audio: 3.3.1 -> 3.3.2
* [`648f16ac`](https://github.com/NixOS/nixpkgs/commit/648f16acccab363aa6a41e750107365bfccd5866) python312Packages.ax-platform: 0.4.3 -> 0.5.0
* [`d8d8124b`](https://github.com/NixOS/nixpkgs/commit/d8d8124b5e16ef021a582aef09440a35bf2ca7ea) python312Packages.synergy: fix build
* [`f09da94a`](https://github.com/NixOS/nixpkgs/commit/f09da94afd265dd6d5fe7ec0de60bbb08b812245) python312Packages.resampy: refactor and fix build on aarch64-linux
* [`8b07f82b`](https://github.com/NixOS/nixpkgs/commit/8b07f82b1c648514c8a59428e743f8ed798c1698) firefly-iii: 6.2.4 -> 6.2.5
* [`2aa1904f`](https://github.com/NixOS/nixpkgs/commit/2aa1904f346a66d9047bb624c0be96be0c6328d1) python312Packages.neo: 0.13.4 -> 0.14.0
* [`e342803c`](https://github.com/NixOS/nixpkgs/commit/e342803c2204bd5c7ca29bee30d53f26312565ac) cups-filters: Fix cross compilation
* [`89494e6a`](https://github.com/NixOS/nixpkgs/commit/89494e6a635e3e72fa658f1799e607aeb2737ac9) cinnamon-common: 6.4.6 -> 6.4.7
* [`ce9995c8`](https://github.com/NixOS/nixpkgs/commit/ce9995c88d940119e6685c97ac90f7d72996809f) teleport_15, teleport_16: Use fetchCargoVendor
* [`457c422d`](https://github.com/NixOS/nixpkgs/commit/457c422df0ecf66a2d269d21a4169aded6000584) trunk: 0.21.5 -> 0.21.7
* [`85e6e044`](https://github.com/NixOS/nixpkgs/commit/85e6e0441e80b296608619d0be5c759d6cdc3b6f) gat: 0.20.0 -> 0.20.3
* [`2ae7bba2`](https://github.com/NixOS/nixpkgs/commit/2ae7bba20eecaf7d14a49a8d5c172ec02e24cc20) python313Packages.pygame-ce: 2.5.2 -> 2.5.3
* [`ca8e2277`](https://github.com/NixOS/nixpkgs/commit/ca8e227777a3917e03fa4a76a1ba2507b197ad7c) mini-calc: 3.3.5 -> 3.4.1
* [`a6621bdf`](https://github.com/NixOS/nixpkgs/commit/a6621bdf837f68f9d2b5c9f24d0e98fdb461ab77) tailwindcss: use finalAttrs, run install hooks
* [`cee2c1b0`](https://github.com/NixOS/nixpkgs/commit/cee2c1b02fe28f9af52cc03daf7889b12b3e6fc8) plasmusic-toolbar: 2.2.0 -> 2.3.0
* [`9e2fa8ba`](https://github.com/NixOS/nixpkgs/commit/9e2fa8baa87c5640cca672f3ab47cc152078dc59) yabai: 7.1.6 -> 7.1.8
* [`a7e4b22c`](https://github.com/NixOS/nixpkgs/commit/a7e4b22c912de8549bb489d021852d5a5448b607) vinegar: 1.7.8 -> 1.8.0
* [`ec820a8d`](https://github.com/NixOS/nixpkgs/commit/ec820a8d452a8b8e0e52a998cf4fbfbfb611e998) haskellPackages.tailwind: enhance override to provide `tailwind` binary
* [`495a1f2b`](https://github.com/NixOS/nixpkgs/commit/495a1f2b6af38c564fba6a82bca2cabd585f2762) python312Packages.types-s3transfer: 0.11.1 -> 0.11.2
* [`e11bcdd5`](https://github.com/NixOS/nixpkgs/commit/e11bcdd56821d66c2d859507dd47583bcebd7fdc) sketchybar-app-font: 2.0.30 -> 2.0.31
* [`e905ca92`](https://github.com/NixOS/nixpkgs/commit/e905ca924547f8c9f664da5a0b0f0b92b982fc71) mitmproxy: relax some dependencies to fix build
* [`11540a7b`](https://github.com/NixOS/nixpkgs/commit/11540a7bfb786b116e40455e1f128bfb375250b8) wcslib: refactor
* [`1cb9c455`](https://github.com/NixOS/nixpkgs/commit/1cb9c4550dc2dee415980f21e276578948071ad0) python312Packages.dask-expr: remove (now included in dask)
* [`24c5862b`](https://github.com/NixOS/nixpkgs/commit/24c5862bbec741e99e5b288c7de2177e4f5ae74b) python312Packages.dask: 2024.12.1 -> 2025.1.0
* [`43ef6784`](https://github.com/NixOS/nixpkgs/commit/43ef67841e9ccc78e7b9d9684b741f9b9c4cab77) python312Packages.streamz: cleanup
* [`57778e07`](https://github.com/NixOS/nixpkgs/commit/57778e074c29671facff76729fad59aa3b3af92e) python312Packages.streamz: add GaetanLepage as maintainer
* [`b6cc264c`](https://github.com/NixOS/nixpkgs/commit/b6cc264c8a30a2d9171732946301d58a7674ac13) python312Packages.narwhals: 1.22.0 -> 1.25.2
* [`f1309365`](https://github.com/NixOS/nixpkgs/commit/f1309365070057256fdd32bc63ece36278ec3b5d) python312Packages.dask-glm: add GaetanLepage as maintainer
* [`8e0c34c2`](https://github.com/NixOS/nixpkgs/commit/8e0c34c2824abbd1fbf9360b535980fbf02fe8bf) python312Packages.dask-glm: fix build
* [`1d526225`](https://github.com/NixOS/nixpkgs/commit/1d52622529ec21840a1684142bd320a0f8d7203e) python312Packages.sparse: add GaetanLepage as maintainer
* [`f4fd33f9`](https://github.com/NixOS/nixpkgs/commit/f4fd33f95e10a48d18374114444e9b5467e1da47) python312Packages.sparse: cleanup & mark as broken on aarch64-linux
* [`e6ea3456`](https://github.com/NixOS/nixpkgs/commit/e6ea345642291962533b3fbccb27dd63ace175c9) python312Packages.devito: fix build
* [`d506ad7f`](https://github.com/NixOS/nixpkgs/commit/d506ad7f5c0fadd3994c2895ebb68ed4aba61856) python312Packages.catboost: mark as broken
* [`cdbaefe7`](https://github.com/NixOS/nixpkgs/commit/cdbaefe74329ed3587d686720e5de04919306292) python312Packages.dask-ml: 2024.4.4 -> 2025.1.0
* [`64249c9b`](https://github.com/NixOS/nixpkgs/commit/64249c9b7d2d80d7983a1efc382b3a53b6a9ae6b) python312Packages.dask-histogram: 2024.12.1 -> 2025.2.0
* [`cb32a8ad`](https://github.com/NixOS/nixpkgs/commit/cb32a8ad1cba105da078243a973927f194e4f821) python312Packages.dask-awkward: 2024.12.2 -> 2025.2.0
* [`3af88eb4`](https://github.com/NixOS/nixpkgs/commit/3af88eb4248b0a96e82a307ab0104e45a5d01d82) python312Packages.awkward-cpp: 43 -> 44
* [`5de8457c`](https://github.com/NixOS/nixpkgs/commit/5de8457c08fdaf5ba12e2d1bab418c5c6c5f5114) python312Packages.awkward: 2.7.2 -> 2.7.4
* [`8d23cded`](https://github.com/NixOS/nixpkgs/commit/8d23cded07fe77e45db1ada00ff3a3bbda2b51ae) python312Packages.mplhep: 0.3.55 -> 0.3.56
* [`5b73ca5a`](https://github.com/NixOS/nixpkgs/commit/5b73ca5a0c6930c157c36983ed4fd54bc90fd5f7) python312Packages.coffea: fix build
* [`ff787004`](https://github.com/NixOS/nixpkgs/commit/ff787004396499583498584e78d705f1f820b592) python312Packages.dask-image: fix build
* [`0a07262b`](https://github.com/NixOS/nixpkgs/commit/0a07262b0f60dd0a1b87474610eba4b6306918a9) lomiri.lomiri-music-app: init at 3.2.2
* [`bc7133b8`](https://github.com/NixOS/nixpkgs/commit/bc7133b8764d3ec0f4e34043bfcbbaff74149420) nixos/lomiri: Fix mediascanner2 service
* [`6fd46df8`](https://github.com/NixOS/nixpkgs/commit/6fd46df8a62f13d174ab39a86ee3f05383216fd8) nixos/lomiri: Add music app
* [`4b3bdd48`](https://github.com/NixOS/nixpkgs/commit/4b3bdd486aac8dd3494dd4ff8736fcf7f6e56e12) lomiri.lomiri-session: Force xdg-user-dirs-update to be run
* [`c4c8c118`](https://github.com/NixOS/nixpkgs/commit/c4c8c1181fdab6ece6f74dfeccf6f65a3a95d829) nixosTests.lomiri-music-app: init
* [`fe7d0cd8`](https://github.com/NixOS/nixpkgs/commit/fe7d0cd8a81956527332e09cdd0cecee4cf63b1f) lomiri.mediascanner2: Apply patch for desktop-independance
* [`105b640a`](https://github.com/NixOS/nixpkgs/commit/105b640ae11406c5b6b01552d531e9c64ec8867e) wleave: 0.4.1 -> 0.5.1
* [`4bfefba8`](https://github.com/NixOS/nixpkgs/commit/4bfefba805262cfb2517764de5106865fb3bc3fa) wleave: format with nixfmt
* [`502580e2`](https://github.com/NixOS/nixpkgs/commit/502580e21a61275e54c0d19e0e6d69bf1e20effd) python312Packages.databricks-sdk: 0.41.0 -> 0.43.0
* [`9bdd0cff`](https://github.com/NixOS/nixpkgs/commit/9bdd0cffcdff05e6b802667344d5369dee5155dc) python3Packages.vfblib: 0.8.2 -> 0.9.1
* [`0a7ac24b`](https://github.com/NixOS/nixpkgs/commit/0a7ac24b2bd3fcc9b18118ce72dcf7abe115dbce) flow-editor: 0.2.1 > 0.3.2
* [`a073f660`](https://github.com/NixOS/nixpkgs/commit/a073f6606354de1c178b9e0fa73b57d44cb79cf3) koboldcpp: 1.82.4 -> 1.83.1
* [`00594b6f`](https://github.com/NixOS/nixpkgs/commit/00594b6f98c0b24bb641bc9115451ef1db5a8b70) bakelite: clean up and provide update script
* [`af541d47`](https://github.com/NixOS/nixpkgs/commit/af541d476acab91db2c486730c4ca2a4e0256df2) penpot-desktop: init at 0.10.0
* [`0677547a`](https://github.com/NixOS/nixpkgs/commit/0677547a9fe7bbf886fb277738b527a15cc1d498) python312Packages.jianpu-ly: 1.826 -> 1.832
* [`c1dc9af8`](https://github.com/NixOS/nixpkgs/commit/c1dc9af8778d7a250149dde8ac2449e3e8ee3ad8) python3Packages.miss-hit-core: init at 0.9.44
* [`de86157b`](https://github.com/NixOS/nixpkgs/commit/de86157b276b626504a661b4b30df7d7cd15a70b) python3Packages.miss-hit: init at 0.9.44
* [`555cce64`](https://github.com/NixOS/nixpkgs/commit/555cce646552384f2851128e77178c27b04c66ba) fex: 2501 -> 2502
* [`2ef08ebf`](https://github.com/NixOS/nixpkgs/commit/2ef08ebfecdd97a46401cd29959fc1c6fd7dc6f5) vaultwarden: 1.33.1 -> 1.33.2
* [`b758238c`](https://github.com/NixOS/nixpkgs/commit/b758238c547e225a2365920e7468b561f7b40c4f) musicpod: 1.12.0 -> 2.9.0
* [`9aefcbba`](https://github.com/NixOS/nixpkgs/commit/9aefcbba8900e376fa2dab2951d83a2790ea02df) truecrack: fix build on gcc-14
* [`a457935b`](https://github.com/NixOS/nixpkgs/commit/a457935bb3fac8bec9c015c6985e3d9cff8b15f5) venta: fix broken symlink to marwaita
* [`9d049880`](https://github.com/NixOS/nixpkgs/commit/9d049880c02badb14c36c28246bbabb84ab0303a) tsm-client: fix symlink fixup
* [`78ffd8bb`](https://github.com/NixOS/nixpkgs/commit/78ffd8bb3795c7f336ac599bd89bc1efbdace5a5) proton-ge-bin: remove uneeded changes
* [`1b0c666e`](https://github.com/NixOS/nixpkgs/commit/1b0c666e99f71e14241258d900c3f2920e1ec1d2) forgejo-runner: 6.2.0 -> 6.2.2
* [`e6682ef3`](https://github.com/NixOS/nixpkgs/commit/e6682ef3f668726fc71883c96fb6501f0b7ebf64) python312Packages.gto: fix build; set SSL_CERT_FILE
* [`fe6ba0d1`](https://github.com/NixOS/nixpkgs/commit/fe6ba0d17756a43098d8926611dd27fc1b4298d4) egglog: 0-unstable-2024-01-26 -> 0.4.0
* [`05caaeac`](https://github.com/NixOS/nixpkgs/commit/05caaeac03a6dca14de5fa9e10d45036736dddff) libreoffice-{still,fresh}-unwrapped: fix build and tests
* [`a161ff01`](https://github.com/NixOS/nixpkgs/commit/a161ff01c7de59e6ee0949d1ac386a026ad653ea) python3Packages.wn: fix build
* [`fcb71bf6`](https://github.com/NixOS/nixpkgs/commit/fcb71bf658d15153b3aff455bae568e0407465ec) nixos/tests/vaultwarden: adapt to new webvault
* [`6ca1674e`](https://github.com/NixOS/nixpkgs/commit/6ca1674e4c5424a9738dbd40272646cdb8f64b9b) jefferson: relax cstruct dependency
* [`f6604f94`](https://github.com/NixOS/nixpkgs/commit/f6604f9491c0c9cecc837659058d6be1339dfda6) flet-client-flutter: adjusting the updater to handle the new cases
* [`8d4f14e2`](https://github.com/NixOS/nixpkgs/commit/8d4f14e20d71aed5b733db065d16661f991e5497) zoxide: 0.9.6 -> 0.9.7
* [`f4946d81`](https://github.com/NixOS/nixpkgs/commit/f4946d810a501c9c4b3b75c90537195af71d2102) flet-client-flutter: 0.25.2 -> 0.26.0
* [`b7ab2d9e`](https://github.com/NixOS/nixpkgs/commit/b7ab2d9e191b87c4bc0a63439792dfadbea17732) flet-client-flutter: fix build
* [`6a68f2f7`](https://github.com/NixOS/nixpkgs/commit/6a68f2f732a0fa76dd7f086bf3c9853dbf4542d4) immich-public-proxy: 1.6.3 -> 1.7.2
* [`7ca7bb9d`](https://github.com/NixOS/nixpkgs/commit/7ca7bb9dee684b31f440d9ad4f49678a6b6a63f5) anilibria-winmaclinux: 2.2.24 -> 2.2.25
* [`36f020a5`](https://github.com/NixOS/nixpkgs/commit/36f020a50fa8ad5b7b56cbc472decf47106fc489) adrs: 0.2.9 -> 0.3.0
* [`2cc96c17`](https://github.com/NixOS/nixpkgs/commit/2cc96c173f001071180a20d56ebaa2588e0f97f1) clap: 1.2.2 -> 1.2.3
* [`55e9df7f`](https://github.com/NixOS/nixpkgs/commit/55e9df7f95048d4db59f9ed9387a620c6b92586b) cppreference-doc: 20241110 -> 20250209
* [`ce9c3ba2`](https://github.com/NixOS/nixpkgs/commit/ce9c3ba23a51d774c608fdc75b2f418a3a7f1ecb) gowall: 0.1.9 -> 0.2.0
* [`bf236cc4`](https://github.com/NixOS/nixpkgs/commit/bf236cc49d7ca410ccaac4cc348f25422cf724f2) wgo: 0.5.7 -> 0.5.9
* [`7a57caad`](https://github.com/NixOS/nixpkgs/commit/7a57caade0267dbc7fb6d68390a55fd48990c128) cargo-zigbuild: 0.19.7 -> 0.19.8
* [`80db1d7e`](https://github.com/NixOS/nixpkgs/commit/80db1d7e7e21092c070e28d23df4647d9459d5dd) lf: 33 -> 34
* [`0da93517`](https://github.com/NixOS/nixpkgs/commit/0da935170fff461a3bb3fc48b8e336618b983df8) lf: move to pkgs/by-name
* [`69a56a74`](https://github.com/NixOS/nixpkgs/commit/69a56a74ae0f7fa0c3e23f9f9c73c810aed9513b) ctpv: move to pkgs/by-name
* [`652fe825`](https://github.com/NixOS/nixpkgs/commit/652fe8258f7d2ab2748325faf467efe2683d9f36) python313Packages.flammkuchen: fix build with NumPy v2
* [`b39a906d`](https://github.com/NixOS/nixpkgs/commit/b39a906d9557e647f48916541440686e3a33a648) python313Packages.stytra: specify build-system
* [`c976561f`](https://github.com/NixOS/nixpkgs/commit/c976561fcf9764eb09eedbf7db6bd498e9cee9ff) mihomo: 1.19.1 -> 1.19.2
* [`0c229d36`](https://github.com/NixOS/nixpkgs/commit/0c229d3692e44a9975279c8caa537f4dc509f7b9) mdbook-d2: 0.3.1 -> 0.3.2
* [`63446d92`](https://github.com/NixOS/nixpkgs/commit/63446d92c6c0b8df396265c3fac4f519464cca3c) nvidia_oc: 0.1.16 -> 0.1.18
* [`b5404e7f`](https://github.com/NixOS/nixpkgs/commit/b5404e7f51a546c9c805cdf79c33c0e3eaa097d9) termusic: fix build
* [`6647b53c`](https://github.com/NixOS/nixpkgs/commit/6647b53cd6f970b7b51d3f92fa10bb28b81c8163) cargo-mutants: 25.0.0 -> 25.0.1
* [`6399f3b2`](https://github.com/NixOS/nixpkgs/commit/6399f3b22d6f7ed0cdc4d4b6fe9e43fd87d6edef) cargo-temp: 0.3.1 -> 0.3.2
* [`9394afab`](https://github.com/NixOS/nixpkgs/commit/9394afabbc80abd9d7936dc8e82592141490f16b) .github/ISSUE_TEMPLATE: fix fields for package request
* [`c62d1dce`](https://github.com/NixOS/nixpkgs/commit/c62d1dce962ec2d9adbf557f64e6ee453bca40c6) proton-ge-bin: GE-Proton9-24 -> GE-Proton9-25
* [`310e3e7a`](https://github.com/NixOS/nixpkgs/commit/310e3e7aea0df740ff5d7bf28ffdd84350290f04) prometheus-snmp-exporter: 0.26.0 -> 0.28.0
* [`29aae62e`](https://github.com/NixOS/nixpkgs/commit/29aae62ed1c548953b44bc0a929664a7d347a3ff) python312Packages.llama-index-graph-stores-neptune: 0.3.0 -> 0.3.1
* [`e0fef4ad`](https://github.com/NixOS/nixpkgs/commit/e0fef4ad7c43e276b4d4cd1cce2ceb5bfdf59ed9) jellyfin-tui: 1.1.0 -> 1.1.1
* [`09331cc1`](https://github.com/NixOS/nixpkgs/commit/09331cc1cc4e8939054ff091f93d4ef0c6c4e044) zoxide: 0.9.6 -> 0.9.7
* [`4d20fd65`](https://github.com/NixOS/nixpkgs/commit/4d20fd65f1c02fc40ec62b5527f26c9406191e37) ytdownloader: 3.18.5 -> 3.19.0
* [`62a3d78c`](https://github.com/NixOS/nixpkgs/commit/62a3d78cb73556bd532024ed3b0c148924618496) chatgpt: init at 1.2025.014
* [`6eba2ef2`](https://github.com/NixOS/nixpkgs/commit/6eba2ef25a17bd11bd3aeea237c77e05d8677c94) jenkins: 2.479.3 -> 2.492.1
* [`d0431c98`](https://github.com/NixOS/nixpkgs/commit/d0431c9884cb73b8c9779eea5ec63900e3d167ad) websurfx: 1.23.0 -> 1.23.6
* [`151acd07`](https://github.com/NixOS/nixpkgs/commit/151acd07537ed8866d7dfd043f564a8c1cb7f24e) circt: 1.104.0 -> 1.105.0
* [`4dc9c397`](https://github.com/NixOS/nixpkgs/commit/4dc9c3973f4905238a540b4d52e1d5525c47c837) mas: 1.8.6 -> 1.9.0
* [`cb8300fb`](https://github.com/NixOS/nixpkgs/commit/cb8300fbae92c8fe802f979b66bcb341e33c6f56) bfg-repo-cleaner: prefer versionCheckHook rather than testers.testVersion
* [`82d95f18`](https://github.com/NixOS/nixpkgs/commit/82d95f18fdcbde3640402db949125c0ba1a430a6) bfg-repo-cleaner: 1.14.0 -> 1.15.0
* [`16398cdc`](https://github.com/NixOS/nixpkgs/commit/16398cdcd42a7dd09586beaed0c25a41feb866c5) python312Packages.deepsearch-toolkit: 2.0.0 -> 2.0.1
* [`f780db45`](https://github.com/NixOS/nixpkgs/commit/f780db4505588b541fd472cd1c7ed9cbd9c4b469) ocamlPackages.magic: 0.7.3 -> 0.7.4, remove myself from maintainer
* [`62cd5d5f`](https://github.com/NixOS/nixpkgs/commit/62cd5d5f7e6a1f682cfa42ae467b370310b04c2c) python312Packages.microsoft-kiota-serialization-multipart: 1.9.1 -> 1.9.2
* [`4f630e0e`](https://github.com/NixOS/nixpkgs/commit/4f630e0e92150cbdc1703aed4e8c46cc5a2f55c4) python3Packages.rioxarray: drop patch applied upstream
* [`605a7ee4`](https://github.com/NixOS/nixpkgs/commit/605a7ee46b79d4beecf690906c1d816b5a8cd2c0) qimgv: 1.0.3-alpha -> 1.0.3-unstable-2024-10-11
* [`4758c02f`](https://github.com/NixOS/nixpkgs/commit/4758c02fc271af4cac017752cbcc7da8d8ee0184) television: 0.10.4 -> 0.10.6
* [`d2636f99`](https://github.com/NixOS/nixpkgs/commit/d2636f9978302a5aaa8b7adcc8bb45257b649f32) spatialite_tools: adopt package under geospatial team
* [`c59f85e6`](https://github.com/NixOS/nixpkgs/commit/c59f85e660f352570910c4d1ae31c164a9a63c60) spatialite_tools: rename package to spatialite-tools
* [`5bb476ab`](https://github.com/NixOS/nixpkgs/commit/5bb476ab6a291a4ce61a6437f06e357d437828b2) maintainers: add zsenai
* [`6fb18991`](https://github.com/NixOS/nixpkgs/commit/6fb189919b40a1bb55be3d30062361d968627c37) lowfi: init at 1.5.6
* [`d09e16b1`](https://github.com/NixOS/nixpkgs/commit/d09e16b1e438291629a647bb43a925a1f6af8e05) python313Packages.bring-api: 1.0.1 -> 1.0.2
* [`4f0353c2`](https://github.com/NixOS/nixpkgs/commit/4f0353c207a84eef20142adeeb2431401eb7acbe) {python3Packages.}pwndbg: remove
* [`53a609dd`](https://github.com/NixOS/nixpkgs/commit/53a609dd6e94eda8a08fa00db6108085ae57cb39) python313Packages.aioshelly: 12.4.1 -> 12.4.2
* [`8493848a`](https://github.com/NixOS/nixpkgs/commit/8493848a9ad3cd7df8e0d09394bac892e5179a26) python313Packages.identify: 2.6.6 -> 2.6.7
* [`7147ab20`](https://github.com/NixOS/nixpkgs/commit/7147ab20f316cf9e07d0369a76fbb3244545b4c4) python313Packages.msgraph-core: 1.2.0 -> 1.3.1
* [`91e7e82d`](https://github.com/NixOS/nixpkgs/commit/91e7e82d0c7afed14309861dae89968daaa2f33b) python313Packages.msgraph-sdk: 1.18.0 -> 1.20.0
* [`10ac6580`](https://github.com/NixOS/nixpkgs/commit/10ac6580d0b9786dba029e0fde8452fdf849c668) h2o: add mainProgram
* [`064b13dc`](https://github.com/NixOS/nixpkgs/commit/064b13dc8c36935a42e6b38726c3b66e90d6944d) python313Packages.tencentcloud-sdk-python: 3.0.1314 -> 3.0.1315
* [`4cc025e2`](https://github.com/NixOS/nixpkgs/commit/4cc025e22e6d55d2288d5c8cf355e94aff801176) python313Packages.publicsuffixlist: 1.0.2.20250202 -> 1.0.2.20250207
* [`c5cd0ac7`](https://github.com/NixOS/nixpkgs/commit/c5cd0ac769d51c7d03c72057c787fcf5f2b78dc0) roundcube: temporarily disable symlinks check
* [`30f46aec`](https://github.com/NixOS/nixpkgs/commit/30f46aecba53aa1966a797c3240668d5bf418f67) roundcube: 1.6.9 -> 1.6.10
* [`fe1d0f13`](https://github.com/NixOS/nixpkgs/commit/fe1d0f13516d291186403eb895a6991327a643aa) python3Packages.truststore: 0.10.0 -> 0.10.1
* [`d509c476`](https://github.com/NixOS/nixpkgs/commit/d509c47663027a854c59a857a950badb47e07652) immich-cli: fix broken symlink ([nixos/nixpkgs⁠#380796](https://togithub.com/nixos/nixpkgs/issues/380796))
* [`083a1ec2`](https://github.com/NixOS/nixpkgs/commit/083a1ec2a9e87d1614bbaf202d7f5b7c9d3a888e) maintainers: add asappia
* [`27490dc9`](https://github.com/NixOS/nixpkgs/commit/27490dc932ac59cc6941e50b6312c755f6e0e909) python313Packages.picologging: fix build
* [`52740553`](https://github.com/NixOS/nixpkgs/commit/527405539523b5ec60451f5f3825cc91545bb98d) python313Packages.psycopg: 3.2.3 -> 3.2.4
* [`3d4b7767`](https://github.com/NixOS/nixpkgs/commit/3d4b776702ad085925909be57a213d45e20127de) python312Packages.primp: 0.6.5 -> 0.12.0
* [`669c6b62`](https://github.com/NixOS/nixpkgs/commit/669c6b62018d96c62fe5a04fe093bfc7bcf04529) feishu: remove unused dependency libcurl.so
* [`61e539c4`](https://github.com/NixOS/nixpkgs/commit/61e539c4ba0b02c037a395e86505deaa94e522a5) deepin.deepin-icon-theme: fix build
* [`ec2d3cd6`](https://github.com/NixOS/nixpkgs/commit/ec2d3cd6577a0ecda42f7251d19d6ff39fc507de) open-webui: 0.5.9 -> 0.5.10
* [`cc1265d9`](https://github.com/NixOS/nixpkgs/commit/cc1265d99558e02ab13a26372c38dd2b56baf924) brlaser: Switch to maintained fork
* [`4d376f1f`](https://github.com/NixOS/nixpkgs/commit/4d376f1f8c2ccf7266875f78a20a9dc24419dbce) brlaser: Change maintainers
* [`083811ef`](https://github.com/NixOS/nixpkgs/commit/083811ef4f1afadbdced814207a37fbf087552ff) xeol: 0.10.3 -> 0.10.4
* [`88b1420c`](https://github.com/NixOS/nixpkgs/commit/88b1420c415c8c5153c9f0f6309c54f7314cb6be) zabbix70: 7.0.8 -> 7.0.9
* [`1495671a`](https://github.com/NixOS/nixpkgs/commit/1495671a0c6d69c63f22a4110d7800e0e1fc98ef) python312Packages.dvclive: 3.48.1 -> 3.48.2
* [`ab15e3b7`](https://github.com/NixOS/nixpkgs/commit/ab15e3b7e847c2f646c00f3b6a9f40aa9aac5a2f) litestar: build for all python version
* [`a88eedee`](https://github.com/NixOS/nixpkgs/commit/a88eedeec72e99093232dc5491d20725d8da55bf) maildir-rank-addr: init at 1.4.1
* [`586fa8aa`](https://github.com/NixOS/nixpkgs/commit/586fa8aae46d37c000cff6441698bee8f7557899) zbus-xmlgen: 5.0.2 -> 5.1.0
* [`ba3471b5`](https://github.com/NixOS/nixpkgs/commit/ba3471b5e7504af0a0c82aa644d55e2596f6cf40) linux/hardened/patches/5.10: v5.10.233-hardened1 -> v5.10.234-hardened1
* [`084714f8`](https://github.com/NixOS/nixpkgs/commit/084714f8d4257a8a0db7ff56cb5cfc0d1ddc7c13) linux/hardened/patches/5.15: v5.15.176-hardened1 -> v5.15.178-hardened1
* [`43519bc0`](https://github.com/NixOS/nixpkgs/commit/43519bc0e747b0f5dd300e98d11610c949665c61) linux/hardened/patches/5.4: v5.4.289-hardened1 -> v5.4.290-hardened1
* [`9e1464b3`](https://github.com/NixOS/nixpkgs/commit/9e1464b34732564618c15a283aaa06753663493e) linux/hardened/patches/6.1: v6.1.126-hardened1 -> v6.1.128-hardened1
* [`5f703fcf`](https://github.com/NixOS/nixpkgs/commit/5f703fcfad4761c024be7b633b18732817130f92) linux/hardened/patches/6.12: v6.12.10-hardened1 -> v6.12.12-hardened1
* [`7e5604eb`](https://github.com/NixOS/nixpkgs/commit/7e5604eba24bad9eb0bc58eda40c14ebbfbacaf9) linux/hardened/patches/6.6: v6.6.73-hardened1 -> v6.6.75-hardened1
* [`f09a72a8`](https://github.com/NixOS/nixpkgs/commit/f09a72a89131e63d793a8e8c856ab60cb784e1f1) python312Packages.amaranth-boards: 0-unstable-2024-12-21 -> 0-unstable-2025-02-07
* [`2133ff69`](https://github.com/NixOS/nixpkgs/commit/2133ff69f58c2ea59edf380a9a5c440c0ba73086) eslint: 9.10.0 -> 9.20.0
* [`aa8f0c3d`](https://github.com/NixOS/nixpkgs/commit/aa8f0c3da23ffd3481a38dedd3759d2159bb3963) linux_testing: 6.14-rc1 -> 6.14-rc2
* [`4ae67c71`](https://github.com/NixOS/nixpkgs/commit/4ae67c716e56ba9e5dea42d91aae780b488dd254) linux_latest-libre: 19707 -> 19712
* [`3f50bc0a`](https://github.com/NixOS/nixpkgs/commit/3f50bc0a4eac6630bbaf5d262a55f8296cfc0eba) vimPlugins.mini-nvim: reduce closure size
* [`d0e8b2ea`](https://github.com/NixOS/nixpkgs/commit/d0e8b2ea0c5c683b48307d985aa87deaec588106) authelia: move web to arguments as authelia-web
* [`9d735ba6`](https://github.com/NixOS/nixpkgs/commit/9d735ba602b694b51832f5f4c0899cc798d472fa) python312Packages.microsoft-kiota-serialization-text: 1.9.1 -> 1.9.2
* [`40e73443`](https://github.com/NixOS/nixpkgs/commit/40e73443881e577305d560fc9dfae5a18dcaed86) nixos/sway: restore list type of xdg.portal.config.sway.default
* [`95e123c7`](https://github.com/NixOS/nixpkgs/commit/95e123c78346d0d483c2d2b3d968fbe559e03acb) build(deps): bump actions/create-github-app-token from 1.11.1 to 1.11.3
* [`9f49de26`](https://github.com/NixOS/nixpkgs/commit/9f49de26057c35d916d4745dcba546f4355f3336) xfce.xfce4-settings: 4.20.0 -> 4.20.1
* [`d7c3d614`](https://github.com/NixOS/nixpkgs/commit/d7c3d614aa7bb587d39939eaec260057b09ec7cd) xfce.thunar: 4.20.1 -> 4.20.2
* [`1e448535`](https://github.com/NixOS/nixpkgs/commit/1e448535a76f848dbe14a10594203ed5b835265c) bdf2psf: 1.233 -> 1.234
* [`121aad35`](https://github.com/NixOS/nixpkgs/commit/121aad353d069a7b720b0d7f83618880e73e85b8) cloudlist: 1.1.0 -> 1.2.0
* [`15fdb273`](https://github.com/NixOS/nixpkgs/commit/15fdb273b8f523e0742dd2a898713833ac549296) coq: align rocq-core version on overrides
* [`ac1ae580`](https://github.com/NixOS/nixpkgs/commit/ac1ae5809bcaf713171de2c40afd75b8af0ec630) erofs-utils: 1.8.4 -> 1.8.5
* [`c8c2d504`](https://github.com/NixOS/nixpkgs/commit/c8c2d50415ce3531ba55494e8d424d53134c83a6) ruff: 0.9.5 -> 0.9.6
* [`feedcd92`](https://github.com/NixOS/nixpkgs/commit/feedcd9238c611513ffc2605101c27c20a4cf636) goat-cli: 1.3.0 -> 1.4.0
* [`b6e7bcd8`](https://github.com/NixOS/nixpkgs/commit/b6e7bcd8ceb8220a7b5e36ec7af58db8ed1bc7b6) colloid-icon-theme: 2024-10-18 -> 2025-02-09
* [`8e260adb`](https://github.com/NixOS/nixpkgs/commit/8e260adb6d42ff196366652e2bba994d53c9e9d3) ocamlPackages.shell: disable tests of version 0.15
* [`76320c89`](https://github.com/NixOS/nixpkgs/commit/76320c89a8dca7477bd8e0ff9d4eae4eaf14752c) ocamlPackages.async_ssl: fix build of version 0.16.1
* [`49e10c7b`](https://github.com/NixOS/nixpkgs/commit/49e10c7b806b7fe9bdc8941fa29d2167238a9156) luaPackages.nvim-dbee: init at 0.1.9-1
* [`259b7b53`](https://github.com/NixOS/nixpkgs/commit/259b7b53f4af3a382840fa4c4057ec935408a555) python312Packages.ruff-lsp: 0.0.61 -> 0.0.62
* [`7b925c96`](https://github.com/NixOS/nixpkgs/commit/7b925c96f925402bdfd529bf70d734c61444ed76) python3Packages.nixpkgs-updaters-library: 1.0.2 -> 1.1.0
* [`da86067e`](https://github.com/NixOS/nixpkgs/commit/da86067e1ffffa345d9fc4e3df8a704545a7aa59) lprobe: 0.1.4 -> 0.1.5
* [`4391342d`](https://github.com/NixOS/nixpkgs/commit/4391342df7be4c4d738611dd86a6b5d385651854) dafny: 4.9.1 -> 4.10.0
* [`9503c225`](https://github.com/NixOS/nixpkgs/commit/9503c225e237bbab4fd94b716512d40230dee472) openterface-qt: 0.0.6 -> 0.1.0
* [`a89703a7`](https://github.com/NixOS/nixpkgs/commit/a89703a79755d6068767a4d359c5f1fb70fd6e66) protonmail-bridge: 3.16.0 -> 3.17.0
* [`3c911b2a`](https://github.com/NixOS/nixpkgs/commit/3c911b2aca0599b15b9d58f7339d73666ffb394a) lib.types: init mergeTypes
* [`86f814fc`](https://github.com/NixOS/nixpkgs/commit/86f814fc41eb5ab804b6f2414a84c642e5cb901a) teleport_17: init at 17.2.1
* [`a02b183b`](https://github.com/NixOS/nixpkgs/commit/a02b183b85d7147a03361226ffe984d43dba0544) linuxPackages.nxp-pn5xx: init at 0.4-unstable
* [`0d67f93d`](https://github.com/NixOS/nixpkgs/commit/0d67f93d7ea0b459a6259555a0ab71a70c94ac0b) libnfc-nci: init at 2.4.1-unstable
* [`f6e9c847`](https://github.com/NixOS/nixpkgs/commit/f6e9c847439a95d916abc4eb5f83df7cefa166e9) ifdnfc-nci: init at 0.2.1
* [`735f85e8`](https://github.com/NixOS/nixpkgs/commit/735f85e845803b8e6e8915d99e9bead9c18373a9) pcscd: allow multiple readerConfig entries
* [`a0519880`](https://github.com/NixOS/nixpkgs/commit/a05198804cdf53c214864a4b7e2eb0db5c25aa5c) nixos/nfc-nci: init
* [`fbf4ceda`](https://github.com/NixOS/nixpkgs/commit/fbf4ceda086fc693fc8130864a73d6059e515e41) nodejs_20: 20.18.2 -> 20.18.3
* [`2b36139f`](https://github.com/NixOS/nixpkgs/commit/2b36139fbe7feab5349e4b7b9d9e864c9f65a269) sipexer: 1.1.0 -> 1.2.0
* [`45f3a21f`](https://github.com/NixOS/nixpkgs/commit/45f3a21fe2a34cb4b9a65ab1d1a29e1c4da2b9e9) autobrr: 1.57.0 -> 1.58.0
* [`f56ea409`](https://github.com/NixOS/nixpkgs/commit/f56ea4095bb4faf653ac33ea75d9371df7070db4) python3Packages.tensorflow: fix typo
* [`eae985d1`](https://github.com/NixOS/nixpkgs/commit/eae985d14073118441213212e0ad8a119d5110a3) ventoy-full: 1.1.00 -> 1.1.01
* [`f9ae842f`](https://github.com/NixOS/nixpkgs/commit/f9ae842f5ab988bea846712d69db797a36581f2b) libvirt: fix shutdownTimeout not working, fix [nixos/nixpkgs⁠#171618](https://togithub.com/nixos/nixpkgs/issues/171618)
* [`dde19949`](https://github.com/NixOS/nixpkgs/commit/dde19949debe8b0fa3592fd0070301500033195c) iwe: init at 0.0.17
* [`f94852ac`](https://github.com/NixOS/nixpkgs/commit/f94852ac7ce12449d3c1834ab8bd2d0f27b316fc) stats: 2.11.26 -> 2.11.30
* [`7df3b324`](https://github.com/NixOS/nixpkgs/commit/7df3b3244756a6ee6b67411aa00cd22a90461058) snx-rs: 2.9.0 -> 3.0.3
* [`ba5135dd`](https://github.com/NixOS/nixpkgs/commit/ba5135dd8040ef300e515b46cf5992f8eb67e514) nezha-theme-nazhua: 0.5.6 -> 0.5.7
* [`1ba6c775`](https://github.com/NixOS/nixpkgs/commit/1ba6c7754fb6278c15f9c68360e6bfa4b0381d14) flintlock: 0.8.0 -> 0.8.1
* [`32e09278`](https://github.com/NixOS/nixpkgs/commit/32e09278844c1bdb22d191710da4e87e60d35a55) Revert "electrum: fixup Exec lines in .desktop"
* [`b0c4f34b`](https://github.com/NixOS/nixpkgs/commit/b0c4f34b535c4400f60bc4aa568adb39d53e2620) electrum: substitute with `--replace-fail`
* [`e3d7bbab`](https://github.com/NixOS/nixpkgs/commit/e3d7bbab8b3bad048037823b6200ae17471225d5) electrum: patch for aiorpcx 0.24 compatibility
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
