### PR TITLE
niv home-manager: update c12dcc9b -> 70fbbf05

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -41,10 +41,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c12dcc9b61429b2ad437a7d4974399ad8f910319",
-        "sha256": "06z7yjxvlpj6iazzp05wl6mc1z0xaq98kvsdfgcvmy3zhav8a9q4",
+        "rev": "70fbbf05a5594b0a72124ab211bff1d502c89e3f",
+        "sha256": "1w40h2rdwag7pyk334vphni55b9akd90a9vaf0mg5w5ab8qq74pw",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/c12dcc9b61429b2ad437a7d4974399ad8f910319.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/70fbbf05a5594b0a72124ab211bff1d502c89e3f.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@c12dcc9b...70fbbf05](https://github.com/nix-community/home-manager/compare/c12dcc9b61429b2ad437a7d4974399ad8f910319...70fbbf05a5594b0a72124ab211bff1d502c89e3f)

* [`74f0a854`](https://github.com/nix-community/home-manager/commit/74f0a8546e3f2458c870cf90fc4b38ac1f498b17) clipse: add additional options ([nix-community/home-manager⁠#6525](https://togithub.com/nix-community/home-manager/issues/6525))
* [`18e74c2e`](https://github.com/nix-community/home-manager/commit/18e74c2e0225189858cd29890eb68212844efccc) aerc-accounts: improve logic for parsing XOAUTH2 URL params ([nix-community/home-manager⁠#6530](https://togithub.com/nix-community/home-manager/issues/6530))
* [`87743e93`](https://github.com/nix-community/home-manager/commit/87743e9383d4cbf4138dc65dd644822fc38e7bbf) firefox: deprecate vendorPath ([nix-community/home-manager⁠#6519](https://togithub.com/nix-community/home-manager/issues/6519))
* [`53c587d2`](https://github.com/nix-community/home-manager/commit/53c587d263f94aaf6a281745923c76bbec62bcf3) tmux: fix shell example ([nix-community/home-manager⁠#5361](https://togithub.com/nix-community/home-manager/issues/5361))
* [`44b86a72`](https://github.com/nix-community/home-manager/commit/44b86a72e73a7c3040ac54ed1c5eab5f156929bd) xidlehook: set Restart=always ([nix-community/home-manager⁠#6533](https://togithub.com/nix-community/home-manager/issues/6533))
* [`6be185eb`](https://github.com/nix-community/home-manager/commit/6be185eb76295e7562f5bf2da42afe374b8beb15) screen-locker: set Restart=always for all services ([nix-community/home-manager⁠#6534](https://togithub.com/nix-community/home-manager/issues/6534))
* [`b8869e4e`](https://github.com/nix-community/home-manager/commit/b8869e4ead721bbd4f0d6b927e8395705d4f16e6) mpd: Add support for darwin ([nix-community/home-manager⁠#6517](https://togithub.com/nix-community/home-manager/issues/6517))
* [`11e6d208`](https://github.com/nix-community/home-manager/commit/11e6d20803cb660094a7657b8f1653d96d61b527) ghostty: fix typo ([nix-community/home-manager⁠#6541](https://togithub.com/nix-community/home-manager/issues/6541))
* [`cf3bf4f1`](https://github.com/nix-community/home-manager/commit/cf3bf4f1b72077e287c36152b9fcead0cfa672d5) mpd: refactor implementation ([nix-community/home-manager⁠#6537](https://togithub.com/nix-community/home-manager/issues/6537))
* [`0208592b`](https://github.com/nix-community/home-manager/commit/0208592b59424449de69619d37f93f735de0fc33) idlehook: fix service.restart merge ([nix-community/home-manager⁠#6544](https://togithub.com/nix-community/home-manager/issues/6544))
* [`343646e0`](https://github.com/nix-community/home-manager/commit/343646e092696d94b6f22b6875ae685756fd4cf0) kitty: add action aliases config ([nix-community/home-manager⁠#6538](https://togithub.com/nix-community/home-manager/issues/6538))
* [`b71edac7`](https://github.com/nix-community/home-manager/commit/b71edac7a3167026aabea82a54d08b1794088c21) launchd: sync up with changes from nix-darwin ([nix-community/home-manager⁠#6508](https://togithub.com/nix-community/home-manager/issues/6508))
* [`f0b5e7e8`](https://github.com/nix-community/home-manager/commit/f0b5e7e8a75abdea32bbff09ddd7b6eeb4b9b445) xdg: add option 'xdg.cacheFile' ([nix-community/home-manager⁠#6548](https://togithub.com/nix-community/home-manager/issues/6548))
* [`4f05ef6a`](https://github.com/nix-community/home-manager/commit/4f05ef6a8adb5c2e9de83fee6d316ce168daf705) firefox: fix wrong syntax grammar for search setting isAppProvided ([nix-community/home-manager⁠#6556](https://togithub.com/nix-community/home-manager/issues/6556))
* [`30da4310`](https://github.com/nix-community/home-manager/commit/30da4310935450ea38931abf775ffe1dfab15355) librewolf: support darwin ([nix-community/home-manager⁠#6561](https://togithub.com/nix-community/home-manager/issues/6561))
* [`17fd27a8`](https://github.com/nix-community/home-manager/commit/17fd27a8ea2d38c52f66c7685e766113ca4b2982) tests: use mkDefault with enable
* [`47c69496`](https://github.com/nix-community/home-manager/commit/47c694963e86b3e0f5d387506642a830871f331e) tests: move xdg to cross platform tests
* [`66505b85`](https://github.com/nix-community/home-manager/commit/66505b851b160a6937053a73b9b9808659df8c56) xdg: add missing stateHome default for legacy
* [`fcac3d6d`](https://github.com/nix-community/home-manager/commit/fcac3d6d88302a5e64f6cb8014ac785e08874c8d) xdg: use mkOptionDefault
* [`70fbbf05`](https://github.com/nix-community/home-manager/commit/70fbbf05a5594b0a72124ab211bff1d502c89e3f) Firefox: Apply global extension force setting to declarative extensions ([nix-community/home-manager⁠#6567](https://togithub.com/nix-community/home-manager/issues/6567))
