### PR TITLE
niv nerd-icons.el: update 6612cc65 -> 14f7278d

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -77,10 +77,10 @@
         "homepage": null,
         "owner": "rainstormstudio",
         "repo": "nerd-icons.el",
-        "rev": "6612cc65373b63e85362b6a5d0bbd440b05be58b",
-        "sha256": "03wnm17wmpsk4w8xpjd2mdshhz8mqf7q4dz6vyzdjf4d6rrnmv2q",
+        "rev": "14f7278dd7eb5eca762a6ff32467c72c661c0aae",
+        "sha256": "1r5wj13k6khlmkn5wy2q2n674bc551rpxn04x46j0brzgmd85k7g",
         "type": "tarball",
-        "url": "https://github.com/rainstormstudio/nerd-icons.el/archive/6612cc65373b63e85362b6a5d0bbd440b05be58b.tar.gz",
+        "url": "https://github.com/rainstormstudio/nerd-icons.el/archive/14f7278dd7eb5eca762a6ff32467c72c661c0aae.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "niv": {


### PR DESCRIPTION
## Changelog for nerd-icons.el:
Branch: main
Commits: [rainstormstudio/nerd-icons.el@6612cc65...14f7278d](https://github.com/rainstormstudio/nerd-icons.el/compare/6612cc65373b63e85362b6a5d0bbd440b05be58b...14f7278dd7eb5eca762a6ff32467c72c661c0aae)

* [`14f7278d`](https://github.com/rainstormstudio/nerd-icons.el/commit/14f7278dd7eb5eca762a6ff32467c72c661c0aae) Change order of file name to icon-alist checks
