### PR TITLE
niv nixpkgs: update 1419cc5c -> 434576cb

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -143,10 +143,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1419cc5c5104185c444079d617096f788f0b2077",
-        "sha256": "1dikw270dsnnhwnk20sj3fc8bc4ypyfb52kp2891m00jbyx32pk5",
+        "rev": "434576cbd5f669de9ccbf4472743a8ba90049484",
+        "sha256": "0d50jh3gckiwmd0d4rmmxy78yvkwgad54lim62ly2b62xiqhik5r",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/1419cc5c5104185c444079d617096f788f0b2077.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/434576cbd5f669de9ccbf4472743a8ba90049484.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@1419cc5c...434576cb](https://github.com/nixos/nixpkgs/compare/1419cc5c5104185c444079d617096f788f0b2077...434576cbd5f669de9ccbf4472743a8ba90049484)

* [`c842beea`](https://github.com/NixOS/nixpkgs/commit/c842beea8f5ef7dbe141ae66a1e21dacb638952c) ebusd: change default configpath
* [`4739a32e`](https://github.com/NixOS/nixpkgs/commit/4739a32ec87577968ed73d79d203d7c69a64bf55) checksec: 2.6.0 -> 3.0.2
* [`617b982c`](https://github.com/NixOS/nixpkgs/commit/617b982c46a149754cd3d415458118cbdbfd5259) cortex-command-community-project: init at 6.2.2
* [`09d8b2e3`](https://github.com/NixOS/nixpkgs/commit/09d8b2e359201af8a91f3d10354c4d9de1fd6781) iotools: Fix werror and refactor definition
* [`1aa767cd`](https://github.com/NixOS/nixpkgs/commit/1aa767cd3571891bb951c5688a484b18d213b178) psb_status: init at 0-unstable-2024-10-10
* [`3153fa49`](https://github.com/NixOS/nixpkgs/commit/3153fa49db2ffdf78752359cc244d9c3b682c8b3) python313Packages.bunch: drop
* [`565ca567`](https://github.com/NixOS/nixpkgs/commit/565ca5671681b57ecb7c4c4c81f0fb9994c10fc5) xosd-xft: init at 1.1.0
* [`e54843b9`](https://github.com/NixOS/nixpkgs/commit/e54843b9a7bae09e40616cb4bf8910522b716cbb) kbd: 2.7.1 -> 2.8.0
* [`2f6b5382`](https://github.com/NixOS/nixpkgs/commit/2f6b53822a3b3c4008f4d7d552d2af134a810567) kbd: enable parallel building
* [`edba77eb`](https://github.com/NixOS/nixpkgs/commit/edba77eb82d747a04385a165d44c11ca60401dcc) haskellPackages.ghc: disable split sections on windows
* [`7e90fcc6`](https://github.com/NixOS/nixpkgs/commit/7e90fcc68c538ded3409d93d21292ee6e4646d49) haskellPackages.ghc: fix windres settings reference when cross-compiling for windows
* [`13bffd83`](https://github.com/NixOS/nixpkgs/commit/13bffd835b74aa359e849c2f25702168710f9995) haskellPackages: fix GHC build on linux->ucrt cross
* [`2a7033b3`](https://github.com/NixOS/nixpkgs/commit/2a7033b350732332642688d9483386dd328c354c) haskellPackages: add ucrt64 to release-haskell jobset on ghc 9.12
* [`f7cb50a2`](https://github.com/NixOS/nixpkgs/commit/f7cb50a2fb56f6d328ecf3045e9c7fae3baaf696) alsa-ucm-conf: 1.2.12 -> 1.2.14
* [`eb11defa`](https://github.com/NixOS/nixpkgs/commit/eb11defad7ffc4724a3ac4308cc2c970aaa9a397) alsa-ucm-conf: Build using stdenvNoCC
* [`b5825dab`](https://github.com/NixOS/nixpkgs/commit/b5825dab3e5e33de4a8261e94bcffa7f552fe635) libdrm: 2.4.124 -> 2.4.125
* [`b034b4da`](https://github.com/NixOS/nixpkgs/commit/b034b4da127c26114b76d64481fd4a8bc280cf7d) maturin: 1.8.6 -> 1.8.7
* [`a7beb46a`](https://github.com/NixOS/nixpkgs/commit/a7beb46aa788193bc07f4de2b3a77de4ac8d30de) haskellPackages: fix GHC 9.12 on android
* [`3799b9e0`](https://github.com/NixOS/nixpkgs/commit/3799b9e0615077df213e2e5a6ddebd950fdcea81) haskellPackages: fix aarch64-android-prebuilt release-haskell jobset
* [`4fe25a04`](https://github.com/NixOS/nixpkgs/commit/4fe25a04939a00a83bb75bc3abc7063a5295edf9) Add note about leaking into RPATH
* [`e2eae470`](https://github.com/NixOS/nixpkgs/commit/e2eae470a8ee8fc6983f958dc337e686db75544c) rav1e: 0.8.0 -> 0.8.1
* [`db98b9a0`](https://github.com/NixOS/nixpkgs/commit/db98b9a00174c52eab658dcbc4e3455f184d40d6) aab: init at 1.0.0-dev.5
* [`bd0b9dd2`](https://github.com/NixOS/nixpkgs/commit/bd0b9dd21bde2b2c61650866df62322ee54c4c28) ankiAddons.review-heatmap: init at 1.0.1
* [`b5daea74`](https://github.com/NixOS/nixpkgs/commit/b5daea748fca99f357152b727cfe9d36ffa842bb) opencv4: protobuf_21 -> protobuf
* [`5a388a9a`](https://github.com/NixOS/nixpkgs/commit/5a388a9a097dc339ff24ccbcbaf13e130b9e72c0) freeorion: 0.5.0.1-unstable-2024-07-28 -> 0.5.1.1
* [`b08aaad1`](https://github.com/NixOS/nixpkgs/commit/b08aaad1c4b3326e071ab50fd0c48cb8a4b06e8e) shadow: 4.17.4 -> 4.18.0
* [`6e78716a`](https://github.com/NixOS/nixpkgs/commit/6e78716a8c4885dbc73bdff7826d40f6f47142df) souffle: 2.4.1 -> 2.5
* [`bfbd17b6`](https://github.com/NixOS/nixpkgs/commit/bfbd17b6e1b5f8ef007b8c44fa824f450a657650) kbd: set strictDeps, and put bash explicitly in buildInputs for wrapping
* [`75c8f84d`](https://github.com/NixOS/nixpkgs/commit/75c8f84d1f6aeddd25601e820cb8d6ce115d3409) kbd: use --replace-fail in unicode_{start,stop} scripts
* [`298d39ed`](https://github.com/NixOS/nixpkgs/commit/298d39ede3dd9abfbc3b58c6e39758ce0f83e57a) kbd: split man & scripts outputs
* [`98672296`](https://github.com/NixOS/nixpkgs/commit/98672296968c1852754a6bb9993242420613e02c) nixos/sssd: add upstream directives in sssd.service
* [`4e40f1c7`](https://github.com/NixOS/nixpkgs/commit/4e40f1c79e5a9939c170a666ce43b695dee0460a) nixos/sssd: add upstream hardening options in sssd-kcm.service
* [`1ab9d08c`](https://github.com/NixOS/nixpkgs/commit/1ab9d08c34689fef8684acfa5d54f589f20942bd) maintainers: add niksingh710
* [`535d6d8b`](https://github.com/NixOS/nixpkgs/commit/535d6d8b69c411806d944d45d5c665f2376340c6) glslang: 15.3.0 -> 15.4.0
* [`38f28e3d`](https://github.com/NixOS/nixpkgs/commit/38f28e3d5033e1c1d2db7666752f38238959c4d9) nettle: 3.10.1 -> 3.10.2
* [`d1964e17`](https://github.com/NixOS/nixpkgs/commit/d1964e1780138fb4dc2032bf7010a271b7bb32a9) gstreamer: 1.26.0 -> 1.26.3
* [`8ade39d2`](https://github.com/NixOS/nixpkgs/commit/8ade39d224483dca15388378ea1d7c1f80f4d301) sunsama: init at 3.1.1
* [`e8b66b8e`](https://github.com/NixOS/nixpkgs/commit/e8b66b8e954fce2ba3b2040c51bae26fec696c0e) remove unnecessary definition
* [`4bca195d`](https://github.com/NixOS/nixpkgs/commit/4bca195d0d330c1f869459d42071d6ed68c33f17) itk: 5.4.3 -> 5.4.4
* [`4dd87a4c`](https://github.com/NixOS/nixpkgs/commit/4dd87a4c82517f9aab4304d5a8449a0523f4beac) re2c: 4.2 -> 4.3
* [`5b19ed06`](https://github.com/NixOS/nixpkgs/commit/5b19ed065f9c28ba530ae5a34479fae29292b86c) netpbm: 11.10.5 -> 11.11.0
* [`3eb8b879`](https://github.com/NixOS/nixpkgs/commit/3eb8b879ace75d30c7bd5f4a73d98d2a004746c9) opencv: use c++ 17 to fix protobuf support
* [`21e2356b`](https://github.com/NixOS/nixpkgs/commit/21e2356bf48deb7004ab3ce1c79ae66d5d5d4b93) python312Packages.find-libpython: 0.4.0 -> 0.4.1
* [`a28e5146`](https://github.com/NixOS/nixpkgs/commit/a28e5146b95c06b7b21ddbc0444911912659c887) haskellPackages.yaml: build executables
* [`2be51f4b`](https://github.com/NixOS/nixpkgs/commit/2be51f4b68a601ae31ceb72a14540b40f07e0a53) shaderc: 2025.2 -> 2025.3
* [`dde790c1`](https://github.com/NixOS/nixpkgs/commit/dde790c12c7a590c4eb11f4f2d8f6b363d133f97) mbedtls: 3.6.3 -> 3.6.4
* [`27af57e5`](https://github.com/NixOS/nixpkgs/commit/27af57e54af18b21790b113e57462fdf405d0147) python313Packages.scipy: use external system libraries as dependencies
* [`b4d71aa5`](https://github.com/NixOS/nixpkgs/commit/b4d71aa5a6964d3e306de2b026e31e73f28be712) squashfsTools: update hash to latest changes on 4.6.1 tag
* [`5cfe11fa`](https://github.com/NixOS/nixpkgs/commit/5cfe11fa97c360f6bf4377c663dc6455845e73f6) haskell-modules/configuration-common: explicitly list amazonka packages
* [`49c98157`](https://github.com/NixOS/nixpkgs/commit/49c98157764ad8543702e0ea80d39751a8db74f9) refactor
* [`2bf66893`](https://github.com/NixOS/nixpkgs/commit/2bf668936b19fdd1986d837c787b00eca790e210) align with freedesktop.org spec
* [`802afd0c`](https://github.com/NixOS/nixpkgs/commit/802afd0c794d8a59eb2f5665f07f06aaf4cd04ae) gupnp_1_6: 1.6.8 -> 1.6.9
* [`44b4054d`](https://github.com/NixOS/nixpkgs/commit/44b4054d6f18a846f93719c10e60aea38070b700) re2: 2024-07-02 -> 2025-06-26b
* [`79abdb30`](https://github.com/NixOS/nixpkgs/commit/79abdb30dd72c60a93adb1e82b7a38970c90ddc0) python3Packages.bandit: 1.8.5 -> 1.8.6
* [`b57280ab`](https://github.com/NixOS/nixpkgs/commit/b57280ab08f2639b202315f89ce581052415fdbc) pkg-config: Fix build with gcc-15
* [`b3daf8c3`](https://github.com/NixOS/nixpkgs/commit/b3daf8c3a5d916b5ee2c94cfefe57ab7ddfe750b) nodejs: split destCPU into stdenv.$platform.node
* [`8199f6b5`](https://github.com/NixOS/nixpkgs/commit/8199f6b551b5a9dfda627ee15887c3a25bd40fed) treewide: replace node platform mapping with stdenv.hostPlatform.node.{arch,platform}
* [`faeab3c8`](https://github.com/NixOS/nixpkgs/commit/faeab3c841ec25e2453297038ffe137868f73c10) buildNpmPackage: push npm_config_* options into npmHooks.npmConfigHook
* [`bea64a7d`](https://github.com/NixOS/nixpkgs/commit/bea64a7d3fbf566d5a41777ab6ec741539b3777a) pnpm.configHook: set npm_config_{arch,platform}
* [`378a7699`](https://github.com/NixOS/nixpkgs/commit/378a7699696f2931f01ba88c41cb74e00cfe69df) haskellPackages.cabal2nix-unstable: move overrides into config*-nix
* [`dca180b5`](https://github.com/NixOS/nixpkgs/commit/dca180b572642b650fb0fe9c84f7017d0f4f9235) haskellPackages.hpack_0_38_1: disable tests accessing network
* [`1c393bb8`](https://github.com/NixOS/nixpkgs/commit/1c393bb828b5616a0533423145174379106dee18) haskellPackages.cabal2nix-unstable: build against Cabal 3.14
* [`9acee8ea`](https://github.com/NixOS/nixpkgs/commit/9acee8ea5cfa40516576b7f909787c4b0ccfb072) kanri: init at 0.8.1
* [`f485a9f5`](https://github.com/NixOS/nixpkgs/commit/f485a9f52baaa755a68da75d61d6c46011c313d3) gatus: 5.17.0 -> 5.19.0
* [`4390d1af`](https://github.com/NixOS/nixpkgs/commit/4390d1af4b62b9995dde60b1064b31146fe43971) libopenmpt: 0.8.0 -> 0.8.1
* [`b892dfe5`](https://github.com/NixOS/nixpkgs/commit/b892dfe549e2494a1d177d48d33030f4b1b77041) systemd: 257.6 -> 257.7
* [`a9d6d3b4`](https://github.com/NixOS/nixpkgs/commit/a9d6d3b4ccb33628aa3d0cbd46729ff0fd0a2efc) swayimg: 4.3 -> 4.5
* [`2b113e52`](https://github.com/NixOS/nixpkgs/commit/2b113e525588837d46654480534636ecc29359c3) choose-gui: add maintainer niksingh710
* [`49efc394`](https://github.com/NixOS/nixpkgs/commit/49efc394218f3ac456ae0275cefcfad088dbf613) choose-gui: 1.3.1 -> 1.5.0
* [`f91476f9`](https://github.com/NixOS/nixpkgs/commit/f91476f97a4ced583c08dae8ede876efbe09629a) cpm-cmake: add nix-update-script
* [`2496c60f`](https://github.com/NixOS/nixpkgs/commit/2496c60f41c0be76a50e5f4c960b8f5766f76813) gpredict: add nix-update-script
* [`d363cd33`](https://github.com/NixOS/nixpkgs/commit/d363cd333936043cc91b90e15e2a5dcc7ecb830a) intel-undervolt: add nix-update-script
* [`733a35ee`](https://github.com/NixOS/nixpkgs/commit/733a35ee4d5161184f1f0ae2191edfa1a77fa7b6) qgroundcontrol: add nix-update-script
* [`1158f20f`](https://github.com/NixOS/nixpkgs/commit/1158f20f1563e8a8e5524d6f910d311956b006a3) maintainers/haskell/update*: print version diff when not committing
* [`f834f1da`](https://github.com/NixOS/nixpkgs/commit/f834f1dacc34bf82f6aa9bfb67b5bfdce0ee534b) maintainers/scripts/haskell: briefer commit message bodies
* [`5e758ae5`](https://github.com/NixOS/nixpkgs/commit/5e758ae57347a54f9d0217589f0354d94f048978) maintainers/haskell/regen-h-packages.sh: let user edit commit msg
* [`34c51b70`](https://github.com/NixOS/nixpkgs/commit/34c51b70fbe2fa69e368268d04413feb6d9cc996) maintainers/scripts/haskell: unify pkg set update into single commit
* [`74793922`](https://github.com/NixOS/nixpkgs/commit/7479392276eede7c7cb89abf1693e8ef9ae5aebd) haskellPackages: stackage LTS 23.24 -> LTS 23.27
* [`4b59ccb4`](https://github.com/NixOS/nixpkgs/commit/4b59ccb4263a3d0be7312938b682f3239b339e9d) haskellPackages.gpu-vulkan-middle: drop obsolete override
* [`fb745cd5`](https://github.com/NixOS/nixpkgs/commit/fb745cd5c470015d6646839d0660ef37b441db43) haskellPackages.persistent-test: drop obsolete overrides
* [`bf811701`](https://github.com/NixOS/nixpkgs/commit/bf811701c8763b650e6b46ee4df2f7638bab626d) haskellPackages.shakespeare: use latest version from Stackage again
* [`543e922b`](https://github.com/NixOS/nixpkgs/commit/543e922b41da1cdf471d74ebd3a703db2405fff4) haskellPackages.shakespeare: disable broken test suite
* [`22e64afc`](https://github.com/NixOS/nixpkgs/commit/22e64afc04fb24324e0fcafddcea606b16963cab) haskellPackages.llvm-ffi: don't unnecessarily pass null
* [`63c4be08`](https://github.com/NixOS/nixpkgs/commit/63c4be08eb289f0d1c901dc8abc22bf417176bdf) djvulibre: 3.5.28 -> 3.5.29
* [`24648489`](https://github.com/NixOS/nixpkgs/commit/24648489c3d9932d452a31c5f6ee6a23098c852f) haskell.packages.ghc912.doctest: 0.24.0 -> 0.24.2
* [`a39fb3bf`](https://github.com/NixOS/nixpkgs/commit/a39fb3bf7d6a73c6d3792facee3d11c0dbe877db) haskellPackages.llvm-ffi: pin to 20.*
* [`f7080c06`](https://github.com/NixOS/nixpkgs/commit/f7080c060690365e55364dc5320099bed67f69c8) systemd: add sysupdated
* [`cbb2734d`](https://github.com/NixOS/nixpkgs/commit/cbb2734d993b3acc9f21792f06b4b8393e96ebbb) systemd: add withSysupdate to passthru
* [`45a71d67`](https://github.com/NixOS/nixpkgs/commit/45a71d67a70c448be7dc86c6a7d7dbacfeae8f56) nixos/sysupdate: add assertion for systemd built with sysupdate support
* [`e84623d3`](https://github.com/NixOS/nixpkgs/commit/e84623d33450a46eebc2b0ccdafef9d1e7f443cf) haskellPackages.servant-client: drop released patch
* [`384fda8e`](https://github.com/NixOS/nixpkgs/commit/384fda8e3475e2976715c6fc0b6057c4ae47446b) kubernix: 0.2.0 -> 0.2.0-unstable-2021-11-16
* [`4e0dda4d`](https://github.com/NixOS/nixpkgs/commit/4e0dda4decefe4259cc2dbdc8fdc02acf4e1d62b) haskellPackages.servant-routes: drop released patch
* [`f256da20`](https://github.com/NixOS/nixpkgs/commit/f256da2029d7bd20134573dc38013e735c616a09) git-annex: update sha256 for 10.20250630
* [`c9858489`](https://github.com/NixOS/nixpkgs/commit/c9858489fca0f4c4c6b71f4a4853f53748f2c388) gssdp_1_6: 1.6.3 -> 1.6.4
* [`fa88eb41`](https://github.com/NixOS/nixpkgs/commit/fa88eb41aa069e3553fcc4add99b37357fe3da16) ninja: 1.12.1 -> 1.13.1
* [`4ccdc6ca`](https://github.com/NixOS/nixpkgs/commit/4ccdc6ca47c6564e3563ceeb9b1b9ae6243b77da) iproute2: add python3 for routel script
* [`6b3a4466`](https://github.com/NixOS/nixpkgs/commit/6b3a446632207cec5d0de799cdc605903b6c601d) lisp-modules: import quicklisp dist 2025-06-22
* [`7992efed`](https://github.com/NixOS/nixpkgs/commit/7992efedf07bcb443c2bb885d992066475064772) lisp-modules: add nixfmt step
* [`e04e1a4c`](https://github.com/NixOS/nixpkgs/commit/e04e1a4ce93d49ef894b98ef057f55fd5aaedc83) wpsoffice-cn: Change license to licenses.unfree due to potential copyright infrigement issues
* [`f1a96f44`](https://github.com/NixOS/nixpkgs/commit/f1a96f44914f43f210759a5d18cb66d0d36f7f24) haskellPackages.Agda: generate interface files for the primitive modules
* [`67a1389d`](https://github.com/NixOS/nixpkgs/commit/67a1389d948d6b853e6beeacf3cf7b0798803224) agdaPackages.standard-library: 2.2 -> 2.2-unstable-2025-07-03
* [`7bd1a191`](https://github.com/NixOS/nixpkgs/commit/7bd1a191f0d0df7ac55bcbf87cae1cbfc9ec9762) agdaPackages._1lab: unstable-2024-08-05 -> unstable-2025-07-01
* [`5a6da0e1`](https://github.com/NixOS/nixpkgs/commit/5a6da0e102b135824904c7227902ccbab572e1a2) agdaPackages.cubical-mini: nightly-20241214 -> 0.5-unstable-2025-06-13
* [`5be62c29`](https://github.com/NixOS/nixpkgs/commit/5be62c29be1d8b17629fafcdc5a87a0768e006b6) agdaPackages.generics: fix build
* [`cc708024`](https://github.com/NixOS/nixpkgs/commit/cc708024f66debc2d7562388173c8f4777bd2e44) stack: use hpack == 0.38.1 to match upstream
* [`902e69b4`](https://github.com/NixOS/nixpkgs/commit/902e69b45877e1f92f6badb03195124948f67dc1) python3Packages.certifi: 2025.06.15 -> 2025.07.14
* [`59ea7fd2`](https://github.com/NixOS/nixpkgs/commit/59ea7fd277bcceff7e8cb36fd8aa5dbfb3f47d64) haskell.compiler.*: enable NUMA in rts if supported
* [`1e59d888`](https://github.com/NixOS/nixpkgs/commit/1e59d888102d06d2af525d1170b0bfef8ed8e185) maintainers: add minegameYTB
* [`5b0ee73c`](https://github.com/NixOS/nixpkgs/commit/5b0ee73c31b024b285e06a9e02e13104837c1dbc) deezer-enhanced: init at 1.3.0
* [`7b981efa`](https://github.com/NixOS/nixpkgs/commit/7b981efa880d3e78beb56df4caaf2240ffee7461) nixos/sysupdate: add support for sysupdated/updatectl
* [`996cc691`](https://github.com/NixOS/nixpkgs/commit/996cc69171d427cf02fe8768ca36454586fd29a8) nixos/sysupdate: add jmbaur as maintainer
* [`61d37d77`](https://github.com/NixOS/nixpkgs/commit/61d37d773358ee34d5fffd99e38eb566981effbd) nixosTests.systemd-sysupdate: use updatectl as frontend for updates
* [`369d01f4`](https://github.com/NixOS/nixpkgs/commit/369d01f47aa6991ca8ee1da7f112b3ce43bfddaf) libyuv: Apply patch to fix ARGBToRGB565DitherRow_C on big-endian
* [`963502fb`](https://github.com/NixOS/nixpkgs/commit/963502fbdefdfa5f289a780d4d7ff0df2a1cb5c4) nodejs_22: 22.17.0 -> 22.17.1
* [`254068dc`](https://github.com/NixOS/nixpkgs/commit/254068dc96ac20ad9f114e744516f164e73ff346) lilv: 0.24.24 -> 0.24.26
* [`6c2ccf3f`](https://github.com/NixOS/nixpkgs/commit/6c2ccf3f6e357b9dc643a9b13391adff62e31c92) make-iso9660-image: drop references to build closure
* [`f03674d8`](https://github.com/NixOS/nixpkgs/commit/f03674d8680c1eb69074d8601a477e7dd51e517f) make-squashfs: drop references to build closure
* [`3bc4d777`](https://github.com/NixOS/nixpkgs/commit/3bc4d7773c37eb8c3cf29e6ec172b69f8d414d25) libadwaita: 1.7.4 -> 1.7.5
* [`acfcf0f4`](https://github.com/NixOS/nixpkgs/commit/acfcf0f40b2f342b3dc28100194579bc05aeb44b) make-system-tarball: use `__structuredAttrs`
* [`575a9f0e`](https://github.com/NixOS/nixpkgs/commit/575a9f0e0bcb38805683668d642a9d3b313be695) make-system-tarball: drop references to build closure
* [`1288f57e`](https://github.com/NixOS/nixpkgs/commit/1288f57e557951419770b5691fc613f8e3266c73) agdaPackages: switch to `--build-library`
* [`850180f1`](https://github.com/NixOS/nixpkgs/commit/850180f1a01c5c15e590f12f9c6ca1d0cf4767f0) unbound-full: 1.23.0 -> 1.23.1
* [`5bc07efc`](https://github.com/NixOS/nixpkgs/commit/5bc07efc6329d06d397aeed713cf6763157dc2db) icingaweb2: 2.12.4 -> 2.12.5
* [`2eae0245`](https://github.com/NixOS/nixpkgs/commit/2eae0245867039a6767a224381a8def593ac739e) game-music-emu: refactor meta section
* [`21629b80`](https://github.com/NixOS/nixpkgs/commit/21629b8005c45ce0dbf854f23967429b75bae1b4) glslang: 15.3.0 -> 15.4.0
* [`39a7c8f2`](https://github.com/NixOS/nixpkgs/commit/39a7c8f2e1b6655e2772b14c3cdccbbd47055b6e) vulkan-headers: 1.4.313.0 -> 1.4.321.0
* [`f6ae946b`](https://github.com/NixOS/nixpkgs/commit/f6ae946baecbd794a24fe0fc0ab7702bbdde7140) vulkan-loader: 1.4.313.0 -> 1.4.321.0
* [`481a484b`](https://github.com/NixOS/nixpkgs/commit/481a484ba80d2a711e96bca418eae10986430f5c) vulkan-validation-layers: 1.4.313.0 -> 1.4.321.0
* [`dc07ed22`](https://github.com/NixOS/nixpkgs/commit/dc07ed2230b70ad24e3530d16c5482c33ffc5ce9) vulkan-tools: 1.4.313.0 -> 1.4.321.0
* [`079be429`](https://github.com/NixOS/nixpkgs/commit/079be4291b2bde77818235c90c07186659f1a608) vulkan-tools-lunarg: 1.4.313.0 -> 1.4.321.0
* [`fd49cf8b`](https://github.com/NixOS/nixpkgs/commit/fd49cf8b75edba7d082493afd125632fd971ac05) vulkan-extension-layer: 1.4.313.0 -> 1.4.321.0
* [`e5e3ecdd`](https://github.com/NixOS/nixpkgs/commit/e5e3ecdd51bb843af63a18e4ed9b4e345e1a3f91) vulkan-utility-libraries: 1.4.313.0 -> 1.4.321.0
* [`baf9d1ca`](https://github.com/NixOS/nixpkgs/commit/baf9d1ca3552de401b81d3ed7f73f7ac0146be97) vulkan-volk: 1.4.313.0 -> 1.4.321.0
* [`93a4ff75`](https://github.com/NixOS/nixpkgs/commit/93a4ff754dc0e2bd21c9558564c60cf596337d5e) spirv-headers: 1.4.313.0 -> 1.4.321.0
* [`1837a31e`](https://github.com/NixOS/nixpkgs/commit/1837a31efcd331c1b79e20b1058426f8122fda56) spirv-cross: 1.4.313.0 -> 1.4.321.0
* [`c52e38e6`](https://github.com/NixOS/nixpkgs/commit/c52e38e629f8b718a964ef63ff1e8b0b552fae0a) spirv-tools: 1.4.313.0 -> 1.4.321.0
* [`ba80420b`](https://github.com/NixOS/nixpkgs/commit/ba80420bcc6731f3228e8d763c514a5f33644836) libxml2: 2.14.4-unstable-2025-06-20 -> 2.14.5
* [`51ec23af`](https://github.com/NixOS/nixpkgs/commit/51ec23af3a769a676dd36269f6e812875902d490) Revert "re2: 2024-07-02 -> 2025-06-26b"
* [`0e19aa4a`](https://github.com/NixOS/nixpkgs/commit/0e19aa4ab51d576d0c91668d8e29b79ce8fe0f2c) sbcl.pkgs.reblocks: fix build after bump
* [`e0226989`](https://github.com/NixOS/nixpkgs/commit/e02269897a9b08b62765f91679104e6125fc101d) haskell.compiler: (make-native-bignum) group unconditional patches
* [`a9be46bf`](https://github.com/NixOS/nixpkgs/commit/a9be46bf73a9878b039254f5980bbe9265715e1a) haskell.compiler: (make-native-bignum) sort cond patches by version
* [`98d795a2`](https://github.com/NixOS/nixpkgs/commit/98d795a2725894ea0fdaf799665c9dd3b2113d92) haskell.compiler: (make built) add libnuma paths to pkg db
* [`e94e63f0`](https://github.com/NixOS/nixpkgs/commit/e94e63f060fe0790a465c9afb2ad3c57629bf626) tests.srcOnly: use equivalent input attrs instead of drvAttrs
* [`436339fa`](https://github.com/NixOS/nixpkgs/commit/436339fa2e85e764f0b8ca9daf587f017f03e0a2) srcOnly: float mkDerivation args that need to be overridden into let
* [`8dfbfd4d`](https://github.com/NixOS/nixpkgs/commit/8dfbfd4d8c9895c97e4c5af89d7478db4ee98d74) srcOnly: move dontUnpack warning into dontUnpack binding
* [`f89a54c9`](https://github.com/NixOS/nixpkgs/commit/f89a54c9ebc1ae8b9901080fd421b9e3ed050920) srcOnly: differentiate between computed and user passed drvAttrs
* [`fe592efe`](https://github.com/NixOS/nixpkgs/commit/fe592efe24e32cd5a8077e2cae810ba8b497b0c4) tests.srcOnly: __impureHostDeps issue is fixed using .overrideAttrs
* [`250924fd`](https://github.com/NixOS/nixpkgs/commit/250924fd7dc84e9fd5d66675bcf1e1a1ca5abeb0) maintainers/update-hackage.sh: don't print diff if no changes
* [`0545642e`](https://github.com/NixOS/nixpkgs/commit/0545642ebb66294593da3048abe7f23a20129cff) maintainers/update-{st,h}ackage.sh: drop support for --do-commit
* [`32d8dd23`](https://github.com/NixOS/nixpkgs/commit/32d8dd2326dd345178b537434ac55e7847047766) Revert "git-annex: apply workaround for test failure with git 2.50"
* [`b6c607e4`](https://github.com/NixOS/nixpkgs/commit/b6c607e4b143040a65c2ab9fa435149eb0e5d13b) automake: 1.16 -> 1.18.1
* [`23f824cc`](https://github.com/NixOS/nixpkgs/commit/23f824ccf6bfb7090f7bd8ead00d041612a709fa) alsa-ucm-conf: add mvs as maintainer
* [`9d00c816`](https://github.com/NixOS/nixpkgs/commit/9d00c816c092b3c32206d375c9ff5fbe7e7c3d7f) sbcl.pkgs.april: fix build after bump
* [`037387d4`](https://github.com/NixOS/nixpkgs/commit/037387d4ba374f2c03cf26590ff143ba459e7cfc) libxml2: get rid of generic arguments
* [`8dc10e9c`](https://github.com/NixOS/nixpkgs/commit/8dc10e9c4fa72e74b8c2d0af5aa8c54ccd921dec) libxml2: remove `with lib;`
* [`2fc39899`](https://github.com/NixOS/nixpkgs/commit/2fc398994878e1de9e4fb02e0a19011503f3876d) libxml2: remove python2 support, don't check for python3
* [`e67ade88`](https://github.com/NixOS/nixpkgs/commit/e67ade88a3b65e00b61e9cabd7f29cf69c1f8f8d) libxml2: rename default.nix to common.nix
* [`febeabf3`](https://github.com/NixOS/nixpkgs/commit/febeabf314cce1f99612825fe14858a4bc682cbc) libxml2: prepare for multiple versions
* [`4c5c6be1`](https://github.com/NixOS/nixpkgs/commit/4c5c6be10f4c5ecfb52e6b1d27b6c2f1f273f86f) libxml2_13: init
* [`dbdc8ca8`](https://github.com/NixOS/nixpkgs/commit/dbdc8ca8f473fde09b3b908ce000a4b055aca228) libxml2_13: freeze update script
* [`348be18a`](https://github.com/NixOS/nixpkgs/commit/348be18ac4b40caa531048d977df7d54b4ea9d14) libxml2_13: add patch for CVE-2025-6021
* [`5b787364`](https://github.com/NixOS/nixpkgs/commit/5b7873647225dbb427157933eb8e04485fb5144c) libxml2_13: add patch for CVE-2025-49794 and CVE-2025-49796
* [`5d3c1810`](https://github.com/NixOS/nixpkgs/commit/5d3c18107abdac1354a12ec09a8e862c9c631553) libxml2_13: add patch for CVE-2025-49795
* [`2da008e2`](https://github.com/NixOS/nixpkgs/commit/2da008e2ee4eda08380f6341db237ec6fef950ad) libxml2_13: add patch for CVE-2025-6170
* [`0d3a5cac`](https://github.com/NixOS/nixpkgs/commit/0d3a5cac50cb67e0e46c09f701453f503c59e372) vim: 9.1.1475 -> 9.1.1566
* [`ff1f353e`](https://github.com/NixOS/nixpkgs/commit/ff1f353e6772a42e63ae4e8bd36a4a8c337a44c1) perlPackages.AuthenSASL: apply patch for CVE-2025-40918
* [`cc8a3137`](https://github.com/NixOS/nixpkgs/commit/cc8a3137be01639bc80a59acf6410e97edc303a5) unciv: 4.16.5 -> 4.17.6
* [`b14809fc`](https://github.com/NixOS/nixpkgs/commit/b14809fc77a729652adf717cec5a3fc527378be3) maturin: 1.8.6 -> 1.9.1
* [`1010b260`](https://github.com/NixOS/nixpkgs/commit/1010b2606b6bda1b4e987886c88e6e94759d983c) e2fsprogs: 1.47.2 -> 1.47.3
* [`1a3c01ca`](https://github.com/NixOS/nixpkgs/commit/1a3c01ca6f16717892291d30d332f28b0245a236) re2: 2024-07-02 -> 2025-07-17
* [`d0190b00`](https://github.com/NixOS/nixpkgs/commit/d0190b008bff158eab9f2dc24622c376eb2ba9c5) python3Packages.hatch-vcs: use gitMinimal
* [`bd9f431c`](https://github.com/NixOS/nixpkgs/commit/bd9f431ce084e1eb616c02193a1e2754bfb94c58) python3Packages.poetry-core: use gitMinimal
* [`9c926ae5`](https://github.com/NixOS/nixpkgs/commit/9c926ae509ef073304ec4b5632a52a327d9c983f) python3Packages.meson-python: use gitMinimal
* [`a4d61af9`](https://github.com/NixOS/nixpkgs/commit/a4d61af95028f0d234d306b7672c0a703673bd40) systemd: Use smaller bootctl patch.
* [`362d606b`](https://github.com/NixOS/nixpkgs/commit/362d606bc22be9c0f08c144e2b973ab44b432eeb) python3Packages.pytest-benchmark: use gitMinimal
* [`1adbdf60`](https://github.com/NixOS/nixpkgs/commit/1adbdf6004ee13620d31f25b0d2f8a8483a6746a) python3Packages.versioningit: use gitMinimal
* [`2d5de228`](https://github.com/NixOS/nixpkgs/commit/2d5de22889ce6ba1febcd1681251d04e0adaa983) cargo-c: add update script
* [`26e7dace`](https://github.com/NixOS/nixpkgs/commit/26e7dace03c30ef63ce8674c79aa34196abad758) cargo-c: 0.10.2 -> 0.10.14
* [`3a355010`](https://github.com/NixOS/nixpkgs/commit/3a355010e6f0b5874149306f48139fd11d4b0dd1) python3Packages.twisted: use gitMinimal
* [`203e523a`](https://github.com/NixOS/nixpkgs/commit/203e523ab70844ea230fd7505511c7e5924c5a9b) python313Packages.dbus-deviation: remove unused setuptools_git dep, modernize
* [`351b2b10`](https://github.com/NixOS/nixpkgs/commit/351b2b10c2ead903c71837b48990cfe880da2232) bash: Fix build with gcc-15
* [`2a9a83e4`](https://github.com/NixOS/nixpkgs/commit/2a9a83e489e867280f65ae00fc61dc14be1de883) glibc: Fix build with gcc-15
* [`88686e2f`](https://github.com/NixOS/nixpkgs/commit/88686e2fe3a9657520a7bed0e0eb53e736345485) gmp: Fix build with gcc-15
* [`88b848ca`](https://github.com/NixOS/nixpkgs/commit/88b848ca71a8561be457b3e83ace14e2cc7a6501) unzip: Fix build with gcc-15
* [`7b960696`](https://github.com/NixOS/nixpkgs/commit/7b9606965db1764d6b473b64670535ccdbc75592) ncurses: fix build with gcc-15
* [`ce3414c7`](https://github.com/NixOS/nixpkgs/commit/ce3414c7a60b474db0e6cb3eba8773e89337814e) qt6.qtwebengine: drop unused git dependency
* [`b8ea17db`](https://github.com/NixOS/nixpkgs/commit/b8ea17dbd3c12fbe1110f89a162e84796436ec0f) tcl,tk: 8.6.15 -> 8.6.16
* [`8b47e326`](https://github.com/NixOS/nixpkgs/commit/8b47e3268a220bbc12583337d4de7f57fe5ae450) qt5.qtwebengine: drop unused git dependency
* [`8ae532aa`](https://github.com/NixOS/nixpkgs/commit/8ae532aabfef284af0dbe56e37d795593357c34c) triton-llvm: remove unused git dependency
* [`12f8e728`](https://github.com/NixOS/nixpkgs/commit/12f8e728368eaf8d28528188ff5dfb55f18b7a48) librenms: 25.6.0 -> 25.7.0
* [`8acee0c6`](https://github.com/NixOS/nixpkgs/commit/8acee0c6a9bb1f24a28123cc0543ccf06539c53b) Revert "hdr10plus: decouple the src from hdr10plus_tool"
* [`2cdbaee7`](https://github.com/NixOS/nixpkgs/commit/2cdbaee7c110f1fe95dbcbbff098e872112f22ad) hdr10plus: add comments back
* [`b079060d`](https://github.com/NixOS/nixpkgs/commit/b079060dd11e6481ed16e49142379fc7578a7022) apache-answer: 1.4.1 -> 1.5.1
* [`e6b8ad33`](https://github.com/NixOS/nixpkgs/commit/e6b8ad33ff67c8dfd87d64876babd0c6db2e05f4) util-linux: 2.41 -> 2.41.1
* [`5cc59d72`](https://github.com/NixOS/nixpkgs/commit/5cc59d724d5c76cea8b8193d12e2d4d9eb79e414) libopenmpt: 0.8.1 -> 0.8.2
* [`27a63981`](https://github.com/NixOS/nixpkgs/commit/27a63981b7d545358c6a543f994e3163a49e2d3b) bash: Drop gcc-15 compatibility workaround for bash-5.2
* [`07bce58d`](https://github.com/NixOS/nixpkgs/commit/07bce58d9c4c7a3be573688ff62f750b24fceacd) cc-wrapper: Workaround gnuabielfv{1,2} support deficiency on Clang
* [`b3aa2205`](https://github.com/NixOS/nixpkgs/commit/b3aa22052fdebcde862a38808411b27b04458c64) maintainers: add stupidcomputer
* [`8f1b5b61`](https://github.com/NixOS/nixpkgs/commit/8f1b5b616633147e527d150ec3db6efd95ee2e39) lua51Packages.luarocks_bootstrap: 3.12.0 -> 3.12.2
* [`45f72c00`](https://github.com/NixOS/nixpkgs/commit/45f72c00e2e921e37c24f7840bccee98dee68423) karakeep: 0.25.0 -> 0.26.0
* [`f0888cd5`](https://github.com/NixOS/nixpkgs/commit/f0888cd57ed457e48c903ff069ac3a76aa48843f) python3Packages.pathvalidate: 3.2.3 -> 3.3.1
* [`67787739`](https://github.com/NixOS/nixpkgs/commit/6778773934c4e42cfb3027bb72e36275ad2faaaf) paperless-ngx: unpin pathvalidate
* [`d276fd09`](https://github.com/NixOS/nixpkgs/commit/d276fd09d8959486cb3c2bd2b23d28f13c1c63b9) python313Packages.osxphotos: add missing tzdata dependency, mark broken due to in tree missing utitools
* [`bd554819`](https://github.com/NixOS/nixpkgs/commit/bd554819709ea70f397965aec1696fb38e1c3e7b) cacert: 3.113.1 -> 3.114
* [`9895bd60`](https://github.com/NixOS/nixpkgs/commit/9895bd603dd6a3419a180b58e29b8d394cf1c138) haskellPackages.Agda: fix build on aarch64-darwin
* [`3641b16d`](https://github.com/NixOS/nixpkgs/commit/3641b16de0c259a404a4d4297cf91038e7351bba) haskellPackages: unbreak packages
* [`8641d2da`](https://github.com/NixOS/nixpkgs/commit/8641d2da644851755fc5a9424f4599381796ff59) sqlite: drop weird LFS64 hacks
* [`aa6c7781`](https://github.com/NixOS/nixpkgs/commit/aa6c7781a9c6827e2008dc211eba7246806e8948) haskell.compiler: elaborate error when cross compiling hadrian ghcs
* [`b8c806c7`](https://github.com/NixOS/nixpkgs/commit/b8c806c701aa7b33744a7d12f2cebc210887f9c5) edmarketconnector: do not add word "installPhase" to args
* [`85fe3f0f`](https://github.com/NixOS/nixpkgs/commit/85fe3f0fe1c5938a57a0c55117912171bf3a09b5) fmt_11: 11.0.2 -> 11.2.0
* [`0d1c07f6`](https://github.com/NixOS/nixpkgs/commit/0d1c07f6bf44882b860a415b09a8efa919e0a89d) vim-full: fix build when built with GUI support
* [`abc50135`](https://github.com/NixOS/nixpkgs/commit/abc50135a4ff1d4a48b42ab2054ee2131b90dc66) rustc: unset PKG_CONFIG_*
* [`30e1ccbf`](https://github.com/NixOS/nixpkgs/commit/30e1ccbf43d16f662ccc2e9514875e74faeee1b0) cider-2: migrate from AppImage to deb
* [`ff992e88`](https://github.com/NixOS/nixpkgs/commit/ff992e88d6248e68b3a1617b609dd65802321a21) cider-2: add amadejkastelic to maintainers
* [`8efc2f9a`](https://github.com/NixOS/nixpkgs/commit/8efc2f9af7ce480760d2c908dc2fbb792d35f155) cider-2: add update script
* [`28e72a42`](https://github.com/NixOS/nixpkgs/commit/28e72a42c799e195d5fe17e6362abc37811facb8) gnupg: Remove broken mirrors
* [`12003e5b`](https://github.com/NixOS/nixpkgs/commit/12003e5b3a7fe65a1e070a52fbd9515effefe174) gnupg: Add patch comments
* [`f0c791e5`](https://github.com/NixOS/nixpkgs/commit/f0c791e5104197c03181d8328fe6b7c1e920037f) gnupg: Enable test suite
* [`4657535e`](https://github.com/NixOS/nixpkgs/commit/4657535e2ed314d82202b3a7def8b2d51af8e807) haskell.compiler: (make built) also patch rts.cabal.in in numa patch
* [`86e02ae0`](https://github.com/NixOS/nixpkgs/commit/86e02ae0a9df9c89bf81bfddb0156fb55033e13b) libcamera: fix regression due to library paths change
* [`fc37a73b`](https://github.com/NixOS/nixpkgs/commit/fc37a73baea14733e57ee61de3ed804b0e108c83) threema-desktop: 1.2.46 -> 1.2.48
* [`429b22f9`](https://github.com/NixOS/nixpkgs/commit/429b22f9428063d448fd09ee4bbd429ca96ed110) libbpf: 1.5.1 -> 1.6.1
* [`b92da7d1`](https://github.com/NixOS/nixpkgs/commit/b92da7d1cb35ab020db64eca19ea11a7a1b2ed4d) replace-workspace-values.py: Update cargo.toml on only lints replace
* [`0d7fc558`](https://github.com/NixOS/nixpkgs/commit/0d7fc558cc3ca7bc8397b22444038e211b5a6090) libpng: 1.6.47 -> 1.6.49
* [`2c79c5d8`](https://github.com/NixOS/nixpkgs/commit/2c79c5d882cb8a0e200eb8b9f0894d3e85e67c0f) masterpdfeditor: 5.9.89 → 5.9.90
* [`ca7d34e7`](https://github.com/NixOS/nixpkgs/commit/ca7d34e71b412fe2e753f449b7d08ee1c7d2f6a4) lisp-modules: Fetch systems over HTTPS
* [`68369330`](https://github.com/NixOS/nixpkgs/commit/68369330d58965e5220e49a6852abfe673cf278a) libmicrohttpd: 1.0.1 -> 1.0.2
* [`eb79e380`](https://github.com/NixOS/nixpkgs/commit/eb79e38026540fe9a86ca7dd002018eb14185449) libmicrohttpd: enable parallel building
* [`d2ee7112`](https://github.com/NixOS/nixpkgs/commit/d2ee711249fe9745fe8c7a47528b69e269d744e9) bash: 5.3p0 -> 5.3p3
* [`09be7dca`](https://github.com/NixOS/nixpkgs/commit/09be7dca3a0d827c8021854853d11a1db727e75f) minio: 2025-06-13T11-33-47Z -> 2025-07-18T21-56-31Z
* [`b0a86ce5`](https://github.com/NixOS/nixpkgs/commit/b0a86ce5d511dc54707527e24db51742cfe97ddc) pipewire: 1.4.6 -> 1.4.7
* [`3ea4c39d`](https://github.com/NixOS/nixpkgs/commit/3ea4c39d98659a789660b5a2b9ef43c7e5e3a2e4) pyairtable: init at 3.1.1
* [`6b2e5b94`](https://github.com/NixOS/nixpkgs/commit/6b2e5b947405fce1033199dfe3b4e754b14e4c35) libtiff: don't propagate unnecessary build inputs
* [`a32e5f93`](https://github.com/NixOS/nixpkgs/commit/a32e5f932c1866456ee2dad1ecabd4480e5de006) libgeotiff: add missing build dependency
* [`f0343f0b`](https://github.com/NixOS/nixpkgs/commit/f0343f0b1506cd2bb60df9cf789aaf77bbc47ca1) libappimage: add missing xz dependency
* [`7c104c9b`](https://github.com/NixOS/nixpkgs/commit/7c104c9ba338167903547cff25e5eb5d2d0fcd04) glibc: 2.40-66 -> 2.40-142, fix CVE-2025-8058
* [`36d94b3e`](https://github.com/NixOS/nixpkgs/commit/36d94b3e6343bb15306333ccb5dd126496478c8e) qt6.qtbase: backport fix for HTTP/2 stream corruption
* [`d2bf2674`](https://github.com/NixOS/nixpkgs/commit/d2bf2674c8f2bd3eb126ac61d82c9e9b24320293) haskellPackages.llvm-ffi: 20.0 -> 21.0
* [`0a5e424e`](https://github.com/NixOS/nixpkgs/commit/0a5e424eebecd01677fa56c826873bf2b3a32259) cpuinfo: 0-unstable-2025-06-10 -> 0-unstable-2025-07-24
* [`4fb18157`](https://github.com/NixOS/nixpkgs/commit/4fb181570f08b1448a22ec318cd20750cf70f4db) clifm: 1.25 -> 1.26
* [`591335bd`](https://github.com/NixOS/nixpkgs/commit/591335bdbe558bac9910cc24d102970f3cb5e26b) equicord: 2025-04-17 -> 2025-07-25, fix version regex
* [`f6170e11`](https://github.com/NixOS/nixpkgs/commit/f6170e11983c999662127bcae9387646b147371c) equibop: 2.1.4 -> 2.1.5
* [`4e2f0650`](https://github.com/NixOS/nixpkgs/commit/4e2f0650396c0f03e9bd03e3e02adc01df9fb305) uv: 0.8.2 -> 0.8.3
* [`1c3b5fdb`](https://github.com/NixOS/nixpkgs/commit/1c3b5fdb927f3a6bf4abee604828397ae6a9ad45) pyright: 1.1.402 -> 1.1.403
* [`e89df558`](https://github.com/NixOS/nixpkgs/commit/e89df558c43a0b50b7f437d0019fcc32f686c77c) python313Packages.numpy: 2.3.1 -> 2.3.2
* [`3d02750b`](https://github.com/NixOS/nixpkgs/commit/3d02750b1459921899030bf1d00880bfc9477b1a) pkl: 0.28.2 -> 0.29.0
* [`859c24df`](https://github.com/NixOS/nixpkgs/commit/859c24dfc86f8d9194bf50a2a5df0fe8d9eceec2) rustc: Fix cross-compilation for the targets with dot in name
* [`8f70ff81`](https://github.com/NixOS/nixpkgs/commit/8f70ff81c02988b7d80ab49ca72faf374dad51a3) jdk{8,11,17,23,24}: always enable __structuredAttrs
* [`1bc0ebeb`](https://github.com/NixOS/nixpkgs/commit/1bc0ebeb6708d91b1b5309d35cad60e0592b0332) jdk{8,11,17,23,24}: cleanup
* [`45a890c4`](https://github.com/NixOS/nixpkgs/commit/45a890c4e328a2e2d0cde7a4854fd8314a26e336) aws-c-common: 0.10.3 -> 0.12.4
* [`e1448631`](https://github.com/NixOS/nixpkgs/commit/e14486315aa65fbc6a9a10641a80b3d14fcf4af8) aws-c-compression: 0.3.0 -> 0.3.1
* [`ad19f8ce`](https://github.com/NixOS/nixpkgs/commit/ad19f8ce71e7054f506ac31baf5331fe316c7f33) aws-c-auth: 0.8.1 -> 0.9.0
* [`8e2ee470`](https://github.com/NixOS/nixpkgs/commit/8e2ee4700c0cc469590dd03f2342421dfe29b0aa) aws-c-event-stream: 0.5.0 -> 0.5.5
* [`9676fdfe`](https://github.com/NixOS/nixpkgs/commit/9676fdfeca61a750e88a30e869485bd0866f0567) aws-c-http: 0.9.2 -> 0.10.4
* [`af28d439`](https://github.com/NixOS/nixpkgs/commit/af28d439d8fcb369a4afcb99c8a10f74aedaf0d8) aws-c-mqtt: 0.11.0 -> 0.13.3
* [`e53b60bc`](https://github.com/NixOS/nixpkgs/commit/e53b60bc61f2c4a7a4f9cce9a913ca0adb096c9c) aws-c-s3: 0.7.1 -> 0.8.6
* [`89247cf9`](https://github.com/NixOS/nixpkgs/commit/89247cf90706c30cd8d0e7804b986eaec478a760) aws-c-io: 0.15.3 -> 0.21.2
* [`006be67a`](https://github.com/NixOS/nixpkgs/commit/006be67aa397160f15072140647b06493e6db839) aws-checksums: 0.2.2 -> 0.2.7
* [`8362fde2`](https://github.com/NixOS/nixpkgs/commit/8362fde2cc0b717bd27ae779afeccb125048fdc8) python3Packages.pygments: 2.19.1 -> 2.19.2
* [`2f9f0ac7`](https://github.com/NixOS/nixpkgs/commit/2f9f0ac7054e314f0b000622966397aa1ea21d7d) python3Packages.pygments: add ryand56 as maintainer
* [`9cc8e112`](https://github.com/NixOS/nixpkgs/commit/9cc8e11298ba17ffcbfc933e3c8a7632cd365ad4) maintainers: add ananthb
* [`066625a5`](https://github.com/NixOS/nixpkgs/commit/066625a5add5ccd2c4f3c2dacfdad5cf16f17d2e) unclutter-xfixes: 1.6 -> 1.6-unstable-2024-11-25, adopt
* [`b532081b`](https://github.com/NixOS/nixpkgs/commit/b532081b67d441db401838e1e98a004a41f1e8e9) s2n-tls: 1.5.22 -> 1.5.23
* [`ed0971e8`](https://github.com/NixOS/nixpkgs/commit/ed0971e829aa0fa271bc24478692b636fc22571e) ncurses: Add patch to recognise linux-gnuabielfv{1,2}
* [`8e437d78`](https://github.com/NixOS/nixpkgs/commit/8e437d789975fce518c71eecb9ed2faed49af612) aws-crt-cpp: 0.29.4 -> 0.33.1
* [`c66c7aea`](https://github.com/NixOS/nixpkgs/commit/c66c7aea2d9996744347c61900471f8792cf9caf) aws-c-sdkutils: 0.2.1 -> 0.2.4
* [`f37c2a71`](https://github.com/NixOS/nixpkgs/commit/f37c2a71baa1d9f64b578897f78fdc75953dc5d4) aws-c-cal: 0.8.0 -> 0.9.2
* [`3897bcab`](https://github.com/NixOS/nixpkgs/commit/3897bcab633af39f7feacced5d75900ccecd98f4) aws-sdk-cpp: 1.11.448 -> 1.11.612
* [`12db0438`](https://github.com/NixOS/nixpkgs/commit/12db043825cb2574093f8240b859a33ee1f0d143) nixVersions.nix_2_3.passthru.aws-sdk-cpp: Mark broken
* [`fee4d7aa`](https://github.com/NixOS/nixpkgs/commit/fee4d7aa5fcf4fc48272b5b36529d89e7db81eed) python3Packages.miraie-ac: init at 1.1.1
* [`5a73e07b`](https://github.com/NixOS/nixpkgs/commit/5a73e07b1089d7d43d5d97305aa5a843de97002f) libmamba: 2.1.1 -> 2.3.0
* [`113cd624`](https://github.com/NixOS/nixpkgs/commit/113cd6243d55c8738aafa5cf088e5b09e020653f) mamba-cpp: use src and version from libmamba
* [`aa5f9058`](https://github.com/NixOS/nixpkgs/commit/aa5f9058cd040168465e521179b9bdd425539015) renpy: pin python3 to 3.12
* [`fb5c5793`](https://github.com/NixOS/nixpkgs/commit/fb5c5793ed1cf69574b50ba35a4542b4aa155938) renpy: 8.3.7.25031702 -> 8.4.1.25072401
* [`f1ca05eb`](https://github.com/NixOS/nixpkgs/commit/f1ca05eb9d0e2fa1e13912e24ea9d481e6520a79) zeromq: Fix cross-compilation
* [`66ba8a58`](https://github.com/NixOS/nixpkgs/commit/66ba8a58af5c40ae845da029aaf6d0a273b68ccd) renpy: automatically update version codename
* [`957606ce`](https://github.com/NixOS/nixpkgs/commit/957606ce4f3bd6f46454c5bd553f4ba375ff04bf) haskell.packages.ghc912.doctest: correctly skip cabal-install tests
* [`3ddc9cb9`](https://github.com/NixOS/nixpkgs/commit/3ddc9cb90a53f999a1b0c3b4b7a6215973fa6df0) haskellPackages.hiedb: downgrade to < 0.7
* [`8076d015`](https://github.com/NixOS/nixpkgs/commit/8076d015a85606deafaa1b93c2f4cfa3d306d1f7) haskell.packages.ghc{810,90}.hpack_0_38_1: avoid broken test dep
* [`73cfabbf`](https://github.com/NixOS/nixpkgs/commit/73cfabbf21355dd061859120bff172edb0bf1a78) darwin.libffi: backport automake-1.18 fix
* [`083824d9`](https://github.com/NixOS/nixpkgs/commit/083824d9b6af1c64d3bc274a44b2561d60eb35e9) publicsuffix-list: 0-unstable-2025-06-10 -> 0-unstable-2025-07-22
* [`29e26c8b`](https://github.com/NixOS/nixpkgs/commit/29e26c8b6e2f1d0ea6e78260e15cde1dfb2b0f7b) haskellPackages.ghc-hie: disable versioned ghc tests
* [`ed889fb4`](https://github.com/NixOS/nixpkgs/commit/ed889fb40b730c2475ee3d5850eec810dbe15966) lima, lima-additional-guestagents: 1.2.0 -> 1.2.1
* [`7ee7d1ea`](https://github.com/NixOS/nixpkgs/commit/7ee7d1ea1fe9ae4ea6bd401d731859f099f25d0b) grpc: 1.73.1 -> 1.74.0
* [`86280098`](https://github.com/NixOS/nixpkgs/commit/862800980b6fcc6a7ea98e9f6e7ab9c817432021) python3Packages.grpcio: 1.73.1 -> 1.74.0
* [`54935fcc`](https://github.com/NixOS/nixpkgs/commit/54935fcc2b0cf630c56a9ed5c603449f19a3a98c) python3Packages.grpcio-channelz: 1.73.1 -> 1.74.0
* [`2cabb595`](https://github.com/NixOS/nixpkgs/commit/2cabb5950a82aaecf917b824f251d5359c7f3411) python3Packages.grpcio-health-checking: 1.73.1 -> 1.74.0
* [`0a44c47b`](https://github.com/NixOS/nixpkgs/commit/0a44c47be2a3c3e117cac6ed40160e62eda341e8) python3Packages.grpcio-reflection: 1.73.1 -> 1.74.0
* [`37d8088e`](https://github.com/NixOS/nixpkgs/commit/37d8088ef74d332c519f5d1068c16c2f3edf2694) python3Packages.grpcio-status: 1.73.1 -> 1.74.0
* [`3397e9c7`](https://github.com/NixOS/nixpkgs/commit/3397e9c79d967158d6dc49c1361ad3284ec6bb02) python3Packages.grpcio-testing: 1.73.1 -> 1.74.0
* [`6fd988a0`](https://github.com/NixOS/nixpkgs/commit/6fd988a003059e4d00c118744b3cc235f47a55c8) python3Packages.grpcio-tools: 1.73.1 -> 1.74.0
* [`a97ed171`](https://github.com/NixOS/nixpkgs/commit/a97ed17136a42e84e98f5ce9b4c8819267d2d7b3) maintainers: add bizmyth
* [`e56f2b60`](https://github.com/NixOS/nixpkgs/commit/e56f2b60dcae52cbf47aea5ed21824069e7356ce) apotris: init at 4.1.0
* [`e759a677`](https://github.com/NixOS/nixpkgs/commit/e759a67713fe77900db3c7c13abf5ffba050b807) websurfx: 1.24.6 -> 1.24.22
* [`4e6b9a1d`](https://github.com/NixOS/nixpkgs/commit/4e6b9a1d40887ab285a1a95ea041bf00d66b2c33) snappy: restore of RTTI patch
* [`b727207a`](https://github.com/NixOS/nixpkgs/commit/b727207a973722fb50d2bb0773cae730006b1a29) ceph: arrow 19 compilation fix with protobuf 30
* [`494c6fb6`](https://github.com/NixOS/nixpkgs/commit/494c6fb60c7992d0d9b9f5c30b57f0c7e35f5e4a) haskellPackages: mark builds failing on hydra as broken
* [`653ed637`](https://github.com/NixOS/nixpkgs/commit/653ed6376f5b0e900e6067aade36a52e4e4137f5) zig.cc: set main program
* [`a1559903`](https://github.com/NixOS/nixpkgs/commit/a155990361349d1e871c0e09a0a81ce754c759b6) gcc-unwrapped: set main program
* [`e9b2edb4`](https://github.com/NixOS/nixpkgs/commit/e9b2edb4916328647571aee01b2a83c02e585df5) linux: un-simplify toolchain selection
* [`c2420281`](https://github.com/NixOS/nixpkgs/commit/c2420281d2c015ddbc3e14d0b5b19174f684dbd7) linux: verify basic configuration sanity
* [`86af86bd`](https://github.com/NixOS/nixpkgs/commit/86af86bd52d4af29f5f0633f42b2881514603b9b) llvmPackages_20: 20.1.6 -> 20.1.8
* [`53e8ad37`](https://github.com/NixOS/nixpkgs/commit/53e8ad37578005290b7a7e5376b99c902978e40a) haskellPackages.agda2hs: fix build with Agda 2.8.0
* [`196eb531`](https://github.com/NixOS/nixpkgs/commit/196eb5312974580e085ffaf3eabc5393e4eb4c67) kexec-tools: Only force ELFv2 on ppc64 when the platform settings aggree
* [`a6117acd`](https://github.com/NixOS/nixpkgs/commit/a6117acd6b61bd8075a3b9aeca52b0cf07a624b7) haskellPackages.haskell-pgmq: provide postgresql+pgmq for tests
* [`54ba7d3e`](https://github.com/NixOS/nixpkgs/commit/54ba7d3e483f790ff0b4d092b2b4a0010b18b336) haskellPackages.haskell-bee-redis: provide redis for tests
* [`9ec35680`](https://github.com/NixOS/nixpkgs/commit/9ec35680798a236a3dd1eed984c79dcd26f6498d) python3Packages.rich: 14.0.0 -> 14.1.0
* [`7568d3cb`](https://github.com/NixOS/nixpkgs/commit/7568d3cb493a37a13a8c307814985314fcbd9cbf) open-vm-tools: convert sed to substituteInPlace --replace-fail
* [`db9bcba7`](https://github.com/NixOS/nixpkgs/commit/db9bcba7f81acb1f1ab6ad47c7eca5125352a7fd) python3Packages.dtlssocket: 0.2.2 -> 0.2.3
* [`d99faf6a`](https://github.com/NixOS/nixpkgs/commit/d99faf6a26163fce2646aef7fe0988b540cc2830) open-vm-tools: fix dlopen path to libguestStoreClient.so.0
* [`eafd3478`](https://github.com/NixOS/nixpkgs/commit/eafd3478090b325150fac22f775def127904bae6) open-vm-tools: move patching to postPatch
* [`1443de73`](https://github.com/NixOS/nixpkgs/commit/1443de732a005a4f24d81cb149c0eaa506a6d91c) qemu: 10.0.2 -> 10.0.3
* [`09a11ee4`](https://github.com/NixOS/nixpkgs/commit/09a11ee4725f0496e093a0c8735fd9a8e642621b) nixVersions.nix_2_3: Remove aws support
* [`4a550833`](https://github.com/NixOS/nixpkgs/commit/4a550833a91f632d1486d0be4bfd8d4136d995a7) ipopt: 3.14.17 -> 3.14.18
* [`2dee2988`](https://github.com/NixOS/nixpkgs/commit/2dee29888f4022b8017dbe29b37cb5155c859f51) teleport: migrate to new buildTeleport
* [`c6d1d4dd`](https://github.com/NixOS/nixpkgs/commit/c6d1d4dd2cd4f359770310e342124aca57299b7b) wasm-bindgen-cli_0_2_99: init at 0.2.99
* [`dc6b7b62`](https://github.com/NixOS/nixpkgs/commit/dc6b7b62b8bc703806dd356f8c0fb9750a025ff8) llvmPackages_20.llvm: always apply riscv64-specific patch
* [`b3be5b65`](https://github.com/NixOS/nixpkgs/commit/b3be5b6560f9f6dfef2e5f81446c533503016348) nordpass: 5.23.12 -> 6.3.15
* [`731391c2`](https://github.com/NixOS/nixpkgs/commit/731391c2b9e7b638eafe13799bfa2315895c2b66) stdenvNoCC: fix `extraBuildInputs` on Darwin
* [`76a80617`](https://github.com/NixOS/nixpkgs/commit/76a80617b12c2d4b36cd07d5d67bb52a356751d5) libarchive: fix tests on Darwin with recent Nix/Lix
* [`2fc95bd9`](https://github.com/NixOS/nixpkgs/commit/2fc95bd982f7f1f74e96c1ac13f72c0aba2c0dda) re2: 2025-07-17 -> 2025-07-22
* [`a413c6f5`](https://github.com/NixOS/nixpkgs/commit/a413c6f5b4ac3561dcd2a0b11a746fb6660aea96) cc-wrapper: use `-fmacro-prefix-map` to scrub `__FILE__` references
* [`6e2e0153`](https://github.com/NixOS/nixpkgs/commit/6e2e0153b07d8909715b6d2dcae52b2f9c6bad56) ceph: 19.2.2 -> 19.2.3
* [`e3b2113f`](https://github.com/NixOS/nixpkgs/commit/e3b2113fc2c067688b9889892d67616638e6397a) nghttp2: 1.65.0 -> 1.66.0
* [`f073e621`](https://github.com/NixOS/nixpkgs/commit/f073e6214c3f901184a625869c8761b6ae6f892f) teleport_18: init at 18.1.1
* [`704686cc`](https://github.com/NixOS/nixpkgs/commit/704686cc6bb17c389c27259a764d823609bc09fa) xkeyboard-config: add patch to fix us-mac
* [`2ff9e8c4`](https://github.com/NixOS/nixpkgs/commit/2ff9e8c46aad554df74875245162581fba05d14d) bmake: 20250528 -> 20250707
* [`ad36bee3`](https://github.com/NixOS/nixpkgs/commit/ad36bee368c5ed7a1ed152697da97c6c68bba0ec) umockdev: 0.19.1 -> 0.19.2
* [`e10606c6`](https://github.com/NixOS/nixpkgs/commit/e10606c671c6a9f7329236908bcad02d9fcf6983) iproute2: do not use dark blue in dark background palette
* [`5b516ba8`](https://github.com/NixOS/nixpkgs/commit/5b516ba8f4fd8d8e7e1c499ba36a7b6de57a0420) superfile: fix build
* [`a167470f`](https://github.com/NixOS/nixpkgs/commit/a167470f76eb475c3a2326ffb91612fb152bc8b8) superfile: 1.3.2 -> 1.3.3
* [`50b5017b`](https://github.com/NixOS/nixpkgs/commit/50b5017b2b410d6759caaba6b703f90ef0965cf1) libxdmcp: refactor, move to pkgs/by-name and rename from xorg.libXdmcp
* [`6ef27624`](https://github.com/NixOS/nixpkgs/commit/6ef2762479702f681bc030b3ee62ec56cb18310f) libxau: refactor, move to pkgs/by-name and rename from xorg.libXau
* [`316108c9`](https://github.com/NixOS/nixpkgs/commit/316108c9d524d62991fe716475b58f3d931e1776) libxcb: refactor and move to pkgs/by-name from xorg namespace
* [`3c1d6186`](https://github.com/NixOS/nixpkgs/commit/3c1d6186b099969e1f9817dd9ca0711b61a69a79) libx11: refactor, move to pkgs/by-name and rename from xorg.libX11
* [`8ce173be`](https://github.com/NixOS/nixpkgs/commit/8ce173bef35972a7dce26a73ecaa31121986270f) libxext: refactor, move to pkgs/by-name and rename from xorg.libXext
* [`75f1b106`](https://github.com/NixOS/nixpkgs/commit/75f1b1067ca51de5592acb68783729ebd6de0f81) qemu: use --replace-fail
* [`c1c14886`](https://github.com/NixOS/nixpkgs/commit/c1c148864b181d31eb0fde10e6e1ba3370911847) cracklib: 2.10.0 -> 2.10.3
* [`e2bd1870`](https://github.com/NixOS/nixpkgs/commit/e2bd187078a96e9940a37dca0271184365cd75bf) eos-installer: add missing xz dependency
* [`5367e677`](https://github.com/NixOS/nixpkgs/commit/5367e6770cebecde42c1a65cd5f9314f394c4dcb) subsurface: fix bad shebang in update script
* [`562849de`](https://github.com/NixOS/nixpkgs/commit/562849de8b7941a4b68ac4ee2a15068b69c4e478) subsurface: 6.0.5231 -> 6.0.5414
* [`025e6374`](https://github.com/NixOS/nixpkgs/commit/025e6374343d4729e4c70ef5a4eb0200ddfdecb0) util-linux: split lastlog into dedicated output
* [`d30eeb3e`](https://github.com/NixOS/nixpkgs/commit/d30eeb3ef4fe4830c11c3fea27e1476f69f56f22) nixos/pam: switch to lastlog2
* [`4401eb4b`](https://github.com/NixOS/nixpkgs/commit/4401eb4b3b27775878959127e72d62dd7a0d108b) sanitiseHeaderPathsHook: drop
* [`bd0d5449`](https://github.com/NixOS/nixpkgs/commit/bd0d5449c00e16d6361d3f13519562c2083e6766) freac: Fix crash when selecting output folder
* [`0efdf365`](https://github.com/NixOS/nixpkgs/commit/0efdf36544bf6a2863a3fe6b8b383a3d01cb8db0) nixos/tests/lastlog: init
* [`2493c8c1`](https://github.com/NixOS/nixpkgs/commit/2493c8c13213c50d410119da18ee83ce3ad0648c) haskell.packages.ghc865Binary.exceptions: fix the eval
* [`07214519`](https://github.com/NixOS/nixpkgs/commit/07214519c6309b727e727fca62f0b606d8efd0b2) uv: 0.8.3 -> 0.8.4
* [`629f720b`](https://github.com/NixOS/nixpkgs/commit/629f720b67025148a4e08ea15ea94327cf661a56) nodejs_22: 22.17.1 -> 22.18.0
* [`c632f2a2`](https://github.com/NixOS/nixpkgs/commit/c632f2a28bc26e848ba38bac2789e1d6c59a71ea) slsk-batchdl: init at 2.4.7
* [`82ec74d1`](https://github.com/NixOS/nixpkgs/commit/82ec74d15ce48effae85ccebc3bd5ccde4a05df7) gogh: init at 361
* [`33a086ac`](https://github.com/NixOS/nixpkgs/commit/33a086ac03856a49abfdd35e800dc28ce8410e97) bash: update hash following upstream re-release
* [`b3383412`](https://github.com/NixOS/nixpkgs/commit/b3383412b09e7f1371eb55b7fc36187e7e80015a) gefyra: init at 2.3.1
* [`d1d1d334`](https://github.com/NixOS/nixpkgs/commit/d1d1d334eadacb4d3a7d9dfa424c97c8f1243908) sratoolkit: fix build due to undefined ATTRIBUTE_UNUSED
* [`067bdc6b`](https://github.com/NixOS/nixpkgs/commit/067bdc6b9d7a79d4ea99d64a620a6c2d11597586) v4l-utils: fix cross-compilation
* [`0b35f897`](https://github.com/NixOS/nixpkgs/commit/0b35f8970dfdad4e45c387524cdf55771e44a9f8) ocamlPackages.macaddr: 5.6.0 -> 5.6.1
* [`494514a6`](https://github.com/NixOS/nixpkgs/commit/494514a67039f7d88e12e4ad454e29ebf1d1414c) python3Packages.bitarray: 3.4.3 -> 3.6.0
* [`313baaad`](https://github.com/NixOS/nixpkgs/commit/313baaada1eb9226ec1a5dd3cdb5dea45f513300) action-validator: 0.6.0-unstable-2025-02-16 -> 0.7.1
* [`023310e4`](https://github.com/NixOS/nixpkgs/commit/023310e44ece2909d40fe6cba62f3fcb7da47d7b) meson: 1.8.2 -> 1.8.3
* [`094b3521`](https://github.com/NixOS/nixpkgs/commit/094b3521c515a43ff2675083128ddfdf96847165) chatgpt: 1.2025.063 -> 1.2025.203
* [`2bcaa2eb`](https://github.com/NixOS/nixpkgs/commit/2bcaa2eb4725f16b064f289edbdfae22b7ec0a5b) whitesur-icon-theme: 2025-02-10 -> 2025-08-02
* [`27c9f074`](https://github.com/NixOS/nixpkgs/commit/27c9f0748771dc13430e0a4a9b31b8bde423b750) aligator: 0.14.0 -> 0.15.0
* [`de8aa73f`](https://github.com/NixOS/nixpkgs/commit/de8aa73f5bdbc002dd8ead199632a1e23a115d1a) google-lighthouse: 12.7.0 -> 12.8.1
* [`162645e9`](https://github.com/NixOS/nixpkgs/commit/162645e9c4369546f05d311f0fce613a2db5b826) flex-ncat: 0.5-2025031901 -> 0.6-20250801.0
* [`c6cdef73`](https://github.com/NixOS/nixpkgs/commit/c6cdef73de3ffa325fde886f31b993a632b52ca9) flex-ndax: 0.4-20240818 -> 0.5-20250801.0
* [`1d616f33`](https://github.com/NixOS/nixpkgs/commit/1d616f33e40efc9a176a974cf7d7c00d3e601f0f) lhasa: 0.4.0 -> 0.5.0
* [`0de77985`](https://github.com/NixOS/nixpkgs/commit/0de77985b71ccae2a607acfe78afbc3841ff7226) gradle_9: init at 9.0.0
* [`3dd3090f`](https://github.com/NixOS/nixpkgs/commit/3dd3090f9aa76d8fa866230621a3445d0468c63f) oath-toolkit: 2.6.12 -> 2.6.13
* [`26b2fa24`](https://github.com/NixOS/nixpkgs/commit/26b2fa2426c96f88c9139104101f7c6da778d16c) python310Packages.pip: fix build failure caused by sphinx-8.2.3
* [`690e42e2`](https://github.com/NixOS/nixpkgs/commit/690e42e26a9b1f3abd4636cac431208427c50615) stdenv: make dumpVars test if $NIX_BUILD_TOP is a directory
* [`e7a8ecd3`](https://github.com/NixOS/nixpkgs/commit/e7a8ecd30cda4f174d2c29f15814b51f75c2d504) groonga: 15.1.3 -> 15.1.4
* [`55fe2325`](https://github.com/NixOS/nixpkgs/commit/55fe2325034f8b91d753b24ef748321c1c8e2710) fix update script
* [`7c786e03`](https://github.com/NixOS/nixpkgs/commit/7c786e0360449301ec3aac0ce32d3cda4594f05b) vivaldi-ffmpeg-codecs: 119293 -> 120726
* [`ecd472d6`](https://github.com/NixOS/nixpkgs/commit/ecd472d6091dbd13f3d5e8b30aa8b0d4dab12ccc) wtfis: 0.12.0 -> 0.13.0
* [`6519e3fb`](https://github.com/NixOS/nixpkgs/commit/6519e3fb71d167b435fa73ff7b06c338e5ef5714) linuxHeaders: fix build on 32-bit systems with 64-bit inodes
* [`f441c08d`](https://github.com/NixOS/nixpkgs/commit/f441c08dc04b1a3c7f6b379c19bfbd0f80c84348) python3Packages.pyogrio: 0.11.0 -> 0.11.1
* [`4641ef6c`](https://github.com/NixOS/nixpkgs/commit/4641ef6c7928bc9e3f1b52d9efc47d8f8f22bf5c) nushellPlugins.hcl: 0.105.1 -> 0.106.1
* [`670a0723`](https://github.com/NixOS/nixpkgs/commit/670a072307f717197c7db3a7cfafa3a951ddf208) tmux-sessionizer: 0.4.5 -> 0.5.0
* [`5c50fa8f`](https://github.com/NixOS/nixpkgs/commit/5c50fa8fbaebb3f780e21935daf2afc61141f2a2) tmux-sessionizer: use finalAttrs
* [`d01b0d11`](https://github.com/NixOS/nixpkgs/commit/d01b0d116a146cdb0e9129ff495214a1d4091044) tmux-sessionizer: formatting
* [`a91823e8`](https://github.com/NixOS/nixpkgs/commit/a91823e83339fcf571b2b5efea0a9fbc668b8cc8) tmux-sessionizer: use versionCheckHook
* [`2c15bf9d`](https://github.com/NixOS/nixpkgs/commit/2c15bf9dda02727a45d2ad14756dc2deefd6f3aa) Revert "abseil-cpp: 20250127.1 -> 20250512.1"
* [`5226b9c2`](https://github.com/NixOS/nixpkgs/commit/5226b9c27b90e09b0ffa407e4ae5e8c911e95911) audit: enable io_uring support
* [`e9552294`](https://github.com/NixOS/nixpkgs/commit/e95522945e94f8f3a05f14285ecbc6cef08c7cfc) audit: install bash completion
* [`0e42aed2`](https://github.com/NixOS/nixpkgs/commit/0e42aed2fb2c698f8b0d62dffad814225bb5fc51) audit: 4.1.0 -> 4.1.1-unstable-2025-08-01
* [`a9fd61ff`](https://github.com/NixOS/nixpkgs/commit/a9fd61ff9f95a31b99471ff3dc07f731f6436acd) audit: disable legacy actions
* [`025afda8`](https://github.com/NixOS/nixpkgs/commit/025afda8d8ea5076e8ade471dfd476a7ff33cb82) audit: disallow bash requirement for lib output
* [`5ba6a021`](https://github.com/NixOS/nixpkgs/commit/5ba6a021b54061b5bff4620ccedc14942c64009a) python3: fix build directory scrubbing
* [`7b250a8b`](https://github.com/NixOS/nixpkgs/commit/7b250a8bcb84006c736621e1a00b8ee35590b04d) meson: increase the maximum length of test logs
* [`1620104e`](https://github.com/NixOS/nixpkgs/commit/1620104ec6c1e40f8a55fd8459730f3e186f8950) {nukeReferences,removeReferencesTo}: simplify and fix quoting
* [`9d094a5f`](https://github.com/NixOS/nixpkgs/commit/9d094a5f85170524c98343841363f028d1e5171f) abseil-cpp_202505: init at 20250512.1
* [`71b2f8cd`](https://github.com/NixOS/nixpkgs/commit/71b2f8cd5f604a699d3527596b3aaaf610d61a50) libcerf: 3.0 -> 3.1
* [`90e9a58c`](https://github.com/NixOS/nixpkgs/commit/90e9a58c9b841630692f311c148074262fe717ee) novelwriter: 2.6.3 -> 2.7.4
* [`7b4572ca`](https://github.com/NixOS/nixpkgs/commit/7b4572ca905a01ad7363eeea484ed39436825dd6) tests.fetchDebianPatch: fix patch name
* [`c0e42f6d`](https://github.com/NixOS/nixpkgs/commit/c0e42f6d95b8dca4d852ee1c59205db05cac6880) Revert "perf: inherit makeFlags from kernel"
* [`48f71e5e`](https://github.com/NixOS/nixpkgs/commit/48f71e5e09c441d41b8b5ebea062a5f8202dde27) hwdata: 0.397 -> 0.398
* [`f8218b54`](https://github.com/NixOS/nixpkgs/commit/f8218b54bda70ec1151b766bc2c6165458136625) open-vm-tools: move vm-support binary to $out/bin and fix missing tools
* [`42e35a4e`](https://github.com/NixOS/nixpkgs/commit/42e35a4edce79c80aca54df64ed006891612bbde) open62541: 1.4.12 -> 1.4.13
* [`29dcdca5`](https://github.com/NixOS/nixpkgs/commit/29dcdca5c303748381f0c73297e59aaa5c37c77b) qtappinstancemanager: init at 1.3.0
* [`aa70f7ce`](https://github.com/NixOS/nixpkgs/commit/aa70f7ce1486889364d9d15e430e49a30fd0c402) solarus-launcher: un-vendor qlementine within nixpkgs; refactor
* [`9acb58f5`](https://github.com/NixOS/nixpkgs/commit/9acb58f589bd7dd0fc3cea82a51415683a1b5d04) solarus-quest-editor: un-vendor qlementine within nixpkgs; refactor
* [`f3793de1`](https://github.com/NixOS/nixpkgs/commit/f3793de1d596eb6920e15545cf639f9085697dbb) papertrail: Refactor package definitions
* [`1ca98b86`](https://github.com/NixOS/nixpkgs/commit/1ca98b8659093113a32d08381216915f8fa8e52b) wpaperd: add man pages and shell completions
* [`66ec0c99`](https://github.com/NixOS/nixpkgs/commit/66ec0c99cc9d0461f80c4d1acd5e433ac6ca6b95) waydroid-helper: add missing pywayland dependency, wrap adb
* [`d291fcc4`](https://github.com/NixOS/nixpkgs/commit/d291fcc46e00d7a588f6b64660cf0b4c799d199c) spice: 0.15.2 -> 0.16.0
* [`3b1c1cd2`](https://github.com/NixOS/nixpkgs/commit/3b1c1cd257759b4acc3f5d264aab16261d0a487d) yadm: 3.3.0 -> 3.5.0
* [`3c2523a1`](https://github.com/NixOS/nixpkgs/commit/3c2523a1780c09a114b5687df62288a3c4be2f2e) Reapply "ibus: add meta.mainProgram"
* [`d9e041f0`](https://github.com/NixOS/nixpkgs/commit/d9e041f0e9b794413d392c8d4c704a0fae49b344) sdl3: 3.2.18 -> 3.2.20
* [`adf7675c`](https://github.com/NixOS/nixpkgs/commit/adf7675c8a6572b42d729ef6e9fb82cb808b7135) kanji-stroke-order-font: 4.004 -> 4.005
* [`f33d0ca4`](https://github.com/NixOS/nixpkgs/commit/f33d0ca45357dda16907d3e4a9ba85072935ddcb) dopamine: 3.0.0-preview.38 -> 3.0.0-preview.39
* [`7404c06f`](https://github.com/NixOS/nixpkgs/commit/7404c06f3007ece43788ffa5941a97ab8b559e9a) sudo-rs: add pam.services.su-l for su -l
* [`a17b3d9f`](https://github.com/NixOS/nixpkgs/commit/a17b3d9f777ce49be61d1216a634c5293abc6797) linuxHeaders: 6.14.7 -> 6.16
* [`0d2321b1`](https://github.com/NixOS/nixpkgs/commit/0d2321b1e49dd3577c19f7e5198136ed97bf1144) ghc{865,8107,902,924,963,984}Binary: don’t depend on `gcc` on Darwin
* [`781246de`](https://github.com/NixOS/nixpkgs/commit/781246ded67c58672354107bae165927c399fec2) ruff: 0.12.4 -> 0.12.5
* [`4e2d650c`](https://github.com/NixOS/nixpkgs/commit/4e2d650ccf3e115ac05a640a6662f1c7414fcf07) libraqm: 0.10.2 -> 0.10.3
* [`f8a4ba73`](https://github.com/NixOS/nixpkgs/commit/f8a4ba73b10b00f8e12749b9af9d16b53799791c) tinty: 0.28.0 -> 0.29.0
* [`68bcdbfc`](https://github.com/NixOS/nixpkgs/commit/68bcdbfc9efe20a27262c7ef79a3a2ab707d1e46) nixos/prosody: substitute environment variables to allow securely loading secrets
* [`91c2eb95`](https://github.com/NixOS/nixpkgs/commit/91c2eb95b5241867c124c84edbd314db0a561d35) ruffle: fix building on darwin
* [`e69ab314`](https://github.com/NixOS/nixpkgs/commit/e69ab3147aa27824f66e8993d0fb6bd26eca1575) python3Packages.cartopy: 0.24.1 -> 0.25.0
* [`045cfbcd`](https://github.com/NixOS/nixpkgs/commit/045cfbcd8976c6dc77e67505b907bae554c0edc7) strace: 6.15 -> 6.16
* [`7036f637`](https://github.com/NixOS/nixpkgs/commit/7036f6374c0f59e0a63074e7425441e8293b1f7c) upterm: 0.15.0 -> 0.15.2
* [`87d7f930`](https://github.com/NixOS/nixpkgs/commit/87d7f93052a81dbe0f5578bb22414a10cf8d2734) doc/reviewing-contributions: Refine the New modules link
* [`d93967f3`](https://github.com/NixOS/nixpkgs/commit/d93967f383ad332822456aeffd4a142cd9cab18d) libx11: fix libxcb not being in propagatedBuildInputs
* [`b66de097`](https://github.com/NixOS/nixpkgs/commit/b66de0973ddab400115f162dbc816cf64e5f1998) log4cxx: 1.2.0 -> 1.5.0
* [`efaca0c1`](https://github.com/NixOS/nixpkgs/commit/efaca0c196f8d9a40956a9df8b7927103514b876) nixos/meta: Fix maintainers example
* [`dcc0ee9e`](https://github.com/NixOS/nixpkgs/commit/dcc0ee9ea10ddfb31f1eb4827379ef0aa91e95d5) nixos/documentation: Allow the inclusion of a nixpkgs/modules directory
* [`0c156a71`](https://github.com/NixOS/nixpkgs/commit/0c156a71440105a9fe1fbc1d89275ff3fe94c92a) modules/generic/meta-maintainers: init
* [`f7c74c9b`](https://github.com/NixOS/nixpkgs/commit/f7c74c9b197d7d14ff1100bfc5ae96100cc3e927) icingaweb2: include schema/ in $out/
* [`8d0b9ddc`](https://github.com/NixOS/nixpkgs/commit/8d0b9ddcc55a6b60d3060a4894def12486ffab6e) Revert "release: don't block on bootstrap tools, temporarily"
* [`2e6f99ed`](https://github.com/NixOS/nixpkgs/commit/2e6f99eddd3af83e3bdf2bff4ee3ccf70a41b339) srcOnly: add warning for usage with non-stdenv derivations
* [`58376e1f`](https://github.com/NixOS/nixpkgs/commit/58376e1f1d079ac0f41515ce26801d442f691e61) eigen: fix bdcsvd
* [`6d1a4c85`](https://github.com/NixOS/nixpkgs/commit/6d1a4c85b521736c6032d69bfd86348692591cad) quarto: 1.7.32 -> 1.7.33
* [`1a5c67af`](https://github.com/NixOS/nixpkgs/commit/1a5c67af7553db8873a2f5e15c841acf0c910885) ocamlPackages.miou: 0.3.1 -> 0.4.0
* [`affbba20`](https://github.com/NixOS/nixpkgs/commit/affbba20319280a16ebb19fe5c11715f5ad2d03a) lego: 4.25.1 -> 4.25.2
* [`a8828d8c`](https://github.com/NixOS/nixpkgs/commit/a8828d8cc25b47e3fd77513c434f7332e25eb1e6) python3Packages.blockbuster: 1.5.23 -> 1.5.25
* [`cceefea3`](https://github.com/NixOS/nixpkgs/commit/cceefea34fb476cbf1c36e69b036677d6e11e37b) bundler: 2.6.9 -> 2.7.1
* [`623b61ac`](https://github.com/NixOS/nixpkgs/commit/623b61ac9240561534834fc1bdb59dcc0855b738) go_1_24: 1.24.5 -> 1.24.6
* [`023037cc`](https://github.com/NixOS/nixpkgs/commit/023037cc964cb51e968829d1436eab8d2f084eef) libnftnl: 1.2.9 -> 1.3.0
* [`27f515a1`](https://github.com/NixOS/nixpkgs/commit/27f515a135909980f47901ba17716938f259a0ad) nftables: 1.1.3 -> 1.1.4
* [`aee83dd4`](https://github.com/NixOS/nixpkgs/commit/aee83dd489158ad8754b7509fd2eba0bb9be4df6) tuatara: init at 1631040452-unstable-2025-04-29
* [`05320d36`](https://github.com/NixOS/nixpkgs/commit/05320d369bd1f95b83db782e8ce10796f999250c) gperftools: 2.15 -> 2.17
* [`57aca6f5`](https://github.com/NixOS/nixpkgs/commit/57aca6f5f081bc2b31b1c04aee221d0e6b374ab7) typespec: 1.1.0 -> 1.3.0
* [`4aa65fbc`](https://github.com/NixOS/nixpkgs/commit/4aa65fbc2a2fa28569284711c34d9c12c7b694a3) osv-scanner: 2.1.0 -> 2.2.0
* [`e33181bc`](https://github.com/NixOS/nixpkgs/commit/e33181bc6273abdcc4ec67cb6161401823f49b57) pypy{27,310,311}: make CFFI builds find libsqlite3
* [`c1513a4f`](https://github.com/NixOS/nixpkgs/commit/c1513a4fd70640aea4ce53fe9b3c99b4bde19990) qdldl: init at 0.1.8
* [`f2d448ac`](https://github.com/NixOS/nixpkgs/commit/f2d448ac0e3ac44dcc169034a68a8dc527039cb5) osqp: 0.6.3 -> 1.0.0
* [`b9e14b77`](https://github.com/NixOS/nixpkgs/commit/b9e14b77190996f65d2a70b19bb4a2d5f9881dde) osqp: clean
* [`c489b392`](https://github.com/NixOS/nixpkgs/commit/c489b3928482d673ba83e49ebbfed1d4b86fdb5c) osqp: use our qdldl src
* [`3eb299d3`](https://github.com/NixOS/nixpkgs/commit/3eb299d3f95ecb37b7e8ee1740198059bd05c319) osqp: pass version
* [`f5462ca3`](https://github.com/NixOS/nixpkgs/commit/f5462ca33320cad7b9bb5052585395669840fa66) casadi: 3.7.0 -> 3.7.1
* [`838a7bde`](https://github.com/NixOS/nixpkgs/commit/838a7bde50103c2622d47099863005ecf8527b82) python313: 3.13.5 -> 3.13.6
* [`e31f1054`](https://github.com/NixOS/nixpkgs/commit/e31f105463f586b97bfd716438ab4a48fa999b9d) simple-completion-language-server: 0-unstable-2025-01-31 -> 0-unstable-2025-07-29
* [`607aeea3`](https://github.com/NixOS/nixpkgs/commit/607aeea392fb7a23ab707761b211f266ba1c7f1f) opencl-headers: 2024.10.24 -> 2025.07.22
* [`0e3b104b`](https://github.com/NixOS/nixpkgs/commit/0e3b104b424ac1a472c2015686411339a5dd9c1f) opencl-clhpp: 2024.10.24 -> 2025.07.22
* [`383c5e5d`](https://github.com/NixOS/nixpkgs/commit/383c5e5dcadc85461668fbab46e6eacbf7379d1c) khronos-ocl-icd-loader: 2024.10.24 -> 2025.07.22
* [`c7eb566c`](https://github.com/NixOS/nixpkgs/commit/c7eb566c4197a26d5721c5f99bd9b800f10abaaf) nixos/grafana: add `prune` option to provision.datasources
* [`c8dd37a4`](https://github.com/NixOS/nixpkgs/commit/c8dd37a4b095c636d2c646d7d295509973ae5b58) nixos/regreet: replace deprecated package attrpath
* [`3dce7f4a`](https://github.com/NixOS/nixpkgs/commit/3dce7f4a77812afd69efcbfe15e5223f98c5c69e) uv: 0.8.4 -> 0.8.6
* [`b0986e89`](https://github.com/NixOS/nixpkgs/commit/b0986e899d5dc8863fd8efc5eb0f66a238ecfcae) gn: merge generic and package
* [`c45027f5`](https://github.com/NixOS/nixpkgs/commit/c45027f5d605eb08260ceb0b9f38d80afa3cf1c9) httptoolkit-server: 1.20.1 -> 1.22.0
* [`4ecbc7a0`](https://github.com/NixOS/nixpkgs/commit/4ecbc7a0c1f85aaa610a26c043856d365e7db0c0) httptoolkit: 1.20.1 -> 1.22.0
* [`5d7c4dfa`](https://github.com/NixOS/nixpkgs/commit/5d7c4dfa66f56ae9ff56ac913fedd51ebc73c9fe) ruff: 0.12.5 -> 0.12.8
* [`2b25cc96`](https://github.com/NixOS/nixpkgs/commit/2b25cc96eacdc9966ef53f7b110be9bd602b26ad) certigo: 1.16.0 -> 1.17.1
* [`e02db034`](https://github.com/NixOS/nixpkgs/commit/e02db034031594c422fdcb517d5b5658a1f6e9bb) libcamera: 0.5.1 -> 0.5.2
* [`b5f54856`](https://github.com/NixOS/nixpkgs/commit/b5f54856b4521bf07d25e86bc90a21e25f28e1af) actual-server: 25.7.1 -> 25.8.0
* [`5fd354ed`](https://github.com/NixOS/nixpkgs/commit/5fd354ed409d7022b0457d0e8e35eb68ac70a217) cypress: 14.5.3 -> 14.5.4
* [`5e3fae19`](https://github.com/NixOS/nixpkgs/commit/5e3fae1957fe888008ff2ff5722b8b151a14e9e0) odin: dev-2025-07 -> dev-2025-08
* [`7c496be4`](https://github.com/NixOS/nixpkgs/commit/7c496be46df8ad580ab67e84d9228216ff935a6b) ols: 0-unstable-2025-06-05 -> 0-unstable-2025-08-08
* [`93bea48e`](https://github.com/NixOS/nixpkgs/commit/93bea48e4ca3b1652689624a392cc7d07e1aa829) fex: 2507.1 -> 2508.1
* [`580c7670`](https://github.com/NixOS/nixpkgs/commit/580c7670a682000d93bffa74341b42eaae5ff447) osl: 1.14.6.0 -> 1.14.7.0
* [`051ca9b2`](https://github.com/NixOS/nixpkgs/commit/051ca9b296b100386b7d3c6431de62c19d849cad) maintainers: add t-monaghan
* [`92d23e02`](https://github.com/NixOS/nixpkgs/commit/92d23e02622b3f15919cc3081b3943dac26c9dec) sesh: add t-monaghan to maintainers
* [`41205c0e`](https://github.com/NixOS/nixpkgs/commit/41205c0e6c894e01be1958b323eb015f95076caf) util-linux: apply patch unconditionally
* [`1abb38d2`](https://github.com/NixOS/nixpkgs/commit/1abb38d2a5489a22b1126245650c14bca4eaf65a) linux: use consistent rustc and rust-bindgen
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
