### PR TITLE
niv home-manager: update 1ad12323 -> 8a318641

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -41,10 +41,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1ad123239957d40e11ef66c203d0a7e272eb48aa",
-        "sha256": "0whlwwv2l1zir93bb4p1a9qmvjwfp4ymaa7c3kldz8aszf2z73lv",
+        "rev": "8a318641ac13d3bc0a53651feaee9560f9b2d89a",
+        "sha256": "0v931s9w3kkcv248c3xsycfr1dyjqb61x424qh2anggl0f4ni84b",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/1ad123239957d40e11ef66c203d0a7e272eb48aa.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/8a318641ac13d3bc0a53651feaee9560f9b2d89a.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@1ad12323...8a318641](https://github.com/nix-community/home-manager/compare/1ad123239957d40e11ef66c203d0a7e272eb48aa...8a318641ac13d3bc0a53651feaee9560f9b2d89a)

* [`a4c3ce44`](https://github.com/nix-community/home-manager/commit/a4c3ce44fcd65849751caab203c2076b092e7069) gpg-agent: pinentryPackage -> pinentry.package and add pinentry.program`
* [`e9c80e27`](https://github.com/nix-community/home-manager/commit/e9c80e277b572f642835afbf0d793b72cf49f551) tests/gpg-agent: add pinentry-program test
* [`9389f373`](https://github.com/nix-community/home-manager/commit/9389f373bee64cc8459253e0ab00635b05c0bcb6) pls: enableAliases -> enableShellIntegration ([nix-community/home-manager⁠#6932](https://togithub.com/nix-community/home-manager/issues/6932))
* [`84d26211`](https://github.com/nix-community/home-manager/commit/84d262115e10ad321ef01cd85903d0f5c3ec113f) nixos,darwin: add osClass (_class) as a specialArg ([nix-community/home-manager⁠#6906](https://togithub.com/nix-community/home-manager/issues/6906))
* [`ca39b348`](https://github.com/nix-community/home-manager/commit/ca39b348299bb772a7cca2271cef9b91845a390a) carapace: fix nushell PATH env var ([nix-community/home-manager⁠#6936](https://togithub.com/nix-community/home-manager/issues/6936))
* [`d2b3e6c8`](https://github.com/nix-community/home-manager/commit/d2b3e6c83d457aa0e7f9344c61c3fed32bad0f7e) flake.lock: Update ([nix-community/home-manager⁠#6937](https://togithub.com/nix-community/home-manager/issues/6937))
* [`c9c2c1a1`](https://github.com/nix-community/home-manager/commit/c9c2c1a14e8d6292857272a0a56a4213664ec8fa) kime: fix systemd service ([nix-community/home-manager⁠#6911](https://togithub.com/nix-community/home-manager/issues/6911))
* [`272eb00d`](https://github.com/nix-community/home-manager/commit/272eb00d1396bd86e77ebefd1abc47dfcab837b3) fcitx5: ensure config doesn't get overwritten ([nix-community/home-manager⁠#6940](https://togithub.com/nix-community/home-manager/issues/6940))
* [`7f301a4d`](https://github.com/nix-community/home-manager/commit/7f301a4d968f3b846efde5a43455d959b69a348f) restic: fix certain integration tests
* [`5f217e5a`](https://github.com/nix-community/home-manager/commit/5f217e5a319f6c186283b530f8c975e66c028433) restic: change service type from `simple` to `oneshot`
* [`81431b6d`](https://github.com/nix-community/home-manager/commit/81431b6d6fa756db641109461fc943ba23b550b7) gpg-agent: fix typo ([nix-community/home-manager⁠#6950](https://togithub.com/nix-community/home-manager/issues/6950))
* [`4e7ee4d0`](https://github.com/nix-community/home-manager/commit/4e7ee4d02cc323fc338ff978ca4a2b72e08f5d8d) home-manager: new formatting of generated configuration
* [`015f1913`](https://github.com/nix-community/home-manager/commit/015f1913109d44c36e683b55f0e47e283b383caa) ci: remove GitLab rycee/nur-expression update
* [`1298a341`](https://github.com/nix-community/home-manager/commit/1298a3418be1a875e9ae6643770b0939814cd441) ci: remove release-24.05 from dependabot setup
* [`361ab448`](https://github.com/nix-community/home-manager/commit/361ab4484e7b91a7b6bdedc6784e2a44d20a3dce) home-environment: add `home.extraDependencies`
* [`f045bd46`](https://github.com/nix-community/home-manager/commit/f045bd46b73c3b0ed4e46cdb6036b3d5823d7dee) fish: keep all fish-completions packages around
* [`669e813c`](https://github.com/nix-community/home-manager/commit/669e813c752696c66ad7e1cd34b65ee4315058d9) element-desktop: add module ([nix-community/home-manager⁠#6935](https://togithub.com/nix-community/home-manager/issues/6935))
* [`c5cad190`](https://github.com/nix-community/home-manager/commit/c5cad190ba252eb94540ee06955a53c7807963f8) zsh: update doc to show how to add `initContent` at multiple location. ([nix-community/home-manager⁠#6945](https://togithub.com/nix-community/home-manager/issues/6945))
* [`f15be4fe`](https://github.com/nix-community/home-manager/commit/f15be4feb6e98fc2c52d4f8088400619381fd171) clipcat: add module ([nix-community/home-manager⁠#6946](https://togithub.com/nix-community/home-manager/issues/6946))
* [`2eabb26d`](https://github.com/nix-community/home-manager/commit/2eabb26d0859c7710a2aa76c3b0ff4149f41b04a) restic: allow the convenience script to source environmentFile ([nix-community/home-manager⁠#6947](https://togithub.com/nix-community/home-manager/issues/6947))
* [`355a6b93`](https://github.com/nix-community/home-manager/commit/355a6b937d07a95cb0b753ef513bcaad09128dea) nushell: throw instead of abort ([nix-community/home-manager⁠#6870](https://togithub.com/nix-community/home-manager/issues/6870))
* [`d6b0c054`](https://github.com/nix-community/home-manager/commit/d6b0c054571a444acd2755b038bb7df5eb7954a7) visidata: add module ([nix-community/home-manager⁠#6956](https://togithub.com/nix-community/home-manager/issues/6956))
* [`1e8c62c6`](https://github.com/nix-community/home-manager/commit/1e8c62c651242fc685b10efc4a48ab777635fb7f) gpg-agent: avoid console output when using ssh
* [`123297c5`](https://github.com/nix-community/home-manager/commit/123297c57e77c692fae7e860e701823367afbec4) onagre: add module ([nix-community/home-manager⁠#6958](https://togithub.com/nix-community/home-manager/issues/6958))
* [`c0962eee`](https://github.com/nix-community/home-manager/commit/c0962eeeabfb8127713f859ec8a5f0e86dead0f2) thunderbird: fix accounts being removed ([nix-community/home-manager⁠#6959](https://togithub.com/nix-community/home-manager/issues/6959))
* [`929f8ee8`](https://github.com/nix-community/home-manager/commit/929f8ee8362aec0a2bcbcbbd485e86e701496a73) thunderbird: deprecate darwinSetupWarning option ([nix-community/home-manager⁠#6531](https://togithub.com/nix-community/home-manager/issues/6531))
* [`75268f62`](https://github.com/nix-community/home-manager/commit/75268f62525920c4936404a056f37b91e299c97e) tests: enable all firefox tests on darwin (plus derivations) ([nix-community/home-manager⁠#6960](https://togithub.com/nix-community/home-manager/issues/6960))
* [`94f4c666`](https://github.com/nix-community/home-manager/commit/94f4c66660faa994676176d1d3d94618a796c39e) tests/darwinScrublist: add more packages ([nix-community/home-manager⁠#6965](https://togithub.com/nix-community/home-manager/issues/6965))
* [`d1bbab6b`](https://github.com/nix-community/home-manager/commit/d1bbab6b04d865d759505f33a5c6743bbb544074) mako: refactor ([nix-community/home-manager⁠#6948](https://togithub.com/nix-community/home-manager/issues/6948))
* [`64f7d5e6`](https://github.com/nix-community/home-manager/commit/64f7d5e6b94e2e66e3b344fe8e002c9da97a57b1) wofi: allow path to style.css ([nix-community/home-manager⁠#6966](https://togithub.com/nix-community/home-manager/issues/6966))
* [`621986fe`](https://github.com/nix-community/home-manager/commit/621986fed37c5d0cb8df010ed8369694dc47c09b) i3bar-river: add module ([nix-community/home-manager⁠#6967](https://togithub.com/nix-community/home-manager/issues/6967))
* [`3a185176`](https://github.com/nix-community/home-manager/commit/3a185176e48206026b8c1e6dc3f3a37ffff4b9f7) flake.lock: Update ([nix-community/home-manager⁠#6969](https://togithub.com/nix-community/home-manager/issues/6969))
* [`8167af65`](https://github.com/nix-community/home-manager/commit/8167af657c0aa58fbe1fabfe7cce0520380c1bb3) mako: fix criterias typo ([nix-community/home-manager⁠#6968](https://togithub.com/nix-community/home-manager/issues/6968))
* [`1a1793f6`](https://github.com/nix-community/home-manager/commit/1a1793f6d940d22c6e49753548c5b6cb7dc5545d) ghostty: fix config syntax file location on darwin ([nix-community/home-manager⁠#6970](https://togithub.com/nix-community/home-manager/issues/6970))
* [`5f1f4725`](https://github.com/nix-community/home-manager/commit/5f1f472565ee59b5001ae5022bbb1a9a64239f91) mako: use ini atom type ([nix-community/home-manager⁠#6977](https://togithub.com/nix-community/home-manager/issues/6977))
* [`8a318641`](https://github.com/nix-community/home-manager/commit/8a318641ac13d3bc0a53651feaee9560f9b2d89a) sway-easyfocus: add module ([nix-community/home-manager⁠#6976](https://togithub.com/nix-community/home-manager/issues/6976))
