### PR TITLE
niv doomemacs: update 2bc05242 -> 56ce6cc2

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "doomemacs",
         "repo": "doomemacs",
-        "rev": "2bc052425ca45a41532be0648ebd976d1bd2e6c1",
-        "sha256": "0a1px0igzhzl7mjl0wkp9jnb3sjggpbi2rnj0w2kga08d8frahcb",
+        "rev": "56ce6cc284e8f4dd0cb0704dde6694a1b8e500ed",
+        "sha256": "193yyg1nvg0nx80vf9w782vn374sdanhiqz0wdsqn67q4k2dkbbn",
         "type": "tarball",
-        "url": "https://github.com/doomemacs/doomemacs/archive/2bc052425ca45a41532be0648ebd976d1bd2e6c1.tar.gz",
+        "url": "https://github.com/doomemacs/doomemacs/archive/56ce6cc284e8f4dd0cb0704dde6694a1b8e500ed.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "emacs-overlay": {


### PR DESCRIPTION
## Changelog for doomemacs:
Branch: master
Commits: [doomemacs/doomemacs@2bc05242...56ce6cc2](https://github.com/doomemacs/doomemacs/compare/2bc052425ca45a41532be0648ebd976d1bd2e6c1...56ce6cc284e8f4dd0cb0704dde6694a1b8e500ed)

* [`d06be8d2`](https://github.com/doomemacs/doomemacs/commit/d06be8d2ffcc202cdf67d66ac777a6bbd9827e55) fix(debugger): dap autoloader for rustic
* [`2bceb217`](https://github.com/doomemacs/doomemacs/commit/2bceb217d914141ab654616be0c8f4229968a6a0) fix(cli): some package files not being byte-compiled (2nd take)
* [`90d2834b`](https://github.com/doomemacs/doomemacs/commit/90d2834bef6ef8408671098fbf76c76f64ac020f) fix(emacs-lisp): handle malformed outline-regexp
* [`a7ee1edf`](https://github.com/doomemacs/doomemacs/commit/a7ee1edf3f85cb08d94376af17578ac6e7f2c7ed) fix(org): allow tab to expand yasnippets in org
* [`765a4bb1`](https://github.com/doomemacs/doomemacs/commit/765a4bb1c100a1a75b664b9cfcd1e7ef045a6486) fix(lookup): use dumb-jump xref instead of dumb-jump-go
* [`39fe608c`](https://github.com/doomemacs/doomemacs/commit/39fe608cfc810b95f928d660c67699764fb3cd81) fix(magit): restore previous default transient visibility
* [`e81b5796`](https://github.com/doomemacs/doomemacs/commit/e81b5796a3a7e7e79ff255f4b6cacb4ea51d5945) bump: dirvish
* [`38868c79`](https://github.com/doomemacs/doomemacs/commit/38868c79f50d5e4f6840bfa29c8700a25941d844) fix: ignore `doom-theme` if `load-theme` is used
* [`79a8abd8`](https://github.com/doomemacs/doomemacs/commit/79a8abd85a181a5b4b5b2bb83d61b1e57a2bc700) bump: :tools
* [`fd765458`](https://github.com/doomemacs/doomemacs/commit/fd765458823f25432f698d7e8b93d13d369be0ea) bump: :os
* [`ea4559b0`](https://github.com/doomemacs/doomemacs/commit/ea4559b02b75529ce27f5427833504c1a0cf5fe1) bump: :app
* [`38dbb1a2`](https://github.com/doomemacs/doomemacs/commit/38dbb1a25bfb215913714b5cb1bf37c031cc7daf) bump: :emacs
* [`1bb191e8`](https://github.com/doomemacs/doomemacs/commit/1bb191e8ebaf0facf47142fd9948f83e39949dbd) bump: :lang
* [`b55d9884`](https://github.com/doomemacs/doomemacs/commit/b55d988491858314e7fcbae8da962dea6ff3f5b7) release(modules): 25.03.0-dev
* [`4e244903`](https://github.com/doomemacs/doomemacs/commit/4e2449031e32a7125992257c5c0f8db4c35add93) fix(elixir): start lsp when ts and lsp are enabled
* [`110b2d28`](https://github.com/doomemacs/doomemacs/commit/110b2d28410543757ae0ce23ce45d2215236f37d) fix(org): interop between org-fancy-priorities & org-export
* [`ffc5c607`](https://github.com/doomemacs/doomemacs/commit/ffc5c607216f61f5f6af5a816e84f5ab51b1f56d) bump: :completion
* [`6e6eaa11`](https://github.com/doomemacs/doomemacs/commit/6e6eaa1189123b05c68f7e4487f0ee557e91b34c) docs: bump latest supported Emacs version to 30.1
* [`4ea19039`](https://github.com/doomemacs/doomemacs/commit/4ea19039fedefc5a028905ef8b8e010a3828c7d4) bump: :checkers
* [`9b61843f`](https://github.com/doomemacs/doomemacs/commit/9b61843f36c2c33e581b04f1c0420b997712e7d2) bump: :ui doom
* [`04cd16a5`](https://github.com/doomemacs/doomemacs/commit/04cd16a5cdec736bec12f44decd83424e13a3a81) bump: package-lint
* [`df3d64aa`](https://github.com/doomemacs/doomemacs/commit/df3d64aa0756c2d0cff240f0da777a143e9bb947) fix(elixir): unbalanced paren in add-hook call
* [`bc3f0ce7`](https://github.com/doomemacs/doomemacs/commit/bc3f0ce7185b0ae56f12865bd624f903df483b1e) fix(vertico): void-function consult--async-split-style error
* [`56ce6cc2`](https://github.com/doomemacs/doomemacs/commit/56ce6cc284e8f4dd0cb0704dde6694a1b8e500ed) fix(lib): modulep!: returning t for disabled modules
