### PR TITLE
niv nixpkgs: update 25b40d75 -> a2867cc3

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -155,10 +155,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "25b40d755501e3e5c499723b0e5b401bd67e7830",
-        "sha256": "0b2bm600h2psvgzqr7makzv7wg4y8f2k21gyn6a4xhpkblxxvx6l",
+        "rev": "a2867cc3f8acc944cb19fe0b73c840e9fa1ba589",
+        "sha256": "0x293i0pdy13hq1gdi6vq4ly5mhc07bc47ib1bgklhqdfh24b9p5",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/25b40d755501e3e5c499723b0e5b401bd67e7830.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/a2867cc3f8acc944cb19fe0b73c840e9fa1ba589.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@25b40d75...a2867cc3](https://github.com/nixos/nixpkgs/compare/25b40d755501e3e5c499723b0e5b401bd67e7830...a2867cc3f8acc944cb19fe0b73c840e9fa1ba589)

* [`1c87deda`](https://github.com/NixOS/nixpkgs/commit/1c87deda6286628e3cb2585a2cc717b2874e8e6d) release: disallow aliases
* [`954c59ff`](https://github.com/NixOS/nixpkgs/commit/954c59fff976140ddc14b8e923eaafd7a5cc92e4) top-level/aliases: Remove unneeded dontDistribute
* [`c689716d`](https://github.com/NixOS/nixpkgs/commit/c689716d48cfa92995ccee73e04cef402ac13965) nixos/prometheus.alertmanagerIrcRelay: fix network-online.target ordering but not depending warning
* [`eba050bc`](https://github.com/NixOS/nixpkgs/commit/eba050bcee71dab0b604890682b710442f97b90f) maintainers: add globule655
* [`24ff7ae7`](https://github.com/NixOS/nixpkgs/commit/24ff7ae790016b99d735a5c8878f1b60e5cf3d08) obs-studio-plugins.distroav: init at 6.0.0
* [`92c9f252`](https://github.com/NixOS/nixpkgs/commit/92c9f252eb49dee51558827bae6181a9f5b6c6d3) ndi-6: init at 6.1.1
* [`693449ae`](https://github.com/NixOS/nixpkgs/commit/693449ae420109457264f954771e7a9f2975b54f) delve: unbreak `go version -m dlv`
* [`8fd6f731`](https://github.com/NixOS/nixpkgs/commit/8fd6f7314022495031fddfac492d37c995bd90bb) nixos/xrdp: use --replace-fail with substituteInPlace, try [nixos/nixpkgs⁠#2](https://togithub.com/nixos/nixpkgs/issues/2)
* [`d2cd6877`](https://github.com/NixOS/nixpkgs/commit/d2cd68772a7b6cbe0b24bd16c5e428bc9317b671) buildRustCrate: add missing env variables for build scripts
* [`c7e817b6`](https://github.com/NixOS/nixpkgs/commit/c7e817b6bebbc9f837601e93897cf7fb3d1001f0) python3Packages.bangla: 0.0.2 -> 0.0.5
* [`b8c58d30`](https://github.com/NixOS/nixpkgs/commit/b8c58d3003da09a7ec2a13482297ba724417037c) obs-studio-plugins.obs-vnc: init at 0.6.1
* [`3aac6e53`](https://github.com/NixOS/nixpkgs/commit/3aac6e53a1bc188e1d6417612cab5e78f6b2cf45) optipng: 0.7.8 -> 7.9.1
* [`a75155a9`](https://github.com/NixOS/nixpkgs/commit/a75155a9edd212b6df169daa4092ce54d0bca7e8) obs-studio-plugins.obs-browser-transition: init at 0.1.3
* [`64ddd5bc`](https://github.com/NixOS/nixpkgs/commit/64ddd5bca0678f8327f11f4f10cd4ee2f74b6e28) netpbm: 11.10.4 -> 11.10.5
* [`10f7d786`](https://github.com/NixOS/nixpkgs/commit/10f7d7860f5b38be48e4f4ead7631d98f21ddbcb) armadillo: 14.4.2 -> 14.4.3
* [`067f315f`](https://github.com/NixOS/nixpkgs/commit/067f315f014b1ecb42d7791a69d7c8f962894bf2) lief: 0.16.5 -> 0.16.6
* [`9efb57e5`](https://github.com/NixOS/nixpkgs/commit/9efb57e500ad4e935059c7cb426c876dcd0b997a) greetd.greetd: Set mainProgram to `greetd`
* [`eef3a1fa`](https://github.com/NixOS/nixpkgs/commit/eef3a1faa801e0d55d004ea4d95c60945ae49f5d) nixos/greetd: make use of package option
* [`ae0c7c5e`](https://github.com/NixOS/nixpkgs/commit/ae0c7c5ea33e8055789f8b5c40aaac03a13ae16c) iputils: 20240905 -> 20250602
* [`59a08084`](https://github.com/NixOS/nixpkgs/commit/59a08084f2a8e46ab024ce4d1cf9e26f2ca534f8) pgadmin: 9.3 -> 9.4
* [`51a6bedd`](https://github.com/NixOS/nixpkgs/commit/51a6beddb7a77890089bd2ae82ee97c291fde48c) maven: 3.9.9 -> 3.9.10
* [`83193098`](https://github.com/NixOS/nixpkgs/commit/83193098bce69fb570f4f72e489531c2960a8da3) bazel-buildtools: 8.2.0 -> 8.2.1
* [`d6591b28`](https://github.com/NixOS/nixpkgs/commit/d6591b28b19b1ce1caa589c2be9d98b6d10c5a9f) nixos/govee2mqtt: start after network-online top hopefully have DNS
* [`20f57fc5`](https://github.com/NixOS/nixpkgs/commit/20f57fc59b18c284c8a79545cf28340752a46717) rdkafka: 2.10.0 -> 2.10.1
* [`4083a554`](https://github.com/NixOS/nixpkgs/commit/4083a554cc2392f844ca9e393c80acb711920326) prowlarr: build from sources
* [`b3716e06`](https://github.com/NixOS/nixpkgs/commit/b3716e06fc33108169fc1584db2a7f8dc9880c04) prowlarr: 1.36.3.5071 -> 1.37.0.5076
* [`51f97363`](https://github.com/NixOS/nixpkgs/commit/51f9736368c444ee586a388374bce7f9e655b52d) nixosTests.prowlarr: replace mv command by rsync to handle not empty directory
* [`48823c71`](https://github.com/NixOS/nixpkgs/commit/48823c71e0001548cb14860dacdef410f54a0be9) cloudlog: 2.6.18 -> 2.6.19
* [`922878e1`](https://github.com/NixOS/nixpkgs/commit/922878e11de6629167a0fff68953697159404335) prowlarr: fetch major versions in update script
* [`572739b3`](https://github.com/NixOS/nixpkgs/commit/572739b33c0bc447d6aac57433e77565ba68abf0) libimobiledevice-glue: 1.3.1 -> 1.3.2
* [`40713e1e`](https://github.com/NixOS/nixpkgs/commit/40713e1e476cd407ee2f8999354cb3747aad60fe) bazel-gazelle: 0.43.0 -> 0.44.0
* [`d660c51d`](https://github.com/NixOS/nixpkgs/commit/d660c51de895f33e1404fe80350842a436f74c53) closurecompiler: 20250407 -> 20250528
* [`2641473e`](https://github.com/NixOS/nixpkgs/commit/2641473ee2fb5172801ea9cab80d1b98620b60cb) iputils: 20250602 -> 20250605
* [`24c0415c`](https://github.com/NixOS/nixpkgs/commit/24c0415ca027abc33e19f81a28036c88d6565b02) gnuplot: 6.0.2 -> 6.0.3
* [`b2d0cbc4`](https://github.com/NixOS/nixpkgs/commit/b2d0cbc4a151c73e7e1c1bba1c955f096ef5e42c) hydra: avoid drawing in development dependencies from nix 2.29 on runtime
* [`6df79a10`](https://github.com/NixOS/nixpkgs/commit/6df79a104ac310baed6f44c1d106a016e3bf7854) converged-security-suite: init at 2.8.1
* [`3cc753c6`](https://github.com/NixOS/nixpkgs/commit/3cc753c6cebe3b39d52d7d8b211d113891558eaa) caesura: init at 0.25.2
* [`0ccf4b0a`](https://github.com/NixOS/nixpkgs/commit/0ccf4b0a00dac659d20509ba221ef57837fe4104) quarto: 1.7.31 -> 1.7.32
* [`9d0f3f0b`](https://github.com/NixOS/nixpkgs/commit/9d0f3f0b9f39a6aebd2818b3c6456911f72b9b7d) mtools: 4.0.48 -> 4.0.49
* [`f7d7ad7b`](https://github.com/NixOS/nixpkgs/commit/f7d7ad7bcffc2dec661514dd6afe749acb4ae743) maiko: 250201-55e20ea9 -> 250616-de1fafba
* [`06e31c37`](https://github.com/NixOS/nixpkgs/commit/06e31c3799ce10ad661a9b72288c9dbeb6467f64) fasmg: kp60 -> ktge
* [`11376029`](https://github.com/NixOS/nixpkgs/commit/113760294f12b3f036d2259f9473f5cac6631750) freecell-solver: 6.12.0 -> 6.14.0
* [`aa9a57e9`](https://github.com/NixOS/nixpkgs/commit/aa9a57e9d73aa7621cd62df403d6eafe9dd33db7) streamlit: 1.45.1 -> 1.46.0
* [`b83d41df`](https://github.com/NixOS/nixpkgs/commit/b83d41dfea8ef9ece9845e0647fa9eb51eb81d9b) postgresql_jdbc: 42.6.1 -> 42.7.7
* [`f95180fc`](https://github.com/NixOS/nixpkgs/commit/f95180fc05509cf7c2ea180a4836c98cb28f886d) bind: 9.20.9 -> 9.20.10
* [`25443718`](https://github.com/NixOS/nixpkgs/commit/2544371869fa0674f52f6d3fea32cb190d388539) iwd: use finalAttrs
* [`07477ca0`](https://github.com/NixOS/nixpkgs/commit/07477ca0e680f49ae490800fae8aaadb658ce9db) iwd: 3.8 -> 3.9
* [`88565ccf`](https://github.com/NixOS/nixpkgs/commit/88565ccffd1ede1a91f1bdd23b66125b461ce585) iwd: avoid error in the logs about a non-existing netdev group
* [`6ab8de77`](https://github.com/NixOS/nixpkgs/commit/6ab8de77c454d6a3d3189c7699788777c12ab2a6) turbo-unwrapped: 2.5.3 -> 2.5.4
* [`b6596b40`](https://github.com/NixOS/nixpkgs/commit/b6596b40bb4b40d4deb3f793bba8439d7e1a08dc) iwd: src.rev -> src.tag
* [`e3b00d6f`](https://github.com/NixOS/nixpkgs/commit/e3b00d6f3a8c71e28db2d9c76dcd542c6a5a11df) tevent: 0.16.2 -> 0.17.0
* [`113f6480`](https://github.com/NixOS/nixpkgs/commit/113f64803aca1b785ec72c153170dbdad90d6f2e) openterface-qt: 0.3.15 -> 0.3.17
* [`d74f64d8`](https://github.com/NixOS/nixpkgs/commit/d74f64d82846ae3827dfd94d1fe1b1260b98bbd6) docker-buildx: 0.23.0 -> 0.25.0
* [`ac1b4b96`](https://github.com/NixOS/nixpkgs/commit/ac1b4b96ec33e76569a90d4de6df8820694e20f9) cppzmq: 4.10.0 -> 4.11.0
* [`b50c433b`](https://github.com/NixOS/nixpkgs/commit/b50c433b7243df69b43f4bf4bece97d479c398b1) python3Packages.msgraph-sdk: 1.33.0 -> 1.34.0
* [`873f2407`](https://github.com/NixOS/nixpkgs/commit/873f2407d61d1fbf88dd726ed077efae677d8432) podget: init at 1.0.0
* [`ecc039f3`](https://github.com/NixOS/nixpkgs/commit/ecc039f32735636d06ba322392266948e5455ce1) lib.filesystem.resolveDefaultNix: init
* [`66016feb`](https://github.com/NixOS/nixpkgs/commit/66016feb83de9c0dba793ee7dd1408c7cb50222b) lib.callPackageWith: Use resolveDefaultNix
* [`97b9708f`](https://github.com/NixOS/nixpkgs/commit/97b9708f76807bdfdb476e1b707b42a0701ea9c7) nixos/documentation: compress configuration.nix.5
* [`f4841c2e`](https://github.com/NixOS/nixpkgs/commit/f4841c2e68ab892760a610fa61508ed93410cec9) sdl_gamecontrollerdb: init at 0-unstable-2025-06-14
* [`8ff91dbe`](https://github.com/NixOS/nixpkgs/commit/8ff91dbe3a8200b6c0990158f8e8d0deb1995c7c) maintainers: add videl
* [`e9deb974`](https://github.com/NixOS/nixpkgs/commit/e9deb974dc8fdec543e1267942dbb36690432eac) sonarr: 4.0.14.2939 -> 4.0.15.2941
* [`1400a718`](https://github.com/NixOS/nixpkgs/commit/1400a718678fe9eb28bae99b3871993478027a4c) ocamlPackages.ocaml_pcre: 8.0.3 -> 8.0.4
* [`b492714e`](https://github.com/NixOS/nixpkgs/commit/b492714eda0ac1ccbb1e38657b108225689b75b7) maintainers: add different-name
* [`7628af12`](https://github.com/NixOS/nixpkgs/commit/7628af124b7764fd7ec9c877e6b8c41da97d0f91) build-support/php: DRY improvements
* [`bb0c422e`](https://github.com/NixOS/nixpkgs/commit/bb0c422eb6ec009b2c98c3f32cb8cfeabe674398) build-support/php: run `shfmt` on hooks
* [`767ed2a8`](https://github.com/NixOS/nixpkgs/commit/767ed2a8d070845ba5230afd250eb5d16a5bcebc) build-support/php: make shellcheck happy
* [`dd4436e8`](https://github.com/NixOS/nixpkgs/commit/dd4436e899237299f92b8861ad6d9d416dc39ee4) python3Packages.yangson: 1.6.2 -> 1.6.3
* [`e812adc8`](https://github.com/NixOS/nixpkgs/commit/e812adc80e13d095c230dc77264eeaaa32b9dc14) txr: 300 -> 301
* [`a5be232d`](https://github.com/NixOS/nixpkgs/commit/a5be232da00cb75da1975a02d7456917c4e6b465) gancioPlugins.telegram-bridge: 1.0.5 -> 1.0.6
* [`8fc98986`](https://github.com/NixOS/nixpkgs/commit/8fc98986d49a879db8e3fe8318557caccb43f759) nodejs_20: 20.19.2 -> 20.19.3
* [`268b753d`](https://github.com/NixOS/nixpkgs/commit/268b753d5cf81ee374e4d060285ced8f884780d3) gnome-commander: 1.18.2 -> 1.18.3
* [`9895036c`](https://github.com/NixOS/nixpkgs/commit/9895036cfc18dbd18ddcb04d7d6c373fd56576e1) python3Packages.useful-types: init at 0.2.1
* [`dcc19204`](https://github.com/NixOS/nixpkgs/commit/dcc19204a1f2b88ddb7f63521181f5b67c96e250) sundials: 7.3.0 -> 7.4.0
* [`bbca94c6`](https://github.com/NixOS/nixpkgs/commit/bbca94c60c668295a357ef9a4b39ea86635e6485) airwindows: 0-unstable-2025-06-08 -> 0-unstable-2025-06-22
* [`9d7a1358`](https://github.com/NixOS/nixpkgs/commit/9d7a13589ef8d38e057ce72317c24d389a562f62) atmos: 1.178.0 -> 1.180.0
* [`332a5130`](https://github.com/NixOS/nixpkgs/commit/332a5130e4ca343fd7482c6f9c077e7859c4e082) libressl: fix deprecated --replace, use TLS_DEFAULT_CA_FILE option again, misc cleanup
* [`45bbfd7c`](https://github.com/NixOS/nixpkgs/commit/45bbfd7c49617fa7d100b08d9e76b8000857f4b1) libressl_3_{6,7,8}: drop
* [`24909728`](https://github.com/NixOS/nixpkgs/commit/2490972847e7552a8808ded8e221ebd727f5e837) python3Packages.cloudflare: 4.2.0 -> 4.3.1
* [`c8523381`](https://github.com/NixOS/nixpkgs/commit/c852338190eab43152c946a68b323eb14f29f232) ibus-engines.libpinyin: 1.16.3 -> 1.16.4
* [`340cc31a`](https://github.com/NixOS/nixpkgs/commit/340cc31a828fdfd75dec8bbce671ff18f41786da) elfutils: build out of tree on libc++
* [`b9e49739`](https://github.com/NixOS/nixpkgs/commit/b9e49739d2d17736dc11492ce4b0d3ba7c439d84) dependency-track: use protogen_30 to fix build
* [`ef8b8e5a`](https://github.com/NixOS/nixpkgs/commit/ef8b8e5a456c9b00e5856ca0dbc9ab9d0a91e81b) xen: 4.19.1 -> 4.20.0
* [`e3c735cc`](https://github.com/NixOS/nixpkgs/commit/e3c735ccd8febea57e8260157a58a6d1ef9a34b4) xen: delete outdated README
* [`4a0180f4`](https://github.com/NixOS/nixpkgs/commit/4a0180f434d7378fdce98fabc08f9fbf010c521e) nixos/xen: dehardcode the .pad section from the UKI builder
* [`d9ee6a3e`](https://github.com/NixOS/nixpkgs/commit/d9ee6a3e629c39005e099b9470a46ff7cb11b0a0) nixVersions.git: 2.30pre20250521 -> 2.30pre20250624
* [`cdd4e5b4`](https://github.com/NixOS/nixpkgs/commit/cdd4e5b4f8aacff5120b8f6704f2b12dbd7ff7fe) google-cloud-sdk: fix gcloud alpha/beta commands
* [`453d6b71`](https://github.com/NixOS/nixpkgs/commit/453d6b714ecbb28a38bc5c26d85b60ae52eb0227) rustPlatform.rustVendorSrc: init
* [`502dfd28`](https://github.com/NixOS/nixpkgs/commit/502dfd28027dceaa2b69ad970de3f6f09676fd5d) qgis-ltr: 3.40.7 -> 3.40.8
* [`b10dabd0`](https://github.com/NixOS/nixpkgs/commit/b10dabd00922911f39909b935504754407533987) nixos/prometheus-wireguard-exporter: Add a new option to export `wireguard_latest_handshake_delay_seconds`.
* [`520250a2`](https://github.com/NixOS/nixpkgs/commit/520250a23bb2564a7e9950ebc773c5893f5220dd) openapi-generator-cli: 7.13.0 -> 7.14.0
* [`97add77c`](https://github.com/NixOS/nixpkgs/commit/97add77ce19ec8afc089ee2ffc6390b9f893aaa9) level-zero: 1.21.9 -> 1.22.4
* [`4d9871f2`](https://github.com/NixOS/nixpkgs/commit/4d9871f2b29d5ea0f6c6abb987023d28b7451632) electron_34-bin: mark as insecure because it's EOL
* [`0251292e`](https://github.com/NixOS/nixpkgs/commit/0251292ee997c11077390c15ca80b293dc63c4f2) electron-source.electron_34: remove as it's EOL
* [`cc3b6f2d`](https://github.com/NixOS/nixpkgs/commit/cc3b6f2d9160794ea69220860ba7673fa1300b83) make-bootstrap-tools-cross: add powerpc64-unknown-linux-gnuabielfv1
* [`ded344bf`](https://github.com/NixOS/nixpkgs/commit/ded344bf5b93be3ba502c83959ddac6f6b942e8e) emscripten: 4.0.8 -> 4.0.10
* [`310dda67`](https://github.com/NixOS/nixpkgs/commit/310dda67329a0a09c4a7b419de6222fa826a06ee) appium-inspector: use electron_36
* [`f34a492c`](https://github.com/NixOS/nixpkgs/commit/f34a492c5f9bf3bf155c1d4c5de450dc897c4358) vintagestory: remove redundant string append
* [`36bfba5d`](https://github.com/NixOS/nixpkgs/commit/36bfba5d65cc1aa744de16a0a1439deffdc9e65d) vintagestory: remove `with lib`
* [`33bf00aa`](https://github.com/NixOS/nixpkgs/commit/33bf00aae908125ca133bdd7c1737227b03deb45) vintagestory: set `meta.sourceProvenance`
* [`1a07a1cd`](https://github.com/NixOS/nixpkgs/commit/1a07a1cd92afe76a59e2e98f7c8b5c85ecb11c87) vintagestory: set `meta.mainProgram`
* [`82542aa6`](https://github.com/NixOS/nixpkgs/commit/82542aa6ba475baa738275b74c22084d151c7c3a) vintagestory: set `meta.platforms`
* [`b01cce1e`](https://github.com/NixOS/nixpkgs/commit/b01cce1e2740dd316950e4d6b0841815edd088b8) vintagestory: set mesa_glthread=true by default
* [`0586368e`](https://github.com/NixOS/nixpkgs/commit/0586368e18d2ff9f9496f821dcf578bd4f06a237) vintagestory: add dtomvan as maintainer
* [`c09adca7`](https://github.com/NixOS/nixpkgs/commit/c09adca78b0af13a343263d577b54e0525a4c07f) vintagestory: 1.20.11 -> 1.20.12
* [`63cc2e2a`](https://github.com/NixOS/nixpkgs/commit/63cc2e2a3638c907e14418eb536c8a4d51caec0c) vintagestory: remove unused `buildInputs`
* [`9c524ecd`](https://github.com/NixOS/nixpkgs/commit/9c524ecd90f8a38a5a1f7fccb197d92e3d9fa6e0) maintainers: add jed-richards
* [`8c6d63ee`](https://github.com/NixOS/nixpkgs/commit/8c6d63ee38d833d9c977bcf0d37ebee2bdb3d117) maintainers: add ccicnce113424
* [`4c6a35df`](https://github.com/NixOS/nixpkgs/commit/4c6a35df8a78db294cd67f59ffe925d835447121) libphonenumber: 9.0.5 -> 9.0.8
* [`993f43c6`](https://github.com/NixOS/nixpkgs/commit/993f43c6a56a5f148e00e28b04545c90fb192491) pam_rssh: add update script
* [`b7575f9c`](https://github.com/NixOS/nixpkgs/commit/b7575f9c192cf532e7e167833e5d3d2ecdcf0a2d) pam_rssh: 1.2.0-rc2 -> 1.2.0
* [`34565774`](https://github.com/NixOS/nixpkgs/commit/34565774c8ad02b7ca71509b4536a82f8cf5f5b0) pam_rssh: add xyenon as maintainer
* [`ea9a4ec8`](https://github.com/NixOS/nixpkgs/commit/ea9a4ec86252191c459656fe8813ed85e7162716) python3Packages.pytest-ruff: 0.4.1 -> 0.5
* [`29ed443f`](https://github.com/NixOS/nixpkgs/commit/29ed443f2cf1a130ab60e4b249fa5d7cbd3158c6) bitsnpicas: init at 2.1
* [`1cde5d5a`](https://github.com/NixOS/nixpkgs/commit/1cde5d5abbfacdf783e7dd2c126e4d2696201f8a) lutgen: v0.12.1 -> v1.0.0
* [`f73b1903`](https://github.com/NixOS/nixpkgs/commit/f73b190353056183f7d112880e2b6f833a5e9a4d) flutter332: 3.32.2 -> 3.32.5
* [`1e2188d5`](https://github.com/NixOS/nixpkgs/commit/1e2188d537806b205079245c2e828daad6dd8461) python3Packages.llm-perplexity: init at 2025.6.0
* [`9d3ddc35`](https://github.com/NixOS/nixpkgs/commit/9d3ddc35a189d5f88e607f7296c002a5a7671988) luaPackages.lze: 0.11.3-1 -> 0.11.4-1
* [`eb5f7264`](https://github.com/NixOS/nixpkgs/commit/eb5f7264dbc5dc7f77827164b91eb880d9f6c181) luaPackages.grug-far.nvim: 1.6.41-1 -> 1.6.42-1
* [`6d0d7a60`](https://github.com/NixOS/nixpkgs/commit/6d0d7a6062248ddc05394568ee84c32df02ad132) luaPackages.fzf-lua: 0.0.1937-1 -> 0.0.1948-1
* [`dd6e5a49`](https://github.com/NixOS/nixpkgs/commit/dd6e5a497cbfb886e68dfd3a2ea3bd8603ab51f9) dmlive: 5.5.8-unstable-2025-04-06 -> 5.6.0-unstable-2025-06-21
* [`6975e71b`](https://github.com/NixOS/nixpkgs/commit/6975e71bc80d73558c3a4a628aa6b34f04e04457) obs-studio-plugins.wlrobs: mark aarch64-linux as supported
* [`75cf8aea`](https://github.com/NixOS/nixpkgs/commit/75cf8aea6495ab9468de3295d13c7f277621d141) apacheHttpdPackages.mod_python: mark broken on darwin
* [`10c70e86`](https://github.com/NixOS/nixpkgs/commit/10c70e86dbb0a1846074c1251831b27b06bffa14) chez-mit: mark broken on darwin
* [`e071ddf0`](https://github.com/NixOS/nixpkgs/commit/e071ddf04831b8addb2a69bffe3242b8c1f70a0f) fastnlo-toolkit: mark broken on darwin
* [`e9632624`](https://github.com/NixOS/nixpkgs/commit/e963262422fb40586abdcc580d7db48cdd7f1a81) lib3270: mark broken on darwin
* [`7ae96bb0`](https://github.com/NixOS/nixpkgs/commit/7ae96bb0ee6cdb9eb2109b0c53a51b928f6256e3) libfilezilla: mark broken on darwin
* [`ade903c5`](https://github.com/NixOS/nixpkgs/commit/ade903c5be452a60de7672df5f11759cb63b9232) python3Packages.pymonctl: mark broken on darwin
* [`2c793099`](https://github.com/NixOS/nixpkgs/commit/2c793099f04b80e7f680a2952f177d3c50e1aefb) xlog: mark broken on darwin
* [`9f670f44`](https://github.com/NixOS/nixpkgs/commit/9f670f44bcca035d477cf79d42486241462e6ee6) xteve: mark broken on darwin
* [`d940164a`](https://github.com/NixOS/nixpkgs/commit/d940164a1e0f8bc2e248c19516d378f1fe0803fa) zap-chip-gui: mark broken on darwin
* [`2fa1151e`](https://github.com/NixOS/nixpkgs/commit/2fa1151e544454140bf72b5304c7b443dd6fb5ca) workflows/labels: label stale issues
* [`dea8b612`](https://github.com/NixOS/nixpkgs/commit/dea8b612186514a574c35c726ff6925af4c09527) cdrtools: unpin llvmPackages_14
* [`e46de464`](https://github.com/NixOS/nixpkgs/commit/e46de4648ac3ab96226eff2af82fbed76273910d) cdrtools: add wegank as maintainer
* [`5dbda211`](https://github.com/NixOS/nixpkgs/commit/5dbda211822f404fc405f56a570812b425c6691f) cyrus-imapd: 3.12.0 -> 3.12.1
* [`22102d33`](https://github.com/NixOS/nixpkgs/commit/22102d334bbfbae887b2facd61df9f9cfc0efc22) xfsprogs: 6.13.0 -> 6.15.0
* [`0268f39d`](https://github.com/NixOS/nixpkgs/commit/0268f39db4c47d1ca84e1bd194b89695bd160825) perses: 0.51.0 -> 0.51.1
* [`32fe7c58`](https://github.com/NixOS/nixpkgs/commit/32fe7c58bac2de515885bcd0602b2a3c31464999) netbox_4_3: 4.3.2 -> 4.3.3
* [`7ae32b9a`](https://github.com/NixOS/nixpkgs/commit/7ae32b9a83be8e32a7541103707a6278aa2b36ad) dependabot-cli: 1.66.0 -> 1.67.1
* [`e8de340d`](https://github.com/NixOS/nixpkgs/commit/e8de340ddb5b48062e71e38bb202cef95df5f2f4) input-leap: build on Darwin at 3.0.3
* [`c672a8c4`](https://github.com/NixOS/nixpkgs/commit/c672a8c46756c672d414d71ce8e6e5079d13d9cf) fflogs: 8.17.13 -> 8.17.18
* [`f8b6b6f5`](https://github.com/NixOS/nixpkgs/commit/f8b6b6f512bb579d11be6a9d92ea2565641c4b08) lib/fetchers: remove unused imports
* [`c6d583c3`](https://github.com/NixOS/nixpkgs/commit/c6d583c3da526f49324d1b34bbad921a2438f9cd) fetchedMavenDeps: add impureEnvVars to FOD
* [`4e3a2b85`](https://github.com/NixOS/nixpkgs/commit/4e3a2b850b29d11139f68792dc2e854f349fe6fd) pritunl-client: Add optional wireguard support
* [`554b465b`](https://github.com/NixOS/nixpkgs/commit/554b465bac817aaacc16add43936efa9bec03068) fetchedMavenDeps: honor HTTP[S]_PROXY, NO_PROXY env vars
* [`cd931bff`](https://github.com/NixOS/nixpkgs/commit/cd931bff240f5dd9425ab5680bca4357f329820d) fetchedMavenDeps: honor NIX_SSL_CERT_FILE
* [`c3798569`](https://github.com/NixOS/nixpkgs/commit/c37985699555f89a42d1124134a30403a9bd3741) python3Packages.gftools: 0.9.85 -> 0.9.86
* [`0773d0c9`](https://github.com/NixOS/nixpkgs/commit/0773d0c98eee6d2e46a66acacc40ae3630cdd80f) home-assistant-custom-components.homematicip_local: 1.84.0 -> 1.84.1
* [`fe214d3c`](https://github.com/NixOS/nixpkgs/commit/fe214d3cf8106d6337783b99f92f1a40ee676569) cargo-local-registry: 0.2.7 -> 0.2.8
* [`82571f88`](https://github.com/NixOS/nixpkgs/commit/82571f88642528f13d7f56c4272501acb607ba9e) cirrus-cli: 0.144.3 -> 0.145.1
* [`40785b6d`](https://github.com/NixOS/nixpkgs/commit/40785b6dd06ad5627733f4d0bcfec87044ff5db3) python3Packages.hatch-docstring-description: init at 1.1.1
* [`baee5913`](https://github.com/NixOS/nixpkgs/commit/baee59130a67e422998afa2fe3679c656ee472fb) python3Packages.hatch-min-requirements: init at 0.1.0
* [`6c71eef5`](https://github.com/NixOS/nixpkgs/commit/6c71eef5ff15ed8f2bea48b707808ba43e320fb6) python3Packages.fast-array-utils: init at 1.2.1
* [`ebe38bcb`](https://github.com/NixOS/nixpkgs/commit/ebe38bcb71613eacf9cb6796db07ca51784106b9) maintainers: add maikotan
* [`1c92c150`](https://github.com/NixOS/nixpkgs/commit/1c92c150882a4f67c1bc39839fee84535fa5f20d) flyctl: 0.3.144 -> 0.3.145
* [`09a1a8ee`](https://github.com/NixOS/nixpkgs/commit/09a1a8eee6dccb593bfc1f312512a83ddf48fc12) wac-cli: init at 0.7.0
* [`3caed9f5`](https://github.com/NixOS/nixpkgs/commit/3caed9f50c4d0773469d0d89bddd853554cace53) portmidi: 2.0.4 -> 2.0.6
* [`3508c26a`](https://github.com/NixOS/nixpkgs/commit/3508c26a60b954ae2ae52ee1a3c4b3de3a3692c8) modules/sway: maintainers: drop colemickens
* [`f0637003`](https://github.com/NixOS/nixpkgs/commit/f06370039b36a9e813e59aed379cbc84014078a5) gebaar-libinput: maintainers: drop colemickens
* [`cf246f5f`](https://github.com/NixOS/nixpkgs/commit/cf246f5fa03a22e60b0e0c60a03a7d937bdb5e88) libquotient: maintainers: drop colemickens
* [`85d3cf98`](https://github.com/NixOS/nixpkgs/commit/85d3cf9801f251e8636f60ae20b54e134cef7985) llama-cpp: 5702 -> 5760
* [`5ca6c3f6`](https://github.com/NixOS/nixpkgs/commit/5ca6c3f63bf747fa267f84b68b4359a5663e06b1) cargo-expand: 1.0.109 -> 1.0.110
* [`a65450f5`](https://github.com/NixOS/nixpkgs/commit/a65450f565376136acd89a90017c497cef732393) luau: 0.679 -> 0.680
* [`0f100728`](https://github.com/NixOS/nixpkgs/commit/0f1007281d57cf944726d847428903d7a5bb52c1) mitra: 4.5.0 -> 4.5.1
* [`20ab3c01`](https://github.com/NixOS/nixpkgs/commit/20ab3c01cd31755a48ab25a674a43521a31ec643) werf: 2.38.0 -> 2.39.1
* [`92f7e7a6`](https://github.com/NixOS/nixpkgs/commit/92f7e7a6a7dc90cf2a3781bb5f2eba0c99a13679) epiphany: 48.3 → 48.5
* [`78cb79aa`](https://github.com/NixOS/nixpkgs/commit/78cb79aab13e9366ad5b3e1425c2e951275eabc9) evolution-ews: 3.56.1 → 3.56.2
* [`7d3eda3a`](https://github.com/NixOS/nixpkgs/commit/7d3eda3a1fa5baa8542db5b31c87f4655df08bc7) ghex: 48.alpha → 48.beta2
* [`65b63692`](https://github.com/NixOS/nixpkgs/commit/65b636920fec1d1d1ecc83044e9d88044530df17) gnome-control-center: 48.2 → 48.3
* [`10b25794`](https://github.com/NixOS/nixpkgs/commit/10b25794d7c3c150d826281601001bdc07d5040c) dart.flutter_vodozemac: init
* [`6ccaedd7`](https://github.com/NixOS/nixpkgs/commit/6ccaedd7f653f94e20c794275ab50f1e39f2c395) orca: 48.2 → 48.6
* [`e08b6636`](https://github.com/NixOS/nixpkgs/commit/e08b6636e70c5aabd4cd84a60c4cab88eb86b09c) papers: 48.2 → 48.4
* [`9faaef48`](https://github.com/NixOS/nixpkgs/commit/9faaef484e11e20acd92811245aff98837594c89) totem: 43.1 → 43.2
* [`c598b213`](https://github.com/NixOS/nixpkgs/commit/c598b213019bd183c5bab144b7bf2403d4746eed) lp_solve: fix cross-compilation
* [`fa9f79c9`](https://github.com/NixOS/nixpkgs/commit/fa9f79c992c88e95c17707fe1eb2da6bc34f6a85) python3Packages.mkdocs-redoc-tag: 0.1.0 -> 0.2.0
* [`07f21185`](https://github.com/NixOS/nixpkgs/commit/07f211853d30fad7cb840ce037afabf909a205bf) glitchtip: 5.0.4 -> 5.0.5
* [`a984d0b3`](https://github.com/NixOS/nixpkgs/commit/a984d0b38318871311b02f5068c8c76e5b6e77d3) google-lighthouse: 12.6.0 -> 12.7.0
* [`c11e60c8`](https://github.com/NixOS/nixpkgs/commit/c11e60c8ea167e6a49af95704704d7eb4e42eda3) anubis: 1.19.1 -> 1.20.0
* [`84840db2`](https://github.com/NixOS/nixpkgs/commit/84840db24727392631299bf1df2a9e6243626ab9) paretosecurity: 0.2.34 -> 0.2.36
* [`3332613a`](https://github.com/NixOS/nixpkgs/commit/3332613adda6c22f06d17002db812ba47f239772) nixos/systemd-initrd: Fix fsck.xfs failing due to missing sh
* [`07549794`](https://github.com/NixOS/nixpkgs/commit/0754979401da94ac2bffa768ba7d469562db0f32) wtfutil: 0.43.0 -> 0.44.1
* [`725a756d`](https://github.com/NixOS/nixpkgs/commit/725a756dbb9bc1713e6b77bcff810b4721decd87) nixos/easytier: init module
* [`61eda88c`](https://github.com/NixOS/nixpkgs/commit/61eda88c6584429039f5093e220cd724d2cf3dbc) flutter_rust_bridge_codegen: skip timeout tests on darwin
* [`de361619`](https://github.com/NixOS/nixpkgs/commit/de3616195b79fb688fc49e2c9a8d148fa0f28e62) mapnik: 4.1.0 → 4.1.1
* [`b5aec1f9`](https://github.com/NixOS/nixpkgs/commit/b5aec1f9cd51c508ee7488113bc2f192cc1143f8) fluffychat: 1.7.0 -> 2.0.0
* [`36c44da0`](https://github.com/NixOS/nixpkgs/commit/36c44da00537c266345d91b67581e9f1c15c383a) vectorcode: 0.6.12 -> 0.7.4
* [`e287baf4`](https://github.com/NixOS/nixpkgs/commit/e287baf449899b724c6864243cb30c6602197109) python3Packages.ipylab: 1.0.0 -> 1.1.0
* [`4f4cd59c`](https://github.com/NixOS/nixpkgs/commit/4f4cd59c743be37c467b7eaa257b91d24f16b014) googleearth-pro: fix build
* [`10a27266`](https://github.com/NixOS/nixpkgs/commit/10a27266f3405bdc7cc3d300c184b0b3324a001e) abook: 0.6.1 -> 0.6.2
* [`c62b7d9a`](https://github.com/NixOS/nixpkgs/commit/c62b7d9a0990996a8aac5e52d508eafae82e832d) python313Packages.publicsuffixlist: 1.0.2.20250617 -> 1.0.2.20250627
* [`965933e2`](https://github.com/NixOS/nixpkgs/commit/965933e299dec869793242a5eaed706ed36d1bc9) ical2orgpy: modernize
* [`314d8b7d`](https://github.com/NixOS/nixpkgs/commit/314d8b7d65b83379a8c79565167243ec6bfcc9ef) ical2orgpy: fix build
* [`08ad7252`](https://github.com/NixOS/nixpkgs/commit/08ad72526a75bab8020a59df7d34e06a82a07191) saga: 9.7.2 → 9.8.1
* [`70514821`](https://github.com/NixOS/nixpkgs/commit/7051482182e1f309d0f0f8db0c5ef6cddcef2512) python3Packages.coredis: 4.22.0 -> 4.23.1
* [`1bf0a5bd`](https://github.com/NixOS/nixpkgs/commit/1bf0a5bd750d9702d1d1da42336695b060198b5f) termshot: 0.5.0 -> 0.6.0
* [`bb190aa3`](https://github.com/NixOS/nixpkgs/commit/bb190aa37d9a0c62762edeed41971198d8c95142) papermc: 1.21.5-112 -> 1.21.6-47
* [`64ee068d`](https://github.com/NixOS/nixpkgs/commit/64ee068def931469131ac4b24e6dfb643a0de17f) scalafmt: 3.9.7 -> 3.9.8
* [`95e9de0a`](https://github.com/NixOS/nixpkgs/commit/95e9de0a49a86dd55cf5486697f0608e5427785c) python3Packages.pypdf: 5.6.0 -> 5.6.1
* [`4f459fd2`](https://github.com/NixOS/nixpkgs/commit/4f459fd2361bc8af059a63b4e39935d994791801) tup: Fix static build
* [`4471a6bb`](https://github.com/NixOS/nixpkgs/commit/4471a6bbc2797beb1f1999ceee61b286f2385609) atlas: 0.34.0 -> 0.35.0
* [`f505095a`](https://github.com/NixOS/nixpkgs/commit/f505095aaa1b75222628f812fd3b88f1b31cabba) cbmc: 6.6.0 -> 6.7.0
* [`fa40fc47`](https://github.com/NixOS/nixpkgs/commit/fa40fc47488b7766a9850e2a156d086eaec51842) python3Packages.blosc2: 3.4.0 -> 3.5.0
* [`591a9fba`](https://github.com/NixOS/nixpkgs/commit/591a9fba70f63dee3562d4dc325df846ab59214e) fawltydeps: init at 0.20.0
* [`af2ca0a5`](https://github.com/NixOS/nixpkgs/commit/af2ca0a571aa48877c4297d7d754dede30ed1d55) adrgen: 0.4.0-beta -> 0.4.1-beta
* [`b3cd8267`](https://github.com/NixOS/nixpkgs/commit/b3cd82673bbe1331050e3d06100e14ec0a152678) vscode-extensions.eamodio.gitlens: 17.2.0 -> 17.2.1
* [`2d02dc9f`](https://github.com/NixOS/nixpkgs/commit/2d02dc9fc19492c35e94c7419567e6991eefc16e) playwright: 1.52.0 -> 1.53.1
* [`af85613e`](https://github.com/NixOS/nixpkgs/commit/af85613eb47ac4a662834c3d3e717f009c346c93) playwright-mcp: init at 0.0.29
* [`b2c72c82`](https://github.com/NixOS/nixpkgs/commit/b2c72c82107914b9dfbf4a5a74baab9ef623788f) maintainers.aduh95: update key fingerprint
* [`f7bd0e60`](https://github.com/NixOS/nixpkgs/commit/f7bd0e6034fa4a03286e2b239503d8d9df480749) i-pi: 3.1.5 -> 3.1.5.1
* [`1d49e9d6`](https://github.com/NixOS/nixpkgs/commit/1d49e9d6c5cf0fb01dea87622f1e8687557513ab) vectorcode: mark as broken on aarch64-linux
* [`28889f56`](https://github.com/NixOS/nixpkgs/commit/28889f564163022c71b63258453f905399d5b21f) duplicity: 3.0.4.1 -> 3.0.5.1
* [`d7ebb03b`](https://github.com/NixOS/nixpkgs/commit/d7ebb03b7b4b3908e48ed83b8276d6532c172491) html2text: fix build with gettext 0.25
* [`f779a712`](https://github.com/NixOS/nixpkgs/commit/f779a712c2416be14838db1188071616ac0362f8) html2text: 2.2.3 -> 2.3.0
* [`b437d80d`](https://github.com/NixOS/nixpkgs/commit/b437d80d828f8adcb2a1fce2d5a7b66a57f1a35d) cargo-binstall: 1.12.7 -> 1.14.1
* [`08755e65`](https://github.com/NixOS/nixpkgs/commit/08755e655bafc33864bde9a3cb8bf49b5c777910) lxqt.lxqt-panel: 2.2.1 -> 2.2.2
* [`92574171`](https://github.com/NixOS/nixpkgs/commit/92574171b810d4130affe01fcec8b075ca40fdce) ladybird: 0-unstable-2025-06-18 -> 0-unstable-2025-06-27
* [`8af4b052`](https://github.com/NixOS/nixpkgs/commit/8af4b052d63e00a7f67f4ceaf78d37e43c6b9bbc) kdePackages.gwenview: add actual phonon video backend using vlc
* [`64ed234f`](https://github.com/NixOS/nixpkgs/commit/64ed234f0388bd6b1e6431e700490943ff399a62) mympd: 21.0.1 -> 22.0.0
* [`0bd96449`](https://github.com/NixOS/nixpkgs/commit/0bd9644980f93a786968332233bc9aff08a2b8e1) kanboard: 1.2.45 -> 1.2.46
* [`dc3fc254`](https://github.com/NixOS/nixpkgs/commit/dc3fc2545696774440ea084aa9178ca6c808f3ed) Reapply "speakersafetyd: 1.0.2 → 1.1.2; refactor package; add myself as maintainer"
* [`49f6d0ed`](https://github.com/NixOS/nixpkgs/commit/49f6d0edbed313d9d25f35e514adacafa3f94144) speakersafetyd: drop User=speakersafetyd line
* [`704946d2`](https://github.com/NixOS/nixpkgs/commit/704946d221d19d1bc309fb6644479035745a0583) neovim: add backward compatibility for luaRcContent in makeNeovimConfig
* [`f3ac88cc`](https://github.com/NixOS/nixpkgs/commit/f3ac88ccdfc40ddd0d1d96a15faa08d17fed6312) uv: 0.7.16 -> 0.7.17
* [`17dcdfc8`](https://github.com/NixOS/nixpkgs/commit/17dcdfc8f6b11f5f2dffbb8154969ce987b44a21) LycheeSlicer: fix runtime deps
* [`66df66ab`](https://github.com/NixOS/nixpkgs/commit/66df66ab2d8733a58bf6147af846809a0bb7bbbe) maintainers: add redlonghead
* [`23b57370`](https://github.com/NixOS/nixpkgs/commit/23b573705de96bf400a30d22bc195acb0763ac12) linux_6_{13,14}{,_hardened}: remove
* [`068033a1`](https://github.com/NixOS/nixpkgs/commit/068033a134504c4ca235694e31167e8bf22b625a) splitcode: 0.31.2 -> 0.31.3
* [`c2c36f69`](https://github.com/NixOS/nixpkgs/commit/c2c36f691231fbc655ba0d9a52cc1d863bbeda57) exegol: relax argcomplete
* [`f4c47d87`](https://github.com/NixOS/nixpkgs/commit/f4c47d873d7f926075ecf9fae823990f6326e8ef) nodejs_24: fix test
* [`4e473966`](https://github.com/NixOS/nixpkgs/commit/4e47396634a9321b2e14af7e12a5bc377848ddb9) marktext: fix typo
* [`e3180b76`](https://github.com/NixOS/nixpkgs/commit/e3180b7675e4aabdb425b24df02aa6271b4497c0) nixos/librenms: fix link
* [`f974807c`](https://github.com/NixOS/nixpkgs/commit/f974807cf8fbac7775d1b8a9dd40b3204c0dbaaa) bitrise: 2.31.2 -> 2.31.3
* [`5c6d52cb`](https://github.com/NixOS/nixpkgs/commit/5c6d52cb60dd873621b07f6cb126e79d85f5df18) gotify-server: remove Go reference
* [`7993b314`](https://github.com/NixOS/nixpkgs/commit/7993b314a4041577b9fcd0caaed70bd36a18b4f1) gojo: 0.3.2 -> 0.3.3
* [`96fb0d67`](https://github.com/NixOS/nixpkgs/commit/96fb0d676476fcb42bb2e7429f37af5e2d490c74) got: 0.113 -> 0.115
* [`c757b757`](https://github.com/NixOS/nixpkgs/commit/c757b757a98e2a2c135799d937e389dcfdc2cf99) guacamole-server: unbreak, update CFLAGS
* [`159dc242`](https://github.com/NixOS/nixpkgs/commit/159dc242d51ffda5690236780db6f6fa1546a89f) guacamole-server: 1.6.0-unstable-2025-05-16 -> 1.6.0-unstable-2025-06-29
* [`6b019372`](https://github.com/NixOS/nixpkgs/commit/6b019372dad828b933d6f51cada71651fa91f6a1) pik: 0.24.0 -> 0.25.0
* [`747b83f4`](https://github.com/NixOS/nixpkgs/commit/747b83f4768f39cdb00b35a88539a8cd32d43e22) rspamd: 3.12.0 -> 3.12.1
* [`6e1cd10a`](https://github.com/NixOS/nixpkgs/commit/6e1cd10adb8b0c6e94822d66e1e8bfc1274884cc) nixos/networkmanager: clean up plugin handling
* [`c6eb8431`](https://github.com/NixOS/nixpkgs/commit/c6eb84310af667b270b4a07095ce955639fbfaf2) networkmanager: drop hard dependency on openconnect
* [`1c031e14`](https://github.com/NixOS/nixpkgs/commit/1c031e147482b3a77402a850c549779da9ff1a43) burpsuite: 2025.6.1 -> 2025.6.2
* [`96cb06e8`](https://github.com/NixOS/nixpkgs/commit/96cb06e818eb92132ec1648ce1ead9ed95b8158d) sherlock-launcher: 0.1.13-hotfix-1 -> 0.1.13-hotfix-2
* [`772b4721`](https://github.com/NixOS/nixpkgs/commit/772b47210b4fc0ce66e7cf13562c0fa3d8eab22e) python3Packages.google-cloud-artifact-registry: 1.16.0 -> 1.16.1
* [`d5253e3c`](https://github.com/NixOS/nixpkgs/commit/d5253e3ca73eee3efb24a85f51db022bc7688148) ntfs2btrfs: 20240115 -> 20250616
* [`b5999bad`](https://github.com/NixOS/nixpkgs/commit/b5999bad15d9d22f7e8ccca98a125b50bea1bbf8) podofo: 1.0.0 -> 1.0.1
* [`80e74d26`](https://github.com/NixOS/nixpkgs/commit/80e74d26a5a4a23c6076643914ecb70ed2208b8c) grafana-alloy: 1.9.1 -> 1.9.2
* [`b67eea73`](https://github.com/NixOS/nixpkgs/commit/b67eea736b87a6e42f9a99171d0337e975060933) python3Packages.duckdb-engine: disable tests that break only under nixpkgs-review
* [`16be21b1`](https://github.com/NixOS/nixpkgs/commit/16be21b1e4f42809abdcf4714eb34e58690f8cf3) python3Packages.pytest-cases: 3.8.6 -> 3.9.1
* [`77db71b3`](https://github.com/NixOS/nixpkgs/commit/77db71b32d3b586c8a117d8f62332abea315ba79) libretro.puae: 0-unstable-2025-05-24 -> 0-unstable-2025-06-14
* [`0bd247ff`](https://github.com/NixOS/nixpkgs/commit/0bd247ffb5a539a71e984fba5632bbb053a671d1) maintainers: add Peter3579
* [`337a911d`](https://github.com/NixOS/nixpkgs/commit/337a911d3ba44bcabaeb560ddac3ed622a462a14) python3Packages.control: init at 0.10.1
* [`825abd1d`](https://github.com/NixOS/nixpkgs/commit/825abd1d7102649666f53fa75196bd72dd683567) python3Packages.model-checker: 0.9.21 -> 0.9.26
* [`382ae5ce`](https://github.com/NixOS/nixpkgs/commit/382ae5ceba97e95148324073676f8aa697ae217c) tplay: 0.6.0 -> 0.6.l3
* [`0db7aecc`](https://github.com/NixOS/nixpkgs/commit/0db7aecca9c682550246c73a32e7afd8d2eb342a) python3Packages.pyezvizapi: 1.0.0.9 -> 1.0.1.0
* [`b2c793fa`](https://github.com/NixOS/nixpkgs/commit/b2c793fa16072a604e77836a02f072d0b3ebcfa9) ps3-disc-dumper: 4.3.6 -> 4.3.9
* [`1d783b5f`](https://github.com/NixOS/nixpkgs/commit/1d783b5fd2a128b313245fabd1f8827d9b8ebc6f) hcdiag: 0.5.7 -> 0.5.8
* [`f03c9c2e`](https://github.com/NixOS/nixpkgs/commit/f03c9c2ec1a19bd11d90dde4b1aa86f84ad8cd9c) python3Packages.glyphslib: 6.10.3 -> 6.11.0
* [`81893394`](https://github.com/NixOS/nixpkgs/commit/8189339445c4ab5ee3ea9422af62b4cdcf438bea) bibiman: 0.12.3 -> 0.12.4
* [`b0971f95`](https://github.com/NixOS/nixpkgs/commit/b0971f959e0be1800f031a6cadc6a2d4052d6793) calico-apiserver: 3.30.1 -> 3.30.2
* [`25a42e24`](https://github.com/NixOS/nixpkgs/commit/25a42e247c1648ea4ab22c4c244ee5ccaa2bdb80) python3Packages.robotframework-databaselibrary: 2.0.4 -> 2.1.3
* [`59259912`](https://github.com/NixOS/nixpkgs/commit/592599120c6091e01d0353b8bb2feac0e92534ab) python3Packages.cf-xarray: 0.10.5 -> 0.10.6
* [`aebd0b42`](https://github.com/NixOS/nixpkgs/commit/aebd0b42c765bd0ba7a63919670fe3dd61444ac4) python313Packages.flashinfer: Respect NIX_BUILD_CORES
* [`24a74cc5`](https://github.com/NixOS/nixpkgs/commit/24a74cc56223a9fee3010319e99fa1de7d367934) buf: use finalAttrs
* [`eb11b0b0`](https://github.com/NixOS/nixpkgs/commit/eb11b0b07220b1f636c7774916de7630aef53810) deepin.dde-shell: fix qml models import in qt 6.9
* [`6d5153e7`](https://github.com/NixOS/nixpkgs/commit/6d5153e727b6420f72b6fd2d6fa99fee4bf86bc2) autocorrect: add definfo as maintainer
* [`0f53b015`](https://github.com/NixOS/nixpkgs/commit/0f53b0157532f28a02a1d85cd9a2b549ae38affe) autocorrect: 2.14.0 -> 2.14.1
* [`0db6182d`](https://github.com/NixOS/nixpkgs/commit/0db6182d1a9557e81b061eda85a249e1ba911943) skim: 0.20.1 -> 0.20.2
* [`8121260f`](https://github.com/NixOS/nixpkgs/commit/8121260fd3cff9095cfa37c732de657e08cae453) jellyfin-tui:1.1.3->1.2.1
* [`15f247e5`](https://github.com/NixOS/nixpkgs/commit/15f247e52531102f51f3c19aab3e2eb5f1988316) release-cuda: add flashinfer
* [`3efba99a`](https://github.com/NixOS/nixpkgs/commit/3efba99a6dfed75dbf030b783a9195c0af16dcb4) warp-terminal: 0.2025.06.20.22.47.stable_05 -> 0.2025.06.25.08.12.stable_01
* [`2797d4ac`](https://github.com/NixOS/nixpkgs/commit/2797d4ac87aa356ce85d4fe02706eb574464968f) python313Packages.model-checker: 0.9.21 -> 0.9.26
* [`ccdca43d`](https://github.com/NixOS/nixpkgs/commit/ccdca43d80049e228f41b2a4159b704129b1a1be) nixos/networkmanager: drop default plugin list and toggle
* [`1771336a`](https://github.com/NixOS/nixpkgs/commit/1771336abe0d4899737c08039af2ce4a7c9f6648) coqPackages.interval: 4.11.1 -> 4.11.2
* [`0619df71`](https://github.com/NixOS/nixpkgs/commit/0619df716ed738e1818532bc6fd74c701a92f572) gh-signoff: init at 0.2.1
* [`d74a76be`](https://github.com/NixOS/nixpkgs/commit/d74a76be1d3332ecc506a4808f70d1047fc34476) llvmPackages_git: 21.0.0-unstable-2025-06-22 -> 21.0.0-unstable-2025-06-29
* [`e0a26159`](https://github.com/NixOS/nixpkgs/commit/e0a2615997529a925a46737c950f53255907815f) rundeck: 5.12.0 -> 5.13.0
* [`e7da11c8`](https://github.com/NixOS/nixpkgs/commit/e7da11c8e203d5dd37fde969b8ea568bfa905b8c) vscode-extensions.ms-toolsai.jupyter: 2025.4.1 -> 2025.5.0
* [`3c434141`](https://github.com/NixOS/nixpkgs/commit/3c4341417760d50588eca0926f29290cd411ee4b) maintainers.shadowrz: update key fingerprint
* [`19e48692`](https://github.com/NixOS/nixpkgs/commit/19e4869241080cea1a831a05c0298b61de944695) coqPackages.*: better formatting fix
* [`a63477fc`](https://github.com/NixOS/nixpkgs/commit/a63477fc0ee93993d00b85869af97209f9d687b6) python312Packages.wgpu-py: 0.21.1 -> 0.22.1
* [`64b8938f`](https://github.com/NixOS/nixpkgs/commit/64b8938f0b39acdffb5d5f8c22933e436796efa9) python3Packages.wgpu-py: combine passthru tests into one `installCheckPhase`
* [`10634730`](https://github.com/NixOS/nixpkgs/commit/1063473001bb85bf3af2fe21f3a76011ea8c558b) release.nix: pass lib-tests to tarball
* [`a61841a5`](https://github.com/NixOS/nixpkgs/commit/a61841a597730a4ec18be3f87a257a3989e629dd) nixVersions.nix_2_3: add knownVulnerabilities
* [`34927b9e`](https://github.com/NixOS/nixpkgs/commit/34927b9ea34c33864aef03c0e38352cb3aa76da1) tooling-language-server: rename to deputy, 0.5.0 -> 0.6.0
* [`dcacba48`](https://github.com/NixOS/nixpkgs/commit/dcacba484d1e5b36a9166329258a860a2c62b24e) deputy: use finalAttrs
* [`cbec9819`](https://github.com/NixOS/nixpkgs/commit/cbec98198257fa7dd6e4f34725ffbef18a8967fe) python3Packages.wgpu-py: 0.22.1 -> 0.22.2
* [`1ef7d632`](https://github.com/NixOS/nixpkgs/commit/1ef7d63228898f5b04019b8f3883f4d2f58f81cf) nixos/installer: ship the minimal ISO with networkmanager
* [`5d4762f8`](https://github.com/NixOS/nixpkgs/commit/5d4762f8ffebe6c0492228971e66475d841b62aa) source-meta-json-schema: 9.3.7 -> 9.4.0
* [`806e0c71`](https://github.com/NixOS/nixpkgs/commit/806e0c719dc816abd138029390f29f5376d4dd9c) parallel-disk-usage: 0.11.1 -> 0.12.0
* [`56b9f694`](https://github.com/NixOS/nixpkgs/commit/56b9f694dd4162fdd557125f87b1af3730bbabac) python313Packages.basswood-av: use cython_3_1
* [`c8dd817b`](https://github.com/NixOS/nixpkgs/commit/c8dd817b958789540bec06033a519eee00e87438) electron-source.electron_37: init at 37.1.0
* [`dae22835`](https://github.com/NixOS/nixpkgs/commit/dae2283583ee83f2dd1aa1d6b3154c459aee7457) electron_37-bin: init at 37.1.0
* [`a36c45a4`](https://github.com/NixOS/nixpkgs/commit/a36c45a4c396c56f17eb1b0509cfec30e672d8cd) electron-chromedriver_37: init at 37.1.0
* [`d923eaab`](https://github.com/NixOS/nixpkgs/commit/d923eaab472f6cbb6c68fc876686c2d25cc041fc) obs-studio: 31.0.3 -> 31.0.4
* [`8bfedc94`](https://github.com/NixOS/nixpkgs/commit/8bfedc94de139c97b93b0cb22a59793299d98df0) path-of-building.data: 2.54.0 -> 2.55.1
* [`c8ca6341`](https://github.com/NixOS/nixpkgs/commit/c8ca634107be32a9fa32e860cb3741ac5546ac52) duplicati: 2.1.0.2 -> 2.1.0.5
* [`0fc73e51`](https://github.com/NixOS/nixpkgs/commit/0fc73e51010df0e889ad7a0cc8a24ab78ac11e92) nixos/duplicati: add parameters-file option
* [`d2a7d406`](https://github.com/NixOS/nixpkgs/commit/d2a7d4065042073387ad319f2c1511a22d04f617) nixos/sourcehut,sourcehut.*,nixosTests.sourcehut: drop
* [`fb0ea04e`](https://github.com/NixOS/nixpkgs/commit/fb0ea04eb0fc6ab88fe353551cb65f52071c6d3c) hyprshell: 4.2.13 -> 4.5.0
* [`d01fb762`](https://github.com/NixOS/nixpkgs/commit/d01fb762053157aa2f53ef3be5bad8bc0c7ff677) dbeaver-bin: change JDK version to 21
* [`98105980`](https://github.com/NixOS/nixpkgs/commit/98105980f1fb3341d58ceb09421bc1621e3d7266) markdown-oxide: 0.25.2 -> 0.25.3
* [`1f73b45f`](https://github.com/NixOS/nixpkgs/commit/1f73b45f6cfe0e335074a27f475a959ac51e5ba7) ntpd-rs: 1.5.0 -> 1.6.0
* [`f2db9d43`](https://github.com/NixOS/nixpkgs/commit/f2db9d43d081ade183a5a44fe134b4e9895a74ac) python3Packages.coiled: 1.103.1 -> 1.106.0
* [`7321d5dc`](https://github.com/NixOS/nixpkgs/commit/7321d5dc7b0b2722d03c67bc8851acd014ec446c) coqPackages.*: fix formatting fix
* [`117f6739`](https://github.com/NixOS/nixpkgs/commit/117f67390dd93fed2659afb55608fe8d038364f3) trezor-suite: 25.6.2 -> 25.6.3
* [`83ccb485`](https://github.com/NixOS/nixpkgs/commit/83ccb4858ced8bea413d63d031d282cf307d8784) netsurf-browser: add fgaz to maintainers
* [`52d3d406`](https://github.com/NixOS/nixpkgs/commit/52d3d40668db6d7d0582678150f849841fc77151) dillo: add fgaz to maintainers
* [`11c5ba81`](https://github.com/NixOS/nixpkgs/commit/11c5ba8107f031783f337967f92c29895c24319e) tclPackages.rl_json: 0.15.2 -> 0.15.3
* [`a785bf33`](https://github.com/NixOS/nixpkgs/commit/a785bf33ca43c2628c86589dd07fc540f3661c56) libphonenumber: add wegank as maintainer
* [`91a31867`](https://github.com/NixOS/nixpkgs/commit/91a31867a6f8b45a165011c6ad1d7d43ef9a4abd) waybar: fix crash when tray element has no default icon
* [`41c3c329`](https://github.com/NixOS/nixpkgs/commit/41c3c329c87e3581b2737fc81a29fd82956bb25e) nixos/gitea: loosen SENDMAIL_PATH type
* [`efe41063`](https://github.com/NixOS/nixpkgs/commit/efe41063621975680bea6beab224e15e83ce00bc) python3Packages.html-sanitizer: 2.4.4 -> 2.6
* [`b11bdcdd`](https://github.com/NixOS/nixpkgs/commit/b11bdcdd4bf4b7e287d4827fbe42f1e11374d02c) paisa: init at 0.7.3
* [`ac91c755`](https://github.com/NixOS/nixpkgs/commit/ac91c7554d357364d5c9cf633bc88c0d470713cf) webcord-vencord: bump electron to `electron_36`
* [`312015ea`](https://github.com/NixOS/nixpkgs/commit/312015eaafbc3af80571bd68c465a6929cf710de) networkmanager-strongswan: rename from networkmanager_strongswan
* [`b2c4e0a6`](https://github.com/NixOS/nixpkgs/commit/b2c4e0a6cbbd4779f3041ea29b256008638d6658) gdevelop: 5.5.231 -> 5.5.233
* [`677a5b34`](https://github.com/NixOS/nixpkgs/commit/677a5b34d5e0091e52663d60e5feba1527351a71) hoppscotch: 25.5.3-0 -> 25.6.0-0
* [`b7188305`](https://github.com/NixOS/nixpkgs/commit/b7188305480b3d6c5b48466d33d8f2b688525ebf) lean4: 4.20.0 -> 4.21.0
* [`693146c3`](https://github.com/NixOS/nixpkgs/commit/693146c3ffe563152dff30b350fa22572df5f783) scalingo: 1.35.0 -> 1.35.1
* [`a087a576`](https://github.com/NixOS/nixpkgs/commit/a087a5760b89244c19505541f5ca060e712634b8) libressl_4_1: init at 4.1.0
* [`928af85c`](https://github.com/NixOS/nixpkgs/commit/928af85c843949d065fe7ef242471af5cd0b1948) libressl: 4.0.0 -> 4.1.0
* [`185eba31`](https://github.com/NixOS/nixpkgs/commit/185eba3148723d34716e2773481c91d1cd1a25b1) nixos/ntpd-rs: Validate the `ntpd-rs.toml` file
* [`5e448789`](https://github.com/NixOS/nixpkgs/commit/5e44878981b496b56a15e89f6e3499fb1cd71dbf) open-policy-agent: 1.5.1 -> 1.6.0
* [`d095a566`](https://github.com/NixOS/nixpkgs/commit/d095a566cb540297d6117c4706f8b135345e3e43) nixos/release-notes: Add note about `ntpd-rs` configuration validation
* [`6ce69de6`](https://github.com/NixOS/nixpkgs/commit/6ce69de6e0c39808e2b1ff6928d0b4cee7dc7a5f) mmc-utils: unstable-2024-03-07 -> 1.0
* [`64e4a742`](https://github.com/NixOS/nixpkgs/commit/64e4a7426bbe08621afb7ac21c930c52bee45d79) nexusmods-app: remove copyDesktopItems hook
* [`437f2274`](https://github.com/NixOS/nixpkgs/commit/437f2274265d3e4d672ce01dab4b6c8a84a5cee1) cpp-jwt: 1.4 -> 1.5
* [`05688076`](https://github.com/NixOS/nixpkgs/commit/05688076f424e3d517ae2406a74b708fdee872a1) libtorrent: 0.15.4 -> 0.15.5
* [`54c298cc`](https://github.com/NixOS/nixpkgs/commit/54c298cc6a148c7ee45ce861cb20730e865b43da) libxml2: Fix MinGW Build
* [`b67cacfb`](https://github.com/NixOS/nixpkgs/commit/b67cacfb674252c1eac39030d3dd7a0df4a6e6db) python3Packages.aider-chat: update homepage
* [`0a335036`](https://github.com/NixOS/nixpkgs/commit/0a335036b15e3747e4d27aec314c0232cbc20503) python3Packages.aider-chat: 0.84.0 -> 0.85.0
* [`752706cc`](https://github.com/NixOS/nixpkgs/commit/752706cc274d22aa73d25b22736de602863fe7ae) python3Packages.ase: cleanup, skip failing test
* [`bda38818`](https://github.com/NixOS/nixpkgs/commit/bda38818c2ea75169d6960f6448a416aa0d47331) vulkan-hdr-layer-kwin6: remove
* [`f0e5b23a`](https://github.com/NixOS/nixpkgs/commit/f0e5b23a086311a52bb03691ee13f1b234902724) python3Packages.pytensor: 2.31.4 -> 2.31.5
* [`3283056c`](https://github.com/NixOS/nixpkgs/commit/3283056c2b98fd8cacc632f0916f17e86f036562) nextcloud31Packages.apps.recognize: more cleanup
* [`2bd9e401`](https://github.com/NixOS/nixpkgs/commit/2bd9e401fd3945dedc91c423e0c372412e9e21e5) nextcloud31Packages.apps.memories: package by hand to remove pre-compiled binaries
* [`7255241a`](https://github.com/NixOS/nixpkgs/commit/7255241a519ca50e5bd9453cf59d625da9f2bcc0) privatebin: 1.7.6 -> 1.7.8
* [`36b693e4`](https://github.com/NixOS/nixpkgs/commit/36b693e407d53c938ab7d8216366cac34e17c282) qlementine-icons: 1.9.0 -> 1.10.0
* [`56457dba`](https://github.com/NixOS/nixpkgs/commit/56457dba070b71a36732248dc5188cc934fe239c) pakku: init at 1.2.1
* [`9af9a433`](https://github.com/NixOS/nixpkgs/commit/9af9a433887f0ffc07a4b33a6de3471e134ecb2d) unison-ucm: 0.5.41 -> 0.5.42
* [`e9efb424`](https://github.com/NixOS/nixpkgs/commit/e9efb4240e3ca7b56b2ebeded8980128e192fe1c) nixos/nix-{gc,optimise}: do not start when switching
* [`ccfe8307`](https://github.com/NixOS/nixpkgs/commit/ccfe830713908b04d7136dcc400a2b85818cddd6) gotify-server: modernize
* [`895138d1`](https://github.com/NixOS/nixpkgs/commit/895138d1b7131e15b5103587341d7c16ba70f5c6) gotify-server.ui: modernize
* [`b9d7717e`](https://github.com/NixOS/nixpkgs/commit/b9d7717e141ef188586b254148e00f6846ea8e1c) cosmic-protocols: 0-unstable-2025-06-19 -> 0-unstable-2025-06-24
* [`255345fd`](https://github.com/NixOS/nixpkgs/commit/255345fde55b1d00d650f7d3965c21dbf6fe207a) nak: 0.14.2 -> 0.14.4
* [`0b4733d8`](https://github.com/NixOS/nixpkgs/commit/0b4733d8e3ad49e1397c67a4cad327560937a2b8) nexusmods-app: refactor desktop entry template
* [`4c7425d1`](https://github.com/NixOS/nixpkgs/commit/4c7425d144505a3f93f52a58a8f66131bf9bae63) oku: init at 0.1.1
* [`5099a914`](https://github.com/NixOS/nixpkgs/commit/5099a914b88dbbedbc476f45578974246b91010f) nexusmods-app: set INSTALL_TRYEXEC in desktop entry
* [`8d70e895`](https://github.com/NixOS/nixpkgs/commit/8d70e8957ef0e3733d38fa09ce759980c01302c5) nexusmods-app: validate desktop entry
* [`157088eb`](https://github.com/NixOS/nixpkgs/commit/157088ebef33a00c323d12cfa3cffd873325ac1c) python3Packages.msgraph-sdk: 1.34.0 -> 1.35.0
* [`959c4eaa`](https://github.com/NixOS/nixpkgs/commit/959c4eaa0ee102ff1d8f90a058500a069d127016) mongodb-ce: 8.0.4 -> 8.0.11
* [`afa62a5f`](https://github.com/NixOS/nixpkgs/commit/afa62a5f50fc3da13245110142a2b06458c906c5) ruffle: 0-nightly-2025-06-21 -> 0-nightly-2025-06-30
* [`7db138cd`](https://github.com/NixOS/nixpkgs/commit/7db138cd3f949a141b94a081066e1f4d6860d552) signalbackup-tools: 20250626 -> 20250630-2
* [`408743fa`](https://github.com/NixOS/nixpkgs/commit/408743fa90e5939993807d8363a5a44205ee7624) vault-bin: 1.19.5 -> 1.20.0
* [`1c462c7c`](https://github.com/NixOS/nixpkgs/commit/1c462c7cb4afc57e05482f658ce28383cd7a675e) forgejo-runner: 6.3.1 -> 6.4.0
* [`057affe5`](https://github.com/NixOS/nixpkgs/commit/057affe59d66940c3933a2a50b899aa55c8d58e9) nixos-rebuild-ng: improve error message on CalledProcessError
* [`12319d98`](https://github.com/NixOS/nixpkgs/commit/12319d98674cf9426d0eababe66e75ce4102ebed) sudo: 1.9.17 -> 1.9.17p1
* [`39b0485b`](https://github.com/NixOS/nixpkgs/commit/39b0485b23a6af93784b9ee7b672a7320a23184c) vacuum-go: 0.17.0 -> 0.17.1
* [`9bac0fac`](https://github.com/NixOS/nixpkgs/commit/9bac0fac14835bc0c6abc3ae59f0d2988e0b0e69) python3Packages.dowhen: init at 0.1.0
* [`ab2dc5c3`](https://github.com/NixOS/nixpkgs/commit/ab2dc5c3f959b945b7d8dff5b59f69b58e06c18d) nixos/prometheus-wireguard-exporter: add support for new flags
* [`c5d6abc2`](https://github.com/NixOS/nixpkgs/commit/c5d6abc24e1e281c11a4be0067568c8135364f06) wezterm: 0-unstable-2025-05-18 -> 0-unstable-2025-06-24
* [`c8fba3af`](https://github.com/NixOS/nixpkgs/commit/c8fba3af158a92a4579ea35b85402d6c0f372d4e) prometheus-blackbox-exporter: 0.26.0 -> 0.27.0
* [`6428b68a`](https://github.com/NixOS/nixpkgs/commit/6428b68ae5b70e602c9143f7462a18c52f669664) libslirp: 4.9.0 -> 4.9.1
* [`b0ed1e14`](https://github.com/NixOS/nixpkgs/commit/b0ed1e14d1634e83aa68747a422d2a69bf064b74) dotnet_{8,9}.stage0.vmr: fix build failure due to compiler optimizations
* [`0dc4b8e9`](https://github.com/NixOS/nixpkgs/commit/0dc4b8e99b1f8474798fdb5fc0fe62036af79461) pgadmin: 9.4 -> 9.5
* [`1171fe85`](https://github.com/NixOS/nixpkgs/commit/1171fe85c875f1a99f86fd37a8aade563e058737) python3Packages.gcal-sync: 7.1.0 -> 7.2.0
* [`6f94f95f`](https://github.com/NixOS/nixpkgs/commit/6f94f95fcadf38d871c315771ee0d66f222138f8) python3Packages.holoviews: fix test breakage
* [`268f3732`](https://github.com/NixOS/nixpkgs/commit/268f3732e15850a9f99020bf9e29b34a6409e584) ocaml-augeas: update download URLs for debian patches
* [`9a75e59a`](https://github.com/NixOS/nixpkgs/commit/9a75e59aec73c62a8d136c4ef8b1f92a7a613c28) ctags-lsp: 0.6.1 -> 0.7.0
* [`69d0b7c9`](https://github.com/NixOS/nixpkgs/commit/69d0b7c9f9f1a44bfeebb779100d3963875fd557) cimg: 3.5.4 -> 3.5.5
* [`e77213e7`](https://github.com/NixOS/nixpkgs/commit/e77213e7dae8dbbb0891a69449a8b0cbe322059f) ocamlPackages.argon2: init at 1.0.2
* [`ef6f34ec`](https://github.com/NixOS/nixpkgs/commit/ef6f34ec9d429959bda626a25225d52d161451f6) pypy3Packages.celery.tests: fix the eval
* [`e256fd4e`](https://github.com/NixOS/nixpkgs/commit/e256fd4e6e36c31329e15e9867c9333964760cca) htslib: 1.21 -> 1.22
* [`78b3dd59`](https://github.com/NixOS/nixpkgs/commit/78b3dd59f42686aceef4ee40dea92fadab65da48) firefox-devedition-unwrapped: 141.0b2 -> 141.0b4
* [`23470836`](https://github.com/NixOS/nixpkgs/commit/23470836ddd46de9f2a87175ddd4ce8e68277f34) firefox-beta-unwrapped: 141.0b2 -> 141.0b4
* [`a0d3df39`](https://github.com/NixOS/nixpkgs/commit/a0d3df39a9d1d1d8dfc460141e999fa8ef0dd218) sourcepawn-studio: 8.1.6 -> 8.1.7
* [`5bacb03a`](https://github.com/NixOS/nixpkgs/commit/5bacb03aeabe9f57238a2b66b72220e761596691) komac: 2.12.0 -> 2.12.1
* [`7b4ae952`](https://github.com/NixOS/nixpkgs/commit/7b4ae952768d24693bfcffe4e90b729ebb129cd9) proxmark3: 4.20142 -> 4.20469
* [`f4fb03b8`](https://github.com/NixOS/nixpkgs/commit/f4fb03b8e6153d28a9e28f6a7bd283ce78599fcc) chromium,chromedriver: 138.0.7204.49 -> 138.0.7204.92
* [`114fa50a`](https://github.com/NixOS/nixpkgs/commit/114fa50a1e2d14068e66969c5f75331b28a18550) python312Packages.geotorch: init at 0.3.0
* [`9e9c66ef`](https://github.com/NixOS/nixpkgs/commit/9e9c66ef3665990320a4d76261ba58d393408bda) lxqt.lxqt-build-tools: 2.2.0 -> 2.2.1
* [`26c306a0`](https://github.com/NixOS/nixpkgs/commit/26c306a0c4e26b78db226f178e766beebd20018d) lxqt.lxqt-powermanagement: 2.2.0 -> 2.2.1
* [`86973f69`](https://github.com/NixOS/nixpkgs/commit/86973f69ae3cfebca048c5bf3baa83b0dde13df0) docker-compose: 2.37.1 -> 2.38.1
* [`74a86de1`](https://github.com/NixOS/nixpkgs/commit/74a86de1216b0b57d413d7df065de69ce165e4d4) ecapture: 1.2.0 -> 1.3.1
* [`99ed3aee`](https://github.com/NixOS/nixpkgs/commit/99ed3aeed2c54451c6df5ebd581f082f38037617) python3Packages.wandb: disable broken/flaky tests
* [`62c7c26d`](https://github.com/NixOS/nixpkgs/commit/62c7c26d4d76643c2d0b8b075397344da8e17530) libretro.beetle-psx: 0-unstable-2025-06-20 -> 0-unstable-2025-06-27
* [`1258e0b5`](https://github.com/NixOS/nixpkgs/commit/1258e0b56774c549e72a471364e05913528f971e) graphite-cli: 1.6.5 -> 1.6.6
* [`88806357`](https://github.com/NixOS/nixpkgs/commit/888063577c3fe3f8716effeee8c9d07e247b07b8) terraform-mcp-server: init at v0.1.0
* [`4f1afea6`](https://github.com/NixOS/nixpkgs/commit/4f1afea63c71dd32954b75e92bcaf4718dd9e871) peergos: 1.6.0 -> 1.7.1
* [`96fdc4b5`](https://github.com/NixOS/nixpkgs/commit/96fdc4b5c2f8de5766892ebf14fd517c27bb63ab) clouddrive2: 0.9.0 -> 0.9.1
* [`87303dd6`](https://github.com/NixOS/nixpkgs/commit/87303dd69df13a48aa31531c7b20cf2f724c3e47) tigerbeetle: 0.16.45 -> 0.16.47
* [`e0b8a357`](https://github.com/NixOS/nixpkgs/commit/e0b8a3577fc453f19d03a8d129abb134cac6187b) oci-cli: 3.59.0 -> 3.61.0
* [`0cbbfde2`](https://github.com/NixOS/nixpkgs/commit/0cbbfde211e6158c1b992a99067f697fd6fe3c3c) aarch64-esr-decoder: 0.2.3 -> 0.2.4
* [`fa037315`](https://github.com/NixOS/nixpkgs/commit/fa037315d03bf4dfd749962fa460ee3c5e624637) phpExtensions.blackfire: 1.92.38 -> 1.92.39
* [`2d3f4f41`](https://github.com/NixOS/nixpkgs/commit/2d3f4f410db3182854194e37ce199e09edbe88e6) alterware-launcher: 0.11.2 -> 0.11.3
* [`067f317f`](https://github.com/NixOS/nixpkgs/commit/067f317fe6ba44f417c556155afe15ffd8dae015) zed-editor: 0.192.7 -> 0.192.8
* [`21963fd6`](https://github.com/NixOS/nixpkgs/commit/21963fd6602180da8fb9ebdd6175e4e33a59053b) grpc-client-cli: 1.22.3 -> 1.22.4
* [`983537d0`](https://github.com/NixOS/nixpkgs/commit/983537d007ca4bbe6149361bf1eec6a08d1f46b9) jreleaser-cli: 1.18.0 -> 1.19.0
* [`834d5f26`](https://github.com/NixOS/nixpkgs/commit/834d5f2646e791b20aaa58ace31fc4ba475c12a3) juicity: 0.4.3 -> 0.5.0
* [`9ff63870`](https://github.com/NixOS/nixpkgs/commit/9ff638701ea5786359a13c32c376153e1959fc68) maintainers/README.md: encourage notifying maintainers
* [`0685b14a`](https://github.com/NixOS/nixpkgs/commit/0685b14ae07b2ff7f859d82171cd664cae4c6084) gobuster: 3.6.0 -> 3.7.0
* [`a8502f89`](https://github.com/NixOS/nixpkgs/commit/a8502f891cbcee904ca7f2e353e2b0943e50603a) proton-ge-bin: GE-Proton10-4 -> GE-Proton10-7
* [`a8332982`](https://github.com/NixOS/nixpkgs/commit/a8332982de322b0529ce00af62f534d3e663d05d) libxlsxwriter: 1.2.2 -> 1.2.3
* [`57177df8`](https://github.com/NixOS/nixpkgs/commit/57177df8c650a0ccff892b76516371fc14149f94) omnom: mv omnom-addons to passthru
* [`a5ecf849`](https://github.com/NixOS/nixpkgs/commit/a5ecf849c51e78254a28580e9ee14febadfe3eba) omnom: install addons in postInstall
* [`e5566b5e`](https://github.com/NixOS/nixpkgs/commit/e5566b5ec572f39a9836748ce117401fc6f0067a) cargo-codspeed: 2.10.1 -> 3.0.1
* [`db462ff6`](https://github.com/NixOS/nixpkgs/commit/db462ff67ebd4457105357486d3f8a784adf08b0) omnom: fix firefox extension
* [`d7eb9384`](https://github.com/NixOS/nixpkgs/commit/d7eb93843091c469a7adfdc0a306dc2fc05a5c52) cloak-pt: 2.10.0 -> 2.11.0
* [`2828cacf`](https://github.com/NixOS/nixpkgs/commit/2828cacf28b256a55e5f361f3da1a5a8318686e2) python3Packages.slepc4py: 3.23.1 -> 3.23.2
* [`99d935c4`](https://github.com/NixOS/nixpkgs/commit/99d935c49c2bb760ee3fa35138761a3f13a1b060) cargo-chef: 0.1.71 -> 0.1.72
* [`e34775b6`](https://github.com/NixOS/nixpkgs/commit/e34775b6a1519b0c488ad2613822a900c6cce1e2) qt6: prevent Xcode version sniffing
* [`567bf4b7`](https://github.com/NixOS/nixpkgs/commit/567bf4b742adc070c14c4ad82b61147b06692974) sheldon: 0.8.2 -> 0.8.3
* [`2b98432e`](https://github.com/NixOS/nixpkgs/commit/2b98432eab9f027eb7c373997895503e19575bee) claude-code: 1.0.35 -> 1.0.38
* [`f31f1bf1`](https://github.com/NixOS/nixpkgs/commit/f31f1bf19c69c0637d39e8d83db4a0073d98c344) redis: 7.2.7 -> 8.0.2
* [`53dbf23d`](https://github.com/NixOS/nixpkgs/commit/53dbf23df1df0d676563052edafc69d4aa9251ea) path-of-building.data: 2.55.1 -> 2.55.2
* [`46a0414d`](https://github.com/NixOS/nixpkgs/commit/46a0414dbc066d21966b8180bfd1676d7522012e) openvas-scanner: 23.20.1 -> 23.20.2
* [`d7d0c4e1`](https://github.com/NixOS/nixpkgs/commit/d7d0c4e12d5e245a110e43fcebd3a6685782ab6a) zsh-forgit: 25.06.0 -> 25.07.0
* [`51143e2b`](https://github.com/NixOS/nixpkgs/commit/51143e2b5f9ae7d6276c729b58c8fe4954ee6220) patch2pr: 0.35.0 -> 0.36.0
* [`e0e88494`](https://github.com/NixOS/nixpkgs/commit/e0e8849436f7fc352a540d4ccffa76fa4daf9b41) emmet-language-server: don't depend on environment's node
* [`501ab4ff`](https://github.com/NixOS/nixpkgs/commit/501ab4ff9ed3163fd0d948bf1e2dc10e4996717b) fishPlugins.forgit: 25.06.0 -> 25.07.0
* [`47935ee0`](https://github.com/NixOS/nixpkgs/commit/47935ee04fb547908b6e0daeaeea70a156da2096) stress-ng: 0.19.01 -> 0.19.02
* [`108d063e`](https://github.com/NixOS/nixpkgs/commit/108d063ec154e7bccf68cea0934e36decb6bdf5e) zsh-autosuggestions-abbreviations-strategy: 1.1.1 -> 1.1.2
* [`2f067f99`](https://github.com/NixOS/nixpkgs/commit/2f067f99de6b1ac2b2975ea8d4b2094666164c61) mergiraf: 0.10.0 -> 0.11.0 ([nixos/nixpkgs⁠#421279](https://togithub.com/nixos/nixpkgs/issues/421279))
* [`7f44452c`](https://github.com/NixOS/nixpkgs/commit/7f44452c4e253e82047797fb6977a7a624c0cfb0) c3c: 0.7.2 -> 0.7.3
* [`de746fbe`](https://github.com/NixOS/nixpkgs/commit/de746fbecefc41d1b1127e8daef7e66cff321c36) haskellPackages.gpu-vulkan-middle: 0.1.0.75 -> 0.1.0.76
* [`30521021`](https://github.com/NixOS/nixpkgs/commit/305210211c94602f7d0c49e9ef305391f077a02b) python3Packages.craft-parts: 2.12.0 -> 2.14.0
* [`2a3f5e78`](https://github.com/NixOS/nixpkgs/commit/2a3f5e78710179d306cfc8d6c97d605ad09081b2) snapcraft: 8.9.5 -> 8.10.0
* [`35beb68f`](https://github.com/NixOS/nixpkgs/commit/35beb68f70c25bcfef33540a0104c090ac1bada4) cargo-modules: 0.24.2 -> 0.24.3
* [`a12acc27`](https://github.com/NixOS/nixpkgs/commit/a12acc270878ae69b42332e11c6de14eb99dacde) aravis: 0.8.34 -> 0.8.35
* [`567c4488`](https://github.com/NixOS/nixpkgs/commit/567c44882cf45bda4e3e4350b566f449f0e35099) nqp: 2025.06 -> 2025.06.1
* [`da51e345`](https://github.com/NixOS/nixpkgs/commit/da51e34502817f51711660a6ef7ffc4ecee1af27) python3Packages.petsc4py: 3.23.3 -> 3.23.4
* [`eddc5aec`](https://github.com/NixOS/nixpkgs/commit/eddc5aec80961ed451a6e16dfdb7ff050b5219ed) fleet: 4.69.0 -> 4.70.0
* [`fb75d761`](https://github.com/NixOS/nixpkgs/commit/fb75d76161396d6f7dbb2911cdf73cbbe509b3e8) rakudo: 2025.06 -> 2025.06.1
* [`a7ce4eed`](https://github.com/NixOS/nixpkgs/commit/a7ce4eedc12e8f89fa6a04aa4b579d539beee5c7) nuclei: 3.4.5 -> 3.4.6
* [`b39a9d97`](https://github.com/NixOS/nixpkgs/commit/b39a9d979c20a4242ee725bebdff7b773638ad21) texlive: fix darwin build
* [`f8bad942`](https://github.com/NixOS/nixpkgs/commit/f8bad9423226da5c6f9a4ae1ac3c3dea3e2dec4c) rocqPackages.parseque init at 0.3.0 ([nixos/nixpkgs⁠#420742](https://togithub.com/nixos/nixpkgs/issues/420742))
* [`819606d8`](https://github.com/NixOS/nixpkgs/commit/819606d826c76823d1e119ea195320b4d5da3e13) mediawriter: 5.2.6 -> 5.2.7
* [`0b99d6a6`](https://github.com/NixOS/nixpkgs/commit/0b99d6a61314e88e52a7ba1e11e348ac987a5330) python3Packages.azure-mgmt-containerservice: 36.0.0 -> 37.0.0
* [`4b8c5064`](https://github.com/NixOS/nixpkgs/commit/4b8c506449d4145384bf659f5c85efc785096dd0) python3Packages.azure-multiapi-storage: 1.4.0 -> 1.4.1
* [`dcb2fea9`](https://github.com/NixOS/nixpkgs/commit/dcb2fea9cc4fd7c0f235b0596f6522b0535a23c6) azure-cli: 2.74.0 -> 2.75.0
* [`ce95db48`](https://github.com/NixOS/nixpkgs/commit/ce95db48d2b6e8fc68d8eeb0046e284a2d3dfdb8) azure-cli-extensions.data-transfer: init at 1.0.0b1
* [`648841eb`](https://github.com/NixOS/nixpkgs/commit/648841ebf343f3f5a16b5f2819bdab1ae192ad8d) azure-cli-extensions.cloudhsm: init at 1.0.0b1
* [`51ce0d1f`](https://github.com/NixOS/nixpkgs/commit/51ce0d1f541c273681cd17988c2eb54f6f8f9e4f) azure-cli-extensions.dependency-map: init at 1.0.0b1
* [`db5da0cd`](https://github.com/NixOS/nixpkgs/commit/db5da0cd90090f37b8ea8cd308923b248140a0d0) azure-cli-extensions.workload-orchestration: init at 1.0.0
* [`5bfe69c1`](https://github.com/NixOS/nixpkgs/commit/5bfe69c1222c41c187d04f1ac60253ac4188b910) azure-cli-extensions.neon: 1.0.0b3 -> 1.0.0b4
* [`8af6ab6b`](https://github.com/NixOS/nixpkgs/commit/8af6ab6bd84014da53653f9e2a8eaf1332de03f4) azure-cli-extensions.providerhub: 1.0.0b1 -> 1.0.0b2
* [`6f787539`](https://github.com/NixOS/nixpkgs/commit/6f787539f66b0418eaa01e7149c5ccb9d7682c3c) azure-cli-extensions.elastic-san: 1.3.0 -> 1.3.1b1
* [`e122bb74`](https://github.com/NixOS/nixpkgs/commit/e122bb748f9bb6026c2e4941c258da287e7836d9) azure-cli-extensions.vme: 1.0.0b1 -> 1.0.0b4
* [`a1269705`](https://github.com/NixOS/nixpkgs/commit/a1269705aad6086b6903d4b707bc8ed133d904f8) azure-cli-extensions.managednetworkfabric: 8.0.0b3 -> 8.0.0b5
* [`9c808c70`](https://github.com/NixOS/nixpkgs/commit/9c808c70777173c353df7b4d56d88a7862665343) azure-cli-extensions.footprint: 1.0.0 -> 1.0.0
* [`24678024`](https://github.com/NixOS/nixpkgs/commit/24678024df0e2ba0986a358d2cc0fd4ed595ee1f) azure-cli-extensions.scvmm: 1.1.2 -> 1.2.0
* [`ad8479a9`](https://github.com/NixOS/nixpkgs/commit/ad8479a97f1949e8592f123f7461f60d6d0535e5) azure-cli-extensions.zones: 1.0.0b3 -> 1.0.0b4
* [`e4c26700`](https://github.com/NixOS/nixpkgs/commit/e4c26700425f30a1e5103b933ed64c17633b1eba) azure-cli-extensions.aem: 0.3.0 -> 1.0.0
* [`ee5bad49`](https://github.com/NixOS/nixpkgs/commit/ee5bad4973707545a1fad124790ed686a1fcc699) azure-cli-extensions.amg: 2.6.0 -> 2.6.1
* [`665d5500`](https://github.com/NixOS/nixpkgs/commit/665d550027ad1fe6dd069afd86e2109a0986d1eb) azure-cli-extensions.notification-hub: 1.0.0a1 -> 2.0.0b1
* [`b2157248`](https://github.com/NixOS/nixpkgs/commit/b2157248e27544978d6c5641e5483f93f5ae7fc2) azure-cli-extensions.azure-firewall: 1.2.3 -> 1.3.0
* [`f8c663bf`](https://github.com/NixOS/nixpkgs/commit/f8c663bfa1aba5f7d117f41cffa3f05e574836ee) azure-cli-extensions.appservice-kube: 0.1.10 -> 0.1.11
* [`cb354bb7`](https://github.com/NixOS/nixpkgs/commit/cb354bb7a76d3c31c09f25bf0ecac3002068763d) azure-cli-extensions.mcc: 1.0.0b2 -> 1.0.0b3
* [`7722b16f`](https://github.com/NixOS/nixpkgs/commit/7722b16f7803ade532fda6a05818b300d9a7e8ba) azure-cli-extensions.bastion: 1.4.0 -> 1.4.1
* [`7220aeed`](https://github.com/NixOS/nixpkgs/commit/7220aeed34410ca2244359b00a453d40c47cced4) azure-cli-extensions.cli-translator: 0.3.0 -> 0.3.0
* [`e7ffae68`](https://github.com/NixOS/nixpkgs/commit/e7ffae68f7321d1b5c249b053113af4198f80063) azure-cli-extensions.amlfs: 1.0.0 -> 1.1.0
* [`9634fcd8`](https://github.com/NixOS/nixpkgs/commit/9634fcd875901667ef19d097cc56d971f7377953) azure-cli-extensions.storage-actions: 1.0.0b1 -> 1.0.0
* [`99a6cbdf`](https://github.com/NixOS/nixpkgs/commit/99a6cbdf67f0ddd9a0416c06224d451a152ea899) azure-cli-extensions.apic-extension: 1.2.0b1 -> 1.2.0b2
* [`70c79a3c`](https://github.com/NixOS/nixpkgs/commit/70c79a3c9ae6d0929e158aa401ca67751f490672) azure-cli-extensions.vmware: 7.2.0 -> 8.0.0
* [`b3f65e16`](https://github.com/NixOS/nixpkgs/commit/b3f65e16df5e80c7b14d1f46bc4343aaa653ad97) azure-cli-extensions.aks-preview: 18.0.0b7 -> 18.0.0b15
* [`161dc960`](https://github.com/NixOS/nixpkgs/commit/161dc9609425e4a2b1ffbbc337a38119602138fd) azure-cli-extensions.dev-spaces: 1.0.6 -> 1.0.6
* [`fa4d2f64`](https://github.com/NixOS/nixpkgs/commit/fa4d2f6476d6cdfa541cb43aa4f06858ea7487da) azure-cli-extensions.qumulo: 2.0.0 -> 2.0.1
* [`6c3c58f1`](https://github.com/NixOS/nixpkgs/commit/6c3c58f1bf0a4874f7e0eb09f866451f5e079c71) azure-cli-extensions.ai-examples: 0.2.5 -> 0.2.5
* [`0cb7a286`](https://github.com/NixOS/nixpkgs/commit/0cb7a2861816c98609ab9b4aa968cf7669c3f090) azure-cli-extensions.dns-resolver: 1.0.0 -> 1.1.0
* [`5ca13e2f`](https://github.com/NixOS/nixpkgs/commit/5ca13e2fb73a197dbca406d196dd4408b1ce1b09) azure-cli-extensions.confluent: 0.6.0 -> 1.0.0
* [`12d71898`](https://github.com/NixOS/nixpkgs/commit/12d718987dedca036da1fc944df755da302fface) azure-cli-extensions.azurestackhci: remove
* [`1d9a9f62`](https://github.com/NixOS/nixpkgs/commit/1d9a9f621119831c6dcf0a66229242e181098be0) azure-cli-extensions.spring-cloud: remove
* [`f1ab3c35`](https://github.com/NixOS/nixpkgs/commit/f1ab3c351e09fbc2d737719a165d6f0d991ae4f5) azure-cli-extensions.sap-hana: remove
* [`3a661a77`](https://github.com/NixOS/nixpkgs/commit/3a661a77f76e64276f9da1c55785ed4af1392fb1) nexusmods-app: run tests in a passthru
* [`327ec54b`](https://github.com/NixOS/nixpkgs/commit/327ec54b4839a43664078d880221db853aa027ca) mufetch: init at 0.1.1
* [`025744af`](https://github.com/NixOS/nixpkgs/commit/025744afbb0d7245967bfefc4b6b098a3211400d) files-cli: 2.15.32 -> 2.15.38
* [`a8d0fa81`](https://github.com/NixOS/nixpkgs/commit/a8d0fa81089d62c4b51154a74742f794642cb3a3) tscli: 0.0.8 -> 0.0.9
* [`6ab50b56`](https://github.com/NixOS/nixpkgs/commit/6ab50b567da9764f649d04d1ba2771b753d43117) lux-cli: 0.7.3 -> 0.7.4
* [`48bc90c3`](https://github.com/NixOS/nixpkgs/commit/48bc90c3a87e23a5cddcb2d22e1fb8cfe1e43c79) doc/installing-pxe: fix formatting
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
