### PR TITLE
niv emacs-overlay: update 51d60eb6 -> 4a0db65b

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -41,10 +41,10 @@
         "homepage": "",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "51d60eb61a64d58e3086bb227d481ac77a12234c",
-        "sha256": "17av9vaiwi1jxvv8qjmv272i6pchmhnjm1pn4m89l8i1qy1m8hf5",
+        "rev": "4a0db65ba7e8499456cacec817196eaae4cd518d",
+        "sha256": "0zih1l5b5c28jyshxw4y4yykgs7azilcrw86bam2rdgk2iy33bxh",
         "type": "tarball",
-        "url": "https://github.com/nix-community/emacs-overlay/archive/51d60eb61a64d58e3086bb227d481ac77a12234c.tar.gz",
+        "url": "https://github.com/nix-community/emacs-overlay/archive/4a0db65ba7e8499456cacec817196eaae4cd518d.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "fast-syntax-highlighting": {


### PR DESCRIPTION
## Changelog for emacs-overlay:
Branch: master
Commits: [nix-community/emacs-overlay@51d60eb6...4a0db65b](https://github.com/nix-community/emacs-overlay/compare/51d60eb61a64d58e3086bb227d481ac77a12234c...4a0db65ba7e8499456cacec817196eaae4cd518d)

* [`fc0e89b0`](https://github.com/nix-community/emacs-overlay/commit/fc0e89b0d64600c939ed9b8fcce123118559b260) Updated nongnu
* [`f3c97a15`](https://github.com/nix-community/emacs-overlay/commit/f3c97a159bef82077c4742c3abf9bc68794a44ea) Updated elpa
* [`bbb4385a`](https://github.com/nix-community/emacs-overlay/commit/bbb4385aff3f7143fa4fba082e4cb43f8f6c77a1) Updated melpa
* [`7466f302`](https://github.com/nix-community/emacs-overlay/commit/7466f3020aa9f156b15e0495b9de8915b4a1b2d5) Updated emacs
* [`07082af5`](https://github.com/nix-community/emacs-overlay/commit/07082af53b3ed89317562fd02f82383e8f62d3f3) Updated flake inputs
* [`0f61474b`](https://github.com/nix-community/emacs-overlay/commit/0f61474b56b5405e0bc9e25918bd6ac40dd66953) Updated nongnu
* [`6d87fd52`](https://github.com/nix-community/emacs-overlay/commit/6d87fd5234c95e9ac7c10c47c6d42d168df43b5b) Updated elpa
* [`82c5e352`](https://github.com/nix-community/emacs-overlay/commit/82c5e3524420971433703790a4f3f615674d9e55) Updated melpa
* [`9153c671`](https://github.com/nix-community/emacs-overlay/commit/9153c6719aff5ba4faf817e90d82e9c2f8b886a1) Updated emacs
* [`f0c30a37`](https://github.com/nix-community/emacs-overlay/commit/f0c30a37baf8e7c86faee0673fbf15acbad217d4) Updated nongnu
* [`6bb8d143`](https://github.com/nix-community/emacs-overlay/commit/6bb8d143201db7c17d0fd8fcf32fa3f58e36856e) Updated elpa
* [`27826d97`](https://github.com/nix-community/emacs-overlay/commit/27826d97ee15ea9db4fb8147aa09b25e74af20fd) Updated melpa
* [`7f21af85`](https://github.com/nix-community/emacs-overlay/commit/7f21af85151a80b90cb1b514a993e56cb6716275) Updated emacs
* [`ce98dfc9`](https://github.com/nix-community/emacs-overlay/commit/ce98dfc99db86aa08547fd053a19df15fee7a370) Updated melpa
* [`778e55ea`](https://github.com/nix-community/emacs-overlay/commit/778e55eaced8cc64c5a364d565e46aab9958d464) Updated emacs
* [`c34b2539`](https://github.com/nix-community/emacs-overlay/commit/c34b2539d7d85651d18f4d8c0ded913d6c950cfb) Updated nongnu
* [`82b09342`](https://github.com/nix-community/emacs-overlay/commit/82b093426839ed945cee37f4d7fc98ca68aa1506) Updated elpa
* [`1be5369c`](https://github.com/nix-community/emacs-overlay/commit/1be5369cdee97b99545091767248277c2ff1fea6) Updated melpa
* [`a826d9e7`](https://github.com/nix-community/emacs-overlay/commit/a826d9e7655704aadc36ba3f64605b38ebaea2a2) Updated emacs
* [`74f3c260`](https://github.com/nix-community/emacs-overlay/commit/74f3c260dc3605e3ce194ece102c2db6bd0d4cef) Updated nongnu
* [`691d191a`](https://github.com/nix-community/emacs-overlay/commit/691d191a324330db4bee9bc87ded0d5b54f72fe4) Updated elpa
* [`f4cd3be0`](https://github.com/nix-community/emacs-overlay/commit/f4cd3be0948d11f06ac921f81080826fa49631e8) Updated melpa
* [`65577582`](https://github.com/nix-community/emacs-overlay/commit/6557758212b4056fa0b3d65c537a3a8e503090ed) Updated emacs
* [`d2fa26ea`](https://github.com/nix-community/emacs-overlay/commit/d2fa26ea3ca5cee5b4368086b3f4423cadbb642f) Updated flake inputs
* [`78278b77`](https://github.com/nix-community/emacs-overlay/commit/78278b770d2c83657657da569544cf20eccee0ef) Updated melpa
* [`63420c7c`](https://github.com/nix-community/emacs-overlay/commit/63420c7ccda26d15a669a7ff20212514ffff9553) Updated nongnu
* [`3f4991b0`](https://github.com/nix-community/emacs-overlay/commit/3f4991b0d9a225f9ceccb69538355045b99ff8fa) Updated elpa
* [`71027696`](https://github.com/nix-community/emacs-overlay/commit/710276966b2d761a277340b02c6d055e730220ff) Updated melpa
* [`52a96356`](https://github.com/nix-community/emacs-overlay/commit/52a963560ebee290e278be63cfda460ce4df5e19) Updated emacs
* [`6fad7c0b`](https://github.com/nix-community/emacs-overlay/commit/6fad7c0b0324f06a1e8e93e7ef737c5362cda409) README.org: replace obsolete symbol emacsGit
* [`c0ad0875`](https://github.com/nix-community/emacs-overlay/commit/c0ad08752a8066414d10f05e1ef2fa998e020d9f) README.org: drop now-unused LocalWords entry
* [`24fc509f`](https://github.com/nix-community/emacs-overlay/commit/24fc509f8973c1dd030c0c17d75e392ea8c1efaf) Updated nongnu
* [`b23f5ee5`](https://github.com/nix-community/emacs-overlay/commit/b23f5ee5d26ee40cafbec9e3d1c4d9cefdf93c27) Updated elpa
* [`48df8197`](https://github.com/nix-community/emacs-overlay/commit/48df8197c882eeed04fb4045ca894f1f2d4aa5c4) Updated melpa
* [`92b75bf8`](https://github.com/nix-community/emacs-overlay/commit/92b75bf8b4e26ae3373fbe6331f9a1c63efc1e29) Updated emacs
* [`734bd730`](https://github.com/nix-community/emacs-overlay/commit/734bd730f2c07c40438562b7505f1e0fca23eb3c) Updated flake inputs
* [`08914a60`](https://github.com/nix-community/emacs-overlay/commit/08914a606839c06be2e3ac7a1dc18c07ffb8c729) Updated melpa
* [`341c6324`](https://github.com/nix-community/emacs-overlay/commit/341c6324d0780f1846c77b1a13c18934172ca9dd) Updated emacs
* [`d70931ba`](https://github.com/nix-community/emacs-overlay/commit/d70931babb1968ddd6e0c3b1e93493c7c0447873) Updated flake inputs
* [`4836cf9b`](https://github.com/nix-community/emacs-overlay/commit/4836cf9bdcf8ba8fc1fd2b4cc1b078a84d82c80e) Updated nongnu
* [`cff04d78`](https://github.com/nix-community/emacs-overlay/commit/cff04d78e771311b67c5503b648731a991524b89) Updated elpa
* [`8806de4a`](https://github.com/nix-community/emacs-overlay/commit/8806de4adc11ca050661b5f375621be5e6f6780d) Updated melpa
* [`c58bd079`](https://github.com/nix-community/emacs-overlay/commit/c58bd079c0ebbde13972fb3f8221924d42295889) Updated emacs
* [`233041cb`](https://github.com/nix-community/emacs-overlay/commit/233041cb05a8cb5c346c6c4e3991e5111de83efe) README.org: update explanation of pure GTK builds
* [`9ab94993`](https://github.com/nix-community/emacs-overlay/commit/9ab94993d524a7b74c8c9423424394d54672fc98) Updated nongnu
* [`13fae16b`](https://github.com/nix-community/emacs-overlay/commit/13fae16b4ff8b0d1ea11c0a173975d5a47089446) Updated elpa
* [`5829b314`](https://github.com/nix-community/emacs-overlay/commit/5829b3144e6607337f6618549422538aa749e0f0) Updated melpa
* [`c1750666`](https://github.com/nix-community/emacs-overlay/commit/c17506666090e412a50b01c57944386ab81d2aa8) Updated emacs
* [`665fc708`](https://github.com/nix-community/emacs-overlay/commit/665fc70866ec89fb7b75eefd4906d8000a0b977b) Updated elpa
* [`943c23be`](https://github.com/nix-community/emacs-overlay/commit/943c23bed00256079ddf09a30bc1acf517c63d50) Updated melpa
* [`ff324514`](https://github.com/nix-community/emacs-overlay/commit/ff324514304d770d533cfbf9aea1b68d68b46e48) Updated emacs
* [`c43d3a84`](https://github.com/nix-community/emacs-overlay/commit/c43d3a844c630784af10e33ce05ba466deda4e64) Updated nongnu
* [`4057e1fc`](https://github.com/nix-community/emacs-overlay/commit/4057e1fcd998c653be0db421a3fb268e28d17d8f) Updated elpa
* [`98f42400`](https://github.com/nix-community/emacs-overlay/commit/98f424001c170bc9d1f9911044d6c9884d8a5cdf) Updated melpa
* [`7a6fc149`](https://github.com/nix-community/emacs-overlay/commit/7a6fc1493c699fa8255275452a0c7bb39aa31fc0) Updated emacs
* [`fcb038ab`](https://github.com/nix-community/emacs-overlay/commit/fcb038ab90fcc025389c65e30882ad7ac8e4ff92) Updated melpa
* [`98f08847`](https://github.com/nix-community/emacs-overlay/commit/98f08847b3f1b9d0efc6ecffadce6311370e8306) Updated emacs
* [`e76e1c64`](https://github.com/nix-community/emacs-overlay/commit/e76e1c644c18f784daa0f904f83b4c608cfe5182) Updated nongnu
* [`20700ef2`](https://github.com/nix-community/emacs-overlay/commit/20700ef27d0f39cb23575f1eda400e7e91d7b587) Updated elpa
* [`a6f51a83`](https://github.com/nix-community/emacs-overlay/commit/a6f51a837dc9b3e2314174698664f59acc745593) Updated melpa
* [`f6850858`](https://github.com/nix-community/emacs-overlay/commit/f6850858f78e2b6328f6e8bb7bf9df10dd0b7973) Updated emacs
* [`9ab8f6a1`](https://github.com/nix-community/emacs-overlay/commit/9ab8f6a1e9a4a2fb26d5ea7837daca08b80835d1) Updated flake inputs
* [`9b3d8897`](https://github.com/nix-community/emacs-overlay/commit/9b3d8897d277e85150207ec7a3f0bb3883df230d) Updated nongnu
* [`c43faab6`](https://github.com/nix-community/emacs-overlay/commit/c43faab6ec82f0e26bd5e4858aa7eb3df8c2f8eb) Updated elpa
* [`b284e9ae`](https://github.com/nix-community/emacs-overlay/commit/b284e9ae28347d2233cc5a6faa70fef7cb53945b) Updated melpa
* [`b9b8dc3f`](https://github.com/nix-community/emacs-overlay/commit/b9b8dc3f2e1e13ed6aed195a4228a20a91ac6376) Updated melpa
* [`8f31878f`](https://github.com/nix-community/emacs-overlay/commit/8f31878f0f1449608ff02c7e6ddbb883357468af) Updated emacs
* [`404d0da2`](https://github.com/nix-community/emacs-overlay/commit/404d0da2ab6ac6cf3a358abc4a00f440620d1d67) Updated nongnu
* [`bdc33058`](https://github.com/nix-community/emacs-overlay/commit/bdc330582b7374a8dabce17106e6e4493984cd13) Updated elpa
* [`c0b2fc75`](https://github.com/nix-community/emacs-overlay/commit/c0b2fc7536fde207d61ddc157d0524b044110829) Updated melpa
* [`b313b010`](https://github.com/nix-community/emacs-overlay/commit/b313b010b457ab15ac323975b10bf418a9de074c) Updated emacs
* [`537ff3a0`](https://github.com/nix-community/emacs-overlay/commit/537ff3a06c1bf4cc6b552a0313af930ba3aa37d1) Updated flake inputs
* [`8a5a6034`](https://github.com/nix-community/emacs-overlay/commit/8a5a6034a2371522029b6217febfd0383d934983) Updated elpa
* [`390482e1`](https://github.com/nix-community/emacs-overlay/commit/390482e1142c5d2d78c2d5b4566e0804d64f33ec) Updated melpa
* [`d084c3ca`](https://github.com/nix-community/emacs-overlay/commit/d084c3caceadedc53585bc24897fd2360bd85405) Updated emacs
* [`8fb63324`](https://github.com/nix-community/emacs-overlay/commit/8fb63324abd5635f2dc940825adf8336cdf9652b) Updated melpa
* [`9cdefbe2`](https://github.com/nix-community/emacs-overlay/commit/9cdefbe2a13f6a88760b2317874411f3c2ccef14) Updated flake inputs
* [`755dc497`](https://github.com/nix-community/emacs-overlay/commit/755dc497686303d84a4d140eb134a5b62593c23d) Updated nongnu
* [`67828782`](https://github.com/nix-community/emacs-overlay/commit/67828782d38f276fd2249c4cad7647792d75aeb6) Updated elpa
* [`38f288f7`](https://github.com/nix-community/emacs-overlay/commit/38f288f7a99e255b9d424aa72f29412a0cd375ee) Updated melpa
* [`f9a3bc6f`](https://github.com/nix-community/emacs-overlay/commit/f9a3bc6f0b0a8416df4602e7583aecca8d8cca57) Updated emacs
* [`ba05300e`](https://github.com/nix-community/emacs-overlay/commit/ba05300e0e1fa6c1a7117880c587f02097c6536b) Updated nongnu
* [`355fd897`](https://github.com/nix-community/emacs-overlay/commit/355fd89797bf5e18b54b34abea7f6d3d4cafbcf8) Updated elpa
* [`af54c588`](https://github.com/nix-community/emacs-overlay/commit/af54c58850148557bf287ad00e5d71103fa836bd) Updated melpa
* [`1f242e34`](https://github.com/nix-community/emacs-overlay/commit/1f242e34e24e88767f9b981fd5c437ddea21ef15) Updated emacs
* [`3bbccf62`](https://github.com/nix-community/emacs-overlay/commit/3bbccf622a5aac194713b0efecde1531a9347116) Updated melpa
* [`3bb5d2b3`](https://github.com/nix-community/emacs-overlay/commit/3bb5d2b3966b1a79258daf1ec62963698cef90d9) Updated emacs
* [`ab923c98`](https://github.com/nix-community/emacs-overlay/commit/ab923c9809d81513c37fdaeb0b0fa863c716849f) Updated nongnu
* [`d2057f7f`](https://github.com/nix-community/emacs-overlay/commit/d2057f7ffdd7b104fafb5120b2e569d6778ada60) Updated elpa
* [`1283178f`](https://github.com/nix-community/emacs-overlay/commit/1283178f848238268d4992320d5a5088ca4dc9e6) Updated melpa
* [`b6c911eb`](https://github.com/nix-community/emacs-overlay/commit/b6c911ebe26ff235dde39d3a35ab6faf22550d40) Updated emacs
* [`5c1db856`](https://github.com/nix-community/emacs-overlay/commit/5c1db8560e34306f8c7b6b5d1296eea3d7d2b14a) Updated nongnu
* [`5d2ccbca`](https://github.com/nix-community/emacs-overlay/commit/5d2ccbcaf1b8109665e7b990dc176e73ad174720) Updated elpa
* [`a1fc4a12`](https://github.com/nix-community/emacs-overlay/commit/a1fc4a1252cf8f730d39a6570d36b9b95b478cd5) Updated melpa
* [`9e764fc5`](https://github.com/nix-community/emacs-overlay/commit/9e764fc56e5a89d699aed30beb149aeefcf92994) Updated melpa
* [`5c793af4`](https://github.com/nix-community/emacs-overlay/commit/5c793af459e1f5d4a36d41f32a4841a3d76b7e9e) Updated emacs
* [`5c6eb453`](https://github.com/nix-community/emacs-overlay/commit/5c6eb453f5aef5b3299945fb9724c3892f022063) Updated nongnu
* [`18c25d56`](https://github.com/nix-community/emacs-overlay/commit/18c25d56fbedc7daedb79f85fd12dca36ce50b66) Updated elpa
* [`5323a8e0`](https://github.com/nix-community/emacs-overlay/commit/5323a8e0c43a53fad9b25fcfb86a30f9b4e8f846) Updated melpa
* [`670cee9d`](https://github.com/nix-community/emacs-overlay/commit/670cee9dc57b926a56657a95abe60915cca332c9) Updated emacs
* [`b03ba2d3`](https://github.com/nix-community/emacs-overlay/commit/b03ba2d334a773ca1e34b93400b41c1c66fafd5c) Updated flake inputs
* [`80a7611b`](https://github.com/nix-community/emacs-overlay/commit/80a7611bc3872fda239c2b2aa69ce3b6bb7057d9) Updated nongnu
* [`1d544dd3`](https://github.com/nix-community/emacs-overlay/commit/1d544dd3cd84aa5372885e244bcb32a583046708) Updated elpa
* [`a59bb5e5`](https://github.com/nix-community/emacs-overlay/commit/a59bb5e5768799dddc0c15ba6d657454ca869d99) Updated melpa
* [`93258b8d`](https://github.com/nix-community/emacs-overlay/commit/93258b8d3986987459f32e3f82a2e6baaf453fe7) Updated melpa
* [`ca5e88a7`](https://github.com/nix-community/emacs-overlay/commit/ca5e88a7eca358aed93c96510e5e0be910015533) Updated emacs
* [`3a88a28d`](https://github.com/nix-community/emacs-overlay/commit/3a88a28d3985c63791a0e28f36d18a77f2a93179) Updated nongnu
* [`aad2bc03`](https://github.com/nix-community/emacs-overlay/commit/aad2bc03768dceb6e8d560dce5d8a98d91fcff41) Updated elpa
* [`7bff0588`](https://github.com/nix-community/emacs-overlay/commit/7bff0588ff3c116e1d846a6005e2268b6cdc167f) Updated melpa
* [`f2bb2b16`](https://github.com/nix-community/emacs-overlay/commit/f2bb2b16cb85b5e54bfa62a92daa674c7b906ca7) Updated emacs
* [`76c3a600`](https://github.com/nix-community/emacs-overlay/commit/76c3a600aa6f80c95346e1899b9c9f3f46b8b286) Updated nongnu
* [`bcc4be31`](https://github.com/nix-community/emacs-overlay/commit/bcc4be31757a746aab15c1757f777a91fbd9433b) Updated elpa
* [`fb4712e7`](https://github.com/nix-community/emacs-overlay/commit/fb4712e75ebdae968b50a03fc24adcd9d1bd769d) Updated melpa
* [`5c374920`](https://github.com/nix-community/emacs-overlay/commit/5c3749201845be35d063b5ce6e80e0aa0cd549c7) Updated emacs
* [`58c8e6ac`](https://github.com/nix-community/emacs-overlay/commit/58c8e6ac22ca9e21f90f2bfbc9713bb3fb95d97c) Updated melpa
* [`911a85c6`](https://github.com/nix-community/emacs-overlay/commit/911a85c6fe56b3f6d89ef45d5ce4fd470ca45d6e) Updated emacs
* [`8b162cf3`](https://github.com/nix-community/emacs-overlay/commit/8b162cf35e551d35e755f4fa036fb8745003c548) Updated flake inputs
* [`cfae5be0`](https://github.com/nix-community/emacs-overlay/commit/cfae5be05e49d06d8f996a7e816c0803926769bd) Updated nongnu
* [`39fda4f1`](https://github.com/nix-community/emacs-overlay/commit/39fda4f19f7ea8839eb647afee252290b3451b16) Updated elpa
* [`4b277d85`](https://github.com/nix-community/emacs-overlay/commit/4b277d85863fa3b7f8528134e372de6ac7c59a28) Updated melpa
* [`da312194`](https://github.com/nix-community/emacs-overlay/commit/da3121947d9e055bd9c8360f628052f122654df4) Updated emacs
* [`5b779fb3`](https://github.com/nix-community/emacs-overlay/commit/5b779fb3c0c2c058537bd6e98dfc9e27e3b263b5) Updated nongnu
* [`10967dac`](https://github.com/nix-community/emacs-overlay/commit/10967dac6ff000287dde08d1d04e7d346098dc49) Updated elpa
* [`2ddea406`](https://github.com/nix-community/emacs-overlay/commit/2ddea40659132136aa8400eee7d3b50ad739be4a) Updated melpa
* [`3dc71658`](https://github.com/nix-community/emacs-overlay/commit/3dc71658b5f4b1493fbf03b1fa48c7b0122bc1c7) Updated emacs
* [`b0d4c4a8`](https://github.com/nix-community/emacs-overlay/commit/b0d4c4a8a244d3787844e2d252cd2de13766acc4) Updated melpa
* [`d2fb39a8`](https://github.com/nix-community/emacs-overlay/commit/d2fb39a8ecf7610891cbc64cff05588308c5166a) Updated emacs
* [`b49f9ce3`](https://github.com/nix-community/emacs-overlay/commit/b49f9ce3ab1ff771a37422e1d066032f789dbdcb) Updated elpa
* [`8c8fd5b7`](https://github.com/nix-community/emacs-overlay/commit/8c8fd5b7e9bde7f0d39d6c2eb1f3475ee264830c) Updated emacs
* [`e19ac914`](https://github.com/nix-community/emacs-overlay/commit/e19ac914a186163a00640b5f9c7e1c776fe029c7) Updated melpa
* [`965bcc9a`](https://github.com/nix-community/emacs-overlay/commit/965bcc9ae6ea6779b5dd89ce6011e818f43e9e69) Updated nongnu
* [`c9f55ca3`](https://github.com/nix-community/emacs-overlay/commit/c9f55ca3b854c7e25f83316e4e37b21903426e68) Updated elpa
* [`358d35f9`](https://github.com/nix-community/emacs-overlay/commit/358d35f9c2725d54448e95e53426f793b0316448) Updated melpa
* [`e589a141`](https://github.com/nix-community/emacs-overlay/commit/e589a1418dfee7b16f7889251d306f094151a928) Updated flake inputs
* [`4f462935`](https://github.com/nix-community/emacs-overlay/commit/4f4629359dac41cf5227a786936e069410abd213) Updated melpa
* [`8c2a905f`](https://github.com/nix-community/emacs-overlay/commit/8c2a905f516d6662a9ed0ce70d9db0e054cd3faa) Updated emacs
* [`8d18042e`](https://github.com/nix-community/emacs-overlay/commit/8d18042e9bf06ad7fcaf600fa5922ea64b710e0f) Updated nongnu
* [`90d12e22`](https://github.com/nix-community/emacs-overlay/commit/90d12e22421147992240f87578dee2e8ff0635af) Updated elpa
* [`f44880a7`](https://github.com/nix-community/emacs-overlay/commit/f44880a7f566f8ee0797a8dac490dfa77d3fdf52) Updated melpa
* [`5479bde4`](https://github.com/nix-community/emacs-overlay/commit/5479bde495cf43766d53b3789a316e83ef7f8905) Updated emacs
* [`59eff251`](https://github.com/nix-community/emacs-overlay/commit/59eff2510803fa546e93332e44ed42b0ef83215c) Updated nongnu
* [`89a36866`](https://github.com/nix-community/emacs-overlay/commit/89a36866e97bace7cf6fc0d4795593b51611883e) Updated elpa
* [`77d295df`](https://github.com/nix-community/emacs-overlay/commit/77d295df371cf9c716c54759dc19900b2bb3a161) Updated melpa
* [`fc1319f0`](https://github.com/nix-community/emacs-overlay/commit/fc1319f0d30bc5d204210842ccfb4091bb57fa2a) Updated melpa
* [`bfb32bbf`](https://github.com/nix-community/emacs-overlay/commit/bfb32bbfc4e0068f66e53ca4ae4bd024f20c2f9f) Updated flake inputs
* [`c2b63abe`](https://github.com/nix-community/emacs-overlay/commit/c2b63abe92d75c5de0956ab57acb0ae7c32e1fed) Updated elpa
* [`60071993`](https://github.com/nix-community/emacs-overlay/commit/600719939fa21def89d037d0b7c7a054cea0b1da) Updated melpa
* [`c545e874`](https://github.com/nix-community/emacs-overlay/commit/c545e874be1fa5453ad4f365e90e9b3dcf6f81ee) Updated emacs
* [`78c51933`](https://github.com/nix-community/emacs-overlay/commit/78c519335f3a8be89d80e56b0baa921d0440df7d) Updated nongnu
* [`0bc720b8`](https://github.com/nix-community/emacs-overlay/commit/0bc720b8b17a004cfbc286190f10b7ed79118f24) Updated elpa
* [`6b229be9`](https://github.com/nix-community/emacs-overlay/commit/6b229be92af31cde9890b3031b0cd365abebdb11) Updated melpa
* [`2f42e686`](https://github.com/nix-community/emacs-overlay/commit/2f42e6862d660095a0a71bc03b84d2759609e47b) Updated melpa
* [`81213938`](https://github.com/nix-community/emacs-overlay/commit/81213938251b6d623de6dce400db7e89e442ffcc) Updated emacs
* [`7a6ff7ec`](https://github.com/nix-community/emacs-overlay/commit/7a6ff7ecebf2e089fa613b7a6a5e5be93a02224c) Updated flake inputs
* [`56f8bda7`](https://github.com/nix-community/emacs-overlay/commit/56f8bda7cc83f888339626c663c76471d1fd9497) Updated nongnu
* [`d71d520e`](https://github.com/nix-community/emacs-overlay/commit/d71d520eb14ab918ad054d24139a609f9bb35c1b) Updated elpa
* [`d2113e15`](https://github.com/nix-community/emacs-overlay/commit/d2113e151e11f32b5cc9c42e3e67a4235e818aa7) Updated melpa
* [`beb6258d`](https://github.com/nix-community/emacs-overlay/commit/beb6258dbb0f0977fa8b96b19c590f7659e856e5) Updated nongnu
* [`785396ba`](https://github.com/nix-community/emacs-overlay/commit/785396ba001d14e95f171a2d4dda5510ddf9b0ef) Updated elpa
* [`1a723b22`](https://github.com/nix-community/emacs-overlay/commit/1a723b22b7c59b6a88c3cf1752d9501a726c9e3d) Updated melpa
* [`81f55880`](https://github.com/nix-community/emacs-overlay/commit/81f55880689625e1e8cd184cb499c3fac8753790) Updated emacs
* [`e230be4f`](https://github.com/nix-community/emacs-overlay/commit/e230be4f6764e270c58612d9adf23f8726b8ac59) Updated melpa
* [`cff16fc1`](https://github.com/nix-community/emacs-overlay/commit/cff16fc129c76889ddfb0ebb17b53b6633c77ba5) Updated emacs
* [`3db1b619`](https://github.com/nix-community/emacs-overlay/commit/3db1b619f355ee953c009a3b9262af841bf8d0ac) Updated nongnu
* [`091b6728`](https://github.com/nix-community/emacs-overlay/commit/091b672849b1dc2b750bfc95a4e8c4d33d809b1e) Updated melpa
* [`79cb0891`](https://github.com/nix-community/emacs-overlay/commit/79cb0891f0cef9be3bd1d514edbd8d2b740e83b3) Updated emacs
* [`435c4139`](https://github.com/nix-community/emacs-overlay/commit/435c4139ce44faa3eb00cbc60fa3abd0f510ae1d) Updated flake inputs
* [`dde7fbce`](https://github.com/nix-community/emacs-overlay/commit/dde7fbce5954c788799277677b6fa4c5dae2aaae) Updated nongnu
* [`9e024bff`](https://github.com/nix-community/emacs-overlay/commit/9e024bff929e48104d61b12c398df881a5ae2371) Updated elpa
* [`78302713`](https://github.com/nix-community/emacs-overlay/commit/78302713c2e102690ca9b531ed36c2c38d2794c9) Updated melpa
* [`48efb8d3`](https://github.com/nix-community/emacs-overlay/commit/48efb8d3ac1f59a07031251ffca7affaee4f018d) Updated emacs
* [`b8647887`](https://github.com/nix-community/emacs-overlay/commit/b864788779c7833d89822b95507a7ad07319e4c2) Updated flake inputs
* [`90856b1b`](https://github.com/nix-community/emacs-overlay/commit/90856b1b570da027a768a8b8c11d49be723a7856) Updated melpa
* [`4ac0b92c`](https://github.com/nix-community/emacs-overlay/commit/4ac0b92c97f2f9350b9b9bcf7931e560c161ec24) Updated nongnu
* [`a5b11dfa`](https://github.com/nix-community/emacs-overlay/commit/a5b11dfa615082fb52e58dc929442ada5662f62b) Updated elpa
* [`39fc85e1`](https://github.com/nix-community/emacs-overlay/commit/39fc85e18fbf49c240d501d93c5280f2cf21c460) Updated melpa
* [`8dc66429`](https://github.com/nix-community/emacs-overlay/commit/8dc664291c0acdd539dd27715fac06b448431f2d) Updated emacs
* [`40964aa9`](https://github.com/nix-community/emacs-overlay/commit/40964aa9d2a257652d1c6593510d97d30eba25dc) Updated nongnu
* [`771e0ba7`](https://github.com/nix-community/emacs-overlay/commit/771e0ba7663e341587cbb1ba745fe1c56c67abfa) Updated elpa
* [`61eacc8d`](https://github.com/nix-community/emacs-overlay/commit/61eacc8de1670d8354f915836aa0706ec8e58c96) Updated melpa
* [`2fab8c74`](https://github.com/nix-community/emacs-overlay/commit/2fab8c74721be21e8e06a95ab35f4e940c93a15e) Updated emacs
* [`bedb216b`](https://github.com/nix-community/emacs-overlay/commit/bedb216b47e78a72376964f1cfeb319f16dc044b) Updated melpa
* [`888abc75`](https://github.com/nix-community/emacs-overlay/commit/888abc75a5686bdb999f95cb4c0106ce5c50b35d) Updated emacs
* [`8eefaea4`](https://github.com/nix-community/emacs-overlay/commit/8eefaea426ef3a421260b6befd34b8a096f2c097) Updated nongnu
* [`a5daf092`](https://github.com/nix-community/emacs-overlay/commit/a5daf092686fd419155ba321822b1d1457435862) Updated elpa
* [`6224529f`](https://github.com/nix-community/emacs-overlay/commit/6224529f64715f5bfcac0b57bce245c6ecbdb716) Updated melpa
* [`74507b87`](https://github.com/nix-community/emacs-overlay/commit/74507b879a4a5c608835b9f24eccc3820e31e40b) Updated nongnu
* [`0bf1f7b3`](https://github.com/nix-community/emacs-overlay/commit/0bf1f7b31487e775fab7256d12f104e2e334b652) Updated elpa
* [`7dac786b`](https://github.com/nix-community/emacs-overlay/commit/7dac786b156ff5a3f21dcb0045a4ab83c7198aa9) Updated melpa
* [`503abe89`](https://github.com/nix-community/emacs-overlay/commit/503abe89e3fdf4030c0acea6dcc71e6313050c74) Updated emacs
* [`c0685e46`](https://github.com/nix-community/emacs-overlay/commit/c0685e46416c614557c25ae89b91552a408f3f63) Updated melpa
* [`04246234`](https://github.com/nix-community/emacs-overlay/commit/04246234941322a19e53aec40447aea9269ed59e) Updated emacs
* [`931654ae`](https://github.com/nix-community/emacs-overlay/commit/931654aec6ae8014146b7bb03b63b6284b277e92) Fix link to nix-community binary cache
* [`370f2cdb`](https://github.com/nix-community/emacs-overlay/commit/370f2cdb87343c8d4c40e8dc7c32c0dffb1893b1) Updated flake inputs
* [`468137d5`](https://github.com/nix-community/emacs-overlay/commit/468137d5e6ecd4be121ae0b0547fe154009c1fb2) Updated nongnu
* [`0d7321aa`](https://github.com/nix-community/emacs-overlay/commit/0d7321aad9166a9431f651ecc135df2ef09dc2de) Updated elpa
* [`51a0c157`](https://github.com/nix-community/emacs-overlay/commit/51a0c157c2556ce628cbc2e4b251570dae4df0af) Updated melpa
* [`4b39688c`](https://github.com/nix-community/emacs-overlay/commit/4b39688c50935c3b279f1443221573cd54698240) Updated emacs
* [`04ed4ae8`](https://github.com/nix-community/emacs-overlay/commit/04ed4ae85a4ee5278c63e41e4aee401f401e1b5e) Updated elpa
* [`796e80e0`](https://github.com/nix-community/emacs-overlay/commit/796e80e085ee9494a7ba122fc58db0489b1af1c5) Updated melpa
* [`b4bf921a`](https://github.com/nix-community/emacs-overlay/commit/b4bf921a1c856836190c9e61e31214aead109c80) Updated emacs
* [`7955edec`](https://github.com/nix-community/emacs-overlay/commit/7955edec3229a3c147b508293fc25c5ae2722187) Updated nongnu
* [`7a26e097`](https://github.com/nix-community/emacs-overlay/commit/7a26e0974d0a1dd5d295a80f533814206d78523f) Updated elpa
* [`c685bc04`](https://github.com/nix-community/emacs-overlay/commit/c685bc04e545c426a7eb6bf28906eb2f0ed265e9) Updated melpa
* [`b316b10e`](https://github.com/nix-community/emacs-overlay/commit/b316b10ed16d92d8b83c340be19324866bea1036) Updated emacs
* [`d4597fa9`](https://github.com/nix-community/emacs-overlay/commit/d4597fa99d130362569a3616c98e33b31ada86cf) Updated nongnu
* [`eb94726c`](https://github.com/nix-community/emacs-overlay/commit/eb94726c3ee0a32c931669a506536ee1367a0ae1) Updated elpa
* [`3d98cbd0`](https://github.com/nix-community/emacs-overlay/commit/3d98cbd003b2097d18a94f6d8d96e1039732cd2e) Updated flake inputs
* [`957aad0d`](https://github.com/nix-community/emacs-overlay/commit/957aad0d85eb5809de0e6aa36ece8e90a0c22c14) Updated nongnu
* [`027b45f7`](https://github.com/nix-community/emacs-overlay/commit/027b45f7f066e4ad6c7d4de45f94d56dbcf83ada) Updated elpa
* [`235e7091`](https://github.com/nix-community/emacs-overlay/commit/235e70919db0fcf2eb489d03927cc12bb0afeb9f) Updated melpa
* [`3b85ea2f`](https://github.com/nix-community/emacs-overlay/commit/3b85ea2f827634d8d582bdc92e1c1a7eb90794ca) Updated emacs
* [`b13d5507`](https://github.com/nix-community/emacs-overlay/commit/b13d55077455690a9b4e25e4077012f3ac724e2c) Updated flake inputs
* [`03f5f12e`](https://github.com/nix-community/emacs-overlay/commit/03f5f12e07ec5e71d110a97ff19c647eff21e930) Updated nongnu
* [`b1b98814`](https://github.com/nix-community/emacs-overlay/commit/b1b988141b9541453a15a90b52a0ab0896a732cd) Updated elpa
* [`9f22df7d`](https://github.com/nix-community/emacs-overlay/commit/9f22df7dec870cfb961d2fa58390a4f327717427) Updated melpa
* [`0cce9a01`](https://github.com/nix-community/emacs-overlay/commit/0cce9a0141bd5d937262adb4861355d07015e715) Updated emacs
* [`85c280f3`](https://github.com/nix-community/emacs-overlay/commit/85c280f3b4b4d49ec4e32acd0fa72e214f2ede54) Updated elpa
* [`6819433b`](https://github.com/nix-community/emacs-overlay/commit/6819433b3f104bd5d0ebe4415587b8cd1837390b) Updated flake inputs
* [`66d24c3a`](https://github.com/nix-community/emacs-overlay/commit/66d24c3ab818f114d7bced1f6d71aa87ca74fc1b) Updated nongnu
* [`37908db8`](https://github.com/nix-community/emacs-overlay/commit/37908db8f6ce22f6db7728c4622d4d02f9ff6d70) Updated elpa
* [`bf248307`](https://github.com/nix-community/emacs-overlay/commit/bf248307196f84d6d9933c9a986d702e8d15ad1c) Updated nongnu
* [`4af4ec1c`](https://github.com/nix-community/emacs-overlay/commit/4af4ec1cdc2b264f3181ff9009a4410d57b8abae) Updated elpa
* [`b4398511`](https://github.com/nix-community/emacs-overlay/commit/b43985117a2fbd866269fcd4cb65f88ce48d20c3) Updated melpa
* [`a9a46545`](https://github.com/nix-community/emacs-overlay/commit/a9a46545034857dee5095930fdb0f76caf12de5a) Updated emacs
* [`eace9de0`](https://github.com/nix-community/emacs-overlay/commit/eace9de06ccfd81c6760dadabdb9bc24cdf804b5) Updated flake inputs
* [`57fd36a6`](https://github.com/nix-community/emacs-overlay/commit/57fd36a674304874fd4f7d28e884721c6c9f7aef) Updated melpa
* [`b4529390`](https://github.com/nix-community/emacs-overlay/commit/b4529390e2e53bae6bfa7a6884dcfa5583b5b858) Updated emacs
* [`f8043b3e`](https://github.com/nix-community/emacs-overlay/commit/f8043b3eb9e4d8271abef203256d1bc616174156) Updated nongnu
* [`08ff3efa`](https://github.com/nix-community/emacs-overlay/commit/08ff3efae64b5e8b0e7748b655d811731cf72ea6) Updated elpa
* [`4cd3eba2`](https://github.com/nix-community/emacs-overlay/commit/4cd3eba24e3902fa4f894ae6a8fc77fd9d3b4c3b) Updated melpa
* [`4c310087`](https://github.com/nix-community/emacs-overlay/commit/4c310087af2403d31fc5ca355e890345c5a52503) Updated emacs
* [`22ca58d6`](https://github.com/nix-community/emacs-overlay/commit/22ca58d68a10eee1f3458b704f568b853e35d467) Updated nongnu
* [`1e96986c`](https://github.com/nix-community/emacs-overlay/commit/1e96986c8544f5b5762ee6f369b524bb009d6e1c) Updated melpa
* [`3c987c33`](https://github.com/nix-community/emacs-overlay/commit/3c987c332e45cd23b2873f9c875b00bc17e29543) Updated emacs
* [`2752b421`](https://github.com/nix-community/emacs-overlay/commit/2752b421efa08d3d7874a1fae482d5f1eb69fb34) Updated melpa
* [`236475c6`](https://github.com/nix-community/emacs-overlay/commit/236475c6fae1cfbf80629e019de4b79de63720ab) Updated emacs
* [`2465573c`](https://github.com/nix-community/emacs-overlay/commit/2465573cdc6cef14a3b896195e1b8b5dbc66c3fd) Updated nongnu
* [`50a1de22`](https://github.com/nix-community/emacs-overlay/commit/50a1de22af011ea05433453f29c445050c4a747c) Updated elpa
* [`aee6e989`](https://github.com/nix-community/emacs-overlay/commit/aee6e989a85d1ec0cb1f53f5339ee9b1077a6800) Updated nongnu
* [`7ea3160e`](https://github.com/nix-community/emacs-overlay/commit/7ea3160e4774fc4bb84cb5ea608e7aad0d9ec4a2) Updated elpa
* [`88c7d876`](https://github.com/nix-community/emacs-overlay/commit/88c7d87694fb4bb3a9a8b64eb24843d7e0782b0f) Remove emacs-pgtk to not shadow the one from Nixpkgs
* [`955b80fe`](https://github.com/nix-community/emacs-overlay/commit/955b80fea64d024c62f938489902e549487e0e85) Updated melpa
* [`9a8ce121`](https://github.com/nix-community/emacs-overlay/commit/9a8ce1212760d342c23fc8b65a71a2ad9bec1408) Updated emacs
* [`bd5c3dea`](https://github.com/nix-community/emacs-overlay/commit/bd5c3deae9355c30d83e38f961458f81ce07d662) Updated emacs
* [`fa76f53c`](https://github.com/nix-community/emacs-overlay/commit/fa76f53c1911cd3b56b1c6378226ec49fb3c2c98) Updated melpa
* [`efb26d91`](https://github.com/nix-community/emacs-overlay/commit/efb26d917bcc5e7b4ec8d24efae4472c08244ed6) Updated flake inputs
* [`b4946a46`](https://github.com/nix-community/emacs-overlay/commit/b4946a46832d62520d5febcedbaebb03a5d14a9f) Updated nongnu
* [`c5cc6bc8`](https://github.com/nix-community/emacs-overlay/commit/c5cc6bc833e686b5477e1a7054c5a0ee3039d413) Updated elpa
* [`4676f012`](https://github.com/nix-community/emacs-overlay/commit/4676f012096addf78c814af22153fe4659604524) Updated flake inputs
* [`8fa8153c`](https://github.com/nix-community/emacs-overlay/commit/8fa8153cfb6a64e6fa26fc9066a41f910bea3372) Updated nongnu
* [`e8b584a5`](https://github.com/nix-community/emacs-overlay/commit/e8b584a552ccd5c6bab96e6e733a0c44a45a9b48) Updated elpa
* [`b4121782`](https://github.com/nix-community/emacs-overlay/commit/b412178267bd815c3cd48676a61952440c677845) Updated emacs
* [`10f086fb`](https://github.com/nix-community/emacs-overlay/commit/10f086fb8668f0e3d08cd2a01180abccc43f6552) Updated melpa
* [`1b9fc954`](https://github.com/nix-community/emacs-overlay/commit/1b9fc9545ef6eac60462def46802c167e7544092) Updated flake inputs
* [`c387866f`](https://github.com/nix-community/emacs-overlay/commit/c387866fd5a224bc8a82ce5b531e50dc6f3d818f) Updated nongnu
* [`a11ef4be`](https://github.com/nix-community/emacs-overlay/commit/a11ef4bed871a38d42993e54192080b4bed97cf1) Updated elpa
* [`3f3b589e`](https://github.com/nix-community/emacs-overlay/commit/3f3b589eac7afd503970722c8a23a27d24954806) Updated melpa
* [`562e5da8`](https://github.com/nix-community/emacs-overlay/commit/562e5da816da90627ed5775d4ba6f968bde0ff57) Updated emacs
* [`74e80365`](https://github.com/nix-community/emacs-overlay/commit/74e80365df20a25050875512c20402abea441240) Updated nongnu
* [`33602303`](https://github.com/nix-community/emacs-overlay/commit/33602303ab14a817c510384630baa93d8bc3350d) Updated elpa
* [`9f73a610`](https://github.com/nix-community/emacs-overlay/commit/9f73a610203b810152591e4e2f20bd474c52bcb1) Updated emacs
* [`28a7010a`](https://github.com/nix-community/emacs-overlay/commit/28a7010a46ee17016c9b37be86f4ce4796c47a71) Updated melpa
* [`bb77ed68`](https://github.com/nix-community/emacs-overlay/commit/bb77ed684cae2381c23040593ed17bf114a8a103) Updated emacs
* [`9e06201e`](https://github.com/nix-community/emacs-overlay/commit/9e06201e3703da9d83c608ad31c5bb44ad0753b6) Updated melpa
* [`429e329f`](https://github.com/nix-community/emacs-overlay/commit/429e329f4d4bbcaf4edba0ad051ded1b4822a857) Updated nongnu
* [`9d099a88`](https://github.com/nix-community/emacs-overlay/commit/9d099a8847d5036277fd6ef5d8d3b57aed10e67b) Updated elpa
* [`6a73fdfe`](https://github.com/nix-community/emacs-overlay/commit/6a73fdfe163f64fb99e99cde7c647e0abfd9a6a0) Updated emacs
* [`4a0db65b`](https://github.com/nix-community/emacs-overlay/commit/4a0db65ba7e8499456cacec817196eaae4cd518d) Updated melpa
