### PR TITLE
niv chrisbarrett-nursery: update b4322641 -> d1425590

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "chrisbarrett",
         "repo": "nursery",
-        "rev": "b4322641ff729e04583ee5478d5def742d2127ab",
-        "sha256": "1z9pv3mymdy8py4nbki15m4x7mdflrdlb8bmn8g1wz44d26lcjr5",
+        "rev": "d142559096b3e3ee288d439c59fa6a30abe1b11f",
+        "sha256": "08s9g7vbq8mvqkrmywx78zwsxxazm8d6lwns6k2ccpmyg2bdysm0",
         "type": "tarball",
-        "url": "https://github.com/chrisbarrett/nursery/archive/b4322641ff729e04583ee5478d5def742d2127ab.tar.gz",
+        "url": "https://github.com/chrisbarrett/nursery/archive/d142559096b3e3ee288d439c59fa6a30abe1b11f.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "cirrus": {


### PR DESCRIPTION
## Changelog for chrisbarrett-nursery:
Branch: main
Commits: [chrisbarrett/nursery@b4322641...d1425590](https://github.com/chrisbarrett/nursery/compare/b4322641ff729e04583ee5478d5def742d2127ab...d142559096b3e3ee288d439c59fa6a30abe1b11f)

* [`12cabfa7`](https://github.com/chrisbarrett/nursery/commit/12cabfa7064988f5bca88bcbafbca6513dbb9699) Indent dblock items to same column as the block itself
* [`13bedff0`](https://github.com/chrisbarrett/nursery/commit/13bedff0ffc55155b320f46f1276fea65e32d22a) Teach org-roam-review actions to work on a selection of nodes
* [`f6ea0a49`](https://github.com/chrisbarrett/nursery/commit/f6ea0a494fd3757dc22112e0d406af347dee402a) Support dblocks in files that aren't roam nodes
* [`ac76a48e`](https://github.com/chrisbarrett/nursery/commit/ac76a48ee0ee471ad4d1f4a37101126d9e76ee73) Inhibit save hooks while saving WIP extracted buffer
* [`b924a5fc`](https://github.com/chrisbarrett/nursery/commit/b924a5fc42f35a562a645262dcec847351178f2b) Fix checkdoc error
* [`e92c0eb1`](https://github.com/chrisbarrett/nursery/commit/e92c0eb1eeb2c74427e1df1bb91a548956b7979f) Offer option to update dblocks silently
* [`c2ab2288`](https://github.com/chrisbarrett/nursery/commit/c2ab228845f262474140c34355af44d252731167) Don't kill buffer-under-review until *after* hooks are run
* [`e092f608`](https://github.com/chrisbarrett/nursery/commit/e092f60878f8dfb5fd2e7bcf4a6b047b5f6e4671) Replace custom buffer display function with direct display-buffer calls
* [`9429aa6c`](https://github.com/chrisbarrett/nursery/commit/9429aa6c76e54201f7c65dce76fe5bb026ccea3f) Ensure modifications to the review buffers occur with buffer selected
* [`cccb4af6`](https://github.com/chrisbarrett/nursery/commit/cccb4af688715c3bb29814e7dd6477c82f615b38) Hoist run-hook
* [`8c438886`](https://github.com/chrisbarrett/nursery/commit/8c438886d89dff74404efd5bdeb1685f2c9801a8) Make node heading formatter a custom var
* [`0cb476ad`](https://github.com/chrisbarrett/nursery/commit/0cb476ad17e001c60cc51b95c5644168f80a08f9) Change org-roam-rewrite--edit-backlinks to take nodes as parameters
* [`a591bd06`](https://github.com/chrisbarrett/nursery/commit/a591bd061382532d9c58695d1ba5710c1de11ea7) Make plisty validator fns return input
* [`f7bbd4de`](https://github.com/chrisbarrett/nursery/commit/f7bbd4dee5bad4645cdabdffb4e7e9a5e269b49e) Spike: preserve customised node titles when renaming
* [`84ea6670`](https://github.com/chrisbarrett/nursery/commit/84ea6670313e96fb97d3602fb8f056aa628c4f56) Fix attempt to operate on possibly non-existent review buffer
* [`eadad0aa`](https://github.com/chrisbarrett/nursery/commit/eadad0aa6695af204c3db9652f7831a6a6626a6e) Add command to indicate a reviewed node was forgotten
* [`97634892`](https://github.com/chrisbarrett/nursery/commit/97634892614da3e83e65f1f12e3ec2c8bfa407d0) Add support for SRS 'memorisation' nodes that are not evergreens
* [`9e45557d`](https://github.com/chrisbarrett/nursery/commit/9e45557d45d00d1243a4389dbcbcfd1fbca0689a) Rename internal function
* [`0ca3dfb1`](https://github.com/chrisbarrett/nursery/commit/0ca3dfb146527f8e2359ddcd28181caf8a36efc4) Ignore spurious error when cleaning up tags
* [`71b9e6f4`](https://github.com/chrisbarrett/nursery/commit/71b9e6f47d5e9eafc779f08c2c340a617d18aea1) Compute slipbox correctly during capture process
* [`a428d1b4`](https://github.com/chrisbarrett/nursery/commit/a428d1b40facd66346a5f70f1d2ba5d25f3bdc73) Increase OK score to 4
* [`832cd36f`](https://github.com/chrisbarrett/nursery/commit/832cd36fe0a68e984f9c6b0b43b55dd2057389a7) Fix reference to possibly nil org-roam-node
* [`ed35d99c`](https://github.com/chrisbarrett/nursery/commit/ed35d99c600b70f8698a514248cbfbfc7ef21fa3) Add some more hooks so I can trigger a git commit on node rename
* [`3310c444`](https://github.com/chrisbarrett/nursery/commit/3310c444cffe78ad425e4d75594c434d7f8a8a8b) Teach some operations to avoid mutating buffer during org-capture
* [`0ac44d70`](https://github.com/chrisbarrett/nursery/commit/0ac44d70a5f62a36645b001bd0901a5d98be9639) Remove use of obsolete function
* [`a5b69ac3`](https://github.com/chrisbarrett/nursery/commit/a5b69ac3f41cd3930f8912b353762f44c0392daa) :lipstick: Docstring
* [`8301db14`](https://github.com/chrisbarrett/nursery/commit/8301db1405dc7a5f57f8c2af95195890afe6cca2) Automatically refile nodes when marking as memorise
* [`768b4c16`](https://github.com/chrisbarrett/nursery/commit/768b4c168f7c02c682268dd86204578f017b3ab1) changes from walrus.local on Tue Jul 4 07:06:20 NZST 2023
* [`6eeacc9d`](https://github.com/chrisbarrett/nursery/commit/6eeacc9d2ab2c78f0bbf0c0d36d6821aaaf5fe23) Exclude backlinks from nodes in same file by default
* [`0fe751a9`](https://github.com/chrisbarrett/nursery/commit/0fe751a9434b32757f42890eae360e703f17a5a4) Avoid autoloading org-roam-node-slipbox method directly
* [`63b30767`](https://github.com/chrisbarrett/nursery/commit/63b307679a8bd4bd25dcd0a2a581f0233062cd32) Use some more emacs built-ins
* [`16e29601`](https://github.com/chrisbarrett/nursery/commit/16e296010fa1a7202aeb98869fb9a8af4f7ec5e8) Move deps into a pkg file
* [`0a6634df`](https://github.com/chrisbarrett/nursery/commit/0a6634df274c84291a35f92a2cc01ea38b922b07) Add autoload directives for org-format
* [`421a3323`](https://github.com/chrisbarrett/nursery/commit/421a33237386cefc089d34c1d009767a1d849c53) Fix org-format so that it works for non-file buffers
* [`b7f6d683`](https://github.com/chrisbarrett/nursery/commit/b7f6d6839aadb0c0864ccce84c92c991f4721cb0) Add bdd-ert
* [`45c4052b`](https://github.com/chrisbarrett/nursery/commit/45c4052b0a79c3f9aedb69159399923a95fff583) Require ert on load
* [`8a0d3974`](https://github.com/chrisbarrett/nursery/commit/8a0d3974598c42e2b09a7d8a670c20195d059fa1) :lipstick: Indentation
* [`5cf0a462`](https://github.com/chrisbarrett/nursery/commit/5cf0a462cd3cfc1410fe11710d947f4ff042cc5e) Fix attempts to access org-element-cache in non-org buffers
* [`00a169c7`](https://github.com/chrisbarrett/nursery/commit/00a169c75b934a2eb42ea8620e8eebf34577d4ca) Suppress spurious warnings from org-element
* [`5ff1237c`](https://github.com/chrisbarrett/nursery/commit/5ff1237cca51ced91a09cbbb4c97133a4167d4b2) Fix file name expansion when refiling slipboxes
* [`d1425590`](https://github.com/chrisbarrett/nursery/commit/d142559096b3e3ee288d439c59fa6a30abe1b11f) Extract function to fix breakage
