### PR TITLE
niv zsh-you-should-use: update 030ac861 -> 64dd9e3f

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -263,10 +263,10 @@
         "homepage": "",
         "owner": "MichaelAquilina",
         "repo": "zsh-you-should-use",
-        "rev": "030ac861f5f1536747407ac7baf208fd3990602a",
-        "sha256": "0gx7gs5ds35vw15ygp98m6v8ryzgd1b57fwwn60zf4svpka43xc8",
+        "rev": "64dd9e3ff977e4ae7d024602b2d9a7a4f05fd8f6",
+        "sha256": "14kjc449kkd1fswqlxdpz6a5vg6pyhab69qbw7kavhjyzy39nxmv",
         "type": "tarball",
-        "url": "https://github.com/MichaelAquilina/zsh-you-should-use/archive/030ac861f5f1536747407ac7baf208fd3990602a.tar.gz",
+        "url": "https://github.com/MichaelAquilina/zsh-you-should-use/archive/64dd9e3ff977e4ae7d024602b2d9a7a4f05fd8f6.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }


### PR DESCRIPTION
## Changelog for zsh-you-should-use:
Branch: master
Commits: [MichaelAquilina/zsh-you-should-use@030ac861...64dd9e3f](https://github.com/MichaelAquilina/zsh-you-should-use/compare/030ac861f5f1536747407ac7baf208fd3990602a...64dd9e3ff977e4ae7d024602b2d9a7a4f05fd8f6)

* [`d9964c6d`](https://github.com/MichaelAquilina/zsh-you-should-use/commit/d9964c6d77d6fb61d89a0e01c68cc67d1c87423d) Fix issue [MichaelAquilina/zsh-you-should-use⁠#148](https://togithub.com/MichaelAquilina/zsh-you-should-use/issues/148) where hardcore mode would run when not enabled
* [`64dd9e3f`](https://github.com/MichaelAquilina/zsh-you-should-use/commit/64dd9e3ff977e4ae7d024602b2d9a7a4f05fd8f6) Bump version to 1.10.1
