### PR TITLE
niv home-manager: update e31db614 -> 26993d87

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -65,10 +65,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e31db6141e47f1007a54bc9e4d8b2a26a9fbd697",
-        "sha256": "0df3mc6jxr8lmidsnad3w4826v160yxm312by7ns82hdhq59cl05",
+        "rev": "26993d87fd0d3b14f7667b74ad82235f120d986e",
+        "sha256": "0ffkkg21vd9m91sza6h6adrgpww114aj3l0n36hg73jsgx16sb1c",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/e31db6141e47f1007a54bc9e4d8b2a26a9fbd697.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/26993d87fd0d3b14f7667b74ad82235f120d986e.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@e31db614...26993d87](https://github.com/nix-community/home-manager/compare/e31db6141e47f1007a54bc9e4d8b2a26a9fbd697...26993d87fd0d3b14f7667b74ad82235f120d986e)

* [`1ecfd8e5`](https://github.com/nix-community/home-manager/commit/1ecfd8e5626b27a9610f468be32cd6a7011f56a0) hyprland: add support for submaps ([nix-community/home-manager⁠#6062](https://togithub.com/nix-community/home-manager/issues/6062)) ([nix-community/home-manager⁠#7277](https://togithub.com/nix-community/home-manager/issues/7277))
* [`5f64bccc`](https://github.com/nix-community/home-manager/commit/5f64bcccef6d54a8fda5f70b29a3a423596c90ea) hyprland: tweak submap line formatting
* [`06179315`](https://github.com/nix-community/home-manager/commit/061793150a092e24315d14ff9e06510889849e75) tests/hyprland: add submap test
* [`f3d3b459`](https://github.com/nix-community/home-manager/commit/f3d3b4592a73fb64b5423234c01985ea73976596) news: add hyprland submap entry
* [`1a6f6fb4`](https://github.com/nix-community/home-manager/commit/1a6f6fb4091a6eb9c3bae8bac6d233f6ee51d489) swappy: add module
* [`a1316b0a`](https://github.com/nix-community/home-manager/commit/a1316b0a77ef3e082a75bc5dc685c249b3c25f2c) new: add swappy entry
* [`30fc1b53`](https://github.com/nix-community/home-manager/commit/30fc1b532645a21e157b6e33e3f8b4c154f86382) nix-init: ensure settings example produces a valid configuration
* [`6159629d`](https://github.com/nix-community/home-manager/commit/6159629d05a0e92bb7fb7211e74106ae1d552401) swayosd: Remove non-existing `display` arg option ([nix-community/home-manager⁠#7752](https://togithub.com/nix-community/home-manager/issues/7752))
* [`b21c1a61`](https://github.com/nix-community/home-manager/commit/b21c1a61a765acea932eef1e4d225fde25a166e0) vivid: add module ([nix-community/home-manager⁠#7772](https://togithub.com/nix-community/home-manager/issues/7772))
* [`ed1a98c3`](https://github.com/nix-community/home-manager/commit/ed1a98c375450dfccf427adacd2bfd1a7b22eb25) aerospace: use upstream example for exec-on-workspace-change ([nix-community/home-manager⁠#7765](https://togithub.com/nix-community/home-manager/issues/7765))
* [`b08f8737`](https://github.com/nix-community/home-manager/commit/b08f8737776f10920c330657bee8b95834b7a70f) hyprpanel: fix dontAssertNotificationDaemons ([nix-community/home-manager⁠#7745](https://togithub.com/nix-community/home-manager/issues/7745))
* [`a51e585a`](https://github.com/nix-community/home-manager/commit/a51e585a05d318f988dfe09ec7fe31de966d9a76) Translate using Weblate (German)
* [`f56bf065`](https://github.com/nix-community/home-manager/commit/f56bf065f9abedc7bc15e1f2454aa5c8edabaacf) polybar: make sure X-Restart-Triggers is a list
* [`a7408ba6`](https://github.com/nix-community/home-manager/commit/a7408ba6dad7266689503b21e21089a63551d285) syncthing: Fix for syncthing v2 ([nix-community/home-manager⁠#7762](https://togithub.com/nix-community/home-manager/issues/7762)) ([nix-community/home-manager⁠#7766](https://togithub.com/nix-community/home-manager/issues/7766))
* [`a3699ec8`](https://github.com/nix-community/home-manager/commit/a3699ec8eee1692132e678375c72978252e82d21) flake.lock: Update
* [`c140680b`](https://github.com/nix-community/home-manager/commit/c140680b7a650e487cc9ca1151f0505d0cc4dd59) plan9port: drop ehmry maintainer
* [`9136120c`](https://github.com/nix-community/home-manager/commit/9136120c369d91144910a985262e3c3b8e8872d6) treewide: nix fmt
* [`9f5966aa`](https://github.com/nix-community/home-manager/commit/9f5966aa05e3ea15733c60e7b3dc9a573241b604) river: river -> river-classic
* [`fc2fe010`](https://github.com/nix-community/home-manager/commit/fc2fe0104db10a04138a215c0173580e67e9e0b4) zoxide: load after prezto
* [`ea3fe2bd`](https://github.com/nix-community/home-manager/commit/ea3fe2bd72caf2a0f75edf3cf9ece8d60c2f9557) hyprsunset: fixed evaluation when hyprland package is null
* [`f35703b4`](https://github.com/nix-community/home-manager/commit/f35703b412c67b48e97beb6e27a6ab96a084cd37) gtk: add color scheme option
* [`d2881029`](https://github.com/nix-community/home-manager/commit/d28810298c27951ea8f52052d75d36ae86b8a5e8) maintainers: update all-maintainers.nix
* [`26993d87`](https://github.com/nix-community/home-manager/commit/26993d87fd0d3b14f7667b74ad82235f120d986e) ci: bump actions/labeler from 5 to 6
