### PR TITLE
niv doomemacs: update fc7b179e -> ca7e226e

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "doomemacs",
         "repo": "doomemacs",
-        "rev": "fc7b179e6cefa59097c87fd58c8272b6121a1dff",
-        "sha256": "11cqkzb15js9byppagnnprrr7452gxsvadx88njaxxjyj147j86w",
+        "rev": "ca7e226e1305ed7f10762315ad48f19c330cdd72",
+        "sha256": "077h3cyn53ylm4w7ap2k9jdqd9wsi1nidf26h99pwdmc3yz4f4r4",
         "type": "tarball",
-        "url": "https://github.com/doomemacs/doomemacs/archive/fc7b179e6cefa59097c87fd58c8272b6121a1dff.tar.gz",
+        "url": "https://github.com/doomemacs/doomemacs/archive/ca7e226e1305ed7f10762315ad48f19c330cdd72.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "emacs-overlay": {


### PR DESCRIPTION
## Changelog for doomemacs:
Branch: master
Commits: [doomemacs/doomemacs@fc7b179e...ca7e226e](https://github.com/doomemacs/doomemacs/compare/fc7b179e6cefa59097c87fd58c8272b6121a1dff...ca7e226e1305ed7f10762315ad48f19c330cdd72)

* [`8afc08a7`](https://github.com/doomemacs/doomemacs/commit/8afc08a7a8b611d198e4c1b1bffbeb2d8ef3e87c) bump: :tools direnv lsp magit
* [`951df2db`](https://github.com/doomemacs/doomemacs/commit/951df2dbee117baa780f79a523aaa5526e5f9584) bump: :completion
* [`5f04b562`](https://github.com/doomemacs/doomemacs/commit/5f04b56229d31c30698ed693498ed3708a60c434) module: add :ui smooth-scroll
* [`f9e9c27a`](https://github.com/doomemacs/doomemacs/commit/f9e9c27a8b6d79e109a1106bf0412979c90cd006) module: remove :tools prodigy
* [`417f3bc8`](https://github.com/doomemacs/doomemacs/commit/417f3bc892bc4319a88df44e16730f80fbc05f63) refactor!(go): remove go-eldoc & company-go
* [`52c385c0`](https://github.com/doomemacs/doomemacs/commit/52c385c033f627d2f2caf74a223adefed7aaf6d7) refactor!(python): remove anaconda-mode
* [`3abd194c`](https://github.com/doomemacs/doomemacs/commit/3abd194c0a40a7c48e9b17893f73c88c1ddd6269) docs(vterm): mention permission error issue on Tumbleweed
* [`27e5ae62`](https://github.com/doomemacs/doomemacs/commit/27e5ae62e48cc09f6c9eb15f43eba28690aec857) fix(vc-gutter): respect diff-hl-bmp-max-width
* [`653b465c`](https://github.com/doomemacs/doomemacs/commit/653b465c74b22bb9d85ee2ac957426ef6b222cdd) refactor: doom-switch-frame-hook
* [`cf418656`](https://github.com/doomemacs/doomemacs/commit/cf418656931878174f031fbcfb77bfd69b9772c4) perf(magit): optimize +magit-mark-stale-buffers-h
* [`760a92e9`](https://github.com/doomemacs/doomemacs/commit/760a92e95204482d0df47aa6a402e44adc3ff3d5) fix(ivy): counsel-projectile-switch-project: empty list on first run
* [`16dd6f86`](https://github.com/doomemacs/doomemacs/commit/16dd6f8674e6abf07a95a18b865c26d7c9573969) fix(dired): don't treat dirvish-side buffers as popups
* [`0bf0ea99`](https://github.com/doomemacs/doomemacs/commit/0bf0ea99100e413099d880665d9182f54f07cdaf) dev: update license year
* [`635f0a3e`](https://github.com/doomemacs/doomemacs/commit/635f0a3eec6f8a2a18891c6c7b5ed1fc5200fc76) refactor(magit): magit-credential-cache-daemon-socket: remove hack
* [`919e6584`](https://github.com/doomemacs/doomemacs/commit/919e6584360d1c4c6b48dcfef972d31805905991) fix(magit): magit-uniquify-buffer-names = nil
* [`98273b63`](https://github.com/doomemacs/doomemacs/commit/98273b639b151bc4fd2bc95474346814e5dce23d) fix: recursive redisplay error from doom-switch-frame-hook
* [`d4c02bcd`](https://github.com/doomemacs/doomemacs/commit/d4c02bcd088d61aa4983076245a27a59db9aa404) refactor(magit): reduce pollution of global namespace
* [`625b7932`](https://github.com/doomemacs/doomemacs/commit/625b793218bbbe6c2c52d68dc82cd3599ef4e918) fix: over-aggressive doom--run-switch-frame-hooks-fn
* [`5fae69b7`](https://github.com/doomemacs/doomemacs/commit/5fae69b7bffbeefbb4c94a7096e73bd30df5fd3e) docs: docstring & comment revisions
* [`63c29561`](https://github.com/doomemacs/doomemacs/commit/63c29561dfbc04a8d1431c37685e5265954b593d) fix(smooth-scroll): add Emacs 29 check
* [`4d44b78c`](https://github.com/doomemacs/doomemacs/commit/4d44b78ccf50de94418c0239eca14d3529ab0706) docs(smooth-scroll): mention Emacs 29 requirement
* [`06118995`](https://github.com/doomemacs/doomemacs/commit/061189953d1d8955d8b42eef3020fe654e8481f1) perf(smooth-scroll): suppress hl-todo, diff-hl-flydiff, & jit-lock
* [`46742977`](https://github.com/doomemacs/doomemacs/commit/46742977b17938cba8426e47eb78dad22cc5d7cb) refactor(emacs-lisp): remove unused +emacs-lisp-indent-function
* [`318e6300`](https://github.com/doomemacs/doomemacs/commit/318e6300373f5d67f5d4972897eddb2b3bcff85b) feat(smooth-scroll): add +interpolate flag
* [`b1e6dec4`](https://github.com/doomemacs/doomemacs/commit/b1e6dec47a2d0fa5fd8f7ab55b5f1012d16cb48b) refactor!(org): +pretty: use org-modern instead
* [`668a4a36`](https://github.com/doomemacs/doomemacs/commit/668a4a36d5863146070c9c0645e7ae456b7b88b7) docs(org): update & reorganize package list
* [`e91a5edd`](https://github.com/doomemacs/doomemacs/commit/e91a5edd3185af773eeebf56f230c5825affcfe8) fix(smooth-scroll): good-scroll & ultra-scroll interop
* [`f98eb382`](https://github.com/doomemacs/doomemacs/commit/f98eb3824f2f2f1f0ed1f7cf44b3802d9cb0a570) revert: refactor(magit): reduce pollution of global namespace
* [`eb19afa8`](https://github.com/doomemacs/doomemacs/commit/eb19afa8c3cf4e69e50dfc098481f38daf2a543b) refactor: remove doom--recentf-file-truename-fn
* [`5aca4562`](https://github.com/doomemacs/doomemacs/commit/5aca4562587a52ec5a48485c6039ee649bc98712) nit: recentf: reformat & revise comments
* [`6919d5e1`](https://github.com/doomemacs/doomemacs/commit/6919d5e1c422d8a6836d21ae1bb84e86e1b55e72) fix(lsp): eglot: don't manage flymake
* [`fce552f4`](https://github.com/doomemacs/doomemacs/commit/fce552f4bf44d1514ccbda7b435b08b98eeebba6) docs(smooth-scroll): mention high CPU w/ +interpolate
* [`b0cd2bec`](https://github.com/doomemacs/doomemacs/commit/b0cd2bec9ee8aada69dccc992ef471db3f4862bb) docs(smooth-scroll): reformat troubleshooting section
* [`9dfcb540`](https://github.com/doomemacs/doomemacs/commit/9dfcb5401f5655168bb90fcaec5149e8c159f535) tweak(org): disable org-modern-hide-stars w/ org-indent-mode
* [`457b7cab`](https://github.com/doomemacs/doomemacs/commit/457b7cab1e2836609408238df64c73ef38c1dc91) docs(undo): doctor: check for other undo package
* [`a13fda7e`](https://github.com/doomemacs/doomemacs/commit/a13fda7ec069ed49b936f82336669b0f1ad5e8ca) fix(magit): don't auto-revert non-file-visiting buffers
* [`5020d592`](https://github.com/doomemacs/doomemacs/commit/5020d592dafc666cee259c8463f2e304826858d1) fix: tooltip-resize-echo-area = t
* [`26b97766`](https://github.com/doomemacs/doomemacs/commit/26b97766e670ac7aac45622c96355db9d2ca40b9) fix(default): replace deprecated magit staging commands
* [`8168a035`](https://github.com/doomemacs/doomemacs/commit/8168a035996019d5512d900b6d62a682560d09c4) fix(org): org-modern: respect defaults for org-*-faces
* [`98e37b9c`](https://github.com/doomemacs/doomemacs/commit/98e37b9ceac87f1123346ae9cb247d7ed35eaef5) tweak(org): org-priority-faces: use shadow face for #C
* [`35e348ea`](https://github.com/doomemacs/doomemacs/commit/35e348ea209e2cd085578fa8e1305af1652b3d1e) bump: :lang org
* [`90b64a03`](https://github.com/doomemacs/doomemacs/commit/90b64a031395711f97c8dd5e52415a8848775ddd) refactor(latex): replace latex-preview-pane w/ auctex-cont-latexmk
* [`32fc210b`](https://github.com/doomemacs/doomemacs/commit/32fc210bf60949e6e7c18ce8537e787c87aa43c3) fix(org): org-modern in org-agenda
* [`a70ce220`](https://github.com/doomemacs/doomemacs/commit/a70ce220c0cfb97c90bb40e7dd83d9f763bc5dd4) refactor(org): use variables instead of +org-pretty-mode
* [`20ad20f8`](https://github.com/doomemacs/doomemacs/commit/20ad20f8eb5dabef85373cf0e10cd3cf9295fc24) fix(syntax): +syntax--only-check-elisp-buffers-in-projects-a signature
* [`c3d4970d`](https://github.com/doomemacs/doomemacs/commit/c3d4970da59123c3694ef3931fdab7207aa8492f) fix(org): do not rely on org-indent being loaded
* [`3a8e9a16`](https://github.com/doomemacs/doomemacs/commit/3a8e9a165f974dbf52f05eaa2c1b2c1939fccd39) fix(vc-gutter): diff-hl-update suppression
* [`b840f902`](https://github.com/doomemacs/doomemacs/commit/b840f902525f02db345508b156fe4585bf877e2b) revert: fix(latex): run after-compilation-finished hook after Tex-Tex-sentinel
* [`13500dd1`](https://github.com/doomemacs/doomemacs/commit/13500dd175adb07b73a7916543538d789b5b54ff) fix(org): org-modern: s/keyword/keywordp
* [`d660853f`](https://github.com/doomemacs/doomemacs/commit/d660853fc37528e7812dd64dcae26e32331c8ce7) tweak(org): org-modern: oversized checkbox symbol
* [`13b64229`](https://github.com/doomemacs/doomemacs/commit/13b64229a01c8dae74177299147156b7ac85094d) fix(popup): fringe/margins adjusted in wrong window
* [`310d0e3a`](https://github.com/doomemacs/doomemacs/commit/310d0e3a5ab51725c51900fbdf1a079fbe041f29) fix(evil): clear modeline search highlights on zero matches
* [`b7f4d312`](https://github.com/doomemacs/doomemacs/commit/b7f4d312186ff7709d4a3ec02c15f22e04bac0f8) fix(dired): dirvish: "window is dedicated to *dirvish-parent-...*"
* [`a39a5c24`](https://github.com/doomemacs/doomemacs/commit/a39a5c24af9424b67a0d4066a033f479606c6c4e) refactor(python): remove local conda.el fix
* [`eae2529e`](https://github.com/doomemacs/doomemacs/commit/eae2529ed8147ab85cb5e433021ebdd7670d19dc) fix(popup): ensure hooks run in popup buffer/window
* [`fda6bd4a`](https://github.com/doomemacs/doomemacs/commit/fda6bd4a4436645a971d582d550dd4c5995e7e76) fix(bidi): set the font for Arabic characters
* [`42fba948`](https://github.com/doomemacs/doomemacs/commit/42fba948f6f091b00cf093af295a0e9d9867ace5) fix(magit): use messages instead of modeline
* [`af908b1b`](https://github.com/doomemacs/doomemacs/commit/af908b1bd08033fcd29bef9e017ab7af507e5cc8) fix(vterm): always set +vterm--id in +vterm/toggle
* [`9a525ea0`](https://github.com/doomemacs/doomemacs/commit/9a525ea0302eee40dd7d38c199c06560af22d0fa) bump: :doom
* [`ae2cdd1c`](https://github.com/doomemacs/doomemacs/commit/ae2cdd1c9114169d2fbe34ebcd1f77b6a4165488) refactor(cc): configure clang-format in :editor format
* [`0150f879`](https://github.com/doomemacs/doomemacs/commit/0150f879ea1928e367190cb95cd96b3022b52df3) feat(magit): introduce +magit-auto-revert option
* [`c233aada`](https://github.com/doomemacs/doomemacs/commit/c233aada0b3e8989b4be78f7f8cae540074b832b) fix(format): void-variable callback when formatting w/ lsp-mode
* [`fb0dc4cc`](https://github.com/doomemacs/doomemacs/commit/fb0dc4cc85e3930e5df16591a8d083b45b6b2ba3) refactor(lib): doom-debug-mode: make verbosity selective
* [`cbdce0dc`](https://github.com/doomemacs/doomemacs/commit/cbdce0dc71b4c6bd538a094650f427d3ad0f3e2e) refactor(cli): doctor: extract symlink check to function
* [`7b5bcc00`](https://github.com/doomemacs/doomemacs/commit/7b5bcc00d49101385b326182e53c53b18ac61314) perf(undo): tune undo limits
* [`dd493e48`](https://github.com/doomemacs/doomemacs/commit/dd493e48ed0f9be46633877cd7534a4423343c56) fix(format): wrong-type-argument listp error
* [`9a63789c`](https://github.com/doomemacs/doomemacs/commit/9a63789cf04e782367d650ba07108ba2c905b986) refactor(org): remove reference to org-superstar
* [`c6f749e6`](https://github.com/doomemacs/doomemacs/commit/c6f749e67c13342007f6aeaa4a81e6fdb00f529f) fix(default): don't override TAB when Corfu isn't visible
* [`1c09989e`](https://github.com/doomemacs/doomemacs/commit/1c09989e48371dc2669e7275c046636363b369a9) fix(eshell): +eshell/search-history sometimes noops
* [`b2f85296`](https://github.com/doomemacs/doomemacs/commit/b2f85296835394e03996b3370cd172384aa09110) fix(magit): projectile-invalidate-cache in wrong buffer
* [`6e92ca59`](https://github.com/doomemacs/doomemacs/commit/6e92ca594f8075b2bd5ae373800a584ec98871ea) perf(magit): noop +magit-mark-stale-buffers-h if disabled
* [`c7ca3ea8`](https://github.com/doomemacs/doomemacs/commit/c7ca3ea8cce31c633070ee608be2d2a08d6e75a9) fix(eshell): don't error if command manpages has no SYNOPSIS
* [`5fdffe19`](https://github.com/doomemacs/doomemacs/commit/5fdffe19db5e26347c69dfc71bce492d8d4a619c) feat(eshell): add help command & lookup handler
* [`d209e519`](https://github.com/doomemacs/doomemacs/commit/d209e519afee2551a1e9700caf819c2053988cff) fix(eshell): highlight syntax after completing from history
* [`e096e7d7`](https://github.com/doomemacs/doomemacs/commit/e096e7d79e452ba29b9d174cfdbf9fb2184d59d9) feat(emacs-lisp): default ielm working buffer to selected
* [`dddc0198`](https://github.com/doomemacs/doomemacs/commit/dddc01982b5d70e6d0a17aa5e82121d8af3bb19a) feat(emacs-lisp): add +emacs-lisp/change-working-buffer command
* [`a45ce1e1`](https://github.com/doomemacs/doomemacs/commit/a45ce1e14d09b585369ce59d62a79588cd46780a) fix(magit): do less on magit-refresh-buffer
* [`6a44a2ea`](https://github.com/doomemacs/doomemacs/commit/6a44a2ea80a7321e998394a5b1b0245af7821f62) tweak: use GUI dialogs on android
* [`1a0fb888`](https://github.com/doomemacs/doomemacs/commit/1a0fb88897fb4d71949f5a9f2ccca179c6c4eab6) feat: doom-quit-p: use popup dialog if available
* [`faea3201`](https://github.com/doomemacs/doomemacs/commit/faea32016287af39fb0335eca58739ad430b4925) tweak(default): swap 'C-c q q' & 'C-c q Q' keybinds
* [`a13719af`](https://github.com/doomemacs/doomemacs/commit/a13719af45133ca2f6520a7fe8139664fffc0c9b) refactor(lib): backport static-{if,when,unless}
* [`97657685`](https://github.com/doomemacs/doomemacs/commit/976576853e883ec4a0ccb38244dc6639262bc76c) nit(lib): doom-compat: make version comments consistent
* [`def4579a`](https://github.com/doomemacs/doomemacs/commit/def4579a9f45bac90c0874b567b5225d03cf4135) fix: silence 'missing lexical-binding cookie' warnings
* [`ad0eb9d5`](https://github.com/doomemacs/doomemacs/commit/ad0eb9d5a2259a67084ea855eb7ab7125376ff6b) bump: :emacs dired
* [`b2ce2106`](https://github.com/doomemacs/doomemacs/commit/b2ce21068f173c2c7c6eaf8a5f45d5bb78e203d5) fix(lib): void-function static-unless error
* [`5f6df26d`](https://github.com/doomemacs/doomemacs/commit/5f6df26d5c88e7cdc1c3e50be4bd247c526c28e3) fix(lib): load doom-compat in 30.x
* [`46647dad`](https://github.com/doomemacs/doomemacs/commit/46647dada650d5f1573393b2797dd8b1373ca20e) fix(lib): load doom-compat unconditionally
* [`88b6d350`](https://github.com/doomemacs/doomemacs/commit/88b6d350824c7b811d4d87f7c3d79379124db462) refactor!(java): remove +eclim and +meghanada
* [`60bf93eb`](https://github.com/doomemacs/doomemacs/commit/60bf93eb9a8ed2199d0f67f22c6e7add0fb22cde) fix(cli): doomscript: end-of-file error
* [`31afe2c8`](https://github.com/doomemacs/doomemacs/commit/31afe2c8b0a4bc42ae8570248c49bdd1f19c0103) fix(org): don't expand latex snippets in latex segments
* [`20c80c46`](https://github.com/doomemacs/doomemacs/commit/20c80c461e607d3a6cc9e95a9012a26f93a38532) fix: void-function use-dialog-box-p
* [`d8b36d8b`](https://github.com/doomemacs/doomemacs/commit/d8b36d8b17b73ce482359b070c221f608959fde4) fix: use-dialog-box only on android
* [`009a285c`](https://github.com/doomemacs/doomemacs/commit/009a285c0a63c305d0aa89f46122b7f98a57e897) fix: doom-quit-p when use-dialog-box
* [`b4276f41`](https://github.com/doomemacs/doomemacs/commit/b4276f41f434b3a70a98bbf7220654259ba70304) fix(eshell): "attempt to open-code ‘anonymous lambda’ with too few arguments"
* [`b51d41e1`](https://github.com/doomemacs/doomemacs/commit/b51d41e1cfbbaea38d251bb41ebf02e9cfe3b6a9) fix(org): save-buffer more selectively after org-refile
* [`0f956da7`](https://github.com/doomemacs/doomemacs/commit/0f956da7f662531e85ca502fc0d68957a52a7fd0) fix(ess): open repl commands
* [`06e270b1`](https://github.com/doomemacs/doomemacs/commit/06e270b1e6d57f1571a93fffdeabb062fa97e51b) fix(ess): add company-backends in inferior mode
* [`8eb4e37f`](https://github.com/doomemacs/doomemacs/commit/8eb4e37ffb6730f7260dcd7f407cfe6afb9710a4) perf(ess): make REPL *R* buffer more responsive
* [`30641328`](https://github.com/doomemacs/doomemacs/commit/306413288152bbcf75e5392b031cce2e7d875f4b) feat(ess): add quarto-mode
* [`bd28169a`](https://github.com/doomemacs/doomemacs/commit/bd28169ac5151623981f9952b3ccd9d605e95839) feat(ess): roxygen: indentation on RET
* [`ebc2cecf`](https://github.com/doomemacs/doomemacs/commit/ebc2cecf3d5c1535a41891e32498708686eb3afc) refactor(ess): reformat keybinds
* [`671e03b0`](https://github.com/doomemacs/doomemacs/commit/671e03b0a1a42af1b270fd6eb9810658e4dd355f) refactor(ess): replace ess-R-data-view w/ ess-view-data
* [`0e7997a0`](https://github.com/doomemacs/doomemacs/commit/0e7997a0998e5404863e7f41e5edb6abe166b176) fix(ess): invisible output to terminal
* [`8057af96`](https://github.com/doomemacs/doomemacs/commit/8057af96e257c1d93a8abbaabdb9c4d3018b70a5) fix(ess): auto-mode-alist entry for ess-julia-mode
* [`2c22a260`](https://github.com/doomemacs/doomemacs/commit/2c22a26042c4797f119b2e2ee58219dd00333517) refactor(ess): remove unused autoloads
* [`baf680f9`](https://github.com/doomemacs/doomemacs/commit/baf680f9c8dc699f458888583423789fd41f8c19) bump: :lang ess
* [`8f979499`](https://github.com/doomemacs/doomemacs/commit/8f97949975c0dce51695ececf3579adbdb98eddc) docs(ess): replace ess-R-data-view w/ ess-view-data
* [`20381dea`](https://github.com/doomemacs/doomemacs/commit/20381dea16c1ef87fb71e0490e37ed39c79051fe) feat(emacs-lisp): add back/forward commands for helpful
* [`ed85328f`](https://github.com/doomemacs/doomemacs/commit/ed85328f570011e211ac959d6d88eeb156c61211) fix(org): allow refiling to top level
* [`b4bd3684`](https://github.com/doomemacs/doomemacs/commit/b4bd368485e4354bcad749459a5c2d947c26e853) refactor!(debugger): replace realgud with dape
* [`bff2ccd9`](https://github.com/doomemacs/doomemacs/commit/bff2ccd974dc5f66e3796033b6cd853e785055ee) refactor: remove vestigial hydra configs
* [`62f1df42`](https://github.com/doomemacs/doomemacs/commit/62f1df4218fc81693693c172bc78a91192e4cc8a) fix: respect auto-revert-remote-files
* [`9cbb8656`](https://github.com/doomemacs/doomemacs/commit/9cbb8656cb0e0cb2d5b72570e4b8a3fff7106368) feat(lookup): +lookup-provider-url-alist: add StackExchange
* [`da32e8e6`](https://github.com/doomemacs/doomemacs/commit/da32e8e6f233a80d54d51964d21c4b46b000323b) fix(lsp): gate gcmh API call behind gcmh-mode check
* [`1681bfba`](https://github.com/doomemacs/doomemacs/commit/1681bfbaf05587efc9a63667d25652701ae6103c) refactor: move doom-highlight-non-default-indentation-h out of core
* [`303dd28d`](https://github.com/doomemacs/doomemacs/commit/303dd28db808b42a2397c0f4b9fdd71e606026ff) feat(lib): introduce doom/describe-char
* [`bb7dc758`](https://github.com/doomemacs/doomemacs/commit/bb7dc7583fae5e51c848b3309365a1afeeaa172b) fix(coq): noop proof-upgrade-elpa-packages
* [`61f69ca9`](https://github.com/doomemacs/doomemacs/commit/61f69ca980a0f5009b65a0c0ae31db118c77301e) fix(coq): corfu integration
* [`795708c1`](https://github.com/doomemacs/doomemacs/commit/795708c1163ea332fd34973cf0a7f7f121dc85d9) feat(sh): add capf completion in shell scripts
* [`92930251`](https://github.com/doomemacs/doomemacs/commit/92930251cfdc893579e5d3f547ec188e7bf47a6a) refactor(clojure): add-hook!: no implicit mode hooks
* [`ac0a3277`](https://github.com/doomemacs/doomemacs/commit/ac0a327721a5d0951b5d80d860b3a6deb1454c08) fix(beancount): activate flymake-mode
* [`440e9520`](https://github.com/doomemacs/doomemacs/commit/440e952056ef2ce6e17a32423e05ba60b35b9a93) fix(beancount): +beancount/balance: make v3 compliant
* [`4fa3bb49`](https://github.com/doomemacs/doomemacs/commit/4fa3bb49509d48b82b53eff910d0a20d484c87e0) feat(beancount): add eval handler
* [`f8f979a5`](https://github.com/doomemacs/doomemacs/commit/f8f979a5812efdff43d2552174cf957e5d5e72f8) tweak(beancount): bind sort commands to <localleader> s
* [`ca7e226e`](https://github.com/doomemacs/doomemacs/commit/ca7e226e1305ed7f10762315ad48f19c330cdd72) refactor(beancount): simplify +beancount--open-in-browser-after-starting-fix-a
