### PR TITLE
niv doomemacs: update ca7e226e -> f71cbb9f

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "",
         "owner": "doomemacs",
         "repo": "doomemacs",
-        "rev": "ca7e226e1305ed7f10762315ad48f19c330cdd72",
-        "sha256": "077h3cyn53ylm4w7ap2k9jdqd9wsi1nidf26h99pwdmc3yz4f4r4",
+        "rev": "f71cbb9f5c646e99135edb55412a617bf823aa98",
+        "sha256": "1f2g20vv8rgihjkq1ky7wa1bh3i0p3n6cf5xdvc7cbdyc4lg1wih",
         "type": "tarball",
-        "url": "https://github.com/doomemacs/doomemacs/archive/ca7e226e1305ed7f10762315ad48f19c330cdd72.tar.gz",
+        "url": "https://github.com/doomemacs/doomemacs/archive/f71cbb9f5c646e99135edb55412a617bf823aa98.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "emacs-overlay": {


### PR DESCRIPTION
## Changelog for doomemacs:
Branch: master
Commits: [doomemacs/doomemacs@ca7e226e...f71cbb9f](https://github.com/doomemacs/doomemacs/compare/ca7e226e1305ed7f10762315ad48f19c330cdd72...f71cbb9f5c646e99135edb55412a617bf823aa98)

* [`9f636686`](https://github.com/doomemacs/doomemacs/commit/9f6366865e329ca01d3882c44f174b29ca84837a) fix(notmuch): don't open main notmuch buffer as popup
* [`b2db71e5`](https://github.com/doomemacs/doomemacs/commit/b2db71e55a43697c3e71baeb118ec9b4e6a9275e) revert: feature/workspaces: persist indirect buffers
* [`9c2b2473`](https://github.com/doomemacs/doomemacs/commit/9c2b2473be79b398c50d84ae9f261403161811b0) release(modules): 25.06.0-dev
* [`30501abd`](https://github.com/doomemacs/doomemacs/commit/30501abd59422e47b32904fe5955752ed744be29) fix(vc): browse to remote from git-timemachine revisions
* [`2b1e07dc`](https://github.com/doomemacs/doomemacs/commit/2b1e07dcf0c5ffce89489c960ef59d204fe8ac3e) fix(vc): better line selection in git-timemachine buffers when browse at remote
* [`52dbde01`](https://github.com/doomemacs/doomemacs/commit/52dbde017a03795bd92abc8908cebee9aff77ffc) fix(debugger): error if breakpoints dir is missing
* [`f00dd3d4`](https://github.com/doomemacs/doomemacs/commit/f00dd3d466bea75af49c36e608fb5d6c049c005c) fix(lib): setq-hook!: remove docstrings from defuns
* [`7088257f`](https://github.com/doomemacs/doomemacs/commit/7088257f2ee04d785a6f7c7eb728a788cf01250d) bump: *
* [`f5b9cce5`](https://github.com/doomemacs/doomemacs/commit/f5b9cce5e0a29cae13465f84491cafaf62de98e7) fix(magit): don't widen repo buffers on auto-revert
* [`e6ee3325`](https://github.com/doomemacs/doomemacs/commit/e6ee332573239791351bf3241349386c047cedb8) fix(lib): autoload doom/describe-char
* [`55568003`](https://github.com/doomemacs/doomemacs/commit/555680036ca9db9f58f5c91346b02fe3167add70) fix(lookup): dash docset lookup
* [`722f5a2e`](https://github.com/doomemacs/doomemacs/commit/722f5a2e18b77553443a9316eaa51a7b9575f13c) fix(workspaces): use existing workspace on project switch
* [`13e92ceb`](https://github.com/doomemacs/doomemacs/commit/13e92ceb3c046263e49b6ac43c499fb9b585f683) revert: eglot
* [`b70d137f`](https://github.com/doomemacs/doomemacs/commit/b70d137f1a224cdbac3994d249fb5e8c7fcc203a) tweak(default): font-size adjustment keybinds on macos
* [`9f16efbb`](https://github.com/doomemacs/doomemacs/commit/9f16efbb4ed3262be9f24075f0a35fc55f448ae2) tweak(default): move macos send-to-*/open-in-* app keybinds
* [`6898a9c2`](https://github.com/doomemacs/doomemacs/commit/6898a9c267fd97d9934c00ea9a2d55ad30a2263f) module: add :tools llm
* [`31994ef1`](https://github.com/doomemacs/doomemacs/commit/31994ef1360b5259512a2afdf75084c0c834385b) fix(tabs): errors on dead buffers
* [`87de6e45`](https://github.com/doomemacs/doomemacs/commit/87de6e45f203f909ca0e4611b807bc6450744b14) fix(tabs): show unreal buffers in tab list
* [`cd227e67`](https://github.com/doomemacs/doomemacs/commit/cd227e675ac724b6def1df2bd8349b1d9bd53573) refactor(python): remove redundant :mode
* [`13396d4a`](https://github.com/doomemacs/doomemacs/commit/13396d4accba2ae739830dd5b494fe30366c01a1) refactor(python): move conda-env-intiailize-eshell to eshell-load-hook
* [`49591fd5`](https://github.com/doomemacs/doomemacs/commit/49591fd5a0461288972d6a7883d4afe0ebe201ff) tweak(python): init poetry-tracking-mode sooner
* [`d99742ff`](https://github.com/doomemacs/doomemacs/commit/d99742ff92565d75ccaf8119d3f4e895b9ea4ae6) tweak(default): move macos send-to-*/open-in-* app keybinds
* [`61198800`](https://github.com/doomemacs/doomemacs/commit/61198800aa284b915d27ab1b87dc2f8980f4ea24) feat(llm): add <leader> o l prefix for non-evil users
* [`5477ba4c`](https://github.com/doomemacs/doomemacs/commit/5477ba4c16c2e9cb7a6afad1b1c0d06fab57a6a1) module: add :lang janet
* [`51034797`](https://github.com/doomemacs/doomemacs/commit/510347977e4dd86ccf5ce74a78633902a6e2766b) docs(lib): revise various docstrings
* [`66f1b25d`](https://github.com/doomemacs/doomemacs/commit/66f1b25dac30ca97779e8a05e735e14230556492) fix(upload): install ssh-deploy from emacsmirror
* [`44136a66`](https://github.com/doomemacs/doomemacs/commit/44136a66dd16b1a5146a2d650419730a1e99cc43) bump: :emacs dired
* [`5a696370`](https://github.com/doomemacs/doomemacs/commit/5a6963707204343d47b526bc472b71e6fd46008e) tweak(default): font resizing keybinds
* [`190a389c`](https://github.com/doomemacs/doomemacs/commit/190a389cf83167157c079422b3c316beb61ffce0) fix(org): remove [return] keybinds
* [`12f08c9f`](https://github.com/doomemacs/doomemacs/commit/12f08c9fb8f65c9b009393416fc74c2d8c8465e6) fix(csharp): s/dotnet-csharpier/csharpier
* [`56fc5410`](https://github.com/doomemacs/doomemacs/commit/56fc5410c2a577866279dd2f9a1303238099f85e) fix(terraform): duplicate localleader keybind
* [`07ea4b1e`](https://github.com/doomemacs/doomemacs/commit/07ea4b1ee087b19a80eebe692aeef648c82458a0) nit(terraform): reformat
* [`0658c1f8`](https://github.com/doomemacs/doomemacs/commit/0658c1f863d3bfd5818291c7ee39d738915ce18b) fix(use-package): omit bind-key-pkg.el
* [`e614ffbd`](https://github.com/doomemacs/doomemacs/commit/e614ffbda8b278bc9fd9a9cb3a836d636b1091e6) fix(llm): don't auto-kill gptel popup buffer
* [`3c8240df`](https://github.com/doomemacs/doomemacs/commit/3c8240dfaab18610ba67c20ca850efc17a36c575) fix(cli): error if $EMACSDIR/.local/etc/eln missing
* [`4b99e6f1`](https://github.com/doomemacs/doomemacs/commit/4b99e6f1563cbd8da6acc9e8a1d8329ce0c4f791) fix(debugger): wrong-number-of-arguments error
* [`4be8557e`](https://github.com/doomemacs/doomemacs/commit/4be8557eb3e576e8a2ca6840fe8272487e3a733f) docs(cc): Specify `--` with command for bear
* [`6c1965b1`](https://github.com/doomemacs/doomemacs/commit/6c1965b1ed4a297779a06c297ea9193cd6014d9f) fix(magit): +magit-auto-revert: handle edge cases
* [`50200762`](https://github.com/doomemacs/doomemacs/commit/50200762cdf581e6ce5c230d890673ed396de276) bump: :tools
* [`3a9d6071`](https://github.com/doomemacs/doomemacs/commit/3a9d6071f35eb107fab9e96214c1588727cd082d) fix: defining as dynamic an already lexical var
* [`fabce333`](https://github.com/doomemacs/doomemacs/commit/fabce333e003324cbfafa01fa0cd967a2712df1d) fix(undo): undo-tree visualizer refusing to quit in some cases
* [`621ea4d5`](https://github.com/doomemacs/doomemacs/commit/621ea4d56cd8092d0f232f52c30d5af0c375fefa) refactor(hy): remove redundant mode/interpreter entries
* [`78f55f3a`](https://github.com/doomemacs/doomemacs/commit/78f55f3a45a1b3d328e9727a647f9d83f3020a15) fix(magit): update diff-hl on revert
* [`e25e6840`](https://github.com/doomemacs/doomemacs/commit/e25e68401479cb41301b2c62bbff84abc85d7b62) feat(tty): add support for TTY child frames in 31+
* [`bd908e4c`](https://github.com/doomemacs/doomemacs/commit/bd908e4c4773e20a4a37aaa9aec3fbade14e9df4) revert: eglot
* [`6d948482`](https://github.com/doomemacs/doomemacs/commit/6d9484820abbbecd80a8a47f6f5e73e01d186498) fix(tty): s/tty-setup-hoom/tty-setup-hook
* [`55e97eb7`](https://github.com/doomemacs/doomemacs/commit/55e97eb78a75f978144c519788252a476cf4c75c) fix(beancount): +beancount/balance: omit zeroed accounts
* [`bda27228`](https://github.com/doomemacs/doomemacs/commit/bda27228eba446f59844aa2fdeca4081cdb6aee1) fix(beancount): linter in narrowed buffers
* [`57b8d5fd`](https://github.com/doomemacs/doomemacs/commit/57b8d5fd8ee881a3c9aa2d05f6e578394af2af69) fix(beancount): flymake-bean: false positives from relative paths
* [`11b4b8d2`](https://github.com/doomemacs/doomemacs/commit/11b4b8d2e5072f1f62df27943ca378c616678a72) revert: transient
* [`5d13d6ce`](https://github.com/doomemacs/doomemacs/commit/5d13d6ce9942dee8821cbde63c444352aec923dc) fix(lib): doom-file-cookie: what argument-less cookies return
* [`b173feda`](https://github.com/doomemacs/doomemacs/commit/b173fedaff5ec49ed3cc4b618848b901f7adac80) refactor(beancount): move autoloads to sub-directory
* [`8627117d`](https://github.com/doomemacs/doomemacs/commit/8627117d636c5d009f07509de3f6eecc76b47e2f) feat(beancount): activate on *.bean files too
* [`a02871ba`](https://github.com/doomemacs/doomemacs/commit/a02871ba83d481d5dd3037f12045a6965af117a2) feat(beancount): support lines only read by linter
* [`d3e8ca8d`](https://github.com/doomemacs/doomemacs/commit/d3e8ca8d9d20780a30208435727fd96c6ccc1b4e) feat(beancount): enhance completion across the board
* [`c22bb498`](https://github.com/doomemacs/doomemacs/commit/c22bb498e58097b15f66e0d0ffb2aea5e2158da6) fix(lib): doom-print-minimum-level: type error if level is undefined
* [`7f8b24d1`](https://github.com/doomemacs/doomemacs/commit/7f8b24d1b8057996fad440fa0f26ce5a3ad02424) fix(beancount): enhance +beancount/clone-{,this-}transaction
* [`5df769e9`](https://github.com/doomemacs/doomemacs/commit/5df769e994aa6906ee1a2ab0063cc92c7046b0ca) feat(beancount): add commodity/currency completion
* [`cfea950e`](https://github.com/doomemacs/doomemacs/commit/cfea950e60961e45fc43a820d855eb6212856126) fix(beancount): hangs when completion cache is empty
* [`5026de65`](https://github.com/doomemacs/doomemacs/commit/5026de65bb95600f118573b7b60fa28c18cad76a) refactor(beancount): don't complete commodities from prices
* [`8406c1ff`](https://github.com/doomemacs/doomemacs/commit/8406c1ff22b95bd0f816de4a0223fa3ce3c82568) feat(beancount): highlight custom directives
* [`0199727d`](https://github.com/doomemacs/doomemacs/commit/0199727de5b0c60ef63ad887f632b18f77b4b148) fix(beancount): relax prefix on virtual lines
* [`8667b181`](https://github.com/doomemacs/doomemacs/commit/8667b181fcf5eb113c8a437467291ba30dd51ae5) feat(beancount): add account completion on budget directives
* [`4d685029`](https://github.com/doomemacs/doomemacs/commit/4d685029f9a5cea867c3f3057e11a64d442b4fee) perf(beancount): speed up flymake checker advice
* [`96ac6b00`](https://github.com/doomemacs/doomemacs/commit/96ac6b0037226758ed6742fd3a1f5add6d72f1ac) fix(beancount): completion edge cases
* [`6a6ac8f3`](https://github.com/doomemacs/doomemacs/commit/6a6ac8f315cdf7aba13480c7ede2724ae98d81e0) fix(eshell): disable undo while process is executing
* [`24aec7cd`](https://github.com/doomemacs/doomemacs/commit/24aec7cd2be59f5bc9d81f6d4217ad842222f8b2) fix(coq): void-function company-coq
* [`361eec11`](https://github.com/doomemacs/doomemacs/commit/361eec11a4da3dd9ee16a05468a0a7e6a1ce4046) fix(workspaces): avoid duplicate workspace creation when no frame exists
* [`f71cbb9f`](https://github.com/doomemacs/doomemacs/commit/f71cbb9f5c646e99135edb55412a617bf823aa98) docs(hl-todo): Remove removed keybinding
