### PR TITLE
niv emacs-overlay: update 4ed6313a -> 226b43dd

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -41,10 +41,10 @@
         "homepage": "",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "4ed6313ad6f2e7ed940143096808085c44028afa",
-        "sha256": "0sm6mzx0i7rlrcns5a8cn6bjsli4iazmgcc95kwfs33b4rn34cg9",
+        "rev": "226b43dd8907c28899c02527e27ca5961f96a064",
+        "sha256": "0jsa26vy90qr3p2i0v0v040rj7sap8ri752ra5mn8q6cvgf26sgj",
         "type": "tarball",
-        "url": "https://github.com/nix-community/emacs-overlay/archive/4ed6313ad6f2e7ed940143096808085c44028afa.tar.gz",
+        "url": "https://github.com/nix-community/emacs-overlay/archive/226b43dd8907c28899c02527e27ca5961f96a064.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "fast-syntax-highlighting": {


### PR DESCRIPTION
## Changelog for emacs-overlay:
Branch: master
Commits: [nix-community/emacs-overlay@4ed6313a...226b43dd](https://github.com/nix-community/emacs-overlay/compare/4ed6313ad6f2e7ed940143096808085c44028afa...226b43dd8907c28899c02527e27ca5961f96a064)

* [`b48c03cf`](https://github.com/nix-community/emacs-overlay/commit/b48c03cf85580c7996ce59ee149a7bdcddcdc503) Updated nongnu
* [`4175315b`](https://github.com/nix-community/emacs-overlay/commit/4175315b099e1adb444de2610d712921446bb6da) Updated elpa
* [`728c49d9`](https://github.com/nix-community/emacs-overlay/commit/728c49d97ecd4f0af3835b09c9d60b4f20f69ca4) Updated emacs
* [`b7b0edd2`](https://github.com/nix-community/emacs-overlay/commit/b7b0edd24abbdd05fde75c80d59001c9fd9b5598) Updated melpa
* [`c9975f40`](https://github.com/nix-community/emacs-overlay/commit/c9975f4091f29354e372e6b654d225294d214137) Updated flake inputs
* [`70daf116`](https://github.com/nix-community/emacs-overlay/commit/70daf11699abf34753629cb88ffaeef1198277f8) Updated nongnu
* [`6c6e3715`](https://github.com/nix-community/emacs-overlay/commit/6c6e3715bc2799c2f016ab191b71066e5a1d0528) Updated melpa
* [`a2c4e31c`](https://github.com/nix-community/emacs-overlay/commit/a2c4e31c1f77ddc72342af1ab4f90847d46e1cc6) Updated emacs
* [`748227ef`](https://github.com/nix-community/emacs-overlay/commit/748227ef471bb95363a0e86ca04083bb98eb0627) Updated nongnu
* [`c7fdb7d6`](https://github.com/nix-community/emacs-overlay/commit/c7fdb7d668eceb3e3d96ccc7e5459f651256fd0c) Updated elpa
* [`ab168974`](https://github.com/nix-community/emacs-overlay/commit/ab168974831d4ef27fa4cbdc11396d2f8427abd8) Updated emacs
* [`eb9539b6`](https://github.com/nix-community/emacs-overlay/commit/eb9539b615cfe3d5871baf6d78303033e3f31b86) Updated melpa
* [`a63bd8d2`](https://github.com/nix-community/emacs-overlay/commit/a63bd8d267777776bb1ddb5eed3419210b8d768a) Updated melpa
* [`eae92963`](https://github.com/nix-community/emacs-overlay/commit/eae92963de9d6cc715993a479bf7d9c097110264) Updated elpa
* [`e5c1eb0d`](https://github.com/nix-community/emacs-overlay/commit/e5c1eb0df9c698c9356da00fcc01001bc2421806) Updated melpa
* [`7ee9a6e8`](https://github.com/nix-community/emacs-overlay/commit/7ee9a6e8993ebf33e56cd02aab0ec80cfe16df64) Updated emacs
* [`541f4e57`](https://github.com/nix-community/emacs-overlay/commit/541f4e57412ef5faa7dbc9d3312ce104cd616034) Updated nongnu
* [`e2605be2`](https://github.com/nix-community/emacs-overlay/commit/e2605be20a68d8d72e6879c8b0522ee16fad0acf) Updated elpa
* [`d9d697c8`](https://github.com/nix-community/emacs-overlay/commit/d9d697c855f533f2d523299f89d8286e87f6e5d8) Updated emacs
* [`2ef1f8b3`](https://github.com/nix-community/emacs-overlay/commit/2ef1f8b3080bb8753bcfca3733cc4b7219261dcd) Updated melpa
* [`3904086a`](https://github.com/nix-community/emacs-overlay/commit/3904086aa9fd95a3329f21bf78a0ca837d9ff9ef) Updated nongnu
* [`55b38132`](https://github.com/nix-community/emacs-overlay/commit/55b381328e9133c57f7ed010184471dcbd374227) Updated elpa
* [`3a132ebe`](https://github.com/nix-community/emacs-overlay/commit/3a132ebef10f47d8bf916f1552301d7fb03816b9) Updated emacs
* [`2df87ae7`](https://github.com/nix-community/emacs-overlay/commit/2df87ae7b3909cd4c3e0c8269989599f100a0f30) Updated melpa
* [`d04f1a9d`](https://github.com/nix-community/emacs-overlay/commit/d04f1a9d416694d2227c06ee12e2fb8d0260fd0a) Updated nongnu
* [`b7a1ede5`](https://github.com/nix-community/emacs-overlay/commit/b7a1ede556c97d41c9d028f48b7de35580c07e59) Updated elpa
* [`ecd03e89`](https://github.com/nix-community/emacs-overlay/commit/ecd03e89863c0cfa994355905ee2e7497a06ef3c) Updated emacs
* [`dc8f6950`](https://github.com/nix-community/emacs-overlay/commit/dc8f6950b1d59a7275b7ab3a275ca43cf8632a2e) Updated melpa
* [`8aebf2a9`](https://github.com/nix-community/emacs-overlay/commit/8aebf2a959f8cd1bff7489e002de5565c83f8307) Updated flake inputs
* [`d55830b9`](https://github.com/nix-community/emacs-overlay/commit/d55830b972dfbbb6e1a01a5e886abb8bceb7c4bf) Updated nongnu
* [`a195eb43`](https://github.com/nix-community/emacs-overlay/commit/a195eb43aaa011e264b8df0d450c36b4ca5c8cd2) Updated elpa
* [`a8c18a3f`](https://github.com/nix-community/emacs-overlay/commit/a8c18a3f130ec05774b741318d47caa375b34ad1) Updated emacs
* [`ea37d730`](https://github.com/nix-community/emacs-overlay/commit/ea37d7305404538ce26f1dbf26c32f32678a9e7c) Updated melpa
* [`bf5f6ffc`](https://github.com/nix-community/emacs-overlay/commit/bf5f6ffceac1e758ea096c0a036555f322606367) Updated nongnu
* [`ba878501`](https://github.com/nix-community/emacs-overlay/commit/ba8785013fa36610f4559343cdbf42122ba3c91e) Updated elpa
* [`46465925`](https://github.com/nix-community/emacs-overlay/commit/46465925bd5c40ec2c64151736d94bae305ffb49) Updated melpa
* [`a9a66708`](https://github.com/nix-community/emacs-overlay/commit/a9a667084c0cf89081842d3002aef7b4829980aa) Updated emacs
* [`637fc597`](https://github.com/nix-community/emacs-overlay/commit/637fc597773051bf2eaf3760009c5629a2a7449d) Updated elpa
* [`4c14abae`](https://github.com/nix-community/emacs-overlay/commit/4c14abae6235cb18ebcc4131c805d56a60fc90fc) Updated melpa
* [`8aec6211`](https://github.com/nix-community/emacs-overlay/commit/8aec6211de0ee48f1435727077e1fad5cfb9e97e) Updated emacs
* [`373932b6`](https://github.com/nix-community/emacs-overlay/commit/373932b6cfa1697b2c45a2cb60c41ce0e66f15b3) Updated elpa
* [`f70ec008`](https://github.com/nix-community/emacs-overlay/commit/f70ec00832c6bbd8b0103db14f1ef0cdbccefb03) Updated emacs
* [`3b40bb2e`](https://github.com/nix-community/emacs-overlay/commit/3b40bb2e104b70d8c5985bf16d1e1bf1e81371a4) Updated melpa
* [`16df9c01`](https://github.com/nix-community/emacs-overlay/commit/16df9c01c4ffcf630ac558f62e52b96984ab48e7) Updated emacs
* [`c5a84597`](https://github.com/nix-community/emacs-overlay/commit/c5a84597e793a99636c36597db270fb61b812505) Updated melpa
* [`5190f992`](https://github.com/nix-community/emacs-overlay/commit/5190f992f7394e678ce237dfa9775bb42cbf531b) Updated elpa
* [`2c22a6da`](https://github.com/nix-community/emacs-overlay/commit/2c22a6da1ce7b317b9f21d21ce042046c63592f7) Updated emacs
* [`b06a3530`](https://github.com/nix-community/emacs-overlay/commit/b06a3530c28a876a14b5525bd45ddb283e0bb6a0) Updated melpa
* [`b721acd6`](https://github.com/nix-community/emacs-overlay/commit/b721acd611b36383b2b925c071dcc9f61713f0a5) Updated nongnu
* [`5fbbd096`](https://github.com/nix-community/emacs-overlay/commit/5fbbd096b6b21abe7a2cfb3f39f4ef2171cadab0) Updated elpa
* [`04ec165c`](https://github.com/nix-community/emacs-overlay/commit/04ec165c91c2fbe9026dd02a191638a325a18331) Updated melpa
* [`71fa26b1`](https://github.com/nix-community/emacs-overlay/commit/71fa26b129fae935b173310057f4dfedce3474f0) Updated melpa
* [`364f261a`](https://github.com/nix-community/emacs-overlay/commit/364f261a0cad0646d6faf2965d29bc75fc509bcc) Updated emacs
* [`f7404f87`](https://github.com/nix-community/emacs-overlay/commit/f7404f8720f954164cd027990263b09fd752d7b2) Updated flake inputs
* [`ef147d2e`](https://github.com/nix-community/emacs-overlay/commit/ef147d2ef78a96d66c22536d943455dd4fb09b3a) Updated nongnu
* [`57488635`](https://github.com/nix-community/emacs-overlay/commit/57488635b02cb24d4899a5a64003ea43070f6c84) Updated melpa
* [`735ea15f`](https://github.com/nix-community/emacs-overlay/commit/735ea15fb7a3b808c622734203b2692fc32374f0) Updated emacs
* [`eb8dadef`](https://github.com/nix-community/emacs-overlay/commit/eb8dadef0345ad3b05fcd190c702205f7b89d0a8) Updated nongnu
* [`98c154af`](https://github.com/nix-community/emacs-overlay/commit/98c154afbeb0379120faed0b011d07ed7e84cc7f) Updated elpa
* [`2bd6c82a`](https://github.com/nix-community/emacs-overlay/commit/2bd6c82a33abb153d21cd8ffac30bf10b5175186) Updated emacs
* [`a27abb50`](https://github.com/nix-community/emacs-overlay/commit/a27abb508a1c7f7768bd6eaeb3077dc6a47aaabf) Updated melpa
* [`a1a215bb`](https://github.com/nix-community/emacs-overlay/commit/a1a215bb6e346786dce58b6296bfd8a0eb2dc26f) Updated emacs
* [`1fa76891`](https://github.com/nix-community/emacs-overlay/commit/1fa7689126b0d1f2182f673e91bdb8ad332b670d) Updated nongnu
* [`1675a48a`](https://github.com/nix-community/emacs-overlay/commit/1675a48a03a89688d1ba72d4d2faea6d30f17f57) Updated elpa
* [`fd7af51d`](https://github.com/nix-community/emacs-overlay/commit/fd7af51d5a242bcea9ac1c8b0a4d57e0e8089893) Updated emacs
* [`19243a23`](https://github.com/nix-community/emacs-overlay/commit/19243a2335c4df92a2c7cc34bef8a1a3e1210c1b) Updated melpa
* [`1e300f73`](https://github.com/nix-community/emacs-overlay/commit/1e300f736c857fcd0d06d73ea7a3f1cb0d08dc7a) Updated nongnu
* [`e8d74af1`](https://github.com/nix-community/emacs-overlay/commit/e8d74af1d18b3bcdf049871d4cc37a480a38a6b9) Updated elpa
* [`ebdcc673`](https://github.com/nix-community/emacs-overlay/commit/ebdcc6731597eb4546a76c4418ff89efcc51d114) Updated emacs
* [`c5aea461`](https://github.com/nix-community/emacs-overlay/commit/c5aea4616a2c482eb3f1765f90de9771ba1d134a) Updated melpa
* [`0833d9a8`](https://github.com/nix-community/emacs-overlay/commit/0833d9a869e3162bd8baede2c919f736e6b90991) Updated emacs
* [`9dffdb70`](https://github.com/nix-community/emacs-overlay/commit/9dffdb70d5a10e15a9d65f9bb038926a25e8839b) Updated melpa
* [`538d8c3c`](https://github.com/nix-community/emacs-overlay/commit/538d8c3c8f58aaf0b843496f54ee569113466ad3) Updated nongnu
* [`edf36b81`](https://github.com/nix-community/emacs-overlay/commit/edf36b816e5e0a209727ffc402f0501264ada1bb) Updated elpa
* [`ed671f0a`](https://github.com/nix-community/emacs-overlay/commit/ed671f0ab0ff0c782cf391a4a7c9515d7fbd4d7e) Updated emacs
* [`d2307906`](https://github.com/nix-community/emacs-overlay/commit/d23079069762b731ba233d5ab2f72ab1bfa179e3) Updated melpa
* [`730f32dd`](https://github.com/nix-community/emacs-overlay/commit/730f32dd4f55814fd7f931a0b9d732aa995889b5) Updated nongnu
* [`c684c5f0`](https://github.com/nix-community/emacs-overlay/commit/c684c5f057409a42d83c45ce161781e91e5520a7) Updated elpa
* [`8cce3e86`](https://github.com/nix-community/emacs-overlay/commit/8cce3e86d0eb14d8c264c957262934ec4f784249) Updated melpa
* [`77eaa0a0`](https://github.com/nix-community/emacs-overlay/commit/77eaa0a0645978d25309a70da33e40e24ee56f01) Updated emacs
* [`49317d9e`](https://github.com/nix-community/emacs-overlay/commit/49317d9eecf37825a7fdf2f98283ac357860e8cc) Updated flake inputs
* [`0561a59b`](https://github.com/nix-community/emacs-overlay/commit/0561a59b3a80de47fd6617152fac9eaec3712a58) Updated emacs
* [`a8f1ef39`](https://github.com/nix-community/emacs-overlay/commit/a8f1ef391d688e3287095e44589278381756bea7) Updated melpa
* [`e47193da`](https://github.com/nix-community/emacs-overlay/commit/e47193da5fe16bd776128200110229a4dc829caf) Updated nongnu
* [`9db61ba5`](https://github.com/nix-community/emacs-overlay/commit/9db61ba5f807bc2fccabc4eab568ebd0c96e86b3) Updated elpa
* [`dd8fa902`](https://github.com/nix-community/emacs-overlay/commit/dd8fa9020d078fc96ff0dd4c1a7bff14b19aee62) Updated melpa
* [`fe338276`](https://github.com/nix-community/emacs-overlay/commit/fe338276cb7724b0dc6adba92a1b8dda874ad25e) Updated nongnu
* [`c9f73717`](https://github.com/nix-community/emacs-overlay/commit/c9f73717ad385de42dc6b64b5a2de6f5a9916a10) Updated elpa
* [`6d0695fb`](https://github.com/nix-community/emacs-overlay/commit/6d0695fbc0800c0d9073db9cf52294179ee2aa3c) Updated elpa
* [`d32a2fb3`](https://github.com/nix-community/emacs-overlay/commit/d32a2fb3bfe51a24e0c261d402c606c99aae8a5b) Updated nongnu
* [`bf8458fc`](https://github.com/nix-community/emacs-overlay/commit/bf8458fce92d173ee248fa17a0b804b38ef1b861) Updated elpa
* [`045d03da`](https://github.com/nix-community/emacs-overlay/commit/045d03dacf4caee93d07dd728d511aa13dd20826) Updated emacs
* [`8916044b`](https://github.com/nix-community/emacs-overlay/commit/8916044b55506a9b05b7c681ac864b302d867b34) Updated melpa
* [`2f6387de`](https://github.com/nix-community/emacs-overlay/commit/2f6387de30ef597cd78e69cec7765b6500f7b9dc) Updated emacs
* [`c78dc0e6`](https://github.com/nix-community/emacs-overlay/commit/c78dc0e6f53e072f114196be4fdda2a081fb7805) Updated melpa
* [`bbc03ad7`](https://github.com/nix-community/emacs-overlay/commit/bbc03ad73a3794daa65d77beeb762466cd336e55) Updated nongnu
* [`fe7a7818`](https://github.com/nix-community/emacs-overlay/commit/fe7a78181e94f164b7959e409dda78e21459e681) Updated elpa
* [`447bb49a`](https://github.com/nix-community/emacs-overlay/commit/447bb49a7d70e3e8a601239ec3f790eb9a0bc08f) Updated melpa
* [`a86865a7`](https://github.com/nix-community/emacs-overlay/commit/a86865a7014f4e91cdf045177fd57ab917972f73) Updated emacs
* [`d45009ca`](https://github.com/nix-community/emacs-overlay/commit/d45009cae1a50440b5ca2480edaa9f9450110300) Updated nongnu
* [`7b07a44e`](https://github.com/nix-community/emacs-overlay/commit/7b07a44e1c655561cb20e64db2566dc3ba38f270) Updated elpa
* [`f9cda441`](https://github.com/nix-community/emacs-overlay/commit/f9cda441c7588de556bc2b4344d281a62cb25644) Updated melpa
* [`2376e541`](https://github.com/nix-community/emacs-overlay/commit/2376e54195ed3e9770c9943ec744fdb937977dab) Updated emacs
* [`c939170e`](https://github.com/nix-community/emacs-overlay/commit/c939170e1c6a20912966030fb32d65740c296d39) Updated melpa
* [`7811f003`](https://github.com/nix-community/emacs-overlay/commit/7811f003d2cf575cf8f6e5b755055e73b1ac5e17) Updated flake inputs
* [`1be91d12`](https://github.com/nix-community/emacs-overlay/commit/1be91d128824aa1039fe82b79f2fc83bdd2c471e) Updated nongnu
* [`5e2c1e74`](https://github.com/nix-community/emacs-overlay/commit/5e2c1e74b6433249ef8f0065b4e730f8bb7241de) Updated elpa
* [`f350d990`](https://github.com/nix-community/emacs-overlay/commit/f350d990a97c3ed060d028a193dde02f6ec2bc39) Updated emacs
* [`f6151862`](https://github.com/nix-community/emacs-overlay/commit/f6151862155f7bb5e21b7682bc89905a8f188da2) Updated melpa
* [`48df22b8`](https://github.com/nix-community/emacs-overlay/commit/48df22b83ebf2645e3ca6c0c773847a1e09f316b) Updated nongnu
* [`5125ae83`](https://github.com/nix-community/emacs-overlay/commit/5125ae83bc49f9c97ac403c568a044a06c394279) Updated elpa
* [`6232e87e`](https://github.com/nix-community/emacs-overlay/commit/6232e87e90334db949b2f52667b7e6c657bcb5dd) Updated emacs
* [`fed28056`](https://github.com/nix-community/emacs-overlay/commit/fed2805613ce5968e4a175472eb86ad36e45e516) Updated melpa
* [`21dcd69f`](https://github.com/nix-community/emacs-overlay/commit/21dcd69f358b3f829b283fbfd5aa59fd4a02cc44) Updated elpa
* [`daec74a9`](https://github.com/nix-community/emacs-overlay/commit/daec74a940365c90b9f23658a4ea54d5bbd361e8) Updated melpa
* [`93b4d290`](https://github.com/nix-community/emacs-overlay/commit/93b4d290691b68c068df845463c33e9fabf640fd) Updated emacs
* [`6117b4f6`](https://github.com/nix-community/emacs-overlay/commit/6117b4f6b99b91eab916d65d9d1052f120bc2662) Updated nongnu
* [`57c9a0b8`](https://github.com/nix-community/emacs-overlay/commit/57c9a0b8665251aefe63b9a368ce8781b762e3e7) Updated elpa
* [`01b78d12`](https://github.com/nix-community/emacs-overlay/commit/01b78d1212108acb7bc4e0676ec55736e46ba682) Updated emacs
* [`d94f174b`](https://github.com/nix-community/emacs-overlay/commit/d94f174b22b302c90f25e572fb187f4e2b877a17) Updated melpa
* [`696652cd`](https://github.com/nix-community/emacs-overlay/commit/696652cd29de0dbcdc55e61c37d4381a7de51b09) Updated melpa
* [`55068c4e`](https://github.com/nix-community/emacs-overlay/commit/55068c4e5545a8a9ab810ecb03a9452e1859a5ae) Updated flake inputs
* [`cc462418`](https://github.com/nix-community/emacs-overlay/commit/cc462418110f6f2464a783a1abc44ccc02539e95) Updated nongnu
* [`417a856b`](https://github.com/nix-community/emacs-overlay/commit/417a856bfc786852f30897c5fb4bf46c34a458b1) Updated elpa
* [`f5cc754a`](https://github.com/nix-community/emacs-overlay/commit/f5cc754af9a1857366a10171a05b208fab5b46e0) Updated melpa
* [`c605ab6f`](https://github.com/nix-community/emacs-overlay/commit/c605ab6f57a308ab7d8cc1c29ca9ca63d9a11edf) Updated emacs
* [`871aa612`](https://github.com/nix-community/emacs-overlay/commit/871aa612988ba3de7008c9ce9e5a651a786e36e5) Updated nongnu
* [`9c6bf713`](https://github.com/nix-community/emacs-overlay/commit/9c6bf7130e93a95ddc480d5efa41fd99ee69db15) Updated elpa
* [`49c623d7`](https://github.com/nix-community/emacs-overlay/commit/49c623d71fbbace5ee943e60168fbc2e0b998966) Updated melpa
* [`bc7321cd`](https://github.com/nix-community/emacs-overlay/commit/bc7321cdb9b2195f25217fdc534b893c3a96311a) Updated melpa
* [`44876fb8`](https://github.com/nix-community/emacs-overlay/commit/44876fb8febcbd38ca4532f1e580a8fbfbb72e46) Updated emacs
* [`e2d0d7f2`](https://github.com/nix-community/emacs-overlay/commit/e2d0d7f208d393fdb771092fe4a3fbbf370b3b72) Updated elpa
* [`b00018af`](https://github.com/nix-community/emacs-overlay/commit/b00018aff6a4b815e2019a14036650b181cd2591) Updated nongnu
* [`bd9469f5`](https://github.com/nix-community/emacs-overlay/commit/bd9469f5e562c167d76629efc22c219004775ae1) Updated elpa
* [`4fcd9742`](https://github.com/nix-community/emacs-overlay/commit/4fcd9742919db1ad8c5afdcadad316583b650889) Updated melpa
* [`308e67fd`](https://github.com/nix-community/emacs-overlay/commit/308e67fd713f17b56507cad565937179ab19b6ca) Updated emacs
* [`8896fe82`](https://github.com/nix-community/emacs-overlay/commit/8896fe8207ae222e0ca478d45a09625773ec8671) Updated melpa
* [`d7798c55`](https://github.com/nix-community/emacs-overlay/commit/d7798c553a703f458b1456468d5901a88e337a54) Updated nongnu
* [`2e3de5c6`](https://github.com/nix-community/emacs-overlay/commit/2e3de5c6247ea4c446cf2f20a1fae49c1e9480fc) Updated elpa
* [`d9efeb5d`](https://github.com/nix-community/emacs-overlay/commit/d9efeb5d2b55d013b18e07117f9af155fe70efcc) Updated melpa
* [`5d7b6b2d`](https://github.com/nix-community/emacs-overlay/commit/5d7b6b2d78415c0bcc19e3e651b0ec997a9acbad) Updated emacs
* [`3d761ff4`](https://github.com/nix-community/emacs-overlay/commit/3d761ff45ac9c07aaf665e8a6210f0d5c3cd0779) Updated nongnu
* [`25c5b039`](https://github.com/nix-community/emacs-overlay/commit/25c5b0394805ad5fc3416afc722c23e61037abc8) Updated elpa
* [`f57fabee`](https://github.com/nix-community/emacs-overlay/commit/f57fabeeef73658eaac452697d95ff00bd1f4694) Updated melpa
* [`1862d841`](https://github.com/nix-community/emacs-overlay/commit/1862d841acdb7425cf2ab6d0c8200bb1447dac45) Updated emacs
* [`b7e25dfc`](https://github.com/nix-community/emacs-overlay/commit/b7e25dfc00eeaff5a7c6f2c4fd2213f9b42428ef) Updated melpa
* [`382428e9`](https://github.com/nix-community/emacs-overlay/commit/382428e9af7df6b10ad9caefcad0ca8322d5e352) Updated nongnu
* [`2881db6b`](https://github.com/nix-community/emacs-overlay/commit/2881db6b1f9da926de98637cc821e3ca7c28dcfc) Updated nongnu
* [`c0104f37`](https://github.com/nix-community/emacs-overlay/commit/c0104f3788064e999c4b3a60516f98126164fc1a) Updated elpa
* [`fb702bca`](https://github.com/nix-community/emacs-overlay/commit/fb702bca614129012bab74a1621cead9d4d5faf4) Updated emacs
* [`c67dd16b`](https://github.com/nix-community/emacs-overlay/commit/c67dd16b807bc8089f5bacc9480c97ea89f973b3) Updated melpa
* [`d464f257`](https://github.com/nix-community/emacs-overlay/commit/d464f257f66ebcd24aa286eb54b9a90d4775a1e0) Updated elpa
* [`c4161142`](https://github.com/nix-community/emacs-overlay/commit/c4161142c743857dc0df81e62c91d11e8d9378e8) Updated melpa
* [`df1e0259`](https://github.com/nix-community/emacs-overlay/commit/df1e0259cd03c65ba9f08a8173106c49cc7b98fe) Updated emacs
* [`d4c63b61`](https://github.com/nix-community/emacs-overlay/commit/d4c63b61672ced2efa7af225f36bb0453fb7b558) Updated nongnu
* [`95165973`](https://github.com/nix-community/emacs-overlay/commit/95165973bbdf124e3086f8d4c8a9fca8491a64b6) Updated elpa
* [`c6613c13`](https://github.com/nix-community/emacs-overlay/commit/c6613c134b4140f1c96f2da095f80e08d2b28a41) Updated melpa
* [`988cd961`](https://github.com/nix-community/emacs-overlay/commit/988cd9611f47a1c2acff1e9a1bc6b7ace4e1c884) Updated flake inputs
* [`6df759a2`](https://github.com/nix-community/emacs-overlay/commit/6df759a268d3c38cf5182a3aec98735bb9fc73c8) Updated elpa
* [`40493389`](https://github.com/nix-community/emacs-overlay/commit/404933899705192fd19225fa4be4d36404c505f5) Updated emacs
* [`69f77500`](https://github.com/nix-community/emacs-overlay/commit/69f77500f06ee7f2e59cb9f2d9b7f50d2b6ac0b7) Updated melpa
* [`f4a59c08`](https://github.com/nix-community/emacs-overlay/commit/f4a59c089b953ec3f5e8983df6bb946317a36ad9) Updated nongnu
* [`c51b4bec`](https://github.com/nix-community/emacs-overlay/commit/c51b4becdeba996eafe13856ef9276ed63fbafa3) Updated nongnu
* [`6ad93abe`](https://github.com/nix-community/emacs-overlay/commit/6ad93abe00d34c3720c6c50cb55c890be191e713) Updated elpa
* [`5b63476c`](https://github.com/nix-community/emacs-overlay/commit/5b63476c115c9bca5595eb853890c9132099b119) Updated emacs
* [`aa2b75fe`](https://github.com/nix-community/emacs-overlay/commit/aa2b75fea660839482abc3432808afcae5bb2998) Updated melpa
* [`46854f3a`](https://github.com/nix-community/emacs-overlay/commit/46854f3aa55ca95915288e752e67ecdad7a4adcf) Updated emacs
* [`ed45d1a1`](https://github.com/nix-community/emacs-overlay/commit/ed45d1a140ce3e712fff9b6e9e8c09855faacc8e) Updated melpa
* [`c9499389`](https://github.com/nix-community/emacs-overlay/commit/c94993894ffc1c8cc79186ee7ec75aff0386496c) Updated nongnu
* [`04ba6f25`](https://github.com/nix-community/emacs-overlay/commit/04ba6f25aa7f646c7903435ddaaf3dc8048c5221) Updated elpa
* [`ffcbc1b4`](https://github.com/nix-community/emacs-overlay/commit/ffcbc1b4f36021dde45bf2234bfdf2ab7971be68) Updated emacs
* [`016d29b6`](https://github.com/nix-community/emacs-overlay/commit/016d29b671ddce7500e7b7d448259008fe9ad6c3) Updated melpa
* [`6da78fcf`](https://github.com/nix-community/emacs-overlay/commit/6da78fcfcff23bd1205a698376b2e232dd3cccfd) Updated nongnu
* [`2135488c`](https://github.com/nix-community/emacs-overlay/commit/2135488c3adbb010fb3a305c1c430ae8a5a6d6b5) Updated elpa
* [`a3473437`](https://github.com/nix-community/emacs-overlay/commit/a3473437f19dcac71650c90a4ff4cd735079556e) Updated melpa
* [`c536443f`](https://github.com/nix-community/emacs-overlay/commit/c536443f1d592b96267bb3973a17e9ed8693330c) Updated melpa
* [`cae0c030`](https://github.com/nix-community/emacs-overlay/commit/cae0c0305e1e27b0dfaec4bd9f17db5612a7e246) Updated nongnu
* [`e4bb798d`](https://github.com/nix-community/emacs-overlay/commit/e4bb798dabebcacb473c7d9f19dd00b9845f3f03) Updated elpa
* [`a1c9b681`](https://github.com/nix-community/emacs-overlay/commit/a1c9b68194e1262b820c2ab6f92612bb78b45a88) Updated emacs
* [`57d1c7ab`](https://github.com/nix-community/emacs-overlay/commit/57d1c7abf226954672ef6fd46a1c7d598f5661cf) Updated melpa
* [`5203d973`](https://github.com/nix-community/emacs-overlay/commit/5203d97308a655287bcbd78076be433fcae4b228) Updated nongnu
* [`83d0b7bc`](https://github.com/nix-community/emacs-overlay/commit/83d0b7bc8a150c08f27141f7c21fc2fe5ca2ab64) Updated elpa
* [`0d7e7b6f`](https://github.com/nix-community/emacs-overlay/commit/0d7e7b6f2b01d7511d784e1a46daff7339f9b8dc) Updated emacs
* [`c23bf31a`](https://github.com/nix-community/emacs-overlay/commit/c23bf31aade269bebf5b2ed4ce442f5bcabdc52d) Updated melpa
* [`980386b3`](https://github.com/nix-community/emacs-overlay/commit/980386b329df4557265accca44d7cd0805a16b4a) Updated emacs
* [`5c3afeab`](https://github.com/nix-community/emacs-overlay/commit/5c3afeab1a0a913290098a782b485a8e48634a30) Updated melpa
* [`8626bfcb`](https://github.com/nix-community/emacs-overlay/commit/8626bfcbafd429f119a23c0f18ef4ffbdd9f37d5) Updated nongnu
* [`4991be3c`](https://github.com/nix-community/emacs-overlay/commit/4991be3c8ede9978a02904f9d2559511fc0806a1) Updated elpa
* [`e4783894`](https://github.com/nix-community/emacs-overlay/commit/e478389446d1cf56b5bb33f15501248d2c53b136) Updated melpa
* [`45149a7a`](https://github.com/nix-community/emacs-overlay/commit/45149a7a11823b8e730802f514c0399fdab5e32d) Updated emacs
* [`9f303ef4`](https://github.com/nix-community/emacs-overlay/commit/9f303ef429e3a6cf0aabedd007e4ea6398a6f67b) Updated elpa
* [`2a014d1e`](https://github.com/nix-community/emacs-overlay/commit/2a014d1eaec40908ea07fb1822c0f77a8dcbc2e9) Updated emacs
* [`9e3a5b9a`](https://github.com/nix-community/emacs-overlay/commit/9e3a5b9a0c79e66b4a1e2490be606a058a6712fe) Updated melpa
* [`fd440a9e`](https://github.com/nix-community/emacs-overlay/commit/fd440a9e5f980a18270df764ce17facc7a328249) Updated emacs
* [`38f372e2`](https://github.com/nix-community/emacs-overlay/commit/38f372e203d68849c672f3a06bb892e9875f237e) Updated melpa
* [`ba62cc53`](https://github.com/nix-community/emacs-overlay/commit/ba62cc538d20816710ac815e3d79448c1ada62ea) Updated nongnu
* [`2c3341cc`](https://github.com/nix-community/emacs-overlay/commit/2c3341cc0fb268c865bfa1e932b89ec4614f22bd) Updated elpa
* [`05a04760`](https://github.com/nix-community/emacs-overlay/commit/05a04760ee0101d28cf25334e4b3e9654276d50c) Updated emacs
* [`6e64ccc5`](https://github.com/nix-community/emacs-overlay/commit/6e64ccc5fe49ef8bbda0cecb3e281afdb53b3af7) Updated melpa
* [`b2c2b727`](https://github.com/nix-community/emacs-overlay/commit/b2c2b727913631e4e83657daf6cd4e76a0b8a09a) Updated nongnu
* [`fc95ce28`](https://github.com/nix-community/emacs-overlay/commit/fc95ce286d06c08305079493962de94f2bfca910) Updated elpa
* [`2d1971b2`](https://github.com/nix-community/emacs-overlay/commit/2d1971b21f1ca04b4e88bc2c0f4dac15903923ad) Updated emacs
* [`074188fe`](https://github.com/nix-community/emacs-overlay/commit/074188feb9e37d326cbcb0d6815c90182c5789a7) Updated melpa
* [`2742a674`](https://github.com/nix-community/emacs-overlay/commit/2742a67491818ab16da4ffabd9c127a0cae3f507) Updated flake inputs
* [`3cfeca94`](https://github.com/nix-community/emacs-overlay/commit/3cfeca94a7a3d08018fb165cbe71b12d9f477f93) Updated melpa
* [`cf7aaac0`](https://github.com/nix-community/emacs-overlay/commit/cf7aaac09acc0fad9b15d8fe76745396125c0e3e) Updated emacs
* [`73f09ad1`](https://github.com/nix-community/emacs-overlay/commit/73f09ad17753af7637d349ed88652351038bb612) Updated nongnu
* [`650853c4`](https://github.com/nix-community/emacs-overlay/commit/650853c4edcb96f0e567964ad38dbf1fba47695f) Updated elpa
* [`2ff48aaf`](https://github.com/nix-community/emacs-overlay/commit/2ff48aaf3821624e9b2ed088ba1a38a643f59653) Updated emacs
* [`3b3e842c`](https://github.com/nix-community/emacs-overlay/commit/3b3e842cce376e332b0a4606ca18a846fbc49430) Updated melpa
* [`ca74057e`](https://github.com/nix-community/emacs-overlay/commit/ca74057e78c7eaa94e7c830364340e89c96efd86) Updated nongnu
* [`c25de825`](https://github.com/nix-community/emacs-overlay/commit/c25de8251c745da2788a38126665eb648610af2a) Updated elpa
* [`3849e50c`](https://github.com/nix-community/emacs-overlay/commit/3849e50c6fa6573ae7d78627f2c0162e674fc27a) Updated emacs
* [`f4a1a64e`](https://github.com/nix-community/emacs-overlay/commit/f4a1a64e3581bf49791529105ae4b1c664c17072) Updated melpa
* [`fcf35e87`](https://github.com/nix-community/emacs-overlay/commit/fcf35e87032e244e2cf85f1e0fc1c1c26f3400d0) Updated elpa
* [`6203ac91`](https://github.com/nix-community/emacs-overlay/commit/6203ac910f37c7cf7d09bfc92b55d6db0a428723) Updated emacs
* [`a94e89d2`](https://github.com/nix-community/emacs-overlay/commit/a94e89d207acc053fe1e954a68838c67e1f3770f) Updated melpa
* [`e35ef693`](https://github.com/nix-community/emacs-overlay/commit/e35ef69369eb7120c6e6144722e05fd9407fef07) Updated flake inputs
* [`bd5cff74`](https://github.com/nix-community/emacs-overlay/commit/bd5cff74db13473beb87ffa2eee94853f93e4286) Updated nongnu
* [`3ebbd963`](https://github.com/nix-community/emacs-overlay/commit/3ebbd963cdb783d8260219bfcf37b07aeb8ecf0f) Remove `srcRepo` override
* [`656c4043`](https://github.com/nix-community/emacs-overlay/commit/656c40437f2ad596a9f26110d774098d869a96ad) Updated elpa
* [`25ecba3b`](https://github.com/nix-community/emacs-overlay/commit/25ecba3b3ae6620f672066ddc6e568cd09b177e7) Updated emacs
* [`d6459e39`](https://github.com/nix-community/emacs-overlay/commit/d6459e395f0cd9d8673a776728491781083b207a) Updated melpa
* [`c58a057d`](https://github.com/nix-community/emacs-overlay/commit/c58a057db0e2ca21742c7e0e9388f7a6428e370c) fixup! Remove `srcRepo` override
* [`e6284e76`](https://github.com/nix-community/emacs-overlay/commit/e6284e769bcc1beb81b35f56fc0598ad613ac51f) Updated elpa
* [`e4002c05`](https://github.com/nix-community/emacs-overlay/commit/e4002c05c262b1c41681704775d489800d8e3fb6) Updated emacs
* [`452a7694`](https://github.com/nix-community/emacs-overlay/commit/452a76945fd25463c5855a8eb419f0580104cef1) Updated melpa
* [`1385f894`](https://github.com/nix-community/emacs-overlay/commit/1385f894b52be475da89833fb6d1158fea870834) Updated nongnu
* [`ed41a187`](https://github.com/nix-community/emacs-overlay/commit/ed41a1871addef809f6b87845ee6c576e2a23b1a) Updated elpa
* [`792b33fe`](https://github.com/nix-community/emacs-overlay/commit/792b33fe5e6914c3ed0a59c5c543dfa4f63a55d6) Updated melpa
* [`289484e7`](https://github.com/nix-community/emacs-overlay/commit/289484e721d484bda81c5180c9e602d134dcded3) Revert "fixup! Remove `srcRepo` override"
* [`4ed9b132`](https://github.com/nix-community/emacs-overlay/commit/4ed9b1325679a951380c422a3a28498aa566c39f) Revert "Remove `srcRepo` override"
* [`086c17a6`](https://github.com/nix-community/emacs-overlay/commit/086c17a63a666a4a3902799346d2daef2c76b679) Update flake inputs
* [`0f2b1646`](https://github.com/nix-community/emacs-overlay/commit/0f2b16469b0d38a628aff4c215ac1ed2ea3ffa9c) Updated nongnu
* [`228497d1`](https://github.com/nix-community/emacs-overlay/commit/228497d179e680f32879242754c45f82670ddce6) Updated elpa
* [`7c7fe831`](https://github.com/nix-community/emacs-overlay/commit/7c7fe8312c417c20e38f2c2e318203061ceef7f5) Updated melpa
* [`70f78565`](https://github.com/nix-community/emacs-overlay/commit/70f78565e9055b2f39249b7630073d59f8663efb) Updated emacs
* [`81acff4c`](https://github.com/nix-community/emacs-overlay/commit/81acff4c0f1ddfa734fbb145e405d2013c52cb81) Updated nongnu
* [`81148fdf`](https://github.com/nix-community/emacs-overlay/commit/81148fdf7566226833dc07c0d70cabd1d3d53c96) Updated elpa
* [`3e33bb09`](https://github.com/nix-community/emacs-overlay/commit/3e33bb09007a170bb39c2784761170bcc0f3c991) Updated emacs
* [`9ea70e7e`](https://github.com/nix-community/emacs-overlay/commit/9ea70e7ea6d66396f414fc661b1f02ebc27bef8d) Updated melpa
* [`2e4d97a5`](https://github.com/nix-community/emacs-overlay/commit/2e4d97a53a1cd7e5aa28b54dcc86e5e63670edd3) Updated emacs
* [`1c6ba6fb`](https://github.com/nix-community/emacs-overlay/commit/1c6ba6fb3b8a444dec1cbebff0d5914b569b4d24) Updated melpa
* [`134039e3`](https://github.com/nix-community/emacs-overlay/commit/134039e337e85d114e26f9265ba5d113c81f2c98) Updated elpa
* [`b0fbf3b9`](https://github.com/nix-community/emacs-overlay/commit/b0fbf3b96866ef5f0c8976d0cce5c41dedf9de96) Updated emacs
* [`045f679c`](https://github.com/nix-community/emacs-overlay/commit/045f679c6863cd4d1090472933165f264a7dc1db) Updated melpa
* [`21dd1952`](https://github.com/nix-community/emacs-overlay/commit/21dd19528ec602cdb8d219be36967d99b85eebb2) Updated flake inputs
* [`e378c190`](https://github.com/nix-community/emacs-overlay/commit/e378c190fade65df56f34543ece09a4f199c060f) Updated nongnu
* [`fb41a291`](https://github.com/nix-community/emacs-overlay/commit/fb41a291328dafa0a77c221d731f048e4675b823) Updated elpa
* [`4cea6c88`](https://github.com/nix-community/emacs-overlay/commit/4cea6c8843f1fe6d86ea46872a89c4b54220a146) Updated emacs
* [`8f00462d`](https://github.com/nix-community/emacs-overlay/commit/8f00462d59b210314cb3881e01931a65b10ae6e5) Updated melpa
* [`226b43dd`](https://github.com/nix-community/emacs-overlay/commit/226b43dd8907c28899c02527e27ca5961f96a064) Updated nongnu
