### PR TITLE
niv nixpkgs: update f0edbb60 -> 4957613f

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "f0edbb60123249fb349827794c35139340e29dfb",
-        "sha256": "1lzl0q8zxy0mgx7lh5s1r01nwxb7y74syis6s0xwcjwidifcnxxz",
+        "rev": "4957613fe2351224fe2b985a642f2551a778313c",
+        "sha256": "12mcj8wdlp4y7ia6wx9f1yfgwsf4qn92wzla2pjkhlm2c94fm54d",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/f0edbb60123249fb349827794c35139340e29dfb.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/4957613fe2351224fe2b985a642f2551a778313c.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@f0edbb60...4957613f](https://github.com/nixos/nixpkgs/compare/f0edbb60123249fb349827794c35139340e29dfb...4957613fe2351224fe2b985a642f2551a778313c)

* [`f4bd2c83`](https://github.com/NixOS/nixpkgs/commit/f4bd2c83e909dbb182cf77ac9f2c16e6544ae1f8) nixos/users-groups: Add assert on null shells
* [`6257c8d2`](https://github.com/NixOS/nixpkgs/commit/6257c8d29bc7e23281deea452df3c7546bdb15da) gdmd: init at 0.1.0-unstable-2024-05-30
* [`66571c8e`](https://github.com/NixOS/nixpkgs/commit/66571c8e7d976816fdec05360533a7f6b9abefbe) nixos/phosh: enable services.graphical-desktop
* [`6c0c5b1e`](https://github.com/NixOS/nixpkgs/commit/6c0c5b1e0b3ae740faeb5fbea56a1dfce239eb68) xercesc: 3.2.5 -> 3.3.0
* [`6355db00`](https://github.com/NixOS/nixpkgs/commit/6355db00b220725993c6e483aa972dc46e77e8cf) Mount /dev when creating a VM image from RPMs
* [`14ffa0e5`](https://github.com/NixOS/nixpkgs/commit/14ffa0e572af53f331bd3795715dd68708818352) stirling-pdf: use Gradle 8
* [`e7ce8059`](https://github.com/NixOS/nixpkgs/commit/e7ce805987b885b4d58db07a4cedfd63a4dfd528) qqmusic: init at 1.1.7
* [`e7c21191`](https://github.com/NixOS/nixpkgs/commit/e7c21191edfd80a4dc2d9a59161979f88d816fc7) mmj2: init at 2.5.2-unstable-2023-06-27
* [`e947089d`](https://github.com/NixOS/nixpkgs/commit/e947089d443c07ab6d4370677363dc924b05eda9) beetsPackages.audible: init at 1.0.0
* [`2aae7efa`](https://github.com/NixOS/nixpkgs/commit/2aae7efa83467c55adba880320d000371f5444d0) simulide: don't redeclare in all-packages.nix
* [`0dd34532`](https://github.com/NixOS/nixpkgs/commit/0dd3453251f4e7d0422fc524e809986250d73991) simulide_1_1_0: 1.1.0-SR0 -> 1.1.0-SR1
* [`1169ee8c`](https://github.com/NixOS/nixpkgs/commit/1169ee8c6c0a66a4c3def5f774609f4c30bddfe2) simulide_1_2_0: init at 1.2.0-RC1
* [`efd26167`](https://github.com/NixOS/nixpkgs/commit/efd26167c92e3d88bc541816c0109dd9e29cf902) simulide: set simulide_1_1_0 as default
* [`d1a28bbd`](https://github.com/NixOS/nixpkgs/commit/d1a28bbdb48244f7a3edf027e4c90b6de0bb1bf3) nixos/nginx: add locations."name".uwsgiPass and related options and use it
* [`e14a6521`](https://github.com/NixOS/nixpkgs/commit/e14a65219276f68631090e9630864a9e18a39827) worldpainter: init at 2.23.2
* [`69cb4982`](https://github.com/NixOS/nixpkgs/commit/69cb4982d9f30f42603ce650bdb3d6520d744ea2) mopidy-local: 3.2.1 -> 3.3.0
* [`4cb2498f`](https://github.com/NixOS/nixpkgs/commit/4cb2498f3f180797b47165ad32198b644e3554e8) perlPackages.Tirex: fix build with recent mapnik
* [`54199c86`](https://github.com/NixOS/nixpkgs/commit/54199c86cf14dc6b3fb96ad8071c10469572e3a2) spdx-license-list-data: 3.25.0 -> 3.26.0
* [`29b42bd7`](https://github.com/NixOS/nixpkgs/commit/29b42bd7310ff6a7f33bdd98944dfcf52fa7b0cc) nixos/osquery: fix database_path + logger_path opts per systemd docs
* [`ae48d2c8`](https://github.com/NixOS/nixpkgs/commit/ae48d2c87e4cc74b6ba87d793827856fa20071b3) thttpd: fix build with GCC >= 14
* [`7ba55caf`](https://github.com/NixOS/nixpkgs/commit/7ba55caf754a4959c2072110ffe95a363da453cb) sblim-sfcc: 2.2.9 -> 2.2.8-unstable-2023-06-26
* [`f22692dc`](https://github.com/NixOS/nixpkgs/commit/f22692dc23849201290a935881b573ac81c7a9a6) SDL2_ttf: 2.22.0 -> 2.24.0
* [`8d45fcd4`](https://github.com/NixOS/nixpkgs/commit/8d45fcd45c61586c3a0a9820f089f6e5453775ac) perlPackages.SDL: fix build with GCC 14
* [`93262df2`](https://github.com/NixOS/nixpkgs/commit/93262df2270083d9b4e04e0bddd1e48e304d4a47) fileshare: fix build with GCC 14, misc. cleanup
* [`1f067869`](https://github.com/NixOS/nixpkgs/commit/1f067869e82991ec96b39412d96a23eaf268361d) tt-rss-plugin-freshapi: init at unstable-2024-11-14
* [`0beaadb1`](https://github.com/NixOS/nixpkgs/commit/0beaadb13a0b5766c1a19042f0cdd0c3a7de625e) tigerjython: 2.39 -> 2.40
* [`602583a7`](https://github.com/NixOS/nixpkgs/commit/602583a7203823d97da2880aa3f83f9eb56c6eb4) maintainers: add EmanuelM153
* [`c4da4930`](https://github.com/NixOS/nixpkgs/commit/c4da49304055b9270c682a2206e1557a8872f254) python312Packages.peblar: init at 0.3.3
* [`e2320adf`](https://github.com/NixOS/nixpkgs/commit/e2320adf506674a3d3c77f3b705855250c011fc2) home-assistant: update component-packages
* [`391398af`](https://github.com/NixOS/nixpkgs/commit/391398af520e8ff1b7ec854c42bb9f268af3b91d) add network-online dependency to netclient module to get rid of warning
* [`a21afd41`](https://github.com/NixOS/nixpkgs/commit/a21afd414245559e3a1310be92d1928c73c3b4c4) tmuxPlugins.tmux-sessionx: init at 0-unstable-2024-09-22
* [`93559749`](https://github.com/NixOS/nixpkgs/commit/93559749834b579f38f2cc10f4fc2e2ef9d7d616) maintainers: add okwilkins
* [`42c0aeb9`](https://github.com/NixOS/nixpkgs/commit/42c0aeb9b75305a4bf2277c8b46ae7885cd92e2f) apacheHttpdPackages.mod_python: 3.5.0.2 -> 3.5.0.4
* [`576a0754`](https://github.com/NixOS/nixpkgs/commit/576a0754c8185cc766022059d542eff1a90bc37b) maintainers: add jolars
* [`d810e9e9`](https://github.com/NixOS/nixpkgs/commit/d810e9e936624d5f3d3e0acb5cca43f7853896b6) snakefmt: init at 0.10.2
* [`8adfe0f8`](https://github.com/NixOS/nixpkgs/commit/8adfe0f8350c7e6e69175daf0bd4394027d23828) paho-mqtt-c: 1.3.13 -> 1.3.14
* [`53ab149d`](https://github.com/NixOS/nixpkgs/commit/53ab149dc75c368282804d3bd99385ad29c78a17) rpcs3: 0.0.34-17265-418a99a62 -> 0.0.34-17323-92d070729
* [`f83cf62e`](https://github.com/NixOS/nixpkgs/commit/f83cf62e2330d239592e8d36513d630b2d4c0c52) paho-mqtt-c: modernize
* [`f8158e82`](https://github.com/NixOS/nixpkgs/commit/f8158e825bc57de45b2afc9a7aa4da90c08c45b8) spacenavd: 1.3 -> 1.3.1
* [`6f23ec73`](https://github.com/NixOS/nixpkgs/commit/6f23ec73235149273bd67ce78b69972af2846978) nixos/hostapd: run nixfmt-rfc-style
* [`19e38587`](https://github.com/NixOS/nixpkgs/commit/19e38587b2c0f19d9605ede8b74ca3f45ee152ac) nixos/hostapd: run nixfmt-rfc-stylenixos/hostapd: add `passwordFile` option for structured sae password settings
* [`fac2647f`](https://github.com/NixOS/nixpkgs/commit/fac2647fdfaa502931b9539dc6cd78aab91c07d0) xdg-desktop-portal-gtk: 1.15.1 -> 1.15.2
* [`9fa82861`](https://github.com/NixOS/nixpkgs/commit/9fa828614a1c666c4244e892ce64a153cfd19bc7) finamp: 0.9.12-beta -> 0.9.13-beta
* [`55fd2e6e`](https://github.com/NixOS/nixpkgs/commit/55fd2e6ebf0ccdaf3d00e73c64414a217f1e4564) zgv: fix GCC 14 build
* [`1671ec91`](https://github.com/NixOS/nixpkgs/commit/1671ec916941bdedcb00465624c375ca36ce4d29) pugixml: 1.14 -> 1.15
* [`2c47cfa4`](https://github.com/NixOS/nixpkgs/commit/2c47cfa4ed05b293d81fab6f9132662297b38628) pgbouncer: 1.23.1 -> 1.24.0
* [`15205620`](https://github.com/NixOS/nixpkgs/commit/152056209b1c5adea1308aaa0fcee3d955f9eeb0) irpf: 2024-1.5 -> 2024-1.6
* [`362ab3da`](https://github.com/NixOS/nixpkgs/commit/362ab3dacdcdfbc20e6b868525a328fae08bbe3c) imgbrd-grabber: 7.12.2 -> 7.13.0
* [`1bd30bda`](https://github.com/NixOS/nixpkgs/commit/1bd30bda66702486e654dd7310a77d71d18130f3) open-adventure: init at 1.20
* [`c0e8ae25`](https://github.com/NixOS/nixpkgs/commit/c0e8ae2591696c2a5fbf8fc0ff9cfed4797fbe4c) pysolfc: 3.1.0 -> 3.2.0
* [`6cab8a3e`](https://github.com/NixOS/nixpkgs/commit/6cab8a3e045bf3350b326f3d349ef7ca95d37114) evolution-ews: 3.54.2 -> 3.54.3.0
* [`303a115d`](https://github.com/NixOS/nixpkgs/commit/303a115d49bdce287885deaedae8abd186bd4936) python312Packages.sqlalchemy-json: refactor
* [`490d6ecd`](https://github.com/NixOS/nixpkgs/commit/490d6ecdf9c073fddc00f9ad2dac06889db9298a) ocamlPackages.miou: 0.3.0 -> 0.3.1
* [`b8fea704`](https://github.com/NixOS/nixpkgs/commit/b8fea7045c85333047cf57a82cfdb16ee8ba352f) dxx-rebirth: 0.60.0-beta2-unstable-2024-12-07 -> 0.60.0-beta2-unstable-2025-01-12
* [`2d1609b0`](https://github.com/NixOS/nixpkgs/commit/2d1609b0ef74cbdeeb69242a1bcb14196fc5b91c) armTrustedFirmwareTools: 2.10.0 -> 2.12.0
* [`3dd58b0b`](https://github.com/NixOS/nixpkgs/commit/3dd58b0beeeb5eb055b4f86dcc98d101c958818b) opensc: fix strictDeps build
* [`394f6fe0`](https://github.com/NixOS/nixpkgs/commit/394f6fe075cd62459f0473908a0af1e5cea841b1) qtox: 1.18.0 -> 1.18.2
* [`5892745d`](https://github.com/NixOS/nixpkgs/commit/5892745d1360f0c5b72c720a600c059a6a61781c) authentik: sentry-sdk -> sentry-sdk_2
* [`f00f508b`](https://github.com/NixOS/nixpkgs/commit/f00f508bdb5ba9c23669ce1dae0d5a6ad64d7e6d) nixos/soju: add option to overwrite generated configFile
* [`fc5f292e`](https://github.com/NixOS/nixpkgs/commit/fc5f292eef5987c67bb6b9abe27b36f23db272c0) pugixml: modernize
* [`cf14b5d6`](https://github.com/NixOS/nixpkgs/commit/cf14b5d63b3e9f6174da80510bcda863c85e89ec) inxi: 3.3.35-1 -> 3.3.37-1
* [`1da907e6`](https://github.com/NixOS/nixpkgs/commit/1da907e6d39cc3d32e8408a5f863fad3f5e43c5d) ocamlPackages.spdx_licenses: 1.2.0 -> 1.3.0
* [`659babe8`](https://github.com/NixOS/nixpkgs/commit/659babe816692bc60588a205608599fad5ef5767) python312Packages.jax-cuda12-pjrt: add missing cuda libraries
* [`9bd08f04`](https://github.com/NixOS/nixpkgs/commit/9bd08f040ed9ce929f90314e4461e93b97872e51) python3Packages.jax-cuda12-plugin: patch like jax-cuda12-pjrt
* [`17b79646`](https://github.com/NixOS/nixpkgs/commit/17b79646e2648e36d234021233ce8c8bc342cd75) python3Packages.jax: remove outdated longDescription
* [`e0aadd10`](https://github.com/NixOS/nixpkgs/commit/e0aadd1072a7247737c575eec2ff334c1a3c5544) libdevil: move to openexr_3
* [`5890cd90`](https://github.com/NixOS/nixpkgs/commit/5890cd9043cf3074d38fc8433fa20861e5d017bd) ocamlPackages.ocaml_sqlite3: 5.2.0 -> 5.3.0
* [`61cc8b99`](https://github.com/NixOS/nixpkgs/commit/61cc8b99aa2501d36fb0cfc92029f41a97b711a6) brainflow: 5.15.0 -> 5.16.0
* [`d5f1d13d`](https://github.com/NixOS/nixpkgs/commit/d5f1d13dc22b9866a57512959f6b713cd19c339c) loopwm: 1.1.1 -> 1.2.0
* [`9ffa0a59`](https://github.com/NixOS/nixpkgs/commit/9ffa0a5945cc7f3fc668ab4d353c3459166bcdef) nixos/tests/nextcloud: test for notify_push in with-declarative-redis-and-secrets
* [`598ba392`](https://github.com/NixOS/nixpkgs/commit/598ba3922cc17aadb35d19534285fbd09ab2fcac) nixos/nextcloud: use writeShellApplication for nextcloud-occ
* [`e6b07898`](https://github.com/NixOS/nixpkgs/commit/e6b078981b0b6a0a45468d6881a06e957e2e57e6) nixos/nextcloud: move systemd service overrides for phpfpm-nextcloud closer to phpfpm config
* [`2ce1e841`](https://github.com/NixOS/nixpkgs/commit/2ce1e841032eac4913f2cd3dce416da3d5c799ef) nixos/nextcloud: use LoadCredential to read secrets
* [`18de1c26`](https://github.com/NixOS/nixpkgs/commit/18de1c264ec53c07da9241b2a07775ff2cc8434a) nixos/tests/nextcloud: use lib instead of pkgs.lib wherever trivial
* [`549d8a6d`](https://github.com/NixOS/nixpkgs/commit/549d8a6d44b9a4462428c932286a9c16b7975f54) nixos/tests/nextcloud: fix redis cache non empty tests
* [`3d290927`](https://github.com/NixOS/nixpkgs/commit/3d29092753fac7499478b77f38aea30e441adc73) ocamlPackages.ocaml-version: 3.7.2 -> 3.7.3
* [`b4481aeb`](https://github.com/NixOS/nixpkgs/commit/b4481aebc5b6e25c9ec321fb97d1da505a5d62df) graalvmPackages.graaljs: 24.1.1 -> 24.1.2
* [`13d30d31`](https://github.com/NixOS/nixpkgs/commit/13d30d31a976fba3aadd2afb5a7ade4221c9431f) sweethome3d: rename `default.nix` to `linux.nix`
* [`50415274`](https://github.com/NixOS/nixpkgs/commit/50415274585401e4614d61306fdcf083c289c0e1) pingvin-share: 1.8.1 -> 1.8.2
* [`8583a0de`](https://github.com/NixOS/nixpkgs/commit/8583a0de6f3d57e4fc2d64b59de1ccdb7ee3301e) nixos/nextcloud: document systemd credentials as a backwards incompatible change in the 25.05 release notes
* [`5356b1a5`](https://github.com/NixOS/nixpkgs/commit/5356b1a56bee6eb9e6fbf4a1ec94c31af933fc06) minify: 2.21.2 -> 2.21.3
* [`ef350156`](https://github.com/NixOS/nixpkgs/commit/ef3501569bc1aebc1b9908631a9900051b246085) prometheus-pve-exporter: 3.4.7 -> 3.5.1
* [`92d43657`](https://github.com/NixOS/nixpkgs/commit/92d43657bfbb5bfd37c204bb639fd49b855ca362) graalvmPackages.truffleruby: 24.1.1 -> 24.1.2
* [`fde5b228`](https://github.com/NixOS/nixpkgs/commit/fde5b228873b62cd33368efca375225fe9e22a27) graalvmPackages.graalpy: 24.1.1 -> 24.1.2
* [`2eb68947`](https://github.com/NixOS/nixpkgs/commit/2eb68947d3ae7fe16ea342def65539180faf47b8) graalvmPackages.graalnodejs: 24.1.1 -> 24.1.2
* [`cf69ff82`](https://github.com/NixOS/nixpkgs/commit/cf69ff82653dd459418f93ad2903eda8dc0bbdfe) newlib-nano: Fix build
* [`a67e49cb`](https://github.com/NixOS/nixpkgs/commit/a67e49cb831e87dca239e9002252e482b02c31f5) neovim-qt-unwrapped: 0.2.18 -> 0.2.19
* [`60ecc05e`](https://github.com/NixOS/nixpkgs/commit/60ecc05efe0360e7d92f848a96c3136f47c7683f) ocamlPackages.gen_js_api: 1.1.3 -> 1.1.4
* [`e64437c7`](https://github.com/NixOS/nixpkgs/commit/e64437c75ea87b1da1b83ec410821c4026aa11b5) pidgin: 2.14.13 -> 2.14.14
* [`a674d9be`](https://github.com/NixOS/nixpkgs/commit/a674d9be7ce6b6500467b238d9a46ea1327962ce) metacubexd: 1.176.1 -> 1.176.2
* [`ab66c4d9`](https://github.com/NixOS/nixpkgs/commit/ab66c4d9f95a68081956f82e16f36fc00b1db4df) catboost: use llvm 14 for cuda
* [`2f9da746`](https://github.com/NixOS/nixpkgs/commit/2f9da746fed71b80949a916fdbf6fb57aea330f1) ocamlPackages.tezt: 4.1.0 -> 4.2.0
* [`db96f5bf`](https://github.com/NixOS/nixpkgs/commit/db96f5bfc44dca23bacebdd04cb3bc93c6189a62) osquery: 5.14.1 -> 5.15.0
* [`201f2771`](https://github.com/NixOS/nixpkgs/commit/201f27715e71d51df97569fcb3e224451a8ffb2a) network: make network-setup service do not depend on udevd directly; fix typo with GRE tunnels
* [`2ee6dd35`](https://github.com/NixOS/nixpkgs/commit/2ee6dd35b83c8ce8db087f8652eecb22f0dff57c) python312Packages.pyphen: 0.17.0 -> 0.17.2
* [`705289bf`](https://github.com/NixOS/nixpkgs/commit/705289bf705f5edb1d1065e1a98227cb401c1983) prusa-slicer: patch curl version checks
* [`b5bf515e`](https://github.com/NixOS/nixpkgs/commit/b5bf515e8569bdcd47ca7d3546a65026fa8680c4) lyx: 2.4.2.1 -> 2.4.3
* [`9ed89a0a`](https://github.com/NixOS/nixpkgs/commit/9ed89a0a6d1ce8019485a242ef172f42b6cb2b39) socket_wrapper: 1.4.3 -> 1.4.4
* [`66200fb0`](https://github.com/NixOS/nixpkgs/commit/66200fb07eda2efa0d89dbd148ed9da16b1fceb5) osinfo-db: 20240701 -> 20250124
* [`dc12443c`](https://github.com/NixOS/nixpkgs/commit/dc12443c1e53ce625bd5cd59547ed7c5e603a043) kpcli: 4.1.2 -> 4.1.3
* [`066f62aa`](https://github.com/NixOS/nixpkgs/commit/066f62aa43eeec4bc6268b24b99cea7e4a0f688b) diamond: 2.1.10 -> 2.1.11
* [`0a654e75`](https://github.com/NixOS/nixpkgs/commit/0a654e7585370602f242f93252cf993bce7cd372) freetds: 1.4.24 -> 1.4.26
* [`247fef29`](https://github.com/NixOS/nixpkgs/commit/247fef296b4546ee3b130946b2d24e3e5de6f90e) jbang: 0.122.0 -> 0.123.0
* [`17bae968`](https://github.com/NixOS/nixpkgs/commit/17bae9683ede9ae215acb0cb633f1ebeb794bb08) vkquake: 1.31.3 -> 1.32.0
* [`be1df66c`](https://github.com/NixOS/nixpkgs/commit/be1df66c9dbf0ed6807aa3b0a2bf70654e772dbd) argparse: 3.1 -> 3.2
* [`55831434`](https://github.com/NixOS/nixpkgs/commit/558314344fbfaceee80b58a7f60bede77a491a06) f2fs-tools: backport upstream C23 fix
* [`8151f40a`](https://github.com/NixOS/nixpkgs/commit/8151f40abc9904c14a980af90b592eb4afafac40) python312Packages.blake3: 1.0.2 -> 1.0.4
* [`00bcf9d7`](https://github.com/NixOS/nixpkgs/commit/00bcf9d7726a8a38afdbc4619c8e074bd00b1c12) clash-rs: adopt
* [`7b24e1e0`](https://github.com/NixOS/nixpkgs/commit/7b24e1e0fed0f94698cc9ee0ef58a97597af22ed) whistle: 2.9.93 -> 2.9.94
* [`71bee16c`](https://github.com/NixOS/nixpkgs/commit/71bee16c3088f4dcb8714c1f5d1c46493c5d0b01) zabbix.proxy: add curl
* [`ed3e064d`](https://github.com/NixOS/nixpkgs/commit/ed3e064d3b767300e54154ce1f971bba7bdd321d) megasync: 5.6.1.0 -> 5.7.1.0
* [`c7951199`](https://github.com/NixOS/nixpkgs/commit/c7951199092983184054c42ccffbc9c61bc266ec) parallel-hashmap: 1.4.1 -> 2.0.0
* [`61a05336`](https://github.com/NixOS/nixpkgs/commit/61a05336ef3d12990282ddd81c7007da57573aca) semgrep{,-core}: 1.74.0 -> 1.104.0
* [`ec8f90c9`](https://github.com/NixOS/nixpkgs/commit/ec8f90c9ed8b639fb9f23b8ea3735efd244bfb41) converseen: 0.12.2.4 -> 0.12.2.5
* [`a21fefe1`](https://github.com/NixOS/nixpkgs/commit/a21fefe1b6f6b57efee24c41695ed4e603d7fd64) rootlesskit: 2.3.1 -> 2.3.2
* [`f8a89970`](https://github.com/NixOS/nixpkgs/commit/f8a8997007ff678cfb4c62dd3bc40edbf89d4f6a) cvc5: 1.2.0 -> 1.2.1
* [`bee5c5f4`](https://github.com/NixOS/nixpkgs/commit/bee5c5f4db64f7890c3f64ae291bdb5930b5e95f) python312Packages.berkeleydb: 18.1.12 -> 18.1.13
* [`17b3ef77`](https://github.com/NixOS/nixpkgs/commit/17b3ef77f0b2a9072665eb3b88989b8dbc503d6a) cri-o: 1.31.3 -> 1.32.0
* [`c8da9eb6`](https://github.com/NixOS/nixpkgs/commit/c8da9eb6d4137ac419b0a66374252ec7ee5f77d2) lynis: 3.1.3 -> 3.1.4
* [`b34d268c`](https://github.com/NixOS/nixpkgs/commit/b34d268c919704b3bdf7971670da1401434a127a) tvm: 0.17.0 -> 0.19.0
* [`e341ccc1`](https://github.com/NixOS/nixpkgs/commit/e341ccc14570e6d473f2437b6298cf6af4bd0a00) sickgear: 3.32.15 -> 3.33.2
* [`bac390a1`](https://github.com/NixOS/nixpkgs/commit/bac390a1ecc13f036318f02c99ac04bd5241337b) kazumi: 1.5.1 -> 1.5.4
* [`3fcc905d`](https://github.com/NixOS/nixpkgs/commit/3fcc905d877a733fe92240498b9898a1afeec2bb) python312Packages.ansible-core: 2.18.1 -> 2.18.2
* [`4da0e1d3`](https://github.com/NixOS/nixpkgs/commit/4da0e1d3632e7528621c2743f7f13dd49dffbf0a) confy: 0.7.1 -> 0.8.0
* [`5dce3f0a`](https://github.com/NixOS/nixpkgs/commit/5dce3f0a1f400a44986f1971275eddc64e8f3264) python312Packages.pyworld: 0.3.4 -> 0.3.5
* [`84c9dd39`](https://github.com/NixOS/nixpkgs/commit/84c9dd39ee2302d226bcb9db0324d92fd394d459) zsh-wd: 0.9.2 -> 0.9.3
* [`c45c1d39`](https://github.com/NixOS/nixpkgs/commit/c45c1d39db27a34749f3278932a4f8bd239cf17b) mitama-cpp-result: 10.0.4 -> 11.0.0
* [`5ef45827`](https://github.com/NixOS/nixpkgs/commit/5ef4582726d330f07e7c53208e187cb73384cbb1) python312Packages.jsonconversion: 1.0.2 -> 1.1.1
* [`f05962d7`](https://github.com/NixOS/nixpkgs/commit/f05962d7fc11a4c9daf232b3b79a5bad53df1879) archtika: init at 1.0.1
* [`9abdf723`](https://github.com/NixOS/nixpkgs/commit/9abdf7235ff7765b0bfcaa740ae5b931dd84240e) vscode-extensions.github.codespaces: 1.16.9 -> 1.17.3
* [`95d113d9`](https://github.com/NixOS/nixpkgs/commit/95d113d9ea011ea8726a0a5e647b83272f09af47) libslirp: 4.8.0 -> 4.9.0
* [`33662aec`](https://github.com/NixOS/nixpkgs/commit/33662aec644733a41ed5330dd929f1f0866ea761) python312Packages.brian2: 2.8.0 -> 2.8.0.4
* [`0558ef36`](https://github.com/NixOS/nixpkgs/commit/0558ef36600f8ce09156615ceac69f6db82dad58) python312Packages.axisregistry: 0.4.11 -> 0.4.12
* [`6b09037d`](https://github.com/NixOS/nixpkgs/commit/6b09037d9554b22a80358dc5e70d849a4c398b5e) python312Packages.pylsp-mypy: 0.6.9 -> 0.7.0
* [`ca2d5e14`](https://github.com/NixOS/nixpkgs/commit/ca2d5e1485f6697610c8b9144066111e94191b57) python312Packages.karton-core: 5.5.1 -> 5.6.0
* [`4727c8aa`](https://github.com/NixOS/nixpkgs/commit/4727c8aa842290fd27f09473e54adf5777b20a7a) python312Packages.atlassian-python-api: 3.41.16 -> 3.41.19
* [`313735bf`](https://github.com/NixOS/nixpkgs/commit/313735bf51a70854ad1227002ba629fda805c7f3) python312Packages.mockito: 1.5.3 -> 1.5.4
* [`67302a21`](https://github.com/NixOS/nixpkgs/commit/67302a21ae9cb0865c80965ec898122b6879d008) maintainers: add kpbaks
* [`62faa8bc`](https://github.com/NixOS/nixpkgs/commit/62faa8bc50651d7d6a5e1b451bab2dfc98ba79eb) python312Packages.openstep-plist: 0.4.0 -> 0.5.0
* [`14319787`](https://github.com/NixOS/nixpkgs/commit/1431978735c1d46e7293b5c132d71227cc41b767) flaci: init at 0-unstable-2024-12-10
* [`db981947`](https://github.com/NixOS/nixpkgs/commit/db981947e356d5009555e09a75e6bdb33a56502e) llvmPackages_18.lldbPlugins.llef: 1.2.0 -> 1.2.1
* [`db1e38a5`](https://github.com/NixOS/nixpkgs/commit/db1e38a5c5165c2ad15e9199c6f86b30f77a78ae) python312Packages.glyphslib: 6.9.5 -> 6.10.1
* [`926bb427`](https://github.com/NixOS/nixpkgs/commit/926bb4273e564ef15a4e55811f370ef3d331d311) parted: backport upstream C23 fix
* [`fa3cb966`](https://github.com/NixOS/nixpkgs/commit/fa3cb966a91b715d7ffdba43e3957236ad7fd891) parted: enable parallel building and testing
* [`6b494066`](https://github.com/NixOS/nixpkgs/commit/6b4940663030cb09c397aba152e5a32f9fafd25e) g2o: 20230806 -> 20241228
* [`7eba8431`](https://github.com/NixOS/nixpkgs/commit/7eba8431429cf65c42a50938bfe1bd7ee76cd77a) fasmg: kl0e -> kp60
* [`1dd23b5d`](https://github.com/NixOS/nixpkgs/commit/1dd23b5d74525ec5a093d43f73535a94aa5a9c86) nixos/user-groups: add a toggle for user account creation
* [`d36a3641`](https://github.com/NixOS/nixpkgs/commit/d36a3641485ae31f7e773323030bc4a04dc5e8a0) nixos/tests: add user-enable-option
* [`813244ed`](https://github.com/NixOS/nixpkgs/commit/813244ed0ff412ebc702dbe8b815f37b3144dda9) nixos/userborn: filter enabled users
* [`65bb3bc8`](https://github.com/NixOS/nixpkgs/commit/65bb3bc8656f058fbc20a92e9a4b90003695559d) mujs: 1.3.5 -> 1.3.6
* [`8e839dac`](https://github.com/NixOS/nixpkgs/commit/8e839dac4c434c6fe6db9b15a511a275c79a455a) tandoor-recipes: 1.5.29 -> 1.5.31
* [`dd1d577a`](https://github.com/NixOS/nixpkgs/commit/dd1d577ac3b3b952bfebf846ecb61da6c48135d3) mesa: backport dril patch that fixes xf86videointel
* [`c103e585`](https://github.com/NixOS/nixpkgs/commit/c103e585af9cb8a3077d137c032df95bc4b65594) re-add and update xf86videointel driver
* [`f9c16aa4`](https://github.com/NixOS/nixpkgs/commit/f9c16aa4768850e24021d1ae684125177c8ebfe3) python3Packages.jax: add operations to cuda test
* [`8f5c5900`](https://github.com/NixOS/nixpkgs/commit/8f5c59005391d11f93ca9c26f613b08fb4e27930) maintainers: add wrvsrx
* [`6bd323bf`](https://github.com/NixOS/nixpkgs/commit/6bd323bfd77c46f434779d029162fdb910d04599) super-productivity: 10.0.11 -> 11.1.2
* [`57dae198`](https://github.com/NixOS/nixpkgs/commit/57dae198289717a1836c264d25321f4ac63e22a7) golink: 0-unstable-2024-01-26 -> 1.0.0
* [`054ff11b`](https://github.com/NixOS/nixpkgs/commit/054ff11ba228836d9fd58e18e3382d7016d32d0b) maintainers: add wenjinnn
* [`00a218ab`](https://github.com/NixOS/nixpkgs/commit/00a218abb2d469f2a4cd4b2721b24b0dcfdb8cd1) mkBinaryCache: support different compression methods: xz (default), zstd, none
* [`1fd7ca74`](https://github.com/NixOS/nixpkgs/commit/1fd7ca74dfc7ca6564c74e46a9fac7639d9b16d2) re-flex: 5.1.1 -> 5.2.2
* [`b4e50bb2`](https://github.com/NixOS/nixpkgs/commit/b4e50bb2931539bb9659078f902ffd939bd0a6b5) rdfind: 1.6.0 -> 1.7.0
* [`766ca46a`](https://github.com/NixOS/nixpkgs/commit/766ca46a6e233573d13b977a96c7a2409e560567) gpu-screen-recorder-gtk: 5.0.0 -> 5.1.2
* [`09b2a1dc`](https://github.com/NixOS/nixpkgs/commit/09b2a1dccce7267d4eddd49a81fee1b0ca71a858) epson_201207w: 1.0.0 -> 1.0.1
* [`960b2f6d`](https://github.com/NixOS/nixpkgs/commit/960b2f6d055a21f0d11f5d124e4a38a5f7ed5df7) armTrustedFirmwareTools: fix build issues
* [`93426690`](https://github.com/NixOS/nixpkgs/commit/93426690040b825f67aa95956827d4619e7d64fb) armTrustedFirmwareTools: reformat with nixfmt
* [`b1218ce2`](https://github.com/NixOS/nixpkgs/commit/b1218ce254c81316f384d5c95c49a00493e29999) hylafaxplus: use `finalAttrs` pattern
* [`cc4b18c5`](https://github.com/NixOS/nixpkgs/commit/cc4b18c542c706a7a380510d2a0811eab908d400) hylafaxplus: enable parallel building
* [`61740d37`](https://github.com/NixOS/nixpkgs/commit/61740d3793062aafc8598f443566d6d0aa217e55) hylafaxplus: 7.0.9 -> 7.0.10
* [`8378491d`](https://github.com/NixOS/nixpkgs/commit/8378491df3d5e6c1187d738130ef70ae2ba8a50b) nixos/hylafax: unify `lib` imports
* [`455c195f`](https://github.com/NixOS/nixpkgs/commit/455c195fe4522173694f3a30f3fa214c2aa4a5d1) nixos/hylafax: use `getExe'`
* [`6e51b487`](https://github.com/NixOS/nixpkgs/commit/6e51b48777e7b57e1058eb4c99539f3ec85c1a9e) nixos/hylafax: use `concatLines`
* [`eb52347d`](https://github.com/NixOS/nixpkgs/commit/eb52347d8c59fc17dcf9b648d6e8f2408cde6f2b) nixos/hylafax: use `toGNUCommandLine`
* [`39003ad9`](https://github.com/NixOS/nixpkgs/commit/39003ad9d710b302376ba9d201a495a1e32676ae) nixos/hylafax: add `package` option
* [`8723d0f7`](https://github.com/NixOS/nixpkgs/commit/8723d0f793c6ee9fb756b9d5d0d70151420c95cc) rosegarden: 24.12 -> 24.12.1
* [`74e0178d`](https://github.com/NixOS/nixpkgs/commit/74e0178dee9c2ec59cc86c0ed6c4be68e5408a3d) rotonda: 0.2.1 -> 0.3.0
* [`4958f38b`](https://github.com/NixOS/nixpkgs/commit/4958f38b3851ab675408a30547c298a64ffc2e21) Add fetchpatch dependency
* [`d5f3dfe3`](https://github.com/NixOS/nixpkgs/commit/d5f3dfe32784636379194bfd09e3fa439573a0a8) tdb: 1.4.12 -> 1.4.13
* [`5f7664a5`](https://github.com/NixOS/nixpkgs/commit/5f7664a53b51869d300e13f8d05a7aa2f3c06582) nixos/archtika: init module
* [`6a601965`](https://github.com/NixOS/nixpkgs/commit/6a601965e5975dc686e0412a6c592b87ade08fdf) maintainers: add thiloho
* [`6e9f32c2`](https://github.com/NixOS/nixpkgs/commit/6e9f32c27f55574b6c55a6e4608d3cd1517f07ef) python312Packages.habanero: 2.0.0 -> 2.2.0
* [`30cb36ef`](https://github.com/NixOS/nixpkgs/commit/30cb36ef220fc64598c906148e287ab84672ac38) python312Packages.pytest-playwright: 0.6.2 -> 0.7.0
* [`f5d26663`](https://github.com/NixOS/nixpkgs/commit/f5d266635a14eb97933950a474c4189f61a3af33) dovecot_fts_xapian: 1.8.4 -> 1.9
* [`fcb54a3a`](https://github.com/NixOS/nixpkgs/commit/fcb54a3abd9472fbf9fa12b08877106005bc948c) talloc: 2.4.2 -> 2.4.3
* [`eae349ff`](https://github.com/NixOS/nixpkgs/commit/eae349ff91aadd51d00c44c1a4b19a2238f619ce) entr: 5.6 -> 5.7
* [`c71535b8`](https://github.com/NixOS/nixpkgs/commit/c71535b85dedd0e7fb20678ba1206156a269c994) maintainers: add monkieeboi
* [`10e92c18`](https://github.com/NixOS/nixpkgs/commit/10e92c1832132e1a52735508ccdcdd8728f21884) part-db: init at 1.14.5
* [`8cd960c4`](https://github.com/NixOS/nixpkgs/commit/8cd960c4db0fb61b8a25d2f60d89afe3b10716c4) top-git: 0.19.13 -> 0.19.14
* [`594df168`](https://github.com/NixOS/nixpkgs/commit/594df16873bb6d3bb6b5846f2bc33727b73a025d) nco: 5.3.0 -> 5.3.2
* [`f2ac05ce`](https://github.com/NixOS/nixpkgs/commit/f2ac05ced6e912ca74d72f69f10897ce89ea4c05) 1password-cli: define nativeBuildInputs properly
* [`54e699dd`](https://github.com/NixOS/nixpkgs/commit/54e699dd67e244de3c6bb02b8b2e6b6305255606) bigpemu: 1.17 -> 1.18, fix metadata
* [`fa412119`](https://github.com/NixOS/nixpkgs/commit/fa41211913acbfb8daccdad5a4ba4513276c3131) SDL2_mixer: 2.8.0 -> 2.8.1
* [`f5eda5a8`](https://github.com/NixOS/nixpkgs/commit/f5eda5a823ca8d17cf749657ed67bdcac8386ac7) wasmi: 0.31.0 -> 0.40.0, useFetchCargoVendor, use nix-update-script
* [`f6e3ec6f`](https://github.com/NixOS/nixpkgs/commit/f6e3ec6f192e46794d1cfee74b792805b549e432) terraform-local: 0.20.0 -> 0.20.1
* [`fd367461`](https://github.com/NixOS/nixpkgs/commit/fd367461233060f084814a6b1ecdc3e3a9e8a6a0) python312Packages.ansible: 11.1.0 -> 11.2.0
* [`20a94263`](https://github.com/NixOS/nixpkgs/commit/20a94263c1e93b74875e238e052d2df84c8a52bb) snd: 25.0 -> 25.1
* [`395316bf`](https://github.com/NixOS/nixpkgs/commit/395316bf3a67ec4a78f4f81a88fdc534d99c6cd7) mmex: 1.8.1 -> 1.9.0
* [`5bfe54b3`](https://github.com/NixOS/nixpkgs/commit/5bfe54b3a1df5f291cf7507e5676ff614a368497) iosevka-bin: 32.4.0 -> 32.5.0
* [`a528f04c`](https://github.com/NixOS/nixpkgs/commit/a528f04cd4fad737bbf28c7933258a8c991ebb19) clojure: 1.12.0.1495 -> 1.12.0.1517
* [`21044229`](https://github.com/NixOS/nixpkgs/commit/2104422985fa1b000e838ad0ffba3597f6af4032) sweethome3d: add darwin support
* [`8cf2863a`](https://github.com/NixOS/nixpkgs/commit/8cf2863ab8dfed80f696b9ce6b7081b846b60792) sweethome3d: format `linux.nix`
* [`a02b96e2`](https://github.com/NixOS/nixpkgs/commit/a02b96e22237594d4a837035a85ab8722666572c) liboggz: 1.1.1 -> 1.1.2
* [`9b6fddee`](https://github.com/NixOS/nixpkgs/commit/9b6fddeeef7a76ee53d15a2d3121e1c09a3a7eae) pipeline: 2.1.0 -> 2.1.1
* [`7660fca7`](https://github.com/NixOS/nixpkgs/commit/7660fca7e3c9782120b599742b5a8c1b8f77e8d7) simple-completion-language-server: init at version 0-unstable-2025-01-31
* [`06141eb5`](https://github.com/NixOS/nixpkgs/commit/06141eb5ab9694f5def0e11c0bc7c47a756aefd5) grml-zsh-config: 0.19.12 -> 0.19.14
* [`2f76c052`](https://github.com/NixOS/nixpkgs/commit/2f76c052df6da107623dae1f8c037eb0df4eaa9d) python312Packages.cssbeautifier: 1.15.1 -> 1.15.2
* [`5a0ba5bb`](https://github.com/NixOS/nixpkgs/commit/5a0ba5bb9646d7f001d0999b629e20bc2b84c38b) gegl: 0.4.52 -> 0.4.54
* [`46296f5f`](https://github.com/NixOS/nixpkgs/commit/46296f5fa4e34012d7c3ebd03a6f03a15c86168d) qtractor: 1.5.2 -> 1.5.3
* [`57fcc948`](https://github.com/NixOS/nixpkgs/commit/57fcc948ae882f8d0853082cc18b316950185b85) paho-mqtt-cpp: 1.4.1 → 1.5.1
* [`db525b01`](https://github.com/NixOS/nixpkgs/commit/db525b0197942b5ddf8b0c66ede21952d9f36f61) python312Packages.boltztrap2: 24.9.4 -> 25.2.1
* [`ee92bcfe`](https://github.com/NixOS/nixpkgs/commit/ee92bcfed7febcbecb838819d393dd9d652a001c) moodle: 4.5.1 -> 4.5.2
* [`28b1005a`](https://github.com/NixOS/nixpkgs/commit/28b1005a573f67a9dd7c0f9b853acbbbe444f6a1) python312Packages.cwcwidth: 0.1.9 -> 0.1.10
* [`dbd31d47`](https://github.com/NixOS/nixpkgs/commit/dbd31d478b76ca5bc27b0db76a2f602a55e7e334) subversion: remove obsolete Darwin cruft
* [`6d9d6455`](https://github.com/NixOS/nixpkgs/commit/6d9d6455c4b896d3e39e8d10cccf55cdc91ddadc) cockatrice: 2023-09-14-Release-2.9.0 -> 2025-02-10-Release-2.10.0
* [`04e5f1d3`](https://github.com/NixOS/nixpkgs/commit/04e5f1d3f79a33de38da2ea50cd4fade26e4bfc1) castxml: 0.6.10 -> 0.6.11
* [`f2d31558`](https://github.com/NixOS/nixpkgs/commit/f2d31558b8d44a6971a9b9b9b104924582d07f9e) ceph: 19.2.0 -> 19.2.1
* [`4f1d0a11`](https://github.com/NixOS/nixpkgs/commit/4f1d0a11ae03a0f8fe513882100fcd69fa5def20) hyprlandPlugins.hyprsplit: 0.47.0 -> 0.47.2
* [`99ab2288`](https://github.com/NixOS/nixpkgs/commit/99ab228827cc704a6154af5e7f08f4d44b6c54a1) linux-manual: remove use of rec
* [`0b0485e7`](https://github.com/NixOS/nixpkgs/commit/0b0485e729fffd8421dc1c95d5dc71335fb73f03) linux-manual: remove use of with lib;
* [`9b19af17`](https://github.com/NixOS/nixpkgs/commit/9b19af176f07cec7089937a3419889fbae8eb4ac) linux-manual: define meta.platforms
* [`192ae83b`](https://github.com/NixOS/nixpkgs/commit/192ae83bd19b3a8fa70da2b41d955d3b87d025c8) linux-manual: rely on SOURCE_DATE_EPOCH instead of stat
* [`0f8ba00a`](https://github.com/NixOS/nixpkgs/commit/0f8ba00a48480b171756be86a412b13a3d552800) linux-manual: properly quote all shell expansions
* [`b26abf80`](https://github.com/NixOS/nixpkgs/commit/b26abf80023b96d4aaf8dbbabee23b915a5538e5) linux-manual: call pre / post hooks
* [`884b4116`](https://github.com/NixOS/nixpkgs/commit/884b4116d26aadd24ff0616bdee847eb21d69b23) linux-manual: provide simple installation check
* [`c256d7b5`](https://github.com/NixOS/nixpkgs/commit/c256d7b5ecd90d2a12ff6de378bdcb6c6607afbe) nixos/k3s: use dynamic networking in multi node test
* [`53abb119`](https://github.com/NixOS/nixpkgs/commit/53abb1196c528de024a08d6d71f3411252dd6c57) python3Packages.glocaltokens: init at 0.7.3
* [`b11d9fdb`](https://github.com/NixOS/nixpkgs/commit/b11d9fdb29a7003d079383e22445b0c1712ce5c4) python312Packages.scim2-server: 0.1.2 -> 0.1.4
* [`2d313632`](https://github.com/NixOS/nixpkgs/commit/2d3136320b0303ba71167c3f40c18fcc36ee680f) partio: 1.17.3 -> 1.19.0
* [`bfa83fd3`](https://github.com/NixOS/nixpkgs/commit/bfa83fd383c8926c1d825a926103e396c81e7429) python3Packages.pylibrespot-java: init at 0.1.1
* [`fa7a7091`](https://github.com/NixOS/nixpkgs/commit/fa7a70912c208049fdd8c6182aa302a3bb51e99d) minizinc: 2.8.7 -> 2.9.0
* [`ee162e13`](https://github.com/NixOS/nixpkgs/commit/ee162e131625fa49bb0de4df932fbb75a8190ede) minizincide: 2.8.7 -> 2.9.0
* [`67d1a170`](https://github.com/NixOS/nixpkgs/commit/67d1a17016fa34cb721b27e43e2b3a11d2a5a775) python312Packages.yosys: 0.49 -> 0.50
* [`98e5b834`](https://github.com/NixOS/nixpkgs/commit/98e5b834f768f8f9b6befa3021223f9ea5ab6668) python312Packages.python-qt: 3.5.7 -> 3.6.0
* [`0f200cef`](https://github.com/NixOS/nixpkgs/commit/0f200cef4e26ad488772b4429d9ee4765f839e9d) qdrant-web-ui: 0.1.36 -> 0.1.37
* [`fea02b40`](https://github.com/NixOS/nixpkgs/commit/fea02b40e876e57381e679280b5caf1a39bd469e) w_scan2: 1.0.15 -> 1.0.16
* [`53214ca4`](https://github.com/NixOS/nixpkgs/commit/53214ca46c1fc1d1227a18ee429ac91a5d2e5f4a) python312Packages.harlequin-postgres: 1.0.0 -> 1.1.1
* [`2a8ccbbc`](https://github.com/NixOS/nixpkgs/commit/2a8ccbbcb9a2b3a8b14ea59f4b2359663a2d9079) cmake-language-server: 0.1.10 -> 0.1.11
* [`c9f50d1d`](https://github.com/NixOS/nixpkgs/commit/c9f50d1d045a7f09e99258993bff5df94c8baeb3) ocamlPackages.posix-base: 2.0.2 -> 2.2.0
* [`28ec4a35`](https://github.com/NixOS/nixpkgs/commit/28ec4a356f2a548092c8c8c5791158c7fefc1e30) texturepacker: 7.5.0 -> 7.6.0
* [`d08ebe30`](https://github.com/NixOS/nixpkgs/commit/d08ebe30f733ccc1a37a635b0892c748358790c3) python312Packages.hg-evolve: 11.1.6 -> 11.1.7.post1
* [`c4a4b019`](https://github.com/NixOS/nixpkgs/commit/c4a4b01937f8e456e6563eea27e1158bd3420b24) python312Packages.toml-adapt: 0.3.3 -> 0.3.4
* [`7e5e1010`](https://github.com/NixOS/nixpkgs/commit/7e5e101009afab435ceccb811e48d9f1e2f4dde3) python312Packages.tablib: 3.7.0 -> 3.8.0
* [`80fa8bd2`](https://github.com/NixOS/nixpkgs/commit/80fa8bd2111e3621abb57833e1324e9b3a875ef5) opensearch: 2.18.0 -> 2.19.0
* [`c9f907af`](https://github.com/NixOS/nixpkgs/commit/c9f907af404b601952667ed636964d184969ce17) solana-cli: enable bpf and sbf commands
* [`4b13d16c`](https://github.com/NixOS/nixpkgs/commit/4b13d16cb0cbef17c0f67fb2a31edfb1ea46d1be) python312Packages.django-simple-history: 3.7.0 -> 3.9.0
* [`ff4eb25a`](https://github.com/NixOS/nixpkgs/commit/ff4eb25a33984048b2b4a94b3f929494ced42ff2) pingvin-share: 1.8.2 -> 1.9.0
* [`5dc45cb2`](https://github.com/NixOS/nixpkgs/commit/5dc45cb249aecbc536e68458d99bbe79300b782f) python312Packages.dendropy: 5.0.2 -> 5.0.6
* [`875148c9`](https://github.com/NixOS/nixpkgs/commit/875148c924abaa7a4e84c08a5e21922f0b4e8c25) python3Packages.mwxml: 0.3.4 -> 0.3.5
* [`c0bde802`](https://github.com/NixOS/nixpkgs/commit/c0bde8027cc65f729af3f67e7108057bfffaf17a) wasmi: use tag
* [`3e57eb05`](https://github.com/NixOS/nixpkgs/commit/3e57eb0541e5faa3e49c669918cb91618972417d) mullvad-vpn: 2025.2 -> 2025.3
* [`d07b3837`](https://github.com/NixOS/nixpkgs/commit/d07b3837395ccd9dcbe9ef2222f4bc34f3937db1) mullvad: 2025.2 -> 2025.3
* [`8fdfc49b`](https://github.com/NixOS/nixpkgs/commit/8fdfc49bfcbb1f9ab8db274f1f4bc3d053e5717c) paperlib: refactor
* [`94ae1a6a`](https://github.com/NixOS/nixpkgs/commit/94ae1a6aaec9835fb4f4a5932e127a42b97f3bd5) paperlib: 3.1.6 -> 3.1.10
* [`bbeb4ad8`](https://github.com/NixOS/nixpkgs/commit/bbeb4ad82fc3d7a149c39980a2e1dd14fb3b7ba5) sqlcl: 24.3.2.330.1718 -> 24.4.1.042.1221
* [`788eb078`](https://github.com/NixOS/nixpkgs/commit/788eb078aa78576f395bb43e0c93d5b06cd18d36) symlinkJoin: ability to strip prefix from tree
* [`c213c2f9`](https://github.com/NixOS/nixpkgs/commit/c213c2f9fdc40f1dd73bd2974444951c009af189) symlinkJoin: documentation & tests for stripPrefix
* [`715c5298`](https://github.com/NixOS/nixpkgs/commit/715c5298f5367c96562b5e06e1f5a4329d01a4a8) frawk: disable llvm support
* [`302c6450`](https://github.com/NixOS/nixpkgs/commit/302c6450deb86796de6312b8edf29c7094b8aa28) odoo: 18.0.20241010 -> 18.0.20250213
* [`fab959f3`](https://github.com/NixOS/nixpkgs/commit/fab959f345b0450175a18ede1cf82dd0d41992f6) python312Packages.azure-servicebus: 7.13.0 -> 7.14.0
* [`0cca0a13`](https://github.com/NixOS/nixpkgs/commit/0cca0a131f4a66720c59d6ffdde4795ce0203135) magic-vlsi: 8.3.515 -> 8.3.517
* [`284d8eec`](https://github.com/NixOS/nixpkgs/commit/284d8eecb4572c59cf4c75e8d8df917e9c28103b) bino3d: 2.3 -> 2.4
* [`7afc14c8`](https://github.com/NixOS/nixpkgs/commit/7afc14c894804784ae0d59834c2b184a9df4be62) texworks: 0.6.9 -> 0.6.10
* [`559f172e`](https://github.com/NixOS/nixpkgs/commit/559f172e477b94effbfaa4473222196515fcc7c7) python3Packages.qpsolvers: add proxsuite
* [`20e53fbc`](https://github.com/NixOS/nixpkgs/commit/20e53fbc3b2a9b8b228a0f9e3de27bdc8f6482c0) python3Packages.pipq: fix on darwin
* [`f41f1b70`](https://github.com/NixOS/nixpkgs/commit/f41f1b70f83798abbe0b75442cdb3e5ee07ef78e) amber-lang: 0.3.5-alpha -> 0.4.0-alpha
* [`44d502b8`](https://github.com/NixOS/nixpkgs/commit/44d502b8eb1e86f3c0e9ef1a98f64359e6db1614) capypdf: 0.14.0 -> 0.15.0
* [`0386c7f0`](https://github.com/NixOS/nixpkgs/commit/0386c7f09685302372823b8a41b41cd65a61bd57) scrypt: 1.3.2 -> 1.3.3
* [`361013dd`](https://github.com/NixOS/nixpkgs/commit/361013dd5c06e4b4774c889d356164df8e0a3b41) ethash: 1.0.1 -> 1.1.0
* [`0be91b8e`](https://github.com/NixOS/nixpkgs/commit/0be91b8e52bc24fc162e0e6852559dc2a92f1a75) mangayomi: add update script
* [`a1a68629`](https://github.com/NixOS/nixpkgs/commit/a1a6862929e6531132d1128828ccbadadd399d6b) mangayomi: refactor
* [`7f676a8e`](https://github.com/NixOS/nixpkgs/commit/7f676a8e18b5242ef5e78f8bcd7085da8d323f0f) maintainers: add averdow
* [`13e2f381`](https://github.com/NixOS/nixpkgs/commit/13e2f381d522430f019db2a02bc0de77a1576d40) python3Packages.aria2p: Changed mkDerivation input arguments into buildPythonPackage inputs
* [`9208cef2`](https://github.com/NixOS/nixpkgs/commit/9208cef238e9c54bf7f5a1b8a480b4aa3dc298ea) python3Packages.aria2p: Change python3Packages.appdirs to python3Packages.platformdirs in dependencies
* [`76d00863`](https://github.com/NixOS/nixpkgs/commit/76d008636fa2a90be5a26ca0a441d4d6da6c369a) ijhttp: 242.21829.56 -> 243.24978.46
* [`5047b0f0`](https://github.com/NixOS/nixpkgs/commit/5047b0f03b8178beb4c2cb38f4a8bc7ca87008ce) zpaqfranz: 60.10 -> 61.1
* [`01ad9416`](https://github.com/NixOS/nixpkgs/commit/01ad94162b51cedf9532a796e92889866c359c15) flacon: 11.4.0 -> 12.0.0
* [`bff27deb`](https://github.com/NixOS/nixpkgs/commit/bff27deb00e191cf249b7faec03108e2a9aec50d) cutemaze: 1.3.4 -> 1.3.5
* [`ed8e53dc`](https://github.com/NixOS/nixpkgs/commit/ed8e53dc2383b3acb0aadc3872039c71851802c0) eccodes: 2.39.0 -> 2.40.0
* [`d1cae720`](https://github.com/NixOS/nixpkgs/commit/d1cae72004be22881aed11e035c19da8e88d16b1) flyway: 11.0.1 -> 11.3.2
* [`d844bcf2`](https://github.com/NixOS/nixpkgs/commit/d844bcf2940972635b0c3598ac233ba6d94bbd7b) qlog: 0.41.1 -> 0.42.0
* [`ba6af448`](https://github.com/NixOS/nixpkgs/commit/ba6af44810f5bd3b6e983005f4153a093b7233c2) python312Packages.google-cloud-bigquery-storage: 2.27.0 -> 2.28.0
* [`1bc51528`](https://github.com/NixOS/nixpkgs/commit/1bc51528a63a52d83a792dca53106cda92821e85) python312Packages.reportlab: 4.2.5 -> 4.3.1
* [`95fb56fa`](https://github.com/NixOS/nixpkgs/commit/95fb56faff8e3f043ac60f2aaf7ec9e122c39146) maintainers: add yunz
* [`c782c8cd`](https://github.com/NixOS/nixpkgs/commit/c782c8cd03b900c1b707b4ea8dada3df717965bb) python3Packages.logbook: add missing pytest-rerunfailures dep
* [`1a67a646`](https://github.com/NixOS/nixpkgs/commit/1a67a646df6a56b6aac82f3d247be2954fc50c2e) hxtools: fix shebangs
* [`bff0bfee`](https://github.com/NixOS/nixpkgs/commit/bff0bfee5348bf67828614e33a537b0a06c73b35) python312Packages.picos: 2.5.1 -> 2.6.0
* [`bc5caaa0`](https://github.com/NixOS/nixpkgs/commit/bc5caaa08843a3531a135cdff7034d4a38d6a3eb) ckbcomp: 1.232 -> 1.234
* [`37967be7`](https://github.com/NixOS/nixpkgs/commit/37967be7fe35a0be2693a05b8115c57e77a3a13f) luau: 0.621 -> 0.661
* [`05a1f724`](https://github.com/NixOS/nixpkgs/commit/05a1f7248f0bfdf91fc3421e9d28ef44442ac404) lidarr: 2.8.2.4493 -> 2.9.6.4552
* [`5ca0e661`](https://github.com/NixOS/nixpkgs/commit/5ca0e6610fa58095f7fa96dcf4a733a393ad66cc) ultrastardx: 2025.2.0 -> 2025.2.1
* [`de241cf9`](https://github.com/NixOS/nixpkgs/commit/de241cf96ede53ca840ecf76a1835a1cab4a6fbe) azpainter: 3.0.10 -> 3.0.11
* [`54a76959`](https://github.com/NixOS/nixpkgs/commit/54a769594ba3d191f9d63e3f0d3d2cd5b40fbc34) python312Packages.strawberry-django: 0.55.0 -> 0.55.2
* [`8add72d6`](https://github.com/NixOS/nixpkgs/commit/8add72d64b89b0296d489ef6b831878cfbb662c3) maintainers: add FKouhai
* [`429b582e`](https://github.com/NixOS/nixpkgs/commit/429b582e3774201d9b52692300521b55b6451453) hubble: 0.13.6 -> 1.17.1
* [`1b700ed6`](https://github.com/NixOS/nixpkgs/commit/1b700ed6382336e166993507c4ce4f4bb08961f7) benthos: 4.43.0 -> 4.44.1
* [`5532b1cd`](https://github.com/NixOS/nixpkgs/commit/5532b1cddc3ab53ccf66915e0d87917a5fadb152) terraform-providers.mongodbatlas: 1.25.0 -> 1.26.1
* [`564acb6f`](https://github.com/NixOS/nixpkgs/commit/564acb6f6cdc50a6ba4f98bea6ca1c4d45096615) bililiverecorder: format
* [`489769f7`](https://github.com/NixOS/nixpkgs/commit/489769f7c4d7285aa68145d07f77e208045f0235) pandoc-mustache: init at 0.1.0
* [`b6a8d436`](https://github.com/NixOS/nixpkgs/commit/b6a8d43649c8f56eaa0c56b73234dc5ba4950ca6) radarr: 5.17.2.9580 -> 5.18.4.9674
* [`1503c9c6`](https://github.com/NixOS/nixpkgs/commit/1503c9c6d495711b8589b197b8d512dd9b5a4cc4) flameshot: 12.1.0-unstable-2025-02-01 -> 12.1.0-unstable-2025-02-12
* [`dff280f2`](https://github.com/NixOS/nixpkgs/commit/dff280f27c63a2bba55217d32bd3d02427aa5959) python312Packages.cucumber-tag-expressions: 6.1.1 -> 6.1.2
* [`8c10180e`](https://github.com/NixOS/nixpkgs/commit/8c10180ef4bc40b9c2400782277db70e9348c2dd) openiscsi: 2.1.10 -> 2.1.11
* [`4b39fb89`](https://github.com/NixOS/nixpkgs/commit/4b39fb895131b64110428efe19ec62e28acee0e3) gridcoin-research: 5.4.8.0-hotfix-1 -> 5.4.9.0
* [`dc30d4ba`](https://github.com/NixOS/nixpkgs/commit/dc30d4bace5283e6c39c52c56569b9c4cc62bd8f) qsv: 0.138.0 -> 2.2.1
* [`6ddbab44`](https://github.com/NixOS/nixpkgs/commit/6ddbab442dcfdda60cd969c930db6a7bb64b31a3) skypilot: 0.7.0 -> 0.8.0
* [`50d86bfb`](https://github.com/NixOS/nixpkgs/commit/50d86bfb74214c300796ff012d68ab9d26ca9ed0) python312Packages.pymdown-extensions: 10.14 -> 10.14.3
* [`15a777a4`](https://github.com/NixOS/nixpkgs/commit/15a777a4f147c51096a6ef2118510368862767e5) steampipePackages.steampipe-plugin-azure: 1.1.0 -> 1.1.1
* [`ab42274d`](https://github.com/NixOS/nixpkgs/commit/ab42274dc92527a8da4f27b675feaeb03c8a57e9) ols: 0-unstable-2025-01-28 -> 0-unstable-2025-02-11
* [`e6028481`](https://github.com/NixOS/nixpkgs/commit/e60284817101b9530f8947a6cf3af4fa51f21b78) terraform-providers.google-beta: 6.14.1 -> 6.20.0
* [`29314a92`](https://github.com/NixOS/nixpkgs/commit/29314a92af8de8cb14db9d5c232d0f97966e4916) python312Packages.ufolib2: 0.17.0 -> 0.17.1
* [`fe5633a1`](https://github.com/NixOS/nixpkgs/commit/fe5633a16b32bb1bcd1740112112729abd5aef77) python312Packages.qtpy: 2.4.2 -> 2.4.3
* [`129752b6`](https://github.com/NixOS/nixpkgs/commit/129752b6de1a8e9ffd783eda02cf2b9247b16de9) linuxPackages.corefreq: 2.0.0 -> 2.0.1
* [`2462695f`](https://github.com/NixOS/nixpkgs/commit/2462695f88b3e1c47942e2cbf022a0ba49ca3fcb) ustreamer: 6.27 -> 6.31
* [`224f7fc4`](https://github.com/NixOS/nixpkgs/commit/224f7fc47810fcf69cdcef021f06ece75110c12b) nixos/networkd-dispatcher: added missing enum value "enslaved" to option "onState"
* [`01f8f316`](https://github.com/NixOS/nixpkgs/commit/01f8f3168568900ea30f0bbadb56a174456fc4c3) python312Packages.strawberry-django: 0.55.2 -> 0.56.0
* [`3bf4b696`](https://github.com/NixOS/nixpkgs/commit/3bf4b696ffce65d158ea8d99c07e65f2b1a03e79) bind.dnsutils: remove reference to main output
* [`3020a7cf`](https://github.com/NixOS/nixpkgs/commit/3020a7cfb68dbe9321137c5bbc6bdef97f0cd0d5) libwpe: 1.16.0 -> 1.16.2
* [`ebf1d3ef`](https://github.com/NixOS/nixpkgs/commit/ebf1d3ef300267199eadcae45a338ac2ce2c1fad) verifast: 25.01 -> 25.02
* [`bc7dc358`](https://github.com/NixOS/nixpkgs/commit/bc7dc358951a8e944f0f5bbbcbf3cfb10251f3e1) dotenvx: 1.34.0 -> 1.36.0
* [`6efdb231`](https://github.com/NixOS/nixpkgs/commit/6efdb23193c8567eebbb832d90b8b463e1205726) pingvin-share: 1.9.0 -> 1.9.1
* [`62d4b3f3`](https://github.com/NixOS/nixpkgs/commit/62d4b3f3c7c3a877f774d65186403d201c8f8789) signal-export: 3.2.2 -> 3.4.1
* [`d4c59a63`](https://github.com/NixOS/nixpkgs/commit/d4c59a631dc87d333655693635ec95fc78e4c233) msbuild-structured-log-viewer: 2.2.392 -> 2.2.441
* [`f03da212`](https://github.com/NixOS/nixpkgs/commit/f03da2128b987e374995552d653cf5e17b082c65) pymol: 3.0.0 -> 3.1.0, fix msgpack on non-Darwin
* [`a6e63830`](https://github.com/NixOS/nixpkgs/commit/a6e63830e9f0f698a12331f6f2faa115927f47b4) openttd-jgrpp: 0.64.0 -> 0.64.1
* [`73fc0de1`](https://github.com/NixOS/nixpkgs/commit/73fc0de129639661dcad2f5c6482cdfb0596cdf5) local-ai: 2.25.0 -> 2.26.0
* [`d4558c0e`](https://github.com/NixOS/nixpkgs/commit/d4558c0e9516e96d01a898739ebcf8d0c19022e5) alfaview: 9.20.0 -> 9.21.0
* [`834b999e`](https://github.com/NixOS/nixpkgs/commit/834b999e8d5597133e8554d9da1df91674e5424a) opera: 116.0.5366.71 -> 117.0.5408.32
* [`51aa6d6b`](https://github.com/NixOS/nixpkgs/commit/51aa6d6bb341b98a7c5380d5ef781962b4c0afcc) html-xml-utils: 8.6 -> 8.7
* [`848dca61`](https://github.com/NixOS/nixpkgs/commit/848dca6155dc5bfde456402b3d09006c82052996) bpftop: 0.5.2 -> 0.6.0
* [`2b617b11`](https://github.com/NixOS/nixpkgs/commit/2b617b1156f5e936d2ee6dcd1d8e129c1cdbb2f3) gbsplay: 0.0.97 -> 0.0.98
* [`d815e9f3`](https://github.com/NixOS/nixpkgs/commit/d815e9f33cd2bc157a74d4b0dc10093d8557a37c) lesspipe: 2.17 -> 2.18
* [`fa587bbf`](https://github.com/NixOS/nixpkgs/commit/fa587bbf34fb41c8559a0461b69294bb68b1b2fe)   guile-goblins: 0.14.0 -> 0.15.0
* [`81bd85b5`](https://github.com/NixOS/nixpkgs/commit/81bd85b51758f4be46a7da3ff0ec7b9a9d480cf2) ocamlPackages.unisim_archisec: 0.0.9 -> 0.0.10
* [`ae57fe02`](https://github.com/NixOS/nixpkgs/commit/ae57fe02b16f7de0d16e8db7968eb1e33b8aebe2) schismtracker: 20241226 -> 20250208
* [`2aea7f3d`](https://github.com/NixOS/nixpkgs/commit/2aea7f3dfcbf457f75f5ec01eb5d0167b9da48f2) bunster: init at v0.8.0
* [`97233e7f`](https://github.com/NixOS/nixpkgs/commit/97233e7fd738ebd83acd857be9794ea1ccdb7c5b) kcl: 0.11.0 -> 0.11.1
* [`3196a386`](https://github.com/NixOS/nixpkgs/commit/3196a386c95bb975c5c4630808bad3b430a0afe2) cloudflared: 2024.12.2 -> 2025.2.0
* [`aadc6e3e`](https://github.com/NixOS/nixpkgs/commit/aadc6e3e12e94a9b3353e8ef6b01cf55067cee12) python312Packages.awscrt: 0.23.9 -> 0.23.10
* [`f7a4f85e`](https://github.com/NixOS/nixpkgs/commit/f7a4f85e378fa14c1cbfaad1ffdc9d97c57efca7) hydrus: 598 -> 609
* [`5806b312`](https://github.com/NixOS/nixpkgs/commit/5806b3122535fa09bc12ccac6ba830dc5dc6037d) steampipe: 1.0.2 -> 1.0.3
* [`bf067df9`](https://github.com/NixOS/nixpkgs/commit/bf067df904a804e7d525f7846d4eb4d5789cb04a) linkerd_edge: 24.11.8 -> 25.2.1
* [`61beca9d`](https://github.com/NixOS/nixpkgs/commit/61beca9d8f6dba53113546630ab545f2d970ca14) terraform-providers.rundeck: 0.4.9 -> 0.5.0
* [`910a70b2`](https://github.com/NixOS/nixpkgs/commit/910a70b257ad7dcff02b898f93d293bcdebaf7e1) flowblade: 2.18 -> 2.18.1
* [`5996b63e`](https://github.com/NixOS/nixpkgs/commit/5996b63e60bb88c2264da4ebb6eeca3dbcf14ba9) ocamlPackages.domain-name: 0.4.0 -> 0.4.1
* [`33f4e605`](https://github.com/NixOS/nixpkgs/commit/33f4e6054996764cc58bcab35f10d29c28660949) pgmoneta: 0.15.1 -> 0.15.2
* [`53c60b8c`](https://github.com/NixOS/nixpkgs/commit/53c60b8c6144c25ed0bd6454e967de0e263e73d1) melodeon: 0.4.3 -> 0.4.4
* [`e121b9a0`](https://github.com/NixOS/nixpkgs/commit/e121b9a062611cb5460edb62a42953b39f35e855) camunda-modeler: 5.30.0 -> 5.32.0
* [`6dd52fd0`](https://github.com/NixOS/nixpkgs/commit/6dd52fd0866f53efe69acaf2ee87c1894f1e4277) tomcat9: 9.0.98 -> 9.0.100
* [`e27365cf`](https://github.com/NixOS/nixpkgs/commit/e27365cf4b25b2c2917c7726ee87c8e80316544b) netbox: add option to listen on Unix socket
* [`eae292b6`](https://github.com/NixOS/nixpkgs/commit/eae292b6afbcd4291be79a4bbf0a5a64b2c05bc3) lilypond-unstable: 2.25.22 -> 2.25.24
* [`b5075f9c`](https://github.com/NixOS/nixpkgs/commit/b5075f9c94a0426899250ad2d742080a1c7bbc24) pathvector: add shell completions
* [`5aa1fe8e`](https://github.com/NixOS/nixpkgs/commit/5aa1fe8ea995ab8baa1147ad99b9fc8842424edc) mxnet: remove cuda support
* [`cb4113f7`](https://github.com/NixOS/nixpkgs/commit/cb4113f747ae6a82b6cd6fd9517a8d3dac690813) ankama-launcher: 3.12.30 → 3.12.35
* [`6b11e89c`](https://github.com/NixOS/nixpkgs/commit/6b11e89c58f3d6e7992b8666c7fd4f6697506fe7) ptouch-print: enable build on unix
* [`f22822e3`](https://github.com/NixOS/nixpkgs/commit/f22822e360dc6b76f4d1593eb2a125a7ab0237d5) terraform-providers.newrelic: 3.54.1 -> 3.56.0
* [`d5359a53`](https://github.com/NixOS/nixpkgs/commit/d5359a5379a5a09c58c473d5677c9000798c9ccd) terraform-providers.linode: 2.33.0 -> 2.34.1
* [`ccf55867`](https://github.com/NixOS/nixpkgs/commit/ccf55867bb8827db4b8296605d80f72eb23f7eb1) terraform-providers.avi: 30.2.2 -> 31.1.1
* [`b0dc6060`](https://github.com/NixOS/nixpkgs/commit/b0dc6060a29983709a10df640f910d74562807ce) steampipePackages.steampipe-plugin-aws: 1.5.0 -> 1.6.0
* [`9b1e9f90`](https://github.com/NixOS/nixpkgs/commit/9b1e9f90c85412dc880c0be96f55f63ed612d4a7) cosmic-applibrary: hardcode repository name
* [`763021c5`](https://github.com/NixOS/nixpkgs/commit/763021c5c2c3103a195f73111d5b54606d0bdfa8) cosmic-applibrary: remove `with lib` from meta
* [`734a0f9c`](https://github.com/NixOS/nixpkgs/commit/734a0f9c0039e505e51bc2e8653e1115c5c1180d) cosmic-applibrary: use libcosmicAppHook
* [`4d8ea4f1`](https://github.com/NixOS/nixpkgs/commit/4d8ea4f13b1d9be5ee70e232f66ad55b05a258ad) cosmic-applibrary: add updateScript
* [`57a337be`](https://github.com/NixOS/nixpkgs/commit/57a337bec72f1cf20782a607ff4df3be9018b10b) cosmic-applibrary: 0-unstable-2024-02-09 -> 1.0.0-alpha.5.1
* [`e74c81ea`](https://github.com/NixOS/nixpkgs/commit/e74c81eaf75f261e3ef761354da23387c8184d47) cosmic-applibrary: disable just check
* [`0b16ea1c`](https://github.com/NixOS/nixpkgs/commit/0b16ea1c93b78e596ad909e6925043877d54a5de) cosmic-applibrary: add HeitorAugustoLN as a maintainer
* [`ca69347a`](https://github.com/NixOS/nixpkgs/commit/ca69347aea5df11f53056538b6e5f22662f598e5) dosage-tracker: 1.8.3 -> 1.9.1
* [`a14ef5f5`](https://github.com/NixOS/nixpkgs/commit/a14ef5f53f620cece65d40b2605bfab2bced6796) passepartui: 0.1.5 -> 0.1.7
* [`11c6b7de`](https://github.com/NixOS/nixpkgs/commit/11c6b7def95b0b80a91ee6e7d3f59d96242c36eb) kimai: 2.28.0 -> 2.29.0
* [`32875fcd`](https://github.com/NixOS/nixpkgs/commit/32875fcd6af8466d4a9e75db196df4a488cf61ab) powerpipe: 1.0.1 -> 1.2.2
* [`fe2727c4`](https://github.com/NixOS/nixpkgs/commit/fe2727c45b7c6660f128f98c61fc704320536a11) tandoor_recipes: use static user and group instead of DynamicUser
* [`cfa3c4bb`](https://github.com/NixOS/nixpkgs/commit/cfa3c4bb3eec5d5fa93b3fe33d03bf4664f46737) terraform-providers.oci: 6.21.0 -> 6.26.0
* [`dd1599d9`](https://github.com/NixOS/nixpkgs/commit/dd1599d9ecd635be08b7bca62bb495b6c11327f1) python312Packages.panel: 1.5.5 -> 1.6.1
* [`28b2fd3e`](https://github.com/NixOS/nixpkgs/commit/28b2fd3e8eb63803359d3dac82c6a834fe40056d) python312Packages.mlflow: 2.20.1 -> 2.20.2
* [`298f8021`](https://github.com/NixOS/nixpkgs/commit/298f8021bac98e3784e33c25f13495c9f2a393bc) segger-jlink: Change install path to /opt/SEGGER/JLink
* [`0f2db7e1`](https://github.com/NixOS/nixpkgs/commit/0f2db7e1ad5ff9c4101a354335c0fe4ff4025cca) gatus: 5.15.0 -> 5.16.0
* [`119100e2`](https://github.com/NixOS/nixpkgs/commit/119100e289166ae4e57e10d889da9b4bbceb92be) terraform-providers.azurerm: 4.16.0 -> 4.19.0
* [`361f29cf`](https://github.com/NixOS/nixpkgs/commit/361f29cf694857e12a0f7a90c77dec56ba70e700) podman-bootc: init at 0.1.2
* [`cd656d36`](https://github.com/NixOS/nixpkgs/commit/cd656d36a37543e2b972d42041389a7f4e1af412) tt-rss: 0-unstable-2024-12-22 -> 0-unstable-2025-02-08
* [`2101d8e1`](https://github.com/NixOS/nixpkgs/commit/2101d8e102b19ef479d4be5aec9b14d2e8ff9c7d) ocamlPackages.netchannel: 2.1.2 -> 2.1.3
* [`a5c20f15`](https://github.com/NixOS/nixpkgs/commit/a5c20f1537459003ce5725461ed268155ef7782a) biliup-rs: init at 0.2.2
* [`aa105181`](https://github.com/NixOS/nixpkgs/commit/aa105181b6df20cbb959b43ebc4a474ecb2a6ede) ocamlPackages.functoria-runtime: 4.4.1 -> 4.4.2
* [`16a1ed48`](https://github.com/NixOS/nixpkgs/commit/16a1ed4802915d40432e047a1a8fa5d12f9ff1b0) fcitx5-mcbopomofo: enable strictDeps
* [`fd55802c`](https://github.com/NixOS/nixpkgs/commit/fd55802c96c5c81fc3afe85e265ffe5f3fda661f) altair: 8.1.4 -> 8.1.5
* [`f49fa96e`](https://github.com/NixOS/nixpkgs/commit/f49fa96e8fd1b6cf1eeb3e1d00216412e86fbf8f) ethercat: 1.6.2 -> 1.6.3
* [`262940c6`](https://github.com/NixOS/nixpkgs/commit/262940c69d913aa77bcc9263436beb76b5848441) codeium: 1.32.1 -> 1.38.0
* [`715bf97a`](https://github.com/NixOS/nixpkgs/commit/715bf97a406c0125b741f6f0a1e775696a0617f0) maestro: 1.39.7 -> 1.39.13
* [`cdd0b7c9`](https://github.com/NixOS/nixpkgs/commit/cdd0b7c9d15e29c0c163708b10218227d8e21708) python312Packages.django-stubs-ext: 5.1.2 -> 5.1.3
* [`2a3c600a`](https://github.com/NixOS/nixpkgs/commit/2a3c600af8876982edb50afddd2eedfa87d9612c) zoom-us: 6.3.6.6315 -> 6.3.10.7150
* [`9c9b50a0`](https://github.com/NixOS/nixpkgs/commit/9c9b50a0d6a4f9a341945003fa5ae757fd7988dc) liferea: 1.15.8 -> 1.16-RC1
* [`9a4c80e9`](https://github.com/NixOS/nixpkgs/commit/9a4c80e931159bd511a45255dcc5c268ffa535b2) grocy: 4.2.0 -> 4.3.0
* [`604809c3`](https://github.com/NixOS/nixpkgs/commit/604809c3c2840876853c61b59f3ef0aa9af12720) zrok: 0.4.45 -> 0.4.46
* [`b90f6cd8`](https://github.com/NixOS/nixpkgs/commit/b90f6cd8247caa218e8800af7281dace28309d94) jan: 0.5.14 -> 0.5.15
* [`54f63650`](https://github.com/NixOS/nixpkgs/commit/54f63650cdbbbbfcd09c1b90ff092f906f7a7fa9) protoc-gen-connect-es: remove
* [`f57fbfb5`](https://github.com/NixOS/nixpkgs/commit/f57fbfb5f4eb340b23884617cdae6436ad23fdf8) efibootmgr: fetch patch to allow reordering boot entries
* [`f2894a13`](https://github.com/NixOS/nixpkgs/commit/f2894a1362ebcd43c17d90059f13220d44b545a8) alacritty-theme: 0-unstable-2025-01-27 -> 0-unstable-2025-02-16
* [`930f7c6e`](https://github.com/NixOS/nixpkgs/commit/930f7c6eca92ef05fd974b5de05f64e439c14ba8) armadillo: 14.2.2 -> 14.4.0
* [`f3662049`](https://github.com/NixOS/nixpkgs/commit/f36620496ae3a76ccd90ce55021a76ea0e753f0f) base16-shell-preview: 1.0.0 -> 1.1.0
* [`151b4a07`](https://github.com/NixOS/nixpkgs/commit/151b4a0763963299db36c967efa4eb9cbb2a8086) fsautocomplete: add update script
* [`943c49ef`](https://github.com/NixOS/nixpkgs/commit/943c49ef29ffa1622264287053ea178a48a7f6c0) fsautocomplete: 0.75.0 -> 0.77.2
* [`6c11bef8`](https://github.com/NixOS/nixpkgs/commit/6c11bef8813b5f2e38a14473613f8ea606964065) nrfconnect-bluetooth-low-energy: init at 4.0.4
* [`30ec0da2`](https://github.com/NixOS/nixpkgs/commit/30ec0da2b355726bf46ba9fd562c0daf5c5a6dc4) nrfconnect: Clean up syntax
* [`3e8a2893`](https://github.com/NixOS/nixpkgs/commit/3e8a2893ec4fb3d5dce7cd723b710874ff617e12) sonar-scanner-cli: 7.0.1.4817 -> 7.0.2.4839
* [`aa2db3ac`](https://github.com/NixOS/nixpkgs/commit/aa2db3ac260ad37ef4435332cfd3835d35ddedf9) fio: 3.38 -> 3.39
* [`3d2139ba`](https://github.com/NixOS/nixpkgs/commit/3d2139bae77a3ff48f37a1a90e77e8e0a4d60491) bisq2: add coreutils and tor to PATH
* [`d278331a`](https://github.com/NixOS/nixpkgs/commit/d278331a30218151f347e2bb14110938fc57d712) engelsystem: 3.5.0 -> 3.6.0
* [`b4069de3`](https://github.com/NixOS/nixpkgs/commit/b4069de368a95e1c0d68cfc24c265677a4ecfa2e) libcupsfilters: 2.1.0 -> 2.1.1
* [`eba9750c`](https://github.com/NixOS/nixpkgs/commit/eba9750c5f347f37cf36d16918964c2c8674e8bc) rocksndiamonds: 4.4.0.3 -> 4.4.0.4
* [`07751da4`](https://github.com/NixOS/nixpkgs/commit/07751da4fd7e16641ac83e28de55774e1645b22a) terser: 5.36.0 -> 5.38.0
* [`51bb5c08`](https://github.com/NixOS/nixpkgs/commit/51bb5c08db6220d840f8c994c855660c4c24c175) octavePackages.vrml: 1.0.13 -> 1.0.14
* [`483f4290`](https://github.com/NixOS/nixpkgs/commit/483f42905e1e22a41733707add09aa4bdf068a39) kubevela: 1.9.13 -> 1.10.1
* [`e4883d63`](https://github.com/NixOS/nixpkgs/commit/e4883d63a891f032f5703b6a542de878a6be4d3c) awscli2: 2.23.11 -> 2.24.7
* [`497e97d6`](https://github.com/NixOS/nixpkgs/commit/497e97d678a3e972446d5a259074e49b55c13a81) micronaut: 4.7.5 -> 4.7.6
* [`d81a9740`](https://github.com/NixOS/nixpkgs/commit/d81a974063163bc0c2b5d9b023747be9c55159fc) opencomposite: 0-unstable-2025-02-08 -> 1.0.1473
* [`6a257647`](https://github.com/NixOS/nixpkgs/commit/6a2576476bea882205b8db255fd70c1aed55b7ce) pioasm: 2.1.0 -> 2.1.1
* [`fd53e99f`](https://github.com/NixOS/nixpkgs/commit/fd53e99ffed2d62abc615afad8d312fedff313c1) libetebase: 0.5.6 -> 0.5.7
* [`e63d0145`](https://github.com/NixOS/nixpkgs/commit/e63d014548374363a6a94e2a578754aa7fb3b18d) dbgate: 6.1.0 -> 6.2.0
* [`d5051fcc`](https://github.com/NixOS/nixpkgs/commit/d5051fcc52bab18ddfdee668651cf040adc45bed) ghostfolio: init at 2.139.1
* [`00aadaea`](https://github.com/NixOS/nixpkgs/commit/00aadaea3e9c1df975f904ca1b1e1023f7cc4998) maintainers: add mapperfr
* [`5e8040f0`](https://github.com/NixOS/nixpkgs/commit/5e8040f097c8e4071d89d220658ddf5f42ccd320) crosvm: 0-unstable-2025-02-04 -> 0-unstable-2025-02-18
* [`12b7c042`](https://github.com/NixOS/nixpkgs/commit/12b7c042bce22624a5342bd3e9e2e2c546094175) tetris: init at 0.1.6
* [`1de885ab`](https://github.com/NixOS/nixpkgs/commit/1de885ab5d3a6402fd198c205ff96e1fbcb89f05) sosreport: 4.8.2 -> 4.9.0
* [`98bcf55e`](https://github.com/NixOS/nixpkgs/commit/98bcf55e95839b485d535aafca0d22245c9ea587) biglybt: 3.7.0.0 -> 3.8.0.0
* [`763115c8`](https://github.com/NixOS/nixpkgs/commit/763115c819a1a8c40766fe7f96ceda72ac0a7a1f) apt-offline: 1.8.5 -> 1.8.6
* [`a293dbbd`](https://github.com/NixOS/nixpkgs/commit/a293dbbda638836db9acbf9c7d26b333affa554c) eas-cli: replace yarnInstallHook to fix symlink and missing cli features
* [`8d94befd`](https://github.com/NixOS/nixpkgs/commit/8d94befdfd62a53f99adb09b1b62b5af9c143c6e) ghidra: 11.3 -> 11.3.1
* [`ce5f4333`](https://github.com/NixOS/nixpkgs/commit/ce5f4333e2ee39a5f6d6d8228e76631a366ed7b6) gihdra-bin: 11.3 -> 11.3.1
* [`636a1207`](https://github.com/NixOS/nixpkgs/commit/636a1207c461961db3d8c008d2183e64cb0bc973) kikit: 1.6.0 -> 1.7.0
* [`ae35385e`](https://github.com/NixOS/nixpkgs/commit/ae35385e0fa7c898284cb0183c33d8f5d1bdd7ac) garnet: 1.0.55 -> 1.0.57
* [`e3512989`](https://github.com/NixOS/nixpkgs/commit/e35129899cd02fb52b0260c83e54b3862db3743c) museum: 0.9.81 -> 0.9.98
* [`8e075ab3`](https://github.com/NixOS/nixpkgs/commit/8e075ab3a8f28a9205f13bed451536d45759f7e1) pacman-game: init at 0-unstable-2017-01-30
* [`75c33b43`](https://github.com/NixOS/nixpkgs/commit/75c33b433a03d07bfbb679b2b8870f8c84ec3d7f) zxtune: 5081 -> 5090
* [`08eb90d4`](https://github.com/NixOS/nixpkgs/commit/08eb90d41e33827023e54861b747bc1b4b260215) yourkit-java: 2024.9-b163 -> 2024.9-b164
* [`d94a71cc`](https://github.com/NixOS/nixpkgs/commit/d94a71cc66c3f93247badc4f3dab5bf86f152bba) flink: 1.20.0 -> 1.20.1
* [`c9935e34`](https://github.com/NixOS/nixpkgs/commit/c9935e34741b7258037862e2360732f50a074da4) vkd3d: 1.14 -> 1.15
* [`5747767a`](https://github.com/NixOS/nixpkgs/commit/5747767a460a3b2e2b727b096084ec28427f8820) xournalpp: 1.2.5 -> 1.2.6
* [`13d6a447`](https://github.com/NixOS/nixpkgs/commit/13d6a447dcc09a16a207f8477c765b6ebc24bc80) powwow: init at 1.2.23
* [`450078d5`](https://github.com/NixOS/nixpkgs/commit/450078d52e1fb3a56f9e9f4ca82e120316def168) prettier: fix ENOENT if node isn't on the user's path
* [`def2a5ae`](https://github.com/NixOS/nixpkgs/commit/def2a5ae37301c6b56c716e3493ac357cf3d140e) prettierd: 0.25.3 -> 0.26.1
* [`ee7fd661`](https://github.com/NixOS/nixpkgs/commit/ee7fd661e8f859d319d893a520127cfef9c43e8b) wasm-language-tools: init at 0.3.2
* [`3d36f0d2`](https://github.com/NixOS/nixpkgs/commit/3d36f0d2a72d90939d7d1d43e00de1d78c7e31ce) buildkit: 0.19.0 -> 0.20.0
* [`f7ee78c6`](https://github.com/NixOS/nixpkgs/commit/f7ee78c68266d5b3fdb77b721cbbb667eca60912) tpm2-pkcs11: 1.9.0 -> 1.9.1
* [`de85fc8e`](https://github.com/NixOS/nixpkgs/commit/de85fc8eadf19ed375d229db4b4aee2eddf87277) tpm2-pkcs11: add numinit as maintainer
* [`0891239e`](https://github.com/NixOS/nixpkgs/commit/0891239e13998e1c9360116f904cc0f7aa7dc192) maintainers: add i01011001
* [`baccfe89`](https://github.com/NixOS/nixpkgs/commit/baccfe8940408668cd85bdcba99e03b23411089b) unity-test:init at 2.61
* [`387f1d12`](https://github.com/NixOS/nixpkgs/commit/387f1d12820bf5c91218f9bd95702e669ab3e104) libretro.mame2003-plus: 0-unstable-2025-02-04 -> 0-unstable-2025-02-11
* [`6858114f`](https://github.com/NixOS/nixpkgs/commit/6858114f1d3ecdd85a77a4cef0e40262d945af82) subxt: 0.38.1 -> 0.39.0
* [`c2f48cc9`](https://github.com/NixOS/nixpkgs/commit/c2f48cc9dfabdb019d4f53a1c001acf49c08fa28) snyk: 1.1295.2 -> 1.1295.3
* [`ab7885f1`](https://github.com/NixOS/nixpkgs/commit/ab7885f1ef92fedc51c2aaeea9f49ef6cdbd33c0) nodejs_18: 18.20.6 -> 18.20.7
* [`89888968`](https://github.com/NixOS/nixpkgs/commit/89888968cffccdddfe78427901475f4f3ef380da) vue-language-server: 2.2.0 -> 2.2.2
* [`167ca814`](https://github.com/NixOS/nixpkgs/commit/167ca8146c29885fa417d1c7556f9ea62313fd38) qir-runner: init at 0.7.5
* [`7dfdd2c7`](https://github.com/NixOS/nixpkgs/commit/7dfdd2c7c8976d150c08fb43764547be5e8d399e) blasfeo: 0.1.4.1 -> 0.1.4.2
* [`3bc1d33e`](https://github.com/NixOS/nixpkgs/commit/3bc1d33e81f8525d3bc3fa6992528d72d41bda90) exoscale-cli: 1.77.2 -> 1.83.1
* [`8d62b093`](https://github.com/NixOS/nixpkgs/commit/8d62b09309bee7d119508190e4f712041265a5d6) teleport_15: 15.4.26 -> 15.4.29
* [`2c8f17bd`](https://github.com/NixOS/nixpkgs/commit/2c8f17bd418c0f14016a8b44753ba6ab9fe6c663) teleport_16: 16.4.14 -> 16.4.16
* [`d05cf763`](https://github.com/NixOS/nixpkgs/commit/d05cf7637e854beeec3f5849558a5a47b434ff84) teleport_17: 17.2.1 -> 17.2.8
* [`29e175ca`](https://github.com/NixOS/nixpkgs/commit/29e175caa7462eb3d7d222538ee61ea12c5f83a0) benchexec: 3.21 → 3.27
* [`42a38dc0`](https://github.com/NixOS/nixpkgs/commit/42a38dc097322d70a85e6592a6eda52fa8165ccd) qucs-s: 24.4.1 -> 25.1.0
* [`c780b282`](https://github.com/NixOS/nixpkgs/commit/c780b282fa2eb678553ca442a91caaa6a2ecd885) fcitx5-bamboo: 1.0.6 -> 1.0.7
* [`60abacf4`](https://github.com/NixOS/nixpkgs/commit/60abacf4dc5deeb2233a475fb2d8f658533ebde3) eigenrand: skip test_mv
* [`8837ec05`](https://github.com/NixOS/nixpkgs/commit/8837ec052ec98e0de0697646fad73086b1b294a9) nwjs-ffmpeg-prebuilt: 0.94.1 -> 0.96.0
* [`4bef3d66`](https://github.com/NixOS/nixpkgs/commit/4bef3d66230df46402ee6d6f7c8d485cde1e1804) xlights: 2025.01 -> 2025.03
* [`345e8a30`](https://github.com/NixOS/nixpkgs/commit/345e8a30fa024ff6f4950828b2492c41371c3452) python312Packages.ntc-templates: 7.6.0 -> 7.7.0
* [`b18dade7`](https://github.com/NixOS/nixpkgs/commit/b18dade7fcdfe893f143c4d65d4d4171a6e28e68) kuro: use 512x512 icon, resolves [nixos/nixpkgs⁠#354644](https://togithub.com/nixos/nixpkgs/issues/354644)
* [`091a9595`](https://github.com/NixOS/nixpkgs/commit/091a9595f34cee856026e4451920d14e23ed0852) buildRustCrate: make default value for codegenUnits configurable
* [`fd4e5841`](https://github.com/NixOS/nixpkgs/commit/fd4e5841f27939eecfe5fc9399174beb006ab7e2) python3Packages.peacasso: init at 0.0.19a0
* [`6f187658`](https://github.com/NixOS/nixpkgs/commit/6f18765884b891de6fc2d94f413362e6c6c63ce7) linux_xanmod, linux_xanmod_latest: 2025-02-17
* [`c92fc770`](https://github.com/NixOS/nixpkgs/commit/c92fc770e528a6e613e40f2b36ca931be990ca40) linux_xanmod, linux_xanmod_latest: 2025-02-19
* [`052d2344`](https://github.com/NixOS/nixpkgs/commit/052d23442b1f97857a2080e668f8d1250e4dd977) dart.rhttp: add 0.10.0
* [`69c09ae8`](https://github.com/NixOS/nixpkgs/commit/69c09ae8881a20325b3324a4de5738eadc56e8a6) localsend: 1.16.1 -> 1.17.0
* [`267f63cb`](https://github.com/NixOS/nixpkgs/commit/267f63cb9b4faf3ef8fd5be997f1864c29795b2b) netbird: 0.36.6 -> 0.36.7
* [`005df694`](https://github.com/NixOS/nixpkgs/commit/005df694048fa56c36fdd01aa643bcd7cd8449e0) zluda: 3 -> 4-unstable-2025-01-28
* [`b3fed22e`](https://github.com/NixOS/nixpkgs/commit/b3fed22ea8c206dc126e6950555675a05f0e3f4f) regreet: set right data dir (NixOS[nixos/nixpkgs⁠#377585](https://togithub.com/nixos/nixpkgs/issues/377585))
* [`97d6788c`](https://github.com/NixOS/nixpkgs/commit/97d6788c5e06a811e3f8eee82061817825b85445) ablog: 0.11.11 -> 0.11.12
* [`e10f7fc9`](https://github.com/NixOS/nixpkgs/commit/e10f7fc96c4d0447b973ffb70dac3731b12bb695) maintainers: update fredeb
* [`3b484100`](https://github.com/NixOS/nixpkgs/commit/3b484100dc56df0649dacd6fd3163e40e3506228) copilot-language-server: init at 1.273.0
* [`cdeaae76`](https://github.com/NixOS/nixpkgs/commit/cdeaae7690692397129e203afa830926f53b4e5c) wordpress: 6.7.1 -> 6.7.2
* [`239511fa`](https://github.com/NixOS/nixpkgs/commit/239511fa044279b02d5fa6924bc556138f603a65) git-machete: 3.32.1 -> 3.33.0
* [`da575956`](https://github.com/NixOS/nixpkgs/commit/da575956a7b007dfcfd236fffafb8c85ef75c300) rsyslog: 8.2412.0 -> 8.2502.0
* [`9ddba5b1`](https://github.com/NixOS/nixpkgs/commit/9ddba5b125b40bc3864a5abd10ea00838f97667e) hoppscotch: 24.12.0-0 -> 25.1.1-0
* [`cb2cb028`](https://github.com/NixOS/nixpkgs/commit/cb2cb028b09a0b4c14e9fb6b08474a3814117f3f) kubeswitch: 0.9.2 -> 0.9.3
* [`fe4e676f`](https://github.com/NixOS/nixpkgs/commit/fe4e676f53b7f0d7dd63026a904a4c5c624e96e4) midori-unwrapped: mark as broken
* [`21105d47`](https://github.com/NixOS/nixpkgs/commit/21105d474082be72ebd620082df34732d38408eb) firefoxpwa: mark it linux only
* [`b8564373`](https://github.com/NixOS/nixpkgs/commit/b856437376fd346ed9054a671ec602eff16f496f) firefox, thunderbird: enable wrapped derivations for darwin
* [`123b8874`](https://github.com/NixOS/nixpkgs/commit/123b8874a78666bb30990411049f1c7405c26b89) firefox: transform shell variables into nix expressions
* [`705cea1e`](https://github.com/NixOS/nixpkgs/commit/705cea1e5238eab3875b63cf916253c83a7e8bf8) thunderbird: fix build failure due to different path to omni.ja
* [`2c5b2531`](https://github.com/NixOS/nixpkgs/commit/2c5b25312aca35125bf7ebe6fcafb6988351e92b) firefox: also copy any embedded *.app bundles on Darwin
* [`6aa8e4a1`](https://github.com/NixOS/nixpkgs/commit/6aa8e4a1e9f533289679ae0625592c48dfb51223) python312Packages.ufo2ft: 3.4.0 -> 3.4.2
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
