### PR TITLE
niv home-manager: update 8a318641 -> 535a541b

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -41,10 +41,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "8a318641ac13d3bc0a53651feaee9560f9b2d89a",
-        "sha256": "0v931s9w3kkcv248c3xsycfr1dyjqb61x424qh2anggl0f4ni84b",
+        "rev": "535a541b429c1e89f0955c160df1d6d2bfeaf802",
+        "sha256": "04pkpr5b9ajvhfkq8mmrwdw037yamhblj6jzhiscl069kic53rwq",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/8a318641ac13d3bc0a53651feaee9560f9b2d89a.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/535a541b429c1e89f0955c160df1d6d2bfeaf802.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@8a318641...535a541b](https://github.com/nix-community/home-manager/compare/8a318641ac13d3bc0a53651feaee9560f9b2d89a...535a541b429c1e89f0955c160df1d6d2bfeaf802)

* [`60964ff8`](https://github.com/nix-community/home-manager/commit/60964ff845ec5965cde978377f3f73bcef84abe5) mako: fix example config ([nix-community/home-manager⁠#6987](https://togithub.com/nix-community/home-manager/issues/6987))
* [`35535345`](https://github.com/nix-community/home-manager/commit/35535345be0be7dbae2e9b787c6cf790f8c893d5) television: add shell integrations ([nix-community/home-manager⁠#6983](https://togithub.com/nix-community/home-manager/issues/6983))
* [`e121442b`](https://github.com/nix-community/home-manager/commit/e121442b6583fdbfd968cca6fb7def58af0b6288) lib/strings: add toSnakeCase
* [`9cebc4cb`](https://github.com/nix-community/home-manager/commit/9cebc4cb8af0d4f71acadbb5f53bee1e406cec03) lib/strings: add toKebabCase
* [`94d32062`](https://github.com/nix-community/home-manager/commit/94d32062ca42d8149cd77d2b3e3ec5c8c4103084) lib/strings: add toCaseWithSeparator
* [`327885ce`](https://github.com/nix-community/home-manager/commit/327885ceae1aecc9b966e9370eb4043d2c169b0c) lib/deprecations: add mkSettingsRenamedOptionModules with transform parameter
* [`f78a171f`](https://github.com/nix-community/home-manager/commit/f78a171fe4e6a6e0ae5c33c5be8abe72e8a43eb3) mako: use toKebabCase for option transformation
* [`ba454389`](https://github.com/nix-community/home-manager/commit/ba45438996c3bc6c245af9833904c12836923b8d) tests/darwinScrublist: add newsboat
* [`76274a21`](https://github.com/nix-community/home-manager/commit/76274a2130db36a6754f0bf262daac63f2afbd1e) tests/man: index.bt -> index.db
* [`5da6eafc`](https://github.com/nix-community/home-manager/commit/5da6eafceb2ea15b39de54d853cc224409e4c1a9) treewide: remove unused code ([nix-community/home-manager⁠#6985](https://togithub.com/nix-community/home-manager/issues/6985))
* [`1d5fb9da`](https://github.com/nix-community/home-manager/commit/1d5fb9da1061e30012ee68675a489ac5780c1877) flake.lock: Update ([nix-community/home-manager⁠#6992](https://togithub.com/nix-community/home-manager/issues/6992))
* [`f3384e68`](https://github.com/nix-community/home-manager/commit/f3384e688da328fcec78c6a437566b40fd6f8a18) tmpfiles: also remove files that need to be removed during activation ([nix-community/home-manager⁠#6980](https://togithub.com/nix-community/home-manager/issues/6980))
* [`ae442685`](https://github.com/nix-community/home-manager/commit/ae442685297517b5fcdd85787d95c3927e4aabf5) prezto: Remove unnecessary import-from-derivation
* [`708074ae`](https://github.com/nix-community/home-manager/commit/708074ae6db9e0468e4f48477f856e8c2d059795) treewide: Prevent IFD by default
* [`a8e2d08f`](https://github.com/nix-community/home-manager/commit/a8e2d08ffdc68123316b57cf2ad51244c7eca335) alot: allow commas in maildir path ([nix-community/home-manager⁠#6989](https://togithub.com/nix-community/home-manager/issues/6989))
* [`ec71b516`](https://github.com/nix-community/home-manager/commit/ec71b5162848e6369bdf2be8d2f1dd41cded88e8) sbt: Scoping credentials to ThisBuild ([nix-community/home-manager⁠#6026](https://togithub.com/nix-community/home-manager/issues/6026))
* [`50894120`](https://github.com/nix-community/home-manager/commit/50894120e8ac792a5d3046d23e4e4c4ef32cf09c) modules/modules.nix: drop duplicate entry ([nix-community/home-manager⁠#7000](https://togithub.com/nix-community/home-manager/issues/7000))
* [`2ede089d`](https://github.com/nix-community/home-manager/commit/2ede089d11b68d7abfcb022c60cf71249504c3b0) git: configure patdiff through [patdiff] git section ([nix-community/home-manager⁠#6978](https://togithub.com/nix-community/home-manager/issues/6978))
* [`cea975d4`](https://github.com/nix-community/home-manager/commit/cea975d46d08293eae3ad0d9f16207f1ce2dfc81) rofi: modes option ([nix-community/home-manager⁠#6115](https://togithub.com/nix-community/home-manager/issues/6115))
* [`c84396bd`](https://github.com/nix-community/home-manager/commit/c84396bda0371cb42147c82ad051bebf8a158bd5) rofi: modes optional ([nix-community/home-manager⁠#7003](https://togithub.com/nix-community/home-manager/issues/7003))
* [`3c59c513`](https://github.com/nix-community/home-manager/commit/3c59c5132b64e885faca381e713b579dcbddba75) wayprompt: init module ([nix-community/home-manager⁠#7002](https://togithub.com/nix-community/home-manager/issues/7002))
* [`a5159823`](https://github.com/nix-community/home-manager/commit/a51598236f23c89e59ee77eb8e0614358b0e896c) lutris: add module ([nix-community/home-manager⁠#6964](https://togithub.com/nix-community/home-manager/issues/6964))
* [`5d428b68`](https://github.com/nix-community/home-manager/commit/5d428b68dd56b98f023f5360002e3fe4b66a2b63) docs: update filename of generated HTML manual ([nix-community/home-manager⁠#7010](https://togithub.com/nix-community/home-manager/issues/7010))
* [`8d2ee399`](https://github.com/nix-community/home-manager/commit/8d2ee39915119dead6b794f7d2b63d6a1554941d) waveterm: add module ([nix-community/home-manager⁠#7004](https://togithub.com/nix-community/home-manager/issues/7004))
* [`ce1ba0e9`](https://github.com/nix-community/home-manager/commit/ce1ba0e9f34df84e1e1d7c8ab3d4c948e81f0e20) neovide: fix error when no settings are declared ([nix-community/home-manager⁠#7005](https://togithub.com/nix-community/home-manager/issues/7005))
* [`9e10d73c`](https://github.com/nix-community/home-manager/commit/9e10d73cea313708e9f9b98114963fbaac6ec99b) onlyoffice: use pkgs.formats and use mkIf in config file generation ([nix-community/home-manager⁠#7006](https://togithub.com/nix-community/home-manager/issues/7006))
* [`8f723d61`](https://github.com/nix-community/home-manager/commit/8f723d613588e4a55e8838197741727e4dea4944) lutris: fix runners not working due to wrong config name ([nix-community/home-manager⁠#7008](https://togithub.com/nix-community/home-manager/issues/7008))
* [`cbd8e8e9`](https://github.com/nix-community/home-manager/commit/cbd8e8e9a040db35d6a74a8f8903a32a2e47b8c5) PR_TEMPLATE: update example for module maintainer ([nix-community/home-manager⁠#7011](https://togithub.com/nix-community/home-manager/issues/7011))
* [`3be7c80a`](https://github.com/nix-community/home-manager/commit/3be7c80a11b3b1c3c14d0061dfaa44f1c96673ff) wayprompt: add news entry for linux ([nix-community/home-manager⁠#7009](https://togithub.com/nix-community/home-manager/issues/7009))
* [`f2b5bf55`](https://github.com/nix-community/home-manager/commit/f2b5bf55aa439a6c517adfcb9715a5a952020c5f) direnv: update nushell env conversion logic ([nix-community/home-manager⁠#6999](https://togithub.com/nix-community/home-manager/issues/6999))
* [`e9bd9568`](https://github.com/nix-community/home-manager/commit/e9bd9568db6b627155664090ea39a1b6ece0af47) jujutsu: store configuration in $XDG_CONFIG_HOME for all platforms ([nix-community/home-manager⁠#6994](https://togithub.com/nix-community/home-manager/issues/6994))
* [`b706037a`](https://github.com/nix-community/home-manager/commit/b706037a60acc727f1b5c037e84dc61a35ef1db1) distrobox: make systemd unit optional ([nix-community/home-manager⁠#7007](https://togithub.com/nix-community/home-manager/issues/7007))
* [`e95a7c5b`](https://github.com/nix-community/home-manager/commit/e95a7c5b6fa93304cd2fd78cf676c4f6d23c422c) Revert "direnv: update nushell env conversion logic ([nix-community/home-manager⁠#6999](https://togithub.com/nix-community/home-manager/issues/6999))" ([nix-community/home-manager⁠#7014](https://togithub.com/nix-community/home-manager/issues/7014))
* [`c4bd004d`](https://github.com/nix-community/home-manager/commit/c4bd004d9d8981837d958264b809f7edc93d9957) flake.nix: expose create-news-entry as a package
* [`6fd639db`](https://github.com/nix-community/home-manager/commit/6fd639dbe5183850b6c4a7fb47ae04c4808cb891) docs: update news.md to highlight create-news-entry command
* [`12e67385`](https://github.com/nix-community/home-manager/commit/12e67385964d9c9304daa81d0ad5ba3b01fdd35e) docs: remove recommendation to wait for maintainers for news
* [`b96c332d`](https://github.com/nix-community/home-manager/commit/b96c332dce9a1974ee046a4dcd5860a5f41009f5) maintainers: add lowlevl
* [`4f442217`](https://github.com/nix-community/home-manager/commit/4f44221724ce074404fb0e569acdd6c456ed22d2) services.autorandr: add lowlevl to maintainers
* [`555f88ad`](https://github.com/nix-community/home-manager/commit/555f88ad3452f1d2ce1560e7209b0b6af0c6033b) services.autorandr: add package option
* [`1875b5a1`](https://github.com/nix-community/home-manager/commit/1875b5a1606a897d9285d80600c7ab566911c7bc) services.autorandr: improve configurability
* [`13289f06`](https://github.com/nix-community/home-manager/commit/13289f06429700f3ecf8f5109ed8831839f09145) services.autorandr: improve systemd unit description
* [`9ef92f1c`](https://github.com/nix-community/home-manager/commit/9ef92f1c6b77944198fd368ec805ced842352a1d) waveterm: fix markdown in description
* [`de496c9c`](https://github.com/nix-community/home-manager/commit/de496c9ccb705ed76c1f23c2cad13e8970c37f0b) television: add support for channels ([nix-community/home-manager⁠#7026](https://togithub.com/nix-community/home-manager/issues/7026))
* [`6991569c`](https://github.com/nix-community/home-manager/commit/6991569cb7cdde9891f52b43abe9916779df45b0) flake.lock: Update
* [`ff915842`](https://github.com/nix-community/home-manager/commit/ff915842e4a2e63c4c8c5c08c6870b9d5b3c3ee9) Translate using Weblate (Catalan)
* [`5daf23a3`](https://github.com/nix-community/home-manager/commit/5daf23a38f53119803d1e329bf2eaa101563999c) zellij: add themes option ([nix-community/home-manager⁠#7031](https://togithub.com/nix-community/home-manager/issues/7031))
* [`563e1b6c`](https://github.com/nix-community/home-manager/commit/563e1b6cb08256aa883526f5f3deb6970f390e58) maintainers: add Aehmlo
* [`ecb21624`](https://github.com/nix-community/home-manager/commit/ecb216242293f8a31c5426b40190700e5b3686fd) numbat: add module
* [`910292fe`](https://github.com/nix-community/home-manager/commit/910292fe342071f83d6906c7ca24864eba28676a) halloy: add module ([nix-community/home-manager⁠#7034](https://togithub.com/nix-community/home-manager/issues/7034))
* [`a48fecda`](https://github.com/nix-community/home-manager/commit/a48fecda099e9324134f6dd88fe7e38f58d2d9d2) files: add home.file.<name>.ignorelinks
* [`7a3f3e55`](https://github.com/nix-community/home-manager/commit/7a3f3e550737c3ed43f6abf33a560cb58537d21f) misc: fix mozilla native messaging hosts
* [`c74665ab`](https://github.com/nix-community/home-manager/commit/c74665abd6e4e37d3140e68885bc49a994ffa53c) bacon: add prefs location to settings decription ([nix-community/home-manager⁠#7030](https://togithub.com/nix-community/home-manager/issues/7030))
* [`4a7311c2`](https://github.com/nix-community/home-manager/commit/4a7311c2353a1ae1292500e25b0e18866dd115aa) misc: add news entries for May modules
* [`0083d901`](https://github.com/nix-community/home-manager/commit/0083d901a33696bf8d29966775bc420e302fb7ea) misc: add news entries for April modules
* [`fb061f55`](https://github.com/nix-community/home-manager/commit/fb061f555f821fe4fb49f8f6f2a0cc3d5728bd52) misc: add news entries for March modules
* [`58795314`](https://github.com/nix-community/home-manager/commit/587953146298b13e897b827181967ff2298fb63c) wayprompt: tweak example ([nix-community/home-manager⁠#7040](https://togithub.com/nix-community/home-manager/issues/7040))
* [`0b24658e`](https://github.com/nix-community/home-manager/commit/0b24658ec09908e5a6515cacc54f29d589c8423b) halloy: add themes option ([nix-community/home-manager⁠#7043](https://togithub.com/nix-community/home-manager/issues/7043))
* [`f0a7db5e`](https://github.com/nix-community/home-manager/commit/f0a7db5ec1d369721e770a45e4d19f8e48186a69) direnv: update nushell env conversion logic ([nix-community/home-manager⁠#7015](https://togithub.com/nix-community/home-manager/issues/7015))
* [`bc13c13e`](https://github.com/nix-community/home-manager/commit/bc13c13ed7f7545a9f34010fa8c3febd1a92c58b) news: reorganize news into YYYY/MM directory structure
* [`628d8cfa`](https://github.com/nix-community/home-manager/commit/628d8cfa5441eabe07fbb24861df1236a8e6dde5) news: migrate news entries to YYYY/MM directory structure
* [`665c49e0`](https://github.com/nix-community/home-manager/commit/665c49e0c2982d94f30a9826712850a59f70eeb4) gnome-terminal: add package option ([nix-community/home-manager⁠#7048](https://togithub.com/nix-community/home-manager/issues/7048))
* [`012cc9e1`](https://github.com/nix-community/home-manager/commit/012cc9e1666b8ce0d6f677b902651f6858dfbe45) halloy: add note about server being required ([nix-community/home-manager⁠#7047](https://togithub.com/nix-community/home-manager/issues/7047))
* [`535a541b`](https://github.com/nix-community/home-manager/commit/535a541b429c1e89f0955c160df1d6d2bfeaf802) halloy: fix themes example ([nix-community/home-manager⁠#7046](https://togithub.com/nix-community/home-manager/issues/7046))
