### PR TITLE
niv nixpkgs: update de9c29bb -> d9da6cda

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -143,10 +143,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "de9c29bbd3512d3a776f1c0f150ee02d3477ff00",
-        "sha256": "0bymhnib39sx8n9h9z5qrzm262ij947z5wy55s5swjghcf0prymk",
+        "rev": "d9da6cda4e5eed60e8c5489789d092be51a565be",
+        "sha256": "1wyc6dfgkz4hk5xmx67v9xsaw7v8z072v2bv1ndw6kq1vc5wrmnf",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/de9c29bbd3512d3a776f1c0f150ee02d3477ff00.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/d9da6cda4e5eed60e8c5489789d092be51a565be.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@de9c29bb...d9da6cda](https://github.com/nixos/nixpkgs/compare/de9c29bbd3512d3a776f1c0f150ee02d3477ff00...d9da6cda4e5eed60e8c5489789d092be51a565be)

* [`18e236d8`](https://github.com/NixOS/nixpkgs/commit/18e236d89dd72b89cc8fe19c15c73b9e87985c31) nixos/prometheus.exporters.bitcoin: fix SC2155
* [`3be190a1`](https://github.com/NixOS/nixpkgs/commit/3be190a1fc7a91ca0f3ceed8f354f1d3a22f9a78) nixos/prometheus.exporters.bitcoin: remove unused attributes
* [`a73ba5c9`](https://github.com/NixOS/nixpkgs/commit/a73ba5c93a5acd8b4b8082ececffdcd99af72520) nixos/kanidm: bind ca-bundle to validate url on provisioning
* [`c0787728`](https://github.com/NixOS/nixpkgs/commit/c07877286bbd80d7b3eb9d82e31cfd4780d814f4) libirecovery: fix udevrule
* [`31f49c2d`](https://github.com/NixOS/nixpkgs/commit/31f49c2d6f3005fa64f54856b8ad6828ea00472a) maintainers: add ralleka
* [`b333e183`](https://github.com/NixOS/nixpkgs/commit/b333e1832e2a091df0d015565c2785f9fe8a858c) maintainers: add toyboot4e
* [`5a8e4e32`](https://github.com/NixOS/nixpkgs/commit/5a8e4e32d403df835969a02949819762784d715b) pyrefly: 0.17.1 -> v0.20.2; refactor
* [`bbb383e6`](https://github.com/NixOS/nixpkgs/commit/bbb383e659d9e46dedcf69335821b899a020d944) ieda: 0-unstable-2025-05-30 -> 0-unstable-2025-06-30
* [`0aaa8960`](https://github.com/NixOS/nixpkgs/commit/0aaa8960cb147a46af8036893d84252b5dfa0f4c) nixos/vim: assert that both enable and defaultEditor is set
* [`e73fe64d`](https://github.com/NixOS/nixpkgs/commit/e73fe64d31e8eea2d2b2349da711f248280c08f0) cerberus: init at 0-unstable-2025-06-29
* [`2d226ea3`](https://github.com/NixOS/nixpkgs/commit/2d226ea311808e32559bfec22f21be240e559a93) spdx-license-list-data: 3.26.0 -> 3.27.0
* [`c7394936`](https://github.com/NixOS/nixpkgs/commit/c739493612610415b34d4118ecde1946d747e566) pyload-ng: 0.5.0b3.dev87 -> 0.5.0b3.dev88
* [`cba8a70e`](https://github.com/NixOS/nixpkgs/commit/cba8a70efd735e1b791dd2772cee0763bb383ddc) ocamlPackages.spdx_licenses: 1.3.0 -> 1.4.0
* [`eff70005`](https://github.com/NixOS/nixpkgs/commit/eff700051b6b12c65bf357eeda2537cf413b3264) python3Packages.srctools: init at 2.6.0
* [`b6e14825`](https://github.com/NixOS/nixpkgs/commit/b6e148251f44e30e14cefb5ddf92fce657a06a8c) mdk-sdk: 0.33.0 -> 0.33.1
* [`87f62130`](https://github.com/NixOS/nixpkgs/commit/87f6213006df821ac218d982d32fcb7cb9cef5e6) floorp: disable LTO
* [`b9c5f0d4`](https://github.com/NixOS/nixpkgs/commit/b9c5f0d4b1a4687e8f01b1e228a3bedeba1fd073) ocamlPackages.unisim_archisec: 0.0.10 -> 0.0.11
* [`9d769b6b`](https://github.com/NixOS/nixpkgs/commit/9d769b6b9d50195ec7370ec34fbd2b1aaea840c6) nixos/unlock-bcachefs: Fix x-systemd.requires/wants= matching.
* [`45bb7f83`](https://github.com/NixOS/nixpkgs/commit/45bb7f83f4c85dd14781b171ef657020168f5a4c) nixos/unlock-bcachefs: Support x-systemd.requires/wants-mounts-for=
* [`7c06d057`](https://github.com/NixOS/nixpkgs/commit/7c06d0575d440742ed61640b5ca8fda658eae00c) python3Packages.softlayer: 6.2.6 -> 6.2.7
* [`5b2aee74`](https://github.com/NixOS/nixpkgs/commit/5b2aee74c200064e78776efb41f7dcb06e2d5d7f) enry: init at 1.3.0
* [`86d0bfc8`](https://github.com/NixOS/nixpkgs/commit/86d0bfc85d063c3c66b04b7724b00f01d8ce7619) ocamlPackages.sail: 0.19 -> 0.19.1
* [`bceb6f25`](https://github.com/NixOS/nixpkgs/commit/bceb6f25dfbe461461c1866d0242810dc12c1882) redwax-tool: 0.9.9 -> 1.0.0
* [`e56bfd3c`](https://github.com/NixOS/nixpkgs/commit/e56bfd3c4fa6a3ece52dc2cd93ef275204abaa90) marble-shell-theme: 48.0.1 -> 48.3.2
* [`01294e0f`](https://github.com/NixOS/nixpkgs/commit/01294e0ff50a17adf2d95a41f1be38242aa89bc5) libsolv: 0.7.33 -> 0.7.34
* [`c85a9d30`](https://github.com/NixOS/nixpkgs/commit/c85a9d305c62e680cd72868765e37e016e58156f) bicep: 0.36.1 -> 0.36.177
* [`6aa87a71`](https://github.com/NixOS/nixpkgs/commit/6aa87a71ddc55bc3b8a966ffb6efbbf5d65455ad) tkdiff: 5.7 -> 6.0
* [`58b2008d`](https://github.com/NixOS/nixpkgs/commit/58b2008d2f593373ea242d8ec1e26514dcd527aa) firefoxpwa: add firefoxRuntime parameter
* [`6907e0de`](https://github.com/NixOS/nixpkgs/commit/6907e0de8026402771b3b2c15d95efdb747367ec) zxtune: 5100 -> 5101
* [`72b76af1`](https://github.com/NixOS/nixpkgs/commit/72b76af1f2be066001d6efd596eb687555c23dae) asus-wmi-screenpad-ctl: init at 1.0.0
* [`8b620404`](https://github.com/NixOS/nixpkgs/commit/8b620404968926be8993898432d87365343ac301) stirling-pdf: 0.33.1 -> 1.0.2
* [`9b307c42`](https://github.com/NixOS/nixpkgs/commit/9b307c42f0ee13e0f75e33cf4df03cfe2d267b4f) stirling-pdf: Switch to MIT license
* [`148e2e3d`](https://github.com/NixOS/nixpkgs/commit/148e2e3d49249a0f2109fac40f501cbd403cd67e) stirling-pdf: Disable proprietary features
* [`10ca1d58`](https://github.com/NixOS/nixpkgs/commit/10ca1d5883a4f71c316c8f1dbd8a031744bd7f63) ios-webkit-debug-proxy: 1.9.1 -> 1.9.2
* [`a4133153`](https://github.com/NixOS/nixpkgs/commit/a4133153f18a921a2b0920629b81ff81217ccd81) pdfquery: init at 0.4.3
* [`a08205f1`](https://github.com/NixOS/nixpkgs/commit/a08205f1733531605d1817ee68a43f601ef27a3d) ao3downloader: init at 2025.6.1
* [`06782187`](https://github.com/NixOS/nixpkgs/commit/06782187cd9e39374a9f96e23bb33c382a409933) gdbgui: 0.15.2.0 -> 0.15.3.0
* [`fd81356c`](https://github.com/NixOS/nixpkgs/commit/fd81356c3c58e1c1fe7c4131394764d823721757) hubstaff: 1.6.31-a6da06ad -> 1.7.3-6c31e21a
* [`0b3c70cf`](https://github.com/NixOS/nixpkgs/commit/0b3c70cf94d9712997db0033d6b24a0b0a63c72d) acr-cli: 0.15 -> 0.16
* [`42072f4a`](https://github.com/NixOS/nixpkgs/commit/42072f4a8360f0229b64270cfdcd29e09fc0b499) gmm: 5.4.2 -> 5.4.4
* [`288d679d`](https://github.com/NixOS/nixpkgs/commit/288d679dad58b08953117d7ff5b7e33b42be59b6) prometheus-frr-exporter: 1.7.0 -> 1.8.0
* [`031d34fd`](https://github.com/NixOS/nixpkgs/commit/031d34fdaac9620806b4b10d04c92cb508975a0c) vrpn: 07.35 -> 07.36
* [`b2b41c57`](https://github.com/NixOS/nixpkgs/commit/b2b41c57b58958ba5781251ee7c7138bde03d9a9) ipatool: 2.1.6 -> 2.2.0
* [`1b88d69b`](https://github.com/NixOS/nixpkgs/commit/1b88d69bfeed4f8618766e5a8adc9eff6a0e326f) znc: 1.10.0 -> 1.10.1
* [`41deb362`](https://github.com/NixOS/nixpkgs/commit/41deb3621113450de8f2e6bdeca761e48f140409) gnu-shepherd: 1.0.5 -> 1.0.6
* [`16f3086d`](https://github.com/NixOS/nixpkgs/commit/16f3086dc8f6d25dca1c3afda5708c47798bf8df) localstack: 4.5.0 -> 4.6.0
* [`f6ffcf17`](https://github.com/NixOS/nixpkgs/commit/f6ffcf17ef90daae09109c9d4dbe9453f8f7085c) apt: 3.1.2 -> 3.1.3
* [`f4602eee`](https://github.com/NixOS/nixpkgs/commit/f4602eeec1b40661d756fe1bd4f690c4c209273f) pgmoneta: 0.17.2 -> 0.18.0
* [`2015ab9c`](https://github.com/NixOS/nixpkgs/commit/2015ab9cba62c960661fa36f7b36aea975ef13e9) tarlz: 0.28 -> 0.28.1
* [`10f846d4`](https://github.com/NixOS/nixpkgs/commit/10f846d425bce4fb784e2555464eae09cfb70d99) junicode: 2.211 -> 2.216
* [`dec847a3`](https://github.com/NixOS/nixpkgs/commit/dec847a345a5dc8acc056a2c494c8fc4516311ac) google-alloydb-auth-proxy: 1.13.3 -> 1.13.4
* [`6ee60ec7`](https://github.com/NixOS/nixpkgs/commit/6ee60ec750bd1f331a32d99c463048eaa941dcb3) python3Packages.stackprinter: init at 0.2.12
* [`975e7f98`](https://github.com/NixOS/nixpkgs/commit/975e7f985f527531416c95eae9b7c020e9c2d6d6) checkstyle: 10.25.1 -> 10.26.1
* [`3c25db6a`](https://github.com/NixOS/nixpkgs/commit/3c25db6a7cbc09020b8a6da9b6046d462a353d09) amneziawg-tools: 1.0.20241018 -> 1.0.20250706
* [`9d6e008b`](https://github.com/NixOS/nixpkgs/commit/9d6e008bb678f779de0ebc9026b960c650b54b04) phoenixd: 0.6.0 -> 0.6.1
* [`245a054c`](https://github.com/NixOS/nixpkgs/commit/245a054c9058d26aac650b1261b9a54746781647) micronaut: 4.9.0 -> 4.9.1
* [`cf1fee81`](https://github.com/NixOS/nixpkgs/commit/cf1fee816101964d95096063252b1203281192ab) numcpp: 2.14.1 -> 2.14.2
* [`e57dcc9d`](https://github.com/NixOS/nixpkgs/commit/e57dcc9d0dc2c4ced5a1ca00100099c11648523d) rdkafka: Enable SASL GSSAPI support.
* [`eb94edd7`](https://github.com/NixOS/nixpkgs/commit/eb94edd79e50ad88b0b5002e3d110c55e6f8d60a) youtrack: 2025.1.82518 -> 2025.1.86199
* [`713f2600`](https://github.com/NixOS/nixpkgs/commit/713f26005dd72ad3b526c89032864a58879daf91) mockoon: 9.2.0 -> 9.3.0
* [`6c7298d5`](https://github.com/NixOS/nixpkgs/commit/6c7298d549dc62151f669a8eebeab1250731e08b) python3Packages.pyqt6-sip: 13.8.0 -> 13.10.2
* [`a80b91ee`](https://github.com/NixOS/nixpkgs/commit/a80b91eed6434e5eeef286e926023b79061aa6d4) openturns: 1.25 -> 1.25.1
* [`62e0397a`](https://github.com/NixOS/nixpkgs/commit/62e0397aaa6d57504e2c3451b327ce76dfe89446) flrig: 2.0.07 -> 2.0.08
* [`97896223`](https://github.com/NixOS/nixpkgs/commit/978962236bd5e6b28a0b28d5f93de5309c71aaa9) rocketchat-desktop: 4.7.0 -> 4.7.1
* [`12da12f8`](https://github.com/NixOS/nixpkgs/commit/12da12f8abb21874e8b3aacaaafbd982872172cf) fzy: 1.0 -> 1.1
* [`ec0a646a`](https://github.com/NixOS/nixpkgs/commit/ec0a646a345216a55cc7a6b874e63176386d7d8e) morgen: 3.6.15 -> 3.6.16
* [`6329a46c`](https://github.com/NixOS/nixpkgs/commit/6329a46c43876847f7728d8d78d561f1f5aa2c76) doomretro: 5.7 -> 5.7.1
* [`780b0fcd`](https://github.com/NixOS/nixpkgs/commit/780b0fcd9a372a448bdea76b66e24c8903c33bc2) pyhon3Packages.lazrs: init at 0.7.0
* [`9d672390`](https://github.com/NixOS/nixpkgs/commit/9d672390889aff93743682a5cf5596c571cf1204) python3Packages.laspy: 2.5.3 -> 2.6.1
* [`08160185`](https://github.com/NixOS/nixpkgs/commit/08160185c29d6e9864541be26655ea40a223cd4f) python3Packages.laspy: Add fast lazrs backend
* [`cf6a7660`](https://github.com/NixOS/nixpkgs/commit/cf6a766055141466fc231db238adb2af4917cb9b) python3Packages.laspy: Add geospatial team maintenance
* [`697dc060`](https://github.com/NixOS/nixpkgs/commit/697dc0603745678dd375831db13c2e9496edc999) lefthook: 1.11.15 -> 1.12.2
* [`cd46515e`](https://github.com/NixOS/nixpkgs/commit/cd46515e72e1075120d4b9774640864b349308b5) git-quick-stats: 2.6.2 -> 2.7.0
* [`6f7b843d`](https://github.com/NixOS/nixpkgs/commit/6f7b843d437131dd9bcf1660f748803d560c5906) vkquake: add meta.license
* [`d2392c7a`](https://github.com/NixOS/nixpkgs/commit/d2392c7a2b84dd6efb66660786101f25afdcd800) resholve: fix using Nix API with overlays
* [`f60bd2f5`](https://github.com/NixOS/nixpkgs/commit/f60bd2f5877d7de5e758fc86c04a9349d432032e) renoise: 3.4.4 -> 3.5.0
* [`b004a052`](https://github.com/NixOS/nixpkgs/commit/b004a052f1550da820bc7af216f1a8fb531b7bf8) eddie: 2.24.4 -> 2.24.6
* [`40081f3c`](https://github.com/NixOS/nixpkgs/commit/40081f3ceda4853e065fb765d34db3f53bd87b2a) eddie: `rec` -> `finalAttrs`
* [`cdd1f345`](https://github.com/NixOS/nixpkgs/commit/cdd1f34595ac443dd1219ec2d32e4f1ccfc8a087) eddie: add ryand56 as maintainer
* [`e6727a95`](https://github.com/NixOS/nixpkgs/commit/e6727a950e8be4d8f18587228cea5815828b8a8a) uxn: 1.0-unstable-2025-07-03 -> 1.0-unstable-2025-07-12
* [`536d3a23`](https://github.com/NixOS/nixpkgs/commit/536d3a238870bdad7c154711afb899ba764a6c2e) ocenaudio: 3.15 -> 3.15.2
* [`d66dc61d`](https://github.com/NixOS/nixpkgs/commit/d66dc61db20df6a7d316b58157184fc47bc24761) mopidy-tidal: 0.3.9 -> 0.3.10
* [`39935cb2`](https://github.com/NixOS/nixpkgs/commit/39935cb27b2a8b904bed7562c7ff71de92c6eeed) gopeed: 1.7.0 -> 1.7.1
* [`0f56caa8`](https://github.com/NixOS/nixpkgs/commit/0f56caa881fc6143abe2c12a540c4d0bc785cb77) thin-provisioning-tools: fix cross compilation
* [`61df4f3c`](https://github.com/NixOS/nixpkgs/commit/61df4f3c305db8cb9ee6e6fb8ab42b8f721ef855) bootstrap-studio: 7.1.1 -> 7.1.2
* [`c7d1cc7e`](https://github.com/NixOS/nixpkgs/commit/c7d1cc7e1b8ef056ee8b012b1b0fa622f57365ba) solo5: 0.9.1 -> 0.9.2
* [`31dcccb0`](https://github.com/NixOS/nixpkgs/commit/31dcccb074647ddb7a681ea41cfdac2a430d6faf) nixos/lasuite-meet: fix preStart script for backend
* [`48742217`](https://github.com/NixOS/nixpkgs/commit/48742217e289f668910563f35ab7a8ee3f05c7f8) kardolus-chatgpt-cli: init at 1.8.4
* [`0a66cf90`](https://github.com/NixOS/nixpkgs/commit/0a66cf90963263c148f91eea8a419630c83c72ac) linuxkit: 1.7.0 -> 1.7.1
* [`868a4c21`](https://github.com/NixOS/nixpkgs/commit/868a4c215e016234ed2ffe9c631e11967e7584ed) traccar: 6.7.3 -> 6.8.1
* [`12f4b908`](https://github.com/NixOS/nixpkgs/commit/12f4b9085ea436d2006580f9ec4f12c20651ba2e) commonsLang: 3.17.0 -> 3.18.0
* [`af63bf44`](https://github.com/NixOS/nixpkgs/commit/af63bf44b3de490c73f80e06c6b6bfc433e07e9c) dpkg: 1.22.20 -> 1.22.21
* [`845dba92`](https://github.com/NixOS/nixpkgs/commit/845dba92186f1710dc1696749247c697197dc49c) kubevpn: 2.8.0 -> 2.8.1
* [`703e7154`](https://github.com/NixOS/nixpkgs/commit/703e7154870e96506a0e6b56d5c179f4429c92a1) juju: 3.6.7 -> 3.6.8
* [`67598fd7`](https://github.com/NixOS/nixpkgs/commit/67598fd72a9d3e2f4c467de93c67cc985347872e) boxflat: 1.33.0 -> 1.34.2
* [`0ace77e3`](https://github.com/NixOS/nixpkgs/commit/0ace77e3abadeaf7cd82eb874f2456ad2f8c396b) kando: 1.8.0 -> 2.0.0
* [`9187d82d`](https://github.com/NixOS/nixpkgs/commit/9187d82daf89d4c1712a22b87d689afcadd43869) git-town: 21.2.0 -> 21.3.0
* [`c4be68f0`](https://github.com/NixOS/nixpkgs/commit/c4be68f06e8dc9212aa348be524c7029289c899f) nixos/tests/oku: init
* [`c0553b80`](https://github.com/NixOS/nixpkgs/commit/c0553b8070f3fc0eb11af5da5df0d5949d309de8) cadaver: 0.26 -> 0.27
* [`3aed2ac7`](https://github.com/NixOS/nixpkgs/commit/3aed2ac768c72c0041b8b0b006a6e4c1554d0416) nixos/installation-cd-base: fix installer expecting LUKS devices
* [`a52c8650`](https://github.com/NixOS/nixpkgs/commit/a52c86509bc5f5bbdb1546c8d58ebdcab6b00aee) maintainers: add bohanubis
* [`daee60c9`](https://github.com/NixOS/nixpkgs/commit/daee60c911eb656975da791e465e192b668e7589) stalwart-mail: fix 16 KB page size on ARM systems
* [`df7b7181`](https://github.com/NixOS/nixpkgs/commit/df7b71810f398785fcf753f638cd6c6cbc5366ca) factorio: 2.0.55 -> 2.0.60
* [`b0fc2fe5`](https://github.com/NixOS/nixpkgs/commit/b0fc2fe5936de1483ff92998d5450d75d54d2ff5) lesspipe: 2.18 -> 2.19
* [`bbb90656`](https://github.com/NixOS/nixpkgs/commit/bbb906562db368f74c509470e419bf0ac41f3159) mopidy-listenbrainz: init 0.3.0
* [`c76fa2a8`](https://github.com/NixOS/nixpkgs/commit/c76fa2a8153034b61d6efc81a66faf62cb7c1f0c) figma-agent: 0.3.2 -> 0.3.2-unstable-2024-11-16
* [`a867e7f5`](https://github.com/NixOS/nixpkgs/commit/a867e7f50d9f373997217a1b5caf64e5442bdd37) python3Packages.pygame-sdl2: 8.3.7.25031702 -> 8.4.0.25071206
* [`e35652e0`](https://github.com/NixOS/nixpkgs/commit/e35652e06637cda0f40fd8da1e194480fe5255b7) freeciv: 3.1.5 -> 3.2.0
* [`14de5eff`](https://github.com/NixOS/nixpkgs/commit/14de5eff5a34d19ed63d9dd9b00eb173dc9ec2cb) converseen: 0.14.0.0 -> 0.15.0.2
* [`2d7b6afa`](https://github.com/NixOS/nixpkgs/commit/2d7b6afac6eace12647ae9df9e35d3613d82db34) wxsqlite3: 4.10.9 -> 4.10.11
* [`86337846`](https://github.com/NixOS/nixpkgs/commit/86337846bdc84d5d896a9953a556ccd8a6a4d71d) sysdig-cli-scanner: 1.22.4 -> 1.22.5
* [`9e962f2c`](https://github.com/NixOS/nixpkgs/commit/9e962f2ce1ee4e843c97745243e1ecce848716d7) ddev: 1.24.6 -> 1.24.7
* [`21844eb6`](https://github.com/NixOS/nixpkgs/commit/21844eb65937c33e2b0e608e217bc8f66e9e1dab) gauge-unwrapped: 1.6.18 -> 1.6.19
* [`72db7a82`](https://github.com/NixOS/nixpkgs/commit/72db7a828d470dde2117505b1e335a5810020210) tartube-yt-dlp: 2.5.100 -> 2.5.156
* [`b0e42ddc`](https://github.com/NixOS/nixpkgs/commit/b0e42ddced78aa66a23e466a2f369e183a57c18e) docs/factor: fixup Factor docs referencing correct vocab root name
* [`f5055e80`](https://github.com/NixOS/nixpkgs/commit/f5055e80c36a84e217613dea5fb122a26774310b) svelte-language-server: 0.17.16 -> 0.17.17
* [`012b3276`](https://github.com/NixOS/nixpkgs/commit/012b3276b38ad6d54fcdf523c327080be628269d) cloudlog: 2.6.19 -> 2.6.20
* [`f32ab6f2`](https://github.com/NixOS/nixpkgs/commit/f32ab6f2bfbaf507243e19f5254c5c86651b9263) hevea: 2.36 -> 2.37
* [`fe9d86b7`](https://github.com/NixOS/nixpkgs/commit/fe9d86b713153501ed715b4cdf2daa77fe4e9672) qtractor: 1.5.6 -> 1.5.7
* [`b29f43d9`](https://github.com/NixOS/nixpkgs/commit/b29f43d9cd25ecb93b580ae3c50233ba6a8dcdc8) dracula-theme: 4.0.0-unstable-2025-06-11 -> 4.0.0-unstable-2025-07-17
* [`1f24b23b`](https://github.com/NixOS/nixpkgs/commit/1f24b23b22dea1b13fc3d72128de38e8d6f1af1b) marp-cli: 4.2.0 -> 4.2.1
* [`5b38c743`](https://github.com/NixOS/nixpkgs/commit/5b38c7435fb1112a8b36b1652286996a7998c5b5) open-webui: 0.6.16 -> 0.6.18
* [`2e16d703`](https://github.com/NixOS/nixpkgs/commit/2e16d7034a6d90bb6b153859d043623cabbbe605) homebox: 0.19.0 -> 0.20.0
* [`0903c120`](https://github.com/NixOS/nixpkgs/commit/0903c1205787e0699523eef288a41cea15d3e3a1) homebox: 0.20.1 -> 0.20.2
* [`b7e9deef`](https://github.com/NixOS/nixpkgs/commit/b7e9deef02bb5ed3db614d42263da3bb1fcd1eac) homebox: bugfix -> version expects v as it is actually a tag
* [`c90112d3`](https://github.com/NixOS/nixpkgs/commit/c90112d30421d5037860f61567a1d3781ca3f936) homebox: add tebriel as maintainer
* [`76f768a3`](https://github.com/NixOS/nixpkgs/commit/76f768a360dafc0189b6240675bebb36abc291ba) x11_ssh_askpass: replace xmkmf with autoconf
* [`ed9b5119`](https://github.com/NixOS/nixpkgs/commit/ed9b5119c4dbdc714de0125b73eb575d9371a2fa) termius: 9.25.1 -> 9.26.0
* [`5e872a49`](https://github.com/NixOS/nixpkgs/commit/5e872a497448f8c03d13a45996de60afa27da013) nixos/wrappers: explicitly set RestrictSUIDSGID = false
* [`248c463f`](https://github.com/NixOS/nixpkgs/commit/248c463f69c5779342dc8b7e1b893b50598128a8) nixos/tmpfiles: explicitly set RestrictSUIDSGID = false
* [`2fa35382`](https://github.com/NixOS/nixpkgs/commit/2fa35382fcb80873fe62f762eadb28ffaa6b4619) maintainers: drop jyp
* [`af21fbd5`](https://github.com/NixOS/nixpkgs/commit/af21fbd51604cb3fe65d7f4cb926b35bd4de83b6) txr: 301 -> 302
* [`d5bd1419`](https://github.com/NixOS/nixpkgs/commit/d5bd1419fe7157e73cdd5b5baead1cb649c6a8aa) maintainers: drop arjix
* [`9c1784c4`](https://github.com/NixOS/nixpkgs/commit/9c1784c4e99340f3aced7572e7ef3f633321d284) ibmcloud-cli: 2.34.2 -> 2.35.0
* [`f5aec270`](https://github.com/NixOS/nixpkgs/commit/f5aec270fb433ea953c60e571da8ae691c5bd69e) igir: add mjm as maintainer
* [`6d8bc6e0`](https://github.com/NixOS/nixpkgs/commit/6d8bc6e0f6ef359e34c227762db15abff87635fc) brewtarget: 4.1.2 -> 4.1.3
* [`b38cf32e`](https://github.com/NixOS/nixpkgs/commit/b38cf32e0f986526bc263dd8178ed9fc408f41a3) vscode-extension-update: Fix usage of experimental Nix features
* [`8234d896`](https://github.com/NixOS/nixpkgs/commit/8234d8967021a93a6e4fc54ea8115dfd804c8d2b) madonctl: 2.3.2 -> 3.0.3
* [`7f531561`](https://github.com/NixOS/nixpkgs/commit/7f53156148e9eb5868a1467fb1cd1c8f63108494) hunspellDictsChromium: add sv_SE
* [`43f536e5`](https://github.com/NixOS/nixpkgs/commit/43f536e5b3250efb92d85cce96360606adf61f3d) hunspellDictsChromium: expose mkDictFromChromium
* [`6e57a010`](https://github.com/NixOS/nixpkgs/commit/6e57a010e1e23e65063f4f6ca82bd97065876818) wolfssl: 5.7.6 -> 5.8.2
* [`05df896b`](https://github.com/NixOS/nixpkgs/commit/05df896b8d40067852bae8ccc86346a2053889f1) tuned: init at 2.25.1
* [`cc31439e`](https://github.com/NixOS/nixpkgs/commit/cc31439edcb873e1b4fbd7727df880190830a59a) orbvis: init at 0.3.2
* [`248ba42e`](https://github.com/NixOS/nixpkgs/commit/248ba42e80d73169fb5029bbea5bebf98b19926a) oci2git: 0.2.0 -> 0.2.1
* [`81cd6de5`](https://github.com/NixOS/nixpkgs/commit/81cd6de5c8a95da21af087b366c5e53c3681d8e6) keycloak.plugins.keycloak-restrict-client-auth: 24.0.0 -> 26.1.0
* [`7a1df610`](https://github.com/NixOS/nixpkgs/commit/7a1df610a905a7d0f8621aa859ccd1e2555b8f4c) vscode-extensions.wgsl-analyzer.wgsl-analyzer: init at 0.10.178
* [`608d1ce6`](https://github.com/NixOS/nixpkgs/commit/608d1ce62b537851c4bccb3d69200c2019524169) mealie: 2.8.0 -> 3.0.1
* [`3cd4cce6`](https://github.com/NixOS/nixpkgs/commit/3cd4cce6a7d9d585925f02b24e4244cb0517088e) fixup, add release notes
* [`2b4cdabe`](https://github.com/NixOS/nixpkgs/commit/2b4cdabe6716b830c3759e09167ba821ebe92a8f) format
* [`f0526a89`](https://github.com/NixOS/nixpkgs/commit/f0526a8986433c08e60b66263870bab2829ab9f8) papilo: 2.4.2 -> 2.4.3
* [`67f33a07`](https://github.com/NixOS/nixpkgs/commit/67f33a0738a43d0745044bc06722c9aa0a650570) beeper: 4.0.821 -> 4.1.1
* [`5545fa18`](https://github.com/NixOS/nixpkgs/commit/5545fa182780d112d423e5627b8d951b2b40c372) wolfssl: disable tests on loongarch64
* [`3c677d47`](https://github.com/NixOS/nixpkgs/commit/3c677d4754405c2607295bc244e815f507aab1ee) apr: unpin autotools
* [`5db41209`](https://github.com/NixOS/nixpkgs/commit/5db41209e37b1cb64077c4fb037fa475e4a6fce4) postgresqlPackages.timescaledb-apache: 2.21.0 -> 2.21.1
* [`05f3a735`](https://github.com/NixOS/nixpkgs/commit/05f3a735a0be3fbc15bb9bf8259abf5156ae9520) free42: 3.3.6 -> 3.3.8
* [`919f5400`](https://github.com/NixOS/nixpkgs/commit/919f5400729f717e87674b922a7e7fb2bf224fdd) vectorscan: 5.4.11 -> 5.4.12
* [`1e3e107f`](https://github.com/NixOS/nixpkgs/commit/1e3e107fb7df82a6c00e9cb929fdf1cfc1853af6) electron-fiddle: 0.36.6 -> 0.36.6-unstable-2025-07-17, bump electron
* [`e9cc071e`](https://github.com/NixOS/nixpkgs/commit/e9cc071eb53b18b9ea925f3461e44337049ce83e) jellyseerr: 2.7.0 -> 2.7.2
* [`9127e920`](https://github.com/NixOS/nixpkgs/commit/9127e920e39057b37c89d8061ff8769c1acbc530) upcloud-cli: 3.20.2 -> 3.21.0
* [`531ddd0a`](https://github.com/NixOS/nixpkgs/commit/531ddd0ad96b17fd3fdb6c058a0b256f82bf57ce) angie: 1.9.1 -> 1.10.1
* [`ee7377d5`](https://github.com/NixOS/nixpkgs/commit/ee7377d5d96019946d53b601279be873180f7e34) qgis-ltr: 3.40.8 -> 3.40.9
* [`8be3373a`](https://github.com/NixOS/nixpkgs/commit/8be3373abb60373d8ea6857ead72537709375633) qgis: 3.44.0 -> 3.44.1
* [`ce7d03b8`](https://github.com/NixOS/nixpkgs/commit/ce7d03b8b70bcfacc1d7c7d40170aeae585b1348) aws-lc: 1.55.0 -> 1.56.0
* [`547a2646`](https://github.com/NixOS/nixpkgs/commit/547a264671ae2ee7b35a08fd1636fac493920e96) nixos/meilisearch: harden
* [`134cc129`](https://github.com/NixOS/nixpkgs/commit/134cc129b3083f8fe0c4527f51340c214e477346) cross-seed: 6.11.1 -> 6.13.1
* [`5f3351d8`](https://github.com/NixOS/nixpkgs/commit/5f3351d86e3a18357ccbd618a58c4370e7376389) Update to 3.0.2
* [`b91c6a1c`](https://github.com/NixOS/nixpkgs/commit/b91c6a1cd6c9a15c05493d210084bb7842c45840) hyprshade: 3.2.1 -> 4.0.0
* [`4a0b6962`](https://github.com/NixOS/nixpkgs/commit/4a0b69624cd27a6a69d1f09cad24c6e098d4db7a) schemacrawler: 16.26.2 -> 16.26.3
* [`73495435`](https://github.com/NixOS/nixpkgs/commit/734954354e55b0ea3eac4f26556221fabdbfb313) schroedinger: unpin autotools
* [`a6cdf3f0`](https://github.com/NixOS/nixpkgs/commit/a6cdf3f0f059f594dc3bf18647938423aa4a18aa) Add API tests for mealie
* [`badcde89`](https://github.com/NixOS/nixpkgs/commit/badcde8977e6c9a068a17bf8a670d4368a213962) Update documentation to 3.0.2
* [`f5650227`](https://github.com/NixOS/nixpkgs/commit/f5650227261c6aea3b1b23ca05001c57bd6d226a) stunner-webrtc: init at 0.5.8
* [`25cfd534`](https://github.com/NixOS/nixpkgs/commit/25cfd534c432f57751a19b40bc2eb9ae71e49af8) aws-lc: fix tests in sandboxed darwin
* [`8e7760c8`](https://github.com/NixOS/nixpkgs/commit/8e7760c8715654c0b0dcc5a066f719d2d107ec2f) redis-plus-plus: 1.3.14 -> 1.3.15
* [`cf113828`](https://github.com/NixOS/nixpkgs/commit/cf113828ccb314c219dd67969de28114c68c1769) go-httpbin: init at 2.18.3
* [`224dc30d`](https://github.com/NixOS/nixpkgs/commit/224dc30d39666971172f070541145ac865e35e89) nixos/go-httpbin: init module
* [`e1b8c6c4`](https://github.com/NixOS/nixpkgs/commit/e1b8c6c49379913cf22cbcabd9a0d0dade2cfa03) nixos/tests/go-httpbin: init
* [`1e20a508`](https://github.com/NixOS/nixpkgs/commit/1e20a5082396cace9e9beca3adbe60347b18b00f) maintainers: add guilhermenl
* [`6bbd27a4`](https://github.com/NixOS/nixpkgs/commit/6bbd27a458bfbed76c3b8c1498dc4c8889ffa3ce) go-ios: 1.0.180 -> 1.0.182
* [`0657e565`](https://github.com/NixOS/nixpkgs/commit/0657e56507c6d1171345b80ef4459bfb5f5c1bb5) diamond: 2.1.12 -> 2.1.13
* [`b799b52c`](https://github.com/NixOS/nixpkgs/commit/b799b52c0f6d3f1f4fa1288e454ba4280c143b26) dbmate: 2.27.0 -> 2.28.0
* [`4b1cd91d`](https://github.com/NixOS/nixpkgs/commit/4b1cd91d4ff13b7659a1d449bfaa750fd6c7b060) storj-uplink: 1.131.7 -> 1.133.5
* [`7fbb1d87`](https://github.com/NixOS/nixpkgs/commit/7fbb1d8719b69931b8a5a444a5a67b19ad6af30b) shopify-cli: 3.82.1 -> 3.83.0
* [`1af5c109`](https://github.com/NixOS/nixpkgs/commit/1af5c109a92a5a4d2db95124e1f6f1a220fa2194) vorbis-tools: unpin autotools
* [`996ee9dc`](https://github.com/NixOS/nixpkgs/commit/996ee9dc0f62aa9896bf0319d70bdd0926f5c515) youtubeuploader: 1.25.1 -> 1.25.3
* [`54a5a0eb`](https://github.com/NixOS/nixpkgs/commit/54a5a0eb5bfa6562fb6f473794dbe2291c5d9cd4) beebeep: use stdenv mkDerivation
* [`ea771243`](https://github.com/NixOS/nixpkgs/commit/ea771243e29ada507450c7087b5de848b5632b9b) kn: 1.18.0 -> 1.19.0
* [`577bdf03`](https://github.com/NixOS/nixpkgs/commit/577bdf038350b4fbf50fba8211509e1eb104186f) kustomize: 5.7.0 -> 5.7.1
* [`1b8f52a0`](https://github.com/NixOS/nixpkgs/commit/1b8f52a0f2e8c062202b5c712fcc2c154eae75ee) grpc_cli: 1.73.0 -> 1.74.0
* [`a27e9b49`](https://github.com/NixOS/nixpkgs/commit/a27e9b49daeff6875342081c142e7d16e7b603ed) exoscale-cli: 1.85.3 -> 1.85.4
* [`570a5081`](https://github.com/NixOS/nixpkgs/commit/570a5081de3d76edc525f2ec69fe51b813d903e3) rat-king-adventure: 2.2.2 -> 2.2.3
* [`5ddb0a51`](https://github.com/NixOS/nixpkgs/commit/5ddb0a51e667ddff7e2c9979a35ae11225f81ba2) piper-{tts, train}: move to by-name
* [`05c9cbdb`](https://github.com/NixOS/nixpkgs/commit/05c9cbdbc5d7f338b2327a0ce9c6d3aa82a4efbb) xdcc-cli: init at 0.1.0
* [`4727309d`](https://github.com/NixOS/nixpkgs/commit/4727309dccdfd57da86a13b358bd8ac9ad889a35) kid3: 3.9.6 -> 3.9.7
* [`b7308ccf`](https://github.com/NixOS/nixpkgs/commit/b7308ccff6ab60b6caaf64a7f69619b40c08d1df) prctl: init at 1.7
* [`4e0a5c2b`](https://github.com/NixOS/nixpkgs/commit/4e0a5c2b25f1f83747ececf7935e1aabfffc2d7d) online-judge-verify-helper: init at 5.6.0
* [`410752a8`](https://github.com/NixOS/nixpkgs/commit/410752a882c51ad35562eb161625ffbad7c0ceaa) ntfy-sh: Add meta.mainProgram
* [`31cc9ad8`](https://github.com/NixOS/nixpkgs/commit/31cc9ad85e40a8ad1ba94b9910990bebaee85f6b) rqlite: 8.39.1 -> 8.41.0
* [`1d5ae6c5`](https://github.com/NixOS/nixpkgs/commit/1d5ae6c537d9e10fa5c2595cf40dd7aaf0b3c0c0) sitespeed-io: 37.8.0 -> 38.0.0
* [`3abf0233`](https://github.com/NixOS/nixpkgs/commit/3abf0233464fd2f32f61fbdd34dec7b15437d0a4) python3Packages.posthog: 6.1.0 -> 6.3.1
* [`933a2dd0`](https://github.com/NixOS/nixpkgs/commit/933a2dd0de4475eeebc607a46e4bd6daf4fafa74) python3Packages.pyosohotwaterapi: 1.1.5 -> 1.2.0
* [`1033ce03`](https://github.com/NixOS/nixpkgs/commit/1033ce03b4c2ca08fa0ea66c255d8ef7d6737e24) lowdown: 1.3.2 -> 2.0.2
* [`db90b279`](https://github.com/NixOS/nixpkgs/commit/db90b27976387040e64eec33146f661f5416fb10) nixVersions.nix_2_24: fix build against lowdown 2.0.2
* [`413d3444`](https://github.com/NixOS/nixpkgs/commit/413d3444bfa5aa0d8ed373541ab854b8beb8e2fd) lixPackageSets.*.lix: apply patches for lowdown >= 1.4 compat
* [`c435a6af`](https://github.com/NixOS/nixpkgs/commit/c435a6afe2c8c5a0b09bc11831df4632e0ad5812) elasticmq-server-bin: 1.6.12 -> 1.6.14
* [`d8fd3576`](https://github.com/NixOS/nixpkgs/commit/d8fd3576e9c7c315228b712a2f89ad006e87d609) igir: 2.11.0 -> 4.1.1
* [`43cabfcc`](https://github.com/NixOS/nixpkgs/commit/43cabfccc5c44d9da794f00ab2aa1578d8a206b1) ipxe: 1.21.1-unstable-2025-07-16 -> 1.21.1-unstable-2025-07-24
* [`a70d47d5`](https://github.com/NixOS/nixpkgs/commit/a70d47d59b3516341534e59c32ce419bb5118c9f) vault: 1.20.0 -> 1.20.1
* [`62da9933`](https://github.com/NixOS/nixpkgs/commit/62da9933f28139eda70adac64c52f3658cb88540) autobrr: 1.63.1 -> 1.64.0
* [`df8afd7f`](https://github.com/NixOS/nixpkgs/commit/df8afd7f48664148bb0db83ed9e4919955fff827) jhentai: 8.0.8+295 -> 8.0.9
* [`2cc1c494`](https://github.com/NixOS/nixpkgs/commit/2cc1c494f88d45c785b388582220d9864da612bc) python313Packages.qtile: 0.32.0 -> 0.33.0
* [`e39a6b19`](https://github.com/NixOS/nixpkgs/commit/e39a6b19f0d3ff95d8a42c1c7ca043be350cf5d7) python313Packages.qtile-extras: 0.32.0 -> 0.33.0
* [`1535cf9d`](https://github.com/NixOS/nixpkgs/commit/1535cf9dbf77421327e99a425634e09bdd4f25e0) cherry-studio: 1.4.8 -> 1.5.3
* [`7b1ad552`](https://github.com/NixOS/nixpkgs/commit/7b1ad552e1543f423137e819f74b03b1f2c9afe6) node-core-utils: init at 5.14.1
* [`99b93f7d`](https://github.com/NixOS/nixpkgs/commit/99b93f7d9fa9f68691ed6dab642aa922a4b3ca83) grafana: 12.0.2+security-01 -> 12.1.0
* [`89a69905`](https://github.com/NixOS/nixpkgs/commit/89a699050b488d292e04e6f66dcbc463253f0552) cloudflare-warp: 2025.5.893 -> 2025.5.943
* [`64696c5f`](https://github.com/NixOS/nixpkgs/commit/64696c5fb59b7739ef257f5c7daa7deb94ea06d1) lego: 4.23.1 -> 4.25.1
* [`d3e3d9c9`](https://github.com/NixOS/nixpkgs/commit/d3e3d9c9bf2b4605611f4dfb9d495249c86ceac2) maintainers: add szaffarano
* [`a85fdbf4`](https://github.com/NixOS/nixpkgs/commit/a85fdbf4c5a351fd6eb73f3c3443fdd198b7e70a) luaPackages: update on 2025-07-24
* [`479d59e0`](https://github.com/NixOS/nixpkgs/commit/479d59e0fa13ef2229968e2b443aa288755a80b6) ngtcp2-gnutls: 1.13.0 -> 1.14.0
* [`5ddf0050`](https://github.com/NixOS/nixpkgs/commit/5ddf00503da14844a3263bdc6750641a6616f176)  ticktick: 6.0.30 -> 6.0.40
* [`d44ee7c7`](https://github.com/NixOS/nixpkgs/commit/d44ee7c738886ea508e607269ccc9558180937ad) appdaemon: 4.4.2 -> 4.5.11
* [`80889d91`](https://github.com/NixOS/nixpkgs/commit/80889d91b8185425b327184cfbd8237b93c02ff0) kanshi: 1.7.0 -> 1.8.0
* [`8af1e1b6`](https://github.com/NixOS/nixpkgs/commit/8af1e1b6b2c9581c9b417472da0d29832c316458) kanshi: add aleksana to maintainers
* [`e9172282`](https://github.com/NixOS/nixpkgs/commit/e9172282fda667dcb055b1a2bd5036174a2413ca) scalingo: 1.35.1 -> 1.36.0
* [`966957b5`](https://github.com/NixOS/nixpkgs/commit/966957b5d26957849fd8dc3f6a52bf17d4920484) python3Packages.openai: 1.97.0 -> 1.97.1
* [`cb834222`](https://github.com/NixOS/nixpkgs/commit/cb8342229dd839da480cc7cb018a6a73a971fe27) suitesparse-graphblas: 10.1.0 -> 10.1.1
* [`d1815fee`](https://github.com/NixOS/nixpkgs/commit/d1815feee49cfcc40323671724197ec3e153232f) python313Packages.pyosohotwaterapi: clean-up
* [`fb8cc934`](https://github.com/NixOS/nixpkgs/commit/fb8cc934ee6633d98de0931b5cb6b01d32407024) libation: 12.3.1 -> 12.4.9, add updateScript
* [`330b2e10`](https://github.com/NixOS/nixpkgs/commit/330b2e1041966624a60e736bfa09c64acf940e1d) binaryninja-free: 5.0.7648 -> 5.1.8005
* [`5c69af23`](https://github.com/NixOS/nixpkgs/commit/5c69af230ba1184c880a53c772167e5c1d0542d0) python3Packages.pystac-client: 0.8.6 → 0.9.0
* [`0c3d1429`](https://github.com/NixOS/nixpkgs/commit/0c3d14291f91b2b21b5d4c7583b9cd415a9748f9) kodiPackages.radioparadise: 2.1.2 -> 2.2.0
* [`af0579be`](https://github.com/NixOS/nixpkgs/commit/af0579be82c3c7ab4aa8ccc189cbbdf45262fae7) python3Packages.cysignals: 1.12.3 -> 1.12.4
* [`ef746fa5`](https://github.com/NixOS/nixpkgs/commit/ef746fa55742daa3ef3974c422e4505b7e7ad07f) xtf: 0-unstable-2025-05-19 -> 0-unstable-2025-07-24
* [`3f5d7d41`](https://github.com/NixOS/nixpkgs/commit/3f5d7d413434f815598485ef94d794dfe65069c0) python3Packages.netbox-reorder-rack: 1.1.3 -> 1.1.4
* [`2d5c4468`](https://github.com/NixOS/nixpkgs/commit/2d5c4468526b760a72b6bec9c8837faf195ba2f8) kodiPackages.controller-topology-project: 1.0.3 -> 1.0.4
* [`247ca114`](https://github.com/NixOS/nixpkgs/commit/247ca114b220731c83120e2c9861b0bd21125f73) ghdl: 5.0.1 -> 5.1.1
* [`15ed1420`](https://github.com/NixOS/nixpkgs/commit/15ed1420f9506eebe28ee9ee113c2df636949d66) yosys-ghdl: 2022.01.11 -> 0-unstable-2025-05-23
* [`47498b82`](https://github.com/NixOS/nixpkgs/commit/47498b82b4648f9413021ca8ea3c5fca8f50e743) redux: 1.3.5 -> 1.4.1
* [`2c39b81d`](https://github.com/NixOS/nixpkgs/commit/2c39b81d7a0b4331f78a533a4eea2978005b0891) terraform-local: 0.24.0 -> 0.24.1
* [`041c3c56`](https://github.com/NixOS/nixpkgs/commit/041c3c5622ec4b72107c2cea5c7eef5dfc54c9c2) cc2538-bsl: 2.1-unstable-2025-01-14 -> 2.1-unstable-2025-03-28
* [`a76501f2`](https://github.com/NixOS/nixpkgs/commit/a76501f2074499e55f5b3e2db6bf1e48d9f2d5ad) python3Packages.lightning-utilities: 0.14.3 -> 0.15.0
* [`beffdea9`](https://github.com/NixOS/nixpkgs/commit/beffdea9ee3f00c0160831878579cefb72425820) lug-helper: 4.1 -> 4.2
* [`3742a725`](https://github.com/NixOS/nixpkgs/commit/3742a725a69d6cf87427145e21a5bcff1c8e9309) systemd: Detect ELF ABI version for bpf build on powerpc64
* [`e62971b0`](https://github.com/NixOS/nixpkgs/commit/e62971b005f2b85bdc72a5e810120ac7b135e87f) nixos/nginx: sync with Mozilla Intermediate TLS configuration
* [`15e1ff1b`](https://github.com/NixOS/nixpkgs/commit/15e1ff1b349f6ceb7e8dd0f1c8035d3979524838) yandex-music: 5.57.0 -> 5.61.1
* [`4261815f`](https://github.com/NixOS/nixpkgs/commit/4261815f5c6861dbe196e7ac6ba5f43610b8b7c3) slushload: init at 3
* [`15e8c2a2`](https://github.com/NixOS/nixpkgs/commit/15e8c2a2f2d222a50c23f9fdfcea5ca27637bba1) cjdns: 21.4 -> 22.1
* [`c10e91b0`](https://github.com/NixOS/nixpkgs/commit/c10e91b0f84097df635a8cc7ae173f6c754e76d6) chatterino7: unpin boost
* [`14714421`](https://github.com/NixOS/nixpkgs/commit/14714421da278f0c6eefa1b7d3a4c0ba900102ba) qtgreet: 2.0.3.95 -> 2.0.4
* [`3137848e`](https://github.com/NixOS/nixpkgs/commit/3137848e7529ad563fc402fe6bcf84f969bbd374) q2pro: 0-unstable-2025-05-03 -> 0-unstable-2025-07-21
* [`eb4af751`](https://github.com/NixOS/nixpkgs/commit/eb4af751b3af8ff7ed8d6f1959f26c6fb76b9945) kubernetes: move to by-name
* [`5d06cce5`](https://github.com/NixOS/nixpkgs/commit/5d06cce58c3acfde5e889d88a8bc7851aa979049) kubectl: move to by-name
* [`04eefc0c`](https://github.com/NixOS/nixpkgs/commit/04eefc0c3a855a1181815acea96af244e5a8aef8) go-jsonschema: init at 0.20.0
* [`58def163`](https://github.com/NixOS/nixpkgs/commit/58def163c0d1e98f5ab10485d0741c9adbc4de2e) nixos/nextcloud: fix eval
* [`83bc8f05`](https://github.com/NixOS/nixpkgs/commit/83bc8f05d912e700f94a238ab1a1126b40a581d4) edgetx: 2.11.0-rc3 -> 2.11.2
* [`19f88ab5`](https://github.com/NixOS/nixpkgs/commit/19f88ab5f08f0738fbec21cf90f1b3a438977fde) maintainers: drop dan4ik605743
* [`904f08d5`](https://github.com/NixOS/nixpkgs/commit/904f08d5e4a518968429c15d81a7c310367b9ef7) maintainers: add tbaldwin
* [`86b6ce2d`](https://github.com/NixOS/nixpkgs/commit/86b6ce2d5c33a3c21d9015b0332b7798c1ecc0e8) scuba: init at 2.14.0
* [`eb50ba87`](https://github.com/NixOS/nixpkgs/commit/eb50ba873a50bbcc453890d1e4671c6646d85acc) carapace: 1.3.3 -> 1.4.1
* [`06c34b00`](https://github.com/NixOS/nixpkgs/commit/06c34b005f1cb5c3bf850459da0371629e6ecd4f) wakatime-cli: 1.118.0 -> 1.124.1
* [`222178f5`](https://github.com/NixOS/nixpkgs/commit/222178f5b2c6c9926137855a36373e942ac14ab3) mozillavpn: 2.29.0 → 2.30.0
* [`e422223c`](https://github.com/NixOS/nixpkgs/commit/e422223c767e22ac8f01bfe5c1ad47a0fd3ee36e) jdd: 0.4.3 -> 0.4.4
* [`de6d1e2d`](https://github.com/NixOS/nixpkgs/commit/de6d1e2d427b0ca064bf61dd145d0ad46e59bf4e) gdevelop: 5.5.237 -> 5.5.238
* [`a85eaf31`](https://github.com/NixOS/nixpkgs/commit/a85eaf31c29bffc3d482014f94fd038409a793e8) build-support/php: let `vendorHash` be overridden correctly
* [`162204c4`](https://github.com/NixOS/nixpkgs/commit/162204c48ec5a94e2ed01b74136bda33f8dd86ac) sunshine: use finalAttrs
* [`60e9ad10`](https://github.com/NixOS/nixpkgs/commit/60e9ad1028ba1f65d32be64f0d1f6e2b9fbd3f69) sunshine: remove with lib
* [`5e3fcc12`](https://github.com/NixOS/nixpkgs/commit/5e3fcc12935c2e74de4e8a517808e78fc817244c) sunshine: refactor
* [`095f69f1`](https://github.com/NixOS/nixpkgs/commit/095f69f1d9c9d64faec9a86830ae178e5c2ede14) jfrog-cli: 2.77.0 -> 2.78.1
* [`cf9b6c1e`](https://github.com/NixOS/nixpkgs/commit/cf9b6c1e2a154f14161afb9c381ed71a3755fe45) sunshine: update updater.sh
* [`39772184`](https://github.com/NixOS/nixpkgs/commit/39772184cc545f20961c7c2edf1d6cea589510ab) sunshine: sort
* [`27128e1c`](https://github.com/NixOS/nixpkgs/commit/27128e1cbc40886c7efde1e62716aa4485a35e54) maintainers: drop `anatolypopov`
* [`4c0485bf`](https://github.com/NixOS/nixpkgs/commit/4c0485bf6bda8144587cd305fa7c425baed43df6) kodiPackages.jurialmunkey: 0.2.28 -> 0.2.29
* [`76f7114f`](https://github.com/NixOS/nixpkgs/commit/76f7114f70054cc8b1fc1b42f195f81d3efed9ae) zeek: 7.2.1 -> 7.2.2
* [`91524d13`](https://github.com/NixOS/nixpkgs/commit/91524d133088739f9573e97f88b326f1fe004f5f) corsix-th: 0.68.0 -> 0.69.0
* [`e1391ef1`](https://github.com/NixOS/nixpkgs/commit/e1391ef11b6b2b59162cca4498c74f54e60a34d5) python3Packages.webtest-aiohttp: add aiohttp to dependencies
* [`cc298902`](https://github.com/NixOS/nixpkgs/commit/cc29890289151099720eb769ae536d6f8fb7900f) signal-export: 3.6.0 -> 3.7.0
* [`3dcd2027`](https://github.com/NixOS/nixpkgs/commit/3dcd2027b438798ee2665b177f9f00070fdb74e5) umu-launcher: don't die with parent
* [`e26067cc`](https://github.com/NixOS/nixpkgs/commit/e26067cc621f74f3c1b25224b0afe3d799eb2dc6) python3Packages.xdis: 6.1.4 -> 6.1.5
* [`fa9dec15`](https://github.com/NixOS/nixpkgs/commit/fa9dec157bd27c810c31c311c89f35e024fc9833) python3Packages.langchain-deepseek: 0.1.3 -> 0.1.4
* [`7084774c`](https://github.com/NixOS/nixpkgs/commit/7084774c15b902265bd0341aa5b469c1922468c4) python3Packages.msgraph-sdk: 1.38.0 -> 1.39.0
* [`0e4c2ded`](https://github.com/NixOS/nixpkgs/commit/0e4c2dedd6f62ff8cadf2573efe26e6d15dca6a8) ruffle: 0-nightly-2025-07-19 -> 0-nightly-2025-07-27
* [`dedf852c`](https://github.com/NixOS/nixpkgs/commit/dedf852ccd920c9ea2f8efc879d2fb504c19a325) nixos/systemd-boot: refactor json.load() logic for better error message
* [`2973d1d5`](https://github.com/NixOS/nixpkgs/commit/2973d1d5675b1fcd3bcefa9660d5b86856580c77) webfontkitgenerator: 1.2.0 -> 1.3.0
* [`55432fae`](https://github.com/NixOS/nixpkgs/commit/55432fae0e465683ea71bc18bd43334471ca0e0f) steam: refactor and expose fhsenv building
* [`bcc93336`](https://github.com/NixOS/nixpkgs/commit/bcc93336cb6cab56ae758bdee3dff4b1691da893) heroic: use steam.buildRuntimeEnv
* [`3f94560d`](https://github.com/NixOS/nixpkgs/commit/3f94560d867213e66db219417d906e4790387823) umu-launcher: use steam.buildRuntimeEnv
* [`246199e4`](https://github.com/NixOS/nixpkgs/commit/246199e41161f534cfcc558f7f0cde92633bb121) buildFHSEnv: skip other fhsenvs for includeClosures
* [`c259a15f`](https://github.com/NixOS/nixpkgs/commit/c259a15f704fbd7f011a4dd5324d83798f8d0545) buildFHSEnv: clippy
* [`f56f3839`](https://github.com/NixOS/nixpkgs/commit/f56f383983d1b5c32a0340b12b4cb5a50d737de3) buildFHSEnv: update deps
* [`6cc44487`](https://github.com/NixOS/nixpkgs/commit/6cc44487a6b863b0badc15eba2fbd14f91a8ce30) heroic: always pull in our umu-launcher
* [`dcdb8fed`](https://github.com/NixOS/nixpkgs/commit/dcdb8fed6917b9f926b6a21ef3c20f915c95f3dc) brev-cli: 0.6.311 -> 0.6.312
* [`44eabba4`](https://github.com/NixOS/nixpkgs/commit/44eabba4971a9627887271a750bc5c152907325d) maintainers: add pascalj
* [`8d98d122`](https://github.com/NixOS/nixpkgs/commit/8d98d1229bc1f0ddcbdec03a294d1ed7ce520ef0) chatbox: 1.15.0 -> 1.15.2
* [`41962288`](https://github.com/NixOS/nixpkgs/commit/419622880a89aa83c8f2fe108611b08573564a64) open-policy-agent: skip test too dependent on go version
* [`cfb99f1c`](https://github.com/NixOS/nixpkgs/commit/cfb99f1c895b6999f2e77cb088882a499f3006c3) zsign: init at 0.7
* [`7476494b`](https://github.com/NixOS/nixpkgs/commit/7476494b3b16a4861035ef4a876d47050b7f1505) nixos/cjdns: update for cjdns 22.1 compatibility
* [`0639f762`](https://github.com/NixOS/nixpkgs/commit/0639f762d9ddff0032975235dff17f89a2a17006) cjdns: remove usage of with lib
* [`4b5c5664`](https://github.com/NixOS/nixpkgs/commit/4b5c5664cc66ff707cb09431d00ad528cc85950f) cjdns: enable darwin support
* [`ac71292a`](https://github.com/NixOS/nixpkgs/commit/ac71292aa1deb1df1914029f45b1321d647da21a) cjdns-tools: enable darwin support
* [`72626fff`](https://github.com/NixOS/nixpkgs/commit/72626fff03ab539951e0f0855acac2cad232c477) cjdns-tools: remove usage of with lib
* [`b5ccf171`](https://github.com/NixOS/nixpkgs/commit/b5ccf171ae55c250f51ab063ca971806c5e493ec) affine: 0.22.4 -> 0.23.2
* [`ce76beed`](https://github.com/NixOS/nixpkgs/commit/ce76beed2fd00a240e6d32d4d9a2704e22b2d6fa) jbrowse: 3.6.3 -> 3.6.4
* [`306809c3`](https://github.com/NixOS/nixpkgs/commit/306809c3baf5c7523f572f65cbc5910d8ced8761) python3Packages.langchain-ollama: 0.3.5 -> 0.3.6
* [`daa91693`](https://github.com/NixOS/nixpkgs/commit/daa91693b974ba3d24bdc35c5d1ddd56e540e51f) python313Packages.publicsuffixlist: 1.0.2.20250719 -> 1.0.2.20250724
* [`4ae348e2`](https://github.com/NixOS/nixpkgs/commit/4ae348e2d1bcead0263669bad85451fac22401ac) tigerbeetle: 0.16.50 -> 0.16.51
* [`d86254d4`](https://github.com/NixOS/nixpkgs/commit/d86254d4683e628e74ecded8bcc18d3540d5327a) python312Packages.mypy-boto3-appintegrations: 1.39.0 -> 1.39.14
* [`949affc6`](https://github.com/NixOS/nixpkgs/commit/949affc63806f33145b950fdc365652168a8033c) python312Packages.mypy-boto3-budgets: 1.39.0 -> 1.39.14
* [`1f000184`](https://github.com/NixOS/nixpkgs/commit/1f0001844c19766c7267c2a9da2eef4a44411d68) python312Packages.mypy-boto3-config: 1.39.0 -> 1.39.14
* [`5752f85a`](https://github.com/NixOS/nixpkgs/commit/5752f85aa4484fc9cacab7fabdb8fc3afb3b59b6) python312Packages.mypy-boto3-ec2: 1.39.10 -> 1.39.14
* [`0426824a`](https://github.com/NixOS/nixpkgs/commit/0426824ade486929889e9349a674505fecd3b6b4) python312Packages.mypy-boto3-glue: 1.39.7 -> 1.39.12
* [`f1e3c237`](https://github.com/NixOS/nixpkgs/commit/f1e3c237136526c28e04082f66f0398844c0e761) python312Packages.mypy-boto3-kms: 1.39.0 -> 1.39.14
* [`39097907`](https://github.com/NixOS/nixpkgs/commit/390979072be4e686268e01cedc3323f58708a82a) python312Packages.mypy-boto3-mediapackagev2: 1.39.7 -> 1.39.14
* [`c6de65ca`](https://github.com/NixOS/nixpkgs/commit/c6de65ca1f947866059c15a7e1a139a2f8f602ec) python312Packages.mypy-boto3-omics: 1.39.0 -> 1.39.13
* [`781572b2`](https://github.com/NixOS/nixpkgs/commit/781572b236e0de7ff96e0f41dbe60a5f81a50e2e) python312Packages.mypy-boto3-sqs: 1.39.0 -> 1.39.14
* [`4ace4850`](https://github.com/NixOS/nixpkgs/commit/4ace4850b3bcd933c5717d48d748f1db55d431f8) python313Packages.boto3-stubs: 1.39.11 -> 1.39.14
* [`28db0bbb`](https://github.com/NixOS/nixpkgs/commit/28db0bbb72f3c32bb75b993db3c2d766afc1321e) oci-cli: 3.62.2 -> 3.63.0
* [`a34f00fe`](https://github.com/NixOS/nixpkgs/commit/a34f00feb107fc87a33bc5ee982d0a33d2510498) vectorcode: use makeWrapperArgs to prefix PYTHONPATH
* [`8800a2f5`](https://github.com/NixOS/nixpkgs/commit/8800a2f531d4c96df11e9ecbaba4872bf1c91539) terraform-providers.google: 6.44.0 -> 6.45.0
* [`201da458`](https://github.com/NixOS/nixpkgs/commit/201da4580bfbac40931dc51b41727c7a00fe82a9) diffoscope: 301 -> 302
* [`34f9932c`](https://github.com/NixOS/nixpkgs/commit/34f9932c8d9c15d86e1f2e5c1f3234018e6ebb10) tscli: 0.0.13 -> 0.0.15
* [`6734b696`](https://github.com/NixOS/nixpkgs/commit/6734b696a580142679b7ff958453bba4ab887837) webfontkitgenerator: rename to webfont-bundler
* [`dc07ea2a`](https://github.com/NixOS/nixpkgs/commit/dc07ea2a1d69fdc95c2824916ffed2439cbba719) python3Packages.msrplib: init at 0.20.1-unstable-2021-06-01
* [`89685f0a`](https://github.com/NixOS/nixpkgs/commit/89685f0a0cfe0bcd61caa2cd948eb0205f935794) xcrawl3r: 1.0.0 -> 1.1.0
* [`d179728f`](https://github.com/NixOS/nixpkgs/commit/d179728f9a408cb3a85cffccd325f1c3e220476e) xsubfind3r: 1.0.0 -> 1.1.0
* [`3084dc1a`](https://github.com/NixOS/nixpkgs/commit/3084dc1a0077c28fc2a6d5eead53e05a315d1e14) python3Packages.xcaplib: init at 2.0.1-unstable-2025-03-20
* [`9303e05a`](https://github.com/NixOS/nixpkgs/commit/9303e05a44fb60a6ac06437fd909f44b220aee1b) jikken: add version-regex to updateScript
* [`7711d6d5`](https://github.com/NixOS/nixpkgs/commit/7711d6d5a0b732448b5431565f52c0a80bdac0c9) tinystatus: use finalAttrs
* [`329dc91a`](https://github.com/NixOS/nixpkgs/commit/329dc91add31ae30b4754248d752a44430e1b494) tinystatus: remove with lib
* [`d82eb97c`](https://github.com/NixOS/nixpkgs/commit/d82eb97c111b8b2debc319a4cd94c49d69a06814) tinystatus: add preInstallCheck and postInstallCheck and remove runtimeInputs
* [`c46d1ce2`](https://github.com/NixOS/nixpkgs/commit/c46d1ce27e3341fad31c4b9f03b999618ad82300) tinystatus: sort
* [`6db08993`](https://github.com/NixOS/nixpkgs/commit/6db0899396b692bfa9b38f012f85d159f91d0b3e) tinystatus: 0-unstable-2021-07-09 -> 0-unstable-2025-03-27
* [`edec20fa`](https://github.com/NixOS/nixpkgs/commit/edec20fa2638533e645161a5b07c632f8c5c63d5) usbguard: unpin protobuf_29
* [`5e941fed`](https://github.com/NixOS/nixpkgs/commit/5e941fed6e25bf4f46b1eb9b9ecd6d5a125da12d) bpfilter: 0.4.0 -> 0.5.2
* [`63dcaabc`](https://github.com/NixOS/nixpkgs/commit/63dcaabc15023c52a519b86bd41a42d276cd28cb) ocamlPackages.pure-html: 3.11.0 -> 3.11.1
* [`73f350ac`](https://github.com/NixOS/nixpkgs/commit/73f350ac3c7309ce69000356281c118d99fa8122) nzbhydra2: 7.15.3 -> 7.16.0
* [`ea5608d8`](https://github.com/NixOS/nixpkgs/commit/ea5608d8251637569ceeae1645e1c7ce7eb9f19e) usbguard: cleanup
* [`caac0b38`](https://github.com/NixOS/nixpkgs/commit/caac0b38589d2f53851500777b54c193d2191deb) cnspec: 11.63.0 -> 11.64.0
* [`d1c6d00c`](https://github.com/NixOS/nixpkgs/commit/d1c6d00c2ab1f34744ed86aa83e23a242b8ddd52) python313Packages.python-join-api: init at 0.0.9
* [`aa3ccb51`](https://github.com/NixOS/nixpkgs/commit/aa3ccb51b4b0d04107449cc71706089e4b7f26c8) home-assistant: update component packages
* [`5e84f4cb`](https://github.com/NixOS/nixpkgs/commit/5e84f4cb0f45b93d61e63d4ad8fe3624b05c6d0c) python313Packages.pymonoprice: init at 0.5
* [`19de23bc`](https://github.com/NixOS/nixpkgs/commit/19de23bc7fb9ce67908e4ac6d4d7b8e0db33b19c) home-assistant: update component packages
* [`74bb1e77`](https://github.com/NixOS/nixpkgs/commit/74bb1e77f9de1be03e3abbed8e91c5a75a929c1d) terraform-providers.rootly: 3.4.0 -> 3.5.1
* [`56054747`](https://github.com/NixOS/nixpkgs/commit/560547479b6126e63e52023d0f3cc9d7dea22429) koboldcpp: 1.96 -> 1.96.2
* [`f1e584bc`](https://github.com/NixOS/nixpkgs/commit/f1e584bca043d2962cae468e968987c3ee3fb355) koboldcpp: remove `env.NIX_C{XX,}FLAGS_COMPILE`
* [`9086fc17`](https://github.com/NixOS/nixpkgs/commit/9086fc179a63b8b3fefb3ddeb08b5397ee7b2bcf) changie: 1.22.0 -> 1.22.1
* [`6fac1f69`](https://github.com/NixOS/nixpkgs/commit/6fac1f69471a2068ab4a976780886b2362fd7daa) ada: 3.2.6 -> 3.2.7
* [`92808bae`](https://github.com/NixOS/nixpkgs/commit/92808bae636fb90a22cc448e83af0313f87d310c) python3Packages.pymilvus: 2.5.13 -> 2.5.14
* [`66c87bfc`](https://github.com/NixOS/nixpkgs/commit/66c87bfce21887703785f0e96937a8b6b4fb640a) rkik: init at 0.5.0
* [`7c886e98`](https://github.com/NixOS/nixpkgs/commit/7c886e98609084947c3ddeefc1ee848a75cd7180) mandelbrot-cli: init at 0-unstable-2025-07-16
* [`6bf69d77`](https://github.com/NixOS/nixpkgs/commit/6bf69d779a1d3b589a2ddb8ee785387336f666e6) python3Packages.coffea: 2025.7.2 -> 2025.7.3
* [`04d17561`](https://github.com/NixOS/nixpkgs/commit/04d17561186dc7a7e8a8fa4fd87e3e5b6220a68f) nixos/vaultwarden: Start after network-online.target
* [`6d4764d3`](https://github.com/NixOS/nixpkgs/commit/6d4764d3c053c7d4527d842a04ff12b7665add56) maintainers: update guyonvarch
* [`ef9448f1`](https://github.com/NixOS/nixpkgs/commit/ef9448f13d6fb8cd7e69631e3443be73b3a7ade8) terraform-providers.acme: 2.34.0 -> 2.35.0
* [`ff0ec221`](https://github.com/NixOS/nixpkgs/commit/ff0ec221fb65e433e50c8539ba1a92d289a2263d) python3Packages.pyopencl: 2025.2.5 -> 2025.2.6
* [`8f66a11c`](https://github.com/NixOS/nixpkgs/commit/8f66a11cc1d84d221e9d0f9d719352b05a35b1f3) miniflux: 2.2.10 -> 2.2.11
* [`5205d193`](https://github.com/NixOS/nixpkgs/commit/5205d193ab9bf78503f3fff296cbdb5ed3517131) tinystatus: use makeBinaryWrapper
* [`65abcd2a`](https://github.com/NixOS/nixpkgs/commit/65abcd2a5dace76ef63adbab2eab7ada322b8862) python3Packages.license-expression: 30.4.3 -> 30.4.4
* [`0f3dd253`](https://github.com/NixOS/nixpkgs/commit/0f3dd2531ac52ebb4f1d25459623b216e76cc213) hugo: 0.148.1 -> 0.148.2
* [`2c674a7d`](https://github.com/NixOS/nixpkgs/commit/2c674a7d3a6945fb145d70162f9c4b6fddc42848) gruvbox-gtk-theme: 0-unstable-2025-04-24 -> 0-unstable-2025-07-21
* [`64b49d2c`](https://github.com/NixOS/nixpkgs/commit/64b49d2c7de6bfbb79b4146c67287d2ddc062d7a) python3Packages.gftools: 0.9.86 -> 0.9.87
* [`c4968b97`](https://github.com/NixOS/nixpkgs/commit/c4968b978ae4d8b4ee2f5e270fccea3d9b65d415) python3Packages.anthropic: 0.55.0 -> 0.59.0
* [`c27e74ac`](https://github.com/NixOS/nixpkgs/commit/c27e74acd403e3db7dfc00e9e7413d48e10e0806) cargo-update: 16.4.0 -> 17.0.0
* [`ac031589`](https://github.com/NixOS/nixpkgs/commit/ac031589280bba177a0a1f51d47575be0bcc3eff) quarkus: 3.24.4 -> 3.24.5
* [`b148f019`](https://github.com/NixOS/nixpkgs/commit/b148f01950975662590b691b4cdcd631755bbc7c) terraform-providers.tfe: 0.68.0 -> 0.68.1
* [`34e95f83`](https://github.com/NixOS/nixpkgs/commit/34e95f8347c03cfd175ce4e6cdc409a61cba0b94) findomain: 9.0.4 -> 10.0.1
* [`ad914f55`](https://github.com/NixOS/nixpkgs/commit/ad914f55dce51c7b8c982e9c0f3d98282595f823) mattermost: disable another S3 test
* [`5b864cb3`](https://github.com/NixOS/nixpkgs/commit/5b864cb366aca487126d945429b2f99057aaace9) pied: 0.3.0 -> 0.3.1
* [`ac9f0ff3`](https://github.com/NixOS/nixpkgs/commit/ac9f0ff3818c906b657c7cc94c869f9ec677bd8c) devenv: 1.8 -> 1.8.1
* [`93260787`](https://github.com/NixOS/nixpkgs/commit/932607871a90c813c2e72d9eb29af6782f71d3eb) github-mcp-server: 0.8.0 -> 0.9.0
* [`90948497`](https://github.com/NixOS/nixpkgs/commit/90948497a0d7bf9e0e69610643818d527f727989) python3Packages.django-markup: 1.9.1 -> 1.10
* [`45f26104`](https://github.com/NixOS/nixpkgs/commit/45f261041539785076258319a62216737f6c44e6) nixos/lemurs: Fix test
* [`a9986bde`](https://github.com/NixOS/nixpkgs/commit/a9986bde480524a3636c3dbc6f2b2f15177db661) xray: 25.2.21 -> 25.7.26
* [`ef71b4cd`](https://github.com/NixOS/nixpkgs/commit/ef71b4cd67978ead52c0e73777800e77e59d2621) v2ray: 5.37.0 -> 5.38.0
* [`ca28859d`](https://github.com/NixOS/nixpkgs/commit/ca28859d29ba6ba01be4f03656c16dc165f183a1) python3Packages.llm-gemini: 0.23 -> 0.24
* [`e732b776`](https://github.com/NixOS/nixpkgs/commit/e732b776095df835428af3aaf0bb8afbdfcdf894) terraform-providers.minio: 3.6.1 -> 3.6.2
* [`ebc5946d`](https://github.com/NixOS/nixpkgs/commit/ebc5946d59bf11c988d27151be0c33bb9ed92bcf) maintainers: drop omasanori
* [`9029816f`](https://github.com/NixOS/nixpkgs/commit/9029816f53b6a4868f93c78c9dbcc73e5038497a) xenia-canary: 0-unstable-2025-07-07 -> 0-unstable-2025-07-27
* [`c6b15e1d`](https://github.com/NixOS/nixpkgs/commit/c6b15e1db9ebefd385e058cdb6afbd596ed9c6e5) treewide: fix mismatched runHook invocations in Phase
* [`8f127c3c`](https://github.com/NixOS/nixpkgs/commit/8f127c3ce7156293e63b6742b156c7df671553b1) vulkan-cts: 1.4.3.1 -> 1.4.3.2
* [`135d2de3`](https://github.com/NixOS/nixpkgs/commit/135d2de3aa8dbace5f9fa963e6397b42bc7c8566) xdg-ninja: 0.2.0.2-unstable-2025-06-07 -> 0.2.0.2-unstable-2025-07-25
* [`2b6fabfa`](https://github.com/NixOS/nixpkgs/commit/2b6fabfae99611de0b32656c067fb3c5089a453c) cargo-leptos: 0.2.38 -> 0.2.42
* [`a2da4cab`](https://github.com/NixOS/nixpkgs/commit/a2da4cab4b59677d82cb6ba9312e939f6c058c4f) xmrig: patch modprobe path
* [`c95e58f4`](https://github.com/NixOS/nixpkgs/commit/c95e58f4525bdce551defb149ceb006b32d825f8) vscode-extensions.marp-team.marp-vscode: 3.2.0 -> 3.2.1
* [`380ecfa4`](https://github.com/NixOS/nixpkgs/commit/380ecfa4a4606671f2abcb49560436e2ec00813a) xpipe: 16.7 -> 17.3
* [`ee0866bd`](https://github.com/NixOS/nixpkgs/commit/ee0866bddda29235c7c412a1596cfbe791273a81) treewide: conform descriptions to the standards
* [`425262ea`](https://github.com/NixOS/nixpkgs/commit/425262eab5f780a394fe00ac4d3c2d25b07dee4e) codebuff: 1.0.436 -> 1.0.441
* [`2a866d58`](https://github.com/NixOS/nixpkgs/commit/2a866d5813e55ed5c1c22aeb0b0c06b5824c1111) linux_6_16: init at 6.16
* [`c6c1a1c3`](https://github.com/NixOS/nixpkgs/commit/c6c1a1c3188fa049776aadbc9d647af679689fa3) fclones-gui: move to by-name
* [`80cb8ec4`](https://github.com/NixOS/nixpkgs/commit/80cb8ec428acc1a54dabed95acf1a1379418f587) linux/common-config: enable new 6.16 features
* [`fa5d5025`](https://github.com/NixOS/nixpkgs/commit/fa5d50257d6d58380bb2c0d0e67aa2e40c009bca) fclones-gui: use hicolor
* [`a12a2456`](https://github.com/NixOS/nixpkgs/commit/a12a2456ec9dc6d3c7b7d91cb15a77bd3b315e33) renode-dts2repl: 0-unstable-2025-07-08 -> 0-unstable-2025-07-24
* [`b94b1d6d`](https://github.com/NixOS/nixpkgs/commit/b94b1d6db1babef7624def46e0b5508d0b012286) fwup: 1.13.1 -> 1.13.2
* [`423d7361`](https://github.com/NixOS/nixpkgs/commit/423d736158d919e90a312a0e401690a6a2de4911) runme: 3.14.2 -> 3.15.0
* [`676c5d37`](https://github.com/NixOS/nixpkgs/commit/676c5d37e1a9fc4bf7f91e31725b0e0411184770) cargo-binstall: 1.14.1 -> 1.14.2
* [`1af42c49`](https://github.com/NixOS/nixpkgs/commit/1af42c491031aae7738cb914cd3acf450ecf1f95) oxlint: 1.3.0 -> 1.6.0
* [`61bcf642`](https://github.com/NixOS/nixpkgs/commit/61bcf6429340b303791eca41b19f36a1681b4768) mailmap: add Martin Häcker
* [`8cc59c3d`](https://github.com/NixOS/nixpkgs/commit/8cc59c3dae712e687a0e50ae219e8dc59b6222de) lms: 3.67.0 -> 3.68.1
* [`6a4159f1`](https://github.com/NixOS/nixpkgs/commit/6a4159f1ab2cad7edb38f96c6d07ba9921b17672) wdt: 1.27.1612021-unstable-2025-07-09 -> 1.27.1612021-unstable-2025-07-23
* [`aa4a3805`](https://github.com/NixOS/nixpkgs/commit/aa4a380548776c6417637c874d98bd7899b58c24) config: Add microsoftVisualStudioLicenseAccepted option for MSVC
* [`45832cb2`](https://github.com/NixOS/nixpkgs/commit/45832cb2a827b2b6efaba0594759edd982997b83) terraform-providers.turbot: 1.12.3 -> 1.12.4
* [`c712665d`](https://github.com/NixOS/nixpkgs/commit/c712665d82e64fd4c1886d81a38c0dd2fb646368) terraform-providers.tencentcloud: 1.82.11 -> 1.82.13
* [`f532942d`](https://github.com/NixOS/nixpkgs/commit/f532942d6ec159b137919b48cda84800211f0ead) claude-code: add markus1189 to maintainers
* [`c7a6f489`](https://github.com/NixOS/nixpkgs/commit/c7a6f489ae35c3541e6374cffb85a01a5b94a09f) cargo-hack: 0.6.36 -> 0.6.37
* [`660ef4d5`](https://github.com/NixOS/nixpkgs/commit/660ef4d559830b6ea3cffb009c91096b9c0417a9) cargo-mutants: 25.2.0 -> 25.2.2
* [`ba7f57ea`](https://github.com/NixOS/nixpkgs/commit/ba7f57ea95f0b74c9abb7adf0515e4e19b998381) rust-motd: 1.1.0 -> 2.0.0
* [`db607f1a`](https://github.com/NixOS/nixpkgs/commit/db607f1a01520c415c807b8dd64e7a6bf1276a47) argc: 1.22.0 -> 1.23.0
* [`eab8ae93`](https://github.com/NixOS/nixpkgs/commit/eab8ae93a566cd25edabbfa34ae59f373ddddc18) lianad: 11.1 -> 12.0
* [`cb59d7de`](https://github.com/NixOS/nixpkgs/commit/cb59d7dee2128bdd6934a82c23d1bdfedf69498e) system76-power: 1.2.6 -> 1.2.7
* [`5e5df3f3`](https://github.com/NixOS/nixpkgs/commit/5e5df3f3a32dcee4142742e85e612cb49741b160) stu: 0.7.2 -> 0.7.3
* [`673c9c57`](https://github.com/NixOS/nixpkgs/commit/673c9c577f6e5c56ff318c4c40910f12bc8be07a) firefoxpwa: 2.14.1 -> 2.15.0
* [`01eebc23`](https://github.com/NixOS/nixpkgs/commit/01eebc23c796e28edf33a61d6789522fe2024f5d) mago: 0.23.0 -> 0.26.1
* [`30b7d9a3`](https://github.com/NixOS/nixpkgs/commit/30b7d9a3a8b916bdfdd83e868b1d370895cf975a) squawk: 2.15.0 -> 2.21.0
* [`b0605c46`](https://github.com/NixOS/nixpkgs/commit/b0605c46903cfd443e77e97a274dc89160b1d8c1) gitoxide: 0.44.0 -> 0.45.0
* [`03c68b63`](https://github.com/NixOS/nixpkgs/commit/03c68b637f0cac41e426b67e4cfdf75ceeae45f1) sentry-cli: 2.46.0 -> 2.50.2
* [`ca824f07`](https://github.com/NixOS/nixpkgs/commit/ca824f078d31e7fdfbf85d90188fd3f9ff6ef0d1) terraform-providers.temporalcloud: 0.9.0 -> 0.9.1
* [`4cb0fb91`](https://github.com/NixOS/nixpkgs/commit/4cb0fb91f57758d483f78c68de2badaed2d512b8) scooter: 0.5.3 -> 0.5.4
* [`f2e5693e`](https://github.com/NixOS/nixpkgs/commit/f2e5693e026acdb5b70fa6f91cc3009272f4f568) rabbitmqadmin-ng: 2.2.1 -> 2.7.1
* [`776840ad`](https://github.com/NixOS/nixpkgs/commit/776840ad48d439777ffe2b13a8aaaff1c914140f) cargo-shear: 1.4.0 -> 1.4.1
* [`017bd740`](https://github.com/NixOS/nixpkgs/commit/017bd740cf21a14609af8886b67fef2b4a6236e4) impala: 0.2.4 -> 0.3.0
* [`0f76b3d2`](https://github.com/NixOS/nixpkgs/commit/0f76b3d2c6fcd7b9587040341db0cfdc181bfbb8) cargo-bolero: 0.13.3 -> 0.13.4
* [`5ef78d28`](https://github.com/NixOS/nixpkgs/commit/5ef78d286ed8bd3970d3261d60f89992c3d8baee) yaydl: 0.17.2 -> 0.17.3
* [`3ee06315`](https://github.com/NixOS/nixpkgs/commit/3ee063159e2125176be995c89018ca44831f6f26) storj-uplink: fix tests on sandboxed darwin
* [`e6dbba13`](https://github.com/NixOS/nixpkgs/commit/e6dbba13d740bfa35d9fc9487c8db6a4f8efba3d) storj-uplink: renew
* [`8221e7f7`](https://github.com/NixOS/nixpkgs/commit/8221e7f78fef1fba046e51696d8b5a69104156ea) mcp-nixos: init at 1.0.0
* [`cec204a7`](https://github.com/NixOS/nixpkgs/commit/cec204a74e8a7e7d419c69949b91caa09242fc1e) librewolf-bin-unwrapped: 140.0.4-1 -> 141.0-1
* [`a08b1018`](https://github.com/NixOS/nixpkgs/commit/a08b10181a4339358ac6fb706bc11feee8f6e76e) go-task: 3.44.0 -> 3.44.1
* [`b3e47fdd`](https://github.com/NixOS/nixpkgs/commit/b3e47fdddbd20047eff317ceb28ec456d7f4c709) blanket: 0.7.0 -> 0.8.0
* [`84d5aca1`](https://github.com/NixOS/nixpkgs/commit/84d5aca150266a1eec618026b355d339e090f00f) vimPlugins.avante-nvim: 0.0.25-unstable-2025-07-11 -> 0.0.27-unstable-2025-07-28
* [`7d5b04ab`](https://github.com/NixOS/nixpkgs/commit/7d5b04ab57f66fd152b902b7d0520f6a38801aa8) cdncheck: 1.1.28 -> 1.1.29
* [`ea05e38d`](https://github.com/NixOS/nixpkgs/commit/ea05e38d71b360bbbddc91be72c712fe7d47139b) python313Packages.censys: 2.2.17 -> 2.2.18
* [`489f0ced`](https://github.com/NixOS/nixpkgs/commit/489f0ced17665eaa737f03d4c8c4262e37a5fc80) python313Packages.cwl-utils: 0.38 -> 0.39
* [`cae6502f`](https://github.com/NixOS/nixpkgs/commit/cae6502fceca96b5ad1a1898a0c8335920bc4516) python313Packages.dnfile: 0.15.1 -> 0.16.4
* [`c98ce34d`](https://github.com/NixOS/nixpkgs/commit/c98ce34d21ba3375c953f4481cbbdf46d46257ef) python313Packages.cyclopts: 3.22.2 -> 3.22.3
* [`9133914f`](https://github.com/NixOS/nixpkgs/commit/9133914fef50216f51c588616226b0ee448f0762) redlib: 0.36.0 -> 0.36.0-unstable-2025-07-21; use rev instead of tag for unstable updates
* [`bcb241ea`](https://github.com/NixOS/nixpkgs/commit/bcb241ead558a3f1c5bb2a90f585a65ad832341f) python313Packages.griffe: 1.7.3 -> 1.8.0
* [`a3449289`](https://github.com/NixOS/nixpkgs/commit/a3449289628570fa96c1a590d56572e7b62db815) mise: 2025.7.17 -> 2025.7.29
* [`b796153a`](https://github.com/NixOS/nixpkgs/commit/b796153ac0a4b90061e07db42a949aa6421cc0e3) python313Packages.jsonargparse: 4.40.0 -> 4.40.1
* [`2014a8b2`](https://github.com/NixOS/nixpkgs/commit/2014a8b27a90ef142462b5dfabc8e73bb95bec8b) hyprprop: 0.1-unstable-2025-07-18 -> 0.1-unstable-2025-07-23
* [`6497d443`](https://github.com/NixOS/nixpkgs/commit/6497d443452cfba1405034e2f54cec5801f2bfdc) release: don't block on bootstrap tools, temporarily
* [`a1a470f5`](https://github.com/NixOS/nixpkgs/commit/a1a470f5906600df601037241a356f833e7c5257) maintainers: add ungeskriptet
* [`e1d7968b`](https://github.com/NixOS/nixpkgs/commit/e1d7968b15a0d6f0b23fce9f2936734dcd945685) samfirm-js: init at 0.3.0-unstable-2023-12-27
* [`3e0d2d58`](https://github.com/NixOS/nixpkgs/commit/3e0d2d58de6fe3cd88fb777fe1690619cd11fb97) python3Packages.knx-frontend: 2025.6.13.181749 -> 2025.7.23.50952
* [`c6e3db54`](https://github.com/NixOS/nixpkgs/commit/c6e3db54b7cef4219431eafce7f9a600ae9925c3) python3Packages.tenant-schemas-celery: 4.0.1 -> 4.0.2
* [`b23b91fe`](https://github.com/NixOS/nixpkgs/commit/b23b91fe528703c599fa06456723ba0c73262815) terraform-providers.alicloud: 1.253.0 -> 1.254.0
* [`1b069079`](https://github.com/NixOS/nixpkgs/commit/1b069079496cac762589dae20019579b94ec884f) vtk: 9.2.6 -> 9.5.0
* [`0fa2824f`](https://github.com/NixOS/nixpkgs/commit/0fa2824f5736efe22cdd514a0e742dab54388996) pulumi-bin: 3.185.0 -> 3.186.0
* [`44c9bfcc`](https://github.com/NixOS/nixpkgs/commit/44c9bfcc7df493365fea42bae387ada8f831450c) euphonica: 0.94.1-alpha -> 0.96.1-beta
* [`750dab33`](https://github.com/NixOS/nixpkgs/commit/750dab33d0e702e6a79e2d781c9537d53425b967) clementine: 1.4.1-45-g34eb666c0 -> 1.4.1-48-g12e851937
* [`d52048e6`](https://github.com/NixOS/nixpkgs/commit/d52048e66de5c4726e22eadc9419223f0c050ffa) python312Packages.pymatgen: fix disabledTestPaths
* [`aa408b15`](https://github.com/NixOS/nixpkgs/commit/aa408b15e26b14086453d52a97d0e69b97e98646) floorp: 11.28.0 -> 11.29.0
* [`ebaf7a33`](https://github.com/NixOS/nixpkgs/commit/ebaf7a33ecd7f43988fc5be1b1ecc6d72da2cb6b) nixos/systemd: add settings.Manager option
* [`08a745f3`](https://github.com/NixOS/nixpkgs/commit/08a745f33ae64c5ed5e4010bfba5c214ee52d594) wechat: install icon to a better place for linux
* [`f0b71eeb`](https://github.com/NixOS/nixpkgs/commit/f0b71eebdc0b099904f046e30be33eab93e292ab) nixos/systemd: add boot.initrd.systemd.settings.Manager option
* [`222ee8fa`](https://github.com/NixOS/nixpkgs/commit/222ee8fabfad815e6c988882defe282d1e79dc1a) nixos/testing: migrate to systemd.settings.Manager
* [`5077e5f1`](https://github.com/NixOS/nixpkgs/commit/5077e5f1e88eddb87596a60a7e99575c6645d021) nixos/tests/systemd: migrate to systemd.settings.Manager
* [`9142cadd`](https://github.com/NixOS/nixpkgs/commit/9142cadd5e46c9449f6e0e456625bf977fcfb2f5) nixos/pam: point to systemd.settings.Manager
* [`a48bc46a`](https://github.com/NixOS/nixpkgs/commit/a48bc46a3eb284a94b2c1074ff11d91962d55c3b) nixos/tests/switchTest: migrate to systemd.settings.Manager
* [`1a846a2f`](https://github.com/NixOS/nixpkgs/commit/1a846a2fffb0041b978db145c3ec08f3982ae028) nixos/systemd: remove systemd.extraConfig
* [`071ce0b4`](https://github.com/NixOS/nixpkgs/commit/071ce0b44a70fdaab1b28bed8e06f44d3dc1430b) nixos/systemd: remove boot.initrd.systemd.extraConfig
* [`5bc2d42b`](https://github.com/NixOS/nixpkgs/commit/5bc2d42ba9c84e805bcd388d9973f9f69da54925) nixos/systemd: make boot.initrd.systemd.managerEnvironment affect boot.initrd.systemd.settings.Manager
* [`897933fc`](https://github.com/NixOS/nixpkgs/commit/897933fc9eacb221f3b0ec0f469ab199b4bb9d1d) nixos/systemd: move systemd.managerEnvironment to systemd.settings.Manager.ManagerEnvironment
* [`583a9817`](https://github.com/NixOS/nixpkgs/commit/583a98175b1e35de1be2b9bd00cecca4d1ceacf4) cve-prioritizer: 1.9.0 -> 1.10.1
* [`4d3ab0e8`](https://github.com/NixOS/nixpkgs/commit/4d3ab0e8d39d50cdf1472fa33834e1947b139fc8) nixos/systemd: make systemd.managerEnvironment affect systemd.settings.Manager
* [`493f1339`](https://github.com/NixOS/nixpkgs/commit/493f1339b026de47fdaca57f37d881530795935d) nixos/systemd: move systemd.watchdog.* to systemd.settings.Manager
* [`62acc591`](https://github.com/NixOS/nixpkgs/commit/62acc59148037c85c71c5e9819e696c8c20c30e3) nixos/systemd: move systemd.watchdog.* to systemd.settings.Manager
* [`69e833f1`](https://github.com/NixOS/nixpkgs/commit/69e833f187993396b1bcaf0fc8792497fe95c9d6) nixos/systemd: set DefaultLimitCORE in systemd.settings.Manager explicitly
* [`9c429f00`](https://github.com/NixOS/nixpkgs/commit/9c429f004d100ff895b9b08432bdab38b5a73fb6) nixos/systemd: remove obsolete definition for DefaultLimitCORE
* [`265152f7`](https://github.com/NixOS/nixpkgs/commit/265152f770a8ccd503bd93f5638d0c68aff82536) nixos/systemd: explicitly set systemd.settings.Manager.Default*Accounting
* [`f47b1007`](https://github.com/NixOS/nixpkgs/commit/f47b100763688781069914595aaf9261d426672a) nixos/systemd: remove obsolete DefaultBlockIOAccounting option
* [`231c1427`](https://github.com/NixOS/nixpkgs/commit/231c14276631a2f9530c9af93f27616abd3bfb69) nixos/systemd: remove obsolete DefaultCPUAccounting option
* [`84cbe9dc`](https://github.com/NixOS/nixpkgs/commit/84cbe9dce4bab8d3172fef22c496cfd9d6aa5815) nixos/netdata: remove cgroup accounting enable
* [`fad6dbb9`](https://github.com/NixOS/nixpkgs/commit/fad6dbb9e67642a8daec2cfb9533dc899ec6531a) nixos/systemd: remove enableCgroupAccounting option
* [`6cd6573d`](https://github.com/NixOS/nixpkgs/commit/6cd6573d41643a989a7e3f11fc3b4d2fd5484720) nixos/doc/rl-2511: document rfc42 conversion for systemd.extraConfig
* [`41918461`](https://github.com/NixOS/nixpkgs/commit/41918461d6ed3d921697e87af111c1239d20a7d5) sgt-puzzles: 20250714.880288c -> 20250722.dbe6378
* [`ca071030`](https://github.com/NixOS/nixpkgs/commit/ca071030417f2474791cf6c4c970d36ce06d0193) namespace-cli: 0.0.431 -> 0.0.433
* [`1f76bd99`](https://github.com/NixOS/nixpkgs/commit/1f76bd997d9420347fe869f51a1a66dd8f16dd97) python3Packages.python-hcl2: 7.2.1 -> 7.3.1
* [`78dce13c`](https://github.com/NixOS/nixpkgs/commit/78dce13c2b42632add5d4a5ed2fb0c052454e888) reaction: 2.1.1 -> 2.1.2
* [`4ecb0ab0`](https://github.com/NixOS/nixpkgs/commit/4ecb0ab071283ceb2f0be64b9b3a2df5429a8e49) vectorscan: don't build benchmarks
* [`b9d04091`](https://github.com/NixOS/nixpkgs/commit/b9d04091222217474d3ee6c58696be638ca0bffc) spotify-player: 0.20.6 -> 0.20.7
* [`e449c6cd`](https://github.com/NixOS/nixpkgs/commit/e449c6cd90b605264499aa2c20d78b3478d1f33b) python3Packages.buildstream-plugins: init at 2.4.0
* [`9527b262`](https://github.com/NixOS/nixpkgs/commit/9527b262b09b56dc82484dfdf0226ae57ad26a21) peering-manager: 1.8.3 -> 1.9.6
* [`6f35ae80`](https://github.com/NixOS/nixpkgs/commit/6f35ae801e6fd0d06fb279739de40dcb1f0a3270) nixos/peering-manager: remove enableOidc option since it is now builtin
* [`4c21b284`](https://github.com/NixOS/nixpkgs/commit/4c21b28447013fbdc59b2e75360786d33d3c9f97) nixos/peering-manager: add environmentFile option
* [`1918e3ce`](https://github.com/NixOS/nixpkgs/commit/1918e3ced1882d3a31f3ba0753abe78fa84781e4) nixos/peering-manager: fix bgp session poller
* [`c49832e8`](https://github.com/NixOS/nixpkgs/commit/c49832e84be5eb1406a70eac07278f56a6cb307b) terraform-providers.mongodbatlas: 1.38.0 -> 1.39.0
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
