### PR TITLE
niv mach-nix: update 98781c6f -> c409df53

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -119,10 +119,10 @@
         "homepage": "",
         "owner": "DavHau",
         "repo": "mach-nix",
-        "rev": "98781c6f60d22f8a7f1af521ef81907d337c3619",
-        "sha256": "0f2zs21yry4x6mlz24wlp02icz6869b2fp53q7lqfa5s0kcm2x98",
+        "rev": "c409df5347ef23f0bcba0aefc9a6345ef17b3441",
+        "sha256": "10jwpwmdf3789aidqjbzhzr2r7mz04l1wfjaja4mzns8lf91g3w1",
         "type": "tarball",
-        "url": "https://github.com/DavHau/mach-nix/archive/98781c6f60d22f8a7f1af521ef81907d337c3619.tar.gz",
+        "url": "https://github.com/DavHau/mach-nix/archive/c409df5347ef23f0bcba0aefc9a6345ef17b3441.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nerd-icons.el": {


### PR DESCRIPTION
## Changelog for mach-nix:
Branch: master
Commits: [DavHau/mach-nix@98781c6f...c409df53](https://github.com/DavHau/mach-nix/compare/98781c6f60d22f8a7f1af521ef81907d337c3619...c409df5347ef23f0bcba0aefc9a6345ef17b3441)

* [`78fa7644`](https://github.com/DavHau/mach-nix/commit/78fa7644d89a9551b1a97ab47116a3121a8773d7) Bump cachix/install-nix-action from 24 to 25
* [`61db3d46`](https://github.com/DavHau/mach-nix/commit/61db3d46864883af257b0dcd7cb8a4fb3bac52b1) Readme.md: link to current wiki
