### PR TITLE
niv nixpkgs: update 44d04664 -> 1419cc5c

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -143,10 +143,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "44d04664098a11b5204036a0f42ce5cf9edb524d",
-        "sha256": "0g9ip555dd40rfxzvbw8x9imb3n4yh0djxnfgy5py9f0jqwnq1pl",
+        "rev": "1419cc5c5104185c444079d617096f788f0b2077",
+        "sha256": "1dikw270dsnnhwnk20sj3fc8bc4ypyfb52kp2891m00jbyx32pk5",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/44d04664098a11b5204036a0f42ce5cf9edb524d.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/1419cc5c5104185c444079d617096f788f0b2077.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@44d04664...1419cc5c](https://github.com/nixos/nixpkgs/compare/44d04664098a11b5204036a0f42ce5cf9edb524d...1419cc5c5104185c444079d617096f788f0b2077)

* [`51bad44c`](https://github.com/NixOS/nixpkgs/commit/51bad44cd8712f26a77a7b5a2581e6526ff6e1c1) Initial commit
* [`ed8c45dc`](https://github.com/NixOS/nixpkgs/commit/ed8c45dc5c9cae8163d9b8d277fd808af0590421) Update README
* [`dada7b8e`](https://github.com/NixOS/nixpkgs/commit/dada7b8e98eebfd2334e521a198853b9019cc32b) Add examples
* [`3d9cd96c`](https://github.com/NixOS/nixpkgs/commit/3d9cd96c56780d71de0133b01f8980c378815310) Reorganize samegame/ example
* [`1b808ba2`](https://github.com/NixOS/nixpkgs/commit/1b808ba2ca5ca82ba8e1640bf37de328f5ebc39c) Explain how to test branding components, ignore compiled QML
* [`52714cf3`](https://github.com/NixOS/nixpkgs/commit/52714cf33ee150e68d91d14bfd11434871ca24ab) Import unchanged KaOS branding
* [`dc6c6253`](https://github.com/NixOS/nixpkgs/commit/dc6c62530e745da0003de80c99f0f84dd8e5b05e) Set KaOS to auto-advance as well
* [`4fea58d9`](https://github.com/NixOS/nixpkgs/commit/4fea58d94d0d2ea9fbb98343d312341879df1a4f) Mention KaOS branding
* [`b6e90e68`](https://github.com/NixOS/nixpkgs/commit/b6e90e68bb4119b6697bf92280eb0131d5abf14a) Shuffle branding into a subdirectory, add a module
* [`b014e5e7`](https://github.com/NixOS/nixpkgs/commit/b014e5e71a3f267b9ba500a2923e8a3d36e80e3b) Fix up after the reshuffle:
* [`9c644310`](https://github.com/NixOS/nixpkgs/commit/9c6443107844e3663d3994ad94f430d10522b1f9) CMake: update for re-vamp of Calamares CMake support
* [`5a30a1eb`](https://github.com/NixOS/nixpkgs/commit/5a30a1eba0ee926c75e2a45af775e6c159587556) Docs: try to be more verbose, add TODO
* [`55a5a3ee`](https://github.com/NixOS/nixpkgs/commit/55a5a3eeab9c34b10d8db990909223abfc4daabd) [filekeeper] Fix includes
* [`0ee9453d`](https://github.com/NixOS/nixpkgs/commit/0ee9453d03e1884e3630b70d03301e61d92be545) [filekeeper] Calamares plugins already link to Calamares::calamares
* [`8aa5fd74`](https://github.com/NixOS/nixpkgs/commit/8aa5fd74521667542414441960057a513d789c40) [freebsddisk] Add a (stub) FreeBSD disk selection module
* [`474d4896`](https://github.com/NixOS/nixpkgs/commit/474d4896210192f961c8a547dafb3d7c647a35c1) Update default/branding.desc to copy current branding config format.
* [`fce3562d`](https://github.com/NixOS/nixpkgs/commit/fce3562dae6c797740195a21271c1d4da14200a6) [freebsddisk] Fix QML -- margins property
* [`694ebe1b`](https://github.com/NixOS/nixpkgs/commit/694ebe1bfcf91be2eb3a04eafff505e90442a5ae) Branding: the *slideshowAPI* key is mandatory
* [`0aba2ac1`](https://github.com/NixOS/nixpkgs/commit/0aba2ac1a1ad798a56b0ffd0a5c1ed4b2ced3e85) CMake: add some documentation, remove cruft
* [`91926fa2`](https://github.com/NixOS/nixpkgs/commit/91926fa210d0c012fba17c45d7c9137e4332e63b) Flesh out the examples:
* [`76cf47fb`](https://github.com/NixOS/nixpkgs/commit/76cf47fb3d14e0bb0642a8ae0bcfd8e9d717515b) Docs: mention the specific module examples
* [`6a32719d`](https://github.com/NixOS/nixpkgs/commit/6a32719d0758d12505b7574eb6593991bdbb885b) Fix broken link
* [`35b3ab65`](https://github.com/NixOS/nixpkgs/commit/35b3ab650daf9f280cf623c2cb3404c11bee219f) [mobile] add mobile friendly module and branding
* [`6a9f90dd`](https://github.com/NixOS/nixpkgs/commit/6a9f90dd010b36f04746f0e5c0009b11fad5b5d3) [mobile] use SPDX-FileCopyrightText
* [`527df980`](https://github.com/NixOS/nixpkgs/commit/527df9800ab014973db462888d88cac73b89ed6c) CMakeLists: add find_package YAMLCPP
* [`5346fd72`](https://github.com/NixOS/nixpkgs/commit/5346fd7281a48e49f113470508247c77214f5508) [mobile] Conventionally, create null QString with default constructor
* [`03cda7d9`](https://github.com/NixOS/nixpkgs/commit/03cda7d91b7c35fa749a79102f040e769904d47d) [mobile] QPair with const member types is problematic
* [`43b2f50a`](https://github.com/NixOS/nixpkgs/commit/43b2f50a5548ffb84a987bec10d3022c893eb27b) [mobile] Fix build (and conventions)
* [`55c139da`](https://github.com/NixOS/nixpkgs/commit/55c139dabc2ae68931559d766e3087cd90c182c0) [mobile] Fix link
* [`6cfeaab8`](https://github.com/NixOS/nixpkgs/commit/6cfeaab82e5c8a7fd2801b63482b9f37b26da2f9) Add formatting guides / coding style
* [`5e8fd0c2`](https://github.com/NixOS/nixpkgs/commit/5e8fd0c2ebdb3f5874ac7e45d89619264686e79d) Apply coding-style
* [`b33d20ab`](https://github.com/NixOS/nixpkgs/commit/b33d20ab5bd383ba58056f345d28d57e59a1487c) Apply coding-style
* [`c58a5be2`](https://github.com/NixOS/nixpkgs/commit/c58a5be2d0abe7460d467e0211c33aee20d4583f) Apply coding-style
* [`24980f34`](https://github.com/NixOS/nixpkgs/commit/24980f347bf477378b3e0e9016ba6268939a2660) CMake: add version target for release script
* [`b2df3eb0`](https://github.com/NixOS/nixpkgs/commit/b2df3eb0da46890095cfe67ee4b84b70ad694545) CMake: add -C to pass extra arguments to release-cmake
* [`7ef7b877`](https://github.com/NixOS/nixpkgs/commit/7ef7b877c53aad6ae20f3c86029e0f893921be0b) [mobile] Missing
* [`8043616f`](https://github.com/NixOS/nixpkgs/commit/8043616ffd131705d04b23fa6d79561c81c82298) [mobile] navTo: add log message for screen change
* [`4cbf5c9f`](https://github.com/NixOS/nixpkgs/commit/4cbf5c9f62bc8a099dfc92db0a59ec89e63737a0) [mobile] Refactor screen navigation logic
* [`bb79dd6a`](https://github.com/NixOS/nixpkgs/commit/bb79dd6a54252a9c8dde67c1333e09b0c5919898) [mobile] navNextFeature: support skipping features
* [`acbb1a27`](https://github.com/NixOS/nixpkgs/commit/acbb1a270b9bbe6c12a878b2044a5731d8e208a1) [mobile] Make sshd feature optional
* [`911a27bc`](https://github.com/NixOS/nixpkgs/commit/911a27bc4805c73a9de71d6641923a349a4da591) [mobile] mobile.qml: fix whitespace error
* [`a1ecd650`](https://github.com/NixOS/nixpkgs/commit/a1ecd650cf28952a570edd232cdd9ee64bfadc9b) [mobile] Config.h: tweak signal related comments
* [`ea2d2052`](https://github.com/NixOS/nixpkgs/commit/ea2d20522f1f10142549ed84d422d51c31354540) [mobile] mobile.conf: tweak line ending
* [`8a107c6e`](https://github.com/NixOS/nixpkgs/commit/8a107c6e3b1d65b80e7477e41469e04212ad16c4) [mobile] qml: use generic names for id fields
* [`92e68777`](https://github.com/NixOS/nixpkgs/commit/92e687770a4fe26986b8200d5c20b2c1a9ee5abc) [mobile] create Users job in jobs()
* [`80a7bd89`](https://github.com/NixOS/nixpkgs/commit/80a7bd8995ca383f59ce97193dd4c3479a971d12) [mobile] MobileQmlViewStep: remove unused include
* [`7b0f097b`](https://github.com/NixOS/nixpkgs/commit/7b0f097bcad21a5ffe3a40f4ea63f06819b0cfbb) [mobile] Don't ignore partition job errors
* [`f960eb6f`](https://github.com/NixOS/nixpkgs/commit/f960eb6f4a59e23271dfe6b42c0f87fc25c0294e) [mobile] *Job: 'const QString&' for args
* [`578445d0`](https://github.com/NixOS/nixpkgs/commit/578445d0699faa8fe83f64ffeec4a6fc09ad64fe) [mobile] Config: remove redundant get{Bool,Str}
* [`851e5052`](https://github.com/NixOS/nixpkgs/commit/851e5052f37e69e5e52daed18ee9321d7cdaeda4) [mobile] skipDisabledFeatures: add skip by func
* [`399e88e2`](https://github.com/NixOS/nixpkgs/commit/399e88e2d6343341aad34eda0edaeb2d16220641) [mobile] Offer to install from SD to eMMC
* [`d6426b9e`](https://github.com/NixOS/nixpkgs/commit/d6426b9edf44f6f4dcc0df356a41735c6327f261) CMake: behave a little more modern
* [`bafb9c05`](https://github.com/NixOS/nixpkgs/commit/bafb9c0506b5d74ec11ed8533d49fa7aa2c93ad4) Changes: pre-release housekeeping
* [`b2a3afbe`](https://github.com/NixOS/nixpkgs/commit/b2a3afbef088d38ae4b0284f936695d09770b5dd) Changes: post-release housekeeping
* [`1d4e208a`](https://github.com/NixOS/nixpkgs/commit/1d4e208a8bf7418abc3277f373d44a8d36ff409e) [mobile] wait screen: reword 20s -> 2 min
* [`c069fddd`](https://github.com/NixOS/nixpkgs/commit/c069fddd02c1871ca61afecc49ab6254df6d3fad) CI: try to run CI for the extensions, too
* [`2e237084`](https://github.com/NixOS/nixpkgs/commit/2e2370848f06f46653b699f4639856a32965063e) CI: extract the tarball from calamares first
* [`0b42a33c`](https://github.com/NixOS/nixpkgs/commit/0b42a33c6bca48fbca7131712eacd4ddb9671989) Docs: mention the *mobile* module
* [`47dc3eaa`](https://github.com/NixOS/nixpkgs/commit/47dc3eaa8e468c9abca5f3bcd19e3c9cc45f5d58) CI: massage message a bit and adjust naming scheme
* [`9ef5e0ac`](https://github.com/NixOS/nixpkgs/commit/9ef5e0ac0e76269f953516df065af7402772d722) [image-slideshow] Add an example QML slideshow for images
* [`b2088dcd`](https://github.com/NixOS/nixpkgs/commit/b2088dcd51e3e0926daf83e3e1467ce8bc4a6c56) [mobile] Allow user to configure filesystem type
* [`66197970`](https://github.com/NixOS/nixpkgs/commit/66197970b275ec270a710d7a1489fb0a6ddb4122) [mobile] bugfix: initialise externalToInternal
* [`a64e4305`](https://github.com/NixOS/nixpkgs/commit/a64e4305e0221cd3f9610290f3c9f0a6e9408bba) CI: add the style tool from calamares
* [`316ae1b9`](https://github.com/NixOS/nixpkgs/commit/316ae1b9bcefc034817478e964df94e913ed487d) [mobile] Apply coding style
* [`d83e79aa`](https://github.com/NixOS/nixpkgs/commit/d83e79aa2e2c4661f85b9bc049a32bdb6a8fa49f) Changes: pre-release housekeeping
* [`4126f253`](https://github.com/NixOS/nixpkgs/commit/4126f2533ddffceac62ac4bbe006607fffb2aa5a) CI: note that the release-script is Linux-only
* [`4e7399e1`](https://github.com/NixOS/nixpkgs/commit/4e7399e1c46a3b86398d6b853aa0bd13a015ac5c) Docs: polish the README to match new additions
* [`a8c4cfab`](https://github.com/NixOS/nixpkgs/commit/a8c4cfab78b13cec5f20c9488996dfb7f2927e46) Docs: README: update mobile description
* [`94cfc197`](https://github.com/NixOS/nixpkgs/commit/94cfc197c3cefc4d7d244d1f172772da07e7e9f6) Import os-* modules from the main repo
* [`7ed233b3`](https://github.com/NixOS/nixpkgs/commit/7ed233b3a45935e3899937d97db61244ef1332a6) Add os-* modules to the build
* [`8423fba4`](https://github.com/NixOS/nixpkgs/commit/8423fba440f07a0f7614bc8a91b809fbc22088b5) CMake: bail out on broken CMake folders
* [`b131a419`](https://github.com/NixOS/nixpkgs/commit/b131a419801f7f345d4d2fd5029bd7e2b198daa3) [os-freebsd] Until there's a config file, mark it explicitly without
* [`3705c128`](https://github.com/NixOS/nixpkgs/commit/3705c1285b59146a0f85c8d8a4f38be061125d2d) [os-freebsd] Remove superfluous linking
* [`d472e99e`](https://github.com/NixOS/nixpkgs/commit/d472e99ea5a9090be2ec28f62287206a498a2d85) CMake: collect and report the skipped modules
* [`b0639382`](https://github.com/NixOS/nixpkgs/commit/b0639382cf9c4f4a81f1f8d2d00a94c0fb16ddbf) [mobile] Don't need to list headers as source
* [`de708e51`](https://github.com/NixOS/nixpkgs/commit/de708e5124401108437438fe536ed515bf6b2517) [unpackfsc] Stub of unpackfsc
* [`8ea06c3c`](https://github.com/NixOS/nixpkgs/commit/8ea06c3c9a9efbc4b93fa153c81fb1210fb1e67a) [unpackfsc] Load and log configuration
* [`cf98b93d`](https://github.com/NixOS/nixpkgs/commit/cf98b93df09d29f8f3ec72eaf9b49cdba7ca9c80) [mobile] add option builtinVirtualKeyboard
* [`e2910edd`](https://github.com/NixOS/nixpkgs/commit/e2910edd08bad5bd1b705bc93c5c3bee7d6efeaa) [mobile] rename default_pin -> user_pass
* [`1be3aa4c`](https://github.com/NixOS/nixpkgs/commit/1be3aa4cbbc281217ae11cafe8ddf2b7e62859b0) [mobile] add option userPasswordNumeric
* [`a0d3850b`](https://github.com/NixOS/nixpkgs/commit/a0d3850b21b22b70b94b42394eb4649934228f04) [mobile] tweak invalid chars msg/related comments
* [`d6454ed1`](https://github.com/NixOS/nixpkgs/commit/d6454ed11edbf99b193f5ce8ce60dbf25155e1b6) [mobile] navNextFeature: fix skipping > 1 feature
* [`4810f89f`](https://github.com/NixOS/nixpkgs/commit/4810f89f9e931154e72c066a7a4091a84b653b2b) mobile.qml: refactor navNextFeature()
* [`6b46d98e`](https://github.com/NixOS/nixpkgs/commit/6b46d98e4624ae471473bb53687ddb03ca2a9f45) [mobile] Consistent initialization-expressions in declaration of Config
* [`a753766d`](https://github.com/NixOS/nixpkgs/commit/a753766d658b363eda62e30203c46897563894ef) CMake: bump version
* [`958d32c6`](https://github.com/NixOS/nixpkgs/commit/958d32c6334421a2ea9181ae1af785e2ac8a10e5) Docs: add release announcement
* [`c4841652`](https://github.com/NixOS/nixpkgs/commit/c4841652397ece1055af3e1c532161679feec4cd) CMake: update versioning infrastructure
* [`cc703df3`](https://github.com/NixOS/nixpkgs/commit/cc703df3448eec913a5003408d6b525a39e98431) CI: Use new versioning support from CMakeLists.txt
* [`0bb9d816`](https://github.com/NixOS/nixpkgs/commit/0bb9d8161b256ffa5e2e73095e44e8016fe83771) CI: sign release tarball after it's made
* [`7fc0448a`](https://github.com/NixOS/nixpkgs/commit/7fc0448aa1df1f607607e03451d84c95307bbbf3) CMake: Calamares is C++17, use it in extensions as well.
* [`dd5f5e28`](https://github.com/NixOS/nixpkgs/commit/dd5f5e282429189db01633f2280ca7e6899f40e4) [unpackfsc] Simplify to **one** unpack action
* [`15d499f7`](https://github.com/NixOS/nixpkgs/commit/15d499f7b1670522d28fe3e7dbada693eae89d69) [unpackfsc] Add stubs for calling the external tools.
* [`715d6286`](https://github.com/NixOS/nixpkgs/commit/715d6286fcff111b5c108f559b7ef9dc4d7fc832) CMake: Calamares is C++17, use it in extensions as well.
* [`8098a5d9`](https://github.com/NixOS/nixpkgs/commit/8098a5d9da204c8a78c1de0c8ebec2b46f7eedb1) [unpackfsc] Start implementing fsarchive runner
* [`adbe299a`](https://github.com/NixOS/nixpkgs/commit/adbe299a6a948d1f8491dd726fd5dc5d54e6032c) [unpackfsc] Apply coding style
* [`19f5166d`](https://github.com/NixOS/nixpkgs/commit/19f5166da004d2af7a4664b429c6669676203e74) [unpackfsc] Stub of the Unsquash runner
* [`de1f7497`](https://github.com/NixOS/nixpkgs/commit/de1f7497a5abcb0ae7c8a5f17ae30456850adca3) [unpackfsc] Support functions for Runners
* [`e896434a`](https://github.com/NixOS/nixpkgs/commit/e896434a7635e026531559a0ea41b5754a3dc75e) [unpackfsc] Build a proxy for handling process output
* [`860aaf16`](https://github.com/NixOS/nixpkgs/commit/860aaf16cc504d238fc20d98b6b01b60d0567481) Docs: mention the communication channels
* [`00d7c1a9`](https://github.com/NixOS/nixpkgs/commit/00d7c1a9a3e25ff7cc1ed26a6a09caeb5fa5a791) Docs: add a CONTRIBUTING document
* [`e5fb6e71`](https://github.com/NixOS/nixpkgs/commit/e5fb6e71508e0086bd5b18023034b9da1aa99fac) Docs: badge for Matrix
* [`eae41d0b`](https://github.com/NixOS/nixpkgs/commit/eae41d0bf67d16110a4537775a09e6a60f61c2f4) CMake: bump required Calamares version
* [`65949378`](https://github.com/NixOS/nixpkgs/commit/65949378d15ae8c43fe133b75230d2c9ea09c5fb) CI: switch to matrix notifications
* [`1fe0869d`](https://github.com/NixOS/nixpkgs/commit/1fe0869d00007b1b32d9fc0f25fbc2522f58b749) CI: repair the action YAML
* [`3c82b24e`](https://github.com/NixOS/nixpkgs/commit/3c82b24e522848834e533bdfa5f2bfdade93ebda) CI: restore the success/fail check, silence curl output
* [`4d61e14f`](https://github.com/NixOS/nixpkgs/commit/4d61e14fce32d3936a74d89672a2f5ad398baf53) CI: Add Matrix notification action
* [`a25101d1`](https://github.com/NixOS/nixpkgs/commit/a25101d1bd838e17bebb4bddba033e653070f272) CI: update to current matrix-notifications
* [`b3ba53af`](https://github.com/NixOS/nixpkgs/commit/b3ba53afd039872e8e0549b27ed9b365240e4ec3) CI: try to use (shared) Calamares notification action
* [`93df4e96`](https://github.com/NixOS/nixpkgs/commit/93df4e964286028b831752088a08da7e4acef696) CI: try to use (shared) Calamares notification action
* [`5fd66596`](https://github.com/NixOS/nixpkgs/commit/5fd665965655ef4e9499b3c387b8e07ff8517a8a) CI: switch to shared Calamares actions entirely
* [`f2c9c081`](https://github.com/NixOS/nixpkgs/commit/f2c9c081e0c59ba859dbbc4bd2c129ae8146258a) CI: use generic-build action instead of expanding it here
* [`37683b04`](https://github.com/NixOS/nixpkgs/commit/37683b042f7216cd245ce5817704b44fb41a7b1c) CI: factor out prepatation, chase update to build
* [`0d0118cf`](https://github.com/NixOS/nixpkgs/commit/0d0118cfa177940c5d6b7aa5f291b4602ec81b04) CI: chase new tag in actions repo
* [`7aadd4a0`](https://github.com/NixOS/nixpkgs/commit/7aadd4a07697e23073f6bf54e6ab487492f82708) Docs: IRC links to Libera.Chat
* [`12c6c1bb`](https://github.com/NixOS/nixpkgs/commit/12c6c1bb14cc062955d3b1b1848652e3c75a82b1) Docs: do not use freenode
* [`418cf9b5`](https://github.com/NixOS/nixpkgs/commit/418cf9b5897ae0e73a71d1bad95d7127aee038c9) CMake: adjust extensions to changes in Calamares core
* [`79889656`](https://github.com/NixOS/nixpkgs/commit/79889656728caaff6a8e88d2e4b3c37e1fc6fafe) SPDX: add license texts
* [`a0be5029`](https://github.com/NixOS/nixpkgs/commit/a0be5029d60267033997d5a90ae6b9841d7f6ffd) [os-nixos] Replace useless stub implementation
* [`29c4aaca`](https://github.com/NixOS/nixpkgs/commit/29c4aaca1d3d8d2b437bf1e80f062f358423ef55) SPDX: wrangling
* [`c4567e9f`](https://github.com/NixOS/nixpkgs/commit/c4567e9f1dbec5f87025d30564f99c802a13e1cd) SPDX: add dep5-blanket for build artifacts and GH cruft
* [`504b9ec1`](https://github.com/NixOS/nixpkgs/commit/504b9ec15ca8e2d25c6d0cf7f9989a19d9ede2b8) SPDX: tag various
* [`2efc7710`](https://github.com/NixOS/nixpkgs/commit/2efc7710a3663e75353cf78292034b3c05a52a25) SPDX: tag modules
* [`6023add4`](https://github.com/NixOS/nixpkgs/commit/6023add49574b95dfe8c3098537a3b39a5359318) [os-nixos] Example global-config file, for tests
* [`e9346259`](https://github.com/NixOS/nixpkgs/commit/e93462597413c9d343ddae30c78db7128e32c3b4) [refind] adding a simple rEFInd module
* [`e3379b63`](https://github.com/NixOS/nixpkgs/commit/e3379b63724ee1b4ff96d78ec346a5437a622452) [refind] apply requested changes
* [`15cf5b78`](https://github.com/NixOS/nixpkgs/commit/15cf5b7847b5ddd9fc1348bf17d6c4433e05195c) How is Kolkata in Europe?
* [`1f58048d`](https://github.com/NixOS/nixpkgs/commit/1f58048d9510928126ec2971471f3fbe7fe11232) [refind] kernel_params is a list (converted to space-separated later)
* [`4fb5043c`](https://github.com/NixOS/nixpkgs/commit/4fb5043ca05b952227c92d0c4b5bad2669b377ef) [refind] Python stylings
* [`524f2e77`](https://github.com/NixOS/nixpkgs/commit/524f2e77ffe8b3ad51ebe858c4f887b3af5ac0dc) [refind] Improve device-detection warnings
* [`33356bad`](https://github.com/NixOS/nixpkgs/commit/33356bad70f7d0a7d2f5436e1e44c2e30f3d7c9b) [refind] Python stylings
* [`958e1882`](https://github.com/NixOS/nixpkgs/commit/958e1882678b2d5a1979e952103fc7ada9408838) [refind] Remove checks
* [`15662109`](https://github.com/NixOS/nixpkgs/commit/156621097d0b4cd77771e2ada450eb29c9052464) [refind] Add module to build
* [`398db413`](https://github.com/NixOS/nixpkgs/commit/398db413a6622ca805263783deb67130309d5eab) CMake: enable tests
* [`63661bea`](https://github.com/NixOS/nixpkgs/commit/63661beae9ca887ee6910a396198544f06accc6a) [refind] Fix tests
* [`f70b2e75`](https://github.com/NixOS/nixpkgs/commit/f70b2e7526d78e778e4e23e65aeb2b1d0ac37304) CI: update to core calamares version of scripts
* [`e08cb335`](https://github.com/NixOS/nixpkgs/commit/e08cb335262262d5d9130ce399746d7f5db620a8) [mobile] Keep the tests happy
* [`87bcb12f`](https://github.com/NixOS/nixpkgs/commit/87bcb12f72ba747731078e00181e8c571ade6dcb) [filekeeper] Load part of the config file
* [`ff1ef79c`](https://github.com/NixOS/nixpkgs/commit/ff1ef79cd6c2b6bd994635ef4dfcf49c7b33c7c5) [refind] Fix warning function name
* [`a8a8f5bb`](https://github.com/NixOS/nixpkgs/commit/a8a8f5bbefb57e3374d4a7601773ce2d993c92ea) [os-nixos] Avoid None-concatenate-with-str
* [`5f5849e9`](https://github.com/NixOS/nixpkgs/commit/5f5849e9399810ba0f71ee0dcf30f9bef66b2ec6) CMake: bump version and Calamares-requirement
* [`6c997867`](https://github.com/NixOS/nixpkgs/commit/6c997867246a424bef717fbe422d8ced28fbd82d) [unpackfsc] Use libcalamares version of Runner now
* [`c99d5b1e`](https://github.com/NixOS/nixpkgs/commit/c99d5b1e508e60190f924956be71abaf02e68889) Remove filekeeper job
* [`bf2dcafd`](https://github.com/NixOS/nixpkgs/commit/bf2dcafd9a80234e90897ff26e2ca616f3e6451e) [unpackfsc] Factor out command-name, it doesn't need translation
* [`bd07bca7`](https://github.com/NixOS/nixpkgs/commit/bd07bca74da52f665cf1458868502ce04936b04d) [unpackfsc] Implement most of unsquash
* [`3b162c83`](https://github.com/NixOS/nixpkgs/commit/3b162c83b8b4de3706bdf4ea82fde21b6fa57c4c) [unpackfsc] Hook up progress
* [`ca002ace`](https://github.com/NixOS/nixpkgs/commit/ca002ace139b72866a3b63cb221ea67941589c7b) [unpackfsc] Remove unreachable progress
* [`524414a9`](https://github.com/NixOS/nixpkgs/commit/524414a9e95373645b908036e8e0b77526c57a91) [unpackfs] Include a message in progress reports
* [`64ef46c6`](https://github.com/NixOS/nixpkgs/commit/64ef46c66d644d6c0a12b6a167eb6824cea3a525) [unpackfsc] Map destination path to target system
* [`5c648925`](https://github.com/NixOS/nixpkgs/commit/5c6489253e71e5826e94d15f23c15eb1b7bf5d23) [unpackfsc] Get the total number of inodes
* [`7c7fe244`](https://github.com/NixOS/nixpkgs/commit/7c7fe24485e1aff1c509576494c9783d278b06a8) [unpackfs] Don't reformat table of enum names
* [`5212d6fa`](https://github.com/NixOS/nixpkgs/commit/5212d6fa4b155d5dc8fb071af72cd16784d7c088) [unpackfsc] Avoid newlines in filenames
* [`2567a8d9`](https://github.com/NixOS/nixpkgs/commit/2567a8d9eb7be6066f7a5f56194eeef67e65571e) [unpackfsc] strip() is Python, I guess
* [`49b442db`](https://github.com/NixOS/nixpkgs/commit/49b442dbff42b6c7e3377367c567b993e033026f) [unpackfsc] Report progress through status message
* [`f0996c71`](https://github.com/NixOS/nixpkgs/commit/f0996c71bbd70ee3296bc0b120b24f0405d3932f) [unpackfsc] Fix build with old Qt
* [`b505012a`](https://github.com/NixOS/nixpkgs/commit/b505012a58167c4834a7d9e5be1669e0c6837f18) CI: fix build-script with new-style version reporting
* [`90363a6a`](https://github.com/NixOS/nixpkgs/commit/90363a6a839009ffcb0f6a6b28911460619b947a) Changes: post-release housekeeping
* [`ba0a1997`](https://github.com/NixOS/nixpkgs/commit/ba0a199717d6123be286028769cf88d15d2ef4f2) [unpackfsc] Report fsarchiver progress, too
* [`6cfb9909`](https://github.com/NixOS/nixpkgs/commit/6cfb990920516fae6f5179e7a409198a43c4eb6e) [unpackfsc] Add test-configs for fsarchiver-unpack
* [`7f651498`](https://github.com/NixOS/nixpkgs/commit/7f6514983f3268fd96a8646bd12827f1f4e640d7) [unpackfsc] Use restdir instead of restfs
* [`6bf1724c`](https://github.com/NixOS/nixpkgs/commit/6bf1724c5de610c3425d8bcca7c2e24518cb70e0) [unpackfsc] Reduce number of status updates in fsarchiver
* [`f629fc2a`](https://github.com/NixOS/nixpkgs/commit/f629fc2a0b8f8740a39b1718935a075bda147c43) [unpackfs] Document that fsarchiver uses savedir/restdir
* [`7631c1ec`](https://github.com/NixOS/nixpkgs/commit/7631c1ec37a165e4690396768eddac3d79010cd5) Changes: pre-release housekeeping
* [`14bf1f7e`](https://github.com/NixOS/nixpkgs/commit/14bf1f7e154522fe212adbfffbf715514e31358a) Add NixOS modules and remove others
* [`1d45c7d1`](https://github.com/NixOS/nixpkgs/commit/1d45c7d1bd6a352d57bc529e44a70f6d392195fd) Update nixos-customize-config to add keyboard selection
* [`bb595f49`](https://github.com/NixOS/nixpkgs/commit/bb595f49cabf53914762d2afd8f05ac36e82b0c7) Update modules and refactor config generation
* [`c68a80f4`](https://github.com/NixOS/nixpkgs/commit/c68a80f4e7856675eac8f2028e1501647dcc3c38) EFI grub device always nodev
* [`fd4a2953`](https://github.com/NixOS/nixpkgs/commit/fd4a2953bc0c6cbf60e66501faa49e7e45dd5699) Truncate nixos-version
* [`87af3250`](https://github.com/NixOS/nixpkgs/commit/87af3250d84c87d66005ab5ca5a9f3f5bcbdd118) Remove redundent services
* [`af9fce9d`](https://github.com/NixOS/nixpkgs/commit/af9fce9ddf3238e309071451669f97566da2331d) Remove broken swap options
* [`e5aa60c7`](https://github.com/NixOS/nixpkgs/commit/e5aa60c7d3dde891a6f86bd4b0a9d9b2f79ed6a6) Format and add some checks for settings groups
* [`e6ca169b`](https://github.com/NixOS/nixpkgs/commit/e6ca169b98b5b6b6710219171c327d6269e7ee82) Fix luks and swap
* [`0f322f28`](https://github.com/NixOS/nixpkgs/commit/0f322f2892d346a89f8870a65b379e66a959fdc1) Add support for multiple luks encrypted partitions
* [`d0c31075`](https://github.com/NixOS/nixpkgs/commit/d0c310754b4737c969046f50c99fa0f56ba7836d) Add desktop selection
* [`c4554b75`](https://github.com/NixOS/nixpkgs/commit/c4554b7509f2d49241f4b39fc87169bf3eea68a0) Use nmapplet option
* [`3f83c2c2`](https://github.com/NixOS/nixpkgs/commit/3f83c2c2bdd20098084b49e324c741878f5831e1) Merge modules into singular  module
* [`b86ce275`](https://github.com/NixOS/nixpkgs/commit/b86ce275b7cae66faf0619b338611bd8246cecb7) Switch efi to systemd-boot
* [`4aff7499`](https://github.com/NixOS/nixpkgs/commit/4aff74990fe496395ba8cc16d62c184454f7438e) Fix LUKS and swap
* [`a286e81a`](https://github.com/NixOS/nixpkgs/commit/a286e81a033714b1856307d3cb85297175460471) Remove lumina desktop and clean up
* [`e38ea069`](https://github.com/NixOS/nixpkgs/commit/e38ea069e9e8d5a0f05e83647263e2f42b520bb6) Remove unfree packages and run as user
* [`9b8d991e`](https://github.com/NixOS/nixpkgs/commit/9b8d991eb7bcee0bf31d6c3efbba0307d17aa0ff) Allow selection of unfree packages
* [`ba1c3fb3`](https://github.com/NixOS/nixpkgs/commit/ba1c3fb33941f4d9d1d9ca6a89c8a8db093c9a73) Add descriptions
* [`032f526a`](https://github.com/NixOS/nixpkgs/commit/032f526a1ee093c51e21794efe2c70a3aa3ac7c5) Switch to libcalamares calls
* [`aa04f404`](https://github.com/NixOS/nixpkgs/commit/aa04f404e6d5402fa2034da7b5795bd66f9f5189) Fix error messages
* [`0f4734da`](https://github.com/NixOS/nixpkgs/commit/0f4734da519f2a6aa94a07314b518a6c513662d3) Misc fixes
* [`abc86b6e`](https://github.com/NixOS/nixpkgs/commit/abc86b6e2ae782917111a60c12656dc69f55a3b8) Actually fix whitespace and format
* [`64db8642`](https://github.com/NixOS/nixpkgs/commit/64db864236235731a5cda7424b16cbf2e5aef3b4) Update desktop descriptions
* [`d3aada27`](https://github.com/NixOS/nixpkgs/commit/d3aada27f880739d8fd43c088d5c38f47498e148) Fix console keymap and remove unecessary packages
* [`bf77fe73`](https://github.com/NixOS/nixpkgs/commit/bf77fe73c6447c23abe9bd5c1b85308cfa2141dc) Fix partitions and luks
* [`0ed01b57`](https://github.com/NixOS/nixpkgs/commit/0ed01b57a5775eb8c8861efde58d79a9e4160bc7) Fix tty autologin and misc options
* [`8254c0d5`](https://github.com/NixOS/nixpkgs/commit/8254c0d5e4f16ea540c13dba6a662d6372421715) Disable networking for No Desktop
* [`fd7951f8`](https://github.com/NixOS/nixpkgs/commit/fd7951f89c4a7c72d6b9487a8bda4dde05110851) Switch ping url and add locale geoip
* [`82802ebe`](https://github.com/NixOS/nixpkgs/commit/82802ebe3aeef846fd0d0f98379193a6c848f2c9) Add licensing to config files
* [`9ff2dcd6`](https://github.com/NixOS/nixpkgs/commit/9ff2dcd6b28d19638feaaa36785dff7cf4663136) Add some branding licensing
* [`809dc46e`](https://github.com/NixOS/nixpkgs/commit/809dc46e34ffbef7a37ba35e14e4acfd13840567) Image licensing
* [`bc63ab0c`](https://github.com/NixOS/nixpkgs/commit/bc63ab0c6bf20c76ae82bb96d050e5ac3cef0f36) Re-add networkmanager for No Desktop choice
* [`d4ba4e3d`](https://github.com/NixOS/nixpkgs/commit/d4ba4e3dc34fdba7eb6965e0e4e5106812ff7e91) Remove typo in config
* [`9ef50487`](https://github.com/NixOS/nixpkgs/commit/9ef50487d985ca2e0cb58b44af73497d623f5c6e) Improve installation logging
* [`95158dbf`](https://github.com/NixOS/nixpkgs/commit/95158dbf27733fe4248702445249e555a3cf96ce) Add some packages to user rather than system
* [`eea2a08d`](https://github.com/NixOS/nixpkgs/commit/eea2a08d277d1ea6f459cc9bca856f99c4e50b67) Add cache.nixos.org internet check url
* [`54977f36`](https://github.com/NixOS/nixpkgs/commit/54977f36ce7ea0333f708f9233068d7bcf8f9314) Support locales from glibc SUPPORTED file
* [`526c43e9`](https://github.com/NixOS/nixpkgs/commit/526c43e9bbbc30e15232acfdc3350cd44ca1eb15) Add Budgie as a desktop option
* [`2793e5bf`](https://github.com/NixOS/nixpkgs/commit/2793e5bf243e52bc606f47020c191ce4e5a8f358) Use the default efi mount point `/boot`
* [`da5f1405`](https://github.com/NixOS/nixpkgs/commit/da5f1405949b0513d93f6ee7366d22ddbab0c751) Add Deepin as an option on the Desktop section
* [`6228cd3e`](https://github.com/NixOS/nixpkgs/commit/6228cd3e1ac1d095fb1ade1536cff1d51e9f1900) Fix LUKS keyfile exposure
* [`a8127f7b`](https://github.com/NixOS/nixpkgs/commit/a8127f7baa52aca94f1ab1ea3b51d19c92ff6ba2) Revert "Fix LUKS keyfile exposure"
* [`13e41a9d`](https://github.com/NixOS/nixpkgs/commit/13e41a9d6bef4676834b13045221a0bbebc1af5b) Do not use crypto_keyfile.bin in UEFI, but leave BIOS the same.
* [`08bd210f`](https://github.com/NixOS/nixpkgs/commit/08bd210fc3f5c4df338ff5c7a165daba08141188) Updates for 3.3.0 and luks2
* [`d01520fe`](https://github.com/NixOS/nixpkgs/commit/d01520fe489febcec40cb70b2f3f685b50f8cd01) Use the Firefox module instead of the package directly
* [`dd4c4334`](https://github.com/NixOS/nixpkgs/commit/dd4c4334c765dd0b2f62e26b775cae55189a83d5) Define deafult partition layout
* [`e7f18e40`](https://github.com/NixOS/nixpkgs/commit/e7f18e403f6998f59312042e5d0e3ac20ffb3da8) fix pipewire sound config
* [`5d8ae4de`](https://github.com/NixOS/nixpkgs/commit/5d8ae4de9fe36eeadb1ceda4a82ca2ab6f66668c) Advertise Plasma 6, adjust config for Plasma 5
* [`4c8b9e74`](https://github.com/NixOS/nixpkgs/commit/4c8b9e74c5876424fda635d2ce240c261484a077) Don't mount swap twice
* [`c737ac93`](https://github.com/NixOS/nixpkgs/commit/c737ac9361485715726070d853e43cb3cbbe2187) Update deprecated xkb options
* [`3d383f8b`](https://github.com/NixOS/nixpkgs/commit/3d383f8b9e9ca0e80e7eddcb152540d19c1705ce) fix crypto_keyfile creation condition
* [`74edaae6`](https://github.com/NixOS/nixpkgs/commit/74edaae64e6680ed826ea42786ed65017fbdf4e7) showNotEncryptedBootMessage: false
* [`091efd84`](https://github.com/NixOS/nixpkgs/commit/091efd84def07eb25e64b09188a1d9d2272cdfed) fix(mount): boot umask
* [`bf578d9b`](https://github.com/NixOS/nixpkgs/commit/bf578d9bc13a35e490a1d0d8e515a3043da8e5e0) Bootstrap testing
* [`2b2db81c`](https://github.com/NixOS/nixpkgs/commit/2b2db81c059b80cd2d8fa8f26686a7014574bb74) Trivial linting
* [`d0ee6b0a`](https://github.com/NixOS/nixpkgs/commit/d0ee6b0ab0f16a0434d7e0e3335ddb3601d3f91d) Use proxy when installing, if set
* [`07d1d3db`](https://github.com/NixOS/nixpkgs/commit/07d1d3db4edd1e60328179437fa445165c551c83) Don't emit autoLogin config with eval warning
* [`c1420d2b`](https://github.com/NixOS/nixpkgs/commit/c1420d2b33002216351354380291f65bdef1ce9a) Respect Kernel setting in /etc/nixos-generate-config.conf
* [`ad55bb96`](https://github.com/NixOS/nixpkgs/commit/ad55bb96886971d106a144e2b7aac91916838513) kanidm: Fix timeout from endless loop when provisioning
* [`290ea266`](https://github.com/NixOS/nixpkgs/commit/290ea2667ba69b8f32d94af854fe0c17be74e63d) Drop Plasma 5
* [`a2b66963`](https://github.com/NixOS/nixpkgs/commit/a2b6696377cd381e32ce9a0bb52fef9f38564566) Change default /boot partition size to 1GiB
* [`f1d02403`](https://github.com/NixOS/nixpkgs/commit/f1d02403fb349d8ee435c866ed130ab616a7bc46) Update Pulseaudio option name
* [`f886d71d`](https://github.com/NixOS/nixpkgs/commit/f886d71d7b49b732d4245b422c282adb90e67bde) nixos: Elaborate documentation for fileSystems.* options
* [`88fbfdc0`](https://github.com/NixOS/nixpkgs/commit/88fbfdc076053a8b79dd8d24b8b73f7e1703360d) python312Packages.mkdocs-simple-blog: init at 0.2.0
* [`b8d052a7`](https://github.com/NixOS/nixpkgs/commit/b8d052a70d591a4700304dcebc1a4a6b6834e881) nixos/nginx: add prependConfig options
* [`1bd9fe3c`](https://github.com/NixOS/nixpkgs/commit/1bd9fe3c16702a191d2ef65ba55f332480260f15) tidal-hifi: meta: platforms: only x86_64-linux is supported
* [`500e0511`](https://github.com/NixOS/nixpkgs/commit/500e0511cf5498b667d11531cbaeb3452be4e6f7) python3Packages.nethsm: 1.4.0 -> 1.4.1
* [`1bf62881`](https://github.com/NixOS/nixpkgs/commit/1bf62881ec64321c05e6476f24d4be16c4ef05a6) python3Packages.partial-json-parser: 0.2.1.1.post5 -> 0.2.1.1.post6
* [`38b3dd5e`](https://github.com/NixOS/nixpkgs/commit/38b3dd5ef85138f2ab0a331a0f764f687353310e) python3Packages.django-simple-history: 3.9.0 -> 3.10.1
* [`284b25a1`](https://github.com/NixOS/nixpkgs/commit/284b25a12c3fff7a680d57737b26c4b8d6180394) maintainers: add dstremur
* [`8f0f76a3`](https://github.com/NixOS/nixpkgs/commit/8f0f76a32c61af59b97293819f6d32fed2c9d824) nixos/grub: install memtest and other grub.extraFiles correctly when using mirroredBoots
* [`090c2fc0`](https://github.com/NixOS/nixpkgs/commit/090c2fc089580504fef7108d2cca5d0d3381f3ca) python3Packages.pcffont: 0.0.20 -> 0.0.21
* [`cc412943`](https://github.com/NixOS/nixpkgs/commit/cc4129432e3b294e9c14ef36c1f9434479ade5de) python3Packages.mail-parser: 4.1.3 -> 4.1.4
* [`3f5534bd`](https://github.com/NixOS/nixpkgs/commit/3f5534bd2501521dff0dd63f8f0fcbb0dc5d9c9d) maintainers: add sxmair
* [`84d821e6`](https://github.com/NixOS/nixpkgs/commit/84d821e615410402e0b42a429812b12ffb2950c6) wmutils-opt: 1.0 -> 1.0-unstable-2024-09-09
* [`4fbdb6f8`](https://github.com/NixOS/nixpkgs/commit/4fbdb6f81a5c8de4b34b36a3ca698d4f4c3aa5d1) python3Packages.mwparserfromhell: 0.6.6 -> 0.7.2
* [`24b6c29a`](https://github.com/NixOS/nixpkgs/commit/24b6c29aec3f73cde49c7d24fb1373ba959b116a) nixos/restic: Add SFTP repository to tests
* [`e588b1af`](https://github.com/NixOS/nixpkgs/commit/e588b1af4cc594fce167526c635c76be5fb62e16) python3Packages.imap-tools: 1.10.0 -> 1.11.0
* [`c0066c43`](https://github.com/NixOS/nixpkgs/commit/c0066c4316521c971c00168731f1d62a53a383cc) Add missing sanoid options regarding script hooks.
* [`f56d876a`](https://github.com/NixOS/nixpkgs/commit/f56d876abae75732d05cd637219924686f3c1cfe) keyguard: 1.12.3 -> 1.13.0
* [`f44f7d33`](https://github.com/NixOS/nixpkgs/commit/f44f7d3399d68a559a335c5f8648f73fc4547cc3) vulkan-extension-layer: 1.4.313.0 -> 1.4.321
* [`2c814ed0`](https://github.com/NixOS/nixpkgs/commit/2c814ed026786ac18c1643bf15113e4aea61cd92) home-assistant-custom-components.localtuya: 2025.6.0 -> 2025.7.0
* [`baf7500a`](https://github.com/NixOS/nixpkgs/commit/baf7500aad20f1834e8ed3bd76616f6c54127996) jruby: 9.4.12.0 -> 10.0.0.0
* [`54312344`](https://github.com/NixOS/nixpkgs/commit/54312344a9033605840e16ada5bae08eaf974b1f) tidal-hifi: 5.19.0 -> 5.20.0
* [`dc59ae0e`](https://github.com/NixOS/nixpkgs/commit/dc59ae0ec9da09c625344707e1e9bca004521a4a) xrdp: 0.10.3 -> 0.10.4.1
* [`6ff54413`](https://github.com/NixOS/nixpkgs/commit/6ff5441378e22152861c919682d88647ec83fccd) nsd: 4.11.1 -> 4.12.0
* [`5793980f`](https://github.com/NixOS/nixpkgs/commit/5793980fc15f37c8d8bcf5f6aa19160f715b2def) qlog: 0.44.1 -> 0.45.0
* [`a074c186`](https://github.com/NixOS/nixpkgs/commit/a074c186d530d7dc4851eaa955198fa1ed1f223b) argyllcms: 3.3.0 -> 3.4.0
* [`e75da4af`](https://github.com/NixOS/nixpkgs/commit/e75da4af059c7207d1d03bc793ed29ad588440a2) python3Packages.svg-py: 1.6.0 -> 1.7.0
* [`406f4802`](https://github.com/NixOS/nixpkgs/commit/406f480248130130bd1b6302d38582b0c4b2ee6a) winetricks: add dependencies
* [`ebd97d61`](https://github.com/NixOS/nixpkgs/commit/ebd97d61f3e4d3622b9a84520c1bf10f6f835e1a) python3Packages.pylibacl: 0.7.2 -> 0.7.3
* [`9b68a403`](https://github.com/NixOS/nixpkgs/commit/9b68a4033c86a770eb3ccea98367c1411511c9a0) nixos/pcscd: Allow configuration of filters
* [`d33f086e`](https://github.com/NixOS/nixpkgs/commit/d33f086ed1707dd228402cb0eaa8938c1049cf8a) python3Packages.djoser: 2.3.1 -> 2.3.3
* [`3fdc01e3`](https://github.com/NixOS/nixpkgs/commit/3fdc01e32a470d5e752e71b3af795e725b52ff3e) maintainers: add jf-uu
* [`6ff81398`](https://github.com/NixOS/nixpkgs/commit/6ff8139859648a7e585b5b36d092f2c5470149ad) 3cpio: init at 0.8.0
* [`a7243296`](https://github.com/NixOS/nixpkgs/commit/a72432965d5586e00fc23261da0511b3c05842ea) libphidget22: 1.22.20250324 -> 1.22.20250714
* [`39426ff3`](https://github.com/NixOS/nixpkgs/commit/39426ff3fc379198295d83931139346a84f7b1bd) icingaweb2-thirdparty: 0.13.0 -> 0.13.1
* [`614e4dbe`](https://github.com/NixOS/nixpkgs/commit/614e4dbe37a04ffa3dda306a12b61da8f97ac824) icingaweb2-ipl: 0.16.1 -> 0.17.0
* [`a25a705f`](https://github.com/NixOS/nixpkgs/commit/a25a705ff39e53caec80b1d9ef1fce8afe13e055) zeroad: 0.27.0 -> 0.27.1
* [`4604f8e1`](https://github.com/NixOS/nixpkgs/commit/4604f8e1159f941dd5b0fd3f23a7d2f9f3d5f780) ubootBananaPim2Zero: init at 2023.07.02
* [`d8c6eaa9`](https://github.com/NixOS/nixpkgs/commit/d8c6eaa95b775101ac7a7060137aae356008f910) ubootTools: add `mkeficapsule` to installed tools
* [`c841163a`](https://github.com/NixOS/nixpkgs/commit/c841163aaad97e004ea8e1f4f8f9385d8a16d443) jdk24: 24.0.1+9 -> 24.0.2+12
* [`952a2267`](https://github.com/NixOS/nixpkgs/commit/952a2267c7ed743b4e30bd6cd083f813c1b60a03) yaru-theme: 25.04.2 -> 25.10.1
* [`d9cac534`](https://github.com/NixOS/nixpkgs/commit/d9cac53478aed00c84bcee044ab252fe8fac78b9) kcc: 7.5.1 -> 8.0.4, fix wrapping, use pyproject = true
* [`5856066e`](https://github.com/NixOS/nixpkgs/commit/5856066e1248a59fbb84d8547081837b3a1e1c20) kcc: remove leftover files
* [`5e557fac`](https://github.com/NixOS/nixpkgs/commit/5e557facc913fa12c365c94f3f262a12a6b8a5fc) multiqc: use pyproject = true, clean up
* [`d4c6b991`](https://github.com/NixOS/nixpkgs/commit/d4c6b9911f7db7ccc40140a3f0e9ce69c5fd89ef) dbip-country-lite: 2025-06 -> 2025-07
* [`843e7066`](https://github.com/NixOS/nixpkgs/commit/843e706680b6f1b8ecbcfa329d2801cf85bd4ffe) dbip-city-lite: 2025-06 -> 2025-07
* [`27a90951`](https://github.com/NixOS/nixpkgs/commit/27a909511603fb9f845a8c3aa1ed5d1bfeb609a1) dbip-asn-lite: 2025-06 -> 2025-07
* [`a4624b1d`](https://github.com/NixOS/nixpkgs/commit/a4624b1d1ad7ef909484b09638dac837a03d6c99) jdk8: 8u442-b06 -> 8u462-b08
* [`297c4a41`](https://github.com/NixOS/nixpkgs/commit/297c4a41c541490319b1afdbdcb0d85049ffcdd0) cyclonedx-python: 6.1.2 -> 7.0.0
* [`26c9a8bf`](https://github.com/NixOS/nixpkgs/commit/26c9a8bf13a941e5722075daddb99fa980d16dea) thanos: 0.38.0 → 0.39.1
* [`ce60d2df`](https://github.com/NixOS/nixpkgs/commit/ce60d2df8fbbb08533c497fc0868b3b415a4fb1d) nixos/thanos: Migrate test to runTest, fix name
* [`8473ce8c`](https://github.com/NixOS/nixpkgs/commit/8473ce8c958d4086c2fc384b30b4815895a567a8) thanos: 0.39.1 → 0.39.2
* [`a2fb7b85`](https://github.com/NixOS/nixpkgs/commit/a2fb7b85e83938761415ca419a0d5a83b55cd05a) mailspring: 1.15.1 -> 1.16.0
* [`4b81ba62`](https://github.com/NixOS/nixpkgs/commit/4b81ba62e708592cfa7b9e017f2fe28ff498c27e) overseerr: init at 1.34.0
* [`50b7400d`](https://github.com/NixOS/nixpkgs/commit/50b7400d9343a1bd52e3f8b3f63318441111c403) nixos/overseerr: init
* [`35c1d426`](https://github.com/NixOS/nixpkgs/commit/35c1d426c1e69779f36dad7c8abecc379e87b868) carburetor: set the binary path in desktop file exec command
* [`c87da712`](https://github.com/NixOS/nixpkgs/commit/c87da712e4ee7f6c5e331107d4778eb2cf8cd969) carburetor: 5.0.0 -> 5.1.1
* [`e5fe9cc5`](https://github.com/NixOS/nixpkgs/commit/e5fe9cc5ac7025dc75136dbab3c1ac7abfb5ecfd) python3Packages.tmdbsimple: init at 2.9.2-unstable-2025-01-07
* [`016a7e7f`](https://github.com/NixOS/nixpkgs/commit/016a7e7f05cc9ccf4d874f1e0ea18eba1c049e93) grafanaPlugins.grafana-polystat-panel: 2.1.14 -> 2.1.15
* [`809d70e4`](https://github.com/NixOS/nixpkgs/commit/809d70e46ad81bafdcc6f1995d2933f57e44eaf1) zabbix70: 7.0.16 -> 7.0.17
* [`8bb140e8`](https://github.com/NixOS/nixpkgs/commit/8bb140e8d415361579e834b1c7b93d80b29df454) python3Packages.upcloud-api: 2.6.0 -> 2.7.0
* [`24235658`](https://github.com/NixOS/nixpkgs/commit/24235658e8fa092405bd5661947ec96fdb801384) dpdk: 25.03 -> 25.07
* [`6d8da589`](https://github.com/NixOS/nixpkgs/commit/6d8da589c38611c8a1d9e73f007c499bd2d5f7ef) mongodb-6_0: drop
* [`29a7ca73`](https://github.com/NixOS/nixpkgs/commit/29a7ca7340702e0ce87f87563f8da23d5fc3f57a) nixos/victorialogs: add basicAuth options
* [`4faaa9ab`](https://github.com/NixOS/nixpkgs/commit/4faaa9ab9e359ff08594e12533706831eebe0e12) vlagent: init at 1.25.0
* [`37deae36`](https://github.com/NixOS/nixpkgs/commit/37deae36ba72330d4ad2c5d88d6748caaf5206aa) nixos/vlagent: init
* [`cea3b9b1`](https://github.com/NixOS/nixpkgs/commit/cea3b9b1e2c0b804892e16d190f3603a2a044e06) nixos/victorialogs: add integration test with vlagent
* [`57f3309a`](https://github.com/NixOS/nixpkgs/commit/57f3309a8e89bf6deac3d6936e380f993ac96384) megasync: 5.12.0.1 -> 5.14.0.2
* [`cfa13520`](https://github.com/NixOS/nixpkgs/commit/cfa1352056e4a534146bf4b59b580f50507a39ed) jitsi-videobridge: 2.3-236-g95ef6210 -> 2.3-249-g9a2123ad4
* [`d6f91cb4`](https://github.com/NixOS/nixpkgs/commit/d6f91cb439ea07cd25e298967708910900bdf1af) hydrus: 627 -> 631
* [`c6795052`](https://github.com/NixOS/nixpkgs/commit/c6795052ec2548fd9fd4d9f5e45eab022111f620) uclibc-ng: 1.0.52 -> 1.0.54
* [`e2ce8a39`](https://github.com/NixOS/nixpkgs/commit/e2ce8a39872ec028fb4e67c8866cd6bf5e77e863) jerryscript: init at 3.0.0
* [`7b787be4`](https://github.com/NixOS/nixpkgs/commit/7b787be4ec86ec6e0a75e0f10ec19e218bf5d8e4) traefik: 3.4.4 -> 3.5.0
* [`70ed8432`](https://github.com/NixOS/nixpkgs/commit/70ed84324e3b1e5e1eca06034c99c8b432f32b8b) keycloak: 26.3.1 -> 26.3.2
* [`bcb8fffb`](https://github.com/NixOS/nixpkgs/commit/bcb8fffb448a662b14d785bd1544c96d77a40710) libnvme: 1.11.1 -> 1.15
* [`6e209b15`](https://github.com/NixOS/nixpkgs/commit/6e209b158ef97112035b1b1cabf5597fbdb2eb97) livi: 0.3.1 -> 0.3.2
* [`1242c28e`](https://github.com/NixOS/nixpkgs/commit/1242c28e9ab93152819ebc69af78c22eaaae4b58) python3Packages.israel-rail-api: 0.1.2 -> 0.1.3
* [`926822b5`](https://github.com/NixOS/nixpkgs/commit/926822b5d87a1943d1002f00855b72a03c488a7e) jicofo: 1.0-1138 -> 1.0-1153
* [`4a223545`](https://github.com/NixOS/nixpkgs/commit/4a2235453aff42e51ba195449040c39dbd42b135) qview: 7.0 -> 7.1
* [`750c1642`](https://github.com/NixOS/nixpkgs/commit/750c1642441a28a3e734d4623c2d226c55ce0998) epsonscan2: move qt5 out of toplevel
* [`a6b55f5f`](https://github.com/NixOS/nixpkgs/commit/a6b55f5ff50274de7749443463d2bb96bb0b5809) afterburn: 5.8.2 -> 5.9.0
* [`150c556e`](https://github.com/NixOS/nixpkgs/commit/150c556e4e56e1f896d8cf33d3ec18e0b31e1921) pdfsam-basic: 5.3.1 -> 5.3.2
* [`74276c14`](https://github.com/NixOS/nixpkgs/commit/74276c14d4070d0ec989398b8ba10ce775db510b) weaviate: 1.31.6 -> 1.32.1
* [`ef00b6e4`](https://github.com/NixOS/nixpkgs/commit/ef00b6e47a500ac29dccde9eba4e53a3805392c9) python3Packages.docling-jobkit: 1.1.1 -> 1.2.0
* [`2e8ddbf7`](https://github.com/NixOS/nixpkgs/commit/2e8ddbf7f359265962579988e0995fa3cacc440f) python3Packages.libear: init at 19.1.7
* [`15e4bf1a`](https://github.com/NixOS/nixpkgs/commit/15e4bf1a47f5363cce529c9ebe27ac40dc4c312f) python3Packages.libscanbuild: init at 19.1.7
* [`231a7703`](https://github.com/NixOS/nixpkgs/commit/231a770356c1e71eb67f4dd194bbe440c374e643) intercept-build: init at 19.1.7
* [`9e536408`](https://github.com/NixOS/nixpkgs/commit/9e53640859014a6b658286d3d885845fec3ceb50) scan-build: init at 19.1.7
* [`b8f9fca9`](https://github.com/NixOS/nixpkgs/commit/b8f9fca96ab3934c5d5f7dc7d52855c5b058e541) analyze-build: init at 19.1.7
* [`aff46d19`](https://github.com/NixOS/nixpkgs/commit/aff46d194332bf063d149ef1010c29b5ca1fe2dd) python3Packages.weasyprint: 65.1 -> 66.0
* [`e48b448e`](https://github.com/NixOS/nixpkgs/commit/e48b448ea6db7cbeaef1977f2eff53f2c309c205) clapgrep: 25.05+1 -> 25.07
* [`1c571455`](https://github.com/NixOS/nixpkgs/commit/1c57145569424b9084922347b3c08d0e8b704bc7) cni-plugin-flannel: 1.6.2-flannel1 -> 1.7.1-flannel2
* [`41677158`](https://github.com/NixOS/nixpkgs/commit/41677158261f7cafaa8fbcf73a3f6cc3b573b849) python3Packages.cleanit: 0.4.8 -> 0.4.9
* [`573183be`](https://github.com/NixOS/nixpkgs/commit/573183beccc0b76b6daa81cfc39b0f99e770976b) mfaktc: init at 0.23.5
* [`1d57cdc6`](https://github.com/NixOS/nixpkgs/commit/1d57cdc601753915c8468fc8e41dc1f105c79ec6) rmfakecloud: 0.0.24 -> 0.0.25
* [`f0449a48`](https://github.com/NixOS/nixpkgs/commit/f0449a4887ce1dda54b41553fce56385f5a1d50e) kopia: 0.20.1 -> 0.21.1
* [`d2bc4bae`](https://github.com/NixOS/nixpkgs/commit/d2bc4bae0f28977b81ddb3c4d56ad8c62a5b6ffe) hasura-cli: 2.48.1 -> 2.48.3
* [`53374dff`](https://github.com/NixOS/nixpkgs/commit/53374dff9d460981b972f0cdf0df302f174543c5) xcaddy: 0.4.4 -> 0.4.5
* [`346afb36`](https://github.com/NixOS/nixpkgs/commit/346afb36b0cdf89156c91b275325efcc7f4ba66c) python3Packages.trakit: 0.2.2 -> 0.2.5
* [`cd90bc77`](https://github.com/NixOS/nixpkgs/commit/cd90bc775ec6979badd7ab3b4ebc52fcb5dadffc) pgsrip: 0.1.11 -> 0.1.12
* [`b8ee90d1`](https://github.com/NixOS/nixpkgs/commit/b8ee90d1c7220175fb0d64e198963057788f3ec7) sudo: add updateScript
* [`c364bacd`](https://github.com/NixOS/nixpkgs/commit/c364bacdab322505731af2e6fa442c6517b8ca76) zxcvbn-c: 2.5 -> 2.6
* [`471c0b53`](https://github.com/NixOS/nixpkgs/commit/471c0b53d2da13b8bf1b66e69155069561afa156) mumble: Add build option CMAKE_UNITY_BUILD for compilation speed
* [`b49e030d`](https://github.com/NixOS/nixpkgs/commit/b49e030d55728dcfc11e6e71b005aca2f5716446) prometheus-postfix-exporter: 0.11.0 -> 0.12.1
* [`284b065a`](https://github.com/NixOS/nixpkgs/commit/284b065a5810329feb084297f931280936c8ce40) gitea-mcp-server: 0.2.0 -> 0.3.0
* [`ca5dbda2`](https://github.com/NixOS/nixpkgs/commit/ca5dbda2561174cdee32fc025bb9e7c29cada3af) delly: 1.3.3 -> 1.5.0
* [`27dd888b`](https://github.com/NixOS/nixpkgs/commit/27dd888b85361411461e86aba203da832432f191) cozette: 1.29.0 -> 1.30.0
* [`b58a96fd`](https://github.com/NixOS/nixpkgs/commit/b58a96fdc823ffcf7a2277e9e93c190951cdcd40) nitrokey-app2: 2.3.3 -> 2.3.5
* [`e1ca4fc0`](https://github.com/NixOS/nixpkgs/commit/e1ca4fc01c25f98d2afd903c8dcd9618a7bb5b53) doublecmd: 1.1.26 -> 1.1.27
* [`46d1ed95`](https://github.com/NixOS/nixpkgs/commit/46d1ed9504b439fa7bcf41b6bfc1151868d65c65) calibre: 8.6.0 -> 8.7.0
* [`5669a548`](https://github.com/NixOS/nixpkgs/commit/5669a54817eb1237e1bd1268bafdc37ccd444075) grpcui: 1.4.3 -> 1.5.1
* [`00ca6d7a`](https://github.com/NixOS/nixpkgs/commit/00ca6d7aaa313465804f030e0f43992b5052769d) iroh: 0.90.0 -> 0.91.0
* [`7ba0b38f`](https://github.com/NixOS/nixpkgs/commit/7ba0b38f6ff3969ccad91f48c78dafbca584238f) python3Packages.python-gitlab: 6.1.0 -> 6.2.0
* [`db2e6445`](https://github.com/NixOS/nixpkgs/commit/db2e6445c0da2154d7a37953a7ae1d91f6ca5ef6) persepolis updated from 5.1.1 -> 5.2.0
* [`a3bca2ec`](https://github.com/NixOS/nixpkgs/commit/a3bca2ecab5b3b7a49f6b62cfeda25eb22f12056) added L0L1P0P1 to persepolis maintainers
* [`b5c24b15`](https://github.com/NixOS/nixpkgs/commit/b5c24b1524d0b038e51592af127cab670e9cdc32) schismtracker: 20250415 -> 20250728
* [`4e2640b9`](https://github.com/NixOS/nixpkgs/commit/4e2640b9056a6b5b1bc659133f36ac259417a9a9) gitlab-runner: 18.1.2 -> 18.1.3
* [`8ae12fbe`](https://github.com/NixOS/nixpkgs/commit/8ae12fbefde3006f11426865eb371567b470606b) flink: 2.0.0 -> 2.1.0
* [`d6014288`](https://github.com/NixOS/nixpkgs/commit/d60142881b21fe986bcf2086a2ff1961ff4ecf2b) rgbds: 0.9.3 -> 0.9.4
* [`2442167e`](https://github.com/NixOS/nixpkgs/commit/2442167ed1e1bf1901bede42c6cee2bd767b849d) kopia: replace gitUpdater with nix-update script
* [`c1e66862`](https://github.com/NixOS/nixpkgs/commit/c1e6686209ded4a7900ae3c08271dc0bb6b2b177) kopia: replace meta = with lib; add changelog link
* [`0bcf8c0c`](https://github.com/NixOS/nixpkgs/commit/0bcf8c0c8720f1182051cb49c4f0fc04e71c8f4c) libinput: 1.28.1 -> 1.29.0
* [`f144afb7`](https://github.com/NixOS/nixpkgs/commit/f144afb7b741559fd603b4e39e1c941d94803788) kubevirt: 1.5.2 -> 1.6.0
* [`cc477cd3`](https://github.com/NixOS/nixpkgs/commit/cc477cd32bad97e53182611bf50c2f08cb635f65) nix-serve-ng: 1.0.0-unstable-2024-12-02 -> 1.0.1-unstable-2025-05-28
* [`07deefb3`](https://github.com/NixOS/nixpkgs/commit/07deefb3fa36c3ca1669ea4ff3dffc00f536a088) nix-serve-ng: use overrideSrc
* [`6d920978`](https://github.com/NixOS/nixpkgs/commit/6d92097803e6eeb32fdd57a88ec318324fa86907) msbuild-structured-log-viewer: 2.3.17 -> 2.3.34
* [`8ebda453`](https://github.com/NixOS/nixpkgs/commit/8ebda4530f47b13debc49f02153debda93082b9e) nix-serve-ng: unbreak on aarch64-darwin
* [`999a7f16`](https://github.com/NixOS/nixpkgs/commit/999a7f16cac623224048fb39d3d56eb7c714fc20) openpgl: 0.7.0 -> 0.7.1
* [`0c61ea20`](https://github.com/NixOS/nixpkgs/commit/0c61ea206396431a766922c13fd3f49a84ad3270) asn: 0.78.3 -> 0.78.6
* [`51911bd6`](https://github.com/NixOS/nixpkgs/commit/51911bd697e7b1b4b211d37b78570abd60b417ee) gcs: 5.36.1 -> 5.37.1
* [`4c544f12`](https://github.com/NixOS/nixpkgs/commit/4c544f125f99cdc8b1ea375e400371391ed5a5d8) obs-cmd: 0.18.5 -> 0.19.2
* [`c14502ba`](https://github.com/NixOS/nixpkgs/commit/c14502baaf13b34249f07c028ffde4ee59ce9341) storj-uplink: 1.133.5 -> 1.134.2
* [`c6cd5774`](https://github.com/NixOS/nixpkgs/commit/c6cd577488e5052651e97c25eb4a67969b393e42) waybar-lyric: 0.10.0 -> 0.11.0
* [`55989003`](https://github.com/NixOS/nixpkgs/commit/559890037c0c5f4654c909a2cc449bfb2f94b3d9) parallel-launcher: 8.2.1 -> 8.3.0
* [`2a4ccacb`](https://github.com/NixOS/nixpkgs/commit/2a4ccacb2e3c99bf0eb02c410d8d6570ee0a8a11) kopia: add blenderfreaky and nadir-ishiguro as maintainers
* [`929f3a33`](https://github.com/NixOS/nixpkgs/commit/929f3a33021d3b2a3eacc2ffc38829f380942551) auditwheel: 6.4.0 -> 6.4.2
* [`8592e203`](https://github.com/NixOS/nixpkgs/commit/8592e203991bab24e4df61d6b50dce25fbdcc3e7) stress-ng: 0.19.02 -> 0.19.03
* [`5d75012b`](https://github.com/NixOS/nixpkgs/commit/5d75012b621292c8215f70f68b1640c5f07eb790) maintainers: add frantathefranta
* [`43e2724c`](https://github.com/NixOS/nixpkgs/commit/43e2724cfdd5353e090394bbc5b631f55c631bae) etcd_3_5: scope passthru dependencies
* [`3032e375`](https://github.com/NixOS/nixpkgs/commit/3032e37534595526136ffbba69527fdfb6773488) etcd_3_5: 3.5.21 -> 3.5.22
* [`6966a708`](https://github.com/NixOS/nixpkgs/commit/6966a708226a748caf01eb5801ad70591dcca587) etcd_3_5: use underscore for version directory name
* [`c04ca0c6`](https://github.com/NixOS/nixpkgs/commit/c04ca0c6cf619aaef89810f349870302a8177000) python3Packages.pyside6-fluent-widgets: 1.8.3 -> 1.8.4
* [`40f5472f`](https://github.com/NixOS/nixpkgs/commit/40f5472fb88c325c0b480b1fc222725b0f1a7b64) zwave-js-server: 3.1.0 -> 3.2.1
* [`2342d6f4`](https://github.com/NixOS/nixpkgs/commit/2342d6f4931858a8d964205d5ef7881aad1cd34f) tandoor-recipes: 1.5.35 -> 2.0.1
* [`522f66c1`](https://github.com/NixOS/nixpkgs/commit/522f66c1dd367fc56fe228f6afb14f72354099b0) hcxtools: 6.3.5 -> 7.0.0
* [`e802fbad`](https://github.com/NixOS/nixpkgs/commit/e802fbad7342e1af8c793932c032f22d7a988cc9) hcxdumptool: 6.3.5 -> 7.0.0
* [`3e40339d`](https://github.com/NixOS/nixpkgs/commit/3e40339d4472d5a51b4dbaca1b7009f73ee05723) python3Packages.elevenlabs: 2.7.1 -> 2.8.1
* [`fd7f4874`](https://github.com/NixOS/nixpkgs/commit/fd7f4874296be9666a8d3bc84e18c16eabe1fcdd) immich: 1.136.0 -> 1.137.3
* [`55552b87`](https://github.com/NixOS/nixpkgs/commit/55552b87ec8abaf31f825a98c0e5fa021e689078) redocly: 1.34.4 -> 2.0.2
* [`bb25caaf`](https://github.com/NixOS/nixpkgs/commit/bb25caafc56e3ab1e04153f6eefe6a7851451625) alsa-utils-nhlt: init
* [`6f79a7af`](https://github.com/NixOS/nixpkgs/commit/6f79a7af3a5dad337aad4313664730ad5c60c66d) Doc/nixosOptionsDoc: fix baseModules cannot be empty
* [`65cbe525`](https://github.com/NixOS/nixpkgs/commit/65cbe525f06efa1d5d92189b19f0b9bb83d775a2) etcd_3_5: darwin network workaround
* [`70f1d94f`](https://github.com/NixOS/nixpkgs/commit/70f1d94f7143eca6ca84d36b43f3e37e7e52cbac) etcd_3_5: move buildGoModule pinning to top-level to comply with override interface
* [`a8355672`](https://github.com/NixOS/nixpkgs/commit/a835567247302417bfbecc304493042aedcc490d) linuxPackages.vmware: workstation-17.6.3-20250608 -> workstation-17.6.3-20250728
* [`f2ee8ab3`](https://github.com/NixOS/nixpkgs/commit/f2ee8ab37ce97c249747593d02c9ccb1a3ed3a3a) confluent-cli: 4.32.0 -> 4.34.0
* [`ec83fe41`](https://github.com/NixOS/nixpkgs/commit/ec83fe41940459e4ac6848ad7f2c6f7f22bfef08) etcd_3_5: add dtomvan as maintainer
* [`78c5476c`](https://github.com/NixOS/nixpkgs/commit/78c5476c267da288fed44103f34a98e9a4939632) zulu24: 24.0.1 -> 24.0.2
* [`6c289785`](https://github.com/NixOS/nixpkgs/commit/6c2897852656e66543df52aca8913661f5896a0e) etcd_3_5: remove offline from maintainers for inactivity
* [`9a52af3e`](https://github.com/NixOS/nixpkgs/commit/9a52af3e72cad9ef2ff8ac05cad6e046a962cf71) kics: 2.1.11 -> 2.1.12
* [`f4dcc3d7`](https://github.com/NixOS/nixpkgs/commit/f4dcc3d75ccdab32c5753c9c2fd0ecc9ac5b8bcf) vpl-gpu-rt: 25.3.0 -> 25.3.1
* [`26e33ac3`](https://github.com/NixOS/nixpkgs/commit/26e33ac37f514180d4bccc835086837313bc2a4a) jan: 0.6.5 -> 0.6.6
* [`07728c24`](https://github.com/NixOS/nixpkgs/commit/07728c24f2a8fed4dbe6fe0a657465bdeefa3612) python3Packages.pypdf: 5.7.0 -> 5.9.0
* [`55bfb8c7`](https://github.com/NixOS/nixpkgs/commit/55bfb8c7635a73f968e9489878ccdb3f01ee79df) python3Packages.trytond: 7.6.3 -> 7.6.5
* [`4ac84a65`](https://github.com/NixOS/nixpkgs/commit/4ac84a657a62228c2ba5ae69a9a360474634fe23) apriltag: 3.4.3 -> 3.4.4
* [`9b6fe45f`](https://github.com/NixOS/nixpkgs/commit/9b6fe45fc7f0fada45227046fed2952d770122e0) sublime-merge: 2102 -> 2110
* [`55e3119d`](https://github.com/NixOS/nixpkgs/commit/55e3119d26ee64b2317e1edac9e528c15dbd78a7) gl3w: 0-unstable-2025-04-08 -> 0-unstable-2025-08-02
* [`ad91f278`](https://github.com/NixOS/nixpkgs/commit/ad91f2783d3f911a3c971569bd24102ad2f86ca6) python3Packages.textual-autocomplete: 4.0.4 -> 4.0.5
* [`33a2e571`](https://github.com/NixOS/nixpkgs/commit/33a2e5716d837ced68c0fff1673ff3a469587eb0) posting: 2.7.0 -> 2.7.1
* [`521ec9f2`](https://github.com/NixOS/nixpkgs/commit/521ec9f2821f12ab5f37c40da464c03e7223f3cf) openrct2: 0.4.24 -> 0.4.25
* [`294792c9`](https://github.com/NixOS/nixpkgs/commit/294792c9053a60ad29ff7d11975765ba257d5795) openrct2: modernize cmakeFlags
* [`2ccf06c4`](https://github.com/NixOS/nixpkgs/commit/2ccf06c42e1e9f5b27cda04ccf45a47bf8e53313) brakeman: migrate to by-name
* [`7a010f1b`](https://github.com/NixOS/nixpkgs/commit/7a010f1bfd65de57145c4f16fee44d3acd1484ed) pragha: remove unused pcre dependency
* [`10634b03`](https://github.com/NixOS/nixpkgs/commit/10634b03f176c761701b520951130f48b5dee5b6) breitbandmessung: add `sourceRoot` for darwin
* [`ceeb66b3`](https://github.com/NixOS/nixpkgs/commit/ceeb66b3b8968eb6b0fb5ac0e3d576d7bd5db20a) breitbandmessung: add `dont{Fixup,Strip}` for darwin
* [`0bcef7f5`](https://github.com/NixOS/nixpkgs/commit/0bcef7f512654c19ca2d28c75849be1069cc3524) abbaye-des-morts: use `finalAttrs` pattern
* [`058b2b16`](https://github.com/NixOS/nixpkgs/commit/058b2b16921f2e72b317fa2d2dd68e9c1a4797ef) abbaye-des-morts: use `${placeholder "out"}`
* [`acca62bc`](https://github.com/NixOS/nixpkgs/commit/acca62bcd114fabdb2a602e17f89f4570ce97ad7) abbaye-des-morts: drop `preInstall`
* [`67ab5122`](https://github.com/NixOS/nixpkgs/commit/67ab5122c1bb9e7f366384d9d5c04d7e9533bc07) abbaye-des-morts: fix darwin build
* [`4f81d58a`](https://github.com/NixOS/nixpkgs/commit/4f81d58a5db81cb927ff117cc26d33833ead4e9c) lint-staged: 16.1.2 -> 16.1.3
* [`f68d8c92`](https://github.com/NixOS/nixpkgs/commit/f68d8c927c86aa89b6c1235342bda877f51b27a4) grandorgue: 3.15.4-1 -> 3.16.0-1
* [`abad83c4`](https://github.com/NixOS/nixpkgs/commit/abad83c495c1ce10f694b61d0f02b8d17741a909) trillian-im: remove unused webkitgtk_4_0 dependency
* [`6cf0fe8a`](https://github.com/NixOS/nixpkgs/commit/6cf0fe8aa7ae9c312ff8c96d7201eb6465b89db9) trillian-im: 6.3.0.1 -> 6.3.0.2
* [`f26cc726`](https://github.com/NixOS/nixpkgs/commit/f26cc7265c80fd6b8035731fd2da6b801914588e) high-tide: 0.1.7 -> 0.1.8
* [`7c979330`](https://github.com/NixOS/nixpkgs/commit/7c9793306072ca98d0e03b309030e83d4293dc19) flow-control: 0.4.0 -> 0.5.0
* [`e338c7b8`](https://github.com/NixOS/nixpkgs/commit/e338c7b8dc84e4f91a991d22506c3809a1dfec86) nixos/wireguard-networkd: fix 'cannot find device' error
* [`2e90eacd`](https://github.com/NixOS/nixpkgs/commit/2e90eacdc5ce4ca3a3fa43201ee24f0602919176) gradia: add `passthru.updateScript`
* [`5b96e5cc`](https://github.com/NixOS/nixpkgs/commit/5b96e5ccd424e0b39f7c7079fd7fe5a09ccc3c31) rego-query: init at 0.0.14
* [`eaa197d9`](https://github.com/NixOS/nixpkgs/commit/eaa197d9eb71229287e4628f497fb9e0ee783bbc) nucleus: init at 1
* [`b1ada6e2`](https://github.com/NixOS/nixpkgs/commit/b1ada6e29841bb3c2963bc4f4bc69beb9d8762f1) storm: 2.8.1 -> 2.8.2
* [`2ca81423`](https://github.com/NixOS/nixpkgs/commit/2ca814230d2a3afd15855308c632a823b8e3b280) snd: 25.5 -> 25.6
* [`e0c16a6a`](https://github.com/NixOS/nixpkgs/commit/e0c16a6a966fd22d6af433f878f11946174ee8b0) kicad: 9.0.2 -> 9.0.3
* [`d4e4b7dd`](https://github.com/NixOS/nixpkgs/commit/d4e4b7dd51477a7b9bf517235df95c79dd87c8d8) python3Packages.storage3: fix typo
* [`7468c655`](https://github.com/NixOS/nixpkgs/commit/7468c655858432ce08726b33808148403cd343ad) hail: init at 0.2.2
* [`5a864049`](https://github.com/NixOS/nixpkgs/commit/5a864049649d7229b4af99305808553cc9f81f49) feishu: 7.42.17 -> 7.46.11
* [`2f66b2cb`](https://github.com/NixOS/nixpkgs/commit/2f66b2cbdacee0b4cc9143e87496b3a3d075a71b) python3Packages.warp-lang: 1.8.0 -> 1.8.1
* [`68710f40`](https://github.com/NixOS/nixpkgs/commit/68710f4064b6437e25121538cea6c7f221536d25) virtualisation/oci-containers: fix podman systemd service name
* [`1188a085`](https://github.com/NixOS/nixpkgs/commit/1188a0857c4160ab4615a3b56064b024e34ad4b2) jdt-language-server: 1.48.0 -> 1.49.0
* [`88977088`](https://github.com/NixOS/nixpkgs/commit/88977088971b36f2981a7588eadc53743a56c1a0) clj-kondo: 2025.07.26 -> 2025.07.28
* [`49994e8e`](https://github.com/NixOS/nixpkgs/commit/49994e8ed8a39ef8e55b6e9e6b2577af80bd2c4c) beszel: 0.11.1 -> 0.12.3
* [`269c84bc`](https://github.com/NixOS/nixpkgs/commit/269c84bc2135e9a5cd4ac513e99636ac546f21c2) boogie: 3.5.4 -> 3.5.5
* [`1a8e00bb`](https://github.com/NixOS/nixpkgs/commit/1a8e00bbe5da569d0ba3dcd471d7b78ac7a39a60) xjobs: 20250209 -> 20250529
* [`433575f2`](https://github.com/NixOS/nixpkgs/commit/433575f27d31a4416964d8742af3555cedd68dc9) abiword: 3.0.6 -> 3.0.7
* [`e1d6f4f8`](https://github.com/NixOS/nixpkgs/commit/e1d6f4f8b49f09284c82022f793e2d4f985e9f5a) kubectl-gadget: 0.42.0 -> 0.43.0
* [`fd2fc997`](https://github.com/NixOS/nixpkgs/commit/fd2fc997af490147d121293a91ddf00333125b15) node-gyp: 11.2.0 -> 11.3.0
* [`7784c900`](https://github.com/NixOS/nixpkgs/commit/7784c900e994dcb2204949df842cadee87326d9b) python313Packages.python-telegram-bot: 22.1 -> 22.3
* [`2d317784`](https://github.com/NixOS/nixpkgs/commit/2d3177841a1b7e82ca77e2cb10a10f1cc522ab53) python3Packages.llama-cloud: 0.1.34 -> 0.1.36
* [`c4795f77`](https://github.com/NixOS/nixpkgs/commit/c4795f772ed8f88b3f4066441625d1b9c094b0d1) go-ethereum: 1.16.1 -> 1.16.2
* [`1c134a8f`](https://github.com/NixOS/nixpkgs/commit/1c134a8ffc29e7742d65ad913c6b380ae32f6817) onedrivegui: 1.1.1a -> 1.2.1, modernize
* [`0381027a`](https://github.com/NixOS/nixpkgs/commit/0381027a38d7d241cb140a21e518e31e7340c6c6) onedrivegui: add update script
* [`63c58039`](https://github.com/NixOS/nixpkgs/commit/63c58039afdcea3d8f0fbb399fd5bc5dff742011) onedrivegui: add philipdb as maintainer
* [`4fc4196a`](https://github.com/NixOS/nixpkgs/commit/4fc4196a713fa75658252f6bc70fb2bba0d713cd) wasmedge: 0.14.1 -> 0.15.0
* [`24b9d6dd`](https://github.com/NixOS/nixpkgs/commit/24b9d6ddcbed94e4cf026932ac6ebb1b833fa072) zsh-prezto: 0-unstable-2025-01-10 -> 0-unstable-2025-07-30
* [`4b038dfb`](https://github.com/NixOS/nixpkgs/commit/4b038dfbab6df760c9c403cf2fa22a9adb65dc5e) nixos/{consul-template,vault-agent}: drop `template` sub-option
* [`25571e9a`](https://github.com/NixOS/nixpkgs/commit/25571e9a55d100eae86f2991935b2a5d0d7d4cdf) bazel-gazelle: 0.44.0 -> 0.45.0
* [`c216bace`](https://github.com/NixOS/nixpkgs/commit/c216baceb6c96ef67e06a3961e0f93e0a1cb721e) fabric-installer: 1.0.3 -> 1.1.0
* [`7ec621e4`](https://github.com/NixOS/nixpkgs/commit/7ec621e4b81ffcf1dbb245796e69710f232b13df) tartube-yt-dlp: 2.5.156 -> 2.5.164
* [`9e062811`](https://github.com/NixOS/nixpkgs/commit/9e06281127bcc8a6a7fac9cadd7759b7e0dd034d) etesync-dav: 0.35.0 -> 0.35.1
* [`bc214653`](https://github.com/NixOS/nixpkgs/commit/bc2146534ec5d5deebee291e3f429418df612087) jib-cli: init at 0.13.0
* [`429be34f`](https://github.com/NixOS/nixpkgs/commit/429be34fbe196d888de1a7f77ee81505ba3bae4d) wineasio: 1.2.0 -> 1.3.0
* [`a836782a`](https://github.com/NixOS/nixpkgs/commit/a836782af79d98f6c4f46770d5127ac88b871ad2) zombietrackergps: use callPackage
* [`12bc7a5e`](https://github.com/NixOS/nixpkgs/commit/12bc7a5e5da3f5fcc5581484e6db43d0120ee3a8) zombietrackergps: remove rec
* [`67d8b9e1`](https://github.com/NixOS/nixpkgs/commit/67d8b9e1757e548c22204e52af4a50d8fc6c81d4) zombietrackergps: remove with lib
* [`1a020d05`](https://github.com/NixOS/nixpkgs/commit/1a020d050913a838ad59d40c69707f222c577090) zombietrackergps: move to by-name
* [`126bd4d9`](https://github.com/NixOS/nixpkgs/commit/126bd4d9a400be955b3fc258b8af9287c929f1b5) tautulli: 2.15.2 -> 2.15.3
* [`61b00afc`](https://github.com/NixOS/nixpkgs/commit/61b00afc45534ef77647497a43f9b9f5ecb79888) icestorm: 2020.12.04 -> 0-unstable-2025-06-03
* [`bffa59d5`](https://github.com/NixOS/nixpkgs/commit/bffa59d5bc778bf9850d21259a521550fc7bfda5) icestorm: add examples as integration tests
* [`04c039f9`](https://github.com/NixOS/nixpkgs/commit/04c039f993175056ec96a409f7ac6987ddbd4f71) workflows/merge-group: init
* [`42b73d66`](https://github.com/NixOS/nixpkgs/commit/42b73d667f04a4464fb923e2428f78fe5b1e6393) rustdesk-flutter: 1.4.0 -> 1.4.1
* [`efb5e36c`](https://github.com/NixOS/nixpkgs/commit/efb5e36c22d517dcf6e4a1759845afb5092c096c) dracula-theme: 4.0.0-unstable-2025-07-17 -> 4.0.0-unstable-2025-08-04
* [`07c35dcc`](https://github.com/NixOS/nixpkgs/commit/07c35dccded5c896c20107d18c9822f9d1df0db6) virt-v2v: 2.6.0 -> 2.8.1
* [`08b18634`](https://github.com/NixOS/nixpkgs/commit/08b1863454fbdfb73d09d3af4ddadd331d940c43) maintainers: Add viitorags
* [`aa0a17e8`](https://github.com/NixOS/nixpkgs/commit/aa0a17e8557f78d87f704c35dbc93fbe7b400231) virt-v2v: add updateScript
* [`2c8adb01`](https://github.com/NixOS/nixpkgs/commit/2c8adb01de4777f376a4685ff8e8ba356519fc0b) pokemon-colorscripts: 0-unstable-2024-10-19
* [`409e80d2`](https://github.com/NixOS/nixpkgs/commit/409e80d2446aa57e888eeb5327c035819466c220) ktimetracker: migrate to by-name
* [`8e309e5a`](https://github.com/NixOS/nixpkgs/commit/8e309e5a186af069db31c4153d58fc3a8c984fdd) openlinkhub: 0.6.0 -> 0.6.1
* [`38c7c217`](https://github.com/NixOS/nixpkgs/commit/38c7c217aa43e10fb7592cb8e4ba8184cb27fd65) squishyball: migrate to by-name
* [`181ba5f1`](https://github.com/NixOS/nixpkgs/commit/181ba5f166189864b3a53a82a60b3c2d2d4dc899) tutanota-desktop: add electron ozone flags
* [`a7cc6431`](https://github.com/NixOS/nixpkgs/commit/a7cc6431ebbe249b32d123b3a827c01c602c5743) tutanota-desktop: add awwpotato as maintainer
* [`c07bb08a`](https://github.com/NixOS/nixpkgs/commit/c07bb08a76ea87eb2f78b1a9626f816ff52e8268) sylkserver: init at 6.5.0
* [`f4f6c55e`](https://github.com/NixOS/nixpkgs/commit/f4f6c55e5bde9724d0ca60683c62e7dd3f8f7f91) rocketchat-desktop: 4.7.1 -> 4.8.1
* [`d8e27204`](https://github.com/NixOS/nixpkgs/commit/d8e272041f43a915ef4bdf1449331702a1bed8e1) protoc-gen-es: 2.6.2 -> 2.6.3
* [`fe08e9fa`](https://github.com/NixOS/nixpkgs/commit/fe08e9fa5fd40700af43d90dcbed97b3d48c1000) element-desktop: fix sandbox build on darwin
* [`5ad70481`](https://github.com/NixOS/nixpkgs/commit/5ad70481a3f3b7dd6bc4db77e0372da1fac057eb) oxidized: 0.33.0 -> 0.34.3
* [`657e16aa`](https://github.com/NixOS/nixpkgs/commit/657e16aa42cd6cc054da7741051551e58239e921) oxidized: add nixosTests
* [`09ed4ac3`](https://github.com/NixOS/nixpkgs/commit/09ed4ac3e3e8f6eb2e32fed39370f8b438b7a47f) maintainers: add dmkhitaryan
* [`c5a99e9f`](https://github.com/NixOS/nixpkgs/commit/c5a99e9f052bc856f0dd452a088b0a4a9a2af515) poetry: 2.1.3 -> 2.1.4
* [`148ed30c`](https://github.com/NixOS/nixpkgs/commit/148ed30cb483afd70ba84aed7ec2e3983edd78dd) egl-wayland: 1.1.19 -> 1.1.20
* [`8b91afdb`](https://github.com/NixOS/nixpkgs/commit/8b91afdb78c564ef2b6556fe944cc2fc72ec047d) camunda-modeler: 5.37.0 -> 5.38.0
* [`21435454`](https://github.com/NixOS/nixpkgs/commit/21435454e233f1e99f5d8f9f3c3340da5559bb3f) protonmail-desktop: 1.8.1 -> 1.9.0
* [`13325121`](https://github.com/NixOS/nixpkgs/commit/13325121b5a0b70fee795347a4a457c0124a1af0) impression: 3.4.0 -> 3.5.0
* [`cdee96ee`](https://github.com/NixOS/nixpkgs/commit/cdee96eedcf47770b7a7ef5c78a8b35fe62c4791) python312Packages.numcodecs: 0.15.1 -> 0.16.0
* [`b7dac30b`](https://github.com/NixOS/nixpkgs/commit/b7dac30bd41462e4e63b8f3ccbb991d3ac7012c7) teamviewer: 15.67.4 -> 15.68.5
* [`df209dd0`](https://github.com/NixOS/nixpkgs/commit/df209dd063cf9a367074341b2d360b71135ed5e9) teamviewer: updated update-script to properly target aarch64-linux hash as well
* [`b4959fc9`](https://github.com/NixOS/nixpkgs/commit/b4959fc9b741ac2574ed993ea93becf4f608f9b2) wl-mirror: 0.18.2 -> 0.18.3
* [`663f1d8b`](https://github.com/NixOS/nixpkgs/commit/663f1d8ba2753ce68fcf7f9ef8198b4c35d13558) nixos/modules/installer/sd-card: allow to customize volume label
* [`1a4f70d6`](https://github.com/NixOS/nixpkgs/commit/1a4f70d6a6331417bb4d3bdd3af920b20c74de40) botan3: 3.8.1 -> 3.9.0
* [`3236cf2c`](https://github.com/NixOS/nixpkgs/commit/3236cf2c58ea5f2689550b0d7001ec5d25304b8f) pythonPackages.botan3: init at 3.9.0
* [`f101ee3b`](https://github.com/NixOS/nixpkgs/commit/f101ee3bf885591dc3158c20866c0b728722c649) habitat: 1.6.1243 -> 1.6.1244
* [`b8405477`](https://github.com/NixOS/nixpkgs/commit/b8405477fba2aaeef5ef050714db398830d5996d) bottom: 0.10.2 -> 0.11.0
* [`438cf52e`](https://github.com/NixOS/nixpkgs/commit/438cf52e55b397db1f1737a100e561cca9fbc991) n8n: 1.104.1 -> 1.105.3
* [`58518ee2`](https://github.com/NixOS/nixpkgs/commit/58518ee251a0ff3eb853d872da0be1689d2ae112) python3Packages.cohere: 5.15.0 -> 5.16.2
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
