### PR TITLE
npins home-manager: update 9a2dc0ef -> 12fa8548

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -61,9 +61,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "9a2dc0efbc569ce9352a6ffb8e8ec8dbc098e142",
-      "url": "https://github.com/nix-community/home-manager/archive/9a2dc0efbc569ce9352a6ffb8e8ec8dbc098e142.tar.gz",
-      "hash": "14xnr63ljq7ysas104vd46r0d1nwjwkjwgr0jfgdq876yzh79vx7"
+      "revision": "12fa8548feefa9a10266ba65152fd1a787cdde8f",
+      "url": "https://github.com/nix-community/home-manager/archive/12fa8548feefa9a10266ba65152fd1a787cdde8f.tar.gz",
+      "hash": "0dyy7wdbj1qcksf9z6rvwm2iz95bjvlbm1kfbc2zkbnz2nqvri8k"
     },
     "hs-grille": {
       "type": "Git",


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@9a2dc0ef...12fa8548](https://github.com/nix-community/home-manager/compare/9a2dc0efbc569ce9352a6ffb8e8ec8dbc098e142...12fa8548feefa9a10266ba65152fd1a787cdde8f)

* [`366b60b8`](https://github.com/nix-community/home-manager/commit/366b60b8a06d237dbadd9a573ab21532dec70031) ahoviewer: add module
* [`5468c92a`](https://github.com/nix-community/home-manager/commit/5468c92a2350ca76e15ee6617a083c0e6ce7ade7) news: add ahoviewer entry
* [`293d1059`](https://github.com/nix-community/home-manager/commit/293d105993e07fb92deb68a150ca801e3e459c85) anki: strip usernameFile and passwordFile contents
* [`f5852ea3`](https://github.com/nix-community/home-manager/commit/f5852ea36c05f48d01d6e378d45449c962ba6fb4) anki: fix `ankiAddons.passfail2` example
* [`131f4e22`](https://github.com/nix-community/home-manager/commit/131f4e22c30c114378dcf6191cb75c97eba673d0) anki: rename `sync.passwordFile`, improve documentation
* [`676c0159`](https://github.com/nix-community/home-manager/commit/676c0159ed51d10489a249ecdc61e115c2a90d03) sway: print hint when checking the config file fails ([nix-community/home-manager⁠#7665](https://togithub.com/nix-community/home-manager/issues/7665))
* [`ef376249`](https://github.com/nix-community/home-manager/commit/ef3762499bb1ecd542e236b5b073c3c9399f8782) flake.lock: Update ([nix-community/home-manager⁠#7864](https://togithub.com/nix-community/home-manager/issues/7864))
* [`cb68b5cd`](https://github.com/nix-community/home-manager/commit/cb68b5cd6a90325c05a9aa0cb27d8c1c98bc14ae) syncthing: handle per-folder `encryptionPasswordFile`
* [`6ce2e180`](https://github.com/nix-community/home-manager/commit/6ce2e18007ff022db41d9cc042f8838e8c51ed66) nix-your-shell: Allow using `nom` for `nix` commands
* [`f678263e`](https://github.com/nix-community/home-manager/commit/f678263ecf5b347ed98d2a187d37d052c4f71b0c) mpvpaper: fix typos
* [`d398f95f`](https://github.com/nix-community/home-manager/commit/d398f95f1e9108f18c7dbe45423c71ccf52497c4) nixgl: use original package name
* [`142acd7a`](https://github.com/nix-community/home-manager/commit/142acd7a7d9eb7f0bb647f053b4ddfd01fdfbf1d) bash: source session variable file directly
* [`68a92b03`](https://github.com/nix-community/home-manager/commit/68a92b0301ac0a2d5ac2c60aadce6bc8460591b5) aiac: add module
* [`2e260431`](https://github.com/nix-community/home-manager/commit/2e260431fca7a782e0d0591985f2040944b43541) news: add aiac entry
* [`e2ecfbf6`](https://github.com/nix-community/home-manager/commit/e2ecfbf6d034617f85b38fa9043d0539da2d5c03) tahoe-lafs: update default package
* [`74a78aac`](https://github.com/nix-community/home-manager/commit/74a78aacb7fe6b5d8fac79f9314abddbdaf07f09) maintainers: update all-maintainers.nix
* [`ade85015`](https://github.com/nix-community/home-manager/commit/ade850153b41793e785e730f812b09302e9fd3b4) syncthing: remove deprecated code
* [`23245405`](https://github.com/nix-community/home-manager/commit/232454052008027c8e925979d13a951e92729781) syncthing: assert tray service content in test
* [`39d26c16`](https://github.com/nix-community/home-manager/commit/39d26c16866260eee6d0487fe9c102ba1c1bf7b2) ssh-agent: add defaultMaximumIdentityLifetime setting ([nix-community/home-manager⁠#7876](https://togithub.com/nix-community/home-manager/issues/7876))
* [`c1a47eae`](https://github.com/nix-community/home-manager/commit/c1a47eae05fb93788d3e3a7f1e63d7fc34d60c63) desktoppr: init module ([nix-community/home-manager⁠#7878](https://togithub.com/nix-community/home-manager/issues/7878))
* [`f3235d91`](https://github.com/nix-community/home-manager/commit/f3235d91abedc9bcfdcbf1d7807b5bce94258884) mods: get ipsavitsky from Nixpkgs maintainers list
* [`ef5c1426`](https://github.com/nix-community/home-manager/commit/ef5c1426bfb558f13cf0e585e1b2830ded87a970) maintainers: update all-maintainers.nix
* [`40e91665`](https://github.com/nix-community/home-manager/commit/40e916658dcbd4e66647a68f502ff8e98c311027) maintainers: remove ipsavitsky
* [`80094132`](https://github.com/nix-community/home-manager/commit/800941320b26d699cd78dd427ecaf116b2bafbf3) syncthing: install tray package when tray is enabled
* [`29e8b08f`](https://github.com/nix-community/home-manager/commit/29e8b08f65b4f45831ae6d6e4d14affb6c86fa31) maintainers: add aionescu
* [`b91c7e43`](https://github.com/nix-community/home-manager/commit/b91c7e43ed7ee644b032b068343472a48c703a10) syncthing: add aionescu as maintainer
* [`173a29f7`](https://github.com/nix-community/home-manager/commit/173a29f735c69950cfeaac310d7e567115976be0) docs: add note of Synthing tray option removal
* [`6238bbc0`](https://github.com/nix-community/home-manager/commit/6238bbc0ae04951b64a3ad1b69d3e03b8b329e51) tailscale-systray: add module ([nix-community/home-manager⁠#7821](https://togithub.com/nix-community/home-manager/issues/7821))
* [`8a135785`](https://github.com/nix-community/home-manager/commit/8a1357854d21246059d79258b0752834f965ee25) airlift: add module
* [`fb2ae64b`](https://github.com/nix-community/home-manager/commit/fb2ae64bed1ee4997a8e350bc18f4bc5bffa670c) news: add airlift entry
* [`9947d3c0`](https://github.com/nix-community/home-manager/commit/9947d3c003e414e29b13e76884b21a482563f5fb) aider-chat: add module
* [`35329d44`](https://github.com/nix-community/home-manager/commit/35329d44f3e3578fb33fc7e410c5b26a05fb1e53) news: add aider-chat entry
* [`e3e15e76`](https://github.com/nix-community/home-manager/commit/e3e15e765d164454db72ca30290c2d3a4917daf9) aichat: add agents option
* [`497e2bfa`](https://github.com/nix-community/home-manager/commit/497e2bfa8a45bebe9788e2aa13e766e6a96677cd) news: add aichat agents option entry
* [`bc2afee5`](https://github.com/nix-community/home-manager/commit/bc2afee55bc5d3b825287829d6592b9cc1405aad) Translate using Weblate (Russian)
* [`11cc3d55`](https://github.com/nix-community/home-manager/commit/11cc3d55ded3346a8195000ddeadde782a611e56) macos-remap-keys: add NonUSBackslash keycode
* [`a8dbb4e3`](https://github.com/nix-community/home-manager/commit/a8dbb4e325e9fce15f96de8e77bdbb7c9af6e51d) lib/shell: add formatShellArrayContent function for intelligent width optimization
* [`5176d93c`](https://github.com/nix-community/home-manager/commit/5176d93c0a0e5c25a08f298c7f1c4268d4726e5e) lib/zsh: fix shell escaping and integrate formatShellArrayContent
* [`bd81c11e`](https://github.com/nix-community/home-manager/commit/bd81c11eb3f854befe8f165cf23b0047fd621eab) tests/darwinScrublist: add zsh-history-substring-search
* [`c26a2ac2`](https://github.com/nix-community/home-manager/commit/c26a2ac2e430f0a54495eca33b5df342cbcd736e) zsh/plugins: optimize plugin loading with array-based loops
* [`04f672b5`](https://github.com/nix-community/home-manager/commit/04f672b5db5ed5b2fa56aff523089cd29049cb4d) zsh/history: optimize history options with array-based loops
* [`3aaf3401`](https://github.com/nix-community/home-manager/commit/3aaf340173d3151dd131f679b3bf419da5cd456b) zsh: optimize setOptions with array-based loops
* [`26ace005`](https://github.com/nix-community/home-manager/commit/26ace005b720b7628fdf2d4923e7feecdd1631c4) tests/zsh: add comprehensive smart formatting test
* [`1dbb3fd2`](https://github.com/nix-community/home-manager/commit/1dbb3fd2f79c804859e6b65fd42f164f7527ff39) radio-active: add module to create config files
* [`c75fd8e3`](https://github.com/nix-community/home-manager/commit/c75fd8e300b79502b8eecdacd8a426b12fadb460) gurk-rs: remove references to deprecated 'data_path' option
* [`64a809b1`](https://github.com/nix-community/home-manager/commit/64a809b198904668c043d662043d17e14498cd54) lib/zsh: exportAll add support for indentation
* [`2b03dc82`](https://github.com/nix-community/home-manager/commit/2b03dc82bb1c47af32d90edc8ebeb887c93d9b7e) lib/zsh: revert escapeShellArg in toZshValue
* [`a97df40c`](https://github.com/nix-community/home-manager/commit/a97df40c1966cc46b5f6817ac8d8e240da03de96) zsh: envVarsStr fix indentation
* [`e9114f96`](https://github.com/nix-community/home-manager/commit/e9114f96efc6e40ecf60e3db130c0a0ca88d1800) tests: rename test-all-* tests
* [`6ee84731`](https://github.com/nix-community/home-manager/commit/6ee8473173af7a0181a788e8a3d4fa164f4cc72c) tests: improve debugging for failed test runs
* [`50375df1`](https://github.com/nix-community/home-manager/commit/50375df1f734f955a6b532bcc900c2588cddd3ab) git-worktree-switcher: use cfg.package
* [`580ff74a`](https://github.com/nix-community/home-manager/commit/580ff74a7132af3228f7dd778a07083b3c338aeb) intelli-shell: add module
* [`619ae569`](https://github.com/nix-community/home-manager/commit/619ae569293b6427d23cce4854eb4f3c33af3eec) news: add intelli-shell entry
* [`12fa8548`](https://github.com/nix-community/home-manager/commit/12fa8548feefa9a10266ba65152fd1a787cdde8f) maintainers: update all-maintainers.nix
