### PR TITLE
niv home-manager: update 535a541b -> 45c29856

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -41,10 +41,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "535a541b429c1e89f0955c160df1d6d2bfeaf802",
-        "sha256": "04pkpr5b9ajvhfkq8mmrwdw037yamhblj6jzhiscl069kic53rwq",
+        "rev": "45c2985644b60ab64de2a2d93a4d132ecb87cf66",
+        "sha256": "0zksadj7hs2z1ij8hfskpi995lfs6b5p2m9gnvf5y6ddfgzvi6hm",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/535a541b429c1e89f0955c160df1d6d2bfeaf802.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/45c2985644b60ab64de2a2d93a4d132ecb87cf66.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@535a541b...45c29856](https://github.com/nix-community/home-manager/compare/535a541b429c1e89f0955c160df1d6d2bfeaf802...45c2985644b60ab64de2a2d93a4d132ecb87cf66)

* [`dc589997`](https://github.com/nix-community/home-manager/commit/dc5899978f8fa5d72424d5242784fb7e84e8573e) services/mako: refactor settings to support INI sections
* [`0be2c246`](https://github.com/nix-community/home-manager/commit/0be2c246e37a5b6e851111bfcf07ab37194e4954) mako: deprecate criteria option
* [`78ad8e3c`](https://github.com/nix-community/home-manager/commit/78ad8e3c31cc5239674dfd7ca6159e5ca14da0e8) tests/mako: add a deprecation test
* [`df556f2a`](https://github.com/nix-community/home-manager/commit/df556f2a17b7b94148d0275c1a57fed20e62ad18) tests/mako: add a original deprecation test
* [`8d832ddf`](https://github.com/nix-community/home-manager/commit/8d832ddfda9facf538f3dda9b6985fb0234f151c) foliate: init ([nix-community/home-manager⁠#7049](https://togithub.com/nix-community/home-manager/issues/7049))
* [`b44c39cf`](https://github.com/nix-community/home-manager/commit/b44c39cf4618ccf58df2b68827ca95a3fecf0655) foliate: fix theme settings example ([nix-community/home-manager⁠#7053](https://togithub.com/nix-community/home-manager/issues/7053))
* [`5f36563a`](https://github.com/nix-community/home-manager/commit/5f36563a5cae05bcfbaa5e08a69d2e8d94242f61) zsh: consider zsh.{profile,login,logout,env}Extra in prezto
* [`7c1cefb9`](https://github.com/nix-community/home-manager/commit/7c1cefb98369cc85440642fdccc1c1394ca6dd2c) zsh: avoid IFD while sourcing prezto
* [`6bf057fc`](https://github.com/nix-community/home-manager/commit/6bf057fc8326e83bda05a669fc08d106547679fb) zsh: do not duplicate zsh.{profile,login,logout,env}Extra in prezto ([nix-community/home-manager⁠#7061](https://togithub.com/nix-community/home-manager/issues/7061))
* [`02ea7985`](https://github.com/nix-community/home-manager/commit/02ea79853ce42853d019ce689f533dc93e462862) emacs: respect `defaultEditor` on Darwin ([nix-community/home-manager⁠#7063](https://togithub.com/nix-community/home-manager/issues/7063))
* [`954615c5`](https://github.com/nix-community/home-manager/commit/954615c510c9faa3ee7fb6607ff72e55905e69f2) flake.lock: Update ([nix-community/home-manager⁠#7058](https://togithub.com/nix-community/home-manager/issues/7058))
* [`ad1e8bb7`](https://github.com/nix-community/home-manager/commit/ad1e8bb782ed91b4966ab5b642f9b2c5813354ce) dbus: Create with pacakges options ([nix-community/home-manager⁠#7064](https://togithub.com/nix-community/home-manager/issues/7064))
* [`3b930bb6`](https://github.com/nix-community/home-manager/commit/3b930bb653dd9ed7da5fe86c147bbc67492efe2c) services.nix-gc: improve error message when nix.gc.frequency is invalid on darwin
* [`1c2fccef`](https://github.com/nix-community/home-manager/commit/1c2fccef832e5fbf2df4162f742f76a153aa5443) services.nix-gc: extract darwin agent interval code to new library file
* [`34d44d7f`](https://github.com/nix-community/home-manager/commit/34d44d7f1b7da16509538f72ec6bee121932a3e1) services.borgmatic: wrap systemd configuration within a isLinux condition
* [`c09ccd7d`](https://github.com/nix-community/home-manager/commit/c09ccd7d39eb4c246fcb0e2b3e4be0361a85c19a) services.borgmatic: add initial support for darwin
* [`c310818d`](https://github.com/nix-community/home-manager/commit/c310818dca3d92fa6ab769a572c46e04f24b1f87) mako: Fix missing dbus service file ([nix-community/home-manager⁠#7065](https://togithub.com/nix-community/home-manager/issues/7065))
* [`ff73544e`](https://github.com/nix-community/home-manager/commit/ff73544e4a59dce43a6de7051858a453186ae9bb) dconf: Provide dconf package and dbus service file
* [`ec8205c3`](https://github.com/nix-community/home-manager/commit/ec8205c3d7d4b19998d9b762d2c5abd2fc11faa7) dconf: set env var
* [`a99bddfe`](https://github.com/nix-community/home-manager/commit/a99bddfe53cb5ae488bfb0dc0170dae258b2c572) lapce: fix no argument hash for pluginFromRegistry ([nix-community/home-manager⁠#7062](https://togithub.com/nix-community/home-manager/issues/7062))
* [`b022c9e3`](https://github.com/nix-community/home-manager/commit/b022c9e3b805484e44aaad1973ed7572b0c1b5c4) vscode: allow specifying paths for VSCode JSON settings ([nix-community/home-manager⁠#7055](https://togithub.com/nix-community/home-manager/issues/7055))
* [`dbc90cc3`](https://github.com/nix-community/home-manager/commit/dbc90cc3ae9c8f927200a6ceaf4aa247ea6bc443) rclone: declarative mounts ([nix-community/home-manager⁠#7060](https://togithub.com/nix-community/home-manager/issues/7060))
* [`8ae36f8e`](https://github.com/nix-community/home-manager/commit/8ae36f8ea2e0621b6cdea862e938aaa018e0ef27) nix-gc: fix documentation
* [`098e365d`](https://github.com/nix-community/home-manager/commit/098e365dd83311cc8236f83ea6be42abb49a6c76) borgmatic: add darwin-specific documentation to services.borgmatic.frequency
* [`a1a72d18`](https://github.com/nix-community/home-manager/commit/a1a72d18ee75ce4559b5f59296a7b2d37f608c1c) pgcli: init ([nix-community/home-manager⁠#7072](https://togithub.com/nix-community/home-manager/issues/7072))
* [`d2263ce5`](https://github.com/nix-community/home-manager/commit/d2263ce5f4c251c0f7608330e8fdb7d1f01f0667) nix-darwin: use `launchctl asuser` now that activation runs as root ([nix-community/home-manager⁠#7051](https://togithub.com/nix-community/home-manager/issues/7051))
* [`74d31e11`](https://github.com/nix-community/home-manager/commit/74d31e1165341bf510ee2017841a599f5cfc1608) ptyxis: init module ([nix-community/home-manager⁠#7075](https://togithub.com/nix-community/home-manager/issues/7075))
* [`5d132608`](https://github.com/nix-community/home-manager/commit/5d13260881eae0e9894f2c1dffd2cb97d6b79a07) treewide: lnl7 -> nix-darwin
* [`ae755329`](https://github.com/nix-community/home-manager/commit/ae755329092c87369b9e9a1510a8cf1ce2b1c708) templates/nix-darwin: nixpkgs track nixpkgs-unstable
* [`e08e6e23`](https://github.com/nix-community/home-manager/commit/e08e6e2389234000b0447e57abf61d8ccd59a68e) home-manager: set 25.05 as stable
* [`9a4a9f1d`](https://github.com/nix-community/home-manager/commit/9a4a9f1d6e43fe4044f6715ae7cc85ccb1d2fe09) home-manager: prepare 25.11
* [`10d13a62`](https://github.com/nix-community/home-manager/commit/10d13a62e3ab95ba904cbc3d2a44ac177d85da65) flake.lock: Update
* [`ee85cfc5`](https://github.com/nix-community/home-manager/commit/ee85cfc5c132e2cf956a7b5ab156ddaedaefcbbc) home-manager: add missing file
* [`97118a31`](https://github.com/nix-community/home-manager/commit/97118a310eb8e13bc1b9b12d67267e55b7bee6c8) flake-module: use toString primop
* [`45c29856`](https://github.com/nix-community/home-manager/commit/45c2985644b60ab64de2a2d93a4d132ecb87cf66) ci: bump DeterminateSystems/update-flake-lock from 24 to 25 ([nix-community/home-manager⁠#7091](https://togithub.com/nix-community/home-manager/issues/7091))
