### PR TITLE
niv emacs-overlay: update 125a3649 -> 3fe8f6c0

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "125a36498b1468c259acfbfb641ef68b4fcef8a8",
-        "sha256": "19hxyf2z7jckrms23svh6sxiig6ycqgjdb7vwk7572hg0xxc31f6",
+        "rev": "3fe8f6c091e799d7a932f9447b762df7c8812619",
+        "sha256": "0cihccjd6xlsf012hfr8p1pv2dw5jbyy6cnlrd2lzygk50yhpsby",
         "type": "tarball",
-        "url": "https://github.com/nix-community/emacs-overlay/archive/125a36498b1468c259acfbfb641ef68b4fcef8a8.tar.gz",
+        "url": "https://github.com/nix-community/emacs-overlay/archive/3fe8f6c091e799d7a932f9447b762df7c8812619.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "fast-syntax-highlighting": {


### PR DESCRIPTION
## Changelog for emacs-overlay:
Branch: master
Commits: [nix-community/emacs-overlay@125a3649...3fe8f6c0](https://github.com/nix-community/emacs-overlay/compare/125a36498b1468c259acfbfb641ef68b4fcef8a8...3fe8f6c091e799d7a932f9447b762df7c8812619)

* [`64a6c0a5`](https://github.com/nix-community/emacs-overlay/commit/64a6c0a53debb7df15510df9b59ac7786b33f59c) Updated melpa
* [`b330e15b`](https://github.com/nix-community/emacs-overlay/commit/b330e15b67dd5dfb413455dd10f161c2d87dfe34) Updated emacs
* [`08c393b5`](https://github.com/nix-community/emacs-overlay/commit/08c393b5550213be99daf14795a257ea300864a6) Updated flake inputs
* [`def3611a`](https://github.com/nix-community/emacs-overlay/commit/def3611a88dbb462a14ee2ca708041dfd49986ab) Updated melpa
* [`25b732c2`](https://github.com/nix-community/emacs-overlay/commit/25b732c255ccb41258d70d775afb9f16e25fa3d5) Updated emacs
* [`6734cac0`](https://github.com/nix-community/emacs-overlay/commit/6734cac0dff7a8f28bbdbe13f43985efa230c191) Updated nongnu
* [`853677de`](https://github.com/nix-community/emacs-overlay/commit/853677de00453b36ad157c49ff281223f768a7fe) Updated elpa
* [`1d7cd9ca`](https://github.com/nix-community/emacs-overlay/commit/1d7cd9ca0f25ecaba43b5ab862d070e52759d1d5) Updated melpa
* [`317e9986`](https://github.com/nix-community/emacs-overlay/commit/317e9986ebfbcdccfe2c105557c8d724c394843a) Updated emacs
* [`962bfba0`](https://github.com/nix-community/emacs-overlay/commit/962bfba0e234812c75a9e8152eda902fc9eea3af) Updated nongnu
* [`25a6cbcf`](https://github.com/nix-community/emacs-overlay/commit/25a6cbcfc86cf2485269062126d11c7b85b8fe01) Updated elpa
* [`964db202`](https://github.com/nix-community/emacs-overlay/commit/964db2028a2c75f290218026d86536ecbda8cc17) Updated melpa
* [`07b94b74`](https://github.com/nix-community/emacs-overlay/commit/07b94b745e7c9f7be4e50309a85770cf97c8b9e9) Updated emacs
* [`7c7a8ce2`](https://github.com/nix-community/emacs-overlay/commit/7c7a8ce2d8d92b0a43c1a10ca9a1b9200adc1537) Updated melpa
* [`92360d92`](https://github.com/nix-community/emacs-overlay/commit/92360d92e7866b18b836c4503d6a56583046ebf0) Updated emacs
* [`d9492638`](https://github.com/nix-community/emacs-overlay/commit/d9492638daa77fca7bf84e5b218cd95598ac3f72) Updated flake inputs
* [`14359af6`](https://github.com/nix-community/emacs-overlay/commit/14359af6615294b759e0231a1da2ef7c79d7e3a9) Updated nongnu
* [`d52bccd0`](https://github.com/nix-community/emacs-overlay/commit/d52bccd00912d307acb90aac7b587b4ff8f9347f) Updated elpa
* [`631115ae`](https://github.com/nix-community/emacs-overlay/commit/631115aefc00f857fb8e4e85f432b9c9da06cd51) Updated melpa
* [`72ba1ab1`](https://github.com/nix-community/emacs-overlay/commit/72ba1ab1718cb98af75b6ad499d1c21d3ded5909) Updated emacs
* [`1380335c`](https://github.com/nix-community/emacs-overlay/commit/1380335c04290c350fc6c9c68aad5b1042db7f45) Updated melpa
* [`a2f3f627`](https://github.com/nix-community/emacs-overlay/commit/a2f3f627209efaac4b41810e1d3464ea59c5e9ef) Updated emacs
* [`1a01699a`](https://github.com/nix-community/emacs-overlay/commit/1a01699a722bb2ad99c91c55af38fd9768edbacd) Updated nongnu
* [`89a692ea`](https://github.com/nix-community/emacs-overlay/commit/89a692ea4dd03aecfb3d00e9d61199f0a5085b04) Updated elpa
* [`07db8ce6`](https://github.com/nix-community/emacs-overlay/commit/07db8ce61e871ee3d09794051711b2bbfbd01073) Updated melpa
* [`a3bf2052`](https://github.com/nix-community/emacs-overlay/commit/a3bf20522b1fa7295ca05ea4a8d37546915e598e) Updated emacs
* [`a9e823f2`](https://github.com/nix-community/emacs-overlay/commit/a9e823f2647f26b99aaacaf3bf6a5112ba40907c) Updated flake inputs
* [`e78ff1a3`](https://github.com/nix-community/emacs-overlay/commit/e78ff1a3628c122ccd2d5b2881455abd50c2e9a7) Updated nongnu
* [`fcedbc41`](https://github.com/nix-community/emacs-overlay/commit/fcedbc416147a78eb1c1a86c514f6e3a2356b8af) Updated elpa
* [`ca678124`](https://github.com/nix-community/emacs-overlay/commit/ca6781247e2693f5aa7de347398d5ec8dba78fe2) Updated melpa
* [`055dec4a`](https://github.com/nix-community/emacs-overlay/commit/055dec4a21185c6024f35f36398c395193e86491) Updated emacs
* [`7e5b7f85`](https://github.com/nix-community/emacs-overlay/commit/7e5b7f8596ecc33ef6a4e1832ede86f5e62ed8a4) Updated melpa
* [`55019a35`](https://github.com/nix-community/emacs-overlay/commit/55019a35f027fca211caff7ef7a7a870e82ceec8) Updated emacs
* [`a0fe5d5a`](https://github.com/nix-community/emacs-overlay/commit/a0fe5d5ac55d9c20e51c040984cbdef48d69e306) Updated nongnu
* [`4a09d090`](https://github.com/nix-community/emacs-overlay/commit/4a09d090c2c67640cc22fb5cd75342d10a419a53) Updated elpa
* [`7ba25893`](https://github.com/nix-community/emacs-overlay/commit/7ba25893e77211cf52374858ad40e192814f039b) Updated melpa
* [`40466220`](https://github.com/nix-community/emacs-overlay/commit/40466220218949e1f8b36d6ba44e27644dd6bc14) Updated emacs
* [`d78a4467`](https://github.com/nix-community/emacs-overlay/commit/d78a44674c43943b751fd664fcbbe905a990a90d) Updated nongnu
* [`9e9da591`](https://github.com/nix-community/emacs-overlay/commit/9e9da5913711176f19fd3650e5d97fe02bc10da0) Updated elpa
* [`b914784d`](https://github.com/nix-community/emacs-overlay/commit/b914784db149a0fffc64b35be7027b54457084b7) Updated melpa
* [`abeede51`](https://github.com/nix-community/emacs-overlay/commit/abeede518295bf29ce648cbf016c025a6b0e8c09) Updated emacs
* [`6429ee53`](https://github.com/nix-community/emacs-overlay/commit/6429ee53a1c1199637602275c00aca475d8e8057) repos/emacs: Rewrite unstable updater using Python
* [`7d03e8ca`](https://github.com/nix-community/emacs-overlay/commit/7d03e8ca90e6b438820dee99144a0d03d556f530) Updated flake inputs
* [`ffcf0dae`](https://github.com/nix-community/emacs-overlay/commit/ffcf0dae804167e97b5ccb25ab1366f523384f76) Updated flake inputs
* [`d6871ef5`](https://github.com/nix-community/emacs-overlay/commit/d6871ef57d1e1e520d64e40c01b1f0f171d0c3f7) overlays/emacs: rename emacs-pgtk to emacs-git-pgtk
* [`cb747e4b`](https://github.com/nix-community/emacs-overlay/commit/cb747e4bc76c308d2ece3721bf07f534d10cb196) Updated flake inputs
* [`30ca4323`](https://github.com/nix-community/emacs-overlay/commit/30ca43239c2b58a25fb73c7ed972d8e87e04d845) Updated flake inputs
* [`5f5a48f8`](https://github.com/nix-community/emacs-overlay/commit/5f5a48f87c3f0e35dbb34f50d4d13595038901d2) .github: Unpin Nix 2.18 for CI
* [`87d5e2bb`](https://github.com/nix-community/emacs-overlay/commit/87d5e2bbc04a8d2ddff9e1f9e266bf81c3bd45b2) Updated flake inputs
* [`c34d2288`](https://github.com/nix-community/emacs-overlay/commit/c34d22888cd6fcb565cbb6a05fcd45e6099ce5f4) overlay/emacs: update patch for [nix-community/emacs-overlay⁠#318](https://togithub.com/nix-community/emacs-overlay/issues/318) (upstream bug[nix-community/emacs-overlay⁠#63288](https://togithub.com/nix-community/emacs-overlay/issues/63288) bug[nix-community/emacs-overlay⁠#76523](https://togithub.com/nix-community/emacs-overlay/issues/76523))
* [`e129cea3`](https://github.com/nix-community/emacs-overlay/commit/e129cea3d6d3ea152429f5d0926cec2d148d2ec6) Temporarily make `packages` correspond to emacs-unstable
* [`be12ed91`](https://github.com/nix-community/emacs-overlay/commit/be12ed914c415a330efb69600b6732add76b0a87) Revert "Temporarily make `packages` correspond to emacs-unstable"
* [`4944e1c6`](https://github.com/nix-community/emacs-overlay/commit/4944e1c699d13c014df2882dffc981069c36dca2) Temporarily make `packages` correspond to emacs-unstable
* [`6e4d92e5`](https://github.com/nix-community/emacs-overlay/commit/6e4d92e5c26dc81241d4c800531ad1f8ee68f213) Revert "Temporarily make `packages` correspond to emacs-unstable"
* [`df8a3133`](https://github.com/nix-community/emacs-overlay/commit/df8a3133fae8a6c98ae23b249b57d902f03eff84) Updated flake inputs
* [`1558e250`](https://github.com/nix-community/emacs-overlay/commit/1558e2501940c87434e4cba90babc1517c1ccacd) Updated nongnu
* [`d47cbc64`](https://github.com/nix-community/emacs-overlay/commit/d47cbc6420041baf1f8185b859d92bff8d8cf4df) Updated elpa
* [`a231ca83`](https://github.com/nix-community/emacs-overlay/commit/a231ca8318ad9e18cd71383b6e6252c104318696) .github: pin Nix 2.24.12 for CI
* [`0e7d88c3`](https://github.com/nix-community/emacs-overlay/commit/0e7d88c313f7eab70ebac6897b427df026e47e98) Updated melpa
* [`db37ae9c`](https://github.com/nix-community/emacs-overlay/commit/db37ae9cd947031ad83288dec514233ffd262ffd) Updated emacs
* [`21501175`](https://github.com/nix-community/emacs-overlay/commit/21501175a56405ee0050a1e2fd3bbebc38961010) Updated melpa
* [`257cf838`](https://github.com/nix-community/emacs-overlay/commit/257cf8385441733ba3594e1e9f8edcf10adfbc31) Updated emacs
* [`409ef878`](https://github.com/nix-community/emacs-overlay/commit/409ef8787b0fed67147af9124ef15562a1187d88) Updated nongnu
* [`a554bd33`](https://github.com/nix-community/emacs-overlay/commit/a554bd3376a0f58d221c43377c50f4a92b139860) Updated elpa
* [`a08f98d5`](https://github.com/nix-community/emacs-overlay/commit/a08f98d5802594b910424fd61287af654a4ef6fe) Updated melpa
* [`70dcaaf2`](https://github.com/nix-community/emacs-overlay/commit/70dcaaf21a78253742d3caae56dadc5447d85c15) Updated emacs
* [`6f2afe90`](https://github.com/nix-community/emacs-overlay/commit/6f2afe90ca842c346e5ec4ddc9a7e2a5a6be0cec) Updated flake inputs
* [`0ff5e038`](https://github.com/nix-community/emacs-overlay/commit/0ff5e0381a8023bd456be3cbbda62d396cbed0f9) Updated nongnu
* [`abda9338`](https://github.com/nix-community/emacs-overlay/commit/abda9338130e71108be0447c364a94c1a9d1d050) Updated elpa
* [`9f323fca`](https://github.com/nix-community/emacs-overlay/commit/9f323fcaa64ee12653b9d67d49e791a9d21113d2) Updated melpa
* [`7236e0ba`](https://github.com/nix-community/emacs-overlay/commit/7236e0baef0a94fa7826f034ea96433224bcea89) Updated emacs
* [`4b3be58e`](https://github.com/nix-community/emacs-overlay/commit/4b3be58e33b2075d0a1abb82d45fcf35b498624c) Updated melpa
* [`7a25a145`](https://github.com/nix-community/emacs-overlay/commit/7a25a145b8a7f455e62185af431001d70471b199) Updated emacs
* [`fb5010aa`](https://github.com/nix-community/emacs-overlay/commit/fb5010aa3179e77f595cd3be1760817b86b6dbda) Updated nongnu
* [`6a25d3f9`](https://github.com/nix-community/emacs-overlay/commit/6a25d3f956603e1f18499f33951ad6f2a9fa2f6e) Updated elpa
* [`706c0b0f`](https://github.com/nix-community/emacs-overlay/commit/706c0b0f6f2abe59c8e3071366e9fcedeb2bb641) Updated flake inputs
* [`37428a43`](https://github.com/nix-community/emacs-overlay/commit/37428a4344c0ce40b09431787190fdb4cbb5c296) Updated nongnu
* [`6cdcd31f`](https://github.com/nix-community/emacs-overlay/commit/6cdcd31f6f9d252a2c94eac01e6e23696bc3d0ff) Updated elpa
* [`b8093212`](https://github.com/nix-community/emacs-overlay/commit/b8093212f99e5d41e077a65bd4d21fd81f5cb092) Updated melpa
* [`e6acc432`](https://github.com/nix-community/emacs-overlay/commit/e6acc4327ba98ade994a6b804b01ab5087726ce2) Updated emacs
* [`84fbb394`](https://github.com/nix-community/emacs-overlay/commit/84fbb394e473b356dab59820a185d13feffb7203) Updated flake inputs
* [`2886bb1f`](https://github.com/nix-community/emacs-overlay/commit/2886bb1fa37af55db9eed88505917930fc82bcd4) Updated melpa
* [`5fdeee5c`](https://github.com/nix-community/emacs-overlay/commit/5fdeee5cee62b5f5b09f9d0c7a103f1c5c426d2b) Updated emacs
* [`04892169`](https://github.com/nix-community/emacs-overlay/commit/04892169ec614a3ddeb1ca4a8e6a86e9d410d30c) starhugger: fix src hash
* [`eda1672f`](https://github.com/nix-community/emacs-overlay/commit/eda1672f7c1062ffa7bd9392c3796a45ee5f7b63) Updated nongnu
* [`2695d538`](https://github.com/nix-community/emacs-overlay/commit/2695d53827b4200a195f932a5beb47fe5f9e3213) Updated elpa
* [`e4e75569`](https://github.com/nix-community/emacs-overlay/commit/e4e7556964ff3cffd494fb1015f6655129011e59) Updated nongnu
* [`c46bbc0d`](https://github.com/nix-community/emacs-overlay/commit/c46bbc0d6dd03af88ae94f62cf74fc7a309d0a11) Updated elpa
* [`14a84d58`](https://github.com/nix-community/emacs-overlay/commit/14a84d587dc86a10542329f6f15df8db8d56d52b) Updated melpa
* [`dd4b8102`](https://github.com/nix-community/emacs-overlay/commit/dd4b810268262c2790475a7bb4f2583c292f1ee4) Updated emacs
* [`92655efb`](https://github.com/nix-community/emacs-overlay/commit/92655efb6a543af855d9ee117a4836139d4fe0ea) Updated melpa
* [`04d8748d`](https://github.com/nix-community/emacs-overlay/commit/04d8748de599621ca0ae7f9766c489adf45d63de) Updated emacs
* [`1000f664`](https://github.com/nix-community/emacs-overlay/commit/1000f6646f2167d50c6493d920a16e75c27dd926) Updated nongnu
* [`cfe450e7`](https://github.com/nix-community/emacs-overlay/commit/cfe450e7c41c66aa5b87c855b72d8e2969907fae) Updated elpa
* [`db5b856b`](https://github.com/nix-community/emacs-overlay/commit/db5b856bb02ebb6abd621aa00e7664ff357c6d68) Updated melpa
* [`e69c9add`](https://github.com/nix-community/emacs-overlay/commit/e69c9add9acc10220d9679f4f3ca34ea01a4c7be) Updated emacs
* [`d35b8422`](https://github.com/nix-community/emacs-overlay/commit/d35b8422e591b87bef34382a01258eb4f32b2f23) Updated nongnu
* [`1c31da84`](https://github.com/nix-community/emacs-overlay/commit/1c31da84e07ab95cb1bb5c26c4e9ddbe94725584) Updated elpa
* [`e2499376`](https://github.com/nix-community/emacs-overlay/commit/e2499376503d31b4a263a9820bcd64b8f3430f83) Updated melpa
* [`34c2a5d9`](https://github.com/nix-community/emacs-overlay/commit/34c2a5d93606f6f952c34a85e5346029869bd8f0) Updated emacs
* [`80ae1125`](https://github.com/nix-community/emacs-overlay/commit/80ae11251c3bb81474e9e14a4cd77fecb726ef17) Updated melpa
* [`3ec299dc`](https://github.com/nix-community/emacs-overlay/commit/3ec299dc7f35c1c6164859777321d1b1f0305ad3) Updated emacs
* [`ae149842`](https://github.com/nix-community/emacs-overlay/commit/ae149842faeb725ee444f0eed5ec8eb0861b8d0d) Updated flake inputs
* [`1b0330de`](https://github.com/nix-community/emacs-overlay/commit/1b0330deb5dcd993d934c4380e1ecd96e87bd162) Updated nongnu
* [`755cb642`](https://github.com/nix-community/emacs-overlay/commit/755cb6420c7bc3b9c55aaf54568e090c1b2903a5) Updated elpa
* [`da88eada`](https://github.com/nix-community/emacs-overlay/commit/da88eadabf11bf42cbc5dd35dc8a572635c04d7f) Updated melpa
* [`7066864e`](https://github.com/nix-community/emacs-overlay/commit/7066864e5344c117e53320bfa798e9131b0eb5db) Updated emacs
* [`4d008ab4`](https://github.com/nix-community/emacs-overlay/commit/4d008ab4feb8d398819ae2a23565b81f395e86f6) Updated flake inputs
* [`e4dd6105`](https://github.com/nix-community/emacs-overlay/commit/e4dd610561afe502e72918f6bc1e4070e3443d8d) Updated nongnu
* [`dbc622fe`](https://github.com/nix-community/emacs-overlay/commit/dbc622fee56f7de989ed34c8603e4be3a72133bf) Updated elpa
* [`3fb47ca2`](https://github.com/nix-community/emacs-overlay/commit/3fb47ca23e2fa45d30eedcf2219552385f91b596) Updated melpa
* [`efab8094`](https://github.com/nix-community/emacs-overlay/commit/efab809432104b6f93d3903aa47e6fbbe2939038) Updated emacs
* [`b43e58ca`](https://github.com/nix-community/emacs-overlay/commit/b43e58ca70f2b494e1b91d82893a36bc2b7ff9b3) Updated melpa
* [`5d6c4842`](https://github.com/nix-community/emacs-overlay/commit/5d6c484290f0754ce745ea6f7e2b7d037bdc7b76) Updated emacs
* [`d72523e2`](https://github.com/nix-community/emacs-overlay/commit/d72523e2f7238ebce18f06c018e954d5131de6c3) Updated elpa
* [`4ecca5ba`](https://github.com/nix-community/emacs-overlay/commit/4ecca5ba1a749e52e1f5f927d89e620f9a14f9d7) Updated melpa
* [`5ca8419d`](https://github.com/nix-community/emacs-overlay/commit/5ca8419dfc9f6c451aa9bfee0f37ff28c9582774) Updated emacs
* [`9a878feb`](https://github.com/nix-community/emacs-overlay/commit/9a878febfcb31d35a4b33a6b30a8c9d276f8a84c) Updated nongnu
* [`7c8613e3`](https://github.com/nix-community/emacs-overlay/commit/7c8613e351a14fb3a5f4c61c365e067530a72217) Updated elpa
* [`a5846781`](https://github.com/nix-community/emacs-overlay/commit/a5846781f6570a46af25337bddadfc4b50b59af8) Updated melpa
* [`bcadbffd`](https://github.com/nix-community/emacs-overlay/commit/bcadbffd57a2160d2cf5089adcfa47d50594d36f) Updated emacs
* [`e138db11`](https://github.com/nix-community/emacs-overlay/commit/e138db11982437a66216ac559de564728e42c4a2) Updated elpa
* [`7e13aa50`](https://github.com/nix-community/emacs-overlay/commit/7e13aa507d714371e6ff70a91d76dcb339311773) Updated fromElisp
* [`d1e4a12b`](https://github.com/nix-community/emacs-overlay/commit/d1e4a12b288c9402139ab409460620d11d1b88ae) Updated melpa
* [`c799d9c6`](https://github.com/nix-community/emacs-overlay/commit/c799d9c6c955de5a698373b0ebb96daa7c8063ce) Updated emacs
* [`e2e02bea`](https://github.com/nix-community/emacs-overlay/commit/e2e02bea39ae8e7e48a40e476ffec438e181d930) Updated flake inputs
* [`1f50951e`](https://github.com/nix-community/emacs-overlay/commit/1f50951e95b896fb6fbe9388914d4838909e91b1) Updated fromElisp
* [`a9700718`](https://github.com/nix-community/emacs-overlay/commit/a9700718d9e66273b3600a5313d6cf745fdcc069) Updated flake inputs
* [`fe7f0c0f`](https://github.com/nix-community/emacs-overlay/commit/fe7f0c0f04123a4a9f2eed3276fa9d23a7e50f58) Updated nongnu
* [`961e2380`](https://github.com/nix-community/emacs-overlay/commit/961e23802247c5580ef4a2106dbcf187d88622a6) Updated elpa
* [`7f3451c7`](https://github.com/nix-community/emacs-overlay/commit/7f3451c7f055d88e4df22b19620885022cbb3c7e) Updated melpa
* [`a06c25da`](https://github.com/nix-community/emacs-overlay/commit/a06c25dabe2db425e5c0e9a6a56371bc9886337c) Updated emacs
* [`5d5c1f6f`](https://github.com/nix-community/emacs-overlay/commit/5d5c1f6fdce7fab42ee84bc94eb3e39f112fc42f) Updated melpa
* [`7a9a2538`](https://github.com/nix-community/emacs-overlay/commit/7a9a25389a6ad9402f9aa5087ccb36f8383045a8) Updated emacs
* [`dc8481f1`](https://github.com/nix-community/emacs-overlay/commit/dc8481f18cdb6d7b3b02b95419059f60b982f12b) Bump cachix/cachix-action from 15 to 16
* [`d706c55c`](https://github.com/nix-community/emacs-overlay/commit/d706c55c58c012dc917be46b9f973b048ea4cb53) Updated nongnu
* [`406d2a3d`](https://github.com/nix-community/emacs-overlay/commit/406d2a3d0cfdc4dc5c0476b19773927e477229ab) Updated nongnu
* [`771324e4`](https://github.com/nix-community/emacs-overlay/commit/771324e439b2e58fdac19801f311fb04ba780fd9) Updated elpa
* [`3e29088f`](https://github.com/nix-community/emacs-overlay/commit/3e29088fe999648dca4a09293367626c4000cedd) Updated melpa
* [`8b2e6a35`](https://github.com/nix-community/emacs-overlay/commit/8b2e6a35c25a495311acd41f4115daa543a50709) Updated emacs
* [`3d30a184`](https://github.com/nix-community/emacs-overlay/commit/3d30a184b68deddb95990a24c95f821f82c5abbe) Bump cachix/install-nix-action from 30 to 31
* [`b856b055`](https://github.com/nix-community/emacs-overlay/commit/b856b055ef825bb78a4b0a488f693ac78b1301ce) Revert ".github: pin Nix 2.24.12 for CI"
* [`006123de`](https://github.com/nix-community/emacs-overlay/commit/006123de77fdafa8748b365ea7abdb514421f223) Updated flake inputs
* [`af4abc35`](https://github.com/nix-community/emacs-overlay/commit/af4abc353d2dc12aa0971ccfb10c2db76a692529) Updated nongnu
* [`ecaf1d4d`](https://github.com/nix-community/emacs-overlay/commit/ecaf1d4d12cd4a6007bc73674d3398aa806c3993) Updated elpa
* [`3c75f0f3`](https://github.com/nix-community/emacs-overlay/commit/3c75f0f339d9e23c5c71ea26d67eb0ed2d5b498d) Updated melpa
* [`91c89f41`](https://github.com/nix-community/emacs-overlay/commit/91c89f41cb7c5a8804a7970cdfdaf9c401db6164) Updated emacs
* [`ad79b25b`](https://github.com/nix-community/emacs-overlay/commit/ad79b25bb65446895c811ccf348b961583649a16) Updated melpa
* [`23c39b79`](https://github.com/nix-community/emacs-overlay/commit/23c39b791e1add67525fe83bd0b1d0f92ee75d80) Updated nongnu
* [`545fa06e`](https://github.com/nix-community/emacs-overlay/commit/545fa06e94538b5ee8705199d86debb1710e73c4) Updated elpa
* [`450130c7`](https://github.com/nix-community/emacs-overlay/commit/450130c769dd6de54354c4db0409d41d0f9d2de6) Updated melpa
* [`9503dff9`](https://github.com/nix-community/emacs-overlay/commit/9503dff9b07e6980bce78c7c4c0ed2c070064cc5) Updated emacs
* [`88e5af73`](https://github.com/nix-community/emacs-overlay/commit/88e5af734af21da9d12eeab0a59c11b8dc921599) Updated flake inputs
* [`f3fe04dd`](https://github.com/nix-community/emacs-overlay/commit/f3fe04dd81fa25496e9b27e3fda96d08ccbfc275) Updated melpa
* [`e1dda3fb`](https://github.com/nix-community/emacs-overlay/commit/e1dda3fbcee95d17233b6648b6c2dacabc052744) Updated nongnu
* [`2261955a`](https://github.com/nix-community/emacs-overlay/commit/2261955a6935c9619746629fbc2cf30078686474) Updated elpa
* [`8a580131`](https://github.com/nix-community/emacs-overlay/commit/8a580131660c6c6999ddadc8bd55b487a6cce02e) Updated melpa
* [`26e784b3`](https://github.com/nix-community/emacs-overlay/commit/26e784b36d9619a9857b6412c89969e4b83eb2a8) Updated emacs
* [`4e632e99`](https://github.com/nix-community/emacs-overlay/commit/4e632e99aa1352521f583b43f777c4b68111159c) Updated nongnu
* [`b95dbb1a`](https://github.com/nix-community/emacs-overlay/commit/b95dbb1a831e484036eac624fa9bb8b0e74bc8cb) Updated elpa
* [`47ae9445`](https://github.com/nix-community/emacs-overlay/commit/47ae944500aabb8102c9588899a3b3445326bc3a) Updated melpa
* [`2fa195d9`](https://github.com/nix-community/emacs-overlay/commit/2fa195d926963ec26b34fa463412081f93d91747) Updated emacs
* [`4e90e203`](https://github.com/nix-community/emacs-overlay/commit/4e90e203bc51f2453e0b2cbe4a453fcc65d7c85f) Updated melpa
* [`d8b5b164`](https://github.com/nix-community/emacs-overlay/commit/d8b5b1643d15bca3308b687918461f5f370f8c6d) Updated emacs
* [`2600d932`](https://github.com/nix-community/emacs-overlay/commit/2600d9324f1235740233313b9a8cec81d8f2db4b) org-re-reveal: fix src hash
* [`cea26be4`](https://github.com/nix-community/emacs-overlay/commit/cea26be44236b6fbcdf6a59683447297dd1d266e) Updated flake inputs
* [`9da82e6c`](https://github.com/nix-community/emacs-overlay/commit/9da82e6c25030b8e4d3e77b8998f5001d6ff4db7) Updated nongnu
* [`579f9ad9`](https://github.com/nix-community/emacs-overlay/commit/579f9ad90b9cfe0fea9c6e127558993dcb3a8a92) Updated elpa
* [`dbb1f4a7`](https://github.com/nix-community/emacs-overlay/commit/dbb1f4a704ad22f6ce85c6e9f2ddb17eb5d8f043) Updated melpa
* [`267b2c6c`](https://github.com/nix-community/emacs-overlay/commit/267b2c6c63a6bd881b2b0df3b320e480d16b2cc6) Updated emacs
* [`019e8f27`](https://github.com/nix-community/emacs-overlay/commit/019e8f27127bd6df233c445b6abbfcc90b1420e4) Updated flake inputs
* [`51492f08`](https://github.com/nix-community/emacs-overlay/commit/51492f085b00e7841e588ec543f126e3d9499c4d) Updated nongnu
* [`b4eb6f51`](https://github.com/nix-community/emacs-overlay/commit/b4eb6f516044b9cd684688db5b76929719fe75aa) Updated elpa
* [`a61682fe`](https://github.com/nix-community/emacs-overlay/commit/a61682fe03208c4c7dd03df1168cc649e9b53a2e) Updated melpa
* [`808ae038`](https://github.com/nix-community/emacs-overlay/commit/808ae0382b035600bc8829918bfe5ea1fa63dab4) Updated emacs
* [`eb9ed82a`](https://github.com/nix-community/emacs-overlay/commit/eb9ed82ad09dd90999157ae430a3bd4f760fe9a9) Updated melpa
* [`3afcb9aa`](https://github.com/nix-community/emacs-overlay/commit/3afcb9aa51c5e6ac42c643c035729c695bd15a60) Updated flake inputs
* [`5b2a716c`](https://github.com/nix-community/emacs-overlay/commit/5b2a716c2380d7d1c1b0a914f2dcf5c977d7f79f) Updated nongnu
* [`d569e8e8`](https://github.com/nix-community/emacs-overlay/commit/d569e8e880441dee471e379fb6bf670ddce8205c) Updated elpa
* [`1c9ef4a0`](https://github.com/nix-community/emacs-overlay/commit/1c9ef4a01434e2704dd0dfe4f7cf7c6c3152a1a8) Updated emacs
* [`610d71db`](https://github.com/nix-community/emacs-overlay/commit/610d71db8074a369a0498572ff75b444d284409d) Updated melpa
* [`1b606ebe`](https://github.com/nix-community/emacs-overlay/commit/1b606ebe8ca90d7f0d43c661b7b0225facf5c08e) Updated nongnu
* [`23410425`](https://github.com/nix-community/emacs-overlay/commit/23410425af373451cf1bc19de6d3cc02a8704d2f) Updated elpa
* [`bd42aa36`](https://github.com/nix-community/emacs-overlay/commit/bd42aa36e2ebb59a4f7d3ad09c424cb40542eb83) Updated melpa
* [`724499d6`](https://github.com/nix-community/emacs-overlay/commit/724499d6305658949e21e01f5624ac429d9ab48a) Updated emacs
* [`60fccc42`](https://github.com/nix-community/emacs-overlay/commit/60fccc4236b6045b8d66e3bd4e5996dd6f3f55e6) Updated melpa
* [`31ee8006`](https://github.com/nix-community/emacs-overlay/commit/31ee8006935d8c3ce678854d8e46d74915a16960) Updated emacs
* [`b994d654`](https://github.com/nix-community/emacs-overlay/commit/b994d654c0125ba00b4e71807b8b136165f22f6c) Updated nongnu
* [`9d9fd66b`](https://github.com/nix-community/emacs-overlay/commit/9d9fd66b04458c37431f5d24f3931cd842bdb936) Updated elpa
* [`4d18179d`](https://github.com/nix-community/emacs-overlay/commit/4d18179df3bdc525d47b305a9c2bfd3777d5daa4) Updated melpa
* [`19f9488c`](https://github.com/nix-community/emacs-overlay/commit/19f9488c8af0a0572e610d1bbf9d9b833df57524) Updated emacs
* [`b2d9aed4`](https://github.com/nix-community/emacs-overlay/commit/b2d9aed459819478d03016c728fdfdc797801ff3) Updated nongnu
* [`6165241a`](https://github.com/nix-community/emacs-overlay/commit/6165241a57f8a03b1442f2d8206a049d71c1f224) Updated elpa
* [`aeb802f1`](https://github.com/nix-community/emacs-overlay/commit/aeb802f1435767a5b004dfeb551461b59b66ae38) Updated melpa
* [`bcc49aba`](https://github.com/nix-community/emacs-overlay/commit/bcc49aba7034c9ec53a9a2cb84f738b6e0096031) Updated emacs
* [`ce25fe74`](https://github.com/nix-community/emacs-overlay/commit/ce25fe74afb1cdcaaea2f9bad45af6ade508cba0) Updated melpa
* [`f42d70c2`](https://github.com/nix-community/emacs-overlay/commit/f42d70c2f52e2e1da8e6cdd0fb1a5a1485e51a5e) Updated emacs
* [`60c7e153`](https://github.com/nix-community/emacs-overlay/commit/60c7e153c4427fda98f8a3f529af964bae90f722) Updated nongnu
* [`9452615e`](https://github.com/nix-community/emacs-overlay/commit/9452615e48e59a0230689d652fbd4577f8196439) Updated elpa
* [`b97a3361`](https://github.com/nix-community/emacs-overlay/commit/b97a3361d70afa1c7445a5f2a1de7bd0ee4b0962) Updated melpa
* [`7ea1ac24`](https://github.com/nix-community/emacs-overlay/commit/7ea1ac244572b6186965d15ef05ec5d466aac1ea) Updated emacs
* [`3e3eebc9`](https://github.com/nix-community/emacs-overlay/commit/3e3eebc9023bd4d9f12492a122ffedaad8e3503e) Updated flake inputs
* [`1a68860f`](https://github.com/nix-community/emacs-overlay/commit/1a68860fdb98eed4af06df26aebfca5a2de6e4ef) Updated nongnu
* [`07687120`](https://github.com/nix-community/emacs-overlay/commit/07687120e3ad939356003cbceaecf8ec70b2652e) Updated elpa
* [`b682a3e4`](https://github.com/nix-community/emacs-overlay/commit/b682a3e473d4fd927a29f27a5a9c476804b1b13c) Updated melpa
* [`27ba6c50`](https://github.com/nix-community/emacs-overlay/commit/27ba6c5075c4b1b53db6a1c7795b16ba4047dde7) Updated emacs
* [`aa264941`](https://github.com/nix-community/emacs-overlay/commit/aa264941dac4e2f66f8cf516cd59563a394473c4) Updated flake inputs
* [`b43f60c8`](https://github.com/nix-community/emacs-overlay/commit/b43f60c83346eb87f0026f8f8b9fe1ea46e02b14) Updated melpa
* [`1fce7ecc`](https://github.com/nix-community/emacs-overlay/commit/1fce7ecc2e2f9ed0687443a752b7c90528fff383) Updated emacs
* [`d4b1161f`](https://github.com/nix-community/emacs-overlay/commit/d4b1161f3dcdfc3791ca12c78f2b9e8a30b2a806) Updated nongnu
* [`e47075c2`](https://github.com/nix-community/emacs-overlay/commit/e47075c2d6dbf9ac28b3a1666e27f82b5c31e112) Updated elpa
* [`d86a74c6`](https://github.com/nix-community/emacs-overlay/commit/d86a74c6f6a4331686551423190b9d9d906acc36) Updated melpa
* [`cb257a1d`](https://github.com/nix-community/emacs-overlay/commit/cb257a1d672f75f2f3e375fe1080216131dd1fb0) Updated emacs
* [`346d78c7`](https://github.com/nix-community/emacs-overlay/commit/346d78c7e60dd9c70ff21e8868ba5cd29d8c44cc) Updated nongnu
* [`bae62204`](https://github.com/nix-community/emacs-overlay/commit/bae622049a9a44675ed9bcc786110a8764e40109) Updated elpa
* [`e5cebb96`](https://github.com/nix-community/emacs-overlay/commit/e5cebb964c2cc690268a9b473d68f6cafe50ac23) Updated melpa
* [`19e1382e`](https://github.com/nix-community/emacs-overlay/commit/19e1382e83aff8a36649951d1b31d7894f34d9b6) Updated emacs
* [`7a2638b7`](https://github.com/nix-community/emacs-overlay/commit/7a2638b739c4442c081ebe9d9c1afbf6f788e5f4) Updated melpa
* [`703bcc93`](https://github.com/nix-community/emacs-overlay/commit/703bcc932b2865780db8a6dff16f01f1646f8012) Updated emacs
* [`1682b0cf`](https://github.com/nix-community/emacs-overlay/commit/1682b0cff38bb84874d4b025f67b0cd09c3b9209) Updated nongnu
* [`db9a65f3`](https://github.com/nix-community/emacs-overlay/commit/db9a65f3237a2c62880c7b6a3c42df46033fd9db) Updated elpa
* [`9160b7d6`](https://github.com/nix-community/emacs-overlay/commit/9160b7d694548b35eb19e75e566fd981306deb58) Updated melpa
* [`6d55b448`](https://github.com/nix-community/emacs-overlay/commit/6d55b448e61097a6efdd8ee2aa5c48b8bbbf9c8c) Updated emacs
* [`7bcb7f0f`](https://github.com/nix-community/emacs-overlay/commit/7bcb7f0f34a5c1619290c5f4b965485931d88f32) Updated nongnu
* [`823311cf`](https://github.com/nix-community/emacs-overlay/commit/823311cf70d42ac9a47d739f03f32caaee1afb22) Updated elpa
* [`3e99d755`](https://github.com/nix-community/emacs-overlay/commit/3e99d7551b584e6bea226e3584a9a1badb1dc0be) Updated melpa
* [`1dbdb57a`](https://github.com/nix-community/emacs-overlay/commit/1dbdb57a8759ac9f32ad5ce8effa188bf43c70da) Updated emacs
* [`4cdd23dd`](https://github.com/nix-community/emacs-overlay/commit/4cdd23dd293850c2df56732e7272c8fd1be98b64) Updated melpa
* [`6a171492`](https://github.com/nix-community/emacs-overlay/commit/6a1714928534fd6e2c0c68f42507f05d9dba6820) Updated emacs
* [`8566c4f4`](https://github.com/nix-community/emacs-overlay/commit/8566c4f4dea1698078dc003a7c55ba7f59ac3b27) Updated flake inputs
* [`864e85fe`](https://github.com/nix-community/emacs-overlay/commit/864e85fe4ddf014da3dd5d296e987ba3fa69c7d4) Updated nongnu
* [`290c10bc`](https://github.com/nix-community/emacs-overlay/commit/290c10bc7a3c4a66410e2f25aed40998a884c511) Updated elpa
* [`db7e1fa7`](https://github.com/nix-community/emacs-overlay/commit/db7e1fa7a20e0815263063f7cea8b7883f1f08dc) Updated melpa
* [`b9d19638`](https://github.com/nix-community/emacs-overlay/commit/b9d19638352bd5a7b601ac47f3f20d8fb9b82028) Updated emacs
* [`3c71542f`](https://github.com/nix-community/emacs-overlay/commit/3c71542fc0dd16002a5336767c1a9e0d10a3a746) python-mode: fix src hash
* [`616ec6ce`](https://github.com/nix-community/emacs-overlay/commit/616ec6ce6e0df878a95ad6884452fd728e8e9386) Updated flake inputs
* [`93fbd5a8`](https://github.com/nix-community/emacs-overlay/commit/93fbd5a873d74bb035f249a65c20cb0dfdc0c2e5) Updated melpa
* [`5c22a238`](https://github.com/nix-community/emacs-overlay/commit/5c22a2387d4ac1e1d64d66489e7d3ecb0a30cbcd) Updated emacs
* [`9d534b57`](https://github.com/nix-community/emacs-overlay/commit/9d534b5749cd539145580f0ad588a912990841dc) Updated elpa
* [`b33e5b1c`](https://github.com/nix-community/emacs-overlay/commit/b33e5b1ce7e2bdb6e8532d259928c89f2bb3c973) Updated nongnu
* [`45285809`](https://github.com/nix-community/emacs-overlay/commit/45285809053bff315187b2c915554f19608dc0b6) Updated elpa
* [`a6b2ff5a`](https://github.com/nix-community/emacs-overlay/commit/a6b2ff5a6122cca749ad9686f1ef5f70dfba667a) Updated melpa
* [`16b1c42e`](https://github.com/nix-community/emacs-overlay/commit/16b1c42e9567cb7fc145674e169d1d724a221a8d) Updated emacs
* [`76ed1d1b`](https://github.com/nix-community/emacs-overlay/commit/76ed1d1b6c3ae80cc12dfc464e3efa743cccd720) Updated melpa
* [`40a9308b`](https://github.com/nix-community/emacs-overlay/commit/40a9308b06ee2061c5871038024ffcfd992a9ce8) Updated emacs
* [`a8c83905`](https://github.com/nix-community/emacs-overlay/commit/a8c8390564a2189d14eace17a02e65e19e17f766) Updated nongnu
* [`c553e898`](https://github.com/nix-community/emacs-overlay/commit/c553e898a9639c65ee1ace89580edf48147530cf) Updated elpa
* [`313b7a77`](https://github.com/nix-community/emacs-overlay/commit/313b7a777f7f9755ea8a7c3c284f0d0ab6f9520b) Updated melpa
* [`849cd492`](https://github.com/nix-community/emacs-overlay/commit/849cd4920ec9a1976dc916b192f7f2401ec13c5b) Updated emacs
* [`580c98c4`](https://github.com/nix-community/emacs-overlay/commit/580c98c4c9a140f2f6f01d9c87bb0f7130420f82) Updated flake inputs
* [`cbb037af`](https://github.com/nix-community/emacs-overlay/commit/cbb037aff028f1ead04d0364dafa37488c00e3ed) Updated nongnu
* [`bc789ba9`](https://github.com/nix-community/emacs-overlay/commit/bc789ba9f1147999c213d625f635a155f043151c) Updated elpa
* [`03bc4aa1`](https://github.com/nix-community/emacs-overlay/commit/03bc4aa163546aa0d3c5909c8047fcd2992e0cd3) Updated melpa
* [`d4c8403d`](https://github.com/nix-community/emacs-overlay/commit/d4c8403d372379595c2e608f36312157e0fc0938) Updated emacs
* [`092a831b`](https://github.com/nix-community/emacs-overlay/commit/092a831b09bce1c328efeacd99fc1dcb2f825655) Updated melpa
* [`2ac7be36`](https://github.com/nix-community/emacs-overlay/commit/2ac7be36de0ef1e6936c7ba89fbf8d2ae87f4ddd) Updated emacs
* [`aef3d84c`](https://github.com/nix-community/emacs-overlay/commit/aef3d84c6134082f056e27fb538606ca6237c786) Updated nongnu
* [`ea0e0d32`](https://github.com/nix-community/emacs-overlay/commit/ea0e0d323d7a6da70589a290ff5eb8c15d3777c0) Updated elpa
* [`fea7b861`](https://github.com/nix-community/emacs-overlay/commit/fea7b861199eab24c45c1cccae4063e09822e247) Updated melpa
* [`93e148ba`](https://github.com/nix-community/emacs-overlay/commit/93e148ba6bdd5db1a40878ab04f5901e263553f6) Updated emacs
* [`e4d0afb6`](https://github.com/nix-community/emacs-overlay/commit/e4d0afb69413c4e051817da3a025073bde388a30) Updated flake inputs
* [`eb4887de`](https://github.com/nix-community/emacs-overlay/commit/eb4887de64a5fd0e12654b6e1256ca210b55f52f) Updated nongnu
* [`266302f8`](https://github.com/nix-community/emacs-overlay/commit/266302f8e5781ba8b4597d4da4e471b2c81a42b4) Updated elpa
* [`a9743da3`](https://github.com/nix-community/emacs-overlay/commit/a9743da37057722611286077ea01fc55efc0099e) Updated melpa
* [`e6361983`](https://github.com/nix-community/emacs-overlay/commit/e6361983cfc586fc16d27aba29cc799818f2051b) Updated emacs
* [`dd4c7375`](https://github.com/nix-community/emacs-overlay/commit/dd4c7375201c434741edf42ce560cf2aa56daa8d) Updated melpa
* [`d9008b26`](https://github.com/nix-community/emacs-overlay/commit/d9008b26a6827690c44d65d6c92ba90176c0dede) Updated emacs
* [`c4ac49fb`](https://github.com/nix-community/emacs-overlay/commit/c4ac49fb4b212fcf52867f2fe28bf3f29bd25b80) Updated nongnu
* [`ac743c4c`](https://github.com/nix-community/emacs-overlay/commit/ac743c4c14382f4ec05c2f8c54598ef6a5cdf0f3) Updated elpa
* [`29040dae`](https://github.com/nix-community/emacs-overlay/commit/29040daea41a538090d3d9c5fe88db73a7058b24) Updated melpa
* [`b32134c9`](https://github.com/nix-community/emacs-overlay/commit/b32134c9ab10f44aec6dfc3e76d4e51383130cd8) Updated emacs
* [`fdd12f9f`](https://github.com/nix-community/emacs-overlay/commit/fdd12f9f1011c6bf22aad083aadbeea2a4396388) Updated flake inputs
* [`4fbe4254`](https://github.com/nix-community/emacs-overlay/commit/4fbe4254fdf5223b5b66a222e801030f70944885) Updated nongnu
* [`cef67817`](https://github.com/nix-community/emacs-overlay/commit/cef6781712f39fe74f09cdcfc109799ffe81aba6) Updated elpa
* [`c6be3549`](https://github.com/nix-community/emacs-overlay/commit/c6be354945805ac0015725b7b9b49e9ecad85c8f) Updated melpa
* [`d39448af`](https://github.com/nix-community/emacs-overlay/commit/d39448af6c3224f349aba1fd8923e1833d8f4460) Updated melpa
* [`6164f832`](https://github.com/nix-community/emacs-overlay/commit/6164f832e3e21a8c5df6f3ccaa82facf3cef21c0) Updated emacs
* [`115c507f`](https://github.com/nix-community/emacs-overlay/commit/115c507f3298f60579d8ae37b948cc2fbd6955b4) Updated flake inputs
* [`fd96db82`](https://github.com/nix-community/emacs-overlay/commit/fd96db82c19e763bd22b7e92299e387814caee7f) Updated nongnu
* [`081e845f`](https://github.com/nix-community/emacs-overlay/commit/081e845fa004616a620ccde84fea9ddeedfdc43b) Updated elpa
* [`5fa8029c`](https://github.com/nix-community/emacs-overlay/commit/5fa8029c3c950a8fbf68335a13158e64dcc27106) Updated melpa
* [`6da4875e`](https://github.com/nix-community/emacs-overlay/commit/6da4875ee60564cb6941f9365494252d24061d1e) Updated emacs
* [`f0c5236b`](https://github.com/nix-community/emacs-overlay/commit/f0c5236b15d6db5a3a57306fc88819420660fbed) Updated nongnu
* [`d799dd63`](https://github.com/nix-community/emacs-overlay/commit/d799dd6335a6fa6492e35d3ef8fe162e733b13c5) Updated elpa
* [`38a249fd`](https://github.com/nix-community/emacs-overlay/commit/38a249fda284859c84a52b4cf01eb4ce228123ee) Updated melpa
* [`0d92783c`](https://github.com/nix-community/emacs-overlay/commit/0d92783cc1d0ec68d631f6e93204b21282505806) Updated emacs
* [`3fe8f6c0`](https://github.com/nix-community/emacs-overlay/commit/3fe8f6c091e799d7a932f9447b762df7c8812619) Updated melpa
