### PR TITLE
niv doomemacs: update 56ce6cc2 -> fc7b179e

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "doomemacs",
         "repo": "doomemacs",
-        "rev": "56ce6cc284e8f4dd0cb0704dde6694a1b8e500ed",
-        "sha256": "193yyg1nvg0nx80vf9w782vn374sdanhiqz0wdsqn67q4k2dkbbn",
+        "rev": "fc7b179e6cefa59097c87fd58c8272b6121a1dff",
+        "sha256": "11cqkzb15js9byppagnnprrr7452gxsvadx88njaxxjyj147j86w",
         "type": "tarball",
-        "url": "https://github.com/doomemacs/doomemacs/archive/56ce6cc284e8f4dd0cb0704dde6694a1b8e500ed.tar.gz",
+        "url": "https://github.com/doomemacs/doomemacs/archive/fc7b179e6cefa59097c87fd58c8272b6121a1dff.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "emacs-overlay": {


### PR DESCRIPTION
## Changelog for doomemacs:
Branch: master
Commits: [doomemacs/doomemacs@56ce6cc2...fc7b179e](https://github.com/doomemacs/doomemacs/compare/56ce6cc284e8f4dd0cb0704dde6694a1b8e500ed...fc7b179e6cefa59097c87fd58c8272b6121a1dff)

* [`8846d151`](https://github.com/doomemacs/doomemacs/commit/8846d151814ebbf7fb90d9d5dd16cd737257408e) perf(lib): setq-hook!: don't load pp at startup
* [`117d9127`](https://github.com/doomemacs/doomemacs/commit/117d9127f3ba5ae57c6841a4af60626d38217225) fix(python): stop anaconda-eldoc-mode when lsp server launches
* [`7beb83ca`](https://github.com/doomemacs/doomemacs/commit/7beb83ca6f32e860abee86c593f51b35216287b0) bump: :lang python
* [`bca4265e`](https://github.com/doomemacs/doomemacs/commit/bca4265e64c29698a061a879a84407c7c1d80d7d) fix(vertico): fix display with embark-act-all
* [`bf528be1`](https://github.com/doomemacs/doomemacs/commit/bf528be137d21fe83de332e708bd619684a9acff) fix(vc-gutter): diff-hl-revert-hunk misplacing point
* [`71d9ceea`](https://github.com/doomemacs/doomemacs/commit/71d9ceead42611d83efc6cc58df3ea7cbc0dbdac) fix: ensure empty DEBUG envvar is ignored
* [`c95015d7`](https://github.com/doomemacs/doomemacs/commit/c95015d7066476d32784c6f0ed7463b92b931bec) bump: :completion
* [`49d8cbd8`](https://github.com/doomemacs/doomemacs/commit/49d8cbd8bc3e80239a19e8ea5fbfe30db40ba34d) fix: use mirror for nongnu-elpa
* [`012cacaa`](https://github.com/doomemacs/doomemacs/commit/012cacaa86c5bd70c191beaf98e815a517887ed2) fix(kotlin): module check for flycheck-kotlin
* [`466490c2`](https://github.com/doomemacs/doomemacs/commit/466490c252d06f42a9c165f361de74a6e6abad8d) release(modules): 25.04.0-dev
* [`32368d0e`](https://github.com/doomemacs/doomemacs/commit/32368d0e945ba56e475488deb2aad5a0e566212b) bump: projectile
* [`d9292040`](https://github.com/doomemacs/doomemacs/commit/d92920405ac6d8364baeff3ad26b4d5db3687f50) docs(fsharp): add presence check for `dotnet fsi`
* [`53387f49`](https://github.com/doomemacs/doomemacs/commit/53387f49053d39993e0c0787c06e27a9528eb19f) fix(vertico): remove undefined completion style
* [`f65fdd59`](https://github.com/doomemacs/doomemacs/commit/f65fdd598a3a2bc1ba67a7f414a7e5f165d79785) bump: :editor evil
* [`869a5e63`](https://github.com/doomemacs/doomemacs/commit/869a5e631eda8fd691ccf36b25210aac0aa7f007) refactor!(emacs-lisp): remove cask support
* [`1d18ac4e`](https://github.com/doomemacs/doomemacs/commit/1d18ac4e41a89f338dd1501cc588171fa3aedf20) bump: :doom
* [`960b537c`](https://github.com/doomemacs/doomemacs/commit/960b537cf67abfdceae65ad1f4b063f99064539f) bump: :emacs dired
* [`0e576806`](https://github.com/doomemacs/doomemacs/commit/0e5768064cf0437624e2c9c6c3f5134f4249272d) fix: TAB & RET keybinds in daemon sessions
* [`2f54077c`](https://github.com/doomemacs/doomemacs/commit/2f54077c3eec779faba42ff6658d548629b574c8) perf(tty): move global-kkp-mode to tty-setup-hook
* [`056d117b`](https://github.com/doomemacs/doomemacs/commit/056d117b07ecc84361a54fe89d67acacdf061bef) fix(dired): void-function dirvish-find-entry-a error
* [`ef9ff57c`](https://github.com/doomemacs/doomemacs/commit/ef9ff57caf93c3d164b14297184931aeb79d9611) bump: :tools debugger lsp
* [`0163aef7`](https://github.com/doomemacs/doomemacs/commit/0163aef765968e4ce36daca0019e772e9b1ca06e) bump: :tools magit
* [`6cc12841`](https://github.com/doomemacs/doomemacs/commit/6cc12841719821cb3574e7bf2ffe9e5ce2af551a) bump: :lang org
* [`bdd37019`](https://github.com/doomemacs/doomemacs/commit/bdd3701987e80f1b1044d2ee0a725b5cb5828705) fix(common-lisp): inferior-lisp-program: accept list
* [`2f7f37d4`](https://github.com/doomemacs/doomemacs/commit/2f7f37d49b94fb8d46ff6ffa51a3375ac5883465) refactor(evil): evil-collection: simplify init
* [`dac6e05b`](https://github.com/doomemacs/doomemacs/commit/dac6e05b87b5ab19a8660faafbd2718d99276b2e) refactor: deprecate appendq!, prependq!, & delq! macros
* [`1d3830f8`](https://github.com/doomemacs/doomemacs/commit/1d3830f8c014e00da56231c7fdebcafd300f94f1) bump: :editor
* [`d5e161a9`](https://github.com/doomemacs/doomemacs/commit/d5e161a9aebb9b195eecf225e00e739b034c75c3) bump: :tools
* [`4def7f35`](https://github.com/doomemacs/doomemacs/commit/4def7f359cf696fd9afbca08631409b61fdfc787) refactor(evil): remove +evil--dont-move-cursor-a
* [`c3a93884`](https://github.com/doomemacs/doomemacs/commit/c3a9388452df549e40b644b3fd9e5dacb0550d91) fix: projectile: centralize per-project cache files
* [`ad7d9fa6`](https://github.com/doomemacs/doomemacs/commit/ad7d9fa65794c978a849577244898c6815a4a69b) refactor: projectile init
* [`b2944943`](https://github.com/doomemacs/doomemacs/commit/b29449434b04a774a09d09955dba6dd0bd4ddf72) nit(evil): revise & reformat comments
* [`65a5e50d`](https://github.com/doomemacs/doomemacs/commit/65a5e50d1c5d88e5407934213257dd1c0bd73f7a) fix(magit): transient: window config jank
* [`da071559`](https://github.com/doomemacs/doomemacs/commit/da071559e1c851f989e6e7c5eda700c6033b5ffb) fix(magit): polish +magit-display-buffer-fn
* [`1e1fd5c8`](https://github.com/doomemacs/doomemacs/commit/1e1fd5c8e45382034f53d2a617697b2ba75bcc42) fix(magit): evil-collection-magit-section overrides
* [`8a2c7fe3`](https://github.com/doomemacs/doomemacs/commit/8a2c7fe3d430d899e85295f80311917006c8c733) fix: malformed projectile-known-projects-file
* [`5b103261`](https://github.com/doomemacs/doomemacs/commit/5b103261f4169e6e1d0d3633163a8e2031234dcf) feat: add wsl detection
* [`1ac579e0`](https://github.com/doomemacs/doomemacs/commit/1ac579e08ac6e8b0f63c455eea7443ce0293b95a) fix: clipboard issues on Windows + WSL
* [`5e43944e`](https://github.com/doomemacs/doomemacs/commit/5e43944ef324ff3c04a6cff995cae86ae2878efd) fix(evil): evil-collection: disable some submodules
* [`c9afc6cd`](https://github.com/doomemacs/doomemacs/commit/c9afc6cdd33b1f515ba451a7c6a6b0f77a1c2ec6) bump: :emacs :term :app :email
* [`9e624b5d`](https://github.com/doomemacs/doomemacs/commit/9e624b5dfe54b7d8523d55313c22a5ef54659540) fix(evil): +evil-collection-disabled-list implementation
* [`17a870fe`](https://github.com/doomemacs/doomemacs/commit/17a870fef816a3c392af79a7cf45b27190cab611) fix(magit): reload related buffers after git ops
* [`64c71949`](https://github.com/doomemacs/doomemacs/commit/64c71949f8af0b0e23ff4679eada02d299b6791d) fix: projectile-find-file: stringp error in no-project buffers
* [`65d43ae4`](https://github.com/doomemacs/doomemacs/commit/65d43ae472103a847d52f4ae05796ec0d80036d3) fix: init known projects before projectile-ensure-project
* [`7827d32c`](https://github.com/doomemacs/doomemacs/commit/7827d32cc6de60d94dda6971135658a42099d4a2) refactor(go): 'go test ...' commands
* [`a1ff0513`](https://github.com/doomemacs/doomemacs/commit/a1ff0513aa48d7e68c308e402189dc01b29b77c8) feat(go): add 'go generate ...' keybinds
* [`2eca7016`](https://github.com/doomemacs/doomemacs/commit/2eca7016151820a65e1430a23859fa4ad19e67b9) fix(corfu): trigger cape-file on { in latex buffers
* [`dfe5b8d4`](https://github.com/doomemacs/doomemacs/commit/dfe5b8d4e91173e1cba8e2432cace0168c4e6976) refactor(corfu): conform to conventions
* [`d8bbe03d`](https://github.com/doomemacs/doomemacs/commit/d8bbe03d0c7f3c8d970049ae15826b7291ae3940) bump: :lang haskell
* [`9be19e20`](https://github.com/doomemacs/doomemacs/commit/9be19e20dc1e5a20289715223ce3141b5a348e1d) bump: :lang cc clojure coq elixir lua ocaml php purescript
* [`5ab71091`](https://github.com/doomemacs/doomemacs/commit/5ab710911a70a511af8009401644447cbde3b16a) bump: :email wanderlust
* [`67933f9f`](https://github.com/doomemacs/doomemacs/commit/67933f9f620013e0bc180c81bc30678a64b35702) tweak(wanderlust): Ignore headers from SMX email filter
* [`f3165c1c`](https://github.com/doomemacs/doomemacs/commit/f3165c1c5b67d811d15a9028b5681401e40545b4) fix(corfu): corfu-terminal for daemon users
* [`74817a6f`](https://github.com/doomemacs/doomemacs/commit/74817a6f251a81f179ac0ff4fe635ba80df16849) nit(corfu): revise comments, grammar, and formatting
* [`00d624d6`](https://github.com/doomemacs/doomemacs/commit/00d624d66abe8fec5b8aa92d1fca3d0066858f45) tweak(corfu): completions-first-difference: don't nullify :inherit
* [`084a0f42`](https://github.com/doomemacs/doomemacs/commit/084a0f42a35c7854dcd8b03796f4a1bbb251a864) bump: ws-butler
* [`26c372cd`](https://github.com/doomemacs/doomemacs/commit/26c372cd01728a4555b1642fc1409a4763c98e21) fix(evil): don't auto-set evil-shift-width in org-mode
* [`52183d71`](https://github.com/doomemacs/doomemacs/commit/52183d717d9cadb0c2ca8a9cd5f135a9905d33c0) fix(corfu): void-variable cape-file-prefix error
* [`0d1c8942`](https://github.com/doomemacs/doomemacs/commit/0d1c8942dbdd8503ed62b4efa97f571b5ef87e02) fix(corfu): fix default minibuffer completion
* [`d775ed82`](https://github.com/doomemacs/doomemacs/commit/d775ed822cf14d4c71dffab2f087e49000f69ff0) fix(corfu): void-variable local-map error
* [`8b37baad`](https://github.com/doomemacs/doomemacs/commit/8b37baada7e99478d437fddcf591a199007a2182) revert: refactor(evil): remove +evil--dont-move-cursor-a
* [`5b11ac72`](https://github.com/doomemacs/doomemacs/commit/5b11ac7267b9976e80c4e2f46ad718375e8af63e) feat(popup): +popup/raise: use visible popup if none selected
* [`9c760c91`](https://github.com/doomemacs/doomemacs/commit/9c760c9106aacded9ea925c2bddaf900587991e7) docs: update paypal link in project readme
* [`68ec9e9c`](https://github.com/doomemacs/doomemacs/commit/68ec9e9c86009623ced5849343534bced2e6fcd3) tweak(evil): evil-escape-key-sequence: disable by default
* [`99e46ed6`](https://github.com/doomemacs/doomemacs/commit/99e46ed69fadb119269b6a53705af93e1c713c78) fix(cc,javascript): projectile-globally-ignored-directories
* [`7941dfa7`](https://github.com/doomemacs/doomemacs/commit/7941dfa766581d7f6de10a538c7f2033f320bca8) fix(workspaces): only trigger projectile-*-switch-project-hook once
* [`c6f979b4`](https://github.com/doomemacs/doomemacs/commit/c6f979b4e097d0b8950ef209a03ba86ab579eba4) refactor(workspaces): projectile integration
* [`6f6302d4`](https://github.com/doomemacs/doomemacs/commit/6f6302d42d1f094b35f0236e1641a7a97f7f34c5) fix(workspaces): clobbering pre-existing workspaces on switch-project
* [`6a1ab50e`](https://github.com/doomemacs/doomemacs/commit/6a1ab50e02c8703995d872caa785be4b948dbca6) release(modules): 25.05.0-dev
* [`94731a85`](https://github.com/doomemacs/doomemacs/commit/94731a85c27a9bad4eec639170480ad660769d77) bump: :ui :input :config :checkers
* [`fc7b179e`](https://github.com/doomemacs/doomemacs/commit/fc7b179e6cefa59097c87fd58c8272b6121a1dff) bump: :lang
