### PR TITLE
niv nixpkgs: update a2867cc3 -> 2defa371

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -143,10 +143,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a2867cc3f8acc944cb19fe0b73c840e9fa1ba589",
-        "sha256": "0x293i0pdy13hq1gdi6vq4ly5mhc07bc47ib1bgklhqdfh24b9p5",
+        "rev": "2defa37146df235ef62f566cde69930a86f14df1",
+        "sha256": "0lr2f1j6wqmxb8vg1v92qvs4q89yvbv4h7505gwgqfl261yybhpq",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/a2867cc3f8acc944cb19fe0b73c840e9fa1ba589.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/2defa37146df235ef62f566cde69930a86f14df1.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@a2867cc3...2defa371](https://github.com/nixos/nixpkgs/compare/a2867cc3f8acc944cb19fe0b73c840e9fa1ba589...2defa37146df235ef62f566cde69930a86f14df1)

* [`e6c504c5`](https://github.com/NixOS/nixpkgs/commit/e6c504c5f39d581cd9c38c07ab26823906e2b138) junicode: 2.209 -> 2.211
* [`2f7506af`](https://github.com/NixOS/nixpkgs/commit/2f7506af3a4507b9d2dc1e028bfa7c700d75b1e9) doc: fixed number of Privacy Extensions RFC 4941
* [`fbeabe3c`](https://github.com/NixOS/nixpkgs/commit/fbeabe3c0871a97199e79d70d49e2bca74e3c73f) openmpi: mark cross as broken
* [`e77499c7`](https://github.com/NixOS/nixpkgs/commit/e77499c7d6762c3cecf5f97fdef416f64d5c885f) fig2dev: apply patches for CVE-2025-31162 and CVE-2025-31163
* [`b6bf78eb`](https://github.com/NixOS/nixpkgs/commit/b6bf78eb6f0f0e6ba4816e117bf891bbe93f2f52) nixos/cnping: fix setcap wrapper
* [`2a8b17f1`](https://github.com/NixOS/nixpkgs/commit/2a8b17f1d5bef1f03e4769cf2d6802261d1315c7) glmark2: don't overwrite LD_LIBRARY_PATH from environment
* [`8f00a09a`](https://github.com/NixOS/nixpkgs/commit/8f00a09a558d68d240089b104b3caf17b0be8d8f) tmuxPlugins.vim-tmux-navigator: unstable-2022-08-21 -> unstable-2025-04-25
* [`537e9ee3`](https://github.com/NixOS/nixpkgs/commit/537e9ee383a2429d2d0fcb34ece1f9e299e8fca2) zed-discord-presence: init at 0.8.0
* [`8b1088a5`](https://github.com/NixOS/nixpkgs/commit/8b1088a522217fc83b157329a95e29ed5b16b8f0) python3Packages.drf-nested-routers: 0.93.4 -> 0.94.2
* [`d7650693`](https://github.com/NixOS/nixpkgs/commit/d7650693efe20e27700ce4331305ff96dbd62160) python3Packages.drf-nested-routers: add meta.changelog
* [`91170698`](https://github.com/NixOS/nixpkgs/commit/9117069870ffe73155799b5e6cc3ad19ddfb01fa) python312Packages.spacy-transformers: 1.3.8 -> 1.3.9
* [`4eb04812`](https://github.com/NixOS/nixpkgs/commit/4eb048120ac1ebfe00db1e4c3e51c754acd36eb1) unicode-paracode: update to Unicode 16.0.0
* [`a01df6c4`](https://github.com/NixOS/nixpkgs/commit/a01df6c4372a476af4e0d52c635638b68d12ae52) kopia: 0.19.0 -> 0.20.1
* [`9c0693a7`](https://github.com/NixOS/nixpkgs/commit/9c0693a71c0cca89f8f2278d6132953b9d9df6a2) syncthing-relay: 1.29.5 -> 1.29.7
* [`b30dbb1b`](https://github.com/NixOS/nixpkgs/commit/b30dbb1bae7301b20fd6419d57433a1201bffda8) pretix: fix pretix-manage runserver by using makeWrapper
* [`02ce9cba`](https://github.com/NixOS/nixpkgs/commit/02ce9cba7e5ec455c16baba59733b023288e5017) kaldi: 0-unstable-2024-11-29 -> 0-unstable-2025-04-28
* [`de9bccb5`](https://github.com/NixOS/nixpkgs/commit/de9bccb5669a3752d154bbe45cc455872956ef47) znc: 1.9.1 -> 1.10.0
* [`ec274619`](https://github.com/NixOS/nixpkgs/commit/ec274619509db382f0bfebc012e3071800564773) lazynpm: init at 0.1.4
* [`93b72119`](https://github.com/NixOS/nixpkgs/commit/93b72119d8c5edb8f80aac841f5237945382b8de) nixos/fcitx5: fix ignoreUserConfig being ignored in some cases
* [`20dd05a4`](https://github.com/NixOS/nixpkgs/commit/20dd05a4568e34c9451dca43ed0ea0bbf35e7ca5) mcp-k8s-go: init at 0.3.5
* [`92ad4152`](https://github.com/NixOS/nixpkgs/commit/92ad4152e5f0312b823a0eea6976466cdc195286) mupdf: rename icon so it shows in menu
* [`2f42b3ea`](https://github.com/NixOS/nixpkgs/commit/2f42b3eac37d25e7a0e648dcbf3fa5bb18566b84) python313Packages.airportsdata: enable tests
* [`d5773f30`](https://github.com/NixOS/nixpkgs/commit/d5773f3073bd7a56759b7241f3db79432326f453) maintainers: add delafthi
* [`ae9adb2f`](https://github.com/NixOS/nixpkgs/commit/ae9adb2fa1d5b26327a8b51555a36696dcd2260a) nixos/drupal: make https default for caddy
* [`8d34c8e5`](https://github.com/NixOS/nixpkgs/commit/8d34c8e5c1f81de33134fb22b639ee6d82184034) codex: 0.1.2504301751 -> 0.02506060849
* [`d226c3fe`](https://github.com/NixOS/nixpkgs/commit/d226c3fe88ac6477118599d7d0ec3408adf64e77) cfn-changeset-viewer: init at 0.1.0
* [`cd384792`](https://github.com/NixOS/nixpkgs/commit/cd384792b46e8e93895b092b124e6f3b3169dcc4) lixPackageSets.stable.nixpkgs-review: init
* [`7d113673`](https://github.com/NixOS/nixpkgs/commit/7d113673b780eb1e67b4416ad497f3b3175754ed) python313Packages.python-mystrom: 2.2.0 -> 2.4.0
* [`b0554f20`](https://github.com/NixOS/nixpkgs/commit/b0554f20242298cfd12de6f9478c976868c8b022) lsr: 0.2.0 -> 1.0.0
* [`7c7cd4da`](https://github.com/NixOS/nixpkgs/commit/7c7cd4da982d846de63284efb102fd0ae4127c18) p2pool: 4.7 -> 4.8
* [`e201ee74`](https://github.com/NixOS/nixpkgs/commit/e201ee74eeefc4a709d0e169a9eb9b2a71d837df) hut: embed version string
* [`471a8bdc`](https://github.com/NixOS/nixpkgs/commit/471a8bdcc216b90e7b859c0dffc6c166038adae3) hut: modernize
* [`a1b23b79`](https://github.com/NixOS/nixpkgs/commit/a1b23b791f7983ba7b31afb1d3ab39626f22bc51) ecapture: support non-core btf mode
* [`8f84a394`](https://github.com/NixOS/nixpkgs/commit/8f84a39401bba0826627688c93f34feaed714fa5) esptool: 4.8.1 -> 4.9.0
* [`a2f1023f`](https://github.com/NixOS/nixpkgs/commit/a2f1023f57b9ce21b195fbcdcf48fe9d9cda7795) doc: fix example consistency on `mapAttrsRecursiveCond`
* [`8a1b0296`](https://github.com/NixOS/nixpkgs/commit/8a1b029672ae04fc836cdfc468452c4e5615eefb) resholve: 0.10.5 -> 0.10.6
* [`54a76be5`](https://github.com/NixOS/nixpkgs/commit/54a76be590f5f1551df19a469becf50dd7de77eb) rc-9front: 0-unstable-2025-04-12 -> 0-unstable-2025-06-14
* [`0ad888f1`](https://github.com/NixOS/nixpkgs/commit/0ad888f1e278446cc1c66c875ab798b4af3721cf) krillinai: update repo name
* [`34519077`](https://github.com/NixOS/nixpkgs/commit/34519077d01423e5739550e02db0062ed28ef651) git-town: 21.0.0 -> 21.1.0
* [`8655c356`](https://github.com/NixOS/nixpkgs/commit/8655c3569c49773d7514eb97855e0171d31ec22f) sourcegit: 2025.19 -> 2025.23, add updateScript
* [`a719a505`](https://github.com/NixOS/nixpkgs/commit/a719a5053d3e6a9715898437be2a978d700ef1ad) matrix-conduit: 0.10.4 -> 0.10.5
* [`f246c7f3`](https://github.com/NixOS/nixpkgs/commit/f246c7f3e1e90eda55aa05c0b27f6810d8a59931) maintainers: add delafthi
* [`8325ab7c`](https://github.com/NixOS/nixpkgs/commit/8325ab7c23a0d7ad2523d344af8124defc8e4bd3) newsboat: 2.39 -> 2.40
* [`f5db46f5`](https://github.com/NixOS/nixpkgs/commit/f5db46f5e45db3be365ef420d9ce2c86a639ae72) wit-bindgen: 0.42.1 -> 0.43.0
* [`e7e86df7`](https://github.com/NixOS/nixpkgs/commit/e7e86df73183065006d5e6088dfa2cfee8eb4ecd) proto: 0.50.0 -> 0.50.1
* [`3828979a`](https://github.com/NixOS/nixpkgs/commit/3828979a85b99e13c94835b4411ba033917aa328) filebeat8: 8.18.2 -> 8.18.3
* [`96639b07`](https://github.com/NixOS/nixpkgs/commit/96639b07dc250b8b70a483d02e1a84c9ac98fa3c) bazel-watcher: 0.26.1 -> 0.26.3
* [`257ff93a`](https://github.com/NixOS/nixpkgs/commit/257ff93a62de89786b31338dfd1245490fcb44c9) frp: 0.62.1 -> 0.63.0
* [`a6efa1fd`](https://github.com/NixOS/nixpkgs/commit/a6efa1fd361e78ce67923a5944b12ceebefeb83f) templ: 0.3.898 -> 0.3.906
* [`8ec81b03`](https://github.com/NixOS/nixpkgs/commit/8ec81b03f6444fa194d3afa1f51274d30dc83ed8) rancher: 2.11.2 -> 2.11.3
* [`8105d6cd`](https://github.com/NixOS/nixpkgs/commit/8105d6cdf6a783a45a9ad33246077ab7617f9d3d) sigtop: 0.19.0 -> 0.20.0
* [`bc56559a`](https://github.com/NixOS/nixpkgs/commit/bc56559ab504a57092b279a4eb0933f6e98636f3) python313Packages.pygitguardian: 1.22.0 -> 1.23.0
* [`04268677`](https://github.com/NixOS/nixpkgs/commit/042686771ce77e03f050d612ab11d264d761248d) python3Packages.tftpy: 0.8.5 -> 0.8.6
* [`2c8b3c81`](https://github.com/NixOS/nixpkgs/commit/2c8b3c81d3a51a3d260d4ffcd581d99b53eff95f) moar: 1.31.10 -> 1.32.1
* [`20e0e145`](https://github.com/NixOS/nixpkgs/commit/20e0e145d98e8b08ed85d255df5b75716af1c7d7) yakut: 0.14.0 -> 0.14.1
* [`8ace7bce`](https://github.com/NixOS/nixpkgs/commit/8ace7bce144c3da4c4136a9b4c583c2b7d29eb2f) svd2rust-form: init at 0.13.0
* [`9d3ecb45`](https://github.com/NixOS/nixpkgs/commit/9d3ecb45093987f10d7b25a4b3ac7500d4207171) bees: 0.10 -> 0.11
* [`c6d0d166`](https://github.com/NixOS/nixpkgs/commit/c6d0d166204fb8ea0092f096398f71dc2c078dc5) kamailio: 6.0.1 -> 6.0.2
* [`9feba7c2`](https://github.com/NixOS/nixpkgs/commit/9feba7c2ffc877ef3e2a87ec005271745c205114) nixos/nixos-generate-config: remove extra indentation in flake output
* [`a82569c2`](https://github.com/NixOS/nixpkgs/commit/a82569c2c2a52585dd54a66573edc9c1ea9e1f6b) bitwig-studio: 5.3.8 -> 5.3.11
* [`40c35807`](https://github.com/NixOS/nixpkgs/commit/40c358076c7f35516d914a291d7ef72276c6fd3c) postgresqlPackages.{pgvectorscale,pgx_ulid}: pin cargo-pgrx 0.12.6
* [`136519ba`](https://github.com/NixOS/nixpkgs/commit/136519ba0aae07001fad3508dc23ef5959cf9341) cargo-pgrx_0_14_1: init; cargo-pgrx: 0.12.6 -> 0.14.1
* [`a7787dbe`](https://github.com/NixOS/nixpkgs/commit/a7787dbed497da50ed47a8067b7ba3dcf8bcd145) pluto: 5.21.7 -> 5.21.8
* [`7f44f8f1`](https://github.com/NixOS/nixpkgs/commit/7f44f8f1c52dbf8808539bc75abc8c49ab09eb28) antimony: move to by-name
* [`d30424cb`](https://github.com/NixOS/nixpkgs/commit/d30424cb5da7263811add205bc9a93fb1de9fafa) rosa: 1.2.53 -> 1.2.54
* [`8076307c`](https://github.com/NixOS/nixpkgs/commit/8076307cd0afcd0d9ca9d54599d394ad55e0442e) cctz: unbreak on darwin
* [`bb49e043`](https://github.com/NixOS/nixpkgs/commit/bb49e0432f1f9bc91b93855c2957ee662aa73842) openrct2: 0.4.22 -> 0.4.23
* [`b0575c6f`](https://github.com/NixOS/nixpkgs/commit/b0575c6fd24c750a46209f20a518b829f39b99e5) python3Packages.scipy-stubs: init at 1.16.0.0
* [`097ccc54`](https://github.com/NixOS/nixpkgs/commit/097ccc54f01e6bf3f37fe51b2aa917a2a04e2d53) protoc-gen-lint: init at 0.3.0
* [`8b272b6d`](https://github.com/NixOS/nixpkgs/commit/8b272b6d9c2effcf52a33c3a8a4b199236dfb5df) cnquery: 11.59.0 -> 11.60.0
* [`acee5225`](https://github.com/NixOS/nixpkgs/commit/acee522557e05a826753acc034f48eb4d52290e0) ghidra: rework extension builders to use extendMkDerivation
* [`84983852`](https://github.com/NixOS/nixpkgs/commit/84983852e75bdcc8c7b873261c91970775d378d0) ghidra: Use finalAttrs for extensions where sensible
* [`23d467f3`](https://github.com/NixOS/nixpkgs/commit/23d467f3537a932370cb95fa401d913b059b9fed) bililiverecorder: 2.17.0 -> 2.17.1
* [`4ee53e7f`](https://github.com/NixOS/nixpkgs/commit/4ee53e7f6caef83641a3e21fe1d28da7c4df65f0) goatcounter: 2.5.0 -> 2.6.0
* [`66499b33`](https://github.com/NixOS/nixpkgs/commit/66499b33336a30408b4ac8b9c3311c6835ea14ef) hydralauncher: 3.6.1 -> 3.6.2
* [`71cad131`](https://github.com/NixOS/nixpkgs/commit/71cad131a6bb7a288cfdf44c1ed9db7878a3f60d) transcribe: 9.41.2 -> 9.42.0
* [`af60da0a`](https://github.com/NixOS/nixpkgs/commit/af60da0aa1b786aa5c652dd0d619ae2fe8dafb9a) convertall: 1.0.1 -> 1.0.2
* [`4512f6c1`](https://github.com/NixOS/nixpkgs/commit/4512f6c1caef6aaa85bd97ed5dab772b418c6bb1) dump1090-fa: 10.1 -> 10.2
* [`15ba2519`](https://github.com/NixOS/nixpkgs/commit/15ba25192ade225b71eff419c49d9c1521ecb166) wiremix: 0.4.0 -> 0.5.0
* [`63ff4b68`](https://github.com/NixOS/nixpkgs/commit/63ff4b68715e53195163836dedef6c8ef622925d) mieru: 3.16.0 -> 3.16.1
* [`81b332f7`](https://github.com/NixOS/nixpkgs/commit/81b332f792b2f43ee2cbcd8d66b213cb70280265) hydrus: 624 -> 627
* [`78fcdda7`](https://github.com/NixOS/nixpkgs/commit/78fcdda7edf3195d3840c01c17890797228f2441) moon: 1.37.3 -> 1.38.0
* [`7dd65b76`](https://github.com/NixOS/nixpkgs/commit/7dd65b7608446f6793a8c39df271c073d0a2496c) renovate: 40.60.0 -> 41.16.0
* [`cdc95fd8`](https://github.com/NixOS/nixpkgs/commit/cdc95fd8143e14e44fdaf7555d00c70773500e50) nixos/doc/rl-2511: document renovate major upgrade
* [`8a058ec9`](https://github.com/NixOS/nixpkgs/commit/8a058ec9ff0c60245942f1c86b4b879df10285dc) xk6: 1.0.0 -> 1.0.1
* [`5fe61d18`](https://github.com/NixOS/nixpkgs/commit/5fe61d18c402b93ea49ff7a2cc075744b136ddd3) maintainers: add WheelsForReals
* [`e2e240b5`](https://github.com/NixOS/nixpkgs/commit/e2e240b5f18b8966b90610c69d4baf65dbe11609) nixos/rust-motd: use existing PAM options to configure pam_motd
* [`47930595`](https://github.com/NixOS/nixpkgs/commit/479305951f01e8107bc8287608ce1aa70eb1f076) babeltrace2: 2.0.6 -> 2.1.1
* [`ca7d60b6`](https://github.com/NixOS/nixpkgs/commit/ca7d60b6e32d1ee869017e8eb02247f8a02469f8) nixos/fish: follow symlinks in completion generation
* [`07ea40bf`](https://github.com/NixOS/nixpkgs/commit/07ea40bfcfbce807b39fbda0ab4e0a6dbf455b8b) efivar: mark as broken if hostPlatform.is32bit
* [`aafe5d78`](https://github.com/NixOS/nixpkgs/commit/aafe5d7829ac0e3a51f2cdb7c7d9ef6977ba3c70) master_me: 1.2.0 -> 1.3.0
* [`6966a2cd`](https://github.com/NixOS/nixpkgs/commit/6966a2cd474117c6585bf666a2c829b9c5825599) gh-poi: 0.13.0 -> 0.14.0
* [`28382768`](https://github.com/NixOS/nixpkgs/commit/28382768e17b8e43779a969e33f87fb3b8a87eb2) packet: 0.5.1 → 0.5.3
* [`83566a84`](https://github.com/NixOS/nixpkgs/commit/83566a843df3733d3082a99ab9302c1fcf639237) python3Packages.osc-sdk-python: 0.33.0 -> 0.34.0
* [`b0554193`](https://github.com/NixOS/nixpkgs/commit/b05541933def8314368712dd1cff27449e8d6e58) nixos/installer: enable networkmanager by default
* [`9250532b`](https://github.com/NixOS/nixpkgs/commit/9250532b6169f19093fd9286364557dee9a9c677) python3Packages.cynthion: refactor for 3.13
* [`ef933773`](https://github.com/NixOS/nixpkgs/commit/ef93377305ef49b58b2bbbca4585f9f9ca1dc3b9) atac: 0.20.1 -> 0.20.2
* [`55d6bce7`](https://github.com/NixOS/nixpkgs/commit/55d6bce7d86eca4edcbd716136f0be898d192454) memcached-exporter: init at 0.15.3
* [`f1b6d538`](https://github.com/NixOS/nixpkgs/commit/f1b6d538ad16606c5d49a9376d644972d39df4b7) dotbot: 1.21.0 -> 1.22.0
* [`509f9b4f`](https://github.com/NixOS/nixpkgs/commit/509f9b4f054a5d8f2e67a82bcd1cc444fd9512d3) orchard: 0.34.0 -> 0.35.0
* [`22d58bfb`](https://github.com/NixOS/nixpkgs/commit/22d58bfb4d5854d16bd55dac732de95e7b8d253e) galene-stream: init at 0.2.0
* [`44661754`](https://github.com/NixOS/nixpkgs/commit/446617549c0a29e8e85896439378f34f362945cf) nixosTests.galene.stream: init
* [`6bfa191e`](https://github.com/NixOS/nixpkgs/commit/6bfa191ec321e7cc0c87f7f5437e818bd173100a) nixosTests.galene: Modernise / simplify test code
* [`a2225026`](https://github.com/NixOS/nixpkgs/commit/a22250261d4c86a295ed1dfcd2a42034e10bc87e) opentrack: add neuralnet tracker by incuding onnxruntime
* [`e6482dae`](https://github.com/NixOS/nixpkgs/commit/e6482dae1b4ec42170409af19ab4762cadd3ff05) python3Packages.fast-simplification: init at 0.1.11
* [`412bbf94`](https://github.com/NixOS/nixpkgs/commit/412bbf941213f68188ea8b59a7c8ef7611e35b4d) binaryninja-free: Fix libxml2 breakage
* [`8ea3f5e5`](https://github.com/NixOS/nixpkgs/commit/8ea3f5e509eac563e8f575534236218c178d4e31) python3Packages.kuzu: 0.10.0 -> 0.10.1
* [`376e54b3`](https://github.com/NixOS/nixpkgs/commit/376e54b34bf5dfc283dbaf50ee7af9596bfb4bf2) simple-http-server: 0.6.12 -> 0.6.13
* [`4f762fd5`](https://github.com/NixOS/nixpkgs/commit/4f762fd56289091d7b37433187cb0c7ae173d16c) chatbox: 1.14.1 -> 1.14.3
* [`cefb3d5f`](https://github.com/NixOS/nixpkgs/commit/cefb3d5fa31ef9d3c549db51553e7803c89b652c) rsrpc: init at 0.24.2
* [`91fa73c0`](https://github.com/NixOS/nixpkgs/commit/91fa73c0a8acccc62cfb136b48a3a35de6dbeacb) similarity: init at 0.2.4
* [`8d40136f`](https://github.com/NixOS/nixpkgs/commit/8d40136f8de9bec3fa0eb236fe69908410e0581c) amazon-q-cli: 1.12.1 -> 1.12.2
* [`6a3906cb`](https://github.com/NixOS/nixpkgs/commit/6a3906cb0e510349aa3f6c0011cbc6116a508e0d) mediawiki: 1.43.1 -> 1.43.2
* [`67c6bd9c`](https://github.com/NixOS/nixpkgs/commit/67c6bd9ca59d9bf9c5056f5f042c6f586804d581) tint: 0.1.6 -> 0.1.7
* [`90527374`](https://github.com/NixOS/nixpkgs/commit/9052737463f2765c6092603829ac439ea9d7bea6) cargo-mutants: 25.1.0 -> 25.2.0
* [`c721b7df`](https://github.com/NixOS/nixpkgs/commit/c721b7dfe9811b3f9ba5423e9a2bff1454d62fe0) nixos/corteza: init
* [`354d9d79`](https://github.com/NixOS/nixpkgs/commit/354d9d7986387d6ef8b91777f54b746eed9c49a7) nixosTests.corteza: init
* [`3034ec7d`](https://github.com/NixOS/nixpkgs/commit/3034ec7d0798f013a2c5b970c602c5267298365d) nixos/doc/rl-25.11: add corteza
* [`14084084`](https://github.com/NixOS/nixpkgs/commit/14084084f307041a256f0290858b179cb1b8133a) termusic: 0.10.0 -> 0.11.0
* [`626a888b`](https://github.com/NixOS/nixpkgs/commit/626a888bbd2d087310f19a0ae1704856fd30d54e) python3Packages.python3-application: 3.0.6 -> 3.0.9, add NGI team
* [`23ee725f`](https://github.com/NixOS/nixpkgs/commit/23ee725f160c7a1feddc27c2b917c9c160c75671) python3Packages.python3-application: Add passthru.updateScript
* [`e2897552`](https://github.com/NixOS/nixpkgs/commit/e2897552dfe5ef0222db27e6b0d46a42c8ac670e) clickhouse: 25.3.4.190 → 25.3.5.42
* [`08f3c578`](https://github.com/NixOS/nixpkgs/commit/08f3c5781f15b386288d6cb7f1f76fd3aa633a98) openlinkhub: 0.5.8 -> 0.5.9
* [`748f408f`](https://github.com/NixOS/nixpkgs/commit/748f408fb0bf02f4bfdd5fc9e7999d262ff36d7e) klog-time-tracker: 6.5 -> 6.6
* [`c7f8cbc4`](https://github.com/NixOS/nixpkgs/commit/c7f8cbc4c166ec1ce8f9f8f91df1ccc9bf22aa99) python3Packages.django-pgtrigger: init at 4.15.3
* [`947a163e`](https://github.com/NixOS/nixpkgs/commit/947a163e68a3cccd89524d08a505f58428704ef1) python3Packages.pytest-asyncio-cooperative: init at 0.40.0
* [`4169a952`](https://github.com/NixOS/nixpkgs/commit/4169a952a4bd22753b91ad5d39c1e7d227a459b6) blueman: 2.4.4 -> 2.4.6
* [`5b95d5d9`](https://github.com/NixOS/nixpkgs/commit/5b95d5d95b27cc05052fa52f807fef46163fb966) vscode-extensions.dart-code.flutter: 3.112.0 -> 3.114.0
* [`4b514634`](https://github.com/NixOS/nixpkgs/commit/4b51463478b0e12e52a3be04094af33ce568a391) vscode-extensions.dart-code.dart-code: 3.112.0 -> 3.114.0
* [`d5126584`](https://github.com/NixOS/nixpkgs/commit/d5126584eadd4e7c5d09117f65f70b62fde59010) codebuff: 1.0.119 -> 1.0.424
* [`ba555396`](https://github.com/NixOS/nixpkgs/commit/ba555396ee6bb7ea60108992eb6e3f653f758734) mise: 2025.6.5 -> 2025.7.0
* [`96d163fe`](https://github.com/NixOS/nixpkgs/commit/96d163fe481cbafb3b18a918fd7dd3508b64c560) python3Packages.flax: 0.10.6 -> 0.10.7
* [`4cecda22`](https://github.com/NixOS/nixpkgs/commit/4cecda224c60a3540a914b4e35eae16a0a451244) rofi-calc: 2.3.2 -> 2.4.0
* [`248f798c`](https://github.com/NixOS/nixpkgs/commit/248f798c46c786085cf89159f2ae094d897e6aec) rofi-calc: use lib.getExe
* [`b1724709`](https://github.com/NixOS/nixpkgs/commit/b17247099ebae363809d79194574bdcdaa37f07a) nwg-dock-hyprland: 0.4.6 -> 0.4.7
* [`72595dd3`](https://github.com/NixOS/nixpkgs/commit/72595dd39df1e36c20d7e7bc45a9fb525720d0e1) pokeget-rs: 1.6.3 -> 1.6.5
* [`5f858d2a`](https://github.com/NixOS/nixpkgs/commit/5f858d2afd59477f778d981751aba24dbd64619b) sish: 2.19.0 -> 2.20.0
* [`1dcec23c`](https://github.com/NixOS/nixpkgs/commit/1dcec23c6b99b2712e7ac962a3d715e1ffa8e9de) zabbix72: 7.2.5 -> 7.2.10
* [`bf448303`](https://github.com/NixOS/nixpkgs/commit/bf448303dd36e348af530d73df5c26cb1e842226) zabbix70: 7.0.14 -> 7.0.16
* [`58a779b1`](https://github.com/NixOS/nixpkgs/commit/58a779b10505c028e7c1da81ea885f2b54d69d90) zabbix: add Zabbix 7.4 version
* [`da806408`](https://github.com/NixOS/nixpkgs/commit/da80640883001effced46e71a899ab086ab131ec) python312Packages.schedula: init at 1.5.62
* [`1e968849`](https://github.com/NixOS/nixpkgs/commit/1e968849c167dd400b51e2d87083d19242c1c315) deno: 2.3.7 -> 2.4.0
* [`96e17579`](https://github.com/NixOS/nixpkgs/commit/96e17579a1091e01920b6cb2a6c196236e048542) hmcl: avoid with lib
* [`9bb6f268`](https://github.com/NixOS/nixpkgs/commit/9bb6f268c4e9b93c06623f59494f8165d11d7a47) hmcl: correct finalAttrs usage
* [`c147291a`](https://github.com/NixOS/nixpkgs/commit/c147291ac446f0f7857957553edd5a3802cf649b) hmcl: add comment explaining why it’s not built from source
* [`e5dcb41b`](https://github.com/NixOS/nixpkgs/commit/e5dcb41b50ba42de1eab1e7fc292b3f2cfcaec8e) hmcl: add updateScript
* [`6cd7e9d3`](https://github.com/NixOS/nixpkgs/commit/6cd7e9d3c626024d7c930f6a06508c6039b98ffa) hmcl: gen multiple size icons
* [`c6603237`](https://github.com/NixOS/nixpkgs/commit/c6603237ac6dc3da4ee9b32f6d531a4757231846) hmcl: follow upstream, switch to HMCL-dev org
* [`9bd5502f`](https://github.com/NixOS/nixpkgs/commit/9bd5502f42070514b22dd821c5ec8fc2aa12603f) hmcl: add myself as maintainer
* [`88ee47d6`](https://github.com/NixOS/nixpkgs/commit/88ee47d6fa68e11d1b83cb7b0a6d814255c5d00e) astal.source: 0-unstable-2025-05-12 -> 0-unstable-2025-06-28
* [`eb093eb7`](https://github.com/NixOS/nixpkgs/commit/eb093eb77a8dcb8fdc24390bbb910a2c85a536b9) vscode-extensions.discloud.discloud: 2.23.9 -> 2.24.2
* [`ab82f5a5`](https://github.com/NixOS/nixpkgs/commit/ab82f5a51158d05d8d713bfc6f4cbec0456f85eb) postgresqlPackages.vectorchord: init at 0.4.2
* [`c049f174`](https://github.com/NixOS/nixpkgs/commit/c049f1746c5dfc2e2e02b8bbab66b6470c783887) nixos/nextcloud-notify_push: allow overwriting recommendedProxySettings without mkForce
* [`cfd5cb75`](https://github.com/NixOS/nixpkgs/commit/cfd5cb75961f7b09bbbab6c62cd2347c214ad6b3) readest: 0.9.61 -> 0.9.62
* [`02f7ac63`](https://github.com/NixOS/nixpkgs/commit/02f7ac63c074b4b5b88c18a0308c236160998eb9) zulu: add installCheckPhase
* [`65cfd1d2`](https://github.com/NixOS/nixpkgs/commit/65cfd1d284a92a21dfc71358e0f7af2fc6e17839) nixVersions.latest: nix_2_28 -> nix_2_29
* [`678ffaca`](https://github.com/NixOS/nixpkgs/commit/678ffaca3c410cb5d754e7744b81aa88b7470282) magic-vlsi: 8.3.529 -> 8.3.530, fix technology missing
* [`43765d2a`](https://github.com/NixOS/nixpkgs/commit/43765d2a3e5c515bffa9b1d7e35d40e2e4bc3fc2) vscode-extensions.julialang.language-julia: 1.146.2 -> 1.149.2
* [`80d7c6f3`](https://github.com/NixOS/nixpkgs/commit/80d7c6f3f7444e64d2be853d3119d0c02d47aa94) wasm-language-tools: 0.5.0 -> 0.5.1
* [`7bce67f2`](https://github.com/NixOS/nixpkgs/commit/7bce67f2a4ab9839d3a4f8303ab031c5793f10de) alvr: 20.13.0 -> 20.14.0
* [`5fba6862`](https://github.com/NixOS/nixpkgs/commit/5fba68622780eecf8c451ee48e60068f75431ec6) noto-fonts: 2025.06.01 -> 2025.07.01
* [`1eeb17dd`](https://github.com/NixOS/nixpkgs/commit/1eeb17ddee13e2dbe03010b86b912a2ff6759b71) go-errorlint: Set up auto-updates
* [`eefac55a`](https://github.com/NixOS/nixpkgs/commit/eefac55ab6928f3bc5f64844e05b1836dfe56163) go-errorlint: Add myself as maintainer
* [`075dc042`](https://github.com/NixOS/nixpkgs/commit/075dc042407190fcaccf5618e84bc38c20350831) git-spice: 0.14.1 -> 0.15.1
* [`f89a4b3c`](https://github.com/NixOS/nixpkgs/commit/f89a4b3cd805369480ca441e77fd234fad53b6bf) opencode: 0.0.52 -> 0.1.169
* [`0b563524`](https://github.com/NixOS/nixpkgs/commit/0b5635242721eb1246833e524676cb8c5283b75c) cilium-cli: 0.18.4 -> 0.18.5
* [`2945a2cd`](https://github.com/NixOS/nixpkgs/commit/2945a2cd5e1b679f14c920d5a6c8f7557e4b2098) cargo-shuttle: 0.55.0 -> 0.56.0
* [`9ded4656`](https://github.com/NixOS/nixpkgs/commit/9ded46560d8919f9b5d42b9b5df29169bfddc07b) Use pass thru.tests.version not custom installCheckPhase script
* [`81a238a5`](https://github.com/NixOS/nixpkgs/commit/81a238a58d585dff4a550c8723124d96700e04e2) home-manager: 0-unstable-2025-06-22 -> 0-unstable-2025-07-02
* [`0e556a9a`](https://github.com/NixOS/nixpkgs/commit/0e556a9a89ebbcd77967e9b0b048b9a1ef6e1ee7) n8n: 1.98.2 -> 1.100.1
* [`4721ddd7`](https://github.com/NixOS/nixpkgs/commit/4721ddd76f0ebd076f1e782ad3d22ec21f6bffe2) opencode: 0.1.69 -> 0.1.176
* [`8486619f`](https://github.com/NixOS/nixpkgs/commit/8486619ffaf7ded0efd3cfb1cedb3d3124c10e81) vscode-extensions.tabnine.tabnine-vscode: 3.291.0 -> 3.293.0
* [`010b7ec2`](https://github.com/NixOS/nixpkgs/commit/010b7ec26bd5cc90e59126e5f45814cd885e5ea9) vscode-extensions.ziglang.vscode-zig: 0.6.10 -> 0.6.11
* [`e242db00`](https://github.com/NixOS/nixpkgs/commit/e242db005ca4132ae177382dec567e6c116aeffa) reth: 1.4.8 -> 1.5.0
* [`93cc932e`](https://github.com/NixOS/nixpkgs/commit/93cc932ee66da799dabd036a5e957443ed6a8172) zulu: Fix passthru.tests
* [`6cac5214`](https://github.com/NixOS/nixpkgs/commit/6cac5214af50899dd7210d4d74f0ab42beabcb0e) jwx: 3.0.7 -> 3.0.8
* [`fdb85c6d`](https://github.com/NixOS/nixpkgs/commit/fdb85c6dd4be7515e92081731c0848407e3c2b3c) magic-vlsi: fix darwin
* [`96576911`](https://github.com/NixOS/nixpkgs/commit/96576911776181ae921f7d9dffb0a20cca4dd1b1) navidrome: 0.56.1 -> 0.57.0
* [`2ca967c7`](https://github.com/NixOS/nixpkgs/commit/2ca967c78afe8aaa3dd563bcec770f7964240c74) syncthingtray: 1.7.8 -> 1.7.9
* [`610bc437`](https://github.com/NixOS/nixpkgs/commit/610bc4379bd061bf12c7a607b21ef7db83490606) breitbandmessung: 3.9.0 -> 3.9.1
* [`347d5096`](https://github.com/NixOS/nixpkgs/commit/347d509691c76ddd2740deeb6912a12b080a1a55) abctl: 0.26.0 -> 0.28.0
* [`949e299d`](https://github.com/NixOS/nixpkgs/commit/949e299d246a7e2d64402dec4c3c0a841416987a) kubernetes: use util-linuxMinimal instead of util-linux.withPatches
* [`e6886d70`](https://github.com/NixOS/nixpkgs/commit/e6886d7080bac9c1c59b03c9ae1e65030106437b) k3s: drop util-linux.withPatches
* [`91a3afac`](https://github.com/NixOS/nixpkgs/commit/91a3afac528cad2c1a6048a9bb0c2d1d31207440) util-linux: drop withPatches
* [`79e418ec`](https://github.com/NixOS/nixpkgs/commit/79e418ecbeccd1e5017e33edeeb2becd1c7a0b84) vscode-extensions.ms-dotnettools.csdevkit: 1.20.35 -> 1.30.32
* [`980eedab`](https://github.com/NixOS/nixpkgs/commit/980eedab05476595fb080e6536e0740271d4618a) typos-lsp: 0.1.39 -> 0.1.40
* [`4477d077`](https://github.com/NixOS/nixpkgs/commit/4477d077f9cb862d0bb2920767b1aed9772fbe1d) vpp: 25.02 -> 25.06
* [`c47a37d0`](https://github.com/NixOS/nixpkgs/commit/c47a37d00bfcae77ddb622af168dffa5c2053ba8) mediaelch: move to by-name and clean up
* [`94fd8ff8`](https://github.com/NixOS/nixpkgs/commit/94fd8ff88c8a9d075e21cd2cdc7741ffad95e121) traefik: 3.4.1 -> 3.4.3
* [`1371762d`](https://github.com/NixOS/nixpkgs/commit/1371762d80a2c4b71769d2fb32d06ac66ba568a4) opencode: 0.1.176 -> 0.1.181
* [`42d1efb5`](https://github.com/NixOS/nixpkgs/commit/42d1efb5d0308b6cbe87a63fc703ccec0eda0dcd) vscode-extensions.ms-kubernetes-tools.vscode-kubernetes-tools: 1.3.24 -> 1.3.25
* [`18ebd322`](https://github.com/NixOS/nixpkgs/commit/18ebd3225f0e4f5ae70249ba18e287cf3152810c) tailscale: 1.84.2 -> 1.84.3
* [`a2c73a51`](https://github.com/NixOS/nixpkgs/commit/a2c73a516570f06a9b555b521d53db681d2fe485) git-town: 21.1.0 -> 21.2.0
* [`56a71ae5`](https://github.com/NixOS/nixpkgs/commit/56a71ae59248c3ef7f0a482e68c00424cb1cdd85) dissent: 0.0.34 -> 0.0.35
* [`872fd0c1`](https://github.com/NixOS/nixpkgs/commit/872fd0c102ca5f07a4bf140964f7f32ffdae6b20) opencode: 0.1.181 -> 0.1.182
* [`e769ea2d`](https://github.com/NixOS/nixpkgs/commit/e769ea2dcd2547f0d5c9795feea052c2a764b1bb) voicevox-core: 0.15.7 -> 0.15.8
* [`fad46aab`](https://github.com/NixOS/nixpkgs/commit/fad46aabd67ea3c906155b63c6c7eeadbdafb398) python313Packages.kanalizer: init at 0.1.1
* [`c675af8e`](https://github.com/NixOS/nixpkgs/commit/c675af8ef1be1ee9f293ded79084db554d4a5e70) voicevox-engine: 0.23.0 -> 0.24.0
* [`0fed32dd`](https://github.com/NixOS/nixpkgs/commit/0fed32dd3b20527490d93eebf04792220ccf0397) voicevox: 0.23.0 -> 0.24.1
* [`53b89aca`](https://github.com/NixOS/nixpkgs/commit/53b89aca2becb7ac2a28dfe91590e16784ad0aeb) postgresqlPackages.omnigres: 0-unstable-2025-06-03 -> 0-unstable-2025-06-27
* [`5e480191`](https://github.com/NixOS/nixpkgs/commit/5e4801914bec1c79bbddb4ae582b350ea53ee3da) nixos/stage-1: fix option path in message
* [`dd4e9bdc`](https://github.com/NixOS/nixpkgs/commit/dd4e9bdc17dd9fd88815008f36348099dd6c3dd1) grafana: change convention on Go version changes
* [`fe26703f`](https://github.com/NixOS/nixpkgs/commit/fe26703f5469257096f58a9f077ea145c9f8eb8b) python3Packages.pytest-unmagic: init at 1.0.0
* [`228be7ac`](https://github.com/NixOS/nixpkgs/commit/228be7ac8cb6b5f65059cc209e565ad9bdf9c724) python3Packages.django-cte: 1.3.3 -> 2.0.0
* [`8b31d5da`](https://github.com/NixOS/nixpkgs/commit/8b31d5da6d7f3792c69cdabeafdba7739744d1bb) musescore: 4.5.2 -> 4.5.2-unstable-2025-07-03
* [`3ed3dc16`](https://github.com/NixOS/nixpkgs/commit/3ed3dc16466ebff0b33b9cc7f337b48750a18d3b) s-tui: 1.1.6 -> 1.2.0
* [`d821bc7a`](https://github.com/NixOS/nixpkgs/commit/d821bc7a52bb58138671e0fc6c521224f59c6b96) wl-kbptr: 0.3.0 -> 0.4.0
* [`ffec6b6e`](https://github.com/NixOS/nixpkgs/commit/ffec6b6e3e79a27abe607aa25784ba33a2472948) slimevr: 0.15.0 -> 0.16.0
* [`1b64ff30`](https://github.com/NixOS/nixpkgs/commit/1b64ff30a2f28c12f562cfeb7789d64ea1b22f33) maintainers: add vanadium5000
* [`6df26a52`](https://github.com/NixOS/nixpkgs/commit/6df26a5244e1a255dc5946e02f2293c7f10c1c34) saman_ttf: init at 1.001
* [`4edc790b`](https://github.com/NixOS/nixpkgs/commit/4edc790bc06b32de3d0f13cdc30c732265984212) linuxPackages.universal-pidff: 0.1.0 -> 0.1.1
* [`52e82b0b`](https://github.com/NixOS/nixpkgs/commit/52e82b0b04df1abc6f612ba7ef2ecd95eb69a356) parallel-launcher: init at 8.2.0
* [`81124a73`](https://github.com/NixOS/nixpkgs/commit/81124a7323468a7db9b9eabfcd6332ae310da30c) python3Packages.flowmc: 0.4.4 -> 0.4.5
* [`3b666d62`](https://github.com/NixOS/nixpkgs/commit/3b666d62d7e704792dfec67846e960f8be15f936) python3Packages.pytensor: 2.31.5 -> 2.31.6
* [`792018f0`](https://github.com/NixOS/nixpkgs/commit/792018f0b4cd862ba0ace52f61c1d36e5bf435a5) flake-checker: 0.2.7 -> 0.2.8
* [`acbe99ca`](https://github.com/NixOS/nixpkgs/commit/acbe99ca03955f2fd5d8a895b2b5e8519762015d) ruff: 0.12.1 -> 0.12.2
* [`819775e8`](https://github.com/NixOS/nixpkgs/commit/819775e8452635cc4884d991a589df1dec82626c) python3Packages.pylance: 0.30.0 -> 0.31.0
* [`b4fc4e52`](https://github.com/NixOS/nixpkgs/commit/b4fc4e529f51837d343f2064f3a86f27cdf5e165) paperless-ngx: disable failing favicon tests
* [`28648aca`](https://github.com/NixOS/nixpkgs/commit/28648acaf2ebfb387f8c1ad7ee00cec55be6c02f) abracadabra: 3.2.0 -> 3.3.0
* [`0db5ce5d`](https://github.com/NixOS/nixpkgs/commit/0db5ce5d194d9169459cbb2649d44fa2a47f48fb) conduktor-ctl: 0.6.0 -> 0.6.1
* [`97ca333c`](https://github.com/NixOS/nixpkgs/commit/97ca333cedf54ae273af783232a4a91b42abe7b5) olympus: make env var set in wrapper overridable
* [`862b1fcc`](https://github.com/NixOS/nixpkgs/commit/862b1fcc1f02323f46ce8e6a443491a405402848) vscode-extensions.ms-python.vscode-pylance: 2025.6.1 -> 2025.6.2
* [`9329f9fd`](https://github.com/NixOS/nixpkgs/commit/9329f9fdc5f0e402cd0c92b28e9633270e05f5f1) python3Packages.ppdeep: 20250622 -> 20250625
* [`786e0510`](https://github.com/NixOS/nixpkgs/commit/786e05104325713a185f76fc04b78eb1e8a0e233) paraview: fix build by downgrading to python 3.12
* [`c1e0d4c2`](https://github.com/NixOS/nixpkgs/commit/c1e0d4c2e8349f22598e41063cb82652cee918d5) windsurf: 1.10.5 -> 1.10.7
* [`125ae45f`](https://github.com/NixOS/nixpkgs/commit/125ae45fe620e2730738fe513d7f76228c99e45c) backrest: never download restic from an external URL
* [`c8e94d29`](https://github.com/NixOS/nixpkgs/commit/c8e94d293b7daa6a3c2ce694c0d58bbea8735329) ansible-lint: add maintainer HarisDotParis
* [`20c68b7d`](https://github.com/NixOS/nixpkgs/commit/20c68b7d98de9e335aad6f5879e1f7442bc4b68d) python3Packages.pyexploitdb: 0.2.86 -> 0.2.87
* [`9f0ba6c1`](https://github.com/NixOS/nixpkgs/commit/9f0ba6c169f7875622a43662d1668ab2dc869d2d) waybar-lyric: init at 0.10.0
* [`588d4d6f`](https://github.com/NixOS/nixpkgs/commit/588d4d6f621ed7224f2859d38c8e18cea2c3080b) python3Packages.livekit-api: 1.0.2 -> 1.0.3
* [`4559a018`](https://github.com/NixOS/nixpkgs/commit/4559a0181b71a240a1757d85e763fdd8ea0486b3) python3Packages.aioamazondevices: 3.1.14 -> 3.2.2
* [`61ea9259`](https://github.com/NixOS/nixpkgs/commit/61ea925961bdcad85201487bf3010798ce2843dd) python3Packages.aioimmich: 0.9.1 -> 0.10.1
* [`991842fc`](https://github.com/NixOS/nixpkgs/commit/991842fc28c0055030dc74defd06d8ff0dc7282d) python3Packages.aioshelly: 13.6.0 -> 13.7.1
* [`edbf86f9`](https://github.com/NixOS/nixpkgs/commit/edbf86f97a3b8f0e5ffd5d6854f3ca39ef870f7b) python3Packages.aiosomecomfort: 0.0.32 -> 0.0.34
* [`a917d6fd`](https://github.com/NixOS/nixpkgs/commit/a917d6fd2dd85a1bac5210f9f8744d77a77171fc) python3Packages.airtouch5py: 0.2.11 -> 0.3.0
* [`8aea29a1`](https://github.com/NixOS/nixpkgs/commit/8aea29a182f565e07a2739af52b79ff2e13e5858) python3Packages.bluetooth-data-tools: 1.28.1 -> 1.28.2
* [`f98ec00b`](https://github.com/NixOS/nixpkgs/commit/f98ec00b4c98112d768e212e18bea639b1d3abe1) python3Packages.deebot-client: 13.4.0 -> 13.5.0
* [`21bb7025`](https://github.com/NixOS/nixpkgs/commit/21bb7025b5cdfbc41bc382cd9694ccb3bff2420a) python313Packages.demetriek: 1.2.0 -> 1.3.0
* [`c6a76b3f`](https://github.com/NixOS/nixpkgs/commit/c6a76b3f4462d03ff1e04a0ac33357bdcddf557c) python3Packages.hass-nabucasa: 0.101.0 -> 0.105.0
* [`58bdd4e0`](https://github.com/NixOS/nixpkgs/commit/58bdd4e0f529ee118725b8b6ab458bf77214631e) python3Packages.music-assistant-models: 1.1.43 -> 1.1.51
* [`f82687fa`](https://github.com/NixOS/nixpkgs/commit/f82687fae54f54efcb4342116ae9c5e41e9a8391) python3Packages.music-assistant-client: 1.2.0 -> 1.2.4
* [`e4856507`](https://github.com/NixOS/nixpkgs/commit/e4856507e6d2f2a893f7714ff9905d41e95cbd29) python3Packages.nettigo-air-monitor: 4.1.0 -> 5.0.0
* [`a4b762a3`](https://github.com/NixOS/nixpkgs/commit/a4b762a3068bf578d0a2a42dad9efb647d941496) python3Packages.onvif-zeep-async: 3.2.5 -> 4.0.1
* [`f8e8db70`](https://github.com/NixOS/nixpkgs/commit/f8e8db707a19f84a586223351624a9d357493f78) python3Packages.py-dormakaba-dkey: 1.0.5 -> 1.0.6
* [`b62163f7`](https://github.com/NixOS/nixpkgs/commit/b62163f7b24184dbba52749fd562acd6eb4e2ac0) python313Packages.pyairnow: 1.2.2 -> 1.3.1
* [`7476952e`](https://github.com/NixOS/nixpkgs/commit/7476952eed9daea362321dd6c0167e79a9e00b55) python313Packages.pyairnow: remove disabled
* [`cb2412df`](https://github.com/NixOS/nixpkgs/commit/cb2412dfc0bf4a10ede03e9bd8bc5bb91d166a55) python3Packages.pyenphase: 1.26.1 -> 2.1.2
* [`d3ff992a`](https://github.com/NixOS/nixpkgs/commit/d3ff992a95e469f3103ea1ece1f399b03927b144) python3Packages.pynecil: 4.1.0 -> 4.1.1
* [`4febeae1`](https://github.com/NixOS/nixpkgs/commit/4febeae18faf895493718e6e10c1a84cf31b0273) python3Packages.pypaperless: 4.1.0 -> 4.1.1
* [`db144384`](https://github.com/NixOS/nixpkgs/commit/db1443842db13618bb73be91c4fd5ce6eea10eff) python3Packages.pyseventeentrack: 1.0.2 -> 1.1.1
* [`ad1c28ea`](https://github.com/NixOS/nixpkgs/commit/ad1c28eafb66cb3afc1ab894a6008023bdd354cd) python313Packages.pysml: 0.1.4 -> 0.1.5
* [`2df2ee8c`](https://github.com/NixOS/nixpkgs/commit/2df2ee8c22dc4254cb99ae1afc07ed9a3afb8a1c) python3Packages.pyswitchbot: 0.65.0 -> 0.67.0 ([nixos/nixpkgs⁠#416117](https://togithub.com/nixos/nixpkgs/issues/416117))
* [`018a6134`](https://github.com/NixOS/nixpkgs/commit/018a6134dd312eb0047abccc3ad7c9c7430fa72d) python3Packages.python-homewizard-energy: 8.3.2 -> 9.2.0
* [`c91a8237`](https://github.com/NixOS/nixpkgs/commit/c91a8237484b0213ae2a40f45c3f96829595e3b4) python3Packages.pytibber: 0.31.5 -> 0.31.6
* [`432ebed5`](https://github.com/NixOS/nixpkgs/commit/432ebed5870e30b3c43983192d407052c4ccd660) python3Packages.pywizlight: 0.6.2 -> 0.6.3
* [`3d3b06a8`](https://github.com/NixOS/nixpkgs/commit/3d3b06a8cc7d8324107dd709bd1bc93d7b4467f8) python3Packages.reolink-aio: 0.14.1 -> 0.14.2
* [`078b2a00`](https://github.com/NixOS/nixpkgs/commit/078b2a00b1d7da89f9edae9a5372f01feca9b622) python3Packages.thermopro-ble: 0.13.0 -> 0.13.1
* [`d4f83403`](https://github.com/NixOS/nixpkgs/commit/d4f83403c1adf224a96c4e5a3a4705f0ccc8c848) python3Packages.related: unbreak and pep517 build
* [`a8e95729`](https://github.com/NixOS/nixpkgs/commit/a8e957295e4f9dbca63d68abd283730f9b1194a8) python3Packages.bellows: 0.45.0 -> 0.45.2
* [`34d57c1b`](https://github.com/NixOS/nixpkgs/commit/34d57c1bebb96be4460e0d6e529dcbfd2b165749) python3Packages.zha-quirks: 0.0.138 -> 0.0.139
* [`071ec20a`](https://github.com/NixOS/nixpkgs/commit/071ec20a531352d7eb9ff80f3728202804911ca6) python3Packages.zha: 0.0.60 -> 0.0.62
* [`cb74bd28`](https://github.com/NixOS/nixpkgs/commit/cb74bd28e246936c4c4f1888f06174737173fbfd) dynisland: 0.1.3 -> 0.1.4
* [`cf68c4e0`](https://github.com/NixOS/nixpkgs/commit/cf68c4e01bc55b5232d0477cd84a8b2538e8494a) python3Packages.ha-mqtt-discoverable: 0.19.2 -> 0.20.0
* [`2b6bfe23`](https://github.com/NixOS/nixpkgs/commit/2b6bfe2339fe8814aa0f6ab25535f6a94068ddcd) sql-formatter: 15.6.5 -> 15.6.6
* [`64c15ddc`](https://github.com/NixOS/nixpkgs/commit/64c15ddceb6d00bc95718830a30fb2596d64a67c) python3Packages.zwave-js-server-python: 0.63.0 -> 0.65.0
* [`a41bc8e2`](https://github.com/NixOS/nixpkgs/commit/a41bc8e2aa5e903b2d5e9a0c90b3b9c36fa8bbd7) home-assistant.intents: 2025.6.10 -> 2025.6.23
* [`35fac70a`](https://github.com/NixOS/nixpkgs/commit/35fac70ae85946d938418197b3fe64cbe6fd0024) python3Packages.libpyfoscamcgi: init at 0.0.6
* [`723f6f0e`](https://github.com/NixOS/nixpkgs/commit/723f6f0e4ed8af478db6c1f42cc14f0efe3f773c) python3Packages.altruistclient: init at 0.1.1
* [`bf405c43`](https://github.com/NixOS/nixpkgs/commit/bf405c434693a9a7b59a138675203c68458218a1) home-assistant: 2025.6.3 -> 2025.7.0
* [`6f8cfc8e`](https://github.com/NixOS/nixpkgs/commit/6f8cfc8e492606d9bb75b31813cb49d0cfb4fcf7) python3Packages.libpyfoscam: drop
* [`86dcb4b3`](https://github.com/NixOS/nixpkgs/commit/86dcb4b3266c525a62364cf4af59df4dd1e054c9) python3Packages.homeassistant-stubs: 2025.6.3 -> 2025.7.0
* [`1617947c`](https://github.com/NixOS/nixpkgs/commit/1617947c9ab710f80933fddb54a4da5ccd6386d4) home-assistant.python.pkgs.pytest-homeassistant-custom-component: 0.13.253 -> 0.13.260
* [`4a21025e`](https://github.com/NixOS/nixpkgs/commit/4a21025efdb04b8fe0f08e781eae24f05dfb4ccb) home-assistant-custom-lovelace-modules.bubble-card: 3.0.0-beta.9 -> 3.0.0-rc.3
* [`8eb793b1`](https://github.com/NixOS/nixpkgs/commit/8eb793b19c6afb2c9e2786a8883bb3ecaed75398) home-assistant-custom-components.adaptive_lighting: 1.25.0 -> 1.26.0
* [`fa482da9`](https://github.com/NixOS/nixpkgs/commit/fa482da9ecbe9cb1f28e4d95f2811302e255ede9) home-assistant-custom-components.frigate: 5.9.2 -> 5.9.3
* [`1767d805`](https://github.com/NixOS/nixpkgs/commit/1767d805ff4dbd815379d1047280d32091b7e23e) home-assistant-custom-components.midea_ac: 2025.5.1 -> 2025.6.0
* [`1befa7a2`](https://github.com/NixOS/nixpkgs/commit/1befa7a25bcb7813447718c76f0638f559c50a23) home-assistant-custom-lovelace-modules.clock-weather-card: 2.8.11 -> 2.8.12
* [`174f11ec`](https://github.com/NixOS/nixpkgs/commit/174f11ecdb902fc0fb0e2acb6081eb7de11954d7) home-assistant-custom-lovelace-modules.custom-sidebar: 10.2.0 -> 10.3.0
* [`526be080`](https://github.com/NixOS/nixpkgs/commit/526be0801f1de54bb89b82500e8228277df75b14) maple-font: 7.3 -> 7.4
* [`0fec73c6`](https://github.com/NixOS/nixpkgs/commit/0fec73c60133eb58c6f24685c1fdcdf7a9bf7b3c) lunar-client: 3.3.11 -> 3.4.3
* [`f0d8cf4e`](https://github.com/NixOS/nixpkgs/commit/f0d8cf4ef437d0078b4ccbf497e5e40de2775ccf) python3Packages.switchbot-api: 2.6.0 -> 2.7.0
* [`7b4794ea`](https://github.com/NixOS/nixpkgs/commit/7b4794ea7643a712a6bbe88500314993db2a64a0) retroarch-bare: add pipewire support
* [`06383a52`](https://github.com/NixOS/nixpkgs/commit/06383a525f00582e07dafe539ccf873c4a8212ff) repomix: 0.3.9 -> 1.0.0
* [`49ab2164`](https://github.com/NixOS/nixpkgs/commit/49ab2164fe76fbff5524cef887fa30fa83166a1c) vscode-extensions.ms-dotnettools.csharp: 2.80.16 -> 2.84.19
* [`ac2111da`](https://github.com/NixOS/nixpkgs/commit/ac2111dadaee68506eabe3af31cd30e964e866f4) python3Packages.langchain-aws: 0.2.26 -> 0.2.27
* [`f508bb0f`](https://github.com/NixOS/nixpkgs/commit/f508bb0f9f23cddea011bce189130d76050e9e70) jdd: 0.2.0 -> 0.4.3
* [`054ebe60`](https://github.com/NixOS/nixpkgs/commit/054ebe60c011dba4e9589ea3576af22e7532f0a4) linux: drop dependency on nettools
* [`f086f9a6`](https://github.com/NixOS/nixpkgs/commit/f086f9a6bc3bcf9beb9b603d4f58fb2b36063d71) prometheus-fastly-exporter: 9.4.0 -> 9.5.0
* [`2cf70c09`](https://github.com/NixOS/nixpkgs/commit/2cf70c09a6d216387104e218fb643d70d5c2ed00) go-exploitdb: 0.6.0 -> 0.6.1
* [`387e804c`](https://github.com/NixOS/nixpkgs/commit/387e804c99d576911dcb0c9a02ad0eeb6cb7966d) hostname-debian: set main program
* [`c21be356`](https://github.com/NixOS/nixpkgs/commit/c21be3563ed335e85ed205183c181abfb32aa37c) nixos/ec2-data: use hostname-debian to set hostname from metadata
* [`a0a53485`](https://github.com/NixOS/nixpkgs/commit/a0a53485396f1dbf58dac165ae5f4e3d4d857b90) python3Packages.aiobafi6: 0.9.0 -> 0.10.0
* [`87a13967`](https://github.com/NixOS/nixpkgs/commit/87a13967025fb6a7f75eec638e97323c9e30531f) nixos/zfs: use hostname-debian for hostname lookups
* [`b5309c00`](https://github.com/NixOS/nixpkgs/commit/b5309c0046853bb20b4aeb6fd43998f8645e81e5) php81: 8.1.32 -> 8.1.33
* [`f8792321`](https://github.com/NixOS/nixpkgs/commit/f8792321d725579e3c36a5c8f59049ce0d5b135f) php82: 8.2.28 -> 8.2.29
* [`629b7488`](https://github.com/NixOS/nixpkgs/commit/629b7488d740100d4e980214399b2561d9594a03) php83: 8.3.22 -> 8.2.23
* [`d23be9b4`](https://github.com/NixOS/nixpkgs/commit/d23be9b417dde2cb9ab1e720b3a13d54f12b5827) php84: 8.4.8 -> 8.4.10
* [`69251712`](https://github.com/NixOS/nixpkgs/commit/6925171285ae040d01d2ee10e9b81727f4a27c33) aerogramme: add updateScript
* [`a0634a22`](https://github.com/NixOS/nixpkgs/commit/a0634a22c3319eaa9cdddf2ac54c102646b21805) agorakit: add updateScript
* [`0e94cbfd`](https://github.com/NixOS/nixpkgs/commit/0e94cbfd4b8a653e0a92cff975f8bc16c10412e6) python313Packages.deebot-client: 13.4.0 -> 13.5.0
* [`a2ad08a3`](https://github.com/NixOS/nixpkgs/commit/a2ad08a3c2ea3b30c1aefe17735eaa6ffb446b0a) python313Packages.aiobafi6: refactor
* [`11688b33`](https://github.com/NixOS/nixpkgs/commit/11688b33b41addada7110c43385cf3ace8375c56) agorakit: 1.9.3 -> 1.11
* [`0be3318b`](https://github.com/NixOS/nixpkgs/commit/0be3318b46ee127d6f8055b166e3a01892beaa0b) whatsapp-emoji-font: 2.25.9.78-1 -> 2.25.9.78-2
* [`e3a5e1b6`](https://github.com/NixOS/nixpkgs/commit/e3a5e1b6d6de183835661591a8bda9e7ef02a542) python313Packages.types-awscrt: 0.27.2 -> 0.27.4
* [`35257fd2`](https://github.com/NixOS/nixpkgs/commit/35257fd26a3bcd35ac4fdd0cf9be775aa50e9790) lbreakouthd: fix darwin build (case-insensitive FS problem)
* [`ee6739c2`](https://github.com/NixOS/nixpkgs/commit/ee6739c28d9fd1d8541e6d650107bbde0d08d3fd) gel: 7.3.0 -> 7.7.0
* [`9c41abcf`](https://github.com/NixOS/nixpkgs/commit/9c41abcfda72bea23e3b8ae262ed01c1a8ceaec2) structorizer: 3.32-26 -> 3.32-27
* [`723a2b2e`](https://github.com/NixOS/nixpkgs/commit/723a2b2ea413ff4bb87a0431f69e56798cf85a7a) python3Packages.sagemaker-core: 1.0.40 -> 1.0.41
* [`58332290`](https://github.com/NixOS/nixpkgs/commit/58332290833b3de7ba4f3638b81ab33ca31b157b) tailwindcss-language-server: 0.14.23 -> 0.14.24
* [`87405d27`](https://github.com/NixOS/nixpkgs/commit/87405d273b0789342228865717285dd845e480ac) tailwindcss-language-server: use lts versions of nodejs
* [`b77d1858`](https://github.com/NixOS/nixpkgs/commit/b77d18585d2cbe97fffebc141aad22ee05ce44c5) alibuild: 1.17.18 -> 1.17.21
* [`25dfc886`](https://github.com/NixOS/nixpkgs/commit/25dfc886c8ed78e76b4dc4b1c99b2462cca86223) vscode-extensions.gleam.gleam: 2.12.0 -> 2.12.1
* [`d99267c3`](https://github.com/NixOS/nixpkgs/commit/d99267c3b3bf186cce92432d8957f637c784f5da) vscode-extensions.ms-vscode.cpptools: 1.25.3 -> 1.26.3
* [`607684c3`](https://github.com/NixOS/nixpkgs/commit/607684c3c7845489fd8685e2d6bcfaede65a174d) vscode-extensions.redhat.ansible: 25.4.0 -> 25.7.0
* [`a6a81c47`](https://github.com/NixOS/nixpkgs/commit/a6a81c47a9707bceed37935b28d6bddae4d95cd4) vscode-extensions.csharpier.csharpier-vscode: 2.0.7 -> 2.0.8
* [`cc776efe`](https://github.com/NixOS/nixpkgs/commit/cc776efe8414e3ad35812dcd155de367eb31b631) vscode-extensions.sumneko.lua: 3.14.0 -> 3.15.0
* [`889802fd`](https://github.com/NixOS/nixpkgs/commit/889802fdb8786b5beb40d407337c225569cfe6bf) vscode-extensions.ms-vscode.powershell: 2025.1.0 -> 2025.2.0
* [`7900a161`](https://github.com/NixOS/nixpkgs/commit/7900a1618fafca40373dec053a0823988ed2d937) workflows/labels: manage "needs: reviewer" label
* [`474834ee`](https://github.com/NixOS/nixpkgs/commit/474834ee7346da6ccf7c86bdfa45f845dc08e378) vscode-extensions.fstarlang.fstar-vscode-assistant: 0.17.2 -> 0.18.1
* [`88d50966`](https://github.com/NixOS/nixpkgs/commit/88d50966f9fdc2926adcebad0851be2707bd16b9) vscode-extensions.mechatroner.rainbow-csv: 3.19.0 -> 3.20.0
* [`643b0cb9`](https://github.com/NixOS/nixpkgs/commit/643b0cb905a95c9d94e8a64fdbe3d399e74edda3) vscode-extensions.k--kato.intellij-idea-keybindings: 1.7.4 -> 1.7.5
* [`cb66d6f8`](https://github.com/NixOS/nixpkgs/commit/cb66d6f8b7bb1013c0a25420c9e07ee6e2e985eb) vscode-extensions.jnoortheen.nix-ide: 0.4.21 -> 0.4.22
* [`84175d99`](https://github.com/NixOS/nixpkgs/commit/84175d992c4900fd1911fefaf977023eba086e9d) vscode-extensions.waderyan.gitblame: 11.1.3 -> 11.1.4
* [`8ff5933c`](https://github.com/NixOS/nixpkgs/commit/8ff5933ccc6b06b94afc97630b075c2400d9dfc7) opencode: 0.1.182 -> 0.1.185
* [`2daee956`](https://github.com/NixOS/nixpkgs/commit/2daee956e9fd2006f6a4b9159afbbbcb50324d9e) vscode-extensions.danielsanmedium.dscodegpt: 3.12.89 -> 3.12.107
* [`5d4311b7`](https://github.com/NixOS/nixpkgs/commit/5d4311b789c6988c950fa5a12ab7117544a82262) vscode-extensions.bradlc.vscode-tailwindcss: 0.14.23 -> 0.14.24
* [`af6922a6`](https://github.com/NixOS/nixpkgs/commit/af6922a69c39cfe04f219eb29263cd5e6e4fe6f6) python3Packages.calmsize: init at 0.1.3
* [`e5d1fc72`](https://github.com/NixOS/nixpkgs/commit/e5d1fc72d26c1cd6ff66756119e3982cfea931c6) opencode: 0.1.182 -> 0.1.189
* [`4a8f705f`](https://github.com/NixOS/nixpkgs/commit/4a8f705f9e6090c3060bebe762cd51fdaaab77f8) python3Packages.pytorch-memlab: init at 0.3.0
* [`e2d2b2c0`](https://github.com/NixOS/nixpkgs/commit/e2d2b2c0247cf32ae3ee081f3a094d698a3d19bd) assimp: 5.4.3 -> 6.0.2
* [`b67d54da`](https://github.com/NixOS/nixpkgs/commit/b67d54da343a7df05da1d2679125259f9b8edae5) vscode-extensions.golang.go: 0.47.2 -> 0.48.0
* [`2c30e009`](https://github.com/NixOS/nixpkgs/commit/2c30e0098416ca737100e22a073fd5e9c069c1db) python3Packages.pyopencl: 2025.2.4 -> 2025.2.5
* [`767d725d`](https://github.com/NixOS/nixpkgs/commit/767d725da9cea6ee2df575fb9159769a263be690) python3Packages.huggingface-hub: 0.33.1 -> 0.33.2
* [`d41a0597`](https://github.com/NixOS/nixpkgs/commit/d41a059709e72fc74af48e8b922c14c798982284) python3Packages.transformers: 4.53.0 -> 4.53.1
* [`1efa8149`](https://github.com/NixOS/nixpkgs/commit/1efa81490ad80fd29aef48423a064a1686157458) python3Packages.awkward-cpp: 46 -> 47
* [`f47a7009`](https://github.com/NixOS/nixpkgs/commit/f47a70093a57993ee7f5eb90f5272d4cfece5b79) python3Packages.awkward: 2.8.4 -> 2.8.5
* [`80b63a16`](https://github.com/NixOS/nixpkgs/commit/80b63a16bcb93c8df0d895072a8f0bfeace98707) vscode-extensions.vue.volar: 2.2.10 -> 3.0.1
* [`f7ecabbb`](https://github.com/NixOS/nixpkgs/commit/f7ecabbb6690bd5b0f305ca5154c0082fae66f7b) clusterlint: init at 0.12.0
* [`91a5481f`](https://github.com/NixOS/nixpkgs/commit/91a5481ff2db02dce17cedca99a69db933709ba4) vscode-extensions.github.copilot: 1.336.0 -> 1.338.0
* [`5176434e`](https://github.com/NixOS/nixpkgs/commit/5176434e53cf280cf71f1cd96e1d62a8d201ecdc) vscode-extensions.danielgavin.ols: 0.1.37 -> 0.1.38
* [`d3c1e174`](https://github.com/NixOS/nixpkgs/commit/d3c1e1747e9511fa32f7947fcf7fa62b3e9e311f) vscode-extensions.amazonwebservices.amazon-q-vscode: 1.78.0 -> 1.81.0
* [`5e2baf54`](https://github.com/NixOS/nixpkgs/commit/5e2baf54d48b025461698ea2023473af6753edd9) nixos/test-driver: fix race from filename clash in OCR
* [`97e94439`](https://github.com/NixOS/nixpkgs/commit/97e94439e64f8a1b0a4283bb11afb4e12342fa12) vscode-extensions.RoweWilsonFrederiskHolme.wikitext: 4.0.1 -> 4.0.2
* [`27661a11`](https://github.com/NixOS/nixpkgs/commit/27661a1142bada4e445b65c239ba3ca743a3cd22) assimp: modernize
* [`548dd365`](https://github.com/NixOS/nixpkgs/commit/548dd3651925a5b9617ab74dc97c40b5d6683c5c) python3Packages.llama-cloud-services: 0.6.37 -> 0.6.41
* [`b108b7e4`](https://github.com/NixOS/nixpkgs/commit/b108b7e4236e4985ef0ddb6c68b3cba3750c0dc1) vscode-extensions.twpayne.vscode-testscript: 0.0.6 -> 0.0.7
* [`2a725beb`](https://github.com/NixOS/nixpkgs/commit/2a725beb5290870acf7304acf8af1037f6171a9d) vscode-extensions.github.copilot-chat: 0.28.2 -> 0.28.5
* [`30005fee`](https://github.com/NixOS/nixpkgs/commit/30005fee37ef7d6b24734856990d22a5e16f67fc) vscode-extensions.tuttieee.emacs-mcx: 0.65.1 -> 0.65.2
* [`1158bd72`](https://github.com/NixOS/nixpkgs/commit/1158bd72f5d8d605dcecfd801bed43786a79403a) assimp: remove ehmry from maintainers
* [`3cff6377`](https://github.com/NixOS/nixpkgs/commit/3cff6377b8b46bf4cdaa6a61588e91c8cb8f30c1) python3Packages.eheimdigital: 1.2.0 -> 1.3.0
* [`d128a486`](https://github.com/NixOS/nixpkgs/commit/d128a486f605f7ca4b139bfe68be678def47e04e) meteor-git: 0.28.1 -> 0.28.2
* [`769d76a9`](https://github.com/NixOS/nixpkgs/commit/769d76a998f8174f0a1ce36866488c900fc19689) cargo-show-asm: 0.2.50 -> 0.2.51
* [`2d3d9f49`](https://github.com/NixOS/nixpkgs/commit/2d3d9f497192aa5f8dfd1a4281854816fec6cc76) redis: disable aarch64-linux failing test
* [`521e3e5e`](https://github.com/NixOS/nixpkgs/commit/521e3e5eca0d2f076fb4472ef5a36011b1a15559) kdePackages.qt3d: unvendor assimp
* [`d10cf627`](https://github.com/NixOS/nixpkgs/commit/d10cf627aafa99a752c0ee5364444dbae26701d6) aerogramme: add ngi team
* [`8aecdfdd`](https://github.com/NixOS/nixpkgs/commit/8aecdfddf5e390020783e31b290f357aeaa57e81) agorakit: add ngi team
* [`e0d7b3db`](https://github.com/NixOS/nixpkgs/commit/e0d7b3dbd3329a98f0d38a3fa08a6eb576501db1) talhelper: 3.0.29 -> 3.0.30
* [`2f0e31f7`](https://github.com/NixOS/nixpkgs/commit/2f0e31f77ab65d9cfb8eedb7de2845f4bcbf0f94) openlist: avoid using emulator for completions
* [`5dd3b622`](https://github.com/NixOS/nixpkgs/commit/5dd3b622fa32e029a3ece0fd9bb6cd9346fdb75a) openlist: 4.0.1 -> 4.0.8
* [`7c250bf6`](https://github.com/NixOS/nixpkgs/commit/7c250bf676fb448a2ff187ac8c69e1f088211762) python3Packages.vector: skip failing tests
* [`3faafa4e`](https://github.com/NixOS/nixpkgs/commit/3faafa4ea16649cf544b040c88e4635303c33cd9) git-repo: 2.55.2 -> 2.56
* [`8c5990e5`](https://github.com/NixOS/nixpkgs/commit/8c5990e52474d00f30b2c98aaa6be534f9a97424) wcurl: remove
* [`404d2524`](https://github.com/NixOS/nixpkgs/commit/404d25243c469c716634b3fa6e8d05a2524f2557) nixosTests.birdwatcher: handleTest -> runTest
* [`16e6e745`](https://github.com/NixOS/nixpkgs/commit/16e6e7455011b34eecce49b52554a11e1e63cff2) nixosTests.blocky: handleTest -> runTest
* [`4e792f52`](https://github.com/NixOS/nixpkgs/commit/4e792f525ecef83b61e45b54ebfc833f0b35a1f7) nixosTests.bpf: handleTest -> runTest
* [`2e4fac6d`](https://github.com/NixOS/nixpkgs/commit/2e4fac6dfdbc71b35708aef46c546b2dd2ae38b4) nixosTests.cadvisor: handleTest -> runTest
* [`f4a714d8`](https://github.com/NixOS/nixpkgs/commit/f4a714d8d5b94ed393a9c429bef90594255ff764) nixosTests.cassandra_4: handleTest -> runTest
* [`50f3960d`](https://github.com/NixOS/nixpkgs/commit/50f3960dc8031aeeea5b0a4f14599c10e51518af) nixosTests.ceph-multi-node: handleTest -> runTest
* [`9206b0ad`](https://github.com/NixOS/nixpkgs/commit/9206b0adec594ea5a382d757c3756d475bdabff9) nixosTests.ceph-single-node: handleTest -> runTest
* [`644443d5`](https://github.com/NixOS/nixpkgs/commit/644443d59a7167b18963fa8a28e16b435fee7b8a) nixosTests.ceph-single-node-bluestore: handleTest -> runTest
* [`4db8ad5f`](https://github.com/NixOS/nixpkgs/commit/4db8ad5fa617b1ab05ccd42dfd2f03d7885254e2) nixosTests.ceph-single-node-bluestore-dmcrypt: handleTest -> runTest
* [`4633acf7`](https://github.com/NixOS/nixpkgs/commit/4633acf70e6c8142b718ace096b9136558a8685a) nixosTests.certmgr: handleTest -> runTest
* [`1fe77250`](https://github.com/NixOS/nixpkgs/commit/1fe7725039725c7bf9d198cf0136edac9e7a85a1) nixosTests.cfssl: handleTest -> runTest
* [`4f26991b`](https://github.com/NixOS/nixpkgs/commit/4f26991b9f5dbb5eb71a13275f3b353089bf2c73) nixosTests.chrony: handleTest -> runTest
* [`950a25ab`](https://github.com/NixOS/nixpkgs/commit/950a25abb6b14be1582b3c547350acd342b8ab2e) nixosTests.chrony-ptp: handleTest -> runTest
* [`3faac88e`](https://github.com/NixOS/nixpkgs/commit/3faac88ef380cb7ead365f33cc984e261cd10eb6) nixosTests.cloud-init: handleTest -> runTest
* [`501fabc8`](https://github.com/NixOS/nixpkgs/commit/501fabc856d502cddf7da90e5f8c5b0d8d956803) nixosTests.cloud-init-hostname: handleTest -> runTest
* [`9b445d35`](https://github.com/NixOS/nixpkgs/commit/9b445d35967b84d9fa106ee3f38fc4019f424599) nixosTests.cntr: handleTest -> runTest
* [`9a020378`](https://github.com/NixOS/nixpkgs/commit/9a02037834a662d7b15be4acbe46c3d4c660aabc) nixosTests.cockroachdb: handleTest -> runTest
* [`4257e82b`](https://github.com/NixOS/nixpkgs/commit/4257e82bcf26f34823d20e6c6ebf13b7b30a5b4d) nixosTests.corerad: handleTest -> runTest
* [`2dd453b7`](https://github.com/NixOS/nixpkgs/commit/2dd453b74b60f903933dd141475fd9dd89fa45a4) nixosTests.cri-o: handleTest -> runTest
* [`5d3ba0f9`](https://github.com/NixOS/nixpkgs/commit/5d3ba0f9a55063847a62ea9ffa104cf2600b4dfc) nixosTests.dhparams: handleTest -> runTest
* [`9880867c`](https://github.com/NixOS/nixpkgs/commit/9880867c45313f14bdd817c9e00ae666c17b27d9) nixosTests.dnscrypt-proxy2: handleTest -> runTest
* [`ea619766`](https://github.com/NixOS/nixpkgs/commit/ea619766ea05f723ad9e9cc77b12632a9d6aef90) nixosTests.docker-tools: handleTest -> runTest
* [`af4f6415`](https://github.com/NixOS/nixpkgs/commit/af4f64154f099a398becddaa6079793b713aed7c) nixosTests.custom-ca: handleTest -> runTest
* [`a72c8b8f`](https://github.com/NixOS/nixpkgs/commit/a72c8b8f6999338bdfb667273a996fa35b792a71) nixosTests.dovecot: handleTest -> runTest
* [`7ea4b7c7`](https://github.com/NixOS/nixpkgs/commit/7ea4b7c71aec46d92350bf7a58c3e7056e37a2ae) nixosTests.earlyoom: handleTest -> runTest
* [`5df085c5`](https://github.com/NixOS/nixpkgs/commit/5df085c57ac03d8f23aed492b1ee80a8ef24d007) nixosTests.early-mount-options: handleTest -> runTest
* [`969bed3f`](https://github.com/NixOS/nixpkgs/commit/969bed3f901ad5c5f1cfb63baa11cf1c3c507aba) nixosTests.etcd: handleTest -> runTest
* [`748a3d52`](https://github.com/NixOS/nixpkgs/commit/748a3d52661f932fb4531ace0af05fc22305ff3c) nixosTests.etcd-cluster: handleTest -> runTest
* [`a5e74df2`](https://github.com/NixOS/nixpkgs/commit/a5e74df22d3f719dcec00b8b946cf61feeb69004) nixosTests.fcitx5: handleTest -> runTest
* [`ab94f951`](https://github.com/NixOS/nixpkgs/commit/ab94f9518a829f4b7f71f01de4949ca7959855c7) nixosTests.ferretdb: handleTest -> runTest
* [`bb763213`](https://github.com/NixOS/nixpkgs/commit/bb7632138666b9121c6e3f00b7706114364d7b5f) nixosTests.firewall{,-nftables}: handleTest -> runTest
* [`40a27ed8`](https://github.com/NixOS/nixpkgs/commit/40a27ed8e72e3ac29dd4e703a488ffdc1cd16b1a) nixosTests.flannel: handleTest -> runTest
* [`da6ecbe5`](https://github.com/NixOS/nixpkgs/commit/da6ecbe5390cbf0e3267e6d5e0151609535de5ba) nixosTests.freshrss: handleTest -> runTest
* [`bc32ab80`](https://github.com/NixOS/nixpkgs/commit/bc32ab809c27f95b05b240c94e1eb303d2325df8) nixosTests.fsck{,-systemd-stage-1}: handleTest -> runTest
* [`503a6ed7`](https://github.com/NixOS/nixpkgs/commit/503a6ed79d37f625343cd1ee4d4b0fce3493ca53) nixosTests.gemstash: handleTest -> runTest
* [`c6f0162e`](https://github.com/NixOS/nixpkgs/commit/c6f0162e5b0a5301ed92e438ec4ada1c1ffeb762) python3Packages.llama-index-vector-stores-postgres: 0.5.3 -> 0.5.4
* [`612960b5`](https://github.com/NixOS/nixpkgs/commit/612960b52e89979ef075d92fef24cdf16ffd5cfa) goshs: 1.0.6 -> 1.1.0
* [`1c8c3c3c`](https://github.com/NixOS/nixpkgs/commit/1c8c3c3c06deaa9741eb6251d0cf80ac2344ffe8) pgroll: 0.13.0 -> 0.14.0
* [`1fa4a873`](https://github.com/NixOS/nixpkgs/commit/1fa4a87353b7fa540961d7d8759fafcd24134b30) python312Packages.adafruit-platformdetect: 3.80.0 -> 3.81.0
* [`188cbfa1`](https://github.com/NixOS/nixpkgs/commit/188cbfa183dcfbc27e9bea99440a8613ea89e22a) python312Packages.reolink-aio: 0.14.1 -> 0.14.2
* [`cc07223a`](https://github.com/NixOS/nixpkgs/commit/cc07223adbd0bd2319984e5bef5e6ce2cd8c92c0) python3Packages.jupyter-docprovider: 2.0.2 -> 2.1.0
* [`77cfb5b4`](https://github.com/NixOS/nixpkgs/commit/77cfb5b4bcf7385344ca6cc2cddca30147acc0ba) honk: 1.5.1 -> 1.5.2
* [`0b06fb10`](https://github.com/NixOS/nixpkgs/commit/0b06fb100e1acb9bf53e036d21bb20052cbad9bd) python3Packages.homematicip: 2.0.6 -> 2.0.7
* [`90475f63`](https://github.com/NixOS/nixpkgs/commit/90475f6398fd0a2f98bdb771eefb429a3e7e3796) sparkle: 1.6.7 -> 1.6.9
* [`fa301642`](https://github.com/NixOS/nixpkgs/commit/fa301642370aa5fce7c2964fe8623c8dba1c2fef) owi: init at 0.2-unstable-2025-05-05
* [`6ff7da34`](https://github.com/NixOS/nixpkgs/commit/6ff7da34f7d79d1214da52c0dc2e236945d2cb4d) karabiner-elements: 15.3.0 -> 15.4.0
* [`a41b6d92`](https://github.com/NixOS/nixpkgs/commit/a41b6d921338a45d9bff9e5d6d37847b6999ec41) git-buildpackage: init at 0.9.37
* [`1402eef9`](https://github.com/NixOS/nixpkgs/commit/1402eef98ff4fa5a8ab5739fa60d86983285b7f6) python312Packages.mypy-boto3-accessanalyzer: 1.38.38 -> 1.39.0
* [`2aedc5d2`](https://github.com/NixOS/nixpkgs/commit/2aedc5d2dea0ffad84d35e3bc97a01ff83435a78) python312Packages.mypy-boto3-account: 1.38.0 -> 1.39.0
* [`dd3549b1`](https://github.com/NixOS/nixpkgs/commit/dd3549b10663d46e5471e0fcc543c2c52ba63cc7) python312Packages.mypy-boto3-acm: 1.38.38 -> 1.39.0
* [`627c173a`](https://github.com/NixOS/nixpkgs/commit/627c173a1c71314c05e1077d7b2724c295d9dc24) python312Packages.mypy-boto3-acm-pca: 1.38.0 -> 1.39.0
* [`23b25fc0`](https://github.com/NixOS/nixpkgs/commit/23b25fc0ebd32140bfa662a88bbe7066f844fff7) python312Packages.mypy-boto3-amp: 1.38.22 -> 1.39.0
* [`ed8f1679`](https://github.com/NixOS/nixpkgs/commit/ed8f16799f785526e2df68d7e2ff73c38df516a3) python312Packages.mypy-boto3-amplify: 1.38.30 -> 1.39.0
* [`37a037f5`](https://github.com/NixOS/nixpkgs/commit/37a037f591b3d208949ef69d8494b2183661604c) python312Packages.mypy-boto3-amplifybackend: 1.38.0 -> 1.39.0
* [`883f5631`](https://github.com/NixOS/nixpkgs/commit/883f5631a2b44872205295b9189529d10160d3d4) python312Packages.mypy-boto3-amplifyuibuilder: 1.38.0 -> 1.39.0
* [`d9698e75`](https://github.com/NixOS/nixpkgs/commit/d9698e7595bf1f26f06c0ef2a3e3b9d4cb0e6722) python312Packages.mypy-boto3-apigateway: 1.38.36 -> 1.39.0
* [`a59b170f`](https://github.com/NixOS/nixpkgs/commit/a59b170f1da485f6503041c8e23b1a201f79e660) python312Packages.mypy-boto3-apigatewaymanagementapi: 1.38.0 -> 1.39.0
* [`2b9937d7`](https://github.com/NixOS/nixpkgs/commit/2b9937d7a9058d61e0fbd3c2516549e2ec1dbea3) python312Packages.mypy-boto3-apigatewayv2: 1.38.36 -> 1.39.0
* [`57f5a004`](https://github.com/NixOS/nixpkgs/commit/57f5a0040befb22e0de52ad9d3d8c268498048fe) python312Packages.mypy-boto3-appconfig: 1.38.7 -> 1.39.0
* [`5272aad5`](https://github.com/NixOS/nixpkgs/commit/5272aad57a35fc4ce27a5d077bbb336a7e75edcc) python312Packages.mypy-boto3-appconfigdata: 1.38.0 -> 1.39.0
* [`138cf971`](https://github.com/NixOS/nixpkgs/commit/138cf971cfe487d866e6ff8b38547fa7defa9ce8) python312Packages.mypy-boto3-appfabric: 1.38.0 -> 1.39.0
* [`e6c46b2f`](https://github.com/NixOS/nixpkgs/commit/e6c46b2fe4903df5b99000c47c8b3e7f8bd17f85) python312Packages.mypy-boto3-appflow: 1.38.0 -> 1.39.0
* [`af0fbb44`](https://github.com/NixOS/nixpkgs/commit/af0fbb4483e8b4fa01285ccf75ac6162d8fc8c8d) python312Packages.mypy-boto3-appintegrations: 1.38.0 -> 1.39.0
* [`eea6b6a4`](https://github.com/NixOS/nixpkgs/commit/eea6b6a4a4343c7dd2c813d51a633582619d78a3) python312Packages.mypy-boto3-application-autoscaling: 1.38.21 -> 1.39.0
* [`c662bc7b`](https://github.com/NixOS/nixpkgs/commit/c662bc7ba3f433941e94dae1f60efe32809fe49c) python312Packages.mypy-boto3-application-insights: 1.38.0 -> 1.39.0
* [`e94f95c1`](https://github.com/NixOS/nixpkgs/commit/e94f95c12cbc3b6ac6cf7d46dde1c81d7e4e4013) python312Packages.mypy-boto3-applicationcostprofiler: 1.38.0 -> 1.39.0
* [`54ba12ea`](https://github.com/NixOS/nixpkgs/commit/54ba12ea8ddf017424d1146645319fc7de1c4637) python312Packages.mypy-boto3-appmesh: 1.38.0 -> 1.39.0
* [`a8c578b0`](https://github.com/NixOS/nixpkgs/commit/a8c578b0834022fa57464737a52729196194a424) python312Packages.mypy-boto3-apprunner: 1.38.2 -> 1.39.0
* [`e278e97e`](https://github.com/NixOS/nixpkgs/commit/e278e97ee21dece69c2c4ea23071e82fbce3e340) python312Packages.mypy-boto3-appstream: 1.38.0 -> 1.39.0
* [`fb463fa1`](https://github.com/NixOS/nixpkgs/commit/fb463fa11de4082ad495b716942f21cf50c6e6d9) python312Packages.mypy-boto3-appsync: 1.38.33 -> 1.39.0
* [`59b6e0b2`](https://github.com/NixOS/nixpkgs/commit/59b6e0b2541d9bc832924c5966d2d8cd9b338190) python312Packages.mypy-boto3-arc-zonal-shift: 1.38.0 -> 1.39.0
* [`df582640`](https://github.com/NixOS/nixpkgs/commit/df582640ae1cee69e4703fb683e71d2189a1f45e) python312Packages.mypy-boto3-athena: 1.38.28 -> 1.39.0
* [`379ebf01`](https://github.com/NixOS/nixpkgs/commit/379ebf010bd9ef59ce25c1e040ef701a135b0a1f) python312Packages.mypy-boto3-auditmanager: 1.38.22 -> 1.39.0
* [`d4563045`](https://github.com/NixOS/nixpkgs/commit/d456304557af7f6e9cfb22ca457e8767cb466f2b) python312Packages.mypy-boto3-autoscaling: 1.38.39 -> 1.39.0
* [`95027d0c`](https://github.com/NixOS/nixpkgs/commit/95027d0c18d16b351eb5c5c886f8303ccc192172) python312Packages.mypy-boto3-autoscaling-plans: 1.38.0 -> 1.39.0
* [`99a70d84`](https://github.com/NixOS/nixpkgs/commit/99a70d84892530c7bb19a15acfe62e04306d7505) python312Packages.mypy-boto3-backup: 1.38.38 -> 1.39.0
* [`ad89cfb2`](https://github.com/NixOS/nixpkgs/commit/ad89cfb262ac2cc80cbaa15bf89cc08ddd72fbf1) python312Packages.mypy-boto3-backup-gateway: 1.38.0 -> 1.39.0
* [`b0d52562`](https://github.com/NixOS/nixpkgs/commit/b0d52562119a221338e68b3f823c456c81538bed) python312Packages.mypy-boto3-batch: 1.38.43 -> 1.39.0
* [`2b9398d5`](https://github.com/NixOS/nixpkgs/commit/2b9398d5281c43bc869a89eaef593cafdb5b3eeb) python312Packages.mypy-boto3-billingconductor: 1.38.0 -> 1.39.0
* [`dd076dd2`](https://github.com/NixOS/nixpkgs/commit/dd076dd2173769c65f5a58944cdfea8510b976e6) python312Packages.mypy-boto3-braket: 1.38.0 -> 1.39.0
* [`d15b7643`](https://github.com/NixOS/nixpkgs/commit/d15b7643d49ae34fcb678db8f3c050fd30a5bf62) python312Packages.mypy-boto3-budgets: 1.38.0 -> 1.39.0
* [`26d6026c`](https://github.com/NixOS/nixpkgs/commit/26d6026c95831c76f7e0b6e251387e54877074d6) python312Packages.mypy-boto3-ce: 1.38.33 -> 1.39.0
* [`3147c6df`](https://github.com/NixOS/nixpkgs/commit/3147c6df094069e350ac729bfcc9aeee863ac082) python312Packages.mypy-boto3-chime: 1.38.0 -> 1.39.0
* [`8672b463`](https://github.com/NixOS/nixpkgs/commit/8672b4636aa34bb7059beb62c96353c0167bf091) python312Packages.mypy-boto3-chime-sdk-identity: 1.38.0 -> 1.39.0
* [`e4c1e39e`](https://github.com/NixOS/nixpkgs/commit/e4c1e39e9f4c4d743917468349f8fe3e5fe9bc16) python312Packages.mypy-boto3-chime-sdk-media-pipelines: 1.38.0 -> 1.39.0
* [`92912701`](https://github.com/NixOS/nixpkgs/commit/92912701459c2d53f24c0c486290182fa9585ad5) python312Packages.mypy-boto3-chime-sdk-meetings: 1.38.0 -> 1.39.0
* [`62321830`](https://github.com/NixOS/nixpkgs/commit/623218303d2dd786ec30aa5def071b69ab91affc) python312Packages.mypy-boto3-chime-sdk-messaging: 1.38.0 -> 1.39.0
* [`a366bcd4`](https://github.com/NixOS/nixpkgs/commit/a366bcd4bbf3e5589b7ae9abf814260b8933bdd6) python312Packages.mypy-boto3-chime-sdk-voice: 1.38.0 -> 1.39.0
* [`0c85e5dc`](https://github.com/NixOS/nixpkgs/commit/0c85e5dc51d0deb0fd528b8df9a8fa5b92ee160b) python312Packages.mypy-boto3-cleanrooms: 1.38.6 -> 1.39.0
* [`19896f27`](https://github.com/NixOS/nixpkgs/commit/19896f270dcd7a6cb29ba030c35199037e884505) python312Packages.mypy-boto3-cloud9: 1.38.0 -> 1.39.0
* [`d59459bd`](https://github.com/NixOS/nixpkgs/commit/d59459bd2b0a8f870761aa0fc839973c11808ba2) python312Packages.mypy-boto3-cloudcontrol: 1.38.0 -> 1.39.0
* [`92664659`](https://github.com/NixOS/nixpkgs/commit/92664659cb2ce4a0d1a4dc23f0349da23d7fcca6) python312Packages.mypy-boto3-clouddirectory: 1.38.0 -> 1.39.0
* [`819230af`](https://github.com/NixOS/nixpkgs/commit/819230afad19afd2ce0fac3311b7ad4b654a8367) python312Packages.mypy-boto3-cloudformation: 1.38.31 -> 1.39.0
* [`0b7825d8`](https://github.com/NixOS/nixpkgs/commit/0b7825d8590bab3b2503d74906d991e0a745ac0a) python312Packages.mypy-boto3-cloudfront: 1.38.12 -> 1.39.0
* [`dd3a67ae`](https://github.com/NixOS/nixpkgs/commit/dd3a67ae34bf8c4b327d331429162e38434e31f0) python312Packages.mypy-boto3-cloudhsm: 1.38.0 -> 1.39.0
* [`e314d06d`](https://github.com/NixOS/nixpkgs/commit/e314d06d8eb0994d206fb040138074f70e428237) python312Packages.mypy-boto3-cloudhsmv2: 1.38.0 -> 1.39.0
* [`8ee9d105`](https://github.com/NixOS/nixpkgs/commit/8ee9d105b8feaed397b6ccf612bd93100bb8d1d8) python312Packages.mypy-boto3-cloudsearch: 1.38.0 -> 1.39.0
* [`0d8dd5cd`](https://github.com/NixOS/nixpkgs/commit/0d8dd5cd2cb3bec1eaef2f11e6becbfa5fdef797) python312Packages.mypy-boto3-cloudsearchdomain: 1.38.0 -> 1.39.0
* [`cf796c1e`](https://github.com/NixOS/nixpkgs/commit/cf796c1e4a298b249a05632a9368aa5fe6b05f05) python312Packages.mypy-boto3-cloudtrail: 1.38.26 -> 1.39.0
* [`d6370490`](https://github.com/NixOS/nixpkgs/commit/d6370490678972abac62d530867388f2808f73ea) python312Packages.mypy-boto3-cloudtrail-data: 1.38.0 -> 1.39.0
* [`d4133f32`](https://github.com/NixOS/nixpkgs/commit/d4133f32b6737125e81b1349d680ca5a082c76d9) python312Packages.mypy-boto3-cloudwatch: 1.38.21 -> 1.39.0
* [`d26e24e6`](https://github.com/NixOS/nixpkgs/commit/d26e24e6ffcff41e31dfb5d4d0fc70371dce1212) python312Packages.mypy-boto3-codeartifact: 1.38.0 -> 1.39.0
* [`0a9ae1dd`](https://github.com/NixOS/nixpkgs/commit/0a9ae1dda36c8133bda0e0b010016aec27ba1ddd) python312Packages.mypy-boto3-codebuild: 1.38.17 -> 1.39.0
* [`844a52ab`](https://github.com/NixOS/nixpkgs/commit/844a52ab447b60f720ec1b727299c44fc3f9f41c) python312Packages.mypy-boto3-codecatalyst: 1.38.0 -> 1.39.0
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
