### PR TITLE
niv nixpkgs: update 7d7f2608 -> 25b40d75

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -155,10 +155,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "7d7f26089219e03cd47eff924eac18deb525ea62",
-        "sha256": "1c6d961j88h6l7h0rhdmywyyxaks2wagw2zvrr7rg2j0yk2sshky",
+        "rev": "25b40d755501e3e5c499723b0e5b401bd67e7830",
+        "sha256": "0b2bm600h2psvgzqr7makzv7wg4y8f2k21gyn6a4xhpkblxxvx6l",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/7d7f26089219e03cd47eff924eac18deb525ea62.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/25b40d755501e3e5c499723b0e5b401bd67e7830.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@7d7f2608...25b40d75](https://github.com/nixos/nixpkgs/compare/7d7f26089219e03cd47eff924eac18deb525ea62...25b40d755501e3e5c499723b0e5b401bd67e7830)

* [`db874485`](https://github.com/NixOS/nixpkgs/commit/db87448540a528c51e145ab5287c7bb46e34028e) maintainers: add Nindouja
* [`4457f52f`](https://github.com/NixOS/nixpkgs/commit/4457f52f679f8f6b24ee675ffdc07d29d6393e17) maintainers: add Darkalex
* [`cf1dc580`](https://github.com/NixOS/nixpkgs/commit/cf1dc580d1ef0d884482e3032eb58d8e07b97043) managarr: add darkalex and nindouja to maintainers
* [`51ddcb48`](https://github.com/NixOS/nixpkgs/commit/51ddcb481f73e90137a19b2948a77185d885b794) prometheus-mailman3-exporter: init at 0.9.1
* [`d33d1dda`](https://github.com/NixOS/nixpkgs/commit/d33d1dda8f50f1cf681ff8806bede4c9b5e8d599) nixos/prometheus-mailman3-exporter: init module
* [`a119ecea`](https://github.com/NixOS/nixpkgs/commit/a119ecea11e51cb65bb9ab5c09036d3ab54c3f4c) pyxel: 2.1.6 -> 2.3.18
* [`c4fae33b`](https://github.com/NixOS/nixpkgs/commit/c4fae33b450397a4574136ec838eed02e6d0b996) hunspell: refactor to by-name and finalAttrs
* [`d8220bdb`](https://github.com/NixOS/nixpkgs/commit/d8220bdba88e6ea898672739b7739039b3a28d6b) hunspell: refactor, add withDict wrapper passthru function
* [`42a03465`](https://github.com/NixOS/nixpkgs/commit/42a03465e45059069e85e27af1046aa038bca9ee) onboard: Fix hunspell warning
* [`126b88ba`](https://github.com/NixOS/nixpkgs/commit/126b88ba138c6accc3bd2ce0a7acf18ae672b93e) linuxwave: 0.2.0 -> 0.3.0
* [`ec038e96`](https://github.com/NixOS/nixpkgs/commit/ec038e960e0d689a00b00979a61b22968120b3ff) sipsak: 4.1.2.1 -> 4.5.12.1
* [`2d66a5a3`](https://github.com/NixOS/nixpkgs/commit/2d66a5a3bfcd1fa54976e3d265949391a845377f) python3Packages.openfga-sdk: 0.9.1 -> 0.9.4
* [`2f123aff`](https://github.com/NixOS/nixpkgs/commit/2f123aff3975665cc3e5f00082f1213f0ba6b88f) python3Packages.crytic-compile: 0.3.9 -> 0.3.10
* [`649a542f`](https://github.com/NixOS/nixpkgs/commit/649a542f80c7901a225fc17f3335939b2bf15bff) python3Packages.dbt-adapters: 1.14.4 -> 1.14.8
* [`7a049cc8`](https://github.com/NixOS/nixpkgs/commit/7a049cc82294029878cf519c082a155bcaf6b5f6) speedscope: init at 1.22.2
* [`c1d55a12`](https://github.com/NixOS/nixpkgs/commit/c1d55a122aeb1aaf41f323471f3f98f1088419e8) python3Packages.pythonfinder: 2.1.0 -> 3.0.0
* [`809103f3`](https://github.com/NixOS/nixpkgs/commit/809103f3aa13c0312a234e59ad63a9822974a615) python3Packages.docplex: 2.29.241 -> 2.29.245
* [`0b83186c`](https://github.com/NixOS/nixpkgs/commit/0b83186c9dc2034058439285107a6ca7860935b3) python3Packages.python-sql: 1.5.2 -> 1.6.0
* [`2e0dc8b9`](https://github.com/NixOS/nixpkgs/commit/2e0dc8b95a9708d08d25fcd0e03f95d1d8e536a8) python3Packages.pudb: 2024.1.3 -> 2025.1
* [`c896cc4c`](https://github.com/NixOS/nixpkgs/commit/c896cc4ca98ab6a6dfbbcf499fcaf1dcc58adcb8) python3Packages.compliance-trestle: 3.8.1 -> 3.9.0
* [`b45843a5`](https://github.com/NixOS/nixpkgs/commit/b45843a5a74b995ecc7e72de6339ff6584701ec8) python3Packages.deap: 1.4.2 -> 1.4.3
* [`17c4f799`](https://github.com/NixOS/nixpkgs/commit/17c4f799d848d206fb391a48007fc1b831eef6e7) plandex: 1.1.1 -> 2.1.2
* [`73e01a91`](https://github.com/NixOS/nixpkgs/commit/73e01a9113ed3733e8343b90d22a3961486a1aec) [kicad]: also wrap kicad-cli
* [`04f0152f`](https://github.com/NixOS/nixpkgs/commit/04f0152f81672c11edf49ca438ed2ee94f3082f3) python3Packages.firebase-messaging: 0.4.4 -> 0.4.5
* [`f20530d4`](https://github.com/NixOS/nixpkgs/commit/f20530d4d0b70111d65a871fa5cb6c634bfa62d5) maintainers: add voidnoi
* [`6560614b`](https://github.com/NixOS/nixpkgs/commit/6560614b10bb54ef2823f20c9ad66567c33802f8) python3Packages.wagtail-localize: 1.11.3 -> 1.12.1
* [`5309164a`](https://github.com/NixOS/nixpkgs/commit/5309164a9632bbe971a3b8915f6e0164962d9be0) makeHardcodeGsettingsPatch: Fix `schemaExistsFunction` w/o stdbool.h
* [`eeeaad66`](https://github.com/NixOS/nixpkgs/commit/eeeaad66d2137a5ee3d9e3e07aa5869e5bafae65) python3Packages.bottleneck: 1.4.2 -> 1.5.0
* [`8e03e66b`](https://github.com/NixOS/nixpkgs/commit/8e03e66b2f2b37293875f382df4a32282bed12c1) python3Packages.oelint-parser: 8.1.0 -> 8.1.1
* [`e34cf51c`](https://github.com/NixOS/nixpkgs/commit/e34cf51ccc6bbf75883326f8420d6c5f583f6cfb) game-rs: 0.2.0 -> 5
* [`78235db3`](https://github.com/NixOS/nixpkgs/commit/78235db333b85f9fec00903f93c17726860c8b47) trgui-ng: init at 1.4.0-unstable-2025-05-18
* [`fe667695`](https://github.com/NixOS/nixpkgs/commit/fe667695f5ac6c61412f73f8c073397cb31fd829) vapoursynth-bestsource: 6 → 11
* [`3d81d6ba`](https://github.com/NixOS/nixpkgs/commit/3d81d6ba8d997e318e7df02e55e2653d1639b1f9) vapoursynth-bestsource: remove cmake from `buildInputs`
* [`635d6d7a`](https://github.com/NixOS/nixpkgs/commit/635d6d7a4a3d91ab9189a2f9f9d46f4e099675ab) vapoursynth-bestsource: depend on ffmpeg with Little CMS2 support
* [`7256dc7b`](https://github.com/NixOS/nixpkgs/commit/7256dc7bc3ddd09328df073ccb432528633ae9bb) vapoursynth-bestsource: set `passthru.updateScript`
* [`2bbe77aa`](https://github.com/NixOS/nixpkgs/commit/2bbe77aa8aa8c23c5002598f8a69fc11919fcdce) python3Packages.django-leaflet: 0.31.0 -> 0.32.0
* [`dc98b707`](https://github.com/NixOS/nixpkgs/commit/dc98b7073212fd5a4ed939e23575f8d01983f7fd) maintainers: add felipe-9
* [`2678016d`](https://github.com/NixOS/nixpkgs/commit/2678016dd07f6f4c378f6b8ef7f997021dd8fee4) ejson2env: 2.0.7 -> 2.0.8
* [`220971db`](https://github.com/NixOS/nixpkgs/commit/220971dbaa93dbcf4f570042ebf24f8f6226fdb2) yaziPlugins.wl-clipboard: init at 0-unstable-2025-05-22
* [`93c85d17`](https://github.com/NixOS/nixpkgs/commit/93c85d17f6f0b9b1036300aabeef42fa724c0157) skeditor: 2.8.9 -> 2.9.0
* [`e701d380`](https://github.com/NixOS/nixpkgs/commit/e701d3803df2265325d3387933bf10daf48bf29f) python3Packages.py3status: 3.61 -> 3.62
* [`25c579e5`](https://github.com/NixOS/nixpkgs/commit/25c579e50b45fc718bf413bf36566a2a6169a63e) python3Packages.west: 1.3.0 -> 1.4.0
* [`2f9b3632`](https://github.com/NixOS/nixpkgs/commit/2f9b36321ae5c0eb98f715f4d75a6d09fc7da5d4) trgui-ng: build webui as 'passthru.frontend'
* [`ad582fc8`](https://github.com/NixOS/nixpkgs/commit/ad582fc807271c92a1460dac14847e723a2a21ef) trgui-ng-web: init
* [`094c27f0`](https://github.com/NixOS/nixpkgs/commit/094c27f02320ee331a299f2d5334f4e1b979bf21) trgui-ng: add 'updateScript'
* [`2cecf087`](https://github.com/NixOS/nixpkgs/commit/2cecf087e0982fab9001c336f3cbde0efb6fddbb) python3Packages.ntc-templates: 7.8.0 -> 7.9.0
* [`c697b7f9`](https://github.com/NixOS/nixpkgs/commit/c697b7f9c21d2f2659348825ac80e67ea6817cad) python3Packages.toggl-cli: 3.0.3 -> 4.0.0
* [`e23281ec`](https://github.com/NixOS/nixpkgs/commit/e23281ec3e355961ae3f2f9510b7a81fed701ba2) python3Packages.icalendar: 6.3.0 -> 6.3.1
* [`d317f8c9`](https://github.com/NixOS/nixpkgs/commit/d317f8c9c9b9bbedb175f8506a7ea63cd16ae2a7) python3Packages.cucumber-tag-expressions: 6.1.2 -> 6.2.0
* [`817c60fe`](https://github.com/NixOS/nixpkgs/commit/817c60fe20ca5bb7a5e621075765cc3a14d5ecc8) maintainers: add felipe-9
* [`25b08c7d`](https://github.com/NixOS/nixpkgs/commit/25b08c7d319b46b9640b8b9d1ba166ba85f86100) wasmtime: 32.0.0 -> 33.0.0
* [`523818e7`](https://github.com/NixOS/nixpkgs/commit/523818e7ca24622472403c5a683961e1cbf1c10e) yaziPlugins.gitui: init at 0-unstable-2025-05-26
* [`46b144a2`](https://github.com/NixOS/nixpkgs/commit/46b144a26eee99b198bc56a51f044e07c1e6dbf6) python3Packages.moviepy: 2.1.2 -> 2.2.1
* [`a836189e`](https://github.com/NixOS/nixpkgs/commit/a836189e85999101866b1a519eb6c7bfceb7a471) python3Packages.monotonic-alignment-search: 0.1.1 -> 0.2.0
* [`aa610261`](https://github.com/NixOS/nixpkgs/commit/aa610261842ec098eb88a0cbe3258e71f8e87ddf) python3Packages.mistral-common: 1.5.4 -> 1.5.6
* [`b21fcdd5`](https://github.com/NixOS/nixpkgs/commit/b21fcdd5d88c6653421f5bd37f294598f6c8ad30) bcc: 0.34.0 -> 0.35.0
* [`b0d0e5b0`](https://github.com/NixOS/nixpkgs/commit/b0d0e5b035f7d63dcda1baac976bd1ca8644d636) coturn: 4.6.3 -> 4.7.0
* [`e58df9a0`](https://github.com/NixOS/nixpkgs/commit/e58df9a0d36f36a3ecce57a27d9a3e3245b317a5) python3Packages.kde-material-you-colors: 1.10.0 -> 1.10.1
* [`1a3c2131`](https://github.com/NixOS/nixpkgs/commit/1a3c2131ac9d4b652796b74178b8c8376f0269b4) python3Packages.hiredis: 3.1.1 -> 3.2.1
* [`47d4dce4`](https://github.com/NixOS/nixpkgs/commit/47d4dce4886353f82b7480223eb63a81fee0f8c2) python3Packages.mkdocs-git-revision-date-localized-plugin: 1.3.0 -> 1.4.7
* [`b93e36d2`](https://github.com/NixOS/nixpkgs/commit/b93e36d2a5e57ff70ef60ea4abb9137ae4f21812) alda: 2.3.1 -> 2.3.2
* [`af559f79`](https://github.com/NixOS/nixpkgs/commit/af559f79474272fd95b1500486a748a425721731) maintainers: add sylonin
* [`daf57186`](https://github.com/NixOS/nixpkgs/commit/daf57186940b7c7008ece692e629f8cc9ef67460) ocamlPackages.hxd: 0.3.3 -> 0.3.4
* [`88f72e72`](https://github.com/NixOS/nixpkgs/commit/88f72e7278ed2fc8dccc38f6d84db94e56b7f416) synapse-admin: 0.11.0 -> 0.11.1
* [`0414bf64`](https://github.com/NixOS/nixpkgs/commit/0414bf644eace59b32862c156fe1ec117c1f708c) console-setup: 1.236 -> 1.237
* [`8b321792`](https://github.com/NixOS/nixpkgs/commit/8b32179234f3fe5b1155eb9657249d505d3a2c65) kubernetes-helmPlugins.helm-s3: 0.16.3 -> 0.17.0
* [`cfd4d27a`](https://github.com/NixOS/nixpkgs/commit/cfd4d27a1dd7a707cfcfdf483ea18a08e9d2ecd5) verifast: 25.02 -> 25.06
* [`09d42ce8`](https://github.com/NixOS/nixpkgs/commit/09d42ce87255133dec8d4cb6d6b02ee03b3d7d01) texlive: 2024-final -> 2025.20250603
* [`35891e5f`](https://github.com/NixOS/nixpkgs/commit/35891e5f6561d3888760ef998b89d5d00e0add2c) passh: remove usage of pname
* [`577800dd`](https://github.com/NixOS/nixpkgs/commit/577800ddf86def28940810038313d0fd15c69a86) passh: add hooks to script
* [`c23d05cc`](https://github.com/NixOS/nixpkgs/commit/c23d05cc867dd05d2aaa181c8ff08f9bbd9e5016) passh: Update gpl3 license from nixpkgs-hammering
* [`995c402d`](https://github.com/NixOS/nixpkgs/commit/995c402dff6be5aac0b56e4eefcabfaa45a37ee6) duo-unix: 2.0.4 -> 2.1.0
* [`4d7ff1d5`](https://github.com/NixOS/nixpkgs/commit/4d7ff1d59d4e4948f0f46d29e01bad106bdee327) python3Packages.tskit: 0.6.3 -> 0.6.4
* [`63af8d5b`](https://github.com/NixOS/nixpkgs/commit/63af8d5bcbda5bc6501db50970b07b93d693a3c5) python3Packages.celery: 5.5.2 -> 5.5.3
* [`4ec18b35`](https://github.com/NixOS/nixpkgs/commit/4ec18b35715d477cd20f0b97dd09ecedd67d0066) python3Packages.python-arango: 8.1.6 -> 8.2.0
* [`1c607fa6`](https://github.com/NixOS/nixpkgs/commit/1c607fa638fcc306377edd4ee65cd79402b97470) gost: 2.12.0 -> 3.0.0
* [`16987dd2`](https://github.com/NixOS/nixpkgs/commit/16987dd2e47abe400baa7ce2f8a4e16cb0684746) python3Packages.rich-argparse: 1.7.0 -> 1.7.1
* [`9ffaffa6`](https://github.com/NixOS/nixpkgs/commit/9ffaffa6f5f1345e20c893e81723a17328d75395) python3Packages.panel: 1.6.3 -> 1.7.1
* [`816cfd86`](https://github.com/NixOS/nixpkgs/commit/816cfd86f48e3e048f781a1eae35f22a7f7ff2df) yubikey-touch-detector: 1.12.5 -> 1.13.0
* [`b62037b7`](https://github.com/NixOS/nixpkgs/commit/b62037b798fe29dc8ef1bcc7323682bb25e09506) python3Packages.python-gitlab: 5.6.0 -> 6.0.0
* [`645f20c0`](https://github.com/NixOS/nixpkgs/commit/645f20c09ae4a3f68e682bb6a1ad569bb621e05b) ocamlPackages.bitwuzla-cxx: 0.6.1 -> 0.8.0
* [`207ff798`](https://github.com/NixOS/nixpkgs/commit/207ff798f2fa5fc8225ce6a64f5751d79a2fa47d) balanceofsatoshis: 19.4.10 -> 19.4.14
* [`f599de2a`](https://github.com/NixOS/nixpkgs/commit/f599de2a8694116b1ae691d04dd6813109728467) python3Packages.pyaml: 25.1.0 -> 25.5.0
* [`3d4647f6`](https://github.com/NixOS/nixpkgs/commit/3d4647f6f578efbea300848cd3b7cb98256de802) maple-font: 7.2 -> 7.3
* [`000c72bc`](https://github.com/NixOS/nixpkgs/commit/000c72bc5a1fb0165dc0e6d9b6a333e950b5cea0) crc: 2.49.0 -> 2.51.0
* [`0ebe9f39`](https://github.com/NixOS/nixpkgs/commit/0ebe9f3986ab7241e8b3c55a9eb92633f3dd8fa5) libretro.picodrive: 0-unstable-2025-04-10 -> 0-unstable-2025-05-31
* [`d79c2683`](https://github.com/NixOS/nixpkgs/commit/d79c26830d7be9c8e532a54781ff66967f21ba6f) python3Packages.curtsies: 0.4.2 -> 0.4.3
* [`30a98977`](https://github.com/NixOS/nixpkgs/commit/30a989774a67f59381dbb4077619a796017f73dd) socklog: 2.1.0 -> 2.1.1
* [`ce93cb70`](https://github.com/NixOS/nixpkgs/commit/ce93cb704fc0942a4e440010a2f36248d0b5e60b) dpkg: 1.22.19 -> 1.22.20
* [`7efe14de`](https://github.com/NixOS/nixpkgs/commit/7efe14de00ce5935a45f20bd03478fbc82856b8c) jitsi-videobridge: 2.3-220-g7cda0a66 -> 2.3-236-g95ef6210
* [`5a89322a`](https://github.com/NixOS/nixpkgs/commit/5a89322af6d26e1d6331c83f64d26eb4efd646ae) python3Packages.aiolifx-themes: 0.6.11 -> 1.0.0
* [`f3583d9c`](https://github.com/NixOS/nixpkgs/commit/f3583d9c573d72f6079755bf0d09d52c8e469973) timeline: 2.6.0 -> 2.10.0
* [`ab8e8d55`](https://github.com/NixOS/nixpkgs/commit/ab8e8d550d16e37e5ab6f2195fc3cd4862fcee4c) moodle: 5.0 -> 5.0.1
* [`11eacc01`](https://github.com/NixOS/nixpkgs/commit/11eacc018e847d09e803a044863a42968f6bfc01) coroot-node-agent: 1.24.0 -> 1.25.1
* [`2741d2ce`](https://github.com/NixOS/nixpkgs/commit/2741d2ce3e92311558dcc9f57587f0127e0ed2d3) python312Packages.nominal-api: disable auto update
* [`237660aa`](https://github.com/NixOS/nixpkgs/commit/237660aa6457d2851f5e499a801208b82edfd839) python312Packages.nominal-api-protos: disable auto update
* [`6c49fb45`](https://github.com/NixOS/nixpkgs/commit/6c49fb45a30b19ddd6ccaec9bf03664b6db717bf) jitsi-meet-prosody: 1.0.8542 -> 1.0.8648
* [`ffddb361`](https://github.com/NixOS/nixpkgs/commit/ffddb361816f20e668f27296dd913c48c2606680) python3Packages.python-engineio: 4.12.1 -> 4.12.2
* [`e6ad95ba`](https://github.com/NixOS/nixpkgs/commit/e6ad95baf89e8caed44793e449d67054db42c806) bitwarden-directory-connector: 2025.5.0 -> 2025.6.0
* [`670a861c`](https://github.com/NixOS/nixpkgs/commit/670a861c268499b3c45cf5e0a262bb7f0c8d8049) apt: 3.1.0 -> 3.1.2
* [`04b4614d`](https://github.com/NixOS/nixpkgs/commit/04b4614d8eec45eed3d6353195b711723100a72b) jicofo: 1.0-1128 -> 1.0-1138
* [`45d7516f`](https://github.com/NixOS/nixpkgs/commit/45d7516fb70f3a88e8692b76cd8c34561a161adb) python3Packages.dendropy: 5.0.6 -> 5.0.8
* [`2d3e757a`](https://github.com/NixOS/nixpkgs/commit/2d3e757aa6678c2eb73ad0666d5b3dc25100eb28) libndctl: 81 -> 82
* [`93d285d0`](https://github.com/NixOS/nixpkgs/commit/93d285d0bc7f021963af900048492f083d914e18) python3Packages.casbin: 1.43.0 -> 1.45.0
* [`efd45be8`](https://github.com/NixOS/nixpkgs/commit/efd45be8b7107fbc114ff18081ef0c3783aefc08) python3Packages.pycasbin: rename to python3Packages.pycasbin
* [`89ce0665`](https://github.com/NixOS/nixpkgs/commit/89ce0665497a3f1efe671e966ea0a25438408b14) nushellPlugins.semver: 0.11.4 -> 0.11.5
* [`d5a7aff2`](https://github.com/NixOS/nixpkgs/commit/d5a7aff28885b1ec5f877013d5d9805708634faf) fishPlugins.fishbang: init at 0-unstable-2025-01-10
* [`15c6d153`](https://github.com/NixOS/nixpkgs/commit/15c6d153a65dbfde3a812632c2776f0a629dcd0f) plexRaw: 1.41.7.9823-59f304c16 -> 1.41.8.9834-071366d65
* [`763f8a88`](https://github.com/NixOS/nixpkgs/commit/763f8a880a4c759f927d132aad0702927d1e96f4) protoc-gen-es: 2.5.1 -> 2.5.2
* [`47c897bd`](https://github.com/NixOS/nixpkgs/commit/47c897bd9cb270ed43c75ab7804fa5c777cad82b) ooniprobe-cli: 3.25.0 -> 3.26.0
* [`97357684`](https://github.com/NixOS/nixpkgs/commit/97357684018e49f3e8b25b227ea295065f616042) ocamlPackages.sel: 0.6.0 -> 0.7.0
* [`92f31794`](https://github.com/NixOS/nixpkgs/commit/92f3179408aa568563eb965fe8afde5fc382748a) docker-compose: 2.36.0 -> 2.37.1
* [`4eb94613`](https://github.com/NixOS/nixpkgs/commit/4eb94613073d47f9ffdf3a0e6f7982b6d63dd218) infisical: 0.41.7 -> 0.41.85
* [`c29aadf4`](https://github.com/NixOS/nixpkgs/commit/c29aadf46d5eee560db30dd041e328b45350a634) python3Packages.pymunk: 6.11.1 -> 7.0.1
* [`79b16101`](https://github.com/NixOS/nixpkgs/commit/79b1610132f83ba8b344cfb5e8c6c3e3d5af56c1) python3Packages.dramatiq: 1.17.1 -> 1.18.0
* [`0e8982e0`](https://github.com/NixOS/nixpkgs/commit/0e8982e0930002c55f5e881ea0143e08b402957e) jibri: 8.0-177-g3325e37 -> 8.0-183-g7b406bf
* [`57d8fd1c`](https://github.com/NixOS/nixpkgs/commit/57d8fd1c3c62853473c4c1c969a6ccba83442390) doomretro: 5.6.2 -> 5.7
* [`a3352d2c`](https://github.com/NixOS/nixpkgs/commit/a3352d2c31b70a7248dc913437e4f227c481a829) protox: 0.5.0 -> 0.9.0
* [`c02e9777`](https://github.com/NixOS/nixpkgs/commit/c02e977717dc040a8cadb0d589c9b519d0e30a01) linuxPackages.tuxedo-drivers: 4.13.1 -> 4.14.0
* [`cbfe2417`](https://github.com/NixOS/nixpkgs/commit/cbfe24171a5f92777886440e75f0d52810a1c8a8) cpr: 1.11.2 -> 1.12.0
* [`6ad4c1dd`](https://github.com/NixOS/nixpkgs/commit/6ad4c1dd312a806d08aabdfd7d0dc90392506b04) phpExtensions.ioncube-loader: 13.0.2 -> 14.4.1
* [`f8782f3a`](https://github.com/NixOS/nixpkgs/commit/f8782f3aafe4a85dbf8ddac6b28c62ebb4bb5bbe) frida-tools: 13.7.1 -> 14.1.2
* [`6f8194b4`](https://github.com/NixOS/nixpkgs/commit/6f8194b4361778b46d24f1a3a4375c336635ba06) python3Packages.google-cloud-pubsub: 2.29.1 -> 2.30.0
* [`f0a05184`](https://github.com/NixOS/nixpkgs/commit/f0a051843848e37008df3ace1c84a58b6337a6fb) lidarr: 2.11.2.4629 -> 2.12.4.4658
* [`ad67b35a`](https://github.com/NixOS/nixpkgs/commit/ad67b35a8fd1dcb2fd94dda6ea8b0811cd846118) git-recent: 2.0.1 -> 2.0.2
* [`3c5ab7f0`](https://github.com/NixOS/nixpkgs/commit/3c5ab7f0aed8c578916a40a82187d4c19c250236) python3Packages.asdf-standard: 1.2.0 -> 1.3.0
* [`1a935f1a`](https://github.com/NixOS/nixpkgs/commit/1a935f1aa3215cc357a0f9d4843033d0fe783354) opencryptoki: 3.24.0 -> 3.25.0
* [`1e09c914`](https://github.com/NixOS/nixpkgs/commit/1e09c914410c21ea474820d69e9065b40e94546f) python3Packages.migen: 0.9.2-unstable-2025-02-07 -> 0.9.2-unstable-2025-06-10
* [`0c876aef`](https://github.com/NixOS/nixpkgs/commit/0c876aeffe444cea4a3dcc0ec61ff158527beec9) gpodder: 3.11.4 -> 3.11.5
* [`2abca94f`](https://github.com/NixOS/nixpkgs/commit/2abca94fa7be341a5e638af278694cfbc8e24927) whisparr: 2.0.0.987 -> 2.0.0.1112
* [`fefa6091`](https://github.com/NixOS/nixpkgs/commit/fefa6091bed875ee10ce65711c511ac138246295) vcluster: 0.25.0 -> 0.25.1
* [`f9d65e69`](https://github.com/NixOS/nixpkgs/commit/f9d65e69df4a71ecc82ed9cfcd3610e66242b2a8) python3Packages.ufo2ft: 3.4.3 -> 3.5.0
* [`7225418d`](https://github.com/NixOS/nixpkgs/commit/7225418d97849bb812890560e88f5088fd127f7b) swagger-codegen: 2.4.38 -> 2.4.45
* [`42e08119`](https://github.com/NixOS/nixpkgs/commit/42e081190c4e5ec8d9898f7532149d998d3ab1bf) yabasic: 2.91.2 -> 2.91.3
* [`9756b3f1`](https://github.com/NixOS/nixpkgs/commit/9756b3f128f2a6d342c1f5d998d4ecf14751dbef) mcpp: 2.7.2.1 -> 2.7.2.2
* [`2d13c084`](https://github.com/NixOS/nixpkgs/commit/2d13c0849cbc17c26f89d3e8b80785f807b1f8d9) python3Packages.pytapo: 3.3.44 -> 3.3.46
* [`4d96c551`](https://github.com/NixOS/nixpkgs/commit/4d96c551f7b2ea99b936d1f21dcf9f7346f6df66) python3Packages.plaid-python: 31.0.0 -> 34.0.0
* [`5cd57430`](https://github.com/NixOS/nixpkgs/commit/5cd57430d135f20f0ba006f51f82d0fd2f0fa37d) linuxKernel.packages.new-lg4ff: 0-unstable-2024-11-25 -> 0.5.0
* [`d633a2e7`](https://github.com/NixOS/nixpkgs/commit/d633a2e7dcba5ac0a585ed2b2c7497fbd051e51c) linuxKernel.packages.new-lg4ff: remove usages of with lib;
* [`8c5fec75`](https://github.com/NixOS/nixpkgs/commit/8c5fec751584ce9f5bb3d1ba096be8c724c440bd) new-lg4ff: add amadejkastelic to maintainers
* [`f1f38df8`](https://github.com/NixOS/nixpkgs/commit/f1f38df8fdd171310694d4161affa003c1bf0b24) python3Packages.sv-ttk: 2.6.0 -> 2.6.1
* [`358ad1bc`](https://github.com/NixOS/nixpkgs/commit/358ad1bc12fc93d260d44eaf028a8630b87cd9fb) python3Packages.habanero: 2.2.0 -> 2.3.0
* [`56a0dabe`](https://github.com/NixOS/nixpkgs/commit/56a0dabe79a5e379bb4decc8bc4f6e2893ee618b) python3Packages.google-cloud-secret-manager: 2.23.3 -> 2.24.0
* [`a994c922`](https://github.com/NixOS/nixpkgs/commit/a994c9225b6a355856dc3f820eb56a45b5313809) furnace: 0.6.8.2 -> 0.6.8.3
* [`683ffede`](https://github.com/NixOS/nixpkgs/commit/683ffedebf936c9b9faca9d9a4936b5a2b4b8d60) python3Packages.orange-widget-base: 4.25.1 -> 4.26.0
* [`385cd5c2`](https://github.com/NixOS/nixpkgs/commit/385cd5c2041269f2fa70095bca26aa7bfaa18d70) python3Packages.pyinstaller: 6.14.0 -> 6.14.1
* [`83e11a96`](https://github.com/NixOS/nixpkgs/commit/83e11a96fb9d0795e6776105daad6633bcd412dd) psi-plus: 1.5.2072 -> 1.5.2081
* [`d31f465d`](https://github.com/NixOS/nixpkgs/commit/d31f465dcd9ad952b57876b9dda4f8111ff05498) unifi: 9.1.120 -> 9.2.87
* [`f6ae834e`](https://github.com/NixOS/nixpkgs/commit/f6ae834efcba68f1fb0945caedea1381adc88f36) whistle: 2.9.98 -> 2.9.99
* [`92b97950`](https://github.com/NixOS/nixpkgs/commit/92b9795003234a782db49c40929a9698d0429ba0) ppsspp: 1.18.1 -> 1.19.2
* [`d59dedca`](https://github.com/NixOS/nixpkgs/commit/d59dedca67f6271519051cae178a3dbf38e72bd5) netmaker: 0.90.0 -> 0.99.0
* [`557d7b09`](https://github.com/NixOS/nixpkgs/commit/557d7b0973a0a2406b8b6f3e286bab00c1cae733) netclient: 0.90.0 -> 0.99.0
* [`6068cd35`](https://github.com/NixOS/nixpkgs/commit/6068cd35529199e0f8f0272ede6ba73e922fa65d) flowblade: 2.20 -> 2.22
* [`8c910f09`](https://github.com/NixOS/nixpkgs/commit/8c910f09108fe5968ba9961fa316c8f233e1e18f) sof-firmware: 2025.01.1 -> 2025.05
* [`e9ffd6a4`](https://github.com/NixOS/nixpkgs/commit/e9ffd6a4fa30d95c5118f305f552fa92e7b7ce04) sentry-cli: 2.45.0 -> 2.46.0
* [`0d678539`](https://github.com/NixOS/nixpkgs/commit/0d678539a1b519ca3aa48ce3ad7b807e462c86be) fluidd: 1.34.2 -> 1.34.3
* [`d606025d`](https://github.com/NixOS/nixpkgs/commit/d606025d4b5ffad63f02781396c4bc79935a0ba8) treewide: remove astsmtl as maintainer
* [`8288977b`](https://github.com/NixOS/nixpkgs/commit/8288977bb6166ef2750ba0a8d4ff718243e54766) maintainers: removing astsmtl
* [`65e18787`](https://github.com/NixOS/nixpkgs/commit/65e187875206a959fb5fd81ff57855e4b18b7513) ocamlPackages.metrics: 0.4.1 -> 0.5.0
* [`8e8635cf`](https://github.com/NixOS/nixpkgs/commit/8e8635cf0cf886dc4393fb9ead5e5ce98103aa89) cctz: 2.4 -> 2.5
* [`0b3faba1`](https://github.com/NixOS/nixpkgs/commit/0b3faba1eb50a01ec92e029b5f46bc847b054e47) vpnc: unstable-2024-12-20 -> unstable-2025-06-16
* [`5927e844`](https://github.com/NixOS/nixpkgs/commit/5927e844788cfd1a1ab86d014f50eec4e83563a9) python3Packages.pyfiglet: 1.0.2 -> 1.0.3
* [`7bb84445`](https://github.com/NixOS/nixpkgs/commit/7bb844458b83be4852740408d357571829590939) cannelloni: 1.2.1 -> 2.0.0
* [`4c968b64`](https://github.com/NixOS/nixpkgs/commit/4c968b64399df0ae70708e3e5b2a586205ec933e) min-ed-launcher: 0.12.0 -> 0.12.1
* [`9217cdaf`](https://github.com/NixOS/nixpkgs/commit/9217cdaf86a6e1a2413822cefb7c1e5c24f03bbd) qcad: 3.32.1.0 -> 3.32.3.1
* [`9d246dc2`](https://github.com/NixOS/nixpkgs/commit/9d246dc2054c5c1b86e0057f8234b7d294d93573) linkerd_edge: 25.6.1 -> 25.6.2
* [`7c942c33`](https://github.com/NixOS/nixpkgs/commit/7c942c339f8f7d67d8db5ffd7cb7fb10e48b5f5d) gpupad: 2.6.1 -> 2.7.0
* [`7baf0f4b`](https://github.com/NixOS/nixpkgs/commit/7baf0f4b9e651cc8d15e86f211d7df11bc04dabe) shopify-cli: 3.69.3 -> 3.81.2
* [`c426bfa9`](https://github.com/NixOS/nixpkgs/commit/c426bfa9a8fcdc2ed771a8e2c50f45d7dd7729ce) crowdsec: 1.6.8 -> 1.6.9
* [`a2a606ad`](https://github.com/NixOS/nixpkgs/commit/a2a606ad721129bb9f6417c7865a2c672cf94226) python3Packages.sqlmap: 1.9.5 -> 1.9.6
* [`cb40ffff`](https://github.com/NixOS/nixpkgs/commit/cb40ffffebc264a791701282f355cce4edcc97f0) python3Packages.optimum: 1.25.3 -> 1.26.1
* [`2811321a`](https://github.com/NixOS/nixpkgs/commit/2811321a4e76f2936f878b5a21353ce410afa22d) twitterBootstrap: 5.3.6 -> 5.3.7
* [`639d4e25`](https://github.com/NixOS/nixpkgs/commit/639d4e2503a9557d28504e0a36f12918c0296e98) python3Packages.azure-keyvault-administration: 4.5.0 -> 4.6.0
* [`1b8d7a8d`](https://github.com/NixOS/nixpkgs/commit/1b8d7a8d5c0a140c3364865d6bc1549df278b596) confd-calico: 3.30.0 -> 3.30.1
* [`ace7a6b7`](https://github.com/NixOS/nixpkgs/commit/ace7a6b7167c4f3e6f216854bde6f59d2598b812) python3Packages.pyahocorasick: 2.1.0 -> 2.2.0
* [`763ada20`](https://github.com/NixOS/nixpkgs/commit/763ada20518ada52fae7bdd9d63a7fa98daf0117) python3Packages.azure-keyvault-secrets: 4.9.0 -> 4.10.0
* [`63524c68`](https://github.com/NixOS/nixpkgs/commit/63524c68dbad4be7ed13315cff8bf17430559031) python313Packages.pyahocorasick: refactor
* [`662436f0`](https://github.com/NixOS/nixpkgs/commit/662436f0b51bf93e6226149cb610b5db382e2fb6) python3Packages.google-cloud-monitoring: 2.27.1 -> 2.27.2
* [`dfce67ef`](https://github.com/NixOS/nixpkgs/commit/dfce67ef7e3d6ef2a70970760bb78ed6f7b856d9) python3Packages.pathvalidate: 3.2.3 -> 3.3.1
* [`9f15b838`](https://github.com/NixOS/nixpkgs/commit/9f15b838ec5464ce6232de8d1113880d0c91b895) python3Packages.ansible: 11.5.0 -> 11.7.0
* [`dfdf44c7`](https://github.com/NixOS/nixpkgs/commit/dfdf44c7a0156af78b10c6589d2c504628cdc772) python3Packages.litestar-htmx: 0.4.1 -> 0.5.0
* [`e8946fee`](https://github.com/NixOS/nixpkgs/commit/e8946feed31fa30613f02d35d04bbaaf5df6a8e6) python3Packages.superqt: 0.7.3 -> 0.7.5
* [`287e2bc9`](https://github.com/NixOS/nixpkgs/commit/287e2bc9315453974ce0372a8632569d087c2f01) kubeshark: 52.7.7 -> 52.7.8
* [`60db51b6`](https://github.com/NixOS/nixpkgs/commit/60db51b69262f8d7f21409f2b35b9ebc34ed40a0) zwave-js-server: 3.0.2 -> 3.1.0
* [`eb5f9a4f`](https://github.com/NixOS/nixpkgs/commit/eb5f9a4ff939a1d9983a70a2b5187a48063aeb9e) src-cli: avoid need for networking in passthru.tests
* [`9664103c`](https://github.com/NixOS/nixpkgs/commit/9664103c069690fc844831a66657e381d6d4cfed) src-cli: remove xorg.libX11 from buildInputs
* [`20607c08`](https://github.com/NixOS/nixpkgs/commit/20607c08a132de3ef86c2a63ae42af3a2e8e59a7) src-cli: 6.3.0 -> 6.4.0
* [`e8a26068`](https://github.com/NixOS/nixpkgs/commit/e8a26068500150634aa7d9be1ee14a4b9f593558) src-cli: add keegancsmith as a maintainer
* [`f6449470`](https://github.com/NixOS/nixpkgs/commit/f6449470d81806fec7e1c9bb74688121e5322457) boinc: 8.2.2 -> 8.2.4
* [`b9a1bb97`](https://github.com/NixOS/nixpkgs/commit/b9a1bb9730a7aa88a16ae88588b9dde94335d956) gcsfuse: 2.12.2 -> 3.0.0
* [`c69d7a7b`](https://github.com/NixOS/nixpkgs/commit/c69d7a7bdb5ad422855683902bac079b8ca97f4d) icingaweb2-thirdparty: 0.12.1 -> 0.13.0
* [`2184d321`](https://github.com/NixOS/nixpkgs/commit/2184d321fce81b9ec389422a386b24b6674b9b25) icingaweb2-ipl: 0.16.0 -> 0.16.1
* [`126d8cdd`](https://github.com/NixOS/nixpkgs/commit/126d8cdd2cb42418f3e860bba6b80b860fa6143e) python313Packages.rstcheck-core: 1.2.1 -> 1.2.2
* [`0839749f`](https://github.com/NixOS/nixpkgs/commit/0839749f6d69a356e0dee0122ef1206a98485d0a) benthos: 4.52.0 -> 4.53.0
* [`29ef6379`](https://github.com/NixOS/nixpkgs/commit/29ef6379b066d4b66af76bccf1e7accd304c7e2d) python3Packages.r2pipe: 1.9.4 -> 1.9.6
* [`910d69b9`](https://github.com/NixOS/nixpkgs/commit/910d69b9734b67a3fea3175903a822ed4e912a00) sudachidict: 20250129 -> 20250515
* [`1c25734b`](https://github.com/NixOS/nixpkgs/commit/1c25734b0200ebd32f1bd26ea4a2a55995da637f) icinga2-agent: 2.14.6 -> 2.15.0
* [`870c0b72`](https://github.com/NixOS/nixpkgs/commit/870c0b72faeb3436e6b772974dcd7835a17956d8) python3Packages.pypcap: drop
* [`c1810bbc`](https://github.com/NixOS/nixpkgs/commit/c1810bbc422b163923b825805f12faa295e6a00b) confluent-cli: 4.28.0 -> 4.29.0
* [`13991bb8`](https://github.com/NixOS/nixpkgs/commit/13991bb8b27e60f0524cba338ffcf951e1263131) python3Packages.dissect-esedb: refactor
* [`e1fa4277`](https://github.com/NixOS/nixpkgs/commit/e1fa4277a425eac3d8bcae798bfb59aab3532b82) python3Packages.pywikibot: 10.0.0 -> 10.2.0
* [`0930b566`](https://github.com/NixOS/nixpkgs/commit/0930b566b81e632832a9b908470ce10541bd3c2c) CONTRIBUTING: Add guideline to document motivation for special packaging choices
* [`898ee6bf`](https://github.com/NixOS/nixpkgs/commit/898ee6bfc819da1153c4fb6c19ba41352d1afba5) mendeley: 2.134.0 -> 2.135.0
* [`c75d1b19`](https://github.com/NixOS/nixpkgs/commit/c75d1b19c40654c3b998e601d93ce2b707c448cb) aws-iam-authenticator: 0.7.2 -> 0.7.3
* [`f3a8b9b2`](https://github.com/NixOS/nixpkgs/commit/f3a8b9b2a0692d0b2192f6b04d3fbb445643d397) hermitcli: 0.44.8 -> 0.44.9
* [`61a3cbe9`](https://github.com/NixOS/nixpkgs/commit/61a3cbe92e9c0f4718bb0e1c33574d024204ba95) pcsx2: 2.3.407 -> 2.3.424
* [`2756e83f`](https://github.com/NixOS/nixpkgs/commit/2756e83f13e5fc3dbd0537d3fe9e3b5175345870) garnet: 1.0.70 -> 1.0.72
* [`7b8dc0b8`](https://github.com/NixOS/nixpkgs/commit/7b8dc0b8ea3d63f62c058422a383423cd4abd8af) open-vm-tools: 12.5.2 -> 13.0.0
* [`050c5d00`](https://github.com/NixOS/nixpkgs/commit/050c5d00d0b882b3dc9d0167c8ce2f71c048165f) open-vm-tools-headless: 12.5.2 -> 13.0.0
* [`ca8e474c`](https://github.com/NixOS/nixpkgs/commit/ca8e474c3dfa3fe8f4e2a0d807b7a30e658a61d5) steampipe: 1.1.4 -> 2.0.1
* [`4f4eaf1b`](https://github.com/NixOS/nixpkgs/commit/4f4eaf1b5348ee845483d5b6a8b7889122edf042) python3Packages.jax[lib]: 0.6.1 -> 0.6.2
* [`3d97d71a`](https://github.com/NixOS/nixpkgs/commit/3d97d71a7b41fcd004c824a3b41f5f7f286d46d3) cherry-studio: 1.4.2 -> 1.4.3
* [`96e92ae6`](https://github.com/NixOS/nixpkgs/commit/96e92ae6206a5db9751a71cfaaf11931a5edb09d) python3Packages.langchain-openai: 0.3.23 -> 0.3.24
* [`26d1bcc9`](https://github.com/NixOS/nixpkgs/commit/26d1bcc90da06ee54c92e4fb26501c97ccc9900a) ocamlPackages.iri: 1.0.0 -> 1.1.0
* [`96cf82e1`](https://github.com/NixOS/nixpkgs/commit/96cf82e1ba4bd6bd41245815b3c717cbaca81d0b) linuxPackages.r8125: 9.015.00 -> 9.016.00
* [`4de300d5`](https://github.com/NixOS/nixpkgs/commit/4de300d597c07e2840b495f1bc19a9f696482972) rnp: 0.17.1 -> 0.18.0
* [`8dd0a637`](https://github.com/NixOS/nixpkgs/commit/8dd0a637159b161120cb1ab97f3a677dacd885e9) obs-studio-plugins.advanced-scene-switcher: 1.30.1 -> 1.30.2
* [`35575d58`](https://github.com/NixOS/nixpkgs/commit/35575d58827eee2a414b3612c979e3125e6ca3d2) python313Packages.dissect-esedb: update license
* [`4e50dbf0`](https://github.com/NixOS/nixpkgs/commit/4e50dbf0a0850189570a468b9b0bcc7a8fd11b89) cnspec: 11.58.0 -> 11.59.0
* [`f4157ffe`](https://github.com/NixOS/nixpkgs/commit/f4157ffe2c5bca600a969f7b9da221d41bf0283e) web-ext: 8.7.1 -> 8.8.0
* [`20341c32`](https://github.com/NixOS/nixpkgs/commit/20341c32b11674a9fd47979191c5aabbfddf0156) ocamlPackages.ppx_irmin: 3.10.0 -> 3.11.0
* [`1049274c`](https://github.com/NixOS/nixpkgs/commit/1049274cf71d0958a8b208cc46bf3337e9c41ab8) python3Packages.google-cloud-bigquery-datatransfer: 3.19.1 -> 3.19.2
* [`06ae1188`](https://github.com/NixOS/nixpkgs/commit/06ae1188550540f117a0b8ce425bc236c39cbca4) postgres-lsp: 0.8.0 -> 0.8.1
* [`1eee16ca`](https://github.com/NixOS/nixpkgs/commit/1eee16cac492c21501068561bb47b1612fc4e4c7) narsil: 1.4.0-61-gb724a9e67 -> 1.4.0-62-g781c0f9c3
* [`bbc61e99`](https://github.com/NixOS/nixpkgs/commit/bbc61e99c389b0a09dd10bbfa4fd88b834a37671) python3Packages.podman: 5.4.0.1 -> 5.5.0
* [`8340a8a6`](https://github.com/NixOS/nixpkgs/commit/8340a8a6bd942900eb170d60215a892c6c69f982) zsh-you-should-use: 1.9.0 -> 1.10.0
* [`ef06b4d0`](https://github.com/NixOS/nixpkgs/commit/ef06b4d0489da467cfdfc78edc4ac279c08f3f67) libcec: 7.0.0 -> 7.1.0
* [`a61acd4b`](https://github.com/NixOS/nixpkgs/commit/a61acd4b5ae66ec89b4fb9512402a466f38ae0b4) droidcam: 2.1.3 -> 2.1.4
* [`26ba645e`](https://github.com/NixOS/nixpkgs/commit/26ba645ecd47d3600bb15e4f43eba7fa5c2798f2) handheld-daemon-ui: 3.3.6 -> 3.3.7
* [`f2971ac3`](https://github.com/NixOS/nixpkgs/commit/f2971ac3ed11e5f586739d31022b195d097d9f8a) re-flex: 5.5.0 -> 6.0.0
* [`f10ca051`](https://github.com/NixOS/nixpkgs/commit/f10ca05101dc2a41470f373955bade4e5c8e80c7) python3Packages.pyscard: 2.2.1 -> 2.2.2
* [`fa3c8472`](https://github.com/NixOS/nixpkgs/commit/fa3c8472bb518fcb75c48e91ec8d843b08ad956e) ocamlPackages.postgresql: 5.1.3 -> 5.2.0
* [`983b4ccd`](https://github.com/NixOS/nixpkgs/commit/983b4ccddff7cd06fe6fa53ed13e386c93b62c0e) python3Packages.pymupdf: 1.26.0 -> 1.26.1
* [`2300f9ba`](https://github.com/NixOS/nixpkgs/commit/2300f9bacbed4863ef85e56195116229e1c30417) river-bedload: init at 0.1.1-unstable-2025-03-19
* [`65f66db8`](https://github.com/NixOS/nixpkgs/commit/65f66db8ef36b707878466d52a8cda1a29e7c531) source-meta-json-schema: 9.3.5 -> 9.3.7
* [`296a1fcc`](https://github.com/NixOS/nixpkgs/commit/296a1fcc90b127cc16d99fbd55e3896d64db6698) libdigidocpp: 4.1.0 -> 4.2.0
* [`02ddaae6`](https://github.com/NixOS/nixpkgs/commit/02ddaae66e2be7388d5f902098c5c04c13aec84e) libsignal-ffi: 0.72.1 -> 0.74.1
* [`b90cc0be`](https://github.com/NixOS/nixpkgs/commit/b90cc0be55bb9d8c7877fc5b9c10d0f66c5a721a) mautrix-signal: 0.8.3 -> 0.8.4
* [`63ebb3b3`](https://github.com/NixOS/nixpkgs/commit/63ebb3b30450feb6529bb031309a8406e5b17daa) heroku: 10.10.0 -> 10.10.1
* [`09a538da`](https://github.com/NixOS/nixpkgs/commit/09a538da9447f71a49eb0e6c770d45790d352e45) endgame-singularity: remove unused updater and use tag instead of rev
* [`abe7a53b`](https://github.com/NixOS/nixpkgs/commit/abe7a53b31a5b3473e8c61f9a932a43d9eeb2672) magic-vlsi: 8.3.528 -> 8.3.529
* [`6597dfe5`](https://github.com/NixOS/nixpkgs/commit/6597dfe5d8bdef12f2f53bfc0811597242714ff8) librecast: 0.10.0 -> 0.11.2
* [`3a691497`](https://github.com/NixOS/nixpkgs/commit/3a691497ab86b7c876718cad8c211a4c6e712d62) qsv: 4.0.0 -> 5.1.0
* [`dac14a15`](https://github.com/NixOS/nixpkgs/commit/dac14a1581ca035c7e3942dda2d8f46b31127146) mermaid-cli: 11.4.3 -> 11.6.0
* [`c1aadba0`](https://github.com/NixOS/nixpkgs/commit/c1aadba0ae1a8bf5509fbc9b83bd5a25f814acac) tarlz: 0.27.1 -> 0.28
* [`8b9251cf`](https://github.com/NixOS/nixpkgs/commit/8b9251cfdde42619209f1e533d2e7a55064e9e99) lyx: 2.4.3 -> 2.4.4
* [`6d8e2f0b`](https://github.com/NixOS/nixpkgs/commit/6d8e2f0b157f4d7f4d1c0fec9789ff987d254b59) dotenvx: 1.44.2 -> 1.45.1
* [`b50c90d6`](https://github.com/NixOS/nixpkgs/commit/b50c90d66f2da1c3022ad3898b5cdfada6c22e6f) spring-boot-cli: 3.5.0 -> 3.5.3
* [`64e7fad0`](https://github.com/NixOS/nixpkgs/commit/64e7fad03872084999ebf8b76b413f8afed37d0a) nixos/postfix-tlspol: fix postfix integration
* [`9c070c95`](https://github.com/NixOS/nixpkgs/commit/9c070c95dd373be7ed339f637f7b08dedc8e08ce) stacs: 0.2.0 -> 0.5.1
* [`0236c1ca`](https://github.com/NixOS/nixpkgs/commit/0236c1cae446357e32eedd32517a90167791600f) pysolfc: 3.2.0 -> 3.4.0
* [`7828a402`](https://github.com/NixOS/nixpkgs/commit/7828a40276f366510d4612c4c73c82eceada314e) trealla: 2.73.3 -> 2.73.16
* [`a7ce21af`](https://github.com/NixOS/nixpkgs/commit/a7ce21affe959c180e07e7d1fee995230cbccb00) svelte-language-server: 0.17.15 -> 0.17.16
* [`a18d1ab1`](https://github.com/NixOS/nixpkgs/commit/a18d1ab10cd244662a710c28d11073bee65e4878) python3Packages.e3-testsuite: 26.0 -> 27.2
* [`26533383`](https://github.com/NixOS/nixpkgs/commit/2653338310d74677000cfd7ff37d16a8c6a9aff5) maintainers: add ttschnz
* [`326618e7`](https://github.com/NixOS/nixpkgs/commit/326618e71067c3e7e4a5061a622433ae07fbbf31) vscode-extensions.smcpeak.default-keys-windows: add ttschnz to maintainers
* [`35e98439`](https://github.com/NixOS/nixpkgs/commit/35e98439adf2ce94c53947b39188ea0a89c140fd) vscode-extensions.smcpeak.default-keys-windows: 0.0.10 -> 1.0.0
* [`014965c6`](https://github.com/NixOS/nixpkgs/commit/014965c6280dae2c3867d5ab15e4e976b271f9eb) positron-bin: 2025.06.0-146 -> 2025.07.0-112
* [`83ac2a71`](https://github.com/NixOS/nixpkgs/commit/83ac2a71d83875fb537135f6a64e776b23cac939) yandex-music: 5.54.0 -> 5.56.0
* [`df7777da`](https://github.com/NixOS/nixpkgs/commit/df7777daf968c3656e04f1ec7228898e24901782) pulumi-bin: 3.177.0 -> 3.178.0
* [`38265e74`](https://github.com/NixOS/nixpkgs/commit/38265e747f9f05e853050ed45138242bfc1b3f99) worker: 5.2.1 -> 5.2.2
* [`35ffb2d1`](https://github.com/NixOS/nixpkgs/commit/35ffb2d1a8ae7295df75584304f0619c3a30171f) ocamlPackages.ocamlformat-mlx-lib: 0.27.0.0 -> 0.27.0.1
* [`c146164b`](https://github.com/NixOS/nixpkgs/commit/c146164b4ff47f5f6ae93a6b3a4e35f88a2ed2a2) lcevcdec: 3.3.7 -> 3.3.8
* [`45c86ea5`](https://github.com/NixOS/nixpkgs/commit/45c86ea5b0c928f06f89c3ac46b33bc23e0e23f7) peergos: 1.5.0 -> 1.6.0
* [`6ade8b16`](https://github.com/NixOS/nixpkgs/commit/6ade8b16d4c80d16a9bcfefc8923dafb0844ae1b) python313Packages.python-bsblan: 2.1.0 -> 2.2.5
* [`9f4ec39e`](https://github.com/NixOS/nixpkgs/commit/9f4ec39e6a6724205e09a11f88f44a43dfaa8924) checkstyle: 10.25.0 -> 10.25.1
* [`00302975`](https://github.com/NixOS/nixpkgs/commit/00302975f51d12daa455b73bc87c254663d978f2) xdg-terminal-exec: 0.12.4 -> 0.13.1
* [`d8b4467a`](https://github.com/NixOS/nixpkgs/commit/d8b4467a2f4262a460fe76c4d81a56ced4619aab) python3Packages.awscrt: 0.27.2 -> 0.27.4
* [`07bac1ab`](https://github.com/NixOS/nixpkgs/commit/07bac1abbb8305156b38e6337b27cbb96254a66a) python3Packages.radio-beam: 0.3.8 -> 0.3.9
* [`4161410f`](https://github.com/NixOS/nixpkgs/commit/4161410fee23e636998239f97fb1c6f28750dbfa) rabbitmqadmin-ng: 2.1.0 -> 2.2.1
* [`ab311e9a`](https://github.com/NixOS/nixpkgs/commit/ab311e9aac3aeec4dfd0889a709293ea5f9b3c26) prometheus-sql-exporter: 0.6 -> 0.8
* [`5ee7f893`](https://github.com/NixOS/nixpkgs/commit/5ee7f8931ae666bedd8e0ccb41a61457fef0dd96) quarkus: 3.23.3 -> 3.23.4
* [`8dcc198c`](https://github.com/NixOS/nixpkgs/commit/8dcc198c4118c94b8b1ecf4cf6a022efade022c3) youtrack: 2025.1.76253 -> 2025.1.82518
* [`9d019100`](https://github.com/NixOS/nixpkgs/commit/9d019100b45153acbbc5ec52dcf3384a01124fa4) python3Packages.evaluate: 0.4.3 -> 0.4.4
* [`2c0376d3`](https://github.com/NixOS/nixpkgs/commit/2c0376d3454f171131cd2b2da47246cf79b520e1) seamly2d: 2025.6.9.216 -> 2025.6.16.216
* [`c7c2288b`](https://github.com/NixOS/nixpkgs/commit/c7c2288b77ee2ed10d944a7b67b9f8ba59fa9261) kyverno: 1.14.1 -> 1.14.3
* [`75e31ca6`](https://github.com/NixOS/nixpkgs/commit/75e31ca6b23700b5d9304c01d16de62be52d419c) pycapnp: update to Cython 3
* [`09617329`](https://github.com/NixOS/nixpkgs/commit/09617329999c7f168e7976d1e94cae755224960e) kargo: 1.5.1 -> 1.5.3
* [`f648bcbc`](https://github.com/NixOS/nixpkgs/commit/f648bcbc8fb2985d95845b74a357c53444dc8abc) flrig: 2.0.05 -> 2.0.07
* [`264a4797`](https://github.com/NixOS/nixpkgs/commit/264a47976a566679b84727f8bee12384b953d7f8) libwacom: 2.15.0 -> 2.16.1
* [`04541908`](https://github.com/NixOS/nixpkgs/commit/045419081e5499c0fb1050fc4efbac8210131782) rocketchat-desktop: 4.5.0 -> 4.6.0
* [`f76e0581`](https://github.com/NixOS/nixpkgs/commit/f76e058136cc0c3ca0bbb9f0cd1f44d9fc9079ff) regrippy: init at 2.0.1
* [`e12a71c7`](https://github.com/NixOS/nixpkgs/commit/e12a71c71704d17ee2b00eba3699b0d5764234b0) pycapnp: adopt, cleanup
* [`373a3baa`](https://github.com/NixOS/nixpkgs/commit/373a3baa23ef2c4425598fb671fb2c6bc196814c) activemq: 6.1.6 -> 6.1.7
* [`ec666e25`](https://github.com/NixOS/nixpkgs/commit/ec666e25162910dd7cd0d7305d94085db7ab1bec) grml-zsh-config: 0.19.19 -> 0.19.21
* [`3124ca2d`](https://github.com/NixOS/nixpkgs/commit/3124ca2d541d4ae16182b14cf5ff443e392e1c3c) flix: 0.59.0 -> 0.60.0
* [`140b3ba4`](https://github.com/NixOS/nixpkgs/commit/140b3ba46d0ec2d16b99811e5f8dcf47d361ad48) weaviate: 1.31.1 -> 1.31.2
* [`faec14a4`](https://github.com/NixOS/nixpkgs/commit/faec14a49024e1687dbe492eb37d4a6789d7aa93) wvkbd: 0.16 -> 0.17
* [`962afb93`](https://github.com/NixOS/nixpkgs/commit/962afb9377b9fc29916ae59137361fff72b0a8bd) bluemap: 5.7 -> 5.8
* [`73bbdbfe`](https://github.com/NixOS/nixpkgs/commit/73bbdbfeba1ea65f6244f420d13a06600dfde50a) dash-mpd-cli: 0.2.26 → 0.2.27
* [`44dd5096`](https://github.com/NixOS/nixpkgs/commit/44dd50960de83e7fe0137eea13415a72d035e617) nwjs: 0.90.0 -> 0.100.1
* [`bdb25020`](https://github.com/NixOS/nixpkgs/commit/bdb250203a4b6e4db4be7666257422cb0d155af5) python3Packages.aiolifx-themes: bump minimum python requirement to 3.12
* [`65cfdb24`](https://github.com/NixOS/nixpkgs/commit/65cfdb247c781eb0da9c4f624702cbce106519c1) ibmcloud-cli: 2.34.1 -> 2.34.2
* [`219158d3`](https://github.com/NixOS/nixpkgs/commit/219158d36caa1e2fed83d944eead56e9534fd7f2) hdf5-blosc: 1.0.0 -> 1.0.1
* [`519c9061`](https://github.com/NixOS/nixpkgs/commit/519c9061deb8acf08fc3f46c976e6d136c89cbaa) hdf5-blosc: add passthru.updateScript, cleanup, add test
* [`397e65c4`](https://github.com/NixOS/nixpkgs/commit/397e65c4657445a08d0cb70f7e9fc95259e8dbc7) schemacrawler: 16.26.1 -> 16.26.2
* [`5c576d03`](https://github.com/NixOS/nixpkgs/commit/5c576d03d01ceb40dda02cfbba9897c89798c89e) python3Packages.notion-client: 2.3.0 -> 2.4.0
* [`a4a5c990`](https://github.com/NixOS/nixpkgs/commit/a4a5c990f161f17b4259a765bac0a1962e5c0526) icewm: 3.7.5 -> 3.8.0
* [`b67003d5`](https://github.com/NixOS/nixpkgs/commit/b67003d53ab10e47807a9979d50a7a5bf255f07c) ecs-agent: 1.92.0 -> 1.95.0
* [`28379dea`](https://github.com/NixOS/nixpkgs/commit/28379deacfadc35b7854f821a769fb5d7f64df7b) python3Packages.jaxlib-build: pass pkgs.snappy as snappy-cpp
* [`c1238432`](https://github.com/NixOS/nixpkgs/commit/c12384329f3c3e206b546d2625653da875be5b4a) python3Packages.python-snappy: pass pkgs.snappy as snappy-cpp
* [`d0fc6ee5`](https://github.com/NixOS/nixpkgs/commit/d0fc6ee5119d1a6409a20a3cdb44dc77801abeca) python3Packages.tensorflow-build: pass pkgs.snappy as snappy-cpp
* [`480755c2`](https://github.com/NixOS/nixpkgs/commit/480755c2f1099212e4ecbbb5d1a416e6f62b8942) ocamlPackages.ppx_expect: 0.17.0 → 0.17.2
* [`83234868`](https://github.com/NixOS/nixpkgs/commit/832348682114ac3e3bfaaf4675e92c03410195b3) mattermost: disable MySQL tests
* [`e0e6662c`](https://github.com/NixOS/nixpkgs/commit/e0e6662c9ace75c0cc5096fc423738b87f1358b0) skim: 0.18.0 -> 0.20.1
* [`38454e14`](https://github.com/NixOS/nixpkgs/commit/38454e145b3a65d3e6025083ffe5f82e92c12370) infrastructure-agent: 1.64.0 -> 1.65.0
* [`3e57d8f2`](https://github.com/NixOS/nixpkgs/commit/3e57d8f2b8ac326d279bf25e6a7a69dda223608d) komga: 1.21.3 -> 1.22.0
* [`5d32bad5`](https://github.com/NixOS/nixpkgs/commit/5d32bad539642a919a1db9aea075bb82fa59773a) sem: 0.31.0 -> 0.32.0
* [`9acb6cab`](https://github.com/NixOS/nixpkgs/commit/9acb6cabb9c001a68cf18c53f82afb4e5a8578ec) readsb: 3.14.1666 -> 3.14.1683
* [`8455a2fd`](https://github.com/NixOS/nixpkgs/commit/8455a2fd8f06f726db31fc01785a4bb654df7509) maintainers: add tye-exe
* [`037b597f`](https://github.com/NixOS/nixpkgs/commit/037b597fae5ebcf60d54a68504bc2d583ae587de) hatari: 2.5.0 -> 2.6.0
* [`2032774c`](https://github.com/NixOS/nixpkgs/commit/2032774c51941c658f7ba13d4909a8358138dc77) python313Packages.openstackdocstheme: drop disabled
* [`d449c9ca`](https://github.com/NixOS/nixpkgs/commit/d449c9cae1dd42d95431dd7a204b98da831c2668) python313Packages.python-cinderclient: disable very sensitive test which failed due to a dependency update
* [`c4eb0853`](https://github.com/NixOS/nixpkgs/commit/c4eb085322ba2935746d98b49e1c6556b5517d07) treewide: bump openstack clis to python 3.13
* [`d8864b2f`](https://github.com/NixOS/nixpkgs/commit/d8864b2f5aeb2809f4b7d8d0e053d7bd49f2c4d3) level-zero: 1.21.9 -> 1.22.4
* [`0eb3352e`](https://github.com/NixOS/nixpkgs/commit/0eb3352e678932daf59cab3998a0192c36560588) wechat: 4.0.5.24 -> 4.0.5.27-29258 for darwin
* [`3d5bea05`](https://github.com/NixOS/nixpkgs/commit/3d5bea05a9c4263db0c5d6864f44693a6ef2444b) nextcloudPackages.dav_push: init at 0.0.3
* [`739b7bb7`](https://github.com/NixOS/nixpkgs/commit/739b7bb706e81f3b61900e837da2abbe6e785640) python3Packages.pyais: 2.9.4 -> 2.10.0
* [`25823769`](https://github.com/NixOS/nixpkgs/commit/25823769745660be1afca9bb3ba807a0e27b04da) livekit-ingress: init at 1.4.3
* [`f19355f5`](https://github.com/NixOS/nixpkgs/commit/f19355f5ed804e79dee494930fc33016fc073852) nixos/livekit-ingress: init
* [`aefa79cf`](https://github.com/NixOS/nixpkgs/commit/aefa79cfc95b8ecd4b775131239335f38cf7cffb) nixos/livekit{,-ingress}: automatically configure redis for locally distributed setups
* [`b9559be8`](https://github.com/NixOS/nixpkgs/commit/b9559be8c40ed77f89706e8b420da498d90db290) nixos/tests/livekit: test local ingress service integration
* [`106ba85d`](https://github.com/NixOS/nixpkgs/commit/106ba85d7120eb4049b7764088e71fe38e5945d6) gnome-decoder: overhaul derivation, move to pkgs/by-name
* [`3df5e81d`](https://github.com/NixOS/nixpkgs/commit/3df5e81d2eaaee8a6dda20704baae98984d5b190) git-quick-stats: 2.5.8 -> 2.6.2
* [`b73d5e49`](https://github.com/NixOS/nixpkgs/commit/b73d5e49cbac56b42254b7751e4a5b62f4fe1c47) conduktor-ctl: 0.5.1 -> 0.6.0
* [`8a77cc3d`](https://github.com/NixOS/nixpkgs/commit/8a77cc3db4381c675864b02c181467679e1f9cae) garage_0_8: remove
* [`45c0608a`](https://github.com/NixOS/nixpkgs/commit/45c0608ace23b6b11d84dedbc403e12e3fdbed68) garage_0_9: mark eol
* [`2b90c413`](https://github.com/NixOS/nixpkgs/commit/2b90c413dfb68283e7be8bf00fe3b04cad524d3e) garage_1_x: rename to garage_1
* [`77c84b02`](https://github.com/NixOS/nixpkgs/commit/77c84b0260407befbb78c51a19a77334f538a61c) libetonyek: fix cross-compilation
* [`acdff763`](https://github.com/NixOS/nixpkgs/commit/acdff763efbf0a4e8de2a6e9f1ce7deb1c54f8d3) python3Packages.trl: 0.17.0 -> 0.19.0
* [`c398bc61`](https://github.com/NixOS/nixpkgs/commit/c398bc61d424ad33648b920f22be76f047675579) python312Packages.anthropic: 0.52.2 -> 0.55.0
* [`c1788d46`](https://github.com/NixOS/nixpkgs/commit/c1788d460844e114f3f30f1eb33e8388ac94bc80) python3Packages.reptor: 0.28 -> 0.31
* [`c79a19ce`](https://github.com/NixOS/nixpkgs/commit/c79a19cea1bf20524269f2fd3bf232a907bd467b) vorta: move to by-name
* [`924c52cc`](https://github.com/NixOS/nixpkgs/commit/924c52cc23269410addc5d86e82a1514f105f14e) python3Packages.ppdeep: 20200505 -> 20250622
* [`222fb398`](https://github.com/NixOS/nixpkgs/commit/222fb398d42dbb15a721741a51aead61f8ca88bb) python3Packages.azure-mgmt-appconfiguration: 4.0.0 -> 5.0.0
* [`d6859b38`](https://github.com/NixOS/nixpkgs/commit/d6859b38d11f6118723a3ab074ca6dae1dd03a19) typst: Update typst packages as of 06-24-2025
* [`04c5ae88`](https://github.com/NixOS/nixpkgs/commit/04c5ae88ae4742f0462de5c2993a77e1df82db23) melange: 0.26.6 -> 0.26.13
* [`3fb83c13`](https://github.com/NixOS/nixpkgs/commit/3fb83c139cf2dc946bc970f6efc21073d3bd8e4b) python3Packages.langchain-aws: 0.2.25 -> 0.2.26
* [`9e124197`](https://github.com/NixOS/nixpkgs/commit/9e1241970b79207f7b78333062161be3021c4e8e) oxlint: 0.16.9 -> 1.3.0
* [`b708ede1`](https://github.com/NixOS/nixpkgs/commit/b708ede1438b8506404bb7d93e16ba7c6ea02af0) lms: 3.66.1 -> 3.67.0
* [`6f0ded03`](https://github.com/NixOS/nixpkgs/commit/6f0ded032df79790f07e0115cc55a7a1308eab52) oakctl: 0.2.12 -> 0.11.0
* [`33ab0a19`](https://github.com/NixOS/nixpkgs/commit/33ab0a191e70b0baa51560c2a0680ae5a1a870c4) nixos/netbox: don't force use of sudo in netbox-manage
* [`d7cebe67`](https://github.com/NixOS/nixpkgs/commit/d7cebe6783f668b1b54a037f1023a29e071076f9) vscode-extensions.csharpier.csharpier-vscode: 2.0.6 -> 2.0.7
* [`7582289b`](https://github.com/NixOS/nixpkgs/commit/7582289b18011622946c3a7b870fa6f1af61b76a) vscode-extensions.jnoortheen.nix-ide: 0.4.18 -> 0.4.21
* [`408b2523`](https://github.com/NixOS/nixpkgs/commit/408b2523b4787d651bab1c144d9c8c9df51ef990) vscode-extensions.banacorn.agda-mode: 0.5.7 -> 0.6.0
* [`eb321111`](https://github.com/NixOS/nixpkgs/commit/eb321111ffe5a8fdb6a70f51a1bb218f93438e8e) vscode-extensions.wakatime.vscode-wakatime: 25.0.4 -> 25.0.6
* [`2031adff`](https://github.com/NixOS/nixpkgs/commit/2031adff183091587f56bc52ba9b143913ebb0dd) vscode-extensions.foam.foam-vscode: 0.26.11 -> 0.26.12
* [`2e84befd`](https://github.com/NixOS/nixpkgs/commit/2e84befd318aed86649b3e970e20a0bf273dae99) vscode-extensions.danielsanmedium.dscodegpt: 3.12.81 -> 3.12.89
* [`0653b466`](https://github.com/NixOS/nixpkgs/commit/0653b4665e4f2d762778522f09878f367eddd404) vscode-extensions.bradlc.vscode-tailwindcss: 0.14.21 -> 0.14.23
* [`f6e233cb`](https://github.com/NixOS/nixpkgs/commit/f6e233cbf48965b265b5c69789dfffe6bfe2d526) vscode-extensions.databricks.databricks: 2.9.4 -> 2.10.1
* [`c5a9b9fb`](https://github.com/NixOS/nixpkgs/commit/c5a9b9fbe112829ad8a9f19a753e9ee442f55d2c) vscode-extensions.ms-dotnettools.vscode-dotnet-runtime: 2.3.5 -> 2.3.6
* [`a85e9a68`](https://github.com/NixOS/nixpkgs/commit/a85e9a68705936054966f9bec1215e5179b20025) vscode-extensions.kahole.magit: 0.6.66 -> 0.6.67
* [`0ba30f81`](https://github.com/NixOS/nixpkgs/commit/0ba30f8150cea73888476499a2f71f0668251301) pnpm_10: 10.12.1 -> 10.12.3
* [`44860f6d`](https://github.com/NixOS/nixpkgs/commit/44860f6d9f28af32d61eacc8d29af95a15eb74a2) vscode-extensions.ban.spellright: 3.0.142 -> 3.0.144
* [`d735743b`](https://github.com/NixOS/nixpkgs/commit/d735743b3984a9b0a0808adab35ccc8c174bdd95) linux/common-config: enable AX25
* [`56cbb4e5`](https://github.com/NixOS/nixpkgs/commit/56cbb4e5d8c3b45d577964ea9e11a5a1da9ee2aa) Revert "linuxPackages_ham: init"
* [`ba946127`](https://github.com/NixOS/nixpkgs/commit/ba946127f9466328a9013df70f315f59f650178b) proton-pass: 1.31.5 -> 1.32.0
* [`b9b805b9`](https://github.com/NixOS/nixpkgs/commit/b9b805b92321715f3c850c4c6a11440b386ca490) twilio-cli: 5.23.1 -> 6.0.0
* [`c1198487`](https://github.com/NixOS/nixpkgs/commit/c119848700e6675c1181e03b9e76daf5157a9e73) nixos/postgresql: align maintainers with postgresql package
* [`41c5662c`](https://github.com/NixOS/nixpkgs/commit/41c5662cbec9930b337a895c7cb010948d9766a9) nixos/postgresql: move postStart into separate unit
* [`9656e1aa`](https://github.com/NixOS/nixpkgs/commit/9656e1aa9d466b83157954d2bc89835ac2cce0c3) nixos/postgresql: make postgresql.target wait until recovery is done
* [`c463263d`](https://github.com/NixOS/nixpkgs/commit/c463263dcfb7c0edcf5f6b3d137838b7bd456be9) fosrl-gerbil: minor refactoring
* [`b8cc3f60`](https://github.com/NixOS/nixpkgs/commit/b8cc3f604f965697aef7637cf73232c2b6b39808) c-blosc2: 2.18.0 -> 2.19.0
* [`70db9134`](https://github.com/NixOS/nixpkgs/commit/70db913431b12b3914407d7fa87c86b462b06529) garage: add adamcstephens as maintainer
* [`7f8136bb`](https://github.com/NixOS/nixpkgs/commit/7f8136bb28cbcc764c454eca9efe93913e4d7c8e) mpvScripts.modernx-zydezu: 0.4.2 -> 0.4.3
* [`02d91c78`](https://github.com/NixOS/nixpkgs/commit/02d91c78d566dc1d6510496b332ab291de145da7) firefox-devedition-unwrapped: 140.0b9 -> 141.0b1
* [`a108dbc7`](https://github.com/NixOS/nixpkgs/commit/a108dbc79f209aac0e39203cdca1b17f1ee0a398) pop-wallpapers: refactor Makefile handling
* [`5ad67720`](https://github.com/NixOS/nixpkgs/commit/5ad67720a03253093e0d1210e8340cf7bc5f6a59) python313Packages.oslo-log: ignore some new test failures, remove one no longer relevant one
* [`eed41b0b`](https://github.com/NixOS/nixpkgs/commit/eed41b0b20d40a63bf65103916bc7b875a851c5a) pop-wallpapers: 1.0.5 → 1.0.5-unstable-2025-06-24
* [`74a55427`](https://github.com/NixOS/nixpkgs/commit/74a55427badc7e0c8162b0d5a6df5bf190fd59da) pop-wallpapers: add normalcea as maintainer
* [`5df79858`](https://github.com/NixOS/nixpkgs/commit/5df798588863eee145747224771c69010cdeae3e) tidal-hifi: reorder desktop entry keys according to spec
* [`29b86572`](https://github.com/NixOS/nixpkgs/commit/29b86572318ed7b2f9cb2db96f8255a9ec3be49b) tidal-hifi: improve quality of the desktop entry
* [`e014cb68`](https://github.com/NixOS/nixpkgs/commit/e014cb68ccd512fde1de37a678607d98735cff38) sccmhunter: 1.0.9 -> 1.0.10
* [`8a510bd1`](https://github.com/NixOS/nixpkgs/commit/8a510bd15c6b42d189380b93f091e5bea4fcfbd5) python3Packages.jplephem: 2.22 -> 2.23
* [`777f8cb8`](https://github.com/NixOS/nixpkgs/commit/777f8cb818bc8d3f80b191cd32c7170208a39d93) python313Packages.python-glanceclient: add more failed tests
* [`d5deebda`](https://github.com/NixOS/nixpkgs/commit/d5deebda5a334245ec856544cbc88bae4355b58a) kolla: ignore test which failed because of an additional close syscall
* [`519949d2`](https://github.com/NixOS/nixpkgs/commit/519949d2b23c8ed7b3ae26f9bb28829d7934b8cc) rockstarlang: 2.0.30 -> 2.0.31
* [`839c7acc`](https://github.com/NixOS/nixpkgs/commit/839c7acc5dafb0da0eb2c8729134b8fa45a07cec) firezone-gateway: 1.4.10 -> 1.4.11
* [`9cfb76a7`](https://github.com/NixOS/nixpkgs/commit/9cfb76a75b99d46fc0eca2f4ea16f541295873fe) uxn: 1.0-unstable-2025-05-17 -> 1.0-unstable-2025-06-16
* [`2d96edf9`](https://github.com/NixOS/nixpkgs/commit/2d96edf9fb2faf76ec2a6040c592d12755e3c276) ibus-engines.typing-booster-unwrapped: 2.27.64 -> 2.27.65
* [`b1744596`](https://github.com/NixOS/nixpkgs/commit/b1744596816c4e2e48e94158215162721f90f62a) matrix-authentication-service: 0.16.0 -> 0.17.1
* [`aa5ed728`](https://github.com/NixOS/nixpkgs/commit/aa5ed728e65f0e1b9395383f003b8ad6ef574dc0) ut1999: 469d → 469e-rc8
* [`f46e1a4b`](https://github.com/NixOS/nixpkgs/commit/f46e1a4b9e8bf6b1b0cdc1ef09d543802cebdca2) finamp: 0.9.16-beta -> 0.9.18-beta
* [`b99939dc`](https://github.com/NixOS/nixpkgs/commit/b99939dc9e917c530d1a737139f414ced70d4926) epy: add dependency removed from python stdlib
* [`8b38ae24`](https://github.com/NixOS/nixpkgs/commit/8b38ae2466016293517461e1fc5a4d78a7943a00) Revert "opencv: export CUDA_TOOLKIT_ROOT_DIR so findCUDA uses Nix-selected toolkit"
* [`a2430016`](https://github.com/NixOS/nixpkgs/commit/a2430016224843b7a1890c31f3b5333ed121a0ff) opencv: use FindCudaToolkit module in CMake config
* [`e2606609`](https://github.com/NixOS/nixpkgs/commit/e260660977ccb58c954ab4faca5eda8360c24ef3) bambu-studio: use OpenCV's cxxdev output
* [`4c5f4394`](https://github.com/NixOS/nixpkgs/commit/4c5f4394a9da37f060cf8b46121af0f2dae46061) basalt-monado: use OpenCV's cxxdev output
* [`23cb263c`](https://github.com/NixOS/nixpkgs/commit/23cb263c38ac576f1abeebff3fa9f0fd17a58892) orca-slicer: use OpenCV's cxxdev output
* [`5859ccdc`](https://github.com/NixOS/nixpkgs/commit/5859ccdca36c7036b73b5551857a53a7b91b163b) qimgv: use OpenCV's cxxdev output
* [`7c4cbeea`](https://github.com/NixOS/nixpkgs/commit/7c4cbeea8ee659bb40035052b26f94cbc71c2a44) rpcs3: use OpenCV's cxxdev output
* [`32b9c68b`](https://github.com/NixOS/nixpkgs/commit/32b9c68ba12f67af504296a961db9a2be7367de8) python3Packages.pontos: 25.4.0 -> 25.6.0
* [`30dc713a`](https://github.com/NixOS/nixpkgs/commit/30dc713a31492c0435e855845cda294db5669ae9) obs-studio-plugins.obs-backgroundremoval: use OpenCV's cxxdev output
* [`61669115`](https://github.com/NixOS/nixpkgs/commit/61669115478687eec4e4de2e025b5c70235a2acc) python3Packages.meraki: 2.0.2 -> 2.0.3
* [`8e553a70`](https://github.com/NixOS/nixpkgs/commit/8e553a70b44214bf93f8009ffea1e91274660259) nelua: 0-unstable-2024-12-14 -> 0-unstable-2025-06-24
* [`1c8d13d3`](https://github.com/NixOS/nixpkgs/commit/1c8d13d3657feb25c98cc195df8ace6497d76379) xivlauncher: 1.1.2 -> 1.2.0
* [`94a17423`](https://github.com/NixOS/nixpkgs/commit/94a174237bdd796cbb7e0e402d01d616cf32f227) thin-provisioning-tools: 1.1.0 -> 1.2.0
* [`0c931da6`](https://github.com/NixOS/nixpkgs/commit/0c931da66cfbb82178ff3122b0a957233b5404ba) kubelogin: 0.2.8 -> 0.2.9
* [`185d4726`](https://github.com/NixOS/nixpkgs/commit/185d47262bb1d4413782a2b6650a51317495447d) linuxPackages.xone: 0.3.1 -> 0.3.2
* [`46e2dac3`](https://github.com/NixOS/nixpkgs/commit/46e2dac3a50d2ee072a6174efc179d310d37d5ee) zoom-us: 6.4.13.2309 -> 6.5.1.2550
* [`106aed9f`](https://github.com/NixOS/nixpkgs/commit/106aed9f99ed55d5b495b1d6dd458b25e3a24d35) maintainers: add RadxaYuntian
* [`b84f8e6e`](https://github.com/NixOS/nixpkgs/commit/b84f8e6e039ba2b3f017e26eb42320c3b8618cd5) ch9344: 0-unstable-2024-11-15 -> 2.3
* [`c7676799`](https://github.com/NixOS/nixpkgs/commit/c76767997cf7fcd8606e18c359da5e1206c68106) jellyseerr: 2.5.2 -> 2.7.0
* [`48fd4d6c`](https://github.com/NixOS/nixpkgs/commit/48fd4d6c82f4d663c2ace363e621cdafbb6fdd4e) python3Packages.livekit-protocol: 1.0.3 -> 1.0.4
* [`9b0bb2fd`](https://github.com/NixOS/nixpkgs/commit/9b0bb2fd421493147df584f0e816f38ad075057b) steampipePackages.steampipe-plugin-aws: 1.13.0 -> 1.16.1
* [`b1e21921`](https://github.com/NixOS/nixpkgs/commit/b1e21921fb7e3202fb85f6449e020cbf63774d16) vscode-extensions.gitlab.gitlab-workflow: 6.25.0 -> 6.28.2
* [`ea13ae30`](https://github.com/NixOS/nixpkgs/commit/ea13ae3056922422e18809c548e8d868f7a3b8a1) poliedros: 1.0.1 -> 1.5.0
* [`48de7e12`](https://github.com/NixOS/nixpkgs/commit/48de7e12608143eb05bfc0228ea4644c742f02f3) pocketbase: 0.28.3 -> 0.28.4
* [`a09756aa`](https://github.com/NixOS/nixpkgs/commit/a09756aae904f5448b3a4cde8f4cdd135e872fad) fishPlugins.exercism-cli-fish-wrapper: 0-unstable-2025-06-12 -> 0-unstable-2025-06-23
* [`3724ebc9`](https://github.com/NixOS/nixpkgs/commit/3724ebc9d5d357313a23944c08a8e156f272589d) python3Packages.cut-cross-entropy: 25.3.1 -> 25.5.1
* [`90e2028b`](https://github.com/NixOS/nixpkgs/commit/90e2028bcddda9d80f552a720f69d6794f5c1062) python3Packages.unsloth-zoo: 2025.5.11 -> 2025.6.4
* [`f6820ee4`](https://github.com/NixOS/nixpkgs/commit/f6820ee4c3806d74c54c765b83df6ae2284e3690) python3Packages.unsloth: 2025.5.9 -> 2025.6.5
* [`9cb5924e`](https://github.com/NixOS/nixpkgs/commit/9cb5924e758daaef0f7f5d43ecfbfafb85b4735b) htmlhint: 1.5.1 -> 1.6.3
* [`eb31ebf9`](https://github.com/NixOS/nixpkgs/commit/eb31ebf9ca76bd9fd728710ad653f18051a1fe26) alistral: 0.5.11 -> 0.5.12
* [`1bfe4e76`](https://github.com/NixOS/nixpkgs/commit/1bfe4e7644f73dcaef71ce011c5a26f8d1c5b9a7) python3Packages.xarray-einstats: 0.9.0 -> 0.9.1
* [`605472a6`](https://github.com/NixOS/nixpkgs/commit/605472a6d15a5b880e4e19ef2cdf3ce0aa2ff223) gitlab: 18.1.0 -> 18.1.1
* [`33d84b98`](https://github.com/NixOS/nixpkgs/commit/33d84b98e51588854dac959361000b5cfb74e06c) python3Packages.bilibili-api-python: 17.2.0 -> 17.2.1
* [`ccc8e1e5`](https://github.com/NixOS/nixpkgs/commit/ccc8e1e5b42afc57d0bef6003a9613ab09557410) python3Packages.yolink-api: 0.5.4 -> 0.5.5
* [`74d67de1`](https://github.com/NixOS/nixpkgs/commit/74d67de12752a82fd6bcd0767dbf188ace4a4449) msbuild-structured-log-viewer: 2.2.508 -> 2.3.13
* [`c4f7b48d`](https://github.com/NixOS/nixpkgs/commit/c4f7b48d2c55b11ff042dd7dfb0a5bbfc240d27c) pdqsort: init at unstable-2021-03-14
* [`2ecb2c1a`](https://github.com/NixOS/nixpkgs/commit/2ecb2c1a3d2f9885de33597903a90aab7b7a8411) linuxKernel.packages.vmware: workstation-17.6.3 -> workstation-17.6.3-20250608
* [`ed549950`](https://github.com/NixOS/nixpkgs/commit/ed549950d6639004c4399be708c6011f123e09a7) linuxKernel.packages.vmware: remove usage of with lib;
* [`d968aa8c`](https://github.com/NixOS/nixpkgs/commit/d968aa8c9ed500847a17ecb2448348660da6e7ad) nix: 2.26.3 -> 2.26.4
* [`506b6d2f`](https://github.com/NixOS/nixpkgs/commit/506b6d2f68da96c2039e196e59aca4b7b8f5a14b) aws-lc: 1.52.0 -> 1.53.1
* [`53253334`](https://github.com/NixOS/nixpkgs/commit/532533340b1af216efeb9d3d6097a9e31f22b68d) python3Packages.pypck: 0.8.8 -> 0.8.9
* [`943026b9`](https://github.com/NixOS/nixpkgs/commit/943026b966e32909ece584996dac41daa0e484c5) mdns-scanner: 0.13.0 -> 0.15.0
* [`012200a3`](https://github.com/NixOS/nixpkgs/commit/012200a35727ce375d1edeb28f15f59da4ec2efb) measureme: add update script
* [`27414c1b`](https://github.com/NixOS/nixpkgs/commit/27414c1b1e0c4599a9ddbc4fa3529a5b6bd49251) measureme: 12.0.0 -> 12.0.1
* [`adc557cb`](https://github.com/NixOS/nixpkgs/commit/adc557cb75f2fd5a72b843b145e7db2aaa09290f) hyprpanel: 0-unstable-2025-06-20 -> 0-unstable-2025-06-22
* [`af71a187`](https://github.com/NixOS/nixpkgs/commit/af71a18798a340ffbf30e70e0f1f2015625f33e8) portfolio: 0.77.2 -> 0.77.3
* [`c4f9164d`](https://github.com/NixOS/nixpkgs/commit/c4f9164d904ed9af6d2a9df97250136b92ddd38f) sentry-native: 0.9.0 -> 0.9.1
* [`6f39ba16`](https://github.com/NixOS/nixpkgs/commit/6f39ba165410eaea7b5a82ccd02122326cebee8d) mihomo: 1.19.10 -> 1.19.11
* [`8789d7a1`](https://github.com/NixOS/nixpkgs/commit/8789d7a1d0f601612d7845a9f739f8009dff234c) starboard: 0.15.25 -> 0.15.26
* [`790b9d5b`](https://github.com/NixOS/nixpkgs/commit/790b9d5b16b17c16d90e023b47ed3ca425fae159) kitex: 0.14.0 -> 0.14.1
* [`57da44f5`](https://github.com/NixOS/nixpkgs/commit/57da44f579d6997d06c13b12b7ad8b79a6f4959e) nhost-cli: 1.29.8 -> 1.29.9
* [`b05f5052`](https://github.com/NixOS/nixpkgs/commit/b05f5052a9fc4607958df802646b789bc038eed2) kubectl-view-allocations: 0.22.0 -> 0.22.1
* [`c2618fc5`](https://github.com/NixOS/nixpkgs/commit/c2618fc5e3c2ee75261f57d6c6055e3f64beeb72) emscripten: node_modules fix, cache location fix
* [`0de074a0`](https://github.com/NixOS/nixpkgs/commit/0de074a09fe39cae84c3db5cc8fc0e13a53f9c75) caf: 1.0.2 -> 1.1.0
* [`de243afe`](https://github.com/NixOS/nixpkgs/commit/de243afec4fd9b4d69a64b3522d47f9b550fbac5) polypane: drop
* [`8a1ba7b6`](https://github.com/NixOS/nixpkgs/commit/8a1ba7b6eb4c860a0f257551045c5f8653d6f589) raycast: 1.100.0 -> 1.100.3
* [`2fb30491`](https://github.com/NixOS/nixpkgs/commit/2fb304914e7ad2f3ca4e384c1b4324ecfd752b1d) vieb: drop
* [`f6bd6c4f`](https://github.com/NixOS/nixpkgs/commit/f6bd6c4f2be5d25f23df0ba43d06503250a0a7b1) rectangle: 0.87 -> 0.88
* [`0b628255`](https://github.com/NixOS/nixpkgs/commit/0b628255ce7d3babd3deee4c2ce2b36503507d55) star: 2.7.10b -> 2.7.11b
* [`6f87f7a4`](https://github.com/NixOS/nixpkgs/commit/6f87f7a4e067267727b2435139cac8cb935449d0) python3Packages.pyglet: add darwin support
* [`3bb1754d`](https://github.com/NixOS/nixpkgs/commit/3bb1754d41436cab99d60c3ba887bb2f390c273d) catalyst-browser: drop
* [`f84b1481`](https://github.com/NixOS/nixpkgs/commit/f84b14815177279561b01b9b38378962bcc536f0) powershell: 7.5.1 -> 7.5.2
* [`09d72528`](https://github.com/NixOS/nixpkgs/commit/09d7252842c9754e5c1ae91166531ca56ff190f5) xfce.thunar-dropbox-plugin: 0.3.1 -> 0.3.2
* [`d66e5e4e`](https://github.com/NixOS/nixpkgs/commit/d66e5e4e01343c4ec5ab890c4405a4cfcd95c74c) json-sort-cli: 2.0.3 -> 3.0.0
* [`27cfd94b`](https://github.com/NixOS/nixpkgs/commit/27cfd94b5081651d462de53b2d4cc7b570fe9e1f) indilib, indi-3rdparty: 2.1.3 -> 2.1.4
* [`b5a1fb88`](https://github.com/NixOS/nixpkgs/commit/b5a1fb88692811aef1e72b6ead8b75bb89c185c4) xmrig-proxy: 6.22.0 -> 6.24.0
* [`f4bcc425`](https://github.com/NixOS/nixpkgs/commit/f4bcc425d1d13106a36ec0f9387618ceeb501d9c) xmrig: 6.22.3 -> 6.24.0
* [`6e43f003`](https://github.com/NixOS/nixpkgs/commit/6e43f0037484025c107f1160bd4e14f67565d32f) cosmic-session: fix XDG desktop portal binary location
* [`1e88c6cd`](https://github.com/NixOS/nixpkgs/commit/1e88c6cdd0c960600b1d46d60508d8058ae1c1aa) gigalixir: modernize
* [`2dc9d1e0`](https://github.com/NixOS/nixpkgs/commit/2dc9d1e04f47f3290f1544f8e398717e08573fdc) komodo: 1.18.3 -> 1.18.4
* [`bd67f6ff`](https://github.com/NixOS/nixpkgs/commit/bd67f6ff85909a36f2b89e9fdd701f96b9151162) symbolicator: 25.5.1 -> 25.6.1
* [`1c57ff7b`](https://github.com/NixOS/nixpkgs/commit/1c57ff7b201d9bcb2e82f4b8ec8acc64298dce3a) matrix-commander-rs: 0.10.1 -> 1.0.0
* [`c61c4192`](https://github.com/NixOS/nixpkgs/commit/c61c419273845843cbac98d72b1f777c23e35b47) gigalixir: 1.13.1 -> 1.14.0; switch to fetching from github
* [`f7592a51`](https://github.com/NixOS/nixpkgs/commit/f7592a51e72e81cc9ef4579b655700b16a9c0f11) surrealdb: 2.3.4 -> 2.3.5
* [`343279ec`](https://github.com/NixOS/nixpkgs/commit/343279ec23ac1f406618bb95d35608e304c2e5b0) colorls: fix local gem ignored warning
* [`ecd75359`](https://github.com/NixOS/nixpkgs/commit/ecd753598008dbc4997d89bea47d6142f654fc93) deepin-anything: 6.1.9 -> 6.2.10
* [`5e8e97db`](https://github.com/NixOS/nixpkgs/commit/5e8e97db51b6eaba125a8299b696cf056485cb45) slint-viewer: 1.12.0 -> 1.12.1
* [`fc5b0b77`](https://github.com/NixOS/nixpkgs/commit/fc5b0b77d7d86867947cb3e1050595683097392a) spirv-llvm-translator: 15.0.12 -> 15.0.13
* [`4849ec19`](https://github.com/NixOS/nixpkgs/commit/4849ec19208e717e161479b63bfdefa69637ee36) intel-graphics-compiler: 2.11.7 -> 2.12.5
* [`b2bc7903`](https://github.com/NixOS/nixpkgs/commit/b2bc7903f2a6e2a238e74ef72de62cf6b9662f39) firefox-esr-140-unwrapped: init at 140.0esr
* [`dd919920`](https://github.com/NixOS/nixpkgs/commit/dd919920b98c973b904628c6c3bf57a9fcfca596) txtpbfmt: 0-unstable-2025-03-26 -> 0-unstable-2025-06-25
* [`6f12747a`](https://github.com/NixOS/nixpkgs/commit/6f12747ade6404bcf18c2c4800ccc57f9e83efd7) python313Packages.aria2p: build with tui by default
* [`44e363ac`](https://github.com/NixOS/nixpkgs/commit/44e363ac53e79f0ab78b82cb54c81e8848f5f44d) python313Packages.aria2p: mark broken on darwin
* [`bf049492`](https://github.com/NixOS/nixpkgs/commit/bf049492518aa9d0772097d20e6e9b9d964afeaa) python313Packages.aria2p: modernize
* [`48328e21`](https://github.com/NixOS/nixpkgs/commit/48328e21e0006cbef78df142409fb62ad2911bf7) netgen: typo fix: Resouces-> Resources
* [`1a55efca`](https://github.com/NixOS/nixpkgs/commit/1a55efcac1bdf898c7329cb166fa0cef4fd7f63d) bootstrap-studio: 7.0.3 -> 7.1.1
* [`41bf5b8b`](https://github.com/NixOS/nixpkgs/commit/41bf5b8bc52056f2aa7c2dbde2af668482000069) drupal: 11.1.7 -> 11.2.1
* [`c428082a`](https://github.com/NixOS/nixpkgs/commit/c428082aae0bb8e74c111519437c6bc29bad95a9) reindeer: 2025.06.16.00 -> 2025.06.23.00
* [`84764c0f`](https://github.com/NixOS/nixpkgs/commit/84764c0ffbaa3a7128cee0132062158226ee5f00) mrtrix: 3.0.4-unstable-2025-04-09 -> 3.0.6
* [`0c7a8d52`](https://github.com/NixOS/nixpkgs/commit/0c7a8d5255c2724f0c6076832fd2766ebd5125c1) nixos/nextcloud: sync nginx config with upstream
* [`89532e50`](https://github.com/NixOS/nixpkgs/commit/89532e50950c39d07bc6aa6179d292a3361cb935) vault: 1.19.5 -> 1.20.0
* [`03476bb9`](https://github.com/NixOS/nixpkgs/commit/03476bb97bbebefa575ce39f0cf192b39cf17ec9) tanka: 0.32.0 -> 0.33.0
* [`90005257`](https://github.com/NixOS/nixpkgs/commit/90005257fb8c72da207c02575014dba6d173be43) tootik: 0.16.1 -> 0.17.0
* [`5b5b8375`](https://github.com/NixOS/nixpkgs/commit/5b5b83757f2f9a3463c04a833042ceba2d3d88e5) nvchecker: 2.17 -> 2.18
* [`34ae1e56`](https://github.com/NixOS/nixpkgs/commit/34ae1e56c1305b84309ea6b750db7af6af62862c) nvchecker: adopt, set passthru.updateScript
* [`b9c7f6e7`](https://github.com/NixOS/nixpkgs/commit/b9c7f6e7d7067046508130a1e669fe74744863d1) splash: 3.11.3 -> 3.11.4
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
