### PR TITLE
niv nerd-icons.el: update 4476b4ca -> 31ca7059

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -119,10 +119,10 @@
         "homepage": null,
         "owner": "rainstormstudio",
         "repo": "nerd-icons.el",
-        "rev": "4476b4cabe63f5efafa3c0a8b370db4f6a92e90c",
-        "sha256": "1d345y4z9j2m065j03kd6zb8hcr139mqzvpvxmg1147hrb9w25hn",
+        "rev": "31ca7059761c000bd7ebbcb2625c895ba65284a7",
+        "sha256": "1blm4lq0ljavsn5bjzg44sjkj1h3qy7nndby9k3lx2qw5bp59dkh",
         "type": "tarball",
-        "url": "https://github.com/rainstormstudio/nerd-icons.el/archive/4476b4cabe63f5efafa3c0a8b370db4f6a92e90c.tar.gz",
+        "url": "https://github.com/rainstormstudio/nerd-icons.el/archive/31ca7059761c000bd7ebbcb2625c895ba65284a7.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "niv": {


### PR DESCRIPTION
## Changelog for nerd-icons.el:
Branch: main
Commits: [rainstormstudio/nerd-icons.el@4476b4ca...31ca7059](https://github.com/rainstormstudio/nerd-icons.el/compare/4476b4cabe63f5efafa3c0a8b370db4f6a92e90c...31ca7059761c000bd7ebbcb2625c895ba65284a7)

* [`3f2757e8`](https://github.com/rainstormstudio/nerd-icons.el/commit/3f2757e83b9841699086f7097d23e1b3dc922cc2) address inconsistencies for ruby, makefile, perl and gpg icons in [rainstormstudio/nerd-icons.el⁠#31](https://togithub.com/rainstormstudio/nerd-icons.el/issues/31)
* [`46040d0c`](https://github.com/rainstormstudio/nerd-icons.el/commit/46040d0cccb3c858d626777149de9d511b65e601) address inconsistencies for typescript, scheme, puppet and vue
* [`31ca7059`](https://github.com/rainstormstudio/nerd-icons.el/commit/31ca7059761c000bd7ebbcb2625c895ba65284a7) add contrib package in readme
