### PR TITLE
niv zsh-you-should-use: update 56616de0 -> 17c49d7c

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -275,10 +275,10 @@
         "homepage": "",
         "owner": "MichaelAquilina",
         "repo": "zsh-you-should-use",
-        "rev": "56616de037082f7dc0a143eb244ea27e5a697ef9",
-        "sha256": "10al3dj2y9kdfnv3zwr22gm7digfyf3rrspcapn059084nkxkd2x",
+        "rev": "17c49d7c5ee3383c58f18bf3d6502a29e1bf1650",
+        "sha256": "131gjcv9zqsp2ywdhga7pyvbvm8cv2grcd03vy5zjkwxkw4z9719",
         "type": "tarball",
-        "url": "https://github.com/MichaelAquilina/zsh-you-should-use/archive/56616de037082f7dc0a143eb244ea27e5a697ef9.tar.gz",
+        "url": "https://github.com/MichaelAquilina/zsh-you-should-use/archive/17c49d7c5ee3383c58f18bf3d6502a29e1bf1650.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }


### PR DESCRIPTION
## Changelog for zsh-you-should-use:
Branch: master
Commits: [MichaelAquilina/zsh-you-should-use@56616de0...17c49d7c](https://github.com/MichaelAquilina/zsh-you-should-use/compare/56616de037082f7dc0a143eb244ea27e5a697ef9...17c49d7c5ee3383c58f18bf3d6502a29e1bf1650)

* [`bcd0978c`](https://github.com/MichaelAquilina/zsh-you-should-use/commit/bcd0978c407b42367c8a41951de5735d9aaf8746) feat: add hardcore mode for specific aliases
* [`84e8b113`](https://github.com/MichaelAquilina/zsh-you-should-use/commit/84e8b1131bb4c7a24936cf0aaaaf8251007e8f0d) test: mock kill command and exit code
* [`ec49a1f9`](https://github.com/MichaelAquilina/zsh-you-should-use/commit/ec49a1f93d3ce47c1e75ce859018f34d0d3f8054) test: add bootstrap to reduce duplications
* [`78617df0`](https://github.com/MichaelAquilina/zsh-you-should-use/commit/78617df02e09fcc06f41a91d934b7048947fc62d) Bump to version 1.10.0
* [`17c49d7c`](https://github.com/MichaelAquilina/zsh-you-should-use/commit/17c49d7c5ee3383c58f18bf3d6502a29e1bf1650) Remove git tag test - to be moved to pre-commit in the future
