### PR TITLE
niv home-manager: update 869f2ec2 -> c21383b5

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -41,10 +41,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "869f2ec2add75ce2a70a6dbbf585b8399abec625",
-        "sha256": "0iy4gbhydx7h37dnpnzcqaz8ycy4i4zqzdvax22496rrxds42z0p",
+        "rev": "c21383b556609ce1ad901aa08b4c6fbd9e0c7af0",
+        "sha256": "05jyfabmws6zzcrb32hv1wrlp1sm3zi54crr52nidf8l1sl6gkdv",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/869f2ec2add75ce2a70a6dbbf585b8399abec625.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/c21383b556609ce1ad901aa08b4c6fbd9e0c7af0.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@869f2ec2...c21383b5](https://github.com/nix-community/home-manager/compare/869f2ec2add75ce2a70a6dbbf585b8399abec625...c21383b556609ce1ad901aa08b4c6fbd9e0c7af0)

* [`29806065`](https://github.com/nix-community/home-manager/commit/298060655681ec239491252da9b295d854ff51fe) distrobox: replace hardcoded path with config package's path ([nix-community/home-manager⁠#6701](https://togithub.com/nix-community/home-manager/issues/6701))
* [`e3dded7a`](https://github.com/nix-community/home-manager/commit/e3dded7a85c68f8445a735d70920fc00a808621b) fish: Fix manpage completion generation with paths containing spaces ([nix-community/home-manager⁠#6703](https://togithub.com/nix-community/home-manager/issues/6703))
* [`5abb21dc`](https://github.com/nix-community/home-manager/commit/5abb21dc10e4a9aaee5874c36e800a2609eceaef) distrobox: fix typo
* [`529906d6`](https://github.com/nix-community/home-manager/commit/529906d6a2ef020130110f4f8214a4513aa7996f) podman: fix typo
* [`8bef8b7a`](https://github.com/nix-community/home-manager/commit/8bef8b7a0a95d347018f09b291e2fa0a77abd23f) direnv: fix typo
* [`d8b4ba07`](https://github.com/nix-community/home-manager/commit/d8b4ba070f5dfcb6c051c74fb31eafb58127580b) mergiraf: init module ([nix-community/home-manager⁠#6633](https://togithub.com/nix-community/home-manager/issues/6633))
* [`f565da89`](https://github.com/nix-community/home-manager/commit/f565da89e759ebf57b236510aa955b8a2d41c779) davmail: add package option ([nix-community/home-manager⁠#6705](https://togithub.com/nix-community/home-manager/issues/6705))
* [`b9da58d5`](https://github.com/nix-community/home-manager/commit/b9da58d50551ebd74226fb8487b248a5a36c988f) carapace: conditionally disable unnecessary fish completion workaround on fish 4.0 ([nix-community/home-manager⁠#6694](https://togithub.com/nix-community/home-manager/issues/6694))
* [`338b2eab`](https://github.com/nix-community/home-manager/commit/338b2eabdfde14a79755341ea472e2c55d1064c4) waybar: integrate with tray.target ([nix-community/home-manager⁠#6675](https://togithub.com/nix-community/home-manager/issues/6675))
* [`2321c688`](https://github.com/nix-community/home-manager/commit/2321c6889bd473d384b687c7d536d88fec3b3256) ripgrep-all: Add module ([nix-community/home-manager⁠#5459](https://togithub.com/nix-community/home-manager/issues/5459))
* [`0ff53f6d`](https://github.com/nix-community/home-manager/commit/0ff53f6d336edb3ad81647dc931ad1c9c7f890ca) helix: add extraConfig option ([nix-community/home-manager⁠#6575](https://togithub.com/nix-community/home-manager/issues/6575))
* [`ce287a5c`](https://github.com/nix-community/home-manager/commit/ce287a5cd3ef78203bc78021447f937a988d9f6f) mpdscribble: add module ([nix-community/home-manager⁠#6259](https://togithub.com/nix-community/home-manager/issues/6259))
* [`693840c0`](https://github.com/nix-community/home-manager/commit/693840c01b9bef9e54100239cef937e53d4661bf) vscode: Fix version checks when using Cursor ([nix-community/home-manager⁠#6680](https://togithub.com/nix-community/home-manager/issues/6680))
* [`171915bf`](https://github.com/nix-community/home-manager/commit/171915bfce41018528fda9960211e81946d999b7) fzf: fix zsh integration (keybinds rewritten by omz) ([nix-community/home-manager⁠#6712](https://togithub.com/nix-community/home-manager/issues/6712))
* [`b14a70c4`](https://github.com/nix-community/home-manager/commit/b14a70c40f4fd0b73d095ab04a7c6e31fbc18e52) fzf: update zsh integration to be after plugins ([nix-community/home-manager⁠#6716](https://togithub.com/nix-community/home-manager/issues/6716))
* [`13d68e9a`](https://github.com/nix-community/home-manager/commit/13d68e9ac05caccc1f81ce40612a8086421e1706) helix: avoid IFD ([nix-community/home-manager⁠#6714](https://togithub.com/nix-community/home-manager/issues/6714))
* [`26ccff08`](https://github.com/nix-community/home-manager/commit/26ccff08df360afd888b08633a5dddbb99f04d8f) thunderbird: set additional gmail smtpserver settings ([nix-community/home-manager⁠#6713](https://togithub.com/nix-community/home-manager/issues/6713))
* [`1efd2503`](https://github.com/nix-community/home-manager/commit/1efd2503172016a6742c87b47b43ca2c8145607d) flake.lock: Update ([nix-community/home-manager⁠#6708](https://togithub.com/nix-community/home-manager/issues/6708))
* [`3527c8c7`](https://github.com/nix-community/home-manager/commit/3527c8c7785d1855ccf9da0e8436a0e769190b18) sesh: add module ([nix-community/home-manager⁠#5789](https://togithub.com/nix-community/home-manager/issues/5789))
* [`1f679ed2`](https://github.com/nix-community/home-manager/commit/1f679ed2a2ebe3894bad9f89fb0bd9f141c28a68) zsh-abbr: Add global abbreviations ([nix-community/home-manager⁠#6720](https://togithub.com/nix-community/home-manager/issues/6720))
* [`f1d4acaa`](https://github.com/nix-community/home-manager/commit/f1d4acaa1085930f76165e99db356db9f9f9fda6) treewide: use mkPackageOption ([nix-community/home-manager⁠#6727](https://togithub.com/nix-community/home-manager/issues/6727))
* [`a710f337`](https://github.com/nix-community/home-manager/commit/a710f337d6f541f5ba50bc2d5daa6c34e9ee5834) launchd: remove with lib
* [`ef8f8987`](https://github.com/nix-community/home-manager/commit/ef8f898727d174b16a154b29e8c0f82d39cbac21) launchd: add khaneliman maintainer
* [`86d2e3b0`](https://github.com/nix-community/home-manager/commit/86d2e3b00561a166f8c31ff9ec6a947ca0992ec5) launchd: remove checkLaunchAgents
* [`b4314965`](https://github.com/nix-community/home-manager/commit/b431496538b0e294fbe44a1441b24ae8195c63f0) launchd: refactor setupLaunchAgents
* [`71703001`](https://github.com/nix-community/home-manager/commit/717030011980e9eb31eb8ce011261dd532bce92c) podman: fix service name in generated manifest ([nix-community/home-manager⁠#6710](https://togithub.com/nix-community/home-manager/issues/6710))
* [`2760046f`](https://github.com/nix-community/home-manager/commit/2760046f34780cc72f67e06240ccf6a7a3ae3765) docs: correct improper import of home.nix ([nix-community/home-manager⁠#6732](https://togithub.com/nix-community/home-manager/issues/6732))
* [`8ce84337`](https://github.com/nix-community/home-manager/commit/8ce84337430492b984a7ddd73371773e8d19ad73) granted: Add override for package ([nix-community/home-manager⁠#6722](https://togithub.com/nix-community/home-manager/issues/6722))
* [`802653e5`](https://github.com/nix-community/home-manager/commit/802653e5d1f654ac67c045ca6eea8c8cfa8fc052) auto-upgrade: unbreak on unattended, loginctl enable-linger systems ([nix-community/home-manager⁠#6719](https://togithub.com/nix-community/home-manager/issues/6719))
* [`1d2ed9c5`](https://github.com/nix-community/home-manager/commit/1d2ed9c503cf41ca7f3db091edc8519dcdcd8b41) flake.lock: Update ([nix-community/home-manager⁠#6730](https://togithub.com/nix-community/home-manager/issues/6730))
* [`09280e17`](https://github.com/nix-community/home-manager/commit/09280e17bbd29536efd1549751038fa155489bd4) xdg-autostart: Add readOnly option ([nix-community/home-manager⁠#6629](https://togithub.com/nix-community/home-manager/issues/6629))
* [`b6fd653e`](https://github.com/nix-community/home-manager/commit/b6fd653ef8fbeccfd4958650757e91767a65506d) newsboat: add a package option to the module ([nix-community/home-manager⁠#6717](https://togithub.com/nix-community/home-manager/issues/6717))
* [`21669077`](https://github.com/nix-community/home-manager/commit/216690777e47aa0fb1475e4dbe2510554ce0bc4b) nixos-module: Fix potential recursion between users.users and home-manager.users ([nix-community/home-manager⁠#6622](https://togithub.com/nix-community/home-manager/issues/6622))
* [`ccd7df83`](https://github.com/nix-community/home-manager/commit/ccd7df836e1f42ea84806760f25b77b586370259) mcfly: Fix fzf overriding mcfly's Ctrl+R bind on fish([nix-community/home-manager⁠#6736](https://togithub.com/nix-community/home-manager/issues/6736))
* [`0b491b46`](https://github.com/nix-community/home-manager/commit/0b491b460f52e87e23eb17bbf59c6ae64b7664c1) treewide: remove with lib ([nix-community/home-manager⁠#6735](https://togithub.com/nix-community/home-manager/issues/6735))
* [`5e193cdc`](https://github.com/nix-community/home-manager/commit/5e193cdcab61b5e7096ef3c132fdc0149e14f2d9) msmtp: fix missing inherits ([nix-community/home-manager⁠#6741](https://togithub.com/nix-community/home-manager/issues/6741))
* [`c21383b5`](https://github.com/nix-community/home-manager/commit/c21383b556609ce1ad901aa08b4c6fbd9e0c7af0) streamlink: init module ([nix-community/home-manager⁠#6031](https://togithub.com/nix-community/home-manager/issues/6031))
