### PR TITLE
niv home-manager: update 7fb86787 -> c657142e

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -41,10 +41,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "7fb8678716c158642ac42f9ff7a18c0800fea551",
-        "sha256": "0mg9gkp1j34yjaam8pirj6garl8gz3rcjabs3njwdmr1irbiz9nr",
+        "rev": "c657142e24a43ea1035889f0b0a7c24598e0e18a",
+        "sha256": "05v0p3c9yqwj01aa8ryzk5fi8cassvmivbm66vxfcf2xpcajivnm",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/7fb8678716c158642ac42f9ff7a18c0800fea551.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/c657142e24a43ea1035889f0b0a7c24598e0e18a.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@7fb86787...c657142e](https://github.com/nix-community/home-manager/compare/7fb8678716c158642ac42f9ff7a18c0800fea551...c657142e24a43ea1035889f0b0a7c24598e0e18a)

* [`7fd6dc2b`](https://github.com/nix-community/home-manager/commit/7fd6dc2b94f10b0229f5e6b8fd5ed49636f895e1) granted: fix fish shell integration ([nix-community/home-manager⁠#6602](https://togithub.com/nix-community/home-manager/issues/6602))
* [`c630dfa8`](https://github.com/nix-community/home-manager/commit/c630dfa8abcc65984cc1e47fb25d4552c81dd37e) nix-darwin: respect username setting of home-manager in activation script ([nix-community/home-manager⁠#5881](https://togithub.com/nix-community/home-manager/issues/5881))
* [`5871e21c`](https://github.com/nix-community/home-manager/commit/5871e21c1145f3f5e278545d1c09539b52183ccd) screen-locker: add lockCmdEnv option ([nix-community/home-manager⁠#6592](https://togithub.com/nix-community/home-manager/issues/6592))
* [`dd41a390`](https://github.com/nix-community/home-manager/commit/dd41a39055d7eb54330b5cd0611467e5d687d022) swaylock: accept path type for settings values ([nix-community/home-manager⁠#6607](https://togithub.com/nix-community/home-manager/issues/6607))
* [`144f13f5`](https://github.com/nix-community/home-manager/commit/144f13f535be35c906241043f6bfcf21c1c419a0) flake.lock: Update ([nix-community/home-manager⁠#6606](https://togithub.com/nix-community/home-manager/issues/6606))
* [`32531e45`](https://github.com/nix-community/home-manager/commit/32531e457215000b739da6cd40acfb080823f396) home-cursor: explicit lib usage
* [`00712ac0`](https://github.com/nix-community/home-manager/commit/00712ac0fb87bbfa13e892603863469ac4fd96a0) home-cursor: use .enable pattern
* [`dcc20acf`](https://github.com/nix-community/home-manager/commit/dcc20acf93f338a47468996a0055cda1112c051c) home-cursor: add doticons option
* [`74f2ed6a`](https://github.com/nix-community/home-manager/commit/74f2ed6a64a087fadb39a4af84c5ecc8083b686d) test/home-cursor: add new .enable check
* [`18780912`](https://github.com/nix-community/home-manager/commit/18780912345970e5b546b1b085385789b6935a83) home-cursor: louder deprecation
* [`7832b5aa`](https://github.com/nix-community/home-manager/commit/7832b5aa95f68a421dc9b4b3c17dcf942ac6145b) zsh: refactor zsh configuration for better order control over `.zshrc` ([nix-community/home-manager⁠#6479](https://togithub.com/nix-community/home-manager/issues/6479))
* [`ef257da5`](https://github.com/nix-community/home-manager/commit/ef257da52a299a47cc7235da270ab3b427a4ea5b) docs: enhance comment for home.stateVersion option ([nix-community/home-manager⁠#6116](https://togithub.com/nix-community/home-manager/issues/6116))
* [`6576167e`](https://github.com/nix-community/home-manager/commit/6576167e6b3f2b5c60e48b62f792410bd3b4824c) macos-remap-keys: add ([nix-community/home-manager⁠#6605](https://togithub.com/nix-community/home-manager/issues/6605))
* [`d30c1d30`](https://github.com/nix-community/home-manager/commit/d30c1d30bfbc287883c3d9e2ee811e2ac22ff879) zoxide: move to bottom of zsh content
* [`56374cc6`](https://github.com/nix-community/home-manager/commit/56374cc64d58451b359bb4e8502387d3a96e7c7b) zoxide: remove with lib
* [`b5142d46`](https://github.com/nix-community/home-manager/commit/b5142d46a3f912ef99e9cec3e51d757fbeaf14ea) zsh: remove with lib
* [`ad487d38`](https://github.com/nix-community/home-manager/commit/ad487d3863e94ac839b2e1e451197ab5a4aafd1b) zsh: move config variables closer to usage
* [`1b0efe3d`](https://github.com/nix-community/home-manager/commit/1b0efe3d335f452595512c7b275e5dddfbfb28a5) zsh: move option variables closer to usage
* [`5d511628`](https://github.com/nix-community/home-manager/commit/5d5116286269c4e11976f6450afde1b30c3834c0) syncthing: have tray wait in submodule ([nix-community/home-manager⁠#6617](https://togithub.com/nix-community/home-manager/issues/6617))
* [`0e46e842`](https://github.com/nix-community/home-manager/commit/0e46e84279d3d8eb7dcb044cb8aa9baa93298e66) zsh: cleanup empty / wrong generated lines
* [`0b0baed7`](https://github.com/nix-community/home-manager/commit/0b0baed7b2bf6a5e365d4cba042b580a2bc32e34) tests/default: blacklist sapling
* [`8f8f5432`](https://github.com/nix-community/home-manager/commit/8f8f5432d152d64dfde0e77c61530c3754dce660) tests/zsh: fix zshrc content priority test
* [`6914c15c`](https://github.com/nix-community/home-manager/commit/6914c15c09e3e635ce678eb72f5781e5a85a6b24) tests/default: scrub zsh
* [`30cce684`](https://github.com/nix-community/home-manager/commit/30cce6848a5aa41ceb5fb33185b84868cc3e9bef) synthing: fix synthing config being deleted on rebuild ([nix-community/home-manager⁠#6621](https://togithub.com/nix-community/home-manager/issues/6621))
* [`e30c6a41`](https://github.com/nix-community/home-manager/commit/e30c6a41bc8548738341d10c0b17f8fead8e55ee) megasync: remove with lib
* [`4e12151c`](https://github.com/nix-community/home-manager/commit/4e12151c9e014e2449e0beca2c0e9534b96a26b4) megasync: add option to enable wayland
* [`5a6e5a59`](https://github.com/nix-community/home-manager/commit/5a6e5a59a4d332edaa7d5d1604eb58ead27af851) tests: stub more expected packages darwin ([nix-community/home-manager⁠#6649](https://togithub.com/nix-community/home-manager/issues/6649))
* [`e94ec0a6`](https://github.com/nix-community/home-manager/commit/e94ec0a6cd4cabca56b9bc2d5e2c05374132f34a) kubecolor: add enableZshIntegration option for completion
* [`f9f766c6`](https://github.com/nix-community/home-manager/commit/f9f766c6009410f4523f28cfc0ec7d194b2676fa) kubecolor: add oc alias
* [`f55c5f65`](https://github.com/nix-community/home-manager/commit/f55c5f6569c98f36969def802f84bde44f254f41) kubecolor: create oc alias conditionally
* [`eae06a96`](https://github.com/nix-community/home-manager/commit/eae06a96af1903655f06cb401907555ea4048357) ci: bump cachix/install-nix-action from 30 to 31 ([nix-community/home-manager⁠#6643](https://togithub.com/nix-community/home-manager/issues/6643))
* [`18e7d548`](https://github.com/nix-community/home-manager/commit/18e7d548992eb1900fdaad5f1a3eb8fd849b0cdd) ci: bump cachix/cachix-action from 15 to 16 ([nix-community/home-manager⁠#6644](https://togithub.com/nix-community/home-manager/issues/6644))
* [`b870fb2d`](https://github.com/nix-community/home-manager/commit/b870fb2d62ee0deb657951f83e8689143dce98c8) zsh: update zsh initContent example to use lib.literalExpression ([nix-community/home-manager⁠#6637](https://togithub.com/nix-community/home-manager/issues/6637))
* [`c657142e`](https://github.com/nix-community/home-manager/commit/c657142e24a43ea1035889f0b0a7c24598e0e18a) thunderbird: add message filters option  ([nix-community/home-manager⁠#6652](https://togithub.com/nix-community/home-manager/issues/6652))
