### PR TITLE
niv nixpkgs: update 2defa371 -> a94dd3a6

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -143,10 +143,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2defa37146df235ef62f566cde69930a86f14df1",
-        "sha256": "0lr2f1j6wqmxb8vg1v92qvs4q89yvbv4h7505gwgqfl261yybhpq",
+        "rev": "a94dd3a654caea2e1229fc4eea0bd6f2f85ca530",
+        "sha256": "0kx5zbbvh3ndcbxn87iikzjfa8shlixc49ybkrfr5jwgjasdc06k",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/2defa37146df235ef62f566cde69930a86f14df1.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/a94dd3a654caea2e1229fc4eea0bd6f2f85ca530.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@2defa371...a94dd3a6](https://github.com/nixos/nixpkgs/compare/2defa37146df235ef62f566cde69930a86f14df1...a94dd3a654caea2e1229fc4eea0bd6f2f85ca530)

* [`5524013d`](https://github.com/NixOS/nixpkgs/commit/5524013d04168a7314e6e9d1fbb8827f6abd4799) grafanaPlugins.grafana-github-datasource: 1.9.0 -> 1.9.2
* [`fbe94a25`](https://github.com/NixOS/nixpkgs/commit/fbe94a25689ab1c763a83c52ef4e62314bdfdc1b) coqPackages.Ordinal: 0.5.3 -> 0.5.4
* [`da0bcbb2`](https://github.com/NixOS/nixpkgs/commit/da0bcbb232c2ee67cb27c72eb44b32eba00f73cd) libedit: 20240808-3.1 -> 20250104-3.1
* [`3e21bff5`](https://github.com/NixOS/nixpkgs/commit/3e21bff586c9ec097fffb05e2bf2279d8427cae8) ceedling: 1.0.0 -> 1.0.1
* [`fa813bf1`](https://github.com/NixOS/nixpkgs/commit/fa813bf120b659ea8b392f918c27606496c60ec7) starc: refactor
* [`34e16b61`](https://github.com/NixOS/nixpkgs/commit/34e16b61339afa5c237a08233481a57d2b2f2aa6) xfsprogs: mark as broken on musl
* [`738723a8`](https://github.com/NixOS/nixpkgs/commit/738723a8044a48e7be38f1767da3fe153181aa00) sbc: 2.0 -> 2.1
* [`9bdda692`](https://github.com/NixOS/nixpkgs/commit/9bdda69267d4f0ab4c11f6ffca10771dd685ca91) exempi: 2.6.5 -> 2.6.6
* [`c308179f`](https://github.com/NixOS/nixpkgs/commit/c308179f6c3a02de146a3dfbb0c6e100c80dfcc2) ocl-icd: 2.3.2 -> 2.3.3
* [`9a2cd0e2`](https://github.com/NixOS/nixpkgs/commit/9a2cd0e2882ccc4c0e1f282c405509b13b0c6ded) mpfr: disable trivialautovarinit hardening flag
* [`f6b6b316`](https://github.com/NixOS/nixpkgs/commit/f6b6b316a95ea6537f31244dc1ba4b0e66aef008) soundtouch: 2.3.3 -> 2.4.0
* [`b7e3409d`](https://github.com/NixOS/nixpkgs/commit/b7e3409dc8fc9926558e3406f39335569a163a9d) cups: 2.4.11 -> 2.4.12
* [`bd23faa5`](https://github.com/NixOS/nixpkgs/commit/bd23faa5fb73aab5bacaaf3252f7d0a8655b3909) inih: 58 -> 60
* [`f1bf0a27`](https://github.com/NixOS/nixpkgs/commit/f1bf0a27a9b3f85ba28308c95d18fab2f627e206) isocodes: 4.17.0 -> 4.18.0
* [`e604be51`](https://github.com/NixOS/nixpkgs/commit/e604be51b6ea97505eeb66b8d36bbdc46107f382) libaom: 3.11.0 -> 3.12.1
* [`ccbf4cb3`](https://github.com/NixOS/nixpkgs/commit/ccbf4cb3ac2968562b23bc3c8e98a1a31c07a79f) openfec: 1.4.2.11 -> 1.4.2.12
* [`9b88776d`](https://github.com/NixOS/nixpkgs/commit/9b88776d080c35b053b2afaeeed4e56cd58744ee) bats-detik: 1.3.2 -> 1.3.3
* [`f370ef7a`](https://github.com/NixOS/nixpkgs/commit/f370ef7ab3329198f7e3b0007452e5a6a2f0bb63) python312Packages.uncertainties: 3.2.2 -> 3.2.3
* [`8128069a`](https://github.com/NixOS/nixpkgs/commit/8128069a9e238ba97440b7aceeb30ab7f381e8fe) python312Packages.uncertainties: no with lib; in meta
* [`dc339e4c`](https://github.com/NixOS/nixpkgs/commit/dc339e4c09795ed045b3881315c26976bd77563f) python312Packages.uncertainties: add doronbehar to maintainers
* [`de9e4cce`](https://github.com/NixOS/nixpkgs/commit/de9e4cced34b11fdffe30353812f6171f857222b) python312Packages.uncertainties: update meta.homepage
* [`110ffe44`](https://github.com/NixOS/nixpkgs/commit/110ffe44633cea535b4b46e3467a9d17ffe75eb4) memcached: 1.6.37 -> 1.6.38
* [`8029435a`](https://github.com/NixOS/nixpkgs/commit/8029435ac936a1dc41649b005a23efcfdb65314f) python3Packages.openai-agents: init at 0.0.13
* [`58bb6b61`](https://github.com/NixOS/nixpkgs/commit/58bb6b61e44346463da6d803d315c95cdf6f63bf) lmfit: patch a test failure with uncertainties 3.2.3
* [`e8a205e2`](https://github.com/NixOS/nixpkgs/commit/e8a205e2bb5bb0c67ed4f58e54c9a66ea3f44c25) gtest: 1.16.0 -> 1.17.0
* [`34180c10`](https://github.com/NixOS/nixpkgs/commit/34180c104a0a6450819de08858acbc718b39c971) jdk11: 11.0.26+4 -> 11.0.27+6
* [`5fdb425d`](https://github.com/NixOS/nixpkgs/commit/5fdb425d242551559c41f6a920c3b73c070f361c) rkbin: unstable-2024.10.23 -> 0-unstable-2025-01-24
* [`819364cf`](https://github.com/NixOS/nixpkgs/commit/819364cf0c0eeda17f9ee15cc5927f94067acdb8) ubootTools: add fw_printenv/fw_setenv tool
* [`cf478129`](https://github.com/NixOS/nixpkgs/commit/cf4781291c75a6c0df6da51cef68969ae8101842) r53-ddns: 1.1.0 -> 1.3.0
* [`d69eadeb`](https://github.com/NixOS/nixpkgs/commit/d69eadeb94c291d73bc448d715bdb5c07a22a563) nixos/r53-ddns: Add new option for record ttl
* [`77dda472`](https://github.com/NixOS/nixpkgs/commit/77dda472ebbdb5fd03ef9c4992af302f259223d2) temurin-{,jre-}bin-{8,11,17,24}: update
* [`098b4ad7`](https://github.com/NixOS/nixpkgs/commit/098b4ad72808e3a17b2bcc458e3bdd4cdcb6c4d0) libsystemtap: 5.2 -> 5.3
* [`e65bb5dd`](https://github.com/NixOS/nixpkgs/commit/e65bb5dd95ad1dd04334451ef0426d96595665cc) fluidsynth: 2.4.4 -> 2.4.6
* [`f353836b`](https://github.com/NixOS/nixpkgs/commit/f353836b642516fea7623400ba2dc605531bd6e4) gumbo: 0.13.0 -> 0.13.1
* [`5240499f`](https://github.com/NixOS/nixpkgs/commit/5240499fb672c5f7e25cd84bff780062cb3cf75a) snappy: 1.2.1 -> 1.2.2 (take 2)
* [`2fc7ee32`](https://github.com/NixOS/nixpkgs/commit/2fc7ee32edbd78fbaf2a96ad39cbc27d92105834) libplist: 2.6.0 -> 2.7.0
* [`3e41cf9c`](https://github.com/NixOS/nixpkgs/commit/3e41cf9c05832ca47a886d134fe1967fed4c0cd3) libdecor: 0.2.2 -> 0.2.3
* [`cc0105ed`](https://github.com/NixOS/nixpkgs/commit/cc0105ed3c064a9fe0ba9bb12934b7aa6d95c0cc) haskell.packages.ghc912.feed: jailbreak t avoid bounds on time, base
* [`272b8f93`](https://github.com/NixOS/nixpkgs/commit/272b8f93b781254cac1f33f50f4d5b9c798355e4) haskell.packages.ghc912.xml-conduit: fix test suite with GHC 9.12
* [`ca0a6818`](https://github.com/NixOS/nixpkgs/commit/ca0a68187bbc3aad6f58c1f6664df71d1486f2cf) haskellPackages.migrant-{core,sqlite-simple,hdbc,postgresql-simple}: unbreak
* [`09bb119f`](https://github.com/NixOS/nixpkgs/commit/09bb119fa228b2347d7adccef4e4751fb10d570a) haskell.packages.ghc90.sv2v: drop obsolete override
* [`e3bf9811`](https://github.com/NixOS/nixpkgs/commit/e3bf9811986d255fad07f738bea5ba5b949de915) chromaprint: disable trivialautovarinit hardening flag
* [`3efb9be7`](https://github.com/NixOS/nixpkgs/commit/3efb9be7872b58eefcc3cb7c5b3369f6f738e3fc) harfbuzz: 10.2.0 -> 11.2.1
* [`091dc00d`](https://github.com/NixOS/nixpkgs/commit/091dc00dc384b2a42ed83539a127ab377108f71f) less: 668 -> 678
* [`92d4357d`](https://github.com/NixOS/nixpkgs/commit/92d4357d64d16988dd0264b4b9a4c16a78bb2b86) liburcu: 0.15.2 -> 0.15.3
* [`9b27c596`](https://github.com/NixOS/nixpkgs/commit/9b27c596f4a66d32259e8f2e2eec5a4d0fb3f615) liburcu: enable parallel building
* [`430a1e6f`](https://github.com/NixOS/nixpkgs/commit/430a1e6f49c1e1b98074646f79faa3632173c511) ocamlPackages.gapi-ocaml: 0.4.5 -> 0.4.6
* [`95d01d9e`](https://github.com/NixOS/nixpkgs/commit/95d01d9e6c50bda13f4f39fc2f921a20b153a644) haskellPackages.cabal-lenses: build with required version of Cabal
* [`f95b0821`](https://github.com/NixOS/nixpkgs/commit/f95b0821149f6a477b62b90206c035448f143947) devpi-server: 6.14.0 -> 6.15.0
* [`2d7cbf1b`](https://github.com/NixOS/nixpkgs/commit/2d7cbf1b1df2633bae3b1c45e402b30759db56bf) openresolv: 3.13.2 -> 3.16.5
* [`a1de5187`](https://github.com/NixOS/nixpkgs/commit/a1de5187fbdb70c5d350dbdd7028cb09ccb2cb56) openssl: 3.4.1 -> 3.5.0
* [`a157a39c`](https://github.com/NixOS/nixpkgs/commit/a157a39c563de4381366c0181e089bd23d35763d) quictls: fix openssl patch paths for 3.5
* [`3faaa3c8`](https://github.com/NixOS/nixpkgs/commit/3faaa3c83b014e51359e00a9b5606fd5002e5062) openssl: adaptations for combined handshakes and the PQC era
* [`6b31f8df`](https://github.com/NixOS/nixpkgs/commit/6b31f8df35e7febc6c48df6f73e2d2d2e8990be6) openssl_3_5: fix for CVE-2025-4575
* [`b174c206`](https://github.com/NixOS/nixpkgs/commit/b174c2069a4800531ff128bace2802f290f07077) gutenprint: 5.3.4 -> 5.3.5
* [`1b29695c`](https://github.com/NixOS/nixpkgs/commit/1b29695c8bb75f97e3fe9b06b558e4ee3bd7a119) libvoikko: 4.3.2 -> 4.3.3
* [`7c0dfa5f`](https://github.com/NixOS/nixpkgs/commit/7c0dfa5fae98b1bcbb73a89604504c8e7c7d958c) doxygen: 1.13.2 -> 1.14.0
* [`72567ad7`](https://github.com/NixOS/nixpkgs/commit/72567ad7eef2155f862adf2c22f756b3e937578f) zix: 0.4.2 -> 0.6.2
* [`eb4de2e9`](https://github.com/NixOS/nixpkgs/commit/eb4de2e9667ade588db8f27506a82a7c0edd8b96) gbenchmark: 1.9.1 -> 1.9.4
* [`11c29f09`](https://github.com/NixOS/nixpkgs/commit/11c29f0964c00ab8623c4bae05284ede9c30c105) python3Packages.gyp: unstable-2022-04-01 -> unstable-2024-02-07
* [`aebdf4f1`](https://github.com/NixOS/nixpkgs/commit/aebdf4f1b17d674d88eec824f400343bf900a8c4) iproute2: 6.14.0 -> 6.15.0
* [`105a92c4`](https://github.com/NixOS/nixpkgs/commit/105a92c4ef1a30f013cd1672488bc0e6c965d04b) pahole: 1.29 -> 1.30
* [`4d6af36c`](https://github.com/NixOS/nixpkgs/commit/4d6af36c7368131c503ff0527f260889c71c1592) tiny-dfr: 0.3.2 -> 0.3.5
* [`16dca700`](https://github.com/NixOS/nixpkgs/commit/16dca700d737702eb122fd50f5794ecb8a75e491) haskell.compiler.ghc94: don't roundtrip C compilation via assembly
* [`1b450cd7`](https://github.com/NixOS/nixpkgs/commit/1b450cd798644fae74bd7127eba25a278df8d9c9) supercollider: use wrapQtAppsHook when building
* [`3c3fef04`](https://github.com/NixOS/nixpkgs/commit/3c3fef04a2180000b1ce537b08d3f80e991c959b) haskell.compiler.ghc*Binary: detect -lnuma based on library list
* [`221e06a5`](https://github.com/NixOS/nixpkgs/commit/221e06a56d6fd1cb70aa3d75a4fee49a317d2cd4) haskell.compiler.ghc902Binary: init at 9.0.2
* [`da08e91e`](https://github.com/NixOS/nixpkgs/commit/da08e91e7761fdc453d8c9132bbead7634e40027) haskell.compiler.ghc94: bootstrap from 9.0.2 bindist
* [`e941d468`](https://github.com/NixOS/nixpkgs/commit/e941d4686f46202f15dfc9de19141e299ef7de7d) haskell.compiler.ghc928: bootstrap from 9.0.2 bindist
* [`21169e4a`](https://github.com/NixOS/nixpkgs/commit/21169e4a28aba86166d4d3f2f02953ac5963f999) amf-headers: fix hash
* [`4416e7b0`](https://github.com/NixOS/nixpkgs/commit/4416e7b0811ad038afd696f6c9f7bda38beba5e4) xvfb-run: fix and enable strictDeps
* [`884f87ec`](https://github.com/NixOS/nixpkgs/commit/884f87ec2c25184589a490628a65c57d79cbef64) kdePackages.taglib: 2.0.2 -> 2.1
* [`1660cdab`](https://github.com/NixOS/nixpkgs/commit/1660cdab1c4819a3b2fcc9a061c88147daead030) aliases: remove buildFHSUserEnv*
* [`db8b2611`](https://github.com/NixOS/nixpkgs/commit/db8b2611a28af0fa3bada3e5f50a1d7eddc7fa59) python3Packages.pytest-trio: modernize
* [`8b6b9329`](https://github.com/NixOS/nixpkgs/commit/8b6b9329ea4b1a85781b0e74199b60e1e40e0e84) python3Packages.pytest-trio: add mit license to meta.license
* [`4723cc30`](https://github.com/NixOS/nixpkgs/commit/4723cc3000960d3590b30c3c5a90ecf2f2b880ce) python3Packages.trio: remove formatter from nativeCheckInputs
* [`fcc4b91f`](https://github.com/NixOS/nixpkgs/commit/fcc4b91f7412183756d823e5993b0cb051175ded) python3Packages.zstandard: modernize
* [`a1a67c2e`](https://github.com/NixOS/nixpkgs/commit/a1a67c2e071d97b68855f9062992d016046658a7) python3Packages.zstandard: enable tests
* [`5a24de05`](https://github.com/NixOS/nixpkgs/commit/5a24de05c237776b966b49fa1942167c1daab996) python3Packages.zstandard: add note explaining why we don't provide system zstd
* [`c670990e`](https://github.com/NixOS/nixpkgs/commit/c670990e329f5014c3e04facd0ba3d541844649f) armips: migrate to by-name
* [`d0c39b61`](https://github.com/NixOS/nixpkgs/commit/d0c39b61cdb9c651750070f9d643f66d322d24af) armips: build with Clang instead of GCC 10, run tests
* [`aec7733e`](https://github.com/NixOS/nixpkgs/commit/aec7733ebf636c13e2b8e093543941f99f09dd75) python313Packages.pysmi: 1.5.9 -> 1.5.10
* [`9d5a4d1c`](https://github.com/NixOS/nixpkgs/commit/9d5a4d1cfe183a5d2f9272c136140589823f0b44) pypy3Packages.pycodestyle: disable broken test
* [`0372fe59`](https://github.com/NixOS/nixpkgs/commit/0372fe5909ff5770eb804f7506f7413434cb72e4) haskellPackages: stackage LTS 23.21 -> LTS 23.24
* [`09fd7b1c`](https://github.com/NixOS/nixpkgs/commit/09fd7b1c404e3873ceae8be5a040016545c668e3) all-cabal-hashes: 2025-05-05T12:06:43Z -> 2025-06-01T18:10:16Z
* [`db893e3f`](https://github.com/NixOS/nixpkgs/commit/db893e3f7e969c621cfbd53467971113147605b7) haskellPackages: regenerate package set based on current config
* [`ec0d7f60`](https://github.com/NixOS/nixpkgs/commit/ec0d7f60e250b31e42e1bdb1200b18c91784ff88) alsa-lib: 1.2.13 -> 1.2.14
* [`5d69a7eb`](https://github.com/NixOS/nixpkgs/commit/5d69a7eb2866b6464b178c365c8b81222a5ff7b9) haskell.packages.ghc910.ghc-lib: 9.10.2.20250503 -> 9.10.2.20250515
* [`13746bf7`](https://github.com/NixOS/nixpkgs/commit/13746bf7ccea496707c56acc01f4e1329145266e) libopenmpt: 0.7.13 -> 0.8.0
* [`2c45299b`](https://github.com/NixOS/nixpkgs/commit/2c45299b8dc01412b93e73f84ee7dfbb7bcbbf9a) pandoc: Backport patch from 3.6.4 to fix tests
* [`edb66477`](https://github.com/NixOS/nixpkgs/commit/edb66477bd66dd4717900d600b4cad9295eec68b) openal-soft: 1.24.2 -> 1.24.3, modernize
* [`3ab768c7`](https://github.com/NixOS/nixpkgs/commit/3ab768c729979792e21bfb1fbd4f1134c75d51c4) openal-soft: remove cross-compilation workaround
* [`d52317e9`](https://github.com/NixOS/nixpkgs/commit/d52317e91933c6e92580197127183b1813f13e85) haskell.compiler.ghc910: 9.10.1 -> 9.10.2
* [`c6c2ebf9`](https://github.com/NixOS/nixpkgs/commit/c6c2ebf98386588f139c29c3a373f7c0ed5a3d49) haskell.packages.ghc910.git-annex: test on Hydra
* [`6aee08b6`](https://github.com/NixOS/nixpkgs/commit/6aee08b687514c52491aa6a21814c8f0b1ce8851) haskellPackages.bsb-http-chunked: re-enable tests on i686
* [`85d97632`](https://github.com/NixOS/nixpkgs/commit/85d97632cf6dac91378d277c8cccb8a64410feb3) haskellPackages.feedback: drop override
* [`1ffb8b4a`](https://github.com/NixOS/nixpkgs/commit/1ffb8b4af1f21fa56633e737d194efb10c7e59aa) haskellPackages.gogol: remove source override
* [`b79d0b5f`](https://github.com/NixOS/nixpkgs/commit/b79d0b5f455e040a84bfd16f3635276d976d9268) haskellPackages.gi-vte: drop patch
* [`a4e47204`](https://github.com/NixOS/nixpkgs/commit/a4e47204abdb040ee1b7954deec009f57e613a1a) haskellPackages: use warnIf instead of assert
* [`5d3f0664`](https://github.com/NixOS/nixpkgs/commit/5d3f0664a2621f77fe76f5339184dec8c385c4a2) haskellPackages: remove patches merged upstream
* [`9fd64b6f`](https://github.com/NixOS/nixpkgs/commit/9fd64b6fb8668f53c3c863831de08c7bede0b806) lttng-ust: 2.13.8 -> 2.13.9
* [`068ae71a`](https://github.com/NixOS/nixpkgs/commit/068ae71a175a98f2f767c554b359c9c9b0e3312e) haskellPackages.jsaddle-warp: fix build and tests
* [`2c526a5d`](https://github.com/NixOS/nixpkgs/commit/2c526a5d52a941722c59465a07befddbb3b300a3) haskell-language-server: Fix build (on ghc 9.12)
* [`a9ed7156`](https://github.com/NixOS/nixpkgs/commit/a9ed7156a06a7a95a11d93be93bd8ec9dd4808b9) libarchive: 3.8.0 -> 3.8.1
* [`141e7eb6`](https://github.com/NixOS/nixpkgs/commit/141e7eb60553ffe6d3a5de28712a5213ce0dfd13) haskellPackages: run treefmt
* [`443e53e2`](https://github.com/NixOS/nixpkgs/commit/443e53e24bdf47b4e9bd6e76ef779aa971920d05) haskellPackages: unbreak packages
* [`913f23ab`](https://github.com/NixOS/nixpkgs/commit/913f23ab095dbc75d3df58e19872d1c719958d11) libcamera: 0.5.0 -> 0.5.1
* [`a9d7c5ee`](https://github.com/NixOS/nixpkgs/commit/a9d7c5ee5fcdeaa8dfaff6154beb6d60e0d0730c) gcc: Add missing patch comments
* [`16368883`](https://github.com/NixOS/nixpkgs/commit/16368883496f90804c442b9f75d2eb261b2bcab8) gcc: Switch a patch to the upstream source
* [`6b1a63dd`](https://github.com/NixOS/nixpkgs/commit/6b1a63dd4880b4522d6f7d0fafced0de7b6e39e1) gcc: Fetch a patch instead of having it locally
* [`ac165bd9`](https://github.com/NixOS/nixpkgs/commit/ac165bd9b70ba67831121ebab277c7ccc956231a) gcc: Remove unnecessary patch update script
* [`f4840869`](https://github.com/NixOS/nixpkgs/commit/f4840869975217e2a9262ad621afa7919e9a6588) gcc: download patch instead of storing it in-tree
* [`f08bf9d0`](https://github.com/NixOS/nixpkgs/commit/f08bf9d01a17accf82f699c8bc1898b6c421cc55) haskellPackages.ghc: don't depend on libiconv on android-prebuilt
* [`571e7eb5`](https://github.com/NixOS/nixpkgs/commit/571e7eb5d272b9c6b0700fe49b14501e6f090c71) haskellPackages: disable shared libraries on android-prebuilt
* [`3094b65a`](https://github.com/NixOS/nixpkgs/commit/3094b65aa7251027bb186554b9a40395a72c9a87) haskellPackages.android-activity: unmark broken on android
* [`2e79a5a3`](https://github.com/NixOS/nixpkgs/commit/2e79a5a3aefd6588193c4da7d2f58ed41e17d6b8) haskellPackages: add aarch64-android-prebuilt to release-haskell jobset on ghc 9.10
* [`c327ff43`](https://github.com/NixOS/nixpkgs/commit/c327ff43ba4971f9bb980ad0d548c11ca7d37b4f) haskellPackages.persistent-test: pin to < 2.13.1.4, match persistent
* [`1265c0f2`](https://github.com/NixOS/nixpkgs/commit/1265c0f2927ebeba39c4eec57c7e463dcf8c86a6) git-annex: update sha256 for 10.20250520
* [`bfd42933`](https://github.com/NixOS/nixpkgs/commit/bfd42933b2f38c35855c5ddb9df521510a3859be) haskellPackages: remove unneeded jailbreaks
* [`b0ca5ddc`](https://github.com/NixOS/nixpkgs/commit/b0ca5ddc9916f66d40648f20757ed7f56b33d501) tree-sitter: 0.25.4 -> 0.25.6
* [`2c0bcc52`](https://github.com/NixOS/nixpkgs/commit/2c0bcc52862730282d1d15039e35c701c1082794) tree-sitter: update grammars
* [`56cca541`](https://github.com/NixOS/nixpkgs/commit/56cca54190e87044fa8d3e863b8bb217ecd53e7e) python3Packages.tree-sitter-rust: 0.23.2 -> 0.24.0
* [`dec3de4f`](https://github.com/NixOS/nixpkgs/commit/dec3de4f57b58146abb9610e893f1e4b164f8b6e) python3Packages.tree-sitter-yaml: 0.7.0 -> 0.7.1
* [`63ec21e3`](https://github.com/NixOS/nixpkgs/commit/63ec21e3e60749619581441980225bab48b24ab5) python3Packages.tree-sitter-markdown: 0.4.1 -> 0.5.0
* [`c1cc6ff0`](https://github.com/NixOS/nixpkgs/commit/c1cc6ff0c0680ae6d8228953ebba93c131e04775) patch-shebangs.sh: fix for macos sandbox
* [`69a7cf11`](https://github.com/NixOS/nixpkgs/commit/69a7cf114c6d3a2f6034ee967c5e1d6849683bd1) s2n-tls: 1.5.20 -> 1.5.21
* [`0ba3f034`](https://github.com/NixOS/nixpkgs/commit/0ba3f03439ebf27b90d8d28b49a0595b166d1a6b) rocmPackages: add gfx1200 and gfx1201 to gpuTargets
* [`f5efef28`](https://github.com/NixOS/nixpkgs/commit/f5efef2835099d389a40f88d36b178066d71b474) cc-wrapper: tidy logic for implied hardening flags
* [`ddbe9a1a`](https://github.com/NixOS/nixpkgs/commit/ddbe9a1a1e1ed1596de6555843787d7c12d092d5) cairo: 1.18.2 -> 1.18.4
* [`66031f45`](https://github.com/NixOS/nixpkgs/commit/66031f45a9dbbc88f8b731542d068c6a2263f845) libass: 0.17.3 -> 0.17.4
* [`57de197a`](https://github.com/NixOS/nixpkgs/commit/57de197aada4a9fce214a70460743fef3b13a1e2) mongodb-6_0: 6.0.23 -> 6.0.24
* [`75c86052`](https://github.com/NixOS/nixpkgs/commit/75c86052bffe7c9b20caa73da3776c6c04bf2549) python3Packages.geoip2: remove unused mocket dependency
* [`4081597c`](https://github.com/NixOS/nixpkgs/commit/4081597cf1cda5654a1dd7203bd397fc7bc7479d) haskell.packages.ghc9102.servant-client: fix for text >= 2.1.2
* [`0e051017`](https://github.com/NixOS/nixpkgs/commit/0e051017d42a2880b38a3c1324a7c82aa3f30dfc) haskellPackages.amazonka-s3-streaming: Use source from hackage
* [`38c30290`](https://github.com/NixOS/nixpkgs/commit/38c30290a306f4bb171f58c62c708ca479b77f4b) rust-bindgen-unwrapped: 0.71.1 -> 0.72.0
* [`95825b45`](https://github.com/NixOS/nixpkgs/commit/95825b452b868d54056b74736e556db208d7996c) sbcl: 2.5.4 -> 2.5.5
* [`4379d92d`](https://github.com/NixOS/nixpkgs/commit/4379d92dc957b3bf12971e907184c744b38afe4d) audit: 4.0.3 -> 4.0.5
* [`97227efc`](https://github.com/NixOS/nixpkgs/commit/97227efc3bf4316edbc9223d114b8b14bcb4c5d0) unicon: 11.7 -> 13.2-unstable-2025-06-02
* [`4fe48a57`](https://github.com/NixOS/nixpkgs/commit/4fe48a575887e0a00f3c3f70d38d8b5524a94989) unnethack: 5.3.2 -> 6.0.14
* [`0832fbec`](https://github.com/NixOS/nixpkgs/commit/0832fbec56910e9be7d182f261c00b9540fb25ab) luaPackages.luarocks: 3.11.1-1 -> 3.12.0
* [`1007183d`](https://github.com/NixOS/nixpkgs/commit/1007183dc15d12624103541316a653d63bb23ce8) luaPackages.luarocks_bootstrap: add versionCheckHook
* [`130e159f`](https://github.com/NixOS/nixpkgs/commit/130e159fbd18cd13233438298994f0076f0993f0) luaPackages.luarocks_bootstrap: 3.11.1-1 -> 3.12.0
* [`794890dd`](https://github.com/NixOS/nixpkgs/commit/794890dd317e6e56eb7eddee060c432912f8e9e8) luaPackages.luarocks: add versionCheckHook
* [`845d01c1`](https://github.com/NixOS/nixpkgs/commit/845d01c14769c572df877df3ecffa2205de07638) luarocks-nix: disable version check
* [`5c5e419c`](https://github.com/NixOS/nixpkgs/commit/5c5e419c2d166de91ccdc93050a6a82e00856a18) xkeyboard-config: 2.44 -> 2.45
* [`ad06620a`](https://github.com/NixOS/nixpkgs/commit/ad06620ad2e365b7d59c7f4fd172ba51097b6bb4) haskellPackages.adblock2privoxy: unbreak
* [`b116ba58`](https://github.com/NixOS/nixpkgs/commit/b116ba58dceb2fe1f0643a8c23c75a093dc9fcd1) buildEnv: improve error messages a little bit
* [`37862cbe`](https://github.com/NixOS/nixpkgs/commit/37862cbe7ff51a62bdf9ca3e009adfe711f9259d) libmpg123: 1.32.10 -> 1.33.0
* [`50d43d29`](https://github.com/NixOS/nixpkgs/commit/50d43d29091b91aa557016f21068d062584b1f2f) pkgsStatic.gpm: fix build
* [`c419691c`](https://github.com/NixOS/nixpkgs/commit/c419691ccb3075b695afda529605a6210fd387f3) Revert "audit-tmpdir.sh: optimize - make use of parallelMap"
* [`6b8e23b9`](https://github.com/NixOS/nixpkgs/commit/6b8e23b9f2278e8bd7aa9adec2732c68d0dc7c27) Revert "parallelRun, parallelMap: init"
* [`b64f5f44`](https://github.com/NixOS/nixpkgs/commit/b64f5f449ac3085e6a1ab37fe9c2cb8c87bee54f) grpc: 1.73.0 -> 1.73.0
* [`4f39940f`](https://github.com/NixOS/nixpkgs/commit/4f39940f7cf5ff18ea46bd4d83d04c0ca94ab26e) python3Packages.grpcio: 1.72.0 -> 1.73.0
* [`f7c386cf`](https://github.com/NixOS/nixpkgs/commit/f7c386cffdf81969931b97863540af272ff38141) python3Packages.grpcio-channelz: 1.72.0 -> 1.73.0
* [`1deeff7e`](https://github.com/NixOS/nixpkgs/commit/1deeff7e0c3ba470a4134ae6441b86ad9f6861b8) python3Packages.grpcio-health-checking: 1.72.0 -> 1.73.0
* [`03bae572`](https://github.com/NixOS/nixpkgs/commit/03bae572a09d482a00e2b775f13f779fc7726f42) python3Packages.grpcio-reflection: 1.72.0 -> 1.73.0
* [`a2fd3a6b`](https://github.com/NixOS/nixpkgs/commit/a2fd3a6b9a3ec0087202a0189597371c14303a2e) python3Packages.grpcio-status: 1.72.0 -> 1.73.0
* [`7397d435`](https://github.com/NixOS/nixpkgs/commit/7397d4356c26f80b1360be25e6c43ebc76b00475) python3Packages.grpcio-testing: 1.72.0 -> 1.73.0
* [`e4958517`](https://github.com/NixOS/nixpkgs/commit/e4958517c9d25bd39c4bf837d66ce6606b44ed56) python3Packages.grpcio-tools: 1.72.0 -> 1.73.0
* [`c866bcb7`](https://github.com/NixOS/nixpkgs/commit/c866bcb727514b43e046057cce00c2ebd330268c) zint: split library and GUI
* [`4cdaf744`](https://github.com/NixOS/nixpkgs/commit/4cdaf74416bcf787bd796ab531a8472bd3754acb) aliases: sort some unsorted aliases
* [`05fb388e`](https://github.com/NixOS/nixpkgs/commit/05fb388ea76b1b42426f2d7b81e82cd097f66aae) libapparmor: 4.1.0 -> 4.1.1
* [`74cd665d`](https://github.com/NixOS/nixpkgs/commit/74cd665d8f8789eae4489498c5e0df6eb62179f0) apparmor-parser: enable most tests on musl
* [`00031cc7`](https://github.com/NixOS/nixpkgs/commit/00031cc76b1dfd732bf99c2c68907501ad596f94) libtpms: 0.10.0 -> 0.10.1
* [`16b0f360`](https://github.com/NixOS/nixpkgs/commit/16b0f360f6b527996373973042deab82fdc72991) qemu: 10.0.0 -> 10.0.2
* [`0c76bb45`](https://github.com/NixOS/nixpkgs/commit/0c76bb45322593633a38970687db32403bc2a609) pixman: 0.46.0 -> 0.46.2
* [`55c37b17`](https://github.com/NixOS/nixpkgs/commit/55c37b17b404b11a4b9f1172261d63dc696fa7ae) publicsuffix-list: 0-unstable-2025-03-12 -> 0-unstable-2025-06-10
* [`516e32cd`](https://github.com/NixOS/nixpkgs/commit/516e32cd7c17f4a35d4bb89388c4df6e7de27ac6) python3Minimal: remove dependency on libffi
* [`9f40562c`](https://github.com/NixOS/nixpkgs/commit/9f40562c5307bd28c1bf9adc9d1e794167d20741) pandoc-crossref: Remove myself as maintainer
* [`9baf24bc`](https://github.com/NixOS/nixpkgs/commit/9baf24bcd3169b9a8db05934cab2e064a52c7e10) libcamera: use udev, not systemd
* [`21669b00`](https://github.com/NixOS/nixpkgs/commit/21669b002b0cb2a8a2f9b1f915fe00a4895c4f07) bluez: get udevadm from udev, not systemd
* [`4df6d52d`](https://github.com/NixOS/nixpkgs/commit/4df6d52d963430a6a33d545bc82553c57fec3f69) haskell.packages.ghc910.haskell-language-server: Fix build
* [`c96d965e`](https://github.com/NixOS/nixpkgs/commit/c96d965e14b77045f4b3a883853c4341d8cf84d8) haskellPackages.pandoc-crossref: pin to 0.3.19
* [`d3af908b`](https://github.com/NixOS/nixpkgs/commit/d3af908be6e79ef83e42d1ffb07c91c998179d6d) elmPackages.elm-instrument: build using GHC 9.4
* [`d1357baf`](https://github.com/NixOS/nixpkgs/commit/d1357baf08ab3e2dac76ac396f743d8cf62c670b) swtpm: fixup tpm2_avoid_da_lockout test
* [`b357ca72`](https://github.com/NixOS/nixpkgs/commit/b357ca72b6807f59000ae95e5fa60529508409f3) qt6: 6.9.0 -> 6.9.1
* [`373cd32e`](https://github.com/NixOS/nixpkgs/commit/373cd32e7308587bb1c747f4d6b7ecbda3fb7088) qt6Packages.qtmqtt: 6.9.0 -> 6.9.1
* [`0bc3b6ac`](https://github.com/NixOS/nixpkgs/commit/0bc3b6ac9f43acaa61e6dc3a6c3e9049b396ddaf) qt6Packages.qtdeclarative: drop upstreamed patches
* [`9b36201b`](https://github.com/NixOS/nixpkgs/commit/9b36201b947ba570f890b13e94961cb286506879) no-broken-symlinks: fail on links to /build
* [`78a125c8`](https://github.com/NixOS/nixpkgs/commit/78a125c8827b943ea34ce85dee80b511ca8f8c20) qt6Packages.qtwayland: drop upstreamed patch
* [`f43c0e78`](https://github.com/NixOS/nixpkgs/commit/f43c0e780e881405a0bd60fb820d1289a844d2e2) qt6Packages.qtdeclarative: drop unused argument
* [`361352db`](https://github.com/NixOS/nixpkgs/commit/361352db0d9d6574a3f2dc9274180833e101800b) qt6Packages.qtgrpc: drop upstreamed patch
* [`3adc150f`](https://github.com/NixOS/nixpkgs/commit/3adc150fd559ad371d05274aa7fd97feb47d3cd9) python313Packages.pytest-datadir: 1.6.1 -> 1.7.2
* [`2cacd479`](https://github.com/NixOS/nixpkgs/commit/2cacd479ff9612c460ac052f219ca9ad7d46b6bb) qt6Packages.qtwebengine: drop upstreamed patch
* [`ed818ad5`](https://github.com/NixOS/nixpkgs/commit/ed818ad52af5c4b8b674fd4883f002cf82189d87) qt6Packages.qtmultimedia: drop upstreamed patch
* [`70b32c16`](https://github.com/NixOS/nixpkgs/commit/70b32c168d054a88348bdcafe22e717745c0b77d) python313: 3.13.4 -> 3.13.5
* [`a57f0acd`](https://github.com/NixOS/nixpkgs/commit/a57f0acd0640a1c27d0435b87c4aa47c7df141e7) gnum4: 1.4.19 -> 1.4.20
* [`ca971864`](https://github.com/NixOS/nixpkgs/commit/ca971864847951c85a7daa307296a55e33124db2) elmPackages.elm-pages: fix build
* [`0b3a725f`](https://github.com/NixOS/nixpkgs/commit/0b3a725fa31302f66103a471012c288982a7e7e1) elmPackages.elm-verify-examples: fix build
* [`46919f57`](https://github.com/NixOS/nixpkgs/commit/46919f572c5aec8d1cfa286bcf427e0a4085c3ef) elmPackages.elm-verify-examples: remove unused dependency esbuild
* [`6bf506ee`](https://github.com/NixOS/nixpkgs/commit/6bf506ee2c7ce6bc0b960e9108329f8f763761b3) elmPackages: run generate-node-packages.sh
* [`2ab04f12`](https://github.com/NixOS/nixpkgs/commit/2ab04f126ac9dc8100d9b99b5da75c24a39306b5) ffmpeg: fix nvcc build
* [`9404d8d5`](https://github.com/NixOS/nixpkgs/commit/9404d8d57e4257af1923c909fc9f9d5ea39d3583) elmPackages.elm-coverage: drop
* [`ac4fa7a8`](https://github.com/NixOS/nixpkgs/commit/ac4fa7a81f8d08a0d6e4c4dffc5bd8406e434df8) waf: 2.1.5 -> 2.1.6
* [`794f904b`](https://github.com/NixOS/nixpkgs/commit/794f904bf3f6a985fcbd8d3a75d29ac7e84c3a50) treewide: pytestFlagsArray -> enabledTestPaths (trivial)
* [`a167dcb9`](https://github.com/NixOS/nixpkgs/commit/a167dcb961c32f7baea11c8ae5c7ed17852fd6cb) odin: dev-2025-04 -> dev-2025-06
* [`c6431176`](https://github.com/NixOS/nixpkgs/commit/c6431176fac15ee8ff2181b28466549e5f6d5448) wlvncc: 0-unstable-2025-04-21 -> 0-unstable-2025-04-20
* [`795db514`](https://github.com/NixOS/nixpkgs/commit/795db5146d838ab605c57b3013651614714407b6) mariadb_118: init at 11.8.2
* [`d822ab9f`](https://github.com/NixOS/nixpkgs/commit/d822ab9f51d73b214c5fc5c6fefd04d653d0c74c) docbook2x: allow configure to find osx
* [`4aaab78e`](https://github.com/NixOS/nixpkgs/commit/4aaab78eee71f1b5db9c6bd630fe24452ca2faf6) msedit: init at 1.2.0
* [`73415c7a`](https://github.com/NixOS/nixpkgs/commit/73415c7a3405832115ff87a0261459647944c8ec) bmake: 20250308 -> 20250528
* [`014ca1cc`](https://github.com/NixOS/nixpkgs/commit/014ca1cc3d3283967ec009d79d57047af85aa2e9) nixos-render-docs: Display relevant source for errors
* [`061f6a1a`](https://github.com/NixOS/nixpkgs/commit/061f6a1a3846e308be78664e16d329183a740787) python3Packages.cython_3_1: 3.1.1 -> 3.1.2
* [`77b65fa8`](https://github.com/NixOS/nixpkgs/commit/77b65fa8f6afd6ba5da7ed4158926f1029cf8c8d) grpc: fix hash mismatch for 1.73.0
* [`cb5a21de`](https://github.com/NixOS/nixpkgs/commit/cb5a21dee40ce77bdc61f1ec69ed5564760696f7) lttng-ust: modernize derivation
* [`47ba72e4`](https://github.com/NixOS/nixpkgs/commit/47ba72e4404e79a95933d83a142bb70489f37cad) lttng-ust: remove unnecessary hardeningDisable
* [`c9b33290`](https://github.com/NixOS/nixpkgs/commit/c9b33290bbe33e0362ae9a88ea9ac4d75779be75) lttng-ust: improve pkg-config support
* [`0ad0abeb`](https://github.com/NixOS/nixpkgs/commit/0ad0abebcea7c4096292e80ff86ccbf4cf23559b) lttng-ust: enable testing
* [`a24c1126`](https://github.com/NixOS/nixpkgs/commit/a24c1126ea5438e4a95b954248999b215c7a2c94) lttng-ust: use GitHub source instead of tarball, add updateScript
* [`805d3393`](https://github.com/NixOS/nixpkgs/commit/805d3393e490491fde66426a178f9d85afbc1654) wayland-protocols: 1.44 -> 1.45
* [`62fc76db`](https://github.com/NixOS/nixpkgs/commit/62fc76db06654ad036c36ef661e496f42fe2c3f3) python3Packages.ipython: 9.2.0 -> 9.3.0
* [`cfeaf14c`](https://github.com/NixOS/nixpkgs/commit/cfeaf14c52585eaa8125defa8482cd2f7198d9bd) nodejs*: skip some flaky tests
* [`b1a3c470`](https://github.com/NixOS/nixpkgs/commit/b1a3c47018acfb8ac6a4a980dd8fc31b7cd8b6c8) linkFarm: allow files/directories with leading dashes
* [`a1fd80fb`](https://github.com/NixOS/nixpkgs/commit/a1fd80fb9bf9d00ab00d46b6ead93672a4e17f6d) guile: fix cross
* [`facae77b`](https://github.com/NixOS/nixpkgs/commit/facae77bf5d377b44069a821c667312b12a926ae) python3Packages.sphinxHook: move to preFixupPhases
* [`a924c0eb`](https://github.com/NixOS/nixpkgs/commit/a924c0eb95c787a36e5c5e9ad61f6fc8541882b8) separateDebugInfo: add symlinks to executable and source for debuginfod support
* [`318b8c61`](https://github.com/NixOS/nixpkgs/commit/318b8c61bdacb3e5c190c5ab3a7acdfecf8cf8dc) git: __structuredAttrs = true
* [`4f3fd5b7`](https://github.com/NixOS/nixpkgs/commit/4f3fd5b70e2fb50670f11e1da9d6310dcaf3f667) openjdk: __structuredAttrs = true
* [`832e521e`](https://github.com/NixOS/nixpkgs/commit/832e521ef9bd5e28934511b64ce6ab0da62d8996) python: __structuredAttrs = true
* [`abe472da`](https://github.com/NixOS/nixpkgs/commit/abe472daf38b1cead85e77cca94b1b867fa26b00) systemd: __structuredAttrs = true
* [`f3780103`](https://github.com/NixOS/nixpkgs/commit/f37801034aed8b67c485444b49589f419901a264) mesa: __structuredAttrs = true
* [`a4d35534`](https://github.com/NixOS/nixpkgs/commit/a4d355342976e9e9823fb94f133bc43ebec9da5b) mkDerivation: disable reference whitelisting in debug outputs created by separateDebugInfo
* [`24cd0842`](https://github.com/NixOS/nixpkgs/commit/24cd08426a07616f036b270643b0538e44b37123) lix: __structuredAttrs = true
* [`b0d26fa2`](https://github.com/NixOS/nixpkgs/commit/b0d26fa2cdd3c8a5d298f94e3e0d19218b85c0c7) autoPatchelfHook: teach it to avoid objects created by separateDebugInfo
* [`d641797b`](https://github.com/NixOS/nixpkgs/commit/d641797bed1d6d705f62f8cecc768547c2569f8b) release notes: document interactions between separateDebugInfo and ref blacklisting
* [`9b0b0b9f`](https://github.com/NixOS/nixpkgs/commit/9b0b0b9fe0eacea9616a5becb53cd814a66f18f4) python3Packages.aiohttp: 3.12.10 -> 3.12.13
* [`1d7cc74b`](https://github.com/NixOS/nixpkgs/commit/1d7cc74b9fd23ea69eaad420efc9b6dd7843d913) python312Packages.bqplot: 0.12.43 -> 0.12.45
* [`d37d2d31`](https://github.com/NixOS/nixpkgs/commit/d37d2d312ba57a11c39bbdbed52bc07d5ae0ff14) python312Packages.ipywidgets: 8.1.5 -> 8.1.7
* [`31704beb`](https://github.com/NixOS/nixpkgs/commit/31704beb75ddf1ba08f6c3d00ee4ec44142aa32b) python312Packages.jupyter-core: 5.7.2 -> 5.8.1
* [`a5b4a0f7`](https://github.com/NixOS/nixpkgs/commit/a5b4a0f70cb0235b25f371f1b3f40e935f69e4e2) python312Packages.jupyter-events: 0.11.0 -> 0.12.0
* [`51b353b8`](https://github.com/NixOS/nixpkgs/commit/51b353b81a32e175bf0423362638068e48b18605) python312Packages.jupyter-server: 2.15.0 -> 2.16.0
* [`7ca9e0f5`](https://github.com/NixOS/nixpkgs/commit/7ca9e0f5c3e20bb4a55d84516d6014caed510232) python312Packages.jupyterlab-git: 0.51.1 -> 0.51.2
* [`eff3bcda`](https://github.com/NixOS/nixpkgs/commit/eff3bcda089534f38549f8151065a927b999daae) python312Packages.jupyterlab-widgets: 3.0.13 -> 3.0.15
* [`6bff6c60`](https://github.com/NixOS/nixpkgs/commit/6bff6c6065c732a56b0b19e1e1503c71d679cef4) python312Packages.notebook: 7.4.1 -> 7.4.3
* [`5203c84c`](https://github.com/NixOS/nixpkgs/commit/5203c84c62d494c6644978118e5e058b2ae12618) python312Packages.spyder-kernels: 3.1.0a1 -> 3.1.0a2
* [`13a6b785`](https://github.com/NixOS/nixpkgs/commit/13a6b7858bedf0f5ec9e9679bc11a556fa44276d) python312Packages.widgetsnbextension: 4.0.13 -> 4.0.14
* [`6fe89b8e`](https://github.com/NixOS/nixpkgs/commit/6fe89b8ec30e6040ff4746432d86cc0e18b84c78) python3Packages.jupyterlab: 4.4.1 -> 4.4.3
* [`bbc0ed0c`](https://github.com/NixOS/nixpkgs/commit/bbc0ed0c06b9cbc05d4bed1777d1bb461bcc0596) python3Packages.jupyterlab-lsp: 5.1.0 -> 5.1.1
* [`da3ac21e`](https://github.com/NixOS/nixpkgs/commit/da3ac21eded593d6b407763bb6299f09c932947f) python3Packages.pycrdt: 0.12.20 -> 0.12.21
* [`09704779`](https://github.com/NixOS/nixpkgs/commit/097047795e0a79985e1186a6be7d938374c53918) python3Packages.cryptography: 45.0.2 -> 45.0.4
* [`5d8f5a0f`](https://github.com/NixOS/nixpkgs/commit/5d8f5a0f8ec1c514787fb613b87e98d793cb6ca8) util-linux: restrict X-mount.subdir to real mounts
* [`e9fb5f87`](https://github.com/NixOS/nixpkgs/commit/e9fb5f87ea4241d51cd798c712d90ab7da383be6) valkey: 8.0.3 -> 8.1.2
* [`cdfd14fd`](https://github.com/NixOS/nixpkgs/commit/cdfd14fd932c3cbb56a16b6603d4e4f9c12a06c6) libcap: 2.75 -> 2.76
* [`f78aa37a`](https://github.com/NixOS/nixpkgs/commit/f78aa37a7b03d05a5576ac71a53267b5f6fc68c4) tinysparql: remove systemd and dbus dependencies
* [`464233da`](https://github.com/NixOS/nixpkgs/commit/464233da4e379c76309b669990e61d9dcf224454) openexr: 3.2.4 -> 3.3.4
* [`0c8cc4c1`](https://github.com/NixOS/nixpkgs/commit/0c8cc4c19c7cc1cc91bf357fd74adf18d54921b6) stdenv: pass `meta.mainProgram` to build environment as `NIX_MAIN_PROGRAM`
* [`76e2a397`](https://github.com/NixOS/nixpkgs/commit/76e2a397c25a4a711abd5f4b697d54f0e509cb12) treewide: pytestFlagsArray -> pytestFlags and join flag and option argument
* [`04f9b96e`](https://github.com/NixOS/nixpkgs/commit/04f9b96e20df6f66ad5ddb57917d214a0d26c18c) python3Packages.pecan: format
* [`866252aa`](https://github.com/NixOS/nixpkgs/commit/866252aa3a3ecb32a2b13794cd7f5fa087521d4e) python3Packages.scikit-learn-extra: format
* [`4945a86b`](https://github.com/NixOS/nixpkgs/commit/4945a86bbc9aa6d1eb1759c359532eeddb519281) python3Packages.scikit-misc: format
* [`98380fcf`](https://github.com/NixOS/nixpkgs/commit/98380fcfe11be39ca8c92b0b913309d2ecf4a764) doc/rl-25.11: Changing `meta.mainProgram` influences package rebuilds
* [`1b92d2f2`](https://github.com/NixOS/nixpkgs/commit/1b92d2f2827098a825c5e1aab0b769505eb3c15a) versionCheckHook: consider `NIX_MAIN_PROGRAM` as a fallback for `versionCheckProgram`
* [`651abd93`](https://github.com/NixOS/nixpkgs/commit/651abd93078062cc19f0fa0e44b225d98f60839e) doc: `versionCheckProgram` first defaults to `$outputBin/bin/$NIX_MAIN_PROGRAM`
* [`32a6fb65`](https://github.com/NixOS/nixpkgs/commit/32a6fb65a103f1021cb6c1d361273367034e4e37) versionCheckHook: emit warning when falling back to pname
* [`16cfdb23`](https://github.com/NixOS/nixpkgs/commit/16cfdb239668fff30c933759ee456892903d8fd3) libavif: avoid dev dependencies for depending binaries
* [`d416d5ac`](https://github.com/NixOS/nixpkgs/commit/d416d5ac28cda87b2da4b31c7fcb5e0bb9b5b208) python3Packages.pikepdf: 9.7.1 -> 9.8.1
* [`da43362a`](https://github.com/NixOS/nixpkgs/commit/da43362af598bd5d0d7a15b0aa83ec67b27dcc34) unicode-emoji: 16.0 -> 17.0
* [`37eb7a28`](https://github.com/NixOS/nixpkgs/commit/37eb7a2842ff9ac678ce628d81f6c1659a093ecc) xterm: 399 -> 400
* [`f7e33bf7`](https://github.com/NixOS/nixpkgs/commit/f7e33bf7645631c5dae63faf13a75e471d3837f8) libadwaita: 1.7.3 → 1.7.4
* [`132b8ef5`](https://github.com/NixOS/nixpkgs/commit/132b8ef5cb569f6cfa6bd40afa6bd25403724df1) gtk4: 4.18.5 → 4.18.6
* [`b13a0922`](https://github.com/NixOS/nixpkgs/commit/b13a09226c72d9910721c76a94a452c42a092b3c) glib: 2.84.2 → 2.84.3
* [`9b71cd56`](https://github.com/NixOS/nixpkgs/commit/9b71cd5612d3fa5d658879174e70ea180d8f023d) cups: 2.4.11 -> 2.4.12
* [`5bd5b31a`](https://github.com/NixOS/nixpkgs/commit/5bd5b31aa635572c232ff658074b4bb2167f3625) rofi-rbw: 1.4.2 -> 1.5.1
* [`4a42314f`](https://github.com/NixOS/nixpkgs/commit/4a42314f724525d77499f3d6be39bcd5db3fdd6b) generic-builder: optimize - reduce execve calls when sourcing
* [`5c1b00a9`](https://github.com/NixOS/nixpkgs/commit/5c1b00a90b6944b041e1da1bdf24dc6aae01f704) bluez: 5.80 -> 5.83
* [`805bfdf0`](https://github.com/NixOS/nixpkgs/commit/805bfdf0a4ccd76220c5db64467df2606a91da55) yubihsm-shell: 2.6.0 -> 2.7.0
* [`fdf412c6`](https://github.com/NixOS/nixpkgs/commit/fdf412c6cbda7287c00b7869d3ccf56cdfbba112) Revert "gnum4: 1.4.19 -> 1.4.20"
* [`f0b3061f`](https://github.com/NixOS/nixpkgs/commit/f0b3061fe882f4e8264fccbb95aaa43cd429a40c) nodejs_22: re-add patch to fix sandboxed builds using gyp on Darwin
* [`0382d0f9`](https://github.com/NixOS/nixpkgs/commit/0382d0f93001f1aeda0bd64a387ff672d337d0fd) gnum4: 1.4.19 -> 1.4.20 (take 2)
* [`c3001863`](https://github.com/NixOS/nixpkgs/commit/c3001863cb78a31f698a9f9446f044507e6e7580) git: 2.49.0 -> 2.50.0
* [`fa8a4789`](https://github.com/NixOS/nixpkgs/commit/fa8a4789839b5379063bc484b39eed58984fd5b0) git: add me-and as maintainer
* [`f342e99a`](https://github.com/NixOS/nixpkgs/commit/f342e99aaf8b26e45e5be7f7bb3856ad706f866d) xorg.xorgserver: 21.1.16 -> 21.1.17
* [`cb4f2749`](https://github.com/NixOS/nixpkgs/commit/cb4f2749778df37f8e8ee135caf1da75f4cc5483) xorg.*: update
* [`d3a1f2f9`](https://github.com/NixOS/nixpkgs/commit/d3a1f2f9deadc3ef0fafd68cfee0c6544ac6b844) abseil-cpp: 20250127.1 -> 20250512.1
* [`ec96074a`](https://github.com/NixOS/nixpkgs/commit/ec96074ad0d07200451077d157fb4c925b63197a) test: fix mismerge
* [`998e9f01`](https://github.com/NixOS/nixpkgs/commit/998e9f0161736542459b3099accd5ced79716ef9) nodejs_20: use stable URL for GYP patches
* [`e5628b13`](https://github.com/NixOS/nixpkgs/commit/e5628b139ef41584f82fafde4f081ac02b26455d) python3Packages.smartypants: 2.0.1 -> 2.0.2
* [`77b52c35`](https://github.com/NixOS/nixpkgs/commit/77b52c35202d3e52f4e4a30dd76bbe36feb97a87) libxml2: Apply ABI breaking patch from Chromium needed for libxslt CVE fixes
* [`434fce63`](https://github.com/NixOS/nixpkgs/commit/434fce63ce93e1acd02d1ac9c1aa54f853e7161b) gnum4: use `finalAttrs` idiom
* [`33bc9467`](https://github.com/NixOS/nixpkgs/commit/33bc9467b0b0c9b7d847acb0a5803340284c005c) cpuinfo: 0-unstable-2025-03-27 -> 0-unstable-2025-06-10
* [`b27ce01c`](https://github.com/NixOS/nixpkgs/commit/b27ce01ca7a14b6863ca5535c79ae5247fe5a256) git: add philiptaron as a maintainer
* [`edd9d78d`](https://github.com/NixOS/nixpkgs/commit/edd9d78de04acb1efa80a542898148bef47272fd) git: remove unnecessary cmd-list.made build target
* [`1199a445`](https://github.com/NixOS/nixpkgs/commit/1199a445ae3d888d2872297650a57d3752e52887) git: tidy handling of unsupported binaries
* [`ec85d0a7`](https://github.com/NixOS/nixpkgs/commit/ec85d0a7c9522a4627b327706788660445521875) git: skip patching test files when unused
* [`29950c97`](https://github.com/NixOS/nixpkgs/commit/29950c9795a29e15f2a467ba095a49200871cfdf) libjpeg8: 3.1.0 -> 3.1.1
* [`627d42ac`](https://github.com/NixOS/nixpkgs/commit/627d42acfb6adfb0c8100577aea8bc173e88bb20) python3Packages.requests: 2.32.3 -> 2.32.4
* [`6fe92b48`](https://github.com/NixOS/nixpkgs/commit/6fe92b4813208e8c6674f6113576ebcc6903f557) libxslt: Fix three security issues
* [`14e46eb8`](https://github.com/NixOS/nixpkgs/commit/14e46eb813e638a86a836d02095d3d2689dbdbad) xorg.*: update
* [`64e3a5d1`](https://github.com/NixOS/nixpkgs/commit/64e3a5d1d28f9af35fa4c46fb192f03885b6d00c) openblas: 0.3.29 -> 0.3.30
* [`26c092bb`](https://github.com/NixOS/nixpkgs/commit/26c092bbc7d8b2b15d2d7a4edbc2b29228114d9a) linux-pam: apply patch for CVE-2025-6020
* [`17449b07`](https://github.com/NixOS/nixpkgs/commit/17449b07d6358426739e2e282d5d314ddc09983d) pyright: 1.1.400 -> 1.1.402
* [`d48965aa`](https://github.com/NixOS/nixpkgs/commit/d48965aa58ee13a779c869ce237e885830c45baa) ell: 0.77 -> 0.78
* [`589c3fa0`](https://github.com/NixOS/nixpkgs/commit/589c3fa0db8cba6ec4ea6c221385180ee3065402) fuse3: don't build examples
* [`54c0bcc9`](https://github.com/NixOS/nixpkgs/commit/54c0bcc96ee135155518d2d6d068d71773d338d5) oelint-adv: 7.2.6 -> 8.1.2
* [`27e00a87`](https://github.com/NixOS/nixpkgs/commit/27e00a8743425190a0ece70d7a975c55ec1ff166) python3Packages.orderedmultidict: modernize
* [`bbca52fd`](https://github.com/NixOS/nixpkgs/commit/bbca52fd9960a8f776ed664720f7a92977cf029e) python3Packages.furl: modernize
* [`2f74eb51`](https://github.com/NixOS/nixpkgs/commit/2f74eb51acf304c538efe00cb9976e7727d45574) meson: 1.8.0 -> 1.8.2
* [`f105d662`](https://github.com/NixOS/nixpkgs/commit/f105d662f9636d9205aee3fdc8e6f0af07d97ed8) haskell.packages.ghc94.stan: don't use directory-ospath-streaming
* [`a6131a41`](https://github.com/NixOS/nixpkgs/commit/a6131a419d379b87f48ab21c54cf31f9c1863b3d) kdePackages.plasma-wayland-protocols: 1.17.0 -> 1.18.0
* [`d5cb9997`](https://github.com/NixOS/nixpkgs/commit/d5cb9997a42ce8169ceac130179ed1323668e3cf) libvpx: 1.15.0 -> 1.15.2
* [`4c94f27c`](https://github.com/NixOS/nixpkgs/commit/4c94f27c746e82d35e2d3d5bc52ec812bed4b19a) libgpg-error: 1.51 -> 1.55
* [`39c01d22`](https://github.com/NixOS/nixpkgs/commit/39c01d22bf5f1897d6474e19661f821b7f54300d) net-tools: rename from nettools
* [`33c122ae`](https://github.com/NixOS/nixpkgs/commit/33c122aece87f916392b2ad3a182a265e1e0cbe2) haskellPackages.cabal2nix-unstable: 2025-04-30 -> 2025-06-14
* [`08c7dcbd`](https://github.com/NixOS/nixpkgs/commit/08c7dcbdae0d9906b5e0266fd8d39651d861df1b) haskellPackages: regenerate package set based on current config ([nixos/nixpkgs⁠#416056](https://togithub.com/nixos/nixpkgs/issues/416056))
* [`931445b3`](https://github.com/NixOS/nixpkgs/commit/931445b357aa89e64a9cbecb614932086101ee88) python3Packages.ghome-foyer-api: 1.2.2 -> 1.2.3
* [`ffcada97`](https://github.com/NixOS/nixpkgs/commit/ffcada9749c35bfb4a5ddef74693a66ec1d82672) haskellPackages.postgrest: 13.0.0 -> 13.0.4
* [`3a21e962`](https://github.com/NixOS/nixpkgs/commit/3a21e9629f4cb3af8bdbef76f999387f2441c464) sdl3: fix cross compilation
* [`eb668785`](https://github.com/NixOS/nixpkgs/commit/eb668785b5e7cd435ea7770a4ea4a4fca0592e67) maintainers: add archercatneo
* [`74042ae1`](https://github.com/NixOS/nixpkgs/commit/74042ae1cd5bdef282b8ef32ff99eea0ddeb4969) gettext: 0.22.5 -> 0.25
* [`8cdd90d2`](https://github.com/NixOS/nixpkgs/commit/8cdd90d2e7f7cb176bfbe466ebd3c61db2ee10b5) gettext: set am_cv_func_iconv_works to yes on darwin
* [`c6311868`](https://github.com/NixOS/nixpkgs/commit/c6311868b3d0c70a6228adc4043702078d10ed8e) less: 668 -> 679
* [`7e300463`](https://github.com/NixOS/nixpkgs/commit/7e3004638f34a2eabff6d1d4a1e25f0b54386480) linuxPackages.ajantv2: mark broken for 5.{10,15}-hardened
* [`ce43bbe5`](https://github.com/NixOS/nixpkgs/commit/ce43bbe5b6b30101323b9059a9224fa3096fd6e0) libajantv2: 17.1.3 -> 17.5.0
* [`4c69602a`](https://github.com/NixOS/nixpkgs/commit/4c69602aead48e4cfad9c68a8e3b1e720a4cc3eb) v4l-utils: add Yarny (= myself) to maintainers
* [`e83b1046`](https://github.com/NixOS/nixpkgs/commit/e83b10463b93d6ee40b747e2240ed0c431bcd330) v4l-utils: change `${pname}` to string literal
* [`837c25d1`](https://github.com/NixOS/nixpkgs/commit/837c25d142ede34a120ce27ba0b715e602ea05ad) v4l-utils: use `finalAttrs` pattern instead of `rec`
* [`9e25ab57`](https://github.com/NixOS/nixpkgs/commit/9e25ab57b1ca9976934e3094c78ddcfeeaae87be) v4l-utils: 1.24.1 -> 1.30.1
* [`f70702eb`](https://github.com/NixOS/nixpkgs/commit/f70702ebb5a0506851d02496eb217a79e979ed52) v4l-utils: separate doc output for 6 MiB of html files
* [`e13c3c36`](https://github.com/NixOS/nixpkgs/commit/e13c3c3628760473f7cf72d87e13e7f3c5a6f7e9) edid-decode: replace with v4l-utils
* [`e3f4f345`](https://github.com/NixOS/nixpkgs/commit/e3f4f3452b406c616c442bccb3a7aeea3ffd28ce) ibusMinimal: fix cross compilation
* [`0c9e4ca4`](https://github.com/NixOS/nixpkgs/commit/0c9e4ca4c817936166b1eb4b195b2455f042b306) python3Packages.glocaltokens: 0.7.4 -> 0.7.5
* [`4fc2c005`](https://github.com/NixOS/nixpkgs/commit/4fc2c005eadef198cc8e37f5515241047252bdd9) linuxPackages_6_15.ajantv2: fix build
* [`58be8942`](https://github.com/NixOS/nixpkgs/commit/58be894241b8b6453dee9212c750724814758215) libgcrypt: 1.10.3 -> 1.11.1
* [`2cc29299`](https://github.com/NixOS/nixpkgs/commit/2cc2929905c7d45c9a2ac0ecbf3ba28274bad57f) plasmusic-toolbar: 2.5.0 -> 3.0.0
* [`ec049d73`](https://github.com/NixOS/nixpkgs/commit/ec049d732fb00865ee3dff919be685c5f4b33998) cacert: 3.111 -> 3.113
* [`8eae4972`](https://github.com/NixOS/nixpkgs/commit/8eae4972240f69c834bf56d5a5c9b39adb1c02c4) python3Packages.triton: 3.1.0 -> 3.3.1
* [`19c33d60`](https://github.com/NixOS/nixpkgs/commit/19c33d60c6a71a6b79d53f914a1c425469006290) pciutils: 3.13.0 -> 3.14.0
* [`4578b4e6`](https://github.com/NixOS/nixpkgs/commit/4578b4e63e32be23ff8c7ffe8a60a5b1ee6980e3) haskellPackages.hexstring: unbreak
* [`4e7fb0c2`](https://github.com/NixOS/nixpkgs/commit/4e7fb0c25da4ed40c5804c94734a7b0f2d4c4c16) portablemc: don't grab linux deps on non-linux
* [`50b75325`](https://github.com/NixOS/nixpkgs/commit/50b75325305279d26777f6c7790cf9b64c2993d9) haskellPackages.tree-diff: disable flaky test / failing on edge case
* [`9141a8d3`](https://github.com/NixOS/nixpkgs/commit/9141a8d39032544c938ee02e16b66e59d05ed920) free42: 3.3.5 -> 3.3.6 and switch to new upstream location
* [`4f842e17`](https://github.com/NixOS/nixpkgs/commit/4f842e17f828e1ea77e4ab4dc56c73ce22a76225) python312Packages.pythran: 0.17.0 -> 0.18.0
* [`9efb5b9c`](https://github.com/NixOS/nixpkgs/commit/9efb5b9cb2efa9d105380bd89c1206c65723dfdd) python312Packages.numpy: 2.3.0 -> 2.3.1
* [`5ae70921`](https://github.com/NixOS/nixpkgs/commit/5ae70921da48705eb72bc6bdb36fe2df77feaaac) python312Packages.scipy: 1.15.3 -> 1.16.0
* [`cc642ccc`](https://github.com/NixOS/nixpkgs/commit/cc642ccc8b70beb4b45e900ff5bdd940eb75f2a6) python313Packages.scipy: remove tests not failing anymore
* [`3d4c1c0d`](https://github.com/NixOS/nixpkgs/commit/3d4c1c0d26831da8417babd8026a3c0b353fe598) .editorconfig: two spaces for .js files
* [`dd23e181`](https://github.com/NixOS/nixpkgs/commit/dd23e181c8bfe6b2f7a9bc63cc94ce66e8aa6fe1) elmPackages.elm-format: 0.8.7 -> 0.8.8
* [`e6ef81d4`](https://github.com/NixOS/nixpkgs/commit/e6ef81d433cb172b24d6905833b725d065b5e935) elmPackages: update and run the `update.sh` script
* [`be6544dd`](https://github.com/NixOS/nixpkgs/commit/be6544dd480e3f4517ebd2b5424bd12d715648d1) btrfs-progs: 6.14 -> 6.15
* [`b4ec6dff`](https://github.com/NixOS/nixpkgs/commit/b4ec6dffe9522615a41249a71a546b6ef48039d8) jhentai: 8.0.7 -> 8.0.8+295
* [`5ce9f8bc`](https://github.com/NixOS/nixpkgs/commit/5ce9f8bc2ff42a437d83c5f7e228f88277556ed7) libxml2: 2.14.3 -> 2.14.4-unstable-06-20
* [`2ac1defe`](https://github.com/NixOS/nixpkgs/commit/2ac1defe80cabcc7076c91fa9fe553da257a7455) vim: 9.1.1401 -> 9.1.1475
* [`02631a43`](https://github.com/NixOS/nixpkgs/commit/02631a432b9aa6457dd6928643ac65b8c3e737b8) last: 1639 -> 1642
* [`9a146d12`](https://github.com/NixOS/nixpkgs/commit/9a146d12448f32d549825dc71b7d1922c2522e35) postgresql.withPackages.pg_config: fix paths
* [`5d17f562`](https://github.com/NixOS/nixpkgs/commit/5d17f562c88df43033caa4c01da9ba82303db338) wikicurses: install man page via installManPage
* [`397d2687`](https://github.com/NixOS/nixpkgs/commit/397d2687b734d9f53e911022ee77cbb019071440) gotenberg: 8.20.1 -> 8.21.1
* [`1c57a2a2`](https://github.com/NixOS/nixpkgs/commit/1c57a2a24c0e5fce7a2899162c6a5bca12ffd177) haskellPackages.jpeg-turbo: fix dep discovery and tests
* [`bdf3d512`](https://github.com/NixOS/nixpkgs/commit/bdf3d512be23448e066992ab5acc4df6ec106852) hred: convert to finalAttrs, add binlore
* [`4f2183dd`](https://github.com/NixOS/nixpkgs/commit/4f2183dd8d3d34942f55265079405a73d3ad14ac) libssh: 0.11.1 -> 0.11.2
* [`7194772d`](https://github.com/NixOS/nixpkgs/commit/7194772de7d075e4a94e308934da9bf12efe1dbc) qgis: 3.42.3 -> 3.44.0
* [`99705f81`](https://github.com/NixOS/nixpkgs/commit/99705f81b47123f87ae2807659cd9198cfb8a733) redisTestHook: fix failure when run directory already exists
* [`5da63791`](https://github.com/NixOS/nixpkgs/commit/5da63791ea57798f717a0c84684d1f015edfd0dd) osv-scanner: 2.0.2 -> 2.0.3
* [`6fa77178`](https://github.com/NixOS/nixpkgs/commit/6fa771782bd048f1f4bc678a85a74c908472b1fa) reaction: 2.0.1 -> 2.1.0
* [`c9751941`](https://github.com/NixOS/nixpkgs/commit/c9751941493a5f0e17d803f769a9a7784d7c6c6e) wait4x: 3.3.1 -> 3.4.0
* [`07eb6883`](https://github.com/NixOS/nixpkgs/commit/07eb6883f1f88e0a05388cfefa5409d07b2bd017) spaceship-prompt: 4.18.0 -> 4.19.0
* [`25507c8e`](https://github.com/NixOS/nixpkgs/commit/25507c8e71048c55e6b3f724fef5271dbe8356b8) prometheus-junos-czerwonk-exporter: 0.14.2 -> 0.14.3
* [`1ea64fd2`](https://github.com/NixOS/nixpkgs/commit/1ea64fd25960d2d5a5e0beea0b597efe2a88e210) kube-state-metrics: 2.15.0 -> 2.16.0
* [`1eb140ab`](https://github.com/NixOS/nixpkgs/commit/1eb140ab221dd9780166ebd168fc1c3c730bb871) libcap_ng: modernize
* [`7b7a1f13`](https://github.com/NixOS/nixpkgs/commit/7b7a1f1359846b7b9f97bc61dfc768a65fdffec7) libcap_ng: add pkg-config passthru test
* [`1a0d09ef`](https://github.com/NixOS/nixpkgs/commit/1a0d09ef5209ac7d54f657825d6ee7545bedbcdb) libcap_ng: use github sources
* [`075b80a4`](https://github.com/NixOS/nixpkgs/commit/075b80a4caa665d3e6403954aed602a44bf3a8fe) libcap_ng: enable check
* [`6be5e909`](https://github.com/NixOS/nixpkgs/commit/6be5e909c5f567a61f39b879b88d39d553f8f872) libcap_ng: add updateScript
* [`b22910a0`](https://github.com/NixOS/nixpkgs/commit/b22910a00618bb8fc7c83677a941d01454fe414d) libcap_ng: add grimmauld to maintainers
* [`69d04f67`](https://github.com/NixOS/nixpkgs/commit/69d04f67806830ecfd6b7261201341b50cc05efa) lomiri.lomiri-gsettings-overrides: init
* [`ef3fba06`](https://github.com/NixOS/nixpkgs/commit/ef3fba0687151a4f5b6a5fdbbc8a675d88c91cfc) lomiri.lomiri: 0.4.1 -> 0.5.0
* [`74d5cd0d`](https://github.com/NixOS/nixpkgs/commit/74d5cd0d83a7391150e9810fe0efb5a71aabe25f) coin3d: 4.0.3 -> 4.0.4
* [`d0f3dc90`](https://github.com/NixOS/nixpkgs/commit/d0f3dc903f40cc492e694ca6068d78eab017a911) livebook: 0.16.2 -> 0.16.4
* [`67b1ef51`](https://github.com/NixOS/nixpkgs/commit/67b1ef519f2797d0cbeeb0cfce1d4a660f6a2a81) webrtc-audio-processing: set default to 2.1
* [`49fcd62d`](https://github.com/NixOS/nixpkgs/commit/49fcd62de5d888b201bf6c648ad842dc948c7fc5) webrtc-audio-processing: remove bigEndian from badPlatforms
* [`7f4a6663`](https://github.com/NixOS/nixpkgs/commit/7f4a6663c885f5e57e76b4caa1d8cc7abfac1421) jami: webrtc-audio-processing -> webrtc-audio-processing_0_3
* [`3fb12c0a`](https://github.com/NixOS/nixpkgs/commit/3fb12c0a937da0eb55792539327c203dfb7d5cdd) webrtc-audio-processing: add fzdslr to maintainers
* [`5bbe55d5`](https://github.com/NixOS/nixpkgs/commit/5bbe55d514bb532fc231a36948b0e84a9bc85d88) webrtc-audio-processing: add passthru.tests.pkg-config
* [`74a99ca7`](https://github.com/NixOS/nixpkgs/commit/74a99ca7fd24b850b58d743d5bd2c1798f15a860) dino: webrtc-audio-processing_1 -> webrtc-audio-processing
* [`6dbbfbe0`](https://github.com/NixOS/nixpkgs/commit/6dbbfbe04a01a1e46434c2143e6613df26fef07b) webrtc-audio-processing: move lower versions under pkgs/by-name
* [`aecafce6`](https://github.com/NixOS/nixpkgs/commit/aecafce699665da484910ae8656b5a2c9a73774c) pipewire: use webrtc-audio-processing v2
* [`5c509c0f`](https://github.com/NixOS/nixpkgs/commit/5c509c0fa8341a9fdec81a3831a86d0088c9ddbf) sope: 5.12.1 -> 5.12.2
* [`59f30cae`](https://github.com/NixOS/nixpkgs/commit/59f30cae6856067aeaadd5ce6cbfb1ed0e90a68f) grpc: 1.73.0 -> 1.73.1
* [`5ffe0312`](https://github.com/NixOS/nixpkgs/commit/5ffe0312906664bf012f06d04db39c33295c64e5) python3Packages.grpcio: 1.73.0 -> 1.73.1
* [`2c037d2c`](https://github.com/NixOS/nixpkgs/commit/2c037d2cbf30d5e82a21991c4e602262d8cf3dd1) python3Packages.grpcio-channelz: 1.73.0 -> 1.73.1
* [`bf64642b`](https://github.com/NixOS/nixpkgs/commit/bf64642b80792b591eda5d185d9f8d4e6c8dd4e1) python3Packages.grpcio-health-checking: 1.73.0 -> 1.73.1
* [`d69349ad`](https://github.com/NixOS/nixpkgs/commit/d69349add85153a67f9e93fe279809bf2ad49799) python3Packages.grpcio-reflection: 1.73.0 -> 1.73.1
* [`845ef710`](https://github.com/NixOS/nixpkgs/commit/845ef71066805c7f53789dc53f986b7e343e5f12) python3Packages.grpcio-status: 1.73.0 -> 1.73.1
* [`b9349ff3`](https://github.com/NixOS/nixpkgs/commit/b9349ff312d17abd75b5403760a546efb7f779aa) python3Packages.grpcio-testing: 1.73.0 -> 1.73.1
* [`5e25054d`](https://github.com/NixOS/nixpkgs/commit/5e25054d024bafff4dc70ac42d8187a60442058a) python3Packages.grpcio-tools: 1.73.0 -> 1.73.1
* [`efd1e065`](https://github.com/NixOS/nixpkgs/commit/efd1e065c6bac23ff88411dc92f71ec5a59a3531) nixosTests.lomiri: Fix mouse coords
* [`7c40b26d`](https://github.com/NixOS/nixpkgs/commit/7c40b26d20960d5325a088c3f6b163b808521db2) fido2-manage: 0-unstable-2024-11-22 → 0-unstable-2025-06-06
* [`f1a51fd6`](https://github.com/NixOS/nixpkgs/commit/f1a51fd601a95120643b693af0231e010e7de830) fido2-manage: add `updateScript`
* [`02654724`](https://github.com/NixOS/nixpkgs/commit/02654724204e79ab077b2731e58bcadd633ecf74) redisinsight: 2.68.0 -> 2.70.0
* [`cb9cfc5e`](https://github.com/NixOS/nixpkgs/commit/cb9cfc5e70e6a405e747a5d8f550fa609fa03251) maptool: 1.17.0 -> 1.17.1
* [`cc05b7ff`](https://github.com/NixOS/nixpkgs/commit/cc05b7ff15ccb0a5b1f34fccfb8b59f70bedb313) prism-model-checker: use gcc 13
* [`a0fcb414`](https://github.com/NixOS/nixpkgs/commit/a0fcb414b6c244a195ecb32d3340654f7c823079) python3Packages.cantools: 40.2.2 -> 40.2.3
* [`cf0803c5`](https://github.com/NixOS/nixpkgs/commit/cf0803c54b7c3ae42932b0130ada992f6a7138ea) kubernetes-polaris: 9.6.3 -> 9.6.4
* [`f84c95ec`](https://github.com/NixOS/nixpkgs/commit/f84c95ec49498fff8a12671288ab5ebb409fea94) gate: 0.49.2 -> 0.50.0
* [`71837b51`](https://github.com/NixOS/nixpkgs/commit/71837b51e71f7799f8a27902859dc7a18a0a0694) jack2: Don't use special libs for NetJack
* [`73d99634`](https://github.com/NixOS/nixpkgs/commit/73d99634924d822abdd528cfb4f77f520951c422) nixosTests.qemu-vm-external-disk-image: fix test
* [`78851559`](https://github.com/NixOS/nixpkgs/commit/78851559c41546b3f29182c2637012b9ae531951) stalwart-mail-webadmin: 0.1.27 -> 0.1.28
* [`d4338e08`](https://github.com/NixOS/nixpkgs/commit/d4338e081d05dfa61e8320ba5424564d25a3b911) fopnu: 1.67 -> 1.68
* [`3dc866c4`](https://github.com/NixOS/nixpkgs/commit/3dc866c475dd680885594c9c773933072e849eab) rust: 1.87.0 -> 1.88.0
* [`bfd5f799`](https://github.com/NixOS/nixpkgs/commit/bfd5f799c15dfd2dbd236dd18b191c36c02bbd6a) levant: 0.3.3 -> 0.4.0
* [`5d42e807`](https://github.com/NixOS/nixpkgs/commit/5d42e80772a0816845c857352e596da7980adad7) balsa: 2.6.4 -> 2.6.5, modernize
* [`60d23972`](https://github.com/NixOS/nixpkgs/commit/60d23972f49d1e22a9ad1f74eb94eecaf006d2ef) wox: 2.0.0-beta.2 -> 2.0.0-beta.3
* [`00daedd0`](https://github.com/NixOS/nixpkgs/commit/00daedd087bdcf96a27dc057030f2504affab8e0) python3Packages.lizard: 1.17.30 -> 1.17.31
* [`ebc09893`](https://github.com/NixOS/nixpkgs/commit/ebc098931dc3cb0e5666b2d3ee907cab31ffff12) vitess: 22.0.0 -> 22.0.1
* [`aeabb239`](https://github.com/NixOS/nixpkgs/commit/aeabb2396cf9873b2e97ed4e0e2ca7efe8805515) stylance-cli: 0.6.0 -> 0.7.0
* [`dab75e66`](https://github.com/NixOS/nixpkgs/commit/dab75e66e1f4890d63c58df016d3f1128bbcc715) wavpack: fix build
* [`a23150d3`](https://github.com/NixOS/nixpkgs/commit/a23150d3080dd9676c2b2f9a79aade0edf128e18) wavpack: clean up obsolete copy
* [`be9e7056`](https://github.com/NixOS/nixpkgs/commit/be9e7056e415238610bb35ea86b7c67f5cb7afcd) gnupg: 2.4.7 -> 2.4.8
* [`1627c5f6`](https://github.com/NixOS/nixpkgs/commit/1627c5f6121835fbe4de326af137dc1f86a078c4) ergo: 5.0.27 -> 6.0.0
* [`116dbafc`](https://github.com/NixOS/nixpkgs/commit/116dbafce7c32d01977b20999c7f6da2a65d23de) xdg-user-dirs: fix build
* [`060b3662`](https://github.com/NixOS/nixpkgs/commit/060b366274db22fc17e265f9b0ce4f302fdda700) pipewire: 1.4.5 -> 1.4.6
* [`24ec343f`](https://github.com/NixOS/nixpkgs/commit/24ec343f49bac4484287a93d72d0d33f28a3d1dd) sqldef: 2.0.2 -> 2.0.4
* [`9c64ab86`](https://github.com/NixOS/nixpkgs/commit/9c64ab862f61bf7a0b09eb8ae473c73865927bc7) juno-theme: 0.0.1 -> 0.0.3
* [`bb295589`](https://github.com/NixOS/nixpkgs/commit/bb295589ec9c669c3bc89b6672afff150942b45b) kube-bench: 0.10.7 -> 0.11.1
* [`65a7e5e6`](https://github.com/NixOS/nixpkgs/commit/65a7e5e637e5364ed6e2e76335bfec08b5c893a4) matrix-synapse-plugins.synapse-http-antispam: 0.4.0 -> 0.5.0
* [`15643f94`](https://github.com/NixOS/nixpkgs/commit/15643f94a456659b0dcca4ed77f604da88f85c76) goverter: 1.8.3 -> 1.9.0
* [`1a256b7d`](https://github.com/NixOS/nixpkgs/commit/1a256b7d67d752e5142123657f83e605795d8eb2) hypercore: 11.9.1 -> 11.10.0
* [`1c823a71`](https://github.com/NixOS/nixpkgs/commit/1c823a71086357bbd1c7a03b4166681e7dd5a6e3) fx: 36.0.3 -> 37.0.0
* [`c3484b6e`](https://github.com/NixOS/nixpkgs/commit/c3484b6e6deca34e820eba7760bc000a159e96ed) etherpad-lite: 2.3.0 -> 2.3.2
* [`d44aec9e`](https://github.com/NixOS/nixpkgs/commit/d44aec9e4f743404c8f0efcc842e37438b459a0b) slsa-verifier: 2.7.0 -> 2.7.1
* [`edf6caf0`](https://github.com/NixOS/nixpkgs/commit/edf6caf06ef1f176c57a8baf2138f86a6e3deddf) ocamlPackages.pure-html: 3.10.1 -> 3.11.0
* [`01d32ee5`](https://github.com/NixOS/nixpkgs/commit/01d32ee571b1a0be90c84a720efe52cf210ef5b5) odpic: 5.4.1 -> 5.6.0
* [`a0ff2dac`](https://github.com/NixOS/nixpkgs/commit/a0ff2daceabe8780b3d33eab11cf9e88463e161a) libiio: 0.24 -> 0.26
* [`12be651b`](https://github.com/NixOS/nixpkgs/commit/12be651bc20954b27cac7b8e79464bece0f909be) rio: 0.2.19 -> 0.2.20
* [`b222541e`](https://github.com/NixOS/nixpkgs/commit/b222541e3178f07c7f6f65646bce3755f6fef9e3) clash-verge-rev: move IPC path to /run/clash-verge-rev/service.sock for better security
* [`4b5d9e4a`](https://github.com/NixOS/nixpkgs/commit/4b5d9e4a0d2200435ca8611047d57a267e8d9749) nixos/clash-verge: move IPC path to /run/clash-verge-rev/service.sock for better security
* [`6e8f0006`](https://github.com/NixOS/nixpkgs/commit/6e8f0006a9981dcab5b4b004f9d4089cded80d98) gnum4: unconditionally disable format hardening
* [`3e4ee8a0`](https://github.com/NixOS/nixpkgs/commit/3e4ee8a0497a860cca4fadee84ee6168596f09e2) zoraxy: 3.2.2 -> 3.2.4
* [`e8503699`](https://github.com/NixOS/nixpkgs/commit/e850369989fb0748b686e49b84e97f9b43dec9d1) XML::SAX: fix cross-compilation
* [`b2f11156`](https://github.com/NixOS/nixpkgs/commit/b2f111560211bbfc57a0a95d91402feff74a3cea) coroot-node-agent: 1.25.1 -> 1.25.4
* [`c450a258`](https://github.com/NixOS/nixpkgs/commit/c450a25874c1cb0e09ed41b58bc1ca8da9709b01) python3Packages.bundlewrap: 4.22.0 -> 4.23.1
* [`2c977281`](https://github.com/NixOS/nixpkgs/commit/2c977281d2538953c12207539e556a07ffda775e) acr: 2.2.0 -> 2.2.2
* [`466d3e3e`](https://github.com/NixOS/nixpkgs/commit/466d3e3eb5d9e0e43a9e6f2b0ad688cca30c2aa6) iosevka: 33.2.5 -> 33.2.6
* [`f3f8bad8`](https://github.com/NixOS/nixpkgs/commit/f3f8bad8c46bc0019a8e25a82f4c01cb6e92fc79) e2fsprogs: support mkfs.ext4 -d with libarchive
* [`4df1e891`](https://github.com/NixOS/nixpkgs/commit/4df1e89189c24491a025c693c66293da8c557827) e2fsprogs: add usertam to maintainers
* [`7b73b900`](https://github.com/NixOS/nixpkgs/commit/7b73b900128f4e96aafbe9310729705587398e93) yamlfmt: 0.17.1 -> 0.17.2
* [`853e7509`](https://github.com/NixOS/nixpkgs/commit/853e75095efb1dd47c712f3a6ccac82ffa89d9fe) mongodb-cli: 2.0.3 -> 2.0.4
* [`54217c53`](https://github.com/NixOS/nixpkgs/commit/54217c5366ca5bd27c9dd15b300bde40ff4a2a0f) xan: 0.50.0 -> 0.51.0
* [`03776f6f`](https://github.com/NixOS/nixpkgs/commit/03776f6f4817338bb25def74785118c15b9bcf50) libcec: 7.1.0 -> 7.1.1
* [`2cc9a1eb`](https://github.com/NixOS/nixpkgs/commit/2cc9a1eb4b2c60f9ce808461e2bafbc5c31f6b8d) python3Packages.scancode-toolkit: 32.3.3 -> 32.4.0
* [`9a6e279d`](https://github.com/NixOS/nixpkgs/commit/9a6e279d3a88b5275c015ea0fd3cb6bc646f3e73) python312Packages.acme-tiny: 5.0.1 -> 5.0.2
* [`638f2e3f`](https://github.com/NixOS/nixpkgs/commit/638f2e3f5fea2faf6343af660025b280c636f040) goose-cli: 1.0.29 -> 1.0.30
* [`f1d4eb1c`](https://github.com/NixOS/nixpkgs/commit/f1d4eb1c309c0e7bc270693db9fcc57ad121203f) cryptsetup: 2.7.5 -> 2.8.0
* [`47d115f5`](https://github.com/NixOS/nixpkgs/commit/47d115f5808ed64a1f84516d02b80527a8a9243f) cryptsetup: enable parallel building
* [`8f7bfa2f`](https://github.com/NixOS/nixpkgs/commit/8f7bfa2f6b9a46b4bca4cce4ae52673ed1c263dd) nodejs_22: 22.16.0 -> 22.17.0
* [`4b3b2dca`](https://github.com/NixOS/nixpkgs/commit/4b3b2dca1a1a64e295893b00bc69121ef6d70011) jdt-language-server: 1.47.0 -> 1.48.0
* [`19cd4516`](https://github.com/NixOS/nixpkgs/commit/19cd45160a663dde95114a5e93f28b21481c933e) harsh: 0.10.21 -> 0.10.22
* [`2f7be1c4`](https://github.com/NixOS/nixpkgs/commit/2f7be1c414cbef3aaa24d4f826c2fbeccbc52524) python3Packages.pyliblo3: init at 0.16.3
* [`0702aae2`](https://github.com/NixOS/nixpkgs/commit/0702aae2176088e419752fe618553bf5332474e7) carla: use pyliblo3
* [`56157c3f`](https://github.com/NixOS/nixpkgs/commit/56157c3f8528351fa70616d971511e86231244e9) raysession: use pyliblo3
* [`4276e92b`](https://github.com/NixOS/nixpkgs/commit/4276e92b4f450ebfc99eeb45e171e3f3e4fe0592) python3Packages.pyliblo: drop
* [`0c47eea3`](https://github.com/NixOS/nixpkgs/commit/0c47eea355869afe2ae95b61f6229f55606dff16) kissat: 4.0.2 -> 4.0.3
* [`0edfc9c6`](https://github.com/NixOS/nixpkgs/commit/0edfc9c6ca0ae11a123695141aba65035f7fbf1d) haskellPackages.haskore: fixed broken package (doJailbreak, dontCheck)
* [`4b626366`](https://github.com/NixOS/nixpkgs/commit/4b626366b4a4d5bd5079163a59e2efc785b13b1d) wealthfolio: 1.1.4 -> 1.1.5
* [`fd0985f1`](https://github.com/NixOS/nixpkgs/commit/fd0985f124e61c2c24ab1657aa055b022e594373) yaru-theme: 25.04.1 -> 25.04.2
* [`7e5c7131`](https://github.com/NixOS/nixpkgs/commit/7e5c7131297f79a2227b615333cbcb79ef3895d0) plantuml-server: 1.2025.3 -> 1.2025.4
* [`6fb45f9c`](https://github.com/NixOS/nixpkgs/commit/6fb45f9c4a1b6b59cc49beb5e7bae513a0a40e20) keymapper: 4.12.1 -> 4.12.2
* [`617ac447`](https://github.com/NixOS/nixpkgs/commit/617ac44724da5daa2ea7884ae708a2dbef413782) simplescreenrecorder: 0.4.4-unstable-2025-01-25 -> 0.4.4-unstable-2025-06-14
* [`74f1c747`](https://github.com/NixOS/nixpkgs/commit/74f1c747d5a1afa04b83a90401c59345266802a1) libserdes: 7.9.1 -> 7.9.2
* [`243fac58`](https://github.com/NixOS/nixpkgs/commit/243fac58b46cc83816bac89e707254c06d9e9c63) fuse: fix build
* [`d78f40b5`](https://github.com/NixOS/nixpkgs/commit/d78f40b5c8367e3d6c30e0b3f1e6670f1ce625ee) typeshare: 1.13.2 -> 1.13.3
* [`bd1096f6`](https://github.com/NixOS/nixpkgs/commit/bd1096f6de3da2866bdc5f09aef62f465d4c718f) tinfoil-cli: 0.0.22 -> 0.0.24
* [`b285a4c4`](https://github.com/NixOS/nixpkgs/commit/b285a4c4884343bfa6a14419cd8eaa5c01b78004) hpx: 1.10.0 -> 1.11.0
* [`579c0a53`](https://github.com/NixOS/nixpkgs/commit/579c0a5393b69b203a047592e818497a272f67d9) spirv-tools: use --replace-fail
* [`76f27bb4`](https://github.com/NixOS/nixpkgs/commit/76f27bb44c2cf253caf5c3fd101b64648a18306a) spirv-llvm-translator: drop llvm 11 support
* [`adf79f76`](https://github.com/NixOS/nixpkgs/commit/adf79f767a761a594d5cd6bd7a7810b4caf6a663) spirv-llvm-translator: use attrset for version selection, switch to finalAttrs, add passthru tests for all versions
* [`468cca66`](https://github.com/NixOS/nixpkgs/commit/468cca660d9e5be4c1680f4cd9f5057d4e1aa76b) spirv-llvm-translator: 19.1.0 -> 19.1.6
* [`44bec87e`](https://github.com/NixOS/nixpkgs/commit/44bec87eec47d628fdaf6d09ec5a4c3f83c5d517) spirv-llvm-translator: 18.1.0 -> 18.1.11
* [`bd88475e`](https://github.com/NixOS/nixpkgs/commit/bd88475e30130d3260a002dc9e5bac6f0622e717) spirv-llvm-translator: 17.0.0 -> 17.0.11
* [`0909a149`](https://github.com/NixOS/nixpkgs/commit/0909a14982a9f6433d5cff6d6ebf36c2f67d091b) spirv-llvm-translator: 16.0.0 -> 16.0.11
* [`dddde3aa`](https://github.com/NixOS/nixpkgs/commit/dddde3aaa916e6d78f12d6062dc4f147c29efee6) spirv-llvm-translator: correct 14 version number
* [`38f9392f`](https://github.com/NixOS/nixpkgs/commit/38f9392f8c22514819c2659f6f0e3809a778de6b) openssh: fix compilation to static hosts
* [`f722b576`](https://github.com/NixOS/nixpkgs/commit/f722b576649c91b4de00fd415fd59d2ae252f70d) triton-llvm: 19.1.0-rc1 -> 21.0.0-git
* [`194cbf4a`](https://github.com/NixOS/nixpkgs/commit/194cbf4a0895705600d67f5c98c9e2e0a1654811) haskellPackages.selda-json: unbreak
* [`4d5170aa`](https://github.com/NixOS/nixpkgs/commit/4d5170aadd8ba4618df97f6e235b6286c81a10d2) haskellPackages.cabal2nix: unstable-2025-04-30 -> unstable-2025-06-14
* [`5e6d29f0`](https://github.com/NixOS/nixpkgs/commit/5e6d29f0b21cd887a1e3920bd432a2de52f552fe) haskellPackages: regenerate package set based on current config
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
