### PR TITLE
niv home-manager: update c21383b5 -> a4d80208

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -41,10 +41,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c21383b556609ce1ad901aa08b4c6fbd9e0c7af0",
-        "sha256": "05jyfabmws6zzcrb32hv1wrlp1sm3zi54crr52nidf8l1sl6gkdv",
+        "rev": "a4d8020820a85b47f842eae76ad083b0ec2a886a",
+        "sha256": "0n0432m675xr1rddy2xycn80v8njfcdrjfypcrbwhjqp0kbibbpm",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/c21383b556609ce1ad901aa08b4c6fbd9e0c7af0.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/a4d8020820a85b47f842eae76ad083b0ec2a886a.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@c21383b5...a4d80208](https://github.com/nix-community/home-manager/compare/c21383b556609ce1ad901aa08b4c6fbd9e0c7af0...a4d8020820a85b47f842eae76ad083b0ec2a886a)

* [`55cf1f16`](https://github.com/nix-community/home-manager/commit/55cf1f16324e694c991e846ad5fc897f0f75ac64) firefox: fix missing lib ([nix-community/home-manager⁠#6744](https://togithub.com/nix-community/home-manager/issues/6744))
* [`0afad8f0`](https://github.com/nix-community/home-manager/commit/0afad8f08014c992c832466c1d46a0aa96ca2563) Revert "nixos-module: Fix potential recursion between users.users and home-ma…" ([nix-community/home-manager⁠#6745](https://togithub.com/nix-community/home-manager/issues/6745))
* [`f4d9d1e2`](https://github.com/nix-community/home-manager/commit/f4d9d1e2ad19d544a0a0cf3f8f371c6139c762e9) broot: get rid of IFDs ([nix-community/home-manager⁠#6723](https://togithub.com/nix-community/home-manager/issues/6723))
* [`89279a66`](https://github.com/nix-community/home-manager/commit/89279a66f4c6c32ea39940a6af63171dae75aafd) fcitx5: set SDL_IM_MODULE ([nix-community/home-manager⁠#6742](https://togithub.com/nix-community/home-manager/issues/6742))
* [`e355ae93`](https://github.com/nix-community/home-manager/commit/e355ae93a3cdaff64a3152c78b944ef36a85e8ce) docs: add docs for mkOutOfStoreSymlink ([nix-community/home-manager⁠#6660](https://togithub.com/nix-community/home-manager/issues/6660))
* [`938e802b`](https://github.com/nix-community/home-manager/commit/938e802b70ee7700141b18ef8dca05ad89917a37) alacritty: add `theme` option ([nix-community/home-manager⁠#5238](https://togithub.com/nix-community/home-manager/issues/5238))
* [`28242a60`](https://github.com/nix-community/home-manager/commit/28242a60d3cdcb6675dfe68ebbb64bf43c7be4e0) home-manager-auto-expire: init
* [`5ee44bc7`](https://github.com/nix-community/home-manager/commit/5ee44bc7c2e853f144390a12ebe5174ad7e3b9e0) news: add services.home-manager.autoExpire entry
* [`81f38986`](https://github.com/nix-community/home-manager/commit/81f38986a2a63ed9b1a61e60c700a9f01bd96f3f) jq: add missing color option ([nix-community/home-manager⁠#6734](https://togithub.com/nix-community/home-manager/issues/6734))
* [`98d718b4`](https://github.com/nix-community/home-manager/commit/98d718b46d2628a3703a10028d0b51620351b0c5) starship: build-time nushell config generation
* [`267f6ada`](https://github.com/nix-community/home-manager/commit/267f6ada1ecc1a3534023d6414a7407008140e96) zoxide: build-time nushell config generation
* [`3722855a`](https://github.com/nix-community/home-manager/commit/3722855a1cd480d4179477a21d82d5eca2e33e57) atuin: build-time nushell config generation
* [`dde05a0b`](https://github.com/nix-community/home-manager/commit/dde05a0b10d7db1410c3d9641026a84707e945cd) carapace: build-time nushell config generation
* [`287cbbbf`](https://github.com/nix-community/home-manager/commit/287cbbbf80d460cd07ef66e05b92565b4b1eee6e) nix-your-shell: build-time nushell config generation
* [`812a12d0`](https://github.com/nix-community/home-manager/commit/812a12d014c8bca72304c68d92e057e2cdd5028b) oh-my-posh: build-time nushell config generation
* [`180fd43e`](https://github.com/nix-community/home-manager/commit/180fd43eea296e62ae68e079fcf56aba268b9a1a) pay-respects: allow setting custom options
* [`53cacafd`](https://github.com/nix-community/home-manager/commit/53cacafd9be391e5ec41f688846edd1e1830c822) treewide: nushell build time configs suffixed
* [`28273920`](https://github.com/nix-community/home-manager/commit/282739209a55470c8a17b821301962e8b841d265) atuin: fix nushell config
* [`49748c74`](https://github.com/nix-community/home-manager/commit/49748c74cdbae03d70381f150b810f92617f23aa) tests/atuin: add nushell test
* [`579a71b9`](https://github.com/nix-community/home-manager/commit/579a71b948533667c6c65e603f18990bdffc8530) flake.lock: Update ([nix-community/home-manager⁠#6746](https://togithub.com/nix-community/home-manager/issues/6746))
* [`b24689a1`](https://github.com/nix-community/home-manager/commit/b24689a173f085e506d16e2f5e88ce3ce1819f94) treewide: use mkPackageOption
* [`0bbc3fc5`](https://github.com/nix-community/home-manager/commit/0bbc3fc5c6092a57d7e3a1999e0809fa7d2efa6a) alacritty: null package support
* [`a99c12d2`](https://github.com/nix-community/home-manager/commit/a99c12d23e108ad40b7da75d46a55cad9871c146) antidote: null package support
* [`fcdd04e0`](https://github.com/nix-community/home-manager/commit/fcdd04e0f9948a7c7814b10b56bd9c9b15ddc1f4) astroid: only generate `poll.sh` when script provided
* [`107352dd`](https://github.com/nix-community/home-manager/commit/107352dde4ff3c01cb5a0b3fe17f5beef37215bc) treewide: add missing package option
* [`66a6ec65`](https://github.com/nix-community/home-manager/commit/66a6ec65f84255b3defb67ff45af86c844dd451b) cliphist: use configured systemdTargets throughout service ([nix-community/home-manager⁠#6751](https://togithub.com/nix-community/home-manager/issues/6751))
* [`f3ac07f2`](https://github.com/nix-community/home-manager/commit/f3ac07f2f7c368952a9e7da64ec0991526f49020) smug: init module ([nix-community/home-manager⁠#6696](https://togithub.com/nix-community/home-manager/issues/6696))
* [`a802defb`](https://github.com/nix-community/home-manager/commit/a802defb16dcdcc7fd0ff5a2d7be913ce2fe79e7) playerctld: add to `$PATH` ([nix-community/home-manager⁠#6753](https://togithub.com/nix-community/home-manager/issues/6753))
* [`bb036cb3`](https://github.com/nix-community/home-manager/commit/bb036cb35383982066e01a6ac8d45597132cf5d5) swaync: Add onChange ([nix-community/home-manager⁠#6233](https://togithub.com/nix-community/home-manager/issues/6233))
* [`07547d29`](https://github.com/nix-community/home-manager/commit/07547d29e12deeb82dedf893cdc89b127fe7195c) swaync: use lib.getExe ([nix-community/home-manager⁠#6755](https://togithub.com/nix-community/home-manager/issues/6755))
* [`0f5908da`](https://github.com/nix-community/home-manager/commit/0f5908daf890c3d7e7052bef1d6deb0f2710aaa1) home-environment: enable home aliases for nushell ([nix-community/home-manager⁠#6754](https://togithub.com/nix-community/home-manager/issues/6754))
* [`46f93825`](https://github.com/nix-community/home-manager/commit/46f93825af684a094950ae66ba5ef24a4b10c49f) redshift/gammastep: fix tray.target dependency
* [`b5e29565`](https://github.com/nix-community/home-manager/commit/b5e29565131802cc8adee7dccede794226da8614) redshift/gammastep: add tray tests
* [`d094c676`](https://github.com/nix-community/home-manager/commit/d094c6763c6ddb860580e7d3b4201f8f496a6836) news: create an individual file for each news entry ([nix-community/home-manager⁠#6747](https://togithub.com/nix-community/home-manager/issues/6747))
* [`ef3b2a6b`](https://github.com/nix-community/home-manager/commit/ef3b2a6b602c3f1a80c6897d6de3ee62339a3eb7) flake.lock: Update ([nix-community/home-manager⁠#6762](https://togithub.com/nix-community/home-manager/issues/6762))
* [`8c9b5450`](https://github.com/nix-community/home-manager/commit/8c9b54504c89f3aec9c82b262c1f4304407fbad6) swaync: use x-restart-triggers for reload ([nix-community/home-manager⁠#6764](https://togithub.com/nix-community/home-manager/issues/6764))
* [`8871d0b1`](https://github.com/nix-community/home-manager/commit/8871d0b1ef705554db56982916bbceefd3253e78) cliphist: systemdTargets default to wayland.systemd target
* [`a90ab0ab`](https://github.com/nix-community/home-manager/commit/a90ab0ab5f00efce68729df4e0ea196f03b2d2c6) wlsunset: systemdTarget default to wayland.systemd target
* [`320e152d`](https://github.com/nix-community/home-manager/commit/320e152d0bade4ca3c1054c1ddee97bb50dfb541) wlsunset: systemdTarget used for all targets
* [`c15ab0ce`](https://github.com/nix-community/home-manager/commit/c15ab0ce0dbe64843358a3081b09ed35144dfd65) swayr: systemd.target default to wayland.systemd target
* [`f463902a`](https://github.com/nix-community/home-manager/commit/f463902a3f03e15af658e48bcc60b39188ddf734) .git-blame-ignore-revs: init ([nix-community/home-manager⁠#6767](https://togithub.com/nix-community/home-manager/issues/6767))
* [`14269b06`](https://github.com/nix-community/home-manager/commit/14269b06a06601aecfd10c33f3f2a45b304b23d5) docs/flake.nix: add flake outputs for docs
* [`1a186efb`](https://github.com/nix-community/home-manager/commit/1a186efb48030b06975677a6b8331fbe9e9a3e46) default.nix: add htmlOpenTool output for docs
* [`a4d80208`](https://github.com/nix-community/home-manager/commit/a4d8020820a85b47f842eae76ad083b0ec2a886a) flake.nix: include more doc outputs
