### PR TITLE
niv nixpkgs: update e9761a0d -> cbb9bf84

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -155,10 +155,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e9761a0d6685771814d3ee7a4cb3fc8f01485fa5",
-        "sha256": "17xbghmjyvnlb1jkf77nz570cxkvnsddmqz32izc0va6wnnjjfga",
+        "rev": "cbb9bf84ff3e497091c5450032600fbff7a05589",
+        "sha256": "1rc2d9ckqra11vszbzv616hpix8mkryd0nid0179bbmvfjxy4dc8",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/e9761a0d6685771814d3ee7a4cb3fc8f01485fa5.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/cbb9bf84ff3e497091c5450032600fbff7a05589.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@e9761a0d...cbb9bf84](https://github.com/nixos/nixpkgs/compare/e9761a0d6685771814d3ee7a4cb3fc8f01485fa5...cbb9bf84ff3e497091c5450032600fbff7a05589)

* [`329c7a09`](https://github.com/NixOS/nixpkgs/commit/329c7a097c8a559be12ec7daf0d5ae150d138ab0) maintainers: add petingoso
* [`34fc9a0b`](https://github.com/NixOS/nixpkgs/commit/34fc9a0b25a25e95746ab264f96338557ba4a426) maintainers: add sdedovic
* [`2f0949c4`](https://github.com/NixOS/nixpkgs/commit/2f0949c45d38745d066d848da04c4b21c3c69de5) tsx: init at 4.19.3
* [`62e93c10`](https://github.com/NixOS/nixpkgs/commit/62e93c107f2d34dc6e3f6cde1cc95c733b76703f) nixos-option: Match the behavior described in detection order
* [`cc947082`](https://github.com/NixOS/nixpkgs/commit/cc9470828dd7621c7f913b43aa0816a683b0cfb8) maintainers: add dsalwasser
* [`a919a6e6`](https://github.com/NixOS/nixpkgs/commit/a919a6e611dadecf1e2847ca1d899accd70c41b3) makeBinaryWrapper: use GNU bintools for extractCmd
* [`96f5dbef`](https://github.com/NixOS/nixpkgs/commit/96f5dbef8a6d654a6d0fa4bd80f1beac47460c87) giada: 1.0.0 -> 1.1.1
* [`d54d73ca`](https://github.com/NixOS/nixpkgs/commit/d54d73ca4bf2c359766cd1c6e5cdf48cc51da26c) vscode-extensions.natqe.reload: init at 0.0.7
* [`19232240`](https://github.com/NixOS/nixpkgs/commit/19232240502222043e650d9b02e6bbc3cf4b0edd) librewolf: fix extraPolicies
* [`d61f4af5`](https://github.com/NixOS/nixpkgs/commit/d61f4af5b6df73b3695cd13cef4a7941eb7e0dee) rose-pine-kvantum: 0-unstable-2025-03-26 -> 0-unstable-2025-04-16
* [`67781475`](https://github.com/NixOS/nixpkgs/commit/67781475658634f92e1d09a503a716982011842f) crypto-org-wallet: 0.1.1 -> 1.5.1
* [`6baafc74`](https://github.com/NixOS/nixpkgs/commit/6baafc747013798e79759259c98bf4b38b1b275e) mysql-shell: 8.4.4 -> 8.4.5
* [`86f10e2a`](https://github.com/NixOS/nixpkgs/commit/86f10e2a961506a0f984d1b721d10c99243d5329) mysql-shell-innovation: 9.2.0 -> 9.3.0
* [`8e42061b`](https://github.com/NixOS/nixpkgs/commit/8e42061bcbce45b344e8eb63b4e4dac84238cc80) quickemu: add passthru.updateScript
* [`6c13a5ac`](https://github.com/NixOS/nixpkgs/commit/6c13a5acbca45e038097d301c9ad16c49cc95c36) quickemu: 4.9.6 -> 4.9.7
* [`7779d290`](https://github.com/NixOS/nixpkgs/commit/7779d29045c991c8bf9b57e8c4fd5b7d7e4f76a1) hylafaxplus: 7.0.10 -> 7.0.11
* [`3902b08d`](https://github.com/NixOS/nixpkgs/commit/3902b08d8be2a1d21f5565e4a5541acf81f9c24e) libslirp: fix DNS resolution on MacOS
* [`f90236a8`](https://github.com/NixOS/nixpkgs/commit/f90236a8f2c33cc8814428ac4cda1e77e43c2375) linux-builder: remove DNS hack for libslirp
* [`ac777639`](https://github.com/NixOS/nixpkgs/commit/ac77763941394e13630578f1439ad73367100bad) hyperledger-fabric: 2.5.5 -> 2.5.13
* [`201515be`](https://github.com/NixOS/nixpkgs/commit/201515be8317cb4f3d33d0fe87b68406a9366672) ior: 3.3.0 -> 4.0.0
* [`1e1a3ccd`](https://github.com/NixOS/nixpkgs/commit/1e1a3ccd2c27d4ae5c41fdda31044bd75b342647) plex-desktop: unset QT env variables that may cause crashing
* [`f248446f`](https://github.com/NixOS/nixpkgs/commit/f248446f9b476826d44b46f4167eba91a6a1780d) server-box: init at 1.0.1130-unstable-2025-04-25
* [`d241d22d`](https://github.com/NixOS/nixpkgs/commit/d241d22daad106419c897d6c17a0f70bbbf768a6) ryubing: change upstream of updater.sh
* [`2eb01626`](https://github.com/NixOS/nixpkgs/commit/2eb016262b2f306b62620cf4cdfadd17db145564) ryubing: 1.2.86 -> 1.3.1
* [`3be662c3`](https://github.com/NixOS/nixpkgs/commit/3be662c31b6cc04b10043641f4ccfc97c8a34704) olympus{,-unwrapped}: init at 25.04.20.01
* [`ce8c8fea`](https://github.com/NixOS/nixpkgs/commit/ce8c8feab9aeef8c086f262e2b00e60152a3e602) multimarkdown: 6.6.0 -> 6.7.0
* [`baf36915`](https://github.com/NixOS/nixpkgs/commit/baf36915c40a60711fff8534b444c9c4baa72998) dump1090: Build faup1090 for FlightAware collector
* [`baef1855`](https://github.com/NixOS/nixpkgs/commit/baef1855fed962e65fb3b119806b2d800bcbd3c9) blueutil: 2.10.0 -> 2.12.0
* [`9865da74`](https://github.com/NixOS/nixpkgs/commit/9865da7478651851603d102025792b48c45ee50a) hoppscotch: improve update script
* [`157acdac`](https://github.com/NixOS/nixpkgs/commit/157acdac6fe93334d56d883c871b393bf127d15f) megatools: 1.11.1 -> 1.11.3
* [`32749ad4`](https://github.com/NixOS/nixpkgs/commit/32749ad4b59af755bb352d773cefaeac2f0b17e5) megatools: modernise derivation
* [`2012e7dd`](https://github.com/NixOS/nixpkgs/commit/2012e7dd9cc6ff3edfa34f69a971e82a9e956a72) megatools: add maintainer vji
* [`b474b5f2`](https://github.com/NixOS/nixpkgs/commit/b474b5f2cfb759a3b3fbe7672ad912bd65786cbe) megatools: 1.11.3 -> 1.11.4
* [`ef60b68d`](https://github.com/NixOS/nixpkgs/commit/ef60b68d62f3921fd6718830b29d03e491991a0a) megatools: remove "with lib"
* [`48ad608c`](https://github.com/NixOS/nixpkgs/commit/48ad608c3b41c2987fbe67b9d89adedadee44169) python3Packages.highctidh: init at 1.0.2025051200
* [`d3402765`](https://github.com/NixOS/nixpkgs/commit/d3402765327e862d996ac1f13eef1ddf4862492a) proxsuite: clean
* [`74af8a1a`](https://github.com/NixOS/nixpkgs/commit/74af8a1a14c702867374d4ddb723dd49bc6217bc) proxsuite: 0.6.7 -> 0.7.2
* [`bb051b65`](https://github.com/NixOS/nixpkgs/commit/bb051b65d7bdbc479956c28e4cd6bc755d87aea7) python3Packages.proxsuite: pybind11 -> nanobind
* [`5333a03e`](https://github.com/NixOS/nixpkgs/commit/5333a03e39fd09973cea20a8b72d9bd2989a461f) aligator: clean
* [`6208fbff`](https://github.com/NixOS/nixpkgs/commit/6208fbff634ce263067f01bad8e3066eb23624b2) aligator: 0.12.0 -> 0.13.0
* [`fb21d6c0`](https://github.com/NixOS/nixpkgs/commit/fb21d6c0edc32c33230542457246f3b4c9ee8c1b) jrl-cmakemodules: 0-unstable-2025-01-29 -> 0-unstable-2025-05-04
* [`c930de82`](https://github.com/NixOS/nixpkgs/commit/c930de820ebcbb2b66410fc3c0871dbc065e4e5c) aligator: 0.13.0 -> 0.14.0
* [`29faf4a3`](https://github.com/NixOS/nixpkgs/commit/29faf4a363d0c7dafa82c442af0f2d68d41a3705) noip: 2.1.9-1 -> 3.3.0
* [`84497e0c`](https://github.com/NixOS/nixpkgs/commit/84497e0c95e8269bf6db40caeb26caac61641ff1) numatop: 2.2 -> 2.5.1
* [`8c7f0a16`](https://github.com/NixOS/nixpkgs/commit/8c7f0a16b70a270ca9edc01c8b5a5eefb0d2f0ce) opensplat: patch for torch 2.6
* [`76e0538f`](https://github.com/NixOS/nixpkgs/commit/76e0538fcd79feb3fade4a4abe66a1c74e4c2afa) amnezia-vpn: add support for Amnezia Premium official servers
* [`40b9a8ac`](https://github.com/NixOS/nixpkgs/commit/40b9a8acac481e4281e4929911d94ee2523d380a) insync-emblem-icons: drop
* [`9905f0ed`](https://github.com/NixOS/nixpkgs/commit/9905f0ed3980fadd410019e24f824c6474767f13) corestore: init at 7.1.0
* [`3dac6fb3`](https://github.com/NixOS/nixpkgs/commit/3dac6fb3618c9fe51e386c237cbf174544f7cf6f) mozjpeg_lossless_optimization: init at 1.1.3
* [`8afcd39e`](https://github.com/NixOS/nixpkgs/commit/8afcd39eb94bd4b3ceb360c1ca0fc94265a4d596) kcc: 5.5.1 -> 7.3.3
* [`340cd4a4`](https://github.com/NixOS/nixpkgs/commit/340cd4a44555ef472865d36b06a9e41b3810c72f) nixos/hardware/nvidia: add prime.offload.offloadCmdMainProgram
* [`30eebcb4`](https://github.com/NixOS/nixpkgs/commit/30eebcb427edfc42fa7bc114f192434bee411db1) taler-mdb: init at 1.0.0
* [`4f80e496`](https://github.com/NixOS/nixpkgs/commit/4f80e4962d43c0fc7d2874a3b65f285e7f77d8bf) snyk: 1.1296.1 -> 1.1297.1
* [`997fedf5`](https://github.com/NixOS/nixpkgs/commit/997fedf514a5daa0e2886e23d54760fb91947be8) opencryptoki: 3.23.0 -> 3.24.0
* [`4abce219`](https://github.com/NixOS/nixpkgs/commit/4abce219e7b9f52780ec4e459b6eea0e2c8a2f89) beetsPackages.audible: 1.0.1 -> 1.0.2
* [`1f31a537`](https://github.com/NixOS/nixpkgs/commit/1f31a537411251a0eec91c8a7f91d51a240f2c0c) python3Packages.bayesian-optimization: 2.0.3 -> 2.0.4
* [`72a0ae47`](https://github.com/NixOS/nixpkgs/commit/72a0ae47520b5c12eeb66cc51e3bee042a700dd2) python313Packages.mobly: 1.12.4 -> 1.13
* [`86adc4bf`](https://github.com/NixOS/nixpkgs/commit/86adc4bf3e0d45ada9914667878721f04266d553) djview: move to pkgs/by-name
* [`9fedd72f`](https://github.com/NixOS/nixpkgs/commit/9fedd72fb8cae009524034b236057fb320b75e8b) djview: unbreak for darwin
* [`84e39aae`](https://github.com/NixOS/nixpkgs/commit/84e39aaeaada5b58b16fd943e0bbe07df6b1c81d) stockfish: remove unused input
* [`b153f78a`](https://github.com/NixOS/nixpkgs/commit/b153f78ae7c0826606d508116ed9e570440f8a18) stockfish: add updateScript
* [`32b302b7`](https://github.com/NixOS/nixpkgs/commit/32b302b7cc43c23c8d414a59552061a018aba7e8) stockfish: add versionCheckHook
* [`41e85ee7`](https://github.com/NixOS/nixpkgs/commit/41e85ee7c1a81da0d68cf11df2710e1a1f9310af) stockfish: 17 -> 17.1
* [`67e81835`](https://github.com/NixOS/nixpkgs/commit/67e81835313fcb0ba3b0eccee7439c93734e5a3f) lomiri.lomiri-gallery-app: 3.1.0 -> 3.1.1
* [`8bf28aa1`](https://github.com/NixOS/nixpkgs/commit/8bf28aa1aab925933761308db871f1dcb98ab501) nixosTests.lomiri-gallery-app: Optimise OCR
* [`ccbacd73`](https://github.com/NixOS/nixpkgs/commit/ccbacd7380d2aea59f706c6dc9fe44932f0fc770) jekyll: update gems to latest versions
* [`ada07fa8`](https://github.com/NixOS/nixpkgs/commit/ada07fa89d7c24a9d84d291d1b645863e4705871) neuron: 8.2.6 -> 8.2.7
* [`1015c45b`](https://github.com/NixOS/nixpkgs/commit/1015c45b0e6082bd817e9c40342abdbd27b3df9c) OWNERS: add more standard environment–related libraries
* [`096300d6`](https://github.com/NixOS/nixpkgs/commit/096300d628a3765d5ee489cf11646e59b507e790) cloudflare-dyndns: 5.3 -> 5.4
* [`51b9d7eb`](https://github.com/NixOS/nixpkgs/commit/51b9d7ebc86018d1372fdd87eb3e278f14a90154) libe57format: Disable LTO to fix linker error in downstream builds that use `.a` file.
* [`da48a93c`](https://github.com/NixOS/nixpkgs/commit/da48a93ca40bb18754d83016b0bd993970228375) libe57format: 3.1.1 -> 3.2.0
* [`d1d8870f`](https://github.com/NixOS/nixpkgs/commit/d1d8870fa1cf4dce119006b86ed8910aa0992bd0) qbittorrent-enhanced-nox: 5.1.0.10 -> 5.1.0.11
* [`9293bae2`](https://github.com/NixOS/nixpkgs/commit/9293bae27b5bea7f9db6a31165b36f2607fd9758) nixosTests.lomiri-gallery-app: Split format checks into separate tests
* [`a646528d`](https://github.com/NixOS/nixpkgs/commit/a646528d452e4eea55f93ac906cc43d55146e1b7) python3Packages.google-cloud-bigtable: 2.30.1 -> 2.31.0
* [`a46dd573`](https://github.com/NixOS/nixpkgs/commit/a46dd57329b76fe3907ba3c5c83abe4d4a5716ef) biz-ud-gothic: init at 1.051
* [`6a84a15c`](https://github.com/NixOS/nixpkgs/commit/6a84a15c869a886517bd8320b4e2ba91a3c5adcd) cudaPackages_11_0.autoAddCudaCompatRunpath.libcudaPath: fix the eval
* [`ebed8fb6`](https://github.com/NixOS/nixpkgs/commit/ebed8fb6dc2cbe9cf89b9ce8e6bbe3faf0986b08) maintainers: add junestepp
* [`52e98a13`](https://github.com/NixOS/nixpkgs/commit/52e98a13184f2aeb3a7b42cc971756004c2f238e) lkl: 2022-08-08 -> 2025-03-20
* [`06388c42`](https://github.com/NixOS/nixpkgs/commit/06388c42f59d753d665c2cf22c0c9df519044934) lkl: Move to the by-name package tree
* [`b0675d7e`](https://github.com/NixOS/nixpkgs/commit/b0675d7ea16d71d7dbcbe26f6b9331d1606987eb) lkl: Remove inactive maintainers, add myself
* [`b30db924`](https://github.com/NixOS/nixpkgs/commit/b30db924b81d2bfe1b4e67c616583d4cbab3de1a) drawio: ensure node_modules is created
* [`23274a2a`](https://github.com/NixOS/nixpkgs/commit/23274a2a2a121419d6d2ab9e7f50fb28bd724dac) nixosTests.lomiri-gallery-app: Remove format extension check
* [`95ab3116`](https://github.com/NixOS/nixpkgs/commit/95ab3116e6581efb55fd8d3867f4a72bb0c0c65b) yaak: added darwin support
* [`69c0260d`](https://github.com/NixOS/nixpkgs/commit/69c0260d343e473a52cef6a04cb59045350cb394) yaak: fix version in final build
* [`b24bb041`](https://github.com/NixOS/nixpkgs/commit/b24bb041c2b57f74e1b287043de7d829994009c5) python313Packages.openai: 1.78.1 -> 1.82.0
* [`2f1aaed2`](https://github.com/NixOS/nixpkgs/commit/2f1aaed20f4a0e7d20fb008e5efbe834d7ec7275) python312Packages.llama-index-llms-openai: 0.3.42 -> 0.3.44
* [`21321e26`](https://github.com/NixOS/nixpkgs/commit/21321e263e5b51f5c874564346cb073d7dea09f2) spirv-llvm-translator: 15.0.11 -> 15.0.12
* [`3878c101`](https://github.com/NixOS/nixpkgs/commit/3878c101a18798cd2d11c967baaeb88f2b00c4e3) intel-graphics-compiler: 2.10.8 -> 2.11.7
* [`168a5e08`](https://github.com/NixOS/nixpkgs/commit/168a5e08bae4045943603d694e924d4e82378bc7) mpvScripts.easycrop: init at 0-unstable-2018-01-24
* [`34561f41`](https://github.com/NixOS/nixpkgs/commit/34561f41902952d36ffaedfb35a9c0a95b9f4219) joshuto: 0.9.8-unstable-2024-07-20 -> 0.9.9
* [`319b25a9`](https://github.com/NixOS/nixpkgs/commit/319b25a9f3c65994874817168fa994484f3313a7) jsonnet-language-server: 0.15.0 -> 0.16.0
* [`aa15d720`](https://github.com/NixOS/nixpkgs/commit/aa15d7203d5413b163ad241a34918162818478e9) rawtherapee: 5.11 -> 5.12
* [`f5b8914c`](https://github.com/NixOS/nixpkgs/commit/f5b8914cdccacfec13713e58f944df4f936dfc0f) buildOctavePackage: add octave.withPackages passthru test
* [`4cd9944d`](https://github.com/NixOS/nixpkgs/commit/4cd9944dbf8b8008b7a54fc41c65e0b3011fdbf0) ffmpeg_4: 4.4.5 -> 4.4.6
* [`cd30ac6e`](https://github.com/NixOS/nixpkgs/commit/cd30ac6e6d9429aaec4e631f4444bd9ed1187785) maintainers: add stackptr
* [`aff794fe`](https://github.com/NixOS/nixpkgs/commit/aff794fe22430fc8bbb436369b303602804794e4) nixosTests.lomiri-gallery-app: Cache media in thumbnailer ahead-of-time, retry until successful
* [`f2d9cad8`](https://github.com/NixOS/nixpkgs/commit/f2d9cad8793afeb99988095af8c753999562a41d) davinci-resolve: add XBagon to maintainers
* [`0c3fc1cd`](https://github.com/NixOS/nixpkgs/commit/0c3fc1cd3494aa52a2c111d5f18a7689fd15ab83) davinci-resolve: 19.1.4 -> 20.0
* [`42727278`](https://github.com/NixOS/nixpkgs/commit/42727278cd2e946d1b37530d7a11308535e687be) python3Packages.miniupnpc: 2.3.2 -> 2.3.3
* [`158bfaf7`](https://github.com/NixOS/nixpkgs/commit/158bfaf735401219af77573e80c2892cdfc02ac4) wiremix: init at 0.4.0
* [`62f19463`](https://github.com/NixOS/nixpkgs/commit/62f1946374dc9d463544293244ffc596f22b5c59) mangohud: hardcode libGL & libX11
* [`89f3632a`](https://github.com/NixOS/nixpkgs/commit/89f3632a848cba1ebcfe6e88b76c1c81389c12de) vfox: init at 0.6.10
* [`0631a6fd`](https://github.com/NixOS/nixpkgs/commit/0631a6fdda553f58b007882d684da279f93d4cb4) maintainers: add keyruu
* [`0b843987`](https://github.com/NixOS/nixpkgs/commit/0b843987c92498af2d3a230b3a0d992a098fbc1e) kind: 0.27.0 -> 0.29.0
* [`a6826b41`](https://github.com/NixOS/nixpkgs/commit/a6826b41036446fd2e66e0af48c88e2eaef6585f) anki: add withAddons
* [`6d7a5d96`](https://github.com/NixOS/nixpkgs/commit/6d7a5d963282abac0e3917fe9b37e177b5fdf61d) maintainers: add isotoxal
* [`11617fbd`](https://github.com/NixOS/nixpkgs/commit/11617fbd2e4404fd798b7f95c6c7075026488f35) scroll-reverser: init at 1.9
* [`00e32326`](https://github.com/NixOS/nixpkgs/commit/00e32326f6904add473731eefb716877a08fb230) meme-suite: 5.5.7 -> 5.5.8
* [`b5b25206`](https://github.com/NixOS/nixpkgs/commit/b5b252067914513d3df98717be44c32dc99918c5) strobealign: init 0.16.1
* [`5bf3d72a`](https://github.com/NixOS/nixpkgs/commit/5bf3d72affe83f50d7d4ce9597bf8eaf611877dd) maintainers: add joshprk
* [`ff7d7582`](https://github.com/NixOS/nixpkgs/commit/ff7d7582dc67c32ce4f865572cb0e7cc67c1a718) databricks-cli: 0.250.0 -> 0.253.0
* [`fd4e7203`](https://github.com/NixOS/nixpkgs/commit/fd4e72032090552d1db3f22117dc6cd0a1d43d7f) prometheus-frr-exporter: 1.6.0 -> 1.7.0
* [`5033057e`](https://github.com/NixOS/nixpkgs/commit/5033057ec17e382fe5cff94236f80d112f5946ba) sea-orm-cli: 1.1.11 -> 1.1.12
* [`912c4b9b`](https://github.com/NixOS/nixpkgs/commit/912c4b9be2349fc8ecb26e618a19cc11ea640b32) tart: 2.24.0 -> 2.27.2
* [`1607bc43`](https://github.com/NixOS/nixpkgs/commit/1607bc4319d1e60ab9564118a7209963fbf8b408) submit50: init at 3.2.0
* [`e66b952b`](https://github.com/NixOS/nixpkgs/commit/e66b952be1711ad40142ef4f7d819b9f380de575) python3Packages.x-transformers: 2.3.5 -> 2.3.12
* [`0364cac5`](https://github.com/NixOS/nixpkgs/commit/0364cac5628027b019cff7806108abd46c4a05db) tintin: 2.02.42 -> 2.02.51
* [`6d895f43`](https://github.com/NixOS/nixpkgs/commit/6d895f43c2b28c8c6035859e6964daff97cfd120) gum: 0.16.0 -> 0.16.1
* [`b59c9df8`](https://github.com/NixOS/nixpkgs/commit/b59c9df834b1e4d0690de51376c80fb370e8570d) directx-shader-compiler: 1.8.2502 -> 1.8.2505
* [`f4036f94`](https://github.com/NixOS/nixpkgs/commit/f4036f947b55c0be6a8e10c24a1336cb51db2523) simpleDBus: 0.9.1 -> 0.10.1
* [`d19f6eaf`](https://github.com/NixOS/nixpkgs/commit/d19f6eaf6f463c1c425d7bf6e1cca1b687053126) linux: add extraPassthru
* [`d0851295`](https://github.com/NixOS/nixpkgs/commit/d0851295e9405abd1e25c48d348df1abb2ee4946) linux_zen: use extraPassthru.updateScript
* [`a6a450c1`](https://github.com/NixOS/nixpkgs/commit/a6a450c101dc3597403934aead32194d9cd722e6) linux-libre: use extraPassthru.updateScript
* [`2d5f476a`](https://github.com/NixOS/nixpkgs/commit/2d5f476a03e7ff1f61c278366b1aaa27690c03d1) kagen: init at 1.1.0
* [`b1b41e62`](https://github.com/NixOS/nixpkgs/commit/b1b41e622519b917940a4ee957894db6f8cd3aee) kaminpar: init at 3.5.1
* [`9dba3a34`](https://github.com/NixOS/nixpkgs/commit/9dba3a34eccbb7129254949184e2ff1902f43379) lomiri.lomiri-indicator-network: 1.1.0 -> 1.1.1
* [`cfa10c8c`](https://github.com/NixOS/nixpkgs/commit/cfa10c8c7a79752032c28afa6daa756631b07029) fetchsvn: simplify `repoToName` and move it outside the thunk
* [`27b01599`](https://github.com/NixOS/nixpkgs/commit/27b01599c56d8954decb41e4a80753ee61a2fc15) pkgs/top-level/config.nix: remove some unneded lines
* [`7c8a4efb`](https://github.com/NixOS/nixpkgs/commit/7c8a4efb688b4bf3e8dbf71a43e8b963d8fe3bca) lib, treewide: introduce `repoRevToName`, use it in most `fetch*` functions
* [`ccb18520`](https://github.com/NixOS/nixpkgs/commit/ccb18520b6d8c9096b33bf853a2623d04cb2f5d1) i-pi: 3.1.4 -> 3.1.5
* [`7c1bb016`](https://github.com/NixOS/nixpkgs/commit/7c1bb016991421a76ef103d27aaa089433bea4be) python3Packages.ldap3: refactor, use git src, run tests
* [`97f7843d`](https://github.com/NixOS/nixpkgs/commit/97f7843dacf01d9a717f294f2a5a28d985285570) frr: 10.3 -> 10.3.1
* [`d0c2fbd2`](https://github.com/NixOS/nixpkgs/commit/d0c2fbd21b465770eb546b4dff6c649656dd1842) iwmenu: init at 0.2.0
* [`284bf4fd`](https://github.com/NixOS/nixpkgs/commit/284bf4fd54e4757f192ff89d0784d5045f442b5f) androidenv: emulator: fix non-Linux path/binary symlink
* [`4a2735df`](https://github.com/NixOS/nixpkgs/commit/4a2735dfd54561bdc278852fcb65d5ebed790f38) androidenv: emulator: nixfmt emulator.nix
* [`33d10ce0`](https://github.com/NixOS/nixpkgs/commit/33d10ce08ede7f6704ffbe67e00be63c063b73a9) python3Packages.mail-parser: 4.1.2 -> 4.1.3
* [`957f0e34`](https://github.com/NixOS/nixpkgs/commit/957f0e34974dd42855a351977402d2db5e1b4836) azure-cli-extensions.containerapp: 1.1.0b5 -> 1.2.0b1
* [`f3996233`](https://github.com/NixOS/nixpkgs/commit/f3996233dcceffe37f19d6ec60a03012ea722aef) python3Packages.panphon: 0.21.2 -> 0.22.0
* [`c9994145`](https://github.com/NixOS/nixpkgs/commit/c999414503cefabe2c9aac1ffb0db5de2b838bc9) oneDNN: 3.8 -> 3.8.1
* [`af71a50c`](https://github.com/NixOS/nixpkgs/commit/af71a50cfaecbecc9be6da5eb78c447fb2a6dc81) python313Packages.ollama: 0.4.8 -> 0.5.1
* [`eb28360c`](https://github.com/NixOS/nixpkgs/commit/eb28360c5a9f76e9ad0599a13f042a1ce10741f6) libqalculate: no with lib; in meta
* [`30f92cda`](https://github.com/NixOS/nixpkgs/commit/30f92cdaba23696b9cc0d599f6d16f96e3054102) libqalculate: Remove not happening patchPhase substitution
* [`3cddbe11`](https://github.com/NixOS/nixpkgs/commit/3cddbe116c3b04ae07d50645169073ee25326c86) libqalculate: use tag and not rev in src.
* [`961dda9c`](https://github.com/NixOS/nixpkgs/commit/961dda9c6aa099e0900cb109825d4b5daef57cdb) libqalculate: Don't overrde patchPhase completely
* [`e12409a3`](https://github.com/NixOS/nixpkgs/commit/e12409a3b2369958cc50fd88e99fd924a28006a0) seagoat: 0.54.18 -> 1.0.6
* [`e43a3fe5`](https://github.com/NixOS/nixpkgs/commit/e43a3fe505ff341229188c0f161001d792a3ba0e) _4ti2: 1.6.11 -> 1.6.12
* [`d6adcac8`](https://github.com/NixOS/nixpkgs/commit/d6adcac86404c9d9ef82dbe898f3b01fcc6dc0cf) zsh-forgit: 25.05.0 -> 25.06.0
* [`62147d08`](https://github.com/NixOS/nixpkgs/commit/62147d087d37613c15d2b2526fa4e886c2aae806) esbuild: 0.25.4 -> 0.25.5
* [`e9c0ef1c`](https://github.com/NixOS/nixpkgs/commit/e9c0ef1c0057b7ca9c1a4ba06978e183ac2fb5af) openjph: 0.21.2 -> 0.21.3
* [`0c95f0d1`](https://github.com/NixOS/nixpkgs/commit/0c95f0d166f9cd95aaad3a7054fa95cb7a32b34d) c2patool: 0.17.0 -> 0.18.0
* [`9400bcd0`](https://github.com/NixOS/nixpkgs/commit/9400bcd0814fa6b7fac9c0859a3c5c8c9df2781d) marge-bot: 0.10.1 -> 0.15.3
* [`4db34059`](https://github.com/NixOS/nixpkgs/commit/4db34059a341493677ed3e73154d7b6a70c04380) marge-bot: add updateScript
* [`3133e081`](https://github.com/NixOS/nixpkgs/commit/3133e081629ee6c3604479fa5d2b6e43969a8d45) marge-bot: add lelgenio as maintainer
* [`24d12cef`](https://github.com/NixOS/nixpkgs/commit/24d12cef04c78cb0011b0f2dc5620adf135875c1) pgpool: 4.6.0 -> 4.6.2
* [`a57b0045`](https://github.com/NixOS/nixpkgs/commit/a57b0045b98d0e1d2a952f8c8e8b1193b77ba90d) maintainers: add cybardev
* [`80f4c2a1`](https://github.com/NixOS/nixpkgs/commit/80f4c2a1cc70c848f003e1c0cee915e78d97ac26) universal-ctags: 6.1.0 -> 6.2.0
* [`a9bfae1a`](https://github.com/NixOS/nixpkgs/commit/a9bfae1a12d13b46e8b09e062e3b35616373c047) spring-boot-cli: 3.4.5 -> 3.5.0
* [`cb3755da`](https://github.com/NixOS/nixpkgs/commit/cb3755da36276249cd9e3fc73560f3d622d4dabc) python3Packages.azure-mgmt-resource: 23.3.0 -> 23.4.0
* [`f9b24048`](https://github.com/NixOS/nixpkgs/commit/f9b24048446100b7f15b3b5326a3b57a135f6b4c) txr: 299 -> 300
* [`fe0bdbbf`](https://github.com/NixOS/nixpkgs/commit/fe0bdbbfd31d86f4f2393df79ca11569b9ceed5e) soundsource: 5.8.2 -> 5.8.3
* [`d836f994`](https://github.com/NixOS/nixpkgs/commit/d836f99414555156fd7e51fb994796b6ede2d0f2) plantuml-server: 1.2025.2 -> 1.2025.3
* [`dbd61015`](https://github.com/NixOS/nixpkgs/commit/dbd610155a9604e9c67978b6a241aac5230a4f06) python3Packages.django-stubs: 5.1.3 -> 5.2.0
* [`d30becbb`](https://github.com/NixOS/nixpkgs/commit/d30becbb9901c8e84f8c75b86eb5db880de4baa9) files-cli: 2.15.7 -> 2.15.16
* [`a3bca8ea`](https://github.com/NixOS/nixpkgs/commit/a3bca8eac965f207143fb7c78b01420e314e1f74) chatbox: 1.12.3 -> 1.13.2
* [`53dd91be`](https://github.com/NixOS/nixpkgs/commit/53dd91bed02047270d5ad42c7cea92eea6f313de) amazon-ec2-net-utils: 2.5.5 -> 2.6.0
* [`d8cd35e1`](https://github.com/NixOS/nixpkgs/commit/d8cd35e19926e060fbd9f50659040507fdad5f95) lightwalletd: 0.4.16 -> 0.4.18
* [`255e8b58`](https://github.com/NixOS/nixpkgs/commit/255e8b5810676d17c50079c8781e3108d95039d9) dnglab: 0.6.3 -> 0.7.0
* [`2e36f9ff`](https://github.com/NixOS/nixpkgs/commit/2e36f9ff75c1cffc4a88d09b65ecc0cac3f6b600) arcticons-sans: 0.592 -> 0.593
* [`da907856`](https://github.com/NixOS/nixpkgs/commit/da907856cb22ece07d3e3af33b522e58be13dd74) openttd: remove unused flags
* [`fa9dd4bf`](https://github.com/NixOS/nixpkgs/commit/fa9dd4bf4ca3cae97edeb84f10dfdd6fbbbc85b7) maintainers: add QuiNzX
* [`2aa44cba`](https://github.com/NixOS/nixpkgs/commit/2aa44cba7f11f59746c923d7617e3f875be53c16) openttd: modernize derivation
* [`045f0b2c`](https://github.com/NixOS/nixpkgs/commit/045f0b2c797dd012abf760a8eeac6bf6f5195251) openttd: remove dependency on nlohmann_json
* [`2c88839b`](https://github.com/NixOS/nixpkgs/commit/2c88839bef099c4238d2de2ca532ca22005019ad) dcfldd: 1.9.2 -> 1.9.3
* [`8f4b40a9`](https://github.com/NixOS/nixpkgs/commit/8f4b40a99e4380eeeeabe32cbc82bbab2494c065) wsdd: 0.8 -> 0.9
* [`4089c351`](https://github.com/NixOS/nixpkgs/commit/4089c35147f1a37edd5c06d695717decc337d0e3) zsync: 0.6.2-unstable-2017-04-25 -> 0.6.3-unstable-2025-05-29
* [`a9eed0ef`](https://github.com/NixOS/nixpkgs/commit/a9eed0efde3f95e2031b0a705cf7fac95524a3cf) ansible-lint: 25.4.0 -> 25.5.0
* [`119fe2ab`](https://github.com/NixOS/nixpkgs/commit/119fe2ab69e9344aeacff1e608091bfcc09b0f93) wivrn: manually wrap wivrn-dashboard to avoid double-wrapping
* [`f5f8ebf9`](https://github.com/NixOS/nixpkgs/commit/f5f8ebf9ee81edc12d4288f70867fff667d69f4f) annotator: 1.2.1 -> 2.0.0
* [`90b30289`](https://github.com/NixOS/nixpkgs/commit/90b30289448dbcfa4df9299c06d9d50c991531d0) maintainers: add bandithedoge
* [`fc825aa8`](https://github.com/NixOS/nixpkgs/commit/fc825aa8b3dde795cc74bbe46207fc0c6cb9b061) nugget-doom: init at 4.3.0
* [`73524f50`](https://github.com/NixOS/nixpkgs/commit/73524f5008f156eaaf521fbc380fc7e8e10daa1f) git-town: 20.2.0 -> 21.0.0
* [`6d26f0e8`](https://github.com/NixOS/nixpkgs/commit/6d26f0e865e57c0dcd61a3f71d705e22aef7d816) sladeUnstable: 3.2.7-unstable-2025-05-09 -> 3.2.7-unstable-2025-05-31
* [`70524690`](https://github.com/NixOS/nixpkgs/commit/70524690dd9ad5bcfe5543c9bdcee2be12813eee) v2ray: 5.32.0 -> 5.33.0
* [`74dcbe1c`](https://github.com/NixOS/nixpkgs/commit/74dcbe1cee27642ba5b694821bb4cf8a7e100eb2) shottr: init at 1.8.1
* [`96b2e674`](https://github.com/NixOS/nixpkgs/commit/96b2e674212d3ebd9016c0d2cf56e16c75cd9414) python3Packages.klayout: 0.30.1 -> 0.30.2
* [`b92f1fdc`](https://github.com/NixOS/nixpkgs/commit/b92f1fdc226d6c099efc064f182dd23e884acc00) pyrefly: init at 0.17.1
* [`bfa36019`](https://github.com/NixOS/nixpkgs/commit/bfa36019b94e1a452161b97dc9e42d1e65223f6a) ibus-engines.chewing: init at 2.1.4
* [`53a2aac7`](https://github.com/NixOS/nixpkgs/commit/53a2aac77b647585f9151cd4e7224995a746a2a9) pdm: fix AGPL issues
* [`1ebeaf89`](https://github.com/NixOS/nixpkgs/commit/1ebeaf890dfc9e09ab8181ab611007c7aaf11c8f) linuxPackages.cpupower: prepare for linux v6.16
* [`e7a17963`](https://github.com/NixOS/nixpkgs/commit/e7a179637633542baa6a65d553a39d4b628f4705) apko: 0.27.6 -> 0.27.9
* [`56d25e02`](https://github.com/NixOS/nixpkgs/commit/56d25e02f1294bf3e6c6923b8edc0bc98957690f) MMA: 21.09 -> 25.05.0
* [`365fe8db`](https://github.com/NixOS/nixpkgs/commit/365fe8dbe5964d4832c2ba72da3bcfe80a221d3d) sesh: 2.13.0 -> 2.14.0
* [`17effa31`](https://github.com/NixOS/nixpkgs/commit/17effa31a8dd39dbcbc1a4dee0eea2bd20af3807) openttd: fix cross-compilation
* [`e5abc746`](https://github.com/NixOS/nixpkgs/commit/e5abc746088317503b448eb991782d8f0dde6f9f) python312Packages.basswood-av: init at 15.2.1
* [`a04c3b29`](https://github.com/NixOS/nixpkgs/commit/a04c3b2985e6ce764a6e35ee2bbbee4f32468c00) auto-editor: 26.2.0 -> 28.0.0
* [`c31f93c9`](https://github.com/NixOS/nixpkgs/commit/c31f93c9d35fac1d44031b4b7015abef62fe4154) nng: 1.10.1 -> 1.11
* [`55bd1338`](https://github.com/NixOS/nixpkgs/commit/55bd133882a07ecbce9e563fb58f3a69b28dcf15) icewm: enable on darwin
* [`5957890e`](https://github.com/NixOS/nixpkgs/commit/5957890e5b1992299ae426f8596d7ee8ab0db5db) icewm: modernize
* [`3168d99d`](https://github.com/NixOS/nixpkgs/commit/3168d99d3e592da92b846589d74cf152ea49864e) jmol: 16.3.23 -> 16.3.25
* [`343001d7`](https://github.com/NixOS/nixpkgs/commit/343001d755ece557ad428a323c8e61a086352862) sonarlint-ls: 3.22.0.76129 -> 3.23.0.76182
* [`b566a4ca`](https://github.com/NixOS/nixpkgs/commit/b566a4ca14f3faa66969093faa9c99b62922c8f5) mps: add darwin support
* [`13f5fc7a`](https://github.com/NixOS/nixpkgs/commit/13f5fc7a86edf5021c8bbd99c84460e52e11a2bb) sparkle: 1.6.4 -> 1.6.6
* [`fef06592`](https://github.com/NixOS/nixpkgs/commit/fef065928d84d4add6211bdac94a4e5ffe08cf69) cherry-studio: 1.3.12 -> 1.4.0
* [`0871979e`](https://github.com/NixOS/nixpkgs/commit/0871979e4b602c7bc8a01a945043b942c0bdccae) beekeeper-studio: 5.2.9 -> 5.2.10
* [`4bdc2a15`](https://github.com/NixOS/nixpkgs/commit/4bdc2a156db80b996682986a37a8ed68bb031a4a) wechat-uos: Fix icon missing on GNOME
* [`d05a1115`](https://github.com/NixOS/nixpkgs/commit/d05a1115416aba5d3ba6f64598b0659d4327a9cc) anubis{,-xess}: 1.18.0 -> 1.19.1
* [`b6fd30e3`](https://github.com/NixOS/nixpkgs/commit/b6fd30e3a270399ae22db8bdd2f5f4a305b2e0f5) unityhub: add missing dependencies for bug reporter
* [`aedca008`](https://github.com/NixOS/nixpkgs/commit/aedca008131af6f22c4bf5cff02b119e6facf23a) nixos/opentelemetry-collector: fix tests
* [`af93405b`](https://github.com/NixOS/nixpkgs/commit/af93405bb34e3717f8639b08483631128fceb628) brave: set CHROME_WRAPPER to brave
* [`58d3bc9e`](https://github.com/NixOS/nixpkgs/commit/58d3bc9e062dd824bdb5ff618e560eef7e927414) matrix-conduit: 0.10.3 -> 0.10.4
* [`1161ba59`](https://github.com/NixOS/nixpkgs/commit/1161ba59a7be43418e09dd101a05489df3e461c7) deno: enable tests
* [`4156354e`](https://github.com/NixOS/nixpkgs/commit/4156354ee7a6c0d2cb1956d8a5cefb96623b597f) obs-studio-plugins.obs-rgb-levels: 1.0.2 -> 1.0.3
* [`3cf68375`](https://github.com/NixOS/nixpkgs/commit/3cf683759678ac5aea262025166bc02dff5d5218) obs-studio-plugins.obs-dvd-screensaver: 0.0.2 -> 0.1.0
* [`7b3197bc`](https://github.com/NixOS/nixpkgs/commit/7b3197bc1d5ed03c305704dfe008ad213e921f1f) python3Packages.curve25519-donna: remove as obsolete
* [`c69a7311`](https://github.com/NixOS/nixpkgs/commit/c69a7311f62e626dd9741295561540ece75ab7e5) gcr_4: build with ssh-agent
* [`940f85fe`](https://github.com/NixOS/nixpkgs/commit/940f85fe3e4110613b53fe9c6283c57ba1f2a8bb) gnome-keyring: remove ssh-agent
* [`1693054e`](https://github.com/NixOS/nixpkgs/commit/1693054e48c68b8304ccf47f08566ab2553382be) octavePackages.bim: 1.1.6 -> 1.1.7
* [`78c34e97`](https://github.com/NixOS/nixpkgs/commit/78c34e97c66149fa8266cf83e668b7e296e1d4cc) boring: init at 0.11.4
* [`b08ea14f`](https://github.com/NixOS/nixpkgs/commit/b08ea14f5ed40aff6e4e18628db186595387a7b5) xarchiver: enable on darwin
* [`1057b47b`](https://github.com/NixOS/nixpkgs/commit/1057b47b4e705ed91f7661cc51e81884c9e812dd) python3Packages.pyturbojpeg: 1.7.7 -> 1.8.0
* [`28fc5f74`](https://github.com/NixOS/nixpkgs/commit/28fc5f748f284fc0624342aadcb6a6afde5aa2a2) python3Packages.scheduler: 0.8.5 -> 0.8.8
* [`cd6c4b47`](https://github.com/NixOS/nixpkgs/commit/cd6c4b470fec50f233d0d8182d5d9453d0d12e3d) python313Packages.bleak-esphome: 2.15.1 -> 2.16.0
* [`bb871f56`](https://github.com/NixOS/nixpkgs/commit/bb871f562ea693325211ccafb629e788ad02fda5) simdjson: 3.12.3 -> 3.13.0
* [`fb195778`](https://github.com/NixOS/nixpkgs/commit/fb195778d6b129e2b48e3349da2db562a420f0d4) nixosTests.lomiri-camera-app: Fix OCR, round 2
* [`8ae8da2e`](https://github.com/NixOS/nixpkgs/commit/8ae8da2e5075f591d78e5f0bf47ed18d929e6779) nixosTests.morph-browser: Fix OCR
* [`2a004393`](https://github.com/NixOS/nixpkgs/commit/2a00439306652564a38587b7506da3a1defa4a72) nixosTests.lomiri-camera-app: Fix OCR, round 3
* [`3be4b789`](https://github.com/NixOS/nixpkgs/commit/3be4b7894ae64ff93bbe6dbbaeaee0aad087a0b4) nixosTests.teleports: Fix OCR
* [`d2dbbefc`](https://github.com/NixOS/nixpkgs/commit/d2dbbefc3f6ebedc9d21d421458c46fce6863542) waybar: remove dependency on hyperland/sway
* [`7843256f`](https://github.com/NixOS/nixpkgs/commit/7843256f6798a38fd4c4b4f37de8214b1dda4901) apfsprogs: add passthru.updateScript
* [`f406f54c`](https://github.com/NixOS/nixpkgs/commit/f406f54c5bdef54ae58746b80960a148ce007a56) apfsprogs: 0.2.0 -> 0.2.1
* [`e335cece`](https://github.com/NixOS/nixpkgs/commit/e335cece5318a49f61218a6af63e3bf02dbd85de) daed: 0.9.0 -> 1.0.0
* [`07176039`](https://github.com/NixOS/nixpkgs/commit/071760391009951b4d6efb9ffa82154c654e36b9) megasync: 5.9.0.3 -> 5.12.0.1
* [`5356518e`](https://github.com/NixOS/nixpkgs/commit/5356518e99f80f6e5abcfe1d671bb8619cb71a69) minizincide: add desktop file
* [`4e69dca9`](https://github.com/NixOS/nixpkgs/commit/4e69dca94536351974d672d821e8050291ceb73e) lillydap: fix update script
* [`8ec58295`](https://github.com/NixOS/nixpkgs/commit/8ec582950f4f7888ab74be8928aa4c37fda45a51) nixos/patroni: assert on conflicts with postgresql.dataDir
* [`c4a3706a`](https://github.com/NixOS/nixpkgs/commit/c4a3706a8d17b9b389e687cffd7a9329f2e8b907) elementsd-simplicity: drop
* [`ff870352`](https://github.com/NixOS/nixpkgs/commit/ff870352fe4702323f356963c89fd2d292b5b2b9) nsis: 3.06.1 -> 3.11
* [`ebf65fa2`](https://github.com/NixOS/nixpkgs/commit/ebf65fa21ab523a28bf5b7f6e3a4801fbd948b2d) nsis: run nix fmt
* [`c6c9550e`](https://github.com/NixOS/nixpkgs/commit/c6c9550ed5b29022817fde616b9c2d398d8c18e2) rke2_1_29: remove
* [`835f60e5`](https://github.com/NixOS/nixpkgs/commit/835f60e578b47e91a8da4922877fee57a5b25f4f) python3Packages.gotify: stdenv.isDarwin -> stdenv.buildPlatform.isDarwin
* [`1f57618c`](https://github.com/NixOS/nixpkgs/commit/1f57618cae5cc3db01d713fc23bf037c9803c71d) nixosTests.lomiri-camera-app: Fix OCR, round 4
* [`ddf9a3eb`](https://github.com/NixOS/nixpkgs/commit/ddf9a3eba5d0ce359f283f0b0b32a35b7aa6ba28) nixos/prometheus: Extend prometheus-pair test to verify first compaction succeeds
* [`5491d4ae`](https://github.com/NixOS/nixpkgs/commit/5491d4aed2a02d10e2b576634ae3d042eca97775) wallabag: 2.6.12 -> 2.6.13
* [`2935f0db`](https://github.com/NixOS/nixpkgs/commit/2935f0dbd4418f13541e8bcbee043c9052195df2) libusbmuxd: 2.1.0 -> 2.1.1
* [`68d64791`](https://github.com/NixOS/nixpkgs/commit/68d647919333b5efd2cbe14199ee8f71bc63c312) python3Packages.temporalio: 1.11.0 → 1.12.0
* [`7fe16a7d`](https://github.com/NixOS/nixpkgs/commit/7fe16a7df1b57e95c0375868ce74c2551fc06525) python3Packages.torch: 2.7.0 -> 2.7.1
* [`b3def483`](https://github.com/NixOS/nixpkgs/commit/b3def483ce7bbe4f470bc1f53c444fe760af8db5) python3Packages.torchaudio: 2.7.0 -> 2.7.1
* [`30ce5ddf`](https://github.com/NixOS/nixpkgs/commit/30ce5ddfa8c3ebc721812486f94dd2db8bcba1f9) python3Packages.torchvision: 0.22.0 -> 0.22.1
* [`17a870ec`](https://github.com/NixOS/nixpkgs/commit/17a870ecc6c77e51ff8b6aeabf4b171fecc33406) sane-backends: 1.3.1 -> 1.4.0
* [`eb69fe36`](https://github.com/NixOS/nixpkgs/commit/eb69fe3666c44e465ab6bcf98cbc3212586b9ddb) zet: 1.0.0 -> 2.0.1
* [`e5854a62`](https://github.com/NixOS/nixpkgs/commit/e5854a6288976e9ccf7197b23a3cbf089d9006d8) protonup-rs: init at 0.9.0
* [`1ee35a5e`](https://github.com/NixOS/nixpkgs/commit/1ee35a5ea264de4e433993fe37d72c7efabf8aac) microsoft-identity-broker: fix runtime link errors
* [`9c71553d`](https://github.com/NixOS/nixpkgs/commit/9c71553dfe5e77329fc4f3b4f18f9483b52f0ccc) microsoft-identity-broker: add sensible JVM memory & GC-options
* [`301880e8`](https://github.com/NixOS/nixpkgs/commit/301880e89d666847746985507b72e4a2cf837076) lighthouse: mark cross as broken
* [`76781c7f`](https://github.com/NixOS/nixpkgs/commit/76781c7f6156ee04eeb1f7d037052cf36b66769a) shaderbg: init at 0-unstable-2024-11-26
* [`11930b4e`](https://github.com/NixOS/nixpkgs/commit/11930b4e1eea595b9ff130cb573816e8c6399a5b) ladybird: 0-unstable-2025-05-24 -> 0-unstable-2025-06-03
* [`2cd7118c`](https://github.com/NixOS/nixpkgs/commit/2cd7118c0740cf328f87ae5c9dd60c5e35c916ea) endgame-singularity: 1.00-unstable-2025-03-18 -> 1.1
* [`4d6b2347`](https://github.com/NixOS/nixpkgs/commit/4d6b2347d030854a499e3ac183f1bc6b58e17838) ranger: use unstable version instead of 1.9.4 (broken build)
* [`75378043`](https://github.com/NixOS/nixpkgs/commit/75378043876d7606d81f653cd9422fd8e7e4f287) angie: 1.9.0 -> 1.9.1
* [`324ca26e`](https://github.com/NixOS/nixpkgs/commit/324ca26eba519d5ee7b2d650050e4083b573d80b) python312Packages.granian: don't force a custom allocator
* [`60ee48a3`](https://github.com/NixOS/nixpkgs/commit/60ee48a34d4f68a81dabb2ba251c975e1b0811a6) hover: hardcode pname
* [`4970bfdc`](https://github.com/NixOS/nixpkgs/commit/4970bfdca6ad58038bda969c677701cd396d673c) hover: 0.47.0 -> 0.47.2
* [`c57036a1`](https://github.com/NixOS/nixpkgs/commit/c57036a1e742862afc00275613837e315135dab6) fromager: 0.46.1 -> 0.47.0
* [`9c48df34`](https://github.com/NixOS/nixpkgs/commit/9c48df34df542f44938b0c00a0e517e6c1beb49a) python3Packages.llama-cloud-services: 0.6.23 -> 0.6.28
* [`174483f2`](https://github.com/NixOS/nixpkgs/commit/174483f2530199da6a106379d8d9d8e6f9dcd20a) cherry-studio: 1.4.0 -> 1.4.1
* [`172998bf`](https://github.com/NixOS/nixpkgs/commit/172998bfef7c8db2f375c6d388718bf4768be884) legends-of-equestria: 2024.06.02 -> 2025.02.001
* [`f217bb1f`](https://github.com/NixOS/nixpkgs/commit/f217bb1f0288e1004d6e937bd20a8750da85e742) noto-fonts: 2025.05.01 -> 2025.06.01
* [`02208870`](https://github.com/NixOS/nixpkgs/commit/022088703754caee06a228fad469b9a803df91f1) sentry-native: 0.8.5 -> 0.9.0
* [`dc2e0a7c`](https://github.com/NixOS/nixpkgs/commit/dc2e0a7c27689cfdef2d905d2d4680ecd6a8aa3b) amazon-cloudwatch-agent: 1.300056.0 -> 1.300056.1
* [`25a40ead`](https://github.com/NixOS/nixpkgs/commit/25a40ead28cb77bc49a5fa9e7213fbf538fe25d0) nixos/vector: add graceful shutdown limit option
* [`f034395a`](https://github.com/NixOS/nixpkgs/commit/f034395a662d5fa668ff32bc652750473ad67824) xsensors: 0.70 -> 0.80
* [`e49188f0`](https://github.com/NixOS/nixpkgs/commit/e49188f00caf1b6a6cf05f3d9a096a1cb9268e18) xscope: 1.4.1 -> 1.4.5
* [`ec91045f`](https://github.com/NixOS/nixpkgs/commit/ec91045f959682707fd4e33974613df87230b06e) pamtester: refactor enable on Darwin
* [`8eb145bf`](https://github.com/NixOS/nixpkgs/commit/8eb145bf7ab1df311b58932a3425441116df847d) glab: 1.57.0 -> 1.59.2
* [`348ec8c8`](https://github.com/NixOS/nixpkgs/commit/348ec8c846cce39c467cac90ddbbc9ce9bf61bd8) factorio, factorio-experimental: 2.0.{43,45} -> 2.0.55
* [`77ae1ddf`](https://github.com/NixOS/nixpkgs/commit/77ae1ddf3adcec0c2d33514573bd550f90977988) python3Packages.globus-sdk: 3.56.1 -> 3.57.0
* [`2623c7d2`](https://github.com/NixOS/nixpkgs/commit/2623c7d241655bcd90949aef3962aa1a911176f1) python3Packages.authlib: 1.5.2 -> 1.6.0
* [`efc0903e`](https://github.com/NixOS/nixpkgs/commit/efc0903e173d4216612979534e03a9aeac73b1ca) filebeat8: 8.18.0 -> 8.18.2
* [`ee862a54`](https://github.com/NixOS/nixpkgs/commit/ee862a54b7ad53c1a0b797c4e01f9b933c228919) kaidan: move to by-name
* [`1001a577`](https://github.com/NixOS/nixpkgs/commit/1001a577e6c7cfac57a8cbbb4268d1ad0f8a58d1) kaidan: use finalAttrs
* [`209dc617`](https://github.com/NixOS/nixpkgs/commit/209dc6172e041ffd434b08fc8d2be8c3eab00392) kaidan: avoid with lib;
* [`c2074261`](https://github.com/NixOS/nixpkgs/commit/c20742614c340fe1f2e39152521a969335652176) qxmpp: move to by-name
* [`a7dcf1e0`](https://github.com/NixOS/nixpkgs/commit/a7dcf1e09afc97b685062045eff322f017af3749) qxmpp: avoid with lib;
* [`c1c8a415`](https://github.com/NixOS/nixpkgs/commit/c1c8a4150e02656c745594feb0072e42d9886726) qxmpp: use finalAttrs
* [`a72edd6d`](https://github.com/NixOS/nixpkgs/commit/a72edd6dc1b86cd2d240ac9e31bdfa524c020bf7) qxmpp: update upstream
* [`d02baa0b`](https://github.com/NixOS/nixpkgs/commit/d02baa0b676710692b4a559e5e79cb8e1e5b4b4e) qxmpp: 1.10.2 -> 1.10.4
* [`0be43c55`](https://github.com/NixOS/nixpkgs/commit/0be43c55b01518394604743e20f10c431c5cdbd6) shellhub-agent: 0.18.3 -> 0.19.0
* [`79d5d6d6`](https://github.com/NixOS/nixpkgs/commit/79d5d6d6e248525a14b8b93d086905883f37a03a) x2t: add tests
* [`cb645ca7`](https://github.com/NixOS/nixpkgs/commit/cb645ca716cca6e976b988c5949aae4c7fd80bf3) element-web-unwrapped: 1.11.100 -> 1.11.102
* [`84458a3f`](https://github.com/NixOS/nixpkgs/commit/84458a3fcd32fe1119ee8899098938334fecd08e) element-desktop: 1.11.110 -> 1.11.102
* [`6e588bcc`](https://github.com/NixOS/nixpkgs/commit/6e588bcc5e614e6f50d1c6126588629baa0b6d25) jellyfin-ffmpeg: 7.1.1-3 -> 7.1.1-4
* [`09b33ed3`](https://github.com/NixOS/nixpkgs/commit/09b33ed3c0951cd0fb18765163b89db44bf73e5f) ISSUE_TEMPLATE: fix missing image
* [`5fc3dd02`](https://github.com/NixOS/nixpkgs/commit/5fc3dd02d83d123357048bd33846fe691c6bed91) ISSUE_TEMPLATE: remove alert blocks that don't render
* [`28bc042c`](https://github.com/NixOS/nixpkgs/commit/28bc042c2fbd95ad844f3d3b883cd3cabfed1552) ISSUE_TEMPLATE: add missing line breaks
* [`e0926f78`](https://github.com/NixOS/nixpkgs/commit/e0926f78db2cd764fe026c2b1397189743247bf4) docker_28: 28.1.1 -> 28.2.2
* [`3ff8082b`](https://github.com/NixOS/nixpkgs/commit/3ff8082ba9845184c09bd5929569e46c40c75483) kopia-ui: 0.20.0 -> 0.20.1
* [`319feec0`](https://github.com/NixOS/nixpkgs/commit/319feec0a2c71f9bba3aa7e1cd53c99cdacd3a53) ubootVisionFive2: init
* [`81fdbaa3`](https://github.com/NixOS/nixpkgs/commit/81fdbaa33ec17ef361f17d165c82afac295a2c43) ioquake3: Fix build on darwin
* [`d13d965a`](https://github.com/NixOS/nixpkgs/commit/d13d965aa0a0ce5aab3bac56e86aaa1643b05a38) ioquake3: reuse description
* [`0ecd50f8`](https://github.com/NixOS/nixpkgs/commit/0ecd50f8f1ba5581293ba92e35ae9f481ef4670e) quake3-wrapper: Fix build on darwin
* [`1fad2b71`](https://github.com/NixOS/nixpkgs/commit/1fad2b71e8e068c8dd9369609035fcd2cf1ab293) quake3-hires: Add more high resolution enhancements for quake
* [`11b1c3ae`](https://github.com/NixOS/nixpkgs/commit/11b1c3aec5b065b3da5ddbfa02a26e230f118313) quake3-hires: switch from rec to fixpoint
* [`ff0ec8e6`](https://github.com/NixOS/nixpkgs/commit/ff0ec8e6a15e3b323ce7ab6ab60b26f97e7741b9) quake3-hires: annotate version to note that this is an unstable version
* [`fbf8c9ff`](https://github.com/NixOS/nixpkgs/commit/fbf8c9ff59e70d5c12ca99a94d33861b838228d6) quake3: stop using star matches, as there is nothing to match
* [`4954fc6b`](https://github.com/NixOS/nixpkgs/commit/4954fc6bb1991623f37ca9ac62256e82e11f395d) quake3: name outputs from pname for consistently named binaries
* [`d73f3953`](https://github.com/NixOS/nixpkgs/commit/d73f395319139963e347933e4d848d92686b599e) quake3: extract basepath into variable to remove duplication
* [`2e74aafe`](https://github.com/NixOS/nixpkgs/commit/2e74aafeb6b9682877c218d6eed52c0c26c21131) quake3: rename the darwin wrapper for consistency
* [`1824b615`](https://github.com/NixOS/nixpkgs/commit/1824b615d147cf14fd95b8ff6db71890f55cc710) quake3: Inherit wrapper attributes from ioquake3 and the used pak file
* [`9104fce8`](https://github.com/NixOS/nixpkgs/commit/9104fce8d6aa751834940205b5ff640a7b9e13ba) quake3-hires: only set pname and leave the rest to the wrapper
* [`cf75508b`](https://github.com/NixOS/nixpkgs/commit/cf75508bb1c0b5dde221f7f52668bc421ea4f538) pdd: 1.6 -> 1.7
* [`bff4b056`](https://github.com/NixOS/nixpkgs/commit/bff4b05642863048ba1f706cfbfe68b57ac233a1) xld: 20240511 -> 20250302
* [`3a985fd7`](https://github.com/NixOS/nixpkgs/commit/3a985fd74f8c6174b248e7770785481cc2fca13d) xld: fix updateScript xmlstarlet xPath
* [`2391076a`](https://github.com/NixOS/nixpkgs/commit/2391076a095589e0c8ba000a7c7bed116943be93) python3Packages.trimesh: 4.6.10 -> 4.6.11
* [`03c49769`](https://github.com/NixOS/nixpkgs/commit/03c49769f20239394da5e3f238c09f013590b908) maintainers: add bugarela
* [`11e770ff`](https://github.com/NixOS/nixpkgs/commit/11e770ff34a6225a86d6a85213e7fa579cfee551) texturepacker: 7.7.0 -> 7.7.1
* [`741c9d1b`](https://github.com/NixOS/nixpkgs/commit/741c9d1b99b4660eaeb2a7f6b34475eb9f1dd7d0) livebook: 0.16.1 -> 0.16.2
* [`e926b19c`](https://github.com/NixOS/nixpkgs/commit/e926b19c2dd78f3e80bb7419da83d095d788ae7c) hath-rust: init at 1.11.0
* [`134b7a17`](https://github.com/NixOS/nixpkgs/commit/134b7a174d1b8f799d4e45d4ef8dcb1124e161d8) xdg-desktop-portal-luminous: 0.1.8 -> 0.1.10
* [`5e611a56`](https://github.com/NixOS/nixpkgs/commit/5e611a56c32cd44e16506f2638bebd64187a2b01) readest: 0.9.51 -> 0.9.52
* [`06484799`](https://github.com/NixOS/nixpkgs/commit/06484799c5bf63b99113d6116791b00f5c3932c5) readest: 0.9.52 -> 0.9.53
* [`a849a908`](https://github.com/NixOS/nixpkgs/commit/a849a90897029a7a33ed0a8b76dc0ca936601f83) yubikey-personalization-gui: drop
* [`0393531d`](https://github.com/NixOS/nixpkgs/commit/0393531d6b99b9e8c16ad47432c45ad25d6fbe4f) neomutt: 20250113 -> 20250510
* [`b0d3f8e4`](https://github.com/NixOS/nixpkgs/commit/b0d3f8e4613f4d113ea956e93f23a40e9a651a1d) neomutt: Add update script
* [`9bb1700d`](https://github.com/NixOS/nixpkgs/commit/9bb1700d790325f5a8608e3287b51bd5bdb56e90) opencv: export CUDA_TOOLKIT_ROOT_DIR so findCUDA uses Nix-selected toolkit
* [`62ab65aa`](https://github.com/NixOS/nixpkgs/commit/62ab65aa5aeaeaa687a6097d4eb76e661bc7a1ad) services.siproxd: drop
* [`46da18fe`](https://github.com/NixOS/nixpkgs/commit/46da18fe4ce2286df0e437d4951261b447c925d0) siproxd: fix typo in removal notice
* [`68386963`](https://github.com/NixOS/nixpkgs/commit/68386963006b88f17e80466a8054a5a50d20187b) readest: 0.9.53 -> 0.9.55
* [`ad5cb190`](https://github.com/NixOS/nixpkgs/commit/ad5cb190a1cad7456e2b027c6047fc8477285a60) gtkdialog: 0.8.3 -> 0.8.5e
* [`3e470a0f`](https://github.com/NixOS/nixpkgs/commit/3e470a0f6738274e6c2354fa56f9e1869475e5f7) gtkdialog: add aleksana to maintainers
* [`235a38e4`](https://github.com/NixOS/nixpkgs/commit/235a38e4eba2bdcfef823942c121f71d636c11f2) netbird-ui: 0.45.2 -> 0.46.0
* [`d494acad`](https://github.com/NixOS/nixpkgs/commit/d494acad37d085063620360962402982ad26d500) storj-uplink: 1.128.4 -> 1.130.6
* [`00549dc6`](https://github.com/NixOS/nixpkgs/commit/00549dc6269a8bf5b4fc5f6807ba0ee0d76ad820) wealthfolio: 1.1.2 -> 1.1.3
* [`749f2991`](https://github.com/NixOS/nixpkgs/commit/749f29911a93f3e3808cdb58f7155da72e165d60) wpgtk: 6.5.9 -> 6.7.0
* [`8e57ebf1`](https://github.com/NixOS/nixpkgs/commit/8e57ebf15ae6dec6598d9e0bd18c06af20a9c816) wireguard-tools: 1.0.20210914 -> 1.0.20250521
* [`c0f76286`](https://github.com/NixOS/nixpkgs/commit/c0f7628631b6cc9989adc9e1717e3c66fdfac2b2) nixos/tests/wireguard: fix eval with `allowAliases = false;`
* [`d5c4ea47`](https://github.com/NixOS/nixpkgs/commit/d5c4ea47a00f3253d7ad9a022ea20da58caf0464) python3Packages.django-app-helper: 3.3.4 -> 3.3.5
* [`5725fe62`](https://github.com/NixOS/nixpkgs/commit/5725fe623ff9a88db0f28e5d79b4123c76220d7b) netdata: 2.5.2 -> 2.5.3
* [`d674be05`](https://github.com/NixOS/nixpkgs/commit/d674be05acd5a9c15546289c35b5533ce9cb0b4a) objfw: 1.3 -> 1.3.1
* [`c49e0970`](https://github.com/NixOS/nixpkgs/commit/c49e0970e795e2b13b3e19ab4e4a40f7e30aabc9) python3Packages.llama-index-agent-openai: 0.4.8 -> 0.4.9
* [`e304a835`](https://github.com/NixOS/nixpkgs/commit/e304a8352a3664aa972a4d740d4f8aefbb89a3b4) nixosTests.dovecot: fix eval
* [`ae3ac94b`](https://github.com/NixOS/nixpkgs/commit/ae3ac94bf45676f46d4532904c252486b440b932) wavebox: 10.136.15-2 -> 10.137.9-2
* [`ea354d7b`](https://github.com/NixOS/nixpkgs/commit/ea354d7bfa759706843bc08f8d7d8c6d3b3f5544) plutosvg: patch includedir path
* [`5034ff29`](https://github.com/NixOS/nixpkgs/commit/5034ff295423a3e0fcc6f29966bb0671ed8a4f25) pcsx2: inline sources
* [`10ac6157`](https://github.com/NixOS/nixpkgs/commit/10ac6157edc26aec5f947e0905023afe1287945c) pcsx2: add update script
* [`5b226370`](https://github.com/NixOS/nixpkgs/commit/5b226370b76b6301fafc7addfd30f7a853c565f8) pcsx2: 2.3.39 -> 2.3.407
* [`165ad6ef`](https://github.com/NixOS/nixpkgs/commit/165ad6efdc86942cb7a0639549b5fdd970c4cc4c) cie-middleware-linux: 1.5.6 -> 1.5.9
* [`6cad81fe`](https://github.com/NixOS/nixpkgs/commit/6cad81fed55a295840228342f3383c9237af8b52) lazpaint: 7.2.2-unstable-2024-01-23 → 7.3
* [`f59281f1`](https://github.com/NixOS/nixpkgs/commit/f59281f1c7c35de4a6ba0f02a45df560ad62e3d8) quake3-arena: add full game with dependency on externally provided pak0.pk3
* [`c89d34d7`](https://github.com/NixOS/nixpkgs/commit/c89d34d7728b0d89778f390cc09c15b3b9b51c2e) quake3: move all the files into a set to make visible that they belong together
* [`dd50a049`](https://github.com/NixOS/nixpkgs/commit/dd50a04913a949055d4a6bc59e7b2007629fc127) quake3-hires: switch from deprecated sha256 attribute
* [`a5b5293b`](https://github.com/NixOS/nixpkgs/commit/a5b5293befb856f6eb68d23e635b89f61806febd) quake3-hires: Better way to download github sources
* [`a9466cb9`](https://github.com/NixOS/nixpkgs/commit/a9466cb9d6b76bedf9a6e2f5720ae3eeb4405b9f) quake3-hires: better attribution
* [`054514a5`](https://github.com/NixOS/nixpkgs/commit/054514a5633daa8a032bb26d1dc6bfe5d657c7a6) quake3: Update resolution guidance
* [`65b3fa95`](https://github.com/NixOS/nixpkgs/commit/65b3fa956f1a93d254b60780e1b6d4de66c36374) quake3: fix mainProgram
* [`53508897`](https://github.com/NixOS/nixpkgs/commit/5350889704ee4e391352924c51886538caa8de94) amp-cli: 0.0.1748865683-g71e54e -> 0.0.1749297687-g3e4f54
* [`c712a2d7`](https://github.com/NixOS/nixpkgs/commit/c712a2d78cfaf8259fb41bff6015bc80c9423467) cie-middleware-linux: try re-enabling darwin
* [`44098dcd`](https://github.com/NixOS/nixpkgs/commit/44098dcd0917e77ca4a5bb094c93bdf72377cebb) pihole-web: 6.1 -> 6.2.1
* [`ee7dbeb3`](https://github.com/NixOS/nixpkgs/commit/ee7dbeb3b1bb336eaf4fd7398dcd84a4d1be8091) gst_all_1.gst-plugins-base: fix build with disabled X11
* [`6276e095`](https://github.com/NixOS/nixpkgs/commit/6276e0953073bf5db53530ce8c49014593ec499c) workflows/backport: cancel concurrent runs
* [`1dbcbd1b`](https://github.com/NixOS/nixpkgs/commit/1dbcbd1b1598a34c00c70fd3d7e04ac94ef60f78) renovate: 40.33.1 -> 40.48.0
* [`b87b889c`](https://github.com/NixOS/nixpkgs/commit/b87b889cb37bc79f4c433a2572575b731a221c01) yodl: 4.03.03 -> 4.05.00
* [`69e3a3a4`](https://github.com/NixOS/nixpkgs/commit/69e3a3a4cda0079b8f652eadc59fd858ede11b3f) sydbox: 3.34.0 -> 3.35.1
* [`fa6c2e77`](https://github.com/NixOS/nixpkgs/commit/fa6c2e77ee44bfa3d7da0b0f72c95340807c1cf8) base16-schemes: modernize
* [`05cfa02e`](https://github.com/NixOS/nixpkgs/commit/05cfa02e24267c16b0bbc2e858ae5deac7b13627) base16-schemes: unstable-2025-04-18 -> 0-unstable-2025-06-04
* [`69cc10fe`](https://github.com/NixOS/nixpkgs/commit/69cc10fe0c1cc1396b5260f3612a345069729ce7) python3Packages.python-bsblan: 1.2.2 -> 2.1.0
* [`51ab3264`](https://github.com/NixOS/nixpkgs/commit/51ab3264d81f157d7d3417bb6dd24e07be6917c4) groonga: 15.0.4 -> 15.1.1
* [`8c4f36a2`](https://github.com/NixOS/nixpkgs/commit/8c4f36a2d8ee05b7c58fc63945d82fcf914bb0e4) whois: 5.6.1 -> 5.6.2
* [`837312f3`](https://github.com/NixOS/nixpkgs/commit/837312f307b9dcb29fcba4e6692961cac4b508bd) whisky: init at 2.3.2
* [`ee9b4c7b`](https://github.com/NixOS/nixpkgs/commit/ee9b4c7b70b2076600392a4a400d6caad41bf219) opensnitch: 1.6.9 -> 1.7.0.0
* [`65af7250`](https://github.com/NixOS/nixpkgs/commit/65af72507c50b8537968324e038aab3e706ac3f7) nixos/tests/opensnitch: increase logging level
* [`012ee3ac`](https://github.com/NixOS/nixpkgs/commit/012ee3ac74f3aaefff881508202787211d173bca) tenv: 4.6.2 -> 4.7.0
* [`d7d1b885`](https://github.com/NixOS/nixpkgs/commit/d7d1b8859ba72c4586981e144486e2c6b210135f) snapweb: 0.8.0 -> 0.9.0
* [`b5383069`](https://github.com/NixOS/nixpkgs/commit/b53830692765d91553a583dcb800cac89e6d10f0) rpi-imager: 1.9.0 -> 1.9.4
* [`c4d590ac`](https://github.com/NixOS/nixpkgs/commit/c4d590ac2ed924993f68a03bdb696fdcd691a936) python3Packages.bump-my-version: 1.1.4 -> 1.2.0
* [`a6824084`](https://github.com/NixOS/nixpkgs/commit/a682408491652e22440863f0908a8fdbfd92bb56) python3Packages.pygreat: 2024.0.3 -> 2024.0.5
* [`41754a50`](https://github.com/NixOS/nixpkgs/commit/41754a502e88a0e69617c0853a2492454b7ddbff) libretro-shaders-slang: 0-unstable-2025-05-20 -> 0-unstable-2025-05-31
* [`6a93a3cc`](https://github.com/NixOS/nixpkgs/commit/6a93a3cc0312ffcf8bcb6331270a06e96a5b85f8) python3Packages.qutip: 5.1.1 -> 5.2.0
* [`418b4e0a`](https://github.com/NixOS/nixpkgs/commit/418b4e0ab1ccbc7b132b8b186c8361b356fbeb18) zbctl: 8.2.11 -> 8.4.19
* [`d8c5a5de`](https://github.com/NixOS/nixpkgs/commit/d8c5a5de27af1efab38eedc5dc899b53e1291cc7) orbuculum: 2.1.0 -> 2.2.0
* [`8353cbd7`](https://github.com/NixOS/nixpkgs/commit/8353cbd71ef468ae1315f4e193c43078a0868274) opkg: 0.7.0 -> 0.8.0
* [`e1082cec`](https://github.com/NixOS/nixpkgs/commit/e1082cec4ad91b7d5a26f9f50b4ccc12399381d6) coder: 2.20.3 -> 2.22.1
* [`ccc43068`](https://github.com/NixOS/nixpkgs/commit/ccc43068134d80133e339a540701fc41e32bbf17) stalwart-mail-webadmin: 0.1.26 -> 0.1.27
* [`3079f281`](https://github.com/NixOS/nixpkgs/commit/3079f2814cab6a4c95dc683373aefa8c9c557ef1) dnstake: fix build
* [`0b78cff0`](https://github.com/NixOS/nixpkgs/commit/0b78cff04b075d46d784d311eb31744bb85a89c7) python3Packages.yte: 1.7.0 -> 1.8.0
* [`aec172c0`](https://github.com/NixOS/nixpkgs/commit/aec172c0dffbffdd741aee0fe64f0aa87b7cf7ef) dqlite: use finalAttrs
* [`7836a555`](https://github.com/NixOS/nixpkgs/commit/7836a555c3d09fac5247b78bad1356627909b812) dqlite: avoid with lib;
* [`8d81e1a9`](https://github.com/NixOS/nixpkgs/commit/8d81e1a9b8a82af195aafec0ace218ae8593d76b) dsf2flac: avoid with lib;
* [`e3db3c24`](https://github.com/NixOS/nixpkgs/commit/e3db3c2433dffb33430812524c9e29c77e4b2b9e) dsf2flac: fix build
* [`30b2aaa0`](https://github.com/NixOS/nixpkgs/commit/30b2aaa0edaa1e99b4031667691307064b752c01) linuxPackages.prl-tools: 20.3.1-55959 -> 20.3.2-55975
* [`a8197e35`](https://github.com/NixOS/nixpkgs/commit/a8197e35fb033734e1a10ed464bccc9b0f4a91de) polarity: latest-unstable-2025-05-19 -> latest-unstable-2025-06-06
* [`5c695bad`](https://github.com/NixOS/nixpkgs/commit/5c695bad7863dfa391de5b72c77ced715913e456) pyfa: 2.63.0 -> 2.63.1
* [`3bd0085e`](https://github.com/NixOS/nixpkgs/commit/3bd0085ec557218929c70c4fe3d7c47366951de2) apt-dater: fix build
* [`6574d6be`](https://github.com/NixOS/nixpkgs/commit/6574d6beb6d90cbe060507397b9516dcdd32e8c6) prometheus-redis-exporter: 1.73.0 -> 1.74.0
* [`b1b91c3d`](https://github.com/NixOS/nixpkgs/commit/b1b91c3d59d90344f5785d43f2113a780951e1e7) typos: 1.32.0 -> 1.33.1
* [`a176b829`](https://github.com/NixOS/nixpkgs/commit/a176b8295b0e65c2110b974e55267f4c2afe0cdd) python3Packages.pygreat: remove python requirement
* [`66201a75`](https://github.com/NixOS/nixpkgs/commit/66201a75efe8473a0962bfed09ca13f73182235c) python3Packages.llama-index-readers-file: 0.4.8 -> 0.4.9
* [`430fd377`](https://github.com/NixOS/nixpkgs/commit/430fd3779767b464835d3a8e05e19f76dec24e5f) openstack-rs: 0.12.1 -> 0.12.2
* [`a64351a4`](https://github.com/NixOS/nixpkgs/commit/a64351a4d502e4063be87ad5fdfeb4704f3d049f) memos: 0.24.3 -> 0.24.4
* [`cae972af`](https://github.com/NixOS/nixpkgs/commit/cae972af0a7a293b6b17aa4afefda3d0db1a20da) libsForQt5.timed,qt6Packages.timed: 3.6.23 -> 3.6.24
* [`52d521e3`](https://github.com/NixOS/nixpkgs/commit/52d521e383b4040b7c6c358525e22a5339c51947) prr: 0.17.0 -> 0.20.0
* [`f1b5c162`](https://github.com/NixOS/nixpkgs/commit/f1b5c16260223c1e90c660e597278b06f4ee2d40) codec2: revert mark cross as broken
* [`d76142c1`](https://github.com/NixOS/nixpkgs/commit/d76142c1c7d2cb9fc1db52a56a827aa76d10c9a5) python3Packages.hyperscan: 0.7.13 -> 0.7.16
* [`dcf6af33`](https://github.com/NixOS/nixpkgs/commit/dcf6af335a6c0f3cafb04178925c6c3f75f0262a) haskellPackages.lz4-frame-conduit: Fix test by adding lz4 binary
* [`a35490b7`](https://github.com/NixOS/nixpkgs/commit/a35490b72db1b186c82b63bf2b1fc4d692eba45a) geminicommit: 0.4.0 -> 0.4.1
* [`5f4effe8`](https://github.com/NixOS/nixpkgs/commit/5f4effe804243ebf55a38d196e15e8c14e94c186) xfce.libxfce4windowing: 4.20.2 -> 4.20.3
* [`05dc8c09`](https://github.com/NixOS/nixpkgs/commit/05dc8c09aa5847e95d8e17bbea9b1c9631ab79ba) famistudio: 4.3.3 -> 4.4.0
* [`44c774ca`](https://github.com/NixOS/nixpkgs/commit/44c774caf24d3d3a2efec1a75396542b4f292d78) space-orbit: remove
* [`8cf5bf45`](https://github.com/NixOS/nixpkgs/commit/8cf5bf456120711bbd21d298f6beb2efd1748b1c) prowler: 5.7.2 -> 5.7.3
* [`9356acde`](https://github.com/NixOS/nixpkgs/commit/9356acde96e42cbdfdaa6b4b631a13967d70b69e) kubevpn: 2.7.12 -> 2.7.15
* [`7090d752`](https://github.com/NixOS/nixpkgs/commit/7090d752357c4ffceb410c5c35d2e342f4f71a00) yafc-ce: 2.11.1 -> 2.13.0
* [`5b31e8bf`](https://github.com/NixOS/nixpkgs/commit/5b31e8bfef6a95ecbf5d36f0006b2e60df809bf8) scite: 5.5.6 -> 5.5.7
* [`7d41b4d8`](https://github.com/NixOS/nixpkgs/commit/7d41b4d86fea29605448f20421e57bb807909fb6) python312Packages.bitsandbytes: 0.45.1 -> 0.46.0
* [`c15b6b98`](https://github.com/NixOS/nixpkgs/commit/c15b6b98c8e2e801cc3afac6a308a52996ed9d9c) python313Packages.woob: 3.6 -> 3.7
* [`8d99101d`](https://github.com/NixOS/nixpkgs/commit/8d99101d35fdfbbff0465dd899334321eee61363) smplayer: 24.5.0 -> 25.6.0
* [`e38a23bc`](https://github.com/NixOS/nixpkgs/commit/e38a23bc1455128993ba3685fd0cfc02f129a87a) jwt-hack: 1.2.0 -> 2.0.0
* [`d7478b5d`](https://github.com/NixOS/nixpkgs/commit/d7478b5d2b9e557a9c36f04330c6035d97f4f14f) wl-color-picker: 1.3 -> 1.4
* [`e594b4c9`](https://github.com/NixOS/nixpkgs/commit/e594b4c918f6c3bfc698a552df3d27816e967a9a) prometheus-postfix-exporter: 0.9.0 -> 0.10.0
* [`756145d0`](https://github.com/NixOS/nixpkgs/commit/756145d09abfb649a57d7154edda1b7ff9bf9558) weasis: 4.5.1 -> 4.6.1
* [`cd927bba`](https://github.com/NixOS/nixpkgs/commit/cd927bba62eb66f98bdc732991c71b51ca7bcaba) magic-wormhole: add updateScript
* [`7582e956`](https://github.com/NixOS/nixpkgs/commit/7582e9565b299e96e1d034272b6c90bff3b00299) magic-wormhole: 0.18.0 -> 0.19.2
* [`fed6847c`](https://github.com/NixOS/nixpkgs/commit/fed6847c22279a54681731a004fab0c130299296) tahoe-lafs: pin magic-wormhole to version 0.18.0
* [`4c1ec45e`](https://github.com/NixOS/nixpkgs/commit/4c1ec45e5abf6d18b3b3972845384f565ff1d4f9) ankiAddons.adjust-sound-volume: init at 0.0.6
* [`2d98ddf6`](https://github.com/NixOS/nixpkgs/commit/2d98ddf69951424c57714216844f848e03f92062) ankiAddons.anki-connect: init at 24.7.25.0
* [`f0e483d0`](https://github.com/NixOS/nixpkgs/commit/f0e483d06dd2bdaa512d9131415482b76dcda7f9) ankiAddons.passfail2: init at 0.3.0-unstable-2024-10-17
* [`133b3319`](https://github.com/NixOS/nixpkgs/commit/133b3319e54d9fe5383a525c8ad4a207c23f4354) ankiAddons.reviewer-refocus-card: init at 0-unstable-2022-12-24
* [`6eebb203`](https://github.com/NixOS/nixpkgs/commit/6eebb20365bfe01caaf27b10acc876e84f282620) ankiAddons.yomichan-forvo-server: init at 0-unstable-2024-10-21
* [`8dc12689`](https://github.com/NixOS/nixpkgs/commit/8dc12689a0a6e07d9e977e741c04c3a5df240d5f) ankiAddons.local-audio-yomichan: init at 0-unstable-2025-04-26
* [`e9216c0d`](https://github.com/NixOS/nixpkgs/commit/e9216c0d4cecf55013a275abea07076136dea8d5) ankiAddons.recolor: init at 3.1
* [`72d3be4a`](https://github.com/NixOS/nixpkgs/commit/72d3be4aa88dc9f3869b77be7909b0e7ffd605ab) teapot: refactor package definitions
* [`34a118f7`](https://github.com/NixOS/nixpkgs/commit/34a118f784b8e408046ff2369aeddfcc083f2b53) pngpaste: refactor package.nix and hardcode repo.
* [`4ac7f4bc`](https://github.com/NixOS/nixpkgs/commit/4ac7f4bc10a85a943b95eb827ce313c05ecfe937) harper: 0.40.0 -> 0.41.0
* [`6c889223`](https://github.com/NixOS/nixpkgs/commit/6c88922374134e8c941b283ae98428df5018c614) hysteria: 2.6.1 -> 2.6.2
* [`cfcdbad6`](https://github.com/NixOS/nixpkgs/commit/cfcdbad6375bc115b1cf09b98c38f0cb2703c209) nixos/man-db: fix cross‐compilation
* [`10548992`](https://github.com/NixOS/nixpkgs/commit/10548992d613219ea382265e0595adf3fdb8649c) pscale: 0.243.0 -> 0.245.0
* [`d005dbaa`](https://github.com/NixOS/nixpkgs/commit/d005dbaae9775493ab1b0f0bd9b6be70a76bfeb5) nzbhydra2: 7.13.2 -> 7.14.1
* [`e8d7a4d4`](https://github.com/NixOS/nixpkgs/commit/e8d7a4d428b081e7f0f7d9285bdef9ec10e17e17) gcsfuse: 2.12.1 -> 2.12.2
* [`a92970f8`](https://github.com/NixOS/nixpkgs/commit/a92970f85f1f3d472d750ab54933d7babd132178) maintainers: add hemera
* [`d5c08a2e`](https://github.com/NixOS/nixpkgs/commit/d5c08a2e53ffb2cec243268ed46678febae47306) python3Packages.cddlparser: init at 0.5.0
* [`e3a712dc`](https://github.com/NixOS/nixpkgs/commit/e3a712dc103a129319135ba8c1b42a001f79b38c) tryton: 7.6.1 -> 7.6.2
* [`b25e4397`](https://github.com/NixOS/nixpkgs/commit/b25e4397daf15a0790a033701edb6bcebe72a56d) fwupd-efi: 1.6 -> 1.7
* [`d008f045`](https://github.com/NixOS/nixpkgs/commit/d008f045dbf202a51d33a082ac82070ae4bbb5c9) nixos/tests/incus: add test for apparmor.service
* [`dd5faa98`](https://github.com/NixOS/nixpkgs/commit/dd5faa98aec25d34ae35e30d32c343084064e3bd) nixos/incus: update AppArmor profile for new versions
* [`3c49dfc1`](https://github.com/NixOS/nixpkgs/commit/3c49dfc1d97dc406993d3a1d16894e8a6038c955) patroni: 4.0.5 -> 4.0.6
* [`35cbcbb8`](https://github.com/NixOS/nixpkgs/commit/35cbcbb8e834da2274a96aace58e95dcb2d242c5) quark-engine: 25.5.1 -> 25.6.1
* [`e6483893`](https://github.com/NixOS/nixpkgs/commit/e64838938a6f8cc0620ef6c25161d3fb9c2b1fe8) geoserver: 2.27.0 -> 2.27.1
* [`e41ea86a`](https://github.com/NixOS/nixpkgs/commit/e41ea86af129e0b736b8579a00dd6c2cf8952e27) mpls: 0.15.2 -> 0.15.3
* [`4deda24c`](https://github.com/NixOS/nixpkgs/commit/4deda24c4a2b11a1dc53999f4ce7a7cd99ae266c) ipxe: 1.21.1-unstable-2025-05-27 -> 1.21.1-unstable-2025-06-02
* [`7abdffe2`](https://github.com/NixOS/nixpkgs/commit/7abdffe2fb60b8654e9e200229d2b22be118f9d8) logdy: fix hash
* [`50e7996c`](https://github.com/NixOS/nixpkgs/commit/50e7996cfae2d64e8f5f6b7dbbff0b46f85697d5) harlequin: Add tree-sitter-sql as dependency
* [`ec239d24`](https://github.com/NixOS/nixpkgs/commit/ec239d24a9b59e097fb8b448b431206bfb7cc18c) circleci-cli: 0.1.32067 -> 0.1.32367
* [`eec53d98`](https://github.com/NixOS/nixpkgs/commit/eec53d98fcfe00baa94fd24e618a5ef533571d99) cnquery: 11.56.0 -> 11.57.2
* [`8d828525`](https://github.com/NixOS/nixpkgs/commit/8d8285253bb1933273d011c85fb8bddb5407be37) geoserver: modernize
* [`136b7ebe`](https://github.com/NixOS/nixpkgs/commit/136b7ebe2d2d6a3f4a17d56f6e3d268d383d3ef3) grpc_cli: 1.72.0 -> 1.73.0
* [`22b85982`](https://github.com/NixOS/nixpkgs/commit/22b85982b0223d6a2f5e0c5caf1b399498ca8562) jinja-lsp: 0.1.85 -> 0.1.86
* [`a91a66d4`](https://github.com/NixOS/nixpkgs/commit/a91a66d4ca43fedecb62c720be943e3409edf6fe) greenmask: 0.2.11 -> 0.2.12
* [`407b36a0`](https://github.com/NixOS/nixpkgs/commit/407b36a0c920ac393c3f407e3aec2b0dae3f159e) kubetui: 1.7.1 -> 1.8.1
* [`4aa74145`](https://github.com/NixOS/nixpkgs/commit/4aa741451ebc26efcc1f6149600741e18b4dbb09) goctl: 1.8.3 -> 1.8.4
* [`ba60945d`](https://github.com/NixOS/nixpkgs/commit/ba60945dcdcbab4a17baad7e2c0d6d24200a2232) kdlfmt: 0.0.17 -> 0.1.0
* [`1e002dfc`](https://github.com/NixOS/nixpkgs/commit/1e002dfcf1d3854a114c9160a8be63d500b7d5c5) snipe-it: 8.1.4 -> 8.1.15
* [`884f985f`](https://github.com/NixOS/nixpkgs/commit/884f985f1b08109c214ef6c8dc67c30472fa9485) python3Packages.osmapi: init at 4.3.0
* [`1af0a950`](https://github.com/NixOS/nixpkgs/commit/1af0a950e5fec769215e0c0f249fc53607a4bfb8) sslh: 2.2.3 -> 2.2.4
* [`584d060e`](https://github.com/NixOS/nixpkgs/commit/584d060e65155dd3375024d1c4578c9a4055f448) cargo-tally: 1.0.64 -> 1.0.65
* [`8f831c7e`](https://github.com/NixOS/nixpkgs/commit/8f831c7ef45df7b3fe7f60d62bc596ea4c21ce72) flyctl: 0.3.132 -> 0.3.140
* [`5d241a09`](https://github.com/NixOS/nixpkgs/commit/5d241a0907e1bfd4a44e97d2a3e902ab6f95a54b) lxgw-neoxihei: 1.216.2 -> 1.217
* [`0aa93417`](https://github.com/NixOS/nixpkgs/commit/0aa93417d819f5bfa6e1600b47aea5c516b2103b) dependabot-cli: 1.65.0 -> 1.66.0
* [`5eb7eb17`](https://github.com/NixOS/nixpkgs/commit/5eb7eb17f0a36993a31594ad3d32ce1a2c26c47d) python3Packages.jupytext: 1.17.1 -> 1.17.2
* [`e40d5b87`](https://github.com/NixOS/nixpkgs/commit/e40d5b879a10d56494cefbd32dad029f75a0d04e) terraform-providers.btp: 1.12.0 -> 1.13.0
* [`eb0af689`](https://github.com/NixOS/nixpkgs/commit/eb0af68971776e6aa234d3292657f705a44035d6) cura-appimage: 5.10.0 -> 5.10.1
* [`dd23a4ec`](https://github.com/NixOS/nixpkgs/commit/dd23a4ec894d360c776811f5c9df6cd220f0a7a8) python3Packages.jupyter-book: skip flaky test
* [`ba7a0ea8`](https://github.com/NixOS/nixpkgs/commit/ba7a0ea826b4d938c8b670f8c60dfc0bdb395d1c) bilibili: 1.16.4-1 -> 1.16.5-2
* [`648da7bb`](https://github.com/NixOS/nixpkgs/commit/648da7bb86eca60778f10b7a201ff5b6591bd4f7) vacuum-go: 0.16.13 -> 0.17.0
* [`74799e93`](https://github.com/NixOS/nixpkgs/commit/74799e9308d5262a241e551822caa2f7790e8da8) harlequin: 2.0.0 -> 2.1.2
* [`07440544`](https://github.com/NixOS/nixpkgs/commit/07440544a9c0a275f7872c712747f0f5ef453d1b) tailwindcss-language-server: 0.14.19 -> 0.14.21
* [`5c4ede54`](https://github.com/NixOS/nixpkgs/commit/5c4ede54b4917fb79fd35692f19a2543fec736f7) python3Packages.skorch: disable package on darwin
* [`4eea4215`](https://github.com/NixOS/nixpkgs/commit/4eea4215be181deabee4bda258688dc4da293fdf) python3Packages.onnxslim: 0.1.51 -> 0.1.56
* [`4fca7dcd`](https://github.com/NixOS/nixpkgs/commit/4fca7dcdaf5516ce0176180eab2e8a8b66f55a93) python3Packages.mkdocstrings-python: 1.16.11 -> 1.16.12
* [`5b89278f`](https://github.com/NixOS/nixpkgs/commit/5b89278f4799eb0c6aeac381248ed5f4ee411740) flutter332: 3.32.0 -> 3.32.2
* [`2747c473`](https://github.com/NixOS/nixpkgs/commit/2747c473cc38a1db053934af833a182253e9b788) python313Packages.pdfminer-six: 20240706 -> 20250506
* [`b6007cee`](https://github.com/NixOS/nixpkgs/commit/b6007ceed579027cd4558df4a7d10f7287884ba1) python313Packages.pdfplumber: 0.11.5 -> 0.11.6
* [`5ccca867`](https://github.com/NixOS/nixpkgs/commit/5ccca8674f04d6bf8826fd7bb492571ffedd215a) telepresence2: 2.22.4 -> 2.22.6
* [`7e86f64d`](https://github.com/NixOS/nixpkgs/commit/7e86f64dcb66a7312df2409427749a3b445ec69e) paperless-ngx: 2.16.2 -> 2.16.3
* [`e9339c6f`](https://github.com/NixOS/nixpkgs/commit/e9339c6ff3ad5589c6de826f51194e1634315a29) iksemel: update to newer texinfo
* [`53bc2be4`](https://github.com/NixOS/nixpkgs/commit/53bc2be44734eca7cb76420f2d6413a000db8195) gpm: unpin texinfo
* [`3356c105`](https://github.com/NixOS/nixpkgs/commit/3356c10541ddef49d7226f512273c5fc6d57cacd) fwknop: 2.6.10 -> 2.6.11
* [`b391ddf5`](https://github.com/NixOS/nixpkgs/commit/b391ddf579956c4b9e8a0bc0f42d15f6343b552a) texinfo6_7: drop
* [`8543bc49`](https://github.com/NixOS/nixpkgs/commit/8543bc4907fa21022950a28faabd9a85dc4bdaea) gnulib: drop now unused patch
* [`cc9349bb`](https://github.com/NixOS/nixpkgs/commit/cc9349bbe485313070ea2c0571bde36df1f1e993) allegro: unpin texinfo
* [`26b4a9ea`](https://github.com/NixOS/nixpkgs/commit/26b4a9ea81dbfa71ee1758e467481f1633d97563) texinfo6_5: drop
* [`c9390a53`](https://github.com/NixOS/nixpkgs/commit/c9390a5353d940497a7bc9b10e49a67a401c23fd) newelle: 0.9.7 -> 0.9.8
* [`2b6a5771`](https://github.com/NixOS/nixpkgs/commit/2b6a57710bc97721f8d70d09788038033f9bc1e5) maintainers: add tuxy
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
