### PR TITLE
niv nerd-icons.el: update 72d78d3a -> 43178575

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -77,10 +77,10 @@
         "homepage": null,
         "owner": "rainstormstudio",
         "repo": "nerd-icons.el",
-        "rev": "72d78d3ae973635068f9cd1682279c17fdf69b98",
-        "sha256": "1m6przvbbb3x5gx5q7z29wb3d9rcj1kd6vds3bw5sxdzdv6rwpgy",
+        "rev": "43178575201e3d2ef8c4a507ed4c281b0936f39a",
+        "sha256": "1hvnl3xpn5d3pg6i1minzv6sjc9dahs2snzlsy76wvwf4kcjf9z5",
         "type": "tarball",
-        "url": "https://github.com/rainstormstudio/nerd-icons.el/archive/72d78d3ae973635068f9cd1682279c17fdf69b98.tar.gz",
+        "url": "https://github.com/rainstormstudio/nerd-icons.el/archive/43178575201e3d2ef8c4a507ed4c281b0936f39a.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "niv": {


### PR DESCRIPTION
## Changelog for nerd-icons.el:
Branch: main
Commits: [rainstormstudio/nerd-icons.el@72d78d3a...43178575](https://github.com/rainstormstudio/nerd-icons.el/compare/72d78d3ae973635068f9cd1682279c17fdf69b98...43178575201e3d2ef8c4a507ed4c281b0936f39a)

* [`d0240d36`](https://github.com/rainstormstudio/nerd-icons.el/commit/d0240d36d8f98586687b251acf53e0086798afa8) fix!: use correct names for matlab, jupyter, d3js and apache
* [`d75364b9`](https://github.com/rainstormstudio/nerd-icons.el/commit/d75364b982afda171cccca6d9c6d4c06ec03c91d) Add icons for several modes/file types ([rainstormstudio/nerd-icons.el⁠#99](https://togithub.com/rainstormstudio/nerd-icons.el/issues/99))
* [`ce7c7d99`](https://github.com/rainstormstudio/nerd-icons.el/commit/ce7c7d99e0f304e4da0c0f997dbacf8cd38a7899) change the go icon from devicon to sucicon ([rainstormstudio/nerd-icons.el⁠#104](https://togithub.com/rainstormstudio/nerd-icons.el/issues/104))
* [`a9cb361c`](https://github.com/rainstormstudio/nerd-icons.el/commit/a9cb361cc8320586adbe83e747164a40bde8c1c1) add an icon for the old kdb keepass database format
* [`43178575`](https://github.com/rainstormstudio/nerd-icons.el/commit/43178575201e3d2ef8c4a507ed4c281b0936f39a) add icons for arch packaging files
