### PR TITLE
niv fast-syntax-highlighting: update dcee72bb -> 3d574ccf

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,10 +53,10 @@
         "homepage": null,
         "owner": "zdharma-continuum",
         "repo": "fast-syntax-highlighting",
-        "rev": "dcee72bb99b422bb8e4510f5087af9c1721392e4",
-        "sha256": "1cil68bg6z5z6a050vxxnfnqalqihxbxznwfjqgmdyxzzbq6lazn",
+        "rev": "3d574ccf48804b10dca52625df13da5edae7f553",
+        "sha256": "085132b1s114six9s4643ghgcmmn6allj2w1z1alymj0h8pm8a36",
         "type": "tarball",
-        "url": "https://github.com/zdharma-continuum/fast-syntax-highlighting/archive/dcee72bb99b422bb8e4510f5087af9c1721392e4.tar.gz",
+        "url": "https://github.com/zdharma-continuum/fast-syntax-highlighting/archive/3d574ccf48804b10dca52625df13da5edae7f553.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "home-manager": {


### PR DESCRIPTION
## Changelog for fast-syntax-highlighting:
Branch: master
Commits: [zdharma-continuum/fast-syntax-highlighting@dcee72bb...3d574ccf](https://github.com/zdharma-continuum/fast-syntax-highlighting/compare/dcee72bb99b422bb8e4510f5087af9c1721392e4...3d574ccf48804b10dca52625df13da5edae7f553)

* [`5ecd353c`](https://github.com/zdharma-continuum/fast-syntax-highlighting/commit/5ecd353c81214f82bdeca5483fab6ccc5a2d5494) feat(chroma/make): new makefile colorization caching strategy ([zdharma-continuum/fast-syntax-highlighting⁠#82](https://togithub.com/zdharma-continuum/fast-syntax-highlighting/issues/82))
* [`3922b911`](https://github.com/zdharma-continuum/fast-syntax-highlighting/commit/3922b911a3f248a2b27ccc56e597a52b90b954b4) _chroma/-perl.ch: Support -E flag ([zdharma-continuum/fast-syntax-highlighting⁠#61](https://togithub.com/zdharma-continuum/fast-syntax-highlighting/issues/61))
* [`3d574ccf`](https://github.com/zdharma-continuum/fast-syntax-highlighting/commit/3d574ccf48804b10dca52625df13da5edae7f553) misc(make): trigger new parser only when new shared cache is enabled ([zdharma-continuum/fast-syntax-highlighting⁠#83](https://togithub.com/zdharma-continuum/fast-syntax-highlighting/issues/83))
