### PR TITLE
niv home-manager: update ba4a1a11 -> 5cfbf5cc

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -41,10 +41,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "ba4a1a110204c27805d1a1b5c8b24b3a0da4d063",
-        "sha256": "13ky419aycilw37w6rv1nyq8vxd5adihvk00zirdgx6gf70lamvy",
+        "rev": "5cfbf5cc37a3bd1da07ae84eea1b828909c4456b",
+        "sha256": "1lmprwj3267fvbkzfyzjymfyv0gm0zm34fff9s5n2dcv7fj1glxc",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/ba4a1a110204c27805d1a1b5c8b24b3a0da4d063.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/5cfbf5cc37a3bd1da07ae84eea1b828909c4456b.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@ba4a1a11...5cfbf5cc](https://github.com/nix-community/home-manager/compare/ba4a1a110204c27805d1a1b5c8b24b3a0da4d063...5cfbf5cc37a3bd1da07ae84eea1b828909c4456b)

* [`59fe145f`](https://github.com/nix-community/home-manager/commit/59fe145f0bb7cfde99f148140a47a54deb8cc23f) eww: make configDir optional ([nix-community/home-manager⁠#6282](https://togithub.com/nix-community/home-manager/issues/6282))
* [`9c8169b4`](https://github.com/nix-community/home-manager/commit/9c8169b4466391999b1ad5ea86be4e79d560af52) git-worktree-switcher: init module
* [`8f351726`](https://github.com/nix-community/home-manager/commit/8f351726c5841d86854e7fa6003ea472352f5208) git-worktree-switcher: use lib.hm.shell.mkShellIntegrationOption
* [`f0a31d38`](https://github.com/nix-community/home-manager/commit/f0a31d38e6de48970ce1fe93e6ea343e20a9c80a) neomutt: fix default for 'map' in macros/binds ([nix-community/home-manager⁠#6429](https://togithub.com/nix-community/home-manager/issues/6429))
* [`83bd3a26`](https://github.com/nix-community/home-manager/commit/83bd3a26ac0526ae04fa74df46738bb44b89dcdd) email: add migadu.com flavor
* [`f8729b11`](https://github.com/nix-community/home-manager/commit/f8729b11ee49a40fc21b6ec6578a16e9a5261414) eww: fix confDir config using missing attribute "types.isNull"
* [`1f6fa878`](https://github.com/nix-community/home-manager/commit/1f6fa878080fd1b59b21b43695fd523ea4cae8d6) eww: added tests
* [`d303453b`](https://github.com/nix-community/home-manager/commit/d303453b134cff1dec350ae2e50fec34d06bee73) eww: add null configDir test
* [`15b59d41`](https://github.com/nix-community/home-manager/commit/15b59d4191b993ebdfcb1f61b834fced217882ba) eww: fix eww source creation
* [`c9d343cf`](https://github.com/nix-community/home-manager/commit/c9d343cfa0565671cc7e8d5aefebaf61cc840abd) docs(zellij): `programs.zellij.settings` are serialized as `kdl` and not `yaml` from version 0.32.0 ([nix-community/home-manager⁠#6010](https://togithub.com/nix-community/home-manager/issues/6010))
* [`a70d7889`](https://github.com/nix-community/home-manager/commit/a70d788923061a00a488f60a01768ca4c6a8b727) aerospace: fix workspace assignment config ([nix-community/home-manager⁠#6442](https://togithub.com/nix-community/home-manager/issues/6442))
* [`22b418c1`](https://github.com/nix-community/home-manager/commit/22b418c13fb0be43f4bc5c185f323a3237028594) bash: Make HISTFILESIZE and HISTSIZE nullable ([nix-community/home-manager⁠#6443](https://togithub.com/nix-community/home-manager/issues/6443))
* [`20fac9bb`](https://github.com/nix-community/home-manager/commit/20fac9bbdf22d697ad68faabb7f95d4deba4f712) syncthing: use package options
* [`5031c6d2`](https://github.com/nix-community/home-manager/commit/5031c6d2978109336637977c165f82aa49fa16a7) syncthing: remove with lib
* [`7da01bc4`](https://github.com/nix-community/home-manager/commit/7da01bc47ad48d696c96fcfd63d10063855d5486) git: support alternate signing methods ([nix-community/home-manager⁠#5516](https://togithub.com/nix-community/home-manager/issues/5516))
* [`9daae9a6`](https://github.com/nix-community/home-manager/commit/9daae9a67af7b4d341e2c806fa274a9c0925d7cf) nixos/common: forward `nix.enable` from the OS configuration ([nix-community/home-manager⁠#6383](https://togithub.com/nix-community/home-manager/issues/6383))
* [`582d3cd4`](https://github.com/nix-community/home-manager/commit/582d3cd42df7d2c7565d77119106336ea46e33df) yubikey-agent: init service module ([nix-community/home-manager⁠#6446](https://togithub.com/nix-community/home-manager/issues/6446))
* [`67b9f9de`](https://github.com/nix-community/home-manager/commit/67b9f9de22c78bd1d2cf45583bfb18470d1d3ef8) vscode: add windsurf directories ([nix-community/home-manager⁠#6427](https://togithub.com/nix-community/home-manager/issues/6427))
* [`6d3163ae`](https://github.com/nix-community/home-manager/commit/6d3163aea47fdb1fe19744e91306a2ea4f602292) git: change stateVersion check for compatiblity ([nix-community/home-manager⁠#6453](https://togithub.com/nix-community/home-manager/issues/6453))
* [`8bc5e4c9`](https://github.com/nix-community/home-manager/commit/8bc5e4c9b277e571d6d639d82b0b9335a8e490a9) git-maintenance: More details in the documentation
* [`53efb68b`](https://github.com/nix-community/home-manager/commit/53efb68b4b098a37b1584757e2e7f4119d7ad92c) move syncthing-copy-keys to dedicated variable
* [`17a78d3e`](https://github.com/nix-community/home-manager/commit/17a78d3eeddc70be09b53dfa34357b0845e9d11a) nix variable for syncthing's configuration directory
* [`33ffe942`](https://github.com/nix-community/home-manager/commit/33ffe942525d57310ef64b34e95fb55c1535a7dc) move curl shell function into string variable
* [`26454abc`](https://github.com/nix-community/home-manager/commit/26454abc03b7fbdeccd63f7696ebd451c74c4f7d) provide RUNTIME_DIRECTORY manually if not given by systemd
* [`14223a82`](https://github.com/nix-community/home-manager/commit/14223a82611b14ee9a98c7725e76b5e51629c11d) refactor launchd.agents.syncthing
* [`85e9d1cc`](https://github.com/nix-community/home-manager/commit/85e9d1cc8fa7be999c6fb05818154806e4e053c1) syncthing: expand declarative config to Darwin
* [`45c07fcf`](https://github.com/nix-community/home-manager/commit/45c07fcf7d28b5fb3ee189c260dee0a2e4d14317) formatting according to HM's format tool
* [`eb44c160`](https://github.com/nix-community/home-manager/commit/eb44c1601ed99896525e983bc9b15eb8b4d5879e) nixpkgs-disabled: fix `useGlobalPkgs` assertion ([nix-community/home-manager⁠#6172](https://togithub.com/nix-community/home-manager/issues/6172))
* [`ec130e70`](https://github.com/nix-community/home-manager/commit/ec130e700959ee10b63eedbc87758d20264a9588) firefox: correct vendorPath of firefox forks ([nix-community/home-manager⁠#6421](https://togithub.com/nix-community/home-manager/issues/6421))
* [`e5bc9c2a`](https://github.com/nix-community/home-manager/commit/e5bc9c2af1dca75271aeaeb39035ce7a6125c395) git: reduce priority of signing.format ([nix-community/home-manager⁠#6465](https://togithub.com/nix-community/home-manager/issues/6465))
* [`b15e9ec6`](https://github.com/nix-community/home-manager/commit/b15e9ec6769d770879759f086dd4e51fae7f2394) flake-module: set _class ([nix-community/home-manager⁠#6461](https://togithub.com/nix-community/home-manager/issues/6461))
* [`25870c66`](https://github.com/nix-community/home-manager/commit/25870c6600660c93c5aa10f0f328a5eecd60150b) nixos/common: fix `options` reference ([nix-community/home-manager⁠#6473](https://togithub.com/nix-community/home-manager/issues/6473))
* [`662fa98b`](https://github.com/nix-community/home-manager/commit/662fa98bf488daa82ce8dc2bc443872952065ab9) nixpkgs-disabled: warn instead of assert ([nix-community/home-manager⁠#6466](https://togithub.com/nix-community/home-manager/issues/6466))
* [`30b9cd6f`](https://github.com/nix-community/home-manager/commit/30b9cd6f1a69921e59e71df1214604be62636284) mpv: drop old wrapMpv compatibility ([nix-community/home-manager⁠#6024](https://togithub.com/nix-community/home-manager/issues/6024))
* [`5c5697b8`](https://github.com/nix-community/home-manager/commit/5c5697b82a8a34f9ce39dd18690c6ef623565fc4) git: support not configuring signing.format ([nix-community/home-manager⁠#6478](https://togithub.com/nix-community/home-manager/issues/6478))
* [`c1ea92cd`](https://github.com/nix-community/home-manager/commit/c1ea92cdfb85bd7b0995b550581d9fd1c3370bf9) nh: change flake option type to singleLineStr ([nix-community/home-manager⁠#6468](https://togithub.com/nix-community/home-manager/issues/6468))
* [`9d0d48f4`](https://github.com/nix-community/home-manager/commit/9d0d48f4c3d2fb1a8c8607da143bb567a741d914)  nh: fixes and addition to warnings/assertions ([nix-community/home-manager⁠#6470](https://togithub.com/nix-community/home-manager/issues/6470))
* [`f4f6dd26`](https://github.com/nix-community/home-manager/commit/f4f6dd26985f1e44721325cb6d783d0cf4cd4dbc) git: fix setting format on >=25.05 ([nix-community/home-manager⁠#6480](https://togithub.com/nix-community/home-manager/issues/6480))
* [`edad23eb`](https://github.com/nix-community/home-manager/commit/edad23ebc1bcc226ef5eb57c8d779b9b425adca1) mako: add max-history option ([nix-community/home-manager⁠#6009](https://togithub.com/nix-community/home-manager/issues/6009))
* [`3a0cf8f1`](https://github.com/nix-community/home-manager/commit/3a0cf8f1aae507ec9bb8c141369458ca0244a01b) maintainers: add HPsaucii
* [`27ffa351`](https://github.com/nix-community/home-manager/commit/27ffa35178bc6f359293a8809d32c5da23aaabc7) firefox: add support for configuring extensions
* [`6c93eea8`](https://github.com/nix-community/home-manager/commit/6c93eea85daddd0dc8d4a3a687473461f3122961) firefox: add HPSaucii maintainer
* [`69dfc316`](https://github.com/nix-community/home-manager/commit/69dfc316c5b5f2de1d68e477393fecbf19a0cdba) mise: enable nushell integration ([nix-community/home-manager⁠#6363](https://togithub.com/nix-community/home-manager/issues/6363))
* [`5cfbf5cc`](https://github.com/nix-community/home-manager/commit/5cfbf5cc37a3bd1da07ae84eea1b828909c4456b) flake: don't import modules ([nix-community/home-manager⁠#6481](https://togithub.com/nix-community/home-manager/issues/6481))
