### PR TITLE
niv nerd-icons.el: update d972dee3 -> 71d162a7

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -131,10 +131,10 @@
         "homepage": null,
         "owner": "rainstormstudio",
         "repo": "nerd-icons.el",
-        "rev": "d972dee349395ffae8fceae790d22fedc8fe08e8",
-        "sha256": "0bn58yr6i2vn1j7f3xna2li9p5bckfkjhb0s5fzimvszkcic2ymp",
+        "rev": "71d162a75bf6178ecff1536ac94dfa25e617b6ed",
+        "sha256": "0cdws2mkvpds7s533dqcbjqksyvkwdhvvpjjchdkd59ygdwzvjwn",
         "type": "tarball",
-        "url": "https://github.com/rainstormstudio/nerd-icons.el/archive/d972dee349395ffae8fceae790d22fedc8fe08e8.tar.gz",
+        "url": "https://github.com/rainstormstudio/nerd-icons.el/archive/71d162a75bf6178ecff1536ac94dfa25e617b6ed.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "niv": {


### PR DESCRIPTION
## Changelog for nerd-icons.el:
Branch: main
Commits: [rainstormstudio/nerd-icons.el@d972dee3...71d162a7](https://github.com/rainstormstudio/nerd-icons.el/compare/d972dee349395ffae8fceae790d22fedc8fe08e8...71d162a75bf6178ecff1536ac94dfa25e617b6ed)

* [`71d162a7`](https://github.com/rainstormstudio/nerd-icons.el/commit/71d162a75bf6178ecff1536ac94dfa25e617b6ed) change the messages-buffer icon from a file to a log
