### PR TITLE
niv home-manager: update 45c29856 -> d23d20f5

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -77,10 +77,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "45c2985644b60ab64de2a2d93a4d132ecb87cf66",
-        "sha256": "0zksadj7hs2z1ij8hfskpi995lfs6b5p2m9gnvf5y6ddfgzvi6hm",
+        "rev": "d23d20f55d49d8818ac1f1b2783671e8a6725022",
+        "sha256": "1h32x8cyhjnz8jhnijs2xh98xmg1q2rrl9gmlj1l3sd8bjr9v929",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/45c2985644b60ab64de2a2d93a4d132ecb87cf66.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/d23d20f55d49d8818ac1f1b2783671e8a6725022.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@45c29856...d23d20f5](https://github.com/nix-community/home-manager/compare/45c2985644b60ab64de2a2d93a4d132ecb87cf66...d23d20f55d49d8818ac1f1b2783671e8a6725022)

* [`382b34f6`](https://github.com/nix-community/home-manager/commit/382b34f6569262e92b0e947ca5c49354c61b7f8c) services.home-manager.autoExpire: wrap systemd configuration within a isLinux condition
* [`04ebd2c4`](https://github.com/nix-community/home-manager/commit/04ebd2c4224ad6a78385bbc30f06dd89f0aa843b) services.home-manager.autoExpire: extract cleanup script to new variable
* [`20974416`](https://github.com/nix-community/home-manager/commit/20974416338898f0725a87832e4cd9bd82cbdaad) services.home-manager.autoExpire: add support for darwin
* [`65d2282f`](https://github.com/nix-community/home-manager/commit/65d2282ff6cf560f54997013bd1e575fbd0a7ebf) fontconfig: Fix missing default fontconfig files ([nix-community/home-manager⁠#7045](https://togithub.com/nix-community/home-manager/issues/7045))
* [`d3f5d870`](https://github.com/nix-community/home-manager/commit/d3f5d870e3f33f69fa6c0f9bcc44f8803a30e38e) home-manager: add force option for gtk-2 config ([nix-community/home-manager⁠#7073](https://togithub.com/nix-community/home-manager/issues/7073))
* [`559f6d36`](https://github.com/nix-community/home-manager/commit/559f6d36b32dd2180ebac40c522dd36290430fc5) news: add some more missing news items ([nix-community/home-manager⁠#7097](https://togithub.com/nix-community/home-manager/issues/7097))
* [`3f591550`](https://github.com/nix-community/home-manager/commit/3f591550a99fe5a2a57927ccab15dedb4210e53e) formatter: remove script, add treefmt.toml + keep-sorted ([nix-community/home-manager⁠#7056](https://togithub.com/nix-community/home-manager/issues/7056))
* [`29dda415`](https://github.com/nix-community/home-manager/commit/29dda415f5b2178278283856c6f9f7b48a2a4353) qutebrowser: add support for per domain settings ([nix-community/home-manager⁠#7078](https://togithub.com/nix-community/home-manager/issues/7078))
* [`2468b2d3`](https://github.com/nix-community/home-manager/commit/2468b2d35512d093aeb04972a1d8c20a0735793f) files: show colliding files at bottom in checkLinkTargets ([nix-community/home-manager⁠#5495](https://togithub.com/nix-community/home-manager/issues/5495))
* [`6c2eb1e2`](https://github.com/nix-community/home-manager/commit/6c2eb1e24cd0e76d88bdd633ef4c50d6286586e0) flake.lock: Update ([nix-community/home-manager⁠#7101](https://togithub.com/nix-community/home-manager/issues/7101))
* [`a69ebd97`](https://github.com/nix-community/home-manager/commit/a69ebd97025969679de9f930958accbe39b4c705) direnv: Fix `default` syntax for nushell integration ([nix-community/home-manager⁠#7081](https://togithub.com/nix-community/home-manager/issues/7081))
* [`f9186c64`](https://github.com/nix-community/home-manager/commit/f9186c64fcc6ee5f0114547acf9e814c806a640b) Revert "fontconfig: Fix missing default fontconfig files ([nix-community/home-manager⁠#7045](https://togithub.com/nix-community/home-manager/issues/7045))" ([nix-community/home-manager⁠#7103](https://togithub.com/nix-community/home-manager/issues/7103))
* [`a8685705`](https://github.com/nix-community/home-manager/commit/a868570581f0dbdef7e33c8c9bb34b735dfcbacf) news: fix timestamp ([nix-community/home-manager⁠#7109](https://togithub.com/nix-community/home-manager/issues/7109))
* [`74192507`](https://github.com/nix-community/home-manager/commit/7419250703fd5eb50e99bdfb07a86671939103ea) treewide: convert package options to use mkPackageOption ([nix-community/home-manager⁠#7116](https://togithub.com/nix-community/home-manager/issues/7116))
* [`8fc1e46a`](https://github.com/nix-community/home-manager/commit/8fc1e46ab6d5daac4563c2a3684d68cc0106f458) github: remove Sumner as automatic assignee on issues ([nix-community/home-manager⁠#7122](https://togithub.com/nix-community/home-manager/issues/7122))
* [`cf9ff6d9`](https://github.com/nix-community/home-manager/commit/cf9ff6d9930f74dd949ff2fde953470ecde37749) wayvnc: init ([nix-community/home-manager⁠#7123](https://togithub.com/nix-community/home-manager/issues/7123))
* [`c3d48a17`](https://github.com/nix-community/home-manager/commit/c3d48a17aad6778348abb1c4109add90cc42107c) obsidian: add module ([nix-community/home-manager⁠#6487](https://togithub.com/nix-community/home-manager/issues/6487))
* [`5dc3bc33`](https://github.com/nix-community/home-manager/commit/5dc3bc336851e979c95eb18d2498698a49d2a178) sketchybar: add module
* [`e4b0102f`](https://github.com/nix-community/home-manager/commit/e4b0102f697f97af8f4177ba9552995b0bf70b49) sketchybar: use finalpackage wrapper
* [`abe66194`](https://github.com/nix-community/home-manager/commit/abe66194b93701323ea321a618c969c9050046dc) lib/types: add sourceFileOrLines
* [`c096c39a`](https://github.com/nix-community/home-manager/commit/c096c39afc2d09341732681890780a5b0b9537b0) sketchybar: config sourceFileOrLines
* [`c1e67103`](https://github.com/nix-community/home-manager/commit/c1e671036224089937e111e32ea899f59181c383) sketchybar: add includeSystemPath
* [`901f8fef`](https://github.com/nix-community/home-manager/commit/901f8fef7f349cf8a8e97b3230b22fd592df9160) flake.lock: Update ([nix-community/home-manager⁠#7125](https://togithub.com/nix-community/home-manager/issues/7125))
* [`03affdcb`](https://github.com/nix-community/home-manager/commit/03affdcbf2bf300e5b9dea29daac2f6bf4529cf6) dconf: Fix dconf config not apply correctly ([nix-community/home-manager⁠#7130](https://togithub.com/nix-community/home-manager/issues/7130))
* [`a45222c7`](https://github.com/nix-community/home-manager/commit/a45222c731d61b259d267346e8e098b320f4c681) superfile: add exiftool when metadata enabled ([nix-community/home-manager⁠#7118](https://togithub.com/nix-community/home-manager/issues/7118))
* [`d23d20f5`](https://github.com/nix-community/home-manager/commit/d23d20f55d49d8818ac1f1b2783671e8a6725022) sway: add bindswitches option ([nix-community/home-manager⁠#7095](https://togithub.com/nix-community/home-manager/issues/7095))
