### PR TITLE
niv emacs-overlay: update 49b92479 -> 125a3649

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "49b92479d543bfc85fc7935a390e32fa023bc08c",
-        "sha256": "0disk7fvs0v5782jl7frry295c1dv8ma965w78lyr6swsbyjav30",
+        "rev": "125a36498b1468c259acfbfb641ef68b4fcef8a8",
+        "sha256": "19hxyf2z7jckrms23svh6sxiig6ycqgjdb7vwk7572hg0xxc31f6",
         "type": "tarball",
-        "url": "https://github.com/nix-community/emacs-overlay/archive/49b92479d543bfc85fc7935a390e32fa023bc08c.tar.gz",
+        "url": "https://github.com/nix-community/emacs-overlay/archive/125a36498b1468c259acfbfb641ef68b4fcef8a8.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "fast-syntax-highlighting": {


### PR DESCRIPTION
## Changelog for emacs-overlay:
Branch: master
Commits: [nix-community/emacs-overlay@49b92479...125a3649](https://github.com/nix-community/emacs-overlay/compare/49b92479d543bfc85fc7935a390e32fa023bc08c...125a36498b1468c259acfbfb641ef68b4fcef8a8)

* [`40146848`](https://github.com/nix-community/emacs-overlay/commit/401468485c283e01395926beba2ffd7e0d25fd57) Updated nongnu
* [`b043aa17`](https://github.com/nix-community/emacs-overlay/commit/b043aa179e5f6e2cab982a7a1a829aa62eaf0152) Updated elpa
* [`a7d107bc`](https://github.com/nix-community/emacs-overlay/commit/a7d107bce5ede7f7a7bbc5f3cfba4a66db58d391) Updated melpa
* [`6e04073e`](https://github.com/nix-community/emacs-overlay/commit/6e04073ea3d01fde5003e4fe0fd326286f921583) Updated emacs
* [`7d4eee10`](https://github.com/nix-community/emacs-overlay/commit/7d4eee101a9d0cb8d5ef9aa808e69a90e001208a) Updated flake inputs
* [`f1a63305`](https://github.com/nix-community/emacs-overlay/commit/f1a6330580de72bab1974fcdc22ae1157f4195ea) Updated melpa
* [`2c113c71`](https://github.com/nix-community/emacs-overlay/commit/2c113c718a7cbe167e6e5ac7f9228f02c815c8e5) Updated emacs
* [`ed14de81`](https://github.com/nix-community/emacs-overlay/commit/ed14de81fe63a9c2e8a944176bc91f6fc6b872bf) Updated nongnu
* [`635dd541`](https://github.com/nix-community/emacs-overlay/commit/635dd541608e440cba25c39cbce6c8adb4930a34) Updated elpa
* [`7e2397cd`](https://github.com/nix-community/emacs-overlay/commit/7e2397cd915221afd6d2d0ba372e01c0797f0f7c) Updated melpa
* [`0e90dd66`](https://github.com/nix-community/emacs-overlay/commit/0e90dd66704c0f06531cf10829c2704b2c017be9) Updated emacs
* [`2ea5345a`](https://github.com/nix-community/emacs-overlay/commit/2ea5345a3b286ccb9b03e33117903cd231787ccc) Updated flake inputs
* [`e7d4ad3f`](https://github.com/nix-community/emacs-overlay/commit/e7d4ad3f3aad64c637756bfaecb65f1697e9edcf) Updated nongnu
* [`44ae5ad1`](https://github.com/nix-community/emacs-overlay/commit/44ae5ad163002c91d3f897a2dc369f42a5974f93) Updated elpa
* [`612d55ca`](https://github.com/nix-community/emacs-overlay/commit/612d55ca04d52588122ce011fd2a98c12a32723d) Updated melpa
* [`ff7476cf`](https://github.com/nix-community/emacs-overlay/commit/ff7476cfaab15541bb4eb769b50dc213c86fcf70) Updated emacs
* [`b357c15f`](https://github.com/nix-community/emacs-overlay/commit/b357c15f993289f99d93683f68a3566b3cc89f84) Updated melpa
* [`a7f332f6`](https://github.com/nix-community/emacs-overlay/commit/a7f332f6e0813c9d0f53fe6539be1e7a65fff2e4) Updated emacs
* [`3b77afd3`](https://github.com/nix-community/emacs-overlay/commit/3b77afd355f01fe690ba8ab2de31c5e6bedac6b5) Updated flake inputs
* [`f4bf81c0`](https://github.com/nix-community/emacs-overlay/commit/f4bf81c0b81c77eb4aad1a7f9a8eb7e00018546b) Updated nongnu
* [`154ff4be`](https://github.com/nix-community/emacs-overlay/commit/154ff4be52034cb91cf074b758516431a04d472a) Updated elpa
* [`99fc7bf4`](https://github.com/nix-community/emacs-overlay/commit/99fc7bf47112954e851da89e06b824fbc25e9859) Updated melpa
* [`e48d296c`](https://github.com/nix-community/emacs-overlay/commit/e48d296c3c6fb18dae58a8f017f254f3a430ee83) Updated emacs
* [`fd3dd6a1`](https://github.com/nix-community/emacs-overlay/commit/fd3dd6a1e1f4b8d51062851852c396265937a71f) Updated nongnu
* [`a5ac7ca0`](https://github.com/nix-community/emacs-overlay/commit/a5ac7ca091f5c5b3704269155dbde1e401f345e9) Updated elpa
* [`025aa96d`](https://github.com/nix-community/emacs-overlay/commit/025aa96db4a0fed4b70332b587343fae38bc734e) Updated melpa
* [`501c905c`](https://github.com/nix-community/emacs-overlay/commit/501c905c37fbfaef6ae9b64cd2ff9d90f1383212) Updated emacs
* [`6c57210f`](https://github.com/nix-community/emacs-overlay/commit/6c57210f1f5564c837784b86a724e4bfba055585) Updated melpa
* [`969abb73`](https://github.com/nix-community/emacs-overlay/commit/969abb7370a3957d80cbbca57f5ee8a66a0e73ac) Updated emacs
* [`b741206d`](https://github.com/nix-community/emacs-overlay/commit/b741206d6417476ca65c4211308e38f7b4c13800) Updated nongnu
* [`31f66b0e`](https://github.com/nix-community/emacs-overlay/commit/31f66b0e448ba6829aa7807ff456addee2598faa) Updated elpa
* [`7020fb5a`](https://github.com/nix-community/emacs-overlay/commit/7020fb5a9bd99b6c0114314365f2780ad1bebf15) Updated melpa
* [`714895eb`](https://github.com/nix-community/emacs-overlay/commit/714895ebc7583064d471784c7372b6ad476ee4ab) Updated emacs
* [`a9e3f738`](https://github.com/nix-community/emacs-overlay/commit/a9e3f738c29a111b08b4ab1ab3f63826d1bf489c) Updated nongnu
* [`9f020975`](https://github.com/nix-community/emacs-overlay/commit/9f0209759b360b3045dc7b99acdf90e49f3a291a) Updated elpa
* [`80e7e1b9`](https://github.com/nix-community/emacs-overlay/commit/80e7e1b95c0035dd74c8b9ace558bc7007a01ace) Updated melpa
* [`9fd9faae`](https://github.com/nix-community/emacs-overlay/commit/9fd9faae20df9454e37a71e05ce589a2c8f3fa66) Updated emacs
* [`9dcfbe77`](https://github.com/nix-community/emacs-overlay/commit/9dcfbe779f6f6de6f31bc47d0bdc36554c5cd1d4) Updated flake inputs
* [`52f31b67`](https://github.com/nix-community/emacs-overlay/commit/52f31b67d641dbb79ded6253e2731c48a79b8de9) Updated melpa
* [`52f13caa`](https://github.com/nix-community/emacs-overlay/commit/52f13caa3c3570bc59582578593b8fafd40f8aaa) Updated nongnu
* [`15593a66`](https://github.com/nix-community/emacs-overlay/commit/15593a66be927b04922b53cc9610de17000abdee) Updated melpa
* [`c5aa853f`](https://github.com/nix-community/emacs-overlay/commit/c5aa853ffd1d4ded1a409cb41e282436606dde17) Updated emacs
* [`6eea1e35`](https://github.com/nix-community/emacs-overlay/commit/6eea1e3527f5ed2e8527413ae6644a9a4f921113) Updated flake inputs
* [`7b66dfa4`](https://github.com/nix-community/emacs-overlay/commit/7b66dfa401ccf9feeb20a2373b6033fa55e8dac7) Updated nongnu
* [`efc32276`](https://github.com/nix-community/emacs-overlay/commit/efc3227671b728430c3ccb1facca69a2e28c8fe9) Updated elpa
* [`de230458`](https://github.com/nix-community/emacs-overlay/commit/de230458610866f11773e0d33b7e97dbc0d44d56) Updated melpa
* [`9af406ea`](https://github.com/nix-community/emacs-overlay/commit/9af406ea66edc730a2c64cf82b74a03513b94f5e) Updated emacs
* [`54996435`](https://github.com/nix-community/emacs-overlay/commit/54996435624bb4e2ff4af3364cd1dfd4e1e14a4d) Updated flake inputs
* [`1d2b5233`](https://github.com/nix-community/emacs-overlay/commit/1d2b5233e20b6876a8328e20aa28f8e5c80af2a4) Updated melpa
* [`abfa104f`](https://github.com/nix-community/emacs-overlay/commit/abfa104fff496f9eb7a091728af73067ccf8802d) Updated emacs
* [`592a8d7a`](https://github.com/nix-community/emacs-overlay/commit/592a8d7aeb04c3f3129882f44d7179dd09411f35) Updated nongnu
* [`4b0189c8`](https://github.com/nix-community/emacs-overlay/commit/4b0189c89c572ac95ea2c4dc6da64cb92c4c59d1) Updated elpa
* [`22ec5d70`](https://github.com/nix-community/emacs-overlay/commit/22ec5d70287ef483e8149dd288136394f606478d) Updated melpa
* [`ed5cb1be`](https://github.com/nix-community/emacs-overlay/commit/ed5cb1becdad3465ca08dd8ef0b156ae4390505f) Updated emacs
* [`1fb9e197`](https://github.com/nix-community/emacs-overlay/commit/1fb9e19710b4d1b4c26bda5855d0d5ba1587d510) Updated nongnu
* [`c4d38ecc`](https://github.com/nix-community/emacs-overlay/commit/c4d38eccd88f3c740a03d9f04af2fa14efa2e802) Updated elpa
* [`1d0b6f62`](https://github.com/nix-community/emacs-overlay/commit/1d0b6f6290644c764ab1dffb1fee2d0702cd9d0e) Updated melpa
* [`590d6eca`](https://github.com/nix-community/emacs-overlay/commit/590d6ecac05c53ae8a87af317efa06f4a99ab116) Updated emacs
* [`a2828925`](https://github.com/nix-community/emacs-overlay/commit/a2828925c87502bfd319541d7082112a64628612) Updated nongnu
* [`be1fc044`](https://github.com/nix-community/emacs-overlay/commit/be1fc044a82b9c6901e2da382a2234b8502b4f11) Updated elpa
* [`7882f1b3`](https://github.com/nix-community/emacs-overlay/commit/7882f1b342e9170d89dc45d5915e7596409044cb) Updated melpa
* [`1d19c188`](https://github.com/nix-community/emacs-overlay/commit/1d19c1885c8807e044eb861162ee0120b6749dea) Updated emacs
* [`f7ad53b9`](https://github.com/nix-community/emacs-overlay/commit/f7ad53b9e50d15e72eb0f6d56defe3a841a45977) Updated elpa
* [`55549fb7`](https://github.com/nix-community/emacs-overlay/commit/55549fb7cc17bd4b772bee3b6eecb0152db31801) Updated melpa
* [`ec094137`](https://github.com/nix-community/emacs-overlay/commit/ec094137fed63ffe5503b8434071f6b755494927) Updated emacs
* [`62e6f266`](https://github.com/nix-community/emacs-overlay/commit/62e6f266d6fc1443d83457c65ef4b860d2f3835a) Updated flake inputs
* [`35357ca3`](https://github.com/nix-community/emacs-overlay/commit/35357ca3a046eb7fa72fa8e433496434895af36c) Updated melpa
* [`d1a312c5`](https://github.com/nix-community/emacs-overlay/commit/d1a312c524fe9f1a6836fc3fd63c6fd09f795abb) Updated emacs
* [`59997c63`](https://github.com/nix-community/emacs-overlay/commit/59997c63608b3ba0ccb68beb589969cafd952477) Updated nongnu
* [`f5ef1413`](https://github.com/nix-community/emacs-overlay/commit/f5ef1413cddc9c62bea01fd2bf85c211e6b7c3eb) Updated elpa
* [`15150761`](https://github.com/nix-community/emacs-overlay/commit/1515076129d7104cf3b43ea7f54bbd04a49af6a6) Updated melpa
* [`849f0e08`](https://github.com/nix-community/emacs-overlay/commit/849f0e08654c40c8da1c3d830caf5497eb366f93) Updated emacs
* [`08d6d24e`](https://github.com/nix-community/emacs-overlay/commit/08d6d24e34281b5b3529e29b168591f2fdfa21c6) Updated flake inputs
* [`bbcfcbd4`](https://github.com/nix-community/emacs-overlay/commit/bbcfcbd4d34f24a71dc4cd2aea333b606007b4c9) Updated nongnu
* [`be3cfb0a`](https://github.com/nix-community/emacs-overlay/commit/be3cfb0a089b93aa28338340e0eb4133fc340aa9) Updated elpa
* [`1568d60d`](https://github.com/nix-community/emacs-overlay/commit/1568d60da7fcbb1fd524d6b044b9ddce14c32dbc) Updated melpa
* [`ad169255`](https://github.com/nix-community/emacs-overlay/commit/ad16925507732f4f57f6cc5595bdfa90d2692278) Updated emacs
* [`6444d227`](https://github.com/nix-community/emacs-overlay/commit/6444d227d432cf4efa7c58803a2bcef3b84d41cc) Updated flake inputs
* [`8607d39d`](https://github.com/nix-community/emacs-overlay/commit/8607d39d386a84ad7652ab1d1f9ae328861a4cd6) Updated melpa
* [`5b1779b1`](https://github.com/nix-community/emacs-overlay/commit/5b1779b13077a122dba393d0b0c148a0e5bf16f6) Updated emacs
* [`c9b90161`](https://github.com/nix-community/emacs-overlay/commit/c9b9016134bcc0ef644c10cc52157c7636808180) Updated nongnu
* [`21b6b2d9`](https://github.com/nix-community/emacs-overlay/commit/21b6b2d9c0d96a74d0c9f0302eb3cec0fba3570b) Updated elpa
* [`84d0eecc`](https://github.com/nix-community/emacs-overlay/commit/84d0eecc7ba8201a2afba980f57eb1e5b081516e) Updated melpa
* [`0bfadcfd`](https://github.com/nix-community/emacs-overlay/commit/0bfadcfd92855d3eb7e5c6401aff2ba348b1e7b7) Updated emacs
* [`1332b6ab`](https://github.com/nix-community/emacs-overlay/commit/1332b6ab2cccc0f12f7ce10a7ae09421ec88c0de) Updated flake inputs
* [`8906677e`](https://github.com/nix-community/emacs-overlay/commit/8906677ebdd9e7a70a46fade8f5eca26c7893a2a) Updated nongnu
* [`ce509b25`](https://github.com/nix-community/emacs-overlay/commit/ce509b25a8d65cebd8ee5722423151690b4e5e70) Updated elpa
* [`42d13c0f`](https://github.com/nix-community/emacs-overlay/commit/42d13c0f389aa455b55476fdd16347e512c44679) Updated melpa
* [`6c02db1d`](https://github.com/nix-community/emacs-overlay/commit/6c02db1d65ff3c8d1a871c50bd2cdf3b4822fafd) Updated emacs
* [`6cc967bc`](https://github.com/nix-community/emacs-overlay/commit/6cc967bc5867561fbb4ee6e8ea8f4b5de71a740a) Updated melpa
* [`70518f71`](https://github.com/nix-community/emacs-overlay/commit/70518f71b346044308d0c42fdbb79263bd85bf8f) Updated emacs
* [`a0dac4c5`](https://github.com/nix-community/emacs-overlay/commit/a0dac4c5cd0df16d552c030e9ef8a4cfeea895eb) Updated nongnu
* [`909a7b97`](https://github.com/nix-community/emacs-overlay/commit/909a7b974edcdccd9696a03182fab846ce3a50ae) Updated elpa
* [`a3a8f640`](https://github.com/nix-community/emacs-overlay/commit/a3a8f64036679fbdac85f94058c0849ba0ed2015) Updated melpa
* [`3e356346`](https://github.com/nix-community/emacs-overlay/commit/3e35634650753a5644cf07148cf49df1f023efce) Updated emacs
* [`5b698d0b`](https://github.com/nix-community/emacs-overlay/commit/5b698d0b9b766f0a15d0514e715215107f55f146) Updated flake inputs
* [`09ad0eaa`](https://github.com/nix-community/emacs-overlay/commit/09ad0eaa8649c177a73df401174ab3d4ddad9b12) Updated nongnu
* [`2be3f23b`](https://github.com/nix-community/emacs-overlay/commit/2be3f23b7f9ea49e9512711b2214e3042511bb5b) Updated elpa
* [`c85f23ef`](https://github.com/nix-community/emacs-overlay/commit/c85f23ef251b4f8c6e10f82a090eb2660e35db2a) Updated melpa
* [`842e29a4`](https://github.com/nix-community/emacs-overlay/commit/842e29a45130c88e0cdc99e14745d7199bb062c9) Updated emacs
* [`e4af4181`](https://github.com/nix-community/emacs-overlay/commit/e4af4181ee774221e43dc071ede0ed5777f71bc4) Updated melpa
* [`76d66ccb`](https://github.com/nix-community/emacs-overlay/commit/76d66ccb5d6e8d58967e9716454fb0e2b3ed9d29) Updated emacs
* [`c490d049`](https://github.com/nix-community/emacs-overlay/commit/c490d0493f0f9efb38ccbb2b42989018083d8621) Updated nongnu
* [`4580261f`](https://github.com/nix-community/emacs-overlay/commit/4580261f8d9fdbde765a6657a526e99deb4148c5) Updated elpa
* [`fc60f8b4`](https://github.com/nix-community/emacs-overlay/commit/fc60f8b46ef1ef6c1542a740ca6916deab3b3416) Updated melpa
* [`66b6a800`](https://github.com/nix-community/emacs-overlay/commit/66b6a800edf6c6ef58d021b81ab7e6a10ae34834) Updated emacs
* [`d0dc89d5`](https://github.com/nix-community/emacs-overlay/commit/d0dc89d556140e723afa628fd0efdab5e03eb86f) Updated nongnu
* [`7b512de1`](https://github.com/nix-community/emacs-overlay/commit/7b512de162fb12311393c88d558e2e3452eeb7f2) Updated elpa
* [`6c678971`](https://github.com/nix-community/emacs-overlay/commit/6c6789714c116cf6a5bf702b97bda2009db5a969) Updated melpa
* [`9bb2d793`](https://github.com/nix-community/emacs-overlay/commit/9bb2d793316aeb2951f2b2dd9a8cefb66ee5e904) Updated emacs
* [`84e1abab`](https://github.com/nix-community/emacs-overlay/commit/84e1abab380d830c96b6d8e953443df1045d32e0) Updated melpa
* [`20e2333e`](https://github.com/nix-community/emacs-overlay/commit/20e2333eb7184318ddfa0c9269a8e509b6de85d6) Updated emacs
* [`08eb6156`](https://github.com/nix-community/emacs-overlay/commit/08eb61561a369afa53d914c92fc4dec41068dffb) Updated nongnu
* [`f69abd1d`](https://github.com/nix-community/emacs-overlay/commit/f69abd1dadc4e7823a3db12538fba2d2eeca4905) Updated elpa
* [`9bbc62c7`](https://github.com/nix-community/emacs-overlay/commit/9bbc62c7dc4107e4a04c8a30f2b17d09069f07f8) Updated melpa
* [`096d802c`](https://github.com/nix-community/emacs-overlay/commit/096d802c6545f32eb718483ef66ae8013abf9a36) Updated emacs
* [`5447db0b`](https://github.com/nix-community/emacs-overlay/commit/5447db0b785fe0954475e50fb09a89a6c72ab20b) Updated flake inputs
* [`96a88d24`](https://github.com/nix-community/emacs-overlay/commit/96a88d2499742c1f1c5efae2bcf715dec276db7e) Updated nongnu
* [`3d098f31`](https://github.com/nix-community/emacs-overlay/commit/3d098f31c121b8051ccad6e80a549050a7496120) Updated elpa
* [`52b6b413`](https://github.com/nix-community/emacs-overlay/commit/52b6b41397b27cd10e866dea9ba04bc50ea2bea0) Updated melpa
* [`80ccdb81`](https://github.com/nix-community/emacs-overlay/commit/80ccdb81a7e20a618aa9be869e90cb083925459f) Updated emacs
* [`944d35f6`](https://github.com/nix-community/emacs-overlay/commit/944d35f6f9bdf31e899b579c0f940f8875eb6e7f) Updated melpa
* [`8d99adb2`](https://github.com/nix-community/emacs-overlay/commit/8d99adb21eab7b97c4004af67ea640ed245215a1) Updated emacs
* [`4a4fdc8b`](https://github.com/nix-community/emacs-overlay/commit/4a4fdc8b9a6f6230cd9e7cab52c9f01477003a09) Updated nongnu
* [`4c869359`](https://github.com/nix-community/emacs-overlay/commit/4c869359d3490374563b56bbf42db92293982e4b) Updated elpa
* [`a2eaa98f`](https://github.com/nix-community/emacs-overlay/commit/a2eaa98fe318a49b2c1bfd6eca0f00f6e1f1dce0) Updated melpa
* [`88f3cba3`](https://github.com/nix-community/emacs-overlay/commit/88f3cba36d23f40c7e6b868d0b80555c55cdc3a5) Updated emacs
* [`057dca0b`](https://github.com/nix-community/emacs-overlay/commit/057dca0b0e4c6ac953b05fbb46ac00a17e593f18) Updated nongnu
* [`9868eea1`](https://github.com/nix-community/emacs-overlay/commit/9868eea14531e913b38c5767e0a12ed14e6b862b) Updated elpa
* [`2a6a8976`](https://github.com/nix-community/emacs-overlay/commit/2a6a8976401f01bdf866385f00c4205e6818b316) Updated melpa
* [`8a91f48b`](https://github.com/nix-community/emacs-overlay/commit/8a91f48b10b4ef312f483af4fc2ca768f05118b6) Updated emacs
* [`acb48471`](https://github.com/nix-community/emacs-overlay/commit/acb4847148697ae370090c9c1e3a4addc08ff8fe) Updated melpa
* [`388f3558`](https://github.com/nix-community/emacs-overlay/commit/388f3558cc759d1686c2e0001cd52c4c89a6d44e) Updated emacs
* [`9196c8d5`](https://github.com/nix-community/emacs-overlay/commit/9196c8d59c9110238c98c38cbb452ed49ef35ce3) Updated flake inputs
* [`4d002846`](https://github.com/nix-community/emacs-overlay/commit/4d002846f8cce10370e846846909b582e8ae540e) Updated nongnu
* [`8cf8f68c`](https://github.com/nix-community/emacs-overlay/commit/8cf8f68ca90dc05d7ecd4feb7f36beaf2f5fbd18) Updated elpa
* [`141bb2ab`](https://github.com/nix-community/emacs-overlay/commit/141bb2ab7b30a4d50ac6c23bc3eb37ee45258607) Updated melpa
* [`56f3570e`](https://github.com/nix-community/emacs-overlay/commit/56f3570e6a3cfa13a7255c7b39c4a8427367e646) Updated emacs
* [`fb6fcbfc`](https://github.com/nix-community/emacs-overlay/commit/fb6fcbfc802e2d4e5e458c385bfba76cb5ffff92) Updated flake inputs
* [`911c0cf1`](https://github.com/nix-community/emacs-overlay/commit/911c0cf1bc533951594eab080db23094c830c322) Updated nongnu
* [`aa543ab6`](https://github.com/nix-community/emacs-overlay/commit/aa543ab67245e3109fd0d396bddc89ffd22b0e36) Updated elpa
* [`b98ec2bd`](https://github.com/nix-community/emacs-overlay/commit/b98ec2bd221d27671ed99a0b59f66317955a1fee) Updated melpa
* [`e9a20ce4`](https://github.com/nix-community/emacs-overlay/commit/e9a20ce4908add82fd2f31d85bd6844ba0c0a8e9) Updated emacs
* [`5a593ca1`](https://github.com/nix-community/emacs-overlay/commit/5a593ca15d1bb84a5ae2c12fba347309b6f0aeff) Updated melpa
* [`24720cc6`](https://github.com/nix-community/emacs-overlay/commit/24720cc605015be05e56b9402dd022c397be0b89) Updated emacs
* [`7b9cb254`](https://github.com/nix-community/emacs-overlay/commit/7b9cb25425a6bcc5a5e8b4e4a5be2ee0400bec78) Updated nongnu
* [`55002e9e`](https://github.com/nix-community/emacs-overlay/commit/55002e9eb67d3e5aa6783a46da5f70ce804ebb03) Updated elpa
* [`9262057c`](https://github.com/nix-community/emacs-overlay/commit/9262057cc86e7512d742a1c1ae9d7d118bb82d48) Updated melpa
* [`3a93a0a8`](https://github.com/nix-community/emacs-overlay/commit/3a93a0a8f94fd52260b39aefc05e7bc667ded0ab) Updated emacs
* [`9cf919c9`](https://github.com/nix-community/emacs-overlay/commit/9cf919c9a1b50235109de97e19ba9ca6ae58a52e) Updated nongnu
* [`c0c562c3`](https://github.com/nix-community/emacs-overlay/commit/c0c562c3488b11f20ec78a5f538e1517d47ccf44) Updated elpa
* [`09e66f60`](https://github.com/nix-community/emacs-overlay/commit/09e66f60f120756c309328a1910b143bd3eef8d5) Updated melpa
* [`119c1e60`](https://github.com/nix-community/emacs-overlay/commit/119c1e609911a1a24af83e342fa4e2b11faa2096) Updated emacs
* [`dce38f81`](https://github.com/nix-community/emacs-overlay/commit/dce38f8164f7c9d6ff4255df45c597394de9e359) Updated melpa
* [`15fe2e79`](https://github.com/nix-community/emacs-overlay/commit/15fe2e796e097c4fda4ed481401ae80f2b714525) Updated emacs
* [`d475ac96`](https://github.com/nix-community/emacs-overlay/commit/d475ac967ec0149952fc7cdebe4d91afcc71d5d0) Updated flake inputs
* [`4f15fdfa`](https://github.com/nix-community/emacs-overlay/commit/4f15fdfa8fc61db80bc680dde4c6d923d9da5e53) Updated nongnu
* [`defe89aa`](https://github.com/nix-community/emacs-overlay/commit/defe89aacf73954b2afe39742cfd4fd8ae29c1d6) Updated elpa
* [`e786c72d`](https://github.com/nix-community/emacs-overlay/commit/e786c72d165992ad3447356581f81662282ab91b) Updated melpa
* [`b19f5700`](https://github.com/nix-community/emacs-overlay/commit/b19f57002c6428aa6c057d5ba8ab5caa5c2777ed) Updated emacs
* [`5272dcdd`](https://github.com/nix-community/emacs-overlay/commit/5272dcdd4289080450907ad261af726b6f7c15ad) Updated nongnu
* [`bc21dcb7`](https://github.com/nix-community/emacs-overlay/commit/bc21dcb73a775e1b1439cabca732e491954d43b5) Updated elpa
* [`8cf8a9da`](https://github.com/nix-community/emacs-overlay/commit/8cf8a9dad53ec99ba5a9a4aa6f3be3cb721df68e) Updated melpa
* [`9ab982da`](https://github.com/nix-community/emacs-overlay/commit/9ab982da8f82359a7619f25718fb6bd838ca34ce) Updated emacs
* [`1d995657`](https://github.com/nix-community/emacs-overlay/commit/1d99565768b67e930e80fc8f03acea9860395da2) Updated melpa
* [`7bbf9041`](https://github.com/nix-community/emacs-overlay/commit/7bbf9041d7164cb7f9ce853bc7cc485159411f9a) Updated nongnu
* [`3a42b363`](https://github.com/nix-community/emacs-overlay/commit/3a42b3637705c3e92485370b23df9677aedfdb51) Updated elpa
* [`c356eb83`](https://github.com/nix-community/emacs-overlay/commit/c356eb83c3461c19c2bf355d351354a0dcf76655) Updated melpa
* [`5f197230`](https://github.com/nix-community/emacs-overlay/commit/5f19723032f94906619cbae99776e938d9c36ee3) Updated flake inputs
* [`130cf7b2`](https://github.com/nix-community/emacs-overlay/commit/130cf7b20fb44eb3d1ba514d4659e65b23153ccc) Updated nongnu
* [`44cbdb78`](https://github.com/nix-community/emacs-overlay/commit/44cbdb78a0be12fa56271a24b319dcb01fc3f89a) Updated elpa
* [`2784fd66`](https://github.com/nix-community/emacs-overlay/commit/2784fd66800ba9ea38bab7eae7237c8f19908dad) Updated melpa
* [`99e720a4`](https://github.com/nix-community/emacs-overlay/commit/99e720a423a5886a59aa1a6da0d0162ecbbc5a8c) Updated emacs
* [`03873f4f`](https://github.com/nix-community/emacs-overlay/commit/03873f4f3035100a26b7bf4939d1581369f759a6) Updated melpa
* [`783cff85`](https://github.com/nix-community/emacs-overlay/commit/783cff85c13e857ab95b441020621ea64e7a9843) Updated emacs
* [`cfa522cb`](https://github.com/nix-community/emacs-overlay/commit/cfa522cbf861b4d78ab360b023ea992c165ba3fb) Updated flake inputs
* [`021d41d8`](https://github.com/nix-community/emacs-overlay/commit/021d41d8d933d33146a5b90e216087b9bc4741b6) Updated nongnu
* [`c41ad03e`](https://github.com/nix-community/emacs-overlay/commit/c41ad03ebbfcb81a2ab77f877fdaa6e8e88bafef) Updated elpa
* [`f46d961b`](https://github.com/nix-community/emacs-overlay/commit/f46d961b45787fd1bd9b46226d094ef7dbc5a2ac) Updated melpa
* [`b51c3cce`](https://github.com/nix-community/emacs-overlay/commit/b51c3cceb739735185e06878bb05c2a0a3c16b9b) Updated emacs
* [`2882bd00`](https://github.com/nix-community/emacs-overlay/commit/2882bd003d1dd23e9089acc47fc4e5491a898cd9) Updated flake inputs
* [`e0df9cff`](https://github.com/nix-community/emacs-overlay/commit/e0df9cfff486aab3d855689c67b3ecba5e8f3570) Updated elpa
* [`ba40c1a6`](https://github.com/nix-community/emacs-overlay/commit/ba40c1a645cfde6c367aa5575dabec813e171f51) Updated nongnu
* [`ec02bf2e`](https://github.com/nix-community/emacs-overlay/commit/ec02bf2e195fceaa06f3407f11e2c97c7d25f6c0) Updated melpa
* [`53b218d3`](https://github.com/nix-community/emacs-overlay/commit/53b218d3d3d187724e86b2a63ce9a960d005faac) Updated emacs
* [`0246e477`](https://github.com/nix-community/emacs-overlay/commit/0246e477a9015e6f15de303393b3cc3144104b94) Updated melpa
* [`044b275c`](https://github.com/nix-community/emacs-overlay/commit/044b275cd7f349b0d8e4890e2131316ccc22d98b) Updated emacs
* [`311b0c96`](https://github.com/nix-community/emacs-overlay/commit/311b0c968b9092e64df961150b78e82ec34582ac) Updated nongnu
* [`d3b44edf`](https://github.com/nix-community/emacs-overlay/commit/d3b44edf424120461ea2c3e4f0db3857d19fa21d) Updated elpa
* [`c9366f20`](https://github.com/nix-community/emacs-overlay/commit/c9366f203ab37518ba6614149428d060608dd4bc) Updated melpa
* [`27a75333`](https://github.com/nix-community/emacs-overlay/commit/27a753338e52cb2ad04b534861054f415e596b42) Updated emacs
* [`a02e9c9d`](https://github.com/nix-community/emacs-overlay/commit/a02e9c9d3a2cc1613a8fdb745ccac93611164bea) Updated nongnu
* [`99cd9760`](https://github.com/nix-community/emacs-overlay/commit/99cd97600e9ad11d1ba24fcc390f4bf305c95f84) Updated elpa
* [`4b2cfb13`](https://github.com/nix-community/emacs-overlay/commit/4b2cfb13bd1434c917b50ecc0ff8557946df0019) Updated melpa
* [`ac68198c`](https://github.com/nix-community/emacs-overlay/commit/ac68198cb33b20aaae32527d3810a86acb796bd6) Updated emacs
* [`9f30fb22`](https://github.com/nix-community/emacs-overlay/commit/9f30fb22dc6473cdf4afc6b1d38d70b8606cc4b1) Updated flake inputs
* [`ba87bc36`](https://github.com/nix-community/emacs-overlay/commit/ba87bc36bef058c43f7b01cea988a00d70294b5f) Updated melpa
* [`4e9632a6`](https://github.com/nix-community/emacs-overlay/commit/4e9632a65f5be82a51decac2020b0b360215f456) Updated emacs
* [`cb720535`](https://github.com/nix-community/emacs-overlay/commit/cb720535c94cab344eed4df0d59f29465ec2691d) Updated nongnu
* [`6fca983d`](https://github.com/nix-community/emacs-overlay/commit/6fca983dce156512d0e0dda49a4852c1c1874900) Updated elpa
* [`4b75a5af`](https://github.com/nix-community/emacs-overlay/commit/4b75a5af90db4a751447c02b289897f5b712bb09) Updated melpa
* [`773caf72`](https://github.com/nix-community/emacs-overlay/commit/773caf72c0ccfb793883b03f65b4a2919c9e1a10) Updated emacs
* [`599c3ed9`](https://github.com/nix-community/emacs-overlay/commit/599c3ed9bce96e8e35654a34bb214c5c7194fa32) Updated flake inputs
* [`be0fef5a`](https://github.com/nix-community/emacs-overlay/commit/be0fef5a7f07d4ec14e5354800d340e3f24c246c) Updated nongnu
* [`4443f457`](https://github.com/nix-community/emacs-overlay/commit/4443f45710cf56df88b1f465e7952eae552979ec) Updated elpa
* [`233de5f1`](https://github.com/nix-community/emacs-overlay/commit/233de5f17c1bdf62be3d8054916686f9d2fccb11) Updated melpa
* [`6f91e1aa`](https://github.com/nix-community/emacs-overlay/commit/6f91e1aa56760a4f5f81cf8259b428cb987e295d) Updated emacs
* [`fc19ce22`](https://github.com/nix-community/emacs-overlay/commit/fc19ce22940d2fec85101c2511df7f872f757ccf) Updated melpa
* [`ad562828`](https://github.com/nix-community/emacs-overlay/commit/ad562828e30f625181cec2a1be61ef28229f8e34) Updated emacs
* [`e1ed34a7`](https://github.com/nix-community/emacs-overlay/commit/e1ed34a710acba33ec8b802acba255f4ccadaa2a) Updated nongnu
* [`f9830d78`](https://github.com/nix-community/emacs-overlay/commit/f9830d78de821c22aabbd55b1a9ba57f7a79ce37) Updated elpa
* [`5926d0cc`](https://github.com/nix-community/emacs-overlay/commit/5926d0cc91ca83ec68a86ea4550224af0c44d959) Updated melpa
* [`759b7252`](https://github.com/nix-community/emacs-overlay/commit/759b725256597a6b3020f56988ad12562e6d02c6) Updated emacs
* [`f97767b1`](https://github.com/nix-community/emacs-overlay/commit/f97767b1869d55e78aa2353528c717cf2f47d5cb) Updated nongnu
* [`ca7043dc`](https://github.com/nix-community/emacs-overlay/commit/ca7043dc160e28e08924e2d3e7a9a15d6229f9a6) Updated elpa
* [`d4bb0f57`](https://github.com/nix-community/emacs-overlay/commit/d4bb0f5705e60ce5923dd28c27d36072fea92546) Updated melpa
* [`1e16548e`](https://github.com/nix-community/emacs-overlay/commit/1e16548eb941484f83c854504631e7a70282a0ca) Updated emacs
* [`de40897a`](https://github.com/nix-community/emacs-overlay/commit/de40897ad8e35fef6f268822655c52bd65aac0f0) Updated melpa
* [`38cde30c`](https://github.com/nix-community/emacs-overlay/commit/38cde30c151765ba64e8e7b0b47ec35ecbbbdb02) Updated emacs
* [`ca734695`](https://github.com/nix-community/emacs-overlay/commit/ca73469546221017f1183e1312803b6e2c7d02eb) Updated nongnu
* [`85c49bdb`](https://github.com/nix-community/emacs-overlay/commit/85c49bdbbbea83bbe8f605cb5ef504df008a7a36) Updated elpa
* [`5fffd529`](https://github.com/nix-community/emacs-overlay/commit/5fffd529d5235d2bd4b13857562906b643c1c4b6) Updated melpa
* [`5087fd2d`](https://github.com/nix-community/emacs-overlay/commit/5087fd2de336359f61e50a608f4d50fd4c3ef10f) Updated emacs
* [`dce84a0c`](https://github.com/nix-community/emacs-overlay/commit/dce84a0c7c5457627fb63597cbe62db18f73c475) Updated nongnu
* [`c3775b4a`](https://github.com/nix-community/emacs-overlay/commit/c3775b4a82a884d8e88d13b431d5b2bd034d2cc9) Updated elpa
* [`7e41e738`](https://github.com/nix-community/emacs-overlay/commit/7e41e7387833e0787c3651a860c5b697d1595bc3) Updated melpa
* [`33b94573`](https://github.com/nix-community/emacs-overlay/commit/33b945739322cb13a351114563ffad9c4f67968c) Updated emacs
* [`2e5c8290`](https://github.com/nix-community/emacs-overlay/commit/2e5c829031eff28f624f6aa4bf5c228918e50589) Updated melpa
* [`10d666ad`](https://github.com/nix-community/emacs-overlay/commit/10d666ad8ae003661063ac31ec97bf8412365e00) Updated emacs
* [`5682e635`](https://github.com/nix-community/emacs-overlay/commit/5682e6355a915c1a529a663da6c27b76fb4a1a37) repos/emacs: Fix update unstable
* [`d30068dd`](https://github.com/nix-community/emacs-overlay/commit/d30068dd0433250991335f12f75882f1688ac465) Updated nongnu
* [`38861b2e`](https://github.com/nix-community/emacs-overlay/commit/38861b2e34a2075608d3d6c88a126d276fc9b8a3) Updated elpa
* [`f004ea60`](https://github.com/nix-community/emacs-overlay/commit/f004ea60b2c4646b8beceb218bb058140b69be49) Updated melpa
* [`7df2b725`](https://github.com/nix-community/emacs-overlay/commit/7df2b725e16d70b5ccd949a5abf1370fcad7f1f9) Updated emacs
* [`f6f9a60d`](https://github.com/nix-community/emacs-overlay/commit/f6f9a60d81a5c651e6d0f59153e38f30a6d30063) Updated melpa
* [`79f1e193`](https://github.com/nix-community/emacs-overlay/commit/79f1e19358130a73a057c11bfedb10974a28f1aa) Updated flake inputs
* [`f8f80c7c`](https://github.com/nix-community/emacs-overlay/commit/f8f80c7c85c7ceb7c0248967543c88ff18893ffc) Updated nongnu
* [`829a6fa0`](https://github.com/nix-community/emacs-overlay/commit/829a6fa087927f783ff151e23da149cc7a840ca7) Updated elpa
* [`50069039`](https://github.com/nix-community/emacs-overlay/commit/500690394a759611ceda396b800fe845ae661204) Updated melpa
* [`dcb9bed7`](https://github.com/nix-community/emacs-overlay/commit/dcb9bed7a8cc9e98586f4535d8ddadade5b1b0b2) Updated emacs
* [`8970d33b`](https://github.com/nix-community/emacs-overlay/commit/8970d33b560a366d41a5f5867782cfab25f79f17) Updated melpa
* [`920cd4e8`](https://github.com/nix-community/emacs-overlay/commit/920cd4e86af18bd67a60013d80a79ff2cd7a176b) Updated emacs
* [`6f753dda`](https://github.com/nix-community/emacs-overlay/commit/6f753ddacb4828a6c27b02c00e8066266517324e) Updated flake inputs
* [`ce2bb956`](https://github.com/nix-community/emacs-overlay/commit/ce2bb956486001473be5067243c688df2232c085) Updated nongnu
* [`1efaf5b1`](https://github.com/nix-community/emacs-overlay/commit/1efaf5b1996a2664dd131dbbaa1b21d2e7aa6134) Updated elpa
* [`63383c89`](https://github.com/nix-community/emacs-overlay/commit/63383c897a48902d9db34a4f0119c446138e7ed8) Updated melpa
* [`84420d19`](https://github.com/nix-community/emacs-overlay/commit/84420d1963cada13bc63be2e118082586690728a) Updated emacs
* [`83cacf2e`](https://github.com/nix-community/emacs-overlay/commit/83cacf2eec19d4ec4b2da24f6d15160ee6d7f17c) Updated nongnu
* [`65f79051`](https://github.com/nix-community/emacs-overlay/commit/65f79051adf6b396295b66774d098035756643af) Updated elpa
* [`283ec87e`](https://github.com/nix-community/emacs-overlay/commit/283ec87e72aee66efba226dab834898427205455) Updated melpa
* [`7499231e`](https://github.com/nix-community/emacs-overlay/commit/7499231e05179138025dc0475e71f7e9de367ee1) Updated emacs
* [`3122bebc`](https://github.com/nix-community/emacs-overlay/commit/3122bebca19dcd9e65afdae12b65e9350880eb8b) Updated melpa
* [`5e5da9a8`](https://github.com/nix-community/emacs-overlay/commit/5e5da9a8fc5088aa96d20acc8c39c7a0c0cc8a76) Updated emacs
* [`87aac93c`](https://github.com/nix-community/emacs-overlay/commit/87aac93cb9d741533c9f4b5f0d11913399002640) Updated flake inputs
* [`84b31213`](https://github.com/nix-community/emacs-overlay/commit/84b312133edf151e8564c7ef81a26e9d3741ffa6) Updated nongnu
* [`be151c9c`](https://github.com/nix-community/emacs-overlay/commit/be151c9c85940398b90492db97d84a2a43e66fa6) Updated elpa
* [`8e1487c5`](https://github.com/nix-community/emacs-overlay/commit/8e1487c5b4754b564c9a67549513365c31045c60) Updated nongnu
* [`e344b295`](https://github.com/nix-community/emacs-overlay/commit/e344b295cd95068a7a8a152b1e0e2c7b2840fae3) Updated elpa
* [`a102af41`](https://github.com/nix-community/emacs-overlay/commit/a102af41f3208c038f38a78329cf158f60efe82f) Updated melpa
* [`252ff563`](https://github.com/nix-community/emacs-overlay/commit/252ff563400439aceaba651d3e53a620da882cf6) Updated emacs
* [`328acd88`](https://github.com/nix-community/emacs-overlay/commit/328acd88b3ae28d4045d19ff57352ccc716292ac) Updated melpa
* [`1f5b2624`](https://github.com/nix-community/emacs-overlay/commit/1f5b2624c2ee0491b1767be073765d6b9a3c67f4) Updated emacs
* [`fc3c4c71`](https://github.com/nix-community/emacs-overlay/commit/fc3c4c71024415bc186fa3155df6ec87a5caf91b) Updated nongnu
* [`d82d304b`](https://github.com/nix-community/emacs-overlay/commit/d82d304bcd1398e223dee8de927db024dced5128) Updated elpa
* [`c8e5624d`](https://github.com/nix-community/emacs-overlay/commit/c8e5624dfce7df62b2c7f60a8af697fb1350af69) Updated melpa
* [`e61547b1`](https://github.com/nix-community/emacs-overlay/commit/e61547b1c4cdf6e6ed72862748397e49df9129ca) Updated emacs
* [`35d679a9`](https://github.com/nix-community/emacs-overlay/commit/35d679a967cdd6b19619505d3e8ae6f2a57acb4a) Updated nongnu
* [`f76e0708`](https://github.com/nix-community/emacs-overlay/commit/f76e0708c040298b5e2d5ebffe121dea6c03ad98) Updated elpa
* [`9fa26d5e`](https://github.com/nix-community/emacs-overlay/commit/9fa26d5e4f4589fe75e44ba45ed6f0a0e9b0c64c) Updated melpa
* [`443bea7e`](https://github.com/nix-community/emacs-overlay/commit/443bea7e42fe696fd7696eb70e70b6b4cd52e478) Updated emacs
* [`d7041525`](https://github.com/nix-community/emacs-overlay/commit/d7041525918c740c0968cb3b17c05f302b06533e) Updated flake inputs
* [`f80acca5`](https://github.com/nix-community/emacs-overlay/commit/f80acca5c290e81d19aa124177b0e92998bc0ae0) Updated melpa
* [`213d27a8`](https://github.com/nix-community/emacs-overlay/commit/213d27a8b579113ffe399ee672d84519464b11e8) Updated emacs
* [`f14ef843`](https://github.com/nix-community/emacs-overlay/commit/f14ef8436bed7233832bb746c46cf1fa54e50c6b) Updated nongnu
* [`3ef72281`](https://github.com/nix-community/emacs-overlay/commit/3ef722812a5a439b44b3efcb4c6625207e14e84c) Updated elpa
* [`376ea070`](https://github.com/nix-community/emacs-overlay/commit/376ea0703f24e172d2dbf2ef9ff2cca50d45dcc5) Updated melpa
* [`27928cb2`](https://github.com/nix-community/emacs-overlay/commit/27928cb214eda2ce3663f739bc26c7414164abee) Updated emacs
* [`d86a911d`](https://github.com/nix-community/emacs-overlay/commit/d86a911dd1bccb6b3359c3103cf54da7213e7b8c) Updated nongnu
* [`bc2df4c6`](https://github.com/nix-community/emacs-overlay/commit/bc2df4c6d209c0bc469156d972af4fa4625577f9) Updated elpa
* [`ebb0d1f1`](https://github.com/nix-community/emacs-overlay/commit/ebb0d1f10ad7cdc1f6fb32b705b3fd9af1f4ba79) Updated melpa
* [`ee8442ab`](https://github.com/nix-community/emacs-overlay/commit/ee8442abce734e9a1d0e5824818062bcbf358e73) Updated emacs
* [`a0b1fd87`](https://github.com/nix-community/emacs-overlay/commit/a0b1fd87b709569b28ba3c5ef53c15ad32eea39d) Updated melpa
* [`1d3a6e22`](https://github.com/nix-community/emacs-overlay/commit/1d3a6e22ae1e938a2fd284b67ea9eb4d0ce044af) Updated emacs
* [`2d746a0d`](https://github.com/nix-community/emacs-overlay/commit/2d746a0d7869f210bda1c5f234b56e25886ddf2b) Updated flake inputs
* [`9574465e`](https://github.com/nix-community/emacs-overlay/commit/9574465ed1622fdd07f04ace51a50518eb135896) Updated nongnu
* [`b8e573e0`](https://github.com/nix-community/emacs-overlay/commit/b8e573e04f5511292aa55ade043aff99fe064aff) Updated elpa
* [`6c0990dd`](https://github.com/nix-community/emacs-overlay/commit/6c0990dd521678094ccb1e75773916e1c849e40d) Updated melpa
* [`0f095d48`](https://github.com/nix-community/emacs-overlay/commit/0f095d48c2018d23ba5d7c4ff59ddd7e65364532) Updated emacs
* [`b926ba80`](https://github.com/nix-community/emacs-overlay/commit/b926ba80f7c96487d5117f53003e3f9a6ae55759) Updated flake inputs
* [`d4a74627`](https://github.com/nix-community/emacs-overlay/commit/d4a7462796499731f35090dc6a9d5723d1d68798) Updated nongnu
* [`cf54a476`](https://github.com/nix-community/emacs-overlay/commit/cf54a476c3668c857790fdab45f6d57c0b75d8a2) Updated elpa
* [`4d07ad50`](https://github.com/nix-community/emacs-overlay/commit/4d07ad503083e74d8f1452d89b0aadda7d84d88c) Updated melpa
* [`729ae31c`](https://github.com/nix-community/emacs-overlay/commit/729ae31cfa6a051b9585f9f4076e3df082bacfa2) Updated emacs
* [`e1a4ad6a`](https://github.com/nix-community/emacs-overlay/commit/e1a4ad6a8f4d5f59f8e60c204f36b4fcf44a020d) Updated melpa
* [`502293ae`](https://github.com/nix-community/emacs-overlay/commit/502293ae094f7ecd604500ffb19ad35bd429311b) Updated emacs
* [`4e5ec287`](https://github.com/nix-community/emacs-overlay/commit/4e5ec287045fb5606fb2c803c786bff45d67635e) Updated nongnu
* [`8caa640e`](https://github.com/nix-community/emacs-overlay/commit/8caa640eefce63e1eb794764c72eb310b81a2f6b) Updated elpa
* [`beeab7d7`](https://github.com/nix-community/emacs-overlay/commit/beeab7d70df6af0b89a5a72fc15e14ee8bc7e802) Updated melpa
* [`4a462936`](https://github.com/nix-community/emacs-overlay/commit/4a462936ca22eae70fd47fa3c9bef7f00153d2a1) Updated emacs
* [`5a69438d`](https://github.com/nix-community/emacs-overlay/commit/5a69438d395151fc8c8f54d7b76186a51bdaa2ea) Updated nongnu
* [`125a3649`](https://github.com/nix-community/emacs-overlay/commit/125a36498b1468c259acfbfb641ef68b4fcef8a8) Updated elpa
