### PR TITLE
niv home-manager: update 427c9604 -> 28eef872

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -77,10 +77,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "427c96044f11a5da50faf6adaf38c9fa47e6d044",
-        "sha256": "0sk62jkv4vc961x4g5cwlcwpj5wf272avkjmjqxly0lvlvplbgsh",
+        "rev": "28eef8722d1af18ca13e687dbf485e1c653a0402",
+        "sha256": "0i27b08xasw22z4fmfwhy5ajddh4v9r173mqcs0c4ggpa2v4av1b",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/427c96044f11a5da50faf6adaf38c9fa47e6d044.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/28eef8722d1af18ca13e687dbf485e1c653a0402.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@427c9604...28eef872](https://github.com/nix-community/home-manager/compare/427c96044f11a5da50faf6adaf38c9fa47e6d044...28eef8722d1af18ca13e687dbf485e1c653a0402)

* [`450f06ec`](https://github.com/nix-community/home-manager/commit/450f06ec3cd0d86f67db58a7245db8848773e895) meli: support include statement ([nix-community/home-manager⁠#7248](https://togithub.com/nix-community/home-manager/issues/7248))
* [`02040b77`](https://github.com/nix-community/home-manager/commit/02040b7777f65342b96c7f826a5c6aef95585057) flake.lock: Update ([nix-community/home-manager⁠#7251](https://togithub.com/nix-community/home-manager/issues/7251))
* [`faeab325`](https://github.com/nix-community/home-manager/commit/faeab32528a9360e9577ff4082de2d35c6bbe1ce) ci: fix bars labeler ([nix-community/home-manager⁠#7253](https://togithub.com/nix-community/home-manager/issues/7253))
* [`5ab15331`](https://github.com/nix-community/home-manager/commit/5ab15331c213350b2c6611454b5f7abb660568af) targets/darwin: fix ShowDate default description ([nix-community/home-manager⁠#7256](https://togithub.com/nix-community/home-manager/issues/7256))
* [`09859234`](https://github.com/nix-community/home-manager/commit/09859234f8a8fee31a1e2293f101504324578199) zed-editor: don't add activation scripts if there is nothing to merge ([nix-community/home-manager⁠#7254](https://togithub.com/nix-community/home-manager/issues/7254))
* [`dd12be86`](https://github.com/nix-community/home-manager/commit/dd12be8603041a26f56f8d0cc9199c6e88a7fb14) maintainers: add justdeeevin
* [`0215073a`](https://github.com/nix-community/home-manager/commit/0215073a704e9b8992d8e59761344d83d8c72e8b) ashell: add module
* [`18f3a0d2`](https://github.com/nix-community/home-manager/commit/18f3a0d21c3739a242aafa17c04c5238bbab5a41) opensnitch-ui: add package option ([nix-community/home-manager⁠#7260](https://togithub.com/nix-community/home-manager/issues/7260))
* [`f1113939`](https://github.com/nix-community/home-manager/commit/f1113939873a62f185c18a51f4e45ae66686822b) ashell: minor description improvements
* [`79dfd9aa`](https://github.com/nix-community/home-manager/commit/79dfd9aa295e53773aad45480b44c131da29f35b) meli: move freeformat settings to example ([nix-community/home-manager⁠#7259](https://togithub.com/nix-community/home-manager/issues/7259))
* [`8fabeb9c`](https://github.com/nix-community/home-manager/commit/8fabeb9c142a303e02270c3a3a0d8e00af9d0dfe) fix meli eval warning  ([nix-community/home-manager⁠#7267](https://togithub.com/nix-community/home-manager/issues/7267))
* [`c5f34515`](https://github.com/nix-community/home-manager/commit/c5f345153397f62170c18ded1ae1f0875201d49a) atuin: fix docs url ([nix-community/home-manager⁠#7252](https://togithub.com/nix-community/home-manager/issues/7252))
* [`6e36b1be`](https://github.com/nix-community/home-manager/commit/6e36b1be0b477547967178422d6b6aedf8efb79b) ncspot: adopt
* [`dceefa87`](https://github.com/nix-community/home-manager/commit/dceefa87dc19661186f2c519dce6a9670a1d1b36) ncspot: make package nullable
* [`04672588`](https://github.com/nix-community/home-manager/commit/04672588c61aebd18c0d0ada66dd7bb4d8edab0d) way-displays: support stateful configuration file ([nix-community/home-manager⁠#7138](https://togithub.com/nix-community/home-manager/issues/7138))
* [`30b6daf8`](https://github.com/nix-community/home-manager/commit/30b6daf8723429190e56bc2f296837578c41aca8) kakoune: implement a final package option ([nix-community/home-manager⁠#7275](https://togithub.com/nix-community/home-manager/issues/7275))
* [`676e40a2`](https://github.com/nix-community/home-manager/commit/676e40a2464783e05146ab5cb196a68230dffc45) sketchybar: inherit meta in finalPackage ([nix-community/home-manager⁠#7276](https://togithub.com/nix-community/home-manager/issues/7276))
* [`83030f0e`](https://github.com/nix-community/home-manager/commit/83030f0e4a82a1f39f13fc057e3510938841c761) ci: labeler issues permission ([nix-community/home-manager⁠#7278](https://togithub.com/nix-community/home-manager/issues/7278))
* [`cef3e0ad`](https://github.com/nix-community/home-manager/commit/cef3e0adc0b671062c2f911b46d9aacfd7235816) maintainers: update aguirre-matteo email ([nix-community/home-manager⁠#7279](https://togithub.com/nix-community/home-manager/issues/7279))
* [`66523b0e`](https://github.com/nix-community/home-manager/commit/66523b0efe93ce5b0ba96dcddcda15d36673c1f0) thunderbird: support declaration of calendars ([nix-community/home-manager⁠#5484](https://togithub.com/nix-community/home-manager/issues/5484))
* [`1db3cb41`](https://github.com/nix-community/home-manager/commit/1db3cb415da14c81d8e0fdd3a5edeba82ad13a1f) lib/strings: add PascalCase support for toCaseWithSeperator ([nix-community/home-manager⁠#7282](https://togithub.com/nix-community/home-manager/issues/7282))
* [`0edffd08`](https://github.com/nix-community/home-manager/commit/0edffd088e42fdc48598b37d88eb5345e2ca3937) firefox: allow separators in bookmarks ([nix-community/home-manager⁠#7284](https://togithub.com/nix-community/home-manager/issues/7284))
* [`28eef872`](https://github.com/nix-community/home-manager/commit/28eef8722d1af18ca13e687dbf485e1c653a0402) vscode: fix version checks when using Windsurf ([nix-community/home-manager⁠#7285](https://togithub.com/nix-community/home-manager/issues/7285))
