### PR TITLE
npins nixpkgs: update a1f79a17 -> e9f00bd8

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -132,8 +132,8 @@
     "nixpkgs": {
       "type": "Channel",
       "name": "nixpkgs-unstable",
-      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-25.11pre864673.a1f79a1770d0/nixexprs.tar.xz",
-      "hash": "0j33hiaprbpdhax2vxd2rddf5zsayqcj819f47py6vi9jd80byk0"
+      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-25.11pre868392.e9f00bd89398/nixexprs.tar.xz",
+      "hash": "1n08xvypbyygjzrrkyna06sjbxg987jvmvdib5qmzp8avx6dlprb"
     },
     "powerlevel10k": {
       "type": "Git",


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: release-25.11
Commits: [nixos/nixpkgs@a1f79a17...e9f00bd8](https://github.com/nixos/nixpkgs/compare/a1f79a1770d0...e9f00bd89398)

* [`2b540c97`](https://github.com/NixOS/nixpkgs/commit/2b540c97f99e33fdc5312674bfbf6fd23e58034b) nixos/invoiceplane: Add quoteTemplates option
* [`244b31e6`](https://github.com/NixOS/nixpkgs/commit/244b31e61b38b2cd86de15af6c9aa005b6fef942) doc/build-helpers: fix appimage example where postExtract is used
* [`855da9ad`](https://github.com/NixOS/nixpkgs/commit/855da9ad3547b2052d31eac96946bbb984028480) doc/build-helpers: don't overuse pname
* [`8e59164a`](https://github.com/NixOS/nixpkgs/commit/8e59164a8f8d3508199baecbbe84236c36a98ef9) maintainers: add vaisriv
* [`64880045`](https://github.com/NixOS/nixpkgs/commit/64880045c60cf093fa8a9f6256bc79a4d4bcc2e3) xed: 2025.03.02 -> 2025.06.08
* [`14d4a883`](https://github.com/NixOS/nixpkgs/commit/14d4a883e8b14e795755039d7ba741e8c89fb2a6) nixos/bird: print config file with line numbers during config check
* [`35688eeb`](https://github.com/NixOS/nixpkgs/commit/35688eeb43127cf1365f43d878cc56bd7c1fe953) python3Packages.pyhdfe: init at 0.2.0
* [`ed3411a8`](https://github.com/NixOS/nixpkgs/commit/ed3411a8174d84e6bf72317e4e490520df21b171) python3Packages.linearmodels: init at 6.1
* [`1d7f1c63`](https://github.com/NixOS/nixpkgs/commit/1d7f1c633b928a08691a9abb25f62b1249accefb) cnpypp: init at 0-unstable-2025-06-22
* [`d4963a3a`](https://github.com/NixOS/nixpkgs/commit/d4963a3a58bd6364c90735f201ab8a88ef0d28aa) pkgs/README: Clarify library dependent incluson criterion
* [`03997705`](https://github.com/NixOS/nixpkgs/commit/0399770512e352f82eec025b484305bb939e5319) plex-mpv-shim: 1.11.0 -> 1.11.0-unstable-2025-03-17
* [`1d720335`](https://github.com/NixOS/nixpkgs/commit/1d72033564847153e394e8a394ffe87d6d9d845a) maintainers: add kenshineto
* [`f12fc240`](https://github.com/NixOS/nixpkgs/commit/f12fc2409b3640503ade14af92634274da2cab64) jdk11: 11.0.27+6 -> 11.0.28+6
* [`5a0333fc`](https://github.com/NixOS/nixpkgs/commit/5a0333fc63e9f4c8451918512d53d21d625e3465) hatchet: init at 0.6.0
* [`6ca1c4ae`](https://github.com/NixOS/nixpkgs/commit/6ca1c4ae536fa8554c375f05ce45af250d7f37cc) libraw: cleanup and modernize
* [`599f2bbe`](https://github.com/NixOS/nixpkgs/commit/599f2bbeb28a321e77dea1b2a432088f7fc9cb14) parseable: 2.3.5 -> 2.4.0
* [`b3817d87`](https://github.com/NixOS/nixpkgs/commit/b3817d877331e78d300f9fd6b451c491f2b53516) tevent: 0.17.0 -> 0.17.1
* [`7ba29b30`](https://github.com/NixOS/nixpkgs/commit/7ba29b306f50f71796cd23312a2cbe6e6d41f357) nixos/mealie: add trustedProxies option to fix OIDC redirect uri
* [`a7f40a26`](https://github.com/NixOS/nixpkgs/commit/a7f40a2648fe922f00d83491b605e3bec292e940) nixos/mealie: add extraOptions to allow setting trusted proxies for OIDC redirect uri
* [`5de22fc6`](https://github.com/NixOS/nixpkgs/commit/5de22fc6efade86a001a738f7f179d4acdf86231) python3Packages.timple: init at 0.1.8
* [`8115523d`](https://github.com/NixOS/nixpkgs/commit/8115523decfaecb3b692a61f72900a17ff8c159f) powerview: init at 2025.1.1
* [`cf47cb7c`](https://github.com/NixOS/nixpkgs/commit/cf47cb7c1043f0b3e555e7962cc8f1e117adc55d) openrgb: add startupProfile option to service
* [`d482faeb`](https://github.com/NixOS/nixpkgs/commit/d482faeb1a4c3fc4f7735a4fda14fadebf6f405d) python3Packages.pyfiglet: 1.0.3 -> 1.0.4
* [`ade7c684`](https://github.com/NixOS/nixpkgs/commit/ade7c684727d146c82f0c2c80d4f78cd268054bc) spicy-parser-generator: 1.13.2 -> 1.14.0
* [`39462b5c`](https://github.com/NixOS/nixpkgs/commit/39462b5c2c907e44e93afccad485d8e4fb4918e9) python3Packages.click-odoo-contrib: 1.20 -> 1.21
* [`4451b230`](https://github.com/NixOS/nixpkgs/commit/4451b230eb8734b804a2b138c55f8f043ef9a80b) python3Packages.pyslim: 1.0.4 -> 1.1.0
* [`9e44cb74`](https://github.com/NixOS/nixpkgs/commit/9e44cb74757f2e6f95f32322b9539606934f39ed) python3Packages.truststore: 0.10.1 -> 0.10.4
* [`579ef71b`](https://github.com/NixOS/nixpkgs/commit/579ef71b96532b080810158db64b7f75138c50b0) nixos/ipa: fix path to ldap.conf
* [`42784ebc`](https://github.com/NixOS/nixpkgs/commit/42784ebc67daa63faf3f21cde9a128a24d704839) wayland: mark broken on darwin
* [`94172d6e`](https://github.com/NixOS/nixpkgs/commit/94172d6e8a64307f8c3f5a89c1a49210b0df63b9) aws-signing-helper: 1.6.0 -> 1.7.1
* [`abb32938`](https://github.com/NixOS/nixpkgs/commit/abb329387baa6ff651a07862d50e2e0357aba032) python3Packages.diffusers: 0.34.0 -> 0.35.1
* [`75032b01`](https://github.com/NixOS/nixpkgs/commit/75032b01202c7b3128bc18b12228845f54c1ce96) angular-language-server: 20.2.1 -> 20.2.2
* [`990dce30`](https://github.com/NixOS/nixpkgs/commit/990dce30e1fb1dead0367b1410265079d377b373) bzflag: switch from fetchurl to fetchFromGitHub
* [`7d8ff0b4`](https://github.com/NixOS/nixpkgs/commit/7d8ff0b4e6eaa35d5d047306423a53567f9689fe) bcftools: switch from fetchurl to fetchFromGitHub
* [`eff9933e`](https://github.com/NixOS/nixpkgs/commit/eff9933eedc988bfd775fc6f90a1c90951e57792) form: switch from fetchurl to fetchFromGitHub
* [`07233a56`](https://github.com/NixOS/nixpkgs/commit/07233a56c9ec6c6c526b8b6cfd580def96b702f5) python3Packages.checksumdir: 1.2.0 -> 1.3.0
* [`cf1b86f4`](https://github.com/NixOS/nixpkgs/commit/cf1b86f4640a434e44f1e5aa965f050b894ff5e1) ocamlPackages.unionFind: 20220122 -> 20250818
* [`151af4aa`](https://github.com/NixOS/nixpkgs/commit/151af4aa29f6f15b7f39d4380b8fe17411e6a32e) vscode-extensions.angular.ng-template: 20.2.1 -> 20.2.2
* [`01180cea`](https://github.com/NixOS/nixpkgs/commit/01180cea77420572feceda44c0c781764c796efe) python3Packages.jenkinsapi: 0.3.14 -> 0.3.15
* [`0911d651`](https://github.com/NixOS/nixpkgs/commit/0911d651e32e0b45b938ef5ed7b0b81129517ba6) vscode-extensions.dendron.dendron-markdown-preview-enhanced: remove
* [`3487bc5e`](https://github.com/NixOS/nixpkgs/commit/3487bc5e2566bf3b8ee708f3c5662d602227631e) httm: 0.48.4 -> 0.48.5
* [`570c84fe`](https://github.com/NixOS/nixpkgs/commit/570c84fe01f9e7f85a57fb2ab6e67c504732bc70) hcdiag: 0.5.8 -> 0.5.9
* [`63f54f74`](https://github.com/NixOS/nixpkgs/commit/63f54f74a2d806a7712af78e1fff1a6310ee0e68) python3Packages.pysatochip: 0.15.1 -> 0.17.0
* [`040faf5c`](https://github.com/NixOS/nixpkgs/commit/040faf5c3006f809202643f92697f778ba52c5bb) python3Packages.ploomber-core: 0.2.26 -> 0.2.27
* [`b55edec5`](https://github.com/NixOS/nixpkgs/commit/b55edec5ec68991fbe0eed9fb91fa41dd7af0d03) junicode: 2.216 -> 2.218
* [`58c0e213`](https://github.com/NixOS/nixpkgs/commit/58c0e21380d8536564bfb597ddcf614124dcee62) spring-boot-cli: 3.5.4 -> 3.5.5
* [`15d19163`](https://github.com/NixOS/nixpkgs/commit/15d19163c39beee42598edc07b9dc55ec6a40382) python3Packages.pydsdl: 1.22.0 -> 1.22.2
* [`381d2c39`](https://github.com/NixOS/nixpkgs/commit/381d2c3960142175a4a5be9daefc901b653a1f49) archivy: 1.7.3 -> 1.7.7
* [`a985f8fe`](https://github.com/NixOS/nixpkgs/commit/a985f8feae62de7ab6885b0850ff006bc9ba620e) python3Packages.gb-io: 0.3.5 -> 0.3.6
* [`32fc6b52`](https://github.com/NixOS/nixpkgs/commit/32fc6b5225c925eff97801e18e711cba790c2dad) tektoncd-cli: 0.41.1 -> 0.42.0
* [`c45f71fd`](https://github.com/NixOS/nixpkgs/commit/c45f71fd1c3af8b41e90f4183296fd8bf8697066) ctags-lsp: 0.7.0 -> 0.8.1
* [`47c65f18`](https://github.com/NixOS/nixpkgs/commit/47c65f189ffe1056a8e3883b115c2fe0d62e94e1) python3Packages.prance: 23.06.21.0 -> 25.04.08.0
* [`abb5c463`](https://github.com/NixOS/nixpkgs/commit/abb5c4631098eca5c9ac01f7a2ddb573348d35b5) ocamlPackages.tls-eio: 2.0.1 -> 2.0.2
* [`b854517e`](https://github.com/NixOS/nixpkgs/commit/b854517ed358f574ffa7e019bca52157421b8a6d) ocamlPackages.mirage-crypto: 2.0.1 -> 2.0.2
* [`47390ef8`](https://github.com/NixOS/nixpkgs/commit/47390ef80cb10536c6011980027fb160fa31d7e6) vscode-extensions.illixion.vscode-vibrancy-continued: 1.1.59 -> 1.1.60
* [`a6d24316`](https://github.com/NixOS/nixpkgs/commit/a6d24316d3f9a68db0e7d1caf0b7ac7e96be551a) bepasty: 1.2.1 -> 1.2.2
* [`9e91a40d`](https://github.com/NixOS/nixpkgs/commit/9e91a40de4b40304b22f7b170e6edd20e1b9d247) python3Packages.atlassian-python-api: 4.0.4 -> 4.0.7
* [`b88a97a2`](https://github.com/NixOS/nixpkgs/commit/b88a97a2868998bddf049be3e99661052fe57ac7) mastodon-archive: 1.4.2 -> 1.4.8
* [`f6063f41`](https://github.com/NixOS/nixpkgs/commit/f6063f417e1ab4eca86ada14e7be4561a2810d5f) video-downloader: 0.12.26 -> 0.12.27
* [`ef61e3be`](https://github.com/NixOS/nixpkgs/commit/ef61e3beb821e29349f59c3f5cb4c640af71f047) pdm: 2.25.5 -> 2.25.9
* [`f3c66601`](https://github.com/NixOS/nixpkgs/commit/f3c666012b09133e3fc2de7262e828237975c0b7) gdal: 3.11.0 -> 3.11.3
* [`b6ea50cb`](https://github.com/NixOS/nixpkgs/commit/b6ea50cbadccb5bc01cd099b0e537ac769e5f9dd) ocamlPackages.github: 4.4.1 -> 4.5.0
* [`39afb4b3`](https://github.com/NixOS/nixpkgs/commit/39afb4b3e0db55bd87534e06b9c2a29a1628bd49) python3Packages.imgdiff: 1.7.1 -> 1.8.0
* [`f9a432c7`](https://github.com/NixOS/nixpkgs/commit/f9a432c773e71b09f38b28c7e0e9a16ca36b778d) python3Packages.quart-schema: 0.21.0 -> 0.22.0
* [`20c4d175`](https://github.com/NixOS/nixpkgs/commit/20c4d17502f90be14398a388528bc4bd8eb2a486) octodns: 1.11.0 -> 1.13.0
* [`4404e0ed`](https://github.com/NixOS/nixpkgs/commit/4404e0ed1ffb4a575dfbadf1baf2fbb9dbab640c) python3Packages.widlparser: 1.1.5 -> 1.4.0
* [`f90110ff`](https://github.com/NixOS/nixpkgs/commit/f90110ff046357af602cd941b68b8ce7321d0972) python3Packages.sqlite-migrate: 0.1a2 -> 0.1b0
* [`2170297e`](https://github.com/NixOS/nixpkgs/commit/2170297e6288d299bbcc5050df7add17bff3be1f) h3_4: 4.2.0 -> 4.3.0
* [`cfdc6e2f`](https://github.com/NixOS/nixpkgs/commit/cfdc6e2f187987eafbbe87bd487e73e42449fa0b) deark: 1.7.0 -> 1.7.1
* [`2b4a8849`](https://github.com/NixOS/nixpkgs/commit/2b4a8849e93f0f03326fab9e67629fd1bd806e9e) phpExtensions.snuffleupagus: 0.11.0 -> 0.12.0
* [`f42fcf5a`](https://github.com/NixOS/nixpkgs/commit/f42fcf5a59272d333a87bd49b3c7290ce1189ec7) pyupgrade: 3.19.1 -> 3.20.0
* [`26809ca5`](https://github.com/NixOS/nixpkgs/commit/26809ca52c73f87953b9bf911830ecf29e1b1b2d) python3Packages.rpyc: 6.0.1 -> 6.0.2
* [`a19a9a52`](https://github.com/NixOS/nixpkgs/commit/a19a9a52f0300da6ffde119ad0fabc863a0fcf53) python3Packages.ipynbname: 2024.1.0.0 -> 2025.8.0.0
* [`032c63e5`](https://github.com/NixOS/nixpkgs/commit/032c63e54960cec83af3a08199b84cc45bc48c06) python3Packages.zope-testbrowser: 7.0 -> 7.0.1
* [`ad56eae9`](https://github.com/NixOS/nixpkgs/commit/ad56eae95821f8ae8d5262d44b3bbfa8e511bc4d) python3Packages.setuptools-odoo: 3.3 -> 3.3.1
* [`1535ad7a`](https://github.com/NixOS/nixpkgs/commit/1535ad7ab20c86959b755a103bdcc0ed20aeaa50) bkcrack: 1.7.1 -> 1.8.0
* [`08b06a23`](https://github.com/NixOS/nixpkgs/commit/08b06a2364c25985036e35c5b6f12e67d77b8eea) httpstat: 1.3.1 -> 1.3.2
* [`0539f392`](https://github.com/NixOS/nixpkgs/commit/0539f392d457618c323a7af5a0ec47aebc1139b4) fltk14: 1.4.x-2021-12-21 -> 1.4.4
* [`ab4e4190`](https://github.com/NixOS/nixpkgs/commit/ab4e4190e94a6b9b7a2c13fe4fa42280145d300d) lcov: 2.3.1 -> 2.3.2
* [`8a0e07cf`](https://github.com/NixOS/nixpkgs/commit/8a0e07cfca5db0cf07212f8a2f4fbddb97b33c17) lightning-terminal: 0.15.1-alpha -> 0.15.2-alpha
* [`ac973cf4`](https://github.com/NixOS/nixpkgs/commit/ac973cf49140d2976524b25066f6fa60c09e55fc) maltego: 4.10.0 -> 4.10.1
* [`9f5bec75`](https://github.com/NixOS/nixpkgs/commit/9f5bec752d96ee24aba2b3f06c6251b2f426b074) python3Packages.injector: 0.21.0 -> 0.22.0
* [`347d9252`](https://github.com/NixOS/nixpkgs/commit/347d9252d4fdf5c48c04c70d802aa0685a1259d6) python3Packages.posix-ipc: 1.1.1 -> 1.3.0
* [`002ef966`](https://github.com/NixOS/nixpkgs/commit/002ef9664180b193c8564affbd8858f6388ac29c) python3Packages.pylint-plugin-utils: 0.8.2 -> 0.9.0
* [`72cf4896`](https://github.com/NixOS/nixpkgs/commit/72cf4896e339198ec3ff615ce657b6a8d8ff220f) sphinx-autobuild: 2024.10.03 -> 2025.08.25
* [`1bf358a4`](https://github.com/NixOS/nixpkgs/commit/1bf358a4b80d3a7819c61d6e57d2054b02d72ecd) kyverno-chainsaw: 0.2.12 -> 0.2.13
* [`fec6a167`](https://github.com/NixOS/nixpkgs/commit/fec6a16748ecd47ab499519027200e0ae5bda770) gfal2-util: 1.8.1 -> 1.9.0
* [`3048947b`](https://github.com/NixOS/nixpkgs/commit/3048947bcc805b9b3f4bc94146f65bdaaf40218c) python3Packages.pontos: 25.8.0 -> 25.8.1
* [`772da8ee`](https://github.com/NixOS/nixpkgs/commit/772da8ee62906160efe5af1a8231e65b66dc835d) mopidy-tidal: 0.3.10 -> 0.3.11
* [`f7513a55`](https://github.com/NixOS/nixpkgs/commit/f7513a5544fd4eb02982188ec4a332a111c58868) schismtracker: 20250728 -> 20250825
* [`9cc1acc0`](https://github.com/NixOS/nixpkgs/commit/9cc1acc0e951fc91edb57829a0da5e31b9423563) duo-unix: 2.1.0 -> 2.2.0
* [`8c902fa4`](https://github.com/NixOS/nixpkgs/commit/8c902fa426bc81027e2a6f3450ee946faa6eb3d1) python3Packages.hawkauthlib: 0.1.1 -> 2.0.0
* [`f6b13771`](https://github.com/NixOS/nixpkgs/commit/f6b137714aa6996c2da8928004d1b532945eb913) python3Packages.distorm3: 3.5.2 -> 3.5.2b
* [`900ebdb9`](https://github.com/NixOS/nixpkgs/commit/900ebdb9e482bdfc63f8231d93a058d4836e7ae9) lima, lima-additional-guestagents: share source
* [`f435beda`](https://github.com/NixOS/nixpkgs/commit/f435beda456baf4ac545473520b10a7499d11ee6) apt: 3.1.4 -> 3.1.5
* [`5b06c2ec`](https://github.com/NixOS/nixpkgs/commit/5b06c2ecd632a78eb1e9b82cee8c2ffd1c5cf986) maintainers: add skohtv
* [`4393259b`](https://github.com/NixOS/nixpkgs/commit/4393259b5a631d7ba2bcedfc074fb5734509370f) vivify: init at 0.8.2
* [`33f3668e`](https://github.com/NixOS/nixpkgs/commit/33f3668ea7b861c0d873087f5a0073112e176843) python3Packages.trainer: 0.2.2 -> 0.3.1
* [`6d116162`](https://github.com/NixOS/nixpkgs/commit/6d1161626e9b718632d371d4ae8acdebdb7f7a58) python3Packages.sphinxemoji: 0.2.0 -> 0.3.1
* [`662f3e4a`](https://github.com/NixOS/nixpkgs/commit/662f3e4a4766521791e41d5bf8f4a2d5722714df) python3Packages.pyspelling: 2.10 -> 2.11
* [`ceea7f39`](https://github.com/NixOS/nixpkgs/commit/ceea7f39c347fe4333951f81db7950eaabc61a68) bettercap: 2.41.1 -> 2.41.4
* [`c6cadf5f`](https://github.com/NixOS/nixpkgs/commit/c6cadf5fd90bdf75dd3e9fa3c02393075ce44a3c) python3Packages.py-datastruct: 1.1.0 -> 2.0.0
* [`ff4b51cb`](https://github.com/NixOS/nixpkgs/commit/ff4b51cb2602f8d2c10353422fc41dc9e76124b5) python3Packages.tree-sitter: remove unused test dependencies
* [`44da3033`](https://github.com/NixOS/nixpkgs/commit/44da303307c6d1b57cdd0d0ea20c435cb8a3f062) python3Packages.tree-sitter: remove unneded patch for tests
* [`3366e2a0`](https://github.com/NixOS/nixpkgs/commit/3366e2a0844826c073b7b4eb0d6df0cb94b0f026) python3Packages.sphinx-notfound-page: 1.0.0 -> 1.1.0
* [`3888382d`](https://github.com/NixOS/nixpkgs/commit/3888382dc2593917eec408e680fcf639c9e31630) python3Packages.django-ninja: 1.4.3 -> 1.4.3t
* [`e9b79fd8`](https://github.com/NixOS/nixpkgs/commit/e9b79fd858d8d1e16e82ab1820aff84b9223e387) python3Packages.scikit-survival: 0.24.1 -> 0.25.0
* [`55d4a165`](https://github.com/NixOS/nixpkgs/commit/55d4a165dff3ef9e827f76b6faa49fcf7cf7a1f3) python3Packages.opensimplex: 0.4.3 -> 0.4.5
* [`d5db78d7`](https://github.com/NixOS/nixpkgs/commit/d5db78d7d43940e78ed72e3907ce73ecf0f48124) rewaita: 1.0.1 -> 1.0.5
* [`2bad65c8`](https://github.com/NixOS/nixpkgs/commit/2bad65c85cbad7d0368370c9b990e509e4fe437c) rewaita: add getchoo to maintainers
* [`1d176d0f`](https://github.com/NixOS/nixpkgs/commit/1d176d0f61bb512bf1443c872259cb9bf651bbf8) stripe-cli: 1.29.0 -> 1.30.0
* [`0fba50a3`](https://github.com/NixOS/nixpkgs/commit/0fba50a3a84e679767ed45b2015b72bac1bf0743) rancher: 2.12.0 -> 2.12.1
* [`db901226`](https://github.com/NixOS/nixpkgs/commit/db901226ac0549cb71a2ee933e0d6db7163e9e42) python3Packages.opentsne: 1.0.2 -> 1.0.3
* [`7bf1d93e`](https://github.com/NixOS/nixpkgs/commit/7bf1d93e1b44e9b24c0f83483255368df85706bd) python3Packages.hyperscan: 0.7.22 -> 0.7.25
* [`88dfd803`](https://github.com/NixOS/nixpkgs/commit/88dfd8034a8090feec9730035c32387ce34800c2) quartoMinimal: 1.7.33 -> 1.7.34
* [`7e712bfc`](https://github.com/NixOS/nixpkgs/commit/7e712bfcc16153c6b2a43a7c9d851914b4e6542f) python3Packages.gcsa: 2.1.0 -> 2.6.0
* [`0596c107`](https://github.com/NixOS/nixpkgs/commit/0596c1072e3a712005048a4d5fe0fba758930999) circleci-cli: 0.1.33128 -> 0.1.33163
* [`89a5fcaf`](https://github.com/NixOS/nixpkgs/commit/89a5fcaf5c036a4ad7174dbf7889ef451ebc364e) python3Packages.virt-firmware: 24.7 -> 25.7.3
* [`c19ef78e`](https://github.com/NixOS/nixpkgs/commit/c19ef78e5e41ae1f3db32928c3ac41c646daf85f) python3Packages.tensorboardx: 2.6.2 -> 2.6.2.2
* [`8f5d4af1`](https://github.com/NixOS/nixpkgs/commit/8f5d4af1b5bfb7c71a414aaec34e1fa89daa36bf) python3Packages.lzallright: 0.2.5 -> 0.2.6
* [`a6717dca`](https://github.com/NixOS/nixpkgs/commit/a6717dcaf34cdb38baafbc1d28833d6b64b843d9) apriltag: 3.4.4 -> 3.4.5
* [`568833b5`](https://github.com/NixOS/nixpkgs/commit/568833b51da89e9863decd897daa5a8758f4f2df) kubefirst: 2.9.0 -> 2.9.1
* [`e973e242`](https://github.com/NixOS/nixpkgs/commit/e973e242cae315eb9c2af6fff15c4697c955d8ba) python3Packages.django-payments: 3.0.1 -> 3.1.0
* [`40622459`](https://github.com/NixOS/nixpkgs/commit/406224595af8b599bb5e7a061f10f47db3567e83) rednotebook: 2.39 -> 2.41
* [`43a1ec1a`](https://github.com/NixOS/nixpkgs/commit/43a1ec1afd2329088ffee1ac35f6c50eb71f666e) oauth2-proxy: 7.11.0 -> 7.12.0
* [`67011bda`](https://github.com/NixOS/nixpkgs/commit/67011bdabf6cbaf95d20985ef409e20f265b660e) python3Packages.sphinx-autobuild: 2024.10.03 -> 2025.08.25
* [`96cda2c1`](https://github.com/NixOS/nixpkgs/commit/96cda2c1a1fde8f52a760be4175d467db2130996) pandoc-imagine: 0.1.6 -> 0.1.7
* [`f5847d5d`](https://github.com/NixOS/nixpkgs/commit/f5847d5dba6b7ea5fb50c54715c10be19ecd82d7) vscode-extensions.eamodio.gitlens: 17.3.4 -> 17.4.1
* [`643533ee`](https://github.com/NixOS/nixpkgs/commit/643533ee3a6d2fd941cd0081bea26994825d694a) python3Packages.recoll: 1.43.4 -> 1.43.5
* [`ad96bca7`](https://github.com/NixOS/nixpkgs/commit/ad96bca707427014d3203c4c5f1ddfd6fdab5b3e) python3Packages.django-mcp-server: 0.5.4 -> 0.5.6
* [`a527d65c`](https://github.com/NixOS/nixpkgs/commit/a527d65ce84046e99f30a87d16ec4a5be4b31fd2) python3Packages.leanblueprint: 0.0.10 -> 0.0.18
* [`ea1b8acc`](https://github.com/NixOS/nixpkgs/commit/ea1b8acca307b99f3a81d1a7f571d42e78a66c86) libmamba: 2.3.0 -> 2.3.2
* [`44574b95`](https://github.com/NixOS/nixpkgs/commit/44574b95399db109daad7a86096ebd8370af3520) vals: 0.42.0 -> 0.42.1
* [`952636b1`](https://github.com/NixOS/nixpkgs/commit/952636b1479ce5f740bc412657736c92aab78c74) python3Packages.osc-sdk-python: 0.35.0 -> 0.36.0
* [`f7b410ad`](https://github.com/NixOS/nixpkgs/commit/f7b410adb3f38f7b591efb947266884252bde9f9) python3Packages.ledgerwallet: 0.5.0 -> 0.5.3
* [`9c267407`](https://github.com/NixOS/nixpkgs/commit/9c267407fad74c7e1e18f8ed88a53968e7b91374) tlsx: 1.2.0 -> 1.2.1
* [`ddbfa1a0`](https://github.com/NixOS/nixpkgs/commit/ddbfa1a0ca82239914e228ffbe8652f114c3a1f7) stress-ng: 0.19.03 -> 0.19.04
* [`6f379875`](https://github.com/NixOS/nixpkgs/commit/6f379875ef43b2ac366ae04768dd7745491679af) snyk: 1.1298.3 -> 1.1299.0
* [`cbf047c5`](https://github.com/NixOS/nixpkgs/commit/cbf047c58ab8c1565e2c055980e817a36674e2fd) testkube: 2.2.1 -> 2.2.5
* [`419c9ef9`](https://github.com/NixOS/nixpkgs/commit/419c9ef949eb8fd28916d0559c881c16d6c687a1) faudio: 25.08 -> 25.09
* [`e264eedd`](https://github.com/NixOS/nixpkgs/commit/e264eedd068d20db237adc73696666f430bc46ff) infrastructure-agent: 1.66.1 -> 1.67.3
* [`9c2eaab0`](https://github.com/NixOS/nixpkgs/commit/9c2eaab08f550c92c090d9bd5121c75157abe67d) epubcheck: 5.2.1 -> 5.3.0
* [`e80574d2`](https://github.com/NixOS/nixpkgs/commit/e80574d2d6bc44e0dcef35b216f1529bd2a41d4b) python3Packages.mahotas: 1.4.14 -> 1.4.18
* [`bb3a8ae5`](https://github.com/NixOS/nixpkgs/commit/bb3a8ae548fcc439060668432347f597cffc5215) ngspice: 44.2 -> 45
* [`496e841d`](https://github.com/NixOS/nixpkgs/commit/496e841dce6bcb8a814be168d71f0bc88190cef2) crowdsec: 1.6.11 -> 1.7.0
* [`11c7c7bc`](https://github.com/NixOS/nixpkgs/commit/11c7c7bca511d4d98653cda478e884ab041aa074) sqlmap: 1.9.8 -> 1.9.9
* [`ac62a5f3`](https://github.com/NixOS/nixpkgs/commit/ac62a5f3c5db6b0b197ffc73bda5335c97d48ac2) go-ethereum: 1.16.2 -> 1.16.3
* [`9518cd52`](https://github.com/NixOS/nixpkgs/commit/9518cd527e3a7c6bbbc6087ea815f211c4287468) jackett: 0.22.2319 -> 0.22.2390
* [`3264f7c6`](https://github.com/NixOS/nixpkgs/commit/3264f7c600795d64431b49c4eb86e1b93a464fad) zabbix70: 7.0.17 -> 7.0.18
* [`12a19050`](https://github.com/NixOS/nixpkgs/commit/12a1905020becd9bba10c33855bc8f42be4fd5f2) lychee: 0.20.0 -> 0.20.1
* [`72f3b766`](https://github.com/NixOS/nixpkgs/commit/72f3b76679168b1682c0834129f21b633337ff26) python3Packages.unidata-blocks: 0.0.17 -> 0.0.18
* [`3fd43476`](https://github.com/NixOS/nixpkgs/commit/3fd43476ff22fdfa9884e550b342199868c82210) python3Packages.phonopy: 2.38.2 -> 2.43.2
* [`cb9408dc`](https://github.com/NixOS/nixpkgs/commit/cb9408dcb100337d441983789fe93a9b8f6fa455) calibre-web: 0.6.24 -> 0.6.25
* [`53ae17a6`](https://github.com/NixOS/nixpkgs/commit/53ae17a6880b75ea73b1312a75d0f8ec06ccbfd6) python3Packages.coloraide: 4.7.2 -> 5.1
* [`d7af8834`](https://github.com/NixOS/nixpkgs/commit/d7af8834e0977af73ae3176820d0cf06a28610a0) cproto: 4.7x -> 4.7y
* [`5c7d1355`](https://github.com/NixOS/nixpkgs/commit/5c7d13556a0b13b75a56e6bad788bff0f68f3a2c) ocelot-desktop: 1.13.1 -> 1.14.1
* [`f9fdcc1e`](https://github.com/NixOS/nixpkgs/commit/f9fdcc1e848cb739e37d5f6e16130369eb7f5d3b) freerdp: 3.17.0 -> 3.17.1
* [`fd61c0be`](https://github.com/NixOS/nixpkgs/commit/fd61c0be5f68ef253607ce8ec711f92001827e06) cloudlog: 2.7.0 -> 2.7.1
* [`dc9286b4`](https://github.com/NixOS/nixpkgs/commit/dc9286b44357c2ae47ba6c3a4859a93a40bc0c0c) python3Packages.biom-format: 2.1.16 -> 2.1.17
* [`bfe339a1`](https://github.com/NixOS/nixpkgs/commit/bfe339a1ed564dd144dee3299946ec8398c96b87) gate: 0.52.0 -> 0.53.0
* [`6191822d`](https://github.com/NixOS/nixpkgs/commit/6191822d5133206d2a7a7164b28a95c9d749bbe6) python3Packages.langfuse: 3.2.1 -> 3.3.4
* [`fb465fb4`](https://github.com/NixOS/nixpkgs/commit/fb465fb4e17ffef4276c4be7e673779728774d31) checkstyle: 11.0.0 -> 11.0.1
* [`7450f558`](https://github.com/NixOS/nixpkgs/commit/7450f5581d5c1304959c57a969e91cde6785ab91) python3Packages.troposphere: 4.9.3 -> 4.9.4
* [`88cda46b`](https://github.com/NixOS/nixpkgs/commit/88cda46b423fbd017a591b9ffdad3f2cd4ac86ba) terser: 5.38.0 -> 5.44.0
* [`5dd4dc6a`](https://github.com/NixOS/nixpkgs/commit/5dd4dc6a223f668503957d3ea022ee0f9754412a) thc-hydra: 9.5 -> 9.6
* [`6db15319`](https://github.com/NixOS/nixpkgs/commit/6db15319ea4c50af221ea933e6a40efa3867534c) ngtcp2-gnutls: 1.15.0 -> 1.15.1
* [`d5309039`](https://github.com/NixOS/nixpkgs/commit/d530903922e1ff195908032435a9673b2673c64e) ngtcp2: 1.14.0 -> 1.15.1
* [`82d71552`](https://github.com/NixOS/nixpkgs/commit/82d715521039cc63acb7ca0c9e773e4b2811d672) buildkit: 0.23.2 -> 0.24.0
* [`fcea3563`](https://github.com/NixOS/nixpkgs/commit/fcea3563e6d7f0cd60eebd698408c8c443e1fc53) semtools: init at 1.2.0
* [`c86ea2bf`](https://github.com/NixOS/nixpkgs/commit/c86ea2bf7cd348f2ca215d3a5b250911f893e0e7) kubectl: 1.33.4 -> 1.34.0
* [`ad6f5f5b`](https://github.com/NixOS/nixpkgs/commit/ad6f5f5b4068f7fa092f7acb72ca2aa5c306bda1) wavelog: 2.0.7 -> 2.1
* [`70c8650a`](https://github.com/NixOS/nixpkgs/commit/70c8650ae1ad9bfe294e0346a0c9f2d488c042ee) onlykey: migrate to buildNpmPackage
* [`ddbea230`](https://github.com/NixOS/nixpkgs/commit/ddbea230030dd53913fc0137685932242c2fbf57) flatter: 0-unstable-2025-08-12 -> 0-unstable-2025-08-25
* [`434bdf5d`](https://github.com/NixOS/nixpkgs/commit/434bdf5d52ad53996f2a3fca02312a6433439e28) python3Packages.python-novaclient: 18.10.0 -> 18.11.0
* [`6bbb9a6b`](https://github.com/NixOS/nixpkgs/commit/6bbb9a6bdb616a57945e8f3ef09f4574e0719965) osv-scanner: 2.2.1 -> 2.2.2
* [`4ce63ca5`](https://github.com/NixOS/nixpkgs/commit/4ce63ca5bf2129eb303028bbec2a07046770f0ff) biglybt: 3.8.0.0 -> 3.9.0.0
* [`cfdb1fcf`](https://github.com/NixOS/nixpkgs/commit/cfdb1fcf4ad76edef9806be1fbd2ea72ab002dfc) clojure: 1.12.1.1561 -> 1.12.2.1565
* [`12525e0f`](https://github.com/NixOS/nixpkgs/commit/12525e0f220db625d6874784ddcbd1f38c35894a) xgboost: 3.0.4 -> 3.0.5
* [`484b3f8c`](https://github.com/NixOS/nixpkgs/commit/484b3f8ce596d449521c1b425254303b6efbddf5) capypdf: 0.16.0 -> 0.17.0
* [`b4679c57`](https://github.com/NixOS/nixpkgs/commit/b4679c57875a0e3063a4fddf4be80d8c96444859) atmos: 1.188.0 -> 1.189.0
* [`1caba3e5`](https://github.com/NixOS/nixpkgs/commit/1caba3e5d9bdb9532d8b730bddb390157ecb07e4) cockpit: add branding, fix app visibility conditions, add andre4ik3 as maintainer
* [`395b4112`](https://github.com/NixOS/nixpkgs/commit/395b4112402c0f069a7cd13810b002c2b7b45223) nixos/cockpit: add SSH to wsinstance path and issue banner support
* [`e8787cd3`](https://github.com/NixOS/nixpkgs/commit/e8787cd33de6be2bb57a951946ac5bc3ac3dd1ae) python3Packages.pytelegrambotapi: 4.28.0 -> 4.29.1
* [`8db2ca7f`](https://github.com/NixOS/nixpkgs/commit/8db2ca7f99ebae07d2ce73ac7f588d5b90a28af9) livekit: 1.9.0 -> 1.9.1
* [`257278fa`](https://github.com/NixOS/nixpkgs/commit/257278fae3312df083ab8c84b9c3b78eee682859) regclient: 0.9.1 -> 0.9.2
* [`10302bd6`](https://github.com/NixOS/nixpkgs/commit/10302bd6b61f68d2f647088f59aebd3f10abfac3) libdatachannel: 0.23.1 -> 0.23.2
* [`e8673536`](https://github.com/NixOS/nixpkgs/commit/e86735362fd98233ee365b943243d11ce1a08f90) kustomize-sops: 4.3.3 -> 4.4.0
* [`212c9fcd`](https://github.com/NixOS/nixpkgs/commit/212c9fcd8eed35b82fc60b1b2415569cdaddecff) starboard: 0.15.26 -> 0.15.27
* [`501a82e4`](https://github.com/NixOS/nixpkgs/commit/501a82e406edc1c91f2df08e1cb5f051715cf1f0) mozart: pin boost to boost183
* [`ff959099`](https://github.com/NixOS/nixpkgs/commit/ff959099ad5a46c51c10861580fa2d820fb5a6aa) python3Packages.crypt4gh: init at 1.7
* [`2ce9d785`](https://github.com/NixOS/nixpkgs/commit/2ce9d785135a536552b788d5d83eb495b13d2123) netsurf-buildsystem: move to by-name
* [`caba7cee`](https://github.com/NixOS/nixpkgs/commit/caba7ceefbebddf4edd40e81cde8aca87c194580) libparserutils: move to by-name
* [`79097233`](https://github.com/NixOS/nixpkgs/commit/79097233b9cfe7cffdaeffaad27cbed828159451) libwapcaplet: move to by-name
* [`04a49fa4`](https://github.com/NixOS/nixpkgs/commit/04a49fa416bae75f5bc2d5de43bf19c542319729) libcss: move to by-name
* [`24296f56`](https://github.com/NixOS/nixpkgs/commit/24296f56983f9692a940d8e4a73100e4f6509d83) libhubbub: move to by-name
* [`398e1eec`](https://github.com/NixOS/nixpkgs/commit/398e1eec0785b1769b1ed17c47bba160317d6434) libdom: move to by-name
* [`41c1934d`](https://github.com/NixOS/nixpkgs/commit/41c1934d04936687ec1bc89d3f9e110e0b316c4c) libnsbmp: move to by-name
* [`c5fe6204`](https://github.com/NixOS/nixpkgs/commit/c5fe62044e05b64cd3a9428eeb651a373a0ce5f9) libnsfb: move to by-name
* [`b6689d74`](https://github.com/NixOS/nixpkgs/commit/b6689d7480ff8b7b974ec2cbe7db22cf7d766274) libnsgif: move to by-name
* [`8d08e7a0`](https://github.com/NixOS/nixpkgs/commit/8d08e7a079def6207ad28f409024d28938661384) libnslog: move to by-name
* [`da5860d2`](https://github.com/NixOS/nixpkgs/commit/da5860d2b6c26d081e7610975f0940b9224d3ad3) libnspsl: move to by-name
* [`7a246810`](https://github.com/NixOS/nixpkgs/commit/7a24681060945dff04373c0dd36b20af5f113111) libnsutils: move to by-name
* [`792039a9`](https://github.com/NixOS/nixpkgs/commit/792039a935ed02d5cc2f4415c57186d162086d36) libsvgtiny: move to by-name
* [`9bc2f708`](https://github.com/NixOS/nixpkgs/commit/9bc2f708ae92bcf6f82b6226eb0bf5dfb28b69b7) libutf8proc: move to by-name
* [`279c298c`](https://github.com/NixOS/nixpkgs/commit/279c298cbb0e5488ab2864e743bc2c0c455501c1) nsgenbind: move to by-name
* [`829014a2`](https://github.com/NixOS/nixpkgs/commit/829014a2d00615627335727b10c3c47e82a1427d) netsurf-browser: move to by-name
* [`b36a8544`](https://github.com/NixOS/nixpkgs/commit/b36a8544ccbf7fb430043b52790f5587141f3319) netsurf: drop package set
* [`84617475`](https://github.com/NixOS/nixpkgs/commit/8461747583f254588343f4b630c3754fff94892d) vscode-extensions.ms-pyright.pyright: 1.1.403 -> 1.1.405
* [`e6219181`](https://github.com/NixOS/nixpkgs/commit/e6219181a67ba22755340f4eb8c3122efa614693) fluidd: 1.34.3 -> 1.34.4
* [`bb9f4664`](https://github.com/NixOS/nixpkgs/commit/bb9f4664edfcf5c1fbb02399167da408c7f621c4) overturemaps: 0.15.0 -> 0.16.0
* [`353306f0`](https://github.com/NixOS/nixpkgs/commit/353306f0971825c6a44406036e7fa24745aaeb47) keychain: 2.9.5 -> 2.9.6
* [`9ac99d9c`](https://github.com/NixOS/nixpkgs/commit/9ac99d9c0dfdd8b2e17c373ff398ce032ca0ae16) python3Packages.fpdf2: 2.8.3 -> 2.8.4
* [`7d5278cd`](https://github.com/NixOS/nixpkgs/commit/7d5278cd79a78b23580c65372f0a2265912287fb) g3proxy: 1.12.1 -> 1.12.2
* [`407a7206`](https://github.com/NixOS/nixpkgs/commit/407a72068d29a86b9e78bef5b401abbc123e186f) tomcat9: 9.0.108 -> 9.0.109
* [`c38322cf`](https://github.com/NixOS/nixpkgs/commit/c38322cfc7cabeba0a43d3729e79e363654afd5c) kafkactl: 5.12.0 -> 5.12.1
* [`17de4d6d`](https://github.com/NixOS/nixpkgs/commit/17de4d6d937fdf07e30ab59673b7b1b347861650) vscode-extensions.redhat.java: 1.44.0 -> 1.45.0
* [`cba06600`](https://github.com/NixOS/nixpkgs/commit/cba06600e527e9a69e374afd62415ab903aeb4c3) python3Packages.python-gitlab: 6.2.0 -> 6.3.0
* [`bb9f9ab8`](https://github.com/NixOS/nixpkgs/commit/bb9f9ab8ea05773a4ae42388d67c0a79f637673b) maintainers: add shokerplz
* [`608ba7a4`](https://github.com/NixOS/nixpkgs/commit/608ba7a407519c535d553fd2b63ccf828b03c7de) modules/postfix: fix manpage number in option description
* [`39d37da1`](https://github.com/NixOS/nixpkgs/commit/39d37da1bec9a5a18f052c82797bb3b192b5c065) arti: 1.4.6 -> 1.5.0
* [`e1d28ae4`](https://github.com/NixOS/nixpkgs/commit/e1d28ae48680298adaf1b58f97c5453623218ec8) ia-writer-mono: init at 0-unstable-2023-06-16
* [`0a6fbaef`](https://github.com/NixOS/nixpkgs/commit/0a6fbaef9746027e7dd877129c8e40c81762779c) alacritty-theme: 0-unstable-2025-08-04 -> 0-unstable-2025-08-18
* [`62a2e589`](https://github.com/NixOS/nixpkgs/commit/62a2e589cbce27589dfd1df17aa0e72d1357e2b3) stylelint: 16.23.1 -> 16.24.0
* [`186bb09d`](https://github.com/NixOS/nixpkgs/commit/186bb09d073f935629b16f81c530f3bcd66a2e11) afflib: 3.7.21 -> 3.7.22
* [`a4560567`](https://github.com/NixOS/nixpkgs/commit/a45605679efcfb2130d84a2ec6e868747d27d77c) python3Packages.labelbox: 7.1.1 -> 7.2.0
* [`4d62c06b`](https://github.com/NixOS/nixpkgs/commit/4d62c06b51e74a0c6fff2ceada5264feb6612c71) janet: 1.38.0 -> 1.39.1
* [`4543e9e6`](https://github.com/NixOS/nixpkgs/commit/4543e9e61384984b19e85993754ba4ab801f2623) babashka-unwrapped: 1.12.207 -> 1.12.208
* [`4080cc6b`](https://github.com/NixOS/nixpkgs/commit/4080cc6be865a9322598ccc4af5c69cfcd34f617) nixos/tests/kubernetes: bump featureGates used in test, to work with v1.34
* [`2fa52764`](https://github.com/NixOS/nixpkgs/commit/2fa5276435d632355134527a431be9de01b4f380) python3Packages.sepaxml: 2.6.2 -> 2.7.0
* [`32fd00fd`](https://github.com/NixOS/nixpkgs/commit/32fd00fd767ba4d5c74fa134818895bcde3895f2) zabbix74: 7.4.0 -> 7.4.2
* [`47684e56`](https://github.com/NixOS/nixpkgs/commit/47684e5689f5892be5009c2f81ea9aefb70603f4) camunda-modeler: 5.38.1 -> 5.39.0
* [`eab7e8e4`](https://github.com/NixOS/nixpkgs/commit/eab7e8e4f677e2db663e059a51f2b995a175a654) python313Packages.narwhals: 2.0.1 -> 2.4.0
* [`3d50f7f7`](https://github.com/NixOS/nixpkgs/commit/3d50f7f760a63fd67fa1bac5385b52103e52955f) adminer: 5.3.0 -> 5.4.0
* [`4014ce13`](https://github.com/NixOS/nixpkgs/commit/4014ce137cf0a4f28b2c07c65eb404d24ae5a056) sydbox: 3.37.9 -> 3.38.2
* [`c18b2402`](https://github.com/NixOS/nixpkgs/commit/c18b2402d733c572ed87ea11363fdc4bea2a1d95) kubernetes-helmPlugins.helm-secrets: 4.6.6 -> 4.6.10
* [`50595e10`](https://github.com/NixOS/nixpkgs/commit/50595e103ea8381774c09e2235c0d16eb5c771c6) i2pd: 2.57.0 -> 2.58.0
* [`77eff875`](https://github.com/NixOS/nixpkgs/commit/77eff87518d1ba634108bdf8562d18c263d9b4d6) angie-console-light: 1.8.0 -> 1.8.1
* [`110b0de2`](https://github.com/NixOS/nixpkgs/commit/110b0de2170ae02c6f5fc1c3be8629323031a413) psi-plus: 1.5.2081 -> 1.5.2115
* [`a1579cc8`](https://github.com/NixOS/nixpkgs/commit/a1579cc8f181981ce4abaf1f578ae5b696621392) python3Packages.bottleneck: 1.5.0 -> 1.6.0
* [`b20ad689`](https://github.com/NixOS/nixpkgs/commit/b20ad6893d1fe4ad5ca509f6974c4546878a6be1) maintainers: add magicquark
* [`0d54c602`](https://github.com/NixOS/nixpkgs/commit/0d54c60268b8fe05a2d5b145ebe2c1d86b3ceb31) python3Packages.locust-cloud: init at 1.26.3
* [`6114a478`](https://github.com/NixOS/nixpkgs/commit/6114a4780d78940b365145515abee9a506bbbde9) napari: 0.6.3 -> 0.6.4
* [`f25468d8`](https://github.com/NixOS/nixpkgs/commit/f25468d88f78ab931be596548b3e8b5322d962b1) mackerel-agent: 0.85.0 -> 0.85.1
* [`2f729ef0`](https://github.com/NixOS/nixpkgs/commit/2f729ef07a01ea7c8ce4afb9da5ee682871b8151) neomutt: 20250510 -> 20250905
* [`477f9b7f`](https://github.com/NixOS/nixpkgs/commit/477f9b7febb75cdffe747db72dec007f6416960f) python3Packages.hikari: 2.3.5 -> 2.4.1
* [`9f39ad8b`](https://github.com/NixOS/nixpkgs/commit/9f39ad8bf77eb3c96c0873be6d1b4953cbf89542) unicorn: 2.1.3 -> 2.1.4
* [`5de0e19f`](https://github.com/NixOS/nixpkgs/commit/5de0e19fd497363d375b33ea85db2d86bb512267) ckbcomp: 1.240 -> 1.242
* [`13cf61eb`](https://github.com/NixOS/nixpkgs/commit/13cf61eb118dcf3846190873873b01b360f2f5f7) sitespeed-io: 38.1.2 -> 38.3.0
* [`092896e1`](https://github.com/NixOS/nixpkgs/commit/092896e14297ade94d6def650e7d720b3f102e38) python3Packages.langchain-tests: 0.3.20 -> 0.3.21
* [`623eb06a`](https://github.com/NixOS/nixpkgs/commit/623eb06a0c72b5f47c598f5a974e19c7e3e7c784) tryton: 7.6.2 -> 7.6.3
* [`2e417277`](https://github.com/NixOS/nixpkgs/commit/2e4172771838228ff6c87086f7fb4a0c0c88045e) frankenphp: 1.9.0 -> 1.9.1
* [`6c63f3b5`](https://github.com/NixOS/nixpkgs/commit/6c63f3b5e500ec3ff9b223a0528e240b9bc2034f) guile-gcrypt: 0.4.0 -> 0.5.0
* [`0aaea8f2`](https://github.com/NixOS/nixpkgs/commit/0aaea8f2d479c7c8b2eca9e28844059332593be5) verilator: 5.038 -> 5.040
* [`90faef45`](https://github.com/NixOS/nixpkgs/commit/90faef45660b13befe34f7ed2e0b0ec9981d5d83) autobrr: 1.65.0 -> 1.66.1
* [`1e0fbbfb`](https://github.com/NixOS/nixpkgs/commit/1e0fbbfb86d62ee284ec1fb6de8454303db57b4f) hired: init at 0.14.3
* [`839a86b3`](https://github.com/NixOS/nixpkgs/commit/839a86b3f21fecdaa63ba7fbcc8846e291f88b3c) olympus: add finderHints argument
* [`652f6e08`](https://github.com/NixOS/nixpkgs/commit/652f6e08f4ac0669e26fc879ab40b093b3950589) python3Packages.aws-encryption-sdk: 4.0.2 -> 4.0.3
* [`1e1c03fc`](https://github.com/NixOS/nixpkgs/commit/1e1c03fc1fec1e963af1df19a085dfb5f20870f8) victoriatraces: init at 0.2.0
* [`949a2a78`](https://github.com/NixOS/nixpkgs/commit/949a2a78b2afc5d94b6103f46aa93b1de1065e8a) clementine: use `lib.cmake{Bool,Feature}`
* [`897418fe`](https://github.com/NixOS/nixpkgs/commit/897418fed39305c3bb91aaf6e9c2e5a06a3cbf78) clementine: remove obsolete parens
* [`3c31a37b`](https://github.com/NixOS/nixpkgs/commit/3c31a37b908a639789a3a4c5e417857290a0f3ce) clementine: add `meta.mainProgram`
* [`e70f8441`](https://github.com/NixOS/nixpkgs/commit/e70f84411387c75129acbf45a9e89b68665117ff) clementine: replace `util-linux` with `util-linuxMinimal`
* [`3c9b0f85`](https://github.com/NixOS/nixpkgs/commit/3c9b0f85a4e2cf540fdba870bc035d4145d30c06) buildGoModule: remove compatibility layer for directly specified CGO_ENABLED
* [`6527ff7f`](https://github.com/NixOS/nixpkgs/commit/6527ff7fa4a536cff36b81b31bb63f3d881b2582) python3Packages.netbox-attachments: 8.0.4 -> 9.0.0
* [`49e06b12`](https://github.com/NixOS/nixpkgs/commit/49e06b12d99edff3737d4ab45cba9394b034422a) isl_0_27: init at 0.27
* [`350f2ac6`](https://github.com/NixOS/nixpkgs/commit/350f2ac6a51070d9a359b9d2e64e663675be3bfc) python3Packages.microsoft-kiota-http: 1.9.5 -> 1.9.7
* [`fe054918`](https://github.com/NixOS/nixpkgs/commit/fe054918b4385c1fcd47e421282ff0701bc7fe4b) python3Packages.microsoft-kiota-abstractions: 1.9.5 -> 1.9.7
* [`b5be3fe0`](https://github.com/NixOS/nixpkgs/commit/b5be3fe04cb6843f1bfadeae792b9fb25e40c842) python3Packages.coredis: 5.0.1 -> 5.1.0
* [`98c79456`](https://github.com/NixOS/nixpkgs/commit/98c79456d59294b38865db7f61bbbbea553a4b78) ansifilter: 2.21 -> 2.22
* [`2f19f4fe`](https://github.com/NixOS/nixpkgs/commit/2f19f4fe369d25dd575bb54e4f23366849ef8e8b) soapui: 5.9.0 -> 5.9.1
* [`2bb08c47`](https://github.com/NixOS/nixpkgs/commit/2bb08c476961cae813542795ddd84f3d3c93a45d) jj-fzf: 0.32.0 -> 0.33.0
* [`df673deb`](https://github.com/NixOS/nixpkgs/commit/df673deb4e9c89ef02351ba3c90d2cf3a0231293) python3Packages.microsoft-kiota-serialization-form: 1.9.5 -> 1.9.7
* [`7cf0371e`](https://github.com/NixOS/nixpkgs/commit/7cf0371e03d03e0d52e75e1054bd353b83a246ed) opentelemetry-collector-builder: 0.134.0 -> 0.135.0
* [`35693b32`](https://github.com/NixOS/nixpkgs/commit/35693b3279b4e70bdd611f49b38b78e4d0b93deb) nixos/pgadmin: Apply hardening options
* [`53aeea03`](https://github.com/NixOS/nixpkgs/commit/53aeea03a88098a5075c8fe4358a8f8d8a1bc7f7) nixos/jenkins: Apply hardening options
* [`901c4d71`](https://github.com/NixOS/nixpkgs/commit/901c4d710f24bc7279dd55af6324da3ef167ae8c) cppcheck: 2.18.1 -> 2.18.3
* [`9c7ba83c`](https://github.com/NixOS/nixpkgs/commit/9c7ba83c99a797eec1b3e89dac8357ae9c16d5a8) lombok: 1.18.38 -> 1.18.40
* [`259664ac`](https://github.com/NixOS/nixpkgs/commit/259664ac1da4a29bb9b7788ea2f30d6bf1357c73) kamailio: 6.0.2 -> 6.0.3
* [`a9fea55f`](https://github.com/NixOS/nixpkgs/commit/a9fea55f71629b363093f7ed53f2f171a5a27d3a) papermc: 1.21.8-56 -> 1.21.8-60
* [`9e989bf6`](https://github.com/NixOS/nixpkgs/commit/9e989bf6b116282530ddffc4c594c1c5e295b708) netmaker-full: 1.0.0 -> 1.1.0
* [`87f8e934`](https://github.com/NixOS/nixpkgs/commit/87f8e9345bb7b45e612a221452d0a227b19a985b) netclient: 1.0.0 -> 1.1.0
* [`1ce4c51c`](https://github.com/NixOS/nixpkgs/commit/1ce4c51c22ceec14d136e6ff84fdb53b890e32c3) netmaker: 1.0.0 -> 1.1.0
* [`9455b61f`](https://github.com/NixOS/nixpkgs/commit/9455b61fbbd709f3310acb2edb9bcd0a2e50d556) python3Packages.pytransportnswv2: 2.0.0 -> 2.0.1
* [`88ec7dc6`](https://github.com/NixOS/nixpkgs/commit/88ec7dc6b601de0c8117f61ef732ca4f04b06582) python313Packages.gto: 1.7.2 -> 1.8.0
* [`82621ad2`](https://github.com/NixOS/nixpkgs/commit/82621ad205c198ffb6b255095514045cdda20d9b) python313Packages.nessclient: 1.2.0 -> 1.3.1
* [`6457cece`](https://github.com/NixOS/nixpkgs/commit/6457cecef4d3bd03c2c50e132aeeff10eaeff0c2) python313Packages.authlib: 1.6.1 -> 1.6.3
* [`10646e25`](https://github.com/NixOS/nixpkgs/commit/10646e253304b003c82ff09fdc93f7c197c4b7ce) sea-orm-cli: 1.1.14 -> 1.1.16
* [`1b0d456e`](https://github.com/NixOS/nixpkgs/commit/1b0d456efb19c49112d496f06cd0692751b5ecc9) unit: 1.34.2 -> 1.35.0
* [`00cd67cd`](https://github.com/NixOS/nixpkgs/commit/00cd67cd0681ec17a3ad71ec9faeaaf6e4adf242) kubernetes-helmPlugins.helm-diff: 3.12.5 -> 3.13.0
* [`6d1b5644`](https://github.com/NixOS/nixpkgs/commit/6d1b564427ce2e2f5dacf231d0a8f671aedbb180) redocly: 2.0.7 -> 2.1.0
* [`4a09f3a1`](https://github.com/NixOS/nixpkgs/commit/4a09f3a1f5814effce52574399c2b7e9579a0b8f) crates-lsp: init at 0.4.2
* [`010cf001`](https://github.com/NixOS/nixpkgs/commit/010cf0010c1a789676ccb19bd7efbe188e220f25) vscode-extensions.ocamllabs.ocaml-platform: 1.32.0 -> 1.32.3
* [`889b5008`](https://github.com/NixOS/nixpkgs/commit/889b5008dba43abbc8c9c999c22e5de66d1f887a) dbgate: 6.6.1 -> 6.6.3
* [`8bffdd4c`](https://github.com/NixOS/nixpkgs/commit/8bffdd4ccfc94eedd84b56d346adb9fac46b5ff6) treewide: gate command execution for `installShellCompletion` behind `buildPlatform.canExecute hostPlatform`
* [`566b6ee0`](https://github.com/NixOS/nixpkgs/commit/566b6ee0e5b4b4d9f781a2beee5d454c94a95038) python3Packages.oci: 2.158.2 -> 2.160.0
* [`0e0af0de`](https://github.com/NixOS/nixpkgs/commit/0e0af0deab0a649fb7bfbf1105c690c7ddb7704f) docker_25: 25.0.12 -> 25.0.13
* [`96ccdeb4`](https://github.com/NixOS/nixpkgs/commit/96ccdeb40e111af6b9c59dd097c62ec8dd3c3085) docker_28: 28.3.3 -> 28.4.0
* [`d876ea27`](https://github.com/NixOS/nixpkgs/commit/d876ea27714aaf332858679d45ede87017dc0ac1) jailer: 16.7.1 -> 16.9.1
* [`f4f73f20`](https://github.com/NixOS/nixpkgs/commit/f4f73f206e8a198a69f1ba5b3a8be05a1adafed2) electron-source.electron_35: remove as it's EOL
* [`b67464cf`](https://github.com/NixOS/nixpkgs/commit/b67464cfb67bc88be9a8b627b1f0ab22618746fa) electron_35-bin: mark as insecure because it's EOL
* [`7036e027`](https://github.com/NixOS/nixpkgs/commit/7036e0273609acebfb52a74fd11b83908b022d30) qlog: 0.45.0 -> 0.46.0
* [`a942c398`](https://github.com/NixOS/nixpkgs/commit/a942c39809adafd647bf14544726d150ddf0b402) prometheus-artifactory-exporter: 1.16.0 -> 1.16.1
* [`92965b45`](https://github.com/NixOS/nixpkgs/commit/92965b451c0c26d0fca0dcb256a054bf800f9485) pcm: 202502 -> 202509
* [`555133dd`](https://github.com/NixOS/nixpkgs/commit/555133dd40032166f099f22becf3e385cf00c524) hyperrogue: 13.1c -> 13.1e
* [`5da17c31`](https://github.com/NixOS/nixpkgs/commit/5da17c31f443c744476d91d95c89af670e6c41a9) codeql: 2.22.4 -> 2.23.0
* [`0dcdfc20`](https://github.com/NixOS/nixpkgs/commit/0dcdfc20aa66e422b73133a9830a03ee790b3e27) steampipePackages.steampipe-plugin-azure: 1.6.0 -> 1.7.0
* [`bb3443a8`](https://github.com/NixOS/nixpkgs/commit/bb3443a8b7dca10bd2abc928d5dbbc46ba7e20d3) cudaPackages: patch for issue[nixos/nixpkgs⁠#434096](https://togithub.com/nixos/nixpkgs/issues/434096)
* [`1f954b79`](https://github.com/NixOS/nixpkgs/commit/1f954b791ae2d98a520f8206fd1e35acb6705ca0) python3Packages.localstack-ext: 4.7.0 -> 4.8.0
* [`632d1401`](https://github.com/NixOS/nixpkgs/commit/632d140165d4d1d71e74ca8ee70dedca489ad871) equicord: 2025-09-01 -> 2025-09-12
* [`f4e74e49`](https://github.com/NixOS/nixpkgs/commit/f4e74e4934c646eb2573b32316d53f441b845290) decker: 1.58 -> 1.59
* [`63acf34e`](https://github.com/NixOS/nixpkgs/commit/63acf34e951e178c39329f2f7c1d728f345a90fb) pageedit: 2.5.0 -> 2.6.2
* [`7b3b69d2`](https://github.com/NixOS/nixpkgs/commit/7b3b69d261cc6547a8961b64ba4fdd4f2f7d1cac) tabiew: 0.11.0 -> 0.11.1
* [`364577c8`](https://github.com/NixOS/nixpkgs/commit/364577c873c3b4798238b9bcc17c6e1bba8bde8e) steampipePackages.steampipe-plugin-github: 1.5.0 -> 1.6.0
* [`901ba79d`](https://github.com/NixOS/nixpkgs/commit/901ba79de6c399730334bdaa1904710279fa5f6d) python3Packages.cf-xarray: 0.10.7 -> 0.10.9
* [`dd21aaa2`](https://github.com/NixOS/nixpkgs/commit/dd21aaa2c8e36a99c8754255b020c3c11ed60f31) sby: 0.56 -> 0.57
* [`abf79610`](https://github.com/NixOS/nixpkgs/commit/abf7961070a627e9e455dc96279806d3a5deba5d) vscode-extensions.ms-toolsai.jupyter: 2025.7.0 -> 2025.8.0
* [`4464c227`](https://github.com/NixOS/nixpkgs/commit/4464c227fd9d6b36784256f4bf553b3c644687cb) carapace: 1.4.1 -> 1.5.0
* [`d455b14c`](https://github.com/NixOS/nixpkgs/commit/d455b14c1ece9e40f3806c771b3d4515c8b0c431) heroku: 10.12.0 -> 10.13.1
* [`cf22a046`](https://github.com/NixOS/nixpkgs/commit/cf22a0463a2de16bf56969a512b01196d136cce4) openjph: 0.21.4 -> 0.23.0
* [`96b64686`](https://github.com/NixOS/nixpkgs/commit/96b64686f10778f39bc2718b7f87382cc649f0db) vscode-extensions.hashicorp.terraform: 2.34.5 -> 2.36.2
* [`54f57ced`](https://github.com/NixOS/nixpkgs/commit/54f57cedbe53a20efc3e2a057e4898955a1cf2e1) python3Packages.pyside6-qtads: 4.3.1.4 -> 4.4.0.3
* [`5af62df6`](https://github.com/NixOS/nixpkgs/commit/5af62df6efc6bc6c9d3d5fb206f7793ffbe05f99) stash: Refactor to use finalAttrs, straighten out src references
* [`bc71c978`](https://github.com/NixOS/nixpkgs/commit/bc71c9782df956f521dbd8e6531e2cb352d590f3) lego: 4.25.2 -> 4.26.0
* [`a8cf32dc`](https://github.com/NixOS/nixpkgs/commit/a8cf32dc2292aa4dee8348f0cd925da2df1c719a) pychess: 1.0.5 -> 1.0.6
* [`bec65b6d`](https://github.com/NixOS/nixpkgs/commit/bec65b6dc8ee2ed7bfa786db85daa9b9b8c72595) python3Packages.llama-index-multi-modal-llms-openai: 0.6.0 -> 0.6.1
* [`bdbdc189`](https://github.com/NixOS/nixpkgs/commit/bdbdc1899a737a29e286a9a32a4f799cd400feb8) iosevka: 33.2.9 -> 33.3.0
* [`aa1b1952`](https://github.com/NixOS/nixpkgs/commit/aa1b195269348f20f9fc37f8cf1abc2d5d3a22dd) rain-bittorrent: 2.2.1 -> 2.2.2
* [`36928a05`](https://github.com/NixOS/nixpkgs/commit/36928a05c4202e5a3f00e710d065256e1c4dd4a8) mullvad: 2025.7 -> 2025.9
* [`2e9b935e`](https://github.com/NixOS/nixpkgs/commit/2e9b935ed53c2633ace2401fe544df34c70f29dd) python3Packages.msgraph-sdk: 1.40.0 -> 1.44.0
* [`d57afbaa`](https://github.com/NixOS/nixpkgs/commit/d57afbaaa13f80a83348419d967b97031c6fd2c6) firefoxpwa: 2.15.0 -> 2.16.0
* [`3b301b11`](https://github.com/NixOS/nixpkgs/commit/3b301b1170bb203009b3d30236b043c9a3de61a3) switch-to-configuration-ng: split new_dbus_proxies into systemd1_proxy and login1_proxy
* [`368ed5d9`](https://github.com/NixOS/nixpkgs/commit/368ed5d96ef20485c235ca0a70d5076c8bd8dfb2) lix: disable AWS if not available on the host platform
* [`5de01fe1`](https://github.com/NixOS/nixpkgs/commit/5de01fe11b48229d1755ad51e7f5e612926ebda0) komac: 2.12.1 -> 2.13.0
* [`13f26bd1`](https://github.com/NixOS/nixpkgs/commit/13f26bd119107f3d5825d81b7a28046d4d420c6a) drawterm: 0-unstable-2025-08-18 -> 0-unstable-2025-09-11
* [`44d32662`](https://github.com/NixOS/nixpkgs/commit/44d32662c3373cfee8a60596736a7d572d6d4acd) oci-cli: 3.64.1 -> 3.66.0
* [`174651dc`](https://github.com/NixOS/nixpkgs/commit/174651dc36c1e1792918f92cdfddb0dcf984f348) python3Packages.azure-mgmt-containerservice: 39.0.0 -> 39.1.0
* [`c589f3f5`](https://github.com/NixOS/nixpkgs/commit/c589f3f52d52b037482f8727f86a8f1e4be6acd1) ibus-engines.typing-booster-unwrapped: 2.27.73 -> 2.27.74
* [`ec1640cd`](https://github.com/NixOS/nixpkgs/commit/ec1640cd44f005c9769813be8a5ed21b5f52f1f9) python3Packages.llama-index-vector-stores-qdrant: 0.8.3 -> 0.8.4
* [`dea2a960`](https://github.com/NixOS/nixpkgs/commit/dea2a96060db49d8e3ba02bd6ed06bd2da44afb2) python3Packages.requests-pkcs12: 1.25 -> 1.27
* [`dac70f42`](https://github.com/NixOS/nixpkgs/commit/dac70f423b24dc8ae011faa7d3b0d3deab8b5f36) python3Packages.azure-synapse-artifacts: 0.20.0 -> 0.21.0
* [`3b9b0821`](https://github.com/NixOS/nixpkgs/commit/3b9b08212a390463388a214e05cfe31042402a55) sysdig: 0.38.1 -> 0.40.1
* [`15230368`](https://github.com/NixOS/nixpkgs/commit/15230368f8b5c6c97676add68a1410f913a7335e) python3Packages.biocframe: init at 0.6.3
* [`5a15e435`](https://github.com/NixOS/nixpkgs/commit/5a15e435d451788afb9805248ace858c5b247d28) linux-router-without-wifi: 0.7.6 -> 0.8.1
* [`b8864258`](https://github.com/NixOS/nixpkgs/commit/b8864258f43e4ac1a554caa73cecbfec4b62ae47) quarkus: 3.25.4 -> 3.26.3
* [`8befc6a5`](https://github.com/NixOS/nixpkgs/commit/8befc6a5a806e9105da48003af6682a9e60964d6) linuxkit: 1.7.1 -> 1.8.1
* [`1524ebdd`](https://github.com/NixOS/nixpkgs/commit/1524ebdd02a223493c3a9add4468d5757334b31b) yquake2: 8.51 -> 8.60
* [`8c319dd3`](https://github.com/NixOS/nixpkgs/commit/8c319dd31fd1e75a2272ea41d6499c789cb2d742) brewtarget: 4.1.3 -> 4.2.1
* [`461fd40e`](https://github.com/NixOS/nixpkgs/commit/461fd40e59fb00ae9063065c147e80dab008f25d) github-mcp-server: 0.14.0 -> 0.15.0
* [`f924064b`](https://github.com/NixOS/nixpkgs/commit/f924064b5e32d0eab3b11d8452ba35eed9d230d4) clipper2: 1.5.3 -> 1.5.4
* [`367f80b8`](https://github.com/NixOS/nixpkgs/commit/367f80b85877ba1fe9be784cb363a98e8a56b210) karakeep: 0.26.0 -> 0.27.0
* [`b74a192e`](https://github.com/NixOS/nixpkgs/commit/b74a192ef77a88dbfa747d1417f600023ad0d311) python3Packages.microsoft-kiota-authentication-azure: 1.9.5 -> 1.9.7
* [`5930fa7e`](https://github.com/NixOS/nixpkgs/commit/5930fa7e644f26f80bf6bfd7652612fc782ca0a9) clipper2: add passthru.updateScript
* [`c47110b3`](https://github.com/NixOS/nixpkgs/commit/c47110b3754e76796fc6b5deb61edec3f7711b6c) geph: fix geph5-client-gui
* [`dce979e4`](https://github.com/NixOS/nixpkgs/commit/dce979e4889d94e830c21ce84cf50af1a4779573) poetry: 2.1.4 -> 2.2.0
* [`bed1eb3d`](https://github.com/NixOS/nixpkgs/commit/bed1eb3d9a9d7bc501e02af06030eb296759b270) mariadb-connector-java: 3.5.5 -> 3.5.6
* [`6f90368a`](https://github.com/NixOS/nixpkgs/commit/6f90368af111f76208e255f790ab11fd9114f1e6) python3Packages.dbt-protos: 1.0.351 -> 1.0.376
* [`b7e307e2`](https://github.com/NixOS/nixpkgs/commit/b7e307e2212159adab27828bfc47015586cd0642) reviewdog: 0.20.3 -> 0.21.0
* [`2d687cce`](https://github.com/NixOS/nixpkgs/commit/2d687cce94792e9cc3448e622d6dc8370388a81d) codebuff: 1.0.473 -> 1.0.485
* [`bb42d26e`](https://github.com/NixOS/nixpkgs/commit/bb42d26e1f648e382143314abec0f94e863f7b9e) python3Packages.pins: 0.9.0 -> 0.9.1
* [`ef4b2e4f`](https://github.com/NixOS/nixpkgs/commit/ef4b2e4f4b03e543fdca2f3a7598ffe622c954a2) nixos/loki: refine option descriptions
* [`4a3f74ef`](https://github.com/NixOS/nixpkgs/commit/4a3f74efdb94831991c7c05a5b9b987ae3ac1354) python3Packages.klayout: 0.30.3 -> 0.30.4
* [`c352933c`](https://github.com/NixOS/nixpkgs/commit/c352933c9c2aaedde8c0055af0b4e2d1e1334750) gqlgen: 0.17.78 -> 0.17.79
* [`57aab1d5`](https://github.com/NixOS/nixpkgs/commit/57aab1d525d558f101576fc21a78211e0d6f6762) uriparser: 0.9.8 -> 0.9.9
* [`d17f93b2`](https://github.com/NixOS/nixpkgs/commit/d17f93b25ca4112bebe7f425bc6257dc4ed92379) gnu-shepherd: 1.0.6 -> 1.0.7
* [`8ec944a9`](https://github.com/NixOS/nixpkgs/commit/8ec944a972b2eaabb8c278688822ae4a5d03ea31) ark-pixel-font: 2025.08.11 -> 2025.08.24
* [`67319c27`](https://github.com/NixOS/nixpkgs/commit/67319c27fd3b3343f20cc1e7005e121bb063b2dc) python3Packages.drf-nested-routers: 0.94.2 -> 0.95.0
* [`f7548864`](https://github.com/NixOS/nixpkgs/commit/f7548864712cccad29d63af212c7563f274be5d7) cloudflare-ddns: init at 1.15.1
* [`9007662f`](https://github.com/NixOS/nixpkgs/commit/9007662fd02c72f608d84a5a2727799b858c9cfb) nixos/cloudflare-ddns: init module
* [`5d407262`](https://github.com/NixOS/nixpkgs/commit/5d40726289914295fe7123943ea07395c68aa2b2) doc: add cloudflare-ddns to release notes
* [`4b567a39`](https://github.com/NixOS/nixpkgs/commit/4b567a39f115b78620068229a67e4264a616e748) cloudflare-ddns: refactor buildGoModule usage
* [`d7ba474b`](https://github.com/NixOS/nixpkgs/commit/d7ba474bedb64b5bc4715c94775b4ada63058408) whistle: 2.9.101 -> 2.9.102
* [`7ca8735b`](https://github.com/NixOS/nixpkgs/commit/7ca8735bfc4c11aec27af02eabc58d6ca7f7ccf6) stylua: 2.1.0 -> 2.2.0
* [`56a49abb`](https://github.com/NixOS/nixpkgs/commit/56a49abbc3172d2cb4cd006454b29dfe27f35ab7) python3Packages.microsoft-kiota-serialization-json: 1.9.5 -> 1.9.7
* [`997f2bf9`](https://github.com/NixOS/nixpkgs/commit/997f2bf9d4802111d4ef79d4b8273f9f2f0db6ae) maa-assistant-arknights: 5.24.1 -> 5.24.2
* [`9988f8dd`](https://github.com/NixOS/nixpkgs/commit/9988f8dd20bfce3b6e71f61fe38e0f039c9c7255) kcc: 9.0.0 -> 9.1.0
* [`d32af8da`](https://github.com/NixOS/nixpkgs/commit/d32af8da6f00390e990e0dd5f6a0332a0d1c5368) aws-iam-authenticator: 0.7.5 -> 0.7.7
* [`8e86c439`](https://github.com/NixOS/nixpkgs/commit/8e86c439203f3bef487038cc1da4624d116443a8) magic-vlsi: 8.3.541 -> 8.3.551
* [`27175b70`](https://github.com/NixOS/nixpkgs/commit/27175b70df38cc9235470f6133a50d2e758bac7e) flac2all: 5.1 -> 5.4
* [`95734b13`](https://github.com/NixOS/nixpkgs/commit/95734b13e988d7771a8df85521d78b37306426f6) python3Packages.swh-model: 7.1.0 -> 8.4.1
* [`7f9ad853`](https://github.com/NixOS/nixpkgs/commit/7f9ad8535b0662a4c9be030d91eaa5151c638ff0) ocamlPackages.reason: 3.16.0 → 3.17.0
* [`feb52436`](https://github.com/NixOS/nixpkgs/commit/feb5243618550e654212df28c29bfb9aa042beee) gitlab-ci-ls: 1.1.9 -> 1.2.1
* [`2f7398ef`](https://github.com/NixOS/nixpkgs/commit/2f7398ef44d0b8276746231a9637366dc32e2ae9) ocamlPackages.odoc: 2.4.4 → 3.1.0
* [`0e115163`](https://github.com/NixOS/nixpkgs/commit/0e115163323be1ea0937c8ed8d9bf3562d209400) typos-lsp: 0.1.41 -> 0.1.43
* [`d8df9ed3`](https://github.com/NixOS/nixpkgs/commit/d8df9ed3a0117225401287bd573e786a0069d0ef) jpegoptim: 1.5.5 -> 1.5.6
* [`60147632`](https://github.com/NixOS/nixpkgs/commit/60147632666da637007a1f124175023683960b23) velero: 1.16.2 -> 1.17.0
* [`888f7372`](https://github.com/NixOS/nixpkgs/commit/888f7372421871b7f6d9c446e0d0d47408993bd8) python3Packages.django-modeltranslation: 0.19.16 -> 0.19.17
* [`485060b7`](https://github.com/NixOS/nixpkgs/commit/485060b71034f90e936230b227285b9c5f6fda78) spire: 1.12.5 -> 1.13.0
* [`c9bc4932`](https://github.com/NixOS/nixpkgs/commit/c9bc49321aed7c513e9a83b86f9bdb9412fbc75a) home-assistant-custom-components.versatile_thermostat: 7.3.2 -> 7.3.4
* [`086337ac`](https://github.com/NixOS/nixpkgs/commit/086337ac02c4d3673a4e4d8dfb430aa9e3f12b68) dpic: 2024.01.01 -> 2025.08.01
* [`9695d470`](https://github.com/NixOS/nixpkgs/commit/9695d4704bb724b4c2bf101af94b02eb40ed6155) bambu-studio: 02.02.01.60 -> 02.02.02.56
* [`6a435e65`](https://github.com/NixOS/nixpkgs/commit/6a435e65168d4ffad963338b52d580401642fcdc) signal-cli: 0.13.18 -> 0.13.19
* [`82505857`](https://github.com/NixOS/nixpkgs/commit/82505857ed34a5771912b67f59e778e724dcacff) home-manager: 0-unstable-2025-09-04 -> 0-unstable-2025-09-15
* [`96c58abe`](https://github.com/NixOS/nixpkgs/commit/96c58abee55be6a50e4b2203cc37bebf1e64c1e2) kdePackages.koi: 0.5.1 -> 0.6
* [`5e249aae`](https://github.com/NixOS/nixpkgs/commit/5e249aae04ca68938f168dbd719ff1360e19dedf) libreoffice: add withJava option
* [`679309d8`](https://github.com/NixOS/nixpkgs/commit/679309d85d89d7797a0b8a9500e0d04521fb2f8d) brush-splat: init at 0.2.0
* [`97706a97`](https://github.com/NixOS/nixpkgs/commit/97706a9770cf04823c6bf4876830890e63668f74) python3Packages.microsoft-kiota-serialization-multipart: 1.9.5 -> 1.9.7
* [`62bed03a`](https://github.com/NixOS/nixpkgs/commit/62bed03aefadc01a663cc70e2ede9078b9f8470e) python3Packages.microsoft-kiota-serialization-text: 1.9.5 -> 1.9.7
* [`4350765e`](https://github.com/NixOS/nixpkgs/commit/4350765e1cd96bc5abcab8a3993a6d7c17fd6f32) vscode-extensions.ms-ceintl.vscode-language-pack-fr: 1.103.2025080609 -> 1.104.2025091009
* [`de1c00b1`](https://github.com/NixOS/nixpkgs/commit/de1c00b1639e3b7fc3b6aa7a866a1886c363e28f) groovy: 4.0.28 -> 5.0.1
* [`653273a8`](https://github.com/NixOS/nixpkgs/commit/653273a8f0d4c1d2de2b12f138758c6b24ee382e) asciinema_3: 3.0.0-rc.5 -> 3.0.0
* [`803882b5`](https://github.com/NixOS/nixpkgs/commit/803882b566cbaeb19273d5c79edf43816f47c8d7) asciinema_3: remove disabled test
* [`43b39da6`](https://github.com/NixOS/nixpkgs/commit/43b39da6a3780bef896d37cf199ce20aeeb40aa3) hyprshell: 4.6.0 -> 4.6.4
* [`5604f0a2`](https://github.com/NixOS/nixpkgs/commit/5604f0a2ce20a09d6e455e03b1bf1f3c1765b8e0) vscode-extensions.visualjj.visualjj: 0.16.2 -> 0.16.4
* [`5c77e74e`](https://github.com/NixOS/nixpkgs/commit/5c77e74e4d2995beeabecf04a073f6b7f446b0eb) flow: 0.279.0 -> 0.281.0
* [`cbb25728`](https://github.com/NixOS/nixpkgs/commit/cbb25728a57458c49ba2483f568ac4598b455938) gabutdm: 2.6.0 -> 2.7.0
* [`5fd65222`](https://github.com/NixOS/nixpkgs/commit/5fd65222dfde8e416cea895d4391f4d2c5bec34f) flix: 0.60.0 -> 0.62.0
* [`255b133f`](https://github.com/NixOS/nixpkgs/commit/255b133f01a2a90720f650e58a3892c44163ea8e) python3Packages.pynvml: 12.0.0 -> 13.0.1
* [`1fef615a`](https://github.com/NixOS/nixpkgs/commit/1fef615ae51757f0d8107d427ae0543f7cd47fa1) rqlite: 8.43.4 -> 9.0.1
* [`64169e99`](https://github.com/NixOS/nixpkgs/commit/64169e994ab641838b9ca76f9a642613f674bd90) cudaPackages: patch for issue[nixos/nixpkgs⁠#434096](https://togithub.com/nixos/nixpkgs/issues/434096) modifying setup hook
* [`9b4f94be`](https://github.com/NixOS/nixpkgs/commit/9b4f94be4d6629c00888e1fd21a622dfc7234730) fldigi: 4.2.07 -> 4.2.09
* [`d876fdba`](https://github.com/NixOS/nixpkgs/commit/d876fdba04a69499a1cccec7eb9eefe84d76dc5e) python3Packages.asyncserial: unstable-2022-06-10 -> 1.0
* [`8c9daaad`](https://github.com/NixOS/nixpkgs/commit/8c9daaad01716a8363e6942977fec4baf67af027) netbird-relay: 0.57.0 -> 0.57.1
* [`fd009034`](https://github.com/NixOS/nixpkgs/commit/fd009034b819620af5ec198e4989c62aa2adb494) netbird-upload: 0.57.0 -> 0.57.1
* [`3640584d`](https://github.com/NixOS/nixpkgs/commit/3640584dee97d6ac7248bbd321d2748c7c716fb1) netbird-signal: 0.57.0 -> 0.57.1
* [`7400c30c`](https://github.com/NixOS/nixpkgs/commit/7400c30c09c850c08fea94c200e2d09bf1a10900) netbird-management: 0.57.0 -> 0.57.1
* [`0dfa86b0`](https://github.com/NixOS/nixpkgs/commit/0dfa86b0636ce471c4e16019f71c10c7620490cd) easyjson: 0.9.0 -> 0.9.1
* [`e181a4b3`](https://github.com/NixOS/nixpkgs/commit/e181a4b38ddad463366a46e74af235451fe65548) gopass-jsonapi: 1.15.16 -> 1.15.17
* [`ad7a9f6b`](https://github.com/NixOS/nixpkgs/commit/ad7a9f6b4b65df53a79b7b3aaf80e2a34fa4ee6f) darkly-qt5: 0.5.22 -> 0.5.23
* [`fe64edab`](https://github.com/NixOS/nixpkgs/commit/fe64edabc24120d0b09d0ea452b4b29459f550f7) aerospike: 8.0.0.9 -> 8.0.0.10
* [`cc8a5ddf`](https://github.com/NixOS/nixpkgs/commit/cc8a5ddfd3fe90dd95d5794124bb4918f8da2d4a) simpleTpmPk11: 0.06 -> 0.07
* [`4a3ed535`](https://github.com/NixOS/nixpkgs/commit/4a3ed535c027f8f08397d02069e123b6ca8dc457) ibus-engines.chewing: 2.1.6 -> 2.1.7
* [`6ad2a94b`](https://github.com/NixOS/nixpkgs/commit/6ad2a94ba2dd6572b3b1f86057b4149dd870da0b) dart: 3.9.2 -> 3.9.3
* [`272467ba`](https://github.com/NixOS/nixpkgs/commit/272467ba042794e808e9839097c0b723d7b66234) python3Packages.knowit: init at 0.5.11
* [`4c77cd41`](https://github.com/NixOS/nixpkgs/commit/4c77cd417035e563a6ecfb7bad0c51d5c9fef49a) python3Packages.subliminal: fix build
* [`3cd981e1`](https://github.com/NixOS/nixpkgs/commit/3cd981e13d45e0e627fa91fe415cf931ad338d15) mercure: 0.20.0 -> 0.20.2
* [`f7fa6b75`](https://github.com/NixOS/nixpkgs/commit/f7fa6b751beb1d306e74aaf83ff509c2b69879c6) ocamlPackages.lambdapi: 2.6.0 → 3.0.0
* [`4bbf6a92`](https://github.com/NixOS/nixpkgs/commit/4bbf6a929aa5332d808c690deed1a321a5fe6dab) symbolicator: 25.8.0 -> 25.9.0
* [`6fc8ed68`](https://github.com/NixOS/nixpkgs/commit/6fc8ed680f51be7e933cca12ade00669ba0c2bd1) vscode-extensions.ms-dotnettools.csdevkit: 1.41.11 -> 1.50.51
* [`167ebcf1`](https://github.com/NixOS/nixpkgs/commit/167ebcf138339399754f7a19991d47bc64e76e9d) sssd: 2.9.7 -> 2.11.1
* [`d693a26c`](https://github.com/NixOS/nixpkgs/commit/d693a26c9a77856080b033ae69476a3e6e5fc19a) sssd: add liberodark to maintainers
* [`978d7301`](https://github.com/NixOS/nixpkgs/commit/978d730107735cc060829429d8c8d3bf6f21e6da) weblate: 5.13.1 -> 5.13.3
* [`a8c43472`](https://github.com/NixOS/nixpkgs/commit/a8c43472c67e31171012d772703e88b56ff93eee) etherape: 0.9.20 -> 0.9.21
* [`2ad222af`](https://github.com/NixOS/nixpkgs/commit/2ad222af310aae6bdba05483781f9b9be9c0a3f5) vscode-extensions.kilocode.kilo-code: init at 4.91.0
* [`0cf41743`](https://github.com/NixOS/nixpkgs/commit/0cf41743444c1a37b33bfa5e653e936df1f167dc) vscode-extensions.emmanuelbeziat.vscode-great-icons: 2.1.119 -> 2.1.120
* [`f49c602f`](https://github.com/NixOS/nixpkgs/commit/f49c602fc3b2e17df012260524fc0e00cde6eb40) lief: 0.16.6 -> 0.17.0
* [`1a14dc6e`](https://github.com/NixOS/nixpkgs/commit/1a14dc6e44ee905e5e404c6360980be8c70f3884) haskellPackages.callPackage: preserve functionArgs
* [`af3ddfa2`](https://github.com/NixOS/nixpkgs/commit/af3ddfa2b42730c153e1ea1d39b9ce0ec5a8d22e) python3Packages.pyenchant: 3.2.2 -> 3.3.0
* [`717bb9db`](https://github.com/NixOS/nixpkgs/commit/717bb9db24be2f3104e21511645bca83996b39fe) lib/types: submodule fix description with freeformType
* [`0898e7bc`](https://github.com/NixOS/nixpkgs/commit/0898e7bc0d416f2af0a55a089fcbba417c622309) lief: Fix failing build
* [`c761a3fb`](https://github.com/NixOS/nixpkgs/commit/c761a3fb98cdb8cb476c057ed0077bccce22f19c) lief: Add nix-update-script
* [`d692d6ee`](https://github.com/NixOS/nixpkgs/commit/d692d6ee28361fff78c1c4be77c912b6518b94d3) dolt: 1.59.2 -> 1.59.10
* [`de5a6242`](https://github.com/NixOS/nixpkgs/commit/de5a6242e8893fa6c4360e1657a9b2f7891cc3e7) python313Packages.holidays: 0.80 -> 0.81
* [`d71d93c5`](https://github.com/NixOS/nixpkgs/commit/d71d93c5ed2e55f362b522e19c63a6a51d0b568a) diesel-cli: 2.2.12 -> 2.3.0
* [`57ec47db`](https://github.com/NixOS/nixpkgs/commit/57ec47db4708c2eba67433e96d71d3d93dd987a1) dotnet-ef: 9.0.8 -> 9.0.9
* [`c59bb412`](https://github.com/NixOS/nixpkgs/commit/c59bb412974eccdfcdf203fc1b39f9dfd65423ab) python3Packages.trl: 0.22.2 -> 0.23.0
* [`1ca1329e`](https://github.com/NixOS/nixpkgs/commit/1ca1329e2f9396e9444150735059aa491877c73b) lefthook: 1.12.4 -> 1.13.0
* [`9c460b6e`](https://github.com/NixOS/nixpkgs/commit/9c460b6e749241d87bc3179fef4d5ef2f4c3825d) rutabaga_gfx: enable debug info
* [`88093492`](https://github.com/NixOS/nixpkgs/commit/88093492f7d157c8742c3da06276dc021935625b) alfaview: 9.22.12 -> 9.23.1
* [`1152347e`](https://github.com/NixOS/nixpkgs/commit/1152347e78afcf938f6a61b7930f5ddb00506868) tqsl: 2.8.1 -> 2.8.2
* [`9dfc3e3c`](https://github.com/NixOS/nixpkgs/commit/9dfc3e3ce52e4c44abd8a0d371cc4d52919d0578) passt: 2025_08_05.309eefd -> 2025_09_11.6cbcccc
* [`f2261262`](https://github.com/NixOS/nixpkgs/commit/f22612621dd65590b8f12f74d8cb943b4bff1b7e) vscode-extensions.ms-dotnettools.csharp: 2.89.19 -> 2.90.60
* [`f80e6944`](https://github.com/NixOS/nixpkgs/commit/f80e6944cca320bf63cce1c3001f580449771060) whisparr: 2.0.0.1253 -> 2.0.0.1278
* [`f7f9a2cb`](https://github.com/NixOS/nixpkgs/commit/f7f9a2cb70fba91cdd7e18ec3f437c5e1e497d46) flyway: 11.11.0 -> 11.13.0
* [`4643be49`](https://github.com/NixOS/nixpkgs/commit/4643be49280ba1e93f9b8f26229eedd19c435737) syncstorage-rs: 0.20.1 -> 0.21.0
* [`a3b8c00f`](https://github.com/NixOS/nixpkgs/commit/a3b8c00f2b60a6b6ec463c0c43a89de990940b1c) networkmanager-fortisslvpn: add fix for pppd-2.5.2
* [`cfcea9c6`](https://github.com/NixOS/nixpkgs/commit/cfcea9c6581454c0b7b46b4397d87f06718a24c6) rclone-ui: 1.7.1 -> 2.2.0
* [`f5a3c932`](https://github.com/NixOS/nixpkgs/commit/f5a3c93215e42971781bf963779d0e3f623b16e9) electron_36-bin: 36.8.1 -> 36.9.1
* [`ff8b5b41`](https://github.com/NixOS/nixpkgs/commit/ff8b5b418dc3d4974e9b79faf7ffb42c0b0033ab) electron-chromedriver_36: 36.8.1 -> 36.9.1
* [`6a634ade`](https://github.com/NixOS/nixpkgs/commit/6a634ade04367af357645ee8d008ae69f3dcafbe) electron_37-bin: 37.4.0 -> 37.5.1
* [`49b9e20f`](https://github.com/NixOS/nixpkgs/commit/49b9e20f6d777cc0882952600b3ab78a964e4e66) electron-chromedriver_37: 37.4.0 -> 37.5.1
* [`35cb0d92`](https://github.com/NixOS/nixpkgs/commit/35cb0d92d8d6dadf13053954f989e1a61aad5534) lib/tests/modules: Test description composition
* [`2202d4ac`](https://github.com/NixOS/nixpkgs/commit/2202d4ac7712320d429e55b5e7d76c1b00564ce5) wine64Packages.{unstable,staging}: 10.14 -> 10.15
* [`2a57b635`](https://github.com/NixOS/nixpkgs/commit/2a57b635ff090176b2c7fdad2b5d679b8163af6b) rspamd: 3.12.1 -> 3.13.0
* [`cfddfd28`](https://github.com/NixOS/nixpkgs/commit/cfddfd28df2c253c0ec0e0d3152aa8cdadc52bb7) vscode-extensions.github.copilot: 1.350.0 -> 1.372.0
* [`e55f687a`](https://github.com/NixOS/nixpkgs/commit/e55f687a9baf59018e2c74e48f5fa5b38017c0c0) etlegacy-unwrapped: enable `strictDeps`
* [`2412bf89`](https://github.com/NixOS/nixpkgs/commit/2412bf89b0f00b0cd916640036fc749ab4b97d13) etlegacy-unwrapped: use `lib.cmake*` functions
* [`df3b69d7`](https://github.com/NixOS/nixpkgs/commit/df3b69d77d402c988bbac4ecdc71861569140dda) etlegacy-unwrapped: add more cmakeFlags
* [`4903a160`](https://github.com/NixOS/nixpkgs/commit/4903a160965f424708d6a6b86cc749631ceaded7) etlegacy-unwrapped: remove `preBuild`
* [`080e0bf1`](https://github.com/NixOS/nixpkgs/commit/080e0bf1aef42f9f41c67144577bf553df610446) ecs-agent: 1.98.0 -> 1.99.0
* [`f5888d15`](https://github.com/NixOS/nixpkgs/commit/f5888d15f80e5d341d99280db6fa8e1990a5ab41) fzf-lua: disable flakey tests
* [`71a45c98`](https://github.com/NixOS/nixpkgs/commit/71a45c98181bfd2b47d3a6ea17f4f2a7fe974757) nextcloud-client: 3.17.1 -> 3.17.2
* [`ace466b8`](https://github.com/NixOS/nixpkgs/commit/ace466b8dc84c65d38e435e66af7853bd64f365a) vscode-extensions.github.copilot-chat: 0.30.1 -> 0.31.0
* [`bc6ab16c`](https://github.com/NixOS/nixpkgs/commit/bc6ab16c90efb8aeb9c34fbbc375f2c66aeae39d) Revert "pyroaring: Override Cython version for tests/build"
* [`9faa942d`](https://github.com/NixOS/nixpkgs/commit/9faa942deec8d59bc145040ebfdd4fdc11e08e3b) python3Packages.docling-core: 2.45.0 -> 2.48.1
* [`b3995ee9`](https://github.com/NixOS/nixpkgs/commit/b3995ee921f5d392a18f85c31ea1e7f2148ebbce) rure: 0.2.2 -> 0.2.3
* [`e631a27f`](https://github.com/NixOS/nixpkgs/commit/e631a27feb81502c0e1fe540a819f5ad8ce64e6d) electron_38-bin: 38.0.0 -> 38.1.2
* [`eb705983`](https://github.com/NixOS/nixpkgs/commit/eb70598327a29998021666a79e2d339fdb418d2e) electron-chromedriver_38: 38.0.0 -> 38.1.2
* [`980c2b3b`](https://github.com/NixOS/nixpkgs/commit/980c2b3b91be8189c0edc5c6b026e8814f9e606f) electron-source.electron_36: 36.8.1 -> 36.9.1
* [`97149bcc`](https://github.com/NixOS/nixpkgs/commit/97149bcce18173cf77f5aa6bd34f4c40cddac3ba) electron-source.electron_37: 37.4.0 -> 37.5.1
* [`b5c8484b`](https://github.com/NixOS/nixpkgs/commit/b5c8484b585cf4df2542f87704f11ffcfdf56022) electron-source.electron_38: 38.0.0 -> 38.1.2
* [`62b53e77`](https://github.com/NixOS/nixpkgs/commit/62b53e77993775b4fac7f00c268784cd49cd5ff5) web-ext: 8.9.0 -> 8.10.0
* [`76789bd9`](https://github.com/NixOS/nixpkgs/commit/76789bd9f031d8a4a1f85a08db4b3c73ebe771b8) lix: add nix-update
* [`b91a7322`](https://github.com/NixOS/nixpkgs/commit/b91a7322fb08fd1a768aa7ea6e1694b334f40796) julia_110: 1.10.9 -> 1.10.10
* [`1e99817c`](https://github.com/NixOS/nixpkgs/commit/1e99817c08d832e7c246d3efa12aef2a9ba3af34) julia_110-bin: 1.10.9 -> 1.10.10
* [`0d20243e`](https://github.com/NixOS/nixpkgs/commit/0d20243eb6494389d34ba0ec613e5d5eca3f742b) movit: 1.7.1 -> 1.7.2
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
