### PR TITLE
niv home-manager: update d5cdf55b -> 1ad12323

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -41,10 +41,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d5cdf55bd9f19a3debd55b6cb5d38f7831426265",
-        "sha256": "04js6xdqv4wlr37i9yz4c9vcwhxh2c1cqmn55fi5jcq3jdlhd93b",
+        "rev": "1ad123239957d40e11ef66c203d0a7e272eb48aa",
+        "sha256": "0whlwwv2l1zir93bb4p1a9qmvjwfp4ymaa7c3kldz8aszf2z73lv",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/d5cdf55bd9f19a3debd55b6cb5d38f7831426265.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/1ad123239957d40e11ef66c203d0a7e272eb48aa.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@d5cdf55b...1ad12323](https://github.com/nix-community/home-manager/compare/d5cdf55bd9f19a3debd55b6cb5d38f7831426265...1ad123239957d40e11ef66c203d0a7e272eb48aa)

* [`85c513aa`](https://github.com/nix-community/home-manager/commit/85c513aa862228d5b51295b20ccbdcc5fdf086bc) home-manager: Feature test for flake support ([nix-community/home-manager⁠#6824](https://togithub.com/nix-community/home-manager/issues/6824))
* [`db7738e6`](https://github.com/nix-community/home-manager/commit/db7738e67a101ad945abbcb447e1310147afaf1b) nh: remove incorrect warning on gc conflicts ([nix-community/home-manager⁠#6802](https://togithub.com/nix-community/home-manager/issues/6802))
* [`401e7b54`](https://github.com/nix-community/home-manager/commit/401e7b544e7c8e8a59f4ec7f1745f7619bbfbde3) Translate using Weblate (Dutch) ([nix-community/home-manager⁠#6828](https://togithub.com/nix-community/home-manager/issues/6828))
* [`5d48f3de`](https://github.com/nix-community/home-manager/commit/5d48f3ded3b55ef32d5853c9022fb4df29b3fc45) mcfly: Fix mcfly-fzf initialization crash for fish and zsh ([nix-community/home-manager⁠#6827](https://togithub.com/nix-community/home-manager/issues/6827))
* [`d8263c0b`](https://github.com/nix-community/home-manager/commit/d8263c0b845cec48869dc6b2ba80125fa002ff03) labwc: Add module for Labwc ([nix-community/home-manager⁠#6807](https://togithub.com/nix-community/home-manager/issues/6807))
* [`7ede02c3`](https://github.com/nix-community/home-manager/commit/7ede02c32a729db0d6340bdb41d10e73ec511ca0) progs: firefox: *.userChrome may be path or drv ([nix-community/home-manager⁠#6761](https://togithub.com/nix-community/home-manager/issues/6761))
* [`b35bccc3`](https://github.com/nix-community/home-manager/commit/b35bccc32d3fc49f6fcc4e08ccfd6025c9eefa20) home-manager-auto-expire: fix spelling error ([nix-community/home-manager⁠#6829](https://togithub.com/nix-community/home-manager/issues/6829))
* [`cb65c814`](https://github.com/nix-community/home-manager/commit/cb65c81403f61f49483858730b087ff6699c61c1) chawan: init module ([nix-community/home-manager⁠#6768](https://togithub.com/nix-community/home-manager/issues/6768))
* [`1827e843`](https://github.com/nix-community/home-manager/commit/1827e84344ff7cb814e3e4dfad51a45856ea50f6) mkFirefoxModule: fix userChrome
* [`c6b75d69`](https://github.com/nix-community/home-manager/commit/c6b75d69b6994ba68ec281bd36faebcc56097800) tests/firefox: add userchrome test cases
* [`c3c91dd8`](https://github.com/nix-community/home-manager/commit/c3c91dd8b4974ce221748b997e644c4838e3ebbc) mkFirefoxModule: fix userChrome with leading comment ([nix-community/home-manager⁠#6836](https://togithub.com/nix-community/home-manager/issues/6836))
* [`baa2a0b3`](https://github.com/nix-community/home-manager/commit/baa2a0b3bd23de23ba23f50508e44e9d77819ec2) tests/firefox: consolidate userChrome.css test files
* [`2c71aae6`](https://github.com/nix-community/home-manager/commit/2c71aae678c03a39c2542e136b87bd040ae1b3cb) tests/firefox: validate folder linking
* [`88e61873`](https://github.com/nix-community/home-manager/commit/88e61873646616ed80605e14b75332de22934481) atuin: add support for themes
* [`e72178b8`](https://github.com/nix-community/home-manager/commit/e72178b84e440703e17ff5d393ba060784bed099) tests/atuin: add theme test
* [`72526a5f`](https://github.com/nix-community/home-manager/commit/72526a5f7cde2ef9075637802a1e2a8d2d658f70) tests/firefox: fix test commands ([nix-community/home-manager⁠#6840](https://togithub.com/nix-community/home-manager/issues/6840))
* [`5e6a8203`](https://github.com/nix-community/home-manager/commit/5e6a8203cee7cc33b2e0d9a0adb7268f46447292) khard: add option to set mutiple subdirs ([nix-community/home-manager⁠#6823](https://togithub.com/nix-community/home-manager/issues/6823))
* [`54b494a7`](https://github.com/nix-community/home-manager/commit/54b494a77fb9fa68b0ebd7f75a8179cca0b286cd) keepassxc: add module
* [`4d6a8f59`](https://github.com/nix-community/home-manager/commit/4d6a8f590e46e62075e6787860f0ea030bab7651) keepassxc: nullable package support
* [`fc09cb7a`](https://github.com/nix-community/home-manager/commit/fc09cb7aaadb70d6c4898654ffc872f0d2415df9) tests/labwc: fix autostart
* [`412eb166`](https://github.com/nix-community/home-manager/commit/412eb166eb6725549c7e6b317eb48dc2bc648e39) tests/thunderbird: dont use realPkgs
* [`39037b08`](https://github.com/nix-community/home-manager/commit/39037b08f11ed034f4e0649aadbcdd856fab0ced) tests: darwin stub hjson-go
* [`4bc9b08c`](https://github.com/nix-community/home-manager/commit/4bc9b08c330842cb6e0cdafdb3c3b900cdde111a) tests/broot: stub broot
* [`67f60ebc`](https://github.com/nix-community/home-manager/commit/67f60ebce88a89939fb509f304ac554bcdc5bfa6) tests/home-cursor: don't use realPkgs
* [`991a4804`](https://github.com/nix-community/home-manager/commit/991a4804720669220f7cbba078a2a27e2496eb69) mkFirefoxModule: userchrome support derivations ([nix-community/home-manager⁠#6844](https://togithub.com/nix-community/home-manager/issues/6844))
* [`307281bf`](https://github.com/nix-community/home-manager/commit/307281bfda7f3e3469234a03a7dd9d0026bf9f36) labeler: expand labels ([nix-community/home-manager⁠#6846](https://togithub.com/nix-community/home-manager/issues/6846))
* [`ae84885d`](https://github.com/nix-community/home-manager/commit/ae84885d9b6b62dc58ccd300e9ab321a3fd9f9c7) workflows/conflicts: init ([nix-community/home-manager⁠#6845](https://togithub.com/nix-community/home-manager/issues/6845))
* [`9676e8a5`](https://github.com/nix-community/home-manager/commit/9676e8a52a177d80c8a42f66566362a6d74ecf78) inori: init module ([nix-community/home-manager⁠#6289](https://togithub.com/nix-community/home-manager/issues/6289))
* [`20705949`](https://github.com/nix-community/home-manager/commit/20705949f101952182694be8e7ccd890f61824c2) kitty: add git diff integration ([nix-community/home-manager⁠#6855](https://togithub.com/nix-community/home-manager/issues/6855))
* [`b8d186ab`](https://github.com/nix-community/home-manager/commit/b8d186abf8e14b3cffc8e0aee6459a323bc83eb0) fish: allow multiple commands for command option in abbreviations ([nix-community/home-manager⁠#6851](https://togithub.com/nix-community/home-manager/issues/6851))
* [`f6d295ce`](https://github.com/nix-community/home-manager/commit/f6d295cee3f6c9f8e968e1bfa4fda29bf9314bc5) flake.lock: Update ([nix-community/home-manager⁠#6854](https://togithub.com/nix-community/home-manager/issues/6854))
* [`e8b68f99`](https://github.com/nix-community/home-manager/commit/e8b68f99c6921c3ea8a79df85a2e980a71b17bfb) eza: add theme option ([nix-community/home-manager⁠#6850](https://togithub.com/nix-community/home-manager/issues/6850))
* [`bb8d2866`](https://github.com/nix-community/home-manager/commit/bb8d286649e97b89ad7dedae90418ff78f028c9d) zed-editor: add themes option ([nix-community/home-manager⁠#6832](https://togithub.com/nix-community/home-manager/issues/6832))
* [`f98314bb`](https://github.com/nix-community/home-manager/commit/f98314bb064cf8f8446c44afbadaaad2505875a7) restic: init module ([nix-community/home-manager⁠#6729](https://togithub.com/nix-community/home-manager/issues/6729))
* [`48bbe7bc`](https://github.com/nix-community/home-manager/commit/48bbe7bc4895a976e563b559316e8b178d474a0c) maintainers: add kiara
* [`aa2c7ac4`](https://github.com/nix-community/home-manager/commit/aa2c7ac40455ba98a106b9b5b22959a19e05a629) wallust: add module
* [`6a676ee4`](https://github.com/nix-community/home-manager/commit/6a676ee476543fcaea916d3b7a6e130112c44603) wallust: null package support
* [`642d3e3b`](https://github.com/nix-community/home-manager/commit/642d3e3bad75f688fa68edc01f2c3c8fe9833737) atuin: add support for str + path themes ([nix-community/home-manager⁠#6849](https://togithub.com/nix-community/home-manager/issues/6849))
* [`3cecde80`](https://github.com/nix-community/home-manager/commit/3cecde80a57211a05972aad49dab3ab4957178ae) maintainers: added lilleaila
* [`a0461b67`](https://github.com/nix-community/home-manager/commit/a0461b67ff657b6b6e51bb4a547ad98907d28dc8) vesktop: created module
* [`1d2d6b95`](https://github.com/nix-community/home-manager/commit/1d2d6b95688a6cb7555e2d50ba6ef1ebaa916546) uv: init module
* [`b71ca269`](https://github.com/nix-community/home-manager/commit/b71ca269615b0837724dac13358a2f0d6816d372) uv: nullable package support
* [`496fa9c0`](https://github.com/nix-community/home-manager/commit/496fa9c054d3a212c8bcb3ac80ab310841eed361) PR_TEMPLATE: mention nix fmt ([nix-community/home-manager⁠#6859](https://togithub.com/nix-community/home-manager/issues/6859))
* [`b0cc0924`](https://github.com/nix-community/home-manager/commit/b0cc092405da805da6fa964f5a178343658ceaf0) shikane: init module ([nix-community/home-manager⁠#4096](https://togithub.com/nix-community/home-manager/issues/4096))
* [`ac21ae37`](https://github.com/nix-community/home-manager/commit/ac21ae37168f339cccfd7002039314aeb3829bf6) maintainers: add Oughie
* [`14eda3db`](https://github.com/nix-community/home-manager/commit/14eda3db4e0347bb03f0d2e32f28f4467744abe1) clock-rs: add module
* [`63bfbf55`](https://github.com/nix-community/home-manager/commit/63bfbf55b6e561f5c517a29f9bf9157ff9dd8c87) ranger: nullable package support
* [`3fbe9a2b`](https://github.com/nix-community/home-manager/commit/3fbe9a2b76ff5c4dcb2a2a2027dac31cfc993c8c) tests/ranger: null package
* [`6695b1d4`](https://github.com/nix-community/home-manager/commit/6695b1d477246e30a3f14a7084c82775b30c09c1) kconfig: escape arguments properly ([nix-community/home-manager⁠#6867](https://togithub.com/nix-community/home-manager/issues/6867))
* [`82ee14ff`](https://github.com/nix-community/home-manager/commit/82ee14ff60611b46588ea852f267aafcc117c8c8) treewide: remove with lib ([nix-community/home-manager⁠#6871](https://togithub.com/nix-community/home-manager/issues/6871))
* [`ddda2b1f`](https://github.com/nix-community/home-manager/commit/ddda2b1f20ffc92b803fc5c8c0d80bbfb54cd478) direnv: only set sessionVariable for old version ([nix-community/home-manager⁠#6842](https://togithub.com/nix-community/home-manager/issues/6842))
* [`ca836711`](https://github.com/nix-community/home-manager/commit/ca8367117a20e11139b6b887aa19cb5d48dc1075) atuin: Fix deprecated string type warning ([nix-community/home-manager⁠#6861](https://togithub.com/nix-community/home-manager/issues/6861))
* [`08b85bd0`](https://github.com/nix-community/home-manager/commit/08b85bd0002c7ac500b8d9ac0112467885712b1f) vesktop: add support for multiple themes ([nix-community/home-manager⁠#6860](https://togithub.com/nix-community/home-manager/issues/6860))
* [`be4e5ec6`](https://github.com/nix-community/home-manager/commit/be4e5ec62ce5703a00e40668f7a1a79d04c2195d) nix-init: add module ([nix-community/home-manager⁠#6864](https://togithub.com/nix-community/home-manager/issues/6864))
* [`22b326b4`](https://github.com/nix-community/home-manager/commit/22b326b42bf42973d5e4fe1044591fb459e6aeac) television: add module ([nix-community/home-manager⁠#6866](https://togithub.com/nix-community/home-manager/issues/6866))
* [`42d90297`](https://github.com/nix-community/home-manager/commit/42d90297b38424a62235550a191fca875913e2f7) git: support maintenance on darwin ([nix-community/home-manager⁠#6868](https://togithub.com/nix-community/home-manager/issues/6868))
* [`81541ea3`](https://github.com/nix-community/home-manager/commit/81541ea36d1fead4be7797e826ee325d4c19308b) lorri: fix missing makeSearchPath ([nix-community/home-manager⁠#6875](https://togithub.com/nix-community/home-manager/issues/6875))
* [`ce8dc1f7`](https://github.com/nix-community/home-manager/commit/ce8dc1f77ada561f4deee2c76f7cd6f6c7b8feec) xsettingsd: Remove erroneous `lib.` insertion ([nix-community/home-manager⁠#6877](https://togithub.com/nix-community/home-manager/issues/6877))
* [`cf0c5e01`](https://github.com/nix-community/home-manager/commit/cf0c5e0105c5920f203473b571bbdc051c46995a) xdg-autostart: fix runCommandNoCCLocal deprecation ([nix-community/home-manager⁠#6880](https://togithub.com/nix-community/home-manager/issues/6880))
* [`342b3e3e`](https://github.com/nix-community/home-manager/commit/342b3e3e6df239dc972372e6a641acf052ff74aa) msmtp: rename environment variables ([nix-community/home-manager⁠#6839](https://togithub.com/nix-community/home-manager/issues/6839))
* [`b925865c`](https://github.com/nix-community/home-manager/commit/b925865c74a783c2fd42f0f340f18f2276baa316) ci: label msmtp changes with "mail" ([nix-community/home-manager⁠#6881](https://togithub.com/nix-community/home-manager/issues/6881))
* [`c9433ae6`](https://github.com/nix-community/home-manager/commit/c9433ae62fbb4bd09609e242569edc3b551e21a9) keepassxc: register as native messaging host ([nix-community/home-manager⁠#6879](https://togithub.com/nix-community/home-manager/issues/6879))
* [`6899001a`](https://github.com/nix-community/home-manager/commit/6899001a762b0e089ad7b8ec7637d0a678640b8e) fcitx5: add `themes` and `classicUiConfig` options ([nix-community/home-manager⁠#6876](https://togithub.com/nix-community/home-manager/issues/6876))
* [`b99e3e46`](https://github.com/nix-community/home-manager/commit/b99e3e46b86aefc01f229e0a29d0c03c1079aaed) ci: fixed redundant rule ([nix-community/home-manager⁠#6883](https://togithub.com/nix-community/home-manager/issues/6883))
* [`c42f04c8`](https://github.com/nix-community/home-manager/commit/c42f04c83f866e3ad7d285072b253dffdabad6fe) mkFirefoxModule: revert userChrome changes ([nix-community/home-manager⁠#6887](https://togithub.com/nix-community/home-manager/issues/6887))
* [`f1aabf1d`](https://github.com/nix-community/home-manager/commit/f1aabf1deb6981176b7608cdf67140519a3d442b) zsh: deprecate initLocation options in favor of initContent ([nix-community/home-manager⁠#6841](https://togithub.com/nix-community/home-manager/issues/6841))
* [`68bc080c`](https://github.com/nix-community/home-manager/commit/68bc080cdf00b1ec65f78c1d1e65e9828904cd22) fcitx5: refactor logic ([nix-community/home-manager⁠#6886](https://togithub.com/nix-community/home-manager/issues/6886))
* [`97a62d8e`](https://github.com/nix-community/home-manager/commit/97a62d8eef74ab06b20152be0b323292dfe03c88) tests/default: add zoxide darwin stub ([nix-community/home-manager⁠#6888](https://togithub.com/nix-community/home-manager/issues/6888))
* [`7ef31370`](https://github.com/nix-community/home-manager/commit/7ef3137035deca91854c38c114eeaf611707b005) vesktop: fix config path on darwin ([nix-community/home-manager⁠#6889](https://togithub.com/nix-community/home-manager/issues/6889))
* [`585bae4b`](https://github.com/nix-community/home-manager/commit/585bae4bbb48789ece06f4b18cb373651760c4ab) i18n.inputMethod: align enable option with nixos
* [`1d0e1390`](https://github.com/nix-community/home-manager/commit/1d0e13904bd8c444ab1595f686ede5eff377e881) i18n.inputMethod: add awwpotato as maintainer
* [`814521fd`](https://github.com/nix-community/home-manager/commit/814521fdc16813b036415edb4bb42a8733729dd5) flake.lock: Update ([nix-community/home-manager⁠#6891](https://togithub.com/nix-community/home-manager/issues/6891))
* [`b01a9411`](https://github.com/nix-community/home-manager/commit/b01a94118403af8a3ce646b3d703ba3d18bed042) tests/default: add more darwin stubs
* [`a3e713cb`](https://github.com/nix-community/home-manager/commit/a3e713cb82af628105480ae54dc7500b5ec8ebd1) tests/darwinScrublist: move darwin scrub list to new file
* [`6c132a09`](https://github.com/nix-community/home-manager/commit/6c132a098e61163fb559db986efe913acd3df4e7) tests/darwinScrublist: add more darwin stubs
* [`ff6adf83`](https://github.com/nix-community/home-manager/commit/ff6adf83b9cfdc88dc0b035a608e08d3eb674b3a) input-method: fix enable condition ([nix-community/home-manager⁠#6896](https://togithub.com/nix-community/home-manager/issues/6896))
* [`b7527e2d`](https://github.com/nix-community/home-manager/commit/b7527e2daf755437a2948f09761a8ed07debd075) vesktop: only generate settings when configured ([nix-community/home-manager⁠#6897](https://togithub.com/nix-community/home-manager/issues/6897))
* [`59de2dfb`](https://github.com/nix-community/home-manager/commit/59de2dfb0a08ebcbc73e3bb8488d2c23057e6ad8) workflows: only run conflicts and update flake on main repo ([nix-community/home-manager⁠#6893](https://togithub.com/nix-community/home-manager/issues/6893))
* [`6d1f834c`](https://github.com/nix-community/home-manager/commit/6d1f834ca63700604a96d8c38aa8ac272d95071a) fcitx5: add upstream options ([nix-community/home-manager⁠#6892](https://togithub.com/nix-community/home-manager/issues/6892))
* [`d31710fb`](https://github.com/nix-community/home-manager/commit/d31710fb2cd536b1966fee2af74e99a0816a61a8) fcitx5: fix iniFormat usage ([nix-community/home-manager⁠#6899](https://togithub.com/nix-community/home-manager/issues/6899))
* [`abfad3d2`](https://github.com/nix-community/home-manager/commit/abfad3d2958c9e6300a883bd443512c55dfeb1be) treewide: substituteAll -> replaceVars/substitute
* [`dedfde15`](https://github.com/nix-community/home-manager/commit/dedfde15f6ad102596d0a3110f9f2852063cbc35) format: Set {,XDG_CONFIG_}HOME to empty dir rather than empty string
* [`98f4fef7`](https://github.com/nix-community/home-manager/commit/98f4fef7fd7b4a77245db12e33616023162bc6d9) format: Fix failing due to no cache access
* [`54207806`](https://github.com/nix-community/home-manager/commit/542078066b1a99cdc5d5fce1365f98b847ca0b5a) wezterm: don't create config if extraConfig is empty, and don't create one by default ([nix-community/home-manager⁠#6908](https://togithub.com/nix-community/home-manager/issues/6908))
* [`4d2d3223`](https://github.com/nix-community/home-manager/commit/4d2d32231797bfa7213ae5e8ac89d25f8caaae82) thefuck: Add alias option ([nix-community/home-manager⁠#6909](https://togithub.com/nix-community/home-manager/issues/6909))
* [`2f5819a9`](https://github.com/nix-community/home-manager/commit/2f5819a962489e037a57835f63ed6ff8dbc2d5fb) onedrive: add module ([nix-community/home-manager⁠#6907](https://togithub.com/nix-community/home-manager/issues/6907))
* [`ef47f364`](https://github.com/nix-community/home-manager/commit/ef47f36450b36d437f5c2f6953022648d76c0638) flake.lock: Update ([nix-community/home-manager⁠#6912](https://togithub.com/nix-community/home-manager/issues/6912))
* [`50bb714a`](https://github.com/nix-community/home-manager/commit/50bb714a8259b0c29b6c3429099a3b837771dab4) rmpc: add module ([nix-community/home-manager⁠#6910](https://togithub.com/nix-community/home-manager/issues/6910))
* [`1d2f0b3d`](https://github.com/nix-community/home-manager/commit/1d2f0b3d4be0fed93c31d21603f988c68d5a4d16) espanso: add phanirithvij as maintainer
* [`29fce40e`](https://github.com/nix-community/home-manager/commit/29fce40e1391477b66ef3a24ea7867f0bc5b52a1) espanso: add crossplatform support
* [`6ed700bf`](https://github.com/nix-community/home-manager/commit/6ed700bfe4fe6b66a9121365056f63041b85ab3d) espanso: fix test
* [`9c3b33c2`](https://github.com/nix-community/home-manager/commit/9c3b33c2a7531cd4cbdcc5690cc0f69e93e60aa3) espanso: add wayland test
* [`0fbd8207`](https://github.com/nix-community/home-manager/commit/0fbd8207e913b2d1660a7662f9ae80e5e639de65) news: forward args to file news entries
* [`adb3fbc5`](https://github.com/nix-community/home-manager/commit/adb3fbc58455de60ad4131c6e59d596ea2bb105f) neomutt: use correct neomutt in config file ([nix-community/home-manager⁠#6915](https://togithub.com/nix-community/home-manager/issues/6915))
* [`2a264c17`](https://github.com/nix-community/home-manager/commit/2a264c17d5fb3673eeec891ea4a82027a41addc3) zsh: add type to zprof.enable option ([nix-community/home-manager⁠#6916](https://togithub.com/nix-community/home-manager/issues/6916))
* [`edaeeda2`](https://github.com/nix-community/home-manager/commit/edaeeda26429aa3d25b9119f358075813bd9d4ba) eza: default disable nushell integration again
* [`7b2aae3f`](https://github.com/nix-community/home-manager/commit/7b2aae3fb39928aecc5e41c10a9c87c4881614d5) eza: add tests
* [`9c46dc88`](https://github.com/nix-community/home-manager/commit/9c46dc881c2afcb50ac9ae9f1c36b2a4ebba3c8a) mkFirefoxModule: support wrapped darwin derivations ([nix-community/home-manager⁠#6913](https://togithub.com/nix-community/home-manager/issues/6913))
* [`cf351071`](https://github.com/nix-community/home-manager/commit/cf351071fb4aac4add29ed6a88cc75a8c2865b5e) lsd: enableAliases -> enableShellIntegration
* [`77f849c1`](https://github.com/nix-community/home-manager/commit/77f849c11458ee00dcf722ca267edefd3f51743e) lsd: refactor module
* [`be7cf170`](https://github.com/nix-community/home-manager/commit/be7cf1709b469a2a2c62169172a167d1fed3509f) lsd: add package option
* [`69c60b03`](https://github.com/nix-community/home-manager/commit/69c60b035e6bb51a4c5607f184bf64312c294139) kickoff: add module ([nix-community/home-manager⁠#6918](https://togithub.com/nix-community/home-manager/issues/6918))
* [`6f974faa`](https://github.com/nix-community/home-manager/commit/6f974faa1962e2ee081635124ab96a1bfacb2f25) gh: add `hosts` option ([nix-community/home-manager⁠#6925](https://togithub.com/nix-community/home-manager/issues/6925))
* [`c54a8ab0`](https://github.com/nix-community/home-manager/commit/c54a8ab0d2ea7486eadb14f1dc498817ff164f59) rofi: remove thiagokokada from maintainers ([nix-community/home-manager⁠#6928](https://togithub.com/nix-community/home-manager/issues/6928))
* [`d0d9d0a1`](https://github.com/nix-community/home-manager/commit/d0d9d0a1454d5a0200693570618084d80a8b336c) mpvpaper: add module ([nix-community/home-manager⁠#6926](https://togithub.com/nix-community/home-manager/issues/6926))
* [`4d2baba7`](https://github.com/nix-community/home-manager/commit/4d2baba75e9de32f6f552fe02797f46cd6f46bd9) espanso: fix alias in news ([nix-community/home-manager⁠#6931](https://togithub.com/nix-community/home-manager/issues/6931))
* [`c803a389`](https://github.com/nix-community/home-manager/commit/c803a38927b9b3b15dc83aecae27af3172be5ee2) nh: add path option for flake ([nix-community/home-manager⁠#6898](https://togithub.com/nix-community/home-manager/issues/6898))
* [`1ad12323`](https://github.com/nix-community/home-manager/commit/1ad123239957d40e11ef66c203d0a7e272eb48aa) rclone: make secret injection non-interactive ([nix-community/home-manager⁠#6919](https://togithub.com/nix-community/home-manager/issues/6919))
