### PR TITLE
niv home-manager: update d07e9cce -> 96354906

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -77,10 +77,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d07e9cceb4994ed64a22b9b36f8b76923e87ac38",
-        "sha256": "179b5paq5dwi57lapn2w0f5d3rskrbxb0yyb4cpwpvlm32bjp4dd",
+        "rev": "96354906f58464605ff81d2f6c2ea23211cbf051",
+        "sha256": "0pcsnhggwgphh7f78q0842l3dq84yhgipvn4cpf5xckydjpxbnd6",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/d07e9cceb4994ed64a22b9b36f8b76923e87ac38.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/96354906f58464605ff81d2f6c2ea23211cbf051.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@d07e9cce...96354906](https://github.com/nix-community/home-manager/compare/d07e9cceb4994ed64a22b9b36f8b76923e87ac38...96354906f58464605ff81d2f6c2ea23211cbf051)

* [`a4bac2b9`](https://github.com/nix-community/home-manager/commit/a4bac2b9ba2f9bd68032880da8ae6b44fbc46047) helix: fix configuration file creation logic ([nix-community/home-manager⁠#7319](https://togithub.com/nix-community/home-manager/issues/7319))
* [`d400c361`](https://github.com/nix-community/home-manager/commit/d400c361660526a199e1e56cc22f073c09c71d35) tests/flake.lock: remove ([nix-community/home-manager⁠#7324](https://togithub.com/nix-community/home-manager/issues/7324))
* [`951f0b30`](https://github.com/nix-community/home-manager/commit/951f0b30c535a46817aa5ef4c66ddc4445f3e324) ci: schedule release flake lock updates ([nix-community/home-manager⁠#7325](https://togithub.com/nix-community/home-manager/issues/7325))
* [`ff31a467`](https://github.com/nix-community/home-manager/commit/ff31a4677c1a8ae506aa7e003a3dba08cb203f82) fix(zed): support preexisting JSON5 settings ([nix-community/home-manager⁠#7317](https://togithub.com/nix-community/home-manager/issues/7317))
* [`080e8b48`](https://github.com/nix-community/home-manager/commit/080e8b48b0318b38143d5865de9334f46d51fce3) mako: "settings" is an attrset, so use that as example too ([nix-community/home-manager⁠#7330](https://togithub.com/nix-community/home-manager/issues/7330))
* [`da077f20`](https://github.com/nix-community/home-manager/commit/da077f20db88a173629624a30380658840d377b3) fix(service/gpg-agent): ensure SSH_AUTH_SOCK is set on Darwin ([nix-community/home-manager⁠#7117](https://togithub.com/nix-community/home-manager/issues/7117))
* [`76d0c31f`](https://github.com/nix-community/home-manager/commit/76d0c31fce2aa0c71409de953e2f9113acd5b656) formatter: add deadnix ([nix-community/home-manager⁠#7331](https://togithub.com/nix-community/home-manager/issues/7331))
* [`2b3bb17e`](https://github.com/nix-community/home-manager/commit/2b3bb17e871b22250e7ee5dbf422b8c40c5d5c79) oh-my-posh: fix nushell with v26.0.0 ([nix-community/home-manager⁠#7342](https://togithub.com/nix-community/home-manager/issues/7342))
* [`522c681a`](https://github.com/nix-community/home-manager/commit/522c681ac22bf3b4d2cfc5f74e71401da82001cc) flake.lock: Update ([nix-community/home-manager⁠#7326](https://togithub.com/nix-community/home-manager/issues/7326))
* [`a4f9ab00`](https://github.com/nix-community/home-manager/commit/a4f9ab000564187663c79e2dd68c74bae98012e7) sway: add `wayland.windowManager.sway.systemd.dbusImplementation` ([nix-community/home-manager⁠#7271](https://togithub.com/nix-community/home-manager/issues/7271))
* [`3faf4a15`](https://github.com/nix-community/home-manager/commit/3faf4a15072006f684dcce8ca95d198aeaf2c2f4) syncthing: add guiAddress to configuration ([nix-community/home-manager⁠#7281](https://togithub.com/nix-community/home-manager/issues/7281))
* [`cab8104e`](https://github.com/nix-community/home-manager/commit/cab8104e9236fab1eb9a702165454ffed353c20f) home-manager: add repl subcommand ([nix-community/home-manager⁠#5600](https://togithub.com/nix-community/home-manager/issues/5600))
* [`f6deff17`](https://github.com/nix-community/home-manager/commit/f6deff178cc4d6049d30785dbfc831e6c6e3a219) quickshell: add module ([nix-community/home-manager⁠#7316](https://togithub.com/nix-community/home-manager/issues/7316))
* [`0f21ed51`](https://github.com/nix-community/home-manager/commit/0f21ed5182a158d2f84e9136f6bf8539fd9a6890) bash: change sessionVariables to attrsOf ... ([nix-community/home-manager⁠#7300](https://togithub.com/nix-community/home-manager/issues/7300))
* [`ee2189cb`](https://github.com/nix-community/home-manager/commit/ee2189cb2f6c9e2b9c734a839faa20ed2ba8b577) gh: insert empty helper when using credential helper ([nix-community/home-manager⁠#7347](https://togithub.com/nix-community/home-manager/issues/7347))
* [`78fc50f1`](https://github.com/nix-community/home-manager/commit/78fc50f1cf8e57a974ff4bfe654563fce43d6289) direnv: fix nushell cell-path handling ([nix-community/home-manager⁠#7339](https://togithub.com/nix-community/home-manager/issues/7339))
* [`e8a3e2c1`](https://github.com/nix-community/home-manager/commit/e8a3e2c1e06c1dd488292929f7263ccfa765c7d8) nh: fix clean option behaviour for Darwin
* [`40741217`](https://github.com/nix-community/home-manager/commit/40741217965a63be07dcfcf51865d6f65ef88e71) nh: update maintainers
* [`96354906`](https://github.com/nix-community/home-manager/commit/96354906f58464605ff81d2f6c2ea23211cbf051) files: show better error when file would be clobbered ([nix-community/home-manager⁠#7348](https://togithub.com/nix-community/home-manager/issues/7348))
