### PR TITLE
niv nerd-icons.el: update e98b1424 -> 6868c05c

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -119,10 +119,10 @@
         "homepage": null,
         "owner": "rainstormstudio",
         "repo": "nerd-icons.el",
-        "rev": "e98b14248fec120cc23c5f3a5aa1128d98156c2c",
-        "sha256": "0162hhvm9cqcxxaj3g918p06kcbhzk2iyy1hckdvagsg7sb24cjn",
+        "rev": "6868c05c6eb56c6625ee7fa38450b514542ab636",
+        "sha256": "0bpbd5rr638cc5py4nv0wi98k4k1scq2iybmi2xayf0a5kgp1nn2",
         "type": "tarball",
-        "url": "https://github.com/rainstormstudio/nerd-icons.el/archive/e98b14248fec120cc23c5f3a5aa1128d98156c2c.tar.gz",
+        "url": "https://github.com/rainstormstudio/nerd-icons.el/archive/6868c05c6eb56c6625ee7fa38450b514542ab636.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "niv": {


### PR DESCRIPTION
## Changelog for nerd-icons.el:
Branch: main
Commits: [rainstormstudio/nerd-icons.el@e98b1424...6868c05c](https://github.com/rainstormstudio/nerd-icons.el/compare/e98b14248fec120cc23c5f3a5aa1128d98156c2c...6868c05c6eb56c6625ee7fa38450b514542ab636)

* [`203a5e8f`](https://github.com/rainstormstudio/nerd-icons.el/commit/203a5e8f45a2874228031c8c5726363cd98d3292) add support for m4b
* [`52f814ff`](https://github.com/rainstormstudio/nerd-icons.el/commit/52f814ffe00187d139493425b6cda4900433f09b) Add icons for heif (and friends)
* [`9fa0676b`](https://github.com/rainstormstudio/nerd-icons.el/commit/9fa0676b8c2066f64291cdb832734650a1b0ee32) Add support for show-font
* [`6868c05c`](https://github.com/rainstormstudio/nerd-icons.el/commit/6868c05c6eb56c6625ee7fa38450b514542ab636) Add journalctl icons
