### PR TITLE
niv emacs-overlay: update 4a0db65b -> 4ed6313a

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -41,10 +41,10 @@
         "homepage": "",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "4a0db65ba7e8499456cacec817196eaae4cd518d",
-        "sha256": "0zih1l5b5c28jyshxw4y4yykgs7azilcrw86bam2rdgk2iy33bxh",
+        "rev": "4ed6313ad6f2e7ed940143096808085c44028afa",
+        "sha256": "0sm6mzx0i7rlrcns5a8cn6bjsli4iazmgcc95kwfs33b4rn34cg9",
         "type": "tarball",
-        "url": "https://github.com/nix-community/emacs-overlay/archive/4a0db65ba7e8499456cacec817196eaae4cd518d.tar.gz",
+        "url": "https://github.com/nix-community/emacs-overlay/archive/4ed6313ad6f2e7ed940143096808085c44028afa.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "fast-syntax-highlighting": {


### PR DESCRIPTION
## Changelog for emacs-overlay:
Branch: master
Commits: [nix-community/emacs-overlay@4a0db65b...4ed6313a](https://github.com/nix-community/emacs-overlay/compare/4a0db65ba7e8499456cacec817196eaae4cd518d...4ed6313ad6f2e7ed940143096808085c44028afa)

* [`f39b1178`](https://github.com/nix-community/emacs-overlay/commit/f39b11789236935b3632e0311ff93995f36f6319) Updated flake inputs
* [`6bec2d2a`](https://github.com/nix-community/emacs-overlay/commit/6bec2d2a4e81bbbac202ac371205f2b6d70a8a26) Updated nongnu
* [`6c366ca4`](https://github.com/nix-community/emacs-overlay/commit/6c366ca46d9a952305eda2207184d88b7b172485) Updated elpa
* [`3e2b295e`](https://github.com/nix-community/emacs-overlay/commit/3e2b295e2dcad08449f48669a2d1ef2596b2e5d3) Updated melpa
* [`91ca3306`](https://github.com/nix-community/emacs-overlay/commit/91ca33064d3592f7d7c30f27de18150b1c9995b7) Updated emacs
* [`6ab8bb68`](https://github.com/nix-community/emacs-overlay/commit/6ab8bb6826895f1ac82366eddeed184a69729e5a) Updated melpa
* [`76d8edce`](https://github.com/nix-community/emacs-overlay/commit/76d8edce6fcbaa33a48abe327afb64d62a52575f) Updated flake inputs
* [`7e9eee00`](https://github.com/nix-community/emacs-overlay/commit/7e9eee00348df080b271279e13fa5501172a446f) Updated nongnu
* [`07d844f0`](https://github.com/nix-community/emacs-overlay/commit/07d844f03a392ff3fe8073dbe5a9c728e176ef19) Updated elpa
* [`517a6987`](https://github.com/nix-community/emacs-overlay/commit/517a698702b3614beb761c91d34df6382b465b59) Updated emacs
* [`6b8981d1`](https://github.com/nix-community/emacs-overlay/commit/6b8981d1d7c06ce113a467db09a24ba3bb815351) Updated melpa
* [`7eb0169a`](https://github.com/nix-community/emacs-overlay/commit/7eb0169a5ed29130421732641069e69b77461e99) Updated nongnu
* [`90efeb9a`](https://github.com/nix-community/emacs-overlay/commit/90efeb9a2880c3d0af37e5cec028be58581bbea7) Updated elpa
* [`6f4540bf`](https://github.com/nix-community/emacs-overlay/commit/6f4540bf073014dca1ea1b12a79ad23ad0ba47ce) Updated emacs
* [`6b5c9e8d`](https://github.com/nix-community/emacs-overlay/commit/6b5c9e8d4cfe157a398aedf877ad6fbb71c6bca6) Updated melpa
* [`85362161`](https://github.com/nix-community/emacs-overlay/commit/853621610af3735d6f12e08b1975b8ba9b7dca12) Updated nongnu
* [`1de278e4`](https://github.com/nix-community/emacs-overlay/commit/1de278e46115d49a11ee9b01bfca5b74432e6074) Updated elpa
* [`8e6e0124`](https://github.com/nix-community/emacs-overlay/commit/8e6e01245f40b1f8a1f548db553bc9061e4ef412) Updated melpa
* [`2f69b6f4`](https://github.com/nix-community/emacs-overlay/commit/2f69b6f471d881d3aecb69148863f78e83a68a48) Updated nongnu
* [`345ee27d`](https://github.com/nix-community/emacs-overlay/commit/345ee27dfa367ce181e29e410f57ee8322f6a537) Updated elpa
* [`c8c7ef94`](https://github.com/nix-community/emacs-overlay/commit/c8c7ef94b6600add651b3d3aea1db5665b1b92eb) Updated melpa
* [`2dd8d2a4`](https://github.com/nix-community/emacs-overlay/commit/2dd8d2a429c834a0f85066f5313d38c5661bf5e0) Updated melpa
* [`47e4d553`](https://github.com/nix-community/emacs-overlay/commit/47e4d553bed49a63a3bff54c90e9781127628b52) Updated elpa
* [`2d56fcf9`](https://github.com/nix-community/emacs-overlay/commit/2d56fcf92235c019306b6f763bceac51d6e4a177) Updated emacs
* [`bb79080f`](https://github.com/nix-community/emacs-overlay/commit/bb79080f5f1f9ce1cd29617d3e6bad6dc8f815fb) Updated melpa
* [`fe62bd67`](https://github.com/nix-community/emacs-overlay/commit/fe62bd676b51946027f48c80a5e07fc57492afe1) Updated elpa
* [`90da85c2`](https://github.com/nix-community/emacs-overlay/commit/90da85c2423f60e0a1ce9018784c84e0493f8b7e) Updated emacs
* [`acdb3607`](https://github.com/nix-community/emacs-overlay/commit/acdb3607deb5a42163249378da3513ba1a8ada05) Updated melpa
* [`02aa49bb`](https://github.com/nix-community/emacs-overlay/commit/02aa49bbe8e37acfd6dffab70e085c1af3b1876a) Updated nongnu
* [`00d4d098`](https://github.com/nix-community/emacs-overlay/commit/00d4d09883863ae7456f86c8bb2f3c03719e3c02) Updated elpa
* [`ad9f3477`](https://github.com/nix-community/emacs-overlay/commit/ad9f347739b80f42f517dbba401a8bfb0cea30b2) Updated nongnu
* [`96f9656c`](https://github.com/nix-community/emacs-overlay/commit/96f9656c86d4190ced26c529907efed49de0726f) Updated emacs
* [`5ccdea94`](https://github.com/nix-community/emacs-overlay/commit/5ccdea942b6d6483c626a82a5a2eb856afb4a96e) Updated melpa
* [`80b1e931`](https://github.com/nix-community/emacs-overlay/commit/80b1e9317e0a571db079e99efa135a345e9d1889) Updated emacs
* [`c444de8a`](https://github.com/nix-community/emacs-overlay/commit/c444de8aed68439fa788b7d3740b98f3c1bdef6b) Updated melpa
* [`57d1fbfd`](https://github.com/nix-community/emacs-overlay/commit/57d1fbfd7ad6bbc3c4ff0b6e8fd8dde33620d52b) Updated nongnu
* [`0442e156`](https://github.com/nix-community/emacs-overlay/commit/0442e15621c2474483d513dd29ab0f78ae8302ac) Updated emacs
* [`ab81896f`](https://github.com/nix-community/emacs-overlay/commit/ab81896fac2f4238718d42248af2cba678050963) Updated melpa
* [`78145636`](https://github.com/nix-community/emacs-overlay/commit/7814563653df513416099284cb1d95c2bf96f95f) Updated flake inputs
* [`03292e30`](https://github.com/nix-community/emacs-overlay/commit/03292e302b78321eaba835d0126a35aca0f8bafc) Updated nongnu
* [`35e4150b`](https://github.com/nix-community/emacs-overlay/commit/35e4150b360528360680a0b75e142396c6fbd484) Updated elpa
* [`77a1d284`](https://github.com/nix-community/emacs-overlay/commit/77a1d284c248dc84412cc329150a02f08657aaab) Updated emacs
* [`2447869c`](https://github.com/nix-community/emacs-overlay/commit/2447869cbd64a802a72d9c94122dede36d51a335) Updated melpa
* [`ea29925b`](https://github.com/nix-community/emacs-overlay/commit/ea29925b983074e1f1482b884e4cb9aa9b9e02de) Updated emacs
* [`9b4124eb`](https://github.com/nix-community/emacs-overlay/commit/9b4124ebcf6b1387e61761f5b46e940f91f18d5a) Updated melpa
* [`374852af`](https://github.com/nix-community/emacs-overlay/commit/374852af1b33829dab1734c890e41ceb2a75828c) Updated nongnu
* [`b36094ff`](https://github.com/nix-community/emacs-overlay/commit/b36094ff60e3b8e3d8cda96f2824bd57bbf32d93) Updated elpa
* [`4f520d47`](https://github.com/nix-community/emacs-overlay/commit/4f520d4784a7039db9eb0d6c5bbf46c1578fafc0) Updated emacs
* [`9ef65f39`](https://github.com/nix-community/emacs-overlay/commit/9ef65f3921dab451acc52c96daad68fecd6ea2e1) Updated melpa
* [`80a24045`](https://github.com/nix-community/emacs-overlay/commit/80a240454472243430b763ab2bdcb37c8149a388) Updated nongnu
* [`d88b4b41`](https://github.com/nix-community/emacs-overlay/commit/d88b4b41d40b012ca06bbeb465871cd66b8b9d27) Updated elpa
* [`20946dca`](https://github.com/nix-community/emacs-overlay/commit/20946dca55a61b69a5f0edf1eac8bf3c46ec258f) Updated flake inputs
* [`81d9dcf0`](https://github.com/nix-community/emacs-overlay/commit/81d9dcf0fc065bb7d89761dde4f2fed0c8e443eb) Updated emacs
* [`7117741b`](https://github.com/nix-community/emacs-overlay/commit/7117741b454cf1aa6c6d47f1a8d213e62ab0bb84) Updated melpa
* [`c02f3cc9`](https://github.com/nix-community/emacs-overlay/commit/c02f3cc9672fc13e99c717fecf94f700be4c4340) Updated nongnu
* [`55455e01`](https://github.com/nix-community/emacs-overlay/commit/55455e01b28a9eab4a158dd6ab07dee73c4986f9) Updated elpa
* [`adaca1ef`](https://github.com/nix-community/emacs-overlay/commit/adaca1efb09beb4adaef5b5db27e2641b8a53325) Updated emacs
* [`8e4ecd7c`](https://github.com/nix-community/emacs-overlay/commit/8e4ecd7c43c5e061dd2fc4d9d1994ec4d67cab2e) Updated melpa
* [`867dab2a`](https://github.com/nix-community/emacs-overlay/commit/867dab2adb75e75dcc2521dc9e30f40973febc40) Updated nongnu
* [`49d5fcc7`](https://github.com/nix-community/emacs-overlay/commit/49d5fcc70ce467bee03500e0ebc147e95f78c652) Updated elpa
* [`cd307021`](https://github.com/nix-community/emacs-overlay/commit/cd3070218132ac6cbd71b180fda5b51a8348fb20) Updated emacs
* [`82937ee6`](https://github.com/nix-community/emacs-overlay/commit/82937ee6d83abf5a9a5a8ae05329c37c0e9380cf) Updated melpa
* [`b30dc844`](https://github.com/nix-community/emacs-overlay/commit/b30dc844217930d65fb76b757eb34d188a9ad8ca) Updated nongnu
* [`73c5d354`](https://github.com/nix-community/emacs-overlay/commit/73c5d354a7af9cf692e6cc5f044e06349d411884) Updated elpa
* [`5a64a848`](https://github.com/nix-community/emacs-overlay/commit/5a64a848253e773d14dffe72e95bf302932e6d02) Updated melpa
* [`eb09bd12`](https://github.com/nix-community/emacs-overlay/commit/eb09bd1221dddece1b7f45c57ef902b2c6815bb2) Updated flake inputs
* [`8bd29457`](https://github.com/nix-community/emacs-overlay/commit/8bd294574bb1a71be550ba970708fdc46fea9614) Updated nongnu
* [`6770bb9f`](https://github.com/nix-community/emacs-overlay/commit/6770bb9f9c937921d14c3da94d03717e3a6a0fed) Updated elpa
* [`6c6d3785`](https://github.com/nix-community/emacs-overlay/commit/6c6d3785428bc4c739ca8c27b58267428ec2fa00) Updated melpa
* [`f038fa72`](https://github.com/nix-community/emacs-overlay/commit/f038fa723daa69b6c0e6bb479163a4093a5af4d9) Updated emacs
* [`8f91ee19`](https://github.com/nix-community/emacs-overlay/commit/8f91ee1966747aadcaa12c7ec1351216889c4869) Updated nongnu
* [`5c75507a`](https://github.com/nix-community/emacs-overlay/commit/5c75507a03c0ee10985b9124a344fd457a219c63) Updated elpa
* [`cff6620e`](https://github.com/nix-community/emacs-overlay/commit/cff6620e9c8030f47dd76c2f6575cf20a4c66768) Updated emacs
* [`febfa20b`](https://github.com/nix-community/emacs-overlay/commit/febfa20b8cf0e03b474fa6029fe75dfa2cabc97f) Updated melpa
* [`1bd26960`](https://github.com/nix-community/emacs-overlay/commit/1bd269600d7264dfe397f57222a8dd8221ded020) Updated nongnu
* [`9972974b`](https://github.com/nix-community/emacs-overlay/commit/9972974b23747d11421187718a5039bec3b5f675) Updated elpa
* [`ec732454`](https://github.com/nix-community/emacs-overlay/commit/ec73245421f7e82629552ad5053359bd5293ed2d) Updated nongnu
* [`fc31ccb4`](https://github.com/nix-community/emacs-overlay/commit/fc31ccb4f9b115e9447e57dafb0cd356841f3f5f) Updated elpa
* [`72553272`](https://github.com/nix-community/emacs-overlay/commit/7255327281cdb819f7e2bf959097c087d815907e) Updated emacs
* [`d797bda1`](https://github.com/nix-community/emacs-overlay/commit/d797bda1908ae40e437d51a4fcd15b6dc2956195) Updated melpa
* [`11215952`](https://github.com/nix-community/emacs-overlay/commit/112159521737d020bee75bfb8702d26933eeca19) Updated melpa
* [`4bf862ff`](https://github.com/nix-community/emacs-overlay/commit/4bf862fff2ff0d2618813b698d5b2dbf9cc355cc) Updated emacs
* [`fcd9c1b4`](https://github.com/nix-community/emacs-overlay/commit/fcd9c1b4bded92ec89abe7b41cb2fdb1dd1dd370) Updated nongnu
* [`b8713c1b`](https://github.com/nix-community/emacs-overlay/commit/b8713c1b9d142fd2331a442b6bb4448e2db0e47d) Updated nongnu
* [`561dcd2c`](https://github.com/nix-community/emacs-overlay/commit/561dcd2c7a0f8cb2f869d51a16cda65d3612dce7) Updated elpa
* [`a3be3e4b`](https://github.com/nix-community/emacs-overlay/commit/a3be3e4b7ca8417296e2df299b6a1f24c9f29c14) Updated melpa
* [`ae74fa06`](https://github.com/nix-community/emacs-overlay/commit/ae74fa0656db7456569f6fd35a972ac8f9b70b74) Updated emacs
* [`ac94b8cd`](https://github.com/nix-community/emacs-overlay/commit/ac94b8cdab49de848a968971045b6c8abf3fded2) Updated nongnu
* [`f381dd05`](https://github.com/nix-community/emacs-overlay/commit/f381dd05cc5685a65fec42fc0a4e34ac62e81806) Updated elpa
* [`4b34db84`](https://github.com/nix-community/emacs-overlay/commit/4b34db84579acf308f72b1d7276ed30bb6436d4a) Updated emacs
* [`8bf19581`](https://github.com/nix-community/emacs-overlay/commit/8bf19581d2e547159929f1340ed5b65d7b6bce4e) Updated melpa
* [`7156f2a5`](https://github.com/nix-community/emacs-overlay/commit/7156f2a51358943b6d7c52b909606a0be8bb4e2f) Updated nongnu
* [`e925f282`](https://github.com/nix-community/emacs-overlay/commit/e925f282365e2f7aee93fc6fa0d2147b3439609e) Updated elpa
* [`73aafa5b`](https://github.com/nix-community/emacs-overlay/commit/73aafa5b5340b54120688c9ad01bebfb0631107e) Updated melpa
* [`50e5f561`](https://github.com/nix-community/emacs-overlay/commit/50e5f56157a376783dc487f6a5d234f6848e7fc8) Updated elpa
* [`59eb1fa3`](https://github.com/nix-community/emacs-overlay/commit/59eb1fa39cd2be1417ae5cba268047d86c016b61) Updated melpa
* [`9269c21c`](https://github.com/nix-community/emacs-overlay/commit/9269c21c67d88d2d318d926a5a72ca9a157833e9) Updated emacs
* [`d7492854`](https://github.com/nix-community/emacs-overlay/commit/d7492854188009e5ab02cb80983e25c8f71c26c9) Updated nongnu
* [`c4414fe6`](https://github.com/nix-community/emacs-overlay/commit/c4414fe6190438088351901c985765ce2e3a41d1) Updated elpa
* [`8ab4a7f3`](https://github.com/nix-community/emacs-overlay/commit/8ab4a7f38e270f1e168f221288e1909a15068844) Updated melpa
* [`1741446a`](https://github.com/nix-community/emacs-overlay/commit/1741446afec9d812af576df394a2304f90e22257) Updated emacs
* [`2d5ed41c`](https://github.com/nix-community/emacs-overlay/commit/2d5ed41c71e166fb880992d38d4cee085aee6137) Updated nongnu
* [`d8b93c51`](https://github.com/nix-community/emacs-overlay/commit/d8b93c516047ef95c70dd99716dfa75a7ab1961b) Updated emacs
* [`23f01b93`](https://github.com/nix-community/emacs-overlay/commit/23f01b932e0f2f8c7a3f877da0add697cedda30c) Updated melpa
* [`d846dd46`](https://github.com/nix-community/emacs-overlay/commit/d846dd4691d42b6f68e86c7cf5dbeffe80dec5cf) Updated nongnu
* [`126f2a16`](https://github.com/nix-community/emacs-overlay/commit/126f2a1659dbe936f5c744654fb4d61f821be109) Updated elpa
* [`78c231d9`](https://github.com/nix-community/emacs-overlay/commit/78c231d9dc3d8d7ddf75abe2acdb43da29367445) Updated emacs
* [`39514385`](https://github.com/nix-community/emacs-overlay/commit/39514385b3c81dbd20bebcf6ee64cd452ca2fce8) Updated melpa
* [`f3eb21a2`](https://github.com/nix-community/emacs-overlay/commit/f3eb21a25e66cf4eaab7986f7688994565492aba) Updated flake inputs
* [`56c61d31`](https://github.com/nix-community/emacs-overlay/commit/56c61d31e73662ef2ed2bbb60ec862b9f7694d54) Updated melpa
* [`0d512bc7`](https://github.com/nix-community/emacs-overlay/commit/0d512bc7b5222c91a5e450dd645e9ac26c4537f4) Updated nongnu
* [`6512601b`](https://github.com/nix-community/emacs-overlay/commit/6512601b23450a49e84d749bac0026fb94fa5456) Updated elpa
* [`95e3e2dc`](https://github.com/nix-community/emacs-overlay/commit/95e3e2dc0f22191f0cd61b6cecbd83c7e1724f51) Updated emacs
* [`b8c12697`](https://github.com/nix-community/emacs-overlay/commit/b8c1269741faa8b59cb4635569e16e12bf47e664) Updated melpa
* [`2e02805c`](https://github.com/nix-community/emacs-overlay/commit/2e02805c22d28483e68c212e980804dcbdce3c39) Updated nongnu
* [`1f8b8772`](https://github.com/nix-community/emacs-overlay/commit/1f8b8772b192c6b5f88417d7b452ed8cf737c326) Updated elpa
* [`48ba7a60`](https://github.com/nix-community/emacs-overlay/commit/48ba7a600813e14a21d4181bd3d07ce94b8c1102) Updated melpa
* [`3573872d`](https://github.com/nix-community/emacs-overlay/commit/3573872da6a5aad4cfa25410eebcb619cfdea9c1) Updated emacs
* [`0b93a6b3`](https://github.com/nix-community/emacs-overlay/commit/0b93a6b35b4ac0c45e4ea09932c5d8447f4afa14) Updated nongnu
* [`43160550`](https://github.com/nix-community/emacs-overlay/commit/4316055067738a21c925415821890e15e976ee76) Updated elpa
* [`24cd4475`](https://github.com/nix-community/emacs-overlay/commit/24cd4475147293d112e9df15fc2f3bc8bb02eaa7) Updated melpa
* [`5d67c0f1`](https://github.com/nix-community/emacs-overlay/commit/5d67c0f1c6115d723b187a6f00832b15e346c8b5) Updated emacs
* [`68bbd4bb`](https://github.com/nix-community/emacs-overlay/commit/68bbd4bb06b2e38c760ef457422019d870b30efa) Updated nongnu
* [`4a99bb63`](https://github.com/nix-community/emacs-overlay/commit/4a99bb63260c70441613eea081818526c9f4c6fe) Updated elpa
* [`d9c000fc`](https://github.com/nix-community/emacs-overlay/commit/d9c000fcee032fbf262ff0d5f09b1c5b2165ff63) Updated emacs
* [`bdb0c5ba`](https://github.com/nix-community/emacs-overlay/commit/bdb0c5ba7a493bf064de0d065a55ea4d0300ef67) Updated melpa
* [`79c5920e`](https://github.com/nix-community/emacs-overlay/commit/79c5920ec4af99639c653215ffcb3d8f1dff6982) Updated nongnu
* [`3412c21e`](https://github.com/nix-community/emacs-overlay/commit/3412c21eb8b163f23b68785c332fe9b37753d165) Updated nongnu
* [`984abb8c`](https://github.com/nix-community/emacs-overlay/commit/984abb8ccffe5a6164a0a3813cd0ff884f33d2be) Updated elpa
* [`b771d822`](https://github.com/nix-community/emacs-overlay/commit/b771d822cc4a71e6c140d8d86089df1120026020) Updated emacs
* [`9d41880e`](https://github.com/nix-community/emacs-overlay/commit/9d41880e6f1d613e4074ba4b39bdafbf0b5c7e09) Updated melpa
* [`e6965fdf`](https://github.com/nix-community/emacs-overlay/commit/e6965fdf21d2865e0fac627268219d9f1063f7cb) Updated flake inputs
* [`eca402d5`](https://github.com/nix-community/emacs-overlay/commit/eca402d5a7d31af0fe1cfe1bb161746184509ed1) Updated melpa
* [`ec568d50`](https://github.com/nix-community/emacs-overlay/commit/ec568d50f0c82751c60c99efa282f1392d515ab4) Updated emacs
* [`614abf79`](https://github.com/nix-community/emacs-overlay/commit/614abf799bbc623abdd197cc47222161781dbaf7) Updated elpa
* [`52c2c670`](https://github.com/nix-community/emacs-overlay/commit/52c2c6707d5c22e72363cc0460f86cc0bce818fb) Updated nongnu
* [`ff6e9d75`](https://github.com/nix-community/emacs-overlay/commit/ff6e9d75622b02d35076d7fd9ae118bac480d9f5) Updated elpa
* [`8abc4be5`](https://github.com/nix-community/emacs-overlay/commit/8abc4be5a46f043d17fb82b1f053ac227752598c) Updated melpa
* [`487c33cc`](https://github.com/nix-community/emacs-overlay/commit/487c33cc9c100af127f363393cacc170e42d3b61) Updated emacs
* [`2e3107b2`](https://github.com/nix-community/emacs-overlay/commit/2e3107b21499146e7c9c5a45bfd6f264a341eff6) Updated nongnu
* [`dad8515b`](https://github.com/nix-community/emacs-overlay/commit/dad8515b9bc9facb51f9cab79f657e6711087e38) Updated elpa
* [`3145e73c`](https://github.com/nix-community/emacs-overlay/commit/3145e73c49b64f1924c6ccf941337d960e191e11) Updated melpa
* [`19efa4ef`](https://github.com/nix-community/emacs-overlay/commit/19efa4ef6b8505bdd15a42a03ec6b02612163693) Updated emacs
* [`2aa74265`](https://github.com/nix-community/emacs-overlay/commit/2aa74265d60bf95673a7fea800755e9fad91b964) Updated nongnu
* [`e60a014b`](https://github.com/nix-community/emacs-overlay/commit/e60a014b49fc79d6a6066658a0568e557d0c5f88) Updated elpa
* [`89b61360`](https://github.com/nix-community/emacs-overlay/commit/89b61360e19575a78c35da0b3375eb2984f14c9a) Updated emacs
* [`397bf9fd`](https://github.com/nix-community/emacs-overlay/commit/397bf9fdd15b35cbf16d1b10f2148185eba3b0c1) Updated melpa
* [`2b8574e2`](https://github.com/nix-community/emacs-overlay/commit/2b8574e2acf6588e0ac6d3a52e76739307a1d23b) Updated emacs
* [`58dae564`](https://github.com/nix-community/emacs-overlay/commit/58dae564cab8143a83cc38672dcf71a1c301443b) Updated melpa
* [`f5254c7d`](https://github.com/nix-community/emacs-overlay/commit/f5254c7d813835df860a1acf7d5cb2ac18656c05) Updated flake inputs
* [`dc7c432f`](https://github.com/nix-community/emacs-overlay/commit/dc7c432f20089264d5ac14f09e2a68c436799b50) Updated nongnu
* [`0685d7da`](https://github.com/nix-community/emacs-overlay/commit/0685d7da6e8054dd9f9bc9e2cd3d416289713e42) Updated elpa
* [`81523c81`](https://github.com/nix-community/emacs-overlay/commit/81523c81b44f3a5697c04b3e0f6984a6dae2d6d5) Updated melpa
* [`2aa171e1`](https://github.com/nix-community/emacs-overlay/commit/2aa171e1b491047b7465466e39e2e55540ccd3f1) Updated emacs
* [`a4098718`](https://github.com/nix-community/emacs-overlay/commit/a4098718f27d13c7252f1d9f7634b6693c814bc3) Updated nongnu
* [`6db77842`](https://github.com/nix-community/emacs-overlay/commit/6db77842d89c5a343722b5f5fa6bcb18c875548a) Updated elpa
* [`6b85b21d`](https://github.com/nix-community/emacs-overlay/commit/6b85b21dcbee3bbc11a2260b920bbd0001d63ff9) Updated emacs
* [`2a54b26b`](https://github.com/nix-community/emacs-overlay/commit/2a54b26bae8366c15757f417d5f92c4c2a759481) Updated melpa
* [`5217e36c`](https://github.com/nix-community/emacs-overlay/commit/5217e36c603d4cac440eda6224cba5749b218b23) Updated nongnu
* [`6c37ac5a`](https://github.com/nix-community/emacs-overlay/commit/6c37ac5a2e87e04321857e6e106676448ef8fc29) Updated elpa
* [`85e2ea41`](https://github.com/nix-community/emacs-overlay/commit/85e2ea411a339424a30a7d7ae23d3e8fff5f8913) Updated emacs
* [`45e27e29`](https://github.com/nix-community/emacs-overlay/commit/45e27e2994de2b559a4bc9ac17f0447a67cd89b2) Updated melpa
* [`ea45a51c`](https://github.com/nix-community/emacs-overlay/commit/ea45a51cd08a93a5651dbd6882e14f1a6c10df66) Updated nongnu
* [`d75249b0`](https://github.com/nix-community/emacs-overlay/commit/d75249b0821f1600870249020408cc2fb32a6775) Updated elpa
* [`b0267c6a`](https://github.com/nix-community/emacs-overlay/commit/b0267c6a2287147a31521319944fc441000e0d43) Updated melpa
* [`b49484b0`](https://github.com/nix-community/emacs-overlay/commit/b49484b0f55e5132cdce2dae8ec3970869c30c09) Updated emacs
* [`713a1c66`](https://github.com/nix-community/emacs-overlay/commit/713a1c668be353a338eb42436f355ba3f411cd97) Updated melpa
* [`e4f66b03`](https://github.com/nix-community/emacs-overlay/commit/e4f66b031618c2d974c14514d7af709aa29f3880) Updated nongnu
* [`9d2b0fdc`](https://github.com/nix-community/emacs-overlay/commit/9d2b0fdce3172fe81c96dc92eff743243b3ba6d1) Updated elpa
* [`64310045`](https://github.com/nix-community/emacs-overlay/commit/643100453da6015e69b0325c9b7400498aaadc72) Updated emacs
* [`aa1acbf4`](https://github.com/nix-community/emacs-overlay/commit/aa1acbf4633b38c014b547447d87bc634ff113c9) Updated melpa
* [`d91e9a72`](https://github.com/nix-community/emacs-overlay/commit/d91e9a72cdf37f54a3570bc84fd8fe83ed8a07d7) Update emacs-git-pgtk on hydra
* [`e4391465`](https://github.com/nix-community/emacs-overlay/commit/e43914657d9fcb7c3ad5150b18477f055090bc74) Build emacs-lsp and commercial-emacs on hydra
* [`93646b16`](https://github.com/nix-community/emacs-overlay/commit/93646b16d31589d8ff18c0846445cb857d4e387a) Updated nongnu
* [`bff30b7d`](https://github.com/nix-community/emacs-overlay/commit/bff30b7d0f62f8022078be50c013a73c2c3e6076) Updated elpa
* [`384b67a3`](https://github.com/nix-community/emacs-overlay/commit/384b67a33ab7185cfa277193774840d8f7d88c83) Updated melpa
* [`bf91b636`](https://github.com/nix-community/emacs-overlay/commit/bf91b636582d1b73b81dfd64b54c45a35ac415b7) Updated nongnu
* [`7758f7f2`](https://github.com/nix-community/emacs-overlay/commit/7758f7f259b9455bbe056f15e1479228159b35da) Updated melpa
* [`b768ba90`](https://github.com/nix-community/emacs-overlay/commit/b768ba904f606b4970f9f3f67e009c4f247d9759) Updated emacs
* [`de81495d`](https://github.com/nix-community/emacs-overlay/commit/de81495d7bf78a6e647250cdf4af0a6940d38ce3) Updated nongnu
* [`433215bd`](https://github.com/nix-community/emacs-overlay/commit/433215bd3a49a88698bb3202013b21140a9de0c4) Updated emacs
* [`7e4ef911`](https://github.com/nix-community/emacs-overlay/commit/7e4ef911d11f1201cef6e48143eba991e087bce9) Updated melpa
* [`32dba417`](https://github.com/nix-community/emacs-overlay/commit/32dba4171fa76c4e00d87533bf0c39432947b26a) Updated flake inputs
* [`ddac3455`](https://github.com/nix-community/emacs-overlay/commit/ddac345590a88937958cebd46589178d142b97d7) Updated melpa
* [`0d05b599`](https://github.com/nix-community/emacs-overlay/commit/0d05b5991a44f94622584b2a5f8f359ff7836f5a) Updated nongnu
* [`3baa4a0f`](https://github.com/nix-community/emacs-overlay/commit/3baa4a0f3ae85abf0928771f87ee84fa81b65439) Updated elpa
* [`1d498ea2`](https://github.com/nix-community/emacs-overlay/commit/1d498ea2f01c1b069a82c276c80fa66ef2aa2df5) Updated emacs
* [`b8df6094`](https://github.com/nix-community/emacs-overlay/commit/b8df6094952273f3b7e5e7c99b96ed1bf9830034) Updated melpa
* [`7e4408e2`](https://github.com/nix-community/emacs-overlay/commit/7e4408e251279fcf9ad21dee131b18a4af9c0557) Updated nongnu
* [`4326edea`](https://github.com/nix-community/emacs-overlay/commit/4326edeae3543f3afac1decf2991986744fb09f1) Updated elpa
* [`9f626bb4`](https://github.com/nix-community/emacs-overlay/commit/9f626bb4afb25ac287ff37a83aae0f4ded9e25cb) Updated emacs
* [`f95d76f8`](https://github.com/nix-community/emacs-overlay/commit/f95d76f855a08eada6da509bc53e6227d8e4803f) Updated melpa
* [`047a34f0`](https://github.com/nix-community/emacs-overlay/commit/047a34f0472201fe544031ed23e024e94e86688e) Updated emacs
* [`b68427b8`](https://github.com/nix-community/emacs-overlay/commit/b68427b8c5bfea32a281b09c51ec97d170a849d3) Updated melpa
* [`e4183e19`](https://github.com/nix-community/emacs-overlay/commit/e4183e1949d228bfa17cc6a73e3cb8e7908b721e) Updated nongnu
* [`07c08ea0`](https://github.com/nix-community/emacs-overlay/commit/07c08ea0037b2fd7e0b5416361586d4552ac8255) Updated elpa
* [`234d7cac`](https://github.com/nix-community/emacs-overlay/commit/234d7cacd38e056b51bed1c619ababee1629e697) Updated nongnu
* [`55f920eb`](https://github.com/nix-community/emacs-overlay/commit/55f920ebcef4357786f00d367a913e4a2819b8c3) Updated elpa
* [`2011b60e`](https://github.com/nix-community/emacs-overlay/commit/2011b60e519c66ee1a9473051217dcf93de5b0ee) Updated emacs
* [`37b552ff`](https://github.com/nix-community/emacs-overlay/commit/37b552ff889582192ebfcfb23d1baaf4f7f44673) Updated melpa
* [`7e0438cf`](https://github.com/nix-community/emacs-overlay/commit/7e0438cf52fc6349efce721ecb1ff7c98ed8a39f) Updated flake inputs
* [`fe84d9de`](https://github.com/nix-community/emacs-overlay/commit/fe84d9de435663c7f191cf2cd4920dde2bd1b629) Updated melpa
* [`c465e235`](https://github.com/nix-community/emacs-overlay/commit/c465e235cdb8947f81e1dd65f2bf7052435cce28) Updated nongnu
* [`b6df7296`](https://github.com/nix-community/emacs-overlay/commit/b6df7296a9a5ddaefacf7c1d2e08492c4b2dddc7) Updated emacs
* [`983dc5da`](https://github.com/nix-community/emacs-overlay/commit/983dc5dacc3654f92e9c914c10d678ff32f5ca13) Updated melpa
* [`7565f308`](https://github.com/nix-community/emacs-overlay/commit/7565f308f547bf50984aec1b8730e323d727dd97) Updated elpa
* [`c7165384`](https://github.com/nix-community/emacs-overlay/commit/c7165384a3567db171650e19a61fe47403ec59a1) Updated emacs
* [`2d6e5536`](https://github.com/nix-community/emacs-overlay/commit/2d6e5536a0cd507c089234e0a87ff6eba6b327b0) Updated melpa
* [`edf5550d`](https://github.com/nix-community/emacs-overlay/commit/edf5550df669e12f402aec6411409d2a1ecc28e9) Updated emacs
* [`16fb7a40`](https://github.com/nix-community/emacs-overlay/commit/16fb7a40da305fd43b679b2a8b987aa21f1203de) Updated melpa
* [`4c71a9bc`](https://github.com/nix-community/emacs-overlay/commit/4c71a9bcac6d1d528520263c1f8718753074a267) Updated nongnu
* [`b798ba95`](https://github.com/nix-community/emacs-overlay/commit/b798ba95dcec69337712d76c68ee6698c48c215a) Updated elpa
* [`62be4100`](https://github.com/nix-community/emacs-overlay/commit/62be41004cbfe8eca0dbf272c8fd4e66831569cc) Updated emacs
* [`06e3e3be`](https://github.com/nix-community/emacs-overlay/commit/06e3e3be8aff792547dfd0825c7e5dc0c65bd4db) Updated melpa
* [`3ccb8d0c`](https://github.com/nix-community/emacs-overlay/commit/3ccb8d0c9393d2fbda69b83f37eb17b097a9d3a6) Updated nongnu
* [`05e1028f`](https://github.com/nix-community/emacs-overlay/commit/05e1028fc46c7c76554e4e5ff67526d4c39d1ca6) Updated elpa
* [`d897508e`](https://github.com/nix-community/emacs-overlay/commit/d897508eb2803d712e5b1da3434ad92194716515) Updated emacs
* [`7ff67f2f`](https://github.com/nix-community/emacs-overlay/commit/7ff67f2fe892122aaa0fb28af341171d526173fe) Updated melpa
* [`d07a07a9`](https://github.com/nix-community/emacs-overlay/commit/d07a07a9e47610a49781ecef915e8cd97fb6516c) Updated flake inputs
* [`100807ee`](https://github.com/nix-community/emacs-overlay/commit/100807ee8983b230b41e5f15e3a6f1a666abf2b9) Updated melpa
* [`570d679b`](https://github.com/nix-community/emacs-overlay/commit/570d679bdf08d80e3864541b417fc94ba2a5da7e) Updated emacs
* [`8b4613ee`](https://github.com/nix-community/emacs-overlay/commit/8b4613ee78a3f1ec2a58e71ed6c8a8ea93e7dd40) Updated nongnu
* [`a460ed2b`](https://github.com/nix-community/emacs-overlay/commit/a460ed2bc3383fcb691f8b88c254145d237b4283) Updated elpa
* [`65702d12`](https://github.com/nix-community/emacs-overlay/commit/65702d1291c2573b4282a2789699750c2ce6bba9) Updated nongnu
* [`40b490e9`](https://github.com/nix-community/emacs-overlay/commit/40b490e9b56db7c95f8e6133bbba466673abccdb) Updated elpa
* [`8a3f303a`](https://github.com/nix-community/emacs-overlay/commit/8a3f303addf562ae3f726f7a5fadb9e867bea0e3) Updated melpa
* [`e99297e5`](https://github.com/nix-community/emacs-overlay/commit/e99297e5463abbaeb02451be0fe119da6477dd46) Updated emacs
* [`2df62666`](https://github.com/nix-community/emacs-overlay/commit/2df626665bf05449f81db5a6b4e8196030e88a86) Updated flake inputs
* [`50c8bdc8`](https://github.com/nix-community/emacs-overlay/commit/50c8bdc8446b314820114afad9865c3a567785cb) Updated elpa
* [`be689ed5`](https://github.com/nix-community/emacs-overlay/commit/be689ed533e7ee95fdaef70936408ea61a97e31a) Updated emacs
* [`1763ae43`](https://github.com/nix-community/emacs-overlay/commit/1763ae43e84ec57682d46cda291a37e81c6c80c9) Updated melpa
* [`eb963c7b`](https://github.com/nix-community/emacs-overlay/commit/eb963c7b0a5d50746cfa9eeed61f4c1b4a3d5f29) Updated elpa
* [`4d121973`](https://github.com/nix-community/emacs-overlay/commit/4d1219736a41546be96de8ac24699ba768b9bc54) Updated emacs
* [`7f59ede0`](https://github.com/nix-community/emacs-overlay/commit/7f59ede0d13c9ec991db28a42ce3812227f7b675) Updated melpa
* [`219da114`](https://github.com/nix-community/emacs-overlay/commit/219da11402d8bf5ab9b4661ab8c91fea965e22e5) Updated melpa
* [`7de4db2d`](https://github.com/nix-community/emacs-overlay/commit/7de4db2dbeb1e88dbf1945cd3e3fc92e36d0b964) Updated nongnu
* [`31c5ded0`](https://github.com/nix-community/emacs-overlay/commit/31c5ded0cfc2cf79e1a9acc8b3b1373cf5fedc75) Updated elpa
* [`09e1b065`](https://github.com/nix-community/emacs-overlay/commit/09e1b065c0fbba5738d410b911d93aee8566db27) Updated emacs
* [`91802f42`](https://github.com/nix-community/emacs-overlay/commit/91802f4208e83e409f7a864c8f2ce2a5f08c23ea) Updated melpa
* [`5e3853d8`](https://github.com/nix-community/emacs-overlay/commit/5e3853d8ed0cdeb40db7f05a083b6c12d1d3c47e) Updated nongnu
* [`f502ded0`](https://github.com/nix-community/emacs-overlay/commit/f502ded0d175e4c4c6cf7b504a08e82651a0dafb) Updated elpa
* [`6ad9ec2a`](https://github.com/nix-community/emacs-overlay/commit/6ad9ec2a5a640c77530385479aca545d2033456e) Updated emacs
* [`bd0f14a0`](https://github.com/nix-community/emacs-overlay/commit/bd0f14a038b52c908561ecfdb392e84e29635d67) Updated melpa
* [`633b5e2f`](https://github.com/nix-community/emacs-overlay/commit/633b5e2f351e1c7960323d70290e4d46bc901969) Updated melpa
* [`2dc863f0`](https://github.com/nix-community/emacs-overlay/commit/2dc863f0ba0b72414695f5bedabeeb4a1eef0c44) Updated emacs
* [`01a52dd7`](https://github.com/nix-community/emacs-overlay/commit/01a52dd77357a78153687f8b0ad720ec849efcdd) Updated elpa
* [`4d717d76`](https://github.com/nix-community/emacs-overlay/commit/4d717d76e879174c0760cc697d751f8819823b15) Updated emacs
* [`4ed6313a`](https://github.com/nix-community/emacs-overlay/commit/4ed6313ad6f2e7ed940143096808085c44028afa) Updated melpa
