### PR TITLE
niv nixpkgs: update 184cf802 -> e9761a0d

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -155,10 +155,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "184cf80254382ba91cc0a86af2cb62b8d9d94637",
-        "sha256": "0zw3bsc669gnhwjdw37gc93n1arsmpfnjb4djq3ihr2ck20zxavy",
+        "rev": "e9761a0d6685771814d3ee7a4cb3fc8f01485fa5",
+        "sha256": "17xbghmjyvnlb1jkf77nz570cxkvnsddmqz32izc0va6wnnjjfga",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/184cf80254382ba91cc0a86af2cb62b8d9d94637.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/e9761a0d6685771814d3ee7a4cb3fc8f01485fa5.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@184cf802...e9761a0d](https://github.com/nixos/nixpkgs/compare/184cf80254382ba91cc0a86af2cb62b8d9d94637...e9761a0d6685771814d3ee7a4cb3fc8f01485fa5)

* [`5effd640`](https://github.com/NixOS/nixpkgs/commit/5effd6403dbe11a515f33033051c727614ba6c27) adapted AUR's cozette PKGBUILD
* [`39409302`](https://github.com/NixOS/nixpkgs/commit/39409302e4d890a4ef5050d23f764e19d001132a) allow psf codepoints to be overridden
* [`dbcc74bf`](https://github.com/NixOS/nixpkgs/commit/dbcc74bfe10b2a4bdc1b268a6b1624287a265087) kodiPackages.six: set PYTHON_PATH
* [`9ad8aafa`](https://github.com/NixOS/nixpkgs/commit/9ad8aafad28f37dc6d6ffc98634525306e6db38e) veridian: init at d094c9d
* [`bec56298`](https://github.com/NixOS/nixpkgs/commit/bec562981304f4997fd129b81c3aa49b72e93a0e) python313Packages.simplekv: fix inputs
* [`c8def8c2`](https://github.com/NixOS/nixpkgs/commit/c8def8c2181fe49d78a50547fcbd1ac79aabf1f6) rott: move to pkgs/by-name tree
* [`fa72edbd`](https://github.com/NixOS/nixpkgs/commit/fa72edbde75f4f75a73266f82ee39e65513a5730) rott: refactor
* [`c0f8e318`](https://github.com/NixOS/nixpkgs/commit/c0f8e318d77c0c3d9afdd095632282c47555a322) rott-shareware: include shareware data
* [`723f9b5d`](https://github.com/NixOS/nixpkgs/commit/723f9b5d881f0f4bbc0da909718f4abafd1e7b2c) saxon: use stdenvNoCC instead of stdenv
* [`8a8dab47`](https://github.com/NixOS/nixpkgs/commit/8a8dab4758bc503f8df90dd712b1db5c4f17b4b3) saxon: use installPhase instead of buildCommand
* [`a1ac54e2`](https://github.com/NixOS/nixpkgs/commit/a1ac54e2679f77f09f69c5cd06acabc466cd4551) saxon: use makeWrapper to create mainProgram and additional binaries
* [`09a349e1`](https://github.com/NixOS/nixpkgs/commit/09a349e10410d02cd7f283c97b1ffa877a432ed9) saxon: use sri hashes
* [`55fc5541`](https://github.com/NixOS/nixpkgs/commit/55fc5541738eda81a2876e5efa1a4001c4781a92) python313Packages.simplekv: Move dulwich to nativeCheckInputs
* [`613cca16`](https://github.com/NixOS/nixpkgs/commit/613cca1638182c1d4ca3edc3264c323b9e61c3b9) python313Packages.simplekv: Add dependency groups for backends
* [`01b6a6d0`](https://github.com/NixOS/nixpkgs/commit/01b6a6d00f7ab75cfc16721b840d3a32c416ced1) python313Packages.simplekv: Add bbenne10 as maintainer
* [`15e3bd7a`](https://github.com/NixOS/nixpkgs/commit/15e3bd7ab07cbb2c761615c759ff1af0c8521b3f) maintainer-list: update bbenne10 information
* [`4d657c9c`](https://github.com/NixOS/nixpkgs/commit/4d657c9c560a33b93290fce2ac22d36e6c8152b2) saxon: use sourceRoot
* [`133974d0`](https://github.com/NixOS/nixpkgs/commit/133974d0174b36f6a15d75d7826d3087462f4949) nixos/tailscale-auth: restart on-failure and wait for tailscaled
* [`65cc82ca`](https://github.com/NixOS/nixpkgs/commit/65cc82caaec0458b8177246d1b725d32ff8a1052) cargo-component: 0.20.0 -> 0.21.1
* [`11badbc0`](https://github.com/NixOS/nixpkgs/commit/11badbc0093b552aab5b7e302d8cba40395d306d) python312Packages.curl-cffi: 0.7.4 -> 0.10.0
* [`d8f9c635`](https://github.com/NixOS/nixpkgs/commit/d8f9c63512b01e519465476a4dc7acb0848d676b) nixos/networkd: update valid KeepConfiguration values
* [`9bf1c685`](https://github.com/NixOS/nixpkgs/commit/9bf1c6850bdb4d8cf65811941bf8e8562764f6f8) pavucontrol: remove libpressureaudio build input
* [`fa568964`](https://github.com/NixOS/nixpkgs/commit/fa56896456dd075d1db65105ed12c05e150276a8) librespot: add withMDNS + withDNS-SD arguments
* [`88ef9cf9`](https://github.com/NixOS/nixpkgs/commit/88ef9cf9940497d28bf392e4e497eea7eb090e9d) zig: unconditionally enable strictDeps
* [`82493b30`](https://github.com/NixOS/nixpkgs/commit/82493b30a07543680635a18c94a0dfaee7c86af9) zig: remove SystemVersion.plist from Darwin __impureHostDeps
* [`409d7cdf`](https://github.com/NixOS/nixpkgs/commit/409d7cdfa9e855bc24868e69c4dde06447f7ebcd) zluda: provide fallback CMAKE_BUILD_TYPE
* [`261aa665`](https://github.com/NixOS/nixpkgs/commit/261aa665176b4641da822f068a4c2d4d242a3e07) osquery: 5.16.0 -> 5.17.0
* [`a2219e55`](https://github.com/NixOS/nixpkgs/commit/a2219e5559ab8626ec607b67e57fb22e3744efa8) pinact: ignore pre-release versions in updateScript
* [`a8fd6871`](https://github.com/NixOS/nixpkgs/commit/a8fd6871bc7fcd2f7c641c46dfe9de0c16108602) perlPackages.NetMQTTSimple: Add IO::Socket::SSL
* [`3cef998e`](https://github.com/NixOS/nixpkgs/commit/3cef998e3880128858030cb49ef53bee67a71f13) ns-usbloader: 7.1 -> 7.2
* [`22d5893f`](https://github.com/NixOS/nixpkgs/commit/22d5893faec01fce7b9abbe9f9ba415f924c21b0) prelink: unstable-2019-06-24 -> 20151030-unstable-2024-07-02
* [`bb331755`](https://github.com/NixOS/nixpkgs/commit/bb33175535573b926ad840e224a3529dc26ee0c4) whatsapp-chat-exporter: 0.10.5 -> 0.12.0
* [`e9d158c8`](https://github.com/NixOS/nixpkgs/commit/e9d158c842fed0e530682dd7dd2ef587900ab82e) pnpm.fetchDeps: allow overriding the pnpm version
* [`ec71f25a`](https://github.com/NixOS/nixpkgs/commit/ec71f25aca0c85f41f599bf83de9df2301f98fef) bitwig-studio: 5.3.5 -> 5.3.8
* [`5b1167fd`](https://github.com/NixOS/nixpkgs/commit/5b1167fd145014df6668fca0600df899224506c8) openbooks: init at 4.5.0
* [`1c73ac43`](https://github.com/NixOS/nixpkgs/commit/1c73ac43d63197a65ad82b936415cbb6dedc32c9) tandoor-recipes: 1.5.32 -> 1.5.34
* [`cefb3364`](https://github.com/NixOS/nixpkgs/commit/cefb33646aee9e36f77e9f3f7a04b7487b137075) spectre-meltdown-checker: 0.46 -> 0.46-unstable-2024-08-04
* [`2da84ac3`](https://github.com/NixOS/nixpkgs/commit/2da84ac31d69ddcdf70a9dff741d985fccccbabc) spectre-meltdown-checker: use replace-fail
* [`ccb9ae1d`](https://github.com/NixOS/nixpkgs/commit/ccb9ae1decb8350c88b63a88544b351caeca5e5f) spectre-meltdown-checker: add updateScript
* [`23eb3482`](https://github.com/NixOS/nixpkgs/commit/23eb34822d486b5a3b2febc3ab0d4703da81f001) zenergy: 0-unstable-2024-10-10 -> 0-unstable-2025-04-15
* [`bd3f055e`](https://github.com/NixOS/nixpkgs/commit/bd3f055ed832f92cfd3d923ae27c8de2bc2e204c) joplin-desktop: correct WMClass
* [`b58041ab`](https://github.com/NixOS/nixpkgs/commit/b58041abb1aaf09cde92843107f0288a191d6290) autopsy: fix java.lang.UnsatisfiedLinkError
* [`34cd7596`](https://github.com/NixOS/nixpkgs/commit/34cd7596702ceb02bcd54f25e3c4628f5c855c1d) ibus-table-chinese: 1.8.3 -> 1.8.12
* [`4eb5ddb5`](https://github.com/NixOS/nixpkgs/commit/4eb5ddb53decdf5314247e554d95e5e053c0e565) signal-desktop: add commandLineArgs for persistent flags
* [`89187a62`](https://github.com/NixOS/nixpkgs/commit/89187a62b44068351c8395ed28195bdfd81da9ef) nixos/kandim: Fix pkg name withSecretProvisioning
* [`cd3824f7`](https://github.com/NixOS/nixpkgs/commit/cd3824f7bc8eaa57a3d2332a0c0349715c9ea35f) nixos/alloy: add environmentFile option
* [`07932025`](https://github.com/NixOS/nixpkgs/commit/07932025155462e4b0363b39d76188dffb91df6b) ignition: 1.1.3 -> 2.1.1
* [`be16ca64`](https://github.com/NixOS/nixpkgs/commit/be16ca643fd3ef82388eb15cd7a26c9449f9a48d) multipath-tools: 0.9.8 -> 0.11.1
* [`484833bc`](https://github.com/NixOS/nixpkgs/commit/484833bcf85721cea12e7ef8ca112a5bfcd7e112) bootspec: 1.0.0 -> 1.0.1
* [`4a80f62e`](https://github.com/NixOS/nixpkgs/commit/4a80f62ecbe36ca1de4265d187e85556f479710c) arrow-cpp: ignore one more test
* [`62fb31ee`](https://github.com/NixOS/nixpkgs/commit/62fb31ee74ebc169f83dfe6a73bcf3f2cb820cd8) arrow-cpp: update for protobuf 30
* [`93e26688`](https://github.com/NixOS/nixpkgs/commit/93e26688f170c65813929728b5e7748a1dd21a19) arrow-cpp: enable Apache ORC
* [`493cbcc7`](https://github.com/NixOS/nixpkgs/commit/493cbcc714712f050bb97ab0eeb6fe346e4400e6) python3Packages.pyarrow: check orc import
* [`55d05faa`](https://github.com/NixOS/nixpkgs/commit/55d05faa1f57d312b29a0a36386fd641a4aa344d) nodeenv: expose binary from python3Packages.nodeenv as an application package
* [`c00a9089`](https://github.com/NixOS/nixpkgs/commit/c00a9089374d41bb6f04c856ef05a9cdd37b2bff) shogihome: refine updateScript to support electron version
* [`d2358d77`](https://github.com/NixOS/nixpkgs/commit/d2358d770d1718d8b18752f72bd5dea96f6df9ed) shogihome: 1.22.1 -> 1.23.0
* [`e9c93a13`](https://github.com/NixOS/nixpkgs/commit/e9c93a13161bb1bda0e5510ee43243e58562904c) libsForQt5.qtpbfimageplugin: 4.0 → 4.2
* [`e39a2999`](https://github.com/NixOS/nixpkgs/commit/e39a2999310d7d3fdbf56d17121d503bcd4cdb10) gpu-screen-recorder{,-gtk}: move to pkgs/by-name
* [`2f3a205f`](https://github.com/NixOS/nixpkgs/commit/2f3a205f64a9123a02077582c76d59d2cf4eeb0c) gpu-screen-recorder{,-gtk}: add passthru.updateScript
* [`ee022814`](https://github.com/NixOS/nixpkgs/commit/ee022814764a73749561b069ae3d677aea78ce44) gpu-screen-recorder{,-gtk}: use fetchgit instead of fetchurl
* [`9bfb3e72`](https://github.com/NixOS/nixpkgs/commit/9bfb3e72b7be38cc255e775cc22296b5f4b404b4) gpu-screen-recorder{,-gtk}: add myself as maintainer
* [`6fe3a613`](https://github.com/NixOS/nixpkgs/commit/6fe3a6135eb94799ca106aa38ba4c922d72709e7) gpu-screen-recorder: 5.2.0 -> 5.5.3
* [`f18cf012`](https://github.com/NixOS/nixpkgs/commit/f18cf012cfef88a114ab2c414e6302fec9a5e929) nixos/gpu-screen-recorder: add `cap_sys_nice` back
* [`110d7b29`](https://github.com/NixOS/nixpkgs/commit/110d7b29b30208a6aaa4e95b8c878e3d6e4c0709) gpu-screen-recorder-gtk: 5.1.6 -> 5.7.0
* [`b9406622`](https://github.com/NixOS/nixpkgs/commit/b94066224171c81d56a278c87eeb0f4509ab6139) libresprite: 1.1 -> 1.2
* [`48487115`](https://github.com/NixOS/nixpkgs/commit/4848711568852e98e3452bcb77ad8b20e13626ea) app2unit: init at 0-unstable-2025-05-09
* [`d3e0b0e2`](https://github.com/NixOS/nixpkgs/commit/d3e0b0e297cbd867b35909fa55987cff9110ee82) radicle: Remove sunset package aliases
* [`f41757fe`](https://github.com/NixOS/nixpkgs/commit/f41757fecf565e9666dc3e373ccd69ece0484cbd) chawan: 0-unstable-2025-04-18 -> 0-unstable-2025-05-13
* [`4cf1744f`](https://github.com/NixOS/nixpkgs/commit/4cf1744fecaee82994c34a11eee289eb09957b32) fakeroot: 1.36 -> 1.37.1.2
* [`a1d904f9`](https://github.com/NixOS/nixpkgs/commit/a1d904f9a4803e5c1a411e01307de25f212d6658) alacritty-graphics: init at 0.15.1
* [`3196134d`](https://github.com/NixOS/nixpkgs/commit/3196134d906ffeca4e56c9dae6b7062c6cd3f71c) gleam: add myself as maintainer
* [`21e7164d`](https://github.com/NixOS/nixpkgs/commit/21e7164d77ec2e5c9913159a94eac7b797e4f024) libkate: 0.4.1 -> 0.4.3
* [`a4854954`](https://github.com/NixOS/nixpkgs/commit/a4854954965a0597ba85e082f4e93452aefc2de4) libsidplayfp: 2.13.1 -> 2.14.0
* [`58dc404a`](https://github.com/NixOS/nixpkgs/commit/58dc404ae053730777f87a96b7366a6978695d16) ocrodjvu: 0.13.2 -> 0.14; python3Packages.python-djvulibre: 0.9.1 ->
* [`3a45ce7b`](https://github.com/NixOS/nixpkgs/commit/3a45ce7bb0779c0da6bb38602d6e0cd553132881) adw-gtk3: 5.10 -> 6.2
* [`4f91e646`](https://github.com/NixOS/nixpkgs/commit/4f91e6463eedb45a9ce6a37083f46cfe7f595532) adw-gtk3: add myself as maintainer
* [`b7ae196d`](https://github.com/NixOS/nixpkgs/commit/b7ae196d3f6e5c3f3fbff73aff73b6697514c041) shogihome: 1.23.0 -> 1.23.2
* [`ca8ccdb5`](https://github.com/NixOS/nixpkgs/commit/ca8ccdb5f20dfc080a87d7b92a5fb4ee0cf3248c) bitwig-studio: fix missing lcms dependency
* [`712e1a62`](https://github.com/NixOS/nixpkgs/commit/712e1a622e7dd630d8c3b4e71ad9a6bfa4fd8c51) super-productivity: 12.0.5 -> 13.0.10
* [`2e3bb958`](https://github.com/NixOS/nixpkgs/commit/2e3bb9581af4775889d690f19bd4dbc911dbebad) nixos/nix-required-mounts: example typo
* [`1e2df291`](https://github.com/NixOS/nixpkgs/commit/1e2df291f14c433663d5755b48f891c98724f26e) anki: minorly simplify build
* [`3e76f46f`](https://github.com/NixOS/nixpkgs/commit/3e76f46fb9335648771914ce0bdac86fcb6e952a) anki: 24.11 -> 25.02.5
* [`1b4bcf24`](https://github.com/NixOS/nixpkgs/commit/1b4bcf24b59d90bc11318b24e3edd0c86f2abb58) zabbix70: 7.0.12 -> 7.0.13
* [`3bf8940c`](https://github.com/NixOS/nixpkgs/commit/3bf8940c4ac0ba38dc145ebb7938f6fbd87e760f) jazz2: 3.2.0 -> 3.3.0
* [`f0bee9da`](https://github.com/NixOS/nixpkgs/commit/f0bee9da80d0a461df1ddac9c7cc3bef2681bbe0) jazz2: sort and enable strictDeps
* [`bd6c30c1`](https://github.com/NixOS/nixpkgs/commit/bd6c30c1b0efdb44609301bd357d750bc9e87cf5) python3Packages.dep-logic: 0.5.0 -> 0.5.1
* [`0235c3f3`](https://github.com/NixOS/nixpkgs/commit/0235c3f34bb3e4cda745e43fab256c496027bf4b) patool: 3.1.0 -> 4.0.1
* [`c4f052c0`](https://github.com/NixOS/nixpkgs/commit/c4f052c08ae5724614fda2913280233cb3c142f0) nixos/kanidm: Fix bind paths
* [`60e131c8`](https://github.com/NixOS/nixpkgs/commit/60e131c86b442453d10d26f61029785560a81fea) python313Packages.starlette-admin: 0.14.1 -> 0.15.0
* [`71e6fda6`](https://github.com/NixOS/nixpkgs/commit/71e6fda65f0ce335087fb4fd22bf56fb7c11f1f2) libdiscid: modernize
* [`da6d32b3`](https://github.com/NixOS/nixpkgs/commit/da6d32b32c2716aeabd5d73f9474df55150fbe09) libdiscid: 0.6.4 -> 0.6.5
* [`3f47b2cf`](https://github.com/NixOS/nixpkgs/commit/3f47b2cf27dbd04fb0e7c6122fbf5cc91dcbd018) fish-lsp: use finalAttrs
* [`28189a7a`](https://github.com/NixOS/nixpkgs/commit/28189a7ac0226c2ee2d3738a4ead413de4be095e) nixos/matrix-synapse: Fix merging log configuration
* [`d8eb7d36`](https://github.com/NixOS/nixpkgs/commit/d8eb7d36e0dff8470b73c9180c76f179d6cc29f8) nats-server: 2.11.3 -> 2.11.4
* [`1b2f0d57`](https://github.com/NixOS/nixpkgs/commit/1b2f0d579db076f383e6294f40c7f201dcde1f6c) xdg-desktop-portal: 1.20.0 -> 1.20.3
* [`77e4c5a0`](https://github.com/NixOS/nixpkgs/commit/77e4c5a0fafae63c61161ba32462f665f244ae43) mariadb: 10.6.22, 10.11.13, 11.4.7
* [`ca1ec659`](https://github.com/NixOS/nixpkgs/commit/ca1ec659ee9168db0a159a7d433cdc241c5616e3) kubie: wrap kubectl
* [`1d8ea85c`](https://github.com/NixOS/nixpkgs/commit/1d8ea85cdaf870196d91915c0793e12f4f939aad) kubie: add fish completion
* [`0ab19b63`](https://github.com/NixOS/nixpkgs/commit/0ab19b633c82225c7ab350a2631b5959337f4d93) terragrunt: 0.78.4 -> 0.80.2
* [`1d320871`](https://github.com/NixOS/nixpkgs/commit/1d32087125a9bb3e700b206ceb6eea28fdf07716) fetchpatch: add support for patches to files with apostrophes
* [`b2a979a4`](https://github.com/NixOS/nixpkgs/commit/b2a979a4b468139f3cf102d9d83dc5bed91620d7) python313Packages.stomp-py: init at 8.2.0
* [`f40fdc43`](https://github.com/NixOS/nixpkgs/commit/f40fdc43f53b68b367e61b7bf7a152910940cf83) python3Packages.luna-usb: 0.1.3 -> 0.2.0
* [`ed96ad91`](https://github.com/NixOS/nixpkgs/commit/ed96ad9101a0e3e74dcde8fd8bf81520c0a33b25) python3Packages.luna-soc: 0.2.2 -> 0.3.2
* [`fd2905b9`](https://github.com/NixOS/nixpkgs/commit/fd2905b9a8e25b412a28b91c42beeffe9bf24e2f) python3Packages.cynthion: 0.1.8 -> 0.2.0
* [`c1d715fc`](https://github.com/NixOS/nixpkgs/commit/c1d715fce65a032123e885024516498277aab2ca) cynthion: remove amaranth version override
* [`f443d8a5`](https://github.com/NixOS/nixpkgs/commit/f443d8a56e90484f375acd7a1192167c46ae9bbc) python313Packages.pyrender: use llvmpipeHook
* [`35eb2878`](https://github.com/NixOS/nixpkgs/commit/35eb287841065d28bbd76c05b9e25860aebb4f5b) maintainers: add leana8959
* [`c9eddce6`](https://github.com/NixOS/nixpkgs/commit/c9eddce63eab42d95bbce2073d0eb386f9025dd0) noto-fonts-cjk-serif: add static option
* [`5c4cd8db`](https://github.com/NixOS/nixpkgs/commit/5c4cd8db3abeec10739ad2128c055e32153c1d30) kissfftFloat: migrate cmakeFeature to cmakeBool
* [`eb222495`](https://github.com/NixOS/nixpkgs/commit/eb222495bcbf7df5b8a7d3929ef05b08b57044e7) vanillara: migrate cmakeFeature to cmakeBool
* [`664bd068`](https://github.com/NixOS/nixpkgs/commit/664bd068f5a03611b9a582e0e7b00c2609ba25a1) python3Packages.djangosaml2: 1.10.1 -> 1.11.0
* [`2844748c`](https://github.com/NixOS/nixpkgs/commit/2844748c4bdf9d001079c225b309df7d5a3b9d2d) mozhi: init at 0-unstable-2025-04-14
* [`f0c9b09b`](https://github.com/NixOS/nixpkgs/commit/f0c9b09b8552ea0e44a3a0447b8604fa1a1119b2) python313Packages.textx.passthru.tests.*: fix meta.homepage
* [`511c0174`](https://github.com/NixOS/nixpkgs/commit/511c01740cbf6cff4601061854190fbaa59bdf91) lnav: fix running in tmux
* [`d24d2fc0`](https://github.com/NixOS/nixpkgs/commit/d24d2fc0d956e6d480a33885421fe37870417863) python3Packages.influxdb-client: 1.48.0 -> 1.49.0
* [`fb78afbb`](https://github.com/NixOS/nixpkgs/commit/fb78afbbd0ea83eed2e02d6f8d5a43719fb438df) linux/common-config: Enable ACPI_DEBUG
* [`60a907b7`](https://github.com/NixOS/nixpkgs/commit/60a907b76a50c85aae6cbcf51aea8b8bd2c060dd) hyphen: add Russian dictionary, update readmeFileName values
* [`c2fcace1`](https://github.com/NixOS/nixpkgs/commit/c2fcace1ac068de1f603993a64c5b0f56c873e34) eduke32: automatically update VC_REV
* [`120880f1`](https://github.com/NixOS/nixpkgs/commit/120880f12c0b8214776eb0981a0a682f07d9becb) eduke32: add update script
* [`e189ab9a`](https://github.com/NixOS/nixpkgs/commit/e189ab9ace70332fc8f89b2ed6b17cb6c685466a) kchmviewer: enable on unix
* [`b05f6f14`](https://github.com/NixOS/nixpkgs/commit/b05f6f1403ef3eeaf6c64bea2d89b0e0b39af43b) kchmviewer: modernize
* [`f399a6d5`](https://github.com/NixOS/nixpkgs/commit/f399a6d589bcd77af1cbed55eb476369ec29882c) kchmviewer: migrate to by-name
* [`597012fb`](https://github.com/NixOS/nixpkgs/commit/597012fb7006b32aeaa1d0c6cd5114fcab0a1cdb) typescript-go: init at 0-unstable-2025-05-23
* [`526fe214`](https://github.com/NixOS/nixpkgs/commit/526fe21447883e9b6d9b531d9c057be69e3a1a60) linuxPackages.opensnitch-ebpf: remove linux.dev references
* [`d5c77fd3`](https://github.com/NixOS/nixpkgs/commit/d5c77fd3fb83b3f983088ff516ca3b00c08c26dd) gex: fix Darwin build
* [`9456b271`](https://github.com/NixOS/nixpkgs/commit/9456b271f4f86303a6562ec8d8cf0e14acf3b915) pingvin-share: 1.11.1 -> 1.13.0
* [`415318fe`](https://github.com/NixOS/nixpkgs/commit/415318fedf90bc8d72988597dbdaa65cdc0be796) aseprite: 1.3.7 -> 1.3.13
* [`31fb6485`](https://github.com/NixOS/nixpkgs/commit/31fb64851e752b18fc9fbda1af6b94fce7c23e1e) racket, racket-minimal: 8.16 -> 8.17
* [`84047a31`](https://github.com/NixOS/nixpkgs/commit/84047a3142a9ac2f17957aec8e35a5d97a80decb) racket, racket-minimal: move to pkgs/by-name
* [`a8d0fd7e`](https://github.com/NixOS/nixpkgs/commit/a8d0fd7e40a2368dcb88296b0c52bd0e8116b9a4) racket, racket-minimal: specify meta.sourceProvenance
* [`1b17b966`](https://github.com/NixOS/nixpkgs/commit/1b17b966d46898db1d11deb3efc7e342836a974e) python3Packages.molecule: 25.4.0 -> 25.5.0
* [`56267970`](https://github.com/NixOS/nixpkgs/commit/56267970c2a7818a5f89508e1733520d7deb7df8) adw-gtk3: add normalcea as maintainer
* [`1228b36d`](https://github.com/NixOS/nixpkgs/commit/1228b36dbf39428356553f19db23c2e152e99885) adw-gtk3: change description
* [`42af7c53`](https://github.com/NixOS/nixpkgs/commit/42af7c534c901d08a4435f196578844d173358aa) racket, racket-minimal: remove redundant patch for Darwin
* [`bda9a249`](https://github.com/NixOS/nixpkgs/commit/bda9a249be44f3643617c4031cd01daecd6042c5) plutovg: 1.0.0 -> 1.1.0
* [`c1afaee9`](https://github.com/NixOS/nixpkgs/commit/c1afaee9edfeada46e3e8c5a2b2aa586860d4cf2) pre-commit: 4.0.1 → 4.2.0
* [`ac52796e`](https://github.com/NixOS/nixpkgs/commit/ac52796e8b16a3a401005baf51aab3778358990e) maid: update all gems
* [`2f51cb1f`](https://github.com/NixOS/nixpkgs/commit/2f51cb1f8f65c7e0a6f7a8006e88dfd50fc9746f) dorion: 5.0.1 → 6.7.1; dorion: build from source
* [`38724aa8`](https://github.com/NixOS/nixpkgs/commit/38724aa8849d9ac5c6f7941a81d9cc4552e561fb) wmenu: 0.1.9-unstable-2025-03-01 -> 0.2.0
* [`94a3c1a1`](https://github.com/NixOS/nixpkgs/commit/94a3c1a13d87525b351a663d2d129340a9dbdc27) wmenu: add sweiglbosker as maintainer
* [`28e98041`](https://github.com/NixOS/nixpkgs/commit/28e980411dee1da39f1fe499f57afbb1a4b9aff4) matrix-continuwuity: add rocksdb to passthru
* [`554ede7e`](https://github.com/NixOS/nixpkgs/commit/554ede7eefb10674057032e44fb3722e999f8427) maintainers: add nilathedragon
* [`bff33677`](https://github.com/NixOS/nixpkgs/commit/bff336776d788149c0886d2095ff7015179ed611) oh-my-posh: 24.11.4 -> 25.23.2
* [`542dc8f4`](https://github.com/NixOS/nixpkgs/commit/542dc8f4aeb49bc44566fd153db6bb35716fed1d) chawan: 0-unstable-2025-05-13 -> 0-unstable-2025-05-25
* [`1d614683`](https://github.com/NixOS/nixpkgs/commit/1d6146832fcf8b5d2fc11d355694d725a43ff357) ngtcp2-gnutls: 1.12.0 -> 1.13.0
* [`73dd2530`](https://github.com/NixOS/nixpkgs/commit/73dd253079c63b08fbea81295584a047499bbeff) solarus: 1.6.4 -> 2.0.0
* [`b83872b8`](https://github.com/NixOS/nixpkgs/commit/b83872b85a2eb898a35d2d8fc32bf2aab2937b07) binaryninja-free: 5.0.7290 -> 5.0.7486
* [`c7ef20e6`](https://github.com/NixOS/nixpkgs/commit/c7ef20e66c55eab380121e13d3cbf14c6430006c) spotify_player: Install shell completions
* [`f3752be2`](https://github.com/NixOS/nixpkgs/commit/f3752be2ff1ab451324391c2a0d005a9277c657b) python313Packages.granian: use jemalloc hook to fix aarch64-linux
* [`0b09bcb3`](https://github.com/NixOS/nixpkgs/commit/0b09bcb3f8b88383bcece055b845cc7e315ef299) python313Packages.reflex: 0.7.12 -> 0.7.13
* [`770f223c`](https://github.com/NixOS/nixpkgs/commit/770f223c2bb4e796d11f66cd0ad269de1efef43f) harper: 0.38.0 -> 0.39.0
* [`9fc20cc5`](https://github.com/NixOS/nixpkgs/commit/9fc20cc5e9da299098563a5f412f1eb4be2b3551) eduke32: remove gtk2
* [`f1948299`](https://github.com/NixOS/nixpkgs/commit/f194829964688221378472a48c7897c714dae1be) python313Packages.pip-install-test: init at 0.5
* [`e54fd3c3`](https://github.com/NixOS/nixpkgs/commit/e54fd3c32a37768ef5b8ee2ccf2bc823e33da45c) python313Packages.newspaper3k: init at 0.2.8
* [`e33586bd`](https://github.com/NixOS/nixpkgs/commit/e33586bdacc060dbb5f53853a95025060250c159) updfparser: Update src URL
* [`16229022`](https://github.com/NixOS/nixpkgs/commit/1622902267ec658a71a151799d1f237d463fcbde) updfparser: unstable-2023-08-08 -> unstable-2023-03-24
* [`6325ef64`](https://github.com/NixOS/nixpkgs/commit/6325ef64df2065516dc7f1479298214c2fa3bae3) libgourou: Update src URL
* [`64aa7ba7`](https://github.com/NixOS/nixpkgs/commit/64aa7ba7f0721c42d67aa55e2066e8d1d808772d) libgourou: 0.8.2 -> 0.8.7
* [`dd00f45c`](https://github.com/NixOS/nixpkgs/commit/dd00f45c405537e34aae1b510c91866bb33ed9ac) kimai: 2.33.0 -> 2.34.0
* [`d2e750de`](https://github.com/NixOS/nixpkgs/commit/d2e750deebe66a7f718d2ea3595e0b1677536e7c) chatzone-desktop: 5.3.0 -> 5.3.2
* [`41aa024e`](https://github.com/NixOS/nixpkgs/commit/41aa024e28dd69ccd1fda2e465d576e943fa2f0e) tracee: 0.20.0 -> 0.23.1
* [`d18d7c6b`](https://github.com/NixOS/nixpkgs/commit/d18d7c6bf8aea63ab66b0d5c67be168fe847b84a) solarus-quest-editor: 1.6.4 -> 2.0.0
* [`f3422b9f`](https://github.com/NixOS/nixpkgs/commit/f3422b9f78b6ec29a80d1fad3e7057af2f3f9a36) solarus: move to by-name
* [`c73bd2a7`](https://github.com/NixOS/nixpkgs/commit/c73bd2a75c664e39868200d5a999cbc6b9de213f) solarus-quest-editor: move to by-name
* [`068806f7`](https://github.com/NixOS/nixpkgs/commit/068806f7ab60c57a837dd8a479d8420ce890da52) contour: remove shell integration scripts
* [`cac9b3f6`](https://github.com/NixOS/nixpkgs/commit/cac9b3f6b84f488884027f0e4ed10761cb410da0) k3s: make update script work with all versions
* [`1e3dae0c`](https://github.com/NixOS/nixpkgs/commit/1e3dae0cce9cd9cf8e78dc619e3104333d48c661) matrix-continuwuity: enable direct_tls build feature
* [`33a3784d`](https://github.com/NixOS/nixpkgs/commit/33a3784d5e37111b2e933cec41ce2532c8dca2b8) siyuan: 3.1.28 -> 3.1.31
* [`a5c7410e`](https://github.com/NixOS/nixpkgs/commit/a5c7410e0ba82993edce6f747e65fe65f579cb5f) nix-check-deps: init at 0-unstable-2025-04-09
* [`975b2c6d`](https://github.com/NixOS/nixpkgs/commit/975b2c6d25c063a0b07b5b97c1b5fcf58d3fd840) bitbucket-server-cli: drop
* [`fbf104ce`](https://github.com/NixOS/nixpkgs/commit/fbf104cef0379395f32ca6159fed629022a76a60) licensed: 5.0.0 -> 5.0.4
* [`0e784416`](https://github.com/NixOS/nixpkgs/commit/0e784416ad7efbe050d49b54b37a7b42f84de6a4) mdbook: 0.4.50 -> 0.4.51
* [`3bd27372`](https://github.com/NixOS/nixpkgs/commit/3bd273723b24cbd8d9d42c330178b1122cd6f540) fantomas: 7.0.1 -> 7.0.2
* [`4cb3d98c`](https://github.com/NixOS/nixpkgs/commit/4cb3d98c05f111bc24c894252d19b83a9988a7d9) v2rayn: 7.11.1 -> 7.12.5
* [`cb55e580`](https://github.com/NixOS/nixpkgs/commit/cb55e580f0d8f15b2280ab3d9ffa9af7f515de5d) python3Packages.sanic-ext: init at 24.12.0
* [`1566c47d`](https://github.com/NixOS/nixpkgs/commit/1566c47d297425152930dda276a4d98626675b2a) cctag: 1.0.3 -> 1.0.4
* [`4eea7ff4`](https://github.com/NixOS/nixpkgs/commit/4eea7ff42736d0fba240ce2fadb7ce00aeffbaca) cctag: Fix Darwin build
* [`67ed0d11`](https://github.com/NixOS/nixpkgs/commit/67ed0d116b527ad7c8205bbc677452b2548b3264) avalanchego: use go 1.23
* [`47a68b52`](https://github.com/NixOS/nixpkgs/commit/47a68b5224687236592a1c16e5f391e78e085253) avalanchego: use finalAttrs
* [`ef559bc0`](https://github.com/NixOS/nixpkgs/commit/ef559bc06c36efb5eba617da7037572c5ac2515e) avalanchego: 1.12.1 -> 1.13.0
* [`3fc5420e`](https://github.com/NixOS/nixpkgs/commit/3fc5420e5f82b4a29c62f959a238e30863d33ddc) mitmproxy: 12.0.1 -> 12.1.1
* [`7ca9f213`](https://github.com/NixOS/nixpkgs/commit/7ca9f213611f4a2ee11baa55a1972336d25af6c0) nixos/wyoming-satellite: fix override to use dependencies
* [`cda4a355`](https://github.com/NixOS/nixpkgs/commit/cda4a3550cf2501d5ee0033c8c6914fcb6327dba) oqs-provider: 0.8.0 -> 0.9.0
* [`039addba`](https://github.com/NixOS/nixpkgs/commit/039addba0c9d22fa3446c98499d9844561b5d80a) zrok: 0.4.46 -> 1.0.4
* [`c4649878`](https://github.com/NixOS/nixpkgs/commit/c46498783a810d687d22d80198aa2512c16e4a4f) animeko: fix
* [`ae1eeae6`](https://github.com/NixOS/nixpkgs/commit/ae1eeae643fc7cd01fc06664f6a278816b58203b) meshcentral: 1.1.44 -> 1.1.45
* [`1d38981b`](https://github.com/NixOS/nixpkgs/commit/1d38981ba5264f5de1530d9762fcf2eb1dd8e128) wol: build on aarch64-darwin
* [`f9ceab72`](https://github.com/NixOS/nixpkgs/commit/f9ceab72671014391386997142704e425358a0dd) shadps4: fix update script
* [`6f852f57`](https://github.com/NixOS/nixpkgs/commit/6f852f57aaaf893612bd066ccda957720af4a3d9) protonplus: 0.4.30 -> 0.4.31
* [`1901d2b3`](https://github.com/NixOS/nixpkgs/commit/1901d2b321f08a03551058de9d968f0ad5fd2b6c) haproxy: 3.1.7 -> 3.2.0
* [`4196e2ce`](https://github.com/NixOS/nixpkgs/commit/4196e2ce85413d7f21a7ac932bfcf0ad70d2ef01) vintagestory: 1.20.9 -> 1.20.11
* [`7f3855ae`](https://github.com/NixOS/nixpkgs/commit/7f3855aee71de319b5b1157c6019fc9eadcb3ffa) srb2: 2.2.13 -> 2.2.15
* [`67b6b488`](https://github.com/NixOS/nixpkgs/commit/67b6b488e474b6a7700c0a0a55710bcb488ac6e1) joplin-desktop: revert deletion of --enable-wayland-ime
* [`23c88614`](https://github.com/NixOS/nixpkgs/commit/23c8861471c06100e5688bfa230deb91dbb1b65d) hotspot: Add kgraphviewer and qcustomplot
* [`43622917`](https://github.com/NixOS/nixpkgs/commit/43622917f3a0d78894d891b237e7a7e7eb23e452) gitlab-triage: 1.23.1 -> 1.44.5
* [`feef46cb`](https://github.com/NixOS/nixpkgs/commit/feef46cb80cc0fd17371a7c90042db0401a4b72f) nix-your-shell: Add generate-config script
* [`5125c5e5`](https://github.com/NixOS/nixpkgs/commit/5125c5e5743a80b12c09f63532663fb6ee121b47) hotspot: Add maintainer tmarkus
* [`fae935a9`](https://github.com/NixOS/nixpkgs/commit/fae935a9f4f11194b8e6b9019e808f708898957b) hotspot: use qt6
* [`b15b9525`](https://github.com/NixOS/nixpkgs/commit/b15b952554a0311909622831d45044ff6b1f3f5c) kddockwidgets: move to by-name
* [`0ed87663`](https://github.com/NixOS/nixpkgs/commit/0ed8766367c1b2da3b9444174d6ba7e9bf304d98) hotspot: move to by-name
* [`21806777`](https://github.com/NixOS/nixpkgs/commit/21806777f2c18104f043bb229f29adf5358983f2) python3Packages.google-cloud-spanner: add optional dependencies for tracing
* [`6c52e60f`](https://github.com/NixOS/nixpkgs/commit/6c52e60f205ed8ebfc636bcaed8cf4fedcae45d6) python3Packages.google-cloud-spanner: 3.54.0 -> 3.55.0
* [`7139b502`](https://github.com/NixOS/nixpkgs/commit/7139b502d10f1f378360e46d77abf31b4010f1ab) freecad: unpin python311
* [`d9360309`](https://github.com/NixOS/nixpkgs/commit/d9360309637b550e9d264982348a4b3c0cf948f5) frescobaldi: unpin python311
* [`b6dd19a1`](https://github.com/NixOS/nixpkgs/commit/b6dd19a100b1f8989f160a9365980e32bfbf8ac0) gpodder: unpin python311
* [`1fe7cd22`](https://github.com/NixOS/nixpkgs/commit/1fe7cd22a9c10d2d7a143a3ae39bde2a932bbe90) nixos/tests/thelounge: fix eval by disabling theme test
* [`8487c267`](https://github.com/NixOS/nixpkgs/commit/8487c267b5872b27ed7c3cb2ef56a69f029cc081) grafana-image-renderer: 3.12.5 -> 3.12.6
* [`bec1f651`](https://github.com/NixOS/nixpkgs/commit/bec1f651b9374f55366c79d48d5736ba0033d35b) pysolfc: unpin python311
* [`6fb8189c`](https://github.com/NixOS/nixpkgs/commit/6fb8189cbc1264ef629cc606519afb33da84b490) renderdoc: unpin python311
* [`26576db8`](https://github.com/NixOS/nixpkgs/commit/26576db882c4fd5c5558744a8ec7617018aeea5e) toolong: unpin python311
* [`94ea5940`](https://github.com/NixOS/nixpkgs/commit/94ea5940baeb3818b132d1dd920d4e91d68fd9c9) dooit-extras: unpin python311
* [`b191a713`](https://github.com/NixOS/nixpkgs/commit/b191a71325d0073fd27e0e5562956a5c3c311ecb) dooit: unpin python311
* [`ac08339a`](https://github.com/NixOS/nixpkgs/commit/ac08339ad2c68f27824e26f632af779c4e491b68) py3c: unpin python311
* [`167c2e87`](https://github.com/NixOS/nixpkgs/commit/167c2e876af02219ab31ab441a7b1bfa6b50843b) smassh: unpin python311
* [`57bb5467`](https://github.com/NixOS/nixpkgs/commit/57bb5467500f96fb16fb1e3af3624d6e34480cd8) thelounge: unpin python311
* [`5a1f82be`](https://github.com/NixOS/nixpkgs/commit/5a1f82be1bdccac0dc109170f541a281a5160612) volk_2: unpin python311
* [`a84750bb`](https://github.com/NixOS/nixpkgs/commit/a84750bbb49e675b1b49278f49c95e66b6c2fd3f) hyprshade: unpin python311
* [`3f133a58`](https://github.com/NixOS/nixpkgs/commit/3f133a589107302b0ac7798a5e2cecb519b05b53) manuskript: unping python311
* [`75c00536`](https://github.com/NixOS/nixpkgs/commit/75c00536edca19b51190fe18279660b4c5ec7bfa) steamback: unpin python311
* [`2a2b9ed5`](https://github.com/NixOS/nixpkgs/commit/2a2b9ed586a74bf5aedb763dc721b2716ce3a006) deepsecrets: unpin python311
* [`c8daad6b`](https://github.com/NixOS/nixpkgs/commit/c8daad6b5932a969485dbde71f721906dadb6806) python3Packages.monitorcontrol: 3.1.0 -> 4.1.1
* [`6fe1b5b1`](https://github.com/NixOS/nixpkgs/commit/6fe1b5b11010b2b5c4f3e5a20f3c702be92c1490) Update and fix jextract for jdk23
* [`e4a17179`](https://github.com/NixOS/nixpkgs/commit/e4a171790d37a2f2b9d4a50bf7bf353a26aaafc9) ocenaudio: 3.14.11 -> 3.15
* [`4f4d591c`](https://github.com/NixOS/nixpkgs/commit/4f4d591cd4a54513aea45223bb6c8d35e10ba115) bitbox: 4.47.2 -> 4.47.3
* [`e27f6537`](https://github.com/NixOS/nixpkgs/commit/e27f65376c49a45f8c2546c8b68cc0cc4b002b4b) foonathan-memory: 0.7-3 -> 0.7-4
* [`4520789b`](https://github.com/NixOS/nixpkgs/commit/4520789b04bcb91f0da64b7e6ccfc734da989366) game-devices-udev-rules: 0.23 -> 0.24
* [`b67bacd7`](https://github.com/NixOS/nixpkgs/commit/b67bacd756bdd21284a5e79eff1eee98379ae2ff) game-devices-udev-rules: modernize
* [`a961dc9a`](https://github.com/NixOS/nixpkgs/commit/a961dc9a4d27f9ed93ab9011e78df64044976672) algol68g: 3.4.2 -> 3.5.14
* [`606afc27`](https://github.com/NixOS/nixpkgs/commit/606afc277267ec9b4b926bec6ca1c8d04fb7c6d2) librewolf-unwrapped: 139.0-1 -> 139.0.1-1
* [`ee06a3a7`](https://github.com/NixOS/nixpkgs/commit/ee06a3a7bfa7c58dc6b5e526cf1c611f64b017a0) altair: 8.2.3 -> 8.2.5
* [`6464331b`](https://github.com/NixOS/nixpkgs/commit/6464331b636183650c1bb72301bdc3a4a2ad9826) gsl-lite: 0.43.0 -> 1.0.1
* [`943cc6fc`](https://github.com/NixOS/nixpkgs/commit/943cc6fc1d9e93de09c1b18d4a5680c51884cac3) matrix-hookshot: 6.0.3 -> 7.0.0
* [`7063762d`](https://github.com/NixOS/nixpkgs/commit/7063762d13524286c73085a3c986b2595ed5e10e) lib/types: add doc warning to addCheck
* [`7f030992`](https://github.com/NixOS/nixpkgs/commit/7f030992944ff9bc51dc451bedc3a9ddb6d8f19d) burpsuite: add updateScript
* [`037c3606`](https://github.com/NixOS/nixpkgs/commit/037c360635a2a548694a4411dafa95857cfff3f7) victoriametrics: add update script for maintainers/scripts/update.nix
* [`02071f39`](https://github.com/NixOS/nixpkgs/commit/02071f39e370bd5ade093278a7dbb0126f32d138) victoriametrics: 1.117.1 -> 1.118.0
* [`58990080`](https://github.com/NixOS/nixpkgs/commit/5899008057fafda4c645ae234c4335cefe2b2844) python3Packages.types-s3transfer: 0.12.0 -> 0.13.0
* [`8a9641f8`](https://github.com/NixOS/nixpkgs/commit/8a9641f84e37a9d3626fb08b8e8aa0568c78ab8f) python313Packages.opensfm: disable flaky test
* [`a31f77a5`](https://github.com/NixOS/nixpkgs/commit/a31f77a520ceccfd558d28fd6858f6eb362e286d) harper: 0.39.0 -> 0.40.0
* [`3c91dc3f`](https://github.com/NixOS/nixpkgs/commit/3c91dc3f90c7865e94a11bc4705d3b1f2bfd82d7) python313Packages.pygame-gui: 0613 -> 0614
* [`6962d391`](https://github.com/NixOS/nixpkgs/commit/6962d391678eba678a1e196280d48be9ea880fab) openterface-qt: 0.3.12 -> 0.3.14
* [`11291afc`](https://github.com/NixOS/nixpkgs/commit/11291afcb3f633920281af8d9bc71091d1dd70ca) testers.hasCmakeConfigModules: init
* [`e4ab873c`](https://github.com/NixOS/nixpkgs/commit/e4ab873cc1e63bbd704d580ac7cc2269839a5381) testers.hasCmakeConfigModules: add self tests
* [`bb3d46c9`](https://github.com/NixOS/nixpkgs/commit/bb3d46c9943623f078d3fcd46a336b3c5d9346c0) c-blosc2: add cmake-config and propagate buildInputs
* [`fbd42376`](https://github.com/NixOS/nixpkgs/commit/fbd42376f9654be0625a798666064bd7b4190160) nixos/jenkins: Make use of mkEnableOption
* [`131d83ea`](https://github.com/NixOS/nixpkgs/commit/131d83ea6a2459b24c93faaaad24d6613260e7ef) nixos/jenkins: Introduce and make use of javaPackage option
* [`46be72d3`](https://github.com/NixOS/nixpkgs/commit/46be72d31539780a988f60b3a5f46bc3726d9bad) nixos/unitOption: remove unnecessary definition filtering
* [`6d8eca96`](https://github.com/NixOS/nixpkgs/commit/6d8eca96ba0a8d55bbc4e4e1f21b7e1fa0d52e61) sysctl: remove unnecessary definition filtering
* [`3df624ee`](https://github.com/NixOS/nixpkgs/commit/3df624ee81ed176eaba0c7eccb50d4ac70744db1) libvgm: 0-unstable-2025-05-03 -> 0-unstable-2025-05-30
* [`5ecd7ff4`](https://github.com/NixOS/nixpkgs/commit/5ecd7ff46e93099ee85e05eb3c5bf38414a0b988) pimsync: 0.4.1 -> 0.4.2
* [`d1f0807d`](https://github.com/NixOS/nixpkgs/commit/d1f0807db5ba3d1229917c338009ababb6463cac) nixos/jenkins: Bump Java version to 21
* [`98da4519`](https://github.com/NixOS/nixpkgs/commit/98da4519c9b8b3775c4d987dadc61ceaceeadfb2) linuxKernel.kernels.linux_zen: 6.14.7-zen1 -> 6.14.9-zen1
* [`4bf93b4e`](https://github.com/NixOS/nixpkgs/commit/4bf93b4e31eb2292f47f13131cd42bbafa589966) linuxKernel.kernels.linux_lqx: 6.14.7-lqx1 -> 6.14.9-lqx1
* [`ea722c21`](https://github.com/NixOS/nixpkgs/commit/ea722c21ddea9a1ba2f221d560fc1022aa215ba3) navidrome: 0.55.2 -> 0.56.1
* [`f9460c7b`](https://github.com/NixOS/nixpkgs/commit/f9460c7b56e158f1f1d7b7487e6f0886257c2b9b) llvmPackages_20: 20.1.5 -> 20.1.6
* [`6617c167`](https://github.com/NixOS/nixpkgs/commit/6617c167f75c5caf1707daff993f006c4e20b7dc) nixos/monero: use lib.getExe
* [`1907ea56`](https://github.com/NixOS/nixpkgs/commit/1907ea56d3a4419cbeb13f13b5221dfac6d152cf) azahar: 2121.1 -> 2121.2
* [`fa7b5cc9`](https://github.com/NixOS/nixpkgs/commit/fa7b5cc939db0aae1cf99bb49cea4f0b43d1c910) librewolf-unwrapped: add owners
* [`00309273`](https://github.com/NixOS/nixpkgs/commit/0030927398148bcc6ded3fa0621dff5691535b31) firefox-unwrapped: drop lovesegfault from maintainers
* [`4aadd440`](https://github.com/NixOS/nixpkgs/commit/4aadd44044e291e0fdc529d97b46be152b1c3989) zig: fix cc and bintools
* [`63f12ff9`](https://github.com/NixOS/nixpkgs/commit/63f12ff91b6dd00645b096eabb4c7b95fc40801c) python313Packages.validator-collection: remove unused inputs
* [`c3285545`](https://github.com/NixOS/nixpkgs/commit/c328554512a87466d746bc7180ed65897e024c30) albert: 0.27.8 -> 0.28.0
* [`1a031647`](https://github.com/NixOS/nixpkgs/commit/1a031647f73275cc2357864a8bdb580fcf8f1131) high-tide: 0-unstable-2025-05-01 -> 0.1.5
* [`e894c5ea`](https://github.com/NixOS/nixpkgs/commit/e894c5eae53d01f42aa48e7e9182f8a8867f94d0) vte: 0.80.1 -> 0.80.2
* [`b398c5a3`](https://github.com/NixOS/nixpkgs/commit/b398c5a391fd9a5438f9d5471098f760f4b10873) python3Packages.labgrid: 24.0.2 -> 25.0
* [`5133c60c`](https://github.com/NixOS/nixpkgs/commit/5133c60c2f558ea065b2ff6ed822fb29a7ad4fc6) waagent: 2.13.1.1 -> 2.14.0.0
* [`282c93a9`](https://github.com/NixOS/nixpkgs/commit/282c93a98bb2cbcd6b26507215750ea0f99da771) lomiri.lomiri-download-manager: 0.1.3 -> 0.2.1
* [`3d47a138`](https://github.com/NixOS/nixpkgs/commit/3d47a13894580b09a94d34bf4bf0d3bbc46bcff2) ieda: 0-unstable-2025-04-14 -> 0-unstable-2025-05-30
* [`ffb4c8cb`](https://github.com/NixOS/nixpkgs/commit/ffb4c8cb1152302ff62fe17ddb554541754ccb3f) hackneyed: 0.9.1 -> 0.9.3
* [`e111280e`](https://github.com/NixOS/nixpkgs/commit/e111280e04ed6639dbd712e2da967d4f26280af6) hackneyed: remove usages of with lib;
* [`1502da49`](https://github.com/NixOS/nixpkgs/commit/1502da49ba62c3a3830db3075c2da260184d9eda) nwg-panel: 0.10.2 -> 0.10.4
* [`d02513e2`](https://github.com/NixOS/nixpkgs/commit/d02513e21651d950e0446ae1cd907016e5b320ce) diffoscope: 295 -> 297
* [`1ffc9042`](https://github.com/NixOS/nixpkgs/commit/1ffc904284479f89de42cb79f279400086113d45) nixos/monero: add an option to use ip ban-list
* [`cd3f12cb`](https://github.com/NixOS/nixpkgs/commit/cd3f12cbec6db6edf5a192e4691e9f0e4e1d8403) openra: remove devtest
* [`0233a698`](https://github.com/NixOS/nixpkgs/commit/0233a69802c4ce48f781fb1fe4596bef12118ddf) openra: add updateScript
* [`7996084a`](https://github.com/NixOS/nixpkgs/commit/7996084a7a052ffe5d1e488759a5649a97ffcea4) openraPackages.engines.bleed: init at 20250531
* [`b782b7e8`](https://github.com/NixOS/nixpkgs/commit/b782b7e8451be4755b520fdb34d3f552ca5f915d) duplicity: 3.0.4 -> 3.0.4.1
* [`6a01ad2e`](https://github.com/NixOS/nixpkgs/commit/6a01ad2ec64b96c7d176181ade076b9423b2a688) corrscope: 0.10.1 -> 0.11.0, migrate to Qt6
* [`20f73ae6`](https://github.com/NixOS/nixpkgs/commit/20f73ae6571b393a4689a64bf2bdb5ba43cb1427) gokapi: 1.9.6 -> 2.0.0
* [`74be6ce9`](https://github.com/NixOS/nixpkgs/commit/74be6ce921c16b52aac0460b0735bbb9f948c4ed) pmbootstrap: 3.4.0 -> 3.4.2
* [`b98e7bb9`](https://github.com/NixOS/nixpkgs/commit/b98e7bb95a1e66d951a9c517cadb151694358bad) OWNERS: simplify workflow/ci owners
* [`5446ad30`](https://github.com/NixOS/nixpkgs/commit/5446ad302b58605f3a4e9c3fe588f8c3c082faf6) xwayland-satellite: 0.5.1 -> 0.6
* [`c0962292`](https://github.com/NixOS/nixpkgs/commit/c0962292fb8899f1ff0746fe61a431f0df02fe37) librenms: use php instead of php82
* [`6f390b24`](https://github.com/NixOS/nixpkgs/commit/6f390b2412263d48a6fed1e70632bb19925331c2) xfce.xfce4-screenshooter: 1.11.1 -> 1.11.2
* [`53cfda6c`](https://github.com/NixOS/nixpkgs/commit/53cfda6c64474cfa6390b6f1de6b831cd30ce361) xfce.xfce4-taskmanager: 1.5.8 -> 1.6.0
* [`eed59a53`](https://github.com/NixOS/nixpkgs/commit/eed59a53436d7956a8a7bf6468875ea1a9003655) xfce.xfce4-volumed-pulse: 0.2.5 -> 0.3.0
* [`9e6bd241`](https://github.com/NixOS/nixpkgs/commit/9e6bd241b241ab0b7f4ccaa61293588d51311a0c) xfce.xfmpc: 0.3.2 -> 0.4.0
* [`66b72c81`](https://github.com/NixOS/nixpkgs/commit/66b72c81b35b32b8b8bb5eec06e711e7bad0e1df) python3Packages.aioairq: 0.4.4 -> 0.4.6
* [`39fe05de`](https://github.com/NixOS/nixpkgs/commit/39fe05dec00a81a87b5826e0f82421909d9038eb) nixos/lasuite-docs: fix media proxying
* [`e9d282cf`](https://github.com/NixOS/nixpkgs/commit/e9d282cf7face7c82f2292d0c943fa4fdca0cb05) pdfarranger: 1.11.1 -> 1.12.0
* [`9bca3187`](https://github.com/NixOS/nixpkgs/commit/9bca3187758b4459d9404943d69bf1196a1a38da) nixos/murmur: Use lib.mkEnableOption where possible
* [`f13ada12`](https://github.com/NixOS/nixpkgs/commit/f13ada1223f8d8af00c1204463ea59a21f53afb0) nixos/murmur: Get rid global lib expansion
* [`7c7c839a`](https://github.com/NixOS/nixpkgs/commit/7c7c839a26215b2585c685c4be87103a0e9198fa) nixos/murmur: Drop warnings regarding renamed/removed options
* [`c27ca7e2`](https://github.com/NixOS/nixpkgs/commit/c27ca7e237f647c70fdb3bbe2b7a51feaa1b8f8c) hyprswitch: rename to hyprshell
* [`1b242d7b`](https://github.com/NixOS/nixpkgs/commit/1b242d7ba56ed93cf30941c5fdffeef30166542b) numworks-epsilon: do not package build dependencies
* [`3d13b270`](https://github.com/NixOS/nixpkgs/commit/3d13b2705a1565aebdd8ee9615cf52e171c405f9) gvisor: 20240401.0 -> 20250512.0
* [`d35936c9`](https://github.com/NixOS/nixpkgs/commit/d35936c994db57ea95edfda3f8da00fecf2dcfec) karmor: 1.3.4 -> 1.4.1
* [`03d860ac`](https://github.com/NixOS/nixpkgs/commit/03d860ac2bfa6ae89ce032012a7b8c94b7b74e91) tomcat-native: 2.0.8 -> 2.0.9
* [`c89beaa4`](https://github.com/NixOS/nixpkgs/commit/c89beaa4a32d080a240abb822817c97474cb7b1e) slurm: 24.11.5.1 -> 25.05.0.1
* [`586abb0c`](https://github.com/NixOS/nixpkgs/commit/586abb0c0703820bf711ac3993662e0e7ff8a331) xarchiver: build with strictDeps=true
* [`f134697b`](https://github.com/NixOS/nixpkgs/commit/f134697b8417b4fc5318f0a7c6eb7ed6c10c3973) petsc: 3.23.2 -> 3.23.3
* [`2ee0f9a8`](https://github.com/NixOS/nixpkgs/commit/2ee0f9a8b209bad9794be919bcf613ad84bb3e90) ne: modernize
* [`48746c56`](https://github.com/NixOS/nixpkgs/commit/48746c5692e8a3f3eb5d130296bed89a1011ba7c) maintainers: update numinit's keys
* [`7137985c`](https://github.com/NixOS/nixpkgs/commit/7137985c3993817bc82838174ec0b4d92155557c) llm: move to by-name
* [`98756a64`](https://github.com/NixOS/nixpkgs/commit/98756a6482a81e624f9815a547cbc9309170adae) llm: add enable-llm-anthropic override
* [`b8a7b821`](https://github.com/NixOS/nixpkgs/commit/b8a7b821f7b011381126ebc84a1abc834041263d) llm: add enable-llm-cmd override
* [`ab5c974d`](https://github.com/NixOS/nixpkgs/commit/ab5c974d2ed8f556b9aca522a7a3105dcc8eef4a) llm: add enable-llm-gemini override
* [`85868f71`](https://github.com/NixOS/nixpkgs/commit/85868f71a08ae0a2e29f7c121179dbdbef754cce) llm: add enable-llm-gguf override
* [`cf62949f`](https://github.com/NixOS/nixpkgs/commit/cf62949f31624f22dfa8ed76a8fc370358d3e0fb) llm: add enable-llm-jq override
* [`96bde7a7`](https://github.com/NixOS/nixpkgs/commit/96bde7a7d37aa6809ad20c7a1378ea02901b95ff) llm: add enable-llm-ollama override
* [`c48e583d`](https://github.com/NixOS/nixpkgs/commit/c48e583dd99b50446138ff72f8cbed7e8903a966) llm: add enable-llm-openai-plugin override
* [`31c73863`](https://github.com/NixOS/nixpkgs/commit/31c73863a7187894251f4ba2a724bf5d4a114565) python3Packages.llm-mistral: init at 0.12
* [`12bcd7aa`](https://github.com/NixOS/nixpkgs/commit/12bcd7aa10ed3475f8bde0ffb72e05969e2c7937) python3Packages.llm-command-r: init at 0.3.1
* [`41ca7809`](https://github.com/NixOS/nixpkgs/commit/41ca780911b4422bd2b41518fc8815d09a4ee58c) python3Packages.llm-grok: init at 1.0.1
* [`97b709d4`](https://github.com/NixOS/nixpkgs/commit/97b709d4da41e48ce5772e2ef741fb2682c58135) python3Packages.llm-groq: init at 0.8
* [`31d4b6f6`](https://github.com/NixOS/nixpkgs/commit/31d4b6f6cd1f5d8434b7b70fc6054ac146e04687) python3Packages.llm-openrouter: init at 0.4.1
* [`d8b57ca3`](https://github.com/NixOS/nixpkgs/commit/d8b57ca3c280de1098e2165ea6beb48213675a5d) python3Packages.llm-deepseek: init at 0.1.6
* [`b271e2ca`](https://github.com/NixOS/nixpkgs/commit/b271e2cad2323d7b777a17eb8efdf77401f5122f) python3Packages.llm-venice: init at 0.6.0
* [`9c246b23`](https://github.com/NixOS/nixpkgs/commit/9c246b23edbfe8eafcab3d05fcd08584e5d5b3f4) python3Packages.llm-video-frames: init at 0.1
* [`d5a30a5a`](https://github.com/NixOS/nixpkgs/commit/d5a30a5a482e8ffcfb7ed58045c293ca8d6fb37b) python3Packages.llm-templates-github: init at 0.1
* [`56df4194`](https://github.com/NixOS/nixpkgs/commit/56df419440c70d8af8ec2a1349d8bf509b0690ff) python3Packages.llm-templates-fabric: init at 0.2
* [`b0f2c846`](https://github.com/NixOS/nixpkgs/commit/b0f2c846c9a7790b722901459abd8acb537b6185) python3Packages.llm-hacker-news: init at 0.1.1
* [`68ec32a1`](https://github.com/NixOS/nixpkgs/commit/68ec32a1bb776d0fbc08556c769785c57326ba53) python3Packages.llm-fragments-github: init at 0.3
* [`c83f08dd`](https://github.com/NixOS/nixpkgs/commit/c83f08dd2b33af7d09fb5492c842815e07a2e07e) python3Packages.llm-fragments-pypi: init at 0.1.1
* [`5471027b`](https://github.com/NixOS/nixpkgs/commit/5471027b2c9a4fd9c654fe76ff6beeeb1e168388) python3Packages.llm-sentence-transformers: init at 0.3.2
* [`794f8c04`](https://github.com/NixOS/nixpkgs/commit/794f8c04b063b49a49118800112e63d9e4d35327) python3Packages.llm: introduce mkPluginTest and use it
* [`0d50348b`](https://github.com/NixOS/nixpkgs/commit/0d50348b5199eacca771098fe221b16a35e5893e) llm: reintroduce withPlugins
* [`b06e408d`](https://github.com/NixOS/nixpkgs/commit/b06e408d0dd51270606513d48b936774799f1c0f) llm: customize the message on `llm install` and `llm uninstall` with the list of plugins possible
* [`81b35cd5`](https://github.com/NixOS/nixpkgs/commit/81b35cd59bc06990d7f610291f22666ac347a97a) llm: add philiptaron to maintainers
* [`a8e9182c`](https://github.com/NixOS/nixpkgs/commit/a8e9182cd86827dcd5bb23c97a1b550cd04b86cd) python3Packages.llm-anthropic: 0.15.1 -> 0.16a2
* [`1927529a`](https://github.com/NixOS/nixpkgs/commit/1927529a05eefe6e62db1b99e81e8ccebfd6954b) python3Packages.llm-fragments-github: 0.3 -> 0.4
* [`264bef7e`](https://github.com/NixOS/nixpkgs/commit/264bef7edb35e4c70f510a99e6a8b50c2a20ed3a) python3Packages.llm-mistral: 0.12 -> 0.13
* [`9e07fc75`](https://github.com/NixOS/nixpkgs/commit/9e07fc75645d6af362a71c746325a5976e14dbfc) python3Packages.llm-ollama: 0.10.0 -> 0.11a0
* [`cc134a91`](https://github.com/NixOS/nixpkgs/commit/cc134a91d32c5464f0340eddd5639e788cc5a450) python3Packages.llm-venice: 0.6.0 -> 0.7.0
* [`e8237dfe`](https://github.com/NixOS/nixpkgs/commit/e8237dfe32991a25134f45c0399f8e7f29a09d89) python3Packages.llm-echo: init at 0.2
* [`36e9a7dd`](https://github.com/NixOS/nixpkgs/commit/36e9a7ddb91e5649e089d66d1caf6c1a50f19263) python3Packages.llm: 0.25 -> 0.26
* [`518d9a98`](https://github.com/NixOS/nixpkgs/commit/518d9a98567f9fe13fda9213e719ae02fa4c7e49) python3Packages.llm-anthropic: 0.16a2 -> 0.17
* [`c80dc765`](https://github.com/NixOS/nixpkgs/commit/c80dc765ca26c26510d679ed5968e590166f0f5f) python3Packages.llm-gemini: 0.20 -> 0.21
* [`414b770c`](https://github.com/NixOS/nixpkgs/commit/414b770ca537b8e1d66c1f3b10300c694e1379c5) python3Packages.llm-mistral: 0.13 -> 0.14
* [`89950d8e`](https://github.com/NixOS/nixpkgs/commit/89950d8ecb3e5a973b2cd9ac760ceaca4c4941b0) python3Packages.llm-ollama: 0.11a0 -> 0.11.0
* [`2074fa15`](https://github.com/NixOS/nixpkgs/commit/2074fa159b50bb41ac326d85e256d6fec30bfe5e) python3Packages.quickjs: init at 1.19.4
* [`7438a10a`](https://github.com/NixOS/nixpkgs/commit/7438a10a796b646295d7d804bf79f8dc55fd003e) python3Packages.llm-tools-quickjs: init at 0.1
* [`d935c30c`](https://github.com/NixOS/nixpkgs/commit/d935c30c3d2bcee3819437ae7ee4e28befd63735) python3Packages.llm-tools-sqlite: init at 0.1
* [`550a2409`](https://github.com/NixOS/nixpkgs/commit/550a2409216c8318dfe1a71fe4daf040080f6793) python3Packages.llm-tools-datasette: init at 0.1
* [`43975920`](https://github.com/NixOS/nixpkgs/commit/4397592022cbabe3b7a09f22db08de56164e2b76) python3Packages.llm-llama-server: init at 0.2
* [`2ee7c8ea`](https://github.com/NixOS/nixpkgs/commit/2ee7c8ea88ed8e327b6af64ae90a4178a1612dc4) python3Packages.llm-tools-simpleeval: init at 0.1.1
* [`3d646501`](https://github.com/NixOS/nixpkgs/commit/3d646501ff9c68746a85dac2413d72bbbf1c15ca) python3Packages.llm-fragments-reader: init at 0.1
* [`8d872ce2`](https://github.com/NixOS/nixpkgs/commit/8d872ce25063db13f18278b8885c501f8f5f469b) python3Packages.llm-docs: init at 0.2.1
* [`e2e0a82a`](https://github.com/NixOS/nixpkgs/commit/e2e0a82a49c0c90f555e06e44733466af418bd8e) python3Packages.icudiff: init at 2.0.7
* [`8ef5aeea`](https://github.com/NixOS/nixpkgs/commit/8ef5aeead23e5e15fbb82b4bdb2d4c266995ebdc) python3Packages.pytest-icudiff: init at 0.5-unstable-2024-09-04
* [`6a92dd13`](https://github.com/NixOS/nixpkgs/commit/6a92dd13019cd592515b073f57dc8411d5e48040) python3Packages.symbex: init at 2.0
* [`2db9fe2f`](https://github.com/NixOS/nixpkgs/commit/2db9fe2fd0a179a69cf50136000e8dae94f6d623) python3Packages.llm-fragments-symbex: init at 0.1
* [`cedea09b`](https://github.com/NixOS/nixpkgs/commit/cedea09b469f909744058e12ad260630e54cc980) python3Packages.files-to-prompt: init at 0.6
* [`5aed3c68`](https://github.com/NixOS/nixpkgs/commit/5aed3c68318cc13423e70a3c5f9ba3add173d212) python3Packages.llm-git: init at 0.2.2
* [`727e1052`](https://github.com/NixOS/nixpkgs/commit/727e10522cfba95c6935fc0ceee774376d8c83ba) llm: cap the derivation name to something sensible
* [`6fba1361`](https://github.com/NixOS/nixpkgs/commit/6fba136127cd770810372af0894b603d8d1041c1) python3Packages.llm-pdf-to-images: init at 0.1
* [`42fa505c`](https://github.com/NixOS/nixpkgs/commit/42fa505cf79a73532642eb2bda4b009e7bac87ee) python3Packages.llm-*: use llm in the dependencies
* [`837cff79`](https://github.com/NixOS/nixpkgs/commit/837cff79ca793c40db34781fcbd27c81949dbf8c) llm: include the tests for all plugins as part of passthru.tests
* [`2b4d3ea2`](https://github.com/NixOS/nixpkgs/commit/2b4d3ea2ddd4dcc6dd82e9d222e4c23dab732d9d) sysdig-cli-scanner: 1.22.1 -> 1.22.2
* [`6e62f900`](https://github.com/NixOS/nixpkgs/commit/6e62f90071e4906dc1efb5502f1cf9f6d3f23f16) python3Packages.coiled: 1.96.1 -> 1.100.0
* [`2359da18`](https://github.com/NixOS/nixpkgs/commit/2359da18503696f3a8087521fe29d499d8e48302) gridtracker2: init at 2.250507.0
* [`14abe2ce`](https://github.com/NixOS/nixpkgs/commit/14abe2ce8f6d4aaa74b2f23eb6a0ea85622a6c2b) zam-plugins: 4.3 -> 4.4
* [`9b336fcc`](https://github.com/NixOS/nixpkgs/commit/9b336fcc61a970432022f9abfbcb5c3e21bd045b) signal-desktop: 7.54.0 -> 7.56.0
* [`96895658`](https://github.com/NixOS/nixpkgs/commit/96895658f5e91a29b8f300b329d0e1cbafc0ead9) checkstyle: 10.24.0 -> 10.25.0
* [`14918d8f`](https://github.com/NixOS/nixpkgs/commit/14918d8f887b0135a6af32ac3c09bc6e6f3f2ae8) libusb-package: init at 1.0.26.3
* [`db1bfc28`](https://github.com/NixOS/nixpkgs/commit/db1bfc2878f2b5628bfc11cf27f52b349975fd25) hoppscotch: 25.4.2-0 -> 25.5.1-0
* [`f3328011`](https://github.com/NixOS/nixpkgs/commit/f33280111dd32764307177b63595b130cf238f50) firefly-iii: 6.2.10 -> 6.2.16
* [`ae49c563`](https://github.com/NixOS/nixpkgs/commit/ae49c563ac95a731c2ac95e14adb0bddf1b34d0a) balena-cli: 21.1.14 -> 22.0.5
* [`198bdbc8`](https://github.com/NixOS/nixpkgs/commit/198bdbc88819d2d5f8e8fde923ce2ec6b5f09b17) mapproxy: 4.1.1 -> 4.1.2
* [`1462abdd`](https://github.com/NixOS/nixpkgs/commit/1462abddeaf142100f396b244020fec5eb7ec2d1) vscode-extensions.sourcery.sourcery: 1.36.0 -> 1.37.0
* [`d893a789`](https://github.com/NixOS/nixpkgs/commit/d893a789d48801374f0d1b20a3c9393e387765e1) python3Packages.corallium: 0.3.3 -> 2.1.1
* [`c65ce361`](https://github.com/NixOS/nixpkgs/commit/c65ce3613cdd21a3cf421c22060124764a4b2001) arc-browser: 1.91.2-62278 -> 1.97.0-63507
* [`19c0c5cb`](https://github.com/NixOS/nixpkgs/commit/19c0c5cb3218c4d35e7ae0fdc10a15f7986ff961) roundcube: 1.6.10 -> 1.6.11
* [`7bc1aa32`](https://github.com/NixOS/nixpkgs/commit/7bc1aa3262a8c0c38ac768396d922801cccb6ceb) offrss: drop due to age and lack of maintainer
* [`1074fecf`](https://github.com/NixOS/nixpkgs/commit/1074fecf390435d036474f482414a6ff7732efbf) logdy: 0.16.0 -> 0.17.0
* [`24f99aa5`](https://github.com/NixOS/nixpkgs/commit/24f99aa552007a3ae0748f80bf51c37e21ec9d3b) ente-auth: 4.3.5 -> 4.3.6
* [`ff11f6ae`](https://github.com/NixOS/nixpkgs/commit/ff11f6aec001a6a7acb9aace4591767e53393e94) nak: 0.14.1 -> 0.14.2
* [`962db807`](https://github.com/NixOS/nixpkgs/commit/962db8079611bf6c3282197436b37af3ddbb4718) nixosTests.ngingx-http3: fix race condition
* [`a86c9f45`](https://github.com/NixOS/nixpkgs/commit/a86c9f454da9aa125288f0cd692e3040b5a8fb89) act: 0.2.77 -> 0.2.78
* [`1e76f45c`](https://github.com/NixOS/nixpkgs/commit/1e76f45c065ed2216014aed09d71c86e93ac78a8) python3Packages.xdis: 6.1.3 -> 6.1.4
* [`f0bef342`](https://github.com/NixOS/nixpkgs/commit/f0bef342fb99aa347f02241ddaff862da7d1ff6a) git-jump: init at 0.3.1
* [`ab95fc17`](https://github.com/NixOS/nixpkgs/commit/ab95fc17177a620f13baaab609c3d5687abcf82e) animeko: 4.10.1 -> 4.11.1
* [`0b95d24d`](https://github.com/NixOS/nixpkgs/commit/0b95d24dabddd50d7c12de449372e241e085cfa6) cflib: init at 0.1.28
* [`b6529db3`](https://github.com/NixOS/nixpkgs/commit/b6529db3f2d9c2b4c415baed15711c6967cd052f) cfclient: init at 2025.2
* [`8a760227`](https://github.com/NixOS/nixpkgs/commit/8a7602273eaba7c142f4109f9d97b5bdceb772af) git-metrics: init at 0.2.6
* [`e9d0806e`](https://github.com/NixOS/nixpkgs/commit/e9d0806e31dfdfd91e93ade8595f96fae7f74ff4) dart.rhttp: add 0.12.0
* [`4b0eefd2`](https://github.com/NixOS/nixpkgs/commit/4b0eefd26b545fde3feb93ccf19476c994bc8eef) venera: 1.4.3 -> 1.4.4
* [`571d6432`](https://github.com/NixOS/nixpkgs/commit/571d64322458c3e474cb0c01d431d1c1afd1d6e4) scooter: 0.5.0 -> 0.5.2
* [`6e451ef7`](https://github.com/NixOS/nixpkgs/commit/6e451ef75a176847a68ab2c129d83418a2d61f9e) elmerfem: unstable-2023-09-18 -> 9.0-unstable-2025-05-25
* [`e1b7bd33`](https://github.com/NixOS/nixpkgs/commit/e1b7bd330ec2f0340fdb8406a9ed8e7ae7273105) gdcm: 3.0.24 -> 3.0.25
* [`6cffba31`](https://github.com/NixOS/nixpkgs/commit/6cffba31f094136e82d6923a50eb846134ec7562) gdcm: use ctestCheckHook
* [`7a875d8a`](https://github.com/NixOS/nixpkgs/commit/7a875d8aa53f8dbe7907a2b8a040822617e2a0ff) gimx: fix build
* [`68b26525`](https://github.com/NixOS/nixpkgs/commit/68b26525cf0f93a32aa4215b007bc10d70535779) python3Packages.fontparts: 0.12.5 -> 0.12.7
* [`decd2f9b`](https://github.com/NixOS/nixpkgs/commit/decd2f9b55fa0e800fe229f71145786a9bf20588) python3Packages.py-sucks: 0.9.10 -> 0.9.11
* [`256b7b3e`](https://github.com/NixOS/nixpkgs/commit/256b7b3e6a449fd859fb36531dbab7601b5558f9) markdownlint-cli2: 0.17.2 -> 0.18.1
* [`7270abb9`](https://github.com/NixOS/nixpkgs/commit/7270abb90fc3d8d9bf00553220aa64341d7b73a1) python3Packages.numpy-groupies: 0.11.2 -> 0.11.3
* [`7738f634`](https://github.com/NixOS/nixpkgs/commit/7738f63454eaf8dd47a336c617ea38ff55a29e5f) python3Packages.pytubefix: 9.0.1 -> 9.1.1
* [`6f34b4ec`](https://github.com/NixOS/nixpkgs/commit/6f34b4ec6ef323f80041569d5a375b9b6fbef7c9) terraform-providers.dnsimple: 1.9.0 -> 1.9.1
* [`d1869c61`](https://github.com/NixOS/nixpkgs/commit/d1869c611ef27bbf7011853f825044b6dfbb3c7e) chirp: 0.4.0-unstable-2025-05-14 -> 0.4.0-unstable-2025-05-29
* [`6eb9bb33`](https://github.com/NixOS/nixpkgs/commit/6eb9bb33f5c7100555a171f09b57ea2002f21e85) yandex-music: 5.51.1 -> 5.52.0
* [`55963bf9`](https://github.com/NixOS/nixpkgs/commit/55963bf96c43917538418ce53ee25214677b4142) python3Packages.atlassian-python-api: modernize
* [`75d912f0`](https://github.com/NixOS/nixpkgs/commit/75d912f07c956617fb9e31dc3484f45e1c77259f) python3Packages.atlassian-python-api: 3.41.21 -> 4.0.4
* [`9e748962`](https://github.com/NixOS/nixpkgs/commit/9e7489622bde7abd10927289b81fe990262c8ee1) cargo-nextest: 0.9.95 -> 0.9.97
* [`f35e7f8b`](https://github.com/NixOS/nixpkgs/commit/f35e7f8b6dea3694e62b32fc93a239598c983f19) openimageio: 3.0.6.1 -> 3.0.7.0
* [`129e9e7f`](https://github.com/NixOS/nixpkgs/commit/129e9e7f692f93fc4ce629ed539d09262e99d81b) ecapture: 1.0.2 -> 1.1.0
* [`3e5e1cf0`](https://github.com/NixOS/nixpkgs/commit/3e5e1cf05e4ebeb2280f33088c7221bcb42508a5) qownnotes: 25.5.10 -> 25.6.0
* [`a5bbc504`](https://github.com/NixOS/nixpkgs/commit/a5bbc5046bdb5be452c7d9e0b844a012468a6291) doc/haskell: Add GHC deprecation policy
* [`a0127a90`](https://github.com/NixOS/nixpkgs/commit/a0127a902ddc6d7ffb5c2e78f9c68a3cf1daf2d0) helm-ls: 0.2.2 -> 0.3.0
* [`42bf3489`](https://github.com/NixOS/nixpkgs/commit/42bf3489df2e207b04f5b36242780b843440b282) vscode-extensions.ms-azuretools.vscode-docker: 1.29.6 -> 2.0.0
* [`eac0b8db`](https://github.com/NixOS/nixpkgs/commit/eac0b8db576e5de5bb702c5b627342a07ff6b6dc) intune-portal: fix openssl version mismatch
* [`a665e7a6`](https://github.com/NixOS/nixpkgs/commit/a665e7a601f55e39e107bc7727742277e60ea8f9) intune-portal: 1.2405.17-jammy -> 1.2503.10-noble
* [`be43dfa9`](https://github.com/NixOS/nixpkgs/commit/be43dfa9dc531bcec480892eff9441d8c03fd878) maintainers: add naggie
* [`edbaf6d0`](https://github.com/NixOS/nixpkgs/commit/edbaf6d08076c9abf36419ae4d2f95bcb8c45b97) ollama: 0.7.1 -> 0.9.0
* [`fa15f5c9`](https://github.com/NixOS/nixpkgs/commit/fa15f5c9a586fcd70f0d573d0a755cb077c78c2f) swayimg: 4.0 -> 4.1
* [`ca5c2857`](https://github.com/NixOS/nixpkgs/commit/ca5c28577c3afc08e676370c66273b1f93648da7) zizmor: 1.8.0 -> 1.9.0
* [`4126720e`](https://github.com/NixOS/nixpkgs/commit/4126720e3873a60b4684b617dddda5b79a400ce6) timoni: 0.24.0 -> 0.25.0
* [`6d7e0c08`](https://github.com/NixOS/nixpkgs/commit/6d7e0c086f4634900e9b9d49fcef421c54f8b220) Fix build error with current Qt6
* [`d262e402`](https://github.com/NixOS/nixpkgs/commit/d262e402bb510fdbf94f6824f06baf230e9bbd34) windowmaker: enable for darwin
* [`f7d27be6`](https://github.com/NixOS/nixpkgs/commit/f7d27be69bd3341888ad383804744c3f92edd56d) terraform-providers.buildkite: 1.18.0 -> 1.19.0
* [`7f6f0dec`](https://github.com/NixOS/nixpkgs/commit/7f6f0decc06093d403e935a0b7ffc4a6635178c8) python3Packages.ical: 9.2.5 -> 10.0.0
* [`b166fb2c`](https://github.com/NixOS/nixpkgs/commit/b166fb2c12a4adfea358899a2bf74905192447e6) python3Packages.caldav: 1.5.0 -> 1.6.0
* [`78415f13`](https://github.com/NixOS/nixpkgs/commit/78415f13c1e0084cc9c3626f5e5d64da261a41c0) manifold: 3.1.0 -> 3.1.1
* [`c9dc80f3`](https://github.com/NixOS/nixpkgs/commit/c9dc80f3c97bd860885268a414ae2be2e7c8ff19) python313Packages.manifold3d: 3.1.0 -> 3.1.1
* [`fe501c44`](https://github.com/NixOS/nixpkgs/commit/fe501c44ad6daa2276ca8fa454ef597d927adc9d) vscode-extensions.illixion.vscode-vibrancy-continued: 1.1.52 -> 1.1.53
* [`d2cb4c31`](https://github.com/NixOS/nixpkgs/commit/d2cb4c3126c0df92a618b6d3083f10a47dee5050) clouddrive2: 0.8.19 -> 0.8.20
* [`55859b9a`](https://github.com/NixOS/nixpkgs/commit/55859b9a21deff22bdfa7105a947de8e83685dd0) python3Packages.langfuse: 2.60.5 -> 2.60.7
* [`78a0e4df`](https://github.com/NixOS/nixpkgs/commit/78a0e4dfadce7a5687f33d7d9ec930ca19856ca4) pencil2d: added ffmpeg dependency; fixed build
* [`589ca366`](https://github.com/NixOS/nixpkgs/commit/589ca366c7c901ffd7c9ec8b690f9bd81b979b26) protoc-gen-dart: 21.1.2 -> 22.1.0
* [`c71e84ac`](https://github.com/NixOS/nixpkgs/commit/c71e84ac6d7783393fa488a4e9b3d1ed1c59882e) python3Packages.redshift-connector: 2.1.6 -> 2.1.7
* [`8ad45dfe`](https://github.com/NixOS/nixpkgs/commit/8ad45dfec6a77b6124d49fd41f1c47c0d6cb414c) containerlab: use finalAttrs
* [`99824f30`](https://github.com/NixOS/nixpkgs/commit/99824f302393c0eb3543415c18c3b267c263d0a9) tigerbeetle: 0.16.41 -> 0.16.42
* [`68c76b14`](https://github.com/NixOS/nixpkgs/commit/68c76b145720fc6ed7a688c31ee52a1000a1ad46) pb: use finalAttrs
* [`c6fd64bf`](https://github.com/NixOS/nixpkgs/commit/c6fd64bf7375aec046abf3c3949f6d97e193e8e5) mmctl: 10.5.6 -> 10.5.7
* [`564f0a56`](https://github.com/NixOS/nixpkgs/commit/564f0a5629223decdfed13b9b1d66ce50b6c9b95) terraform-providers.google: 6.36.1 -> 6.37.0
* [`bc45e0df`](https://github.com/NixOS/nixpkgs/commit/bc45e0df13f36e7878164cf19c6de275e91663f6) maintainers: add b-m-f
* [`a340f97e`](https://github.com/NixOS/nixpkgs/commit/a340f97e3a1ef2bff9dcf68080b7ce00e0b30860) dracula-theme: 4.0.0-unstable-2025-04-27 -> 4.0.0-unstable-2025-05-24
* [`f233f68d`](https://github.com/NixOS/nixpkgs/commit/f233f68df50dea01b86f7f7b101163af375d1751) slimevr: 0.14.1 -> 0.15.0
* [`299190d5`](https://github.com/NixOS/nixpkgs/commit/299190d5107cd59fc2a4211602bc0b356490d3c0) python3Packages.spacy: cleanup, add maintainer
* [`41239e15`](https://github.com/NixOS/nixpkgs/commit/41239e15c43605d83a5e44739cf6b3ef9cda58ba) python3Packages.spacy: 3.8.6 -> 3.8.7
* [`7b1ab108`](https://github.com/NixOS/nixpkgs/commit/7b1ab108a81810b5ee14c820aa47d0e35d761014) phpExtensions.blackfire: 1.92.36 -> 1.92.37
* [`1aa9a9b3`](https://github.com/NixOS/nixpkgs/commit/1aa9a9b385329ae1d2ccf4a7eaf15a2d73783f67) xdg-terminal-exec: 0.12.3 -> 0.12.4
* [`97810937`](https://github.com/NixOS/nixpkgs/commit/9781093779fea7d33600747de99351bb9ca719ee) changie: 1.21.1 -> 1.22.0
* [`9d4c03db`](https://github.com/NixOS/nixpkgs/commit/9d4c03db015dacac22fb4b40c76608aa4e4653f1) sqruff: 0.20.2 → 0.25.28
* [`0fc2ab2e`](https://github.com/NixOS/nixpkgs/commit/0fc2ab2e0e15e6f0917363de28579eb2dd959f35) nixos/vivid: correct meta.maintainer
* [`e310c2ce`](https://github.com/NixOS/nixpkgs/commit/e310c2ceb5d2fde87a38398cc943c0e86dc38688) python3Packages.gflanguages: 0.7.4 -> 0.7.5
* [`5e0d8687`](https://github.com/NixOS/nixpkgs/commit/5e0d8687e1237b13268c0a017e4a13d298330bcb) protoc-gen-dart: 22.1.0 -> 22.3.0
* [`1859534d`](https://github.com/NixOS/nixpkgs/commit/1859534d39fe28f23aff39ccccaca050b96af59c) dart-sass: 1.89.0 -> 1.89.1
* [`081bb902`](https://github.com/NixOS/nixpkgs/commit/081bb902cf597fa259e2458a55cebb80d0d87653) multipass: update protobuf
* [`8b3517b8`](https://github.com/NixOS/nixpkgs/commit/8b3517b8f4a45c11efbab756800875e8e0d0c15e) unstructured-api: 0.0.82 -> 0.0.85
* [`fc7dcbfe`](https://github.com/NixOS/nixpkgs/commit/fc7dcbfe5b6be4abace94daac204b9da56d27909) itamae: update all gems to latest versions
* [`54d01b59`](https://github.com/NixOS/nixpkgs/commit/54d01b597bebf56af49cb93fde18bf650804f19a) terraform-providers.rootly: 2.27.1 -> 2.27.2
* [`aa9c7275`](https://github.com/NixOS/nixpkgs/commit/aa9c727515656a927b7937621972252172c608dd) python3Packages.pysmlight: 0.2.4 -> 0.2.5
* [`788e16a8`](https://github.com/NixOS/nixpkgs/commit/788e16a8e9edee9613b3ccdda02018c854452e8d) bitwarden: 2025.4.2 -> 2025.5.0
* [`0b572db5`](https://github.com/NixOS/nixpkgs/commit/0b572db5dc48798d148beb5d7bba321c8f3aaae6) fastlane: 2.227.1 -> 2.227.2
* [`fbeb29c7`](https://github.com/NixOS/nixpkgs/commit/fbeb29c7bdfdb1d0cd60ad637e74973e5ae077b8) veryl: 0.16.0 -> 0.16.1
* [`66f7fabe`](https://github.com/NixOS/nixpkgs/commit/66f7fabe5910d1f3cbb5ae43e7e7a58153a8d048) python3Packages.pymilvus: 2.5.9 -> 2.5.10
* [`bed389dd`](https://github.com/NixOS/nixpkgs/commit/bed389dd2fd59e6e59a52cd6476fa36cf6c2eb91) traccar: 6.7.0 -> 6.7.2
* [`d9cd6cae`](https://github.com/NixOS/nixpkgs/commit/d9cd6cae2a57c3ef3a12b18bf0830ae4a2002fb1) web-ext: 8.7.0 -> 8.7.1
* [`7a24afd1`](https://github.com/NixOS/nixpkgs/commit/7a24afd11b798b09e0e00a059eb766cb201a56bd) kool: 3.5.0 -> 3.5.2
* [`0656fbc4`](https://github.com/NixOS/nixpkgs/commit/0656fbc43f9b36c62bc4ffd6b4c845d3b48fc19c) yubikey-manager: 5.6.1 -> 5.7.0
* [`547fe24c`](https://github.com/NixOS/nixpkgs/commit/547fe24c1181395f39944124421315ba3da18bab) vectorcode: 0.6.9 -> 0.6.10
* [`38479681`](https://github.com/NixOS/nixpkgs/commit/38479681c0a9cc42ac75220d061338b7f46980c5) bpftrace: 0.23.3 -> 0.23.4
* [`245d4243`](https://github.com/NixOS/nixpkgs/commit/245d42430b2ee14f9e1aae77f94c05adebd68588) github-copilot-cli: drop
* [`f86a47b1`](https://github.com/NixOS/nixpkgs/commit/f86a47b15d971497b339dbd4a8056723e303e591) python3Packages.aiokem: 0.5.11 -> 0.5.12
* [`c7e92d12`](https://github.com/NixOS/nixpkgs/commit/c7e92d125ea8c57c9f630bb28d2221f6c40b60d4) shopware-cli: 0.6.1 -> 0.6.3
* [`545535eb`](https://github.com/NixOS/nixpkgs/commit/545535eb5c49af73789d58407fdf805723c4b005) proton-ge-bin: GE-Proton10-3 -> GE-Proton10-4
* [`792f2e04`](https://github.com/NixOS/nixpkgs/commit/792f2e04c353df9425813ebd92328d5aae5d6101) scalafmt: 3.9.6 -> 3.9.7
* [`3cc2f5fd`](https://github.com/NixOS/nixpkgs/commit/3cc2f5fd4b6217a4e847cac5a44be1dc7c4c59a3) treewide: substitute finalAttrs.pname for strings
* [`13ad1dc3`](https://github.com/NixOS/nixpkgs/commit/13ad1dc3dbc519424b78342f8ca110b39b110bdf) terraform-providers.aws: 5.98.0 -> 5.99.1
* [`1fa4b8f5`](https://github.com/NixOS/nixpkgs/commit/1fa4b8f503fcc4a15e795b43b1af11e4a794b405) python3Packages.command-runner: 1.7.3 -> 1.7.4
* [`692cd46b`](https://github.com/NixOS/nixpkgs/commit/692cd46b8aea1a472d0b655767e7779cbef0c496) python3Packages.imeon-inverter-api: 0.3.13 -> 0.3.14
* [`f82ace02`](https://github.com/NixOS/nixpkgs/commit/f82ace024edec54e4cce02917fdeaba8441437b3) python3Packages.mkdocs-rss-plugin: 1.17.1 -> 1.17.3
* [`b7f032c0`](https://github.com/NixOS/nixpkgs/commit/b7f032c04c1b9a72eabea37457cfaf34bfa09940) audio-sharing: inherit pname+version
* [`9797f62b`](https://github.com/NixOS/nixpkgs/commit/9797f62b35b97f72d87d36d3b88d61d5c94577ee) fretboard: inherit pname+version
* [`2199079b`](https://github.com/NixOS/nixpkgs/commit/2199079b1002a1f56656fc741d78f09f7812f61c) furtherance: inherit pname+version
* [`4b1f1be6`](https://github.com/NixOS/nixpkgs/commit/4b1f1be69a7782e22e4033330ef247077c1e7956) gnome-obfuscate: inherit pname+version
* [`b2568b75`](https://github.com/NixOS/nixpkgs/commit/b2568b752824ab9e3c032cb8d70e249add212161) lorem: inherit pname+version
* [`30f4d61c`](https://github.com/NixOS/nixpkgs/commit/30f4d61c71cc37b81e43f73b68921396e5ec02a8) rustls-ffi: inherit pname+version
* [`8f2f709e`](https://github.com/NixOS/nixpkgs/commit/8f2f709eae88340c6098848c26900f3d849180ee) protolint: 0.55.5 -> 0.55.6
* [`628ef043`](https://github.com/NixOS/nixpkgs/commit/628ef0435f6f47052773b7839b543061283cc246) python3Packages.ghome-foyer-api: 1.1.1 -> 1.2.2
* [`122c35d8`](https://github.com/NixOS/nixpkgs/commit/122c35d8d1930342495bfdd399be5aa19e6d367a) vimPlugins.sonarlint-nvim: 0-unstable-2025-05-16 -> 0-unstable-2025-05-30
* [`a5eecde9`](https://github.com/NixOS/nixpkgs/commit/a5eecde98db9fc944c2493b823f3188189d2ac9b) tasks: 0.1.1 -> 0.2.0
* [`5b264d69`](https://github.com/NixOS/nixpkgs/commit/5b264d69f77096f9ca190b0951bab636deb0bda2) python3Packages.managesieve: 0.8 -> 0.8.1
* [`eea8fa32`](https://github.com/NixOS/nixpkgs/commit/eea8fa322e20cde868f7f24fd415338cf64b66b0) qmk: 1.1.7 -> 1.1.8
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
