### PR TITLE
niv home-manager: update 9e3a33c0 -> e31db614

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -65,10 +65,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "9e3a33c0bcbc25619e540b9dfea372282f8a9740",
-        "sha256": "09xg976ss7nimrd5nla0wx12k6k9h7rx42ww7vfx0z07pvkbfn17",
+        "rev": "e31db6141e47f1007a54bc9e4d8b2a26a9fbd697",
+        "sha256": "0df3mc6jxr8lmidsnad3w4826v160yxm312by7ns82hdhq59cl05",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/9e3a33c0bcbc25619e540b9dfea372282f8a9740.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/e31db6141e47f1007a54bc9e4d8b2a26a9fbd697.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@9e3a33c0...e31db614](https://github.com/nix-community/home-manager/compare/9e3a33c0bcbc25619e540b9dfea372282f8a9740...e31db6141e47f1007a54bc9e4d8b2a26a9fbd697)

* [`32940bca`](https://github.com/nix-community/home-manager/commit/32940bcae87c138976e819113de6e321acb108af) Translate using Weblate (Arabic)
* [`9ea3df74`](https://github.com/nix-community/home-manager/commit/9ea3df74ea739e519550a77a4ef13c96109346e6) maintainers: update all-maintainers.nix
* [`e49a2511`](https://github.com/nix-community/home-manager/commit/e49a2511fe61f4d77974f3394362ae33ba485806) docs: update formatting information
* [`600ce016`](https://github.com/nix-community/home-manager/commit/600ce016e2850d8e5bf7a08d2e92477849434f1d) flake.lock: Update
* [`59aabcd3`](https://github.com/nix-community/home-manager/commit/59aabcd3db975f9ff7a5df918ad17284361723c0) swaylock: document how to fix PAM on non-NixOS
* [`3882f886`](https://github.com/nix-community/home-manager/commit/3882f88691147dc325feb6bfece09ab6d058fb67) ssh: remove top level options
* [`2c4ef7d7`](https://github.com/nix-community/home-manager/commit/2c4ef7d7172708f6247d2ed9b56f0341b9ce63e1) blueman-applet: fix typo in systemdTargets
* [`77f348da`](https://github.com/nix-community/home-manager/commit/77f348da3176dc68b20a73dab94852a417daf361) fcitx5: migrate to qt6Packages
* [`a3d90c99`](https://github.com/nix-community/home-manager/commit/a3d90c996f8af2333b96512a973686d7559172ec) docs: fix typo in collision.md
* [`77a71380`](https://github.com/nix-community/home-manager/commit/77a71380c38fb2a440b4b5881bbc839f6230e1cb) ssh: provide code snippet in enableDefaultConfig description
* [`99a69bdf`](https://github.com/nix-community/home-manager/commit/99a69bdf8a3c6bf038c4121e9c4b6e99706a187a) pizauth: reload on change and option type
* [`6c8db975`](https://github.com/nix-community/home-manager/commit/6c8db97536780085f2e7c25d0ea5a9e5c6f19971) Translate using Weblate (Bulgarian)
* [`30fbfd27`](https://github.com/nix-community/home-manager/commit/30fbfd27a262a86d8c9d4acfff0650c03fe18603) Translate using Weblate (Bulgarian)
* [`27d306e1`](https://github.com/nix-community/home-manager/commit/27d306e1e46faac9ae24d50ad75dc93efbb61d51) Translate using Weblate (Bulgarian)
* [`feba2b2d`](https://github.com/nix-community/home-manager/commit/feba2b2daa9823b27dc53b53e8e159d9aba33dbd) programs.rclone: fix typo
* [`4896177e`](https://github.com/nix-community/home-manager/commit/4896177e2c01ea9c93bd19f4ae0af9c8b3db376d) programs.rclone: set Service.Type=notify
* [`e4454907`](https://github.com/nix-community/home-manager/commit/e44549074a574d8bda612945a88e4a1fd3c456a8) programs.rclone: fix injecting secret when value begins with "-"
* [`f27974d3`](https://github.com/nix-community/home-manager/commit/f27974d3b4aa0af533539ce626622c7b6b53c3f5) shpool: init shpool module
* [`2842bac6`](https://github.com/nix-community/home-manager/commit/2842bac626ed087e83400a7a23da8e8923c6c7e6) flake.lock: Update
* [`71b57070`](https://github.com/nix-community/home-manager/commit/71b57070771aac60ca949b47d6b2bd2afd5e49d8) tests/darwinScrublist: add pgclii
* [`f671e772`](https://github.com/nix-community/home-manager/commit/f671e772d3c3b893e44399afedb84a0b3f27f922) qt: Remove Plasma 5 and related Qt5 packages
* [`1e759786`](https://github.com/nix-community/home-manager/commit/1e759786e526a87a3c05beeff5db41743d763569) qt: deprecate kde6
* [`b4b5f008`](https://github.com/nix-community/home-manager/commit/b4b5f008d772c0e8e9c420cfa0d240a447747e0a) hyprpanel: deprecate `theme.name` option
* [`a48dd228`](https://github.com/nix-community/home-manager/commit/a48dd228d977b1c5085cb8e014fd0ccfc45ca77b) jq: make `colors` and `package` nullable
* [`b7cc2466`](https://github.com/nix-community/home-manager/commit/b7cc2466f1a695326ffc1a14040cd4d3b4358ea0) distrobox: add settings option and other general improvements
* [`fccb44df`](https://github.com/nix-community/home-manager/commit/fccb44df77266a3891939f35197f538dace3442f) mkFirefoxModule: make policies work on darwin
* [`29ab63bb`](https://github.com/nix-community/home-manager/commit/29ab63bbb3d9eee4a491f7ce701b189becd34068) maintainers: update all-maintainers.nix
* [`e7c24fc5`](https://github.com/nix-community/home-manager/commit/e7c24fc522443c402b21b25f8cd78ec90d238ee2) Translate using Weblate (Dutch)
* [`9bd58094`](https://github.com/nix-community/home-manager/commit/9bd580947cdd01f30f043d827cef7b6ac8733f7a) Translate using Weblate (Hindi)
* [`aa35affc`](https://github.com/nix-community/home-manager/commit/aa35affc6f8561bed3dd6ca67fc9d1a7d01a8233) Translate using Weblate (Hindi)
* [`e31db614`](https://github.com/nix-community/home-manager/commit/e31db6141e47f1007a54bc9e4d8b2a26a9fbd697) Translate using Weblate (Hindi)
