### PR TITLE
niv nixpkgs: update d9da6cda -> 44d04664

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -143,10 +143,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d9da6cda4e5eed60e8c5489789d092be51a565be",
-        "sha256": "1wyc6dfgkz4hk5xmx67v9xsaw7v8z072v2bv1ndw6kq1vc5wrmnf",
+        "rev": "44d04664098a11b5204036a0f42ce5cf9edb524d",
+        "sha256": "0g9ip555dd40rfxzvbw8x9imb3n4yh0djxnfgy5py9f0jqwnq1pl",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/d9da6cda4e5eed60e8c5489789d092be51a565be.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/44d04664098a11b5204036a0f42ce5cf9edb524d.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@d9da6cda...44d04664](https://github.com/nixos/nixpkgs/compare/d9da6cda4e5eed60e8c5489789d092be51a565be...44d04664098a11b5204036a0f42ce5cf9edb524d)

* [`b9253c10`](https://github.com/NixOS/nixpkgs/commit/b9253c1018e8bde30f557c11c7575406578809e2) questdb: fix missing script
* [`cf523f3f`](https://github.com/NixOS/nixpkgs/commit/cf523f3f84d603c2f9581d2995f2f89d39339138) nixos/caddy: Make virtualHosts' logFormat optional
* [`1ea95719`](https://github.com/NixOS/nixpkgs/commit/1ea957198f60f99c7a271ebf8c9026d520c8ceaf) fetchFromBitbucket: add test, repro need for url escape
* [`81e79780`](https://github.com/NixOS/nixpkgs/commit/81e797802040ede04319ae7ef3845b8a1bf97177) fetchFromBitbucket: url escape rev attr
* [`18dc3dd0`](https://github.com/NixOS/nixpkgs/commit/18dc3dd0b9977e17c11f449b57188aca6261f454) nixos/zwave-js: allow non-world-readable secrets
* [`37b94e79`](https://github.com/NixOS/nixpkgs/commit/37b94e7967c359f5c33bd381ee01299197e1adc1) flaresolverr: 3.3.21-unstable-2025-03-04 -> 3.3.24
* [`339e8fcf`](https://github.com/NixOS/nixpkgs/commit/339e8fcf68bfab7892b1588e470b0a09412de0a4) python3Packages.declinate: init at 0.0.6
* [`9cb24fe4`](https://github.com/NixOS/nixpkgs/commit/9cb24fe48da6ffc1856a41e4c28a85b450cc9b58) python3Packages.rosbags: init at 0.10.10
* [`654c6df5`](https://github.com/NixOS/nixpkgs/commit/654c6df53a567ec5c21a6f860ceb19917ba09e8f) python3Packages.rosbags: rev -> tag
* [`4999e434`](https://github.com/NixOS/nixpkgs/commit/4999e4345a2707d93e6ac2f69055b5cb9a2e5cc3) nixos/tests/velocity: fix mcstatus command
* [`a1219a64`](https://github.com/NixOS/nixpkgs/commit/a1219a6470c6a266bb4cff2901ec125a48cc7758) python3Packages.bracex: 2.5.post1 -> 2.6
* [`5336f6d5`](https://github.com/NixOS/nixpkgs/commit/5336f6d5a9632fe471ea1020c325a9ec24c6b539) opensubdiv: 3.6.0 -> 3.6.1
* [`7db47b0f`](https://github.com/NixOS/nixpkgs/commit/7db47b0fffc12d14369d026be49d2a555be90ebd) hdrhistogram_c: init at 0.11.8
* [`c99fae3a`](https://github.com/NixOS/nixpkgs/commit/c99fae3a0fe224de2a86ee2e84f6a64c5c93472c) corosync: apply patch for CVE-2025-30472
* [`cc471a65`](https://github.com/NixOS/nixpkgs/commit/cc471a6520ea48c338d3f61517ed2ac74639d581) python313Packages.whirlpool-sixth-sense: 0.20.0 -> 0.21.1
* [`71784007`](https://github.com/NixOS/nixpkgs/commit/71784007f61409ca9227f677362ca70779f7d5a9) python3Packages.opensearch-py: 2.8.0 -> 3.0.0
* [`dd855347`](https://github.com/NixOS/nixpkgs/commit/dd85534711f5af53aedcb63c7444554742b0bd34) libdatachannel: 0.23.0 -> 0.23.1
* [`541afad2`](https://github.com/NixOS/nixpkgs/commit/541afad2ab47d3b2c74ff34f7ec326db45bc032d) python3Packages.app-model: 0.3.1 -> 0.4.0
* [`7a6db4f5`](https://github.com/NixOS/nixpkgs/commit/7a6db4f50cd2d2eab67646a9f34459375e6e9cd1) python3Packages.dateparser: 1.2.1 -> 1.2.2
* [`1b3ef613`](https://github.com/NixOS/nixpkgs/commit/1b3ef61356dc1d5d43951f1b4d0a3ea33030fc68) python3Packages.google-cloud-dlp: 3.30.0 -> 3.31.0
* [`33ba88d1`](https://github.com/NixOS/nixpkgs/commit/33ba88d14b3c21e67e212b3e1ca17bdfba2231c2) python3Packages.aioftp: 0.25.2 -> 0.26.2
* [`3205097c`](https://github.com/NixOS/nixpkgs/commit/3205097c7c7a1a64c57d0b318deb3191358e55ec) python3Packages.google-cloud-securitycenter: 1.38.1 -> 1.39.0
* [`4e15f373`](https://github.com/NixOS/nixpkgs/commit/4e15f373201319c844a7f117264856f0c0f5b26c) python3Packages.hid: 1.0.7 -> 1.0.8
* [`b66f9d6c`](https://github.com/NixOS/nixpkgs/commit/b66f9d6c08d958ebd3faed16419a2e5e567442d6) osl: 1.14.5.1 -> 1.14.6.0
* [`51d4adf6`](https://github.com/NixOS/nixpkgs/commit/51d4adf6c8fe74e6b95083019187f7b644db9dc8) arc-browser: use `xmlstartlet` for `passthru.updateScript`
* [`0132c034`](https://github.com/NixOS/nixpkgs/commit/0132c034d191cbd0d4903fa1e08b91c1c8861fd7) libgphoto2: 2.5.31 -> 2.5.32
* [`b264a6a3`](https://github.com/NixOS/nixpkgs/commit/b264a6a3f7f373da4244c17c84811bc93119ce8d) python3Packages.pyobjc-core: 11.0 -> 11.1
* [`9c143fce`](https://github.com/NixOS/nixpkgs/commit/9c143fceacbae535791654b52049484a5a69b8f9) python3Packages.pyobjc-framework-Cocoa: 11.0 -> 11.1
* [`aba5b003`](https://github.com/NixOS/nixpkgs/commit/aba5b003ca10f37bd00bf958a8433e9bbff6610d) python3Packages.pyroaring: 1.0.1 -> 1.0.2
* [`8e4b4311`](https://github.com/NixOS/nixpkgs/commit/8e4b43119d0ac9002a920f2af2bc757d21a847b5) python3Packages.eccodes: 2.41.0 -> 2.42.0
* [`a3c11f3a`](https://github.com/NixOS/nixpkgs/commit/a3c11f3a5b3f7860ce8e28571694351b591ef6fc) python3Packages.coredis: 4.23.1 -> 4.24.0
* [`33319798`](https://github.com/NixOS/nixpkgs/commit/333197982d1eb189e550293c02197766b196f0a4) python3Packages.holoviews: 1.20.2 -> 1.21.0
* [`ae1dc0c5`](https://github.com/NixOS/nixpkgs/commit/ae1dc0c57675530a82f6a0658c9156692a690bae) cf-hero: init at 1.0.4
* [`176f5090`](https://github.com/NixOS/nixpkgs/commit/176f50904b2aa5c28bbf88ecdb4457103990a1f8) bcftools: 1.21 -> 1.22
* [`74c453cb`](https://github.com/NixOS/nixpkgs/commit/74c453cbd5cebfae0249c6c1c5ba288a2d3a06db) python313Packages.types-html5lib: 1.1.11.20250516 -> 1.1.11.20250708
* [`29f345ea`](https://github.com/NixOS/nixpkgs/commit/29f345eadcee3d74da17334f665b7ea45442e3a6) hqplayerd: 5.5.0-13 -> 5.13.2-39
* [`3f8c5ee4`](https://github.com/NixOS/nixpkgs/commit/3f8c5ee41ad1e2728c80a283dfc02ffeae2383f4) python3Packages.xlrd: 2.0.1 -> 2.0.2
* [`4a567f70`](https://github.com/NixOS/nixpkgs/commit/4a567f705479deb3db80f19832fa2b12158a7f05) python3Packages.latexcodec: 3.0.0 -> 3.0.1
* [`e2ea9129`](https://github.com/NixOS/nixpkgs/commit/e2ea91295b1c2f626c092d5ad70918539b70a7ff) python3Packages.asana: 5.1.0 -> 5.2.0
* [`cc45743d`](https://github.com/NixOS/nixpkgs/commit/cc45743d729b7dc061d7d63d020403b21e1e3eae) ibus: add meta.mainProgram
* [`aa79b513`](https://github.com/NixOS/nixpkgs/commit/aa79b5136cfc94ce23888de666eb1719efe26077) python3Packages.colorful: 0.5.6 -> 0.5.7
* [`e2ee1dbb`](https://github.com/NixOS/nixpkgs/commit/e2ee1dbbbf3646c8d5c220c6596a82cfe2f0e328) treewide: add stephen-huan as maintainer
* [`65bd9b6b`](https://github.com/NixOS/nixpkgs/commit/65bd9b6bd0a81068bf7e33cc81651c1620054df1) python3Packages.shippai: remove
* [`df229a1e`](https://github.com/NixOS/nixpkgs/commit/df229a1ef38bd8d5a9581ab8604339a445261e8b) python3Packages.mathlibtools: remove
* [`3ce2b52d`](https://github.com/NixOS/nixpkgs/commit/3ce2b52d82b649e5da78226dd25d0deed68e3f8e) python3Packages.transitions: 0.9.2 -> 0.9.3
* [`d3658e63`](https://github.com/NixOS/nixpkgs/commit/d3658e63415429ae4c9fc74657b96b6fd1870964) python3Packages.airportsdata: 20250523 -> 20250706
* [`593b7dff`](https://github.com/NixOS/nixpkgs/commit/593b7dffc9abd5a8ada00dd25b7548fa2f556084) python3Packages.sphinx-codeautolink: 0.17.4 -> 0.17.5
* [`97b8d41a`](https://github.com/NixOS/nixpkgs/commit/97b8d41a63471b98c4def09b15274dd8630b91b1) scotch: 7.0.7 -> 7.0.8
* [`8db8449a`](https://github.com/NixOS/nixpkgs/commit/8db8449ac82515930decad934c4f5eac2c2904cd) python3Packages.pyopensprinkler: init at 0.7.15
* [`f4352af1`](https://github.com/NixOS/nixpkgs/commit/f4352af1aa50b34ded999221279d71a288fb752b) home-assistant-custom-components.hass-opensprinkler: init at 1.5.1
* [`f9d48637`](https://github.com/NixOS/nixpkgs/commit/f9d48637fda09cbe07de11d5cf5284ee6b121549) wuffs: init at 0.4.0-alpha.9
* [`9cf033c4`](https://github.com/NixOS/nixpkgs/commit/9cf033c4412ac6acaa2048ae693a1e05766328cc) rocksdb: 10.2.1 -> 10.4.2
* [`a1a66934`](https://github.com/NixOS/nixpkgs/commit/a1a669347362bd7017ca21be4860ae0467815b65) xpra: 6.3 -> 6.3.2
* [`8758d8e5`](https://github.com/NixOS/nixpkgs/commit/8758d8e53d6a1736d933b3d37a9a37cf7ebf5d56) a2ps: 4.15.6 -> 4.15.7
* [`749a981c`](https://github.com/NixOS/nixpkgs/commit/749a981cb948271b626e9b92d3be5f95c7ff7a1a) python3Packages.ssort: 0.14.0 -> 0.15.0
* [`c3185d0c`](https://github.com/NixOS/nixpkgs/commit/c3185d0c38618e1917de0cd2ca6c88c09542fb82) liboqs: 0.13.0 -> 0.14.0
* [`34fb567c`](https://github.com/NixOS/nixpkgs/commit/34fb567cfe8e29910d954bf0fa011adef3a4a05a) python3Packages.hvplot: 0.11.2 -> 0.11.3
* [`dcb0f258`](https://github.com/NixOS/nixpkgs/commit/dcb0f258036db539fc31ec7286e86eb678fcb3ea) python3Packages.compliance-trestle: 3.9.0 -> 3.9.1
* [`d5fdecd8`](https://github.com/NixOS/nixpkgs/commit/d5fdecd89485483b1954360b8234f4fafa90c626) jetbrains-plugins: fix copilot plugin
* [`9ea89707`](https://github.com/NixOS/nixpkgs/commit/9ea897074543753ec79efefa7ae852436b8a7c00) python3Packages.gphoto2: 2.6.1 -> 2.6.2
* [`edca9dae`](https://github.com/NixOS/nixpkgs/commit/edca9daeed89b180bafb23a119954fa000da370a) gearlever: 3.3.3 -> 3.3.4
* [`827a377c`](https://github.com/NixOS/nixpkgs/commit/827a377cc4f2d93ff86c06b11e39f109fddd0ef9) closurecompiler: 20250528 -> 20250706
* [`0bf901f1`](https://github.com/NixOS/nixpkgs/commit/0bf901f19a0ab22e84322d9c3c70f0322f5b63d8) skeditor: 2.9.0 -> 2.9.3
* [`533ee2fb`](https://github.com/NixOS/nixpkgs/commit/533ee2fb2dbba1bd27d1ee91520d195686d63eda) python3Packages.pymodes: 2.20 -> 2.21.1
* [`642318ba`](https://github.com/NixOS/nixpkgs/commit/642318ba476ee5c1df8b97b449ab599da2cb2c55) terraform-mcp-server: 0.2.0 -> 0.2.1
* [`3bdbc0a9`](https://github.com/NixOS/nixpkgs/commit/3bdbc0a96e2c557570130ace52279a02a58a9560) vial: 0.7.3 -> 0.7.4
* [`1cbd2c6e`](https://github.com/NixOS/nixpkgs/commit/1cbd2c6e6ea681f10d09bea27ee651e6018afbf9) tabby-agent: 0.30.0 -> 0.30.1
* [`9df808f6`](https://github.com/NixOS/nixpkgs/commit/9df808f610e3ef1b723111674b875f1a658bdaa0) dotnet-ef: 9.0.6 -> 9.0.7
* [`7f4021d4`](https://github.com/NixOS/nixpkgs/commit/7f4021d4481d83ad48aaa6f1e65a4094804f0080) linuxPackages.universal-pidff: 0.1.1 -> 0.2.0
* [`722b7b80`](https://github.com/NixOS/nixpkgs/commit/722b7b80f0be94976fc7ef30e153d370d453624a) gnomeExtensions.valent: 1.0.0.alpha.47 -> 1.0.0.alpha.48
* [`cdc60563`](https://github.com/NixOS/nixpkgs/commit/cdc6056344ae2b7e7816d8b564c80bc9e781e60a) pipenv: 2025.0.3 -> 2025.0.4
* [`c1390c04`](https://github.com/NixOS/nixpkgs/commit/c1390c04857f909fd12f1d7a3ec8bfe4660f9fc6) linuxPackages.akvcam: 1.2.7 -> 1.3.0
* [`357f3309`](https://github.com/NixOS/nixpkgs/commit/357f330910973ad342e8962bfd2286444a6b224f) maintainers/sweiglbosker: add gpg key
* [`0bb91f1b`](https://github.com/NixOS/nixpkgs/commit/0bb91f1bb19c3d4f62f57afc17312567d80b402f) python3Packages.xattr: 1.1.4 -> 1.2.0
* [`e4d9053b`](https://github.com/NixOS/nixpkgs/commit/e4d9053b1a70af9edcd2e3e1bf5472fb385d5d81) staruml: 6.3.3 -> 6.3.4
* [`13ae490f`](https://github.com/NixOS/nixpkgs/commit/13ae490f3243c25c883382e934922df24aa550b3) python3Packages.libtfr: init at 2.1.9
* [`82f578b5`](https://github.com/NixOS/nixpkgs/commit/82f578b515e3befa4d65982375880de9974779be) nwjs-ffmpeg-prebuilt: 0.101.1 -> 0.101.2
* [`ada9b83c`](https://github.com/NixOS/nixpkgs/commit/ada9b83c4da43a792f68505de05e928eb774b733) mattermostLatest: 10.9.2 -> 10.10.1
* [`d9276ebd`](https://github.com/NixOS/nixpkgs/commit/d9276ebdbdf3a482a8f0d873e0c3a5860953e13a) doublecmd: refactor inherit statement
* [`7efb19e0`](https://github.com/NixOS/nixpkgs/commit/7efb19e07923831b5e672ecc461db4db6b03f467) protozero: 1.8.0 -> 1.8.1
* [`df1b3361`](https://github.com/NixOS/nixpkgs/commit/df1b336183df2c41e591b6fc254d732a426c4e71) graalvmPackages.graalpy: 24.2.1 -> 24.2.2
* [`33146709`](https://github.com/NixOS/nixpkgs/commit/33146709e0decc0580a192bf69c1c471f782fb16) jetbrains-toolbox: 2.6.3.43718 -> 2.7.0.48109
* [`f7fbe207`](https://github.com/NixOS/nixpkgs/commit/f7fbe207f79f8af8529db61939e831a8c9d95351) poppler: 25.05.0 -> 25.07.0
* [`71c84e00`](https://github.com/NixOS/nixpkgs/commit/71c84e007545533be67296465d02f1bb09c58595) inkscape: fix build with poppler 25.07.0
* [`a7e801b1`](https://github.com/NixOS/nixpkgs/commit/a7e801b185f6d893fb4fae83f4c304195152d7a9) scribus: fix build with poppler 25.07.0
* [`ab9d93b8`](https://github.com/NixOS/nixpkgs/commit/ab9d93b840ad146f2f6f882217cc1ba924227c5f) boinc: 8.2.4 -> 8.2.5
* [`f010e1d4`](https://github.com/NixOS/nixpkgs/commit/f010e1d47a3123a9362f98ad19c361bfcdf71d7c) h2o: 2.3.0.20250519 → 2.3.0.20250716
* [`42d3f76a`](https://github.com/NixOS/nixpkgs/commit/42d3f76a6e10f1ae665bff0579c2149f254fbe24) zsh-fast-syntax-highlighting: 1.55 -> 1.56
* [`297dac57`](https://github.com/NixOS/nixpkgs/commit/297dac57387f61857c5dd8159d100b7466f70ecb) mongodb-atlas-cli: merge with previous init pr
* [`1f73b372`](https://github.com/NixOS/nixpkgs/commit/1f73b3723b6466a53dccb0ff36c5ca16f20057e7) xml2rfc: 3.29.0 -> 3.30.0
* [`0f3e6cb9`](https://github.com/NixOS/nixpkgs/commit/0f3e6cb9364ef50e57bea33a7ce1bf65ef485324) handheld-daemon-ui: 3.3.11 -> 3.3.14
* [`ce3e0572`](https://github.com/NixOS/nixpkgs/commit/ce3e0572aef9bf742f0447f39e31a1202fc5d8e1) python3Packages.pytools: 2025.1.6 -> 2025.2.2
* [`e21fef90`](https://github.com/NixOS/nixpkgs/commit/e21fef90eab15b5f66f8aa16411385d57a4ae8ef) samtools: 1.21 -> 1.22.1
* [`eb360fbe`](https://github.com/NixOS/nixpkgs/commit/eb360fbe6efdcfee8a7bcc5f3b414f2bd81db770) h2o: 2.3.0.20250716 → 2.3.0.20250717
* [`9d50f2dd`](https://github.com/NixOS/nixpkgs/commit/9d50f2dd2fd1b2cb793caf4467f64883abfe9043) nixos/dnsmasq: make dnsmasq --test test the config file
* [`8c2dc66a`](https://github.com/NixOS/nixpkgs/commit/8c2dc66a4148854c88b0627c81083e6ac4a47489) graalvmPackages.graalvm-ce: 24.0.1 -> 24.0.2
* [`f421e25a`](https://github.com/NixOS/nixpkgs/commit/f421e25ac19b4e5ef8d6a3ad54f3ac0de180c290) sby: 0.52 -> 0.55
* [`1b754ab0`](https://github.com/NixOS/nixpkgs/commit/1b754ab08bf1e866d7f4413ac1d912f1ee0863ff) sbt-extras: 2025-06-15 -> 2025-07-06
* [`6189acd5`](https://github.com/NixOS/nixpkgs/commit/6189acd550660563c7af606f277fd5be04bc8102) slacky: 0.0.5 -> 0.0.6
* [`a1f8d236`](https://github.com/NixOS/nixpkgs/commit/a1f8d236a765eb74fb64a2bd8af93479daa2d785) slacky: remove electron from nativeBuildInputs, use lib.getExe and add ozone flags for wayland
* [`38078d86`](https://github.com/NixOS/nixpkgs/commit/38078d86e0da122a21be47d1f90c8329d3c76631) slacky: expand platform support to linux
* [`e38a6631`](https://github.com/NixOS/nixpkgs/commit/e38a66314d917c39ebb2ca12847d398e0541d8a0) heroku: 10.11.0 -> 10.12.0
* [`7454288c`](https://github.com/NixOS/nixpkgs/commit/7454288c9186ba712980c4c25cd43779e23b84c3) nixos/resolveconf: not resetting package
* [`e4b8ae62`](https://github.com/NixOS/nixpkgs/commit/e4b8ae6263edf375808d11a6d4dc68dc5e735c95) capacities: 1.48.7 -> 1.50.4
* [`c7069708`](https://github.com/NixOS/nixpkgs/commit/c70697088d98de54247b6e80566655c559a14fa7) libretro.beetle-psx: 0-unstable-2025-07-04 -> 0-unstable-2025-07-18
* [`1b09ef9b`](https://github.com/NixOS/nixpkgs/commit/1b09ef9bc79d9a4d4f8c8050791c90dcb2960239) python3Packages.optype: 0.11.0 -> 0.12.0
* [`39e129bc`](https://github.com/NixOS/nixpkgs/commit/39e129bc1a331887ec3c7f77ccd0c9dd8db3f453) vengi-tools: 0.0.38 -> 0.1.0
* [`2e4dec02`](https://github.com/NixOS/nixpkgs/commit/2e4dec027d4c94d1fb97ff8e9739bace69cba1ba) meerk40t: 0.9.7051 -> 0.9.7930
* [`f738cd1f`](https://github.com/NixOS/nixpkgs/commit/f738cd1ff59631377ecc6b434134502b45b6eed5) graalvmPackages.graaljs: 24.2.1 -> 24.2.2
* [`675707e7`](https://github.com/NixOS/nixpkgs/commit/675707e7ca389ea5de33d9fe2493a30084ddf884) hamrs-pro: 2.41.1 -> 2.42.1
* [`a1341a2b`](https://github.com/NixOS/nixpkgs/commit/a1341a2be58f7d5e4bc1ea0a4b56fab6c1fee3e3) console-setup: 1.239 -> 1.240
* [`345f1faa`](https://github.com/NixOS/nixpkgs/commit/345f1faa78f18fcb4b542d0852cbebb00239af87) blobfuse: 2.4.2 -> 2.5.0
* [`4f27444a`](https://github.com/NixOS/nixpkgs/commit/4f27444a44b942fb5bb18a3d15b071364ae94afe) vagrant: Set dontCheckForBrokenSymlinks
* [`6c9c7342`](https://github.com/NixOS/nixpkgs/commit/6c9c7342a8394d120fad1b43a55899a23d2d0a85) evil-helix: use lambda instead of rec attrs
* [`122adcf5`](https://github.com/NixOS/nixpkgs/commit/122adcf55abee4de61f60d6b0c1674775e26bc79) helix: use lambda instead of rec attrs
* [`46488d27`](https://github.com/NixOS/nixpkgs/commit/46488d27361ad348a3a8e3253d2473944be55e8a) iosevka-bin: 33.2.6 -> 33.2.7
* [`b1c60eb3`](https://github.com/NixOS/nixpkgs/commit/b1c60eb3afffbfc74fd9afc009f1e53a0beb7ba1) mercure: 0.19.2 -> 0.20.0
* [`596c6120`](https://github.com/NixOS/nixpkgs/commit/596c6120223754cd885b50208d6bf8429525481d) python313Packages.colcon-library-path: init at 0.2.1
* [`e7f309c1`](https://github.com/NixOS/nixpkgs/commit/e7f309c1408be74f7e622f3987199ba18de447d9) infisical: 0.41.88 -> 0.41.90
* [`46f931dc`](https://github.com/NixOS/nixpkgs/commit/46f931dca240075d5d9c168c7dcfbae3ed2aeec0) postgresqlPackages.omnigres: 0-unstable-2025-06-27 -> 0-unstable-2025-07-17
* [`9c0e8ab3`](https://github.com/NixOS/nixpkgs/commit/9c0e8ab35d5a5e7db1b71145037e196cbc2fbfeb) vcg: 2023.12 -> 2025.07
* [`d65c7969`](https://github.com/NixOS/nixpkgs/commit/d65c79692984093f5b0a9e7e4c0dcf5116355d20) sonar-scanner-cli-minimal: 7.1.0.4889 -> 7.2.0.5079
* [`34be3edb`](https://github.com/NixOS/nixpkgs/commit/34be3edbde63b1871fbcf338e5c4324e60212f91) scipopt-papilo: 2.4.2 -> 2.4.3
* [`f8421367`](https://github.com/NixOS/nixpkgs/commit/f842136751fe3b448f3cc4225dda379a4d6f012f) tiledb: 2.28.0 -> 2.28.1
* [`59c51fb4`](https://github.com/NixOS/nixpkgs/commit/59c51fb433854f2f9fb88b539dd19a78abf3f871) pff-tools: init at 0-unstable-2025-07-22
* [`d8f85991`](https://github.com/NixOS/nixpkgs/commit/d8f8599178c5056e8b179c27664f8e6fa51f8370) libmysqlconnectorcpp: 9.3.0 -> 9.4.0
* [`ee3ebd96`](https://github.com/NixOS/nixpkgs/commit/ee3ebd96e68135ddacebf429229fc269fc7016b2) python3Packages.diff-cover: 9.3.2 -> 9.6.0
* [`d4ef54f8`](https://github.com/NixOS/nixpkgs/commit/d4ef54f8fa717c2e3a142dee19f12fda0f9883a7) github-release: 0.10.1-unstable-2024-06-25 -> 0.11.0
* [`19245606`](https://github.com/NixOS/nixpkgs/commit/192456062bbadb436c565656492c64f5ea9a8934) treewide: migrate git python packages to by-name
* [`047b5cd1`](https://github.com/NixOS/nixpkgs/commit/047b5cd12fe38b9fab7e8f427e2ff25a471b5d76) treewide: refactor git python package definitions
* [`cdec8121`](https://github.com/NixOS/nixpkgs/commit/cdec81212d0d27f4e05422c4bc3ea67f8c7fb1f1) git-publish: fix python error
* [`61c4a646`](https://github.com/NixOS/nixpkgs/commit/61c4a6463b658d602e03dea7a71530b80ece508a) nixos/mediawiki: wfGetDB removed
* [`0918d45d`](https://github.com/NixOS/nixpkgs/commit/0918d45da948ccbcc81eab645514e6c850146106) nixos/mediawiki: update maintenance script usage
* [`e0de9ad1`](https://github.com/NixOS/nixpkgs/commit/e0de9ad1a9d6ae00798f116e73939928d0915f80) graalvmPackages.truffleruby: 24.2.1 -> 24.2.2
* [`d5b518e5`](https://github.com/NixOS/nixpkgs/commit/d5b518e5bd1bdbc865de7624b17c4fc919fe5200) azure-cli-extensions: update docs on adding extension
* [`10006997`](https://github.com/NixOS/nixpkgs/commit/10006997ad5cff35056835ecc73e9c5963226f37) guile-gnutls: 4.0.1 -> 5.0.1
* [`673fd26a`](https://github.com/NixOS/nixpkgs/commit/673fd26a58734326500aaaa463356deae405fc94) ckbcomp: 1.239 -> 1.240
* [`15d269c6`](https://github.com/NixOS/nixpkgs/commit/15d269c660be51327127780bd2821d75345a2495) kssd: 2.21 -> 2.21-unstable-2024-05-27
* [`e8493017`](https://github.com/NixOS/nixpkgs/commit/e84930174fa554586978eb2e33255dfc83350a5d) babashka-unwrapped: 1.12.200 -> 1.12.206
* [`c6817988`](https://github.com/NixOS/nixpkgs/commit/c6817988cd45446c617582c41c7ab1925e68e0de) python3Packages.accelerate: 1.7.0 -> 1.9.0
* [`29b0c591`](https://github.com/NixOS/nixpkgs/commit/29b0c5917810b65a71c6cb75960dac182a7bdeec) apacheHttpd: 2.6.62 -> 2.6.65
* [`38753e68`](https://github.com/NixOS/nixpkgs/commit/38753e68425ebe8a72c04525d839904a5a040a3c) verifast: 25.06 -> 25.07
* [`ce904fef`](https://github.com/NixOS/nixpkgs/commit/ce904fef3a94a633a3965c64ef3624236ed95c41) python3Packages.retrying: 1.3.4 -> 1.4.1
* [`f71bfbcd`](https://github.com/NixOS/nixpkgs/commit/f71bfbcd5e68aa6116618ec6efb311878cc5b103) python3Packages.google-cloud-compute: 1.31.0 -> 1.33.0
* [`351ddbe5`](https://github.com/NixOS/nixpkgs/commit/351ddbe5dff201c1ff1d688a1dd5e90138e1409e) lunasvg: Add some testers and build static library when requested
* [`2b2cc09e`](https://github.com/NixOS/nixpkgs/commit/2b2cc09e9437fb58d2f34df86ee73acc2163ef57) python3Packages.ansible: 11.7.0 -> 11.8.0
* [`bb51f702`](https://github.com/NixOS/nixpkgs/commit/bb51f7022cef0427493e1262396a23fec89189e1) python312Packages.banks: 2.1.3 -> 2.2.0
* [`6f6cc673`](https://github.com/NixOS/nixpkgs/commit/6f6cc673b8d8bfdd4240836ba2ec0612259384a6) plutosvg: Add cmake tester
* [`c8366fed`](https://github.com/NixOS/nixpkgs/commit/c8366fed2721f206d9bd441635062564cd60ecbf) plutovg: Add module testers
* [`55f39fa0`](https://github.com/NixOS/nixpkgs/commit/55f39fa0613e748e15c56e47cba945d449dc1222) movim: 0.30.1 → 0.31
* [`00ac980a`](https://github.com/NixOS/nixpkgs/commit/00ac980af1112162e1b7ebf174cc6cc2b18f0352) mysql80: 8.0.42 -> 8.0.43
* [`8608f6e7`](https://github.com/NixOS/nixpkgs/commit/8608f6e7b3321d8319230cf869a0dad96255479b) mysql84: 8.4.5 -> 8.4.6
* [`da26ba9b`](https://github.com/NixOS/nixpkgs/commit/da26ba9b86b3dd2296fcb66132e9043f5ecac4f0) alsa-utils: use finalAttrs pattern
* [`1b2517c4`](https://github.com/NixOS/nixpkgs/commit/1b2517c4c93f5572002705da0a65abb20c287de5) alsa-utils: remove use of with lib;
* [`851540a9`](https://github.com/NixOS/nixpkgs/commit/851540a931f1ee8f040453e227aa6bc81f92ffbb) alsa-utils: 1.2.13 -> 1.2.14
* [`10e1a6b5`](https://github.com/NixOS/nixpkgs/commit/10e1a6b53980144d1787cf7100aa53e05b1729da) alsa-utils: provide precise licence information
* [`8a752946`](https://github.com/NixOS/nixpkgs/commit/8a752946ac61cc5adf03d888f4110f4a1f992c63) ngtcp2: 1.13.0 -> 1.14.0
* [`057164a7`](https://github.com/NixOS/nixpkgs/commit/057164a72bee5d6a12985afa6b8473d41f05bd85) nghttp3: 1.10.1 -> 1.11.0
* [`96071082`](https://github.com/NixOS/nixpkgs/commit/960710826bf2db56a94ba50472658769f7ddd491) gci: 0.13.6 -> 0.13.7
* [`923a41ab`](https://github.com/NixOS/nixpkgs/commit/923a41ab44668d7c410d625796debac15406fad0) linuxPackages.nvidiaPackages.legacy_535: 535.216.01 -> 535.261.03
* [`c687b753`](https://github.com/NixOS/nixpkgs/commit/c687b753ee1f6c18b53fe5302cdcbba085049498) cppcheck: 2.17.1 -> 2.18.0
* [`af364aca`](https://github.com/NixOS/nixpkgs/commit/af364acaaca540b7534af29fbf9f10f2a2bcd47e) semantic-release: 24.2.5 -> 24.2.7
* [`0c7f204f`](https://github.com/NixOS/nixpkgs/commit/0c7f204faad19bbf6ab8d8db9c57ceaa13a1e0bd) spotify-qt: 4.0.0 -> 4.0.1
* [`2a358e65`](https://github.com/NixOS/nixpkgs/commit/2a358e658589eb9e9981f0a79623ab133f3c80c3) postgresqlPackages.pgmq: 1.5.1 -> 1.6.1
* [`c6e81e73`](https://github.com/NixOS/nixpkgs/commit/c6e81e73fb6fb209c277b502db082914e54faf2b) pyenv: 2.6.3 -> 2.6.5
* [`1ab2936a`](https://github.com/NixOS/nixpkgs/commit/1ab2936a54482b20f326ca275c655a5a651d6134) kaldi: 0-unstable-2025-04-28 -> 0-unstable-2025-07-22
* [`3352c7c4`](https://github.com/NixOS/nixpkgs/commit/3352c7c46a3d4bd9726d4948f0c19be91a8ae2ce) maintainers: add DoctorDalek1963
* [`4ebd1ea7`](https://github.com/NixOS/nixpkgs/commit/4ebd1ea7b46a3e9fb32dc44ccfaaaddebe3d832b) deja-dup: 48.2 -> 48.3
* [`569c54ca`](https://github.com/NixOS/nixpkgs/commit/569c54cae350e54eec33d9d74fe69abcb2231e45) jay: 1.10.0 -> 1.11.0
* [`4978943d`](https://github.com/NixOS/nixpkgs/commit/4978943db36519b6ff972af0fa43ec6edb3d566c) chsrc: 0.2.1 -> 0.2.2
* [`31be393a`](https://github.com/NixOS/nixpkgs/commit/31be393abff1f30dd3bf10699c9c847167fd5be8) step-ca: 0.28.3 -> 0.28.4
* [`03d0fed6`](https://github.com/NixOS/nixpkgs/commit/03d0fed6f89352200d32c455b50844a616d997d0) nixos/postgresql: implement auto-restart & rework dependencies of postgresql.target
* [`6ae194e4`](https://github.com/NixOS/nixpkgs/commit/6ae194e419471d9f6afe98e988cc2be172f72479) nixos/postgresql: set Restart=always for postgresql.service
* [`fec16cf2`](https://github.com/NixOS/nixpkgs/commit/fec16cf2ada44c67b69316c601e855a4f66ca072) lilypond-unstable: 2.25.26 -> 2.25.27
* [`b94c2d86`](https://github.com/NixOS/nixpkgs/commit/b94c2d8677ba7fee4dde51a6a6eb937ed20a5d6b) step-ca: make source reproducible
* [`f170812e`](https://github.com/NixOS/nixpkgs/commit/f170812e0bcc1be3a85a5cc31d9b9d7f60d4aba6) typesense: 28.0 -> 29.0
* [`9fa16897`](https://github.com/NixOS/nixpkgs/commit/9fa16897dde5c51379130eb3fb6c1e0529791370) weasis: 4.6.1 -> 4.6.2
* [`bbd17a45`](https://github.com/NixOS/nixpkgs/commit/bbd17a459e18eae810597291aad1be563773005d) watchyourlan: 2.1.2 -> 2.1.3
* [`0f9850b1`](https://github.com/NixOS/nixpkgs/commit/0f9850b127f9a4b1fd3255a40e47ac506ab74fb6) git-machete: 3.36.1 -> 3.36.3
* [`9e2d007b`](https://github.com/NixOS/nixpkgs/commit/9e2d007b94325158199e8da26c778e2851c4e9aa) nixos/nextcloud: configure redis by default
* [`cac658f3`](https://github.com/NixOS/nixpkgs/commit/cac658f3b412490b646e1e62f0f873ae145d90b9) python3Packages.azure-mgmt-netapp: 13.5.0 -> 13.6.0
* [`62350b72`](https://github.com/NixOS/nixpkgs/commit/62350b72074e3f9957c2088ab3e270bb19a9bf68) gmt: 6.5.0 -> 6.6.0
* [`0ebe81d2`](https://github.com/NixOS/nixpkgs/commit/0ebe81d2c6e63d554aa0abc765cde1c4281455e0) jackett: 0.22.2097 -> 0.22.2196
* [`f2b0a479`](https://github.com/NixOS/nixpkgs/commit/f2b0a4795e763a7b7b2adabc9dc6f1e61afa0d4d) lunasvg: 3.3.0 -> 3.4.0
* [`7ceba4c9`](https://github.com/NixOS/nixpkgs/commit/7ceba4c99c845fea74fc671f20b4ff5b528dc73d) nushellPlugins.skim: 0.15.0 -> 0.16.0
* [`db203fff`](https://github.com/NixOS/nixpkgs/commit/db203fff5ecbcb528c03770ce0bfde09749df1e3) koka: 3.1.2 -> 3.2.2
* [`5ead0dea`](https://github.com/NixOS/nixpkgs/commit/5ead0deab1b2acc1a1395e9bcf176f3fb03d7f5c) spring-boot-cli: 3.5.3 -> 3.5.4
* [`1eb0e955`](https://github.com/NixOS/nixpkgs/commit/1eb0e955b5fac9ceb2f3c2d0a34a16c0fe757dd8) sunsetr: init at 0.6.1
* [`2e6c1010`](https://github.com/NixOS/nixpkgs/commit/2e6c1010e69c3b2f816739e54c91f41bfe8e21de) python3Packages.kuzu: 0.11.0 -> 0.11.1
* [`0eb8d674`](https://github.com/NixOS/nixpkgs/commit/0eb8d674fb9c9515b56d01852bc0736489a4fa20) python3Packages.lib50: 3.0.12 -> 3.1.1
* [`e0bac290`](https://github.com/NixOS/nixpkgs/commit/e0bac290b98c92037c6fb7737557cf45be72325a) koka: migrate to pkgs/by-name
* [`0b5647da`](https://github.com/NixOS/nixpkgs/commit/0b5647dabd4a17cd03f43dc73143d63c13957cce) koka: update executableHaskellDepends
* [`a9a5663d`](https://github.com/NixOS/nixpkgs/commit/a9a5663dfdcda1b6620c37f07ee024703752efac) trealla: 2.78.24 -> 2.79.2
* [`e5a1a745`](https://github.com/NixOS/nixpkgs/commit/e5a1a745d4e2d72a8d6ccad2cade24e3760c78b8) graalvmPackages.graalnodejs: 24.2.1 -> 24.2.2
* [`54efdfe7`](https://github.com/NixOS/nixpkgs/commit/54efdfe708956a54823a5edb89b863fb4ebe27ed) mmseqs2: 17-b804f -> 18-8cc5c
* [`77c2981a`](https://github.com/NixOS/nixpkgs/commit/77c2981a7d404f2c59e7017d124156285463e247) lib.attrsets.filterAttrs: Add tips to doc
* [`10a9cf5e`](https://github.com/NixOS/nixpkgs/commit/10a9cf5ed1595338931debca30586f9164174630) nixseparatedebuginfod2: init at 0.1.0
* [`4a2c2ca5`](https://github.com/NixOS/nixpkgs/commit/4a2c2ca55317b8ae7682e5747651eb474341485e) nixosTests.nixseparatedebuginfod: fix test
* [`991125c8`](https://github.com/NixOS/nixpkgs/commit/991125c88f119603dcfdc4341a993b6b21030b7f) anilibria-winmaclinux: 2.2.28 -> 2.2.29
* [`3ff6bd15`](https://github.com/NixOS/nixpkgs/commit/3ff6bd15586123dc38176075843c6202e878a46e) qolibri: 2.1.5-unstable-2024-03-17 -> 2.1.5-unstable-2025-01-18
* [`f5f310b3`](https://github.com/NixOS/nixpkgs/commit/f5f310b31ae7605de71990071aba7f245a1e8bde) wezterm: fix auto update
* [`5c66f57c`](https://github.com/NixOS/nixpkgs/commit/5c66f57cf16d7f0d0e25ac1810fffbcc0584d77b) wezterm: 0-unstable-2025-06-24 -> 0-unstable-2025-07-10
* [`a844e9bb`](https://github.com/NixOS/nixpkgs/commit/a844e9bb1f326f91e6ed6976e92e688a51637286) questdb: 8.3.3 -> 9.0.1
* [`ca548d4d`](https://github.com/NixOS/nixpkgs/commit/ca548d4da9036c1de4ebef87c29dad5405777728) nixos: make it possible for several modules to provide a debuginfod server
* [`22bb61d1`](https://github.com/NixOS/nixpkgs/commit/22bb61d1f848d64708fbf10ee542c7f850d22dbe) nixos: add module for nixseparatedebuginfod2
* [`b2682fee`](https://github.com/NixOS/nixpkgs/commit/b2682fee04c655576bf7d634c7a802a2bf55d6e0) matrix-synapse.plugins.matrix-synapse-ldap3: 0.2.2 -> 0.3.0
* [`52019bf7`](https://github.com/NixOS/nixpkgs/commit/52019bf7cab86008965464b69466160df7842e5a) zpaqfranz: 62.2 -> 62.4
* [`6e62d39e`](https://github.com/NixOS/nixpkgs/commit/6e62d39edc04adaa79f9c1bc4bd38a955862e768) bvi: 1.4.2 -> 1.5.0
* [`93897244`](https://github.com/NixOS/nixpkgs/commit/938972440b597c33fe8ae84efd600774acd3c04d) seamly2d: 2025.6.23.216 -> 2025.7.21.216
* [`1a5dfb19`](https://github.com/NixOS/nixpkgs/commit/1a5dfb192952ef1b860c55c35b939a7524af35d5) secretspec: 0.2.0 -> 0.3.0
* [`f226a47b`](https://github.com/NixOS/nixpkgs/commit/f226a47b192211cca56122927fb5cc2b97348320) python3Packages.pbs-installer: 2025.06.12 -> 2025.07.23
* [`50c5fdde`](https://github.com/NixOS/nixpkgs/commit/50c5fdde42cf4a8880c751b6a1908d59a82a2bd9) jx: 3.11.97 -> 3.16.1
* [`137488b8`](https://github.com/NixOS/nixpkgs/commit/137488b80c4eb31270af10735e84e74128c08639) skim: 0.20.2 -> 0.20.3
* [`c84bd6c7`](https://github.com/NixOS/nixpkgs/commit/c84bd6c75070a50dae2f5044a3f309d65cc4efae) markuplinkchecker: 0.22.0 -> 1.0.0
* [`27af2667`](https://github.com/NixOS/nixpkgs/commit/27af2667603a1153dd0b6e3eb98142b6636a0433) elmPackages.elm-test-rs: 3.0 -> 3.0.1
* [`a247197b`](https://github.com/NixOS/nixpkgs/commit/a247197b4c0987d7c1a6c2a1c24c8c9224f7b7ce) ark-pixel-font: 2025.03.14 -> 2025.07.21
* [`39c3a0f4`](https://github.com/NixOS/nixpkgs/commit/39c3a0f421806b0b5915aa8f895dff76bae43c3d) dotenvx: 1.45.2 -> 1.48.3
* [`d3f3671d`](https://github.com/NixOS/nixpkgs/commit/d3f3671d4e66036ad7c2bf7beb84db6b16079d61) mysql_jdbc: 9.3.0 -> 9.4.0
* [`6f5c7308`](https://github.com/NixOS/nixpkgs/commit/6f5c730889b92133a3f6e9b3fd4a2b23dfcf07f6) upterm: 0.14.3 -> 0.15.0
* [`787f1794`](https://github.com/NixOS/nixpkgs/commit/787f1794d15bc36a5449e05855e4be126511c5b5) protoc-gen-es: 2.6.1 -> 2.6.2
* [`6660d471`](https://github.com/NixOS/nixpkgs/commit/6660d4714c2ccb5245448cee7cb1d2427f11619c) maa-assistant-arknights: 5.20.0 -> 5.21.1
* [`fc6be91e`](https://github.com/NixOS/nixpkgs/commit/fc6be91e4d90d7a212b0e39c77d46aaea867503f) gildas: 20250701_a -> 20250701_b
* [`76e61bc4`](https://github.com/NixOS/nixpkgs/commit/76e61bc403c7fb69bf35dc5ec951e8e1050d4ba1) krillinai: 1.3.0 -> 1.3.1
* [`5cced1bb`](https://github.com/NixOS/nixpkgs/commit/5cced1bb35c931bfec4f94da3df0fcee52e97007) nushellPlugins.highlight: 1.4.7+0.105.1 -> 1.4.8+0.106.0
* [`31580377`](https://github.com/NixOS/nixpkgs/commit/3158037749dc4119365886fa2a43b7494e797b08) mdfried: 0.12.2 -> 0.12.4
* [`6448c640`](https://github.com/NixOS/nixpkgs/commit/6448c640b963eb5e480ef384628eed20a6bed16f) kubernetes-kcp: 0.27.1 -> 0.28.0
* [`008adf53`](https://github.com/NixOS/nixpkgs/commit/008adf53f92ae0eba9e04fadd7cd5428dc1d7bf1) python3Packages.tokenizers: 0.21.3 -> 0.21.4
* [`b0e56fb9`](https://github.com/NixOS/nixpkgs/commit/b0e56fb99b48060a7c39bef8021efeca45adb22f) tg-timer: init at 0.7.0
* [`08ea9971`](https://github.com/NixOS/nixpkgs/commit/08ea9971c854ca98f8cb2872cbea1fe387bf2c46) nexttrace: 1.4.0 -> 1.4.2
* [`564c1af5`](https://github.com/NixOS/nixpkgs/commit/564c1af5b959ec2ec754259c55b2f93be7fe8f99) seq66: 0.99.20 -> 0.99.21
* [`e58d1953`](https://github.com/NixOS/nixpkgs/commit/e58d1953a43a2d881b605b5e3abe0bc6ddbeefba) vaultwarden: 1.34.1 -> 1.34.2
* [`dbe7d385`](https://github.com/NixOS/nixpkgs/commit/dbe7d3851608a28ca1b42d02e827db67e3cad644) vaultwarden.webvault: 2025.5.0.0 -> 2025.7.0.0
* [`417eb0e3`](https://github.com/NixOS/nixpkgs/commit/417eb0e3b732828fa86dfa8d4702693c94559ec1) container2wasm: 0.8.2 -> 0.8.3
* [`864811bd`](https://github.com/NixOS/nixpkgs/commit/864811bd675e2d287bd9318959a4c0b9772c8d21) vscode-extensions.ziglang.vscode-zig: 0.6.11 -> 0.6.12
* [`e17893f4`](https://github.com/NixOS/nixpkgs/commit/e17893f45012c88ff9317d68155344620bf0e779) gwyddion: 2.68 -> 2.69
* [`78589d66`](https://github.com/NixOS/nixpkgs/commit/78589d665327028d767fb6feab9c62708caee11d) pulumi-esc: 0.14.3 -> 0.15.0
* [`addd2a41`](https://github.com/NixOS/nixpkgs/commit/addd2a413ba4979a45c0484301528eec6b374019) ankiAddons.anki-quizlet-importer-extended: init at 2025.03.13
* [`a3f7ce8e`](https://github.com/NixOS/nixpkgs/commit/a3f7ce8ec2acf81c7c7ca7ad18f49b5b299178d1) dart: 3.8.1 -> 3.8.2
* [`83aa62b2`](https://github.com/NixOS/nixpkgs/commit/83aa62b2463415b3564efcf64260efb7593c2e4b) lynis: 3.1.4 -> 3.1.5
* [`635bd4d7`](https://github.com/NixOS/nixpkgs/commit/635bd4d71ad75f6b804ed5fb6739d116aa4cf341) oscar: 1.6.0 -> 1.6.1
* [`16e356cb`](https://github.com/NixOS/nixpkgs/commit/16e356cb23b1f7cd0ad7e4bf5792dcfd366c1ea9) git-statuses: 0.4.0 -> 0.5.1
* [`9855b727`](https://github.com/NixOS/nixpkgs/commit/9855b727c6e0cb1c45c2ac536c9cf6bafd064109) gclient2nix: add fuchsia to platform list
* [`607ab003`](https://github.com/NixOS/nixpkgs/commit/607ab00371f5617e81b0e7c6054c7c2946f28432) git-statuses: install shell completion
* [`e2d1a158`](https://github.com/NixOS/nixpkgs/commit/e2d1a15821708917aab469c04661de5a7667fbcb) oniux: 0.5.0 -> 0.6.0
* [`e04e700f`](https://github.com/NixOS/nixpkgs/commit/e04e700f987ce8d6737218c5f3b840f484df80a7) privatebin: 1.7.8 -> 2.0.0
* [`dd94c2d4`](https://github.com/NixOS/nixpkgs/commit/dd94c2d4109dbd6629d69e4f62a411947ec147f2) stylelint: 16.22.0 -> 16.23.0
* [`3e15b6c8`](https://github.com/NixOS/nixpkgs/commit/3e15b6c8d762ee6ae2980040a48c0d8401b18181) mumble: Switch to upstream build system: ninja
* [`16e3556f`](https://github.com/NixOS/nixpkgs/commit/16e3556f2211629189cdb507cf7de44e1aee86c8) edl: 3.52.1-unstable-2025-06-08 -> 3.52.1-unstable-2025-07-28
* [`643032ea`](https://github.com/NixOS/nixpkgs/commit/643032ea4fdfc92b01d20826e04abecfb4592adb) openxr-loader: 1.1.49 -> 1.1.50
* [`91775829`](https://github.com/NixOS/nixpkgs/commit/91775829fc43391aae2e267a2e61fd8a2a64aa09) codeql: 2.22.1 -> 2.22.2
* [`0c850ee8`](https://github.com/NixOS/nixpkgs/commit/0c850ee8661ad6a644734867486c9167a3b219ad) protonplus: 0.5.9 -> 0.5.12
* [`0722e56d`](https://github.com/NixOS/nixpkgs/commit/0722e56da77f25739b1f4971895704336f44c38b) atmos: 1.182.0 -> 1.183.1
* [`78318bc9`](https://github.com/NixOS/nixpkgs/commit/78318bc94ddf174d7eb2001182adbb97fb280504) python3Packages.ml-dtypes: 0.5.2 -> 0.5.3
* [`6155cb14`](https://github.com/NixOS/nixpkgs/commit/6155cb1401ba40049fad460b2b23d005a52b6c3e) fluxcd-operator-mcp: 0.24.1 -> 0.26.0
* [`de67f8b5`](https://github.com/NixOS/nixpkgs/commit/de67f8b54eeaa99fd6332170faaa310bdb29fdb3) kubebuilder: 4.5.1 -> 4.7.0
* [`68d2a413`](https://github.com/NixOS/nixpkgs/commit/68d2a413b0460ab17ac0fb97928f3c42c9cc0bb1) python3Packages.google-cloud-pubsub: 2.30.0 -> 2.31.1
* [`b0e1f082`](https://github.com/NixOS/nixpkgs/commit/b0e1f0828122697dae6871011302b9eeda8549ac) docker-buildx: 0.25.0 -> 0.26.1
* [`dc47ec03`](https://github.com/NixOS/nixpkgs/commit/dc47ec03b47b2b2463b7fc9508a4a8bca85b6627) python3Packages.rlp: 4.0.0 -> 4.1.0
* [`978e4370`](https://github.com/NixOS/nixpkgs/commit/978e4370d9f040f0a57662def5370d430105a2fe) python3Pacakges.py-ecc: 7.0.0 -> 8.0.0
* [`1465130c`](https://github.com/NixOS/nixpkgs/commit/1465130c05585ca75e5d84a003c9f971be25d99c) python3Packages.trie: 3.0.1 -> 3.1.0
* [`80a4d69b`](https://github.com/NixOS/nixpkgs/commit/80a4d69b1d783196a6bf5dae1bab2e02aa0ec96a) python3Packages.eth-typing: 5.1.0 -> 5.2.1
* [`1c90d71c`](https://github.com/NixOS/nixpkgs/commit/1c90d71c2815cea4c4542f371312eb438e7ab6ee) python3Packages.eth-utils: 5.1.0 -> 5.3.0
* [`14f90a64`](https://github.com/NixOS/nixpkgs/commit/14f90a64011637e10b8f94f3b989010c6fafb704) python3Packages.eth-account: 0.13.5 -> 0.13.7
* [`b48f0d7d`](https://github.com/NixOS/nixpkgs/commit/b48f0d7d32752dc4f2176c0a4e98f1fc62f0c5dd) python3Packages.eth-keyfile: 0.8.1 -> 0.9.1
* [`64a7489c`](https://github.com/NixOS/nixpkgs/commit/64a7489c3f4cf4507cc3f038e52de69bdf4c7cef) python3Packages.eth-keys: 0.6.0 -> 0.7.0
* [`c5dd7d74`](https://github.com/NixOS/nixpkgs/commit/c5dd7d749d5d260fa445fd41ce69876954b78677) python3Packages.hexbytes: 1.2.0 -> 1.3.1
* [`9a378e92`](https://github.com/NixOS/nixpkgs/commit/9a378e929ca3d8e4392b3a944134989a4f21af1c) python3Packages.py-evm: 0.10.1-beta.2 -> 0.12.1-beta.1
* [`938a88c3`](https://github.com/NixOS/nixpkgs/commit/938a88c36ecb8b18423de58b855c2e86afe634a9) python3Packages.eth-abi: 5.1.0 -> 5.2.0
* [`e0f15338`](https://github.com/NixOS/nixpkgs/commit/e0f15338b7db405cc9b18afd407a24a03647e2d8) python3Packages.eth-tester: 0.12.0-beta.2 -> 0.13.0-beta.1
* [`a90678ad`](https://github.com/NixOS/nixpkgs/commit/a90678ad2cba94f5a0b774f1cbeabf0da4aad85d) python3Packages.eth-rlp: 2.1.0 -> 2.2.0
* [`9306e311`](https://github.com/NixOS/nixpkgs/commit/9306e311ca844472e9619c7158cea34aee6ff8ea) python3Packages.web3: 7.8.0 -> 7.12.1
* [`e8b4b8b9`](https://github.com/NixOS/nixpkgs/commit/e8b4b8b9e6d5b522cc79961c8405fda36a9e2d8b) python3Packages.slither-analyzer: 0.10.3 -> 0.11.3
* [`6c180919`](https://github.com/NixOS/nixpkgs/commit/6c1809192c42bf64a46abd6187eadbf6618fcba9) ch9344: support Linux 6.16
* [`530c9a4d`](https://github.com/NixOS/nixpkgs/commit/530c9a4d4c7d8f0b3535ce9a8a3cc8d0044914cd) osm-gps-map: patch out libsoup 2
* [`ac8d1e76`](https://github.com/NixOS/nixpkgs/commit/ac8d1e76d09a453346a644053618eb46119f8e68) oh-my-zsh: 2025-07-01 -> 2025-07-28
* [`4f5e540a`](https://github.com/NixOS/nixpkgs/commit/4f5e540a102e4bdfc7a38c79951d6fddf65e31ec) eternal-terminal: 6.2.9 -> 6.2.11
* [`1876a365`](https://github.com/NixOS/nixpkgs/commit/1876a3655ce75b92b108c8ac4f527858a7543800) alibuild: 1.17.21 -> 1.17.26
* [`55cf9530`](https://github.com/NixOS/nixpkgs/commit/55cf9530c0db4e09a28bd6d92ce85a2bb9b02a97) vaultwarden: 1.34.2 -> 1.34.3
* [`a0a6c891`](https://github.com/NixOS/nixpkgs/commit/a0a6c89156421a0353c111542256fb0734affdb7) Augment to support x86 and arm64
* [`677b38ab`](https://github.com/NixOS/nixpkgs/commit/677b38ab341d7da4d8399a979792d17b52466c9c) chawan: 0.2.1 -> 0.2.2
* [`0512c74e`](https://github.com/NixOS/nixpkgs/commit/0512c74e41ae6c910152fd299adbd796f32c6183) geeqie: replace libchamplain with libchamplain_libsoup3
* [`dfd25086`](https://github.com/NixOS/nixpkgs/commit/dfd250868b82c9b206abbe14fe32893469edb79c) docker_28: 28.3.2 -> 28.3.3
* [`ff6b64f2`](https://github.com/NixOS/nixpkgs/commit/ff6b64f296fabba00e6d53c0b5c0dacd7f53acda) docker_25: 25.0.11 -> 25.0.12
* [`9c249cf0`](https://github.com/NixOS/nixpkgs/commit/9c249cf00b2c4ff09904c86e2b0d574864653142) zipline: add meta.downloadPage
* [`6087625a`](https://github.com/NixOS/nixpkgs/commit/6087625ade5740b32785d3467332a5d93a64de64) zipline: 4.2.0 -> 4.2.1
* [`d7f7648f`](https://github.com/NixOS/nixpkgs/commit/d7f7648fe5f9e423cfe19c9b18a5b9a403693691) xgboost: 3.0.2 -> 3.0.3
* [`ec82ddc9`](https://github.com/NixOS/nixpkgs/commit/ec82ddc977dc3121e7fc601af1b90838375f6e14) zipline: set git sha
* [`fc5d1ff6`](https://github.com/NixOS/nixpkgs/commit/fc5d1ff631cf8d83400832c32132a6ad5b021621) cilium-cli: 0.18.5 -> 0.18.6
* [`e7d401d0`](https://github.com/NixOS/nixpkgs/commit/e7d401d09c7576d1acb7b66a1bdd3544848c28f8) cef-binary: 138.0.17 -> 138.0.33
* [`52d6c20d`](https://github.com/NixOS/nixpkgs/commit/52d6c20d53380f676f1c0bf9993fe2793e516f60) ibus-engines.typing-booster-unwrapped: 2.27.68 -> 2.27.72
* [`56f7ba5b`](https://github.com/NixOS/nixpkgs/commit/56f7ba5b1413706480da3ddf67e5df19d380e0e2) rofi-bluetooth: unstable-2023-02-03 -> 0-unstable-2025-04-14
* [`c2e3bcd5`](https://github.com/NixOS/nixpkgs/commit/c2e3bcd53aa8717061b3a6dd8697b87327606e6f) debianutils: 5.23.1 -> 5.23.2
* [`70151570`](https://github.com/NixOS/nixpkgs/commit/7015157054164a3db69ced98263e9c50c7da0db3) lsfg-vk: init at 1.0.0
* [`1bb668b7`](https://github.com/NixOS/nixpkgs/commit/1bb668b7eba161536e8860191d54e9c4f8a0a134) lsfg-vk-ui: init at 1.0.0
* [`a59bbf69`](https://github.com/NixOS/nixpkgs/commit/a59bbf69f424d67f4ee703f4d9abbc93db8f4359) python3Packages.streamlit: 1.46.0 -> 1.47.1
* [`23ec993c`](https://github.com/NixOS/nixpkgs/commit/23ec993c04ddbf97a2981e912799774f697e72c9) container 0.2.0 -> 0.3.0
* [`9048da1e`](https://github.com/NixOS/nixpkgs/commit/9048da1eb20bf54d6f4df8a78de65ad59eb3b7f3) deno: 2.4.2 -> 2.4.3
* [`63ae28d2`](https://github.com/NixOS/nixpkgs/commit/63ae28d2c8de50d6226b7495360df5e60b99e198) flashrom: 1.5.1 -> 1.6.0
* [`d1a518ba`](https://github.com/NixOS/nixpkgs/commit/d1a518ba2b06ed057e6695892c09d0ede9a28606) python3Packages.pymdown-extensions: 10.15 -> 10.16.1
* [`56b4e4f8`](https://github.com/NixOS/nixpkgs/commit/56b4e4f81d1cdfdb8dc8370631f5faabb565af92) opentelemetry-collector-builder: 0.129.0 -> 0.131.0
* [`ebd217f9`](https://github.com/NixOS/nixpkgs/commit/ebd217f981dad624bd4e56ce6749527b0a06b0ae) youtube-tui: 0.8.3 -> 0.9.0
* [`6df45ae2`](https://github.com/NixOS/nixpkgs/commit/6df45ae2813b31d4f8c893c54ff70298032a6638) nixos/system-path: add corePackages option
* [`f5ffdbfe`](https://github.com/NixOS/nixpkgs/commit/f5ffdbfeb0c0850ce76a9569096547e376f47a3e) nixos/network-interfaces: add packages to corePackages
* [`400882d4`](https://github.com/NixOS/nixpkgs/commit/400882d409cca20ef3a88502c5e6f7d9be4b34e2) nixos/kernel: don't include append-initrd-secrets when unused
* [`089e2e5e`](https://github.com/NixOS/nixpkgs/commit/089e2e5eaff96a3873739e396afb458013ecaf9e) nixos/activation-script: disable userActivationScripts when system is not activatable
* [`eca55074`](https://github.com/NixOS/nixpkgs/commit/eca55074cb9ceb1fae09d948f3a1b657fd990a39) nixos/fuse: add enable option
* [`9948eade`](https://github.com/NixOS/nixpkgs/commit/9948eade4d482c80dd84ba35393507b9af240c98) buf: 1.55.1 -> 1.56.0
* [`52fb9ff2`](https://github.com/NixOS/nixpkgs/commit/52fb9ff20eecd6a39358338979120aa627d24df8) cudaPackages.cuda_cudart: move *.pc file to lib/pkgconfig
* [`84e39be3`](https://github.com/NixOS/nixpkgs/commit/84e39be3fc284ae717337621ce1abc001988dc77) python3Packages.gotrue: 2.12.0 -> 2.12.3
* [`3eb24679`](https://github.com/NixOS/nixpkgs/commit/3eb2467926ff0a2eb980965f8a286f7c444c7739) unityhub: remove 2019 support since gconf is broken
* [`1d1c808e`](https://github.com/NixOS/nixpkgs/commit/1d1c808e2851e12d9e496e443d53aad81b3691b4) unityhub: move to pkgs/by-name
* [`61ede8ed`](https://github.com/NixOS/nixpkgs/commit/61ede8ed23386c29871335a0b6c8b026a5dd176e) waydroid-helper: various fixes
* [`88df1b40`](https://github.com/NixOS/nixpkgs/commit/88df1b409fc07d82af8bdc7c31b8eb90258a70f9) waydroid-helper: 0.1.2 -> 0.2.3
* [`10cbc86a`](https://github.com/NixOS/nixpkgs/commit/10cbc86a5c2c628c6fa11ae5c05659a2d6f8797b) waydroid-helper: sort
* [`c9207b0f`](https://github.com/NixOS/nixpkgs/commit/c9207b0f818a25e200dc723ae922628fdce6dab2) grafanaPlugins.volkovlabs-variable-panel: 4.0.0 -> 4.1.0
* [`188a8288`](https://github.com/NixOS/nixpkgs/commit/188a82889e1caee540600a78c1461ee36bd5bf41) wt: 4.11.4 -> 4.12.0
* [`f5461d0f`](https://github.com/NixOS/nixpkgs/commit/f5461d0f09e1a890ce5b3785a3ff702d5a91e464) opa-envoy-plugin: 1.6.0-envoy-2 -> 1.7.1-envoy
* [`db42eeba`](https://github.com/NixOS/nixpkgs/commit/db42eeba6b191e01356d4537546a9ca33699ad61) nixos/iso-image: Support systemd initrd
* [`6428768e`](https://github.com/NixOS/nixpkgs/commit/6428768e431ceb72ef46f3056c7360f1fdd2ca1e) blisp: 0.0.4 -> 0.0.5
* [`9d39a082`](https://github.com/NixOS/nixpkgs/commit/9d39a0828113d0798f70f3df53d889c4bd7a499b) katana: 1.1.3 -> 1.2.1
* [`5ff1b303`](https://github.com/NixOS/nixpkgs/commit/5ff1b30307577df5393ee8a3af3bfe35f18687c3) azurite: 3.34.0 -> 3.35.0
* [`0e85afda`](https://github.com/NixOS/nixpkgs/commit/0e85afdad01e3d4e3d30519dfec79027425c573c) fosrl-pangolin: 1.2.0 -> 1.8.0
* [`281244d1`](https://github.com/NixOS/nixpkgs/commit/281244d1b45f65e379ebaf36433b3fa5ff57e9fc) kimai: 2.36.1 -> 2.37.0
* [`f49ac123`](https://github.com/NixOS/nixpkgs/commit/f49ac123c688e8252a5f686b5710469d2e5d3096) python3Packages.backtesting: 0.6.4 -> 0.6.5
* [`b350fb4a`](https://github.com/NixOS/nixpkgs/commit/b350fb4a8154093825949b563bc1dad2b87a0550) vue-language-server: 3.0.1 -> 3.0.4
* [`e91a1270`](https://github.com/NixOS/nixpkgs/commit/e91a1270c2a3ab76243a4016f54e88b96c8a697c) containerd: 2.1.3 -> 2.1.4
* [`cc20f14a`](https://github.com/NixOS/nixpkgs/commit/cc20f14ae45dc220af298c3d14ff16ac016573e3) nixos/kexec: add enable option
* [`63b7ebbd`](https://github.com/NixOS/nixpkgs/commit/63b7ebbdb18084d2726d95f1d34416b11f9c7fb7) nixos/bash: re-introduce enable option
* [`d9ce0679`](https://github.com/NixOS/nixpkgs/commit/d9ce06790d3d58ee8139017658774e98f359e8c3) stdenv: Remove extra merge operator in meta
* [`9af1f695`](https://github.com/NixOS/nixpkgs/commit/9af1f69529dec2c6f9774f02a2f50662808591e3) ting: init at 0.1.0
* [`acf3679d`](https://github.com/NixOS/nixpkgs/commit/acf3679dcee3a3ee506cc610fe857ef351628d23) cue: 0.13.2 -> 0.14.0
* [`86f78c00`](https://github.com/NixOS/nixpkgs/commit/86f78c00cee567656785d9a044d6ff02c04171e6) airgeddon: 11.50 -> 11.51
* [`0e15d9a4`](https://github.com/NixOS/nixpkgs/commit/0e15d9a4b993cd3f15ef429d6e539d92ae9412c6) exegol: rename to exegol4
* [`90614947`](https://github.com/NixOS/nixpkgs/commit/90614947857ea700f66724bf488e6d3e1e8f190a) renovate: 41.21.3 -> 41.49.0
* [`7d442d65`](https://github.com/NixOS/nixpkgs/commit/7d442d6579a4cd5963170e0cf57a4f0c9b3ae921) exegol: 4.3.11 -> 5.1.1
* [`90adcba2`](https://github.com/NixOS/nixpkgs/commit/90adcba2133616da92370ba5a5246be1c58dbe86) material-kwin-decoration: migrate to by-name
* [`f882afff`](https://github.com/NixOS/nixpkgs/commit/f882afff2c68092ac29f1b953fb24bf88a8e3cb0) kora-icon-theme: migrate to by-name
* [`98ed6675`](https://github.com/NixOS/nixpkgs/commit/98ed667537829499b5400d6232301c1cd7efe6d6) bind: fix cross compilation
* [`357c7e5f`](https://github.com/NixOS/nixpkgs/commit/357c7e5f2e48f9d47060afca96f7a819845599d3) noto-fonts: 2025.07.01 -> 2025.08.01
* [`c6dcf38f`](https://github.com/NixOS/nixpkgs/commit/c6dcf38f77fad6193502714863ae6d795c208589) openimageio: 3.0.8.1 -> 3.0.9.0
* [`51462b8a`](https://github.com/NixOS/nixpkgs/commit/51462b8a68c06fb3886feb53a429a143acbad122) nixos/traccar: Rework configuration file creation.
* [`be3916c4`](https://github.com/NixOS/nixpkgs/commit/be3916c40e0830503841bc98bd96ccbebef2ec45) nixos/lomiri: Replace NIX_GSETTINGS_OVERRIDES_DIR with Dconf database
* [`d1cef34d`](https://github.com/NixOS/nixpkgs/commit/d1cef34d092c16ae28bc72e77a6c87b77ac7d992) lomiri.lomiri-gsettings-overrides: Drop
* [`4529ed91`](https://github.com/NixOS/nixpkgs/commit/4529ed911451f941ae8f79218abe7c9f46e7e874) nixosTests.lomiri: Replace wallpaper service with Dconf setting
* [`7a787e12`](https://github.com/NixOS/nixpkgs/commit/7a787e122bb704cf5a889ccdb3e1fcd773480f49) lib.modules: Add hint when using `config` in `imports`
* [`77ff2272`](https://github.com/NixOS/nixpkgs/commit/77ff2272cdb67b7cd18ae74d5c557febd4f12532) nixos/k3s: fix undefined variable error
* [`07a94c65`](https://github.com/NixOS/nixpkgs/commit/07a94c65fd9797ba30295747fd6c881893881f2f) nixos/k3s: extend autoDeployCharts test to cover charts with values file
* [`c8d099c6`](https://github.com/NixOS/nixpkgs/commit/c8d099c63a3a3a0de4b135ae579ce5f455c1c1ce) nixos/k3s: remove usages of with builtins
* [`c5b84bff`](https://github.com/NixOS/nixpkgs/commit/c5b84bff0cf5353aa7b609306c7e409c81534b45) langgraph-cli: 0.2.10 -> 0.3.6
* [`5dcc8a5f`](https://github.com/NixOS/nixpkgs/commit/5dcc8a5f1e21f887de51f874ed97688ba1301933) ecs-agent: 1.96.0 -> 1.97.0
* [`f273a07d`](https://github.com/NixOS/nixpkgs/commit/f273a07dffcf96d69644ab12457341205312aaf7) linuxPackages.openafs: Patch for Linux kernel 6.16
* [`6e0b3898`](https://github.com/NixOS/nixpkgs/commit/6e0b3898fb5e4dc8e9261f88e26b9f0a8669a3b4) oqs-provider: 0.9.0 -> 0.10.0
* [`ed5e8dee`](https://github.com/NixOS/nixpkgs/commit/ed5e8dee708a6635acbd12035cfe098b22abe85d) grafanaPlugins.victoriametrics-metrics-datasource: 0.17.0 -> 0.18.2
* [`b80b7b57`](https://github.com/NixOS/nixpkgs/commit/b80b7b571f965b6c23dc36f5d4583a26adc261e2) grafanaPlugins.victoriametrics-logs-datasource: 0.18.1 -> 0.19.2
* [`6525fbba`](https://github.com/NixOS/nixpkgs/commit/6525fbbaf3edea461444013d7150be18952e0b12) nixosTests.lomiri: Fix session & keymap tests
* [`56a85ee6`](https://github.com/NixOS/nixpkgs/commit/56a85ee6590102c83805c9bd44ffd460c497eb2a) centrifugo: 6.2.2 -> 6.2.4
* [`c97bb6f7`](https://github.com/NixOS/nixpkgs/commit/c97bb6f7ec73a309117cf0f85b68fef4fa458677) ilspycmd: 9.0-preview3 -> 9.1
* [`1bfa47c7`](https://github.com/NixOS/nixpkgs/commit/1bfa47c7a755cca3923d389848990e7a99298929) davinci-resolve{,studio}: 20.0 -> 20.0.1
* [`6c8c88c6`](https://github.com/NixOS/nixpkgs/commit/6c8c88c6229534778cfa03a8a1fd83aa198a79de) buildMix: default to removing target config
* [`b9a1b0d1`](https://github.com/NixOS/nixpkgs/commit/b9a1b0d1f494e8fd06893ef58e90cba604b2dab2) pwsafe: 1.21.0fp -> 1.22.0fp
* [`a271356a`](https://github.com/NixOS/nixpkgs/commit/a271356a4a7bcace91927e7e9744d3f24d5c2297) contact: init at 1.3.16
* [`e28f3f0c`](https://github.com/NixOS/nixpkgs/commit/e28f3f0cd018d60a3793cb705b5a24f76b78dedd) lib.modules: Test infinite recursion hint
* [`3ad01858`](https://github.com/NixOS/nixpkgs/commit/3ad01858c5e0316de7a7e40568ed217a126e5fb7) nixos/snips-sh: init module
* [`98460649`](https://github.com/NixOS/nixpkgs/commit/98460649ab80823a0bbe289b40e06403041817f4) nixosTests.snips-sh: init
* [`e01a50d5`](https://github.com/NixOS/nixpkgs/commit/e01a50d5bfd68874d9b3e2f23f7e2c8bf9097a40) snips-sh: add NixOS test
* [`9dad048f`](https://github.com/NixOS/nixpkgs/commit/9dad048f2118dd8678b8fbf69b7355b9a399d3cf) lib.modules: Generalize the import hint to _module.args
* [`3d15b12d`](https://github.com/NixOS/nixpkgs/commit/3d15b12d8f7acd0764a3cf08a2b3b58db4449a26) lib.modules: Make _module.args evaluation explicit in trace
* [`c34e0848`](https://github.com/NixOS/nixpkgs/commit/c34e08489ec87a23cd18dd4f6035c840071995b9) lib.modules: Adjust error message
* [`05635422`](https://github.com/NixOS/nixpkgs/commit/05635422e00408218dda5cb08f5be4e7fc86af55) python3Packages.auditwheel: 6.4.0 -> 6.4.2
* [`bf1ed585`](https://github.com/NixOS/nixpkgs/commit/bf1ed58534bd9bcdc8d958e84fcfa573d4fde3db) .devcontainer: nixfmt-rfc-style -> nixfmt
* [`3d070424`](https://github.com/NixOS/nixpkgs/commit/3d070424cfbb983031bbbb1809bcbe0c334275ab) python3Packages.pybase64: 1.4.1 -> 1.4.2
* [`a326bc6c`](https://github.com/NixOS/nixpkgs/commit/a326bc6ce690700598226553e52ec7a09a41a797) python3Packages.smp: 3.3.1 -> 3.3.2
* [`7628faf0`](https://github.com/NixOS/nixpkgs/commit/7628faf01d8347d7aceb1d91291ee142bf6aab07) telegram-desktop: 5.16.4 -> 6.0.2
* [`287c9751`](https://github.com/NixOS/nixpkgs/commit/287c9751167baecada36692cdf097ad4a957f35b) timeshift: 24.06.6 -> 25.07.4
* [`30a9a6f0`](https://github.com/NixOS/nixpkgs/commit/30a9a6f032562fcc3816b4b67420e22db8da9dc3) protoc-gen-entgrpc: 0.6.0 -> 0.7.0
* [`2dfb965a`](https://github.com/NixOS/nixpkgs/commit/2dfb965aff71fe9d20a85af5b632a0aa2f607217) mitra: 4.6.0 -> 4.7.0
* [`615e5d7b`](https://github.com/NixOS/nixpkgs/commit/615e5d7b86f5526e66e24acac1e9efae9b054524) snes9x: move out of top-level
* [`b1123057`](https://github.com/NixOS/nixpkgs/commit/b1123057f50d03424e8715436ac7d7869c935052) squawk: 2.21.0 -> 2.21.1
* [`eb17e8bd`](https://github.com/NixOS/nixpkgs/commit/eb17e8bd7030fd76a47b2f361b2bf0cd4f533e11) apio: migrate to by-name
* [`2a8bfd27`](https://github.com/NixOS/nixpkgs/commit/2a8bfd27eabd69b1ffe859a0feb206cc4ed3fece) python3Packages.ddgs: 9.4.3 -> 9.5.1
* [`c3f0b0da`](https://github.com/NixOS/nixpkgs/commit/c3f0b0da54d16c833daf29cfb5d6440c87022417) crun: 1.22 -> 1.23.1
* [`ca16d03d`](https://github.com/NixOS/nixpkgs/commit/ca16d03ddbb6c8f33a9f67de2ee61bfbbfe09b9e) fishPlugins.macos: 7.0.1 -> 7.1.0
* [`de74240d`](https://github.com/NixOS/nixpkgs/commit/de74240d03acfd332c99dce42fc93239dcaa9cdf) awscli2: 2.27.61 -> 2.28.1
* [`3d98a498`](https://github.com/NixOS/nixpkgs/commit/3d98a4985618ad4c76c006b3c4942beb1a9aabfb) greetd.*: move to 'pkgs/by-name' and top level
* [`78e7bb6a`](https://github.com/NixOS/nixpkgs/commit/78e7bb6ad583bb5e9f0d3a58a175a1c7f018b543) greetd: clean up and modernize
* [`b4704ef1`](https://github.com/NixOS/nixpkgs/commit/b4704ef13e2fc440e453ebcf29c6dbe60b86655d) greetd: add update script
* [`478930a7`](https://github.com/NixOS/nixpkgs/commit/478930a7126a919b0494c4380d252f24413ad85b) gtkgreet: clean up and modernize
* [`32d4d81c`](https://github.com/NixOS/nixpkgs/commit/32d4d81c957ab0ccf7c70467f2f4cdf2ca57901d) gtkgreet: add update script
* [`e487dee1`](https://github.com/NixOS/nixpkgs/commit/e487dee12f50ed7ba6337f0d4d03c7c3f22838ce) regreet: clean up and modernize
* [`3f53712e`](https://github.com/NixOS/nixpkgs/commit/3f53712e6e17e45c4db198118249e35d8d5a2efe) regreet: add update script
* [`525b40eb`](https://github.com/NixOS/nixpkgs/commit/525b40ebed4d4bcd70decab1e332190ab51b4168) tuigreet: clean up and modernize
* [`d4bc7464`](https://github.com/NixOS/nixpkgs/commit/d4bc74646acffd6c7c42e4c3ea1b0467cc672064) tuigreet: add update script
* [`b61108a7`](https://github.com/NixOS/nixpkgs/commit/b61108a776c6030aa53397ff4546f89f4d134358) wlgreet: clean up and modernize
* [`3b1824f7`](https://github.com/NixOS/nixpkgs/commit/3b1824f7032cf7ebd2b5cd6bcdf2d5d3ec18c603) wlgreet: add update script
* [`7b8c7a16`](https://github.com/NixOS/nixpkgs/commit/7b8c7a16b7315ccbd879bd77d74a795c646beb69) trexio: 2.5.0 -> 2.6.0
* [`c8d34e88`](https://github.com/NixOS/nixpkgs/commit/c8d34e88f49b8c51d4cf2090b163a82954813ed2) matrix-synapse: 1.134.0 -> 1.135.0
* [`ceac5080`](https://github.com/NixOS/nixpkgs/commit/ceac5080ea5f001505ca38da96947821418122e6) json-fortran: 9.0.3 -> 9.0.4
* [`f054be2d`](https://github.com/NixOS/nixpkgs/commit/f054be2d658c637651c7adffa30009a88001b9ac) renode-unstable: 1.15.3+20250720git2309db7fd -> 1.15.3+20250801git3f8169b88
* [`e31923bd`](https://github.com/NixOS/nixpkgs/commit/e31923bdf47a9db7ef019bd90e50aa1ef2f5e69c) coin3d: 4.0.3 -> 4.0.4
* [`cb292234`](https://github.com/NixOS/nixpkgs/commit/cb292234eba1de00c636e184bff11c02a53300f0) unrar: 7.1.9 -> 7.1.10
* [`25750b26`](https://github.com/NixOS/nixpkgs/commit/25750b264d73f8ccc169c7f5c5eb6864bb78b5f8) nixos/i2pd: add ssu2 options
* [`9200c874`](https://github.com/NixOS/nixpkgs/commit/9200c874c54a477c6e5060f67de7dff3d56f5405) nixosTests.{qtile,qtile-extras}: Seperate to distint tests
* [`7a637d9c`](https://github.com/NixOS/nixpkgs/commit/7a637d9c2da700ff18163981e358f420fe6852f0) unityhub: 3.12.1 -> 3.13.1
* [`c7e09fa1`](https://github.com/NixOS/nixpkgs/commit/c7e09fa10fe6a08484e1b3508bcb9d8cf11787b6) flyctl: 0.3.161 -> 0.3.164
* [`9aef52d3`](https://github.com/NixOS/nixpkgs/commit/9aef52d30a089919e2c55b4a32f0efc5c5206fe2) _64gram: 1.1.58 -> 1.1.77
* [`80da1a60`](https://github.com/NixOS/nixpkgs/commit/80da1a606cf5993528be591384e23fb23979c932) materialgram: 5.16.4.1 -> 6.0.0.1
* [`7068fb8b`](https://github.com/NixOS/nixpkgs/commit/7068fb8b30af78b774e7adbed28e69591afe7ec6) garnet: 1.0.78 -> 1.0.79
* [`344f2b10`](https://github.com/NixOS/nixpkgs/commit/344f2b103d097c1acc5dc779e1e962a6c2b7c499) nixosTests.{qtile,qtile-extras}: Use startup hook to determine when wm is ready
* [`7576bbed`](https://github.com/NixOS/nixpkgs/commit/7576bbed5b71a4ee6cf0352bda100f29eba0b809) rio: 0.2.23 -> 0.2.24
* [`0363b4f1`](https://github.com/NixOS/nixpkgs/commit/0363b4f16f856fda8b63d364170f4fb778dc85d1) vscode-extensions.haskell.haskell: 2.6.0 -> 2.6.1
* [`448600ce`](https://github.com/NixOS/nixpkgs/commit/448600ce8f78e5bb13cb7086976e5c68061c9d88) obs-studio-plugins.obs-retro-effects: 1.0.0 -> 1.0.1
* [`80fd0971`](https://github.com/NixOS/nixpkgs/commit/80fd09719cf2f8d7c0d83812b6827e9db901dc34) nvidia-x11.open: allow usage with PREEMPT_RT
* [`b551582d`](https://github.com/NixOS/nixpkgs/commit/b551582dc4c0ec94c38608581c4be7690daa48db) snac2: 2.80 -> 2.81
* [`c931d47c`](https://github.com/NixOS/nixpkgs/commit/c931d47c723705034186cee46e1a0a5ed149c3be) ast-grep: 0.39.1 -> 0.39.2
* [`bef9c27b`](https://github.com/NixOS/nixpkgs/commit/bef9c27b4bef7abffcafc0027c58ca36ea02ffa0) wtfutil: 0.44.1 -> 0.45.0
* [`54a378b1`](https://github.com/NixOS/nixpkgs/commit/54a378b15f96f93b1046be8d663c002e4c6e16c1) vscodium: 1.102.24914 -> 1.102.35058
* [`015a6edc`](https://github.com/NixOS/nixpkgs/commit/015a6edcc045a7667af33f24d4b94ed8e8e422fe) github-runner: 2.326.0 -> 2.327.1
* [`60578704`](https://github.com/NixOS/nixpkgs/commit/60578704388a4d144dbfd4e1fb4addc2c07b88e5) python313Packages.scrypt: 0.8.27 -> 0.8.29
* [`77346cb9`](https://github.com/NixOS/nixpkgs/commit/77346cb9ff039f4f5b6713af7d74bd86f8b7824d) fishPlugins.tide: 6.1.1 -> 6.2.0
* [`02eb6d05`](https://github.com/NixOS/nixpkgs/commit/02eb6d057194cd9670bfe669617161d9e7736f5a) gcc13: 13.3.0 -> 13.4.0
* [`d687cdb8`](https://github.com/NixOS/nixpkgs/commit/d687cdb8697097b99d209d5c7f361d7350d1680c) matrix-alertmanager: 0.8.0 -> 0.9.0
* [`8cdb0f15`](https://github.com/NixOS/nixpkgs/commit/8cdb0f159a3c368c3aa729c642944f4b2be70c07) gnat13Packages.gnatprove: fixup build after gcc13 update
* [`e0383ff8`](https://github.com/NixOS/nixpkgs/commit/e0383ff85a87660550978b21cf2d5aa2c74d6821) arrow: 3.0.0 -> 3.1.0
* [`78545d5e`](https://github.com/NixOS/nixpkgs/commit/78545d5ec031c6d294d5d7960009220943df9d08) komikku: 1.83.0 -> 1.84.0
* [`f33d8a0d`](https://github.com/NixOS/nixpkgs/commit/f33d8a0d1dab27907132fcca0d04ef68d8ad1a27) python313Packages.xiaomi-ble: 1.1.0 -> 1.2.0
* [`b65f0f7d`](https://github.com/NixOS/nixpkgs/commit/b65f0f7dcef767185e92df4c208dd3fb0f476d95) python313Packages.qbusmqttapi: 1.3.0 -> 1.4.2
* [`dcc9ff0a`](https://github.com/NixOS/nixpkgs/commit/dcc9ff0aa33eecb5201e92de549bae39efe33cc6) subtitleedit: 4.0.12 -> 4.0.13
* [`8998b358`](https://github.com/NixOS/nixpkgs/commit/8998b35826e27c3a59e74275b36349bcded5fabe) mkvtoolnix: 93.0 -> 94.0
* [`2bd8641b`](https://github.com/NixOS/nixpkgs/commit/2bd8641b156a7bda566a4b4a7964d0756d4b4e33) python313Packages.authlib: 1.6.0 -> 1.6.1
* [`40950e1e`](https://github.com/NixOS/nixpkgs/commit/40950e1eb3c1d53d4d09ff886b30edc3389b2fa6) python313Packages.apprise: 1.9.3 -> 1.9.4
* [`608f2606`](https://github.com/NixOS/nixpkgs/commit/608f260609b01ecd11d9b76e1f8194d34501dce8) velocity: 3.4.0-unstable-2025-06-11 -> 3.4.0-unstable-2025-08-02
* [`174d72c9`](https://github.com/NixOS/nixpkgs/commit/174d72c9529be1655464d1472b5d7ec46881a7bc) palemoon-bin: 33.8.0 -> 33.8.1.1
* [`0258f52c`](https://github.com/NixOS/nixpkgs/commit/0258f52c9e23c15bd95a6c7fa32f6cf1babc9254) palemoon-gtk2-bin: init at 33.8.1.1
* [`a28c4211`](https://github.com/NixOS/nixpkgs/commit/a28c42116e6a39a6f03340f3c16048009324c38d) vuetorrent: 2.27.0 -> 2.28.1
* [`802cd6ea`](https://github.com/NixOS/nixpkgs/commit/802cd6ea7f99b532e0b45c0fc324d8565750ac16) autobase: 7.7.0 -> 7.17.0
* [`e4702380`](https://github.com/NixOS/nixpkgs/commit/e470238011919b2df8fae7bed1857554e9432a2b) frr: 10.4.0 -> 10.4.1
* [`ac8ddefc`](https://github.com/NixOS/nixpkgs/commit/ac8ddefcca3a456f629a9a6714e10342dee6830a) snapweb: 0.9.0 -> 0.9.1
* [`e776ad34`](https://github.com/NixOS/nixpkgs/commit/e776ad34b04b8018cc06381e182f7ed39d50ea1a) xtf: 0-unstable-2025-07-24 -> 0-unstable-2025-07-26
* [`6bb4d5d4`](https://github.com/NixOS/nixpkgs/commit/6bb4d5d44d326b63416a2a962830d55f7363bf60) python3Packages.pytransportnswv2: 0.8.7 -> 0.8.10
* [`d41ff58a`](https://github.com/NixOS/nixpkgs/commit/d41ff58adc36cbe8b565da3adcea8c5094b85f43) jawiki-all-titles-in-ns0: 0-unstable-2025-07-01 -> 0-unstable-2025-08-01
* [`e5c4486a`](https://github.com/NixOS/nixpkgs/commit/e5c4486af3ec91bc9b10e1da6f4ab820ff491713) cyme: 2.2.3 -> 2.2.4
* [`fd2190fb`](https://github.com/NixOS/nixpkgs/commit/fd2190fbc3ed34db0aaf234d79d4bb8b82ff60ed) carla: 2.5.9 -> 2.5.10
* [`9f5d7335`](https://github.com/NixOS/nixpkgs/commit/9f5d73353364423320fd7f96eb5f612111c7993e) pass-git-helper: 3.3.0 -> 4.0.0
* [`c20cacbf`](https://github.com/NixOS/nixpkgs/commit/c20cacbf2b7fd10ef90853a9235f8d2e5a1b3163) libretro.vice-x128: 0-unstable-2025-07-19 -> 0-unstable-2025-07-30
* [`e3cb5cf4`](https://github.com/NixOS/nixpkgs/commit/e3cb5cf465384d3ce10e497924a3b1b8b4616801) gql: 0.39.0 -> 0.40.0
* [`b665c040`](https://github.com/NixOS/nixpkgs/commit/b665c040886764e0364194369558aaabbeef8d4e) icestudio: 0.12-unstable-2025-03-08 -> 0.12-unstable-2025-08-03
* [`fb67d037`](https://github.com/NixOS/nixpkgs/commit/fb67d037a6a3d6b4a4f532648a4e32e5a1747a69) jsonschema-cli: don't use pname in src
* [`76c385af`](https://github.com/NixOS/nixpkgs/commit/76c385af8d0acc6a798328cceb9aa6c2ee4807da) jsonschema-cli: use finalAttrs instead of rec
* [`b37ad428`](https://github.com/NixOS/nixpkgs/commit/b37ad4281b979547d3680d4028ddfaf8b93367d6) fire: 1.0.1-unstable-2025-03-12 -> 1.0.2-unstable-2025-07-05
* [`79b58002`](https://github.com/NixOS/nixpkgs/commit/79b58002f1e12942895f1f3e03d2001aebe5c1d9) python3Packages.inquirer: 3.4.0 -> 3.4.1
* [`71e30518`](https://github.com/NixOS/nixpkgs/commit/71e305189cdf20ceab8a1a8f25ada91b5fe01b07) ArchiSteamFarm: 6.1.7.8 -> 6.2.0.5
* [`0d28386f`](https://github.com/NixOS/nixpkgs/commit/0d28386fad7b066d0f07498a4c61ed81ae836ec4) naja: 0.2.1 -> 0.2.2
* [`1837155a`](https://github.com/NixOS/nixpkgs/commit/1837155ab32b9e27ad7990f03543d45295623179) typstyle: 0.13.16 -> 0.13.17
* [`c37c9bdd`](https://github.com/NixOS/nixpkgs/commit/c37c9bdd5bf87f1d854a194023693cc5f23fdba4) nextcloudPackages.apps: update
* [`77bd5a72`](https://github.com/NixOS/nixpkgs/commit/77bd5a72b6378cfb19a2ad5af9c65f1de6ad46a1) duckstation: remove
* [`4ffa30a0`](https://github.com/NixOS/nixpkgs/commit/4ffa30a0f02fd91cd1746317b8d5459abad9b81d) duckstation-bin: remove
* [`c8e54fd7`](https://github.com/NixOS/nixpkgs/commit/c8e54fd7dde98d34c70017064804ec72b559c379) python3Packages.axisregistry: 0.4.12 -> 0.4.16
* [`48f811cc`](https://github.com/NixOS/nixpkgs/commit/48f811cc53949e3b15951a1dee2be21ec93d690b) re-isearch: 2.20220925.4.0a-unstable-2025-03-16 -> 2.20220925.4.0a-unstable-2025-05-15
* [`92faf1ad`](https://github.com/NixOS/nixpkgs/commit/92faf1ad7c79f672a6b21b5e9aab8cf7ba19a32f) moonraker: 0.9.3-unstable-2025-07-16 -> 0.9.3-unstable-2025-08-01
* [`ff4d9b8f`](https://github.com/NixOS/nixpkgs/commit/ff4d9b8f495985f1769df98c40255b3932fd29ca) wayland-bongocat: 1.2.2 -> 1.2.3
* [`0162d117`](https://github.com/NixOS/nixpkgs/commit/0162d1179e0205a17fd7bd70772c76500b537e7b) ip2asn: init at 0.1.2
* [`4ad92f79`](https://github.com/NixOS/nixpkgs/commit/4ad92f79ec0de9e07bcd98b4ec566939848b9a50) diffoscope: 302 -> 303
* [`f92169c8`](https://github.com/NixOS/nixpkgs/commit/f92169c861c2fa389a15623569165d76fc78622f) grub2: refactor platforms logic, avoid abusing `meta.broken`
* [`9d173208`](https://github.com/NixOS/nixpkgs/commit/9d17320844d494306344060ced4d1de2a86b5aa5) vscode-extensions.eamodio.gitlens: 17.3.2 -> 17.3.3
* [`1d3cc906`](https://github.com/NixOS/nixpkgs/commit/1d3cc9064ef2575eb85a24be2b618bbdeaa67990) steamworks: Various fixes
* [`f3da09df`](https://github.com/NixOS/nixpkgs/commit/f3da09dfef69b458fae8d4004d34d3c600cc7edb) re-isearch: Disable enableParallelBuilding again
* [`fcf82c51`](https://github.com/NixOS/nixpkgs/commit/fcf82c51ca478ad825546d33d7026cc39c4566c4) _7zz: 25.00 -> 25.01
* [`7abf00a8`](https://github.com/NixOS/nixpkgs/commit/7abf00a8aec89d2eeafe519bb7dc02bca7e7772b) portfolio: 0.77.3 -> 0.78.0
* [`08e20673`](https://github.com/NixOS/nixpkgs/commit/08e206737475db9de0192745aa8f6ff2d9283d9d) k3s: fix update script
* [`1e9d62d0`](https://github.com/NixOS/nixpkgs/commit/1e9d62d094c157e1e9ff5ea25689e034d81d261a) vscode-extensions.detachhead.basedpyright: 1.31.0 -> 1.31.1
* [`9d78192f`](https://github.com/NixOS/nixpkgs/commit/9d78192fbfa58a939898db27dfcd9d6941393099) kanidm_1_7: init at 1.7.0
* [`8dca13f4`](https://github.com/NixOS/nixpkgs/commit/8dca13f41473c44054ad10965331424fe8d7d290) kanidm: add EOL notice and set for 1.6
* [`9b6cad46`](https://github.com/NixOS/nixpkgs/commit/9b6cad46ea7f139329bc067a1abfc7772b841557) kanidm: use package version in tests
* [`3ad9fd2c`](https://github.com/NixOS/nixpkgs/commit/3ad9fd2c464eae92306f08e600985a81b69fe568) maintainers: add mirror230469
* [`083f4c71`](https://github.com/NixOS/nixpkgs/commit/083f4c71b8b74128f00e5373a404e42ebb9c27c1) prosody: add mirror230469 as maintainer
* [`b919d1cd`](https://github.com/NixOS/nixpkgs/commit/b919d1cd8fedc0b085944a52609bfc8fc553caa8) prosody: use finalAttrs pattern
* [`e46dcd70`](https://github.com/NixOS/nixpkgs/commit/e46dcd7074c41d570e7edbc5a8ef159b19c9ebb8) prosody: 0.12.5 -> 13.0.2, nixos/prosody: fix startup
* [`246e3fbf`](https://github.com/NixOS/nixpkgs/commit/246e3fbf0f16b3a8c710ca018d9aeca99c71f1df) nixos/prosody: allow listening on port 80
* [`21e3f8e7`](https://github.com/NixOS/nixpkgs/commit/21e3f8e74201feb65c7a85f334da37ee4bef5e8f) prosody: minor cleanups
* [`187ee9d8`](https://github.com/NixOS/nixpkgs/commit/187ee9d89568fd82f24b35190264005682759b78) prosody: add c3d2 team as maintainer
* [`c26ed9f3`](https://github.com/NixOS/nixpkgs/commit/c26ed9f39126e932759319b0601401f4d3b0c3fd) nixos/prosody: remove vcard_muc as it has been obsoloted
* [`4e12c9b9`](https://github.com/NixOS/nixpkgs/commit/4e12c9b92e1d9dad6f6f4b7fe68b11061c18d593) nixos/prosody: remove obsoloted http_upload and replace it with http_file_share
* [`d323803e`](https://github.com/NixOS/nixpkgs/commit/d323803eee83a3654648f412e1111f0797545ab7) nixos/prosody: minor formatting cleanup
* [`c8094c2f`](https://github.com/NixOS/nixpkgs/commit/c8094c2f0376b70474106f3284fcbfe8c6a2c874) nixos/prosody: fix logged error that /etc/mime.types cannot be found
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
