### PR TITLE
niv home-manager: update 70fbbf05 -> 7fb86787

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -41,10 +41,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "70fbbf05a5594b0a72124ab211bff1d502c89e3f",
-        "sha256": "1w40h2rdwag7pyk334vphni55b9akd90a9vaf0mg5w5ab8qq74pw",
+        "rev": "7fb8678716c158642ac42f9ff7a18c0800fea551",
+        "sha256": "0mg9gkp1j34yjaam8pirj6garl8gz3rcjabs3njwdmr1irbiz9nr",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/70fbbf05a5594b0a72124ab211bff1d502c89e3f.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/7fb8678716c158642ac42f9ff7a18c0800fea551.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@70fbbf05...7fb86787](https://github.com/nix-community/home-manager/compare/70fbbf05a5594b0a72124ab211bff1d502c89e3f...7fb8678716c158642ac42f9ff7a18c0800fea551)

* [`3f08cd8e`](https://github.com/nix-community/home-manager/commit/3f08cd8ef77dcd7586075a460a61c8432baf25a9) ci: add labels for firefox ([nix-community/home-manager⁠#6520](https://togithub.com/nix-community/home-manager/issues/6520))
* [`6f71acf7`](https://github.com/nix-community/home-manager/commit/6f71acf71bd6a8a6f3152769737a53af6da6ae63) git: apply sendmailCmd instead of smtpServer ([nix-community/home-manager⁠#6399](https://togithub.com/nix-community/home-manager/issues/6399))
* [`b1b964ea`](https://github.com/nix-community/home-manager/commit/b1b964ea9348aef08cab514fa88e9c99def6fd63) mbsync: support maildir paths containing spaces
* [`def0dbbc`](https://github.com/nix-community/home-manager/commit/def0dbbcea715d4514ca343ab4d6d7f3a1742da0) vscode: Support Cursor AI ([nix-community/home-manager⁠#6417](https://togithub.com/nix-community/home-manager/issues/6417))
* [`f6ac8a34`](https://github.com/nix-community/home-manager/commit/f6ac8a3414181cb7e97fb76973a14bd661e9492f) flake.lock: Update
* [`486b0660`](https://github.com/nix-community/home-manager/commit/486b066025dccd8af7fbe5dd2cc79e46b88c80da) specialisation: escape specialisation name
* [`04c915bc`](https://github.com/nix-community/home-manager/commit/04c915bcf1a1eac3519372ff3185beef053fba7c) firefox: Support paths for userChrome & userContent ([nix-community/home-manager⁠#3856](https://togithub.com/nix-community/home-manager/issues/3856))
* [`83f46293`](https://github.com/nix-community/home-manager/commit/83f4629364b6e627ce25d7d246058e48ffa4b111) granted: support fish shell ([nix-community/home-manager⁠#6549](https://togithub.com/nix-community/home-manager/issues/6549))
* [`95711f92`](https://github.com/nix-community/home-manager/commit/95711f926676018d279ba09fe7530d03b5d5b3e2) treewide: remove with lib ([nix-community/home-manager⁠#6512](https://togithub.com/nix-community/home-manager/issues/6512))
* [`6c2b7940`](https://github.com/nix-community/home-manager/commit/6c2b79403e9ae852fbf1d55b29f2ea4d2aa43255) treewide: use graphical-session.target for GUI services ([nix-community/home-manager⁠#5785](https://togithub.com/nix-community/home-manager/issues/5785))
* [`d2c014e1`](https://github.com/nix-community/home-manager/commit/d2c014e1c73195d1958abec0c5ca6112b07b79da) treewide: null package support ([nix-community/home-manager⁠#6582](https://togithub.com/nix-community/home-manager/issues/6582))
* [`3ade6542`](https://github.com/nix-community/home-manager/commit/3ade65425772e5ee25989726b41074fcb4a9a372) tests/neovide: fix deprecation
* [`1347b0b4`](https://github.com/nix-community/home-manager/commit/1347b0b468ddf355657d58e50811238cfff517cb) tests: move vinegar to linux only
* [`5ab4305f`](https://github.com/nix-community/home-manager/commit/5ab4305f345ccf628fbcaa7a2dfd3696accd907b) gh-dash: fix
* [`26f6b862`](https://github.com/nix-community/home-manager/commit/26f6b862645ff281f3bada5d406e8c20de8d837c) tests/gh-dash: enable gh to test extension adding
* [`c040d1c5`](https://github.com/nix-community/home-manager/commit/c040d1c556476d9b82c7f3f1a0ce0906fcdf7108) xembed-sni-proxy: change default package ([nix-community/home-manager⁠#6587](https://togithub.com/nix-community/home-manager/issues/6587))
* [`2c87a647`](https://github.com/nix-community/home-manager/commit/2c87a6475fba12c9eb04ccb7375da0e32da48dc1) flake-module: rename `homeManagerModules` to `homeModules` ([nix-community/home-manager⁠#6406](https://togithub.com/nix-community/home-manager/issues/6406))
* [`b2314312`](https://github.com/nix-community/home-manager/commit/b2314312f2ee6893c83d0b5af74d949bc8530409) zsh: correct syntax option to syntax-highlighting ([nix-community/home-manager⁠#5792](https://togithub.com/nix-community/home-manager/issues/5792))
* [`20a6b363`](https://github.com/nix-community/home-manager/commit/20a6b3631bb9b9308a3ed2348e261c9029b5f7eb) navi: handle xdg directory on darwin ([nix-community/home-manager⁠#6589](https://togithub.com/nix-community/home-manager/issues/6589))
* [`65d6043d`](https://github.com/nix-community/home-manager/commit/65d6043d32db2bf7fa22abd274443485cecef053) flake.lock: Update ([nix-community/home-manager⁠#6588](https://togithub.com/nix-community/home-manager/issues/6588))
* [`7f4c60a3`](https://github.com/nix-community/home-manager/commit/7f4c60a3d6e548dbc13666565c22cb3f8dcdad44) podman: fix podman-user-wait-network-online ([nix-community/home-manager⁠#6586](https://togithub.com/nix-community/home-manager/issues/6586))
* [`b23c4d4c`](https://github.com/nix-community/home-manager/commit/b23c4d4cbe931240fad25bba01509edc03c3aac6) flake.lock: Update ([nix-community/home-manager⁠#6591](https://togithub.com/nix-community/home-manager/issues/6591))
* [`72580374`](https://github.com/nix-community/home-manager/commit/72580374c81ad8803675ee0dc829a60773d24401) Translate using Weblate (Chinese (Traditional Han script)) ([nix-community/home-manager⁠#6581](https://togithub.com/nix-community/home-manager/issues/6581))
* [`b74402e4`](https://github.com/nix-community/home-manager/commit/b74402e4e8f8cebbec860f0ba8fef2f703ad79f0) tests: expose scrubDerivation
* [`b3e11ed4`](https://github.com/nix-community/home-manager/commit/b3e11ed4a99bca48e47d7d7df6535c80dc73c79e) tests: central darwin stubbing
* [`91f88408`](https://github.com/nix-community/home-manager/commit/91f88408ccb7649dc6feec5ba565aee4e2097510) .github/workflows/test.yml: enable darwin tests
* [`1909541f`](https://github.com/nix-community/home-manager/commit/1909541fc7e844266df393a25c386cb4ca14f6e3) tests/targets-darwin: fix user-defaults test
* [`15498b94`](https://github.com/nix-community/home-manager/commit/15498b94ec2c7aa857864af105b72cb41def0b00) tests/syncthing: fix extra-options on darwin
* [`68540fb7`](https://github.com/nix-community/home-manager/commit/68540fb7755d3be96c71cfc5a6f43a3d615d9de7) tests/syncthing: syncthing wrapper stubbing for darwin
* [`4c964336`](https://github.com/nix-community/home-manager/commit/4c9643363a0f218a3d473149f6a024c8a66d0f62) tests/ollama: fix darwin test
* [`4f2c4612`](https://github.com/nix-community/home-manager/commit/4f2c4612861405d40bc81fa8a8575d15bee6e8d2) tests/yubikey-agent-darwin: fix test
* [`8d2a0581`](https://github.com/nix-community/home-manager/commit/8d2a05810834119b96531745de7943cc8ba5bb79) tests/thunderbird: fix darwin test
* [`1fd39a10`](https://github.com/nix-community/home-manager/commit/1fd39a105575ea997b32a043a0dd2c49294add5b) tests/vscode: fix darwin snippets test
* [`07f505f9`](https://github.com/nix-community/home-manager/commit/07f505f91e0c7112550845425222f41865c4260a) qt: add "kde6" to qt.platformTheme ([nix-community/home-manager⁠#6493](https://togithub.com/nix-community/home-manager/issues/6493))
* [`277eea1c`](https://github.com/nix-community/home-manager/commit/277eea1cc7a5c37ea0b9aa8198cd1f2db3d6715c) home-environment: add home.sessionSearchVariables
* [`601f8d07`](https://github.com/nix-community/home-manager/commit/601f8d073c0b2f1fb4601b4727fb43ba6412685b) im/fcitx5: use home.sessionSearchVariables for QT_PLUGIN_PATH
* [`daab3230`](https://github.com/nix-community/home-manager/commit/daab32302b0bdd9bfff9e75d32375353d95b9c4f) debug: use home.sessionSearchVariables for NIX_DEBUG_INFO_DIRS
* [`5094e32c`](https://github.com/nix-community/home-manager/commit/5094e32ccea3168a5cb9ee6e3b7e74aaf4d866a9) home-cursor: use home.sessionSearchVariables for XCURSOR_PATH
* [`ab56fd8d`](https://github.com/nix-community/home-manager/commit/ab56fd8db811581323bb7aecd9c47c5956b3b17c) targets/generic-linux: use home.sessionSearchVariables for XCURSOR_PATH
* [`cf47e7ea`](https://github.com/nix-community/home-manager/commit/cf47e7ea2182c5638fdd1b42de329cc7d185cf8b) qt: use home.sessionSearchVariables
* [`2967de4d`](https://github.com/nix-community/home-manager/commit/2967de4d1146f1b6aa820eed85b823ea2ebfd0fa) debug: make NIX_DEBUG_INFO_DIRS a list of strings ([nix-community/home-manager⁠#6595](https://togithub.com/nix-community/home-manager/issues/6595))
* [`db4386d6`](https://github.com/nix-community/home-manager/commit/db4386d686fb0b2788e7422e6a2299deace9c4b1) home-environment: add line-break after sessionSearchVariables ([nix-community/home-manager⁠#6596](https://togithub.com/nix-community/home-manager/issues/6596))
* [`597f9c2f`](https://github.com/nix-community/home-manager/commit/597f9c2f06af8791b31c48ad05471ac5afbd0f0a) thunderbird: set additional gmail server settings ([nix-community/home-manager⁠#6579](https://togithub.com/nix-community/home-manager/issues/6579))
* [`f8bb0ba6`](https://github.com/nix-community/home-manager/commit/f8bb0ba6de361c43c1c1e9756375f23ffadac1f9) zoxide: update mkOrder to place bash configuration at end of bashrc ([nix-community/home-manager⁠#6572](https://togithub.com/nix-community/home-manager/issues/6572))
* [`ce9cb249`](https://github.com/nix-community/home-manager/commit/ce9cb2496c48ebb33e42ee0ab82267f67b82f71e) podman: added volume, image, and build quadlets ([nix-community/home-manager⁠#6137](https://togithub.com/nix-community/home-manager/issues/6137))
* [`744f749d`](https://github.com/nix-community/home-manager/commit/744f749dd6fbc1489591ea370b95156858629cb9) mods: add a mods module ([nix-community/home-manager⁠#6339](https://togithub.com/nix-community/home-manager/issues/6339))
* [`3593ee59`](https://github.com/nix-community/home-manager/commit/3593ee59a44974b8518829a5239b2f77222e3c81) xdg-mime: Fix cross compilation ([nix-community/home-manager⁠#6500](https://togithub.com/nix-community/home-manager/issues/6500))
* [`7fb86787`](https://github.com/nix-community/home-manager/commit/7fb8678716c158642ac42f9ff7a18c0800fea551) Fix missing styleName for kde6 ([nix-community/home-manager⁠#6597](https://togithub.com/nix-community/home-manager/issues/6597))
