### PR TITLE
niv home-manager: update c5d7e957 -> d19f3213

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -65,10 +65,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c5d7e957397ecb7d48b99c928611c6e780db1b56",
-        "sha256": "1r6c9smcnx5qfdjjcg9mhqkxds3as7axigwvnlqlqcvagn98id9l",
+        "rev": "d19f3213e51469321835a9188adfa20391ff9371",
+        "sha256": "1dxdx7gkwq692szyzr5j4djq7r70k2y4hvh4fpla485kbwqgsiyz",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/c5d7e957397ecb7d48b99c928611c6e780db1b56.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/d19f3213e51469321835a9188adfa20391ff9371.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@c5d7e957...d19f3213](https://github.com/nix-community/home-manager/compare/c5d7e957397ecb7d48b99c928611c6e780db1b56...d19f3213e51469321835a9188adfa20391ff9371)

* [`36ad7d25`](https://github.com/nix-community/home-manager/commit/36ad7d25fbc60b820d3a06dbf4cf6200948f7fc4) zsh: option to define autoloadable site-functions ([nix-community/home-manager⁠#7611](https://togithub.com/nix-community/home-manager/issues/7611))
* [`0cda19d4`](https://github.com/nix-community/home-manager/commit/0cda19d4209bb28db8fcaa54df4621eb97c36b5d) grep: init module ([nix-community/home-manager⁠#7613](https://togithub.com/nix-community/home-manager/issues/7613))
* [`6d1fddb1`](https://github.com/nix-community/home-manager/commit/6d1fddb13b0663ffd7464c2d39379972502ef126) gcc: init module ([nix-community/home-manager⁠#7614](https://togithub.com/nix-community/home-manager/issues/7614))
* [`672381a3`](https://github.com/nix-community/home-manager/commit/672381a34e2bc7c872f6943d46293f0044c6cf87) fontconfig: add maintainer bmrips
* [`74b4edc2`](https://github.com/nix-community/home-manager/commit/74b4edc2d28cff9b225ef12ebae9ce14948ba8d8) fontconfig: add options for font rendering
* [`28caf471`](https://github.com/nix-community/home-manager/commit/28caf471a643f951e60b4b71d367b990ff6bbbf1) Add self as maintainer
* [`b7ee8dee`](https://github.com/nix-community/home-manager/commit/b7ee8deefca4f88be521077b2f6975618c7e0ab6) programs/nix-search-tv: init
* [`a0b1afdb`](https://github.com/nix-community/home-manager/commit/a0b1afdb5efbf59f4b6e934d090cf8d150517890) news: add new module entries
* [`9b59dcee`](https://github.com/nix-community/home-manager/commit/9b59dcee0b0190de497bfc177687265b665c6c1d) vscode: quote path
* [`c23168ac`](https://github.com/nix-community/home-manager/commit/c23168acf558fc24adc8240533c4fbf9591f183e) vscode: specify full path
* [`f0d81a41`](https://github.com/nix-community/home-manager/commit/f0d81a415d7a8fbf57b518aec5cf7dca20576389) news: add new feature entries
* [`a3790776`](https://github.com/nix-community/home-manager/commit/a3790776751d1a6365aa0717f509d05adee90734) sherlock: init module
* [`8f02266b`](https://github.com/nix-community/home-manager/commit/8f02266b8e49c1c6bbe122b5602e1c877e42c5be) news: fix font config entry
* [`ac351d43`](https://github.com/nix-community/home-manager/commit/ac351d435afd1b648b30202edc3f6390497708ae) tests/news: add new test for news entries
* [`998c2374`](https://github.com/nix-community/home-manager/commit/998c2374f0e332f46ea3100157d0acfcdcfa4e97) news: cleanup invalid timestamps
* [`c15ffc85`](https://github.com/nix-community/home-manager/commit/c15ffc850c1f0dff20602742cd660c32bdaa1c8c) news: fix duplicate news id
* [`f6cc29aa`](https://github.com/nix-community/home-manager/commit/f6cc29aab07640942da39250ac8e23a69ebe0f3e) flake.lock: Update
* [`ad5d2b4a`](https://github.com/nix-community/home-manager/commit/ad5d2b4aa770fdc74c80fd682fee0b00a8ad7991) rescrobbled: add module
* [`88913c98`](https://github.com/nix-community/home-manager/commit/88913c98fe674e10302bbdb71b4e173f527b69c2) goto: init module
* [`bf2dc7eb`](https://github.com/nix-community/home-manager/commit/bf2dc7ebd8e3fd10f24cfe0a8acfd3d2676666c7) tests: add tests package to search / run tests
* [`53bf4fab`](https://github.com/nix-community/home-manager/commit/53bf4fab3013c9c200593a45c95469dba12c5315) docs: add tests command documentation
* [`2a299689`](https://github.com/nix-community/home-manager/commit/2a29968912815e825a8cae73e2535a94424a9d1b) git-credential-keepassxc: init module
* [`13461dec`](https://github.com/nix-community/home-manager/commit/13461dec40bf03d9196ff79d1abe48408268cc35) git-credential-keepassxc: fix eval
* [`13c5c2fb`](https://github.com/nix-community/home-manager/commit/13c5c2fb4cbed19ee40552a29a1b0fac8839a2dd) Translate using Weblate (Ukrainian)
* [`cb8cfa0e`](https://github.com/nix-community/home-manager/commit/cb8cfa0eb9a7f2ab2edaaf934f5e413b91800c31) keepassxc: add maintainer bmrips
* [`62fdc8d4`](https://github.com/nix-community/home-manager/commit/62fdc8d41097313e681446b46681a4f89544e51c) keepassxc: add autostart option
* [`475d3579`](https://github.com/nix-community/home-manager/commit/475d35797d9537354d825260cf583114537affc2) treefmt: handle deadnix excludes
* [`5ab62b61`](https://github.com/nix-community/home-manager/commit/5ab62b61fb4d47f2740bfcef52d540f95335360e) accounts.email: add authentication mechanism
* [`6275d1fc`](https://github.com/nix-community/home-manager/commit/6275d1fc57d3c149691cddba0809ef040dfa7843) accounts.email: add 'davmail' flavor
* [`c7acf2b1`](https://github.com/nix-community/home-manager/commit/c7acf2b1bf1ec6c3a17b0b598e62e4190a1f1844) mullvad-vpn: add module
* [`a5506862`](https://github.com/nix-community/home-manager/commit/a5506862dc265a20b6790ae48e017ac2b3da6454) mullvad-vpn: fix home.package -> home.packages
* [`d8a475e1`](https://github.com/nix-community/home-manager/commit/d8a475e179888553b6863204a93295da6ee13eb4) tests: add mullvad-vpn to darwin scrublist
* [`faa5b42e`](https://github.com/nix-community/home-manager/commit/faa5b42eca5b59ec9edcda3a5aa4b4524f4c2a12) codex: support XDG Base Directory specification
* [`2b87f9a5`](https://github.com/nix-community/home-manager/commit/2b87f9a53a9fc3ba95caa262b6e887a9c933b8b5) tests: refactor outputs
* [`07b994ba`](https://github.com/nix-community/home-manager/commit/07b994baedd3647f57b3fa8c6b022bff56bddbc9) tests: include integration tests in buildbot
* [`dbfcd329`](https://github.com/nix-community/home-manager/commit/dbfcd3292d8af44eed8e41b222cbbf8685b950c6) accounts.email: add option to disable an account
* [`5de16c70`](https://github.com/nix-community/home-manager/commit/5de16c704b0fc8f519b2c19ed3f683a9e68f3884) getmail: remove redundant filter
* [`5f8bb123`](https://github.com/nix-community/home-manager/commit/5f8bb123b9b6d0a9e9bbc82a958d9013007f4955) sheldon: init module
* [`7a985e8f`](https://github.com/nix-community/home-manager/commit/7a985e8f5dca513a13c7060d0b7260cf1b63728a) maintainers: add elanora96
* [`cc2fa233`](https://github.com/nix-community/home-manager/commit/cc2fa2331aebf9661d22bb507d362b39852ac73f) maintainers: add Kyure_A
* [`3ec1cd9a`](https://github.com/nix-community/home-manager/commit/3ec1cd9a0703fbd55d865b7fd2b07d08374f0355) launchd+targets/darwin: Escape XML in plists ([nix-community/home-manager⁠#7356](https://togithub.com/nix-community/home-manager/issues/7356))
* [`58320509`](https://github.com/nix-community/home-manager/commit/58320509c5b83c93012b328c9c9a943d8d90f932) flake.lock: Update ([nix-community/home-manager⁠#7651](https://togithub.com/nix-community/home-manager/issues/7651))
* [`715ecee4`](https://github.com/nix-community/home-manager/commit/715ecee4511d3d8da741335b1cecc29e2c4bd3cb) jrnl: add module ([nix-community/home-manager⁠#7652](https://togithub.com/nix-community/home-manager/issues/7652))
* [`85ed337f`](https://github.com/nix-community/home-manager/commit/85ed337f360f5039a83f6dbda87564fa227df0b4) PULL_REQUEST_TEMPLATE: update flake test runner command
* [`e7969e2f`](https://github.com/nix-community/home-manager/commit/e7969e2ffa261e6c0587183f67bc906f482ba115) PULL_REQUEST_TEMPLATE: format
* [`91586008`](https://github.com/nix-community/home-manager/commit/91586008a23c01cc32894ee187dca8c0a7bd20a4) firefoxpwa: fix ULID length typo ([nix-community/home-manager⁠#7653](https://togithub.com/nix-community/home-manager/issues/7653))
* [`0d492b89`](https://github.com/nix-community/home-manager/commit/0d492b89d1993579e63b9dbdaed17fd7824834da) walker: add module ([nix-community/home-manager⁠#7649](https://togithub.com/nix-community/home-manager/issues/7649))
* [`2aceb6a8`](https://github.com/nix-community/home-manager/commit/2aceb6a8cc23fc657602137be42bbc280074cd79) maintainers: update all-maintainers.nix ([nix-community/home-manager⁠#7657](https://togithub.com/nix-community/home-manager/issues/7657))
* [`600e3f67`](https://github.com/nix-community/home-manager/commit/600e3f6712735452a39451e1f8db86bfc631362f) yambar: remove deleted maintainer
* [`fc68e110`](https://github.com/nix-community/home-manager/commit/fc68e1100ae6b2d46e3d423945121a41901eca9b) maintainers: jkarlson -> ethorsoe
* [`eb243d27`](https://github.com/nix-community/home-manager/commit/eb243d27f8eb51896b1df601d95817ec9c50510c) PULL_REQUEST_TEMPLATE: add some additional check
* [`b4a07cd1`](https://github.com/nix-community/home-manager/commit/b4a07cd14b6ad8bd26f4753107dde2fd71af4803) docs/tests: expand test documentation for contributors
* [`e11d6c32`](https://github.com/nix-community/home-manager/commit/e11d6c321f3f848178a3fb2a8984aa5fe08c0996) PULL_REQUEST_TEMPLATE: fix commit message link formatting
* [`627a3932`](https://github.com/nix-community/home-manager/commit/627a3932b9cfccd276e028c128f7fbbeef285804) swww: add extraArgs for swww-daemon
* [`9248ba7c`](https://github.com/nix-community/home-manager/commit/9248ba7ce10d06ca46a17ff891892a2b7ac8cfce) news: add missing news entries for new modules
* [`0b7147a5`](https://github.com/nix-community/home-manager/commit/0b7147a547cadfc4b13f5ef0c33164bf00795312) maintainers: add Swarsel
* [`18ea6d7a`](https://github.com/nix-community/home-manager/commit/18ea6d7a8f8e6b5378db269ec6cdbb38f22d0356) pizauth: init module
* [`9a132f29`](https://github.com/nix-community/home-manager/commit/9a132f297117f802fdb31ae6271e888d40fc83fe) less: generate `lesskey` only when non-empty
* [`dfcea057`](https://github.com/nix-community/home-manager/commit/dfcea0573da618e24ff74f95fbf21e72ba72856b) less: rename `keys` to `config`
* [`67393957`](https://github.com/nix-community/home-manager/commit/67393957c27b4e4c6c48a60108a201413ced7800) less: configure LESS options
* [`d19f3213`](https://github.com/nix-community/home-manager/commit/d19f3213e51469321835a9188adfa20391ff9371) Translate using Weblate (Italian)
