### PR TITLE
niv home-manager: update a4d80208 -> d5cdf55b

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -41,10 +41,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a4d8020820a85b47f842eae76ad083b0ec2a886a",
-        "sha256": "0n0432m675xr1rddy2xycn80v8njfcdrjfypcrbwhjqp0kbibbpm",
+        "rev": "d5cdf55bd9f19a3debd55b6cb5d38f7831426265",
+        "sha256": "04js6xdqv4wlr37i9yz4c9vcwhxh2c1cqmn55fi5jcq3jdlhd93b",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/a4d8020820a85b47f842eae76ad083b0ec2a886a.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/d5cdf55bd9f19a3debd55b6cb5d38f7831426265.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@a4d80208...d5cdf55b](https://github.com/nix-community/home-manager/compare/a4d8020820a85b47f842eae76ad083b0ec2a886a...d5cdf55bd9f19a3debd55b6cb5d38f7831426265)

* [`bd33ce40`](https://github.com/nix-community/home-manager/commit/bd33ce4000800a44b66e9d5a596d8abe6bf4bb16) tests: stub neovim and vimPlugins and darwin ([nix-community/home-manager⁠#6779](https://togithub.com/nix-community/home-manager/issues/6779))
* [`0daadc77`](https://github.com/nix-community/home-manager/commit/0daadc77840a1ed34cafa581f8b0ab08cb2fcadc) btop: add `themes` option ([nix-community/home-manager⁠#6777](https://togithub.com/nix-community/home-manager/issues/6777))
* [`e741f979`](https://github.com/nix-community/home-manager/commit/e741f97967aa8225c7d866c76833634b7df32202) astroid: Fix use of `fromJSON`
* [`cbdf1c1e`](https://github.com/nix-community/home-manager/commit/cbdf1c1e330fd2aae62ffcfa0892b3457b0c60d8) astroid: fromJSON to importJSON
* [`05cd3420`](https://github.com/nix-community/home-manager/commit/05cd34203e04ed9b948c06929924017008c1eb4c) kitty: fromJSON to importJSON
* [`df09fb59`](https://github.com/nix-community/home-manager/commit/df09fb59817f68fa4c8049b58d12a9b398b92aee) tests: stub more packages on darwin ([nix-community/home-manager⁠#6780](https://togithub.com/nix-community/home-manager/issues/6780))
* [`5966fc8b`](https://github.com/nix-community/home-manager/commit/5966fc8bd1e3da947e917767d0a3b5936f7cc9db) xdg-portal: improve description of `extraPortals` ([nix-community/home-manager⁠#6760](https://togithub.com/nix-community/home-manager/issues/6760))
* [`80ae77ee`](https://github.com/nix-community/home-manager/commit/80ae77eed3a3b48597ec9c1d23ce6e4784214071) kdeconnect: trigger indicator service after generic tray.target ([nix-community/home-manager⁠#6711](https://togithub.com/nix-community/home-manager/issues/6711))
* [`95861b5d`](https://github.com/nix-community/home-manager/commit/95861b5d9fc73f080b385776167c3dd2874e355b) aerospace: Add flattenOnWindowDetected function
* [`7137c8ae`](https://github.com/nix-community/home-manager/commit/7137c8ae4e63fe010cb86676f2d3da9752da566c) tests/aerospace: include on-window-detected
* [`74b681d6`](https://github.com/nix-community/home-manager/commit/74b681d66552e24248a3c36524c932c4c796f985) flake.nix: nixfmt -> treefmt
* [`04a2e5ce`](https://github.com/nix-community/home-manager/commit/04a2e5cedeeaf6c1dd69f4356c87902054669cce) format: use nixfmt-tree treefmt
* [`5df48c42`](https://github.com/nix-community/home-manager/commit/5df48c425569a638a7471af3ad61fb62e4c18c60) flake.nix: add formatter check
* [`cba2f9ce`](https://github.com/nix-community/home-manager/commit/cba2f9ce95c8d10b66cacf05a275e3ad71959638) treewide: reformat nixfmt-rfc-style
* [`fefb6ae1`](https://github.com/nix-community/home-manager/commit/fefb6ae1b301b620a81645789e19945092b079da) .git-blame-ignore-revs: add treewide reformat
* [`760eed59`](https://github.com/nix-community/home-manager/commit/760eed59594f2f258db0d66b7ca4a5138681fd97) flake.nix: remove treefmt-nix input ([nix-community/home-manager⁠#6782](https://togithub.com/nix-community/home-manager/issues/6782))
* [`4040c577`](https://github.com/nix-community/home-manager/commit/4040c5779ce56d36805bc7a83e072f0f894eae7d) modules/programs/ssh: support identityAgent ([nix-community/home-manager⁠#6783](https://togithub.com/nix-community/home-manager/issues/6783))
* [`fcb8a2b6`](https://github.com/nix-community/home-manager/commit/fcb8a2b62b30ae054a4eadbf43c913a755f1d14c) swaylock: fix path values in config file ([nix-community/home-manager⁠#6786](https://togithub.com/nix-community/home-manager/issues/6786))
* [`a1036d4d`](https://github.com/nix-community/home-manager/commit/a1036d4d3e939d740149508aa68b2545c4964d37) tests: stub notmuch darwin ([nix-community/home-manager⁠#6788](https://togithub.com/nix-community/home-manager/issues/6788))
* [`9864a2f4`](https://github.com/nix-community/home-manager/commit/9864a2f421e859d9784b6c413ec25d1415ddfe08) thunderbird: add accountsOrder option ([nix-community/home-manager⁠#6310](https://togithub.com/nix-community/home-manager/issues/6310))
* [`542efdf2`](https://github.com/nix-community/home-manager/commit/542efdf2dfac351498f534eb71671525b9bd45ed) flake.lock: Update ([nix-community/home-manager⁠#6785](https://togithub.com/nix-community/home-manager/issues/6785))
* [`79461936`](https://github.com/nix-community/home-manager/commit/79461936709b12e17adb9c91dd02d1c66d577f09) hyprland: load plugins using exec-once ([nix-community/home-manager⁠#6789](https://togithub.com/nix-community/home-manager/issues/6789))
* [`92266c9a`](https://github.com/nix-community/home-manager/commit/92266c9a6f03b7d86efc056580a1fddb89635a59) btop: adjust `themes` option example ([nix-community/home-manager⁠#6793](https://togithub.com/nix-community/home-manager/issues/6793))
* [`140a7df9`](https://github.com/nix-community/home-manager/commit/140a7df916f6257c755b8663fb27ed79e81c8e89) formatter: use a different treefmt root ([nix-community/home-manager⁠#6792](https://togithub.com/nix-community/home-manager/issues/6792))
* [`8638a0b2`](https://github.com/nix-community/home-manager/commit/8638a0b28727a8cdbe851fefded3b8e96f4cf763) sesh: add icons option ([nix-community/home-manager⁠#6794](https://togithub.com/nix-community/home-manager/issues/6794))
* [`543caa31`](https://github.com/nix-community/home-manager/commit/543caa313abe45b56520efdaa35d379703f79e3a) xmonad: fix binary name lookup on armv7l when cross-compiled ([nix-community/home-manager⁠#6795](https://togithub.com/nix-community/home-manager/issues/6795))
* [`47eb2d80`](https://github.com/nix-community/home-manager/commit/47eb2d80f943521ec88fe92899925c5f444c8a5c) accounts/contact: add sensible defaults to the localModule ([nix-community/home-manager⁠#6799](https://togithub.com/nix-community/home-manager/issues/6799))
* [`cf6314f8`](https://github.com/nix-community/home-manager/commit/cf6314f8e173e208882e32ed85158f78bf74d085) hyprsunset: init
* [`f1ffd097`](https://github.com/nix-community/home-manager/commit/f1ffd097e717a8d1b441577b8d23f9d2c96e0657) hyprsunset: support multiple commands to IPC
* [`da624eaa`](https://github.com/nix-community/home-manager/commit/da624eaad0fefd4dac002e1f09d300d150c20483) jujutsu: evaluate the settings after merging with other options ([nix-community/home-manager⁠#6775](https://togithub.com/nix-community/home-manager/issues/6775))
* [`e15c4203`](https://github.com/nix-community/home-manager/commit/e15c4203ea04cd80edbd8005d0eadb53eded45ea) hyprland: plugins use hyprctl from path ([nix-community/home-manager⁠#6801](https://togithub.com/nix-community/home-manager/issues/6801))
* [`f0c69ede`](https://github.com/nix-community/home-manager/commit/f0c69ede700deeef5aa0d7b8604f35a4e7d292bf) way-displays: init module ([nix-community/home-manager⁠#6791](https://togithub.com/nix-community/home-manager/issues/6791))
* [`6bccb54a`](https://github.com/nix-community/home-manager/commit/6bccb54a4f98408f22d2e45921bb401f393f2174) aerospace: revert flattening on-window-detected rules ([nix-community/home-manager⁠#6803](https://togithub.com/nix-community/home-manager/issues/6803))
* [`e43c6bcb`](https://github.com/nix-community/home-manager/commit/e43c6bcb101ba3301522439c459288c4a248f624) anyrun: init module ([nix-community/home-manager⁠#6804](https://togithub.com/nix-community/home-manager/issues/6804))
* [`cfd7df8a`](https://github.com/nix-community/home-manager/commit/cfd7df8a2151682ea8efadf4618e98a08c6a8907) waybar: systemd cleanup
* [`d8e2fdc0`](https://github.com/nix-community/home-manager/commit/d8e2fdc09c9ee737ec66e64578413690833be3d9) .git-blame-ignore-revs: fix fmt hash
* [`b74b22bb`](https://github.com/nix-community/home-manager/commit/b74b22bb6167e8dff083ec6988c98798bf8954d3) waybar: add debug option
* [`db56335c`](https://github.com/nix-community/home-manager/commit/db56335ca8942d86f2200664acdbd5b9212b26ad) way-displays: fix failing use of `lib.mkDefault` ([nix-community/home-manager⁠#6809](https://togithub.com/nix-community/home-manager/issues/6809))
* [`4f898f37`](https://github.com/nix-community/home-manager/commit/4f898f373d8b0bfdac635b036396c90b0ad17be8) helix: add support for path and string themes ([nix-community/home-manager⁠#6814](https://togithub.com/nix-community/home-manager/issues/6814))
* [`cfa196c7`](https://github.com/nix-community/home-manager/commit/cfa196c705a896372319249d757085876ab62448) flake.lock: Update ([nix-community/home-manager⁠#6812](https://togithub.com/nix-community/home-manager/issues/6812))
* [`14229249`](https://github.com/nix-community/home-manager/commit/1422924908881faf59722810884addf109ebea07) Translate using Weblate (Czech) ([nix-community/home-manager⁠#6813](https://togithub.com/nix-community/home-manager/issues/6813))
* [`ac3c1f4f`](https://github.com/nix-community/home-manager/commit/ac3c1f4fa40497b07f1f3ea3c4f644ce5dbcd2a4) foot: enable duplicate key-bindings ([nix-community/home-manager⁠#6815](https://togithub.com/nix-community/home-manager/issues/6815))
* [`e980d0e0`](https://github.com/nix-community/home-manager/commit/e980d0e0e216f527ea73cfd12c7b019eceffa7f1) nh: support 4.0 for flake option ([nix-community/home-manager⁠#6818](https://togithub.com/nix-community/home-manager/issues/6818))
* [`85dd758c`](https://github.com/nix-community/home-manager/commit/85dd758c703ffbf9d97f34adcef3a898b54b4014) yazi: remove assertions ([nix-community/home-manager⁠#6817](https://togithub.com/nix-community/home-manager/issues/6817))
* [`33754144`](https://github.com/nix-community/home-manager/commit/337541447773985f825512afd0f9821a975186be) helix: fix str + path theme ([nix-community/home-manager⁠#6816](https://togithub.com/nix-community/home-manager/issues/6816))
* [`273ad32f`](https://github.com/nix-community/home-manager/commit/273ad32fbb4769ac56e15caccdbdaad2c2e6b88a) tests/nh: init tests ([nix-community/home-manager⁠#6819](https://togithub.com/nix-community/home-manager/issues/6819))
* [`5a096a88`](https://github.com/nix-community/home-manager/commit/5a096a8822cb98584c5dc4f2616dcd5ed394bfd7) superfile: initial support ([nix-community/home-manager⁠#6610](https://togithub.com/nix-community/home-manager/issues/6610))
* [`ae5fcad7`](https://github.com/nix-community/home-manager/commit/ae5fcad746ac79ea2f791c6369089e4db7ad6bc1) direnv: fix silent option after update to direnv v2.36.0
* [`d5cdf55b`](https://github.com/nix-community/home-manager/commit/d5cdf55bd9f19a3debd55b6cb5d38f7831426265) direnv: add tests for silent option
