### PR TITLE
niv home-manager: update fd9e55f5 -> 1e548375

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -65,10 +65,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "fd9e55f5fac45a26f6169310afca64d56b681935",
-        "sha256": "0cikf631s9h9s4dfgdqnmklcllw1qkb8b5m51k8bx56k478c4c38",
+        "rev": "1e54837569e0b80797c47be4720fab19e0db1616",
+        "sha256": "1hj8779ag5ngjjlr60b7zlbyb5wp43r7w917047xd0x737xr2ip2",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/fd9e55f5fac45a26f6169310afca64d56b681935.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/1e54837569e0b80797c47be4720fab19e0db1616.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@fd9e55f5...1e548375](https://github.com/nix-community/home-manager/compare/fd9e55f5fac45a26f6169310afca64d56b681935...1e54837569e0b80797c47be4720fab19e0db1616)

* [`619c84d9`](https://github.com/nix-community/home-manager/commit/619c84d9e03efcfb91b69b9f591846d0670aac13) issue_template: update feature request
* [`923782b2`](https://github.com/nix-community/home-manager/commit/923782b2c6e31aad339da898f80e103dc951dcc7) issue_template: add new module request
* [`fa135487`](https://github.com/nix-community/home-manager/commit/fa135487acbfa186b3d545d4d4807b7be5510cd0) issue_template: remove assignees
* [`1edfb622`](https://github.com/nix-community/home-manager/commit/1edfb62244493fcdfc83304e7d166ba2c90b1553) ci: bump DeterminateSystems/update-flake-lock from 25 to 26
* [`c0073055`](https://github.com/nix-community/home-manager/commit/c00730550e2dbcb4f8dd1552b3aa9d17d32d5ac6) tray-tui: add module ([nix-community/home-manager⁠#7415](https://togithub.com/nix-community/home-manager/issues/7415))
* [`5751fa77`](https://github.com/nix-community/home-manager/commit/5751fa774fa61837f35efb82f3b6e105d4c63ced) twitch-tui: add module ([nix-community/home-manager⁠#7416](https://togithub.com/nix-community/home-manager/issues/7416))
* [`218da00b`](https://github.com/nix-community/home-manager/commit/218da00bfa73f2a61682417efe74549416c16ba6) firefoxpwa: add module ([nix-community/home-manager⁠#7408](https://togithub.com/nix-community/home-manager/issues/7408))
* [`bec8ff39`](https://github.com/nix-community/home-manager/commit/bec8ff39811568eb7c8c8d1e2a1a476326748f51) wlogout: use lines for css style
* [`206ed3c7`](https://github.com/nix-community/home-manager/commit/206ed3c71418b52e176f16f58805c96e84555320) neomutt: improve error when no way to send mail
* [`50330593`](https://github.com/nix-community/home-manager/commit/50330593f33d0b873e0b6b05294164d093c0992a) flake.lock: Update ([nix-community/home-manager⁠#7419](https://togithub.com/nix-community/home-manager/issues/7419))
* [`d81cb050`](https://github.com/nix-community/home-manager/commit/d81cb050f5530fc84aa0ddb421d50722ee662600) hyprshell: add module ([nix-community/home-manager⁠#7409](https://togithub.com/nix-community/home-manager/issues/7409))
* [`fb12dbbc`](https://github.com/nix-community/home-manager/commit/fb12dbbce39ca29919e2b45913ce244c54d009de) lutris: make module x86_64-linux only ([nix-community/home-manager⁠#7425](https://togithub.com/nix-community/home-manager/issues/7425))
* [`d52da303`](https://github.com/nix-community/home-manager/commit/d52da303efeb39d67fdedd08f7d8fc8efd5f4332) firefox: add extension permissions ([nix-community/home-manager⁠#7402](https://togithub.com/nix-community/home-manager/issues/7402))
* [`729c5e54`](https://github.com/nix-community/home-manager/commit/729c5e5465a0585b2c492a40d9308ec3ad78a296) docker-cli: add module ([nix-community/home-manager⁠#7411](https://togithub.com/nix-community/home-manager/issues/7411))
* [`d52abd5b`](https://github.com/nix-community/home-manager/commit/d52abd5b525e2f4ccc57b07db9759d1a147472fd) email: allow more extensive configuration of aliases
* [`3978bcd6`](https://github.com/nix-community/home-manager/commit/3978bcd6961847385121db30c58dbd444d4a73df) thunderbird: configure SMTP and GPG for aliases
* [`fab659b3`](https://github.com/nix-community/home-manager/commit/fab659b346c0d4252208434c3c4b3983a4b38fec) trippy: add module ([nix-community/home-manager⁠#7426](https://togithub.com/nix-community/home-manager/issues/7426))
* [`ce150018`](https://github.com/nix-community/home-manager/commit/ce15001862e43130b347cb93bed9b4bd4dac990d) cliphist: use lib.getExe ([nix-community/home-manager⁠#7431](https://togithub.com/nix-community/home-manager/issues/7431))
* [`e90b2896`](https://github.com/nix-community/home-manager/commit/e90b28967cacc64de7fb8742314ed0d7d12f47c6) wayfire: allow path in settings ([nix-community/home-manager⁠#7427](https://togithub.com/nix-community/home-manager/issues/7427))
* [`d9915499`](https://github.com/nix-community/home-manager/commit/d9915499e3080fe2afe1f717acabeb697dd21709) gtk: refactor to support more modular customization
* [`18ff4e1e`](https://github.com/nix-community/home-manager/commit/18ff4e1e11b4a42576a30bd260250059c2bfd989) tests/gtk: expand testing for new customization
* [`47443585`](https://github.com/nix-community/home-manager/commit/47443585fe686a283626c27c5fb936883b7666e9) tests/gtk: refactor and organize
* [`fa7d5101`](https://github.com/nix-community/home-manager/commit/fa7d51011f4607a3c44f549d656b27d810b1d885) gtk: refactor and break up to improve readability
* [`a9594d34`](https://github.com/nix-community/home-manager/commit/a9594d34a28201b93f3ca63b4ac65cd2280420cb) gtk: remove long removed option removal assertion
* [`f5b36e5e`](https://github.com/nix-community/home-manager/commit/f5b36e5ecea60542d6f39797974cc6324a834e5e) gtk: add khaneliman maintainer
* [`9d343f08`](https://github.com/nix-community/home-manager/commit/9d343f08806148605e61af532e36d80ed47cef3e) ci: update-maintainers cleanup / tweaks ([nix-community/home-manager⁠#7433](https://togithub.com/nix-community/home-manager/issues/7433))
* [`b8b7e5ec`](https://github.com/nix-community/home-manager/commit/b8b7e5ec3570eb003d55f4947dd39af15c3ca98d) ci: extract-maintainers-meta tweaks ([nix-community/home-manager⁠#7434](https://togithub.com/nix-community/home-manager/issues/7434))
* [`03bf1bd8`](https://github.com/nix-community/home-manager/commit/03bf1bd8d6bad7521ce1c69dbe9b953156ca1148) gtk2: fix missing force option ([nix-community/home-manager⁠#7437](https://togithub.com/nix-community/home-manager/issues/7437))
* [`6d8ed2b4`](https://github.com/nix-community/home-manager/commit/6d8ed2b4fc2aaba8c87f44b1cf4931e22b683583) ci: tag-maintainer workflow refactor ([nix-community/home-manager⁠#7436](https://togithub.com/nix-community/home-manager/issues/7436))
* [`a3f4b998`](https://github.com/nix-community/home-manager/commit/a3f4b998ecaa9cf87f1a6244a49e5ed96a81f03e) wpaperd: handle empty settings properly
* [`3976e050`](https://github.com/nix-community/home-manager/commit/3976e0507edc9a5f332cb2be93fa20e646d22374) test/wpaperd: add test for empty settings
* [`7c6f7377`](https://github.com/nix-community/home-manager/commit/7c6f7377ccca88c45a28875e7755c38b604c5ff3) vscode: enable defining `mcp.json` separate from `settings.json` ([nix-community/home-manager⁠#7441](https://togithub.com/nix-community/home-manager/issues/7441))
* [`392ddb64`](https://github.com/nix-community/home-manager/commit/392ddb642abec771d63688c49fa7bcbb9d2a5717) home-manager: add flake support for repl command ([nix-community/home-manager⁠#7439](https://togithub.com/nix-community/home-manager/issues/7439))
* [`9b76feaf`](https://github.com/nix-community/home-manager/commit/9b76feafd02c84935ca3dea671057ca28b08131f) zsh: move oh-my-zsh to separate file
* [`3d95ab3c`](https://github.com/nix-community/home-manager/commit/3d95ab3cdca4e931b062e4dff39dea5563cbc2e3) zsh: move zprof to separate file
* [`80a07bc6`](https://github.com/nix-community/home-manager/commit/80a07bc6f7f062d78c7dbc91ae8863eca0cabb2a) zsh: move history to separate file
* [`26b987cf`](https://github.com/nix-community/home-manager/commit/26b987cf8840e74b89bf3fe42d48fdf84af108b3) zsh: move deprecated options to separate file
* [`196487c5`](https://github.com/nix-community/home-manager/commit/196487c54f58f237fade6b85dfd57f097c8b5581) zsh: group plugins in a separate directory
* [`ae62fd8a`](https://github.com/nix-community/home-manager/commit/ae62fd8ad8347e6bb5b615057f39f33d595a1c47) tests/zsh: add zprof test
* [`ea24675e`](https://github.com/nix-community/home-manager/commit/ea24675e4f4f4c494ccb04f6645db2a394d348ee) lib: Improve KDL generator ([nix-community/home-manager⁠#7429](https://togithub.com/nix-community/home-manager/issues/7429))
* [`f2795aa0`](https://github.com/nix-community/home-manager/commit/f2795aa053ef11f958fba49aef15a5c4d9734c02) ci: tag-maintainers further refactoring ([nix-community/home-manager⁠#7446](https://togithub.com/nix-community/home-manager/issues/7446))
* [`78d93389`](https://github.com/nix-community/home-manager/commit/78d9338934a6c9485d9804df6f1a0917b6797180) zellij: add support for layouts generation
* [`908200d6`](https://github.com/nix-community/home-manager/commit/908200d6808bf961718ae96c5aad7ae6b0f8bda9) tests/zellij: add zellij layout test
* [`2a8220dd`](https://github.com/nix-community/home-manager/commit/2a8220dd923f5b4a06a8c8abc11d75e17b11e599) ci: fix tag-maintainers ([nix-community/home-manager⁠#7448](https://togithub.com/nix-community/home-manager/issues/7448))
* [`fc253984`](https://github.com/nix-community/home-manager/commit/fc25398450cdab61af9654928dfef9d101f51140) zellij: add keybind examples ([nix-community/home-manager⁠#7447](https://togithub.com/nix-community/home-manager/issues/7447))
* [`bf893ad4`](https://github.com/nix-community/home-manager/commit/bf893ad4cbf46610dd1b620c974f824e266cd1df) tests: re-add module argument
* [`7969ed8b`](https://github.com/nix-community/home-manager/commit/7969ed8baac8363b32775c5f55e132668bab8123) gurk-rs: add module ([nix-community/home-manager⁠#7466](https://togithub.com/nix-community/home-manager/issues/7466))
* [`1a4d8ffd`](https://github.com/nix-community/home-manager/commit/1a4d8ffd320c2393b72e7ebc5b647122d5703056) gurk-rs: fix missing s in home.packages ([nix-community/home-manager⁠#7467](https://togithub.com/nix-community/home-manager/issues/7467))
* [`1e548375`](https://github.com/nix-community/home-manager/commit/1e54837569e0b80797c47be4720fab19e0db1616) ci: extract-maintainers handle non-existent files ([nix-community/home-manager⁠#7469](https://togithub.com/nix-community/home-manager/issues/7469))
