### PR TITLE
niv zsh-autosuggestions: update 0e810e5a -> 85919cd1

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -215,10 +215,10 @@
         "homepage": null,
         "owner": "zsh-users",
         "repo": "zsh-autosuggestions",
-        "rev": "0e810e5afa27acbd074398eefbe28d13005dbc15",
-        "sha256": "0y866dsm8l164afbyd9cafbl97yf9viqwms9bbn0799nwgsb15pk",
+        "rev": "85919cd1ffa7d2d5412f6d3fe437ebdbeeec4fc5",
+        "sha256": "1885w3crr503h5n039kmg199sikb1vw1fvaidwr21sj9mn01fs9a",
         "type": "tarball",
-        "url": "https://github.com/zsh-users/zsh-autosuggestions/archive/0e810e5afa27acbd074398eefbe28d13005dbc15.tar.gz",
+        "url": "https://github.com/zsh-users/zsh-autosuggestions/archive/85919cd1ffa7d2d5412f6d3fe437ebdbeeec4fc5.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "zsh-histdb": {


### PR DESCRIPTION
## Changelog for zsh-autosuggestions:
Branch: master
Commits: [zsh-users/zsh-autosuggestions@0e810e5a...85919cd1](https://github.com/zsh-users/zsh-autosuggestions/compare/0e810e5afa27acbd074398eefbe28d13005dbc15...85919cd1ffa7d2d5412f6d3fe437ebdbeeec4fc5)

* [`a00927c6`](https://github.com/zsh-users/zsh-autosuggestions/commit/a00927c6732da1162dbe207782f1857472067758) INSTALL.md: Add FreeBSD
* [`da75fc22`](https://github.com/zsh-users/zsh-autosuggestions/commit/da75fc226d80b732b482fbde1c21396d285ac3e3) Update homebrew install link to point to homebrew website.
