### PR TITLE
niv nixpkgs: update 3b63f31e -> d44f2e86

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -143,10 +143,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3b63f31ef13f96726cd3357391519eee8a91792d",
-        "sha256": "15wanfc12q6wy1yvh6xyg7nkhh8wmr646cbfa3f8r93hkmgidd4a",
+        "rev": "d44f2e86707bae01ecce6af5d4da3674529d183c",
+        "sha256": "11phwqnz13pry2j2w4nqqbsbc2inyz01prm86l32zqfy89hcila6",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/3b63f31ef13f96726cd3357391519eee8a91792d.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/d44f2e86707bae01ecce6af5d4da3674529d183c.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@3b63f31e...d44f2e86](https://github.com/nixos/nixpkgs/compare/3b63f31ef13f96726cd3357391519eee8a91792d...d44f2e86707bae01ecce6af5d4da3674529d183c)

* [`fbccaa29`](https://github.com/NixOS/nixpkgs/commit/fbccaa295a2bdea6001eb23936655dc1c079afef) opentelemetry-cpp: add option to use STL
* [`bffdfc23`](https://github.com/NixOS/nixpkgs/commit/bffdfc23278cd7e3310ea0ed962328d418abb620) opentelemetry-cpp: increased configurability of cmake options and dependencies
* [`58f9fdb6`](https://github.com/NixOS/nixpkgs/commit/58f9fdb6925d0247c86b8beed73cb57929e5b88f) opentelemetry-cpp: update versions.
* [`75faf48d`](https://github.com/NixOS/nixpkgs/commit/75faf48d819d0ac3202ff4bce8dc29bb4963ea49) labymod-launcher: 2.1.10 -> 2.1.12
* [`12ed9e23`](https://github.com/NixOS/nixpkgs/commit/12ed9e2343b097d747d736dee1fce9dd01a68ca2) python3Packages.sphinx-tippy: init at 0.4.3
* [`d28e064e`](https://github.com/NixOS/nixpkgs/commit/d28e064e5d4478cf77f5124b8a344eccb85d423b) whisky: 2.3.2 -> 2.3.5
* [`9be70d9a`](https://github.com/NixOS/nixpkgs/commit/9be70d9ad13edc388bea9649ecbfecd32c08d6ae) llvmPackages.llvm: drop a test on loongarch64
* [`13a041b1`](https://github.com/NixOS/nixpkgs/commit/13a041b1746da698ea4e1ad5994c42a817403170) headscale: support PKCE verifier
* [`9e30dc38`](https://github.com/NixOS/nixpkgs/commit/9e30dc38aa41e9aa9664df8ae9bbf5f4e3eeb13a) freenet: 01501 -> 01503
* [`7259b7ca`](https://github.com/NixOS/nixpkgs/commit/7259b7ca67392490f869013e27155553ba950ea7) nixos/hedgedoc: add configureNginx option
* [`3b72ee80`](https://github.com/NixOS/nixpkgs/commit/3b72ee808c02fcc77b215afa45a353818e886cb7) immersed: add sources to passthru
* [`60199cb5`](https://github.com/NixOS/nixpkgs/commit/60199cb5f2c5a26c79ae2b5acfe28ff7477c63d1) immersed: 10.6.0 -> 10.9.0
* [`82e1d65d`](https://github.com/NixOS/nixpkgs/commit/82e1d65d32a7d092ebf306d3bad076bf62e36a9a) dsremote: init at 0-unstable-2025-07-07
* [`1195e675`](https://github.com/NixOS/nixpkgs/commit/1195e6757a967eeff49b01a3dcd6f683322516a6) maintainers: add heichro
* [`ffc90136`](https://github.com/NixOS/nixpkgs/commit/ffc901364b4825dacbfabe95a1db01e41c3a6bf8) netbootxyz-efi: 2.0.82 -> 2.0.87; modernize
* [`0999330a`](https://github.com/NixOS/nixpkgs/commit/0999330aac10eec56b588c1076166a6c7465e2d7) promptfoo: add jk as maintainer
* [`99257be9`](https://github.com/NixOS/nixpkgs/commit/99257be995d9529e13511c3d76fb155cf14040c2) promptfoo: move to finalAttrs pattern
* [`c488a10d`](https://github.com/NixOS/nixpkgs/commit/c488a10d0c614ee8265e0e83a3e98f968f6b7861) promptfoo: use tag to fetchFromGitHub
* [`1e04a650`](https://github.com/NixOS/nixpkgs/commit/1e04a65035e6fd06b80766ca4fe340120dfb50bd) promptfoo: 0.79.0 -> 0.117.4
* [`82aba98f`](https://github.com/NixOS/nixpkgs/commit/82aba98fa193553778c62b7fa460822bc817f949) perl: fix build when cross-compiling to the musl libc
* [`085f7147`](https://github.com/NixOS/nixpkgs/commit/085f714777daeaf7383db606dd8a8e97a953ddc7) sourcegit: 2025.25 -> 2025.29
* [`4c54e184`](https://github.com/NixOS/nixpkgs/commit/4c54e18421fd7dbddfd312a967161461e9609a18) python3Packages.wgnlpy: fix exception when WGPEER_A_LAST_HANDSHAKE_TIME is None
* [`cc2a6795`](https://github.com/NixOS/nixpkgs/commit/cc2a67957580cb1791ff848896292dd4582cbecf) haskellPackages.botan-bindings: Fix broken package
* [`e582f969`](https://github.com/NixOS/nixpkgs/commit/e582f9694046c50e69c0e9c4c1e6d7eae39e90ee) botan-low: Disable failing testcases
* [`4f9fee9b`](https://github.com/NixOS/nixpkgs/commit/4f9fee9b3ffe6fa0d531e59407b51a35be99797c) perlPackages.Tirex: 0.7.1 → 0.8.0
* [`2c3ce3eb`](https://github.com/NixOS/nixpkgs/commit/2c3ce3eb31b2bb22aac829a5d74cc2c15a92ee29) grub: build grub2_xen_pvh
* [`47881f96`](https://github.com/NixOS/nixpkgs/commit/47881f96c7eff2641cc9386ed28667fc44fa78c1) grub: build grub2_pvhgrub_image together with grub2_pvgrub_image
* [`dcfb3202`](https://github.com/NixOS/nixpkgs/commit/dcfb3202bd9cc8b83d17cbe9b1a539120c3ddd11) cue.validator: fix deprecated --strict flag
* [`99791e02`](https://github.com/NixOS/nixpkgs/commit/99791e0252efdde07079c1a22dc92889a11a2530) tantivy-go: 1.0.1 -> 1.0.4
* [`4ee1d0a3`](https://github.com/NixOS/nixpkgs/commit/4ee1d0a347a0e5ed571d813d1b1bedb85aa55211) check-meta: Fall back to fullName for the license name
* [`6addbade`](https://github.com/NixOS/nixpkgs/commit/6addbade741665019e36ec1cb7dc4ee20ff3cd45) maintainers: add ljxfstorm
* [`a956dc12`](https://github.com/NixOS/nixpkgs/commit/a956dc122c3c73cd89c5eb42cc8518f9941467d3) ifstate: init at 2.0.0
* [`c00b7b00`](https://github.com/NixOS/nixpkgs/commit/c00b7b002bdd868ab3c0071a22f14d468ee647e4) espflash: don't build xtask
* [`645af1a6`](https://github.com/NixOS/nixpkgs/commit/645af1a6983e2d6f45cefd2d2eecc7e60ad5b2c5) nixos/calibre-web: fix book cover not showing up due to cache directory defaults to cps path under /nix/store/
* [`63b06645`](https://github.com/NixOS/nixpkgs/commit/63b06645110ef2949968b9b76e05d4c3180ecab8) caddy: clean up withPlugins logic and support replacement
* [`3274b12d`](https://github.com/NixOS/nixpkgs/commit/3274b12d482ee41222faa2c10cb8b95ab41a4136) julia.withPackages: bump registry
* [`7dfc1692`](https://github.com/NixOS/nixpkgs/commit/7dfc1692c01d5ff80c4c4bc86e164c63172dd656) julia.withPackages: improve test parallelism and logging
* [`12182c9d`](https://github.com/NixOS/nixpkgs/commit/12182c9d0cf86199688157c385874303ab49aa55) julia.withPackages: fix addPackagesToPython
* [`338b5bde`](https://github.com/NixOS/nixpkgs/commit/338b5bde5de829a4d50ba1e94e821ec7d787272c) julia.withPackages: improve weak dependency handling
* [`295795c5`](https://github.com/NixOS/nixpkgs/commit/295795c55a65a273f56a17379dbff70ae6f0a821) kcc: add wayland support
* [`029fe7b8`](https://github.com/NixOS/nixpkgs/commit/029fe7b89a53bcdb58ded7a1281e294671f51790) wxsqlite3: enable parallel building
* [`4bcccbcc`](https://github.com/NixOS/nixpkgs/commit/4bcccbcc9a1efcd4f34a0f234a90a11c48ce22de) wxsqlite3: add test
* [`5788f48b`](https://github.com/NixOS/nixpkgs/commit/5788f48b96684b42a035a88a3122e090aa55f4c4) python3Packages.pyluwen: init at 0.7.11
* [`20663ce4`](https://github.com/NixOS/nixpkgs/commit/20663ce41d578ae319e443763078c923f5202b11) nomad: 1.10.3 -> 1.10.4
* [`a6bef88f`](https://github.com/NixOS/nixpkgs/commit/a6bef88f3ff366ae5d559545f814fa70db70c41b) fzf: don't source automatically 
* [`41aa46af`](https://github.com/NixOS/nixpkgs/commit/41aa46afb9357d74d8439c338170fdae1a85f69f) vscode-extensions.continue.continue: 1.1.49 -> 1.1.76
* [`26ae6417`](https://github.com/NixOS/nixpkgs/commit/26ae6417113b646631e6bdf8d2fa57bf2a7adf06) vscode-extensions.continue.continue: add flacks as maintainer
* [`b44db68d`](https://github.com/NixOS/nixpkgs/commit/b44db68d42d572284b76f4d2dfec7b59db95b813) python3Packages.tt-tools-common: init at 1.4.25
* [`f0e1c35a`](https://github.com/NixOS/nixpkgs/commit/f0e1c35a3bf7c9bf7eabf19ca286cedb879951e9) python3Packages.tt-flash: init at 3.3.3
* [`4113c68e`](https://github.com/NixOS/nixpkgs/commit/4113c68e441cea4bf1db6e48fe30424c4b9a1817) python3Packages.arro3: Init at 0.5.1
* [`6ab2bd99`](https://github.com/NixOS/nixpkgs/commit/6ab2bd99d9fc333a87dd3e48f9057821a1888476) python313Packages.pyjpegls: init at 1.5.1
* [`71e56037`](https://github.com/NixOS/nixpkgs/commit/71e560379007d211451006e1fe6ce02c6be0c077) python313Packages.highdicom: add missing pyjpegls dependency
* [`eade4033`](https://github.com/NixOS/nixpkgs/commit/eade4033151b515b9be5477458bc15a0712080ce) hidviz: fix path of internal library
* [`8d64b8c7`](https://github.com/NixOS/nixpkgs/commit/8d64b8c77a4a13538fed6fcaf5435c88d8ea229e) python3Packages.ttfautohint-py: 0.5.1 -> 0.6.0
* [`e258b5f9`](https://github.com/NixOS/nixpkgs/commit/e258b5f9ee00c372b5919c76c24c1dde926b3909) python313Packages.pydicom: add missing pyjpegls optional dependency
* [`c6435a9d`](https://github.com/NixOS/nixpkgs/commit/c6435a9da7bdc323c7a2a5336b61c6138ab08d0f) {irods,irods-icommands}: 4.3.3 -> 5.0.1
* [`5ede2652`](https://github.com/NixOS/nixpkgs/commit/5ede2652e0e01071872d1d5b31878981b64cdf25) bazelisk: 1.25.0 -> 1.27.0
* [`834b4478`](https://github.com/NixOS/nixpkgs/commit/834b447829521fa1368ed4edd4a9e184f747820a) python313Packages.pylibjpeg-rle: init at 2.1.0
* [`4cb180a9`](https://github.com/NixOS/nixpkgs/commit/4cb180a99e0ef924096525890bc6d191c0c431e0) govc: 0.51.0 -> 0.52.0
* [`ebb09539`](https://github.com/NixOS/nixpkgs/commit/ebb095396d4ade9589e33ce90a03d3c963819272) nixos/zookeeper: replace outdated log4j with logback.xml
* [`f5a4b1db`](https://github.com/NixOS/nixpkgs/commit/f5a4b1dbdf6005594a7c06caeb013f4f0e1f65ec) clusterctl: 1.10.4 -> 1.11.0
* [`2a290963`](https://github.com/NixOS/nixpkgs/commit/2a2909634efa550b04c439b69b5fa896b30b6c86) bazel_7: fix build with modern Clang on macOS
* [`3548ae10`](https://github.com/NixOS/nixpkgs/commit/3548ae103e64c37094668228d4a17a3849d314f5) peazip: restructure of icon install, addition of 48px icons
* [`78c93e50`](https://github.com/NixOS/nixpkgs/commit/78c93e503c9308acd94feb83176a70062545ff7b) peazip: replace substitute's deprecated --replace
* [`713c2cb8`](https://github.com/NixOS/nixpkgs/commit/713c2cb86db0726db91eae573d3ab62ee2345542) k3sup: 0.13.10 -> 0.13.11
* [`190fc36e`](https://github.com/NixOS/nixpkgs/commit/190fc36ecbc63effd3acef8e94c3f520f4d4b49e) weasis: Add support for aarch64-darwin
* [`54717a35`](https://github.com/NixOS/nixpkgs/commit/54717a3566ec5eae681f288c0f5a8460dbffc41a) weasis: 4.6.2 -> 4.6.3
* [`c1a32c8c`](https://github.com/NixOS/nixpkgs/commit/c1a32c8cba382f66fcf58bcffbf1c9f945e9fa41) maintainers: add deej-io
* [`fc5f4f82`](https://github.com/NixOS/nixpkgs/commit/fc5f4f8247d6f14c315d3a46ba967bc8aa29fbf3) enpass-cli: init at 1.6.5
* [`977c55de`](https://github.com/NixOS/nixpkgs/commit/977c55de24046386e907bbbccd8d1f88e7286d5c) spoolman: init service
* [`f707d8b6`](https://github.com/NixOS/nixpkgs/commit/f707d8b65e702f55d2821df47d89355a860f2d5d) tika: apply patch for CVE-2025-54988
* [`bb96669f`](https://github.com/NixOS/nixpkgs/commit/bb96669feb6b7ed971ecd17f87441761b713293a) paretosecurity: 0.3.2 -> 0.3.3
* [`8d8c9633`](https://github.com/NixOS/nixpkgs/commit/8d8c9633bf0a62167418d2259e5697496a97fd22) nixos/ifstate: init
* [`1b52d81b`](https://github.com/NixOS/nixpkgs/commit/1b52d81b647b867499000a2c4a00233ac9b92620) falcoctl: 0.11.2 -> 0.11.3
* [`3a5eb03d`](https://github.com/NixOS/nixpkgs/commit/3a5eb03d6248f0a51ebf34fcb4f4bf15b27b564b) codeql: 2.22.3 -> 2.22.4
* [`e033e7c7`](https://github.com/NixOS/nixpkgs/commit/e033e7c7531065d4ceec1ce5f326f2b28d7a3e45) envoy: fix up Rust builds
* [`6c959584`](https://github.com/NixOS/nixpkgs/commit/6c9595844f2bb6aec59752644abc03a5aa62ca88) envoy: add git dependency
* [`6cfa3cff`](https://github.com/NixOS/nixpkgs/commit/6cfa3cff385c4d44aa6658fb8e7e560a878b29b2) envoy: allow overriding depsHash externally
* [`f89b85d6`](https://github.com/NixOS/nixpkgs/commit/f89b85d6d00c9764c6716d047522cb01cfa752ab) envoy: switch default WASM runtime to wasmtime
* [`d178a341`](https://github.com/NixOS/nixpkgs/commit/d178a341499831997870aa89d473f5325bedeaba) rke: 1.8.5 -> 1.8.6
* [`bff6c57c`](https://github.com/NixOS/nixpkgs/commit/bff6c57cd9cf79c44d1eb0185f971c8cec3e7236) go-minimock: 3.4.5 -> 3.4.6
* [`67c23dd7`](https://github.com/NixOS/nixpkgs/commit/67c23dd7df5b7465e539e9a2366dfdd07af0f5f7) credhub-cli: 2.9.48 -> 2.9.49
* [`675f28f2`](https://github.com/NixOS/nixpkgs/commit/675f28f28b2de4cac92befa8c222bdca1b74aac2) gonic: 0.16.4 -> 0.17.0
* [`5575efd3`](https://github.com/NixOS/nixpkgs/commit/5575efd3842e431205cf816175aa45597996408e) python3Packages.ultralytics-thop: 2.0.15 -> 2.0.16
* [`84d4d28d`](https://github.com/NixOS/nixpkgs/commit/84d4d28d4fc334ed0e5ff35cce0eba69883ee4eb) anytype-heart: 0.40.21 -> 0.43.0-rc02
* [`4358b24f`](https://github.com/NixOS/nixpkgs/commit/4358b24f052964b5725b4bcaadb5b4cbe6a6b556) kube-bench: 0.11.2 -> 0.12.0
* [`d30ffe3f`](https://github.com/NixOS/nixpkgs/commit/d30ffe3fb1929b6539c43a0c5ac8facc009f2614) python313Packages.scikit-rf: disable failing test on Linux too
* [`a8301aee`](https://github.com/NixOS/nixpkgs/commit/a8301aee64a5210415252fb0352b05a144994e8f) python313Packages.verilogae: switch to maintained fork
* [`378be5d2`](https://github.com/NixOS/nixpkgs/commit/378be5d2d774244ee77f353d38aaa7b541b12f6c) vscode-extensions.ms-dotnettools.csharp: 2.87.31 -> 2.89.19
* [`2ead225f`](https://github.com/NixOS/nixpkgs/commit/2ead225fed784c3e578a34796b69ecf6e791b0ec) cpu-x: 5.3.1 -> 5.4.0
* [`36bfc27d`](https://github.com/NixOS/nixpkgs/commit/36bfc27d8dbdcecc56e65187da829ff51255e76e) python3Packages.netbox-contextmenus: init at 1.4.8
* [`08e7bcfa`](https://github.com/NixOS/nixpkgs/commit/08e7bcfaf7bfab58683f26681bab56b3c5e5f380) templ: 0.3.937 -> 0.3.943
* [`4a80d003`](https://github.com/NixOS/nixpkgs/commit/4a80d00387837229fc4f85fedcef8258fcab6c15) prometheus-script-exporter: switch to maintained fork
* [`dc05318f`](https://github.com/NixOS/nixpkgs/commit/dc05318fb3140bbf2b2597eb9faaf0c179a5fd36) quarkus: 3.25.3 -> 3.25.4
* [`166ee74f`](https://github.com/NixOS/nixpkgs/commit/166ee74f0028a646cbe397de7d0df3af2c96b5ef) wgcf: 2.2.28 -> 2.2.29
* [`89232203`](https://github.com/NixOS/nixpkgs/commit/8923220337b9d44a773a20d57e675044df9fab3c) joker: 1.5.2 -> 1.5.6
* [`3ac1ce82`](https://github.com/NixOS/nixpkgs/commit/3ac1ce821e42eefad7eb1f44ea0aa67dad0d5493) pgadmin: 9.6 -> 9.7
* [`5f7b6feb`](https://github.com/NixOS/nixpkgs/commit/5f7b6feb6ea7a9c02213f32163dbff993d341e38) rofi-games: 1.12.2 -> 1.12.3
* [`e359611e`](https://github.com/NixOS/nixpkgs/commit/e359611e77d9457ff23d6521b1b9ae8a3618fb3d) treewide: migrate ruby packages to by-name and update
* [`9fe45f0a`](https://github.com/NixOS/nixpkgs/commit/9fe45f0a764256dd3dcf972ce5ebd51a1fcf5cd9) bosh-cli: 7.9.9 -> 7.9.10
* [`bcaf8667`](https://github.com/NixOS/nixpkgs/commit/bcaf8667d8b906aaf8789b5726b090f0f10e4544) klee: 3.1 -> 3.1-unstable-2025-07-11
* [`97ebc87e`](https://github.com/NixOS/nixpkgs/commit/97ebc87ea0584ec2fc8dac8b1faf4f54d715a594) klee: disable assertions
* [`13a49270`](https://github.com/NixOS/nixpkgs/commit/13a49270e5802216269ad7924bdba09a3821952a) klee: make tests more verbose
* [`a91dd2c5`](https://github.com/NixOS/nixpkgs/commit/a91dd2c5c6228def2505c3274fc1f65545e8d523) linuxPackages.drbd: 9.2.12 -> 9.2.14
* [`56fd2b52`](https://github.com/NixOS/nixpkgs/commit/56fd2b520d188f90283c8392cab8e20aaa1511dc) grafanaPlugins.victoriametrics-logs-datasource: 0.19.2 -> 0.19.3
* [`bf6ec1f8`](https://github.com/NixOS/nixpkgs/commit/bf6ec1f889dfde74e8d88128563f6c5daa5ab341) kyverno: 1.15.0 -> 1.15.1
* [`5fde0505`](https://github.com/NixOS/nixpkgs/commit/5fde05051b65b6a245fda38e9d87fc6cecbac1a1) python3Packages.atproto: 0.0.61 -> 0.0.62
* [`b5c602cc`](https://github.com/NixOS/nixpkgs/commit/b5c602cc5d81669c4160ef0ba9c8b3d7ab7c4659) cargo-machete: 0.9.0 -> 0.9.1
* [`4c8227f1`](https://github.com/NixOS/nixpkgs/commit/4c8227f166c23505ebd1931e325595a371a4ac49) python3Packages.stups-cli-support: 1.1.20 -> 1.1.22
* [`6cc8a8cd`](https://github.com/NixOS/nixpkgs/commit/6cc8a8cdb582660c8f33f23ad949f4a5da07ee7a) nixos/mattermost: remove fallback charset for MySQL
* [`749675c6`](https://github.com/NixOS/nixpkgs/commit/749675c629bb17deb26e35fe6c7053fe5ed73a55) mattermost: tests: use UTF-8 for database charset
* [`96c91f1f`](https://github.com/NixOS/nixpkgs/commit/96c91f1f26bae33eda0f38c820fae9e8b5602626) equibop: 2.1.5 -> 2.1.6
* [`e4e6cc24`](https://github.com/NixOS/nixpkgs/commit/e4e6cc242db3ace23cae472ba60f53a817378e9c) equibop: remove broken withSystemEquicord argument
* [`f67c1f3a`](https://github.com/NixOS/nixpkgs/commit/f67c1f3acfba3f93daa5b8cef895a7b13abc6425) spire: 1.12.4 -> 1.12.5
* [`e691d5f9`](https://github.com/NixOS/nixpkgs/commit/e691d5f91ba4f8e2274cc8a60fb3acee8d140efc) slipshow: 0.5.0 -> 0.6.0
* [`5e13ac32`](https://github.com/NixOS/nixpkgs/commit/5e13ac324eba02b36a63f3f66e3a3620167fc001) syncthing: 1.30.0 -> 2.0.3
* [`88b0ebe0`](https://github.com/NixOS/nixpkgs/commit/88b0ebe026c8a6f0b0977edec04e7199bed0af0e) tuir: 1.31.0 -> 1.31.1
* [`65d3cb7c`](https://github.com/NixOS/nixpkgs/commit/65d3cb7ca0522125b62594b362ebf99dab44986b) prometheus-zfs-exporter: 2.3.8 -> 2.3.10
* [`c54f5d63`](https://github.com/NixOS/nixpkgs/commit/c54f5d632bb142e64b30a842dd1f700b43c30298) goose-cli: 1.4.0 -> 1.6.0
* [`2d01080c`](https://github.com/NixOS/nixpkgs/commit/2d01080cdea6843b20d396bf2a067be4a6991c1c) s-tar: force '-std=c89' so it builds with recent compilers
* [`821e8edd`](https://github.com/NixOS/nixpkgs/commit/821e8edd5ee791e7afd196033f472d85fd5f2227) klee: bump to LLVM 18
* [`6361b81c`](https://github.com/NixOS/nixpkgs/commit/6361b81c8eb27a54883ad52c7d82347fd6d06519) application-title-bar: 0.8.5 -> 0.8.6
* [`a58eabe0`](https://github.com/NixOS/nixpkgs/commit/a58eabe0fd293ae3d80afa48551637bf3aa899cd) kubedock: 0.18.1 -> 0.18.2
* [`559d58ef`](https://github.com/NixOS/nixpkgs/commit/559d58efbe3f9d96b328a79425ffac98d9093682) osv-scanner: 2.2.0 -> 2.2.1
* [`ae11304c`](https://github.com/NixOS/nixpkgs/commit/ae11304ceb4045369ee204d858e39312e0d7f716) regbot: 0.9.0 -> 0.9.1
* [`c7b55285`](https://github.com/NixOS/nixpkgs/commit/c7b552857e82a5b106ad50719f4870f6e9a800ad) fbjni: drop
* [`656aa163`](https://github.com/NixOS/nixpkgs/commit/656aa1633312f642d817082fd24bf2c4a33bef4c) gr-framework: drop
* [`5c92c4f7`](https://github.com/NixOS/nixpkgs/commit/5c92c4f7adfeb40629216c0a4540dc4dedc063b5) ibm-sw-tpm2: drop
* [`e1072713`](https://github.com/NixOS/nixpkgs/commit/e10727139af6928b350638ed9a76685d72859413) bind: 9.20.11 -> 9.20.12
* [`522fe3f2`](https://github.com/NixOS/nixpkgs/commit/522fe3f2aa033e6a0b2a25c1d107044e0a321dcd) python3Packages.cvxpy: 1.7.1 -> 1.7.2
* [`e906bd7b`](https://github.com/NixOS/nixpkgs/commit/e906bd7b613d60778c1f6f140bb31c264f7137f6) sbt: 1.11.4 -> 1.11.5
* [`5e1d0788`](https://github.com/NixOS/nixpkgs/commit/5e1d078877e93071d274dafd5c26c4778081a1f9) autotrash: reintroduce checking with pytest
* [`206a9f5a`](https://github.com/NixOS/nixpkgs/commit/206a9f5ac397eb9e625b78bb0e52b64d1ed08941) aptakube: 1.11.10 -> 1.13.0
* [`327eae33`](https://github.com/NixOS/nixpkgs/commit/327eae33cd776a8bb7f1ab07682edb52a7aa4c56) anytype: 0.46.5 -> 0.49.2
* [`39ce31bf`](https://github.com/NixOS/nixpkgs/commit/39ce31bf662867c3d384cf3d9fb9a39f05899597) melange: 0.30.6 -> 0.31.0
* [`59b8cc7b`](https://github.com/NixOS/nixpkgs/commit/59b8cc7b9c3c943f116e91881136d79080c18c3b) prometheus-ping-exporter: 1.1.3 -> 1.1.4
* [`4728a593`](https://github.com/NixOS/nixpkgs/commit/4728a593573ac8a84bd56c89619a03bbe658b7d8) python3Packages.django-currentuser: 0.8.0 -> 0.9.0
* [`5b7fe6f3`](https://github.com/NixOS/nixpkgs/commit/5b7fe6f389d618b36e8a101e194c682e9c51402c) maintainers: add PaulGrandperrin
* [`4096fb30`](https://github.com/NixOS/nixpkgs/commit/4096fb30d94fd208399daccd8f91d1ab0577bc5d) virt-manager: 5.0.0 -> 5.1.0
* [`3e5dc987`](https://github.com/NixOS/nixpkgs/commit/3e5dc9873d40fe618b29d7355c8f849cb831c869) python3Packages.regress: 2025.3.1 -> 2025.5.1
* [`4eae2071`](https://github.com/NixOS/nixpkgs/commit/4eae20718f7335f2a0f2a73fd9521d19edfc206b) python3Packages.aioboto3: 15.0.0 -> 15.1.0
* [`bfb483e7`](https://github.com/NixOS/nixpkgs/commit/bfb483e7a72c437097311fc22e3aa8895f27e13b) maintainers: drop chrpinedo
* [`6eebc51e`](https://github.com/NixOS/nixpkgs/commit/6eebc51ec200378023bb7eb4722eacba228bd5c4) maintainers: drop galaxy
* [`509cc57a`](https://github.com/NixOS/nixpkgs/commit/509cc57ac81855bbfb610ecbd93a8dc9020a724b) maintainers: drop elysasrc
* [`63c23752`](https://github.com/NixOS/nixpkgs/commit/63c23752b2d6c5f8330cd75006cdd1e727571fdb) maintainers: drop hikari
* [`e5eda90d`](https://github.com/NixOS/nixpkgs/commit/e5eda90da8e8c8bb9d30e62c9ccb01b44a556ee2) tmuxPlugins.minimal-tmux-status: init at unstable-2025-06-04
* [`6027a812`](https://github.com/NixOS/nixpkgs/commit/6027a812f9f9d661b7ebcd41a7f7ecb4a811126e) maintainers: drop srghma
* [`0c409dde`](https://github.com/NixOS/nixpkgs/commit/0c409ddebd36a3b747dad596fdaed8f68ef2ba8e) python3Packages.plyer: Fix FTBFS
* [`50d67d02`](https://github.com/NixOS/nixpkgs/commit/50d67d0284b13638828d1c24595fbbcd1773ff28) python3Packages.plyer: Adopt by NGI team
* [`a2da282d`](https://github.com/NixOS/nixpkgs/commit/a2da282d8eb37376ebc75c708d0df11e2966e462) hcl2json: 0.6.7 -> 0.6.8
* [`ddf79c56`](https://github.com/NixOS/nixpkgs/commit/ddf79c56e694a384c807e840c64b03add51629e4) steampipePackages.steampipe-plugin-aws: 1.22.0 -> 1.23.0
* [`09397c61`](https://github.com/NixOS/nixpkgs/commit/09397c61aa6b42f5720e911dacf7fc1d018575a4) wasmtime: 33.0.0 -> 36.0.2
* [`cf20b51a`](https://github.com/NixOS/nixpkgs/commit/cf20b51ab55da918d74d8490fe62263ac0bb164a) dart.metadata_god: drop
* [`4b4bc20c`](https://github.com/NixOS/nixpkgs/commit/4b4bc20c3aaa101d0fce4339c1ffaac2fb186e7a) dart.fvp: drop
* [`f9eb31a8`](https://github.com/NixOS/nixpkgs/commit/f9eb31a8de3730a9ef30fa07cde7d55c29e4b517) dart.audiotags: drop
* [`f8d7869b`](https://github.com/NixOS/nixpkgs/commit/f8d7869b380e3b944e0892e3c8843e5cd22ea4b6) sparse: 0.6.4 -> 0.6.4-unstable-2024-02-03
* [`7fb5b2dc`](https://github.com/NixOS/nixpkgs/commit/7fb5b2dc8caf5d23cbfa8953c4265c3231d49fe5) python3Packages.realtime: 2.5.2 -> 2.7.0
* [`0de4ba04`](https://github.com/NixOS/nixpkgs/commit/0de4ba042404e95366b9f143a4cb1949c013d5a5) fuzzel: 1.13.0 -> 1.13.1
* [`6496761a`](https://github.com/NixOS/nixpkgs/commit/6496761ae2304bcf6aeff7d576a41aafbba3f8ce) python313Packages.orm: drop
* [`575af146`](https://github.com/NixOS/nixpkgs/commit/575af146a89d882a220e2c28d38fe4a8a53216aa) luci-go: drop
* [`c374b808`](https://github.com/NixOS/nixpkgs/commit/c374b808bb16798b348c25acfcb5914f79be8c81) kumactl: 2.11.4 -> 2.11.5
* [`03e63ed0`](https://github.com/NixOS/nixpkgs/commit/03e63ed0d941b69f3182169aa303a47389b0e753) maintainers: add github/githubId for tomkoid
* [`f0343b50`](https://github.com/NixOS/nixpkgs/commit/f0343b50ea700c20c700810720d99cc153cd243a) sitelen-sewi-kiwen: unstable-2022-06-28 -> 1.8.1
* [`8d7354a0`](https://github.com/NixOS/nixpkgs/commit/8d7354a02c51780127540e7d00c8d75f111ac3d1) python3Packages.open-clip-torch: 3.0.0 -> 3.1.0
* [`55038b89`](https://github.com/NixOS/nixpkgs/commit/55038b891cc1b15ab454f9c6b7f21475b9f568b5) crystal_1_17: init at 1.17.1
* [`3bfd5caf`](https://github.com/NixOS/nixpkgs/commit/3bfd5caf7214483876ae2ae4b7e0683af626a607) docker-sync: drop
* [`70829433`](https://github.com/NixOS/nixpkgs/commit/7082943360f5f195c472f4e57bd6a5595affacc1) easyrsa: 3.2.3 -> 3.2.4
* [`e419db9f`](https://github.com/NixOS/nixpkgs/commit/e419db9fc248d8aee6d97cb360ff5e77321c45d9) rcu: 4.0.24 -> 4.0.25
* [`ced53550`](https://github.com/NixOS/nixpkgs/commit/ced535503fe2a85410ae6b92bef95a3e9b4222f6) icloudpd: 1.30.0 -> 1.31.0
* [`c38a8459`](https://github.com/NixOS/nixpkgs/commit/c38a8459c752e086336f5f7bfd89604870887d23) chirpstack-fuota-server: 3.0.0-test.4-unstable-2024-04-02 -> 3.0.0-test.4-unstable-2025-08-26
* [`010eaf6f`](https://github.com/NixOS/nixpkgs/commit/010eaf6f1b47996616ec7ae4457e45d28ace7c13) sniproxy: switch to pcre2
* [`77ffc77f`](https://github.com/NixOS/nixpkgs/commit/77ffc77f539ae55b5845cd401d0f92d42fa5f63d) maintainers/README.md: clarify maintainer removal
* [`52663dec`](https://github.com/NixOS/nixpkgs/commit/52663dec47aeacb76ae12c04eedd4d8c51e8ec12) maintainers: fix GitHub handles
* [`582c0f95`](https://github.com/NixOS/nixpkgs/commit/582c0f9598ccea6a4b05d7e725e60801bce5d178) wit-bindgen: 0.44.0 -> 0.45.0
* [`997f4108`](https://github.com/NixOS/nixpkgs/commit/997f41082f28f87e61327e629005d77e9b294c30) element-unwrapped: 1.11.109 -> 1.11.110
* [`5feaf8b6`](https://github.com/NixOS/nixpkgs/commit/5feaf8b6b53e4608d3aba7f40672e50bcc75e1ef) element-desktop: 1.11.109 -> 1.11.110
* [`07284d9e`](https://github.com/NixOS/nixpkgs/commit/07284d9e7b62586b8beb7bc8e52fda99e24bc221) youtube-dl: switch license to Unlicense
* [`32cc7d3c`](https://github.com/NixOS/nixpkgs/commit/32cc7d3c93a8eb17534648bbe1d467d67f2605c7) xe: switch license to cc0
* [`2141b4e3`](https://github.com/NixOS/nixpkgs/commit/2141b4e38b8bae900b823b2cd1e2e59c5fa1368d) lib.addMetaAttrs: use overrideAttrs when available
* [`2dcbb6fd`](https://github.com/NixOS/nixpkgs/commit/2dcbb6fd89b87f4bb9056a1a653833ce61b154b8) timewarrior: 1.9.0 -> 1.9.1
* [`533c81c4`](https://github.com/NixOS/nixpkgs/commit/533c81c4c17a0f5306d33fb47e477201854384ab) swappy: 1.7.1 -> 1.8.0
* [`1d7006fe`](https://github.com/NixOS/nixpkgs/commit/1d7006fe99672bac50d1533ccbdfe2b00ed11a7b) socklog: switch license to bsd3
* [`1d83f10f`](https://github.com/NixOS/nixpkgs/commit/1d83f10fdb18946d1cbd3576e2d8e3f4c299d32e) sct: switch license to isc
* [`747d0aee`](https://github.com/NixOS/nixpkgs/commit/747d0aee49e86a185b2e46db6ac72405d2e9aad3) wgetpaste: switch license to mit
* [`290a166e`](https://github.com/NixOS/nixpkgs/commit/290a166e06ed2462fc193aa9a5b331c373d70b29) sope: switch license to lgpl2Plus
* [`4c475554`](https://github.com/NixOS/nixpkgs/commit/4c475554d99c8ce39c85e8584e80afc8cb7d428b) stb: switch license to mit or unlicense
* [`de66c73a`](https://github.com/NixOS/nixpkgs/commit/de66c73a1938d53625e552ab8e1cdfa62ae4fb1f) maintainers: add m0ustach3
* [`398f31cc`](https://github.com/NixOS/nixpkgs/commit/398f31cc66a618f9e62f5648262142f46ce193cf) grafanaPlugins.grafana-lokiexplore-app: 1.0.25 -> 1.0.26
* [`a2c6b5e6`](https://github.com/NixOS/nixpkgs/commit/a2c6b5e6af20f102f91b8c15b4d23618454a6882) nixos/crowdsec: init module
* [`0f2126e6`](https://github.com/NixOS/nixpkgs/commit/0f2126e69cce219c2131ba6a4a8030149cc8f58b) grafanaPlugins.grafana-oncall-app: 1.16.4 -> 1.16.5
* [`b26f7f00`](https://github.com/NixOS/nixpkgs/commit/b26f7f0097c1b48b698a24cb58d94ccd1113b777) grafanaPlugins.grafana-pyroscope-app: 1.7.0 -> 1.8.1
* [`02f79d84`](https://github.com/NixOS/nixpkgs/commit/02f79d8431fb433b15540b332ba3a5c9f9656241) xrootd: 5.8.1 -> 5.8.4
* [`dc473d50`](https://github.com/NixOS/nixpkgs/commit/dc473d50203936f0ec0c76d38385b14dd9ca4116) python312Packages.rucio: 37.7.1 -> 38.0.0
* [`3a911c15`](https://github.com/NixOS/nixpkgs/commit/3a911c1572072e1990a311a48866206c328cb3b1) chrony: 4.7 -> 4.8
* [`ee7e58e4`](https://github.com/NixOS/nixpkgs/commit/ee7e58e48e5e2d01ca0fc89dd69abe2525166eec) python3Packages.pcodec: 0.4.2 -> 0.4.6
* [`3c460dd0`](https://github.com/NixOS/nixpkgs/commit/3c460dd0e716b5fba08eddfbc1d6573eb05c9a60) cargo-expand: 1.0.114 -> 1.0.115
* [`558ded8a`](https://github.com/NixOS/nixpkgs/commit/558ded8aeac032ea490340c4980d47af97329e2c) xtensor: 0.26.0 -> 0.27.0
* [`c6bcb7df`](https://github.com/NixOS/nixpkgs/commit/c6bcb7dfb18861ed106239dbf062f027b5e4e862) ocamlPackages.bstr: init at 0.0.2
* [`a03ce7eb`](https://github.com/NixOS/nixpkgs/commit/a03ce7ebd7f03ea82fb5bf611fe4c8f73d8f3c78) ocamlPackages.h1: 1.0.0 → 1.1.0
* [`d8f89b48`](https://github.com/NixOS/nixpkgs/commit/d8f89b48aca9e1d23639bae5946a2a5e69016979) xtensor-blas: 0.22.0 -> 0.23.0
* [`501c0637`](https://github.com/NixOS/nixpkgs/commit/501c0637d1012dea0de00e0fb09b6fe8e1c86002) python3Packages.islpy: 2025.2.4 -> 2025.2.5
* [`c70b5896`](https://github.com/NixOS/nixpkgs/commit/c70b58962e8cd454173901ca04a2deef83a420bf) python3Packages.telethon: 1.37.0 -> 1.40.0
* [`cb2eae95`](https://github.com/NixOS/nixpkgs/commit/cb2eae952ac49ea465d8ba522b7a54a0068b41b9) cloudflared: 2025.8.0 -> 2025.8.1
* [`0d76146b`](https://github.com/NixOS/nixpkgs/commit/0d76146bb7ea15973bc1aca2d4e3a65096fafe32) python3Packages.plyer: Maintain abit
* [`e1515b90`](https://github.com/NixOS/nixpkgs/commit/e1515b900b6a5323b3e20a41773596041ed8eb28) postgresqlPackages.pgddl: 0.29 -> 0.30
* [`7f275e7c`](https://github.com/NixOS/nixpkgs/commit/7f275e7c8537f816923ae58238592eb613ce4fd0) lug-helper: 4.2 -> 4.4
* [`d1c3483e`](https://github.com/NixOS/nixpkgs/commit/d1c3483eb91d4a1d002f0e58b7e31f4503b98590) omnissa-horizon-client: 2503 -> 2506
* [`e8efaf56`](https://github.com/NixOS/nixpkgs/commit/e8efaf56a9f5e6405876ba69375af8cf8292d85f) svix-server: 1.73.0 -> 1.75.0
* [`11041306`](https://github.com/NixOS/nixpkgs/commit/1104130607d356a66a33c98571891e31c6f735e2) tuleap-cli: 1.1.0 -> 1.2.0
* [`5309a6ec`](https://github.com/NixOS/nixpkgs/commit/5309a6ecce2bdaae1045faf913fcdcf6b113d061) mattermostLatest: 10.11.1 -> 10.11.2
* [`4de06f70`](https://github.com/NixOS/nixpkgs/commit/4de06f704941bfc937154e32e1da2407b13a4f57) forge-mtg: improve update script and patch handling
* [`e59a7777`](https://github.com/NixOS/nixpkgs/commit/e59a7777050d9ba74044d482b06f30c1d89575f6) netbox_4_3: 4.3.5 -> 4.3.7
* [`26b7cfcc`](https://github.com/NixOS/nixpkgs/commit/26b7cfccad0123da5b1182f039ed52d9d8cdda27) signal-desktop: 7.66.0 -> 7.68.0
* [`36ac3d91`](https://github.com/NixOS/nixpkgs/commit/36ac3d918606c4d8289f3f4820ab3299d86e2c61) open-policy-agent: 1.7.1 -> 1.8.0
* [`9d0e807b`](https://github.com/NixOS/nixpkgs/commit/9d0e807b19259003a3fc62be9112242199696606) openttd-ttf: 0.7 -> 0.8
* [`04c3b27e`](https://github.com/NixOS/nixpkgs/commit/04c3b27e2616584a8a49ecd9816adb869673ed7a) xbrightness: drop
* [`e986605c`](https://github.com/NixOS/nixpkgs/commit/e986605cacbf29a38f75ee2ba2961a90c996eec6) pwdsphinx: init at 2.0.3
* [`ee56f797`](https://github.com/NixOS/nixpkgs/commit/ee56f797a4a4d1de200cfaafc563bf01f9264ad3) rcu: 4.0.25 -> 4.0.26
* [`e8901347`](https://github.com/NixOS/nixpkgs/commit/e8901347c8e4e51c2a13e492e8d25468c43346f4) phpPackages.grumphp: 2.14.0 -> 2.15.0
* [`a8e8cced`](https://github.com/NixOS/nixpkgs/commit/a8e8cced5477ece89ebb47ba0237bc74d20901c8) dependency-track: 4.13.3 -> 4.13.4
* [`bd93e9a8`](https://github.com/NixOS/nixpkgs/commit/bd93e9a8a5d03cb861781ed94a4879a61c802321) bant: 0.2.1 -> 0.2.2
* [`2bafc40b`](https://github.com/NixOS/nixpkgs/commit/2bafc40b52729cdae8da2ba7565104adeb387480) tuned: 2.25.1 -> 2.26.0
* [`9c61bedc`](https://github.com/NixOS/nixpkgs/commit/9c61bedc9f202d390e39c53998ff34c6b46a72d6) unifi: 9.3.45 -> 9.4.19
* [`efe1fea3`](https://github.com/NixOS/nixpkgs/commit/efe1fea3cd9eb9d47f22542a00423b939e25c148) tuned: patch profile scripts
* [`ebb878b3`](https://github.com/NixOS/nixpkgs/commit/ebb878b36307c211ba3f2fb59c6c65ebde7922ff) whistle: 2.9.100 -> 2.9.101
* [`8e9c88d9`](https://github.com/NixOS/nixpkgs/commit/8e9c88d9c88973794f70050e48b15517fa1a8553) libphonenumber: 9.0.12 -> 9.0.13
* [`20737bde`](https://github.com/NixOS/nixpkgs/commit/20737bde97adb0ccb0e9a1af508b8ae834f4fa34) cargo-flamegraph: 0.6.8 -> 0.6.9
* [`dec6dc5d`](https://github.com/NixOS/nixpkgs/commit/dec6dc5d0b580eaad7825856ddc64bcaaa10b4d7) x3270: 4.3ga8 -> 4.4ga6
* [`6d1eef9f`](https://github.com/NixOS/nixpkgs/commit/6d1eef9fa3c02ba6e2a2b098b75198ad8e15a86e) x3270: remove with lib
* [`48fee47b`](https://github.com/NixOS/nixpkgs/commit/48fee47b5e64be280975d9703d74aea8d39630d0) openxr-loader: 1.1.50 -> 1.1.51
* [`74bb634f`](https://github.com/NixOS/nixpkgs/commit/74bb634fb5abd3fe2a09bd3a0a2152f2c13ccfae) python3Packages.langsmith: 0.4.14 -> 0.4.20
* [`1ada050b`](https://github.com/NixOS/nixpkgs/commit/1ada050ba6404635644aeef5d312b64cd4666f16) meshoptimizer: 0.24 -> 0.25
* [`f4542bbc`](https://github.com/NixOS/nixpkgs/commit/f4542bbc9dcffc33f232f37282d8aa557a21f876) hmcl: 3.6.15 -> 3.6.16
* [`9dd1ed3b`](https://github.com/NixOS/nixpkgs/commit/9dd1ed3b6b9d3b14bb1c92238b65ab8edeb6b3c6) wifi-password: drop
* [`3deb3f78`](https://github.com/NixOS/nixpkgs/commit/3deb3f78d9c173fde416a1facec2a648431002ec) python3Packages.webdataset: 0.2.107 -> 0.3.2
* [`e9b89ff8`](https://github.com/NixOS/nixpkgs/commit/e9b89ff8b42f95a8388b47b40726bea4abffea78) whitesur-icon-theme: Remove blackPanelIcons option
* [`227d978e`](https://github.com/NixOS/nixpkgs/commit/227d978ef1ee20de76ccf18e09a82015e6663b8b) whalebird: 6.2.2-unstable-2025-06-12 -> 6.2.4
* [`f65c4499`](https://github.com/NixOS/nixpkgs/commit/f65c449978af8cb193cdfc21162e3f1a75dd3fc7) broot: 1.47.0 -> 1.48.0
* [`c4bf9a7f`](https://github.com/NixOS/nixpkgs/commit/c4bf9a7f9bb6f98d6be1c23ef620039725ed9f58) typos: 1.35.5 -> 1.35.6
* [`efdf2cec`](https://github.com/NixOS/nixpkgs/commit/efdf2cec0019c8de8662ebb003808d26e57e0425) nnd: 0.38 -> 0.45
* [`f19395ed`](https://github.com/NixOS/nixpkgs/commit/f19395ed10d2dca99fd945676e60e06fd0a2f371) slack: add prince213 to maintainers
* [`a78e39d5`](https://github.com/NixOS/nixpkgs/commit/a78e39d566663dcf12ec07ee4eaf38f803b7171d) slack: copy entire .app on darwin
* [`5d4509bc`](https://github.com/NixOS/nixpkgs/commit/5d4509bc031dd7a223064db0e2710f2f7056578f) slack: avoid with lib;
* [`aa64b8a0`](https://github.com/NixOS/nixpkgs/commit/aa64b8a07f5040030c8a59e34365ba7b8d8199bb) slack: split by system
* [`ec0c44f9`](https://github.com/NixOS/nixpkgs/commit/ec0c44f9c3f53716938c90090e3600f13b6eb6fe) slack: add sources.nix & fix update.sh
* [`71468897`](https://github.com/NixOS/nixpkgs/commit/71468897503c414b97d7768b487500a6053bda71) slack: 4.45.64 -> 4.45.69
* [`3011f3e4`](https://github.com/NixOS/nixpkgs/commit/3011f3e497ee5e2099ff64ca5ce8987a51e6afe3) w_scan: drop
* [`85df8e93`](https://github.com/NixOS/nixpkgs/commit/85df8e9381435ea4587705fee43df4a7433fa163) stats: 2.11.49 -> 2.11.51
* [`446604b2`](https://github.com/NixOS/nixpkgs/commit/446604b2880992c9c3c08c9c6f3e349d0be61980) nvidia-mig-parted: 0.12.1 -> 0.12.3
* [`b553a5b8`](https://github.com/NixOS/nixpkgs/commit/b553a5b8b39a75ec2e568ecf0e7d3c4bbb3f3414) appflowy: 0.9.7 -> 0.9.8
* [`9a2f99bc`](https://github.com/NixOS/nixpkgs/commit/9a2f99bcf063ab7c0924a850a41ca3ec8e9696ad) python3Packages.segments: 2.2.1 -> 2.3.0
* [`8020a147`](https://github.com/NixOS/nixpkgs/commit/8020a147882dc81fc67e7334f615dac135016f0d) python313Packages.mkdocs-autorefs: 1.4.2 -> 1.4.3
* [`f5e139fb`](https://github.com/NixOS/nixpkgs/commit/f5e139fb6d44d418795a3d65feb2d729ca45ac7d) cargo-sort: 2.0.1 -> 2.0.2
* [`317c9f4b`](https://github.com/NixOS/nixpkgs/commit/317c9f4bce25491d49083aa48a626bcbe734103e) weasis: Add support for aarch64-linux
* [`c47eacd0`](https://github.com/NixOS/nixpkgs/commit/c47eacd006798d13be87402807c7271d06fbcf5b) cnquery: 11.68.0 -> 11.69.1
* [`c2a7bd7b`](https://github.com/NixOS/nixpkgs/commit/c2a7bd7b11938553f4ec517248b34bd852ecc574) wasmtime: don't propagate binaries for C API & library
* [`86b7fe15`](https://github.com/NixOS/nixpkgs/commit/86b7fe152b6e492ac066d6026d25c1409ae54de6) wasmtime: use `moveToOutput` in postInstall
* [`01620f6d`](https://github.com/NixOS/nixpkgs/commit/01620f6dbe08c649018da1f003580aa3e47672a9) pkl: 0.29.0 -> 0.29.1
* [`6c867d22`](https://github.com/NixOS/nixpkgs/commit/6c867d22dee9c36a93a1874697da46702fc99059) wasmtime: add nekowinston to maintainers
* [`aea0d81e`](https://github.com/NixOS/nixpkgs/commit/aea0d81eb2d949506611d44ee06c75842bbc8a78) kubernetes-polaris: 10.1.0 -> 10.1.1
* [`c721f920`](https://github.com/NixOS/nixpkgs/commit/c721f92084b697901d6ba6e1f05e047ab4de742c) python3Packages.pywikibot: 10.3.0 -> 10.3.2
* [`6f587345`](https://github.com/NixOS/nixpkgs/commit/6f587345b64f9acb67c262d7e2e2d192c2866bbf) eslint: 9.33.0 -> 9.34.0
* [`1e602171`](https://github.com/NixOS/nixpkgs/commit/1e602171ccf00cd14cd039d78beea2698feb2d61) vscode-extensions.ndonfris.fish-lsp: 0.1.11 -> 0.1.13
* [`cae6777c`](https://github.com/NixOS/nixpkgs/commit/cae6777cc114fb0f47639ef326faa59beec6791f) vscode-extensions.biomejs.biome: 2025.2.72227 -> 2025.7.41733
* [`a7d23d2b`](https://github.com/NixOS/nixpkgs/commit/a7d23d2b66d8e483e12121d994230be0cee97647) python3Packages.mkdocs-mermaid2-plugin: 1.2.1 -> 1.2.2
* [`de8af9a3`](https://github.com/NixOS/nixpkgs/commit/de8af9a3dcf2da3d489d18b0aaf3ae3014f6d0f1) python3Packages.certomancer: 0.12.3 -> 0.13.0
* [`9ee239da`](https://github.com/NixOS/nixpkgs/commit/9ee239da66e85f43510703de2839c5f98400e56b) vscode-extensions.ms-vscode.theme-tomorrowkit: drop
* [`6a5cb7d8`](https://github.com/NixOS/nixpkgs/commit/6a5cb7d8d6ab50bb2732ccc8312ca95177b8d26c) kustomize: return same version as official releases
* [`da4b0677`](https://github.com/NixOS/nixpkgs/commit/da4b0677231eefb7d02cdb82263dbbed64bf10a9) kustomize: modernize
* [`a4303e0d`](https://github.com/NixOS/nixpkgs/commit/a4303e0d637367dad9d1e054c9e87bb1de4c3c81) kustomize: add test case to check returned version
* [`2f93bbed`](https://github.com/NixOS/nixpkgs/commit/2f93bbed9ad5eae0f15c9fb8cff40518cd9788f0) gh-s: 0.0.11 -> 0.0.12
* [`ce74b58b`](https://github.com/NixOS/nixpkgs/commit/ce74b58b8f9338dff99372a40347ac909c88412f) csvlens: 0.12.0 -> 0.13.0
* [`2fa69671`](https://github.com/NixOS/nixpkgs/commit/2fa696716950e20ea700da95fc773280ceb628c4) etherpad-lite: 2.4.2 -> 2.5.0
* [`9808c80c`](https://github.com/NixOS/nixpkgs/commit/9808c80cd83fe4fe04ef38d494ade4dc94d952f3) python3Packages.supabase: fix pname
* [`24cbb28f`](https://github.com/NixOS/nixpkgs/commit/24cbb28fcf2de376151235fe50103915efb47ac8) python3Packages.python-ctags3: 1.5.0 -> 1.6.0
* [`6b2cb6ae`](https://github.com/NixOS/nixpkgs/commit/6b2cb6aec7ebbb5c6631d84da1ceca6511aff645) python3Packages.supabase: 2.16.0 -> 2.17.0
* [`85a8f5e6`](https://github.com/NixOS/nixpkgs/commit/85a8f5e6c2fa174dc76eec9e2f1bbf7e75b85b16) python3Packages.postgrest: rename from postgrest-py
* [`1522e2bf`](https://github.com/NixOS/nixpkgs/commit/1522e2bf8aa7fdd55f9f4424e5b96b5cccbd856f) volanta: add updateScript
* [`6d8948ed`](https://github.com/NixOS/nixpkgs/commit/6d8948ed1438fafe1cd254b201231ba5e36a7c02) volanta: 1.12.0 -> 1.12.4
* [`df10188f`](https://github.com/NixOS/nixpkgs/commit/df10188f01c69a49008dd26a97fa6a9f47497398) volanta add --wayland-text-input-version=3
* [`2d1f19a4`](https://github.com/NixOS/nixpkgs/commit/2d1f19a49b6d5cdde39c08498dcb27aeeb3b8cae) vivictpp: 1.1.0 -> 1.3.0
* [`27ed5e6c`](https://github.com/NixOS/nixpkgs/commit/27ed5e6c1b05ce8f923149a1625f26d0cc94369a) vivictpp: remove with lib
* [`6bed541e`](https://github.com/NixOS/nixpkgs/commit/6bed541e6bd112683e65dc02b6cfbcc6eb82c838) garnet: 1.0.82 -> 1.0.83
* [`45de2973`](https://github.com/NixOS/nixpkgs/commit/45de29733269ed1de477415cf7cf1cc5d8371957) xen: Add support for multiboot binary
* [`c0dcc49d`](https://github.com/NixOS/nixpkgs/commit/c0dcc49d242daa954448cd4d80d0b252aa3aa30d) nixos/xen: Add v2 bootspec extension with multiboot support
* [`647c04f2`](https://github.com/NixOS/nixpkgs/commit/647c04f2e97a543b34ea011871d506c3ff45b892) nixos/limine: Add support for booting Xen
* [`b32ce975`](https://github.com/NixOS/nixpkgs/commit/b32ce9753cd98e2099a6c23a0d805269dedd0399) anydesk: add systemd service
* [`5fa08c49`](https://github.com/NixOS/nixpkgs/commit/5fa08c496dd3a52d365ea7e2104b646696f04edc) cherry-studio: 1.5.6 -> 1.5.7
* [`a805c660`](https://github.com/NixOS/nixpkgs/commit/a805c660deaf631690f0f17397d152291ad07c8f) cpp-jwt: 1.5 -> 1.5.1
* [`2dc854ee`](https://github.com/NixOS/nixpkgs/commit/2dc854ee20a1c6e638f25d7b1edc4cfda0a443fd) moralerspace-nf: remove
* [`fa8a1ad9`](https://github.com/NixOS/nixpkgs/commit/fa8a1ad94795990111eedcd9471c9eb19b70d090) moralerspace-hwnf: remove
* [`4f8fb005`](https://github.com/NixOS/nixpkgs/commit/4f8fb005d257b608a77b980cd280a511b53c91f9) moralerspace: 1.1.0 -> 2.0.0
* [`98241cae`](https://github.com/NixOS/nixpkgs/commit/98241caed0dee8931046410b94a970c08834fab9) jan: 0.6.8 -> 0.6.9
* [`27f9638a`](https://github.com/NixOS/nixpkgs/commit/27f9638a9c735337b0512cf56d729f52202201ce) python3Packages.braintree: 4.29.0 -> 4.38.0
* [`2b9f4f9b`](https://github.com/NixOS/nixpkgs/commit/2b9f4f9b6202dfc0362fdfaab01157abd8fcb07a) microsoft-edge: 139.0.3405.111 -> 139.0.3405.125
* [`a9b4ed50`](https://github.com/NixOS/nixpkgs/commit/a9b4ed50350acc5fec3a9593a6c87f3f0d7f3a20) heaptrack: 1.5.0 -> 1.5.0-unstable, switch to Qt6
* [`b087f2ca`](https://github.com/NixOS/nixpkgs/commit/b087f2ca8beb44e97a2e1fc5e97121cad0821099) gitversion: drop
* [`50021ed9`](https://github.com/NixOS/nixpkgs/commit/50021ed95d54a83ceb77649e5f955cb54af7e819) kbibtex: drop
* [`fd434e8d`](https://github.com/NixOS/nixpkgs/commit/fd434e8dfc1c590ccfce77667716b63a8be00e0c) kmplayer: drop
* [`f2ede327`](https://github.com/NixOS/nixpkgs/commit/f2ede3274fb4447bc7c055516d22f253fe6fc53e) xk6: 1.1.2 -> 1.1.3
* [`8343919d`](https://github.com/NixOS/nixpkgs/commit/8343919d409bdb57273849384ada9dc7aad0ff57) kotatogram-desktop: build without kimageformats
* [`40528dc1`](https://github.com/NixOS/nixpkgs/commit/40528dc1d684093743948f58789b643e9b5163ac) krename: drop
* [`03279a69`](https://github.com/NixOS/nixpkgs/commit/03279a69c46f453c633c590c9d53a587ab9b12b9) krunner-translator: drop
* [`8dc328a8`](https://github.com/NixOS/nixpkgs/commit/8dc328a87b2f6675752ccd07fc5cd1725fece387) krunner-pass: drop
* [`bf727c16`](https://github.com/NixOS/nixpkgs/commit/bf727c16d0342af17e3bd5f3a71c53fdaca8ea42) libreoffice: drop Qt5 builds
* [`ef013d7b`](https://github.com/NixOS/nixpkgs/commit/ef013d7b426e6919e40cacd054c9f6ad318db3ec) libsForQt5.kpeoplevcard: drop
* [`45c8546d`](https://github.com/NixOS/nixpkgs/commit/45c8546d76b2cd07e35e879a00608b4c12112031) libsForQt5.kweathercore: drop
* [`1c69df60`](https://github.com/NixOS/nixpkgs/commit/1c69df60e052cc9dc5155815817eb47716c41b5b) nm-tray: drop
* [`bc779518`](https://github.com/NixOS/nixpkgs/commit/bc779518c97c405e35fe9a37d8cb904878c8cf6e) nomacs: switch to Qt6 only
* [`a3192abf`](https://github.com/NixOS/nixpkgs/commit/a3192abffff03121a776927815f7f3b645332a75) skrooge: switch to Qt6
* [`99d4380a`](https://github.com/NixOS/nixpkgs/commit/99d4380aaa526304685deafc77229dbe0a803f3d) treewide: trim some leaves from KF5
* [`7cb8db5c`](https://github.com/NixOS/nixpkgs/commit/7cb8db5c059a7876a984422036ec03e4464acb15) cloudflare-warp: 2025.5.943 -> 2025.6.1335
* [`889a4b6f`](https://github.com/NixOS/nixpkgs/commit/889a4b6fb754f0183a2259ba3c8f1e7b8008edb7) lapce: 0.4.2 -> 0.4.4
* [`cbd34910`](https://github.com/NixOS/nixpkgs/commit/cbd349107fa83f2484fc73c992313b71cc96777e) ghidra, ghidra-bin: 11.3.2 -> 11.4.2
* [`d481e1f4`](https://github.com/NixOS/nixpkgs/commit/d481e1f4aa69d1f47a2a9e5e42069b26f64fc7c1) udisks2: 2.10.1 -> 2.10.2
* [`27cada11`](https://github.com/NixOS/nixpkgs/commit/27cada1157e88208ddadefa6351150fbfdabd246) librewolf-bin-unwrapped: 142.0.1 -> 142.0.1-1
* [`64c37990`](https://github.com/NixOS/nixpkgs/commit/64c37990631efb5611d55fd81c895e75992a5340) python3Packages.pykdtree: 1.4.2 -> 1.4.3
* [`ee4d329a`](https://github.com/NixOS/nixpkgs/commit/ee4d329aff682cedc6ab56a4931005c07229bb47) inxi: 3.3.38-1 -> 3.3.39-1
* [`473e6619`](https://github.com/NixOS/nixpkgs/commit/473e66193764a3f1ad57fcaf039fc8bafe5453b7) litmus: 0.14 -> 0.17
* [`d593eadf`](https://github.com/NixOS/nixpkgs/commit/d593eadfc66875e41778d753b8970818512854be) nixVersions: give unit tests access to a $HOME directory
* [`5e7b9010`](https://github.com/NixOS/nixpkgs/commit/5e7b9010cf49024bd5edec0a193acd3a7cf737bf) nixVersions: use writableTmpDirAsHomeHook for the unit tests
* [`e1ff94f0`](https://github.com/NixOS/nixpkgs/commit/e1ff94f0921f808ef0a10503cbe1f93190a64557) nixVersions: fix impurity trying to access the Nix daemon in libstore-tests
* [`f6cbf3ec`](https://github.com/NixOS/nixpkgs/commit/f6cbf3ec402538b3b383af59256f45b7a7f5c2b0) nixVersions: increase the initial Boehm GC mark stack size
* [`fe134e42`](https://github.com/NixOS/nixpkgs/commit/fe134e42fff55d8045270888ee65273ab966fded) nixVersions: use `writableTmpDirAsHomeHook` in `nix-fetchers-tests` execution environment
* [`269f0be9`](https://github.com/NixOS/nixpkgs/commit/269f0be9ee6682bd5665a90faf03a2b6dd179b23) bmake: interrupt-compat test fails on x86_64-linux building for i686-linux
* [`f7fecd58`](https://github.com/NixOS/nixpkgs/commit/f7fecd580268026398e9e5927e3a122e6aa6b2dd) nixosTests.nix-upgrade: fix eval
* [`42e6ff43`](https://github.com/NixOS/nixpkgs/commit/42e6ff4333af70e7385820837a8fac96833c24e8) nixVersions.nix_2_31: init at 2.31.0
* [`540e1887`](https://github.com/NixOS/nixpkgs/commit/540e188796bfdb9580218f3be979a372023c27e7) ci/eval/compare: ping maintainers of removed packages
* [`d9c86142`](https://github.com/NixOS/nixpkgs/commit/d9c8614245ed5ff28d51fa56ecaf4bc9dc47019a) starpls: 0.1.22-unstable-2025-12-30 -> 0.1.22
* [`2ec00b14`](https://github.com/NixOS/nixpkgs/commit/2ec00b143f4febf5c4356c52080bd4ecb69254f3) python3Packages.chirpstack-api: 3.12.4 -> 3.12.5
* [`774a012f`](https://github.com/NixOS/nixpkgs/commit/774a012f8d51f125cf22feadd61d0b437021fd4a) vidmerger: 0.3.0 -> 0.4.0
* [`423d5437`](https://github.com/NixOS/nixpkgs/commit/423d5437d65e77194b38175863ac4a9505b068fa) vidmerger: remove with lib
* [`80656b67`](https://github.com/NixOS/nixpkgs/commit/80656b677ee20df14e2e63e3b183ea8046c89e78) python3Packages.colored: 2.2.3 -> 2.3.1
* [`dd769802`](https://github.com/NixOS/nixpkgs/commit/dd769802f786c44a84cb90a310c8a6253f4bb21f) codecrafters-cli: 36 -> 37
* [`eaaf18d2`](https://github.com/NixOS/nixpkgs/commit/eaaf18d2e406ef0555efcea9382247eec6d49a87) vale-ls: 0.3.8 -> 0.4.0
* [`c76a43e1`](https://github.com/NixOS/nixpkgs/commit/c76a43e1c7df80a5350c37e960c61ac200442f29) vale-ls: remove with lib
* [`47289576`](https://github.com/NixOS/nixpkgs/commit/47289576ce2c8bb84ae0c02ba194c5f8c2f14d37) python3Packages.optuna-dashboard: 0.19.0 -> 0.20.0b1
* [`66ab45eb`](https://github.com/NixOS/nixpkgs/commit/66ab45eb9aea41f62e11b8d1e7c8c0f60ce97106) doc: updated breaking changes notes for prometheus-script-exporter
* [`0753aa45`](https://github.com/NixOS/nixpkgs/commit/0753aa45805ec81f120a6d059979623ad3581416) ci/eval/compare: remove package validity check
* [`e88dd3a8`](https://github.com/NixOS/nixpkgs/commit/e88dd3a8b278ffe22b7de999183220beeda05a54) ci/eval/compare: only check changed attrpaths
* [`4126ef7e`](https://github.com/NixOS/nixpkgs/commit/4126ef7e00fe76fb543d5235f1e5fe33dc3e50e2) ci/eval/compare: refactor
* [`12be28bc`](https://github.com/NixOS/nixpkgs/commit/12be28bc4ce6deea7314649b5c3f9145cf8dba63) usbsdmux: 24.1.1 -> 25.8
* [`ac3e9c99`](https://github.com/NixOS/nixpkgs/commit/ac3e9c990e7df67cbe271a7fe4b0468f64c86c91) usbsdmux: remove with lib
* [`4b2fffef`](https://github.com/NixOS/nixpkgs/commit/4b2fffef22d058389f86ac61269242414fb5cb8c) glitchtip: 5.1.0 -> 5.1.1
* [`8040c3fb`](https://github.com/NixOS/nixpkgs/commit/8040c3fbaa09ede5803fd9a017c825ff0698511b) kind: 0.29.0 -> 0.30.0
* [`4b29594d`](https://github.com/NixOS/nixpkgs/commit/4b29594de4892f614cdd28cdedb10c44cee599d7) python3Packages.jianpu-ly: 1.860 -> 1.862
* [`1ba1f526`](https://github.com/NixOS/nixpkgs/commit/1ba1f5265821785e6a3076d04b73b4fdab40dc7a) opentelemetry-collector-builder: 0.131.0 -> 0.134.0
* [`8b4862c6`](https://github.com/NixOS/nixpkgs/commit/8b4862c60819d60b48724814d1aea1003b65deda) nixos/radicle: add httpd.aliases option
* [`df1422e9`](https://github.com/NixOS/nixpkgs/commit/df1422e9a4b07ce96130396207f6553a4df1cf7d) nixos/listmonk: fix db settings type
* [`d5f2cf18`](https://github.com/NixOS/nixpkgs/commit/d5f2cf186fd6ab873568a1821716c45d5836382a) spacer: 0.4.5 -> 0.5.0
* [`288f11f0`](https://github.com/NixOS/nixpkgs/commit/288f11f0ec057569a613cbe994db4d87b8493f83) obsidian: enable text-input-v3 on Wayland
* [`32a339dc`](https://github.com/NixOS/nixpkgs/commit/32a339dcc62981733eeaa58e7a8c769164a24437) katana: 1.2.1 -> 1.2.2
* [`63d3b398`](https://github.com/NixOS/nixpkgs/commit/63d3b3981200b6c8a18180263503dc617afc2d80) python3Packages.django-otp: 1.6.0 -> 1.6.1
* [`0b40fa82`](https://github.com/NixOS/nixpkgs/commit/0b40fa822f9a1de5099e3c8f749e353570dc8517) python3Packages.plexapi: 4.17.0 -> 4.17.1
* [`ebd48860`](https://github.com/NixOS/nixpkgs/commit/ebd488603d8158a9054037e028ab7acd833ec3da) imagemagick: 7.1.2-2 -> 7.1.2-3
* [`7db5a1c7`](https://github.com/NixOS/nixpkgs/commit/7db5a1c7ed61378c06841efc3d4da8ca98ce2eba) python313Packages.i3ipc: fix build
* [`99a5b16b`](https://github.com/NixOS/nixpkgs/commit/99a5b16b7606934b54ae0a2181332a790cfd7a37) python313Packages.i3ipc: add pytest-timeout dependency
* [`3d53ad12`](https://github.com/NixOS/nixpkgs/commit/3d53ad129b680202045ecc77bd36d273577268f3) python313Packages.i3ipc: refactor
* [`9fac4d51`](https://github.com/NixOS/nixpkgs/commit/9fac4d51ec9e5ccfdb61966f273ab86ad13e610e) librasterlite2: fix build
* [`4f6020ba`](https://github.com/NixOS/nixpkgs/commit/4f6020baa6f23fc4fb411dec66b10e71e5db7f4f) python313Packages.i3ipc: improve test stability
* [`02fbf7e2`](https://github.com/NixOS/nixpkgs/commit/02fbf7e201db4b442c70ee0f5d072e83c5b67e6f) lxrandr: move from lxde.lxrandr
* [`126a57d7`](https://github.com/NixOS/nixpkgs/commit/126a57d77a72c78e5b225fe698714b0379ee7d40) lxpanel: move from lxde.lxpanel
* [`98e2c2d5`](https://github.com/NixOS/nixpkgs/commit/98e2c2d56dd9ec149b7d2f03f789e191d879dbf5) lxsession: move from lxde.lxsession
* [`67b69746`](https://github.com/NixOS/nixpkgs/commit/67b69746bce45b68533b4ce2c74366796cd19fbb) lxtask: move from lxde.lxtask
* [`8e217aa1`](https://github.com/NixOS/nixpkgs/commit/8e217aa17eac35c6e23aaafec237b470f493df7e) lxmenu-data: move from lxde.lxmenu-data
* [`a7eea2d9`](https://github.com/NixOS/nixpkgs/commit/a7eea2d9d7c2020957019bf2d09fd92b82132996) ceph: Use full path to mount(8) when remounting FUSE fs
* [`4cb0b20a`](https://github.com/NixOS/nixpkgs/commit/4cb0b20affdcad4f2016521539ada5d5ec545904) lxappearance{,-gtk2}: move from lxde.lxappearance{,-gtk2}
* [`3fd8469e`](https://github.com/NixOS/nixpkgs/commit/3fd8469e01ab4a91cc05a549a0793d427d8ee781) vscode-extensions.apollographql.vscode-apollo: 2.6.2 -> 2.6.3
* [`c782e020`](https://github.com/NixOS/nixpkgs/commit/c782e020d98798263bbdada2943861974925bb2b) python3Packages.adlfs: 2024.12.0 -> 2025.8.0
* [`9c4b2462`](https://github.com/NixOS/nixpkgs/commit/9c4b246222ff61134eb7fb89e9b3017527c292e6) usage: 2.1.1 -> 2.2.2
* [`820558b6`](https://github.com/NixOS/nixpkgs/commit/820558b692b72766a9aaf348deee80506bb0b2f2) krelay: 0.1.2 -> 0.1.3
* [`68c9911e`](https://github.com/NixOS/nixpkgs/commit/68c9911ec30ae72d050f3664ed24e4915cdf0193) kubedb-cli: 0.57.0 -> 0.58.0
* [`b4d3baa7`](https://github.com/NixOS/nixpkgs/commit/b4d3baa727c0fb03e63c29ab9bd6bfe781abffa9) python3Packages.lm-format-enforcer: 0.10.12 -> 0.11.3
* [`b9d2f67b`](https://github.com/NixOS/nixpkgs/commit/b9d2f67b72fe82770337f8f24182ae20c273579d) papermc: 1.21.8-40 -> 1.21.8-56
* [`da8cdb8c`](https://github.com/NixOS/nixpkgs/commit/da8cdb8c9b78011bef9d5920a2acee3f45bd3f47) ocamlPackages.smtml: 0.9.0 -> 0.10.0
* [`0aef16b9`](https://github.com/NixOS/nixpkgs/commit/0aef16b9d1bb4b63c36363914dbdc798cce840de) mcdreforged: 2.14.7 -> 2.15.1
* [`b407cd44`](https://github.com/NixOS/nixpkgs/commit/b407cd44106af6c4ce79b6cc7345c21ea623caa6) nagiosPlugins.check_systemd: 4.1.0 -> 5.0.0
* [`ff4728cb`](https://github.com/NixOS/nixpkgs/commit/ff4728cb69fef9368517f8f9e650746b975159c9) cargo-deb: 3.5.1 -> 3.6.1
* [`a245d115`](https://github.com/NixOS/nixpkgs/commit/a245d1159d46b164d683bacae8691fe214c11137) python3Packages.python-youtube: 0.9.7 -> 0.9.8
* [`a116c18d`](https://github.com/NixOS/nixpkgs/commit/a116c18dd87b727511ceaae28ecab8f1590b39d4) doc/vim: fix instructions on vim-plugins-updater update
* [`e37fb430`](https://github.com/NixOS/nixpkgs/commit/e37fb4306b0665f29ef860b1c4bbbbf4db34cfb3) upcloud-cli: 3.21.0 -> 3.22.0
* [`1f8555a6`](https://github.com/NixOS/nixpkgs/commit/1f8555a6f9e5bb4bb14c51d8c121b6df222cdfe1) nezha-agent: 1.13.0 -> 1.13.1
* [`c485ada9`](https://github.com/NixOS/nixpkgs/commit/c485ada958a200b9f4764e9d6da1af26182789c1) wine-staging: 10.13 -> 10.14
* [`360daa3e`](https://github.com/NixOS/nixpkgs/commit/360daa3eb41c591f930b6687f84a8cfd224f793c) cargo-geiger: 0.12.0 -> 0.13.0
* [`cad17194`](https://github.com/NixOS/nixpkgs/commit/cad17194fe73ab224313a157856c08a36bcbf15e) perfect_dark: init at 0-unstable-2025-08-25
* [`063267b7`](https://github.com/NixOS/nixpkgs/commit/063267b71192d849cf8300c05afcedd520dabdd5) nixos/syncthing: fix flags against 2.0 release
* [`0075a3a3`](https://github.com/NixOS/nixpkgs/commit/0075a3a3e43d0205773f6c1b08d2b75cabc6e388) python313Packages.boost-histogram: fix build
* [`89accea4`](https://github.com/NixOS/nixpkgs/commit/89accea40190cde9923a71862ff4ca0f2953bd71) python313Packages.boost-histogram: update `nativeCheckInputs`
* [`fff3dacf`](https://github.com/NixOS/nixpkgs/commit/fff3dacf2dc25bd91817550aef82a85aeb634ea0) python313Packages.boost-histogram: add `pythonImportsCheck`
* [`534b89d3`](https://github.com/NixOS/nixpkgs/commit/534b89d387b7ab196b5d23f6e365e84f421d933e) protolint: 0.56.1 -> 0.56.4
* [`4047d491`](https://github.com/NixOS/nixpkgs/commit/4047d4912f4d914b771701cfbcc7526bfe28b5f3) iosevka: 33.2.8 -> 33.2.9
* [`72d6b3a8`](https://github.com/NixOS/nixpkgs/commit/72d6b3a803acee52c843b1e1af49a92725d8bd67) src-cli: 6.7.0 -> 6.7.1104
* [`6ea6f7bc`](https://github.com/NixOS/nixpkgs/commit/6ea6f7bcb27119e223996d7b2ada72108996ce6f) ecm: fix build via `-enable-gmp-cflags=false`
* [`0d51e920`](https://github.com/NixOS/nixpkgs/commit/0d51e920d3307ec0c61a9dc3abf951a87d442523) top-level/release-outpaths: move to ci/eval
* [`2aae1425`](https://github.com/NixOS/nixpkgs/commit/2aae1425298dc478f02c9f05c01762b656975fd2) ci/eval: remove ofborg references
* [`9524a21f`](https://github.com/NixOS/nixpkgs/commit/9524a21fe03039b17b259fd95de606118fed6832) ci/eval/attrpaths: remove left-over condition
* [`04fcbb45`](https://github.com/NixOS/nixpkgs/commit/04fcbb45e1af2393c7ac372ed19d30ed5b1dd71f) ci/eval/attrpaths: refactor
* [`b627d181`](https://github.com/NixOS/nixpkgs/commit/b627d181e9e5130a460c70f381f8a420297f8426) ci/eval: remove unused checkMeta argument
* [`0d14bc89`](https://github.com/NixOS/nixpkgs/commit/0d14bc89cf8cd22aeba9a3190e900a08d84432af) pyenv: 2.6.6 -> 2.6.7
* [`11e67914`](https://github.com/NixOS/nixpkgs/commit/11e679147d35f460ecec40052d33f5e6b5d3cac2) CONTRIBUTING: use pr-template short link
* [`7b862c39`](https://github.com/NixOS/nixpkgs/commit/7b862c3976aaf4eac688cd44e6dff83d2fa60966) uhdm: 1.84-unstable-2024-11-12 -> 1.86
* [`e76092ed`](https://github.com/NixOS/nixpkgs/commit/e76092ed348485e0aed52213619f62697826016e) surelog: 1.84-unstable-2024-12-06 -> 1.86
* [`038efa72`](https://github.com/NixOS/nixpkgs/commit/038efa72eae0fc85bacd27fbe8833ba02deb4b35) python3Packages.pbxproj: 4.2.1 -> 4.3.0
* [`556baa19`](https://github.com/NixOS/nixpkgs/commit/556baa193258f6c30ce3e0ed4f82997e3f659ecd) wasmi: 0.51.0 -> 0.51.1
* [`7aeeaa4f`](https://github.com/NixOS/nixpkgs/commit/7aeeaa4f29afc060247d8093997d68caecb9405d) oxker: 0.10.5 -> 0.11.1
* [`869d879d`](https://github.com/NixOS/nixpkgs/commit/869d879d98df7f3c0ac6e70dcdd9548f34e8abcd) opencode: 0.5.28 -> 0.5.29
* [`e9951f32`](https://github.com/NixOS/nixpkgs/commit/e9951f3277592ea70ea21352b5a6dd65a43335e1) cobra-cli: install shell completions for bash, zsh, and fish
* [`aee96d72`](https://github.com/NixOS/nixpkgs/commit/aee96d720ba6f1d3a8715b2197066b9ade3bef5d) davis: 5.1.2 -> 5.1.3
* [`459de063`](https://github.com/NixOS/nixpkgs/commit/459de06328ab03b0e36241e1797dada3bb529e7a) php84: 8.4.11 -> 8.4.12
* [`8abe9d80`](https://github.com/NixOS/nixpkgs/commit/8abe9d80345e2f15a66285b14f4fcaa67af684c1) oils-for-unix: 0.34.0 -> 0.35.0
* [`e621b5ad`](https://github.com/NixOS/nixpkgs/commit/e621b5add5aa1786875dbb8d2d59361937908e4a) python313Packages.pywebview: fix, use Qt 6, modernize
* [`8e0b2cf5`](https://github.com/NixOS/nixpkgs/commit/8e0b2cf57702ec9d99105c5c38abcfbe00c94c91) python3Packages.ipv8-rust-tunnels: 0.1.33 -> 0.1.34
* [`456625d5`](https://github.com/NixOS/nixpkgs/commit/456625d56c042d2b1e83c9773e464644da69b25e) zeekstd: 0.4.1 -> 0.4.2
* [`38ca19b2`](https://github.com/NixOS/nixpkgs/commit/38ca19b24bd48c13153e69cfc191248203bed4a5) bup: 0.33.8 -> 0.33.9
* [`efd5d4ff`](https://github.com/NixOS/nixpkgs/commit/efd5d4ff8f08cebba86f707a15430c6d37a548a0) mitra: 4.8.0 -> 4.9.0
* [`409107d2`](https://github.com/NixOS/nixpkgs/commit/409107d2f5f3abbc5ea5f6414902948776e9954d) nixos/grafana: don't set X-XSS-Protection anymore
* [`936c94e4`](https://github.com/NixOS/nixpkgs/commit/936c94e4ed50ea78b4801480df3f4514ae3b0a8a) lune: 0.10.1 -> 0.10.2
* [`d8529299`](https://github.com/NixOS/nixpkgs/commit/d8529299d3da59d7320dfa64dbcfb457459422a2) ghidra-extensions.findcrypt: 3.1.1 -> 3.1.2
* [`bda800cd`](https://github.com/NixOS/nixpkgs/commit/bda800cd77c3f08ad7feb3cdeead5f8e0590cf94) python313Packages.pystemd: fix build
* [`6ee0933c`](https://github.com/NixOS/nixpkgs/commit/6ee0933c4031822aef061a1e4a96273b15f7b910) python313Packages.pystemd: fetch src from GitHub
* [`756b6b88`](https://github.com/NixOS/nixpkgs/commit/756b6b88f056cf7dcfff4f5cf08ddcb700551826) python313Packages.pystemd: refactor
* [`8cf6121d`](https://github.com/NixOS/nixpkgs/commit/8cf6121da45ee28a4683d286fd2de12a474448e5) python3Packages.pyomo: 6.9.3 -> 6.9.4
* [`f0cc7051`](https://github.com/NixOS/nixpkgs/commit/f0cc7051c0fc4e1077db61bb32b9e5771bc6d876) matrix-alertmanager-receiver: 2025.8.20 -> 2025.8.27
* [`b26db463`](https://github.com/NixOS/nixpkgs/commit/b26db463716c5ee80eaf76d517c8c9b4054104ee) python313Packages.asdf-standard: 1.3.0 -> 1.4.0
* [`18561139`](https://github.com/NixOS/nixpkgs/commit/185611390cb96448197c79a60964048ce1820218) python312Packages.databackend: init at 0.0.3
* [`6f5de811`](https://github.com/NixOS/nixpkgs/commit/6f5de8114f811e3e13f7a8e8ac44c93677bb457a) python312Packages.pins: add missing inputs
* [`790bfe7a`](https://github.com/NixOS/nixpkgs/commit/790bfe7a5f1a6338f2b7a60426710c4cee849661) sieve-editor-gui: 0.6.1-unstable-2024-01-06 -> 0.6.1-unstable-2025-03-12
* [`e9de9b50`](https://github.com/NixOS/nixpkgs/commit/e9de9b50ceab24dd309e2515cf53d4ec4d7ab74f) nixos/tests/glitchtip: test sourcemap uploads
* [`44af9e1f`](https://github.com/NixOS/nixpkgs/commit/44af9e1ffe35538f46c6b2225bf9bf94d60429d3) sieve-editor-gui: support darwin
* [`44cd52cc`](https://github.com/NixOS/nixpkgs/commit/44cd52cc31441c7f1417607c033bc7bfd68c65af) sieve-editor-gui: misc improvements
* [`a979ca95`](https://github.com/NixOS/nixpkgs/commit/a979ca95310b2e8bb510d84ca9514cae2bc8ef93) vault: 1.20.2 -> 1.20.3
* [`93846e90`](https://github.com/NixOS/nixpkgs/commit/93846e90473ac43c33e35ede5c517a6beb2119a0) python313Packages.roma: 1.5.1 -> 1.5.4
* [`6cff6c67`](https://github.com/NixOS/nixpkgs/commit/6cff6c67472eceab8aba80db6a9c5ae486505213) rocmPackages.rocminfo: set meta.mainProgram
* [`ba314360`](https://github.com/NixOS/nixpkgs/commit/ba31436010ce6857ed3b7cc1e77a38f842cb56a5) rocmPackages.composable_kernel: provide python3 for build scripts
* [`df73da3a`](https://github.com/NixOS/nixpkgs/commit/df73da3a3a3115611ee5a9c73b24dde6ca4c7be5) rocmPackages.rccl: provide python3 for build scripts
* [`a8ad616b`](https://github.com/NixOS/nixpkgs/commit/a8ad616b6e9d620dfbacf48baa92a8081e08ff73) python3Packages.ase: 3.25.0-unstable-2025-06-24 -> 3.26.0
* [`8af13b12`](https://github.com/NixOS/nixpkgs/commit/8af13b1251ff261d26ec9c22cb6dd2c2944b5364) vault-bin: 1.20.2 -> 1.20.3
* [`d8b49c68`](https://github.com/NixOS/nixpkgs/commit/d8b49c68a95b2006d98e68aa11b344538d0e635b) portfolio: 0.79.0 -> 0.79.1
* [`c32ddc1d`](https://github.com/NixOS/nixpkgs/commit/c32ddc1d444977bfa7a47a6166b2849f8a7a5bd0) cdecl-blocks: fix build
* [`14df5b73`](https://github.com/NixOS/nixpkgs/commit/14df5b73389b43a67afcce3dbbfa4a827cfc4ba8) libvgm: 0-unstable-2025-07-14 -> 0-unstable-2025-08-31
* [`93c74417`](https://github.com/NixOS/nixpkgs/commit/93c74417d4044477644b70a8da0b3d3de4866d0f) novelwriter: support svg icons
* [`43207573`](https://github.com/NixOS/nixpkgs/commit/432075731e0a3a442698ee9c6f217fb47d4fcb19) python3Packages.dscribe: disable tests that fail with ase 3.26
* [`d0c0b875`](https://github.com/NixOS/nixpkgs/commit/d0c0b875f7bbf75a255d5410a356fca3043aee97) treewide: remove __recurseIntoDerivationForReleaseJobs
* [`883564f9`](https://github.com/NixOS/nixpkgs/commit/883564f90639796835d722cf0263c08f1cdcbc00) rectangle: 0.89 -> 0.90
* [`81041001`](https://github.com/NixOS/nixpkgs/commit/81041001012392d916f7d5daec17695b48bdb3e9) ci/eval/attrpaths: update cross stdenvs
* [`3d5e7261`](https://github.com/NixOS/nixpkgs/commit/3d5e72615c09fea7af3e675c263c540024969bf1) lock: 1.7.3 -> 1.7.5
* [`3f7c6e64`](https://github.com/NixOS/nixpkgs/commit/3f7c6e64926dfe4b3d0e6027a6cae5252779900d) glooctl: 1.19.4 -> 1.19.6
* [`0960d502`](https://github.com/NixOS/nixpkgs/commit/0960d502488e1f988a5641e455ce5390fae4cba7) exiv2: 0.28.5 -> 0.28.7
* [`2493853e`](https://github.com/NixOS/nixpkgs/commit/2493853e5982ea8fe5aee6484a6259738268a2b8) python3Packages.pysnooz: fix tests
* [`d15a686e`](https://github.com/NixOS/nixpkgs/commit/d15a686e8d18f50d6191e1d1082720ce844a621b) finit: init at 4.14
* [`8fa15577`](https://github.com/NixOS/nixpkgs/commit/8fa15577842ba38283385ed0ba5b9fabb87e5879) CONTRIBUTING: clarify pushing to others' PRs is allowed
* [`0ba05751`](https://github.com/NixOS/nixpkgs/commit/0ba05751f984c92083b936c2dc321be76c9b80e3) CONTRIBUTING: default to non-blocking comments
* [`a426d0fb`](https://github.com/NixOS/nixpkgs/commit/a426d0fbf65ef7ccd86f7a599dd170bd48a911cb) jreleaser-cli: 1.19.0 -> 1.20.0
* [`caf604b5`](https://github.com/NixOS/nixpkgs/commit/caf604b538754aa054873d18c998aae24e7249bc) python3Packages.rfc3161-client: 1.0.3 -> 1.0.4
* [`c372a3fb`](https://github.com/NixOS/nixpkgs/commit/c372a3fbe950d549489952180dec28c0814d8a0a) nixos/systemd-oomd: add `After=swap.target` to fix swap detection issues
* [`1f164a44`](https://github.com/NixOS/nixpkgs/commit/1f164a442aa4c4e57b63002dd52df9174a18a142) chhoto-url: 6.2.13 -> 6.3.0
* [`18d09c0d`](https://github.com/NixOS/nixpkgs/commit/18d09c0dbb2a551b6185f43cc631d5a74791bdc5) python3Packages.nexia: 2.10.0 -> 2.11.1
* [`42132283`](https://github.com/NixOS/nixpkgs/commit/4213228329439773a7cbdbac00caeab0149662ab) vencord: 1.12.12 -> 1.12.13
* [`0a0143c5`](https://github.com/NixOS/nixpkgs/commit/0a0143c5e82073a78c2487a0026e1d0cf01d5a86) protonup-qt: 2.12.0 -> 2.13.0
* [`07ac0dbe`](https://github.com/NixOS/nixpkgs/commit/07ac0dbe704bcbfef0510bd9d419c6e84fcc58f9) openvpn3: fix build on latest Linux
* [`4f00be1c`](https://github.com/NixOS/nixpkgs/commit/4f00be1c772616febdd3733e2f429d8beadc862c) rocmPackages.hiprt: provide python3 for build scripts
* [`f44a98d7`](https://github.com/NixOS/nixpkgs/commit/f44a98d711af6f614fe9ed8716310189ce9aaa00) rocmPackages.rocminfo: don't propagate python3
* [`20afe0f4`](https://github.com/NixOS/nixpkgs/commit/20afe0f410d52d267a5135f11e819ea152005fd1) python312Packages.torchWithRocm: unmark as broken
* [`843ea58c`](https://github.com/NixOS/nixpkgs/commit/843ea58ca0ba9b970c134537a1853a206aee710e) python3Packages.medvol: 0.0.15 -> 0.0.16
* [`a29f3139`](https://github.com/NixOS/nixpkgs/commit/a29f3139624c601eea7dce9a314c1eac54ac8daa) lmstudio: 0.3.23.3 -> 0.3.24.6
* [`7486df5c`](https://github.com/NixOS/nixpkgs/commit/7486df5cd1610d644bbec307cfcfab5de7a95016) codebook: 0.3.8 -> 0.3.9
* [`32eca66f`](https://github.com/NixOS/nixpkgs/commit/32eca66fcd647d24edfb7eb98f1f6a8d74b56ae7) python3Packages.potentials: 0.4.0 -> 0.4.1
* [`978fdb56`](https://github.com/NixOS/nixpkgs/commit/978fdb569acf506798d7b9575563ec9d324527ce) firebase-tools: 14.13.0 -> 14.15.1
* [`455ed058`](https://github.com/NixOS/nixpkgs/commit/455ed05807baefe63435507a767496810fe46650) optnix: 0.2.0 -> 0.3.0
* [`9c5e2eab`](https://github.com/NixOS/nixpkgs/commit/9c5e2eab95b0a0c85f2138c2b4dda4a0ae9d9426) wipefreespace: 2.6 -> 3.0
* [`04c3daae`](https://github.com/NixOS/nixpkgs/commit/04c3daae6c126f1b44f284b560d2463df9458193) wipefreespace: remove with lib
* [`c776a13c`](https://github.com/NixOS/nixpkgs/commit/c776a13c8d6f43c07c60e03bf7a45b7251f5df45) wipefreespace: remove catap as maintainer
* [`18057b5e`](https://github.com/NixOS/nixpkgs/commit/18057b5e4783693b70514df29bb36b0a7f798b2f) wipefreespace: add kyehn as maintainer
* [`cdcbf8f6`](https://github.com/NixOS/nixpkgs/commit/cdcbf8f61db3dc903287afb9f1ad9639eaec8ae8) python3Packages.starlette-compress: 1.6.0 -> 1.6.1
* [`e4bef2a7`](https://github.com/NixOS/nixpkgs/commit/e4bef2a79d20630be964d2e8eeb5a5db601beff7) protoc-gen-grpc-java: make update script update version
* [`e2e5eb02`](https://github.com/NixOS/nixpkgs/commit/e2e5eb0278e0fcf18bb50c79873c0ad4b7f35dbc) protoc-gen-grpc-java: 1.73.0 -> 1.75.0
* [`60474930`](https://github.com/NixOS/nixpkgs/commit/60474930608954509721ed00ff3906c960b3e674) python3Packages.graph-tool: 2.97 -> 2.98
* [`450c540f`](https://github.com/NixOS/nixpkgs/commit/450c540f1adb4db92cd1a68a4fd46bd26f494159) widevine-cdm: refactor x86_64-linux to use official sources, add update script
* [`88a118c3`](https://github.com/NixOS/nixpkgs/commit/88a118c37ee95be6447b28b5775b977b72ad2499) widevine-cdm: refactor to use regex, various other update script changes
* [`e9e10127`](https://github.com/NixOS/nixpkgs/commit/e9e10127d7bdc4d3137dcb91cd36c229acbfee8b) lr: 1.6 -> 2.0
* [`0ada9f41`](https://github.com/NixOS/nixpkgs/commit/0ada9f41cfc9ea1e98de3e4de94604be96c2d191) bs-manager: 1.5.3 -> 1.5.4
* [`9a250ef2`](https://github.com/NixOS/nixpkgs/commit/9a250ef29595e7aee7bd257719da584d310aef9b) fishPlugins.forgit: 25.08.0 -> 25.09.0
* [`76d36cc0`](https://github.com/NixOS/nixpkgs/commit/76d36cc0f3a45695dea0e82500961ab18af65771) holos: 0.104.1 -> 0.104.2
* [`4c3558df`](https://github.com/NixOS/nixpkgs/commit/4c3558dff4f21db88872e815955ca8d2aa8ea2bd) butterfly: fix updateScript
* [`a1335202`](https://github.com/NixOS/nixpkgs/commit/a133520218e8d032a6f05a36e7b9bb9907a7119c) butterfly: 2.3.3 -> 2.3.4
* [`47fcf230`](https://github.com/NixOS/nixpkgs/commit/47fcf2302680625abd6750f86e0abf6694266d8c) nixos/kanboard: remove X-XSS-Protection
* [`c3581a9e`](https://github.com/NixOS/nixpkgs/commit/c3581a9ebc0031977932449f001ef895f467a110) kdePackages.qodeassist-plugin: 0.6.1 -> 0.6.2
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
