### PR TITLE
niv doomemacs: update f71cbb9f -> fdc0fa3b

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "",
         "owner": "doomemacs",
         "repo": "doomemacs",
-        "rev": "f71cbb9f5c646e99135edb55412a617bf823aa98",
-        "sha256": "1f2g20vv8rgihjkq1ky7wa1bh3i0p3n6cf5xdvc7cbdyc4lg1wih",
+        "rev": "fdc0fa3becb9e80311cbe638d1e8b518a44bd1ee",
+        "sha256": "1r5vz919jrhr0bcw9knn91xxvdp4pkmm4y5wrhn6cqi8190cp0s3",
         "type": "tarball",
-        "url": "https://github.com/doomemacs/doomemacs/archive/f71cbb9f5c646e99135edb55412a617bf823aa98.tar.gz",
+        "url": "https://github.com/doomemacs/doomemacs/archive/fdc0fa3becb9e80311cbe638d1e8b518a44bd1ee.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "emacs-overlay": {


### PR DESCRIPTION
## Changelog for doomemacs:
Branch: master
Commits: [doomemacs/doomemacs@f71cbb9f...fdc0fa3b](https://github.com/doomemacs/doomemacs/compare/f71cbb9f5c646e99135edb55412a617bf823aa98...fdc0fa3becb9e80311cbe638d1e8b518a44bd1ee)

* [`4ca742a2`](https://github.com/doomemacs/doomemacs/commit/4ca742a28181b88723fd380d86d31fd4fea8e364) fix(format): lsp format scratch buffer
* [`50a2ba05`](https://github.com/doomemacs/doomemacs/commit/50a2ba058669941f16b47fa5241904a851fac6b2) fix(format): eglot format scratch buffer
* [`c1632fa8`](https://github.com/doomemacs/doomemacs/commit/c1632fa8876f44a3e8799cc92a0f8a7c54561339) fix(debugger): don't persist breakpoints
* [`aa6f3903`](https://github.com/doomemacs/doomemacs/commit/aa6f3903d57e033bc869f34e7ceb43740826dfda) fix(smooth-scroll): potential out-of-bounds error
* [`6ce4ba3d`](https://github.com/doomemacs/doomemacs/commit/6ce4ba3d1877f837211dbe6959c927ae6ada3830) release(modules): 25.07.0-dev
* [`313e8fb4`](https://github.com/doomemacs/doomemacs/commit/313e8fb48be6381aac7b42c6c742d6d363cc7d35) fix(smooth-scroll): advice on wrong function
* [`d60d639e`](https://github.com/doomemacs/doomemacs/commit/d60d639efe50eb609fb3b7e0555e8d1782ac27bf) fix(magit): Remove +magit-optimize-process-calls-h
* [`ed860b2b`](https://github.com/doomemacs/doomemacs/commit/ed860b2b065777d11ecfcd53e5d67e78b02fd3f2) feat(eww): Add jump-to-heading in EWW
* [`7280e44d`](https://github.com/doomemacs/doomemacs/commit/7280e44dc57b718e6723dc641dd3bb2cd4bdf00b) fix(beancount): link completion
* [`18bb2da8`](https://github.com/doomemacs/doomemacs/commit/18bb2da849262cd7febd6ccaf3150debebb81450) fix(lib): doom-project-find-file: allow arbitrary roots
* [`68010af0`](https://github.com/doomemacs/doomemacs/commit/68010af0906171e3c989fc19bcb3ba81f7305022) bump: :tools llm
* [`f96af872`](https://github.com/doomemacs/doomemacs/commit/f96af872ac13522aeaa53fb9b4b482f432bdc339) bump: :tools
* [`442f4db4`](https://github.com/doomemacs/doomemacs/commit/442f4db4d43dfea5304dd32fcff39a77ec439e37) bump: :ui
* [`aa7dd61a`](https://github.com/doomemacs/doomemacs/commit/aa7dd61a2c773a6507d1da807c91e8eb0b228904) fix(magit): require Emacs 29.1+ for +forge
* [`197419f0`](https://github.com/doomemacs/doomemacs/commit/197419f041673dcc94cceed700a123af77aadd0c) fix(magit): +forge: fail gracefully on <29.1
* [`b6927d06`](https://github.com/doomemacs/doomemacs/commit/b6927d0698804ce1a57f6b8ef91994ee97ba881d) bump: :editor
* [`4d92921b`](https://github.com/doomemacs/doomemacs/commit/4d92921b597baa7ecd10930f939438b34a4211c9) bump: :app
* [`35c565f6`](https://github.com/doomemacs/doomemacs/commit/35c565f6cef122d430f9113efc24ec731c671c81) bump: :os
* [`ce51b4e8`](https://github.com/doomemacs/doomemacs/commit/ce51b4e8bba312b36f91c965ca724a154812107d) bump: :completion
* [`0bedac65`](https://github.com/doomemacs/doomemacs/commit/0bedac650a3214a4a157fbb9b085b31d5b4a6147) bump: :doom
* [`267aa3d7`](https://github.com/doomemacs/doomemacs/commit/267aa3d78850dec1718fa0d3baeb153677618691) bump: :email wanderlust
* [`e6c75530`](https://github.com/doomemacs/doomemacs/commit/e6c755305358412a71a990fc2cf592c629edde1e) feat(emacs-lisp): reduce flycheck in org-edit-special buffers
* [`a4d00445`](https://github.com/doomemacs/doomemacs/commit/a4d00445d26ae54cbfb017af74c4dc5735453a6f) tweak(markdown): markdown-mouse-follow-link = nil
* [`589fa734`](https://github.com/doomemacs/doomemacs/commit/589fa73435ea54c1b465d1fb869d5115df4c7157) fix(lib): doom/reload: on Windows
* [`cdc9566d`](https://github.com/doomemacs/doomemacs/commit/cdc9566d0b7a2b721b2736ca94883f8e624b47e7) fix(cli): doom.ps1: malformed geometry in __DOOMGEOM
* [`f0c8290a`](https://github.com/doomemacs/doomemacs/commit/f0c8290ae2bf41ddfcc1bd2fabcb5990012f6777) fix(format): prefix arg inhibiting format-on-save
* [`f64e1995`](https://github.com/doomemacs/doomemacs/commit/f64e199517e03d441382450afec1e6c2f45caa99) bump: :lang org
* [`7f6a2d28`](https://github.com/doomemacs/doomemacs/commit/7f6a2d284eb5b2dae6afdef199efa31a13f85619) refactor(cli): doom run: rename to 'doom emacs'
* [`c46583e3`](https://github.com/doomemacs/doomemacs/commit/c46583e3ec243ed8adc0aec347f7f9785033823b) refactor(cli): doom version: add -v/--verbose option
* [`fee14d07`](https://github.com/doomemacs/doomemacs/commit/fee14d073f05a6184008fc777c8aea29bd0d72ba) dev: update & simplify bug_report issue template
* [`d5a35c22`](https://github.com/doomemacs/doomemacs/commit/d5a35c224a496a48afd688f84d128dec031ad8e3) dev: update issue links to project resources
* [`cab27813`](https://github.com/doomemacs/doomemacs/commit/cab27813d5cdd64b297551f4ad4e80eb03755fa5) dev: fix issue links
* [`bffc593b`](https://github.com/doomemacs/doomemacs/commit/bffc593b9fec2bea674a9e6263138cdcf284472c) bump: ghub
* [`7ac03e3f`](https://github.com/doomemacs/doomemacs/commit/7ac03e3f0f5a7e9fc95ffcfd9f146986de1bde26) bump: :email wanderlust
* [`57fcd95e`](https://github.com/doomemacs/doomemacs/commit/57fcd95e7dd61fcfc235293d7909e7b008466113) tweak(latex): don't insert braces after sub/superscript
* [`be73e968`](https://github.com/doomemacs/doomemacs/commit/be73e9685b70bce02cca178cfcbd97393dca4bfa) docs(cli): update SEE ALSO links
* [`c55abb1b`](https://github.com/doomemacs/doomemacs/commit/c55abb1bf72bd773c015e5b4449b7a4efa1de8a0) fix(cli): doom.ps1: ParserError on $PATH
* [`3d75d8e2`](https://github.com/doomemacs/doomemacs/commit/3d75d8e205eb0c0def40920be6e30469eb5f4769) fix(cli): doom emacs: command not found
* [`957b1266`](https://github.com/doomemacs/doomemacs/commit/957b1266bf9e6c39156f9e38241df879c4a78662) refactor(minimap): replace minimap.el w/ demap.el
* [`59c6b8e6`](https://github.com/doomemacs/doomemacs/commit/59c6b8e61403d425b10dfacdac9fc3f3c53a41a1) refactor!(ruby): remove rubocop
* [`5cb34fa1`](https://github.com/doomemacs/doomemacs/commit/5cb34fa15155c6525ceb33a715b6c1944410bad3) refactor!: remove highlight-numbers
* [`87b616e5`](https://github.com/doomemacs/doomemacs/commit/87b616e5d8dcb9763a8caf7b83e1e8e9016b6d1d) refactor!: remove rainbow-delimiters
* [`fdc0fa3b`](https://github.com/doomemacs/doomemacs/commit/fdc0fa3becb9e80311cbe638d1e8b518a44bd1ee)  docs(markdown): doctor: allow for alternate grips
