### PR TITLE
niv home-manager: update c657142e -> 869f2ec2

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -41,10 +41,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c657142e24a43ea1035889f0b0a7c24598e0e18a",
-        "sha256": "05v0p3c9yqwj01aa8ryzk5fi8cassvmivbm66vxfcf2xpcajivnm",
+        "rev": "869f2ec2add75ce2a70a6dbbf585b8399abec625",
+        "sha256": "0iy4gbhydx7h37dnpnzcqaz8ycy4i4zqzdvax22496rrxds42z0p",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/c657142e24a43ea1035889f0b0a7c24598e0e18a.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/869f2ec2add75ce2a70a6dbbf585b8399abec625.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@c657142e...869f2ec2](https://github.com/nix-community/home-manager/compare/c657142e24a43ea1035889f0b0a7c24598e0e18a...869f2ec2add75ce2a70a6dbbf585b8399abec625)

* [`fb74bb76`](https://github.com/nix-community/home-manager/commit/fb74bb76d94a6c55632376c931fc108131260ee9) vscode: fix creation of storage.json file ([nix-community/home-manager⁠#6650](https://togithub.com/nix-community/home-manager/issues/6650))
* [`22a36aa7`](https://github.com/nix-community/home-manager/commit/22a36aa709de7dd42b562a433b9cefecf104a6ee) swww: add swww service module for swww-daemon ([nix-community/home-manager⁠#6543](https://togithub.com/nix-community/home-manager/issues/6543))
* [`229648c5`](https://github.com/nix-community/home-manager/commit/229648c51e732cb8e70de7e0af5223f3e8160304) home-manager: support `--log-format` flag ([nix-community/home-manager⁠#6093](https://togithub.com/nix-community/home-manager/issues/6093))
* [`62dc8c30`](https://github.com/nix-community/home-manager/commit/62dc8c30ef292c003610ebae62ec5ec7544cdffe) home-manager: add autocomplete for `--log-format`
* [`1727f417`](https://github.com/nix-community/home-manager/commit/1727f417b7774953fe081ebb3757b60dab8a2943) flake.lock: Update ([nix-community/home-manager⁠#6636](https://togithub.com/nix-community/home-manager/issues/6636))
* [`9d554281`](https://github.com/nix-community/home-manager/commit/9d554281e059196661f4dbb44e99f2eff9bfd381) firefox: refactor bookmarks into a submodule & require force ([nix-community/home-manager⁠#6402](https://togithub.com/nix-community/home-manager/issues/6402))
* [`66f565db`](https://github.com/nix-community/home-manager/commit/66f565db48ebc9cef33f651c44151e7355400e10) maintainers: add jess
* [`eb5d59da`](https://github.com/nix-community/home-manager/commit/eb5d59dac9d77717135fdec1ef51c14a72e8c9f9) rclone: add module
* [`4108ec3a`](https://github.com/nix-community/home-manager/commit/4108ec3aa80244948d86f95c82c1dfc22daeb35c) podman: use dependency quadlets directly in build for generator
* [`81bf639d`](https://github.com/nix-community/home-manager/commit/81bf639da70763a844b79ffecd5de59b83f5ecb2) podman: link dependent quadlets during build
* [`8bb07191`](https://github.com/nix-community/home-manager/commit/8bb071912b32e858cfc4daba1a5683d5c62f1955) podman: warn if values match a quadlet only by name
* [`bb72d79f`](https://github.com/nix-community/home-manager/commit/bb72d79f5d319a11fd6226303ebf7a5dd1fd1913) podman: use type in attr name of built quadlets
* [`27a72d99`](https://github.com/nix-community/home-manager/commit/27a72d991305cfd9b15018a6e7eb3db93a32bc60) podman: include systemd in quadlet service path
* [`0d616edb`](https://github.com/nix-community/home-manager/commit/0d616edbacaa4e6a8cf794e573244f3d948f4150) maintainers: add noodlez
* [`1e0c64b6`](https://github.com/nix-community/home-manager/commit/1e0c64b6a23f2b7cd02106b0083069476c7fab61) waylogout: added configuration module
* [`e0be70bc`](https://github.com/nix-community/home-manager/commit/e0be70bcf94be20f8f0f6d215d909b614ab6ebeb) waylogout: remove with lib
* [`16a2a802`](https://github.com/nix-community/home-manager/commit/16a2a802de24a122800ec744639976cb457dde23) waylogout: nullable package support
* [`e4a40b44`](https://github.com/nix-community/home-manager/commit/e4a40b441e49443ffd25c05614ad9c134a12e53c) waylogout: add path support
* [`6b8cea64`](https://github.com/nix-community/home-manager/commit/6b8cea647349f53f2d57399535478001bebed053) easyeffects: add option to import presets
* [`e278f46a`](https://github.com/nix-community/home-manager/commit/e278f46a0990344b3186d09a35350fbcb6fa4dbd) easyeffects: add hausken as maintainer
* [`b5976017`](https://github.com/nix-community/home-manager/commit/b5976017741653251258112f7e6ee5d8b9e3a832) easyeffects: remove with lib
* [`c1dc900a`](https://github.com/nix-community/home-manager/commit/c1dc900a1ac0b2688115508c7b3c2a70a990ff8d) firefox: migrate search config to v7
* [`b44d79a5`](https://github.com/nix-community/home-manager/commit/b44d79a5b2d63ec1286fd4cb6d347df2b90679cb) firefox: migrate search config to v11
* [`8b629b54`](https://github.com/nix-community/home-manager/commit/8b629b5424dd2b10ff5cbca7fa52fa66ef33a196) firefox: migrate search config to v12
* [`9556d3c2`](https://github.com/nix-community/home-manager/commit/9556d3c2b48c0ec9a5cf4aa444b368cfb85fa60e) tex-fmt: add module
* [`eb0f617a`](https://github.com/nix-community/home-manager/commit/eb0f617aecbaf1eff5bacec789891e775af2f5a3) tex-fmt: add null package support
* [`cfaa4426`](https://github.com/nix-community/home-manager/commit/cfaa4426a3eee6e71ab02a4d72410e69abf06a12) megasync: use getExe instead of getExe' ([nix-community/home-manager⁠#6665](https://togithub.com/nix-community/home-manager/issues/6665))
* [`8675edf7`](https://github.com/nix-community/home-manager/commit/8675edf7d36bfc972f66481a33f4f453d3b2d06e) fish: add command option for abbreviations ([nix-community/home-manager⁠#6666](https://togithub.com/nix-community/home-manager/issues/6666))
* [`97a00e06`](https://github.com/nix-community/home-manager/commit/97a00e0659b2807454507eb3a593bd09b099bd80) librespot: init module ([nix-community/home-manager⁠#6229](https://togithub.com/nix-community/home-manager/issues/6229))
* [`94605dca`](https://github.com/nix-community/home-manager/commit/94605dcadefeaff6b35c8931c9f38e4f4dc7ad0a) tests/firefox: add applicationName to mock ([nix-community/home-manager⁠#6668](https://togithub.com/nix-community/home-manager/issues/6668))
* [`c36cc49e`](https://github.com/nix-community/home-manager/commit/c36cc49e55aff5562b0ca924f34285de6d6273be) onlyoffice: add module ([nix-community/home-manager⁠#6667](https://togithub.com/nix-community/home-manager/issues/6667))
* [`fc189507`](https://github.com/nix-community/home-manager/commit/fc189507bc0bc74b3794ee6912a5b80de8dfcc0c) docs: nixos module declarative installation instructions ([nix-community/home-manager⁠#6208](https://togithub.com/nix-community/home-manager/issues/6208))
* [`d725df5a`](https://github.com/nix-community/home-manager/commit/d725df5ad8cee60e61ee6fe3afb735e4fbc1ff41) mcfly: fix mcfly-fzf in non-interactive shells ([nix-community/home-manager⁠#6669](https://togithub.com/nix-community/home-manager/issues/6669))
* [`20ec3c10`](https://github.com/nix-community/home-manager/commit/20ec3c10498938c3ff78075b5fae94fe1cd4a715) mcfly: Fix swapped shell names
* [`46efc3b2`](https://github.com/nix-community/home-manager/commit/46efc3b2e14783d39f595cb0e5954a3a1edb0217) lazydocker: add module
* [`65413f29`](https://github.com/nix-community/home-manager/commit/65413f297f8c4c42a99270c15bce7bda1bfea724) lazydocker: remove with lib
* [`2e9981ca`](https://github.com/nix-community/home-manager/commit/2e9981ca0d6cee56f54a5e265b5edcd4dfc1b554) lazydocker: null package support
* [`da018181`](https://github.com/nix-community/home-manager/commit/da0181819479ddc034a3db9a77ed21ea3bcc0668) tests: scrub lazy{docker,git} on darwin
* [`cc538c37`](https://github.com/nix-community/home-manager/commit/cc538c3793322ec773f75631065ad9acfe04678a) hyprpolkitagent: init module
* [`5503a758`](https://github.com/nix-community/home-manager/commit/5503a758f9e2f9580dac416d342a113f4c7e7370) lxqt-policykit-agent: init module
* [`29c6f2b0`](https://github.com/nix-community/home-manager/commit/29c6f2b0cb2a028ae27ad7c51c0f516ac3d5e4f8) polkit-gnome: init module
* [`c1ca8974`](https://github.com/nix-community/home-manager/commit/c1ca8974b3330301c8b6939277db3beedb5c3ca1) hyprpolkitagent: use wayland.systemd.target
* [`71cbeb3a`](https://github.com/nix-community/home-manager/commit/71cbeb3afd1ea8fa95af9dd6c0567d763ba44bee) hyprpolkitagent: add khaneliman maintainer
* [`e5ab1811`](https://github.com/nix-community/home-manager/commit/e5ab18116c4dae69be789aaf33d70e901b5a9ba6) iamb: new module
* [`d6171149`](https://github.com/nix-community/home-manager/commit/d61711497be9ad6a6633aaf203b038b5a970621f) iamb: nullable package support
* [`8a68f18e`](https://github.com/nix-community/home-manager/commit/8a68f18e96bcab13e4f97bece61e6602298a3141) distrobox: add module ([nix-community/home-manager⁠#6528](https://togithub.com/nix-community/home-manager/issues/6528))
* [`296ddc64`](https://github.com/nix-community/home-manager/commit/296ddc64627f4a6a4eb447852d7346b9dd16197d) zsh: adjust initContent priorities ([nix-community/home-manager⁠#6676](https://togithub.com/nix-community/home-manager/issues/6676))
* [`10deb9d0`](https://github.com/nix-community/home-manager/commit/10deb9d043e625d8c6a629f5575718e0768dcfb4) treewide: zsh initExtra -> initContent
* [`94ea2cb5`](https://github.com/nix-community/home-manager/commit/94ea2cb536fa083665e12d08515d97313e0900f1) treewide: zsh initExtraBeforeCompInit -> initContent
* [`63e77d09`](https://github.com/nix-community/home-manager/commit/63e77d09a133ac641a0c204e7cfb0c97e133706d) jankyborders: add module ([nix-community/home-manager⁠#6677](https://togithub.com/nix-community/home-manager/issues/6677))
* [`7a08b8c8`](https://github.com/nix-community/home-manager/commit/7a08b8c898bb594f271bbabd3972af2c89d68b11) rclone: correctly escape whitespace in secrets
* [`7853236f`](https://github.com/nix-community/home-manager/commit/7853236fae80bb625c319df8d730cad2a5584f26) rclone: ensure remotes have a type field
* [`9172a6f9`](https://github.com/nix-community/home-manager/commit/9172a6f956f7e0f7810861b9b1146f1c43d9abcb) skhd: add module ([nix-community/home-manager⁠#6682](https://togithub.com/nix-community/home-manager/issues/6682))
* [`57e9a8a2`](https://github.com/nix-community/home-manager/commit/57e9a8a290cbeeb173b12d6bec1681e177ce6570) davmail: init module ([nix-community/home-manager⁠#6674](https://togithub.com/nix-community/home-manager/issues/6674))
* [`b61ae3b6`](https://github.com/nix-community/home-manager/commit/b61ae3b677a07c30cf6be5233e772b97a3a8b2fb) flake.lock: Update ([nix-community/home-manager⁠#6684](https://togithub.com/nix-community/home-manager/issues/6684))
* [`5ff90f09`](https://github.com/nix-community/home-manager/commit/5ff90f09d1bd189b722e60798513724cdd3580b6) wofi: merge multiple style definitions ([nix-community/home-manager⁠#6673](https://togithub.com/nix-community/home-manager/issues/6673))
* [`62d6a893`](https://github.com/nix-community/home-manager/commit/62d6a8931eb03b8bcaca425dbbe5b327c794ec37) firefox: fix bookmarks backwards compatibility
* [`d7f451d7`](https://github.com/nix-community/home-manager/commit/d7f451d7b13bbe075abecfd345f8b149a000216a) firefox: replace with-lib-expression with inherit-expression
* [`ecbcd792`](https://github.com/nix-community/home-manager/commit/ecbcd792e1f6cd018b0858b5b3d11733cd19c46f) firefox: check if bookmarks attrset is of correct type
* [`0e75a404`](https://github.com/nix-community/home-manager/commit/0e75a40458d065d1e5c6a10d0b74b9e35b550ae6) firefox: fix assertion when missing force for extensions ([nix-community/home-manager⁠#6688](https://togithub.com/nix-community/home-manager/issues/6688))
* [`4f453846`](https://github.com/nix-community/home-manager/commit/4f4538467fd29a8f5037c0939592cd89cd401155) firefox: fix migrate search v7 test for all firefox forks ([nix-community/home-manager⁠#6690](https://togithub.com/nix-community/home-manager/issues/6690))
* [`ad0614a1`](https://github.com/nix-community/home-manager/commit/ad0614a1ec9cce3b13169e20ceb7e55dfaf2a818) firefox: don't show migration warning when bookmarks isn't set ([nix-community/home-manager⁠#6689](https://togithub.com/nix-community/home-manager/issues/6689))
* [`908e055e`](https://github.com/nix-community/home-manager/commit/908e055e157a0b35466faf4125d7e7410ff56160) git: option to use difftastic as difftool ([nix-community/home-manager⁠#5335](https://togithub.com/nix-community/home-manager/issues/5335))
* [`0394c71f`](https://github.com/nix-community/home-manager/commit/0394c71f2bc00be1e8e76d2931549721c710904c) zellij: Add additional options for integrating with shells
* [`6d4148df`](https://github.com/nix-community/home-manager/commit/6d4148df8e531b264c87ad86a151a4ea3047a1b5) zellij: refactor implementation
* [`10dca990`](https://github.com/nix-community/home-manager/commit/10dca990ae02aaf41ff12c5b18dd3dcf258c0d04) zellij: remove with lib
* [`82a32114`](https://github.com/nix-community/home-manager/commit/82a32114771cb3d7f392c48d679a7f66c064dd46) zellij: add khaneliman maintainer
* [`a9042b53`](https://github.com/nix-community/home-manager/commit/a9042b53c2be62487c33ec296a27623989320e2a) zellij: default integration disabled again
* [`2d057cd9`](https://github.com/nix-community/home-manager/commit/2d057cd9d4f767737498e0aae75b07353c75bdee) zellij: use mkPackageOption
* [`c4d5d728`](https://github.com/nix-community/home-manager/commit/c4d5d72805d14ea43c140eeb70401bf84c0f11b4) neomutt: remove empty lines ([nix-community/home-manager⁠#6523](https://togithub.com/nix-community/home-manager/issues/6523))
* [`869f2ec2`](https://github.com/nix-community/home-manager/commit/869f2ec2add75ce2a70a6dbbf585b8399abec625) zsh: fix concatenation of aliases and global aliases ([nix-community/home-manager⁠#6698](https://togithub.com/nix-community/home-manager/issues/6698))
