### PR TITLE
niv home-manager: update d23d20f5 -> c7fdb7e9

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -77,10 +77,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d23d20f55d49d8818ac1f1b2783671e8a6725022",
-        "sha256": "1h32x8cyhjnz8jhnijs2xh98xmg1q2rrl9gmlj1l3sd8bjr9v929",
+        "rev": "c7fdb7e90bff1a51b79c1eed458fb39e6649a82a",
+        "sha256": "199hn3p4gdqr1y0ymw9c436hx6m1vs1n4qhnmdd3xl6ah76qn7qh",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/d23d20f55d49d8818ac1f1b2783671e8a6725022.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/c7fdb7e90bff1a51b79c1eed458fb39e6649a82a.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@d23d20f5...c7fdb7e9](https://github.com/nix-community/home-manager/compare/d23d20f55d49d8818ac1f1b2783671e8a6725022...c7fdb7e90bff1a51b79c1eed458fb39e6649a82a)

* [`8cb8a04c`](https://github.com/nix-community/home-manager/commit/8cb8a04cb1383fe08bb6cbf672f00ed60c92bbbd) home-cursor: set hyprcursor size default ([nix-community/home-manager⁠#7145](https://togithub.com/nix-community/home-manager/issues/7145))
* [`ad22169e`](https://github.com/nix-community/home-manager/commit/ad22169efa67448badd870076e441778f4cf7948) jellyfin-mpv-shim: add module ([nix-community/home-manager⁠#7129](https://togithub.com/nix-community/home-manager/issues/7129))
* [`f5b12be8`](https://github.com/nix-community/home-manager/commit/f5b12be834874f7661db4ced969a621ab2d57971) polkit-gnome: Change `After` target ([nix-community/home-manager⁠#7137](https://togithub.com/nix-community/home-manager/issues/7137))
* [`9bf9b1ae`](https://github.com/nix-community/home-manager/commit/9bf9b1ae000a8484f718bef93a381fe7752e98b5) Translate using Weblate (Persian) ([nix-community/home-manager⁠#7150](https://togithub.com/nix-community/home-manager/issues/7150))
* [`02077149`](https://github.com/nix-community/home-manager/commit/02077149e2921014511dac2729ae6dadb4ec50e2) flake.lock: Update ([nix-community/home-manager⁠#7148](https://togithub.com/nix-community/home-manager/issues/7148))
* [`115344f3`](https://github.com/nix-community/home-manager/commit/115344f32b56ae9581386bf0ab9e3df7adc92a82) chromium: allow nullable package ([nix-community/home-manager⁠#7149](https://togithub.com/nix-community/home-manager/issues/7149))
* [`ad88262f`](https://github.com/nix-community/home-manager/commit/ad88262f06e903e6643e760dfeaee01d492c4662) kitty: make extraConfig obey mkOrder
* [`7d2fcc86`](https://github.com/nix-community/home-manager/commit/7d2fcc864eb10139258a020611b67111df54a604) pywal: make kitty config appear at start to not override user vals
* [`13ed57aa`](https://github.com/nix-community/home-manager/commit/13ed57aaa679253d7989db21f4581ae85b2167fa) meli: adding the meli email client ([nix-community/home-manager⁠#7111](https://togithub.com/nix-community/home-manager/issues/7111))
* [`85a27991`](https://github.com/nix-community/home-manager/commit/85a27991d5d9c980e33179b2fc7f0eb4f7262db0) fish: add binds option ([nix-community/home-manager⁠#7121](https://togithub.com/nix-community/home-manager/issues/7121))
* [`95c988cf`](https://github.com/nix-community/home-manager/commit/95c988cf08e9a5a8fe7cc275d5e3f24e9e87bd51) xsession: add xdg-desktop-autostart to requires of hm-graphical-session ([nix-community/home-manager⁠#7108](https://togithub.com/nix-community/home-manager/issues/7108))
* [`da282034`](https://github.com/nix-community/home-manager/commit/da282034f4d30e787b8a10722431e8b650a907ef) darwinScrublist: update ([nix-community/home-manager⁠#7157](https://togithub.com/nix-community/home-manager/issues/7157))
* [`2f4db1cd`](https://github.com/nix-community/home-manager/commit/2f4db1cd5be0afaa0a2ec8fa5da6460f0ebdbc11) yambar: add systemd service ([nix-community/home-manager⁠#5469](https://togithub.com/nix-community/home-manager/issues/5469))
* [`8a4b3826`](https://github.com/nix-community/home-manager/commit/8a4b38262755fce39551e1182af1621a06ddde35) kodi: make type for settings less restrictive ([nix-community/home-manager⁠#5277](https://togithub.com/nix-community/home-manager/issues/5277))
* [`4e9efaa6`](https://github.com/nix-community/home-manager/commit/4e9efaa68b0be7e19127dad4f0506a9b89e28ef4) misc: add librewolf native messaging hosts ([nix-community/home-manager⁠#7127](https://togithub.com/nix-community/home-manager/issues/7127))
* [`d3a3aee5`](https://github.com/nix-community/home-manager/commit/d3a3aee558979d9b0dde1c0814d8f9f96884aeed) dconf: Fix Gio module variable breakage ([nix-community/home-manager⁠#7146](https://togithub.com/nix-community/home-manager/issues/7146))
* [`482c306e`](https://github.com/nix-community/home-manager/commit/482c306ef70785f53d9d90839b6b5643521ac031) home-manager: update xgettext and PO files
* [`d36ac1f0`](https://github.com/nix-community/home-manager/commit/d36ac1f0db0bc5e8f6ac4e230c9cca7f9e35a179) hwatch: add module ([nix-community/home-manager⁠#7158](https://togithub.com/nix-community/home-manager/issues/7158))
* [`d800d198`](https://github.com/nix-community/home-manager/commit/d800d198b8376ffb6d8f34f12242600308b785ee) podman: use quadlet source from file drv ([nix-community/home-manager⁠#7102](https://togithub.com/nix-community/home-manager/issues/7102))
* [`214f9bd3`](https://github.com/nix-community/home-manager/commit/214f9bd3a693bbc8cc6d705d01421787e04eaacd) linux-wallpaperengine: fix evaluation error when passing null ([nix-community/home-manager⁠#7161](https://togithub.com/nix-community/home-manager/issues/7161))
* [`6f0a6e7b`](https://github.com/nix-community/home-manager/commit/6f0a6e7ba7ab4fb01ced557378d64740554a0766) Update translation files ([nix-community/home-manager⁠#7162](https://togithub.com/nix-community/home-manager/issues/7162))
* [`379c9fb8`](https://github.com/nix-community/home-manager/commit/379c9fb858ef9abe92d5590e7502a7c1387c076a) yazi: use mgr instead of manager in example ([nix-community/home-manager⁠#7160](https://togithub.com/nix-community/home-manager/issues/7160))
* [`9d2ae595`](https://github.com/nix-community/home-manager/commit/9d2ae59579b61a2137f12d87452733e3ab04d721) ci: add backport workflow
* [`7c60ea02`](https://github.com/nix-community/home-manager/commit/7c60ea029602851cdeb2f3246e991fcc117195bc) ci: add 'GitHub App' TODO to update workflow
* [`b65126fa`](https://github.com/nix-community/home-manager/commit/b65126fa71e744c53fbae44d90139d3069711ac4) ci: fix backport if condition ([nix-community/home-manager⁠#7167](https://togithub.com/nix-community/home-manager/issues/7167))
* [`6d09fd37`](https://github.com/nix-community/home-manager/commit/6d09fd37a7d4110251c1c03cb09fbf6321fbe10d) ci: alternative fix for backport if condition ([nix-community/home-manager⁠#7169](https://togithub.com/nix-community/home-manager/issues/7169))
* [`b6bd7c62`](https://github.com/nix-community/home-manager/commit/b6bd7c629fcb34aec25781478fa7a228f59ebbfd) ci: add more modules to labeler
* [`5118087a`](https://github.com/nix-community/home-manager/commit/5118087a159f448e2a569f03282eac7ceeb75793) ci: sort label categories
* [`7ccda857`](https://github.com/nix-community/home-manager/commit/7ccda8574fc76a3e1361ae482a301a1d883a90f3) ci: labels dedupe and reorganize
* [`765ceb93`](https://github.com/nix-community/home-manager/commit/765ceb93d1b75401b9b85da00a36c58864a3fb27) lib: remove literalExpression and literalDocBook logic
* [`cc8896c3`](https://github.com/nix-community/home-manager/commit/cc8896c32130182c9d6633fd4dea16b096073f1f) ci: remove literalExpression step
* [`6587238e`](https://github.com/nix-community/home-manager/commit/6587238e406dcb64cd74a7f17b9d3e2461908519) lib: remove 22.11 deprecations
* [`60e46243`](https://github.com/nix-community/home-manager/commit/60e4624302d956fe94d3f7d96a560d14d70591b9) news: re-add dropped news entries ([nix-community/home-manager⁠#7173](https://togithub.com/nix-community/home-manager/issues/7173))
* [`5675a968`](https://github.com/nix-community/home-manager/commit/5675a9686851d9626560052a032c4e14e533c1fa) home-cursor: sway depend on cfg.size instead of gtk.cursorTheme.size ([nix-community/home-manager⁠#7176](https://togithub.com/nix-community/home-manager/issues/7176))
* [`9882f43f`](https://github.com/nix-community/home-manager/commit/9882f43f9b870367105b9e4954e1f09c014e5c4d) ci: switch to a GitHub App
* [`6abf2794`](https://github.com/nix-community/home-manager/commit/6abf27943bbb09a0f9d443df45ec70b07a6cbe20) ci: set a more useful update PR body
* [`654b6865`](https://github.com/nix-community/home-manager/commit/654b686536e5405504299a93c6a330169c23372a) mako: add extraConfig back
* [`6861cfa1`](https://github.com/nix-community/home-manager/commit/6861cfa165b7fbc6f5a0305cae7c5b3985de6886) mako: remove criteria
* [`c7fdb7e9`](https://github.com/nix-community/home-manager/commit/c7fdb7e90bff1a51b79c1eed458fb39e6649a82a) tests/mako: test extraConfig
