### PR TITLE
niv nixpkgs: update cf47c7d2 -> 817e93d7

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -101,10 +101,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "cf47c7d239f5e9082a36d9b59644ce7e5f7874f9",
-        "sha256": "0g0hgdaawzcnxnll4150r7gxr22rz3pr5zs763v53pspzhwq306l",
+        "rev": "817e93d76bd7e1d8bce3cf7fa401dbce749cc7d8",
+        "sha256": "0najfi679xqqw2mkkmmm0gm0rwbm6si4p8rcf416xv8zwrvblcmd",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/cf47c7d239f5e9082a36d9b59644ce7e5f7874f9.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/817e93d76bd7e1d8bce3cf7fa401dbce749cc7d8.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@cf47c7d2...817e93d7](https://github.com/nixos/nixpkgs/compare/cf47c7d239f5e9082a36d9b59644ce7e5f7874f9...817e93d76bd7e1d8bce3cf7fa401dbce749cc7d8)

* [`8d18fff1`](https://github.com/NixOS/nixpkgs/commit/8d18fff192cec984211184b31a684c71c5171f59) maintainers: add yarekt
* [`9ba76471`](https://github.com/NixOS/nixpkgs/commit/9ba7647102a4934e15424bf5850c9002c980ecd5) text-engine: refactor
* [`81da8104`](https://github.com/NixOS/nixpkgs/commit/81da8104df2775400e57e639041f181cc22d2982) text-engine: 0.1.1 -> 0.1.1-unstable-2024-09-16
* [`25ba6fc4`](https://github.com/NixOS/nixpkgs/commit/25ba6fc46300383e72713b37fc16cc2b91a7eb0d) text-engine: remove the `json-glib` dependency
* [`4160c780`](https://github.com/NixOS/nixpkgs/commit/4160c7807b31743063c5a2627e025f19b52cc150) maintainers: add theverygaming
* [`8457f10d`](https://github.com/NixOS/nixpkgs/commit/8457f10d350e7c812c43c1b0af072a0b82187199) libtommath: fix cross build
* [`b30f23ae`](https://github.com/NixOS/nixpkgs/commit/b30f23ae5488c738d467640803f59c0b5d117dd1) cato: init at 5.2.1.1
* [`97013e6c`](https://github.com/NixOS/nixpkgs/commit/97013e6c0a7fa89645361830dfa4f81b7a781c79) pass-secret-service: unstable-2022-07-18 -> 0-unstable-2023-12-16
* [`a3f57452`](https://github.com/NixOS/nixpkgs/commit/a3f57452168c355ad88f558eedccb7f2a9b3e895) python3Packages.backtesting: init at 0.6.3
* [`2001d936`](https://github.com/NixOS/nixpkgs/commit/2001d9369864730629beca9d7b043ef91066e9c7) maintainers: add appleboblin
* [`453fba73`](https://github.com/NixOS/nixpkgs/commit/453fba73eaa50da0e83c74c4e86a39f9578cdf98) vlc: fix dependencies
* [`24269400`](https://github.com/NixOS/nixpkgs/commit/242694006e7dfdadc91f37567bcfdad762797b87) vlc: disable VDPAU for now
* [`73c2b475`](https://github.com/NixOS/nixpkgs/commit/73c2b4750ddfa2f1b33aee509386082eb190fa88) emblem: 1.4.0 -> 1.5.0
* [`33758fc5`](https://github.com/NixOS/nixpkgs/commit/33758fc537199e2ea6545423566dfcc6e58cd070) eyedropper: 2.0.1 -> 2.1.0
* [`45aa4ef2`](https://github.com/NixOS/nixpkgs/commit/45aa4ef21182ea507f4786649023ee18b327ece2) eyedropper: modernize
* [`b6e36b68`](https://github.com/NixOS/nixpkgs/commit/b6e36b68fccf595af647b13f5c3261505d1eed33) gnome-decoder: 0.6.1 -> 0.7.0
* [`b40764fb`](https://github.com/NixOS/nixpkgs/commit/b40764fbd26aa6f36649e581b8493ca0bc5ce63d) gnomeExtensions.guillotine: 25 -> 26
* [`4118f045`](https://github.com/NixOS/nixpkgs/commit/4118f0451e6b1589b74d2bdb97e37819a290c6d2) python3.pkgs.sphinx-issues: avoid use of pandoc in build closure
* [`58c4582b`](https://github.com/NixOS/nixpkgs/commit/58c4582b76b5e32e0da4869b310e57fc4b0ab9cf) maintainers: add vaavaav
* [`ab5a7b55`](https://github.com/NixOS/nixpkgs/commit/ab5a7b5518610b873202450a033c5839417fb49b) openpace: init at 1.1.3
* [`553b5165`](https://github.com/NixOS/nixpkgs/commit/553b51654adf4004a7ef367f8c57bade5e41b145) doxygen: use finalAttrs
* [`60d84247`](https://github.com/NixOS/nixpkgs/commit/60d8424744c2f2d575614234d0ce3ac1554364a7) doxygen: clean iconv
* [`8955bab2`](https://github.com/NixOS/nixpkgs/commit/8955bab27aff175d8b56f2fdaa0977244e0d3ab9) python3Packages.doxmlparser: init at 1.12.0
* [`89c19152`](https://github.com/NixOS/nixpkgs/commit/89c19152d62c3741cf4c7c7e8b60ec558d4c4c4a) faust2jack: fix strictDeps build
* [`571db1ae`](https://github.com/NixOS/nixpkgs/commit/571db1ae4a174e3ce709137fc4ef19758735b99f) magnetophonDSP.VoiceOfFaust: fix strictDeps build, disable PIE
* [`f8f070bd`](https://github.com/NixOS/nixpkgs/commit/f8f070bd4479bd9663ec842e36d640d06722320b) snappy: 1.2.1 -> 1.2.2
* [`7eb5686b`](https://github.com/NixOS/nixpkgs/commit/7eb5686bf911f86b935b6edf4aa7b9deff5c53a6) libevdev: 1.13.3 -> 1.13.4
* [`ba82c4d1`](https://github.com/NixOS/nixpkgs/commit/ba82c4d19a67aeee180e54f07486ae13e35e3cd9) warp: 0.8.1 -> 0.9.2
* [`9e08cce0`](https://github.com/NixOS/nixpkgs/commit/9e08cce04fb2af25928e8c4643d4f0c49aad4f1a) curtail: 1.12.0 -> 1.13.0
* [`ebeba5c5`](https://github.com/NixOS/nixpkgs/commit/ebeba5c57e3d3132cf00c9668fc5257743f5278a) darkly{-qt5}: init at 0.5.18
* [`eaefd357`](https://github.com/NixOS/nixpkgs/commit/eaefd3571bf024ed20c3a3252984a0a191998970) orgformat: init at 0-unstable-2024-10-23
* [`d920a4a5`](https://github.com/NixOS/nixpkgs/commit/d920a4a5351270a65b48c3f65f306c653f95ea2b) libnotify: 0.8.4 -> 0.8.6
* [`febc0387`](https://github.com/NixOS/nixpkgs/commit/febc03879fbb8812e61631281e3909df2109a11f) spdlog: 1.15.1 -> 1.15.2
* [`e0f88a77`](https://github.com/NixOS/nixpkgs/commit/e0f88a77fb0609a7bfe3191bac3fda1a5ab1c394) alda: build from source
* [`3dd5d860`](https://github.com/NixOS/nixpkgs/commit/3dd5d8606a9f7217c5f880be5bf0eed3a84c51d4) nixos/hddfancontrol: use attrset for config
* [`848e754b`](https://github.com/NixOS/nixpkgs/commit/848e754b8156a878050dd12b54e0c12b454fdf59) syncthing: handle encryptionPassword secret
* [`d8b850d8`](https://github.com/NixOS/nixpkgs/commit/d8b850d88f416c1d8da0ba6c194939fcf182695a) syncthing: expose encryptionPassword
* [`a8cd913d`](https://github.com/NixOS/nixpkgs/commit/a8cd913df279463f29b43526487d08800d473ca6) nixosTests.syncthing: define test for declarative folders
* [`b7f1fd5c`](https://github.com/NixOS/nixpkgs/commit/b7f1fd5caa1ea4aee3335be3240ec23610e1285e) nixosTests.syncthing: create encrypted device test
* [`715ba701`](https://github.com/NixOS/nixpkgs/commit/715ba701fa4a4e48f2e2bdae81d25c7274d9cc73) doc: 24.11: release note for syncthing changes
* [`42cd6e85`](https://github.com/NixOS/nixpkgs/commit/42cd6e85f78b7cf1296de9c7916df972486cabac) python3Packages.httpx: unset SSL_CERT_FILE in hook
* [`97c64f03`](https://github.com/NixOS/nixpkgs/commit/97c64f03d42ec31315a1b569a5de60c170bd25a3) python3Packages.hypercorn: drop obsolote fix for httpx
* [`85cd0e42`](https://github.com/NixOS/nixpkgs/commit/85cd0e42da43045d4d510d05bfc51b1eb7be74dc) python3Packages.sanic: drop obsolete fix for httpx
* [`e6114564`](https://github.com/NixOS/nixpkgs/commit/e611456426fe00452d517fe5b2860fd0afc0658f) python3Packages.authlib: drop obsolete httpx fix
* [`aca74515`](https://github.com/NixOS/nixpkgs/commit/aca74515162a9fb0324f1699a75755d280e7666e) python3Packages.confluent-kafka: drop obsolete httpx fix
* [`821e2a4c`](https://github.com/NixOS/nixpkgs/commit/821e2a4cf339962466a5e4c073a322aaa08d704d) python3Packages.speechrecognition: drop obsolete httpx fix
* [`42e24c68`](https://github.com/NixOS/nixpkgs/commit/42e24c68e0d1e771ebc7c5027a09244f516c85fe) python3Packages.pyssim: modernize
* [`e955e0c6`](https://github.com/NixOS/nixpkgs/commit/e955e0c6688a63bc628cb56405c66c61d2294869) identity: 0.7.0 -> 25.03
* [`317e6180`](https://github.com/NixOS/nixpkgs/commit/317e6180794e2ca4003387cf967659eb5ccabed1) luaPackages.luv: 1.48.0-2 -> 1.50.0-1
* [`51934865`](https://github.com/NixOS/nixpkgs/commit/51934865adf9e56ad8e46c2ca4f6c3299ac1d122) luaPackages.luv: use manual packaging
* [`3a83abf7`](https://github.com/NixOS/nixpkgs/commit/3a83abf73ff3e31ca9de21353da3799b47b78ccd) libcamera: 0.4.0 -> 0.5.0
* [`c550aab8`](https://github.com/NixOS/nixpkgs/commit/c550aab8093ff8368369818dc95f221a8d122645) prusa-slicer: fix gcode viewer desktop file
* [`5cd28031`](https://github.com/NixOS/nixpkgs/commit/5cd2803192f6945e029ec19e8bc6225c09dfeeb1) wpsoffice-cn: 11.1.0.11723 -> 12.1.0.17900
* [`a2efbfee`](https://github.com/NixOS/nixpkgs/commit/a2efbfeead40760b0207b3c759e7596f573d8665) imlib2: 1.12.4 -> 1.12.5
* [`755d831a`](https://github.com/NixOS/nixpkgs/commit/755d831a525bbe61707a35e464eaa43b0c42d0b8) c3c: fix PIE hardening build
* [`3e9a3e27`](https://github.com/NixOS/nixpkgs/commit/3e9a3e27b1acb326345193ed8215c565816f215f) wayland-protocols: 1.42 -> 1.43
* [`b932e6aa`](https://github.com/NixOS/nixpkgs/commit/b932e6aa3408731bb799f414cfc01f655f02db40) git: update documentation patch
* [`6dd4a9ff`](https://github.com/NixOS/nixpkgs/commit/6dd4a9ff9effc206a1b7beab61cc943fdbbc58fb) pythonPackages.bezier: init at 2024.6.20
* [`55450106`](https://github.com/NixOS/nixpkgs/commit/55450106358a750fb6cb25a0dc4540639843037f) rofi-games: 1.10.9 -> 1.12.2
* [`980d7103`](https://github.com/NixOS/nixpkgs/commit/980d71039d2fb7a7dabc84bd95df064f23072338) curl: 8.12.1 -> 8.13.0
* [`6679b5d3`](https://github.com/NixOS/nixpkgs/commit/6679b5d38c8974b9b7e3de50a20ade1fedae6fab) cmake: fix cmake build by backport
* [`f4e5e3e5`](https://github.com/NixOS/nixpkgs/commit/f4e5e3e54914cc449a68a72b17b3d6159c3eb336) ghostty: fix `meta.outputsToInstall`
* [`55cb5e1e`](https://github.com/NixOS/nixpkgs/commit/55cb5e1e0641a1d6e2e10e78eda83e7ed86e8f22) python3Packages.hypothesis: fix downstream flaky test failures
* [`d6bfe18f`](https://github.com/NixOS/nixpkgs/commit/d6bfe18fbf2f97a17e3a61c599fa54fb2ff33e28) python3Packages.mutagen: fix for hypothesis CI profile
* [`35a4f4ae`](https://github.com/NixOS/nixpkgs/commit/35a4f4ae41c188a1ee4809b8a5177f399859e1bc) mbedtls: disable trivialautovarinit hardening flag on clang
* [`f96ed30d`](https://github.com/NixOS/nixpkgs/commit/f96ed30dca3550d373b2b070710e0f288d86d7a1) rnote: 0.11.0 -> 0.12.0
* [`f2fb7123`](https://github.com/NixOS/nixpkgs/commit/f2fb7123378456ffc87191bf40e26aa99a6efaa6) mvfst: disable pacret & trivialautovarinit hardening flags
* [`3a54e411`](https://github.com/NixOS/nixpkgs/commit/3a54e41151a9b7767cb7a6288669942c7bc21390) maintainers: add dolphindalt as maintainer
* [`1d0f040a`](https://github.com/NixOS/nixpkgs/commit/1d0f040a74e52ad61e61e40fc0a73cd820fc041c) python-coinmarketcap: init at 0.6
* [`dcb7c76f`](https://github.com/NixOS/nixpkgs/commit/dcb7c76f94d93e23bd989842d7ef49c81fd8eaa3) wxGTK32: update to libsoup_3
* [`a09ad8e2`](https://github.com/NixOS/nixpkgs/commit/a09ad8e2029bbc94cfe73e3ad641488ee56b9f13) python3Packages.wxpython: update to libsoup_3
* [`7466f164`](https://github.com/NixOS/nixpkgs/commit/7466f164975459466e3b7d20bc900ed36f4aa66c) prusa-slicer: build against webkitgtk_4_1 and mainline wxGTK32
* [`13c92dea`](https://github.com/NixOS/nixpkgs/commit/13c92dea43ae95270592ce05eb7a3fde09fd5a93) gupnp-igd: refactor; gupnp-igd: 1.2.0 → 1.6.0
* [`399845af`](https://github.com/NixOS/nixpkgs/commit/399845afd6f4292dda288ff0b2e089a55b4b7620) libnice: refactor; add patch for gupnp-igd 1.6.0
* [`11963707`](https://github.com/NixOS/nixpkgs/commit/11963707bf5da847de57396c7fb278db1856e94b) ssh-tpm-agent: 0.7.0 -> 0.8.0
* [`2d53678b`](https://github.com/NixOS/nixpkgs/commit/2d53678b816c133ceb94d9a9178c25b8a24f1735) plakativ: init at 0.5.3
* [`cf21fe42`](https://github.com/NixOS/nixpkgs/commit/cf21fe4271f1bb94f08120d5da845e41057fe91a) bind: 9.20.7 -> 9.20.8
* [`9dd7d430`](https://github.com/NixOS/nixpkgs/commit/9dd7d430f49371904ba1dd58fbc5cad9ee47f4c2) Update pkgs/development/python-modules/python-coinmarketcap/default.nix
* [`13c98861`](https://github.com/NixOS/nixpkgs/commit/13c9886115411d18d6e4b47b6ca14f148a516036) jemalloc: cleanup
* [`acac22aa`](https://github.com/NixOS/nixpkgs/commit/acac22aafcfba3a891f7a5d24e50bd207f498b22) dino: 0.4.5 -> 0.5.0
* [`dab3970f`](https://github.com/NixOS/nixpkgs/commit/dab3970f538225c5b742f8468e17b372cb19f460) rocmPackages_6.rocm-runtime: fix shebangs correctly for strictDeps
* [`807044e5`](https://github.com/NixOS/nixpkgs/commit/807044e566e79ceca02b47d7e8f3a6d011a47298) rocmPackages_6.hipblas-common: fix and enable strictDeps
* [`8a378f44`](https://github.com/NixOS/nixpkgs/commit/8a378f44d1b03ea85144cc994c0e36cb1acaeae9) libnftnl: 1.2.8 -> 1.2.9
* [`cb243631`](https://github.com/NixOS/nixpkgs/commit/cb2436316f5a116d6876d747aef243b8e4bb296f) surgescript: init at 0.6.1
* [`484b00be`](https://github.com/NixOS/nixpkgs/commit/484b00be2055decb393ce6dd6d95316bb4e3261d) nixos/etc: remove rogue continue
* [`d7b4afcd`](https://github.com/NixOS/nixpkgs/commit/d7b4afcd2dc8a2fd11db247703c2ac44685dc6c9) hedgemodmanager: init at 8.0.0-beta4
* [`aeb7bd8a`](https://github.com/NixOS/nixpkgs/commit/aeb7bd8ac3912c028dbb0fa94737ab3eb8c1bfeb) bluejay: init at 1.0.2
* [`e6fd4ffd`](https://github.com/NixOS/nixpkgs/commit/e6fd4ffd2d132f54b6ab1c9964098b2df100da43) s2n-tls: 1.5.12 -> 1.5.17
* [`85450c50`](https://github.com/NixOS/nixpkgs/commit/85450c50f46a54abdc2ef84b14399441b4aeddec) netpbm: 11.9.3 -> 11.10.2
* [`2de724fb`](https://github.com/NixOS/nixpkgs/commit/2de724fb82de7a4f61d4e6187c5d8cbb1115583b) scipopt-scip: 9.2.1 -> 9.2.2
* [`3d9f5854`](https://github.com/NixOS/nixpkgs/commit/3d9f58545febd4bace772f26b943f75b0573728b) scipopt-zimpl: scipVersion: 9.2.1 -> 9.2.2
* [`9ca8bc7c`](https://github.com/NixOS/nixpkgs/commit/9ca8bc7cafda9b63609a3e1484dcd247b9c9033b) scipopt-ug: scipVersion: 9.2.1 -> 9.2.2
* [`0bb6a910`](https://github.com/NixOS/nixpkgs/commit/0bb6a910f5caf7e8bba4afbdc5b0af0c272ebcb5) scipopt-papilo: 2.4.1 -> 2.4.2
* [`531c93a5`](https://github.com/NixOS/nixpkgs/commit/531c93a5ebdbd10a0eacf526479df0489b4b3a77) scipopt-soplex: 713 -> 714
* [`43ead788`](https://github.com/NixOS/nixpkgs/commit/43ead788f9734b9414f76303387331cbeab61c95) Made service restart after 5s
* [`71e486cd`](https://github.com/NixOS/nixpkgs/commit/71e486cd10cc5d78490e25551c2d975a9a5ea9d1) python313Packages.auditwheel: refactor
* [`e890c4a4`](https://github.com/NixOS/nixpkgs/commit/e890c4a4ca0a11a43ee4d4eeaf811c8efff41e1f) lief: 0.16.4 -> 0.16.5
* [`a9d8e520`](https://github.com/NixOS/nixpkgs/commit/a9d8e520660e47c28b80018060a0dfbd706f07d5) docbook2x: fix strictDeps for real
* [`f591a9f7`](https://github.com/NixOS/nixpkgs/commit/f591a9f748ce7d25fab66572a60c098baeb0fc22) calls: 47.0 -> 48.1
* [`f4b81996`](https://github.com/NixOS/nixpkgs/commit/f4b8199654bc0f1c0b0523c3106bcb8626da9a5b) vcpkg-tool-unwrapped: 2025-03-13 -> 2025-04-16
* [`5cdef1a5`](https://github.com/NixOS/nixpkgs/commit/5cdef1a5bfd92cd1b40b0bcba76223df96175927) treewide: move extra-cmake-modules to nativeBuildInputs
* [`ff53ebdc`](https://github.com/NixOS/nixpkgs/commit/ff53ebdc485947a8e19a97f677ea78a6a43b4131) exatorrent: init at 1.3.0
* [`711ccb63`](https://github.com/NixOS/nixpkgs/commit/711ccb63f84a5c145ccf32f82a04212ba8bc9aca) guile-irregex: init at 0.9.11
* [`61aebef9`](https://github.com/NixOS/nixpkgs/commit/61aebef93f175e1ace121f9f1af4fa92f0ae3a82) guile-json-rpc: init at 0.4.5a
* [`9557f3be`](https://github.com/NixOS/nixpkgs/commit/9557f3be47e9a6527c4d6db8e7c5f465b8a63f45) clash-rs: 0.7.5 -> 0.7.7
* [`f011e900`](https://github.com/NixOS/nixpkgs/commit/f011e9009456d87d99d8daee29f04c4fdf07317a) Fix useMoldLinker when cross compiling
* [`6eea4278`](https://github.com/NixOS/nixpkgs/commit/6eea427841c47d77178b4db10cee25e8aaea9c3f) resvg: 0.44.0 -> 0.45.1
* [`cd062f04`](https://github.com/NixOS/nixpkgs/commit/cd062f040e60c0330fe0ca810b3ddda71398b5ab) treewide: update to webkitgtk_4_1 where possible
* [`5ec8be1d`](https://github.com/NixOS/nixpkgs/commit/5ec8be1dc41dfd84a152498c94ed9af293785272) krep: 0.4.2 -> 1.1.2
* [`73379a24`](https://github.com/NixOS/nixpkgs/commit/73379a242318630b397e253bc197c3419e685b5e) posting: 2.6.0 -> 2.7.0
* [`3644532b`](https://github.com/NixOS/nixpkgs/commit/3644532b67352c13303cbf0f2e25a9060244bf18) jay: 1.9.1 -> 1.10.0
* [`f6306d05`](https://github.com/NixOS/nixpkgs/commit/f6306d05b77efd97666e41916282909e38d79908) egl-wayland: 1.1.18 -> 1.1.19
* [`81aca8b2`](https://github.com/NixOS/nixpkgs/commit/81aca8b2efe3fc8c57cb2bede033b1fa94f8a5fc) rocqPackages.rocq-elpi: 2.5.0 -> 2.5.1
* [`3753a9e1`](https://github.com/NixOS/nixpkgs/commit/3753a9e13331be52c4a83be6a0c0ba7c2a0c0647) visualvm: 2.1.10 -> 2.2
* [`de7487e0`](https://github.com/NixOS/nixpkgs/commit/de7487e084a2c6cab34c790bdff53a5e58b6f1aa) pipe-viewer: 0.5.5 -> 0.5.6
* [`77dd48e3`](https://github.com/NixOS/nixpkgs/commit/77dd48e363e881d23ff088072515de80617c0cde) haskellPackages: stackage LTS 23.17 -> LTS 23.19
* [`b3b6955d`](https://github.com/NixOS/nixpkgs/commit/b3b6955ddff69799808d1bb37f4372825a0ef499) all-cabal-hashes: 2025-03-30T11:13:14Z -> 2025-04-21T04:38:52Z
* [`6de45ff9`](https://github.com/NixOS/nixpkgs/commit/6de45ff9a5883841dd73ad341c43347154a3dd91) haskellPackages: regenerate package set based on current config
* [`88de1ef8`](https://github.com/NixOS/nixpkgs/commit/88de1ef84a200ac7c54373b7f7e33ad1d77ffa57) haskellPackages: Cabal* 3.14.1.* -> 3.14.2.0
* [`d4dcbad5`](https://github.com/NixOS/nixpkgs/commit/d4dcbad5c2ee4d473359ecedc07dde5cfa96e73a) haskellPackages.network-control: use version from stackage
* [`7de85216`](https://github.com/NixOS/nixpkgs/commit/7de85216658770857623e84669127abda8fbe016) stack: pin hpack to == 0.38.0 for 3.5.1
* [`45230a25`](https://github.com/NixOS/nixpkgs/commit/45230a25385b6ba6c4bd3078c05355ca48bef284) git-annex: update sha256 for 10.20250416
* [`4e361b37`](https://github.com/NixOS/nixpkgs/commit/4e361b379a79e08cf98b9c167e353b9ce1135c7c) parallel: 20250322 -> 20250422
* [`314e3786`](https://github.com/NixOS/nixpkgs/commit/314e378636d50219f4a8834489c633749b49c7bb) kando: 1.7.0 -> 1.8.0
* [`861a5305`](https://github.com/NixOS/nixpkgs/commit/861a5305c0cc62d737ec03e46539d2bfe02ce317) haskell.packages.ghc9122.interpolate: disable tests due to GHC bug
* [`c3857c69`](https://github.com/NixOS/nixpkgs/commit/c3857c6972cff6a9c4026e53788ff4b29d4c07f8) haskell.packages.ghc9122.hpack: 0.37.0 -> 0.38.0
* [`a7ab1a41`](https://github.com/NixOS/nixpkgs/commit/a7ab1a41e9e602d2a507c0a87d08d206752bfe3c) haskellPackages.cabal2nix-unstable: 2025-04-22 -> 2025-04-23
* [`117c6e37`](https://github.com/NixOS/nixpkgs/commit/117c6e37ef287fe3e00b7fb0a2ca7750c196dfa8) postgrest: 12.2.7 -> 12.2.11
* [`343d4770`](https://github.com/NixOS/nixpkgs/commit/343d477014d9c849fbc8de2929fc51e7b5612892) regbot: 0.8.2 -> 0.8.3
* [`530fbe21`](https://github.com/NixOS/nixpkgs/commit/530fbe21fc6e781a5e7f3d310f4174be2f116643) xgboost: 2.1.4 -> 3.0.0
* [`4580db52`](https://github.com/NixOS/nixpkgs/commit/4580db5286ec855d010e45e02f1ba780f697bedf) protobuf_25: 25.6 -> 25.7
* [`a22b58e7`](https://github.com/NixOS/nixpkgs/commit/a22b58e791f3588b59148bfa440d54ed4e32344c) nftables: 1.1.1 -> 1.1.3
* [`0411fb2b`](https://github.com/NixOS/nixpkgs/commit/0411fb2bb9429a9079d5bd59304b928d135e14f3) guile-srfi-145: init at unstable-2023-06-04
* [`d866ea1f`](https://github.com/NixOS/nixpkgs/commit/d866ea1feb87b07641a38be7510564cc9658e94c) guile-srfi-180: init at unstable-2023-06-04
* [`e203028e`](https://github.com/NixOS/nixpkgs/commit/e203028e40616e5d929b8f0043256cdcd6468e33) guile-lsp-server: init at 0.4.7
* [`9d3178e8`](https://github.com/NixOS/nixpkgs/commit/9d3178e8ee5e7b903dd03e69e18df76c7fb915c0) unbound: 1.22.0 -> 1.23.0
* [`32dba7af`](https://github.com/NixOS/nixpkgs/commit/32dba7af3048a4a877fed2f19de59f199afa32f5) twingate: 2025.72.142645 -> 2025.114.149890
* [`eb1a88bf`](https://github.com/NixOS/nixpkgs/commit/eb1a88bfb457761339caffb04b1bab4845cf6501) valkey: 8.0.2 -> 8.0.3
* [`781d00aa`](https://github.com/NixOS/nixpkgs/commit/781d00aab288b140deba30d99f53c974ef794412) nexttrace: 1.3.7 -> 1.4.0
* [`c6cc6b0f`](https://github.com/NixOS/nixpkgs/commit/c6cc6b0f27eefee91f70904bedbb26005343f853) circleci-cli: 0.1.31543 -> 0.1.31632
* [`f6d7faef`](https://github.com/NixOS/nixpkgs/commit/f6d7faef5805cf0426c2d1098473fac6e85c5aa9) boost187: Fix ABI detection for empty 'os.platform'
* [`f96b36ba`](https://github.com/NixOS/nixpkgs/commit/f96b36ba52774d615592dfef93654156d7b40b77) python3Packages.moderngl: fix context detection under NixOS
* [`5d7e0e35`](https://github.com/NixOS/nixpkgs/commit/5d7e0e358387d3227e3622411abd0bea1139fc65) libxcvt: refactor and move to pkgs/by-name from xorg namespace
* [`b9625e34`](https://github.com/NixOS/nixpkgs/commit/b9625e346549f77c917fa15a345b67c31ddf0b3e) makedepend: refactor and move to pkgs/by-name from xorg namespace
* [`521809e8`](https://github.com/NixOS/nixpkgs/commit/521809e86ff9763fa5349a4ac61722ebaa7a2feb) util-macros: refactor, move to pkgs/by-name and rename from xorg.utilmacros
* [`69fbbd33`](https://github.com/NixOS/nixpkgs/commit/69fbbd33a6cf076c89bb3f4aff40d5992573e5d0) xbitmaps: refactor and move to pkgs/by-name from xorg namespace
* [`e85c9ea8`](https://github.com/NixOS/nixpkgs/commit/e85c9ea8b228bab2bbc5e170c3ffa6ad656649b2) xcb-proto: refactor, move to pkgs/by-name and rename from xorg.xcbproto
* [`01415ddd`](https://github.com/NixOS/nixpkgs/commit/01415dddcd6f27a0db77f9211c0855bfd16b2609) sdl3: avoid pulling in fcitx5
* [`3a5c613c`](https://github.com/NixOS/nixpkgs/commit/3a5c613ce2f3cec13da588d76e6ed86ea5cd2151) nixos/gancio: fix cli not passing all args
* [`0faaf891`](https://github.com/NixOS/nixpkgs/commit/0faaf891051707aca6744d1e7a17303cd6f2340c) gnome-decoder: 0.7.0 -> 0.7.1
* [`c4bf62f1`](https://github.com/NixOS/nixpkgs/commit/c4bf62f1c058710ddd627ac53ab998e4e6ac378b) xcb-imdkit: fix cross compilation
* [`0ad42cab`](https://github.com/NixOS/nixpkgs/commit/0ad42cabe13a47b74130a7b3f1f781804664c9f5) fcitx5: fix cross compilation
* [`2a921c63`](https://github.com/NixOS/nixpkgs/commit/2a921c63867e99b1bbd92624266c357c58a44c4e) libmysqlconnectorcpp: 9.2.0 -> 9.3.0
* [`54e5360b`](https://github.com/NixOS/nixpkgs/commit/54e5360b8f812ffc15e79fe359aa78e43174b39a) qemu: add libcbor to enable building nitro-enclave machine type
* [`98a7bd3b`](https://github.com/NixOS/nixpkgs/commit/98a7bd3b3c5dca68eafb56f635db348b559c3803) skrooge: 25.1.0 -> 25.4.0
* [`2db05fba`](https://github.com/NixOS/nixpkgs/commit/2db05fba55b22f24d954814de3517f284bd1c2aa) cedar: 4.3.3 -> 4.4.0
* [`4e8b25a6`](https://github.com/NixOS/nixpkgs/commit/4e8b25a6ff9b8ef89879303444c104660e8ceca5) llvm: print output when running tests
* [`be7cd58f`](https://github.com/NixOS/nixpkgs/commit/be7cd58f2ef71ce52c3734fd15aeeeb75d9dd4bb) gaugePlugins.xml-report: 0.5.1 -> 0.5.2
* [`61f884e8`](https://github.com/NixOS/nixpkgs/commit/61f884e8093b73a91e71f5b16208dc5167fd6d9f) gaugePlugins.html-report: 4.3.1 -> 4.3.2
* [`9f124558`](https://github.com/NixOS/nixpkgs/commit/9f12455853434a4f3448eed8c87c44d357433e8d) haskellPackages.hail: unbreak
* [`60af548e`](https://github.com/NixOS/nixpkgs/commit/60af548e3ccdbf69313cbd650e08698323dc9215) haskellPackages.aeson-better-errors: fix build
* [`ad252b08`](https://github.com/NixOS/nixpkgs/commit/ad252b083f6ada02a698846228ef0b15ee080087) haskellPackages.mvc-updates: fix build
* [`b4580cf8`](https://github.com/NixOS/nixpkgs/commit/b4580cf884398c1e80bd879198035562a96ada77) haskellPackages.taskwarrior: fix build
* [`4b22f304`](https://github.com/NixOS/nixpkgs/commit/4b22f304b826f5a09b482f18bc6f81ede84f843d) haskell.packages.ghc912.generic-arbitrary: fix build
* [`7b9c6346`](https://github.com/NixOS/nixpkgs/commit/7b9c6346ffc9c16910c25c56534733e70935f306) makeWrapper: --add-flag and --append-flag arguments
* [`0a8b014f`](https://github.com/NixOS/nixpkgs/commit/0a8b014f67f1d42a7153179097e61f78ae54f630) image/file-options: use defaultText
* [`1df1c882`](https://github.com/NixOS/nixpkgs/commit/1df1c8828d2866c3ac8556c8ec1ca6bcbbfc3a1b) image/repart: run nixfmt
* [`03a698c6`](https://github.com/NixOS/nixpkgs/commit/03a698c6a511ba5ac03afd49bfba4220efbfd313) python3Packages.anyio: disable unreliable darwin tests
* [`4eecf80f`](https://github.com/NixOS/nixpkgs/commit/4eecf80f20e29e924715d10cc4b493c01c824ce0) unbound: add Scrumplex to maintainers
* [`96fa7dae`](https://github.com/NixOS/nixpkgs/commit/96fa7dae4d3603d94a5a350913dc00f4f7599ad8) unbound: add updateScript
* [`7abce42d`](https://github.com/NixOS/nixpkgs/commit/7abce42d72118f5a5e88a5efea3c34af212e7ea3) unbound: remove with lib
* [`11852102`](https://github.com/NixOS/nixpkgs/commit/118521021bc60697182b8531c7a1747bd11f6909) linuxquota: 4.09 -> 4.10
* [`1baac6e8`](https://github.com/NixOS/nixpkgs/commit/1baac6e836f637515e0c85bab5e128b0c7a0cf01) mkspiffs: fix Darwin build
* [`93912787`](https://github.com/NixOS/nixpkgs/commit/93912787dbbc41606bd14bf3b5af95192c32e157) libtheora: 1.1.1 -> 1.2.0
* [`48d23026`](https://github.com/NixOS/nixpkgs/commit/48d23026d5fe49c15d7b6d9c06e9003a9e318a89) freetds: 1.4.27 -> 1.5.1
* [`7b035d22`](https://github.com/NixOS/nixpkgs/commit/7b035d227692a76cdd510d38211c626fd4d0e9ce) python3Packages.httpcore: 1.0.7 -> 1.0.9
* [`47426e53`](https://github.com/NixOS/nixpkgs/commit/47426e53fd7594c4fb195e3143de99c16c5f7577) h11: 0.14.0 -> 0.16.0
* [`4ac319fc`](https://github.com/NixOS/nixpkgs/commit/4ac319fc930625806709bd7c4aa87e3591ccea26) python312Packages.greenlet: 3.1.1 -> 3.2.1
* [`9e6e5152`](https://github.com/NixOS/nixpkgs/commit/9e6e5152ba5099f6694ddd412ea9e1c21efb2d4d) image/repart: repart.imageFile(BaseName) -> image.baseName, etc
* [`29a55e18`](https://github.com/NixOS/nixpkgs/commit/29a55e18199b21a56015697db0641484704133cc) mkspiffs: modernize derivation
* [`3d8b9f46`](https://github.com/NixOS/nixpkgs/commit/3d8b9f46f2a0075779fe3b8d021a39c20727efab) tokyonight-gtk-theme: 0-unstable-2024-11-06 -> 0-unstable-2025-04-24
* [`02ecc1a4`](https://github.com/NixOS/nixpkgs/commit/02ecc1a41f05eb91ce4bfe44924e8671f4bf66ee) haskellPackages.accelerate: overrideSrc from GH
* [`283799cd`](https://github.com/NixOS/nixpkgs/commit/283799cd6f0aee63dea3f7eafd5ca1405dfe25ce) haskellPackages: regenerate package set based on current config
* [`fa0c0a09`](https://github.com/NixOS/nixpkgs/commit/fa0c0a09866944d1cd1bbb80563f8a69ac3f87e8) meme-suite: 5.5.4 -> 5.5.7
* [`7c607cf9`](https://github.com/NixOS/nixpkgs/commit/7c607cf90866585af0fe5f6def90f85141c01d6f) Revert "libapparmor: fix build if doCheck = false (e.g. on cross)"
* [`8326a9a0`](https://github.com/NixOS/nixpkgs/commit/8326a9a0f54139dc5c75060aaaaed3f42cefe3f6) libapparmor: fix cross properly
* [`63b4c7ce`](https://github.com/NixOS/nixpkgs/commit/63b4c7ce843e9ca5f6d5c4ccaa9c4686e40df880) gruvbox-gtk-theme: 0-unstable-2024-11-06 -> 0-unstable-2025-04-24
* [`a1d539f8`](https://github.com/NixOS/nixpkgs/commit/a1d539f8eecffd258f3ed1ccc3a055aed56fbaa1) libselinux: fix build for musl
* [`3ba61ea2`](https://github.com/NixOS/nixpkgs/commit/3ba61ea2c10cd33d99eab37df7444165628a3067) bcachefs-tools: 1.25.1 -> 1.25.2
* [`7da44a25`](https://github.com/NixOS/nixpkgs/commit/7da44a255b436faf07685fae719feac9f2e9536c) nodemon: 3.1.9 -> 3.1.10
* [`ba312daf`](https://github.com/NixOS/nixpkgs/commit/ba312dafa5ae2e0dbb641b5ba9cd2474eb8259ce) python313Packages.sphinx-autodoc-typehints: 3.1.0 -> 3.2.0
* [`b88aca0a`](https://github.com/NixOS/nixpkgs/commit/b88aca0a1b11947ef4a72f58903cbfcf8b80d0da) nightfox-gtk-theme: 0-unstable-2024-11-06 -> 0-unstable-2025-04-24
* [`112464f2`](https://github.com/NixOS/nixpkgs/commit/112464f2ace88e6d3f8ce6e3184da272c1cec9cf) python312Packages.ipython: 9.0.2 -> 9.2.0
* [`b1c6aaf8`](https://github.com/NixOS/nixpkgs/commit/b1c6aaf870d184f1b828ddfc146048d8f12306ad) python312Packages.ipython: update meta.homepage
* [`18245fe9`](https://github.com/NixOS/nixpkgs/commit/18245fe9185ee97491a601d3cb07a841b3894bbe) ell: 0.73 -> 0.76
* [`e9ab8e88`](https://github.com/NixOS/nixpkgs/commit/e9ab8e889a6f41e3f36b63bb5e1a1281a94d1f89) python3Packages.mypy-extensions: 1.0.0 -> 1.1.0
* [`9ea1f044`](https://github.com/NixOS/nixpkgs/commit/9ea1f044a1943ec0e89a6437b713bb796b6f8eb4) varia: 2025.1.24-1 -> 2025.4.22
* [`caeba35f`](https://github.com/NixOS/nixpkgs/commit/caeba35f3b4792cdb7944b7b843541997a7f4471) mar1d: unbreak aarch64
* [`d8ac7497`](https://github.com/NixOS/nixpkgs/commit/d8ac7497299fa97b8ce0c70212ca87eb87f1d3b8) SDL2{,_classic}_mixer_2_0: drop
* [`c365a901`](https://github.com/NixOS/nixpkgs/commit/c365a90143981ffbb00f224465d30a25ff9a9089) rotonda: 0.3.0 -> 0.4.0
* [`40aa16f9`](https://github.com/NixOS/nixpkgs/commit/40aa16f9ff62c0c012cc3884e90172d1be7c10ec) binaryninja-free: 4.2.6455 -> 5.0.7290
* [`b4e17037`](https://github.com/NixOS/nixpkgs/commit/b4e17037fa8999e358631f0297eefedea48fd715) kdePackages.qtbase: remove unused pcre dependency
* [`c4849f0e`](https://github.com/NixOS/nixpkgs/commit/c4849f0ed4ce782acba4a1ca13b4226fedac6785) xorg.libXft: 2.3.8 -> 2.3.9
* [`04d7426c`](https://github.com/NixOS/nixpkgs/commit/04d7426caa8bb93322130312f20572ee7a1847d7) fcitx5: remove unused pcre dependecy
* [`e3e00735`](https://github.com/NixOS/nixpkgs/commit/e3e0073548fca0a1adddd634ebddc5305340c4d9) haskellPackages.reflex-dom: remove eval warning
* [`331e494e`](https://github.com/NixOS/nixpkgs/commit/331e494eedd468014494d6bd9bb7caca81342735) appstream: remove unused pcre dependency
* [`43081484`](https://github.com/NixOS/nixpkgs/commit/43081484dd9a447edbfac8312cbbac789df6168b) linuxPackages.hid-tmff2: 0-unstable-2025-04-12 -> 0-unstable-2025-04-22
* [`3bfcf78c`](https://github.com/NixOS/nixpkgs/commit/3bfcf78cb785ef7255e49caa1c6c4c1112e9e0dc) libsForQt5.polkit-qt: remove unused dependencies
* [`6055ada9`](https://github.com/NixOS/nixpkgs/commit/6055ada9ac09a2f471b05d1a7a07fd711a1bb6e4) iredis: 1.15.0 -> 1.15.1
* [`a02d25fb`](https://github.com/NixOS/nixpkgs/commit/a02d25fb2aa1315b005cdcc5e93096783548330d) actiona: 3.10.2 -> 3.11.1
* [`826931e0`](https://github.com/NixOS/nixpkgs/commit/826931e082aaa6c2627736fee9658cf03e5d55f5) actiona: move to pkgs/by-name
* [`077afa36`](https://github.com/NixOS/nixpkgs/commit/077afa36fbb41c2d21cc70e32bacd91ced8dff19) ocamlPackages.xenstore_transport: 1.3.0 -> 1.4.0
* [`4dce82f7`](https://github.com/NixOS/nixpkgs/commit/4dce82f7fd665ab95264fdb9c986caa58601f8f8) ocamlPackages.xenstore-tool: drop postPatch
* [`a14e2285`](https://github.com/NixOS/nixpkgs/commit/a14e2285ea6c208f451bc30b355a406605992578) cagebreak: 2.4.0 -> 3.0.0
* [`d65a53e4`](https://github.com/NixOS/nixpkgs/commit/d65a53e40cfca98205a76cbeea84d29505cb9d46) tome2: update version, fixes compilation
* [`befac760`](https://github.com/NixOS/nixpkgs/commit/befac760b19ba12069a3d2843e10aa14f795e43e) gnome-frog: 1.5.2 -> 1.6.0
* [`65bcc82e`](https://github.com/NixOS/nixpkgs/commit/65bcc82e40abda9c0a0f36f0a80bb364b53a5fc6) augeas: disable parallel building
* [`25b1a2f6`](https://github.com/NixOS/nixpkgs/commit/25b1a2f66f23fe258d3abac9aab74d7f20a1ce56) katriawm: 23.08 -> 25.04
* [`e8a88209`](https://github.com/NixOS/nixpkgs/commit/e8a88209a4c3e647944e78074547690d667e3e7c) texinfoInteractive: refactor XFAIL_TESTS
* [`272953fd`](https://github.com/NixOS/nixpkgs/commit/272953fd808945b28f31f033d1c5c9a9eff5dd4d) npm-check-updates: 17.1.18 -> 18.0.1
* [`42416909`](https://github.com/NixOS/nixpkgs/commit/424169091cab52bfef50637428d06e8d750b7e35) tome2: 2.4 -> 2.4-unstable-2025-02-17
* [`1955443b`](https://github.com/NixOS/nixpkgs/commit/1955443bdafb3018d981969ecfcb5a7e748adce1) SDL_net: 1.2.8-unstable-2024-04-23 -> 1.2.8-unstable-2025-04-21
* [`8d0862f0`](https://github.com/NixOS/nixpkgs/commit/8d0862f003dcb437f018c0d60f894c62833c55c1) miniupnpd-nftables: 2.3.8 -> 2.3.9
* [`bae6c9f5`](https://github.com/NixOS/nixpkgs/commit/bae6c9f5aee68f29dca43f82007c77902e069541) oauth2-proxy: 7.8.2 -> 7.9.0
* [`60d29b30`](https://github.com/NixOS/nixpkgs/commit/60d29b30306fa9d6c7d153a1cc3b955b7525c1e2) fcgi: 2.4.5 -> 2.4.6
* [`8eed584a`](https://github.com/NixOS/nixpkgs/commit/8eed584a6d031e41c171ceb8e131e5809453c4e9) llvmPackages.{clang,mlir}: Mark big-parallel
* [`83160ab7`](https://github.com/NixOS/nixpkgs/commit/83160ab759a8b4acf1cd672cc11c6d6249a3ebb8) quilt: 0.68 -> 0.69
* [`e164da51`](https://github.com/NixOS/nixpkgs/commit/e164da51e8992b2915a0358bd3282fa491ba3dc7) libsigsegv: 2.14 -> 2.15
* [`5e36aaa7`](https://github.com/NixOS/nixpkgs/commit/5e36aaa7914f75b8d1036b351a5d8b622250eb25) druid: 32.0.1 -> 33.0.0
* [`8226e4eb`](https://github.com/NixOS/nixpkgs/commit/8226e4eb86d4362ff6b2777098e048bfe703b5c6) opensnitch-ui: 1.6.8 -> 1.6.9
* [`cf774702`](https://github.com/NixOS/nixpkgs/commit/cf77470250907460f4c33c05483c249c8dd02b31) opensnitch: 1.6.7 -> 1.6.9
* [`fbf8306c`](https://github.com/NixOS/nixpkgs/commit/fbf8306c7ef7d56eacc71ddff447351bcc253578) wayland-protocols: 1.43 -> 1.44
* [`056b4f5d`](https://github.com/NixOS/nixpkgs/commit/056b4f5d42f6b70e65a0b43d1fc2544eb3424fc7) qt5.qtbase: fix loongarch64-linux build
* [`9e00468d`](https://github.com/NixOS/nixpkgs/commit/9e00468d7c3e164b84485ed2b0ec64bb76d5e7c2) webrtc-audio-processing_1: add loongarch64-linux support
* [`768b4c7e`](https://github.com/NixOS/nixpkgs/commit/768b4c7e13ab7062f353b22faad8f38471188541) libconfig: 1.7.3 -> 1.8
* [`762dbcc9`](https://github.com/NixOS/nixpkgs/commit/762dbcc9109855e34d810caf1761d6ca032d4abe) ocamlPackages.fix: 20230505 -> 20250428
* [`313962f4`](https://github.com/NixOS/nixpkgs/commit/313962f485315a3bde1153e01d27973eb3a867d5) ghostscript: 10.05.0 -> 10.05.1
* [`526c3dc2`](https://github.com/NixOS/nixpkgs/commit/526c3dc2a1c3b91c16367072671aeb179d8f7144) Revert "haskell.compiler.*: avoid rebuild on 64-bit for now"
* [`361853ae`](https://github.com/NixOS/nixpkgs/commit/361853ae4ebc5eb71db8a7eafe529562bb559e3c) python3Packages.typing-extensions: 4.13.0 -> 4.13.2
* [`25e365b5`](https://github.com/NixOS/nixpkgs/commit/25e365b5ccb1b90284706533b859afcfa936d1ab) Update pkgs/development/python-modules/python-coinmarketcap/default.nix
* [`e1943c44`](https://github.com/NixOS/nixpkgs/commit/e1943c444581a152f8b91a55211636ce04ee9ef8) Update pkgs/development/python-modules/python-coinmarketcap/default.nix
* [`842904c6`](https://github.com/NixOS/nixpkgs/commit/842904c6333b02434692ea2dd8fae4c2b8481738) linux: restrict zinstall to aarch and risc-v
* [`ef5433c7`](https://github.com/NixOS/nixpkgs/commit/ef5433c71c8953f381288d96a4e105553270095a) bazel-buildtools: 8.0.3 -> 8.2.0
* [`bf3fbffc`](https://github.com/NixOS/nixpkgs/commit/bf3fbffcb366bc36d1c4914843bd357711f152f5) python-coinmarketcap: nix fmt
* [`f3d2c8b0`](https://github.com/NixOS/nixpkgs/commit/f3d2c8b055722d4c3873cc22cc7568b6d82683c4) python-coinmarketcap: add setup tools input
* [`191a7e87`](https://github.com/NixOS/nixpkgs/commit/191a7e87f471356ca29992fe6437a04356f5672d) libpisp: init at 1.2.1
* [`8fcd9969`](https://github.com/NixOS/nixpkgs/commit/8fcd9969943e268457049d5371b2885063423805) libcamera: fix build on aarch64
* [`b2e00d06`](https://github.com/NixOS/nixpkgs/commit/b2e00d06822329648caa88ff88efa55d823435ab) swtpm: 0.10.0 -> 0.10.1
* [`16c8180b`](https://github.com/NixOS/nixpkgs/commit/16c8180b75973f64feb8f3ddb51176b632d0ea6e) sladeUnstable: 3.2.6-unstable-2024-11-26 -> 3.2.7-unstable-2025-04-22
* [`e98e87c9`](https://github.com/NixOS/nixpkgs/commit/e98e87c9bf271a6b26a012db4f53e80f9849e876) sladeUnstable: add fix for crossbuild
* [`ea4ecfe2`](https://github.com/NixOS/nixpkgs/commit/ea4ecfe264f84f795e33672c6c7b4f6ffd9d11ae) sladeUnstable: avoid `with lib`
* [`b02060cf`](https://github.com/NixOS/nixpkgs/commit/b02060cf8e01217d940fa5d52f97e009bccccfc4) csvquote: fix cross patching
* [`0056729c`](https://github.com/NixOS/nixpkgs/commit/0056729cb5964c5226885abed2ea57f22b4480b8) rmate-sh: fix cross patching
* [`875bb585`](https://github.com/NixOS/nixpkgs/commit/875bb58595158f0e82586f1c12e8968d5440091a) script-directory: fix cross patching
* [`8ad110ac`](https://github.com/NixOS/nixpkgs/commit/8ad110ac304aa196eebfb3e909ca69fcb79720f8) sx: fix cross patching
* [`69c74ba1`](https://github.com/NixOS/nixpkgs/commit/69c74ba1fe7e7ec3ca82d1a3c589df0d530d8dd4) wifi-qr: fix cross patching
* [`585527fd`](https://github.com/NixOS/nixpkgs/commit/585527fd8a57bc7db54d5c4f54e4d5a2e2cab256) aespipe: 2.4h -> 2.4i
* [`5e9fbb5a`](https://github.com/NixOS/nixpkgs/commit/5e9fbb5aa1567938620790b5ae486a350aa5c7a1) spice-protocol: 0.14.4 -> 0.14.5
* [`ec7fc67a`](https://github.com/NixOS/nixpkgs/commit/ec7fc67ac861c592d96b206e740459d0475ac446) git: fix building with llvm
* [`3e2eb9b0`](https://github.com/NixOS/nixpkgs/commit/3e2eb9b01c5d8df739d39aa17b878a779e344089) boinc: 8.2.1 -> 8.2.2
* [`b0206915`](https://github.com/NixOS/nixpkgs/commit/b020691564bb35cba37226c86034fd9ecff2601f) container2wasm: 0.8.0 -> 0.8.1
* [`f2948ee4`](https://github.com/NixOS/nixpkgs/commit/f2948ee4791705b9e3bae423d6a45c2415d053f6) git: fix checks by limiting build cores
* [`05656058`](https://github.com/NixOS/nixpkgs/commit/056560588e2f51c84a5154caff036cf365b16106) sqlcl: 25.1.0.101.2353 -> 25.1.1.113.2054
* [`32167620`](https://github.com/NixOS/nixpkgs/commit/32167620461fcbfc44de5bfb7ba480bc1acc0af7) nixos/cloudflared: fix certFile path credential
* [`e6aab7c8`](https://github.com/NixOS/nixpkgs/commit/e6aab7c8893b4c7966692c90a7b76bcbb504a071) mediainfo: 25.03 -> 25.04
* [`6193060e`](https://github.com/NixOS/nixpkgs/commit/6193060e0f8e0a5f807f7261499fd45356409a58) libmediainfo: 25.03 -> 25.04
* [`e4f2f56d`](https://github.com/NixOS/nixpkgs/commit/e4f2f56d7e7eb8e7f4b355fa4cae5bbe2004f9a2) stress-ng: 0.18.12 -> 0.19.00
* [`b2fdbcc1`](https://github.com/NixOS/nixpkgs/commit/b2fdbcc17a4cb2e02184df8b254ec31a2a0fe234) ghorg: 1.11.0 -> 1.11.1
* [`65354842`](https://github.com/NixOS/nixpkgs/commit/65354842895b3f051377ee142e79989e8c9259e2) hypseus-singe: 2.11.4 -> 2.11.5
* [`97a55d1f`](https://github.com/NixOS/nixpkgs/commit/97a55d1f466389521f96d94ab4bcd128e5fd9e28) rclone: 1.69.1 -> 1.69.2
* [`2b9bc9bf`](https://github.com/NixOS/nixpkgs/commit/2b9bc9bf1d20bc3bb78654045202a15a91ad0b69) haskellPackages.sensei: disable test suite
* [`97df32c5`](https://github.com/NixOS/nixpkgs/commit/97df32c57e965077ff0cfc7a109eeb29eb17cd26) haskellPackages.sensei: drop outdated override
* [`dbb2d5c1`](https://github.com/NixOS/nixpkgs/commit/dbb2d5c1fa4ef1e98e126129376864a7d107e60d) haskellPackages.reflex-dom: reformat override
* [`f5c221fe`](https://github.com/NixOS/nixpkgs/commit/f5c221fe72d34320c2b14381ec009d5c0e4ae27b) dnsdist: 1.9.8 -> 1.9.9
* [`f945f947`](https://github.com/NixOS/nixpkgs/commit/f945f947f7b97c53afd1bcaa0e5231c564bf3313) Update rbtools to the latest version 5.2.1
* [`d773ab68`](https://github.com/NixOS/nixpkgs/commit/d773ab689016c356f9a6106b26e5958e001694ef) qt5.qtscript: fix loongarch64-linux build
* [`f501d9be`](https://github.com/NixOS/nixpkgs/commit/f501d9be3b88484f5bc231796cdb4177efef0bc4) haskellPackages.pinecone: disable network dependent tests
* [`3d9dba78`](https://github.com/NixOS/nixpkgs/commit/3d9dba7860ebad0c0ed06f3aa70ac9e7aa6ac771) haskellPackages.cabal2nix-unstable: 2025-04-23 -> 2025-04-30
* [`290cac96`](https://github.com/NixOS/nixpkgs/commit/290cac96c749bc3af34f711c42ad1f63497a3e6b) haskellPackages.postgresql-libpq-configure: unbreak
* [`0de580a4`](https://github.com/NixOS/nixpkgs/commit/0de580a4a13e68ddf1c5a07ee6a87d36731b2654) haskellPackages.HDBC-postgresql: unbreak
* [`ac0e3075`](https://github.com/NixOS/nixpkgs/commit/ac0e30753c43147574566ac25df45025c6517bc4) python312Packages.pygount: 1.8.0 -> 2.0.0
* [`ca10fead`](https://github.com/NixOS/nixpkgs/commit/ca10fead0feef909d7f4bea5eae016c833a78668) haskellPackages.jsonpatch: disable broken test suite
* [`56c6a168`](https://github.com/NixOS/nixpkgs/commit/56c6a168ebdf12ce4390d5aeff5ad901054475fc) xeus: 5.2.0 -> 5.2.2
* [`993ded7b`](https://github.com/NixOS/nixpkgs/commit/993ded7ba7d55b7e7a20020f3d99d38a41a05df7) haskellPackages.what4_1_7: also apply overrides
* [`1f27ec82`](https://github.com/NixOS/nixpkgs/commit/1f27ec822211162c1635cda2e1cf3b2eaddf816e) haskellPackages.crucible*: use what4 >= 1.7
* [`bb5df8dd`](https://github.com/NixOS/nixpkgs/commit/bb5df8dd9eaf1757047d12e5246a554118dbef21) haskellPackages.crucible-llvm: provide test dependency z3
* [`eae7f8f8`](https://github.com/NixOS/nixpkgs/commit/eae7f8f82d1004e30be984917934fb58a0bdddf7) haskellPackages.crux: provide simple-get-opt < 0.5
* [`f1376ca3`](https://github.com/NixOS/nixpkgs/commit/f1376ca33b3ab5ee5c0a02e2bae01f3da0e31c6b) libepoxy: propagate buildInputs
* [`059b98fa`](https://github.com/NixOS/nixpkgs/commit/059b98fad6521cff39db4c486afcff9e544d7a49) smlnj: 110.99.7.1 -> 110.99.8
* [`58922e45`](https://github.com/NixOS/nixpkgs/commit/58922e45771ed7a30ac2aac858183e30a24b8cd2) _4ti2: 1.6.10 -> 1.6.11
* [`aeffc631`](https://github.com/NixOS/nixpkgs/commit/aeffc6318358f5a2f579923916aab1d9d7c7c706) quickjs-ng: 0.9.0 -> 0.10.0
* [`8c70e1a8`](https://github.com/NixOS/nixpkgs/commit/8c70e1a831da8455b70260ac51bcc7e248fc04ae) libconfig: backport test fix for 32-bit systems
* [`1eab52fe`](https://github.com/NixOS/nixpkgs/commit/1eab52fe3cfbc7bf8b5d44278acd5d6d99c98fda) haskellPackages: unbreak various packages
* [`54c671d3`](https://github.com/NixOS/nixpkgs/commit/54c671d3703d9f26c4474187f6bb96541a934a62) haskellPackages.postgrest: 12.2.11 -> 12.2.12
* [`23c274b1`](https://github.com/NixOS/nixpkgs/commit/23c274b199b3e82bd9fd20ad45c326bc9de3c4c4) pe-bear: 0.7.0.4 -> 0.7.1
* [`226b547a`](https://github.com/NixOS/nixpkgs/commit/226b547a920771e927f0691a12b4a393778c5709) borgmatic: 2.0.4 -> 2.0.5
* [`ff0120ed`](https://github.com/NixOS/nixpkgs/commit/ff0120edcbc909d018cf4a434093cfe0cd16d6b5) dumphfdl: init at 1.6.1
* [`bc05eaf7`](https://github.com/NixOS/nixpkgs/commit/bc05eaf7360c7c541509776766a7307c6a0cc202) haskellPackages: mark builds failing on hydra as broken
* [`4624b24e`](https://github.com/NixOS/nixpkgs/commit/4624b24efb1c82740818662472bcfefc3b1f4208) flac: don't depend on pandoc for riscv64
* [`1bf51cce`](https://github.com/NixOS/nixpkgs/commit/1bf51ccef32a9c80f7ee608e38e9a433ff6638a2) spicedb: 1.42.1 -> 1.43.0
* [`d0bbc335`](https://github.com/NixOS/nixpkgs/commit/d0bbc3354372245eddfa38e6bd75b540224e9a0e) python313Packages.whenever: 0.7.3 -> 0.8.0
* [`600a0d76`](https://github.com/NixOS/nixpkgs/commit/600a0d76d385e0d3b3f7816b4fdd2d1c58328c78) insync-nautilus: 3.8.7.50516 -> 3.9.5.60024
* [`5a7e7c19`](https://github.com/NixOS/nixpkgs/commit/5a7e7c19361c5ba92d170ff1be7c2a5d58920350) vimPlugins: update on 2025-05-01
* [`146c323a`](https://github.com/NixOS/nixpkgs/commit/146c323a6a51c8b031bea454da8833414c320f11) psqlodbc: fix cross
* [`8baa33a8`](https://github.com/NixOS/nixpkgs/commit/8baa33a8bf7457d4523fe69e57fb8bcb36c1e0cf) libsoup_3: 3.6.4 -> 3.6.5
* [`2930d7d5`](https://github.com/NixOS/nixpkgs/commit/2930d7d5acf98e6e83dae64b94b0c0406397c679) atmos: 1.171.0 -> 1.174.0
* [`a49872dd`](https://github.com/NixOS/nixpkgs/commit/a49872dd4cb781cf01a53496421680c09374190f) openrazer-daemon: Add missing dependency
* [`33039560`](https://github.com/NixOS/nixpkgs/commit/33039560627e274aadffa0b85b81a6ff9651ad47) qt6.qttools: fix cross compilation
* [`3db367e4`](https://github.com/NixOS/nixpkgs/commit/3db367e4342dd234d67a977d5bfeeda1fba15335) qt6.qtwayland: fix cross compilation
* [`f50e815c`](https://github.com/NixOS/nixpkgs/commit/f50e815cabc4bd760bf7e727096e47fdb9e89124) mkspiffs: fix cross
* [`e681e605`](https://github.com/NixOS/nixpkgs/commit/e681e6050a46ab832b87cdddfa9cb14873138c45) mkspiffs: add versionCheckHook
* [`286a31f9`](https://github.com/NixOS/nixpkgs/commit/286a31f9ebd41c9584b216071696cb62278453c9) gst_all_1.gst-plugins-bad: fix eval for riscv64
* [`dab9f811`](https://github.com/NixOS/nixpkgs/commit/dab9f8117fb0108b0fc66ca5c37b4a8cd48dc7a6) youtubeuploader: init at 1.24.4
* [`c14bdb23`](https://github.com/NixOS/nixpkgs/commit/c14bdb2352f01e83bd868a9630e6846ab28c5be8) python312Packages.sqlframe: 3.31.2 -> 3.31.3
* [`a37c5966`](https://github.com/NixOS/nixpkgs/commit/a37c5966a9b9e07e7f20d8b6ed5a1a1e38030008) duktape: use upstream pkg-config file
* [`87d1ccc7`](https://github.com/NixOS/nixpkgs/commit/87d1ccc7c3ab7691ff148bd152da16209c82ad4c) python3Packages.cachecontrol: 0.14.2 -> 0.14.3
* [`dba4342b`](https://github.com/NixOS/nixpkgs/commit/dba4342b23fc7c5699108bcb5769c748e7ff2543) qt6.qttranslations: bootstrap directly
* [`054da5f2`](https://github.com/NixOS/nixpkgs/commit/054da5f255ff99e86baf4d3951be1d62309d28f5) python313Packages.asyncprawcore: init at 2.4.0
* [`63dea02c`](https://github.com/NixOS/nixpkgs/commit/63dea02c931d188242fd27e2b175235938188a70) python3Packages.pytestCheckHook: fix Bash heredoc EOF outside subshell
* [`842f12f8`](https://github.com/NixOS/nixpkgs/commit/842f12f8ff17df159821de01a2352709d6dc358e) python3Packages.pytestCheckHook: format with shfmt
* [`1b7b89c4`](https://github.com/NixOS/nixpkgs/commit/1b7b89c4efc7e7338cc68eb0e34db94a43bd2200) Demonstration of an alternate way to embed secrets into syncthing config
* [`812b6eb1`](https://github.com/NixOS/nixpkgs/commit/812b6eb19c242c655bee2a9eed1e32a53b13bf59) tabby-agent: 0.27.0 -> 0.28.0
* [`c2913591`](https://github.com/NixOS/nixpkgs/commit/c291359123f2c984ace912649191f9b8ba5f8e64) octavePackages.image: 2.16.0 -> 2.16.1
* [`3f1cf450`](https://github.com/NixOS/nixpkgs/commit/3f1cf450d187be8714e4237174232a677d6b5bb0) maintainers: add emilia
* [`be3845b6`](https://github.com/NixOS/nixpkgs/commit/be3845b696f29bc49b430bbb2de2edeff2e2e534) libcdio: make manpages optional
* [`63714311`](https://github.com/NixOS/nixpkgs/commit/63714311997cd3d6bcd368577a113f2ddd5db65a) containerlab: fix version definition in LDFLAGS
* [`504bb713`](https://github.com/NixOS/nixpkgs/commit/504bb7135483f2289d9ddfcff424e409730da17d) python313Packages.asyncpraw: init at 7.8.1
* [`090aa284`](https://github.com/NixOS/nixpkgs/commit/090aa2849a8bbe4aed4ecbe67d4263e93cb5023d) opencode: init at 0.0.34
* [`4f424c53`](https://github.com/NixOS/nixpkgs/commit/4f424c53bcf9fbbd78319367926c3d3fc2762d18) ovito: 3.11.1 -> 3.12.2
* [`93b852d0`](https://github.com/NixOS/nixpkgs/commit/93b852d02865d227dbf34203c4bf8604067f2058) python3Packages.twscrape: init at 0.17.0
* [`0f712d38`](https://github.com/NixOS/nixpkgs/commit/0f712d384a109bf9d4d4913c50db1e1eba227f3e) lifeograph: 2.0.3 -> 3.0.1
* [`95a910a0`](https://github.com/NixOS/nixpkgs/commit/95a910a0587eea8b6b506181193b5db3f1ba7d21) python-coinmarketcap: explicitly disable check
* [`564c1c2b`](https://github.com/NixOS/nixpkgs/commit/564c1c2b218feb99f74bb9a94c7f11498aa0f435) python-coinmarketcap: comment explaining repo has no tags
* [`522711a2`](https://github.com/NixOS/nixpkgs/commit/522711a2c60ed67d33b67b36a574e0757fe8d8a5) sourcehut.srht: 0.71.8 -> 0.76.1
* [`5dffe55d`](https://github.com/NixOS/nixpkgs/commit/5dffe55d38803f4aa56b66d51f49adb3042b5fb6) wasmtime: 31.0.0 -> 32.0.0
* [`e2b9a8d3`](https://github.com/NixOS/nixpkgs/commit/e2b9a8d3269aa8c80d64079ff8037f8f1b7bc36d) tarts: init at 0.1.16-unstable-2025-05-04
* [`a210ac61`](https://github.com/NixOS/nixpkgs/commit/a210ac613b3ae48dfc006c2d58ba804d1d8b9638) nuspell: Fix RiscV cross-compile
* [`3c74ac27`](https://github.com/NixOS/nixpkgs/commit/3c74ac27e649cf32c860eef8335ee27f201d43f2) gssdp_1_6: don't depend on pandoc on exotic platforms
* [`3fba1c80`](https://github.com/NixOS/nixpkgs/commit/3fba1c80f28172fb6430616b3a96859ed806cd0e) sbcl: fix patches ahead of 2.5.3 release
* [`27e8c55d`](https://github.com/NixOS/nixpkgs/commit/27e8c55d545b0ce4ae049b6606dd866f83b2026e) sbcl: 2.5.2 -> 2.5.3
* [`7e2d7eaf`](https://github.com/NixOS/nixpkgs/commit/7e2d7eaf44ab6fe7e68daf8273ab6a2e5058fd69) sbcl: disable broken test on 2.5.3
* [`272af780`](https://github.com/NixOS/nixpkgs/commit/272af7802bd01d05a97c4793f1aba889a3d3d2b7) sbcl: 2.5.3 -> 2.5.4
* [`f232dc59`](https://github.com/NixOS/nixpkgs/commit/f232dc594f10b5337fc5ee2be60f54095a422b8c) sbcl: dont define pre/post<phase> in deriv
* [`a38846a4`](https://github.com/NixOS/nixpkgs/commit/a38846a4ef430a11f4a7e8fad54b650ab6ecfbe7) sbcl: pin 2.5.2 instead of 2.5.3
* [`4c1ad38c`](https://github.com/NixOS/nixpkgs/commit/4c1ad38c74b851ef00d03ec2a8f42fffd1e84338) sourcehut.scmsrht: 0.22.24 -> 0.22.28
* [`66866083`](https://github.com/NixOS/nixpkgs/commit/66866083c7f5899b02df68bd8b315fccd4848dc3) python312Packages.scooby: 0.10.0 -> 0.10.1
* [`6675eae4`](https://github.com/NixOS/nixpkgs/commit/6675eae4a5bf02a06a5b1a57857f4c451be456a9) python312Packages.scooby: modernize
* [`788c0d4b`](https://github.com/NixOS/nixpkgs/commit/788c0d4b0e48d0356382a841f131b742190c9fb7) svxlink: 24.02 -> 25.05
* [`b4e52b41`](https://github.com/NixOS/nixpkgs/commit/b4e52b4124e36c6ea7d0c9ee726cb5ecbb9807f7) gz-cmake: add passthru.updateScript
* [`0031c382`](https://github.com/NixOS/nixpkgs/commit/0031c3829d9e5a1aaa490bd70260b351264c6255) gz-cmake: 4.1.1 -> 4.2.0
* [`738bb429`](https://github.com/NixOS/nixpkgs/commit/738bb429cc986cdf4b33e81433f6e6a4c91e58cd) sdl3: 3.2.10 -> 3.2.12
* [`143124c1`](https://github.com/NixOS/nixpkgs/commit/143124c1cca907eca1c9cc5eccb0b80f4eed4348) sdl2-compat: 2.32.54 -> 2.32.56
* [`b21c692c`](https://github.com/NixOS/nixpkgs/commit/b21c692cd6093fda279666ef667feb57638854c3) llvmPackages_git: 21.0.0-unstable-2025-04-27 -> 21.0.0-unstable-2025-05-04
* [`b4c2b162`](https://github.com/NixOS/nixpkgs/commit/b4c2b162f55dde4e896b271e3924fbd4aff39b0c) whois: 5.5.23 -> 5.6.0
* [`bce6548c`](https://github.com/NixOS/nixpkgs/commit/bce6548ce49160531c80fe76fea530abdb2a08fe) pocketbase: 0.26.6 -> 0.27.2
* [`331d67ae`](https://github.com/NixOS/nixpkgs/commit/331d67aed22cd6da58b0202136b342fec6d76666) cloudflare-warp: wrap warp-cli to fix browser opening
* [`921a47b8`](https://github.com/NixOS/nixpkgs/commit/921a47b8c6e102aa25322272c2d91c72426401b4) python3Packages.wrapio: allow check phase
* [`1304eef9`](https://github.com/NixOS/nixpkgs/commit/1304eef92d48aee229df5cd070f3fa3b782734e9) python3Packages.wrapio: remove 'with lib'
* [`0bdf8304`](https://github.com/NixOS/nixpkgs/commit/0bdf8304f3c34d549585233da7fef1863370be29) python3Packages.survey: allow check phase
* [`5ba196f0`](https://github.com/NixOS/nixpkgs/commit/5ba196f04fefba2ede0ca7b7335627d0af27441e) python3Packages.survey: remove 'with lib'
* [`5e666d12`](https://github.com/NixOS/nixpkgs/commit/5e666d1260de4e5c67d5f3aec378c1c60ab17197) cacert: 3.108 -> 3.111
* [`c878ad10`](https://github.com/NixOS/nixpkgs/commit/c878ad10fbe97228ecd863856883e3e5f51d409c) matrix-continuwuity: init at 0.5.0-rc.5; nixos/matrix-continuwuity: init
* [`95083051`](https://github.com/NixOS/nixpkgs/commit/95083051ec8cc019dff918db26640be7ac4b41f5) git: disable more flaky tests
* [`0b41e43f`](https://github.com/NixOS/nixpkgs/commit/0b41e43fe9073d5902ec161e8515bd1518625466) vscode-extensions.ms-dotnettools.csharp: fix .NET patching.
* [`24090ebb`](https://github.com/NixOS/nixpkgs/commit/24090ebb6abbbdc2d06ba0c1f7b4579796ad1732) vscode-extensions.ms-dotnettools.csharp: fix license.
* [`d2f7caa7`](https://github.com/NixOS/nixpkgs/commit/d2f7caa736754ca9a58c9842a506c55dbc93aa76) vscode-extensions.ms-dotnettools.csdevkit: fix .NET patching.
* [`d8b0ce1e`](https://github.com/NixOS/nixpkgs/commit/d8b0ce1e407f26bc446d2e2ad25aab470b63c47b) Upgrade kata-runtime to 3.16.0
* [`7a5d50b9`](https://github.com/NixOS/nixpkgs/commit/7a5d50b91c75f226b93d304ff5e944ac2de61dc4) harper: 0.32.1 -> 0.33.0
* [`ee87d6ee`](https://github.com/NixOS/nixpkgs/commit/ee87d6ee0d7015ee0c11926543bedc39795d36ac) vscode-utils.buildVscodeExtension: set passthru.updateScript default to vscode-extension-update-script
* [`df482fb6`](https://github.com/NixOS/nixpkgs/commit/df482fb6c722fe02917fe81c153b2a3c85532a6a) SDL2_classic: fix update script
* [`1f49a562`](https://github.com/NixOS/nixpkgs/commit/1f49a562de8eae6e3c8e7ea549f784a06b36717e) SDL2_classic: 2.32.4 -> 2.32.6
* [`267994cf`](https://github.com/NixOS/nixpkgs/commit/267994cfa88912c52b9a0794435e9d2c554839c3) yeahconsole: modernize
* [`e37815b8`](https://github.com/NixOS/nixpkgs/commit/e37815b84c2b3d83899421cd9df858f5cd42f9eb) sshguard: 2.4.3 -> 2.5.1
* [`708b43ca`](https://github.com/NixOS/nixpkgs/commit/708b43cad497c092bd1ee9b10b5a0a1b6e9fb5db) gmic: 3.5.3 -> 3.5.4
* [`3bb8c5d8`](https://github.com/NixOS/nixpkgs/commit/3bb8c5d8ec9c740959d5640d84be2b5710cad00c) mpvScripts.manga-reader: 0-unstable-2025-04-16 -> 0-unstable-2025-05-01
* [`a7e19463`](https://github.com/NixOS/nixpkgs/commit/a7e194630ab99c3d8472974a50dc79e5730642e8) sourcehut.buildsrht: 0.89.15 -> 0.95.1
* [`2200d554`](https://github.com/NixOS/nixpkgs/commit/2200d554322cc9f80d73ccfdea8054983e722a11) sourcehut.gitsrht: 0.85.9 -> 0.88.10
* [`f56d90f9`](https://github.com/NixOS/nixpkgs/commit/f56d90f9a4ed131ce3fa5b09e3ed6f118967ddd8) subnetcalc: 2.6.2 -> 2.6.4
* [`9fb9ce99`](https://github.com/NixOS/nixpkgs/commit/9fb9ce99b3e0e99df98a722e68c3e73fee807560) glslang: 15.1.0 -> 15.3.0
* [`7a66c7d7`](https://github.com/NixOS/nixpkgs/commit/7a66c7d7480b417896d45e188f56d176a1d1534e) vulkan-headers: 1.4.309.0 -> 1.4.313.0
* [`ffde3c74`](https://github.com/NixOS/nixpkgs/commit/ffde3c74d31da56960d7e42e2b01851e9079f496) vulkan-loader: 1.4.309.0 -> 1.4.313.0
* [`84c037ee`](https://github.com/NixOS/nixpkgs/commit/84c037ee7fa58efa9d8eb5208a3fb52c2bd0e6ee) vulkan-validation-layers: 1.4.309.0 -> 1.4.313.0
* [`d8824ae1`](https://github.com/NixOS/nixpkgs/commit/d8824ae1475dc0fc3ea28a6d0b86ac516d53d0de) vulkan-tools: 1.4.309.0 -> 1.4.313.0
* [`6f3fbb3e`](https://github.com/NixOS/nixpkgs/commit/6f3fbb3ec1c6bafb057399e3f44c00f357934d9f) vulkan-tools-lunarg: 1.4.309.0 -> 1.4.313.0
* [`8715356a`](https://github.com/NixOS/nixpkgs/commit/8715356a4ac07533b16ff84f0f8885c4253b9cea) vulkan-extension-layer: 1.4.309.0 -> 1.4.313.0
* [`687d9e1a`](https://github.com/NixOS/nixpkgs/commit/687d9e1a5a6df6915678be481e3810b98ccd7523) vulkan-utility-libraries: 1.4.309.0 -> 1.4.313.0
* [`f66e5425`](https://github.com/NixOS/nixpkgs/commit/f66e5425f58551a22816e7c7e5b2740e5036dcdb) vulkan-volk: 1.4.309.0 -> 1.4.313.0
* [`28dbfdd2`](https://github.com/NixOS/nixpkgs/commit/28dbfdd2f8464a97f31f8243c7c56cf6ce38a3e0) spirv-headers: 1.4.309.0 -> 1.4.313.0
* [`a451d3bd`](https://github.com/NixOS/nixpkgs/commit/a451d3bdaffbece27aeaaece78586573581b2a1c) spirv-cross: 1.4.309.0 -> 1.4.313.0
* [`264ca98b`](https://github.com/NixOS/nixpkgs/commit/264ca98b96f81e2a437e0cb017b981c8afb866b8) spirv-tools: 1.4.309.0 -> 1.4.313.0
* [`9dbf4ac1`](https://github.com/NixOS/nixpkgs/commit/9dbf4ac1cd839018bb9ee8b392d0d70c503d001a) folly: disable tests on exotic platforms
* [`c8357a5c`](https://github.com/NixOS/nixpkgs/commit/c8357a5c2f9b04ad2c43f43fed0d05d3356f8eff) python312Packages.pastedeploy: fix hash
* [`f606bbe4`](https://github.com/NixOS/nixpkgs/commit/f606bbe42a2f3855165150cb2db6f0f35621c2c0) matrix-authentication-service: 0.14.1 -> 0.16.0
* [`357aa51d`](https://github.com/NixOS/nixpkgs/commit/357aa51d79efe5907318959e4f32448ebdc3575a) python3Packages.onnxslim: init at 0.1.51
* [`452e5e69`](https://github.com/NixOS/nixpkgs/commit/452e5e69ffb6f9982faf56fc0a670db34f028fee) coder: 2.19.1 -> 2.20.3
* [`3ceffaef`](https://github.com/NixOS/nixpkgs/commit/3ceffaef6b22ea0e0056aa2cca80e1bf81232f25) atf: 0.22 -> 0.23 ([nixos/nixpkgs⁠#403962](https://togithub.com/nixos/nixpkgs/issues/403962))
* [`4f2a8ea4`](https://github.com/NixOS/nixpkgs/commit/4f2a8ea42ee12aa9361a662c12cc4b8830e77113) go_1_24: 1.24.2 -> 1.24.3
* [`13992b88`](https://github.com/NixOS/nixpkgs/commit/13992b881ebf2ae2afc5a528fc5c58f6d5859e7a) five-or-more: Use finalAttrs pattern
* [`dea418e1`](https://github.com/NixOS/nixpkgs/commit/dea418e1c2cbe3ade3a7a62dce68cad13057f0a5) gnome-control-center: 47.4 → 48.beta
* [`ec747978`](https://github.com/NixOS/nixpkgs/commit/ec7479780c715aa78a6cf614080c9f995c513ebf) gnome-boxes: 47.0 → 48.alpha
* [`bb6caec7`](https://github.com/NixOS/nixpkgs/commit/bb6caec73d78cf81e48a0cd25c7c3ee520e58534) gnome-font-viewer: 47.0 → 48.alpha.1
* [`c0dc351f`](https://github.com/NixOS/nixpkgs/commit/c0dc351fbcbe95bf8db1f01c0d830c14f3a200c6) gnome-software: 47.4 → 48.rc
* [`c98870f8`](https://github.com/NixOS/nixpkgs/commit/c98870f8c2f11dc6447bbadc12c7003cc84abc4a) gnome-connections: 47.2.1 → 48.rc
* [`f8315893`](https://github.com/NixOS/nixpkgs/commit/f83158935431a9cc4093417f08a00476d4776c72) gnome-music: 47.1 → 48.beta
* [`13fd2598`](https://github.com/NixOS/nixpkgs/commit/13fd259803eded2c0d27128f9cf9a8c35b20d651) d-spy: 47.0 → 48.rc
* [`2f84e6ba`](https://github.com/NixOS/nixpkgs/commit/2f84e6ba26412cf33eed4b38e58f8afee7f3bcd7) gnome-mahjongg: 47.2 → 48.rc
* [`f01d6de0`](https://github.com/NixOS/nixpkgs/commit/f01d6de0a32b58cb44bc1b5fbff517f8bc5f8b65) gnome-builder: 47.2 → 48.rc
* [`f89333df`](https://github.com/NixOS/nixpkgs/commit/f89333df41909d762fbc0dfc61d81b3b4f58467b) gnome-nibbles: 4.1.0 → 4.2.rc6
* [`809c333a`](https://github.com/NixOS/nixpkgs/commit/809c333aa237ecb0d3026bb661ebce77fa91e10e) gnome-weather: 47.0 → 48.beta
* [`b1225003`](https://github.com/NixOS/nixpkgs/commit/b122500317c304f214fd60d33bd2eb34fb78ab68) swell-foop: 46.0 → 48.alpha
* [`dd47a4d8`](https://github.com/NixOS/nixpkgs/commit/dd47a4d86cf72f74729ab69f702d6893b2ea4bc0) libmsgraph: 0.2.3 → 0.3.3
* [`22313dbc`](https://github.com/NixOS/nixpkgs/commit/22313dbc22269865c0476495451a31256265406c) gnome-contacts: 47.1.1 → 48.beta
* [`98b9ca01`](https://github.com/NixOS/nixpkgs/commit/98b9ca01734a2a9e3caac438aff4a0937eca05dd) gnome-text-editor: 47.3 → 48.rc
* [`f58bc7ca`](https://github.com/NixOS/nixpkgs/commit/f58bc7ca625275c132098a1a8d87d45f83d1d626) gnome-mines: 40.1 → 48.alpha.2
* [`d7043c64`](https://github.com/NixOS/nixpkgs/commit/d7043c6432c1e9419bd332f56df6d604cbe47a47) gnome-sudoku: 47.1.1 → 48.rc
* [`0d1889c9`](https://github.com/NixOS/nixpkgs/commit/0d1889c9bfaa223ebf4ff0ad70ebd67a6979d5e2) orca: 47.3 → 48.beta
* [`110663dc`](https://github.com/NixOS/nixpkgs/commit/110663dc55b484c70f9342c0b8ec22ff500a885b) ghex: 46.2 → 48.alpha
* [`64798dad`](https://github.com/NixOS/nixpkgs/commit/64798dadbda76ffeea7c82ea4dbbe231984ff5a7) baobab: 47.0 → 48.alpha
* [`b278c579`](https://github.com/NixOS/nixpkgs/commit/b278c57988654bbef8c88c842b2c96ff0e0fd36b) gnome-characters: 47.0 → 48.alpha
* [`8c20da8c`](https://github.com/NixOS/nixpkgs/commit/8c20da8cc59bbf23cfece14656df190c53d74275) gnome-calculator: 47.1 → 48.rc
* [`c6425583`](https://github.com/NixOS/nixpkgs/commit/c64255838f1da384d1d757a816205d3bac11d932) five-or-more: 3.32.3 → 48.alpha
* [`723a5200`](https://github.com/NixOS/nixpkgs/commit/723a5200006d840c51a6cd5da107e0e5c895fa81) gnome-chess: 47.0 → 48.alpha2
* [`2b241859`](https://github.com/NixOS/nixpkgs/commit/2b241859a1557afe648cfc7b23dac99d08aff9d3) gnome-system-monitor: 47.1 → 48.rc
* [`f7b05156`](https://github.com/NixOS/nixpkgs/commit/f7b05156fba508f9d481cefdf0a23fe5dde41ec1) epiphany: 47.3.1 → 48.rc
* [`ce24a0d0`](https://github.com/NixOS/nixpkgs/commit/ce24a0d0698732b9d7364003d7900924365cb5a9) lightsoff: 46.0 → 48.rc
* [`dc782622`](https://github.com/NixOS/nixpkgs/commit/dc7826220e34c7f4a7b1736a8b790b43d4cc1a3a) gnome-backgrounds: 47.0 → 48.beta
* [`a596d02f`](https://github.com/NixOS/nixpkgs/commit/a596d02fa88b1762214631ca988f8dce91187f1f) gnome-remote-desktop: 47.3 → 48.rc
* [`f717c344`](https://github.com/NixOS/nixpkgs/commit/f717c344e9e6b23bfdb8347a6369775f23d036ba) evolution-data-server: 3.54.3 → 3.55.3
* [`64e3aab7`](https://github.com/NixOS/nixpkgs/commit/64e3aab77d53a59197273461e9a4b8dd58f690bd) evolution: 3.54.3 → 3.55.3
* [`fadde5a9`](https://github.com/NixOS/nixpkgs/commit/fadde5a9052290c658cdab900bb88cd57bbab0f6) gnome-shell-extensions: 47.4 → 48.beta
* [`a98f93da`](https://github.com/NixOS/nixpkgs/commit/a98f93da2b11316e6104479f6cd473deb21ffe4f) evince: 46.3.1 → 48.rc
* [`6b4e7d01`](https://github.com/NixOS/nixpkgs/commit/6b4e7d01692eec5900b0848e0e3be7a5b7c49143) libshumate: 1.3.2 → 1.4.rc
* [`615db442`](https://github.com/NixOS/nixpkgs/commit/615db442c52b5ba40f25cae6c8845aa25d0d7eb9) zenity: 4.0.5 → 4.1.90
* [`8799bf5d`](https://github.com/NixOS/nixpkgs/commit/8799bf5dab17955e32f4dd0754b3b09f2c4a7b86) nautilus: 47.2 → 48.beta
* [`6e98f5a9`](https://github.com/NixOS/nixpkgs/commit/6e98f5a9a177b17af634a8f7669a97676daddd07) gnome-shell: 47.4 → 48.beta
* [`47b6146c`](https://github.com/NixOS/nixpkgs/commit/47b6146c5d72da11715304f12faf8723e2698273) vte: 0.78.4 → 0.79.91
* [`5a33364f`](https://github.com/NixOS/nixpkgs/commit/5a33364fd3c881039b52bbd35df963b7bf07167c) gnome-terminal: 3.54.4 → 3.55.91
* [`0d8895bf`](https://github.com/NixOS/nixpkgs/commit/0d8895bf43addd9285c589647157116a003852f7) gnome-user-share: 47.2 → 48.alpha.1
* [`8dfda7ae`](https://github.com/NixOS/nixpkgs/commit/8dfda7ae12d795091e0decd8abab864670f28821) localsearch: 3.8.2 → 3.9.rc
* [`58d1ecc5`](https://github.com/NixOS/nixpkgs/commit/58d1ecc5c3621b56577a9c8f955672ac935c1eba) gnome-keyring: 46.2 → 48.beta
* [`1a773566`](https://github.com/NixOS/nixpkgs/commit/1a773566f8dedf9cd66289ef89eb94f3e9fad83e) gdm: 47.0 → 48.beta
* [`61b0e30c`](https://github.com/NixOS/nixpkgs/commit/61b0e30c9c17f0744a0815b75cca76310d1b6bf0) mutter: 47.5 → 48.beta
* [`618b0693`](https://github.com/NixOS/nixpkgs/commit/618b06931817cf1df86ad4a1da7db9c448c3bf53) gnome-clocks: 47.0 → 48.beta
* [`cf4ad10e`](https://github.com/NixOS/nixpkgs/commit/cf4ad10e4407dc26d99496a22a6b07c86f0d178c) gnome-tecla: 47.0 → 48.rc
* [`c1bfb6f5`](https://github.com/NixOS/nixpkgs/commit/c1bfb6f5a1ca48a9a665e809bd5aeb45a5b367a3) gnome-online-accounts: 3.52.3.1 → 3.53.2
* [`844126fd`](https://github.com/NixOS/nixpkgs/commit/844126fdb3ee2bbfe53c0d37155ad351e4fa4fcc) gnome-settings-daemon: 47.2 → 48.rc
* [`f2d4a14b`](https://github.com/NixOS/nixpkgs/commit/f2d4a14ba2c95cd26cd57b4ef7a2a804618faaba) libdex: 0.8.1 → 0.9.1
* [`e2fd3f64`](https://github.com/NixOS/nixpkgs/commit/e2fd3f64185b17afe6b36d3a2ca63af3a40e5481) gcr_4: 4.3.1 → 4.3.91
* [`089caeb9`](https://github.com/NixOS/nixpkgs/commit/089caeb99fb30818e70ebbf45a434db82f51b986) libpanel: 1.8.1 → 1.9.0
* [`cc85fcc1`](https://github.com/NixOS/nixpkgs/commit/cc85fcc1a199c01578f433a20087ed054157f982) gjs: 1.82.1 → 1.83.90
* [`b4076b25`](https://github.com/NixOS/nixpkgs/commit/b4076b2522753ab9d647ba46245cb09644ed9905) adwaita-icon-theme: 47.0 → 48.beta
* [`8fb8885e`](https://github.com/NixOS/nixpkgs/commit/8fb8885ebd72269f2257b99c979bf52f5c77ff18) gtk4: 4.16.12 → 4.17.5
* [`d1ceff72`](https://github.com/NixOS/nixpkgs/commit/d1ceff727c7e23715c18ef39aae815a2882d820b) gnome-initial-setup: 47.4 → 48.rc
* [`f2c70599`](https://github.com/NixOS/nixpkgs/commit/f2c70599f86f09289a63774cd3b5ca27aa854471) xdg-desktop-portal-gnome: 47.3 → 48.rc
* [`8ce968bb`](https://github.com/NixOS/nixpkgs/commit/8ce968bba5d6990b6a0a03967c21e82054bc8e49) libadwaita: 1.6.4 → 1.7.rc
* [`6fa1cabb`](https://github.com/NixOS/nixpkgs/commit/6fa1cabb73c751528783bf511d4c474c047bb69a) loupe: 47.4 → 48.rc
* [`7600e0f2`](https://github.com/NixOS/nixpkgs/commit/7600e0f2dd9fc9caf4d39527294f40634c8273dd) glycin-loaders: 1.1.6 → 1.2.rc
* [`4616f367`](https://github.com/NixOS/nixpkgs/commit/4616f367047edde4f5e90e18fcc9c91489935e62) gnome-calendar: 47.0 → 48.rc
* [`01105ba6`](https://github.com/NixOS/nixpkgs/commit/01105ba6e475d81fdfe7e51fb01f501609b0fa5f) gnome-maps: 47.4 → 48.rc
* [`639feac1`](https://github.com/NixOS/nixpkgs/commit/639feac1d5fcc61826542f39158077ff3f39ea89) snapshot: 47.1 → 48.0.1
* [`1e82e84d`](https://github.com/NixOS/nixpkgs/commit/1e82e84d56229e56aecb3c4008fb7d4d3aeb6884) gtksourceview5: 5.14.2 → 5.15.1
* [`65b29540`](https://github.com/NixOS/nixpkgs/commit/65b2954049e8fc33352f4507b206d5108c930ff4) gtkmm4: 4.16.0 → 4.17.0
* [`3b382769`](https://github.com/NixOS/nixpkgs/commit/3b3827692697d7961898ed56655cdac5d5e0fffa) at-spi2-core: 2.54.1 → 2.55.90
* [`bf55c78b`](https://github.com/NixOS/nixpkgs/commit/bf55c78b900d83d4e9fc9d8bf56db94c91dfff30) tinysparql: 3.8.2 → 3.9.rc
* [`2caf0e26`](https://github.com/NixOS/nixpkgs/commit/2caf0e26a8b72c6a740a3fa2a56f103901f28590) gsettings-desktop-schemas: 47.1 → 48.rc
* [`d8dddbe5`](https://github.com/NixOS/nixpkgs/commit/d8dddbe52b6cbdfc6145f64840df29eca5318697) vala_0_56: 0.56.17 → 0.56.18
* [`73b10182`](https://github.com/NixOS/nixpkgs/commit/73b1018231d94b9a34871c622b6af2fde6dfafc0) gobject-introspection: 1.82.0 → 1.83.2
* [`c9afde4c`](https://github.com/NixOS/nixpkgs/commit/c9afde4c1ee0a06103ddc3cebb5a897409ba8bb3) glib: 2.82.5 → 2.83.5
* [`27b47ea9`](https://github.com/NixOS/nixpkgs/commit/27b47ea93debd61a2bb4ba8df0fe9f7e54b13a09) gvfs: 1.56.1 → 1.57.2
* [`d637b708`](https://github.com/NixOS/nixpkgs/commit/d637b708b211bfe08f15a854ad138a45a37ad385) glibmm_2_68: 2.82.0 → 2.83.1
* [`ad0fc732`](https://github.com/NixOS/nixpkgs/commit/ad0fc732f1144bf92ee2d0b1a0d79bacc72e13ba) sysprof: 47.2 → 48.beta
* [`ebcbcfcc`](https://github.com/NixOS/nixpkgs/commit/ebcbcfcc58ec42b4794a624fe30ab9addab35baf) gupnp-tools: 0.12.1 → 0.12.2
* [`5fcc66e6`](https://github.com/NixOS/nixpkgs/commit/5fcc66e6408e7496ec65cde2273d21c91aa5a26e) gnome-usage: 46.0 → 48.rc
* [`0438b841`](https://github.com/NixOS/nixpkgs/commit/0438b841e1616a9308a1748f8b5fde669d205491) gnome-console: 47.1 → 48.rc
* [`22721761`](https://github.com/NixOS/nixpkgs/commit/2272176106329b8cc9b05e6285723d548e2ce0aa) orca: 48.beta → 48.rc
* [`cf7bc14f`](https://github.com/NixOS/nixpkgs/commit/cf7bc14f8efad2ae5626d461aa9f583041eda014) gnome-control-center: 48.beta → 48.rc.1
* [`554b09b5`](https://github.com/NixOS/nixpkgs/commit/554b09b5e770a5a3fdb071c2c1a49da369d3bcb9) gnome-backgrounds: 48.beta → 48.rc
* [`c0298f9d`](https://github.com/NixOS/nixpkgs/commit/c0298f9d445d478945b998fc523fbbb954637299) gnome-shell-extensions: 48.beta → 48.rc
* [`162ece42`](https://github.com/NixOS/nixpkgs/commit/162ece422725a35c05bcd969d979ef10a985fede) gnome-shell: 48.beta → 48.rc
* [`608bd55e`](https://github.com/NixOS/nixpkgs/commit/608bd55e8f6137b410300a17a6fa43722f2a6e8b) libgnome-games-support_2_0: 2.0.0 → 2.0.1
* [`a7696289`](https://github.com/NixOS/nixpkgs/commit/a7696289a31297e948a15fe03bd6cab69120569e) nautilus: 48.beta → 48.rc
* [`ce55d91e`](https://github.com/NixOS/nixpkgs/commit/ce55d91e6d909716eac20e9a4a7bb4f6aa04cefe) mutter: 48.beta → 48.rc
* [`18d1ff10`](https://github.com/NixOS/nixpkgs/commit/18d1ff10539de38fc9229ceba12fa2b78aa0beba) glibmm_2_68: 2.83.1 → 2.84.0
* [`f2a3cc1a`](https://github.com/NixOS/nixpkgs/commit/f2a3cc1abeeda8ceae7351a48047a5156652f2bd) gtk4: 4.17.5 → 4.17.6
* [`1fa3dc23`](https://github.com/NixOS/nixpkgs/commit/1fa3dc23f89609b68483a268021e4075fbe739da) gobject-introspection: 1.83.2 → 1.83.4
* [`b08c9f4f`](https://github.com/NixOS/nixpkgs/commit/b08c9f4f806226347b3e13774f19f1016f30d9bd) glib: 2.83.5 → 2.84.0
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
