### PR TITLE
niv emacs-overlay: update 3fe8f6c0 -> 438dfc04

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "3fe8f6c091e799d7a932f9447b762df7c8812619",
-        "sha256": "0cihccjd6xlsf012hfr8p1pv2dw5jbyy6cnlrd2lzygk50yhpsby",
+        "rev": "438dfc0467bb6e194f3a5e5a78ed4bac716940cf",
+        "sha256": "1caqsx0nraz0rr4h663ms8yi7yhqcf87959lq3whwsr6va1igbry",
         "type": "tarball",
-        "url": "https://github.com/nix-community/emacs-overlay/archive/3fe8f6c091e799d7a932f9447b762df7c8812619.tar.gz",
+        "url": "https://github.com/nix-community/emacs-overlay/archive/438dfc0467bb6e194f3a5e5a78ed4bac716940cf.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "fast-syntax-highlighting": {


### PR DESCRIPTION
## Changelog for emacs-overlay:
Branch: master
Commits: [nix-community/emacs-overlay@3fe8f6c0...438dfc04](https://github.com/nix-community/emacs-overlay/compare/3fe8f6c091e799d7a932f9447b762df7c8812619...438dfc0467bb6e194f3a5e5a78ed4bac716940cf)

* [`de76e72a`](https://github.com/nix-community/emacs-overlay/commit/de76e72ac45f352e52135d433e25b759e6f0908c) Updated nongnu
* [`0116ef85`](https://github.com/nix-community/emacs-overlay/commit/0116ef85eea312a054e686d50e81f849e30ab368) Updated elpa
* [`cdfc6459`](https://github.com/nix-community/emacs-overlay/commit/cdfc64596e5100a1028bd877cb10ed2e35a06782) Updated melpa
* [`546597a4`](https://github.com/nix-community/emacs-overlay/commit/546597a40c0f033b319ea9b64ff40e1aaaee2faf) Updated emacs
* [`751252c3`](https://github.com/nix-community/emacs-overlay/commit/751252c3406c870b80a958bfab637d4e47b856d1) Updated nongnu
* [`db8a2610`](https://github.com/nix-community/emacs-overlay/commit/db8a2610df1f0e87a0278991689672fa05dcd465) Updated elpa
* [`544c96b7`](https://github.com/nix-community/emacs-overlay/commit/544c96b704ea59fe3e1bd76a536758633ee96148) Updated melpa
* [`e55eb3c7`](https://github.com/nix-community/emacs-overlay/commit/e55eb3c7e5b57cbf8de23e1f720e42ccad09fcee) Updated emacs
* [`b8bab028`](https://github.com/nix-community/emacs-overlay/commit/b8bab028ca2806eadbe539b20b54bbcbaa520903) Updated flake inputs
* [`8520c52a`](https://github.com/nix-community/emacs-overlay/commit/8520c52a6a0ea9ab39f9754ae924cfa8f0b2e836) forge-llm: fix src hash
* [`b2863692`](https://github.com/nix-community/emacs-overlay/commit/b2863692cfdfa842ee357d7d93e9c781feb92dc7) Updated melpa
* [`f605d671`](https://github.com/nix-community/emacs-overlay/commit/f605d671012752f0c70648241219227e58d9eb7b) Updated nongnu
* [`fa36f304`](https://github.com/nix-community/emacs-overlay/commit/fa36f3040ca690af3fecf3e961e00bff4a8f122a) Updated elpa
* [`10d05194`](https://github.com/nix-community/emacs-overlay/commit/10d05194480b19d4cfecf920702562c778120e84) Updated melpa
* [`513da799`](https://github.com/nix-community/emacs-overlay/commit/513da799bd6dc36b9ee69db71f102257dab665e6) Updated emacs
* [`44d956da`](https://github.com/nix-community/emacs-overlay/commit/44d956daf53daacc0b1316a851189f0593c44736) Updated flake inputs
* [`6a4ee5a6`](https://github.com/nix-community/emacs-overlay/commit/6a4ee5a6397d15fe320ea15bf2cba764cdbbb884) Updated nongnu
* [`3a4cc0a6`](https://github.com/nix-community/emacs-overlay/commit/3a4cc0a640f371ddaa7b60e69e504e6187091b88) Updated elpa
* [`cb631280`](https://github.com/nix-community/emacs-overlay/commit/cb6312802128587651a0e8042021499e361a6155) Updated melpa
* [`44ee05e4`](https://github.com/nix-community/emacs-overlay/commit/44ee05e41df82bdc7e38186c4b9a740f84ef48c3) Updated emacs
* [`eb18749a`](https://github.com/nix-community/emacs-overlay/commit/eb18749a2f536373ea5199cb753f3823d6afd3ac) Updated melpa
* [`4f1f635f`](https://github.com/nix-community/emacs-overlay/commit/4f1f635f5ae1bc6a77ae7ca20a2699439dd53647) Updated emacs
* [`5aa617f5`](https://github.com/nix-community/emacs-overlay/commit/5aa617f590dfbfb75f1376584d6a12c15686886f) Updated nongnu
* [`d429b29a`](https://github.com/nix-community/emacs-overlay/commit/d429b29afa9a398d772ea22fb9901bbfbdb5b0ad) Updated melpa
* [`8c76e579`](https://github.com/nix-community/emacs-overlay/commit/8c76e5792ef50a67e89ad54e792769f89d721f4a) Updated emacs
* [`6c597cc8`](https://github.com/nix-community/emacs-overlay/commit/6c597cc80d8b7b4cc8f79cd9b7d0d47dc79224d1) Updated nongnu
* [`627f992f`](https://github.com/nix-community/emacs-overlay/commit/627f992f371222ccb22b3d720f1eb2d26f8014d1) Updated elpa
* [`ca0909ad`](https://github.com/nix-community/emacs-overlay/commit/ca0909ad6913fa60159446f302c87761e929dff6) Updated melpa
* [`a0b56b9a`](https://github.com/nix-community/emacs-overlay/commit/a0b56b9a497cf5e329f88cd58aca7e88cafee005) Updated emacs
* [`7a007e60`](https://github.com/nix-community/emacs-overlay/commit/7a007e60b93c041c6474a12e7edd25872fc51997) Updated melpa
* [`58615b78`](https://github.com/nix-community/emacs-overlay/commit/58615b780b5944683045d00cd204feefefc43c58) Updated emacs
* [`441e7ba4`](https://github.com/nix-community/emacs-overlay/commit/441e7ba4e4a128422b85039fe6b9662b259ba5eb) Updated nongnu
* [`75050b55`](https://github.com/nix-community/emacs-overlay/commit/75050b559c1b712bd7e8115c7654cf3f5645171a) Updated flake inputs
* [`774e7e2f`](https://github.com/nix-community/emacs-overlay/commit/774e7e2fa3716f2e9226e1aa73b6c8732846c0dd) Updated elpa
* [`ae570549`](https://github.com/nix-community/emacs-overlay/commit/ae5705497f7b49bf69fac2018c211e6924abcfb4) Updated melpa
* [`c26fc034`](https://github.com/nix-community/emacs-overlay/commit/c26fc03462cd33ad9e58f54a8f4e24c322243400) Updated emacs
* [`8f0d46ac`](https://github.com/nix-community/emacs-overlay/commit/8f0d46ac030b6e9235ed54404e799a9eed2c2d13) Updated melpa
* [`f529d875`](https://github.com/nix-community/emacs-overlay/commit/f529d87520a4ca4083b94c28a47b33b3d9593669) Updated emacs
* [`8eb8960e`](https://github.com/nix-community/emacs-overlay/commit/8eb8960e3aabf5486534c7ffad38504c53bf8d66) Updated elpa
* [`b247d679`](https://github.com/nix-community/emacs-overlay/commit/b247d679cea76b98f9c45dd4b04ef2ec0d1ecfc9) Updated melpa
* [`761195be`](https://github.com/nix-community/emacs-overlay/commit/761195be1ba33f90242eb52d7be277252c459e38) Updated emacs
* [`9c1eefd3`](https://github.com/nix-community/emacs-overlay/commit/9c1eefd3f24fcf3752cb8b4e6156f2225136d3d2) Updated flake inputs
* [`12e0fdc7`](https://github.com/nix-community/emacs-overlay/commit/12e0fdc7939a48266277beea0903b87ae5ca0cec) Updated nongnu
* [`baba5a0b`](https://github.com/nix-community/emacs-overlay/commit/baba5a0bbe1a45a2fb8c7e37a646667f01a9aea5) Updated elpa
* [`7ba17c75`](https://github.com/nix-community/emacs-overlay/commit/7ba17c75e171caea0baa7a6d43c4216553b3a4d5) Updated melpa
* [`34ec7c1b`](https://github.com/nix-community/emacs-overlay/commit/34ec7c1b36a27952a0c9610f6a701efd8a7324dc) Updated emacs
* [`9f6c0252`](https://github.com/nix-community/emacs-overlay/commit/9f6c02523e4d5e722152b5324b225de24453b4f0) Updated melpa
* [`3fb12f3a`](https://github.com/nix-community/emacs-overlay/commit/3fb12f3aacdc18ee1f455cca300c33d5f20de175) Updated emacs
* [`336b7bbf`](https://github.com/nix-community/emacs-overlay/commit/336b7bbf8ceecbc67e0f104324b3ecf9661a27e6) Updated flake inputs
* [`6b258d37`](https://github.com/nix-community/emacs-overlay/commit/6b258d37244fe9eeb7aacac961df03b407ff1dba) Updated nongnu
* [`985e403c`](https://github.com/nix-community/emacs-overlay/commit/985e403c76691e625df5f66a6d57ffd0e66bf88a) Updated elpa
* [`59951191`](https://github.com/nix-community/emacs-overlay/commit/599511911cff75a453ff1894256b3135c7a9d51e) Updated melpa
* [`c7e8e7be`](https://github.com/nix-community/emacs-overlay/commit/c7e8e7beb913fcdde90239c009bf3f7c21a3fdda) Updated emacs
* [`2cc68dac`](https://github.com/nix-community/emacs-overlay/commit/2cc68dac4e32d102c583502ffa84e4731a8f712b) Updated nongnu
* [`6e7df2e8`](https://github.com/nix-community/emacs-overlay/commit/6e7df2e86c47c815dd6c09ffa280c2991f270a9f) Updated elpa
* [`ac8af15c`](https://github.com/nix-community/emacs-overlay/commit/ac8af15c5f586879c08cd257b69749f791d94e68) Updated melpa
* [`00b6ee68`](https://github.com/nix-community/emacs-overlay/commit/00b6ee68e9fef7cce2a827f248ab935bca5eca6e) Updated melpa
* [`0e8ebcd5`](https://github.com/nix-community/emacs-overlay/commit/0e8ebcd53894f053d5a08b057741191850995983) Updated emacs
* [`3602ed70`](https://github.com/nix-community/emacs-overlay/commit/3602ed70285b776c525512c345ac29c4b689eaee) Updated flake inputs
* [`2b322396`](https://github.com/nix-community/emacs-overlay/commit/2b32239699f4fcf0ae390cb4d1059ef9a59291c5) Updated nongnu
* [`2ebddbab`](https://github.com/nix-community/emacs-overlay/commit/2ebddbabd7428499640618e6f6942542e5c13185) Updated elpa
* [`9e1692ee`](https://github.com/nix-community/emacs-overlay/commit/9e1692ee163411c9d8b44b23ff92b3aee18bff8a) Updated melpa
* [`affd3c65`](https://github.com/nix-community/emacs-overlay/commit/affd3c65261ebefc1d78a9d8fe16bb0dbce310f1) Updated emacs
* [`8717bed0`](https://github.com/nix-community/emacs-overlay/commit/8717bed057a7955dd95b5532d01314b2772af1f9) Updated melpa
* [`1a0e36d7`](https://github.com/nix-community/emacs-overlay/commit/1a0e36d797582e1a3fc82a36f151ef3d9409fd3c) Updated elpa
* [`bfa6ce27`](https://github.com/nix-community/emacs-overlay/commit/bfa6ce27bfad29111f7316113a64c9eae274387b) Updated elpa
* [`cc0f5cf8`](https://github.com/nix-community/emacs-overlay/commit/cc0f5cf82032d73a788830d5c1e922ee7d626176) Updated melpa
* [`757b6e91`](https://github.com/nix-community/emacs-overlay/commit/757b6e91336f3005527b4648c830cf0de121499b) Updated emacs
* [`ea0057e1`](https://github.com/nix-community/emacs-overlay/commit/ea0057e19e72b4f6005270e82198a23257bd13d0) Updated flake inputs
* [`1c4b6c99`](https://github.com/nix-community/emacs-overlay/commit/1c4b6c990807e89ba5e810eb5313416214110c3c) Updated melpa
* [`be94a29e`](https://github.com/nix-community/emacs-overlay/commit/be94a29ebf72beea675f3d80606f1ad6eb046b76) Updated emacs
* [`b90c535b`](https://github.com/nix-community/emacs-overlay/commit/b90c535b214a74c5ce74c1d28050f556244a944d) Updated nongnu
* [`162b4ed9`](https://github.com/nix-community/emacs-overlay/commit/162b4ed9b15ca18db5979096f9bce23b2f5c146d) Updated elpa
* [`8d01f801`](https://github.com/nix-community/emacs-overlay/commit/8d01f801846716f6ec32547c32d3f09a31ef3f05) Updated melpa
* [`dc0ad90f`](https://github.com/nix-community/emacs-overlay/commit/dc0ad90f083fee12c5b9f3ae6b3cbfc01f011264) Updated flake inputs
* [`1dc8f505`](https://github.com/nix-community/emacs-overlay/commit/1dc8f5052510c3f1cd8ef3517a24de670c3f6682) Updated elpa
* [`b6b3b866`](https://github.com/nix-community/emacs-overlay/commit/b6b3b866d7269dd0129270222231d97619a6bcc3) Updated melpa
* [`8b3ca61c`](https://github.com/nix-community/emacs-overlay/commit/8b3ca61c2811c31d90ab8d6b1b30bcd83a8be483) Updated emacs
* [`c4861650`](https://github.com/nix-community/emacs-overlay/commit/c48616503e63e2f98ab18aff257e4f5a19088a9c) Updated melpa
* [`be75f7ec`](https://github.com/nix-community/emacs-overlay/commit/be75f7ec9e7d6eee5a0f98b702716b3d55e7a8a7) Updated emacs
* [`a58c0013`](https://github.com/nix-community/emacs-overlay/commit/a58c00135108be1d6bdfbe4bcd15baae7f4b0e2e) Updated nongnu
* [`aeb20cfd`](https://github.com/nix-community/emacs-overlay/commit/aeb20cfd71e98867c7416a1959d8c426f7b65791) Updated elpa
* [`f16aec4d`](https://github.com/nix-community/emacs-overlay/commit/f16aec4d9c9608ba3084ae402eb20760abfee8fb) Updated melpa
* [`e41a1c92`](https://github.com/nix-community/emacs-overlay/commit/e41a1c92e062d5ef07c58b5d781d46d3921d9b13) Updated emacs
* [`8ae077c2`](https://github.com/nix-community/emacs-overlay/commit/8ae077c2e3ebe723028e0b9e7029604df8795e19) Updated nongnu
* [`a084beaf`](https://github.com/nix-community/emacs-overlay/commit/a084beaf62e48727f0a99734864c043ac5265aa7) Updated elpa
* [`d7d05ef6`](https://github.com/nix-community/emacs-overlay/commit/d7d05ef6bccf1f6256617ef65fc44bc76c271d71) Updated melpa
* [`8aa1c071`](https://github.com/nix-community/emacs-overlay/commit/8aa1c071bbcb8a270bb841e4797a0d14528709d4) Updated emacs
* [`57fbca38`](https://github.com/nix-community/emacs-overlay/commit/57fbca3813e60c0a6a69a5a874ab8293895941cc) Updated melpa
* [`63490862`](https://github.com/nix-community/emacs-overlay/commit/6349086278c4a5ecc1bb93286edfe9b618685c2d) Updated emacs
* [`56acf060`](https://github.com/nix-community/emacs-overlay/commit/56acf06006e4e5dd451398f2a35ce00b156c1434) Updated flake inputs
* [`1f2952c4`](https://github.com/nix-community/emacs-overlay/commit/1f2952c45202c860601b1ce1c54e1b5dba880c7c) Updated nongnu
* [`566511cb`](https://github.com/nix-community/emacs-overlay/commit/566511cb2be359ac3744061ea3bf71a34d6361c1) Updated elpa
* [`b7b033ae`](https://github.com/nix-community/emacs-overlay/commit/b7b033aeb63bf3f39d928198abc88e1aba7f1974) Updated melpa
* [`2d35141c`](https://github.com/nix-community/emacs-overlay/commit/2d35141c7cfac4d784498427f3ad6f28bf980c3d) Updated emacs
* [`0b6f1ff4`](https://github.com/nix-community/emacs-overlay/commit/0b6f1ff4327d6af1eed0fc8d2d4bc4b559f7b1f4) Updated nongnu
* [`260c8c09`](https://github.com/nix-community/emacs-overlay/commit/260c8c09409bd89f3e530267c7a9fadac11824f2) Updated elpa
* [`56cd7f22`](https://github.com/nix-community/emacs-overlay/commit/56cd7f22729aa95a08097028df1c871622a20bf7) Updated melpa
* [`97d803e4`](https://github.com/nix-community/emacs-overlay/commit/97d803e417dbf766b2ada1b7f971d6b45961d0a3) Updated emacs
* [`84dd46a4`](https://github.com/nix-community/emacs-overlay/commit/84dd46a42402cb530154ece11210b73f8573f06c) Updated melpa
* [`ff148db0`](https://github.com/nix-community/emacs-overlay/commit/ff148db04653261fa37c10816b293e43efac3cfb) Updated emacs
* [`bfbb1016`](https://github.com/nix-community/emacs-overlay/commit/bfbb101605cfb53ba1632bdfb9ff3636bd779be9) Updated nongnu
* [`1fc1a56e`](https://github.com/nix-community/emacs-overlay/commit/1fc1a56e3a6e56ef992f9d3097ba5d39830c7b7d) Updated elpa
* [`51e71e8f`](https://github.com/nix-community/emacs-overlay/commit/51e71e8f04f66d487cd5953949dc583fb731823d) Updated melpa
* [`ff930b5e`](https://github.com/nix-community/emacs-overlay/commit/ff930b5e806d659480b70f6ac3b2ba7efb346682) Updated emacs
* [`5494c453`](https://github.com/nix-community/emacs-overlay/commit/5494c453843359d4b03ace92e06cbf8143ef62b0) Updated flake inputs
* [`400ba5d0`](https://github.com/nix-community/emacs-overlay/commit/400ba5d0c6c93ee4a86ff70cfbb400db05c37769) Updated nongnu
* [`402c7f07`](https://github.com/nix-community/emacs-overlay/commit/402c7f0793b4356de1d737fcfea820c97974462e) Updated elpa
* [`e3e42579`](https://github.com/nix-community/emacs-overlay/commit/e3e425798c8583e5d1e33cf3e9ac5df9506baea2) Updated melpa
* [`147f6b98`](https://github.com/nix-community/emacs-overlay/commit/147f6b98f17b0d66866eb8923a6ae6fe9c23b65e) Updated emacs
* [`9d6881c3`](https://github.com/nix-community/emacs-overlay/commit/9d6881c300b811da2241d147ae622efbf429e464) Updated flake inputs
* [`56ea16bb`](https://github.com/nix-community/emacs-overlay/commit/56ea16bbc5ca66565cdce7a2cfcf19e9c0175cc8) Updated nongnu
* [`23e3e143`](https://github.com/nix-community/emacs-overlay/commit/23e3e143f8a550b9dbd4bc5660126aaa082d26d9) Updated elpa
* [`60218c88`](https://github.com/nix-community/emacs-overlay/commit/60218c88d2d3a176304d1f518c20dd0493c37d88) Updated melpa
* [`1997c83d`](https://github.com/nix-community/emacs-overlay/commit/1997c83d637f2ab52651826d90099e1e1561bab7) Updated emacs
* [`198f22dd`](https://github.com/nix-community/emacs-overlay/commit/198f22ddc21c0254f8c89485874398c086b1ae5a) Updated nongnu
* [`3f0ea006`](https://github.com/nix-community/emacs-overlay/commit/3f0ea0069dc9c68f13ca2e393b42aabc29c825df) Updated elpa
* [`59321a67`](https://github.com/nix-community/emacs-overlay/commit/59321a67a04cb7f5e23bd45b8b2933c9579347ed) Updated melpa
* [`346003c5`](https://github.com/nix-community/emacs-overlay/commit/346003c50ebfa5597c5e08b17c6683b83ff9cffa) Updated emacs
* [`3253a4b2`](https://github.com/nix-community/emacs-overlay/commit/3253a4b2cfcfad6810746f5c62d0e6bf53ba97a9) Updated melpa
* [`43c27c8f`](https://github.com/nix-community/emacs-overlay/commit/43c27c8fc1544cecd001b7174f91a9f1e9ebdab9) Updated nongnu
* [`f6ea355d`](https://github.com/nix-community/emacs-overlay/commit/f6ea355d7b9818394bb9e073b2bdad4b0d1717be) Updated elpa
* [`71a0b92e`](https://github.com/nix-community/emacs-overlay/commit/71a0b92e70f73f0b41624e52120fc79d52595ca5) Updated nongnu
* [`a4216bb0`](https://github.com/nix-community/emacs-overlay/commit/a4216bb03c069faf34c355b6c915c93a2eeb559e) Updated elpa
* [`4f4a9b3e`](https://github.com/nix-community/emacs-overlay/commit/4f4a9b3e83a234235976191ad2ac76c91add9c1a) Updated melpa
* [`d601c3de`](https://github.com/nix-community/emacs-overlay/commit/d601c3de7e1932384a43585408a398ddccf3e1c6) Updated emacs
* [`54536e8f`](https://github.com/nix-community/emacs-overlay/commit/54536e8fc37931d76c0a02164986db9383d71c9e) Updated melpa
* [`cc39626b`](https://github.com/nix-community/emacs-overlay/commit/cc39626b787d64e5df5364a529423d624543b6a6) Updated emacs
* [`30d14807`](https://github.com/nix-community/emacs-overlay/commit/30d14807368f822be183ecb2197e274ee512dc3a) Updated nongnu
* [`2657fe95`](https://github.com/nix-community/emacs-overlay/commit/2657fe95abbb3eca5207df6fb82e6522643c7fea) Updated melpa
* [`097bb237`](https://github.com/nix-community/emacs-overlay/commit/097bb2373e84a4c544754bb09d0742f0362818dd) Updated emacs
* [`37229afc`](https://github.com/nix-community/emacs-overlay/commit/37229afc3e39b05b565053cded360e8e421ae371) forge-llm: fix src hash
* [`f37681b8`](https://github.com/nix-community/emacs-overlay/commit/f37681b88e68d622af06a3ed126d4cbdc82080cb) Updated nongnu
* [`5dcf49dc`](https://github.com/nix-community/emacs-overlay/commit/5dcf49dc761020e101be476cd1d8c9584b90cc44) Updated elpa
* [`4c314977`](https://github.com/nix-community/emacs-overlay/commit/4c314977d36fad8db0d596959c13c17401e62a21) Updated melpa
* [`3b51e6be`](https://github.com/nix-community/emacs-overlay/commit/3b51e6be2d706273cfd58cf060a74ef7a89fea47) Updated emacs
* [`0a61d7a5`](https://github.com/nix-community/emacs-overlay/commit/0a61d7a5c08530cb0f43350a3487681bb82aba1c) Updated melpa
* [`bb1a2819`](https://github.com/nix-community/emacs-overlay/commit/bb1a28197681dc640b89a9a9bec75cdcd7e8d6ec) Updated emacs
* [`99928599`](https://github.com/nix-community/emacs-overlay/commit/99928599699bfcdfb401c5e34ca2a90b7d78704d) Updated nongnu
* [`a2a1ef5a`](https://github.com/nix-community/emacs-overlay/commit/a2a1ef5a9ada7ec05796c07094aef032e9ac3c87) Updated elpa
* [`c9f0db33`](https://github.com/nix-community/emacs-overlay/commit/c9f0db33baed9d70822483a9e7efd8048a748756) Updated melpa
* [`896bc4ee`](https://github.com/nix-community/emacs-overlay/commit/896bc4ee7494db74a921559c2fc2771789f9296b) Updated emacs
* [`ecd7a457`](https://github.com/nix-community/emacs-overlay/commit/ecd7a457955429c08826e1582565f401e7ef823f) Updated nongnu
* [`58b60b8e`](https://github.com/nix-community/emacs-overlay/commit/58b60b8e735b8b4285657dce8f1dce1781a041de) Updated elpa
* [`6e7999fb`](https://github.com/nix-community/emacs-overlay/commit/6e7999fb70859ac71f7931f303b73720451ac7e9) Updated melpa
* [`fc950eda`](https://github.com/nix-community/emacs-overlay/commit/fc950eda6b8a2b0b1e2085317a3185a96cbf1ba6) Updated emacs
* [`267181fa`](https://github.com/nix-community/emacs-overlay/commit/267181fa5b73ab1fedfafef6f8031c4563c510e6) Updated melpa
* [`c54fd7dc`](https://github.com/nix-community/emacs-overlay/commit/c54fd7dc3e696136c8257abfe12815274b42660e) Updated emacs
* [`e8c9077c`](https://github.com/nix-community/emacs-overlay/commit/e8c9077c469bd6810371c873d80225d46b3135cd) Updated flake inputs
* [`90642af1`](https://github.com/nix-community/emacs-overlay/commit/90642af1fb7ab5e4c6deb221305acf6fc4472582) Updated nongnu
* [`b7e6cde5`](https://github.com/nix-community/emacs-overlay/commit/b7e6cde5ae589cedb0be5f2bcfbb8b799736a481) Updated nongnu
* [`112e4f32`](https://github.com/nix-community/emacs-overlay/commit/112e4f326dbd814cbd78a7997ee6cdb24420eed1) Updated elpa
* [`a291d1e4`](https://github.com/nix-community/emacs-overlay/commit/a291d1e4578d24def7c194d7db89807eed1ed4ae) Updated melpa
* [`7d65488e`](https://github.com/nix-community/emacs-overlay/commit/7d65488eb308352f94c7bab3d55289b23cc2a391) Updated emacs
* [`37c7ddf1`](https://github.com/nix-community/emacs-overlay/commit/37c7ddf183243a8f95db9ff76c53f42477c1c3cd) Updated melpa
* [`ebc08516`](https://github.com/nix-community/emacs-overlay/commit/ebc085160ae5154d0f97accc6f5972e434c2ef9b) Updated emacs
* [`d0ed4d1c`](https://github.com/nix-community/emacs-overlay/commit/d0ed4d1c1128a1e395d6d2d24e848654809a211b) Updated nongnu
* [`d7a385f9`](https://github.com/nix-community/emacs-overlay/commit/d7a385f9569138aab03f3f62564bfeb574ea5281) Updated melpa
* [`46b2111a`](https://github.com/nix-community/emacs-overlay/commit/46b2111a95afe41d9f9a09d7f33ff5b324cbd96d) Updated emacs
* [`eaea0ec5`](https://github.com/nix-community/emacs-overlay/commit/eaea0ec58d1c09478cdd59f810e627bd73f49f46) Updated nongnu
* [`690c4bb1`](https://github.com/nix-community/emacs-overlay/commit/690c4bb1fb83b0ffd8d6c662b8824a6e9fe77092) Updated elpa
* [`82c46e0e`](https://github.com/nix-community/emacs-overlay/commit/82c46e0e82832ff51cf0772417b37d008fccb4e2) Updated melpa
* [`96632d4a`](https://github.com/nix-community/emacs-overlay/commit/96632d4afa0ac7c9367101e428faba22f2b640f5) Updated melpa
* [`e1d2be27`](https://github.com/nix-community/emacs-overlay/commit/e1d2be273b54b677cc5179e2c068127bff035c98) Updated emacs
* [`07fc4caa`](https://github.com/nix-community/emacs-overlay/commit/07fc4caaef2dcd9a8526ad6da384d23c9c708de0) Updated nongnu
* [`960b0a20`](https://github.com/nix-community/emacs-overlay/commit/960b0a206a243016bc4372e4bb27ad03188cbc61) Updated elpa
* [`e6f04b11`](https://github.com/nix-community/emacs-overlay/commit/e6f04b118076626a54cb97719b1dc12e5d36b768) Updated melpa
* [`d2422478`](https://github.com/nix-community/emacs-overlay/commit/d24224780e6cb41af7b46a17d39306e5e982aa15) Updated emacs
* [`02301397`](https://github.com/nix-community/emacs-overlay/commit/02301397cb4539ab09da12b3214641f7bed59076) Updated nongnu
* [`8218d67d`](https://github.com/nix-community/emacs-overlay/commit/8218d67d1cd6f8a546cd55e6890fc8dfce364dff) Updated elpa
* [`f0596882`](https://github.com/nix-community/emacs-overlay/commit/f05968823bb35d2559618bb5023dcc9c139bd302) Updated melpa
* [`bb9c4990`](https://github.com/nix-community/emacs-overlay/commit/bb9c49904ec77db95ed5c1a1f1cf60911841559c) Updated emacs
* [`6e665457`](https://github.com/nix-community/emacs-overlay/commit/6e66545784d54c078ea464ff7f3b94c8cf3d3f69) Updated melpa
* [`1b9c9238`](https://github.com/nix-community/emacs-overlay/commit/1b9c9238adead881769a70346f9f17207dbcea13) Updated emacs
* [`99a01c9e`](https://github.com/nix-community/emacs-overlay/commit/99a01c9e200ffa1898097865e71a9e8182428de5) Updated nongnu
* [`421149e3`](https://github.com/nix-community/emacs-overlay/commit/421149e3c9f3b39c3c7a13a9cb53748510647042) Updated nongnu
* [`1ba73bfa`](https://github.com/nix-community/emacs-overlay/commit/1ba73bfaabf674905e715ccd74515eaf2977b19f) Updated elpa
* [`490492d7`](https://github.com/nix-community/emacs-overlay/commit/490492d7421c9e903a9874414fd6c05484a9ec2a) Updated melpa
* [`bf179134`](https://github.com/nix-community/emacs-overlay/commit/bf17913474d4ff3305a0551f74ed806dae926ac1) Updated emacs
* [`7d873a92`](https://github.com/nix-community/emacs-overlay/commit/7d873a92ac91f1d13685d59c31ac73fc032efa06) Updated elpa
* [`42cab8f8`](https://github.com/nix-community/emacs-overlay/commit/42cab8f8710af3cdafd47ddaec571dc5bb4cf86a) Updated melpa
* [`029d994c`](https://github.com/nix-community/emacs-overlay/commit/029d994c584161072f221206b52411dd6c3df227) Updated emacs
* [`07106a1d`](https://github.com/nix-community/emacs-overlay/commit/07106a1db062249293fe32fc6588b54bdba43f06) Updated flake inputs
* [`a300cb5c`](https://github.com/nix-community/emacs-overlay/commit/a300cb5cdcc4c80fe07e900976e00c6eb5553cd4) Updated flake inputs
* [`4f1f718d`](https://github.com/nix-community/emacs-overlay/commit/4f1f718d24f7474d1f8ba7489ac7b8fcf2f2d8de) Updated nongnu
* [`e25b2005`](https://github.com/nix-community/emacs-overlay/commit/e25b20056312115f598bd67426c5cda620456800) Updated elpa
* [`334c3a55`](https://github.com/nix-community/emacs-overlay/commit/334c3a55dca157d123389ff2b8f1dfb16173054b) Updated melpa
* [`d8bad40d`](https://github.com/nix-community/emacs-overlay/commit/d8bad40da349c15b37f83159019a5e7f452cecc6) Updated emacs
* [`838172ec`](https://github.com/nix-community/emacs-overlay/commit/838172ec5a825686cc79ac6cdb21a77c8d9e08f4) Updated nongnu
* [`41785dbb`](https://github.com/nix-community/emacs-overlay/commit/41785dbbb27b5cee0e7c3349400424e4c74b5319) Updated elpa
* [`d9570f37`](https://github.com/nix-community/emacs-overlay/commit/d9570f37d337059cf11c89cc7b461649da509d36) Updated melpa
* [`6f915e3d`](https://github.com/nix-community/emacs-overlay/commit/6f915e3dd23b65dd5b1a9d86e171ceb702282680) Updated emacs
* [`1bb2aec5`](https://github.com/nix-community/emacs-overlay/commit/1bb2aec516a656432d2b53952caff1af365ff4d0) Updated nongnu
* [`3da37baf`](https://github.com/nix-community/emacs-overlay/commit/3da37baf004d3ecbc5c9ef131c27db837ae00a78) Updated elpa
* [`71cb11e4`](https://github.com/nix-community/emacs-overlay/commit/71cb11e48cb83264f86c2cee0b689900df989067) Updated melpa
* [`5131ae06`](https://github.com/nix-community/emacs-overlay/commit/5131ae065291256d4af83be7eda7fcb9196815c3) Updated emacs
* [`acf94b5d`](https://github.com/nix-community/emacs-overlay/commit/acf94b5dd33ce8e3fb995421cd1a719bb0d9c804) Updated flake inputs
* [`fe215e4a`](https://github.com/nix-community/emacs-overlay/commit/fe215e4a5b487ebfe2bd04e10cb2c303c710b4b6) Updated nongnu
* [`2e939b25`](https://github.com/nix-community/emacs-overlay/commit/2e939b25ef18fd3efbd60829fc7f87c8235cdd40) Updated elpa
* [`7d75d84a`](https://github.com/nix-community/emacs-overlay/commit/7d75d84a8d5db4ecd5ce03be713e717b5fa2079c) Updated flake inputs
* [`d57dbbd3`](https://github.com/nix-community/emacs-overlay/commit/d57dbbd3bd341f2fc0aefb8852ff965cc2c7081d) Updated nongnu
* [`7091cf72`](https://github.com/nix-community/emacs-overlay/commit/7091cf72a7ee24a87490873e91d7652f37d79fe1) Updated elpa
* [`4b4a9f8f`](https://github.com/nix-community/emacs-overlay/commit/4b4a9f8f4984809d8eec285f8232eb47eebc1de1) Updated melpa
* [`7e630e5c`](https://github.com/nix-community/emacs-overlay/commit/7e630e5c5e5b860f89d05a64129e51f342766b70) Updated emacs
* [`9232d20a`](https://github.com/nix-community/emacs-overlay/commit/9232d20ad5eb26fc56f16bdb5d4dca44ad74a1d4) Updated nongnu
* [`50a91ffb`](https://github.com/nix-community/emacs-overlay/commit/50a91ffb312baae05113117481c501b1e124101b) Updated nongnu
* [`c13007bb`](https://github.com/nix-community/emacs-overlay/commit/c13007bb88589447401b3bef2b78341cfa8f8e36) Updated elpa
* [`d1dd13f6`](https://github.com/nix-community/emacs-overlay/commit/d1dd13f60fec1cad758de09792f7efddad4ae05e) Updated melpa
* [`4bd92848`](https://github.com/nix-community/emacs-overlay/commit/4bd928487268eeb51c5f522c8b8866afb8e376c8) Updated emacs
* [`dbc579e0`](https://github.com/nix-community/emacs-overlay/commit/dbc579e088c6f297995073d964fb8eaf2eb78524) Updated flake inputs
* [`01d8fde1`](https://github.com/nix-community/emacs-overlay/commit/01d8fde195d65f63ba7135dd7a6b638ac12539a3) Updated melpa
* [`9b045c00`](https://github.com/nix-community/emacs-overlay/commit/9b045c0040bb1799f62c1d2a31b54764c70102e0) Updated emacs
* [`c9da69ce`](https://github.com/nix-community/emacs-overlay/commit/c9da69cefa46d4dc8a9dce3f54fa012132e2dcd4) Updated nongnu
* [`6ffae7f5`](https://github.com/nix-community/emacs-overlay/commit/6ffae7f578f152c5b3d63861565c53482fadb241) Updated elpa
* [`ba23aed6`](https://github.com/nix-community/emacs-overlay/commit/ba23aed65e7027566fbc3fd11384aa79157480ee) Updated melpa
* [`5f11758c`](https://github.com/nix-community/emacs-overlay/commit/5f11758ce78b3267b9658dec65fbc1a39a94abd9) Updated emacs
* [`41562988`](https://github.com/nix-community/emacs-overlay/commit/41562988dc594df649380875b0f098342b00817c) Updated nongnu
* [`afe4de20`](https://github.com/nix-community/emacs-overlay/commit/afe4de20891541dd67274ad65e7cce7f2a16cbc6) Updated elpa
* [`da7fe3b1`](https://github.com/nix-community/emacs-overlay/commit/da7fe3b169a6e35d1dbf5bd2e7af9c223023739f) Updated melpa
* [`24a3e2b6`](https://github.com/nix-community/emacs-overlay/commit/24a3e2b6b0dda50c1afaa3da730f156d0400e95a) Updated emacs
* [`2a6d6d06`](https://github.com/nix-community/emacs-overlay/commit/2a6d6d064e33d65dc660b65c28ce17195e539db6) Updated flake inputs
* [`15e5b1c9`](https://github.com/nix-community/emacs-overlay/commit/15e5b1c90f999c69ab1709a4bb653f852256f32b) Updated nongnu
* [`c8327eab`](https://github.com/nix-community/emacs-overlay/commit/c8327eab84622ee300ca60f7cedb013e8540770a) Updated elpa
* [`74c6e173`](https://github.com/nix-community/emacs-overlay/commit/74c6e1737e1a8bce8aacbea490bef6cdca6b270d) Updated nongnu
* [`fec2a9e0`](https://github.com/nix-community/emacs-overlay/commit/fec2a9e0f550f5687d2e48f77f30ee32f211f85b) Updated elpa
* [`43f387b9`](https://github.com/nix-community/emacs-overlay/commit/43f387b97b21770d8dbf7e575cc93792d9e5dde9) Updated melpa
* [`2b5aba73`](https://github.com/nix-community/emacs-overlay/commit/2b5aba7380821a8be1bb3291083af4431cbf3dd5) Updated emacs
* [`05af93bd`](https://github.com/nix-community/emacs-overlay/commit/05af93bd5e29158d58fe39d6f9d0763b1d3de668) Updated flake inputs
* [`839bdeb0`](https://github.com/nix-community/emacs-overlay/commit/839bdeb05c9f17fe977adcf2b14aeb3a89375527) Updated melpa
* [`841c18a6`](https://github.com/nix-community/emacs-overlay/commit/841c18a6fe787b669ea362e3e14f54a5bd12a63c) Updated emacs
* [`2da7c494`](https://github.com/nix-community/emacs-overlay/commit/2da7c494c2ab4aae052dcf565c2281640945cfd0) Updated flake inputs
* [`22aa1dc5`](https://github.com/nix-community/emacs-overlay/commit/22aa1dc560e6d394a9fa89445b6c45a212a2c861) Updated elpa
* [`54497d5d`](https://github.com/nix-community/emacs-overlay/commit/54497d5d2379fa5c034e0245462f89308d054506) Updated melpa
* [`d6a9fa08`](https://github.com/nix-community/emacs-overlay/commit/d6a9fa089a3442f1fb2d98b4e4dd6f847b7b5964) Updated emacs
* [`189fb62b`](https://github.com/nix-community/emacs-overlay/commit/189fb62b68ceed28bc0a0377fbf1d5c0cb01ed9e) Updated flake inputs
* [`6dd719a1`](https://github.com/nix-community/emacs-overlay/commit/6dd719a1921c83216d9eec2649dadf3d4d188581) Updated nongnu
* [`ed0cacc0`](https://github.com/nix-community/emacs-overlay/commit/ed0cacc0f692ae3fd7dd6f34d9f2c0086c0ad6f6) Updated elpa
* [`39c9dad7`](https://github.com/nix-community/emacs-overlay/commit/39c9dad7207be7ebc450eb4bc03af19ce325327e) Updated melpa
* [`8f3e60a5`](https://github.com/nix-community/emacs-overlay/commit/8f3e60a5d3c89eba0df8ae395556132bac13533d) Updated emacs
* [`769f426e`](https://github.com/nix-community/emacs-overlay/commit/769f426eb3f6bc6d26f03106ac5772b98595a7b8) Updated flake inputs
* [`2d7c5757`](https://github.com/nix-community/emacs-overlay/commit/2d7c5757ecdf4850fb012faba35539415cf81687) Updated nongnu
* [`e9b0301e`](https://github.com/nix-community/emacs-overlay/commit/e9b0301e96c5893c5b235af960e9e06f4b62d2ff) Updated elpa
* [`57654843`](https://github.com/nix-community/emacs-overlay/commit/57654843b2641cb1091eeaf64bd2d506d1d2edbd) Updated melpa
* [`438dfc04`](https://github.com/nix-community/emacs-overlay/commit/438dfc0467bb6e194f3a5e5a78ed4bac716940cf) Updated emacs
