### PR TITLE
niv home-manager: update 1e548375 -> e4bf85da

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -65,10 +65,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1e54837569e0b80797c47be4720fab19e0db1616",
-        "sha256": "1hj8779ag5ngjjlr60b7zlbyb5wp43r7w917047xd0x737xr2ip2",
+        "rev": "e4bf85da687027cfc4a8853ca11b6b86ce41d732",
+        "sha256": "10bwgr0hpqx7vssjblw4d3xb01jply4wq1h6sgdxbf07s19y6bfj",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/1e54837569e0b80797c47be4720fab19e0db1616.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/e4bf85da687027cfc4a8853ca11b6b86ce41d732.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@1e548375...e4bf85da](https://github.com/nix-community/home-manager/compare/1e54837569e0b80797c47be4720fab19e0db1616...e4bf85da687027cfc4a8853ca11b6b86ce41d732)

* [`4cc9cc67`](https://github.com/nix-community/home-manager/commit/4cc9cc67ebd2847f5ed332a226e9109c97336ecf) wayfire: fix broken configuration.ini test ([nix-community/home-manager⁠#7478](https://togithub.com/nix-community/home-manager/issues/7478))
* [`f7a45b08`](https://github.com/nix-community/home-manager/commit/f7a45b08319233b9b93ba60bbfccb41df75a7ac1) nix: use-sandbox -> sandbox ([nix-community/home-manager⁠#7475](https://togithub.com/nix-community/home-manager/issues/7475))
* [`a1c0a349`](https://github.com/nix-community/home-manager/commit/a1c0a3493867abb0a2da20528e4bff4366ed6fb4) ci: fix tag-maintainers ([nix-community/home-manager⁠#7480](https://togithub.com/nix-community/home-manager/issues/7480))
* [`30533223`](https://github.com/nix-community/home-manager/commit/30533223ee89f0f07fe2e8a683298c84b667e33f) ci: generate-all-maintainers remove unused function
* [`6613b6ce`](https://github.com/nix-community/home-manager/commit/6613b6ce49b2f4f62c54faec2479905e8b8dcda2) ci: update-maintainers include eval diff
* [`f14ef40c`](https://github.com/nix-community/home-manager/commit/f14ef40c4578e395e815ae21c0042065167a005d) ci: dont run github_pages on forks
* [`e8c19a3c`](https://github.com/nix-community/home-manager/commit/e8c19a3cec2814c754f031ab3ae7316b64da085b) maintainers: update all-maintainers.nix
* [`460f1e9a`](https://github.com/nix-community/home-manager/commit/460f1e9af95b081fb7e2022485b6c22b92085936) starship: set `STARSHIP_CONFIG` var and add option to set config path ([nix-community/home-manager⁠#7435](https://togithub.com/nix-community/home-manager/issues/7435))
* [`8eb2f2a2`](https://github.com/nix-community/home-manager/commit/8eb2f2a26ae540cc89300eed97c61fa264c2ff7f) treewide: Remove unwanted dependencies ([nix-community/home-manager⁠#7487](https://togithub.com/nix-community/home-manager/issues/7487))
* [`50adf434`](https://github.com/nix-community/home-manager/commit/50adf43449743dfc0e4e82ab533112ef110bcfb0) nushell: fix `get -i` deprecation ([nix-community/home-manager⁠#7490](https://togithub.com/nix-community/home-manager/issues/7490))
* [`2d55a529`](https://github.com/nix-community/home-manager/commit/2d55a52963d8a3856792e2fd6604f307176026bc) radio-cli: add module ([nix-community/home-manager⁠#7488](https://togithub.com/nix-community/home-manager/issues/7488))
* [`e595fe1d`](https://github.com/nix-community/home-manager/commit/e595fe1df49d75e971b33f311e365f032089f450) flake.lock: Update ([nix-community/home-manager⁠#7450](https://togithub.com/nix-community/home-manager/issues/7450))
* [`63994b71`](https://github.com/nix-community/home-manager/commit/63994b71d223b48007dbec0089bbfd62d9cd4e1d) direnv: fix silent clobbering global config
* [`8320333a`](https://github.com/nix-community/home-manager/commit/8320333a4547422afb68b6df7ac7edfa2733038b) tests/direnv: refactor tests
* [`bc9f3c84`](https://github.com/nix-community/home-manager/commit/bc9f3c8413a3aaa01ed959c371c1f9e57515965b) direnv: misc cleanup
* [`defabc11`](https://github.com/nix-community/home-manager/commit/defabc11abd602bed3af5fe4111d023f638ccfc3) ci: move validate maintainers logic to lib
* [`7c78e592`](https://github.com/nix-community/home-manager/commit/7c78e592a895f2f1921f0024848fe193e2f8518e) maintainers: remove duplicate nixpkgs maintainers
* [`dcfd70f8`](https://github.com/nix-community/home-manager/commit/dcfd70f80fe6d872c2dc58fe3be384a681e56fea) ssh-tpm-agent: init module ([nix-community/home-manager⁠#7495](https://togithub.com/nix-community/home-manager/issues/7495))
* [`d0300c88`](https://github.com/nix-community/home-manager/commit/d0300c8808e41da81d6edfc202f3d3833c157daf) direnv: fix broken nushell integration ([nix-community/home-manager⁠#7498](https://togithub.com/nix-community/home-manager/issues/7498))
* [`e0402627`](https://github.com/nix-community/home-manager/commit/e0402627096f236943a6691fbe037b55dabef4d1) flake.lock: Update ([nix-community/home-manager⁠#7505](https://togithub.com/nix-community/home-manager/issues/7505))
* [`7834432c`](https://github.com/nix-community/home-manager/commit/7834432ca540b4179959b4864c40ed29f2720732) thunderbird: support declaration of address books ([nix-community/home-manager⁠#7443](https://togithub.com/nix-community/home-manager/issues/7443))
* [`13a83d1b`](https://github.com/nix-community/home-manager/commit/13a83d1b6545b7f0e8f7689bad62e7a3b1d63771) zed-editor: support tasks ([nix-community/home-manager⁠#7493](https://togithub.com/nix-community/home-manager/issues/7493))
* [`e4bf85da`](https://github.com/nix-community/home-manager/commit/e4bf85da687027cfc4a8853ca11b6b86ce41d732) neomutt: allow default email sending behaviour ([nix-community/home-manager⁠#7476](https://togithub.com/nix-community/home-manager/issues/7476))
