### PR TITLE
niv home-manager: update d19f3213 -> c613ac14

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -65,10 +65,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d19f3213e51469321835a9188adfa20391ff9371",
-        "sha256": "1dxdx7gkwq692szyzr5j4djq7r70k2y4hvh4fpla485kbwqgsiyz",
+        "rev": "c613ac14f5600033bf84ae75c315d5ce24a0229b",
+        "sha256": "0ab1n93ik300grac5b5pinvpx3nn1dnwchxpcyamb5676grzdc5k",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/d19f3213e51469321835a9188adfa20391ff9371.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/c613ac14f5600033bf84ae75c315d5ce24a0229b.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@d19f3213...c613ac14](https://github.com/nix-community/home-manager/compare/d19f3213e51469321835a9188adfa20391ff9371...c613ac14f5600033bf84ae75c315d5ce24a0229b)

* [`461706d2`](https://github.com/nix-community/home-manager/commit/461706d28bd9e2ef2555756a17edc93e79612047) maintainers: add rrvsh
* [`27a26be5`](https://github.com/nix-community/home-manager/commit/27a26be51ff0162a8f67660239f9407dba68d7c5) gemini-cli: init module
* [`4b6dd06c`](https://github.com/nix-community/home-manager/commit/4b6dd06c6a92308c06da5e0e55f2c505237725c9) glance: restart service when settings file changes
* [`d9a57c59`](https://github.com/nix-community/home-manager/commit/d9a57c597c31f4c7523a395fe2a7ae4910e193e2) davmail: enable access to the display server ([nix-community/home-manager⁠#7671](https://togithub.com/nix-community/home-manager/issues/7671))
* [`279ca5ad`](https://github.com/nix-community/home-manager/commit/279ca5addcdcfa31ac852b3ecb39fc372684f426) PULL_REQUEST_TEMPLATE: fix commit message link formatting ([nix-community/home-manager⁠#7673](https://togithub.com/nix-community/home-manager/issues/7673))
* [`11626a43`](https://github.com/nix-community/home-manager/commit/11626a4383b458f8dc5ea3237eaa04e8ab1912f3) keepassxc: note the manifest installation conflict ([nix-community/home-manager⁠#7675](https://togithub.com/nix-community/home-manager/issues/7675))
* [`2a749f47`](https://github.com/nix-community/home-manager/commit/2a749f4790a14f7168be67cdf6e548ef1c944e10) sherlock: add systemd.enable option ([nix-community/home-manager⁠#7678](https://togithub.com/nix-community/home-manager/issues/7678))
* [`56731200`](https://github.com/nix-community/home-manager/commit/567312006a06ccb398816152eb1a5f6b65f8a8b2) tmux: make package nullable ([nix-community/home-manager⁠#7682](https://togithub.com/nix-community/home-manager/issues/7682))
* [`8b4ac149`](https://github.com/nix-community/home-manager/commit/8b4ac149687e8520187a66f05e9d4eafebf96522) claude-code: init module ([nix-community/home-manager⁠#7685](https://togithub.com/nix-community/home-manager/issues/7685))
* [`8275e5d3`](https://github.com/nix-community/home-manager/commit/8275e5d3157ff8797cf7b01f044ad5479e031b42) maintainers: add epixtm
* [`1daeb063`](https://github.com/nix-community/home-manager/commit/1daeb0638a891baf19bca3094598159b17c3cda7) protonmail-bridge: init module
* [`b9600670`](https://github.com/nix-community/home-manager/commit/b96006701369a5f576ca20ce0a8ab2ea347ab3b5) maintainers: add joker9944
* [`3dcae8af`](https://github.com/nix-community/home-manager/commit/3dcae8af51acd6f5ecc039fa23d044439cd19ae0) hyprshot: init module
* [`bc014931`](https://github.com/nix-community/home-manager/commit/bc014931784c62b566cad39b8510e76dde588d94) mypy: init module ([nix-community/home-manager⁠#7656](https://togithub.com/nix-community/home-manager/issues/7656))
* [`d2ffdedf`](https://github.com/nix-community/home-manager/commit/d2ffdedfc39c591367b1ddf22b4ce107f029dcc3) flake.lock: Update ([nix-community/home-manager⁠#7686](https://togithub.com/nix-community/home-manager/issues/7686))
* [`5ca4c81f`](https://github.com/nix-community/home-manager/commit/5ca4c81fd5a9bbe6899379ee729d6f495564ed3f) ci: bump actions/checkout from 4 to 5 ([nix-community/home-manager⁠#7690](https://togithub.com/nix-community/home-manager/issues/7690))
* [`f8af2cbe`](https://github.com/nix-community/home-manager/commit/f8af2cbe386f9b96dd9efa57ab15a09377f38f4d) issue_template: remove git blame from issue template ([nix-community/home-manager⁠#7692](https://togithub.com/nix-community/home-manager/issues/7692))
* [`0a06e46a`](https://github.com/nix-community/home-manager/commit/0a06e46a3b888123780eecd1cb81757b431dd7c4) anyrun: Added `margin` config option ([nix-community/home-manager⁠#7687](https://togithub.com/nix-community/home-manager/issues/7687))
* [`bf450a08`](https://github.com/nix-community/home-manager/commit/bf450a0844e80e6aa22652d3f3728f20cd974527) maintainers: update all-maintainers.nix ([nix-community/home-manager⁠#7693](https://togithub.com/nix-community/home-manager/issues/7693))
* [`ec369a58`](https://github.com/nix-community/home-manager/commit/ec369a58f9af13626cde7842b62e22e4dc36fc09) ssh-agent: add maintainer bmrips
* [`af03309c`](https://github.com/nix-community/home-manager/commit/af03309c122ac714da6ec497f74dbd61d875f3f2) ssh-tpm-agent: add maintainer bmrips
* [`94a238f9`](https://github.com/nix-community/home-manager/commit/94a238f9c1b84dbb299b938bee2436ce9633c3ed) ssh-agent: add option for the socket name
* [`f9ea660b`](https://github.com/nix-community/home-manager/commit/f9ea660b241e95577ff3ccc58351e6a84aa0c017) ssh-tpm-agent: fix ssh-agent proxy
* [`3a5136d8`](https://github.com/nix-community/home-manager/commit/3a5136d8ddd2e264389868232abacd4c1ef846ea) ssh-tpm-agent: on NixOS, check TPM accessibility
* [`0d1e116e`](https://github.com/nix-community/home-manager/commit/0d1e116e4f2d9d22ff57e412a57b37b8edca3710) ssh-tpm-agent: match the upstream systemd units
* [`bbfbda4a`](https://github.com/nix-community/home-manager/commit/bbfbda4ad8ee3e94cfab012249493a8375382dd0) aerospace: allow colemak on key-mapping
* [`e293a1a1`](https://github.com/nix-community/home-manager/commit/e293a1a12f448a6d92309daebd7cbda03e0f75c4) aerospace: add test
* [`c613ac14`](https://github.com/nix-community/home-manager/commit/c613ac14f5600033bf84ae75c315d5ce24a0229b) nh: allow absolute flake paths
