### PR TITLE
npins home-manager: update 5820376b -> 9a2dc0ef

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -61,9 +61,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "5820376beb804de9acf07debaaff1ac84728b708",
-      "url": "https://github.com/nix-community/home-manager/archive/5820376beb804de9acf07debaaff1ac84728b708.tar.gz",
-      "hash": "0b2a2qjsim6lj9p10h54mv515qj5siq8c9ii1hipwd5pdyh5mv8p"
+      "revision": "9a2dc0efbc569ce9352a6ffb8e8ec8dbc098e142",
+      "url": "https://github.com/nix-community/home-manager/archive/9a2dc0efbc569ce9352a6ffb8e8ec8dbc098e142.tar.gz",
+      "hash": "14xnr63ljq7ysas104vd46r0d1nwjwkjwgr0jfgdq876yzh79vx7"
     },
     "hs-grille": {
       "type": "Git",


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@5820376b...9a2dc0ef](https://github.com/nix-community/home-manager/compare/5820376beb804de9acf07debaaff1ac84728b708...9a2dc0efbc569ce9352a6ffb8e8ec8dbc098e142)

* [`6c1a1efa`](https://github.com/nix-community/home-manager/commit/6c1a1efa028aff04a277fc69781081a0bd6e0ca2) watcher: fix example typo for aw-watcher-window ([nix-community/home-manager⁠#7822](https://togithub.com/nix-community/home-manager/issues/7822))
* [`0a2145ea`](https://github.com/nix-community/home-manager/commit/0a2145eae2546f8fb7ce20b5bf21c9dacce37092) activitywatch: add service status cmd to desc ([nix-community/home-manager⁠#7823](https://togithub.com/nix-community/home-manager/issues/7823))
* [`6efc49be`](https://github.com/nix-community/home-manager/commit/6efc49be7c6115a0e07b3a2fa042cd41d9195545) floorp: use -bin, as source package was dropped ([nix-community/home-manager⁠#7818](https://togithub.com/nix-community/home-manager/issues/7818))
* [`ec73c06d`](https://github.com/nix-community/home-manager/commit/ec73c06d34859ed01e2ce0e15d5972b4dd539694) vscode: add config and exension dir for kiro ([nix-community/home-manager⁠#7825](https://togithub.com/nix-community/home-manager/issues/7825))
* [`75f97fcb`](https://github.com/nix-community/home-manager/commit/75f97fcbe31cd6d4151527f3ac50cacbe8f1ff0d) sway: order input config from least to most specific ([nix-community/home-manager⁠#7684](https://togithub.com/nix-community/home-manager/issues/7684))
* [`fad8e303`](https://github.com/nix-community/home-manager/commit/fad8e3033e95d0a4595080e1efc8927b16ac18ed) fontconfig: add fonts.fontconfig.extraConfigFiles option ([nix-community/home-manager⁠#7754](https://togithub.com/nix-community/home-manager/issues/7754))
* [`d507f57d`](https://github.com/nix-community/home-manager/commit/d507f57df23d067165f3d1a1dd5fb169b4f6bc37) maintainers: update all-maintainers.nix ([nix-community/home-manager⁠#7815](https://togithub.com/nix-community/home-manager/issues/7815))
* [`624c97de`](https://github.com/nix-community/home-manager/commit/624c97de9cae5ba1432557df579b64a79d90fadc) oh-my-posh: added option to supply config path
* [`51372c4a`](https://github.com/nix-community/home-manager/commit/51372c4afb961c310beab90090f93d88e3b1c1e6) oh-my-posh: add assertion for config source
* [`10f5a0cc`](https://github.com/nix-community/home-manager/commit/10f5a0cc4b98c61298a8d130185a25032e9fe3b8) tests/oh-my-posh: expand test coverage
* [`846f27fb`](https://github.com/nix-community/home-manager/commit/846f27fba84839a93015c3378449edd255071e42) claude-code: support paths for agents/commands
* [`fb928abb`](https://github.com/nix-community/home-manager/commit/fb928abb67bd4df99040721ed48c3b42e24b1d08) tests/claude-code: add path tests for agents/commands
* [`d7686f26`](https://github.com/nix-community/home-manager/commit/d7686f26e8b623f32f2739cf2c5f1b37efbf1366) opencode: add support for agent and command files
* [`c104ee92`](https://github.com/nix-community/home-manager/commit/c104ee92bf1cf4c9b4ccaa773fd108627a83bbf3) opencode: path support for agents/commands
* [`53538044`](https://github.com/nix-community/home-manager/commit/53538044d9e23b30ea7d5c1b0028feb9517995b3) tests/opencode: expand tests for agents / commands
* [`b0355462`](https://github.com/nix-community/home-manager/commit/b035546241d842053c7f19c517e330d79d1dc801) news: add opencode entry for new agent and command support
* [`bc8967cd`](https://github.com/nix-community/home-manager/commit/bc8967cdb03c9d805288dd80b845b16ef8c4111b) gpg-agent: write nushell initialization to config file
* [`12dfb0cf`](https://github.com/nix-community/home-manager/commit/12dfb0cff99865ea9e7fd0e3db3a301102b948f9) restic: fix integration test
* [`5c14260f`](https://github.com/nix-community/home-manager/commit/5c14260fad23f9fda91a0dd74b1c58cf3be95221) systemd: make unit definitions freeform modules
* [`9f408dc5`](https://github.com/nix-community/home-manager/commit/9f408dc51c8e8216a94379e6356bdadbe8b4fef9) ssh-tpm-agent: fix test case
* [`9093a3f2`](https://github.com/nix-community/home-manager/commit/9093a3f2002298239de7f10bd8bcdd9652d6904e) formiko: add module
* [`a504aee7`](https://github.com/nix-community/home-manager/commit/a504aee7d452ecf8881b933b1eb573535a543a03) news: add formiko entry
* [`9e771132`](https://github.com/nix-community/home-manager/commit/9e771132aa2bce8e65eab2c5557d508f5218dda9) Translate using Weblate (Bulgarian)
* [`4dbbc965`](https://github.com/nix-community/home-manager/commit/4dbbc965c0becd3c0adfdbce703ee9ad602b312a) Translate using Weblate (Bulgarian)
* [`64507361`](https://github.com/nix-community/home-manager/commit/64507361488885f315c2911728499d25790fc1de) Translate using Weblate (Bulgarian)
* [`be9c10d4`](https://github.com/nix-community/home-manager/commit/be9c10d4a7286e9940147d8933a78dd308c760a0) Translate using Weblate (Bulgarian)
* [`bf7056c6`](https://github.com/nix-community/home-manager/commit/bf7056c6a2d893d80db18d06d7e730d6515aaae8) nextcloud-client: add stop and restart settings to the service
* [`b5698ed5`](https://github.com/nix-community/home-manager/commit/b5698ed57db7ee7da5e93df2e6bbada91c88f3ce) retext: add module
* [`acaf3971`](https://github.com/nix-community/home-manager/commit/acaf3971c19f873c1a0d364439a2819b6a814310) abaddon: add module
* [`32bfbc99`](https://github.com/nix-community/home-manager/commit/32bfbc996e4310c4d3a24464af88f5d3e6012505) news: add abaddon entry
* [`b8596c1b`](https://github.com/nix-community/home-manager/commit/b8596c1b2352cd31b34173001d8502c304f130c3) acd-cli: add module
* [`891d675c`](https://github.com/nix-community/home-manager/commit/891d675cd62de524c50c4f1f0b60c789d0304cec) news: add acd-cli entry
* [`3cb08dd3`](https://github.com/nix-community/home-manager/commit/3cb08dd360e3bee6cf2ca4dd011802c523695fc1) nvchecker: add module
* [`3f47f72c`](https://github.com/nix-community/home-manager/commit/3f47f72c97ec23d117d9ce6ad15a42552cfce66d) mise: disable shell integration when package == null
* [`b47ea12f`](https://github.com/nix-community/home-manager/commit/b47ea12ff4442029c7016c13d5c55f86e10cbad3) mise: statically generate nushell config
* [`363007f1`](https://github.com/nix-community/home-manager/commit/363007f12930caf8b0ea59c0bf5be109c52ad0ef) nushell: expose config dir location as option
* [`ace87597`](https://github.com/nix-community/home-manager/commit/ace8759715a203f6cc63fd7235f4fbb78b5d476a) swaync: fix eval problem ([nix-community/home-manager⁠#7844](https://togithub.com/nix-community/home-manager/issues/7844))
* [`e81d71d5`](https://github.com/nix-community/home-manager/commit/e81d71d53aa7f54e9cae745dc06d389217ff172d) nix-remote-build: add module
* [`e3875193`](https://github.com/nix-community/home-manager/commit/e38751933802481b37fee1f9251cbb86e63df381) news: add entry for nix-remote-build
* [`efcba687`](https://github.com/nix-community/home-manager/commit/efcba687d355f4e46cb7754c385720ae454fe543) xdg-mime-apps: add defaultApplicationPackages option
* [`55b1f5b7`](https://github.com/nix-community/home-manager/commit/55b1f5b7b191572257545413b98e37abab2fdb00) wleave: init ([nix-community/home-manager⁠#7835](https://togithub.com/nix-community/home-manager/issues/7835))
* [`d5fb6ebc`](https://github.com/nix-community/home-manager/commit/d5fb6ebc4f7304f4485a8adb7258b1b65547a3f9) Translate using Weblate (Basque)
* [`edc7468e`](https://github.com/nix-community/home-manager/commit/edc7468e12be92e926847cb02418e649b02b59dd) yazi: add extraPackages option for wrapper PATH extension
* [`7a615e2a`](https://github.com/nix-community/home-manager/commit/7a615e2a56429dee04524c9bacaae2c3d9ab8520) flake.lock: Update
* [`20d75ecd`](https://github.com/nix-community/home-manager/commit/20d75ecd36fae11588aa86730f916b23d5f93123) animdl: add module
* [`f3ff73a5`](https://github.com/nix-community/home-manager/commit/f3ff73a5e13b62b4bebc69849eac58913aa2fc3a) news: add animdl entry
* [`61c84a3b`](https://github.com/nix-community/home-manager/commit/61c84a3bbfcf75953f0eeb150a68f54ca1aad964) fabric: add module
* [`939e91e1`](https://github.com/nix-community/home-manager/commit/939e91e1cff1f99736c5b02529658218ed819a2a) news: add fabric-ai entry
* [`9b6e609a`](https://github.com/nix-community/home-manager/commit/9b6e609a6e41ee5ca4a46465bdc0475fe2212fc8) octant: remove module
* [`de536983`](https://github.com/nix-community/home-manager/commit/de5369834ff1f75246c46be89ef993392e961c26) maintainers: update all-maintainers.nix
* [`f59891d5`](https://github.com/nix-community/home-manager/commit/f59891d511d692ac0ed0bb366b39f778d5b594ed) xdg-mime-apps: no spaces in default app entries
* [`9a2dc0ef`](https://github.com/nix-community/home-manager/commit/9a2dc0efbc569ce9352a6ffb8e8ec8dbc098e142) zellij: Add extraConfig
