### PR TITLE
niv nerd-icons.el: update 546ee20c -> a29fcbc2

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -77,10 +77,10 @@
         "homepage": null,
         "owner": "rainstormstudio",
         "repo": "nerd-icons.el",
-        "rev": "546ee20caf825e65da4c5435d31f13d269ed2a81",
-        "sha256": "0vmzywzaizphj15rqvihw1znjp1i74w8fkhrg7kvic10iv0fpga8",
+        "rev": "a29fcbc24a7827d5e97a05302398f15a155fe18a",
+        "sha256": "0pi2bs9nx9d4pvmsnv4dw0hpvrf8i29877cchnkpg1ykqbvap6hy",
         "type": "tarball",
-        "url": "https://github.com/rainstormstudio/nerd-icons.el/archive/546ee20caf825e65da4c5435d31f13d269ed2a81.tar.gz",
+        "url": "https://github.com/rainstormstudio/nerd-icons.el/archive/a29fcbc24a7827d5e97a05302398f15a155fe18a.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "niv": {


### PR DESCRIPTION
## Changelog for nerd-icons.el:
Branch: main
Commits: [rainstormstudio/nerd-icons.el@546ee20c...a29fcbc2](https://github.com/rainstormstudio/nerd-icons.el/compare/546ee20caf825e65da4c5435d31f13d269ed2a81...a29fcbc24a7827d5e97a05302398f15a155fe18a)

* [`3a47753e`](https://github.com/rainstormstudio/nerd-icons.el/commit/3a47753ef4f9d7e83474f50c0188a7b39f1ff32d) feat: add go-work-ts-mode icon
* [`cc91fbbf`](https://github.com/rainstormstudio/nerd-icons.el/commit/cc91fbbfe258458d74525ec4205bfc4827464f9d) Added 4 file icons ([rainstormstudio/nerd-icons.el⁠#97](https://togithub.com/rainstormstudio/nerd-icons.el/issues/97))
* [`a29fcbc2`](https://github.com/rainstormstudio/nerd-icons.el/commit/a29fcbc24a7827d5e97a05302398f15a155fe18a) Add/update values for Apple development files ([rainstormstudio/nerd-icons.el⁠#95](https://togithub.com/rainstormstudio/nerd-icons.el/issues/95))
