### PR TITLE
niv nixpkgs: update 5d4f0d22 -> efa1f973

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5d4f0d2222258cbd1b558988ff83945832b89768",
-        "sha256": "01q6yn404rybgycmh4b8p8cp23crcmk6cx3q7bd1ghngx6ff17qb",
+        "rev": "efa1f9731768dc5488f415b183e323cb151980ce",
+        "sha256": "02xdiaadgz7yy3in92qdgqq2sscd63pjz6krqni1047yb08j6v92",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/5d4f0d2222258cbd1b558988ff83945832b89768.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/efa1f9731768dc5488f415b183e323cb151980ce.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@5d4f0d22...efa1f973](https://github.com/nixos/nixpkgs/compare/5d4f0d2222258cbd1b558988ff83945832b89768...efa1f9731768dc5488f415b183e323cb151980ce)

* [`8032f774`](https://github.com/NixOS/nixpkgs/commit/8032f77462fbc681c0ca617102c37f97137641c4) nixos/filesystems: init bindfs
* [`69f37ce6`](https://github.com/NixOS/nixpkgs/commit/69f37ce6dca756d9e95be8f3194c790ebbdafc7a) nixos/environment: make {sessionV,v}ariables items nullable
* [`abe5d2cd`](https://github.com/NixOS/nixpkgs/commit/abe5d2cdef6de5d0362e8ecc4d7502c1c4f75932) libfilezilla: 0.47.0 -> 0.49.0
* [`13daba5c`](https://github.com/NixOS/nixpkgs/commit/13daba5c275e164e0114d7bbd6863f66d6b42a69) filezilla: 3.67.0 -> 3.68.1
* [`8a34d575`](https://github.com/NixOS/nixpkgs/commit/8a34d575f660577c125911f5d8b1fc7c138b6e88) nixos/k3b: remove module as obsolete
* [`7fb6eaee`](https://github.com/NixOS/nixpkgs/commit/7fb6eaee9d6fd4d2cc7c180a25563238cb1d0228) transcode: drop
* [`8d680a8c`](https://github.com/NixOS/nixpkgs/commit/8d680a8c59f9ba3bc73d533862b06b9121068511) calibre-web: fix ebook conversion missing config_binariesdir setting
* [`e20c21e1`](https://github.com/NixOS/nixpkgs/commit/e20c21e12cf12c4ae68732eec4f4ade3855f2191) foxtrotgps: fix for GCC 14
* [`14076af9`](https://github.com/NixOS/nixpkgs/commit/14076af9843287bbc827d8d502e8f90d1c3fd0e0) anthy: fix cross build
* [`a44dfabf`](https://github.com/NixOS/nixpkgs/commit/a44dfabfc2e08b7b840a70d1239fadaa1a260103) lcov: fix and enable strictDeps
* [`f3a53c39`](https://github.com/NixOS/nixpkgs/commit/f3a53c390f5d53fc578b5312493e8dc10d4e461f) nixos/bluetooth: add systemd hardening
* [`58c1ab24`](https://github.com/NixOS/nixpkgs/commit/58c1ab247b838ab8053ded6fa5320f110634ff0e) nixos/bluetooth: use escapeSystemdExecArgs
* [`7118a85d`](https://github.com/NixOS/nixpkgs/commit/7118a85d9348fd81058929a94e8ce9eaad8900cb) llvmPackages.libunwind: fix mingw build problem
* [`c6317736`](https://github.com/NixOS/nixpkgs/commit/c6317736e08a7fe52c0e5a5ebfcb21a4c3cbbf3e) oneanime: 1.3.7 -> 1.3.8
* [`3de7bccd`](https://github.com/NixOS/nixpkgs/commit/3de7bccd4aeaedebf5ae4217db989cc607e52dde) nixos/systemd-boot: strip newline from machine-id
* [`4ded262f`](https://github.com/NixOS/nixpkgs/commit/4ded262fbcfb976feb0369d65e1776420292a3ef) nixos/steam: allow overriding args passed to Steam in session
* [`970afe19`](https://github.com/NixOS/nixpkgs/commit/970afe19fabcda832109efd4dd693a9f7c935c2a) jdk11: 11.0.25+9 -> 11.0.26+4
* [`b19037d7`](https://github.com/NixOS/nixpkgs/commit/b19037d7322f7a6d55edc59674b9fbf22f62127d) jdk17: 17.0.13+11 -> 17.0.14+7
* [`c025652d`](https://github.com/NixOS/nixpkgs/commit/c025652ded68dbd9e538e75f1d3d52c3c3b45485) jdk8: 8u432-b06 -> 8u442-b06
* [`a7c82e2e`](https://github.com/NixOS/nixpkgs/commit/a7c82e2e7f10e226b1b852f29a926d2c74a10f68) libretro.stella: 0-unstable-2025-01-02 -> 0-unstable-2025-02-16
* [`c1f962ef`](https://github.com/NixOS/nixpkgs/commit/c1f962ef394e596acbcf365eb46db1ad4cbaec2c) breakpointHook: prefer system-provided nsenter
* [`6c1977e5`](https://github.com/NixOS/nixpkgs/commit/6c1977e5cb0eab5aac5f1a2e0d7a4cbe60229641) libretro.mgba: 0-unstable-2025-01-14 -> 0-unstable-2025-02-17
* [`d5591043`](https://github.com/NixOS/nixpkgs/commit/d5591043728336bace9001cd95bab5fc2598200a) libretro.picodrive: 0-unstable-2024-12-31 -> 0-unstable-2025-02-19
* [`db53cce5`](https://github.com/NixOS/nixpkgs/commit/db53cce5998d5de4e17fac7b2a462de33f6832bb) libretro.puae: 0-unstable-2025-01-24 -> 0-unstable-2025-02-20
* [`6fadeb20`](https://github.com/NixOS/nixpkgs/commit/6fadeb200b13c57532a3215c5ad039e098b4296d) krusader: remove with lib
* [`feb585fb`](https://github.com/NixOS/nixpkgs/commit/feb585fbd769d96df8bb0a4a9bb63eb04fce0570) krusader: 2.8.1 -> 2.9.0
* [`6d27ecd3`](https://github.com/NixOS/nixpkgs/commit/6d27ecd36e8b2c7114c668f041b4b5d239e2116d) python312Packages.kubernetes: 31.0.0 -> 32.0.1
* [`2445cedc`](https://github.com/NixOS/nixpkgs/commit/2445cedc627e4a0a9cd869b2d6d2d17a9ad3935f) avfs: 1.1.5 -> 1.2.0
* [`c194cceb`](https://github.com/NixOS/nixpkgs/commit/c194cceb8a37ea506d0a62bb30ffce93266b0419) guestfs-tools: 1.52.2 -> 1.52.3
* [`e5f58da3`](https://github.com/NixOS/nixpkgs/commit/e5f58da3292ca772bd7dbc0fc362f40cfb5ae679) qtbitcointrader: 1.40.43 -> 1.42.21
* [`4acb8d38`](https://github.com/NixOS/nixpkgs/commit/4acb8d380f1c4800b132488c3980444df4622fba) prometheus-rabbitmq-exporter: 1.0.0-RC19 -> 1.0.0
* [`baa84e5a`](https://github.com/NixOS/nixpkgs/commit/baa84e5a272ea3c7644ad05fb523d46882e377b7) python312Packages.ephem: 4.1.6 -> 4.2
* [`30359ab6`](https://github.com/NixOS/nixpkgs/commit/30359ab63d2663a1d01cb4eeb50da63e5d5839f1) python312Packages.pylibacl: 0.7.0 -> 0.7.2
* [`3ad4f9f0`](https://github.com/NixOS/nixpkgs/commit/3ad4f9f033464ee36edea5bc50c3615c841c79b2) python312Packages.aerosandbox: 4.2.6 -> 4.2.8
* [`91abfdbe`](https://github.com/NixOS/nixpkgs/commit/91abfdbe456a428904e7708283043505c86b0de8) cargo-machete: 0.7.0 -> 0.8.0
* [`50f907b3`](https://github.com/NixOS/nixpkgs/commit/50f907b3000dcea0152ff368d5e8f31e81495473) python312Packages.dohq-artifactory: 0.10.3 -> 1.0.0
* [`bd950968`](https://github.com/NixOS/nixpkgs/commit/bd950968fcb467ba43b7f4ac49ddd022f77b6bc6) rtmidi: 5.0.0 -> 6.0.0
* [`3485903b`](https://github.com/NixOS/nixpkgs/commit/3485903b0656068900a1937540552cf1e6ac0a1b) python312Packages.thespian: 3.10.7 -> 4.0.0
* [`68168ba7`](https://github.com/NixOS/nixpkgs/commit/68168ba73cc170342f6c2c5f7985e7aa0cc75a66) python312Packages.thespian: refactor
* [`532bb82d`](https://github.com/NixOS/nixpkgs/commit/532bb82d5aa84c847ba5e40a8fa7e45ae3ae6f69) picolisp: fix darwin build
* [`7b7084f8`](https://github.com/NixOS/nixpkgs/commit/7b7084f8e3f97e24ea19cb08e03e1e70f21bd045) python312Packages.napari-npe2: 0.7.7 -> 0.7.8
* [`40701569`](https://github.com/NixOS/nixpkgs/commit/407015698a25267a09808e88d7bf472fb68c8080) sauce-connect: 4.9.1 -> 5.2.2
* [`dc3d0967`](https://github.com/NixOS/nixpkgs/commit/dc3d0967f166c490b0626885b7759f04e4e82c71) babashka-unwrapped: 1.12.196 -> 1.12.197
* [`f43f0265`](https://github.com/NixOS/nixpkgs/commit/f43f0265ff011930bec881951e0d3087da0145f6) src: 1.33 -> 1.41
* [`aa75d18f`](https://github.com/NixOS/nixpkgs/commit/aa75d18fc6636710c0080be5e0fb23b244cf229e) python312Packages.tinytag: 2.0.0 -> 2.1.0
* [`4709fe2c`](https://github.com/NixOS/nixpkgs/commit/4709fe2c8a253ff53bcb75e4b2b369a6abd0a26c) python312Packages.scikit-rf: 1.5.0 -> 1.6.2
* [`5cca576c`](https://github.com/NixOS/nixpkgs/commit/5cca576c00ff49d212ea621810fa8fa0520a4f23) libretro.vice-x128: 0-unstable-2025-02-07 -> 0-unstable-2025-02-23
* [`b7694c7c`](https://github.com/NixOS/nixpkgs/commit/b7694c7cfec54f236ba4a96b01e17c79f4306c7e) lsp-plugins: 1.2.20 -> 1.2.21
* [`cc325867`](https://github.com/NixOS/nixpkgs/commit/cc3258675b6dd9a4cb2008195824243565aa9ea7) ghdl: 4.1.0 -> 5.0.1
* [`38a7301f`](https://github.com/NixOS/nixpkgs/commit/38a7301ffa8462b0542d74bbc7a8262afb4f41ae) subnetcalc: 2.5.1 -> 2.6.2
* [`5f43e96a`](https://github.com/NixOS/nixpkgs/commit/5f43e96a8d112ed075a7f4923ba33d8d99ba1764) swaysettings: 0.4.0 -> 0.5.0
* [`1f48bb2a`](https://github.com/NixOS/nixpkgs/commit/1f48bb2a81cff4602779d547c60cae8724514582) tarmac: 0.7.0 -> 0.8.2
* [`6d116c06`](https://github.com/NixOS/nixpkgs/commit/6d116c0603cc1060d5931c42c5a3fa8bec630923) fleetctl: init at 4.64.1
* [`09ffd4cd`](https://github.com/NixOS/nixpkgs/commit/09ffd4cd92d50951acd9d726208caed3faa0ce3f) libretro.snes9x: 0-unstable-2024-12-17 -> 0-unstable-2025-02-24
* [`58c1ae9d`](https://github.com/NixOS/nixpkgs/commit/58c1ae9dce1cce1999217375b0a450bf0b2d924e) therion: 6.1.8 -> 6.3.3
* [`9c02e582`](https://github.com/NixOS/nixpkgs/commit/9c02e582006fd754926dbda158ae674b7315ff6b) python312Packages.mlflow: 2.20.2 -> 2.20.3
* [`0502f6d0`](https://github.com/NixOS/nixpkgs/commit/0502f6d0776a0bae8fc862e224dc201556917c10) tika: 2.9.2 -> 2.9.3
* [`d6521f55`](https://github.com/NixOS/nixpkgs/commit/d6521f550362f4fa46bc389548acef0e66584c31) roomarranger: init at 10.0.1
* [`e9c38f77`](https://github.com/NixOS/nixpkgs/commit/e9c38f777d45fb14902dce1632f310fbf0349caf) maintainers: add bellackn
* [`4b907920`](https://github.com/NixOS/nixpkgs/commit/4b907920036d2e41f8e9d7b4c81174693780eec0) tonelib-jam: 4.7.8 -> 4.8.7
* [`e30a6209`](https://github.com/NixOS/nixpkgs/commit/e30a62093e92954f35732777c5588bd9f3d09afd) xpra: add libsystemd for optional systemd support
* [`1ef1bcec`](https://github.com/NixOS/nixpkgs/commit/1ef1bcec0982e03328ced1f8508b890af8232519) nixos/caddy: use lib.getExe
* [`63b6df42`](https://github.com/NixOS/nixpkgs/commit/63b6df42de91b5a4bf53c7e9da924cc8d3a39e91) nixos/caddy: validate at build-time
* [`743cd3df`](https://github.com/NixOS/nixpkgs/commit/743cd3dfaf9d9c4a2573a506584c41cf57e738f0) nixosTests.pgadmin4: Use runTest
* [`c9b6ad69`](https://github.com/NixOS/nixpkgs/commit/c9b6ad69e4050d1ef308aa8b599bb3c5528cd075) squashfuse: 0.5.2 -> 0.6.0
* [`cc5d75bf`](https://github.com/NixOS/nixpkgs/commit/cc5d75bf424937b327e64ad5ca1404b0ca648b3d) libretro.mupen64plus: 0-unstable-2024-10-29 -> 0-unstable-2025-03-04
* [`59974ca0`](https://github.com/NixOS/nixpkgs/commit/59974ca0a93c29f546bbf5a7ba2a8f27f0871109) tarlz: 0.26 -> 0.27.1
* [`67a1d022`](https://github.com/NixOS/nixpkgs/commit/67a1d022b62797bd3cb1fe8a9a7665ea2dd189b3) lxd-ui: 0.15 -> 0.16
* [`d184facb`](https://github.com/NixOS/nixpkgs/commit/d184facbd91f2c1d3f2d665975e37ab6a6786c68) diesel-cli: 2.2.7 -> 2.2.8
* [`3630050b`](https://github.com/NixOS/nixpkgs/commit/3630050b75e4fb20973b8d3fce67a5d5755ce77d) sdl3: 3.2.6 -> 3.2.8
* [`0d894d40`](https://github.com/NixOS/nixpkgs/commit/0d894d40bb0cc450ab55a48c7b63bbe504989202) nginxModules.njs: fix build
* [`a907e4e0`](https://github.com/NixOS/nixpkgs/commit/a907e4e08e295d1e5dfa1a6085bc09e8f8bde8f4) nginxModules.njs: 0.8.7 -> 0.8.9
* [`7914e92a`](https://github.com/NixOS/nixpkgs/commit/7914e92a13085ebeb0b20fe1aa3da011a9f77086) python312Packages.libnbd: 1.20.2 -> 1.22.1
* [`ed09b84f`](https://github.com/NixOS/nixpkgs/commit/ed09b84f1d4cb197e790f4c42cc1d2cf2650dc38) python312Packages.nemosis: 3.8.0 -> 3.8.1
* [`621b78be`](https://github.com/NixOS/nixpkgs/commit/621b78be6b92289e0a448cfd0b422a1c44e1e034) python312Packages.raylib-python-cffi: fix build
* [`f0e2f34a`](https://github.com/NixOS/nixpkgs/commit/f0e2f34afec44a658199f73bb6be2fb09bcf20e1) python313Packages.normality: 2.5.0 -> 2.6.1
* [`50d3e8d3`](https://github.com/NixOS/nixpkgs/commit/50d3e8d3ac5680dc505547c7b3983e175a9dff64) tiledb: 2.18.2 -> 2.27.2
* [`392534f2`](https://github.com/NixOS/nixpkgs/commit/392534f2bc4cf9422502c244a8bd4e50b53e9916) gradle: 8.12.1 -> 8.13
* [`4013bf67`](https://github.com/NixOS/nixpkgs/commit/4013bf675cab314c7cd06db74b2f3e60d6161b85) dxx-rebirth: 0.60.0-beta2-unstable-2025-01-12 -> 0.60.0-beta2-unstable-2025-03-01
* [`2c006c26`](https://github.com/NixOS/nixpkgs/commit/2c006c265e95a5814ea5be51498a3d9d4e7eb05f) deskflow: 1.19.0 -> 1.20.1
* [`885090c9`](https://github.com/NixOS/nixpkgs/commit/885090c958a96c58d86347e17b821e67d66786f6) jadx: resolve dependencies with gradle 8.13
* [`2fc4fe56`](https://github.com/NixOS/nixpkgs/commit/2fc4fe567f3e0b6796d3899ad40bbd5d6c17c559) keyguard: resolve dependencies with gradle 8.13
* [`f2a96d52`](https://github.com/NixOS/nixpkgs/commit/f2a96d52e0ae0d40de1d3e295125f536159e5aec) velocity: resolve dependencies with gradle 8.13
* [`057211b4`](https://github.com/NixOS/nixpkgs/commit/057211b4360a3ff6098fc07a726a29eede45f6e8) freeplane: add a patch to support Gradle 8.13
* [`48c18d04`](https://github.com/NixOS/nixpkgs/commit/48c18d04b52ddf6cbca62b8b48b3e07af8655e4b) netlify-cli: 18.1.0 -> 19.0.2
* [`3661ec5d`](https://github.com/NixOS/nixpkgs/commit/3661ec5d9af61f98ccfeec4f2784d94fa5a60aa2) dart.printing: refactor
* [`b1c5625b`](https://github.com/NixOS/nixpkgs/commit/b1c5625bc3ac29933a034458bfacd733e859262e) butterfly: use dart.printing
* [`80a8ba12`](https://github.com/NixOS/nixpkgs/commit/80a8ba12feb3b2e6f971e690891c52ec41a93e84) circt: fix cmake paths
* [`39c47ceb`](https://github.com/NixOS/nixpkgs/commit/39c47cebd3fdea747917854b755ed220f2b68790) python312Packages.ledger-bitcoin: 0.3.0 -> 0.4.0
* [`39668d77`](https://github.com/NixOS/nixpkgs/commit/39668d77267d8932e9d6e5b1d09962f0a9045452) osquery: 5.15.0 -> 5.16.0
* [`27c0b818`](https://github.com/NixOS/nixpkgs/commit/27c0b8180ba25ee5e4ec7d0a087bca40b103230a) osquery: add myself to the maintainers
* [`8b1c27ad`](https://github.com/NixOS/nixpkgs/commit/8b1c27adaec66bc418d2f09f94a9796b41607e14) python312Packages.boltztrap2: 25.2.1 -> 25.3.1
* [`49cb60c0`](https://github.com/NixOS/nixpkgs/commit/49cb60c0d66d6a8b9cc5d50103ff52b62880a84e) ums: 10.12.0 -> 13.2.1
* [`f2cfd4b6`](https://github.com/NixOS/nixpkgs/commit/f2cfd4b62f2bcd7e1868409f6f802c60c1042730) python312Packages.treelib: 1.7.0 -> 1.7.1
* [`801eacdd`](https://github.com/NixOS/nixpkgs/commit/801eacddccaa6e016ff9285add97844c6a8ff8eb) replace multiple optional w/ one optionals
* [`0f8f5d94`](https://github.com/NixOS/nixpkgs/commit/0f8f5d94e4fcb5d7d23c12715ee1cb2bfe3927b3) vexctl: 0.1.0 -> 0.3.0
* [`2a0f98e0`](https://github.com/NixOS/nixpkgs/commit/2a0f98e0f80a1f3a514ffce13883203b0fdc20cf) vimb: 3.6.0 -> 3.7.0
* [`f7572bb5`](https://github.com/NixOS/nixpkgs/commit/f7572bb58ea72c9cc0f9f8805ccb8a40c57f6989) vipsdisp: 2.6.3 -> 3.1.0
* [`dd5947c8`](https://github.com/NixOS/nixpkgs/commit/dd5947c825e1c631949f9cf1baff8e2b1be1fdab) python312Packages.myfitnesspal: 2.1.0 -> 2.1.2
* [`d00ab47d`](https://github.com/NixOS/nixpkgs/commit/d00ab47d42c829fd89a560d3c25f8ff08a4cf00b) alpaca: 5.0.6 -> 5.2.0
* [`a40d7f44`](https://github.com/NixOS/nixpkgs/commit/a40d7f4467c2b00b194ec5944783692517630918) python312Packages.scripttest: 1.3 -> 2.0
* [`e4ad8c2a`](https://github.com/NixOS/nixpkgs/commit/e4ad8c2a71df14fd6a4ad5e4f4179b88da057348) wpscan: 3.8.27 -> 3.8.28
* [`a96a14ea`](https://github.com/NixOS/nixpkgs/commit/a96a14eafa73918aa91d589c2bc8e65075a66fcc) python312Packages.audiotools: 3.1.1 -> 3.1.1-unstable-2020-07-29
* [`832e84f5`](https://github.com/NixOS/nixpkgs/commit/832e84f57e33cb462498dfdea2bda22bd846dafd) python312Packages.sopel: 8.0.1 -> 8.0.2
* [`638d8a5c`](https://github.com/NixOS/nixpkgs/commit/638d8a5c54a76e92bdde0c6365a59e994e0d5d4e) python312Packages.harlequin-postgres: 1.1.1 -> 1.2.0
* [`181fe6e8`](https://github.com/NixOS/nixpkgs/commit/181fe6e83b8d3b4c989b29c95a6e772ffb6ef48b) python312Packages.coredis: 4.18.0 -> 4.20.0
* [`fae52c1c`](https://github.com/NixOS/nixpkgs/commit/fae52c1c1274700df879a7d9cfebf02ed2a41bca) python3Packages.sphinxext-rediraffe: init at 0.2.7
* [`0645e675`](https://github.com/NixOS/nixpkgs/commit/0645e675ef9f33ff95f3dd6f2a94ce620e607bf8) nixos/nvidia: update busIDType to correctly handle PCI bus domain
* [`72ffdcd4`](https://github.com/NixOS/nixpkgs/commit/72ffdcd4a6c11c44403318c6a60f7ebf519a68bb) nixos/nvidia: update description of BusIds for caveats
* [`930646f7`](https://github.com/NixOS/nixpkgs/commit/930646f7835358f85aafb028939a1c2d0a56e55f) libfprint-tod: 1.90.7+git20210222+tod1 -> 1.94.9+tod1
* [`56cb21c4`](https://github.com/NixOS/nixpkgs/commit/56cb21c42b58073d2c9b5bfffdbe600c5a388f6a) smartmontools: fix static build
* [`eef8d0e9`](https://github.com/NixOS/nixpkgs/commit/eef8d0e951e410674247806ae93d8cea7c246e07) python312Packages.oracledb: 2.5.1 -> 3.0.0
* [`65bc040a`](https://github.com/NixOS/nixpkgs/commit/65bc040a6f33ff2985b49b182cf53f5e005ef2f8) nixos/hickory-dns: combine Hint and Forward zone types into one
* [`08354798`](https://github.com/NixOS/nixpkgs/commit/08354798e094de5d5136605306571dfc1ce8ee6f) python312Packages.ipyvuetify: 1.11.0 -> 1.11.1
* [`06d13968`](https://github.com/NixOS/nixpkgs/commit/06d139683389706982cc8288d8627b5668dc3938) gopls: build modernize and gofix binaries
* [`12fd9a6d`](https://github.com/NixOS/nixpkgs/commit/12fd9a6d4b1025dd72f1ac3aa63445d4bb978ab2) python312Packages.pywikibot: 9.6.3 -> 10.0.0
* [`2d57079b`](https://github.com/NixOS/nixpkgs/commit/2d57079b80c65f215f17776633dd2907bfb65fc5) windterm: 2.6.1 -> 2.7.0
* [`d766ff4c`](https://github.com/NixOS/nixpkgs/commit/d766ff4ccfe7de0690da9aa6a711ed214dbe2856) rpm-ostree: upgrade pcre to pcre2
* [`9ee92a82`](https://github.com/NixOS/nixpkgs/commit/9ee92a821d615e6a1d4a4ce4afe306d460f7fc29) vampire: 4.6.1 -> 4.9
* [`b7545634`](https://github.com/NixOS/nixpkgs/commit/b7545634839c7a664a8b6ac8d1d59c0f8041e8fe) bino3d: 2.4 -> 2.5
* [`903c6028`](https://github.com/NixOS/nixpkgs/commit/903c60286e8d68da1f7ad24b20a9d2be55ed8570) kamailio: 5.7.4 -> 6.0.1
* [`45faf7ac`](https://github.com/NixOS/nixpkgs/commit/45faf7ac1c7ad8d3a119c3a957a23711db55832d) faustPhysicalModeling: 2.77.3 -> 2.79.3
* [`cd07925c`](https://github.com/NixOS/nixpkgs/commit/cd07925c7eb952b4bc333282770b9966f7358729) openwsman: 2.7.2 -> 2.8.1
* [`a0b18b13`](https://github.com/NixOS/nixpkgs/commit/a0b18b13527c0bfb22db4582875cd588acf132c1) wsmancli: 2.6.2 -> 2.8.0
* [`fbfcaf8c`](https://github.com/NixOS/nixpkgs/commit/fbfcaf8c6d1ca5c8c98c795f6439afd5c214252b) pythonPackages.yara-x: init at 0.13.0
* [`9093754e`](https://github.com/NixOS/nixpkgs/commit/9093754eed0783698089b5d3975e5222f2ae1336) python312Packages.dbt-core: 1.9.2 -> 1.9.3
* [`5501b68d`](https://github.com/NixOS/nixpkgs/commit/5501b68dbcbd8075b861017e412389a8b32f8c14) wox: init at 2.0.0-beta.1
* [`cb8f76c0`](https://github.com/NixOS/nixpkgs/commit/cb8f76c0e4d55bd62cb9cfe37ca00cf786167f25) python312Packages.raylib-python-cffi: add passthru tests
* [`5db3f8fa`](https://github.com/NixOS/nixpkgs/commit/5db3f8fa4fafd6f21c2e36afceac78719f319a9b) gnomeExtensions.pop-shell: 1.2.0-unstable-2025-02-20 -> 1.2.0-unstable-2025-03-10
* [`4a47e96b`](https://github.com/NixOS/nixpkgs/commit/4a47e96b526aa9bd60330cde45af72a98e9a7ab0) python312Packages.psd-tools: 1.10.4 -> 1.10.7
* [`dbb0dbfe`](https://github.com/NixOS/nixpkgs/commit/dbb0dbfe19f7e2dfd3ececa30d9fec06c237bcdf) python312Packages.language-tool-python: 2.8.0 -> 2.9.0
* [`5ba08717`](https://github.com/NixOS/nixpkgs/commit/5ba08717b99fa4ef99f9f7640f53f6bc42d0022d) libwpe-fdo: 1.14.3 -> 1.16.0
* [`33edad6f`](https://github.com/NixOS/nixpkgs/commit/33edad6f3bde48ae6bd070c2496cfe0994bf5951) streamlit: 1.42.2 -> 1.43.2
* [`40ee3153`](https://github.com/NixOS/nixpkgs/commit/40ee315377995202244fc4063034ed11326e951e) slackdump: 3.0.7 -> 3.0.8
* [`1e54b473`](https://github.com/NixOS/nixpkgs/commit/1e54b4734c585df1c4aebf15b2da3c4502cad198) android-udev-rules: 20241109 -> 20250314
* [`e4469e8b`](https://github.com/NixOS/nixpkgs/commit/e4469e8b3ac2db25102441dc84149a4ca7fdc033) zwave-js-server: 1.40.3 -> 3.0.0
* [`24707b98`](https://github.com/NixOS/nixpkgs/commit/24707b98a3c3a33855b93a1e682f2aac970a00b9) python313Packages.unicode-rbnf: 2.2.0 -> 2.3.0
* [`028efd92`](https://github.com/NixOS/nixpkgs/commit/028efd9234d3c5d4bef64d554c981f02e72f7639) python312Packages.smart-open: 7.1.0 -> 7.2.0
* [`4573a316`](https://github.com/NixOS/nixpkgs/commit/4573a3162c691f7c7df8e8c4a5f937adfb8e2c21) networkmanager_dmenu: 2.5.0 -> 2.6.0
* [`e116b7cc`](https://github.com/NixOS/nixpkgs/commit/e116b7cc6c2877743fe39e8ad7097e57a8d5757f) schismtracker: 20250208 -> 20250313
* [`8eb33d8c`](https://github.com/NixOS/nixpkgs/commit/8eb33d8c0761025b1e3fd1deea95294d6792f92f) python312Packages.pyomo: 6.8.2 -> 6.9.1
* [`61301c2c`](https://github.com/NixOS/nixpkgs/commit/61301c2c9bd7b32d11eb1066a84d6f2505e85a70) renode-unstable: 1.15.3+20250227git5f21d12f9 -> 1.15.3+20250314git5b219d820
* [`5ce416fd`](https://github.com/NixOS/nixpkgs/commit/5ce416fd60f2d7a2078600ba8d90427521d4f357) rPackages.stringi: remove unneeded override
* [`e5c20952`](https://github.com/NixOS/nixpkgs/commit/e5c209527d0be2d100f7e55b9269386f44329ba6) maintainers: add charludo
* [`392773a1`](https://github.com/NixOS/nixpkgs/commit/392773a15445c850f7299ebdacaef0bf2c7a7ad8) libfprint-2-tod1-vfs0090: mark broken
* [`cbe04943`](https://github.com/NixOS/nixpkgs/commit/cbe04943d1901e88d98e8691732e1bc0147c1b40) firehol: 3.1.7 -> 3.1.8
* [`b87b7f62`](https://github.com/NixOS/nixpkgs/commit/b87b7f62c2cdfbcb17672f1284c695d69ad2b217) libretro.ppsspp: 0-unstable-2025-01-14 -> 0-unstable-2025-03-15
* [`8af7b198`](https://github.com/NixOS/nixpkgs/commit/8af7b198e4a013bccc0aa1c764cf3964268a2d78) libretro.fbneo: 0-unstable-2025-01-13 -> 0-unstable-2025-03-11
* [`ab830523`](https://github.com/NixOS/nixpkgs/commit/ab8305233e84a45442ac509f10f885b05b2b59e6) libretro.flycast: 0-unstable-2025-01-10 -> 0-unstable-2025-03-14
* [`e17d3887`](https://github.com/NixOS/nixpkgs/commit/e17d38877aedb0197ef3608e6e1e250923d287f6) libretro.dosbox-pure: 0-unstable-2025-01-12 -> 0-unstable-2025-03-13
* [`0c6d283b`](https://github.com/NixOS/nixpkgs/commit/0c6d283b53758c586ca258ed12b1faaa1a63d0c4) metacubexd: 1.176.2 -> 1.186.1
* [`a3e93dbf`](https://github.com/NixOS/nixpkgs/commit/a3e93dbfc843e9e65659364915551e8e491f448b) codeium: 1.40.1 -> 1.42.3
* [`1b3fbe43`](https://github.com/NixOS/nixpkgs/commit/1b3fbe4340d94c842c03bd076cc802d7d81777c0) azure-cli-extensions.application-insights: 1.2.2 -> 1.2.3
* [`e3488d04`](https://github.com/NixOS/nixpkgs/commit/e3488d0458aa555434a10fd8b732545ef97ffc03) patool: Fix shell completion
* [`018cb798`](https://github.com/NixOS/nixpkgs/commit/018cb798bda3446479c2e59cd844d25f9c5de021) maintainers: add aware70
* [`7f3be44a`](https://github.com/NixOS/nixpkgs/commit/7f3be44a4b5ac40bf3afdef36e8e2013aabebd6c) auditwheel: 6.2.0 -> 6.3.0
* [`57b8c66e`](https://github.com/NixOS/nixpkgs/commit/57b8c66e11acfbd9367161d4d29858aea5ab4e46) c-intro-and-ref: 0.0-unstable-2024-08-31 -> 0-unstable-2025-03-09
* [`b954cbc8`](https://github.com/NixOS/nixpkgs/commit/b954cbc8cf86f3d32c2bb8d3b65dedd237d456a3) vscode-extensions.ziglang.vscode-zig: 0.5.1 -> 0.6.6
* [`d33b0f61`](https://github.com/NixOS/nixpkgs/commit/d33b0f613bafc7bf93ac8452fc89186611063332) xpad-noone: init at 0-unstable-2024-01-10
* [`c33e419d`](https://github.com/NixOS/nixpkgs/commit/c33e419dd18472ec29e966217a2a6128b7ad704f) nixos/xpad-noone: init
* [`e05745ad`](https://github.com/NixOS/nixpkgs/commit/e05745ad5fec11b9069b36f5abe0a08cdb6c4b23) supercell-wx: init at 0.4.8
* [`db774749`](https://github.com/NixOS/nixpkgs/commit/db774749043b1e03473d5566cbc5ff88f868d0c6) proton-pass: 1.29.5 -> 1.29.8
* [`76e539f3`](https://github.com/NixOS/nixpkgs/commit/76e539f3a6adb7934e295c0da2db26e56ad74287) inkscape-extensions.textext: 1.11.0 -> 1.11.1
* [`f9973544`](https://github.com/NixOS/nixpkgs/commit/f99735447bf8ab1ddac222fe5b6aa4a040203045) zsh-abbr: 6.1.0 -> 6.2.1
* [`391dccea`](https://github.com/NixOS/nixpkgs/commit/391dccea0013e9e93bc22e58a743b6beadcc0722) python312Packages.bitstruct: 8.19.0 -> 8.20.0
* [`f6920266`](https://github.com/NixOS/nixpkgs/commit/f6920266f31644f2c1be0f24f210360f4455123d) python312Packages.bitstruct: modernize
* [`dcba7434`](https://github.com/NixOS/nixpkgs/commit/dcba74345ba337431a54ade7db076616a201faa6) python312Packages.db-dtypes: 1.3.1 -> 1.4.2
* [`9d91793b`](https://github.com/NixOS/nixpkgs/commit/9d91793b3df948ab5cbc0e129fec778aecd4a865) creds: 0.5.2 -> 0.5.3
* [`65a51171`](https://github.com/NixOS/nixpkgs/commit/65a511718109c34a9876e92f080e44893d1d288c) fluidd: 1.32.4 -> 1.33.0
* [`8c109e6e`](https://github.com/NixOS/nixpkgs/commit/8c109e6e25e03c4c590ff3a2002ff6dc9bcdc316) gifski: 1.32.0 -> 1.33.0
* [`7d6c9f3c`](https://github.com/NixOS/nixpkgs/commit/7d6c9f3cf810d4fd200549d1c6ab0fd7787a207d) onedrive: 2.5.4 -> 2.5.5
* [`e01a88db`](https://github.com/NixOS/nixpkgs/commit/e01a88dbef3fd5a264a4c2e6c16ade6435b12f24) osv-scanner: 1.9.2 -> 2.0.0
* [`9d182364`](https://github.com/NixOS/nixpkgs/commit/9d18236490844b22c5b6032d64124d7ed5660db2) libppd: 2.1.0 -> 2.1.1
* [`f69ed2bc`](https://github.com/NixOS/nixpkgs/commit/f69ed2bcbf24b56eba7caf8e1429f67caa62cb1f) goimports-reviser: 3.8.2 -> 3.9.1
* [`cdb86589`](https://github.com/NixOS/nixpkgs/commit/cdb86589a75c83d87e64a163c419f84e5877f48b) libretro.play: 0-unstable-2025-01-11 -> 0-unstable-2025-03-10
* [`2c21aa95`](https://github.com/NixOS/nixpkgs/commit/2c21aa9551687de397694879af02a11580e7ad46) libretro.pcsx2: 0-unstable-2025-01-12 -> 0-unstable-2025-03-15
* [`f27d4d4a`](https://github.com/NixOS/nixpkgs/commit/f27d4d4a362250fde0e6f53450ff561385bd42ed) sortmerna: 4.2.0 -> 4.3.7
* [`01170a87`](https://github.com/NixOS/nixpkgs/commit/01170a87627d60cba20c689edf8f474a147719b2) libretro.nestopia: 0-unstable-2025-02-22 -> 0-unstable-2025-03-16
* [`ee781fe3`](https://github.com/NixOS/nixpkgs/commit/ee781fe3cbf6b01d838bf324422d393914e9c007) libretro.scummvm: 0-unstable-2024-12-03 -> 0-unstable-2025-03-09
* [`02102f2a`](https://github.com/NixOS/nixpkgs/commit/02102f2abb91373ce3f11bed7fd37f2fd37bb91b) libretro.pcsx-rearmed: 0-unstable-2025-01-14 -> 0-unstable-2025-03-17
* [`cfe10ddd`](https://github.com/NixOS/nixpkgs/commit/cfe10ddd47eaf0203434f17fa39f01e81c0ff5e4) libretro.mame2003-plus: 0-unstable-2025-02-11 -> 0-unstable-2025-03-15
* [`ed639953`](https://github.com/NixOS/nixpkgs/commit/ed63995346d09d6023da792fea842613f6a46442) libretro.beetle-psx: 0-unstable-2025-01-10 -> 0-unstable-2025-03-16
* [`c13ce386`](https://github.com/NixOS/nixpkgs/commit/c13ce38667ec86f620a6c412f159533dd924096a) bzflag: 2.4.28 -> 2.4.30
* [`e1dc3132`](https://github.com/NixOS/nixpkgs/commit/e1dc3132ff275f54cbde82f4dd52025a5944f37b) libretro.mame: 0-unstable-2025-01-04 -> 0-unstable-2025-03-06
* [`854fc622`](https://github.com/NixOS/nixpkgs/commit/854fc6225ce6ae6eb1cd451ba69cbf5333fdeb6c) slimserver: 9.0.1 -> 9.0.2
* [`36bd42bc`](https://github.com/NixOS/nixpkgs/commit/36bd42bca91fad276214fe5608a22176276f421f) trippy: avoid building example binaries
* [`8cd320a0`](https://github.com/NixOS/nixpkgs/commit/8cd320a05edb2be9f661db2795c8e0b4cca6d349) irust: 1.71.30 -> 1.72.0
* [`fadf7774`](https://github.com/NixOS/nixpkgs/commit/fadf77743083ef0c9766b3146b3cec428ce2aebf) amazon-cloudwatch-agent: 1.300053.0 -> 1.300053.1
* [`6ab4b327`](https://github.com/NixOS/nixpkgs/commit/6ab4b32721a57df6a8a91b63b24d60232dab75f6) sass: Update gems to improve security.
* [`5364044a`](https://github.com/NixOS/nixpkgs/commit/5364044ab6de546588762aa95ea582d6d43afc6a) xfe: 2.0 -> 2.0.1
* [`87d42cfb`](https://github.com/NixOS/nixpkgs/commit/87d42cfb168b9e5744b8c009ca538a3fcd30d836) fire: 1.0.1-unstable-2024-10-22 -> 1.0.1-unstable-2025-03-12
* [`a2b61ec9`](https://github.com/NixOS/nixpkgs/commit/a2b61ec9e0b298bb995b98675827f9580b337e5a) cilium-cli: 0.18.0 -> 0.18.2
* [`1292ebb3`](https://github.com/NixOS/nixpkgs/commit/1292ebb377247de443ed98e9fc7f79c8dd41dc57) couchdb3: 3.4.2 -> 3.4.3
* [`bf39f30a`](https://github.com/NixOS/nixpkgs/commit/bf39f30a76898d9da6d38746aadf03e1c0f529ca) libz: 1.2.8.2015.12.26-unstable-2018-03-31 -> 1.2.8.2025.03.07
* [`1d9096d6`](https://github.com/NixOS/nixpkgs/commit/1d9096d672c9f78c5ee4345b9f11552ab89a1161) gcsfuse: 2.10.0 -> 2.11.0
* [`dac70fb1`](https://github.com/NixOS/nixpkgs/commit/dac70fb1aff0acb3fe7352f6e4c82ee9a67b762c) ansel: 0-unstable-2025-03-06 -> 0-unstable-2025-03-18
* [`bcc5c188`](https://github.com/NixOS/nixpkgs/commit/bcc5c188084191eec8f3eb82da97b071be07203f) psi-plus: remove with lib;
* [`69ebbfbc`](https://github.com/NixOS/nixpkgs/commit/69ebbfbc7fe60a767f7fab1b89c08b55d2b7e373) psi-plus: make plugins-only libs optional
* [`79d05b0b`](https://github.com/NixOS/nixpkgs/commit/79d05b0beb318d527ea962b48b9d188efb6b43b7) psi-plus: 1.5.1653 → 1.5.2072
* [`6c38886c`](https://github.com/NixOS/nixpkgs/commit/6c38886c405268fc268c1947c36abb2486ae3538) python312Packages.py-deviceid: 0.1.0 -> 0.1.1
* [`a88e42cb`](https://github.com/NixOS/nixpkgs/commit/a88e42cba9da1aa2f9c482bf4e1a82e53946438e) svelte-language-server: 0.17.10 -> 0.17.11
* [`062783dd`](https://github.com/NixOS/nixpkgs/commit/062783dd57e892ba21e1055a720e692c0db28080) subxt: 0.40.0 -> 0.41.0
* [`0ef409a4`](https://github.com/NixOS/nixpkgs/commit/0ef409a4eb28f194c2e8bf756099c9d0da079533) python312Packages.cloup: 3.0.5 -> 3.0.7
* [`b5d67de5`](https://github.com/NixOS/nixpkgs/commit/b5d67de5b2997f7306ff250a9fe40041129c9fa2) drawterm: 0-unstable-2025-01-13 -> 0-unstable-2025-03-18
* [`f30a2c99`](https://github.com/NixOS/nixpkgs/commit/f30a2c99a3078ab7d7304a6640d4f8fcbae850f3) runme: 3.12.2 -> 3.12.6
* [`0f505a0c`](https://github.com/NixOS/nixpkgs/commit/0f505a0c83d2518e5c4d5883d5d10d241befb2be) pinchflat: init at 2025.3.17
* [`3e3b7747`](https://github.com/NixOS/nixpkgs/commit/3e3b7747325968983ca5b1148cdafcbaf95d108d) nixos/pinchflat: init
* [`c61398f3`](https://github.com/NixOS/nixpkgs/commit/c61398f311c5b273f6edcd4ddc181c814c9fe04d) enzyme: 0.0.172 -> 0.0.173
* [`58bf95e1`](https://github.com/NixOS/nixpkgs/commit/58bf95e11401405af8a1bd1d8265223a5bba087f) sendme: 0.24.0 -> 0.25.0
* [`47d812ac`](https://github.com/NixOS/nixpkgs/commit/47d812ace009d5e184cdb8306aaff286326170af) nwg-drawer: 0.6.3 -> 0.6.4
* [`884c800b`](https://github.com/NixOS/nixpkgs/commit/884c800b1bd4eb3dee13dd63354da76e6688fbbf) ipp-usb: 0.9.29 -> 0.9.30
* [`4bdb7612`](https://github.com/NixOS/nixpkgs/commit/4bdb76124db5fde83794975ba4deecf7029438c6) seamly2d: 2025.3.3.205 -> 2025.3.17.207
* [`fb373485`](https://github.com/NixOS/nixpkgs/commit/fb373485629648370d820cfe228416f13f522685) mautrix-signal: 0.8.0 -> 0.8.1
* [`9dcea423`](https://github.com/NixOS/nixpkgs/commit/9dcea42349864d62aba20bd600859824441eae8a) tooling-language-server: 0.4.2 -> 0.5.0
* [`6645374c`](https://github.com/NixOS/nixpkgs/commit/6645374cc78e1890a6c08478943637cd1eb563b1) prometheus-redis-exporter: 1.68.0 -> 1.69.0
* [`eeaf071c`](https://github.com/NixOS/nixpkgs/commit/eeaf071c8daf5fddbf41b377af824933a8506b6d) sanoid: fix sudo for syncoid
* [`0d3cf095`](https://github.com/NixOS/nixpkgs/commit/0d3cf095c7b5a398dadc4e1e547b2856a091d088) python312Packages.conda-libmamba-solver: 25.1.1 -> 25.3.0
* [`100559d8`](https://github.com/NixOS/nixpkgs/commit/100559d83c9468a70bb5c711d48af7e9cacef0e3) nixos/dokuwiki: Remove unused enable option
* [`41d29f20`](https://github.com/NixOS/nixpkgs/commit/41d29f20c382dc66bddc877112b05772d99673e5) fittrackee: 0.9.2 -> 0.9.3
* [`29b47d5e`](https://github.com/NixOS/nixpkgs/commit/29b47d5e28de1419782865fef01912251394f745) proxypin: init at 1.1.7
* [`322cc86f`](https://github.com/NixOS/nixpkgs/commit/322cc86f1371f781618b6acf6cc27d072d878bc8) web-ext: 8.4.0 -> 8.5.0
* [`1453184e`](https://github.com/NixOS/nixpkgs/commit/1453184e8f9f844a0da6e1fb7b77e8727121274e) mssql_jdbc: 12.8.1 -> 12.10.0
* [`f228380e`](https://github.com/NixOS/nixpkgs/commit/f228380ea80f6e915ce34ac69fe4706c74bb61da) b3sum: 1.6.1 -> 1.7.0
* [`f1276534`](https://github.com/NixOS/nixpkgs/commit/f12765342122001dea3e31a3c6062e1d44442e4a) libblake3: 1.6.1 -> 1.7.0
* [`372b3a00`](https://github.com/NixOS/nixpkgs/commit/372b3a003e86878152b7caea017e2402422e1eac) libblake3: add fpletz to maintainers
* [`7d167404`](https://github.com/NixOS/nixpkgs/commit/7d167404e1220c73c04273256203b5a24360bad1) suricata: 7.0.8 -> 7.0.9
* [`8f0d258b`](https://github.com/NixOS/nixpkgs/commit/8f0d258b0861041c9365c1c0cd1de1efc75a852d) kics: 2.1.5 -> 2.1.6
* [`95713435`](https://github.com/NixOS/nixpkgs/commit/95713435eca914c68f9f848661d9b08075f90b93) qdrant-web-ui: 0.1.37 -> 0.1.38
* [`6e43cd33`](https://github.com/NixOS/nixpkgs/commit/6e43cd33a755700c301da61041d25c42cdfb6002) opengrok: 1.13.26 -> 1.13.27
* [`3bb8ff5f`](https://github.com/NixOS/nixpkgs/commit/3bb8ff5f97f8827c2c289fe6010d511e1480193b) opentelemetry-collector-builder: 0.121.0 -> 0.122.1
* [`cd064356`](https://github.com/NixOS/nixpkgs/commit/cd064356d9453f6ef53c7a37193201d78e5ff47c) gir-rs: 0.17.1 -> 0.19.0
* [`3813e43c`](https://github.com/NixOS/nixpkgs/commit/3813e43ce959d65d5bfbe3956948afa1f4dff711) codeql: 2.20.6 -> 2.20.7
* [`6916ebda`](https://github.com/NixOS/nixpkgs/commit/6916ebda655f5e665ad1fa9bfc127b5c1da1b39e) gotrue-supabase: 2.169.0 -> 2.170.0
* [`26b8ea35`](https://github.com/NixOS/nixpkgs/commit/26b8ea354228fc4ead6507c50c99d7f91b4391a6) kraft: 0.9.4 -> 0.11.5
* [`486f01cd`](https://github.com/NixOS/nixpkgs/commit/486f01cdfce83f474c4d2ac1fd5647d369e1ad69) antlr4_13: add patch to fix libantlrcpp_INCLUDE_INSTALL_DIR
* [`aedc155c`](https://github.com/NixOS/nixpkgs/commit/aedc155cdcf8b7dd091f22b8424089c82fd03644) hwatch: 0.3.18 -> 0.3.19
* [`6110c257`](https://github.com/NixOS/nixpkgs/commit/6110c257c539f7c9f04f4b38754a985a9e22aa91) jbang: 0.124.0 -> 0.125.0
* [`836932ec`](https://github.com/NixOS/nixpkgs/commit/836932ec789f4e2b32d61266411c1b2e56d3dbd9) opencolorio: 2.4.1 -> 2.4.2
* [`a1a9d26a`](https://github.com/NixOS/nixpkgs/commit/a1a9d26a376481d4036cf20243621a91d01b4514) partclone: 0.3.33 -> 0.3.34
* [`bd5d6c34`](https://github.com/NixOS/nixpkgs/commit/bd5d6c3444c3b489685d7d8fe4ba1b1171120e74) maintainers: add wrbbz
* [`578aade1`](https://github.com/NixOS/nixpkgs/commit/578aade117c4eb0d4c159812f5ae2aa51befbc44) pulumi-bin: 3.156.0 -> 3.157.0
* [`c279e24e`](https://github.com/NixOS/nixpkgs/commit/c279e24e0879740b13df77df08da157e2c91838c) trilium-next-{desktop,server}: 0.91.6 -> 0.92.4
* [`a92c607f`](https://github.com/NixOS/nixpkgs/commit/a92c607faf81bdb860005020c729e58747f1bba0) photoprism: 240711-2197af848 -> 250228-43447fa38
* [`1b1a71a1`](https://github.com/NixOS/nixpkgs/commit/1b1a71a1de2e1a55212d43fb37520dcd4e531dce) python312Packages.h3: 4.2.1 -> 4.2.2
* [`9ac3ef08`](https://github.com/NixOS/nixpkgs/commit/9ac3ef08ce3aaaf3ba704609e32b64ade5f6c3be) tutanota-desktop: 271.250227.0 -> 274.250312.0
* [`0bb95209`](https://github.com/NixOS/nixpkgs/commit/0bb95209dd2a41a6d8774191382914bd8e7afa78) apt: 2.9.31 -> 2.9.33
* [`c30fdeca`](https://github.com/NixOS/nixpkgs/commit/c30fdecabb380bd86eed78751483b4fbd131ef38) coroot: 1.8.11 -> 1.9.0
* [`378ad964`](https://github.com/NixOS/nixpkgs/commit/378ad964ae1347518a58f1e2a8e6842588a68967) nixpacks: 1.34.0 -> 1.34.1
* [`cbdd0fb3`](https://github.com/NixOS/nixpkgs/commit/cbdd0fb311566146d5f166da10f30d227adfb7c6) jitterentropy: 3.6.0 -> 3.6.2
* [`124810b1`](https://github.com/NixOS/nixpkgs/commit/124810b19fa555b684b3127b71707d2f27b8769c) imagemagick: 7.1.1-45 -> 7.1.1-46
* [`1f255e5c`](https://github.com/NixOS/nixpkgs/commit/1f255e5ccd35b05c1cfef6aa1754441f93140c56) sunxi-tools: 0-unstable-2024-10-13 -> 0-unstable-2025-03-07
* [`51cb063f`](https://github.com/NixOS/nixpkgs/commit/51cb063f6b65e3faff34f28ee0521ed4dcf33b8d) python312Packages.sphinxcontrib-confluencebuilder: 2.11.0 -> 2.12.0
* [`efa37a2a`](https://github.com/NixOS/nixpkgs/commit/efa37a2acc292dc768785ddc2b93a3372fef63d3) python312Packages.etils: 1.11.0 -> 1.12.2
* [`157c24bf`](https://github.com/NixOS/nixpkgs/commit/157c24bfd84a8d48b01ac1b2f4a4f0ccae0c84ab) arduino-language-server: 0.7.6 -> 0.7.7
* [`cff0af37`](https://github.com/NixOS/nixpkgs/commit/cff0af37dba2a4ae5a56c5b73f69d13b4c630b14) crowdsec: 1.6.5 -> 1.6.6
* [`76e9062b`](https://github.com/NixOS/nixpkgs/commit/76e9062b9a3c46f3b7115089ace67dc347f8854a) nextcloudPackages: update
* [`0354cb86`](https://github.com/NixOS/nixpkgs/commit/0354cb868247cbbd10a83960d687f85cdd041c80) nextcloudPackages: add oidc_login
* [`c86a9eab`](https://github.com/NixOS/nixpkgs/commit/c86a9eabb9a27ec432cb7f4772b7950b088353ee) nextcloudPackages: edit README.md
* [`e58fb6b1`](https://github.com/NixOS/nixpkgs/commit/e58fb6b16f60c0da5ac00beedf1f97b334224f47) aws-sam-cli: 1.134.0 -> 1.135.0
* [`fe594054`](https://github.com/NixOS/nixpkgs/commit/fe594054c4e4a24ae2f91de1d3278e7e1887d04a) python312Packages.databricks-sql-connector: 3.7.1 -> 4.0.1
* [`c021d09d`](https://github.com/NixOS/nixpkgs/commit/c021d09d1d87172572393977b0a564358b09d07a) ccid: 1.6.1 -> 1.6.2
* [`51950a5e`](https://github.com/NixOS/nixpkgs/commit/51950a5e8370f5a77d0ec7bf0bf7d3f30382dd11) iosevka-bin: 33.0.1 -> 33.1.0
* [`acd3e908`](https://github.com/NixOS/nixpkgs/commit/acd3e908a016233657989d5e7ca4353618ccd664) ddnet-server: fix Darwin build
* [`894f30ec`](https://github.com/NixOS/nixpkgs/commit/894f30ecbfbb4738ab67a3726368cbf2d7630084) ddnet-server: set correct mainProgram
* [`740d9d65`](https://github.com/NixOS/nixpkgs/commit/740d9d65cfff05755618643fcf53be1a5340f5fb) dart: 3.7.1 -> 3.7.2
* [`b13a4f84`](https://github.com/NixOS/nixpkgs/commit/b13a4f84b50bba04137ab5494818d4cc4d7ea111) cpu-x: 5.1.2 -> 5.1.3
* [`de5d1711`](https://github.com/NixOS/nixpkgs/commit/de5d17112156bf80bb0f3870167c8a9f5268ebeb) sonarr: 4.0.13.2932 -> 4.0.14.2939
* [`bd90c37d`](https://github.com/NixOS/nixpkgs/commit/bd90c37da7597c62806c2a57a03555d543dc100e) feishu: 7.32.11 -> 7.36.11
* [`77e8d59b`](https://github.com/NixOS/nixpkgs/commit/77e8d59b94911371474af75182c2b101e0903767) cocogitto: 6.2.0 -> 6.3.0
* [`1736a4bd`](https://github.com/NixOS/nixpkgs/commit/1736a4bd216d9bbac33716b053d84b7e4baeb572) gnu-shepherd: 1.0.2 -> 1.0.3
* [`5fa98ba3`](https://github.com/NixOS/nixpkgs/commit/5fa98ba37ba39367f46f4338e241829d284a5e57) rke: 1.7.3 -> 1.8.0
* [`7f3765d9`](https://github.com/NixOS/nixpkgs/commit/7f3765d941edd4e0a9b46b0266a3d9d6f324d07f) ecs-agent: 1.91.0 -> 1.91.1
* [`e243e546`](https://github.com/NixOS/nixpkgs/commit/e243e5462be688b16711e262b10ab2987575d4a9) rootlesskit: 2.3.2 -> 2.3.4
* [`eb5a9174`](https://github.com/NixOS/nixpkgs/commit/eb5a917430d4eb1ebb379c747ff304acd009ebd2) python312Packages.es-client: 8.17.1 -> 8.17.4
* [`1deeb5d6`](https://github.com/NixOS/nixpkgs/commit/1deeb5d60f3bcae0b4e3fde6ac2c2fd9caf1e44b) liboggz: 1.1.2 -> 1.1.3
* [`1a183e35`](https://github.com/NixOS/nixpkgs/commit/1a183e35a379cde04452a2ee3169d8bceea6255f) lxgw-neoxihei: 1.214 -> 1.215
* [`0edf0940`](https://github.com/NixOS/nixpkgs/commit/0edf09400e6df236978d018635a0e481137e63ef) prometheus-pihole-exporter: 1.0.0 -> 1.0.1
* [`6d04c787`](https://github.com/NixOS/nixpkgs/commit/6d04c787166eb177061e70f40e7fae804adb9835) fio: fix static build
* [`7dee90bf`](https://github.com/NixOS/nixpkgs/commit/7dee90bf30b137c2cf11c721f1131558e4bc02d0) python312Packages.nipype: 1.9.2 -> 1.10.0
* [`4cf91749`](https://github.com/NixOS/nixpkgs/commit/4cf917492b7a2de76ff87ecabe57e56a2807376e) sentry-native: 0.8.1 -> 0.8.2
* [`9f6bb851`](https://github.com/NixOS/nixpkgs/commit/9f6bb851142ebdc9f227d0bad8b2ff856ac0188c) python312Packages.jianpu-ly: 1.839 -> 1.842
* [`86b1a415`](https://github.com/NixOS/nixpkgs/commit/86b1a4155faa801ad5d1dbea505247ebe888cdbb) jellyfin-media-player: 1.11.1 -> 1.12.0
* [`c8d5e050`](https://github.com/NixOS/nixpkgs/commit/c8d5e050d8ba2e9810b8f9bd4df6424eeb4c9da7) kuma: 2.9.4 -> 2.10.0
* [`bf9fbb50`](https://github.com/NixOS/nixpkgs/commit/bf9fbb508cad246856f39e6a8c08cd04fd4b1f13) mint: 0.22.0 -> 0.23.1
* [`7405246c`](https://github.com/NixOS/nixpkgs/commit/7405246ca9853556fa7f4112fe3fc9475f826ed7) pinniped: 0.37.0 -> 0.38.0
* [`cd10f9a8`](https://github.com/NixOS/nixpkgs/commit/cd10f9a8745bd688b8a02c1a1d4808c412137ca7) nixos/keycloak: add realmFiles option
* [`e71a41b4`](https://github.com/NixOS/nixpkgs/commit/e71a41b497b498676d526f5dfe596882c213e158) luaPackages.tl: add mainProgram
* [`1b162e53`](https://github.com/NixOS/nixpkgs/commit/1b162e535d4d33302d50bbbab0606b2f13b9677c) mosdepth: loosen compiler pointer checks
* [`cd591a2a`](https://github.com/NixOS/nixpkgs/commit/cd591a2a543be03c1545247509d15d7f8847637b) python312Packages.pynput: 1.7.7 -> 1.8.1
* [`2de40c60`](https://github.com/NixOS/nixpkgs/commit/2de40c60642bd094b85750fe35186f36fdd75401) python312Packages.bundlewrap: 4.21.0 -> 4.22.0
* [`de2ac147`](https://github.com/NixOS/nixpkgs/commit/de2ac14738af470ee03b9dc958daf064a6a28960) kakoune-lsp: 18.1.2 -> 18.1.3
* [`6e4416e7`](https://github.com/NixOS/nixpkgs/commit/6e4416e7636c32eb083074c613782a0c75dc9396) kotlin: 2.1.10 -> 2.1.20
* [`ab630974`](https://github.com/NixOS/nixpkgs/commit/ab630974f5301eff2d3ca93360b05ec38b8efd50) obs-studio-plugins.obs-source-record: 0.4.4 -> 0.4.5
* [`075975b9`](https://github.com/NixOS/nixpkgs/commit/075975b966d3aeb678c4dbc2c1ce654953c43f06) previewqt: 3.0 -> 4.0
* [`baf115d6`](https://github.com/NixOS/nixpkgs/commit/baf115d6fad5a1bebbb047ef6dcc7fc2ad753604) python3Packages.wat: 0.5.1 -> 0.6.0
* [`d96fd22f`](https://github.com/NixOS/nixpkgs/commit/d96fd22f3871e63cc4db9e31dea22d9e26294456) python312Packages.graph-tool: 2.91 -> 2.92
* [`482beabb`](https://github.com/NixOS/nixpkgs/commit/482beabbbde032c18daf5039bd9739db25a7ea93) NixOS Test driver: Display Qemu windows on macOS in interactive mode
* [`7c322472`](https://github.com/NixOS/nixpkgs/commit/7c3224727205bb3a3d00ab3862a62b0b70e6b5a2) signal-desktop: 7.46.0 -> 7.47.0
* [`676d471f`](https://github.com/NixOS/nixpkgs/commit/676d471ff0636ebe62ee889fb9e48ba6f0f0ee67) signal-desktop(aarch64): 7.46.0-1 -> 7.47.0-1
* [`467defb3`](https://github.com/NixOS/nixpkgs/commit/467defb3860c124cddb50437c2e5fb16b11627ca) signal-desktop(darwin): 7.46.0 -> 7.47.0
* [`cea7608b`](https://github.com/NixOS/nixpkgs/commit/cea7608bbf22154f9f0df6edf5e5bfa0901efa76) tinyxml-2: 10.0.0 -> 11.0.0
* [`a55cb1d5`](https://github.com/NixOS/nixpkgs/commit/a55cb1d505988a0f28d1791e07eb46e8ac5aea62) google-cloud-sdk: 513.0.0 -> 515.0.0
* [`3f48f5d9`](https://github.com/NixOS/nixpkgs/commit/3f48f5d986dfa6a332542d19cd12ff48bd618f9e) msitools: 0.103 → 0.106
* [`332b107a`](https://github.com/NixOS/nixpkgs/commit/332b107a25978369905b60eb4f797a17a567e085) questdb: 8.2.2 -> 8.2.3
* [`86196fb0`](https://github.com/NixOS/nixpkgs/commit/86196fb036c8e471c6df456fe227836fa281bb59) databricks-cli: 0.243 -> 0.244
* [`a7b4cd94`](https://github.com/NixOS/nixpkgs/commit/a7b4cd943a6cbd622f5eadc93bd1d1f8892b2038) glaze: 5.0.0 -> 5.0.1
* [`93e12ada`](https://github.com/NixOS/nixpkgs/commit/93e12ada1a5e5610bf4d0d749170c6e26254cc6b) immich-public-proxy: 1.8.0 -> 1.9.0
* [`698db407`](https://github.com/NixOS/nixpkgs/commit/698db4075e4c9b6b3d25945b8f02560aa64fb207) ticker: fix version set at buildtime
* [`78eb1a5d`](https://github.com/NixOS/nixpkgs/commit/78eb1a5dfc0289ff14b22a39b3fa2c2fda4a96ef) ticker: init passthru.tests.version
* [`5355df14`](https://github.com/NixOS/nixpkgs/commit/5355df142cf91681627527329d8a8625f3ac1fff) gui-for-singbox: 1.9.3 -> 1.9.4
* [`9e0b90b2`](https://github.com/NixOS/nixpkgs/commit/9e0b90b2db7f1209dec6d5555e9776f316b64a14) graylog-5_2: remove
* [`7d9df997`](https://github.com/NixOS/nixpkgs/commit/7d9df99795ef8481071d42c08b8675cd622af96d) python3Packages.betterproto: switch to existing pytest-asyncio downgrade
* [`aec6ccc9`](https://github.com/NixOS/nixpkgs/commit/aec6ccc985b15692c2cde29fd7af8773664bb883) libjodycode: 3.1.1 -> 3.1.2
* [`8313fbed`](https://github.com/NixOS/nixpkgs/commit/8313fbedec3c9ae10b179f0840bb34e1acbf8038) zimfw: 1.17.1 -> 1.18.0
* [`5571878c`](https://github.com/NixOS/nixpkgs/commit/5571878c247b1e17691f162abe006a2e4adadb02) gitlab-release-cli: 0.22.0 -> 0.23.0
* [`28297fcd`](https://github.com/NixOS/nixpkgs/commit/28297fcd325011e4fe0aee51752c036e0e59bab3) node-env.nix: use each nodejs' python instead of python2
* [`3814cd05`](https://github.com/NixOS/nixpkgs/commit/3814cd057750aec2ea3ea82b5f42bd69dfeb346d) elmPackages.node: remove reference to python2
* [`b6ecdd7c`](https://github.com/NixOS/nixpkgs/commit/b6ecdd7c8f9f8400ab18ea1390dbf49a8deed9d3) base16-builder: remove reference to python2
* [`3450d8ba`](https://github.com/NixOS/nixpkgs/commit/3450d8ba82c5600bd19e2d96f8d69df0a6264030) mx-puppet-discord: remove reference to python2
* [`a06ebb3b`](https://github.com/NixOS/nixpkgs/commit/a06ebb3b609ec2740849211b93d4551d7e4f0b91) ethercalc: remove reference to python2
* [`ba862e80`](https://github.com/NixOS/nixpkgs/commit/ba862e80fd1b1732c7c9f1c654a0691ceca6242e) onlykey: remove reference to python2
* [`136d3b96`](https://github.com/NixOS/nixpkgs/commit/136d3b96d2c34220dbfa597008eef0054061cc66) composition.nix: remove reference to python2
* [`f86abd8b`](https://github.com/NixOS/nixpkgs/commit/f86abd8bb1a9a962415089db938ef1e43dd7f1ac) node-env.nix: remove ellipsis
* [`4ba1bebf`](https://github.com/NixOS/nixpkgs/commit/4ba1bebfc81d2ca8e557cb1240b47310f7c619fd) kubo: 0.33.2 -> 0.34.0
* [`ad8e10d7`](https://github.com/NixOS/nixpkgs/commit/ad8e10d700064c38b97009590187112309cc7bc2) git-town: 18.0.0 -> 18.1.0
* [`8946046d`](https://github.com/NixOS/nixpkgs/commit/8946046dd0d1f496fefbcefe09fbf42d916390ff) normaliz: migrate to flint3
* [`223edfea`](https://github.com/NixOS/nixpkgs/commit/223edfea2b0725610f7c69b3313652575b60d6fd) pplite: migrate to flint3
* [`205f8269`](https://github.com/NixOS/nixpkgs/commit/205f8269ee16092fb5bb1de69e0933ee0351c67f) gradle: add test for toolchain functionality
* [`22aa6628`](https://github.com/NixOS/nixpkgs/commit/22aa66285871f1c7f9eb1ef31fa7c23ed144560b) keymapper: 4.11.0 -> 4.11.1
* [`25269947`](https://github.com/NixOS/nixpkgs/commit/2526994708fb0a2e23020277bb0d518ce548af2f) firecracker: 1.10.1 -> 1.11.0
* [`329fdc57`](https://github.com/NixOS/nixpkgs/commit/329fdc57631f3a5ca3af3e75d6fc6c3f9f099cea) ebusd: update to 24.1 and add new log facility option ("device")
* [`d69f7965`](https://github.com/NixOS/nixpkgs/commit/d69f7965eebbb71112c24adf705090f7c9ccd75f) repomix: 0.2.36 -> 0.3.0
* [`f9818e0d`](https://github.com/NixOS/nixpkgs/commit/f9818e0d00e8c3ee44b86176f9c4952bd2f514ee) python312Packages.kornia-rs: use fetchCargoVendor
* [`34da0bd4`](https://github.com/NixOS/nixpkgs/commit/34da0bd4fc7a80495bc5725a775befea0b0e132c) nixos/nextcloud: Also install when config.php exists but is empty
* [`b828ba32`](https://github.com/NixOS/nixpkgs/commit/b828ba3247e9d6adf09d5614eec235796d91a8c6) nixos/h2o: wait for open ports in tests
* [`e260ad37`](https://github.com/NixOS/nixpkgs/commit/e260ad378242549cbbb4d4906d3cef1422c6034b) jazz2: add updateScript
* [`ba330a9d`](https://github.com/NixOS/nixpkgs/commit/ba330a9d5966aa5d914152e227b0047f7a73a231) jazz2: 3.1.0 -> 3.2.0
* [`2b2b2288`](https://github.com/NixOS/nixpkgs/commit/2b2b22886c3d4dcac3b6b7224a7aad6883090baa) plotext: 5.2.8 -> 5.3.2
* [`90984d85`](https://github.com/NixOS/nixpkgs/commit/90984d85ac81766361e88a4a53712f0bcb3d9da5) jekyll: 4.3.4 -> 4.4.1
* [`1905cd89`](https://github.com/NixOS/nixpkgs/commit/1905cd89f8ed8467c95e359595114aa3437a5ade) nixos/h2o: move to runTest
* [`357a75fd`](https://github.com/NixOS/nixpkgs/commit/357a75fda7058668434fa46f118e71a15f52c608) xdg/portals/lxqt: Fix documentation string indent
* [`a4ee7ac4`](https://github.com/NixOS/nixpkgs/commit/a4ee7ac4ae3bd777e8f2efc29a6de4c4cdae4cb3) uhk-agent: 5.1.0 -> 6.0.0
* [`a600481a`](https://github.com/NixOS/nixpkgs/commit/a600481a0a58689bf35ffafcf9b9037957b087f7) leptosfmt: 0.1.30 -> 0.1.33
* [`4ef3858d`](https://github.com/NixOS/nixpkgs/commit/4ef3858dcb558345ce47c744ba97f6a820c8a6c1) nmrpflash: 0.9.24 -> 0.9.25
* [`695c0173`](https://github.com/NixOS/nixpkgs/commit/695c0173abd011a4736cd2c3d4705f6ae024bc38) kitsas: 5.8 -> 5.9
* [`a07fc16d`](https://github.com/NixOS/nixpkgs/commit/a07fc16d4809e4f2bd8a5423048ed2796afae539) syncplay: 1.7.3 -> 1.7.4
* [`b2059c45`](https://github.com/NixOS/nixpkgs/commit/b2059c45c41a775d4731557d965048a27d26eb16) ts_query_ls: 1.9.0 -> 1.10.0
* [`546aaa8d`](https://github.com/NixOS/nixpkgs/commit/546aaa8d4b010d3ef070793724cdd7eec409f049) python312Packages.lml: 0.1.0 -> 0.2.0
* [`e69c6d0f`](https://github.com/NixOS/nixpkgs/commit/e69c6d0fdc392864445dd78c7a2e0ba39a9fa33e) reposilite: add updateScript
* [`961f3403`](https://github.com/NixOS/nixpkgs/commit/961f340355ad48966e877d0fc9a5ebdca31cff1f) reposilite: 3.5.21 -> 3.5.22
* [`4a5d03c5`](https://github.com/NixOS/nixpkgs/commit/4a5d03c5b03b5468a414b6d797e0d1ed30e25871) mono: remove llvm build
* [`6b757a73`](https://github.com/NixOS/nixpkgs/commit/6b757a7363dfe7e2b86ad16704ebffcd3d295087) rubyPackages.libv8: drop
* [`44a28f26`](https://github.com/NixOS/nixpkgs/commit/44a28f26c861221553912743e3ac3a0812030657) or-tools: 9.11 -> 9.12
* [`e2e69dc0`](https://github.com/NixOS/nixpkgs/commit/e2e69dc0cf8b75298e2edbf4af9ab7df2359c7ce) orchard: 0.28.3 -> 0.29.0
* [`73058db2`](https://github.com/NixOS/nixpkgs/commit/73058db24156cc6ce538ee6d6a14ebaf0256048b) maintainers-list: add QF0xB
* [`4723b6a7`](https://github.com/NixOS/nixpkgs/commit/4723b6a7d0f672c005cd6207257b736fc6135218) nwg-displays: adopt package
* [`0d5b3c20`](https://github.com/NixOS/nixpkgs/commit/0d5b3c2038367de79acbe476bdf2d076f91fe73d) flexget: add libtorrent dependency
* [`09aac85f`](https://github.com/NixOS/nixpkgs/commit/09aac85fe355774f37844cbc3712f4682bbc9de3) veilid: 0.4.3 -> 0.4.4
* [`81348926`](https://github.com/NixOS/nixpkgs/commit/813489269a1db3e7edde866b20424f0b3a9ebac0) python312Packages.xvfbwrapper: 0.2.9 -> 0.2.10
* [`e589a04f`](https://github.com/NixOS/nixpkgs/commit/e589a04f5e0ca048e93fce24e58bb4446a632447) python312Packages.lml: refactor
* [`2719cec3`](https://github.com/NixOS/nixpkgs/commit/2719cec3fea42ca1f111e9ae1f1c1d0c07ad4ad3) flutter_rust_bridge_codegen: 2.8.0 -> 2.9.0
* [`2aea1f78`](https://github.com/NixOS/nixpkgs/commit/2aea1f78e2b4293545ff438ae1d13d9c7a824367) python312Packages.pygnmi: 0.8.14 -> 0.8.15
* [`3c132b92`](https://github.com/NixOS/nixpkgs/commit/3c132b9207fef27c2a6f5e5e2f99ff29023d8bbe) python312Packages.fake-useragent: 2.0.3 -> 2.1.0
* [`f790e3be`](https://github.com/NixOS/nixpkgs/commit/f790e3be5a65f428eea7f90197d7627c0ae742d7) sopwith: 2.7.0 -> 2.8.0
* [`131e89a3`](https://github.com/NixOS/nixpkgs/commit/131e89a3ae0e4c4144beac5c5500d1fe755eae65) python312Packages.segno: 1.6.1 -> 1.6.6
* [`3d5ec896`](https://github.com/NixOS/nixpkgs/commit/3d5ec896208944cdbf095a89c65c06da7d7368e3) checkpolicy: 3.8 -> 3.8.1
* [`8aff7c82`](https://github.com/NixOS/nixpkgs/commit/8aff7c823d9cdf5808523670a335b55b3693dbd7) libsemanage: 3.8 -> 3.8.1
* [`d3097dbb`](https://github.com/NixOS/nixpkgs/commit/d3097dbbfb2524f38e9f4f7a44a72af72edf545d) jbrowse: 3.0.5 -> 3.2.0
* [`e6872e16`](https://github.com/NixOS/nixpkgs/commit/e6872e163836444f2872ff456adcefc890329d53) policycoreutils: 3.8 -> 3.8.1
* [`79da1abe`](https://github.com/NixOS/nixpkgs/commit/79da1abe9fce7f4f8989ee15f3633033a157d85b) alsa-scarlett-gui: 0.5.0 -> 0.5.1
* [`12c098f0`](https://github.com/NixOS/nixpkgs/commit/12c098f0ca839ef7e50a6fd123c1baba26f792b7) nixos/amazon-ec2-amis: remove
* [`93dff566`](https://github.com/NixOS/nixpkgs/commit/93dff566ad375d249d1ba4830d0c004bfc894fdb) ddrescue: 1.29 -> 1.29.1
* [`148ce094`](https://github.com/NixOS/nixpkgs/commit/148ce09437bfeb2dff362b519a07668219f97412) npm-check-updates: 17.1.15 -> 17.1.16
* [`13eec743`](https://github.com/NixOS/nixpkgs/commit/13eec7433827007ac5b2dd8db55b632ad8d6f2ff) tarsnap: 1.0.40 -> 1.0.41
* [`b4892027`](https://github.com/NixOS/nixpkgs/commit/b48920277378cfecf9959cd2128c80c3d8dec466) mdk-sdk: 0.31.0 -> 0.32.0
* [`3adc1f1b`](https://github.com/NixOS/nixpkgs/commit/3adc1f1b77c5dfdf72ea2ba62c21fbb3fa0dacd7) firefly-iii: 6.2.9 -> 6.2.10
* [`12ea84d6`](https://github.com/NixOS/nixpkgs/commit/12ea84d6e0a351545037e3b14d40653addfe9550) doublecmd: 1.1.22 -> 1.1.23
* [`6ff9fa97`](https://github.com/NixOS/nixpkgs/commit/6ff9fa979905a7f120c3ac01465adf2820b46ae3) eslint: avoid dev dependencies to reduce closure size
* [`20ec2e12`](https://github.com/NixOS/nixpkgs/commit/20ec2e12a638bcd398ecc4e3c1f25152d516734a) projectm-sdl-cpp: 0-unstable-2025-02-28 -> 0-unstable-2025-03-17
* [`b0ae2731`](https://github.com/NixOS/nixpkgs/commit/b0ae273190021197a564e1198a4ac4776b463eb5) yamlscript: 0.1.94 -> 0.1.95
* [`aa043b44`](https://github.com/NixOS/nixpkgs/commit/aa043b4486e8ba190b7ad941a495a9fe951777fd) python312Packages.superqt: 0.7.1 -> 0.7.2
* [`85530321`](https://github.com/NixOS/nixpkgs/commit/85530321076743c2fb8b194c4fb3492788322c68) teleport_16: 16.4.17 -> 16.4.18
* [`fb44aa17`](https://github.com/NixOS/nixpkgs/commit/fb44aa17bfdb419d757921c81c9558bfd05e2307) maintainers: add taliyahwebb
* [`3fa01353`](https://github.com/NixOS/nixpkgs/commit/3fa013536773bf3a9db64579a8175df56b20b50c) xdragon: add taliyahwebb as maintainer
* [`f8545ffc`](https://github.com/NixOS/nixpkgs/commit/f8545ffcad1f04b8e7a05706b1dc4a1d8720ac3f) xdragon: license gpl3 -> gpl3Plus
* [`a9c22aa9`](https://github.com/NixOS/nixpkgs/commit/a9c22aa99aa055c6131563974533d588f3786548) xdragon: manual migration to pkgs/by-name
* [`3f72a67d`](https://github.com/NixOS/nixpkgs/commit/3f72a67d9a2060444b45ba0167879c1b494c4764) msieve: unbreak on GCC 14
* [`00e36366`](https://github.com/NixOS/nixpkgs/commit/00e36366a99cb916645101d48a8c18ad3cb6c353) hoarder: 0.22.0 -> 0.23.0
* [`9b5a61af`](https://github.com/NixOS/nixpkgs/commit/9b5a61afd520097fedec00a50809165366618e93) python312Packages.google-cloud-speech: 2.31.0 -> 2.31.1
* [`1671c4d3`](https://github.com/NixOS/nixpkgs/commit/1671c4d3739f8a47895ec88b8231f8d4c1a81cb8) ldc: 1.39.0 -> 1.40.1
* [`2dad8350`](https://github.com/NixOS/nixpkgs/commit/2dad8350338b3c313da4ca4bdbaceb2ec2308a26) nextcloud-occ: work with sudo disabled
* [`37062ccc`](https://github.com/NixOS/nixpkgs/commit/37062ccc6c6789ee9c540a668d26fbb38528b1c5) ccache: 4.11.2 -> 4.11.2
* [`72b97427`](https://github.com/NixOS/nixpkgs/commit/72b97427683370e424572e5ca68c8f7f1dfc8754) nixos/nextcloud-notify_push: add nextcloud-setup
* [`eee5fd9f`](https://github.com/NixOS/nixpkgs/commit/eee5fd9ffa7d6f660775d24fd6174a3720445451) lms: 3.62.1 -> 3.64.0
* [`78ddc82d`](https://github.com/NixOS/nixpkgs/commit/78ddc82d2f40229e5006c02b7cfc0f119433b0b6) dar: 2.7.16 -> 2.7.17
* [`6169a5e1`](https://github.com/NixOS/nixpkgs/commit/6169a5e158d0a919ec26a8a67ad5c10b3ec5903d) python3Packages.geeknote: drop
* [`9d77d960`](https://github.com/NixOS/nixpkgs/commit/9d77d960fd02b565314d978efefa12d2ec2d3364) python3Packages.evernote: drop
* [`e3b68322`](https://github.com/NixOS/nixpkgs/commit/e3b683229306d3da00faa5ae63a99758963a4e5d) python3Packages.modestmaps: drop
* [`2cc5727a`](https://github.com/NixOS/nixpkgs/commit/2cc5727af97baace4f04f5915ba6e245b9b5a081) gython3Packages.tilestache: drop
* [`a4df9193`](https://github.com/NixOS/nixpkgs/commit/a4df9193336594a898de8385b79184da32868949) python3Packages.python-wifi: drop
* [`76fba3ef`](https://github.com/NixOS/nixpkgs/commit/76fba3ef796f012caba0cc4de148dda25557b120) python3Packages.pychart: drop
* [`1c64b909`](https://github.com/NixOS/nixpkgs/commit/1c64b9098063738066588d4ca62de5493f0092c6) objfw: 1.2.4 -> 1.3
* [`b0d52206`](https://github.com/NixOS/nixpkgs/commit/b0d522069803a9c9eb523bee7bdb95f74844b6a8) davinci-resolve-studio: 19.1.3 -> 19.1.4
* [`ae27c4b2`](https://github.com/NixOS/nixpkgs/commit/ae27c4b279978bea01e9012eff9102ab83e81c70) nux: drop
* [`13c410f9`](https://github.com/NixOS/nixpkgs/commit/13c410f98017c83c5d7094694dc7db2f6fa2bc3b) sqlpage: 0.33.1 -> 0.34.0
* [`f78a2990`](https://github.com/NixOS/nixpkgs/commit/f78a2990bf4e6625a5ac1fae0cd152cf09df1364) trealla: 2.64.4 -> 2.66.2
* [`1eebd793`](https://github.com/NixOS/nixpkgs/commit/1eebd79380784e9c60dfb686ee630866f4bd1bf0) python312Packages.metaflow: 2.15.0 -> 2.15.6
* [`b47e6d8f`](https://github.com/NixOS/nixpkgs/commit/b47e6d8fe97d4cac09b91ff47bdbf443d6fa0297) kubelogin: 0.1.9 -> 0.2.7
* [`0a1f81bd`](https://github.com/NixOS/nixpkgs/commit/0a1f81bd402a4721de8c5d5948cd9709d10f8281) python312Packages.langchain-core: 0.3.44 -> 0.3.47
* [`41a80506`](https://github.com/NixOS/nixpkgs/commit/41a80506c8de5c7d735f0df81361ab9d749cf4db) python312Packages.netbox-dns: 1.2.5 -> 1.2.6
* [`c17fd407`](https://github.com/NixOS/nixpkgs/commit/c17fd407fbc118710e70cea6715b4e0ebcffe372) python312Packages.netbox-topology-views: 4.2.0 -> 4.2.1
* [`66026a5f`](https://github.com/NixOS/nixpkgs/commit/66026a5f702fa1597b7dc610d74e6b03fe7946d9) komga: 1.21.1 -> 1.21.2
* [`493bda5e`](https://github.com/NixOS/nixpkgs/commit/493bda5ef0f93cfa9596c3c88b9887788b056e2d) chmlib: Fix build on darwin
* [`849b5b54`](https://github.com/NixOS/nixpkgs/commit/849b5b546e4b92c6e7b4b55e9e89194d4164fc6c) decker: 1.53 -> 1.54
* [`eedf68f2`](https://github.com/NixOS/nixpkgs/commit/eedf68f2cd8c910b62cf29f2cba6202346ca1c8a) inferno: 0.12.1 -> 0.12.2
* [`7c3c0434`](https://github.com/NixOS/nixpkgs/commit/7c3c04344ddc366581e1b48824606d2d5d694ffa) python313Packages.discordpy: 2.4.0 -> 2.5.2
* [`ea08288e`](https://github.com/NixOS/nixpkgs/commit/ea08288e98f0016061315e3f13cbe7a531de17fa) python312Packages.hcloud: 2.3.0 -> 2.4.0
* [`7acf5851`](https://github.com/NixOS/nixpkgs/commit/7acf585179a75d8ef6661690d0d53f71269b218e) python313Packages.generic: 1.1.3 -> 1.1.4
* [`792bcda7`](https://github.com/NixOS/nixpkgs/commit/792bcda76332fc0ff8a56a4c06bb1cb55d34c4fa) python313Packages.generic: refactor
* [`6664ac56`](https://github.com/NixOS/nixpkgs/commit/6664ac56da802d404419860859dfd4b819053f36) python313Packages.approvaltests: 14.3.0 -> 14.3.1
* [`4228dfd5`](https://github.com/NixOS/nixpkgs/commit/4228dfd529062eede22199d3cf7ea7a225f0e634) texture-synthesis: fix build with rust 1.76+
* [`ab5e33b5`](https://github.com/NixOS/nixpkgs/commit/ab5e33b54f264cae428afbf79eec41ca920ed7b4) python313Packages.mailsuite: 1.9.18 -> 1.9.20
* [`e382ff7a`](https://github.com/NixOS/nixpkgs/commit/e382ff7a43c4d095cb4b0781ceca3adf92a5068e) python313Packages.meraki: 1.54.0 -> 1.56.0
* [`e58434f1`](https://github.com/NixOS/nixpkgs/commit/e58434f1d2c9bce68309440f1a5adfad80545b74) python313Packages.mediafile: 0.12.0 -> 0.13.0
* [`0f6f8b23`](https://github.com/NixOS/nixpkgs/commit/0f6f8b23d7a1aed833915a78c8cff4a8bfbd2902) hashlink: 1.14 -> 1.15
* [`0ca1c255`](https://github.com/NixOS/nixpkgs/commit/0ca1c255a30459536591db3972f92188788fcd16) k3s: source k3s version.sh in update script to get component versions
* [`1d1d9923`](https://github.com/NixOS/nixpkgs/commit/1d1d9923655402c638854ee3b057b6440353176c) python313Packages.django-admin-datta: 1.0.16 -> 1.0.17
* [`a5682c19`](https://github.com/NixOS/nixpkgs/commit/a5682c19934dd6479b001b5c0a3ce319f8832574) python313Packages.django-htmx: 1.21.0 -> 1.23.0
* [`91728069`](https://github.com/NixOS/nixpkgs/commit/91728069e2e6e5aa3ec17bbc4b3859e8c3180327) libphonenumber: 8.13.55 -> 9.0.1
* [`b25e110a`](https://github.com/NixOS/nixpkgs/commit/b25e110ac44b6c296f8c40043bdf2718daf04b26) python312Packages.bilibili-api-python: 17.1.3 -> 17.1.4
* [`89b30e5b`](https://github.com/NixOS/nixpkgs/commit/89b30e5b1523b2a849619b0c8a70d589d949365d) nixos/postgresql: fix spelling and grammar in docs
* [`24775f65`](https://github.com/NixOS/nixpkgs/commit/24775f65439f1fc53c1d8f2888cd1fcce8ff7b9f) nixos/postgresql: fix reference to LLVM closure size
* [`0bc099ab`](https://github.com/NixOS/nixpkgs/commit/0bc099abd6989a3053b930c5657494329c048749) nixos/postgresql: add docs about procedural languages
* [`b485269c`](https://github.com/NixOS/nixpkgs/commit/b485269cef458e65d8b5d13c3bb5d117bf413ae8) cozette: 1.26.0 -> 1.27.0
* [`dff9eace`](https://github.com/NixOS/nixpkgs/commit/dff9eacebb28cc68fad775cb7ea5aedfd38f8747) python312Packages.setuptools-dso: 2.11 -> 2.12.2
* [`0e19ef79`](https://github.com/NixOS/nixpkgs/commit/0e19ef796dd6f88ffea6c76fcbdbbf1206135e70) distribution: 3.0.0-rc.3 -> 3.0.0-rc.4
* [`fce465fa`](https://github.com/NixOS/nixpkgs/commit/fce465fa11f12353fdaec14c13ae419ca54d2865) libreoffice-bin: 7.6.7 -> 25.2.1
* [`72b86b6b`](https://github.com/NixOS/nixpkgs/commit/72b86b6bb9ac2ddee2301779229bb5f3267807dc) python312Packages.pglast: 7.3 -> 7.5
* [`7a35667a`](https://github.com/NixOS/nixpkgs/commit/7a35667a1c0d9e2df7ce0a60d44b81ded92a996d) postgresql: simplify doInstallCheck condition and fix comments
* [`dc723285`](https://github.com/NixOS/nixpkgs/commit/dc7232857d8ce8948c77ebb935ecfbef4b27a693) python312Packages.azure-servicebus: 7.14.0 -> 7.14.1
* [`cb034500`](https://github.com/NixOS/nixpkgs/commit/cb034500d90d69b24ead6bcc2b275d4c232769ac) nabi: 1.0.0 -> 1.0.1
* [`ff7ef81b`](https://github.com/NixOS/nixpkgs/commit/ff7ef81b8419031d258549f028dadf3566df4f98) gtree: 1.10.14 -> 1.10.15
* [`51c38979`](https://github.com/NixOS/nixpkgs/commit/51c389796e72ed12c217058269ccccea5b347925) python312Packages.django-modeltranslation: 0.19.12 -> 0.19.13
* [`45a15990`](https://github.com/NixOS/nixpkgs/commit/45a1599094b6155877aecdbc1ee311b70b811bed) spire: 1.11.2 -> 1.12.0
* [`5cb6eeeb`](https://github.com/NixOS/nixpkgs/commit/5cb6eeeb0a28b8aaf71312cb4c68b803ed3ac03b) python313Packages.django-modeltranslation: refactor
* [`a0c047fe`](https://github.com/NixOS/nixpkgs/commit/a0c047fece65c73713aa5d0ecc72d141ac51cb57) percona-server: 8.4.3-3 -> 8.4.4-4
* [`0d072e67`](https://github.com/NixOS/nixpkgs/commit/0d072e679d82c20044ebc758cfd38edcdffc1430) python312Packages.nicegui: 2.12.1 -> 2.13.0
* [`14153b31`](https://github.com/NixOS/nixpkgs/commit/14153b31a8f1e1b04e52cbe7457c54657b1b54d5) froide-govplan: init at 0-unstable-2025-01-27
* [`4a8b7bb4`](https://github.com/NixOS/nixpkgs/commit/4a8b7bb45d90c84fbc3a38fe40bb5b0265e5c0fc) nixos/froide-govplan: init
* [`4d32c67c`](https://github.com/NixOS/nixpkgs/commit/4d32c67c73a91a68dd3d64a4f5a64abb2b695f65) nixos/tests/froide-govplan: init
* [`9d2159eb`](https://github.com/NixOS/nixpkgs/commit/9d2159ebe0531cb5f6cb5e21545f8f372ee4b3a1) apacheKafka: init at 4.0.0
* [`513e56cc`](https://github.com/NixOS/nixpkgs/commit/513e56cc4ac956a101d93a5e348378986eae4cbe) nixos/kafka: Set default test mode to KRaft, Zookeeper is deprecated from 4.0
* [`b58241cd`](https://github.com/NixOS/nixpkgs/commit/b58241cd971b58686dc803e93d0045fd0a54f662) bicep: 0.33.93 -> 0.34.1
* [`3575d7df`](https://github.com/NixOS/nixpkgs/commit/3575d7df90ffd31de6a97ad851f9886c58e29814) maintainers: add phodina
* [`c1f20fe5`](https://github.com/NixOS/nixpkgs/commit/c1f20fe5fbc39341ffc7838dcbd306e89ea38999) mirrord: 3.134.2 -> 3.136.0
* [`cd050a12`](https://github.com/NixOS/nixpkgs/commit/cd050a12ad99461e7c78ca59641b02d5667e468d) electron_35-bin: init at 35.0.3
* [`c9123340`](https://github.com/NixOS/nixpkgs/commit/c91233402a7e0f35c2b65ed7bdeccbec7f56a716) electron-chromedriver_35: init at 35.0.3
* [`9c12ed5f`](https://github.com/NixOS/nixpkgs/commit/9c12ed5fad150e80206478f8ab12326400d75fd4) electron-source.electron_35: init at 35.0.3
* [`eb661695`](https://github.com/NixOS/nixpkgs/commit/eb6616954503440616d75d435aa322ef8e6b8c78) electron: remove duplicate use_qt flag
* [`112942f6`](https://github.com/NixOS/nixpkgs/commit/112942f6140b936aae30699b35afd43ed70e13e2) electron: 35+ header generation needs ELECTRON_OUT_DIR
* [`2a66805e`](https://github.com/NixOS/nixpkgs/commit/2a66805e83a0c89903c74754279ab63348cbd1a9) chromium: move gnChromium to nativeBuildInputs,
* [`5213e7ee`](https://github.com/NixOS/nixpkgs/commit/5213e7eef40ae3d1c058e7be377ce9e30c46c713) electron: node_module_version should be int
* [`506d38b4`](https://github.com/NixOS/nixpkgs/commit/506d38b43275ad601c917c1c542fd7d2aad3dffc) electron-source: try to avoid log spam
* [`76836a0b`](https://github.com/NixOS/nixpkgs/commit/76836a0b2deb24f2880e2df0ee3402fe7f340bb1) python3Packages.dash: 2.18.2 -> 3.0.0
* [`a8cf7ad7`](https://github.com/NixOS/nixpkgs/commit/a8cf7ad70c890b5dc3c449098aee40e8aa4b44fa) maintainers: add alexandrutocar
* [`6df1c4b3`](https://github.com/NixOS/nixpkgs/commit/6df1c4b376a3a33e93549fc3529003c2a9ba6d3c) creek: init at 0.4.2
* [`17aa7064`](https://github.com/NixOS/nixpkgs/commit/17aa70642262296c25e54243521b7c241f6e60f8) das: relax dash dependency
* [`70df4cf8`](https://github.com/NixOS/nixpkgs/commit/70df4cf866f81ef5cc3779fe443a946a2b5d94ab) lttoolbox: 3.7.1 -> 3.7.6
* [`aec25933`](https://github.com/NixOS/nixpkgs/commit/aec25933860268b294c010b76a418afcca72ca40) lttoolbox: use autoreconfHook and nativeCheckInputs
* [`a80fc08c`](https://github.com/NixOS/nixpkgs/commit/a80fc08cab702fa9a0697e118dbcc3aafeb8ac7b) tootik: 0.15.4 -> 0.15.5
* [`0da9eb2d`](https://github.com/NixOS/nixpkgs/commit/0da9eb2d23dd97cf51525a23ce002b99e1bbaf99) nodePackages.orval: drop
* [`c5f46fff`](https://github.com/NixOS/nixpkgs/commit/c5f46fffc3562c9b4ac942157bcb64447a2de25a) python312Packages.django-picklefield: 3.2.0 -> 3.3.0
* [`6919ff6f`](https://github.com/NixOS/nixpkgs/commit/6919ff6fc79fe15af3fcefd4e7d987f5c757f903) python312Packages.django-picklefield: refactor
* [`f555b99b`](https://github.com/NixOS/nixpkgs/commit/f555b99bdf64d8171e3cc82ac35603c2a65c4a28) nodePackages.prettier-plugin-toml: drop
* [`9f8c2fed`](https://github.com/NixOS/nixpkgs/commit/9f8c2fed5ca2b04ff5a9c6931060a6482c593c37) grub2: remove security patch causing segfault with `grub-mount` / NTFS
* [`9141f46c`](https://github.com/NixOS/nixpkgs/commit/9141f46cc970d73d0b9d7e4a1b510c2d3d9ee7d1) dive: 0.12.0 -> 0.13.0
* [`c4c41658`](https://github.com/NixOS/nixpkgs/commit/c4c4165803d6bbc718bfa9b8eebe6dc032c575d6) python312Packages.django-appconf: 1.0.6 -> 1.1.0
* [`cc72d075`](https://github.com/NixOS/nixpkgs/commit/cc72d0751e7acd7eabe672f5c86bb763edb0f3f7) python312Packages.django-allauth: 65.4.1 -> 65.5.0
* [`126ac27a`](https://github.com/NixOS/nixpkgs/commit/126ac27a8e7180b24bc173253cbacb64ed1b2bd7) nodePackages."reveal.js": drop
* [`bbc00ab5`](https://github.com/NixOS/nixpkgs/commit/bbc00ab5071d3b4cff8d5cb9a5374f1588e28c3d) python312Packages.libknot: 3.4.4 -> 3.4.5
* [`dd87b173`](https://github.com/NixOS/nixpkgs/commit/dd87b173d2717f7a6e2b4ed023744b353ad19109) python312Packages.django-mfa3: 0.13.0 -> 0.15.1
* [`bbe68868`](https://github.com/NixOS/nixpkgs/commit/bbe68868f13e11dce1d7faf301b821243a484dcd) creds: fix changelog
* [`a91de1be`](https://github.com/NixOS/nixpkgs/commit/a91de1be231cefcb7a8d71782381e78569a6bdb9) nodePackages."socket.io": drop
* [`8d27ef5b`](https://github.com/NixOS/nixpkgs/commit/8d27ef5bf68689b1a3dc285baff671b6e16e35ca) zsv: 0.3.8-alpha -> 0.4.4-alpha
* [`eca59564`](https://github.com/NixOS/nixpkgs/commit/eca595646780484b33eec5c8e881a6c2c242f999) unigine-superposition: fix exec case in desktopItem
* [`59c75047`](https://github.com/NixOS/nixpkgs/commit/59c75047ba86c555cb29e510f04c0c192201191a) python312Packages.routeros-api: 0.18.1 -> 0.21.0
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
