### PR TITLE
niv nixpkgs: update cbb9bf84 -> 45d99199

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -155,10 +155,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "cbb9bf84ff3e497091c5450032600fbff7a05589",
-        "sha256": "1rc2d9ckqra11vszbzv616hpix8mkryd0nid0179bbmvfjxy4dc8",
+        "rev": "45d9919944202c82c9310d1d2a8149a7576d2e9b",
+        "sha256": "0sv8w8an4pgxvbwbs1cn5vzbk1cdvckflr7vjhk703hydf73b8n4",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/cbb9bf84ff3e497091c5450032600fbff7a05589.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/45d9919944202c82c9310d1d2a8149a7576d2e9b.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@cbb9bf84...45d99199](https://github.com/nixos/nixpkgs/compare/cbb9bf84ff3e497091c5450032600fbff7a05589...45d9919944202c82c9310d1d2a8149a7576d2e9b)

* [`776480ae`](https://github.com/NixOS/nixpkgs/commit/776480ae063ac0af5d18851d7caaf1652f5cee16) scrutiny-collector: build for darwin
* [`c1f2face`](https://github.com/NixOS/nixpkgs/commit/c1f2face8f069559028864007a2e378812612d19) scrutiny.collector: fix endpoint to include basepath
* [`0ab9f97f`](https://github.com/NixOS/nixpkgs/commit/0ab9f97fcc015f8132f37174f28ef4a569145619) clang-wrapper: add special case for FreeBSD headers
* [`aede63e5`](https://github.com/NixOS/nixpkgs/commit/aede63e568e8c9e3b0ac4cd538144c0d39586b4a) tdb: fix FreeBSD cross build by vendoring configure answers
* [`18fc4428`](https://github.com/NixOS/nixpkgs/commit/18fc4428c2e65d2775da106128a5f2e3274ebfe2) libidn: 1.42 -> 1.43
* [`8076af1a`](https://github.com/NixOS/nixpkgs/commit/8076af1a5a7b7fcd5a0f34f783e4ac3b71d18734) avahi: add patch fixing libevent name in the .pc file
* [`ca159cd3`](https://github.com/NixOS/nixpkgs/commit/ca159cd3b80fd87e7a5d49c8f981b6b776ce8d57) giflib: patch CVE-2025-31344
* [`93b9cc2e`](https://github.com/NixOS/nixpkgs/commit/93b9cc2e2d0baf65c0f3065f39eaae1448235654) maintainers: add theonlymrcat
* [`12a5caba`](https://github.com/NixOS/nixpkgs/commit/12a5caba49dbfe4b734f6c5172e791b861d2ed61) libjpeg: refactor
* [`b914dfff`](https://github.com/NixOS/nixpkgs/commit/b914dfff908efb1e48cb70a71fb945fdf4913d88) libjpeg: add update script
* [`78ca2309`](https://github.com/NixOS/nixpkgs/commit/78ca23098c5ff0adcafaff27174adf441eae4e78) libjpeg: 3.0.4 -> 3.1.0
* [`2fce8ef5`](https://github.com/NixOS/nixpkgs/commit/2fce8ef584084a93de351b9d08d4e581ca24f774) gnupatch: 2.7.6 -> 2.8
* [`5d8770d7`](https://github.com/NixOS/nixpkgs/commit/5d8770d7da7aaf5f9b91be5867764315b82513a2) libraw: 0.21.3 -> 0.21.4
* [`6f6a4b7e`](https://github.com/NixOS/nixpkgs/commit/6f6a4b7eb111b102f701fe6d2186a4b1e4ac21d7) gasket: fix build with kernel >= 6.13
* [`4752577d`](https://github.com/NixOS/nixpkgs/commit/4752577dd6177044913018acdf2bd456b4e08837) lib.modules: Add _prefix module argument
* [`ce0c6e26`](https://github.com/NixOS/nixpkgs/commit/ce0c6e269d6c0a40c63e1f8b7f40ec1aac0e7ffd) lib.modules: Typos
* [`38bb05d1`](https://github.com/NixOS/nixpkgs/commit/38bb05d169a51fc7c7187867440d2968212d1267) lib.modules: Add prefix to imports type check error
* [`1de329f5`](https://github.com/NixOS/nixpkgs/commit/1de329f5e181b4e46607934ef323f4931803e42b) doc: Module arguments
* [`0d041818`](https://github.com/NixOS/nixpkgs/commit/0d041818c311f1afa98836b11c50f5757201f2dd) swig: 4.3.0 -> 4.3.1
* [`099a7a9e`](https://github.com/NixOS/nixpkgs/commit/099a7a9e5facfbe4865214782125a14c217498a0) swig: enable parallel building
* [`81ec0f39`](https://github.com/NixOS/nixpkgs/commit/81ec0f393f7f39ad488a26b7f48188d3433f9414) gnugrep: 3.11 -> 3.12
* [`730c40a5`](https://github.com/NixOS/nixpkgs/commit/730c40a5cde80ea8c9ff21827ff4a5fa7c011ade) svt-av1: 2.3.0 → 3.0.2
* [`21689554`](https://github.com/NixOS/nixpkgs/commit/21689554b842f10adf814439f40fea272d818b88) ffmpeg: fix build with svt-av1 3.0.0
* [`5116fbd3`](https://github.com/NixOS/nixpkgs/commit/5116fbd378c16a4500e14112915eaf732705c3e2) svt-av1: set `meta.mainProgram`
* [`553b82a3`](https://github.com/NixOS/nixpkgs/commit/553b82a349c3cd8250e950b4ce1b5435cf7a0f2d) svt-av1: limit x86_64-specific dependencies
* [`cff15fae`](https://github.com/NixOS/nixpkgs/commit/cff15fae198f031986cb7456f62d73c654618e75) gperf_3_0: remove, no users in `nixpkgs`
* [`4344578f`](https://github.com/NixOS/nixpkgs/commit/4344578f9d2d3dd542b495d0264920c80efa906b) ibus: 1.5.31 -> 1.5.32
* [`5fc635b2`](https://github.com/NixOS/nixpkgs/commit/5fc635b2cc7ac93ca1e4581dc62c49f1ab59d02c) gdb: 16.2 -> 16.3
* [`51d30ce7`](https://github.com/NixOS/nixpkgs/commit/51d30ce737699e90507a58aa06cfad6d707cf476) gperf: 3.1 -> 3.3
* [`9407b1df`](https://github.com/NixOS/nixpkgs/commit/9407b1dfd1e39bf8229ead302593ab2c9fa08941) nodejs_22: 22.14.0 -> 22.15.0
* [`4bb08abe`](https://github.com/NixOS/nixpkgs/commit/4bb08abe141498c48ddba3604771364b523ecc5a) fontconfig: prefer GitLab for src
* [`ad4e0450`](https://github.com/NixOS/nixpkgs/commit/ad4e04502c006ab259eda808a677e286489e4849) fontconfig: add updateScript
* [`227188af`](https://github.com/NixOS/nixpkgs/commit/227188afb014f039e1753be181136b706eca8816) fontconfig: add versionCheckHook
* [`873eb8ea`](https://github.com/NixOS/nixpkgs/commit/873eb8eafe9a681b1ed6d8077440a97576752909) fontconfig: 2.16.0 -> 2.16.2
* [`b3bb63f4`](https://github.com/NixOS/nixpkgs/commit/b3bb63f4410df02280b31e5e1ca711c45bbfe73f) fontconfig: use tarball for src to include man pages
* [`f80a7881`](https://github.com/NixOS/nixpkgs/commit/f80a788128b2f8235b62f08cc1b4eed3077b308a) fontconfig: add man pages checks
* [`002c1428`](https://github.com/NixOS/nixpkgs/commit/002c14287b335ca433779719a02aac3b05e43ee3) re2c: 4.1 -> 4.2
* [`f2a5ddd7`](https://github.com/NixOS/nixpkgs/commit/f2a5ddd7d388f0b03aed6bd5233446e9463a858b) gotenberg: 8.16.0 -> 8.20.1
* [`5fa2cf0a`](https://github.com/NixOS/nixpkgs/commit/5fa2cf0a320b87f4b6b191a4a01c979babb250f1) xkeyboard-config: refactor, move to pkgs/by-name and rename from xorg.xkeyboardconfig
* [`d2298641`](https://github.com/NixOS/nixpkgs/commit/d2298641256d3bb306eb759f7eaa7a1b85a22e26) xorg-cf-files: refactor, move to pkgs/by-name and rename from xorg.xorgcffiles
* [`ac2c00e1`](https://github.com/NixOS/nixpkgs/commit/ac2c00e10fe959190bfba685e9615527ef3c12f5) gcc: stop passing --with-ld when cross compiling
* [`67564e09`](https://github.com/NixOS/nixpkgs/commit/67564e09a539eeb63fde4197ad24c441e8408b73) buildPython*: pass check-related args whenever specified
* [`dbfa6860`](https://github.com/NixOS/nixpkgs/commit/dbfa6860ff07b57d5f3ab01d5c24166c61531be6) python312Packages.flask-cors: 5.0.0 -> 5.0.1
* [`47b8f556`](https://github.com/NixOS/nixpkgs/commit/47b8f5561ce7b85cc832d60530496362caa69b43) taskflow: 3.9.0 -> 3.10.0
* [`d655219d`](https://github.com/NixOS/nixpkgs/commit/d655219d6fcc690a9c9f2a88456e73104317e088) haskellPackages: remove unneeded jailbreaks
* [`86b0198a`](https://github.com/NixOS/nixpkgs/commit/86b0198a2a8493fa2aef1a6bb27d6d9ab99204d9) elfutils: 0.192 -> 0.193
* [`81531df2`](https://github.com/NixOS/nixpkgs/commit/81531df23d99e7aeabc6c198c69ddd0ab832b681) pixman: 0.44.2 -> 0.46.0
* [`fd6f5af2`](https://github.com/NixOS/nixpkgs/commit/fd6f5af29df4ae8e2ae1a9065c47d655d8d62331) haskell.compiler.ghcHEAD: 9.13.20250205 -> 9.13.20250428
* [`54ff5b44`](https://github.com/NixOS/nixpkgs/commit/54ff5b44d72e712451be217fe068f354a6fe9552) sqlite: enable Geopoly, Math functions and RBU extensions
* [`9e1b5205`](https://github.com/NixOS/nixpkgs/commit/9e1b520590ce455daa8f9f95fee90dc11899fd4b) man-db: 2.13.0 -> 2.13.1
* [`5e715c4a`](https://github.com/NixOS/nixpkgs/commit/5e715c4a9ab5f852e0d71ab4e1f69e8e0893649a) libpng: 1.6.46 -> 1.6.47
* [`992e1b5a`](https://github.com/NixOS/nixpkgs/commit/992e1b5a9ba37261c9d00cd511f596c95f002e46) all-cabal-hashes: 2025-04-21T04:38:52Z -> 2025-05-05T12:06:43Z
* [`c0c2fac0`](https://github.com/NixOS/nixpkgs/commit/c0c2fac038da368cd6a77a99d56b1251de986be6) haskellPackages: stackage LTS 23.19 -> LTS 23.21
* [`64f3c047`](https://github.com/NixOS/nixpkgs/commit/64f3c047a6c1e086a223a7bd5947a111ccdda231) haskellPackages: regenerate package set based on current config
* [`c1459b8d`](https://github.com/NixOS/nixpkgs/commit/c1459b8d779c5c93031c05fb1c766043c2d36062) go-mockery: 2.53.3 -> 3.2.5
* [`aebc5607`](https://github.com/NixOS/nixpkgs/commit/aebc5607942ee5778f2f2908c7f92774786797bb) go-mockery: replace tests by versionCheckHook
* [`b2bd4339`](https://github.com/NixOS/nixpkgs/commit/b2bd43391d779407820bcfc874624a8b9625a44d) maintainers/scripts/haskell: sort case- and locale-insensitively consistently
* [`4eaa7b86`](https://github.com/NixOS/nixpkgs/commit/4eaa7b86cb0684ede7554cff54cb02f51fd305ba) haskell-modules/configuration-hackage2nix: set up keep-sorted for main.yaml
* [`63b7dbb9`](https://github.com/NixOS/nixpkgs/commit/63b7dbb9d56d326bba0d07c9b660b4fac54507bd) haskell-modules/configuration-hackage2nix: run keep-sorted on main.yaml
* [`893e0a5f`](https://github.com/NixOS/nixpkgs/commit/893e0a5f22e3c93bbe523b611d4cf2c95c02784d) haskell-modules/configuration-common: clean up some comments
* [`c51d1cd7`](https://github.com/NixOS/nixpkgs/commit/c51d1cd7b5c71bf6b7e198e09771945e2d813234) haskell-modules/configuration-{common,nix}: add comment about arbitrary insert position to avoid merge conflicts
* [`e63cbab5`](https://github.com/NixOS/nixpkgs/commit/e63cbab56a48d78708ace3a38b54b0640ba518e2) haskell.packages.ghc910.ghc-lib-parser: 9.10.1.20250103 -> 9.10.2.20250503
* [`9380ece8`](https://github.com/NixOS/nixpkgs/commit/9380ece8c77bbb74ac95f0cc24473e6bf631c4f6) haskellPackages.cborg: drop obsolete override
* [`d7be3551`](https://github.com/NixOS/nixpkgs/commit/d7be3551aa40e5fe41a1375ff419620b2589a26a) haskell.packages.ghc912.ghc-lib-parser: 9.12.2.20250320 -> 9.12.2.20250421
* [`b96d7818`](https://github.com/NixOS/nixpkgs/commit/b96d781847f39645f15ed5f1792d8aefe970abf9) haskellPackages: unbreak various packages
* [`cb084dff`](https://github.com/NixOS/nixpkgs/commit/cb084dff5943840e23d276ff0848533858629339) haskellPackages.jsonpatch: remove override
* [`a05a12a4`](https://github.com/NixOS/nixpkgs/commit/a05a12a4d3993167478d92f00a24a72b913547d1) python313Packages.aiodns: 3.2.0 -> 3.3.0
* [`a4b5a2ce`](https://github.com/NixOS/nixpkgs/commit/a4b5a2ce4a5c6b88cabe1b2d444a5b06d4664ebb) versionCheckHook: add `versionCheckDontIgnoreEnvironment` parameter
* [`d28271d7`](https://github.com/NixOS/nixpkgs/commit/d28271d7ef04ec3caad2e9a244c2eb06ea48bd7a) cargo-seek: add `versionCheckDontIgnoreEnvironment = true;`
* [`c3b3bec2`](https://github.com/NixOS/nixpkgs/commit/c3b3bec2cba1df1180b1d5e6a9197683881ce668) crc: add `versionCheckDontIgnoreEnvironment = true;`
* [`b31d37bc`](https://github.com/NixOS/nixpkgs/commit/b31d37bc11986a7385a5bbc5427159518e23b9d6) libfido2: 1.15.0 -> 1.16.0
* [`27766705`](https://github.com/NixOS/nixpkgs/commit/27766705c0bb4fa1520a569e967d8e244b534b73) lvm2: 2.03.31 -> 2.03.32
* [`794a6b6b`](https://github.com/NixOS/nixpkgs/commit/794a6b6b3229d6ff4162fab3a0af50d0f55116bb) lvm2: enable parallel building
* [`70e2c348`](https://github.com/NixOS/nixpkgs/commit/70e2c348ce5e3ffbf50d4d39035eb1ea57d558f8) gst_all_1.gst-plugins-bad: Disable lcevcdecoder plugin
* [`35333462`](https://github.com/NixOS/nixpkgs/commit/35333462dbe1e2304afe85fa0157028d12600163) systemd: enable tests
* [`a938e44b`](https://github.com/NixOS/nixpkgs/commit/a938e44b4a01105e29399df80c5da32becdfd78e) libgbm: 25.0.1 -> 25.1.0
* [`97d45fbe`](https://github.com/NixOS/nixpkgs/commit/97d45fbe20f686984299a3adab86fa8f26c076ad) mesa-gl-headers: 25.0.1 -> 25.1.0
* [`193079be`](https://github.com/NixOS/nixpkgs/commit/193079bef506a285458cb7b6324e5d06c1b63923) pypresence: 4.3.0 -> 4.3.0-unstable-2025-03-27
* [`69dcb962`](https://github.com/NixOS/nixpkgs/commit/69dcb962a4be854de881bb7c39599530c3892b1d) mpdecimal: 4.0.0 -> 4.0.1
* [`1b540b08`](https://github.com/NixOS/nixpkgs/commit/1b540b086de7c4c032fa9debf4604d99adc616d5) libheif: 1.19.7 -> 1.19.8, adopt orphan, CVE-2025-29482
* [`f4b495ea`](https://github.com/NixOS/nixpkgs/commit/f4b495ea0aafa0b7cac49bd7506dddac927e9341) openclonk: drop non-mandatory dependency libXrandr
* [`d656fb4a`](https://github.com/NixOS/nixpkgs/commit/d656fb4a44ac0dc25e3448c43fc84323bd93d36e) pyright: 1.1.399 -> 1.1.400
* [`4d234df8`](https://github.com/NixOS/nixpkgs/commit/4d234df8cc11c4509388d7d8170c24be51718cbc) spacecookie: drop obsolete override
* [`10180ce6`](https://github.com/NixOS/nixpkgs/commit/10180ce6c8f54b5dfd0d1a7c7456fb0fbc5acf5f) haskellPackages.ghcide: allow building with hie-bios >= 0.15
* [`c5ba2b7e`](https://github.com/NixOS/nixpkgs/commit/c5ba2b7e400cb57736d463e34c77c2029f7f5526) haskell.packages.ghc912.cabal-install: pass in Cabal 3.14.2.0
* [`588a342d`](https://github.com/NixOS/nixpkgs/commit/588a342dc6146df9dca34267f2d3ec65cb469b2e) qemu: 9.2.3 -> 10.0.0
* [`fb2224d5`](https://github.com/NixOS/nixpkgs/commit/fb2224d55230aafa5396b0dbc115eaf4b3d52cae) haskellPackages.stm-queue: skip flaky test case
* [`0d754b5f`](https://github.com/NixOS/nixpkgs/commit/0d754b5fdc9f56b25fa2a7ae96d18b454dc4e6f1) bundler: 2.6.6 -> 2.6.8
* [`4ed9e5c9`](https://github.com/NixOS/nixpkgs/commit/4ed9e5c9957cf07a1e299c6eda4d194dfadbd43a) haskellPackages.jsaddle-warp: fix installPhase
* [`e33f817a`](https://github.com/NixOS/nixpkgs/commit/e33f817a1e71f8a9bc5a7b1f2390e96e1d350a93) ruby.rubygems: 3.6.6 -> 3.6.8
* [`5e6504c0`](https://github.com/NixOS/nixpkgs/commit/5e6504c0dfc3663665ce05bb52489150ab014fca) doc/module-system: Apply suggestions from code review
* [`736327d6`](https://github.com/NixOS/nixpkgs/commit/736327d6ca401e4bbcc8272d9604ec0a4cfe2630) doc/module-system: Adjust markdown syntax
* [`98965d96`](https://github.com/NixOS/nixpkgs/commit/98965d96a32d6abc7c9acb545d005e398ffcbe46) haskell.packages.ghc910.ghc-lib: 9.10.1.20250103 -> 9.10.2.20250503
* [`f2a8f830`](https://github.com/NixOS/nixpkgs/commit/f2a8f8308f42769aaa6a30ef2cd8c8ca71da4201) haskell.packages.ghc912.ghc-lib: 9.12.2.20250320 -> 9.12.2.20250421
* [`55a863d1`](https://github.com/NixOS/nixpkgs/commit/55a863d13be6300bcefdc32f95a5cb0293266726) Revert "haskell-modules/configuration-hackage2nix: run keep-sorted on main.yaml"
* [`58c26191`](https://github.com/NixOS/nixpkgs/commit/58c261918459cb6efd42c4cc575597a2ea99a831) configuration-hackage2nix: add missing keep-sorted annotations
* [`f583a19d`](https://github.com/NixOS/nixpkgs/commit/f583a19d8e9d02ce35b86b7042ec1fa5092d8e37) haskell-modules/configuration-hackage2nix: run keep-sorted
* [`72542147`](https://github.com/NixOS/nixpkgs/commit/72542147a19e3a6387eb9c9b12f24a0bf8cdb66c) vimgolf: migrate to by-name
* [`00e35049`](https://github.com/NixOS/nixpkgs/commit/00e35049baaed30d386699ca9a16146b25d9c2e0) vimgolf: update ruby gems and add abbrev to prepare for ruby 3.40
* [`a5d537ba`](https://github.com/NixOS/nixpkgs/commit/a5d537badb0018de2c36b18fb0f0f748f096b524) swtpm: fix swtpm_setup and swtpm_localca not finding own binaries
* [`f21f9736`](https://github.com/NixOS/nixpkgs/commit/f21f973686020e1b22ad63d91b02893f3cbddc1a) haskellPackages.network: allow local networking on Darwin
* [`262532f4`](https://github.com/NixOS/nixpkgs/commit/262532f409d893e2ef187972a9ef0a32b338e498) removeReferencesTo: unbreak when __structuredAttrs is enabled
* [`5d061344`](https://github.com/NixOS/nixpkgs/commit/5d0613447576bdc7cf256a5011f2f1b8b40199fd) darwin.signingUtils: unbreak when __structuredAttrs is enabled
* [`bf74f38c`](https://github.com/NixOS/nixpkgs/commit/bf74f38c0fb48fa1c4aa2e8ba8da374af3f38580) lua5_{2,4}: unbreak on darwin when __structuredAttrs is enabled
* [`a2d28b99`](https://github.com/NixOS/nixpkgs/commit/a2d28b9987a579105e19cbcfec74dbf1dc640fab) pkg-config-wrapper: unbreak when __structuredAttrs is enabled
* [`f01ad19a`](https://github.com/NixOS/nixpkgs/commit/f01ad19accc385bafd957a90d484e06c4cf729a3) ell: 0.76 -> 0.77
* [`933e7ec6`](https://github.com/NixOS/nixpkgs/commit/933e7ec6e06abdc1c5404e4d82e55b7785c0601a) iwd: 3.6 -> 3.8
* [`286bd401`](https://github.com/NixOS/nixpkgs/commit/286bd4015c6e09d65766cf35b89c7e828db10e71) python312Packages.grpcio-tools: 1.71.0 -> 1.72.0
* [`ebb12e7a`](https://github.com/NixOS/nixpkgs/commit/ebb12e7a223d99d08dce8d432ca03fbeb27ed49b) python312Packages.grpcio-testing: 1.71.0 -> 1.72.0
* [`dfd77158`](https://github.com/NixOS/nixpkgs/commit/dfd77158136e54033871b8cc2220aa18a1d5397f) python312Packages.grpcio-status: 1.71.0 -> 1.72.0
* [`ab1e7b1b`](https://github.com/NixOS/nixpkgs/commit/ab1e7b1bb03c6c53bb82105f556ba376f7856869) python312Packages.grpcio-reflection: 1.71.0 -> 1.72.0
* [`475fb75c`](https://github.com/NixOS/nixpkgs/commit/475fb75cbd69daabe27cceca614f49667f4b8abb) python312Packages.grpcio-health-checking: 1.71.0 -> 1.72.0
* [`5f81c19a`](https://github.com/NixOS/nixpkgs/commit/5f81c19aa88f8df8f5f508df1612fc91b6536115) python312Packages.grpcio-channelz: 1.71.0 -> 1.72.0
* [`99f49247`](https://github.com/NixOS/nixpkgs/commit/99f492478dfddb910cda52fd667e5e2386c909da) python312Packages.grpcio: 1.71.0 -> 1.72.0
* [`391ecdd0`](https://github.com/NixOS/nixpkgs/commit/391ecdd0083a5d2b39d60165b781f6cb0286c9a0) grpc: 1.71.0 -> 1.72.0
* [`55ded0b1`](https://github.com/NixOS/nixpkgs/commit/55ded0b17388b1965c4475ad605de4f26f844325) citrix-workspace: 24.11.0.85 -> 25.03.0.66
* [`43901723`](https://github.com/NixOS/nixpkgs/commit/43901723c8b4bc78dedcc744e2b7d9389e5a6c50) libdeflate: 1.23 -> 1.24
* [`958cbcd4`](https://github.com/NixOS/nixpkgs/commit/958cbcd4d7a3d0b9bdf6c0101bab6821bbe9ce2b) haskellPackages: remove patches merged upstream
* [`d24875ea`](https://github.com/NixOS/nixpkgs/commit/d24875eaaf98d32d664415d036c3a833681f743d) iana-etc: 20250108 -> 20250505
* [`b634edb1`](https://github.com/NixOS/nixpkgs/commit/b634edb1a4223649e85da5cdad3176cc9e379e0c) python3Minimal: make it truly minimal
* [`f3c20061`](https://github.com/NixOS/nixpkgs/commit/f3c200612bddb06bd2d016a64efb83bf6e0ebed3) fuse3: 3.16.2 -> 3.17.2
* [`8609088d`](https://github.com/NixOS/nixpkgs/commit/8609088dd0ef81d3d92695ecbee5b5d58c293bf5) bumblebee-status: python -> python3 plugins argument
* [`90432ace`](https://github.com/NixOS/nixpkgs/commit/90432ace867f926b43733962288b8b85840cd056) cmake: 3.31.6 -> 3.31.7
* [`3165b1b4`](https://github.com/NixOS/nixpkgs/commit/3165b1b4fb7001cd380247dd95788b8b34f7f8e5) kotlin: 2.1.20 -> 2.1.21
* [`ffbfd9c8`](https://github.com/NixOS/nixpkgs/commit/ffbfd9c828ec7a75fc506d952dbc6e38a9562466) rustc: ensure standard library docs are installed
* [`b06b4b5b`](https://github.com/NixOS/nixpkgs/commit/b06b4b5b8294bf393a5a633ce5178d3d916d8b87) lcevcdec: 3.3.5 -> 3.3.7
* [`112d13c5`](https://github.com/NixOS/nixpkgs/commit/112d13c5c7c83593972e786cfa9f6fcef06bdfd9) cargoSetupHook: fix setting crt-static
* [`8d022c6c`](https://github.com/NixOS/nixpkgs/commit/8d022c6c7c575843dec6b9e2c8383ddcb2d23823) compress-man-pages: optimize, use multiple cores
* [`1a716d1a`](https://github.com/NixOS/nixpkgs/commit/1a716d1ac9ad2d2c21a96c1abcdebc34f9a7ca41) haskellPackages.servant-routes: patch bug to fix test suite
* [`a6fc1b08`](https://github.com/NixOS/nixpkgs/commit/a6fc1b0875b79c2075f4a608fe1990178c2edda5) haskellPackages: mark builds failing on hydra as broken
* [`e68cfdab`](https://github.com/NixOS/nixpkgs/commit/e68cfdab68d49b90d2bf43288914cabebe849305) haskell.packages.ghc9102.ghc-lib*: allow ghc-prim == 0.12.0
* [`09317d97`](https://github.com/NixOS/nixpkgs/commit/09317d97fd052c431027a009d4b425a69c0434b2) haskell.packages.ghc9102.ghcide: patch for changed ghci interface
* [`a9a90f4b`](https://github.com/NixOS/nixpkgs/commit/a9a90f4bada71cf8ca3ccff60c40edb3fdfd53d9) openssh: Enable extra tests
* [`e258dc4b`](https://github.com/NixOS/nixpkgs/commit/e258dc4b328fae867ff6db8876c31b5dc707ac79) libxml2: 2.13.8 -> 2.14.3
* [`0f544ad2`](https://github.com/NixOS/nixpkgs/commit/0f544ad2a0250794800e6512bc78baa4bc064c4e) iana-etc: fix hash
* [`4a31be78`](https://github.com/NixOS/nixpkgs/commit/4a31be78fe9775aae39361b71cc4121a25304cd6) bundler: 2.6.8 -> 2.6.9
* [`fb4500d0`](https://github.com/NixOS/nixpkgs/commit/fb4500d095f49e53d0401632094e3c880a76a230) ruby.rubygems: 3.6.8 -> 3.6.9
* [`802c06b8`](https://github.com/NixOS/nixpkgs/commit/802c06b865f1aa7a19d052deb61ea02c723adca6) haskellPackages.selda-sqlite: unbreak
* [`76b50cbb`](https://github.com/NixOS/nixpkgs/commit/76b50cbbf100ee3857cacaf97d5595d093af223e) vim: 9.1.1336 -> 9.1.1385
* [`98652f9a`](https://github.com/NixOS/nixpkgs/commit/98652f9a901aac50c1d7780ea3507439803a3408) nixos/kernel: Allow controlling modules with attrsets
* [`028b3e14`](https://github.com/NixOS/nixpkgs/commit/028b3e1411841a5a2e53dcf1912409e7d63cc000) nixos: Use common modulesClosure in scripted and systemd initrd
* [`96fb5551`](https://github.com/NixOS/nixpkgs/commit/96fb55514f1286ae28f5dddf3fc5665306b5189e) nixos/stage-1: Add option for allowing missing modules
* [`2f48f7c0`](https://github.com/NixOS/nixpkgs/commit/2f48f7c0d6b7d46107d05be85b9dc6793c06d435) harfbuzz: default withCoreText to true on darwin
* [`d3900130`](https://github.com/NixOS/nixpkgs/commit/d3900130913dbbc1d36e81ace76f881e3e399137) cacert: avoid using unreadable inherited certificate bundle
* [`f976f173`](https://github.com/NixOS/nixpkgs/commit/f976f173f4a044237c6847bf4ced0f86fc991eaa) haskellPackages.selda-sqlite: regenerate package expression
* [`e5da9907`](https://github.com/NixOS/nixpkgs/commit/e5da99075b0a39e2c0e8fcf09a3db755d2c2b51f) build-support/meson: set crt-static for rustc
* [`3b58d0ac`](https://github.com/NixOS/nixpkgs/commit/3b58d0ac8533e58882c9b4e6e2ffe0fc4a300dbf) rustc: 1.86.0 -> 1.87.0
* [`4efa2ff7`](https://github.com/NixOS/nixpkgs/commit/4efa2ff7a1c0343a0a253fb02c7725d119a4321c) rustc: remove redundant libiconv dependency on darwin
* [`1000a826`](https://github.com/NixOS/nixpkgs/commit/1000a826ebc4b104746cb127852993ca3910efbd) buildRustPackage: remove redundant libiconv dependency on darwin
* [`bd5e71fa`](https://github.com/NixOS/nixpkgs/commit/bd5e71fad8e86ae1fb5388d0c3f5ed9f6c3877d4) nettools: apply patch for CVE-2025-46836
* [`ea1ea5ef`](https://github.com/NixOS/nixpkgs/commit/ea1ea5efa36e1fd52173380e31d09ada2beed5b7) sdl3: 3.2.12 -> 3.2.14
* [`a6f944ba`](https://github.com/NixOS/nixpkgs/commit/a6f944ba4a0826a62c13867657fc23e45eb27833) dwarfs: 0.12.3 -> 0.12.4 and enable brotli support
* [`7377f9e6`](https://github.com/NixOS/nixpkgs/commit/7377f9e6ad0b70856476194d8cc2c3ec57efd55a) Revert "file: 5.45 -> 5.46", to fix Zip files regressions
* [`3dd811c4`](https://github.com/NixOS/nixpkgs/commit/3dd811c4b9f7963a66a6cb17b4dbac5a7ce68a26) lib.types.attrNamesToTrue: unpublish temporarily
* [`4e216d50`](https://github.com/NixOS/nixpkgs/commit/4e216d5059aa8281647391da9953c7f8fa486729) haskellPackages.postgres-websockets: fix at run-time
* [`915a9a61`](https://github.com/NixOS/nixpkgs/commit/915a9a613609ae016dad0b3f8355e00cde29ddab) nodejs_22: 22.15.0 -> 22.15.1
* [`0f1cd560`](https://github.com/NixOS/nixpkgs/commit/0f1cd560b66008babd603191b0df874a8d22e988) libmanette: fix cross compilation
* [`a067794e`](https://github.com/NixOS/nixpkgs/commit/a067794eec4e6b2af87ee0a102486ea5ceb72c72) insulator2: clean up dependencies and fix structure of $out
* [`840f68eb`](https://github.com/NixOS/nixpkgs/commit/840f68ebe86891bcf520a58fdd65a406a597abf0) x2gokdriveclient: init at version 0.0.0.1-unstable-2024-09-10
* [`97e21e3f`](https://github.com/NixOS/nixpkgs/commit/97e21e3f5f7f8dbd95926b578c63df47875ef5a3) util-linux: fix mount regression
* [`119315a5`](https://github.com/NixOS/nixpkgs/commit/119315a57c07c7f71bd3d8993ad8f282c5afefc5) kexec-tools: Enable update script
* [`1e0e9561`](https://github.com/NixOS/nixpkgs/commit/1e0e9561ab7b9fbc539366e60b1f03d245186701) kexec-tools: 2.0.29 -> 2.0.31
* [`961ee670`](https://github.com/NixOS/nixpkgs/commit/961ee670b3b82bc1f3e70f6b617baaad8b4f31a4) kexec-tools: Enable zstd support
* [`2f4c7490`](https://github.com/NixOS/nixpkgs/commit/2f4c74906d9e0d3c32a3a4e1db38f20a2c1501ad) glibc: use secure_getenv for loading locale archive
* [`64e707d9`](https://github.com/NixOS/nixpkgs/commit/64e707d9f0db7ba9100fb92355d4ad6b3336d1de) tree-sitter: 0.25.3 -> 0.25.4
* [`584cbef2`](https://github.com/NixOS/nixpkgs/commit/584cbef20641d4ed7e0c31d475e717282b86903a) python3Packages.backtesting: 0.6.3 -> 0.6.4
* [`04db9fed`](https://github.com/NixOS/nixpkgs/commit/04db9fed9e8a9ef0dae2c829b0abe864e2e7f9df) qrencode: update src url, use autoreconfHook
* [`b8246ba6`](https://github.com/NixOS/nixpkgs/commit/b8246ba626f8c122e615b239985fc340d2eed27c) qrencode: remove SDL2 to fix infinite recursion in tests
* [`67c99e3e`](https://github.com/NixOS/nixpkgs/commit/67c99e3e49527776e19540302fb4547496684d11) libuv: 1.50.0 -> 1.51.0
* [`37eac179`](https://github.com/NixOS/nixpkgs/commit/37eac179b389a2e7361299139534c73f52892d4b) python312Packages.numpy: 2.2.5 -> 2.2.6
* [`4e440ec1`](https://github.com/NixOS/nixpkgs/commit/4e440ec12443885423bdf37beb5b5bc1e1ebf700) nixos/stage-2-init: support nosuid/nodev mount options for /nix/store
* [`55f22504`](https://github.com/NixOS/nixpkgs/commit/55f225049e3705cfec0454ea02ccebaf3064cd5c) nixos/tests/boot-stage2: check mount options
* [`1b18ff36`](https://github.com/NixOS/nixpkgs/commit/1b18ff36694c4d945ce45396262d2cf974079358) nixos/stage2-init: test nosuid and nodev mount options
* [`aa3e5a27`](https://github.com/NixOS/nixpkgs/commit/aa3e5a273888c3f0dffe8376f9c8be93338f66bf) nixos/stage-2-init: remove 'readOnlyNixStore' option
* [`1cc2b695`](https://github.com/NixOS/nixpkgs/commit/1cc2b695415fc1c64bee65e30ab8282c765f13b0) meson: 1.7.2 -> 1.8.0
* [`b9a3d659`](https://github.com/NixOS/nixpkgs/commit/b9a3d659b736ba1fa81a85dc49e372f52c23e50f) saxon-he: 12.6 -> 12.7
* [`e76c689a`](https://github.com/NixOS/nixpkgs/commit/e76c689a3da8ee876c4bbe7c6549da92e4bcf279) nodejs: fix dev output
* [`137a367b`](https://github.com/NixOS/nixpkgs/commit/137a367b17866f2984b266c9efa3e3c72878c69d) nvim-treesitter grammars updater: small improvements
* [`1a47b9ef`](https://github.com/NixOS/nixpkgs/commit/1a47b9efd078cb8c458e99744258138214362aae) nvim-treesitter grammars updater: avoid silent fails
* [`20d81ec4`](https://github.com/NixOS/nixpkgs/commit/20d81ec4c737eb15714ebd8925c2faaaa1d64f5c) hidapi: 0.14.0 -> 0.15.0
* [`ac120e60`](https://github.com/NixOS/nixpkgs/commit/ac120e6007cd9f3db847f07e351d93d813d3a368) protobuf: 30.2 -> 31.0
* [`aff98d44`](https://github.com/NixOS/nixpkgs/commit/aff98d4427e3d47519d5dc48db61873308f2b9a9) bats: 1.11.1 -> 1.12.0
* [`7f26fd2c`](https://github.com/NixOS/nixpkgs/commit/7f26fd2c4076649522f8c06ee5eda9601e71bf67) libavif: 1.2.1 -> 1.3.0
* [`4e5996d5`](https://github.com/NixOS/nixpkgs/commit/4e5996d5d824d5a8c0a040641908367d0e76a7c2) termbook: don't vendor Cargo.lock, shirnk lockfile patch
* [`84808705`](https://github.com/NixOS/nixpkgs/commit/84808705c2199a1225331ff512d65f422e4ad367) ofono: 2.14 -> 2.17
* [`f201c1ab`](https://github.com/NixOS/nixpkgs/commit/f201c1abead6960a0b0199c6569483a340be5f32) Fix mapscript Python package install
* [`0f51f081`](https://github.com/NixOS/nixpkgs/commit/0f51f08127916c075d19c79268636959d9df4998) libbpf: 1.5.0 -> 1.5.1
* [`c720fdc0`](https://github.com/NixOS/nixpkgs/commit/c720fdc0e7a0a8bc9cb160285197abc3126987ba) maintainers: add chrjabs
* [`fdfc65da`](https://github.com/NixOS/nixpkgs/commit/fdfc65da928f1e0d06002ed1d6cfb21316e7ec6c) rust-cbindgen: 0.28.0 -> 0.29.0
* [`9e5d98ae`](https://github.com/NixOS/nixpkgs/commit/9e5d98ae0649cfc08f58659ff7d6ea3f76c9d8dd) osmscout-server: 3.1.0 -> 3.1.5
* [`62b98a8d`](https://github.com/NixOS/nixpkgs/commit/62b98a8d5731309005f0c5c17b1f938c3690f24e) pagemon: 0.01.18 -> 0.02.05
* [`612c7050`](https://github.com/NixOS/nixpkgs/commit/612c7050764e9bfd630af3384c24f33aac9316fe) boogie: 3.5.1 -> 3.5.3
* [`0ee255ab`](https://github.com/NixOS/nixpkgs/commit/0ee255abf2c07695f8b571887b5b327ca24b97df) xterm: 397 -> 399
* [`24f44dba`](https://github.com/NixOS/nixpkgs/commit/24f44dba80075614e25f9fa15b06cbdb59d34b72) xterm: enable parallel building
* [`1120d4fa`](https://github.com/NixOS/nixpkgs/commit/1120d4faa7dcbb05c49d460396520eb81cedaad0) cryptsetup: fix tests on zfs
* [`525263cc`](https://github.com/NixOS/nixpkgs/commit/525263cc6c71d195c2237b0f150132bccb0dd86c) libarchive: 3.7.8 -> 3.8.0
* [`33c12af9`](https://github.com/NixOS/nixpkgs/commit/33c12af90d507f5a536d21a219faa8098bebd2e2) lua51Packages.libluv: 1.50.0-1 -> 1.51.0-1
* [`84794e6b`](https://github.com/NixOS/nixpkgs/commit/84794e6b39982ce300d91419753414cbcefa78fd) libadwaita: increase tests timeout to 300 seconds
* [`55e5e0aa`](https://github.com/NixOS/nixpkgs/commit/55e5e0aa0ca2e274f4de2ce6427086917bd0e88f) nextcloud*.packages.apps.nextpod: init at 0.7.7
* [`69a20593`](https://github.com/NixOS/nixpkgs/commit/69a20593ac168b44ef3c9f9037d3a795fc849cda) highlight: 4.15 -> 4.16
* [`d7211731`](https://github.com/NixOS/nixpkgs/commit/d7211731d89af9d8930fab948a1a372e15119a02) nodejs_22: 22.15.1 -> 22.16.0
* [`4132cedd`](https://github.com/NixOS/nixpkgs/commit/4132cedd58c01258ff6e15db6c3ee8b16250b81e) gtk-layer-shell: 0.9.1 -> 0.9.2
* [`c885eaa1`](https://github.com/NixOS/nixpkgs/commit/c885eaa12fb42c6805e43b8dc10b9f36510bf70c) gpgme: 1.24.2 -> 1.24.3
* [`8a8b09cd`](https://github.com/NixOS/nixpkgs/commit/8a8b09cd1e8f69fe10b7aed1b48454cf18d3d9e2) python3Packages.click-option-group: clean up disabledTests
* [`608422bd`](https://github.com/NixOS/nixpkgs/commit/608422bd4ba434d02278602bc74c46d10bfde2ba) libjpeg: drop freeimage support
* [`1cb94639`](https://github.com/NixOS/nixpkgs/commit/1cb94639f5594f2f6691e9b077865026e6d4f718) rustc: pass the linker for the target platform first
* [`953c2eb0`](https://github.com/NixOS/nixpkgs/commit/953c2eb039cc42bc48683cfa5255f51192d6142c) qt5: 5.15.16 -> 5.15.17
* [`737d1596`](https://github.com/NixOS/nixpkgs/commit/737d15966b5d0ef66b813d780e0b1dc65867f04f) pipewire: 1.4.2 -> 1.4.3
* [`57282c6a`](https://github.com/NixOS/nixpkgs/commit/57282c6a1c914595d8dbd472577985c765763ddd) sdl3: reenable OpenGL on darwin
* [`cbe6305d`](https://github.com/NixOS/nixpkgs/commit/cbe6305d282f78627ef1fb8e03da332ae3308f97) vim: 9.1.1336 -> 9.1.1401
* [`7df377ec`](https://github.com/NixOS/nixpkgs/commit/7df377ecf54b9399f49c01fee665ca749273095d) valgrind: 3.24.0 -> 3.25.1
* [`95c782bc`](https://github.com/NixOS/nixpkgs/commit/95c782bcde91b0b7c25230ed632944a413746766) audit-tempdir.sh: optimize - execute checks in parallel
* [`75b9701d`](https://github.com/NixOS/nixpkgs/commit/75b9701d01dd611d0c74ac128d254f49a60d1c2b) taplo: 0.9.3 -> 0.10.0
* [`1381c111`](https://github.com/NixOS/nixpkgs/commit/1381c1114a41ca19a5fa674993dbe5b449c7a0c6) minizinc: 2.9.2 -> 2.9.3
* [`033d93e7`](https://github.com/NixOS/nixpkgs/commit/033d93e793a5dfa4abd900e36cfabc038827af0f) python3: 3.12.10 -> 3.13.3
* [`f5cb1b9c`](https://github.com/NixOS/nixpkgs/commit/f5cb1b9c250b6ec4836b34c934215fd925761f95) python313Packages.packaging: 24.2 -> 25.0
* [`427a4399`](https://github.com/NixOS/nixpkgs/commit/427a4399344d2b3cb9bc7938e84c4ee753c40ce8) python313Packages.setuptools: 78.1.0 -> 80.7.1
* [`f5c2155a`](https://github.com/NixOS/nixpkgs/commit/f5c2155a59efd55004ee8ca4e50f22c9485e5a32) python313Packages.setuptools-scm: 8.2.0 -> 8.3.1
* [`98b0485b`](https://github.com/NixOS/nixpkgs/commit/98b0485b0f1ebf67c05960add569615251572424) python313Packages.hypothesis: 6.130.12 -> 6.131.17
* [`c9659ef5`](https://github.com/NixOS/nixpkgs/commit/c9659ef5bcd594196a48a5be09fe93c1049a943b) python313Packages.poetry-core: 2.1.2 -> 2.1.3
* [`e2daab56`](https://github.com/NixOS/nixpkgs/commit/e2daab564dfa487a3124e0ce325515e0ae606558) python313Packages.meson-python: 0.17.1 -> 0.18.0
* [`b23588a0`](https://github.com/NixOS/nixpkgs/commit/b23588a0e20d8346a69dfbf4d46a4b1fe07a0e48) python313Packages.pip: 25.0.1 -> 25.1.1
* [`4c81a6ae`](https://github.com/NixOS/nixpkgs/commit/4c81a6ae8e248684311875d73635182660177b46) python313Packages.meson-python: refactor and adopt
* [`5086b18f`](https://github.com/NixOS/nixpkgs/commit/5086b18f0ddaf2a4809df80544e2163f7a424381) python313Packages.lxml: 5.3.1 -> 5.4.0
* [`6729f111`](https://github.com/NixOS/nixpkgs/commit/6729f1111f98ce4ca6b9424662c0268a08ed84c4) python313Packages.certifi: 2025.01.31 -> 2025.04.26
* [`6f92d19e`](https://github.com/NixOS/nixpkgs/commit/6f92d19ea71d70979dab333c10cf2827a944905f) python313Packages.sqlalchemy: 2.0.40 -> 2.0.41
* [`2da4301a`](https://github.com/NixOS/nixpkgs/commit/2da4301a229c08b546d17b9ef366919563ec5f83) python313Packages.urllib3: 2.3.0 -> 2.4.0
* [`c37ee23f`](https://github.com/NixOS/nixpkgs/commit/c37ee23f31df0c236bfd45d3479180e0b0e21e70) python313Packages.charset-normalizer: 3.4.1 -> 3.4.2
* [`aebf2917`](https://github.com/NixOS/nixpkgs/commit/aebf2917d814af9b03f3f803bc0ae08d3102f8dd) maturin: 1.8.3 -> 1.8.6
* [`622f9253`](https://github.com/NixOS/nixpkgs/commit/622f92538c2f73ccf18e2e60fc82b3e370ac7ace) python313Packages.cryptography: 44.0.2 -> 44.0.3
* [`13990d0c`](https://github.com/NixOS/nixpkgs/commit/13990d0cd59d0ee6539376f9b14c170930f5f964) python313Packages.pydantic-core: 2.33.2 -> 2.33.2
* [`7072ecff`](https://github.com/NixOS/nixpkgs/commit/7072ecff01b9d3f067e753faccb6b500c981d000) python313Packages.importlib-metadata: 8.6.1 -> 8.7.0
* [`9ed0a391`](https://github.com/NixOS/nixpkgs/commit/9ed0a391e0bc34f1115a2e8ddeab890bbe83fa6f) cpython: drop leftover CVE-2025-0398 patch
* [`e3a83ef1`](https://github.com/NixOS/nixpkgs/commit/e3a83ef13721f46dc880c90d3e681d698e4812c8) python313Packages.pydantic: 2.11.1 -> 2.11.4
* [`bc4700d3`](https://github.com/NixOS/nixpkgs/commit/bc4700d33d51ed0abba172153cae87116163d25d) python313Packages.typer: 0.15.2 -> 0.15.4
* [`eda65094`](https://github.com/NixOS/nixpkgs/commit/eda65094fb6a4be51fb3fcafe79568035deb68b8) python313Packages.aiodns: 3.3.0 -> 3.4.0
* [`e84aa1bb`](https://github.com/NixOS/nixpkgs/commit/e84aa1bb7765de77b4e9f428cd811f0689c44775) python313Packages.starlette: 0.46.1 -> 0.46.2
* [`b1de0692`](https://github.com/NixOS/nixpkgs/commit/b1de06920c50701b445a9c56284a6bb401f2574d) python313Packages.s3transfer: 0.11.2 -> 0.12.0
* [`a212dc39`](https://github.com/NixOS/nixpkgs/commit/a212dc39d65f303a6bf1e6501c6030c4ab7a2c38) python313Packages.pycares: 4.5.0 -> 4.8.0
* [`a3c1188c`](https://github.com/NixOS/nixpkgs/commit/a3c1188c2c5814353f5e2c07a032a66a1801ce5d) python313Packages.aiohttp: 3.11.15 -> 3.11.18
* [`3ee1b8ae`](https://github.com/NixOS/nixpkgs/commit/3ee1b8aee4f84ccd5a3d8504acbfeb180f91f813) python313Packages.setuptools-rust: 1.11.0 -> 1.11.1
* [`ac8a061b`](https://github.com/NixOS/nixpkgs/commit/ac8a061b0392c2b3866f1387dca29e69df6c217b) python313Packages.orjson: 3.10.16 -> 3.10.18
* [`f05729b9`](https://github.com/NixOS/nixpkgs/commit/f05729b94c0191e5e6d7963ecef72962edc9d751) python313Packages.pendulum: 3.0.0 -> 3.1.0
* [`e49b2591`](https://github.com/NixOS/nixpkgs/commit/e49b2591edb7ac2434c976c6bec3639f08b3449b) python313Packages.fsspec: 2025.3.1 -> 2025.3.2
* [`cefa1271`](https://github.com/NixOS/nixpkgs/commit/cefa127140a08ba35eca674aac38e309c005a72f) python313Packages.platformdirs: 4.3.7 -> 4.3.8
* [`b2fc3a59`](https://github.com/NixOS/nixpkgs/commit/b2fc3a5923ff22751764930439e67582786e074c) python313Packages.wheel: 0.45.1 -> 0.46.1
* [`6f6c8598`](https://github.com/NixOS/nixpkgs/commit/6f6c859859ee0ec46eeb67ab1e8cd8b11a9f63ab) python313Packages.pluggy: 1.5.0 -> 1.6.0
* [`5a8f3f73`](https://github.com/NixOS/nixpkgs/commit/5a8f3f7376df8a97a1dd0eb0abcb91dfb44a1596) python313Packages.virtualenv: 20.30.0 -> 20.31.2
* [`374fc1bf`](https://github.com/NixOS/nixpkgs/commit/374fc1bf1246e37546b9b47ba0d6e9c70023e288) python313Packages.yarl: 1.18.3 -> 1.20.0
* [`22918764`](https://github.com/NixOS/nixpkgs/commit/22918764aa9aeedf213f6f837f9c3c40ffed5c32) python313Packages.moto: 5.1.1 -> 5.1.4
* [`9f76f027`](https://github.com/NixOS/nixpkgs/commit/9f76f027c5f7692278438e70a64c206e5d066747) python313Packages.frozenlist: 1.5.0 -> 1.6.0
* [`d4c208df`](https://github.com/NixOS/nixpkgs/commit/d4c208df8ff9390695507e53c4d41ee1ff6faa10) python313Packages.greenlet: 3.2.1 -> 3.2.2
* [`c7272045`](https://github.com/NixOS/nixpkgs/commit/c7272045fb2ec59fec62fb96767522b71d314bfc) python313Packages.soupsieve: 2.6 -> 2.7
* [`62beefc5`](https://github.com/NixOS/nixpkgs/commit/62beefc5f4e5f0d0942f87c55c34449ff367da60) python313Packages.eventlet: 0.38.2 -> 0.40.0
* [`db613776`](https://github.com/NixOS/nixpkgs/commit/db61377684aaddbbf259c0f10dea2e7ab6ec6856) python313Packages.more-itertools: 10.6.0 -> 10.7.0
* [`896c65b7`](https://github.com/NixOS/nixpkgs/commit/896c65b7ae6b30b9722fc79a95a9a49f626bf277) python313Packages.exceptiongroup: 1.2.2 -> 1.3.0
* [`dd593861`](https://github.com/NixOS/nixpkgs/commit/dd59386100be9769a09a3ac71555429bf669cdfd) python313Packages.aiobotocore: 2.19.0 -> 2.22.0
* [`84e4eb2c`](https://github.com/NixOS/nixpkgs/commit/84e4eb2c4c39f5ac9e690974c43165854d956dcc) python313Packages.trove-classifiers: 2025.3.19.19 -> 2025.5.9.12
* [`93663970`](https://github.com/NixOS/nixpkgs/commit/9366397088abc6b09b3c618e2e847ef48f0549be) python313Packages.tenacity: 9.0.0 -> 9.1.2
* [`49920274`](https://github.com/NixOS/nixpkgs/commit/49920274c30d562fca27a6797d6ba3b61c0e24fb) python313Packages.rpds-py: 0.24.0 -> 0.25.0
* [`98f9db9f`](https://github.com/NixOS/nixpkgs/commit/98f9db9f28478fc3c14b57422b06457bec719174) python313Packages.jsonschema-specifications: 2024.10.1 -> 2025.4.1
* [`9e134b7e`](https://github.com/NixOS/nixpkgs/commit/9e134b7e12876d03037a4efa603a47540ba36ea4) python313Packages.msal: 1.32.0 -> 1.32.3
* [`a6c4020d`](https://github.com/NixOS/nixpkgs/commit/a6c4020d58bbed45451e9eec4144cf6405fd3d0e) python313Packages.dill: 0.3.9 -> 0.4.0
* [`04b39706`](https://github.com/NixOS/nixpkgs/commit/04b397067a4c04d5506bca1b0d6b4bea9764ada2) python313Packages.scikit-build-core: 0.11.1 -> 0.11.3
* [`37ad7f08`](https://github.com/NixOS/nixpkgs/commit/37ad7f08092621965ce8b78e90bf4af6319995b9) python313Packages.pyzmq: 26.3.0 -> 26.4.0
* [`94b14d60`](https://github.com/NixOS/nixpkgs/commit/94b14d60139e0eb2752495b87274448884b73d0e) python313Packages.snowflake-connector-python: 3.14.0 -> 3.15.0
* [`c3eb1a78`](https://github.com/NixOS/nixpkgs/commit/c3eb1a78b2f6ffce3810c7f0114041222f122346) python313Packages.contourpy: 1.3.1 -> 1.3.2
* [`7bff2c82`](https://github.com/NixOS/nixpkgs/commit/7bff2c82eabe7765dd0c6b6d8dede80eddf7e890) python313Packages.joblib: 1.4.2 -> 1.5.0
* [`eaad77b7`](https://github.com/NixOS/nixpkgs/commit/eaad77b77dac138dd11776f8699565b97fbfd1ef) python313Packages.prompt-toolkit: 3.0.50 -> 3.0.51
* [`8d8f2fb2`](https://github.com/NixOS/nixpkgs/commit/8d8f2fb2e4227a6a0a54a876e764510ccd569367) python313Packages.uvicorn: 0.34.0 -> 0.34.2
* [`2a276b78`](https://github.com/NixOS/nixpkgs/commit/2a276b78f443e2dcbbafcdcc69f7c2bf9bcc8e61) python313Packages.matplotlib: 3.10.1 -> 3.10.3
* [`f76585cc`](https://github.com/NixOS/nixpkgs/commit/f76585cc3f121405aebdfbf47be81561e6b2c548) python313Packages.flask: 3.1.0 -> 3.1.1
* [`08ebc818`](https://github.com/NixOS/nixpkgs/commit/08ebc81894135c3dc516fcb69dc8c561cc67c20f) python313Packages.rich-toolkit: 0.14.1 -> 0.14.6
* [`524c7525`](https://github.com/NixOS/nixpkgs/commit/524c7525c499e146d60334e2ac0a4b65c6b7e18d) python313Packages.redis: 5.2.1 -> 6.1.0
* [`5158e4b7`](https://github.com/NixOS/nixpkgs/commit/5158e4b76f95d0d89e144ebd57309818787e1788) python313Packages.pytest-cov: 6.1.0 -> 6.1.1
* [`af444d6b`](https://github.com/NixOS/nixpkgs/commit/af444d6b25f07ec22960c7155e421b7d448275f6) python313Packages.openai: 1.78.1 -> 1.79.0
* [`2b9fac83`](https://github.com/NixOS/nixpkgs/commit/2b9fac83e374815209c4cc2ff3390484f14eb562) python313Packages.termcolor: 3.0.0 -> 3.1.0
* [`2a759fb1`](https://github.com/NixOS/nixpkgs/commit/2a759fb1bd0993f05769a27f0c67276263cf62c0) python313Packages.mako: 1.3.9 -> 1.3.10
* [`e4926024`](https://github.com/NixOS/nixpkgs/commit/e492602493a85cea2fe6265bf351beaaf3c5d469) python313Packages.prometheus-client: 0.21.1 -> 0.22.0
* [`7295f23b`](https://github.com/NixOS/nixpkgs/commit/7295f23bc863f2d5d4fe71256264622587b3f955) python313Packages.sympy: 1.13.3 -> 1.14.0
* [`6643bc08`](https://github.com/NixOS/nixpkgs/commit/6643bc081e6a8a7d4a9d986d0f08e945c50c6e74) python313Packages.multiprocess: 0.70.17 -> 0.70.18
* [`2dec6976`](https://github.com/NixOS/nixpkgs/commit/2dec6976be6fbc9379e9a8bca673f9c9ba3e7c78) python313Packages.argcomplete: 3.5.3 -> 3.6.2
* [`49877bdb`](https://github.com/NixOS/nixpkgs/commit/49877bdbed9e89d43066d5011b4f9112341b96e3) python313Packages.pycryptodome: 3.21.0 -> 3.22.0
* [`788cccbf`](https://github.com/NixOS/nixpkgs/commit/788cccbfefd9fdae27b3f58550dcf15f9ada317c) python313Packages.pymongo: 4.11.3 -> 4.13.0
* [`c4ba9d6c`](https://github.com/NixOS/nixpkgs/commit/c4ba9d6c8479837845a7062a9043639e0fffcf9a) python313Packages.shapely: 2.0.7 -> 2.1.0
* [`613f9854`](https://github.com/NixOS/nixpkgs/commit/613f98541f45470910998331e6d915d7a640b686) python313Packages.lz4: 4.4.3 -> 4.4.4
* [`3f426c47`](https://github.com/NixOS/nixpkgs/commit/3f426c475c0d76b3e9d50a0bfe6244537d7785de) python313Packages.setproctitle: 1.3.5 -> 1.3.6
* [`245af4fa`](https://github.com/NixOS/nixpkgs/commit/245af4fad4ca42a93c9987272a01e5e973a617f2) python313Packages.gcsfs: 2025.3.1 -> 2025.3.2
* [`df01bab1`](https://github.com/NixOS/nixpkgs/commit/df01bab147e0a6413bfc552e53d84b46d034f0c1) python313Packages.mistune: 3.1.2 -> 3.1.3
* [`c12a1541`](https://github.com/NixOS/nixpkgs/commit/c12a15410d13c5078bb46066d099e9de89c908b3) python313Packages.pydantic-settings: 2.8.1 -> 2.9.1
* [`79457958`](https://github.com/NixOS/nixpkgs/commit/79457958d36263dfe8adbba76f706441351b60bb) python313Packages.elasticsearch: 8.17.2 -> 9.0.1
* [`7accf5e8`](https://github.com/NixOS/nixpkgs/commit/7accf5e8cbc74312ee93352e75349325012cb146) python313Packages.cattrs: 24.1.2 -> 24.1.3
* [`e7f0482c`](https://github.com/NixOS/nixpkgs/commit/e7f0482cf0b69936cac62a140e09c6a51a041a22) python313Packages.astroid: 3.3.8 -> 3.3.10
* [`8e706436`](https://github.com/NixOS/nixpkgs/commit/8e706436324e49ca9f24a51c87edfed3e3285f8f) python313Packages.deepdiff: 8.4.1 -> 8.5.0
* [`4cf1a47b`](https://github.com/NixOS/nixpkgs/commit/4cf1a47b3a3ffbc527b00fb1a8df6dd1db0b35b9) python313Packages.absl-py: 2.2.1 -> 2.2.2
* [`9f684e94`](https://github.com/NixOS/nixpkgs/commit/9f684e9432c38ed62f27fc6441aa1b691c74c07f) python313Packages.json5: 0.10.0 -> 0.12.0
* [`7f419085`](https://github.com/NixOS/nixpkgs/commit/7f4190857cdcee1a74be89f099fe75e4cf0442c1) python313Packages.python-telegram-bot: 22.0 -> 22.1
* [`13050a72`](https://github.com/NixOS/nixpkgs/commit/13050a72a9bb555a9f823632b9139f43c6b958e5) python313Packages.pylint: 3.3.6 -> 3.3.7
* [`af0a7f4b`](https://github.com/NixOS/nixpkgs/commit/af0a7f4bd080a6edb83d4c9409a00a801a349ae1) python313Packages.faker: 37.1.0 -> 37.3.0
* [`38c27141`](https://github.com/NixOS/nixpkgs/commit/38c2714181efb47dd95d57baa45e84b951349be9) python313Packages.cryptography: 44.0.3 -> 45.0.2
* [`0b35082b`](https://github.com/NixOS/nixpkgs/commit/0b35082b65047fcdcc9c9c826755a8a0f1d9b250) python313Packages.tox: 4.23.2 -> 4.26.0
* [`281143fd`](https://github.com/NixOS/nixpkgs/commit/281143fda6f76431349c4474999ef3890e1361f5) python313Packages.trio: 0.29.0 -> 0.30.0
* [`fea291d4`](https://github.com/NixOS/nixpkgs/commit/fea291d42a72c5220f88c10671d867fb208b1d5f) hotdoc: 0.15 -> 0.17.4
* [`6c56a93c`](https://github.com/NixOS/nixpkgs/commit/6c56a93c9d6ca60ea0909354388c94b9f4dd55c6) python313Packages.pytest-rerunfailures: 15.0 -> 15.1
* [`8f87882e`](https://github.com/NixOS/nixpkgs/commit/8f87882ee365e2b623ed243bb44052d45195c178) python313Packages.ijson: 3.3.0 -> 3.4.0
* [`1eaa0126`](https://github.com/NixOS/nixpkgs/commit/1eaa01262424944afe4d3780430cfbd2927c9a6d) python313Packages.pycurl: 7.45.3-unstable-2024-10-17 -> 7.45.6
* [`61c85d07`](https://github.com/NixOS/nixpkgs/commit/61c85d0744f6b74155f13321fd5a8da1d93f0d6a) python313Packages.humanize: 4.12.2 -> 4.12.3
* [`22d0ab98`](https://github.com/NixOS/nixpkgs/commit/22d0ab98b632fd88b2809cc06b3f16f46165d8f1) python313Packages.kombu: 5.5.2 -> 5.5.3
* [`3a1f6bf9`](https://github.com/NixOS/nixpkgs/commit/3a1f6bf9f97449abc4eb0675d0f2851f4c8c73b3) python3Packages.google-auth: build from source, add maintainer
* [`081054f5`](https://github.com/NixOS/nixpkgs/commit/081054f557ec8fdbb9d22c9c12886f2d6a001fc4) python3Packages.google-auth: 2.38.0 -> 2.40.1
* [`449d32ac`](https://github.com/NixOS/nixpkgs/commit/449d32ac28d600ebc16ed13095a6574832a2237c) python3Packages.google-auth-httplib2: build from source, add maintainer
* [`2b8d4e08`](https://github.com/NixOS/nixpkgs/commit/2b8d4e084cc1bcf23ade42416340640e26d35172) python3Packages.google-auth-oauthlib: build from source, add maintainer
* [`ec4806c3`](https://github.com/NixOS/nixpkgs/commit/ec4806c346c3f8091632368e7ba5cb754aeba3ba) python3Packages.google-auth-oauthlib: 1.2.1 -> 1.2.2
* [`ff32a6bd`](https://github.com/NixOS/nixpkgs/commit/ff32a6bd01a1530312b2e9bc191742be8bb7afe8) python313Packages.snowballstemmer: 2.2.0 -> 3.0.1
* [`9a84aaa8`](https://github.com/NixOS/nixpkgs/commit/9a84aaa850a4bace34d0b85c2a0c4a569ee0034d) python313Packages.brotli: use pep517 builder
* [`5d7ad53c`](https://github.com/NixOS/nixpkgs/commit/5d7ad53c1c459c83e49c5ac02b17a42336166823) python313Packages.pytest-django: 4.10.0 -> 4.11.1
* [`1160e077`](https://github.com/NixOS/nixpkgs/commit/1160e07739ec5bec421412f115d2c317d9120e22) python313Packages.google-auth; disable failing test
* [`52ccfdfb`](https://github.com/NixOS/nixpkgs/commit/52ccfdfbcc9f46f467742d7fb9613c6425fa81c0) redisTestHook: enable debug and module commands
* [`ab741ed7`](https://github.com/NixOS/nixpkgs/commit/ab741ed74193d574dc388adc34584c244d6015d6) python313Packages.valkey: init at 6.1.0
* [`aba99cbe`](https://github.com/NixOS/nixpkgs/commit/aba99cbeb4d5a233fe62f12274c2c35308b2eba5) python313Packages.limits: 4.0.1 -> 5.2.0
* [`41f6c5a3`](https://github.com/NixOS/nixpkgs/commit/41f6c5a37d9446a0800d8d5d50ee3286d685ab69) python313Packages.dacite: 1.8.1 -> 1.9.2
* [`1281d268`](https://github.com/NixOS/nixpkgs/commit/1281d26886ea5586f28f3b2666eda3520274cbe7) python313Packages.marshmallow-oneofschema: 3.1.1 -> 3.2.0
* [`afe387e9`](https://github.com/NixOS/nixpkgs/commit/afe387e98a180ad91eaaf23b2d5c943fb8b3be05) python313Packages.flask-cors: 5.0.1 -> 6.0.0
* [`9b6947f0`](https://github.com/NixOS/nixpkgs/commit/9b6947f0b648c12ee3e42d086293d09e38c04428) python313Packages.psycopg: 3.2.8 -> 3.2.9
* [`900e6d64`](https://github.com/NixOS/nixpkgs/commit/900e6d643951b87317e1bdaf942d949124a07b85) python313Packages.pytest-timeout: 2.3.1 -> 2.4.0
* [`ded89ddb`](https://github.com/NixOS/nixpkgs/commit/ded89ddbdf0b1339ff056e51ecf47c7937aef0d2) python313Packages.elastic-transport: 8.17.0 -> 8.17.1
* [`27bb003a`](https://github.com/NixOS/nixpkgs/commit/27bb003a0b225f7f336ff2553dd6f1f225dba680) python313Packages.makefun: 1.15.6 -> 1.16.0
* [`a43342bf`](https://github.com/NixOS/nixpkgs/commit/a43342bf5cddb24193f78cbe98dbf9805ff2c31f) python313Packages.validators: 0.34.0 -> 0.35.0
* [`1efd0491`](https://github.com/NixOS/nixpkgs/commit/1efd04912d6c39269fe4280b1df457623d87ec19) python313Packages.python-jose: fix cryptography 45.0 compat
* [`90b8e825`](https://github.com/NixOS/nixpkgs/commit/90b8e8257816c450b854bcfb870946d4731585e6) python313Packages.pydot: 3.0.4 -> 4.0.0
* [`bb575180`](https://github.com/NixOS/nixpkgs/commit/bb5751800289a878181efff65a5270d35ed653c6) python313Packages.cryptography: remove leftover python3.9 conditional
* [`a86cdb2e`](https://github.com/NixOS/nixpkgs/commit/a86cdb2e4254624a108bfb55fee9e5728999fa88) python313Packages.pypdf: 5.4.0 -> 5.5.0
* [`a82025f0`](https://github.com/NixOS/nixpkgs/commit/a82025f0ce0be4bb116bfef331c4c21e863a5e96) python313Packages.pyproject-api: 1.9.0 -> 1.9.1
* [`3ed91826`](https://github.com/NixOS/nixpkgs/commit/3ed91826813d4bd9d2116a741aa551aa3fad1164) python313Packages.jira: 3.9.4 -> 3.10.1
* [`92fae8c6`](https://github.com/NixOS/nixpkgs/commit/92fae8c6a9e2e487d4c3588ade0ca7885e27890e) python313Packages.pyicu: 2.15 -> 2.15.2
* [`ed4b103f`](https://github.com/NixOS/nixpkgs/commit/ed4b103f2b9d2477320f53a7a84c89a402c84bf1) python313Packages.phonenumbers: 9.0.2 -> 9.0.5
* [`69e90de3`](https://github.com/NixOS/nixpkgs/commit/69e90de3b2e57a7d6f4e1c539d18e015efd4b91f) python313Packages.markdownify: 0.14.1 -> 1.1.0
* [`0dbb0269`](https://github.com/NixOS/nixpkgs/commit/0dbb0269f3d980ceb0e16da2777286b3ed099a4d) python313Packages.datetime: 5.4 -> 5.5
* [`04516b38`](https://github.com/NixOS/nixpkgs/commit/04516b3825b403e3be6928be19d8fd38a227bf96) python313Packages.fastavro: 1.10.0 -> 1.11.1
* [`7232ef34`](https://github.com/NixOS/nixpkgs/commit/7232ef34c65ff3f0c8d8a6eeed9d7e728a0f10c7) python313Packages.deltalake: 0.20.1 -> 0.25.5
* [`4acc7bf2`](https://github.com/NixOS/nixpkgs/commit/4acc7bf268d0a79986d013d636b7af5788a9eee0) python313Packages.accelerate: 1.5.2 -> 1.7.0
* [`aed4e2c7`](https://github.com/NixOS/nixpkgs/commit/aed4e2c7f66efb859dac283ab900fcb1cd72e687) python313Packages.plotly: 5.24.1 -> 6.1.0
* [`5e4c331a`](https://github.com/NixOS/nixpkgs/commit/5e4c331ae751b0d5b42db958419ed40ea9038300) python313Packages.einops: 0.8.0 -> 0.8.1
* [`ed8cb36b`](https://github.com/NixOS/nixpkgs/commit/ed8cb36b0fd7d7f8f23fd81cc2152cf86bcbcb10) python313Packages.geopandas: fix compat with shapely 2.1.0
* [`fdd0d572`](https://github.com/NixOS/nixpkgs/commit/fdd0d572497c5987c078883ed7fc9a2ec4aa9b2f) python313Packages.pymdown-extensions: 10.14.3 -> 10.15
* [`479d262d`](https://github.com/NixOS/nixpkgs/commit/479d262df91ed51ba691e60652ffae925f11965d) python313Packages.pandera: 0.23.1 -> 0.24.0
* [`7bbd71c7`](https://github.com/NixOS/nixpkgs/commit/7bbd71c71bb6f59b8d790b3283aea3cbeeb814e8) python313Packages.tifffile: 2025.3.30 -> 2025.5.10
* [`f44d9776`](https://github.com/NixOS/nixpkgs/commit/f44d9776ef6358db57b04f9646a6be0c32a43a89) python313Packages.stripe: 11.6.0 -> 12.1.0
* [`378ab603`](https://github.com/NixOS/nixpkgs/commit/378ab6034c0bd12bcf8850b97bf9a6cdf7a57988) python313Packages.xarray: 2025.01.2 -> 2025.04.0
* [`a02be6fb`](https://github.com/NixOS/nixpkgs/commit/a02be6fbb0be06f25564c0192a3dde3bdfaf1163) python313Packages.pgvector: 0.3.6 -> 0.4.1
* [`34bc1e40`](https://github.com/NixOS/nixpkgs/commit/34bc1e401bca40eb1acc0064ea1055f87762744f) python313Packages.pycryptodome: 3.22.0 -> 3.23.0
* [`5c05b6ca`](https://github.com/NixOS/nixpkgs/commit/5c05b6cae4d4e508372933f54618e9ec45202af8) python313Packages.appnope: 0.1.3 -> 0.1.4
* [`c465b272`](https://github.com/NixOS/nixpkgs/commit/c465b2728cc989218d766423d3d2039b5b02d4e1) python313Packages.reportlab: 4.4.0 -> 4.4.1
* [`e40d59f4`](https://github.com/NixOS/nixpkgs/commit/e40d59f4db66111cdb01c487f972a9e84a39f38d) python313Packages.pyhcl: 0.4.4 -> 0.4.5
* [`23f8a02f`](https://github.com/NixOS/nixpkgs/commit/23f8a02f15e93de853f60052264b22eabc8db9af) python313Packages.bottle: 0.13.2 -> 0.13.3
* [`a28e04cb`](https://github.com/NixOS/nixpkgs/commit/a28e04cbefe3a75d5bfaf961eac297c4567be12f) python313Packages.pyroute2: 0.8.1 -> 0.9.2
* [`9752b9a9`](https://github.com/NixOS/nixpkgs/commit/9752b9a9a4c08eccaba49b26d896ee2428b8e890) python313Packages.onnx: 1.17.0 -> 1.18.0
* [`1627f0a6`](https://github.com/NixOS/nixpkgs/commit/1627f0a62d0a346c0f64171dcbc7aa2a3e931d4c) Revert "python313Packages.pip: 25.0.1 -> 25.1.1"
* [`626f19d3`](https://github.com/NixOS/nixpkgs/commit/626f19d38539d490c82a83332cc7846d5b2d82bb) awsebcli: remove future, relax packaging
* [`63c417cc`](https://github.com/NixOS/nixpkgs/commit/63c417ccf61790025085ee42775dcfacb4092b3e) python313Packages.aiohasupervisor: relax setuptools constraint
* [`6f707fd7`](https://github.com/NixOS/nixpkgs/commit/6f707fd717d82013e1131eae12f540a9b94dcd64) python313Packages.fido2: relax cryptography constraint
* [`8dc61ba7`](https://github.com/NixOS/nixpkgs/commit/8dc61ba7bfb364962667a197ae93c5ed09912267) python3Packages.grandalf: remove future
* [`2d8a302b`](https://github.com/NixOS/nixpkgs/commit/2d8a302b342e035aeb005938103cf773ad63d882) python313Packages.fakeredis: 2.26.2 -> 2.29.0
* [`7ac34f42`](https://github.com/NixOS/nixpkgs/commit/7ac34f42d243a6174f10c385c7491e5a247d041e) python313Packages.confluent-kafka: 2.8.0 -> 2.10.0
* [`1b6fbe58`](https://github.com/NixOS/nixpkgs/commit/1b6fbe58cfc857eea55b57a5eec9e633604946ae) python313Packages.llvmlite: pin to llvm 16
* [`cab7d95e`](https://github.com/NixOS/nixpkgs/commit/cab7d95ede71e8a987e8286013c00e0d4eb3904e) python313Packages.numba: 0.61.0 -> 0.61.2
* [`ec1d0ce7`](https://github.com/NixOS/nixpkgs/commit/ec1d0ce70ea836779baffdf53dd15c03fae28266) paperless-ngx: relax redis constraint
* [`0717d9d0`](https://github.com/NixOS/nixpkgs/commit/0717d9d0827fe1f977995c9e9317d1375123f593) arouteserver: relax packaging constraint
* [`e4e80cae`](https://github.com/NixOS/nixpkgs/commit/e4e80cae4a74d3de569ceb247b973a1b7bf13498) python3Packages.googleapis-common-protos: refactor
* [`c2d0bf6a`](https://github.com/NixOS/nixpkgs/commit/c2d0bf6a9d6f5dc1ceff11d9e410154fba458e12) python3Packages.googleapis-common-protos: refactor: 1.69.2 -> 1.70.0
* [`8a55f791`](https://github.com/NixOS/nixpkgs/commit/8a55f791873fb0b92a8aca21450888b71fee264a) python3Packages.google-api-python-client: build from source, add maintainer
* [`4a02374a`](https://github.com/NixOS/nixpkgs/commit/4a02374a8d7da2d3cfdc28138fc0fd781db35095) python3Packages.google-api-python-client: 2.166.0 -> 2.169.0  
* [`89200676`](https://github.com/NixOS/nixpkgs/commit/89200676c40db7ae0fec71f98f0f640bea9113dc) gixy: fix python3.13 compat
* [`c4469f9b`](https://github.com/NixOS/nixpkgs/commit/c4469f9b92813d267fe10556537741313f44fe02) python313Packages.textfsm: 1.1.3 -> 2.1.0
* [`5b089ae6`](https://github.com/NixOS/nixpkgs/commit/5b089ae6ba6f9b63c3f2b22f5fd88a852eb7f1ec) python313Packages.ntc-templates: relax textfsm constraint
* [`fe7d1f61`](https://github.com/NixOS/nixpkgs/commit/fe7d1f61ed449316c044b0f23e10d5228593cbe3) python313Packages.shlib: 1.6 -> 1.7
* [`1634b4ac`](https://github.com/NixOS/nixpkgs/commit/1634b4ac4719b38bafffeacae2ecd02d99aaa85e) python313Packages.bibtexparser: 1.4.3 -> 2.0.0b8
* [`6177fa3e`](https://github.com/NixOS/nixpkgs/commit/6177fa3e79c136a199b922a5a056743ad30d4891) python313Packages.clldutils: 3.21.0 -> 3.24.2
* [`c4fcee7f`](https://github.com/NixOS/nixpkgs/commit/c4fcee7fec3b2a580ba27aa7b9de2a9f9a47a55d) python313Packages.ansible-runner: 2.4.0 -> 2.4.1
* [`004f8eb7`](https://github.com/NixOS/nixpkgs/commit/004f8eb75372fbf184c084711df2f4a31d95c4a8) python3Packages.curve25519-donna: drop
* [`daf89881`](https://github.com/NixOS/nixpkgs/commit/daf89881f110e776fcbb86612b2a30e4dfe67967) httpie: update disabled tests
* [`c3849d1a`](https://github.com/NixOS/nixpkgs/commit/c3849d1a781bd2d92d1110f41055cd672dbed01d) python313Packages.stringly: 1.0b2 -> 1.0b3
* [`4cccec15`](https://github.com/NixOS/nixpkgs/commit/4cccec15af91fe1ece0205de5a9e5b00449fa9cb) python313Packages.nutils: 8.8 -> 9.0
* [`bb557cc8`](https://github.com/NixOS/nixpkgs/commit/bb557cc890d638a49593f7e296fbf190a428ad4a) python313Packages.rq: 2.3.2 -> 2.3.3
* [`e02bc8e1`](https://github.com/NixOS/nixpkgs/commit/e02bc8e176a098881a09995af23919e209f8e7db) python313Packages.streamlit: relax packaging constraint
* [`ae9e08ef`](https://github.com/NixOS/nixpkgs/commit/ae9e08effd72c8b7b2d57dfac084d31deeb8d49c) python313Packages.langchain-core: relax packaging constraint
* [`1855bb33`](https://github.com/NixOS/nixpkgs/commit/1855bb33625ba7b05682cbdd6b01fd32282fc5d9) Revert "python313Packages.elasticsearch: 8.17.2 -> 9.0.1"
* [`03ad4eda`](https://github.com/NixOS/nixpkgs/commit/03ad4eda990d734a1fc94fffcacca5094605fd47) python313Packages.elasticsearch-dsl: 8.17.1 -> 8.18.0
* [`76b0f128`](https://github.com/NixOS/nixpkgs/commit/76b0f1284492f199a4cf13d384fe6743680b65da) python313Packages.elasticsearch: 8.17.2 -> 8.18.1
* [`158296e8`](https://github.com/NixOS/nixpkgs/commit/158296e8490b5c93bdd6745103d0814382b1b080) python313Packages.elastic-transport: cleanup
* [`e6fc4da8`](https://github.com/NixOS/nixpkgs/commit/e6fc4da869f9fa1bc05f0695e9023bfd2b49691b) python313Packages.kivy: relax packaging constraint
* [`1e756900`](https://github.com/NixOS/nixpkgs/commit/1e75690075cc4ea9bf29e358178f93095e4d420d) python313Packages.s3transfer: 0.11.2 -> 0.12.0
* [`434eb77a`](https://github.com/NixOS/nixpkgs/commit/434eb77aca67e20fc33bcf0fcfd1d93361ded6b5) python313Packages.botocore: 1.36.21 -> 1.38.9
* [`2629493a`](https://github.com/NixOS/nixpkgs/commit/2629493ac323b808029a160dd437ad223d4ce095) awscli: 1.37.21 -> 1.40.8
* [`e9b5d532`](https://github.com/NixOS/nixpkgs/commit/e9b5d5329aa7ba86f60c0574bca9981fd4ad4989) awscli2: 2.27.2 -> 2.27.8
* [`84a9fb06`](https://github.com/NixOS/nixpkgs/commit/84a9fb06a2ea812a6daa3e818b81519a8b68a36c) python313Packages.pynamodb: 6.0.1 -> 6.0.2
* [`f797c94a`](https://github.com/NixOS/nixpkgs/commit/f797c94aea9c460c3f9424099c707ce3078a2545) python313Packages.aiobotocore: 2.19.0 -> 2.22.0
* [`008b6ffb`](https://github.com/NixOS/nixpkgs/commit/008b6ffbc7245f4a19fdedf3cc1cd6c56155ec31) python313Packages.aioboto3: 13.4.0 -> 14.2.0
* [`fb8ca514`](https://github.com/NixOS/nixpkgs/commit/fb8ca5149e97c4094bb3bfe46c9976763c673e2e) python313Packages.poetry-core: 2.1.2 -> 2.1.3
* [`662a8c85`](https://github.com/NixOS/nixpkgs/commit/662a8c8516b0885c1289abe89d956c0ea5906676) python313Packages.calver: 2025.04.01 -> 2025.04.17
* [`623c6371`](https://github.com/NixOS/nixpkgs/commit/623c6371d341e6a67f785731e5c56ba97f651178) python313Packages.jaraco-path: 3.7.1 -> 3.7.2
* [`a2c2e516`](https://github.com/NixOS/nixpkgs/commit/a2c2e516f43abcb48febca49f8e12f936eea0e78) python313Packages.multidict: 6.2.0 -> 6.4.3
* [`28dc6ccf`](https://github.com/NixOS/nixpkgs/commit/28dc6ccf70ffaa19538b57ba55c34c0fcc35b710) python313Packages.mistune: 3.1.2 -> 3.1.3
* [`2ee6323b`](https://github.com/NixOS/nixpkgs/commit/2ee6323b5372b147669c7211eed5a8412ec16fcc) python313Packages.markdown: 3.7 -> 3.8
* [`f19c513c`](https://github.com/NixOS/nixpkgs/commit/f19c513c712934bb23d832cd3765e94bd9a53780) python313Packages.pikepdf: 9.5.2 -> 9.6.0
* [`b00efc9c`](https://github.com/NixOS/nixpkgs/commit/b00efc9c6aa8a760ba8364a36b0ace2a06f36246) python313Packages.libpass: 1.9.0 -> 1.9.1
* [`cf1501fd`](https://github.com/NixOS/nixpkgs/commit/cf1501fda9d9796720c8e1c5d04bccd9fee38d76) Revert "python313Packages.bibtexparser: 1.4.3 -> 2.0.0b8"
* [`9f85b886`](https://github.com/NixOS/nixpkgs/commit/9f85b88644b40d348a49188776a8fbf2f814aaa7) Revert "python313Packages.clldutils: 3.21.0 -> 3.24.2"
* [`cabc9649`](https://github.com/NixOS/nixpkgs/commit/cabc9649cdfb6f7f0a127e148692ca6cbf3e7876) python3Packages.typing-inspection: 0.4.0 -> 0.4.1
* [`ad5729e1`](https://github.com/NixOS/nixpkgs/commit/ad5729e1495ef48e6debda3abd84009b2b6ab37a) python3Packages.multidict: 6.4.3 -> 6.4.4
* [`c07ae7c5`](https://github.com/NixOS/nixpkgs/commit/c07ae7c55397f7c8ffe60a32de9a3387b542da2e) python3Packages.pikepdf: 9.6.0 -> 9.7.1
* [`f579360c`](https://github.com/NixOS/nixpkgs/commit/f579360cfcc420407dfb01be606058a0af2e7f3d) python3Packages.aws-encryption-sdk: disable tests requiring aws-cryptographic-material-providers
* [`c8fb5fd9`](https://github.com/NixOS/nixpkgs/commit/c8fb5fd9e5582ca158df07cc39416cf28f33bd2b) python3Packages.google-cloud-datacatalog: refactor
* [`3cb99f87`](https://github.com/NixOS/nixpkgs/commit/3cb99f871940cedd39c990ad1132f19e88c341fa) python3Packages.google-cloud-datacatalog: 3.26.1 -> 3.27.1
* [`e4937a38`](https://github.com/NixOS/nixpkgs/commit/e4937a385c09c8038fe79a65124592e58cea20ae) python3Packages.google-cloud-asset: refactor
* [`9c8f813a`](https://github.com/NixOS/nixpkgs/commit/9c8f813aa9a7d11af9d4edac8e837ae841e9bcd2) python313Packages.napalm: remove telnetlib usage
* [`9a2cee0f`](https://github.com/NixOS/nixpkgs/commit/9a2cee0fde8a217e1c34ff8785aa2f1167d99bc2) python313Packages.google-auth: 2.40.1 -> 2.40.2
* [`e2b8d393`](https://github.com/NixOS/nixpkgs/commit/e2b8d3937d48d26ad636ebfcf32d028a9acb0ea1) python313Packages.granian: 2.2.5 -> 2.3.1
* [`9a4ba9d1`](https://github.com/NixOS/nixpkgs/commit/9a4ba9d1d4d4557c8bdcbddb74289ae6f65b762e) python313Packages.apache-beam: relax redis constraint
* [`d2b9444b`](https://github.com/NixOS/nixpkgs/commit/d2b9444bb9b731e65aa7986120c47d337e90220e) python313Packages.django-tasks: 0.6.1 -> 0.7.0
* [`d2c984fd`](https://github.com/NixOS/nixpkgs/commit/d2c984fd5d00fbafe25a6b113e7882842da0c6f2) python313Packages.aioguardian: relax frozenlist constraint
* [`57043c2a`](https://github.com/NixOS/nixpkgs/commit/57043c2a816d16226074dda0af81232d758307dd) Revert "sdl3: reenable OpenGL on darwin"
* [`a375a2bf`](https://github.com/NixOS/nixpkgs/commit/a375a2bf06e6f0554c8ef18f21e22e59e324f8c2) python313Packages.beautifulsoup4: 4.12.3 -> 4.13.4
* [`8c89e993`](https://github.com/NixOS/nixpkgs/commit/8c89e993c326e4eec2ce636625bffa768f69f0a5) python313Packages.inline-snapshot: 0.21.3 -> 0.23.0
* [`9a19bed3`](https://github.com/NixOS/nixpkgs/commit/9a19bed33f77d383129372f4a9ff91da67f9bbd5) python313Packages.django-scheduler: refactor
* [`c8dc69f5`](https://github.com/NixOS/nixpkgs/commit/c8dc69f5eabd54047223644c243e990f0c14dded) python313Packages.django-compressor: fix bs4 4.13 compat
* [`e6a6ace9`](https://github.com/NixOS/nixpkgs/commit/e6a6ace9107e402214ae04fb928e922470b96828) pretalx: relax beautifulsoup4 constraint
* [`e84b1b3d`](https://github.com/NixOS/nixpkgs/commit/e84b1b3d2df0bf840527a8b926a553e8e0f01da0) embellish: add nix-update-script
* [`7208740a`](https://github.com/NixOS/nixpkgs/commit/7208740a433e245b8be5b0655a5a66d2b743d413) glib: 2.84.1 -> 2.84.2
* [`6c085c8e`](https://github.com/NixOS/nixpkgs/commit/6c085c8ead0779b20a55e6936c31607e62561e46) libapparmor: avoid generating __pycache__ in tests
* [`bf5f223e`](https://github.com/NixOS/nixpkgs/commit/bf5f223ec97de65f2c48b77d921620190a076b77) libzip: 1.11.3 -> 1.11.4
* [`e2886f64`](https://github.com/NixOS/nixpkgs/commit/e2886f6472470c31e2e1c113cdc12a2a6812c890) libunwind: 1.8.1 -> 1.8.2
* [`3f1a00c7`](https://github.com/NixOS/nixpkgs/commit/3f1a00c79d0d0e3b7f0893c7163ab8e821b9bebd) cc-wrapper: add support for strictflexarrays1 & strictflexarrays3 hardening flags
* [`a3d6882c`](https://github.com/NixOS/nixpkgs/commit/a3d6882c67f72dca3142d5fd5373140f97c12958) tests.hardeningFlags: refactor, moving musl brokenness into checkTestBin
* [`2c0c7045`](https://github.com/NixOS/nixpkgs/commit/2c0c7045c9f29cb243ff7a4ef7f64f3187eeb8d9) tests.hardeningFlags: enable fortifyExplicitEnabledExecTest for clang/glibc
* [`31e6de5f`](https://github.com/NixOS/nixpkgs/commit/31e6de5f70a69a60cfb0fb143220ffda39060e45) tests.hardeningFlags: add tests for strictflexarrays1 & 3 flags
* [`c4bc9401`](https://github.com/NixOS/nixpkgs/commit/c4bc9401957e4ee1c773c1e7d670ce34c95f9780) tests.hardeningFlags: use --nobranchprotection for hardening-check
* [`e7faa8ba`](https://github.com/NixOS/nixpkgs/commit/e7faa8bad7bcaa9b74fe79e886cea7bc8d5cb5ae) glibc: disable strictflexarrays3 hardening flag
* [`3d49f61e`](https://github.com/NixOS/nixpkgs/commit/3d49f61e8acba7dece6828465972521e79f32dcc) gdbm: disable strictflexarrays3 hardening flag
* [`ea933260`](https://github.com/NixOS/nixpkgs/commit/ea933260d4ea090613e60e6f6966118796d3b098) unzip: disable strictflexarrays3 hardening flag
* [`79c3782e`](https://github.com/NixOS/nixpkgs/commit/79c3782ef848c05fea8a8c9ce351842f1e18ac78) libgpg-error: disable strictflexarrays3 hardening flag
* [`185f5f70`](https://github.com/NixOS/nixpkgs/commit/185f5f70bc3c3e2cd98befd03139983cc3e6ae99) libtpms: disable strictflexarrays3 hardening flag
* [`6e7b7ac6`](https://github.com/NixOS/nixpkgs/commit/6e7b7ac6ecd04f38d42969ea8aa4be32a44422e9) libgcrypt: disable strictflexarrays3 hardening flag
* [`43929ac9`](https://github.com/NixOS/nixpkgs/commit/43929ac9ccf00c092cde97507c8ebc11e9d752c8) libksba: disable strictflexarrays3 hardening flag
* [`339c9369`](https://github.com/NixOS/nixpkgs/commit/339c93697ffa4c159aefbb88600abfe3ebb4e508) libarchive: disable strictflexarrays3 hardening flag
* [`5da561c2`](https://github.com/NixOS/nixpkgs/commit/5da561c2ec4465a7a17e5fd509985c79e2e0bb5c) elfutils: disable strictflexarrays3 hardening flag
* [`b7771e10`](https://github.com/NixOS/nixpkgs/commit/b7771e10fca3014de26e876bcc2d39418f1d75ed) dash: disable strictflexarrays3 hardening flag
* [`a40c2476`](https://github.com/NixOS/nixpkgs/commit/a40c247627c04de6aeadace1d20ff796d17b8174) libunwind: enable parallel building
* [`5188a039`](https://github.com/NixOS/nixpkgs/commit/5188a039c9d57cacce94cfa44fb790617f84e516) dart: 3.7.3 -> 3.8.0
* [`dbe033c7`](https://github.com/NixOS/nixpkgs/commit/dbe033c72eb5fc04e3ad560216074bba9b9abec0) clipper2: 1.5.2 -> 1.5.3
* [`b6df7be4`](https://github.com/NixOS/nixpkgs/commit/b6df7be47c992d301ca8b2ea0a0a03eae98abd6a) linuxPackages.shufflecake: 0.5.1 -> 0.5.2
* [`3a9486b0`](https://github.com/NixOS/nixpkgs/commit/3a9486b017ce85c5e2f12a3c60b62baac685d709) linuxPackages.shufflecake: fix build with gcc 14
* [`c5cea38e`](https://github.com/NixOS/nixpkgs/commit/c5cea38e690922026a14bec43c21370ec67503f3) linuxPackages.veikk-linux-driver: fix build
* [`38b93605`](https://github.com/NixOS/nixpkgs/commit/38b936056fdeebe9d7f69d58cadd54b0dccb39b7) linuxPackages.veikk-linux-driver: small improvements
* [`231a5993`](https://github.com/NixOS/nixpkgs/commit/231a5993606cbf1d729447c887515b64c6174ede) linuxPackages.rtl8821cu: unstable-2024-09-27 -> unstable-2025-05-08
* [`8fa0b532`](https://github.com/NixOS/nixpkgs/commit/8fa0b532afdaa4146287b968d2de39ae20f87e5d) libarchive: Add patch to fix macOS metadata handling when reading certain tarballs
* [`7e7e5721`](https://github.com/NixOS/nixpkgs/commit/7e7e5721a62a54c5e913f2c0645cc11b7236033c) xorg-docs: refactor, move to pkgs/by-name and rename from xorg.xorgdocs
* [`ba5254ab`](https://github.com/NixOS/nixpkgs/commit/ba5254abef6a730e98742395fd10729506186c17) xorg-sgml-doctools: refactor, move to pkgs/by-name and rename from xorg.xorgsgmldoctools
* [`6937e421`](https://github.com/NixOS/nixpkgs/commit/6937e42168a66ea64528080bbd2d427aa1a9dbc6) xtrans: refactor and move to pkgs/by-name from xorg namespace
* [`dc2e7bea`](https://github.com/NixOS/nixpkgs/commit/dc2e7bea50cdb1df16cf2218d729667760dbb082) gcc14: 14.2.1.20250322 -> 14.3.0
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
