### PR TITLE
niv nixpkgs: update a94dd3a6 -> de9c29bb

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -143,10 +143,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a94dd3a654caea2e1229fc4eea0bd6f2f85ca530",
-        "sha256": "0kx5zbbvh3ndcbxn87iikzjfa8shlixc49ybkrfr5jwgjasdc06k",
+        "rev": "de9c29bbd3512d3a776f1c0f150ee02d3477ff00",
+        "sha256": "0bymhnib39sx8n9h9z5qrzm262ij947z5wy55s5swjghcf0prymk",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/a94dd3a654caea2e1229fc4eea0bd6f2f85ca530.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/de9c29bbd3512d3a776f1c0f150ee02d3477ff00.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@a94dd3a6...de9c29bb](https://github.com/nixos/nixpkgs/compare/a94dd3a654caea2e1229fc4eea0bd6f2f85ca530...de9c29bbd3512d3a776f1c0f150ee02d3477ff00)

* [`72c7dd36`](https://github.com/NixOS/nixpkgs/commit/72c7dd36151d26007d40bce359634bec5cfcba38) nixos/redlib: harden systemd service
* [`7f96340e`](https://github.com/NixOS/nixpkgs/commit/7f96340e991fbefe8812cc55e8179026f9544c95) neon: 0.32.5 -> 0.34.2
* [`4d0dbe13`](https://github.com/NixOS/nixpkgs/commit/4d0dbe13f1ef9219177e9fac0aeb7c80549d485e) tmuxPlugins.harpoon: init at 0.4.0
* [`3f9dd53a`](https://github.com/NixOS/nixpkgs/commit/3f9dd53a32aa29a7fb6f7084bc42e6a6ea4ebd78) tmuxPlugins.dotbar: init at 0.3.0
* [`715a1b1c`](https://github.com/NixOS/nixpkgs/commit/715a1b1c49e10a665cdf6f659720b511c0bcd963) maintainers: add Anton-4
* [`5d0142f0`](https://github.com/NixOS/nixpkgs/commit/5d0142f09fc4fa99c5d14f443c15bae1597b92a2) maintainers: add rtfeldman
* [`265fde48`](https://github.com/NixOS/nixpkgs/commit/265fde48bfa13ba43de59fac3a3db965553953f5) maintainers: add bhansconnect
* [`72d63939`](https://github.com/NixOS/nixpkgs/commit/72d6393910239639d195cff7cf68e29914d1d88d) wine: fix updateScript
* [`52cc3a21`](https://github.com/NixOS/nixpkgs/commit/52cc3a211daeca7e740ed7d77c40e1b255bc0e24) python3Packages.netbox-qrcode: 0.0.17 -> 0.0.18
* [`b792ea9d`](https://github.com/NixOS/nixpkgs/commit/b792ea9d7a9ea4a73789c470b79d87db6f907061) python3Packages.netbox-topology-views: 4.2.1 -> 4.3.0
* [`5c14fd3c`](https://github.com/NixOS/nixpkgs/commit/5c14fd3cb4d5e0744c6471c9733e380dd935270a) Add patch that suppresses ctrl-event-signal-change messages for wpa_supplicant
* [`4162ef27`](https://github.com/NixOS/nixpkgs/commit/4162ef27454dffb40bc1e5cfe430582526316650) python3Packages.netbox-floorplan-plugin: 0.6.0 -> 0.7.0
* [`2ce1d06b`](https://github.com/NixOS/nixpkgs/commit/2ce1d06baf33806ab9d32ceb38ac0534fe8f3dec) nixos/kresd: don't explicitly set group id
* [`73afdf4c`](https://github.com/NixOS/nixpkgs/commit/73afdf4c7ee42dd2e609a071288e700af38966fa) python3Packages.netbox-interface-synchronization: 4.1.6 -> 4.1.7
* [`d4c40349`](https://github.com/NixOS/nixpkgs/commit/d4c403493742e8d4a16bea691411b326d2e8b435) dhcpcd: 10.1.0 -> 10.2.4
* [`633d762f`](https://github.com/NixOS/nixpkgs/commit/633d762f09253e72fd8402a1f16eaffc1f42ab72) python3Packages.netbox-documents: 0.7.2 -> 0.7.3
* [`efbd6691`](https://github.com/NixOS/nixpkgs/commit/efbd6691a089b0831a279dee38079df224b346b4) kdenlive: add to release-cuda
* [`f5e7f9cd`](https://github.com/NixOS/nixpkgs/commit/f5e7f9cd07989458512bb185fe2226402d9a3db5) octave: add to release-cuda
* [`aa0c7adc`](https://github.com/NixOS/nixpkgs/commit/aa0c7adcd6333fd525128545039d70dcdd293aaa) grayjay: 7 -> 8
* [`52aa361b`](https://github.com/NixOS/nixpkgs/commit/52aa361b92eddf6d0cadce2a7151f39f09e68c38) comic-neue: fetch source from GitHub
* [`bf5143d4`](https://github.com/NixOS/nixpkgs/commit/bf5143d4803bea59f1c80ee80b3b72c4740fe4ae) libde265: 1.0.15 -> 1.0.16
* [`563ad3e4`](https://github.com/NixOS/nixpkgs/commit/563ad3e49f9dd93f482c71cb9f1f4a16405f480d) capnproto: 1.1.0 -> 1.2.0
* [`9fdce1a7`](https://github.com/NixOS/nixpkgs/commit/9fdce1a71b7008d7f2bd52de21065c66d055ea4b) maintainers: add eu90h
* [`af9937b2`](https://github.com/NixOS/nixpkgs/commit/af9937b224867c2c94182ed9bb63fedaee5430f9) python-modules.langchain-google-genai: init at 2.1.5
* [`02ab7d2c`](https://github.com/NixOS/nixpkgs/commit/02ab7d2c87545601cb03ce03ad1a148cf39b1ad5) tun2socks: 2.5.2-unstable-2024-02-28 -> 2.6.0
* [`64f7da59`](https://github.com/NixOS/nixpkgs/commit/64f7da590915f6fc01f58a0fd8e5d57ac1a3bb45) build-support/rust: support default_features in cargo manifest
* [`32c19533`](https://github.com/NixOS/nixpkgs/commit/32c195332c7c9da4033126e1b768f59a83ea65a6) league-mono: init at 2.300
* [`61acadb9`](https://github.com/NixOS/nixpkgs/commit/61acadb99cdbfef67d121e160d4f1b8807a56efd) league-of-moveable-type: add league-mono
* [`624cb0a2`](https://github.com/NixOS/nixpkgs/commit/624cb0a248309813a7e170e89768e2199d2018b5) libogg: 1.3.5 -> 1.3.6
* [`698f8c73`](https://github.com/NixOS/nixpkgs/commit/698f8c73450fa37cbf015d94d2f447b22717e57b) Revert "cnijfilter_2_80: Fix build"
* [`c9ebaf5c`](https://github.com/NixOS/nixpkgs/commit/c9ebaf5c581b1da4cdff833caac5cabfec5c6c25) nixos/tsm-client: drop migration code from 2023 freeform update
* [`37922d6e`](https://github.com/NixOS/nixpkgs/commit/37922d6e2f22d762bde2129a498092eb320b77d8) tsm-client: 8.1.25.0 -> 8.1.26.0
* [`f9cc9bf9`](https://github.com/NixOS/nixpkgs/commit/f9cc9bf9119c61511908c400e2e4a3f4c87ffdb4) tsm-client: 8.1.26.0 -> 8.1.27.0
* [`4eec0199`](https://github.com/NixOS/nixpkgs/commit/4eec01995fcba21e00959c70444965aff8fb8bf8) libffi: 3.4.8 -> 3.5.1
* [`6a77abb2`](https://github.com/NixOS/nixpkgs/commit/6a77abb2c75551f77432a46be07ab57e75a4876a) kotlin: 2.1.21 -> 2.2.0
* [`4b2d88a9`](https://github.com/NixOS/nixpkgs/commit/4b2d88a9b458ea727e4d0feb8edef8f22dc59241) ethtool: 6.14 -> 6.15
* [`0603748c`](https://github.com/NixOS/nixpkgs/commit/0603748cf7d9b5377541cce5a0d8d41cbc1fe911) twingate: 2025.155.154174 -> 2025.175.154551
* [`d5426291`](https://github.com/NixOS/nixpkgs/commit/d54262911cee609de70c254cf6f3407d962219c8) nixos/systemd: fix run0 failing to run commands
* [`c01f4bd6`](https://github.com/NixOS/nixpkgs/commit/c01f4bd6e24e4ecd89e1e5eb5a7d56b953194fc6) ansible-lint: 25.5.0 -> 25.6.1
* [`2612a34a`](https://github.com/NixOS/nixpkgs/commit/2612a34a6d1e082d159f8c9e452e646eb3f8cb23) kumactl: 2.11.0 -> 2.11.1
* [`4d3073ab`](https://github.com/NixOS/nixpkgs/commit/4d3073ab5a26b0468ac82f5c768571bff3b29d15) python3Packages.safe-pysha3: 1.0.4 -> 1.0.5
* [`a36d414e`](https://github.com/NixOS/nixpkgs/commit/a36d414e2261bf43523edc5d7d266e3e2abdfeff) proxysql: 2.7.1 -> 3.0.1
* [`61ebbf15`](https://github.com/NixOS/nixpkgs/commit/61ebbf154a191843651111f028c7cd7162396fdc) z3: 4.15.1 -> 4.15.2
* [`14176541`](https://github.com/NixOS/nixpkgs/commit/14176541cb99a790283fde2720e809395508261c) python3Packages.scikit-fmm: 2025.1.29 -> 2025.6.23
* [`5affb840`](https://github.com/NixOS/nixpkgs/commit/5affb8408ad7f0d6860bcf33a602ad6e6a5ad238) python3Packages.gsd: 3.4.2 -> 4.0.0
* [`efe8bacb`](https://github.com/NixOS/nixpkgs/commit/efe8bacb4052c50d37d29c1e38f48b089ce4a8ba) fmit: remove with lib
* [`e43bb605`](https://github.com/NixOS/nixpkgs/commit/e43bb6058ab4e45cfd17f89df8b7fa111d1521b0) fmit: use finalAttrs
* [`b85e45c6`](https://github.com/NixOS/nixpkgs/commit/b85e45c6f9fb30c2db3631a8642854284e618ad3) fmit: use callPackage
* [`601b789c`](https://github.com/NixOS/nixpkgs/commit/601b789cd74c604e45768cc7c2da1f46561a5025) fmit: move to by-name
* [`cdddae6c`](https://github.com/NixOS/nixpkgs/commit/cdddae6cd995a8f82c09825f58406fe67cb48d73) k3sup: 0.13.9 -> 0.13.10
* [`a2d0bd86`](https://github.com/NixOS/nixpkgs/commit/a2d0bd86da403e324afb1a53993df8e8b7169f8c) python3Packages.django-import-export: 4.3.7 -> 4.3.8
* [`0b938541`](https://github.com/NixOS/nixpkgs/commit/0b93854119a56415d6e7d57e4b7f74289e2da8a2) grafanaPlugins: recurse into package set
* [`99a0bf12`](https://github.com/NixOS/nixpkgs/commit/99a0bf120a7d9e61ee20d273c13c2d05d9f3c90d) hopper: Fix libxml2 ABI breakage
* [`c010dfee`](https://github.com/NixOS/nixpkgs/commit/c010dfee08e9c89780270a89408e6bd46cae20a1) prometheus-opnsense-exporter: init at 0.0.10
* [`008b7a45`](https://github.com/NixOS/nixpkgs/commit/008b7a455ff2baec196439edb76113fb5e040f6f) chawan: 0.2.0 -> 0.2.1
* [`f641a43f`](https://github.com/NixOS/nixpkgs/commit/f641a43f6f5084793371672b075448c33d8a0040) snis-unwrapped: 1.0.8 -> 1.0.9
* [`67c23f06`](https://github.com/NixOS/nixpkgs/commit/67c23f0648b68430a32e381c1916e9390e0fdb7d) sqlite, sqlite-analyzer: 3.50.1 -> 3.50.2
* [`31764760`](https://github.com/NixOS/nixpkgs/commit/317647607b3105754ecbe3cc4fec78e2692d68a1) freetds: 1.5.3 -> 1.5.4
* [`2f894229`](https://github.com/NixOS/nixpkgs/commit/2f8942290ff480f71ded3cd953d5c5f7272789f5) mimalloc: 3.0.3 -> 3.1.5
* [`201e8fa4`](https://github.com/NixOS/nixpkgs/commit/201e8fa440565e2180ec4b01c5d20e59cd1b4fb9) libfreehand: init at 0.1.2
* [`854270d4`](https://github.com/NixOS/nixpkgs/commit/854270d45fd1e84a75da3a6dbab2dedef6fcb769) libpagemaker: init at 0.0.4
* [`cfde5ac4`](https://github.com/NixOS/nixpkgs/commit/cfde5ac44ee5b387f8480a5ca44a3bfd598fff4f) libmspub: init at 0.1.4
* [`5ad7e194`](https://github.com/NixOS/nixpkgs/commit/5ad7e1948b171ee638a57eaaceb29601b203d60e) libqxp: init at 0.0.2
* [`cf18d4b7`](https://github.com/NixOS/nixpkgs/commit/cf18d4b7b221d45ce5b4aac2229499e33b5f4fb9) python3Packages.numpydoc: 1.8.0 -> 1.9.0
* [`f4fdbb70`](https://github.com/NixOS/nixpkgs/commit/f4fdbb70e804717292dcb5f9981cb2dabf207551) boogie: 3.5.3 -> 3.5.4
* [`11007801`](https://github.com/NixOS/nixpkgs/commit/11007801f30d97b5d53d873e4d5c966fc88c22b1) python3Packages.binary: 1.0.1 -> 1.0.2
* [`a4786928`](https://github.com/NixOS/nixpkgs/commit/a47869283c933c2694bdffe33ffca200b251693b) python3Packages.pymupdf4llm: 0.0.17 -> 0.0.25
* [`6fb90eaf`](https://github.com/NixOS/nixpkgs/commit/6fb90eaf1d92181ef0398b5b35d792eb3dbfc0ca) regclient: 0.8.3 -> 0.9.0
* [`f0b4f331`](https://github.com/NixOS/nixpkgs/commit/f0b4f33120d6cc49b295a8e9415060df99bd359f) regsync: 0.8.3 -> 0.9.0
* [`88dd9182`](https://github.com/NixOS/nixpkgs/commit/88dd9182a347a9f7b9a45214f4280197b0f85797) nix-fast-build: added bashInteractive as runtime dependency
* [`19a4a85b`](https://github.com/NixOS/nixpkgs/commit/19a4a85ba838ecc9dfd8a607277509f6ebe6a3bb) maintainers: add e-v-o-l-v-e
* [`e862646f`](https://github.com/NixOS/nixpkgs/commit/e862646fc1bb6d88a750f3692ce5428104b80fb1) lsof: 4.99.4 -> 4.99.5
* [`ed3f4665`](https://github.com/NixOS/nixpkgs/commit/ed3f4665ebf10cc8532c1c43d377e6f764c145ae) minecraft-server: 1.21.6 -> 1.21.7
* [`fde3dce1`](https://github.com/NixOS/nixpkgs/commit/fde3dce1c8d1e369ee231de1e154b27daf37c290) bitwuzla: 0.7.0 -> 0.8.0
* [`2bbdb6d3`](https://github.com/NixOS/nixpkgs/commit/2bbdb6d3fee7a1f5ed5de063ac298d1316299bfa) aiger: 1.9.9 -> 1.9.20
* [`86bb270c`](https://github.com/NixOS/nixpkgs/commit/86bb270cf0164155a6d5294ac666bf35d530d013) aiger: install pkg-config file
* [`6eb20357`](https://github.com/NixOS/nixpkgs/commit/6eb203573f65b46e7d8424ca5e9c4ce93b0b47a2) bitwuzla: provide optional dep aiger
* [`fc5fd5ee`](https://github.com/NixOS/nixpkgs/commit/fc5fd5ee8c00e3493ef0854e54a951b1c8071323) google-cloud-sdk: 525.0.0 -> 529.0.0
* [`864ffcd1`](https://github.com/NixOS/nixpkgs/commit/864ffcd1e159537d8756ec0434d5be492981a06f) nixos/plasma6: fix autorotation when IIO module is enabled
* [`4155b779`](https://github.com/NixOS/nixpkgs/commit/4155b779ce698a4116c0116e8efebb2b02fe5529) cloud-init: 24.2 -> 25.1.3
* [`a8050ebe`](https://github.com/NixOS/nixpkgs/commit/a8050ebed5d7f28bd28defdbfb743c2fe11b219c) faudio: 25.06 -> 25.07
* [`974e4fcb`](https://github.com/NixOS/nixpkgs/commit/974e4fcb1955d9c0dd80d0b826f4392093052d74) python3Packages.gocardless-pro: 3.1.0 -> 3.2.0
* [`29787267`](https://github.com/NixOS/nixpkgs/commit/29787267e2b23fecd554c22f481a319513ad7c1f) maintainers: Add mrdev023
* [`94a5e9a6`](https://github.com/NixOS/nixpkgs/commit/94a5e9a6980e6614b8ab1e3ef8eb9fb78cad6bee) dosfstools: fix build
* [`aa415e89`](https://github.com/NixOS/nixpkgs/commit/aa415e8988fe1246f7efac6defe15af0f0752e67) yt-dlp: use `fetchFromGitHub`
* [`6e5b5905`](https://github.com/NixOS/nixpkgs/commit/6e5b59053159fdc1366e3ef0fd749e891d10b06f) python3Packages.google-cloud-translate: 3.20.3 -> 3.21.1
* [`84cd68f5`](https://github.com/NixOS/nixpkgs/commit/84cd68f55584b684e122457d58e169ca69d008a6) litestream: fix CVE-2024-41254 by adding SSH host key verification
* [`fef2f0d4`](https://github.com/NixOS/nixpkgs/commit/fef2f0d454828164646103f5f68b1d69e624ed5d) python3Packages.strawberry-graphql: 0.271.0 -> 0.275.5
* [`c897b562`](https://github.com/NixOS/nixpkgs/commit/c897b562e13be7ac666d2b5fbcbe7dc8a57a7ad9) util-linuxMinimal: use fetchurlBoot
* [`cfc7ee3c`](https://github.com/NixOS/nixpkgs/commit/cfc7ee3c304cf77a4fbab284687c85655f2f6d4a) libcpr: 1.11.2 -> 1.12.0
* [`26c5111b`](https://github.com/NixOS/nixpkgs/commit/26c5111b7c5c6fc6b9e70daa01c55ba727f05eb9) treewide: Correctly force Java font anti-aliasing to gasp mode
* [`14f75ec3`](https://github.com/NixOS/nixpkgs/commit/14f75ec36686a00b12f467eab8a892437c46ff45) yt-dlp: use `nix-update-script`
* [`d8ada6c1`](https://github.com/NixOS/nixpkgs/commit/d8ada6c1d6991dadadb0758313581b7265bc49c1) nixos/nextcloud-notify_push: delay restart and add same dependences for setup unit
* [`db75f901`](https://github.com/NixOS/nixpkgs/commit/db75f901032d7cea58f43cef27d12d9754cc099a) nixos/nginx: remove recommendedZstdSettings, add experimental option
* [`9a317eb9`](https://github.com/NixOS/nixpkgs/commit/9a317eb99391f9575d235c5bd26d293d01230559) nhentai: 0.5.3 -> 0.5.25
* [`1e52226c`](https://github.com/NixOS/nixpkgs/commit/1e52226c363319261a9d931e8d17b933a854dc12) improv-setup: init at 1.0.0
* [`59ce6343`](https://github.com/NixOS/nixpkgs/commit/59ce63437d2e83f270433305ecf32ff42c029187) nushell: Set NU_TEST_LOCALE_OVERRIDE to standardize locale used in test
* [`f4fe5e45`](https://github.com/NixOS/nixpkgs/commit/f4fe5e45a0e7248abe2ff45129c68e128731c8ea) opencv.passthru.tests.opencv4-tests: refactor and fix CUDA tests
* [`8e55d140`](https://github.com/NixOS/nixpkgs/commit/8e55d14081a8db92d7ce44f9b074ecc85391b30c) borgmatic: 2.0.6 -> 2.0.7
* [`b8d8a6a0`](https://github.com/NixOS/nixpkgs/commit/b8d8a6a0a15aeafa4422ccf75dc599fa44788387) vue-language-server: 2.2.8 -> 3.0.1
* [`cab80254`](https://github.com/NixOS/nixpkgs/commit/cab80254706561a96a9d4625c07a4cccc89c2fac) nixos/bookstack: Updated to accommodate passwordless login for mysql
* [`49e1508d`](https://github.com/NixOS/nixpkgs/commit/49e1508df2a73c06c37e89797c00d86dd076136d) pkgsStatic.toybox: fix macOS build
* [`bd5c4ca1`](https://github.com/NixOS/nixpkgs/commit/bd5c4ca1c0b3a57599534cbf27b65ca1e0309259) pkgsStatic.toybox: fix linux build
* [`5f4f3db7`](https://github.com/NixOS/nixpkgs/commit/5f4f3db7011b30d0f8268f33b6944f6e2dbe3fa3) cloudflared: 2025.6.1 -> 2025.7.0
* [`963a898a`](https://github.com/NixOS/nixpkgs/commit/963a898a33aec55fd0677c2f0ab3049ea20a026c) qmapshack: migrate to by-name
* [`85dec7df`](https://github.com/NixOS/nixpkgs/commit/85dec7df938b7d90e580df411f0b63e1a5ce1415) gradle_7: 7.6.5 -> 7.6.6
* [`a70581ef`](https://github.com/NixOS/nixpkgs/commit/a70581ef626e844a8276bffd56a81f823f2c684f) gradle_8: 8.14.2 -> 8.14.3
* [`14760848`](https://github.com/NixOS/nixpkgs/commit/14760848150158f3f50f56ca2f7d236c46ce2691) qmapshack: 1.17.1 → 1.18.0
* [`6a13f90e`](https://github.com/NixOS/nixpkgs/commit/6a13f90e88435fd4bc505d7124ee949dcd7279ed) zulu24: 24.0.0 -> 24.0.1
* [`2a87e0c4`](https://github.com/NixOS/nixpkgs/commit/2a87e0c41583c4570913cc7e1ac50db7fba66e93) libproxy: 0.5.9 -> 0.5.10
* [`9ffc4b48`](https://github.com/NixOS/nixpkgs/commit/9ffc4b48305c4d2646f210ed7f38377795387b87) local-content-share: init at 31
* [`84a45f5b`](https://github.com/NixOS/nixpkgs/commit/84a45f5bb29fef92c1db9e5faa3798d7ba35f139) pcsx2: switch updater to stable versions
* [`bec3154e`](https://github.com/NixOS/nixpkgs/commit/bec3154e3028d97493be4a24cf794e2c7c262d22) pcsx2: 2.3.424 -> 2.4.0
* [`e04333cb`](https://github.com/NixOS/nixpkgs/commit/e04333cb3c452d0a4c9a3e1beab5fdf6f515978d) nzbget: 25.0 -> 25.2
* [`e72fbae4`](https://github.com/NixOS/nixpkgs/commit/e72fbae409b33ff6dfeebb7d4f1fce0708316b8f) pcsx2: use wayland by default
* [`e47cbf39`](https://github.com/NixOS/nixpkgs/commit/e47cbf3942da373f1b0cba256ad08d38eab1ec6b) nixos/systemd/repart: add extraArgs option
* [`28d41fc5`](https://github.com/NixOS/nixpkgs/commit/28d41fc5912cc0526e9dae9388f9e7cadf9acb34) nixos/tests/systemd-repart: make sizeDiff configurable
* [`f1054a79`](https://github.com/NixOS/nixpkgs/commit/f1054a79c85b9d3668193b44429036577e7d9a0c) nixos/tests/systemd-repart: add Encrypt=tpm2 test
* [`9a3a54f1`](https://github.com/NixOS/nixpkgs/commit/9a3a54f1123cb2ae270b7af45c052985f0748fc5) froide-govplan: 0-unstable-2025-01-27 -> 0-unstable-2025-06-25
* [`7f1da3b0`](https://github.com/NixOS/nixpkgs/commit/7f1da3b0ae0a1168e249b95c02fdb8fd69d38e8f) froide: 0-unstable-2025-04-25 -> 0-unstable-2025-06-01
* [`b43b36e1`](https://github.com/NixOS/nixpkgs/commit/b43b36e1fcbb2ace67788c9605ebbc8905d8fba3) gdcm: 3.0.25 -> 3.0.26
* [`2851a5ad`](https://github.com/NixOS/nixpkgs/commit/2851a5ad707c7994ca9b297a86388f2d15e9f806) wordpressPackages.plugins.sqlite-database-integration: init at 2.2.3
* [`17cfe1b3`](https://github.com/NixOS/nixpkgs/commit/17cfe1b31685caa6a267faa09f8d308e53755362) _389-ds-base: 3.1.2 -> 3.1.3
* [`05a9ddb0`](https://github.com/NixOS/nixpkgs/commit/05a9ddb0a50bf5dc67e5d97befa40eb1ec6dc912) nixos/sing-box: apply migrations in tests
* [`4bb25b1b`](https://github.com/NixOS/nixpkgs/commit/4bb25b1beca57b45aeaa073d9749034c63ee50d8) mdns-scanner: 0.16.1 -> 0.17.1
* [`01909f1b`](https://github.com/NixOS/nixpkgs/commit/01909f1bdbe696069276aee3ee77426e86bdc470) gibo: 1.0.6 -> 3.0.14
* [`cb7ff9d9`](https://github.com/NixOS/nixpkgs/commit/cb7ff9d9e3f9ae95189f7e9462fb9501b1e1d566) nasm: set mainProgram
* [`1155da2f`](https://github.com/NixOS/nixpkgs/commit/1155da2fa740d017d6e3bd52e6cc8df2a42f5880) ghidra-extensions.ghidra-firmware-utils: init at 2024.04.20
* [`2d6d7a58`](https://github.com/NixOS/nixpkgs/commit/2d6d7a58d88b9c283ae9309dff2926ea07db1ce2) xavs2: init at 1.4
* [`3ec64f38`](https://github.com/NixOS/nixpkgs/commit/3ec64f388b4adc5b38c551e9dd4b47c61bbabf24) davs2: init at 1.7
* [`75a11fed`](https://github.com/NixOS/nixpkgs/commit/75a11fed3b7feb4481d93e6536b8a447c245a7df) uavs3d: init at 1.1-unstable-2023-02-23
* [`b923d163`](https://github.com/NixOS/nixpkgs/commit/b923d163ac104b6b6d9b2430be6d4b2ab616b980) ffmpeg: add avs options
* [`521f7291`](https://github.com/NixOS/nixpkgs/commit/521f729120943c559b19549be2c95d8daa99ee40) openblas: Add config for powerpc64-linux
* [`22e84b31`](https://github.com/NixOS/nixpkgs/commit/22e84b31da6c56ec2fa8182c6ec465977344d7dc) gst_all_1.gst-plugins-bad: Only enable ldacbt and webrtc-audio-processing_1 when supported
* [`17fda221`](https://github.com/NixOS/nixpkgs/commit/17fda221a70ca88e87efccb6a551d2746734fd2b) python3Packages.pyasynchat: fix build on sandboxed Darwin
* [`bc884bc5`](https://github.com/NixOS/nixpkgs/commit/bc884bc5f6a06f4133eb2a8ab3430e08bf1f3b03) kexec-tools: fix static build
* [`5a0a89d8`](https://github.com/NixOS/nixpkgs/commit/5a0a89d8da60084a69becb38533f923c14cb7af9) xterm: 400 -> 401
* [`7428330d`](https://github.com/NixOS/nixpkgs/commit/7428330dd1d9e5b5416accef1fa48271b120e306) python3Packages.pylette: 4.0.1 -> 4.1.0
* [`505b444f`](https://github.com/NixOS/nixpkgs/commit/505b444fb6e991bc379065a2d2ffe9d263352895) psqlodbc: 17.00.0002 -> 17.00.0006
* [`afade4de`](https://github.com/NixOS/nixpkgs/commit/afade4de86973440393b7f605e0b9fd47ac6e47c) fontforge: remove unused uthash dependency
* [`81eb0786`](https://github.com/NixOS/nixpkgs/commit/81eb0786d2adb7b3b0f5b7536d55ee5fba45e842) maintainers: add shellhazard
* [`9c4d06fd`](https://github.com/NixOS/nixpkgs/commit/9c4d06fd12d46b8895c33a703ce5ed26a2fe81f2) python3Packages.edk2-pytool-library: 0.23.3 -> 0.23.4
* [`b9ab49b0`](https://github.com/NixOS/nixpkgs/commit/b9ab49b07face73b5399daaa0d41309ed71ad14d) pinta: 3.0.1 -> 3.0.2
* [`27063df4`](https://github.com/NixOS/nixpkgs/commit/27063df46af3631e094d9ec5dcf3f3af28de82a6) wayland: 1.23.1 -> 1.24.0
* [`8acf8df8`](https://github.com/NixOS/nixpkgs/commit/8acf8df82d19adfffbf77df4e17b07b9eb04ad44) python313Packages.certifi: 2025.4.26 -> 2025.6.15 ([nixos/nixpkgs⁠#420216](https://togithub.com/nixos/nixpkgs/issues/420216))
* [`34fa8ce9`](https://github.com/NixOS/nixpkgs/commit/34fa8ce995b5a377fae41031340210444f50ca89) lightning-terminal: remove package.json
* [`0a419572`](https://github.com/NixOS/nixpkgs/commit/0a419572969eff6ebcf90ce5d6af1c67df11faaa) lightning-terminal: fix frontend build
* [`413eb5fc`](https://github.com/NixOS/nixpkgs/commit/413eb5fcf0ae3858bf3831bedbc4196931516d52) redocly: 1.34.2 -> 1.34.4
* [`a3e42aaf`](https://github.com/NixOS/nixpkgs/commit/a3e42aafa6819ca197788ea1455b63899f81fc3f) snd: 25.4 -> 25.5
* [`70505b12`](https://github.com/NixOS/nixpkgs/commit/70505b1234da58deedca75b110e9ed1700af3a93) iir1: 1.9.5 -> 1.10.0
* [`19d4db09`](https://github.com/NixOS/nixpkgs/commit/19d4db0923f4d789ade029075b3337c2ac938011) python3Packages.qpsolvers: 4.7.1 -> 4.8.0
* [`157c02ab`](https://github.com/NixOS/nixpkgs/commit/157c02ab6bf4ab6bd8c42d9ca74acbacf1bcb6b8) diffoscope: disable flaky test_non_unicode_filename test
* [`1febde0e`](https://github.com/NixOS/nixpkgs/commit/1febde0e97a549fc18e7bce13046daec69eaa710) dbtpl: init at 1.1.0
* [`e80c0626`](https://github.com/NixOS/nixpkgs/commit/e80c06264b0fa368e491d1e078995e2a71b14fbd) torsocks: move to by-name
* [`bb1e3933`](https://github.com/NixOS/nixpkgs/commit/bb1e393337761062dab85ecdd0224e92531de8de) torsocks: 2.4.0 -> 2.5.0
* [`60a6246f`](https://github.com/NixOS/nixpkgs/commit/60a6246f2bb3872134366088cfba3170ef4f86f2) tor: move to by-name
* [`3283402e`](https://github.com/NixOS/nixpkgs/commit/3283402efe94ac769ae764c039565bb5d0e2a5d2) tor: cleanup
* [`28877c22`](https://github.com/NixOS/nixpkgs/commit/28877c223a4f5954b132a7ebde404af369db963f) python3Packages.netbox-dns: 1.2.11 -> 1.3.4
* [`5afac852`](https://github.com/NixOS/nixpkgs/commit/5afac852f362f037374d59942575c79f8d777595) rshim-user-space: 2.2.4 -> 2.4.2
* [`fe748ee8`](https://github.com/NixOS/nixpkgs/commit/fe748ee89180b3b64f282ccbc3609c93cd81133d) mlxbf-bootimages: 4.10.0-13520 -> 4.11.0-13611
* [`c8f46a60`](https://github.com/NixOS/nixpkgs/commit/c8f46a60b9628ca2ec2454806644db4359dd43e7) mlxbf-bootctl: 1.1-6 -> unstable-2025-01-16
* [`04514c4b`](https://github.com/NixOS/nixpkgs/commit/04514c4b7de3cc1b91aa7fe6c0063f90d9bd1182) bfscripts: unstable-2023-05-15 -> unstable-2025-06-27
* [`edfd40fe`](https://github.com/NixOS/nixpkgs/commit/edfd40fecda8baffd86721da899a48ecf8a48f3a) inko: use finalAttrs
* [`a1154d63`](https://github.com/NixOS/nixpkgs/commit/a1154d6348511153fe41da3656c7ec4a35be9a83) patch-shebangs: fix binary data corrupt after patching
* [`7cd7a16d`](https://github.com/NixOS/nixpkgs/commit/7cd7a16d7a8dc6b0c3b305200d13a89c540f76ac) woomer: 0.1.0 -> 0.2.0
* [`2e056782`](https://github.com/NixOS/nixpkgs/commit/2e05678219e2a6ddf9dd1dcdc37976b8b40a396b) museeks: 0.22.2 -> 0.22.3
* [`fc7352a9`](https://github.com/NixOS/nixpkgs/commit/fc7352a9b961f599e0f6ac8880bb43b8bfb4b604) gettext: backport upstream memory safety fix
* [`f107d00f`](https://github.com/NixOS/nixpkgs/commit/f107d00f91dfaa7701fa04d6f919cc1f0dcf86e3) cc1541: 4.1 -> 4.2
* [`8a49c215`](https://github.com/NixOS/nixpkgs/commit/8a49c215e3fa7e9c951ea8a2cfdaa5655c99dd10) bililiverecorder: 2.17.1 -> 2.17.3
* [`da4672b5`](https://github.com/NixOS/nixpkgs/commit/da4672b591c45884f61e0690037b784e643cc391) importNpmLock: fix native dependencies for Darwin
* [`b6bffc94`](https://github.com/NixOS/nixpkgs/commit/b6bffc94209129d7695fa86f0b40a2f14dc68435) hclfmt: 2.23.0 -> 2.24.0
* [`c358dd7b`](https://github.com/NixOS/nixpkgs/commit/c358dd7b2441e324546fa85a569eb42bb8720858) kics: 2.1.10 -> 2.1.11
* [`cab9f2c6`](https://github.com/NixOS/nixpkgs/commit/cab9f2c66e684701a099c166174e9a07758e1147) Revert "rebar3: don't patchShebangs"
* [`1a95e72b`](https://github.com/NixOS/nixpkgs/commit/1a95e72bce24df8f2f4414c55b66e26b133540d1) cables: 0.6.0 -> 0.7.0
* [`f7e134de`](https://github.com/NixOS/nixpkgs/commit/f7e134def959e06f0f2eed5a9d157aab8a5faa2a) nixos/lanraragi: add openFirewall option
* [`d6b0a9a2`](https://github.com/NixOS/nixpkgs/commit/d6b0a9a2902f9067652a80302f2027c943105245) python3Packages.filecheck: 0.0.24 -> 1.0.2
* [`95022acc`](https://github.com/NixOS/nixpkgs/commit/95022acc72d3ee2f16b2227b50271403ed7df105) summon: 0.10.4 -> 0.10.5
* [`dab4052d`](https://github.com/NixOS/nixpkgs/commit/dab4052df3e82ce56625c7362b635341d3b55f5a) mieru: 3.16.1 -> 3.16.2
* [`c27529e5`](https://github.com/NixOS/nixpkgs/commit/c27529e5259de8f709db4524fd52149986f22b09) fanficfare: 4.46.0 -> 4.47.0
* [`d8205dc4`](https://github.com/NixOS/nixpkgs/commit/d8205dc4436194a22d00813391de853a6e324da6) sudo-rs: fix manpages install
* [`039a503e`](https://github.com/NixOS/nixpkgs/commit/039a503e7f65649a5f7290be64df9f273c35344b) sudo-rs: add version and manpage check, update skips
* [`21f99d52`](https://github.com/NixOS/nixpkgs/commit/21f99d521b515beb090958530b1cf1230ca90bb6) swayfx-unwrapped: 0.5 -> 0.5.3; scenefx: 0.2.1 -> 0.4.1
* [`e0f39774`](https://github.com/NixOS/nixpkgs/commit/e0f397744cdcfe9cf0e771c8551cefcb7f7b2ecc) tiny-rdm: 1.2.3 -> 1.2.4
* [`c1a58dad`](https://github.com/NixOS/nixpkgs/commit/c1a58dad3405ca5c2310e612f8247065ef8ab6a0) python312Packages.paddlex: 3.0.3 -> 3.1.1
* [`c03bcb20`](https://github.com/NixOS/nixpkgs/commit/c03bcb202c44e34e4a581f306091a8444c40858b) v4l-utils: fix build for musl
* [`5ca4c0c0`](https://github.com/NixOS/nixpkgs/commit/5ca4c0c09d72a84b0d4eea2192a42008d7c5ccfc) gthumb: build with libjxl
* [`f93421e4`](https://github.com/NixOS/nixpkgs/commit/f93421e410979e00311323b424d634c18a039d7b) snac2: 2.78 -> 2.80
* [`53b8db20`](https://github.com/NixOS/nixpkgs/commit/53b8db20634d9ddcb845f03c31f1b86b3dc0f5ce) touchosc: 1.4.3.234 -> 1.4.4.236
* [`3587eb72`](https://github.com/NixOS/nixpkgs/commit/3587eb72e474b0f4e4827537c2d82c14c8728333) freedv: 1.9.9.2 -> 2.0
* [`3090ecba`](https://github.com/NixOS/nixpkgs/commit/3090ecbae7db69e2d0b92c5c0652340b927c5272) python3Packages.manifestoo-core: 1.8.2 -> 1.9
* [`5c24314a`](https://github.com/NixOS/nixpkgs/commit/5c24314aec8a13c9421c2026166aa393f2922f72) python3Packages.conda-package-streaming: 0.11.0 -> 0.12.0
* [`cabc8db4`](https://github.com/NixOS/nixpkgs/commit/cabc8db4bfd28a9197ff57dad54c9dc0d9da8a29) powertabeditor: 2.0.21 -> 2.0.22
* [`3e8f215d`](https://github.com/NixOS/nixpkgs/commit/3e8f215df4400ada2a91ac0663073e94926abb15) q: 0.19.2 -> 0.19.5
* [`b510c517`](https://github.com/NixOS/nixpkgs/commit/b510c51711b85da33409feaabb4dc3ab3fd0ed5c) python3Packages.scipy-stubs: 1.16.0.0 -> 1.16.0.2
* [`bd458aa2`](https://github.com/NixOS/nixpkgs/commit/bd458aa23fdc19498036f901a9c65061ecdd1843) i3status-rust: 0.33.2 -> 0.34.0
* [`1efcfe7a`](https://github.com/NixOS/nixpkgs/commit/1efcfe7a7d1c3a9a34610f99239b1c5870404288) parallel-launcher: 8.2.0 -> 8.2.1
* [`44e6acae`](https://github.com/NixOS/nixpkgs/commit/44e6acaebbbd9074a19fe575a0960ce83117182e) roxctl: 4.7.4 -> 4.8.0
* [`de27f900`](https://github.com/NixOS/nixpkgs/commit/de27f900fc95d1a064f2f1383116156a5c7c1f75) rain: 1.23.0 -> 1.23.1
* [`ccb971f3`](https://github.com/NixOS/nixpkgs/commit/ccb971f3aa695a05d2f3eeb8428a02f44814d766) ly: 1.1.0 -> 1.1.1
* [`762726b2`](https://github.com/NixOS/nixpkgs/commit/762726b2a1924ac756779dad7643ec9108244848) github-runner: 2.325.0 -> 2.326.0
* [`c811cf1d`](https://github.com/NixOS/nixpkgs/commit/c811cf1dbb9624f0a55ffad8baa355166ea0d1c2) iniparser: use unity-test from nixpkgs
* [`de5e0637`](https://github.com/NixOS/nixpkgs/commit/de5e0637d544508d9ccfe5c1ef3094fddc9d64fd) trzsz-ssh: init at 0.1.22
* [`e088f75a`](https://github.com/NixOS/nixpkgs/commit/e088f75a2224a8d80b5ae2c698f0ab48a7373636) s2n-tls: 1.5.21 -> 1.5.22
* [`84113d15`](https://github.com/NixOS/nixpkgs/commit/84113d1581a54710fd64754ba6e747bf1c1d7a2a) python3Packages.azure-mgmt-storage: 23.0.0 -> 23.0.1
* [`02114302`](https://github.com/NixOS/nixpkgs/commit/02114302dc4e9198dddd6993d566baaea1573cfe) python3Packages.optuna-dashboard: 0.18.0 -> 0.19.0
* [`9f863f5c`](https://github.com/NixOS/nixpkgs/commit/9f863f5c56ec011a0406081de459f9f5fc71d90e) python3Packages.django-allauth: 65.7.0 -> 65.9.0
* [`27c51c7c`](https://github.com/NixOS/nixpkgs/commit/27c51c7c51c09280d7fc1eb575e39afbb485d84b) django-filingcabinet: 0.17-unstable-2025-04-10 -> 0.17-unstable-2025-07-01
* [`3d106afc`](https://github.com/NixOS/nixpkgs/commit/3d106afccc54e6cce9099ddcb57e306f79eb4704) python3Packages.django-mfa3: 0.15.1 -> 1.0.0
* [`5941eb23`](https://github.com/NixOS/nixpkgs/commit/5941eb238f405e6c4cd367b9fafc34f97e1e3c70) vokoscreen-ng: 4.5.2 -> 4.6.0
* [`16426f94`](https://github.com/NixOS/nixpkgs/commit/16426f94914eaa8509e5ae83cb97eb8451a4248f) opencode: 0.1.194 -> 0.2.5
* [`2b777929`](https://github.com/NixOS/nixpkgs/commit/2b77792944c579f8c8ae51a138a55aefd19f4b35) tana: 1.0.36 -> 1.0.37
* [`2cddd116`](https://github.com/NixOS/nixpkgs/commit/2cddd1165a02d30ad78ae58d0a8f6bb71db3bd85) reaction: 2.1.0 -> 2.1.1
* [`e615182d`](https://github.com/NixOS/nixpkgs/commit/e615182da27b07e7f4685aeb7d01e55134f55d5f) ncspot: 1.2.2 -> 1.3.0
* [`d780e942`](https://github.com/NixOS/nixpkgs/commit/d780e942be3caaa81ad8d42fa058af71a4983dc0) pop-gtk-theme: fix cross-compilation
* [`8046e4a6`](https://github.com/NixOS/nixpkgs/commit/8046e4a6f8e4eec20f404911b090025c1fde99e9) nixos/varnish: turn listen addresses into structured config
* [`5efcef1c`](https://github.com/NixOS/nixpkgs/commit/5efcef1c3e312d69c31f553035973c7a5573e2e9) gotrue-supabase: 2.176.1 -> 2.177.0
* [`ed6e1521`](https://github.com/NixOS/nixpkgs/commit/ed6e15210393167a9692638ab4857f82206ede5f) valkey: 8.1.2 -> 8.1.3
* [`51b1a4d2`](https://github.com/NixOS/nixpkgs/commit/51b1a4d21002b236ec30dc82890605d4b6196ef8) networkmanager: 1.52.0 -> 1.52.1
* [`aa139f0e`](https://github.com/NixOS/nixpkgs/commit/aa139f0e239922c7f6d2d8b88f18168fb3bf98c3) searxng: 0-unstable-2025-06-28 -> 0-unstable-2025-07-08
* [`1a7d3e42`](https://github.com/NixOS/nixpkgs/commit/1a7d3e42e607e03a97b6b7e9be638d9375077649) vscode-extensions.llvm-vs-code-extensions.lldb-dap: init at 0.2.15
* [`6101f4e5`](https://github.com/NixOS/nixpkgs/commit/6101f4e5228a2ab3d0f7d1622b3b38882ce04441) linuxPackages.nvidiaPackages.vulkan_beta: 570.123.18 -> 570.123.19
* [`a4dde870`](https://github.com/NixOS/nixpkgs/commit/a4dde87093e42a4bde9cd7fedd89eabf82e871e3) linuxPackages.nvidiaPackages.vulkan_beta: bump utilities to r570
* [`1968d347`](https://github.com/NixOS/nixpkgs/commit/1968d347352ca0d7ed9ed6d6dcebc0c2cf4babb6) python3Packages.flask-session2: init at 1.3.1
* [`d1a79fcd`](https://github.com/NixOS/nixpkgs/commit/d1a79fcd1714d6d32ede425e70dcbf1cc7cb132c) opencode: 0.2.5 -> 0.2.6
* [`b28f77be`](https://github.com/NixOS/nixpkgs/commit/b28f77becf849a60df4e98611c269dc7c31e3ffe) rymdport: 3.8.0 -> 3.9.0
* [`9cf396a3`](https://github.com/NixOS/nixpkgs/commit/9cf396a3dcfacdde4d595546a782c76c5651e4f1) nugget-doom: fix tag name in update script
* [`3c982ee1`](https://github.com/NixOS/nixpkgs/commit/3c982ee1dc1f651dab1a215c01668b6a2bc3b19b) bolt-launcher: 0.17.0 -> 0.18.0
* [`627a4a4a`](https://github.com/NixOS/nixpkgs/commit/627a4a4a493c2658dac5b094393a8ced53a93a9b) zathura: 0.5.11 -> 0.5.12
* [`6c00ea29`](https://github.com/NixOS/nixpkgs/commit/6c00ea29367c467054680f7a603305e2c8c16321) git: 2.50 -> 2.50.1
* [`1bb9a0aa`](https://github.com/NixOS/nixpkgs/commit/1bb9a0aa641229047dc657c67bd4dc45199943e3) x32edit,m32edit: 4.3 -> 4.4
* [`1220274c`](https://github.com/NixOS/nixpkgs/commit/1220274c790df4df5d21ab47015e338b8833dbbc) nbdkit: 1.42.1 -> 1.44.1
* [`885017bf`](https://github.com/NixOS/nixpkgs/commit/885017bf9e63391f9ab9222061fe075a8eefcaad) go_1_24: 1.24.4 -> 1.24.5
* [`bfc73fd1`](https://github.com/NixOS/nixpkgs/commit/bfc73fd139fc9cb89f33b5a663d93cda1cdf2fe0) stdenv: Don't reappend patchFlags
* [`54e4e95e`](https://github.com/NixOS/nixpkgs/commit/54e4e95e6ba0d8f063818490d38484d89b0fb689) nomad_1_10: 1.10.2 -> 1.10.3
* [`c821b395`](https://github.com/NixOS/nixpkgs/commit/c821b3953025fbd8232881efc862a9da48e2eacf) nomad: 1.10.2 -> 1.10.3
* [`45652f34`](https://github.com/NixOS/nixpkgs/commit/45652f3496764d5f6a0850deeadbdf910056f303) lock: 1.6.2 -> 1.6.5
* [`405f561c`](https://github.com/NixOS/nixpkgs/commit/405f561c3775f7c11e173150352675cc96848024) mstflint_access: use kernel Makefile for install
* [`69fd2399`](https://github.com/NixOS/nixpkgs/commit/69fd2399508ece1d0112a3c3244fb96740c99eaf) python3Packages.color-parser-py: init at 0.1.6
* [`83607993`](https://github.com/NixOS/nixpkgs/commit/83607993f8476e37c2eba28bb0f6810035ed2afd) devtoolbox: 1.2.5 -> 1.3.0
* [`776b1fdc`](https://github.com/NixOS/nixpkgs/commit/776b1fdc62904c0874c10aca120a5c6f400336cf) python3Packages.azure-keyvault-certificates: 4.9.0 -> 4.10.0
* [`e65c57cb`](https://github.com/NixOS/nixpkgs/commit/e65c57cbbc5d4258ee6445078afca9d1f0be0d66) game-music-emu: 0.6.3 -> 0.6.4 | source migration
* [`cf1333af`](https://github.com/NixOS/nixpkgs/commit/cf1333af3b661221edf62befe40340cee8d39878) vscode-extensions.ocamllabs.ocaml-platform: 1.30.0 -> 1.30.1
* [`afa0c5dc`](https://github.com/NixOS/nixpkgs/commit/afa0c5dc82ec21b74169e1cf9d8787abcac976da) opencode: 0.2.6 -> 0.2.13
* [`3c794bc8`](https://github.com/NixOS/nixpkgs/commit/3c794bc86a8cef0570b07cfdec55b284e2b0eb8d) LycheeSlicer: 7.3.2 -> 7.4.0
* [`16889202`](https://github.com/NixOS/nixpkgs/commit/1688920298030e84e51f93f7c3e883fdbde05c33) mdp: 1.0.15 -> 1.0.17
* [`f3f6c442`](https://github.com/NixOS/nixpkgs/commit/f3f6c442a18676e4db8b6ca5b137cc9f5f180d4d) vscode-extensions.ms-toolsai.jupyter-renderers: 1.1.2025012901 -> 1.3.0
* [`8d74a906`](https://github.com/NixOS/nixpkgs/commit/8d74a9061c4cd4b131089fae99269e3d3ddda47e) nodejs_24: 24.3.0 -> 24.4.0
* [`38914c80`](https://github.com/NixOS/nixpkgs/commit/38914c8076f2f63911c46258983b2c3f1e74f4e6) python3Packages.dj-rest-auth: Fix compatibility with django-allauth
* [`cd85e93f`](https://github.com/NixOS/nixpkgs/commit/cd85e93ff776c1f347a911c7ecbb19e0d7bedda0) nixos/froide-govplan: Fix PYTHONPATH
* [`30b46a50`](https://github.com/NixOS/nixpkgs/commit/30b46a50bc1bbb66984cbb4961a6ddcb1c1026a0) paperless-ngx: Pin django-allauth version
* [`99d4350e`](https://github.com/NixOS/nixpkgs/commit/99d4350e1241334d64ece49da7bd9a48cbf6d9dc) python3Packages.fido2_2: init at 2.0.0
* [`81edb3c9`](https://github.com/NixOS/nixpkgs/commit/81edb3c9865bbf6a6cbb98337ed0b2e69edfa099) nixos/nextcloud: move phpPackage default into option
* [`53f664d3`](https://github.com/NixOS/nixpkgs/commit/53f664d33df063e69a93cb9e35206a9e81e15fd6) aichat: 0.29.0 -> 0.30.0
* [`aa18f87e`](https://github.com/NixOS/nixpkgs/commit/aa18f87e062c6acca74996ee2b1adb42c2abede9) postgresqlPackages.hypopg: 1.4.1 -> 1.4.2
* [`cfb4e645`](https://github.com/NixOS/nixpkgs/commit/cfb4e6450ea049ee6db0d29c9d5d79f77919555c) postgresqlPackages.hypopg: add meta.changelog
* [`c3d25e49`](https://github.com/NixOS/nixpkgs/commit/c3d25e49019df195eeb3fc6a62c6fe0b9dfbf4bd) keycloak: 26.2.5 -> 26.3.1
* [`bf888fe1`](https://github.com/NixOS/nixpkgs/commit/bf888fe11107abee930050593494bbceeb49ebc1) vulkan-cts: 1.4.2.0 -> 1.4.3.1
* [`4966328d`](https://github.com/NixOS/nixpkgs/commit/4966328d147484b92760950150dd007112c0f80b) ignite-cli: 28.10.0 -> 28.11.0
* [`65648b54`](https://github.com/NixOS/nixpkgs/commit/65648b547119f1096476ed67a800f5a2ced6f9f6) master_me: 1.3.0 -> 1.3.1
* [`6e5554c4`](https://github.com/NixOS/nixpkgs/commit/6e5554c44c2c70bea1e25e350f8153608972a672) nixos/mautrix-whatsapp: add manual entry
* [`89445e7a`](https://github.com/NixOS/nixpkgs/commit/89445e7a4b0ad86017de4380585c5254ca65d2a0) naev: 0.12.5 -> 0.12.6
* [`93b02556`](https://github.com/NixOS/nixpkgs/commit/93b02556ec6c4f01e82c3c534e57354a2ee3a927) python3Packages.conda-libmamba-solver: add missing dependency
* [`ad675104`](https://github.com/NixOS/nixpkgs/commit/ad675104af1bb161da642f50d5891fc2a83aefdd) python3Packages.conda: 25.1.0 -> 25.5.1
* [`bc122c4f`](https://github.com/NixOS/nixpkgs/commit/bc122c4fab1e3540e6f878e1bfe63c2d339d116e) lychee: 0.18.1 -> 0.19.1
* [`95994832`](https://github.com/NixOS/nixpkgs/commit/95994832132d37f183dde67eac4e43cec7ffbf77) vscode-extensions.angular.ng-template: 20.0.1 -> 20.1.1
* [`5b9157c8`](https://github.com/NixOS/nixpkgs/commit/5b9157c88e341b1e33882350e963983a8862b79a) geoipupdate: 7.1.0 -> 7.1.1
* [`4e0bd794`](https://github.com/NixOS/nixpkgs/commit/4e0bd794fa21003b55e7302b1344f3281b731a8f) ghidra-extensions.kaiju: 250610 -> 250709
* [`cd9ac20a`](https://github.com/NixOS/nixpkgs/commit/cd9ac20af512fea5f3bfca5acc9ddf1b081474d7) scribus: 1.6.4 -> 1.7.0
* [`bdd3e4f3`](https://github.com/NixOS/nixpkgs/commit/bdd3e4f38ac17d0f49e730289e7c5a5c7b463a24) nixosTests.mitmproxy: init
* [`80363bfd`](https://github.com/NixOS/nixpkgs/commit/80363bfd8da4b2df79d6811157f3566ced867b7c) git-machete: 3.36.0 -> 3.36.1
* [`8589f095`](https://github.com/NixOS/nixpkgs/commit/8589f095bf194c44fde743cc273299dd31c421de) lvm2: 2.03.32 -> 2.03.33
* [`47138a6d`](https://github.com/NixOS/nixpkgs/commit/47138a6da97ae1a8f6f8c001fd6591c5c9908a2d) python3Packages.bayesian-optimization: 3.0.0 -> 3.0.1
* [`853430d4`](https://github.com/NixOS/nixpkgs/commit/853430d47e8c5be9ab1ee4e3ac4954a4708b369e) lima, lima-additional-guestagents: 1.1.1 -> 1.2.0
* [`bf3555dd`](https://github.com/NixOS/nixpkgs/commit/bf3555dd3feea0ad092217370e4db0dd6c9e6253) xorg.xvfb: restore GLX/DRI support
* [`8094ca3d`](https://github.com/NixOS/nixpkgs/commit/8094ca3dde7e436094d06e6fd5f6775beb5b82ad) krita: 5.2.9 -> 5.2.10
* [`3f4418f7`](https://github.com/NixOS/nixpkgs/commit/3f4418f79d24ce04decc6871e1e472e8d3704129) rundeck-cli: fix missing `java.logging` module
* [`d6e35165`](https://github.com/NixOS/nixpkgs/commit/d6e3516544e5754483496a5f6aa9c3d9e64932f3) nixos/froide-govplan: Increase startup timeout
* [`1f7db7b8`](https://github.com/NixOS/nixpkgs/commit/1f7db7b820addab0ed7fb97d476fdece269097d1) maintainers: drop vidister
* [`e9c609f6`](https://github.com/NixOS/nixpkgs/commit/e9c609f61adab4de2eb4073267a608a99598d72f) dotbot: 1.22.0 -> 1.23.0
* [`aa3511b0`](https://github.com/NixOS/nixpkgs/commit/aa3511b00cc6bd3a6f426a1b0c1b5f98cab8be6a) vscode-extensions.ms-toolsai.jupyter: 2025.5.0 -> 2025.6.0
* [`dfb2cac6`](https://github.com/NixOS/nixpkgs/commit/dfb2cac6aa5d7917881d7e3e36cabc74e431c5e0) parallel-disk-usage: 0.12.0 -> 0.13.1
* [`3804083c`](https://github.com/NixOS/nixpkgs/commit/3804083ce4b4fa87d90bfff429b0623280a8b268) python313Packages.pylitterbot: 2024.2.1 -> 2024.2.2
* [`0d9b468a`](https://github.com/NixOS/nixpkgs/commit/0d9b468a64721dc27627784cc89542373510a275) python3Packages.langchain-mistralai: 0.2.10 -> 0.2.11
* [`1eb41304`](https://github.com/NixOS/nixpkgs/commit/1eb4130494764f27ca0deaabb68d1325ebf09398) qt6.qtwebengine: fix build for gcc
* [`b2a9f721`](https://github.com/NixOS/nixpkgs/commit/b2a9f721586ae549445585503d174a8383a73ec6) angie-console-light: 1.4.0 -> 1.8.0
* [`4a3cdf0c`](https://github.com/NixOS/nixpkgs/commit/4a3cdf0ca093ed71dd49d8ed0106bb23174f52ac) qt6Packages.qwt: build qwt for Qt6
* [`201b1cc5`](https://github.com/NixOS/nixpkgs/commit/201b1cc567ef2eaa083ee2401c942113f1b1b623) dbvisualizer: 25.1.4 -> 25.1.5
* [`7bc19468`](https://github.com/NixOS/nixpkgs/commit/7bc194686d26b9f8320c62d73ef8ee82457af8bc) opencode: 0.2.13 -> 0.2.20
* [`3b687ae6`](https://github.com/NixOS/nixpkgs/commit/3b687ae656c88507c2c33e34e08989e53b9b356a) libwebp: 1.5.0 -> 1.6.0
* [`4bd71569`](https://github.com/NixOS/nixpkgs/commit/4bd715690f656f97b61660a1c41085e1f6889dcc) git-codereview: 1.15.0 -> 1.16.0
* [`13509e2f`](https://github.com/NixOS/nixpkgs/commit/13509e2fb731b75015fc1eb4f4ff0186e9c11d4f) xen: 4.20.0 -> 4.20.1
* [`8e96e65a`](https://github.com/NixOS/nixpkgs/commit/8e96e65a9a07961ae9581695129c18cba8ed48ce) xpipe: 16.6 -> 16.7
* [`f0b7c3bc`](https://github.com/NixOS/nixpkgs/commit/f0b7c3bc4331105844c8e6361e84997e7502abdf) game-music-emu: fix hash
* [`813f95d5`](https://github.com/NixOS/nixpkgs/commit/813f95d5cbdf9773b1a2a2383acb34d3c9aeb9b2) kubeone: 1.10.1 -> 1.11.0
* [`1f6463e2`](https://github.com/NixOS/nixpkgs/commit/1f6463e2914688c7641be4790712c4a3208fc069) kmetronome: Migrate to by-name
* [`a05ecf0d`](https://github.com/NixOS/nixpkgs/commit/a05ecf0d45e715ef30febca6586c7ff0dddf8e93) flannel: 0.27.0 -> 0.27.1
* [`8513c75f`](https://github.com/NixOS/nixpkgs/commit/8513c75f68bee0b4f9aa35772cb79abf7921c4b9) gnutls: 3.8.9 -> 3.8.10
* [`7f448818`](https://github.com/NixOS/nixpkgs/commit/7f448818767b8dfcc204873ec9a485d75ec5e17e) codipack: 2.3.2 -> 3.0.0
* [`5a9ae7aa`](https://github.com/NixOS/nixpkgs/commit/5a9ae7aafa4da2900e49e3798b8d8b135494f864) arsenal: modernize
* [`ce17acba`](https://github.com/NixOS/nixpkgs/commit/ce17acbab3d51cde3d5bd184efa604c5e5730dab) arsenal: 1.1.0 -> 1.2.7
* [`91bdcc0f`](https://github.com/NixOS/nixpkgs/commit/91bdcc0f29ee42a62f56015f3b05a17b281982ea) mpsolve: 3.2.1 -> 3.2.2
* [`1ae010b3`](https://github.com/NixOS/nixpkgs/commit/1ae010b3b11837aa75070b827e16a8370cdc7b46) python3Packages.metaflow: 2.15.18 -> 2.15.20
* [`e7ee980f`](https://github.com/NixOS/nixpkgs/commit/e7ee980f5e9cc997d00b164881d46f3609084b3c) do-agent: 3.17.1 -> 3.18.0
* [`a5fa5508`](https://github.com/NixOS/nixpkgs/commit/a5fa5508dbb03966a1e74012c57d13b7f5539335) doc: Add necessary details to understand dep propagation
* [`3e1661ea`](https://github.com/NixOS/nixpkgs/commit/3e1661ea7ff1ad2b580296bc8ea3652fece8708a) opencode: 0.2.20 -> 0.2.23
* [`a435da79`](https://github.com/NixOS/nixpkgs/commit/a435da7902de33caef36e890f128e125f196bcf7) opencode: 0.2.23 -> 0.2.25
* [`fda9a5f9`](https://github.com/NixOS/nixpkgs/commit/fda9a5f9e34131008ca8e8b9d33f688edec58c07) g-ls: 0.30.0 -> 0.31.0
* [`8b3c6b85`](https://github.com/NixOS/nixpkgs/commit/8b3c6b8536a0dce4f073dd792ec8f41d3d1e76fb) liquibase: 4.32.0 -> 4.33.0
* [`a4114b2a`](https://github.com/NixOS/nixpkgs/commit/a4114b2a0c649392eb032b6b6de4ba1027c0524e) vacuum-go: 0.17.1 -> 0.17.5
* [`0bbb2099`](https://github.com/NixOS/nixpkgs/commit/0bbb2099b875eb21cc7bfb0c56de407be0854dab) python3Packages.xformers: support aarch64-darwin
* [`7dc2414b`](https://github.com/NixOS/nixpkgs/commit/7dc2414beb3a8aad4719428e40b14f86740f0754) microsoft-edge: 138.0.3351.77 -> 138.0.3351.83
* [`e2fc417b`](https://github.com/NixOS/nixpkgs/commit/e2fc417b2eea8b22dca75f46dad675e7cb09092d) trealla: 2.77.23 -> 2.78.0
* [`c5f91ea8`](https://github.com/NixOS/nixpkgs/commit/c5f91ea8108e69779a261e89f3a8db91603605b5) chatbox: 1.14.3 -> 1.15.0
* [`17c863a0`](https://github.com/NixOS/nixpkgs/commit/17c863a0498e5e067edfb3cf8f85196aa4e813f7) smartgit: 24.1.3 -> 24.1.4
* [`dfe10ddd`](https://github.com/NixOS/nixpkgs/commit/dfe10ddd842a313701270b04633c93a6aea72829) go-blueprint: 0.10.10 -> 0.10.11
* [`239544b4`](https://github.com/NixOS/nixpkgs/commit/239544b4899f5af5b42c61d1b31d12a02a9eef2e) stackql: 0.8.141 -> 0.8.175
* [`42bdf169`](https://github.com/NixOS/nixpkgs/commit/42bdf169a79d405c21dfa70c68916a9d78574efa) cargo-nextest: 0.9.99 -> 0.9.100
* [`598be38e`](https://github.com/NixOS/nixpkgs/commit/598be38ee478189110531456632cdd16a4af1983) python3Packages.langchain-ollama: 0.3.3 -> 0.3.4
* [`3f8ee501`](https://github.com/NixOS/nixpkgs/commit/3f8ee50157312fa368341ed77a555df3edda0e09) python3Packages.mkdocs-mermaid2-plugin: 1.1.0 -> 1.2.1
* [`dacef641`](https://github.com/NixOS/nixpkgs/commit/dacef64157acf7b4301c0949920950cb3e288a97) mpvScripts.quality-menu: 4.2.0 -> 4.2.1
* [`4f666a69`](https://github.com/NixOS/nixpkgs/commit/4f666a693af6c571c5242cbd39c0002d532f2c1b) vscode-extensions.illixion.vscode-vibrancy-continued: 1.1.54 -> 1.1.57
* [`3468468e`](https://github.com/NixOS/nixpkgs/commit/3468468e3c1f6b47f75785dbf84ad7312603eb96) fzf-git-sh: 0-unstable-2025-05-08 -> 0-unstable-2025-07-10
* [`7fc48d12`](https://github.com/NixOS/nixpkgs/commit/7fc48d12766062cb12286e3d93c11057835eb946) drawterm: 0-unstable-2025-06-13 -> 0-unstable-2025-06-29
* [`6dab1fd5`](https://github.com/NixOS/nixpkgs/commit/6dab1fd5e77f1d5878c92de0a0b633db4730befd) peergos: 1.7.1 -> 1.8.0
* [`8e388824`](https://github.com/NixOS/nixpkgs/commit/8e3888242d2d88094893251c5bdd36b2bfc828f8) audit: 4.0.5 -> 4.1.0
* [`55b7eea2`](https://github.com/NixOS/nixpkgs/commit/55b7eea21aff422a42e76cb44b0926d715623303) cargo-tally: 1.0.65 -> 1.0.66
* [`31dc88c4`](https://github.com/NixOS/nixpkgs/commit/31dc88c4ad5caeccadf894d4b4cf51c74458ffd8) python3Packages.redshift-connector: 2.1.7 -> 2.1.8
* [`5fd0aef1`](https://github.com/NixOS/nixpkgs/commit/5fd0aef18303a36d5ba79819e0b56d99559e1e61) perlPackages.FileShareDir: Fix cross-compilation
* [`45e9f457`](https://github.com/NixOS/nixpkgs/commit/45e9f457f9943c5e9ff28a22d4cc4c8da10370d4) ada: 3.2.4 -> 3.2.5
* [`a1a86470`](https://github.com/NixOS/nixpkgs/commit/a1a86470e399843e4e44f47e11ab3bcfefe5d2f2) nixos/network-interfaces-scripted: disable DAD
* [`1a8c9012`](https://github.com/NixOS/nixpkgs/commit/1a8c90128bb6d58addac981eaaa92d8bc9583bb8) nixos/network-interfaces: add option to set source address
* [`71663453`](https://github.com/NixOS/nixpkgs/commit/716634530e39e0423f038b464bc61427db6e4707) nixos/networking-interfaces: clean up networking.sits
* [`1c5b9429`](https://github.com/NixOS/nixpkgs/commit/1c5b9429ea95419a5bfccf99734a89c529b4ac9c) nixos/tests/networking: test both 6in4 and UDP-encapsulated tunnels
* [`4e5205a6`](https://github.com/NixOS/nixpkgs/commit/4e5205a68ab124b909e16685747c6eeb066c8ee0) nixos/networking-interfaces: add IPIP tunnels
* [`0bd522a4`](https://github.com/NixOS/nixpkgs/commit/0bd522a407d34d2d14fb43014f671d11c7212d3d) nixos/release-notes: mention networking.interfaces changes
* [`7536460f`](https://github.com/NixOS/nixpkgs/commit/7536460f2f28d326414c6963127697da2f2d9537) nixos/release-combined: update networking tests names
* [`602006b0`](https://github.com/NixOS/nixpkgs/commit/602006b0b6924221978833a06e905c8d2b89347d) nixos/networking-interfaces: add rnhmjoj as maintainer
* [`632c8f72`](https://github.com/NixOS/nixpkgs/commit/632c8f720eb7ed2a4ba341adff303378820f61b7) nixos/tests/networking: add rnhmjoj as maintainer
* [`0bcdde01`](https://github.com/NixOS/nixpkgs/commit/0bcdde01294b874346912f489fb9c3338b8102ce) amazon-q-cli: 1.12.2 -> 1.12.4
* [`354336f6`](https://github.com/NixOS/nixpkgs/commit/354336f686e97ede48034f0da42f2e54972d0d44) docker: 28.2.2 -> 28.3.2
* [`651d395b`](https://github.com/NixOS/nixpkgs/commit/651d395beb3a01e52827bfe236537b514ad876f0) docker_25: 25.0.10 -> 25.0.11
* [`0cf28330`](https://github.com/NixOS/nixpkgs/commit/0cf28330f5f2c1945a458d2a7fbacf583d707343) mediawiki: 1.43.2 -> 1.44.0
* [`b618c517`](https://github.com/NixOS/nixpkgs/commit/b618c517ee82a9e8b05e60b108c6e6042b85933f) cargo-codspeed: 3.0.1 -> 3.0.2
* [`ffe79b95`](https://github.com/NixOS/nixpkgs/commit/ffe79b95e8c9debef031d80d801fc7a35cdf9672) sheldon: 0.8.3 -> 0.8.4
* [`64ad2a63`](https://github.com/NixOS/nixpkgs/commit/64ad2a6356ea9c8c41eea092a215b4c9d3cf3440) maintainers: add norpol
* [`7177cb15`](https://github.com/NixOS/nixpkgs/commit/7177cb15172425a3591f6181468a122015331e0e) stalwart-mail: Fix spam-filter missing from `/etc`
* [`c8bd8fc5`](https://github.com/NixOS/nixpkgs/commit/c8bd8fc51f6d1023702cdb672fbd705a4571d2ce) stalwart-mail: webmail, ensure overridable recursive attributes
* [`dabbedd7`](https://github.com/NixOS/nixpkgs/commit/dabbedd709d4e740a76b7e888a5a0bb6c983f3cd) opencode: remove unnecessary `mkdir` in `installPhase`
* [`5815bb72`](https://github.com/NixOS/nixpkgs/commit/5815bb720e8f6b292f4362a55b1f00bfd4110c2b) pcsx2-bin: 2.3.180 -> 2.4.0
* [`f2652ec5`](https://github.com/NixOS/nixpkgs/commit/f2652ec5da533f8ee4fe3662990ef29c44334f0a) python3Packages.optype: 0.10.0 -> 0.11.0
* [`8049bef5`](https://github.com/NixOS/nixpkgs/commit/8049bef5a694d12486c4cf8c2c687148c00efec4) coreboot-toolchain: pin gcc and gnat to 14
* [`7efa12d9`](https://github.com/NixOS/nixpkgs/commit/7efa12d900018220f167fbe62ef37beac23e2328) dnf5: 5.2.14.0 -> 5.2.15.0
* [`e7f9e5fb`](https://github.com/NixOS/nixpkgs/commit/e7f9e5fb10765d111aadaa6953cbf668107a5a04) vscode-extensions.ms-vscode.cmake-tools: 1.21.6 -> 1.21.36
* [`0108b812`](https://github.com/NixOS/nixpkgs/commit/0108b8124f5f50de7639e3426c2a8d344caecaab) uhk-agent: 7.0.1 -> 8.0.0
* [`d1795ed6`](https://github.com/NixOS/nixpkgs/commit/d1795ed69010032b1654c451b2cf31a4ac7b70a7) openpgp-card-tools: 0.11.9 -> 0.11.10
* [`3888f653`](https://github.com/NixOS/nixpkgs/commit/3888f653497eec535ddbd4e77cff5257ec47cc48) prometheus-ipmi-exporter: 1.10.0 -> 1.10.1
* [`dd88db29`](https://github.com/NixOS/nixpkgs/commit/dd88db29ed76a434460fa544473eeaa867e9a6cd) modules/systemd-oomd: add After=systemd-sysusers.service
* [`547e437a`](https://github.com/NixOS/nixpkgs/commit/547e437a64af67a8f2eb98634b7161943ca0984f) linux_rpi: stable_2024100 -> stable_20250702
* [`939a0d0b`](https://github.com/NixOS/nixpkgs/commit/939a0d0b00f0b124170a8e95c7ca078ad4c8743f) python3Packages.iplotx: 0.3.1 -> 0.4.0
* [`1536ddee`](https://github.com/NixOS/nixpkgs/commit/1536ddeea961c6ea00fef2d6e1dde020f70bfffd) nixos/pihole-ftl: fix openFirewallDHCP ports
* [`4883f43d`](https://github.com/NixOS/nixpkgs/commit/4883f43d367f6b857333853daa72b7dd062cea8f) nixos/pihole-ftl: add openFirewallDNS ports
* [`9da74b34`](https://github.com/NixOS/nixpkgs/commit/9da74b34fe245d23e986630efb7e532cfece7d87) nixos/pihole-ftl: add openFirewallDNS to docs example
* [`6f4fff59`](https://github.com/NixOS/nixpkgs/commit/6f4fff59128c41282513415e2513b269afbc9bc5) opencode: add comment for the necessity of `fix-model-macro.patch`
* [`ae30ba98`](https://github.com/NixOS/nixpkgs/commit/ae30ba98d574b6618aca66457ec121388d439a58) opencode: 0.2.25 -> 0.2.27
* [`0cc3542a`](https://github.com/NixOS/nixpkgs/commit/0cc3542aae1e19e39894f32fc60ea7dc4874d14d) tart: 2.27.2 -> 2.28.1
* [`a0eb65a1`](https://github.com/NixOS/nixpkgs/commit/a0eb65a139177abc6abd8c94d07d8f1efbf8535d) python3Packages.datalad: 1.2.0 -> 1.2.1
* [`d509527a`](https://github.com/NixOS/nixpkgs/commit/d509527a9597b0656add0581d47f0bd3edb6423c) woodpecker-server: 3.7.0 -> 3.8.0
* [`f3ffa332`](https://github.com/NixOS/nixpkgs/commit/f3ffa332d6dea9c05547a5aed97e35a176ccca1a) diffoscope: 300 -> 301
* [`2593d2ea`](https://github.com/NixOS/nixpkgs/commit/2593d2eaa2967dc053096a2821e47787da458e85) discord: 0.0.98 -> 0.0.101
* [`218f3140`](https://github.com/NixOS/nixpkgs/commit/218f3140de5d3fe8823c2d58662ff3f2432971c7) discord-ptb: 0.0.148 -> 0.0.151
* [`2d33835d`](https://github.com/NixOS/nixpkgs/commit/2d33835da9a6247c662e206241e42c486a60dcfc) discord-canary: 0.0.709 -> 0.0.716
* [`dec9a5b6`](https://github.com/NixOS/nixpkgs/commit/dec9a5b6670ab998fad09d8e361c042b87dfacd6) discord-development: 0.0.81 -> 0.0.83
* [`4c4393de`](https://github.com/NixOS/nixpkgs/commit/4c4393dee8b09816f7e50f998208dc01f36a03bc) pkgsCross.aarch64-darwin.discord: 0.0.350 -> 0.0.353
* [`0f38240d`](https://github.com/NixOS/nixpkgs/commit/0f38240de752755fecbe3494fe79ca7eb82f0b82) pkgsCross.aarch64-darwin.discord-ptb: 0.0.179 -> 0.0.181
* [`a6a3d510`](https://github.com/NixOS/nixpkgs/commit/a6a3d510f1b16af447fdbfdac58fe0810ce22cd4) pkgsCross.aarch64-darwin.discord-canary: 0.0.808 -> 0.0.823
* [`c481da90`](https://github.com/NixOS/nixpkgs/commit/c481da90f98f95d2410bffa0fc065f7ed2626b6d) pkgsCross.aarch64-darwin.discord-development: 0.0.94 -> 0.0.96
* [`3ee23e40`](https://github.com/NixOS/nixpkgs/commit/3ee23e403ba5d37124f85166438581bb8bb27456) xmlcopyeditor: fix build with libxml2 2.14
* [`f8977191`](https://github.com/NixOS/nixpkgs/commit/f8977191368d91213a4981a523db989325f5fbde) python3Packages.evaluate: 0.4.4 -> 0.4.5
* [`58ec43ec`](https://github.com/NixOS/nixpkgs/commit/58ec43ec22347d368677cb553406bc2b2bddb1a9) libphonenumber: 9.0.8 -> 9.0.9
* [`c7fcbca9`](https://github.com/NixOS/nixpkgs/commit/c7fcbca90cf4021db675373dd1cdf8bf06e83588) maintainers: drop kanielrkirby
* [`118d81ae`](https://github.com/NixOS/nixpkgs/commit/118d81aeefa749dc1f0abb387eb4f2027f9a55b5) fex: 2506 -> 2507.1
* [`d0130092`](https://github.com/NixOS/nixpkgs/commit/d01300927cc23b095c5cb9580ab429f72e433de1) qscintilla: don't hardcode qt version in package name
* [`c1db8a0c`](https://github.com/NixOS/nixpkgs/commit/c1db8a0cfebdf77066776728854c3bf0f32df09c) scooter: compile only `scooter`
* [`cfb4f17e`](https://github.com/NixOS/nixpkgs/commit/cfb4f17e1faeb2e3b321cd26d6ef107ed7e9d526) soteria: 0.1.4 -> 0.2.0
* [`bec4860d`](https://github.com/NixOS/nixpkgs/commit/bec4860dbcd45a586f8aad8675b5f903e841f25b) python3Packages.xeddsa: 1.1.0 -> 1.1.1
* [`d37715ad`](https://github.com/NixOS/nixpkgs/commit/d37715ad0e53dac4358206f8e2b2648ee764096a) python3Packages.x3dh: 1.1.0 -> 1.2.0
* [`3975ef05`](https://github.com/NixOS/nixpkgs/commit/3975ef050ddf4142e35ae3fa96462769b83f54a7) media-downloader: 5.4.0 -> 5.4.1
* [`a143f721`](https://github.com/NixOS/nixpkgs/commit/a143f72199562a060730d34dbf84ea9b5ec78220) wlvncc: 0-unstable-2025-04-20 -> 0-unstable-2025-07-07
* [`5c03d833`](https://github.com/NixOS/nixpkgs/commit/5c03d833fcdfed83728ef4ee227412187fbf035c) python3Packages.qscintilla-qt5/6: build package for both Qt 5 and Qt 6
* [`061613ce`](https://github.com/NixOS/nixpkgs/commit/061613ce22fdd8c66c64fe6b7c6e845369d9a48a) openimageio: 3.0.8.0 -> 3.0.8.1
* [`dffc9467`](https://github.com/NixOS/nixpkgs/commit/dffc94678602a9b9be0e960ba4dfdd6d5e2cff4c) gccNGPackages_15.gfortran: fix missing spec file
* [`6b03c567`](https://github.com/NixOS/nixpkgs/commit/6b03c5677a2cd71a27f7fb1643f8c395beba3be9) cc-wrapper: fix including libstdcxx from GCC NG
* [`ef481bfb`](https://github.com/NixOS/nixpkgs/commit/ef481bfb2babc8f508704d9adf7a6cacd1540dc8) maintainers: drop d-xo
* [`7994de50`](https://github.com/NixOS/nixpkgs/commit/7994de500bd74bf80080d5aa50b1573c229fd169) lmstudio: 0.3.17.11 -> 0.3.18.3
* [`9519ecce`](https://github.com/NixOS/nixpkgs/commit/9519ecce171570d12b1d34344fda9b4375fa55d5) nom: 2.10.0 -> 2.13.0
* [`a49209e5`](https://github.com/NixOS/nixpkgs/commit/a49209e52fde068d9d985f3c2077172b7a52c754) envoy-bin: 1.34.1 -> 1.34.2
* [`2ed6f862`](https://github.com/NixOS/nixpkgs/commit/2ed6f86266a54388cb21d5ab2800571169134254) cowsql: 1.15.8 -> 1.15.9
* [`90fd14e7`](https://github.com/NixOS/nixpkgs/commit/90fd14e7f384b63193a6bf7d9ee123ba32044f91) kube-linter: 0.6.8 -> 0.7.4
* [`0bb6dd4c`](https://github.com/NixOS/nixpkgs/commit/0bb6dd4ce3e4d195ad0f245896073e34c2180147) v2ray: 5.33.0 -> 5.37.0
* [`2e17b9a4`](https://github.com/NixOS/nixpkgs/commit/2e17b9a4c006b2312ea83753a7f00ff4c9cfe6ec) vscode-extensions.dart-code.dart-code: 3.114.0 -> 3.114.2
* [`90403f6a`](https://github.com/NixOS/nixpkgs/commit/90403f6ac2c53ca1a1568ece99896bd113e2368e) cargo-leptos: 0.2.36 -> 0.2.38
* [`f36ece2a`](https://github.com/NixOS/nixpkgs/commit/f36ece2a4790ef1862708d33aa32c88f77e9bd30) python312Packages.rapidocr-onnxruntime: 1.4.4 -> 2.1.0
* [`7a5b7305`](https://github.com/NixOS/nixpkgs/commit/7a5b7305c00be62fd9f67330ec484c3a40108353) kargo: 1.5.3 -> 1.6.1
* [`35638d21`](https://github.com/NixOS/nixpkgs/commit/35638d2160be5e124654183126233d2163527f04) mark: 14.1.0 -> 14.1.1
* [`87a19275`](https://github.com/NixOS/nixpkgs/commit/87a19275ee1744fecea5c12dd1d6257f36effb3e) wdt: 1.27.1612021-unstable-2025-06-12 -> 1.27.1612021-unstable-2025-07-09
* [`75f55966`](https://github.com/NixOS/nixpkgs/commit/75f559665227c3b20c36babd44b33619c8318cd2) nixos/tests/meilisearch: fix race condition when creating index
* [`d2306173`](https://github.com/NixOS/nixpkgs/commit/d2306173181b517989e393dcde43b999055d690c) prime-server: Expand `platforms` to include `darwin`
* [`b72563de`](https://github.com/NixOS/nixpkgs/commit/b72563dedc47bc7fc22633eb5d16d0d0e541a61c) orthanc: 1.12.7 -> 1.12.8
* [`80ffef33`](https://github.com/NixOS/nixpkgs/commit/80ffef337f631c300b52124aa57c346fbe3dd1a7) megatools: 1.11.4 -> 1.11.5
* [`88c244df`](https://github.com/NixOS/nixpkgs/commit/88c244df810ec2df9545b0bb2f66a90d099a60b9) python3Packages.ancp-bids: 0.2.9 -> 0.3.0
* [`fbfbd2f6`](https://github.com/NixOS/nixpkgs/commit/fbfbd2f64e1f61e83bbf278815d2e937e1ace892) python3Packages.zabbix-utils: 2.0.2 -> 2.0.3
* [`91e91bc5`](https://github.com/NixOS/nixpkgs/commit/91e91bc5963bb23f3f1e17916deb3495701f52b8) doc: add CUDA contributing section and document passthru test attributes
* [`be7e126e`](https://github.com/NixOS/nixpkgs/commit/be7e126e474c29cefe66070743d001404b257fe0) magma: add passthru.testers and passthru.tests
* [`e982a42e`](https://github.com/NixOS/nixpkgs/commit/e982a42e483ca2d561142ce5c63057b3186188ed) rss2email: modernize, move to pkgs/by-name
* [`a61d99e3`](https://github.com/NixOS/nixpkgs/commit/a61d99e3734a00b82a1241865b3bcf70f7f8c36d) mise: 2025.7.0 -> 2025.7.4
* [`2f868233`](https://github.com/NixOS/nixpkgs/commit/2f868233523847151fe29f50a97619c90832c6d5) python3Packages.pyngrok: 7.2.11 -> 7.2.12
* [`36361138`](https://github.com/NixOS/nixpkgs/commit/36361138abfe203bb8f72001671f4dd7123478c4) kdePackages.kquickimageedit: 0.3.0 -> 0.5.1
* [`1112944e`](https://github.com/NixOS/nixpkgs/commit/1112944ee3b09625112b3e57985c4275cac0da68) kaidan: 0.11.0 -> 0.12.2
* [`2cc3ecba`](https://github.com/NixOS/nixpkgs/commit/2cc3ecba0159e49e7f8bd94d159b872b2d80aa15) julia_111-bin: 1.11.5 -> 1.11.6
* [`aa9abfd7`](https://github.com/NixOS/nixpkgs/commit/aa9abfd7203aa473e0979bc44fd580c1f9bbaf14) julia_111: 1.11.5 -> 1.11.6
* [`0d2c6020`](https://github.com/NixOS/nixpkgs/commit/0d2c6020df5d56a507731c724b5240fe9a8b3b78) chirpstack-udp-forwarder: 4.2.0 -> 4.2.1
* [`1f0f2515`](https://github.com/NixOS/nixpkgs/commit/1f0f25154225df0302adcd7b8110ad2c99e48adc) opencode: 0.2.27 -> 0.2.33
* [`eeeb10f9`](https://github.com/NixOS/nixpkgs/commit/eeeb10f9f0126c8186ccdda47307b586da0044bc) umu-launcher-unwrapped: 1.2.7 -> 1.2.9
* [`0b122221`](https://github.com/NixOS/nixpkgs/commit/0b12222191a5bee3e2bcbc36ff378a8c303ffac8) pkgsStatic.llhttp: fix build
* [`23af69ee`](https://github.com/NixOS/nixpkgs/commit/23af69ee041298d8bd5c595a8835d448ad18869b) python3Packages.mpi-pytest: 2025.6.0 -> 2025.7
* [`696ecc14`](https://github.com/NixOS/nixpkgs/commit/696ecc14107e4d7c3aedbfbedf342a61baa45485) python3Packages.tidalapi: 0.8.3 -> 0.8.4
* [`5fd33bd9`](https://github.com/NixOS/nixpkgs/commit/5fd33bd90e8ad9ff7acba0c7d8ba27ed1aab0002) python3Packages.tidalapi: add ryand56 as maintainer
* [`7cc05cc3`](https://github.com/NixOS/nixpkgs/commit/7cc05cc31a9b05cf9ded030537be8e4fd79cefb3) zotero: 7.0.15 -> 7.0.20
* [`ca570b5b`](https://github.com/NixOS/nixpkgs/commit/ca570b5b68117c179b222d1b7bca8b499cf05586) grml-zsh-config: 0.19.21 -> 0.19.23
* [`a9f64372`](https://github.com/NixOS/nixpkgs/commit/a9f6437293f8d3eb57548acaf9effe0f4868a644) eduvpn-client: 4.5.0 -> 4.5.1
* [`75af7ecc`](https://github.com/NixOS/nixpkgs/commit/75af7ecc9cf147b30dc296cdabe31545715a601f) python3Packages.ddgs: init at 9.0.2
* [`d32c8bbc`](https://github.com/NixOS/nixpkgs/commit/d32c8bbc5edd1eb8906e07e81ea5e5594e6962b7) astal.source: 0-unstable-2025-06-28 -> 0-unstable-2025-07-11
* [`aa7757e0`](https://github.com/NixOS/nixpkgs/commit/aa7757e0aea767251336c33d8374cbc186ede301) vscode-extensions.discloud.discloud: 2.24.2 -> 2.24.3
* [`4cd15e83`](https://github.com/NixOS/nixpkgs/commit/4cd15e834f5ca373a503fbb22706afbb8f444aa0) aporetic: 1.1.0 -> 1.2.0
* [`885bf277`](https://github.com/NixOS/nixpkgs/commit/885bf27797e37cf55de127a2c01956d6e8b0cad1) nimble: 0.18.2 -> 0.20.0
* [`e1a1b933`](https://github.com/NixOS/nixpkgs/commit/e1a1b9336b54a1c9ab983ec32cf24b8ac49a305d) harper: 0.47.0 -> 0.50.0
* [`0dfc2d82`](https://github.com/NixOS/nixpkgs/commit/0dfc2d82d0ac5ecc94f2f9fd4072f81238811a0e) libical: don't build examples
* [`093eac6f`](https://github.com/NixOS/nixpkgs/commit/093eac6f3e7f9236ca19818e38c7bd4a23c41f53) libical: fix introspection default
* [`074d2bff`](https://github.com/NixOS/nixpkgs/commit/074d2bff4010110bacfc0351539d6447e7d53bb5) libical: fix static
* [`b1d7400a`](https://github.com/NixOS/nixpkgs/commit/b1d7400ad2b9941f0b990649ea45d584c0719f78) stevenblack-blocklist: 3.15.51 -> 3.15.55
* [`d4af8147`](https://github.com/NixOS/nixpkgs/commit/d4af814753094c6af17ec091361ab4b45b220689) libdwarf: actually compile with compression support
* [`cec96cc3`](https://github.com/NixOS/nixpkgs/commit/cec96cc39356581b1459375e822b65985470621f) bitwuzla: 0.8.0 -> 0.8.1
* [`cbf76b97`](https://github.com/NixOS/nixpkgs/commit/cbf76b9786577c176a0785fbd7124c2bbe047da2) termsvg: 0.9.2 -> 0.9.3
* [`8a92f042`](https://github.com/NixOS/nixpkgs/commit/8a92f0420a43c0a8bb58ec658d2adf518c39c8e9) obs-studio-plugins.obs-shaderfilter: 2.5.0 -> 2.5.1
* [`a64c5bcc`](https://github.com/NixOS/nixpkgs/commit/a64c5bccd8777b43ee31266baca227b1e37e7c79) mydumper: 0.19.3-2 -> 0.19.3-3
* [`45ea7e42`](https://github.com/NixOS/nixpkgs/commit/45ea7e4213d426ed58f7466fff187ad3630e4e89) paru: 2.0.4 -> 2.1.0
* [`44bd9a73`](https://github.com/NixOS/nixpkgs/commit/44bd9a73f47038cb49f1f53c48421b9c95b527d0) cargo-llvm-lines: 0.4.42 -> 0.4.43
* [`e03fbf70`](https://github.com/NixOS/nixpkgs/commit/e03fbf701dce3baf5f5eeab88b448c0ce1fd5270) k9s: use finalAttrs, renew
* [`e16b3be6`](https://github.com/NixOS/nixpkgs/commit/e16b3be6a04ecc4c752f4885d18b9d260dd6dda2) mongodb-7_0: 7.0.16 -> 7.0.21
* [`64dc849b`](https://github.com/NixOS/nixpkgs/commit/64dc849bcc4dae8c79db2b2908ad407284d42bed) labwc: 0.8.4 -> 0.9.0
* [`78b33f63`](https://github.com/NixOS/nixpkgs/commit/78b33f638b92fd77acb32c5001ac3b4e92e21fd7) k9s: ship skins
* [`9ae90069`](https://github.com/NixOS/nixpkgs/commit/9ae900693a1b8e68b31f0aa36683a4d07ae6e488) coredns: 1.11.3 -> 1.12.1
* [`a2e0d904`](https://github.com/NixOS/nixpkgs/commit/a2e0d904770db50a1626cba7b4f8445d31aca3dd) coredns: remove with lib, rec
* [`24705689`](https://github.com/NixOS/nixpkgs/commit/2470568958489aa5f3a7a2de2ed4307644c28861) coredns: remove meta lib inheritance
* [`e56e3f91`](https://github.com/NixOS/nixpkgs/commit/e56e3f912bce8cab4e92dd709430abd711a56641) coredns: replace sha256 with hash
* [`a0dffa6b`](https://github.com/NixOS/nixpkgs/commit/a0dffa6bd109fca2606247722b56b890687c21e1) coredns: add djds as maintainer
* [`21295b64`](https://github.com/NixOS/nixpkgs/commit/21295b6481dfc86db0378cc29b6c91a8296797e7) coredns: allow local networking in Darwin sandbox
* [`42d05aab`](https://github.com/NixOS/nixpkgs/commit/42d05aab87aec2ef53d2b9b55b859fbd4ad95c8b) coredns: 1.12.1 -> 1.12.2
* [`2ddba321`](https://github.com/NixOS/nixpkgs/commit/2ddba3215ad468d27c1afd82737f20dd2cdc2044) dwm-status: migrate to `pkgs/by-name`
* [`9b222821`](https://github.com/NixOS/nixpkgs/commit/9b2228216a35d42922e5daf14e84fe1dd6845072) dwm-status: replace `rec` with `finalAttrs`
* [`1de95f9d`](https://github.com/NixOS/nixpkgs/commit/1de95f9df30b967c47a534417d0c9136bdf9459f) python3Packages.gevent-eventemitter: init at 2.1
* [`009e813a`](https://github.com/NixOS/nixpkgs/commit/009e813a4811b16e534eb9c8a652f53343bab052) python3Packages.steam: init at 1.4.4
* [`5fba2ce2`](https://github.com/NixOS/nixpkgs/commit/5fba2ce2a9782c8acc896d31b8ab974504db30fa) nixosTests.bookstack: Updated to also test passwordless login for mysql
* [`dbad3228`](https://github.com/NixOS/nixpkgs/commit/dbad3228bcfb20479a9ef2a46f7f6884a164f79a) home-manager: 0-unstable-2025-07-02 -> 0-unstable-2025-07-11
* [`2f335737`](https://github.com/NixOS/nixpkgs/commit/2f3357375f2a03b87698e8c2fea965dca57e05d7) dmenu{,-wayland}: migrate to `pkgs/by-name`
* [`8bbc6417`](https://github.com/NixOS/nixpkgs/commit/8bbc6417af90a198a4c34f4de99ea88c244effb6) vscode-extensions.tabnine.tabnine-vscode: 3.293.0 -> 3.296.0
* [`b2f396c9`](https://github.com/NixOS/nixpkgs/commit/b2f396c9465b46b75af03a666ded3d2749f6820e) python3Packages.plugp100: 5.1.4 -> 5.1.5
* [`ddf59fde`](https://github.com/NixOS/nixpkgs/commit/ddf59fde7cd1dd1d79b937dc73c6822be9f4fa17) snapcraft: 8.10.0 -> 8.10.1
* [`0874bc72`](https://github.com/NixOS/nixpkgs/commit/0874bc72c18555e7c6bc8d9bdeb664130a7edfed) Revert "kdePackages.kimageformats: temporarily disable libavif support"
* [`19468c1e`](https://github.com/NixOS/nixpkgs/commit/19468c1ee503411d47e739acb559b095d1ad09c5) bootc: 1.1.2 -> 1.4.0
* [`13e94978`](https://github.com/NixOS/nixpkgs/commit/13e949783ecb4d22f37673838e1886c1b5441ce0) bootc: update upstream
* [`c7206320`](https://github.com/NixOS/nixpkgs/commit/c720632082ed87ee97c917f626dec87e51a2a798) reth: 1.5.0 -> 1.5.1
* [`149672f2`](https://github.com/NixOS/nixpkgs/commit/149672f249f282dd69f532c2ea7bad2d5a474894) wpprobe: 0.7.2 -> 0.7.3
* [`b0de10fe`](https://github.com/NixOS/nixpkgs/commit/b0de10fe5af0266e1e1c87b365f0014e197d839e) yt-dlp: generate manpages with pandoc
* [`9f869f7f`](https://github.com/NixOS/nixpkgs/commit/9f869f7f227ca77a877c52246d0a2904b7924257) yt-dlp: sort `meta`
* [`182bc1e5`](https://github.com/NixOS/nixpkgs/commit/182bc1e5f931c1ea4d7ce90c5b7111ad02b76a34) yt-dlp: remove `with lib`
* [`86fe2555`](https://github.com/NixOS/nixpkgs/commit/86fe2555d72dbfd6e3c12b43d1af37e9c9774dea) dmenu-wayland: modernize
* [`0e6e8c5a`](https://github.com/NixOS/nixpkgs/commit/0e6e8c5a67159cb2615f4d228cc379bbd6fb6ae1) lighthouse: 7.0.1 -> 7.1.0
* [`3762fddd`](https://github.com/NixOS/nixpkgs/commit/3762fddd15ef00c7eb7897a8da1f5f209d914893) dmenu: allow setting options in nixpkgs.config
* [`c3d90468`](https://github.com/NixOS/nixpkgs/commit/c3d90468fffe13141eeeb3624332755cb9004692) libavif: fix cmake files
* [`39b06e9f`](https://github.com/NixOS/nixpkgs/commit/39b06e9fca466384655a3e6100870d80877e991d) audible-cli: 0.3.1 -> 0.3.2
* [`2a48fede`](https://github.com/NixOS/nixpkgs/commit/2a48fede3a25f75619ee3363638a3c96bc553771) dmenu: remove pkg-config
* [`1a1cc628`](https://github.com/NixOS/nixpkgs/commit/1a1cc628def37d9ca1ed9d8a4dacafb667749a10) dmenu: remove unused zlib
* [`6db88336`](https://github.com/NixOS/nixpkgs/commit/6db88336326c1f440e8cbd691321d4ab30b5d3eb) dmenu: modernize
* [`7e06a7c2`](https://github.com/NixOS/nixpkgs/commit/7e06a7c2d0504ab94b3611922d47bd64bb374672) st: move nixpkgs.config options inside the recipe
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
