### PR TITLE
niv home-manager: update 5cfbf5cc -> c12dcc9b

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -41,10 +41,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5cfbf5cc37a3bd1da07ae84eea1b828909c4456b",
-        "sha256": "1lmprwj3267fvbkzfyzjymfyv0gm0zm34fff9s5n2dcv7fj1glxc",
+        "rev": "c12dcc9b61429b2ad437a7d4974399ad8f910319",
+        "sha256": "06z7yjxvlpj6iazzp05wl6mc1z0xaq98kvsdfgcvmy3zhav8a9q4",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/5cfbf5cc37a3bd1da07ae84eea1b828909c4456b.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/c12dcc9b61429b2ad437a7d4974399ad8f910319.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@5cfbf5cc...c12dcc9b](https://github.com/nix-community/home-manager/compare/5cfbf5cc37a3bd1da07ae84eea1b828909c4456b...c12dcc9b61429b2ad437a7d4974399ad8f910319)

* [`a135aae1`](https://github.com/nix-community/home-manager/commit/a135aae1be749a10227413f9eb944a6f887dab86) flake.nix: remove deprecations ([nix-community/home-manager⁠#6485](https://togithub.com/nix-community/home-manager/issues/6485))
* [`4044ad19`](https://github.com/nix-community/home-manager/commit/4044ad191fb07bf3b17714d6aedec1960bc079d4) fish: accept multiple events ([nix-community/home-manager⁠#6489](https://togithub.com/nix-community/home-manager/issues/6489))
* [`97ac0801`](https://github.com/nix-community/home-manager/commit/97ac0801d187b2911e8caa45316399de12f6f199) firefox: prevent extensions settings override ([nix-community/home-manager⁠#6490](https://togithub.com/nix-community/home-manager/issues/6490))
* [`1c189f01`](https://github.com/nix-community/home-manager/commit/1c189f011447810af939a886ba7bee33532bb1f9) tests/home-cursor: init ([nix-community/home-manager⁠#6496](https://togithub.com/nix-community/home-manager/issues/6496))
* [`0c0b0ac8`](https://github.com/nix-community/home-manager/commit/0c0b0ac8af6ca76b1fcb514483a9bd73c18f1e8c) flake-module: use raw for homeConfgurations and deferredModule for modules ([nix-community/home-manager⁠#6504](https://togithub.com/nix-community/home-manager/issues/6504))
* [`3c822853`](https://github.com/nix-community/home-manager/commit/3c82285348bc811b723014cf4dba2f87e7ffc885) vinegar: add module ([nix-community/home-manager⁠#6494](https://togithub.com/nix-community/home-manager/issues/6494))
* [`fadb9cba`](https://github.com/nix-community/home-manager/commit/fadb9cba44957ed623ffc22bc87ddb73d86e6e66) Reapply "thunderbird: add native host support ([nix-community/home-manager⁠#6292](https://togithub.com/nix-community/home-manager/issues/6292))" ([nix-community/home-manager⁠#6371](https://togithub.com/nix-community/home-manager/issues/6371))
* [`7e81c581`](https://github.com/nix-community/home-manager/commit/7e81c581a51e8e4aa30002332385034437655860) thunderbird, firefox: fix file conflict for native messaging hosts
* [`e5e485e7`](https://github.com/nix-community/home-manager/commit/e5e485e73c6e28ba54af4f45ed13f80e0706418f) thunderbird: separate test case for firefox+thunderbird setup
* [`4eef1979`](https://github.com/nix-community/home-manager/commit/4eef19791387f387c6be83663d67ab5d06187494) thunderbird, firefox: don't create native host dirs when program is off
* [`5f5ff397`](https://github.com/nix-community/home-manager/commit/5f5ff39778171e3667ec3ea15bdacdce0edc1242) firefox: remove with keyword use
* [`63146593`](https://github.com/nix-community/home-manager/commit/63146593a928d3b77d0e92e82dbc6d959da8cd12) tests: don't override scraping of nixpkgs for thunderbird suite
* [`fad54a64`](https://github.com/nix-community/home-manager/commit/fad54a641a4419b6dbfabdcf33911bebc87f97f3) tests: check thunderbird with and without native messaging hosts
* [`1a78a4c7`](https://github.com/nix-community/home-manager/commit/1a78a4c7fe9d484c1de9ff0e46007f1970fd0a73) firefox: fix build failure when package is null
* [`bdf73272`](https://github.com/nix-community/home-manager/commit/bdf73272a8408fedc7ca86d5ea47192f6d2dad54) swayimg: add module ([nix-community/home-manager⁠#6506](https://togithub.com/nix-community/home-manager/issues/6506))
* [`148a6b55`](https://github.com/nix-community/home-manager/commit/148a6b55651ac794f5c20bbd76780b4d8fed4334) Translate using Weblate (Catalan)
* [`dde2fba6`](https://github.com/nix-community/home-manager/commit/dde2fba628af2891e2e1ba8abb8be4e597edd49e) home-cursor: add sway support ([nix-community/home-manager⁠#6459](https://togithub.com/nix-community/home-manager/issues/6459))
* [`6eed33a3`](https://github.com/nix-community/home-manager/commit/6eed33a3acb933224917964879634826716a3e5d) jetbrains-remote: do not fail if files do not exist yet ([nix-community/home-manager⁠#6502](https://togithub.com/nix-community/home-manager/issues/6502))
* [`9f74e14a`](https://github.com/nix-community/home-manager/commit/9f74e14a2d9af4c6f2024cca7813b830b020f45e) fcitx5: make boot after graphical session ([nix-community/home-manager⁠#6432](https://togithub.com/nix-community/home-manager/issues/6432))
* [`e512de47`](https://github.com/nix-community/home-manager/commit/e512de4722831c850ec0681f69510fcba44f582d) wluma: init module ([nix-community/home-manager⁠#6463](https://togithub.com/nix-community/home-manager/issues/6463))
* [`f0837fa6`](https://github.com/nix-community/home-manager/commit/f0837fa6730ad497f0329722263e2ef4683b09cf) flake.lock: Update
* [`62d038f4`](https://github.com/nix-community/home-manager/commit/62d038f499b94d406df790dec04e201d222e5098) nushell: reenable test
* [`765cb91e`](https://github.com/nix-community/home-manager/commit/765cb91e9d5ab06ed8c92c25fc0e51d6c11d43cb) psd: add missing module config options ([nix-community/home-manager⁠#6230](https://togithub.com/nix-community/home-manager/issues/6230))
* [`e495cd8c`](https://github.com/nix-community/home-manager/commit/e495cd8c805a050d404abcb658cfe8cdaf589990) tests/firefox: add profiles-extensions ([nix-community/home-manager⁠#6510](https://togithub.com/nix-community/home-manager/issues/6510))
* [`439a125a`](https://github.com/nix-community/home-manager/commit/439a125afef8c97308ec0c6db75d38e15d92208d) tests: remove with lib ([nix-community/home-manager⁠#6511](https://togithub.com/nix-community/home-manager/issues/6511))
* [`f0f0d1ad`](https://github.com/nix-community/home-manager/commit/f0f0d1ade22b51eaaf4d16e6b3f4990d8c348f3e) docs: update copyright year
* [`c31b4e33`](https://github.com/nix-community/home-manager/commit/c31b4e330e40a4fbf55ceb59741bd75bbb9c622c) accounts/email: provide realName option for alias ([nix-community/home-manager⁠#6106](https://togithub.com/nix-community/home-manager/issues/6106))
* [`2b382e49`](https://github.com/nix-community/home-manager/commit/2b382e499aa2fa7ac78bdf1cee079d45fb3a0334) earthly: init module ([nix-community/home-manager⁠#6265](https://togithub.com/nix-community/home-manager/issues/6265))
* [`f4a07823`](https://github.com/nix-community/home-manager/commit/f4a07823a298deff0efb0db30f9318511de7c232) chromium: add nativeMessagingHosts option ([nix-community/home-manager⁠#6019](https://togithub.com/nix-community/home-manager/issues/6019))
* [`dd21b9af`](https://github.com/nix-community/home-manager/commit/dd21b9afd5fefb0c80c3962869703acb3c56a5f2) imapnotify: add extraArgs option to imapnotify-accounts
* [`34d524f3`](https://github.com/nix-community/home-manager/commit/34d524f3edcf3a04c00ad2c09c24ec9d35d937f9) imapnotify-accounts: remove with lib
* [`a51e94e5`](https://github.com/nix-community/home-manager/commit/a51e94e51c7df10f078a2530ce125df7410b4f33) clipse: add module ([nix-community/home-manager⁠#5777](https://togithub.com/nix-community/home-manager/issues/5777))
* [`4949081d`](https://github.com/nix-community/home-manager/commit/4949081d1ee37ebb1ca9fbef289955d85aace405) jqp: add module ([nix-community/home-manager⁠#5716](https://togithub.com/nix-community/home-manager/issues/5716))
* [`e860bd49`](https://github.com/nix-community/home-manager/commit/e860bd49eaa577089de22d370f6126ee4f6e7914) vscode: add profiles support ([nix-community/home-manager⁠#5640](https://togithub.com/nix-community/home-manager/issues/5640))
* [`7ceacd98`](https://github.com/nix-community/home-manager/commit/7ceacd98a9fc99743ae7d9a5c0a4ea7c72314da6) wpaperd: add systemd service; move to services/ from programs/ ([nix-community/home-manager⁠#6302](https://togithub.com/nix-community/home-manager/issues/6302))
* [`90504b9a`](https://github.com/nix-community/home-manager/commit/90504b9a893b64c308640c3b7475a480d113fb2b) thunderbird: allow managing feed accounts ([nix-community/home-manager⁠#5613](https://togithub.com/nix-community/home-manager/issues/5613))
* [`61d8fc9a`](https://github.com/nix-community/home-manager/commit/61d8fc9af0f8568ffaff93e4001cb607f88790f9) firefox: Allow to add PKCS11 modules ([nix-community/home-manager⁠#5608](https://togithub.com/nix-community/home-manager/issues/5608))
* [`413e9b35`](https://github.com/nix-community/home-manager/commit/413e9b35f17b2f24fd3a7ecbfc1237d9c3d502fd) dircolors: respect preferXdgDirectories if set
* [`c327afbf`](https://github.com/nix-community/home-manager/commit/c327afbfd859fee74162e22a4275888f5deb89e3) dircolors: refactor preferXdgDirectories
* [`89b89340`](https://github.com/nix-community/home-manager/commit/89b89340556e6347f494ff45fd8f136f2741b4a4) tests/dircolors: add xdg config test
* [`546949fe`](https://github.com/nix-community/home-manager/commit/546949fea16cf75b4f670c75a5251afee3e5b20f) tests/dircolors: test zsh path
* [`61d8f836`](https://github.com/nix-community/home-manager/commit/61d8f8366fc327a42cc212d62dfff06ae0c3f195) htop: export defaultFields into lib
* [`cb3f6e9b`](https://github.com/nix-community/home-manager/commit/cb3f6e9b59d3a5e51ef9f7da2b8418d5c72aaef8) htop: write-protect entire configuration directory
* [`fb568d75`](https://github.com/nix-community/home-manager/commit/fb568d75cf6c81f30d49eeb73787e9b56454ba16) targets/darwin: allow configuring application linking ([nix-community/home-manager⁠#4809](https://togithub.com/nix-community/home-manager/issues/4809))
* [`7f9ba30a`](https://github.com/nix-community/home-manager/commit/7f9ba30a28f02e51c4785b2cc32bf573f8eac021) tests: check that all firefox derivatives can be installed
* [`6b7cd508`](https://github.com/nix-community/home-manager/commit/6b7cd50812e884a559481c7905317005a968ec08) tests: test librewolf the same way firefox is tested
* [`3b6550f7`](https://github.com/nix-community/home-manager/commit/3b6550f710e754bc9f58c09583f2fa51d9fd14ed) git: add option to use riff as diff tool ([nix-community/home-manager⁠#5748](https://togithub.com/nix-community/home-manager/issues/5748))
* [`ed030a78`](https://github.com/nix-community/home-manager/commit/ed030a787938cae01d693ebaad52bbb672a4a69d) chromium: optional nativeMessagingHosts ([nix-community/home-manager⁠#6515](https://togithub.com/nix-community/home-manager/issues/6515))
* [`b5ab2c7f`](https://github.com/nix-community/home-manager/commit/b5ab2c7fdaa807cf425066ab7cd34b073946b1ca) waybar: support enable inspect from service ([nix-community/home-manager⁠#5922](https://togithub.com/nix-community/home-manager/issues/5922))
* [`3002f1ae`](https://github.com/nix-community/home-manager/commit/3002f1aedfde6d4d8112491ead088897a77ae661) tests/mpd: bash -> bash-interactive
* [`6a2af4ff`](https://github.com/nix-community/home-manager/commit/6a2af4ffb26f812c353415c7316dff0a8b52b525) tests/swayidle: bash -> bash-interactive
* [`12e26a74`](https://github.com/nix-community/home-manager/commit/12e26a74e5eb1a31e13daaa08858689e25ebd449) tests/neovim: resolve deprecation ([nix-community/home-manager⁠#6522](https://togithub.com/nix-community/home-manager/issues/6522))
* [`c12dcc9b`](https://github.com/nix-community/home-manager/commit/c12dcc9b61429b2ad437a7d4974399ad8f910319) xdg: create '$XDG_STATE_HOME' ([nix-community/home-manager⁠#6526](https://togithub.com/nix-community/home-manager/issues/6526))
