### PR TITLE
niv home-manager: update 26993d87 -> 11cc5449

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -65,10 +65,10 @@
         "homepage": "https://nix-community.github.io/home-manager/",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "26993d87fd0d3b14f7667b74ad82235f120d986e",
-        "sha256": "0ffkkg21vd9m91sza6h6adrgpww114aj3l0n36hg73jsgx16sb1c",
+        "rev": "11cc5449c50e0e5b785be3dfcb88245232633eb8",
+        "sha256": "0dpmv7mmyd3lqgv7cj95dwv4kwa8z8rqm9rvr1hfjbhpx1lpmz9j",
         "type": "tarball",
-        "url": "https://github.com/nix-community/home-manager/archive/26993d87fd0d3b14f7667b74ad82235f120d986e.tar.gz",
+        "url": "https://github.com/nix-community/home-manager/archive/11cc5449c50e0e5b785be3dfcb88245232633eb8.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hs-grille": {


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@26993d87...11cc5449](https://github.com/nix-community/home-manager/compare/26993d87fd0d3b14f7667b74ad82235f120d986e...11cc5449c50e0e5b785be3dfcb88245232633eb8)

* [`d587e11c`](https://github.com/nix-community/home-manager/commit/d587e11cef9caa9484ed090eddc55f4c56908342) kitty: add quick-access-terminal configuration
* [`0c7c71a2`](https://github.com/nix-community/home-manager/commit/0c7c71a2128000a8596495ec0b8841cf7407bb60) oh-my-posh: add cache clearing on package version changes ([nix-community/home-manager⁠#7757](https://togithub.com/nix-community/home-manager/issues/7757))
* [`ede1f891`](https://github.com/nix-community/home-manager/commit/ede1f891c01b948bdbdde507cffa1fc3497f329b) Translate using Weblate (Polish) ([nix-community/home-manager⁠#7797](https://togithub.com/nix-community/home-manager/issues/7797))
* [`a60021a8`](https://github.com/nix-community/home-manager/commit/a60021a8c99bf5a28919c0a9fbb6b04422a6a8da) pianobar: add module to create config file ([nix-community/home-manager⁠#7734](https://togithub.com/nix-community/home-manager/issues/7734))
* [`3c97248d`](https://github.com/nix-community/home-manager/commit/3c97248d6f896232355735e34bb518ae9f130c5d) rclone: check existence of file rather than using `cat` ([nix-community/home-manager⁠#7799](https://togithub.com/nix-community/home-manager/issues/7799))
* [`7846968d`](https://github.com/nix-community/home-manager/commit/7846968d23e7417fde9b40084e16fcdbab2fd5d6) flake.lock: Update
* [`b5cb3a5d`](https://github.com/nix-community/home-manager/commit/b5cb3a5daa9218d790f5183a43454abcab2eeec1) tests/darwinScrublist: add lazysql
* [`e0154ae4`](https://github.com/nix-community/home-manager/commit/e0154ae41614e32a443c43ee51eee9eed3ad9a48) pistol: change config path for macOS
* [`5cd2bf51`](https://github.com/nix-community/home-manager/commit/5cd2bf5153a878342c0e6df16d739ba201f750e6) dunst: support reload on configuration change
* [`174ba89c`](https://github.com/nix-community/home-manager/commit/174ba89ccbbfd9fbae185cf6e8ae6ca88ba3e51d) dunst: use dbus service file from configured package
* [`584fccfd`](https://github.com/nix-community/home-manager/commit/584fccfdfa32e720295ec456146b1a18567eda8e) dunst: add tests
* [`61124583`](https://github.com/nix-community/home-manager/commit/61124583121108b5927d73247df663a7ddc4fdf6) dunst: fix deprecated configuration in example
* [`6d7c11a0`](https://github.com/nix-community/home-manager/commit/6d7c11a0adee0db21e3a8ef90ae07bb89bc20b8f) waybar: use X-Reload-Triggers
* [`9eab59f3`](https://github.com/nix-community/home-manager/commit/9eab59f3e71ea3a725e4817d8dcf0da0824ad19d) thefuck: remove module
* [`69083b3c`](https://github.com/nix-community/home-manager/commit/69083b3cdd2e16825d928a800bf1812baad8b7a6) jjui: init module
* [`a3fcc921`](https://github.com/nix-community/home-manager/commit/a3fcc92180c7462082cd849498369591dfb20855) jjui: add adda maintainer
* [`6e28513c`](https://github.com/nix-community/home-manager/commit/6e28513cf2ee9a985c339fcef24d44f43d23456b) nix-darwin: redirect output to stderr
* [`e286f848`](https://github.com/nix-community/home-manager/commit/e286f848a032a94b875af703f7b9ad77faf58b32) lutris: add defaultWinePackage option ([nix-community/home-manager⁠#7778](https://togithub.com/nix-community/home-manager/issues/7778))
* [`987b1140`](https://github.com/nix-community/home-manager/commit/987b11408213a943933853df92667fe94b90467b) podman: add nftables to default container path ([nix-community/home-manager⁠#7802](https://togithub.com/nix-community/home-manager/issues/7802))
* [`768a7042`](https://github.com/nix-community/home-manager/commit/768a7042a69998382d123aa73a627658973bed8d) go: use env file instead of home.sessionVariables ([nix-community/home-manager⁠#7751](https://togithub.com/nix-community/home-manager/issues/7751))
* [`20c79634`](https://github.com/nix-community/home-manager/commit/20c79634716ecc790fb46fb26b7bcdd9bcbc23a4) powerline-go: fix PROMPT_COMMAND duplicate in bash initialization ([nix-community/home-manager⁠#7697](https://togithub.com/nix-community/home-manager/issues/7697))
* [`c3abf8ea`](https://github.com/nix-community/home-manager/commit/c3abf8ea1adf8f601e993de64921bcf4f52b6358) khard: support discover entries ([nix-community/home-manager⁠#7785](https://togithub.com/nix-community/home-manager/issues/7785))
* [`17a10049`](https://github.com/nix-community/home-manager/commit/17a10049486f6698fca32097d8f52c0c895542b0) lsd: allow specifying a path type value for `icons` and `colors` options ([nix-community/home-manager⁠#7733](https://togithub.com/nix-community/home-manager/issues/7733))
* [`343e5556`](https://github.com/nix-community/home-manager/commit/343e5556575f2b6e00fa7f9f4623e46445a2fb8a) claude-code: added memories (claude.md) generation
* [`a641bbbb`](https://github.com/nix-community/home-manager/commit/a641bbbb9bb475181c5d867d01de2ebb6c286ba3) claude-code: added 'agentsDir' option to specify agents from filesystem
* [`be37a349`](https://github.com/nix-community/home-manager/commit/be37a3492d256910e7f9d5a6d8354f37aadd2c07) claude-code: added 'commandsDir' option to specify commands from filesystem
* [`5e06d0f1`](https://github.com/nix-community/home-manager/commit/5e06d0f1844bd150e7813368b06f32b03c816a0d) claude-code: added 'hooks' and 'hooksDir' options to specify hooks from filesystem
* [`0ab5e3c0`](https://github.com/nix-community/home-manager/commit/0ab5e3c054d6555d6239ab9d17c92be5e844b259) flake.lock: Update
* [`11cc5449`](https://github.com/nix-community/home-manager/commit/11cc5449c50e0e5b785be3dfcb88245232633eb8) tests: fix tests
