### PR TITLE
niv home-manager: update e4bf85da -> f49e872f

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -65,10 +65,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e4bf85da687027cfc4a8853ca11b6b86ce41d732",
-        "sha256": "10bwgr0hpqx7vssjblw4d3xb01jply4wq1h6sgdxbf07s19y6bfj",
+        "rev": "f49e872f55e36e67ebcb906ff65f86c7a1538f7c",
+        "sha256": "09qzq4bkxkgn8lp5gzxbyzvqhdlkswq2qxaqmhfgy5508hrxb25y",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/e4bf85da687027cfc4a8853ca11b6b86ce41d732.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/f49e872f55e36e67ebcb906ff65f86c7a1538f7c.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@e4bf85da...f49e872f](https://github.com/nix-community/home-manager/compare/e4bf85da687027cfc4a8853ca11b6b86ce41d732...f49e872f55e36e67ebcb906ff65f86c7a1538f7c)

* [`de448dcb`](https://github.com/nix-community/home-manager/commit/de448dcb577570f2a11f243299b6536537e05bbe) home-manager: avoid profile management during activation
* [`04b710c1`](https://github.com/nix-community/home-manager/commit/04b710c1f0c522b7b2f47600bec60d790becdbdb) maintainers: update all-maintainers.nix
* [`d1db9055`](https://github.com/nix-community/home-manager/commit/d1db9055ea3934e36a82332f6237b789b1d859ab) iamb: use correct config directory on macOS
* [`83674177`](https://github.com/nix-community/home-manager/commit/836741779f18dc111af1609f9749a5236e1e8f33) ci: apply dependabot on release-25.05
* [`847711c7`](https://github.com/nix-community/home-manager/commit/847711c7ffa9944b0c5c39a8342ac8eb6a9f9abc) ci: bump DeterminateSystems/update-flake-lock from 26 to 27
* [`0cdfcdbb`](https://github.com/nix-community/home-manager/commit/0cdfcdbb525b77b951c889b6131047bc374f48fe) Update translation files
* [`62975b8e`](https://github.com/nix-community/home-manager/commit/62975b8e23c4e39599b3303f6e76faa280a02c63) hyprsunset: assert hyprland package is not null ([nix-community/home-manager⁠#7518](https://togithub.com/nix-community/home-manager/issues/7518))
* [`3260a705`](https://github.com/nix-community/home-manager/commit/3260a705861f5174be28e63633663f5f05f59043) flake.lock: Update
* [`6cf61d10`](https://github.com/nix-community/home-manager/commit/6cf61d10e8308f4c5f6eedded9de26a8c1b7234c) tests/darwinScrublist: add opencode
* [`56ee5d06`](https://github.com/nix-community/home-manager/commit/56ee5d06701cc9a0a0721a4d33216233ed46c34a) flake: use nixfmt stable release
* [`b4752b0e`](https://github.com/nix-community/home-manager/commit/b4752b0eda6302b92a6d5dd554c83f188bc3ae6d) treewide: format with latest stable formatter
* [`e9c599e4`](https://github.com/nix-community/home-manager/commit/e9c599e40c8d0d754980f51e580d00ebef3f2fea) yarn: add module ([nix-community/home-manager⁠#7526](https://togithub.com/nix-community/home-manager/issues/7526))
* [`b8d1a792`](https://github.com/nix-community/home-manager/commit/b8d1a79235798d6397db93bc891350901117cf54) Translate using Weblate (Swedish)
* [`3641df95`](https://github.com/nix-community/home-manager/commit/3641df95becab34d2d7a221218091c2cea2d9c2e) Translate using Weblate (Basque)
* [`fe38a5e0`](https://github.com/nix-community/home-manager/commit/fe38a5e02870debe6084203bca56d750e5d67ce8) pueue: enable darwin configuration ([nix-community/home-manager⁠#7519](https://togithub.com/nix-community/home-manager/issues/7519))
* [`1fde6fb1`](https://github.com/nix-community/home-manager/commit/1fde6fb1be6cd5dc513dc1c287d69e4eb2de973e) yofi: add module ([nix-community/home-manager⁠#7528](https://togithub.com/nix-community/home-manager/issues/7528))
* [`e2fe7256`](https://github.com/nix-community/home-manager/commit/e2fe7256c4ebbb35bfd1b4c6f52b57a3845ab1d0) news: add misc news entries for recent modules ([nix-community/home-manager⁠#7531](https://togithub.com/nix-community/home-manager/issues/7531))
* [`0a98177b`](https://github.com/nix-community/home-manager/commit/0a98177bb8a5b81d69d1a2bfb490e47875875b01) maintainers: remove karaolidis keys ([nix-community/home-manager⁠#7537](https://togithub.com/nix-community/home-manager/issues/7537))
* [`08edcbe9`](https://github.com/nix-community/home-manager/commit/08edcbe9dfd4a3098f5d097b13d7ce693ba2ad16) opencode: add support for global custom instructions via `rules` option
* [`1df662dd`](https://github.com/nix-community/home-manager/commit/1df662dde0b46f0480c259f9bb92577afc48ae2b) opencode: add empty-settings test
* [`64796151`](https://github.com/nix-community/home-manager/commit/64796151f79e6f3834bfc55f07c5487708bb5b3f) opencode: add JSON schema reference to config.json output
* [`a35f6b60`](https://github.com/nix-community/home-manager/commit/a35f6b60430ff0c7803bd2a727df84c87569c167) trippy: add forceUserConfig option ([nix-community/home-manager⁠#7536](https://togithub.com/nix-community/home-manager/issues/7536))
* [`060824a6`](https://github.com/nix-community/home-manager/commit/060824a69bcdf4649c8563460ab656e74615984e) mpd: fix typo ([nix-community/home-manager⁠#7541](https://togithub.com/nix-community/home-manager/issues/7541))
* [`80515f55`](https://github.com/nix-community/home-manager/commit/80515f553d27a15d3a40eaf04fb0e3751ffbeed5) Translate using Weblate (Spanish) ([nix-community/home-manager⁠#7539](https://togithub.com/nix-community/home-manager/issues/7539))
* [`70c79ca6`](https://github.com/nix-community/home-manager/commit/70c79ca6f42570b61d36f38d8c4173ac72081858) xdg-terminal-exec: init ([nix-community/home-manager⁠#7527](https://togithub.com/nix-community/home-manager/issues/7527))
* [`308b8570`](https://github.com/nix-community/home-manager/commit/308b8570eced0ca6ddc4c8b291af6a17b2f257a6) home-environment: add `home.checks` ([nix-community/home-manager⁠#7407](https://togithub.com/nix-community/home-manager/issues/7407))
* [`c77de65e`](https://github.com/nix-community/home-manager/commit/c77de65ece7f40307b901548042e294549278fd9) command-not-found: sync with nixpkgs ([nix-community/home-manager⁠#7499](https://togithub.com/nix-community/home-manager/issues/7499))
* [`ef8a9767`](https://github.com/nix-community/home-manager/commit/ef8a9767fcdefbb92cb18594b16f1199c115f0a1) Translate using Weblate (Spanish) ([nix-community/home-manager⁠#7543](https://togithub.com/nix-community/home-manager/issues/7543))
* [`21399def`](https://github.com/nix-community/home-manager/commit/21399deff2b0fab5a6243d1607d474e0356db7f7) zsh: improve dotDir handling
* [`9fca4915`](https://github.com/nix-community/home-manager/commit/9fca4915873d488f267253b00998669697a26453) zsh: improve histfile handling
* [`26e33ea5`](https://github.com/nix-community/home-manager/commit/26e33ea5c0bd17d8dbab9d4c7df291a91526da10) docker-cli: Improve docs, fix enviornment variable
* [`a1817d1c`](https://github.com/nix-community/home-manager/commit/a1817d1c0e5eabe7dfdfe4caa46c94d9d8f3fdb6) yarn: improve docs
* [`37fec70b`](https://github.com/nix-community/home-manager/commit/37fec70bd5dace2fb025d3f7cbc0899a7fce6081) ci: extract maintainers with single file eval ([nix-community/home-manager⁠#7548](https://togithub.com/nix-community/home-manager/issues/7548))
* [`2b73c2fc`](https://github.com/nix-community/home-manager/commit/2b73c2fcca690b6eca4f520179e54ae760f25d4e) treewide: remove config dependency on docs ([nix-community/home-manager⁠#7547](https://togithub.com/nix-community/home-manager/issues/7547))
* [`63dd0e94`](https://github.com/nix-community/home-manager/commit/63dd0e9409accc1df46b81199f423c0446397775) opencode: minor cleanup of option description
* [`42924f0e`](https://github.com/nix-community/home-manager/commit/42924f0eff0f6694d9e374e9c08a75fabc3eb140) xdg-terminal-exec: minor cleanup of option description
* [`ed1eeeee`](https://github.com/nix-community/home-manager/commit/ed1eeeeee6279c371fbc0e4b6d68bc0b39077a16) xdg-terminal-exec: make sure the module is imported
* [`6ce43381`](https://github.com/nix-community/home-manager/commit/6ce433818580edc2acbf7282455331c4a5b95aae) nixos: increase laziness regarding shared modules
* [`710771af`](https://github.com/nix-community/home-manager/commit/710771af3d1c8c3f86a9e5d562616973ed5f3f21) docs: add a poison module
* [`e8867156`](https://github.com/nix-community/home-manager/commit/e88671567b5020c41fa1880ef08428f91448548b) zsh: only apply plugins when zsh is enabled ([nix-community/home-manager⁠#7555](https://togithub.com/nix-community/home-manager/issues/7555))
* [`0daef6fb`](https://github.com/nix-community/home-manager/commit/0daef6fbe0d71cd81967d9595a60c515a31ad034) hyprlock: update example config
* [`72cc1e31`](https://github.com/nix-community/home-manager/commit/72cc1e3134a35005006f06640724319caa424737) tests/hyprlock: update tests with upstream changes
* [`e45ff565`](https://github.com/nix-community/home-manager/commit/e45ff5651ceecfb5b0a2cb37b11a73a7f713235f) ci: split tests into chunks
* [`234f10ec`](https://github.com/nix-community/home-manager/commit/234f10ec6d97a45b401f23caa2de46954b2164bd) tests/flake: add buildbot output
* [`9fa2ad30`](https://github.com/nix-community/home-manager/commit/9fa2ad30c5df6dfa3bfed5ba057dc530b309c0bb) buildbot-nix.toml: add file
* [`7a02711a`](https://github.com/nix-community/home-manager/commit/7a02711a610d921f53e3a5b6a38fe3e71adc51cd) tests: integration tests only run on linux
* [`800f16a9`](https://github.com/nix-community/home-manager/commit/800f16a9c53c279cdd1cdf847bdff5e99438eeb0) tests: forward only test chunks to buildbot
* [`a07400a2`](https://github.com/nix-community/home-manager/commit/a07400a2e53a59e1b06ef5b76f0062bcaf3500fc) ci: don't duplicate test runs on github
* [`e4b032ba`](https://github.com/nix-community/home-manager/commit/e4b032ba5113664f0b8b23d956e59ce8e0bc349d) ci: re-enable home manager install and uninstall tests on darwin
* [`3156a1c4`](https://github.com/nix-community/home-manager/commit/3156a1c4196e03e66ce16220d4f2e58cb19718cb) docs: minor manual style fix
* [`a7b7c6f5`](https://github.com/nix-community/home-manager/commit/a7b7c6f520b51f3577bd6b7a7493d2cdbcb22ec6) docs: add upgrade guide for NixOS version transitions
* [`20cf285e`](https://github.com/nix-community/home-manager/commit/20cf285e9f8e5e3968abca80081c03ea96e7ea73) maintainers: update all-maintainers.nix ([nix-community/home-manager⁠#7558](https://togithub.com/nix-community/home-manager/issues/7558))
* [`938ecd79`](https://github.com/nix-community/home-manager/commit/938ecd797f17b5baa408f7a0af01747a81e4bed6) zsh: fix lib function for env var path parsing
* [`9ff467fb`](https://github.com/nix-community/home-manager/commit/9ff467fbe7d42972068cfcfc9167838e7c66aabc) tests/zsh: add more path test cases
* [`40af7ba0`](https://github.com/nix-community/home-manager/commit/40af7ba06ba959a191ac1297f5f4e6c2786a1e39) zsh: relative path deprecation warning
* [`e52c6c3d`](https://github.com/nix-community/home-manager/commit/e52c6c3da3f9b16e085ef32a75237169c95364bf) zsh: env var assertion for dotdir
* [`08f16235`](https://github.com/nix-community/home-manager/commit/08f162350c5d0062dfc1dd0b628448099bbc8317) news: add news entry for zsh path refactor
* [`471eeaa9`](https://github.com/nix-community/home-manager/commit/471eeaa9753a186338da134243584a44ccfde099) zsh: add khaneliman maintainer
* [`a1b7e7f5`](https://github.com/nix-community/home-manager/commit/a1b7e7f510b93a48406adc894eed6d0811147d11) tests/antidote: remove deprecated relative path usage
* [`f49e872f`](https://github.com/nix-community/home-manager/commit/f49e872f55e36e67ebcb906ff65f86c7a1538f7c) zsh: lib better docstrings
