### PR TITLE
niv home-manager: update c613ac14 -> 9e3a33c0

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -65,10 +65,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c613ac14f5600033bf84ae75c315d5ce24a0229b",
-        "sha256": "0ab1n93ik300grac5b5pinvpx3nn1dnwchxpcyamb5676grzdc5k",
+        "rev": "9e3a33c0bcbc25619e540b9dfea372282f8a9740",
+        "sha256": "09xg976ss7nimrd5nla0wx12k6k9h7rx42ww7vfx0z07pvkbfn17",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/c613ac14f5600033bf84ae75c315d5ce24a0229b.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/9e3a33c0bcbc25619e540b9dfea372282f8a9740.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@c613ac14...9e3a33c0](https://github.com/nix-community/home-manager/compare/c613ac14f5600033bf84ae75c315d5ce24a0229b...9e3a33c0bcbc25619e540b9dfea372282f8a9740)

* [`589efcf9`](https://github.com/nix-community/home-manager/commit/589efcf9c039db9dbc9410d53cf722d9e483dfd3) maintainers: add gauthsvenkat
* [`8af2e064`](https://github.com/nix-community/home-manager/commit/8af2e064f93234ee79df8b9858eeefbf84394488) satty: add satty to program modules
* [`0e0a16b3`](https://github.com/nix-community/home-manager/commit/0e0a16b342bcd435ad83c62f4794ce1a4ccff0ea) anyrun: minor description fix
* [`a9c81dbc`](https://github.com/nix-community/home-manager/commit/a9c81dbcc4d6f4777f11a5eadc45c8cf5501c8e5) sherlock: use `X-Restart-Triggers` instead of `onChange`
* [`dd026d86`](https://github.com/nix-community/home-manager/commit/dd026d86420781e84d0732f2fa28e1c051117b59) sherlock: add `74k1` as maintainer
* [`c2977f8b`](https://github.com/nix-community/home-manager/commit/c2977f8bca62a38ba42fea88a85f67e09d8ffcb2) Add translation using Weblate (Hebrew)
* [`3c3510e6`](https://github.com/nix-community/home-manager/commit/3c3510e61ca5c15a0f13d73c2232fa2d5478a86c) programs/nix-search-tv: add quotes
* [`282b4c98`](https://github.com/nix-community/home-manager/commit/282b4c98de97da6667cb03de4f427371734bc39c) blueman-applet: Add option to change systemd targets ([nix-community/home-manager⁠#7702](https://togithub.com/nix-community/home-manager/issues/7702))
* [`e6422763`](https://github.com/nix-community/home-manager/commit/e6422763eb4594099a889d05304c3cfd06e47c8f) Translate using Weblate (Hebrew)
* [`56b87499`](https://github.com/nix-community/home-manager/commit/56b87499874d16c43f4a732084650cb50b048f15) rclone: modularize subtests
* [`3001400e`](https://github.com/nix-community/home-manager/commit/3001400e9ff29ec5e6d81d82dc3865d3df7254aa) rclone: move activation script to systemd service
* [`6911d3e7`](https://github.com/nix-community/home-manager/commit/6911d3e7f475f7b3558b4f5a6aba90fa86099baa) nix-gc: rename frequency to dates
* [`8b55a6ac`](https://github.com/nix-community/home-manager/commit/8b55a6ac58b678199e5bba701aaff69e2b3281c0) nix-gc: remove unnecessary toString
* [`9e3a33c0`](https://github.com/nix-community/home-manager/commit/9e3a33c0bcbc25619e540b9dfea372282f8a9740) Translate using Weblate (Faroese)
