### PR TITLE
niv nixpkgs: update a4325209 -> 9cee9575

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a4325209863278fc096401bfe9e0a9da34aa9e00",
-        "sha256": "02pnyxmv1vs33l6jpmgdki1dqj3i8hsxyg90sj6ls4p0wx7aqk2y",
+        "rev": "9cee957549db78e17e905f6697511f81443c59a5",
+        "sha256": "0b86iqk5yqzr0gna4gpkmf65msf11akl7s8b4l2c355a1xmmq3z3",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/a4325209863278fc096401bfe9e0a9da34aa9e00.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/9cee957549db78e17e905f6697511f81443c59a5.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@a4325209...9cee9575](https://github.com/nixos/nixpkgs/compare/a4325209863278fc096401bfe9e0a9da34aa9e00...9cee957549db78e17e905f6697511f81443c59a5)

* [`b53b83ac`](https://github.com/NixOS/nixpkgs/commit/b53b83ac9a982a5b45c339a70dd9c97c5aae96dc) mamba-cpp: init at 2.0.5
* [`ec051ee8`](https://github.com/NixOS/nixpkgs/commit/ec051ee841b36bd329374c47424a244b45d5bf98) distrobox: 1.8.1 -> 1.8.1.2
* [`51dd6751`](https://github.com/NixOS/nixpkgs/commit/51dd6751364fae336c85a98185dade696303b0a2) python312Packages.pyssim: 0.6 -> 0.7
* [`d1fd73cb`](https://github.com/NixOS/nixpkgs/commit/d1fd73cbf88eb6770e54f12100daf39c420b1dfd) turbovnc: 3.1.3 -> 3.1.4
* [`9f11f7ed`](https://github.com/NixOS/nixpkgs/commit/9f11f7ed09226d386463e50d87c446e274f79fab) pls: 0.0.1-beta.8 -> 0.0.1-beta.9
* [`95ae51c0`](https://github.com/NixOS/nixpkgs/commit/95ae51c09a588e3325272578298a5a93b16077b7) traefik: 3.3.3 -> 3.3.4
* [`959364e6`](https://github.com/NixOS/nixpkgs/commit/959364e688b92d0f907f0d45215098506b5b8858) rocmPackages_5.clr: fix dangling symlink
* [`a7f6cc0a`](https://github.com/NixOS/nixpkgs/commit/a7f6cc0a767b3a9db14a5e590ef5b681c729b9df) homebox: 0.17.0 -> 0.18.0
* [`1cdca469`](https://github.com/NixOS/nixpkgs/commit/1cdca4694471f8067cdfd313adde18efe10fc62e) nixos/homebox: update default for 0.18.0
* [`2a574e25`](https://github.com/NixOS/nixpkgs/commit/2a574e25f14a9c2106f2844e92bb56d62127159c) navidrome: create music folder with systemd.tmpfiles
* [`bc0f86ab`](https://github.com/NixOS/nixpkgs/commit/bc0f86abd84797216bda215151c9ff4b939568bd) signal-desktop-source: init at 7.45.1
* [`76fee266`](https://github.com/NixOS/nixpkgs/commit/76fee26607007e8bc759039c1ddd587c996d0d32) maintainers: add Emin017
* [`1e70da0c`](https://github.com/NixOS/nixpkgs/commit/1e70da0cde827bbc4f845266e3daffa69c089e2c) nextcloud30Packages: restore .override { apps = ...; } support
* [`68747609`](https://github.com/NixOS/nixpkgs/commit/68747609706a913a9308737afc84b1bd8bcca7db) ieda: 0-unstable-2024-10-11 -> 0-unstable-2025-03-12
* [`232e7b6d`](https://github.com/NixOS/nixpkgs/commit/232e7b6df081108480e0a2c0a4df8db8f1e5f944) nixos/vaultwarden: relax hardening when using sendmail
* [`5ab11bb2`](https://github.com/NixOS/nixpkgs/commit/5ab11bb21669f9b9406963f85221cf6ec744fbe4) signal-desktop-source: build sqlcipher with extension from source
* [`d9141add`](https://github.com/NixOS/nixpkgs/commit/d9141addaeb932964afaceefe1b44de3498f0c21) signal-desktop-source: 7.45.1 -> 7.46.0
* [`12663cf4`](https://github.com/NixOS/nixpkgs/commit/12663cf4708c29a396b72b318b8bab2094ca60b7) yaru-theme: 24.10.4 -> 25.04.1
* [`baaf8e7c`](https://github.com/NixOS/nixpkgs/commit/baaf8e7cc8ad2062464d1864a0b2965385f25cd6) tomcat10: 10.1.34 -> 10.1.39
* [`22a4dec3`](https://github.com/NixOS/nixpkgs/commit/22a4dec340522facc00633f5707c9a9b61dc5d36) tomcat9: 9.0.100 -> 9.0.102
* [`5e3c7b0b`](https://github.com/NixOS/nixpkgs/commit/5e3c7b0bfb2c5211b0c38a20dca29a98a8afa25e) cargo-embassy: init at 0.3.4
* [`57c8ceab`](https://github.com/NixOS/nixpkgs/commit/57c8ceab9d3d7b83d8985e13411f0a61d16acb32) signal-desktop-source: build libsignal from source
* [`4b91de61`](https://github.com/NixOS/nixpkgs/commit/4b91de61410ac7ebd0c5a730e93b6f3f7157726c) signal-desktop-source: copy app launch test
* [`0cdafba3`](https://github.com/NixOS/nixpkgs/commit/0cdafba3846c1635720561b75eebdb4295a3c29a) homebox: only copy needed programs to output
* [`6db99b65`](https://github.com/NixOS/nixpkgs/commit/6db99b651b9f74bbbc6a9062b26d9b3d03d24f1b) rhvoice: 1.14.0 -> 1.16.4
* [`0d8cc0d5`](https://github.com/NixOS/nixpkgs/commit/0d8cc0d577a912915aa48a533054e682c14151a5) bikeshed: 5.1.1 -> 5.1.2
* [`20c9782e`](https://github.com/NixOS/nixpkgs/commit/20c9782e2fc4f0b24b6c1b364eb46cbfe9ebc160) nixos/navidrome: Add environmentFile config option
* [`e7fe3f81`](https://github.com/NixOS/nixpkgs/commit/e7fe3f818c4ad5888c51333e5e4d247ee8aad562) adw-gtk3: 5.6 -> 5.7
* [`57ec4f31`](https://github.com/NixOS/nixpkgs/commit/57ec4f3128e381b500234a6b79e58c30ee27ccac) lib.systems: Add arm-embedded-nano
* [`9d8e15a9`](https://github.com/NixOS/nixpkgs/commit/9d8e15a9f23e074fe41fa33b0a37e7d5467b35da) python313Packages.bring-api: 1.0.2 -> 1.1.0
* [`578393e1`](https://github.com/NixOS/nixpkgs/commit/578393e1d63d16a11af7a0d7606d57142bdbc38e) apt-swarm: init at 0.5.0
* [`9fea0529`](https://github.com/NixOS/nixpkgs/commit/9fea0529e5d3d19a37463ea66e53845d020b9c5c) ISSUE_TEMPLATES: remove the package request template
* [`2ef1ede9`](https://github.com/NixOS/nixpkgs/commit/2ef1ede96a43bb3975588f379fdf54e8d3af09fe) kubernetes-helm: make completion generation platform-dependant
* [`6d23c231`](https://github.com/NixOS/nixpkgs/commit/6d23c231cd2fc9dea229cff0b9ca1db6f0b0ceed) kubernetes-helm: use `finalAttrs` pattern
* [`2d4086ae`](https://github.com/NixOS/nixpkgs/commit/2d4086ae705b69884c158df10a15fc9000def3d1) flink: 1.20.1 -> 2.0.0
* [`46f89abe`](https://github.com/NixOS/nixpkgs/commit/46f89abe85595337c558284c0f23f69b20cb6487) ashell: 0.4.0 -> 0.4.1
* [`9a435111`](https://github.com/NixOS/nixpkgs/commit/9a435111dbb766992faa116514fa1a683daef56f) treewide: replace pythonImportCheck(s) with pythonImportsCheck
* [`32d4da5c`](https://github.com/NixOS/nixpkgs/commit/32d4da5cbf64d65979dca96553197290dc2cb1a2) autobrr: 1.59.0 -> 1.60.0
* [`6918b78a`](https://github.com/NixOS/nixpkgs/commit/6918b78ad9d83a9640d2406a6f401bc0cee22cf1) paretosecurity: 0.0.91 -> 0.0.92
* [`8ed63236`](https://github.com/NixOS/nixpkgs/commit/8ed63236346ee2cf4bbb57166f62d1f3ebac5217) fcron: 3.3.3 -> 3.4.0
* [`f8e7e9a1`](https://github.com/NixOS/nixpkgs/commit/f8e7e9a1a8256819a9ff8aec4f3aa2732be0618f) flatito: Update all ruby gems
* [`4f0aca8b`](https://github.com/NixOS/nixpkgs/commit/4f0aca8b23fa21a3faac08b211faf7fa6ba5e388) espup: Set passthru.updateScript
* [`eaec6a5e`](https://github.com/NixOS/nixpkgs/commit/eaec6a5eaffafa7929531f81a5c9df4995c439a5) archtika: fix update script by passing src to passthru
* [`6cc80309`](https://github.com/NixOS/nixpkgs/commit/6cc803093ca90f4f8885fb513eae10f4e44f5470) nixos/archtika: fix mkEnableOption naming
* [`2c916c03`](https://github.com/NixOS/nixpkgs/commit/2c916c0352c301253c75233232673290f5db76ce) archtika: also pass web to passthru to update npmDepsHash
* [`b65e9df1`](https://github.com/NixOS/nixpkgs/commit/b65e9df1c45cf7c346e05200528fe0e8754db42f) font-awesome: 6.7.1 -> 6.7.2
* [`0c156d9a`](https://github.com/NixOS/nixpkgs/commit/0c156d9a9385fc3f012f99b900d1200042b3d31a) pyspread: 2.3.1 -> 2.4
* [`e07183d6`](https://github.com/NixOS/nixpkgs/commit/e07183d6ad72e58a4c3aff1009b4d15adc1e1329) shattered-pixel-dungeon: 3.0.1 -> 3.0.2
* [`05992468`](https://github.com/NixOS/nixpkgs/commit/059924687e07f8babe5b773d03f64f83d48277d4) backintime: 1.5.3 -> 1.5.4
* [`1cbcf997`](https://github.com/NixOS/nixpkgs/commit/1cbcf997168c69d86dd359d29e3199800625af35) gwyddion: 2.67 -> 2.68
* [`3a8adbb3`](https://github.com/NixOS/nixpkgs/commit/3a8adbb305ed0da89d1620eb836f1ef4f5437eb2) yabasic: 2.91.1 -> 2.91.2
* [`bca90baa`](https://github.com/NixOS/nixpkgs/commit/bca90baae261180cad47b9a57b5bf2b78ee74f28) gemmi: 0.7.0 -> 0.7.1
* [`5277ba66`](https://github.com/NixOS/nixpkgs/commit/5277ba6628f013993bf4a783ccc1561bbb099696) mcaselector: 2.4.2 -> 2.5
* [`72259b6a`](https://github.com/NixOS/nixpkgs/commit/72259b6a480d285f233fd3af63f1f89f2bce4617) openfga-cli: 0.6.4 -> 0.6.5
* [`8f6b977b`](https://github.com/NixOS/nixpkgs/commit/8f6b977bb182c62ca3e6b3f1b2194a2086e75f17) nwg-dock-hyprland: 0.4.3 -> 0.4.4
* [`f33e02b2`](https://github.com/NixOS/nixpkgs/commit/f33e02b27ba08b1d12ab327e286cda195aabea7a) janet: 1.37.1 -> 1.38.0
* [`5b96072b`](https://github.com/NixOS/nixpkgs/commit/5b96072b2bcfc026c562d5ea94311ee68a2e0933) python313Packages.google-api-python-client: don't depend on oauth2client
* [`30e5fa6a`](https://github.com/NixOS/nixpkgs/commit/30e5fa6a9936114a89c7d377fc598283954f3d8d) nwg-hello: 0.3.0 -> 0.3.1
* [`11f9ca46`](https://github.com/NixOS/nixpkgs/commit/11f9ca465ccd4eb88f25aadcb51d500bade0f3f3) croc: 10.2.1 -> 10.2.2
* [`886c08ad`](https://github.com/NixOS/nixpkgs/commit/886c08adcccabbfdecabc0995d0f9e8122ee5ed3) netmaker: 0.30.0 -> 0.90.0
* [`fd5237ae`](https://github.com/NixOS/nixpkgs/commit/fd5237aeadcf02422bca04ea2f518eadf7a70123) rmg-wayland: 0.7.7 -> 0.7.8
* [`45ea418a`](https://github.com/NixOS/nixpkgs/commit/45ea418a773ac19b6a0f894b064bd83620593c1c) malt: 1.2.3 -> 1.2.6
* [`0fedf3de`](https://github.com/NixOS/nixpkgs/commit/0fedf3de6830689f7e5c9e3e883ad89855285604) chezmoi: 2.60.1 -> 2.61.0
* [`7643346e`](https://github.com/NixOS/nixpkgs/commit/7643346e5363c389dec0f114feb075ee51b0cc0e) capstone: 5.0.5 -> 5.0.6
* [`44622047`](https://github.com/NixOS/nixpkgs/commit/44622047b6ea34ef62bf3661ecbd33d4e143f033) netclient: 0.30.0 -> 0.90.0
* [`9ee6dc24`](https://github.com/NixOS/nixpkgs/commit/9ee6dc24784b4f7ccc496a1607a3e757179adc76) flowblade: 2.18.1 -> 2.20
* [`f5ef9071`](https://github.com/NixOS/nixpkgs/commit/f5ef9071f1ad5f2847f0c84fa233fcf45b0f2796) mcaselector: 2.5 -> 2.5.1
* [`979fd39c`](https://github.com/NixOS/nixpkgs/commit/979fd39c32cdb9a99578e3920896fd6a25f3fad8) zap: 2.16.0 -> 2.16.1
* [`38b08b66`](https://github.com/NixOS/nixpkgs/commit/38b08b664c766a6ea642ff5468d53074c372ea02) python312Packages.certbot-dns-google: don't depend on oauth2client
* [`131f611e`](https://github.com/NixOS/nixpkgs/commit/131f611ef36be450c5909a7098cb0c3f726250fe) proxmark3: 4.19552 -> 4.20142
* [`250d6e6c`](https://github.com/NixOS/nixpkgs/commit/250d6e6c57396106be94bf31ebe9ddb87f587da6) python312Packages.google-auth: don't depend on oauth2client
* [`0ec6affd`](https://github.com/NixOS/nixpkgs/commit/0ec6affd1a52afffd2e16f9d72fd8a33ece31e44) graalvmPackages.graaljs: 24.1.2 -> 24.2.0
* [`2d7b0a48`](https://github.com/NixOS/nixpkgs/commit/2d7b0a48b97314d0917539e0dbcf52119dcd2bc6) media-downloader: 5.3.0 -> 5.3.2
* [`4269fe3a`](https://github.com/NixOS/nixpkgs/commit/4269fe3a03e105e397b45190884cad303af779e9) jcal: 0.4.1 -> 0.5.1
* [`100cfd22`](https://github.com/NixOS/nixpkgs/commit/100cfd22cb217b042f8240a8a82f4374e8921389) oauth2-proxy: 7.8.1 -> 7.8.2
* [`7185f01d`](https://github.com/NixOS/nixpkgs/commit/7185f01d939283ceab5d0f039b0678162383ffb8) pam_u2f: 1.3.2 -> 1.4.0
* [`3c6a6603`](https://github.com/NixOS/nixpkgs/commit/3c6a660329bc3a6b667963bec0a0e6ce064d6745) openstack-rs: init at 0.10.0
* [`58561fac`](https://github.com/NixOS/nixpkgs/commit/58561fac4b3db9ddc4dde1ba441ea250facd66ed) hydrus: 612 -> 614
* [`9497f737`](https://github.com/NixOS/nixpkgs/commit/9497f7371ee2afe743c032742bfb6620f0fc414b) qgis-ltr: 3.40.4 -> 3.40.5
* [`b85a4449`](https://github.com/NixOS/nixpkgs/commit/b85a4449e00d3b919b78dc3685e324002a6dd987) rednotebook: 2.38 -> 2.39
* [`a7564c15`](https://github.com/NixOS/nixpkgs/commit/a7564c1507ec6261b5f94ccfb748686a421411b7) protoc-gen-es: 2.2.3 -> 2.2.5
* [`31f0b77f`](https://github.com/NixOS/nixpkgs/commit/31f0b77f4e5b7cb65858808a6b48ada3cff54698) graalvmPackages.truffleruby: 24.1.2 -> 24.2.0
* [`a75203d0`](https://github.com/NixOS/nixpkgs/commit/a75203d0a4e91a104f1fadc7d83de6df0c19cc8c) graalvmPackages.graalpy: 24.1.2 -> 24.2.0
* [`2bcb9372`](https://github.com/NixOS/nixpkgs/commit/2bcb93721b60a71ae0ed2fc170a854ef2ea423ed) graalvmPackages.graalnodejs: 24.1.2 -> 24.2.0
* [`4ca2d9ea`](https://github.com/NixOS/nixpkgs/commit/4ca2d9ea56b56cb1e5e3262a90b60f009c95d7fe) tree-sitter-grammars.tree-sitter-factor: init
* [`9b7d65ad`](https://github.com/NixOS/nixpkgs/commit/9b7d65ad87ab7423dd2f6d53ce536bd189ef1624) nixos/incus: add AppArmor rules to allow access to Nix store
* [`f4fd5a51`](https://github.com/NixOS/nixpkgs/commit/f4fd5a51b5077370848be10639887181b6aeaec8) nixos/tests/incus: fix zfs test configuration
* [`f6128c60`](https://github.com/NixOS/nixpkgs/commit/f6128c605016c95836b546bd38656742c5545dd5) nixos/tests/incus: add AppArmor test
* [`457a0340`](https://github.com/NixOS/nixpkgs/commit/457a03403a63003e92a4b94abe847bbea536399c) mjmap: 0.1.0-unstable-2025-03-06 -> 1.0.1
* [`ac71da1c`](https://github.com/NixOS/nixpkgs/commit/ac71da1cb4580e75cb67198b50c8a08372966de0) icingaweb2-ipl: 0.14.1 -> 0.14.2
* [`09084c77`](https://github.com/NixOS/nixpkgs/commit/09084c77eb8be83381519fab8e5a125b4adbb460) icingaweb2: 2.12.2 -> 2.12.3
* [`e7d55ae8`](https://github.com/NixOS/nixpkgs/commit/e7d55ae84c583e79f6ef0a0d2c66c67265ee8205) anilibria-winmaclinux: 2.2.25 -> 2.2.26
* [`6aaeae81`](https://github.com/NixOS/nixpkgs/commit/6aaeae81aecd05517e03298f6c1bce8f27d2b4c6) Take systemd configuration from upstream package instead of definiting
* [`825381d5`](https://github.com/NixOS/nixpkgs/commit/825381d5ed73b78ce38cdd35474ef5ed3de1762f) nixos/zoxide: init module
* [`e1d8efb9`](https://github.com/NixOS/nixpkgs/commit/e1d8efb94a9a62ca1c822d01b63b2a881f8b626c) terraform-providers.linode: 2.35.1 -> 2.36.0
* [`f08c24bd`](https://github.com/NixOS/nixpkgs/commit/f08c24bd8eb26f2bdeeb5272d49da651d73134e5) jitsi-meet-prosody: 1.0.8448 -> 1.0.8499
* [`ba3346ad`](https://github.com/NixOS/nixpkgs/commit/ba3346adbce9f2e34d2dfa8abdb5afaa00a9ffdc) steampipePackages.steampipe-plugin-aws: 1.9.0 -> 1.10.0
* [`63b841db`](https://github.com/NixOS/nixpkgs/commit/63b841db767c8f0a051bdd19b2513c060f20c27e) deadbeef: 1.9.6 -> 1.10.0
* [`a6760a23`](https://github.com/NixOS/nixpkgs/commit/a6760a23a7eb5260184397024f01ec28662313b9) guile-goblins: 0.15.0 -> 0.15.1
* [`f88b8a6d`](https://github.com/NixOS/nixpkgs/commit/f88b8a6d29841ef0dfa7bb0e8ae1640752f084ad) lightburn: 1.7.07 -> 1.7.08
* [`2b582a07`](https://github.com/NixOS/nixpkgs/commit/2b582a07cc92516a952c3fd849dfc8227c10dbd3) maintainers: add srp
* [`1f4e2682`](https://github.com/NixOS/nixpkgs/commit/1f4e268206f7eb2caaa997870829b7eec3938f12) tt-rss: 0-unstable-2025-03-14 -> 0-unstable-2025-03-19
* [`a0693164`](https://github.com/NixOS/nixpkgs/commit/a069316447dc81a7553bbc90fc140113d8b0cba3) bind: 9.20.6 -> 9.20.7
* [`f4e68a88`](https://github.com/NixOS/nixpkgs/commit/f4e68a88ccf51bc0c07a8b577b13cb7c3f95b1c8) gaugePlugins.screenshot: 0.3.0 -> 0.3.1
* [`016ede9d`](https://github.com/NixOS/nixpkgs/commit/016ede9da4ffd62fd6230988fbc6d000663fd46c) gaugePlugins.ruby: 0.9.2 -> 0.9.3
* [`a25e2999`](https://github.com/NixOS/nixpkgs/commit/a25e299909164a1d6a4754d2048b53d4b45fcebd) git-repo: 2.52 -> 2.53
* [`cf42c6b6`](https://github.com/NixOS/nixpkgs/commit/cf42c6b61ae9b6cc7db0357827f6c811499cbdb2) codeium: 1.42.3 -> 1.42.4
* [`26150bfe`](https://github.com/NixOS/nixpkgs/commit/26150bfea00878593e3876d57dadfa210f33b88c) jellyfin-mpv-shim: 2.8.0 -> 2.9.0
* [`b3584474`](https://github.com/NixOS/nixpkgs/commit/b35844742ce3db15567be3b61f455d728333bbfd) monolith: 2.9.0 -> 2.10.0
* [`9aeec058`](https://github.com/NixOS/nixpkgs/commit/9aeec0584b50692f943049b03106015dd1e140c3) sloth: 0.11.0 -> 0.12.0
* [`4adf8159`](https://github.com/NixOS/nixpkgs/commit/4adf8159d9b4aa70edf0fc73af3aa667eabf009d) klipper: 0.12.0-unstable-2025-03-12 -> 0.12.0-unstable-2025-03-25
* [`94a5d198`](https://github.com/NixOS/nixpkgs/commit/94a5d1986262aba667707491e89a01a230a46326) azure-cli-extensions.containerapp: 1.1.0b3 -> 1.1.0b4
* [`b50a8df2`](https://github.com/NixOS/nixpkgs/commit/b50a8df2e78adb806d5b34d4cbbf117685daa22a) swaylock-plugin: unstable-2025-01-28 -> 1.8.2
* [`149b2321`](https://github.com/NixOS/nixpkgs/commit/149b23217b9fbffed96e998dee5462b82aae1f3b) testkube: 2.1.116 -> 2.1.125
* [`4141c811`](https://github.com/NixOS/nixpkgs/commit/4141c8113f4c7673097a266ab6aef3fd47278577) alacritty-theme: 0-unstable-2025-02-20 -> 0-unstable-2025-03-20
* [`970186f2`](https://github.com/NixOS/nixpkgs/commit/970186f2cb419eb77ad1e88b95c0006730e0dd53) subread: 2.0.8 -> 2.1.0
* [`59da6dea`](https://github.com/NixOS/nixpkgs/commit/59da6dea98f7508a34887669d4465e190343b2c0) prometheus-junos-czerwonk-exporter: 0.14.0 -> 0.14.1
* [`3e6fe826`](https://github.com/NixOS/nixpkgs/commit/3e6fe8260674be1c8fec70d077eedd5898a21520) sonar-scanner-cli: 7.0.2.4839 -> 7.1.0.4889
* [`59f746cc`](https://github.com/NixOS/nixpkgs/commit/59f746cc16033c82753c587dfa9f5a23a3ec2bb7) dependabot-cli: 1.57.0 -> 1.62.1
* [`dfce58ee`](https://github.com/NixOS/nixpkgs/commit/dfce58ee79f6e020fb9be41a718def3804f1af14) f3: 8.0 -> 9.0
* [`54710e9c`](https://github.com/NixOS/nixpkgs/commit/54710e9cc13e74f409c719ebf73da3a023560d9c) nixos/h2o: disable OCSP stapling in tests
* [`aad12187`](https://github.com/NixOS/nixpkgs/commit/aad12187ac2aacb1796b674e2adf89e12bf53683) symbolicator: 24.7.1 -> 25.3.0
* [`07464885`](https://github.com/NixOS/nixpkgs/commit/07464885a5094caa65e82b8b7c55f64680fd6af5) depotdownloader: 3.0.0 -> 3.1.0
* [`2a7c27ca`](https://github.com/NixOS/nixpkgs/commit/2a7c27ca8f014abbfbea63d96492de476f6b51b8) python312Packages.openai: 1.68.2 -> 1.69.0
* [`fed72c38`](https://github.com/NixOS/nixpkgs/commit/fed72c385a5e7de401e4074340dd6151506ce0f6) dnscrypt-proxy: 2.1.7 -> 2.1.8
* [`7382a53b`](https://github.com/NixOS/nixpkgs/commit/7382a53be6b8bd9f202ed8b8c029b296f994eabf) rocketchat-desktop: 4.2.0 -> 4.3.0
* [`85151852`](https://github.com/NixOS/nixpkgs/commit/851518527041028a696f065481e40f292f1b3821) yafc-ce: 2.10.0 -> 2.11.0
* [`c36c43e4`](https://github.com/NixOS/nixpkgs/commit/c36c43e4246b2e709255923efeb3d04609023649) wasmi: 0.42.0 -> 0.43.0
* [`5030f160`](https://github.com/NixOS/nixpkgs/commit/5030f160f49390e98cf16cf37c1f61f56c15f197) android-studio-tools: 11076708 -> 13114758
* [`5710e336`](https://github.com/NixOS/nixpkgs/commit/5710e336c171a15e2a0d497048295f15150c856a) bacula: 15.0.2 -> 15.0.3
* [`d7e36a23`](https://github.com/NixOS/nixpkgs/commit/d7e36a23d4c6bd3322ca91d6420814d782dcb6ca) qsynth: 1.0.2 -> 1.0.3
* [`7e74db02`](https://github.com/NixOS/nixpkgs/commit/7e74db020a257eb8a968bd9c763712b6f5fc946a) trunk: 0.21.9 -> 0.21.12
* [`a6c2af67`](https://github.com/NixOS/nixpkgs/commit/a6c2af6774075976cc1142100f9846ed4e8cfe70) waydroid: 1.4.3 -> 1.5.1
* [`9b57cea2`](https://github.com/NixOS/nixpkgs/commit/9b57cea23aa383c053daf1c0e1ee7708089b1cb4) voms: 2.1.0 -> 2.1.2
* [`a0109d24`](https://github.com/NixOS/nixpkgs/commit/a0109d24d52a1699188e4a4248138541cdb60f1c) jitsi-videobridge: 2.3-209-gb5fbe618 -> 2.3-215-gbee626bf
* [`f9eb7be8`](https://github.com/NixOS/nixpkgs/commit/f9eb7be8f606814f679e8cbced4cfff0b8df76ed) beanhub-import: 1.0.7 -> 1.2.0
* [`3e77df99`](https://github.com/NixOS/nixpkgs/commit/3e77df99289add39fa4ccabdd4ad438e9db3524f) ruffle: nightly-2025-01-25 -> nightly-2025-03-28
* [`bc1be15d`](https://github.com/NixOS/nixpkgs/commit/bc1be15d173089fca1dffdd679b387c2c5bf172b) cockatrice: 2025-02-10-Release-2.10.0 -> 2025-03-27-Release-2.10.1
* [`905ed090`](https://github.com/NixOS/nixpkgs/commit/905ed0906137e93a95c3f43b1be5ab0ad150e4cc) erigon: 2.61.3 -> 3.0.0
* [`eab9920c`](https://github.com/NixOS/nixpkgs/commit/eab9920c7bb327ffe14ef555f60de69c62228259) irpf: 2025-1.0 -> 2025-1.1
* [`0ac35574`](https://github.com/NixOS/nixpkgs/commit/0ac3557494365dd4d63b726de745128ce0b898ec) alpaca: 5.2.0 -> 5.3.0
* [`a87167a6`](https://github.com/NixOS/nixpkgs/commit/a87167a64bfaf4119999e13703569135724daa89) graphite-cli: 1.5.3 -> 1.6.1
* [`6af7c988`](https://github.com/NixOS/nixpkgs/commit/6af7c988e55cfdcb849c94f9729bc59fe25bb2af) morewaita-icon-theme: 47.4 -> 48.1
* [`30133f31`](https://github.com/NixOS/nixpkgs/commit/30133f31e5b79e39c9cf91de4e50b9ec54243462) calibre: 7.26.0 -> 8.1.1
* [`2caa76b2`](https://github.com/NixOS/nixpkgs/commit/2caa76b2e09e20cf098865f55328a71d9585faaa) libdmtx: 0.7.7 -> 0.7.8
* [`d75f7b29`](https://github.com/NixOS/nixpkgs/commit/d75f7b2959f8c6ca463e9e630ecee12e823adab5) liblscp: 1.0.0 -> 1.0.1
* [`7605633c`](https://github.com/NixOS/nixpkgs/commit/7605633c219a4b3900b49cb1aaf3dafd562d80dc) python313Packages.msmart-ng: 2025.3.1 -> 2025.3.3
* [`c3b36902`](https://github.com/NixOS/nixpkgs/commit/c3b36902e41b61f7514182138cd121fda749d33b) home-assistant-custom-components.midea_ac: 2025.3.0 -> 2025.3.1
* [`6764561f`](https://github.com/NixOS/nixpkgs/commit/6764561f3e1783b31fe387b06af2eff255b90a39) nixos/bird-lg: Remove deprecation warnings
* [`845b5ab5`](https://github.com/NixOS/nixpkgs/commit/845b5ab5ff98e692704664bd6bd465248525dff3) twilio-cli: 5.23.0 -> 5.23.1
* [`7052141f`](https://github.com/NixOS/nixpkgs/commit/7052141f53918dbc2f532ffb8f82348c4d478482) bird-lg: 1.3.5 -> 1.3.8
* [`fa76662f`](https://github.com/NixOS/nixpkgs/commit/fa76662f51d1111134e94aea905c697a7faf01f1) infisical: 0.36.21 -> 0.36.22
* [`7cf0473c`](https://github.com/NixOS/nixpkgs/commit/7cf0473ccda2ba2ba73d10027eab556c61db5569) rustPlatform.fetchCargoTarball: drop
* [`bf084b82`](https://github.com/NixOS/nixpkgs/commit/bf084b82011e9f7fc6c928baf05c4bb49c0afdae) lima: 1.0.6 -> 1.0.7
* [`1407e4c9`](https://github.com/NixOS/nixpkgs/commit/1407e4c9155b38a18dbb625144a2cab42df86380) amazon-cloudwatch-agent: 1.300053.1 -> 1.300054.0
* [`1748b239`](https://github.com/NixOS/nixpkgs/commit/1748b23974a2e54912c28c928d332aa0b816cbef) claude-code: 0.2.54 -> 0.2.56
* [`75f5785c`](https://github.com/NixOS/nixpkgs/commit/75f5785c5064e5e581d6c664db8b54d87af21432) cpuinfo: 0-unstable-2025-02-19 -> 0-unstable-2025-03-27
* [`3029bd75`](https://github.com/NixOS/nixpkgs/commit/3029bd758b4ff3a240bead21c3491a51759a6ccd) lixPackageSets.lix_2_92: init
* [`0d079338`](https://github.com/NixOS/nixpkgs/commit/0d079338b2f5e681304215e901eebf9e9cb1dd58) nixos/tests/installer: introduce `lix-simple` variant
* [`bb9c3928`](https://github.com/NixOS/nixpkgs/commit/bb9c3928dc0dade8a39806af7180abb87d714286) python313Packages.syrupy: 4.9.0 -> 4.9.1
* [`8dce1de8`](https://github.com/NixOS/nixpkgs/commit/8dce1de8a8c77cdfc473a5f3e5a64b65d7c1ba1a) shadps4: 0.6.0-unstable-2025-03-18 -> 0.7.0
* [`28fd1557`](https://github.com/NixOS/nixpkgs/commit/28fd155779fc75125fdaaf541d18ea7919d9208d) python3Packages.kubernetes-validate: 0.31.0 -> 0.32.0
* [`325a8a9b`](https://github.com/NixOS/nixpkgs/commit/325a8a9b2a0b721861697763617a1aca818b0016) xca: 2.8.0 -> 2.9.0
* [`38c67b98`](https://github.com/NixOS/nixpkgs/commit/38c67b988a18f095d3a283ed7a9f921c77c9daae) boatswain: 0.4.0 -> 5.0
* [`249670c2`](https://github.com/NixOS/nixpkgs/commit/249670c2251e6525d27bbb93f4802988130ba9dd) boatswain: modernize and clean up deps
* [`4554b243`](https://github.com/NixOS/nixpkgs/commit/4554b243a27aab463175b8c9d869ff077b9677e0) kokkos: 4.5.01 -> 4.6.00
* [`0c675570`](https://github.com/NixOS/nixpkgs/commit/0c67557015535754c8b545dfe0262b077624421e) nixos/h2o: disable OCSP stapling w/ Let’s Encrypt (support sunset)
* [`7c8b3c88`](https://github.com/NixOS/nixpkgs/commit/7c8b3c88bbcabc9d9fddfe252b0cdddff6224984) nixos/h2o: rename certNames → acmeCertNames
* [`13e5fa4c`](https://github.com/NixOS/nixpkgs/commit/13e5fa4cddfe5b205894ab8c04e0dc3b1d53b0f3) aws-lc: 1.47.0 -> 1.49.0
* [`a0d38f09`](https://github.com/NixOS/nixpkgs/commit/a0d38f09eb904b3701e8788aa9c2282255ca3409) di: 5.0.14 -> 6.0.0
* [`685b6881`](https://github.com/NixOS/nixpkgs/commit/685b6881404191ba302375f9284eebc0237f88b3) ansel: 0-unstable-2025-03-18 -> 0-unstable-2025-03-27
* [`0dc9e2c0`](https://github.com/NixOS/nixpkgs/commit/0dc9e2c04179237aaa7a0e7c6fe9bf207f248f08) heroku: 10.2.0 -> 10.4.0
* [`7b163e20`](https://github.com/NixOS/nixpkgs/commit/7b163e205808da4e9f6c47a6ccce18d5ad03d466) vial: 0.7.1 -> 0.7.2
* [`e34de710`](https://github.com/NixOS/nixpkgs/commit/e34de710576078bf6fef73c82f365a62bce7a679) rdkafka: fix cross-compilation
* [`d0c213fe`](https://github.com/NixOS/nixpkgs/commit/d0c213fea5f3ebcbdf80a523953a05356d851b65) jackett: 0.22.1512 -> 0.22.1705
* [`8d2bb2ab`](https://github.com/NixOS/nixpkgs/commit/8d2bb2ab1a07be795ae9fd5a501780181f98b25c) python3Packages.mpv: 1.0.6 -> 1.0.7
* [`ddc6481c`](https://github.com/NixOS/nixpkgs/commit/ddc6481cf5493b0bbda580185231949318d4ec0b) python3Packages.mpv: fix keybinds not working
* [`f717be8d`](https://github.com/NixOS/nixpkgs/commit/f717be8d1c72f59e9b8b96227d9f497ef2df746f) glbinding: 3.3.0 -> 3.4.0
* [`604c9baf`](https://github.com/NixOS/nixpkgs/commit/604c9baf4f9fdbc02e45f5060b5249bc2d1127ed) catppuccin-fcitx5: 0-unstable-2024-09-01 -> 0-unstable-2025-03-22
* [`5929ce55`](https://github.com/NixOS/nixpkgs/commit/5929ce550c80c947820835faa4d31137b70ca39d) mapproxy: 3.1.3 -> 4.0.1
* [`118a3db2`](https://github.com/NixOS/nixpkgs/commit/118a3db2a431a682df68555542f65c77c50cba2f) python312Packages.langchain-openai: 0.3.8 -> 0.3.11
* [`8610d1f1`](https://github.com/NixOS/nixpkgs/commit/8610d1f180d738c6ca3ee559a4df2f4e946dcb8e) hyperrogue: 13.0w -> 13.0x
* [`d3d1c469`](https://github.com/NixOS/nixpkgs/commit/d3d1c4695f603a2618f8d041f73fbd36873d33d9) netbox_4_2: 4.2.3 -> 4.2.6
* [`d7d3b94a`](https://github.com/NixOS/nixpkgs/commit/d7d3b94a85bf58cc7722424289f31223b94fe5b5) microsoft-edge: 134.0.3124.68 -> 134.0.3124.95
* [`06fdef57`](https://github.com/NixOS/nixpkgs/commit/06fdef578a7fb391727e6a44e457e96d02b7d599) dwarfs: 0.11.0 -> 0.11.2
* [`7fe9ed47`](https://github.com/NixOS/nixpkgs/commit/7fe9ed47dba39a6e35d04efaa491d3131620630b) pipe-viewer: 0.5.4 -> 0.5.5
* [`b6187e6b`](https://github.com/NixOS/nixpkgs/commit/b6187e6b9dc5544588fe29f67f06c6a5e4aea483) protonup-qt: 2.11.1 -> 2.12.0
* [`5b226fc8`](https://github.com/NixOS/nixpkgs/commit/5b226fc8020658bd51adbfa1c938ee1e0a6a6aee) pcsc-tools: 1.7.2 -> 1.7.3
* [`8f528c43`](https://github.com/NixOS/nixpkgs/commit/8f528c438cd748dacf3f9a2a66d06de1fee6499a) seamly2d: 2025.3.17.207 -> 2025.3.25.1924
* [`0b2d6d8a`](https://github.com/NixOS/nixpkgs/commit/0b2d6d8ad208cefe190c79470c3ba5014df88643) krakatau2: init at 0-unstable-2025-02-01
* [`32341169`](https://github.com/NixOS/nixpkgs/commit/3234116963f5a4bd5ef93c8dde2944a39893983c) carapace-bridge: 1.2.4 -> 1.2.5
* [`e5e38d2c`](https://github.com/NixOS/nixpkgs/commit/e5e38d2c3898359dfedcf9af715f34061901d407) console-setup: 1.234 -> 1.235
* [`e6a56d1b`](https://github.com/NixOS/nixpkgs/commit/e6a56d1b4a170a9ae71649daeff9cfa0519c1b48) lefthook: 1.11.2 -> 1.11.5
* [`7a89b606`](https://github.com/NixOS/nixpkgs/commit/7a89b6066cc727afc8cd3ea77e4be512826eb42e) python312Packages.langfuse: 2.60.0 -> 2.60.2
* [`4643643b`](https://github.com/NixOS/nixpkgs/commit/4643643b2d4e089b0ac0db61856c0c6062edecb0) astal.io: 0-unstable-2025-03-17 -> 0-unstable-2025-03-21
* [`c28229d7`](https://github.com/NixOS/nixpkgs/commit/c28229d729b40596e77afcbadff27fd827891383) mariadb-connector-java: 3.5.2 -> 3.5.3
* [`6af209c1`](https://github.com/NixOS/nixpkgs/commit/6af209c1aaba942f30c49a6a776849c8da79f6aa) syft: 1.20.0 -> 1.21.0
* [`c0cc0adc`](https://github.com/NixOS/nixpkgs/commit/c0cc0adc575a2b1078a62f9c7142b9549850fc25) elasticmq-server-bin: 1.6.11 -> 1.6.12
* [`12b7441d`](https://github.com/NixOS/nixpkgs/commit/12b7441dda318e870cbb60ff75eaf0bdcc475dd1) persepolis: 5.0.1 -> 5.0.2
* [`a180d093`](https://github.com/NixOS/nixpkgs/commit/a180d093b0378ddd869683f94fcb0b166e5e69e3) xrsh: 0-unstable-2025-02-28 -> 0-unstable-2025-03-28
* [`165e9555`](https://github.com/NixOS/nixpkgs/commit/165e9555c419117e2a81b0311a73b34cf6a61d75) powerjoular: 1.0.5 -> 1.1.0
* [`8c92f0ba`](https://github.com/NixOS/nixpkgs/commit/8c92f0bad75b7dda8af26be26d47d7e345bfd09e) way-displays: 1.12.2 -> 1.13.0
* [`5b03c91e`](https://github.com/NixOS/nixpkgs/commit/5b03c91e27515a0a5384a5bf1a56f8365949832a) gnote: 47.2 -> 48.0
* [`b8168aca`](https://github.com/NixOS/nixpkgs/commit/b8168aca112efa2a3d3eeff7f8e0a084e302b8fa) treesheets: 0-unstable-2025-03-15 -> 0-unstable-2025-03-28
* [`73a718d0`](https://github.com/NixOS/nixpkgs/commit/73a718d02f3ec484358bf201254eb713de76fea7) kubevpn: 2.4.1 -> 2.4.2
* [`c44cf1ed`](https://github.com/NixOS/nixpkgs/commit/c44cf1eda38cc378a7fb53b32be7b5f5a099dde9) sentry-cli: 2.42.3 -> 2.43.0
* [`458fa01a`](https://github.com/NixOS/nixpkgs/commit/458fa01a38ed978efbd47e8dac850f306fb0852a) tlafmt: 0.3.2 -> 0.4.0
* [`42a27d16`](https://github.com/NixOS/nixpkgs/commit/42a27d16dd021ed0a819c0cb1a452a0ae5d2128d) kubernetes-kcp: 0.27.0 -> 0.27.1
* [`b5adf98a`](https://github.com/NixOS/nixpkgs/commit/b5adf98aaa48c30b3a355161d1fc2a7ab866f245) byobu: 6.12 -> 6.13
* [`b3a673eb`](https://github.com/NixOS/nixpkgs/commit/b3a673ebe9ab059b15bdd61cfd51783fdaef19c2) cockpit: 331 -> 336.2
* [`981e00ea`](https://github.com/NixOS/nixpkgs/commit/981e00ea280b9141dde2f180e8320c7187d146e4) mlterm: 3.9.3 -> 3.9.4
* [`55ce2887`](https://github.com/NixOS/nixpkgs/commit/55ce2887eae070be77d1acd3454667828b67cffa) mlterm: small modernizations
* [`dd0f56ac`](https://github.com/NixOS/nixpkgs/commit/dd0f56acf16d4a3c712f857f36aa1e51366b5a17) discord-ptb: 0.0.135 -> 0.0.136
* [`2b8379e1`](https://github.com/NixOS/nixpkgs/commit/2b8379e1600f506dc6a85dcc5019762a09114b67) discord-canary: 0.0.619 -> 0.0.621
* [`07fb4fac`](https://github.com/NixOS/nixpkgs/commit/07fb4face077d4af5f78bee4e05d9df9b34d8be3) pkgsCross.aarch64-darwin.discord-ptb: 0.0.166 -> 0.0.167
* [`ccdfab4b`](https://github.com/NixOS/nixpkgs/commit/ccdfab4b0cf0762122b50e8554ae83de3e11ef2e) pkgsCross.aarch64-darwin.discord-canary: 0.0.727 -> 0.0.729
* [`8ee0e9d4`](https://github.com/NixOS/nixpkgs/commit/8ee0e9d41d01ac961e58dd263ce45b171a46fe96) pkgsCross.aarch64-darwin.discord-development: 0.0.84 -> 0.0.85
* [`bdc45a4f`](https://github.com/NixOS/nixpkgs/commit/bdc45a4f38541edba54647699a382a980405a99e) railway: 3.23.0 -> 4.0.0
* [`6da4c86c`](https://github.com/NixOS/nixpkgs/commit/6da4c86c4b9057173818e7a8b68ce706f809a6bf) tutanota-desktop: 274.250312.0 -> 275.250326.0
* [`f3938845`](https://github.com/NixOS/nixpkgs/commit/f3938845a4b4f03faacc3864552475f3e56fdbcf) apt: 2.9.33 -> 2.9.35
* [`0d6c0953`](https://github.com/NixOS/nixpkgs/commit/0d6c0953987851cc9c9808269aa65ce13693e103) flat-remix-gnome: 20241208 -> 20250330
* [`7dc56449`](https://github.com/NixOS/nixpkgs/commit/7dc56449ad7c4ad3b053cf5393c6d4cabf76bad0) nixos/modules: fix part-db package
* [`8df5121a`](https://github.com/NixOS/nixpkgs/commit/8df5121abec89f694a18076e1751adf5b08f538c) ktx-tools: 4.3.2 -> 4.4.0
* [`c0cc3532`](https://github.com/NixOS/nixpkgs/commit/c0cc3532282a3f3785e2db10efd023a57378d554) dbvisualizer: 25.1 -> 25.1.2
* [`afaa567e`](https://github.com/NixOS/nixpkgs/commit/afaa567e52106ee2d9d3a79075fc10ff79aee612) docker_27: sync runc and containerd versions with upstream
* [`08b4d7d8`](https://github.com/NixOS/nixpkgs/commit/08b4d7d8bbb4bcdba339afb5da58a36a0672434d) rxp: 1.5.0 -> 1.5.2
* [`4e80ecff`](https://github.com/NixOS/nixpkgs/commit/4e80ecff96b4853138c702cbb3b8db6db9e21267) rxp: modernize
* [`9f74f685`](https://github.com/NixOS/nixpkgs/commit/9f74f685f797705c78429a15e092e287f0173712) docker_25: 25.0.6 -> 25.0.8
* [`4494a741`](https://github.com/NixOS/nixpkgs/commit/4494a74190d40f2872529debae2d51f6c81ef4b4) smem: enable matplotlib
* [`06168d1d`](https://github.com/NixOS/nixpkgs/commit/06168d1dea768c977dafda2db690ab1c79e96686) crowdsec: 1.6.6 -> 1.6.8
* [`baa9eef6`](https://github.com/NixOS/nixpkgs/commit/baa9eef6151640e49a1a5ab635bb5298cf84dbd1) youtrack: 2025.1.66652 -> 2025.1.67057
* [`6df2b8e0`](https://github.com/NixOS/nixpkgs/commit/6df2b8e04918414bba58a07e641fec704659ee58) mailpit: 1.23.2 -> 1.24.0
* [`8cdef69a`](https://github.com/NixOS/nixpkgs/commit/8cdef69a0814cfc04df70b5df796adda37cc734b) teleport_15: remove
* [`144b801d`](https://github.com/NixOS/nixpkgs/commit/144b801d0f19174ca9862ce3e72b41ec4d62c88c) vscodium: mark non-glibc as broken
* [`bf88358c`](https://github.com/NixOS/nixpkgs/commit/bf88358cdf03aaabaa61dcf58062fde6fde2470b) dirt: unstable-2018-01-01 -> 0-unstable-2025-03-30
* [`40adef35`](https://github.com/NixOS/nixpkgs/commit/40adef352a89dba629e4b6ef79974aa30e205483) gtranslator: 47.1 -> 48.0
* [`98002c07`](https://github.com/NixOS/nixpkgs/commit/98002c07c47b9203f4382bb09e28460cd910c3ce) stress-ng: 0.18.11 -> 0.18.12
* [`e23e47ca`](https://github.com/NixOS/nixpkgs/commit/e23e47ca6cc8652855af449540dc277cd717526b) lcov: 2.3 -> 2.3.1
* [`93206914`](https://github.com/NixOS/nixpkgs/commit/93206914b041e0614ef0bede3c047ae84a4fed48) runme: 3.12.6 -> 3.13.0
* [`fafabfa5`](https://github.com/NixOS/nixpkgs/commit/fafabfa51bccadc4a060d2e402fd9b8a9dd4f2a1) python312Packages.ansible: 11.3.0 -> 11.4.0
* [`cb9c852d`](https://github.com/NixOS/nixpkgs/commit/cb9c852d1cd2891d86b9f7b4b47c55ea80031e24) sc-controller: 0.5.0 -> 0.5.1
* [`c30c48bc`](https://github.com/NixOS/nixpkgs/commit/c30c48bc5f64f3cc119f50ce4b8029624459446c) maintainers: add tarinaky
* [`cff9b094`](https://github.com/NixOS/nixpkgs/commit/cff9b094327dd65cc3747cb015ca07e0fd4cf055) freefilesync: 14.2 -> 14.3
* [`0ed3f062`](https://github.com/NixOS/nixpkgs/commit/0ed3f062484dc73009969cab9bff0f4dcb88f3d6) gsasl: 2.2.1 -> 2.2.2
* [`a22d95a2`](https://github.com/NixOS/nixpkgs/commit/a22d95a2f99946ed1aa33ec720562c7496ecc7c8) libdatovka: 0.7.0 -> 0.7.1
* [`d5b45a40`](https://github.com/NixOS/nixpkgs/commit/d5b45a40334e00d5dee76ff04ff68091ab93b24c) kanata-with-cmd: 1.8.0 -> 1.8.1
* [`231a1db7`](https://github.com/NixOS/nixpkgs/commit/231a1db7aa687cae58aefb6a131a8684fae4399c) cpu-x: 5.1.3 -> 5.2.0
* [`cc4dba89`](https://github.com/NixOS/nixpkgs/commit/cc4dba893438e5a8e94fe79433a82b850cc64781) routino: 3.4.1 -> 3.4.2
* [`633a0063`](https://github.com/NixOS/nixpkgs/commit/633a006324b34f547dc2223fb0f8164140b66252) imagemagick: 7.1.1-46 -> 7.1.1-47
* [`ae4ecd0b`](https://github.com/NixOS/nixpkgs/commit/ae4ecd0b0b316acf60583747b40ee3012ab8abc7) python313Packages.img2pdf: skip failing test
* [`6412ed67`](https://github.com/NixOS/nixpkgs/commit/6412ed67a64bb5b893e273da5c14c263c926e36a) python313Packages.pathy: mark broken
* [`b06e4593`](https://github.com/NixOS/nixpkgs/commit/b06e4593d075191669f8ffd17275f1c13b3aa5e0) openlinkhub: 0.5.1 -> 0.5.2
* [`9a463345`](https://github.com/NixOS/nixpkgs/commit/9a463345df54eb6f56d69074b5f93e1c7af9164c) nushellPlugins.skim: 0.12.0 -> 0.13.0
* [`d0064ddd`](https://github.com/NixOS/nixpkgs/commit/d0064dddf805545d4d3089761e2d929b91f80ede) converseen: 0.12.2.5 -> 0.13.0.1
* [`b71484f3`](https://github.com/NixOS/nixpkgs/commit/b71484f3e2d4856c8c3e6fa054a187e43dab3db7) discordo: 0-unstable-2025-03-19 -> 0-unstable-2025-03-31
* [`9a8535d5`](https://github.com/NixOS/nixpkgs/commit/9a8535d5741355fbcf024d09f2b185844645ead5) firefox-devedition-unwrapped: 137.0b8 -> 137.0b10
* [`515175a4`](https://github.com/NixOS/nixpkgs/commit/515175a4e8b549365628e85d124566bd4f925d49) cdncheck: 1.1.11 -> 1.1.12
* [`4e469be8`](https://github.com/NixOS/nixpkgs/commit/4e469be8251bb61d9d89ad1deaf68fedd9f59aad) openrefine: 3.9.1 -> 3.9.2
* [`73def4bb`](https://github.com/NixOS/nixpkgs/commit/73def4bb82c1c8a345e515f225f237c70464a252) python3Packages.django-fsm: fix Python parameter
* [`5740a81a`](https://github.com/NixOS/nixpkgs/commit/5740a81ac6a537d27c0c99bcee928b0943810cee) python3Packages.datamodel-code-generator: remove unused parameter
* [`c642a1dc`](https://github.com/NixOS/nixpkgs/commit/c642a1dc8233acfff746850eb71ad1ade59a0cd3) pulsar: 1.127.0 -> 1.127.1
* [`6f46f7f5`](https://github.com/NixOS/nixpkgs/commit/6f46f7f5253d508fdbbea60c3792630ace071541) python313Packages.trimesh: 4.6.5 -> 4.6.6
* [`830647dc`](https://github.com/NixOS/nixpkgs/commit/830647dcec7fdb80fad6ead9eb82ef17939a29a2) pixelorama: 1.0.5 -> 1.1
* [`b58fbbdd`](https://github.com/NixOS/nixpkgs/commit/b58fbbdd23e72a8caa5538f3fe842b088e4845e2) nextcloudPackages.apps: update
* [`468036c1`](https://github.com/NixOS/nixpkgs/commit/468036c152b445fb0ec7cab9f01df3dc4f6993d1) nextcloudPackages.apps: add uppush
* [`37c1a935`](https://github.com/NixOS/nixpkgs/commit/37c1a935995cb5b405845e3de2ef5e2bcc3893bd) python312Packages.nodriver: 0.41 -> 0.43
* [`6fd318a2`](https://github.com/NixOS/nixpkgs/commit/6fd318a21f90e86ffbbb441ec197470433fb2601) python312Packages.jianpu-ly: 1.842 -> 1.844
* [`bca0716a`](https://github.com/NixOS/nixpkgs/commit/bca0716a879f91a093e20870366a13550e036b32) authentik,authentik.outposts.{ldap,radius,proxy}: 2025.2.1 -> 2025.2.3
* [`89e8789a`](https://github.com/NixOS/nixpkgs/commit/89e8789a5f8390528a427c49b5389c2adbe3a782) keepalived: 2.3.2 -> 2.3.3
* [`a4d5782d`](https://github.com/NixOS/nixpkgs/commit/a4d5782d9a0fd897914d8934db7df5eb80bde225) cinny-unwrapped: 4.5.1 -> 4.6.0
* [`d5a0d93d`](https://github.com/NixOS/nixpkgs/commit/d5a0d93d537b6a0c393f53ece0935824b80b9ab4) cinny-desktop: 4.5.1 -> 4.6.0
* [`0c7745d3`](https://github.com/NixOS/nixpkgs/commit/0c7745d3060da43684798f60f63e82701964be87) linuxPackages.oci-seccomp-bpf-hook: 1.2.10 -> 1.2.11
* [`9a4b708c`](https://github.com/NixOS/nixpkgs/commit/9a4b708c9664dd27a0e59ae9d56d1276a7e1f119) immudb: 1.9.5 -> 1.9.6
* [`293843d8`](https://github.com/NixOS/nixpkgs/commit/293843d84c787e547f4fc09849827c45b9b21bd2) yarn-berry: add meta.changelog
* [`03ae574d`](https://github.com/NixOS/nixpkgs/commit/03ae574dbcd82dcdd0d3a6ad4d9720a791c27d11) amberol: 2024.2 -> 2025.1
* [`4759e5b0`](https://github.com/NixOS/nixpkgs/commit/4759e5b0b25bba2f5a0a1ba3170fd6184306addd) criu: 4.0 -> 4.1
* [`b40d9c82`](https://github.com/NixOS/nixpkgs/commit/b40d9c82c1d206de3322241431db2eaf84dbcc3f) nixos/kanidm: don't set RUST_LOG in systemd service
* [`0f34eb4f`](https://github.com/NixOS/nixpkgs/commit/0f34eb4fdd66de41658883c57dfe42b186d04bcd) maintainers: add Continous
* [`1ebd0f5a`](https://github.com/NixOS/nixpkgs/commit/1ebd0f5a5c3914dec43d48d4c53fb012eb6aa5a0) fluidsynth: Migrate to by-name.
* [`f1349aae`](https://github.com/NixOS/nixpkgs/commit/f1349aae9dcf0c05ae672e4345362063ae0a6bd2) argo-rollouts: 1.8.1 -> 1.8.2
* [`4029df17`](https://github.com/NixOS/nixpkgs/commit/4029df17e4c2a2bb1b853b84de17181200ad8a91) saunafs: 4.8.0 -> 4.8.1
* [`d1c0a546`](https://github.com/NixOS/nixpkgs/commit/d1c0a5463da5194378c07d7845c1d7f9f24487bf) immich-public-proxy: 1.9.0 -> 1.9.1
* [`7551ca4a`](https://github.com/NixOS/nixpkgs/commit/7551ca4abdd5532fb4a509dc700540393994cacb) lowfi: 1.5.6 -> 1.6.0
* [`5b59c0e8`](https://github.com/NixOS/nixpkgs/commit/5b59c0e893303e92ffd0cccd504bd5bef699d0cf) lnav: 0.12.3 -> 0.12.4
* [`c152bb3e`](https://github.com/NixOS/nixpkgs/commit/c152bb3e62e2e9aac78cc89a6d01e81e973b665e) aichat: 0.28.0 -> 0.29.0
* [`922a4ab7`](https://github.com/NixOS/nixpkgs/commit/922a4ab7808146b40563a9b433723f949a9b8635) zdoom: Migrate to by-name
* [`b0f00c03`](https://github.com/NixOS/nixpkgs/commit/b0f00c031d29c9d6d6e8e8610fc6328394b9c30c) python312Packages.cstruct: 6.0 -> 6.1
* [`365f29bf`](https://github.com/NixOS/nixpkgs/commit/365f29bf5fed252659f3ca4d150df2144fb00c8e) python313Packages.tnefparse: init at 1.4.0
* [`440cfec7`](https://github.com/NixOS/nixpkgs/commit/440cfec75a7dacc883dcb5e0a3788630c9333bfe) xee: init at 0.1.5
* [`0b44c48d`](https://github.com/NixOS/nixpkgs/commit/0b44c48d8c1e630dada9ef0f661bd9f009482140) soft-serve: 0.8.4 -> 0.8.5
* [`4bc3c223`](https://github.com/NixOS/nixpkgs/commit/4bc3c2231add390b4b306f2045d3e4c837984589) sexpp: 0.9.1 -> 0.9.2
* [`7e7d8d2f`](https://github.com/NixOS/nixpkgs/commit/7e7d8d2f680fbce2888864a970884742abfe444a) xfce.mousepad: 0.6.4 -> 0.6.5
* [`d8862094`](https://github.com/NixOS/nixpkgs/commit/d88620945aece1910af487dedc80ee82ea50c1d0) tpnote: 1.25.5 -> 1.25.6
* [`98c3aaa5`](https://github.com/NixOS/nixpkgs/commit/98c3aaa5d7dae847d7b793333aa192b36c0a4338) monkeysAudio: 10.96 -> 11.01
* [`859a6019`](https://github.com/NixOS/nixpkgs/commit/859a6019bf184350d9de5223b9736ba5935bfaac) carapace: 1.2.1 -> 1.3.0
* [`f82496aa`](https://github.com/NixOS/nixpkgs/commit/f82496aa9082ee4497ba4b3283f379d9ee247c3f) m4ri: 20240729 -> 20250128
* [`291295f6`](https://github.com/NixOS/nixpkgs/commit/291295f6940d0f275cf1fa483a41ed82a3b1e435) m4rie: 20250103 -> 20250128
* [`729ff7c9`](https://github.com/NixOS/nixpkgs/commit/729ff7c933a6bd6b1e21b88d52884413abf26fa9) imgproxy: 3.27.2 -> 3.28.0
* [`927a14bf`](https://github.com/NixOS/nixpkgs/commit/927a14bf1c65e9a076d09c08484fa4f67a88686b) rancher: 2.10.1 -> 2.11.0
* [`03b4cfda`](https://github.com/NixOS/nixpkgs/commit/03b4cfda660c6fdd109858d18be90d0cccae5925) xcp: 0.23.1 -> 0.24.0
* [`0a87330b`](https://github.com/NixOS/nixpkgs/commit/0a87330b0014962365460ec2fa92ab4564ffcc0d) verible: 0.0.3894 -> 0.0.3956
* [`7bda0c38`](https://github.com/NixOS/nixpkgs/commit/7bda0c38460e2d372163f1fa092b662e330bf9d6) python312Packages.amaranth-boards: 0-unstable-2025-03-18 -> 0-unstable-2025-03-29
* [`eb9eeb31`](https://github.com/NixOS/nixpkgs/commit/eb9eeb3178899b20ce6a2102747f99d1e76da253) python313Packages.sensorpush-api: 2.1.1 -> 2.1.2
* [`2390bb9f`](https://github.com/NixOS/nixpkgs/commit/2390bb9f48aa8c893ca23ce652ce5fe626efe7bc) bun: 1.2.7 -> 1.2.8
* [`7b366b0c`](https://github.com/NixOS/nixpkgs/commit/7b366b0c553cfadf789d3aad624c40ccf2bd9a25) python313Packages.aiowebdav2: 0.4.4 -> 0.4.5
* [`00680fb8`](https://github.com/NixOS/nixpkgs/commit/00680fb8c73ae8b1e26801ab95955420e4734e45) python312Packages.radish-bdd: 0.18.1 -> 0.18.2
* [`6cc8cbc9`](https://github.com/NixOS/nixpkgs/commit/6cc8cbc9547838d9286b25704b2298fa97df70c2) python313Packages.bosch-alarm-mode2: init at 0.4.3
* [`6a64f899`](https://github.com/NixOS/nixpkgs/commit/6a64f899e1a685bbb5e70135bb57452a72eb4f56) python3Packages.microsoft-security-utilities-secret-masker: 1.0.0b3 -> 1.0.0b4
* [`0fdc2760`](https://github.com/NixOS/nixpkgs/commit/0fdc2760084db2b6159696f39d13beffd591feed) python3Packages.azure-mgmt-containerservice: 34.1.0 -> 34.2.0
* [`fff84790`](https://github.com/NixOS/nixpkgs/commit/fff8479088ded41cbc59a0051efe4484a2d4ef66) python3Packages.azure-mgmt-keyvault: 10.3.1 -> 11.0.0
* [`2e0c384c`](https://github.com/NixOS/nixpkgs/commit/2e0c384c45603051e69f0eba71e5590d6c620f4a) python3Packages.azure-multiapi-storage: 1.3.0 -> 1.4.0
* [`5ea3b8d9`](https://github.com/NixOS/nixpkgs/commit/5ea3b8d92e2ab477b455175419d3162fe8592b31) azure-cli: 2.70.0 -> 2.71.0
* [`c44ba282`](https://github.com/NixOS/nixpkgs/commit/c44ba28214408774978f0f02f3dd23462fe56fb5) buildkite-cli: 3.7.1 -> 3.8.0
* [`30f6c5ef`](https://github.com/NixOS/nixpkgs/commit/30f6c5ef668464eb109009a9eafd969d81e6fd76) ocis-bin5: rename from ocis-bin
* [`2db95477`](https://github.com/NixOS/nixpkgs/commit/2db95477f94d539cc4cbc1c82988aa8f963dae60) nixos/ocis: default to the newly renamed ocis-bin5 package
* [`368f6893`](https://github.com/NixOS/nixpkgs/commit/368f689306773fadf6bb7018961ffb6686222774) python312Packages.mypy-boto3-ec2: 1.37.16 -> 1.37.24
* [`42e993d4`](https://github.com/NixOS/nixpkgs/commit/42e993d4200c9ec021d81b788e9305586ea1cecd) python312Packages.mypy-boto3-eks: 1.37.22 -> 1.37.24
* [`f68ff8d8`](https://github.com/NixOS/nixpkgs/commit/f68ff8d8170235d954026dd4fce72aec26a5194a) python312Packages.mypy-boto3-marketplace-entitlement: 1.37.20 -> 1.37.24
* [`9ec8883a`](https://github.com/NixOS/nixpkgs/commit/9ec8883ad26ec57319e7b0abbb901d2978ddc2cc) python312Packages.mypy-boto3-outposts: 1.37.0 -> 1.37.24
* [`013e7332`](https://github.com/NixOS/nixpkgs/commit/013e73321e00b3372221a9f3ad7b5381c2c67537) python312Packages.mypy-boto3-s3: 1.37.0 -> 1.37.24
* [`92454fc0`](https://github.com/NixOS/nixpkgs/commit/92454fc02d95ced9a8246b889b593209bb89e4e2) python312Packages.mypy-boto3-s3control: 1.37.12 -> 1.37.24
* [`46baad90`](https://github.com/NixOS/nixpkgs/commit/46baad9026f126c0d41a31ebfd8998368570abd8) python312Packages.mypy-boto3-sesv2: 1.37.0 -> 1.37.24
* [`f0f02627`](https://github.com/NixOS/nixpkgs/commit/f0f02627bb201be8ae12bca1c64fbdf0d37e8d06) python312Packages.mypy-boto3-transfer: 1.37.0 -> 1.37.24
* [`fd3ce5c2`](https://github.com/NixOS/nixpkgs/commit/fd3ce5c2919be6201c38ce7dba2436b401499782) python313Packages.botocore-stubs: 1.37.23 -> 1.37.24
* [`3833a561`](https://github.com/NixOS/nixpkgs/commit/3833a5617ca0bdafac65ffd4d2559128b30483eb) python313Packages.boto3-stubs: 1.37.23 -> 1.37.24
* [`f21064c9`](https://github.com/NixOS/nixpkgs/commit/f21064c9b3f0c6bf242ce14fa5108d750a9534f6) matrix-alertmanager-receiver: 2025.3.19 -> 2025.3.26
* [`a2560e53`](https://github.com/NixOS/nixpkgs/commit/a2560e53a0588fb59e18a3217c805a7ba2d83725) exploitdb: 2025-03-29 -> 2025-03-30
* [`c3400d99`](https://github.com/NixOS/nixpkgs/commit/c3400d996698fba8385075b96717c3c64b6838af) python313Packages.bc-detect-secrets: 1.5.38 -> 1.5.39
* [`62424991`](https://github.com/NixOS/nixpkgs/commit/624249918db365d841683cd84a47af23cae39e61) python313Packages.circuitbreaker: 2.1.0 -> 2.1.3
* [`389d49a3`](https://github.com/NixOS/nixpkgs/commit/389d49a32369eabef3efd8f61cf6465b83ee6d7b) python313Packages.cyclopts: 3.11.1 -> 3.11.2
* [`0fbfb6e7`](https://github.com/NixOS/nixpkgs/commit/0fbfb6e788cb9b99af7f230a93a30ea0806ec570) python313Packages.msticpy: 2.16.0 -> 2.16.1
* [`f7cc3801`](https://github.com/NixOS/nixpkgs/commit/f7cc3801edf6796eb8fc7e68d3bae4031f946a0b) gungnir: 1.2.0 -> 1.3.1
* [`86b9df94`](https://github.com/NixOS/nixpkgs/commit/86b9df94e56e6d0f0cfd88b1ed48ee715ca95471) goreleaser: 2.8.1 -> 2.8.2
* [`b4092fd5`](https://github.com/NixOS/nixpkgs/commit/b4092fd5a19909d9b4af84e20a4b47867257eb93) checkov: 3.2.393 -> 3.2.395
* [`1b57627b`](https://github.com/NixOS/nixpkgs/commit/1b57627b33aa7867724be299b6f37747ed6ebf24) terraform-providers.sysdig: 1.50.0 -> 1.52.0
* [`fe0e2958`](https://github.com/NixOS/nixpkgs/commit/fe0e29587f7c2525ceeba12560140123d2f8dd03) tandoor-recipes: fix nested python.pkgs use
* [`e7c64124`](https://github.com/NixOS/nixpkgs/commit/e7c641248e7ba692039a2d0e7534b2b8c873dbd1) python3Packages.language-tool-python: fix definition
* [`f42cd833`](https://github.com/NixOS/nixpkgs/commit/f42cd833c14d3b50366f3890adaa1028fe706cc9) pythonPackages: prevent incorrect package definitions
* [`08c600ee`](https://github.com/NixOS/nixpkgs/commit/08c600ee0b971543d8c4b3602fc69af8eaeb0d79) python313Packages.oras: 0.2.27 -> 0.2.28
* [`b457b393`](https://github.com/NixOS/nixpkgs/commit/b457b39340679f8606312546887561fe0aa5fb02) logseq: init at 0.10.9-unstable-2025-03-11
* [`e170677b`](https://github.com/NixOS/nixpkgs/commit/e170677ba0bb430a6d38fec0c52016668cc200ce) lean4: 4.17.0 -> 4.18.0
* [`8f60574d`](https://github.com/NixOS/nixpkgs/commit/8f60574d4774ac1bdee3c70767024b96ecdda411) plan-exporter: add update script
* [`91bb1961`](https://github.com/NixOS/nixpkgs/commit/91bb19618ee34209220aa314d4890a1b5ec15ba8) python312Packages.libusb1: 3.3.0 -> 3.3.1
* [`ef4cdcad`](https://github.com/NixOS/nixpkgs/commit/ef4cdcad9eaa74c2ff07c065e08b4017be3665c4) mkosi: 25.3 -> 25.3-unstable-2025-04-01
* [`7eeb573d`](https://github.com/NixOS/nixpkgs/commit/7eeb573de739a5786257f8aed663e09475126db6) walker: 0.12.16 -> 0.12.19
* [`f29bdc10`](https://github.com/NixOS/nixpkgs/commit/f29bdc105c3488dac3603d73b864e6a8cab4e21e) pesign: fix build with gcc14
* [`8e1af12f`](https://github.com/NixOS/nixpkgs/commit/8e1af12f268d4d0a99b338e8237cc167f0a580da) python312Packages.dash-bootstrap-components: 1.7.1 -> 2.0.0
* [`1ff2c330`](https://github.com/NixOS/nixpkgs/commit/1ff2c3305574d1cebde5e6d1fedb3ec6280f4069) fluent-bit: 3.2.9 -> 3.2.6
* [`6bc5d409`](https://github.com/NixOS/nixpkgs/commit/6bc5d409935083351921f0fa7a916274f3471f8b) veryl: 0.14.1 -> 0.15.0
* [`d52184c4`](https://github.com/NixOS/nixpkgs/commit/d52184c471ef437badca1b7dd8829c0019d517c5) q2pro: 0-unstable-2025-03-20 -> 0-unstable-2025-03-26
* [`574e1aaf`](https://github.com/NixOS/nixpkgs/commit/574e1aaf40809d52ded76743a64df72470e69f35) cirrus-cli: 0.139.2 -> 0.140.8
* [`3f9085b9`](https://github.com/NixOS/nixpkgs/commit/3f9085b9f8d3173d225a1149ca9d94fc7814b7d2) saucectl: 0.194.0 -> 0.194.1
* [`76b48f26`](https://github.com/NixOS/nixpkgs/commit/76b48f26f0768eefb60b29ee1b6269dafd9fd37e) vimPlugins.rainbow-delimiters-nvim: unstable-2025-01-12 -> 0.9.1
* [`68664c09`](https://github.com/NixOS/nixpkgs/commit/68664c0952c26c5ccd20afd5e512a31a815dbdc2) mactracker: 7.13.2 -> 7.13.5
* [`3384aaeb`](https://github.com/NixOS/nixpkgs/commit/3384aaebb26f81b240ce3f73e071146469f7be20) fselect: 0.8.10 -> 0.8.11
* [`4aa1ef33`](https://github.com/NixOS/nixpkgs/commit/4aa1ef3387d7fe20ac4b29a5c3e72a837c5aebfb) polkadot: 2412-3 -> 2412-4
* [`b7aec6f4`](https://github.com/NixOS/nixpkgs/commit/b7aec6f4c5fc4453ec5da167e32ac81bdb854c21) gdevelop: 5.5.226 -> 5.5.228
* [`a8e2d76b`](https://github.com/NixOS/nixpkgs/commit/a8e2d76b98a94b66e04640abfbcc71bb4d36c2dd) briar-desktop: 0.6.0 -> 0.6.3
* [`17018c8a`](https://github.com/NixOS/nixpkgs/commit/17018c8a4136d97a91c6795193bdb1cb0ab9bf01) briar-desktop: adds supinie to maintainers
* [`a1bf64c7`](https://github.com/NixOS/nixpkgs/commit/a1bf64c7a50cbfb301632533b21072b32e76b7a4) nixfmt-tree: refactor impl to use `treefmt.withConfig`
* [`0489b397`](https://github.com/NixOS/nixpkgs/commit/0489b3976a7161eefab6518f69856b1e82998332) treewide: remove unused patches files
* [`1c625d2a`](https://github.com/NixOS/nixpkgs/commit/1c625d2acf6001c87fee6c118b4bd67faaa9d17a) panoply: 5.5.5 -> 5.6.0
* [`e8dd02fe`](https://github.com/NixOS/nixpkgs/commit/e8dd02fe7906f53d57bf238dc178cdb80c8654ed) rssguard: 4.8.1 -> 4.8.2
* [`f2087127`](https://github.com/NixOS/nixpkgs/commit/f20871279aed94f3efcf7f6a4946c39e55f01776) ddev: 1.24.3 -> 1.24.4
* [`579639bf`](https://github.com/NixOS/nixpkgs/commit/579639bfec84251292303b32d45438f35987ef38) python313Packages.busylight-for-humans: 0.33.2 -> 0.33.3
* [`fcf435e0`](https://github.com/NixOS/nixpkgs/commit/fcf435e05cb408d56faeb9b00496330de17622a4) spicedb: 1.41.0 -> 1.42.0
* [`08181ad1`](https://github.com/NixOS/nixpkgs/commit/08181ad11d18304f80446eab6bbd3d1c9cfefaec) mpv: Fix build on darwin
* [`e627a1bf`](https://github.com/NixOS/nixpkgs/commit/e627a1bf2bb994d0c570bd418aca5400638475ba) postgresqlPackages.timescaledb-apache: 2.19.0 -> 2.19.1
* [`956496a9`](https://github.com/NixOS/nixpkgs/commit/956496a91bcb10c1c7ea296cf83c9b1706ab7159) claude-code: 0.2.56 -> 0.2.57
* [`ca139fa2`](https://github.com/NixOS/nixpkgs/commit/ca139fa2acc6de8deacecda4dae10902cae23a0b) roon-server: 2.47.1510 -> 2.48.1517
* [`4b90802b`](https://github.com/NixOS/nixpkgs/commit/4b90802b33719bbb114360d8e970bbcf49cc85d0) namespace-cli: 0.0.406 -> 0.0.407
* [`27a5a196`](https://github.com/NixOS/nixpkgs/commit/27a5a19682e7e3225367da69de7533900cc04533) gitlab: 17.9.3 -> 17.10.1
* [`c92c1efa`](https://github.com/NixOS/nixpkgs/commit/c92c1efa465497446d090134c6c8441c5fb9c4b2) proton-ge-bin: GE-Proton9-26 -> GE-Proton9-27
* [`87ac1368`](https://github.com/NixOS/nixpkgs/commit/87ac13688378e64e83f418ba309af3894a01c1bb) hyprlandPlugins.hy3: 0.47.0-1 -> hl0.48.0
* [`3e20b1e3`](https://github.com/NixOS/nixpkgs/commit/3e20b1e31a4039cc10c7fdc4f8e98bcce8765754) nixosTests.magic-wormhole-mailbox-server: migrate to runTest
* [`8f34e1e6`](https://github.com/NixOS/nixpkgs/commit/8f34e1e65dfa27b470a93952a53db8582c02c0f8) fn-cli: 0.6.39 -> 0.6.40
* [`a5f5355f`](https://github.com/NixOS/nixpkgs/commit/a5f5355f5e265ed2e579af1c43ffc29b84a16b8b) openapi-pydantic: init at 0.5.1
* [`2fd066f3`](https://github.com/NixOS/nixpkgs/commit/2fd066f3f1a5c4324037a5d9640fde1c60a4ff23) posting: 2.3.0 -> 2.5.4
* [`763fac13`](https://github.com/NixOS/nixpkgs/commit/763fac1366112b260858bec072fe70d2d427a2fb) home-assistant-custom-lovelace-modules.mushroom: 4.3.1 -> 4.4.0 ([nixos/nixpkgs⁠#395186](https://togithub.com/nixos/nixpkgs/issues/395186))
* [`15cd2e6e`](https://github.com/NixOS/nixpkgs/commit/15cd2e6e26b0df48ed2c0e8b5c9c20df1d2613c3) ov: add `meta.mainProgram`
* [`bf11382c`](https://github.com/NixOS/nixpkgs/commit/bf11382c07458803a25554579b4bfa6f60e8b804) containerlab: 0.66.0 -> 0.67.0
* [`728c87d2`](https://github.com/NixOS/nixpkgs/commit/728c87d2fca9c6b5732e5ecb039578c6169adebd) nodejs_23: 23.10.0 -> 23.11.0
* [`4a622b58`](https://github.com/NixOS/nixpkgs/commit/4a622b585d9e2950d0d10ee20c8d80e5d495ae77) cnspec: 11.47.1 -> 11.48.0
* [`3c80982e`](https://github.com/NixOS/nixpkgs/commit/3c80982ec9501e8f5b3ea7d33829a4e459272b2f) archipelago-minecraft: 0.5.1 -> 0.6.0
* [`5ad8c5cc`](https://github.com/NixOS/nixpkgs/commit/5ad8c5cc384918fbc99846ff84bde06ebbbb25a7) arduino-create-agent: 1.6.1 -> 1.7.0
* [`39c2411e`](https://github.com/NixOS/nixpkgs/commit/39c2411e44ec4a5174ba7921a6dcce6ae20c944c) python312Packages.djangocms-text-ckeditor: 5.1.6 -> 5.1.7
* [`42c621ba`](https://github.com/NixOS/nixpkgs/commit/42c621ba724ef5c45eaf7f0a99b02bdc06250597) nixos/tests/netbox: Adjust tests for 4.2.0+, drop test for 3.6
* [`d9200c44`](https://github.com/NixOS/nixpkgs/commit/d9200c4417487533c35df0f2f672460d61b69040) python312Packages.docx2txt: 0.8 -> 0.9
* [`5e4381c1`](https://github.com/NixOS/nixpkgs/commit/5e4381c1c4e73b3d560dd5d8940806f9720ca02f) age: add a convenience function for wrapping with plugins
* [`5d9c67a8`](https://github.com/NixOS/nixpkgs/commit/5d9c67a8f79143a9e7da17f333122d27ab53e819) sops: add a convenience function for wrapping age plugins
* [`37290199`](https://github.com/NixOS/nixpkgs/commit/37290199a6648a1e501839e07f6f9be95e4c58cc) gitkraken: 10.8.0 -> 11.0.0
* [`1543d8cf`](https://github.com/NixOS/nixpkgs/commit/1543d8cfc3c4edd6cd94c7271fee6914d76ed9ac) firefox-unwrapped: 136.0.3 -> 137.0
* [`157c5db5`](https://github.com/NixOS/nixpkgs/commit/157c5db5b32b46e3e5224f28b676643dd0591331) firefox-bin-unwrapped: 136.0.3 -> 137.0
* [`b5f04a27`](https://github.com/NixOS/nixpkgs/commit/b5f04a27760aa22bf5c3e1c6926d96c3f3e599b8) firefox-esr-128-unwrapped: 128.8.1esr -> 128.9.0esr
* [`eb03e6c2`](https://github.com/NixOS/nixpkgs/commit/eb03e6c2795539164a9c5ea1c7d7c5091d5663e8) python312Packages.rdbtools: init at 0.1.15
* [`84f6e47e`](https://github.com/NixOS/nixpkgs/commit/84f6e47e31010641823373b8add9763c705823c4) omnix: init at 1.0.3
* [`f651e277`](https://github.com/NixOS/nixpkgs/commit/f651e277be93f7be3e0ae37a75a565249e64b89a) postgresqlPackages.pgmq: 1.5.0 -> 1.5.1
* [`8125d74e`](https://github.com/NixOS/nixpkgs/commit/8125d74e21449e7ba702af890297a8bb9dc5f273) nixos/dnsmasq: Fix failure on read-only /etc when resolveLocalQueries=false ([nixos/nixpkgs⁠#391738](https://togithub.com/nixos/nixpkgs/issues/391738))
* [`7a52c8da`](https://github.com/NixOS/nixpkgs/commit/7a52c8da72063bbaa6d0f82267f415902d68670d) resp-app: don't replace already present patches in rdbtools override
* [`28a0fcfa`](https://github.com/NixOS/nixpkgs/commit/28a0fcfa8aba39dadbf07b48bf6c849d73c6b3aa) material-maker: fix crash by using export templates from nixpkgs
* [`67eb7198`](https://github.com/NixOS/nixpkgs/commit/67eb7198cdd2f486e5f1142f89d71300daff16b5) pulumi-bin: 3.159.0 -> 3.160.0
* [`bbea352f`](https://github.com/NixOS/nixpkgs/commit/bbea352f183a8251b4bd25dccc64c506df1f1dce) python312Packages.dbf: 0.99.9 -> 0.99.10
* [`40129eff`](https://github.com/NixOS/nixpkgs/commit/40129eff5669fc53797841aad6f37c966d7aef4a) anytype: Add adda as maintainer
* [`f203edef`](https://github.com/NixOS/nixpkgs/commit/f203edefe5523c83ea6338742ba35b5dd012eb60) python312Packages.nexia: 2.5.0 -> 2.6.0
* [`a566710f`](https://github.com/NixOS/nixpkgs/commit/a566710f1c408254c95793d54fbb07636da1b7a6) python312Packages.cvxopt: fix version
* [`25499add`](https://github.com/NixOS/nixpkgs/commit/25499add4c30945039b83419751a505b23a42bd4) pnpm: 10.7.0 -> 10.7.1
* [`0016ab42`](https://github.com/NixOS/nixpkgs/commit/0016ab4295ae67e3eb2b67305aed732c91822c3b) sdl3: 3.2.8 -> 3.2.10
* [`de1cc8fe`](https://github.com/NixOS/nixpkgs/commit/de1cc8fe1d16471543735b96e51e6434bb48e26f) vimPlugins.jule-nvim: init at 2025-02-22
* [`324fe50d`](https://github.com/NixOS/nixpkgs/commit/324fe50de501579fd80e1d629c67ca6bbcd75ee4) immich: 1.130.3 -> 1.131.2
* [`d56c6643`](https://github.com/NixOS/nixpkgs/commit/d56c66433cfb6851d8f618d5e9e08d143884fc35) python312Packages.decora-wifi: init at 1.4
* [`93cb44e2`](https://github.com/NixOS/nixpkgs/commit/93cb44e2d2c1dabac351b8c76fd3a2f01f5066e4) home-assistant: add decora-wifi
* [`473e7c5b`](https://github.com/NixOS/nixpkgs/commit/473e7c5b944be72175b5bc03fb5cd313170c9011) tailwindcss_4: 4.0.17 -> 4.1.0
* [`b02032e1`](https://github.com/NixOS/nixpkgs/commit/b02032e10e7074c24e1f1ae8fc90207b46fc1fd6) eclipses: retire scala SDK
* [`376fba43`](https://github.com/NixOS/nixpkgs/commit/376fba433223f76ed2b483c47c36efb5fb966ed2) eclipses: extract eclipses.json
* [`5bb31f95`](https://github.com/NixOS/nixpkgs/commit/5bb31f9518544f18e49365e7f32e43ff049aa341) eclipses: implement an updateScript
* [`9c24350f`](https://github.com/NixOS/nixpkgs/commit/9c24350f073616e3959e44c1b9b6ff05b8b46cc0) eclipses: add self as maintainer
* [`7c813c9d`](https://github.com/NixOS/nixpkgs/commit/7c813c9ddef6a8d88305026d92e9292a68dabeba) python312Packages.langsmith: 0.3.10 -> 0.3.22
* [`398e74f7`](https://github.com/NixOS/nixpkgs/commit/398e74f70b6ef824c3891cb8889dddb851d8bab3) shell: Introduce treefmt
* [`5a8296d7`](https://github.com/NixOS/nixpkgs/commit/5a8296d74fd86de63fa441d238b10ccea0b72640) flake.nix: Set formatter
* [`927521a6`](https://github.com/NixOS/nixpkgs/commit/927521a6ace142da9f96ec7e87035a604fba818e) workflows/check-nix-format: Enforce formatting on all files
* [`2140bf39`](https://github.com/NixOS/nixpkgs/commit/2140bf39e41767f25a395d20fb0d5698b8934b33) CONTRIBUTING: Improve and update formatting docs
* [`374e6bcc`](https://github.com/NixOS/nixpkgs/commit/374e6bcc403e02a35e07b650463c01a52b13a7c8) treewide: Format all Nix files
* [`49cf5474`](https://github.com/NixOS/nixpkgs/commit/49cf547427c17515d4b2c7a669ffdbe123d7eac8) git-blame-ignore-revs: Add previous commit
* [`55516075`](https://github.com/NixOS/nixpkgs/commit/55516075b4b534f1d50d843171542735919d7698) code-cursor: 0.47.8 -> 0.48.6
* [`a90ef306`](https://github.com/NixOS/nixpkgs/commit/a90ef306ff3cbbbed0544d70a6eeb0e23710eff0) ugs: 2.1.12 -> 2.1.13
* [`ec798cb3`](https://github.com/NixOS/nixpkgs/commit/ec798cb3b130e7ab2385258f34cc8b9ab0fca6d3) wasm-tools: 1.227.1 -> 1.228.0
* [`762d3dfa`](https://github.com/NixOS/nixpkgs/commit/762d3dfa72b17524f43b070bcf2c743a668fab8e) petsc: reorder inputs
* [`795f035b`](https://github.com/NixOS/nixpkgs/commit/795f035bb7fb988018e9c77e87f8bc74ab7f39b6) petsc: use finalAttrs
* [`1f4f2e02`](https://github.com/NixOS/nixpkgs/commit/1f4f2e029214c3b4badd1166537767de25dadaf3) petsc: add fullDeps test
* [`e477c1f0`](https://github.com/NixOS/nixpkgs/commit/e477c1f0b900848fb8aebb051982abd1a28c20c5) petsc: remove configure flag --with-hdf5-fortran-bindings=1
* [`f00965dc`](https://github.com/NixOS/nixpkgs/commit/f00965dcff5fd8557fc764cd8651b69574277659) petsc: remove unnecssary configure flags
* [`45b86ca4`](https://github.com/NixOS/nixpkgs/commit/45b86ca411ab8768af40fb23b45d46e5d4d0a024) petsc: add withZlib option
* [`0a50de12`](https://github.com/NixOS/nixpkgs/commit/0a50de12c97d36f3aac685e0af4578a16c3e0e2e) petsc: reorder configure flags
* [`62208f0a`](https://github.com/NixOS/nixpkgs/commit/62208f0a1b16be2ee2fb388fb3e347a1fb8bd1aa) petsc: add fortranSupport option
* [`a11a1f19`](https://github.com/NixOS/nixpkgs/commit/a11a1f196bbb9787065464785c9750a84c9c9720) petsc: override external math libraries in scope petscPackages
* [`9b40829f`](https://github.com/NixOS/nixpkgs/commit/9b40829f4da205eafd7947e5dbe9450ca1861f59) petsc: add serial tests
* [`f75b5cfe`](https://github.com/NixOS/nixpkgs/commit/f75b5cfe460b3a14d14b5e8677daa25f3e2da4c7) petsc: add mumps,scalapack,ptscotch to commonDeps in petsc
* [`9b379799`](https://github.com/NixOS/nixpkgs/commit/9b37979905769d2d6e28c58c0c9430a4f5f3e91a) petsc: add hypre,fftw,superlu,suitesparse to commonDeps
* [`bf1af1c7`](https://github.com/NixOS/nixpkgs/commit/bf1af1c732bb8d4381f15b2e352067f549c4f3b3) petsc: change some inputs style from kebab-case to camelCase
* [`9f0a2d26`](https://github.com/NixOS/nixpkgs/commit/9f0a2d26fce4e188dfc4272f2db3044e81d1c74c) petsc: remove with lib in meta attrs
* [`605ec776`](https://github.com/NixOS/nixpkgs/commit/605ec77678e47441a008a743e16e57d82d5b6bb8) petsc: 3.22.4 -> 3.23.0
* [`1c3507db`](https://github.com/NixOS/nixpkgs/commit/1c3507db7e102141e271ae2b98e05ca83915123d) uiua-unstable: 0.15.0-rc.1 -> 0.15.0-rc.2
* [`baecb706`](https://github.com/NixOS/nixpkgs/commit/baecb706a125c32f0bf527ee95035218571484d7) prometheus-node-exporter: 1.9.0 -> 1.9.1
* [`2a71140a`](https://github.com/NixOS/nixpkgs/commit/2a71140aba7402f794c61c2def4504e0f50ed807) petsc: fix ptscotch dependencies
* [`26d320d7`](https://github.com/NixOS/nixpkgs/commit/26d320d7a9695e1af414d1df62569935c03df7ff) slepc: 3.22.2 -> 3.23.0
* [`a755059e`](https://github.com/NixOS/nixpkgs/commit/a755059ee4e80801a7a2577553511433543e5a52) zigbee2mqtt_2: 2.1.3 -> 2.2.0
* [`fe5391e1`](https://github.com/NixOS/nixpkgs/commit/fe5391e180cd8ed9c03c9325ddfc00fdd7895695) nixosTests.bcachefs: migrate to runTest
* [`1ddc0a9c`](https://github.com/NixOS/nixpkgs/commit/1ddc0a9c8147fd9a2073e647493ac92a1ef27a51) kbld: 0.45.0 -> 0.45.1
* [`77cb9637`](https://github.com/NixOS/nixpkgs/commit/77cb9637765e177eb34202f2491784e1cfe6a425) kubernetes-controller-tools: 0.17.2 -> 0.17.3
* [`fab4accc`](https://github.com/NixOS/nixpkgs/commit/fab4acccedbca68694602e12b50a475f3b3ccd0a) nixosTests.binary-cache{no-compression,xz}: migrate to runTest
* [`a5b4c7f3`](https://github.com/NixOS/nixpkgs/commit/a5b4c7f3a2a58012b41ee225a070d7e31f801814) jnv: 0.5.0 -> 0.6.0
* [`2e5115f7`](https://github.com/NixOS/nixpkgs/commit/2e5115f7948bd1f0a0fa994da6c0c88a96823d1c) python312Packages.docling: cleanup dependencies
* [`96d9ab06`](https://github.com/NixOS/nixpkgs/commit/96d9ab064ed55129d568955c5fec8a676415d6b8) python312Packages.docling: disable one test
* [`426ef3f9`](https://github.com/NixOS/nixpkgs/commit/426ef3f9d60bd82d952d0e7014f184df152707b0) docling-serve: init at 0.7.0
* [`25264d10`](https://github.com/NixOS/nixpkgs/commit/25264d105d4a34a8807141cc8587871b12dfe32b) nixos/docling-serve: init
* [`0e553a83`](https://github.com/NixOS/nixpkgs/commit/0e553a831e4c154d623c3b4b862d0daf6215ec8e) build(deps): bump cachix/install-nix-action from {30,31} to 31.1.0 ([nixos/nixpkgs⁠#394893](https://togithub.com/nixos/nixpkgs/issues/394893))
* [`8f2f1814`](https://github.com/NixOS/nixpkgs/commit/8f2f18147878deea7e7ee32fc341b4712dcef623) readest: 0.9.28 -> 0.9.29
* [`5179f462`](https://github.com/NixOS/nixpkgs/commit/5179f4621cb4dea41797ff39e9ee6d4cebe9b9d2) nixosTests.buildbot: migrate to runTest
* [`8e1346b3`](https://github.com/NixOS/nixpkgs/commit/8e1346b3ae19aae7aad124289692faa8e61982a3) inputplumber: 0.49.6 -> 0.50.0
* [`dff8e834`](https://github.com/NixOS/nixpkgs/commit/dff8e834a006b9e8c976971e67a3248b399f4cc6) googler: drop
* [`81799670`](https://github.com/NixOS/nixpkgs/commit/817996705e4e626781c8e23da07e66ea78963ef2) clash-meta: 1.19.3 -> 1.19.4
* [`1586a89d`](https://github.com/NixOS/nixpkgs/commit/1586a89d9ee3019b233a4d73014c96da8d8d498c) chromium,chromedriver: 134.0.6998.165 -> 135.0.7049.52
* [`7704c34c`](https://github.com/NixOS/nixpkgs/commit/7704c34c04d9b2f9f9f3094926d6e0adadf2ab59) cargo-codspeed: 2.9.1 -> 2.10.0
* [`bb742fb4`](https://github.com/NixOS/nixpkgs/commit/bb742fb49ba7cdb0b732c6370119d22100e5a7a9) python313Packages.tencentcloud-sdk-python: 3.0.1351 -> 3.0.1352
* [`38c30057`](https://github.com/NixOS/nixpkgs/commit/38c300576d8f0f30bf6eba0756d320665cb8c38a) cnspec: 11.47.1 -> 11.48.0
* [`fffb97ba`](https://github.com/NixOS/nixpkgs/commit/fffb97ba1166333536c558f0e781dfb12ead5d5b) python313Packages.evohome-async: 1.0.4 -> 1.0.5
* [`5ff5fbd0`](https://github.com/NixOS/nixpkgs/commit/5ff5fbd0e8c2428b63d4230453cc723dacdd6c66) vimPlugins.vim-foldsearch: init at 2024-05-15
* [`8c94060d`](https://github.com/NixOS/nixpkgs/commit/8c94060dc76a82d39619ec99113ecc188eafa70c) python313Packages.aiomqtt: 2.3.0 -> 2.3.1
* [`36a43399`](https://github.com/NixOS/nixpkgs/commit/36a43399ea839dc5ce2294e58dd44fcd8d5a9c55) judy: make build reproducible by removing timestamps from manpages and LC_UUID on macos
* [`54be451a`](https://github.com/NixOS/nixpkgs/commit/54be451a0f3ce4905b2614ed37ad6cac92af3a96) python313Packages.apprise: 1.9.2 -> 1.9.3
* [`181ba57e`](https://github.com/NixOS/nixpkgs/commit/181ba57e9bc800523b2ac77ace534028242c4ebd) python313Packages.django-storages: 1.14.4 -> 1.14.5
* [`99c209dc`](https://github.com/NixOS/nixpkgs/commit/99c209dc5cd008d59649a9830247bf8475ea9bd2) python313Packages.django-admin-sortable2: 2.2.4 -> 2.2.6
* [`0867a9b9`](https://github.com/NixOS/nixpkgs/commit/0867a9b91d7b24132d34810c8e8549a850928ee9) python313Packages.django-allauth: 65.5.0 -> 65.6.0
* [`bd7ead7f`](https://github.com/NixOS/nixpkgs/commit/bd7ead7fc3ebe794f8261889adc7924d6d26ec40) python313Packages.dirigera: 1.2.2 -> 1.2.3
* [`61bffce5`](https://github.com/NixOS/nixpkgs/commit/61bffce5dc37af57bf257b7e78d398b960cbbc41) python313Packages.pyfronius: 0.7.7 -> 0.8.0
* [`82b16da5`](https://github.com/NixOS/nixpkgs/commit/82b16da55d72874d252ea5b831e0ddc2ad789377) vimPlugins.vim-fold-cycle: init at 2020-05-11
* [`c13f4fa8`](https://github.com/NixOS/nixpkgs/commit/c13f4fa827c57c4ec333527eb16e01a459c5a7fe) python313Packages.mcpadapt: 0.0.18 -> 0.0.19
* [`dc3df2d0`](https://github.com/NixOS/nixpkgs/commit/dc3df2d066f6e064638d9592aca56c21f746c9da) nixosTests.beanstalkd: migrate to runTest
* [`e6b51c91`](https://github.com/NixOS/nixpkgs/commit/e6b51c9110dbfff2d43aa5c8dd9be0a4ba5985ff) strfry: init at 1.0.4
* [`dfd82bf3`](https://github.com/NixOS/nixpkgs/commit/dfd82bf3e5b6893798389c333d35fa28b9ad6e24) nixos/strfry: init
* [`3086bb93`](https://github.com/NixOS/nixpkgs/commit/3086bb9365b4c3e803e73872c80a7a6ba6120417) monocle: init at 0.8.0
* [`8a73fafc`](https://github.com/NixOS/nixpkgs/commit/8a73fafca5841e02ada1793e89cc41b95eda3874) python313Packages.pychromecast: 14.0.6 -> 14.0.7
* [`3eac5d4f`](https://github.com/NixOS/nixpkgs/commit/3eac5d4f480634a464309975d8250cbfa7de177d) python313Packages.mypy-boto3-builder: 8.9.2 -> 8.10.1
* [`aaf92e57`](https://github.com/NixOS/nixpkgs/commit/aaf92e571229c204ad873bd3ab2a7b84da3599ff) python313Packages.pynmeagps: 1.0.46 -> 1.0.48
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
