### PR TITLE
niv nixpkgs: update 374b5fab -> cf47c7d2

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "374b5fab08713e4d0221a0e082f5c12e47bc9080",
-        "sha256": "1ddrfzv9w6vgvcsnay93vzay48sdqcgx40pbwq4j9xnj00ygklck",
+        "rev": "cf47c7d239f5e9082a36d9b59644ce7e5f7874f9",
+        "sha256": "0g0hgdaawzcnxnll4150r7gxr22rz3pr5zs763v53pspzhwq306l",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/374b5fab08713e4d0221a0e082f5c12e47bc9080.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/cf47c7d239f5e9082a36d9b59644ce7e5f7874f9.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@374b5fab...cf47c7d2](https://github.com/nixos/nixpkgs/compare/374b5fab08713e4d0221a0e082f5c12e47bc9080...cf47c7d239f5e9082a36d9b59644ce7e5f7874f9)

* [`d909b947`](https://github.com/NixOS/nixpkgs/commit/d909b947042fcbefa44ce118d4da6a24e50d6bc9) joplin-desktop: exclude apple code signatures when unpacking DMG archive with 7zz on x86_64-darwin
* [`7cd6e300`](https://github.com/NixOS/nixpkgs/commit/7cd6e3002385b7be47714a660b45c6aca2d9ba63) texinfo7: 7.1.1 -> 7.2
* [`ca854035`](https://github.com/NixOS/nixpkgs/commit/ca85403559eeaf4282074d5679b39a5cb1948e52) haskellPackages.libtorch-ffi: Fix the link to libtorch
* [`0145fac0`](https://github.com/NixOS/nixpkgs/commit/0145fac03b41ddc9ef961d507af19b6ca0f93268) haskellPackages.sysinfo: Disable the test. Metrics are not collected properly on the sandbox of macOS.
* [`febbc861`](https://github.com/NixOS/nixpkgs/commit/febbc86150999afdcf7a2b159040d718ddca4c53)  haskellPackages: add mangoiv as maintainer
* [`aec84430`](https://github.com/NixOS/nixpkgs/commit/aec84430976bb8c530e90f94140ed310276f429f) haskellPackages: stackage LTS 22.43 -> LTS 23.3
* [`61ad0f55`](https://github.com/NixOS/nixpkgs/commit/61ad0f55b68c0aa6234a0fcef47b4c30d819e86d) all-cabal-hashes: 2024-12-23T18:27:47Z -> 2025-01-05T13:11:15Z
* [`7e2a5a59`](https://github.com/NixOS/nixpkgs/commit/7e2a5a598c4f759c200142d0753215a20647eb65) haskellPackages: regenerate package set based on current config
* [`70744040`](https://github.com/NixOS/nixpkgs/commit/707440405db881591c21dbc63747c7697c1d14a0) haskellPackages.Cabal_3_14_*: 3.14.1.0 -> 3.14.1.1
* [`9c47348b`](https://github.com/NixOS/nixpkgs/commit/9c47348bc90e8ea13a9008462b2fd74d0b75c57c) pandoc_3_6: remove at 3.6
* [`6d2e77f7`](https://github.com/NixOS/nixpkgs/commit/6d2e77f7c369993534b0c038e67f7fc798500888) haskell.packages.ghc98: remove _some_ unnecessary version overrides
* [`c7920df2`](https://github.com/NixOS/nixpkgs/commit/c7920df25c5017528c014554509a47d29b43ab55) haskell.packages.ghc98.semaphore-compat: mark as core package
* [`93febf2e`](https://github.com/NixOS/nixpkgs/commit/93febf2ec0e9b7631d38704f4b71d223563542e9) haskellPackages.ghc-lib*: 9.10.1.20241103 -> 9.10.1.20250103
* [`ad994005`](https://github.com/NixOS/nixpkgs/commit/ad99400541281d1369405d9ef89f453edddff81e) haskellPackages.ghc: 9.6.6 -> 9.8.4
* [`a4a73418`](https://github.com/NixOS/nixpkgs/commit/a4a73418f0f83cafc737459359bb0f05efd3b905) haskellPackages.password: drop override
* [`430ee161`](https://github.com/NixOS/nixpkgs/commit/430ee161c91e180f2c62740a5ff00d4f5e3c40eb) haskellPackages.postgresql-libpq: don't shuffle library*Depends
* [`10f1af06`](https://github.com/NixOS/nixpkgs/commit/10f1af063508cbc129e3e04d525f61e78baa5eb7) haskellPackages.gi_g*k_4: remove machinery
* [`d65a8c28`](https://github.com/NixOS/nixpkgs/commit/d65a8c283bc31e248351300888b4fbd24b38a20b) haskellPackages: remove all references to removed versioned attrs
* [`4c0634c6`](https://github.com/NixOS/nixpkgs/commit/4c0634c6333f600a40cba015599ffd6ff3d3dbd8) haskell.packages.ghc9121: remove all references to removed attrs
* [`16acc69f`](https://github.com/NixOS/nixpkgs/commit/16acc69f6091074a2804157947628d48e2619eb8) haskellPackages.hashable: fix test suite bounds
* [`edda3fbe`](https://github.com/NixOS/nixpkgs/commit/edda3fbeccba117bfe7bef2aba781d3a109f1a33) haskellPackages.happy: provide happy executable to test suite
* [`dd7439ed`](https://github.com/NixOS/nixpkgs/commit/dd7439edc8e5790456a33aad8ebafad966353359) haskellPackages.happy_2_1_3: build against matching happy-lib
* [`c5b7ed37`](https://github.com/NixOS/nixpkgs/commit/c5b7ed37615f103fa59dc2d97f49dcc7b40f2995) haskellPackages.aeson: drop upstreamed patch
* [`59c33441`](https://github.com/NixOS/nixpkgs/commit/59c33441aad07f654ff9af9197bd051bf923a355) haskellPackages.text-iso8601: allow tasty-quickcheck == 0.11.*
* [`82a2f09f`](https://github.com/NixOS/nixpkgs/commit/82a2f09f5e0a8aa51f1af15707255ba231469c52) haskellPackages.{cborg,serialise}: fix with tasty-quickcheck 0.11
* [`53a9369d`](https://github.com/NixOS/nixpkgs/commit/53a9369d1586856bfaaeb17865b9299b1ce80cd7) haskell.packages.ghc9101: remove all references to removed attrs
* [`9cdffcfe`](https://github.com/NixOS/nixpkgs/commit/9cdffcfedb71f25fc4ce059836d739e433c41bbb) haskellPackages.wherefrom-compat: remove broken flag
* [`fcb42466`](https://github.com/NixOS/nixpkgs/commit/fcb42466890db800be0bc833596f0d34462b6f47) cabal-install: drop merged patch
* [`d72e1d90`](https://github.com/NixOS/nixpkgs/commit/d72e1d90e75e234b068c6f0bcc2177f7130b917d) haskellPackages.psqueues: allow tasty-quickcheck == 0.11.*
* [`59001acf`](https://github.com/NixOS/nixpkgs/commit/59001acf880f7be73e6c806ffcbbbc5ac8292056) haskellPackages.commutative-semigroups: remove upstreamed patch
* [`976c7061`](https://github.com/NixOS/nixpkgs/commit/976c706178659bc043f4228b23c8cdf6b8fbf3d4) haskellPackages.dependent-sum-template: remove upstreamed patch
* [`9b9a6f53`](https://github.com/NixOS/nixpkgs/commit/9b9a6f531a6eed04e58412c2e8d70ab4dcc70a2a) haskellPackages.pandoc-cli: remove reference to typst
* [`f2ff77e1`](https://github.com/NixOS/nixpkgs/commit/f2ff77e1d6771e2606edee2680645ce86b5a7860) haskellPackages.reflex: workaround deprecated module
* [`aa12f819`](https://github.com/NixOS/nixpkgs/commit/aa12f819f233ed217c5fbb03431f9796b554a5f3) haskellPackages.reflex: re-enable tests
* [`2a2d18d9`](https://github.com/NixOS/nixpkgs/commit/2a2d18d9f8f692e793da1b4bead1a96d30c6f6d2) haskellPackages: add alexfmpe as maintainer to more packages
* [`7b995f06`](https://github.com/NixOS/nixpkgs/commit/7b995f0602a57bf533e1ef34a2e9e7a02e520022) haskellPackages.postgresql-libpq: fix build
* [`2bccaaae`](https://github.com/NixOS/nixpkgs/commit/2bccaaaea050d64222b33336ccc2d19cc23c7f67) haskellPackages.relude: support hedgehog 1.5
* [`2f5e79c2`](https://github.com/NixOS/nixpkgs/commit/2f5e79c271e12291a6ae4827a39fe68af4c6f69b) haskellPackages.hnix-store-*: remove fixed packages from broken list
* [`8f47155a`](https://github.com/NixOS/nixpkgs/commit/8f47155a57f23eaa72e90614b2caa16555c084c9) haskell.compiler.ghcHEAD: 9.13.20241031 -> 9.13.20250115
* [`43ff75c4`](https://github.com/NixOS/nixpkgs/commit/43ff75c408b7b18c9d9400be459410bd5c2025ec) haskell.compiler: backport patch for unix 32bit type size issue
* [`808b83ce`](https://github.com/NixOS/nixpkgs/commit/808b83ceacb4bdd2b278f7324057e583bcc46c35) haskell.packages.*.semaphore-compat: provide for GHC < 9.8
* [`a2c0b6e7`](https://github.com/NixOS/nixpkgs/commit/a2c0b6e7b7f6fa976aac7ff275a8bfbdb0469927) haskell.packages.ghc865Binary: fix eval of some pkgs using fake llvm
* [`eb1be4ae`](https://github.com/NixOS/nixpkgs/commit/eb1be4ae9d8aa3c180b04b1c9be41a6fa219ddf7) haskellPackages.monad-schedule: drop obsolete override
* [`9b11649c`](https://github.com/NixOS/nixpkgs/commit/9b11649ce830304afb2e0f59b78c65313bbd0dff) haskellPackages.clay: drop obsolete override
* [`2a6e5e6e`](https://github.com/NixOS/nixpkgs/commit/2a6e5e6eff52f391d9457a648a2471128eae06e6) haskellPackages.filepath-bytestring: assume equivalent to 1.4.301.0
* [`38e18d0d`](https://github.com/NixOS/nixpkgs/commit/38e18d0dd13dd69fca34e6758f9b85f2afd157cf) haskellPackages.socket: allow bytestring == 0.12.*
* [`c2f080a6`](https://github.com/NixOS/nixpkgs/commit/c2f080a6f201b9f2e6fc100f4fce0f7b05756d2b) haskellPackages.gi-javascriptcore*: work around argv limit
* [`4913c739`](https://github.com/NixOS/nixpkgs/commit/4913c739e9a8f234b381c8f5800027b7d81c8f60) haskellPackages.gi-g*k4: work around argv limit
* [`a0141c76`](https://github.com/NixOS/nixpkgs/commit/a0141c766539cfe404fd2ada667ebace85f6f0a7) haskell-language-server: support haskellPackages.ghc.version by default
* [`f97ee617`](https://github.com/NixOS/nixpkgs/commit/f97ee61708fd141d26d018db7218f07080e67972) haskellPackages.haskell-language-server: patch deps
* [`505a2190`](https://github.com/NixOS/nixpkgs/commit/505a21908a0f533f293431ef9877a72a62b6ff37) haskellPackages.cabal2nix-unstable: 2024-12-31 -> 2025-01-17
* [`4d998c97`](https://github.com/NixOS/nixpkgs/commit/4d998c973d916a7087af1cf8cf870eda767c2d02) haskellPackages: drop stale broken flags showing up in eval
* [`2358667c`](https://github.com/NixOS/nixpkgs/commit/2358667cb3d88cde1f4b3e7afafcc116b48d4d59) haskellPackages.hsc3: downgrade to match hosc
* [`d3425b04`](https://github.com/NixOS/nixpkgs/commit/d3425b04a2bbef8df043da5e43b726a4b6ebc47c) pipewire: set meta.pkgConfigModules
* [`632e61c1`](https://github.com/NixOS/nixpkgs/commit/632e61c141bcd2b4bf9ef9d495c905bf20c568ea) haskellPackages.libremidi: work around argv limit
* [`d5ca2c9b`](https://github.com/NixOS/nixpkgs/commit/d5ca2c9b4dd67d7d549a1058ab4d93f77cef868c) haskell.packages.ghc96.libtorch-ffi: update broken flags
* [`ea13a8bd`](https://github.com/NixOS/nixpkgs/commit/ea13a8bd5db362f54cce6a23178307217204e718) haskellPackages.gi-gdkx114,gi-gtksource5: work around argv limit
* [`513b5305`](https://github.com/NixOS/nixpkgs/commit/513b5305cf7a0a0568c5012478bc39dd9fe4b26d) haskellPackages.patch: remove jailbreak on JS backend
* [`bb5f42bc`](https://github.com/NixOS/nixpkgs/commit/bb5f42bc24e48f6b0477bede99be367847e6d3d7) gitit: relax bounds for compatibility with Stackage LTS 23
* [`21631571`](https://github.com/NixOS/nixpkgs/commit/2163157181265fe1f743b145f9cc0643ea11d2ce) haskellPackages: use upstream version for reflex-dom(-core)
* [`467cb31c`](https://github.com/NixOS/nixpkgs/commit/467cb31c7c2885d3e2e20d6ddeb3ed6ab23e8121) haskellPackages.reflex: use upstream version
* [`a53d1dac`](https://github.com/NixOS/nixpkgs/commit/a53d1dac020a14e893ca9ed7a1313032ebaac9c1) haskellPackages.jsaddle-webkit2gtk: bypass compatibility packages for gi-gtk and gi-javascriptcore
* [`dae3c95f`](https://github.com/NixOS/nixpkgs/commit/dae3c95fb5c07d8b1083043e94fbecae14635338) haskellPackages.reflex-dom-core: workaround TH bug in JS backend
* [`590f2edd`](https://github.com/NixOS/nixpkgs/commit/590f2edddcdb08020addfca4281fd43efc79f1a4) haskellPackages.hoogle: bump to unstable
* [`8dc98a93`](https://github.com/NixOS/nixpkgs/commit/8dc98a93594f9e59ef855fd524339fac45305b0b) haskellPackages.proto3-wire: support tasty-quickcheck 0.11
* [`7245f047`](https://github.com/NixOS/nixpkgs/commit/7245f047807d03381e0193438b580ac36aa8e166) haskellPackages.cpython: add doJailbreak to unbreak package
* [`c1797f20`](https://github.com/NixOS/nixpkgs/commit/c1797f206813cbce0a9aa3742e4c32fed50e605e) haskellPackages.unleash-client-haskell-core: Jailbreak
* [`c6b77e01`](https://github.com/NixOS/nixpkgs/commit/c6b77e01684109cf33fcd2191b7f1dc3a75db3ae) haskellPackages.unleash-client-haskell: Add comment
* [`d2712b87`](https://github.com/NixOS/nixpkgs/commit/d2712b877f9a3f0d482a0b0cf8a1203f85045109) haskellPackages.http2-client: fix bounds
* [`3127c749`](https://github.com/NixOS/nixpkgs/commit/3127c7499081ae7c2399c0ce179a2c34a0968dba) haskellPackages.warp-systemd: jailbreak
* [`ce5904d2`](https://github.com/NixOS/nixpkgs/commit/ce5904d2d6df776dfc49bf00122a564ef4e11f97) haskellPackages.warp-systemd: set maintainer to mpscholten
* [`e0c60083`](https://github.com/NixOS/nixpkgs/commit/e0c600835f94e8c535f4c8006194189a523036e2) wtwitch: improvements
* [`6de4685e`](https://github.com/NixOS/nixpkgs/commit/6de4685e778d3ef349b49e7893e0014133a62c1e) haskellPackages.gogol-core: unbreak
* [`132ad67f`](https://github.com/NixOS/nixpkgs/commit/132ad67fb7be7d20a4d3b8bc7bd64b415b13b98a) haskellPackages.gogol{,-core}: unbreak
* [`be64a9fd`](https://github.com/NixOS/nixpkgs/commit/be64a9fd6bfe4c6ac9aed1e88b48988bc8fcf5ec) haskellPackages.gogol-*: unbreak
* [`bea6e6b5`](https://github.com/NixOS/nixpkgs/commit/bea6e6b5edbde0730c9cb00e291fec4eea3f37d1) haskellPackages.gogol-*: enable hydra build
* [`e5064c2d`](https://github.com/NixOS/nixpkgs/commit/e5064c2d11d971f2e62c6f3052f29a34997002be) haskellPackages.gogol{-core}: add version assert
* [`67304a06`](https://github.com/NixOS/nixpkgs/commit/67304a067748709eaa7de40a6d3bcf0089b3ff34) haskellPackages.gogol-*: use lib.genAttrs instead of manual fold
* [`0cbd903d`](https://github.com/NixOS/nixpkgs/commit/0cbd903dcc4b89a1680373e824935b0c0888c949) haskellPackages.gogol-core: base64_1_0 => base64
* [`d3685257`](https://github.com/NixOS/nixpkgs/commit/d36852576cbb3bbb33004d93884bd8ee50cfcb49) haskellPackages: remove overrides no longer needed on 9.10+
* [`46d6097e`](https://github.com/NixOS/nixpkgs/commit/46d6097eebf4d5770e999cd176466a4d708d0ea4) haskellPackages.lucid: jailbreak on 9.12 instead
* [`ef85af19`](https://github.com/NixOS/nixpkgs/commit/ef85af19db37a7cedd3b3c6d57c6592da47be965) haskellPackages.jailbreak-cabal: remove override on 9.12
* [`11fb5443`](https://github.com/NixOS/nixpkgs/commit/11fb5443e0e0e6c43fb68f6ebf17a86cef2b1b46) cabal-install: use buildTools in override
* [`0dbb48f0`](https://github.com/NixOS/nixpkgs/commit/0dbb48f0d784a2ee296b541130ed98f80304fa43) haskellPackages.yesod-core: unbreak
* [`62410012`](https://github.com/NixOS/nixpkgs/commit/624100124a4a78e3e136da15188900a3f000127e) haskellPackages.hledger*: unbreak ([nixos/nixpkgs⁠#376607](https://togithub.com/nixos/nixpkgs/issues/376607))
* [`a4a989c6`](https://github.com/NixOS/nixpkgs/commit/a4a989c6104df4a0de7c5328a174e8072d98e099) haskellPackages.data-array-byte: allow tasty-quickcheck == 0.11.*
* [`6441beaa`](https://github.com/NixOS/nixpkgs/commit/6441beaa6e4d188465fb187ef9dc8a104844922a) haskellPackages.hledger*_1_40: drop obsolete overrides
* [`c5c2204c`](https://github.com/NixOS/nixpkgs/commit/c5c2204c51142df00b9a55bce2d85b8a163bff75) Reapply "cachix: 1.7.5 -> 1.7.6"
* [`5a55e4af`](https://github.com/NixOS/nixpkgs/commit/5a55e4affeb1ba78d3b5173445efdef3800931a9) haskellPackages.hevm: fix build 0.54.2 for ghc 9.8.4
* [`47f4b53e`](https://github.com/NixOS/nixpkgs/commit/47f4b53ed3148c643aafa4f79ed4643e229a0a2e) echidna: 2.2.3 -> 2.2.6
* [`eff48dc8`](https://github.com/NixOS/nixpkgs/commit/eff48dc8936f2340c790f4db9d02b52ce783efd5) haskellPackages.minio-hs: use latest master, support crypto-connection >= 0.4.0
* [`4ded44b3`](https://github.com/NixOS/nixpkgs/commit/4ded44b38fb40dfc4bc236907538cb7f827f7cbd) haskellPackages.gogol-*: mark deprecated packages as broken
* [`660cdd1a`](https://github.com/NixOS/nixpkgs/commit/660cdd1ac762c63c2f2934050cad921d777a1438) all-cabal-hashes: 2025-01-05T13:11:15Z -> 2025-01-27T07:59:56Z
* [`9153c98b`](https://github.com/NixOS/nixpkgs/commit/9153c98bbd1b3b4292184fa51a1bae9f86c12043) haskellPackages: stackage LTS 23.3 -> LTS 23.5
* [`5d870925`](https://github.com/NixOS/nixpkgs/commit/5d8709258d74714a68006ee408a627082ea10dfb) haskellPackages: regenerate package set based on current config
* [`b0b78c06`](https://github.com/NixOS/nixpkgs/commit/b0b78c06cf53919a0940be25822c124c7aa3fd09) haskell.packages.ghc98.ghc-syntax-highlighter: use stackage version
* [`02ce24ea`](https://github.com/NixOS/nixpkgs/commit/02ce24eaae983b0757164cd83236b5446ff22519) haskellPackages.jacinda: adjust to happy 2.1.3 -> 2.1.4
* [`a7921823`](https://github.com/NixOS/nixpkgs/commit/a792182340fab03ab1fcf00549bfaf6825ba5db8) haskellPackages.HaskellNet-SSL: drop upstreamed patch
* [`3f49cdd2`](https://github.com/NixOS/nixpkgs/commit/3f49cdd2fc3c5e0e969a5d8cdea27cf29db73aa8) haskellPackages: drop obsolete reflex overrides
* [`08a68576`](https://github.com/NixOS/nixpkgs/commit/08a68576d1502c56efc1c896c77ca21579873b00) haskellPackages.tls_2_0_6: remove at 2.0.6
* [`359b4e0a`](https://github.com/NixOS/nixpkgs/commit/359b4e0a0aa8438b93b94afb24e311ee418e4546) haskell.packages.ghc9121.alex: workaround incorrect datadir in tests
* [`fcf2edf2`](https://github.com/NixOS/nixpkgs/commit/fcf2edf28d496e4ff7c752dc71bc8e6d485f604d) haskellPackages.filepath-bytestring: drop obsolete jailbreak
* [`842c5ec9`](https://github.com/NixOS/nixpkgs/commit/842c5ec97e9054f288107c940fc8fbaf8626579f) haskell.packages.ghc9101.fourmolu: 0.16.2.0 -> 0.17.0.0
* [`2e57661e`](https://github.com/NixOS/nixpkgs/commit/2e57661eb17b262105aac527360be80556b57d0c) haskellPackages.{libtorch-ffi-helper,mockcat,posix-timer}:not broken
* [`29f311fe`](https://github.com/NixOS/nixpkgs/commit/29f311fe0afe4499daa08dbec01d8abc2ed61177) haskellPackages.microlens-pro: unbreak
* [`20e6b993`](https://github.com/NixOS/nixpkgs/commit/20e6b993b5a678ef0b9e9e7eeddc514d96acce64) haskell.packages.ghc9121.ghc-lib*: use 9.12 versions
* [`9f1ab09f`](https://github.com/NixOS/nixpkgs/commit/9f1ab09fef3088a740669c9a63c25e923f06a8f1) haskell.packages.ghc9121.ghc-syntax-highlighter: use 0.0.13.0
* [`be762a74`](https://github.com/NixOS/nixpkgs/commit/be762a74adf40991a76c80d328d536952d0d0fa5) dhall-lsp-server: use released version again
* [`cc39263f`](https://github.com/NixOS/nixpkgs/commit/cc39263f9f8847367169e5ef5e184d49e7a3506f) dhall-json: allow newer aeson, text and bytestring
* [`c1d2537d`](https://github.com/NixOS/nixpkgs/commit/c1d2537d9cd594f93c14dc4db055b2665f7130d3) dhall-lsp-server: build using lsp-types == 2.1.*
* [`a761d45c`](https://github.com/NixOS/nixpkgs/commit/a761d45ca2e13e0e61bb1e92142fa2a94f697722) haskellPackages.amazonka{,-*}: build with latest source from github
* [`d65f4423`](https://github.com/NixOS/nixpkgs/commit/d65f44238f8c367ee8965e8574dc0e0beadfde14) haskellPackages.amazonka: add mpscholten as maintainer
* [`219859f8`](https://github.com/NixOS/nixpkgs/commit/219859f8985847b63b6fd7c08275d1dcdcaab63d) haskellPackages.monad-logger-extras: drop released patch
* [`a9533bee`](https://github.com/NixOS/nixpkgs/commit/a9533beeeddad349aee4368567f91ac4b6b3bd41) haskellPackages: cleanup after latest hackage/stackage bump
* [`4c688713`](https://github.com/NixOS/nixpkgs/commit/4c688713bbd358fe984fbbbc2ab2cc4b1171e90f) haskellPackages.cabal2nix-unstable: 2025-01-17 -> 2025-01-28
* [`3b4b5279`](https://github.com/NixOS/nixpkgs/commit/3b4b52796495d9ec532f42d1e767fc1b9f249a15) haskellPackages: regenerate package set based on current config
* [`b460ad49`](https://github.com/NixOS/nixpkgs/commit/b460ad4968094506614840060cfa3b4af73c27c2) haskellPackages.lifted-base: patch instead of jailbreaking in newer GHC
* [`396f1a6f`](https://github.com/NixOS/nixpkgs/commit/396f1a6f5e0571362056be913681ad42907c6b18) haskellPackages.fused-effects-readline: remove jailbreak
* [`7425afae`](https://github.com/NixOS/nixpkgs/commit/7425afaef0408bcfddfba753e2b3d9bf8c5ca67a) haskellPackages.doctest: fix build and tests on ghc 9.12
* [`f66f34f0`](https://github.com/NixOS/nixpkgs/commit/f66f34f0d1dc39f2cb8bdf8053a26afeefc5cbfd) haskellPackages.password: don't pull in scrypt if unsupported
* [`61443767`](https://github.com/NixOS/nixpkgs/commit/61443767915305957127ff03c0d1d7a9463d96eb) haskell.packages.ghc9121.time-compat: 1.9.7 -> 1.9.8
* [`adeca654`](https://github.com/NixOS/nixpkgs/commit/adeca654dcb9d369582fcc42bdddcafbe7829ba9) haskell.packages.ghc9121.ed25519: allow ghc-prim == 0.13.*
* [`9b60fc0c`](https://github.com/NixOS/nixpkgs/commit/9b60fc0c8f74718642a0161303429f2170091749) haskell.packages.ghc9121.doctest: use 0.23.0 as base for overrides
* [`9505a8b6`](https://github.com/NixOS/nixpkgs/commit/9505a8b672b579f79cd553c7793f91a601b91943) haskell.packages.ghc9121.doctest: use patch for 9.12 support
* [`93f6e8d1`](https://github.com/NixOS/nixpkgs/commit/93f6e8d16bc5653505d0165ccec7b667690f7071) haskell.packages.ghc9121.cabal-install: fix eval with Cabal core pkg
* [`8926b9dd`](https://github.com/NixOS/nixpkgs/commit/8926b9dd5560dc18d221983d1a1bace394791a3a) haskellPackages.servant: jailbreak on 9.12
* [`097f9c5d`](https://github.com/NixOS/nixpkgs/commit/097f9c5d8824a66fd24cda60f2a7c3947461e310) haskellPackages.req: ignore revised bounds on Hackage
* [`28ec594c`](https://github.com/NixOS/nixpkgs/commit/28ec594cd44c47140fe95ceefec21ab5e5b82e82) haskellPackages.stan: drop patch
* [`10d90711`](https://github.com/NixOS/nixpkgs/commit/10d907111d5d3f6d885efaa22ca82d4d0b06385e) haskellPackages.bsb-http-chunked: fix test suite
* [`f83f6a25`](https://github.com/NixOS/nixpkgs/commit/f83f6a25ce92fd1b6b331f3473f91bb5626ce67f) installer: fix broken search suggestion in default config
* [`52f04f6e`](https://github.com/NixOS/nixpkgs/commit/52f04f6e3679260c3515a23d3dba583d0d40b0b7) haskellPackages.ghc-source-gen: allow tasty-quickcheck == 0.11.*
* [`1236b61f`](https://github.com/NixOS/nixpkgs/commit/1236b61f3c5266cf1fa8d8b255c971b00a02f423) haskell.packages.ghc{90,810}.nothunks:don't pull in wherefrom-compat
* [`693cc5ff`](https://github.com/NixOS/nixpkgs/commit/693cc5ffe409800801d9214f1a97e0bdba325c43) haskell.packages.*.semaphore-compat: only test on GHC == 9.6.*
* [`d61f72dd`](https://github.com/NixOS/nixpkgs/commit/d61f72dd7edd1b1b4c9f0b79e76ba717f3fc9d02) haskell.compiler.ghcHEAD: 9.13.20250115 -> 9.13.20250205
* [`a7493a6a`](https://github.com/NixOS/nixpkgs/commit/a7493a6a7c864bbbb4289eac321db7841a74b433) pdftricks: init at 0.4.1
* [`37e1494d`](https://github.com/NixOS/nixpkgs/commit/37e1494da90d1c89e6dcbbb1001a7fdc43fe7446) haskellPackages.doctest*: unify doctest overrides
* [`f1c66362`](https://github.com/NixOS/nixpkgs/commit/f1c66362a2e0fbff990f9cd985bd12703783f066) haskellPackages: regenerate package set based on current config
* [`c77155e4`](https://github.com/NixOS/nixpkgs/commit/c77155e4fd1a9055ba5fc19270c7e3d061f3fa34) haskellPackages.aws-spend-summary: unbreak
* [`5d04bbf0`](https://github.com/NixOS/nixpkgs/commit/5d04bbf0ae7a1dc01a290916603b997cdc91d320) haskellPackages.reflex-dom: override or jailbreak deps on GHC 9.12
* [`4f6d1dd7`](https://github.com/NixOS/nixpkgs/commit/4f6d1dd754b97c13db840105b84219ea12a3f88c) haskellPackages: add miso/reflex-dom ghcjs 9.12 to release-haskell
* [`b0a53a75`](https://github.com/NixOS/nixpkgs/commit/b0a53a756a1829546530df189ba97699cd5c4a44) haskellPackages: stackage LTS 23.5 -> LTS 23.8
* [`b78d09f8`](https://github.com/NixOS/nixpkgs/commit/b78d09f82f9a63cbfe4b44a5f666ccbbc864261e) all-cabal-hashes: 2025-01-27T07:59:56Z -> 2025-02-10T08:47:10Z
* [`fe3de557`](https://github.com/NixOS/nixpkgs/commit/fe3de557904f87b67264d03bd73821867554181a) haskellPackages: regenerate package set based on current config
* [`631bba9b`](https://github.com/NixOS/nixpkgs/commit/631bba9bb043bd0b6e56c94b04a728c7845c7588) haskell.packages: adjust to (latest) version bumps in latest hackage
* [`27b4d7a8`](https://github.com/NixOS/nixpkgs/commit/27b4d7a8956e5044624a1f53b4c1ea0efc42b646) haskellPackages.deferred-folds: drop obsolete patch
* [`512af68e`](https://github.com/NixOS/nixpkgs/commit/512af68ef1e64627bc569c9829c7449393a6d281) haskellPackages.postgresql-libpq: build against libpq only
* [`a9dc84ca`](https://github.com/NixOS/nixpkgs/commit/a9dc84caad69d8a5e4cabb05af33c081b00e1b05) haskellPackages.psqueues: remove patch
* [`f8544ff5`](https://github.com/NixOS/nixpkgs/commit/f8544ff57edafee9197f82ef25742943ba7744c8) haskellPackages.text-builder: 0.6.7.2 -> 0.6.7.3
* [`6b72f835`](https://github.com/NixOS/nixpkgs/commit/6b72f835cb77c79980d58861a8cf2916892e16f5) haskellPackages.postgrest: 12.0.3 -> 12.2.7
* [`062fde00`](https://github.com/NixOS/nixpkgs/commit/062fde00ff78a3f15bed5eebb7e7dd062f24401e) pkgsStatic.haskellPackages.postgrest: fix build
* [`f1fe7e8e`](https://github.com/NixOS/nixpkgs/commit/f1fe7e8e3fac9e2bc48cfb26d45344e110e90924) top-level/release-haskell.nix: add postgrest to pkgsStatic
* [`69cff7ec`](https://github.com/NixOS/nixpkgs/commit/69cff7ecd3c5311f4020508d2ea485af4d924063) haskellPackages.pinboard-notes-backup: allow tls >= 2.0
* [`7baf979a`](https://github.com/NixOS/nixpkgs/commit/7baf979a931da0a8c1289003d18c5da430e8b378) haskellPackages.aws-spend-summary: drop obsolete override
* [`417ce2b9`](https://github.com/NixOS/nixpkgs/commit/417ce2b9cda5f8fb3f50089d116d90ab73d195d9) haskellPackages.extensions: update jailbreak comment
* [`198692b6`](https://github.com/NixOS/nixpkgs/commit/198692b696d32692f29d6b2c8ce12b7b333db7fb) haskellPackages.vector: remove jailbreak
* [`e53514a3`](https://github.com/NixOS/nixpkgs/commit/e53514a3bc59c7da834bdbb781af2315e3ba03c1) haskellPackages.http-api-data: remove jailbreak
* [`01d2854b`](https://github.com/NixOS/nixpkgs/commit/01d2854bce1b09f053882828e45cd2048902be5e) haskellPackages.tasty-discover: update jailbreak comment
* [`d42a902a`](https://github.com/NixOS/nixpkgs/commit/d42a902a7c9c71dc5688727edcf72b3203577c0a) haskellPackages.provide: remove jailbreak
* [`8609cf1d`](https://github.com/NixOS/nixpkgs/commit/8609cf1d129ddf7605d072ff8ba339bd9f65635f) haskellPackages.lawful-conversions: remove jailbreak
* [`c9c03f27`](https://github.com/NixOS/nixpkgs/commit/c9c03f277716b3e9a81f4b777c724d65035d69e4) haskellPackages.tasty-hunit-compat: fix build
* [`84a74215`](https://github.com/NixOS/nixpkgs/commit/84a742157f78cfc55dabb219f2ffa57fc54cbffd) haskellPackages: regenerate package set
* [`4afbfb93`](https://github.com/NixOS/nixpkgs/commit/4afbfb93516a403926ff0645a899ef7ef35883bd) haskellPackages.monad-bayes: unbreak
* [`a1c521a1`](https://github.com/NixOS/nixpkgs/commit/a1c521a18d25c925b4aa808b11978f6c50b6f7c2) haskellPackages.statistics: enable tests
* [`0345ddf3`](https://github.com/NixOS/nixpkgs/commit/0345ddf31d99d14f5639fe2379da77bbf443959c) haskellPackages.config-value: remove jailbreak
* [`f331a482`](https://github.com/NixOS/nixpkgs/commit/f331a482a9087d3e17818acbee51923b585b0f9d) haskellPackages.brick: enable test
* [`9ccf0931`](https://github.com/NixOS/nixpkgs/commit/9ccf09317f0ecdb943e2976768d2e022f782e4f4) haskellPackages.ghc-debug-common: jailbreak
* [`345ce230`](https://github.com/NixOS/nixpkgs/commit/345ce230cb2c0351f1f1869b613a3d6b7fe816b7) haskellPackages.ghc-debug-client: remove jailbreak
* [`42001ce0`](https://github.com/NixOS/nixpkgs/commit/42001ce06b66d7a5db59ca97fe702022c2058360) haskellPackages.threadscope: add TODO
* [`2d44ad02`](https://github.com/NixOS/nixpkgs/commit/2d44ad02e1b70f5689d002a47faa6020ad4bfa74) haskellPackages.rel8: remove jailbreak
* [`970fbc2a`](https://github.com/NixOS/nixpkgs/commit/970fbc2ac95b0bc2a526a9c6f16435713429747e) haskellPackages.tasty-checklist: fix build
* [`d41db62b`](https://github.com/NixOS/nixpkgs/commit/d41db62b22b408649baef5ceb620508e82a1fc31) haskellPackages.tasty-sugar: update jailbreak comment
* [`c8332d39`](https://github.com/NixOS/nixpkgs/commit/c8332d39a64a78a7a88af9bf6958c7cbda51ec81) haskellPackages.hedgehog-extras: unbreak
* [`67ba2e85`](https://github.com/NixOS/nixpkgs/commit/67ba2e859e182ce37fee80551da84215e5b371ff) haskellPackages.mueval: remove jailbreak
* [`f02c90d7`](https://github.com/NixOS/nixpkgs/commit/f02c90d746d6781df068ba7bd9c81d2c0af07557) haskellPackages.multistate: remove jailbreak
* [`dae993b0`](https://github.com/NixOS/nixpkgs/commit/dae993b0eed44bb1b28c17a7dbc959a121050f20) haskellPackages.pontarius-xmpp: remove jailbreak
* [`754ab622`](https://github.com/NixOS/nixpkgs/commit/754ab6225db8594773b3cc1967d2de7b6dd23b37) haskellPackages.applicative-quoters: remove jailbreak
* [`e39d5ae4`](https://github.com/NixOS/nixpkgs/commit/e39d5ae44ee543496e1934d9155c8b4ac6742ddc) haskellPackages.digestive-functors-blaze: update jailbreak comment
* [`4a4e0c35`](https://github.com/NixOS/nixpkgs/commit/4a4e0c352d288ec76d2703f0051a2baa01741db5) haskellPackages.sensei: enable test
* [`ec11232e`](https://github.com/NixOS/nixpkgs/commit/ec11232e89de46590f46c405bf637a0afe248628) haskellPackages.int-cast: remove jailbreak
* [`89fdca53`](https://github.com/NixOS/nixpkgs/commit/89fdca533c897f3901f6979d97992118fb4f499f) haskellPackages.pointfree: remove jailbreak
* [`ed1a9eb8`](https://github.com/NixOS/nixpkgs/commit/ed1a9eb86345872468b84740bc9969e868e40a02) haskellPackages.snap-templates: remove jailbreak
* [`9f22e12d`](https://github.com/NixOS/nixpkgs/commit/9f22e12deadfd5c81992c742052d6dd9a011792b) haskellPackages.mkDerivation: Replace testTarget with testTargets
* [`07f41ef2`](https://github.com/NixOS/nixpkgs/commit/07f41ef2d0478da7398283b10b97f7e361cce407) git-annex: update sha256 for 10.20250115
* [`164d61a4`](https://github.com/NixOS/nixpkgs/commit/164d61a4d6dd1665d9e7a42f5f4e0b94c1ee88ea) haskellPackages.superbuffer: allow bytestring >= 0.12
* [`2c8bbc8c`](https://github.com/NixOS/nixpkgs/commit/2c8bbc8c3ad9f94260cedb08e8ce5302c348fdc8) haskellPackages.pipes-http: allow bytestring >= 0.12
* [`e06cc9e4`](https://github.com/NixOS/nixpkgs/commit/e06cc9e4359ab9e025b9a16c4bcf062831b97f31) haskellPackages.bytebuild: allow tasty-quickcheck == 0.11.*
* [`87b31378`](https://github.com/NixOS/nixpkgs/commit/87b3137876da8c58bbd6c8c4b604bf9d282304ab) haskellPackages.large-generics: allow base >= 4.19
* [`726f64a7`](https://github.com/NixOS/nixpkgs/commit/726f64a78e77dfcd131438fe3f3fff1131c630c9) haskellPackages.heystone: allow bytestring >= 0.12
* [`ff231fb0`](https://github.com/NixOS/nixpkgs/commit/ff231fb0e2cdac1e496d5b5a077b188656dddd31) haskellPackages.shh: remove jailbreak
* [`0b158acf`](https://github.com/NixOS/nixpkgs/commit/0b158acfde1cb39cb3c19750c5910031d8ab070e) haskellPackages.vulkan-utils: enable tests
* [`6a97f278`](https://github.com/NixOS/nixpkgs/commit/6a97f2784831fbc046b2893812ebbc6baef50200) haskellPackages.servant-auth-server: remove jailbreak
* [`71fb29ab`](https://github.com/NixOS/nixpkgs/commit/71fb29ab22bbfc3c7c4738d1d18dd0a7c8a545d4) haskellPackages.servant-foreign: remove jailbreak
* [`3da6a28c`](https://github.com/NixOS/nixpkgs/commit/3da6a28c45372fb7fc51b8315afeafd3dfb66d36) haskellPackages.dhall-nixpkgs: update comment about jailbreak
* [`7924813f`](https://github.com/NixOS/nixpkgs/commit/7924813f25cc72edd85249b330c6d382a71d9246) haskellPackages.dhall-nix: remove jailbreak
* [`91261e61`](https://github.com/NixOS/nixpkgs/commit/91261e61f837664c752598f0543dbb6580ae0392) haskellPackages.lima: enable tests
* [`6211cf8d`](https://github.com/NixOS/nixpkgs/commit/6211cf8d53f56abd81c1e565a9151d1f10f6d477) haskellPackages.json-alt: fix build
* [`d0b156e5`](https://github.com/NixOS/nixpkgs/commit/d0b156e58d01b2dd7f1d619c3e19bbf06af634e0) haskellPackages.Chart-tests: remove jailbreak
* [`d24a1cff`](https://github.com/NixOS/nixpkgs/commit/d24a1cff754bc780903e9add4041fa70e56e865d) haskellPackages.cabal-install-parsers: remove jailbreak
* [`2f79e32b`](https://github.com/NixOS/nixpkgs/commit/2f79e32b3fad6a425896613715d1206d8b5384b4) haskellPackages.persistent-postgresql: enable tests
* [`6b5cd386`](https://github.com/NixOS/nixpkgs/commit/6b5cd3864fb343617a00c6f91bbcce4f400f4242) haskellPackages.persistent-sqlite: enable tests
* [`5868b672`](https://github.com/NixOS/nixpkgs/commit/5868b6728eb6852ac214c0e82624bb2c0c1fd1bf) haskellPackages.lsql-csv: remove jailbreak
* [`7a751e4c`](https://github.com/NixOS/nixpkgs/commit/7a751e4cb2fed73da0d5f3a5ccb439b4f9e7a025) haskellPackages.stm-containers: remove jailbreak
* [`f5f355cb`](https://github.com/NixOS/nixpkgs/commit/f5f355cb0be619984cc56fcbaf70cf72c4603c57) haskellPackages.servant-swagger-ui-core: remove jailbreak
* [`e8e5a1b5`](https://github.com/NixOS/nixpkgs/commit/e8e5a1b52b020c928740c8fd807fc68982f4abe5) haskellPackages.haddock-library: remove jailbreak
* [`e259180c`](https://github.com/NixOS/nixpkgs/commit/e259180cdafe2c893f29bbe85fbdea1403fce906) haskellPackages.nothunks: enable tests
* [`3403a758`](https://github.com/NixOS/nixpkgs/commit/3403a7589180774687fe81c1f1cd4424cd9828a1) haskellPackages.http-client-restricted: remove jailbreak
* [`566c4f7a`](https://github.com/NixOS/nixpkgs/commit/566c4f7ab076b37cfbf84199cc2727c3ce823f06) haskellPackages.vivid-osc: enable tests
* [`fa148375`](https://github.com/NixOS/nixpkgs/commit/fa148375e42504283c3a2839fc32bb2ec161d770) haskellPackages.cli-nix: remove outdated comment
* [`f8c2e690`](https://github.com/NixOS/nixpkgs/commit/f8c2e6908a7a6a38b398e832d880ada20cb1c377) haskellPackages.ginger: remove jailbreak
* [`b9f70e3c`](https://github.com/NixOS/nixpkgs/commit/b9f70e3c33062baaac5565b81753f709eb0d72d2) haskellPackages.blake2: fix build, enable tests
* [`7ed949c2`](https://github.com/NixOS/nixpkgs/commit/7ed949c23ec3da2cc689ffbf9286a508228db2bb) haskellPackages.matrix-client: remove jailbreak
* [`4fb4a37c`](https://github.com/NixOS/nixpkgs/commit/4fb4a37c699d0126fb97715edd1d46631a4d7935) haskellPackages.exact-pi: fix build
* [`1758421f`](https://github.com/NixOS/nixpkgs/commit/1758421f32a054c8cca80b67f1d35aa19d50a9bd) haskellPackages.table-layout: update jailbreak comment
* [`5db9a848`](https://github.com/NixOS/nixpkgs/commit/5db9a848abe1cacc7a19d9bdf03da04d1e935a5e) haskellPackages.streamly-bytestring: fix build
* [`b058d6ea`](https://github.com/NixOS/nixpkgs/commit/b058d6eaeef4cd02fc0c1455377f501fc9aee305) haskellPackages.hsexif: fix build
* [`f14f794a`](https://github.com/NixOS/nixpkgs/commit/f14f794a5711422c262f13e832790ec29ab1e632) haskellPackages.morpheus-graphql-code-gen: unbreak
* [`f733c415`](https://github.com/NixOS/nixpkgs/commit/f733c4157e8cc802904dac10ebe8150158595792) haskellPackages.morpheus-graphql: fix build
* [`b2cab973`](https://github.com/NixOS/nixpkgs/commit/b2cab9734fc6122c6d45002c8f2b458cf844b37f) haskellPackages.validation-selective: update jailbreak comment
* [`99ba4290`](https://github.com/NixOS/nixpkgs/commit/99ba42905b7b929cf7a7e3124e45f74d51b2fbe2) haskellPackages.validation: remove jailbreak
* [`dd81a88b`](https://github.com/NixOS/nixpkgs/commit/dd81a88b027c35ac5f9d20485b62518578ea803f) haskellPackages.shower: update jailbreak comment
* [`8f94929e`](https://github.com/NixOS/nixpkgs/commit/8f94929ed26c65df9736ec71d90ecc5aa6e09114) haskellPackages.ema: update jailbreak comment
* [`d7920de6`](https://github.com/NixOS/nixpkgs/commit/d7920de6502a5f38808312e45d5d8182092b8c0b) haskellPackages.relude: remove patch
* [`5f623713`](https://github.com/NixOS/nixpkgs/commit/5f623713641b9607f3e16767ffc0f4629480d8ab) haskellPackages.system-fileio: remove jailbreak
* [`034e4a58`](https://github.com/NixOS/nixpkgs/commit/034e4a580861ed3a8dcb4e5a3f2260b0a86a0d5b) haskellPackages.conduit-aeson: remove overrides
* [`dd7a226b`](https://github.com/NixOS/nixpkgs/commit/dd7a226ba8f9fc26d875ed11338890e9926b0330) haskellPacakges.hermes-json: update jailbreak comment
* [`b5d17c13`](https://github.com/NixOS/nixpkgs/commit/b5d17c13b1796f5f834bfac46fca1f0f6dd74c03) haskellPackages.rdf: remove jailbreak
* [`d45068a5`](https://github.com/NixOS/nixpkgs/commit/d45068a56f5e6b9e909cd8b37ca9d90ff74d9642) haskellPackages.cases: remove jailbreak
* [`671332b0`](https://github.com/NixOS/nixpkgs/commit/671332b05d078c90a59fe32e67c2474990c706f5) haskellPackages.numbered-semigroups: remove jailbreak
* [`0a955b7a`](https://github.com/NixOS/nixpkgs/commit/0a955b7a12dcbf461bee77038065e6cd539f3456) haskellPackages.fast-builder: remove jailbreak
* [`94a1d9b6`](https://github.com/NixOS/nixpkgs/commit/94a1d9b653ad92b6d2a30dfe9527c38291d606d2) haskellPackages.tagtree: remove jailbreak
* [`e4b79e92`](https://github.com/NixOS/nixpkgs/commit/e4b79e920ce96139bfad5db119a25ebd1d38662a) haskellPackages.polysemy: remove jailbreak
* [`5ffe828c`](https://github.com/NixOS/nixpkgs/commit/5ffe828cf84d3d718fe53ef846bd66a47afa2d00) haskellPackages.co-log-polysemy: remove jailbreak
* [`9ab30278`](https://github.com/NixOS/nixpkgs/commit/9ab30278a13aa4d8478a817602bca91de0109cd0) haskellPackages.posix-api: remove jailbreak
* [`f8469d14`](https://github.com/NixOS/nixpkgs/commit/f8469d14164c5ff8ebb7b6fa90069dbc7bd66666) haskellPackages.swagger2: remove jailbreak
* [`064f144d`](https://github.com/NixOS/nixpkgs/commit/064f144d3622d037f947a04541e180fd6d12c2b2) haskellPackages.unleash-client-haskell-core: remove jailbreak
* [`bcf13487`](https://github.com/NixOS/nixpkgs/commit/bcf13487657fd8ae649b63466a04d29254d35bb1) haskellPackages.lzma: remove jailbreak
* [`30dbca47`](https://github.com/NixOS/nixpkgs/commit/30dbca479b1ae9215251557ce4f8c8c67ec653ad) haskellPackages.warp-systemd: fix indent
* [`7c0a5b61`](https://github.com/NixOS/nixpkgs/commit/7c0a5b61c8d3632713611b06f81956e2d270b112) haskellPackages.quickcheck-state-machine: drop obsolete override
* [`ceaff924`](https://github.com/NixOS/nixpkgs/commit/ceaff92431df2c90b74891bc3bf7f3f2294e13ae) haskellPackages: remove srid from maintainers
* [`8aadf528`](https://github.com/NixOS/nixpkgs/commit/8aadf528beba855f27b8ae2953449d8c3b6ecbb6) haskell-modules/HACKING: drop note about deleting haskell-updates
* [`d38e3dc4`](https://github.com/NixOS/nixpkgs/commit/d38e3dc423ac136869fb13a5d17daaf815ced549) haskell-modules/HACKING: document new workflow w.r.t. target branch
* [`b3d74de2`](https://github.com/NixOS/nixpkgs/commit/b3d74de2a1ba47f6e3f0c37f9d7d6b4a116ef6a3) maintainers/haskell/merge-and-open-pr.sh: target staging
* [`e8d51923`](https://github.com/NixOS/nixpkgs/commit/e8d519239e7d6a83239cc3072046cdad981c1438) maintainers: add psyclyx
* [`c0147bb6`](https://github.com/NixOS/nixpkgs/commit/c0147bb6cb3ac847a1f7157dfa564d30661a429c) maintainers: add marnas and conduktorbot
* [`b5e8ee3b`](https://github.com/NixOS/nixpkgs/commit/b5e8ee3b3abf2f1af37eef75d62fdaf582f488fa) conduktor-ctl: init at 0.4.0
* [`f0a17fd2`](https://github.com/NixOS/nixpkgs/commit/f0a17fd27c51a0069e74b806dc2cfb5ed949bc17) haskell.packages.ghc{90,810}.cabal2nix: fix build of dependency tar
* [`18bfcc93`](https://github.com/NixOS/nixpkgs/commit/18bfcc939c91f324bd81f30b3db6430b132d7bce) haskellPackages: remove version overrides now default
* [`31f1c125`](https://github.com/NixOS/nixpkgs/commit/31f1c125eb2d15e5269d1c8b285b508df6c24dd1) hasura-graphql-engine, haskellPackages: remove all broken hasura pkgs
* [`b71bdc9f`](https://github.com/NixOS/nixpkgs/commit/b71bdc9f2ad909342d7c4030acf0173b313fa354) haskellPackages.{ci-info, hasura-resource-pool}: remove
* [`80b7f912`](https://github.com/NixOS/nixpkgs/commit/80b7f91201385128b615d79261bfcecf2ee6cd68) haskellPackages.http-api-data: jailbreak on 4.12
* [`bb9e2af8`](https://github.com/NixOS/nixpkgs/commit/bb9e2af866102976797da9cda264a7e97959c40d) haskellPackages.cabal2nix-unstable: 2025-01-28 -> 2025-02-14
* [`c4a7559c`](https://github.com/NixOS/nixpkgs/commit/c4a7559ce6a866702a6b48259a1085623370db9c) haskellPackages.Chart-tests: fix build
* [`17e00da6`](https://github.com/NixOS/nixpkgs/commit/17e00da64ca52eacb3d1ccb9449b020129870d7e) haskellPackages.threadscope: remove some patches
* [`3e41db10`](https://github.com/NixOS/nixpkgs/commit/3e41db10c8618885d81fd29bfc856523519a9ee8) haskellPackages.attoparsec-varword: fix build
* [`5533f8ff`](https://github.com/NixOS/nixpkgs/commit/5533f8ffbfa1bf5b85854535e3fc09c1ec6aa39f) haskellPackages.kewar: unbreak
* [`b144b7c4`](https://github.com/NixOS/nixpkgs/commit/b144b7c4c244381ad7bdb19ad3ad04cf521bac2b) haskellPackages: move markBroken to broken.yaml
* [`2ad60c21`](https://github.com/NixOS/nixpkgs/commit/2ad60c21484650ab86e9a6092f0d10ae5e4ca773) haskellPackages: remove changelog-d
* [`dbb8e3c9`](https://github.com/NixOS/nixpkgs/commit/dbb8e3c96510dd863bc7fa0a34f439a3d919b555) haskellPackages: remove config for bounds-related broken packages
* [`140bae34`](https://github.com/NixOS/nixpkgs/commit/140bae3490e8c4550ef82b82f4a7887387582033) dhall-bash, dhall-yaml: ignore bounds on text, bytestring
* [`58f75e8b`](https://github.com/NixOS/nixpkgs/commit/58f75e8b64205aa12c38ec48833f28a10361283c) diffutils: 3.10 -> 3.11
* [`cb87da52`](https://github.com/NixOS/nixpkgs/commit/cb87da52967f7ebaa53d8607931459c85d1cb6a0) krank: apply patches for incompatibilities with recent stackage versions
* [`a5091b10`](https://github.com/NixOS/nixpkgs/commit/a5091b10fe8a4d4ab5d54344d2e93a4c5745489d) all-cabal-hashes: 2025-02-10T08:47:10Z -> 2025-02-15T14:17:54Z
* [`96095a4e`](https://github.com/NixOS/nixpkgs/commit/96095a4ede4301ac7c75cb412f1844e9d35d9c33) haskellPackages: regenerate package set based on current config
* [`ca49a9ad`](https://github.com/NixOS/nixpkgs/commit/ca49a9ad8574379241d5237e5abd32bd9ac870d2) haskellPackages.pinboard-notes-backup: drop incorrect override
* [`6c42718c`](https://github.com/NixOS/nixpkgs/commit/6c42718cebb15d9daefb308dfe11a2de69192dca) haskellPackages: add sellout as maintainer for their Hackage packages
* [`1bc037ad`](https://github.com/NixOS/nixpkgs/commit/1bc037ad15fdeab46306f014ae96d14d5e29194b) qpdf: 11.10.0 -> 11.10.1
* [`a8115e84`](https://github.com/NixOS/nixpkgs/commit/a8115e84789c71d2c3e24454c1c622100afb8326) re2c: 4.0.2 -> 4.1
* [`13517dc5`](https://github.com/NixOS/nixpkgs/commit/13517dc5da5ff154b3fe221007bf98012993033b) maintainers/scripts/haskell: add unbreak.nu script
* [`aa295449`](https://github.com/NixOS/nixpkgs/commit/aa2954498a284410d5e72984e24d3cf79ae3a24c) haskellPackages: unbreak packages
* [`27855fb3`](https://github.com/NixOS/nixpkgs/commit/27855fb32313966051de851011ef86691360ea69) haskellPackages: regenerate transitive-broken.yaml
* [`4f2c2da3`](https://github.com/NixOS/nixpkgs/commit/4f2c2da3956c1134b78306bf052be17c037b2cb5) cljstyle: init at 0.17.642
* [`2c2ccd22`](https://github.com/NixOS/nixpkgs/commit/2c2ccd22f04a4c38939ede5ac04188fd595a7988) haskellPackages.natural-transformation: allow tasty-quickcheck 0.11
* [`7d4116ba`](https://github.com/NixOS/nixpkgs/commit/7d4116ba3ca4df7004e3ed08aab32d94dd0ca8ba) haskellPackages.hookup: allow building with network == 3.2.*
* [`c1bfc3da`](https://github.com/NixOS/nixpkgs/commit/c1bfc3da0de99f6bc6fd168e7d98770c2701501d) haskellPackages: relax some jailbreaks
* [`b5d11659`](https://github.com/NixOS/nixpkgs/commit/b5d11659b7677a56106c0b6c11da7cd226561c59) haskellPackages: remove jailbreak for many packages
* [`14109fbd`](https://github.com/NixOS/nixpkgs/commit/14109fbdbfc02d8b7e5f993949408c72569baf6b) haskellPackages.ixset-typed: fix build with template-haskell >= 2.21
* [`1ee8e4b8`](https://github.com/NixOS/nixpkgs/commit/1ee8e4b88ec6454028a74aa822a88660f392aa2d) haskellPackages.aeson: disable tests for GHC < 9.8
* [`a2c86d93`](https://github.com/NixOS/nixpkgs/commit/a2c86d93f4eab759ecbe72df2e07299b34dfb0c8) hadolint: build with language-docker >= 13
* [`870d8e30`](https://github.com/NixOS/nixpkgs/commit/870d8e307e41a644f737f579bd0e56090f47aac4) haskellPackages.lattices: allow tasty-quickcheck == 0.11.*
* [`f5ebc8e4`](https://github.com/NixOS/nixpkgs/commit/f5ebc8e442667d333bbb24c1bb77aba408fd6958) haskell.compiler.ghcjs: match ansi-terminal* to ansi-wl-pprint
* [`34134db2`](https://github.com/NixOS/nixpkgs/commit/34134db233d1150f6e0d83ab259268db1f63259e) haskellPackages.base32: allow bytestring == 0.12.*
* [`736e9ff0`](https://github.com/NixOS/nixpkgs/commit/736e9ff05c95a630f7f950565a85ea3b656d6916) .devcontainer: add commands to adjust permissions under Codespaces
* [`ad48f676`](https://github.com/NixOS/nixpkgs/commit/ad48f676439e644e964b68ce3f1851396c335b73) haskellPackages.cabal2nix-unstable: 2025-02-14 -> 2025-03-03
* [`5c8323dc`](https://github.com/NixOS/nixpkgs/commit/5c8323dc9ba7f20e6c2fc0c0eb5d47d30de9cf63) haskell.compiler.ghc92{5,6,7}: remove
* [`d7e77268`](https://github.com/NixOS/nixpkgs/commit/d7e772681966e508a0ff4146d3aa9683dfea8591) haskell.compiler.*.some: add base-orphans dependency if necessary
* [`3a456afc`](https://github.com/NixOS/nixpkgs/commit/3a456afc66e4f17b4a8a5a179eb2cee986fa5d41) haskellPackages.primitive: pull in Hackage revisions
* [`454424ea`](https://github.com/NixOS/nixpkgs/commit/454424ea0f3433afda421de26ae97754ee7d35b2) haskellPackages.http2-client: fix w/ current http2, tls, network
* [`5672a3bc`](https://github.com/NixOS/nixpkgs/commit/5672a3bc48d386e18bd660596651da451de96014) haskellPackages.lsp-types_2_1_0_0: make build independently
* [`f58de0aa`](https://github.com/NixOS/nixpkgs/commit/f58de0aaf994cc71867e877ecf001541677479f7) haskellPackages.lsp_2_4_0_0: allow lens >= 5.3
* [`ff6e6b99`](https://github.com/NixOS/nixpkgs/commit/ff6e6b99477511c9e30a9c61b37618b53139ebca) haskell.packages.ghc{981-983,9101}.cabal-install: ignore unix bound
* [`033cf433`](https://github.com/NixOS/nixpkgs/commit/033cf4331ebb8104330c550bd58b5a734e5d1ab3) haskellPackages.jsaddle-warp: manually specify deps when built with js backend
* [`7a25c988`](https://github.com/NixOS/nixpkgs/commit/7a25c988dbf276c96cb1c4934d1599ebca136972) haskellPackages.miso-examples: fix build on js backend
* [`465ba967`](https://github.com/NixOS/nixpkgs/commit/465ba967e2c5c17724d54450cc178bbd52b96165) haskellPackages: unmark broken miso packages
* [`01c392c5`](https://github.com/NixOS/nixpkgs/commit/01c392c56bfa577d7029e5ae691176bc63579112) haskellPackages: relax some dontChecks
* [`918d67fe`](https://github.com/NixOS/nixpkgs/commit/918d67fec6f318ce5fb7aba905a96919cf7083ef) haskellPackages: re-enable tests for many packages
* [`6c43fcf0`](https://github.com/NixOS/nixpkgs/commit/6c43fcf0102e1e2cfa76a60e730ad24a4bf5bbd3) tamarin-prover: don't mix and match callPackage approaches
* [`04c02c77`](https://github.com/NixOS/nixpkgs/commit/04c02c77e003178bc08e348a95133a2456b07c1a) haskellPackages.fclabels: mark as broken for GHC >= 9.8
* [`4165a454`](https://github.com/NixOS/nixpkgs/commit/4165a45480994c18dcd3b15061fe126408f632ac) update-nix-fetchgit: patch for GHC >= 9.8
* [`0095736c`](https://github.com/NixOS/nixpkgs/commit/0095736cc132f1eaca0832c6c507cfee123fc0f8) ghc: make sure to also use 9.8 if targetPackages is empty
* [`3a790aa5`](https://github.com/NixOS/nixpkgs/commit/3a790aa5655933539abe56d95e09c138e161a8c0) tamarin-prover: build using GHC 9.6 until fclabels supports >= 9.8
* [`07e23f41`](https://github.com/NixOS/nixpkgs/commit/07e23f41cfd4e858e1ecd24c33a9b84b76935822) haskell.packages.ghc96*.cabal-install: ignore unix bound
* [`6df18504`](https://github.com/NixOS/nixpkgs/commit/6df185049563d9a635b954d879d8cfdfa2a998c5) elmPackages.elm-format: build using GHC 9.4
* [`00ce341f`](https://github.com/NixOS/nixpkgs/commit/00ce341f8a6c88f182014f49c3368f2607348998) haskell.packages.ghc912: add missing core packages
* [`387665e4`](https://github.com/NixOS/nixpkgs/commit/387665e425e59a6421599cc88667ac676e228e53) haskellPackages.hw-prim: unify overrides
* [`fe280c1a`](https://github.com/NixOS/nixpkgs/commit/fe280c1a67e5c8edf6bb978ad70fc007a39d7922) .editorconfig: unify free-standing bash with Nix-embedded bash
* [`c88013f7`](https://github.com/NixOS/nixpkgs/commit/c88013f757761449fa21d7eed1398c99d5f82813) stop maintaining candid and leb128-cereal
* [`2b77c8d4`](https://github.com/NixOS/nixpkgs/commit/2b77c8d4683a59469c0a863e16f5502ea6843d31) haskellPackages.espial: Remove maintainer
* [`69641d35`](https://github.com/NixOS/nixpkgs/commit/69641d3531756c88e1edf7b112f8c3dd76530f9c) installer/tools: fix grammatical error in docs
* [`299563c3`](https://github.com/NixOS/nixpkgs/commit/299563c31d97070fc1ee4654337f532129d874ba) haskellPackages.yaya-hedgehog: remove dependency override
* [`e634937d`](https://github.com/NixOS/nixpkgs/commit/e634937d85042b98ee99bbc284e4d0c8a28b8527) haskellPackages.blucontrol: jailbreak
* [`84990cbb`](https://github.com/NixOS/nixpkgs/commit/84990cbb50111dd0797af9cbc1cf0a29ad98fa4a) haskellPackages.haskell-ci: jailbreak
* [`f61f5fec`](https://github.com/NixOS/nixpkgs/commit/f61f5fec6e55be07c9647c8189af943e957c00ff) haskell.packages.ghc96.ghc-exactprint: use 1.7.1.0
* [`aa5009a8`](https://github.com/NixOS/nixpkgs/commit/aa5009a87aaf803de4195df6b63a18c29d5f02bc) fast-float: 8.0.1 -> 8.0.2
* [`ce0970e1`](https://github.com/NixOS/nixpkgs/commit/ce0970e19baa3555b919b79d6c5359f2a32f9d08) nixos/evremap: get rid of unecessary bash
* [`c2f04b2c`](https://github.com/NixOS/nixpkgs/commit/c2f04b2c1173baf34ed402f2637da74e33c11fac) pappl: 1.4.8 -> 1.4.9
* [`531808ae`](https://github.com/NixOS/nixpkgs/commit/531808ae70f284363a2a3dd83e18907722902f77) SDL2_image: 2.8.5 -> 2.8.8
* [`f8cfe08a`](https://github.com/NixOS/nixpkgs/commit/f8cfe08a3f50bbd0fe91d5068b4dc45d0d0380e1) kdePackages.plasma-wayland-protocols: 1.16.0 -> 1.17.0
* [`e13ae12c`](https://github.com/NixOS/nixpkgs/commit/e13ae12c3eee399770194b4af7537936c037b0bc) mercurial: 6.9.1 -> 6.9.4
* [`7157ae91`](https://github.com/NixOS/nixpkgs/commit/7157ae91ba2ca422ca2d29a4d695e8a2f1ccd331) maintainers: add arichtman
* [`ff9e4bce`](https://github.com/NixOS/nixpkgs/commit/ff9e4bce32b35ab6fc61e8ad64e5b91c0624c5b4) haskell: fix shellFor test
* [`56844f9e`](https://github.com/NixOS/nixpkgs/commit/56844f9ee6d1316c363470885bec0cd7630590f6) kubectl-kcl: init at version 0.9.0
* [`5386852b`](https://github.com/NixOS/nixpkgs/commit/5386852b574767e215bae38984fa1bfef7d68a0e) haskell: document shellFor extraDependencies
* [`b31c0516`](https://github.com/NixOS/nixpkgs/commit/b31c05161b31377bb23c6d2c190dd04fca043907) gdbm: 1.24 -> 1.25
* [`c641cb8c`](https://github.com/NixOS/nixpkgs/commit/c641cb8c5dce3b66e2d57a63c8144dbf930369c5) haskellPackages: enable check phase for various packages again
* [`366adcc4`](https://github.com/NixOS/nixpkgs/commit/366adcc463cc3175a34876da10a35f08be30a544) mbedtls: 3.6.2 -> 3.6.3
* [`b95c46e6`](https://github.com/NixOS/nixpkgs/commit/b95c46e6cfa7ff79db43ad8d7b95d1e2953892d0) noseyparker: use vectorscan instead of hyperscan
* [`964d8550`](https://github.com/NixOS/nixpkgs/commit/964d85507b908a1864cdb60057f743f82b02a2eb) ed: 1.21 -> 1.21.1
* [`fae64150`](https://github.com/NixOS/nixpkgs/commit/fae641502513324cece5202570bcc487bd6be464) libowfat: mark cross as broken
* [`bc77f0e7`](https://github.com/NixOS/nixpkgs/commit/bc77f0e7194ff3cda8113503d74b7010030754ca) nixos/regreet: use proper user in tmpfiles
* [`fc3ceeeb`](https://github.com/NixOS/nixpkgs/commit/fc3ceeebc6f099b1d126878200b5b1f05345a0b8) boringssl: run installPhase hooks
* [`f4a65dc7`](https://github.com/NixOS/nixpkgs/commit/f4a65dc7a5d106e4238ba0a999565366c712b6a5) haskell.compiler.ghc9122: init at 9.12.2
* [`568da741`](https://github.com/NixOS/nixpkgs/commit/568da741eef229d8129e92075ab5bf480777f2d8) haskell.compiler.ghc912: 9.12.1 -> 9.12.2
* [`87872520`](https://github.com/NixOS/nixpkgs/commit/878725203fc80308de291d15e27ef945ced831cb) haskell.packages.ghc912.extra: fix build ([nixos/nixpkgs⁠#390788](https://togithub.com/nixos/nixpkgs/issues/390788))
* [`39d24a14`](https://github.com/NixOS/nixpkgs/commit/39d24a14ea5ae1900fef2b87348348030aa0d2b1) haskellPackages: regenerate package set based on current config
* [`2329aa9f`](https://github.com/NixOS/nixpkgs/commit/2329aa9ff08a1f029558bf1d277bf93a3e9b2070) all-cabal-hashes: 2025-02-15T14:17:54Z -> 2025-03-30T11:13:14Z
* [`5544059b`](https://github.com/NixOS/nixpkgs/commit/5544059b96e0c1e2ba624088411136a0db2e2236) haskellPackages: regenerate package set based on current config
* [`4c35e0bc`](https://github.com/NixOS/nixpkgs/commit/4c35e0bcd86974de117ecf931cf7cc0ff86e2c3e) haskellPackages.splitmix: fix build on js backend
* [`8d017779`](https://github.com/NixOS/nixpkgs/commit/8d01777930bbe6ac2ea5d4400bb9d5c5fde4648b) haskellPackages: disable some flaky test suites
* [`6d2cfa96`](https://github.com/NixOS/nixpkgs/commit/6d2cfa967d7fc4e83811d412c8167a745aae51a2) haskell.compiler.ghc967: init at 9.6.7
* [`efeaa785`](https://github.com/NixOS/nixpkgs/commit/efeaa7858ba3619a4924bc758cda71df82898620) haskellPackages.ghcide: remove patch since merged
* [`dc15ca76`](https://github.com/NixOS/nixpkgs/commit/dc15ca767adb358e5d9d2643b1f4b460b2aed738) haskellPackages.cabal-install-parsers: remove Cabal-syntax override
* [`de68ab24`](https://github.com/NixOS/nixpkgs/commit/de68ab24b5b21d5470e96030de854e088976c586) haskellPackages.cabal-add: fix tests
* [`235415ca`](https://github.com/NixOS/nixpkgs/commit/235415cacf3c3caa75ee902ea0e738a827854372) example-robot-data: submodule is no longer required
* [`58c2cb01`](https://github.com/NixOS/nixpkgs/commit/58c2cb01d8f0ce268f2677f14d7499ce79ce2cc1) gawk: 5.3.1 -> 5.3.2
* [`ea01694b`](https://github.com/NixOS/nixpkgs/commit/ea01694bf331a7f4587132551d169bf63a112f4e) python312Packages.pyatmo: 8.1.0 -> 9.0.0
* [`4abf2088`](https://github.com/NixOS/nixpkgs/commit/4abf2088e71042d571411c88131ab9943675b69b) rdma-core: 56.0 -> 56.1
* [`38943842`](https://github.com/NixOS/nixpkgs/commit/389438426075977cacb23116dec43b32383ae4fc) graphite2: point to correct includedir in the .pc file
* [`eeec06e8`](https://github.com/NixOS/nixpkgs/commit/eeec06e84fe2a76e7ec1650a0322ea840988ab09) haskellPackages.postgres-websockets: unbreak
* [`2c63ce9c`](https://github.com/NixOS/nixpkgs/commit/2c63ce9cc0c3436999c1bc2666e7591e90fdbe8f) haskellPackages.postgres-websockets: adopt
* [`456a011e`](https://github.com/NixOS/nixpkgs/commit/456a011e715ca81f65a7d19d5f6ec856cc00e801) love_0_10: add missing xorg.libX11 depend
* [`8e2856fa`](https://github.com/NixOS/nixpkgs/commit/8e2856faf24f06673d18936cf8ceb2bb45371e45) libcdio: remove darwin frameworks
* [`0fb6da6f`](https://github.com/NixOS/nixpkgs/commit/0fb6da6ff12b6007c9d8727d4ef05e7870f8734c) libcdio: move to by-name
* [`937c706c`](https://github.com/NixOS/nixpkgs/commit/937c706c27a925ca60c93896f36a10b488b84dcd) libcdio: use fetchFromGitHub
* [`7c08955d`](https://github.com/NixOS/nixpkgs/commit/7c08955d3462a4ac3b7f2755746ea01508d18bb2) libcdio: split output
* [`79c1f678`](https://github.com/NixOS/nixpkgs/commit/79c1f678fd21e7804215559f1b0f13f3abd5e4b2) libcdio: add pkgConfigModules
* [`ced9e64f`](https://github.com/NixOS/nixpkgs/commit/ced9e64fafc81118179832f18e5c2f9088aff281) libcdio: add update script
* [`afd32df1`](https://github.com/NixOS/nixpkgs/commit/afd32df18c0254b63177bcfa15c9b617a12c72df) libcdio: remove with lib;
* [`5d3b4af4`](https://github.com/NixOS/nixpkgs/commit/5d3b4af481f54a46a3939b5bb95e6c3ab352c1dd) procmail: always use system `strstr`
* [`2babac1f`](https://github.com/NixOS/nixpkgs/commit/2babac1f9dd4d629b79d6017f98dbd85c0ef95f8) mpfr: 4.2.1 -> 4.2.2
* [`58944074`](https://github.com/NixOS/nixpkgs/commit/5894407401d600adefcab3962648c8063bf6a961) systemd: disable pacret hardening flag if withLibBPF
* [`77745996`](https://github.com/NixOS/nixpkgs/commit/77745996884b71793c0c30e413c9522b01e014b6) linux-pam: remove cracklib dependency
* [`c44749de`](https://github.com/NixOS/nixpkgs/commit/c44749debf49549417a964786fe680bb91dff2d3) haskellPackages.taskwarrior: fix bounds error
* [`6418dec0`](https://github.com/NixOS/nixpkgs/commit/6418dec0b6d9a8ae2b60b80b9c3b72a7c180f233) systemd: 257.3 -> 257.5
* [`57e3ec49`](https://github.com/NixOS/nixpkgs/commit/57e3ec49bf0adf40d1830a50d149a176314ad11e) virglrenderer: 1.1.0 -> 1.1.1
* [`ea31fed4`](https://github.com/NixOS/nixpkgs/commit/ea31fed4a3d5cc061a789f470eeea46ab92105db) libei: 1.4.0 -> 1.4.1
* [`050590ec`](https://github.com/NixOS/nixpkgs/commit/050590ec5c3988ce25f6bafcfd1829464e2ad176) libjack2: remove unused eigen dependency
* [`9e12b821`](https://github.com/NixOS/nixpkgs/commit/9e12b821407ac46d18ba79db6c7364f74e875e56) libjack2: remove unused readline and libsndfile dependencies
* [`5e472892`](https://github.com/NixOS/nixpkgs/commit/5e472892ca276f2e57b9c1be01c689e8795b6729) libjack2: refactor
* [`c5223b65`](https://github.com/NixOS/nixpkgs/commit/c5223b653554ff676d61774359ebf837918d20d2) haskellPackages: remove old workarounds for darwin
* [`646c26eb`](https://github.com/NixOS/nixpkgs/commit/646c26ebd028cf8a50d25d7c54f3f548708d4de2) haskellPackages.http-client-tls: jailbreak
* [`566dcac0`](https://github.com/NixOS/nixpkgs/commit/566dcac043d2fd941dfb682ec07b59e284adc877) kore: fix build
* [`71526b0d`](https://github.com/NixOS/nixpkgs/commit/71526b0da2a26238af659e1acbb1eb6489928a63) kore: use libpq 17
* [`78dac4e3`](https://github.com/NixOS/nixpkgs/commit/78dac4e3bd76d5dc947239150cd22bc62f189e10) python3Packages.asyncpg: fix build
* [`cd972edf`](https://github.com/NixOS/nixpkgs/commit/cd972edfe4dc28607d13616c4c3ad416fca8fa7f) postgresqlJitPackages.plv8: unbreak
* [`c0f7566e`](https://github.com/NixOS/nixpkgs/commit/c0f7566ed5b80f185f8b1371a184f455a1d13a85) postgresqlPackages.plv8: mark as broken on darwin
* [`4b164452`](https://github.com/NixOS/nixpkgs/commit/4b1644526a17ff256a8f82d7b32f12664ed7756a) maintainers/scripts/haskell/regenerate-hackage-packages.sh: run nixfmt on hackage-packages.nix
* [`ccdcdd5f`](https://github.com/NixOS/nixpkgs/commit/ccdcdd5f58815bea7586df611d03b7715c5788c1) haskellPackages: regenerate package set based on current config
* [`255987d2`](https://github.com/NixOS/nixpkgs/commit/255987d2505b9b278680bdb8b1852cdb12596d98) gnutls: drop lzip dependency
* [`a455c781`](https://github.com/NixOS/nixpkgs/commit/a455c781b0bbb381d3f9cc6186edf305e304b11c) coturn: add systemd support
* [`1a1b2339`](https://github.com/NixOS/nixpkgs/commit/1a1b23399858b40bb09e377c380037bae6a56dca) nixos/coturn: switch systemd service type to notify
* [`0e68b259`](https://github.com/NixOS/nixpkgs/commit/0e68b25955b7a844b80b603f162af2183e30756f) nixos/coturn: allow unix socket
* [`8b988c2d`](https://github.com/NixOS/nixpkgs/commit/8b988c2df6146e100a6e41b028a2ff83ea1d6336) gnutls: drop unused lzo dependency
* [`2a23ed26`](https://github.com/NixOS/nixpkgs/commit/2a23ed26a92cfd9376b91a721aa11cff276dfdfc) cc-wrapper: heed NIX_CC_WRAPPER_SUPPRESS_TARGET_WARNING
* [`f7f3d17a`](https://github.com/NixOS/nixpkgs/commit/f7f3d17a58f84914c47e33f865b7ad2412668e02) python312Packages.fastremap: init at 1.15.1
* [`c003c7df`](https://github.com/NixOS/nixpkgs/commit/c003c7dfcca56233263644800efaa277471a4e1a) python312Packages.connected-components-3d: init at 3.22.0
* [`dcb7a179`](https://github.com/NixOS/nixpkgs/commit/dcb7a179949df52ff08ad5330982a2c69b1dc519) pkgsMusl.postgresql_jit: disable tests
* [`dd5fd6cc`](https://github.com/NixOS/nixpkgs/commit/dd5fd6cc225c912f73bf38b338507cfa72daa1c8) postgresql: always build with JIT enabled
* [`9f3bea8d`](https://github.com/NixOS/nixpkgs/commit/9f3bea8dca5d7133f23adc76544e9c2555ea8277) pkgsStatic.{libpq,postgresql}: fix linking against libpq.a
* [`444f6a6c`](https://github.com/NixOS/nixpkgs/commit/444f6a6c9a714b2ab5615b40c6017450875b489e) build haskell-language-server for ghc912
* [`bddfe206`](https://github.com/NixOS/nixpkgs/commit/bddfe206bae60814a729a73b5ef1bd0f26a6a4ac) reported GHC bug wrt generic-lens package
* [`6eb682b1`](https://github.com/NixOS/nixpkgs/commit/6eb682b16c77b9e0e98fe793b59564b72baf3d18) organize the ghc912 configuration a little bit
* [`c1e7bdad`](https://github.com/NixOS/nixpkgs/commit/c1e7bdadb04110ace5edc86be53e825b08cf4f15) maintainers/scripts/haskell/regenerate-hackage-packages.sh: run nixfmt without --fast as well
* [`1aeac40b`](https://github.com/NixOS/nixpkgs/commit/1aeac40bfb5b0cf4ef75020768cca685d9c5cb42) haskellPackages.cabal2nix-unstable: 2025-03-03 -> 2025-04-01
* [`ae9206ca`](https://github.com/NixOS/nixpkgs/commit/ae9206cad9f79b82517d2ce0602acd8d6ff85bff) haskellPackages: regenerate package set based on current config
* [`2ec5fbd5`](https://github.com/NixOS/nixpkgs/commit/2ec5fbd5f232a1fd35527ed59911a483e6a0a3c0) haskellPackages.postgresql-libpq-pkgconfig: use libpq v17 in pkgsStatic
* [`19b56d8a`](https://github.com/NixOS/nixpkgs/commit/19b56d8a3b93f0bed4ecd283cb79dc99c303044c) haskell-language-server: Enable hydra build for ghc 9.12
* [`4f79f39c`](https://github.com/NixOS/nixpkgs/commit/4f79f39cadb84d2a14dcad23486c8da78b8cffad) libselinux: 3.8 -> 3.8.1
* [`9a531206`](https://github.com/NixOS/nixpkgs/commit/9a5312065bc9e6409447108a012ba60ef36d07ce) libselinux: use final attrs instead of rec
* [`18fcbf12`](https://github.com/NixOS/nixpkgs/commit/18fcbf12931cc074648e8eb425842fc735482c16) libselinux: move ldflags to env
* [`2296b621`](https://github.com/NixOS/nixpkgs/commit/2296b621419cefd63ca07f6628b5557d782cf311) haskell-modules/configuration-hackage2nix: sort extra-packages
* [`d768246c`](https://github.com/NixOS/nixpkgs/commit/d768246c6c0cb6f17763b969c557870dba7b665b) haskell-modules/configuration-hackage2nix: remove default-package-override for gi-gdkx11
* [`16949808`](https://github.com/NixOS/nixpkgs/commit/169498088ec37f0357db6456dca589a9e713472f) haskell-modules/configuration-hackage2nix: remove default-package-override for hledger-ui
* [`e4f04c32`](https://github.com/NixOS/nixpkgs/commit/e4f04c32f5877ecf5423b20a1700c63b63ea02c9) boost: drop unused expat dependency
* [`781b42b8`](https://github.com/NixOS/nixpkgs/commit/781b42b87dfb3c970583b9107364f91789e97b0b) cc-wrapper: add nostrictaliasing hardening flag support
* [`62f7cfdd`](https://github.com/NixOS/nixpkgs/commit/62f7cfdd636d019291c538e3168708026de4d520) haskell-modules/configuration-hackage2nix: remove default-package-override for xmonad-contrib
* [`cc72b8ea`](https://github.com/NixOS/nixpkgs/commit/cc72b8ea4e2dcb4147e7811c926ea95058cd9a95) haskell-modules/configuration-hackage2nix: remove default-package-override for http-semantics
* [`1c455b6a`](https://github.com/NixOS/nixpkgs/commit/1c455b6a3af29f72b11151a2f94388a76029f6e8) haskell-modules/configuration-hackage2nix: remove some extra-packages
* [`65ce16de`](https://github.com/NixOS/nixpkgs/commit/65ce16dea5da6288766bff1c66a72ee09419baa1) haskellPackages: stackage LTS 23.8 -> LTS 23.17
* [`c4cea53d`](https://github.com/NixOS/nixpkgs/commit/c4cea53dacf3aa23d96e2ccccb41c71a2d786f29) haskellPackages: regenerate package set based on current config
* [`aead5aa5`](https://github.com/NixOS/nixpkgs/commit/aead5aa51c37f27887d6bd8b44c1a9b0101cc679) haskellPackages.network-control: 0.1.5 -> 0.1.6
* [`0be2156c`](https://github.com/NixOS/nixpkgs/commit/0be2156c315dc48df05590d8edeeceb4fe76d227) haskellPackages.pandoc: fix tests
* [`fed41e53`](https://github.com/NixOS/nixpkgs/commit/fed41e532fad2bc2ed71dda5f6f7c2cccab47c03) abseil-cpp: 20240722.1 -> 20250121.1
* [`e39ab468`](https://github.com/NixOS/nixpkgs/commit/e39ab468e0ca18f8a90e8777fd7bc378b530e5ba) nixos/transmission: use Type=notify for systemd service
* [`1b18bd3d`](https://github.com/NixOS/nixpkgs/commit/1b18bd3dd74c8dd628396ee14c4a03c52cb6f57c) stack: change dep from hpack-0.37.0 to hpack-0.38.0 to match upstream
* [`b8594d9b`](https://github.com/NixOS/nixpkgs/commit/b8594d9b63063c34c1deecbee9f3bda01a507835) haskell.compiler.ghc96{3,4}: fix builds on aarch64-linux
* [`1e54d014`](https://github.com/NixOS/nixpkgs/commit/1e54d014343408ef08c694b6a0f5f8e6e9d76362) protobufc: 1.5.1 -> 1.5.2
* [`b87775e2`](https://github.com/NixOS/nixpkgs/commit/b87775e24d3382bfd55ec8784c96b47c0bafa62a) libselinux: fix python output
* [`9de17e0a`](https://github.com/NixOS/nixpkgs/commit/9de17e0a2e2c3fff0d7296ee3cb23957487b6f96) libsemanage: fix python native library filename
* [`79edf9c8`](https://github.com/NixOS/nixpkgs/commit/79edf9c8b083ce70eee3098884381cac7889a3bc) selinux-python: 3.3 -> 3.8.1; fix runtime
* [`2e4dd3a2`](https://github.com/NixOS/nixpkgs/commit/2e4dd3a2abe72ece3eccbaf3d258272968a1b3a1) libsepol, selinux-python: adopt
* [`fed5b575`](https://github.com/NixOS/nixpkgs/commit/fed5b5755b6cff7290f18337c7df0772f8686424) libsemanage: move to by-name
* [`70cfa4fe`](https://github.com/NixOS/nixpkgs/commit/70cfa4feeb736144afca22e10cdd6a5db9275757) protobuf_30: init at 30.0
* [`896199fe`](https://github.com/NixOS/nixpkgs/commit/896199fee5bbec1df330d33e0a693fea94d495ea) protobuf: 29.3 -> 30.0
* [`55903b9d`](https://github.com/NixOS/nixpkgs/commit/55903b9dfc9eb16378eddf5bab1cd3ace7a2b63b) protobuf: 30.0 -> 30.1
* [`37d2424d`](https://github.com/NixOS/nixpkgs/commit/37d2424dc280c7aa7d3de6f8a6c30b0922be4f72) protobuf: 30.1 -> 30.2
* [`d6f4c241`](https://github.com/NixOS/nixpkgs/commit/d6f4c241d6133e8ece8ee662ecc68d3fe7de5634) xcbuild: replace use of system touch binary
* [`94780899`](https://github.com/NixOS/nixpkgs/commit/94780899d9c9cfbc1eb39ffd3eb46c0c540b58c2) systemd: fix mismerge
* [`74e7f976`](https://github.com/NixOS/nixpkgs/commit/74e7f9768b19ae1a3b75632db42b25bf1011ac5e) git: move credential helpers to exec path
* [`6e2b5118`](https://github.com/NixOS/nixpkgs/commit/6e2b511807aebdca71663943cbb801202c6dc3ae) c-ares: 1.34.4 -> 1.34.5
* [`01f0dd23`](https://github.com/NixOS/nixpkgs/commit/01f0dd23b8a63f853266484bcb42384e9fa47ccb) python313Packages.pillow: remove dependency on tkinter
* [`57e92b72`](https://github.com/NixOS/nixpkgs/commit/57e92b7215edfdc3a8458572e6ba78c09f35e895) haskellPackages: remove patches that error on apply
* [`d3d2d10d`](https://github.com/NixOS/nixpkgs/commit/d3d2d10d1167e4708b8b2307c3eda73016fb151f) python312Packages.moto: disable a flaky test
* [`95415a8f`](https://github.com/NixOS/nixpkgs/commit/95415a8fc576e3e13c20e50c25cae7a663d0d66c) llvmPackages_{12,13,14,15,16,17,18,19,20,git}.libunwind: use lib.cmake functions
* [`19cd2061`](https://github.com/NixOS/nixpkgs/commit/19cd20612cb60d9c56e08373c277c2c0f96f9257) llvmPackages_{12,13,14,15,16,17,18,19,20,git}.libunwind: use final attrs instead of rec
* [`dae47665`](https://github.com/NixOS/nixpkgs/commit/dae47665ec2320d124ce9d8091e8b2d6bbc533dd) llvmPackages_{12,13,14,15,16,17,18,19,20,git}.libunwind: move pname
* [`80bedaea`](https://github.com/NixOS/nixpkgs/commit/80bedaea052f2ca6116b3270a165af00f6a97a21) llvmPackages_{12,13,14,15,16,17,18,19,20,git}.libunwind: move src
* [`b512c59d`](https://github.com/NixOS/nixpkgs/commit/b512c59df32b8f5a6ebd1940464e097ea750f277) llvmPackages_{12,13,14,15,16,17,18,19,20,git}.libunwind: move patches
* [`0d1beffa`](https://github.com/NixOS/nixpkgs/commit/0d1beffa7d094181016afd59eac70617cfe298b4) llvmPackages_{12,13,14,15,16,17,18,19,20,git}.libunwind: move pre and post patch hooks
* [`580f5b27`](https://github.com/NixOS/nixpkgs/commit/580f5b27e19f3fe3eede7da067ed95265fb442da) llvmPackages_{12,13,14,15,16,17,18,19,20,git}.libunwind: move post install
* [`a4977f10`](https://github.com/NixOS/nixpkgs/commit/a4977f10532cd2b31526e19a7966665a95303bd4) llvmPackages_{12,13,14,15,16,17,18,19,20,git}.compiler-rt: use lib.cmake functions
* [`b39cd954`](https://github.com/NixOS/nixpkgs/commit/b39cd95424e4fa46af12878cfe4fb71bd66e8ad7) llvmPackages_{12,13,14,15,16,17,18,19,20,git}.compiler-rt: use final attrs
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
