### PR TITLE
niv doomemacs: update fdc0fa3b -> ed9190ef

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "",
         "owner": "doomemacs",
         "repo": "doomemacs",
-        "rev": "fdc0fa3becb9e80311cbe638d1e8b518a44bd1ee",
-        "sha256": "1r5vz919jrhr0bcw9knn91xxvdp4pkmm4y5wrhn6cqi8190cp0s3",
+        "rev": "ed9190ef005829c7a2331e12fb36207794c5ad75",
+        "sha256": "07z707rnw90pjbyxgva0p7fdhhp3crjxc0li333w608h4sdx8kwx",
         "type": "tarball",
-        "url": "https://github.com/doomemacs/doomemacs/archive/fdc0fa3becb9e80311cbe638d1e8b518a44bd1ee.tar.gz",
+        "url": "https://github.com/doomemacs/doomemacs/archive/ed9190ef005829c7a2331e12fb36207794c5ad75.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "emacs-overlay": {


### PR DESCRIPTION
## Changelog for doomemacs:
Branch: master
Commits: [doomemacs/doomemacs@fdc0fa3b...ed9190ef](https://github.com/doomemacs/doomemacs/compare/fdc0fa3becb9e80311cbe638d1e8b518a44bd1ee...ed9190ef005829c7a2331e12fb36207794c5ad75)

* [`1adc318c`](https://github.com/doomemacs/doomemacs/commit/1adc318cac334e3e374601dcac0a6af46ec99955) dev: replace .doomrc w/ .doom.el
* [`000bf3be`](https://github.com/doomemacs/doomemacs/commit/000bf3beead57eb6beb81baef6a5ec1002c6b722) docs(magit): add 29.1+ check for +forge
* [`6a69add7`](https://github.com/doomemacs/doomemacs/commit/6a69add73f2a4865f82ebc9ad3ca6b36ab9c89c5) refactor(file-templates): update doomrc templates
* [`0fe36e12`](https://github.com/doomemacs/doomemacs/commit/0fe36e12a94aa013837f820844a5710588e59f87) nit(bin): doomscript: revise comments
* [`7d69c5f7`](https://github.com/doomemacs/doomemacs/commit/7d69c5f7dfa089a8b9bbdd7199869f583aed3b3a) fix(lib): void-function editorconfig--default-indent-size-function
* [`6bd38e2c`](https://github.com/doomemacs/doomemacs/commit/6bd38e2c4d0e2580cff6e8b9bd8ef74afcdc4729) tweak(python): don't use basedpyright by default
* [`adf5594c`](https://github.com/doomemacs/doomemacs/commit/adf5594c3c9af5013da85beb9e90a70c871e1baf) docs(cli): update exit codes table
* [`6010b402`](https://github.com/doomemacs/doomemacs/commit/6010b40247b8cb4b8a127a34361b99562ea81db9) fix(fold): Use function variables over direct func
* [`5b5b170f`](https://github.com/doomemacs/doomemacs/commit/5b5b170f7902e81826fd8efbec88eb38e23e2807) fix(macos): avoid calling nushell's `open`
* [`1b125ddf`](https://github.com/doomemacs/doomemacs/commit/1b125ddf7b6ce7e8c270231d5dc0e0cb38936a74) feat(:term): make previous command output read-only
* [`5a690fc5`](https://github.com/doomemacs/doomemacs/commit/5a690fc54fa58b0443ab8b6cb65e6588d5b5e9ec) feat(:term): confine undo to comint/eshell prompts
* [`47e52ab8`](https://github.com/doomemacs/doomemacs/commit/47e52ab86ff45225388bff458189f5311153eefa) feat(:term): move cursor to prompt on self-insert-command
* [`29ec1f40`](https://github.com/doomemacs/doomemacs/commit/29ec1f40f39df0ff3e77d3e73c6cb15d8883fcd3) feat(org): jupyter-repl: move cursor to prompt on self-insert-command
* [`1c01ab45`](https://github.com/doomemacs/doomemacs/commit/1c01ab455f53443ae9a21adacd38ecac6be11ed3) docs: update links in project readme
* [`b6cbfea5`](https://github.com/doomemacs/doomemacs/commit/b6cbfea53dbf9c53dd96e09c812488a02e55712d) refactor(org): remove +org--follow-search-string-a
* [`4ae82599`](https://github.com/doomemacs/doomemacs/commit/4ae8259946a5051fb9b3a28aebc6751570409659) release(modules): 25.08.0-dev
* [`dd89efdb`](https://github.com/doomemacs/doomemacs/commit/dd89efdb428ced3177f3e7a9b284f7157c94548d) tweak(lib): doom-debug-variables: add epg-debug
* [`ed9190ef`](https://github.com/doomemacs/doomemacs/commit/ed9190ef005829c7a2331e12fb36207794c5ad75) fix(cli): infinite loop linting long lines in commits
