### PR TITLE
niv fast-syntax-highlighting: update cf318e06 -> dcee72bb

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,10 +53,10 @@
         "homepage": null,
         "owner": "zdharma-continuum",
         "repo": "fast-syntax-highlighting",
-        "rev": "cf318e06a9b7c9f2219d78f41b46fa6e06011fd9",
-        "sha256": "1bmrb724vphw7y2gwn63rfssz3i8lp75ndjvlk5ns1g35ijzsma5",
+        "rev": "dcee72bb99b422bb8e4510f5087af9c1721392e4",
+        "sha256": "1cil68bg6z5z6a050vxxnfnqalqihxbxznwfjqgmdyxzzbq6lazn",
         "type": "tarball",
-        "url": "https://github.com/zdharma-continuum/fast-syntax-highlighting/archive/cf318e06a9b7c9f2219d78f41b46fa6e06011fd9.tar.gz",
+        "url": "https://github.com/zdharma-continuum/fast-syntax-highlighting/archive/dcee72bb99b422bb8e4510f5087af9c1721392e4.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "fzf-tab": {


### PR DESCRIPTION
## Changelog for fast-syntax-highlighting:
Branch: master
Commits: [zdharma-continuum/fast-syntax-highlighting@cf318e06...dcee72bb](https://github.com/zdharma-continuum/fast-syntax-highlighting/compare/cf318e06a9b7c9f2219d78f41b46fa6e06011fd9...dcee72bb99b422bb8e4510f5087af9c1721392e4)

* [`6f57bbe5`](https://github.com/zdharma-continuum/fast-syntax-highlighting/commit/6f57bbe57c5f248939b02b60171857087614dda4) feat(chrome): support for podman ([zdharma-continuum/fast-syntax-highlighting⁠#80](https://togithub.com/zdharma-continuum/fast-syntax-highlighting/issues/80))
* [`dcee72bb`](https://github.com/zdharma-continuum/fast-syntax-highlighting/commit/dcee72bb99b422bb8e4510f5087af9c1721392e4) fix(make): colorize targets from imported make-files ([zdharma-continuum/fast-syntax-highlighting⁠#81](https://togithub.com/zdharma-continuum/fast-syntax-highlighting/issues/81))
