### PR TITLE
niv nixpkgs: update 7208a835 -> 374b5fab

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "7208a8355b30f50ab926a91d127d5f59d556406e",
-        "sha256": "11askjhd0cmipikfrji9fb7hlzv7q2m3h8143j53fqpn2qaaizzg",
+        "rev": "374b5fab08713e4d0221a0e082f5c12e47bc9080",
+        "sha256": "1ddrfzv9w6vgvcsnay93vzay48sdqcgx40pbwq4j9xnj00ygklck",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/7208a8355b30f50ab926a91d127d5f59d556406e.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/374b5fab08713e4d0221a0e082f5c12e47bc9080.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@7208a835...374b5fab](https://github.com/nixos/nixpkgs/compare/7208a8355b30f50ab926a91d127d5f59d556406e...374b5fab08713e4d0221a0e082f5c12e47bc9080)

* [`98495214`](https://github.com/NixOS/nixpkgs/commit/98495214f9763296c0be73b21d8341db8b2cf52d) positron-bin: 2025.02.0-171 -> 2025.04.0-64
* [`d7e5704d`](https://github.com/NixOS/nixpkgs/commit/d7e5704dee184b3bda2fa86b9b4e745584fa225a) positron-bin: disable automatic updates
* [`b521f9ca`](https://github.com/NixOS/nixpkgs/commit/b521f9ca67552ad189792f3ff86155a89ad5d0bc) iniparser: 4.2.5 -> 4.2.6
* [`770aeb38`](https://github.com/NixOS/nixpkgs/commit/770aeb38c873bee43070ca2805abd735570212fe) ecspresso: init at 2.4.6
* [`3d0f1e73`](https://github.com/NixOS/nixpkgs/commit/3d0f1e736ac2c3a6c6bac0825c2c39b53d2ac0b2) nwg-icon-picker: init at 0.1.1
* [`99384545`](https://github.com/NixOS/nixpkgs/commit/99384545e65429c44ba91b47b9186f4efa3b2a13) hbase: 2.5.10 -> 2.5.11, 2.6.1 -> 2.6.2
* [`6709f7ce`](https://github.com/NixOS/nixpkgs/commit/6709f7cea35d58593694676e92c77e92de0387be) nixosTests.hadoop.hbase: fix race condition
* [`28b46461`](https://github.com/NixOS/nixpkgs/commit/28b46461ca80955c2b77f6dc67d77707cd917144) jbigkit: disable parallel tests
* [`50fc446b`](https://github.com/NixOS/nixpkgs/commit/50fc446be16901047ac0efd55fdc77a287845ed5) nixos/gitlab: convert gitlab-registry-cert.service to oneshot
* [`cd7583a7`](https://github.com/NixOS/nixpkgs/commit/cd7583a7d91ffedf4a69a97e9cf9286b3fc2ef34) nixosTests.gitlab: add minimal test for gitlab-container-registry
* [`25dd456c`](https://github.com/NixOS/nixpkgs/commit/25dd456cf9c7d3b8675780ea049163142f5adbea) megasync: change license from `unfree` to `unfreeRedistributable`
* [`090ab43c`](https://github.com/NixOS/nixpkgs/commit/090ab43ceb978ec9c06d16f4b7444d9cc7c785c9) python312Packages.hikari-crescent: 1.1.0 -> 1.2.0
* [`8c3af1b6`](https://github.com/NixOS/nixpkgs/commit/8c3af1b67166056d33dece63f595fc947b7c82a4) etcd: 3.5.16 -> 3.5.19
* [`057a4bb6`](https://github.com/NixOS/nixpkgs/commit/057a4bb60e19c7d3bb4317351be93b76c1b5fc31) ham: 2023-10-06 -> 2025-02-25
* [`980d614f`](https://github.com/NixOS/nixpkgs/commit/980d614f51eb56b10e5fb4dc49b40b85a8357fbc) sourcegit: 2025.08 -> 2025.09
* [`b9f1de8b`](https://github.com/NixOS/nixpkgs/commit/b9f1de8b69c3cc3cd638c5373f0613dfc0944b09) davmail: 6.2.2 -> 6.3.0
* [`a1dfaf51`](https://github.com/NixOS/nixpkgs/commit/a1dfaf51e2400f4698bbd076c56473b0ba6303bf) nixos/test-driver: integrate Python `unittest` assertions
* [`11ff96a6`](https://github.com/NixOS/nixpkgs/commit/11ff96a6795889a3d59b2ec0e9d587b9cf15ed5c) nixos/test-driver: use RequestedAssertionFailed/TestScriptError in Machine class
* [`cc3d409a`](https://github.com/NixOS/nixpkgs/commit/cc3d409adca4d8479faf64b2d9cfd67d523a56ec) nixos/test-driver: log associated machine for `self.nested`
* [`ad312d30`](https://github.com/NixOS/nixpkgs/commit/ad312d303cbb318730cbf5bc1339285d059bc253) graylog-6_1: init at 6.1.8
* [`d587d569`](https://github.com/NixOS/nixpkgs/commit/d587d569e0d6bb4c8dbdb6ddbd6e8e0d8c97bbd7) nixos/test-driver: restructure error classes
* [`e2b3517f`](https://github.com/NixOS/nixpkgs/commit/e2b3517f598471dde1efad1b97ab1a418c6678c9) nixos/test-driver: use ipython via ptpython
* [`e51ab12e`](https://github.com/NixOS/nixpkgs/commit/e51ab12e173e3699bb5c0fbe9985e5231d6729a4) nixos/geoclue2: set default location service to beaconDB
* [`9cc792c8`](https://github.com/NixOS/nixpkgs/commit/9cc792c881a8ba3bc0f1b3f900082885b6da69fe) hevi: init at 1.1.0
* [`586a0dbd`](https://github.com/NixOS/nixpkgs/commit/586a0dbd76daf77646d4638ae04fc25c437c7f99) keepassxc: symlink CLI programs to bin output on Darwin
* [`2a10d4d6`](https://github.com/NixOS/nixpkgs/commit/2a10d4d6729b1a3a52f1457f6b0a0157f648f169) jqfmt: init at 0-unstable-2024-08-15
* [`8715fb4f`](https://github.com/NixOS/nixpkgs/commit/8715fb4f5818869624cb7dac9980a937891a5a74) elvis: unbreak
* [`4510e2aa`](https://github.com/NixOS/nixpkgs/commit/4510e2aacd5e040ca6268e0332af2da620c8cb8b) mmh: unstable-2020-08-21 -> unstable-2023-09-24, unbreak on GCC 14
* [`deff22bc`](https://github.com/NixOS/nixpkgs/commit/deff22bcc8ba821efda81d567301a34a3d51b999) nixos/test-driver: improve wording on comments about new error handling
* [`cfc8fc76`](https://github.com/NixOS/nixpkgs/commit/cfc8fc76c768f379af8f783b87e2ca54342f53fc) modsecurity_standalone: 2.9.7 -> 2.9.8
* [`c372f065`](https://github.com/NixOS/nixpkgs/commit/c372f06594b2289aae0f98bf207df27ec560319f) modsecurity_standalone: unbreak on GCC 14, modernize
* [`3455493a`](https://github.com/NixOS/nixpkgs/commit/3455493ad6df2f2bb14477753eef505e8d8b159a) python3Packages.breezy: 3.3.7 -> 3.3.10
* [`deebf9d0`](https://github.com/NixOS/nixpkgs/commit/deebf9d077c4dc50ddb9564dfccd4f31a7afdf80) asdbctl: init at 1.0.0
* [`a4b2908b`](https://github.com/NixOS/nixpkgs/commit/a4b2908bc6740fe978a4c6c1a09da215e6c4d4f1) python313Packages.pytest-docker-tools: 3.1.3 -> 3.1.9
* [`b349e800`](https://github.com/NixOS/nixpkgs/commit/b349e80087ce8a2f9e85a5d5cad532a647c976a4) treewide: drop copumpkin from maintainers
* [`9cc8fa0c`](https://github.com/NixOS/nixpkgs/commit/9cc8fa0ca7a957a16ea84080e7e94db040cc3b0a) stdenv: add darwin team to darwin bootstrap-tools maintainers
* [`c60ace30`](https://github.com/NixOS/nixpkgs/commit/c60ace300bac9bf155851adefa83e139abfc0693) make-disk-image: Add note about re-factoring plans in [nixos/nixpkgs⁠#324817](https://togithub.com/nixos/nixpkgs/issues/324817)
* [`0989f7d2`](https://github.com/NixOS/nixpkgs/commit/0989f7d25102ec057bd989af408e3bd19f6f564d) tshock: init at 5.2.3
* [`ff97d95f`](https://github.com/NixOS/nixpkgs/commit/ff97d95feecc0b8b70865b940a93b71810836f39) xyce, xyce-parallel: 7.8 -> 7.9
* [`bf46b8ec`](https://github.com/NixOS/nixpkgs/commit/bf46b8ec27c0df8cd650acf376561009a955c96c) matomo: 5.2.2 -> 5.3.1
* [`c1f06a61`](https://github.com/NixOS/nixpkgs/commit/c1f06a61fd349f392ff6f80092f6c9713467b413) easycrypt: 2025.02 -> 2025.03
* [`fd811eb3`](https://github.com/NixOS/nixpkgs/commit/fd811eb3fe3db841e4fb7e9f3bb17ad35f0b2304) rustls-ffi: 0.14.1 -> 0.15.0
* [`f0b96e89`](https://github.com/NixOS/nixpkgs/commit/f0b96e89b10691d38a9e98dcce9ba31bc09c68f9) maintainers: add mymindstorm
* [`3c534256`](https://github.com/NixOS/nixpkgs/commit/3c5342565b36cd6f1ba5815645eb3e58cab20cca) vulkan-cts: Update vk-cts-sources.py for nixfmt
* [`e84cc9e8`](https://github.com/NixOS/nixpkgs/commit/e84cc9e86c0dd6f9fba9337887854611e44db38e) vulkan-cts: Drop deqp-vksc from vulkan-cts package
* [`0b9ab0f7`](https://github.com/NixOS/nixpkgs/commit/0b9ab0f71024c4168e2c128d92dac167f119b93a) vulkan-cts: 1.3.10.0 -> 1.4.1.3
* [`0b4d1d8d`](https://github.com/NixOS/nixpkgs/commit/0b4d1d8d4ae7de68877b24e0fe544e5208008d3b) minecraft-server: 1.21.4 -> 1.21.5
* [`b474165b`](https://github.com/NixOS/nixpkgs/commit/b474165b61a8597b20b94138d1c565658e42df8e) flatpak-xdg-utils: init at 1.0.6
* [`1d2cd5bf`](https://github.com/NixOS/nixpkgs/commit/1d2cd5bfbbbfeed118a8a4909c5436bf3de10bea) warehouse: init at 2.0.2
* [`bc0d96b6`](https://github.com/NixOS/nixpkgs/commit/bc0d96b69fb719b8c3aaf21f6f058762a34598c3) netsurf.libsvgtiny: fix build on GCC 14
* [`fe9da650`](https://github.com/NixOS/nixpkgs/commit/fe9da650ef54668bb0b575a4f2709268b9749a60) overturemaps: 0.12.0 -> 0.14.0
* [`db4da036`](https://github.com/NixOS/nixpkgs/commit/db4da0362f2f8983e9380e7fbf5eb1b90fafee44) fheroes2: 1.1.6 -> 1.1.7
* [`d63e0091`](https://github.com/NixOS/nixpkgs/commit/d63e00912bad061fdb93af67cc2d80a928d39a18) chez: pin to clang-17 on aarch64 darwin
* [`0a0da6de`](https://github.com/NixOS/nixpkgs/commit/0a0da6ded53a8ee683c6344247a3f32b8ec65aca) yle-dl: 20240706 -> 20250316
* [`2776687f`](https://github.com/NixOS/nixpkgs/commit/2776687f80fcfa8ab3e121ee1899aab477e0087b) maintainers: add bohreromir
* [`3018beaa`](https://github.com/NixOS/nixpkgs/commit/3018beaac615590c2bdf077749413af2f8f38e31) tt-rss: Update license
* [`2cc6ef5b`](https://github.com/NixOS/nixpkgs/commit/2cc6ef5b2f4b9c28abf8335a86517146ccbb17d6) tt-rss: fix passthru.tests syntax
* [`e09c54ce`](https://github.com/NixOS/nixpkgs/commit/e09c54ce6b30f851c66890bcb3d29aa7014af82e) tt-rss: More comprehensive test
* [`28e64a09`](https://github.com/NixOS/nixpkgs/commit/28e64a092be2e4e97951f8ecbf8953f0acc04538) tt-rss-plugin-ff-instagram: Mark as broken
* [`57fb1764`](https://github.com/NixOS/nixpkgs/commit/57fb17649b22bf6e39d15dcc9d8a8e809fe1f3cc) tt-rss: Add feediron to tests
* [`d3ac26dc`](https://github.com/NixOS/nixpkgs/commit/d3ac26dcd183fe42cc3e8b2baa935dc52f0923ec) tt-rss: Disable auto-update on each upstream commit
* [`19fee786`](https://github.com/NixOS/nixpkgs/commit/19fee786992fd77cdce19424fafde312e1e9af53) opkssh: add sarcasticadmin as maintainer
* [`4a26827d`](https://github.com/NixOS/nixpkgs/commit/4a26827d408578017c77cf24aba736449e7b6a5e) opkssh: update description
* [`35def808`](https://github.com/NixOS/nixpkgs/commit/35def808e7460da4d685a31b2172473aeb77ac3c) artisan: init at 3.1.0
* [`5b68455c`](https://github.com/NixOS/nixpkgs/commit/5b68455c0bb4555663585f4ace616c735f45117e) python312Packages.flask-security: 5.5.2 -> 5.6.1
* [`6900384c`](https://github.com/NixOS/nixpkgs/commit/6900384c1bd2d2ce42c31ae72bc0f37e44faa10c) doc/importNpmLock.buildNodeModules: Add note regarding package-lock-only
* [`7b7f0508`](https://github.com/NixOS/nixpkgs/commit/7b7f0508e83f07fd48d07796585cc7d16489f961) pangolin: Use libtiff.out as buildInput, finalAttrs and cmakeBool
* [`86f4249a`](https://github.com/NixOS/nixpkgs/commit/86f4249a7af4b62c2c9334a678888513aef160aa) gotestsum: 1.12.0-unstable-2024-09-17 -> 1.12.1
* [`969398b2`](https://github.com/NixOS/nixpkgs/commit/969398b28c6aec50d335c13389772f60871548cb) pico-sdk: 2.1.0 -> 2.1.1
* [`ac93e7a0`](https://github.com/NixOS/nixpkgs/commit/ac93e7a034306179c1af767a050f89786a5a2672) lmstudio: 0.3.14-3 -> 0.3.14-5
* [`1437bdb4`](https://github.com/NixOS/nixpkgs/commit/1437bdb47f6db9736ad19423ec212bfad0b6c4cf) python313Packages.azure-mgmt-compute: 34.0.0 -> 34.1.0
* [`73532fab`](https://github.com/NixOS/nixpkgs/commit/73532fab81ba0f1e2dd12b94cd45fbf6a88b573e) python313Packages.azure-mgmt-containerservice: 34.1.0 -> 34.2.0
* [`76318c59`](https://github.com/NixOS/nixpkgs/commit/76318c59413efd2243f31f1e34a3ccbb061f668c) lla: add shell completions
* [`8f03cb84`](https://github.com/NixOS/nixpkgs/commit/8f03cb84ef057d9e570dd092d54fc1663ab71ed7) jhentai: add update script
* [`4025cc8f`](https://github.com/NixOS/nixpkgs/commit/4025cc8f01aa070dc4150c6b168cbfac53e28837) jhentai: refactor
* [`28a300dd`](https://github.com/NixOS/nixpkgs/commit/28a300dd72fb9a2880a013bae5ab22debcd796bd) jhentai: 8.0.5 -> 8.0.6+277
* [`60c9120e`](https://github.com/NixOS/nixpkgs/commit/60c9120ec0fa7aada33f31ab4284db7e624c91a8) cloudflare-dyndns: 5.0 -> 5.3
* [`72155225`](https://github.com/NixOS/nixpkgs/commit/72155225aa62c6ac9bc67a1253079f140045511f) nixos/lib/testing: avoid generating darwin VM tests
* [`39314dd6`](https://github.com/NixOS/nixpkgs/commit/39314dd6cf8f558aab32a94291412589034458d8) hardinfo2: 2.2.7 -> 2.2.10
* [`5e43ed54`](https://github.com/NixOS/nixpkgs/commit/5e43ed5495ea942dce221ad160b4cb50d8e03f78) typst: add customized builder for typst packages
* [`8149e604`](https://github.com/NixOS/nixpkgs/commit/8149e604ef4df7db42f46d54c94213a4e4ca7b57) maintainers: add cherrypiejam
* [`06f6e784`](https://github.com/NixOS/nixpkgs/commit/06f6e784b06f2bbf77f214b466d8972cf55a7da7) fim: fix cross / strictDeps build
* [`d917696e`](https://github.com/NixOS/nixpkgs/commit/d917696ea5fb86639ce8e8ec706f2ccd3278362e) libndctl: fix musl build
* [`3b4d4050`](https://github.com/NixOS/nixpkgs/commit/3b4d405061e9e1eec53b27944cc6ce9bafe80bc0) mariadb: fix musl build
* [`c0d7db48`](https://github.com/NixOS/nixpkgs/commit/c0d7db4865c4629b0f35eef3845350b82ca34267) littlenavmap: init 3.0.16
* [`203fdbd9`](https://github.com/NixOS/nixpkgs/commit/203fdbd94a7c06ffaea10ed387d5e036b0c6ac95) blender: move openUsdSupport from let-in to attrs
* [`20396156`](https://github.com/NixOS/nixpkgs/commit/20396156cb81c5aa4b409286b3da1055a2b1c6ea) e-imzo: initialize module
* [`c363abc7`](https://github.com/NixOS/nixpkgs/commit/c363abc79f08fbd1c8b6b9c64dfc01eb2ccbd03c) jamin: unbreak on GCC 14, modernize
* [`c8396690`](https://github.com/NixOS/nixpkgs/commit/c8396690422cfdda8df6aca227a5a69e1e6a86ef) imapdedup: 1.1 -> 1.2
* [`5be11945`](https://github.com/NixOS/nixpkgs/commit/5be1194501c6520b1de9804b9a3292a6e5d1ecc3) matrix-sdk-crypto-nodejs: mark broken for cross/static
* [`b1149c65`](https://github.com/NixOS/nixpkgs/commit/b1149c650294bb6bc7511c4b567db67544d84874) drawio: 26.0.16 -> 26.1.1
* [`aadad36a`](https://github.com/NixOS/nixpkgs/commit/aadad36aa2ec547026f06f2cb06228a29b2ededd) python313Packages.trino-python-client: 0.322.0 -> 0.323.0
* [`526183ee`](https://github.com/NixOS/nixpkgs/commit/526183ee02c31529eb2de55384502795966de59c) python313Packages.trino-python-client: add myself as maintainer
* [`ada75629`](https://github.com/NixOS/nixpkgs/commit/ada756299d10c13ef5025d34dac3eda1c0e665ca) omniorb: 4.3.2 -> 4.3.3
* [`b165bf1f`](https://github.com/NixOS/nixpkgs/commit/b165bf1f555bd843ca97de5080647a7165e00ce2) python312Packages.azure-mgmt-postgresqlflexibleservers: 1.1.0b1 -> 1.1.0
* [`80c81eab`](https://github.com/NixOS/nixpkgs/commit/80c81eaba50ad8575d943dc806b0f2c4575122e5) gammastep: 2.0.9 -> 2.0.11
* [`ec004ef5`](https://github.com/NixOS/nixpkgs/commit/ec004ef5f30f4ea66ce0b77bab5ce778883aff5d) rpcs3: 0.0.34-17323-92d070729 -> 0.0.36-17736-c86a25079
* [`74c5c806`](https://github.com/NixOS/nixpkgs/commit/74c5c8069d5d6503af52cc58d09d07b7cf5d2303) jbofihe: fix build with gcc14
* [`04584e18`](https://github.com/NixOS/nixpkgs/commit/04584e18359563fc9a3fbcda66caf318834011e6) jbofihe: modernize
* [`0ae5ebd4`](https://github.com/NixOS/nixpkgs/commit/0ae5ebd4682f0c57f231e0a0675c1f27568f13aa) loco: 0.14.0 -> 0.15.0
* [`4d21ce10`](https://github.com/NixOS/nixpkgs/commit/4d21ce1058d5fa2193e526fe26261e51c311aecf) excalidraw_export: bump nan version to fix build
* [`51ace5ab`](https://github.com/NixOS/nixpkgs/commit/51ace5ab1ae7ff4f4944a50c59715b2f8dc10b04) excalidraw_export: reenable darwin builds
* [`732b3d18`](https://github.com/NixOS/nixpkgs/commit/732b3d1801bf4d4852c857455526967d63886936) wasmtime: include `conf.h` in `include/wasmtime`
* [`b463aa51`](https://github.com/NixOS/nixpkgs/commit/b463aa518a62a1a19bff5916ce12e8b1990568aa) mongoc: 1.30.2 -> 2.0.0
* [`003e0927`](https://github.com/NixOS/nixpkgs/commit/003e0927f456345e0142b955e54ce1397b37b7a6) libstatgrab: enable building saidar by default
* [`282814f2`](https://github.com/NixOS/nixpkgs/commit/282814f232a66aa08f3147ea5b59a6455f915389) metadata-cleaner: modernize
* [`c68fe328`](https://github.com/NixOS/nixpkgs/commit/c68fe32804fcc4f0f5ed5b2d43c19a5dcdf02289) metadata-cleaner: remove gnome circle team from maintainers
* [`57f72d3f`](https://github.com/NixOS/nixpkgs/commit/57f72d3f7898810445fb5d94daca4a62b2b0627c) keypunch: add gnome circle team to maintainers
* [`cc940c97`](https://github.com/NixOS/nixpkgs/commit/cc940c97ea4d8997fac29affadeb12e223616fc4) exercise-timer: init at 1.8.1
* [`bf790d1a`](https://github.com/NixOS/nixpkgs/commit/bf790d1a7fffcfd5c6a92711179d644119128a61) lib/path: properly handle /. in hasStorePathPrefix
* [`931f4645`](https://github.com/NixOS/nixpkgs/commit/931f464581651b32b02eac6b28847b8d1b93ffcd) lib/types: check paths in pathWith with hasStorePathPrefix
* [`805d682f`](https://github.com/NixOS/nixpkgs/commit/805d682ff865dc1b8eea6b2bfbc14ddc3d04c97c) slade: 3.2.6 -> 3.2.7
* [`31af3fb7`](https://github.com/NixOS/nixpkgs/commit/31af3fb73b9570b46a3973012e0f9a3ae8caa283) scite: 5.5.5 -> 5.5.6
* [`f4f89032`](https://github.com/NixOS/nixpkgs/commit/f4f89032a17fdf3d327f9362fcbb4c7cdfe8d1ba) nixos/tests/cups-pdf: migration to `runTest`
* [`055631d8`](https://github.com/NixOS/nixpkgs/commit/055631d81e9475b65ff2ae9503249901dba4bc27) ut: 2.3.0 -> 2.3.1
* [`ba39714e`](https://github.com/NixOS/nixpkgs/commit/ba39714e5de6b4d21edebb635527f446514bfbe9) sauerbraten: fix installPhase symlink source
* [`0e636411`](https://github.com/NixOS/nixpkgs/commit/0e636411317eeb31627ee3e6e7d7813f47522098) kuzu: init at 0.9.0
* [`8f1cad43`](https://github.com/NixOS/nixpkgs/commit/8f1cad433a1fdaa3b928806fed41c1251412ba29) node-gyp: 11.1.0 -> 11.2.0
* [`c7c19aff`](https://github.com/NixOS/nixpkgs/commit/c7c19affe4118ba7243418f2ae6ee303e4432f45) libpg_query: 17-6.0.0 -> 17-6.1.0
* [`cd6cec43`](https://github.com/NixOS/nixpkgs/commit/cd6cec430f4dd2799283dbd7091f0595ddfeea43) spiped: 1.6.3 -> 1.6.4
* [`3b5dced8`](https://github.com/NixOS/nixpkgs/commit/3b5dced853ff8780c235928abe1987af65c791e6) python312Packages.karton-core: 5.6.0 -> 5.6.1
* [`dea1a898`](https://github.com/NixOS/nixpkgs/commit/dea1a898a3dfe48c13675dd48b37eb39eb95e7c2) python312Packages.pytest-ansible: 25.1.0 -> 25.4.0
* [`bef6e422`](https://github.com/NixOS/nixpkgs/commit/bef6e42242573cedefdfa1f55006f93aa808c1bc) nixos/evcc: allow avahi discovery of eebus devices
* [`afef84f5`](https://github.com/NixOS/nixpkgs/commit/afef84f5a16ce916c091c443bad05ad004cdbf35) python312Packages.pysdl2: 0.9.17 -> 0.9.17-unstable-2025-04-03, fix for sdl2-compat
* [`434807a6`](https://github.com/NixOS/nixpkgs/commit/434807a619786f90eebbdb6de9c891f96f4ce8d5) python312Packages.pivy: 0.6.9 -> 0.6.10
* [`98134770`](https://github.com/NixOS/nixpkgs/commit/981347707cbaedaa0e31a3a87927cb728cf3e6a4) wt: 4.11.3 -> 4.11.4
* [`559dfd10`](https://github.com/NixOS/nixpkgs/commit/559dfd1013f067cb1d829c7eaa0298cbb75c8e28) python312modules.humanize: v4.12.1 -> v4.12.2
* [`7d920db4`](https://github.com/NixOS/nixpkgs/commit/7d920db414c19800a9d219e4895b0214b8cb2de5) fittrackee: v0.9.3 -> v0.9.4
* [`87620ad5`](https://github.com/NixOS/nixpkgs/commit/87620ad58a642ddbf6abb406af5752c1b585acaa) python3Packages.kuzu: init at 0.9.0
* [`b466d7a5`](https://github.com/NixOS/nixpkgs/commit/b466d7a57fd9bb33fd0786a7cc0d3495db068a5f) python312Packages.localstack-client: 2.7 -> 2.10
* [`f4066cd9`](https://github.com/NixOS/nixpkgs/commit/f4066cd966b57780c8c964158e1fbeb386a63ea6) as31: fix build with gcc14
* [`e023c0d0`](https://github.com/NixOS/nixpkgs/commit/e023c0d0b8027cdd7857446f2a8ba8086af20d80) as31: fix src and meta.homepage
* [`19916d30`](https://github.com/NixOS/nixpkgs/commit/19916d3068b24f64563ab846cebca4e375a6321a) as31: modernize
* [`1c05d6e9`](https://github.com/NixOS/nixpkgs/commit/1c05d6e99aea9a050ded80d1e58fd62e5ec8d1fc) zabbix: add Zabbix 7.2 version
* [`79cd7af5`](https://github.com/NixOS/nixpkgs/commit/79cd7af5b6bd5db520ba1608b6424b220f6cc69f) maintainers: add joshheinrichs-shopify
* [`73f05ba5`](https://github.com/NixOS/nixpkgs/commit/73f05ba59cb99d65b28e0c0324c6e8d1213c41aa) graphite-cli: add joshheinrichs-shopify to maintainers
* [`c5bcdbe7`](https://github.com/NixOS/nixpkgs/commit/c5bcdbe7a8510a71b67d07ce4a4d616c6e5491f9) aws-signing-helper: 1.4.0 -> 1.5.0
* [`4d08719e`](https://github.com/NixOS/nixpkgs/commit/4d08719e992fe16c698286a38b2300aa31f7ab09) libsolv: 0.7.31 -> 0.7.32
* [`2680c1ea`](https://github.com/NixOS/nixpkgs/commit/2680c1eaffbbaad244e694b1846811a55634b3ba) maintainers: add samfundev
* [`62f3255c`](https://github.com/NixOS/nixpkgs/commit/62f3255cd8da5226bbb559252828fae6e26870e4) lib/licenses: add sfl
* [`ead67ac2`](https://github.com/NixOS/nixpkgs/commit/ead67ac21057907eb0d62733efa051f327e4716d) grayjay: init at version 5
* [`6afd8cd8`](https://github.com/NixOS/nixpkgs/commit/6afd8cd8f19c307bf133bfdafbbd68dc8fc7a5a4) ocserv: add otp support
* [`fc85ed9d`](https://github.com/NixOS/nixpkgs/commit/fc85ed9d2516cd3013f19b8f23053d896354a9f5) cilium-cli: 0.18.2 -> 0.18.3
* [`5c127aa8`](https://github.com/NixOS/nixpkgs/commit/5c127aa8269c8a7623adcec445728624852a72b1) libsForQt5.qcoro: 0.11.0 -> 0.12.0
* [`e4052af2`](https://github.com/NixOS/nixpkgs/commit/e4052af2f035b6856a5b545901788b9d576076fb) maintainers: add Tygo-van-den-Hurk
* [`d000a1a5`](https://github.com/NixOS/nixpkgs/commit/d000a1a5101cb40c8e1fb349fe9a6ca933025fcb) sd-local: 1.0.57 -> 1.0.58
* [`6e85f4bd`](https://github.com/NixOS/nixpkgs/commit/6e85f4bd0b6527708aa50c3a84a7fe7e12aef0a4) libpqxx: 7.10.0 -> 7.10.1
* [`74838606`](https://github.com/NixOS/nixpkgs/commit/74838606a066f302a84beca90b275de8ed23fbf4) {nixos/tests/}/cups-pdf: use `getExe` and `substituteInPlace`
* [`ce5e4279`](https://github.com/NixOS/nixpkgs/commit/ce5e427987ebc851f31c149d5a293064f7273c9b) cups-pdf-to-pdf: resolve `with lib;` in `meta`
* [`63e09c38`](https://github.com/NixOS/nixpkgs/commit/63e09c383c8aa6aa7b220dbd90e2304a070a60fa) decasify: 0.8.0 → 0.10.1
* [`6ce0214b`](https://github.com/NixOS/nixpkgs/commit/6ce0214b71e3ee33a095da15492d058412eb4b76) libsfdo: 0.1.3 -> 0.1.4
* [`d371cf4e`](https://github.com/NixOS/nixpkgs/commit/d371cf4e683308d7f99b58b22cda2a3ad8407c03) okteta: 0.26.20 -> 0.26.21
* [`4e80d330`](https://github.com/NixOS/nixpkgs/commit/4e80d330dbd9f787f5315f8f5f8b61365f7958d1) camunda-modeler: 5.33.1 -> 5.34.0
* [`47224a34`](https://github.com/NixOS/nixpkgs/commit/47224a34dec8540e1f389e8bb9e7b1aed58a5e54) zile: 2.6.3 -> 2.6.4
* [`5d0f8e24`](https://github.com/NixOS/nixpkgs/commit/5d0f8e24c845e14f487b98c866c131a5083f1c17) clementine: 1.4.1-37-g3369f3085 -> 1.4.1-38-g1fc7fe0e1
* [`43284f75`](https://github.com/NixOS/nixpkgs/commit/43284f75496b6a2a2103efc3ebc91b594f530ae4) mangayomi: 0.5.2 -> 0.6.0
* [`3c270cf7`](https://github.com/NixOS/nixpkgs/commit/3c270cf7d0977dacaacdd956f209cade5868dd27) dart.media_kit_libs_linux: adapt to version 1.2.1
* [`11ebec92`](https://github.com/NixOS/nixpkgs/commit/11ebec927ba52ee933e1766f0aa7a6fcdc2bf688) octodns-ddns: init at 0.2.1
* [`5bf1a065`](https://github.com/NixOS/nixpkgs/commit/5bf1a06583f272a1924b0c92724f32f43de96758) mongodb-compass: 1.45.4 -> 1.46.0
* [`fcff4225`](https://github.com/NixOS/nixpkgs/commit/fcff42251885bf641ae758a54c9ff485359f55c5) xmlbeans: 5.1.1-20220819 -> 5.3.0-20241203
* [`0b767610`](https://github.com/NixOS/nixpkgs/commit/0b76761085d346c0451992ad89debd58ff834229) xpad: 5.4.0 -> 5.8.0
* [`1599c37a`](https://github.com/NixOS/nixpkgs/commit/1599c37a6b717e9dc2cd421a31e4968aa7b3744f) nixos/luksroot: remove useless $new_k_luks
* [`96d47166`](https://github.com/NixOS/nixpkgs/commit/96d47166a67fcbbee406775098e6e76fc911b966) fvm: init at 3.2.1
* [`4c26bb58`](https://github.com/NixOS/nixpkgs/commit/4c26bb58b6be82c0b9359ecafe25ee9f7e315fce) plexamp: 4.11.5 -> 4.12.0
* [`9d3a171d`](https://github.com/NixOS/nixpkgs/commit/9d3a171dbf3517201a1e6d60ebc31b26d4758eb1) nixos/containers: fix shell error when privateUsers=no
* [`d368b82a`](https://github.com/NixOS/nixpkgs/commit/d368b82aa70b2ea28991f695b3a08a0d3747f6ec) waveterm: 0.11.1 -> 0.11.2
* [`da701568`](https://github.com/NixOS/nixpkgs/commit/da701568d287ecf5723f3eb4d109a803de4fbe3b) waveterm: refactor
* [`2ef5f112`](https://github.com/NixOS/nixpkgs/commit/2ef5f112f98d4c93b80c36019fb88cc1cc91c8e5) skaffold: 2.14.2 -> 2.15.0
* [`247d892a`](https://github.com/NixOS/nixpkgs/commit/247d892ace76ddb8eae3d6c440ab2677ccfbeb5f) plasticity: 24.2.6 -> 25.1.8
* [`2b918a01`](https://github.com/NixOS/nixpkgs/commit/2b918a018f84bc9672f87f7d5712f4449d4ad3f5) auth0-cli: install shell completion
* [`da26390c`](https://github.com/NixOS/nixpkgs/commit/da26390c4013d6ac18ee4f4294fac4e36004f433) maintainers: add dtomvan
* [`db7e660c`](https://github.com/NixOS/nixpkgs/commit/db7e660c40eedfcc0339c7855234f7f3787129be) python312Packages.rq: 2.2 -> 2.3.1
* [`eb325dd2`](https://github.com/NixOS/nixpkgs/commit/eb325dd24c2b90eb6507b60278f17bfc9b8d44ee) datamash: 1.8 -> 1.9
* [`4d524383`](https://github.com/NixOS/nixpkgs/commit/4d5243832db967cb6441b3bca7da5045267abe51) kernelshark: 2.3.2 -> 2.4.0
* [`43d93e41`](https://github.com/NixOS/nixpkgs/commit/43d93e411c325f0483d86f503e7dbc3b25e8d15a) miniupnpd: 2.3.7 -> 2.3.8
* [`3a01cfcb`](https://github.com/NixOS/nixpkgs/commit/3a01cfcb34f92c265a8d9b0bdc5da482a476d3a7) drumkv1: 1.3.0 -> 1.3.1
* [`10d9241c`](https://github.com/NixOS/nixpkgs/commit/10d9241cb0dd5e67f0ada6f66f6f7080424c319b) samplv1: 1.3.0 -> 1.3.1
* [`bcaa7171`](https://github.com/NixOS/nixpkgs/commit/bcaa717100b1d5db73fd7fa9e57f228b28e63787) celluloid: 0.27 -> 0.28
* [`9bb85472`](https://github.com/NixOS/nixpkgs/commit/9bb85472914f9252ac05aa2f3c0a5f7421390888) celluloid: add maintainer
* [`34a14896`](https://github.com/NixOS/nixpkgs/commit/34a148963d4c55d3f7549655218d12b860478eae) lttng-ust: Migrate to by-name
* [`a5097ecc`](https://github.com/NixOS/nixpkgs/commit/a5097eccf0a5eda6c30f0bb574f01a74d80e2674) navidrome: 0.55.1 -> 0.55.2
* [`b6872a5b`](https://github.com/NixOS/nixpkgs/commit/b6872a5bc9fce3593275977ef222b73f2a739574) navidrome: add tebriel as maintainer
* [`6182f558`](https://github.com/NixOS/nixpkgs/commit/6182f558c8a392cc8049742dbdae516aa5c44d28) itk: 5.4.2 -> 5.4.3
* [`f782e1b6`](https://github.com/NixOS/nixpkgs/commit/f782e1b6a0ebf864e35733a32eebe9aa3f3884da) ergogen: init at 4.1.0
* [`f2f4a065`](https://github.com/NixOS/nixpkgs/commit/f2f4a0658b2add384309d7fae12421e08a0e7115) localstack: 4.2.0 -> 4.3.0
* [`f0c6cb98`](https://github.com/NixOS/nixpkgs/commit/f0c6cb981c4cb1afae190838d19e3e83aa817428) anydesk: 6.4.2 -> 6.4.3
* [`7ede4e96`](https://github.com/NixOS/nixpkgs/commit/7ede4e96aa64465a87f0b349c1d739bc58a84096) ols: 0-unstable-2025-03-12 -> 0-unstable-2025-04-05
* [`725bc908`](https://github.com/NixOS/nixpkgs/commit/725bc9085e92cd7922b7f79637e5574955dda74d) minizip-ng: 4.0.8 -> 4.0.9
* [`10b458f3`](https://github.com/NixOS/nixpkgs/commit/10b458f3464d414ed311578ed7b192cff7891a51) alisthelper: init at 0.2.0-unstable-2025-01-04
* [`9e044e72`](https://github.com/NixOS/nixpkgs/commit/9e044e724d7bc7a686077124619b39ebf843b077) goarista: init at 0-unstable-2025-03-24
* [`27e17c30`](https://github.com/NixOS/nixpkgs/commit/27e17c30073fb64f72f0dab17cf13d439da82e16) lombok: 1.18.36 -> 1.18.38
* [`05dec2f8`](https://github.com/NixOS/nixpkgs/commit/05dec2f8ac7a179ed34c9252dd2c4d2d08d00c17) greenfoot: 3.8.2 -> 3.9.0
* [`a7bbd533`](https://github.com/NixOS/nixpkgs/commit/a7bbd53332c556fd47a7a9f9f78264c2e4d2ad2d) pwsafe: 1.20.0 -> 1.21.0fp
* [`00c8cbbc`](https://github.com/NixOS/nixpkgs/commit/00c8cbbc0452ddc7ff1c889d4c8f92e58bff5551) live555: build dynamic, add check
* [`5b77ad31`](https://github.com/NixOS/nixpkgs/commit/5b77ad31e54402746d1d2899267a5e15aaed900a) openimagedenoise: 2.3.2 -> 2.3.3
* [`d976d61d`](https://github.com/NixOS/nixpkgs/commit/d976d61d9ed836ceafcb60cf2e167a13de4b23b0) typst: add typst packages from typst universe
* [`c47a2a8a`](https://github.com/NixOS/nixpkgs/commit/c47a2a8ac726f3463581dde8ac3cf5324dd050c9) typst: add support to instantiate typst with a set of typst packages
* [`6b1d9846`](https://github.com/NixOS/nixpkgs/commit/6b1d9846e9c20c0285a79d1e4d59e2d4427ca677) doc/languages-frameworks/typst: Add doc for typst env and packages
* [`a0f69133`](https://github.com/NixOS/nixpkgs/commit/a0f69133a68824dd10fc98ba47feecc7fcf74aba) tunefish: unstable-2020-08-13 -> 0-unstable-2021-12-19
* [`8ea3d596`](https://github.com/NixOS/nixpkgs/commit/8ea3d596a70f8e92352bd92bf0a24ba30addbf64) tunefish: small improvements
* [`baf2d3e2`](https://github.com/NixOS/nixpkgs/commit/baf2d3e27f4f12b997d53579f17f6d8b885dd892) nixos/maddy: add package option
* [`1d5b9ec6`](https://github.com/NixOS/nixpkgs/commit/1d5b9ec60259232cb31849df570e06d3e15a711e) cyme: 2.1.2 -> 2.1.3
* [`a665b244`](https://github.com/NixOS/nixpkgs/commit/a665b24468a061ee4807c30d5871990a9c8d134b) tenacity: 1.3.3 -> 1.3.4
* [`e2db73aa`](https://github.com/NixOS/nixpkgs/commit/e2db73aae2f9aec93b2f2798928728a9e59f2493) obs-studio-plugins.obs-livesplit-one: 0.3.4 -> 0.4.1
* [`0a0d1526`](https://github.com/NixOS/nixpkgs/commit/0a0d152666b6d30a8ab5a8d16b76910c1677cf48) python3Packages.torcheval: now supports unix platforms
* [`f832bbe4`](https://github.com/NixOS/nixpkgs/commit/f832bbe444770a9a55cb9aa64f89613f0ace9187) renode-unstable: 1.15.3+20250314git5b219d820 -> 1.15.3+20250406gitea53e3840
* [`3278353c`](https://github.com/NixOS/nixpkgs/commit/3278353c26feb05e38313767b71c6b7cc91797d3) warp-terminal: 0.2025.03.26.08.10.stable_02 -> 0.2025.04.02.08.11.stable_03
* [`4567e55d`](https://github.com/NixOS/nixpkgs/commit/4567e55d048b0afc778a4ee7757fac16106f924f) lixPackageSets.nix-eval-jobs: add `nix` passthru attribute
* [`eb07c868`](https://github.com/NixOS/nixpkgs/commit/eb07c868af6f27e43ffcef2ea883283cd19c0eba) gol: 0.2.1 -> 1.0.2
* [`9a4d51c4`](https://github.com/NixOS/nixpkgs/commit/9a4d51c47631e40dce55253c0460594005b443c0) wivrn: 0.23.2 -> 0.24
* [`071b1931`](https://github.com/NixOS/nixpkgs/commit/071b19310e8689ae0d50770fdfe3f1d81bcc23ee) textcompare: init at 0.1.2
* [`9337e7e1`](https://github.com/NixOS/nixpkgs/commit/9337e7e10a4e17dc2c8c63a430f48b3abb15520d) ploticus: fix zlib file handle type
* [`cdc7c2ba`](https://github.com/NixOS/nixpkgs/commit/cdc7c2ba68d37ada17f9c1de7ff7039208aa09d4) glaze: 5.0.1 -> 5.0.2
* [`a92d4ccd`](https://github.com/NixOS/nixpkgs/commit/a92d4ccd5bcc5202b06a0a17b062769e1fb397d9) sitespeed-io: 34.0.1 -> 37.3.2
* [`ec37d701`](https://github.com/NixOS/nixpkgs/commit/ec37d701e602c16caaaa014020448b2224f8bfb8) moonraker: 0.9.3-unstable-2025-03-26 -> 0.9.3-unstable-2025-04-03
* [`610208c5`](https://github.com/NixOS/nixpkgs/commit/610208c59ca411f6354e02411d5ad7b5155e2538) texturepacker: 7.6.1 -> 7.6.2
* [`a729a402`](https://github.com/NixOS/nixpkgs/commit/a729a402c3695a36dd70e159013d7d70412808bb) analog: use nixpkgs libraries (png, jpeg, zlib, bz2)
* [`bacbdb5a`](https://github.com/NixOS/nixpkgs/commit/bacbdb5a5dd36d129fbc6047c2d1354b78ba4167) yquake2: 8.41 -> 8.50
* [`477902ed`](https://github.com/NixOS/nixpkgs/commit/477902ed94e344446f8049e3272d5da56644e8fc) openscap: 1.4.1 -> 1.4.2
* [`badc7aa7`](https://github.com/NixOS/nixpkgs/commit/badc7aa7fa7d3b3da8da894deaa3d1ec9e1ddadc) system76-firmware: 1.0.70 -> 1.0.71
* [`3936e1e6`](https://github.com/NixOS/nixpkgs/commit/3936e1e6301f50b63a81b1e6bfccf9d99abe0287) python313Packages.rapidfuzz: 3.12.2 -> 3.13.0
* [`37487ef1`](https://github.com/NixOS/nixpkgs/commit/37487ef15e286313118a05a8e80abe1261dee70d) include-what-you-use: 0.23 -> 0.24
* [`8bdc44ec`](https://github.com/NixOS/nixpkgs/commit/8bdc44ec9ac45661b64ab82ecde1da49e552782f) gce-images: drop
* [`c4ac0aeb`](https://github.com/NixOS/nixpkgs/commit/c4ac0aeb7036cbd89d4e7bb77d6fb916716d3e1b) python3Packages.foundationdb: init 7.3.42
* [`17d08970`](https://github.com/NixOS/nixpkgs/commit/17d089705092345a8eed561aad879d3f907293b4) foundationdb: move to pkgs/by-name
* [`d1f6eccd`](https://github.com/NixOS/nixpkgs/commit/d1f6eccd71e08c04bca1a74e89455beeb54a7d06) courier-unicode: 2.3.1 -> 2.3.2
* [`ce1d6971`](https://github.com/NixOS/nixpkgs/commit/ce1d697158636642c982f244cc827c0ee8033740) valijson: 1.0.4 -> 1.0.5
* [`2164a9e0`](https://github.com/NixOS/nixpkgs/commit/2164a9e07e7bed4a6302d4d31f700b200ac30c4b) wavelog: 2.0.2 -> 2.0.3
* [`916d31a3`](https://github.com/NixOS/nixpkgs/commit/916d31a390cb5874d95a215f4fb67c0a83924028) ibus-engines.m17n: 1.4.35 -> 1.4.36
* [`a13e52ca`](https://github.com/NixOS/nixpkgs/commit/a13e52ca022ca66520ea5ec82f5d96d222d222cc) cdecl: 18.4.1 -> 18.4.2
* [`fe663091`](https://github.com/NixOS/nixpkgs/commit/fe66309160e0c99cdcbfab63a0a18f57a4568079) aaaaxy: 1.6.64 -> 1.6.176
* [`69876877`](https://github.com/NixOS/nixpkgs/commit/69876877ee6836de0eb3e50e61a6b97cd01acc2a) havn: use finalAttrs pattern
* [`433b2776`](https://github.com/NixOS/nixpkgs/commit/433b277603f3daecaef261341cf04a56d4669e8b) penpot-desktop: 0.11.0 -> 0.12.0
* [`b1bc2389`](https://github.com/NixOS/nixpkgs/commit/b1bc2389d414a5baf5b21d27fb9096e32852c1a1) ferdium: 7.0.0 -> 7.0.1
* [`dca57091`](https://github.com/NixOS/nixpkgs/commit/dca570910c1c0780fe0801b65a6348be216f750d) kstars: 3.7.5 -> 3.7.6
* [`322c5fdc`](https://github.com/NixOS/nixpkgs/commit/322c5fdc578d7b9ef136cfa8e69b49806b1be509) uclibc-ng: 1.0.51 -> 1.0.52
* [`511d79ae`](https://github.com/NixOS/nixpkgs/commit/511d79aec4dd658d4d78bf799b621713ee17b9f6) indilib, indi-3rdparty: 2.1.2.1 -> 2.1.3
* [`bb4be9a4`](https://github.com/NixOS/nixpkgs/commit/bb4be9a474c87dd9366eca69fa8e2f0aa16fcc83) lib.strings: init splitStringBy
* [`0011bf7d`](https://github.com/NixOS/nixpkgs/commit/0011bf7da930a3392387fc45c5dda7337104171d) whisper-cpp: 1.7.2 -> 1.7.5
* [`be518746`](https://github.com/NixOS/nixpkgs/commit/be518746edae8c544a1671e3bca49aa62a9937cd) whisper-cpp: remove unused `lib.*`` funcs
* [`20b19da2`](https://github.com/NixOS/nixpkgs/commit/20b19da257825f31b23dea7a0eb264a504bbf847)  whisper-cpp: quote paths
* [`4ed08cd5`](https://github.com/NixOS/nixpkgs/commit/4ed08cd55609ca9908fed4a5008b4180f4ee21be) loadwatch: 1.1-1 -> 1.1-4
* [`740cc14f`](https://github.com/NixOS/nixpkgs/commit/740cc14fade08d1878ffc5dbb8d652335121957e) ygot: init at 0.30.0
* [`13b4d6eb`](https://github.com/NixOS/nixpkgs/commit/13b4d6ebe88634c3692dea53f7a6d8d1c9d3abb2) deskflow: add maintainer
* [`1a99ed33`](https://github.com/NixOS/nixpkgs/commit/1a99ed331d7b9e652f1204072d26a532ff8baf15) deskflow: 1.20.1 -> 1.21.2
* [`36b019e1`](https://github.com/NixOS/nixpkgs/commit/36b019e1db6ca5a8af92181af2c84d2cd3d8e9c0) clj-kondo: 2025.02.20 -> 2025.04.07
* [`b8d1fe7f`](https://github.com/NixOS/nixpkgs/commit/b8d1fe7fa3d0d9222fa04aeeb2166c9e871e3d08) lifelines: unstable-2019-05-07 -> 0-unstable-2025-01-05
* [`04c631f4`](https://github.com/NixOS/nixpkgs/commit/04c631f4515c10d3280a7d6ed004668dfbb5b4fd) mathmod: 12.0 -> 12.1
* [`57741734`](https://github.com/NixOS/nixpkgs/commit/577417344339acac020744052a86f4d112c83e2f) Fix [nixos/nixpkgs⁠#396993](https://togithub.com/nixos/nixpkgs/issues/396993) by tracking the new minified name of the `ServerTransferFailed` status code
* [`e2b65c02`](https://github.com/NixOS/nixpkgs/commit/e2b65c023983cd579e1f9eb050504fd5959ecb41) nixos/tzupdate: make enabled module actually be enabled
* [`dab0193b`](https://github.com/NixOS/nixpkgs/commit/dab0193b96c7e826d510c82de1a114eff68fd11a) museum: 1.0.0 -> 1.0.2
* [`153e746e`](https://github.com/NixOS/nixpkgs/commit/153e746e006adce51df7183c71c836887320c5ec) cartero: 0.1.5 -> 0.2.1
* [`75c76dd7`](https://github.com/NixOS/nixpkgs/commit/75c76dd7caba5e7fa6fe8227ef65ba257f3fd853) libdwarf-lite: 0.11.1 -> 0.12.0
* [`263e266c`](https://github.com/NixOS/nixpkgs/commit/263e266c2716e7acc94e36c16986e38d19a27e3e) nixos/release: drop amazonImageAutomaticSize
* [`c7e1962f`](https://github.com/NixOS/nixpkgs/commit/c7e1962f7960103f93354ee23264c283834cbed0) perlPackages.ExtUtilsPkgConfig: fix pkg-config use for cross
* [`21a3af88`](https://github.com/NixOS/nixpkgs/commit/21a3af88ff5c436987611c659eae3974c64e8599) irpf: 2025-1.1 -> 2025-1.2
* [`946c5908`](https://github.com/NixOS/nixpkgs/commit/946c5908742e988f1a1ba12d52681cfe092af012) space-station-14-launcher: 0.29.1 -> 0.31.0
* [`e12c51a0`](https://github.com/NixOS/nixpkgs/commit/e12c51a047bcacf0e0ee845e5ba451f189162d0a) black-hole-solver: migrate to by-name, fix cross
* [`7ba4dd3f`](https://github.com/NixOS/nixpkgs/commit/7ba4dd3fc9da82e59f4fbb1f775c8e8365db1914) satellite: add updateScript
* [`64d53339`](https://github.com/NixOS/nixpkgs/commit/64d533399cacaf37ffa02deb19b0673f443a089f) satellite: 0.9.0 -> 0.9.1
* [`46fc6bd2`](https://github.com/NixOS/nixpkgs/commit/46fc6bd288fa242d4a9de4650089d1c01c0f4800) linuxPackages.nullfs: 0.17 -> 0.18
* [`316d308b`](https://github.com/NixOS/nixpkgs/commit/316d308be0b355c4292cdbbfaa7c012ce8999116) maeparser: 1.3.1 -> 1.3.2
* [`dc617af0`](https://github.com/NixOS/nixpkgs/commit/dc617af0c33b3d9719de952a1f54784d3149bb25) appimageTools.defaultFhsEnvArgs.multiPkgs: add brolti
* [`5bb820b0`](https://github.com/NixOS/nixpkgs/commit/5bb820b071dc4b42c402c371f156675756dcbeb0) inter-alia: init at 0-unstable-2024-01-12
* [`2fa3267a`](https://github.com/NixOS/nixpkgs/commit/2fa3267a64847641d258e54f2068ce346db7a315) m17n_db: 1.8.9 -> 1.8.10
* [`66bfff47`](https://github.com/NixOS/nixpkgs/commit/66bfff4792c06633c295cc30b11c7abeacaf6d34) remmina: 1.4.39 -> 1.4.40
* [`f32e350b`](https://github.com/NixOS/nixpkgs/commit/f32e350b857bf65641ee9559b8156db6929a556b) honeycomb: Migrate to by-name
* [`e68ccc12`](https://github.com/NixOS/nixpkgs/commit/e68ccc1272206cbf762f83450c6f0083644554c0) cockatrice: 2025-03-27-Release-2.10.1 -> 2025-04-03-Release-2.10.2
* [`72d17044`](https://github.com/NixOS/nixpkgs/commit/72d17044e0d5b8661c961ef428ad32e318f1c160) yafc-ce: 2.11.0 -> 2.11.1
* [`6d28ea75`](https://github.com/NixOS/nixpkgs/commit/6d28ea75d4eebff158697073b18fcb01c92756ad) cni: 1.2.3 -> 1.3.0
* [`f5125251`](https://github.com/NixOS/nixpkgs/commit/f5125251a7268217c9c21ad41af398d81e0d78eb) addr-book-combine: init at 0-unstable-2022-12-14
* [`bec5702e`](https://github.com/NixOS/nixpkgs/commit/bec5702e73929390080c6eff41b9c1cfcebf9cce) prometheus-smokeping-prober: 0.9.0 -> 0.10.0
* [`fa82b643`](https://github.com/NixOS/nixpkgs/commit/fa82b643da696a08f0fa58eac9524f897f272cb9) gopeed: 1.6.11 -> 1.7.0
* [`59656574`](https://github.com/NixOS/nixpkgs/commit/5965657453e7d5d59f64551d16ce08d53948caaa) therion: 6.3.3 -> 6.3.4
* [`8bca1d49`](https://github.com/NixOS/nixpkgs/commit/8bca1d49ce35a4f005be4d3eae33cd49f75154f1) element-web: 1.11.96 -> 1.11.97
* [`57818dff`](https://github.com/NixOS/nixpkgs/commit/57818dff0af5a80d9bc412bcbc53783ad70cd983) nixos/gancio: add missing quotes to cli command, remove erroneous dash
* [`79178cc6`](https://github.com/NixOS/nixpkgs/commit/79178cc661cca0a59638d17dda44d6528aa65c4f) nixos/gancio: exec into configured user with cli
* [`b760ece2`](https://github.com/NixOS/nixpkgs/commit/b760ece2bfc8d1f1585d5d12569951d7c18a87f9) nixos/gancio: fix all defaultText
* [`aaaa035a`](https://github.com/NixOS/nixpkgs/commit/aaaa035a994cf2947b52f31b193618c2d283cac3) nanomq: 0.22.1 → 0.23.6
* [`563c329b`](https://github.com/NixOS/nixpkgs/commit/563c329bedb084e49f6bc11da2bde02982169cff) calibre: unbreak on aarch64-linux
* [`2fef5d6b`](https://github.com/NixOS/nixpkgs/commit/2fef5d6b2f2154a4df1c73d562c582c93e00cad4) maintainers: add bricked
* [`9d02f876`](https://github.com/NixOS/nixpkgs/commit/9d02f876c4326b06ada6ed11052357d7f355ecac) nixosTests.discourse: fix after dovecot2 change
* [`f2ebbabd`](https://github.com/NixOS/nixpkgs/commit/f2ebbabda07227ed0a3150124989d330caea457c) discourse: 3.3.2 -> 3.4.2
* [`9522ab87`](https://github.com/NixOS/nixpkgs/commit/9522ab87ff7e1509a85717ebc872116da66e0dcc) discourse.plugins: update for 3.4.2 versions
* [`a6290d3e`](https://github.com/NixOS/nixpkgs/commit/a6290d3e232e2c88e2ba356ac2bddf6042451ef9) hanken-grotesk: init at 0-unstable-2024-01-30
* [`e16a290a`](https://github.com/NixOS/nixpkgs/commit/e16a290a9c1316fd4d484b206d94d7f8a93a7164) foodfetch: init at 0.1.1
* [`a503352b`](https://github.com/NixOS/nixpkgs/commit/a503352bd4f01122721be5e2c7b210e273840a98) maintainers: add noahfraiture
* [`10441100`](https://github.com/NixOS/nixpkgs/commit/104411004f1dda0886cfbe92afda6d968dff4792) async-profiler: 3.0 -> 4.0
* [`dbe728c8`](https://github.com/NixOS/nixpkgs/commit/dbe728c887466998463113aae3e2910e64fb8899) openxr-loader: 1.1.46 -> 1.1.47
* [`7669e832`](https://github.com/NixOS/nixpkgs/commit/7669e832068370ede1186c06a9d2c71bf2a3a75b) pomerium: 0.28.0 -> 0.29.2
* [`d47adb13`](https://github.com/NixOS/nixpkgs/commit/d47adb134c1cc9dc150fdcf115e06a93a4dadc32) thanos: 0.37.2 -> 0.38.0
* [`6ac47a1b`](https://github.com/NixOS/nixpkgs/commit/6ac47a1bcdc60e91bcc31add62e7de6a338b5ccf) maintainers: add tmssngr
* [`e3807568`](https://github.com/NixOS/nixpkgs/commit/e3807568adf07e757d01fb8a20f3d79fcabfc61b) tpm2-pkcs11: fix fapi configure option; split tpm2-pkcs11-{esapi,fapi}
* [`e7356914`](https://github.com/NixOS/nixpkgs/commit/e7356914f4adc49d88d38abd382cfb2d5962d052) tpm2-pkcs11: add release notes
* [`8b5d0ebb`](https://github.com/NixOS/nixpkgs/commit/8b5d0ebbbd6375f1ecd0ce169d44d03388189038) isabelle: 2024 -> 2025
* [`fa09ff7a`](https://github.com/NixOS/nixpkgs/commit/fa09ff7a7d38a618a9d8e2e614dae6b175993a37) isabelle-components.isabelle-linter: 2024-1.0.1 -> 2025-1.0.0
* [`27a16a63`](https://github.com/NixOS/nixpkgs/commit/27a16a6374e26b2531bd39412e2afcc240af8347) python312Packages.gaphas: 5.0.0 -> 5.0.3
* [`6ab7d3db`](https://github.com/NixOS/nixpkgs/commit/6ab7d3db2c1995142570e45dc9c9e175bfa928b3) python312Packages.langchain-ollama: 0.3.0 -> 0.3.1
* [`b0fb2f6b`](https://github.com/NixOS/nixpkgs/commit/b0fb2f6b82580a55dac3033d5e7d4c22b9211ee9) ultrastardx: 2025.3.0 -> 2025.4.0
* [`3ecaffe3`](https://github.com/NixOS/nixpkgs/commit/3ecaffe3b70a85bea1d3b2d0afa3bb60be2da01e) gyroflow: 1.6.0 -> 1.6.1
* [`f8a597f1`](https://github.com/NixOS/nixpkgs/commit/f8a597f1126c1ac4882a1ba04327cb41b8fbc588) python312Packages.langchain-openai: 0.3.11 -> 0.3.12
* [`13b02367`](https://github.com/NixOS/nixpkgs/commit/13b0236723c4e40663e3450876defa90b75eddac) franz: 5.10.0 -> 5.11.0
* [`33125d15`](https://github.com/NixOS/nixpkgs/commit/33125d154431f9f718e0a1d34b8db4791783f838) microsoft-edge: 134.0.3124.95 -> 135.0.3179.54
* [`9280d860`](https://github.com/NixOS/nixpkgs/commit/9280d860776bd4cfaa8826d8ef2a4f85aa0ac4f1) spirit: 0.7.0 -> 0.8.0
* [`8e0197e5`](https://github.com/NixOS/nixpkgs/commit/8e0197e582136dcf46aa8e5c4b3b159ce164bd73) okteto: 3.4.0 -> 3.6.0
* [`9a32e848`](https://github.com/NixOS/nixpkgs/commit/9a32e8488c5ca029ae6dc34ca20e49e880eaedab) oci-cli: 3.54.0 -> 3.54.2
* [`9c7f82ad`](https://github.com/NixOS/nixpkgs/commit/9c7f82ad62e010e6990a345b2f652ae99bcf6727) windsurf: 1.6.2 -> 1.6.3
* [`58a9d910`](https://github.com/NixOS/nixpkgs/commit/58a9d9106dcba255e1aa2d8b894cdf904990145f) mdformat-mkdocs: fix build failure, upstream recommends no longer including mdformat-admon
* [`1b98165b`](https://github.com/NixOS/nixpkgs/commit/1b98165bc0f8b2562f8a4dbdb1d64e7fc05d87ae) mdformat: 0.7.19 -> 0.7.22
* [`e41854bf`](https://github.com/NixOS/nixpkgs/commit/e41854bfe7cd430ca957016e553c098c54b19ba5) mdformat-admon: 2.0.6 -> 2.1.1
* [`a75ec05c`](https://github.com/NixOS/nixpkgs/commit/a75ec05cc89af64468da07c139ba738d575d5bc8) python313Packages.lightning: init at 2.5.1
* [`cf05b123`](https://github.com/NixOS/nixpkgs/commit/cf05b12351bf5d9c5c2ce2533e2ef856cc3a0484) v2ray: 5.29.3 -> 5.30.0
* [`18725dd6`](https://github.com/NixOS/nixpkgs/commit/18725dd6173fb748fea3a3a6a65f1d1d8592c970) carapace-bridge: 1.2.5 -> 1.2.7
* [`3f347ef1`](https://github.com/NixOS/nixpkgs/commit/3f347ef116f9879ffb8414404155231b86d97fac) console-setup: 1.235 -> 1.236
* [`ee2eef2b`](https://github.com/NixOS/nixpkgs/commit/ee2eef2b3afc187ef256df813cc8c5da584d6dcc) rauc: 1.13 -> 1.14, enable composefs
* [`49970e5c`](https://github.com/NixOS/nixpkgs/commit/49970e5c144279c9d164ed1f0e50e80bd6049bf4) vitess: 21.0.3 -> 21.0.4
* [`9f87431a`](https://github.com/NixOS/nixpkgs/commit/9f87431a2153aa75e69a4d7cfbb2753ecf5f8c25) syft: 1.21.0 -> 1.22.0
* [`7fdd2d08`](https://github.com/NixOS/nixpkgs/commit/7fdd2d0873e750e040ac8b04c0c8032b80b8a5a8) bitwig-studio: fix ALSA driver model
* [`7325a48e`](https://github.com/NixOS/nixpkgs/commit/7325a48e283f2afe0929ff54b75b853e406fb95c) renode-dts2repl: 0-unstable-2025-03-17 -> 0-unstable-2025-04-08
* [`70097f7c`](https://github.com/NixOS/nixpkgs/commit/70097f7c6635c82a1493b278c60d678bb6654080) fpm: 1.15.1 -> 1.16.0
* [`34dec3f6`](https://github.com/NixOS/nixpkgs/commit/34dec3f64217c49280afb2f9a02c38c98406ca2a) nixt: 2.6.2 -> 2.6.3
* [`9edbaf79`](https://github.com/NixOS/nixpkgs/commit/9edbaf79b3b082cb0ceaba42ac39562ad94aff23) cemu: 2.5 -> 2.6
* [`7fce4af2`](https://github.com/NixOS/nixpkgs/commit/7fce4af214be2b47c7c301ff73a6df50af690394) regname: init at 0.1.0
* [`d68c28cf`](https://github.com/NixOS/nixpkgs/commit/d68c28cf3f5eed71e5467154f38a3d5bfc59b7b4) factoriolab: 3.12.1 -> 3.13.2
* [`6b873150`](https://github.com/NixOS/nixpkgs/commit/6b8731509e7d59a9c458bdc55eb51b7ac45fe3c6) ggh: init at 0.1.4
* [`cb19a0b8`](https://github.com/NixOS/nixpkgs/commit/cb19a0b8ebb1b7b819beee0d370b2744088e09c3) Update firefoxpwa and fixed chrome.sys.mjs path
* [`6e722383`](https://github.com/NixOS/nixpkgs/commit/6e72238343450a4b33f2ad0d2235cedce9bb0373) tidal-hifi: 5.18.0 -> 5.18.2
* [`a3d76109`](https://github.com/NixOS/nixpkgs/commit/a3d7610925fc77be4ec5c000b0bf6ebea5e52aea) suricata: 7.0.9 -> 7.0.10
* [`e9e80c8c`](https://github.com/NixOS/nixpkgs/commit/e9e80c8c98f67cf21ce4bb638ba586aa0d248d4d) qdrant-web-ui: 0.1.38 -> 0.1.39
* [`3aabb0bb`](https://github.com/NixOS/nixpkgs/commit/3aabb0bb5a7068155faf4beb83620a24bca017cb) maintainers: add seiarotg
* [`47c596d4`](https://github.com/NixOS/nixpkgs/commit/47c596d4052f7afd6c3ebbc37e773293c89353b0) monit: 5.34.4 -> 5.35.0
* [`800e4583`](https://github.com/NixOS/nixpkgs/commit/800e45833fb969fe2d05669d8d78233a6476a300) survex: 1.4.16 -> 1.4.17
* [`e20dee2e`](https://github.com/NixOS/nixpkgs/commit/e20dee2e36be01dfbfd02fdbd51b7b08a2dbe357) npm-check-updates: 17.1.16 -> 17.1.18
* [`8cfac770`](https://github.com/NixOS/nixpkgs/commit/8cfac770ffd3d3369b8148961d659e0ec3b8d079) goshs: init at 1.0.2
* [`e8f073f4`](https://github.com/NixOS/nixpkgs/commit/e8f073f45825e060ce96aef368d173a2b8e80f06) codeql: 2.20.7 -> 2.21.0
* [`63c6cb10`](https://github.com/NixOS/nixpkgs/commit/63c6cb10fc4bc6ac14f340ba586894536f095035) subfont: init at 7.2.1
* [`82ab85c3`](https://github.com/NixOS/nixpkgs/commit/82ab85c33d5b72399519dafc4f222f48583b5023) yo: remove package-lock.json
* [`0ba32d51`](https://github.com/NixOS/nixpkgs/commit/0ba32d516ff11febb7bc2ab689687f2a6a1ee953) eduli: fix fetchzip url and hash
* [`43b37983`](https://github.com/NixOS/nixpkgs/commit/43b37983cf38ae7e4d1f3cb3e99ee91d2d7efcf1) dim: fix build
* [`1eeb5bd9`](https://github.com/NixOS/nixpkgs/commit/1eeb5bd960650ed91301423958ceab18ba41e046) spider: 2.36.2 -> 2.36.34
* [`3c3d212a`](https://github.com/NixOS/nixpkgs/commit/3c3d212a24b2123ba78dd1b83590b27987844b6d) vscode-extensions-update: rename
* [`af5416df`](https://github.com/NixOS/nixpkgs/commit/af5416df0ce4616d8d92ef7ed4a89e61d61f910b) apt: 2.9.35 -> 3.0.0
* [`6ef835f3`](https://github.com/NixOS/nixpkgs/commit/6ef835f39dcfee301a0d6a3bdc3d8300cd5728b4) vscode-extension-update-script: improve
* [`93b811ea`](https://github.com/NixOS/nixpkgs/commit/93b811ea64e089ece4e8909442e7af0dd993005c) python312Packages.torchio: 0.20.4 -> 0.20.6
* [`8f517fbf`](https://github.com/NixOS/nixpkgs/commit/8f517fbfb479eb5b481525b2dc970b6b8abd46e4) zig: use ninja
* [`e3fa9fa8`](https://github.com/NixOS/nixpkgs/commit/e3fa9fa859c71a28f61036619040e128a5df2e8b) zon2nix: 0.1.2 -> 0.1.3-unstable-2025-03-20
* [`f329f393`](https://github.com/NixOS/nixpkgs/commit/f329f393b37d240c9e0698e7baa74cb6ce58104e) backlight-auto: mark as broken
* [`bb17e1ac`](https://github.com/NixOS/nixpkgs/commit/bb17e1ac26662bbffab8b67ca4fe56f2cfa3c714) dt: 1.3.1 -> 1.3.1-unstable-2024-07-16
* [`83782b15`](https://github.com/NixOS/nixpkgs/commit/83782b156896794d6b82c98f2e70223ec482a534) blackshades: 2.5.1 -> 2.5.2-unstable-2025-03-12
* [`8eb1fd04`](https://github.com/NixOS/nixpkgs/commit/8eb1fd04f79d8a5ffc782cc867a8e295318391fa) findup: mark as broken
* [`13476597`](https://github.com/NixOS/nixpkgs/commit/13476597402d425de91bd6eb9e64d1b8a1af7ec3) cyber: unstable-2023-09-19 -> 0-unstable-2025-12-10
* [`6b2f93bd`](https://github.com/NixOS/nixpkgs/commit/6b2f93bd85f7f9fbdc3c299c9e4dde9161643f96) zig_0_11: drop
* [`4fa5b123`](https://github.com/NixOS/nixpkgs/commit/4fa5b123f40c00ab31581054be8838b0dd4419d1) mathgl: mark cross as broken
* [`fb07e96c`](https://github.com/NixOS/nixpkgs/commit/fb07e96cba285588889a0c27cb2563d7fee57354) prometheus-postfix-exporter: 0.8.0 -> 0.9.0
* [`942a3ba0`](https://github.com/NixOS/nixpkgs/commit/942a3ba0c66b2c0344e143094481c34df34be5f2) joplin-desktop: add multiarch update script
* [`bc337519`](https://github.com/NixOS/nixpkgs/commit/bc3375196af1aad1aef766366d929665f0dfff2b) joplin-desktop: fix desktop assets path
* [`c252ce32`](https://github.com/NixOS/nixpkgs/commit/c252ce32740d1efe70e617d8f4c061bdab8bf6b7) joplin-desktop: 3.1.24 -> 3.2.13
* [`6b795ed8`](https://github.com/NixOS/nixpkgs/commit/6b795ed8c277643c6bcb3b2b3c5a295c9ad6b3b6) gensio: 2.8.12 -> 2.8.14
* [`4bc3f439`](https://github.com/NixOS/nixpkgs/commit/4bc3f4392375ef1e59bcc9783f64991a92107ea1) nixos/dependency-track: fix nginx config for frontend
* [`6c10c44f`](https://github.com/NixOS/nixpkgs/commit/6c10c44fbdc780ad7023299bcde2fb5f8e1eac1a) mrtrix: 3.0.4 -> 3.0.4-unstable-2025-04-09
* [`429b574b`](https://github.com/NixOS/nixpkgs/commit/429b574bbfbe8c5dd93f241fa6b57b831f72c16c) mim-solvers: exclude flaky test
* [`52af2b5f`](https://github.com/NixOS/nixpkgs/commit/52af2b5f5ff535b9c0323daac7ab4719b2a4dd9f) maintainers: add dramforever
* [`6d392ea1`](https://github.com/NixOS/nixpkgs/commit/6d392ea172f661e109bc54ee35882c26b971b3ba) go-xmlstruct: init at 1.10.0
* [`ace09922`](https://github.com/NixOS/nixpkgs/commit/ace099220780e4968b74641c24b85c0ae880e670) patchcil: init at 0.2.2
* [`84aa2c4d`](https://github.com/NixOS/nixpkgs/commit/84aa2c4d8e51ce0e3d5080702cc3d538fb72930e) dotnetCorePackages.autoPatchcilHook: init
* [`e2d963b9`](https://github.com/NixOS/nixpkgs/commit/e2d963b9f681f6068704c28ac8babb1ae8276427) docs/autoPatchcilHook: init
* [`fafba57b`](https://github.com/NixOS/nixpkgs/commit/fafba57b31e97a767c627be324ee0918319b9066) openomf: init at 0.8.1
* [`08588814`](https://github.com/NixOS/nixpkgs/commit/0858881489782d277c4720c72108939ae82520db) clojure-lsp: 2025.03.07-17.42.36 -> 2025.03.27-20.21.36
* [`166c5095`](https://github.com/NixOS/nixpkgs/commit/166c5095483046ee26e3368db61c3e6e9cb54e5f) snore: rev -> tag
* [`504f6af8`](https://github.com/NixOS/nixpkgs/commit/504f6af85392470e5ed8b9508ad727d5df4390b6) soapysdr: 0.8.1 -> 0.8.1-unstable-2025-03-30
* [`b16799b9`](https://github.com/NixOS/nixpkgs/commit/b16799b957500a135dbf303c7486a10693bddf5f) netdata: add mainProgram
* [`6f19f18b`](https://github.com/NixOS/nixpkgs/commit/6f19f18b964d0d6a73c313011f3f8acb0b4e0d9a) mark broken packages
* [`ca829335`](https://github.com/NixOS/nixpkgs/commit/ca829335db54862311f218c79f849fbda5680e80) fishnet: prefer versionCheckHook rather than testers.testVersion
* [`85116561`](https://github.com/NixOS/nixpkgs/commit/85116561bcd61a931d98ee883df6d129486a66f1) fishnet: prefer finalAttrs rather than rec
* [`2f8642ea`](https://github.com/NixOS/nixpkgs/commit/2f8642eab588152705dfe012a0b5d707605acdbe) fishnet: prefer hash rather than sha256 in fetchurl
* [`bdce1c44`](https://github.com/NixOS/nixpkgs/commit/bdce1c44a26a09891c680d9dfdcbc38b3954628c) fishnet: prefer tag rather than rev for fetchFromGitHub
* [`c2e4e67c`](https://github.com/NixOS/nixpkgs/commit/c2e4e67cf43e6eb0bc1a18de877fb2282d9b91d1) dput-ng: 1.40 -> 1.42
* [`80314e12`](https://github.com/NixOS/nixpkgs/commit/80314e12ffd9554cbd6261ca9bfad7a290452b6f) canon-cups-ufr2: Fix gcc rpath for libstdc++
* [`c16514b0`](https://github.com/NixOS/nixpkgs/commit/c16514b0f7d6470d4ace6473349e4dd492c614a6) geoserver: 2.26.2 -> 2.27.0
* [`298aa40f`](https://github.com/NixOS/nixpkgs/commit/298aa40f23f245267008d38ba0dbb026f7e20dbd) git-prole: add shell completions
* [`a00e9a3a`](https://github.com/NixOS/nixpkgs/commit/a00e9a3ac0cb59a91af811dfc5292fa05f840a85) gnome-solanum: 5.0.0 -> 6.0.0
* [`da9f701b`](https://github.com/NixOS/nixpkgs/commit/da9f701b1825e03a53ca9af61bcdaa107468b3b8) gnome-solanum: modernize
* [`0a214400`](https://github.com/NixOS/nixpkgs/commit/0a2144000ed2af68d59ef7d735a68cfd5c7a0501) fishnet: add update script
* [`b32d0267`](https://github.com/NixOS/nixpkgs/commit/b32d0267c035f95a7d6fec9b180feaa71521f397) fishnet: 2.9.4 -> 2.9.5
* [`fcc673d4`](https://github.com/NixOS/nixpkgs/commit/fcc673d488f3d992b494aefff044dadc7aff9978) deltachat-desktop: install icon
* [`bfa357fa`](https://github.com/NixOS/nixpkgs/commit/bfa357fa7cd4578b34e8aa9d6a45009800730ef1) cargo-geiger: 0.11.7 -> 0.12.0
* [`8dbb1527`](https://github.com/NixOS/nixpkgs/commit/8dbb15271fe8115f492cd8c725df39961bb80020) pay-respects: 0.7.0 -> 0.7.5
* [`1e60c4e5`](https://github.com/NixOS/nixpkgs/commit/1e60c4e57dd56d51bb8badc3370f5f294477bb0e) portfolio: 0.74.2 -> 0.75.1
* [`d2cdff2e`](https://github.com/NixOS/nixpkgs/commit/d2cdff2e773fb48b58ca8758c0742beafbcd2ec0) vassal: 3.7.15 -> 3.7.16
* [`0a7e077c`](https://github.com/NixOS/nixpkgs/commit/0a7e077c422d7833572ca75036f833cc22f0f9b8) cagebreak: 2.3.1 -> 2.4.0
* [`35faad74`](https://github.com/NixOS/nixpkgs/commit/35faad743778cebc6faaabfa060a6e950f02a9a1) cagebreak: move to `pkgs/by-name`
* [`005e04f0`](https://github.com/NixOS/nixpkgs/commit/005e04f0e866c74cc7bae0986f3503d68198aac5) rutorrent: 5.1.6 -> 5.1.7
* [`c654b67c`](https://github.com/NixOS/nixpkgs/commit/c654b67c83d6dda246f67ab767f156687f5f2653) ord: 0.22.1 -> 0.23.1
* [`3dc06198`](https://github.com/NixOS/nixpkgs/commit/3dc06198d99e1bfab336f59f2bebbe737554b677) bitwig-studio: 5.3.2 -> 5.3.5
* [`e169744a`](https://github.com/NixOS/nixpkgs/commit/e169744ac7210b6f65249b2042b81a3d7339635e) ocamlPackages.qcheck-multicoretests-util: 0.7 -> 0.8
* [`59c8d41a`](https://github.com/NixOS/nixpkgs/commit/59c8d41a413326b74bb0eda87933814fb6b965f0) frida-tools: 13.6.1 -> 13.7.1
* [`c8f4ac92`](https://github.com/NixOS/nixpkgs/commit/c8f4ac92a895785a291ed91fadc238e8ab80fa99) fyne: 2.5.5 -> 2.6.0
* [`1436b85f`](https://github.com/NixOS/nixpkgs/commit/1436b85fc4ad438da39a3ac36ea558e0a0fda3e2) rquickshare: 0.11.4 -> 0.11.5
* [`28e89747`](https://github.com/NixOS/nixpkgs/commit/28e897477c531f2051cc0ff202ab8e4bf1a7043b) python312Packages.debugpy: 1.8.13 -> 1.8.14
* [`d3eaa7ce`](https://github.com/NixOS/nixpkgs/commit/d3eaa7ce120d3a3d9d901ec924a668ea52e421f7) python312Packages.orderly-set: 5.3.0 -> 5.3.2
* [`07251d38`](https://github.com/NixOS/nixpkgs/commit/07251d38564ea52ccb36255222709a59c18a5677) prowlarr: 1.32.2.4987 -> 1.33.3.5008
* [`431ceb3f`](https://github.com/NixOS/nixpkgs/commit/431ceb3f8e26b91f85d1926142794bc8b2023d3d) fix: add versionCheckHook
* [`98ba69fa`](https://github.com/NixOS/nixpkgs/commit/98ba69fa5fad49835c6b57e89a0f4608f1e84dba) fuzzel: 1.11.1 -> 1.12.0
* [`7b48a3cf`](https://github.com/NixOS/nixpkgs/commit/7b48a3cfe3e3300b46105556dbd482e3a93c3c58) bedops: 2.4.41 -> 2.4.42
* [`7ba214a3`](https://github.com/NixOS/nixpkgs/commit/7ba214a334b3689611eea29b1ea1275c3c7ae4ee) weaver: 0.13.2 -> 0.14.0
* [`24d6c8dd`](https://github.com/NixOS/nixpkgs/commit/24d6c8dd6effdab120b5bda228e3c0347dd0cea3) eccodes: 2.40.0 -> 2.41.0
* [`f2c374ca`](https://github.com/NixOS/nixpkgs/commit/f2c374ca0f490763f7d61f0cd71cbfd5dc2c7c60) flare-signal: 0.15.12  -> 0.15.16
* [`59c0f8cc`](https://github.com/NixOS/nixpkgs/commit/59c0f8cc28b2ddb4ce4484504e5895d3577b45be) rapidyaml: 0.8.0 -> 0.9.0
* [`bcf2b7cd`](https://github.com/NixOS/nixpkgs/commit/bcf2b7cde62db2248a2160a976be2d073e3f371a) nats-server: 2.11.0 -> 2.11.1
* [`e4f70e74`](https://github.com/NixOS/nixpkgs/commit/e4f70e74e3d72d425c8505bf322046ba384b5988) boogie: 3.4.2 -> 3.5.1
* [`95fb5388`](https://github.com/NixOS/nixpkgs/commit/95fb53883a77b26ca8df4bebe8d40a9d5985a159) boogie: refactor
* [`6ce3f966`](https://github.com/NixOS/nixpkgs/commit/6ce3f966a81500c6a1ffbb86e9774bfb24694f84) pingvin-share: 1.10.2 -> 1.11.1
* [`54d4ef2f`](https://github.com/NixOS/nixpkgs/commit/54d4ef2fde41df96129c761eea3634973a04e2e6) hexpatch: 1.11.0 -> 1.11.1
* [`ae971ff5`](https://github.com/NixOS/nixpkgs/commit/ae971ff57fa165bead5f5cd802635ccfebbcdbff) python312Packages.grad-cam: 1.5.4 -> 1.5.5
* [`ff773dcc`](https://github.com/NixOS/nixpkgs/commit/ff773dccc37eeaf6c4b36f5a60cb7de197e7a1ed) cargo-geiger: fix some tests
* [`7834b38c`](https://github.com/NixOS/nixpkgs/commit/7834b38cc49dfbc581e6ad40661e4804a3f81bea) cargo-geiger: update meta attrs, remove `with lib;`
* [`48269b33`](https://github.com/NixOS/nixpkgs/commit/48269b3334b541866bb354cc27445c89466ce30f) cargo-geiger: migrate to new apple sdk
* [`41ff65d8`](https://github.com/NixOS/nixpkgs/commit/41ff65d89b1852f10cf95f5a75c865968287f1df) cargo-geiger: add version test
* [`a80eca86`](https://github.com/NixOS/nixpkgs/commit/a80eca86d57f92f1925a368d9951e8931f6c29b2) virtualisation/linode-config: drop "with; lib"
* [`c6476ca1`](https://github.com/NixOS/nixpkgs/commit/c6476ca11990e993f265eba077d65424b9e80d54) repart: Enable discard option
* [`9e704d72`](https://github.com/NixOS/nixpkgs/commit/9e704d72636f87c111f5abbc5813f45bc2ac5628) virtualisation/linode-config: use mkImageMediaOverride...
* [`ae027401`](https://github.com/NixOS/nixpkgs/commit/ae0274015624d3fff799b622a5a56bd24681c247) virtualisation/proxmox-image: remove obsolete proxmox.qemuConf.diskSize usage
* [`3718f356`](https://github.com/NixOS/nixpkgs/commit/3718f356c08bc6d4fbcce96d48d9f26f416fd5a2) virtualisation/promxox-image: use mkImageMediaOverride...
* [`c5d383a7`](https://github.com/NixOS/nixpkgs/commit/c5d383a797cd32a38bd810de253505afe101addd) virtualisation/disk-image: use mkImageMediaOverride...
* [`864030e5`](https://github.com/NixOS/nixpkgs/commit/864030e5e825ec11252811c5c8e20e238c92c220) virtualisation/vmware-image: use mkImageMediaOverride...
* [`4327e179`](https://github.com/NixOS/nixpkgs/commit/4327e179f77d4100e8803ea50e90ef81d7e3f507) virtualisation/virtualbox-image: use mkImageMediaOverride...
* [`2742c716`](https://github.com/NixOS/nixpkgs/commit/2742c7163ad441ffae744c0615f73cb4301fa03d) virtualisation/kubevirt: use mkImageMediaOverride...
* [`61ba0446`](https://github.com/NixOS/nixpkgs/commit/61ba0446582326e339c2dfbf2b96cc37b16db6f2) virtualisation/oci-common: use mkImageMediaOverride...
* [`2f7435b5`](https://github.com/NixOS/nixpkgs/commit/2f7435b5caa75da83305d470fdcbcfbb71a8c47c) virtualisation/hyperv-image: use mkImageMediaOverride...
* [`a79571b0`](https://github.com/NixOS/nixpkgs/commit/a79571b081f6b813f76288134a1f2915e7d1986a) virtualisation/azure-image: use mkImageMediaOverride...
* [`bf2b3f02`](https://github.com/NixOS/nixpkgs/commit/bf2b3f02869b63dd6a56719373101b8d74c18f3c) virtualisation/digital-ocean-config: use mkImageMediaOverride...
* [`6f83796a`](https://github.com/NixOS/nixpkgs/commit/6f83796aa5fad00d64763ad3d95a82cf3584707c) virtualisation/google-compute-config: use mkImageMediaOverride...
* [`da76ddc1`](https://github.com/NixOS/nixpkgs/commit/da76ddc1bc1c272f54b77526ef7c76c094fce135) kitex: 0.13.0 -> 0.13.1
* [`8ca2d5ae`](https://github.com/NixOS/nixpkgs/commit/8ca2d5ae0a0731fcae67cb195aadfba1178cab8f) zinit: 3.13.1 -> 3.14.0
* [`8f87b512`](https://github.com/NixOS/nixpkgs/commit/8f87b512afd60bfddf9ab72b9918b4036f92e932) nixos/emacs: make systemd report clean exit status when stopping
* [`7293e2d5`](https://github.com/NixOS/nixpkgs/commit/7293e2d509911eb3b2d610478462004b3a1e2622) electron{,-bin,-chromedriver}: 34 -> 35
* [`b35b54bf`](https://github.com/NixOS/nixpkgs/commit/b35b54bf07bb1e834dd922369a72ad7683f97911) nixos/iotop: make package overridable
* [`887f7d33`](https://github.com/NixOS/nixpkgs/commit/887f7d33e04bc999838d9dcd87113d84dd0a48c2) virtualisation/openstack: use mkImageMediaOverride...
* [`5bd99195`](https://github.com/NixOS/nixpkgs/commit/5bd99195fab011e2b04c2ff7eed9ef5d44b2fe86) installer/sd-card: use mkImageMediaOverride...
* [`c716e43c`](https://github.com/NixOS/nixpkgs/commit/c716e43cf4f737357a08ba7661fabe81b0c24c95) apparency: 2.0 -> 2.2
* [`4d3929d0`](https://github.com/NixOS/nixpkgs/commit/4d3929d0b1d65d5114c1c54f2fc797d254931d12) nixos/television: init module
* [`69e33438`](https://github.com/NixOS/nixpkgs/commit/69e33438eb1b9be8791ddcff278f6325cadc7ca6) vscodium: 1.99.02289 -> 1.99.22418
* [`39a621dc`](https://github.com/NixOS/nixpkgs/commit/39a621dc5341ac00c58c7843eb923ccad25cefc1) zashboard: init at 1.77.0
* [`6e2711c6`](https://github.com/NixOS/nixpkgs/commit/6e2711c63e6dfabf3adca1eb6a080802c2b3594b) kazumi: 1.5.6 -> 1.6.5
* [`ccf0c7ba`](https://github.com/NixOS/nixpkgs/commit/ccf0c7ba5bb321a5ce6cb2ba1af4f163c6e839b1) ceph-csi: 3.13.1 -> 3.14.0
* [`e2c7748a`](https://github.com/NixOS/nixpkgs/commit/e2c7748a167c30a3c6a9534a11786a079e4d8350) wla-dx: 9.11 -> 10.6
* [`cd6825c7`](https://github.com/NixOS/nixpkgs/commit/cd6825c7e9a54a0d0ae91ded482bfd32005cb919) xmind: 8-update9 -> 25.01.01061-202501070800
* [`eafc0af8`](https://github.com/NixOS/nixpkgs/commit/eafc0af8b7fc6427bcd56bf584e6f7cc5b6ad6bd) vcard: 0.16.1 -> 1.0.0
* [`69d729f6`](https://github.com/NixOS/nixpkgs/commit/69d729f6dd1ab108e7afce49b1c041e546da8461) opcua-commander: 0.39.0 -> 0.40.0
* [`4265d646`](https://github.com/NixOS/nixpkgs/commit/4265d646d354daf57e1d04b780bcf028373a68e8) drawterm-cocoa: init at 0-unstable-2025-03-18
* [`854860f7`](https://github.com/NixOS/nixpkgs/commit/854860f78170692b18e9711c729eab40fff00086) python3Packages.sixel: init at 0.2.0
* [`7fb1fdd4`](https://github.com/NixOS/nixpkgs/commit/7fb1fdd4b483ceedf41d5fe45df4b61c0fa64763) lyto: init at 0.2.2
* [`8ba44929`](https://github.com/NixOS/nixpkgs/commit/8ba44929e67961d3d49b88617f7fac1244957938) boost188: init at 1.88.0
* [`399c9e59`](https://github.com/NixOS/nixpkgs/commit/399c9e5999f5d7a168c741a8ef6f1ffdb12e2405) drawterm: migrate to by-name
* [`2803c871`](https://github.com/NixOS/nixpkgs/commit/2803c8712510d12becc0d0d53e5b12940639cf84) josm: 19307 → 19369
* [`b0fb4e16`](https://github.com/NixOS/nixpkgs/commit/b0fb4e160b5fe9a53a238805e0763604a50ada7f) vscode-extensions.woberg.godot-dotnet-tools: init 0.5.1
* [`be535c2b`](https://github.com/NixOS/nixpkgs/commit/be535c2b929c29d531b9a9d112e24f48112f3080) python312Packages.djangosaml2: 1.9.3 -> 1.10.1
* [`230349c9`](https://github.com/NixOS/nixpkgs/commit/230349c9ea98ddbdc69b19b2555c5fa18a68eac2) atlantis: v0.33.0 -> v0.34.0
* [`e512a024`](https://github.com/NixOS/nixpkgs/commit/e512a0241ed017689989d1751340085f2caf6974) python313Packages.reflex: 0.7.5 -> 0.7.6
* [`45671248`](https://github.com/NixOS/nixpkgs/commit/4567124813fecc6b0b536c3f47847fc4f46a162a) python313Packages.reflex-hosting-cli: 0.1.36 -> 0.1.42
* [`e3acda80`](https://github.com/NixOS/nixpkgs/commit/e3acda804e9f85e6b6ac2f4917b994cb3c9f7617) python312Packages.netbox-documents: 0.7.1 -> 0.7.2
* [`7df7a3f4`](https://github.com/NixOS/nixpkgs/commit/7df7a3f40d10827f6f98229236f4a4d01a38c806) pkgsStatic.gum: fix build
* [`47933fc7`](https://github.com/NixOS/nixpkgs/commit/47933fc7f3cb243907e367b74753a69993601bce) mendeley: 2.132.0 -> 2.132.1
* [`cf15a7a0`](https://github.com/NixOS/nixpkgs/commit/cf15a7a0041032a4b9153152377ac8d79b12391b) teams-for-linux: 1.13.1 -> 2.0.7
* [`6e27178d`](https://github.com/NixOS/nixpkgs/commit/6e27178dcee00ce4ba27f16d76302a371818cab1) notmuch-bower: 1.1 -> 1.1.1
* [`45898256`](https://github.com/NixOS/nixpkgs/commit/4589825627d30dfdfb396e95551d100a2f3555a1) uwsgi: 2.0.28 -> 2.0.29
* [`fbfa1099`](https://github.com/NixOS/nixpkgs/commit/fbfa10995d8c5fe046583c7965ba4252ee5378e4) debianutils: 5.21 -> 5.22
* [`1f477bc8`](https://github.com/NixOS/nixpkgs/commit/1f477bc8607e8c65136112a247ad067686b45ef9) xsnow: 3.8.4 -> 3.8.5
* [`923ad47e`](https://github.com/NixOS/nixpkgs/commit/923ad47ec6efbab38f59ea5a077da9ba1c1efa25) gnunet: 0.24.0 -> 0.24.1
* [`f1db2dfe`](https://github.com/NixOS/nixpkgs/commit/f1db2dfe400bb82d6b7df9e958a1934855677097) dbvisualizer: 25.1.2 -> 25.1.3
* [`fee311ca`](https://github.com/NixOS/nixpkgs/commit/fee311ca3a6eb64b1c50d02fe0518567939a67bb) gh-gei: 1.12.0 -> 1.13.0
* [`520c327b`](https://github.com/NixOS/nixpkgs/commit/520c327ba3382f4a4d7cb86c34c64decb45c4921) way-displays: 1.13.0 -> 1.14.0
* [`4d3ac9fe`](https://github.com/NixOS/nixpkgs/commit/4d3ac9fe9d25f6cdfb632a0b3b21ac135b17d411) flaca: 3.2.3 -> 3.3.2
* [`466b8abe`](https://github.com/NixOS/nixpkgs/commit/466b8abe3aba4ae5c2346c85058eae7f2edd5737) python313Packages.certbot: 3.1.0 -> 4.0.0
* [`86471c0c`](https://github.com/NixOS/nixpkgs/commit/86471c0cdef020b8fb57dad2e2883e6eee79818c) pdfpc: 4.6.0 -> 4.7.0
* [`e2d0babe`](https://github.com/NixOS/nixpkgs/commit/e2d0babe8467006d22fcdb745e04b4e1e34b2b0d) fedistar: 1.11.2 -> 1.11.3
* [`911cb8b7`](https://github.com/NixOS/nixpkgs/commit/911cb8b7a735f5cef1c47a316cf7f5c3488e51e3) pdfpc: add update script
* [`952b8e98`](https://github.com/NixOS/nixpkgs/commit/952b8e985491f84219931bfb94b75f43899506c5) element-desktop: 1.11.96 -> 1.11.97
* [`1b387a2e`](https://github.com/NixOS/nixpkgs/commit/1b387a2e47df77446384701c88112a697dc924d2) netbox_4_2: 4.2.6 -> 4.2.7
* [`d3457cf7`](https://github.com/NixOS/nixpkgs/commit/d3457cf754242249e578248959177da8bfd157ed) argocd: 2.14.7 -> 2.14.9
* [`9dbc03c7`](https://github.com/NixOS/nixpkgs/commit/9dbc03c7079dc7c08fde055a631358f27ff2bf6e) prometheus-redis-exporter: 1.69.0 -> 1.70.0
* [`8aaa9c27`](https://github.com/NixOS/nixpkgs/commit/8aaa9c27fa6994233147dd390d848b17a53088d8) trackma-qt: 0.8.6 -> 0.9
* [`cb339d98`](https://github.com/NixOS/nixpkgs/commit/cb339d9843a5d3ee613911c0851de8d1583813cc) trackma-curses: 0.8.6 -> 0.9
* [`9bcb0d33`](https://github.com/NixOS/nixpkgs/commit/9bcb0d33e95ff8590d22544e09c248b57f88647a) trackma-gtk: 0.8.6 -> 0.9
* [`327a2351`](https://github.com/NixOS/nixpkgs/commit/327a23515dc93d9fbc4b6042b88dd566304bc098) ettercap: upgrade pcre to pcre2
* [`b4c2e8ef`](https://github.com/NixOS/nixpkgs/commit/b4c2e8ef4f3123940833fcb34c6777440750a8ff) k2pdfopt: fix build against mupdf >= 1.25.0
* [`c4692bcd`](https://github.com/NixOS/nixpkgs/commit/c4692bcda1d9d550b14cfd6e4b76af759c6a4f72) netbox_4_1: 4.1.7 -> 4.1.11
* [`857e8f4c`](https://github.com/NixOS/nixpkgs/commit/857e8f4c6c92a907403141369a2ff82dad2ba66b) birdfont: 2.33.3 -> 2.33.6
* [`41ca06f4`](https://github.com/NixOS/nixpkgs/commit/41ca06f4e66c4a49d32652524f55c75d5a840466) birdfont: add update script
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
