### PR TITLE
niv nixpkgs: update 817e93d7 -> 9f387576

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -155,10 +155,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "817e93d76bd7e1d8bce3cf7fa401dbce749cc7d8",
-        "sha256": "0najfi679xqqw2mkkmmm0gm0rwbm6si4p8rcf416xv8zwrvblcmd",
+        "rev": "9f3875761628112140c969c0e7c59295158e09bd",
+        "sha256": "0r4yqgp8ql4vw35z2p3cvhpd1041xws8fkak3h58lyda8qd4djqc",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/817e93d76bd7e1d8bce3cf7fa401dbce749cc7d8.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/9f3875761628112140c969c0e7c59295158e09bd.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@817e93d7...9f387576](https://github.com/nixos/nixpkgs/compare/817e93d76bd7e1d8bce3cf7fa401dbce749cc7d8...9f3875761628112140c969c0e7c59295158e09bd)

* [`fc7aea93`](https://github.com/NixOS/nixpkgs/commit/fc7aea9368cd4d688aa3ee0c56a029c8c21b2fad) nixos/spacenavd: add wantedBy for automatic startup
* [`9c20cc62`](https://github.com/NixOS/nixpkgs/commit/9c20cc62cfbf12bb9ac5a0d243dac47ced3aefcd) microcode-intel: enable building on platforms other than x86_64-linux
* [`b448c6cf`](https://github.com/NixOS/nixpkgs/commit/b448c6cf164cce096db2a5a9c5ce1f50c1d5fafe) veroroute: init at 2.39
* [`09de72aa`](https://github.com/NixOS/nixpkgs/commit/09de72aad036c5b9fb1cca78642cbe04531ea9d8) python3Packages.mlxtend: 0.23.3->0.23.4
* [`475d8959`](https://github.com/NixOS/nixpkgs/commit/475d8959f1bf3cbd9aa9a730c62ea5fd5651f9eb) python312Packages.mlxtend: cleanup unused old numpy_1 argument
* [`faa73bb5`](https://github.com/NixOS/nixpkgs/commit/faa73bb540fd99bae4b14e057b34123d3e8cef61) python3Packages.mlxtend: fix scikit >1.6.0 compat
* [`9891bef5`](https://github.com/NixOS/nixpkgs/commit/9891bef5073b7e2d25a08b336aa5551e663db58c) python3Packages.mlxtend: disable failing tests test_ensemble_vote_classifier, test_stacking_classifier, test_stacking_cv_classifier
* [`2c7a56ce`](https://github.com/NixOS/nixpkgs/commit/2c7a56cee91cdcb62f2a30ca2a6c5e5637ca74a4) nixos/foot: fix zshrc
* [`814378b3`](https://github.com/NixOS/nixpkgs/commit/814378b3f4cd1180b89f25d4094012d5d2bd7967) libspnav: 1.1 -> 1.2
* [`84357787`](https://github.com/NixOS/nixpkgs/commit/84357787467ccd6deb5412d654158f576bc2b17a) linuxPackages.openafs: Patch for Linux kernel 6.14
* [`315681df`](https://github.com/NixOS/nixpkgs/commit/315681dfe26ebf3380077a1a78fcc8e73fdf9692) nixos/doc/rl-2505: add an entry for nixos/agnos
* [`5eaebff8`](https://github.com/NixOS/nixpkgs/commit/5eaebff88194af0a0811cc107490604c74d25aef) vmware-workstation: make overridable
* [`09ff535e`](https://github.com/NixOS/nixpkgs/commit/09ff535e100a3681936602f98ab71d4b4783d3f4) vmware-workstation: modernize
* [`18ba6d13`](https://github.com/NixOS/nixpkgs/commit/18ba6d1375eac5b2c268fd670a6eadeba60cdfc2) vmware-workstation: update meta attrs
* [`5e3aa011`](https://github.com/NixOS/nixpkgs/commit/5e3aa011a08a48b1232416bbd28ae208d221e9c2) vmware-workstation: reorder attrs
* [`47a05695`](https://github.com/NixOS/nixpkgs/commit/47a0569504eb0b1898424de1c8c1b88337b13530) wl-gammarelay-rs: 1.0.0 -> 1.0.1
* [`edb9c458`](https://github.com/NixOS/nixpkgs/commit/edb9c458e89a9a039f7bc11b4c29d0fcab78465d) libinput: 1.27.1 -> 1.28.1
* [`bb3a41f3`](https://github.com/NixOS/nixpkgs/commit/bb3a41f312d0a25779a544935440f9a9897071da) buildPython*: fix the disabled functionality for overrideAttrs-
* [`f4352695`](https://github.com/NixOS/nixpkgs/commit/f4352695bfd98428b48641c2ee20f1f745c5effa) R: 4.4.3 -> 4.5.0
* [`7bcd1196`](https://github.com/NixOS/nixpkgs/commit/7bcd11966b27985155f9a989ef9faced3a280aba) rPackages: CRAN and BioC update
* [`f68603be`](https://github.com/NixOS/nixpkgs/commit/f68603bec0abbdbffb3df53343e9a4e73204e8df) rPackages.rhdf5filters: updated patch
* [`40835aec`](https://github.com/NixOS/nixpkgs/commit/40835aec4e2772e02d16f52b8844330d9bea89ca) rPackages.rJava: fix build
* [`e3a839a6`](https://github.com/NixOS/nixpkgs/commit/e3a839a6787d9084b4086eb781ba1dffa005bc74) rPackages.rJava: make build deterministic
* [`dbb5ac9a`](https://github.com/NixOS/nixpkgs/commit/dbb5ac9aa0975ad3dc97f1f4c4b3d89a4588c0ae) rPackages.rshift: fixed build
* [`bd5144b6`](https://github.com/NixOS/nixpkgs/commit/bd5144b6ff7e3eaf9e497448d4c48a7b5bfe42ac) rPackages.fio: fixed build
* [`da3e442d`](https://github.com/NixOS/nixpkgs/commit/da3e442de894c53ad34fc1f15674d7201196a669) jnitrace: init at 3.3.1
* [`d524316b`](https://github.com/NixOS/nixpkgs/commit/d524316b4e072a8f5f83deb7a46f7150e6a7b55d) rPackages.BayesChange: fixed build
* [`6f3a0e78`](https://github.com/NixOS/nixpkgs/commit/6f3a0e785dab15244f699a5c29804440aac47e57) rPackages.HiCParser: fixed build
* [`764992ac`](https://github.com/NixOS/nixpkgs/commit/764992ac570709419a89e55b8da5b48b5ec66987) rPackages.DEploid_utils: fixed build
* [`c511d9e2`](https://github.com/NixOS/nixpkgs/commit/c511d9e274b511a1468b03aa3cc61e20e342a78d) rPackages.EBSeq: fix build
* [`1e595f40`](https://github.com/NixOS/nixpkgs/commit/1e595f40ae2e83b753a260423ec61e80d3b17008) arduino-cli: 1.2.0 -> 1.2.2
* [`60faec14`](https://github.com/NixOS/nixpkgs/commit/60faec14b9b10b984706b471b65d822e90fdc458) arduino-cli: remove 'with lib'
* [`d123f599`](https://github.com/NixOS/nixpkgs/commit/d123f5997d4a71e4d8804152cd3c3905d800e693) coqPackages_8_20.coqfmt: init at master
* [`45159258`](https://github.com/NixOS/nixpkgs/commit/45159258f7b6d42ef72dfeca2989911e1b762eed) acme-sh: 3.1.0 -> 3.1.1
* [`ef20fe8e`](https://github.com/NixOS/nixpkgs/commit/ef20fe8eacce6e0c5cc12ce924523cc00ddeb929) rPackages.Rigraphlib: add sysdep
* [`483b3565`](https://github.com/NixOS/nixpkgs/commit/483b356575e4b583b1e7e146ac1e6375d9c7c0d3) rPackages.scDDboost: fix build
* [`efcd7503`](https://github.com/NixOS/nixpkgs/commit/efcd75030648116bcb84a2ca90f4b6a6e5e5baf8) rPackages.bandle: fix build
* [`81079a9e`](https://github.com/NixOS/nixpkgs/commit/81079a9ebc0497f7f5b50253fe077623a95b9947) rPackages.methylKit: fix build
* [`182dc78f`](https://github.com/NixOS/nixpkgs/commit/182dc78f397add50eb3cc831542602cbc4b2a324) Update bioc experiment packages
* [`569efb90`](https://github.com/NixOS/nixpkgs/commit/569efb90e7e4fe4ace0a9a28e5ff8c88ad19841a) rPackages.knowYourCG: fix build
* [`464cb8c0`](https://github.com/NixOS/nixpkgs/commit/464cb8c0a903eff83784bfb9f90cbb64df446fb7) rPackages.transmogR: fix build
* [`ee17ad66`](https://github.com/NixOS/nixpkgs/commit/ee17ad66273cffd6d00229ca8c8b1e6aec150cb9) rPackages.Rmpi: fix build
* [`a753044e`](https://github.com/NixOS/nixpkgs/commit/a753044e5f7f7f9cd61f0b1b829e26e2d8aa1b44) rockbox-utility: 1.4.1 -> 1.5.1
* [`ab792bb5`](https://github.com/NixOS/nixpkgs/commit/ab792bb54035c631d2f1a3001d3b2d6de5fb076b) libcerf: 2.4 -> 3.0
* [`281c0c16`](https://github.com/NixOS/nixpkgs/commit/281c0c16c9c6e2e44e78334f55bbd43dc51c0d70) gcc15, gccgo15, gfortran15, gnat15: init at 15.1.0
* [`e7919a44`](https://github.com/NixOS/nixpkgs/commit/e7919a445f022e37f65df273b34ff2a063cb5847) rPackages.hypeR: fix build
* [`e0705250`](https://github.com/NixOS/nixpkgs/commit/e0705250d2b9b192aa0ee430d61e4039c91d1f55) buildNodePackage: enable strictDeps
* [`d3b50e56`](https://github.com/NixOS/nixpkgs/commit/d3b50e56b7ee15285add46c0fcd14654b87fe781) homepage-dashboard: unbreak Darwin
* [`37d8d75e`](https://github.com/NixOS/nixpkgs/commit/37d8d75e88099c84b19cad819091b178adeeee79) rPackages.SynExtend: fix build
* [`cf13f52b`](https://github.com/NixOS/nixpkgs/commit/cf13f52b70bbe7f05f3f9078a579bd182d8a0db3) rPackages.PICS: fix build
* [`f1cbb85e`](https://github.com/NixOS/nixpkgs/commit/f1cbb85ee1eb99f100d90f1c8a1ac467452080e4) ares: 143 -> 144
* [`fdca3f8e`](https://github.com/NixOS/nixpkgs/commit/fdca3f8e35d2e475aba9876fd808544fcb8fa9f8) rPackages.cn_farms: fix build
* [`0fd362e6`](https://github.com/NixOS/nixpkgs/commit/0fd362e6bf94011a2211b2190ef1dd83b2d11649) rPackages.genoCN: fix build
* [`0c0a3ab3`](https://github.com/NixOS/nixpkgs/commit/0c0a3ab35cf0927f187658fc6bd19bfb91043f39) rPackages.trigger: fix build
* [`fccedfe9`](https://github.com/NixOS/nixpkgs/commit/fccedfe9134e89f3d49a011c2368f576a829cfda) rPackages.AneuFinder: fix build
* [`366e3d04`](https://github.com/NixOS/nixpkgs/commit/366e3d0428b6ab4350bfb181210bc7d625ae728b) rPackages.rix: 0.15.7 -> 0.16.0
* [`7a6fb80e`](https://github.com/NixOS/nixpkgs/commit/7a6fb80e6df1f24203a6299c037c6c5ac6408477) gf: 0-unstable-2025-02-04 -> 0-unstable-2025-04-11; bump to latest version
* [`0a51a163`](https://github.com/NixOS/nixpkgs/commit/0a51a163ca3eea7483244decefeee662dcde2694) signal-desktop-bin: 7.52.0 -> 7.55.0
* [`6fba69e6`](https://github.com/NixOS/nixpkgs/commit/6fba69e6eafbccff9f1ff54f24fc15da45bb6521) kohighlights: init at 2.3.1.0
* [`61e61a59`](https://github.com/NixOS/nixpkgs/commit/61e61a59eb99affecc383f18250928c0eb76f21f) nixos-rebuild-ng: kill underlying remote process
* [`062eaf73`](https://github.com/NixOS/nixpkgs/commit/062eaf7379974675dc6c00445f29ce2a4753db0b) nixos-rebuild-ng: alert user if we can't clean-up remote process
* [`2e06b6da`](https://github.com/NixOS/nixpkgs/commit/2e06b6da564f481031f4a5045a637673effcd87f) nixos-rebuild-ng: mark logger as Final
* [`b74e861c`](https://github.com/NixOS/nixpkgs/commit/b74e861c28643c55b7cc4bf909cd91cb907bb790) nixos-rebuild-ng: use Final in constants.py
* [`c570df85`](https://github.com/NixOS/nixpkgs/commit/c570df851d69504e4383235b2ed382dbcd991beb) uefitoolPackages.new-engine: A62 -> A71
* [`371e5493`](https://github.com/NixOS/nixpkgs/commit/371e54933a47446391b987ecb21ca7e4299039b5) python3Packages.dash: 3.0.3 -> 3.0.4
* [`4d4805fc`](https://github.com/NixOS/nixpkgs/commit/4d4805fcee27e91db46706ac0ef920a71926e5f7) python3Packages.aiomisc: 17.7.3 -> 17.7.7
* [`66088bc2`](https://github.com/NixOS/nixpkgs/commit/66088bc2623b7e0b9fe42b5206c46a37f23f90e1) python3Packages.gotenberg-client: 0.9.0 -> 0.10.0
* [`f9ee8448`](https://github.com/NixOS/nixpkgs/commit/f9ee8448aabf0e8bedab768ddc0da568ad88d57f) python3Packages.ase: 3.24.0 -> 3.25.0
* [`cdc8c25c`](https://github.com/NixOS/nixpkgs/commit/cdc8c25cf46994ce0736a096a4cd27b3035a9f6c) python3Packages.pymdown-extensions: 10.14.3 -> 10.15
* [`d9cc2cfd`](https://github.com/NixOS/nixpkgs/commit/d9cc2cfd1d392ad576c36ad4e6bcb02831cafc99) conda: 25.1.1-2 -> 25.3.1-1
* [`2234346c`](https://github.com/NixOS/nixpkgs/commit/2234346c9ba9f0096a1a95b3c8298aeb94cb552c) wine64Packages.{unstable,staging}: 10.5 -> 10.6
* [`f40800fb`](https://github.com/NixOS/nixpkgs/commit/f40800fb5a4b6ea8dd17861a2302d78fe39b29eb) wine64Packages.{unstable,staging}: 10.6 -> 10.7
* [`4b75b7a4`](https://github.com/NixOS/nixpkgs/commit/4b75b7a46eecb697c2fe027e2a46a7ba9efa0ec3) jetbrains: add and improve tests
* [`6b1e8c30`](https://github.com/NixOS/nixpkgs/commit/6b1e8c30c84288764ad81af959f30963733fe816) jetbrains: fix format in README
* [`52b4a325`](https://github.com/NixOS/nixpkgs/commit/52b4a3256b4af8d026bc51d90c6e5ae432e21b54) eas-cli: v14.7.1 -> v16.4.0
* [`487d1383`](https://github.com/NixOS/nixpkgs/commit/487d1383c883c5707bdece8a9c95b00f6bad7a1e) nixos/direnv: fix silent option... again
* [`50f551c3`](https://github.com/NixOS/nixpkgs/commit/50f551c32210910a603ea88514661a57d0104a3c) python3Packages.pmdsky-debug-py: 10.0.21 -> 10.0.48
* [`cfc34d5c`](https://github.com/NixOS/nixpkgs/commit/cfc34d5c451eea8491c8d8e251aab51aef75549c) python3Packages.skytemple-dtef: 1.6.1 -> 1.8.0
* [`4f5893d9`](https://github.com/NixOS/nixpkgs/commit/4f5893d910ee9d505a8a5936bea6312dda328bf4) python3Packages.skytemple-files: 1.8.3 -> 1.8.5
* [`64dfc1d9`](https://github.com/NixOS/nixpkgs/commit/64dfc1d916abb0c47f98a1e591dcb997b416e96f) python3Packages.skytemple-ssb-debugger: 1.8.2 -> 1.8.3
* [`4d7a4ee4`](https://github.com/NixOS/nixpkgs/commit/4d7a4ee479b408d286ba7f46b13ece484f368fe4) skytemple: 1.8.3 -> 1.8.4
* [`af498b1e`](https://github.com/NixOS/nixpkgs/commit/af498b1e5cdd581327a031a5c8300b87df164f8d) ncdu: 2.8 -> 2.8.2
* [`8f91507e`](https://github.com/NixOS/nixpkgs/commit/8f91507efbb2ca319ac5f6e0b59465c4616c9738) nixos/clash-verge: harden systemd service
* [`edf88097`](https://github.com/NixOS/nixpkgs/commit/edf880979370f74f949be2701469c62ee91871d9) nixos/clash-verge: readd tunMode
* [`ac791605`](https://github.com/NixOS/nixpkgs/commit/ac79160520d75ac21e84eff4ab77630632cd6fae) jetbrains: move test to package
* [`b9b40bcd`](https://github.com/NixOS/nixpkgs/commit/b9b40bcd13cecba78eaa41f742376b887ad5b4eb) jetbrains: remove obsolete file
* [`72c84cbe`](https://github.com/NixOS/nixpkgs/commit/72c84cbebbd30294a22d88526d247268216c4867) jetbrains: fix format
* [`55347c19`](https://github.com/NixOS/nixpkgs/commit/55347c1937026a5d389034e28607bd8a529fd623) python3Packages.livekit-protocol: add updateScript
* [`c451881b`](https://github.com/NixOS/nixpkgs/commit/c451881bbae95b9c29c27fc699e274fa9bc506c8) python3Packages.livekit-api: add updateScript
* [`f5efa59a`](https://github.com/NixOS/nixpkgs/commit/f5efa59ad1e3ea384637bd3f3a9472a8ad0cea75) nixos/k3s: support fetching helm charts from OCI registries
* [`fb1e22f5`](https://github.com/NixOS/nixpkgs/commit/fb1e22f57681298627f65eb43a3a4deea96bdbd5) armadillo: 14.4.1 -> 14.4.2
* [`cd16ea24`](https://github.com/NixOS/nixpkgs/commit/cd16ea241cb31e03f928f7c001678e339d796976) nixos/installation-cd-graphical-base: disable hyper-v guest on exotic platforms
* [`1ccb1c4b`](https://github.com/NixOS/nixpkgs/commit/1ccb1c4bdff0a03844d368e2aab0c09c883645bc) python3Packages.rpy2: add zstd
* [`0390f0ce`](https://github.com/NixOS/nixpkgs/commit/0390f0ceb837859a3221531bc52e23b1234a189a) yandex-cloud: 0.147.0 -> 0.148.0
* [`1dfce906`](https://github.com/NixOS/nixpkgs/commit/1dfce9060fa0a59098f985f915a765e1958ce3ed) x11docker: 7.6.0 -> 7.6.0-unstable-2024-04-04
* [`eae93b56`](https://github.com/NixOS/nixpkgs/commit/eae93b565897b735af32b913d425b7547d843817) rPackages.nanonext: fixed build
* [`fba059e9`](https://github.com/NixOS/nixpkgs/commit/fba059e95683662f3301a7011d93ee2bf36b8447) python3Packages.rdflib: 7.1.3 -> 7.1.4
* [`138fce2c`](https://github.com/NixOS/nixpkgs/commit/138fce2c617a9b1af84374468d1128d63db9d1c9) python3Packages.google-auth-oauthlib: 1.2.1 -> 1.2.2
* [`ce5074e8`](https://github.com/NixOS/nixpkgs/commit/ce5074e8a6b17296150b43eab0ce3b8cb8d1c511) ricochet-refresh: 3.0.31 -> 3.0.33
* [`36c93db4`](https://github.com/NixOS/nixpkgs/commit/36c93db4f1b1536c4cae70374cafe32caf5dcdbf) auto-cpufreq: 2.5.0 -> 2.6.0
* [`6c5848fd`](https://github.com/NixOS/nixpkgs/commit/6c5848fd920467ebaa56f858afee3ef72a76c5ad) mos: 3.4.1 -> 3.5.0
* [`becdee5c`](https://github.com/NixOS/nixpkgs/commit/becdee5ccf892ea86f9d736da020a1bccfed155a) python3Packages.ansible: 11.4.0 -> 11.5.0
* [`655ae94e`](https://github.com/NixOS/nixpkgs/commit/655ae94ea51ec0194c79bbae4c3c24bcb9de1a58) libcpuid: 0.7.1 -> 0.8.0
* [`3f8895ac`](https://github.com/NixOS/nixpkgs/commit/3f8895ac373c81b3ed5fea49756bc25ae684791a) bulloak: 0.8.0 -> 0.8.1
* [`d7a74259`](https://github.com/NixOS/nixpkgs/commit/d7a7425974c1bef0fded090be6ca8e4aeba13f1f) libpulsar: 3.7.0 -> 3.7.1
* [`817b9f69`](https://github.com/NixOS/nixpkgs/commit/817b9f692dca44d728e5ad431875e6df63977840) docbook_sgml_dtd: fix unreachable source
* [`d1722bc9`](https://github.com/NixOS/nixpkgs/commit/d1722bc9c829dce4a1ee96add25109e3dc3c3fb7) octavePackages.io: 2.6.4 -> 2.7.0
* [`23b42966`](https://github.com/NixOS/nixpkgs/commit/23b42966ae2f2c8e1b9daab5cb6b62fb49beab07) python3Packages.bdffont: 0.0.30 -> 0.0.31
* [`aef67089`](https://github.com/NixOS/nixpkgs/commit/aef67089a7374c3d55b32e42c96e4abdef940191) renderdoc: 1.37 -> 1.38
* [`cd3045ca`](https://github.com/NixOS/nixpkgs/commit/cd3045ca0c964cacece802b787ad9b2080adc1da) sonata: 1.7.0 -> 1.7.1
* [`bf21f984`](https://github.com/NixOS/nixpkgs/commit/bf21f9843ae9beb07e4298ad706d7503422cffde) renode-unstable: 1.15.3+20250406gitea53e3840 -> 1.15.3+20250507git91a4bb342
* [`3aff7b47`](https://github.com/NixOS/nixpkgs/commit/3aff7b471c61b26a0be6f1bdc35ee8871d0168b7) linux/common-config: enable EFI on supported platforms
* [`9077ba76`](https://github.com/NixOS/nixpkgs/commit/9077ba76a3c358f5f5c2131a9f33170d83ebf286) libosmocore: 1.11.0 -> 1.11.1
* [`e4633ab2`](https://github.com/NixOS/nixpkgs/commit/e4633ab264548740d9f4663114aeddd8e1c536e0) mlt: 7.30.0 -> 7.32.0
* [`c00514cf`](https://github.com/NixOS/nixpkgs/commit/c00514cf877bf84a6f7aa6cfad12ae484c563c14) zziplib: 0.13.78 -> 0.13.79
* [`47adab92`](https://github.com/NixOS/nixpkgs/commit/47adab9257aee0c871f99f4aa9bfc7d962c0c197) zarf: 0.41.0 -> 0.54.0
* [`30ef0e05`](https://github.com/NixOS/nixpkgs/commit/30ef0e052a24466ace1375925285c69c41326086) mas: 2.1.0 -> 2.2.2
* [`9a50a21b`](https://github.com/NixOS/nixpkgs/commit/9a50a21b79baf38852d0e303bdea3d7070ba52f0) trino-cli: 439 -> 475
* [`6b1fcd21`](https://github.com/NixOS/nixpkgs/commit/6b1fcd21a3cf91aede65fd36d028c2ea6287db81) istioctl: 1.25.2 -> 1.26.0
* [`5e40f866`](https://github.com/NixOS/nixpkgs/commit/5e40f866dce459a73e0e8251139f9982863902b4) fuse-overlayfs: 1.14 -> 1.15
* [`e4f2d594`](https://github.com/NixOS/nixpkgs/commit/e4f2d59409f8df55ec826b733c75e2caf6f2a9e8) python3Packages.hatch-autorun: init at 1.1.0
* [`bbe729f9`](https://github.com/NixOS/nixpkgs/commit/bbe729f9d55af82e9cf3018b47eccb70f1b89c61) python3Packages.auto-lazy-imports: init at 0.4.2
* [`f6f1ae32`](https://github.com/NixOS/nixpkgs/commit/f6f1ae3261354289b247f0a768fd8e136d9f33c0) python3Packages.coredis: 4.20.0 -> 4.22.0
* [`fe359e96`](https://github.com/NixOS/nixpkgs/commit/fe359e9681d67beea84189d881efd86970ef7cb1) pmars: Fix FTBFS due to ncurses change
* [`9b3a7f30`](https://github.com/NixOS/nixpkgs/commit/9b3a7f3047479d709aaac7d4da0eaacd93f6000a) linuxPackages.ena: 2.13.3 -> 2.14.0
* [`b541d837`](https://github.com/NixOS/nixpkgs/commit/b541d837f44a42a1408c97ba08c5564bba541a84) mint: 0.23.2 -> 0.24.1
* [`40c05a53`](https://github.com/NixOS/nixpkgs/commit/40c05a534a7123365ecc2c9e97ad107a07e332cc) ghostty-bin: init at 1.1.3
* [`84124e00`](https://github.com/NixOS/nixpkgs/commit/84124e008ccb71c55235f38f8849d86cc12c4db0) ms-sys: 2.6.0 -> 2.7.0
* [`a4d865a9`](https://github.com/NixOS/nixpkgs/commit/a4d865a9c28d08c9d60a0753d06bac94e25cf55e) killport: 0.9.2 -> 1.1.0
* [`9a8379fc`](https://github.com/NixOS/nixpkgs/commit/9a8379fc3a6ffcd4083cd9d730be948065a49bc7) zk: 0.15.0 -> 0.15.1
* [`18f34890`](https://github.com/NixOS/nixpkgs/commit/18f34890d2ed06220fc75d64f692623814fb1ca1) playwright-driver: use upstream chromium build
* [`9424a47a`](https://github.com/NixOS/nixpkgs/commit/9424a47a657f423d3d12ded83fced9974f87a7d9) playwright: add myself as a maintainer
* [`35b3e5bf`](https://github.com/NixOS/nixpkgs/commit/35b3e5bfba979a9eae35581577978c1462391a83) rsyslog: 8.2502.0 -> 8.2504.0
* [`d29c1765`](https://github.com/NixOS/nixpkgs/commit/d29c176566b73f4774147b779dce3deea7d832e6) cables: 0.5.12 -> 0.5.13
* [`6cb7d8e8`](https://github.com/NixOS/nixpkgs/commit/6cb7d8e8c964a3a42647a385fbd6803d58325c74) josm: 19369 → 19396
* [`a3834693`](https://github.com/NixOS/nixpkgs/commit/a38346938f744cc9aaf099da0389fbbd7431453d) jetbrains.plugins.test: Also test bin/src packages explicitly
* [`7caad501`](https://github.com/NixOS/nixpkgs/commit/7caad5016c93968772cd77529272855a9ed2ac79) python3Packages.kombu: 5.5.2 -> 5.5.3
* [`856bddbe`](https://github.com/NixOS/nixpkgs/commit/856bddbe8e07c28ef84bb183f13a7c3a328fc947) vivaldi: 7.3.3635.11 -> 7.3.3635.12
* [`680ad736`](https://github.com/NixOS/nixpkgs/commit/680ad736264d122858db43807eae39bdfdacbb22) mt-st: 1.3 -> 1.8
* [`6dcc6ace`](https://github.com/NixOS/nixpkgs/commit/6dcc6ace728ece2a62c6d19c4d30223c15cd8a85) lilypond-unstable: 2.25.25 -> 2.25.26
* [`5bbd0766`](https://github.com/NixOS/nixpkgs/commit/5bbd07663072bc25a75535afb580e09c42e26864) rustup: 1.27.1 -> 1.28.2
* [`1e6c4457`](https://github.com/NixOS/nixpkgs/commit/1e6c4457678c650bf0577a019d825effe637641e) linux/common-config: disable OF_OVERLAY on x86_64 if version < 5.15
* [`a47b73ff`](https://github.com/NixOS/nixpkgs/commit/a47b73ffdef4273000f0190440af2a8c57879bf8) python3Packages.pydal: 20250228.1 -> 20250501.2
* [`2e6fb8c1`](https://github.com/NixOS/nixpkgs/commit/2e6fb8c12a80b2934f640ab8bd12e08d4aad0a8f) agate: 3.3.14 → 3.3.16
* [`4ed0dee9`](https://github.com/NixOS/nixpkgs/commit/4ed0dee987dc3039f8d0c2fc8a9ef53ba1e58ad4) pgmodeler: move to by-name
* [`e9b91497`](https://github.com/NixOS/nixpkgs/commit/e9b91497d6a6414a1091e74281ac75baec64aa36) pgmodeler: 1.1.6 -> 1.2.0
* [`5aa2d438`](https://github.com/NixOS/nixpkgs/commit/5aa2d4383e50dd633fe0fcd1376092bd7e7a3e0a) python3Packages.coredis: switch to pypa builder
* [`38162484`](https://github.com/NixOS/nixpkgs/commit/381624849761a493851d28cbd72f208c82be5efb) python3Packages.coredis: refactor
* [`b0e1219e`](https://github.com/NixOS/nixpkgs/commit/b0e1219e370e67645244407165d993aa08158db3) python3Packages.hiredis: 3.1.0 -> 3.1.1
* [`9b01e09a`](https://github.com/NixOS/nixpkgs/commit/9b01e09a350a8cb2fc86215bcaa040562e439597) workflows: avoid running jobs when editing title etc.
* [`c8595a8b`](https://github.com/NixOS/nixpkgs/commit/c8595a8bed2d2a3b164c9c2a180351fc49ab6bed) xwax: install default importers
* [`cd55b65d`](https://github.com/NixOS/nixpkgs/commit/cd55b65d4eabcba3d0eca5355ef195d2f1c54c99) free42: 3.2.8 -> 3.3.4
* [`ab1ea56b`](https://github.com/NixOS/nixpkgs/commit/ab1ea56b74e9c06c4c061d0c1090b0b1d12162f1) hplip: stylix
* [`34a65cfa`](https://github.com/NixOS/nixpkgs/commit/34a65cfa85dbc0f66e2fcdd3ae8633bd47d993c7) hplip: 3.24.4 -> 3.25.2
* [`4dfa0ed7`](https://github.com/NixOS/nixpkgs/commit/4dfa0ed7808a4f6fa970cc5e90bbb50c0e50635d) dua: 2.29.4 -> 2.30.1
* [`bd1da829`](https://github.com/NixOS/nixpkgs/commit/bd1da829a63c623879eaf0ddc6aa04875182636a) man-pages: 6.13 -> 6.14
* [`e7ddf711`](https://github.com/NixOS/nixpkgs/commit/e7ddf711a7d5fc62219cb6e5abbd8fb66f31dc50) libndctl: 79 -> 81
* [`9291e4c2`](https://github.com/NixOS/nixpkgs/commit/9291e4c2a03e4d9366dc3f6245b9f388192a6372) python3Packages.pynitrokey: 0.8.1 -> 0.8.3
* [`a21f9ef2`](https://github.com/NixOS/nixpkgs/commit/a21f9ef2300283be055f21cb306249e2ea243f8d) python3Packages.fontparts: 0.12.3 -> 0.12.5
* [`11e499f1`](https://github.com/NixOS/nixpkgs/commit/11e499f1d0597ea37ee8661830a8e347d1dea028) poedit: 3.5.2 -> 3.6.2
* [`9fecdecb`](https://github.com/NixOS/nixpkgs/commit/9fecdecb866fc9aeb97047ff8c3815a8848055bc) linuxPackages.rtl8821au: unstable-2024-03-16 -> unstable-2025-04-08
* [`22966fa8`](https://github.com/NixOS/nixpkgs/commit/22966fa889182eae71feb5dbbaafcc1ae8d8b080) linuxPackages.rtl8821au: fix meta.homepage
* [`f56e9aa4`](https://github.com/NixOS/nixpkgs/commit/f56e9aa4f9f9e74f4bb53cca1728e99bbfc4e949) python3Packages.pygit2: 1.17.0 -> 1.18.0
* [`2b0f385f`](https://github.com/NixOS/nixpkgs/commit/2b0f385fabbf7b605470d995543801bcadd92759) python3Packages.markdownify: 0.14.1 -> 1.1.0
* [`5f478b3a`](https://github.com/NixOS/nixpkgs/commit/5f478b3a2bf44e0a77b318a31c8f2cbfe46365b5) netexec: 1.3.0 -> 1.4.0
* [`7cfb6636`](https://github.com/NixOS/nixpkgs/commit/7cfb663639a1dbfd07c9dfd6cc7fdc6df7012d90) netlogo: 6.1.1 -> 6.4.0
* [`7bbc83ce`](https://github.com/NixOS/nixpkgs/commit/7bbc83cedf3a05d6d7ae0ee23d3171fc73a0b653) authelia: 4.39.1 -> 4.39.3
* [`dde3e32b`](https://github.com/NixOS/nixpkgs/commit/dde3e32b28bca8586148e14d8e273e0f538cadc6) python3Packages.ijson: 3.3.0 -> 3.4.0
* [`e7c7a0ac`](https://github.com/NixOS/nixpkgs/commit/e7c7a0ac5aad0ccd79a7f6a8c8cc45f2652235de) vcpkg: 2025.02.14 -> 2025.04.09
* [`327a1dc1`](https://github.com/NixOS/nixpkgs/commit/327a1dc1e5b882cacc7cbc80686cf34c9652e5a0) sogo: 5.11.2 -> 5.12.1
* [`b71d4f5f`](https://github.com/NixOS/nixpkgs/commit/b71d4f5fb335b8d126273b5b24d3a23a4f5f674a) nixos/pdns-recursor: deprecate settings, add yaml-settings
* [`13accc23`](https://github.com/NixOS/nixpkgs/commit/13accc23b088b7f721e76afd39adaa4e5aa01409) nixos/tests/pdns-recursor: test old-settings
* [`ab8653ab`](https://github.com/NixOS/nixpkgs/commit/ab8653abd56044c8f645b792843a36226eb21754) nixos/release-notes: deprecate services.pdns-recursor.settings
* [`1a1d0e56`](https://github.com/NixOS/nixpkgs/commit/1a1d0e5661ba8d22c31bec67c03099d4f9cf0960) worldpainter: 2.23.2 -> 2.24.1
* [`95e07f4b`](https://github.com/NixOS/nixpkgs/commit/95e07f4bd3a4b7f015b0bdecf9778b63649d5c18) gz-cmake: enable tests again
* [`c6211353`](https://github.com/NixOS/nixpkgs/commit/c621135365c6be1f9dca22ca06a967c6eafce221) tiledb: 2.27.2 -> 2.28.0
* [`506a3ffe`](https://github.com/NixOS/nixpkgs/commit/506a3ffeedf7907b8e7c4b7d9c98614878aadd58) oci2git: init at 0.1.4
* [`8aef10b5`](https://github.com/NixOS/nixpkgs/commit/8aef10b5cdb252cfd436f30eced148e50b683f93) python3Packages.glueviz: 1.21.1 -> 1.22.2
* [`48ccdb5d`](https://github.com/NixOS/nixpkgs/commit/48ccdb5d4e3329bb7c44d0ac6788a3de80cc3383) tests.importCargoLock.*: remove usage of lib.fileset
* [`948c3f5e`](https://github.com/NixOS/nixpkgs/commit/948c3f5e2ce69f7b321f3f4a9c8f771438336214) openssl: don't create `separateDebugInfo` on android
* [`16187b11`](https://github.com/NixOS/nixpkgs/commit/16187b11753d2992e1d043809bf5cba2418b78fb) tests.config.allowPkgsInPermittedInsecurePackages: set system
* [`b494b7ed`](https://github.com/NixOS/nixpkgs/commit/b494b7ed40435689165c70be2d24d7b10ab0ff24) tests.stdenv: remove `__attrsFailEvaluation`
* [`72a87bc2`](https://github.com/NixOS/nixpkgs/commit/72a87bc217f5b673f3f488d78b634c368aef99b9) tests.cross: remove `__attrsFailEvaluation`
* [`33964ab8`](https://github.com/NixOS/nixpkgs/commit/33964ab8ba0d110bdeeea6e51bcab74fd224990d) tests: recurse into more attrs
* [`4c96cad8`](https://github.com/NixOS/nixpkgs/commit/4c96cad82499474c0957a2cb21e5c098ed5a297e) tests.cross.{gcc,llvm}.*: don't recurse into
* [`8ad53eba`](https://github.com/NixOS/nixpkgs/commit/8ad53eba468737af64f98d068e1894f619faf597) netavark: 1.14.1 -> 1.15.0
* [`9aa0e679`](https://github.com/NixOS/nixpkgs/commit/9aa0e679da72a6e76a9fdf70f55a9519011b9559) colima: use source build lima on darwin too
* [`a312acc6`](https://github.com/NixOS/nixpkgs/commit/a312acc618686faacb78f215ea61e97627d33f1a) python3Packages.django-celery-results: 2.5.1 -> 2.6.0
* [`2962b305`](https://github.com/NixOS/nixpkgs/commit/2962b305b36d301c2e2951ceb632c6d620b1f454) python3Packages.magika: 0.6.1 -> 0.6.2
* [`570fdda4`](https://github.com/NixOS/nixpkgs/commit/570fdda40b1be142fffad893b0fb527533872451) python3Packages.aiomqtt: 2.3.2 -> 2.4.0
* [`056358b2`](https://github.com/NixOS/nixpkgs/commit/056358b26dc0c91ab8d49ec8c87df76b30f42d75) keymapp: add darwin platform
* [`8ea963f2`](https://github.com/NixOS/nixpkgs/commit/8ea963f28d94c6ec3658990fe847fb71df929bb1) airdrop-cli: init at 0-unstable-2024-04-13
* [`b89f634b`](https://github.com/NixOS/nixpkgs/commit/b89f634b5d34f8aaf491a8edfc5fc3d9660c6abe) python3Packages.pylsqpack: 0.3.20 -> 0.3.22
* [`9d73295f`](https://github.com/NixOS/nixpkgs/commit/9d73295f719fd574fec8ed993703715c6ef3b216) keymapp: split linux and darwin into separate files
* [`fa95dd9c`](https://github.com/NixOS/nixpkgs/commit/fa95dd9c5d6de8bfaa369fa20be82ba4ae1c5b29) keymapp: add afh as maintainer
* [`d7718008`](https://github.com/NixOS/nixpkgs/commit/d7718008d4203ad8ad1d5619a54dab22db330a6d) python313Packages.trimesh: 4.6.8 -> 4.6.9
* [`0886a171`](https://github.com/NixOS/nixpkgs/commit/0886a1719ee2eca63ef84a5d57c1b7b294dddc7a) linuxPackages.corefreq: 2.0.1 -> 2.0.3
* [`21437713`](https://github.com/NixOS/nixpkgs/commit/2143771374d7906552b48cd22d3261c7f8f459c8) lomiri.lomiri-filemanager-app: 1.1.3 -> 1.1.4
* [`3b244752`](https://github.com/NixOS/nixpkgs/commit/3b24475288d182cdfe708cabba0f3277ab015caa) linuxPackages.system76-acpi: fix build
* [`4adde8f3`](https://github.com/NixOS/nixpkgs/commit/4adde8f35b6f5c6d647aeb3bca37b0d6a9dd5652) linuxPackages.system76-acpi: small improvements
* [`fcd0c831`](https://github.com/NixOS/nixpkgs/commit/fcd0c8318d7484223c88bbfddcc1581522e6fa03) linuxPackages.v86d: fix build
* [`16dc8499`](https://github.com/NixOS/nixpkgs/commit/16dc84994e7450d24acdbfd7e920129f4fb10e83) linuxPackages.v86d: small improvements
* [`66301f51`](https://github.com/NixOS/nixpkgs/commit/66301f51a371c9d7af9dc27688ff374ca9526195) nixosTests.lomiri-filemanager-app: Fix OCR
* [`98ad8444`](https://github.com/NixOS/nixpkgs/commit/98ad8444d1ff85e79d4fcf81a115336f52f4704d) pixelorama: 1.1 -> 1.1.1
* [`d0de1313`](https://github.com/NixOS/nixpkgs/commit/d0de1313ff5d4c5298f14fc872443bd2f13ad999) overlayed: don't vendor Cargo.lock
* [`18623a1e`](https://github.com/NixOS/nixpkgs/commit/18623a1ebecfe2f5498c0328f93eaaac57be96d8) veloren: don't vendor Cargo.lock
* [`61879eac`](https://github.com/NixOS/nixpkgs/commit/61879eac1e2d30243c47da5bcc4c6b5c3caacef5) weylus: don't vendor Cargo.lock
* [`89a6665f`](https://github.com/NixOS/nixpkgs/commit/89a6665f9be0650dc3c708a09abe73172fd63ffa) rustdesk-server: don't vendor Cargo.lock
* [`15b7f476`](https://github.com/NixOS/nixpkgs/commit/15b7f4767f747d5217be506e0fbc4169f0233b4f) xplorer: don't vendor Cargo.lock
* [`ff62fe41`](https://github.com/NixOS/nixpkgs/commit/ff62fe41360357452cd5232c7006661e4f512798) brscan5: remove deprecated SYSFS udev rule
* [`64599ba0`](https://github.com/NixOS/nixpkgs/commit/64599ba0df5ad54de099e7934e57b787e36af000) doctave: don't vendor Cargo.lock
* [`f17b3b25`](https://github.com/NixOS/nixpkgs/commit/f17b3b256d2c1a3abd1246dddab6892747ba8446) sope: 5.11.2 -> 5.12.1
* [`502d9ad1`](https://github.com/NixOS/nixpkgs/commit/502d9ad1699817cd3fa5c37a977ab5a421c28b46) libxmp: 4.6.2 -> 4.6.3
* [`0157a3f3`](https://github.com/NixOS/nixpkgs/commit/0157a3f3b84eaebe01e17e6095b774e34582d448) maestro: 1.40.0 -> 1.40.3
* [`3948075e`](https://github.com/NixOS/nixpkgs/commit/3948075eb59320a6a3c20fde75209761ac765d42) beekeeper-studio: fix update script
* [`3ae0281a`](https://github.com/NixOS/nixpkgs/commit/3ae0281a953b8ab9408e6a2ae26230342d86c180) beekeeper-studio: 5.1.5 -> 5.2.7
* [`cf09e202`](https://github.com/NixOS/nixpkgs/commit/cf09e2022c98944e8e5b340a635721eaba346a8e) netpbm: 11.10.2 -> 11.10.4
* [`d76b5333`](https://github.com/NixOS/nixpkgs/commit/d76b53333ede46f0e8cfa7fd1130f732ec4b9fd8) burpsuite: add yechielw to maintainers
* [`35f0d9e3`](https://github.com/NixOS/nixpkgs/commit/35f0d9e35ed94dba2845571d4a8c0d2427e454d1) linuxPackages.nvidia_x11.persistenced: remove dates from man pages
* [`b7e74c23`](https://github.com/NixOS/nixpkgs/commit/b7e74c23a95840266a4c5569e8d08fc9396b3381) beeper: 4.0.661 -> 4.0.693
* [`9887ab90`](https://github.com/NixOS/nixpkgs/commit/9887ab90ba457f5d1038d05465f125f19e9ffa52) lrcget: use cargo-tauri.hook
* [`17437745`](https://github.com/NixOS/nixpkgs/commit/174377456dbeb7fa6bd5e6e56ce0953e4e3e8e83) rclone: remove tomfitzhenry as maintainer
* [`7c859e43`](https://github.com/NixOS/nixpkgs/commit/7c859e433c849178574d90795f6f629c10ed700d) git-absorb: remove tomfitzhenry as maintainer
* [`80eaabf9`](https://github.com/NixOS/nixpkgs/commit/80eaabf92838903945860ed1cebdb278be8a61de) lomiri.lomiri-system-settings-unwrapped: 1.3.0 -> 1.3.2
* [`8ad6adb4`](https://github.com/NixOS/nixpkgs/commit/8ad6adb4c7d46ca71afb48af8841fd207c4c048d) nordic: 2.2.0-unstable-2025-03-21 -> 2.2.0-unstable-2025-05-05
* [`98b05e94`](https://github.com/NixOS/nixpkgs/commit/98b05e942d4649e9d97dada99c93ed6f18d32bf1) nordic: remove broken symlinks
* [`acb0aca8`](https://github.com/NixOS/nixpkgs/commit/acb0aca85cd38ee6dfa8fa1533987946d89abd21) go-landlock: remove tomfitzhenry as maintainer
* [`5aa68f7a`](https://github.com/NixOS/nixpkgs/commit/5aa68f7ab62ccd11764c0d79b3a05eb96253be23) paper-age: remove tomfitzhenry as maintainer
* [`97082c5f`](https://github.com/NixOS/nixpkgs/commit/97082c5ff9de8376a87c9bf3c6b57d790f2f9cb9) wayidle: remove tomfitzhenry as maintainer
* [`702c5f77`](https://github.com/NixOS/nixpkgs/commit/702c5f774358bd5cb10ed29cde895a3c92cefbbe) ibm-sw-tpm2: remove tomfitzhenry as maintainer
* [`a598371d`](https://github.com/NixOS/nixpkgs/commit/a598371de1535e53ed1dd3857d84d4c32d5af3e0) tpm2-tools: remove tomfitzhenry as maintainer
* [`46f4abdd`](https://github.com/NixOS/nixpkgs/commit/46f4abdd81a5a7334a55d11c13c3f9fe3540f161) kubie: disable the default update feature
* [`6a81ab4f`](https://github.com/NixOS/nixpkgs/commit/6a81ab4f50028af222e045ac3958290b5b165cf0) python3Packages.brian2: 2.8.0.4 -> 2.9.0
* [`d7140264`](https://github.com/NixOS/nixpkgs/commit/d71402645d131a704aa70dc1d36bfaf2c7d11d4b) catppuccin-plymouth: fix variant selection
* [`bb1451f4`](https://github.com/NixOS/nixpkgs/commit/bb1451f46b043b94f740d281b91a7041fb3ecbdf) pdftk: use minimal jre
* [`8867af5e`](https://github.com/NixOS/nixpkgs/commit/8867af5e965f1aabb58b3ace11e47ae8289e7840) nest-cli: 10.4.9 -> 11.0.7
* [`c89426d9`](https://github.com/NixOS/nixpkgs/commit/c89426d9f5036eee9e18ee311178e93afe85f9ce) nest-cli: add phanirithvij as maintainer
* [`07f2db67`](https://github.com/NixOS/nixpkgs/commit/07f2db67e1c4a2ad2babed0aa96e6596ee5381f1) aldente: 1.32 -> 1.33
* [`c7c68261`](https://github.com/NixOS/nixpkgs/commit/c7c682614aa93c44ececfbe99d1b932e0ddb3041) nzbget: 24.8 -> 25.0
* [`4dff0746`](https://github.com/NixOS/nixpkgs/commit/4dff07463fcc048daee0c4f060cf5fad751df852) amazon-cloudwatch-agent: 1.300055.0 -> 1.300055.2
* [`4ff9a066`](https://github.com/NixOS/nixpkgs/commit/4ff9a06625459158727004b9eb1d4e3bb72bdfb6) navicat-premium: 17.2.2 -> 17.2.3
* [`032bd9d0`](https://github.com/NixOS/nixpkgs/commit/032bd9d01319b8d340c9b003a75e77a09f5e0d3a) yacreader: fix darwin build
* [`eabe73d0`](https://github.com/NixOS/nixpkgs/commit/eabe73d0012468956d326b9e384b639c42e4c323) opentelemetry-collector-builder: 0.124.0 -> 0.126.0
* [`1c3439d1`](https://github.com/NixOS/nixpkgs/commit/1c3439d19ae0e6753f11b5929d768faa050728c4) python3Packages.flask-security: 5.6.1 -> 5.6.2
* [`08de3692`](https://github.com/NixOS/nixpkgs/commit/08de36925ae42e7abf8c49e07eeaf1f0afcc086e) python3Packages.icalendar: 6.1.3 -> 6.3.0
* [`7ad05bdb`](https://github.com/NixOS/nixpkgs/commit/7ad05bdb77ab3fd1c6eb1e22fc74c0a0ec8ecc12) twitch-dl: 3.0.0 -> 3.1.0
* [`40d581fd`](https://github.com/NixOS/nixpkgs/commit/40d581fdb17291b9927b90c05ade42ea5896d717) veryl: 0.15.0 -> 0.16.0
* [`764ac574`](https://github.com/NixOS/nixpkgs/commit/764ac574669f942e86f2af4036d65104bbcdbf8a) harper: 0.34.1 -> 0.36.0
* [`9f25810c`](https://github.com/NixOS/nixpkgs/commit/9f25810cd54623ce0ed6816118147efabb3185ff) f3d: Add openusd plugin
* [`d58e9363`](https://github.com/NixOS/nixpkgs/commit/d58e93638b928b508d57b398e7d0309ccebb9520) rs-tftpd: 0.3.3 -> 0.4.0
* [`b44be5fc`](https://github.com/NixOS/nixpkgs/commit/b44be5fc6f042c8974a91b2eb4133e28dbc375fb) rs-tftpd: add adamcstephens as maintainer
* [`e5474c6d`](https://github.com/NixOS/nixpkgs/commit/e5474c6db53b7aa027279a844e266819b443d37d) python3Packages.klayout: fix darwin build
* [`b7a478c8`](https://github.com/NixOS/nixpkgs/commit/b7a478c8eda2ccaa2cc64bd4f3f2a0f666cec71c) kubernetes: 1.33.0 -> 1.33.1
* [`59575cfc`](https://github.com/NixOS/nixpkgs/commit/59575cfcd007b9255a5cf6fd30627cff49126011) conky: 1.19.6 -> 1.22.1
* [`b3bdbf48`](https://github.com/NixOS/nixpkgs/commit/b3bdbf48063b7971a9a90ec77669b9cbd13a28e3) udevCheckHook: init
* [`9f301e8e`](https://github.com/NixOS/nixpkgs/commit/9f301e8e781561a25c955b7b6350289830f20cf6) kew: 3.2.0 -> 3.3.2
* [`02d7e13f`](https://github.com/NixOS/nixpkgs/commit/02d7e13fbd06ce0f4f63d282c8dd931c1b932643) libphonenumber: 9.0.3 -> 9.0.5
* [`53b3401d`](https://github.com/NixOS/nixpkgs/commit/53b3401d388a7f45e5ac707090d8eaa71679f924) ente-web: 1.0.4 -> 1.0.10
* [`58a92a25`](https://github.com/NixOS/nixpkgs/commit/58a92a258b332c18cb3bc83c9e087e547584f0e3) qt6Packages.qgpgme: mark broken on Darwin
* [`203e6267`](https://github.com/NixOS/nixpkgs/commit/203e62674242242dca4c1504f5cbc10d1edc904d) catppuccin-plymouth: fix formatting using nixpkgs-fmt and statix
* [`def8389c`](https://github.com/NixOS/nixpkgs/commit/def8389c97748118172e7d273fcba8c2e00c2178) catppuccin-plymouth: fix formatting using "nix fmt" as written in the CONTRIBUTING.md documentation
* [`db0033b6`](https://github.com/NixOS/nixpkgs/commit/db0033b6142aaf3dd0f3342112f199bbe7eed9d1) all-the-package-names: 2.0.2147 -> 2.0.2154
* [`aea3c8be`](https://github.com/NixOS/nixpkgs/commit/aea3c8be1f6b11702046cf0c002378b9cd245c2b) victoriametrics: 1.116.0 -> 1.117.1
* [`d9a74dfb`](https://github.com/NixOS/nixpkgs/commit/d9a74dfb6b3bf74d085a0fb41a434a61b71d5862) vault: 1.19.3 -> 1.19.4
* [`26088a9a`](https://github.com/NixOS/nixpkgs/commit/26088a9aa88b4f4f4f50d4a4f92a7f43168c8e80) vault-bin: 1.19.3 -> 1.19.4
* [`c0bef8d9`](https://github.com/NixOS/nixpkgs/commit/c0bef8d9e78be0e9b201f938fbdcb661a2ab3c42) museum: 1.0.4 -> 1.0.10
* [`a1699678`](https://github.com/NixOS/nixpkgs/commit/a169967875b3a307d961d5add49f8895a59372d1) ISSUE_TEMPLATES: update releases following 25.11's branch-off
* [`f2594884`](https://github.com/NixOS/nixpkgs/commit/f25948845aba15048f05d9516f94debcbc695d27) element-desktop: 1.11.99 -> 1.11.100
* [`c1ef8348`](https://github.com/NixOS/nixpkgs/commit/c1ef83481f55c21a750c406d1a7625928db40a50) element-web: 1.11.99 -> 1.11.100
* [`6890f690`](https://github.com/NixOS/nixpkgs/commit/6890f690522f963a365b2aaa0756d003b4015a51) reindeer: 2025.05.05.00 -> 2025.05.12.00
* [`17f39c80`](https://github.com/NixOS/nixpkgs/commit/17f39c80567d1179dc0b64f1de7aa335e05b6ff9) python3Packages.pybind11-stubgen: 2.5.3 -> 2.5.4
* [`37ddb080`](https://github.com/NixOS/nixpkgs/commit/37ddb080c9d48c2cf2f9d499089c518c0f9308c9) python3Packages.wyoming: 1.6.0 -> 1.6.1
* [`8a5a2771`](https://github.com/NixOS/nixpkgs/commit/8a5a277122b66a4f9853ec459372b5256cc3832c) rquickshare: clean up dependencies, don't use applyPatches
* [`a8b3c34d`](https://github.com/NixOS/nixpkgs/commit/a8b3c34d4e8a245ed4feb1247aa5616b22f89f4a) pnpm.fetchDeps: allow overriding the hash using `.override`
* [`96d61cc4`](https://github.com/NixOS/nixpkgs/commit/96d61cc488a360573c729e7539975c73bdd65f89) obs-studio-plugins.obs-3d-effect: 0.1.3 -> 0.1.4
* [`3bfe0a49`](https://github.com/NixOS/nixpkgs/commit/3bfe0a499ee44209ea2df5fce54d2d0ff2552305) veilid: 0.4.4 -> 0.4.6
* [`2ba1aa65`](https://github.com/NixOS/nixpkgs/commit/2ba1aa65c4114629fd0e5eba23eb9059566876ed) semantic-release: 24.2.3 -> 24.2.4
* [`84a65774`](https://github.com/NixOS/nixpkgs/commit/84a657749e6b87e0b4db3f31b82cc09d91802e28) netbird-ui: 0.43.3 -> 0.44.0
* [`6d4f1aa1`](https://github.com/NixOS/nixpkgs/commit/6d4f1aa1312e449463a0c7ad53a7bf8b031ed47a) rustdesk-flutter: 1.3.9 -> 1.4.0
* [`22f2e258`](https://github.com/NixOS/nixpkgs/commit/22f2e258af4786c8504c9b20f7047757dfc9a0ea) nixos/security: add landlock, yama, and bpf defaults
* [`727809f5`](https://github.com/NixOS/nixpkgs/commit/727809f534ff37bb5e4486084a7125b04a175373) nixos/k3s: get tests working again
* [`44d7b6dd`](https://github.com/NixOS/nixpkgs/commit/44d7b6dd7bab8ff7fc71da3ba91eb09e5d19d83f) k3s: use util-linuxMinimal
* [`4cf4acae`](https://github.com/NixOS/nixpkgs/commit/4cf4acae57e3be36f86d3f69b9a1e98e68793863) k3s: [nixos/nixpkgs⁠#405952](https://togithub.com/nixos/nixpkgs/issues/405952): fix mount regression
* [`e0810765`](https://github.com/NixOS/nixpkgs/commit/e081076523f05dc6269c3cb519125169fa7398d2) joplin-desktop: fix Joplin Backup plugin failing to creating archive
* [`8403be09`](https://github.com/NixOS/nixpkgs/commit/8403be09b2a30bbbb5b9ec5230f926482a06ebfa) kitty: 0.42.0->0.42.1
* [`dd543892`](https://github.com/NixOS/nixpkgs/commit/dd5438925296cb8940620a11661387bf64a3fff1) python313Packages.tendo: fix build with python 3.13
* [`c16a5fef`](https://github.com/NixOS/nixpkgs/commit/c16a5fefc62bdb18ca437b12b92557f81383abaf) python313Packages.supervisor: fix build with python 3.13
* [`31d520ee`](https://github.com/NixOS/nixpkgs/commit/31d520ee18a6ec3b95feac69d5d359bbe279361b) element-{desktop,web-unwrapped}: {fix,modernize} update script
* [`b0f8a1e4`](https://github.com/NixOS/nixpkgs/commit/b0f8a1e4874d79c6af7121e3b459abff4c482b80) wavebox: 10.135.21-2 -> 10.136.15-2
* [`6cd1df5e`](https://github.com/NixOS/nixpkgs/commit/6cd1df5e597925abd10f44da69b08cec65d0e153) pkgs/README: Document security expectations for new packages
* [`f9d66c36`](https://github.com/NixOS/nixpkgs/commit/f9d66c36aaf338217f325797578a52b28dd464f8) z3: 4.14.1 → 4.15.0, z3_4_14: drop, z3_4_15: init at 4.15.0
* [`ce802f15`](https://github.com/NixOS/nixpkgs/commit/ce802f152e61ff7244bb692009ceae719e879859) fractal: 11 -> 11.1
* [`fff70b51`](https://github.com/NixOS/nixpkgs/commit/fff70b51f18f7ec99fbc71a23c08b6210065d430) amp-cli: 0.0.1747195318-g6d7769 -> 0.0.1747483284-g8cf01d
* [`3de9866a`](https://github.com/NixOS/nixpkgs/commit/3de9866a865681e9bbf88eafdd242afd06c36b97) python3Packages.whisperx: disable import check for aarch64-linux
* [`5733e52c`](https://github.com/NixOS/nixpkgs/commit/5733e52cc3767bc9faeacbb579198b7d190f539f) marisa: 0.2.6 -> 0.2.7
* [`60cbd815`](https://github.com/NixOS/nixpkgs/commit/60cbd815539f8aa7b3d7f96ff41f8ee8d2f328e8) z3: add aliases for older versions
* [`1a776b09`](https://github.com/NixOS/nixpkgs/commit/1a776b0958708740f02de4e8e5aa0b8dc30fc8d7) podman-desktop: refine updateScript to bump electron and pnpm version
* [`32146f41`](https://github.com/NixOS/nixpkgs/commit/32146f41e4b2bee65e56060d6c6bc7c8e0caeb62) podman-desktop: bump electron and pnpm version
* [`3ae75c4b`](https://github.com/NixOS/nixpkgs/commit/3ae75c4bab39831a1829ac3aad53199f3e9037a8) containerd: 2.0.5 -> 2.1.0
* [`7ca585a2`](https://github.com/NixOS/nixpkgs/commit/7ca585a2b771ff25aed1fafcbddb3ce31c098ff2) meli: 0.8.11 -> 0.8.12
* [`d8935f58`](https://github.com/NixOS/nixpkgs/commit/d8935f58f505e7d094e564a2e585340dd3445c73) yakut: 0.13.0 -> 0.14.0
* [`b31bb444`](https://github.com/NixOS/nixpkgs/commit/b31bb4443652de548eb9a95a03be1a764a5271a0) directx-shader-compiler: Include libdxil.so and dxv
* [`bdb59d08`](https://github.com/NixOS/nixpkgs/commit/bdb59d089f8ba2c24b22a638e4ef3d401aafd9c5) python3Packages.bitarray: 3.3.0 -> 3.4.1
* [`df40819f`](https://github.com/NixOS/nixpkgs/commit/df40819f8618b5270922911bf0ac95633fa2dff9) elpa-packages: updated 2025-05-18 (from overlay)
* [`51b5d53e`](https://github.com/NixOS/nixpkgs/commit/51b5d53e29dcbe294a480c463d6b07365240d173) elpa-devel-packages: updated 2025-05-18 (from overlay)
* [`fd98a898`](https://github.com/NixOS/nixpkgs/commit/fd98a8980900c2dfa7fe9cb404a8fd7ea523ac53) melpa-packages: updated 2025-05-18 (from overlay)
* [`364209ce`](https://github.com/NixOS/nixpkgs/commit/364209ce240ed885f6667a3b74ddeb25934bdde5) nongnu-packages: updated 2025-05-18 (from overlay)
* [`106476b4`](https://github.com/NixOS/nixpkgs/commit/106476b4bee73a84758b0c8a866cade69d4209be) nongnu-devel-packages: updated 2025-05-18 (from overlay)
* [`89d1d931`](https://github.com/NixOS/nixpkgs/commit/89d1d931a90a147891755a1eea3191b113903f65) sydbox: 3.32.7 -> 3.34.0
* [`98691088`](https://github.com/NixOS/nixpkgs/commit/98691088c7db99163e684714c280889822b28632) msi-ec-kmods: 0-unstable-2024-11-04 -> 0-unstable-2025-05-17
* [`12ed83a6`](https://github.com/NixOS/nixpkgs/commit/12ed83a6ccfb5ef8ec8496682c91afeba6f21662) updatecli: 0.99.0 -> 0.100.0
* [`eea6cf30`](https://github.com/NixOS/nixpkgs/commit/eea6cf304007fa52212d9bac99228ba853dddc7b) proxypin: 1.1.8 -> 1.1.9
* [`9d5009de`](https://github.com/NixOS/nixpkgs/commit/9d5009deaead6bc50e9ba7d1f747eb1e7b1b3b7b) iosevka: 33.2.2 -> 33.2.3
* [`9b29a33e`](https://github.com/NixOS/nixpkgs/commit/9b29a33ecb8afd2852fa9e5678c01e44f89f2809) netcoredbg: 3.1.0-1031 -> 3.1.2-1054
* [`0ee528d2`](https://github.com/NixOS/nixpkgs/commit/0ee528d2cc689dfdb639688ebe3ca73721768276) gssdp_1_6: Unbreak on Darwin
* [`edd0dc61`](https://github.com/NixOS/nixpkgs/commit/edd0dc6111a9c3f27dd53475471cb9dad72bec67) gssdp_1_6: Use finalAttrs
* [`04431424`](https://github.com/NixOS/nixpkgs/commit/0443142472dc445dbfebede45be0e764d5f1208e) gupnp_1_6: Unbreak on Darwin
* [`96aca752`](https://github.com/NixOS/nixpkgs/commit/96aca7526abb7d1a6353d19fd18b3f8111f34ba4) gupnp_1_6: Use finalAttrs
* [`f2ee7c93`](https://github.com/NixOS/nixpkgs/commit/f2ee7c93b40d5592a2297c68f502320428060454) python312Packages.wandb: 0.19.10 -> 0.19.11
* [`0a714885`](https://github.com/NixOS/nixpkgs/commit/0a7148859b533621df3f07b583af8da65083950e) memray: cleanup, unskip working tests
* [`29fa2785`](https://github.com/NixOS/nixpkgs/commit/29fa27859a63799bee0af0a7c3226bb9627cd6df) python3Packages.tuf: fix failing tests on Darwin
* [`8252fe37`](https://github.com/NixOS/nixpkgs/commit/8252fe375a89ae9e9437b9d4599c092fb149c8e1) python312Packages.equinox: 0.12.1 -> 0.12.2
* [`5d336e7a`](https://github.com/NixOS/nixpkgs/commit/5d336e7a9e2ce446f8c69c3bc877184befa2ce98) apptainer: 1.4.0 -> 1.4.1
* [`d3e1f04c`](https://github.com/NixOS/nixpkgs/commit/d3e1f04cce1f6233930428fe529e103bc266a503) lima-bin: drop; alias to lima
* [`1bdb53fc`](https://github.com/NixOS/nixpkgs/commit/1bdb53fcf8737cc1968c20e87a7408aa9c4fa3c9) dependency-track: 4.12.7 -> 4.13.2
* [`e3002620`](https://github.com/NixOS/nixpkgs/commit/e3002620b903a67bf9ccb26e698215a6af86a663) jimtcl: unmark as broken on Darwin
* [`5de8edee`](https://github.com/NixOS/nixpkgs/commit/5de8edee04f3f00742a960c139328411a8913947) openocd: unmark as broken on Darwin
* [`68443d7d`](https://github.com/NixOS/nixpkgs/commit/68443d7da6c9458501a52363196814b467744b6a) tinygo: unmark as broken on Darwin
* [`d74f180f`](https://github.com/NixOS/nixpkgs/commit/d74f180f83c26a38b641f813ebba5bff6b36af41) maintainers: add jethair
* [`79927b4e`](https://github.com/NixOS/nixpkgs/commit/79927b4ec250465a7ad98692c79861eaba241935) libansilove: init at 1.4.2
* [`93cf1a9a`](https://github.com/NixOS/nixpkgs/commit/93cf1a9a62497013c87792038290a67e3ccb3a34) ansilove: init at 4.2.1
* [`d63f498c`](https://github.com/NixOS/nixpkgs/commit/d63f498cffc58c979417080d907ea967b0a08921) dput-ng: 1.42 -> 1.43
* [`99fddaec`](https://github.com/NixOS/nixpkgs/commit/99fddaec69fb493efc655b61f10a2533d967de55) lazyjournal: 0.7.3 -> 0.7.8
* [`8b3268ba`](https://github.com/NixOS/nixpkgs/commit/8b3268bae528fba2dd2ae41a14f1ac5653b20df2) wikiman: 2.13.2 -> 2.14.1
* [`00ec3977`](https://github.com/NixOS/nixpkgs/commit/00ec3977efb44f7bd009b7c123ee9ca88ae1d62b) dehydrated: 0.7.1 -> 0.7.2
* [`f63ba2b0`](https://github.com/NixOS/nixpkgs/commit/f63ba2b0b633b8f928054887544304fb630ad5d8) cotp: 1.9.4 -> 1.9.5
* [`14386224`](https://github.com/NixOS/nixpkgs/commit/14386224a137b5f02e04718dd2fde9df46c47508) pkgs/top-level/stage.nix: move most nixpkgs sets to variants
* [`7ff2f337`](https://github.com/NixOS/nixpkgs/commit/7ff2f337952632e9a6cea1cf0a363221f1d2a6e2) git-who: 0.7 -> 1.0
* [`cc08b3d8`](https://github.com/NixOS/nixpkgs/commit/cc08b3d8e56c2ad35add3681866507b748f509d6) hadolint-sarif: 0.7.0 -> 0.8.0
* [`9f1a6d1e`](https://github.com/NixOS/nixpkgs/commit/9f1a6d1e3db1a9f7be87b822bde7ed7e1640c669) uiua-unstable: fix updateScript
* [`ef3259d9`](https://github.com/NixOS/nixpkgs/commit/ef3259d9d31f3659e4f3fc3b254ae82c6f03cf95) lint-staged: 15.5.2 -> 16.0.0
* [`cf06bb3b`](https://github.com/NixOS/nixpkgs/commit/cf06bb3bd3febc894ca2bfe4716f43afa0e1979f) python3Packages.commitizen: 4.7.0 -> 4.7.1
* [`5da24a50`](https://github.com/NixOS/nixpkgs/commit/5da24a5050c71e76dc8c26f03187ee975faa1bd0) python3Packages.django-admin-sortable2: 2.2.6 -> 2.2.8
* [`ccd5688c`](https://github.com/NixOS/nixpkgs/commit/ccd5688c946fb85e7125a6384b38f863361215a8) lixPackageSets.{lix_2_92,lix_2_93,git}.lix: fix building on darwin
* [`73f36cc9`](https://github.com/NixOS/nixpkgs/commit/73f36cc9d2109f50403eeee5231ab111cd302fea) bento: 1.6.1 -> 1.7.1
* [`5c8040e4`](https://github.com/NixOS/nixpkgs/commit/5c8040e4431c65629e00948b99444fe51b2176f8) python3Packages.fastbencode: 0.3.1 -> 0.3.2
* [`d4a29cfd`](https://github.com/NixOS/nixpkgs/commit/d4a29cfde5c1aff546ad84e84c1fbcc280499ab8) sarif-fmt: 0.7.0 -> 0.8.0
* [`79f73266`](https://github.com/NixOS/nixpkgs/commit/79f7326693c3db9230273e5a7b8b0623226fbff4) heimdall-proxy: 0.16.1 -> 0.16.2
* [`299a895e`](https://github.com/NixOS/nixpkgs/commit/299a895e2ae2a478949c0b0b77de3e0f61935c04) gowebly: 3.0.2 -> 3.0.3
* [`80cab842`](https://github.com/NixOS/nixpkgs/commit/80cab842c4bd1eef1cf2273fa9a66ba57aa44db1) python3Packages.fastbencode: update disabled
* [`1f899da1`](https://github.com/NixOS/nixpkgs/commit/1f899da194ffb5f17bdde58256da2d51452b24b0) ergochat: 2.15.0 -> 2.16.0
* [`8dcd0339`](https://github.com/NixOS/nixpkgs/commit/8dcd0339f01722510a57f8d1d6374437669ae4b7) nwg-drawer: 0.6.5 -> 0.7.0
* [`21cdf6c8`](https://github.com/NixOS/nixpkgs/commit/21cdf6c82678ad82a1acd7035ab5133bfe1462ec) python312Packages.yfinance: 0.2.58 -> 0.2.61
* [`e0c66486`](https://github.com/NixOS/nixpkgs/commit/e0c6648695f581b61f66506c1a825d1456f29bb9) cinny-unwrapped: 4.6.0 -> 4.7.0
* [`0d0f642c`](https://github.com/NixOS/nixpkgs/commit/0d0f642cc5494b64ab1b8ca86dd8809c6d5da8f5) cinny-desktop: 4.6.0 -> 4.7.0
* [`51650dcf`](https://github.com/NixOS/nixpkgs/commit/51650dcf60688ff010b5b2dce6c1565e265bf190) ptyxis: 47.10 -> 48.3
* [`d4fd40cc`](https://github.com/NixOS/nixpkgs/commit/d4fd40cce41cf8ca11fec936c2d33f3d9413006c) cpuid: 20250419 -> 20250513
* [`556eca1e`](https://github.com/NixOS/nixpkgs/commit/556eca1e184a84e294b6cb27c8daf4eb72ba8fc4) shellcheck-sarif: 0.7.0 -> 0.8.0
* [`595c41ee`](https://github.com/NixOS/nixpkgs/commit/595c41eeaf227359e58bf02960f56a86713bebed) thunderbird-esr-bin-unwrapped: 128.10.0 -> 128.10.1
* [`e849ad02`](https://github.com/NixOS/nixpkgs/commit/e849ad02e0fc6945ffe56f5e63335d6db99a3ca5) bufisk: use finalAttrs
* [`83fccab4`](https://github.com/NixOS/nixpkgs/commit/83fccab40aec2e696e6b59842805d7711727a7bf) fluxcd-operator-mcp: init at 0.20.0
* [`10ff832c`](https://github.com/NixOS/nixpkgs/commit/10ff832c4fe36697cc8e36305afce55b3cf6f031) pgadmin4: fix build for sandbox=relaxed builds on darwin
* [`4f053b60`](https://github.com/NixOS/nixpkgs/commit/4f053b60ae265a038f950e8535b37c092a0e9b35) nixos/nix-gc: allow dates to be a list
* [`57d05a1c`](https://github.com/NixOS/nixpkgs/commit/57d05a1cbe4335d7634387484544210cd8daac1f) nixos/nix-optimise: allow dates to be a single line str
* [`8ae93090`](https://github.com/NixOS/nixpkgs/commit/8ae93090316c25d180d8d3399dde5ab551522a5e) release-notes: rework highlights section
* [`b8b9eaee`](https://github.com/NixOS/nixpkgs/commit/b8b9eaee9be9b0d087cc2a19f91490c1f6aa0fcb) python313Packages.grpc-google-iam-v1: refactor
* [`03d7e5e4`](https://github.com/NixOS/nixpkgs/commit/03d7e5e4b1f35d903d70dc83ac70c9073059c42d) nu_scripts: 0-unstable-2025-05-05 -> 0-unstable-2025-05-15
* [`0047d6e9`](https://github.com/NixOS/nixpkgs/commit/0047d6e995959dd00505c0c30bdcc0a485e92f52) akkoma-admin-fe: Fix build for x86_64-darwin
* [`a6b28e33`](https://github.com/NixOS/nixpkgs/commit/a6b28e33549a3803d856ac258f6500f98e280caa) ghunt: 2.1.0 -> 2.3.3
* [`c529a88f`](https://github.com/NixOS/nixpkgs/commit/c529a88fcce23f8114c9a28b16bee408e59fa0b0) vorbis-tools: remove patch applied upstream
* [`0912a536`](https://github.com/NixOS/nixpkgs/commit/0912a536623a3efadfa6d7a6408cceb9f0f4ba77) python3Packages.hyperscan: 0.7.9 -> 0.7.13
* [`ae1e5f6f`](https://github.com/NixOS/nixpkgs/commit/ae1e5f6f2d209ece31c9fcfa6aa92407534a87e3) auth0-cli: 1.12.0 -> 1.13.0
* [`8e7f1cde`](https://github.com/NixOS/nixpkgs/commit/8e7f1cdeea16479b8c72a717e9e718ecb10a5cdc) ggobi: drop
* [`e3c24c24`](https://github.com/NixOS/nixpkgs/commit/e3c24c24fe2eadbd05fefa65d4d984888589d50f) tpm2-tss: disable tcti-libtpms on darwin
* [`a0964927`](https://github.com/NixOS/nixpkgs/commit/a0964927c914e1fe37c6e35250349911c9102c0b) obs-studio-plugins.obs-vkcapture: 1.5.1 -> 1.5.2
* [`eaeae98d`](https://github.com/NixOS/nixpkgs/commit/eaeae98dd1e11e9b47efd472de5a2c2cad0f8c09) geminicommit: 0.2.7 -> 0.3.1
* [`a952bd4a`](https://github.com/NixOS/nixpkgs/commit/a952bd4a004fe1b7442d82e256f17f13806afc46) cargo-bazel: add libz as buildInput for darwin
* [`c1136468`](https://github.com/NixOS/nixpkgs/commit/c1136468968a31e20c3cbf09ed76ceee827d80d5) maintainers: add Rishabh5321
* [`6a013d51`](https://github.com/NixOS/nixpkgs/commit/6a013d516d6a19418c3e95677fc79f8ce86d8d01) bamtools: 2.5.2 -> 2.5.3
* [`e3019707`](https://github.com/NixOS/nixpkgs/commit/e3019707ce3e5462be3016556a477e536868bb0a) aliyun-cli: 3.0.273 -> 3.0.277
* [`fac15298`](https://github.com/NixOS/nixpkgs/commit/fac152987b4533b1a45fa28ec32564f5e208ccd9) gitrs: add libz on darwin
* [`edaf51cb`](https://github.com/NixOS/nixpkgs/commit/edaf51cb83e3bef31ba33ce7327dfc9ac7f48843) ci/eval: remove left-over stats.json
* [`4d171238`](https://github.com/NixOS/nixpkgs/commit/4d1712384cfffcc1fec8eae85e93133efa9cdc3f) yabai: 7.1.14 -> 7.1.15
* [`fcf4ffd4`](https://github.com/NixOS/nixpkgs/commit/fcf4ffd4cb15677e748fdf5902d58209a5ea356a) kubevpn: 2.7.5 -> 2.7.11
* [`01afe929`](https://github.com/NixOS/nixpkgs/commit/01afe9297fc7fbd1fcfb0b7758b6f83a9f183051) usacloud: 1.14.1 -> 1.15.0
* [`032c5e23`](https://github.com/NixOS/nixpkgs/commit/032c5e23c4b76a4a99eddb439da0ec6cdbb42894) reaper: 7.38 -> 7.39
* [`e7bc7a0e`](https://github.com/NixOS/nixpkgs/commit/e7bc7a0e4a3db07ba357deaf5583ee2b16c5263b) signal-desktop.webrtc: patch in absolute lib paths for dynamic loader
* [`43a98524`](https://github.com/NixOS/nixpkgs/commit/43a985240731a5244ac6283e3050f05a393195b4) signal-desktop.webrtc: execute install hooks
* [`12d60994`](https://github.com/NixOS/nixpkgs/commit/12d609947aa41443ecf4d869caafe5950e251038) renovate: 39.264.0 -> 40.14.4
* [`45743881`](https://github.com/NixOS/nixpkgs/commit/457438810ccc0875fdda2e99b233d80350ae3a28) maintainers: add thevar1able
* [`9f8aa837`](https://github.com/NixOS/nixpkgs/commit/9f8aa837879b7ab992de0d0645f73b0ab20665b7) sparkle: 1.6.2 -> 1.6.4
* [`6dbec0e8`](https://github.com/NixOS/nixpkgs/commit/6dbec0e85435c98ac19dc23b05e5e6f7d7e5e30e) clickhouse: 24.3.7.30 -> 25.3.3.42
* [`d17aba12`](https://github.com/NixOS/nixpkgs/commit/d17aba125e3a3d8bb04dddc08339ab1592e6a044) sing-box: 1.11.10 -> 1.11.11
* [`1d86f262`](https://github.com/NixOS/nixpkgs/commit/1d86f262ccee61f3e879429ac34a4ace86a77c44) librewolf-bin-unwrapped: 138.0.1-2 -> 138.0.3-1
* [`400b8c42`](https://github.com/NixOS/nixpkgs/commit/400b8c420cec2c5127163249d2e97177599f9199) bottles: update `remove-unsupported-warning.patch`
* [`bb8327b8`](https://github.com/NixOS/nixpkgs/commit/bb8327b825d9e11df96c95512c43ef9228aacb93) bottles: add info to disable unsupported popup
* [`159b9aeb`](https://github.com/NixOS/nixpkgs/commit/159b9aeb098495d9d2d364a4fcc61e7f27725736) quark-engine: 25.4.1 -> 25.5.1
* [`f6b2b5ea`](https://github.com/NixOS/nixpkgs/commit/f6b2b5ea2ada993a7ee6ac63e1df8db55844179e) luarocks-packages-updater: run nix fmt automatically
* [`850c00e1`](https://github.com/NixOS/nixpkgs/commit/850c00e115add1bc7c04f0a0aa6a0fb63e71e463) thunderbird-esr-unwrapped: 128.10.0 -> 128.10.1
* [`47b01e7c`](https://github.com/NixOS/nixpkgs/commit/47b01e7cbdfe7f58f149e6e3a5222efb9f5fb534) thunderbird-latest-unwrapped: 138.0 -> 138.0.1
* [`4f6f1dfe`](https://github.com/NixOS/nixpkgs/commit/4f6f1dfeedbec7cd15626f424499da06f6651f22) python3Packages.makefun: 1.15.6 -> 1.16.0
* [`0ca3c6bd`](https://github.com/NixOS/nixpkgs/commit/0ca3c6bd5541e6cf81d25bc08d9d858bf4084b19) mpls: 0.14.0 -> 0.15.0
* [`83a59bb3`](https://github.com/NixOS/nixpkgs/commit/83a59bb3f63f023a0ad7436460944c0fb3f0b5df) rofi-unwrapped: 1.7.8 -> 1.7.9
* [`9909624b`](https://github.com/NixOS/nixpkgs/commit/9909624ba565d28b263463072ce6b37cb492a854) librewolf-unwrapped: 138.0.1-2 -> 138.0.4-1
* [`67a13f12`](https://github.com/NixOS/nixpkgs/commit/67a13f12b091b0f340862c6dd68de9123a370561) libmikmod: enable parallel building
* [`6b057162`](https://github.com/NixOS/nixpkgs/commit/6b057162fb4fd63eb170629736cfd1f5f4aa7829) ome_zarr: 0.10.3 -> 0.11.1
* [`0d1911c3`](https://github.com/NixOS/nixpkgs/commit/0d1911c3c036f7b612a4923e9fda172cef3831c4) burpsuite: 2025.2.3 -> 2025.4.2
* [`19833fda`](https://github.com/NixOS/nixpkgs/commit/19833fda6efd3d974b18a10b64a5c89ae601bfd9) lms: 3.66.0 -> 3.66.1
* [`6f2e7ccf`](https://github.com/NixOS/nixpkgs/commit/6f2e7ccfcedb24952e150a766475812c45500284) python3Packages.gspread: 6.2.0 -> 6.2.1
* [`b3ad8259`](https://github.com/NixOS/nixpkgs/commit/b3ad82595583b1a4d1f7536551bf8338ba2ae513) python313Packages.django_5_2: init at 5.2.1
* [`22d51e08`](https://github.com/NixOS/nixpkgs/commit/22d51e08cf1fb1af0c01b1a40edc5a6b7330a91b) nixos/tests/systemd-journal: Fix failing tests
* [`e434130d`](https://github.com/NixOS/nixpkgs/commit/e434130d0baea01c94270dd2589a2bd811c42116) nixos/systemd: unconditional systemd-journald-audit.socket
* [`48519415`](https://github.com/NixOS/nixpkgs/commit/48519415ce26595fcb84041628050089f5a45a93) cpm-cmake: 0.41.0 -> 0.42.0
* [`33f4db9e`](https://github.com/NixOS/nixpkgs/commit/33f4db9e6bb6a2b9216f65ed5c3ee00f20088299) circleci-cli: 0.1.31632 -> 0.1.31792
* [`ec608a62`](https://github.com/NixOS/nixpkgs/commit/ec608a6224aedd9f8f4a216db8bd4e30815ec703) cnquery: 11.53.2 -> 11.54.0
* [`d18a0c4b`](https://github.com/NixOS/nixpkgs/commit/d18a0c4b3616e87f2941f2b3ee27ff392e17fad8) ruffle: refactor to correct dependencies
* [`c1d1a9dc`](https://github.com/NixOS/nixpkgs/commit/c1d1a9dc273b62c9906d5d5b5165bad32e6f0aee) matrix-synapse-plugins.synapse-http-antispam: 0.3.0 -> 0.4.0
* [`8a9cd899`](https://github.com/NixOS/nixpkgs/commit/8a9cd899ac58cd371b431fbe3839a1cee1d201e2) nixos/tests/oncall: Fix LDAP mapping
* [`be5c87fa`](https://github.com/NixOS/nixpkgs/commit/be5c87fa1f4aa8f73a3904498866f2a871c7b7eb) python312Packages.spacy-curated-transformers: 0.3.0 -> 2.1.2
* [`8600e6b3`](https://github.com/NixOS/nixpkgs/commit/8600e6b358f42530a0fc0ef25e5a1b788d049d05) cubeb: add myself to maintainers
* [`d33be52b`](https://github.com/NixOS/nixpkgs/commit/d33be52bb886488f23c8a6b5c3b81a8383b5bfce) cubeb: make derivation customizable
* [`0d060710`](https://github.com/NixOS/nixpkgs/commit/0d060710c14275704ab48c6ed1ab68236a47184f) python3Packages.sectxt: 0.9.6 -> 0.9.7
* [`b94931a3`](https://github.com/NixOS/nixpkgs/commit/b94931a3fb99ca9392344af8f82fc8d708f0bdc3) maintainers: remove mtreca from maintainers
* [`2f490813`](https://github.com/NixOS/nixpkgs/commit/2f490813880916c7e29f7af4901f9b7db7b20677) python3Packages.std-uritemplate: 2.0.3 -> 2.0.5
* [`aa4a5222`](https://github.com/NixOS/nixpkgs/commit/aa4a522201f6b177c242cf4ec96026b4d9006175) goverter: 1.8.2 -> 1.8.3
* [`dbd91846`](https://github.com/NixOS/nixpkgs/commit/dbd91846484641da4c3ff51de1aa50fcdf19a164) python3Packages.inform: 1.33 -> 1.34
* [`2c83acce`](https://github.com/NixOS/nixpkgs/commit/2c83accecfa81f56e9afa9e815241711d8ea4e6a) mkbrr: init at 1.11.0
* [`6b04d873`](https://github.com/NixOS/nixpkgs/commit/6b04d873a5478a77a0e6d97aa1df14fce8a457b8) portfolio: 0.76.2 -> 0.76.3
* [`f11ff7b9`](https://github.com/NixOS/nixpkgs/commit/f11ff7b9f16464bbe207ad2008e339b0b867fdd7) python312Packages.awkward-cpp: 45 -> 46
* [`31788981`](https://github.com/NixOS/nixpkgs/commit/31788981b4ec8a7f8bf3f3223f10d6f5d9cc9720) python312Packages.awkward: 2.8.2 -> 2.8.3
* [`4a70e954`](https://github.com/NixOS/nixpkgs/commit/4a70e9546ee0899a26d62f7c8f18592efa3c9037) dependabot-cli: 1.63.0 -> 1.64.0
* [`74978da3`](https://github.com/NixOS/nixpkgs/commit/74978da3b6d91ae6f03aea7480dcb8d61f4ca760) python312Packages.uproot: 5.6.1 -> 5.6.2
* [`006b8bc5`](https://github.com/NixOS/nixpkgs/commit/006b8bc52ca2218f4dacebb8e281acc13dde15e3) bottles-unwrapped: add `gamemode` to `propagatedBuildInputs`
* [`aa50c857`](https://github.com/NixOS/nixpkgs/commit/aa50c85761159b7aaaeb1be64a9177fa594f3cdd) teleport: use finalAttrs pattern
* [`f45bf7d6`](https://github.com/NixOS/nixpkgs/commit/f45bf7d6a61b54df4980467a3812aa736c7c1137) teleport: remove with lib
* [`242387e5`](https://github.com/NixOS/nixpkgs/commit/242387e5def5b334958804b1b9114a2ac0674f7b) intentrace: 0.9.7 -> 0.9.8
* [`68861dcf`](https://github.com/NixOS/nixpkgs/commit/68861dcf6039666560d970a8acf4010c126465cc) python3Packages.django-axes: 7.1.0 -> 8.0.0
* [`0c1b5093`](https://github.com/NixOS/nixpkgs/commit/0c1b5093126b2d6a51b82bc2ccc0c9aa3ede8312) flashinfer: init at 0.2.5
* [`36b43931`](https://github.com/NixOS/nixpkgs/commit/36b43931e38c0210a3acc8cfdd6ce92d640ab442) phpExtensions.opentelemetry: 1.1.2 -> 1.1.3
* [`9b14f098`](https://github.com/NixOS/nixpkgs/commit/9b14f098b29e994c2dc4d4892b3d07d43599064e) upgrade-assistant: 0.5.1073 -> 0.5.1084
* [`50266b63`](https://github.com/NixOS/nixpkgs/commit/50266b63d463e4593a66dd09f050ddee85feef70) vacuum-go: 0.16.8 -> 0.16.10
* [`a01b51d0`](https://github.com/NixOS/nixpkgs/commit/a01b51d00b941921566416f85b5d7d789255fd71) teleport: move to by-name
* [`e034c55e`](https://github.com/NixOS/nixpkgs/commit/e034c55e6b294125412e133ff29cf7391f800291) treefmt
* [`e0a0ea50`](https://github.com/NixOS/nixpkgs/commit/e0a0ea50bb3e8a119ab470add31107fcaa809e4a) double-entry-generator: 2.9.0 -> 2.10.1
* [`d7d9f000`](https://github.com/NixOS/nixpkgs/commit/d7d9f0008fe9e20a42934287ccb795cbd4674246) dprint: 0.49.1 -> 0.50.0
* [`7109b8ed`](https://github.com/NixOS/nixpkgs/commit/7109b8ed97793061e462f1e573d3835ef00dd2d3) python3Packages.pyngrok: 7.2.7 -> 7.2.8
* [`64507151`](https://github.com/NixOS/nixpkgs/commit/645071512c8feced472a34bc3e89fd3d4d45f69e) vscode-extensions.denoland.vscode-deno: 3.44.1 -> 3.44.2
* [`f8b64359`](https://github.com/NixOS/nixpkgs/commit/f8b64359d97073fe84ea8bd5391954861f4055a1) sqldef: 1.0.6 -> 1.0.7
* [`95d37034`](https://github.com/NixOS/nixpkgs/commit/95d37034c69bc20c49aefadd89e8bd1a030b380b) dprint-plugins: disable automatic config discovery
* [`c6c5f559`](https://github.com/NixOS/nixpkgs/commit/c6c5f559acdad0a30abb97bc1e03f074bd5d4344) phpExtensions.xdebug: 3.4.2 -> 3.4.3
* [`26b6177f`](https://github.com/NixOS/nixpkgs/commit/26b6177f6fa08e6a0acbbe0045dfab00ed237bda) dprint: prefer finalAttrs
* [`7f6c746f`](https://github.com/NixOS/nixpkgs/commit/7f6c746f45a8dc0284189b6ac18c11be8dd16404) dprint: remove unintended bin/test-process-plugin
* [`36e296cb`](https://github.com/NixOS/nixpkgs/commit/36e296cb2787950a0c4e92720055411b6e20f61f) wait4x: 3.3.0 -> 3.3.1
* [`4658d216`](https://github.com/NixOS/nixpkgs/commit/4658d216f313d50682fb088527e864b7109958ad) hydralauncher: 3.4.7 -> 3.5.1
* [`f14efb6f`](https://github.com/NixOS/nixpkgs/commit/f14efb6fa211d4a8773534ab7ae3e84e723685cd) nixos/gerrit: Add Felix Singer as maintainer
* [`f1233a18`](https://github.com/NixOS/nixpkgs/commit/f1233a18eb124426d666efdba1894b30421235ff) boxflat: 1.30.0 -> 1.30.1
* [`a5fceb3f`](https://github.com/NixOS/nixpkgs/commit/a5fceb3f831c77cab064201076ab022328c56df0) librewolf-bin-unwrapped: 138.0.3-1 -> 138.0.4-1
* [`cd986083`](https://github.com/NixOS/nixpkgs/commit/cd9860831e9984f2785b4b8919efb433b0804670) luaPackages: update on 2025-05-18
* [`b08dedf4`](https://github.com/NixOS/nixpkgs/commit/b08dedf402e367bdfa5e46e1c0a069befaa3ef62) sumo: 1.22.0 -> 1.23.1
* [`89d9c7fd`](https://github.com/NixOS/nixpkgs/commit/89d9c7fd2e9d63bd432692906948729790fe0247) ledger-live-desktop: 2.111.0 -> 2.113.0
* [`8571cc18`](https://github.com/NixOS/nixpkgs/commit/8571cc18d9402e86ce420b66ce0fa518da8179ec) stdenv.mkDerivation: correct requiredSystemFeatures gccarch condition
* [`2ab38670`](https://github.com/NixOS/nixpkgs/commit/2ab386706e5bde733d7680c6af7a1fb86eb3d8ef) terraform-providers.dns: 3.4.2 -> 3.4.3
* [`d1a6afcb`](https://github.com/NixOS/nixpkgs/commit/d1a6afcbeffaa0140e5134fdba879e1086c4ec9a) terraform-providers.oci: 6.35.0 -> 7.0.0
* [`3c21915d`](https://github.com/NixOS/nixpkgs/commit/3c21915d2278387234be0ceae3b7ac0dd348acd9) terraform-providers.aiven: 4.39.0 -> 4.40.0
* [`34b2226f`](https://github.com/NixOS/nixpkgs/commit/34b2226fcb5287a7bfb30ee9ed52cadf5f42a6a4) terraform-providers.migadu: 2025.4.10 -> 2025.5.15
* [`843fa7d2`](https://github.com/NixOS/nixpkgs/commit/843fa7d2cbdc9d00c544bbd7d384568b62ed37c3) terraform-providers.opentelekomcloud: 1.36.37 -> 1.36.38
* [`10b8ac74`](https://github.com/NixOS/nixpkgs/commit/10b8ac747b47359253535c5278a7e9a9bb21b6ef) terraform-providers.datadog: 3.61.0 -> 3.62.0
* [`5e71ed6b`](https://github.com/NixOS/nixpkgs/commit/5e71ed6b2f4e2b5cf4fd9cd79e826b46982cfdc7) terraform-providers.signalfx: 9.13.0 -> 9.13.2
* [`6d84d841`](https://github.com/NixOS/nixpkgs/commit/6d84d841aa51cc3e40c7155bd26c09502a58c5e2) terraform-providers.rundeck: 0.5.0 -> 0.5.1
* [`e08c9ece`](https://github.com/NixOS/nixpkgs/commit/e08c9ece91b697ccc089810051d88b54e6f84b34) terraform-providers.talos: 0.8.0 -> 0.8.1
* [`0af56790`](https://github.com/NixOS/nixpkgs/commit/0af56790bbb9c45fb86554bb153710fb2e25de17) terraform-providers.linode: 2.38.0 -> 2.39.0
* [`0dc05f0b`](https://github.com/NixOS/nixpkgs/commit/0dc05f0bdbed4a68eb3fe6813953dcfce19be235) hifile: 0.9.10.3 -> 0.9.10.4
* [`43ce4eae`](https://github.com/NixOS/nixpkgs/commit/43ce4eae1b653c2b1a984a417d82e87174c38f68) treewide: rm empty inherit
* [`64a9d622`](https://github.com/NixOS/nixpkgs/commit/64a9d622688df901d2835803139b8fd4ee429d76) python3Packages.ufomerge: 1.9.1 -> 1.9.2
* [`65022b03`](https://github.com/NixOS/nixpkgs/commit/65022b03cbeaf6357c7673436c1646206031287b) python3Packages.wadler-lindig: 0.1.5 -> 0.1.6
* [`b77e4769`](https://github.com/NixOS/nixpkgs/commit/b77e476990add093466b7dcd5e5534e1968c5334) bigloo: 4.5b → 4.6a
* [`95077170`](https://github.com/NixOS/nixpkgs/commit/950771707f1862dd46612964688fcd9af624b466) python3Packages.growattserver: 1.7.0 -> 1.7.1
* [`a1110caf`](https://github.com/NixOS/nixpkgs/commit/a1110cafc64b0f54cdc31cb6b6abe6c835ba1c58) qownnotes: 25.5.3 -> 25.5.8
* [`641789db`](https://github.com/NixOS/nixpkgs/commit/641789dbc5c102a90c1646818cda5b5682ff66b5) python3Packages.pyathena: 3.13.0 -> 3.14.0
* [`5dd466e8`](https://github.com/NixOS/nixpkgs/commit/5dd466e8d0cdb48e00a67f5a44ea0e99c9f82eca) git-bug: 0.9.0 -> 0.10.1
* [`09c6d4de`](https://github.com/NixOS/nixpkgs/commit/09c6d4de82a83bd70ea3d2387b39747192626737) lib60870: 2.3.4 -> 2.3.5
* [`e3b9ba1a`](https://github.com/NixOS/nixpkgs/commit/e3b9ba1a7bc5bfa6a66317a3d2793d557c5fccc4) home-assistant-custom-lovelace-modules.universal-remote-card: 4.5.0 -> 4.5.1
* [`b46869e2`](https://github.com/NixOS/nixpkgs/commit/b46869e2b68bb776aec96087e0149c92e88ed9c1) clojure: fix and enable strictDeps
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
