### PR TITLE
npins nixpkgs: update 0d7c1586 -> a1f79a17

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -132,8 +132,8 @@
     "nixpkgs": {
       "type": "Channel",
       "name": "nixpkgs-unstable",
-      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-25.11pre862361.0d7c15863b25/nixexprs.tar.xz",
-      "hash": "1cyha3ias1ab2i8hc5h5p4ys40dsxhcya3rb96brr1fjwfpm2zjb"
+      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-25.11pre864673.a1f79a1770d0/nixexprs.tar.xz",
+      "hash": "0j33hiaprbpdhax2vxd2rddf5zsayqcj819f47py6vi9jd80byk0"
     },
     "powerlevel10k": {
       "type": "Git",


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: release-25.11
Commits: [nixos/nixpkgs@0d7c1586...a1f79a17](https://github.com/nixos/nixpkgs/compare/0d7c15863b25...a1f79a1770d0)

* [`2f11a2af`](https://github.com/NixOS/nixpkgs/commit/2f11a2af9d9a7e366df6a54705a6c6ead44f5398) libiec61850: Add pjungkamp as maintainer
* [`11b932cb`](https://github.com/NixOS/nixpkgs/commit/11b932cb61c11ebae3d9eaed966f76e063ba42df) OVMF: include UninstallMemAttrProtocol patch
* [`eaec9c02`](https://github.com/NixOS/nixpkgs/commit/eaec9c0244d0e38c1c0be3d6512820484da146a1) python3Packages.ubelt: 1.3.6 -> 1.3.7
* [`48db51db`](https://github.com/NixOS/nixpkgs/commit/48db51dbd4b349f9fcd89019f36c9bfd54c1145e) python3Packages.nvidia-dlprof-pytorch-nvtx: init at 1.8.0
* [`f89abe38`](https://github.com/NixOS/nixpkgs/commit/f89abe38ad4799b16ec5faa6d8d3b1110d2a48a6) js8call: rec to finalAttrs
* [`3fe21d76`](https://github.com/NixOS/nixpkgs/commit/3fe21d7625a16abe330887d1d83583fe864f921b) js8call: 2.2.0 -> 2.3.1
* [`4693d31f`](https://github.com/NixOS/nixpkgs/commit/4693d31ff12c423e66f52eb10073e2eee6056600) js8call: add sarcasticadmin as maintainer
* [`91b9ffb0`](https://github.com/NixOS/nixpkgs/commit/91b9ffb052351518fcde64b725340044a713b7d9) python3Packages.pytorch-tabnet: init at 4.1.0
* [`5186488c`](https://github.com/NixOS/nixpkgs/commit/5186488c7a783eb3593e1a80812e063acbe67da3) fasttrackml: init at 0.6.0
* [`47cf6863`](https://github.com/NixOS/nixpkgs/commit/47cf68630cb389a7f9997f664cb3c8b047006fa9) maintainers: add liam-w
* [`4bc4426e`](https://github.com/NixOS/nixpkgs/commit/4bc4426ef0f46460a3631837f1fcb3faa202e501) maplestory-cursor: init at 1.0.0
* [`b371bd74`](https://github.com/NixOS/nixpkgs/commit/b371bd749f17d092918baba4ea589a8cf6b4a762) cubiomes-viewer: move to pkgs/by-name/
* [`1b97951c`](https://github.com/NixOS/nixpkgs/commit/1b97951cb72eab06665cf8738f79faeecc37b87a) nix-prefetch-git: Depend on gitMinimal instead of git
* [`6b3a43b3`](https://github.com/NixOS/nixpkgs/commit/6b3a43b31c6ac0e28918f9983efd96b4a294b744) libiec61850: Add mbedtls for TLS and R-GOOSE support
* [`e9e5d9c6`](https://github.com/NixOS/nixpkgs/commit/e9e5d9c6c5f71e3fb55f561cc35752c981abbf92) tic-80: add support for darwin
* [`8f2056b9`](https://github.com/NixOS/nixpkgs/commit/8f2056b9efa347e16a7639912b454624378947d7) meshlab: modernize
* [`6630a62a`](https://github.com/NixOS/nixpkgs/commit/6630a62a862acff987cefc0ae352783b424c8eeb) meshlab: disable download
* [`c43a5901`](https://github.com/NixOS/nixpkgs/commit/c43a5901f1ee38cd78af0f63a90158469be68fbb) claude-monitor: init at 3.1.0
* [`54929d2a`](https://github.com/NixOS/nixpkgs/commit/54929d2a3c99dbe5f468cf77672a2a1ea685b518) sideswap: do not depend on mesa and libglvnd
* [`1758f835`](https://github.com/NixOS/nixpkgs/commit/1758f83585f265cb64a092f3f6dd039b791dd731) sideswap: factor out gitHashes to a file
* [`b5b67cb8`](https://github.com/NixOS/nixpkgs/commit/b5b67cb8da18aae2fe11019c1fd30709daa5ab77) fontc: init at 0.3.0
* [`1b33b9cf`](https://github.com/NixOS/nixpkgs/commit/1b33b9cfac81653ba14293675d99fa60b6833098) electron-fiddle: 0.36.5-unstable-2025-07-17 -> 0.37.2
* [`e4e086d7`](https://github.com/NixOS/nixpkgs/commit/e4e086d774b1bbd305aa8b9dcddb8daefe53d07f) sideswap: init updateScript
* [`213dfc8d`](https://github.com/NixOS/nixpkgs/commit/213dfc8dd8e83b3a7db9af0a12a390542158a0b4) sideswap: 1.8.0 -> 1.8.2
* [`d8c4d45f`](https://github.com/NixOS/nixpkgs/commit/d8c4d45f7fa0c35488936a1332c4b852e9fd4d0c) googlesans-code: init at 6.000
* [`e3acb404`](https://github.com/NixOS/nixpkgs/commit/e3acb4044b552302ad3bfe5338cdb74edd383dea) noseyparker: fix cross
* [`c06a3245`](https://github.com/NixOS/nixpkgs/commit/c06a3245fdc214543092b01b44c0a5b2b37ff3d9) noseyparker: minor modernisation
* [`42363e00`](https://github.com/NixOS/nixpkgs/commit/42363e0080c9a0e8ff22b4883153811b7bdee78a) levmar: modernize
* [`070969a9`](https://github.com/NixOS/nixpkgs/commit/070969a90ff86455531bf038fc674539963ea662) levmar: fix build on darwin
* [`94a720c4`](https://github.com/NixOS/nixpkgs/commit/94a720c498547ed4cf610175764e6575aebc3155) meshlab: move vcg to native build inputs
* [`47703c44`](https://github.com/NixOS/nixpkgs/commit/47703c4434bebbae89c1192d0c7346d058fc9d92) meshlab: add darwin support
* [`9f7318cc`](https://github.com/NixOS/nixpkgs/commit/9f7318cc3952a6e639d28f2d9783230c87cfbfd9) meshlab-unstable: modernize
* [`471f3e39`](https://github.com/NixOS/nixpkgs/commit/471f3e398b775da8654985aef0b188e1b97e4d2c) meshlab-unstable: add darwin support
* [`831e9edf`](https://github.com/NixOS/nixpkgs/commit/831e9edf99bf394250808d164d0a931769bd93c7) meshlab: add yzx9 as maintainer
* [`249a3dcd`](https://github.com/NixOS/nixpkgs/commit/249a3dcd5e04fbb4b96bc6b8483c185be6002bfb) nixos/ax25/axports: ax25 kernel module check
* [`dc2c7d84`](https://github.com/NixOS/nixpkgs/commit/dc2c7d848133c19acf3752b5d8b96ab6c0cc9ec4) maintainers: add spreetin
* [`95a8edc1`](https://github.com/NixOS/nixpkgs/commit/95a8edc1960b403ff529f8fd844aeaf0992dca1d) szurubooru: 2.5-unstable-2025-02-11 -> 2.5-unstable-2025-07-19
* [`f07a87c1`](https://github.com/NixOS/nixpkgs/commit/f07a87c1e56a3b83f65fb5f1a70d038130ee270c) nixos/szurubooru: change python3.12 to python3
* [`42400b38`](https://github.com/NixOS/nixpkgs/commit/42400b3876e776a09e819d92d15b46f3ea953aa9) arduino-cli: 1.2.2 -> 1.3.0
* [`e9423424`](https://github.com/NixOS/nixpkgs/commit/e9423424ed1bc0332f0d09c71529eea0d847e6fb) arduino-cli: use writableTmpDirAsHomeHook
* [`7674d729`](https://github.com/NixOS/nixpkgs/commit/7674d7296edb836c3f656c4ccd868fb229d3e90d) flutter335: fix macos build
* [`ba029e09`](https://github.com/NixOS/nixpkgs/commit/ba029e09784309af2f4cdc522d8a04687e4a8269) flutter335: fix android build
* [`dfa2862a`](https://github.com/NixOS/nixpkgs/commit/dfa2862afce7e94350b912822891abdd3e1769ef) netbsd.compat: Fix cross-compilation from darwin
* [`abb9ac87`](https://github.com/NixOS/nixpkgs/commit/abb9ac873cf67ee1904a719853c1f9f7ad422392) cubiomes-viewer: small refactor to conform with nixpkgs recommendations
* [`bf1b57c1`](https://github.com/NixOS/nixpkgs/commit/bf1b57c1406606e30394b67512d2f729603a10b4) cubiomes-viewer: add darwin support
* [`5a726767`](https://github.com/NixOS/nixpkgs/commit/5a726767a322058271cefb6fcdb78875395a34fe) verdict: 1.4.2 -> 1.4.4
* [`2971c657`](https://github.com/NixOS/nixpkgs/commit/2971c6578409ddb103e97835bb4f8eccd34cbed3) esptool: add shell completions
* [`76f6cf67`](https://github.com/NixOS/nixpkgs/commit/76f6cf67eee50374b015439de94797ac7954592d) pyroaring: Override Cython version for tests/build
* [`cf287fae`](https://github.com/NixOS/nixpkgs/commit/cf287fae692eeea6e9250548f0ff3371dfb130ba) vscode-extensions.jdinhlife.gruvbox: 1.28.0 -> 1.29.0
* [`5f6cfa4d`](https://github.com/NixOS/nixpkgs/commit/5f6cfa4ddf0ba1629fe7889f8f0a355267e066fb) python3Packages.asteroid-filterbanks: disable a failing test for all linux platforms
* [`64d60146`](https://github.com/NixOS/nixpkgs/commit/64d601469ca05dcf2d4529b92513913ac8c0f503) fzf-preview: init at 0-unstable-2025-06-26
* [`faf7899f`](https://github.com/NixOS/nixpkgs/commit/faf7899f2937e36b7f7da51483beab07d47069a6) phantomsocks: 0-unstable-2023-11-30 -> 0-unstable-2025-08-07
* [`692a7980`](https://github.com/NixOS/nixpkgs/commit/692a7980617248384dc0e47d7d4b480a70fe4632) arduino-cli: 1.3.0 -> 1.3.1
* [`95c9215d`](https://github.com/NixOS/nixpkgs/commit/95c9215d2e19b1cc4069294fb46d116ae90ade60) opa-envoy-plugin: 1.7.1-envoy -> 1.8.0-envoy
* [`f020b4ee`](https://github.com/NixOS/nixpkgs/commit/f020b4ee4a1405528e3ec3060c2dc91cbf982b9f) fluxboxlauncher: 0.2.1 -> 0.2.3
* [`26e4c50a`](https://github.com/NixOS/nixpkgs/commit/26e4c50a37a0d065ce9de291a91665359907d1a3) makeself: 2.4.5 -> 2.5.0
* [`05f950d0`](https://github.com/NixOS/nixpkgs/commit/05f950d07b744af6299fd15094bd158825d516c7) python313Packages.pysam: 0.22.1-unstable-2024-10-30 -> 0.23.3
* [`9eb0b6c7`](https://github.com/NixOS/nixpkgs/commit/9eb0b6c71dc918f66518eb8b0d210d83ac21b494) python313Packages.pysam: refactor
* [`8500e522`](https://github.com/NixOS/nixpkgs/commit/8500e52278abc5fdcd72078eec686a76813a01e2) python313Packages.pysam: add nix-update-script
* [`c57f0d66`](https://github.com/NixOS/nixpkgs/commit/c57f0d66c1fe9185e1a5856ed6cfec8a87fae606) naps2: 7.5.3 -> 8.2.1
* [`cf3b74ef`](https://github.com/NixOS/nixpkgs/commit/cf3b74ef9c91cc661d687c6ee8bc0ec0e8d5f636) python3Packages.mkdocs-swagger-ui-tag: 0.7.1 -> 0.7.2
* [`6af268dc`](https://github.com/NixOS/nixpkgs/commit/6af268dc22dbed710d954773d040127d6492e593) cider-2: fix updateScript
* [`4d94729b`](https://github.com/NixOS/nixpkgs/commit/4d94729b6ebdeec469cd61ad46730b82707cc92d) cider-2: 3.0.0 -> 3.1.1
* [`7247e0ce`](https://github.com/NixOS/nixpkgs/commit/7247e0ceae16892a8eb5d3891dc8f8754c72f379) python3Packages.netbox-contract: 2.4.1 -> 2.4.2
* [`53045862`](https://github.com/NixOS/nixpkgs/commit/5304586274a2b85599272824528b94a166d940d7) wivrn: default to xrizer for openvr compat
* [`1f58bf84`](https://github.com/NixOS/nixpkgs/commit/1f58bf841cc69b806e206deeecef6cceb0fd2d58) nzbget: 25.2 -> 25.3
* [`6fb75b1e`](https://github.com/NixOS/nixpkgs/commit/6fb75b1e89ff22af201733916c0120a4c31b7c0e) vscode-extensions.sonarsource.sonarlint-vscode: 4.27.0 -> 4.30.0
* [`cea6a8bf`](https://github.com/NixOS/nixpkgs/commit/cea6a8bfa5dbd67d6a04c6b3ad83ae58c34c9ab5) multiqc: 1.29 -> 1.30
* [`ed5df576`](https://github.com/NixOS/nixpkgs/commit/ed5df5768165b65e61de1461f3218a17a285720d) tmuxPlugins.vim-tmux-navigator: unstable-2025-04-25 -> unstable-2025-07-15
* [`be69c7d9`](https://github.com/NixOS/nixpkgs/commit/be69c7d9784e3111af50526d0180f49f578af583) gambit-project: 16.3.1 -> 16.4.0
* [`624fe3e9`](https://github.com/NixOS/nixpkgs/commit/624fe3e9b422ce54c89a82e60f2896f91e4080ae) muon: 0.4.0 -> 0.5.0, enable tests
* [`b9a9eb10`](https://github.com/NixOS/nixpkgs/commit/b9a9eb100b5fdfe65db673faa93e627e02f995a2) muon: unbreak on darwin
* [`53889b7b`](https://github.com/NixOS/nixpkgs/commit/53889b7b8e8c9fd3d33f6d9a70ee98287f9afd43) muon: add updateScript and update meta
* [`eb8a4b09`](https://github.com/NixOS/nixpkgs/commit/eb8a4b0917a38479708873584a6ca34d5993f096) python3Packages.sixelcrop: init at 0.1.9
* [`1fe43afe`](https://github.com/NixOS/nixpkgs/commit/1fe43afee2cb3f0ab767b10b72eb25d5597aa00e) python3Packages.timg: init at 1.6.1
* [`9c84445c`](https://github.com/NixOS/nixpkgs/commit/9c84445c83bfabae83d388a2e3d8bd168ca8fc38) ankama-launcher: 3.13.5 -> 3.13.16
* [`ecd91ce1`](https://github.com/NixOS/nixpkgs/commit/ecd91ce14ca4761ef41e89133450bb7c3763fb42) ax25-apps: use nativeBuildInputs
* [`153215af`](https://github.com/NixOS/nixpkgs/commit/153215af4e4da965e0485a8ff2d85797e08c784a) ax25-apps: enable strictDeps
* [`da771f41`](https://github.com/NixOS/nixpkgs/commit/da771f41a4ab6c075c8265e56b3533d44bb63683) ax25-tools: move src to radiocatalog
* [`1be5fea9`](https://github.com/NixOS/nixpkgs/commit/1be5fea9b037a1d867ea24530d2d6e077220f9df) ax25-tools: enable strictDeps
* [`2038053f`](https://github.com/NixOS/nixpkgs/commit/2038053f5cb27bcc129f0c02e4577e4d33e93703) ax25-tools: move to finalAttrs
* [`0d439bef`](https://github.com/NixOS/nixpkgs/commit/0d439bef6f145960aa00554aab4b363f56e0ae36) libax25: move src to radiocatalog
* [`7205c584`](https://github.com/NixOS/nixpkgs/commit/7205c584a1bd9413519ea899a76c805bdef9c380) libax25: move to finalAttrs
* [`ff3cd2bc`](https://github.com/NixOS/nixpkgs/commit/ff3cd2bce1ab1645f34e8ea3995f6d2e040a3e95) libax25: enable strictDeps
* [`8c198068`](https://github.com/NixOS/nixpkgs/commit/8c19806822238ff349fe4d7fdedf64b591bffae1) libfrida-core: init at 17.2.17
* [`13f95ec6`](https://github.com/NixOS/nixpkgs/commit/13f95ec6668bc4f06eff463d3989a6d954d3a88a) maintainers: add m0streng0
* [`80b0301d`](https://github.com/NixOS/nixpkgs/commit/80b0301d229d0b89ea6e8af1c459c64ba41562e9) gcli: 2.8.0 -> 2.9.0
* [`c5509c10`](https://github.com/NixOS/nixpkgs/commit/c5509c1053d6d7beb444378f593fedbb35331c59) varnish60: 6.0.15 -> 6.0.16
* [`0d3b0381`](https://github.com/NixOS/nixpkgs/commit/0d3b03812107a63811d4aa4727982041b3440b06) postgresql_jdbc: add junixsocket-common and junixsocket-native-common
* [`93403bda`](https://github.com/NixOS/nixpkgs/commit/93403bdacd38d36f4a8f2c7397d6bf1a9faf6210) nixos/paretosecurity: Add support for declarative linking
* [`8d0a64c8`](https://github.com/NixOS/nixpkgs/commit/8d0a64c83d90abe662b3f006bb82cc6678c1e55c) apache-answer: 1.5.1 -> 1.6.0
* [`c6ccc3e9`](https://github.com/NixOS/nixpkgs/commit/c6ccc3e9dd97181037a5c324f1f049ed8a50608d) capnproto-rust: 0.21.2 -> 0.21.4
* [`b4f0bcff`](https://github.com/NixOS/nixpkgs/commit/b4f0bcff0f7006059af634ade9dbada679182aaf) linux: fix include path when build with ccache warpped clang
* [`a1623ab7`](https://github.com/NixOS/nixpkgs/commit/a1623ab7516cc90d97b1509ebbf0397244b26d30) tinycdb: 0.80 -> 0.81
* [`ac07f6aa`](https://github.com/NixOS/nixpkgs/commit/ac07f6aa8e8f3844bcde16d395682c6e4432a016) tinycdb: remove with lib
* [`f004867c`](https://github.com/NixOS/nixpkgs/commit/f004867c7f8193468850cf5b990ba70006992f10) onyx: init at 2.0.12
* [`4b8ed607`](https://github.com/NixOS/nixpkgs/commit/4b8ed60791eac45496f6c2cb320f0f92db38d1f3) authelia: 4.39.4 -> 4.39.8
* [`71f3ac41`](https://github.com/NixOS/nixpkgs/commit/71f3ac41e77759f402709a9e0e69bc9d58a36b7e) mcat-unwrapped: add shell completions
* [`a771b27d`](https://github.com/NixOS/nixpkgs/commit/a771b27d218d4be3c1dcae2a7981d155a75c6d5f) nixos/tests/postfix: use writePython3Bin in tests
* [`2b50f4e4`](https://github.com/NixOS/nixpkgs/commit/2b50f4e4d59df3d3117303d4eb8c8519ca8e8598) nixos/tests/postfix: add sasl authentication tests
* [`72861fa2`](https://github.com/NixOS/nixpkgs/commit/72861fa281794acc46fabc812db909b5af48503e) apparency: 2.2 -> 2.3
* [`5cd8d9c3`](https://github.com/NixOS/nixpkgs/commit/5cd8d9c3b2dd386679fc249426d6a5954179f7b4) python3Packages.cv2-enumerate-cameras: init at 1.2.2
* [`f0303c62`](https://github.com/NixOS/nixpkgs/commit/f0303c62efbe20b7ce2e97255a0b818f1d93e9b3) nixos/sillytavern: add it
* [`c61952c5`](https://github.com/NixOS/nixpkgs/commit/c61952c5417a73db7b57ba547e5a9f74fc1bfd6d) team/bazel: add boltzmannrain
* [`a6e992f3`](https://github.com/NixOS/nixpkgs/commit/a6e992f3ac94075ee4a0ec9332fea6535a535c58) python3Packages.blacken-docs: 1.19.1 -> 1.20.0
* [`8b8df7f1`](https://github.com/NixOS/nixpkgs/commit/8b8df7f1aa57347ab55a65fce0597125a12666d4) i2p: 2.9.0 -> 2.10.0
* [`efc1c86b`](https://github.com/NixOS/nixpkgs/commit/efc1c86b2f3549f6bc32aa8b041b9ea1973a9699) multipath-tools: 0.11.1 -> 0.12.0
* [`1992ee89`](https://github.com/NixOS/nixpkgs/commit/1992ee89431f2f1f8976dc1984d69af58dc9da27) muon: only run tests in `passthru.tests`
* [`5a64c863`](https://github.com/NixOS/nixpkgs/commit/5a64c8630bf72aad82c2d7059e34c605b62102ea) muon: use two-stage build, only use needed srcs
* [`99b0deec`](https://github.com/NixOS/nixpkgs/commit/99b0deec1716b36ba17b84d9ce9963845d48032f) python3Packages.dbt-core: 1.10.9 -> 1.10.11
* [`8faddff2`](https://github.com/NixOS/nixpkgs/commit/8faddff2c4d704dcb40ea577112a0d7949294d1d) home-assistant-custom-lovelace-modules.navbar-card: init at 0.18.1
* [`a3068ebb`](https://github.com/NixOS/nixpkgs/commit/a3068ebb668fc855d16101b1f0c8ec82e1a83635) obs-studio-plugins: inherit platforms from obs-studio.meta
* [`5beff2e7`](https://github.com/NixOS/nixpkgs/commit/5beff2e759d7b9ddc3ddabaa2b40f81284ec7913) obs-studio-plugins.input-overlay: fix building for aarch64
* [`5dfc49b9`](https://github.com/NixOS/nixpkgs/commit/5dfc49b9c29b71438c892de801bcf495779c36e6) obs-studio-plugins.obs-nvfb: remove due to glx removal
* [`5a2d3d44`](https://github.com/NixOS/nixpkgs/commit/5a2d3d44dfa863a806d9746eecf249bb16502fd1) ndi-6: fix build
* [`f0b88e68`](https://github.com/NixOS/nixpkgs/commit/f0b88e6888596d15ce0b3de1a2f0f01adf6f9906) python3Packages.itables: 2.4.4 -> 2.5.2
* [`685c72d5`](https://github.com/NixOS/nixpkgs/commit/685c72d5570d354103506862b608ae5cff356f6e) maintainers: drop vanzef
* [`556db31d`](https://github.com/NixOS/nixpkgs/commit/556db31dcbf904403e8b4dfdae292cf4262b9397) openssl: fix powerpc-linux build
* [`b4ac268a`](https://github.com/NixOS/nixpkgs/commit/b4ac268a3d62a9488fe01dbe4eaaf3e3d2259f68) maintainers: drop hjones2199
* [`3f5d1897`](https://github.com/NixOS/nixpkgs/commit/3f5d189720f55f126957794ee5d7bcc211ee1868) yaralyzer: 1.0.6 -> 1.0.9
* [`86ce7b0e`](https://github.com/NixOS/nixpkgs/commit/86ce7b0e78c9d032eb0b5113c4cd396594c07aaa) transito: depend on libxcb independently of libX11 propagating it
* [`8c01dd01`](https://github.com/NixOS/nixpkgs/commit/8c01dd01357e07c58ec7ebe75c1a44907d161895) osquery: 5.18.1 -> 5.19.0
* [`480c10fb`](https://github.com/NixOS/nixpkgs/commit/480c10fbf2edef56b63fce24ebcd97ea82bf425d) tidal-hifi: 5.20.0 -> 5.20.1
* [`34318027`](https://github.com/NixOS/nixpkgs/commit/3431802785b06a63c7dbd2edee43b62be0a063dc) tenere: 0.11.2-unstable-2024-12-05 -> 0.11.3
* [`8287ccc9`](https://github.com/NixOS/nixpkgs/commit/8287ccc99f81f47ceb2e4cc8057213a4624078e0) eclipses.eclipse-platform: 4.36 -> 4.37
* [`f0244a0d`](https://github.com/NixOS/nixpkgs/commit/f0244a0dd363002340431f8169d4fda6cd910075) bcache-tools: 1.0.8 -> 1.1
* [`9309fd75`](https://github.com/NixOS/nixpkgs/commit/9309fd750800b5c8e4d6cb90fbed7fc53885adb1) nixos/murmur: Reverse order of allowed address families
* [`e1b3b47b`](https://github.com/NixOS/nixpkgs/commit/e1b3b47bb135ae2d0d2b36159d7fccc6e49ed532) oras: 1.2.3 -> 1.3.0
* [`2471384a`](https://github.com/NixOS/nixpkgs/commit/2471384a274ee8e1e24937cc3e1520561c91e6a4) cddlib: 0.94m -> 0.94n
* [`1ccca64e`](https://github.com/NixOS/nixpkgs/commit/1ccca64e0800b3b8cea32b96a3d444923da0b126) homebridge-config-ui-x: 5.4.1 -> 5.6.0
* [`7065566e`](https://github.com/NixOS/nixpkgs/commit/7065566e3c1a99fa1e8a8402e1ae05b4be651cc8) python3Packages.rapidfuzz: 3.14.0 -> 3.14.1
* [`4402e311`](https://github.com/NixOS/nixpkgs/commit/4402e311e672f567b0b053b9195e319dffed92e9) python313Packages.msgraph-sdk: 1.40.0 -> 1.44.0
* [`d9dddc49`](https://github.com/NixOS/nixpkgs/commit/d9dddc493a896e381c334486fb69ba4db9e2d56c) python313Packages.snitun: 0.44.0 -> 0.45.0
* [`53245fb0`](https://github.com/NixOS/nixpkgs/commit/53245fb07e87281becc75029e44d95488a0e5188) spotube: 4.0.2 -> 5.0.0
* [`45193d5a`](https://github.com/NixOS/nixpkgs/commit/45193d5a8ce23ab4c1ae75f0cd13d79c309a7ae4) nixos/nixpkgs: correct some option defaults
* [`16a1adab`](https://github.com/NixOS/nixpkgs/commit/16a1adab38ec532d3f3b0a3eaa10e2abcb2171c9) python313Packages.litestar: libvalkey is not available yet
* [`5904bfbd`](https://github.com/NixOS/nixpkgs/commit/5904bfbdf8d8778a77db1fb9e5b654d02e17d4ab) python3Packages.conjure-python-client: 3.0.0 -> 3.1.0
* [`c8c76692`](https://github.com/NixOS/nixpkgs/commit/c8c766921bb153b97b0fc6eec6f0d04e53066f98) faac: 1.30 -> 1.31.1
* [`8250b2de`](https://github.com/NixOS/nixpkgs/commit/8250b2de4004284b6aecb6d583fbfe259568cc71) factoriolab: 3.16.6 -> 3.17.2
* [`41e599f8`](https://github.com/NixOS/nixpkgs/commit/41e599f8b24edb312e6393260921d6e8ea1b6b31) ocamlPackages.uucp: 16.0.0 -> 17.0.0
* [`73212a13`](https://github.com/NixOS/nixpkgs/commit/73212a139192c8ed943c255eeec1e3a80e53bb06) ocamlPackages.uunf: 16.0.0 -> 17.0.0
* [`ca50e231`](https://github.com/NixOS/nixpkgs/commit/ca50e231484574b5e1761deb7fec4dd58fbaf4eb) ocamlPackages.uuseg: 16.0.0 -> 17.0.0
* [`dcf2b9c0`](https://github.com/NixOS/nixpkgs/commit/dcf2b9c0a0b992bf41b281472c0ebd402bd7b85f) nixos/victoriametrics: Add ability to pass basicAuthPasswordFile
* [`d002365b`](https://github.com/NixOS/nixpkgs/commit/d002365bdacb95d22aa7986dfefdab75b6c62ba9) vrcx: 2025.08.17 -> 2025.09.10
* [`907c29cb`](https://github.com/NixOS/nixpkgs/commit/907c29cb970a0e4fde220111282be1d791e1b85b) wealthfolio: 1.2.1 -> 1.2.2
* [`6f95df11`](https://github.com/NixOS/nixpkgs/commit/6f95df119eac884c3108b0a8fce8c8e00bdb2e5c) checkov: fix broken build
* [`94ef8b69`](https://github.com/NixOS/nixpkgs/commit/94ef8b69d6b96ddae090ca066a8896d74ce64bee) dbus-cpp: 5.0.4 -> 5.0.5
* [`b2ad7e1e`](https://github.com/NixOS/nixpkgs/commit/b2ad7e1ed1d80ce664fc3b3f5d010abd9f6426d0) matrix-tuwunel: 1.4.1 -> 1.4.2
* [`8260f049`](https://github.com/NixOS/nixpkgs/commit/8260f049b96a3e911a50c9138e9e7a4eaffedbb2) h2o: 2.3.0-rolling-2025-09-05 → 2.3.0-rolling-2025-09-12
* [`f1330ea7`](https://github.com/NixOS/nixpkgs/commit/f1330ea7db025f54b76161416d09059f4d7e451f) python313Packages.flake8-import-order: fix src
* [`c402e11f`](https://github.com/NixOS/nixpkgs/commit/c402e11ffb226df670b0878be96edd521ae4d18a) python313Packages.flake8-import-order: fix license, refactor
* [`fae41a5e`](https://github.com/NixOS/nixpkgs/commit/fae41a5ee90b944d3bb461038ccb0fb168373ea6) bazel_8: init at 8.4.1
* [`86263107`](https://github.com/NixOS/nixpkgs/commit/86263107aab2cedf4a5b23b827f9443d639428b7) nixosTests.bcache: init
* [`cb965e37`](https://github.com/NixOS/nixpkgs/commit/cb965e378b014d0f690415c5dc41859fea3f00b4) ocamlPackages.utop: 2.15.0 → 2.16.0
* [`50343562`](https://github.com/NixOS/nixpkgs/commit/50343562c84a2ba00561f5b5a3161ebd16d5bed4) php: move $out/lib/build used by phpize to dev output
* [`5127b030`](https://github.com/NixOS/nixpkgs/commit/5127b0309bea1a6f188611a8345da473a35c227c) gemini-cli: 0.3.4 -> 0.4.1
* [`d1bc5c03`](https://github.com/NixOS/nixpkgs/commit/d1bc5c03f12e56f4553df7c1c11c6f13bafdf0be) mctc-lib: remove unneeded input
* [`4e9ab6a8`](https://github.com/NixOS/nixpkgs/commit/4e9ab6a85f4a6120bd49163a9caae21e41b6a7f4) mctc-lib: fix openmp cores in checkPhase
* [`e2ee5e66`](https://github.com/NixOS/nixpkgs/commit/e2ee5e6665d1e8e84cb9387bafc0251fa0e19ee0) dftd4/sirius/tblite: clean up, remove unneeded code
* [`21a288bf`](https://github.com/NixOS/nixpkgs/commit/21a288bffbed5752a22f5dedd462b01e08348dd7) alcom: 1.0.1 -> 1.1.4
* [`530b79aa`](https://github.com/NixOS/nixpkgs/commit/530b79aa41318d78645ed9e7b4cbb796f9928a21) alcom: fix meta.mainProgram
* [`2cd2faed`](https://github.com/NixOS/nixpkgs/commit/2cd2faedd88375f7b252ba0ad52ca085c2109a0c) emhash: init at 1.0.1
* [`c3b170a0`](https://github.com/NixOS/nixpkgs/commit/c3b170a009b9d4218538a0aed1f64b82b3a30cb6) ocamlPackages.ppx_deriving: 6.1.0 → 6.1.1
* [`8c17d0e4`](https://github.com/NixOS/nixpkgs/commit/8c17d0e484facec1018b060eead8f433c7fb27a1) ahk_x11: 1.0.5-unstable-2025-09-04 -> 1.0.6
* [`5c43592f`](https://github.com/NixOS/nixpkgs/commit/5c43592f4f5f4c024d235563701a0fd12de40f4a) nixos/meilisearch: allow access to proc for memory limit
* [`33d20d7c`](https://github.com/NixOS/nixpkgs/commit/33d20d7c0c492439743ba3e42d4de0365a333473) prometheus-postfix-exporter: 0.14.0 -> 0.15.0
* [`0db2e6d9`](https://github.com/NixOS/nixpkgs/commit/0db2e6d9cb6593edc750e88d343cd34bf7c700bd) hoppscotch: 25.8.0-0 -> 25.8.1-0
* [`12e1455d`](https://github.com/NixOS/nixpkgs/commit/12e1455d3412ac14c8ea7134469b3c1e333441bd) gpsd: fix ubxtool failed to import pyserial
* [`9b4cd214`](https://github.com/NixOS/nixpkgs/commit/9b4cd2146995462f64241aaad8f59a6c06917f8f) rofi-nerdy: fix plugin output path
* [`748b5d11`](https://github.com/NixOS/nixpkgs/commit/748b5d1121baef74c0137e9fe00a2e2346fb1597) go_1_24: Disable CGO for powerpc64-linux target
* [`68fcc594`](https://github.com/NixOS/nixpkgs/commit/68fcc594571bf702353cb199e78fc8e9c6d7e94a) go_1_25: Disable CGO for powerpc64-linux target
* [`cd5b7a7e`](https://github.com/NixOS/nixpkgs/commit/cd5b7a7ee7e297fdd3a14dc5a824348c8b698535) maintainers: remove thyol
* [`5f619c0c`](https://github.com/NixOS/nixpkgs/commit/5f619c0c3ccbc17946cc117599d26c2e1b829588) joplin-desktop: use electron_36
* [`32d5aa70`](https://github.com/NixOS/nixpkgs/commit/32d5aa7059099ea0e654c49edf44ea7e1e9f75f5) maintainers: remove artuuge
* [`8d9c0ebc`](https://github.com/NixOS/nixpkgs/commit/8d9c0ebc1c71b167d780ad1968903eae36c88aa3) nextcloud30: 30.0.14 -> 30.0.15
* [`60550bc1`](https://github.com/NixOS/nixpkgs/commit/60550bc14a58d4bdbb25e4e2c48ee880aa885dd7) nextcloud31: 31.0.8 -> 31.0.9
* [`4a86c1d2`](https://github.com/NixOS/nixpkgs/commit/4a86c1d2f1b51bf7a8a9a92b28d436fe5bf73ee6) nextcloudPackages: update
* [`fae62a35`](https://github.com/NixOS/nixpkgs/commit/fae62a354f9206ddb2844317bc91e1201093edfa) maintainers: remove yuuyins
* [`be2c39e1`](https://github.com/NixOS/nixpkgs/commit/be2c39e198a981dbc79fa80b740fe6e641b0f897) vips: 8.17.1 -> 8.17.2
* [`d6ed16a8`](https://github.com/NixOS/nixpkgs/commit/d6ed16a832461a9fe68c526c7d31c5cb92ecb2c4) nixos/bcachefs: add boot.bcachefs.package
* [`81edb918`](https://github.com/NixOS/nixpkgs/commit/81edb918c92620a500856ea75d52dcaa965d3834) maestro: 2.0.2 -> 2.0.3
* [`ce375fea`](https://github.com/NixOS/nixpkgs/commit/ce375feadf84cdffebeaa89ff4a8109e4a443121) lixPackageSets.git: 2.94.0-pre-20250807_8bbd5e1d0df9 -> 2.94.0-pre-20250912_d90e4a65812c
* [`c3f3bd46`](https://github.com/NixOS/nixpkgs/commit/c3f3bd46caf0c504d1fc3718b6984d9238343a43) lldpd: 1.0.19 -> 1.0.20
* [`453a9de9`](https://github.com/NixOS/nixpkgs/commit/453a9de968c6c2ce546edb3923b3ceb58a297e71) oxigraph: 0.4.11 -> 0.5.0
* [`632a1e99`](https://github.com/NixOS/nixpkgs/commit/632a1e990f89e23840d08fbe31203cda3dd6ba6c) lomiri.lomiri-docviewer-app: 3.1.2 -> 3.1.3
* [`bf5dfce2`](https://github.com/NixOS/nixpkgs/commit/bf5dfce26cb71c8d98024b5f461a6da703c8e965) secretspec: 0.3.1 -> 0.3.3
* [`7e530994`](https://github.com/NixOS/nixpkgs/commit/7e53099454fec85d576b7259c4284eb737cbf0d8) andcli: 2.4.0 -> 2.4.1
* [`6717c331`](https://github.com/NixOS/nixpkgs/commit/6717c331a5b69a9f0cf3022ff619342e45f6e934) capnproto: add patch to fix powerpc-linux build
* [`cce88bbc`](https://github.com/NixOS/nixpkgs/commit/cce88bbc7321caf58ad13ad111cdea41447b6741) positron-bin: 2025.08.0-130 -> 2025.09.0-139
* [`cf8d84ac`](https://github.com/NixOS/nixpkgs/commit/cf8d84ac3f80729f39dde62edb672021b3b8ef12) chirp: 0.4.0-unstable-2025-08-31 -> 0.4.0-unstable-2025-09-11
* [`4dd5f320`](https://github.com/NixOS/nixpkgs/commit/4dd5f320db9bf62e8f01329c79d58e76def7654c) python3Packages.langchain-ollama: 0.3.7 -> 0.3.8
* [`2cab5b2f`](https://github.com/NixOS/nixpkgs/commit/2cab5b2faa3952a387950aac2a7e75a599712fc5) dbus-broker: fix test-sockopt on kernel 6.16+
* [`f4b79cb5`](https://github.com/NixOS/nixpkgs/commit/f4b79cb58103f20853eb208eff9e6d70bb07254f) kotlin: 2.2.0 -> 2.2.20
* [`c25b4e07`](https://github.com/NixOS/nixpkgs/commit/c25b4e07d11bd07144453d61f30238df6e6fb3c1) _86Box-with-roms: 5.0 -> 5.1
* [`3b41a66a`](https://github.com/NixOS/nixpkgs/commit/3b41a66a68033ab214fee18c75b8cb9283801bd9) nixos/tests/bcachefs: update meta.maintainers
* [`0dc5a88f`](https://github.com/NixOS/nixpkgs/commit/0dc5a88ff8934b551a309ba36fcd8a278c8c5d89) xpra: 6.3.2 -> 6.3.3
* [`f6d9a910`](https://github.com/NixOS/nixpkgs/commit/f6d9a910e6dc73a2f893a0ab017c756a87761450) nixos/murmur: Hard-code log directory to /var/log/murmur
* [`821665b9`](https://github.com/NixOS/nixpkgs/commit/821665b9aa0bed5d790f23ad4b009d728cec5c4d) python3Packages.pyjnius: 1.6.1 -> 1.7.0
* [`c73a74fa`](https://github.com/NixOS/nixpkgs/commit/c73a74fa7e86493882add83651ae8f14b686be3a) python3Packages.firedrake-fiat: 2025.4.1 -> 2025.4.2
* [`202e99a7`](https://github.com/NixOS/nixpkgs/commit/202e99a7a9f6605b9f623a275caa1c49f50297cf) xdp-tools: fix cross compilation
* [`2f7e2308`](https://github.com/NixOS/nixpkgs/commit/2f7e23086db39787f660a74767c4383b2fc8a63d) knot-dns: fix cross compilation
* [`3b6880db`](https://github.com/NixOS/nixpkgs/commit/3b6880db8776bdfbf09086682527293907e48f55) lunatask: 2.1.6 -> 2.1.7
* [`9e45a940`](https://github.com/NixOS/nixpkgs/commit/9e45a94074457b3b24cf9edfb3e125d8a5154dc6) deno: remove obsolete LTO fix
* [`683d26f3`](https://github.com/NixOS/nixpkgs/commit/683d26f3512693313d912908408abf16f7256f2c) home-assistant-custom-components.climate_group: 1.0.7 -> 1.0.8
* [`da6ae9da`](https://github.com/NixOS/nixpkgs/commit/da6ae9da92512151d869e8ed8e35544e9d29a2ca) gallery-dl: 1.30.6 -> 1.30.7
* [`6a83e112`](https://github.com/NixOS/nixpkgs/commit/6a83e11268ba94bee6e2f906f5e0f56448453824) f2: 2.2.0 -> 2.2.1
* [`34f8ebc7`](https://github.com/NixOS/nixpkgs/commit/34f8ebc70db557b0b3bf2f53000d5d2898b88069) metabase: 0.54.1 -> 0.56.5
* [`2bbce79b`](https://github.com/NixOS/nixpkgs/commit/2bbce79b7f9054a9557d7b3127051dbdf54215ef) pythonPackages.apycula: 0.21 -> 0.25
* [`79752420`](https://github.com/NixOS/nixpkgs/commit/79752420ae1438c86d4b0372fdf681cd8158a222) lunasvg: 3.4.0 -> 3.5.0
* [`daf33929`](https://github.com/NixOS/nixpkgs/commit/daf339296fecabf9375ec2d56fffc9e580a53ffe) imake: add support for riscv and loongarch
* [`6353e039`](https://github.com/NixOS/nixpkgs/commit/6353e03956a649e773cace82229496f68c0d11a0) lucide: 0.541.0 -> 0.544.0
* [`982ede41`](https://github.com/NixOS/nixpkgs/commit/982ede4108972fad3e7f7e77f08039ebeaa78402) nixos/tests/zeronet: update meta.maintainers
* [`9daf1fa7`](https://github.com/NixOS/nixpkgs/commit/9daf1fa76cc2e4bf8201782ba28d750035283816) dumb: remove
* [`25229a53`](https://github.com/NixOS/nixpkgs/commit/25229a538ed4775e089d98eb7f0b78e4c8ca79c1) prboom-plus: remove
* [`1c5a1d77`](https://github.com/NixOS/nixpkgs/commit/1c5a1d77f87594f3e8fa6bcdad2983b69864ac7b) maintainers: remove Madouura
* [`c4b84412`](https://github.com/NixOS/nixpkgs/commit/c4b84412a2f0cbba05f078ca8252c22c74aa5d52) powersupply: 0.9.0 -> 0.10.1
* [`5e2801ab`](https://github.com/NixOS/nixpkgs/commit/5e2801ab5f303db32ddb31e76fc7c122be73b6ff) vscode-extensions.anthropic.claude-code: 1.0.112 -> 1.0.113
* [`62da676c`](https://github.com/NixOS/nixpkgs/commit/62da676c2744936f4c520f4eca287d54779acd4c) delineate: 0.1.0 -> 0.1.1
* [`517bece4`](https://github.com/NixOS/nixpkgs/commit/517bece4b136642ceeb17c47bd52ea67bb9127ca) openlinkhub: 0.6.2 -> 0.6.4
* [`053d5f37`](https://github.com/NixOS/nixpkgs/commit/053d5f37ec3ec0017db953317fde0cd68fea086d) mitscheme: unpin texinfo
* [`6523fb57`](https://github.com/NixOS/nixpkgs/commit/6523fb57e0548a2d0e8a13b9f6114c8f2464074e) burpsuite: 2025.8.2 -> 2025.9.1
* [`7a623736`](https://github.com/NixOS/nixpkgs/commit/7a623736b539d226287c648e0324dee143bf2959) xray: 25.8.3 -> 25.9.11
* [`7ed14dba`](https://github.com/NixOS/nixpkgs/commit/7ed14dba14176ce527d0eaa0e12e6908ffe625ab) v2ray: 5.38.0 -> 5.39.0
* [`30a597b1`](https://github.com/NixOS/nixpkgs/commit/30a597b1fef7e9a3627b8dd0e13a000ba00c1c92) zashboard: 1.103.0 -> 1.103.1
* [`e84019f8`](https://github.com/NixOS/nixpkgs/commit/e84019f8c872ed2a9bbb5195e3437a21cf1d792e) libretro.flycast: 0-unstable-2025-08-29 -> 0-unstable-2025-09-12
* [`7762e682`](https://github.com/NixOS/nixpkgs/commit/7762e6827b0f2c4a207b3db761ddd2ed9bef9908) python3Packages.llama-index-embeddings-openai: 0.5.0 -> 0.5.1
* [`ec9cca39`](https://github.com/NixOS/nixpkgs/commit/ec9cca395924cbca80d3c46c6f0f866a168c0b01) openvas-scanner: 23.24.0 -> 23.27.0
* [`5be8a792`](https://github.com/NixOS/nixpkgs/commit/5be8a792bad80f33636f7e08260849b43fdf6443) nzbhydra2: 7.16.1 -> 7.16.3
* [`3b4558ba`](https://github.com/NixOS/nixpkgs/commit/3b4558ba9c093a94e8b41a35f334ee1190feae25) python3Packages.pkg-about: 1.5.0 -> 2.0.1
* [`8190e4d4`](https://github.com/NixOS/nixpkgs/commit/8190e4d4a600cc3d2cd3bde8d93c2e4a2afe367a) cilium-cli: 0.18.6 -> 0.18.7
* [`443a8b8c`](https://github.com/NixOS/nixpkgs/commit/443a8b8c04ae8fd8e102db008f137a100f8a55ac) python3Packages.decli: 0.6.1 -> 0.6.3
* [`1254586f`](https://github.com/NixOS/nixpkgs/commit/1254586fce41a52047700b8bf35a67074ecffb07) commitizen: remove from python3Packages
* [`0616a7c1`](https://github.com/NixOS/nixpkgs/commit/0616a7c13933be18d32c480624db691dd59582f0) commitizen: 4.8.3 -> 4.9.1
* [`d35ec6ac`](https://github.com/NixOS/nixpkgs/commit/d35ec6acd230409d1f4c6b1ee029985e9dbdb7b5) commitizen: modernize
* [`7ff8d287`](https://github.com/NixOS/nixpkgs/commit/7ff8d287b04e5e1c87954e78533c96175a054631) bosh-cli: 7.9.10 -> 7.9.11
* [`acd4fdee`](https://github.com/NixOS/nixpkgs/commit/acd4fdeed4f9b2abf1bfd3276b034071999cf44a) mdsf: 0.10.6 -> 0.10.7
* [`9b7b2906`](https://github.com/NixOS/nixpkgs/commit/9b7b290696dbe0a7a5f599d52ff7dbb35082a1f7) python313Packages.flake8-import-order: fetch src from GitHub
* [`9da2aa59`](https://github.com/NixOS/nixpkgs/commit/9da2aa59373beda8aadfbd81b12507acf482f292) mise: 2025.8.20 -> 2025.9.10
* [`33374ffe`](https://github.com/NixOS/nixpkgs/commit/33374ffea23ddf7fddcb7a027fe5cb1a51777a10) python3Packages.ultralytics: 8.3.193 -> 8.3.199
* [`42339f4d`](https://github.com/NixOS/nixpkgs/commit/42339f4d0d1b8e17b17207c8aaaa5511342aff82) airwin2rack: 2.13.0-unstable-2025-04-07 -> 2.13.0-unstable-2025-09-14
* [`49272868`](https://github.com/NixOS/nixpkgs/commit/49272868d3729caf489ef9f73caacd0010da1300) svtplay-dl: 4.131 -> 4.137
* [`a4122c11`](https://github.com/NixOS/nixpkgs/commit/a4122c1104e2c23b5be9130cf2e0c1a58a3eedf7) sgt-puzzles: 20250730.a7c7826 -> 20250904.2376227
* [`35908b4c`](https://github.com/NixOS/nixpkgs/commit/35908b4c2489e99814af24170386b87fffcce889) pdfcrack: 0.20 -> 0.21
* [`90e1c6a4`](https://github.com/NixOS/nixpkgs/commit/90e1c6a44468128746adb28c1c34e977811012ce) python3Packages.llama-index-readers-twitter: 0.4.0 -> 0.4.1
* [`078378e2`](https://github.com/NixOS/nixpkgs/commit/078378e220de4ac27cbf9c608c830b4738a01c3d) python3Packages.sonos-websocket: remove async-timeout dependency
* [`7b088b48`](https://github.com/NixOS/nixpkgs/commit/7b088b48773ea79fea0ef09fce51b4786cfe0dbd) protoc-gen-es: 2.7.0 -> 2.8.0
* [`a3a245c6`](https://github.com/NixOS/nixpkgs/commit/a3a245c653686aab45c5ae6233d6e91769dcc992) python3Packages.bluetooth-auto-recovery: only use async-timeout on Python < 3.11
* [`6223b4d2`](https://github.com/NixOS/nixpkgs/commit/6223b4d2dc3159718312bef6586c9eab77159f06) mpvScripts.uosc: 5.11.0 -> 5.12.0
* [`b7e115c6`](https://github.com/NixOS/nixpkgs/commit/b7e115c6c64c4f458617e265a2f03f8f09ad778a) python3Packages.bleak: only use async-timeout on Python < 3.11
* [`0c18f6b0`](https://github.com/NixOS/nixpkgs/commit/0c18f6b0c3d3ea200cce0ed13879843841f8508f) python3Packages.spyder-kernels: run tests
* [`ebb0571f`](https://github.com/NixOS/nixpkgs/commit/ebb0571f9e742543455737b2b5876acf6c600c16) astal.source: 0-unstable-2025-08-29 -> 0-unstable-2025-09-10
* [`dee72805`](https://github.com/NixOS/nixpkgs/commit/dee728054a797450f653ec590985b2bdbca2040c) vscode-extensions.discloud.discloud: 2.26.3 -> 2.27.0
* [`1b524728`](https://github.com/NixOS/nixpkgs/commit/1b5247288b31a2c98de2c17670f1efe6929edc81) nextpnr: 0.8 -> 0.9
* [`648f1f96`](https://github.com/NixOS/nixpkgs/commit/648f1f96489c29df7d63ec765c28f2c88ab1e3ba) yandex-music: workaround of release circle
* [`1e788edb`](https://github.com/NixOS/nixpkgs/commit/1e788edb892a8c6c00b3669f06db34e64e511352) hyprlandPlugins.mkHyprlandPlugin: support finalAttrs through lib.extendMkDerivation
* [`5b875c08`](https://github.com/NixOS/nixpkgs/commit/5b875c0881c926e0f2a56a5d999adffa4f3006c9) athens: 0.16.0 -> 0.16.1
* [`2a5f7563`](https://github.com/NixOS/nixpkgs/commit/2a5f75635f760330bf3780425e52e506a913d9e8) chameleon-cli: 2.1.0-unstable-2025-09-02 -> 2.1.0-unstable-2025-09-12
* [`9c11b648`](https://github.com/NixOS/nixpkgs/commit/9c11b648b3740433524f54440f40ecfb43641b51) kubectl-view-secret: 0.14.0 -> 0.15.0
* [`dfdfb482`](https://github.com/NixOS/nixpkgs/commit/dfdfb482cf4e87523e2ac12ff610a8a0e8c3fa65) ipv6calc: 4.3.3 -> 4.4.0
* [`b279da7f`](https://github.com/NixOS/nixpkgs/commit/b279da7fadbc897ca8921cc25bd42f0f63ba9af3) weaviate: 1.32.5 -> 1.32.8
* [`da022486`](https://github.com/NixOS/nixpkgs/commit/da0224864ac931b4fc56395efcf9e02094beb3f8) python3Packages.rio-stac: 0.11.1 -> 0.11.2
* [`68368b64`](https://github.com/NixOS/nixpkgs/commit/68368b6466789e3d79c85d2693fc1c5a9bb1558f) ddev: fix embedded version and testVersion
* [`7a345b93`](https://github.com/NixOS/nixpkgs/commit/7a345b93400c23229e2981feca9ff7ee3cd6355d) python3Packages.scalar-fastapi: 1.3.0 -> 1.4.0
* [`fc42f909`](https://github.com/NixOS/nixpkgs/commit/fc42f909775842b1fa4c44edb5d728e7e49e1b8c) yash: 2.59 -> 2.60
* [`e66f3eb1`](https://github.com/NixOS/nixpkgs/commit/e66f3eb102d323592025727c959de9845a007e71) mago: use `finalAttrs` pattern
* [`14789e1e`](https://github.com/NixOS/nixpkgs/commit/14789e1eace6b86f11e7c229bf08da1fbabd00c4) mago: use `versionCheckHook`
* [`3fa4584a`](https://github.com/NixOS/nixpkgs/commit/3fa4584a965bc364e7e1badf10bdc8394a706c91) mago: 0.26.1 -> 1.0.0-beta.14
* [`63a7dae8`](https://github.com/NixOS/nixpkgs/commit/63a7dae8bdb7a2ed25f9e6b65f16c09fd62034a9) cyclone-scheme: 0.34.0 -> 0.36.0, mark broken on darwin
* [`c025cec5`](https://github.com/NixOS/nixpkgs/commit/c025cec52c0106dad25b7ba9f82d0b1c3e1588a0) stevenblack-blocklist: 3.16.15 -> 3.16.18
* [`d37a03eb`](https://github.com/NixOS/nixpkgs/commit/d37a03eb5aebba58bd0ccb11f6f4a62133f9c45d) nixos/windmill: Fix database setup config
* [`c9377a2e`](https://github.com/NixOS/nixpkgs/commit/c9377a2ec726db0d5487375ec05450bddb1b1f30) nixos/windmill: Introduce systemd target unit
* [`ca9c50c3`](https://github.com/NixOS/nixpkgs/commit/ca9c50c34c89756bcf3fb47f6671fb4bf0039b48) crewai: 0.175.0 -> 0.186.1
* [`cc4daa3d`](https://github.com/NixOS/nixpkgs/commit/cc4daa3d28872192a585423e450c705617a13142) hyprlandPlugins.hy3: hl0.50.0 -> hl0.51.0
* [`df5fa3c1`](https://github.com/NixOS/nixpkgs/commit/df5fa3c19e5553fe05dde6b53f423723efbb3973) hyprland-plugins: 0.50.0 -> 0.51.0
* [`be6b98a8`](https://github.com/NixOS/nixpkgs/commit/be6b98a88e119c5164928169e12fc50b21cd4e5b) python3Packages.llama-index-cli: 0.5.0 -> 0.5.1
* [`f8ffbe9e`](https://github.com/NixOS/nixpkgs/commit/f8ffbe9e898d9489bc7a80ab448988b0c37a99ff) proxmox-auto-install-assistant: 8.4.6 -> 9.0.7
* [`aea3a730`](https://github.com/NixOS/nixpkgs/commit/aea3a7309a7ad8f964b6d1499254627f05fda8ff) home-assistant-custom-components.octopus_energy: 16.2.0 -> 16.3.1
* [`35b592ba`](https://github.com/NixOS/nixpkgs/commit/35b592ba0cf6b809abb6d25c9ab9860ea9ebdfc4) terraform-compliance: 1.3.52 -> 1.13.0
* [`24b4ffa2`](https://github.com/NixOS/nixpkgs/commit/24b4ffa277621b893ba21e1af24cbc22e4473c8c) renderdoc: 1.39 -> 1.40
* [`880da65f`](https://github.com/NixOS/nixpkgs/commit/880da65f2581cc681a72f730a468b8e9415cc377) xdg-desktop-portal-shana: 0.3.15 -> 0.3.16
* [`7aa09595`](https://github.com/NixOS/nixpkgs/commit/7aa09595a3a62abe5da0fd7eb2c0e1c72a899753) mari0: 1.6.2 -> 1.6.2-unstable-2023-08-08
* [`f198c604`](https://github.com/NixOS/nixpkgs/commit/f198c6044b0d1d6a3fa156782609a0824109d678) hydra: 0-unstable-2025-08-12 -> 0-unstable-2025-09-13
* [`097a8db7`](https://github.com/NixOS/nixpkgs/commit/097a8db79aeea10ca8666885e0ebfd4e7e345e9b) bluej: fix illegal import
* [`643074cf`](https://github.com/NixOS/nixpkgs/commit/643074cfe6e35daa35bed06e2c91831679576c14) python313Packages.django-guardian: 3.1.0 -> 3.1.3
* [`84dea966`](https://github.com/NixOS/nixpkgs/commit/84dea966532e0e4de4dfd2a3a6f488ebfd67479d) rucio: 38.0.0 -> 38.2.0
* [`ddd38aa8`](https://github.com/NixOS/nixpkgs/commit/ddd38aa8f18ddc840ac1e066153cda44e0017121) pwdsafety: 0.4.0 -> 0.4.1
* [`bea21f65`](https://github.com/NixOS/nixpkgs/commit/bea21f650faf5c5631800d0b5b9fe6e1d9d95ae8) nixos/pantheon: Drop services.xserver.updateDbusEnvironment
* [`9aabcd17`](https://github.com/NixOS/nixpkgs/commit/9aabcd1721a25d399f9c7aa1912a24ccf5502993) pantheon.switchboard-plug-applications: 8.1.0 -> 8.2.0
* [`faadbfc4`](https://github.com/NixOS/nixpkgs/commit/faadbfc4b80998a085a286263f0fada4b2f26417) pantheon.wingpanel-quick-settings: 1.2.0 -> 1.3.0
* [`dab21639`](https://github.com/NixOS/nixpkgs/commit/dab21639eb73d96a3fe83a30d1807fc7a553f7f1) pantheon.elementary-session-settings: Allow disabling x11 session
* [`a08b2c64`](https://github.com/NixOS/nixpkgs/commit/a08b2c64f9193a84c156ffa692b02c405dc2fe14) giada: 1.2.1 -> 1.3.0
* [`79085443`](https://github.com/NixOS/nixpkgs/commit/79085443e53258a84962c359dcaed4aeb0739c63) python3Packages.cohere: 5.17.0 -> 5.18.0
* [`2e112cc7`](https://github.com/NixOS/nixpkgs/commit/2e112cc714a0cc0b5031df11a670adbd7df22129) aribb24: make use of autoreconfHook
* [`152f63f7`](https://github.com/NixOS/nixpkgs/commit/152f63f7dafa56e72ac3591f86e3eaaec585e5c0) pocketsphinx: enable doCheck
* [`ab731e3c`](https://github.com/NixOS/nixpkgs/commit/ab731e3cef7ad44410001e9d392e63637c82afaa) vvenc: enable doCheck
* [`c8a31e68`](https://github.com/NixOS/nixpkgs/commit/c8a31e68b3b7ca9aac72cde2aceaaec64fc5f056) victoriametrics: 1.125.1 -> 1.126.0
* [`149f91cc`](https://github.com/NixOS/nixpkgs/commit/149f91cc0858f443b5aba266e51a9825633249dc) xfce.thunar: 4.20.4 -> 4.20.5
* [`73c79f9d`](https://github.com/NixOS/nixpkgs/commit/73c79f9daef29461f61b95af398f60de6f989f06) espeak-ng: 1.51.1 -> 1.52.0
* [`3ec2ba5c`](https://github.com/NixOS/nixpkgs/commit/3ec2ba5c24615c6f26537b712980a197a8116fb5) espeak-ng: build with ucd support
* [`bc541d82`](https://github.com/NixOS/nixpkgs/commit/bc541d82752ff8435207b1fa853b1bccd34a3570) espeak-ng: backport TextToPhonemesWithTerminator support
* [`676ed7c1`](https://github.com/NixOS/nixpkgs/commit/676ed7c17b147dd3266fd7ad10a86197d4181379) piper-tts: 2023.11.14-2 -> 1.3.0
* [`a30a92ba`](https://github.com/NixOS/nixpkgs/commit/a30a92bac1435777e2fb781b1ef31672ddbb6639) piper-train: drop
* [`f00a7cb7`](https://github.com/NixOS/nixpkgs/commit/f00a7cb75e6b97835ec881e25fcd7a525fdee428) nixos/wyoming/piper: add per-server CUDA toggle
* [`25dcf1ac`](https://github.com/NixOS/nixpkgs/commit/25dcf1ac1ceb7082f45ebb0f14f7119b2ad9d35e) local-ai: piper-tts doesn't want phonemize anymore
* [`58cf0a2b`](https://github.com/NixOS/nixpkgs/commit/58cf0a2b7bf057ed97a04846e5cef002f4086c1c) octoprint: 1.11.2 -> 1.11.3
* [`3bbaab61`](https://github.com/NixOS/nixpkgs/commit/3bbaab61847dfddba7c6c5ae1197e4a914886f90) ifstate: 2.0.0 -> 2.0.1
* [`7a41bc00`](https://github.com/NixOS/nixpkgs/commit/7a41bc00c46b6b2a30ff81fa549fe13cd4e77f1e) reth: 1.6.0 -> 1.7.0
* [`eb497d15`](https://github.com/NixOS/nixpkgs/commit/eb497d15d4ceccb38e0610a81bb71ee99bac7770) onedrivegui: 1.2.1 -> 1.2.2
* [`7b68a993`](https://github.com/NixOS/nixpkgs/commit/7b68a993ad79a2024a75751128c1220d1bfdbf90) vimPlugins.blink-cmp: 1.6.0 -> 1.7.0
* [`8a67c5a5`](https://github.com/NixOS/nixpkgs/commit/8a67c5a5baafae948e19aaa5f757cd8aff369700) hyprlandPlugins.hy3: fix update script pattern matching
* [`0237933b`](https://github.com/NixOS/nixpkgs/commit/0237933bea436aa117b908d5d5e915c6ebe3b1b3) python3Packages.tsfresh: 0.21.0 -> 0.21.1
* [`f26637c4`](https://github.com/NixOS/nixpkgs/commit/f26637c478ed0188dd9091c1f0387466473b6754) terraform-providers.rabbitmq: 1.8.0 -> 1.10.1
* [`539a8b7c`](https://github.com/NixOS/nixpkgs/commit/539a8b7cd027b667fd01ec763dff2fbb1d585908) ghostty: 1.1.3 -> 1.2.0
* [`b3fd043d`](https://github.com/NixOS/nixpkgs/commit/b3fd043d72839a569a085784e03e332fcd222358) ghostty-bin: 1.1.3 -> 1.2.0
* [`6c726de7`](https://github.com/NixOS/nixpkgs/commit/6c726de7268aabd6be3a69aab4a1543f53cb5506) kexec-tools: mark powerpc-linux as bad platform
* [`4fa3ecb2`](https://github.com/NixOS/nixpkgs/commit/4fa3ecb2ed79a0ad5e9fea8d47d05d8bf137e895) nix-search-tv: 2.2.0 -> 2.2.1
* [`0d1865a9`](https://github.com/NixOS/nixpkgs/commit/0d1865a9a4366880281402b02ca4536a5cf14983) ipopt: 3.14.18 -> 3.14.19
* [`6f6d35e6`](https://github.com/NixOS/nixpkgs/commit/6f6d35e618a51f95d9dcd5db980ad5cefc5f0f4e) goperf: 0-unstable-2025-08-13 -> 0-unstable-2025-09-09
* [`462b07e6`](https://github.com/NixOS/nixpkgs/commit/462b07e6bebe844d8263e3d7047616f11e5c17c8) smtp4dev: 3.9.0 -> 3.10.1
* [`eaeedfa3`](https://github.com/NixOS/nixpkgs/commit/eaeedfa32a66269eb03a4bec1d93e0976c9bca73) gersemi: 0.22.1 -> 0.22.2
* [`0fe9e0d6`](https://github.com/NixOS/nixpkgs/commit/0fe9e0d61d795f7ed180b5bfb23e5627160b351c) bun: 1.2.21 -> 1.2.22
* [`37f4e53d`](https://github.com/NixOS/nixpkgs/commit/37f4e53db56923761952cacf15a1f8f26d820f66) open5gs{,-webui}: fix webui
* [`14841895`](https://github.com/NixOS/nixpkgs/commit/14841895e581672be04a0e71f19242464f21f6bc) mpv: add `StartupNotify=false` to umpv.desktop
* [`f32c62db`](https://github.com/NixOS/nixpkgs/commit/f32c62dbd2099756f9f3aa500955bf74c23d82eb) mdns-scanner: 0.23.1 -> 0.24.0
* [`c6df0292`](https://github.com/NixOS/nixpkgs/commit/c6df0292bcfe82556106b6b8fbf6bf4b3d8b91eb) metal-cli: 0.25.0 -> 0.26.0
* [`ed53ac40`](https://github.com/NixOS/nixpkgs/commit/ed53ac40fe6c592cd82731b45789a790e781c7ac) plakar: 1.0.3 -> 1.0.4
* [`211d7207`](https://github.com/NixOS/nixpkgs/commit/211d72079e8df8433e28b69176596b849185bf70) music-discord-rpc: 0.6.1 -> 0.6.2
* [`318f5b6c`](https://github.com/NixOS/nixpkgs/commit/318f5b6c91ecf071f6bae8240a7c845e8e529f53) dolibarr: 22.0.0 -> 22.0.1
* [`aa5693fc`](https://github.com/NixOS/nixpkgs/commit/aa5693fc1933a4452ba04efd68373996aca43483) onnxruntime: 1.22.0 -> 1.22.2
* [`62b9d54f`](https://github.com/NixOS/nixpkgs/commit/62b9d54f7824824c2681b924eef07b6718b464ff) python3Packages.onnx: 1.18.0 -> 1.19.0
* [`0a622049`](https://github.com/NixOS/nixpkgs/commit/0a6220495c292f37799b687d8e7fd151765ce165) python3Packages.onnxruntime-tools: cleanup
* [`1a29ea37`](https://github.com/NixOS/nixpkgs/commit/1a29ea3780b398b27fa166780e301532a2da9923) python3Packages.onnxslim: 0.1.62 -> 0.1.68
* [`a3b8cc13`](https://github.com/NixOS/nixpkgs/commit/a3b8cc13e02e5304d0f46531ec01fadcbeb2bbce) python3Packages.onnxruntime: remove commented dependencies
* [`5c980855`](https://github.com/NixOS/nixpkgs/commit/5c980855c5e0f67593a6fae39678fca3f1f77917) python3Packages.onnxconverter-common: 1.15.0 -> 0.16.0
* [`3980e3a3`](https://github.com/NixOS/nixpkgs/commit/3980e3a3fb93cc181ba68cbf8700c6881ba5132d) uw-ttyp0: 1.3 -> 2.1
* [`403ef9ab`](https://github.com/NixOS/nixpkgs/commit/403ef9abb3e984661c2778198cca830e902e47c8) dmenu-rs: Fix build failure
* [`171131fd`](https://github.com/NixOS/nixpkgs/commit/171131fdd24e0e69cce39cc06fa817a33f9a37d8) taterclient-ddnet: 10.5.0 -> 10.5.2
* [`49c5cfd3`](https://github.com/NixOS/nixpkgs/commit/49c5cfd30723951a35d570f54b2c6277e3effa8b) ijq: 1.1.2 -> 1.2.0
* [`8bebc052`](https://github.com/NixOS/nixpkgs/commit/8bebc052ee61d446b093e2cbf8dd51384bd5df51) rustdesk: 1.4.1 -> 1.4.2
* [`caddb361`](https://github.com/NixOS/nixpkgs/commit/caddb361966e9cc390a6527842374b579e3dd633) nixosTests.lxd: remove references to removed test
* [`ee4b3f9f`](https://github.com/NixOS/nixpkgs/commit/ee4b3f9fac8a99c6f688d49a1e6ec77e1e361f75) python3Packages.pypng: ref -> tag, nativeBuildInputs -> build-system
* [`f20ed971`](https://github.com/NixOS/nixpkgs/commit/f20ed971f4df61a7aec806d53e87153e8be0517d) python3Packages.pypng: update homepage
* [`32b6f6f2`](https://github.com/NixOS/nixpkgs/commit/32b6f6f267c4d9b965c6224b42885b7a269facdc) python3Packages.pypng: 0.20220715.0 -> 0.20231004.0
* [`f68891f1`](https://github.com/NixOS/nixpkgs/commit/f68891f1c05930ef02b561c9ac93bce34dc3c1e2) python3Packages.crewai: 0.175.0 -> 0.186.1
* [`f4051a29`](https://github.com/NixOS/nixpkgs/commit/f4051a29d2e3f73045d38160585c859c6f21913a) ddev: use versionCheckHook
* [`1bbea44f`](https://github.com/NixOS/nixpkgs/commit/1bbea44fde840b6af0768ce6ba04b0c7f02aaed0) crawley: 1.7.12 -> 1.7.13
* [`0a3ce757`](https://github.com/NixOS/nixpkgs/commit/0a3ce757a8e45abdc89142077addeb7cd7ac6556) python3Packages.cleanlab: mark as broken (incompatible with datasets 4.0.0)
* [`f7a05100`](https://github.com/NixOS/nixpkgs/commit/f7a0510047928d781f8548640c3ccc009371d5d1) swift: don’t build LLVM tools
* [`37552f07`](https://github.com/NixOS/nixpkgs/commit/37552f074ac3404632abc8eb9ce8c02825e76742) python3Packages.onnxmltools: fix by removing outdated patch
* [`1d4e7fe6`](https://github.com/NixOS/nixpkgs/commit/1d4e7fe6953ab278310abeb3e3c61bc2158b757e) python3Packages.qtconsole: 5.6.1 -> 5.7.0
* [`c71ffb21`](https://github.com/NixOS/nixpkgs/commit/c71ffb21a9d0adcf785c5bd3a0bd69bd0a650b57) pypy: fix eval
* [`743ae5d2`](https://github.com/NixOS/nixpkgs/commit/743ae5d20c55b4f84cede9a2be57a72ad30263ea) pypy: fix installPhase
* [`8795f77e`](https://github.com/NixOS/nixpkgs/commit/8795f77e6d33c89f0bd62785509990697d77c4cd) python3Packages.optax: 0.2.5 -> 0.2.6
* [`c3e2ccfc`](https://github.com/NixOS/nixpkgs/commit/c3e2ccfc5a50c3335cb286a95bc93b6d3bb75e76) scala-next: 3.7.1 -> 3.7.3
* [`2d56b80c`](https://github.com/NixOS/nixpkgs/commit/2d56b80ce3b6f25888ff904218ec2209c545e9a3) python3Packages.kaitaistruct: 0.10 -> 0.11
* [`21d9c45b`](https://github.com/NixOS/nixpkgs/commit/21d9c45bbba5e3f8b5ddaf4a4da243559531ce4a) nirius: init at 0.4.3
* [`bb733d67`](https://github.com/NixOS/nixpkgs/commit/bb733d678d5129c6bac07765aa304d0d8f7da334) calibre: prevent ninja build
* [`9d792b0c`](https://github.com/NixOS/nixpkgs/commit/9d792b0c11ae0754b36c4322b58d335c10b67d1a) gopass-summon-provider: 1.15.16 -> 1.15.17
* [`97c3140a`](https://github.com/NixOS/nixpkgs/commit/97c3140ab839be76c5a93128e61bbde06738e760) intel-graphics-compiler: 2.16.0 -> 2.18.5
* [`e5dd233b`](https://github.com/NixOS/nixpkgs/commit/e5dd233b0c526a743136eb548898e9df8aefef1f) eask-cli: 0.11.7 -> 0.11.8
* [`4ad5afa8`](https://github.com/NixOS/nixpkgs/commit/4ad5afa8f13aa2bdbf7591cc3131d6e79688a66b) spidermonkey_140: 140.2.0 -> 140.3.0
* [`014ced7e`](https://github.com/NixOS/nixpkgs/commit/014ced7eda7e97cab969190d18abe250a7b3b5a2) grpc_cli: 1.74.1 -> 1.75.0
* [`92bf7141`](https://github.com/NixOS/nixpkgs/commit/92bf71414e35fe40a2be79692baf67063df5357e) freeipmi: 1.6.15 -> 1.6.16
* [`e336770a`](https://github.com/NixOS/nixpkgs/commit/e336770aeed842ec4efb9099b30ddf6381eb526c) grype: 0.99.1 -> 0.100.0
* [`27bbe639`](https://github.com/NixOS/nixpkgs/commit/27bbe639ae20c89a081a4ab0d9f8e83ae9dd9e2d) codeberg-cli: 0.4.11 -> 0.5.0
* [`0be20397`](https://github.com/NixOS/nixpkgs/commit/0be203976a665f1baf3ea4ef2c96bbd0f5625dab) python3Packages.mcdreforged: 2.15.1 -> 2.15.2
* [`f174168f`](https://github.com/NixOS/nixpkgs/commit/f174168faf90d77da831e880685d525cf8cf0131) python3Packages.molecule: 25.7.0 -> 25.9.0
* [`0686782a`](https://github.com/NixOS/nixpkgs/commit/0686782a7d7d439ada0bffec02cb87ee22229f97) mint-l-theme: 2.0.1 -> 2.0.2
* [`65b0da63`](https://github.com/NixOS/nixpkgs/commit/65b0da63a357fbf03de75f2dc1e0e6298f836d66) llama-cpp: 6442 -> 6479
* [`19da8779`](https://github.com/NixOS/nixpkgs/commit/19da87792f417276c7d289200708b4af6fd2c6d6) python3Packages.thriftpy2: apply upstream patch to remove toml dep
* [`4c708466`](https://github.com/NixOS/nixpkgs/commit/4c7084667d224936bb8064d80e12a23d2c5671ab) vscode-extensions.charliermarsh.ruff: 2025.24.0 -> 2025.26.0
* [`ac2a8330`](https://github.com/NixOS/nixpkgs/commit/ac2a83303b83b91f7b9d0c584ce70fd2ad713c5f) noto-fonts-color-emoji: 2.048 -> 2.051
* [`4196905d`](https://github.com/NixOS/nixpkgs/commit/4196905d20a47a8cbe31473a2bc40a72a36be9b2) libmusicbrainz: libmusicbrainz_3 -> libmusicbrainz_5
* [`7ae890f1`](https://github.com/NixOS/nixpkgs/commit/7ae890f16ea7f3b3b8e709da921d003b25a7379c) libmusicbrainz3: drop
* [`bb35c2a6`](https://github.com/NixOS/nixpkgs/commit/bb35c2a6b7fccc90d3e02b24e76da2e3bbd7dd07) treewide: libmusicbrainz5 -> libmusicbrainz
* [`e5d6c617`](https://github.com/NixOS/nixpkgs/commit/e5d6c617cf5673b6f66da328c46cde954047c672) libmusicbrainz5: move to aliases
* [`443539a9`](https://github.com/NixOS/nixpkgs/commit/443539a91c246cbbf76cca57fdbb9cbb20b78be6) libmusicbrainz: move to `by-name`
* [`8b2b6233`](https://github.com/NixOS/nixpkgs/commit/8b2b6233df75ef979c82af5a9c8aaf238522ffda) libmusicbrainz: 5.1.0 -> 5.1.0-unstable-2025-07-12
* [`bfa1361a`](https://github.com/NixOS/nixpkgs/commit/bfa1361ad136bc405a3a289aa37f3e7f3dc76af9) freecell-solver: remove unused `libtap` dependency
* [`1d56920e`](https://github.com/NixOS/nixpkgs/commit/1d56920ef790267c99fd3d9262dfc6ffdc7c7236) libtap: drop
* [`5ec16659`](https://github.com/NixOS/nixpkgs/commit/5ec1665962fd5a7a3572a642e57c536a185712ee) osm2xmap: drop
* [`61b477f6`](https://github.com/NixOS/nixpkgs/commit/61b477f6726e915b19b33e445d20f33ff8a2b743) proj_7: drop
* [`5fc1d432`](https://github.com/NixOS/nixpkgs/commit/5fc1d4322e3ea2374c0a9e3e04aee33af2c7fdf2) proj: move to `by-name`
* [`a7b76dbe`](https://github.com/NixOS/nixpkgs/commit/a7b76dbe5a0b0df38c159df72fcf9e9ecf4731a8) yaml-cpp_0_3: drop
* [`b214834c`](https://github.com/NixOS/nixpkgs/commit/b214834cb4356d56964a6e822cd1b89de63731f3) yaml-cpp: move to `by-name`
* [`798a52c3`](https://github.com/NixOS/nixpkgs/commit/798a52c35c680c65fa509091da68da7c8a036e55) yaml-cpp: backport patch for CMake 4
* [`f20d1087`](https://github.com/NixOS/nixpkgs/commit/f20d10875f4f8e6fc716388fad13b13855e85f8e) snx-rs: 4.7.0 -> 4.8.0
* [`a4a7fc30`](https://github.com/NixOS/nixpkgs/commit/a4a7fc303eb2225797e405330cef114ddd03a931) readsb: 3.16.1 -> 3.16.2
* [`907237de`](https://github.com/NixOS/nixpkgs/commit/907237de15ee525b7af411ff63c39c00dd62dc49) luau: 0.690 -> 0.691
* [`213874ad`](https://github.com/NixOS/nixpkgs/commit/213874adfa6d249cddc06de9c5cd8b517144e3f4) sioyek: 2.0.0-unstable-2025-08-08 -> 2.0.0-unstable-2025-09-09
* [`fb661d53`](https://github.com/NixOS/nixpkgs/commit/fb661d533ae6d8addc60b9ca5b4c2b85d9022753) is-fast: 0.17.0 -> 0.17.2
* [`ad7b1a56`](https://github.com/NixOS/nixpkgs/commit/ad7b1a561b0bf3c34452233a6237e55790fe78c4) doc/release-notes: mention uw-ttyp0 update
* [`0821971e`](https://github.com/NixOS/nixpkgs/commit/0821971eccf0bee32d3dd635f0dd67800d72f337) vimPlugins: update on 2025-09-16
* [`263fc11c`](https://github.com/NixOS/nixpkgs/commit/263fc11c5b06d43b829953fc846794ce9e379134) vimPlugins.nvim-treesitter: update grammars
* [`6af380e5`](https://github.com/NixOS/nixpkgs/commit/6af380e5b413f0d0b4c77f06336a4cf9c42ea9b3) tldr: fix completion files for bash & zsh
* [`9b689829`](https://github.com/NixOS/nixpkgs/commit/9b6898292441e97cca52bdc12c4ab73bf239d7b8) exegol: 5.1.1 -> 5.1.2
* [`dcc218ab`](https://github.com/NixOS/nixpkgs/commit/dcc218ab3d37572b604ff98cb0585f39fda06c7e) luaPackages: update on 2025-09-16
* [`782981b1`](https://github.com/NixOS/nixpkgs/commit/782981b163250a6418f87b8b0a0ec954a311c424) yaziPlugins.recycle-bin: 0-unstable-2025-09-08 → 0-unstable-2025-09-15
* [`ae5f1aca`](https://github.com/NixOS/nixpkgs/commit/ae5f1aca84ed9ce133943e24cc0c979f99624241) terraform-providers.akamai: 8.1.0 -> 9.0.1
* [`e1e937c1`](https://github.com/NixOS/nixpkgs/commit/e1e937c16d0d35b75b976d604b7589e859f20fd6) libretro.dosbox-pure: 0-unstable-2025-09-04 -> 0-unstable-2025-09-14
* [`944ed42d`](https://github.com/NixOS/nixpkgs/commit/944ed42d8862bdfa8448d3edacfa151957e39f85) pyradio: 0.9.3.11.16 -> 0.9.3.11.18
* [`77f6b623`](https://github.com/NixOS/nixpkgs/commit/77f6b623941429a81e266f42a060e12b2211ec63) prek: 0.1.6 -> 0.2.1
* [`d0cbfc24`](https://github.com/NixOS/nixpkgs/commit/d0cbfc24c23b2aa72e5fc442a9616a1fdd346fed) ghstack: 0.11.0 -> 0.12.0
* [`36fc2725`](https://github.com/NixOS/nixpkgs/commit/36fc2725f2580c0c135d17de617713a119d9497c) zsh-vi-mode: 0.11.0 -> 0.12.0
* [`04e3e233`](https://github.com/NixOS/nixpkgs/commit/04e3e233b750d7946d2671c9c140fed80cd68e8b) harper: 0.63.0 -> 0.64.0
* [`cb449562`](https://github.com/NixOS/nixpkgs/commit/cb449562c881b7e43f7b6a7d85b213f1bc4615bf) avogadrolibs: 1.100.0 -> 1.101.0
* [`34c88a43`](https://github.com/NixOS/nixpkgs/commit/34c88a43509a46b58146cf55755a952353de8fc4) avogadro2: 1.100.0 -> 1.101.0
* [`28b8ab47`](https://github.com/NixOS/nixpkgs/commit/28b8ab477d538ce6e5acd56342141d1e714d6715) adw-gtk3: 6.2 -> 6.3
* [`b573b224`](https://github.com/NixOS/nixpkgs/commit/b573b2247dc67843d430a4b57fb011ba0c2d6d02) alt-tab-macos: 7.27.0 -> 7.28.0
* [`f6f862c7`](https://github.com/NixOS/nixpkgs/commit/f6f862c70072fbac565633c407809d9739d5f934) iina: 1.3.5 -> 1.4.0
* [`14e5736f`](https://github.com/NixOS/nixpkgs/commit/14e5736fa9f4e76743a8fd3bf79bfe3fe8558da7) yaralyzer: add updateScript
* [`2d9f87fd`](https://github.com/NixOS/nixpkgs/commit/2d9f87fd8e6522eb9dcd47f9e001e515d35a90c2) claude-code: 1.0.113 -> 1.0.115
* [`42379efb`](https://github.com/NixOS/nixpkgs/commit/42379efbd4a69f6ec7a664b24ec02c77b7ab177b) ipopt: adopt
* [`29514f5d`](https://github.com/NixOS/nixpkgs/commit/29514f5d92b8a0b3c899b697e2d992ed5fc1f890) home-assistant-custom-components.philips_airpurifier_coap: 0.34.0 -> 0.34.3
* [`1786c2fd`](https://github.com/NixOS/nixpkgs/commit/1786c2fd1437532f9798e219e41ab000e07462dd) volanta: 1.12.4 -> 1.13.2
* [`28890056`](https://github.com/NixOS/nixpkgs/commit/2889005621f7055a611ff1aff5b5618eaec26e3b) vtk: 9.5.0 -> 9.5.1
* [`460b5904`](https://github.com/NixOS/nixpkgs/commit/460b5904a6cdf06f971c5a4d145f26a15f84d979) corestore: 7.4.5 -> 7.4.7
* [`e938ba4d`](https://github.com/NixOS/nixpkgs/commit/e938ba4da9c74458ed7734a886fd480526263636) hm: init at 18.0
* [`1f675f27`](https://github.com/NixOS/nixpkgs/commit/1f675f274494393f5007b2367ed21c7c2bc5aa03) kvazaar: enable doCheck
* [`c0d59d7b`](https://github.com/NixOS/nixpkgs/commit/c0d59d7be2e448b0002da5602c770613747625a4) artichoke: 0-unstable-2025-08-18 -> 0-unstable-2025-09-07
* [`5e23831d`](https://github.com/NixOS/nixpkgs/commit/5e23831dc44d7ea5e8db1482f17b3962ca77b6fd) cobra-cli: fix generated zsh completion function
* [`f7703314`](https://github.com/NixOS/nixpkgs/commit/f7703314e8b1ba65ee228d5d8257353197fbeb2a) maintainers: add ipsavitsky
* [`76d92983`](https://github.com/NixOS/nixpkgs/commit/76d929833de739a9dbc363bbab488f00d3fba0e3) firmware-updater: 0-unstable-2024-20-11 -> 0-unstable-2025-09-09
* [`1d916135`](https://github.com/NixOS/nixpkgs/commit/1d916135fc33f945271995fbe0c62fabcbb0c9a9) dscanner: init at 0.15.2
* [`c0d41b54`](https://github.com/NixOS/nixpkgs/commit/c0d41b54d6635d3ff2982279ee15acd85c58401f) xenia-canary: 0-unstable-2025-08-22 -> 0-unstable-2025-09-14
* [`5bdecea1`](https://github.com/NixOS/nixpkgs/commit/5bdecea140af91896fdf31ddef70183a94b12765) nixos/ollama: add network-online.target to ollama-model-loader.service
* [`c1ca4528`](https://github.com/NixOS/nixpkgs/commit/c1ca452811f17baef11322a767f40733a33ea951) voxinput: 0.6.2 -> 0.6.3
* [`e9ef9521`](https://github.com/NixOS/nixpkgs/commit/e9ef952169c0a48081bd58fe2d5da0ad3a4b33ea) terraform-providers.spotinst: 1.226.0 -> 1.228.0
* [`81cc1213`](https://github.com/NixOS/nixpkgs/commit/81cc12139c8af49f36bb377728e1d3b0bf73b82c) firefox-devedition-unwrapped: 143.0b9 -> 144.0b1
* [`9c7f5e67`](https://github.com/NixOS/nixpkgs/commit/9c7f5e67fb4a2596be72dac876f679f84cbfb093) terraform-providers.equinix: 4.2.0 -> 4.2.1
* [`0056dbea`](https://github.com/NixOS/nixpkgs/commit/0056dbea960e9df72b78116a93ef0ac3a5144ece) diffoci: fix program name for shell completion
* [`15522090`](https://github.com/NixOS/nixpkgs/commit/155220903f5b20d857cd6222c37f63280517537c) gam 6.58 -> 7.21.01
* [`c6418cf7`](https://github.com/NixOS/nixpkgs/commit/c6418cf7733c142d2a61b6a117370b77f07dc50d) gopass: use `finalAttrs` pattern
* [`a6176933`](https://github.com/NixOS/nixpkgs/commit/a6176933ec66d47cd8bbfd628662d2329a9876d7) gopass: use `makeBinaryWrapper`
* [`1040a6d1`](https://github.com/NixOS/nixpkgs/commit/1040a6d1090a296e4562a9c1757701681bae2eea) gopass: remove `with lib;` from `meta`
* [`a7d2a1ea`](https://github.com/NixOS/nixpkgs/commit/a7d2a1ea5d9bcb2b5b12fb54b3bb0b2e74c9ffcd) gopass: use `src.tag`
* [`e4214004`](https://github.com/NixOS/nixpkgs/commit/e421400448515a3c2712a7fb4e93b51afaf9dc23) gopass: use `gitMinimal`
* [`eff67468`](https://github.com/NixOS/nixpkgs/commit/eff6746848638fabf556ea2904f2eff8a062fe02) gopass: use `versionCheckHook`
* [`0cf04d68`](https://github.com/NixOS/nixpkgs/commit/0cf04d6837ce317fb51fc66040f701c04084d287) python3Packages.netbox-contextmenus: adjust license
* [`45d5f669`](https://github.com/NixOS/nixpkgs/commit/45d5f669f16e8087da83585d2749d5ece9c89730) raycast: 1.102.7 -> 1.103.0
* [`db36deb3`](https://github.com/NixOS/nixpkgs/commit/db36deb3133bf109ad0a4157f7afb2f236287be2) vscode-extensions.antfu.icons-carbon: 0.2.7 -> 0.2.8
* [`308a612f`](https://github.com/NixOS/nixpkgs/commit/308a612fd2ca2f5f4f21eb4b36258b46e005b2c4) ocsp-server: 0.6.0 -> 0.6.1
* [`cee6df3f`](https://github.com/NixOS/nixpkgs/commit/cee6df3f9db443f8f0e7c40dc32ac224258e2553) pypy: fix optimizationLevel 1 erroring
* [`7b2776c9`](https://github.com/NixOS/nixpkgs/commit/7b2776c9046ce5014f172a1fc260ceffff9269df) pypy: create and install _sysconfigdata__*.py like _sysconfigdata__linux_x86_64-linux-gnu.py
* [`92a54ec2`](https://github.com/NixOS/nixpkgs/commit/92a54ec20a7b5eb2021fb7c0ef90900ea40f842e) Revert "nss_latest: 3.115.1 -> 3.116"
* [`e7f5fb95`](https://github.com/NixOS/nixpkgs/commit/e7f5fb95f9022ed79f038c5f135d8e169886e1c0) enzyme: 0.0.195 -> 0.0.196
* [`38f1f27d`](https://github.com/NixOS/nixpkgs/commit/38f1f27d5799ea314318d77852f47414aaf835b7) ghostfolio: 2.193.0 -> 2.199.0
* [`f1c94d46`](https://github.com/NixOS/nixpkgs/commit/f1c94d46ebfca36cb29d93204253951493f81fdc) firefox-beta-unwrapped: 143.0b9 -> 144.0b1
* [`522e5e2c`](https://github.com/NixOS/nixpkgs/commit/522e5e2c01b81ad281fd552c70ece59b74950207) home-assistant-custom-components.solax_modbus: 2025.09.6 -> 2025.09.9
* [`805ce18e`](https://github.com/NixOS/nixpkgs/commit/805ce18e19c87c06ae452c03c73b5940c202be0c) phpunit: 12.3.8 -> 12.3.11
* [`47375e14`](https://github.com/NixOS/nixpkgs/commit/47375e14979c3fb1bea737c2140e4e24cfc45067) python3Packages.p1monitor: 3.1.0 -> 3.2.0
* [`5a278dbd`](https://github.com/NixOS/nixpkgs/commit/5a278dbd807c23b28ed5b49ea5732e1b2d85be6f) python3Packages.types-psycopg2: 2.9.21.20250809 -> 2.9.21.20250915
* [`deb3c2a0`](https://github.com/NixOS/nixpkgs/commit/deb3c2a0526f6a381e41c679f868b9218fdd5dab) jetbrains: 2025.1 -> 2025.2.3
* [`e7ffe185`](https://github.com/NixOS/nixpkgs/commit/e7ffe18552a136b7904379a8b300e3fdaf75f793) jetbrains.plugins: update
* [`2b5004ce`](https://github.com/NixOS/nixpkgs/commit/2b5004ce52225000d109ba1cfb97d6c1bd0cae4f) maintainers: add gpg key for jasonxue1
* [`84f6bb74`](https://github.com/NixOS/nixpkgs/commit/84f6bb74542606adcfa7c300e2148012657d709c) nixos/tests: fix userborn-immutable-etc test
* [`e31e1ce3`](https://github.com/NixOS/nixpkgs/commit/e31e1ce3b817bae5df9942045e3391adbef0b70d) python312Packages.mypy-boto3-ce: 1.40.0 -> 1.40.31
* [`ead127af`](https://github.com/NixOS/nixpkgs/commit/ead127afbe8743f23b46188bcd9cb9488545e7cb) python312Packages.mypy-boto3-medical-imaging: 1.40.0 -> 1.40.31
* [`72da4555`](https://github.com/NixOS/nixpkgs/commit/72da4555058d2cc37ce06261251f98208e0b2305) python312Packages.mypy-boto3-payment-cryptography: 1.40.28 -> 1.40.30
* [`dd495743`](https://github.com/NixOS/nixpkgs/commit/dd4957432b280016253710afddab45e312a4e84f) python312Packages.mypy-boto3-s3control: 1.40.12 -> 1.40.31
* [`f207e0cc`](https://github.com/NixOS/nixpkgs/commit/f207e0cc38e37ffdf8a50621bde767f207fc0936) python313Packages.botocore-stubs: 1.40.29 -> 1.40.31
* [`f87776bd`](https://github.com/NixOS/nixpkgs/commit/f87776bd7c3cc67de6155ed8c9fd32ebda4bfdb0) pkgs/top-level/metrics.nix: use stdenvNoCC.mkDerivation instead of runCommand
* [`c3f0ef37`](https://github.com/NixOS/nixpkgs/commit/c3f0ef37ebf21bfea5c17a7ef7d53afc39f711bc) pkgs/top-level/metrics.nix: add meta explaining this file
* [`a34bbb6b`](https://github.com/NixOS/nixpkgs/commit/a34bbb6b9cd5f511fb5d5cff7d2ceb12d927cffb) pkgs/top-level/metrics.nix: tidy up variables and quoting
* [`29db1d32`](https://github.com/NixOS/nixpkgs/commit/29db1d32be1964eefd223a974f733f261f32ec55) pkgs/top-level/metrics.nix: use __structuredAttrs
* [`b2331161`](https://github.com/NixOS/nixpkgs/commit/b2331161b3aeb84a9a0be008cb1547cb3d34cb56) pkgs/top-level/metrics.nix: remove the aggressive variants
* [`94f1da56`](https://github.com/NixOS/nixpkgs/commit/94f1da567e4717c81fc28195a6eb301e720303b6) pkgs/top-level/metrics.nix: convince the time command to output JSON
* [`b9519e2c`](https://github.com/NixOS/nixpkgs/commit/b9519e2c0af72fe953c48cfa8e941d558219cfa2) pkgs/top-level/metrics.nix: log out the statistics using jq with a header
* [`e35ab562`](https://github.com/NixOS/nixpkgs/commit/e35ab56228ac9027e54c3eae9267fab48aaccd95) pkgs/top-level/metrics.nix: use the eval-system parameter to target a specific system
* [`146c6b9a`](https://github.com/NixOS/nixpkgs/commit/146c6b9aadc712723370be6ecee8d28fc8f60331) pkgs/top-level/metrics.nix: use json, not XML
* [`40e003d0`](https://github.com/NixOS/nixpkgs/commit/40e003d0623bb9e5b97e1740d9d28e6b3bbd455c) dnscontrol: 4.24.0 -> 4.25.0
* [`8e15ec59`](https://github.com/NixOS/nixpkgs/commit/8e15ec59f2df4642b5f2141578f5c625b93e3912) traefik: 3.5.1 -> 3.5.2
* [`dfd90bf4`](https://github.com/NixOS/nixpkgs/commit/dfd90bf4c07b6eb3d101190c2ad2369c92ea52d5) pkgs/top-level/metrics.nix: just run nix-env -qa once
* [`251dff3a`](https://github.com/NixOS/nixpkgs/commit/251dff3a3e2a057cb7c3f8e46e15e1d95211c012) pkgs/top-level/metrics.nix: save the raw files, compressing the output
* [`4973d534`](https://github.com/NixOS/nixpkgs/commit/4973d53405faece1e5394cc9616fca610641d117) pkgs/top-level/metrics.nix: use the latest Nix version, just like CI
* [`8ac12754`](https://github.com/NixOS/nixpkgs/commit/8ac12754cecbfffadeb97178a32584f9342df04b) pkgs/top-level/metrics.nix: turn off aliases in the evaluation
* [`fda7cefc`](https://github.com/NixOS/nixpkgs/commit/fda7cefcdbd5e50052dfd3bf9b97ae5cc32d8cf9) pkgs/top-level/metrics.nix: pass --no-gc-warning so that no spew about --add-root shows up
* [`3aa03ba2`](https://github.com/NixOS/nixpkgs/commit/3aa03ba2fcf006adb93fa5df9cae3fd2005dbaa0) rspamd: add option to use hyperscan or vectorscan
* [`b467d838`](https://github.com/NixOS/nixpkgs/commit/b467d83887d98f76eaca47473a7bfd515ec1ee20) froide-govplan: 0-unstable-2025-06-25 -> 0-unstable-2025-07-14
* [`a7467905`](https://github.com/NixOS/nixpkgs/commit/a7467905907b10d4ef7ebab3976bc2a046abf98c) froide: 0-unstable-2025-07-01 -> 0-unstable-2025-09-10
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
