### PR TITLE
niv home-manager: update c7fdb7e9 -> 427c9604

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -77,10 +77,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c7fdb7e90bff1a51b79c1eed458fb39e6649a82a",
-        "sha256": "199hn3p4gdqr1y0ymw9c436hx6m1vs1n4qhnmdd3xl6ah76qn7qh",
+        "rev": "427c96044f11a5da50faf6adaf38c9fa47e6d044",
+        "sha256": "0sk62jkv4vc961x4g5cwlcwpj5wf272avkjmjqxly0lvlvplbgsh",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/c7fdb7e90bff1a51b79c1eed458fb39e6649a82a.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/427c96044f11a5da50faf6adaf38c9fa47e6d044.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@c7fdb7e9...427c9604](https://github.com/nix-community/home-manager/compare/c7fdb7e90bff1a51b79c1eed458fb39e6649a82a...427c96044f11a5da50faf6adaf38c9fa47e6d044)

* [`2ef52bca`](https://github.com/nix-community/home-manager/commit/2ef52bcab55dfbf4b7c2b23add43f549c9351bb7) tests: pass enableLegacyIfd arg
* [`c3297d77`](https://github.com/nix-community/home-manager/commit/c3297d772174eaffe5601822010c18e2f127e2eb) tests: create `no-big` and `ifd` test outputs.
* [`5adc1a51`](https://github.com/nix-community/home-manager/commit/5adc1a51a2fa8efec9d4eaa4f7df97908cded00d) ci: use flake lock for tests
* [`cb809ec1`](https://github.com/nix-community/home-manager/commit/cb809ec1ff15cf3237c6592af9bbc7e4d983e98c) fzf: prefer `source` for Zsh integration ([nix-community/home-manager⁠#7191](https://togithub.com/nix-community/home-manager/issues/7191))
* [`593b0c66`](https://github.com/nix-community/home-manager/commit/593b0c667d93404972ad8459ffdfc4f5af465d53) doc: fix instructions for enabling flakes in NixOS ([nix-community/home-manager⁠#7189](https://togithub.com/nix-community/home-manager/issues/7189))
* [`bb846c03`](https://github.com/nix-community/home-manager/commit/bb846c031be68a96466b683be32704ef6e07b159) dwm-status: run with --quiet ([nix-community/home-manager⁠#7144](https://togithub.com/nix-community/home-manager/issues/7144))
* [`34a13086`](https://github.com/nix-community/home-manager/commit/34a13086148cbb3ae65a79f753eb451ce5cac3d3) doc: add a missing subcommand ([nix-community/home-manager⁠#7199](https://togithub.com/nix-community/home-manager/issues/7199))
* [`3830a21a`](https://github.com/nix-community/home-manager/commit/3830a21aa2313239b582e4e4ac97f0b25243cb7a) xdg.desktopEntries: Update outdated links in docs ([nix-community/home-manager⁠#7201](https://togithub.com/nix-community/home-manager/issues/7201))
* [`ffab96a8`](https://github.com/nix-community/home-manager/commit/ffab96a8b4a523c4b5e2645ee09e95a75cbdbfab) qutebrowser: null package support ([nix-community/home-manager⁠#7203](https://togithub.com/nix-community/home-manager/issues/7203))
* [`86b95fc1`](https://github.com/nix-community/home-manager/commit/86b95fc1ed2b9b04a451a08ccf13d78fb421859c) aichat: init ([nix-community/home-manager⁠#7207](https://togithub.com/nix-community/home-manager/issues/7207))
* [`13a45ede`](https://github.com/nix-community/home-manager/commit/13a45ede6c17b5e923dfc18a40a3f646436f4809) aichat: fix config example ([nix-community/home-manager⁠#7212](https://togithub.com/nix-community/home-manager/issues/7212))
* [`09b0a4b0`](https://github.com/nix-community/home-manager/commit/09b0a4b0da86c12a57976028bbda3897137c9528) dconf: revert: dconf: Provide dconf ([nix-community/home-manager⁠#7215](https://togithub.com/nix-community/home-manager/issues/7215))
* [`7707ebb0`](https://github.com/nix-community/home-manager/commit/7707ebb05c6a021e730fdefdb41c2b7e8133251d) jellyfin-mpv-shim: make sure the config file is read properly
* [`68cc9eeb`](https://github.com/nix-community/home-manager/commit/68cc9eeb3875ae9682c04629f20738e1e79d72aa) jellyfin-mpv-shim: merge settings with existing config file
* [`de8463dd`](https://github.com/nix-community/home-manager/commit/de8463dd3ef259502b937fac37fadd6adc252bfe) zsh: add plugins.*.completions paths to fpath ([nix-community/home-manager⁠#7197](https://togithub.com/nix-community/home-manager/issues/7197))
* [`0ee810c8`](https://github.com/nix-community/home-manager/commit/0ee810c839ee73b2d3973f5683f9a3bf8d430e8a) zed-editor: respect user interactivity with settings and keymaps ([nix-community/home-manager⁠#6993](https://togithub.com/nix-community/home-manager/issues/6993))
* [`bbb31d83`](https://github.com/nix-community/home-manager/commit/bbb31d835230720c7a5bc085412776c61dabc7bc) ludusavi: fix import ([nix-community/home-manager⁠#7205](https://togithub.com/nix-community/home-manager/issues/7205))
* [`355c7d09`](https://github.com/nix-community/home-manager/commit/355c7d09ede3335b6642cf1736de3df0d4fdd136) chawan: fix example for settings ([nix-community/home-manager⁠#7210](https://togithub.com/nix-community/home-manager/issues/7210))
* [`91287a0e`](https://github.com/nix-community/home-manager/commit/91287a0e9d42570754487b7e38c6697e15a9aab2) nixgl: remove alias ([nix-community/home-manager⁠#7218](https://togithub.com/nix-community/home-manager/issues/7218))
* [`76e9c6e1`](https://github.com/nix-community/home-manager/commit/76e9c6e14aabba36368bc1c0680c80f018451e43) lib/default.nix: remove inefficient second copy ([nix-community/home-manager⁠#7221](https://togithub.com/nix-community/home-manager/issues/7221))
* [`b2483b45`](https://github.com/nix-community/home-manager/commit/b2483b45e6ac37ec81192e9ab979ac3b669ae8e9) flake.lock: Update
* [`812b43b4`](https://github.com/nix-community/home-manager/commit/812b43b45d4807e072b261cd00f35c911c3cbef0) tests/thefuck: explicit stubbing
* [`c18a7679`](https://github.com/nix-community/home-manager/commit/c18a767948ebe573502b564f88fadec448009b88) zed-editor: userKeymaps default to empty array ([nix-community/home-manager⁠#7222](https://togithub.com/nix-community/home-manager/issues/7222))
* [`96482a53`](https://github.com/nix-community/home-manager/commit/96482a538e6103579d254b139759d0536177370b) keychain: warn about deprecated options ([nix-community/home-manager⁠#7196](https://togithub.com/nix-community/home-manager/issues/7196))
* [`1d595a5b`](https://github.com/nix-community/home-manager/commit/1d595a5b64fb887dd67dd98866af30b1a37b0f7a) zed-editor: allow for nullable package ([nix-community/home-manager⁠#7220](https://togithub.com/nix-community/home-manager/issues/7220))
* [`2d7d65f6`](https://github.com/nix-community/home-manager/commit/2d7d65f65b61fdfce23278e59ca266ddd0ef0a36) fish: fix the binds.*.erase option ([nix-community/home-manager⁠#7186](https://togithub.com/nix-community/home-manager/issues/7186))
* [`980aece3`](https://github.com/nix-community/home-manager/commit/980aece33ab30b127e471a617c4ee30e45f4e8b1) flake.lock: Update ([nix-community/home-manager⁠#7235](https://togithub.com/nix-community/home-manager/issues/7235))
* [`bd8946c7`](https://github.com/nix-community/home-manager/commit/bd8946c773906d3e331efa02ea25b3a19a063d68) lazysql: add module ([nix-community/home-manager⁠#7231](https://togithub.com/nix-community/home-manager/issues/7231))
* [`515ab1da`](https://github.com/nix-community/home-manager/commit/515ab1da57955e9805348336b0afd6d9a50c0c7e) ludusavi: fix icon on notification
* [`bc0012d0`](https://github.com/nix-community/home-manager/commit/bc0012d036b02093c1cf0322866db8ddad707ef6) ludusavi: add frequency option
* [`627157cc`](https://github.com/nix-community/home-manager/commit/627157ccebb4c82b6f60c2795e848e595d566dc7) ludusavi: modernize and clean-up
* [`06451df4`](https://github.com/nix-community/home-manager/commit/06451df423dd5e555f39857438ffc16c5b765862) ghostty: only source fish shell integration script when shell is interactive ([nix-community/home-manager⁠#7228](https://togithub.com/nix-community/home-manager/issues/7228))
* [`f23b0935`](https://github.com/nix-community/home-manager/commit/f23b0935a3c7a3ec1907359b49962393af248734) hypridle: add systemdTarget option ([nix-community/home-manager⁠#7237](https://togithub.com/nix-community/home-manager/issues/7237))
* [`2835e8ba`](https://github.com/nix-community/home-manager/commit/2835e8ba0ad99ba86d4a5e497a962ec9fa35e48f) nyxt: add module ([nix-community/home-manager⁠#7232](https://togithub.com/nix-community/home-manager/issues/7232))
* [`eee14095`](https://github.com/nix-community/home-manager/commit/eee140958aa1171183fad3dc8dc3f0cda6af6460) home-manager: fix integration tests
* [`35e1f5a7`](https://github.com/nix-community/home-manager/commit/35e1f5a7c29f2b05e8f53177f6b5c71108c5f4c3) mc: add midnight commander module ([nix-community/home-manager⁠#7225](https://togithub.com/nix-community/home-manager/issues/7225))
* [`74d196c9`](https://github.com/nix-community/home-manager/commit/74d196c9943a67908d1883f61154e594d03863e5) papis: allow libraries to not to be defined ([nix-community/home-manager⁠#7204](https://togithub.com/nix-community/home-manager/issues/7204))
* [`1df816c4`](https://github.com/nix-community/home-manager/commit/1df816c407d3a5090c8496c9b00170af7891f021) fix: ensure newline after vim.cmd[[source...]] in neovim init.lua ([nix-community/home-manager⁠#7219](https://togithub.com/nix-community/home-manager/issues/7219))
* [`f26c378c`](https://github.com/nix-community/home-manager/commit/f26c378c3d0f9958d41b350f6dd12e2bd8f9602a) Translations update from Hosted Weblate ([nix-community/home-manager⁠#7244](https://togithub.com/nix-community/home-manager/issues/7244))
* [`e9763eb1`](https://github.com/nix-community/home-manager/commit/e9763eb195c1e3d508892993cf112bd75d6fd712) niriswitcher: add module ([nix-community/home-manager⁠#7246](https://togithub.com/nix-community/home-manager/issues/7246))
* [`7e3d76e7`](https://github.com/nix-community/home-manager/commit/7e3d76e7f71c05d4c2190d94ae1c438f60f1136e) maintainers: add delafthi
* [`427c9604`](https://github.com/nix-community/home-manager/commit/427c96044f11a5da50faf6adaf38c9fa47e6d044) codex: init
