### PR TITLE
niv home-manager: update f49e872f -> c5d7e957

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -65,10 +65,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f49e872f55e36e67ebcb906ff65f86c7a1538f7c",
-        "sha256": "09qzq4bkxkgn8lp5gzxbyzvqhdlkswq2qxaqmhfgy5508hrxb25y",
+        "rev": "c5d7e957397ecb7d48b99c928611c6e780db1b56",
+        "sha256": "1r6c9smcnx5qfdjjcg9mhqkxds3as7axigwvnlqlqcvagn98id9l",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/f49e872f55e36e67ebcb906ff65f86c7a1538f7c.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/c5d7e957397ecb7d48b99c928611c6e780db1b56.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@f49e872f...c5d7e957](https://github.com/nix-community/home-manager/compare/f49e872f55e36e67ebcb906ff65f86c7a1538f7c...c5d7e957397ecb7d48b99c928611c6e780db1b56)

* [`50adf8fc`](https://github.com/nix-community/home-manager/commit/50adf8fcaa97c9d64309f2d507ed8be54ea23110) PR_TEMPLATE: remove maintainer cc section ([nix-community/home-manager⁠#7569](https://togithub.com/nix-community/home-manager/issues/7569))
* [`2c8306e5`](https://github.com/nix-community/home-manager/commit/2c8306e506718d4c7596ba0b2a595a8e623fc009) ci: manage reviewers add dry run option
* [`1ed730a9`](https://github.com/nix-community/home-manager/commit/1ed730a9771eba6b9426e58b8d29baa7084cba89) ci: manage reviewers doesn't re-add manually removed reviewers
* [`0f9fae16`](https://github.com/nix-community/home-manager/commit/0f9fae161dba7c828de66d1111dfd82909cbd6f8) tests/arrpc: add service module test coverage
* [`cfe397c8`](https://github.com/nix-community/home-manager/commit/cfe397c8c091a06a5a0a4e683e6fca2e57a8312f) arrpc: assert linux
* [`1364772b`](https://github.com/nix-community/home-manager/commit/1364772b57c0dd751dfa3d9baf6c0978c52e0adc) Translate using Weblate (Japanese)
* [`1fa11c8e`](https://github.com/nix-community/home-manager/commit/1fa11c8e830b919b85d9d975567aad12cba69e8c) Translate using Weblate (Turkish)
* [`25deca89`](https://github.com/nix-community/home-manager/commit/25deca893974aae98c9be151fb47d6284c053470) Translate using Weblate (Finnish)
* [`03fdb312`](https://github.com/nix-community/home-manager/commit/03fdb31290d1a4a8d23f52206283450d304c3841) treewide: add missing package options ([nix-community/home-manager⁠#7575](https://togithub.com/nix-community/home-manager/issues/7575))
* [`8aaf3b53`](https://github.com/nix-community/home-manager/commit/8aaf3b53192e62abfd28eddf79f9a9de9d7834f5) hyprsunset: Update module to use hyprsunset.conf
* [`6ff07a01`](https://github.com/nix-community/home-manager/commit/6ff07a01a811f3866e8fab0e30e48392e5741865) hyprsunset: deprecate transitions option
* [`7c01358f`](https://github.com/nix-community/home-manager/commit/7c01358ff6f555330addf5f606d39fb97c70f8e3) hyprsunset: Add tests for hyprsunset.conf file
* [`fa184c54`](https://github.com/nix-community/home-manager/commit/fa184c5460b1099ad7dafeba0ae980a998a12d8d) hyprsunset: Add tests for transitons option
* [`f4e8bc1a`](https://github.com/nix-community/home-manager/commit/f4e8bc1ab6d3e2a178b86141d39f8b847dc52a1b) hyprsunset: refactor implementation
* [`2f588d27`](https://github.com/nix-community/home-manager/commit/2f588d275ebd8243be6c29e7bf3ec7409baa0aa7) hyprsunset: add program to home packages
* [`85a52871`](https://github.com/nix-community/home-manager/commit/85a5287116c6c09ce01ff006a3f14ba7a9d3c21b) tests/gnome-keyring: add test coverage
* [`cec4c1be`](https://github.com/nix-community/home-manager/commit/cec4c1be7eaae2ad3ec780b3c7cd26dbe8c3ce20) tests/ssh-agent: add test coverage
* [`1a8b119e`](https://github.com/nix-community/home-manager/commit/1a8b119e60158711ac53962f7a6ad478796f449a) tests/caffeine: add test coverage
* [`b108e6b7`](https://github.com/nix-community/home-manager/commit/b108e6b7f75d2767a1a559345689e7bedfe7dd11) editorconfig: fix insert_final_newline unset for json files
* [`909d3939`](https://github.com/nix-community/home-manager/commit/909d39391efa9a1f74f7386cb6919b2722e06310) PULL_REQUEST_TEMPLATE: nixfmt-rfc-style -> nixfmt ([nix-community/home-manager⁠#7580](https://togithub.com/nix-community/home-manager/issues/7580))
* [`4bf12467`](https://github.com/nix-community/home-manager/commit/4bf124678be14242e916f4dec2596158900780d4) hyprland: Add `"output"` to `importantPrefixes` option default ([nix-community/home-manager⁠#7507](https://togithub.com/nix-community/home-manager/issues/7507))
* [`fc55d9a4`](https://github.com/nix-community/home-manager/commit/fc55d9a42b178a62edb15a1d11b7085274a922a2) flake.lock: Update
* [`ab148052`](https://github.com/nix-community/home-manager/commit/ab14805267c132c5e9ac66129ca5361abd592a3a) darwinScrublist: add superfile
* [`d732b648`](https://github.com/nix-community/home-manager/commit/d732b648e5a7e3b89439ee25895e4eb24b7e5452) udiskie: fix getExe warning
* [`53524d8b`](https://github.com/nix-community/home-manager/commit/53524d8b274a4710ff9e2bf3468764937217ed8e) tests: chunk size 250 -> 50
* [`0630790b`](https://github.com/nix-community/home-manager/commit/0630790b31d4547d79ff247bc3ba1adda3a017d9) tests: include test names in passthru
* [`bd82507e`](https://github.com/nix-community/home-manager/commit/bd82507edd860c453471c46957cbbe3c9fd01b5c) home-manager: re-enable gcroot handling for NixOS module
* [`4e97102b`](https://github.com/nix-community/home-manager/commit/4e97102bd44899c514411aa8e604ecc33a9da356) nh: add options for specific flakes ([nix-community/home-manager⁠#7566](https://togithub.com/nix-community/home-manager/issues/7566))
* [`e2238e60`](https://github.com/nix-community/home-manager/commit/e2238e60736a2dd86f5bcf6fafee72429a9cd6ff) anki: remove trailing whitespace
* [`7035020a`](https://github.com/nix-community/home-manager/commit/7035020a507ed616e2b20c61491ae3eaa8e5462c) anki: set valid language default
* [`08cf2543`](https://github.com/nix-community/home-manager/commit/08cf2543eac2a88435d7fe4553fd5322f80f587e) Translate using Weblate (French) ([nix-community/home-manager⁠#7596](https://togithub.com/nix-community/home-manager/issues/7596))
* [`899af421`](https://github.com/nix-community/home-manager/commit/899af4218c5a8dd6d6f98e55e21d0c7ccc6b13f7) tmux: fix prefix and shortcut settings ([nix-community/home-manager⁠#7549](https://togithub.com/nix-community/home-manager/issues/7549))
* [`614956c9`](https://github.com/nix-community/home-manager/commit/614956c9932b607a758d7910a5c133af44110309) sesh: switch from `fzf-tmux -p` to `fzf --tmux`
* [`712c6dad`](https://github.com/nix-community/home-manager/commit/712c6dad6cc41abd77c103dc76cda7c443b6c4b3) sesh: fix kill-session field seperator
* [`19f94a3e`](https://github.com/nix-community/home-manager/commit/19f94a3e0e6c8573ea58dac685e96c36e2526cfa) sesh: Add preview window
* [`e102920c`](https://github.com/nix-community/home-manager/commit/e102920c1becb114645c6f92fe14edc0b05cc229) zoxide: move zsh priority ([nix-community/home-manager⁠#7593](https://togithub.com/nix-community/home-manager/issues/7593))
* [`187e0af2`](https://github.com/nix-community/home-manager/commit/187e0af20adf97f799992bf2821a123b7c4dfb3b) nh: remove .nix suffix check for flake paths ([nix-community/home-manager⁠#7600](https://togithub.com/nix-community/home-manager/issues/7600))
* [`d492e3c3`](https://github.com/nix-community/home-manager/commit/d492e3c3811ebd0e67bad5145c618b108cf84a4f) nixos: improve description of enableLegacyProfileManagement
* [`98aed449`](https://github.com/nix-community/home-manager/commit/98aed449ba2ec9f9c4bc265da37a7666e3ad04bd) television: update channel location
* [`e6e2f43a`](https://github.com/nix-community/home-manager/commit/e6e2f43a62b7dbc8aa8b1adb7101b0d8b9395445) televison: add PopeRigby as maintainer
* [`2d3b2f33`](https://github.com/nix-community/home-manager/commit/2d3b2f33a70b5521f98e8ab8218f09cd1f29883b) Translate using Weblate (Finnish)
* [`0de18bd5`](https://github.com/nix-community/home-manager/commit/0de18bd5c6681280d7ae017fa34ffd91bdcf0557) flake.lock: Update
* [`5954bb38`](https://github.com/nix-community/home-manager/commit/5954bb383edce727ced7549bc4b79b2fcdc32843) Add translation using Weblate (Faroese)
* [`c89fdd32`](https://github.com/nix-community/home-manager/commit/c89fdd3291f4bd98feaf0e158ad91c9136013c69) htop: add more fields
* [`d4c53262`](https://github.com/nix-community/home-manager/commit/d4c53262ca0a6bf449b65fa0529d76dbc1b0a4c3) htop: add more platform-independence fields
* [`a26e907c`](https://github.com/nix-community/home-manager/commit/a26e907ca1cd4ccba1295f0ea2957c04cb244fdf) htop: sort fields by its id
* [`1d7abbd5`](https://github.com/nix-community/home-manager/commit/1d7abbd5454db97e0af51416f4960b3fb64a4773) htop: add field `M_VIRT` and `TTY` as alias
* [`c5d7e957`](https://github.com/nix-community/home-manager/commit/c5d7e957397ecb7d48b99c928611c6e780db1b56) nushell: remove Philipp-M as maintainer
