### PR TITLE
niv nerd-icons.el: update 14f7278d -> 1cb883d9

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -77,10 +77,10 @@
         "homepage": null,
         "owner": "rainstormstudio",
         "repo": "nerd-icons.el",
-        "rev": "14f7278dd7eb5eca762a6ff32467c72c661c0aae",
-        "sha256": "1r5wj13k6khlmkn5wy2q2n674bc551rpxn04x46j0brzgmd85k7g",
+        "rev": "1cb883d928ec046358d2b65db0bb898a1dfffd0a",
+        "sha256": "0r3gv9z04asqjsnasjm2avk9gllqkng6ns14l0svrqxac4c2pp70",
         "type": "tarball",
-        "url": "https://github.com/rainstormstudio/nerd-icons.el/archive/14f7278dd7eb5eca762a6ff32467c72c661c0aae.tar.gz",
+        "url": "https://github.com/rainstormstudio/nerd-icons.el/archive/1cb883d928ec046358d2b65db0bb898a1dfffd0a.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "niv": {


### PR DESCRIPTION
## Changelog for nerd-icons.el:
Branch: main
Commits: [rainstormstudio/nerd-icons.el@14f7278d...1cb883d9](https://github.com/rainstormstudio/nerd-icons.el/compare/14f7278dd7eb5eca762a6ff32467c72c661c0aae...1cb883d928ec046358d2b65db0bb898a1dfffd0a)

* [`1cb883d9`](https://github.com/rainstormstudio/nerd-icons.el/commit/1cb883d928ec046358d2b65db0bb898a1dfffd0a) update to nerd font 3.4.0
