### PR TITLE
niv nixpkgs: update d44f2e86 -> 26833ad1

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -143,10 +143,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d44f2e86707bae01ecce6af5d4da3674529d183c",
-        "sha256": "11phwqnz13pry2j2w4nqqbsbc2inyz01prm86l32zqfy89hcila6",
+        "rev": "26833ad1dad83826ef7cc52e0009ca9b7097c79f",
+        "sha256": "0h82vxblnzf29xsfl6lhibf2ry5c9c96q6cazkpc2jpjyq0hm7fm",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/d44f2e86707bae01ecce6af5d4da3674529d183c.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/26833ad1dad83826ef7cc52e0009ca9b7097c79f.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "powerlevel10k": {


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@d44f2e86...26833ad1](https://github.com/nixos/nixpkgs/compare/d44f2e86707bae01ecce6af5d4da3674529d183c...26833ad1dad83826ef7cc52e0009ca9b7097c79f)

* [`53682256`](https://github.com/NixOS/nixpkgs/commit/5368225673400136286646c3ce5288648bab366f) perl buildPerlPackage: use patchShebangs by default
* [`9425abcd`](https://github.com/NixOS/nixpkgs/commit/9425abcdffdf1caf0df616dcc46d2779b3dc31c5) python3Packages.flasgger: fix build
* [`dfbb8d8b`](https://github.com/NixOS/nixpkgs/commit/dfbb8d8b83fc5511652c5118fe8eee5e91d9577c) libxmlxx3: 3.0.1 -> 3.2.5
* [`e606e1b0`](https://github.com/NixOS/nixpkgs/commit/e606e1b060a53876218bd44339e41cf51a20770e) libmbim: 1.30.0 -> 1.32.0
* [`edfd16e5`](https://github.com/NixOS/nixpkgs/commit/edfd16e5353a803ff40bc5d073bba3acaf13ab32) modemmanager: 1.22.0 -> 1.24.0
* [`7747ba0f`](https://github.com/NixOS/nixpkgs/commit/7747ba0fdba45c199cc8a792b3dd15fadfcbfb8b) libseccomp: Apply patch to fix test failures on big-endian architectures
* [`02756043`](https://github.com/NixOS/nixpkgs/commit/02756043195aaca5440d66d7468e566ccb982ee8) libseccomp: Switch to fetching OOB patch
* [`6ffc64b8`](https://github.com/NixOS/nixpkgs/commit/6ffc64b81b50ccb9e5b99af19f49b609e7a33775) bpftools: Re-apply patch to fix build on powerpc64*
* [`23244c7f`](https://github.com/NixOS/nixpkgs/commit/23244c7f77780087fcc849948f100a46aae385fb) maintainers/scripts/bootstrap-files: Add ELFv1 powerpc64 to CROSS_TARGETS
* [`7a98a469`](https://github.com/NixOS/nixpkgs/commit/7a98a46940363d603d0f4736bba1acfcd512942f) pkgs/stdenv/linux: add powerpc64-unknown-linux-gnuabielfv1 bootstrap-files
* [`4d6eb79c`](https://github.com/NixOS/nixpkgs/commit/4d6eb79c6d0d8682d5e090190d7f7536f9ef101c) nagstamon: add missing dependency setuptools
* [`58ac5484`](https://github.com/NixOS/nixpkgs/commit/58ac548447efe078456d65059185bc2828b6a0af) nagstamon: add maintainer videl
* [`8af12908`](https://github.com/NixOS/nixpkgs/commit/8af12908c217bba4b30bea5690e8dba9938739ac) nixos/anubis: add missing botPolicy option implementation
* [`8dd9c919`](https://github.com/NixOS/nixpkgs/commit/8dd9c9197acde02ee76ebd0b426e8d1ecaf5127e) nixos/tests/anubis: add testing for anubis botPolicy option
* [`51121e66`](https://github.com/NixOS/nixpkgs/commit/51121e661c40c0bdb1e93b57743ac7a806c3f954) maintainers: add heitorPB
* [`1986cfb2`](https://github.com/NixOS/nixpkgs/commit/1986cfb231fb9e40851c4426bc91a7ff5c9d7d21) fluidsynth: 2.4.6 -> 2.4.7
* [`577422ac`](https://github.com/NixOS/nixpkgs/commit/577422ac4fe15bfdc35e75442cab66e1908d3623) kdePackages.taglib: 2.1 -> 2.1.1
* [`89a5c19c`](https://github.com/NixOS/nixpkgs/commit/89a5c19c4dd6f936f6d860d6e064fcd28813c604) libtiff: Apply patch to fix test_directory test on big-endian
* [`56463934`](https://github.com/NixOS/nixpkgs/commit/56463934a63a0b5ecb7d19470f719eaf8b3bba41) jdk: 21.0.7+6 -> 21.0.8+9
* [`21c8967f`](https://github.com/NixOS/nixpkgs/commit/21c8967f1c05993637ab5b1456a7ad614432e4d6) buildGoModule: add buildTestBinaries option
* [`6117f5c0`](https://github.com/NixOS/nixpkgs/commit/6117f5c030c9fdf9068764038e9398d0cf07fb80) ideamaker: fix download link
* [`b8247463`](https://github.com/NixOS/nixpkgs/commit/b8247463bcabb2015796d4985940a49d19ed06e8) ideamaker: fix update script
* [`48cddb1e`](https://github.com/NixOS/nixpkgs/commit/48cddb1e8f87f38de02995e8e69d66c3591f5c49) ideamaker: 4.3.3.6560 -> 5.1.4.8480
* [`c7549034`](https://github.com/NixOS/nixpkgs/commit/c75490342370d951f4eb569811627b13b6d8dd8b) ideamaker: fix jq missing for updateScript
* [`b64acec9`](https://github.com/NixOS/nixpkgs/commit/b64acec9a45b73f790d6efa0d2927332d0601558) ideamaker: attempt using older openexr version
* [`99bb6622`](https://github.com/NixOS/nixpkgs/commit/99bb66222fea499d765348cc273459218d88d4ce) ideamaker: attempt using bundled qt libs
* [`7e4b0d4e`](https://github.com/NixOS/nixpkgs/commit/7e4b0d4ea36a5d45a2b435f18068a5545bf3afaa) ideamaker: manually wrap qt application
* [`05a895b3`](https://github.com/NixOS/nixpkgs/commit/05a895b39811cdb6b074503a60d689f162c56bb4) ideamaker: remove unused file
* [`1a6b5d8f`](https://github.com/NixOS/nixpkgs/commit/1a6b5d8f36869f67059a4989d3623fa70b7fa357) ideamaker: 5.1.4.8480 -> 5.2.2.8570
* [`868bd310`](https://github.com/NixOS/nixpkgs/commit/868bd310c35820e6b735b4e60152d125aedf3d1d) inih: 60 -> 61
* [`1d256383`](https://github.com/NixOS/nixpkgs/commit/1d2563835a20392a2b867de6cfe8c1a176c6dc53) buildGoModule: add test for buildTestBinaries
* [`969cc016`](https://github.com/NixOS/nixpkgs/commit/969cc016b0c096ebc5b2c7beecee96b06d05a654) docs: document buildTestBinaries for buildGoModule
* [`ee9f7477`](https://github.com/NixOS/nixpkgs/commit/ee9f747726b3ab760aaf8298471fd40e9278f701) jdk17: 17.0.15+6 -> 17.0.16+8
* [`d5754ff8`](https://github.com/NixOS/nixpkgs/commit/d5754ff89847c67247c95fc909e050cadf74daa7) memcached: 1.6.38 -> 1.6.39
* [`223a5ba4`](https://github.com/NixOS/nixpkgs/commit/223a5ba4fd8925cdd6305d3d19bd669a36274cbe) openexr: 3.3.4 -> 3.3.5
* [`bcd242f0`](https://github.com/NixOS/nixpkgs/commit/bcd242f02e85f74c63d633eb3be9ead173297a43) python313Packages.mypy: fix build on Darwin with case‐sensitive store
* [`61b1d30e`](https://github.com/NixOS/nixpkgs/commit/61b1d30e553048da697e3b755ab099288725ce36) ico: refactor and move to pkgs/by-name from xorg namespace
* [`7c2537d7`](https://github.com/NixOS/nixpkgs/commit/7c2537d7b9e034f7a337e4ef4f35bcb15c8dc0c1) libapplewm: refactor and migrate to pkgs/by-name from xorg.libAppleWM
* [`e1ebdea2`](https://github.com/NixOS/nixpkgs/commit/e1ebdea2aa12137f4ebf681264deed60c76b2219) libdmx: refactor and migrate to pkgs/by-name from xorg namespace
* [`e234ad4b`](https://github.com/NixOS/nixpkgs/commit/e234ad4b007fb599a20790476389d1466319b83f) libfontenc: refactor and move to pkgs/by-name from xorg namespace
* [`60fd3304`](https://github.com/NixOS/nixpkgs/commit/60fd33046a3d2c63a8a171db9d1d28910237aca0) libfs: refactor and migrate to pkgs/by-name from xorg.libFS
* [`24a342d5`](https://github.com/NixOS/nixpkgs/commit/24a342d53569310de913d243e048f28cd229367f) transset: 1.0.3 -> 1.0.4 && refactor and move to pkgs/by-name from xorg namespace
* [`90990b93`](https://github.com/NixOS/nixpkgs/commit/90990b93f2f735335e7b89779a96306dfba81ff4) xcmsdb: refactor and migrate to pkgs/by-name from xorg namespace
* [`59a16f28`](https://github.com/NixOS/nixpkgs/commit/59a16f2888c449892f2dad2fd230e86768a3f504) xprop: 1.2.7 -> 1.2.8 && refactor and move to pkgs/by-name from xorg namespace
* [`ae18c40b`](https://github.com/NixOS/nixpkgs/commit/ae18c40b85505ada15a04bdeef5048d63f1f37e3) xrefresh: refactor and migrate to pkgs/by-name from xorg namespace
* [`2f91c6aa`](https://github.com/NixOS/nixpkgs/commit/2f91c6aa23df10a90ea37995863e9c86d229856b) xwininfo: refactor and migrate to pkgs/by-name from xorg namespace
* [`83ea1c36`](https://github.com/NixOS/nixpkgs/commit/83ea1c364681c44cee98a939580cb0e0df9db58e) xwud: refactor and move to pkgs/by-name from xorg namespace
* [`05ae0e04`](https://github.com/NixOS/nixpkgs/commit/05ae0e0406286a9c6b8b75dad66af0b3c1d9e5a5) neon: 0.34.2 -> 0.35.0
* [`9ad3a410`](https://github.com/NixOS/nixpkgs/commit/9ad3a410d24b53f1b023548fd88ec7d99e3e432c) libxv: refactor and migrate to pkgs/by-name from xorg.libXv
* [`0412b1ef`](https://github.com/NixOS/nixpkgs/commit/0412b1ef6c573b4a742614a69aa7073385f9c405) libxfixes: refactor and migrate to pkgs/by-name from xorg.libXfixes
* [`c8bd0548`](https://github.com/NixOS/nixpkgs/commit/c8bd0548a6b0b5cc3b0d9fd68a80ebbeb3f91581) libxrender: refactor and migrate to pkgs/by-name from xorg.libXrender
* [`aae6be8d`](https://github.com/NixOS/nixpkgs/commit/aae6be8d50e058c9344b6c66129f25534f16d6a1) libxcursor: refactor and migrate to pkgs/by-name from xorg.libXcursor
* [`21144d55`](https://github.com/NixOS/nixpkgs/commit/21144d55a93da9e66b3151b9136b5b8742f72386) libxrandr: refactor and migrate to pkgs/by-name from xorg.libXrandr
* [`81e10b98`](https://github.com/NixOS/nixpkgs/commit/81e10b98d139814b8a66cacdd8c9dbf7bc4a9229) xdriinfo: 1.0.7 -> 1.0.8, refactor and migrate to pkgs/by-name from xorg namespace
* [`b91f8ce4`](https://github.com/NixOS/nixpkgs/commit/b91f8ce4289b8bda8ce420ccaaebb92fd568629c) xlsatoms: refactor and migrate to pkgs/by-name from xorg namespace
* [`8ef333a6`](https://github.com/NixOS/nixpkgs/commit/8ef333a61fd251e9f4f9c39623ae0707a941deaf) xlsclients: refactor and migrate to pkgs/by-name from xorg namespace
* [`4fbe4c9f`](https://github.com/NixOS/nixpkgs/commit/4fbe4c9f5a4b43f2974335fdf8fc093c817014dd) xlsfonts: refactor and migrate to pkgs/by-name from xorg namespace
* [`cc984a2d`](https://github.com/NixOS/nixpkgs/commit/cc984a2d2e948fe74de939f1d60243fb5e8f082b) xmodmap: refactor and migrate to pkgs/by-name from xorg namespace
* [`f52d374f`](https://github.com/NixOS/nixpkgs/commit/f52d374f46bf74cc19a9357acdaf0658198d7f6a) mkfontscale: refactor and move to pkgs/by-name from xorg namespace
* [`e055c898`](https://github.com/NixOS/nixpkgs/commit/e055c89829cb26828d1fcf45079e7d7c71c0cf1d) honey-home: init at 0-unstable-2022-10-25
* [`3cdf37b2`](https://github.com/NixOS/nixpkgs/commit/3cdf37b2ff03643ee5f068c34e364517266e5576) ffmpeg: use gmp for rtmp(e)
* [`867c793a`](https://github.com/NixOS/nixpkgs/commit/867c793adbdf4aafdc21fef39c4e38811ee3ffb6) jasper: 4.2.5 -> 4.2.6
* [`f1b2ab45`](https://github.com/NixOS/nixpkgs/commit/f1b2ab45b4af4707bb6318157cf09357b9a0a292) atf: don’t install test programs
* [`f8bc00ef`](https://github.com/NixOS/nixpkgs/commit/f8bc00efc5671bd6084f88f995d6928956e6b85f) postgresql.pg_config: make overrideable
* [`43fddf04`](https://github.com/NixOS/nixpkgs/commit/43fddf04c0d04300c5859c2853965d725ed5e8cf) Revert "python3Packages.pgvector: temporarily disable checkPhase"
* [`267991cc`](https://github.com/NixOS/nixpkgs/commit/267991cc76cdad7f266d5c375492add53ed1620f) Revert "python3Packages.langgraph-checkpoint-postgres: temporarily disable checkPhase"
* [`23d3a000`](https://github.com/NixOS/nixpkgs/commit/23d3a000714df4410f861c589b057ed69c7b9ab9) installShellFiles: Add nushell support to installShellCompletion
* [`62d5fd3f`](https://github.com/NixOS/nixpkgs/commit/62d5fd3f0be0ab4e7a245715c85bea0e195f88db) installShellFiles.tests: Add nushell to tests
* [`c2f9c14b`](https://github.com/NixOS/nixpkgs/commit/c2f9c14b9d2435408a5dd50e1f352e3dab6b724a) docs: Update installShellFiles docs for Nushell completions
* [`4eaccb1e`](https://github.com/NixOS/nixpkgs/commit/4eaccb1e4fd6ccfe2e3f824af02841e4719cea7a) aqbanking: 6.6.0 -> 6.6.1
* [`b1560dda`](https://github.com/NixOS/nixpkgs/commit/b1560ddaa1881ea24386ad1c4f88ad424a805219) maintainers: add S0AndS0
* [`23c6c0b1`](https://github.com/NixOS/nixpkgs/commit/23c6c0b189f205a43ee557491a60932c263e79dc) ycmd: add maintainer S0AndS0
* [`cbe92242`](https://github.com/NixOS/nixpkgs/commit/cbe92242d016a6d87f17411ab1286a50d5d30b48) llvmPackages.tblgen: only install the tools we use
* [`0b2b7c18`](https://github.com/NixOS/nixpkgs/commit/0b2b7c18ed5e4f9f629dac862a8a3b9e39b038ed) zlib-ng: 2.2.4 -> 2.2.5
* [`d9fe0e52`](https://github.com/NixOS/nixpkgs/commit/d9fe0e52bbbf2e6447ed72f806cea3c34d258da7) libxmlb: 0.3.22 -> 0.3.23
* [`3d0a214d`](https://github.com/NixOS/nixpkgs/commit/3d0a214d1e9818a952f518154959aec772207000) tcping-rs: init at 1.2.18
* [`d8e966ca`](https://github.com/NixOS/nixpkgs/commit/d8e966caccba22c83200e6edadc8161f6c9ae8f8) systemd: 257.7 -> 257.8
* [`412d9bb7`](https://github.com/NixOS/nixpkgs/commit/412d9bb78f3d274a39d89ccb7624f82dea9519ef) segger-jlink: refactor source.nix and update.py
* [`82967411`](https://github.com/NixOS/nixpkgs/commit/829674115b10f68c8c901f1a546ae1717255039d) segger-jlink: refactor build attributes in preparation for adding Darwin
* [`0d481a52`](https://github.com/NixOS/nixpkgs/commit/0d481a52058f8b824cce822b24ea8cbac385f6d9) segger-jlink: 810 -> 824
* [`75cc9494`](https://github.com/NixOS/nixpkgs/commit/75cc94944b0044f3e7d81b37eb3fd9c442424349) segger-jlink: add Darwin support
* [`b27f4ff5`](https://github.com/NixOS/nixpkgs/commit/b27f4ff50d50feb4e50c325cec093c9054e95c31) segger-jlink: remove 'with lib;' antipattern from meta
* [`e58c9e7d`](https://github.com/NixOS/nixpkgs/commit/e58c9e7dd621a7d7216f8dd95be32840a46b18ec) e2fsprogs: move scripts to separate output
* [`198dff9e`](https://github.com/NixOS/nixpkgs/commit/198dff9ed8e91d6f743dae51e6fdbf7712d3617e) s2n-tls: 1.5.23 -> 1.5.24
* [`2342757c`](https://github.com/NixOS/nixpkgs/commit/2342757c686873afe17954a5c218b05e8abdea20) libxkbcommon: 1.10.0 -> 1.11.0
* [`43bd726e`](https://github.com/NixOS/nixpkgs/commit/43bd726e1bd532c8adeaf1c5e2606cee381acb6f) iproute2: 6.15.0 -> 6.16.0
* [`5f2a2237`](https://github.com/NixOS/nixpkgs/commit/5f2a2237d3f5c9b8823476a3c339ac4a0e5fad23) mpg123: 1.33.0 -> 1.33.2
* [`0bb6676d`](https://github.com/NixOS/nixpkgs/commit/0bb6676d7443cb1e77dfe17516dac505978be25a) nixos/tailscale: Add option to disable upstream debug logging
* [`c08ce34a`](https://github.com/NixOS/nixpkgs/commit/c08ce34a7af8ab78e115d8b8baf19477071f073a) linux: build scripts_gdb
* [`a1ab3bdb`](https://github.com/NixOS/nixpkgs/commit/a1ab3bdb47f16cd1e96e0112e6a2f5a51b184bba) postgresql_18: disable NUMA test-case
* [`494a1b4a`](https://github.com/NixOS/nixpkgs/commit/494a1b4a17e5cfe30cf436c61c98f30171577c02) shadow: use /bin/sh as default shell
* [`30f57ba9`](https://github.com/NixOS/nixpkgs/commit/30f57ba9b9cbccf52cdb06b6b7ead5322bcae7b4) perl540Packages.DigestHMAC: 1.04 -> 1.05
* [`a734ea8f`](https://github.com/NixOS/nixpkgs/commit/a734ea8f912b946a4e39eda0e4468d3a323e1fad) perl540Packages.CryptURandom: 0.39 -> to 0.54
* [`da89a2d0`](https://github.com/NixOS/nixpkgs/commit/da89a2d075f2279a09585c1b217b8f7382817339) libpcap: add separate lib output
* [`6fda4f93`](https://github.com/NixOS/nixpkgs/commit/6fda4f93ee26114d10d3a9869f1018812638be3f) linux-pam: move scripts to separate output
* [`8c8d4b0e`](https://github.com/NixOS/nixpkgs/commit/8c8d4b0eea464f661faaa53283de3f9a6b96c3e0) lvm2: move scripts to separate output
* [`7440b16b`](https://github.com/NixOS/nixpkgs/commit/7440b16b7ea1a9d2d58d878cb279d3e6ecb8d4dc) krb5: move all binaries to out
* [`4049a364`](https://github.com/NixOS/nixpkgs/commit/4049a3645f99f1e344d388e9afd730b8673e9063) kbd: do not compress by default
* [`5211a3ec`](https://github.com/NixOS/nixpkgs/commit/5211a3ecb262a319233da0ff21bfb3d78f3bcae8) iptables: add separate lib output
* [`c70f1544`](https://github.com/NixOS/nixpkgs/commit/c70f154403d7e7e6a655731e0d8a166fa3dd3a70) systemd: remove iptables dependency
* [`4f4f18b9`](https://github.com/NixOS/nixpkgs/commit/4f4f18b9bb2c1de74137812d6738ab794d950664) systemd: set debug-shell to upstream default /bin/sh
* [`9ddad561`](https://github.com/NixOS/nixpkgs/commit/9ddad561cce6340172a3857de6249a3d81dd3f36) systemd: remove bashInteractive
* [`294b2f54`](https://github.com/NixOS/nixpkgs/commit/294b2f54afb46198e382ffd941595bcbe0a137eb) systemd: add bash to disallowedRequisites
* [`f974948e`](https://github.com/NixOS/nixpkgs/commit/f974948e56948c1de3dabcc169d1b5b623db5041) glib: 2.84.3 -> 2.84.4
* [`5c164306`](https://github.com/NixOS/nixpkgs/commit/5c1643066dd6352a9cb2c86fa0a60b98e74d7bd7) scikit-build-core: Add setup hook to handle cmake flags
* [`8d9afa0e`](https://github.com/NixOS/nixpkgs/commit/8d9afa0e85faf27a66897647343b1b7b279de0d3) python3Packages.units-llnl: set cmakeFlags directly
* [`9daeaddf`](https://github.com/NixOS/nixpkgs/commit/9daeaddf2c2e6630a485caa77ade172204c7c6c2) python3Packages.llama-cpp-python: set cmakeFlags directly
* [`d3a5ae5f`](https://github.com/NixOS/nixpkgs/commit/d3a5ae5f84693329db94c2be04f7d60756358908) python3Packages.islpy: use cmakeFlags instead of pypaBuildFlags
* [`4fb21651`](https://github.com/NixOS/nixpkgs/commit/4fb21651935d1154a3cb07114b5838ef6be46fc9) python3Packages.lightgbm: use cmakeFlags directly
* [`58495d40`](https://github.com/NixOS/nixpkgs/commit/58495d4096414bc6b1e9fb3925cee524526ee71b) python3Packages.fenics-basix: switch to cmakeFlags from CMAKE_ARGS
* [`404fd115`](https://github.com/NixOS/nixpkgs/commit/404fd115a028a82fbec893d7745907df9964e881) python3Packages.pillow-jpls: Use cmakeFlags
* [`8e06eb1e`](https://github.com/NixOS/nixpkgs/commit/8e06eb1e30ad76aefdf5c570ada9790835278dee) python3Packages.soxr: use cmakeFlags
* [`bc69e094`](https://github.com/NixOS/nixpkgs/commit/bc69e094f26db3a3fddeb8105e3733608ee0c37e) alvr: don't build xtask
* [`4d48a4e9`](https://github.com/NixOS/nixpkgs/commit/4d48a4e93b9ffbd291b2d9ca3315848e27eed800) ycmd: unstable-2023-11-06 -> unstable-2025-06-16
* [`35556ae4`](https://github.com/NixOS/nixpkgs/commit/35556ae41ce8a3ce5a07eaf062644761df4e4069) libxmlxx3: run nix fmt
* [`899c40e6`](https://github.com/NixOS/nixpkgs/commit/899c40e6f8ed0baee363a7a5d3be39241a40a1b7) stdenv: remove .attrs.sh fallback for structuredAttrs
* [`a30cf310`](https://github.com/NixOS/nixpkgs/commit/a30cf31051307a852a4cb5ec2546d400e718e998) vim: 9.1.1566 -> 9.1.1623
* [`def9ecde`](https://github.com/NixOS/nixpkgs/commit/def9ecde939309ac0e3020a6d1333bb3a6cc1a1a) audiofile: add many CVE patches
* [`6f001d6f`](https://github.com/NixOS/nixpkgs/commit/6f001d6faba6a08ab9bcd06fcd4c60148c14d665) spirv-llvm-translator: add llvm 21 support
* [`129b8040`](https://github.com/NixOS/nixpkgs/commit/129b804005ca320f551b086a7ec592cb8272dc7e) spirv-llvm-translator: add llvm 20 support
* [`4a1519ed`](https://github.com/NixOS/nixpkgs/commit/4a1519ed7ab5cc0f0632a45ba39261923b17afb5) spirv-llvm-translator: 19.1.6 -> 19.1.10
* [`c70e9730`](https://github.com/NixOS/nixpkgs/commit/c70e9730b7e7bb82d66c7d919a0eed7a64e8ab5f) spirv-llvm-translator: 18.1.11 -> 18.1.15
* [`9d9285c3`](https://github.com/NixOS/nixpkgs/commit/9d9285c35c63ded2216d30ac529bd65dfcde3f77) spirv-llvm-translator: 17.0.11 -> 17.0.15
* [`44c95706`](https://github.com/NixOS/nixpkgs/commit/44c95706464ee5859e1bf14d5f61fa4a00e86081) spirv-llvm-translator: 16.0.11 -> 16.0.15
* [`12f5b3d0`](https://github.com/NixOS/nixpkgs/commit/12f5b3d0fbc2d6d0068b25bd7d6d169707d11441) spirv-llvm-translator: 15.0.13 -> 15.0.15
* [`3bb9bd5d`](https://github.com/NixOS/nixpkgs/commit/3bb9bd5d4efbe38a41973bdadb75c7921735e87b) spirv-llvm-translator: 14.0.11+unstable-2025-01-28 -> 14.0.14
* [`0dc5987f`](https://github.com/NixOS/nixpkgs/commit/0dc5987f31114c78c5f65544d1fe812234f91b76) patchelf: 0.15.0 -> 0.15.2
* [`cf9f4753`](https://github.com/NixOS/nixpkgs/commit/cf9f47535013dba26379fb6bd64aa2b722c7dc1f) installShellFiles: Allow installManPage to take a piped input
* [`49059b8b`](https://github.com/NixOS/nixpkgs/commit/49059b8bb818598a52d823d5b2655003adca56e1) docs: Allow installManPage to take a piped input
* [`39aef906`](https://github.com/NixOS/nixpkgs/commit/39aef90642dfb0e30565ea05a7a83bdbdaa2f475) rustc: Fix configure flags for custom target JSON
* [`d3878418`](https://github.com/NixOS/nixpkgs/commit/d38784184371f921e1e4db92d417f42a4f3c2089) rust/hooks: Use rustcTargetSpec for --target
* [`8dbf0b34`](https://github.com/NixOS/nixpkgs/commit/8dbf0b34233f0c8da3d584c591f57d6ce1a3e5c3) cpython: remove libxcrypt on 3.13 and newer
* [`f63e7d24`](https://github.com/NixOS/nixpkgs/commit/f63e7d248ced7346cbc53ce97f87ee94f6271e0b) ruff: 0.12.8 -> 0.12.9
* [`4d93764f`](https://github.com/NixOS/nixpkgs/commit/4d93764f963a2fdc91b04a66a2444ed2596e6a8c) libxmlxx-v3: remove loskutov from maintainers ([nixos/nixpkgs⁠#432953](https://togithub.com/nixos/nixpkgs/issues/432953))
* [`3370b8b9`](https://github.com/NixOS/nixpkgs/commit/3370b8b98624b6dfefd28fdfab30d75606c02e96) re2: 2025-08-05 -> 2025-08-12
* [`4c70fc08`](https://github.com/NixOS/nixpkgs/commit/4c70fc087ac99bc302648333b3b125aa575bdaff) libpq: 17.5 -> 17.6
* [`4345a376`](https://github.com/NixOS/nixpkgs/commit/4345a37636726d3c82138575578a2ace2704268a) python313: 3.13.6 -> 3.13.7
* [`69fb788e`](https://github.com/NixOS/nixpkgs/commit/69fb788e4557d912d4c9585d0e6109bfbde11c78) ruff: remove postPatch
* [`8d8d2550`](https://github.com/NixOS/nixpkgs/commit/8d8d2550cf88ed492ddec11d57626024ca4e90c7) gitFull: fix cross compilation evaluate and build
* [`676cdfae`](https://github.com/NixOS/nixpkgs/commit/676cdfae80d6353ebdbbdcf24a5679568c885ab8) w3m: add toastal to maintainers
* [`e4895c4d`](https://github.com/NixOS/nixpkgs/commit/e4895c4dff19e52191384e33fa1e8609e9edd98d) w3m: 0.5.3+git20230121 → 0.5.4
* [`76d0ab5d`](https://github.com/NixOS/nixpkgs/commit/76d0ab5d74796392aabd37454c4dfee142f99a4e) w3m: use finalAttrs
* [`a0c979de`](https://github.com/NixOS/nixpkgs/commit/a0c979de3d7280c4115c578afca6a3c60eb7a7df) davmail: enable its internal browser
* [`15efb120`](https://github.com/NixOS/nixpkgs/commit/15efb120d177b04ecfd2e7f9667a4e0535d6913c) postgresql: fix build
* [`b0729bef`](https://github.com/NixOS/nixpkgs/commit/b0729bef3448f8b935e24ef929eeef81eaa9cb11) uv: 0.8.6 -> 0.8.7
* [`b21d6348`](https://github.com/NixOS/nixpkgs/commit/b21d6348cd7a9b98f812737ec63ce62dfd7ba3ae) python3Packages.uv: account for new binary lookup methods
* [`b4d223b9`](https://github.com/NixOS/nixpkgs/commit/b4d223b979f3c1b335f34eeb09d8c46ecc0fa083) uv: 0.8.7 -> 0.8.11
* [`2790457d`](https://github.com/NixOS/nixpkgs/commit/2790457dc96d614b173e49e71fc50584a445c947) zimg: 3.0.5 -> 3.0.6
* [`d27a82ec`](https://github.com/NixOS/nixpkgs/commit/d27a82ec7096dc60acd465f0302772ce01766edf) elmPackages.elm-review: 2.13.2 -> 2.13.4
* [`e0ba61e2`](https://github.com/NixOS/nixpkgs/commit/e0ba61e2773af6517a8f665521636535b3e5ab99) karabiner-elements: 15.4.0 -> 15.5.0
* [`6cf981fd`](https://github.com/NixOS/nixpkgs/commit/6cf981fd63fc6e57ceea7c5914c3951a1c21748a) cacert: 3.114 -> 3.115
* [`fea9101a`](https://github.com/NixOS/nixpkgs/commit/fea9101ab466481c66f8a8138e849dd283c0c340) rsync: fix tests in Darwin sandbox
* [`612e1e9b`](https://github.com/NixOS/nixpkgs/commit/612e1e9be4b1f391b4f9d3ee8ef681b1d56a1b90) moltenvk: 1.2.11 -> 1.3.0
* [`41613e73`](https://github.com/NixOS/nixpkgs/commit/41613e73b3c3e5dd13118146a847b2fbf98eff91) sillytavern: change to global installation
* [`2ca19ba6`](https://github.com/NixOS/nixpkgs/commit/2ca19ba6eed74de98988416322fe03b5b80ad59b) pinentry_mac: fix the build with `sandbox = true`
* [`c368b872`](https://github.com/NixOS/nixpkgs/commit/c368b87289aaa3a9fb89418bc449a79a75dfd98a) btrfs-progs: 6.15 -> 6.16
* [`bf29a613`](https://github.com/NixOS/nixpkgs/commit/bf29a6134dcd9ca9bd734733739403e9f2a1350c) pdf2htmlex: init at 0.18.8.rc1
* [`94567c34`](https://github.com/NixOS/nixpkgs/commit/94567c3495ea51cf1d591551c3391175215f0cd0) dovecot_fts_xapian: remove
* [`0456b29f`](https://github.com/NixOS/nixpkgs/commit/0456b29ff803e9337002fa62113f96fc271f4c95) php: fix systemdLibs dependency
* [`b17f8f14`](https://github.com/NixOS/nixpkgs/commit/b17f8f14edf1937dc6957d2156a959ae1afbf2d4) at-spi2-core: fix systemdLibs dependency
* [`6f6f2f35`](https://github.com/NixOS/nixpkgs/commit/6f6f2f358a08fa29b231b2307829018a8b14fe34) python3Packages.mypy: 1.15.0 -> 1.17.1
* [`f2b5d603`](https://github.com/NixOS/nixpkgs/commit/f2b5d603728f84f5f8f4dceda13f5116c898907b) bubblewrap: add dev output to reduce closure size of static build ([nixos/nixpkgs⁠#433640](https://togithub.com/nixos/nixpkgs/issues/433640))
* [`5bf25dff`](https://github.com/NixOS/nixpkgs/commit/5bf25dffb60121a57c192893820058f916a6601b) python3Packages.buildPythonPackage: default enabledTestPaths = [ "." ]
* [`bca7f749`](https://github.com/NixOS/nixpkgs/commit/bca7f7493062145e34713a0e09c1c10df1f992e2) cargo-c: 0.10.14 → 0.10.15
* [`31695681`](https://github.com/NixOS/nixpkgs/commit/31695681ed6470a60fc9171e8c218ba436f8ae8e) nsdiff: init at 1.85
* [`260eef77`](https://github.com/NixOS/nixpkgs/commit/260eef77c3075eb3fc02e8475147d6940ec837d2) util-macros: don't propegate tools
* [`a4f579ce`](https://github.com/NixOS/nixpkgs/commit/a4f579ce48242441b1b26499d96f4c5b5494a3db) util-macros: remove unused inputs
* [`6edbf9f2`](https://github.com/NixOS/nixpkgs/commit/6edbf9f2bb2c151cabba657f413f0b55c1913b53) util-macros: switch from fetchurl to fetchFromGitLab
* [`5742f1cc`](https://github.com/NixOS/nixpkgs/commit/5742f1cc4c01c2c2946f40b3ff41d89b58a46f75) util-macros: add maintainers
* [`bb9f1ba7`](https://github.com/NixOS/nixpkgs/commit/bb9f1ba75968ad147483f42bd1e8b89fc7fbaeb9) xorg-autoconf: remove in favor if util-macros
* [`8da1841b`](https://github.com/NixOS/nixpkgs/commit/8da1841bfe1e0700b9e84f5cfbc8506f2111c922) git: 2.50.1 -> 2.51.0
* [`7cd9593b`](https://github.com/NixOS/nixpkgs/commit/7cd9593babb2f55c9bf0f785eb622b6556143cef) python3Packages.cfn-lint: 1.38.2 -> 1.38.3
* [`8d51c627`](https://github.com/NixOS/nixpkgs/commit/8d51c6277ecc2ffe3a97f0fda789160b49147615) kbd: 2.8.0 -> 2.8.0-unstable-2025-08-12
* [`b254ec74`](https://github.com/NixOS/nixpkgs/commit/b254ec74f985dfe84d79b01d860c61520105d5be) kbdCompress: drop
* [`33ebeb9d`](https://github.com/NixOS/nixpkgs/commit/33ebeb9d19e76946cabdcc27eca68d63f43a7683) imath: 3.2.0 -> 3.2.1
* [`af25844d`](https://github.com/NixOS/nixpkgs/commit/af25844da2b78dc17c8fffda9a89104803ead743) ruby_3_3: 3.3.8 -> 3.3.9
* [`f4612d49`](https://github.com/NixOS/nixpkgs/commit/f4612d4949b9353d7b36fcafd1125429221defa4) inputplumber: 0.60.8 -> 0.62.2
* [`484ef2ad`](https://github.com/NixOS/nixpkgs/commit/484ef2ad0577dc24644f15c9d0fadf15d41a4e59) cryptsetup: 2.8.0 -> 2.8.1
* [`e1e6def4`](https://github.com/NixOS/nixpkgs/commit/e1e6def4f95cc93c3c5cb04638e427d8877a2a29) Update update-librusty script to fetch Cargo.lock from repository
* [`6c1d4d9f`](https://github.com/NixOS/nixpkgs/commit/6c1d4d9fc00ce97f776eb833ac220eedc22561f7) pkgs/README: update `buildMozillaMach` location
* [`25fedb00`](https://github.com/NixOS/nixpkgs/commit/25fedb005fc6f3f82eb42341ee6b44798600be64) Revert "python3Packages.buildPythonPackage: default enabledTestPaths = [ "." ]"
* [`a79f97b9`](https://github.com/NixOS/nixpkgs/commit/a79f97b971d903a229f919d7920063dae8cf731d) libice: refactor, move to pkgs/by-name and rename from xorg.libICE
* [`36573543`](https://github.com/NixOS/nixpkgs/commit/365735436e5d5b216eba0a3eb1f07bfc9e80fae8) libsm: refactor, move to pkgs/by-name and rename from xorg.libSM
* [`96349f4b`](https://github.com/NixOS/nixpkgs/commit/96349f4b00899c20e3e796e515da19bfd23d769d) libxt: refactor, move to pkgs/by-name and rename from xorg.libXt
* [`ee1a92b0`](https://github.com/NixOS/nixpkgs/commit/ee1a92b0c935e27d0530d9377217ed18766a62f6) libxmu: refactor, move to pkgs/by-name and rename from xorg.libXmu
* [`2301e67b`](https://github.com/NixOS/nixpkgs/commit/2301e67b505cfb20722c74aa0de628992e63e0e6) libxpm: refactor, move to pkgs/by-name and rename from xorg.libXpm
* [`847dbb84`](https://github.com/NixOS/nixpkgs/commit/847dbb84a3dd2e98f120f438c3b76a45b72e44f9) libxaw: refactor, move to pkgs/by-name and rename from xorg.libXaw
* [`b7a50d3f`](https://github.com/NixOS/nixpkgs/commit/b7a50d3f5348688f00c4040ef1e2b5e5d26b8cd4) libxvmc: refactor, move to pkgs/by-name and rename from xorg.libXvMC
* [`809bf617`](https://github.com/NixOS/nixpkgs/commit/809bf617cfdd7d6998726b778e69dc05d5140361) libxxf86dga: refactor, move to pkgs/by-name and rename from xorg.libXxf86dga
* [`cdda889c`](https://github.com/NixOS/nixpkgs/commit/cdda889cee20a007f23cd7204c0ea0eea4ef2499) libxxf86misc: refactor, move to pkgs/by-name and rename from xorg.libXxf86misc
* [`f5077a75`](https://github.com/NixOS/nixpkgs/commit/f5077a75cf102fe252c338c8587dc6fff4727f45) libxxf86vm: refactor, move to pkgs/by-name and rename from xorg.libXxf86vm
* [`d41e8bba`](https://github.com/NixOS/nixpkgs/commit/d41e8bba2271fc6be2fd6814e38530d79a5f5c3e) libxcb-util: refactor, move to pkgs/by-name and rename from xorg.xcbutil
* [`d051ea0c`](https://github.com/NixOS/nixpkgs/commit/d051ea0c859fa14e7f63a16b26183ed886709f00) libxcb-errors: refactor, move to pkgs/by-name and rename from xorg.xcbutilerrors
* [`a2a6f2a2`](https://github.com/NixOS/nixpkgs/commit/a2a6f2a295ff1c4febdbede3da80af5307edf012) libxcb-image: refactor, move to pkgs/by-name and rename from xorg.xcbutilimage
* [`6a2c2ed9`](https://github.com/NixOS/nixpkgs/commit/6a2c2ed9208bd32313b6a322f005cfa0847a42f4) libxcb-keysyms: refactor, move to pkgs/by-name and rename from xorg.xcbutilkeysyms
* [`c1db54b7`](https://github.com/NixOS/nixpkgs/commit/c1db54b7d85931b61a9fed9bd6a541504be71e1e) libxcb-render-util: refactor, move to pkgs/by-name and rename from xorg.xcbutilrenderutil
* [`3edf0cc9`](https://github.com/NixOS/nixpkgs/commit/3edf0cc9ce5ce96a85eea76e42f6d60c9e2b8ba1) libxcb-wm: refactor, move to pkgs/by-name and rename from xorg.xcbutilwm
* [`88b2fcd5`](https://github.com/NixOS/nixpkgs/commit/88b2fcd5e16e60f8e62fe450df6ac3ba544f3e42) uv: 0.8.11 -> 0.8.12
* [`ce6aad3d`](https://github.com/NixOS/nixpkgs/commit/ce6aad3dab6f52d9c0e34301d9787d16b57ac2dd) gitwatch: 0.3 -> 0.4
* [`6f93cd7b`](https://github.com/NixOS/nixpkgs/commit/6f93cd7bfdfeb085caf5da1631a689b85f5a134b) spirv-llvm-translator: remove ROCm special handling
* [`5e3cff9c`](https://github.com/NixOS/nixpkgs/commit/5e3cff9cb540fa808246d72f3e4faf2f9b884821) spirv-llvm-translator: pass BASE_LLVM_VERSION for LLVM 20 and 21
* [`9eaf6ae3`](https://github.com/NixOS/nixpkgs/commit/9eaf6ae3682c63a461a86713cfba480d696d849e) spirv-llvm-translator: mark as broken for LLVM 21 with SPIRV Headers 1.4.321
* [`707b72f7`](https://github.com/NixOS/nixpkgs/commit/707b72f75655a18fc885e0f2805f23bae3c2425c) python3Packages.mypy: propagate pathspec
* [`749fb9db`](https://github.com/NixOS/nixpkgs/commit/749fb9dbce3c0ccc1bc010ec361bed717079a889) python3Packages.charset-normalizer: 3.4.2 -> 3.4.3
* [`8fa36c60`](https://github.com/NixOS/nixpkgs/commit/8fa36c6042742425fb045fba3e3678e41ea348d8) oxlint: 1.6.0 -> 1.12.0
* [`3749d736`](https://github.com/NixOS/nixpkgs/commit/3749d736c647ef81cf706aa1a17a71583ea00f89) singularity-overriden-nixos: 4.3.2 -> 4.3.3
* [`8e4f0fcc`](https://github.com/NixOS/nixpkgs/commit/8e4f0fcc17184c8eee13856cb56778edd1b39c28) m2-planet: 1.11.0 -> 1.12.0
* [`0c2d60d6`](https://github.com/NixOS/nixpkgs/commit/0c2d60d60ceedb689b4d8d14fdd2cca9846cb96b) opengrok: 1.14.1 -> 1.14.2
* [`4108382f`](https://github.com/NixOS/nixpkgs/commit/4108382f36f3dc56fd3335c61850c9ab23cfcdfb) compress-man-pages: don't leak build timestamp into archive
* [`9ccbdd33`](https://github.com/NixOS/nixpkgs/commit/9ccbdd33d066870e18ca0ada7589ab8745ba7bd1) libxrender: propagate libx11
* [`8ac5f6de`](https://github.com/NixOS/nixpkgs/commit/8ac5f6dec055f66d00fdd2561c348970cfe1d48e) python3Packages.google-cloud-storage: build from GitHub
* [`397c8fec`](https://github.com/NixOS/nixpkgs/commit/397c8fec7bfe00705a915c31f1a809f658945c23) python3Packages.google-cloud-storage: add sarahec as maintainer
* [`87598dd2`](https://github.com/NixOS/nixpkgs/commit/87598dd2df79dd7178461568739a7f64f52a3af1) python3Packages.google-cloud-storage: 3.2.0 -> 3.3.0
* [`df0589eb`](https://github.com/NixOS/nixpkgs/commit/df0589eb83350adca90b08a26dc75a9ecdbc7251) kde-rounded-corners: 0.8.0 -> 0.8.1
* [`557a2eef`](https://github.com/NixOS/nixpkgs/commit/557a2eef7798b8da2ae3aba036db7a65768a9a3e) python3Packages.google-api-core: cleanup
* [`8fddfbde`](https://github.com/NixOS/nixpkgs/commit/8fddfbde5010a38ade5291c32fbd209aac58658c) python3Packages.google-api-core: add sarahec as maintainer
* [`679ab941`](https://github.com/NixOS/nixpkgs/commit/679ab9415d7113f652a52d6ea39c150d3c405318) bmake: 20250707 -> 20250804
* [`17769ba6`](https://github.com/NixOS/nixpkgs/commit/17769ba66c1ab33ad9077a00e76544e0dcf9b76b) python313Packages.sphinx: disable racy tests
* [`b6aaf4d7`](https://github.com/NixOS/nixpkgs/commit/b6aaf4d7ba869f1bfaac9c7e274d0fc654c13ffe) nodejs: do not skip passing test
* [`0caa862d`](https://github.com/NixOS/nixpkgs/commit/0caa862d168646b35476658508248cc60a587cb1) c-blosc2: 2.19.1 -> 2.21.1
* [`2fa8f417`](https://github.com/NixOS/nixpkgs/commit/2fa8f417f169dc2b9a441d44c18dffe4e5710f9b) font-encodings: refactor, move to pkgs/by-name and rename from xorg.encodings
* [`cd85e69f`](https://github.com/NixOS/nixpkgs/commit/cd85e69fde892760ea4b2cb22b9bfc6e2271bb3e) handheld-daemon-ui: 3.3.14 -> 3.4.0
* [`22b9ac1e`](https://github.com/NixOS/nixpkgs/commit/22b9ac1e5cf9ef1ad47ced474173467b814e23d7) xcursorgen: refactor and move to pkgs/by-name from xorg namespace
* [`66ca0ad2`](https://github.com/NixOS/nixpkgs/commit/66ca0ad28cff983efd2dca71e9e4a7cd544508ad) xcursor-themes: refactor, move to pkgs/by-name and rename from xorg.xcursorthemes
* [`60176ccb`](https://github.com/NixOS/nixpkgs/commit/60176ccb0429f65d7a84ce0dbcb6b49476d7950b) xev: refactor and move to pkgs/by-name from xorg namespace
* [`12e753b5`](https://github.com/NixOS/nixpkgs/commit/12e753b55c1ec322ee12ee4a36c70a0768fd8d99) xfsinfo: 1.0.7 -> 1.0.8, refactor & move to pkgs/by-name from xorg namespace
* [`f4db99ab`](https://github.com/NixOS/nixpkgs/commit/f4db99ab73512c452c26d52facbeda418968c296) xrandr: refactor and move to pkgs/by-name from xorg namespace
* [`21a80441`](https://github.com/NixOS/nixpkgs/commit/21a80441cc9f14fdff48eac5d2f259bb66c3d14f) xvinfo: refactor and move to pkgs/by-name from xorg namespace
* [`b9a112d4`](https://github.com/NixOS/nixpkgs/commit/b9a112d42cc40ae4047dbbf21b7794c30ef12349) xterm: add mainProgram
* [`8b9ae6bd`](https://github.com/NixOS/nixpkgs/commit/8b9ae6bd832fa6d1691d4034876ddf514e0faf51) libadwaita: 1.7.5 -> 1.7.6
* [`cd7c44ec`](https://github.com/NixOS/nixpkgs/commit/cd7c44ecf054a088bd072512f72bdae7b187d873) gstreamer: 1.26.3 -> 1.26.5
* [`96c07856`](https://github.com/NixOS/nixpkgs/commit/96c07856e25db8be0c68933c0660a26370554611) libarchive: unconditionally disable bsdcpio_test patrs on all linux targets
* [`0d8059fd`](https://github.com/NixOS/nixpkgs/commit/0d8059fd8317755f2b919b5119c50000810349da) go,buildGoModule: 1.24 -> 1.25
* [`99ebddd2`](https://github.com/NixOS/nixpkgs/commit/99ebddd2fa074398be793491ac83ed9116d81733) anvil-editor: mark broken
* [`c581870d`](https://github.com/NixOS/nixpkgs/commit/c581870d062cbe37e2ef44b1f49f10b348dfaf3d) avalanchego: unpin buildGoModule
* [`51df53f6`](https://github.com/NixOS/nixpkgs/commit/51df53f67322c3fc58cf59758f7329e21eef97a4) certinfo: unpin buildGoModule
* [`69a9d025`](https://github.com/NixOS/nixpkgs/commit/69a9d025967eb016c8e353803039ef0d6338c975) d2: unpin buildGoModule
* [`8453dbbb`](https://github.com/NixOS/nixpkgs/commit/8453dbbbe021f34bb8679dc0901f15132d203751) glasskube: unpin buildGoModule
* [`44fe12cb`](https://github.com/NixOS/nixpkgs/commit/44fe12cb37f7756f49068162ad55cef5ab90c35e) local-ai: mark broken
* [`26012875`](https://github.com/NixOS/nixpkgs/commit/2601287546030561c21d194305e35995a78470a8) screego: unpin buildGoModule
* [`a7570d9f`](https://github.com/NixOS/nixpkgs/commit/a7570d9f8ee72aa0b0ab7d49b87ba4aef9ba248b) stash: unpin buildGoModule
* [`0b71ad69`](https://github.com/NixOS/nixpkgs/commit/0b71ad696cb4667fccab92add33b9be6593bac2b) deck: unpin buildGoModule
* [`23552a8f`](https://github.com/NixOS/nixpkgs/commit/23552a8f0fa0b9fa0614c3830798dd151ef59c1e) cyclonedx-gomod: unpin buildGoModule
* [`ee8945f8`](https://github.com/NixOS/nixpkgs/commit/ee8945f8269839ad5e50cdd95d9e3535bf0a0054) carapace: unpin buildGoModule
* [`49faa36e`](https://github.com/NixOS/nixpkgs/commit/49faa36ea1e8d319e7e4ca3bfd293fb09d3ee3b0) gowitness: unpin buildGoModule
* [`270aa20b`](https://github.com/NixOS/nixpkgs/commit/270aa20bd62f22253340cc7d6aff0cfe76993d63) teleport: unpin buildGoModule
* [`a4096c1f`](https://github.com/NixOS/nixpkgs/commit/a4096c1f9e4e28e522a5c472478dae46b5b85048) cryptsetup: use finalAttrs
* [`9600cdcf`](https://github.com/NixOS/nixpkgs/commit/9600cdcfb5f461fb6336b8d5e26044c5bdaf583d) sointu: unpin buildGoModule
* [`f4d727e4`](https://github.com/NixOS/nixpkgs/commit/f4d727e4ff1b7c71abd6576e335a48b6fcf13136) go_1_23,buildGo123Module: remove
* [`c8eef872`](https://github.com/NixOS/nixpkgs/commit/c8eef872104a3a3efa7d5f736605a2b2c2df4d35) pgpool: 4.6.2 -> 4.6.3
* [`5aecb507`](https://github.com/NixOS/nixpkgs/commit/5aecb50780f1e201669e525290306e4d22fc8a70) lvm2: fix build on static
* [`1b4c8dc9`](https://github.com/NixOS/nixpkgs/commit/1b4c8dc98856365739b63e06652e391a87f96261) bash-completion: fix `mount -t` tab completion
* [`cedc84cf`](https://github.com/NixOS/nixpkgs/commit/cedc84cf81b35d13c93956068e6d0d6b0a09f904) util-linux: use --replace-fail everywhere
* [`0e113241`](https://github.com/NixOS/nixpkgs/commit/0e113241968c39fad868ee04412dac17b7741d29) util-linux: fix mount -t tab completion
* [`e392577a`](https://github.com/NixOS/nixpkgs/commit/e392577a43a966b45330ed8ccb2232e3f98c7d33) rebuilderd: 0.24.0 -> 0.25.0
* [`9d6e6ae9`](https://github.com/NixOS/nixpkgs/commit/9d6e6ae9934cf5402df922d675beb2afe792fb7c) ruff: 0.12.9 -> 0.12.10
* [`89f086c8`](https://github.com/NixOS/nixpkgs/commit/89f086c82b5f714c06809ed7698a9455ceb76c85) rambox: 2.5.0 -> 2.5.1
* [`94c392c7`](https://github.com/NixOS/nixpkgs/commit/94c392c7d948dddc7914f35b0d07e25642c155e5) uv: 0.8.12 -> 0.8.13
* [`27345cbe`](https://github.com/NixOS/nixpkgs/commit/27345cbed88609d02013c44e8c1bece5c362e1f1) apl386: 0-unstable-2024-01-10 -> 0-unstable-2025-03-11
* [`cf928387`](https://github.com/NixOS/nixpkgs/commit/cf928387eda2fc4775ef45aacfc886e60dee607b) gowitness: buildGo123Module -> buildGoModule
* [`9f48ab3f`](https://github.com/NixOS/nixpkgs/commit/9f48ab3f22e7336bd96c0f41f49ce4d491018b9f) gowitness: add versionCheckHook
* [`9b2783fa`](https://github.com/NixOS/nixpkgs/commit/9b2783fae9b141717f670bd5c11d36823ceef2a9) pihole-ftl: Fix log deleter service creating an empty database
* [`9d3892e4`](https://github.com/NixOS/nixpkgs/commit/9d3892e48a418150b84ffe7eeff25026097a6b50) mpd-discord-rpc: 1.8.1 -> 1.9.0
* [`5c3464e7`](https://github.com/NixOS/nixpkgs/commit/5c3464e7dbaadc220970a56d4922c18338ed5477) fuse3: 3.17.2 -> 3.17.4
* [`2b532660`](https://github.com/NixOS/nixpkgs/commit/2b532660bda80099249e78c81cf0f19469a31ea3) libdigidocpp: 4.2.0 -> 4.2.1
* [`613db841`](https://github.com/NixOS/nixpkgs/commit/613db841c42cdd50de51c2dd36a877531602444c) profanity: 0.15.0 -> 0.15.1
* [`b712355d`](https://github.com/NixOS/nixpkgs/commit/b712355dd5938a696691a923dc36dfc6a03d8a75) libva: depend on libxcb independently of libx11 propagating it
* [`596f710e`](https://github.com/NixOS/nixpkgs/commit/596f710ee3388af1af126d2523d643ce149c3733) pipewire: depend on libxcb independently of libx11 propagating it
* [`3d1033ce`](https://github.com/NixOS/nixpkgs/commit/3d1033ce5c0004fc4186fca5e3e0b8cc381d485b) xkbmon: depend on libxcb independently of libx11 propagating it
* [`a0638925`](https://github.com/NixOS/nixpkgs/commit/a06389255ad292d479152747e547ff7fa5fd73a8) sdl3: depend on libxcb independently of libx11 propagating it
* [`935ab490`](https://github.com/NixOS/nixpkgs/commit/935ab490b84bef462106ca35983d66f286aae12f) anvil-editor: depend on libxcb independently of libx11 propagating it
* [`e2119065`](https://github.com/NixOS/nixpkgs/commit/e211906503b05ad91b149ec9acf9e096270d96b7) azahar: depend on libxcb independently of libx11 propagating it
* [`229cc17e`](https://github.com/NixOS/nixpkgs/commit/229cc17e58e38e244f8d9ba840ff8bf01c9e5933) gst-vaapi: depend on libxcb independently of libx11 propagating it
* [`542ab468`](https://github.com/NixOS/nixpkgs/commit/542ab468425774f7961655c8d116255da3c01584) xidlehook: depend on libxcb independently of libx11 propagating it
* [`c5949b0d`](https://github.com/NixOS/nixpkgs/commit/c5949b0d99e1b365ad40c3791ed650e59953c0ba) wlx-overlay-s: depend on libxcb independently of libx11 propagating it
* [`7427c481`](https://github.com/NixOS/nixpkgs/commit/7427c48155f7ec85ecffb35c9340e3eef1b479ff) espanso: depend on libxcb independently of libx11 propagating it
* [`a0fa1d19`](https://github.com/NixOS/nixpkgs/commit/a0fa1d19a3c37faa23acad12caf4029577ba5c65) gossip: depend on libxcb independently of libx11 propagating it
* [`2469316f`](https://github.com/NixOS/nixpkgs/commit/2469316f441597f58444993bf8b69bf94797fc4f) gotraceui: depend on libxcb independently of libx11 propagating it
* [`9b11be29`](https://github.com/NixOS/nixpkgs/commit/9b11be296ad2cecf8a9f2bfd14e84a9896819400) libuiohook: depend on libxcb independently of libx11 propagating it
* [`4a00f12a`](https://github.com/NixOS/nixpkgs/commit/4a00f12a33bed43a65ab5c6ee22137ac4df16032) mesa-demos: depend on libxcb independently of libx11 propagating it
* [`06279228`](https://github.com/NixOS/nixpkgs/commit/0627922852742497854de8200d865fc65f76044a) slstatus: depend on libxcb independently of libx11 propagating it
* [`7f40bf78`](https://github.com/NixOS/nixpkgs/commit/7f40bf78b5c30b674dde260d0b912760e3dcf2f6) gamescope-wsi: depend on libxcb independently of libx11 propagating it
* [`ecb637f1`](https://github.com/NixOS/nixpkgs/commit/ecb637f1c61186e3fd07b784525d5e5b545d5376) libx11: don't propagate libxcb
* [`89b6e0b3`](https://github.com/NixOS/nixpkgs/commit/89b6e0b308d41ba311f1327742c7c25b9d373a59) yandex-music: 5.61.1 -> 5.63.1
* [`ffbbb868`](https://github.com/NixOS/nixpkgs/commit/ffbbb86871b19e8aeca8f6dcdbfcd5ab3ebb492f) zulu21: 21.0.4 -> 21.0.8
* [`2ae44784`](https://github.com/NixOS/nixpkgs/commit/2ae44784c95dcfdb63b833af5b4353c714026747) graphite-cli: 1.6.7 -> 1.6.8
* [`7efb80dc`](https://github.com/NixOS/nixpkgs/commit/7efb80dccb21bc93e093da4c0b79d09b158be6d4) ruby: remove `fetchFromSavannah` fetcher with files from autoconf
* [`10534f21`](https://github.com/NixOS/nixpkgs/commit/10534f21bba7a6919421c1d7b9709ff270eaf4f0) python3Packages.qh3: init at 1.5.4
* [`b19d20bf`](https://github.com/NixOS/nixpkgs/commit/b19d20bf661e7e5d81b2832266964b5a276a9763) cdogs-sdl: 2.3.1 -> 2.3.2
* [`10cc2988`](https://github.com/NixOS/nixpkgs/commit/10cc298857955c8514e5e9ecb7421279ff3f6bec) w3m: 0.5.4 → 0.5.5
* [`73468347`](https://github.com/NixOS/nixpkgs/commit/73468347b58bfb0fe28f174891e116d29f186390) libbpf: 1.6.1 -> 1.6.2
* [`b864be49`](https://github.com/NixOS/nixpkgs/commit/b864be49263ee968012e13dc5d3304a525c913d1) python312Packages.blosc2: 3.6.1 -> 3.7.1
* [`3826354a`](https://github.com/NixOS/nixpkgs/commit/3826354ada46746c4099208e3553ff4943566ccd) Revert "froide: fix initdb not being in PATH"
* [`e3fe433b`](https://github.com/NixOS/nixpkgs/commit/e3fe433bcff5e8c8156fbded6bfccea115131ee6) liburing: 2.11 -> 2.12
* [`37b9f46d`](https://github.com/NixOS/nixpkgs/commit/37b9f46de6449ef1e050b40226bafb2532a11eb8) python3Packages.grpclib: 0.4.7 -> 0.4.8
* [`38ba6fb3`](https://github.com/NixOS/nixpkgs/commit/38ba6fb329faf4b9afa2aaedda5d2877abac410a) cpython: enable pie
* [`20fcbbc2`](https://github.com/NixOS/nixpkgs/commit/20fcbbc22ec82164fd1125f96604104cb476b86c) photocollage: 1.4.6 -> 1.5.0
* [`607497e8`](https://github.com/NixOS/nixpkgs/commit/607497e8e7a744e7042cdf4ac3715185543785e8) jmol: 16.3.31 -> 16.3.33
* [`957b9c94`](https://github.com/NixOS/nixpkgs/commit/957b9c94ebd2d7637e5935645fc5ba332713acb5) krb5: 1.21.3 -> 1.22.1
* [`366c417a`](https://github.com/NixOS/nixpkgs/commit/366c417aa3fe5330e2a8948c91c5d563d0a49c96) python3Packages.scalar-fastapi: 1.2.3 -> 1.3.0
* [`3eec07ec`](https://github.com/NixOS/nixpkgs/commit/3eec07ec599649009c44abf7db5a5ac24bcda374) cc-wrapper: add glibcxxassertions hardening flag
* [`1293be88`](https://github.com/NixOS/nixpkgs/commit/1293be8892244428a5c1356b9e39bbc0b06ec971) arrow-cpp: disable glibcxxassertions hardening flag
* [`81fdff5f`](https://github.com/NixOS/nixpkgs/commit/81fdff5f106aa748187037282665b5e2c77cebfc) netpbm: 11.11.0 -> 11.11.1
* [`6ffb4fe9`](https://github.com/NixOS/nixpkgs/commit/6ffb4fe911c4296ac927c3af8a0615dd067c0a01) libmpdclient: 2.23 -> 2.24
* [`dbc4f676`](https://github.com/NixOS/nixpkgs/commit/dbc4f676ddccd7daf1817ae41012a2a3b255a490) iio-hyprland: 0-unstable-2025-06-11 -> 0-unstable-2025-08-21
* [`b8fe0f64`](https://github.com/NixOS/nixpkgs/commit/b8fe0f64255f882f34d2ec115268eb3e35ca3305) complgen: 0.4.0 -> 0.5.0
* [`5a95bdca`](https://github.com/NixOS/nixpkgs/commit/5a95bdca9be08db0860c8908d63e44176ecbf959) linuxPackages.tt-kmd: 2.0.0 -> 2.3.0
* [`cfea21e7`](https://github.com/NixOS/nixpkgs/commit/cfea21e7485ab102cbeb38a568c31b048e43898a) juicefs: 1.2.3 -> 1.3.0
* [`c22e6e5b`](https://github.com/NixOS/nixpkgs/commit/c22e6e5b29a436d110b9431afbba3d545a97cc5d) mpfshell: 2020-04-11 -> 0.9.3-unstable-2025-01-09
* [`5c08aa0a`](https://github.com/NixOS/nixpkgs/commit/5c08aa0a01481034d922148d1536bd3cc9814348) mpfshell: remove meta with lib
* [`4a3a6d3c`](https://github.com/NixOS/nixpkgs/commit/4a3a6d3c8f503604767129cd265263a5061abe43) quartz-wm: 1.3.1 -> 1.3.2; modernize
* [`a02cec6c`](https://github.com/NixOS/nixpkgs/commit/a02cec6cb6d54038db50f003f934f86428d9b32b) ibus-engines.chewing: 2.1.5 -> 2.1.6
* [`ac8ce97f`](https://github.com/NixOS/nixpkgs/commit/ac8ce97fe343bc127e844c6a5859c0f6f6d55591) sbcl: 2.5.5 -> 2.5.7
* [`ad1c377b`](https://github.com/NixOS/nixpkgs/commit/ad1c377b1f4aa47b375099e29bb02027ad2cfa5f) monkeysAudio: 11.30 -> 11.38
* [`f83c78e2`](https://github.com/NixOS/nixpkgs/commit/f83c78e2513b7decba29f50f4870c17c3e6055b0) python3Packages.pycsdr: 0.18.0 -> 0.18.2
* [`44ddda97`](https://github.com/NixOS/nixpkgs/commit/44ddda97af83dc0e01435ac2c52edfff19856dba) ruby-zoom: drop
* [`ff6fc870`](https://github.com/NixOS/nixpkgs/commit/ff6fc870da9daa16943b2fe7fba73accea49eb52) ocamlPackages.tdigest: 2.2.0 -> 2.2.1
* [`9de85286`](https://github.com/NixOS/nixpkgs/commit/9de8528688881708b9548eee2d7a903080bb45bc) kernel-hardening-checker: 0.6.10 -> 0.6.10.2
* [`5789efc4`](https://github.com/NixOS/nixpkgs/commit/5789efc4ca41975410731f931b5acd96e8389160) linuxPackages.nct6687d: 0-unstable-2025-06-30 -> 0-unstable-2025-08-23
* [`b749b3a0`](https://github.com/NixOS/nixpkgs/commit/b749b3a0dba39fb8bec7e267bdd370bbd212ce9e) vscode-extensions.antfu.icons-carbon: 0.2.6 -> 0.2.7
* [`5fdc5999`](https://github.com/NixOS/nixpkgs/commit/5fdc599923e1fbf57d6c023fe418945c4a3167e8) teleport_16: 16.5.13 -> 16.5.14
* [`475e7fd7`](https://github.com/NixOS/nixpkgs/commit/475e7fd75d2b2811365f800e031e2d25af33bbcc) teleport_17: 17.5.4 -> 17.7.0
* [`261402a9`](https://github.com/NixOS/nixpkgs/commit/261402a926da4d671b28c208e278ed1b2bd9bde5) fex: Add support for library forwarding
* [`e66020ef`](https://github.com/NixOS/nixpkgs/commit/e66020ef7ab5143ee1db5678c5288ca0698dd314) vanguards: 0.3.1-unstable-2023-10-31 -> 0.3.1
* [`d1d8b6d8`](https://github.com/NixOS/nixpkgs/commit/d1d8b6d8a836ad65581534e9ef97e901dc808696) libtiff: apply patch CVE-2024-13978 and CVE-2025-9165
* [`48a2b71e`](https://github.com/NixOS/nixpkgs/commit/48a2b71e2bef72b1b8ed2b6e71e47696965c3214) linuxPackages.r8125: 9.016.00 -> 9.016.01
* [`1a2438a5`](https://github.com/NixOS/nixpkgs/commit/1a2438a589f4a0cf2695e1e3722a32aad896ae41) rcp: update derivation to skip additional tests that cannot be run in the sandbox
* [`34c8c187`](https://github.com/NixOS/nixpkgs/commit/34c8c1873929fe21a766e3d12d17543dad8c2b93) rcp: 0.17.0 -> 0.18.0
* [`615e8c18`](https://github.com/NixOS/nixpkgs/commit/615e8c181f22637aac01590ea234afec0e80040a) kxstitch: unstable-2023-12-31 -> unstable-2025-08-16
* [`8f35205f`](https://github.com/NixOS/nixpkgs/commit/8f35205f48815a87830c346a556bb7377fd14050) snowflake-cli: 3.9.1 -> 3.11.0
* [`f4ff3c0b`](https://github.com/NixOS/nixpkgs/commit/f4ff3c0b3746493f46f3e646a117c58e5ad4b1d9) sillytavern: 1.13.2 -> 1.13.3
* [`00864e5f`](https://github.com/NixOS/nixpkgs/commit/00864e5fe55f57587f47a1daabf79cee6ec5c563) libbpf: fix sysinfo redefinition with musl ([nixos/nixpkgs⁠#436237](https://togithub.com/nixos/nixpkgs/issues/436237))
* [`aa53437e`](https://github.com/NixOS/nixpkgs/commit/aa53437e1dbc555429aace67c1116c7e61cc7166) plasma-hud: 19.10.1 -> 22.01.0
* [`3dc2951a`](https://github.com/NixOS/nixpkgs/commit/3dc2951a0faa10570c9404c2d47d0fe307ab0fcc) vscode-extensions.vue.volar: 3.0.5 -> 3.0.6
* [`765b7ffd`](https://github.com/NixOS/nixpkgs/commit/765b7ffdb2f9051bf22508bebf5fa2f12696f83e) python3Packages.pyechonest: drop
* [`0026a859`](https://github.com/NixOS/nixpkgs/commit/0026a859367ccc41df583aec2d759e377b7d5b28) ecs-agent: 1.97.1 -> 1.98.0
* [`53495ad5`](https://github.com/NixOS/nixpkgs/commit/53495ad5b9c3b238d6a3690b9930f66b700ef018) twitterBootstrap: 5.3.7 -> 5.3.8
* [`2a3c9d5f`](https://github.com/NixOS/nixpkgs/commit/2a3c9d5f53949482c1e0975cfc85d39f48a23487) python3Packages.typer-slim: expose from typer package
* [`9a23c9b1`](https://github.com/NixOS/nixpkgs/commit/9a23c9b10329f37018b7cfbdf9d05d7b677dbfed) umockdev: 0.19.2 -> 0.19.3
* [`1ad681a3`](https://github.com/NixOS/nixpkgs/commit/1ad681a3963f81ff1fce03faaf118e7305bd54b1) peru: 1.3.3 -> 1.3.4
* [`69097fa3`](https://github.com/NixOS/nixpkgs/commit/69097fa39cac54c6f2053e4ecff2bed4cbfdaff3) protobuf: 31.1 -> 32.0
* [`fb98d9cb`](https://github.com/NixOS/nixpkgs/commit/fb98d9cbf9f2727e787282cf23efca65cfabcf43) searxng: use typer-slim
* [`e0457e28`](https://github.com/NixOS/nixpkgs/commit/e0457e283bf7d0406b5ac2032c9a260f5f25263d) qgis+qgis-ltr: fix top level package pname
* [`0fec3fb9`](https://github.com/NixOS/nixpkgs/commit/0fec3fb91cf5f6f2a116b58b754065f920818942) font-bh-ttf: refactor, move to pkgs/by-name and rename from xorg.fontbhttf
* [`472fb3da`](https://github.com/NixOS/nixpkgs/commit/472fb3da5adfbfe3a1289e020c9b4eb1bcc58514) font-bh-type1: refactor, move to pkgs/by-name and rename from xorg.fontbhtype1
* [`a525a830`](https://github.com/NixOS/nixpkgs/commit/a525a830f29bbabd662bb322c6eaa09cfb4bfc00) font-mutt-misc: refactor, move to pkgs/by-name and rename from xorg.fontmuttmisc
* [`7407b013`](https://github.com/NixOS/nixpkgs/commit/7407b0137562a3ccc370b49ceb4342e6e0df7745) kubernetes-kcp: 0.28.0 -> 0.28.1
* [`78c82bf1`](https://github.com/NixOS/nixpkgs/commit/78c82bf1d55a6e05ce8dfb2888d813ebcb620082) python3Packages.pint-pandas: 0.6 -> 0.7.1
* [`a078ccf5`](https://github.com/NixOS/nixpkgs/commit/a078ccf5f3cafeaa039dc755f52628d4b809f157) kupfer: 327 -> 328
* [`e0830a25`](https://github.com/NixOS/nixpkgs/commit/e0830a25406e5dd7f7bc64af1ee7ee295be88ede) sharkey: Set nix-update-script
* [`31261bd0`](https://github.com/NixOS/nixpkgs/commit/31261bd08a2ea10dceeb9a89e2e6df292934dfd0) go-dnscollector: 1.9.0 -> 1.10.0
* [`f7f31d8a`](https://github.com/NixOS/nixpkgs/commit/f7f31d8a1cc8ead806f2aa079745abb06dbe9bd5) rss2email: fix build
* [`f84f4e2c`](https://github.com/NixOS/nixpkgs/commit/f84f4e2c0d27331f60cc43542f38a9514d1dbce3) python3Packages.coverage: 7.10.2 -> 7.10.5
* [`b7f63e35`](https://github.com/NixOS/nixpkgs/commit/b7f63e35c912a5c6db109b268714f9a8992bb5da) python3Packages.multidict: 6.6.3 -> 6.6.4
* [`55b03be6`](https://github.com/NixOS/nixpkgs/commit/55b03be62266f321aa4b32311a9fa05131960877) sonusmix: drop
* [`b1914596`](https://github.com/NixOS/nixpkgs/commit/b19145967431b49849d7dc5e0657322134297a24) delfin: fix cross compilation
* [`8df3b0b4`](https://github.com/NixOS/nixpkgs/commit/8df3b0b499d4e3e30a9801d134742f36455fe9d9) python3Packages.ueberzug: limit to Linux
* [`b2de0f2f`](https://github.com/NixOS/nixpkgs/commit/b2de0f2f9c7090f0dc1e973248a14189dd26f1d5) nss_esr: 3.101.2 -> 3.112.1
* [`940f845c`](https://github.com/NixOS/nixpkgs/commit/940f845c3462dc7b6e584f7116d0a1c4e555ce99) sublime-merge-dev: 2109 -> 2111
* [`79da947b`](https://github.com/NixOS/nixpkgs/commit/79da947b2f1427956d9ada0cdb1aedd7aac6a528) sof-firmware: 2025.05 -> 2025.05.1
* [`666e126a`](https://github.com/NixOS/nixpkgs/commit/666e126aeba214a1ae3027589b0db5a8d0cfb89c) tcpreplay: 4.5.1 -> 4.5.2
* [`7e3bdcf0`](https://github.com/NixOS/nixpkgs/commit/7e3bdcf01634c16dc3ca17d8364d7e48ab38d1fa) python3Packages.protobuf: 6.31.1 -> 6.32.0
* [`c81e4553`](https://github.com/NixOS/nixpkgs/commit/c81e4553eb28e620a9c1b3787862cf5f234edc49) fex: Drop use of NIX_CFLAGS_COMPILE
* [`9c842bf4`](https://github.com/NixOS/nixpkgs/commit/9c842bf4ee112320b88442a24a18af217e163fa6) vpl-gpu-rt: 25.3.1 -> 25.3.2
* [`0f80c966`](https://github.com/NixOS/nixpkgs/commit/0f80c96611163ee3d1ed1de502d48ec271dbeeef) tailscale: 1.86.4 -> 1.86.5
* [`7709e56f`](https://github.com/NixOS/nixpkgs/commit/7709e56ffbb1d96b0e7ee71cc8d1abe02d547280) libnss_nis: 3.2 -> 3.4
* [`35b3a977`](https://github.com/NixOS/nixpkgs/commit/35b3a97700f4c84b4fffd16fc818acf7b8d82f7c) gssdp_1_6: disable manpages
* [`5c99d67b`](https://github.com/NixOS/nixpkgs/commit/5c99d67b8618876563e7b9eacf7567cc62aeb7fd) qt6: 6.9.1 -> 6.9.2
* [`2a908a09`](https://github.com/NixOS/nixpkgs/commit/2a908a09be474683a8b4adcbef87077d099d03fc) python313Packages.pyside6: 6.9.1 -> 6.9.2
* [`7cba1337`](https://github.com/NixOS/nixpkgs/commit/7cba1337e1f5b1a472792477b35064508e73e975) flac: build from tarball; always enable man pages
* [`bfd516bb`](https://github.com/NixOS/nixpkgs/commit/bfd516bbaff09084a1e011b7e274c64520666a32) kubebuilder: 4.7.1 -> 4.8.0
* [`2a9fd371`](https://github.com/NixOS/nixpkgs/commit/2a9fd371556b4ecf2f7d3816f5ec91269fc91264) lyra: 1.6.1 -> 1.7.0
* [`a4cc3300`](https://github.com/NixOS/nixpkgs/commit/a4cc33007a8ebc2dde9a684ad4cdeea68fc1ad3a) sycl-info: fix its build
* [`5303c4de`](https://github.com/NixOS/nixpkgs/commit/5303c4deee854494bfe57b7fb83bca048037646d) python3Packages.rtree: 1.4.0 -> 1.4.1
* [`4bd7810c`](https://github.com/NixOS/nixpkgs/commit/4bd7810cc62e34e387662a38bf0e18945454cabe) ytcc: 2.7.2 -> 2.8.0
* [`09d0bd46`](https://github.com/NixOS/nixpkgs/commit/09d0bd46196351f0234ca9782788c592ba3291b9) python3Packages.trove-classifiers: 2025.5.9.12 -> 2025.8.26.11
* [`fded7aa5`](https://github.com/NixOS/nixpkgs/commit/fded7aa574e41012598055d117c8f6351ab227a8) ocamlPackages.bitv: 2.0 -> 2.1
* [`c56ed872`](https://github.com/NixOS/nixpkgs/commit/c56ed872831cfeb9862d2f01056f54fcd85712f6) yap: 6.3.3 -> 7.6.0-unstable-2025-05-23
* [`0834814d`](https://github.com/NixOS/nixpkgs/commit/0834814d77c65b95b275b9ef3b2d097f74d2ea33) serve: init at 14.2.4
* [`48759231`](https://github.com/NixOS/nixpkgs/commit/48759231aae4648b8dc95cc0b70e9a1fe5bfd108) dokieli: nodePackages.serve -> serve
* [`ed5a8826`](https://github.com/NixOS/nixpkgs/commit/ed5a88269a415fa7815953cf3debef9f1ef0c84c) storj-uplink: 1.135.3 -> 1.136.1
* [`23e62a70`](https://github.com/NixOS/nixpkgs/commit/23e62a705d3b8d2ad28cb93f3f90ca91d9785b6c) python3Packages.rowan: 1.3.0 -> 1.3.2
* [`803bb158`](https://github.com/NixOS/nixpkgs/commit/803bb15881756fe844f4241a87254d661767290d) rust-analyzer-unwrapped: 2025-08-11 -> 2025-08-25
* [`0c9b8744`](https://github.com/NixOS/nixpkgs/commit/0c9b8744001fa836e6e33c9960ca24cc173851eb) dt-schema: 2024.02 -> 2025.08
* [`5cfa0482`](https://github.com/NixOS/nixpkgs/commit/5cfa0482b151b0f0579d72ed9517d59902016aaa) qt6.qtwebengine: revert commit that breaks graphics acceleration on Mesa 25.2
* [`f8136a0f`](https://github.com/NixOS/nixpkgs/commit/f8136a0f82e7f36b9e412c75645efc00fb9411d4) font-adobe-75dpi: refactor, move to pkgs/by-name and rename from xorg.fontadobe75dpi
* [`657ebfdd`](https://github.com/NixOS/nixpkgs/commit/657ebfddbb0365705acaaccec01c48525dd9231e) font-adobe-100dpi: refactor, move to pkgs/by-name and rename from xorg.fontadobe100dpi
* [`e21431a1`](https://github.com/NixOS/nixpkgs/commit/e21431a16558e4b69ebcf187691d9af81bccbfd8) font-adobe-utopia-100dpi: refactor, move to pkgs/by-name and rename from xorg.fontadobeutopia100dpi
* [`98df87ea`](https://github.com/NixOS/nixpkgs/commit/98df87ea67a2ef46069c8e5f1a1741026a50af8a) font-adobe-utopia-75dpi: refactor, move to pkgs/by-name and rename from xorg.fontadobeutopia75dpi
* [`9ef0609c`](https://github.com/NixOS/nixpkgs/commit/9ef0609cf31fccaeb2811d939929bba677231e99) font-adobe-utopia-type1: refactor, move to pkgs/by-name and rename from xorg.fontadobeutopiatype1
* [`3da69122`](https://github.com/NixOS/nixpkgs/commit/3da691222765af2a96862fca7a010f729b40511e) python3Packages.libapparmor: init from pkgs.libapparmor
* [`6fceaa2a`](https://github.com/NixOS/nixpkgs/commit/6fceaa2ad5fb40a7b0dbed1fba92dce1988f3f55) apparmor-utils: use libapparmor from python3Packages to fix overriding python version
* [`1e6eeee0`](https://github.com/NixOS/nixpkgs/commit/1e6eeee0a5691e343aac6ffd873980b8ce542dc4) gotrue-supabase: 2.178.0 -> 2.179.0
* [`f34480c1`](https://github.com/NixOS/nixpkgs/commit/f34480c1adab47d82c1223c1d4552fa06b8c12a5) spidermonkey_128: 128.5.0 -> 128.14.0
* [`6c2fb66f`](https://github.com/NixOS/nixpkgs/commit/6c2fb66f4c7c75c3a825d00aa3cfbd594206cb55) python3Packages.python-on-whales: remove unused dependencies
* [`dffd802d`](https://github.com/NixOS/nixpkgs/commit/dffd802d5ed21e041c2b3f95a1166e92488932b1) python3Packages.aiohttp: drop superfluous test dependency
* [`774f782b`](https://github.com/NixOS/nixpkgs/commit/774f782b487669c158baa666d2992bc230d097e5) vscode-extensions.prisma.prisma: 6.13.0 -> 6.15.0
* [`0a1836ce`](https://github.com/NixOS/nixpkgs/commit/0a1836ce8346c3408f3d44c093ff359b794e485b) nodejs_22: 22.18.0 -> 22.19.0
* [`8acc365a`](https://github.com/NixOS/nixpkgs/commit/8acc365a8d46e304c994fc79d3a0070e12bd3301) python3Packages.flask: 3.1.1 -> 3.1.2
* [`9e1b9db5`](https://github.com/NixOS/nixpkgs/commit/9e1b9db5dbdddb6ac763b93d34550f430da177c1) gui-for-singbox: 1.9.8 -> 1.9.9
* [`d79f65da`](https://github.com/NixOS/nixpkgs/commit/d79f65dae3004255ea36bf142af0c7669865f849) python3Packages.txtai: 8.6.0 -> 9.0.0
* [`7182145c`](https://github.com/NixOS/nixpkgs/commit/7182145c092ce0651981f6c82a7403250798abe3) nwjs-ffmpeg-prebuilt: 0.102.1 -> 0.103.0
* [`127b084e`](https://github.com/NixOS/nixpkgs/commit/127b084e12e22f381e9b16683d8db408bb430b8a) verifast: 25.07 -> 25.08
* [`684e28a1`](https://github.com/NixOS/nixpkgs/commit/684e28a12bf1256899320d2456a30965ce18e37b) pgf3: 3.1.11 -> 3.1.11a
* [`69ed93c6`](https://github.com/NixOS/nixpkgs/commit/69ed93c6a7a42aae556105dc7d88bcd08c711afe) util-linux: fix build with systemd disabled
* [`3eea28e9`](https://github.com/NixOS/nixpkgs/commit/3eea28e98228f17e9ac15db099b66b9f1260b906) doc/javascript: Warn against the use of mkYarnPackage
* [`3358263b`](https://github.com/NixOS/nixpkgs/commit/3358263b3da9c118047d19ff23d39410319300f7) cooper: init at 1.01-unstable-2025-05-25
* [`978649ea`](https://github.com/NixOS/nixpkgs/commit/978649eac28cea845668c7fc06ee9d30a16fd012) drafting-mono: init at 1.1-unstable-2024-06-04
* [`428098cb`](https://github.com/NixOS/nixpkgs/commit/428098cb78ca643f477008105b2758d0a5c1c4b7) besley: init at 4.0-unstable-2023-01-09
* [`05d1ce85`](https://github.com/NixOS/nixpkgs/commit/05d1ce858b12b15b7a0f6ec896ffdaa36fa508fb) plex-htpc: init at 1.71.1
* [`240d5045`](https://github.com/NixOS/nixpkgs/commit/240d5045b60ff898ce4705d9d816a3b12c80adcd) xgamma: 1.0.7 -> 1.0.8, refactor & move to pkgs/by-name from xorg namespace
* [`47b8e80c`](https://github.com/NixOS/nixpkgs/commit/47b8e80c55ea416ee98017dba2802f3cac34dab9) xgc: 1.0.6 -> 1.0.7, refactor & move to pkgs/by-name from xorg namespace
* [`744120db`](https://github.com/NixOS/nixpkgs/commit/744120dbc7899fcbede9e9935306dad692574230) xhost: refactor and move to pkgs/by-name from xorg namespace
* [`fea40463`](https://github.com/NixOS/nixpkgs/commit/fea40463335f6a2885d20c59f558268f27b3178b) xkbutils: refactor and move to pkgs/by-name from xorg namespace
* [`3c24cb60`](https://github.com/NixOS/nixpkgs/commit/3c24cb60ff576568fa0bbe8c67f38669d8f26490) xkill: refactor and move to pkgs/by-name from xorg namespace
* [`0d4577bc`](https://github.com/NixOS/nixpkgs/commit/0d4577bce493c159d41fdc303eb7455d87e154a0) spidermonkey_91: drop
* [`2dfb14a8`](https://github.com/NixOS/nixpkgs/commit/2dfb14a85a8de21c7221aa364785cf5598664171) spidermonkey_140: relax SDK requirements for darwin
* [`168959b5`](https://github.com/NixOS/nixpkgs/commit/168959b55be34131b7886cb34f82d56c1ed0f243) cpython: disable pie on aarch64-linux minimal
* [`76b3a464`](https://github.com/NixOS/nixpkgs/commit/76b3a4643608994507e97d8af9984590a9ace19a) bodoni-moda: init at 2.4-unstable-2024-02-18
* [`9060afe0`](https://github.com/NixOS/nixpkgs/commit/9060afe0d61706f7def31ecb87d66458ed0b499e) uv: 0.8.13 -> 0.8.14
* [`9a7dd538`](https://github.com/NixOS/nixpkgs/commit/9a7dd538d01b530d00738101ae409246ef1da3e9) mygui: 3.4.2 -> 3.4.3
* [`ca67e465`](https://github.com/NixOS/nixpkgs/commit/ca67e465912d568b5e797886a6d4a472f761e770) spidermonkey_140: make apple-sdk patch unconditional
* [`25277ab7`](https://github.com/NixOS/nixpkgs/commit/25277ab7d28e4059274545f88c0425076fb05d85) spidermonkey_115: mark as broken on darwin again
* [`42849977`](https://github.com/NixOS/nixpkgs/commit/428499777a5f248d826d024c8dc459ad07818ad7) linuxPackages.opensnitch-ebpf: add passthru test
* [`5ecc3350`](https://github.com/NixOS/nixpkgs/commit/5ecc335091a0eef4f154841457ea5dae88f40858) linuxPackages.opensnitch-ebpf: add grimmauld to maintainers
* [`8c8cb412`](https://github.com/NixOS/nixpkgs/commit/8c8cb412f0939c45e8aa826366e6a83c55d4d47a) nixos/opensnitch: add grimmauld to maintainers
* [`7a048320`](https://github.com/NixOS/nixpkgs/commit/7a048320f73faf90f068344a862accf22c08ea18) nixos/opensnitch: add audit to service if audit backend is selected
* [`53b59eee`](https://github.com/NixOS/nixpkgs/commit/53b59eeee49b310d7f574002064a3ddd0ab52840) nixos/tests/audit: reduce log level to reduce spam
* [`584d4e41`](https://github.com/NixOS/nixpkgs/commit/584d4e417ee6f388163f9b2a4a872eec54b49d11) nixos/tests/opensnitch: assert ebpf modules are loaded successfully
* [`65a97395`](https://github.com/NixOS/nixpkgs/commit/65a973951dcbfee5be9618c469ab13e63237864b) nixos/networkmanager: fix serializing an invalid `wifi.powersave=null`
* [`6e8f5691`](https://github.com/NixOS/nixpkgs/commit/6e8f5691dbddf7c5ec696a6b648dbb773487b760) meson: 1.8.3 -> 1.9.0
* [`93d55d06`](https://github.com/NixOS/nixpkgs/commit/93d55d06c8f2a57fa1d413ee31450e19e5545451) nixos/networkmanager: add frontear as maintainer
* [`fd261cb0`](https://github.com/NixOS/nixpkgs/commit/fd261cb09446b2c81d710d157e9e7c18c7e53d6d) llvmPackages_{20,21}.libclc: reenable and update patches
* [`f86a07ab`](https://github.com/NixOS/nixpkgs/commit/f86a07aba80db5dac364aa8dbac8b8747da81ace) llvmPackages.libclc: replace lib.optional with lib.optionals
* [`c027c69a`](https://github.com/NixOS/nixpkgs/commit/c027c69af94844208bc94c00d45e4d95e2105f68) rl-2511: add note on addition of glibcxxassertions hardening flag
* [`1e7ed3e2`](https://github.com/NixOS/nixpkgs/commit/1e7ed3e27d41154fb28170f3f477bbf3cb988ac8) nodejs: fix hardcoded values in GYP script
* [`8fd955d8`](https://github.com/NixOS/nixpkgs/commit/8fd955d8599f86bc1f0dd89fae07ef6600e4a8d0) nodejs_20: fix build on staging
* [`a70ae6cd`](https://github.com/NixOS/nixpkgs/commit/a70ae6cd7f6cdd9567ff6e08ec59d5bad9fd35ae) python3Packages.setuptools-rust: 1.11.1 -> 1.12.0
* [`cbb3c85f`](https://github.com/NixOS/nixpkgs/commit/cbb3c85f0eec1174ea20fe7706a75583a4c2e97f) nodejs: drop v8 instrumentation patch
* [`1bc6e6c0`](https://github.com/NixOS/nixpkgs/commit/1bc6e6c0954a2089f067fac8cc43fa65a7d204cc) nodejs: use sigtool's codesign in test-macos-app-sandbox
* [`8362b182`](https://github.com/NixOS/nixpkgs/commit/8362b1826bfcf4c599adf9f06c593389f76ad930) nodejs: fix `checkPhase` with `sandbox=relaxed` on Darwin
* [`e77030d0`](https://github.com/NixOS/nixpkgs/commit/e77030d05d25a75d033505e031b4f541d9a6db77) syslogng: fix gRPC plugins missing symbols
* [`3a96e0d8`](https://github.com/NixOS/nixpkgs/commit/3a96e0d846585d69a75a4a8edde1c4c41d3ecf0c) readest: 0.9.75 -> 0.9.76
* [`3869cd8e`](https://github.com/NixOS/nixpkgs/commit/3869cd8efe96356b8f928944b11d361b885d8e17) volk: 3.1.2 -> 3.2.0
* [`c825def7`](https://github.com/NixOS/nixpkgs/commit/c825def75d89ac9f2ced977e42ee9938f07c516d) mktxp: 1.2.9 -> 1.2.12
* [`639641b3`](https://github.com/NixOS/nixpkgs/commit/639641b374ad52347b9c62380fd05d0db263682a) chatmcp: 0.0.74 -> 0.0.76
* [`39df3445`](https://github.com/NixOS/nixpkgs/commit/39df3445b6f2255a206a56e65ad9a5b08744ed1d) python3Packages.tkinter: build standalone from python source tree
* [`bba34e2f`](https://github.com/NixOS/nixpkgs/commit/bba34e2f19e3789a1564753aed7480487ab70aca) cpython: remove x11support
* [`fb9155a5`](https://github.com/NixOS/nixpkgs/commit/fb9155a57662b9c1bbcb7d79fcbe9b1cdcff70dd) bluez-headers: expose bluez header files
* [`251d713d`](https://github.com/NixOS/nixpkgs/commit/251d713d0cf1e5b40ca304e6a335e705ee6ede1e) cpython: build with bluetooth support in default build
* [`1051e7f2`](https://github.com/NixOS/nixpkgs/commit/1051e7f28f0b072fe9a9a81d183b688f57cbce5a) openfreebuds: move to default python
* [`2877deb8`](https://github.com/NixOS/nixpkgs/commit/2877deb8526b39152310af2e1502f8f2e885eab3) python3Full: drop
* [`d75fe643`](https://github.com/NixOS/nixpkgs/commit/d75fe643f4526180cea74ddff3986d1cb9ab671b) logcheck: 1.4.6 -> 1.4.7
* [`06308581`](https://github.com/NixOS/nixpkgs/commit/0630858137b02f98b7eb857b1465c64b327e6b4b) curlie: update homepage
* [`c2ec9234`](https://github.com/NixOS/nixpkgs/commit/c2ec9234e8f7017ee4831ad010e9fd70118fa905) fetchRadiclePatch: init
* [`566b38d4`](https://github.com/NixOS/nixpkgs/commit/566b38d4acd2ad4f02b164a924e0db07bcb7b0f3) doc/redirects.json: amend mismerge from the parent commit
* [`9bff0d59`](https://github.com/NixOS/nixpkgs/commit/9bff0d59ef28a1a8667d687fe0e2e060b80c668e) waydroid-helper: 0.2.5 -> 0.2.6
* [`2275ccd0`](https://github.com/NixOS/nixpkgs/commit/2275ccd0f7f7574f681775c26f00eb69e44fc283) sublime-merge: 2110 -> 2112
* [`cd13923e`](https://github.com/NixOS/nixpkgs/commit/cd13923e4e961324c8174eb6f2197d7f4d6a641b) perl540Packages.AlienBuild: don't patchShebangs
* [`11326949`](https://github.com/NixOS/nixpkgs/commit/11326949fa4606fa2adc861464c05fb93f51119c) bluez: fix meta.position
* [`7fed8dd5`](https://github.com/NixOS/nixpkgs/commit/7fed8dd575c21c5a3ff20763d761567d6a0190ba) ceph-csi: 3.14.1 -> 3.15.0
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
