### PR TITLE
niv nerd-icons.el: update f3e7ba37 -> e98b1424

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -119,10 +119,10 @@
         "homepage": null,
         "owner": "rainstormstudio",
         "repo": "nerd-icons.el",
-        "rev": "f3e7ba37642455e5627968b1031faeefbcac1245",
-        "sha256": "1ar4266lmihsv81iy50g45zh2cjfbzi56h2g4s0y05px9z7pir96",
+        "rev": "e98b14248fec120cc23c5f3a5aa1128d98156c2c",
+        "sha256": "0162hhvm9cqcxxaj3g918p06kcbhzk2iyy1hckdvagsg7sb24cjn",
         "type": "tarball",
-        "url": "https://github.com/rainstormstudio/nerd-icons.el/archive/f3e7ba37642455e5627968b1031faeefbcac1245.tar.gz",
+        "url": "https://github.com/rainstormstudio/nerd-icons.el/archive/e98b14248fec120cc23c5f3a5aa1128d98156c2c.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "niv": {


### PR DESCRIPTION
## Changelog for nerd-icons.el:
Branch: main
Commits: [rainstormstudio/nerd-icons.el@f3e7ba37...e98b1424](https://github.com/rainstormstudio/nerd-icons.el/compare/f3e7ba37642455e5627968b1031faeefbcac1245...e98b14248fec120cc23c5f3a5aa1128d98156c2c)

* [`e98b1424`](https://github.com/rainstormstudio/nerd-icons.el/commit/e98b14248fec120cc23c5f3a5aa1128d98156c2c) feat: Add support for Nushell file and mode icons
