### PR TITLE
niv nixpkgs: update a3383f5f -> 5d4f0d22

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a3383f5fdb09b4d2d79f24f793d7784d0886c909",
-        "sha256": "0q6r5czws5nnlbhpry5igxl4f05jpr42f3zjymld464gszcf92zg",
+        "rev": "5d4f0d2222258cbd1b558988ff83945832b89768",
+        "sha256": "01q6yn404rybgycmh4b8p8cp23crcmk6cx3q7bd1ghngx6ff17qb",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/a3383f5fdb09b4d2d79f24f793d7784d0886c909.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/5d4f0d2222258cbd1b558988ff83945832b89768.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@a3383f5f...5d4f0d22](https://github.com/nixos/nixpkgs/compare/a3383f5fdb09b4d2d79f24f793d7784d0886c909...5d4f0d2222258cbd1b558988ff83945832b89768)

* [`b91e74f2`](https://github.com/NixOS/nixpkgs/commit/b91e74f20453577d655235f129efa6256ef35c00) maintainers: add rypervenche
* [`9b9cff0c`](https://github.com/NixOS/nixpkgs/commit/9b9cff0cab21f09a5b74e19dfaa41db00d07f665) rdrview: unstable-2021-05-30 -> 0.1.3
* [`2b7e55c3`](https://github.com/NixOS/nixpkgs/commit/2b7e55c396ee90cb4e8a46dfa9111b21c2fabd2e) rdrview: add update script
* [`fbc14124`](https://github.com/NixOS/nixpkgs/commit/fbc141246d8b6352853b6a6a325c74499dc972bd) iverilog: set correct build compilers
* [`ae61b489`](https://github.com/NixOS/nixpkgs/commit/ae61b489903263ea1bf91e758142f7b4c1b6f608) freeimage: unstable-2021-11-01 -> unstable-2024-04-18
* [`9f29f3d7`](https://github.com/NixOS/nixpkgs/commit/9f29f3d7d02295d12d877a676ac291867714dfa8) binaryninja-free: init at 4.2.6455
* [`4293b7c0`](https://github.com/NixOS/nixpkgs/commit/4293b7c00b21e8d1604b1fea805ee733f5a39b4d) fped: fix cross build
* [`208ebbec`](https://github.com/NixOS/nixpkgs/commit/208ebbec206f69dda45027201c9e1562e23da049) freeimage: drop autoSignDarwinBinariesHook
* [`d0375313`](https://github.com/NixOS/nixpkgs/commit/d03753137f2435239665a28720e63986cbfe682f) freeimage: move to pkgs/by-name
* [`377dd13b`](https://github.com/NixOS/nixpkgs/commit/377dd13b7788f5a2624968932682afd079e6ac72) ocamlPackages.fileutils: 0.6.4 -> 0.6.6
* [`be185a3f`](https://github.com/NixOS/nixpkgs/commit/be185a3fae48b8201ca1ab790678358dbde23217) nixos/kimai: fix an error on first init after an upgrade
* [`bd57044a`](https://github.com/NixOS/nixpkgs/commit/bd57044a6004aeaef4c4a30b4f09ecba6e2c2412) nixos/kimai: ensure that our local.yaml is valid on init time
* [`aa9f5a43`](https://github.com/NixOS/nixpkgs/commit/aa9f5a43e212d501a84268b067ab4eb84074fc5b) perlPackages.Gtk3: fix strictDeps build
* [`3c20746f`](https://github.com/NixOS/nixpkgs/commit/3c20746f99537b0c8bf42ceef162fe73cdef7c77) doc: Cross-reference roles syntax doc & implementation
* [`3ac6ad07`](https://github.com/NixOS/nixpkgs/commit/3ac6ad07c98b71a2ba9964cfce5890a1f9dcfad6) kubectl-view-allocations: 0.18.1 -> 0.20.3
* [`48a221ff`](https://github.com/NixOS/nixpkgs/commit/48a221fff3361cc0ed2a37b7928cc2d81464c1ea) maintainers: add joaomoreira
* [`7cc5a44a`](https://github.com/NixOS/nixpkgs/commit/7cc5a44a61ac1bab1c998e78e0974d61c8af601e) make-initrd: use closureInfo
* [`e540245e`](https://github.com/NixOS/nixpkgs/commit/e540245ee4a75bde32c931734d5603414ae32f1d) pkgs/pathsFromGraph: drop
* [`46254927`](https://github.com/NixOS/nixpkgs/commit/46254927013f394de68b27ee5d395f300b302142) electron-cash: move to by-name and format
* [`cf28b966`](https://github.com/NixOS/nixpkgs/commit/cf28b966f3590bfcea7edd80e08d4bffeae215fd) electron-cash: 4.3.1 -> 4.4.2, fix build and tests
* [`bd385572`](https://github.com/NixOS/nixpkgs/commit/bd3855728cbc904c26fad741c159e1d9f8cbf679) mathematica: 14.1.0 -> 14.2.0
* [`452816f9`](https://github.com/NixOS/nixpkgs/commit/452816f963227be82d2eb223ee84edc8455d4bbf) mono: mark cross as broken
* [`ae348a66`](https://github.com/NixOS/nixpkgs/commit/ae348a66f11f909ce74e6f390de6f6726a033cc2) cassandra: 4.1.7 -> 4.1.8
* [`70af6304`](https://github.com/NixOS/nixpkgs/commit/70af6304883a2baf8b9cae0679e7f6c5bb06ea2a) cassandra_3_11: 3.11.12 -> 3.11.18
* [`6b6ddc3c`](https://github.com/NixOS/nixpkgs/commit/6b6ddc3c270153330ed38577ba258e83546c6f92) cassandra_3_0: 3.0.28 -> 3.0.31
* [`d69db699`](https://github.com/NixOS/nixpkgs/commit/d69db6997b975ab7abd9f81ebe33fd8ccd66107b) maintainers: add alikindsys
* [`28a8c651`](https://github.com/NixOS/nixpkgs/commit/28a8c651160fa3d9c14fd1d3ff3d10a2e992f24a) SDL2_image: 2.8.4 -> 2.8.5
* [`ce5c5442`](https://github.com/NixOS/nixpkgs/commit/ce5c54420b3cd8aa681ee4b5a7267d220d9b4337) ocaml-crunch: 3.3.1 -> 4.0.0
* [`89de2178`](https://github.com/NixOS/nixpkgs/commit/89de2178e4ee3459c7a876024b46d6bb883f7266) sage: remove optional jmol dep (and thus also jre8)
* [`2ae4878a`](https://github.com/NixOS/nixpkgs/commit/2ae4878af75c7d3c70e04af2908edfa87ffc28bc) elasticsearch: 7.17.16 -> 7.17.27
* [`f7dda0a8`](https://github.com/NixOS/nixpkgs/commit/f7dda0a89387b9c2b0c8a482386183995e5cea87) vlc: ffmpeg_4 -> ffmpeg_6
* [`788911b9`](https://github.com/NixOS/nixpkgs/commit/788911b90ca7c1f2de7676ed356ec1e0733965b4) zoraxy: 3.1.1 -> 3.1.8
* [`434e3136`](https://github.com/NixOS/nixpkgs/commit/434e31369b68abf5b09f00b28cc897d8d61f1456) python3Packages.betterproto: fix build failure
* [`683a958b`](https://github.com/NixOS/nixpkgs/commit/683a958ba529e709cd1c6da526f708492e8fb04e) sl1-to-photon: remove dontUseSetuptoolsCheck specification
* [`24d57822`](https://github.com/NixOS/nixpkgs/commit/24d578228c8588a93cef075f031a7fa8c105410a) sourcehut.coresrht: remove dontUseSetuptoolsCheck specification
* [`92f50eeb`](https://github.com/NixOS/nixpkgs/commit/92f50eebdaddc9b19499310abac572b8ab62e217) sourcehut: scmsrht: remove dontUseSetuptoolsCheck specification
* [`608c8ab7`](https://github.com/NixOS/nixpkgs/commit/608c8ab7487f0edfab3abc3acd122c5c02e9ef31) sourcehut.todosrht: remove dontUseSetuptoolsCheck specification
* [`7d594dc0`](https://github.com/NixOS/nixpkgs/commit/7d594dc01b2f9524f6fafaeeb0da0383214c2845) hifiscan: remove dontUseSetuptoolsCheck specification
* [`9af28577`](https://github.com/NixOS/nixpkgs/commit/9af28577c63a14d10fecc90ecec80629310bcdf9) octoprint: remove dontUseSetuptoolsCheck specification
* [`84873914`](https://github.com/NixOS/nixpkgs/commit/848739146b1ff1fcb98b942330a159204dd0523a) waydroid: remove dontUseSetuptoolsCheck specification
* [`f5afa98f`](https://github.com/NixOS/nixpkgs/commit/f5afa98f5852e55aea243fd6eff80e8a6b8aa49d) python3Packages.blivet: remove dontUseSetuptoolsCheck specification
* [`8d9f4201`](https://github.com/NixOS/nixpkgs/commit/8d9f4201fc91e58b648e33587ac1aab32bdd9171) python3Packages.eventkit: remove dontUseSetuptoolsCheck specification
* [`27f2b5f3`](https://github.com/NixOS/nixpkgs/commit/27f2b5f3645560520ef8cac2cbc91f9265e04db5) python3Packages.fastdtw: remove dontUseSetuptoolsCheck specification
* [`f87a7865`](https://github.com/NixOS/nixpkgs/commit/f87a78659af727c426a2f3fc0e37f43b8795b71f) python3Packages.fastjsonschema: remove dontUseSetuptoolsCheck specification
* [`3e8fa6fd`](https://github.com/NixOS/nixpkgs/commit/3e8fa6fd14833ab8b98710bfad668e066b545461) python3Packages.h5netcdf: remove dontUseSetuptoolsCheck specification
* [`8b03aec2`](https://github.com/NixOS/nixpkgs/commit/8b03aec28388fc6e35ffcf7875d33801d32c37fd) python3Packages.meep: remove dontUseSetuptoolsCheck specification
* [`99ef9660`](https://github.com/NixOS/nixpkgs/commit/99ef966095f4a3b2f1b007b2a65e417e05166926) python3Packages.mnist: remove dontUseSetuptoolsCheck specification
* [`60efacfe`](https://github.com/NixOS/nixpkgs/commit/60efacfe5b74f9bf87ba5121e284957d2321c6ba) python3Packages.napari: remove dontUseSetuptoolsCheck specification
* [`9b095479`](https://github.com/NixOS/nixpkgs/commit/9b09547993facf7cbb7e965c7c3158064ff7a65b) python3Packages.pyarrow: remove dontUseSetuptoolsCheck specification
* [`aa187178`](https://github.com/NixOS/nixpkgs/commit/aa18717844567f4c8dac0ce80f7780a38cf59ea6) python3Packages.pycoin: remove dontUseSetuptoolsCheck specification
* [`32045f2b`](https://github.com/NixOS/nixpkgs/commit/32045f2b1406257b1aebe51f6fa2dd819cc70af1) python3Packages.pylint: remove dontUseSetuptoolsCheck specification
* [`2663549a`](https://github.com/NixOS/nixpkgs/commit/2663549ab199d0ed4a00eeff41c32fddf40a5464) python3Packages.pyhotonfile: remove dontUseSetuptoolsCheck specification
* [`697aff19`](https://github.com/NixOS/nixpkgs/commit/697aff19cc694400d363add805bd8d49ad154f3e) python3Packages.python-constraint: remove dontUseSetuptoolsCheck specification
* [`f40cd8c7`](https://github.com/NixOS/nixpkgs/commit/f40cd8c730a1433f2b315407c6d055996498b3f3) python3Packages.python3-eventlib: remove dontUseSetuptoolsCheck specification
* [`b3101e9d`](https://github.com/NixOS/nixpkgs/commit/b3101e9d6f971011d157c95470923ae5a35c4c73) python3Packages.qiskit-ignis: remove dontUseSetuptoolsCheck specification
* [`3d74ee56`](https://github.com/NixOS/nixpkgs/commit/3d74ee56c3ad3c98e7ba8011a8abb4aed2b12b36) python3Packages.recommonmark: remove dontUseSetuptoolsCheck specification
* [`86cc66b5`](https://github.com/NixOS/nixpkgs/commit/86cc66b5564cd44e3015489ccb891766e5cbbe51) python3Packages.three-merge: remove dontUseSetuptoolsCheck specification
* [`ae07f630`](https://github.com/NixOS/nixpkgs/commit/ae07f630cf6e80f56d088bfb9d207eb368ba2f35) maubot: remove dontUseSetuptoolsCheck specification
* [`3a9616c2`](https://github.com/NixOS/nixpkgs/commit/3a9616c23e39fcab3cba9505fce5dd7b64f7b7c7) s3cmd: remove dontUseSetuptoolsCheck specification
* [`6cf4bb37`](https://github.com/NixOS/nixpkgs/commit/6cf4bb37f597e0fc654828ae8d1ad9588c504bbe) persepolis: remove nativeCheckInputs specification
* [`53dd5df0`](https://github.com/NixOS/nixpkgs/commit/53dd5df0778bfba9fa040219824ead42006ceec5) reaper-reapack-extension: init at 1.2.5
* [`0a8e3a0b`](https://github.com/NixOS/nixpkgs/commit/0a8e3a0b656a92fd485f5345840ffac45f845412) liblc3: 1.1.2 -> 1.1.3
* [`434c4f72`](https://github.com/NixOS/nixpkgs/commit/434c4f720809cc3654cfb0214f48187c719efebc) follow: 0.2.0-beta.2 -> 0.3.7
* [`27c86c79`](https://github.com/NixOS/nixpkgs/commit/27c86c79882c21d0a855a877be99f9c19852a1e2) python312Packages.evdev: 1.9.0 -> 1.9.1
* [`a7d43659`](https://github.com/NixOS/nixpkgs/commit/a7d43659d39c87e4fc5dc4f83265c99bceb883b2) cli11: 2.4.2 -> 2.5.0
* [`7ab5218d`](https://github.com/NixOS/nixpkgs/commit/7ab5218d3eec21d9b1b5f435914f820ecc8fc404) libredirect: log that hook is being activated
* [`43529b6d`](https://github.com/NixOS/nixpkgs/commit/43529b6db8eb715b02896d1b6275e96c3a50432f) chromaprint: format with nixfmt and refactor
* [`135b8b44`](https://github.com/NixOS/nixpkgs/commit/135b8b44104d83d8fefdec2bc9e68d5647fca78c) chromaprint: use ffmpeg-headless
* [`e57ebfcb`](https://github.com/NixOS/nixpkgs/commit/e57ebfcbf8800cd2d6ece06c6d752f34ae78b605) chromaprint: switch from fetchurl to fetchFromGitHub
* [`11ce0795`](https://github.com/NixOS/nixpkgs/commit/11ce07956ee8cfbc28a09657f84c9aa331213827) chromaprint: make building tools and examples optional
* [`4c97e7d5`](https://github.com/NixOS/nixpkgs/commit/4c97e7d59655177ee84f52a33a86ee1b92d6785e) chromaprint: add pkg-config validation
* [`38a133a9`](https://github.com/NixOS/nixpkgs/commit/38a133a966018812de2b9672c420888ef8de4d32) chromaprint: add nix-update-script
* [`8181d2a7`](https://github.com/NixOS/nixpkgs/commit/8181d2a7c120902a66ed15824c2d4ad054f06379) nixos/user-groups: Don't double-UTF8-encode subUidMapFile
* [`b602f868`](https://github.com/NixOS/nixpkgs/commit/b602f8682923e4f71b3a39af68d25bfe1e94693f) nixos/users-groups: Catch invalid usernames early
* [`071b4f5a`](https://github.com/NixOS/nixpkgs/commit/071b4f5a0066712e0dd7acc646c5b99ca0e3f70f) zap-chip: 2024.09.27 -> 2025.02.26
* [`90914f25`](https://github.com/NixOS/nixpkgs/commit/90914f256c592d4512ecf8706d21d097a26dbd96) python312Packages.types-lxml: 2024.12.13 -> 2025.02.24
* [`638bd0c2`](https://github.com/NixOS/nixpkgs/commit/638bd0c219a41206a7bd6dd48dad2e6f7e25c47b) cryptsetup: buildInputs -> propagatedBuildInputs
* [`12ccc770`](https://github.com/NixOS/nixpkgs/commit/12ccc770aacdc80e057a87d4e82b5ec1df46c015) cryptsetup: adopt
* [`020de628`](https://github.com/NixOS/nixpkgs/commit/020de628547f7951e43d7c376795cb6335e114ff) openroad: 2.0-unstable-2024-12-31 -> 2.0-unstable-2025-03-01
* [`cca1a97f`](https://github.com/NixOS/nixpkgs/commit/cca1a97f4dec8383ddecb87750bd1acf61739774) util-linux: add cryptsetup support
* [`cdd88fef`](https://github.com/NixOS/nixpkgs/commit/cdd88fefd4cc070f064e5794153981adfb3bbd99) util-linux: adopt
* [`cf83a2a2`](https://github.com/NixOS/nixpkgs/commit/cf83a2a2a8762be3f6c0d21bca2ca5f0ae23a995) gnome-extensions-cli: 0.10.4 -> 0.10.5
* [`d66c1888`](https://github.com/NixOS/nixpkgs/commit/d66c1888bb00dce7af9d022f4dbf57252f987745) libnotify: 0.8.3 -> 0.8.4
* [`65e87d45`](https://github.com/NixOS/nixpkgs/commit/65e87d455258705ff1541345c15cf99cea871429) sbcl: 2.5.1 -> 2.5.2
* [`1a9e6f6b`](https://github.com/NixOS/nixpkgs/commit/1a9e6f6b072d15b21cb36edd3a4b5734132d0873) sshuttle: 1.2.0 -> 1.3.0
* [`c6712efe`](https://github.com/NixOS/nixpkgs/commit/c6712efead39f8b3d6db8db57fd4d5183ecd5912) ocamlPackages.reactivedata: 0.3 -> 0.3.1
* [`7d71d994`](https://github.com/NixOS/nixpkgs/commit/7d71d994cac2414ebbaa2af78306ad3955568546) rke2_1_29: 1.29.13+rke2r1 -> 1.29.14+rke2r1
* [`2c18aaf1`](https://github.com/NixOS/nixpkgs/commit/2c18aaf1d2d0a11fc3ea73b707a61aebd4ba05f6) rke2_1_30: 1.30.9+rke2r1 -> 1.30.10+rke2r1
* [`722b74c4`](https://github.com/NixOS/nixpkgs/commit/722b74c480e978f1ba5c363306a0b86f4df5a1d1) rke2_1_32: 1.32.1+rke2r1 -> 1.32.2+rke2r1
* [`88f08b35`](https://github.com/NixOS/nixpkgs/commit/88f08b3566ec7269241f39d0fd1aa757b4718933) netpbm: 11.9.2 -> 11.9.3
* [`72edca1c`](https://github.com/NixOS/nixpkgs/commit/72edca1c2af9dce7fd552935fcd10946537926b6) hwdata: 0.392 -> 0.393
* [`e003b9e7`](https://github.com/NixOS/nixpkgs/commit/e003b9e7358b1b3ffcb6b072c424025a1907df5b) t3: 1.0.8 -> 1.0.9
* [`1e6177fb`](https://github.com/NixOS/nixpkgs/commit/1e6177fb6a5de8e875562178c6d24ba9bf165217) borgmatic: migrate to pytest-cov-stub
* [`951f6470`](https://github.com/NixOS/nixpkgs/commit/951f6470b062aace496f7428967b1887cfe44709) python313Packages.adguardhome: migrate to pytest-cov-stub
* [`f23eb902`](https://github.com/NixOS/nixpkgs/commit/f23eb90249860e1d28e605b9ace531864b364f5b) python313Packages.aioconsole: migrate to pytest-cov-stub
* [`edd64ce6`](https://github.com/NixOS/nixpkgs/commit/edd64ce6233ee808e7b8b96e0f0cce8ca0ed40d3) python313Packages.aiocron: migrate to pytest-cov-stub
* [`ebb633f3`](https://github.com/NixOS/nixpkgs/commit/ebb633f3cda9b6f221db98e52abcf0948fe6f243) python313Packages.aiohttp-jinja2: migrate to pytest-cov-stub
* [`967c10e6`](https://github.com/NixOS/nixpkgs/commit/967c10e6cdefad8461f309b87533ae56df5ec4b0) python313Packages.aiohue: migrate to pytest-cov-stub
* [`66960c02`](https://github.com/NixOS/nixpkgs/commit/66960c02b278fa951a40b9339756f76b27c46e8b) python313Packages.aiokef: migrate to pytest-cov-stub
* [`3d205ab2`](https://github.com/NixOS/nixpkgs/commit/3d205ab256f27e077c36940783ba9b75d182cac2) python313Packages.aiolimiter: migrate to pytest-cov-stub
* [`599e5f4b`](https://github.com/NixOS/nixpkgs/commit/599e5f4b3fec203b445cf95b793213444ead3aff) python313Packages.aiopvpc: migrate to pytest-cov-stub
* [`1d418c5c`](https://github.com/NixOS/nixpkgs/commit/1d418c5c1e104361dfe49e68e77f76b11ed3ce36) python313Packages.aioshutil: migrate to pytest-cov-stub
* [`095379ae`](https://github.com/NixOS/nixpkgs/commit/095379aee4c44463d2a1546ed5e654117c6a69c0) python313Packages.aiosignal: migrate to pytest-cov-stub
* [`92478b02`](https://github.com/NixOS/nixpkgs/commit/92478b0292b766fefc6a753ad97f943076c2d5f1) python313Packages.aiosonic: migrate to pytest-cov-stub
* [`4c4dc570`](https://github.com/NixOS/nixpkgs/commit/4c4dc5702f3fc8ec06fd1ae4a9866d98b69c14ad) python313Packages.aiosteamist: migrate to pytest-cov-stub
* [`8b332d6f`](https://github.com/NixOS/nixpkgs/commit/8b332d6fd418ef14b36b21f2996d53782a76bf1b) python313Packages.aioweenect: migrate to pytest-cov-stub
* [`4f8c2702`](https://github.com/NixOS/nixpkgs/commit/4f8c27026fb99699abbe43d1967eab070a9c3c14) python313Packages.aiozoneinfo: migrate to pytest-cov-stub
* [`a9cda7f5`](https://github.com/NixOS/nixpkgs/commit/a9cda7f5e5b5d3ad54f9da2aa98ed9ce8052a971) python313Packages.async-modbus: migrate to pytest-cov-stub
* [`9d9b7de1`](https://github.com/NixOS/nixpkgs/commit/9d9b7de1fc0a2b46f267453cf2ebac21c3c40ef8) python313Packages.bitlist: migrate to pytest-cov-stub
* [`b3fc63ea`](https://github.com/NixOS/nixpkgs/commit/b3fc63ea3b0d32c9c2c8991760d3dec962fd0f0b) libcap: 2.73 -> 2.74
* [`40d793c8`](https://github.com/NixOS/nixpkgs/commit/40d793c8784d846ef81f8935209d3666144f38bf) faad2: 2.11.1 -> 2.11.2
* [`5f58a817`](https://github.com/NixOS/nixpkgs/commit/5f58a817318b4a6900f936ee910c58a5015312c4) grocy: 4.3.0 -> 4.4.2
* [`2d3ce0de`](https://github.com/NixOS/nixpkgs/commit/2d3ce0de8979d55b447c8d455ccd7e6fe119ef5c) lvm2: 2.03.30 -> 2.03.31
* [`80ffcc9b`](https://github.com/NixOS/nixpkgs/commit/80ffcc9b7cbb1b781b6c7356ea59262d67842549) grocy: fix passthru test with second curl invocation
* [`6eba4ded`](https://github.com/NixOS/nixpkgs/commit/6eba4ded398d7ffaf65c52967efb67492ee04125) egl-wayland: 1.1.17 -> 1.1.18
* [`6c0a1ed2`](https://github.com/NixOS/nixpkgs/commit/6c0a1ed2abb8127abda55ec78075fd714fefb169) tshark: 4.4.4 -> 4.4.5
* [`7f3f0faf`](https://github.com/NixOS/nixpkgs/commit/7f3f0fafcd7c065583e5b075cf0f00e04638d9e9) systemd: Enable systemd-firstboot
* [`84e349f5`](https://github.com/NixOS/nixpkgs/commit/84e349f5fcf4e59d3559b03821a4fc014319e05e) gitlab.assets: use yarnConfigHook
* [`6447f715`](https://github.com/NixOS/nixpkgs/commit/6447f7152fbfdd9653424d225e794f70b3bb0a38) gdb: fix build on Apple Silicon
* [`bdd609bf`](https://github.com/NixOS/nixpkgs/commit/bdd609bfd319c01d518f1902eef74b9a30010334) freebsd.libcam: init
* [`3d6f1909`](https://github.com/NixOS/nixpkgs/commit/3d6f19095916a49a43adbad25e5d2fc7535f0d12) cdparanoia: fix build on FreeBSD
* [`11008209`](https://github.com/NixOS/nixpkgs/commit/11008209788e4f139566b3153cee1781751f7126) unixtools: hexdump util-linux -> util-linuxMinimal
* [`4dc2c45a`](https://github.com/NixOS/nixpkgs/commit/4dc2c45a86c9016e5fbb97a2fdf7e1a456a88d41) lerc: fix build on FreeBSD
* [`3703e381`](https://github.com/NixOS/nixpkgs/commit/3703e38135d9920a0b60b56cc1ee8288a9058ed9) noBrokenSymlinks: check for unreadable symlinks
* [`693c7b3d`](https://github.com/NixOS/nixpkgs/commit/693c7b3dadebbbb92c37b26ab13cccef8aad843a) noBrokenSymlinks: add test for unreadable symlinks; fix existing tests
* [`1a9fd786`](https://github.com/NixOS/nixpkgs/commit/1a9fd7866b789ef99e4f4ac353e4da6bfe740aa3) noBrokenSymlinks: use umask instead of chmod to make unreadable symlinks
* [`43178a46`](https://github.com/NixOS/nixpkgs/commit/43178a462f0fe723c1d7b074abc8e63820b6fde0) noBrokenSymlinks: fix tests on Linux
* [`0c4f6e93`](https://github.com/NixOS/nixpkgs/commit/0c4f6e939d0ac1502600f94e8a5cc9531c06f82f) noBrokenSymlinks: move hook to beginning of `defaultNativeBuildInputs`
* [`18d92cd0`](https://github.com/NixOS/nixpkgs/commit/18d92cd065269c5a470662850ce034b068292610) noBrokenSymlinks: set `meta.badPlatforms` for tests
* [`0354b63b`](https://github.com/NixOS/nixpkgs/commit/0354b63bf9325b0deadba0c1f5cfdf80da88e624) noBrokenSymlinks: use `lib.optionalAttrs` instead of `meta.badPlatforms`
* [`0f179437`](https://github.com/NixOS/nixpkgs/commit/0f1794375126c36acf1cf3dfeb119b5b2b0bb7f6) noBrokenSymlinks: apply `lib.recurseIntoAttrs` to set of tests
* [`6d5b2734`](https://github.com/NixOS/nixpkgs/commit/6d5b2734cf3a18388901f73b2127282349541760) SDL2: 2.32.0 -> 2.32.2
* [`0fa5aa82`](https://github.com/NixOS/nixpkgs/commit/0fa5aa827f076361ed659aa23b953c21af4c978b) tera-cli: enable for darwin, add nix-update-script
* [`110b3af9`](https://github.com/NixOS/nixpkgs/commit/110b3af97a8524161cd90e7a2aa5f2c269e4268c) nixos/tests/echoip: use runTest
* [`eccf6388`](https://github.com/NixOS/nixpkgs/commit/eccf6388229ab41dec9b97244fe0432490cbc4cb) nixos/echoip: improve systemd hardening
* [`a6aec17c`](https://github.com/NixOS/nixpkgs/commit/a6aec17c0098d98a8f6ab24d26600c6128a30cce) kdePackages.quazip: 1.4 -> 1.5
* [`040f9379`](https://github.com/NixOS/nixpkgs/commit/040f9379f59d12433edd67994a0c94777671f39a) libsepol: 3.8 -> 3.8.1
* [`16a4d9cc`](https://github.com/NixOS/nixpkgs/commit/16a4d9cc0f471877480062b7384c744b0e8d83c3) cfitsio: fix cross build for FreeBSD
* [`4add78fa`](https://github.com/NixOS/nixpkgs/commit/4add78fa5024be0495bfbfab6979096acdad9630) libraw: Fix build for FreeBSD
* [`cc5629f8`](https://github.com/NixOS/nixpkgs/commit/cc5629f83e17c6c1846d252d80ce9790c9690ecc) libvmaf: Fix build for FreeBSD
* [`6c9e3301`](https://github.com/NixOS/nixpkgs/commit/6c9e33016810d7c8bd291d393b147a8a3c213f5c) setools: refactor
* [`464785ae`](https://github.com/NixOS/nixpkgs/commit/464785aed5e9070b11ac231b564c76c0fac59d2a) ocamlPackages.reason: 3.14.0 -> 3.15.0
* [`b91a772a`](https://github.com/NixOS/nixpkgs/commit/b91a772ab40be099c574b27f95ed45b41ed932e1) python3Packages.enum34: remove
* [`d3b4764f`](https://github.com/NixOS/nixpkgs/commit/d3b4764f651511d2490155c00ee80d1510940020) flite: fix build for FreeBSD
* [`945810d7`](https://github.com/NixOS/nixpkgs/commit/945810d76ec776780038cdac77ce5cae23b4b3ca) webrtc-audio-processing: Fix build for FreeBSD
* [`5aa3d00b`](https://github.com/NixOS/nixpkgs/commit/5aa3d00b178b0f9165c87f006e919375bf637f25) openh264: fix build for FreeBSD
* [`d2b4fdee`](https://github.com/NixOS/nixpkgs/commit/d2b4fdeef2abd2cb56b14e93002c3ff36cd35536) jackaudio: fix cross build for FreeBSD
* [`90e35408`](https://github.com/NixOS/nixpkgs/commit/90e3540805ecf84de8de613bc72426a01e238cef) redis: fix build for FreeBSD
* [`e27c288c`](https://github.com/NixOS/nixpkgs/commit/e27c288c0b8565069318f929a39671d959e70cd2) meson: Configure with -Db_lundef=false on FreeBSD
* [`2e512e7c`](https://github.com/NixOS/nixpkgs/commit/2e512e7cf7d95f8a0249c8e4fc3ede0720a719e0) python3Packages.pytestCheckHook: fix disabledTestPaths glob matching assertion
* [`9346e6aa`](https://github.com/NixOS/nixpkgs/commit/9346e6aa5f2ec3f7f930ad3395e5666923c12226) python3Packages.pytestCheckHook: add tests
* [`b5634dac`](https://github.com/NixOS/nixpkgs/commit/b5634dac85ebdf8742d9be605e309a51dfdb9f4c) git-spice: 0.10.0 -> 0.12.0
* [`96d360ba`](https://github.com/NixOS/nixpkgs/commit/96d360bad6017cf98bd24952b1dbd16f8af9d409) tevent: 0.16.1 -> 0.16.2
* [`a9700212`](https://github.com/NixOS/nixpkgs/commit/a9700212c5b244fca66ca163cc62227717e0b54e) librsvg: generate loaders.cache even when cross compiling
* [`55d08bb8`](https://github.com/NixOS/nixpkgs/commit/55d08bb886c594f10e6c020c5502e87805e71d19) buildPythonPackage: simplify check-related attribute inheritance
* [`7458444e`](https://github.com/NixOS/nixpkgs/commit/7458444ef071aac671fded7215292d2d74bcd191) libid3tag: 0.15.1b -> 0.16.3
* [`73afd256`](https://github.com/NixOS/nixpkgs/commit/73afd256562be260e38c51058902d43dc0f6eb25) mp3fs: misc cleanup
* [`b327d513`](https://github.com/NixOS/nixpkgs/commit/b327d513a624ab6e45e2b39b46b22a5ee1ada0a2) mp3fs: add missing zlib
* [`24ddc2d2`](https://github.com/NixOS/nixpkgs/commit/24ddc2d2d0697732593469156780a7498876a881) raptor: mark broken
* [`261633b6`](https://github.com/NixOS/nixpkgs/commit/261633b66084ed69380b6511f311932a26caf4f5) pre-commit: remove locale specification in preCheck
* [`e3d6fab8`](https://github.com/NixOS/nixpkgs/commit/e3d6fab836121dfb30390e5521e00fad0ddf46eb) gpodder: Use the buildPythonPackage-provide local specification
* [`cc1e059c`](https://github.com/NixOS/nixpkgs/commit/cc1e059ce6a2b4d299c4ff3ac4e4968eb722c4e2) buildbotPackages.buildbot: use the locale specification from buildPythonApplicaiton
* [`5f657746`](https://github.com/NixOS/nixpkgs/commit/5f657746962c83d7fddbe3974634f47380472612) python3Packages.reportlab: use the locale specification from buildPythonPackage
* [`597b3c6f`](https://github.com/NixOS/nixpkgs/commit/597b3c6f545ab03f1f6a59d3fd2cd00aebf1dcea) python3Packages.pathlib2: use the locale specification from buildPythonPackage
* [`b7930587`](https://github.com/NixOS/nixpkgs/commit/b7930587c7a7a346f08027ee213c55e9206a593e) python3Packages.ephem: use the locale specification from buildPythonPackage
* [`511673c8`](https://github.com/NixOS/nixpkgs/commit/511673c81f5e643cdf1cd8ab6647b4925e692545) python3Packages.cligj: use the locale specification from buildPythonPackage
* [`7077d1e8`](https://github.com/NixOS/nixpkgs/commit/7077d1e81f569677a02bf101dd7f75ba42f0e316) python3Packages.pymediainfo: use the locale specification from buildPythonPackage
* [`a93c0f72`](https://github.com/NixOS/nixpkgs/commit/a93c0f72d776338ddbdc7197468071d4257460ab) python3Packages.pyrect: use the locale specification from buildPythonPackage
* [`ae063b98`](https://github.com/NixOS/nixpkgs/commit/ae063b98c043d236820a46816bd9f9474fbe832d) python3Packages.pygel: reset locales after checks
* [`2019f449`](https://github.com/NixOS/nixpkgs/commit/2019f449a415430b79ea9182cfa0da112d84fb69) python3Packages.gruut: use the locale specification from buildPythonPackage
* [`5207d059`](https://github.com/NixOS/nixpkgs/commit/5207d05960db394e387e381cf47fded865fc2b42) python3Packages.jieba: use the locale specification from buildPythonPackage
* [`a6fa7555`](https://github.com/NixOS/nixpkgs/commit/a6fa75556e14909b2b8b7d8f9d06bb74f79863db) python3Packages.nipype: use the locale specification from buildPythonPackage
* [`f66830a7`](https://github.com/NixOS/nixpkgs/commit/f66830a7b467ab5dbb8915a53b9b0368156de966) python3Packages.configparser: use the locale specification from buildPythonPackage
* [`f2487d1b`](https://github.com/NixOS/nixpkgs/commit/f2487d1b69b1aac5a9ad720350ccadd38643dea6) python3Packages.python-magic: unset LC_ALL at the end of checks
* [`46f20b45`](https://github.com/NixOS/nixpkgs/commit/46f20b456ef2cd8a10685fd2bde0d5f8d71ee2e1) python3Packages.sympy: use the locale specification from buildPythonPackage
* [`13475c2e`](https://github.com/NixOS/nixpkgs/commit/13475c2ed68afdae8e46dc9eae8f71a291cdf69b) python3Packages.pandas: use the locale specification from buildPythonPackage
* [`efccb4a8`](https://github.com/NixOS/nixpkgs/commit/efccb4a888505756ebd86d75a1ea79ee674c3806) python3Packages.pyopenssl: use the locale specification from buildPythonPackage
* [`7c93ee15`](https://github.com/NixOS/nixpkgs/commit/7c93ee15979be90bf1dae31c22f40174e0741212) python3Packages.docutils: use the locale specification from buildPythonPackage
* [`b7e39b98`](https://github.com/NixOS/nixpkgs/commit/b7e39b9885cd1c8d5594290e4233d775fc34f2c7) python312Packages.pandoc-latex-environment: fix build
* [`77050724`](https://github.com/NixOS/nixpkgs/commit/77050724f56df3927b31d94d50a5308021ea9eca) ffmpeg: 7.1 -> 7.1.1
* [`f76f5270`](https://github.com/NixOS/nixpkgs/commit/f76f5270a3e7d3f831eb4de22ab7984fd961c7c7) rainfrog: 0.2.14 -> 0.2.15
* [`e7597565`](https://github.com/NixOS/nixpkgs/commit/e7597565ebf03df0588a93c321212ece8e4ab099) python312Packages.dbt-adapters: 1.14.0 -> 1.14.1
* [`58c71c58`](https://github.com/NixOS/nixpkgs/commit/58c71c58d7ffcbe76db60789d8afa9bcd163a977) dmd: 2.109.1 -> 2.110.0
* [`929153f9`](https://github.com/NixOS/nixpkgs/commit/929153f9ddf73bb8d17723e4c80b5261fa1d61f1) python3Packages.case-converter: init at 1.2.0
* [`94d3a20c`](https://github.com/NixOS/nixpkgs/commit/94d3a20c2137673e107e9afea5868302ded8e9ef) cdogs-sdl: 2.2.0 -> 2.3.0
* [`7fe54a62`](https://github.com/NixOS/nixpkgs/commit/7fe54a62eac171a83eae57516f38d861ac5de267) python313Packages.bluetooth-sensor-state-data: migrate to pytest-cov-stub
* [`cbcefe99`](https://github.com/NixOS/nixpkgs/commit/cbcefe9919bd36cd13f53700e1db3bfe0eb6fad4) python313Packages.brunt: migrate to pytest-cov-stub
* [`81f5311e`](https://github.com/NixOS/nixpkgs/commit/81f5311e7c2c718caeeb825e0274181ab1ec4e17) python313Packages.certauth: migrate to pytest-cov-stub
* [`ce001535`](https://github.com/NixOS/nixpkgs/commit/ce001535ebe3483d5886c8e00a62f1ef721e708b) python313Packages.cfn-flip: migrate to pytest-cov-stub
* [`24cec2c8`](https://github.com/NixOS/nixpkgs/commit/24cec2c80958ba5193d35b152dd6b9731d1ad695) python313Packages.cftime: migrate to pytest-cov-stub
* [`543761aa`](https://github.com/NixOS/nixpkgs/commit/543761aab569e3ccadad7dd170e0b19654e8fe2c) python313Packages.chacha20poly1305-reuseable: migrate to pytest-cov-stub
* [`63547d82`](https://github.com/NixOS/nixpkgs/commit/63547d821fae7ea23fd17e496fa2720fc2d9f535) python313Packages.cherrypy: migrate to pytest-cov-stub
* [`a665a7a9`](https://github.com/NixOS/nixpkgs/commit/a665a7a914b0288215fb96c9001ea586f366cffe) python313Packages.click-repl: migrate to pytest-cov-stub
* [`d624a472`](https://github.com/NixOS/nixpkgs/commit/d624a472def5c131178cf65d94d095e40f2d27e8) xorg.xauth: 1.1.3 -> 1.1.4
* [`1c1aba79`](https://github.com/NixOS/nixpkgs/commit/1c1aba79872dbd9b9a0bdcc394d1e803c13f6c28) libqmi: unbreak cross compilation
* [`c2d4e8f4`](https://github.com/NixOS/nixpkgs/commit/c2d4e8f4cb3e2394cc31a949426ccd38f0056339) nixos/nixos-containers: user options take precedence over module ones
* [`fed03725`](https://github.com/NixOS/nixpkgs/commit/fed037254544a4006a4bb9a07461e2d5e37828cb) ocamlPackages.fileutils: bump minimal ocaml version
* [`791fbe96`](https://github.com/NixOS/nixpkgs/commit/791fbe96a246030f91a69a3680bd600cea08b2fa) udftools: 2.0 -> 2.3
* [`9270d7cb`](https://github.com/NixOS/nixpkgs/commit/9270d7cbb6d5cab7d403819df811092713f599f8) nixos/installation-device: add jq.all to extraDependencies
* [`bc157d1d`](https://github.com/NixOS/nixpkgs/commit/bc157d1d01af4ff4906071ff580b28fc8ae3f597) gst_all_1.gst-plugins-base: disable libvisual
* [`7a4e2d47`](https://github.com/NixOS/nixpkgs/commit/7a4e2d47eabb4d6f033e640a6edb06da93bf3703) libvisual: drop
* [`5501f910`](https://github.com/NixOS/nixpkgs/commit/5501f91084e2a756734ae32b99fe6ff8eae90fdb) owntone: init at 28.11
* [`eeb00de3`](https://github.com/NixOS/nixpkgs/commit/eeb00de3bb5e510117da64e0fbbc2b93da0d3df7) pdisk: Modernise
* [`173ec7d6`](https://github.com/NixOS/nixpkgs/commit/173ec7d67a703749c68e1f340bf8cbdfd71e9a55) pdisk: Fix build
* [`1bffa075`](https://github.com/NixOS/nixpkgs/commit/1bffa075dac81f37fc882f24cd3483345eb64a53) pdisk: 0.9 -> 0.10
* [`ca8b67ee`](https://github.com/NixOS/nixpkgs/commit/ca8b67eeedce1abffb09e52d6156fdec82915272) doing: 1.0.10pre -> 2.1.88
* [`d6f48748`](https://github.com/NixOS/nixpkgs/commit/d6f48748f3591ecf1ca9ccd579d8d6a6cf5f4f73) doing: modernize
* [`3c64ac2c`](https://github.com/NixOS/nixpkgs/commit/3c64ac2c3496c4ddcacc004bdd67c47e4c7dbacf) gi-docgen: 2024.1 → 2025.3
* [`bec11184`](https://github.com/NixOS/nixpkgs/commit/bec11184658d68d948e4283c409f7078e7b74061) glib: 2.82.4 → 2.82.5
* [`df7f864a`](https://github.com/NixOS/nixpkgs/commit/df7f864ae98c5d0e5989bb485d28993eec6be3fa) polkit: 124 → 126
* [`8a7bf613`](https://github.com/NixOS/nixpkgs/commit/8a7bf613dd6b080296c33937c0e43f41732b777a) kdePackages.qca: 2.3.9 -> 2.3.10
* [`c6a9d36e`](https://github.com/NixOS/nixpkgs/commit/c6a9d36e25ca85c9a59e2771766a18cff7d3dfde) xorg.libX11: 1.8.11 -> 1.8.12
* [`bc4de002`](https://github.com/NixOS/nixpkgs/commit/bc4de002cffe010be2a15d6aa687a4fd1942a668) infnoise: 0.3.2 -> 0.3.3
* [`5b8dfab0`](https://github.com/NixOS/nixpkgs/commit/5b8dfab0f2e026518f294b2661bb17c67aa917e1) iozone: 3.506 -> 3.507
* [`97778e66`](https://github.com/NixOS/nixpkgs/commit/97778e6618503830bd1f26c4225d11046fc6e8ba) lout: 3.43 -> 3.43.1
* [`ef5143fb`](https://github.com/NixOS/nixpkgs/commit/ef5143fb2a3417f6184c8035efb4b790c104e613) taskjuggler: 3.7.2 -> 3.8.1
* [`ec881d41`](https://github.com/NixOS/nixpkgs/commit/ec881d4134766b0553293391211a5d4381c64c4f) fast-float: 8.0.0 -> 8.0.1
* [`293bd74d`](https://github.com/NixOS/nixpkgs/commit/293bd74d36ea88346e0d83c3411265e5bf8ea1a5) milu: unbreak on GCC 14
* [`476e0782`](https://github.com/NixOS/nixpkgs/commit/476e078248dce4f56ff2da4ddea4c842044eacd9) activemq: 6.1.5 -> 6.1.6
* [`7510a6d5`](https://github.com/NixOS/nixpkgs/commit/7510a6d52ac746cda77aaf127bbbbc53847639e6) ocamlPackages.mrmime: 0.6.1 -> 0.7.0
* [`c1da9049`](https://github.com/NixOS/nixpkgs/commit/c1da9049b3d02ad31c5b5cc9daf3aeaba77326bb) opensearch: 2.19.0 -> 2.19.1
* [`ce1cb632`](https://github.com/NixOS/nixpkgs/commit/ce1cb6327a2e7f2f9ff41448c3b3861701d63529) xorg.xtrans: 1.5.2 -> 1.6.0
* [`adad17e2`](https://github.com/NixOS/nixpkgs/commit/adad17e2d0398246717bcdd8a57d6f735fd3df2c) stdenv: fix propagatedUserEnvPkgs when __structuredAttrs is true
* [`49fe6989`](https://github.com/NixOS/nixpkgs/commit/49fe698936f050b48d496b34e5bd30aee9bc1568) otf2: init at 3.0.3
* [`009de066`](https://github.com/NixOS/nixpkgs/commit/009de0667f91d4bd46fe5a2aa70d8e1f325291da) rust: re add setEnv to cargo build hooks
* [`ba49db00`](https://github.com/NixOS/nixpkgs/commit/ba49db003e4e9ecb43d737d75bb9402d25d102e9) python313Packages.setuptools: 75.8.0 -> 75.8.2
* [`9748434b`](https://github.com/NixOS/nixpkgs/commit/9748434b0b3de15d760cf1da9487c626c742da85) python313Packages.pytest: 8.3.4 -> 8.3.5
* [`ed998d71`](https://github.com/NixOS/nixpkgs/commit/ed998d7134757f26af510fe93099dc22424df0e8) python313Packages.pytest-asyncio: 0.25.2 -> 0.25.3
* [`583c6ccb`](https://github.com/NixOS/nixpkgs/commit/583c6ccbc855c0f54723262584e5535dc354df06) python313Packages.hypothesis: 6.125.2 -> 6.127.4
* [`6a9b5000`](https://github.com/NixOS/nixpkgs/commit/6a9b500027102d7918fe68da5898688246ab7445) python313Packages.mypy: 1.14.1 -> 1.15.0
* [`3f240343`](https://github.com/NixOS/nixpkgs/commit/3f2403435ab47665287af5d883a848ac6a170281) python313Packages.roman-numerals-py: init at 3.1.0
* [`98d5fce8`](https://github.com/NixOS/nixpkgs/commit/98d5fce8e029a9a6bebad80a2113cf0cb7d07c5b) python313Packages.sphinx: 8.1.3 -> 8.2.3
* [`332c4d0b`](https://github.com/NixOS/nixpkgs/commit/332c4d0b7a79a84d6167a472fd5318bd0a97da57) python313Packages.sphinx-autodoc-typehints: 3.0.1 -> 3.1.0
* [`d88d9fee`](https://github.com/NixOS/nixpkgs/commit/d88d9feeb4bfc1bf6837037903c0f28c6f1d06fa) python313Packages.certifi: 2024.12.14 -> 2025.01.31
* [`be4d27fe`](https://github.com/NixOS/nixpkgs/commit/be4d27febe7776aac010f1ce11e1ff1f60f09bdd) python313Packages.pip: 24.0 -> 25.0.1
* [`5f4ed45b`](https://github.com/NixOS/nixpkgs/commit/5f4ed45be07c98c0cda45df5679d08adc4bce01a) python313Packages.importlib-metadata: 8.5.0 -> 8.6.1
* [`8b20103d`](https://github.com/NixOS/nixpkgs/commit/8b20103d797d4993640b8343549864a981617edf) python313Packages.attrs: 24.3.0 -> 25.1.0
* [`1ea433e8`](https://github.com/NixOS/nixpkgs/commit/1ea433e847733cd767737fc6d02edfe32384e34c) python313Packages.pytz: 2024.2 -> 2025.1
* [`937557ee`](https://github.com/NixOS/nixpkgs/commit/937557eedc22385a61ee84149d862f69f38f859e) python313Packages.cachetools: 5.5.0 -> 5.5.2
* [`b4a8330f`](https://github.com/NixOS/nixpkgs/commit/b4a8330f5e260b7d08e3dff64a01e9f70b5a38b2) python313Packages.time-machine: 2.15.0 -> 2.16.0
* [`13186352`](https://github.com/NixOS/nixpkgs/commit/13186352e192e39b9b25db54cb40e78f268acd63) python313Packages.setuptools-scm: 8.1.0 -> 8.2.0
* [`026f3aee`](https://github.com/NixOS/nixpkgs/commit/026f3aee65e21674b3000893b5f083f20c957a93) python313Packages.virtualenv: 20.29.1 -> 20.29.2
* [`4d1866c6`](https://github.com/NixOS/nixpkgs/commit/4d1866c64d69618143506e3abe934007637f3b61) python313Packages.tomli: 2.0.1 -> 2.2.1
* [`9f37eafb`](https://github.com/NixOS/nixpkgs/commit/9f37eafb7603ec0ff196e0870b8618468d952029) python313Packages.psutil: 6.1.1 -> 7.0.0
* [`df51ae20`](https://github.com/NixOS/nixpkgs/commit/df51ae20e1ba0394e029d453c28a3d744db85c2a) python313Packages.lxml: 5.3.0 -> 5.3.1
* [`cc240a69`](https://github.com/NixOS/nixpkgs/commit/cc240a69766af79794eabb26a78a47c5e469f90c) python313Packages.wrapt: 1.17.1 -> 1.17.2
* [`3244adf5`](https://github.com/NixOS/nixpkgs/commit/3244adf50946526f208b0b053cbade08ed64afa1) python313Packages.filelock: 3.16.1 -> 3.17.0
* [`b226f2c7`](https://github.com/NixOS/nixpkgs/commit/b226f2c70d23732a1b73aaf88e4cd8ada4963b93) python313Packages.beautifulsoup4: 4.12.3 -> 4.13.3
* [`20bd11e1`](https://github.com/NixOS/nixpkgs/commit/20bd11e13dff20183ffd007e659948df518b67ab) python313Packages.deprecated: 1.2.15 -> 1.2.18
* [`0f577e57`](https://github.com/NixOS/nixpkgs/commit/0f577e57fe3f6f986525382c38f291ec0d50459f) python313Packages.trove-classifiers: 2025.1.15.22 -> 2025.2.18.16
* [`4065c9c0`](https://github.com/NixOS/nixpkgs/commit/4065c9c05a6747f11362a8cb688b1e27b50b8e81) python313Packages.babel: 2.16.0 -> 2.17.0
* [`38db15da`](https://github.com/NixOS/nixpkgs/commit/38db15dae68c5dea765c3ca60b91328d527d5d54) python313Packages.mako: 1.3.8 -> 1.3.9
* [`bbe31413`](https://github.com/NixOS/nixpkgs/commit/bbe314131a1272871a5e61b3b59fc96bbfd88f18) python313Packages.alembic: 1.14.0 -> 1.14.1
* [`152243bd`](https://github.com/NixOS/nixpkgs/commit/152243bd66b6b821dbdd3e4fc051be5bca134e71) python313Packages.rpds-py: 0.22.3 -> 0.23.1
* [`e160c584`](https://github.com/NixOS/nixpkgs/commit/e160c584c2df3e39100165dcfe4c8351b9d32412) python313Packages.bcrypt: 4.2.1 -> 4.3.0
* [`8688edad`](https://github.com/NixOS/nixpkgs/commit/8688edad2a27dc3b550bf322dcced537093a0d3c) python313Packages.matplotlib: 3.10.0 -> 3.10.1
* [`7eecad76`](https://github.com/NixOS/nixpkgs/commit/7eecad76a6a2347ef24be0ee0dc01c0b5a1c4a8e) python313Packages.cryptography: 44.0.1 -> 44.0.2
* [`a87265f0`](https://github.com/NixOS/nixpkgs/commit/a87265f0f0953b1dfddc3c4ade12594f990064c7) python313Packages.tzdata: 2024.2 -> 2025.1
* [`858a016d`](https://github.com/NixOS/nixpkgs/commit/858a016d041bca9976d3a74d1353cf21871cf327) python313Packages.referencing: 0.36.1 -> 0.36.2
* [`11bcc653`](https://github.com/NixOS/nixpkgs/commit/11bcc653e7771077e64e9711b680ca8a029d6282) python313Packages.fastjsonschema: 2.19.1 -> 2.21.1
* [`7fd19112`](https://github.com/NixOS/nixpkgs/commit/7fd19112e3cba2fdcc0c91249f2ce154e44a0996) python313Packages.myst-parser: 4.0.0 -> 4.0.1
* [`3fc4086f`](https://github.com/NixOS/nixpkgs/commit/3fc4086f6ddb196d0a1cebaa0ffed2da68f2a3ec) python313Packages.typeguard: 4.4.1 -> 4.4.2
* [`fd650aff`](https://github.com/NixOS/nixpkgs/commit/fd650affc705dd652d596da3b3558739e66503d8) python313Packages.prompt-toolkit: 3.0.48 -> 3.0.50
* [`2dfff555`](https://github.com/NixOS/nixpkgs/commit/2dfff5550d660e296202d332ee19c00246ba8510) python313Packages.cython: 3.0.11-1 -> 3.0.12
* [`6b86e9dc`](https://github.com/NixOS/nixpkgs/commit/6b86e9dcc097774466c816f1636900ab06bdb7f9) python313Packages.pycodestyle: 2.12.0 -> 2.12.1
* [`a00e1f96`](https://github.com/NixOS/nixpkgs/commit/a00e1f9643598c66f181eb7176df19c35e9ac0c6) python313Packages.tzlocal: 5.2 -> 5.3
* [`b6bef333`](https://github.com/NixOS/nixpkgs/commit/b6bef333c92be20f8785b3f7763c55fd59be01a8) python313Packages.starlette: 0.45.2 -> 0.46.0
* [`0c722684`](https://github.com/NixOS/nixpkgs/commit/0c7226843927cb889fd3fe83237b187ef2448560) python313Packages.dulwich: 0.22.7 -> 0.22.8
* [`25484cf1`](https://github.com/NixOS/nixpkgs/commit/25484cf1beb4b3af6256d8eda6eb69bd608e9e9c) python313Packages.pydantic: 2.10.5 -> 2.10.6
* [`1dfe0f5b`](https://github.com/NixOS/nixpkgs/commit/1dfe0f5b2c4bc30459d31c5ba247e248919ec7f4) python313Packages.black: 24.10.0 -> 25.1.0
* [`64774164`](https://github.com/NixOS/nixpkgs/commit/64774164ceca2c7addba64fdf7e8e82a0da0db7d) python313Packages.fastapi: 0.115.6 -> 0.115.11
* [`6b1d10a4`](https://github.com/NixOS/nixpkgs/commit/6b1d10a414d649e0e7c89a2883921a7a93e1d881) python313Packages.cleo: 2.1.0 -> 2.2.1
* [`e066c1cb`](https://github.com/NixOS/nixpkgs/commit/e066c1cbeef526fc78de89048eaed32838564704) python313Packages.scikit-build-core: 0.10.7 -> 0.11.0
* [`3e2b050c`](https://github.com/NixOS/nixpkgs/commit/3e2b050cbabfb410419b81d47ab543233f3d3030) python313Packages.pyzmq: 26.2.0 -> 26.2.1
* [`01cef34e`](https://github.com/NixOS/nixpkgs/commit/01cef34e58ad44b13af885e2b62d4e3c39e1cf3d) python313Packages.typer: 0.15.1 -> 0.15.2
* [`a0872e51`](https://github.com/NixOS/nixpkgs/commit/a0872e51ea9a1b81506f93024589cb13ff7470bb) python313Packages.executing: 2.1.0 -> 2.2.0
* [`7f830f27`](https://github.com/NixOS/nixpkgs/commit/7f830f27aa03bccf0737659bd589249752744625) python313Packages.websockets: 14.1 -> 15.0
* [`5db61c7b`](https://github.com/NixOS/nixpkgs/commit/5db61c7bd1d04a5c74f200c261d9dc11db1a44ef) python313Packages.pymongo: 4.10.1 -> 4.11.2
* [`64134ec6`](https://github.com/NixOS/nixpkgs/commit/64134ec65a73a769e7ef336bd623cb5b4e0378a0) python313Packages.setproctitle: 1.3.4 -> 1.3.5
* [`d1b078de`](https://github.com/NixOS/nixpkgs/commit/d1b078de251b6db569870a1d52957448e79073aa) python313Packages.mistune: 3.1.0 -> 3.1.2
* [`de023205`](https://github.com/NixOS/nixpkgs/commit/de02320591872052b1d8f378707769710b8ca789) python312Packages.pytzdata: remove
* [`bf660617`](https://github.com/NixOS/nixpkgs/commit/bf660617308eafa7ddac54300edff7deaa4af121) python313Packages.lz4: 4.4.1 -> 4.4.3
* [`3c3803b1`](https://github.com/NixOS/nixpkgs/commit/3c3803b1ac7826d0c2b57134f31d035cab8ec9be) python313Packages.semver: 3.0.3 -> 3.0.4
* [`d5446e9c`](https://github.com/NixOS/nixpkgs/commit/d5446e9ca470dbeb9f02d6dbcecd796217be1efe) python313Packages.pyopenssl: 24.3.0 -> 25.0.0
* [`25ca0dcd`](https://github.com/NixOS/nixpkgs/commit/25ca0dcd0cbd6b0b42e7aaffec4ec1e833e5baf4) python313Packages.simplejson: 3.19.3 -> 3.20.1
* [`40140c8b`](https://github.com/NixOS/nixpkgs/commit/40140c8b8c1886b400688d925a1d5a1fdff221dc) python313Packages.json5: 0.9.28 -> 0.10.0
* [`61e21052`](https://github.com/NixOS/nixpkgs/commit/61e21052fcc0cb86bbd2ee89ebcc4284af0b6d7f) python313Packages.pydantic-settings: 2.7.1 -> 2.8.1
* [`6c3a56bb`](https://github.com/NixOS/nixpkgs/commit/6c3a56bbb4f3c002714f57b0de501f02375af31d) python313Packages.ulid-transform: 1.2.0 -> 1.2.1
* [`6042e17c`](https://github.com/NixOS/nixpkgs/commit/6042e17c1665cfa5907ed8d74c4346bd5a702a1e) selenium-manager: 4.28.0 -> 4.29.0
* [`dd74b447`](https://github.com/NixOS/nixpkgs/commit/dd74b4475de83e81b045db43981166441fae0ac1) python313Packages.selenium: 4.28.0 -> 4.29.0
* [`e43e30a3`](https://github.com/NixOS/nixpkgs/commit/e43e30a3d6dd4be687aba418afbd09136f708ed1) python313Packages.aiohttp-fast-zlib: 0.2.1 -> 0.2.3
* [`0a3988b5`](https://github.com/NixOS/nixpkgs/commit/0a3988b596a7e97272278e43cfcc52133006844f) python313Packages.aiohttp-asyncmdnsresolver: 0.1.0 -> 0.1.1
* [`6c32fae3`](https://github.com/NixOS/nixpkgs/commit/6c32fae3134af78a28ecbecd507d363c790522cf) python313Packages.pytest-unordered: 0.5.2 -> 0.6.1
* [`170cbb51`](https://github.com/NixOS/nixpkgs/commit/170cbb51b481867730c30cc7bcfc52c245175313) python313Packages.pyproject-api: 1.8.0 -> 1.9.0
* [`8e944d0e`](https://github.com/NixOS/nixpkgs/commit/8e944d0e232d50084e554d2b0b37057d32965197) python313Packages.pbr: 6.1.0 -> 6.1.1
* [`a6f5c82b`](https://github.com/NixOS/nixpkgs/commit/a6f5c82b88375c4ae5520f8343c06e366d1f11e4) python313Packages.faker: 33.3.1 -> 36.1.1
* [`eae2a03a`](https://github.com/NixOS/nixpkgs/commit/eae2a03ad0de657ede845974f160fc749e673a62) python313Packages.mock: 5.1.0 -> 5.2.0
* [`b47f66ce`](https://github.com/NixOS/nixpkgs/commit/b47f66ce23a65e182281451fa55c0eaa08b11506) python313Packages.trio: 0.28.0 -> 0.29.0
* [`6842c0f1`](https://github.com/NixOS/nixpkgs/commit/6842c0f1b77c8fee7a5833f925047efe267c6a8a) python313Packages.deepdiff: 8.1.1 -> 8.2.0
* [`a1a5d8e8`](https://github.com/NixOS/nixpkgs/commit/a1a5d8e84bdb5833afcbe7265529d50f3d0a488a) python313Packages.xarray: 2025.01.1 -> 2025.01.2
* [`67094131`](https://github.com/NixOS/nixpkgs/commit/670941318a420038ed924003c393080e968b94fb) python313Packages.trio-websocket: 0.11.1 -> 0.12.2
* [`0a4b8d07`](https://github.com/NixOS/nixpkgs/commit/0a4b8d07a33175f9964f86bf351b0feb965ae8c2) python313Packages.prettytable: 3.12.0 -> 3.15.1
* [`c15754a4`](https://github.com/NixOS/nixpkgs/commit/c15754a4ba800864df1115838cb8248cd3dc87cc) python313Packages.scikit-image: 0.25.0 -> 0.25.2
* [`9f71e38f`](https://github.com/NixOS/nixpkgs/commit/9f71e38fd6a5d36ecf3484699493262e63fe295a) python313Packages.moto: 5.0.28 -> 5.1.1
* [`31f2e24b`](https://github.com/NixOS/nixpkgs/commit/31f2e24bdb47cf936d49473c9b053591bb7307c6) python313Packages.jsonpickle: 4.0.1 -> 4.0.2
* [`97746f67`](https://github.com/NixOS/nixpkgs/commit/97746f67f22f7da4c1717d0e4d86089ebab32ce1) python313Packages.srsly: fix build
* [`76635143`](https://github.com/NixOS/nixpkgs/commit/7663514351f5d6b5612509244f81c4ada7497df2) python313Packages.pypdf: 5.1.0 -> 5.3.1
* [`b0ebd638`](https://github.com/NixOS/nixpkgs/commit/b0ebd6389f8a3d0a4b86a482fa031c9afabe4e47) python313Packages.bitarray: 3.0.0 -> 3.1.0
* [`ed706ef0`](https://github.com/NixOS/nixpkgs/commit/ed706ef02bb0fd0d9baeac3b52176f47467d0b80) python313Packages.phonenumbers: 8.13.53 -> 8.13.55
* [`3ec3f2f9`](https://github.com/NixOS/nixpkgs/commit/3ec3f2f9829e5d8a1712ca3ab5f7e5ade21a0b29) python312Packages.rapidfuzz: 3.12.1 -> 3.12.2
* [`507ce596`](https://github.com/NixOS/nixpkgs/commit/507ce59631f98e30cbba684a94727cef6e87cc56) python313Packages.pyproj: 3.7.0 -> 3.7.1
* [`c127dc80`](https://github.com/NixOS/nixpkgs/commit/c127dc807daddcbc38e582e25af15990c12d9b92) python312Packages.levenshtein: 0.27.0 -> 0.27.1
* [`befeade2`](https://github.com/NixOS/nixpkgs/commit/befeade2ca211a1525c05a083f9b4e9b521fb32d) python312Packages.resolvelib: 1.0.1 -> 1.1.0
* [`ea803c05`](https://github.com/NixOS/nixpkgs/commit/ea803c055a03805028a27499709ca558253bb0d1) python313Packages.django-cors-headers: 4.6.0 -> 4.7.0
* [`4b5a08ab`](https://github.com/NixOS/nixpkgs/commit/4b5a08abda825452be06f4d514612b2b755244ba) python312Packages.fastparquet: 2024.5.0 -> 2024.11.0
* [`def4a270`](https://github.com/NixOS/nixpkgs/commit/def4a2707204f1b72df7f2bd03eb0424858b5e76) python312Packages.geoip2: 4.8.1 -> 5.0.1
* [`f5988073`](https://github.com/NixOS/nixpkgs/commit/f5988073b54a566cb3c97cd14e1f661f20368459) python312Packages.pytest-django: 4.9.0 -> 4.10.0
* [`6c48714d`](https://github.com/NixOS/nixpkgs/commit/6c48714d9b999f2750ad7fa4e312d9d09a604b2b) python313Packages.posthog: 3.8.3 -> 3.18.1
* [`90fd3bd7`](https://github.com/NixOS/nixpkgs/commit/90fd3bd74440f6f83085ab7a6044bb743e925cbd) python312Packages.jsonlines: 3.1.0 -> 4.0.0
* [`999c27ad`](https://github.com/NixOS/nixpkgs/commit/999c27adda9e9faaacd85130ad682da37668347a) python312Packages.rich-click: 1.8.5 -> 1.8.6
* [`963acd96`](https://github.com/NixOS/nixpkgs/commit/963acd96c77b2e45f1c1c5af965ce03ef0b32af4) python312Packages.stripe: 11.5.0 -> 11.6.0
* [`380945f6`](https://github.com/NixOS/nixpkgs/commit/380945f6e7cc033b3cfccbac107748fb9f1d46bc) python312Packages.boltons: 24.1.0 -> 25.0.0
* [`bd38b7c0`](https://github.com/NixOS/nixpkgs/commit/bd38b7c06ec0d864dcb458b6ecab2d931c8c1dfc) python312Packages.factory-boy: 3.3.1 -> 3.3.3
* [`69dcb66f`](https://github.com/NixOS/nixpkgs/commit/69dcb66fe5d7ada01d4adb15236e41c3924cb7a4) python313Packages.propcache: 0.2.1 -> 0.3.0 ([nixos/nixpkgs⁠#386465](https://togithub.com/nixos/nixpkgs/issues/386465))
* [`35790737`](https://github.com/NixOS/nixpkgs/commit/35790737bb997e43b176dc8fecef0b367a4343f6) python313Packages.requests: don't depend on brotlicffi
* [`9cc0e35e`](https://github.com/NixOS/nixpkgs/commit/9cc0e35e29e74f8f3b7b41826eacc3bac3a993d6) python313Packages.levenshtein: unvendor rapidfuzz-cpp
* [`d7836cdf`](https://github.com/NixOS/nixpkgs/commit/d7836cdfe539981933363fe3fc661929d4570a52) python313Packages.jinja2: 3.1.5 -> 3.1.6
* [`781d80a3`](https://github.com/NixOS/nixpkgs/commit/781d80a3b7e10f1b814faecda437c34cd7d6e80a) python313Packages.trove-classifiers: 2025.2.18.16 -> 2025.3.3.18
* [`f3490036`](https://github.com/NixOS/nixpkgs/commit/f3490036f8dd77274399dc692576c08155e904d8) python313Packages.aiosqlite: 0.20.0 -> 0.21.0
* [`d07b3403`](https://github.com/NixOS/nixpkgs/commit/d07b3403f7e6554b9e52438b69c6e862fb558b81) python313Packages.isal: 1.7.1 -> 1.7.2
* [`ef631cf2`](https://github.com/NixOS/nixpkgs/commit/ef631cf20cb643d116e86275026292a796eb039c) python313Packages.pip-tools: disable failing tests
* [`97adbc53`](https://github.com/NixOS/nixpkgs/commit/97adbc53141e5e578786db52783f8ef64369911b) python313Packages.google-resumable-media: provide brotli for tests
* [`ee1ce300`](https://github.com/NixOS/nixpkgs/commit/ee1ce3007528d02c5e8ad45e16e3124f95522080) python313Packages.jeepney: 0.8.0 -> 0.9
* [`c83260df`](https://github.com/NixOS/nixpkgs/commit/c83260dfa40f777bc1d5b1a06c938c912ea39b9d) python313Packages.tzlocal: 5.3 -> 5.3.1
* [`aee4e568`](https://github.com/NixOS/nixpkgs/commit/aee4e5681e8fe94c513c47000baf71bbc5095cb0) python313Packages.ibm-cloud-sdk-core: enable previously failing tests
* [`81723229`](https://github.com/NixOS/nixpkgs/commit/817232292be9a9364b35676f22280cb4839fa57e) python313Packages.types-setuptools: 75.8.0.20250110 -> 75.8.2.20250305
* [`53093f51`](https://github.com/NixOS/nixpkgs/commit/53093f51d9fae6793f4f158a2f9aa80f974090aa) python313Packages.teamcity-messages: refactor
* [`c51326e6`](https://github.com/NixOS/nixpkgs/commit/c51326e684eaffd8fcd6913537a084615012ab46) python313Packages.google-cloud-testutils: 1.5.0 -> 1.6.0
* [`e079830d`](https://github.com/NixOS/nixpkgs/commit/e079830d67bd5e5a12c46e16cfccd445e3d8f963) python313Packages.types-decorator: 5.1.8.20240310 -> 5.2.0.20250224
* [`4af0a956`](https://github.com/NixOS/nixpkgs/commit/4af0a956e5fa6b2fe6a6f9cea5a3bf6c445b8e9a) python313Packages.webtest: 3.0.3 -> 3.0.4
* [`aee7f577`](https://github.com/NixOS/nixpkgs/commit/aee7f577855aec5d9511679bc113c12abd2dfa75) python313Packages.websockets: 15.0 -> 15.0.1
* [`6d085e0d`](https://github.com/NixOS/nixpkgs/commit/6d085e0dffc542aa36c81289930fd52ba13b5655) python313Packages.types-deprecated: 1.2.15.20241117 -> 1.2.15.20250304
* [`643b1376`](https://github.com/NixOS/nixpkgs/commit/643b1376801cf83e0644f88e74e3c7d20e22f245) python313Packages.types-lxml: 2024.12.13 -> 2025.03.04
* [`d8f2840f`](https://github.com/NixOS/nixpkgs/commit/d8f2840f89ca1dac22526f179c14c0ca709703fc) python313Packages.pytest-codspeed: 3.1.2 -> 3.2.0
* [`797ed862`](https://github.com/NixOS/nixpkgs/commit/797ed86270b4192e4e2cf3c66029eabcce6861de) python313Packages.pytest-httpserver: 1.1.0 -> 1.1.2
* [`853193d3`](https://github.com/NixOS/nixpkgs/commit/853193d3d0614f29e750abceb9a274f80320616a) python313Packages.types-requests: 2.32.0.20241016 -> 2.32.0.20250306
* [`bb597aa1`](https://github.com/NixOS/nixpkgs/commit/bb597aa10a6c206f385a4bbb2a0a0e6e9778aeff) python313Packages.pyelftools: 0.31 -> 0.32
* [`7d8ac0b4`](https://github.com/NixOS/nixpkgs/commit/7d8ac0b40d722ecbb1990ef59858c14f84a521ed) python313Packages.python-fsutil: 0.14.1 -> 0.15.0
* [`053fa6b6`](https://github.com/NixOS/nixpkgs/commit/053fa6b69cbbfb49f3b270e92464cffc55dcf21d) python313Packages.cached-ipaddress: 0.9.2 -> 0.10.0
* [`b39ec771`](https://github.com/NixOS/nixpkgs/commit/b39ec7715053b0d6f915169da114e11059c2e85d) python313Packages.inline-snapshot: 0.19.3 -> 0.20.5
* [`815ae05b`](https://github.com/NixOS/nixpkgs/commit/815ae05b8d1899ba68058dc0fc2fa194d705a53d) python313Packages.pytest-httpbin: 2.0.0 -> 2.1.0
* [`2ea47e5b`](https://github.com/NixOS/nixpkgs/commit/2ea47e5b736c6dd18712ff35cae4da7fc596e52b) python313Packages.pkg-about: 1.1.8 -> 1.2.9
* [`c12963b6`](https://github.com/NixOS/nixpkgs/commit/c12963b600a525af42117277e4dce55e671f52f2) python313Packages.types-mock: 5.1.0.20240425 -> 5.2.0.20250306
* [`a70dde28`](https://github.com/NixOS/nixpkgs/commit/a70dde28b172da13ce1c6fa326f71ea731e68f69) python313Packages.types-psutil: 6.1.0.20241221 -> 7.0.0.20250218
* [`f3ddcb4a`](https://github.com/NixOS/nixpkgs/commit/f3ddcb4acb4591f67673b4e2f87e70e320838d19) python313Packages.types-psycopg2: 2.9.21.20241019 -> 2.9.21.20250121
* [`e495ba10`](https://github.com/NixOS/nixpkgs/commit/e495ba108f2c458e155e4bca96383fd8919ead6b) python313Packages.pkginfo: 1.12.0 -> 1.12.1.2
* [`06090387`](https://github.com/NixOS/nixpkgs/commit/0609038722039c76ca5f53c2583923eeed69d577) python313Packages.tokenize-rt: 5.2.0 -> 6.1.0
* [`a78fdd98`](https://github.com/NixOS/nixpkgs/commit/a78fdd9828f758123a0b1822fd4ad12b33536a8a) python313Packages.pyupgrade: 3.15.0 -> 3.19.1
* [`95644f4f`](https://github.com/NixOS/nixpkgs/commit/95644f4f5fada9d4c64fe53e26e4207c08bac99e) python313Packages.bitarray: refactor
* [`8640fad5`](https://github.com/NixOS/nixpkgs/commit/8640fad51e6f0ff91751525249a814b0262e1240) python313Packages.gcsfs: fix src hash
* [`1670c945`](https://github.com/NixOS/nixpkgs/commit/1670c945104321e96989b2c175bf8a74b85071ac) python313Packages.django_4: 4.2.19 -> 4.2.20
* [`a83922bf`](https://github.com/NixOS/nixpkgs/commit/a83922bf152256337ef85398f862fef83bd11867) python312Packages.ansible-core: 2.18.2 -> 2.18.3
* [`1a9f4af0`](https://github.com/NixOS/nixpkgs/commit/1a9f4af0e3003b5cb25bb989e59f54081951960f) python312Packages.ansible: 11.2.0 -> 11.3.0
* [`8a5ff433`](https://github.com/NixOS/nixpkgs/commit/8a5ff433c5384904be8985b31f6e088da946e312) python313Packages.aioambient: relax poetry-core constraint
* [`64ac8bb7`](https://github.com/NixOS/nixpkgs/commit/64ac8bb7b56f66835e94ad071ff81d7974d70bfb) python313Packages.google-genai: relax websockets constraint
* [`a2797cf3`](https://github.com/NixOS/nixpkgs/commit/a2797cf311935ff521e5661822a71f278abf19cb) Revert "python313Packages.beautifulsoup4: 4.12.3 -> 4.13.3"
* [`34a61777`](https://github.com/NixOS/nixpkgs/commit/34a6177766d7fd4b1e7dca622a83aa3c74bf7f93) python313Packages.aioguardian: relax poetry-core constraint
* [`11d98fc9`](https://github.com/NixOS/nixpkgs/commit/11d98fc97a911e3f338a4987035421282cb076ee) poetry-unwrapped: disable failing test
* [`9737b565`](https://github.com/NixOS/nixpkgs/commit/9737b565d1d25d1e82d6b19671b6b6c729328546) python313Packages.booleanoperations: disable failing tests
* [`50a77dfd`](https://github.com/NixOS/nixpkgs/commit/50a77dfd1969ffc89d5a0fdbb48e4261ce57140e) python313Packages.click-option-group: disable failing test
* [`5562267b`](https://github.com/NixOS/nixpkgs/commit/5562267baef7d190be1cb6523917dd293e630fc8) python313Packages.click-option-group: refactor
* [`07e52736`](https://github.com/NixOS/nixpkgs/commit/07e5273666223add8ca5a3231bce6075be183b31) python313Packages.sanic: fix websockets 14.2 compat
* [`aea34c87`](https://github.com/NixOS/nixpkgs/commit/aea34c87ce79cf88a7d5fa3e4058088959c83989) mediagoblin: fix build by avoiding kombu tests
* [`fb6db3df`](https://github.com/NixOS/nixpkgs/commit/fb6db3dff8e7ddda3ea52b65f1bdc413b137404d) python313Packages.wtforms-sqlalchemy: fix build system
* [`10c07854`](https://github.com/NixOS/nixpkgs/commit/10c078540433a8dbfc67787ef915d3e5fd1fcd1e) pretix: relax pypdf constraint
* [`5f8071e7`](https://github.com/NixOS/nixpkgs/commit/5f8071e7f35e5ac8eace5ead86b1a5962eafd63b) python312Packages.karton-core: relax boto3 constraint
* [`2a90c5ef`](https://github.com/NixOS/nixpkgs/commit/2a90c5effb2e1319cd82cdc929a862b623602a73) python313Packages.safety: relax filelock and psutil constraints
* [`7b5fa9b1`](https://github.com/NixOS/nixpkgs/commit/7b5fa9b18700c474b61620fa8705d0a99e24e644) python313Packages.findpython: 0.6.2 -> 0.6.3
* [`92d16faa`](https://github.com/NixOS/nixpkgs/commit/92d16faa4f1fc5ad03a667f14fb29910d0f0513a) python312Packages.geometric: fix src hash
* [`3a99418a`](https://github.com/NixOS/nixpkgs/commit/3a99418a8699797ad7194fab8b6a1657d0fccc9f) python313Packages.glyphsets: relax setuptools-scm constraint
* [`f942c0b5`](https://github.com/NixOS/nixpkgs/commit/f942c0b5319d7cacb6bbb8d03822fb2b6e12fabd) python313Packages.asdf: 4.0.0 -> 4.1.0
* [`c08bfc29`](https://github.com/NixOS/nixpkgs/commit/c08bfc2905d4aac129804f88f2a79245e11d8b69) python313Packages.spglib: 2.5.0 -> 2.6.0
* [`097d8607`](https://github.com/NixOS/nixpkgs/commit/097d86071677db1eed06831f5b9b694dfddea2e2) python313Packages.asyncua: disable failing test
* [`fb98defc`](https://github.com/NixOS/nixpkgs/commit/fb98defc6161f5c6ce4a37ff5c9d742ca73bfa9d) python313Packages.jsonschema-path: 0.3.3 -> 0.3.4
* [`1d834df8`](https://github.com/NixOS/nixpkgs/commit/1d834df88d325bce6558fa0cb6442148badd077b) python313Packages.beanhub-extract: relax pytz constraint
* [`f3b5d54e`](https://github.com/NixOS/nixpkgs/commit/f3b5d54e49009a2e998690230e5b78b518b883ea) python313Packages.explorerscript: relax scikit-build-core constraint
* [`81aae12c`](https://github.com/NixOS/nixpkgs/commit/81aae12c82a89a7c02d735b1486a5af530a21c33) python313Packages.numpydoc: disable failing tests
* [`036b0e97`](https://github.com/NixOS/nixpkgs/commit/036b0e97fba4af0e075de4572771a25affeed91d) hxtools: 20231224 -> 20250309
* [`be650c20`](https://github.com/NixOS/nixpkgs/commit/be650c205bc493374dd2ca083c21e35565478cb6) microsoft-edge: fix aad sync
* [`74b4cf68`](https://github.com/NixOS/nixpkgs/commit/74b4cf6833902ad6e1937bc2f4e8bd757a177494) git-dump: init at 1.0.8
* [`98e6e17e`](https://github.com/NixOS/nixpkgs/commit/98e6e17ea69a75bb6eabd0e7c8bf1b1a0c658be2) nestopia-ue: 1.5.2 -> 1.6.0
* [`995ed90d`](https://github.com/NixOS/nixpkgs/commit/995ed90d3d20e729a7d0aff8c8a95562465fb57d) rustlings: add gcc to PATH
* [`bf0c4e69`](https://github.com/NixOS/nixpkgs/commit/bf0c4e694e326c7ddcbd7372891abbc7ff85f67f) acpi: 1.7 -> 1.8
* [`2b21c29f`](https://github.com/NixOS/nixpkgs/commit/2b21c29f9a5520c5989204374c43c25be90fecc7) gcc: remove .la files
* [`cfb15c65`](https://github.com/NixOS/nixpkgs/commit/cfb15c65204bcee4539e2bc6dcde197aa57ad95a) Revert "glusterfs: also apply hack"
* [`4e29b6dc`](https://github.com/NixOS/nixpkgs/commit/4e29b6dcac8e197a0f7f3bc537b164f4949e144f) Revert "treewide: apply hack to packages that fail after GCC symlink changes"
* [`80ba6909`](https://github.com/NixOS/nixpkgs/commit/80ba690907467b4554e9adff17cd7e1c8f6a1fae) julia_110-bin: 1.10.8 -> 1.10.9
* [`c8ece57f`](https://github.com/NixOS/nixpkgs/commit/c8ece57f16276862944dd21e268d86a896a33d34) julia_110: 1.10.8 -> 1.10.9
* [`f105c8e9`](https://github.com/NixOS/nixpkgs/commit/f105c8e97340544d1dc6fdade03b33dbe224c23c) julia_111-bin: 1.11.3 -> 1.11.4
* [`ea4edc44`](https://github.com/NixOS/nixpkgs/commit/ea4edc44cce55416794c4254f08d46b78a46b9ae) julia_111: 1.11.3 -> 1.11.4
* [`9ff133e6`](https://github.com/NixOS/nixpkgs/commit/9ff133e66391c86987dfdea8288662c7c2e0f039) libharu: 2.4.4 -> 2.4.5
* [`aa1f3eb6`](https://github.com/NixOS/nixpkgs/commit/aa1f3eb6fa1c7000d80a5c33828d3eaf69fa3bbf) cc-wrapper: warn about cross-compile only with non-default ([nixos/nixpkgs⁠#379593](https://togithub.com/nixos/nixpkgs/issues/379593))
* [`1434add9`](https://github.com/NixOS/nixpkgs/commit/1434add94c3ab74a63db4165ec361a9d5cd89188) nixosTests.{qtile,ragnarwm}: migrate to runTestOn
* [`eaf73267`](https://github.com/NixOS/nixpkgs/commit/eaf7326729ea7debc9af2ce60f4c3e4863ac3c4c) python313Packages.sqlalchemy: 2.0.38 -> 2.0.39
* [`019bbf20`](https://github.com/NixOS/nixpkgs/commit/019bbf203afc6b20ae3422ea15186dfffabc6058) gst_all_1.gst-plugins-bad: disable DirectFB
* [`4bcce448`](https://github.com/NixOS/nixpkgs/commit/4bcce448ae87ed9ab0eb40c8a2cb5f8c132229d2) python312Packages.qpsolvers: 4.4.0 -> 4.5.0
* [`70fb359a`](https://github.com/NixOS/nixpkgs/commit/70fb359aa194281032d13e9c2050948ca5c4ef76) veryl: 0.13.5 -> 0.14.1
* [`8a09bd8d`](https://github.com/NixOS/nixpkgs/commit/8a09bd8d1f220e40c56b4cac071d8fe1e0de38f1) python312Packages.krb5: 0.7.0 -> 0.7.1
* [`10b5f8dd`](https://github.com/NixOS/nixpkgs/commit/10b5f8dd5aa985a9ee173fa88beabd785434ba18) python312Packages.configparser: 7.1.0 -> 7.2.0
* [`b3229208`](https://github.com/NixOS/nixpkgs/commit/b3229208ee54833f2417cc9f675c23bb16baba53) ninjavis: init at 0.2.1
* [`22fce42a`](https://github.com/NixOS/nixpkgs/commit/22fce42a7b7be3ca0848b734060005b10dae97aa) nbdkit: 1.42.0 -> 1.42.1
* [`9a207cbd`](https://github.com/NixOS/nixpkgs/commit/9a207cbdb6fc4cd390d3159660664a0f8b985e53) sysdig: fix build on macOS
* [`3ee5cb72`](https://github.com/NixOS/nixpkgs/commit/3ee5cb7266b4c188106d875804e63445b966662b) Reapply "emacs: enable __structuredAttrs by default in elisp build helpers"
* [`51232abb`](https://github.com/NixOS/nixpkgs/commit/51232abb373f92c93888d0f37104c04245ea0eef) tlafmt: init at 0.3.0
* [`550b7205`](https://github.com/NixOS/nixpkgs/commit/550b7205534015391c39f067441b537e57db8b73) kubernetes: 1.32.2 -> 1.32.3
* [`5639710c`](https://github.com/NixOS/nixpkgs/commit/5639710c2ea9880baa70eea385fb74f8f029b114) nwjs-ffmpeg-prebuilt: 0.96.0 -> 0.97.0
* [`ccaed694`](https://github.com/NixOS/nixpkgs/commit/ccaed6944e16cb828aabeb6abc17dfc474bce2c3) yosys: 0.50 -> 0.51
* [`d6feb36e`](https://github.com/NixOS/nixpkgs/commit/d6feb36ea12fb3c7a2d43ae77345ef58e0e80c4f) Removed "A" from describtion
* [`0a7c1dc8`](https://github.com/NixOS/nixpkgs/commit/0a7c1dc8afa23c5c63790faf29a141871a27be63) Added changelog
* [`e7706ec0`](https://github.com/NixOS/nixpkgs/commit/e7706ec0dfe4248d85dc3e877b8783e696158b40) cloudflare-cli: init at 4.2.0
* [`95d5aa8b`](https://github.com/NixOS/nixpkgs/commit/95d5aa8b4c8ed44e4920d93b13b3e83b9e2d744f) dotnet-ef: 9.0.2 -> 9.0.3
* [`53915255`](https://github.com/NixOS/nixpkgs/commit/53915255096ecfc60f8f6381c4eac603d92e01c9) Revert "mate.eom: Apply hack for GCC symlink changes"
* [`043321fc`](https://github.com/NixOS/nixpkgs/commit/043321fc4c88eb14129671a54c37097503e88b11) python3Packages.cairocffi: fix darwin sandbox build
* [`9eefabc0`](https://github.com/NixOS/nixpkgs/commit/9eefabc0dc9a4c68078a89b19f2de4427d56cdf3) python3Packages.pycairo: fix darwin sandbox build
* [`4922d9ac`](https://github.com/NixOS/nixpkgs/commit/4922d9acc67a3780debd3ca4fb6ecd765d998492) python3Packages.pygal: fix darwin sandbox build
* [`d12b03a9`](https://github.com/NixOS/nixpkgs/commit/d12b03a9b8a17fffda73ad6d4ff2252265d099dc) annextimelog: 0.13.1 -> 0.14.0
* [`e3448357`](https://github.com/NixOS/nixpkgs/commit/e3448357fe5a3530d24d03f7eb80061122b9cafc) hurl: 6.0.0 -> 6.1.0
* [`29ca1c1a`](https://github.com/NixOS/nixpkgs/commit/29ca1c1a789ad26fe5b768a3d3daa258ba1112bc) lcevcdec: fix to make it work when avx is not supported
* [`2959d751`](https://github.com/NixOS/nixpkgs/commit/2959d7514d037433996c2bceab52c7cda67dd8d3) ffmpeg-full: renable lcevcdec support
* [`365e35ea`](https://github.com/NixOS/nixpkgs/commit/365e35ea25352f6d0ed9b3448398ea0a3b94935a) wmutils-libwm: 1.0 -> 1.3
* [`ea878d73`](https://github.com/NixOS/nixpkgs/commit/ea878d73f1e1f0f9866601af6a74288c2b66f57d) mdbook: 0.4.45 -> 0.4.47
* [`bd4128c3`](https://github.com/NixOS/nixpkgs/commit/bd4128c317acdd6f68b94f675ee4d408a3dbd13f) zfs: reduce closure size
* [`e3207f1f`](https://github.com/NixOS/nixpkgs/commit/e3207f1f4b93576ab9d6d4664ef609d2a84ac654) zile: 2.6.2 -> 2.6.3
* [`90112d19`](https://github.com/NixOS/nixpkgs/commit/90112d19b0d94b3fc0231d36a0faf38bf471e6ed) xsnow: 3.8.3 -> 3.8.4
* [`7d829370`](https://github.com/NixOS/nixpkgs/commit/7d8293702c71ac9e4539768d26dfc792eaeb6ff3) oxlint: 0.15.10 -> 0.15.14
* [`3e1c7a9f`](https://github.com/NixOS/nixpkgs/commit/3e1c7a9f0ef5dab4de45df8bbc6921afe3b41f4e) maintainers: add ciflire
* [`b79dce32`](https://github.com/NixOS/nixpkgs/commit/b79dce325d67b3f43e59b4b6b050762a6fed9710) Revert "singular: fix build"
* [`473c1988`](https://github.com/NixOS/nixpkgs/commit/473c1988ab0e3760a5dd48acf9256a127f7a4d96) python3Packages.icalendar-compatibility: init at 0.1.4
* [`4483e78c`](https://github.com/NixOS/nixpkgs/commit/4483e78ccb1268822ae7f01e72f2df92773dd022) python3Packages.x-wr-timezone: 2.0.0 -> 2.0.1
* [`56d7ffe9`](https://github.com/NixOS/nixpkgs/commit/56d7ffe96dc1f556d11ce53207f2d41263e88d83) python3Packages.mergecal: init at 0.5.0
* [`d06fab43`](https://github.com/NixOS/nixpkgs/commit/d06fab435bffb2db245edf1a77aba4317ef16a83) open-web-calendar: 1.42 -> 1.48
* [`1f0ca5cf`](https://github.com/NixOS/nixpkgs/commit/1f0ca5cff52c6fea3d131217a5e0cacb94926b3f) ckbcomp: 1.234 -> 1.235
* [`081ec647`](https://github.com/NixOS/nixpkgs/commit/081ec64709b0e42fddb519122140d8d05730b1c6) ocamlPackages.alcotest: 1.8.0 -> 1.9.0
* [`ebfb5369`](https://github.com/NixOS/nixpkgs/commit/ebfb53692bfd7c8876e3a261392a23c7864fc80b) translatelocally: add buildArch flag
* [`85951e24`](https://github.com/NixOS/nixpkgs/commit/85951e2457267f10c3c47be1d49ed6cc3867ba03) python312Packages.typecode: fix build against file 5.46
* [`8260c9a4`](https://github.com/NixOS/nixpkgs/commit/8260c9a4026090a1124bb48c0e598bfc52e719f6) benthos: 4.44.1 -> 4.45.1
* [`9bb374e0`](https://github.com/NixOS/nixpkgs/commit/9bb374e093df8045b7c4b8f98eb6b1a78f46cef1) ghostscript: 10.04.0 -> 10.05.0
* [`ca6e0c10`](https://github.com/NixOS/nixpkgs/commit/ca6e0c109f89158ae2298761f6f45a982b5d7511) pyright: 1.1.394 -> 1.1.396
* [`c7968cf1`](https://github.com/NixOS/nixpkgs/commit/c7968cf14075c62330b09bfa61e9d8a93da3b984) nixos/wakapi: harden systemd service
* [`317689ee`](https://github.com/NixOS/nixpkgs/commit/317689eefb01c80fd17b295afc96a04faba3157b) nginx: output config on failed gixy check
* [`70044e89`](https://github.com/NixOS/nixpkgs/commit/70044e898988a43bf60f26e98bee3c5db7c2befa)  chromaprint: add checks ([nixos/nixpkgs⁠#389190](https://togithub.com/nixos/nixpkgs/issues/389190))
* [`80c31359`](https://github.com/NixOS/nixpkgs/commit/80c31359820698530646a3bcd59db6be957164b7) magic-wormhole: 0.17.0 -> 0.18.0
* [`a5de042e`](https://github.com/NixOS/nixpkgs/commit/a5de042ebba162c3aca7269812b3efd95c6649dc) python313Packages.garth: 0.5.2 -> 0.5.3
* [`8b4e651a`](https://github.com/NixOS/nixpkgs/commit/8b4e651a70bec76a4d672b046fe1a631c7c6d5a9) icu77: init at 77.1
* [`aaba5898`](https://github.com/NixOS/nixpkgs/commit/aaba589863f4275423cd4f4083a20363e7d17249) tmuxPlugins.kanagawa: init at 0-unstable-2025-02-10
* [`4bbe5426`](https://github.com/NixOS/nixpkgs/commit/4bbe5426caab8e915565759ef261e2b2d8e910e7) duplicity: 3.0.3.2 -> 3.0.4
* [`dbf678fc`](https://github.com/NixOS/nixpkgs/commit/dbf678fc2e503d53067d79968e9d3118d22521f9) go-ios: 1.0.175 -> 1.0.176
* [`1f0f31f3`](https://github.com/NixOS/nixpkgs/commit/1f0f31f3a5c2c5a590abc35efb48d4e77a91ae75) ocamlPackages.ocaml_sqlite3: 5.3.0 -> 5.3.1
* [`da7ecedf`](https://github.com/NixOS/nixpkgs/commit/da7ecedfceb437e61ae41dde9134bcb77e29e98b) pulumi: 3.152.0 -> 3.156.0
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
