### PR TITLE
niv emacs-overlay: update 438dfc04 -> 51d60eb6

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -41,10 +41,10 @@
         "homepage": "",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "438dfc0467bb6e194f3a5e5a78ed4bac716940cf",
-        "sha256": "1caqsx0nraz0rr4h663ms8yi7yhqcf87959lq3whwsr6va1igbry",
+        "rev": "51d60eb61a64d58e3086bb227d481ac77a12234c",
+        "sha256": "17av9vaiwi1jxvv8qjmv272i6pchmhnjm1pn4m89l8i1qy1m8hf5",
         "type": "tarball",
-        "url": "https://github.com/nix-community/emacs-overlay/archive/438dfc0467bb6e194f3a5e5a78ed4bac716940cf.tar.gz",
+        "url": "https://github.com/nix-community/emacs-overlay/archive/51d60eb61a64d58e3086bb227d481ac77a12234c.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "fast-syntax-highlighting": {


### PR DESCRIPTION
## Changelog for emacs-overlay:
Branch: master
Commits: [nix-community/emacs-overlay@438dfc04...51d60eb6](https://github.com/nix-community/emacs-overlay/compare/438dfc0467bb6e194f3a5e5a78ed4bac716940cf...51d60eb61a64d58e3086bb227d481ac77a12234c)

* [`229eed26`](https://github.com/nix-community/emacs-overlay/commit/229eed2696a78e456132bc1348d9feb8c7be7f43) Updated nongnu
* [`3bfb52dc`](https://github.com/nix-community/emacs-overlay/commit/3bfb52dca0a8dd390fbeacaed48fed4ba408a281) Updated elpa
* [`9595ef04`](https://github.com/nix-community/emacs-overlay/commit/9595ef0438bacfeaa1e5eccc2e386b4a9bf524bf) Updated melpa
* [`9a415a8b`](https://github.com/nix-community/emacs-overlay/commit/9a415a8b4c90c1f0719aefed19a80514f7a2f771) Updated emacs
* [`355f8006`](https://github.com/nix-community/emacs-overlay/commit/355f80064e79ed723f1a58e6965e7da4e840c4c1) Updated flake inputs
* [`a73601c0`](https://github.com/nix-community/emacs-overlay/commit/a73601c07aaa58ae69e73a8630f6060aeb2fdb97) Updated nongnu
* [`d496a053`](https://github.com/nix-community/emacs-overlay/commit/d496a053874af07a757eec3e26b4f3cb918aae9f) Updated elpa
* [`8530b228`](https://github.com/nix-community/emacs-overlay/commit/8530b2282aaf0a957a881de5001069073ebe9f20) Updated flake inputs
* [`5c2d3b4a`](https://github.com/nix-community/emacs-overlay/commit/5c2d3b4a84ed5366db6133f2fee58e2a62701280) Updated flake inputs
* [`a738f51b`](https://github.com/nix-community/emacs-overlay/commit/a738f51b28507d1c68ec612d75840a6165ebe1bf) Updated nongnu
* [`16d196ad`](https://github.com/nix-community/emacs-overlay/commit/16d196ad2e52fbbafa1730c5fd1af3c0e842b13c) Updated flake inputs
* [`b0892b5c`](https://github.com/nix-community/emacs-overlay/commit/b0892b5ce1a038cd96724e0836187ca45c9ea457) Updated melpa
* [`66bb2d7a`](https://github.com/nix-community/emacs-overlay/commit/66bb2d7a4df96d0c1e63648850b7aed1b2e8d683) Updated emacs
* [`f438d4f8`](https://github.com/nix-community/emacs-overlay/commit/f438d4f861150aad71e1727d02333b08600c3d90) Updated nongnu
* [`77a5dcff`](https://github.com/nix-community/emacs-overlay/commit/77a5dcff2b2494e74225d5c70739973241401be6) Updated elpa
* [`aa70453c`](https://github.com/nix-community/emacs-overlay/commit/aa70453c6e5e8134d3d22bc0c2b1c3cfe7837d39) Updated flake inputs
* [`9c693028`](https://github.com/nix-community/emacs-overlay/commit/9c693028e9b51d523b5bb8455001f2bbe30cb930) Updated nongnu
* [`19213615`](https://github.com/nix-community/emacs-overlay/commit/192136152f96590b07a495ab992cdc255208300f) Updated elpa
* [`9fb038dd`](https://github.com/nix-community/emacs-overlay/commit/9fb038dd11b0ac1a3676552f8109ed970c099ff2) Updated melpa
* [`5ccae309`](https://github.com/nix-community/emacs-overlay/commit/5ccae3090d7e03bb27b21dc81769d262490e44eb) Updated emacs
* [`afddd57c`](https://github.com/nix-community/emacs-overlay/commit/afddd57cf383f3fa7677ac196eee5664902913d6) Updated nongnu
* [`a281243e`](https://github.com/nix-community/emacs-overlay/commit/a281243eaec6ac810584f2a73126e8dd48c3a15e) Updated elpa
* [`ee6f3f60`](https://github.com/nix-community/emacs-overlay/commit/ee6f3f6077dc9504f27801203dcd1b610608aa6a) Updated flake inputs
* [`1bd89965`](https://github.com/nix-community/emacs-overlay/commit/1bd899657e1395c2f9b89a818f18ec7fb6c490fe) Updated nongnu
* [`030aac02`](https://github.com/nix-community/emacs-overlay/commit/030aac024ccfca682b75e5db5c08b236a7930f4a) Updated elpa
* [`2ad5c111`](https://github.com/nix-community/emacs-overlay/commit/2ad5c111ea3aae2ed1dd109f7f73a143dba8db32) Updated melpa
* [`fc120cc0`](https://github.com/nix-community/emacs-overlay/commit/fc120cc0265ef5e255d87ae4b4408c355d79fa30) Updated emacs
* [`e0143475`](https://github.com/nix-community/emacs-overlay/commit/e01434757cb2fcc01f46bf7ad8fb143eca3d337d) Updated flake inputs
* [`d234cb0d`](https://github.com/nix-community/emacs-overlay/commit/d234cb0d1ba576040f924d15374986a17ad24e0c) Updated elpa
* [`54ff8d2b`](https://github.com/nix-community/emacs-overlay/commit/54ff8d2b829a1a1cb824c40bb6d402f3eef1516d) Updated nongnu
* [`896f9620`](https://github.com/nix-community/emacs-overlay/commit/896f96200e3112e9abd0bb3510751a140bb7af81) Updated melpa
* [`7ed7865b`](https://github.com/nix-community/emacs-overlay/commit/7ed7865b51f7ca63ea51b84545eee5d7c63369e1) Updated emacs
* [`e173bf51`](https://github.com/nix-community/emacs-overlay/commit/e173bf51f3ebeffc0cd1162582be957b2e241eda) Updated nongnu
* [`e682d607`](https://github.com/nix-community/emacs-overlay/commit/e682d607901aea7084c1834d6e19b81c555976b3) Updated elpa
* [`7c2096e1`](https://github.com/nix-community/emacs-overlay/commit/7c2096e15e5152737300915a7f1372621288c4de) Updated melpa
* [`c2f57f60`](https://github.com/nix-community/emacs-overlay/commit/c2f57f602ba4f7da96ac08537240774531cb0fb3) Updated emacs
* [`e34ac821`](https://github.com/nix-community/emacs-overlay/commit/e34ac8210719f8c0655269ffc284cf0b7576a914) Updated nongnu
* [`de5f217d`](https://github.com/nix-community/emacs-overlay/commit/de5f217d9657b61773a6d2508f542afdea491244) Updated melpa
* [`cd0ba3fd`](https://github.com/nix-community/emacs-overlay/commit/cd0ba3fdbed27f695be7c2bd1f2d05acdf6de725) Updated emacs
* [`b2e4ff5b`](https://github.com/nix-community/emacs-overlay/commit/b2e4ff5b3348eda9f84b181962e5f988021faae1) Updated flake inputs
* [`e3e507d9`](https://github.com/nix-community/emacs-overlay/commit/e3e507d94b4df0cf8111dfc0161762dd183421d6) Updated elpa
* [`60602c52`](https://github.com/nix-community/emacs-overlay/commit/60602c520d62d95640bf4d8807da1cd48e2f8f61) Updated melpa
* [`d74081b1`](https://github.com/nix-community/emacs-overlay/commit/d74081b100aa84fd6a6e5911f9f01a8bb572d61e) Updated flake inputs
* [`3ff72fe1`](https://github.com/nix-community/emacs-overlay/commit/3ff72fe166b28786e90834f7febe896efe1afa82) Updated melpa
* [`e0bc994a`](https://github.com/nix-community/emacs-overlay/commit/e0bc994a32f98e96de9af9eee4cdcb7598a68a3d) Updated emacs
* [`af2834bc`](https://github.com/nix-community/emacs-overlay/commit/af2834bcba9f1204a250ca9fd2c7a76ad4a11b67) Updated nongnu
* [`d9e6b204`](https://github.com/nix-community/emacs-overlay/commit/d9e6b2044ed09ad5957306002aef88f7caa05a12) Updated elpa
* [`373de9cd`](https://github.com/nix-community/emacs-overlay/commit/373de9cd1923b3d7ef0bef0887f0f52729a12312) Updated nongnu
* [`3cbccdce`](https://github.com/nix-community/emacs-overlay/commit/3cbccdceacacdb60d18f31272451cfc748039ba4) Updated elpa
* [`551f6a3b`](https://github.com/nix-community/emacs-overlay/commit/551f6a3b8af9113d1d663625b04757f3c46cc121) Updated flake inputs
* [`91800e69`](https://github.com/nix-community/emacs-overlay/commit/91800e6973d6b6eae46dfbb0691ecc3b4fc0d9f5) Updated nongnu
* [`b1d393ea`](https://github.com/nix-community/emacs-overlay/commit/b1d393ea110071da349e395151b8e656bef800fd) Updated melpa
* [`be5aec38`](https://github.com/nix-community/emacs-overlay/commit/be5aec380e041a8b8d5aee9ebf89d9b3f1006c29) Updated emacs
* [`7d1167d2`](https://github.com/nix-community/emacs-overlay/commit/7d1167d2ef4958c8fbb76e30bac9d2e75c55c099) Updated nongnu
* [`8ae92505`](https://github.com/nix-community/emacs-overlay/commit/8ae925057bad39c6a72f55dd2ff0b281e2cea714) Updated elpa
* [`e2c1c9e8`](https://github.com/nix-community/emacs-overlay/commit/e2c1c9e8d01395574a1c268f6864682b105acb64) Updated nongnu
* [`5b5ee505`](https://github.com/nix-community/emacs-overlay/commit/5b5ee505fddb64ec36ff1f410d64ed56f313022e) Updated elpa
* [`2185a4df`](https://github.com/nix-community/emacs-overlay/commit/2185a4df238e290afb8cbb2f3675ed4bd46a5e81) Updated melpa
* [`7a9c1a45`](https://github.com/nix-community/emacs-overlay/commit/7a9c1a45a51e7cc6c2b8405a4a46fa1268ab6359) Updated emacs
* [`94a17b67`](https://github.com/nix-community/emacs-overlay/commit/94a17b67cf27ee8992fb75a01214412be2e7987f) Updated elpa
* [`b836c6ec`](https://github.com/nix-community/emacs-overlay/commit/b836c6ec524a150f0a671cff1c3a51ade1d9e497) Updated melpa
* [`1c2872c0`](https://github.com/nix-community/emacs-overlay/commit/1c2872c034ec7745aa5cfec7579f9e59b53dbfe2) Updated emacs
* [`bac3e427`](https://github.com/nix-community/emacs-overlay/commit/bac3e4274eb6843e504a6c525580b8f2583d85f7) Updated flake inputs
* [`c69a0fe5`](https://github.com/nix-community/emacs-overlay/commit/c69a0fe562987e33ecfad9f7ca09cc3c81d5b478) Updated nongnu
* [`5d426974`](https://github.com/nix-community/emacs-overlay/commit/5d4269746ea5e8f99085ba1f32ec17b7005b6724) Updated elpa
* [`21fce8b4`](https://github.com/nix-community/emacs-overlay/commit/21fce8b42450af35f518c1fd8df2fa9574b14753) Updated melpa
* [`bccc3c8b`](https://github.com/nix-community/emacs-overlay/commit/bccc3c8b3fb243263136fb9430f4099b2b4fffcd) Updated melpa
* [`8a79c78b`](https://github.com/nix-community/emacs-overlay/commit/8a79c78b3d84b550eb48a9988ab79a63478a5768) Updated emacs
* [`3f188376`](https://github.com/nix-community/emacs-overlay/commit/3f18837669f8d9fba26f28da475c08049e7fe454) Updated nongnu
* [`3384a125`](https://github.com/nix-community/emacs-overlay/commit/3384a125e95c77e9d39d6a07ed3976e88cd0a11b) Updated elpa
* [`0f1d08e0`](https://github.com/nix-community/emacs-overlay/commit/0f1d08e0f18c990fc4ccdea6e4104c3c04d75560) Updated melpa
* [`21acd667`](https://github.com/nix-community/emacs-overlay/commit/21acd66775f610a5dfe4a1a3205406666ddd15d7) Updated emacs
* [`13cddec1`](https://github.com/nix-community/emacs-overlay/commit/13cddec12e0ca5cd02cf1d2491a0bff667d02270) Updated flake inputs
* [`11b0e5b7`](https://github.com/nix-community/emacs-overlay/commit/11b0e5b7d58554b0a170013e4b45ef882b68a679) Updated nongnu
* [`49bc3230`](https://github.com/nix-community/emacs-overlay/commit/49bc3230f0691182dc7f3747b0857e39d5dc3e12) Updated elpa
* [`d1021614`](https://github.com/nix-community/emacs-overlay/commit/d1021614525194fd440fcd20b791af15e171b5c3) Updated melpa
* [`2abf7ff5`](https://github.com/nix-community/emacs-overlay/commit/2abf7ff574d907ab63fa11c5ff569c780c7eb465) Updated emacs
* [`ccb78ed9`](https://github.com/nix-community/emacs-overlay/commit/ccb78ed9ae3130498539f013824f4a4a3463dc4c) Updated melpa
* [`f02060c0`](https://github.com/nix-community/emacs-overlay/commit/f02060c00ccf9a7ce3786ee69e1ffdcd10fcdf9a) Updated emacs
* [`e68d7976`](https://github.com/nix-community/emacs-overlay/commit/e68d7976a40fa55113d722ffbd76bee6f58a9960) Updated flake inputs
* [`331f1631`](https://github.com/nix-community/emacs-overlay/commit/331f16310703c7ab3013cbec06469b47fabfbb4d) Updated nongnu
* [`e45b29b3`](https://github.com/nix-community/emacs-overlay/commit/e45b29b357445ffe81c3a29389d11e6726607410) Updated elpa
* [`1f37fd31`](https://github.com/nix-community/emacs-overlay/commit/1f37fd3121d1c5afa1ecb1584816a3e121a7a92d) Updated melpa
* [`aafed657`](https://github.com/nix-community/emacs-overlay/commit/aafed657caad955a1c75dc0a2584aaf7c97e628b) Updated emacs
* [`4a85fd9b`](https://github.com/nix-community/emacs-overlay/commit/4a85fd9b6964f07ed86e7c97bf9e2c1ddce56fc9) Updated nongnu
* [`586384c1`](https://github.com/nix-community/emacs-overlay/commit/586384c18822c4ebc2f5bdf54fb145fb1d80b01c) Updated elpa
* [`7b7d0dba`](https://github.com/nix-community/emacs-overlay/commit/7b7d0dbadd33d232860bd60a23f0d242874bdbc7) Updated melpa
* [`c73b3891`](https://github.com/nix-community/emacs-overlay/commit/c73b38912ab03a0de33c83576cff83c4b89eb1b3) Updated emacs
* [`cd55fd3c`](https://github.com/nix-community/emacs-overlay/commit/cd55fd3c3d51cb79eed19ff3624f7c8159c31f5f) Updated melpa
* [`dbfb966a`](https://github.com/nix-community/emacs-overlay/commit/dbfb966a6ff9dde58a39dfc6a20254e46c4494b1) Updated emacs
* [`9ea5d99f`](https://github.com/nix-community/emacs-overlay/commit/9ea5d99f6d08028a75c2eb09c06fb77652eaa1f1) Updated nongnu
* [`5f40906e`](https://github.com/nix-community/emacs-overlay/commit/5f40906ef216b8d958ea34379ca8e4e92c39498b) Updated elpa
* [`7174443b`](https://github.com/nix-community/emacs-overlay/commit/7174443b8bf24f753a3f7c2017c9303108b417a5) Updated melpa
* [`aa9f9769`](https://github.com/nix-community/emacs-overlay/commit/aa9f9769d54ed2d0e062755a82485f99d90f3d5f) Updated emacs
* [`0398fa5e`](https://github.com/nix-community/emacs-overlay/commit/0398fa5e309d7630e82775c7b680c9592446e839) Updated nongnu
* [`1a3ee9a4`](https://github.com/nix-community/emacs-overlay/commit/1a3ee9a437571f28d63785f58f33a29e4dfe819a) Updated elpa
* [`6d15ffa9`](https://github.com/nix-community/emacs-overlay/commit/6d15ffa9720fc7d6635238d961593a289062b555) Updated melpa
* [`31d4559a`](https://github.com/nix-community/emacs-overlay/commit/31d4559ab0c8070c0ef5f1614f7aca951737f453) Updated melpa
* [`6317599f`](https://github.com/nix-community/emacs-overlay/commit/6317599f5c92ccb08af9e910d0707270b6c7b9ab) Updated emacs
* [`4f7b4f7f`](https://github.com/nix-community/emacs-overlay/commit/4f7b4f7f00dc24aab4f07bfee820a209127e4afd) Updated nongnu
* [`e957dccd`](https://github.com/nix-community/emacs-overlay/commit/e957dccdc908017611810dd99e2b9ee0f1b747ef) Updated elpa
* [`43d0e73d`](https://github.com/nix-community/emacs-overlay/commit/43d0e73d4a34f470045ac7c13dd45e1a7653f57b) Updated melpa
* [`e5647be5`](https://github.com/nix-community/emacs-overlay/commit/e5647be5ff26a1df571757a008e20c2237745cfc) Updated nongnu
* [`1fa37cb3`](https://github.com/nix-community/emacs-overlay/commit/1fa37cb302ac9da82f78da4a51e6f5e4bca56da1) Updated elpa
* [`36988f77`](https://github.com/nix-community/emacs-overlay/commit/36988f77dedc750e7ac81f7c328636a021a721d1) Updated melpa
* [`4267e51c`](https://github.com/nix-community/emacs-overlay/commit/4267e51c6c5fed605eecfd8a2c05cac080b6a32f) Updated emacs
* [`f40f761f`](https://github.com/nix-community/emacs-overlay/commit/f40f761f9e576c39770c9e252b89f73d41e23eaa) Updated flake inputs
* [`d8949f8c`](https://github.com/nix-community/emacs-overlay/commit/d8949f8c77eadcc7b268f994361fd2055cfbf2cb) Updated melpa
* [`0f4b8081`](https://github.com/nix-community/emacs-overlay/commit/0f4b808169272debaf14c10bfbf46c2d29eb9dbd) Updated flake inputs
* [`789a32d5`](https://github.com/nix-community/emacs-overlay/commit/789a32d5bd6dc168feb55d609f8f056f2d51f6e3) Updated nongnu
* [`37bfe5bb`](https://github.com/nix-community/emacs-overlay/commit/37bfe5bb312b203ad5a37ffda7477d7fc1d416a7) Updated melpa
* [`f2919b67`](https://github.com/nix-community/emacs-overlay/commit/f2919b676a957d15a7ef9976192acddf2b8325b2) Updated emacs
* [`95871133`](https://github.com/nix-community/emacs-overlay/commit/95871133ae3622901c094fd94eb01f34c38e0e6c) Updated nongnu
* [`bcf998c0`](https://github.com/nix-community/emacs-overlay/commit/bcf998c005e0542dd6a9d1389055a30700be8ba0) Updated elpa
* [`1f6e78de`](https://github.com/nix-community/emacs-overlay/commit/1f6e78de7117037c77d3426e58da4ec87ad72adb) Updated melpa
* [`68768914`](https://github.com/nix-community/emacs-overlay/commit/6876891497fa209feda114600f4170d905abde53) Updated emacs
* [`15acdba2`](https://github.com/nix-community/emacs-overlay/commit/15acdba225ac8abf32c596685bc75aea033071f7) Updated fromElisp
* [`6983ebec`](https://github.com/nix-community/emacs-overlay/commit/6983ebecec75467b33d96e2bf4a7966682d61628) Updated nongnu
* [`0404f19d`](https://github.com/nix-community/emacs-overlay/commit/0404f19d517fbfa7bce187da98b697e8719bd5d8) Updated elpa
* [`8a4408f1`](https://github.com/nix-community/emacs-overlay/commit/8a4408f147f91dab791e5d5f0baf917fe5858c1a) Updated melpa
* [`c52caefb`](https://github.com/nix-community/emacs-overlay/commit/c52caefb7f44578df586759f3ee675b687c5ab65) Updated emacs
* [`1799cf8c`](https://github.com/nix-community/emacs-overlay/commit/1799cf8c9df7186a23e0a69ab74d2a310b628f98) Revert "Updated fromElisp"
* [`52941c31`](https://github.com/nix-community/emacs-overlay/commit/52941c3156e3723e36ea4182ce7ae3d495fb4027) Updated nongnu
* [`e6839c80`](https://github.com/nix-community/emacs-overlay/commit/e6839c800a1d786f0ebbde21e346b9cd9b494d06) Updated elpa
* [`b95d4e9d`](https://github.com/nix-community/emacs-overlay/commit/b95d4e9dc5bd7962d7f6817855f8d74e2b32911e) Updated melpa
* [`4aa8b62d`](https://github.com/nix-community/emacs-overlay/commit/4aa8b62d3aeb9afef8975c6fcbda404cc718c8fb) Updated flake inputs
* [`59c04dd9`](https://github.com/nix-community/emacs-overlay/commit/59c04dd982a4af9dbf5180da5fcb10b0333bfa7f) Updated melpa
* [`20bad5fa`](https://github.com/nix-community/emacs-overlay/commit/20bad5faaa8cd9782977d70b8b34638f6449a2a7) Updated flake inputs
* [`370f506a`](https://github.com/nix-community/emacs-overlay/commit/370f506ad6abce27ae844d5b79e759630a266b0d) Updated nongnu
* [`cffb9948`](https://github.com/nix-community/emacs-overlay/commit/cffb9948ec70d032616b57dbd5018b0273b1a22d) Updated elpa
* [`1bee0176`](https://github.com/nix-community/emacs-overlay/commit/1bee0176f33ceebeb907921af39fb689ff375983) Updated melpa
* [`ed6c0f95`](https://github.com/nix-community/emacs-overlay/commit/ed6c0f95acb68734d4419d1912860b697f4c5ea6) Updated emacs
* [`ecf3c4fa`](https://github.com/nix-community/emacs-overlay/commit/ecf3c4fa315e19cdda09056ea90bf126b82ff4ef) Updated flake inputs
* [`de4e4701`](https://github.com/nix-community/emacs-overlay/commit/de4e4701349c3bc8ee1251d01306f6f996840860) Updated nongnu
* [`527c14f4`](https://github.com/nix-community/emacs-overlay/commit/527c14f4280d37d857f7e9e70330168ed95a69b4) Updated elpa
* [`1b2bc802`](https://github.com/nix-community/emacs-overlay/commit/1b2bc802bbac29f4695e39fbf982944c0999b45d) Updated flake inputs
* [`0da1350a`](https://github.com/nix-community/emacs-overlay/commit/0da1350a4013afba144fe3a152949291cb8ef93b) Updated nongnu
* [`61324f11`](https://github.com/nix-community/emacs-overlay/commit/61324f118f2ba0a2e3244c1bffbc7954670d2af3) Updated elpa
* [`f45ca856`](https://github.com/nix-community/emacs-overlay/commit/f45ca856fb711c568ecebfe8365897e0d6625ad6) Manually update Emacs, and remove now-merged unstable patch
* [`4549e0cb`](https://github.com/nix-community/emacs-overlay/commit/4549e0cb468aa26b77dfa3d0f242dbf4d3730b13) Updated melpa
* [`f66e9712`](https://github.com/nix-community/emacs-overlay/commit/f66e9712f1b4f61d59f079e2ca46a68547c9d4c4) Updated fromElisp
* [`3cc961f9`](https://github.com/nix-community/emacs-overlay/commit/3cc961f94c5db4e2cdfb498f2d6f02e3511b4991) Revert "Updated fromElisp"
* [`8afd5b5b`](https://github.com/nix-community/emacs-overlay/commit/8afd5b5b988448ce2e8caec4dae8265a77e03bc7) Updated nongnu
* [`581955c1`](https://github.com/nix-community/emacs-overlay/commit/581955c15127c12a548602e58ef2e07d52e79aa7) Updated elpa
* [`17b363c1`](https://github.com/nix-community/emacs-overlay/commit/17b363c108535e549243ed309544a1b38a369bb0) Updated melpa
* [`88ff8a44`](https://github.com/nix-community/emacs-overlay/commit/88ff8a448dec87188f7a5d024bb8838d80a6ffcc) Updated emacs
* [`579b6d9f`](https://github.com/nix-community/emacs-overlay/commit/579b6d9f2dcc1c84929b1e7c09c5cbc29e71e68d) Updated flake inputs
* [`28e53a1d`](https://github.com/nix-community/emacs-overlay/commit/28e53a1d66d5e7e439a773393c3ffaaf7abcbe64) Updated nongnu
* [`899b5745`](https://github.com/nix-community/emacs-overlay/commit/899b574575e52adb99d24484d27dfb28a959fa83) Updated melpa
* [`3f5c5850`](https://github.com/nix-community/emacs-overlay/commit/3f5c585027ef7798de403e4b7093f3005679496f) Updated emacs
* [`dab8132d`](https://github.com/nix-community/emacs-overlay/commit/dab8132d4a9bffeaadb5af2e5a04140439477b7b) Updated flake inputs
* [`b12c721b`](https://github.com/nix-community/emacs-overlay/commit/b12c721b19d42a6eec952b8d319dce3aed0287d0) Updated nongnu
* [`346006d7`](https://github.com/nix-community/emacs-overlay/commit/346006d7b5407b97fde7790d970b500ffca1069f) Updated elpa
* [`dbc7eeea`](https://github.com/nix-community/emacs-overlay/commit/dbc7eeea24157e9c453fed3ddfd75c403bf0d06f) Updated melpa
* [`783e12a6`](https://github.com/nix-community/emacs-overlay/commit/783e12a65f2284fbaf88a77f50c167a28a7d9e1c) Updated emacs
* [`4a1d8da4`](https://github.com/nix-community/emacs-overlay/commit/4a1d8da46c56a3593798438edbfe9a00d2ab5456) Updated nongnu
* [`67fa10fd`](https://github.com/nix-community/emacs-overlay/commit/67fa10fdfd0e958dceb60ce893956aad1ed6bce4) Updated elpa
* [`11a3c5ab`](https://github.com/nix-community/emacs-overlay/commit/11a3c5ab4d08127e3d49ee562ed7ca462096299f) Updated nongnu
* [`dd47e0eb`](https://github.com/nix-community/emacs-overlay/commit/dd47e0eb0d5114c39967d4aa1d2abb9725294737) Updated elpa
* [`3ad21260`](https://github.com/nix-community/emacs-overlay/commit/3ad212608046c130ac9788652f711a78c34ee993) Updated flake inputs
* [`dacd4840`](https://github.com/nix-community/emacs-overlay/commit/dacd48403d171619fc4579abd658f4bba1f904bb) Updated melpa
* [`88b4b5a9`](https://github.com/nix-community/emacs-overlay/commit/88b4b5a913f6f2c257851d275640831fb8dd5825) Updated emacs
* [`8f939044`](https://github.com/nix-community/emacs-overlay/commit/8f939044732a5239ac20e86f536c71e8d78b6011) Updated nongnu
* [`d7ab9d00`](https://github.com/nix-community/emacs-overlay/commit/d7ab9d00bc840fec8a76375634ae36d406ab0513) Updated elpa
* [`b0bb3b17`](https://github.com/nix-community/emacs-overlay/commit/b0bb3b17f2e4bf55f1f6594c866747e0bc32c399) Updated melpa
* [`d818fd97`](https://github.com/nix-community/emacs-overlay/commit/d818fd9717043b794d0012fbc9f6422e12915eaf) Updated emacs
* [`ff63d00c`](https://github.com/nix-community/emacs-overlay/commit/ff63d00c64ecef96658da8419c3b5ffe356c13ed) Updated elpa
* [`fe2147ed`](https://github.com/nix-community/emacs-overlay/commit/fe2147ed80101c5e7efcb4b282185c027de5cf25) Updated melpa
* [`32a8b70b`](https://github.com/nix-community/emacs-overlay/commit/32a8b70b9f0cdbdc3dda1e40524293f7a13ebc36) Updated melpa
* [`972d4819`](https://github.com/nix-community/emacs-overlay/commit/972d48193efde5e8618d907e0a4d2751a329a434) Updated emacs
* [`11bb7cc7`](https://github.com/nix-community/emacs-overlay/commit/11bb7cc7fd71828b0fce809bfb59020f5d61c4fe) Updated nongnu
* [`59bb0142`](https://github.com/nix-community/emacs-overlay/commit/59bb0142a330bf4def630e68b0abd8b040fd123a) Updated elpa
* [`1195950d`](https://github.com/nix-community/emacs-overlay/commit/1195950de932f579d887b28b55cbc751158203e7) Updated melpa
* [`5e55769b`](https://github.com/nix-community/emacs-overlay/commit/5e55769b7a39ab810f761874aff5787c74e981da) Updated emacs
* [`c67f968e`](https://github.com/nix-community/emacs-overlay/commit/c67f968e40ae0f12b925953926a0201d3067438a) Updated flake inputs
* [`2194e805`](https://github.com/nix-community/emacs-overlay/commit/2194e80576a14c4a81a36c1596dd5ce964d647b0) Updated nongnu
* [`464be014`](https://github.com/nix-community/emacs-overlay/commit/464be0142fb4c02b826e4aff67518909dc57f002) Updated elpa
* [`c1fdaae5`](https://github.com/nix-community/emacs-overlay/commit/c1fdaae5c4c397b66fc63c683945c5c272aef1b4) Updated melpa
* [`7e969bfc`](https://github.com/nix-community/emacs-overlay/commit/7e969bfc4c242458ce068fa7a1476fce1fa78898) Updated flake inputs
* [`566f386a`](https://github.com/nix-community/emacs-overlay/commit/566f386a7e716cbde6b60c2cbf5e938655f29911) Updated melpa
* [`437a6b24`](https://github.com/nix-community/emacs-overlay/commit/437a6b24aabddda3dfce57838d05f1b173bf46ec) Updated elpa
* [`176690b1`](https://github.com/nix-community/emacs-overlay/commit/176690b161c9cf8044d8766308d504b89818e54c) Updated melpa
* [`95a64c51`](https://github.com/nix-community/emacs-overlay/commit/95a64c515e22ba212ee0de12509e31b3801e1ba6) Updated emacs
* [`8fcc8c1c`](https://github.com/nix-community/emacs-overlay/commit/8fcc8c1c51565cfe0a7db742273a05bc2da31340) Updated nongnu
* [`c5a55ca8`](https://github.com/nix-community/emacs-overlay/commit/c5a55ca8488fe4590f90fa43e3d6371c37116320) Updated elpa
* [`076abb92`](https://github.com/nix-community/emacs-overlay/commit/076abb929715022935ad532beebfa9e84e94f280) Updated melpa
* [`29430cce`](https://github.com/nix-community/emacs-overlay/commit/29430cce2da82c0f658cd3310191434bf709f245) Updated emacs
* [`e0484338`](https://github.com/nix-community/emacs-overlay/commit/e048433838750a5fd9036e56dd8f59affa6d676b) Updated fromElisp
* [`dbaa3636`](https://github.com/nix-community/emacs-overlay/commit/dbaa3636560e69e430edc5a340b37c69f8de7d28) Updated fromElisp
* [`49ba6a14`](https://github.com/nix-community/emacs-overlay/commit/49ba6a14d9e80baa3715984cc2dde8c9fdf00049) Don't overwrite fromElisp on errors.
* [`0fba546d`](https://github.com/nix-community/emacs-overlay/commit/0fba546d9aa235fc726fe9c8c3bb703e918c14c4) Updated flake inputs
* [`44f10e03`](https://github.com/nix-community/emacs-overlay/commit/44f10e03d04b678d13ee9c36a9bd632dbce84103) Updated flake inputs
* [`fa919dd3`](https://github.com/nix-community/emacs-overlay/commit/fa919dd368ff59318cdf9d5ac16b61a9eb4f7d8e) follow savannah redirect for atom feed
* [`66dcd551`](https://github.com/nix-community/emacs-overlay/commit/66dcd551173d678898d07886cebbc103d0b44645) Updated nongnu
* [`56505e6c`](https://github.com/nix-community/emacs-overlay/commit/56505e6c22457630bc62de98351058e378d51f91) Updated elpa
* [`9c1c0ba8`](https://github.com/nix-community/emacs-overlay/commit/9c1c0ba8fef7d277a1b18a1241c7ac4a645b9257) Updated melpa
* [`8a6d70fb`](https://github.com/nix-community/emacs-overlay/commit/8a6d70fbe08c7be6b1832a1c4614d5f71e8ccf82) Updated emacs
* [`8a4bcb07`](https://github.com/nix-community/emacs-overlay/commit/8a4bcb07e1d1b7ffafe2b4bca79bce7e374c96af) Updated nongnu
* [`2eee58a7`](https://github.com/nix-community/emacs-overlay/commit/2eee58a77e05399ecbebd5ab2d21cdd110abc547) Updated elpa
* [`5f06a39a`](https://github.com/nix-community/emacs-overlay/commit/5f06a39a20d22d187191208d6997a95e97c266d4) Updated melpa
* [`2de3eea4`](https://github.com/nix-community/emacs-overlay/commit/2de3eea4261b2215c732bf81d185179a5e1c2980) Updated emacs
* [`8e1a6d81`](https://github.com/nix-community/emacs-overlay/commit/8e1a6d8182bb59432d0796f4a769ef3b9111bfcb) Updated flake inputs
* [`33d7b320`](https://github.com/nix-community/emacs-overlay/commit/33d7b320ab1e8ee2e0473416c1990a8f62d2519d) Updated nongnu
* [`7651658f`](https://github.com/nix-community/emacs-overlay/commit/7651658f1deb2e31d6d5367eb8dc5cfdb0a4f313) Updated elpa
* [`48ea615f`](https://github.com/nix-community/emacs-overlay/commit/48ea615f66c7b01ccbe603418f88ee64e27bed99) Updated melpa
* [`ff7520b1`](https://github.com/nix-community/emacs-overlay/commit/ff7520b1b7eeaa20f67c1a73da384f53c09bf0d6) Updated emacs
* [`5140763f`](https://github.com/nix-community/emacs-overlay/commit/5140763f6b06268375e06698636796fa063b944c) Updated melpa
* [`5b6b5beb`](https://github.com/nix-community/emacs-overlay/commit/5b6b5beb5c6778d7a7d0b078675dac4de4884cd1) Updated flake inputs
* [`dfa2302b`](https://github.com/nix-community/emacs-overlay/commit/dfa2302b404c9d59296b34cac7b2354f5eca4a55) Updated nongnu
* [`397fd659`](https://github.com/nix-community/emacs-overlay/commit/397fd659a4a7cfb75260b0104f2386cbabdf110e) Updated elpa
* [`7168e351`](https://github.com/nix-community/emacs-overlay/commit/7168e351ba6a0a65ccea47d5023e3f3427f30d26) Updated melpa
* [`f7dd0287`](https://github.com/nix-community/emacs-overlay/commit/f7dd02872d4acc406355965a6c9bbb4f14782400) Updated emacs
* [`f4d411e5`](https://github.com/nix-community/emacs-overlay/commit/f4d411e5e8066f8916a911770dda22506dcb50e3) Updated nongnu
* [`19e8e1c6`](https://github.com/nix-community/emacs-overlay/commit/19e8e1c6541c7c2b4f54c5e7cee9bfe46d97f7bd) Updated elpa
* [`701c1edb`](https://github.com/nix-community/emacs-overlay/commit/701c1edbb332c46284ce6332f117795a0fa8ecba) Updated melpa
* [`e8abde37`](https://github.com/nix-community/emacs-overlay/commit/e8abde37d18efb09d3662d66a5bd36bb517e0db1) Updated emacs
* [`08ab4309`](https://github.com/nix-community/emacs-overlay/commit/08ab4309797b262599c76ca927d0a9012e93e1c9) Updated melpa
* [`0abe78b7`](https://github.com/nix-community/emacs-overlay/commit/0abe78b79df5a7d4d1f952b0d9eca17ba2399dd8) Updated emacs
* [`13be163f`](https://github.com/nix-community/emacs-overlay/commit/13be163faa226f5c7ba1e59718c3c29038d915d3) Updated nongnu
* [`bd14f05a`](https://github.com/nix-community/emacs-overlay/commit/bd14f05adc19cc95d0c516ea6bbf940760be29f2) Updated elpa
* [`8453bd9f`](https://github.com/nix-community/emacs-overlay/commit/8453bd9f0dc54c25c1149e3527df84ab52ce3a6b) Updated melpa
* [`51d60eb6`](https://github.com/nix-community/emacs-overlay/commit/51d60eb61a64d58e3086bb227d481ac77a12234c) Updated emacs
