### PR TITLE
niv nixpkgs: update efa1f973 -> a4325209

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "efa1f9731768dc5488f415b183e323cb151980ce",
-        "sha256": "02xdiaadgz7yy3in92qdgqq2sscd63pjz6krqni1047yb08j6v92",
+        "rev": "a4325209863278fc096401bfe9e0a9da34aa9e00",
+        "sha256": "02pnyxmv1vs33l6jpmgdki1dqj3i8hsxyg90sj6ls4p0wx7aqk2y",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/efa1f9731768dc5488f415b183e323cb151980ce.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/a4325209863278fc096401bfe9e0a9da34aa9e00.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@efa1f973...a4325209](https://github.com/nixos/nixpkgs/compare/efa1f9731768dc5488f415b183e323cb151980ce...a4325209863278fc096401bfe9e0a9da34aa9e00)

* [`2a51c0cf`](https://github.com/NixOS/nixpkgs/commit/2a51c0cf2599457b4461c5da3965ae168849cc9b) vice: 3.8 -> 3.9
* [`1d9ece49`](https://github.com/NixOS/nixpkgs/commit/1d9ece4920520f3b10cd550e1d7c359beb902290) maintainers: add sweiglbosker
* [`b5fd5911`](https://github.com/NixOS/nixpkgs/commit/b5fd59113df5778b03926f8f3a052f3f849a57b6) pinentry-dmenu: init at 0.2.2
* [`ff9b3598`](https://github.com/NixOS/nixpkgs/commit/ff9b3598e6ce7e9fbd4f0cc8a61cfab9b300003d) lib.modules: simplified logic in zipAttrsWith and minor cleanup
* [`841c9ff6`](https://github.com/NixOS/nixpkgs/commit/841c9ff6652e22c2aaf81a8a42b6b93280f32590) qt: add "kde6" to qt.platformTheme
* [`2f2a144f`](https://github.com/NixOS/nixpkgs/commit/2f2a144f0ba057911fc7ef5f4dadc852a48b980d) ayatana-indicator-messages: 24.5.0 -> 24.5.1
* [`8dd383b1`](https://github.com/NixOS/nixpkgs/commit/8dd383b18bf2d47ef9c96f1e01a87b2424045da3) jazzy: 0.15.1 -> 0.15.3
* [`490ac314`](https://github.com/NixOS/nixpkgs/commit/490ac31492562e040b5bff3295f6764e9d4abe76) python312Packages.groq: 0.18.0 -> 0.19.0
* [`5bcb173e`](https://github.com/NixOS/nixpkgs/commit/5bcb173eb1f8fd26851bd8be7cf8aec9ce9c7dd0) rspamd: 3.11.0 -> 3.11.1
* [`00996c9f`](https://github.com/NixOS/nixpkgs/commit/00996c9f33e3f7400ee51887e0f0b8dfadf3fa9c) nixos/rspamd: fix tests, postfix now always throws warnings
* [`9f3e45b2`](https://github.com/NixOS/nixpkgs/commit/9f3e45b253e96b4e040e036a5ef0494db9ead917) mpvScripts.occivink.blacklistExtensions: 0-unstable-2024-01-11 -> 0-unstable-2025-03-09
* [`0c394432`](https://github.com/NixOS/nixpkgs/commit/0c3944320adec9dc23432de40f75241f843594e4) gearlever: 2.3.2 -> 3.0.2
* [`01cee7e8`](https://github.com/NixOS/nixpkgs/commit/01cee7e80ec9114a077a1c5e99b0e75528b2690c) go-grip: init at 0.5.6
* [`3edc23f6`](https://github.com/NixOS/nixpkgs/commit/3edc23f6a074d4e705d9aa080dd1538e4f116b72) appium-inspector: 2024.12.1 -> 2025.3.1
* [`de76a1e8`](https://github.com/NixOS/nixpkgs/commit/de76a1e8524a2ace49db66776fdfae16bcf80108) nixosTests.miriway: Migrate to runTest
* [`5d371953`](https://github.com/NixOS/nixpkgs/commit/5d371953decf919356ef36edf54ea3edaf4c67ae) nixosTests.morph-browser: Migrate to runTest
* [`a210b5ec`](https://github.com/NixOS/nixpkgs/commit/a210b5eca3b8ac9567f44aca810e5acf7fde579f) ayatana-indicator-display: 24.5.0 -> 24.5.1
* [`4f0189e1`](https://github.com/NixOS/nixpkgs/commit/4f0189e1a82c7bc7276d88d6ffcd1b5d405efdbd) fetchFromSavannah: support repos like emacs/elpa
* [`e1b123c3`](https://github.com/NixOS/nixpkgs/commit/e1b123c3043da984e1082233b6db005742599590) miracle-wm: 0.4.1 -> 0.5.1
* [`e0330e0c`](https://github.com/NixOS/nixpkgs/commit/e0330e0c6a896c2d850f70c6466b543cf22383eb) coltrane: 4.1.1 -> 4.1.2
* [`24b2d780`](https://github.com/NixOS/nixpkgs/commit/24b2d78030d2b6d3dcd3be74083556a65bb70e22) readest: 0.9.23 -> 0.9.25
* [`f4511fd7`](https://github.com/NixOS/nixpkgs/commit/f4511fd7e480ee9faaed8b0f32fd8e303fef1860) supercollider: 3.13.0 -> 3.13.1
* [`2ce12b1d`](https://github.com/NixOS/nixpkgs/commit/2ce12b1d2b0261e32f9dae9fb923f9136f912dc0) glances: 4.3.0.8 -> 4.3.1
* [`db687471`](https://github.com/NixOS/nixpkgs/commit/db6874713affebd5a7a0e932b05c9c8453c97985) crocoddyl: 3.0.0 -> 3.0.1
* [`d2be7570`](https://github.com/NixOS/nixpkgs/commit/d2be7570107f52e3df69d4821431a3b9f0d09e93) crocoddyl: clean
* [`2bb7f46e`](https://github.com/NixOS/nixpkgs/commit/2bb7f46e4b2a188bf93a5cc2e996c20c8e753653) aligator: 0.8.0 -> 0.11.0
* [`cfb5aba5`](https://github.com/NixOS/nixpkgs/commit/cfb5aba5208d8174b8f377f9cd6175d07525deca) aligator: silence MPL warnings
* [`be2e9ac6`](https://github.com/NixOS/nixpkgs/commit/be2e9ac6b2439ee145d993d118fd44ef565177b4) aligator: clean
* [`bd38eda8`](https://github.com/NixOS/nixpkgs/commit/bd38eda8d89daab5c8735fd9e2dcb555cc198626) apvlv: 0.5.0 -> 0.6.0
* [`6d0969e8`](https://github.com/NixOS/nixpkgs/commit/6d0969e84d07d4b124abe52205522fba00919fb7) xeus: 3.2.0 -> 5.2.0 ([nixos/nixpkgs⁠#385730](https://togithub.com/nixos/nixpkgs/issues/385730))
* [`fed21c07`](https://github.com/NixOS/nixpkgs/commit/fed21c07b93bc833e264bca1106da9fe9fb67b44) pocketbase: 0.25.9 -> 0.26.3
* [`e8598f84`](https://github.com/NixOS/nixpkgs/commit/e8598f846c64edffebb995a090720124da95361b) remove xeus-zmq reference to xeus 3.2.0
* [`85a6974d`](https://github.com/NixOS/nixpkgs/commit/85a6974d6e3568d131386384da880b3433caed07) python312Packages.rq: 2.1 -> 2.2
* [`c8f80813`](https://github.com/NixOS/nixpkgs/commit/c8f80813975cc1f02c4704e4858a81d02903e88a) lightburn: Migrate to by-name
* [`9b5f2fec`](https://github.com/NixOS/nixpkgs/commit/9b5f2fec893ad8769680d3a77dec83c3a14c4bdf) nitter: 0-unstable-2024-02-26 -> 0-unstable-2025-02-25
* [`b6ba4a49`](https://github.com/NixOS/nixpkgs/commit/b6ba4a499c5ecdbacefbbfb265427e059ed15323) nixos/nitter: rename guestAccounts to sessionsFile
* [`7c9a73fc`](https://github.com/NixOS/nixpkgs/commit/7c9a73fc2393ff3d6d1450972dcdcbf5df2612e3) electron_33-bin: 33.4.5 -> 33.4.6
* [`69d7e249`](https://github.com/NixOS/nixpkgs/commit/69d7e249ebae757f69b0de76152abbadb579d563) electron-chromedriver_33: 33.4.5 -> 33.4.6
* [`64137d69`](https://github.com/NixOS/nixpkgs/commit/64137d69fb6d0921d41396420f34f932ab12221d) electron_34-bin: 34.3.3 -> 34.3.4
* [`eb059ed1`](https://github.com/NixOS/nixpkgs/commit/eb059ed15933561d08ce9856fa3c85e2e3fa59bf) electron-chromedriver_34: 34.3.3 -> 34.3.4
* [`07701af1`](https://github.com/NixOS/nixpkgs/commit/07701af1c599b1834f65f1229b2ecb2dfcf6b09b) electron-source.electron_33: 33.4.5 -> 33.4.6
* [`869af4cb`](https://github.com/NixOS/nixpkgs/commit/869af4cb85f812d034df0f46d6d23aed2bbb0d09) electron-source.electron_34: 34.3.3 -> 34.3.4
* [`d92003b5`](https://github.com/NixOS/nixpkgs/commit/d92003b5c8762861816a551a30a64d1586403596) klayout: fix darwin build
* [`d3110c95`](https://github.com/NixOS/nixpkgs/commit/d3110c95325138076714de5f5d68cca388a002c4) nextcloud: update maintainer information
* [`773094b4`](https://github.com/NixOS/nixpkgs/commit/773094b49c1abd8a6927e6c6a7b5167ec1cc3cd6) nixos/nextcloud: clarify support status of apps in the manual
* [`6886eb5d`](https://github.com/NixOS/nixpkgs/commit/6886eb5d639d630fe45d68e529d3b40aa18c005a) localized: Migrate ruby binaries from system tools
* [`d99a9f82`](https://github.com/NixOS/nixpkgs/commit/d99a9f820bfc2db2a2240a7a3d07f4a18f6d7b26) python312Packages.ansible-core: 2.18.3 -> 2.18.4
* [`e70f438c`](https://github.com/NixOS/nixpkgs/commit/e70f438ce917585c9c84d78f3a66fad87d416190) python312Packages.logbook: 1.8.0 -> 1.8.1
* [`b45da3b2`](https://github.com/NixOS/nixpkgs/commit/b45da3b2efdbee18f3c962b589dba9e0da79cd2d) python3Packages.proton-vpn-api-core: 0.39.0 -> 0.42.3
* [`6128c988`](https://github.com/NixOS/nixpkgs/commit/6128c988fd15465b0b84f0e1912e27549ff63ab1) python3Packages.proton-vpn-network-manager: 0.10.2 -> 0.12.13
* [`a606c665`](https://github.com/NixOS/nixpkgs/commit/a606c6659d0df810ecb8ea625c271ee77248c541) proton-vpn-local-agent: 1.2.0 -> 1.4.4
* [`99ceb335`](https://github.com/NixOS/nixpkgs/commit/99ceb335d0d661a6b2346d49a224683e1d52c29b) protonvpn-gui: 4.8.2 -> 4.9.5
* [`c850d1c4`](https://github.com/NixOS/nixpkgs/commit/c850d1c436fd584b91093b6c4be1897192a2d2b4) prowlarr: 1.31.2.4975 -> 1.32.2.4987
* [`9794620a`](https://github.com/NixOS/nixpkgs/commit/9794620a5dd2e6663c1c370aea367ce3defa9c27) aider-chat: add optional dependencies for help and browser
* [`fca13125`](https://github.com/NixOS/nixpkgs/commit/fca131252727c44b34f6b171e718f1b357dda05c) python3Packages.aider-chat: add optional dependencies
* [`6aecf054`](https://github.com/NixOS/nixpkgs/commit/6aecf054f184bc3ad5285dc9a3a2ee823c3e5e7f) firefox-devedition-bin-unwrapped: 137.0b6 -> 137.0b10
* [`b9f01612`](https://github.com/NixOS/nixpkgs/commit/b9f016123873aada469020b2508e37a39971a90d) buildPgrxExtension: enable building workspaces
* [`75030954`](https://github.com/NixOS/nixpkgs/commit/75030954102e285a6ac97bb4cb655764592e75d8) readest: 0.9.25 -> 0.9.26
* [`4171fbf3`](https://github.com/NixOS/nixpkgs/commit/4171fbf3cf4367771e656f3804d7e50a167b7a4e) airbuddy: 2.7.1 -> 2.7.3
* [`1c5ec481`](https://github.com/NixOS/nixpkgs/commit/1c5ec4812faf9198d03c94c138fd9caf582504d8) airgeddon: 11.11 -> 11.41
* [`a05ff553`](https://github.com/NixOS/nixpkgs/commit/a05ff553100caf217464d11de4c5f709c7f00d15) c-blosc2: 2.17.0 -> 2.17.1
* [`864a9838`](https://github.com/NixOS/nixpkgs/commit/864a983826853662d645c7135d3b7418c20bbb5d) readest: use finalAttrs
* [`dbc61bb1`](https://github.com/NixOS/nixpkgs/commit/dbc61bb109b9e6af4fbbffbe3d6501285009e6a4) eglexternalplatform: 1.2 -> 1.2.1
* [`b854c64f`](https://github.com/NixOS/nixpkgs/commit/b854c64f41d3c07a3c2fafde01c5cd1d65ad306a) discordchatexporter-desktop: 2.44 -> 2.44.2
* [`d403dc52`](https://github.com/NixOS/nixpkgs/commit/d403dc529545a8803598a53db820692ea0c7e954) bloomeetunes: 2.11.3 -> 2.11.4
* [`8aedff85`](https://github.com/NixOS/nixpkgs/commit/8aedff852a453bd1d61cebe20ad9ec76bd5be8cd) postgresqlPackages.pgvectorscale: init at 0.7.0
* [`f27be6ea`](https://github.com/NixOS/nixpkgs/commit/f27be6eaa73d1d006cb640604cd58e04edfd1262) gnupg: move env vars to `env.`
* [`e0f8ea6c`](https://github.com/NixOS/nixpkgs/commit/e0f8ea6cf74f64db3f44a96e06ffca2186df84c7) bun: 1.2.5 -> 1.2.7
* [`a8e93da8`](https://github.com/NixOS/nixpkgs/commit/a8e93da89272cc939dc1a729d36f5d49fe7cc122) basedpyright: 1.28.2 -> 1.28.4
* [`844973ce`](https://github.com/NixOS/nixpkgs/commit/844973ceede1f9383f85f0b8cc1a75d834fe46c2) python313Packages.python-iso639: init at 2025.2.18
* [`30220187`](https://github.com/NixOS/nixpkgs/commit/3022018782b256349c80fe97fe5b7403a76e8e71) python313Packages.python-oxmsg: init at 0.0.2
* [`8479c7ea`](https://github.com/NixOS/nixpkgs/commit/8479c7eaa1242eaf60a2f02ad236063c36c10a0c) python313Packages.typing-inspection: init at 0.4.0
* [`f70c1830`](https://github.com/NixOS/nixpkgs/commit/f70c18307d83adfc9cf10f7ccc454ef029660bf4) python313Packages.unstructured-client: init at 0.31.5
* [`5da7dac8`](https://github.com/NixOS/nixpkgs/commit/5da7dac8b61a073d8009d2b95d36c8675b2f0310) python313Packages.unstructured: 0.16.15 -> 0.17.2
* [`b7569d37`](https://github.com/NixOS/nixpkgs/commit/b7569d37690e0c77d5ef2d03d65c53cda940d5f9) aligator: 0.11.0 -> 0.12.0
* [`e9d89ed0`](https://github.com/NixOS/nixpkgs/commit/e9d89ed0eb437200cbae2c868b04a900b8365235) localized: Migrate ruby admin tools to by-name
* [`fefeed98`](https://github.com/NixOS/nixpkgs/commit/fefeed987af810fd92a8cb3463647411aaf57be4) python3Packages.aider-chat: made withOptional a function with parameters
* [`b54f01f1`](https://github.com/NixOS/nixpkgs/commit/b54f01f1c069ad8f070e552ca00778c0a1a99aff) python3Packages.aider-chat: add bedrock optional dependencies
* [`f27ec3a0`](https://github.com/NixOS/nixpkgs/commit/f27ec3a00d953eaf96c5ecdcd64bc30c44a20315) awscli2: 2.24.24 -> 2.25.5
* [`d4bb8086`](https://github.com/NixOS/nixpkgs/commit/d4bb808685152004781deeb8c14990d534838f38) ladybird: 0-unstable-2025-03-16 -> 0-unstable-2025-03-27
* [`5aafddf8`](https://github.com/NixOS/nixpkgs/commit/5aafddf82d42bb73499060a72f9846708472571a) ticktick: 6.0.21 -> 6.0.30
* [`06326a0d`](https://github.com/NixOS/nixpkgs/commit/06326a0d57ee75bfa0c78c03080f42de9f118e4a) python312Packages.angr: fix optional dependencies
* [`034f2b85`](https://github.com/NixOS/nixpkgs/commit/034f2b8501d6d90c085ca70fb1206b366586f754) chawan: 0-unstable-2025-01-06 -> 0-unstable-2025-03-27
* [`3fb64a07`](https://github.com/NixOS/nixpkgs/commit/3fb64a07b8c7dc6a10a762d66f4faee311b0c6c1) python3Packages.datasets: 3.4.1 -> 3.5.0
* [`ac2a5fa8`](https://github.com/NixOS/nixpkgs/commit/ac2a5fa8f51f9a28277de050512ad926ca3a6f82) grafana: 11.5.2 -> 11.6.0
* [`ffafad5c`](https://github.com/NixOS/nixpkgs/commit/ffafad5cc343e2aadafe21bb622d197d958cdc8d) python3Packages.mcp: 1.3.0 -> 1.5.0
* [`b6f322c4`](https://github.com/NixOS/nixpkgs/commit/b6f322c419adff44ddfb4cb859356a47012937ad) scala: 3.3.4 -> 3.3.5
* [`112e7ced`](https://github.com/NixOS/nixpkgs/commit/112e7ced337482a97838c0f5b1ce046656fbe298) scala-next: 3.6.3 -> 3.6.4
* [`2d9de404`](https://github.com/NixOS/nixpkgs/commit/2d9de404decaf9e54b1601f5771cea8d54909e02) flint3: 3.1.2 -> 3.2.1
* [`71d746b1`](https://github.com/NixOS/nixpkgs/commit/71d746b1fd825ff35ac1b6f17abbe37d900df887) nixosTests.emacs-daemon: migrate to runTest
* [`21954cf0`](https://github.com/NixOS/nixpkgs/commit/21954cf09b63698212cbd73dd05c5e90e1e3395b) nextcloud-news-updater: remove, unmaintained
* [`9c954c60`](https://github.com/NixOS/nixpkgs/commit/9c954c604fe66acbb1b3f8f435514bff66e6bd7e) gprbuild: add compiler configuration for aarch64-unknown-linux-gnu
* [`5f7505bb`](https://github.com/NixOS/nixpkgs/commit/5f7505bb23f6089f359979baa4bb1e520139f925) gnatprove: mute warnings about type conversion for aarch64
* [`9d7c1491`](https://github.com/NixOS/nixpkgs/commit/9d7c1491c72868101b8805f54d8891597677f867) yarn-berry: 4.7.0 -> 4.8.0
* [`ba2b22f3`](https://github.com/NixOS/nixpkgs/commit/ba2b22f3095c0a3b95a184f798da48c6fb8709ba) python313Packages.libcst: 1.6.0 -> 1.7.0
* [`e0bdbdf5`](https://github.com/NixOS/nixpkgs/commit/e0bdbdf54f2c2757cccee1eeed5fecd81c045d17) adminer: 5.0.5 -> 5.1.0
* [`a217d0f0`](https://github.com/NixOS/nixpkgs/commit/a217d0f0158b691673fc0d88bce747b5d222b79f) readest: 0.9.26 -> 0.9.27
* [`682dc6e1`](https://github.com/NixOS/nixpkgs/commit/682dc6e1a37c5c07a8fbca109209acbd3aacd3ca) readest: add eljamm as maintainer
* [`991f6229`](https://github.com/NixOS/nixpkgs/commit/991f6229ad785c57ea05e0717bd29e60e05060ef) waybackurls: init at 0.1.0
* [`47f7b963`](https://github.com/NixOS/nixpkgs/commit/47f7b963773f55e92eb1aeda6d22ecb4be1bdfdb) maintainers: Add provokateurin
* [`4714f769`](https://github.com/NixOS/nixpkgs/commit/4714f769cdce02edd619fec4855e8a3ba859687f) maintainers: Add provokateurin to nextcloud team
* [`cbd704ca`](https://github.com/NixOS/nixpkgs/commit/cbd704ca1c88bfe456e8e320b18d163320a98f33) libpsm2: mark musl as broken
* [`98e0716e`](https://github.com/NixOS/nixpkgs/commit/98e0716ed47722e33c0b48034b849f20e57bef2f) starsector: 0.97a-RC11 -> 0.98a-RC5
* [`d0cb1cb0`](https://github.com/NixOS/nixpkgs/commit/d0cb1cb0aa1659b440288c6cad68ec85b9ee1c84) xfce.xfce4-session: 4.20.0 -> 4.20.2
* [`a8452ed1`](https://github.com/NixOS/nixpkgs/commit/a8452ed16a73062561f60a88f20e279fe2f60d24) oci-cli: 3.53.0 -> 3.54.0
* [`83f156b6`](https://github.com/NixOS/nixpkgs/commit/83f156b6e1f8672777f03693428d22d904168954) readest: 0.9.27 -> 0.9.28
* [`97d01f5c`](https://github.com/NixOS/nixpkgs/commit/97d01f5cc533c865f37faeef6ab2636d5e679e68) grun: drop
* [`3d1aab41`](https://github.com/NixOS/nixpkgs/commit/3d1aab41f78b210b7ffa6bc60779e6ded6f272dd) cyclone: unbreak on GCC 14
* [`31b8468a`](https://github.com/NixOS/nixpkgs/commit/31b8468afb6f312aa221a5f05aba7cc4bbd604e9) networkmanager_strongswan: 1.6.1 -> 1.6.2
* [`1a176f76`](https://github.com/NixOS/nixpkgs/commit/1a176f76e3438c1d74663da9c314d28abbdfb04e) mise: 2025.3.6 -> 2025.3.11
* [`49b4c01f`](https://github.com/NixOS/nixpkgs/commit/49b4c01f5ef422fb8f3290819abc2cfc772102bb) poetry: 2.1.1 -> 2.1.2
* [`3e2faf72`](https://github.com/NixOS/nixpkgs/commit/3e2faf724a0cb2de395db02ce5660c912cced219) python312Packages.yara-x: add module to top-level/python-packages.nix
* [`a6c74872`](https://github.com/NixOS/nixpkgs/commit/a6c74872117de18c2a2d2ae502828065b274ea79) python313Packages.py-dactyl: init at 2.0.5
* [`06be7f5d`](https://github.com/NixOS/nixpkgs/commit/06be7f5d43e6240d25c5815dac06cb08b71208b8) auth0-cli: 1.9.2 -> 1.10.1
* [`c28df727`](https://github.com/NixOS/nixpkgs/commit/c28df727e7139ef0d308cd55b5a63a6cbd4baeb4) casadi: 3.6.7 -> 3.7.0
* [`cb3c84ac`](https://github.com/NixOS/nixpkgs/commit/cb3c84acd1d1b96aab5d5df3d428f89e4351d636) aws-nuke: 3.48.2 -> 3.51.0
* [`7b044daa`](https://github.com/NixOS/nixpkgs/commit/7b044daaf13f047d659e45b3db0817a4a1ada419) spider: 2.34.2 -> 2.36.2
* [`0113cbea`](https://github.com/NixOS/nixpkgs/commit/0113cbea686d6a452251ece085f0c19c98617222) spring-boot-cli: 3.4.3 -> 3.4.4
* [`b92da6e7`](https://github.com/NixOS/nixpkgs/commit/b92da6e77d84fa7c9af02232848822cf0e7c591e) coroot: 1.9.0 -> 1.9.9
* [`064432a5`](https://github.com/NixOS/nixpkgs/commit/064432a51969b027ba80e7daf50ef7f5fbd1858e) nixos/postgrest: init module
* [`428cb0a2`](https://github.com/NixOS/nixpkgs/commit/428cb0a2add2970fe82c1dc7f88fbdaab687b9e6) prometheus-mongodb-exporter: 0.43.1 -> 0.44.0
* [`e59b02bf`](https://github.com/NixOS/nixpkgs/commit/e59b02bfd901ad1b73f3117d612b52bfe577b601) redis-plus-plus: 1.3.13 -> 1.3.14
* [`af7bf784`](https://github.com/NixOS/nixpkgs/commit/af7bf784d754a1b3d00b617638f92c7453e7e7d6) stu: 0.7.0 -> 0.7.1
* [`c19c725b`](https://github.com/NixOS/nixpkgs/commit/c19c725b49b88b4c621caf0e2feb94db97d8d4da) revive: 1.7.0 -> 1.8.0
* [`7f5dd033`](https://github.com/NixOS/nixpkgs/commit/7f5dd0333c18b1183dc71c89a1b0fc1858d5ad15) nestopia-ue: 1.53.0 -> 1.53.1
* [`8fb8f5f8`](https://github.com/NixOS/nixpkgs/commit/8fb8f5f80afadc2002c707c29b9e0e5eb7855160) checkstyle: 10.21.4 -> 10.22.0
* [`997f3373`](https://github.com/NixOS/nixpkgs/commit/997f337362722b9db747e03bf60a6217426c0790) python313Packages.awsiotsdk: patch in correct version string
* [`c27c394c`](https://github.com/NixOS/nixpkgs/commit/c27c394cc6f4f15b7cf0dbd8e381ce525c9f63a3) python312Packages.llm-gemini: 0.15 -> 0.16
* [`f0e8243a`](https://github.com/NixOS/nixpkgs/commit/f0e8243ab5494e27ba4f71ff3779df0e291012ca) bibiman: 0.11.0 -> 0.11.4
* [`dff38268`](https://github.com/NixOS/nixpkgs/commit/dff382687c5a9e0a159dc40454d665ba2eaf8ce5) sunxi-tools: 0-unstable-2025-03-07 -> 0-unstable-2025-03-29
* [`ce06e43a`](https://github.com/NixOS/nixpkgs/commit/ce06e43af897e55d538c5e2c36c5cec8991cff1e) gitleaks: re-enable checks
* [`164be9bf`](https://github.com/NixOS/nixpkgs/commit/164be9bf39831cc9da2882e9f9c4fbd20ab0b5cb) bazelisk: doCheck = true
* [`364dbc6c`](https://github.com/NixOS/nixpkgs/commit/364dbc6c3d6df74da778f4649828255878da4259) python312Packages.pyinstaller-hooks-contrib: 2025.1 -> 2025.2
* [`c9ab0163`](https://github.com/NixOS/nixpkgs/commit/c9ab0163efe7a12bbfcf9f95f113f58f7ac1b16e) nimlangserver: 1.10.0 -> 1.10.2
* [`c731506a`](https://github.com/NixOS/nixpkgs/commit/c731506a91453ebd0bdcb9f895f76b4ec8780821) python312Packages.aiohomekit: 3.2.8 -> 3.2.13
* [`920a9248`](https://github.com/NixOS/nixpkgs/commit/920a9248cb17604fb52d1c761592f567b655f4bc) python312Packages.databricks-sdk: 0.46.0 -> 0.49.0
* [`fcc78f1c`](https://github.com/NixOS/nixpkgs/commit/fcc78f1c764d6a4d27ebca9bca800acf4027be1f) python312Packages.gmpy2: 2.2.0a2 -> 2.2.1
* [`62d6056a`](https://github.com/NixOS/nixpkgs/commit/62d6056ad4c63e07fc1500c3c6a17872f62dfcb8) broot: 1.45.0 -> 1.45.1
* [`e88a6d52`](https://github.com/NixOS/nixpkgs/commit/e88a6d52006c5c99a42261886bd2966fcf57d6ac) tailscale: 1.80.3 -> 1.82.0
* [`da8f1782`](https://github.com/NixOS/nixpkgs/commit/da8f1782c18c3bccdb88639c6245e315d51dfafe) tailscale-gitops-pusher: switch to Go 1.24
* [`f95b89b9`](https://github.com/NixOS/nixpkgs/commit/f95b89b987240e56aa5924e3ea3fe8841b5295e3) electron_33-bin: 33.4.6 -> 33.4.8
* [`b7e6e270`](https://github.com/NixOS/nixpkgs/commit/b7e6e2700eb01381019c181fc5e100d40b1fa789) electron-chromedriver_33: 33.4.6 -> 33.4.8
* [`bf664fe5`](https://github.com/NixOS/nixpkgs/commit/bf664fe5289e18450e8cded3e357f0287f5c02f1) electron_34-bin: 34.3.4 -> 34.4.1
* [`44ad692a`](https://github.com/NixOS/nixpkgs/commit/44ad692ad9a47ad53b8b930a54550557d62a74cd) electron-chromedriver_34: 34.3.4 -> 34.4.1
* [`3f0ca819`](https://github.com/NixOS/nixpkgs/commit/3f0ca819d31e6606830baf7fd6a12b595171401f) electron_35-bin: 35.0.3 -> 35.1.2
* [`f0c56ee7`](https://github.com/NixOS/nixpkgs/commit/f0c56ee777476318668bdc5f4821c730aed3893a) electron-chromedriver_35: 35.0.3 -> 35.1.2
* [`0675251e`](https://github.com/NixOS/nixpkgs/commit/0675251e31153936850a4fa14e0d864ead39b227) electron-source.electron_33: 33.4.6 -> 33.4.8
* [`06e31c5c`](https://github.com/NixOS/nixpkgs/commit/06e31c5c89452e6190b5716bfc962432297b85b4) electron-source.electron_34: 34.3.4 -> 34.4.1
* [`2ca5fa4a`](https://github.com/NixOS/nixpkgs/commit/2ca5fa4a3f3d968fad0149759cb55cd690dda775) electron-source.electron_35: 35.0.3 -> 35.1.2
* [`3cc9dc7a`](https://github.com/NixOS/nixpkgs/commit/3cc9dc7af78bc77a44a818e61bc0b9718111cc92) nwg-clipman: 0.2.4 -> 0.2.5
* [`8d51b192`](https://github.com/NixOS/nixpkgs/commit/8d51b1920321bcef5e5cc18bedc2d3932a93f1dd) python3Packages.nanobind: 2.5.0 -> 2.6.1
* [`aa21f748`](https://github.com/NixOS/nixpkgs/commit/aa21f748d5ad6414b963723acdf3e7e8d997f73a) go-crx3: 1.5.1 -> 1.6.0
* [`0f3235e9`](https://github.com/NixOS/nixpkgs/commit/0f3235e9a57b30795bb8ee5760bb67fc70809bd8) go-crx3: add versionCheckHook
* [`23778922`](https://github.com/NixOS/nixpkgs/commit/237789220e3a787bf86b355ac66adeb622b8cd63) cargo-lambda: 1.8.0 -> 1.8.1
* [`f5bc547d`](https://github.com/NixOS/nixpkgs/commit/f5bc547d296ca190e3480b3b6d38d3f9d8b473a9) offrss: unbreak GCC 14, modernize
* [`ae713673`](https://github.com/NixOS/nixpkgs/commit/ae7136730a99b6ca538228b1b10c480117fa591b) roslyn-ls: 4.14.0-3.25156.1 -> 4.14.0-3.25164.3
* [`26c884c0`](https://github.com/NixOS/nixpkgs/commit/26c884c02cdbde31b08b28ab621656b9f50236d0) python313Packages.lnkparse3: 1.5.0 -> 1.5.1
* [`0e2752f6`](https://github.com/NixOS/nixpkgs/commit/0e2752f61577d32aac10390585a68018c33e6b5e) python313Packages.mcpadapt: 0.0.16 -> 0.0.18
* [`20dd18b4`](https://github.com/NixOS/nixpkgs/commit/20dd18b4a6401d292777dcf366105681633a3fd3) python313Packages.pyexploitdb: 0.2.73 -> 0.2.74
* [`252be5e0`](https://github.com/NixOS/nixpkgs/commit/252be5e0776b104df05e8b4e1e05f58db8fcf3e7) python313Packages.xiaomi-ble: 0.33.0 -> 0.35.0
* [`e9cea0ad`](https://github.com/NixOS/nixpkgs/commit/e9cea0adf3d4f607d8887518e50269f3dce1ca5b) python313Packages.httpx-ws: 0.7.1 -> 0.7.2
* [`d6dab712`](https://github.com/NixOS/nixpkgs/commit/d6dab712e4c50c24481dbed444b7198452a1ed72) sops: 3.9.4 -> 3.10.0
* [`8589ad47`](https://github.com/NixOS/nixpkgs/commit/8589ad4714f731a6c36e67491dca821683afb830) perlPackages.TAPParserSourceHandlerpgTAP: 3.36 -> 3.37
* [`05570069`](https://github.com/NixOS/nixpkgs/commit/0557006956ff00498f118ebcd8d86dbfe1977337) home-manager: 0-unstable-2025-03-18 -> 0-unstable-2025-03-30
* [`347e71e3`](https://github.com/NixOS/nixpkgs/commit/347e71e3e444118a03bb9662fe98514123cd680a) lakectl: 1.53.0 -> 1.53.1
* [`30409918`](https://github.com/NixOS/nixpkgs/commit/30409918667afca754971e04a4adb0ce90bf0c99) fdupes: 2.3.2 -> 2.4.0
* [`1791347c`](https://github.com/NixOS/nixpkgs/commit/1791347c19a1c5277fc7a466fb07cb0fc2850529) python3Packages.langchain*: fix bulk update script
* [`c67e313c`](https://github.com/NixOS/nixpkgs/commit/c67e313cd82cadd77b1220a84abca3cc905e033d) matrix-sdk-crypto-nodejs: use fetchCargoVendor
* [`fc298fad`](https://github.com/NixOS/nixpkgs/commit/fc298fadd1a58012a78f50fef86ce533e82710f5) esbuild: 0.25.1 -> 0.25.2
* [`fd0345db`](https://github.com/NixOS/nixpkgs/commit/fd0345dbb64e24f3a4da03c9502f9389d8bdc6a2) narsil: 7c20b01e055491e86a44201504e8d36873ef1822 -> af7c8c1b33ed0f331710c8ac3ad4a63ad37faacc
* [`0dcb1d02`](https://github.com/NixOS/nixpkgs/commit/0dcb1d02c371c7a6642c6d4096ce0a8b0aeacfd0) narsil: fix version
* [`e69411fb`](https://github.com/NixOS/nixpkgs/commit/e69411fb2b07caf78b43fdac9e77b114b63a0aeb) vscode-extensions-update: improve
* [`da9d6f32`](https://github.com/NixOS/nixpkgs/commit/da9d6f32406ffc452c5c2adbf89e6ad9d50e9a0e) oneDNN: 3.7 -> 3.7.2
* [`74a4a305`](https://github.com/NixOS/nixpkgs/commit/74a4a3058cb6c5279a771349f4a2e71f4b192678) one_gadget: Migrate to by-name
* [`493f1e3b`](https://github.com/NixOS/nixpkgs/commit/493f1e3b8be80df5ecd1ee4566de63ca352af73f) nixVersions.nix_2_26: Improve docs
* [`e1b8acf7`](https://github.com/NixOS/nixpkgs/commit/e1b8acf7ca9c56164dfe6f22dbdc2f81c801c50f) change replace to replace-fail
* [`d74838df`](https://github.com/NixOS/nixpkgs/commit/d74838df79a28007d34bc0c84beeecf78d864687) nixVersions.nix_2_26: Add .overrideScope
* [`bb984408`](https://github.com/NixOS/nixpkgs/commit/bb984408d5c640d4b1eb9f5cc6cbfa500b96a798) lib/tests/release.nix: Use nix.overrideScope for >=2.26
* [`09176212`](https://github.com/NixOS/nixpkgs/commit/09176212819e062d20d011aeb8799df89ba57f4d) vscode-extensions.visualjj.visualjj: add update script
* [`05a397d3`](https://github.com/NixOS/nixpkgs/commit/05a397d3ef53ad5b686d784b2ea9d19addceff78) vscode-extensions.visualjj.visualjj: 0.13.6 -> 0.14.1
* [`8595ce3e`](https://github.com/NixOS/nixpkgs/commit/8595ce3ed671887b6ef9e883afe8e1299a4d834c) compiledb: 0.10.1 -> 0.10.7
* [`593aaf96`](https://github.com/NixOS/nixpkgs/commit/593aaf96ced4a7a501ea4d75833b9e9a30bf7a27) vscode-extensions.charliermarsh.ruff: add update script
* [`fbb72fba`](https://github.com/NixOS/nixpkgs/commit/fbb72fba9868c57232e5fd65fcbf08e3260e297c) vscode-extensions.charliermarsh.ruff: 2025.14.0 -> 2025.22.0
* [`123e789d`](https://github.com/NixOS/nixpkgs/commit/123e789d815155f68459e8bac1958afd3d9414c2) python3Packages.langchain-text-splitters: 0.3.6 -> 0.3.7
* [`ed61cea3`](https://github.com/NixOS/nixpkgs/commit/ed61cea3d9b8d03e552c5cc14ae207bbf402cbbc) python3Packages.langchain-community: 0.3.19 -> 0.3.20
* [`dd676362`](https://github.com/NixOS/nixpkgs/commit/dd676362e406f297c9af6c55606a81a20e2e0ac8) python3Packages.langchain-core: 0.3.47 -> 0.3.49
* [`c241ec44`](https://github.com/NixOS/nixpkgs/commit/c241ec4456e6081b6d7e449fe83b3287146a7457)  python3Packages.langchain-ollama: 0.2.3 -> 0.3.0
* [`9b0a483d`](https://github.com/NixOS/nixpkgs/commit/9b0a483d0e29469768075af19a27c740ed873332) python3Packages.langchain-openai: 0.3.8 -> 0.3.11
* [`6076c385`](https://github.com/NixOS/nixpkgs/commit/6076c38569d245ac9291c74359952bb4f89f36ca) python3Packages.langchain-tests: 0.3.13 -> 0.3.17
* [`2e07c7e2`](https://github.com/NixOS/nixpkgs/commit/2e07c7e2f64047feccce7f3625f31e52092a0b0d) vscode-extensions.anweber.vscode-httpyac: 6.16.6 -> 6.16.7
* [`7b7629e5`](https://github.com/NixOS/nixpkgs/commit/7b7629e5a67d886b8c3c382542e20ee69a3bc7ec) triforce-lv2: 0.2.0 -> 0.2.1
* [`e92837b0`](https://github.com/NixOS/nixpkgs/commit/e92837b03d26c3d661b97825d296c5ca86489c99) feather: 2.7.0 -> 2.8.0
* [`6154ce8b`](https://github.com/NixOS/nixpkgs/commit/6154ce8bddd30621744ed8bbbd4ae32afb859cc8) qpwgraph: 0.8.2 -> 0.8.3
* [`0d509da6`](https://github.com/NixOS/nixpkgs/commit/0d509da698769ba2e7038a8a3fe2e3dcc16c044d) dnscontrol: 4.17.0 -> 4.18.0
* [`21af19fa`](https://github.com/NixOS/nixpkgs/commit/21af19fa5cbf04784303c65a688ce665c9a39e6f) pplite: fix build with flint 3.2
* [`16cce3c3`](https://github.com/NixOS/nixpkgs/commit/16cce3c39c0151682a246b2773a4ee78bc10d357) python313Packages.nhc: 0.4.11 -> 0.4.12
* [`06725c14`](https://github.com/NixOS/nixpkgs/commit/06725c1404def10e827196d1429c45d48bbd5f93) python313Packages.ical: 9.0.2 -> 9.0.3
* [`c5efe798`](https://github.com/NixOS/nixpkgs/commit/c5efe798bc669169236f248e095ee2f91cafa1ed) python313Packages.pyisy: 3.1.14 -> 3.4.0
* [`b6420c7b`](https://github.com/NixOS/nixpkgs/commit/b6420c7bca86997ad66218dcf4fb902efc7ac4f6) gitignore: ignore worktrees
* [`fcc73ad6`](https://github.com/NixOS/nixpkgs/commit/fcc73ad69eb7803633712dd616c5c218f13dccbd) lunatask: 2.0.18 -> 2.0.19
* [`c7da4e2b`](https://github.com/NixOS/nixpkgs/commit/c7da4e2b54a4d789a11af397604ad73fea8a986d) pgroll: 0.8.0 -> 0.10.0
* [`ed2073bf`](https://github.com/NixOS/nixpkgs/commit/ed2073bf6a7b5355f41d31e23e4c92be9a72aec0) python312Packages.mplhep: 0.3.58 -> 0.3.59 ([nixos/nixpkgs⁠#394370](https://togithub.com/nixos/nixpkgs/issues/394370))
* [`58889e17`](https://github.com/NixOS/nixpkgs/commit/58889e17f519ba789e1096eac8afcf73085c1265) mame: 0.275 -> 0.276
* [`c3edb5c0`](https://github.com/NixOS/nixpkgs/commit/c3edb5c06574df697088b8bbc7f3d6bc36ba10b8) python312Packages.scancode-toolkit: 32.3.1 -> 32.3.3
* [`0dbddf81`](https://github.com/NixOS/nixpkgs/commit/0dbddf816a6959442a5314f8654edac721761545) nixosTests.fail2ban: migrate to runTest
* [`cd6f6791`](https://github.com/NixOS/nixpkgs/commit/cd6f6791e94d08b983fe6d127ec6942176737f6a) nixosTests.fail2ban: extend test coverage
* [`eb74e7f1`](https://github.com/NixOS/nixpkgs/commit/eb74e7f1a6eb4ac8dfc80cdee52448dbed8d3a94) obs-studio: 31.0.2 -> 31.0.3
* [`db1bd4fc`](https://github.com/NixOS/nixpkgs/commit/db1bd4fcfee22920e13ac73513fb3c3796b202cb) terraform-providers.spotinst: 1.213.1 -> 1.216.0
* [`9547dfd9`](https://github.com/NixOS/nixpkgs/commit/9547dfd9310f28537804fa53e33555e29ed4f408) golangci-lint: 2.0.0 -> 2.0.2
* [`9980ac66`](https://github.com/NixOS/nixpkgs/commit/9980ac66beb46cd51a2d7e12ee90b843e7757c8d) lazysql: 0.3.6 -> 0.3.7
* [`86c7364c`](https://github.com/NixOS/nixpkgs/commit/86c7364c4cd03c632a30298dace64c898a081d54) rke: 1.8.0 -> 1.8.1
* [`b8300894`](https://github.com/NixOS/nixpkgs/commit/b8300894a946993506d56a9b2ecbfc2af2d5f2ec) ecs-agent: 1.91.1 -> 1.91.2
* [`aa4ea35c`](https://github.com/NixOS/nixpkgs/commit/aa4ea35ccbc12a408dab4831c6c61a4f39d38442) ginkgo: 2.23.1 -> 2.23.3
* [`26c6f178`](https://github.com/NixOS/nixpkgs/commit/26c6f178e1fd79570c1bdae7c00e010c717cc603) grafana-alloy: 1.7.4 -> 1.7.5
* [`49ca8bcb`](https://github.com/NixOS/nixpkgs/commit/49ca8bcb4d7637abc0318918a7f461fb7415c7b5) dsview: unbreak on GCC 14, modernize
* [`7d90b3e7`](https://github.com/NixOS/nixpkgs/commit/7d90b3e7f8133a7a5e31a361f055447e1c942a1d) mpvScripts.mpvacious: 0.38 -> 0.39
* [`087872a1`](https://github.com/NixOS/nixpkgs/commit/087872a16e04536b55ca2edbca0a239d0b7a8f11) afflib: 3.7.20 -> 3.7.21
* [`a83347b1`](https://github.com/NixOS/nixpkgs/commit/a83347b14b0bc885d945cb979f5bae6222ed5aa0) omake: 0.10.6 → 0.10.7
* [`6f6d4aa9`](https://github.com/NixOS/nixpkgs/commit/6f6d4aa9e94380232823d77ec2380d57c035433e) b3sum: 1.7.0 -> 1.8.0
* [`a6af279b`](https://github.com/NixOS/nixpkgs/commit/a6af279b61f0c77e397b57eb57fffffb48121c03) vimPlugins.hurl-nvim: init at 2025-03-04
* [`1ce315b7`](https://github.com/NixOS/nixpkgs/commit/1ce315b7dfeb8db2a41df9ebea9a488a18a58171) edl: 3.52.1-unstable-2024-10-12 -> 3.52.1-unstable-2025-03-23
* [`a9df43c4`](https://github.com/NixOS/nixpkgs/commit/a9df43c4293b355e07998bf0f24cc2b325a54883) mesa: reenable XA for now
* [`6d11b756`](https://github.com/NixOS/nixpkgs/commit/6d11b756a43adb43bc4be31a42e6ab45d7bd7697) xorg.xf86videovmware: restore Mesa/XA dependency
* [`524f7212`](https://github.com/NixOS/nixpkgs/commit/524f7212895650431bad1cb7e650f05106d3e184) obs-studio: enable browser support
* [`1237682d`](https://github.com/NixOS/nixpkgs/commit/1237682d298e430ad1730561f12e4876cb2b6781) python313Packages.tencentcloud-sdk-python: 3.0.1350 -> 3.0.1351
* [`fa0769bf`](https://github.com/NixOS/nixpkgs/commit/fa0769bf6d41fc884c1b2bfee5fb5391245d8e82) kubectl-view-secret: 0.13.0 -> 0.14.0
* [`2a981da0`](https://github.com/NixOS/nixpkgs/commit/2a981da0449038a2159411c67137cfcd1f69fbfa) libblake3: 1.7.0 -> 1.8.0
* [`ce8f18df`](https://github.com/NixOS/nixpkgs/commit/ce8f18df87d6600a65d97de15fe98a19bad170f7) mackerel-agent: 0.84.1 -> 0.84.2
* [`e000d4e4`](https://github.com/NixOS/nixpkgs/commit/e000d4e4953bb399b00cba0d2a96677febd5b1f8) terraform-providers.sumologic: 3.0.6 -> 3.0.7
* [`4117dcee`](https://github.com/NixOS/nixpkgs/commit/4117dceede40303acfc8171e88c39b63dd5a073c) Revert "tiledb: 2.18.2 -> 2.27.2"
* [`d5d9044f`](https://github.com/NixOS/nixpkgs/commit/d5d9044f0aec43813a892df93b4f6621c182596f) meld: 3.22.3 → 3.23.0
* [`3ad75749`](https://github.com/NixOS/nixpkgs/commit/3ad757495a14c036769a1c1e6fd1caeb07191726) appium-inspector: restrict platforms to linux
* [`79417864`](https://github.com/NixOS/nixpkgs/commit/79417864ec0ef7461d8beb016c1fedc799021afa) vimPlugins.nvim-origami: init at 2025-03-31
* [`5fa2e115`](https://github.com/NixOS/nixpkgs/commit/5fa2e1152ec13d8b06a4d3afeb693329cd52a142) v2raya: 2.2.6.6 -> 2.2.6.7
* [`67277b7d`](https://github.com/NixOS/nixpkgs/commit/67277b7de8cb0fbf9274eb3420a76daf9845915f) typos-lsp: 0.1.35 -> 0.1.36
* [`66917f1c`](https://github.com/NixOS/nixpkgs/commit/66917f1c8da3d34dc10e8c33e07da5cc47ae331d) yabridge: revert workaround for wine 9.5 ([nixos/nixpkgs⁠#394378](https://togithub.com/nixos/nixpkgs/issues/394378))
* [`9adf6e59`](https://github.com/NixOS/nixpkgs/commit/9adf6e599ce353a3171a6466d75d779048ab2be2) gnat-bootstrap12: restrict platforms
* [`859e0c96`](https://github.com/NixOS/nixpkgs/commit/859e0c965572c191648eb95d8f9c35239f8b1828) git-aggregator: 4.0.2 -> 4.1
* [`71a4b4bf`](https://github.com/NixOS/nixpkgs/commit/71a4b4bf223d8e448c5208b11043b37cb8c400fd) cloud-hypervisor: 44.0 -> 45.0
* [`44718e84`](https://github.com/NixOS/nixpkgs/commit/44718e84d9a1cc3afbf767907006f2b99b210b00) glab: use finalAttrs pattern and writableTmpDirAsHomeHook
* [`a04a6c76`](https://github.com/NixOS/nixpkgs/commit/a04a6c768e33bcb811e652f85a69db1aa6029beb) lxgw-neoxihei: 1.215 -> 1.216.1
* [`cd85a8a8`](https://github.com/NixOS/nixpkgs/commit/cd85a8a82762745e86e8d1f7a34bd3989ee2748e) nixos/modules: cosmic-greeter: init
* [`cd795fd3`](https://github.com/NixOS/nixpkgs/commit/cd795fd3f0a910b60cf9823284f3e99ba367301e) nixos/modules: cosmic: init
* [`2a7180b3`](https://github.com/NixOS/nixpkgs/commit/2a7180b3db2d9b98683941e8f1d14c444ce93a7a) nixos/release-notes: add release notes for COSMIC modules
* [`98ebf83b`](https://github.com/NixOS/nixpkgs/commit/98ebf83b89f18ed639381b14c14772db4714225e) terraform-providers.acme: 2.30.2 -> 2.31.0
* [`09879a45`](https://github.com/NixOS/nixpkgs/commit/09879a452b37bb07d02599a247cd22aa87b8e864) nixos/hyprland: fix call to wayland-session.nix
* [`e12690d5`](https://github.com/NixOS/nixpkgs/commit/e12690d530ed0116a54598e8ea7fcb31870d63ee) nixos/movim: Fix accidental append to module system property
* [`2107f032`](https://github.com/NixOS/nixpkgs/commit/2107f032ab4befe851cd1035d88db9dd3474689d) nixos/startx: remove graphical-session assertions
* [`b9d27a3b`](https://github.com/NixOS/nixpkgs/commit/b9d27a3bb509192e12b9618020c700d8e08977b6) kuma: 2.10.0 -> 2.10.1
* [`76ba3d47`](https://github.com/NixOS/nixpkgs/commit/76ba3d47e52c003a00934c5b56d9b2b0ad0f0d52) yggstack: 1.0.1 -> 1.0.4
* [`06298d1e`](https://github.com/NixOS/nixpkgs/commit/06298d1e344fe5a2fa5f0373036c6e631dbe6097) mint: 0.23.1 -> 0.23.2
* [`13b177e6`](https://github.com/NixOS/nixpkgs/commit/13b177e67acee32e570705441d99879b9b14c7eb) vacuum-go: 0.16.4 -> 0.16.5
* [`d5037281`](https://github.com/NixOS/nixpkgs/commit/d50372811d7a9952a60d222ca050cadc751a5c15) flutter: readd package_config.json
* [`dcf592b9`](https://github.com/NixOS/nixpkgs/commit/dcf592b94dfa92e6d228eaf8b7886d1570f689d6) gitmux: use finalAttrs pattern
* [`367ce324`](https://github.com/NixOS/nixpkgs/commit/367ce324583edb6f07c007157932eb89515d5578) python312Packages.types-psycopg2: 2.9.21.20250121 -> 2.9.21.20250318
* [`016a24e4`](https://github.com/NixOS/nixpkgs/commit/016a24e4dc5c587259c2bf76f4451241c08fa727) apptainer, singularity: deprecate workarounds for vendorHash overriding
* [`4c0841bb`](https://github.com/NixOS/nixpkgs/commit/4c0841bb6545cce071abee4b4b6ae63425b1000f) buteo-syncfw: 0.11.9 -> 0.11.10
* [`cfa994ed`](https://github.com/NixOS/nixpkgs/commit/cfa994edfb90b15fcea17c988260ec4fd83d8ea4) reposilite: 3.5.22 -> 3.5.23
* [`7489803a`](https://github.com/NixOS/nixpkgs/commit/7489803a69af827da0b40be7f7ebc4246cde320b) vimPlugins.whichpy-nvim: init at 2025-03-14
* [`7d02bb48`](https://github.com/NixOS/nixpkgs/commit/7d02bb4882d1c52694ce190c445e2cd112df85a8) databricks-cli: 0.244.0 -> 0.245.0
* [`4683fd1e`](https://github.com/NixOS/nixpkgs/commit/4683fd1edbea3bf0ea4164a594572cd205ff5131) python312Packages.ttkbootstrap: 1.10.1 -> 1.12.0
* [`66fd59e9`](https://github.com/NixOS/nixpkgs/commit/66fd59e9361f310b039e2e39b3df190bb0a976ff) python312Packages.mcdreforged: 2.14.5 -> 2.14.7
* [`87c04e7e`](https://github.com/NixOS/nixpkgs/commit/87c04e7ef977c16b07f94eda7e9c331654a1b2f2) crowdin-cli: 4.6.1 -> 4.7.0
* [`8bfabcfe`](https://github.com/NixOS/nixpkgs/commit/8bfabcfe6bf823b4dbd58b91129199762f372f18) src-cli: 6.1.0 -> 6.1.1
* [`338941f4`](https://github.com/NixOS/nixpkgs/commit/338941f4b7de811d05fb19a857d1964eb503d325) gurk-rs: 0.6.3 -> 0.6.4
* [`fedcd912`](https://github.com/NixOS/nixpkgs/commit/fedcd912c6f3b9b5f599bafea063d93ac902103a) luaPackages: update on 2025-03-31
* [`7870c120`](https://github.com/NixOS/nixpkgs/commit/7870c1206b13fa3f58841022c4dfb495ffd51a58) minijinja: 2.8.0 -> 2.9.0
* [`37e2a1bb`](https://github.com/NixOS/nixpkgs/commit/37e2a1bb11c54659d19169112cabb39f46bc0cd7) python312Packages.llama-index-llms-openai: 0.3.25 -> 0.3.29
* [`e0186c6d`](https://github.com/NixOS/nixpkgs/commit/e0186c6d5813690a6474ecf2ca57022ec8164c2d) vimPlugins.nvim-tinygit: init at 2025-03-30
* [`b69c99b3`](https://github.com/NixOS/nixpkgs/commit/b69c99b36da80f579cec7e3090545fbdb2bed974) glamoroustoolkit: 1.1.14 -> 1.1.16
* [`5664f191`](https://github.com/NixOS/nixpkgs/commit/5664f19152f68c3948b78f1cd9b7063e2b9ddb3c) vimPlugins.parrot-nvim: init at 2025-03-30
* [`a8fe508e`](https://github.com/NixOS/nixpkgs/commit/a8fe508e275705a05ce70245bd9969522a7f7364) vimPlugins.bitbake-vim: 2025-03-24 -> 2.8.8
* [`090c2790`](https://github.com/NixOS/nixpkgs/commit/090c2790bb570cb6bc695361950bb6776840bef7) nixosTests.n8n: migrate to runTest
* [`3ceea612`](https://github.com/NixOS/nixpkgs/commit/3ceea61224a46a5b9f109d6ad75e860c896bfe6a) mpv: add libdisplay-info to fix dmabuf-wayland
* [`14367cc8`](https://github.com/NixOS/nixpkgs/commit/14367cc8edf84641a49467ecf614ab31b155ce1c) python3Packages.clickhouse-connect: fix build ([nixos/nixpkgs⁠#394385](https://togithub.com/nixos/nixpkgs/issues/394385))
* [`61440cf1`](https://github.com/NixOS/nixpkgs/commit/61440cf18e9f1a21b4a1363e5d0996e023a11705) humility: unstable-2023-11-08-> 0-unstable-2025-02-25 ([nixos/nixpkgs⁠#394104](https://togithub.com/nixos/nixpkgs/issues/394104))
* [`fa97e9e3`](https://github.com/NixOS/nixpkgs/commit/fa97e9e3e8f99a7dc15c1cc404b3efad8c65d2da) linuxPackages.rtl8821ce: 0-unstable-2025-03-12 -> 0-unstable-2025-03-31
* [`7595aa9d`](https://github.com/NixOS/nixpkgs/commit/7595aa9df94f13761d05a79824e2d62734c184d1) luaPackages.lualine-nvim: update on 2025-03-31
* [`c9e57689`](https://github.com/NixOS/nixpkgs/commit/c9e576897af30dc5f65a577f12952964dc752989) automatic-timezoned: 2.0.66 -> 2.0.67
* [`7ad16070`](https://github.com/NixOS/nixpkgs/commit/7ad16070bbf6ee4c6b141bf275593542db3cf0e3) tailwindcss_4: 4.0.15 -> 4.0.17
* [`e76d3c5f`](https://github.com/NixOS/nixpkgs/commit/e76d3c5f8507f914bc68e64870d2c09078774cd8) python312Packages.flax: 0.10.4 -> 0.10.5
* [`6e9b6126`](https://github.com/NixOS/nixpkgs/commit/6e9b612688cf2d1664539c96122f672a96c21e01) uv: 0.6.10 -> 0.6.11
* [`6e2688ad`](https://github.com/NixOS/nixpkgs/commit/6e2688ad175ede1b936c8680743f529d493f0cbd) urh: pin numpy_1 to fix [nixos/nixpkgs⁠#371164](https://togithub.com/nixos/nixpkgs/issues/371164) ([nixos/nixpkgs⁠#391888](https://togithub.com/nixos/nixpkgs/issues/391888))
* [`e5e665ba`](https://github.com/NixOS/nixpkgs/commit/e5e665bae251e25cf4768b6e63fce697f33888e4) treefmt: 2.1.1 -> 2.2.0 ([nixos/nixpkgs⁠#394906](https://togithub.com/nixos/nixpkgs/issues/394906))
* [`07e0be58`](https://github.com/NixOS/nixpkgs/commit/07e0be58f78467c57e50477436c21bbbf6f1ad8e) fsautocomplete: refactor
* [`66401463`](https://github.com/NixOS/nixpkgs/commit/664014638d44b003180c7b012fef5f9a7f9b9888) fsautocomplete: 0.77.4 -> 0.77.5
* [`cf77e949`](https://github.com/NixOS/nixpkgs/commit/cf77e949973ee74ad207bc69558043f9ccf037ee) signalbackup-tools: 20250326 -> 20250331-1
* [`7cce75a6`](https://github.com/NixOS/nixpkgs/commit/7cce75a6f3ba79802a2189e33ee2fe33e27094dd) python3Packages.aider-chat: add additional dependencies for help
* [`2164766a`](https://github.com/NixOS/nixpkgs/commit/2164766ad2a58af4fe4274a7948c8dda1d0fc5cc) aider-chat: refactor aider-chat to all-packages, add variants
* [`bdb1b016`](https://github.com/NixOS/nixpkgs/commit/bdb1b01672d5eefe6e7b3566ccfe2d811c4e458c) xmoto: 0.6.2 -> 0.6.3
* [`eed38c7f`](https://github.com/NixOS/nixpkgs/commit/eed38c7f7458636659b41075e110159b98da6d10) cmph: init at 2.0.2
* [`83cfa063`](https://github.com/NixOS/nixpkgs/commit/83cfa06335461596960ade6b7122b28cd80c538f) xivlauncher: 1.1.1 -> 1.1.2
* [`0f4e17bd`](https://github.com/NixOS/nixpkgs/commit/0f4e17bd7ef3174c32bcf35e39e2c865df81312e) peroxide: remove
* [`020e865b`](https://github.com/NixOS/nixpkgs/commit/020e865b79339a405f162d1eab73a61f7b01c974) sops: 3.10.0 -> 3.10.1
* [`c3e2012f`](https://github.com/NixOS/nixpkgs/commit/c3e2012f923fd367c15ddbf9decd08ec23cb532a) sof-firmware: 2025.01 -> 2025.01.1
* [`24030404`](https://github.com/NixOS/nixpkgs/commit/2403040433a3825ff88bb73b5dbdf6b8bdf15308) python312Packages.mhcflurry: 2.1.4 -> 2.1.5
* [`9537bd50`](https://github.com/NixOS/nixpkgs/commit/9537bd50fb933cdc6118859a9d2e2e85e8efa4db) python312Packages.{proton-vpn-api-core,proton-vpn-network-manager}: Fix import tests
* [`4f7495ca`](https://github.com/NixOS/nixpkgs/commit/4f7495cac2e7a1d33576b5c3bcb0e9f71c1f7990) zig_0_11: mark as broken
* [`7be89c18`](https://github.com/NixOS/nixpkgs/commit/7be89c1891dff3a1e24a821fa483eaae091ce8ab) nixosTests.xscreensaver: migrate to runTest
* [`c99f7ebc`](https://github.com/NixOS/nixpkgs/commit/c99f7ebc0b3cf033c1215265f0acf103d9c45c85) dayon: 16.0.2 -> 16.0.3
* [`f7836c38`](https://github.com/NixOS/nixpkgs/commit/f7836c381c9e05d49646aa29e2959ea0b14bea60) bender: 0.28.1 -> 0.28.2
* [`51d5f490`](https://github.com/NixOS/nixpkgs/commit/51d5f49002bdb6b94f0d01bbfc943fc4106ef25c) python312Packages.pylance: 0.25.1 -> 0.25.2
* [`79c1d5b7`](https://github.com/NixOS/nixpkgs/commit/79c1d5b7c73f478e26301ccf01f49bd13a8c092b) nixosTests.bazarr: migrate to runTest
* [`15ffdcd4`](https://github.com/NixOS/nixpkgs/commit/15ffdcd46fb0755dc00888d2033e6df513359b66) protonvpn-gui: Add missing dep
* [`05bd38df`](https://github.com/NixOS/nixpkgs/commit/05bd38dfc046ac28780adf5001a83d38224a3f27) boxflat: 1.28.4 -> 1.28.5
* [`d235e9cd`](https://github.com/NixOS/nixpkgs/commit/d235e9cd90b0522dc8ffc0b13e45caf8db373aef) nixosTests.firefly-iii: migrate to runTest
* [`e8ea207b`](https://github.com/NixOS/nixpkgs/commit/e8ea207b5f3043f77a6f6e7acb6131dfda9236d8) nixosTests.firefly-iii-data-importer: migrate to runTest
* [`bc96c6b8`](https://github.com/NixOS/nixpkgs/commit/bc96c6b8729fba3b2d86947ffe5c92f7f8c56683) dive: 0.13.0 -> 0.13.1
* [`0f4299f5`](https://github.com/NixOS/nixpkgs/commit/0f4299f5919a984499b38cfeb59fdc807d035c77) python3Packages.langchain-groq: 0.3.1 -> 0.3.2
* [`314b75aa`](https://github.com/NixOS/nixpkgs/commit/314b75aafafa04aeee18454f691f65138b1f663d) python3Packages.nifty8: 8.5.6 -> 8.5.7
* [`230457a4`](https://github.com/NixOS/nixpkgs/commit/230457a4421237a2d223db51386c359333c90db0) python312Packages.pydroid-ipcam: 2.0.0 -> 3.0.0
* [`1cce9861`](https://github.com/NixOS/nixpkgs/commit/1cce98619216a94eff58f904cb70f118cddbd9ec) mimir: 2.15.1 -> 2.16.0
* [`0d415c83`](https://github.com/NixOS/nixpkgs/commit/0d415c830712003ac0ffd42d053d5198b9066d60) python312Packages.huggingface-hub: add optional-dependencies
* [`39484caf`](https://github.com/NixOS/nixpkgs/commit/39484caf3fd9c08f2220b83a12da31980191b35a) python312Packages.kserve: 0.14.1 -> 0.15.0
* [`0592081e`](https://github.com/NixOS/nixpkgs/commit/0592081e2bf4ef156144ccf9456aa361201304f5) kubo: 0.34.0 -> 0.34.1
* [`13720709`](https://github.com/NixOS/nixpkgs/commit/1372070979bbfb9d39b7d0e2b0bf0efb0a87335e) esphome: 2025.3.2 -> 2025.3.3
* [`23cb0303`](https://github.com/NixOS/nixpkgs/commit/23cb03035e5d2a5200a90cfdea5f4fd840bb1f59) python312Packages.pvo: 2.2.0 -> 2.2.1
* [`8e764a0f`](https://github.com/NixOS/nixpkgs/commit/8e764a0f09562865ebd01951e0785a2ac5230b55) anubis: 1.15.0 -> 1.15.1
* [`26aed0dd`](https://github.com/NixOS/nixpkgs/commit/26aed0dd63ee4fe97debb48599fd6df81bdeca32) i2p: 2.8.1 -> 2.8.2
* [`4e8e483a`](https://github.com/NixOS/nixpkgs/commit/4e8e483a4fc3d5422a69a43ebf9391bad2fd5caf) python3Packages.tree-sitter-c-sharp: init at 0.23.2
* [`a9ccf91e`](https://github.com/NixOS/nixpkgs/commit/a9ccf91ea286278ad0722c37d37103f3e2d54007) python3Packages.tree-sitter-embedded-template: init at 0.23.2
* [`de290fd5`](https://github.com/NixOS/nixpkgs/commit/de290fd512e2c6f0b6dba88b165348db673263c5) python3Packages.tree-sitter-yaml: init at 0.7.0
* [`669838a7`](https://github.com/NixOS/nixpkgs/commit/669838a73e22fea65660f7bdfe90ca5fb8511509) python3Packages.tree-sitter-language-pack: init at 0.23.2
* [`4596c638`](https://github.com/NixOS/nixpkgs/commit/4596c6380193ca74afbc6eac823d4c5ef2d5c796) python3Packages.grep-ast: 0.6.1 -> 0.8.1
* [`506f6cf5`](https://github.com/NixOS/nixpkgs/commit/506f6cf56afa4bc82b12c91e92c3c6ff614dbd4f) python3Packages.aider-chat: 0.75.2 -> 0.80.0
* [`c7354f14`](https://github.com/NixOS/nixpkgs/commit/c7354f14f3e4c1ffb5a8e775e6a45010a3f57b94) python312Packages.opentelemetry-instrumentation-httpx: init at 0.50b0
* [`2b4d9b01`](https://github.com/NixOS/nixpkgs/commit/2b4d9b011509775723788446bf1f1f6253b74847) python313Packages.ohme: 1.4.1 -> 1.5.1
* [`78a63895`](https://github.com/NixOS/nixpkgs/commit/78a6389526ee6b1d773ebac8498314bb18825ee0) python313Packages.aiorussound: 4.4.0 -> 4.5.0
* [`887c3a0f`](https://github.com/NixOS/nixpkgs/commit/887c3a0f8c30b0fba13edfc9c76df4590934d1a0) open-webui: 0.5.20 -> 0.6.0
* [`9f02d65a`](https://github.com/NixOS/nixpkgs/commit/9f02d65aad74fb15e1185edf18830788a38cde28) python312Packages.pvo: migrate to pytest-cov-stub
* [`2d479872`](https://github.com/NixOS/nixpkgs/commit/2d479872ab934c30d0f1c7c8907c6f9330cf5b3e) python312Packages.pydroid-ipcam: refactor
* [`63455f1a`](https://github.com/NixOS/nixpkgs/commit/63455f1a21b1e5a96104379f01c7436c9af0839a) docs: add separate Nixpkgs release notes
* [`607c9a05`](https://github.com/NixOS/nixpkgs/commit/607c9a05e5ae3d349d46748531b59cf1d905544c) nezha-theme-nazhua: 0.6.0 -> 0.6.3
* [`66bfee6a`](https://github.com/NixOS/nixpkgs/commit/66bfee6a12f5ef72e4d57ce5c44426a48b26dfcf) aider-chat: fix definition
* [`4b8d9700`](https://github.com/NixOS/nixpkgs/commit/4b8d970047a705a59b735fdedc8cad38a089fd0b) yt-dlp: 2025.3.27 -> 2025.3.31
* [`d9196be0`](https://github.com/NixOS/nixpkgs/commit/d9196be0b62016caff762f47cbdc8fe30c04021a) linux_xanmod: 6.12.20 -> 6.12.21
* [`bcd47211`](https://github.com/NixOS/nixpkgs/commit/bcd47211445d025aa7f2a649e29d6c35b5d6d4f1) linux_xanmod_latest: 6.13.8 -> 6.13.9
* [`c966955d`](https://github.com/NixOS/nixpkgs/commit/c966955db13ed1cdcfaa2b9fb9dfee878a9a97be) television: 0.11.14 -> 0.11.15
* [`51dc1633`](https://github.com/NixOS/nixpkgs/commit/51dc1633648e18eb4d094a6bcec7d00cfbff3ecd) nixos/ananicy: re enable BPF on hardened kernels
* [`209baee2`](https://github.com/NixOS/nixpkgs/commit/209baee20b78ab3795c1b3f661563ba7976aa3cb) nixosTests.doas: migrate to runTest
* [`2113a521`](https://github.com/NixOS/nixpkgs/commit/2113a521add267cdc1d40fb6d3fa47bb08a6fd8b) pyradio: 0.9.3.11.8 -> 0.9.3.11.9
* [`e34066f0`](https://github.com/NixOS/nixpkgs/commit/e34066f045ecb393b587caf821fbdb7a2dae90dd) scilab-bin: fix build
* [`a4325209`](https://github.com/NixOS/nixpkgs/commit/a4325209863278fc096401bfe9e0a9da34aa9e00) home-assistant-custom-components.versatile_thermostat: 7.2.5 -> 7.2.9 ([nixos/nixpkgs⁠#395136](https://togithub.com/nixos/nixpkgs/issues/395136))
