### PR TITLE
niv home-manager: update 28eef872 -> d07e9cce

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -77,10 +77,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "28eef8722d1af18ca13e687dbf485e1c653a0402",
-        "sha256": "0i27b08xasw22z4fmfwhy5ajddh4v9r173mqcs0c4ggpa2v4av1b",
+        "rev": "d07e9cceb4994ed64a22b9b36f8b76923e87ac38",
+        "sha256": "179b5paq5dwi57lapn2w0f5d3rskrbxb0yyb4cpwpvlm32bjp4dd",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/28eef8722d1af18ca13e687dbf485e1c653a0402.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/d07e9cceb4994ed64a22b9b36f8b76923e87ac38.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@28eef872...d07e9cce](https://github.com/nix-community/home-manager/compare/28eef8722d1af18ca13e687dbf485e1c653a0402...d07e9cceb4994ed64a22b9b36f8b76923e87ac38)

* [`f754e377`](https://github.com/nix-community/home-manager/commit/f754e377dc2da5d34dfea6a5215c21741eaf8930) tests/yazi: manager -> mgr ([nix-community/home-manager⁠#7289](https://togithub.com/nix-community/home-manager/issues/7289))
* [`df9fddf7`](https://github.com/nix-community/home-manager/commit/df9fddf70ce619cee027c904a2f796de8ad2720d) flake.lock: Update
* [`70c289b5`](https://github.com/nix-community/home-manager/commit/70c289b54dec227d8b42fc33fd3e8bd5b7c032f9) i3status-rust: farlion -> workflow
* [`85e68c6a`](https://github.com/nix-community/home-manager/commit/85e68c6a388ef1dfc799aaa01f00758c58e87d89) tests/neovim: stub meta.teams
* [`0f355844`](https://github.com/nix-community/home-manager/commit/0f355844e54e4c70906b1ef5cc35a0047d666c04) tests/firefox: fix bookmarks test ([nix-community/home-manager⁠#7292](https://togithub.com/nix-community/home-manager/issues/7292))
* [`86384263`](https://github.com/nix-community/home-manager/commit/863842639722dd12ae9e37ca83bcb61a63b36f6c) hyprland: update wiki domain name ([nix-community/home-manager⁠#7293](https://togithub.com/nix-community/home-manager/issues/7293))
* [`39b7903e`](https://github.com/nix-community/home-manager/commit/39b7903eaba5579046f7069b9d85d3ef4f2f972c) helix: don't ignore extraConfig when no other settings ([nix-community/home-manager⁠#7302](https://togithub.com/nix-community/home-manager/issues/7302))
* [`2d9c66ee`](https://github.com/nix-community/home-manager/commit/2d9c66ee6d8bb3fe3bb3a607101d320749cb118f) flake.lock: Update
* [`19530b8d`](https://github.com/nix-community/home-manager/commit/19530b8d3c568a1fb78c70e0f4263c8a6582cb2c) network-manager-applet: maintainer midirhee12 -> midischwarz12
* [`975908d3`](https://github.com/nix-community/home-manager/commit/975908d3109728f602296a9262b6594e2d7105a6) tests/clipcat: fix expected config
* [`a2231992`](https://github.com/nix-community/home-manager/commit/a2231992dd4714c7ec2fb894ce641d4afefd115d) tests/helix: fix expected config
* [`597d672e`](https://github.com/nix-community/home-manager/commit/597d672e69bc12b451b045867700f4d911a42232) tests/neovide: fix expected config
* [`65db5b85`](https://github.com/nix-community/home-manager/commit/65db5b85d0f69ee1cbc2751d5337db92f983feee) tests/spotify-player: fix expected config
* [`07e72705`](https://github.com/nix-community/home-manager/commit/07e72705a189d3ca0192a4c0364987c6a2dec8a1) tests/niriswitcher: fix expected config
* [`c32df52a`](https://github.com/nix-community/home-manager/commit/c32df52a2f09187aaeda4e9e2c3862f729097ca2) tests/himalaya: fix expected config
* [`3d045a92`](https://github.com/nix-community/home-manager/commit/3d045a92d648a3603c3f94b1ca773299d2272e27) tests/i3status-rust: fix expected config
* [`c8c30aa3`](https://github.com/nix-community/home-manager/commit/c8c30aa316fed11716b2b363e93a278664bb3c8e) tests/meli: fix expected config
* [`fd41fc5f`](https://github.com/nix-community/home-manager/commit/fd41fc5fbf077295e3bc66cac9c0903f4d1c4ec4) tests/numbat: fix expected config
* [`37353185`](https://github.com/nix-community/home-manager/commit/373531850c003c968b04c2a621f3cd8d123608fa) tests/uv: fix expected config
* [`a8e99a96`](https://github.com/nix-community/home-manager/commit/a8e99a960808fa69a2cea937ba604207552fe28a) tests/nix-init: fix expected config
* [`7c355048`](https://github.com/nix-community/home-manager/commit/7c35504839f915abec86a96435b881ead7eb6a2b) tests/neovim: fix expected config
* [`3bd64613`](https://github.com/nix-community/home-manager/commit/3bd646138a9c71f244a9293dde6f59ae1c6875ab) nushell: Make sure the plugins are not garbage-collected ([nix-community/home-manager⁠#7295](https://togithub.com/nix-community/home-manager/issues/7295))
* [`2fbd694f`](https://github.com/nix-community/home-manager/commit/2fbd694fec4a53d0358ab9b1f5f0483fbb876286) labwc: Fix pipemenu([nix-community/home-manager⁠#7236](https://togithub.com/nix-community/home-manager/issues/7236)) and icon in menu generation
* [`6fa01d52`](https://github.com/nix-community/home-manager/commit/6fa01d524bc5b0e77e6702dd37cf453247438480) labwc: do not manage file when in default value([nix-community/home-manager⁠#7240](https://togithub.com/nix-community/home-manager/issues/7240))
* [`520fc4b5`](https://github.com/nix-community/home-manager/commit/520fc4b50af1b365014c3748c126d3f52edb2f3b) k9s: fix config files not generated correctly & improve options ([nix-community/home-manager⁠#7262](https://togithub.com/nix-community/home-manager/issues/7262))
* [`fefeb0e9`](https://github.com/nix-community/home-manager/commit/fefeb0e928d1ec528f54e73892a7c069425d5041) tests/redshift-gammastep: check file exists first
* [`4fca600c`](https://github.com/nix-community/home-manager/commit/4fca600cb1db1d10bed39f67702c443f119117c1) treewide: implement auto importing for modules
* [`06c1392c`](https://github.com/nix-community/home-manager/commit/06c1392ca886553e9df1c7a927e5972261cf98f8) tests: implement auto importing for modules
* [`bbad45b7`](https://github.com/nix-community/home-manager/commit/bbad45b7ea7152f540faa531bafaf98a73b00463) tests/jellyfin-mpv-shim: fix tests
* [`2c4f8cb7`](https://github.com/nix-community/home-manager/commit/2c4f8cb7d6c1958d1afbd30276a3389947be4e59) tests/yubikey-agent: reorganize darwin and linux
* [`e9bde769`](https://github.com/nix-community/home-manager/commit/e9bde7692e7a0b6c87ea36200c3d196759959c31) tests/git-sync: reorganize darwin and linux
* [`c283a23e`](https://github.com/nix-community/home-manager/commit/c283a23ef6c23366837a754ba3c30d45826424c1) tests/emacs: reorganize darwin and linux
* [`d2b2c72a`](https://github.com/nix-community/home-manager/commit/d2b2c72add6796fe95a9eb95690286cb0ab5fab3) tests/espanso: reorganize darwin and linux
* [`5618e7a7`](https://github.com/nix-community/home-manager/commit/5618e7a748706dbe4f23ef11ec303070af7b5ea0) tests/home-manager-auto-expire: reorganize darwin and linux
* [`7a64c023`](https://github.com/nix-community/home-manager/commit/7a64c0234077290079e5457691afb6cb543d45a0) tests/imapnotify: reorganize darwin and linux
* [`41a5f0a9`](https://github.com/nix-community/home-manager/commit/41a5f0a98a4970f27ff23914927aec33da949f2a) tests/nix-gc: reorganize darwin and linux
* [`4c9e99e8`](https://github.com/nix-community/home-manager/commit/4c9e99e8e8e36bcdfa9cdb102e45e4dc95aa5c5b) ci: disable home-manager install tests on darwin
* [`4a8f993c`](https://github.com/nix-community/home-manager/commit/4a8f993c45fcd2edf75d64ee4532cb9aca41566c) home-manager: fix broken path reference
* [`05b8c950`](https://github.com/nix-community/home-manager/commit/05b8c9506452349d8be854ac46e5a7630fa7917d) ci: home-manager switch test aginst codebase
* [`873c5b2d`](https://github.com/nix-community/home-manager/commit/873c5b2dc5c9387bf67e59a12abc4de12a4b8697) way-displays: use `mkOptionDefault` in `systemd.variables` ([nix-community/home-manager⁠#7306](https://togithub.com/nix-community/home-manager/issues/7306))
* [`f5098b07`](https://github.com/nix-community/home-manager/commit/f5098b074051d1ae0e919adf434a60fc3f23347b) programs/hyprpanel: init ([nix-community/home-manager⁠#7303](https://togithub.com/nix-community/home-manager/issues/7303))
* [`bda9deb7`](https://github.com/nix-community/home-manager/commit/bda9deb791b29454d49f8f5c35198e2b23f7751a) modules: allow root level nix files
* [`86402a17`](https://github.com/nix-community/home-manager/commit/86402a17b6c67b07c5536354da5d56c14196de46) treewide: flatten single file modules
* [`d33444e6`](https://github.com/nix-community/home-manager/commit/d33444e63a88f70feccd99971c442dc9d84faff1) aerospace: Add launchd agent and enhance configuration
* [`c9d8158b`](https://github.com/nix-community/home-manager/commit/c9d8158bc56923013fa9a4346ba3e273f3b956b3) tests/aerospace: test launchd agent
* [`d07e9cce`](https://github.com/nix-community/home-manager/commit/d07e9cceb4994ed64a22b9b36f8b76923e87ac38) docs: add note about importing modules ([nix-community/home-manager⁠#7315](https://togithub.com/nix-community/home-manager/issues/7315))
