### PR TITLE
niv nerd-icons.el: update a29fcbc2 -> 72d78d3a

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -77,10 +77,10 @@
         "homepage": null,
         "owner": "rainstormstudio",
         "repo": "nerd-icons.el",
-        "rev": "a29fcbc24a7827d5e97a05302398f15a155fe18a",
-        "sha256": "0pi2bs9nx9d4pvmsnv4dw0hpvrf8i29877cchnkpg1ykqbvap6hy",
+        "rev": "72d78d3ae973635068f9cd1682279c17fdf69b98",
+        "sha256": "1m6przvbbb3x5gx5q7z29wb3d9rcj1kd6vds3bw5sxdzdv6rwpgy",
         "type": "tarball",
-        "url": "https://github.com/rainstormstudio/nerd-icons.el/archive/a29fcbc24a7827d5e97a05302398f15a155fe18a.tar.gz",
+        "url": "https://github.com/rainstormstudio/nerd-icons.el/archive/72d78d3ae973635068f9cd1682279c17fdf69b98.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "niv": {


### PR DESCRIPTION
## Changelog for nerd-icons.el:
Branch: main
Commits: [rainstormstudio/nerd-icons.el@a29fcbc2...72d78d3a](https://github.com/rainstormstudio/nerd-icons.el/compare/a29fcbc24a7827d5e97a05302398f15a155fe18a...72d78d3ae973635068f9cd1682279c17fdf69b98)

* [`86c5b6ef`](https://github.com/rainstormstudio/nerd-icons.el/commit/86c5b6ef8613da08bcf131f91220224768d2480b) added comic book archive file icons
* [`8fa67977`](https://github.com/rainstormstudio/nerd-icons.el/commit/8fa679779541dc98a4247fb15de6c516a5407c0e) ci: support 29.4 and 30.1
* [`72d78d3a`](https://github.com/rainstormstudio/nerd-icons.el/commit/72d78d3ae973635068f9cd1682279c17fdf69b98) feat: support matlab, jupyter, d3js and apache
