### PR TITLE
niv doomemacs: update ed9190ef -> 3e7a20f9

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "",
         "owner": "doomemacs",
         "repo": "doomemacs",
-        "rev": "ed9190ef005829c7a2331e12fb36207794c5ad75",
-        "sha256": "07z707rnw90pjbyxgva0p7fdhhp3crjxc0li333w608h4sdx8kwx",
+        "rev": "3e7a20f972dcbbdf0cda7a30691037b1355a6d11",
+        "sha256": "1kp9y06zaxd143cjdsp6lqb7avjk16zsndyv6533p6wh1xdn23v6",
         "type": "tarball",
-        "url": "https://github.com/doomemacs/doomemacs/archive/ed9190ef005829c7a2331e12fb36207794c5ad75.tar.gz",
+        "url": "https://github.com/doomemacs/doomemacs/archive/3e7a20f972dcbbdf0cda7a30691037b1355a6d11.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "emacs-overlay": {


### PR DESCRIPTION
## Changelog for doomemacs:
Branch: master
Commits: [doomemacs/doomemacs@ed9190ef...3e7a20f9](https://github.com/doomemacs/doomemacs/compare/ed9190ef005829c7a2331e12fb36207794c5ad75...3e7a20f972dcbbdf0cda7a30691037b1355a6d11)

* [`1ac1b70d`](https://github.com/doomemacs/doomemacs/commit/1ac1b70d4e70478297ad3cb40c52c9574c836610) refactor!(tree-sitter): replace tree-sitter w/ treesit
* [`f2678b3e`](https://github.com/doomemacs/doomemacs/commit/f2678b3ea2b3743d6246a3954fb2212b21a9804a) feat(fold): add treesit-fold support
* [`a372eba7`](https://github.com/doomemacs/doomemacs/commit/a372eba7cd58d80aa3d865491d0cda0908feca93) feat(python): add treesit support
* [`7cb23f33`](https://github.com/doomemacs/doomemacs/commit/7cb23f335926283a21c70a0f661e8d783c28e848) feat(markdown): add treesit support
* [`445c9828`](https://github.com/doomemacs/doomemacs/commit/445c9828389ca703a44b55c326c1e338659471b1) feat(ruby): add treesit support
* [`f0024241`](https://github.com/doomemacs/doomemacs/commit/f002424106f3e273022ccbc4768f73cf56342ca7) feat(lua): add treesit support
* [`e6caaef9`](https://github.com/doomemacs/doomemacs/commit/e6caaef9e6071c2d8e51e6e0939788956bb51d26) fix(agda): remove defunct tree-sitter.el support
* [`46b87362`](https://github.com/doomemacs/doomemacs/commit/46b87362f7d4c7aed06e342b47eea1410d655ddf) feat(julia): add treesit support
* [`c403bb5e`](https://github.com/doomemacs/doomemacs/commit/c403bb5e2f77aa1821345d3a76dabbad2c97e314) feat(csharp): add treesit support
* [`1670ce27`](https://github.com/doomemacs/doomemacs/commit/1670ce27679f323282c68a21f6e29eac3cc2532e) feat!(cc): add treesit support
* [`8ac83f46`](https://github.com/doomemacs/doomemacs/commit/8ac83f4600963b74bd8cbd5091df2b56ecfc0f20) fix(indent-guides): treesit support
* [`e0e2c3aa`](https://github.com/doomemacs/doomemacs/commit/e0e2c3aa61c35b36f0972cde7f03af79957084f7) feat(janet): add treesit support
* [`9073b248`](https://github.com/doomemacs/doomemacs/commit/9073b248783e2161a3e2909e23851cf684890813) feat(php): add treesit support
* [`5be0df24`](https://github.com/doomemacs/doomemacs/commit/5be0df24d32fd6278f01de3b9f502144b7c41ad1) docs(csharp,julia,lua,markdown): mention +tree-sitter requirements
* [`8931c489`](https://github.com/doomemacs/doomemacs/commit/8931c48913c625eb734679a363d2307498d095ac) fix(cc): treesit modes not remapped to
* [`2556cb58`](https://github.com/doomemacs/doomemacs/commit/2556cb58f263cbf2c46f62295a751a81c71e31e8) feat(yaml): add treesit support
* [`b5465222`](https://github.com/doomemacs/doomemacs/commit/b5465222573419b8880fd4e442fab4c7274f6c06) docs(tree-sitter): revise doctor output
* [`776da0dc`](https://github.com/doomemacs/doomemacs/commit/776da0dcf18e63cde43a0ddd0015e1678bfb3433) fix(csharp): csharp-ts-mode: side-effects on auto-mode-alist
* [`a329d63f`](https://github.com/doomemacs/doomemacs/commit/a329d63f7db541c5a056f572dbbc8b8b57b5f5c4) fix(tree-sitter): discard COMMIT recipe argument on <=30.x
* [`0c311a51`](https://github.com/doomemacs/doomemacs/commit/0c311a517250262425fafd62d162c0683434c252) feat(elixir): add treesit support
* [`5db361b4`](https://github.com/doomemacs/doomemacs/commit/5db361b4747b6b5dc2b9159dff071a488ce959bb) fix(tree-sitter): remove redundant yaml source
* [`c5dd2847`](https://github.com/doomemacs/doomemacs/commit/c5dd2847ffafd41f4f652983959c491dfbf2e362) feat(scala): add treesit support
* [`f5a1af4b`](https://github.com/doomemacs/doomemacs/commit/f5a1af4bf62be1070c66c797ce8cd423d667bdab) feat(kotlin): add treesit support
* [`7af7280f`](https://github.com/doomemacs/doomemacs/commit/7af7280f9ec1b5543dddf5d5fb32db5f574933ef) feat(json): add treesit support
* [`3b2caa7d`](https://github.com/doomemacs/doomemacs/commit/3b2caa7dcd0380b23fa464e47c91fccee6d2cbd5) feat(docker): add treesit support
* [`9acc5f48`](https://github.com/doomemacs/doomemacs/commit/9acc5f48b6e2d8b8d29a0d5c07a775cc33904116) feat(zig): add treesit support
* [`5b37bfee`](https://github.com/doomemacs/doomemacs/commit/5b37bfee23fdc7e5b800489b29b7dd9470355e98) feat(nix): add treesit support
* [`4df993d6`](https://github.com/doomemacs/doomemacs/commit/4df993d683ec1f228c94c745375a3c48906264fe) fix(tree-sitter): unable to find local grammars
* [`22e03d7e`](https://github.com/doomemacs/doomemacs/commit/22e03d7e9018b1a6252cf1d50f89e27cf5f96cd1) fix(elixir): duplicate auto-mode-alist entries
* [`617d8411`](https://github.com/doomemacs/doomemacs/commit/617d8411e6a1ef5141ac93a1c881c0ef3f081f57) fix(tree-sitter): ignore major-mode-remap-defaults for ts modes
* [`3155fefd`](https://github.com/doomemacs/doomemacs/commit/3155fefd470164e0c5bca4f01f37f5662ba13d30) feat(swift): add treesit support
* [`7c6e1950`](https://github.com/doomemacs/doomemacs/commit/7c6e1950e8d46a2ef904224602ebd7940623657c) feat(go): add treesit support
* [`a287a96a`](https://github.com/doomemacs/doomemacs/commit/a287a96acabf0b701ab13b274e20e50f2d0de015) feat(dart): add treesit support
* [`0d9cf54c`](https://github.com/doomemacs/doomemacs/commit/0d9cf54c842e8e57068a108e8f8815f521ba44c0) refactor(tree-sitter): remove redundant dart grammar
* [`a8ccd2d4`](https://github.com/doomemacs/doomemacs/commit/a8ccd2d47a814aeb5bdcd43f1d7b854e2054ef85) fix(tree-sitter): unable to find local grammars (part 2)
* [`7949d1bf`](https://github.com/doomemacs/doomemacs/commit/7949d1bf274f19c51d4b1799fe8e009b9e272207) fix(tree-sitter): void-variable +tree-sitter--major-mode-remaps-alist
* [`2adbdf13`](https://github.com/doomemacs/doomemacs/commit/2adbdf136061a42b189ba3523e04d1d03089d205) feat(clojure): add treesit support
* [`cf278cab`](https://github.com/doomemacs/doomemacs/commit/cf278cab55511524cdf9f95c05389d45125ffc6b) fix(:term): ensure process-buffer is current
* [`c2c4f74d`](https://github.com/doomemacs/doomemacs/commit/c2c4f74d3e6dc41ac2b4e4e73a589da2d807cf0c) fix(cli): update call using deprecated alias
* [`8b3894a9`](https://github.com/doomemacs/doomemacs/commit/8b3894a94b9dbfb8370f0600717045fb3c539d64) fix(lib): update reference to deprecated alias
* [`7f71924d`](https://github.com/doomemacs/doomemacs/commit/7f71924d3a43dfb0bf2f3f82a2fed561247646e2) fix(cli): update reference to deprecated alias
* [`8d60c982`](https://github.com/doomemacs/doomemacs/commit/8d60c982f32a1fe24e14c5778c08d863244a891b) tweak(file-templates): update dockerfile template
* [`ac530efe`](https://github.com/doomemacs/doomemacs/commit/ac530efe879fd74393afe5b0e4d719c07fa425b0) refactor(latex): reformat code for readability
* [`9219fa7c`](https://github.com/doomemacs/doomemacs/commit/9219fa7c08779a3383476f06437d954a8242cd9c) fix(latex): disable smartparens pairs conflicting with AucTeX
* [`d63a15eb`](https://github.com/doomemacs/doomemacs/commit/d63a15eba76170f06e307012667ae104344b2e20) fix(lsp): shutdown deferral for multiple LSP clients
* [`9b124570`](https://github.com/doomemacs/doomemacs/commit/9b1245708b6412ff120fa0d4dbae3434e02b679c) fix(:term): type error if comint-last-output-start is nil
* [`2c18b61c`](https://github.com/doomemacs/doomemacs/commit/2c18b61c9988dfaf182da4f13b31de6a09e3d013) feat(lib): set-frame-opacity: add FRAMES argument
* [`e3299d93`](https://github.com/doomemacs/doomemacs/commit/e3299d9359a78006f7ea2cadab18622779be301d) release(modules): 25.09.0-dev
* [`09e5bc9e`](https://github.com/doomemacs/doomemacs/commit/09e5bc9ecc472f3680d40454062e7295318ac468) bump: :tools
* [`a9b61258`](https://github.com/doomemacs/doomemacs/commit/a9b61258f5213b833a3d20113cc675b79ed78c49) bump: :editor
* [`708cf08a`](https://github.com/doomemacs/doomemacs/commit/708cf08a74c89a70ba41a75e2364f32aab665903) bump: :app
* [`a1121acc`](https://github.com/doomemacs/doomemacs/commit/a1121acc94dd7eee65c152df6f07495e72dc3561) bump: :ui
* [`dd33275d`](https://github.com/doomemacs/doomemacs/commit/dd33275dc2fc68dbd2cff9c76df416e9d8165713) bump: :lang rest
* [`4afe5ca0`](https://github.com/doomemacs/doomemacs/commit/4afe5ca09a82febfde311fff2a755a8a1c8b140d) fix(org,cli): tangle: load ob-* libs for noweb-usable blocks
* [`0ed0072f`](https://github.com/doomemacs/doomemacs/commit/0ed0072ff23b5a5b5e939ed99dda6ae00878eb47) refactor(lib): doom/set-frame-opacity
* [`9a38ee24`](https://github.com/doomemacs/doomemacs/commit/9a38ee24286645462cfbcb09bf64035da571e0ff) fix(format): prefix arg inhibiting format-on-save (part 2)
* [`c64ca09e`](https://github.com/doomemacs/doomemacs/commit/c64ca09ed27b2cf0975f6feee49be385504951d4) fix(workspaces): arity error creating workspaces
* [`10bfda23`](https://github.com/doomemacs/doomemacs/commit/10bfda23512309eb098fa9843ec3ec6119f135c5) fix(eshell): +eshell-switch-workspace-fn: update signature
* [`751ac613`](https://github.com/doomemacs/doomemacs/commit/751ac6134b6abe204d9c514d300343b07b26da3c) fix(treemacs): persp-mode compatibility
* [`1ede94c8`](https://github.com/doomemacs/doomemacs/commit/1ede94c88a3b0d91f1c2923f8c75fc42aa93ba46) feat(lsp): add `+booster` flag
* [`3ab397b5`](https://github.com/doomemacs/doomemacs/commit/3ab397b520d21a555941afb5b0bb1cc340475088) bump: ob-restclient
* [`52e867d3`](https://github.com/doomemacs/doomemacs/commit/52e867d3865f17f24e0b318127e7e9326f06fbc1) refactor(corfu): use tty child frames in 31+
* [`c2da4f20`](https://github.com/doomemacs/doomemacs/commit/c2da4f20f2becce23930e8cbb18df81d03e7fd90) refactor(lsp): eglot-booster: conform to conventions
* [`c7d5ad62`](https://github.com/doomemacs/doomemacs/commit/c7d5ad622efc8276ad583a5721f3361d45f8126a) docs(lsp): mention +booster
* [`79c86210`](https://github.com/doomemacs/doomemacs/commit/79c86210913788d53dfb41e2a4f88188dac9d51f) fix(lsp): disable lsp-mode + emacs-lsp-booster advice
* [`cde7dbbb`](https://github.com/doomemacs/doomemacs/commit/cde7dbbb0fc1117cb0530a16045478b256428f61) fix(lsp): eglot-booster-io-only only when needed
* [`2129fffc`](https://github.com/doomemacs/doomemacs/commit/2129fffc79189bb6d4fd3bb665a4a936247411c4) bump: :lang beancount emacs-lisp markdown
* [`4bd6d355`](https://github.com/doomemacs/doomemacs/commit/4bd6d3553a4da15181f899099c61edf4ba242ae9) docs: update emacs version prereqs (30.1 -> 30.2)
* [`5217ba75`](https://github.com/doomemacs/doomemacs/commit/5217ba75a29297a8a5e7f7ae248159055e0f238e) refactor(org): remove +org--respect-org-auto-align-tags-a
* [`41876aa0`](https://github.com/doomemacs/doomemacs/commit/41876aa0365a522eef20fd6a0cd2f11045469a0d) refactor(org): remove +org-fix-window-excursions-a
* [`13ffb0fe`](https://github.com/doomemacs/doomemacs/commit/13ffb0fed3723efaa247cbf6d1ca1b3835e61f7f) refactor(org): remove +org-fix-newline-and-indent-in-src-blocks-a
* [`6009c2b8`](https://github.com/doomemacs/doomemacs/commit/6009c2b8382b9c56288b9588a2760d7ffc919319) fix(tree-sitter): backport treesit-{enabled-modes,major-mode-remap-alist}
* [`4154ad88`](https://github.com/doomemacs/doomemacs/commit/4154ad885f331a52cf49a94195b0f0dc7b22f30d) revert: diff-hl
* [`058cb20a`](https://github.com/doomemacs/doomemacs/commit/058cb20a12e29cc1990b0c08b887873689bc968f) bump: :completion
* [`3b587415`](https://github.com/doomemacs/doomemacs/commit/3b587415224e2aa14280ea1e4a1ab3935449f40d) refactor(tree-sitter): centralize grammar config & hacks
* [`086a0d30`](https://github.com/doomemacs/doomemacs/commit/086a0d30d09a6c316bc2e63ab556ec38c731bb49) feat(rust): add treesit support
* [`47fe11cd`](https://github.com/doomemacs/doomemacs/commit/47fe11cd767e8e836b8b0b16fc73d7922a46909b) feat(haskell): add treesit support
* [`c1ac8bc3`](https://github.com/doomemacs/doomemacs/commit/c1ac8bc37a34bdb495e91ab30e7a0b633b43afb0) refactor(ocaml): remove tree-sitter support
* [`bee45157`](https://github.com/doomemacs/doomemacs/commit/bee45157c6817264af5f766e60cf5ac8a5d28ee0) refactor(elm): remove tree-sitter support
* [`3d2abf8b`](https://github.com/doomemacs/doomemacs/commit/3d2abf8b05f378ceff6b00f3249a57e85128b9ae) feat(erlang): add treesit support
* [`bf857679`](https://github.com/doomemacs/doomemacs/commit/bf8576797549279ee7bd763a157b361322e04ae9) refactor(graphviz): remove tree-sitter support
* [`6ca155ea`](https://github.com/doomemacs/doomemacs/commit/6ca155ea112bd065b6512194d8a6cf0dc58a758e) refactor(ess): remove tree-sitter support
* [`07e7c699`](https://github.com/doomemacs/doomemacs/commit/07e7c699cf968a6e5578a5770f4583365c5ad2ef) feat(java): add treesit support
* [`6b203d74`](https://github.com/doomemacs/doomemacs/commit/6b203d74c9fb6f1cc6df8d1c2e4fc973c7b930fc) refactor(sh): remove tree-sitter support
* [`5bf132a8`](https://github.com/doomemacs/doomemacs/commit/5bf132a80fd20f1fe77a01e5b994e9cdf668e9b4) feat(web): add treesit support (for html/css)
* [`cfadd8f6`](https://github.com/doomemacs/doomemacs/commit/cfadd8f6a45a1380aa093500175767a905011aa5) feat(sml): add treesit (and lsp) support
* [`93c085fa`](https://github.com/doomemacs/doomemacs/commit/93c085fa13fd9a4249328e47e35ecfebb9c223da) feat(qt): add treesit (and lsp) support
* [`64b4e565`](https://github.com/doomemacs/doomemacs/commit/64b4e565c3724c19025dea8c6200dd445c9c4875) refactor(tree-sitter): remove redundant grammars
* [`f782b797`](https://github.com/doomemacs/doomemacs/commit/f782b7979719c9c4e3280f120670c0abc49dcb32) feat(graphql): add treesit support
* [`d20c5f12`](https://github.com/doomemacs/doomemacs/commit/d20c5f1273b1c0b94a0079102e153e6852afc3b4) docs(haskell): mention haskell-ts-mode package
* [`ed27f918`](https://github.com/doomemacs/doomemacs/commit/ed27f91822c2be512054575b32b4c21bbca1e8eb) tweak(notmuch): include the user's name in From: header
* [`bd0bee92`](https://github.com/doomemacs/doomemacs/commit/bd0bee92cc53d291fed34c0a1fb02767a4815d8c) feat!(javascript): add treesit support
* [`cd5dd527`](https://github.com/doomemacs/doomemacs/commit/cd5dd5279e8d3ff207cde922cf8775a52eebd29e) fix(tree-sitter): major mode remapping on first-load
* [`702d9766`](https://github.com/doomemacs/doomemacs/commit/702d97666500e5b094b47861f203488fe3d43f4e) docs(tree-sitter): document module hacks
* [`31f5b60f`](https://github.com/doomemacs/doomemacs/commit/31f5b60f5ea0a621e57be9e6769100673bf0b9a3) fix(php): dynamic mode map interpolation error
* [`e7a69dcd`](https://github.com/doomemacs/doomemacs/commit/e7a69dcdacf9332698714bf3b5c497e5f0653730) feat(cli): ci/commit-msg: echo failed commit message
* [`3044812a`](https://github.com/doomemacs/doomemacs/commit/3044812ac11cc133783d92c36b6662e0c7078b0c) fix(clojure): remove vestiges of tree-sitter
* [`7f8568ef`](https://github.com/doomemacs/doomemacs/commit/7f8568ef311adc6b6edbb8b392c2c78f46cd595e) refactor: remove workarounds for better-jumper
* [`b1826a0c`](https://github.com/doomemacs/doomemacs/commit/b1826a0c6469f57b377b08ef7d54005504b12d59) bump: :ui workspaces
* [`9e5e4cf7`](https://github.com/doomemacs/doomemacs/commit/9e5e4cf78bd9b059caf3715e1e0cc479a48b0337) refactor!(php): remove php-extras
* [`7dcedc16`](https://github.com/doomemacs/doomemacs/commit/7dcedc16b5c2c561f89b6a6e2fd8847bc7f6b64c) refactor(tree-sitter): major mode remapping
* [`2870697e`](https://github.com/doomemacs/doomemacs/commit/2870697e1ae3717a970b40eb1da9aab9012b3f6f) fix(go,nix,zig): dynamic keymap interpolation errors
* [`ab4dace6`](https://github.com/doomemacs/doomemacs/commit/ab4dace692cd31b8528dcd9c7ad0338c2bc91a48) refactor(:lang): remove redudant mode-alist lines
* [`0ba85c8f`](https://github.com/doomemacs/doomemacs/commit/0ba85c8f77b58eaddc3fbca96f85ccc5f2c72c0a) refactor(lua): DRY tree-sitter config
* [`bcb2c56d`](https://github.com/doomemacs/doomemacs/commit/bcb2c56dd9d1d4f6cd0d55baf58b54efed28fb5b) fix(haskell): haskell-ts-mode: repl & eglot integration
* [`d77d39ab`](https://github.com/doomemacs/doomemacs/commit/d77d39ab46a4343479db16751a949a9cc36a1f63) refactor(scala): remove redundant config
* [`6084404a`](https://github.com/doomemacs/doomemacs/commit/6084404a07c7a7e8f324ecab88379b25f4652053) docs(beancount): flesh out module readme
* [`4b9f2372`](https://github.com/doomemacs/doomemacs/commit/4b9f23725009d14671f2a5b720a1d73ffbe83c3c) bump: :doom
* [`8cdddd87`](https://github.com/doomemacs/doomemacs/commit/8cdddd87d948cb9ba561f2861f11af6fc74567d9) tweak(cli): download package archives by default
* [`7dd66cc3`](https://github.com/doomemacs/doomemacs/commit/7dd66cc3d7779a4982dc8d35f9a6cb4c9a17be5b) fix(php): remove unused async dependency
* [`2e508c29`](https://github.com/doomemacs/doomemacs/commit/2e508c299d1d6dac9c05d224353bce7fbb57e966) fix(cli): 'Failed to clone package' error
* [`83eba01b`](https://github.com/doomemacs/doomemacs/commit/83eba01bff4195e01703ec3ab0414a117e6fc141) refactor(python): string= first, then executable-find
* [`d9fd5cb8`](https://github.com/doomemacs/doomemacs/commit/d9fd5cb8f30cb2f7f1f9238b993361fa8717ee5f) fix(tree-sitter): treesit-enabled-modes: sort arity in <30
* [`d545fccf`](https://github.com/doomemacs/doomemacs/commit/d545fccf47b64faf8b19f6fdab3fbb7c23a377cf) fix(:lang): missing grammar recipes
* [`98f03062`](https://github.com/doomemacs/doomemacs/commit/98f03062b6fb43988bd2b4125e5a1dd72e37590a) fix(lib): major-mode-remap backport for Emacs <30 users
* [`86b6ba81`](https://github.com/doomemacs/doomemacs/commit/86b6ba81acb551ba9bce8cb865d75db07ca99af6) fix(go): go-{mod,work}-ts-mode
* [`94a1fe64`](https://github.com/doomemacs/doomemacs/commit/94a1fe64a8d3fffee4160e397d320e3850c95b6d) fix(tree-sitter): suppress "Can't find grammar" warnings
* [`571766e6`](https://github.com/doomemacs/doomemacs/commit/571766e6bafe37f7d8b38911a2740cd658ea85fb) fix(qt): eglot support
* [`1dae2bf9`](https://github.com/doomemacs/doomemacs/commit/1dae2bf916ea631ab0d129218cf69ece94a11e4f) fix(tree-sitter): remap to ts-mode w/o base mode
* [`09c01e04`](https://github.com/doomemacs/doomemacs/commit/09c01e04e68d2ccaaced3aa77d6bd4b07ea40598) fix(javascript): vestigial npm-mode reference
* [`3e7a20f9`](https://github.com/doomemacs/doomemacs/commit/3e7a20f972dcbbdf0cda7a30691037b1355a6d11) fix(:lang): project minor mode detection in ts-modes
