### PR TITLE
niv nixpkgs: update 45d99199 -> 7d7f2608

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -155,10 +155,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "45d9919944202c82c9310d1d2a8149a7576d2e9b",
-        "sha256": "0sv8w8an4pgxvbwbs1cn5vzbk1cdvckflr7vjhk703hydf73b8n4",
+        "rev": "7d7f26089219e03cd47eff924eac18deb525ea62",
+        "sha256": "1c6d961j88h6l7h0rhdmywyyxaks2wagw2zvrr7rg2j0yk2sshky",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/45d9919944202c82c9310d1d2a8149a7576d2e9b.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/7d7f26089219e03cd47eff924eac18deb525ea62.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@45d99199...7d7f2608](https://github.com/nixos/nixpkgs/compare/45d9919944202c82c9310d1d2a8149a7576d2e9b...7d7f26089219e03cd47eff924eac18deb525ea62)

* [`718d2287`](https://github.com/NixOS/nixpkgs/commit/718d2287b08534398184fa2107744c81b8fe23ae) makePythonWriter: allow providing function for libraries
* [`e6963216`](https://github.com/NixOS/nixpkgs/commit/e6963216a65a2cc81f883ba68d3c75cccbfed7fa) jetbrains-mono: build from source
* [`7d273b4a`](https://github.com/NixOS/nixpkgs/commit/7d273b4a45bbe5af76e4d5ab4634a65ed46504df) maintainers: add andrewfield
* [`03959029`](https://github.com/NixOS/nixpkgs/commit/03959029e6b4a8127738f44aa4587fbab421ea48) Use direct function application syntax
* [`59a04e2d`](https://github.com/NixOS/nixpkgs/commit/59a04e2da8f7d277609aa59ef9f73f77cc3d01c2) maintainer: add timon
* [`c6158890`](https://github.com/NixOS/nixpkgs/commit/c615889033bc5929b9fcb3e5579f0334b00215d5) live555: add a trivial updater and a single reverse test
* [`76805ecc`](https://github.com/NixOS/nixpkgs/commit/76805ecc3c581976c35bf401b859055e48bb8ba8) maintainers: add nukdokplex
* [`e52f7202`](https://github.com/NixOS/nixpkgs/commit/e52f720223222b0209fa04d985166bd5cb477ef8) dns-collector: init at 1.7.0
* [`23b852dd`](https://github.com/NixOS/nixpkgs/commit/23b852ddd3bf6ae632fe34b34d00b9563ec641a5) epson_201310w: init at 1.0.1
* [`931a48b0`](https://github.com/NixOS/nixpkgs/commit/931a48b0afae6b4de64b4edaa261fd58e84335c6) python3Packages.pyside2: 5.15.16 -> 5.15.17
* [`4506da05`](https://github.com/NixOS/nixpkgs/commit/4506da058e1a7bd78e9f052fd6a6b3314fcc2892) python3Packages.linode-api: 5.29.1 -> 5.32.0
* [`971f03a0`](https://github.com/NixOS/nixpkgs/commit/971f03a0b9f071fe2dbf61b0db42a4470aa53b98) nano: update nixSyntaxHighlight
* [`6e515b92`](https://github.com/NixOS/nixpkgs/commit/6e515b92e616ef43dfae810516308c79bdd5e769) m17n_lib: 1.8.5 -> 1.8.6
* [`ac23c01c`](https://github.com/NixOS/nixpkgs/commit/ac23c01c09c3bf0e5d38ac10b613bc512df8a367) plover.dev: 4.0.0.dev10 -> 4.0.2
* [`8eb57e18`](https://github.com/NixOS/nixpkgs/commit/8eb57e18407389869ebc402d77f30bdd2d2bec71) python3Packages.indexed-gzip: 1.8.7 -> 1.9.5
* [`5c450956`](https://github.com/NixOS/nixpkgs/commit/5c450956dc58d9f1d2c3843a2aa954ad5d98d299) python3Packages.pycuda: 2025.1 -> 2025.1.1
* [`a3c04202`](https://github.com/NixOS/nixpkgs/commit/a3c0420262f9236327b7b3d41f19769d156b901a) python3Packages.cloudsmith-api: 2.0.18 -> 2.0.20
* [`6acf53f6`](https://github.com/NixOS/nixpkgs/commit/6acf53f6547337106235a0d892e6341e01a5c5cd) nixos/sshd: don't use `-a` (KDF rounds) on host keys
* [`044563c8`](https://github.com/NixOS/nixpkgs/commit/044563c8a994e2a2e32765caf993ee0904e317ab) openusd: propagate dependency opengl
* [`37f429d1`](https://github.com/NixOS/nixpkgs/commit/37f429d136714c28f2e1fb636bdfb5b11c23db4f) crawl: 0.32.1 -> 0.33.1
* [`6bacd9da`](https://github.com/NixOS/nixpkgs/commit/6bacd9dad549fcabbe35f4e3651b7760748f74f1) wpcleaner: init at 2.0.5-unstable-2025-04-25
* [`a299a7e6`](https://github.com/NixOS/nixpkgs/commit/a299a7e6158a0004d0319b1a9df6c56b0a399f7d) localstack: 4.4.0 -> 4.5.0
* [`3b267151`](https://github.com/NixOS/nixpkgs/commit/3b267151f0dd360b2c28615e1be5bab4004eafac) libdatachannel: 0.22.6 -> 0.23.0
* [`50294069`](https://github.com/NixOS/nixpkgs/commit/50294069aafa9372aef2e1913e530076addb12da) louvre: 2.16.3-1 -> 2.18.1-1
* [`0bf47e80`](https://github.com/NixOS/nixpkgs/commit/0bf47e80fc5548c725ff74cbe2e1ac376a390f0f) python3Packages.sphinxcontrib-confluencebuilder: 2.12.0 -> 2.13.0
* [`c9fba117`](https://github.com/NixOS/nixpkgs/commit/c9fba117e00e411909dfc071219c11a2625e5746) python3Packages.google-cloud-websecurityscanner: 1.17.2 -> 1.17.3
* [`4576aa86`](https://github.com/NixOS/nixpkgs/commit/4576aa86aa37f3456bd5dfc095c69cb44640ddd0) avalanchego: 1.13.0 -> 1.13.1
* [`1cc8c48c`](https://github.com/NixOS/nixpkgs/commit/1cc8c48cd438590c7234fdc440bf5408f64ba3e3) yoshimi: 2.3.3.3 -> 2.3.4.1
* [`f8c27cf4`](https://github.com/NixOS/nixpkgs/commit/f8c27cf4f2def84b73ede3a69a5e06cf1af04fc1) gcompris: 25.1 -> 25.1.1
* [`72b9eecc`](https://github.com/NixOS/nixpkgs/commit/72b9eecc9eda437049c5cc64d17d807535972958) eclipses.eclipse-platform: 4.35 -> 4.36
* [`d51e1489`](https://github.com/NixOS/nixpkgs/commit/d51e148969a525056cbce20a3a3709cb6b4ed8c5) openturns: 1.24 -> 1.25
* [`456de96e`](https://github.com/NixOS/nixpkgs/commit/456de96e37aec5d81afa60bc31cef70603f1d35c) teamviewer: 15.61.3 -> 15.66.5
* [`bf20087f`](https://github.com/NixOS/nixpkgs/commit/bf20087fe21477f87c7ab16db4f5bb4c871bcadd) git-town: 21.0.0 -> 21.1.0
* [`b7081561`](https://github.com/NixOS/nixpkgs/commit/b708156169fee1fe41f560fd5b456567c27b1ed4) go-task: 3.43.3 -> 3.44.0
* [`80a18c80`](https://github.com/NixOS/nixpkgs/commit/80a18c80e346f8a141625beb858c3090edeef60d) dump: 0.4b48 -> 0.4b51
* [`092bbe66`](https://github.com/NixOS/nixpkgs/commit/092bbe66311bb94574c38506ca964c4b28280205) clazy: 1.14 -> 1.15
* [`0eb9898a`](https://github.com/NixOS/nixpkgs/commit/0eb9898ae9dad488089e30ecb8a862eeca911aa4) libaec: 1.1.3 -> 1.1.4
* [`8730e6e6`](https://github.com/NixOS/nixpkgs/commit/8730e6e680f56e114814db69340315ecc9de31a3) fldigi: 4.2.06 -> 4.2.07
* [`5bb50bf0`](https://github.com/NixOS/nixpkgs/commit/5bb50bf085c02e4ee1e728ce6a3e2ae92887f0d3) python3Packages.openturns: 1.24 -> 1.25
* [`8f235432`](https://github.com/NixOS/nixpkgs/commit/8f235432823d3b7e538a08294871f410e8002c6b) cifs-utils: 7.3 -> 7.4
* [`857ef33a`](https://github.com/NixOS/nixpkgs/commit/857ef33a2b6cd540d263af960c18c1ea2421c254) rsyslog: 8.2504.0 -> 8.2506.0
* [`914b83fc`](https://github.com/NixOS/nixpkgs/commit/914b83fca1ae2620caf6d881896076c528f802bd) nushellPlugins.skim: 0.14.0 -> 0.15.0
* [`0c3e0f86`](https://github.com/NixOS/nixpkgs/commit/0c3e0f861782e61ab4cd959718918ed32475e2bf) cyberchef: Add binary and desktop item
* [`9bbcdd92`](https://github.com/NixOS/nixpkgs/commit/9bbcdd92b095c976e8ae440fbb45d912b46fc67f) nushellPlugins.hcl: 0.104.1 -> 0.105.1
* [`163651bc`](https://github.com/NixOS/nixpkgs/commit/163651bc2cd7b22b7124f11922b4877085e6d62f) nerdfetch: 8.3.1 -> 8.4.0
* [`4dcf0974`](https://github.com/NixOS/nixpkgs/commit/4dcf0974507e0aa5bec3ad1cb5c426f18431238d) alterware-launcher: init at 0.11.2
* [`496bf34c`](https://github.com/NixOS/nixpkgs/commit/496bf34cca104dc6c1fe2eb5b1315ec547fac41b) joplin-desktop: 3.3.12 -> 3.3.13
* [`181c75a9`](https://github.com/NixOS/nixpkgs/commit/181c75a93a78cac7c77873ee56181e5b692395a6) R: 4.5.0 -> 4.5.1
* [`2e555c45`](https://github.com/NixOS/nixpkgs/commit/2e555c459212c94760d7aba61486a3ad2981ff18) rPackages: CRAN and BioC update
* [`4b635e4a`](https://github.com/NixOS/nixpkgs/commit/4b635e4abd6c12f252192eec328177607e7cde0c) prometheus-fastly-exporter: 9.2.0 -> 9.4.0
* [`72e8adbc`](https://github.com/NixOS/nixpkgs/commit/72e8adbc49771a50bdc38f74ce6303a1b8bf4c5d) epson-escpr2: 1.2.28 -> 1.2.34
* [`4376b2aa`](https://github.com/NixOS/nixpkgs/commit/4376b2aaf35f3041e012371916d31a5e07aea928) rPackages.BAT: fix build
* [`4f8dacc1`](https://github.com/NixOS/nixpkgs/commit/4f8dacc1998d4b52c945b2367a93bf91b17be4b6) libblake3: split dev outputs from runtime
* [`6c412adc`](https://github.com/NixOS/nixpkgs/commit/6c412adcfc95b1b85ed90296ca5e33262579a40a) rPackages.pak: fix build
* [`dc86a954`](https://github.com/NixOS/nixpkgs/commit/dc86a954e83014e39854dd6060cea96244818475) rPackages.baseline: fix build
* [`e82c7e5b`](https://github.com/NixOS/nixpkgs/commit/e82c7e5b8350bb36e56091477541a1d89763f46b) nixos/i3: fix i3lock default enable-ing
* [`8aa7813a`](https://github.com/NixOS/nixpkgs/commit/8aa7813a643762c7f43eca79dbb4c8f1433cda90) rqbit: 8.0.0 -> 8.1.1
* [`00eae402`](https://github.com/NixOS/nixpkgs/commit/00eae402c32eb23a7be320a9bbb40d2021befd82) Add yannham to the maintainer list
* [`c7082db8`](https://github.com/NixOS/nixpkgs/commit/c7082db884a50d425c1c07bf871fef6a07a12d87) nickel: add yannham to maintainers
* [`1713262d`](https://github.com/NixOS/nixpkgs/commit/1713262d28c814f3f01bb461718d1534fbdc82c3) nickel: disable nix feature by default
* [`e0ec68ae`](https://github.com/NixOS/nixpkgs/commit/e0ec68aee570cc84a402ad9ed66327ac51c0438f) nickel: 1.11.0 -> 1.12.0
* [`e01fe202`](https://github.com/NixOS/nixpkgs/commit/e01fe2027c4f24d9cc6486b7a00ac348ce2f6440) maintainers: add conneroisu
* [`a36484e2`](https://github.com/NixOS/nixpkgs/commit/a36484e2979026d983a313ed9567ee12f551f854) gitea-mcp-server: init at 0.2.0
* [`71b68bfd`](https://github.com/NixOS/nixpkgs/commit/71b68bfd482ea3ed5ce0493395ea74cce44b45ba) museum: 1.0.10 -> 1.1.0
* [`c1b61e59`](https://github.com/NixOS/nixpkgs/commit/c1b61e594ab08ede43f3d9d9c63fea1db22e276c) dbus-broker: 36 -> 37
* [`1c0409a5`](https://github.com/NixOS/nixpkgs/commit/1c0409a545d64222c88e6a7e3a4725aa20cc6360) staruml: 6.3.2 -> 6.3.3
* [`4e3d543f`](https://github.com/NixOS/nixpkgs/commit/4e3d543f4dd36b7573b1f5ce344d89e519839fac) netgen: move pythonImportsCheckHook to nativeBuildInputs
* [`9f133f01`](https://github.com/NixOS/nixpkgs/commit/9f133f01948010a69cc4518b53b06e8e30c24c52) python3Packages.google-cloud-dataproc: 5.18.1 -> 5.20.0
* [`25e58d5a`](https://github.com/NixOS/nixpkgs/commit/25e58d5a03bf281901b4e3c58b655cc4f41343cd) opentelemetry-collector-builder: 0.126.0 -> 0.128.0
* [`8e543296`](https://github.com/NixOS/nixpkgs/commit/8e543296745096cd02cb93903a19f1ae0309e39c) rPackages.orbweaver: fixed build
* [`78a7cd35`](https://github.com/NixOS/nixpkgs/commit/78a7cd352e5b92fdcd7c4487e37745c84b281005) wavebox: 10.137.9-2 -> 10.137.11-2
* [`ddb314ac`](https://github.com/NixOS/nixpkgs/commit/ddb314accd15387de64e8b532f292a6aa2945958) kimai: 2.35.1 -> 2.36.1
* [`87fbf71e`](https://github.com/NixOS/nixpkgs/commit/87fbf71ed68b111c1ef6c6d24d67b66f0e898f33) nixos/galene: allow using self-signed certificates
* [`c119e109`](https://github.com/NixOS/nixpkgs/commit/c119e10921b68225ee97871f33a6099da36d7637) rPackages.tergo: fixed build
* [`485b06a3`](https://github.com/NixOS/nixpkgs/commit/485b06a37613b0a070eca9eac5573210bc3cc54a) nixos/sysctl: sane inotify defaults globally
* [`90bd8485`](https://github.com/NixOS/nixpkgs/commit/90bd8485b2b70b0689b8610c142f39c18ee72ebd) rPackages.tabs: fixed build
* [`08e2c2df`](https://github.com/NixOS/nixpkgs/commit/08e2c2dfb7474f5188907dc42eed6d46558244a9) rPackages.gglinedensity: fixed build
* [`f3d037c7`](https://github.com/NixOS/nixpkgs/commit/f3d037c7dd88f6f1c0c5759a937531c9709a6ec2) rPackages.red: fixed build
* [`b0cb2096`](https://github.com/NixOS/nixpkgs/commit/b0cb2096e7d984cd1b9dcf3c912d6c774c1903d3) mattermostLatest: 10.8.1 -> 10.9.1
* [`849cf8cf`](https://github.com/NixOS/nixpkgs/commit/849cf8cfbef7f719e00d628cd5dff1c2e3ec4f37) minikube: 1.34.0 -> 1.36.0
* [`b1072b32`](https://github.com/NixOS/nixpkgs/commit/b1072b324c84dbb6c23add2d492cd404a7c3acdc) buildkit: 0.22.0 -> 0.23.0
* [`7c5f3718`](https://github.com/NixOS/nixpkgs/commit/7c5f3718ee680b755e641675719b00996f423ab0) wyoming-faster-whisper: 2.4.0 -> 2.5.0
* [`4f47440a`](https://github.com/NixOS/nixpkgs/commit/4f47440a891845d0b2349b47ac956b4f0634a2d4) use `local` GOTOOLCHAIN for docker-machine-*
* [`d79bf127`](https://github.com/NixOS/nixpkgs/commit/d79bf12714703a6f316360b9361baeea43c4639b) netgen: typo fixup
* [`ed83268a`](https://github.com/NixOS/nixpkgs/commit/ed83268acabc365dd8de9c63f1e883518c83fc97) netgen: 6.2.2501 -> 6.2.2504
* [`d6f9b46f`](https://github.com/NixOS/nixpkgs/commit/d6f9b46f7d5a7320576a0b91fa6fcf31f6defcdd) element-web-unwrapped: 1.11.103 -> 1.11.104
* [`99d89334`](https://github.com/NixOS/nixpkgs/commit/99d8933424f9e72feb46de8fa3ce859070f8ec4e) element-desktop: 1.11.103 -> 1.11.104
* [`27a3b577`](https://github.com/NixOS/nixpkgs/commit/27a3b5779df1734f6cf5a6bcf68b10391f44c2af) giada: 1.1.1 -> 1.2.0
* [`7b95d7c3`](https://github.com/NixOS/nixpkgs/commit/7b95d7c3ded22e68a68e0c1fbe060948cbea6658) grpc-gateway: 2.26.3 -> 2.27.0
* [`749888b0`](https://github.com/NixOS/nixpkgs/commit/749888b0921c3ed50e3c2db86ecf0f1e4c09af2a) olympus-unwrapped: 25.04.20.01 -> 25.06.17.01
* [`fbda3e31`](https://github.com/NixOS/nixpkgs/commit/fbda3e311c78590b7d623240e69f116fea97d0a3) gst_all_1.gst-devtools: update static-files dependency
* [`5034dd73`](https://github.com/NixOS/nixpkgs/commit/5034dd73846be1264d9f44114da5b6a88494e2fc) nixos/wastebin: update default POST size to match upstream
* [`30254eb5`](https://github.com/NixOS/nixpkgs/commit/30254eb55b9d8cc4d4efe7112989b03ea3cdd318) proxsuite: ctestCheckHook + disable failing one
* [`219a846e`](https://github.com/NixOS/nixpkgs/commit/219a846ea46777a05274cdd109cf8e17c733e042) liana: 11.0 -> 11.1
* [`02ec1658`](https://github.com/NixOS/nixpkgs/commit/02ec16588d0fc6eb00f6856dc8060ebc2bf5bfec) lianad: 11.0 -> 11.1
* [`e4d198a4`](https://github.com/NixOS/nixpkgs/commit/e4d198a47c6ae79dbe7575a8890dc97598d0caa7) dbus-broker: add myself as maintainer
* [`bd2a558f`](https://github.com/NixOS/nixpkgs/commit/bd2a558f20ebd8a4cad9f108b0fce812e0c4521b) trafficserver: 9.2.10 -> 9.2.11
* [`3722c7e5`](https://github.com/NixOS/nixpkgs/commit/3722c7e515d9908f9e78ec7302276f3470c23b2d) cnquery: 11.57.2 -> 11.59.0
* [`19a3f4b9`](https://github.com/NixOS/nixpkgs/commit/19a3f4b933b0a328c18b897f80a3c421ef7db70c) python3Packages.itables: 2.4.0 -> 2.4.2
* [`5254700b`](https://github.com/NixOS/nixpkgs/commit/5254700b73d8a15489248ef8008dccd89a90692e) linuxPackages.rtw88: 0-unstable-2024-08-22 -> 0-unstable-2025-05-08
* [`48f276fa`](https://github.com/NixOS/nixpkgs/commit/48f276fab4e3bf3e8ea100cc0ed143cf4a99283b) perlPackages.CryptX: 0.080 -> 0.087
* [`2cf6f62e`](https://github.com/NixOS/nixpkgs/commit/2cf6f62eb5459dc296c0566b2cbbe9828198a3b2) mandelbulber: 2.32 -> 2.33
* [`fe3e7c9e`](https://github.com/NixOS/nixpkgs/commit/fe3e7c9efd64810ec1a29d475ea9984b51f1a204) python3Packages.orbax-checkpoint: 0.11.15 -> 0.11.16
* [`4136b386`](https://github.com/NixOS/nixpkgs/commit/4136b386ed68dde611f41606f4a67be5b577c2e7) x2t: avoid dependency on upstream deb
* [`fd636882`](https://github.com/NixOS/nixpkgs/commit/fd636882374cdce4c1e042b088b4eeaa18bbdb69) python3Packages.warp-lang: init at 1.7.2.post1
* [`4d18fb77`](https://github.com/NixOS/nixpkgs/commit/4d18fb7736283b6ddc99431c1f054a82e07b6fce) firefox-devedition: fix remoting name
* [`fe7b8e2a`](https://github.com/NixOS/nixpkgs/commit/fe7b8e2a0ab7e8b7ef4d4b7eef5bf7293765f9f1) davis: 5.0.2 -> 5.1.2
* [`4e0490de`](https://github.com/NixOS/nixpkgs/commit/4e0490deaaf6e82dccca3c393cc7c0d50caf4c86) ugrep: 7.4.3 -> 7.5.0
* [`c614efb6`](https://github.com/NixOS/nixpkgs/commit/c614efb641e39df0676706081d047c789aed0641) wlr-which-key: 1.1.0 -> 1.2.0
* [`dd36c0a3`](https://github.com/NixOS/nixpkgs/commit/dd36c0a3f522635af4ec36cb1d67bcdf3cd8eca2) wideriver: 1.2.0 -> 1.2.1
* [`67c06904`](https://github.com/NixOS/nixpkgs/commit/67c06904e08d8bd590dac68b4fb27fe6143202c1) buildbox: 1.3.11 -> 1.3.21
* [`66d5d2f2`](https://github.com/NixOS/nixpkgs/commit/66d5d2f2d2134f79549963bd3ba10b53451ceedf) netron: 8.3.8 -> 8.3.9
* [`d40a78e1`](https://github.com/NixOS/nixpkgs/commit/d40a78e1297e3e4859ddce137ba7dff0f66522c3) ledfx: 2.0.108 -> 2.0.109
* [`1d00f6a6`](https://github.com/NixOS/nixpkgs/commit/1d00f6a6671ee1a2c12566646e9d5e1c459082d6) kaniko: 1.24.0 -> 1.25.0
* [`f6f3549d`](https://github.com/NixOS/nixpkgs/commit/f6f3549df6dc19f7b2e4587960e53f95f40d3d6a) python3Packages.wadler-lindig: 0.1.6 -> 0.1.7
* [`8d8b56a7`](https://github.com/NixOS/nixpkgs/commit/8d8b56a7c151d76993b607cf2b862ed1c81cfa5d) xmake: 2.9.9 -> 3.0.0
* [`c62d6420`](https://github.com/NixOS/nixpkgs/commit/c62d6420a2ae46214f90764878410fb37fb82a50) spiffe-helper: init at 0.10.0
* [`5e6997dd`](https://github.com/NixOS/nixpkgs/commit/5e6997ddeaac746b9670602acd8c66fd959ecced) gitlab: 18.0.2 -> 18.1.0
* [`045ceafc`](https://github.com/NixOS/nixpkgs/commit/045ceafca08a350b402f3a3ae60773b1490f7e88) maintainers: add rskew
* [`06b8eafa`](https://github.com/NixOS/nixpkgs/commit/06b8eafa8ebc4137b6f794ba6ab786af2882a299) python3Packages.logging-tree: init at 1.10
* [`485395ea`](https://github.com/NixOS/nixpkgs/commit/485395eaba3fbcc3b465d2bd37cdbc23830d0755) python3Packages.plotly: unbreak on darwin
* [`51a0ea5f`](https://github.com/NixOS/nixpkgs/commit/51a0ea5fb7c3c8eb81e08740870426049cfcf382) python3Packages.plotly: 6.1.0 -> 6.1.2
* [`9d48976c`](https://github.com/NixOS/nixpkgs/commit/9d48976ccc86a60e86f94b647894462cb0a8a481) git-extras: 7.3.0 -> 7.4.0
* [`305e7b0b`](https://github.com/NixOS/nixpkgs/commit/305e7b0bde15f47f305b4a28d828ece650b5199d) librepo: 1.19.0 -> 1.20.0
* [`26cad097`](https://github.com/NixOS/nixpkgs/commit/26cad0975a13f7ad56ece753ed336e9257a67233) librepo: use finalAttrs, cleanup
* [`186e9d52`](https://github.com/NixOS/nixpkgs/commit/186e9d523327c5e5877791b16f071f836db1d28f) dnf5: 5.2.13.1 -> 5.2.14.0
* [`d9113fc5`](https://github.com/NixOS/nixpkgs/commit/d9113fc57eec6ad5d74cdd0c095c214fbfe3c416) nominatim: 4.4.0 -> 5.1.0
* [`d46efba7`](https://github.com/NixOS/nixpkgs/commit/d46efba75e826e42ac4092bf213a806f212c216a) mpdcron: Update all gems to latest versions to test if mac builds
* [`c28b3143`](https://github.com/NixOS/nixpkgs/commit/c28b3143da407c0208a8b57b60b0d236c3196790) nixos/systemd-oomd: use the correct name for the top-level user slice
* [`0615054b`](https://github.com/NixOS/nixpkgs/commit/0615054b269f6ac22c79c15fccb78a15c042d17f) uncover: 1.0.10 -> 1.1.0
* [`8d6e3ef9`](https://github.com/NixOS/nixpkgs/commit/8d6e3ef97ea0922ba6340488f187f9b5cc40f97a) supercronic: 0.2.33 -> 0.2.34
* [`b7156459`](https://github.com/NixOS/nixpkgs/commit/b715645912bf630256df3cb379277d3b24a2bee7) parallel-disk-usage: 0.11.0 -> 0.11.1
* [`9435c037`](https://github.com/NixOS/nixpkgs/commit/9435c037d3393eedbf405e3da69ce80d34a9846d) python3Packages.snowflake-core: init at 1.4.0
* [`a3ab14e5`](https://github.com/NixOS/nixpkgs/commit/a3ab14e5687c2b82ab360f086a626d27c42236bd) snowflake-cli: 3.7.2 -> 3.9.1
* [`3f0aff97`](https://github.com/NixOS/nixpkgs/commit/3f0aff97b1b8d23fbc91797da8a10f2a18fffb1a) python3Packages.slack-sdk: fix test
* [`7faa5c3b`](https://github.com/NixOS/nixpkgs/commit/7faa5c3b58f9d001548a0ea863ae8068600a42b4) python3Packages.slack-sdk: clean up dependencies
* [`005f1ba6`](https://github.com/NixOS/nixpkgs/commit/005f1ba61be25dddba9cc5c91b29b8b545bb706e) _1password-gui: 8.10.78 -> 8.10.80
* [`caf9bd6f`](https://github.com/NixOS/nixpkgs/commit/caf9bd6fff6c8c52c52bd884dc106e50b12202c3) _1password-gui-beta: 8.10.80-18.BETA -> 8.10.82-27.BETA
* [`a19d7c04`](https://github.com/NixOS/nixpkgs/commit/a19d7c04cbe58071178b5a65ea88b7ad3b7154d0) python3Packages.metaflow: 2.15.16 -> 2.15.18
* [`33f3cc7a`](https://github.com/NixOS/nixpkgs/commit/33f3cc7a631b7b4d3284d3b48fdadc1af29851e7) google-cloud-sql-proxy: 2.16.0 -> 2.17.1
* [`b08e5d1b`](https://github.com/NixOS/nixpkgs/commit/b08e5d1b4b45886ec5e7478a4db002d6dd499dce) python3Packages.misaki: init at 0-unstable-2025-06-16
* [`1bd1a4c5`](https://github.com/NixOS/nixpkgs/commit/1bd1a4c5fa2120c0d898fd5859d4c5856043983a) python3Packages.kokoro: init at 0-unstable-2025-06-16
* [`b2fb85da`](https://github.com/NixOS/nixpkgs/commit/b2fb85da5411e518221ca04bc993a93f821daf88) quodlibet: fix python3.13 build
* [`06d80984`](https://github.com/NixOS/nixpkgs/commit/06d80984c41e868df755322e0e484be0234c300d) quodlibet: remove usage of with lib
* [`6e2ea580`](https://github.com/NixOS/nixpkgs/commit/6e2ea5804b1c6cc850add5ce71bc749b9b23a95f) python3Packages.influxdb3-python: 0.13.0 -> 0.14.0
* [`33322641`](https://github.com/NixOS/nixpkgs/commit/3332264100e09315411e3f697b930b9635fdafd7) chatbox: 1.13.4 -> 1.14.1
* [`f46c5996`](https://github.com/NixOS/nixpkgs/commit/f46c5996037647a075807b23b9f62418830bdbbd) haproxy: 3.2.0 -> 3.2.1
* [`acd12841`](https://github.com/NixOS/nixpkgs/commit/acd12841e72494c08b561b3ba08ed2887db122ce) python3Packages.pytubefix: 9.1.1 -> 9.2.0
* [`ace78c7d`](https://github.com/NixOS/nixpkgs/commit/ace78c7d30d96f37f1480ede7ba6afa0d3cb41d9) gitea: 1.24.0 -> 1.24.2
* [`a47a09d0`](https://github.com/NixOS/nixpkgs/commit/a47a09d02425355b27ccf64503e6699810e954b4) postman: 11.46.6 -> 11.50.5
* [`ee6a636e`](https://github.com/NixOS/nixpkgs/commit/ee6a636e79cc3e1bb042a079957e6e5334eb79d2) python3Packages.meilisearch: 0.35 -> 0.36.0
* [`058653fc`](https://github.com/NixOS/nixpkgs/commit/058653fcf2b11c9554424ce2562feaba233e6425) koboldcpp: 1.92 -> 1.94
* [`a17a5f07`](https://github.com/NixOS/nixpkgs/commit/a17a5f0711dcc557dc96f60cafe462193155dfed) ciao: 1.24.0-m1 -> 1.25.0-m1
* [`eaa3f8f5`](https://github.com/NixOS/nixpkgs/commit/eaa3f8f57e65777b1953d79b45a697446099646a) mmctl: 10.5.7 -> 10.5.8
* [`171bf759`](https://github.com/NixOS/nixpkgs/commit/171bf759efa64a9ff49813365694b469bf0cd3f2) task-master-ai: add missing dependency
* [`dc86320b`](https://github.com/NixOS/nixpkgs/commit/dc86320b389bbc55e7c9035e235de00c3fa98c40) vllm: use python 3.12 temporarily
* [`c48b594a`](https://github.com/NixOS/nixpkgs/commit/c48b594afc3079d26a1393494c68c01c82c73180) darktable: 5.0.1 -> 5.2.0
* [`5e3aab16`](https://github.com/NixOS/nixpkgs/commit/5e3aab16040afe6fed8d31aa9d08441992126889) clamav: fix tests on sandboxed Darwin
* [`f2e8fd78`](https://github.com/NixOS/nixpkgs/commit/f2e8fd782141e0ebd2d2ec30947b254e1ad30313) victorialogs: init at 1.24.0
* [`b9a699fe`](https://github.com/NixOS/nixpkgs/commit/b9a699fe22f9ac5f54edaa0bf4af0eb31fc9fcf2) nixos/victorialogs: use pkgs.victorialogs by default
* [`ebfbc036`](https://github.com/NixOS/nixpkgs/commit/ebfbc036efb47330c335442b69399a6c6726ed5f) victoriametrics: remove withVictoriaLogs option
* [`3f9e587d`](https://github.com/NixOS/nixpkgs/commit/3f9e587d444f7fbab1d10bacaff787051a4f31e9) nixos/tests/victorialogs: init
* [`5f5df9b7`](https://github.com/NixOS/nixpkgs/commit/5f5df9b7ad7c9892a3d98966a55763e925eb898b) doc/rl-2511: document victorialogs package migration
* [`41cc14c5`](https://github.com/NixOS/nixpkgs/commit/41cc14c5267cf614eabf22ba6de1d161fa32dc35) vulkan-validation-layers: fix Darwin build by enabling robin-hood-hashing
* [`2de73712`](https://github.com/NixOS/nixpkgs/commit/2de73712006191848225dcdbe6ee1f4587b65628) libgcrypt: fix pkgsStatic build on darwin
* [`bcc00506`](https://github.com/NixOS/nixpkgs/commit/bcc00506477f0a971a31dc7b2dd07336ae751f71) bochs: rely on upstream defaults for experimental options
* [`103665f7`](https://github.com/NixOS/nixpkgs/commit/103665f73618d96d20c95c23aeeabb524f41e94d) bochs: add patrickdag as maintainer
* [`0c0da739`](https://github.com/NixOS/nixpkgs/commit/0c0da739e518f6e84821fec6b91ce0f2f15ddac5) bochs: fix build on darwin
* [`1a1030a0`](https://github.com/NixOS/nixpkgs/commit/1a1030a04bcf55221eb186cd159b4f5b9b870869) netbird-dashboard: 2.9.0 -> 2.12.0
* [`bfe2cc4e`](https://github.com/NixOS/nixpkgs/commit/bfe2cc4e7de09e960c2d93ffe4230f82d824767b) python3Packages.langchain: 0.3.25 -> 0.3.26
* [`27d61867`](https://github.com/NixOS/nixpkgs/commit/27d61867d2d84e2aa06ff5c501f30c04e787adc9) citrix-workspace: fix libxml2 build incompatibility
* [`97df806e`](https://github.com/NixOS/nixpkgs/commit/97df806e127928013840935248409a2c36187c8d) python3Packages.gguf: 0.16.3 -> 0.17.1
* [`d7c1bc51`](https://github.com/NixOS/nixpkgs/commit/d7c1bc51825684569a24d12cb0bb8a4428e4b7a9) worldpainter: 2.24.1 -> 2.24.2
* [`90b3f493`](https://github.com/NixOS/nixpkgs/commit/90b3f4931d1b279185ede78b1fca81a707267b86) gaphor: move to pkgs/by-name
* [`7701707a`](https://github.com/NixOS/nixpkgs/commit/7701707afc494359b04f2dde93ed5e3c4c441d5a) gaphor: furnish meta attributes; add normalcea as maintainer
* [`ee4b8baf`](https://github.com/NixOS/nixpkgs/commit/ee4b8baf8b58bcb754dd105d1af503b7819092ce) gaphor: 3.0.0 → 3.1.0
* [`06f284bd`](https://github.com/NixOS/nixpkgs/commit/06f284bd822275c0b62bc619d2eaf5c1fe6384d9) wluma: 4.9.0 -> 4.10.0
* [`2ddd879d`](https://github.com/NixOS/nixpkgs/commit/2ddd879d9e107094316303f217520e6b95111c71) teams/loongarch64: init
* [`20ccea05`](https://github.com/NixOS/nixpkgs/commit/20ccea0556a8d08fcd070c3f1277e3f6bfb27262) mise: 2025.6.2 -> 2025.6.5
* [`0d76ae1c`](https://github.com/NixOS/nixpkgs/commit/0d76ae1c625fe6e4be7aa8300419bbd1d1f1d049) barman: fix changelog
* [`7fe12ac6`](https://github.com/NixOS/nixpkgs/commit/7fe12ac61bddad80916c555293c0f591be78f81d) barman: add update script
* [`8816ae8e`](https://github.com/NixOS/nixpkgs/commit/8816ae8e9c492a2c5a205d7f1c4edfbba4fa6e70) barman: fix building with python 3.13
* [`d00bf419`](https://github.com/NixOS/nixpkgs/commit/d00bf419a2822f8d9c23af5d76086d48978c74a4) barman: 3.13.3 -> 3.14.1
* [`85e7a555`](https://github.com/NixOS/nixpkgs/commit/85e7a555e06e634682cd55bb3767aa05e21eac84) catppuccin-sddm: 1.0.0 -> 1.1.0
* [`cc39a38a`](https://github.com/NixOS/nixpkgs/commit/cc39a38afb43fd7c20b289c1ae676e65bdf9cc8b) fosrl-pangolin: init at 1.2.0
* [`5715cb1e`](https://github.com/NixOS/nixpkgs/commit/5715cb1e8f4e0bae8f8f54f3b38acb24dfa60196) containerd: 2.1.1 -> 2.1.3
* [`91e22a6a`](https://github.com/NixOS/nixpkgs/commit/91e22a6afb596a5525515f1e0e159766b8ce85ea) kubectl: 1.33.1 -> 1.33.2
* [`c70bbdc0`](https://github.com/NixOS/nixpkgs/commit/c70bbdc00e23199d0e35121f97befcb55d343b51) nushell: 104.1 -> 105.1
* [`2090db21`](https://github.com/NixOS/nixpkgs/commit/2090db2149bf522afaff4bfc8ca20a6098a623c4) sgt-puzzles: 20250523.7fa0305 -> 20250615.b589c5e
* [`258f5c09`](https://github.com/NixOS/nixpkgs/commit/258f5c097d7ecdb91f92933839ef84a44be5dd89) treesheets: 0-unstable-2025-06-09 -> 0-unstable-2025-06-21
* [`b52821ab`](https://github.com/NixOS/nixpkgs/commit/b52821ab35eb76d4a226d842aff38d5c5fc16618) ffsubsync: remove future dependency
* [`3d6b631f`](https://github.com/NixOS/nixpkgs/commit/3d6b631faed7820b9f719a613b42da01e253510e) bun: 1.2.16 -> 1.2.17
* [`940d7549`](https://github.com/NixOS/nixpkgs/commit/940d7549f908f3c5a594819852673f1f55a3e16a) kcc: 7.4.1 -> 7.5.1
* [`5a310320`](https://github.com/NixOS/nixpkgs/commit/5a31032032370d9042a06ada4d3c2782bb74cc6b) ouch: disable unrar by default
* [`7763be5a`](https://github.com/NixOS/nixpkgs/commit/7763be5a804630c4a0edc7c1463e3d3562149da7) workflows/pr: refactor base/head branch decision making
* [`a3ce5970`](https://github.com/NixOS/nixpkgs/commit/a3ce5970e073eba9afcdd0ff4174d383ee3fe64e) workflows/{check,reviewers}: don't run on PRs from secondary development branches
* [`4282cb64`](https://github.com/NixOS/nixpkgs/commit/4282cb646b2bb318f4c21704ed2f6e0ef0168d7d) nanoemoji: 0.15.7 -> 0.15.8
* [`6f02fc8a`](https://github.com/NixOS/nixpkgs/commit/6f02fc8abba8caada1dc6bafc3b1485ec7af2e61) readest: 0.9.59 -> 0.9.60
* [`534ccc66`](https://github.com/NixOS/nixpkgs/commit/534ccc66170c9e515910a71fd8232f678b8b9011) vkquake: 1.32.2 -> 1.32.3
* [`0ead4090`](https://github.com/NixOS/nixpkgs/commit/0ead409018e4a3426677d1931158f51074fcacf3) beam26Packages.elvis-erlang: 4.0.0 -> 4.1.1
* [`c949fa5e`](https://github.com/NixOS/nixpkgs/commit/c949fa5ef70fe4434dada38d4e94b33a04538e5a) vscode-extensions.discloud.discloud: 2.22.50 -> 2.23.9
* [`7f1caf53`](https://github.com/NixOS/nixpkgs/commit/7f1caf53226408a3d498ff4e71439a58209929db) pantheon.elementary-code: 7.4.0 -> 8.0.0
* [`004ba2b8`](https://github.com/NixOS/nixpkgs/commit/004ba2b82737d6755855ff9097656927d0423cc1) freerdp: 3.15.0-unstable-2025-05-16 -> 3.16.0
* [`76329597`](https://github.com/NixOS/nixpkgs/commit/76329597f0b4dd2d2a06e45ca2b08d3d1756b0e9) cinnamon-session: Remove unused dbus-glib
* [`d9a5dc03`](https://github.com/NixOS/nixpkgs/commit/d9a5dc035a4bdb0928f552db8d146ade146a9394) glooctl: 1.19.0 -> 1.19.1
* [`e752bd71`](https://github.com/NixOS/nixpkgs/commit/e752bd719cf334c45127ec06f700eac81154b011) beeper: 4.0.747 -> 4.0.779
* [`a3dd1071`](https://github.com/NixOS/nixpkgs/commit/a3dd1071dd208f38c973d48f0a6ab1f3038af485) cardinal: 24.12 -> 25.06
* [`1519c5d1`](https://github.com/NixOS/nixpkgs/commit/1519c5d166803269f5bb672fdd754e6de939a544) gxml: Disable tests
* [`28215026`](https://github.com/NixOS/nixpkgs/commit/28215026fcd44b942f38ac5876e3fcda4f4daed1) planify: 4.12.0 -> 4.12.2
* [`886a573a`](https://github.com/NixOS/nixpkgs/commit/886a573a1c481828eab92ece271366abe14a08a1) doctl: 1.130.0 -> 1.131.0
* [`221364e6`](https://github.com/NixOS/nixpkgs/commit/221364e65c4d288fe7828a3dea24e8a4124c45d1) libdeltachat: 1.159.5 -> 1.160.0
* [`ce2b5cc3`](https://github.com/NixOS/nixpkgs/commit/ce2b5cc39f6a3fab3d90d8d39cf4d3a6314f8f0f) pullomatic: init at 0.2.2
* [`430d1cc4`](https://github.com/NixOS/nixpkgs/commit/430d1cc4b1a2e9a82c89082d9394bd3e8d3e5a9f) python3Packages.adafruit-platformdetect: 3.79.0 -> 3.80.0
* [`b547fd38`](https://github.com/NixOS/nixpkgs/commit/b547fd38e10e89800f2b5a6528c47844d62b260a) vscode-extensions.julialang.language-julia: 1.144.2 -> 1.146.2
* [`73d3e755`](https://github.com/NixOS/nixpkgs/commit/73d3e75571990bb19b584148f16deef5c07fee7d) python3Packages.requests-unixsocket2: 0.4.2 -> 1.0.0
* [`fe7520be`](https://github.com/NixOS/nixpkgs/commit/fe7520befc6e6958426057fefff227b23b800732) jmol: 16.3.25 -> 16.3.27
* [`5282c060`](https://github.com/NixOS/nixpkgs/commit/5282c060a1eb8fbf521c69452a72080f63fc5498) vopono: 0.10.12 -> 0.10.13
* [`197791fb`](https://github.com/NixOS/nixpkgs/commit/197791fb38f25879a400b2485dd30ee9607de9f5) grafana-image-renderer: 3.12.6 -> 3.12.7
* [`d12edda1`](https://github.com/NixOS/nixpkgs/commit/d12edda1b2b87b13b1ae753ed4c622398b18e800) grafana: 12.0.1+security-01 -> 12.0.2
* [`c1da2629`](https://github.com/NixOS/nixpkgs/commit/c1da26295ccaa66f5ab52a3795505d16458ae994) tflint-plugins.tflint-ruleset-google: 0.32.0 -> 0.33.0
* [`180f091b`](https://github.com/NixOS/nixpkgs/commit/180f091b9696c23d824acca9619b9fd241b4edc5) sillytavern: 1.13.0 -> 1.13.1
* [`87645a41`](https://github.com/NixOS/nixpkgs/commit/87645a4153d26b0a9ebe09f609b3d9e86c84d86f) tabiew: 0.9.4 -> 0.10.0
* [`8add8f9c`](https://github.com/NixOS/nixpkgs/commit/8add8f9caed385a58d4ad1a0013722696e994b45) vscode-extensions.ms-dotnettools.csdevkit: fix libxml2 soname breakage.
* [`b3c99164`](https://github.com/NixOS/nixpkgs/commit/b3c9916455799123301a534ba604880e7cc1d7e5) lib.types.attrTag: expose suboptions at correct level
* [`356bf98a`](https://github.com/NixOS/nixpkgs/commit/356bf98a323f6f650748b6ef8fc445442666f514) workflows: log rate limits consistently
* [`ed67750e`](https://github.com/NixOS/nixpkgs/commit/ed67750e822cae357e1b78a994263d6ab79fdb4e) qownnotes: 25.6.2 -> 25.6.4
* [`2ea3fc91`](https://github.com/NixOS/nixpkgs/commit/2ea3fc91438d7a0db284d26120706973255ad427) dita-ot: 4.3.2 -> 4.3.3
* [`fff79c39`](https://github.com/NixOS/nixpkgs/commit/fff79c396505b9ff3afcc1398704009629058581) mandelbulber: cleanup/add tests
* [`088d48f7`](https://github.com/NixOS/nixpkgs/commit/088d48f74e9aec9d422b49d76a206e421d9f1e41) buildstream: Disable troublesome 'hardlinks' test
* [`f4b295d7`](https://github.com/NixOS/nixpkgs/commit/f4b295d7e0517cb5981b3d894d433b5d8c0123a3) signalbackup-tools: 20250617 -> 20250622-1
* [`d3cfd146`](https://github.com/NixOS/nixpkgs/commit/d3cfd14623e9c01d30611d8fea5240724102b2c8) stevenblack-blocklist: 3.15.45 -> 3.15.48
* [`71d484bf`](https://github.com/NixOS/nixpkgs/commit/71d484bf76ba0e57fb3b4aa7847b48f690d3f1c7) amazon-q-cli: 1.10.1 -> 1.12.1
* [`c7758245`](https://github.com/NixOS/nixpkgs/commit/c7758245ad23ee95b70e16331f7b37248cffaf7d) python3Packages.kmapper: cleanup
* [`c2c115b3`](https://github.com/NixOS/nixpkgs/commit/c2c115b35820566b87cabb15ab4cbbbb06a04848) python3Packages.kmapper: add missing test dependency
* [`bed132b2`](https://github.com/NixOS/nixpkgs/commit/bed132b2edf544eddd12111a4332415def230e73) flask-xml-rpc-re: init at v0.2.0
* [`39b9409d`](https://github.com/NixOS/nixpkgs/commit/39b9409d1a178a68fa844c6b80c48d8bf4c14354) nipap: init at v0.32.7
* [`8071d341`](https://github.com/NixOS/nixpkgs/commit/8071d341875c47d1eeb5d8cd08600a2fdd98373a) pynipap: init at 0.32.7
* [`4abad970`](https://github.com/NixOS/nixpkgs/commit/4abad970d7d207d04dddc8e648503e082ca22c6b) nipap-cli: init at 0.32.7
* [`9c9c3642`](https://github.com/NixOS/nixpkgs/commit/9c9c3642f0c96aa81319e620b7233d84ba9da746) nipap-www: init at 0.32.7
* [`5a0374e2`](https://github.com/NixOS/nixpkgs/commit/5a0374e20e3377e95725c15eb304fe073ba72349) postgresqlPackages.ip4r: init at 2.4.2
* [`861c731a`](https://github.com/NixOS/nixpkgs/commit/861c731a4519d0800cd2a475e14c09a3ba0a23ef) intel-compute-runtime: disable mitigations
* [`3dd6e750`](https://github.com/NixOS/nixpkgs/commit/3dd6e7500a1127f0e09e05d39124a443d1db1993) quickemu: correctly handle version 10.0.0 of QEMU
* [`17a4422d`](https://github.com/NixOS/nixpkgs/commit/17a4422dbaa7f308637f602b595e9874c9c9ee16) smpmgr: 0.12.1 -> 0.13.0
* [`97e2238c`](https://github.com/NixOS/nixpkgs/commit/97e2238c00b3537ee2ea3689f450e807515be4a8) bootdev-cli: 1.19.1 -> 1.19.2
* [`51417577`](https://github.com/NixOS/nixpkgs/commit/514175771fadf9987c043121d59d9cd9101d5030) zfind: 0.4.6 -> 0.4.7
* [`1b1eb2bf`](https://github.com/NixOS/nixpkgs/commit/1b1eb2bfcd5d9dcba8e8aba7a26957067398adeb) vdrPlugins.markad: 4.2.12 -> 4.2.14
* [`55f5e6c4`](https://github.com/NixOS/nixpkgs/commit/55f5e6c4e45dc6a70cba5c7b46ea1b80ae254466) python3Packages.mcstatus: 12.0.1 -> 12.0.2
* [`7c6d0a4c`](https://github.com/NixOS/nixpkgs/commit/7c6d0a4c69d0b3ba9612ea50ceafd626907f611e) microfetch: 0.4.8 -> 0.4.9
* [`2c641452`](https://github.com/NixOS/nixpkgs/commit/2c6414527f03bc38b5ef95fca8200b8a74cd5747) home-manager: 0-unstable-2025-06-13 -> 0-unstable-2025-06-22
* [`ac958b92`](https://github.com/NixOS/nixpkgs/commit/ac958b92f6efb34f0aa15fce59b441021da222ff) n8n: 1.97.1 -> 1.98.2
* [`e0bfbb4f`](https://github.com/NixOS/nixpkgs/commit/e0bfbb4ff7ec29d757571a6308ab5ea3e9b22061) fastfetch: fix bash and zsh completion
* [`a28f530c`](https://github.com/NixOS/nixpkgs/commit/a28f530ca451d7cac1b6b87c20ef5b6a9c5add68) vscode-extensions.tabnine.tabnine-vscode: 3.288.0 -> 3.291.0
* [`4cffd125`](https://github.com/NixOS/nixpkgs/commit/4cffd1256d95d708e2f2d7c982f815d5da4ec5fc) snapcraft: 8.9.4 -> 8.9.5
* [`3a48674f`](https://github.com/NixOS/nixpkgs/commit/3a48674fe4d1a9a85a39e907702f03619f17cc6f) terraform-providers.mongodbatlas: 1.35.1 -> 1.36.0
* [`b3df107b`](https://github.com/NixOS/nixpkgs/commit/b3df107bc9372fb076d96c6e335c5e9f8795e546) terraform-providers.bitwarden: 0.13.6 -> 0.14.0
* [`f88c04fe`](https://github.com/NixOS/nixpkgs/commit/f88c04fe338e3e9732878c633c323b636decd77a) terraform-providers.linode: 2.41.0 -> 3.0.0
* [`2bf0366e`](https://github.com/NixOS/nixpkgs/commit/2bf0366e03a2c22f77d102880e31dd014f292725) terraform-providers.cloudflare: 5.5.0 -> 5.6.0
* [`daa1e015`](https://github.com/NixOS/nixpkgs/commit/daa1e01575a7f377619c66abf756336028e02b01) terraform-providers.tailscale: 0.20.0 -> 0.21.1
* [`4114149b`](https://github.com/NixOS/nixpkgs/commit/4114149bce936db2bb6f3ce69cca0ca01ee6bb2a) terraform-providers.tencentcloud: 1.81.199 -> 1.82.2
* [`b3911c74`](https://github.com/NixOS/nixpkgs/commit/b3911c74da644333e208e1d6d654d5ce0f15fdaf) terraform-providers.yandex: 0.142.0 -> 0.144.0
* [`24d85b25`](https://github.com/NixOS/nixpkgs/commit/24d85b2503dd431017a83d476c1c112341ec1c60) descent3-unwrapped: 1.5.0-beta-unstable-2025-06-03 -> 1.5.0-beta-unstable-2025-06-15
* [`9b7c6dd2`](https://github.com/NixOS/nixpkgs/commit/9b7c6dd29cbf552b2228ab5544045cba0d4e15aa) vscode-extensions.visualjj.visualjj: 0.15.1 -> 0.15.4
* [`407ff824`](https://github.com/NixOS/nixpkgs/commit/407ff82478b2559ad1bea7e509cabe77a037082e) tombi: init at 0.4.9
* [`0138ea93`](https://github.com/NixOS/nixpkgs/commit/0138ea938e5652f0ecd09e2d3ce8c86c4e5eb5b6) jwx: 3.0.6 -> 3.0.7
* [`650d9f6c`](https://github.com/NixOS/nixpkgs/commit/650d9f6c249947a6c68cf445cb482a6418f886a4) makejinja: 2.7.2 -> 2.8.0
* [`e3a03b74`](https://github.com/NixOS/nixpkgs/commit/e3a03b74b064b44fd812fc07440e48cbc155f9a5) jasmin-compiler: 2025.02.1 → 2025.06.0
* [`39f1dfdd`](https://github.com/NixOS/nixpkgs/commit/39f1dfddb0fa1b10b481a902055bc484910cdcbc) redu: 0.2.13 -> 0.2.14
* [`2c4021e5`](https://github.com/NixOS/nixpkgs/commit/2c4021e516141fb8f3d3332be282a0ab7a2348b0) masterpdfeditor: add update script
* [`97bc0852`](https://github.com/NixOS/nixpkgs/commit/97bc085262be512b317d47107b2f7ae917246212) masterpdfeditor: use finalAttrs
* [`d03a7436`](https://github.com/NixOS/nixpkgs/commit/d03a743687211fe4a05666adf5f652df73933bd2) cargo-tarpaulin: 0.32.7 -> 0.32.8
* [`19c1b425`](https://github.com/NixOS/nixpkgs/commit/19c1b4250cdca84b18e66187e9e567c2729c5a5e) nixos/omnom: fix module
* [`56c4e8b5`](https://github.com/NixOS/nixpkgs/commit/56c4e8b5b5754d96cfd81b858fd6abc9eb19c484) nixos/test: init omnom
* [`8c9edecd`](https://github.com/NixOS/nixpkgs/commit/8c9edecd5df313613f05e0d708d2e5670c326d52) omnom: 0.3.0 -> 0.4.0
* [`a74b6c32`](https://github.com/NixOS/nixpkgs/commit/a74b6c323b37586fbc97b87e323125407cc2204f) cvc5: enable libpoly and drop antlr
* [`1a8b45f8`](https://github.com/NixOS/nixpkgs/commit/1a8b45f83fb8e679033e101fd48a5ee1f4e7b0ae) gitlab-ci-ls: 1.1.0 -> 1.1.1
* [`f10c9a6e`](https://github.com/NixOS/nixpkgs/commit/f10c9a6eb1710f987ada149cc2feae2753572116) cvc5: 1.2.1 → 1.3.0
* [`1be40ea3`](https://github.com/NixOS/nixpkgs/commit/1be40ea394f5efba7774638a4df6f1ace50b251a) csharp-ls: 0.17.0 -> 0.18.0
* [`65556fad`](https://github.com/NixOS/nixpkgs/commit/65556fad4477846e981183679a2cd02dc4539a64) snx-rs: 4.4.3 -> 4.4.4
* [`151ec2b3`](https://github.com/NixOS/nixpkgs/commit/151ec2b3be3107eb902cdeaa58bcd40c9574c855) monkeysAudio: 11.17 -> 11.18
* [`c90ef3b5`](https://github.com/NixOS/nixpkgs/commit/c90ef3b582a8d98f553b51fa0ab1dcb0ab66b3d6) vivaldi: 7.4.3684.50 -> 7.4.3684.55
* [`2bce33eb`](https://github.com/NixOS/nixpkgs/commit/2bce33eb8e2d61f821a3be63684aac96d5a24fc0) python3Packages.asf-search: 9.0.1 -> 9.0.2
* [`ac976e07`](https://github.com/NixOS/nixpkgs/commit/ac976e074c4f5c056d241b2caaf5271a9d71d262) tombi: 0.4.9 -> 0.4.13
* [`f3688676`](https://github.com/NixOS/nixpkgs/commit/f368867616ca2ee18bc43d4ace1316d65ad79daa) stellarium: 25.1 -> 25.2
* [`238a2c1f`](https://github.com/NixOS/nixpkgs/commit/238a2c1fbfe6e3d4a11c7400c0956df63b632bb1) vault-unseal: 0.7.0 -> 0.7.1
* [`ec62caa3`](https://github.com/NixOS/nixpkgs/commit/ec62caa352cff6fcdd84a74d35259c8c41ef0dc7) talosctl: 1.10.3 -> 1.10.4
* [`5e50d7bd`](https://github.com/NixOS/nixpkgs/commit/5e50d7bdbee0a877e2e05fa5af84128343210d35) nezha: 1.12.4 -> 1.13.0
* [`cfe014a5`](https://github.com/NixOS/nixpkgs/commit/cfe014a5a2a8d65d85036e7216a28371454616b9) ocamlPackages.linol: 0.6 -> 0.10 ([nixos/nixpkgs⁠#399596](https://togithub.com/nixos/nixpkgs/issues/399596))
* [`08d9b291`](https://github.com/NixOS/nixpkgs/commit/08d9b291c9290742c91c16494297624bf6587724) portfolio: 0.77.1 -> 0.77.2
* [`e5a4517c`](https://github.com/NixOS/nixpkgs/commit/e5a4517c5b344139fde9c8d0cc83fbb019919de6) libretro.gambatte: 0-unstable-2025-06-13 -> 0-unstable-2025-06-20
* [`3ac98e61`](https://github.com/NixOS/nixpkgs/commit/3ac98e61ea2781153a7448e2daad4fee61ec6689) python3Packages.translation-finder: 2.19 -> 2.22
* [`246a42e2`](https://github.com/NixOS/nixpkgs/commit/246a42e2af7165a6c5f00f1cced8b017a202566c) is-fast: 0.16.2 -> 0.17.0
* [`3762f3ee`](https://github.com/NixOS/nixpkgs/commit/3762f3eeee581f08a556abcc7bb37cba66a69e70) python313Packages.tencentcloud-sdk-python: 3.0.1405 -> 3.0.1406
* [`89a43bad`](https://github.com/NixOS/nixpkgs/commit/89a43bad9f217cf559bc04b0e063a7d8d2f8c7c9) python313Packages.adafruit-platformdetect: refactor
* [`9ccd8b58`](https://github.com/NixOS/nixpkgs/commit/9ccd8b5835fb71150e44ab0ec05326327c6e71a7) spider: 2.37.104 -> 2.37.120
* [`953d3ec4`](https://github.com/NixOS/nixpkgs/commit/953d3ec4fbc887b53bb97602bcc47ccf634e27fb) eww: 0.6.0-unstable-2025-05-18 -> 0.6.0-unstable-2025-06-17
* [`d3be31f1`](https://github.com/NixOS/nixpkgs/commit/d3be31f18114227db186aa80d10b0f8bb4c7b960) noto-fonts-color-emoji: 2.047 -> 2.048
* [`30a6ce84`](https://github.com/NixOS/nixpkgs/commit/30a6ce842b99b5f790e24a71861ef885542ce010) glamoroustoolkit: 1.1.24 -> 1.1.32
* [`6ab23cbe`](https://github.com/NixOS/nixpkgs/commit/6ab23cbe035d0920efdf8b6a9407344ceb2cd1eb) moonlight: 1.3.19 -> 1.3.21
* [`26d86dfe`](https://github.com/NixOS/nixpkgs/commit/26d86dfe0bcdcc5d61c5fbd29d1e92cba716a58d) python3Packages.etils: adjust dependencies
* [`9e866b1f`](https://github.com/NixOS/nixpkgs/commit/9e866b1f755be3a7ced3fc98bf657c5a4580836b) libretro.dosbox-pure: 0-unstable-2025-06-14 -> 0-unstable-2025-06-16
* [`e67d5cbb`](https://github.com/NixOS/nixpkgs/commit/e67d5cbb6895757e0e16d98e66454e89e08c1bac) pyradio: 0.9.3.11.13 -> 0.9.3.11.15
* [`418cefae`](https://github.com/NixOS/nixpkgs/commit/418cefae105c274fc7e96571f244b185a9f37ae2) python3Packages.guidata: 3.9.0 -> 3.10.0
* [`b598273a`](https://github.com/NixOS/nixpkgs/commit/b598273a40453dbb7933b1b353063466066f213d) pkgs/README: suggest using `git add -A`
* [`acc1c0ae`](https://github.com/NixOS/nixpkgs/commit/acc1c0ae59106180ec63f11503d0f4bd090436c4) workflows/labels: run with app token
* [`c86ced84`](https://github.com/NixOS/nixpkgs/commit/c86ced841967291650b43d712b83b9cf4cb2ec64) linuxPackages.nct6687d: 0-unstable-2025-05-17 -> 0-unstable-2025-06-19
* [`cd5ba218`](https://github.com/NixOS/nixpkgs/commit/cd5ba2187790ccd2c8772765b10a1ad2dd9b649e) python3Packages.bloodyad: 2.1.18 -> 2.1.20
* [`f6619090`](https://github.com/NixOS/nixpkgs/commit/f661909067d8b60416801a99cbb7116aa5d059ee) llvmPackages_git: 21.0.0-unstable-2025-06-15 -> 21.0.0-unstable-2025-06-22
* [`90557640`](https://github.com/NixOS/nixpkgs/commit/905576405e86b41998436dfeb9cb630affcab9c0) discordo: 0-unstable-2025-06-12 -> 0-unstable-2025-06-21
* [`dbe30c8b`](https://github.com/NixOS/nixpkgs/commit/dbe30c8bc11755edd55f179beb15f0f64f829a92) protoc-gen-go-ttrpc: init at 1.2.7
* [`63f6b134`](https://github.com/NixOS/nixpkgs/commit/63f6b134e4e93f6f6b1449751daa41379fb264ee) vscode-extensions.github.vscode-pull-request-github: 0.110.0 -> 0.112.0
* [`ec161f42`](https://github.com/NixOS/nixpkgs/commit/ec161f42ce57934aed3c8001b97dae766abe8373) parallel: 20250522 -> 20250622
* [`33c8949e`](https://github.com/NixOS/nixpkgs/commit/33c8949e5f0404e6181364bfc5e5eb03e4efc704) treewide: refactor meta section part 2
* [`ed9da5a6`](https://github.com/NixOS/nixpkgs/commit/ed9da5a6ac8d1b6a98ae8913494e8db6ebd1132b) typos-lsp: 0.1.38 -> 0.1.39
* [`fd3d596a`](https://github.com/NixOS/nixpkgs/commit/fd3d596a1c55593529681dd3037f25c2a726c3b8) seafile: remove myself from maintainers
* [`c7a85723`](https://github.com/NixOS/nixpkgs/commit/c7a857230bd24947fdf835e397bb43e48729bf83) scaleway-cli: 2.40.0 -> 2.41.0
* [`67537cf7`](https://github.com/NixOS/nixpkgs/commit/67537cf7b5e9998154d6f1cc11c6c71a586109e6) polylith: 0.2.21 -> 0.2.22
* [`bd4ba51b`](https://github.com/NixOS/nixpkgs/commit/bd4ba51bde5f257fa7a32b7bcf2d3ac9a114ce5c) squirreldisk: fix build error
* [`bca445dd`](https://github.com/NixOS/nixpkgs/commit/bca445dd9f00912abc779cb37f849264e8ef6ac8) zmate: init at 0.3.1
* [`02e712b5`](https://github.com/NixOS/nixpkgs/commit/02e712b55419d3b9b69d4366f6c1aa52c97784fd) app2unit: 0.9.0 -> 0.9.2
* [`6418fbd1`](https://github.com/NixOS/nixpkgs/commit/6418fbd1e508775e987138ab1b3553cc421c61ce) artichoke: 0-unstable-2025-06-01 -> 0-unstable-2025-06-18
* [`30be696d`](https://github.com/NixOS/nixpkgs/commit/30be696d9146a2898f0c312985e8cb749449b560) python3Packages.pytensor: skip failing tests
* [`305503a5`](https://github.com/NixOS/nixpkgs/commit/305503a566df7e86e66a31b15a0168a99eee844b) masterpdfeditor: refactor
* [`e09e9cec`](https://github.com/NixOS/nixpkgs/commit/e09e9cec67b3f05e34dad75a0dab68c876c61796) msolve: 0.8.0 -> 0.9.0
* [`bb418688`](https://github.com/NixOS/nixpkgs/commit/bb418688f22d7c5081c03e2432e3701a1130dfb2) masterpdfeditor: 5.9.86 -> 5.9.89
* [`28ad8219`](https://github.com/NixOS/nixpkgs/commit/28ad82198a2432974e9a27256c244f9d90ec27f8) voxinput: 0.3.0 -> 0.4.0
* [`75d0c240`](https://github.com/NixOS/nixpkgs/commit/75d0c240aca1d3634c941fe42ac9a2ebae3cbd3c) microsoft-edge: 137.0.3296.83 -> 137.0.3296.93
* [`842e50a0`](https://github.com/NixOS/nixpkgs/commit/842e50a0fb2385f104645bd4d26990d0c1a76a66) vscode-extensions.miguelsolorio.min-theme: init at 1.5.0
* [`c79710eb`](https://github.com/NixOS/nixpkgs/commit/c79710eb5b275c08a637af55ce4dc2595f2984de) python313Packages.jwt: 1.3.1 -> 1.4.0
* [`aa4026ae`](https://github.com/NixOS/nixpkgs/commit/aa4026ae93eaaa0212316afdbf7a2a0e7a2d5629) python313Packages.jwt: refactor
* [`e5beedde`](https://github.com/NixOS/nixpkgs/commit/e5beedde9135f6669784673072f50484627d1c6d) kanata-with-cmd: 1.8.1 -> 1.9.0
* [`3f2e885e`](https://github.com/NixOS/nixpkgs/commit/3f2e885ebafe84b78f0be504c75ef33135601406) vscode-extensions.bierner.color-info: init at 0.7.2
* [`b9ca25a0`](https://github.com/NixOS/nixpkgs/commit/b9ca25a0820af957d3d2e1c863d9872a0722210f) terraform-providers.spotinst: 1.220.2 -> 1.220.3
* [`86450d70`](https://github.com/NixOS/nixpkgs/commit/86450d70fede84144fc77b353c4facd91b6ad9fc) python3Packages.bambi: skip failing test
* [`2d808017`](https://github.com/NixOS/nixpkgs/commit/2d808017a795d48ce668acf68cb75b0d192c8df7) vcsh: use finalAttrs
* [`c249aba2`](https://github.com/NixOS/nixpkgs/commit/c249aba29ec883896c21821ebaef26123bc0ae23) vcsh: 2.0.8 -> 2.0.10
* [`3c1b4354`](https://github.com/NixOS/nixpkgs/commit/3c1b4354271e640af32f4760d24c9ce2b34bcaed) ffsubsync: update ffmpeg dependency handling and adjust wrapper arguments
* [`dcdbad28`](https://github.com/NixOS/nixpkgs/commit/dcdbad28aa05996406f06433bfec1315d62239c6) terraform-providers.equinix: 3.9.0 -> 3.10.0
* [`3025da9f`](https://github.com/NixOS/nixpkgs/commit/3025da9f8760894ee90d3eedaafe7165843fe441) lint-staged: 16.1.1 -> 16.1.2
* [`ba4405a5`](https://github.com/NixOS/nixpkgs/commit/ba4405a58dcfc6598e0cc20fb588ee882fd631d7)  python312Packages.tensorflow-datasets: adjust dependencies  ([nixos/nixpkgs⁠#419210](https://togithub.com/nixos/nixpkgs/issues/419210))
* [`b04c5aae`](https://github.com/NixOS/nixpkgs/commit/b04c5aae9628607ea063ed68848343faa1aa247f) pantheon.xdg-desktop-portal-pantheon: 8.0.3 -> 8.0.4
* [`a69fe005`](https://github.com/NixOS/nixpkgs/commit/a69fe005dcd475f5418dbd44866e89c561d888a6) nss_latest: 3.112 -> 3.113
* [`e8c80f28`](https://github.com/NixOS/nixpkgs/commit/e8c80f28fa6b7aed905e3d2059287dacaf9295cf) firefox-unwrapped: 139.0.4 -> 140.0
* [`e0ece258`](https://github.com/NixOS/nixpkgs/commit/e0ece2582646de63907926af098e2cfeafb239c6) firefox-bin-unwrapped: 139.0.4 -> 140.0
* [`55fbc4c0`](https://github.com/NixOS/nixpkgs/commit/55fbc4c0e05a476550743c164744bea79cbec43e) firefox-esr-128-unwrapped: 128.11.0esr -> 128.12.0esr
* [`411e69f2`](https://github.com/NixOS/nixpkgs/commit/411e69f2d1073c7a1f1eae668d7fb19600811447) ceph-csi: 3.14.0 -> 3.14.1
* [`7e71204f`](https://github.com/NixOS/nixpkgs/commit/7e71204f2ccd0ef91acd103d6c4a76b8697cd019) tauno-monitor: 0.2.0 -> 0.2.1
* [`c65d54a7`](https://github.com/NixOS/nixpkgs/commit/c65d54a793af7d8a9f996a80924f94e385f5779b) seagoat: 1.0.8 -> 1.0.9
* [`1fa65046`](https://github.com/NixOS/nixpkgs/commit/1fa650463cf0f5abad01667859175c3092f7aa09) ci/OWNERS: add kernel team to relevant files
* [`1e9b8283`](https://github.com/NixOS/nixpkgs/commit/1e9b82839c1a2449e8e050caac9c9c71c8fa248c) itgmania: 1.0.2 -> 1.1.0
* [`577bb801`](https://github.com/NixOS/nixpkgs/commit/577bb801ec758641bc5b8f5d4d6e9a95d6146cbe) vscode-extensions.devsense.composer-php-vscode: 1.59.17466 -> 1.59.17515
* [`3e03b7bc`](https://github.com/NixOS/nixpkgs/commit/3e03b7bcc55e3fc8874c2f408e73fd45904ab313) python3Packages.aioautomower: 2025.5.1 -> 2025.6.0
* [`00734170`](https://github.com/NixOS/nixpkgs/commit/00734170e272760a1d9adc182180ac19a77dc2fa) python3Packages.dvc-s3: 3.2.1 -> 3.2.2
* [`7aa3d675`](https://github.com/NixOS/nixpkgs/commit/7aa3d675200b7eb3914ae39ec19ccf4340f67134) taterclient-ddnet: 10.3.0 -> 10.4.0
* [`f31b7313`](https://github.com/NixOS/nixpkgs/commit/f31b7313b87edfc41052635334525d1a65411460) libcosmicAppHook: Fix cross-compilation
* [`c9bd45f6`](https://github.com/NixOS/nixpkgs/commit/c9bd45f6dc65f0005f9632d3bc367b82e9ce3f41) quodlibet: 4.6.0-unstable-2024-08-08 -> 4.7.1
* [`0480b545`](https://github.com/NixOS/nixpkgs/commit/0480b545101520d4d37ccbb64683968d9332f500) quodlibet: clean up derivation
* [`aed02e7a`](https://github.com/NixOS/nixpkgs/commit/aed02e7af1bc3073f8e5baa8c01d729c290e12ae) python3Packages.textual: 3.4.0 -> 3.5.0
* [`177f922f`](https://github.com/NixOS/nixpkgs/commit/177f922fcc427f67a7e8f16a0634f235dc30f6ee) memray: skip failing tests
* [`687ce946`](https://github.com/NixOS/nixpkgs/commit/687ce9463bc21af5abf2ba88bec657fb9a6834ec) ghostfolio: 2.170.0 -> 2.173.0
* [`aa3ffdc2`](https://github.com/NixOS/nixpkgs/commit/aa3ffdc2f9c932508fc2a91bf861ce4eb6465107) phpunit: 12.2.2 -> 12.2.3
* [`0c84d34f`](https://github.com/NixOS/nixpkgs/commit/0c84d34f95dbd0dd15eb47a93d2464a799f0cfb1) factorPackages.buildFactorVocab: fix find directory typo
* [`de22d88a`](https://github.com/NixOS/nixpkgs/commit/de22d88acafc95e7d586b9c998485d51c4a8937f) waybar: 0.12.0-unstable-2025-06-13 -> 0.13.0
* [`ed9275ad`](https://github.com/NixOS/nixpkgs/commit/ed9275adcb12a840e50a2afec72df2655b440c1f) python3Packages.uiprotect: 7.13.0 -> 7.14.1 ([nixos/nixpkgs⁠#419323](https://togithub.com/nixos/nixpkgs/issues/419323))
* [`b850eb81`](https://github.com/NixOS/nixpkgs/commit/b850eb81e21438f79928e9ce62a17c948db22ee1) buildstream: Add `buildbox` as a dependency
* [`3d23a55d`](https://github.com/NixOS/nixpkgs/commit/3d23a55dbc341d0a324eb4003b6d6805b78b09cd) python3Packages.fedora-messaging: 3.7.1 -> 3.8.0
* [`18f89bfb`](https://github.com/NixOS/nixpkgs/commit/18f89bfb370f5a496fd2a4cac5d497e87a6a81f4) firefly-iii: 6.2.17 -> 6.2.18
* [`1da9c9a3`](https://github.com/NixOS/nixpkgs/commit/1da9c9a39ac6cb9b662be922b2ebd84624c0a144) maintainers: add jherland
* [`8884e1b1`](https://github.com/NixOS/nixpkgs/commit/8884e1b147a1394a5c9b4cc5c3c3a48abd3fbe70) nixos/plasma6: install ktexteditor explicitly
* [`a2b5af47`](https://github.com/NixOS/nixpkgs/commit/a2b5af4710f1f9011a1ac5896b396c39debda090) limine-install: cleanup, improve type hinting ([nixos/nixpkgs⁠#416188](https://togithub.com/nixos/nixpkgs/issues/416188))
* [`11491149`](https://github.com/NixOS/nixpkgs/commit/114911496ecb5e3b4d6d09a2e93a3b2721e43c41) pykickstart: 3.64 -> 3.65
* [`3597a760`](https://github.com/NixOS/nixpkgs/commit/3597a760ec0946022450a8eb97feb1af5f9d3660) libretro.play: 0-unstable-2025-06-13 -> 0-unstable-2025-06-18
* [`2fcf435b`](https://github.com/NixOS/nixpkgs/commit/2fcf435b8854acd692467a4df39600aed7ba540c) phpdocumentor: 3.7.1 -> 3.8.0
* [`ed5f0fbf`](https://github.com/NixOS/nixpkgs/commit/ed5f0fbfcd89b6109c48e2c8f1909d83b08ab33c) nixos/repart-image: don't pass seed when it's null, update documentation
* [`e0b5037a`](https://github.com/NixOS/nixpkgs/commit/e0b5037a58bd048e22750683800fc6073a2dde05) home-assistant-custom-components.localtuya: 2025.5.1 -> 2025.6.0
* [`ac8cc910`](https://github.com/NixOS/nixpkgs/commit/ac8cc9101171dfb12823352e7408d2e82ef77c3e) lima: prefer versionCheckHook
* [`bee86124`](https://github.com/NixOS/nixpkgs/commit/bee861240dd68621cdb4b48321d45595854fd0dd) dprint: prefer versionCheckHook
* [`f42e6417`](https://github.com/NixOS/nixpkgs/commit/f42e6417991a6aa331456bcc8b526d45f54adeff) python3Packages.qdrant-client: 1.14.2 -> 1.14.3
* [`5140786a`](https://github.com/NixOS/nixpkgs/commit/5140786aa0f86a93092c144a24fc6fbf93ab40c7) seppo: init at 0-unstable-2025-06-03
* [`c841e4ba`](https://github.com/NixOS/nixpkgs/commit/c841e4ba74581a9a263a0bfb73b667435ea9b49e) vectorcode: add python-dotenv to allow use with .env files
* [`0449b4bd`](https://github.com/NixOS/nixpkgs/commit/0449b4bda4d91031193561d2a66c9fcc18c2ef02) libxeddsa: 2.0.0 -> 2.0.1
* [`2b0cf45a`](https://github.com/NixOS/nixpkgs/commit/2b0cf45a1a29b1c503c7d6da2b1ef5e4c2826cd5) kitty-img: 1.0.0 -> 1.1.0
* [`9fec8d17`](https://github.com/NixOS/nixpkgs/commit/9fec8d171986c464698849dfc56d67619484b17e) python3Packages.openai: 1.87.0 -> 1.91.0
* [`b8b9cab6`](https://github.com/NixOS/nixpkgs/commit/b8b9cab64ec2cefb1b51d8e6b14eac6ea2b48616) runme: 3.14.0 -> 3.14.1
* [`7676e88c`](https://github.com/NixOS/nixpkgs/commit/7676e88c94f4ec396bc025d9b90b8821d324cafd) rasm: 2.3.6 -> 2.3.7
* [`9eda4e04`](https://github.com/NixOS/nixpkgs/commit/9eda4e0497e24eea2c1481bdc5be3832c647d4f1) dolt: 1.55.1 -> 1.55.2
* [`f27fdfde`](https://github.com/NixOS/nixpkgs/commit/f27fdfdef425394b3a4a806d77edc19d29693689) jumppad: 0.20.1 -> 0.21.0
* [`e7fc9fbc`](https://github.com/NixOS/nixpkgs/commit/e7fc9fbca2599dc0889df574c4bdfdef23f176f2) openfga: 1.8.15 -> 1.8.16
* [`7884233b`](https://github.com/NixOS/nixpkgs/commit/7884233bbc571b2c8f24d5722e3c3f08411949e4) gum: 0.16.1 -> 0.16.2
* [`79df31ad`](https://github.com/NixOS/nixpkgs/commit/79df31ad38c6ccbc024ad5558b7a895b056849b1) python3Packages.pygmt: 0.15.0 -> 0.16.0
* [`caa29e79`](https://github.com/NixOS/nixpkgs/commit/caa29e794a70a12518ab3dc7506f3273272665b2) mailutils: 3.18 -> 3.19
* [`ead178c6`](https://github.com/NixOS/nixpkgs/commit/ead178c65449968cbb25816cfa542e5666adb1ff) mailutils: modernize derivation
* [`b298fd73`](https://github.com/NixOS/nixpkgs/commit/b298fd73d3c8e9067868070c4b0567db175d8764) mailutils: remove crufty workarounds
* [`1fa31845`](https://github.com/NixOS/nixpkgs/commit/1fa3184541f146b0e32e664156306abd09f5d483) mailutils: unpin guile
* [`66f7d2de`](https://github.com/NixOS/nixpkgs/commit/66f7d2de7441d4e17b751adc56d548c5800387ed) mailutils: allow all hardening flags
* [`e2a57232`](https://github.com/NixOS/nixpkgs/commit/e2a57232aaa7a7ec4ec28dd7d23e8daa7110b9da) mailutils: explicitly use gsasl
* [`59eafaa9`](https://github.com/NixOS/nixpkgs/commit/59eafaa9409923969fc29204cddd1c0aa950513e) mailutils: move to pkgs/by-name
* [`bee4a14c`](https://github.com/NixOS/nixpkgs/commit/bee4a14cc7a78dff7d9457506f9ce3ece4ed5fbc) diesel-cli: 2.2.10 -> 2.2.11
* [`994be05a`](https://github.com/NixOS/nixpkgs/commit/994be05a7667876e58b69ec5122a878a50abd42d) doppler: 3.75.0 -> 3.75.1
* [`8697db82`](https://github.com/NixOS/nixpkgs/commit/8697db8260ae53074d5837ccfe092a2cce3fab58) circleci-cli: 0.1.32367 -> 0.1.32580
* [`f1c8b25d`](https://github.com/NixOS/nixpkgs/commit/f1c8b25dab4643dfcf6dc491432848f15e2c204b) cargo-xwin: 0.18.6 -> 0.19.0
* [`9d644e7e`](https://github.com/NixOS/nixpkgs/commit/9d644e7eedb4abfb24b34185f9c27bfd1a99fb6f) qrencode: adopt, cleanup
* [`5810a0aa`](https://github.com/NixOS/nixpkgs/commit/5810a0aaaa00c883ac81689d8bad30765f631858) avrdude: 8.0 -> 8.1
* [`a013d925`](https://github.com/NixOS/nixpkgs/commit/a013d9258c510d8660e64aaf1200946864959d6a) nixos/nipap: init
* [`9f7948fb`](https://github.com/NixOS/nixpkgs/commit/9f7948fbecd670768e1372773a301d21916c6bb0) nixosTests.nipap: init nipap test
* [`a081327e`](https://github.com/NixOS/nixpkgs/commit/a081327e235368cfc04c6cf0689dec625cdad68d) python3Packages.aioamazondevices: 3.1.12 -> 3.1.14
* [`9844427d`](https://github.com/NixOS/nixpkgs/commit/9844427d4f9a5601d6a6353ca19547478213a541) python3Packages.aioesphomeapi: 32.2.1 -> 33.1.1
* [`9ffbe82e`](https://github.com/NixOS/nixpkgs/commit/9ffbe82e18e641abe85c7e5570f42c71dbf1f1b3) python3Packages.bthome-ble: 3.13.0 -> 3.13.1 ([nixos/nixpkgs⁠#416937](https://togithub.com/nixos/nixpkgs/issues/416937))
* [`b3ea1252`](https://github.com/NixOS/nixpkgs/commit/b3ea12521f362a9201da2c4b506225ed743ad593) python3Packages.deebot-client: 13.3.0 -> 13.4.0
* [`8798c7d0`](https://github.com/NixOS/nixpkgs/commit/8798c7d006ff932da93782f8dfd2dd1572f7e9d4) python3Packages.homematicip: 2.0.5 -> 2.0.6
* [`24b54378`](https://github.com/NixOS/nixpkgs/commit/24b5437818010d3fa52902f353815d950bd12b03) python3Packages.zigpy-zigate: 0.13.2 -> 0.13.3
* [`10a5a91b`](https://github.com/NixOS/nixpkgs/commit/10a5a91bc0a8093d22b2d7d8f696dd084ddf47ca) vectorcode: add bundled chromadb to path
* [`624c2247`](https://github.com/NixOS/nixpkgs/commit/624c224795906207ba12de0a9c748ae8375a70f0) python3Packages.zigpy-znp: 0.14.0 -> 0.14.1
* [`bfefc8d2`](https://github.com/NixOS/nixpkgs/commit/bfefc8d2f32a4f9d60da1cec33f67d2957a42f6d) gnat-bootstrap: remove ld binaries
* [`ab398693`](https://github.com/NixOS/nixpkgs/commit/ab39869328248d4dae26cee94e7c0c8b9390adf3) python3Packages.zha: 0.0.59 -> 0.0.60
* [`1b7c6b61`](https://github.com/NixOS/nixpkgs/commit/1b7c6b61801ad5f2ebff2a2676cd0176d3418463) home-assistant: 2025.6.1 -> 2025.6.2
* [`aad68ab9`](https://github.com/NixOS/nixpkgs/commit/aad68ab9fbbe7da256c0b5979733869a4501f223) python3Packages.gliner: 0.2.20 -> 0.2.21
* [`fdb24670`](https://github.com/NixOS/nixpkgs/commit/fdb246701566109fbdea47a14c0b91482fc16087) magento-cloud: use versionCheckHook
* [`86d9cfd5`](https://github.com/NixOS/nixpkgs/commit/86d9cfd59885ee9aef42296b9fdad1e0a1a410de) python312Packages.netbox-topology-views: fix
* [`3b51de60`](https://github.com/NixOS/nixpkgs/commit/3b51de60e99300e67722f21b15f9917d3bf8f9c3) python312Packages.netbox-napalm-plugin: fix
* [`cd28da24`](https://github.com/NixOS/nixpkgs/commit/cd28da246134d66128e76ce2110aca72226a11e4) python312Packages.netbox-floorplan-plugin: fix
* [`a0cf5b7d`](https://github.com/NixOS/nixpkgs/commit/a0cf5b7d10e8d3eb4f1ac5d108b69949a3f00e10) python312Packages.netbox-contract: fix
* [`fcc7e04c`](https://github.com/NixOS/nixpkgs/commit/fcc7e04c6970b79b654b0ac23acd866936381720) python312Packages.netbox-attachments: fix
* [`a8ca46cf`](https://github.com/NixOS/nixpkgs/commit/a8ca46cf78201c05fa6943f871529c1726371d36) oci2git: 0.1.4 -> 0.1.5
* [`65a6d709`](https://github.com/NixOS/nixpkgs/commit/65a6d7099057b013a65b6563585ffb1b500281e7) fluxcd-operator-mcp: 0.22.0 -> 0.23.0
* [`7891319c`](https://github.com/NixOS/nixpkgs/commit/7891319ca81736c66ebd56d1d95a6941f74c5096) victoriametrics: 1.119.0 -> 1.120.0
* [`64deeffc`](https://github.com/NixOS/nixpkgs/commit/64deeffc0802c55d9b6bc24ea8913fac0349b862) python3Packages.asyncstdlib-fw: init at 3.13.2
* [`c7aef91f`](https://github.com/NixOS/nixpkgs/commit/c7aef91feb8aa82f5d3ff968fe17fe8cf2c403c6) garage_0_x: disable tests
* [`d30cf51b`](https://github.com/NixOS/nixpkgs/commit/d30cf51b8940997221bd0b19ec810dcd0d010f6c) python3Packages.safetensors: 0.5.2 -> 0.6.0
* [`e2e86122`](https://github.com/NixOS/nixpkgs/commit/e2e861227212a1e40d2f022949474cd281a0b984) python3Packages.betterproto-rust-codec: init at 0.1.1
* [`dea994cf`](https://github.com/NixOS/nixpkgs/commit/dea994cf5fa0e83a0942859197336b3433fa2bcb) python3Packages.betterproto-fw: init at 2.0.3
* [`c9be4e50`](https://github.com/NixOS/nixpkgs/commit/c9be4e509ea3e8a0614443a559ce4ad5f28c4be3) python312Packages.fireworks-ai: 0.15.13 -> 0.17.16
* [`b28a98e5`](https://github.com/NixOS/nixpkgs/commit/b28a98e5f116a434dc9819f08ebb8e9598218f0a) python3Packages.awsiotsdk: 1.22.2 -> 1.23.0
* [`d24bba62`](https://github.com/NixOS/nixpkgs/commit/d24bba6220abb8e5199ffb3024f79e4b6e69e666) zapzap: 6.0.1.8 -> 6.1
* [`cd3c21eb`](https://github.com/NixOS/nixpkgs/commit/cd3c21eba6c053b55713e61e7d6c6542fc22d608) libe-book: fix cross-compilation
* [`42271f3d`](https://github.com/NixOS/nixpkgs/commit/42271f3d95ddd75ac76088dbae63e7f651939fb0) tana: 1.0.32 -> 1.0.36
* [`bed3f503`](https://github.com/NixOS/nixpkgs/commit/bed3f503627c224c6999284f98efba17791721b8) xtensor-blas: init at 0.22.0
* [`794e7a17`](https://github.com/NixOS/nixpkgs/commit/794e7a17c13f6bdc0e06020949cd22e0ab433871) gh: 2.74.1 -> 2.74.2
* [`dbf79155`](https://github.com/NixOS/nixpkgs/commit/dbf79155e6046e7a80e6c37fe1551ad7cab669de) supermariowar: 2024-unstable-2025-04-03 -> 2024-unstable-2025-06-18
* [`e2908c53`](https://github.com/NixOS/nixpkgs/commit/e2908c536e25c722d2984ef4a3fd08bbb2c71df6) firefox-esr-128-unwrapped: fix build on darwin
* [`a5926fef`](https://github.com/NixOS/nixpkgs/commit/a5926fef4fb44e8551c0b5f6f323302259999d9e) dprint-plugins.dprint-plugin-markdown: 0.18.0 -> 0.19.0
* [`0cde186e`](https://github.com/NixOS/nixpkgs/commit/0cde186e047281c5d84a1cf3897be181e9a378c7) guacamole-client: 1.5.5 -> 1.6.0
* [`f4881e44`](https://github.com/NixOS/nixpkgs/commit/f4881e4427bd14a31b41427d122c278c79735f66) osslsigncode: 2.9 -> 2.10
* [`52361281`](https://github.com/NixOS/nixpkgs/commit/523612816bda21e78f190356459387d9d0a99e24) az-pim-cli: use versionCheckHook
* [`40e9c371`](https://github.com/NixOS/nixpkgs/commit/40e9c371ebf917f4e0e2a06493d21a33b331376c) dms: 1.7.1 -> 1.7.2
* [`ebd1c636`](https://github.com/NixOS/nixpkgs/commit/ebd1c636f119ae5a143ceb9e800a6f3bdb7078f4) ntfy-alertmanager: 0.4.0 -> 0.5.0
* [`80d6992a`](https://github.com/NixOS/nixpkgs/commit/80d6992a2dd653fe35b8e7a408e49b0e6956c533) wishlist: 0.15.1 -> 0.15.2
* [`e8783077`](https://github.com/NixOS/nixpkgs/commit/e878307708630955e5f774caea9b24916adc9c06) gitqlient: modernize
* [`3b5c14a2`](https://github.com/NixOS/nixpkgs/commit/3b5c14a2c70c086effd0da24f7365924f8fbf2a4) gitqlient: move to by-name
* [`01733d53`](https://github.com/NixOS/nixpkgs/commit/01733d53b09e5b0f1792ef5ecf49447985d72a30) rmpc: 0.8.0 -> 0.9.0
* [`b4e19ca0`](https://github.com/NixOS/nixpkgs/commit/b4e19ca085156fe33b24b49777813c8559b76794) runitor: 1.4.0 -> 1.4.1
* [`52ded836`](https://github.com/NixOS/nixpkgs/commit/52ded8363913f7b5467d115ac4e99ea0cab2e149) python3Packages.pyexploitdb: 0.2.85 -> 0.2.86
* [`6795cd96`](https://github.com/NixOS/nixpkgs/commit/6795cd96c89ea21b81c46184a036ecb12a3a9543) srgn: 0.13.7 -> 0.14.0
* [`56bc6960`](https://github.com/NixOS/nixpkgs/commit/56bc6960a4e55e1cac8a8945574832fcf2157a12) zsh-wd: 0.10.0 -> 0.10.1
* [`f5d66c8b`](https://github.com/NixOS/nixpkgs/commit/f5d66c8b0668abfdfd96a0c2438844aabf63243d) hugo: 0.147.8 -> 0.147.9
* [`31cffc1e`](https://github.com/NixOS/nixpkgs/commit/31cffc1edde308f007c83e8d3bf733253d4f87e4) python3Packages.wcmatch: 10.0 -> 10.1
* [`864a6fdd`](https://github.com/NixOS/nixpkgs/commit/864a6fdd7f577e2cab3c44866017b2f5ce84b5d8) uv: 0.7.13 -> 0.7.14
* [`72d337c2`](https://github.com/NixOS/nixpkgs/commit/72d337c224a8ae43b365961b2e2511b580192988) sql-formatter: 15.6.4 -> 15.6.5
* [`35974b1e`](https://github.com/NixOS/nixpkgs/commit/35974b1ee31bce1a66d9d25e901d0ee2e8d84819) terraform-providers.sakuracloud: 2.27.0 -> 2.28.0
* [`9abe80ee`](https://github.com/NixOS/nixpkgs/commit/9abe80ee31cf7db5bfea0f5980846dab6c994356) python3Packages.switchbot-api: 2.5.0 -> 2.6.0
* [`c50af17f`](https://github.com/NixOS/nixpkgs/commit/c50af17f7852ce82d8d3984d659ce34820e1fed8) wezterm: fix app bundle on darwin
* [`f7359cfb`](https://github.com/NixOS/nixpkgs/commit/f7359cfb204fa2fa38e712d628d74ef65cf0eece) python3Packages.dbt-semantic-interfaces: 0.8.1 -> 0.8.4
* [`2d6c75d8`](https://github.com/NixOS/nixpkgs/commit/2d6c75d8d8fcfc7365524f643b749cb4e6a5a7d4) powerstation: 0.6.0 -> 0.6.1
* [`ef105f44`](https://github.com/NixOS/nixpkgs/commit/ef105f441abeced5abb65ceca7f9daed94371485) nelm: 1.6.0 -> 1.7.0
* [`28bce488`](https://github.com/NixOS/nixpkgs/commit/28bce48828a513af0c844fa067e1d9ad62558840) nushellPlugins.highlight: 1.4.5+0.104.0 -> 1.4.7+0.105.1
* [`3515e24a`](https://github.com/NixOS/nixpkgs/commit/3515e24a18155120d39a82b8844b3bf67bc7cf9e) roddhjav-apparmor-rules: 0-unstable-2025-06-12 -> 0-unstable-2025-06-21
* [`9034c1e4`](https://github.com/NixOS/nixpkgs/commit/9034c1e40a24876a5c0aa8a64a0ba3af65995b2c) halo: 2.21.0 -> 2.21.1
* [`fd751b2c`](https://github.com/NixOS/nixpkgs/commit/fd751b2cae7edc93d8f4bf11916169aae84964aa) vscode: expose vscodeVersion as a passthru attribute
* [`083009d8`](https://github.com/NixOS/nixpkgs/commit/083009d87284ebc4d90672534356fb7d66c9cff5) maintainers/team-list: jetbrains add jamesward
* [`9079857a`](https://github.com/NixOS/nixpkgs/commit/9079857aba0efeaca48dfddcc72fd4fe2b2803c8) auto-editor: 28.0.1 -> 28.0.2
* [`a6e88390`](https://github.com/NixOS/nixpkgs/commit/a6e883907839ef0543d7b870a5d7346584a45889) wiringpi: 3.10 -> 3.16
* [`8976f8ad`](https://github.com/NixOS/nixpkgs/commit/8976f8ad3ba71ea5eaa3ca0dfd39e5b9e1500484) wiringpi: remove `with lib`, add ryand56 as maintainer
* [`24e7e47c`](https://github.com/NixOS/nixpkgs/commit/24e7e47c91afc7e1c264c14c723a7f57e5241dee) workflows/labels: dynamically adjust reservoir to remaining rate limit
* [`2cc80301`](https://github.com/NixOS/nixpkgs/commit/2cc803016c08c0b09a2d30b8872748844b00e9f7) oh-my-zsh: 2025-06-10 -> 2025-06-19
* [`9c2c54e3`](https://github.com/NixOS/nixpkgs/commit/9c2c54e34bc0bc163f869ac1e51d1bdff8125d09) symfony-cli: 5.11.0 -> 5.12.0
* [`37a725b5`](https://github.com/NixOS/nixpkgs/commit/37a725b5ef2ec49e3fb8dc89b409fe2327abeb26) python3Packages.lib4package: 0.3.2 -> 0.3.3
* [`e26d01af`](https://github.com/NixOS/nixpkgs/commit/e26d01aff43d0d097daec233d4b6a181230c4a35) go-exploitdb: 0.5.0 -> 0.6.0
* [`4b083a7d`](https://github.com/NixOS/nixpkgs/commit/4b083a7db8bd55fad5acb8a794f3944e5f27472f) linuxKernel.kernels.linux_lqx: 6.15.2 -> 6.15.3
* [`4fe7209f`](https://github.com/NixOS/nixpkgs/commit/4fe7209f36a2e9d9cb987b9cc6544e1d46cdc41e) lstr: 0.2.0 -> 0.2.1
* [`00f33e63`](https://github.com/NixOS/nixpkgs/commit/00f33e6316283f98ae54b6890aeacd00a3511190) python313Packages.lib4package: fix description typo
* [`0531394d`](https://github.com/NixOS/nixpkgs/commit/0531394d882e9f142fe334b9e741a953a38c95cb) mdbook-d2: 0.3.4 -> 0.3.5
* [`2aa9f0db`](https://github.com/NixOS/nixpkgs/commit/2aa9f0db329a5de14556d9c357f3ae9c7513c90b) kdePackages.kirigami: backport patch recommended by upstream
* [`33ce0ba4`](https://github.com/NixOS/nixpkgs/commit/33ce0ba4f9b590748289ad6b172b375f3736f389) kdePackages.kdepim-runtime: backport patch recommended by upstream
* [`f9bd91aa`](https://github.com/NixOS/nixpkgs/commit/f9bd91aa07c30359540aeec8613a29f0b742f540) nixos/bcachefs: include poly1305 and chacha20 kernel modules for kernel < 6.15
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
