### PR TITLE
niv nixpkgs: update 9f387576 -> 184cf802

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -155,10 +155,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9f3875761628112140c969c0e7c59295158e09bd",
-        "sha256": "0r4yqgp8ql4vw35z2p3cvhpd1041xws8fkak3h58lyda8qd4djqc",
+        "rev": "184cf80254382ba91cc0a86af2cb62b8d9d94637",
+        "sha256": "0zw3bsc669gnhwjdw37gc93n1arsmpfnjb4djq3ihr2ck20zxavy",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/9f3875761628112140c969c0e7c59295158e09bd.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/184cf80254382ba91cc0a86af2cb62b8d9d94637.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@9f387576...184cf802](https://github.com/nixos/nixpkgs/compare/9f3875761628112140c969c0e7c59295158e09bd...184cf80254382ba91cc0a86af2cb62b8d9d94637)

* [`250359a4`](https://github.com/NixOS/nixpkgs/commit/250359a4d5b5afc71fe7fcd007f4999e5b187a3b) nixos/etc-overlay: mark `EROFS_FS` kernel configuration option as required
* [`98c23a61`](https://github.com/NixOS/nixpkgs/commit/98c23a61c3d0cce6bdfd12c76a5d72f4983a3a6d) nixos/networkmanager: add an `enableDefaultPlugins` option
* [`d91b76cb`](https://github.com/NixOS/nixpkgs/commit/d91b76cb89180d330c61d2a460f8553a7a8b6d33) chntpw: consistently use Debian's patches
* [`1c557a26`](https://github.com/NixOS/nixpkgs/commit/1c557a268af3b9513e6fe1d5458b4aa003ee9237) chntpw: refactor
* [`86783802`](https://github.com/NixOS/nixpkgs/commit/86783802bf4633b6cfbe62dfa46720d18e88b5b5) bluemap: 5.4 -> 5.7
* [`385cf708`](https://github.com/NixOS/nixpkgs/commit/385cf708bdfb6b707f91e5b1a2a7045185b3168b) verapdf: 1.26.4 -> 1.26.5
* [`8be1057f`](https://github.com/NixOS/nixpkgs/commit/8be1057f88cbffd2a44d1df8cb52f99849edbfdf) spark: 3.5.4 -> 3.5.5
* [`8b4477c3`](https://github.com/NixOS/nixpkgs/commit/8b4477c31170dd2ccf3dee3941def8070a1b260c) bitbox: 4.46.3 -> 4.47.2
* [`41f1eadb`](https://github.com/NixOS/nixpkgs/commit/41f1eadb7350d7fac73bcb71cf4cddacd416d28e) nixos/zeronsd: fix acl permissions
* [`86364855`](https://github.com/NixOS/nixpkgs/commit/8636485550a0842097b67a95f0216068fe6a7f77) persistent-evdev: don't use python3Packages
* [`ef4115bd`](https://github.com/NixOS/nixpkgs/commit/ef4115bd06d7dc7d796a5055fdf34339408baa8e) perlPackages.SubHandlesVia: 0.050000 -> 0.050002
* [`6fe1ce03`](https://github.com/NixOS/nixpkgs/commit/6fe1ce0392156a0ff87bd7160f86d7b17d04b263) perlPackages.AppSqitch: 1.5.0 -> 1.5.1
* [`3eb4b5c8`](https://github.com/NixOS/nixpkgs/commit/3eb4b5c8f2d0e13bec0b852384fa071f298fa88a) maintainers: add MCSeekeri
* [`b418b2aa`](https://github.com/NixOS/nixpkgs/commit/b418b2aa6782f1db0297a8c9ce18b532040fca31) neovimUtils.wrapNeovimUnstable: support vim.o.exrc
* [`5ea55be1`](https://github.com/NixOS/nixpkgs/commit/5ea55be1150850ea4cf48c3d0be6bad59399fa52) nextcloud31Packages.apps.recognize: fix compilation
* [`0bbeedc6`](https://github.com/NixOS/nixpkgs/commit/0bbeedc62cb8349a1cc06b6addc4220eaa48741f) bitbox: add comment explaining the need of Qt 5
* [`9c446b23`](https://github.com/NixOS/nixpkgs/commit/9c446b23e05091fc607809eb80257c8e88637739) geph: move to by-name
* [`fce2c054`](https://github.com/NixOS/nixpkgs/commit/fce2c054f665fc18b501932e9cf7d0f41d934caa) plex-media-player: drop
* [`64d418de`](https://github.com/NixOS/nixpkgs/commit/64d418def4ac3945357c958bccedb2595e8283fb) edusong: update hash for updated upstream
* [`be4069b7`](https://github.com/NixOS/nixpkgs/commit/be4069b7da7dfa754198bf158bd2a116ac74da25) edusong: harmonize description and longDescription with the other two MOE fonts
* [`00adb096`](https://github.com/NixOS/nixpkgs/commit/00adb0968ce8592db442d4f30bf5a3494a45e101) edusong: ensure correct filename in installPhase
* [`56a66ce9`](https://github.com/NixOS/nixpkgs/commit/56a66ce90a060146edd6117f9b0eecc885827dab) cantata: 2.5.0 -> 3.3.1
* [`b1f58fc1`](https://github.com/NixOS/nixpkgs/commit/b1f58fc1ca542738506489417004b8552e147e79) python3Packages.pluthon: 1.0.0 -> 1.1.0
* [`bb4ba2ab`](https://github.com/NixOS/nixpkgs/commit/bb4ba2ab1c9135561db8b5db202ce0d288f100bf) starship: add xonsh shell configuration
* [`4d4f431f`](https://github.com/NixOS/nixpkgs/commit/4d4f431ff79e70ffd9450e0b7f24a9e6aa587d9e) nixos/nh: allow flake uris
* [`cb445941`](https://github.com/NixOS/nixpkgs/commit/cb4459412af0f7d786ef55b64dd2b168fff320bd) nixos/stash: fix empty immutable plugins
* [`8758e3fe`](https://github.com/NixOS/nixpkgs/commit/8758e3fe227eedea2d0b012a955df813dfbb57dd) flashspace: 2.3.29 -> 3.3.39
* [`0d3967d6`](https://github.com/NixOS/nixpkgs/commit/0d3967d62cfc59a702cf26f30e20bc831e569e28) openssh: Add ssh-keysign patch note
* [`2b946599`](https://github.com/NixOS/nixpkgs/commit/2b946599989e011952ab41b84b3076f16ba564ba) openssh: Add locale archive patch note
* [`5314fe94`](https://github.com/NixOS/nixpkgs/commit/5314fe947d135936ae813fd582248f933fee85d0) taldir: init at 1.0.5
* [`f1047043`](https://github.com/NixOS/nixpkgs/commit/f104704356141d9ad604c92adef8aa7dbde99aa6) pioneer: 20250203 -> 20250501
* [`adbada07`](https://github.com/NixOS/nixpkgs/commit/adbada07745fd30cdbcf275455ddd565cc09a6e9) complgen: 0.3.0 -> 0.4.0
* [`2a2e6cef`](https://github.com/NixOS/nixpkgs/commit/2a2e6cef05bef1aaeec08c75d4ff336bd03a5592) papirus-icon-theme: 20250201 -> 20250501
* [`03c2fa78`](https://github.com/NixOS/nixpkgs/commit/03c2fa7846253824cbaa9e4c90943dcec1805712) gitversion: 5.12.0 -> 6.3.0
* [`aa4b5e16`](https://github.com/NixOS/nixpkgs/commit/aa4b5e16330a49115c67bbfd053c5836cb08da22) simple-live-app: 1.7.7 -> 1.8.3
* [`025ea0ed`](https://github.com/NixOS/nixpkgs/commit/025ea0ed9c959c04c7bbaee1a6b6d0c5346b0edf) lidarr: 2.10.3.4602 -> 2.11.2.4629
* [`f708d949`](https://github.com/NixOS/nixpkgs/commit/f708d94952b3be34e5760bcd76d537321f359301) protoc-gen-twirp_php: 0.13.0 -> 0.14.0
* [`8aa21018`](https://github.com/NixOS/nixpkgs/commit/8aa2101862fc998f10d26c32bbe7ab2981b2e8aa) linuxkit: 1.5.3 -> 1.6.0
* [`f77be466`](https://github.com/NixOS/nixpkgs/commit/f77be466ad3f7166cb9159fe3f07f417242283de) python3Packages.python-kadmin-rs: 0.5.3 -> 0.6.0
* [`6f0e6618`](https://github.com/NixOS/nixpkgs/commit/6f0e661871bd17afa272a24d580bb3d6dff7330a) glab: 1.56.0 -> 1.57.0
* [`60c80819`](https://github.com/NixOS/nixpkgs/commit/60c8081932c417f6fe37f964e3e7b0ce92532bf5) instead: 3.3.2 -> 3.5.2
* [`5781ef6d`](https://github.com/NixOS/nixpkgs/commit/5781ef6de9ff4d3ed6b8ce2f8526825878a850aa) nixos/systemd/networkd: allow passing flow control fields to link
* [`608ed37f`](https://github.com/NixOS/nixpkgs/commit/608ed37f04423f19d324830106b6dd652070e6e5) pipenv: 2024.4.1 -> 2025.0.2
* [`1b71ecce`](https://github.com/NixOS/nixpkgs/commit/1b71ecce98809f9cbacfb968775e293675b8e657) ncdu_1: 1.18.1 -> 1.22
* [`f5871d0d`](https://github.com/NixOS/nixpkgs/commit/f5871d0d3a91f6acbf25f4a046c19612acd46645) ncdu_1: modernize
* [`dc32142e`](https://github.com/NixOS/nixpkgs/commit/dc32142ed290dcd3e701aaf7c616caf7ea550d0d) tabby: 0.27.1 -> 0.28.0
* [`7dcfedb8`](https://github.com/NixOS/nixpkgs/commit/7dcfedb8b534df30d29688a34caf49f1277d42d3) logcheck: 1.4.3 -> 1.4.4
* [`c0826d81`](https://github.com/NixOS/nixpkgs/commit/c0826d818e47d5b98d3c2310543f3e6ef284aa36) soundfont-generaluser: 1.471 -> 2.0.2-unstable-2025-04-21, adopt and modernize
* [`92c9c83b`](https://github.com/NixOS/nixpkgs/commit/92c9c83bde3cf45033db0e116360f0d0ceaa032a) wasabiwallet: 2.5.1 -> 2.6.0
* [`7b246ee8`](https://github.com/NixOS/nixpkgs/commit/7b246ee81e8155cd745966a53128002bd70e9b3b) stackql: 0.7.131 -> 0.8.141
* [`721bd297`](https://github.com/NixOS/nixpkgs/commit/721bd297b16f8a5c113f387af9f2620fc8e5af76) perlPackages.UUID4Tiny: add loongarch64 and riscv64 support
* [`66afc79d`](https://github.com/NixOS/nixpkgs/commit/66afc79dcdf2c74a0704bc648dc1c44cf1117608) spicedb: add shell completion
* [`0be588e1`](https://github.com/NixOS/nixpkgs/commit/0be588e1fa95f126e17e8cf0b4e525ac8c1696d2) fsmon: 1.8.6 -> 1.8.8
* [`aabcf2a8`](https://github.com/NixOS/nixpkgs/commit/aabcf2a8c1f4db2a0c219a1bd573122f445a3a6e) calico-app-policy: 3.29.3 -> 3.30.0
* [`9298a94f`](https://github.com/NixOS/nixpkgs/commit/9298a94f63454c3685c6985f61ab74d19abf0b65) calico-apiserver: 3.29.3 -> 3.30.0
* [`092f5886`](https://github.com/NixOS/nixpkgs/commit/092f5886231735d4997be7e91e29ad9241596c58) couchdb3: 3.4.3 -> 3.5.0
* [`5e6ab3c3`](https://github.com/NixOS/nixpkgs/commit/5e6ab3c31d1158c10bc1b8243139601ac9e551b1) lcrq: 0.2.3 -> 0.2.4
* [`8ef15218`](https://github.com/NixOS/nixpkgs/commit/8ef1521854403e4a7dc2068d79f62e9bf81c3bc5) flycast: 2.4 -> 2.5
* [`681138f5`](https://github.com/NixOS/nixpkgs/commit/681138f501712a3c53596d4c89472a2a05e7847e) ktls-utils: 0.11 -> 1.0.0
* [`d7626b2f`](https://github.com/NixOS/nixpkgs/commit/d7626b2f9579680ff6c75cf0a3f5e5bfc2c8169c) asus-wmi-sensors: drop
* [`cb844fda`](https://github.com/NixOS/nixpkgs/commit/cb844fda2ed473c1ae2ebd6668a3263a4ced3675) fishPlugins.macos: 7.0.0 -> 7.0.1
* [`36459b8f`](https://github.com/NixOS/nixpkgs/commit/36459b8fe14e44b9f49047198864f860c0177207) fishPlugins.macos: add updateScript
* [`7491fdf6`](https://github.com/NixOS/nixpkgs/commit/7491fdf61f3b294f396f6cfccac1d12ce5b600ed) kid3: enable build flag WITH_MP4V2
* [`4cb99639`](https://github.com/NixOS/nixpkgs/commit/4cb99639e1d7399ce570d812198663871bc0bd12) spades: 4.1.0 -> 4.2.0
* [`ca5eecbf`](https://github.com/NixOS/nixpkgs/commit/ca5eecbfa9df51b13bcfe7f5f5f26a712f5c919c) signing-party: 2.11 -> 2.12
* [`a4ed0bdf`](https://github.com/NixOS/nixpkgs/commit/a4ed0bdf6abeb32e28cbc0736718c2e562e42d9d) aws-signing-helper: 1.5.0 -> 1.6.0
* [`190b4b2f`](https://github.com/NixOS/nixpkgs/commit/190b4b2f2f9b816bd11acdb71fe5bdfd673a333d) python3Packages.gst-python: fix darwin build
* [`b73d59b3`](https://github.com/NixOS/nixpkgs/commit/b73d59b3f6c525c138ebc76a1b49cb6f60f3e773) maintainers: add dwt
* [`a9d9fe91`](https://github.com/NixOS/nixpkgs/commit/a9d9fe915a87097e39f19b2e60ee3c0256454e5f) trippy: 0.12.2 -> 0.13.0
* [`ce9dd961`](https://github.com/NixOS/nixpkgs/commit/ce9dd9614850c50a4abe2958439956d14ffe6d48) certspotter: 0.18.0 -> 0.19.1
* [`3779c776`](https://github.com/NixOS/nixpkgs/commit/3779c776e0bbb08100df9c14732a699a95fbb9d3) mieru: 3.14.1 -> 3.15.0
* [`ae078850`](https://github.com/NixOS/nixpkgs/commit/ae078850cc437c3301b7b93c3820247dcf5dec0c) museeks: 0.13.1 -> 0.20.9
* [`5e069988`](https://github.com/NixOS/nixpkgs/commit/5e06998896fce360d2543b014174c44af358eb99) camunda-modeler: 5.34.0 -> 5.35.0
* [`7ba7b707`](https://github.com/NixOS/nixpkgs/commit/7ba7b707400f5ef91ff19a4f1a14c73d0b6f4c5d) skaffold: 2.15.0 -> 2.16.0
* [`321d3dbb`](https://github.com/NixOS/nixpkgs/commit/321d3dbbbdd5544060453e89dd222c7e6527862e) percona-server_8_0: fix compiling on darwin
* [`03ea79a2`](https://github.com/NixOS/nixpkgs/commit/03ea79a2b9ee3f7474d0762df96d96ab1580a9cb) maintainers: add dashietm
* [`10fd5bca`](https://github.com/NixOS/nixpkgs/commit/10fd5bcad9e9463dedc932fcfc9e600492fed350) adaptivecppWithCuda: 24.10.0 -> 25.02.0
* [`afd8ea80`](https://github.com/NixOS/nixpkgs/commit/afd8ea80b8841e8f27569cfcda682cff954ebb2b) harmony-music: 1.11.2 -> 1.12.0
* [`e2fee0d4`](https://github.com/NixOS/nixpkgs/commit/e2fee0d48b01f91df3c9e872e6efdb13131750ee) python3Packages.jupyterlab-git: refactor
* [`9a54dd36`](https://github.com/NixOS/nixpkgs/commit/9a54dd36f14a93d7cdbc3bfb0d63cf51f5eb6869) python3Packages.jupyterlab-git: build from source
* [`2035aa58`](https://github.com/NixOS/nixpkgs/commit/2035aa58e88b15868ec5682ea0841ca24bcf9d32) oneDNN: 3.7.3 -> 3.8
* [`1b28532c`](https://github.com/NixOS/nixpkgs/commit/1b28532c6684dc8095bcd4b9fa1280c12f451db5) steampipePackages.steampipe-plugin-azure: 1.3.0 -> 1.4.0
* [`4e47fae2`](https://github.com/NixOS/nixpkgs/commit/4e47fae23495d499c63ab951446653474b4cdfe6) kokkos: 4.6.00 -> 4.6.01
* [`a9895197`](https://github.com/NixOS/nixpkgs/commit/a9895197dc99fc92e2f79a7ff6ce315c53f07c43) maintainers: add sinjin2300
* [`e3352ec0`](https://github.com/NixOS/nixpkgs/commit/e3352ec0b8ba3f14e345810796c668527e05fa0e) nnd: init at 0.19
* [`49545155`](https://github.com/NixOS/nixpkgs/commit/495451554fc9e53e47dc86ece5f6e5c4736566b2) deja-dup: 47.0 -> 48.1
* [`430c7b3f`](https://github.com/NixOS/nixpkgs/commit/430c7b3f7b98ae364717a43489578dfda1950d1e) localstack: 4.3.0 -> 4.4.0
* [`2549b34e`](https://github.com/NixOS/nixpkgs/commit/2549b34e16e76b694309775fbc2dde9469d2e887) rbdoom-3-bfg: 1.5.1 -> 1.6.0
* [`54f6305b`](https://github.com/NixOS/nixpkgs/commit/54f6305b0a4a2547a89db7557e412fd3a8395430) srm-cuarzo: 0.12.0-1 -> 0.12.1-1
* [`13130a25`](https://github.com/NixOS/nixpkgs/commit/13130a258b16b9f10e33a2c97c3ac2ad73373ca0) python3Packages.phonopy: 2.37.0 -> 2.38.2
* [`b6739b82`](https://github.com/NixOS/nixpkgs/commit/b6739b829a505a401b24f6f2285999bb85e45224) ncgopher: 0.5.0 -> 0.7.0
* [`ddb404fb`](https://github.com/NixOS/nixpkgs/commit/ddb404fb94658455449f62d418cf090d56d41e6d) google-cloud-sql-proxy: 2.15.3 -> 2.16.0
* [`86a5b55c`](https://github.com/NixOS/nixpkgs/commit/86a5b55c3a7b8349a32e1375f78376bdbddc3ccd) s3backer: 2.1.3 -> 2.1.4
* [`9cb162fe`](https://github.com/NixOS/nixpkgs/commit/9cb162fe8db4f3d335afac9c994854afbde59388) cloudlog: 2.6.17 -> 2.6.18
* [`dacbb17c`](https://github.com/NixOS/nixpkgs/commit/dacbb17c19362f84d9fa3f9690d04ae33ea5e585) bazarr: 1.5.1 -> 1.5.2
* [`9fb331fa`](https://github.com/NixOS/nixpkgs/commit/9fb331fa8ca76a636754aca3920769587cdc1240) python3Packages.netbox-contract: 2.3.2 -> 2.4.0
* [`a53fec1e`](https://github.com/NixOS/nixpkgs/commit/a53fec1ececc0701f6bcfc9661733e8f856db770) batik: 1.18 -> 1.19
* [`d7620780`](https://github.com/NixOS/nixpkgs/commit/d76207806846212bf50c8f87c7969f4c296e2900) octavePackages.mapping: 1.4.2 -> 1.4.3
* [`b0440680`](https://github.com/NixOS/nixpkgs/commit/b04406805ef6fa3894ede8cc7e0ba8c0223032b1) octavePackages.mapping: Propagate gdal input to runtime
* [`6fc882a9`](https://github.com/NixOS/nixpkgs/commit/6fc882a95d55a392db5474ea7b84acbbf559a9df) pixelflasher: 7.11.4.0 -> 8.0.1.0
* [`fb82c84b`](https://github.com/NixOS/nixpkgs/commit/fb82c84bfe08d5a1fa69b68678be429910bce67a) conan: 2.15.1 -> 2.16.1
* [`7532d742`](https://github.com/NixOS/nixpkgs/commit/7532d742424a6a280a1a9ab6ec539f8f9565d162) task-keeper: 0.28.1 -> 0.29.0
* [`8d997917`](https://github.com/NixOS/nixpkgs/commit/8d99791752a28317deb8021079270c75df9e59a5) noson: 5.6.8 -> 5.6.10
* [`a17acc0b`](https://github.com/NixOS/nixpkgs/commit/a17acc0bec26718f79171e9adeb0a20b4dfbb8ee) vengi-tools: 0.0.36 -> 0.0.37
* [`48d1692a`](https://github.com/NixOS/nixpkgs/commit/48d1692a26f8542b8493ff74590087941991ef4b) kyverno: 1.14.0 -> 1.14.1
* [`db170a9c`](https://github.com/NixOS/nixpkgs/commit/db170a9c623dc81a7fe38c10ad2f23c18f0e74bf) clazy: 1.13 -> 1.14
* [`89a5f4bb`](https://github.com/NixOS/nixpkgs/commit/89a5f4bb4084e91290a1f290e1c7de867ea00a0a) rocketchat-desktop: 4.3.3 -> 4.4.0
* [`31f97990`](https://github.com/NixOS/nixpkgs/commit/31f979909c195e03a196f38a072d5832bb7b436f) iroh: 0.34.1 -> 0.35.0
* [`13be3127`](https://github.com/NixOS/nixpkgs/commit/13be312711b1a62dcd5ec6af5f26f03ecfd0ed8d) dumbpipe: 0.26.0 -> 0.27.0
* [`01839ab6`](https://github.com/NixOS/nixpkgs/commit/01839ab67e532db7c7d5fad044d944698c297f37) stratisd: 3.7.3 -> 3.8.0
* [`bd4266a6`](https://github.com/NixOS/nixpkgs/commit/bd4266a607c027fdfd520d2da06628e0ebe2d8e4) stratis-cli: 3.7.0 -> 3.8.0
* [`475dd3fe`](https://github.com/NixOS/nixpkgs/commit/475dd3fe95fe54aa790ebfc7c9beff49626c3dea) nixos/stratis: fix test
* [`6b73c05f`](https://github.com/NixOS/nixpkgs/commit/6b73c05fa43fdb03c338a86613f2f8c319a60933) stratisd: 3.8.0 -> 3.8.1
* [`227cc6ec`](https://github.com/NixOS/nixpkgs/commit/227cc6ec73285aee55c41472c3158c7743923aeb) stratis-cli: 3.8.0 -> 3.8.1
* [`530c1394`](https://github.com/NixOS/nixpkgs/commit/530c13944813d0b1b7caed631257bf1b71b00ebd) perlPackages.ApacheDB: unbreak on Darwin
* [`d35f21ec`](https://github.com/NixOS/nixpkgs/commit/d35f21ec470e7e75a71dc7a317c279dac806ed2e) perlPackages.DBDsybase: unbreak on Darwin
* [`0598f4b0`](https://github.com/NixOS/nixpkgs/commit/0598f4b0bfa682fcdcaac1991f1e18042972408b) perlPackages.FileLibMagic: unbreak on Darwin
* [`b860376d`](https://github.com/NixOS/nixpkgs/commit/b860376d83f0f5af5f3ccc7a81de0a03edcdae24) perlPackages.DataUtil: unbreak on Darwin
* [`f09a42bc`](https://github.com/NixOS/nixpkgs/commit/f09a42bc01ce3f3a22bb7d61db970ec923b1f87b) perlPackages.DataMessagePack: unbreak on Darwin and fix description
* [`34ce4c79`](https://github.com/NixOS/nixpkgs/commit/34ce4c790091ded1ab2b1c4597c4d796cd370360) perlPackages.HTMLEscape: unbreak on Darwin
* [`46bd5876`](https://github.com/NixOS/nixpkgs/commit/46bd58768a12d2047ab4a93e3778fc09e2611d0b) perlPackages.MaxMindDBReaderXS: unbreak on Darwin
* [`dd87890f`](https://github.com/NixOS/nixpkgs/commit/dd87890fa3aff2ec73214f84b3b8b2195e1c7042) perlPackages.TextIconv: unbreak on Darwin
* [`cde5ca50`](https://github.com/NixOS/nixpkgs/commit/cde5ca5093ae059737bb30be27b2635b94d904a8) perlPackages.AlienLibGumbo: mark as broken on Linux instead of Darwin
* [`451b6bc2`](https://github.com/NixOS/nixpkgs/commit/451b6bc25220e2e67b58f6f0d5adda25cf5d34d8) perlPackages.SysVirt: unbreak on Darwin
* [`466e7e1d`](https://github.com/NixOS/nixpkgs/commit/466e7e1da652ec53578eb9ebd6a2b109e9380581) perlPackages.MaxMindDBWriter: unbreak on Darwin
* [`06296f6b`](https://github.com/NixOS/nixpkgs/commit/06296f6b11f3b7184ee68430b0d1bc72d0eddc5e) CONTRIBUTING: Add guideline to verify package upstreams
* [`c3b702e9`](https://github.com/NixOS/nixpkgs/commit/c3b702e94a6f6131e73be050d217ca646a81ee4b) remotebox: 3.5 -> 3.6
* [`7970325e`](https://github.com/NixOS/nixpkgs/commit/7970325edbd3ec479b86907bce31f3af885858ba) pidginPackages.pidgin-sipe: fix compilation error with libxml2
* [`d8403672`](https://github.com/NixOS/nixpkgs/commit/d840367223bf9cb44db8392ed97e9fbd9f337937) exult: 1.10.1 -> 1.12.0
* [`cd21e413`](https://github.com/NixOS/nixpkgs/commit/cd21e4131cda290d289dd914ac2be4f8f89762b7) pm2: 5.4.2 -> 6.0.6
* [`ec979d57`](https://github.com/NixOS/nixpkgs/commit/ec979d57b7b62069b45212679ae334018bf74d99) fh: 0.1.22 -> 0.1.24
* [`a94dd454`](https://github.com/NixOS/nixpkgs/commit/a94dd454e915e7c6308ebd51788d43468c079c25) convmv: add dependencies to support additional encodings
* [`07587e8c`](https://github.com/NixOS/nixpkgs/commit/07587e8c9d75e47ac9dfa83663fded4bb61c068c) convmv: add split `bin` output
* [`be8bc65e`](https://github.com/NixOS/nixpkgs/commit/be8bc65ebf94cf07d8e8c1d9f02ec9ecc964b97a) libcifpp: 8.0.0 -> 8.0.1
* [`53d9e997`](https://github.com/NixOS/nixpkgs/commit/53d9e997d491586581cfa0961cc3f913ea53a609) ec2-instance-selector: init at 3.1.1
* [`c3c67e15`](https://github.com/NixOS/nixpkgs/commit/c3c67e15f5e1e15fa9f336719a77d52525a15954) maintainer-list: add wcarlsen
* [`1f0ade48`](https://github.com/NixOS/nixpkgs/commit/1f0ade48d9d10c309f6bdde66258388b134e7f3f) goto: remove updateScript
* [`92cd2635`](https://github.com/NixOS/nixpkgs/commit/92cd263515782c76765c8dcd28eeda46fc9586b5) jdk17: 17.0.14+7 -> 17.0.15+6
* [`7124548d`](https://github.com/NixOS/nixpkgs/commit/7124548dd73fd3248435fc28c0dd0913b5f19630) ftxui: 6.0.2 -> 6.1.9
* [`a29ef95f`](https://github.com/NixOS/nixpkgs/commit/a29ef95f66182b4657f2e7374a85718242b1c1ef) fittrackee: 0.9.8 -> 0.9.10
* [`3af1f87c`](https://github.com/NixOS/nixpkgs/commit/3af1f87c5ddf8d7d98067d16904b7a5c4e2c4622) traefik: 3.3.6 -> 3.4.0
* [`bd9e669d`](https://github.com/NixOS/nixpkgs/commit/bd9e669d49a2de16f4065715f05713dda585c605) edl: 3.52.1-unstable-2025-04-16 -> 3.52.1-unstable-2025-05-05
* [`d1f03e00`](https://github.com/NixOS/nixpkgs/commit/d1f03e00bf09fe0d237bfa64a5fb41ae17ebd579) pykickstart: 3.63 -> 3.64
* [`95a230e3`](https://github.com/NixOS/nixpkgs/commit/95a230e3bb7f543f1fcc2cfe6d9241bf047c3f4c) python313Packages.opensfm: fix build, fixup, add maintainer pbsds
* [`8f7ed703`](https://github.com/NixOS/nixpkgs/commit/8f7ed70339c26ece5a1efaadd5960a29f7b51555) k6: 0.57.0 -> 1.0.0
* [`10ca5df5`](https://github.com/NixOS/nixpkgs/commit/10ca5df52df37a5cecf0adeee5c2c210df348dc7) antidote: 1.9.8 -> 1.9.10
* [`41f8da4e`](https://github.com/NixOS/nixpkgs/commit/41f8da4e9bd83d36fa6644d2490de28c67a7f0ea) kbld: 0.45.2 -> 0.46.0
* [`f6fcf635`](https://github.com/NixOS/nixpkgs/commit/f6fcf635fc5fb64219d518372795c674bd3e41be) rhvoice: 1.16.4 -> 1.16.5
* [`a5a392ba`](https://github.com/NixOS/nixpkgs/commit/a5a392ba60935a443b3f4aa9766542b4923efd95) ckbcomp: 1.236 -> 1.237
* [`306fdc57`](https://github.com/NixOS/nixpkgs/commit/306fdc573b6f08296fb83695b704cbbbf69b3da2) android-file-transfer: 4.4 -> 4.5
* [`0804d548`](https://github.com/NixOS/nixpkgs/commit/0804d548c04a24c0071ce121847aa295c2af3150) matrix-synapse-plugins.matrix-synapse-mjolnir-antispam: 1.9.2 -> 1.10.0
* [`8558cb78`](https://github.com/NixOS/nixpkgs/commit/8558cb783c80f3a39ec99756d5033a7f22c8ebb2) clearlooks-phenix: 7.0.1 -> 7.1
* [`79afd57f`](https://github.com/NixOS/nixpkgs/commit/79afd57f4037e8e9612145c25c9290f551441106) apptainer-overriden-nixos: 1.4.0 -> 1.4.1
* [`d1e73a2a`](https://github.com/NixOS/nixpkgs/commit/d1e73a2a93cbe95a33531a95998567f32dfc0241) oxidized: add ssh support
* [`44d2883c`](https://github.com/NixOS/nixpkgs/commit/44d2883c7c8ab7454e7ef12baa907f67ce69c053) gopher: 3.0.17 -> 3.0.18
* [`7e42e443`](https://github.com/NixOS/nixpkgs/commit/7e42e4431b0692c4968c4114d977aa311969a774) virtualisation/docker: fix nvidia container wrapper
* [`aaecce0f`](https://github.com/NixOS/nixpkgs/commit/aaecce0f1e6888b79a3f588db9da44f6479cfa5d) vcluster: 0.24.1 -> 0.25.0
* [`15ab2fee`](https://github.com/NixOS/nixpkgs/commit/15ab2fee72b3d1de5f4b5ed12a5b22deece0f266) syncstorage-rs: 0.18.2 -> 0.18.3
* [`54ff56ff`](https://github.com/NixOS/nixpkgs/commit/54ff56ff659eeba8c61639aaedfb8ac35b26b10e) raspberrypi-eeprom: 2025.03.10-2712 -> 2025.05.08-2712
* [`bed60068`](https://github.com/NixOS/nixpkgs/commit/bed600685bb42f4562f4e7a49b363185b754b588) python3Packages.kopf: 1.37.5 -> 1.38.0
* [`c22d65b9`](https://github.com/NixOS/nixpkgs/commit/c22d65b91674d478ed6faaba8889a69dd5063b86) quickjs: 2024-01-13 -> 2025-04-26
* [`095f6893`](https://github.com/NixOS/nixpkgs/commit/095f6893c9861589fcfa261be52a44a0adce2142) perlPackages.CryptOpenSSLRSA: 0.33 -> 0.35
* [`e50edd16`](https://github.com/NixOS/nixpkgs/commit/e50edd162befd42b359bc3eae2dad1e63719c7ba) connman: apply patches for CVE-2025-32366 and CVE-2025-32743
* [`b2a3a90e`](https://github.com/NixOS/nixpkgs/commit/b2a3a90e425b1dbd4babfe6cb80510526dbf5a44) nixpacks: 1.37.0 -> 1.39.0
* [`89ab522e`](https://github.com/NixOS/nixpkgs/commit/89ab522e7275732238b4ad16618942529d396d05) cri-o-unwrapped: 1.32.4 -> 1.33.0
* [`c6de44dd`](https://github.com/NixOS/nixpkgs/commit/c6de44dd95fb2d89798591bb756fb127cff49316) arti: 1.4.2 -> 1.4.3
* [`448b3a12`](https://github.com/NixOS/nixpkgs/commit/448b3a121bbf6eda284e4daa6f9debd720375c42) mautrix-gmessages: 0.6.1 -> 0.6.2
* [`46fab456`](https://github.com/NixOS/nixpkgs/commit/46fab4562740b07b519f245b0133946dc654f24a) meowlnir: 0.3.0 -> 0.5.0
* [`0359b985`](https://github.com/NixOS/nixpkgs/commit/0359b985751997c0c4caeb51fa6b5ea5cfc5c2ef) lomiri.mediascanner2: 0.117 -> 0.118
* [`4f318ef2`](https://github.com/NixOS/nixpkgs/commit/4f318ef2444ff03e5067ce441f9cc7f151bce1ac) sublime-merge-dev: 2105 -> 2108
* [`9b841f2f`](https://github.com/NixOS/nixpkgs/commit/9b841f2f53334187f005517b23908fbb36e5d26a) lomiri.lomiri-url-dispatcher: 0.1.3 -> 0.1.4
* [`6f5ca91a`](https://github.com/NixOS/nixpkgs/commit/6f5ca91a70db86afbca1b576a1b725d9346f911d) jove: 4.17.5.3 -> 4.17.5.5
* [`ae335624`](https://github.com/NixOS/nixpkgs/commit/ae335624fc2ccda599d4ad7b9987d059aeb12ce9) jellyfin-ffmpeg: 7.1.1-1 -> 7.1.1-3
* [`e024f6ed`](https://github.com/NixOS/nixpkgs/commit/e024f6ed061ec04d79104f0cbd8b58662736881e) sentry-cli: 2.43.1 -> 2.45.0
* [`26013484`](https://github.com/NixOS/nixpkgs/commit/26013484522904d61e8b8f14f16a734647ac734b) pdftitle: 0.18 -> 0.20
* [`a86c7800`](https://github.com/NixOS/nixpkgs/commit/a86c7800c282178863b7b5ac4928711344ba4cd1) zwave-js-server: 3.0.0 -> 3.0.2
* [`e7c94367`](https://github.com/NixOS/nixpkgs/commit/e7c9436738a301cacb8348a5d9d5d40b5615029a) mxt-app: 1.42 -> 1.43
* [`fe22541e`](https://github.com/NixOS/nixpkgs/commit/fe22541e74555fc87dd541e0d7c41d13adff3bde) nvidia-container-toolkit: 1.17.6 -> 1.17.7
* [`b74592d0`](https://github.com/NixOS/nixpkgs/commit/b74592d07fb97654e0d6628ccedc317f29be5be5) obs-studio-plugins.obs-move-transition: 3.1.2 -> 3.1.3
* [`96b63e5c`](https://github.com/NixOS/nixpkgs/commit/96b63e5c0ccf9303c78f87a4495f668a1edf720f) rmapi: 0.0.29 -> 0.0.30
* [`8aa06f33`](https://github.com/NixOS/nixpkgs/commit/8aa06f3361572892050cfc6b8addd5f11a6d5f6c) networkmanager_dmenu: 2.6.0 -> 2.6.1
* [`eb6d1a08`](https://github.com/NixOS/nixpkgs/commit/eb6d1a086e5d4c002cc054563ffb3c18439cb9de) cargo-tauri.hook: fix installation when $out already exists
* [`31b15b02`](https://github.com/NixOS/nixpkgs/commit/31b15b02efeab05be907881e82c96cda67c49ea3) monit: 5.35.1 -> 5.35.2
* [`93f22acb`](https://github.com/NixOS/nixpkgs/commit/93f22acb535119b6c5e5599e72ed1609f7b17e3e) gnome-extension-manager: 0.6.1 -> 0.6.3
* [`a22fa794`](https://github.com/NixOS/nixpkgs/commit/a22fa7944a3134d85c329d0fcf1014c200ab2212) mvnd: fix build with graalvm-ce 24
* [`b73d9d23`](https://github.com/NixOS/nixpkgs/commit/b73d9d23d076c31e4ef00b3e2901447d18fc31d2) apko: 0.27.2 -> 0.27.6
* [`82196d04`](https://github.com/NixOS/nixpkgs/commit/82196d04149654f740cb2c455cea118330465bca) httm: 0.47.0 -> 0.47.1
* [`0ea65a68`](https://github.com/NixOS/nixpkgs/commit/0ea65a68a70906ea8ca0889942c7f19d45ccb43e) python3Packages.django-celery-beat: 2.8.0 -> 2.8.1
* [`9d1654b9`](https://github.com/NixOS/nixpkgs/commit/9d1654b9816a582b84a4965b962b8091d5c69106) edmarketconnector: init at 5.13.1
* [`bc8ee2f8`](https://github.com/NixOS/nixpkgs/commit/bc8ee2f85190d32f939c8a6c028d70b9dc326ab7) llvmPackages_20: 20.1.4 -> 20.1.5
* [`4f2a13ee`](https://github.com/NixOS/nixpkgs/commit/4f2a13eea418376177e9062fc0d41e3888d5e082) kubevela: 1.10.2 -> 1.10.3
* [`596df5fc`](https://github.com/NixOS/nixpkgs/commit/596df5fc813f11540b6ad646029d2eeea0e983e2) waypaper: add prince213 to maintainers
* [`3a79524c`](https://github.com/NixOS/nixpkgs/commit/3a79524cfb0cdc6e52cc702cf92b71864878a9f0) waypaper: 2.5 -> 2.6
* [`b685d78a`](https://github.com/NixOS/nixpkgs/commit/b685d78a3a33b3f13955c71239d79d24e3acb2dd) waypaper: use python3Packages
* [`11ac85f5`](https://github.com/NixOS/nixpkgs/commit/11ac85f54cb8a82eca45aa40f359019a261cfa7c) waypaper: avoid with lib;
* [`08a2c0fa`](https://github.com/NixOS/nixpkgs/commit/08a2c0fa0dd924234146cc231fd18fbcd85b0471) pspg: 5.8.10 -> 5.8.11
* [`746d6e3b`](https://github.com/NixOS/nixpkgs/commit/746d6e3b28ffebf45e9951aa7393656344e535f9) autocorrect: 2.13.3 -> 2.14.0
* [`3a9aacdc`](https://github.com/NixOS/nixpkgs/commit/3a9aacdc6410f6c3c691e7e6286e5f32ef936474) myanon: 0.6 -> 0.7
* [`26ea5dc6`](https://github.com/NixOS/nixpkgs/commit/26ea5dc66e4ddabe09f41c0f26d3f69b67139b4e) rizin: 0.7.4 -> 0.8.1
* [`08a3f21a`](https://github.com/NixOS/nixpkgs/commit/08a3f21a5f6265dbfcc9f71c663a460acf49a65c) cutter: 2.3.4 -> 2.4.1
* [`685bceab`](https://github.com/NixOS/nixpkgs/commit/685bceab6439413301104b495d9c6ec1317ec02b) cutterPlugins.jsdec: 0.7.0 -> 0.8.0
* [`c239380c`](https://github.com/NixOS/nixpkgs/commit/c239380cc042ba77c1ec89e056a2c419191987ae) cutterPlugins.rz-ghidra: 0.7.0 -> 0.8.0
* [`1d277600`](https://github.com/NixOS/nixpkgs/commit/1d2776003776234c7eb05a6eaa0ad73261b15af0) mcat: init at 0.2.8
* [`83311879`](https://github.com/NixOS/nixpkgs/commit/833118797651cc67fdd21d24af2e959c1e49276d) Google Authenticator 2FA support over XRDP
* [`ab5bbdad`](https://github.com/NixOS/nixpkgs/commit/ab5bbdad9ce7dea4e9495d156837dca97eca6c76) hydra: 0-unstable-2025-04-16 -> 0-unstable-2025-04-23
* [`af4b6cba`](https://github.com/NixOS/nixpkgs/commit/af4b6cba1c8c094107b2ac661530fcba693da2dd) python3Packages.sumo: 2.3.11 -> 2.3.12
* [`7dcad49a`](https://github.com/NixOS/nixpkgs/commit/7dcad49a3007f2fc7bd3795b9ffa2abadf1a3d4a) nixos/stash: fix mutableSettings logic
* [`28dd6a44`](https://github.com/NixOS/nixpkgs/commit/28dd6a442ddc0415a2f4deddf616c60f8b985aa1) pokefinder: 4.2.0 -> 4.2.1
* [`060162f4`](https://github.com/NixOS/nixpkgs/commit/060162f471b9c9302ae0c0412bd92122296a47ee) lla: 0.3.10 -> 0.3.11
* [`7988c45d`](https://github.com/NixOS/nixpkgs/commit/7988c45d0cc76ad0d91b4ddcbcbc230c2eb97fd7) vscode-js-debug: 1.97.1 -> 1.100.1
* [`6e902ba6`](https://github.com/NixOS/nixpkgs/commit/6e902ba6ee5a13dced7a533b474f57b41114c2c4) coroot: 1.10.1 -> 1.11.4
* [`870aa664`](https://github.com/NixOS/nixpkgs/commit/870aa66490ab17613b784d3792c6ecd363d0980a) azpainter: 3.0.11 -> 3.0.12
* [`293bb8f3`](https://github.com/NixOS/nixpkgs/commit/293bb8f3489419dde88799538cefac61fe2d150b) code-cursor: add prince213 to maintainers
* [`5aa3674a`](https://github.com/NixOS/nixpkgs/commit/5aa3674a6194922562409cedebf4a7c6c173c89a) code-cursor: use jq for update.sh
* [`f85a596e`](https://github.com/NixOS/nixpkgs/commit/f85a596e6e3a18c9f19731a33b71546de6be10bc) gojo: add installCheck
* [`58886090`](https://github.com/NixOS/nixpkgs/commit/58886090b72d78135090b4b1da1f7591bfc5665e) gojo: use finalAttrs style
* [`2e68a674`](https://github.com/NixOS/nixpkgs/commit/2e68a674bd80c8ac26013552dbb7abd2bab052c6) nixos/bees: fix option example
* [`346a4e2f`](https://github.com/NixOS/nixpkgs/commit/346a4e2f2c92ce76009e2ea075c0e89f9e072031) vault-tasks: 0.11.0 -> 0.11.1
* [`c4bcaa3d`](https://github.com/NixOS/nixpkgs/commit/c4bcaa3de46e65b7c6229e9360b2588423113b39) sitespeed-io: 37.4.2 -> 37.6.0
* [`472eb192`](https://github.com/NixOS/nixpkgs/commit/472eb192b073f6e39bee661353cfc0251b10b9b6) ath9k: fix build of old gmp by disabling compiler warnings
* [`1e25bba2`](https://github.com/NixOS/nixpkgs/commit/1e25bba2069709a55794ec7764924e0113081738) python3Packages.qpsolvers: 4.6.0 -> 4.7.0
* [`5525f06b`](https://github.com/NixOS/nixpkgs/commit/5525f06bf16f028751ed2973b52bf974bb353a4a) tryton: 7.4.7 -> 7.6.1
* [`49cb198d`](https://github.com/NixOS/nixpkgs/commit/49cb198d05894b7fa3770c42631ef7bcc13e37e7) tmuxPlugins.fingers: 2.4.0 -> 2.4.1
* [`c0e914f7`](https://github.com/NixOS/nixpkgs/commit/c0e914f71422311f7fea8b58c27ab60ad31383ea) containerlab: 0.67.0 -> 0.68.0
* [`182d5e4f`](https://github.com/NixOS/nixpkgs/commit/182d5e4fbcb40bc14145246d633fde170a96c526) k9s: 0.50.5 -> 0.50.6
* [`6186ef38`](https://github.com/NixOS/nixpkgs/commit/6186ef38a017e7ffca0502ec254bb41aade70661) k9s: add devusb to maintainers
* [`9abed4e0`](https://github.com/NixOS/nixpkgs/commit/9abed4e0e16ce02eaf1b32565d12d46d089308a8) clive: 0.12.9 -> 0.12.11
* [`962b58fc`](https://github.com/NixOS/nixpkgs/commit/962b58fcf2df7ed474461cc3c432c84f466a5cf7) irpf: 2025-1.2 -> 2025-1.3
* [`932c4ccf`](https://github.com/NixOS/nixpkgs/commit/932c4ccf4889fd6aa91b970c55b8ae44140e0b38) garnet: 1.0.64 -> 1.0.65
* [`d3bc871f`](https://github.com/NixOS/nixpkgs/commit/d3bc871f8f214bac7c163a1c3eebfd182d8b1531) metacubexd: 1.186.1 -> 1.187.1
* [`66a5e57a`](https://github.com/NixOS/nixpkgs/commit/66a5e57a82495a50874633984cef69092041401b) steampipe: 1.1.2 -> 1.1.3
* [`0239196a`](https://github.com/NixOS/nixpkgs/commit/0239196acb1be3f2d1a825f22f9e2c319e165053) codeql: 2.21.2 -> 2.21.3
* [`b76fcb92`](https://github.com/NixOS/nixpkgs/commit/b76fcb929cc8dee7805549c458726370a8c44fbb) wtfis: 0.10.2 -> 0.11.0
* [`3303249e`](https://github.com/NixOS/nixpkgs/commit/3303249ed2aa2131480737497abcee373e373216) nixos/syncthing: fix cert/key permission error
* [`4d49b3bc`](https://github.com/NixOS/nixpkgs/commit/4d49b3bc17ff683c3465eed33f05759a07f260e7) owncast: 0.2.0 -> 0.2.3
* [`a10c6a20`](https://github.com/NixOS/nixpkgs/commit/a10c6a2007e2215a6c97db6efad110c12b055b7b) python313Packages.granian: 2.2.5 -> 2.3.0
* [`1d474b9c`](https://github.com/NixOS/nixpkgs/commit/1d474b9c92ea0447ea7b85143c9a272fa1209e7e) narsil: 1.4.0-49-g64a513fe4 -> 1.4.0-50-g6cd6ce985
* [`9255da49`](https://github.com/NixOS/nixpkgs/commit/9255da49c615b5d4dc023dafe4457364513e3228) lbreakouthd: 1.1.9 -> 1.1.11
* [`d6db85cb`](https://github.com/NixOS/nixpkgs/commit/d6db85cb4fa1d5f3aed81b2fede651bc0c3b1793) avizo: 1.3 -> 1.3-unstable-2024-11-03
* [`e2c67d0a`](https://github.com/NixOS/nixpkgs/commit/e2c67d0aca9b478a716171703b478a71e0c2db35) velero: 1.16.0 -> 1.16.1
* [`27742275`](https://github.com/NixOS/nixpkgs/commit/27742275c0ff6a5209c91779d19f74e4c25ecc10) mlib: 0.7.4 -> 0.8.0
* [`2086aa5f`](https://github.com/NixOS/nixpkgs/commit/2086aa5f3f9538c68afe79ae2bdebcbdfbadbbba) imsprog: 1.5.3 -> 1.6.1
* [`bbcf5f76`](https://github.com/NixOS/nixpkgs/commit/bbcf5f763a5a4de569e7ef32de9298ae3e55a5d0) obs-studio-plugins.obs-replay-source: remove unnecessary buildInputs
* [`0fb43b60`](https://github.com/NixOS/nixpkgs/commit/0fb43b602638cb757ee366d447895f4ba7313f07) opera: drop
* [`64a34904`](https://github.com/NixOS/nixpkgs/commit/64a34904facd0044766360c6ad75f5bea0c2c021) maintainers: remove kindrowboat
* [`355f5ce5`](https://github.com/NixOS/nixpkgs/commit/355f5ce574e9510e5e8dde0f006d1b845e171ef4) obs-studio-plugins.obs-noise: init at 1.0.0
* [`1d0a5c25`](https://github.com/NixOS/nixpkgs/commit/1d0a5c25fcc440425af096e0996e04866d9c3f78) python3Packages.oauth2-client: init at 1.4.2
* [`241245c7`](https://github.com/NixOS/nixpkgs/commit/241245c764d5e7a6a085209db95ca42fa805f7f0) python3Packages.aiohttp-sse-client: init at 0.2.1
* [`06edb5eb`](https://github.com/NixOS/nixpkgs/commit/06edb5eb15644ed368daad5adfe380ac10fe17b3) python3Packages.home-connect-async: init at 0.8.2
* [`84e02649`](https://github.com/NixOS/nixpkgs/commit/84e0264997e77ddb699b4a0ba8d49da92af60785) home-assistant-custom-components.home_connect_alt: init at 1.2.1
* [`d64db5c5`](https://github.com/NixOS/nixpkgs/commit/d64db5c532241073c65bfc5d3c01ac44f7c81253) roxterm: 3.15.3 -> 3.16.2
* [`cc3615f4`](https://github.com/NixOS/nixpkgs/commit/cc3615f4543af30989144d595eda09f739a6b2ae) pinniped: 0.38.0 -> 0.39.0
* [`069e5514`](https://github.com/NixOS/nixpkgs/commit/069e5514228c2c1d62562e754e3b5f33cdb6bb0a) ktlint: 1.5.0 -> 1.6.0
* [`7ba22724`](https://github.com/NixOS/nixpkgs/commit/7ba227244aaa7ddb238d764ce5b4ae5a630ef584) ocrad: 0.27 -> 0.29
* [`84f68ad6`](https://github.com/NixOS/nixpkgs/commit/84f68ad674bfffc237bb007aeafb81430b0a285d) smlfut: 1.6.2 -> 1.6.4
* [`9f0df290`](https://github.com/NixOS/nixpkgs/commit/9f0df290a5d2fce259680877e9738c542053d764) function-runner: 7.0.1 -> 9.0.0
* [`748d64c2`](https://github.com/NixOS/nixpkgs/commit/748d64c23c97816964cedbfa348c55a6a79bac3e) opencsg: 1.7.0 -> 1.8.1
* [`6b21cd13`](https://github.com/NixOS/nixpkgs/commit/6b21cd131c29e6a9cacf38cc871df2abf7500fe7) stash: 0.27.2 -> 0.28.1
* [`220f9d8f`](https://github.com/NixOS/nixpkgs/commit/220f9d8f28577277894d82464eee9fb7e5dc5399) hamrs-pro: 2.33.0 -> 2.37.0
* [`17c14904`](https://github.com/NixOS/nixpkgs/commit/17c14904ec29f30b6f02bd817e94f6132504d1af) rmg-wayland: 0.7.8 -> 0.7.9
* [`01c97501`](https://github.com/NixOS/nixpkgs/commit/01c975015cd93742eceda2778749225f15242bf7) hamrs-pro: 2.37.0 -> 2.37.1
* [`c0099261`](https://github.com/NixOS/nixpkgs/commit/c0099261f9316d75150231b62289befda8911de5) code-cursor: 0.49.6 -> 0.50.5
* [`d04bf863`](https://github.com/NixOS/nixpkgs/commit/d04bf863816f00125de04500f8c8a4c0a090f93b) nixos.tests.pam-file-contents: fix build failure
* [`3b7b7eec`](https://github.com/NixOS/nixpkgs/commit/3b7b7eec1ecfa646a4313b6e61cebbbd79f7fd96) qgis: 3.42.2 -> 3.42.3
* [`7ccae6c5`](https://github.com/NixOS/nixpkgs/commit/7ccae6c5a033280879433906f45d26d1087b8a68) qgis-ltr: 3.40.6 -> 3.40.7
* [`f9867632`](https://github.com/NixOS/nixpkgs/commit/f986763223d18226aab5e0f8528e43b0307fbef5) twitterBootstrap: 5.3.5 -> 5.3.6
* [`6f6ba119`](https://github.com/NixOS/nixpkgs/commit/6f6ba119b647340936a57c88c6a3975cfe0db227) nmap: 7.96 -> 7.97
* [`3f18f9e1`](https://github.com/NixOS/nixpkgs/commit/3f18f9e1829e7407477406e0e28f00ccb47c5be4) findex: 0.8.2 -> 0.8.3
* [`703026bb`](https://github.com/NixOS/nixpkgs/commit/703026bbd8ee3773f6ab7302a192814145d309bf) obs-studio-plugins.obs-stroke-glow-shadow: init at 1.5.2
* [`5362d7b4`](https://github.com/NixOS/nixpkgs/commit/5362d7b46f750b499e06388ac32b7cddf975de88) lock: 1.6.1 -> 1.6.2
* [`1f213910`](https://github.com/NixOS/nixpkgs/commit/1f2139103db89a4fe8858e70dc6c1ef5d9958567) obs-studio-plugins.obs-urlsource: init at 0.3.7
* [`4de6ded4`](https://github.com/NixOS/nixpkgs/commit/4de6ded4453224b0d41a66696b35393ca18224c7) obs-studio-plugins.pixel-art: init at 0.0.4
* [`90756ed2`](https://github.com/NixOS/nixpkgs/commit/90756ed26c178708f8aea224fa79f1c352a3fe1c) obs-studio-plugins.obs-scene-as-transition: init at 1.1.1
* [`453f97c7`](https://github.com/NixOS/nixpkgs/commit/453f97c7e2b79b90709f0e0618d9f263757b8314) devede: 4.19.0 -> 4.21.0
* [`d1dc1831`](https://github.com/NixOS/nixpkgs/commit/d1dc183171de0ba5a2b6c8245b3e89f05883930c) devede: add baksa to maintainer list
* [`2be5c6a1`](https://github.com/NixOS/nixpkgs/commit/2be5c6a1d6e13c894816f75421e858650bcbd71b) amazon-qldb-shell: don't vendor Cargo.lock
* [`aed65d7e`](https://github.com/NixOS/nixpkgs/commit/aed65d7e52ddf89e195c674cf1947a648f1e1133) python3Packages.langchain-anthropic: 0.3.12 -> 0.3.13
* [`6abb0d23`](https://github.com/NixOS/nixpkgs/commit/6abb0d239ddeff45ad9beddba6cfd9984b8d4504) nixos/keycloak: enable strict shell checks in systemd units
* [`74d01f68`](https://github.com/NixOS/nixpkgs/commit/74d01f685a3e3e82e54dad62f1d10dfb76d87292) obs-studio-plugins.obs-rgb-levels: 1.0.0 -> 1.0.2
* [`65b0112b`](https://github.com/NixOS/nixpkgs/commit/65b0112b39dededeca97f4d3340f70610f0ff890) obs-studio-plugins.obs-dvd-screensaver: init at 0.0.2
* [`2a5ff9bd`](https://github.com/NixOS/nixpkgs/commit/2a5ff9bdeca9adcbc6d363afce44140efd981bde) wob: 0.15.1 -> 0.16
* [`cdfcbc9b`](https://github.com/NixOS/nixpkgs/commit/cdfcbc9b1ad292b15a29f5b93863b3b4fc337f22) obs-studio-plugins.obs-media-controls: init at 0.4.1
* [`b484822c`](https://github.com/NixOS/nixpkgs/commit/b484822cdd3ae065740580bc10b61297c585c778) sqlboiler: 4.19.0 -> 4.19.1
* [`c22ad72e`](https://github.com/NixOS/nixpkgs/commit/c22ad72e7b8d0c20bdb12691e6ea3c7d772df328) obs-studio-plugins.obs-recursion-effect: init at 0.1.0
* [`c13ed29f`](https://github.com/NixOS/nixpkgs/commit/c13ed29fc33a45bec323337e3325ed0021f44424) libinstpatch: 1.1.6 -> 1.1.7
* [`d2d46e76`](https://github.com/NixOS/nixpkgs/commit/d2d46e7682cdded7fdacfc1fc0d3b9aebce7155b) qlog: 0.43.1 -> 0.44.1
* [`8217eaf0`](https://github.com/NixOS/nixpkgs/commit/8217eaf0cb2046c8a255a81d60874ef5eff72664) danger-gitlab: 8.0.0 -> 9.0.0
* [`c84ab5f0`](https://github.com/NixOS/nixpkgs/commit/c84ab5f0f13a78593ec5819ae569d5ea56ab26a5) cider-2: 2.6.1 -> 3.0.2
* [`7fd92eb8`](https://github.com/NixOS/nixpkgs/commit/7fd92eb829ad6266ea296db6c3bba35f9a7a31cc) ithc: mark broken for kernels >= 6.10
* [`fcf9396c`](https://github.com/NixOS/nixpkgs/commit/fcf9396c8916318c35f3a48e1ebee2f86324937b) dbgate: 6.3.3 -> 6.4.2
* [`347cd9d9`](https://github.com/NixOS/nixpkgs/commit/347cd9d9d0ba520cac75a8fc19d20a104bfba6b6) k3s: k3s_1_32 -> k3s_1_33
* [`8e53c647`](https://github.com/NixOS/nixpkgs/commit/8e53c647e1eaa8165e03dcdae0504d013c3727a6) featherpad: 1.6.1 -> 1.6.2
* [`362bea77`](https://github.com/NixOS/nixpkgs/commit/362bea776ebe79664f513cfc74f2f9e8b587ab07) ngrok 3.19.1 -> 3.22.1
* [`0a710206`](https://github.com/NixOS/nixpkgs/commit/0a71020606f5a2b75cdac00ee73ce8750c70bbe0) kubernetes-helmPlugins.helm-secrets: 4.6.4 -> 4.6.5
* [`c75227cc`](https://github.com/NixOS/nixpkgs/commit/c75227cc9a347a276ca6de0f1e70e96491bbbab0) terraform-providers.gitlab: 17.11.0 -> 18.0.0
* [`5bb31d5b`](https://github.com/NixOS/nixpkgs/commit/5bb31d5b58192faf3f8a792a2ae1ebb18b94d611) fio: 3.39 -> 3.40
* [`c82dedcf`](https://github.com/NixOS/nixpkgs/commit/c82dedcfb0a62a600625caf5b03dcbc0b182ae54) dnscrypt-proxy: 2.1.8 -> 2.1.9
* [`b19a744e`](https://github.com/NixOS/nixpkgs/commit/b19a744e0015fd27cc8c0218208b8776572256bc) clusterctl: 1.10.1 -> 1.10.2
* [`47f9f023`](https://github.com/NixOS/nixpkgs/commit/47f9f0234bcb582bc1c2bbdd2468060ed84cf3b9) c2fmzq: 0.4.29 -> 0.4.30
* [`daba399c`](https://github.com/NixOS/nixpkgs/commit/daba399c01a8c2f067ed04c9e67bbb9e94cf50a5) jdt-language-server: 1.46.1 -> 1.47.0
* [`a29c95ae`](https://github.com/NixOS/nixpkgs/commit/a29c95ae6def820e32b5844b13c4914326106352) python313Packages.granian: 2.3.0 -> 2.3.1
* [`cfb6ee5f`](https://github.com/NixOS/nixpkgs/commit/cfb6ee5f1e1415a302c5ff05ace484330c3dbafe) lefthook: 1.11.12 -> 1.11.13
* [`ed13fb98`](https://github.com/NixOS/nixpkgs/commit/ed13fb9859183ae08e506dfaa564f7ab8a909a06) kanboard: 1.2.44 -> 1.2.45
* [`6fd57df2`](https://github.com/NixOS/nixpkgs/commit/6fd57df239bb2c9ca7695ff8bb304a011eddbc8c) cargo-tarpaulin: 0.32.5 -> 0.32.7
* [`092858cb`](https://github.com/NixOS/nixpkgs/commit/092858cbae2d052544dc7a837f71fe67854521bc) sssd: 2.9.5 -> 2.9.7
* [`378f66ee`](https://github.com/NixOS/nixpkgs/commit/378f66eea6569ef36e19d32f3d52bd6f11fdb60d) browsh: 1.8.2 -> 1.8.3
* [`84b10ffc`](https://github.com/NixOS/nixpkgs/commit/84b10ffc37c2e86c2a65245ec72e843c17c01e68) runme: 3.13.2 -> 3.14.0
* [`d7e271ce`](https://github.com/NixOS/nixpkgs/commit/d7e271cec7f537a693a6ba1e0683a6a808f6c266) maintainers: ryota2357
* [`5f726a4b`](https://github.com/NixOS/nixpkgs/commit/5f726a4bd9aee2e29f435009822e00f0e59ed402) ser2net: 4.6.4 -> 4.6.5
* [`10b841b8`](https://github.com/NixOS/nixpkgs/commit/10b841b892e2f4010382a9cfa079099ff1757778) hyperrogue: 13.0x -> 13.0y
* [`e7fc6c5b`](https://github.com/NixOS/nixpkgs/commit/e7fc6c5b99f265874cbc43d8395892e4a581afc5) terraform-providers.okta: 4.18.0 -> 4.19.0
* [`93899a09`](https://github.com/NixOS/nixpkgs/commit/93899a09a7c09ac989dcbdce2e2fdecab79b973b) python3Packages.langgraph-sdk: 0.1.66 -> 0.1.69
* [`dd3f33fc`](https://github.com/NixOS/nixpkgs/commit/dd3f33fca0cb0b1632422e71b189bf222955266d) whois: 5.6.0 -> 5.6.1
* [`30594e0a`](https://github.com/NixOS/nixpkgs/commit/30594e0a4b79ae88227b9782c527ce7fa300ec99) kdePackages.qt6gtk2: 0.5-unstable-2025-03-04 -> 0.4-unstable-2025-05-11
* [`2e586582`](https://github.com/NixOS/nixpkgs/commit/2e586582a5d0ce642faa6e03a736e3a808a23b18) skim: 0.17.2 -> 0.17.3
* [`6e6411a2`](https://github.com/NixOS/nixpkgs/commit/6e6411a28d2f7c80c47f8272244cab5e433e3004) umoci: 0.4.7 -> 0.5.0
* [`21da167f`](https://github.com/NixOS/nixpkgs/commit/21da167f472c2e9089a522c13b098ecb79342c7b) flutter332: 3.32.0-0.4.pre -> 3.32.0
* [`ce4d7781`](https://github.com/NixOS/nixpkgs/commit/ce4d778179f86babed9c54875f42c89b47e9697d) firmware-updater: pin in flutter329
* [`b041c5c2`](https://github.com/NixOS/nixpkgs/commit/b041c5c2aa081ae256269af9d9d74556f1857860) libretrack: pin in flutterPackages-source.v3_29
* [`58d68d16`](https://github.com/NixOS/nixpkgs/commit/58d68d16027c3bc541f2bbeda61f83633e4cb431) finamp: pin in flutter329
* [`348f6516`](https://github.com/NixOS/nixpkgs/commit/348f6516190fd4cd1f019c279a41988ad5d23ae8) cwtch-ui: pin in flutter329
* [`ab0cc8e5`](https://github.com/NixOS/nixpkgs/commit/ab0cc8e55f15595141cb8d08e135866237a283f7) added l0r3v to maintainers
* [`06fccf7e`](https://github.com/NixOS/nixpkgs/commit/06fccf7e8a39670504e8a88c3fcdbda6d1eff6da) quickjs-ng: 0.10.0 -> 0.10.1
* [`5c1b7f19`](https://github.com/NixOS/nixpkgs/commit/5c1b7f1975bdd15289f3f15f43c7db587d9b08e2) lapack: fix static build
* [`e6c8d3b0`](https://github.com/NixOS/nixpkgs/commit/e6c8d3b0051fd87baf28d6af2511180687fbad0d) k3s: add docs for external containerd
* [`82940352`](https://github.com/NixOS/nixpkgs/commit/82940352af524838144370e3941c3098cb9f2253) perlPackages.AuthenKrb5: 1.905 -> 1.906
* [`9e5c9bdf`](https://github.com/NixOS/nixpkgs/commit/9e5c9bdfcd0a8a06a6237ffa954c05e6e43606ba) qtractor: 1.5.4 -> 1.5.5
* [`d5f4262c`](https://github.com/NixOS/nixpkgs/commit/d5f4262c563e5d615c2b9b85216665797d6c53c0) ginac: 1.8.8 -> 1.8.9
* [`47c0b815`](https://github.com/NixOS/nixpkgs/commit/47c0b815df403fdb08e8996630b8c71cdf700045) quiet: 4.1.2 -> 5.0.1
* [`05ff7773`](https://github.com/NixOS/nixpkgs/commit/05ff777324155a41e107ac04d961b6f652a92880) java-service-wrapper: 3.6.0 -> 3.6.1
* [`f9e9c67e`](https://github.com/NixOS/nixpkgs/commit/f9e9c67e53ba2fea76d1e7965e03ca2f78a26db4) android-file-transfer: use qt6
* [`a2810c9a`](https://github.com/NixOS/nixpkgs/commit/a2810c9a9b2049930f565ba7518652c371061712) lixPackageSets.lix_2_91.nix-fast-build: 1.1.0 -> 1.2.0
* [`c8b02ddd`](https://github.com/NixOS/nixpkgs/commit/c8b02ddd23605d38d9726d7231b694e41ced3cfa) ipset: 7.23 -> 7.24
* [`a371ed99`](https://github.com/NixOS/nixpkgs/commit/a371ed99e11d8afe5c144a5182af04120ed65a61) nixfmt-tree: remove `tree-root-file` default
* [`1f5e2990`](https://github.com/NixOS/nixpkgs/commit/1f5e29902a1239a9bdc5b91801963dd199ae0d09) tboot: 1.11.7 -> 1.11.9
* [`d51ffda5`](https://github.com/NixOS/nixpkgs/commit/d51ffda5bc89e9f9bb9cc93566243f675ac302cc) x42-plugins: 20240611 -> 20250512
* [`7d08d67e`](https://github.com/NixOS/nixpkgs/commit/7d08d67ed9677f7ff9b5eb7ef1816ab89e5d14b6) dar: 2.7.17 -> 2.7.18
* [`d0cff692`](https://github.com/NixOS/nixpkgs/commit/d0cff692460f2dec0d71e72b2b7bc78b18cca59a) grandorgue: Use wrapGAppsHook3 to provide correct environment
* [`34bada88`](https://github.com/NixOS/nixpkgs/commit/34bada88632e7bac55078e55568f559c03f6887d) apr: 1.7.5 -> 1.7.6
* [`ecb7b2e9`](https://github.com/NixOS/nixpkgs/commit/ecb7b2e94037b2260dc155042fbf2db709c6249b) snobol4: 2.3.2 -> 2.3.3
* [`844e819c`](https://github.com/NixOS/nixpkgs/commit/844e819cca2e5a93add5cd5a610c91c5273c0f13) authentik,authentik.outposts.{ldap,radius,proxy}: 2025.2.3 -> 2025.4.1
* [`950655e5`](https://github.com/NixOS/nixpkgs/commit/950655e5539e59178024c8ad02b6d8dcb6209a51) winbox4: 4.0beta20 -> 4.0beta21
* [`d7892a79`](https://github.com/NixOS/nixpkgs/commit/d7892a79af430a887492b0537325c5e93779ba99) sparrow: 2.0.0 -> 2.2.1
* [`96bfb6cb`](https://github.com/NixOS/nixpkgs/commit/96bfb6cbc4d09fee1710879715d6d30f0ab7f344) apt: 3.0.1 -> 3.1.0
* [`99e6554f`](https://github.com/NixOS/nixpkgs/commit/99e6554fea1a1d6210a3221b2c8fee32d6a838fe) util-linux: hack: add withPatches passthru
* [`0902abb6`](https://github.com/NixOS/nixpkgs/commit/0902abb6a77910b900f43b02a6b8b14e90473c76) k3s: use util-linuxMinimal.withPatches
* [`e14de858`](https://github.com/NixOS/nixpkgs/commit/e14de8583028cbf4ad1619f9ec4e342ce29eb572) nixos/kubernetes: use util-linux.withPatches
* [`b5f4eb82`](https://github.com/NixOS/nixpkgs/commit/b5f4eb8258ba625288efeb3230375c5a48aa258a) cerca: 0-unstable-2025-05-10 -> 0-unstable-2025-05-21
* [`32e4540b`](https://github.com/NixOS/nixpkgs/commit/32e4540bc039a49717fd0663ac2727c37ff8f9ca) xrdp: 0.10.1 -> 0.10.3, xorgxrdp: 0.10.2 -> 0.10.4
* [`54c9bcab`](https://github.com/NixOS/nixpkgs/commit/54c9bcabb40dc309e76370209f6e21bc79d47cd3) texturepacker: 7.6.3 -> 7.7.0
* [`6800fbd4`](https://github.com/NixOS/nixpkgs/commit/6800fbd4fe1dd76885335868fa64d94ee5732919) leanify: unstable-2023-12-17 -> unstable-2025-05-20
* [`697e57a9`](https://github.com/NixOS/nixpkgs/commit/697e57a9ee3bac161d3f90a31baf0ea181c7e4f4) rescrobbled: 0.7.1 -> 0.7.2
* [`b5a051d0`](https://github.com/NixOS/nixpkgs/commit/b5a051d04348e91c5665c163861cfde5f3c5effa) dune_3: 3.18.2 -> 3.19.0
* [`27541857`](https://github.com/NixOS/nixpkgs/commit/275418575ba2059db6d685b39325691ab456de3f) buildkit: 0.21.1 -> 0.22.0
* [`1286f72a`](https://github.com/NixOS/nixpkgs/commit/1286f72a7a49d11f9b853c04b179b6c83db4a83d) powerpipe: 1.2.5 -> 1.2.7
* [`22a235e4`](https://github.com/NixOS/nixpkgs/commit/22a235e4f41bf59dee0c39578f2066dddcd84c3a) fuc: 3.0.1 -> 3.1.0
* [`e811962d`](https://github.com/NixOS/nixpkgs/commit/e811962dfbd8fbda720c471878147740bacb5bd0) memos: 0.24.2 -> 0.24.3, fix update script
* [`a8993f69`](https://github.com/NixOS/nixpkgs/commit/a8993f698536a30074d7fca7aa355aaf1ee19a67) nanoboyadvance: 1.8.1 -> 1.8.2
* [`2e13b6d7`](https://github.com/NixOS/nixpkgs/commit/2e13b6d7763626bf532da62d0339fb1c5ff40891) nb: 7.18.1 -> 7.19.1
* [`88831fdb`](https://github.com/NixOS/nixpkgs/commit/88831fdb91a287c3c425ef63651c89b9d6fdc579) velocity: 3.4.0-unstable-2025-05-09 -> 3.4.0-unstable-2025-05-21
* [`6478a630`](https://github.com/NixOS/nixpkgs/commit/6478a63099b1814a0b28e902d7a50839351309ed) easeprobe: 2.2.1 -> 2.3.0
* [`9d80569f`](https://github.com/NixOS/nixpkgs/commit/9d80569f4671b4e2dcd199983fe1a98d34ac6eb6) open-vm-tools: 12.5.0 -> 12.5.2
* [`27d5c330`](https://github.com/NixOS/nixpkgs/commit/27d5c330770f69b7989b9e8d14d59fa067bd6a3f) liquibase: 4.31.1 -> 4.32.0
* [`e009d508`](https://github.com/NixOS/nixpkgs/commit/e009d50864060774e33d36b2bbccd965eae6f094) svelte-language-server: 0.17.12 -> 0.17.15
* [`d1465787`](https://github.com/NixOS/nixpkgs/commit/d1465787ab2c1667d9ae4738e11f81c6a788fc25) leo-editor: 6.8.3 -> 6.8.4
* [`3bde254e`](https://github.com/NixOS/nixpkgs/commit/3bde254e590f1614b0fb59156ecbdd70ea78940f) python3Packages.ansible-compat: 25.1.5 -> 25.5.0
* [`046d9dbe`](https://github.com/NixOS/nixpkgs/commit/046d9dbefeb11d527490584b6cfcb141fcd33fb9) tailscale: 1.82.5 -> 1.84.0
* [`4b78b9be`](https://github.com/NixOS/nixpkgs/commit/4b78b9bee5031af00396643018feb2d2b9045c31) tailscale: disable timeout taildrop tests
* [`a296d255`](https://github.com/NixOS/nixpkgs/commit/a296d255d98fcac8de4353027b84f3b6ba09650e) tailscale: disable packet_filter_test
* [`6d626616`](https://github.com/NixOS/nixpkgs/commit/6d62661638fdff6def5625ba016f13ec3c1d0bdb) graphite-cli: 1.6.1 -> 1.6.2
* [`d1578f3c`](https://github.com/NixOS/nixpkgs/commit/d1578f3c7e7480195903f533322e49d3fc77c22a) spotify: set `passthru.updateScript`
* [`19b0dd56`](https://github.com/NixOS/nixpkgs/commit/19b0dd56a138b62be1c406ad7031ce8852af40eb) libplacebo: 7.349.0 -> 7.351.0
* [`f99ce02d`](https://github.com/NixOS/nixpkgs/commit/f99ce02dc87257510295234c4ad8d6d95ec196ad) uhk-agent: 7.0.0 -> 7.0.1
* [`cbeeccdd`](https://github.com/NixOS/nixpkgs/commit/cbeeccddb04ca6c68b462bf0d543f45ad3d822f5) spotify: add macOS support to update script
* [`ee0fd4e0`](https://github.com/NixOS/nixpkgs/commit/ee0fd4e0aee172d4bc98f4aa7b56ba46c4e9005f) spotify/linux: allow overriding `version` and `rev`
* [`afa43e13`](https://github.com/NixOS/nixpkgs/commit/afa43e1383d4d604ed3575bf95b3905354a9a51b) spotify/linux: 1.2.59.514.g834e17d4 -> 1.2.60.564.gcc6305cb
* [`795e3176`](https://github.com/NixOS/nixpkgs/commit/795e317647b0d07ee24e292072d83ac5aea1c964) spotify/darwin: 1.2.40.599.g606b7f29 -> 1.2.64.408
* [`3fe7cacc`](https://github.com/NixOS/nixpkgs/commit/3fe7caccd7a56fc5ab59ec0cfc8805ddc302bab0) linuxConsoleTools: drop SDL
* [`5816abbc`](https://github.com/NixOS/nixpkgs/commit/5816abbcae30b7b46f1b0c715944e02da205c22e) icingaweb2-ipl: 0.14.2 -> 0.16.0
* [`abb968bc`](https://github.com/NixOS/nixpkgs/commit/abb968bc72aa6c29b37e6e1c65960539671c65c0) rotonda: 0.4.0 -> 0.4.1
* [`1978b03a`](https://github.com/NixOS/nixpkgs/commit/1978b03a41fdaf7696c93a7dc34d11050ba69908) vcpkg-tool-unwrapped: 2025-04-16 -> 2025-05-19
* [`439762f8`](https://github.com/NixOS/nixpkgs/commit/439762f849126e9995abef8def6424e510d86f77) robotframework-tidy: 4.16.0 -> 4.17.0
* [`bbc93efe`](https://github.com/NixOS/nixpkgs/commit/bbc93efe71755908e0f0d1c74b2f9bd93ea4ada2) haskellPackages.gi-vte: add missing depencency on gdkpixbuf
* [`e520e12f`](https://github.com/NixOS/nixpkgs/commit/e520e12ffdf6433fedb0501acce368487a8cfd7b) mpvScripts.modernx-zydezu: 0.4.1 -> 0.4.2
* [`9fcf26cd`](https://github.com/NixOS/nixpkgs/commit/9fcf26cd2d72a1e4ec98b26b10cd3a4672daf1cc) python313Packages.django-ninja-cursor-pagination: init at 0.1.0
* [`29f7024e`](https://github.com/NixOS/nixpkgs/commit/29f7024e91bf509e7f21a5eb1c9b300fa31b1358) python313Packages.django-postgres-partition: init at 0.1.1
* [`29bb947d`](https://github.com/NixOS/nixpkgs/commit/29bb947d940e0710f67949a5643c60985395ba37) python3Packages.vfblib: 0.9.2 -> 0.9.4
* [`92057c24`](https://github.com/NixOS/nixpkgs/commit/92057c24448afcec363da90dd58162bd0fad72a0) glitchtip: 4.2.10 -> 5.0.1
* [`accf03b1`](https://github.com/NixOS/nixpkgs/commit/accf03b12f5d1fbbae8a7c6130567d4037774555) varia: 2025.4.22 -> 2025.5.14
* [`51c4bb72`](https://github.com/NixOS/nixpkgs/commit/51c4bb722a4bf6cb5b902ca7f25ab4b7bf4d2b15) traccar: 6.6 -> 6.7.0
* [`a2a052bf`](https://github.com/NixOS/nixpkgs/commit/a2a052bf268697954c8c54247d2bcb0c5524c3de) web-ext: 8.6.0 -> 8.7.0
* [`3160c5e9`](https://github.com/NixOS/nixpkgs/commit/3160c5e9651ce9a3e4748fc6a8eede587b9ba157) pgmoneta: 0.16.1 -> 0.17.0
* [`8be67b24`](https://github.com/NixOS/nixpkgs/commit/8be67b24cf95ed94632d302dd036d75aaadeacbc) home-assistant-custom-components.oref_alert: init at 2.20.1
* [`5240bdf3`](https://github.com/NixOS/nixpkgs/commit/5240bdf3c63d7516f2bb74cd5e099f993a88ab89) ci/eval: don't evaluate packages marked as broken
* [`001f99b2`](https://github.com/NixOS/nixpkgs/commit/001f99b21ff5139e64b6c378981046106010eb00) zsteg: Migrate to by-name
* [`d5b99f8d`](https://github.com/NixOS/nixpkgs/commit/d5b99f8d7f04ef8a89e27e864a49c38c0c94546d) browsers: 0.6.0 -> 0.7.0
* [`c322f8d7`](https://github.com/NixOS/nixpkgs/commit/c322f8d7c87a81d98accd2a461e814be3852d632) zsteg: Update gems and add missing bundler updater.
* [`ff669575`](https://github.com/NixOS/nixpkgs/commit/ff6695751e914745ee89c18f464bbd1f7d6822e7) keystore-explorer: 5.5.3 -> 5.6.0
* [`6cf1923d`](https://github.com/NixOS/nixpkgs/commit/6cf1923dad62aad0df4def53c80b007d93f394c8) sublime_syntax_convertor: Add bundler updater to easily update gems.
* [`ecc5126f`](https://github.com/NixOS/nixpkgs/commit/ecc5126fd0629d6a20c42af5fb0ba080894e0a51) python3Packages.igloohome-api: 0.1.0 -> 0.1.1
* [`598138a1`](https://github.com/NixOS/nixpkgs/commit/598138a191db76f50a98635e68f7722b03fd2718) tokei: don't use pname in src
* [`f7057320`](https://github.com/NixOS/nixpkgs/commit/f7057320c7d4825436d7248d5317fdf6763bb663) tokei: use finalAttrs pattern
* [`a83df17a`](https://github.com/NixOS/nixpkgs/commit/a83df17a078ca97b2ca8d9785aab9418e278b450) tokei: use tag and hash in fetchFromGitHub
* [`5d6cb0e4`](https://github.com/NixOS/nixpkgs/commit/5d6cb0e410b21605f48bdacd63976d3325b10830) tokei: remove `with lib;`
* [`09c5bb16`](https://github.com/NixOS/nixpkgs/commit/09c5bb16d8c34bfe3f84dbab7f02c04825adcbeb) tokei: improve meta.description
* [`dee1607c`](https://github.com/NixOS/nixpkgs/commit/dee1607ccced1e05fe9c3121e1893832e4c09667) tokei: add meta.changelog
* [`ec4ef630`](https://github.com/NixOS/nixpkgs/commit/ec4ef6302c05ce4b5240fe657aade79f56c911a3) tokei: add versionCheckHook
* [`732bec3f`](https://github.com/NixOS/nixpkgs/commit/732bec3fe4cde6d1702227e029f6c143f3e11add) tokei: add nix-update-script
* [`d29618c8`](https://github.com/NixOS/nixpkgs/commit/d29618c87379d75ade9d62e7c111a1d2b76e5510) tokei: add defelo as maintainer
* [`3be41996`](https://github.com/NixOS/nixpkgs/commit/3be419965d9adc8156a405191f1997375720a3b3) softether: 4.41-9782-beta -> 4.44-9807-rtm
* [`77c45ea1`](https://github.com/NixOS/nixpkgs/commit/77c45ea139cdc330f1dd651beee948060d33fcea) oha: Use system jemalloc
* [`974c3874`](https://github.com/NixOS/nixpkgs/commit/974c38747ba338e28515e81d24cb3829121aceb6) llvmPackages_20.libc: fix by removing scudo
* [`b86faaaa`](https://github.com/NixOS/nixpkgs/commit/b86faaaa0dd52ee7f4b0967cc07f6bfc126ce04d) argbash: 2.10.0 -> 2.11.0
* [`2fc65403`](https://github.com/NixOS/nixpkgs/commit/2fc65403f506d06077f28d4bdc4861f18b311431) smartsynchronize: 4.6.1 -> 4.6.2
* [`34553527`](https://github.com/NixOS/nixpkgs/commit/3455352762ce4896ce76b6bc1dc561e33d4ed009) gh-gei: 1.15.0 -> 1.15.1
* [`1f68ce07`](https://github.com/NixOS/nixpkgs/commit/1f68ce074dc6e8208391e57f88b09b806da297b8) youtrack: 2025.1.71685 -> 2025.1.76253
* [`bc6bdef1`](https://github.com/NixOS/nixpkgs/commit/bc6bdef11b3699d0d4eaf3a6d5c11990221cfbc1) python3Packages.djangocms-alias: 2.0.2 -> 2.0.3
* [`5d0d1479`](https://github.com/NixOS/nixpkgs/commit/5d0d14796509873b9e5df9e96c43d1f2d0dea640) remmina: fix Python 3 not available on `PATH`
* [`1d7de97b`](https://github.com/NixOS/nixpkgs/commit/1d7de97be77fd14b18630c554926a5965f45977f) python3Packages.sensorpro-ble: 0.7.0 -> 0.7.1
* [`4907750a`](https://github.com/NixOS/nixpkgs/commit/4907750a173268bf52f55bd16f3669bf2edeac30) mill: 0.12.11 -> 0.12.14
* [`959c8e93`](https://github.com/NixOS/nixpkgs/commit/959c8e931134c3f986474045c24b05f09b1d770e) nixos/anubis: Apply some more hardening settings
* [`6e809040`](https://github.com/NixOS/nixpkgs/commit/6e809040cc7a7e17357eb98ca7a98a57807b9f7d) melos: 6.2.0 -> 6.3.2
* [`1bafb802`](https://github.com/NixOS/nixpkgs/commit/1bafb802cdf0e7ef4c424bfeccc1aedbf985a2de) gaugePlugins.java: 0.11.4 -> 0.12.0
* [`77996231`](https://github.com/NixOS/nixpkgs/commit/7799623124a98f3387a91f6952633a5f8e5a59fa) persepolis: 5.1.0 -> 5.1.1
* [`ef45eca8`](https://github.com/NixOS/nixpkgs/commit/ef45eca82d8baa2833a3ded45eef7f856052dda6) proton-pass: 1.31.2 -> 1.31.4
* [`b9a86fef`](https://github.com/NixOS/nixpkgs/commit/b9a86fef6604ae0fcbc00a76363f6cf7e9215e12) plexRaw: 1.41.6.9685-d301f511a -> 1.41.7.9799-5bce000f7
* [`bf45803a`](https://github.com/NixOS/nixpkgs/commit/bf45803a123e7967f12911ee63748b34cdd90dd6) python3Packages.ultralytics: 8.3.130 -> 8.3.143
* [`19069456`](https://github.com/NixOS/nixpkgs/commit/19069456f778dcdd9b60e6f8833ac48b055084b5) r2modman: 3.1.58 -> 3.2.0
* [`15e71d8d`](https://github.com/NixOS/nixpkgs/commit/15e71d8d3fdd8b769b5fb0915fd333fcf1b42a5b) minizincide: 2.9.2 -> 2.9.3
* [`781a8765`](https://github.com/NixOS/nixpkgs/commit/781a87653e8f479cc02a4c5b6a6128c14b1ba61f) infra-arcana: 22.1.0 -> 23.0.0
* [`19103e65`](https://github.com/NixOS/nixpkgs/commit/19103e65ebcb68579b1df963f0dd6e86a5311da2) cucumber: 9.2.0 -> 9.2.1
* [`4ba4f6f3`](https://github.com/NixOS/nixpkgs/commit/4ba4f6f308d6dc9c45e7d3d371e28ff53cacf614) git-annex-utils: Fix typo in deprecation throw
* [`cbcb9f78`](https://github.com/NixOS/nixpkgs/commit/cbcb9f78bdb7e50c0bda9a61032b930b7c09fb11) basedpyright: 1.29.1 -> 1.29.2
* [`3498fc21`](https://github.com/NixOS/nixpkgs/commit/3498fc21c881cd871e59078dac275ad7845d77ad) plex-desktop: 1.108.1 -> 1.109.0
* [`15719ef2`](https://github.com/NixOS/nixpkgs/commit/15719ef295ab97b10e6a3873e645c26ff41209ee) nushell: 0.104.0 -> 0.104.1
* [`4e6aa99f`](https://github.com/NixOS/nixpkgs/commit/4e6aa99fe277d1244f5cea7c309ba3bd2c182383) treesheets: 0-unstable-2025-05-11 -> 0-unstable-2025-05-19
* [`9b0f238b`](https://github.com/NixOS/nixpkgs/commit/9b0f238bd4e25b17f3e9c994616ca8f540720f7e) termius: 9.19.4 -> 9.20.0
* [`7ead5a69`](https://github.com/NixOS/nixpkgs/commit/7ead5a69cc55a650d8048517fac11b98f721aaa9) mpvScripts.uosc: 5.8.0 -> 5.9.2
* [`a4c6b536`](https://github.com/NixOS/nixpkgs/commit/a4c6b536a1c04d01dc9f6c4fe232a1ed8f2a4884) carapace: 1.3.1 -> 1.3.2
* [`630eb498`](https://github.com/NixOS/nixpkgs/commit/630eb498515088736cb0a5e9f7318a75952ca076) vgmstream: 1980 -> 2023
* [`82b0ae66`](https://github.com/NixOS/nixpkgs/commit/82b0ae6601ef1853b0ed401322d863bd2c674c8e) python3Packages.pymupdf4llm: init at 0.0.17
* [`3d7c2efe`](https://github.com/NixOS/nixpkgs/commit/3d7c2efe8f2589fc841a17c3f27cd15bb9c4f256) maa-assistant-arknights: 5.16.4 -> 5.16.9
* [`ae877216`](https://github.com/NixOS/nixpkgs/commit/ae87721626245f449c12cae4a441cf9a1ddb1a29) nixos-render-docs: make error message on broken redirects less verbose
* [`25122135`](https://github.com/NixOS/nixpkgs/commit/25122135e6c5976ee41c0d560c125a618ee53d6d) tailscale: remove unused fetchpatch
* [`69984d59`](https://github.com/NixOS/nixpkgs/commit/69984d594fc4d175fd0cf0762f98801dc598b99d) tailscale: re-enable `packet_filter_test.go`
* [`6bf8ab3d`](https://github.com/NixOS/nixpkgs/commit/6bf8ab3dedccab2fb98f32f55a0003f8c0ef5ab2) rebels-in-the-sky: 1.0.29 -> 1.0.30
* [`95ae1cc7`](https://github.com/NixOS/nixpkgs/commit/95ae1cc72dbf735f1544ae1eb13e69b96f00ecfc) synapse-admin: 0.10.4 -> 0.11.0
* [`be3ef9cb`](https://github.com/NixOS/nixpkgs/commit/be3ef9cbba2bbb8e018088817ed80d9440540a30) defuddle-cli: init at 0.6.4
* [`dc3a2967`](https://github.com/NixOS/nixpkgs/commit/dc3a2967352130826a26a1200e80f4ea391429a2) python3Packages.pytubefix: 8.13.1 -> 9.0.1
* [`3129e2b3`](https://github.com/NixOS/nixpkgs/commit/3129e2b389b59e9768084db1839b3655bad7e02f) ps2patchelf: init at 1.0.0
* [`09ae6dfd`](https://github.com/NixOS/nixpkgs/commit/09ae6dfdd5994c694a8f40e7a199e9092abd9cf9) gallery-dl: fix missing dependency for SOCKS support
* [`b14a7763`](https://github.com/NixOS/nixpkgs/commit/b14a77638b78e34baa05153b6bf1931d0f634162) nixos/chrysalis: init module
* [`e5725203`](https://github.com/NixOS/nixpkgs/commit/e5725203e96c34fb3ce9454154a144eb6c9534ff) omnictl: 0.49.1 -> 0.50.0
* [`031c09b1`](https://github.com/NixOS/nixpkgs/commit/031c09b1dd3496ae7527d00a194d6edea227cff4) kaniko: 1.23.2 -> 1.24.0
* [`113626a1`](https://github.com/NixOS/nixpkgs/commit/113626a1957228e29ee4af1c77711dbd7462ccb8) kubectl-cnpg: 1.25.1 -> 1.26.0
* [`9a7782a6`](https://github.com/NixOS/nixpkgs/commit/9a7782a6b3254ade1183e86424a326c1249de743) heroic-unwrapped: 2.16.1 -> 2.17.0
* [`625c4ecb`](https://github.com/NixOS/nixpkgs/commit/625c4ecb333e74ce5eb7e6df8ef68bf7fdf3c23b) dayon: 16.0.3 -> 17.0.0
* [`7a51e048`](https://github.com/NixOS/nixpkgs/commit/7a51e0487adb1ae5596fff853917154e5c51108d) python3Packages.google-photos-library-api: fix failing tests on Darwin
* [`0475645f`](https://github.com/NixOS/nixpkgs/commit/0475645fb0539260552416a0fe6760fea47b8bda) python3Packages.google-search-results: build from GitHub, modernize
* [`d870438b`](https://github.com/NixOS/nixpkgs/commit/d870438bcab82f0ec8cc619c7cdf4bf6a17ab563) wezterm: 0-unstable-2025-02-23 -> 0-unstable-2025-05-18
* [`6a3bfcd0`](https://github.com/NixOS/nixpkgs/commit/6a3bfcd042cbce0f909136bcd35f09cd4909d6a0) python3Packages.google-cloud-netapp: build from GitHub
* [`22b58116`](https://github.com/NixOS/nixpkgs/commit/22b58116e3d8c4f5f0ea919e85639abae321f5ac) weaviate: 1.30.3 -> 1.30.5
* [`d733e280`](https://github.com/NixOS/nixpkgs/commit/d733e28057363e3ce5808fd6e51a2edb01d454aa) wasm-language-tools: 0.4.1 -> 0.5.0
* [`81d495bf`](https://github.com/NixOS/nixpkgs/commit/81d495bf47d23206a4015df4d292150f903b30cc) jmol: 16.3.17 -> 16.3.23
* [`c84885bc`](https://github.com/NixOS/nixpkgs/commit/c84885bc051137319cf0e01579d5a188a7790792) rusty-man: use finalAttrs pattern
* [`e954bf81`](https://github.com/NixOS/nixpkgs/commit/e954bf812adb7303eb12a170be5e80eef0789abd) rusty-man: use hash in fetchFromSourcehut
* [`6c4a09dd`](https://github.com/NixOS/nixpkgs/commit/6c4a09dd8947d0c9180fc56b0ada91dd87bb2d5b) rusty-man: remove `with lib;`
* [`453d5d7f`](https://github.com/NixOS/nixpkgs/commit/453d5d7fcdd80888488202a41e4ab59288298224) rusty-man: add versionCheckHook
* [`83e09539`](https://github.com/NixOS/nixpkgs/commit/83e095396ead1045d283bfa8fab69caeb66f9e4d) rusty-man: add updateScript
* [`a37e5702`](https://github.com/NixOS/nixpkgs/commit/a37e5702f29d34d79a184301b7f538be0a6f53a3) rusty-man: add defelo as maintainer
* [`ceabb205`](https://github.com/NixOS/nixpkgs/commit/ceabb2059d7247dfc160ba0ef1d073ecced3df3a) chroot-realpath: Add error context
* [`b6891d4e`](https://github.com/NixOS/nixpkgs/commit/b6891d4e950d077151c75230efb6f63b5c8f0df6) lalrpop: 0.22.1 -> 0.22.2
* [`1a00e826`](https://github.com/NixOS/nixpkgs/commit/1a00e82675b7ec1f84357b20ccfea1ce59e89689) govc: 0.50.0 -> 0.51.0
* [`3641bb38`](https://github.com/NixOS/nixpkgs/commit/3641bb38079c589e4494c5f1ab51a3cbcf4d1c14) ibmcloud-cli: 2.34.0 -> 2.34.1
* [`a98052e4`](https://github.com/NixOS/nixpkgs/commit/a98052e463948bac6035bbd9141de9c0799e0dea) gauge-unwrapped: 1.6.15 -> 1.6.16
* [`1c602451`](https://github.com/NixOS/nixpkgs/commit/1c60245186fd846e2f6722574ccf3d974c335b8f) terraform-providers.kafka: 0.9.0 -> 0.10.1
* [`192e89ae`](https://github.com/NixOS/nixpkgs/commit/192e89aed7597c1a414f35fb5ce923bbbd450a23) questdb: 8.3.1 -> 8.3.2
* [`cd2b034f`](https://github.com/NixOS/nixpkgs/commit/cd2b034fe8bf2a6c03149806e1cec0462cb8c48f) schemacrawler: 16.25.3 -> 16.25.4
* [`f8f7a8c7`](https://github.com/NixOS/nixpkgs/commit/f8f7a8c7698535e83e9667e1b8dd489096310186) wasm-tools: 1.230.0 -> 1.231.0
* [`027db59c`](https://github.com/NixOS/nixpkgs/commit/027db59c22d4bcc66eb2fd8215a333f239a91416) terraform-compliance: 1.3.50 -> 1.3.52
* [`63ffc1e5`](https://github.com/NixOS/nixpkgs/commit/63ffc1e5833b382d4e1556df15f5a1e60e8aa722) intel-compute-runtime: 25.13.33276.16 -> 25.18.33578.6
* [`cc59786a`](https://github.com/NixOS/nixpkgs/commit/cc59786aeb63a54a67ff0cf72f8ad6969d222055) flake-checker: 0.2.5 -> 0.2.6
* [`46a8e585`](https://github.com/NixOS/nixpkgs/commit/46a8e585bd1ba4ea1532ab847a98992f99bb666a) firefox-bin: don't break code signing on macOS
* [`03f47ba6`](https://github.com/NixOS/nixpkgs/commit/03f47ba6093c320834c8fc14237cf2b81d8d56d5) terraform-providers.aviatrix: 3.2.1 -> 8.0.0
* [`882c63ac`](https://github.com/NixOS/nixpkgs/commit/882c63acd4eaba3303981d009597de44dab1e9ef) n8n: 1.91.3 -> 1.93.0
* [`1c26c862`](https://github.com/NixOS/nixpkgs/commit/1c26c86248131e168c10b9a55ab279cc5c1d0333) cbmc: 6.4.1 -> 6.6.0
* [`4ff41543`](https://github.com/NixOS/nixpkgs/commit/4ff415437167fc7c88dc6abe9b34eed67f02bca9) ocamlPackages.ocamlfuse: 2.7.1_cvs12 -> 2.7.1_cvs13
* [`086d0d00`](https://github.com/NixOS/nixpkgs/commit/086d0d00b0b752bb35657b8c9d2f93dc17893955) handheld-daemon: 3.15.3 -> 3.15.7
* [`3b99e5e6`](https://github.com/NixOS/nixpkgs/commit/3b99e5e60cf6030faa844e75352041fb06bee7c5) descent3-unwrapped: 1.5.0-beta-unstable-2025-05-08 -> 1.5.0-beta-unstable-2025-05-23
* [`d5d323a9`](https://github.com/NixOS/nixpkgs/commit/d5d323a907b0ff04ec0b78fbf35d96ea270cafc5) emergencyMode, emergencyAccess: cross reference options in docs.
* [`e02ad17d`](https://github.com/NixOS/nixpkgs/commit/e02ad17dbc8c09356df113d94b130fd573d30b57) reth: 1.3.12 -> 1.4.3
* [`e02add77`](https://github.com/NixOS/nixpkgs/commit/e02add77063b34d13cafd23ecbd58f0f86d81631) hasura-cli: 2.3.1 -> 2.48.1
* [`64ffb469`](https://github.com/NixOS/nixpkgs/commit/64ffb46946dbc7546089deda30b3ee97d7a22f73) avbroot: 3.16.0 -> 3.16.1
* [`b7e5cd68`](https://github.com/NixOS/nixpkgs/commit/b7e5cd681e505582ed2502ce5f6e7b954fba506f) linuxPackages.tuxedo-drivers: 4.13.0 -> 4.13.1
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
