### PR TITLE
niv home-manager: update 96354906 -> fd9e55f5

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -65,10 +65,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "96354906f58464605ff81d2f6c2ea23211cbf051",
-        "sha256": "0pcsnhggwgphh7f78q0842l3dq84yhgipvn4cpf5xckydjpxbnd6",
+        "rev": "fd9e55f5fac45a26f6169310afca64d56b681935",
+        "sha256": "0cikf631s9h9s4dfgdqnmklcllw1qkb8b5m51k8bx56k478c4c38",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/96354906f58464605ff81d2f6c2ea23211cbf051.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/fd9e55f5fac45a26f6169310afca64d56b681935.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@96354906...fd9e55f5](https://github.com/nix-community/home-manager/compare/96354906f58464605ff81d2f6c2ea23211cbf051...fd9e55f5fac45a26f6169310afca64d56b681935)

* [`479f8889`](https://github.com/nix-community/home-manager/commit/479f8889675770881033878a1c114fbfc6de7a4d) bash: support path in sessionVariables again ([nix-community/home-manager⁠#7354](https://togithub.com/nix-community/home-manager/issues/7354))
* [`44a2308d`](https://github.com/nix-community/home-manager/commit/44a2308db94b063c8dcb6505f61fdd225e571041) scripts/generate-all-maintainers.py: add script
* [`11db5613`](https://github.com/nix-community/home-manager/commit/11db56137d1efbf663f614c7714c9224d4dd818d) all-maintainers.nix: initial creation
* [`77bb9e03`](https://github.com/nix-community/home-manager/commit/77bb9e033b500a7111cee096555d510b715a3fb3) ci: add update-maintainers.yml
* [`5d2f3e3e`](https://github.com/nix-community/home-manager/commit/5d2f3e3e7fbb2cd8cab8b5f9e51526b1269645b9) ci: fix update-maintainers reference location ([nix-community/home-manager⁠#7357](https://togithub.com/nix-community/home-manager/issues/7357))
* [`e96a8a32`](https://github.com/nix-community/home-manager/commit/e96a8a325cf23538a7f58b9335b4c4c0b393bacf) ci: conditional test step runs ([nix-community/home-manager⁠#7358](https://togithub.com/nix-community/home-manager/issues/7358))
* [`121b430d`](https://github.com/nix-community/home-manager/commit/121b430df7b5c5eeb9d37dff2a3ba1883a9e51e1) maintainers: fix incorrect entries ([nix-community/home-manager⁠#7360](https://togithub.com/nix-community/home-manager/issues/7360))
* [`212f4a4f`](https://github.com/nix-community/home-manager/commit/212f4a4fb20449d51bbc403e3d140778aab4d18a) ci: update-maintainers fetch nixpkgs from flake.lock rev
* [`29d717aa`](https://github.com/nix-community/home-manager/commit/29d717aab5189b3383d965928823ddac8a95e8f3) ci: tests fetch nixpkgs from flake.lock rev
* [`df122690`](https://github.com/nix-community/home-manager/commit/df12269039dcf752600b1bcc176bacf2786ec384) maintainers: update all-maintainers.nix ([nix-community/home-manager⁠#7361](https://togithub.com/nix-community/home-manager/issues/7361))
* [`6c53df3b`](https://github.com/nix-community/home-manager/commit/6c53df3b9c809e3b4b30d515e18bfa4c6f079254) flake.lock: Update ([nix-community/home-manager⁠#7363](https://togithub.com/nix-community/home-manager/issues/7363))
* [`4bd46345`](https://github.com/nix-community/home-manager/commit/4bd4634525150766b96facdb8a35bb991de67956) ci: fix update-flake branch inputs ([nix-community/home-manager⁠#7345](https://togithub.com/nix-community/home-manager/issues/7345))
* [`77027882`](https://github.com/nix-community/home-manager/commit/77027882a7f637f84f7c221406b75f1463f5a321) ci: prefix flake update prs ([nix-community/home-manager⁠#7366](https://togithub.com/nix-community/home-manager/issues/7366))
* [`3d243d4a`](https://github.com/nix-community/home-manager/commit/3d243d4a16cafe855df585b3030aa99261a27a86) ci: fix which branch to show on pr ([nix-community/home-manager⁠#7368](https://togithub.com/nix-community/home-manager/issues/7368))
* [`7c455533`](https://github.com/nix-community/home-manager/commit/7c455533409411b4053bb6d7db71eb35e0544254) mpvpaper: fix eval if no settings are defined ([nix-community/home-manager⁠#7370](https://togithub.com/nix-community/home-manager/issues/7370))
* [`7241b18a`](https://github.com/nix-community/home-manager/commit/7241b18a7bdaec265b26a7951557a1a1e367d4f8) ci: make update-maintainers check-changes multiline
* [`be8f7e10`](https://github.com/nix-community/home-manager/commit/be8f7e100f285167793f7ff77ce8e5b60ab48e26) ci: move update-maintainers commit/pr to env
* [`bafcf336`](https://github.com/nix-community/home-manager/commit/bafcf336870c9daca80df1c4a09ef926fc497016) ci: use env in update-maintainers changes summary
* [`a7820832`](https://github.com/nix-community/home-manager/commit/a7820832c68180b612587a23f46f1b94a28b3407) ci: fix update-maintainers indentation ([nix-community/home-manager⁠#7372](https://togithub.com/nix-community/home-manager/issues/7372))
* [`9347c61b`](https://github.com/nix-community/home-manager/commit/9347c61bc0cbed0d2062b930144c2cbd557f9189) ci: use GITHUB_TOKEN when app config missing ([nix-community/home-manager⁠#7374](https://togithub.com/nix-community/home-manager/issues/7374))
* [`25f003f8`](https://github.com/nix-community/home-manager/commit/25f003f8a9eae31a11938d53cb23e0b4a3c08d3a) ci: tag maintainers automatically for PR reviews ([nix-community/home-manager⁠#6921](https://togithub.com/nix-community/home-manager/issues/6921))
* [`1b25908d`](https://github.com/nix-community/home-manager/commit/1b25908d1dc6832c3cced1aba29b6ff932b6a0bd) firefox: fix user.js extensions.settings creation
* [`89af52d9`](https://github.com/nix-community/home-manager/commit/89af52d9a893af013f5f4c1d2d56912106827153) tests/firefox: add extension user.js test
* [`a5b56720`](https://github.com/nix-community/home-manager/commit/a5b56720841121d2189c011e445c4be4c943bab5) kitty: add config change signal on darwin ([nix-community/home-manager⁠#7375](https://togithub.com/nix-community/home-manager/issues/7375))
* [`66de606f`](https://github.com/nix-community/home-manager/commit/66de606f48f789b0a407d842714de8dd01893dc5) ci: update all-maintainers on merge
* [`426b405d`](https://github.com/nix-community/home-manager/commit/426b405d979d893832549b95f23c13537c65d244) ci: add validation workflow for maintainers list
* [`b182e64c`](https://github.com/nix-community/home-manager/commit/b182e64c01aa4e61a007691525a3ea498a9aee63) zed-editor: survive if previous files are not JSON5 ([nix-community/home-manager⁠#7351](https://togithub.com/nix-community/home-manager/issues/7351))
* [`1fa73bb2`](https://github.com/nix-community/home-manager/commit/1fa73bb2cc39e250eb01e511ae6ac83bfbf9f38c) fix(service/gpg-agent): allow SSH ForwardAgent compatibility ([nix-community/home-manager⁠#7355](https://togithub.com/nix-community/home-manager/issues/7355))
* [`28639e64`](https://github.com/nix-community/home-manager/commit/28639e6470ef597fe9f5efc4c6594306859d62ed) ci: cancel previous runs ([nix-community/home-manager⁠#7378](https://togithub.com/nix-community/home-manager/issues/7378))
* [`b46c6937`](https://github.com/nix-community/home-manager/commit/b46c6937970a3dc3141136134f8244b5a928a7f6) lib: add extract-maintainers-meta
* [`d03fa2d8`](https://github.com/nix-community/home-manager/commit/d03fa2d84c6c7def463f9ff90d6a36d5873de0fc) ci: generate-all-maintainers use nix eval update
* [`09ef413c`](https://github.com/nix-community/home-manager/commit/09ef413c804bde7afc259c67b2dcb4cc999913f6) all-maintainers: update
* [`7044c3ec`](https://github.com/nix-community/home-manager/commit/7044c3eced5319148c09fe9612659765b9297d4a) ci: tag-maintainers fix fetching maintainers ([nix-community/home-manager⁠#7380](https://togithub.com/nix-community/home-manager/issues/7380))
* [`7582cbfa`](https://github.com/nix-community/home-manager/commit/7582cbfabce2ff1626083f1c73a2e3c74ee4cf40) ci: check for new maintainers on updates
* [`03c3576f`](https://github.com/nix-community/home-manager/commit/03c3576f8b7e3d2154fba3f450e2bfd942024e1e) ci: remove unneeded reviewers
* [`402333d5`](https://github.com/nix-community/home-manager/commit/402333d5ec2f9eed0f2584555936361f39d2f93e) ci: concurrency protect tag flow
* [`83f97881`](https://github.com/nix-community/home-manager/commit/83f978812c37511ef2ffaf75ffa72160483f738a) podman: support mounts configuration ([nix-community/home-manager⁠#7377](https://togithub.com/nix-community/home-manager/issues/7377))
* [`31242bdf`](https://github.com/nix-community/home-manager/commit/31242bdf8f5fff430a23bc167dd8e0fb2fce4c35) polybar: fix meta.maintainer position
* [`18e1f7fb`](https://github.com/nix-community/home-manager/commit/18e1f7fbce644f9fe44cf38faad137f2d0bfa1af) ci: validate maintainers also checks for duplicate maintainers
* [`b8bb556c`](https://github.com/nix-community/home-manager/commit/b8bb556ce5abe5bbc10acb7508ef273b053f647d) maintainers: remove duplicate HM entries
* [`f6d11046`](https://github.com/nix-community/home-manager/commit/f6d11046657ea7e22a70be602f1b05ea61684056) extract-maintainers-meta: include non module system files
* [`412c545b`](https://github.com/nix-community/home-manager/commit/412c545bb6df640c795177b02f79831087132267) extract-maintainers-meta: simplify
* [`7d9e3c35`](https://github.com/nix-community/home-manager/commit/7d9e3c35f0d46f82bac791d76260f15f53d83529) all-maintainers: regenerate with latest changes
* [`57d1027e`](https://github.com/nix-community/home-manager/commit/57d1027e1eaf1220342248ff18d34f42b0beea7b) aerc: allow config sections to be lines ([nix-community/home-manager⁠#7280](https://togithub.com/nix-community/home-manager/issues/7280))
* [`e8da7372`](https://github.com/nix-community/home-manager/commit/e8da7372fd1f0da3fe3874af3aa9ddd78662d8ae) anki: add module ([nix-community/home-manager⁠#7274](https://togithub.com/nix-community/home-manager/issues/7274))
* [`a4fc77c6`](https://github.com/nix-community/home-manager/commit/a4fc77c63d41b74f156f25fb34be905527865028) ashell: new ashell 0.5.0 config standards
* [`19f0ba9c`](https://github.com/nix-community/home-manager/commit/19f0ba9c52f30c1a26e816a05bddf6b4aa9e327d) lib/deprecations: add remapAttrsRecursive
* [`f62e9a81`](https://github.com/nix-community/home-manager/commit/f62e9a8114bc181ae160c9a1d7ce8205fa5619b0) lib/strings: add extra string matching predicates
* [`650a38eb`](https://github.com/nix-community/home-manager/commit/650a38ebe819d439ece41b5a1c510b3244896265) ashell: support yaml and toml config
* [`36c57c6a`](https://github.com/nix-community/home-manager/commit/36c57c6a1d03a5efbf5e23c04dbe21259d25f992) lib/deprecations: add ignore parameter to remapAttrsRecursive
* [`d75a5474`](https://github.com/nix-community/home-manager/commit/d75a547415f08a52a1e8fc84a1bef9e48bba4c5c) programs.msmtp: merge extraConfig and extraAccount into configContent ([nix-community/home-manager⁠#7385](https://togithub.com/nix-community/home-manager/issues/7385))
* [`26d405da`](https://github.com/nix-community/home-manager/commit/26d405da4179c7dafc0a84e611edfa2f5ddf7faa) numbat: Add initFile option
* [`f117b383`](https://github.com/nix-community/home-manager/commit/f117b383dd591fd579bce5ee7bac07a3fdc1d050) numbat: Allow specifying a path for initFile
* [`5a49fe44`](https://github.com/nix-community/home-manager/commit/5a49fe448e81ee05ab48ed3189109b322237ddbf) opencode: init ([nix-community/home-manager⁠#7320](https://togithub.com/nix-community/home-manager/issues/7320))
* [`92db5be8`](https://github.com/nix-community/home-manager/commit/92db5be8e17c5150c46a2ca8f55a85d20df75643) maintainers: add m0nsterrr
* [`af8a8841`](https://github.com/nix-community/home-manager/commit/af8a884164bb50ad34c09719bdbdb2a1b01b917c) kubeswitch: add module
* [`8b0180dd`](https://github.com/nix-community/home-manager/commit/8b0180dde1d6f4cf632e046309e8f963924dfbd0) maintainers: update all-maintainers.nix ([nix-community/home-manager⁠#7392](https://togithub.com/nix-community/home-manager/issues/7392))
* [`cc740783`](https://github.com/nix-community/home-manager/commit/cc7407839d09cef4838c9980ee3a390c28085951) flake.lock: Update ([nix-community/home-manager⁠#7395](https://togithub.com/nix-community/home-manager/issues/7395))
* [`502d9b7d`](https://github.com/nix-community/home-manager/commit/502d9b7d30a1f5940ecdb786b4f71ebf57b1ac13) codex: starting with v0.2.0 codex uses a TOML configuration file ([nix-community/home-manager⁠#7388](https://togithub.com/nix-community/home-manager/issues/7388))
* [`153e680c`](https://github.com/nix-community/home-manager/commit/153e680c4263fbd8fa416ef5b8ef13397e02fd2f) firefox: add release option ([nix-community/home-manager⁠#6784](https://togithub.com/nix-community/home-manager/issues/6784))
* [`b4486ff4`](https://github.com/nix-community/home-manager/commit/b4486ff44addd453a64fd8c176ab2fd7ad3f6eb3) mkFirefoxModule: add extension settings example to policies ([nix-community/home-manager⁠#7397](https://togithub.com/nix-community/home-manager/issues/7397))
* [`9d21f998`](https://github.com/nix-community/home-manager/commit/9d21f9985e279bb5d35dbf03a25644ed6e954d8c) i3-sway/lib: modifier accepts any string ([nix-community/home-manager⁠#7398](https://togithub.com/nix-community/home-manager/issues/7398))
* [`dbac1fbc`](https://github.com/nix-community/home-manager/commit/dbac1fbcd675c7e7149a35309269c37aef6223ee) mkFirefoxModule: set `NoDefaultBookmarks` when a profile has bookmarks are enabled
* [`753ea0b3`](https://github.com/nix-community/home-manager/commit/753ea0b3240ae3d64923dc77e33aa5c1be06b62f) librewolf: allow bookmark configuration
* [`fd9e55f5`](https://github.com/nix-community/home-manager/commit/fd9e55f5fac45a26f6169310afca64d56b681935) tests/firefox: add bookmark policy to profile bookmarks test
