### PR TITLE
niv nixpkgs: update 434576cb -> 3b63f31e

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -143,10 +143,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "434576cbd5f669de9ccbf4472743a8ba90049484",
-        "sha256": "0d50jh3gckiwmd0d4rmmxy78yvkwgad54lim62ly2b62xiqhik5r",
+        "rev": "3b63f31ef13f96726cd3357391519eee8a91792d",
+        "sha256": "15wanfc12q6wy1yvh6xyg7nkhh8wmr646cbfa3f8r93hkmgidd4a",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/434576cbd5f669de9ccbf4472743a8ba90049484.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/3b63f31ef13f96726cd3357391519eee8a91792d.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@434576cb...3b63f31e](https://github.com/nixos/nixpkgs/compare/434576cbd5f669de9ccbf4472743a8ba90049484...3b63f31ef13f96726cd3357391519eee8a91792d)

* [`d7b5e1a9`](https://github.com/NixOS/nixpkgs/commit/d7b5e1a95a54abc72005bd45ea55b774cae20d81) wire-desktop: Add versions.json to enable updateScript
* [`cf36c820`](https://github.com/NixOS/nixpkgs/commit/cf36c820c542b992f0635435b34b5ce516fd5cfa) wire-desktop: Add updateScript
* [`f17eea9f`](https://github.com/NixOS/nixpkgs/commit/f17eea9f30683576834589fe6bd6e396a687f90e) wire-desktop: Add empty hash check
* [`5d218393`](https://github.com/NixOS/nixpkgs/commit/5d21839349aebbbd71b611cbaa485d94284186f6) wire-desktop: linux 3.39.3653 -> 3.40.3718, macos 3.39.5211 -> 3.40.5285
* [`89e5b47c`](https://github.com/NixOS/nixpkgs/commit/89e5b47cde51a99cda5838192c503bf6297c7854) check-meta: add allowBrokenPredicate
* [`70ac7f8b`](https://github.com/NixOS/nixpkgs/commit/70ac7f8bd8e0f5360bb396fff263d314a8009964) ccache: recommend ignoring random_seed
* [`09983006`](https://github.com/NixOS/nixpkgs/commit/09983006bff5263ba2923131c32968fcdf664009) whatsapp-electron: init at 1.1.1
* [`c14eea44`](https://github.com/NixOS/nixpkgs/commit/c14eea4451fa6334c4171572c151b2cd4a8e97ab) maintainer: add nomis
* [`ca596975`](https://github.com/NixOS/nixpkgs/commit/ca596975ab053d6865e328ef7cbd9ac9789963fe) dtee: init at 1.1.3
* [`292073c5`](https://github.com/NixOS/nixpkgs/commit/292073c5cce560c375a17e754cdc4be292d1abb4) victoriametrics & vmagent: Make the config check optional
* [`4a8f1e03`](https://github.com/NixOS/nixpkgs/commit/4a8f1e03d580ef26602ffe671c40fc67bff8ea83) graylog-6_0: 6.0.8 -> 6.0.14
* [`67e47537`](https://github.com/NixOS/nixpkgs/commit/67e4753795eaa144cf7d1530983780f7bb6557e8) seafile-shared: 9.0.8 -> 9.0.14
* [`ffaf4b87`](https://github.com/NixOS/nixpkgs/commit/ffaf4b873a8fa1bef79aae5be7dd4246a7593827) seafile-client: 9.0.12 -> 9.0.14
* [`15a8c673`](https://github.com/NixOS/nixpkgs/commit/15a8c6739ace8be4ff2d1c3fe43dcb3af337e2f9) git-lfs: 3.6.1 -> 3.7.0
* [`a62b50e7`](https://github.com/NixOS/nixpkgs/commit/a62b50e779b5441ee8994594df78066e386cac38) briar-desktop: fix license
* [`12da3cd4`](https://github.com/NixOS/nixpkgs/commit/12da3cd4f42fe1038ea92004b800bfdf147650c2) briar-desktop: avoid with lib;
* [`4da2c5e9`](https://github.com/NixOS/nixpkgs/commit/4da2c5e9f3ac7c3ba50f21976d5e8cab4572f864) briar-desktop: add ngi team
* [`f70e6192`](https://github.com/NixOS/nixpkgs/commit/f70e619203921eb575a92ddf8f0cfcee977abfb8) briar-desktop: use finalAttrs
* [`cea6d77f`](https://github.com/NixOS/nixpkgs/commit/cea6d77f662d2b06b714c44d5df4a7eae7df9ed7) _1password-gui{,-beta}: Re-enable Wayland support
* [`4bdcc227`](https://github.com/NixOS/nixpkgs/commit/4bdcc227b99f26d06a7392fb16bcd5bb2d3f1dc5) python3Packages.astropy-helpers: modernize
* [`927ca2bb`](https://github.com/NixOS/nixpkgs/commit/927ca2bba0bb554429d0929dde56e00f0cc6befc) python3Packages.astropy-helpers: fix build for py312+
* [`9f91eeed`](https://github.com/NixOS/nixpkgs/commit/9f91eeedcbd89f0d64fcf28717c5030e45796b85) python3Packages.astroquery: modernize
* [`549e1bdb`](https://github.com/NixOS/nixpkgs/commit/549e1bdb99d771bab7205a3783887938b8596bee) python3Packages.astroquery: fix build
* [`9f9d9144`](https://github.com/NixOS/nixpkgs/commit/9f9d9144e01d226f8695d652ace3b44db29e6335) deepcool-digital-linux: init at 0.8.3-alpha
* [`7eef2264`](https://github.com/NixOS/nixpkgs/commit/7eef2264d76a874df3d3ae22b200c6f1702bb8b5) nixos/deepcool-digital-linux: init
* [`938bb878`](https://github.com/NixOS/nixpkgs/commit/938bb87845300719169a1d2a450709c0100ae1e7) lib60870: update mbedtls
* [`7cc37f1c`](https://github.com/NixOS/nixpkgs/commit/7cc37f1c7023de827d6066ffcbbd98b8f79afd5d) mautrix-gmessages: 0.6.3 -> 0.6.4
* [`411cdc16`](https://github.com/NixOS/nixpkgs/commit/411cdc160cc83839a69aaa387ea09a09fd5ffd2c) maintainers: add eripa
* [`5fa00b8f`](https://github.com/NixOS/nixpkgs/commit/5fa00b8f2783f7455b16296a5d8c36d0a1eb1757) dezoomify-rs: fix `checkPhase` with `sandbox=relaxed` on Darwin
* [`371c0463`](https://github.com/NixOS/nixpkgs/commit/371c0463c0bb64612d1ad1f0cb5de8e29a1c9eb1) dezoomify-rs: use `finalAttrs` pattern
* [`5f5db01a`](https://github.com/NixOS/nixpkgs/commit/5f5db01a82cdc10811af52d415cf0cca4d9d6b2b) dezoomify-rs: exclude openssl on Darwin
* [`8fb133a8`](https://github.com/NixOS/nixpkgs/commit/8fb133a87f81c2fb0520aa78c9e84827b48a321a) mysql-shell: 8.4.5 -> 8.4.6
* [`9ed1c81a`](https://github.com/NixOS/nixpkgs/commit/9ed1c81a3c03ba5230adbf3d962ae0585339eba0) mysql-shell-innovation: 9.3.0 -> 9.4.0
* [`00c97669`](https://github.com/NixOS/nixpkgs/commit/00c97669d78041edc41a8743fad5f6e30edc79d9) geoserver: 2.27.1 -> 2.27.2
* [`b3255718`](https://github.com/NixOS/nixpkgs/commit/b3255718ac509fcd68d8238e8ac6916071c8d6dd) lib, mkDerivation: Document overriding functions
* [`f83a5d80`](https://github.com/NixOS/nixpkgs/commit/f83a5d808a6fb86490f0e470215a995203f2129d) epson-escpr2: 1.2.34 -> 1.2.35
* [`8a815d62`](https://github.com/NixOS/nixpkgs/commit/8a815d62904bccd18554602486e27b1b17367069) doc: fix link rot to `--keep-failed` in stdenv
* [`6ccf14ba`](https://github.com/NixOS/nixpkgs/commit/6ccf14ba235944f96f67e252812d59ef1fb15e38) dockerTools.streamLayeredImage: fix enableFakechroot
* [`78ced76b`](https://github.com/NixOS/nixpkgs/commit/78ced76b003a19719a35f67f4359151ec2e11a09) nushellPlugins.desktop_notifications: init at 0.106.1
* [`52e13941`](https://github.com/NixOS/nixpkgs/commit/52e13941f4edb48ea3d9bd70b89e6e77305f393c) libretro.swanstation: 0-unstable-2025-05-26 -> 0-unstable-2025-08-02
* [`4b1d8433`](https://github.com/NixOS/nixpkgs/commit/4b1d8433465b54a6db3d363dc2fc46dd5d22901a) homepage-dashboard: fix update script
* [`8628f797`](https://github.com/NixOS/nixpkgs/commit/8628f797b96d623cfadda6d6c93c13eb5e85c12d) homepage-dashboard: 1.3.2 -> 1.4.3
* [`0e2015ef`](https://github.com/NixOS/nixpkgs/commit/0e2015ef187b38291b77440aee7f1d6390c50735) nixos/homepage-dashboard: add support for `proxmox` config
* [`520f14f8`](https://github.com/NixOS/nixpkgs/commit/520f14f89c89a02f85058c34044109add55019c3) nixos/tests/homepage-dashboard: fix failing tests
* [`102dbdf6`](https://github.com/NixOS/nixpkgs/commit/102dbdf64bee8c17a83111bb1ce655d6e4cca29d) qmplay2: remove substituteInPlace
* [`be02b28b`](https://github.com/NixOS/nixpkgs/commit/be02b28bbd354c117a3fec81ec31dc332b43e582) qmplay2: remove fetchSubmodules
* [`4f42092b`](https://github.com/NixOS/nixpkgs/commit/4f42092bebd1eb9117faf9e1bd8739726bdb982e) bisq2: add aarch64-linux support
* [`baa55ff1`](https://github.com/NixOS/nixpkgs/commit/baa55ff144a83ef79e72bd4d9047b68b9cbe6be8) deja-dup: 48.3 -> 48.4
* [`93bd7048`](https://github.com/NixOS/nixpkgs/commit/93bd7048f7734c54f0c3fa17fdb7c4511d8278c7) drum-machine: 1.3.1 -> 1.4.0
* [`e1953434`](https://github.com/NixOS/nixpkgs/commit/e195343469f3419f47d36db43d7a68fef378f8dc) amnezia-vpn: 4.8.9.1 -> 4.8.9.2
* [`049d4a76`](https://github.com/NixOS/nixpkgs/commit/049d4a76494af00c3c223e91a0b65763f2d22792) timoni: 0.25.1 -> 0.25.2
* [`1f82bcd4`](https://github.com/NixOS/nixpkgs/commit/1f82bcd4b6531e5c30eeb2637c1d2f7674c0c017) pythonPackages.pytest-plus: init at 0.8.1
* [`d93477c3`](https://github.com/NixOS/nixpkgs/commit/d93477c3b7b73ecfd9177ab8199364daa5fa2191) pythonPackages.pytest-ansible: 25.5.0 -> 25.6.3
* [`28b186ca`](https://github.com/NixOS/nixpkgs/commit/28b186ca10b2ec16c12cb2c375e44684f3032433) libime: 1.1.10 -> 1.1.11
* [`341c8011`](https://github.com/NixOS/nixpkgs/commit/341c8011bc2e1cef984f464a0023888d28dbdffa) beekeeper-studio: 5.2.12 -> 5.3.4
* [`e5c20541`](https://github.com/NixOS/nixpkgs/commit/e5c205414df62d0e396e5f59c1fbe3a31252c4c1) vscode-extensions.wgsl-analyzer.wgsl-analyzer: 0.10.178 -> 0.11.39
* [`e8e668c5`](https://github.com/NixOS/nixpkgs/commit/e8e668c587b3477aca23d210364aa15eb13ca034) doc: fix incorrect counter for MPI options
* [`09899697`](https://github.com/NixOS/nixpkgs/commit/09899697e4f7c85dd7e2b2646880155e66bad87f) maintainers: add gipphe
* [`defecd64`](https://github.com/NixOS/nixpkgs/commit/defecd64a3ac1dddf483b5d89bddeac2c85cd776) kawa: init at 3.1.1
* [`165104c6`](https://github.com/NixOS/nixpkgs/commit/165104c6a6427ded57b10ce3f1b6fef927b2a31a) squawk: don't build xtask
* [`cd0a1157`](https://github.com/NixOS/nixpkgs/commit/cd0a115755e1d548a6fb67eb22e488d4af2843db) lsp-ai: don't build xtask
* [`c20d9c02`](https://github.com/NixOS/nixpkgs/commit/c20d9c02ec03c312fae248f51b437c18476937c1) virglrenderer: add normalcea as maintainer
* [`4704387d`](https://github.com/NixOS/nixpkgs/commit/4704387db26b048def40eec1bf1564df8b2964c5) virglrenderer: update `meta` attributes
* [`4802caea`](https://github.com/NixOS/nixpkgs/commit/4802caea57987e99fa7c53bea9520b4b418a2ca8) virglrenderer: use `fetchFromGitLab`; use `finalAttrs`
* [`accd401c`](https://github.com/NixOS/nixpkgs/commit/accd401c6616d963ccbb42551ffb7d800e2aac98) virglrenderer: refactor
* [`74887adc`](https://github.com/NixOS/nixpkgs/commit/74887adc4150b3394d50d6bb1197c329c5958073) fdroidserver: 2.4.0 -> 2.4.2
* [`22e6928b`](https://github.com/NixOS/nixpkgs/commit/22e6928bd69c3e74f2a2f7ded88c56a26d264aa8) texlive: allow to add custom mirrors
* [`644527dd`](https://github.com/NixOS/nixpkgs/commit/644527dd57127fd46c40de1fc90d096a6db962b4) lib.modules: init types checkAndMerge to allow adding 'valueMeta' attributes
* [`8fa33000`](https://github.com/NixOS/nixpkgs/commit/8fa33000a388cc63e1d66cae5da47937fe05886f) lib.modules: add tests for option valueMeta
* [`648dbed1`](https://github.com/NixOS/nixpkgs/commit/648dbed1d6903931745babf6bf686b0631970538) lib/types: add 'checkDefsForError' utility for checking defs with a given check
* [`70ab11c2`](https://github.com/NixOS/nixpkgs/commit/70ab11c2f2ed1c8375da40d891f428139146a05d) lib/modules: add new merge.v2 for 'types.{either,coercedTo}'
* [`9f787b30`](https://github.com/NixOS/nixpkgs/commit/9f787b30e520d9fd823c2eec8547acd87af974c1) lib/modules: fix test by matching error message more generically
* [`5d72133a`](https://github.com/NixOS/nixpkgs/commit/5d72133a228d173e3048e8efa2bb6578c2cb2bd3) lib/addCheck: add support for new merge
* [`ebafc3eb`](https://github.com/NixOS/nixpkgs/commit/ebafc3eb747aa13967aac8b35590c3ebb7d889a7) lib/modules: optimize performance by inlining bindings
* [`17653700`](https://github.com/NixOS/nixpkgs/commit/17653700514991920ed518813ec9331dd4df54c1) lib/modules: test revert unentional regression in check
* [`50bef194`](https://github.com/NixOS/nixpkgs/commit/50bef19448743f2bd8c304c355e99d86470d97a2) lib/modules: add nested 'headError.message'
* [`cd2e5bd4`](https://github.com/NixOS/nixpkgs/commit/cd2e5bd46c016666f8cd3c00f95d692479c3027d) types/merge: move 'configuration' of submodules into nested attribute set
* [`45ed757e`](https://github.com/NixOS/nixpkgs/commit/45ed757e104a361ba2f8034181f78b1249b4faf1) types/addCheck: add tests for merge v1 and v2
* [`c99a6b12`](https://github.com/NixOS/nixpkgs/commit/c99a6b126cf2d00c3784283622283335a4ce3aec) amazon-q-cli 1.13.1 -> 1.13.3
* [`1587a343`](https://github.com/NixOS/nixpkgs/commit/1587a343c9bb07ac94dd3d331b6a97422379a47e) nodejs_24: 24.5.0 -> 24.6.0
* [`8f5612dd`](https://github.com/NixOS/nixpkgs/commit/8f5612dd64bb04eab2080479a291096bc2b433ff) maintainers: add shakhzodkudratov and to uzinfocom team
* [`1fed6029`](https://github.com/NixOS/nixpkgs/commit/1fed6029c298183feafb6c4b6cf42527ff74b7e6) lib/tests: introduce lib cross version checks
* [`53ff77e6`](https://github.com/NixOS/nixpkgs/commit/53ff77e6546572980ebdee2c8d84b464ddb8befc) python3Packages.busylight-for-humans: add optional dependencies of busyserve
* [`216d98ab`](https://github.com/NixOS/nixpkgs/commit/216d98ab97fbec49a213e4b5a6df0c6e771aef3d) nixos/systemd-initrd: silence various warnings
* [`e60c8b70`](https://github.com/NixOS/nixpkgs/commit/e60c8b708884e015766fc74fd66025d6af9a5222) beamerpresenter: change repository source to new location
* [`1d45f884`](https://github.com/NixOS/nixpkgs/commit/1d45f884d3a11025e09012bfe1b66a832a9a6967) boost189: init at 1.89.0
* [`bfce999b`](https://github.com/NixOS/nixpkgs/commit/bfce999b9d397a87db0d403b767e0380bf72f5a8) handheld-daemon: Fix chmod path in udev rules
* [`4f2f8faa`](https://github.com/NixOS/nixpkgs/commit/4f2f8faa7f7d3cba5c4eccf6077cef2235f0071a) check-meta: Clarify error message about unsupported platform
* [`bdf36222`](https://github.com/NixOS/nixpkgs/commit/bdf36222ea18cae482f6d2e602b2db2c0529e2cb) comet-gog_heroic: init at 0.2.0; comet-gog: refactor
* [`f3e899c8`](https://github.com/NixOS/nixpkgs/commit/f3e899c89f5204b9f73b60d7266875d48730bf77) comet-gog: add dummy-service passthru
* [`eb430bbd`](https://github.com/NixOS/nixpkgs/commit/eb430bbda1082b9ff71dd5e5fbad87a1aec4e509) comet-gog: add aidalgol to maintainers
* [`22acebbf`](https://github.com/NixOS/nixpkgs/commit/22acebbfe68bb9d7e4f907c504f079e539f8f52a) heroic-unwrapped: correct meta.changelog
* [`481d9aa2`](https://github.com/NixOS/nixpkgs/commit/481d9aa2367700a94c7037f699dc2b9dfed72e15) heroic-unwrapped: remove update script
* [`bf8f6f0d`](https://github.com/NixOS/nixpkgs/commit/bf8f6f0d2f42c3e769d8d71570d2911dcff962ef) heroic-unwrapped: Add missing dependencies
* [`043ee2d9`](https://github.com/NixOS/nixpkgs/commit/043ee2d9c71c43079635200e70fe7dadfb1fc4e4) legendary-heroic: move beside heroic-unwrapped
* [`1632dd63`](https://github.com/NixOS/nixpkgs/commit/1632dd63ca98aba5eaf5bb1aeec5d78a1d1bfea1) markdown-oxide: 0.25.6 -> 0.25.8
* [`21c31914`](https://github.com/NixOS/nixpkgs/commit/21c319142ef82c59c64b3a91a145f6924dbf66f5) super-productivity: 14.1.0 -> 14.3.3
* [`b1ff0e55`](https://github.com/NixOS/nixpkgs/commit/b1ff0e555ee2151ac242829bfc0b62e50ba5d055) haruna: add kdePackages.kdeclarative to buildInputs
* [`20c15f52`](https://github.com/NixOS/nixpkgs/commit/20c15f522771ecdde95be5cb62e4d1cbaf7d1c8d) circt: 1.125.0 -> 1.128.0
* [`d306a602`](https://github.com/NixOS/nixpkgs/commit/d306a6025e228e4112f40f002826cf3109f6df14) slipshow: init nixos test
* [`c5906cc6`](https://github.com/NixOS/nixpkgs/commit/c5906cc638ac55d695a1872d71a49aea1c6a50f8) maintainers: add rein
* [`88e8a403`](https://github.com/NixOS/nixpkgs/commit/88e8a4036877dc2d328fd3e7cb4e732eb037e49c) mautrix-whatsapp: 0.12.3 -> 0.12.4
* [`92769b79`](https://github.com/NixOS/nixpkgs/commit/92769b79e6950e0f06df1dd40aa476d7e8b5b19e) mautrix-gmessages: 0.6.4 -> 0.6.5
* [`df06b2ac`](https://github.com/NixOS/nixpkgs/commit/df06b2acd8092bbfb0ff54e4675de582ad0849cf) libsignal-ffi: 0.76.1 -> 0.78.2
* [`aba64f33`](https://github.com/NixOS/nixpkgs/commit/aba64f33661e81753d722a802b06b5804255727e) mautrix-signal: 0.8.5 -> 0.8.6
* [`e3f96eb4`](https://github.com/NixOS/nixpkgs/commit/e3f96eb478d7c2de9d7aedcf59e39b4796e9f9e4) mautrix-signal: add SchweGELBin as maintainer
* [`1a9dd6be`](https://github.com/NixOS/nixpkgs/commit/1a9dd6becb1f2dbda2565ce226f16a211e16b73b) libsignal-ffi: add SchweGELBin as maintainer
* [`cb86b9ac`](https://github.com/NixOS/nixpkgs/commit/cb86b9acde73e04a6c914aa5cdc5d6f4b285f06e) python3Packages.raspyrfm-client: init at 1.2.8
* [`b0a07121`](https://github.com/NixOS/nixpkgs/commit/b0a071213f164f99cb3b60b12a7be8dfb76efa39) home-assistant: update component packages
* [`d9204785`](https://github.com/NixOS/nixpkgs/commit/d920478572b9051ab521a358464b0fd97b712aa1) gping: 1.19.0 -> 1.20.1
* [`4f802d93`](https://github.com/NixOS/nixpkgs/commit/4f802d935ca444a51ae83d45baa42c2a27a9c683) lib/modules: fix typo
* [`62674262`](https://github.com/NixOS/nixpkgs/commit/62674262590cc7b17b56e5f08ee6a52899a44616) tukai: init at 0.2.3
* [`8b7e2177`](https://github.com/NixOS/nixpkgs/commit/8b7e21778f11abb0b4debc3fbe7440f7d82df92a) charmcraft: 3.5.2 -> 3.5.3
* [`406c8ebe`](https://github.com/NixOS/nixpkgs/commit/406c8ebe1e914c46cce35497e4d13aeebd773861) dartsim: clean
* [`76208518`](https://github.com/NixOS/nixpkgs/commit/7620851833c0302f3a2cbfc50a92c9b148ef5a7c) glsl_analyzer: 1.5.1 -> 1.6.0
* [`a7a8965d`](https://github.com/NixOS/nixpkgs/commit/a7a8965df28349d4e43151d6717713cd2aa004f3) urserver: 3.13.0.2505 -> 3.14.0.2574
* [`53c11eb7`](https://github.com/NixOS/nixpkgs/commit/53c11eb78313f277934f4cf9a74d960467500077) urserver: split buildInputs and wrapProgram arguments
* [`5a339686`](https://github.com/NixOS/nixpkgs/commit/5a33968645f9502dd02490aad3397b9d34154ded) urserver: remove 'with lib'
* [`ffb190df`](https://github.com/NixOS/nixpkgs/commit/ffb190df0e0cc8323cd8c996f9d245c77ea3a56b) e-imzo-manager: init at 0.1.1
* [`1142f675`](https://github.com/NixOS/nixpkgs/commit/1142f675aa04dfc1d4f6d5a5262a0df4d935ec8e) urserver: add versionCheckHook
* [`db02b37b`](https://github.com/NixOS/nixpkgs/commit/db02b37b72500619d78e9970b0fcbffa6ebf0f2b) python313Packages.highdicom: use test data via passthru from pydicom
* [`d5711e37`](https://github.com/NixOS/nixpkgs/commit/d5711e3716c6917cddafad042c85f806b9c78823) nextcloud30: 30.0.13 -> 30.0.14
* [`def1dbd2`](https://github.com/NixOS/nixpkgs/commit/def1dbd2dd70f5675654e29e0ec4f48d3c90a945) nextcloud31: 31.0.7 -> 31.0.8
* [`23f673bb`](https://github.com/NixOS/nixpkgs/commit/23f673bbc6bf13ae7a315c80125bc7e922297cc7) nextcloudPackages.apps: update
* [`19a7b08e`](https://github.com/NixOS/nixpkgs/commit/19a7b08ea77528bec37a418fa47cb5ad1a219fa9) github-runner: add support for node24
* [`8e4573ca`](https://github.com/NixOS/nixpkgs/commit/8e4573ca7e6f4fd82600de7245003d4f1401a875) chow-tape-model: fix build
* [`2b46d0d0`](https://github.com/NixOS/nixpkgs/commit/2b46d0d02a6a0edc24054ab5f57df22ef2cd162d) chow-kick: fix build
* [`2fe4be31`](https://github.com/NixOS/nixpkgs/commit/2fe4be31515a72c539c3be2b4f280a5ffabb465c) python3Packages.holoviews: disable broken test on Darwin
* [`a3d919aa`](https://github.com/NixOS/nixpkgs/commit/a3d919aac4e03a88139da0ff4f3895e34886a58e) python3Packages.celery: build from github
* [`f7b50de9`](https://github.com/NixOS/nixpkgs/commit/f7b50de98b3fb7076214ad1b64004c2ff9e00c95) python3Packages.celery: disable flaky test under load on Darwin
* [`6bf60327`](https://github.com/NixOS/nixpkgs/commit/6bf6032722799c157aee90152b8aa4e1305bc097) heroic-unwrapped: use correct comet-gog version
* [`dae6e7c8`](https://github.com/NixOS/nixpkgs/commit/dae6e7c82a5f70fa0d5eb6d045688c8c76a201db) heroic-unwrapped: Apply patch for upstream bugfix PR
* [`2ebbcb51`](https://github.com/NixOS/nixpkgs/commit/2ebbcb51600daea5b1d2b09683b0d9b1403279af) kamal: 2.6.1 -> 2.7.0
* [`314d9b4f`](https://github.com/NixOS/nixpkgs/commit/314d9b4fa7989682742bab60c8eab5a71cde088a) yaml-merge: Fix running the cross-compiled script
* [`43a812f4`](https://github.com/NixOS/nixpkgs/commit/43a812f428131183d4856ec44045c6d2f4247e1e) dart.file_picker: update
* [`0d23bf3f`](https://github.com/NixOS/nixpkgs/commit/0d23bf3fa7ee886e20c54c822929ea7a345d7f17) proxypin: 1.1.9 -> 1.2.0
* [`996181d3`](https://github.com/NixOS/nixpkgs/commit/996181d3259cf1550779e2af9c762dba64e9deb9) python3Packages.opencc: init at 1.1.9
* [`92f130a4`](https://github.com/NixOS/nixpkgs/commit/92f130a4575c06661ef10459d8770709709aff03) bleep: 0.0.12 -> 0.0.13
* [`f70dae75`](https://github.com/NixOS/nixpkgs/commit/f70dae7523600a38b8ae6dc62dfe26bb4171122b) django-upgrade: 1.22.2 -> 1.25.0
* [`fe6d429d`](https://github.com/NixOS/nixpkgs/commit/fe6d429d05dac33632f48044f6c8cc4eceff7f4c) gir-rs: 0.19.0 -> 0.21.0
* [`47729d6a`](https://github.com/NixOS/nixpkgs/commit/47729d6ab91f6eaba6242aef5812cbb556dbed22) fcitx5: 5.1.12 -> 5.1.13
* [`fbdda4b2`](https://github.com/NixOS/nixpkgs/commit/fbdda4b27a35c4a6feb8d3984b19a224858c4276) fcitx5-anthy: 5.1.6 -> 5.1.7
* [`6aa960df`](https://github.com/NixOS/nixpkgs/commit/6aa960df73862a427326f574dc0204eb5522f730) fcitx5-chewing: 5.1.7 -> 5.1.8
* [`12e154ea`](https://github.com/NixOS/nixpkgs/commit/12e154eaeea810f82dc5b3c7d21f34dc8fe4946b) fcitx5-chinese-addons: 5.1.8 -> 5.1.9
* [`1bea7d29`](https://github.com/NixOS/nixpkgs/commit/1bea7d2965d44429715fb6e36eff345c775b0164) fcitx5-configtool: 5.1.9 -> 5.1.10
* [`21421ab5`](https://github.com/NixOS/nixpkgs/commit/21421ab5f4ca0637a7cc7c3cdc6eb6be72b29221) fcitx5-hangul: 5.1.6 -> 5.1.7
* [`9786f37a`](https://github.com/NixOS/nixpkgs/commit/9786f37a36652a9ead9c809ade26256775aab098) fcitx5-lua: 5.0.14 -> 5.0.15
* [`7ad806d6`](https://github.com/NixOS/nixpkgs/commit/7ad806d6b25fb9f029c4bc1c38b33a82ba1cd987) fcitx5-m17n: 5.1.3 -> 5.1.4
* [`cec68a0f`](https://github.com/NixOS/nixpkgs/commit/cec68a0f528c1eb4cdb9fedaada9747000d9e944) libsForQt5.fcitx5-qt: 5.1.9 -> 5.1.10
* [`92f39ace`](https://github.com/NixOS/nixpkgs/commit/92f39ace7f374e1e5d8dd74e451eb17ca484af7d) fcitx5-rime: 5.1.10 -> 5.1.11
* [`647e6ec0`](https://github.com/NixOS/nixpkgs/commit/647e6ec0ef7178f4f460fb042465942a1f4043a6) fcitx5-skk: 5.1.6 -> 5.1.7
* [`0729c916`](https://github.com/NixOS/nixpkgs/commit/0729c916a2f7f6ae44687d9731df1b2817aac66a) fcitx5-unikey: 5.1.6 -> 5.1.7
* [`7e14cfe4`](https://github.com/NixOS/nixpkgs/commit/7e14cfe4298145850cbd5b988eb06e490c2e8b4b) fcitx5: 5.1.13 -> 5.1.14
* [`249a0472`](https://github.com/NixOS/nixpkgs/commit/249a0472250b52bb15a69b22077c147a9c69a584) python3Packages.ansible: 11.8.0 -> 11.9.0
* [`7f9721ef`](https://github.com/NixOS/nixpkgs/commit/7f9721effff0f4d24a91166fb5fc5dd5182f559b) snyk: 1.1298.2 -> 1.1298.3
* [`f91f2dcf`](https://github.com/NixOS/nixpkgs/commit/f91f2dcfbac3e2d4f3e8cbfcdd8abf7fea85ad25) ibus: Fix cross `No package 'wayland-scanner' found`
* [`28555291`](https://github.com/NixOS/nixpkgs/commit/28555291142cfb7f19e3fcf086f2ef0e54a167c6) nixos/i18n/input-method: Fix cross
* [`5ebd24de`](https://github.com/NixOS/nixpkgs/commit/5ebd24de1aabe9f8fd530186227cf612a39771d9) subsurface: fix build, remove vulnerable qtwebengine
* [`45ed32fb`](https://github.com/NixOS/nixpkgs/commit/45ed32fbc612f7c70305bc0872fcdfa5eb84745f) supercollider: disable vulnerable qtwebengine by default
* [`fdaf9ac0`](https://github.com/NixOS/nixpkgs/commit/fdaf9ac0214d7dea1b3e573434cd96c0d10c9d76) python312Packages.pyside2: disable vulnerable qtwebengine by default
* [`d89ab7ff`](https://github.com/NixOS/nixpkgs/commit/d89ab7ff0799e518a351ece97a4c784677dc2979) qt5.qtwebengine: mark vulnerable
* [`c2a8a9b6`](https://github.com/NixOS/nixpkgs/commit/c2a8a9b6eca3d05c78327a4e57f89603b289d877) add ldflags to kubeconform
* [`c4d9e6d2`](https://github.com/NixOS/nixpkgs/commit/c4d9e6d21924564b148d5901415bb24fb66b45a7) filius,ipfetch,starfetch: fix use of deprecated command options
* [`828349a4`](https://github.com/NixOS/nixpkgs/commit/828349a4d3b69e9234b711674151cff10717f694) orthanc: 1.12.8 -> 1.12.9
* [`be1d19b4`](https://github.com/NixOS/nixpkgs/commit/be1d19b458f8314d8989f971b1120028047e2e65) python3Packages.simsimd: 6.5.0 -> 6.5.1
* [`b91ed935`](https://github.com/NixOS/nixpkgs/commit/b91ed9354e1d0d7a85a1c21f209ca9bb0149199b) python3Packages.pyirishrail: init at 0.0.2
* [`ae2e210f`](https://github.com/NixOS/nixpkgs/commit/ae2e210fbe4b2a37ee5748f0cbeae0c78bc1bba3) home-assistant: update component packages
* [`1cb5f33a`](https://github.com/NixOS/nixpkgs/commit/1cb5f33ae6f818a410a14412038d165ec7443b1d) python3Packages.microBeesPy: init at 0.3.5
* [`c6d8c12c`](https://github.com/NixOS/nixpkgs/commit/c6d8c12ce93a024c0ae12bb2bbf20dd7bb84d17b) home-assistant: update component packages
* [`1aab4326`](https://github.com/NixOS/nixpkgs/commit/1aab4326935a4782d954467cecb05b67c161c8ae) python3Packages.pyebox: init at 1.1.4
* [`60263e65`](https://github.com/NixOS/nixpkgs/commit/60263e6534a93ad1d45ae5ba27af28ab596d0ca2) home-assistant: update component packages
* [`64ac4e79`](https://github.com/NixOS/nixpkgs/commit/64ac4e7990d697f4d5119f53c419829bdad14c25) rio: 0.2.28 -> 0.2.29
* [`ce81f5cb`](https://github.com/NixOS/nixpkgs/commit/ce81f5cb0f4b200295bde0879e18143640ae262e) nixosTests.modular-service-etc: Refine a test assertion
* [`d88b9464`](https://github.com/NixOS/nixpkgs/commit/d88b9464b06021f35e35c30f880a989af58b7f92) system.services: Remove ambiguous, redundant pkgs module argument
* [`90162e81`](https://github.com/NixOS/nixpkgs/commit/90162e8113546e3d16f1b8dead39f3ba7fee6c43) nixos/service/portable: Provide an entrypoint function
* [`8a7e4f58`](https://github.com/NixOS/nixpkgs/commit/8a7e4f589a52eac93a60f13b4a4a07efc78b9d2b) nixos/portable/test.nix: Fix test
* [`43d36478`](https://github.com/NixOS/nixpkgs/commit/43d364787c56f78898a17eab38fff07771ba1842) nixos/fcitx5: remove i18n.inputMethod.fcitx5.plasma6Support
* [`01fc72b3`](https://github.com/NixOS/nixpkgs/commit/01fc72b3566368a219470f4ac0b456216cf5ba29) fcitx5: remove from qt5 packages and use qt6 ones as top-level aliases
* [`4798a0c6`](https://github.com/NixOS/nixpkgs/commit/4798a0c6cee3f5930560de5c80525422c4858585) docker-buildx: 0.26.1 -> 0.27.0
* [`67f0915d`](https://github.com/NixOS/nixpkgs/commit/67f0915d2b53b6b3285f0e51c91514b4474f4693) junixsocket-common: init at 2.10.1
* [`7c117989`](https://github.com/NixOS/nixpkgs/commit/7c1179895554ed6840ee283a95dd8752cd013d53) transito: 0.9.1 -> 0.10.0
* [`19f5c489`](https://github.com/NixOS/nixpkgs/commit/19f5c489cba6a3a6f1bee83dacb69e424fd6d752) cppcheck: 2.18.0 -> 2.18.1
* [`59f0f1e7`](https://github.com/NixOS/nixpkgs/commit/59f0f1e7ea8f2254fef2e9f0705c01b31f48e8f1) nixos/networkd: allow setting `ManageForeignNextHops` option
* [`75e6384b`](https://github.com/NixOS/nixpkgs/commit/75e6384be6fed93d60c0bbb05afb194f392ced8b) pythonPackages.pytest-ansible: add robsliwi as maintainer
* [`bb0bd3d4`](https://github.com/NixOS/nixpkgs/commit/bb0bd3d41349fd1ecabba07ed94741dcb81bf062) lib/modules: add _internal to valueMeta of checkedAndMerged
* [`03f16593`](https://github.com/NixOS/nixpkgs/commit/03f16593904f8a0811ed47143dd4f0f8d73db74b) livebook: move under beam modules
* [`ecd64d01`](https://github.com/NixOS/nixpkgs/commit/ecd64d0153bf2db6797a9ad057fe9e0ab7feda11) beamPackages.livebook: add beam team
* [`41e0112f`](https://github.com/NixOS/nixpkgs/commit/41e0112fdfa44371a75013fe59fd807a57fed309) font-alias: switch from fetchurl to fetchFromGitLab
* [`871f10c7`](https://github.com/NixOS/nixpkgs/commit/871f10c794ce326426cefba4f5d13481459a60f4) thunderbird-128-unwrapped: 128.13.0esr -> 128.14.0esr
* [`9e238cc4`](https://github.com/NixOS/nixpkgs/commit/9e238cc4e64abe4d3de66f9acf65717404cdf37e) phase-cli: 1.19.2 -> 1.19.3
* [`bfeebf7b`](https://github.com/NixOS/nixpkgs/commit/bfeebf7b5c669ff3a7998214f9f649fcd2e5b1e7) wine-staging: 10.12 -> 10.13
* [`72427e25`](https://github.com/NixOS/nixpkgs/commit/72427e253359bfcd4474fbcb0b5d725c5d61555c) junixsocket-native-common: init at 2.10.1
* [`d7f50bf6`](https://github.com/NixOS/nixpkgs/commit/d7f50bf6605a248f28ef94ac973ed19fdc1a6896) lutris: Add adwaita-icon-theme to FHS environment
* [`f95f31ff`](https://github.com/NixOS/nixpkgs/commit/f95f31ff2dfd2e83fb15bec6cd3bca60524f989c) taskchampion-sync-server: 0.6.1 -> 0.7.0
* [`90e377d0`](https://github.com/NixOS/nixpkgs/commit/90e377d0f78c01af9715fcd5f263539b8d40fe24) xbill: fix build on darwin; test that binary exists
* [`321ec842`](https://github.com/NixOS/nixpkgs/commit/321ec8426d2f273b1f728dbc557d5b4ab81aec4a) dartsim: use merged commit patches instead of PR
* [`67cbd741`](https://github.com/NixOS/nixpkgs/commit/67cbd7414c36709528b051a40ca199303dbeb268) cri-tools: 1.33.0 -> 1.34.0
* [`25501709`](https://github.com/NixOS/nixpkgs/commit/255017094fa6f46e3cdcb7035a12b57623815b65) lomiri.teleports: 1.20 -> 1.21
* [`c4c33119`](https://github.com/NixOS/nixpkgs/commit/c4c33119067979895c9ce484dfe445d1a31aa1df) symfony-cli: add completions and adopt
* [`b0cc7ce9`](https://github.com/NixOS/nixpkgs/commit/b0cc7ce96f7103858a8d436ed76a4649f35045a4) spdk: 24.09 -> 25.05
* [`56c38669`](https://github.com/NixOS/nixpkgs/commit/56c38669fd4e8a6f0093486ab3617b5f1ec6b181) filecheck: 1.0.2 -> 1.0.3
* [`7cc80440`](https://github.com/NixOS/nixpkgs/commit/7cc80440a32ca000d61c9a764f8791e4184c38b0) fluent-icon-theme: 2025-02-26 -> 2025-08-21
* [`00c2bcdb`](https://github.com/NixOS/nixpkgs/commit/00c2bcdbdd8c94c4b3a4c46b1b3cdbecca4fbfe3) python3Packages.pytorch-metric-learning: 2.8.1 -> 2.9.0
* [`456219ad`](https://github.com/NixOS/nixpkgs/commit/456219ad361e6a3e7364ab5ef78eb4b1eb34e8ca) xemu: 0.7.135 -> 0.8.96
* [`9a9f5bca`](https://github.com/NixOS/nixpkgs/commit/9a9f5bcaed00d2e5bcb50e9a63ca8f6dc06df0d2) xemu: adopt
* [`122e2919`](https://github.com/NixOS/nixpkgs/commit/122e29198212ac3ddea30f914355355e02203321) nixos/slurm: update test, make more reliable
* [`fd7f32b9`](https://github.com/NixOS/nixpkgs/commit/fd7f32b9fffbbb4666a98aebb1bf8989da31d885) wasm-tools: 1.236.1 -> 1.237.0
* [`63ea54ac`](https://github.com/NixOS/nixpkgs/commit/63ea54ac57217887c9cf15610821d28781d29d73) gitea-mcp-server: 0.3.0 -> 0.3.1
* [`d4a21953`](https://github.com/NixOS/nixpkgs/commit/d4a2195349afbe0191e973c49f258d5a49d9c6f1) python3Packages.craft-application: 5.6.3 -> 5.6.5
* [`ff63eca9`](https://github.com/NixOS/nixpkgs/commit/ff63eca997423e6fc29c72912c4a06bdbbb7f5f8) flameshot: 13.0.1 -> 13.1.0
* [`856dfa14`](https://github.com/NixOS/nixpkgs/commit/856dfa14f410f60ecd3dbb6f04f57af038cbdde4) python3Packages.google-cloud-kms: skip bulk updates
* [`a3005867`](https://github.com/NixOS/nixpkgs/commit/a30058670971fdb2a6d211ad8fe15a44cabc0c52) python3Packages.google-cloud-asset: use gitUpdater
* [`8fafe811`](https://github.com/NixOS/nixpkgs/commit/8fafe8114162120349f30b0ac351aa9e2694f5ff) embellish: 0.4.7 -> 0.5.1
* [`07949979`](https://github.com/NixOS/nixpkgs/commit/0794997950561d7eb8fee8c68f7c9e67736fe162) jenkins: 2.516.1 -> 2.516.2
* [`e5a5b0de`](https://github.com/NixOS/nixpkgs/commit/e5a5b0de7dad339f23e30a061551d545a7340c93) python3Packages.numato-gpio: init at 0.14.0
* [`d4abfff1`](https://github.com/NixOS/nixpkgs/commit/d4abfff176f427f31ec0512610a725f8a69e81ff) home-assistant: update component packages
* [`709056bd`](https://github.com/NixOS/nixpkgs/commit/709056bd4543aa001bc068ee67c8c2a513baa3ec) python3Pacakges.clx-sdk-xms: init at 0-unstable-2017-01-23
* [`1ef1b273`](https://github.com/NixOS/nixpkgs/commit/1ef1b2731a366933e1e863ce69eb3d5c3b4b25b0) home-assistant: update component packages
* [`a1836985`](https://github.com/NixOS/nixpkgs/commit/a1836985b247bac95bc9ab84443fbe489cdab3f1) kubernetes-helm: 3.18.5 -> 3.18.6
* [`d5519a84`](https://github.com/NixOS/nixpkgs/commit/d5519a849c0794a1937feb181486df5039599c63) xjump: drop
* [`99fc3f4e`](https://github.com/NixOS/nixpkgs/commit/99fc3f4e4c04c5999c2d1308c8a8780e26d800d1) python3Packages.yeelightsunflower: init at 0.0.10
* [`1648af8a`](https://github.com/NixOS/nixpkgs/commit/1648af8a59fada6beff862fafb8e7995e0293158) home-assistant: update component packages
* [`f51a786c`](https://github.com/NixOS/nixpkgs/commit/f51a786cff2607ecd4c6653d909908ef65004227) python3Packages.rfk101py: init at 0.0.1
* [`9c37d976`](https://github.com/NixOS/nixpkgs/commit/9c37d976531e153a9079ead126600b3dae8c0429) home-assistant: update component packages
* [`352dc09a`](https://github.com/NixOS/nixpkgs/commit/352dc09a50b5c38e867ab45dfe9f3cad2265f49d) lychee: 0.19.1 -> 0.20.0
* [`931b59fd`](https://github.com/NixOS/nixpkgs/commit/931b59fd50f408c83e9d556b1c7304df4041ef76) rclone-ui: 1.0.4 -> 1.7.1
* [`b7142407`](https://github.com/NixOS/nixpkgs/commit/b71424077a37f4d58ccb3f09076507872b9ae39f) python3Packages.pymarshal: 2.2.0 -> 2.2.1
* [`9de2b9fd`](https://github.com/NixOS/nixpkgs/commit/9de2b9fddb16f73411bba341324eaa33d738d17e) vulnix: 1.11.0 -> 1.12.0
* [`1b39a4b9`](https://github.com/NixOS/nixpkgs/commit/1b39a4b99baa167a2554a41b00a008e4710cce17) python3Packages.logassert: 8.5 -> 8.6
* [`706f659c`](https://github.com/NixOS/nixpkgs/commit/706f659c75c4ec3bbfb24b1843c290f4afe1b308) python3Packages.s3fs: 2025.2.0 -> 2025.7.0
* [`317fc34b`](https://github.com/NixOS/nixpkgs/commit/317fc34b26897c628b53040e2431730bb3e0f06e) freerdp: 3.16.0 -> 3.17.0
* [`f4fbb606`](https://github.com/NixOS/nixpkgs/commit/f4fbb606882d44753e99b95ddabb5e04f7aa55c2) gnuchess: 6.2.11 -> 6.3.0
* [`e27f83ae`](https://github.com/NixOS/nixpkgs/commit/e27f83ae02c5024cc8221f4be2dfe118c9cf3326) openvswitch: 3.5.1 -> 3.6.0
* [`7151ae1b`](https://github.com/NixOS/nixpkgs/commit/7151ae1bcdc0c778ce27a6290c3b3b89ce9dbcde) stdenv: Move all stdenv lookups out of mkDerivation
* [`8d7a928c`](https://github.com/NixOS/nixpkgs/commit/8d7a928c05aa1704ad873c3e71767ba08749b1ef) crowdin-cli: 4.9.1 -> 4.10.0
* [`d261f165`](https://github.com/NixOS/nixpkgs/commit/d261f16536d3288cb21c3ab9f951de0a679111e8) python313Packages.edlib: 1.3.9 -> 1.3.9post1
* [`6b7b6b30`](https://github.com/NixOS/nixpkgs/commit/6b7b6b30b4f3f30eccfea2cb21cdf1ad2a8782b6) maple-font: 7.4 -> 7.6
* [`5241898a`](https://github.com/NixOS/nixpkgs/commit/5241898a20e15031177759db454308929ee6c578) nixos/systemd-user: enable systemd-tmpfiles-clean.timer
* [`44c7414c`](https://github.com/NixOS/nixpkgs/commit/44c7414cc634635bfeee3527fc8cc4ecf52c50c9) nixos/systemd-user: add systemd.user.tmpfiles.enable
* [`12c32772`](https://github.com/NixOS/nixpkgs/commit/12c3277231748ed805db724ec3f46d14eea303eb) python312Packages.nipype: fix dependencies, minor refactor
* [`789cb18a`](https://github.com/NixOS/nixpkgs/commit/789cb18a7e377fe4dabf092f522171375e03e469) flameshot: support wlr by default
* [`a9c550be`](https://github.com/NixOS/nixpkgs/commit/a9c550be4426c041c09c1e2d32a83f0183ef3583) python3Packages.mplfinance: 0.12.7a7 -> 0.12.10b0
* [`cbfa9d3a`](https://github.com/NixOS/nixpkgs/commit/cbfa9d3a813fb6d5127f8de0de179628d3300e23) asciinema-automation: 0.2.0 -> 0.2.2
* [`f21aab67`](https://github.com/NixOS/nixpkgs/commit/f21aab67183b28df3663c9762fb835179643b68a) pcb2gcode: fix finding boost
* [`28dc7132`](https://github.com/NixOS/nixpkgs/commit/28dc7132f648f90436a6532d0775ff95343a06bb) python3Packages.eve: 2.2.0 -> 2.2.1
* [`599d4d89`](https://github.com/NixOS/nixpkgs/commit/599d4d890c237883d23dd31018aa801eb471b477) grafanaPlugins.grafana-sentry-datasource: init at 2.2.1
* [`011a6b6d`](https://github.com/NixOS/nixpkgs/commit/011a6b6d2b92ace11012b5a02fb2f8e50d668636) python3Packages.bk7231tools: 2.0.2 -> 2.1.0
* [`bafc2021`](https://github.com/NixOS/nixpkgs/commit/bafc202175ab4d9917c1178c0a0117ecb1e5d080) netdata: 2.6.2 -> 2.6.3
* [`be80c8a8`](https://github.com/NixOS/nixpkgs/commit/be80c8a868ce1ee3e3584488251c094ccbd05ea7) peergos: 1.9.0 -> 1.10.0
* [`4c39d9ab`](https://github.com/NixOS/nixpkgs/commit/4c39d9ab8ecf569c4c28ee6235219c2808a3c6fc) wealthfolio: 1.1.6 -> 1.2.0
* [`3be790be`](https://github.com/NixOS/nixpkgs/commit/3be790be3a6d3fb6dacfb1f6589f87499bb6bc26) terragrunt: 0.85.0 -> 0.86.0
* [`9c0c6b38`](https://github.com/NixOS/nixpkgs/commit/9c0c6b382654ccd479cb50b2d6e997cfdd0ba8fa) wasilibc: 22-unstable-2024-10-26 -> 27-unstable-2025-07-27
* [`d8603c74`](https://github.com/NixOS/nixpkgs/commit/d8603c74deac7e0a7a9b4d202dd30ae91a136810) wasilibc: refactor and clean up the package
* [`6a4aac01`](https://github.com/NixOS/nixpkgs/commit/6a4aac01d9b272341ace89c1da27cc219f56d407) wasilibc: enable posix thread-model via opt-in arg
* [`f0baf6cb`](https://github.com/NixOS/nixpkgs/commit/f0baf6cb3888806cafe0b61292052ccd03313297) freeimpi: disable hardcoded uid check
* [`4defcb5a`](https://github.com/NixOS/nixpkgs/commit/4defcb5a8b1d8913dc5142b8c33272dce95c4dba) python3Packages.cryptg: 0.5.post0 -> 0.5.1
* [`df8e25a2`](https://github.com/NixOS/nixpkgs/commit/df8e25a2fbb16dabaffbff713f968674eee0f3db) spirit: 0.8.0 -> 0.9.0
* [`c11cf2be`](https://github.com/NixOS/nixpkgs/commit/c11cf2be5a4b32b16b71d919d996d87cc8290939) wire: 0.6.0 -> 0.7.0
* [`83b4a4bd`](https://github.com/NixOS/nixpkgs/commit/83b4a4bde950a6c873a5e95a9c4aabb32a9254ca) joplin-desktop: 3.3.13 -> 3.4.6
* [`2841c91a`](https://github.com/NixOS/nixpkgs/commit/2841c91af6093ee930c2c2b69bc5497f2b04508e) python313Packages.sphinxcontrib-images: 0.9.4 -> 1.0.1
* [`74ab541d`](https://github.com/NixOS/nixpkgs/commit/74ab541dfb460da2c1e7f28aa3cbb6ef472d3c48) fromager: 0.47.0 -> 0.59.0
* [`a20ac7df`](https://github.com/NixOS/nixpkgs/commit/a20ac7df84ec8f414c00b47543a8344a4bca7972) luau: 0.687 -> 0.688
* [`d46d689c`](https://github.com/NixOS/nixpkgs/commit/d46d689c862cb2ad010c22ee3afda6133dafafaa) python3Packages.bonsai: 1.5.3 -> 1.5.4
* [`bb972270`](https://github.com/NixOS/nixpkgs/commit/bb972270d47ea3ae71ec31415a016d7f7b52b717) waymore: 4.7 -> 6.1
* [`b69895b8`](https://github.com/NixOS/nixpkgs/commit/b69895b85d138dc380dc1f671c3d7711f160d1cc) graphinder: 1.11.6 -> 2.0.0b4
* [`0425d398`](https://github.com/NixOS/nixpkgs/commit/0425d3980c368b6b65b54ac76771df148ae33d66) python3Packages.fints: 4.2.3 -> 4.2.4
* [`7d225596`](https://github.com/NixOS/nixpkgs/commit/7d225596fd51f930c5a371631403c2234c3340fc) netavark: 1.16.0 -> 1.16.1
* [`81b728b3`](https://github.com/NixOS/nixpkgs/commit/81b728b3eb6c9a03663ac98d0dee6df9a86cd6e5) virt-top: fix build for gettext 0.25
* [`84a762ee`](https://github.com/NixOS/nixpkgs/commit/84a762ee6c7f168dc3c19d80cf29d6bf8594c62c) shortcat: adds t-monaghan to maintainers
* [`c0387a60`](https://github.com/NixOS/nixpkgs/commit/c0387a60af81ada4fedbf5cd9968bebab92ac399) shortcat: 0.11.4 -> 0.12.2
* [`bb78e709`](https://github.com/NixOS/nixpkgs/commit/bb78e709c53067e84306005b1e746648acbf6384) easytier: 2.4.1 -> 2.4.2
* [`248e39ec`](https://github.com/NixOS/nixpkgs/commit/248e39ec23c64a0322108017f1bd1f7cab400b07) python3Packages.sourmash: 4.8.14 -> 4.9.4
* [`2a211337`](https://github.com/NixOS/nixpkgs/commit/2a2113379eccb33de954a33ebf62352764ce86d0) process-compose: 1.64.1 -> 1.73.0
* [`247a8f01`](https://github.com/NixOS/nixpkgs/commit/247a8f015b6d7d16b5c41df3e6141722afa19db2) python313Packages.tencentcloud-sdk-python: 3.0.1446 -> 3.0.1447
* [`21dda58b`](https://github.com/NixOS/nixpkgs/commit/21dda58bd7d947ba1ee05bcca222d49eacc109d0) ngtcp2-gnutls: 1.14.0 -> 1.15.0
* [`2cddeeb2`](https://github.com/NixOS/nixpkgs/commit/2cddeeb21195301e2d8c36a4b3dcbb2d1c5e60c7) lxterminal: small cleanup
* [`2a2183fb`](https://github.com/NixOS/nixpkgs/commit/2a2183fb9557b53b80a03c97ee21b24c3888687d) prometheus-redis-exporter: 1.75.0 -> 1.76.0
* [`ff8a1499`](https://github.com/NixOS/nixpkgs/commit/ff8a14998e1852f8112a8cd97f4d93f82fcc0b55) sniproxy: fix build gettext 0.25
* [`57c3dfc7`](https://github.com/NixOS/nixpkgs/commit/57c3dfc7d8b483906cd7adedde38ac1137708c1b) spicedb: 1.45.1 -> 1.45.2
* [`41d9e048`](https://github.com/NixOS/nixpkgs/commit/41d9e0480962e3fa6d7e776293933bf602b91f83) peertube: 7.2.1 -> 7.2.3
* [`4df21028`](https://github.com/NixOS/nixpkgs/commit/4df210289a5f18ee009c05ecc8ef0a6703a615ea) sope: 5.12.2 -> 5.12.3
* [`1109cc1a`](https://github.com/NixOS/nixpkgs/commit/1109cc1a416659de71fa2fedfcdbfc404f545254) python313Packages.asyncinotify: 4.2.0 -> 4.2.1
* [`5827278a`](https://github.com/NixOS/nixpkgs/commit/5827278ab41c15aca17ea4a94284cf1aa87a8a1f) tfmigrate: 0.4.2 -> 0.4.3
* [`dd9ccc24`](https://github.com/NixOS/nixpkgs/commit/dd9ccc24ed399a61b08d40ed20005fef0c7730b9) python3Packages.pkg-about: 1.3.7 -> 1.4.0
* [`c8b5657f`](https://github.com/NixOS/nixpkgs/commit/c8b5657f154f59c549e7aab1cb96fd48cae92543) obs-studio-plugins.obs-text-pthread: 2.0.5 -> 2.0.6
* [`6f5ca52d`](https://github.com/NixOS/nixpkgs/commit/6f5ca52d41ed71a40845461f172ddb80db52136a) python3Packages.spyder-kernels: 3.1.0a2 -> 3.1.0a3
* [`5f711585`](https://github.com/NixOS/nixpkgs/commit/5f71158592f4fec1a591ddc85235efaa25e7c95e) openapv: init at 0.2.0.1
* [`5062f1f2`](https://github.com/NixOS/nixpkgs/commit/5062f1f22fb78fdbf25e3772d5b7e123c5a04b40) ffmpeg_8{,-headless,-full}: init at 8.0
* [`eb8e2a6b`](https://github.com/NixOS/nixpkgs/commit/eb8e2a6b4be51ee1c70dcc61b20c9690ef4b3814) python3Packages.pywebview: 5.4 -> 6.0
* [`bd8bb068`](https://github.com/NixOS/nixpkgs/commit/bd8bb06804183ca5a353b296d580acc65c17de5b) solarus{,quest-editor,launcher}: 2.0.0 -> 2.0.1
* [`694d2c92`](https://github.com/NixOS/nixpkgs/commit/694d2c92544202fb5dad8e2c9848b7748e44fb81) todoman: 4.5.0 -> 4.6.0
* [`3fa8d065`](https://github.com/NixOS/nixpkgs/commit/3fa8d065dadf4a291eebfa9fef9167e0babbb851) near-facsimile: init at 1.0.9
* [`e7c7aae4`](https://github.com/NixOS/nixpkgs/commit/e7c7aae4c2e100a76988e1e173bd7b966941b08e) python3Packages.python-clementine-remote: init at 1.0.3
* [`d0c2c911`](https://github.com/NixOS/nixpkgs/commit/d0c2c911bd1b8556d2f8278b59c30ada986235ea) home-assistant: update component packages
* [`a7c15865`](https://github.com/NixOS/nixpkgs/commit/a7c15865d079fbbb1e01c910c34606b6b0e55b63) zapret: 71 -> 71.4
* [`cae15208`](https://github.com/NixOS/nixpkgs/commit/cae15208433c8ea14cb567c56336aee810c3e465) maintainers: add erichelgeson
* [`839adf42`](https://github.com/NixOS/nixpkgs/commit/839adf42dfea5e944f28868d867307dfd1079f40) qmplay2: pin vulkan-headers dependency to specific version
* [`f3b7f6ac`](https://github.com/NixOS/nixpkgs/commit/f3b7f6ac2085fba26f9bdf5a594808cb2750432b) qmplay2: 25.01.19 -> 25.06.27
* [`a9d5b9c6`](https://github.com/NixOS/nixpkgs/commit/a9d5b9c660eebc54346913f0238db2fc63c8429b) osm-gps-map: fix build
* [`c9882aa8`](https://github.com/NixOS/nixpkgs/commit/c9882aa83bb0a51dfcb883bde0d0a2f288422208) ciderpress2: init at 1.1.0
* [`38a6bd63`](https://github.com/NixOS/nixpkgs/commit/38a6bd63b4aa45a6e79a46bf9243d1be86d187fa) mise: 2025.8.10 -> 2025.8.20
* [`1df0ced6`](https://github.com/NixOS/nixpkgs/commit/1df0ced67d397927921987e163c3fbcd58c2c191) cynthion: make udev rules accessible
* [`02a2dd63`](https://github.com/NixOS/nixpkgs/commit/02a2dd63a72549bdbafc880d042ac3d519830e84) protoc-gen-es: 2.6.3 -> 2.7.0
* [`ccc052f3`](https://github.com/NixOS/nixpkgs/commit/ccc052f38d356c888cec8d3952778057c0d3624d) python3Packages.tree-sitter: 0.25.0 -> 0.25.1
* [`ba6c6c9b`](https://github.com/NixOS/nixpkgs/commit/ba6c6c9b05fe7b2776fb6615fde83946b9e972db) lxde.lxrandr: 0.3.2 -> 0.3.3
* [`e8d7b1be`](https://github.com/NixOS/nixpkgs/commit/e8d7b1bee572a205919be9ccc4f5d80561c8c5f9) lxde.lxpanel: change upstream source
* [`abe24880`](https://github.com/NixOS/nixpkgs/commit/abe24880dcb8c8f22fd204d7cd477e0eee12f9dc) lxde.lxpanel: 0.10.1 -> 0.11.1
* [`db00f84b`](https://github.com/NixOS/nixpkgs/commit/db00f84b57848a24dba7e1b75628db9075e65763) lxde.lxtask: cleanup
* [`bc75642e`](https://github.com/NixOS/nixpkgs/commit/bc75642e58b7ad9c8140628ccc030957575104c3) python3Packages.bjoern: 3.2.1 -> 3.2.2
* [`e9f74a2a`](https://github.com/NixOS/nixpkgs/commit/e9f74a2a3124c42f652c573c130cabd1c63931c3) python3Packages.glyphslib: 6.11.4 -> 6.11.6
* [`f4cece24`](https://github.com/NixOS/nixpkgs/commit/f4cece247d4c0934dd0afb6354f1123c50c34906) python3Packages.btest: 1.1 -> 1.2
* [`477089e3`](https://github.com/NixOS/nixpkgs/commit/477089e3a72100014b39a08cdfa98be0418333c1) python3Packages.pyoverkiz: 1.18.1 -> 1.18.2
* [`5b727d64`](https://github.com/NixOS/nixpkgs/commit/5b727d64cadeff58ecb73da158d4bcaabcac3021) python3Packages.pycmus: init at 0.1.1
* [`1abb9a3e`](https://github.com/NixOS/nixpkgs/commit/1abb9a3e84ce8c603557c7d496ef87423339c952) home-assistant: update component packages
* [`246d0d54`](https://github.com/NixOS/nixpkgs/commit/246d0d543967de246fa65063b27db8223f53f5ed) ome_zarr: 0.12.1 -> 0.12.2
* [`389c1f0e`](https://github.com/NixOS/nixpkgs/commit/389c1f0e74eff7aecc5a96b681b7d142cffa2b09) discord-canary: 0.0.740 -> 0.0.745
* [`328b7c32`](https://github.com/NixOS/nixpkgs/commit/328b7c32e8ae5864088df44570a4fd006cb71b57) mousai: 0.7.8 -> 0.7.9
* [`428a6e2a`](https://github.com/NixOS/nixpkgs/commit/428a6e2a503bad4b80f2ccc4bd727e6766f1c481) python3Packages.openai-agents: 0.2.7 -> 0.2.9
* [`44827a9d`](https://github.com/NixOS/nixpkgs/commit/44827a9dbfc2ea6d0459456f767c2a188451056f) maintainers: add acidbong
* [`9ab49299`](https://github.com/NixOS/nixpkgs/commit/9ab4929950d034b780afb037bb22548362afb96a) mpdris2-rs: init at 1.0.2
* [`a480fa1c`](https://github.com/NixOS/nixpkgs/commit/a480fa1c53c9196b8faf495cd3d49b32b5b827b8) equicord: 2025-07-25 -> 2025-08-24
* [`60088b75`](https://github.com/NixOS/nixpkgs/commit/60088b75eb1aab91c3811fcb83f0dc73f41b508c) discord: add equicord support
* [`6b5d51d3`](https://github.com/NixOS/nixpkgs/commit/6b5d51d3b9fd651ad99b350a01242698c8c3cdfe) discord: make vencord, equicord and moonlight mutually exclusive
* [`09ab7943`](https://github.com/NixOS/nixpkgs/commit/09ab794379be9d87f5e3f07dfd8cc662e94831f5) python313Packages.aioelectricitymaps: 1.1.0 -> 1.1.1
* [`151b882c`](https://github.com/NixOS/nixpkgs/commit/151b882c22322e365e83cbdd23ed9c2e3db39a6d) python313Packages.asusrouter: 1.18.2 -> 1.20.1
* [`c52ad993`](https://github.com/NixOS/nixpkgs/commit/c52ad993b0c689ac3c2a648689fbb47f1922d4c9) python313Packages.yalexs: 8.11.1 -> 8.12.0
* [`3d78b025`](https://github.com/NixOS/nixpkgs/commit/3d78b0258b7f836230191ddb6a13607619e72059) python313Packages.bjoern: add changelog to meta
* [`685ee6c8`](https://github.com/NixOS/nixpkgs/commit/685ee6c821777b2ca9e786f2e226498192f668dd) python313Packages.bjoern: modernize
* [`a397c9bb`](https://github.com/NixOS/nixpkgs/commit/a397c9bbf2eb21d2dc71f4ed38a253c54a5add3c) python313Packages.btest: modernize
* [`6d174d69`](https://github.com/NixOS/nixpkgs/commit/6d174d69924fc253ccd914dc9c0d5ea948dfbc1d) python313Packages.fpdf2: modernize
* [`dabf42d8`](https://github.com/NixOS/nixpkgs/commit/dabf42d8e577e57182d36b4c3fe2102a5c709e04) python3Packages.skyfield: 1.49 -> 1.53
* [`4f2529ac`](https://github.com/NixOS/nixpkgs/commit/4f2529ac468accc26a5b02fcbb45fd9c3ee13698) python313Packages.fpdf2: add missing input
* [`2d13a491`](https://github.com/NixOS/nixpkgs/commit/2d13a4916799ea28d854912203b29487c129cc58) python313Packages.firecrawl-py: add missing aiohttp
* [`3bac06a7`](https://github.com/NixOS/nixpkgs/commit/3bac06a772c23491d517c4a589280da7a817e703) xmind: 25.04.03523-202505300040 -> 25.07.03033-202507241842
* [`5524d0c2`](https://github.com/NixOS/nixpkgs/commit/5524d0c2f5a8bab2437018e36da163303d1ad20f) python3Packages.plac: 1.4.3 -> 1.4.5
* [`4cd81eaa`](https://github.com/NixOS/nixpkgs/commit/4cd81eaad5bdaf1431fd916117549df3ab5a1e57) cursor-cli: init at 0-unstable-2025-08-22
* [`83c082c7`](https://github.com/NixOS/nixpkgs/commit/83c082c771d2434ac5bdeecf47e750d6ff58b155) python3Packages.mammoth: 1.8.0 -> 1.10.0
* [`c9ec96dc`](https://github.com/NixOS/nixpkgs/commit/c9ec96dce90982da58fcd056e2a27bda1278d15f) python3Packages.cli-ui: 0.18.0 -> 0.19.0
* [`6f851167`](https://github.com/NixOS/nixpkgs/commit/6f8511675a671ce9ef52934242212ba85be4483c) n8n: 1.106.3 -> 1.107.4
* [`b6bbf7b2`](https://github.com/NixOS/nixpkgs/commit/b6bbf7b2509cf967934baa3bbe5502cdd7fa7151) workflows/check: always run commits job
* [`c96b0e6d`](https://github.com/NixOS/nixpkgs/commit/c96b0e6d3df6c2cc5a156595ac2b3d4d00fd92e2) ci/github-script/commits: split review function into separate file
* [`bd8420d9`](https://github.com/NixOS/nixpkgs/commit/bd8420d9c5ab3b03f9892b6cc8c8771674573240) phpPackages.composer: 2.8.5 -> 2.8.11, add completion, adopt
* [`55206319`](https://github.com/NixOS/nixpkgs/commit/5520631943d2ea53d95fed5f65e9a44014ea4e84) python3Packages.dragonmapper: 0.2.7 -> 0.3.0
* [`801fad36`](https://github.com/NixOS/nixpkgs/commit/801fad36ce3d08cb1b8300e79e3a8d77270a6c3f) zstd: set meta.pkgConfigModules
* [`4218a1dc`](https://github.com/NixOS/nixpkgs/commit/4218a1dc47ad05cebba4a33b389632e6716f6b0f) chameleon-cli: 2.0.0-unstable-2025-08-04 -> 2.0.0-unstable-2025-08-19
* [`6770ea5d`](https://github.com/NixOS/nixpkgs/commit/6770ea5ddde1d5dece5baf96e8434c380449b232) gnumeric: switch to gitlab sources, fix build
* [`fcaf5bdf`](https://github.com/NixOS/nixpkgs/commit/fcaf5bdf162312953dc75df280435e0e4fc075b5) anki: 25.02.5 -> 25.07.5
* [`fd9dd9a8`](https://github.com/NixOS/nixpkgs/commit/fd9dd9a83a62eb80ec3163e3b89358b86fcdf503) python3Packages.pyairtable: 3.1.1 -> 3.2.0
* [`2a630ed6`](https://github.com/NixOS/nixpkgs/commit/2a630ed68970af45f9858d68a198e0a64c71346f) speedtest: 1.3.0 -> 1.4.0
* [`de255942`](https://github.com/NixOS/nixpkgs/commit/de255942cfcdc1c59a0907f1326b486f25e8573c) ulauncher: add desktop item
* [`6d516d5d`](https://github.com/NixOS/nixpkgs/commit/6d516d5d9bfc03559c9c445a6f5b9e1d277aebbe) euphonica: add updateScript
* [`ad662d85`](https://github.com/NixOS/nixpkgs/commit/ad662d85a7a446089add7404131865c93afe5e36) euphonica: build release profile
* [`51ea4a3d`](https://github.com/NixOS/nixpkgs/commit/51ea4a3d0eaabb3ebeab8c0c47a9164f4f5e0cab) euphonica: 0.96.1-beta -> 0.96.3-beta
* [`cb88ba34`](https://github.com/NixOS/nixpkgs/commit/cb88ba34d7702ea99f42170b4060129507aed321) lucida-downloader: switch to nix-update-script
* [`5cf54bdc`](https://github.com/NixOS/nixpkgs/commit/5cf54bdc38e7a99cfb0af57b7de6f3dc21fdf865) lucida-downloader: 0.2.0 -> 0.6.0
* [`930fc1ae`](https://github.com/NixOS/nixpkgs/commit/930fc1ae9ba6724071a414f6bff09d4b60764a12) python3Packages.fire: 0.7.0 -> 0.7.1
* [`2fdf11e6`](https://github.com/NixOS/nixpkgs/commit/2fdf11e6f6250f842890b66b4eab8c64bd206eba) cerberus: 0-unstable-2025-07-25 -> 0-unstable-2025-08-18
* [`6499992b`](https://github.com/NixOS/nixpkgs/commit/6499992bd3498d95d5493a5913a091b769e2cfc8) python3Packages.oracledb: fix build and modernize
* [`19156cb5`](https://github.com/NixOS/nixpkgs/commit/19156cb53739c40fc045d40f1178795e6cba6fc5) python3Packages.django-modeltranslation: fix build and modernize
* [`88670a31`](https://github.com/NixOS/nixpkgs/commit/88670a3166d12740c3b91d2635a4ffc67eee8eb4) python3Packages.pyexcel-xls: fix build
* [`98a41b36`](https://github.com/NixOS/nixpkgs/commit/98a41b36697896a9d67dc9e72d01aba8b0747877) angelscript: 2.37.0 -> 2.38.0
* [`ab59e0f0`](https://github.com/NixOS/nixpkgs/commit/ab59e0f0ff04fb7c230cb91860a5960de950552c) gridtracker2: 2.250815.0 -> 2.250820.0
* [`57fdac4a`](https://github.com/NixOS/nixpkgs/commit/57fdac4a608db7af198d5b75f672375fcddf2073) python3Packages.xvfbwrapper: fix build and enable tests
* [`60066ec4`](https://github.com/NixOS/nixpkgs/commit/60066ec4c5646a0128d3b73085b60ab7fa6db4dd) adios2: force use of -fallow-argument-mismatch
* [`0601cf6f`](https://github.com/NixOS/nixpkgs/commit/0601cf6fd0868b31429d3e1c90781fbba8b2b0c2) ci/github-script/prepare: avoid running CI when targeting channel branches
* [`87d9b08f`](https://github.com/NixOS/nixpkgs/commit/87d9b08ffbb7d91109c159900809097d7e401524) ci/github-script/prepare: identify real base branch
* [`b5b19bf4`](https://github.com/NixOS/nixpkgs/commit/b5b19bf460bf3269e15616792fb8c38a7e61437e) gallery-dl: 1.30.4 -> 1.30.5
* [`397d5560`](https://github.com/NixOS/nixpkgs/commit/397d5560f235d9a23e46e7a6ef751d7ce1c4733a) nixos/temporal: init module
* [`20da4c1b`](https://github.com/NixOS/nixpkgs/commit/20da4c1b706f92a2895e29024e4034e447f9e3d2) nixos/temporal: init test
* [`04fa7e25`](https://github.com/NixOS/nixpkgs/commit/04fa7e2527a6dafe78f8885451e8d82f764ea599) temporal: Add NixOS test to passthru.tests
* [`097eec36`](https://github.com/NixOS/nixpkgs/commit/097eec36759a1cbface8f615c0794ba937ec90b3) python3Packages.temporalio: Add NixOS test to passthru.tests
* [`f20852e4`](https://github.com/NixOS/nixpkgs/commit/f20852e46ff999ae9ff2f2fbeb53044ebdcf4a42) doc/release-notes: 25.11: Add Temporal item to new services
* [`89526e11`](https://github.com/NixOS/nixpkgs/commit/89526e117150b80fc5b57129be8ed363a7350a6c) nixos/logind: migrate to settings option
* [`7d8b7ce6`](https://github.com/NixOS/nixpkgs/commit/7d8b7ce6d12cd499785bfd08b7fdaa602604694d) python3Packages.swh-web-client: 0.9.0 -> 0.9.1
* [`3909c419`](https://github.com/NixOS/nixpkgs/commit/3909c419fbbd6c7b55718cb23cfd475c77d93fff) ed-odyssey-materials-helper: 2.223 -> 2.240
* [`3a5b2aa3`](https://github.com/NixOS/nixpkgs/commit/3a5b2aa3bb4a81fd3234aa5dde9e572602ed81e4) perf_data_converter: bump to Bazel 7
* [`6da76297`](https://github.com/NixOS/nixpkgs/commit/6da76297f0c9e3f4c33ae9352f145a56e5d2da5e) mozc: bump to Bazel 7
* [`adaf301d`](https://github.com/NixOS/nixpkgs/commit/adaf301dad3fbc4ff80bcbef1eb20bc84524cd97) fcitx5-mozc: bump to Bazel 7
* [`11637334`](https://github.com/NixOS/nixpkgs/commit/1163733449992247e4c45fd9fde5aead6cf95e7d) bant: bump to Bazel 7
* [`68c17550`](https://github.com/NixOS/nixpkgs/commit/68c17550acca50c3fa291947e6e8090ded424e41) verible: bump to Bazel 7
* [`047e6c12`](https://github.com/NixOS/nixpkgs/commit/047e6c1274b9bc063be213ed5de662dadfb9cfe6) python3Packages.svg-path: 6.3 -> 7.0
* [`607afb76`](https://github.com/NixOS/nixpkgs/commit/607afb7655bcea3bb5ee4bf8a7b9ca77ef214719) python313Packages.docling-core: 2.44.2 -> 2.45.0
* [`2d2dea19`](https://github.com/NixOS/nixpkgs/commit/2d2dea1980dd3da656ab516137246831af476c8b) python313Packages.docling-parse: 4.1.0 -> 4.2.3
* [`a120ad68`](https://github.com/NixOS/nixpkgs/commit/a120ad68aad1d8c9a0fad127c25fbda66ee2f1b0) python313Packages.docling: 2.43.0 -> 2.47.1
* [`6e17d156`](https://github.com/NixOS/nixpkgs/commit/6e17d1560a09a8a13d9a4c21212cf82b7773dadd) python313Packes.docling: disable tests that access network
* [`7858cb04`](https://github.com/NixOS/nixpkgs/commit/7858cb0472cdd47fedfdfbc37de0c3e3d83256df) amazon-q-cli: 1.13.3 -> 1.14.1
* [`c3a29b5c`](https://github.com/NixOS/nixpkgs/commit/c3a29b5c1d79dbe0ed6b3069dbe7a82a3aa8e8ff) imagemagick: 7.1.2-1 -> 7.1.2-2
* [`961847a6`](https://github.com/NixOS/nixpkgs/commit/961847a69f21dda52975f496ffb66fdee2e2bf85) victorialogs: 1.26.0 -> 1.29.0
* [`c51e3465`](https://github.com/NixOS/nixpkgs/commit/c51e3465b0ce05b1175e5c4530c1bd5a218ac9e4) python3Packages.elevenlabs: 2.8.2 -> 2.12.0
* [`8d128a41`](https://github.com/NixOS/nixpkgs/commit/8d128a41380cd5a9759d8880cca3bdc2cdbdb42c) testers.testEqualContents: add postFailureMessage parameter
* [`e4cbe624`](https://github.com/NixOS/nixpkgs/commit/e4cbe6247099d98a912e570df36ea1223bbdb315) vintagestory: 1.20.12 -> 1.21.0-rc.7
* [`4afbcac6`](https://github.com/NixOS/nixpkgs/commit/4afbcac6c81369f11eaf0ef9e43547c0284966f9) protoc-gen-js: 3.21.2 -> 3.21.4
* [`c2374fd1`](https://github.com/NixOS/nixpkgs/commit/c2374fd15ed1198e71e579d2e5fba5960b5de7ac) bazel: bazel_6 -> bazel_7
* [`95cfbc33`](https://github.com/NixOS/nixpkgs/commit/95cfbc3383cc7b7680fc4c5c74ea8e0ffdaf5d42) bazel_6: drop
* [`3333ada3`](https://github.com/NixOS/nixpkgs/commit/3333ada32855a58703b39ab6ff5f938070ae1677) tparse: 0.17.0 -> 0.18.0
* [`e4688fcb`](https://github.com/NixOS/nixpkgs/commit/e4688fcbde0e3bbe50ab8ea5e04f5bf6c405058a) tombi: 0.5.6 -> 0.5.18
* [`4a6afa1e`](https://github.com/NixOS/nixpkgs/commit/4a6afa1e2c2abb0e5610ab9b5c3e6cdb9fa5afd3) eid-mw: 5.1.21 -> 5.1.23
* [`9a34bfab`](https://github.com/NixOS/nixpkgs/commit/9a34bfab4da963b2443504fec0d63389b9973117) nezha: 1.13.0 -> 1.13.1
* [`edbbe79a`](https://github.com/NixOS/nixpkgs/commit/edbbe79a6defbf900a8497357376f56541f243dc) cdncheck: 1.1.32 -> 1.1.33
* [`93cedfd1`](https://github.com/NixOS/nixpkgs/commit/93cedfd1e76dfe7bc19d773deafd22416fc81afe) ansible-later: remove
* [`e82d0ac2`](https://github.com/NixOS/nixpkgs/commit/e82d0ac21dd78d745f471c88f90d05a3809bcd58) fosrl-pangolin: 1.8.0 -> 1.9.0
* [`4212d5f4`](https://github.com/NixOS/nixpkgs/commit/4212d5f497dd9b9b1f94f9f6c71c31a80bf3c209) libopenraw: fix the (missing `boost` dependency)
* [`29be71ca`](https://github.com/NixOS/nixpkgs/commit/29be71ca4946732d442320cff2c8f2450d837a84) nixos/nixos-containers: actually eliminate costs if no containers are used
* [`13d52457`](https://github.com/NixOS/nixpkgs/commit/13d52457bc93720f6a406d1e72d4c56fdd1d31f2) maintainers: Update pyrotelekinetic
* [`c45e1c3a`](https://github.com/NixOS/nixpkgs/commit/c45e1c3ad0540a98512c748dedf0eb01921ff273) python3Packages.scikit-base: 0.12.4 -> 0.12.5
* [`036be304`](https://github.com/NixOS/nixpkgs/commit/036be304cfbf473540381c78e25d81844ef1c9df) rPackages: CRAN and BioC update
* [`4570f7e6`](https://github.com/NixOS/nixpkgs/commit/4570f7e64990153c70acdfc2fa6ef41b95e9d689) rPackages.fcl: fixed build
* [`c9b5761b`](https://github.com/NixOS/nixpkgs/commit/c9b5761b045fd3ee082a4f1539d3cfb1240b13ca) rPackages.cartogramR: fixed build
* [`d9e40187`](https://github.com/NixOS/nixpkgs/commit/d9e40187de5401c7bb196d44ab380511423b0075) rPackages.caviarpd: fixed build
* [`579ba5cf`](https://github.com/NixOS/nixpkgs/commit/579ba5cf64614ea846080bcaf35c3cbb299380f8) rPackages.heck: fixed build
* [`a2564879`](https://github.com/NixOS/nixpkgs/commit/a25648796362706ce08bb5bae082d9f47fb658b7) rPackages.hypergeo2: fixed build
* [`7267a9f8`](https://github.com/NixOS/nixpkgs/commit/7267a9f835b9e88445c016de55b65a816b7f9feb) rPackages.interpolation: fixed build
* [`bb494d5a`](https://github.com/NixOS/nixpkgs/commit/bb494d5a2ee15eecfe3260c3a070841b8e1a1d4a) rPackages.zoomerjoin: fixed build
* [`de35dae7`](https://github.com/NixOS/nixpkgs/commit/de35dae7611ce9b42702577622cdf4397e50b6dc) rPackages.BulkSignalR: mark as broken
* [`5ec8caeb`](https://github.com/NixOS/nixpkgs/commit/5ec8caeb60109bc38634bdc0dd49932b464e4693) rPackages.RcppPlanc: fix build
* [`64eca23f`](https://github.com/NixOS/nixpkgs/commit/64eca23f5bca70e00ae8d65835ba241e9d1638b3) rPackages.webfakes: fixed build
* [`60483b80`](https://github.com/NixOS/nixpkgs/commit/60483b80470cbb2c76bf45bbc8e312d65ded7834) rPackages.arcgisplaces: fixed build
* [`798b5a2f`](https://github.com/NixOS/nixpkgs/commit/798b5a2f801318c4be156f5be12eaa407b479acc) ghstack: 0.9.4 -> 0.11.0
* [`016140d8`](https://github.com/NixOS/nixpkgs/commit/016140d8abd1a914bf3a5f94d87cb4b96f66dfdf) wox: 2.0.0-beta.3 -> 2.0.0-beta.4
* [`2696d0fa`](https://github.com/NixOS/nixpkgs/commit/2696d0fa3ce933ff964953fce246fb74b514ab92) pocket-id: 1.7.0 -> 1.9.1
* [`a0193443`](https://github.com/NixOS/nixpkgs/commit/a019344338d84d8e6a79ab0a5a1ede443234e331) emacs: replace `fetchFromSavannah` with mirror; adjust build
* [`d85a0bbe`](https://github.com/NixOS/nixpkgs/commit/d85a0bbe79b3fb5661369b76735eac51ff8ddd79) nixos/rspamd: add and use package option
* [`c7348c8e`](https://github.com/NixOS/nixpkgs/commit/c7348c8e35dedb8ab74229e88fbcf130cca46eba) artichoke: 0-unstable-2025-08-03 -> 0-unstable-2025-08-18
* [`f27d8d43`](https://github.com/NixOS/nixpkgs/commit/f27d8d4301e8f699a98853a4acee6b7eba32378a) tweag-credential-helper: 0.0.6 -> 0.0.8
* [`ea2c47f9`](https://github.com/NixOS/nixpkgs/commit/ea2c47f9faf65e08f6b50439b7fc3be2a4ee7b6c) xenia-canary: 0-unstable-2025-08-15 -> 0-unstable-2025-08-22
* [`8d3634ee`](https://github.com/NixOS/nixpkgs/commit/8d3634eece8972dc51372ca70043fed68dae0157) python3Packages.xgrammar: 0.1.22 -> 0.1.23
* [`2d1c98c5`](https://github.com/NixOS/nixpkgs/commit/2d1c98c5df859ecb9ba16d46a62d2b4dc0e618a3) signalbackup-tools: 20250818-1 -> 20250824
* [`c578e45f`](https://github.com/NixOS/nixpkgs/commit/c578e45f5da3e2f861ca72c06bc5973d5ad231b2) npingler: unstable-2025-08-21 -> unstable-2025-08-24
* [`ce56e680`](https://github.com/NixOS/nixpkgs/commit/ce56e68024d42f5d8e033cbaad8ff86a44b43f6a) python3Packages.openai: 1.100.2 -> 1.101.0
* [`a3c1bf2b`](https://github.com/NixOS/nixpkgs/commit/a3c1bf2b2404fa1a45bee916f385c76219b81071) seagoat: 1.0.20 -> 1.0.25
* [`7e861fb7`](https://github.com/NixOS/nixpkgs/commit/7e861fb7f29383385481a1806bb9179bb552f8ce) upbound: 0.40.1 -> 0.40.3
* [`d4f903a9`](https://github.com/NixOS/nixpkgs/commit/d4f903a9bac491167ed7a0e208d8f555b4edb878) python3Packages.pyais: 2.13.0 -> 2.13.1
* [`4b08c4e4`](https://github.com/NixOS/nixpkgs/commit/4b08c4e4e25ccdc694fcbaae9e3c570e958b3563) python3Packages.xgrammar: mark as broken on darwin
* [`8ff9a363`](https://github.com/NixOS/nixpkgs/commit/8ff9a3635c4d848d9946de07e1521b1e5cfe8d1e) python3Packages.xgrammar: mark as broken on aarch64-linux
* [`76612602`](https://github.com/NixOS/nixpkgs/commit/766126029de4041c119d1c04fcd1f5cc362cbc4b) python3Packages.outlines-core: 0.1.26 -> 0.2.11
* [`f41518ce`](https://github.com/NixOS/nixpkgs/commit/f41518ce88b7e62e00e361ac07f07cb05f75f65c) python3Packages.outlines: 1.2.1 -> 1.2.3
* [`15fad33a`](https://github.com/NixOS/nixpkgs/commit/15fad33a2715884a3082ab277949b191571eeaa3) mat2: use python312
* [`9684c484`](https://github.com/NixOS/nixpkgs/commit/9684c484070a8bc050244df21a988b82284c9d55) rbw: 1.13.2 -> 1.14.0
* [`d8a1fc36`](https://github.com/NixOS/nixpkgs/commit/d8a1fc36b5db5dd034ab85bee29c6ffdeaf5da03) libjodycode: 4.0 -> 4.0.1
* [`3917b65f`](https://github.com/NixOS/nixpkgs/commit/3917b65ffe2495a9375d1f50f5632ac038ac9acc) sbom-tool: init at 4.1.0
* [`d26aa5f9`](https://github.com/NixOS/nixpkgs/commit/d26aa5f9514ca4179679df18f3957c3d0e9faead) svgo: init at 4.0.0
* [`6c32fe89`](https://github.com/NixOS/nixpkgs/commit/6c32fe8992ec62a99699ad4fd11966861a7e4cfc) nodePackages.svgo: drop
* [`7477148e`](https://github.com/NixOS/nixpkgs/commit/7477148eb1538b00649854eceae4bcfd717455f8) goose: 3.24.3 -> 3.25.0
* [`9b41674e`](https://github.com/NixOS/nixpkgs/commit/9b41674ef3a3f3ae6cca14266d4ce45cc8538f21) python3Packages.pizzapi: init at 0.0.6
* [`d343eb3a`](https://github.com/NixOS/nixpkgs/commit/d343eb3aa254c4c21889821c8ff619e073bc74f2) python3Packages.types-ujson: 5.10.0.20250326 -> 5.10.0.20250822
* [`12b4a6f3`](https://github.com/NixOS/nixpkgs/commit/12b4a6f3cae57f3639fdc03c3200437f4d0b746c) evil-helix: 20250601 -> 20250823
* [`4e756dad`](https://github.com/NixOS/nixpkgs/commit/4e756dad81aaa4810333a0436e41ee08fa768779) home-assistant: update component packages
* [`5bd7c790`](https://github.com/NixOS/nixpkgs/commit/5bd7c7905d592290933b2db4fa5791206f7fadde) ghostfolio: 2.191.1 -> 2.193.0
* [`ce52e738`](https://github.com/NixOS/nixpkgs/commit/ce52e738122c4a3d089f444b5c20c4d8dadce8e5) obs-studio-plugins.obs-tuna: 1.9.10 -> 1.9.11
* [`d600a9fc`](https://github.com/NixOS/nixpkgs/commit/d600a9fccfdf0fbb0239a3b4e8f71e651b57b3ff) guile-sdl: drop
* [`945a6fc3`](https://github.com/NixOS/nixpkgs/commit/945a6fc37f4e26a4d8201b18e8c737be8de80f89) jscoverage: drop
* [`df625868`](https://github.com/NixOS/nixpkgs/commit/df6258685fae9b7e609731dab7a27d924d4921c9) manaplus: drop
* [`d08d0b2d`](https://github.com/NixOS/nixpkgs/commit/d08d0b2d43c828499d09a53268eab02bf326de40) enzyme: 0.0.189 -> 0.0.191
* [`3bb3bb95`](https://github.com/NixOS/nixpkgs/commit/3bb3bb9561e3922c300abcfe040d44aeb3859225) home-assistant-custom-components.solax_modbus: 2025.07.8b1 -> 2025.08.3
* [`90c912ce`](https://github.com/NixOS/nixpkgs/commit/90c912cecce5a4b6c735924b23976b426307dffc) namazu: drop
* [`85ff054b`](https://github.com/NixOS/nixpkgs/commit/85ff054b7cb284a41d07d7aa617e1551389022f4) nfstrace: drop
* [`d96e3ea7`](https://github.com/NixOS/nixpkgs/commit/d96e3ea7af4e464fb53e161d35d85e90ee7730ce) python3Packages.gitterpy: init at 0.1.7
* [`8a5764ce`](https://github.com/NixOS/nixpkgs/commit/8a5764ce073120b99e4763e527e79e2744910823) home-assistant: update component packages
* [`fc50449a`](https://github.com/NixOS/nixpkgs/commit/fc50449abe121bf169b9cf541ea2fb0ab6780eca) pal: drop
* [`87d45a73`](https://github.com/NixOS/nixpkgs/commit/87d45a7383af79b707d576c288d8c5f5f9862972) python3Packages.horimote: init at 0.4.1
* [`acca207c`](https://github.com/NixOS/nixpkgs/commit/acca207c565fa74349c68ecb308ead695e1b39ac) home-assistant: update component packages
* [`761cf127`](https://github.com/NixOS/nixpkgs/commit/761cf127e77586dd84936f06222bd78bc9057263) python3Packages.greenwavereality: init at 0.5.1
* [`a668257c`](https://github.com/NixOS/nixpkgs/commit/a668257c8fe63552e021fe56d24d3d5a3347453c) home-assistant: update component packages
* [`c997c46b`](https://github.com/NixOS/nixpkgs/commit/c997c46bf3259dca39d1ba2decd78dc4a3b4397c) python3Packages.llama-index-embeddings-gemini: fix build by setting hatchling as build-system
* [`c13e4508`](https://github.com/NixOS/nixpkgs/commit/c13e450857b7ff856df8c9912858ad6684c16d98) python3Packages.llama-index-embeddings-google: fix build by setting hatchling as build-system
* [`b34b2af0`](https://github.com/NixOS/nixpkgs/commit/b34b2af049e4983b7298102aeccd8a2a66ad6c1c) python3Packages.llama-index-embeddings-ollama: fix build by setting hatchling as build-system
* [`2f4d5012`](https://github.com/NixOS/nixpkgs/commit/2f4d5012c8ce8e6c999370a32099c2eac8fff752) python3Packages.llama-index-embeddings-openai: fix build by setting hatchling as build-system
* [`ebff0501`](https://github.com/NixOS/nixpkgs/commit/ebff05012ab976e48d978ef19c2ce09acd27ebc9) python3Packages.llama-index-graph-stores-nebula: fix build by setting hatchling as build-system
* [`2a74d42c`](https://github.com/NixOS/nixpkgs/commit/2a74d42cb07659d87da921964520439682f27072) python3Packages.llama-index-graph-stores-neo4j: fix build by setting hatchling as build-system
* [`7d4fd96c`](https://github.com/NixOS/nixpkgs/commit/7d4fd96cd93c7edf7e2551b83bd59ed3b63febef) python3Packages.llama-index-readers-database: fix build by setting hatchling as build-system
* [`9d3ad8ab`](https://github.com/NixOS/nixpkgs/commit/9d3ad8ab287db2c9fdcac700e64b38d6d87cb957) python3Packages.llama-index-readers-json: fix build by setting hatchling as build-system
* [`b47ac1a3`](https://github.com/NixOS/nixpkgs/commit/b47ac1a348e4297b026cfc4e9907456c4435af74) python3Packages.llama-index-readers-s3: fix build by setting hatchling as build-system
* [`8995fd74`](https://github.com/NixOS/nixpkgs/commit/8995fd742eeba77a30e2ef2636cd714de2b4dc6c) python3Packages.llama-index-readers-twitter: fix build by setting hatchling as build-system
* [`489be72d`](https://github.com/NixOS/nixpkgs/commit/489be72d8ee20eeb1e53cf1412f6513eb1e9f3ad) python3Packages.llama-index-readers-txtai: fix build by setting hatchling as build-system
* [`713f938b`](https://github.com/NixOS/nixpkgs/commit/713f938bcb0ded212f3fc17171c524fbc238ad5e) python3Packages.llama-index-readers-weather: fix build by setting hatchling as build-system
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
