### PR TITLE
niv nerd-icons.el: update 71d162a7 -> 4476b4ca

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -131,10 +131,10 @@
         "homepage": null,
         "owner": "rainstormstudio",
         "repo": "nerd-icons.el",
-        "rev": "71d162a75bf6178ecff1536ac94dfa25e617b6ed",
-        "sha256": "0cdws2mkvpds7s533dqcbjqksyvkwdhvvpjjchdkd59ygdwzvjwn",
+        "rev": "4476b4cabe63f5efafa3c0a8b370db4f6a92e90c",
+        "sha256": "1d345y4z9j2m065j03kd6zb8hcr139mqzvpvxmg1147hrb9w25hn",
         "type": "tarball",
-        "url": "https://github.com/rainstormstudio/nerd-icons.el/archive/71d162a75bf6178ecff1536ac94dfa25e617b6ed.tar.gz",
+        "url": "https://github.com/rainstormstudio/nerd-icons.el/archive/4476b4cabe63f5efafa3c0a8b370db4f6a92e90c.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "niv": {


### PR DESCRIPTION
## Changelog for nerd-icons.el:
Branch: main
Commits: [rainstormstudio/nerd-icons.el@71d162a7...4476b4ca](https://github.com/rainstormstudio/nerd-icons.el/compare/71d162a75bf6178ecff1536ac94dfa25e617b6ed...4476b4cabe63f5efafa3c0a8b370db4f6a92e90c)

* [`4476b4ca`](https://github.com/rainstormstudio/nerd-icons.el/commit/4476b4cabe63f5efafa3c0a8b370db4f6a92e90c) add codeberg.org  to nerd-icons-url-alist
