### PR TITLE
niv nixpkgs: update 4957613f -> a3383f5f

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4957613fe2351224fe2b985a642f2551a778313c",
-        "sha256": "12mcj8wdlp4y7ia6wx9f1yfgwsf4qn92wzla2pjkhlm2c94fm54d",
+        "rev": "a3383f5fdb09b4d2d79f24f793d7784d0886c909",
+        "sha256": "0q6r5czws5nnlbhpry5igxl4f05jpr42f3zjymld464gszcf92zg",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/4957613fe2351224fe2b985a642f2551a778313c.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/a3383f5fdb09b4d2d79f24f793d7784d0886c909.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@4957613f...a3383f5f](https://github.com/nixos/nixpkgs/compare/4957613fe2351224fe2b985a642f2551a778313c...a3383f5fdb09b4d2d79f24f793d7784d0886c909)

* [`3304b346`](https://github.com/NixOS/nixpkgs/commit/3304b34644632347204064d80b9fb1c6d697e5ac) pop-wallpapers: init at 1.0.5
* [`a3f30129`](https://github.com/NixOS/nixpkgs/commit/a3f30129b3a11d579c7747023e53f42d88853516) pop-hp-wallpapers: init at 0-unstable-2022-04-01
* [`2565eb3c`](https://github.com/NixOS/nixpkgs/commit/2565eb3c62ad0e149ab782beafef46cf24a372a9) system76-wallpapers: init at 0-unstable-2024-04-26
* [`ce799c73`](https://github.com/NixOS/nixpkgs/commit/ce799c73e5eb78e5011ebedaa25fec4b11792ac2) nixos/influxdb: Replace custom drv with `pkgs.formats.toml`
* [`429f8968`](https://github.com/NixOS/nixpkgs/commit/429f89688ae073199a52371d16ebe6c624f2f84d) nixos/athens: Replace custom `jq`-based `runCommand` with `pkgs.formats`
* [`94b7b469`](https://github.com/NixOS/nixpkgs/commit/94b7b469aa6ae3f3b7adb08d325eaa6eb434735e) nixos/promtail: Replace custom `jq`-based `runCommand` with `pkgs.formats`
* [`7a2e88f7`](https://github.com/NixOS/nixpkgs/commit/7a2e88f7c13ca9043d6ee1606f7d3239dde8d76b) nixos/traefik: Replace custom config format handling with `pkgs.formats`
* [`adaee656`](https://github.com/NixOS/nixpkgs/commit/adaee656c26fcfb6c84f0d9b742b102851b4aa5f) nixos/ncdns: Replace custom config format handling with `pkgs.formats.toml`
* [`b375b563`](https://github.com/NixOS/nixpkgs/commit/b375b56327f6c8ea3756dfd3d79fddeb17e96a05) nixos/ncdns: remove dead code, mark unused parameters with `_`
* [`46c93546`](https://github.com/NixOS/nixpkgs/commit/46c93546e1d6fe0ab337ba0453a67efa4b1340ae) nixos/thanos: Replace custom config format handling with `pkgs.formats.yaml`
* [`9cfd0a44`](https://github.com/NixOS/nixpkgs/commit/9cfd0a448db964105cfde6c5ebf9c0b5df614e11) clightning: 24.11 -> 24.11.1
* [`1b644053`](https://github.com/NixOS/nixpkgs/commit/1b644053b0be6f686e49596df9bf3dba07cf1b3b) firebird_4: 4.0.2 → 4.0.5
* [`964583f5`](https://github.com/NixOS/nixpkgs/commit/964583f52197b3046c9b196d07b34125cedbd01b) cddl: 0.10.3 -> 0.12.9
* [`3c85958f`](https://github.com/NixOS/nixpkgs/commit/3c85958fdc1b8cdd0976902b8e386dde5844690f) bundlerUpdateScript: format `gemset.nix` with nixfmt
* [`8e3dc64d`](https://github.com/NixOS/nixpkgs/commit/8e3dc64d2efbf22d6f5fe8bb10eda04c5efcf464) cups-bjnp: ignore unused variable
* [`e058c9eb`](https://github.com/NixOS/nixpkgs/commit/e058c9eb0d01ffcd28ac93fe5b94e0c7bcf54e40) openutau: Provide desktop file
* [`4c74e1e4`](https://github.com/NixOS/nixpkgs/commit/4c74e1e457848f4a48d375a302ce422ae280ecff) openutau: Remove trailing whitespaces
* [`e8929f52`](https://github.com/NixOS/nixpkgs/commit/e8929f52396d3797171be625edbf1315ffecc800) facetimehd-firmware: fix strictDeps build
* [`c4a76fc3`](https://github.com/NixOS/nixpkgs/commit/c4a76fc3012da7e17db0487efbbfacb8458858db) sonic-visualiser: use propagated build inputs
* [`3c8370ea`](https://github.com/NixOS/nixpkgs/commit/3c8370ea18a2f9ecb98e5087e2d8f8da4376e372) syslinux: disable PIE hardening
* [`b19212c6`](https://github.com/NixOS/nixpkgs/commit/b19212c61fcfbfc6dfd00d1f473310dec257314c) python3Packages.sphinx-favicon: init at 1.0.1
* [`92d35b69`](https://github.com/NixOS/nixpkgs/commit/92d35b6997a41b1a49efc95a8853b03bb3bdcf62) openutau: Replace `cp` with `install`
* [`b815917c`](https://github.com/NixOS/nixpkgs/commit/b815917c0c051cb3f81e2b9d022dfa2194482337) openutau: Remove trailing whitespace
* [`b7a9e747`](https://github.com/NixOS/nixpkgs/commit/b7a9e74716478f0617681fa865f3cc76dc6933ea) python3Packages.simple-term-menu: 1.6.4 -> 1.6.6
* [`1b868292`](https://github.com/NixOS/nixpkgs/commit/1b86829256bf2922ac9db5bc048f34a975c238f3) ttl2c: init at 1.0.1
* [`50ac4759`](https://github.com/NixOS/nixpkgs/commit/50ac47592a145b124c1c8f9e8b936237df9d3942) jellyflix: init at 1.0.0
* [`66cd5f89`](https://github.com/NixOS/nixpkgs/commit/66cd5f891b8519385f6c7feac3343e3f9beeacf0) ashell: init at 0.3.1
* [`9bda12a6`](https://github.com/NixOS/nixpkgs/commit/9bda12a60b16d4ca73fa609028e4ff6045f01d3d) python312Packages.rebulk: fix test inputs, cleanup
* [`120a97ab`](https://github.com/NixOS/nixpkgs/commit/120a97ab2e98f16dca9eca4dfa827d9b91af06ac) firebird_4: fix strictDeps build
* [`52a5eb1a`](https://github.com/NixOS/nixpkgs/commit/52a5eb1ad3e9872a5a51543cb101875044368b5d) ombi: 4.44.1 -> 4.47.1
* [`e214cec7`](https://github.com/NixOS/nixpkgs/commit/e214cec777baa6c118becee4e8d0d4829b78bd71) maintainers: add thornoar
* [`6192e157`](https://github.com/NixOS/nixpkgs/commit/6192e1577fb9267fa4601400b57d7d45431ecabf) libfm: fetch gcc 14 patch and refactor
* [`21a498eb`](https://github.com/NixOS/nixpkgs/commit/21a498eb60aa272777866b2ffa5d6f481e9e2a56) lcov: 2.2 -> 2.3
* [`265889bb`](https://github.com/NixOS/nixpkgs/commit/265889bb323460e991514c31d60ef08cf2a9967a) depotdownloader: 2.7.4 -> 3.0.0
* [`72b02694`](https://github.com/NixOS/nixpkgs/commit/72b0269435c8a1d52455f8c8fea0078d04365962) xsw: fix GCC 14 build
* [`e69f0c5c`](https://github.com/NixOS/nixpkgs/commit/e69f0c5c4b6d7b850b67ce387ecf3a1dd33f160b) caribou: fix strictDeps build, mark cross as broken
* [`8f1e7d81`](https://github.com/NixOS/nixpkgs/commit/8f1e7d81d5112b084251d980bcc39eaaea78f914) xfe: 1.46.2 -> 2.0
* [`81077e83`](https://github.com/NixOS/nixpkgs/commit/81077e83aec798ae14c4d1844af0970242b9acef) godot3: fix PIE hardening
* [`304a6956`](https://github.com/NixOS/nixpkgs/commit/304a69568ce30e4312119f130214ab8efa1f64f6) luaPackages.argparse: fix strictDeps build
* [`f0f9237a`](https://github.com/NixOS/nixpkgs/commit/f0f9237a399cb7ac4aca54a0ea3a4a2dc0a72837) mudlet: fix strictDeps build
* [`4e89837f`](https://github.com/NixOS/nixpkgs/commit/4e89837f4e475db75b1cd54cefb0fc2ce4be6f52) alacritty-theme: don't litter /
* [`eb1d01fb`](https://github.com/NixOS/nixpkgs/commit/eb1d01fb3a15c7a522fa56c7662221518117976e) processing: 4.3.1 -> 4.3.2
* [`f3c2be6d`](https://github.com/NixOS/nixpkgs/commit/f3c2be6d27198f92f37f4ef401d00b1e7aa15a40) buf: increase test timeout
* [`36c0d740`](https://github.com/NixOS/nixpkgs/commit/36c0d740c6fae16c57136e42991a361e06f67e76) nixos/graylog: change default package version to 6.0
* [`7eed7c8d`](https://github.com/NixOS/nixpkgs/commit/7eed7c8da606a38083a3d750f018236d3484f859) graylog-5_1: remove
* [`f7dbc8c7`](https://github.com/NixOS/nixpkgs/commit/f7dbc8c7d46c12caaa63d23d62bfd77ceb302bf1) python312Packages.netbox-bgp: 0.14.0 -> 0.15.0
* [`8e0d80f9`](https://github.com/NixOS/nixpkgs/commit/8e0d80f9e02457d7a764f3ca5c60fda157ef5df1) skyscraper: init at 3.14.0
* [`cc4da995`](https://github.com/NixOS/nixpkgs/commit/cc4da995d97fb3e660df9dc8d701a47991841ff7) libchewing: mark cross as broken
* [`8cd90aba`](https://github.com/NixOS/nixpkgs/commit/8cd90aba7cf9cf3a79ec410a7c0cbee45cddd1b7) python312Packages.rectpack: init at 0.2.2
* [`b959cc84`](https://github.com/NixOS/nixpkgs/commit/b959cc840e4a8ca364f1f642cdf45130d5c52c17) image_optim: 0.31.3 -> 0.31.4
* [`c7ff62a9`](https://github.com/NixOS/nixpkgs/commit/c7ff62a95b7d007c26e79a9af373edaf007f07da) nudoku: 2.1.0 -> 5.0.0
* [`76abaee7`](https://github.com/NixOS/nixpkgs/commit/76abaee704b870870c50b8969bd353b5e5525e1b) lzip: 1.24.1 -> 1.25
* [`67cde075`](https://github.com/NixOS/nixpkgs/commit/67cde07547a12e811ad03e205678bb1f0a2119bd) frink: 2024-05-09 -> 2025-01-07
* [`dc450a71`](https://github.com/NixOS/nixpkgs/commit/dc450a713d455f93a20759646b6a83158a8306a8) guile-config: fix cross build
* [`40eeae15`](https://github.com/NixOS/nixpkgs/commit/40eeae1500a8b52314379baad2aba1be9f353a28) guile-hall: fix cross build
* [`629b6e25`](https://github.com/NixOS/nixpkgs/commit/629b6e259b546e2e40681918a6314d98b3409b82) graalvmPackages.graalvm-oracle: 22.0.2 -> 23.0.2
* [`95b894ba`](https://github.com/NixOS/nixpkgs/commit/95b894bad77bf210e83cb7a38e7130409cefe1fe) nixos/k3s: add `autoDeployCharts` option
* [`d3cd8299`](https://github.com/NixOS/nixpkgs/commit/d3cd8299b44e829500c9237554a90121c3f47ada) nixos/k3s: use systemd-tmpfiles to activate k3s content
* [`c6f2f8b7`](https://github.com/NixOS/nixpkgs/commit/c6f2f8b736c32514ea8f0665a9b3555ea35a9045) ashell: 0.3.1 -> 0.4.0
* [`9f1341ff`](https://github.com/NixOS/nixpkgs/commit/9f1341ff05f5a4d0f7a4e6f7f3a529fd60d1f18e) python312Packages.bytecode: 0.16.0 -> 0.16.1
* [`b97bcb72`](https://github.com/NixOS/nixpkgs/commit/b97bcb724fd9070718b7bacba148101647734f74) confluent-cli: 3.60.0 -> 4.16.0
* [`fe5fe34a`](https://github.com/NixOS/nixpkgs/commit/fe5fe34a60eb2b1ce8741647e76334be44423ed2) dbus-sharp{,-glib}-{1,2}_0: fix strictDeps build
* [`c74b9a33`](https://github.com/NixOS/nixpkgs/commit/c74b9a33050c12a1417ed1152b5a142961c9280c) mysql_jdbc: 9.1.0 -> 9.2.0
* [`26665fa4`](https://github.com/NixOS/nixpkgs/commit/26665fa4570b9c2e7f9c095d2c6a75566c4f1ca5) ropgadget: 7.5 -> 7.6
* [`1fef9523`](https://github.com/NixOS/nixpkgs/commit/1fef9523533413b81b2df57ca4d6fa9d2c6b7487) include-what-you-use: 0.22 -> 0.23
* [`846ed3d8`](https://github.com/NixOS/nixpkgs/commit/846ed3d86b7ada28ede8a8847990aacb9cff74fd) qc71_laptop: 2023-03-02 -> 2025-01-07
* [`0d6d5b3a`](https://github.com/NixOS/nixpkgs/commit/0d6d5b3a0fb15c46b6c1282c6ffef0dbba98f7f3) qc71_laptop: add updateScript
* [`dea0cb06`](https://github.com/NixOS/nixpkgs/commit/dea0cb06e3e0bd890d814f9f9b0d9581e93a6a10) nixos/open-webui: add additional systemd hardening
* [`3d4b0751`](https://github.com/NixOS/nixpkgs/commit/3d4b075101e81340fc4b05984b67fc194829b758) mdk-sdk: 0.30.1 -> 0.31.0
* [`8984ab5c`](https://github.com/NixOS/nixpkgs/commit/8984ab5c27d49775cea037217636651829d9735f) epson-workforce-635-nx625-series: fix GCC 14 build
* [`e0e12010`](https://github.com/NixOS/nixpkgs/commit/e0e12010414f7976a58ddc1a1e883b0bf5af00a1) darwin.stdenv: drop libtapi from allowedRequisites
* [`ad6f48ca`](https://github.com/NixOS/nixpkgs/commit/ad6f48ca42fe476206446564d6baffc956ef3f6e) solc: remove Z3 version hardcoding
* [`af92d6c5`](https://github.com/NixOS/nixpkgs/commit/af92d6c5f6f7e8ec76e58c93d207099077754de4) torzu: use system vulkan libraries
* [`069a69ca`](https://github.com/NixOS/nixpkgs/commit/069a69ca406fd77a55a4b78d6a355e11ca7d4bdc) torzu: remove old ffmpeg code
* [`89f0fa2f`](https://github.com/NixOS/nixpkgs/commit/89f0fa2faa2f9f5402fcb9642dd0b1aea180efca) torzu: use structured args
* [`d0460eb1`](https://github.com/NixOS/nixpkgs/commit/d0460eb15a406f235c5a571e7f1cbfe4ea02f6a1) simpleini: cherry pick cmake fixes from master
* [`97ef6bd4`](https://github.com/NixOS/nixpkgs/commit/97ef6bd4debbc9bc3ee81921a12083d073406cd6) torzu: use simpleini from system
* [`076c670e`](https://github.com/NixOS/nixpkgs/commit/076c670e2f7d8865ed40949dbf4ea7b653e6e284) Fix building on aarch64-linux
* [`f5512d79`](https://github.com/NixOS/nixpkgs/commit/f5512d79a77afd8216454fd346e84a4fbde8944a) maintainers: add awwpotato
* [`e4a116bc`](https://github.com/NixOS/nixpkgs/commit/e4a116bc24e5787da342d120d2f3ad6b62bd6304) tartube-yt-dlp: 2.5.062 -> 2.5.100
* [`f94db112`](https://github.com/NixOS/nixpkgs/commit/f94db112a4e0734438cfba23d07173855ff7ccb5) jacktrip: 2.4.1 -> 2.5.1
* [`5690ef05`](https://github.com/NixOS/nixpkgs/commit/5690ef052935a730f064d6232dba74f78ce4226c) tree-sitter: 0.24.6 -> 0.25.1
* [`53dbcddc`](https://github.com/NixOS/nixpkgs/commit/53dbcddc09619e88a8d115a6ffb3dbf9b44c3fbe) tree-sitter: fix grammar update doc comment
* [`7cad2aa7`](https://github.com/NixOS/nixpkgs/commit/7cad2aa70b73f67dc71b50d52b8dc977f391f8c8) atproto-goat: 0-unstable-2024-10-29 -> 0-unstable-2025-02-01
* [`d0c3b639`](https://github.com/NixOS/nixpkgs/commit/d0c3b639ecfc9721c49c1d1bfa06730f741eb44f) maintainers: add naelstrof
* [`c3e0d514`](https://github.com/NixOS/nixpkgs/commit/c3e0d51465f2745c9065af954023cfed8446e15a) vvvvvv: 2.4.1 -> 2.4.2
* [`4dbad1c7`](https://github.com/NixOS/nixpkgs/commit/4dbad1c78157a01e03a9ea8efcffcec692b216c9) zsh-histdb: init at 0-unstable-2024-04-18
* [`b490d92c`](https://github.com/NixOS/nixpkgs/commit/b490d92cc706d821e32c277740c1867eb622fffb) butler: init at 15.24.0
* [`1bebfb87`](https://github.com/NixOS/nixpkgs/commit/1bebfb87fa2617d0feb954489d9c6b4a93f5e2d1) python3Packages.language-tool-python: init at 2.8.0
* [`d186b22e`](https://github.com/NixOS/nixpkgs/commit/d186b22eed7fe754bb396dc0f9d5c7ff9c5957e1) textlsp: init at 0.3.2
* [`17c01aad`](https://github.com/NixOS/nixpkgs/commit/17c01aad84c52457a5dd20fa609d872d156fa5be) gcc: explicitly disallow cross + multilib, extract targetLibDir to variable
* [`5e2e98f3`](https://github.com/NixOS/nixpkgs/commit/5e2e98f3b71f1b7e0168e5c071bc9dff029287cb) gcc: document, clean up, undangle install symlink hacks
* [`a820a1b6`](https://github.com/NixOS/nixpkgs/commit/a820a1b67b71c2d6c5f2e0d922acf06f4fae8244) Revert "gcc: disable symlink checks on cross + nolibc for now"
* [`50319982`](https://github.com/NixOS/nixpkgs/commit/50319982e02a215128107b5b30ad310fd4dc5ee3) Revert "libgccjit, gccgo*: remove a reflexive symlink"
* [`49e018f3`](https://github.com/NixOS/nixpkgs/commit/49e018f37847afdc379b9c86e589fe4a0521cd97) gpt-cli: init at 0.3.2
* [`cc2a9d1c`](https://github.com/NixOS/nixpkgs/commit/cc2a9d1c08547c1969754e1310eafd6d1db5fbad) node-gyp: 11.0.0 -> 11.1.0
* [`17037d29`](https://github.com/NixOS/nixpkgs/commit/17037d293ae5e94ae2709db6701d7bc70e91480d) taglib: 1.13.1 -> 2.0.2, taglib_1: init at 1.13.1
* [`eac18d20`](https://github.com/NixOS/nixpkgs/commit/eac18d2059ab89969eac8dce1bbb758807a37b34) go, buildGoModule: default to 1.24
* [`df15e5ec`](https://github.com/NixOS/nixpkgs/commit/df15e5ec57deaae1f88e2848556d17dd247ac4de) python312Packages.pytest-datadir: 1.5.0 -> 1.6.1
* [`00a8c125`](https://github.com/NixOS/nixpkgs/commit/00a8c125b00ce8164b3993be636d4c59fc073597) nixos/kerberos_server: add the "get-keys" ACL permission
* [`b58db919`](https://github.com/NixOS/nixpkgs/commit/b58db91905cbc253218532bb9feb55addc9d47b5) curl: 8.12.0 -> 8.12.1
* [`6977084a`](https://github.com/NixOS/nixpkgs/commit/6977084aa998457e275f5f9f77ec8a40efac3d53) x264: 0-unstable-2023-10-01 -> 0-unstable-2025-01-03
* [`0d91765b`](https://github.com/NixOS/nixpkgs/commit/0d91765b9e122fed0bc5c96571a4b581f4cf87e0) x264: reformat
* [`81a981f5`](https://github.com/NixOS/nixpkgs/commit/81a981f5d97ea7b4d8d2c34fb874abdc3d839065) unicorn: 2.1.1 -> 2.1.2
* [`c8661c68`](https://github.com/NixOS/nixpkgs/commit/c8661c685a5b9ba6509da28701c3eeb47c6129f2) go: remove `xcbuild`
* [`d1d09dcd`](https://github.com/NixOS/nixpkgs/commit/d1d09dcd1ecb0c5709b3f5486d61f1d18cca5ccc) checkpolicy: 3.7 -> 3.8
* [`27e82569`](https://github.com/NixOS/nixpkgs/commit/27e825694ee1a97fdf222a884dbe89d960f287bc) libselinux: 3.7 -> 3.8
* [`c87b3e5d`](https://github.com/NixOS/nixpkgs/commit/c87b3e5dab71b09d0beb4d66ab2a34100cfd5806) policycoreutils: 3.7 -> 3.8
* [`3f29923f`](https://github.com/NixOS/nixpkgs/commit/3f29923fb3959c154fd1edb35c019b4c38e0d742) libsemanage: 3.7 -> 3.8
* [`1488f3a3`](https://github.com/NixOS/nixpkgs/commit/1488f3a320f8c875665571e14a922d07d5e73b7f) systemd: 257.2 -> 257.3
* [`310834fc`](https://github.com/NixOS/nixpkgs/commit/310834fc99dbcf38d89546e6e7404aab55621b44) vimPlugins.neotest-mocha: init at 2024-07-30
* [`2822faf8`](https://github.com/NixOS/nixpkgs/commit/2822faf8160d3572516aa390f9309574a2e1286d) vim: 9.1.1046 -> 9.1.1111
* [`75229802`](https://github.com/NixOS/nixpkgs/commit/75229802d802fcac4d89ca17659cb5e5d8aa0eb3) double-conversion: 3.3.0 -> 3.3.1
* [`fc223e48`](https://github.com/NixOS/nixpkgs/commit/fc223e48a00c4c4ba5947335eef5970263d0f12a) python3Packages.click: 8.1.7 -> 8.1.8
* [`f500ae08`](https://github.com/NixOS/nixpkgs/commit/f500ae084a09cfcb276d2861d06945988572cef3) nixos/kerberos_server: disallow combining "all" with policies != "get-keys"
* [`10ddfffc`](https://github.com/NixOS/nixpkgs/commit/10ddfffcc3094aaca5852b7949077c3ef9214a95) akkoma: use tag attribute for fetchFromGitea
* [`0517cfb3`](https://github.com/NixOS/nixpkgs/commit/0517cfb3a25a96ab84489317c399826e4eacad35) akkoma: provide update script
* [`7422a5f4`](https://github.com/NixOS/nixpkgs/commit/7422a5f4f72c1776b679687e69793a645cf7d41f) akkoma: re‐format according to RFC 166
* [`cceae71b`](https://github.com/NixOS/nixpkgs/commit/cceae71bd2e9198cc85b7a70ee43ee31bd5bb315) akkoma: remove unused rec
* [`1f4b266f`](https://github.com/NixOS/nixpkgs/commit/1f4b266f2aae7799f0b1bdd19f91def607ef329a) akkoma-emoji.blobs_gg: remove use of with lib;
* [`016d391d`](https://github.com/NixOS/nixpkgs/commit/016d391db3d325250727eeee381db05551f55ba3) akkoma-frontends.akkoma-fe: provide update script
* [`0064705c`](https://github.com/NixOS/nixpkgs/commit/0064705ca44ed8f0c98c348c21ad493474b942f8) akkoma-frontends.admin-fe: provide update script
* [`083b0d1b`](https://github.com/NixOS/nixpkgs/commit/083b0d1b4f4c5028eb28c8b1e626e6d85561c753) akkoma: switch to fixed‐output derivation for dependencies
* [`7f12f8cf`](https://github.com/NixOS/nixpkgs/commit/7f12f8cfc592f91c34b55e8382dceeb0476cae0a) akkoma: do not allow additional arguments
* [`895ad18c`](https://github.com/NixOS/nixpkgs/commit/895ad18cd0be08586ad1b1752b936738d84237f6) akkoma-frontends.akkoma-fe: use writableTmpDirAsHomeHook
* [`5aba2e72`](https://github.com/NixOS/nixpkgs/commit/5aba2e72bb65a11c8b96460c8b7c8f5121c839ca) akkoma-frontends.admin-fe: use writableTmpDirAsHomeHook
* [`ed810899`](https://github.com/NixOS/nixpkgs/commit/ed810899551e35da6ecf626f51e03576990e216d) python312Packages.ipython: 8.31.0 -> 8.32.0
* [`e41e61c9`](https://github.com/NixOS/nixpkgs/commit/e41e61c973cc6dc14b4b57cb5b5ca0073a0444e3) qemu: 9.2.0 -> 9.2.1
* [`208a3054`](https://github.com/NixOS/nixpkgs/commit/208a3054284ceb4b19344b1e6e5fe26ee75ca9cc) yandex-music: 5.28.4 -> 5.39.0
* [`1c3ad5fe`](https://github.com/NixOS/nixpkgs/commit/1c3ad5fe4cfb22dc52388ad3260a6387b2f5c5b6) ruby_3_4: 3.4.1 -> 3.4.2
* [`da04c5b5`](https://github.com/NixOS/nixpkgs/commit/da04c5b5bfd5a87366dc56f506394fd8e9354166) publicsuffix-list: 0-unstable-2025-01-16 -> 0-unstable-2025-02-12
* [`26bd2949`](https://github.com/NixOS/nixpkgs/commit/26bd2949967ed240142327add460a80fed64a75c) tparted: init at 2025-01-24
* [`3e7917fc`](https://github.com/NixOS/nixpkgs/commit/3e7917fc454b53fda7a479100f36adb1dfdb1b2b) python312Packages.numpy: 2.2.2 -> 2.2.3
* [`d10b4d69`](https://github.com/NixOS/nixpkgs/commit/d10b4d690f1ade567eaeec792abafceaff703b6a) pyright: 1.1.392 -> 1.1.394
* [`0dd251e2`](https://github.com/NixOS/nixpkgs/commit/0dd251e2471bb1913663f4ac93963be47bbe62ec) darwin.libffi: fix a memory leak
* [`5fee9971`](https://github.com/NixOS/nixpkgs/commit/5fee99715e45ca513a566cb4c07f33af712d203e) darwin.libffi: drop `--enable-pax_emutramp` configure flag
* [`99de8ee9`](https://github.com/NixOS/nixpkgs/commit/99de8ee9a601329a63c9f72526fd514423598330) darwin.libffi: align trampoline dylib linker flags with Xcode project
* [`e26ff7f8`](https://github.com/NixOS/nixpkgs/commit/e26ff7f8a2f71d1037d53fac35498492deb4c62d) python312Packages.botocore: 1.35.99 -> 1.36.21
* [`de5081c7`](https://github.com/NixOS/nixpkgs/commit/de5081c707237a425517c015c7b16c0ee8dee94e) python312Packages.boto3: 1.35.99 -> 1.36.21
* [`609dcd86`](https://github.com/NixOS/nixpkgs/commit/609dcd86e06f6f1455978cb51aea8d6c84e7139e) python312Packages.s3transfer: 0.10.1 -> 0.11.2
* [`06deeb63`](https://github.com/NixOS/nixpkgs/commit/06deeb63dc93fa1a9233dded32b94641596893aa) awscli: 1.36.40 -> 1.37.21
* [`39887b09`](https://github.com/NixOS/nixpkgs/commit/39887b09505c6dd0af476ff0efe75177617b5930) python312Packages.moto: 5.0.26 -> 5.0.28
* [`0b161bcd`](https://github.com/NixOS/nixpkgs/commit/0b161bcd9ed574e16e7fe3e5e5a81d996c8a4c0a) python312Packages.aiobotocore: 2.18.0 -> 2.19.0
* [`d01c1449`](https://github.com/NixOS/nixpkgs/commit/d01c14493612983f6c2375318876fed2ef00b3d9) python312Packages.aioboto3: 13.1.1 -> 13.4.0
* [`84b2a4b8`](https://github.com/NixOS/nixpkgs/commit/84b2a4b8c02eda0268c7090d13f2d1b5e6d419e7) python312Packages.fsspec: 2024.12.0 -> 2025.2.0
* [`90bfc1de`](https://github.com/NixOS/nixpkgs/commit/90bfc1de229298c58b8b108912456051136a810a) python312Packages.s3fs: enable fixed tests
* [`ab0eef87`](https://github.com/NixOS/nixpkgs/commit/ab0eef871df33db880bd185f4d41670195414243) python312Packages.gcsfs: 2024.2.0 -> 2025.2.0
* [`4b191420`](https://github.com/NixOS/nixpkgs/commit/4b1914205359b77f48cc6d50ab5cfcd7de06c618) libpq: fix pg_config --libdir
* [`9f527b1e`](https://github.com/NixOS/nixpkgs/commit/9f527b1e27c6b934e5fd88aaf4063220b674f3e4) darwin.libffi: install Apple’s `ffi.h` header
* [`741de2bc`](https://github.com/NixOS/nixpkgs/commit/741de2bc6396974cdc03ca0f0413fae3993df2ca) Revert "Revert "python312Packages.cffi: remove unnecessary Darwin patch""
* [`d795cc73`](https://github.com/NixOS/nixpkgs/commit/d795cc73795144e9b2a4715b8c06ae928771b278) ocamlPackages.owee: 0.7 -> 0.8
* [`887f6780`](https://github.com/NixOS/nixpkgs/commit/887f678075639b356c7f00d517283fe031c9b80c) minio: 2025-01-20T14-49-07Z -> 2025-02-07T23-21-09Z
* [`8bb480e0`](https://github.com/NixOS/nixpkgs/commit/8bb480e0e398af3c26967e09ec1f69c791e17873) plex-desktop: cleanup flatpak dependencies
* [`9b5f0234`](https://github.com/NixOS/nixpkgs/commit/9b5f0234be2bbe1497672d619df9b5d584989a19) python313Packages.poetry-core: 2.0.1 -> 2.1.1
* [`73ee9e57`](https://github.com/NixOS/nixpkgs/commit/73ee9e57e830a3bb7cb5d4afba747f246637b6ab) qt6.qtdeclarative: add qtsvg as propagated build input
* [`48cf5978`](https://github.com/NixOS/nixpkgs/commit/48cf59783eef765403705d1d484178c83f5b09e4) python3Packages.cryptography: 44.0.0 -> 44.0.1
* [`b587f2c7`](https://github.com/NixOS/nixpkgs/commit/b587f2c7fc13cb4c255213935cef2a73139bb624) jdk23: 23.0.1+11 -> 23.0.2+7
* [`b80ba0a9`](https://github.com/NixOS/nixpkgs/commit/b80ba0a9906767b4e3b93087de8738260584d94c) python312Packages.scipy: 1.15.1 -> 1.15.2
* [`75c12612`](https://github.com/NixOS/nixpkgs/commit/75c12612e36961ddb06eb7418e8ddbb5a787242e) maintainers: add hakujin
* [`a8e9088d`](https://github.com/NixOS/nixpkgs/commit/a8e9088d1a95b24f3e9557b44f4b1ddaa48ba609) release-cuda: fix job names
* [`e0d45da2`](https://github.com/NixOS/nixpkgs/commit/e0d45da20395d0f2a2d0173ccb142b82a1bda56f) python3Packages.theano: remove from release-cuda
* [`108123b3`](https://github.com/NixOS/nixpkgs/commit/108123b38aa5042fd51d728688eff103d49682b7) python3Packages.torch remove duplicate from release-cuda
* [`5c0092ee`](https://github.com/NixOS/nixpkgs/commit/5c0092eeaf36738c72f2a9932d7eb6aa5a37dfe1) python3Packages.keras: switch to primary alias in release-cuda
* [`0c12821e`](https://github.com/NixOS/nixpkgs/commit/0c12821eec1363b9d53a461ed7cca8a967ee3cdf) python3Packages.scikit-image: switch to primary alias in release-cuda
* [`8027d0b2`](https://github.com/NixOS/nixpkgs/commit/8027d0b28bbee429af069029cf11c1b7428f21b4) release-cuda: disable deprecated aliases
* [`fdae7b2b`](https://github.com/NixOS/nixpkgs/commit/fdae7b2b9bab8325bbb0b4c361e7e1ea3d6d74fb) wayland-protocols: 1.40 -> 1.41
* [`7b912bca`](https://github.com/NixOS/nixpkgs/commit/7b912bcafed6326572c4cb217fc058d88cc20fe7) make nix.settings-system-features default mergeable again
* [`7712700b`](https://github.com/NixOS/nixpkgs/commit/7712700b18f5c5f3e390af679fddb2b5afa4a95f) wrapQtAppsHook: actually use makeQtWrapper for symlinks
* [`d5f0bd42`](https://github.com/NixOS/nixpkgs/commit/d5f0bd426a44178e22fc201ad129a65a2ee58633) Revert "icu: make darwin.ICU the default on Darwin"
* [`f0d623de`](https://github.com/NixOS/nixpkgs/commit/f0d623dea25899ae17fde8e666bf06371c413216) nixos/akkoma: remove IFD
* [`6273901d`](https://github.com/NixOS/nixpkgs/commit/6273901d0db3fe64590204a97f37263aeed21022) tree-sitter: update all grammars
* [`ce9d93cc`](https://github.com/NixOS/nixpkgs/commit/ce9d93ccba3b5e36656d141dae006ca53314c4d1) optifine: 1.21.3_HD_U_J2 -> 1.21.4_HD_U_J3
* [`29e1bcac`](https://github.com/NixOS/nixpkgs/commit/29e1bcac1f990e674d82047823f7a617f344100e) libxml: 2.13.5 -> 2.13.6
* [`1e6c310b`](https://github.com/NixOS/nixpkgs/commit/1e6c310bc4466679e7a51da1871551a3d02b07cd) vim: 9.1.1111 -> 9.1.1122
* [`5d808d31`](https://github.com/NixOS/nixpkgs/commit/5d808d3150c9d7e4a43d54ad440a105bc2ac1d50) rustc: use indented string for buildPhase
* [`ea706f98`](https://github.com/NixOS/nixpkgs/commit/ea706f9895e46129746c9309d8bda2dbb4330ced) rustc: fix combining no_std targets with other targets
* [`0289aa11`](https://github.com/NixOS/nixpkgs/commit/0289aa115c32a2b4b6c4b17daa791de10ab20161) rustc: enable bpfe library targets
* [`b885ef3f`](https://github.com/NixOS/nixpkgs/commit/b885ef3fa80f038290cefb8bb62f77cac7435692) rust: remove obsolete darwin frameworks
* [`8233c9ce`](https://github.com/NixOS/nixpkgs/commit/8233c9ceb11c086be059d0744437bbeec55fd39d) mercurial: 6.9 -> 6.9.1
* [`fc85aa10`](https://github.com/NixOS/nixpkgs/commit/fc85aa10667f8adef5822930cdd1eeb111d9e598) awesome-wm-widgets: init at 0-unstable-2024-02-15
* [`a73201e9`](https://github.com/NixOS/nixpkgs/commit/a73201e9724d0ce6170cc728a1cf9ad1f7bc6190) python3Packages.mitmproxy-linux: init at 0.11.5
* [`cdc2ee0c`](https://github.com/NixOS/nixpkgs/commit/cdc2ee0cd494dbad47dacd2723efd6b712353e62) python313Packages.mitmproxy-macos: 0.9.2 -> 0.11.5
* [`413ba94f`](https://github.com/NixOS/nixpkgs/commit/413ba94fdfa421f9297d37aadba908e45e47a6be) python313Packages.mitmproxy-rs: 0.10.7 -> 0.11.5
* [`e7ae5710`](https://github.com/NixOS/nixpkgs/commit/e7ae5710400b229a6dbd25abfc971cbc9a6bb67c) python313Packages.mitmproxy: 11.0.2 -> 11.1.3
* [`3817270a`](https://github.com/NixOS/nixpkgs/commit/3817270aca4068e39be2076a12a17d004cc51efe) python3Packages.shapely: 2.0.6 -> 2.0.7
* [`0bbc1f5d`](https://github.com/NixOS/nixpkgs/commit/0bbc1f5d00b78e5b7b324f74fdcf9a6ca4703dd0) python3Packages.shapely: fetch source from GitHub
* [`653fc0a2`](https://github.com/NixOS/nixpkgs/commit/653fc0a29e4790aeeb8fc2e438387d6c21d6d804) python3Packages.shapely: remove 'with lib' from meta
* [`f5e7229e`](https://github.com/NixOS/nixpkgs/commit/f5e7229e007d2c8bb04cd6a4e0b78709ed89dab5) python3Packages.shapely: replace propagatedBuildInputs with dependencies
* [`41d9504f`](https://github.com/NixOS/nixpkgs/commit/41d9504fbf9d052f45c433ced13d04e62dbfe074) komodo: init at 1.16.12
* [`7cc771f3`](https://github.com/NixOS/nixpkgs/commit/7cc771f350a08c796a90105c8258d9425a150a83) Revert "darwin.ICU: add `stdenv` for compatibility with Tensorflow override"
* [`f3cb6dcd`](https://github.com/NixOS/nixpkgs/commit/f3cb6dcdc08533e796fa039561d2cdd56281a674) Revert "darwin.ICU: enable the C++ API by default"
* [`c5912ba2`](https://github.com/NixOS/nixpkgs/commit/c5912ba233b4201f89d9c44a25ec4128444f0487) Revert "darwin.ICU: use char16_t instead of uint16_t in the C++ API"
* [`593da3b9`](https://github.com/NixOS/nixpkgs/commit/593da3b9c697e4cba9e05b7494dcf28fdcedb0c6) Revert "python312Packages.pyicu: skip test for sjd locale"
* [`027345fc`](https://github.com/NixOS/nixpkgs/commit/027345fc85cc977d4ae4081b65ec580cc9de1971) bun: ensure that only libicucore.dylib is in DYLD_LIBRARY_PATH
* [`13de18d4`](https://github.com/NixOS/nixpkgs/commit/13de18d402837124dfa9cc64b2d581b7539e27ef) icuReal: add to aliases.nix
* [`31d699a4`](https://github.com/NixOS/nixpkgs/commit/31d699a4e7211ed68ed66c3bad0eb9e27dc159e3) darwin.libffi: match upstream configuration
* [`5032ae47`](https://github.com/NixOS/nixpkgs/commit/5032ae475b1706dbb78859b4ff90c9b12c53fc16) gpgme: 1.24.1 -> 1.24.2
* [`3433550d`](https://github.com/NixOS/nixpkgs/commit/3433550d61f8fddffd7d99633490fbfcfabcc3a6) gnutls: 3.8.6 -> 3.8.9
* [`9c22fc47`](https://github.com/NixOS/nixpkgs/commit/9c22fc4730e46dee3500a455fa85544ed0acf526) nixos/direnv: add xonsh integration
* [`32700a75`](https://github.com/NixOS/nixpkgs/commit/32700a75185ac4997df9f29196e27569ff00277b) wgpu-native: 22.1.0.5 -> 24.0.0.1
* [`8a135e8a`](https://github.com/NixOS/nixpkgs/commit/8a135e8acf8d719dd8b123fae8a097bda5e668b4) plex-desktop: update script shouldn't commit changes
* [`78a0698b`](https://github.com/NixOS/nixpkgs/commit/78a0698b6bff1454452a81f34cccea1b5be62d2d) plex-desktop: 1.101.0 -> 1.108.1
* [`10304c30`](https://github.com/NixOS/nixpkgs/commit/10304c30e9c46398b8c58acefeb60b9e20204374) python312Packages.flit: 3.10.1 -> 3.11.0
* [`2092b1f4`](https://github.com/NixOS/nixpkgs/commit/2092b1f45c650e07c4ef96fa38fbd8f2cae53c56) libassuan: 2.5.7 -> 3.0.2
* [`be93e4ee`](https://github.com/NixOS/nixpkgs/commit/be93e4ee28bc13319d17b84b68be1e66f80e02b6) libblockdev: 3.2.1 -> 3.3.0
* [`f3a3e607`](https://github.com/NixOS/nixpkgs/commit/f3a3e607170647cebae857eedb8b3a965f30f876) gnupg-pkcs11-scd: 0.10.0 -> 0.11.0
* [`87f6382e`](https://github.com/NixOS/nixpkgs/commit/87f6382ecaa916d55de86b9d6f738a7c0a2a8b25) gpa: 0.10.0 -> 0.11.0
* [`5e6e65ca`](https://github.com/NixOS/nixpkgs/commit/5e6e65caa883f83be096b1967e45fec963f43f5e) pinentry_mac: fix build with libassuan 3.0
* [`8853e2cc`](https://github.com/NixOS/nixpkgs/commit/8853e2ccca9bb585383c50ab4aa391f5b9757282) libassuan: modernize
* [`4ec86479`](https://github.com/NixOS/nixpkgs/commit/4ec86479c0b4ad8846fe9844e46874c41e4f902b) python313Packages.aiohappyeyeballs: 2.4.4 -> 2.4.6
* [`7839982f`](https://github.com/NixOS/nixpkgs/commit/7839982f9d51953c880aa06b9b5b9debdf745e93) gpa: fix build
* [`a6488ea5`](https://github.com/NixOS/nixpkgs/commit/a6488ea54e5be48912655d024e2c772e3b428b04) heroku: 10.0.2 -> 10.2.0
* [`67716973`](https://github.com/NixOS/nixpkgs/commit/6771697393252f3d9f0f3e28a7c96aad54280ef9) cargo,clippy,rustfmt,rustc: 1.84.1 -> 1.85.0
* [`eafc4eb7`](https://github.com/NixOS/nixpkgs/commit/eafc4eb774758c85daf87405500ed0ef6b055f79) survex: 1.4.15 -> 1.4.16
* [`df82dce6`](https://github.com/NixOS/nixpkgs/commit/df82dce61dc677b828f4b99c8bb9fab6ee8809c8) ngtcp2: 1.10.0 -> 1.11.0
* [`b3e496c2`](https://github.com/NixOS/nixpkgs/commit/b3e496c2dc3003f0f0050244de4241bcb9bc144e) maintainers: add polyfloyd
* [`6dc8946e`](https://github.com/NixOS/nixpkgs/commit/6dc8946ea7197e5366012baf65eb1f1610996c70) go-mod-upgrade: init at 0.11.0
* [`09df795d`](https://github.com/NixOS/nixpkgs/commit/09df795d86df5f47fa97bb25150395fbd23b78d6) qgis: 3.40.3 -> 3.42.0
* [`ffcffac1`](https://github.com/NixOS/nixpkgs/commit/ffcffac14d5b2e9513bb600acf7267b501acd725) openh264: 2.5.0 -> 2.6.0
* [`1720c8c7`](https://github.com/NixOS/nixpkgs/commit/1720c8c7c4fa5f2bcfedcf9b1a0b79296c8c4652) xray: 25.1.30 -> 25.2.21
* [`d791d5d1`](https://github.com/NixOS/nixpkgs/commit/d791d5d18254e0c5fab66b689fcbbc5e503a8ee3) socat: 1.8.0.2 -> 1.8.0.3
* [`d6555f85`](https://github.com/NixOS/nixpkgs/commit/d6555f8567c92cccb74f951c2ccbb3bc2b3055de) ncurses: provide openbsd version number in host triple
* [`9787f192`](https://github.com/NixOS/nixpkgs/commit/9787f192fe9cffc836263be44d231b333e2c9e66) readline: add library symlinks on OpenBSD to compensate for old libtool
* [`a2a5f506`](https://github.com/NixOS/nixpkgs/commit/a2a5f506058c7e8c451579ed910e9b272df76121) mpris-scrobbler: 0.5.5 -> 0.5.6
* [`34e6e718`](https://github.com/NixOS/nixpkgs/commit/34e6e718531de57a9b87cf9a2896e8816d062961) node-red: 4.0.8 -> 4.0.9
* [`e2fc0e0f`](https://github.com/NixOS/nixpkgs/commit/e2fc0e0fc203b50aa3cf3aa490bc34ee0d5c5b2c) clive: init at 0.12.9
* [`5a574ad2`](https://github.com/NixOS/nixpkgs/commit/5a574ad2912e45dda834ec6efa2321d75dc7d05a) emitter: init at 3.1
* [`077b5fe4`](https://github.com/NixOS/nixpkgs/commit/077b5fe4fb534262149f1bef40104c7988608407) nextdns: 1.44.4 -> 1.45.0
* [`5c4dda49`](https://github.com/NixOS/nixpkgs/commit/5c4dda492c362c4a3e2138d22a1ec452319db05b) scaphandre: 0.5.0 -> 1.0.2
* [`f19d4063`](https://github.com/NixOS/nixpkgs/commit/f19d4063a5e6ef6c68d16b188a7a8fc66cb1a922) libcpr: 1.11.1 -> 1.11.2
* [`8ae9d183`](https://github.com/NixOS/nixpkgs/commit/8ae9d18333c3f7d631b365d784e73b6cb00b962c) go: add missing VERSION file
* [`03bd3b6b`](https://github.com/NixOS/nixpkgs/commit/03bd3b6b488fc4a7c6ccd79f6f13f3f19adf861b) ace-of-penguins: fix build
* [`0c5a1032`](https://github.com/NixOS/nixpkgs/commit/0c5a1032173c4e8322365455bd452540b3104ab8) ace-of-penguins: modernize
* [`75de476c`](https://github.com/NixOS/nixpkgs/commit/75de476cf535908b3b41d70940a4a2f3abcd5002) qgis: add update script
* [`b8d7e46e`](https://github.com/NixOS/nixpkgs/commit/b8d7e46ef32c00e79a66005746dc2c36efdde3c2) libcdio: 2.1.0 -> 2.2.0
* [`e56d16e9`](https://github.com/NixOS/nixpkgs/commit/e56d16e94f420d739378acac13a0890916830404) gnomeExtensions.easyScreenCast: 1.10.0 -> 1.11.0
* [`a2818d90`](https://github.com/NixOS/nixpkgs/commit/a2818d9068dad0cf9e59a77fb5457f47322de531) python313Packages.flake8: 7.1.1 -> 7.1.2
* [`6b6f4274`](https://github.com/NixOS/nixpkgs/commit/6b6f42746b5ca36fd9b123145450766c0f715cfb) longcat: init at 0.0.12
* [`56b976c4`](https://github.com/NixOS/nixpkgs/commit/56b976c4304ef66ecadb2fa3c4a5e48bbd2ccecb) streamlit: 1.41.1 -> 1.42.2
* [`96dd72e5`](https://github.com/NixOS/nixpkgs/commit/96dd72e53112da8ef08490696a4a2569d0ec7c8a) llvmPackages_{12..18}.tblgen: backport `gcc-15` fix (add `<cstdint>`)
* [`b8de2d20`](https://github.com/NixOS/nixpkgs/commit/b8de2d206adc5f57f254ba3c4b70ae0328a0453d) rustc: add wasm32v1-none target
* [`6350b7e1`](https://github.com/NixOS/nixpkgs/commit/6350b7e12ae3891e54f4a760e85177162a0c9d26) qgis-ltr: 3.34.15 -> 3.40.4
* [`a816c6d2`](https://github.com/NixOS/nixpkgs/commit/a816c6d2265a2da0a5e52fa1607764ad498e4de6) scraper: 0.22.0 -> 0.23.1
* [`2258a5db`](https://github.com/NixOS/nixpkgs/commit/2258a5dbd2b2a792dd33cfebb0349477d86a1614) tt-rss-plugin-feediron: 1.32 -> 1.33
* [`e3174766`](https://github.com/NixOS/nixpkgs/commit/e3174766d363e09f1dc663c15f1b1113248b9eb6) python312Packages.rcssmin: 1.2.0 -> 1.2.1
* [`08a243cb`](https://github.com/NixOS/nixpkgs/commit/08a243cb4ddc9b85e7159ccda9a17eca679aaa7b) python3Packages.pytaglib: update taglib
* [`a6c31358`](https://github.com/NixOS/nixpkgs/commit/a6c31358a096fabb230d5111a9131d2f55f4feb6) gtk4: add patch fixing glitches on asahi vulkan driver ([nixos/nixpkgs⁠#383350](https://togithub.com/nixos/nixpkgs/issues/383350))
* [`8ae8cca8`](https://github.com/NixOS/nixpkgs/commit/8ae8cca8243650b8267765333e9dedb438e6e40d) python312Packages.rjsmin: 1.2.3 -> 1.2.4
* [`9e7bd412`](https://github.com/NixOS/nixpkgs/commit/9e7bd41259627422209ab6ab43e9f1f8efaad4b7) libxmp: 4.6.1 -> 4.6.2
* [`72bc67e1`](https://github.com/NixOS/nixpkgs/commit/72bc67e16dec1b964a3ef0b81a8c6f2cc1c401ce) ricochet-refresh: 3.0.30 -> 3.0.31
* [`99431585`](https://github.com/NixOS/nixpkgs/commit/99431585d68b296ad0d6bc8195037016f5d95075) pkgs/stdenv/darwin: update bootstrap tools
* [`95af103b`](https://github.com/NixOS/nixpkgs/commit/95af103be7bdbb6ac7c5027062cbe538a00d1931) pkgs/stdenv/darwin: add jq to stage 0
* [`1b86a6d9`](https://github.com/NixOS/nixpkgs/commit/1b86a6d935f51e787f77d389a61ea232927f37f5) pkgs/stdenv/darwin: link `llvm-readtapi` in stage 0
* [`3768d3f5`](https://github.com/NixOS/nixpkgs/commit/3768d3f5c3f87c056a8b7a0675e7ce52dcb15e8c) pkgs/stdenv/darwin: simplify SDK version expression
* [`07c75bb1`](https://github.com/NixOS/nixpkgs/commit/07c75bb1f4b1e74c40382c67382d192854eb8513) pkgs/stdenv/darwin: remove old bootstrap tools workarounds
* [`8ddfc53f`](https://github.com/NixOS/nixpkgs/commit/8ddfc53f2ae1d102786c72cbca09b9b3eeefac8e) pkgs/stdenv/darwin: drop llvm-manpages from bootstrap
* [`18c8cb56`](https://github.com/NixOS/nixpkgs/commit/18c8cb56112a13f76e3cb6b434ef8f9a1b8dea51) pkgs/stdenv/darwin: drop openbsm from the bootstrap
* [`5ced6bb1`](https://github.com/NixOS/nixpkgs/commit/5ced6bb1964a8f9e4f44d312ade003c8111b9bcf) apple-sdk: remove old bootstrap tools workaround
* [`83ee31f3`](https://github.com/NixOS/nixpkgs/commit/83ee31f348641cc2526fe8952fa1794d65afb639) darwin.copyfile: remove old bootstrap tools workaround
* [`87ed486d`](https://github.com/NixOS/nixpkgs/commit/87ed486d4289df9b79f2f56b7f81a5229eb9d3d9) darwin.postLinkSignHook: drop and add to darwin-aliases.nix
* [`069f2754`](https://github.com/NixOS/nixpkgs/commit/069f2754d5fa3577a3909ef4d2e41b3923703ea0) ld64: remove old bootstrap tools workaround
* [`a24847f5`](https://github.com/NixOS/nixpkgs/commit/a24847f53b2bac1c0e0cacb25e846b8d9f905c36) python312Packages.draftjs-exporter: 5.0.0 -> 5.1.0
* [`5700330e`](https://github.com/NixOS/nixpkgs/commit/5700330e5f357464d12ceb647f13814f044d508b) python312Packages.keke: 0.1.4 -> 0.2.0
* [`3f42a6ee`](https://github.com/NixOS/nixpkgs/commit/3f42a6ee1769c90d34ff9ededc3ff5d722400a69) gnome-pomodoro: 0.26.0 -> 0.27.0
* [`27a89c76`](https://github.com/NixOS/nixpkgs/commit/27a89c7676252a8f4b17d4ff4a99bbbe4ad1e938) mythtv: 34.0 -> 35.0
* [`00e1646f`](https://github.com/NixOS/nixpkgs/commit/00e1646ff961614baca764193899193b12c60d15) scitokens-cpp: 1.1.2 -> 1.1.3
* [`d98c91b6`](https://github.com/NixOS/nixpkgs/commit/d98c91b6b81713b5144b2d04c9a0d4700e087e70) jemalloc: disable parallel building to fix reproducibility
* [`6576f1a5`](https://github.com/NixOS/nixpkgs/commit/6576f1a5cdb1f09828a51bc9860bae6f7aebe2d8) pythonPackages.eventlet: skip test_send_timeout
* [`cf24c124`](https://github.com/NixOS/nixpkgs/commit/cf24c12412fc1d6fde3ac493a8a36e4cc193e208) kotlin: 2.1.0 -> 2.1.10
* [`97dee36a`](https://github.com/NixOS/nixpkgs/commit/97dee36a9e1d7a00caa3a1eafe8d13e2517a4cd4) python313Packages.aiohttp: 3.11.12 -> 3.11.13
* [`ce206d6d`](https://github.com/NixOS/nixpkgs/commit/ce206d6d6e96582e1ca4e07b80c791dc461c413b) httplib: 0.18.5 -> 0.19.0
* [`0cfeec58`](https://github.com/NixOS/nixpkgs/commit/0cfeec58f68ba623f679702de150dc1da686e3e5) apple-sdk: don’t remove LDAP framework headers
* [`9fde026a`](https://github.com/NixOS/nixpkgs/commit/9fde026a60100abfabb6522b457682e9541d44ac) meson: remove OpenLDAP dependency
* [`074f6616`](https://github.com/NixOS/nixpkgs/commit/074f661685cd1aaa029870b5b77bbfc1021fcb75) python3Packages.itk: useLibsFrom stdenv gcc12Stdenv
* [`2d0f3e7d`](https://github.com/NixOS/nixpkgs/commit/2d0f3e7d6ae6abeea23847ac80412855cddb6095) meson: remove bitcode patch
* [`fe9275e3`](https://github.com/NixOS/nixpkgs/commit/fe9275e3d1c024192225c699c21d342ceb4b65b2) meson: remove conditional `libxcrypt` dependency
* [`ee6e82cd`](https://github.com/NixOS/nixpkgs/commit/ee6e82cd061dd68727328dd724bb4c57e55d2fbf) meson: remove old Darwin SDK pattern detritus
* [`f139c0cb`](https://github.com/NixOS/nixpkgs/commit/f139c0cbbab6f552e91b66685d11d238d51201da) kazumi: fix broken symlink
* [`61689a5e`](https://github.com/NixOS/nixpkgs/commit/61689a5e41caf6f086f60d07e646b9b0528de775) kazumi: update updateScript
* [`c5a48996`](https://github.com/NixOS/nixpkgs/commit/c5a489962fb4c90711697638729f1a8aa51ee080) kazumi: 1.5.4 -> 1.5.6
* [`5223984c`](https://github.com/NixOS/nixpkgs/commit/5223984c09f5ecb758a272124e6ec43d41d1a9cd) timeular: 6.9.0 -> 6.9.1
* [`9788a6f9`](https://github.com/NixOS/nixpkgs/commit/9788a6f9b4e3c6af16e3eed310b2576d7ca6b1fd) alsa-scarlett-gui: 0.4.0 -> 0.5.0
* [`75e7f401`](https://github.com/NixOS/nixpkgs/commit/75e7f40104a7f25fab5e16d9f744d9fd7c52bd53) libmodsecurity: 3.0.13 -> 3.0.14
* [`46817a30`](https://github.com/NixOS/nixpkgs/commit/46817a30d41ae874238c8d8f86cc2b798beec75e) k3d: 5.8.2 -> 5.8.3
* [`21054266`](https://github.com/NixOS/nixpkgs/commit/2105426688dd9b07d862c67dfe309965537afa9a) python312Packages.ansible-core: 2.18.2 -> 2.18.3
* [`fa423a9a`](https://github.com/NixOS/nixpkgs/commit/fa423a9ab883d5eaa5d8e0c6796d6f396b2cbb89) xorg.xorgserver: 21.1.15 -> 21.1.16 (security)
* [`fb1b6844`](https://github.com/NixOS/nixpkgs/commit/fb1b6844a17ac5f6ccefdde7ff134a9a14ce5ff0) ipxe: fix dangling symlink
* [`08d879c3`](https://github.com/NixOS/nixpkgs/commit/08d879c386ddf39a715039154d89c3bdb85c0874) fpm2: 0.90 -> 0.90.1
* [`e2821e9f`](https://github.com/NixOS/nixpkgs/commit/e2821e9ff0e24f636a649c7a036f1097b0ffbf64) dssp: 4.4.10 -> 4.4.11
* [`89216825`](https://github.com/NixOS/nixpkgs/commit/89216825f537cf0cc341cd4acd8c0dc9994307cd) python312Packages.azure-mgmt-netapp: 13.3.0 -> 13.4.0
* [`1ed0ce7f`](https://github.com/NixOS/nixpkgs/commit/1ed0ce7f460a5a122a24cabdd8ba925b2d546031) libcec: 6.0.2 -> 7.0.0
* [`12185304`](https://github.com/NixOS/nixpkgs/commit/1218530410b491654226bd25e8a9ba1ca2bbc8a8) python312Packages.azure-mgmt-resource: 23.2.0 -> 23.3.0
* [`732a1dca`](https://github.com/NixOS/nixpkgs/commit/732a1dca73efb2981077733cff5449eaa69895db) nixos/pay-respects: fix "(eval):1: parse error near `alias'"
* [`b81f9867`](https://github.com/NixOS/nixpkgs/commit/b81f98670723935be74f29ebe6a6cb63d13aea3f) python312Packages.dploot: 3.1.0 -> 3.1.2
* [`18daf14a`](https://github.com/NixOS/nixpkgs/commit/18daf14a6366cdbe077ada453cee78dee2460b72) python312Packages.spatialmath-python: 1.1.13 -> 1.1.14
* [`e89f220a`](https://github.com/NixOS/nixpkgs/commit/e89f220a22c0cc1126838c880ba87d8baf15cac6) python312Packages.asana: 5.0.15 -> 5.1.0
* [`5e41ff55`](https://github.com/NixOS/nixpkgs/commit/5e41ff55dea26f625d588a25aa9dace91307b723) nss_pam_ldapd: 0.9.12 -> 0.9.13
* [`983ef339`](https://github.com/NixOS/nixpkgs/commit/983ef339d08621e1ec16c958b90bc0739959bf7e) libosmocore: 1.10.1 -> 1.11.0
* [`aa714044`](https://github.com/NixOS/nixpkgs/commit/aa7140442baa7eaaf0bee5fd65e85d476011b94f) python312Packages.sasmodels: 1.0.8 -> 1.0.9
* [`281541f8`](https://github.com/NixOS/nixpkgs/commit/281541f86a4e77519b74faa0371ded25febdab17) Revert "qemu: 9.2.0 -> 9.2.1"
* [`a74921dc`](https://github.com/NixOS/nixpkgs/commit/a74921dc761f6054dee0bca87220ba20bacfae9e) qemu: 9.2.0 -> 9.2.2
* [`167a9171`](https://github.com/NixOS/nixpkgs/commit/167a9171a9bf09a93cc651deeb38746b86465337) python312Packages.pyspark: 3.5.4 -> 3.5.5
* [`94fee8ec`](https://github.com/NixOS/nixpkgs/commit/94fee8ec54ea34c861723134eb39d9eb6181b526) spire: 1.11.1 -> 1.11.2
* [`f4d32e02`](https://github.com/NixOS/nixpkgs/commit/f4d32e02000d7748463fcf70e2ab61c695ff4246) nixForLinking: init
* [`5adcf0a4`](https://github.com/NixOS/nixpkgs/commit/5adcf0a44d628b1b18c578f8b63d67680d708ac4) stdenv/darwin: remove OpenLDAP
* [`047f40a6`](https://github.com/NixOS/nixpkgs/commit/047f40a64b94fc1e4aecbc4bad4c48466222d6d4) darwin.network_cmds: remove obsolete `TARGET_OS_*` workaround
* [`97fd0deb`](https://github.com/NixOS/nixpkgs/commit/97fd0deb4a56e3ac779c0b9246fd84f6302f5dbc) jbigkit: switch to `finalAttrs` pattern
* [`ab24b949`](https://github.com/NixOS/nixpkgs/commit/ab24b9495e8cf0fb6c079beea95d82eaba63e7e9) jbigkit: add more Archlinux patches, set broken on Darwin
* [`52898d4f`](https://github.com/NixOS/nixpkgs/commit/52898d4fb9bd9b47ad6d7fec36fcf3b9d4ca40a6) gh-skyline: init at 0.1.3
* [`6f5e3f0d`](https://github.com/NixOS/nixpkgs/commit/6f5e3f0d63d6f87289c8646456206232302a3258) albert: 0.26.13 -> 0.27.1
* [`7ee475df`](https://github.com/NixOS/nixpkgs/commit/7ee475dfa82bf663823b84dcd23f158ee138acdb) weaviate: 1.28.5 -> 1.29.0
* [`96d104a3`](https://github.com/NixOS/nixpkgs/commit/96d104a3fcbead5efa6d4f504ab8469df689b70c) ptyxis: 47.6 -> 47.10
* [`054f2204`](https://github.com/NixOS/nixpkgs/commit/054f22041702cb7f32b48892073fd948ad81c15d) rustywind: 0.23.1 -> 0.24.0
* [`7583d2da`](https://github.com/NixOS/nixpkgs/commit/7583d2da24192ad06e04db4cd4824f381ad8891f) zwave-js-ui: 9.30.1 -> 9.31.0
* [`ff1c7071`](https://github.com/NixOS/nixpkgs/commit/ff1c70717fe8ab9d7a06ea3808dc2315d35ed03a) elmPackages.elm-test: 0.19.1-revision13 -> 0.19.1-revision15
* [`3d44f73a`](https://github.com/NixOS/nixpkgs/commit/3d44f73a481ba8c82f15e7454f0c2cb5c542e2d8) flyway: 11.3.2 -> 11.3.4
* [`4452383e`](https://github.com/NixOS/nixpkgs/commit/4452383ebfda9a876804a201d7a4f96ca3773e4d) seaweedfs: 3.84 -> 3.85
* [`1613e88d`](https://github.com/NixOS/nixpkgs/commit/1613e88dab8b5db3963d565da9c0e3542da22077) rustPlatform.{importCargoLock,fetchCargoVendor}: remove broken symlinks before copying tree
* [`75675adf`](https://github.com/NixOS/nixpkgs/commit/75675adfff3de946202b4f2f9ddab88138d16041) R: 4.4.2 -> 4.4.3
* [`462e6345`](https://github.com/NixOS/nixpkgs/commit/462e63452b51c9c7b01bd434dac157130fd6f34c) mediathekview: 14.1.0 -> 14.2.0
* [`6af42d9d`](https://github.com/NixOS/nixpkgs/commit/6af42d9d76786bd72087f58ba84a68a71df97507) groovy: 4.0.25 -> 4.0.26
* [`b8faa941`](https://github.com/NixOS/nixpkgs/commit/b8faa9412b438790bd8b0d34fd560aaef084b647) emacsPackages.el-easydraw: 1.2.0-unstable-2025-02-15 -> 1.2.0-unstable-2025-02-21
* [`aefb0bd4`](https://github.com/NixOS/nixpkgs/commit/aefb0bd4a51d6f58c40bcce880e2bb6cee2a1f41) sby: 0.49 -> 0.50
* [`e345b201`](https://github.com/NixOS/nixpkgs/commit/e345b20194e9274dd43153aff1a705e4f7e1e6ec) albert: 0.27.1 -> 0.27.2
* [`9880dcb9`](https://github.com/NixOS/nixpkgs/commit/9880dcb9af1b2fe91e39d0863ab8269eadd208f2) pipenv: 2024.4.0 -> 2024.4.1
* [`d680897e`](https://github.com/NixOS/nixpkgs/commit/d680897e77ee1e138b7d39e8e2b7d83c0beeca99) albert: 0.27.2 -> 0.27.3
* [`8a96dbd3`](https://github.com/NixOS/nixpkgs/commit/8a96dbd335c080575c8921809aba6e2adfe367bc) rPackages: CRAN and BioC update
* [`903c34a9`](https://github.com/NixOS/nixpkgs/commit/903c34a9ea4aaf3e0c77d9282b2792ab7d3f56e6) python313Packages.eventlet: use libredirect.hook
* [`f8449149`](https://github.com/NixOS/nixpkgs/commit/f844914928b1022d8a9c7a22df66c523690bb895) rPackages.prqlr: fixed build
* [`a7c108c4`](https://github.com/NixOS/nixpkgs/commit/a7c108c44e8ae878e6dec01563e79381ea6a446f) gnomeExtensions.unite: 80 -> 81
* [`76d0c721`](https://github.com/NixOS/nixpkgs/commit/76d0c7214306edc8c15b981f555589ac4c52e163) kubernetes-helmPlugins.helm-secrets: 4.6.2 -> 4.6.3
* [`6c10307e`](https://github.com/NixOS/nixpkgs/commit/6c10307e6c66a63e606dff8a3489495b092b462e) libnats-c: 3.9.2 -> 3.10.0
* [`e0d3a5b9`](https://github.com/NixOS/nixpkgs/commit/e0d3a5b9bf7850c7195fac028e4c7a3c14b4fdbb) typescript: 5.7.3 -> 5.8.2
* [`7bc5ef3b`](https://github.com/NixOS/nixpkgs/commit/7bc5ef3b25bc30ef4b2b22e0c8b66e48a7edfe53) open-policy-agent: 1.1.0 -> 1.2.0
* [`831546c9`](https://github.com/NixOS/nixpkgs/commit/831546c90ada37881361f246add50e7bb056e113) radarr: 5.18.4.9674 -> 5.19.3.9730
* [`1bbfce73`](https://github.com/NixOS/nixpkgs/commit/1bbfce73a8b76321b3a49053cecec2839cc11721) snagboot: 2.1 -> 2.2
* [`6ade95fa`](https://github.com/NixOS/nixpkgs/commit/6ade95fa3a585a590992ff9c73d026336f1b2e52) tabby-agent: 0.24.0 -> 0.25.2
* [`4a68bd40`](https://github.com/NixOS/nixpkgs/commit/4a68bd40daf193b6e13f32c67505c4b85f780196) abcmidi: 2025.02.07 -> 2025.02.16
* [`c8eb80c5`](https://github.com/NixOS/nixpkgs/commit/c8eb80c5c6133383b57dab99725ba3280302f789) python3Packages.psycopg2{,cffi}: use libpq instead of postgresql
* [`920cf80d`](https://github.com/NixOS/nixpkgs/commit/920cf80d337324d82a834ef0092d24b6268d6aaa) grub2: apply patches for security issues
* [`e3b0469d`](https://github.com/NixOS/nixpkgs/commit/e3b0469d7fec3a918e3bb4e1aee5090c7c5fcef3) maintainers: add @⁠poopsicles
* [`c8bf108a`](https://github.com/NixOS/nixpkgs/commit/c8bf108a7f1fa2a63d0ce33b050e841231eea598) anydesk: 6.4.1 -> 6.4.2
* [`d3154284`](https://github.com/NixOS/nixpkgs/commit/d31542841abdf3765017e02465adf46a6d8f2ff2) sphinxygen: 1.0.4 -> 1.0.10 ([nixos/nixpkgs⁠#386089](https://togithub.com/nixos/nixpkgs/issues/386089))
* [`f7548ccc`](https://github.com/NixOS/nixpkgs/commit/f7548cccda82477b731dee31032a861573f5be3d) nixos/light: add minBrightness option
* [`e80c35ba`](https://github.com/NixOS/nixpkgs/commit/e80c35badea46bb9af8c0f1038bdb2469d190322) storj-uplink: 1.122.2 -> 1.123.4
* [`16cdde80`](https://github.com/NixOS/nixpkgs/commit/16cdde80082ea5e2e02a53260ae3ef4e281c309c) nixos/kanidm: add extraJsonFile option to allow provisioning from a json file
* [`c14fc535`](https://github.com/NixOS/nixpkgs/commit/c14fc535f321f579e20a683ed3f18231614b1603) rPackages.nanoparquet: fixed build
* [`faa7eb22`](https://github.com/NixOS/nixpkgs/commit/faa7eb22626fc8cb94555efc14606a4c25bca8c8) rPackages.clarabel: fix build
* [`7bb31348`](https://github.com/NixOS/nixpkgs/commit/7bb31348d02ed9efd1869f6299401af17b706ac3) rPackages.ACME: fix build
* [`dc438203`](https://github.com/NixOS/nixpkgs/commit/dc438203ba879769b838620fb903dac23f88f569) stress-ng: 0.18.10 -> 0.18.11
* [`8bbbc49b`](https://github.com/NixOS/nixpkgs/commit/8bbbc49bf6484c7bea09a2c4db30d7ea58aa4d5d) media-downloader: 5.2.2 -> 5.3.0
* [`ceef725b`](https://github.com/NixOS/nixpkgs/commit/ceef725bdaad52699047b4aea0d033602c81feb4) conftest: 0.57.0 -> 0.58.0
* [`27c022f2`](https://github.com/NixOS/nixpkgs/commit/27c022f233e3a8146ec1a00da3d9ed224dc6f113) stormlib: 9.23 -> 9.30
* [`cb0a131e`](https://github.com/NixOS/nixpkgs/commit/cb0a131e1019689abb323ff47aaaf2dced2330f1) openttd-jgrpp: 0.64.1 -> 0.64.2
* [`ec593a0c`](https://github.com/NixOS/nixpkgs/commit/ec593a0c110c0942571858d9b94f54d9a216d02f) rPackages.rix: 0.15.2 -> 0.15.5
* [`cc6ed6d7`](https://github.com/NixOS/nixpkgs/commit/cc6ed6d74296a7ab629d89f07975846a8aba5189) cargo: avoid using system curl on darwin (again)
* [`2434fd6b`](https://github.com/NixOS/nixpkgs/commit/2434fd6bd48c7fcee6fdd63a4c1e5a79c6ae934b) cloudflared: 2025.2.0 -> 2025.2.1
* [`6e87867e`](https://github.com/NixOS/nixpkgs/commit/6e87867ee3e49ee5199fb48a6cf22958286f3c1d) nixos/postgresql: allow customisations of SystemCallFilter
* [`8c1511e8`](https://github.com/NixOS/nixpkgs/commit/8c1511e8be27c14d938d8368d2aaad924d99a8c5) keyguard: 1.10.0 -> 1.10.1
* [`8d94bc56`](https://github.com/NixOS/nixpkgs/commit/8d94bc56745c647759f2df0d613e2da3b335fd39) prowlarr: 1.30.2.4939 -> 1.31.2.4975
* [`e1e8742e`](https://github.com/NixOS/nixpkgs/commit/e1e8742ee3b9bce2786cecfd7eeed581d94745ac) llm: 0.22 -> 0.23
* [`d168b672`](https://github.com/NixOS/nixpkgs/commit/d168b672a4e6ddfd5230297038e8f18eef797a18) beetsPackages.audible: 1.0.0 -> 1.0.1
* [`66f5d66e`](https://github.com/NixOS/nixpkgs/commit/66f5d66edd320c8511e310a49e8af0e28555873b) rednotebook: 2.37 -> 2.38
* [`0828a7bf`](https://github.com/NixOS/nixpkgs/commit/0828a7bfa6bc1e2d90bd4d8bd11b1bb2dc3ce772) buildkite-cli: 3.6.0 -> 3.7.1
* [`4e17c954`](https://github.com/NixOS/nixpkgs/commit/4e17c9546fa35d79ad362268e99577383f611bc6) nixos/sudo-rs: align sudo and sudo-rs config
* [`906fa7c1`](https://github.com/NixOS/nixpkgs/commit/906fa7c18040994dd7133e019c4c0abac7502f17) betterdisplay: 3.3.2 -> 3.4.1
* [`4bba34ce`](https://github.com/NixOS/nixpkgs/commit/4bba34ce4b36f7950bfc8aa587e695fc4fd34a32) c-stdaux: init at 1.5.0
* [`6abfccb7`](https://github.com/NixOS/nixpkgs/commit/6abfccb7dde317a2343e1b671605b7ad93aa7958) c-siphash: init at 1.1.0
* [`190100c4`](https://github.com/NixOS/nixpkgs/commit/190100c498cb25e462f49482f4d291d0b129c819) python312Packages.siphash24: init at 1.7
* [`8cb1bbd4`](https://github.com/NixOS/nixpkgs/commit/8cb1bbd47d36db0e18ddf64e44f5342e7a9ab2de) python312Packages.pytools: add siphash24 support
* [`135deed7`](https://github.com/NixOS/nixpkgs/commit/135deed75a76c9dea5a2a9ba7d36e2037d23a785) c-stdaux: disable tests on darwin
* [`d9de8139`](https://github.com/NixOS/nixpkgs/commit/d9de8139077be4147ea682ae0fcf7e84e0eabf69) rPackages.methylKit: fix build
* [`d4877f6d`](https://github.com/NixOS/nixpkgs/commit/d4877f6d7c72eb7f10938630ab0800752b4c73fc) jitsi-meet-prosody: 1.0.8384 -> 1.0.8448
* [`1158cd5c`](https://github.com/NixOS/nixpkgs/commit/1158cd5c13e25d742af6611277efb2825d5586ad) glibc: install C.utf8 into locale dir instead of archive
* [`b91cb896`](https://github.com/NixOS/nixpkgs/commit/b91cb89649c2cdb3cda1c12083e4dbeca27c8954) maintainers/scripts/update: Format with black
* [`81aed8eb`](https://github.com/NixOS/nixpkgs/commit/81aed8eb80e9e4d540fb8c1c1ddddadf55ec6775) maintainers/scripts/update: Modernize types
* [`76f44542`](https://github.com/NixOS/nixpkgs/commit/76f44542a82ceb22da72c7a320e600ddf04451bf) maintainers/scripts/update: Add missing type hints
* [`fdea10b4`](https://github.com/NixOS/nixpkgs/commit/fdea10b43381f16701fd18863e992494559e2de6) maintainers/scripts/update: Fix update_info type
* [`e3772a9b`](https://github.com/NixOS/nixpkgs/commit/e3772a9bcbad487151a8116d8996437c7c54a91a) maintainers/scripts/update: Mark queue jobs as done
* [`3957f2b4`](https://github.com/NixOS/nixpkgs/commit/3957f2b45374bb0eb33918c99bc10e1d3ad469c0) maintainers: add gamedungeon
* [`e48f0a6e`](https://github.com/NixOS/nixpkgs/commit/e48f0a6eb584c1b0ca78e2e72a9d9ade5b626665) recon-ng: init at 5.1.2
* [`0ee24498`](https://github.com/NixOS/nixpkgs/commit/0ee24498210e397f3beeefb4a3b87e43d1d5817b) cosmic-bg: use mold linker
* [`0a49ff25`](https://github.com/NixOS/nixpkgs/commit/0a49ff25e2c847f255b24cb1cdc2cbe94f8be50c) cosmic-bg: refactor
* [`ad42512f`](https://github.com/NixOS/nixpkgs/commit/ad42512ff34c32e8e061c248df01ae4239773717) cosmic-bg: add HeitorAugustoLN as a maintainer
* [`63a365d8`](https://github.com/NixOS/nixpkgs/commit/63a365d8ffd47ffe7bbd0e577e3fecb51130efed) cosmic-launcher: use mold linker
* [`a91e87b1`](https://github.com/NixOS/nixpkgs/commit/a91e87b1f024e9a69c19a410f2c80e8bea8e5385) cosmic-bg: add updateScript
* [`5dc70716`](https://github.com/NixOS/nixpkgs/commit/5dc70716200a50e58fdaf5f9ed7bc7137cf2d3d7) rPackages.float: disable parallel building
* [`801b31bb`](https://github.com/NixOS/nixpkgs/commit/801b31bb362705233a52c364cef9a7328667ab24) cosmic-randr: use mold linker
* [`08d2b599`](https://github.com/NixOS/nixpkgs/commit/08d2b599b34ccf3f3efd27f67b7da2550494f2bc) taterclient-ddnet: 10.1.1 -> 10.1.2
* [`153d1982`](https://github.com/NixOS/nixpkgs/commit/153d1982b4614c077f0fcee93c24d29da06aa397) snis: 2024-08-02 -> 1.0.2
* [`80c2fa60`](https://github.com/NixOS/nixpkgs/commit/80c2fa60a461086bf252507e8abc8f4ec63f2cab) yara: 4.5.0 -> 4.5.2
* [`f54d20c3`](https://github.com/NixOS/nixpkgs/commit/f54d20c3a1f8386fd98196444934fe773556cb79) maintainers/scripts/update: Do not try to print error when there is not one
* [`6403eb8f`](https://github.com/NixOS/nixpkgs/commit/6403eb8f4bcb54bd4411e4e2736b279072034e92) _experimental-update-script-combinators.sequence: Loosen attrPath constraint
* [`f9d05fe6`](https://github.com/NixOS/nixpkgs/commit/f9d05fe6a156b0fbe729e18e9f49dfc85301ac01) gnome.updateScript: expose canonical attrPath
* [`1d2c1810`](https://github.com/NixOS/nixpkgs/commit/1d2c1810eb0e2c72fabf3c239ee9b0576faaac17) maintainers/scripts/update: Prepare for ordered updates
* [`ce96c797`](https://github.com/NixOS/nixpkgs/commit/ce96c797795486d2a9fb4aa9f8f1ad231e43bd61) maintainers/scripts/update: Allow updating in (reverse) topological order
* [`bdc4a33e`](https://github.com/NixOS/nixpkgs/commit/bdc4a33e1355eea2c1e87d19e9604702d4d29a5d) gcovr: 8.2 -> 8.3
* [`b9837ee7`](https://github.com/NixOS/nixpkgs/commit/b9837ee74cf176fb5932fe895fa7a3c5bbf09328) p2pool: 4.3 -> 4.4
* [`df775937`](https://github.com/NixOS/nixpkgs/commit/df7759378c5f9426cc45263e232c48d33d09f950) ddcui: 0.5.4 -> 0.6.0
* [`32d58ea2`](https://github.com/NixOS/nixpkgs/commit/32d58ea2a5761412c1ffaba610602484811a2b6a) last: 1609 -> 1611
* [`7660ca03`](https://github.com/NixOS/nixpkgs/commit/7660ca0367e87964cbcc8923fea02c844c30d106) emacs28{,-gtk3,-nox}: remove
* [`36bdbdfe`](https://github.com/NixOS/nixpkgs/commit/36bdbdfe3e2a8b771cc5544982bf8838a76478a7) emacs29{,-gtk3,-nox,-pgtk}: remove
* [`c07efdbb`](https://github.com/NixOS/nixpkgs/commit/c07efdbb573cc98c9cdda020c07807bf8b17e888) doc/rl-2505: mention Emacs bump and removal
* [`915668e6`](https://github.com/NixOS/nixpkgs/commit/915668e6e06467877f0749ec732e46d698c6c7bc) spicetify-cli: 2.39.3 -> 2.39.5
* [`ffb3b5e1`](https://github.com/NixOS/nixpkgs/commit/ffb3b5e1fa17f13f182faad00e624a28f7821a0e) reaper: 7.33 -> 7.34
* [`261feca6`](https://github.com/NixOS/nixpkgs/commit/261feca650f1cd65d1a12f395e0e16fb740688f1) grenedalf: init at 0.6.2
* [`41143fe5`](https://github.com/NixOS/nixpkgs/commit/41143fe5d693bf9630e0bf2bf57a4938bd47ad2d) gnutls: adapt linking after 3.8.8
* [`e1efb27a`](https://github.com/NixOS/nixpkgs/commit/e1efb27a386d77d726d20e84a4305a40af24ca15) zoom-us: 6.3.10.7150 -> 6.3.11.7212
* [`74818e25`](https://github.com/NixOS/nixpkgs/commit/74818e25aed728d764886bfdeeecc29fa28e094d) math-preview: fix by overriding nodejs from 22 to 20
* [`b1680bd1`](https://github.com/NixOS/nixpkgs/commit/b1680bd19b9248875b7d354f9faffda0122d7b14) nixos/sudo-rs: use runTest to run the VM test
* [`15531309`](https://github.com/NixOS/nixpkgs/commit/1553130920840a3af728529ac9f9d548daefc9cd) bark: nixfmt
* [`de10ccfb`](https://github.com/NixOS/nixpkgs/commit/de10ccfb11ddf86f6f929aab57c3ba4e358b13e5) jdt-language-server: 1.44.0 -> 1.45.0
* [`6feabbdb`](https://github.com/NixOS/nixpkgs/commit/6feabbdbdd8b2d72ac34776f43b1311038ceb6b9) apple-sdk: add multiple URLs for fetching SDK, prioritizing apple CDN
* [`3164f866`](https://github.com/NixOS/nixpkgs/commit/3164f866cd64e455524a0f0e1020101bf79f8ae0) txr: 298 -> 299
* [`e81f3296`](https://github.com/NixOS/nixpkgs/commit/e81f3296ea285d5fc612ef35a150478cdcaa49d8) matrix-sdk-crypto-nodejs: use fetchCargoVendor and refactor
* [`58156542`](https://github.com/NixOS/nixpkgs/commit/58156542d271b4f0e128ce4984cb1014fe242eaa) cosmic-bg: replace `rec` with `finalAttrs`
* [`713d43cd`](https://github.com/NixOS/nixpkgs/commit/713d43cdb4ccaa6e1df436adbbe5f597f511dcc3) cosmic-randr: replace `rec` with `finalAttrs`
* [`1b269226`](https://github.com/NixOS/nixpkgs/commit/1b269226f081c09d5be0da0f8153728bc8deb4bb) cosmic-launcher: replace `rec` with `finalAttrs`
* [`ea6eafaf`](https://github.com/NixOS/nixpkgs/commit/ea6eafaf2678c67dd3071b8dad9e410bee26446d) python312Packages.aiotarfile: use fetchCargoVendor and refactor
* [`05f0d5ae`](https://github.com/NixOS/nixpkgs/commit/05f0d5aefc5c4af892777bd04ef276ea3246d5b1) python312Packages.open-clip-torch: 2.30.0 -> 2.31.0
* [`024885b2`](https://github.com/NixOS/nixpkgs/commit/024885b2e82e204ec8c53623aa874980571530a0) rPackages.pannotator: fixed build
* [`5c0f6f64`](https://github.com/NixOS/nixpkgs/commit/5c0f6f6456c67d569ba5cf370de225d43804d3be) wasmserve: 1.2.0 -> 1.2.1
* [`668a5204`](https://github.com/NixOS/nixpkgs/commit/668a5204eacb7ed672424d1673dfafd0840a39ea) geos: 3.13.0 -> 3.13.1
* [`d19370a1`](https://github.com/NixOS/nixpkgs/commit/d19370a13305334431e4e0d4ed87c9c866f2060f) iroh: 0.32.1 -> 0.33.0
* [`a13d4a81`](https://github.com/NixOS/nixpkgs/commit/a13d4a81b4f1f4d11e48c2b88eb4d6beab51a387) rPackages.redatamx: fixed build
* [`57bfda83`](https://github.com/NixOS/nixpkgs/commit/57bfda8317016b8b29f70723293deb87c6e4abe9) prometheus-elasticsearch-exporter: 1.8.0 -> 1.9.0
* [`6f76e875`](https://github.com/NixOS/nixpkgs/commit/6f76e87548b54b2d08deaad8dbf54956a1d66319) mackerel-agent: 0.84.0 -> 0.84.1
* [`afc75994`](https://github.com/NixOS/nixpkgs/commit/afc75994fad07c9147de6acbc65b218f91f89407) spicedb: 1.40.1 -> 1.41.0
* [`7089700d`](https://github.com/NixOS/nixpkgs/commit/7089700d7a7377e5a6389439dcd766a89e75179d) workout-tracker: 2.0.3 → 2.1.1
* [`ce7d5bfe`](https://github.com/NixOS/nixpkgs/commit/ce7d5bfeb7df3e910a97ca31a27b07544269eab4) blueprint-compiler: 0.14.0 -> 0.16.0
* [`4dc3d276`](https://github.com/NixOS/nixpkgs/commit/4dc3d2766db44854dffe3f735d605535b91b64bb) black-hole-solver: 1.12.0 -> 1.14.0
* [`2471baeb`](https://github.com/NixOS/nixpkgs/commit/2471baeb3c17782cf85951e23d90626d304f6ceb) jmol: 16.3.9 -> 16.3.11
* [`63157e34`](https://github.com/NixOS/nixpkgs/commit/63157e34d892955234c18461f4c1c14b64912482) nixos/zwave-js-ui: Add chown to allowed syscalls
* [`6e036067`](https://github.com/NixOS/nixpkgs/commit/6e03606720679a4728dd8dc96edd39c2f2f4cc4c) qt6.qtbase: add Vulkan loader to rpath for QtGui
* [`45da5c64`](https://github.com/NixOS/nixpkgs/commit/45da5c64a4aa1fe876790ab14a7d8c376f3a7ca0) rPackages.tergo: fixed build
* [`d45ec824`](https://github.com/NixOS/nixpkgs/commit/d45ec8249408f09f8114e6afcba5ed6e1b594792) rPackages.awdb: fixed build
* [`ddb4302b`](https://github.com/NixOS/nixpkgs/commit/ddb4302bb8533522f187e020e2c060605edf5f0b) rPackages.salso: fixed build
* [`93ef0ead`](https://github.com/NixOS/nixpkgs/commit/93ef0ead538aa3f6f69dcfc23ea72668b072cf02) rPackages.parseLatex: fixed build
* [`cc70d671`](https://github.com/NixOS/nixpkgs/commit/cc70d671101b8275e725c0db304f2e6da75bc864) rPackages.xdvir: fixed build
* [`32a83539`](https://github.com/NixOS/nixpkgs/commit/32a835396afdd728efb5b7d703659c70c048b606) rPackages.watcher: fixed build
* [`fbb34d7f`](https://github.com/NixOS/nixpkgs/commit/fbb34d7f0ecbfe83a07f20f43d2726602e4e4c85) vit: 2.3.2 -> 2.3.3
* [`fc8a513e`](https://github.com/NixOS/nixpkgs/commit/fc8a513efa1fe1718bfc09d2b3d3817ba18a3c8e) rPackages.arcpbf: fixed build
* [`158cc87c`](https://github.com/NixOS/nixpkgs/commit/158cc87cf39301129e0e558d636cb7611eac4454) inform6: 6.42-r6 -> 6.42-r7
* [`6a610677`](https://github.com/NixOS/nixpkgs/commit/6a610677d19f462f7c67b3687979ff2acab475b5) klibc: 2.0.13 -> 2.0.14
* [`ba049fb4`](https://github.com/NixOS/nixpkgs/commit/ba049fb49338b4b1702bc61f514fd1d409ac5c41) rPackages.flint: fixed build
* [`a4811345`](https://github.com/NixOS/nixpkgs/commit/a481134519beea64d025051aeccca8598f040a18) rPackages.cpp11bigwig: fixed build
* [`30ce03f6`](https://github.com/NixOS/nixpkgs/commit/30ce03f656d312f0efee38d546ea22b439f47e5b) rPackages.fangs: fixed build
* [`0350ff72`](https://github.com/NixOS/nixpkgs/commit/0350ff72cb30c01e7c76dc65a91b749e8d38cb2d) fluidd: 1.32.3 -> 1.32.4
* [`8ff84523`](https://github.com/NixOS/nixpkgs/commit/8ff84523e49696392f25aa0784b184f82e8c8af5) opentelemetry-collector-builder: 0.120.0 -> 0.121.0
* [`60cde9e4`](https://github.com/NixOS/nixpkgs/commit/60cde9e4b9f226a7ea526efddcb9b3aaca9ee6a8) python3Packages.ruamel-yaml-string: init at 0.1.1
* [`52ffcb6c`](https://github.com/NixOS/nixpkgs/commit/52ffcb6cd48558837534f583a54fd2398c65add1) python3Packages.rectangle-packer: init at 2.0.2
* [`6f738e08`](https://github.com/NixOS/nixpkgs/commit/6f738e08020e547aad51ba6538c01deed916e076) python3Packages.klayout: init at 0.29.8
* [`12a699c4`](https://github.com/NixOS/nixpkgs/commit/12a699c40a8d5ffb693af3d7cf1db61b497ca2d7) python3Packages.kfactory: init at 0.21.7
* [`25cfb94d`](https://github.com/NixOS/nixpkgs/commit/25cfb94d69daf0ea68a884b53970d2cbb14c05e1) python3Packages.gdsfactory: init at 8.18.1
* [`e42b48de`](https://github.com/NixOS/nixpkgs/commit/e42b48de70b5b12cf3920b20bf06996be9d283df) jitsi-videobridge: 2.3-204-g26cd91bd -> 2.3-209-gb5fbe618
* [`05841708`](https://github.com/NixOS/nixpkgs/commit/05841708916eb3d91b5fb07e800228812c1f9488) chmlib: Also build binary utilities and developper libraries
* [`c45772a2`](https://github.com/NixOS/nixpkgs/commit/c45772a280b4fde06229cd1035a4ae82e5ec751d) sysdig-cli-scanner: 1.20.0 -> 1.21.0
* [`2a415323`](https://github.com/NixOS/nixpkgs/commit/2a415323b10393ac9f89c0b9b40efdea9c1c06dd) maintainers: add semtexerror
* [`c24a0562`](https://github.com/NixOS/nixpkgs/commit/c24a0562ceab9698796e90f7f4420b30a4e935f0) docfx: init at 2.78.3
* [`367239e2`](https://github.com/NixOS/nixpkgs/commit/367239e256a9f77c2e97200475dd2f5586a4a4e1) fishMinimal: init at 4.0.0
* [`ee8e5f77`](https://github.com/NixOS/nixpkgs/commit/ee8e5f77d01f23a4745fc94edd7de2e846b6eb24) neomutt: make notmuch optional
* [`b8700931`](https://github.com/NixOS/nixpkgs/commit/b8700931406ffe530c4a6f61f5a04066ff8d6e2c) maintainers: add RossSmyth
* [`0e0e1e59`](https://github.com/NixOS/nixpkgs/commit/0e0e1e59d58fe44b889c8b18c6e6a696dd01563b) gcli: 2.6.1 -> 2.7.0
* [`cd54ad38`](https://github.com/NixOS/nixpkgs/commit/cd54ad383e0ca03ce52e38a52f9e8c79adc52b5a) borgmatic: add nix-update-script
* [`45b82f9c`](https://github.com/NixOS/nixpkgs/commit/45b82f9c71642ea4b9f5e3b205cb69bbe3931c77) borgmatic: 1.9.12 -> 1.9.13
* [`6b9f15e4`](https://github.com/NixOS/nixpkgs/commit/6b9f15e4b3e3d2ba9233847f173ee5725a8542bb) rPackages.SharedObject: fix build
* [`2debac02`](https://github.com/NixOS/nixpkgs/commit/2debac024e8b934b3f101c69e4686428833e7f66) rPackages.EBSeq: backport fix
* [`6e87a4fb`](https://github.com/NixOS/nixpkgs/commit/6e87a4fb0b54f85f5db66d9acf28065aac4670b6) openfga: 1.8.4 -> 1.8.6
* [`70e75d7b`](https://github.com/NixOS/nixpkgs/commit/70e75d7b796df6459648870f5c76259179f43c58) dbmate: 2.25.0 -> 2.26.0
* [`78ee6902`](https://github.com/NixOS/nixpkgs/commit/78ee69021332e28ce4045cb677a1c0cf615744c3) ipp-usb: 0.9.28 -> 0.9.29
* [`9a78bcc7`](https://github.com/NixOS/nixpkgs/commit/9a78bcc7b7c510feecc081486498947bf5522b71) cadvisor: 0.49.2 -> 0.52.0
* [`aea36294`](https://github.com/NixOS/nixpkgs/commit/aea362944d07f2de6e1d057e9dceb72a30963249) woke: init at 0.19.0
* [`cf602f5d`](https://github.com/NixOS/nixpkgs/commit/cf602f5dba192007a4dd91bdc602a385f09d1802) deno: 2.2.2 -> 2.2.3
* [`a061c588`](https://github.com/NixOS/nixpkgs/commit/a061c58897a56171387d2e38692ef8b63e41c558) go_1_23: 1.23.6 -> 1.23.7
* [`cab62503`](https://github.com/NixOS/nixpkgs/commit/cab625037c4fd49d49c9d0295374e2194ce27e85) morewaita-icon-theme: 47.3 -> 47.4
* [`e786001d`](https://github.com/NixOS/nixpkgs/commit/e786001d44905ec1aa442aa517e8ad8298f87503) finamp: 0.9.13-beta -> 0.9.14-beta
* [`e832b98c`](https://github.com/NixOS/nixpkgs/commit/e832b98c5129932bb94be3e074b7598153b01f8a) slack: 4.41.105 -> 4.42.120
* [`6e2e984a`](https://github.com/NixOS/nixpkgs/commit/6e2e984af0a2f3197ff9ca6897a11fabdeb67ea7) lib/path: allow CA paths in hasStorePathPrefix
* [`6fceb90e`](https://github.com/NixOS/nixpkgs/commit/6fceb90e1a29af7f42f42c145e7ecff2a9a1fb97) maintainers: add arbel-arad
* [`d66da6b6`](https://github.com/NixOS/nixpkgs/commit/d66da6b65b9843b067e6c3fe405d76e5febc2a6d) python312Packages.sentence-transformers: add optional-dependencies
* [`30ec69c0`](https://github.com/NixOS/nixpkgs/commit/30ec69c0dba78166879a2249922059fd0765d618) python313Packages.dulwich: 0.22.7 -> 0.22.8
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
