### PR TITLE
npins emacs-overlay: update 99a77c3d -> cfbc2529

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -35,9 +35,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "99a77c3da5376924f367515fee48795b8ac2368e",
-      "url": "https://github.com/nix-community/emacs-overlay/archive/99a77c3da5376924f367515fee48795b8ac2368e.tar.gz",
-      "hash": "1cr19crxjggnyg9s14kl1f5nhpg9i6x1b1l3vajmv9spwyk4ch40"
+      "revision": "cfbc2529bc343fd8bb2c7d69e29f2fe440ce8461",
+      "url": "https://github.com/nix-community/emacs-overlay/archive/cfbc2529bc343fd8bb2c7d69e29f2fe440ce8461.tar.gz",
+      "hash": "0c40icpzg5shg8lh08ak939h9039pa1gl9rp59ll197sci3ff0lf"
     },
     "fast-syntax-highlighting": {
       "type": "Git",


### PR DESCRIPTION
## Changelog for emacs-overlay:
Branch: master
Commits: [nix-community/emacs-overlay@99a77c3d...cfbc2529](https://github.com/nix-community/emacs-overlay/compare/99a77c3da5376924f367515fee48795b8ac2368e...cfbc2529bc343fd8bb2c7d69e29f2fe440ce8461)

* [`5288aebc`](https://github.com/nix-community/emacs-overlay/commit/5288aebc1845c595d226aacb3f401ecc154a59e9) Updated nongnu
* [`04941f76`](https://github.com/nix-community/emacs-overlay/commit/04941f76d73d89b2685bcee582cccd8e3caddee5) Updated elpa
* [`b887fad1`](https://github.com/nix-community/emacs-overlay/commit/b887fad13f43c1413cd0c02d9075e2fa7475c054) Updated emacs
* [`f834197d`](https://github.com/nix-community/emacs-overlay/commit/f834197dfd4d117ff82d12bd786df02ae16184ec) Updated melpa
* [`cc519514`](https://github.com/nix-community/emacs-overlay/commit/cc5195141dc93bcd011f7a41d224bd0500735c2a) Updated emacs
* [`9dcb4744`](https://github.com/nix-community/emacs-overlay/commit/9dcb4744b824c3853273ae9886e3af81d4bdb53b) Updated nongnu
* [`057134e4`](https://github.com/nix-community/emacs-overlay/commit/057134e47725e8f7b7fee1609ea8b4b434fd7007) Updated melpa
* [`043c6499`](https://github.com/nix-community/emacs-overlay/commit/043c6499bd66428e65792254000608da164348a6) Updated melpa
* [`01c77a3c`](https://github.com/nix-community/emacs-overlay/commit/01c77a3c58b4af9c85334be7f482064987b7fab6) Updated nongnu
* [`d5394e0f`](https://github.com/nix-community/emacs-overlay/commit/d5394e0ff930bdd8699842e5eea7e9b557d746e9) Updated elpa
* [`bb4b6942`](https://github.com/nix-community/emacs-overlay/commit/bb4b6942dfd82f00b5019e0c47cca3ecbe1e2a12) Updated melpa
* [`a94e03ae`](https://github.com/nix-community/emacs-overlay/commit/a94e03ae59662d13fadea35ff3a33dc4f2d2967a) Updated flake inputs
* [`17fc4e4c`](https://github.com/nix-community/emacs-overlay/commit/17fc4e4cec11da220ac24b047f388f1597ffa4cc) Updated melpa
* [`b4ffd36b`](https://github.com/nix-community/emacs-overlay/commit/b4ffd36bc464accccc8868d7ec498eeb21c6d272) Updated emacs
* [`03126bdf`](https://github.com/nix-community/emacs-overlay/commit/03126bdf0b4df3a958fe3e95ec462fcb07d6232f) Updated nongnu
* [`e49bf2e2`](https://github.com/nix-community/emacs-overlay/commit/e49bf2e2204fb2eb634230cab0467173c8c79ab9) Updated elpa
* [`92e902ee`](https://github.com/nix-community/emacs-overlay/commit/92e902ee0a9be5545b505d24aa29686e32d50688) Updated emacs
* [`8643ba44`](https://github.com/nix-community/emacs-overlay/commit/8643ba44d1a1b5620a4802b5d493066c4d659fff) Updated melpa
* [`ddd34c2f`](https://github.com/nix-community/emacs-overlay/commit/ddd34c2fd130286a1fd2c3348dc0937fc2933d93) Updated flake inputs
* [`950f083e`](https://github.com/nix-community/emacs-overlay/commit/950f083ecb6a28f5da554e717ec90236bb5b277f) Updated emacs
* [`d9cac052`](https://github.com/nix-community/emacs-overlay/commit/d9cac052bcce82ca1eddb9e0300864a4cba3685c) Updated melpa
* [`572ef0d5`](https://github.com/nix-community/emacs-overlay/commit/572ef0d5b21ddae7d3356245b02ececc97ede8dc) Updated nongnu
* [`6c351033`](https://github.com/nix-community/emacs-overlay/commit/6c351033c56048587373e0ccc7b58ec002d34cba) Updated elpa
* [`6f7ef377`](https://github.com/nix-community/emacs-overlay/commit/6f7ef37742542c945eb3c7757ba3d2307f95f1ff) Updated melpa
* [`f8ffe04b`](https://github.com/nix-community/emacs-overlay/commit/f8ffe04b8e762a68fb945aaa7619739e42fd0180) Updated emacs
* [`dc0ef993`](https://github.com/nix-community/emacs-overlay/commit/dc0ef9939b584f123e030f9190c25c3489dab280) flake: disable CI for packages
* [`f66ba510`](https://github.com/nix-community/emacs-overlay/commit/f66ba510a95e8b10ab75ce4e23c14dffbddbe2df) Updated elpa
* [`ae272f2e`](https://github.com/nix-community/emacs-overlay/commit/ae272f2e025837c21cf6b62eeaef4022f5388e4a) Updated emacs
* [`c246cffd`](https://github.com/nix-community/emacs-overlay/commit/c246cffd985000b3f7019e24193e0da6ab5a5ff1) Updated melpa
* [`62b58b64`](https://github.com/nix-community/emacs-overlay/commit/62b58b64da779d0962d1761513a5acea3581506a) Updated emacs
* [`516ffa34`](https://github.com/nix-community/emacs-overlay/commit/516ffa347ff2ed3ea4b5283625ca0c6b1a1e31a3) Updated melpa
* [`6459b6ce`](https://github.com/nix-community/emacs-overlay/commit/6459b6ce561e84c2874b708b7aeb2b0a6e3799d8) Updated flake inputs
* [`9d2a795c`](https://github.com/nix-community/emacs-overlay/commit/9d2a795c53c196d51d8cf04d74af997aa85a415c) Updated elpa
* [`453807e1`](https://github.com/nix-community/emacs-overlay/commit/453807e1b7e47698c5153e541993300ddf51fc3f) Updated emacs
* [`e8a89297`](https://github.com/nix-community/emacs-overlay/commit/e8a8929793f54a3e80e29a2e357fbeaa81a3b1a6) Updated melpa
* [`1ac9e5fd`](https://github.com/nix-community/emacs-overlay/commit/1ac9e5fd1cc2dcb4b7df9f716442ba3fe0f51cdf) Updated elpa
* [`871a991a`](https://github.com/nix-community/emacs-overlay/commit/871a991a9a17961e628ea88a0ee0fcf609576045) Updated emacs
* [`ecdeee43`](https://github.com/nix-community/emacs-overlay/commit/ecdeee43fa4e1047496367bfcafff020e1d69d33) Updated melpa
* [`8a1407c6`](https://github.com/nix-community/emacs-overlay/commit/8a1407c6c868212574126672bc6342612013cb45) Updated melpa
* [`56eac524`](https://github.com/nix-community/emacs-overlay/commit/56eac524f805feb8eca1858c3631a46246bac54c) Updated elpa
* [`a0d5de7e`](https://github.com/nix-community/emacs-overlay/commit/a0d5de7eb9918bf34e4d6fd23e801068b93e91a1) Updated melpa
* [`43ffdf3f`](https://github.com/nix-community/emacs-overlay/commit/43ffdf3f1b3fdef5cfda0647e3e7b2ae001a8970) Updated emacs
* [`e88a8c1e`](https://github.com/nix-community/emacs-overlay/commit/e88a8c1edf089b1a31378cf48f7ca3854950dc2a) Updated nongnu
* [`90c2cdd9`](https://github.com/nix-community/emacs-overlay/commit/90c2cdd92cdad829c7c9559e0ecf95107a73efeb) Updated melpa
* [`633b25a0`](https://github.com/nix-community/emacs-overlay/commit/633b25a08a0fd1b931a12dc185240443946e06df) Updated emacs
* [`ee925145`](https://github.com/nix-community/emacs-overlay/commit/ee925145ceeb4ff7733696bfc757366526aad520) Updated nongnu
* [`3f5391ed`](https://github.com/nix-community/emacs-overlay/commit/3f5391edb3f54201632ff6ed05a5e3069f6f1215) Updated emacs
* [`f6188135`](https://github.com/nix-community/emacs-overlay/commit/f6188135617b494d9b72d2afdfcc494eb1b1aae1) Updated melpa
* [`e56e3cf9`](https://github.com/nix-community/emacs-overlay/commit/e56e3cf9c95955f7afeaafb3963ce8ba7ea87f45) Updated nongnu
* [`3e015f31`](https://github.com/nix-community/emacs-overlay/commit/3e015f31aaa873395d1c5a147cfd3efcd1dc3ec4) Updated elpa
* [`9a099da4`](https://github.com/nix-community/emacs-overlay/commit/9a099da4716649b9348d807c2cede581c0e657e4) Updated emacs
* [`dff97e46`](https://github.com/nix-community/emacs-overlay/commit/dff97e46997a60c0ade49d2c7fbd3d7326685401) Updated melpa
* [`6c807468`](https://github.com/nix-community/emacs-overlay/commit/6c807468657f849e02da981f0d2bfd9b61b1c9ca) Updated flake inputs
* [`d3276d9c`](https://github.com/nix-community/emacs-overlay/commit/d3276d9c743cb8513c1e794d604e1a9921c92e52) Updated emacs
* [`2683597c`](https://github.com/nix-community/emacs-overlay/commit/2683597cc70f74a05204ef55c09ef3e6404c4571) Updated melpa
* [`97f944f3`](https://github.com/nix-community/emacs-overlay/commit/97f944f361d883b47ad966c55b2db4f617bd99aa) Updated nongnu
* [`725cd770`](https://github.com/nix-community/emacs-overlay/commit/725cd7702e72d0abc79dc20b77b2d1357248fad1) Updated elpa
* [`5c63591b`](https://github.com/nix-community/emacs-overlay/commit/5c63591b945d6481ee22c2bd97a1a91b7623be5b) Updated melpa
* [`d21be2ca`](https://github.com/nix-community/emacs-overlay/commit/d21be2ca90a6cca9472badf9daf0996eaea558f4) Updated nongnu
* [`058a43b0`](https://github.com/nix-community/emacs-overlay/commit/058a43b0a9a8630e657bc14f45c236bebef8d9be) Updated elpa
* [`aab07703`](https://github.com/nix-community/emacs-overlay/commit/aab07703746ba0617c263ccdccfb0062dc0814fd) Updated melpa
* [`cf579e6a`](https://github.com/nix-community/emacs-overlay/commit/cf579e6aea7aa153c4bacfb0b75869f4194447fd) Updated emacs
* [`fd1b0b2d`](https://github.com/nix-community/emacs-overlay/commit/fd1b0b2df9c05906c4f1c1ead79bbf5add591ea9) Updated emacs
* [`d8da68a0`](https://github.com/nix-community/emacs-overlay/commit/d8da68a0986380aca8ee9d277dfc4bcb0761a278) Updated melpa
* [`01c0bcfc`](https://github.com/nix-community/emacs-overlay/commit/01c0bcfc15ab4cabea974726fb9a66b400c0eb09) Updated elpa
* [`efb0ccd8`](https://github.com/nix-community/emacs-overlay/commit/efb0ccd83eca4b5fd440498556e5a1e9d04e6d4e) Updated melpa
* [`82c3f2cb`](https://github.com/nix-community/emacs-overlay/commit/82c3f2cb4656736607ffc7b607d9c5698b5df7f5) Updated emacs
* [`94eabe74`](https://github.com/nix-community/emacs-overlay/commit/94eabe7490cc8c1fd7343eb779878c2325fe5276) Updated elpa
* [`61d529e7`](https://github.com/nix-community/emacs-overlay/commit/61d529e7fb31de10c2821dece2c2940d0640ef42) Updated emacs
* [`6ba433b4`](https://github.com/nix-community/emacs-overlay/commit/6ba433b4c2f1e8290ee6a4f75809a554c4996fd6) Updated melpa
* [`ad8a52b5`](https://github.com/nix-community/emacs-overlay/commit/ad8a52b5cee00daadfaa6a06b0e424acdc1bbdc2) flake: bump nixpkgs-stable from 24.11 to 25.05
* [`8bf7d1c4`](https://github.com/nix-community/emacs-overlay/commit/8bf7d1c413a2a76e80b231d6ecd6ea7fe1b82ed6) Updated flake inputs
* [`a14dd786`](https://github.com/nix-community/emacs-overlay/commit/a14dd786d7d9590e03e0d09b4bd0f68c60cdb22b) Updated flake inputs
* [`48e1dc9c`](https://github.com/nix-community/emacs-overlay/commit/48e1dc9ce71df2f9e381f320af90f2cdde2662db) Updated nongnu
* [`60f23470`](https://github.com/nix-community/emacs-overlay/commit/60f23470b563570b0e270e7ee65bb671bc6b5938) Updated elpa
* [`2a00cbdf`](https://github.com/nix-community/emacs-overlay/commit/2a00cbdf9b98bb9eb04d1bf1ecee64709062ef0a) Updated melpa
* [`01c1b347`](https://github.com/nix-community/emacs-overlay/commit/01c1b34701bd39882b4c0152f04093277c9f5964) Updated emacs
* [`1f546faa`](https://github.com/nix-community/emacs-overlay/commit/1f546faace6de422f3d04c42451c9cfb8f144467) Updated nongnu
* [`4d9dc667`](https://github.com/nix-community/emacs-overlay/commit/4d9dc6674d6fa2c3c96ae4a2726e4bf2382b2374) Updated elpa
* [`86809fc1`](https://github.com/nix-community/emacs-overlay/commit/86809fc195cc3ed5537c5d486d2155b867c9b34f) Updated melpa
* [`6a0d6f51`](https://github.com/nix-community/emacs-overlay/commit/6a0d6f5108fc5aeef4daed98927e77e3691db736) Updated emacs
* [`c902fe2d`](https://github.com/nix-community/emacs-overlay/commit/c902fe2dc5bc7d95381876e7b68065173af971b6) Updated melpa
* [`a18cb9f4`](https://github.com/nix-community/emacs-overlay/commit/a18cb9f41f256f4bddfa7ad24eea1bf597ed447f) Updated flake inputs
* [`bcd72eda`](https://github.com/nix-community/emacs-overlay/commit/bcd72edaec09fe4f6d00e2f771abbd3e076ba0d3) Updated nongnu
* [`a34cb671`](https://github.com/nix-community/emacs-overlay/commit/a34cb6712f9e49b13613141c1e4e1b18c0e16de2) Updated elpa
* [`aac62a1d`](https://github.com/nix-community/emacs-overlay/commit/aac62a1d330cd4d512a1a85c969d6059c06b79aa) Updated melpa
* [`804e75fd`](https://github.com/nix-community/emacs-overlay/commit/804e75fd1406faceeddd75014bf463dbf5140063) Updated emacs
* [`c4503a39`](https://github.com/nix-community/emacs-overlay/commit/c4503a398eeb6cd8baa5f1a7ed27c1c611f436e0) Updated nongnu
* [`1ae07374`](https://github.com/nix-community/emacs-overlay/commit/1ae073740413b053024a6cb7d112795f1716fb0d) Updated emacs
* [`0b082e40`](https://github.com/nix-community/emacs-overlay/commit/0b082e40b028bff0ab5f587105ace1c990fb2129) Updated melpa
* [`fc94b22f`](https://github.com/nix-community/emacs-overlay/commit/fc94b22fd2b6110333e03180c0e36ffd10ae2029) Updated melpa
* [`8090a7e8`](https://github.com/nix-community/emacs-overlay/commit/8090a7e800c7807399550eddabaf7ee737dcbe63) Updated nongnu
* [`934817c1`](https://github.com/nix-community/emacs-overlay/commit/934817c122e91467fa40bce02d6a75b22409d36e) Updated elpa
* [`c277c4eb`](https://github.com/nix-community/emacs-overlay/commit/c277c4eb24ccb99e0085793968e3b4be96117bec) Updated melpa
* [`f7be96f6`](https://github.com/nix-community/emacs-overlay/commit/f7be96f6f80ba65df30222d9a5cfadf26cf62355) Updated emacs
* [`ae313267`](https://github.com/nix-community/emacs-overlay/commit/ae313267896909fdedbf5c22f3b98e64780db60d) Updated nongnu
* [`1883a57d`](https://github.com/nix-community/emacs-overlay/commit/1883a57dd9085f9a1f41d603f3fcece79693fe1b) Updated elpa
* [`18fbac05`](https://github.com/nix-community/emacs-overlay/commit/18fbac059a772b74ea6affc8743e3f7ba78e9e62) Updated emacs
* [`e347f768`](https://github.com/nix-community/emacs-overlay/commit/e347f7689da8a920769ea7e55ea4e59e7bc3c2fb) Updated melpa
* [`74195e2e`](https://github.com/nix-community/emacs-overlay/commit/74195e2e28e14cdd5dd863c4166dec79c4053913) Updated emacs
* [`ab90ecd7`](https://github.com/nix-community/emacs-overlay/commit/ab90ecd7dab0eda9e69d2cd0d697038078d360c5) Updated melpa
* [`3c590163`](https://github.com/nix-community/emacs-overlay/commit/3c590163ac587b0992e46db5d7d7c7ad9fa6cd2e) Updated nongnu
* [`5e2ff030`](https://github.com/nix-community/emacs-overlay/commit/5e2ff030884005adf2b5eb16bbc3532c4e551001) Updated elpa
* [`d4e5cd0c`](https://github.com/nix-community/emacs-overlay/commit/d4e5cd0c419ae11cbaa73a0849b392f0884d0f03) Updated emacs
* [`ae2a5949`](https://github.com/nix-community/emacs-overlay/commit/ae2a59490e94c38d917d1e1bc479bdab6c9c8f1c) Updated melpa
* [`2166fe91`](https://github.com/nix-community/emacs-overlay/commit/2166fe91297633f2628f531e851d815953a5f171) Updated nongnu
* [`08ced8ed`](https://github.com/nix-community/emacs-overlay/commit/08ced8ed79afe6dcd0c93d37d2620d4aaf02d226) Updated elpa
* [`c8f778ca`](https://github.com/nix-community/emacs-overlay/commit/c8f778ca07cc9d8182599be4e794db6c8e03682e) Updated melpa
* [`fa566057`](https://github.com/nix-community/emacs-overlay/commit/fa5660576dbbd2ae3a68f2e4e6ce8d2855cd4e9e) Updated emacs
* [`a10bc128`](https://github.com/nix-community/emacs-overlay/commit/a10bc128d5f7163149fab25c0e9d56113709356e) Updated melpa
* [`11a9ae10`](https://github.com/nix-community/emacs-overlay/commit/11a9ae10961f511d4c45f115337e982d5ae46e95) Updated flake inputs
* [`a821cd87`](https://github.com/nix-community/emacs-overlay/commit/a821cd87671c3f0c92d4b55778c9b33fd6639c5f) Updated emacs
* [`3c0da90f`](https://github.com/nix-community/emacs-overlay/commit/3c0da90f6e3c7d30201126ba830a457e2c5dc3d1) Updated elpa
* [`feaf095a`](https://github.com/nix-community/emacs-overlay/commit/feaf095a36708c269687bc2ebd565d3bfcd0322b) Updated melpa
* [`1eb9943e`](https://github.com/nix-community/emacs-overlay/commit/1eb9943e35d52668cebd5c87573b8d7bdac6beee) Updated flake inputs
* [`a179972e`](https://github.com/nix-community/emacs-overlay/commit/a179972e2d614813cc0948e59213c2d0bd784a7a) Updated nongnu
* [`6bbda1ce`](https://github.com/nix-community/emacs-overlay/commit/6bbda1ce5dc002b22c95323b01d40518e843a00d) Updated elpa
* [`4352af03`](https://github.com/nix-community/emacs-overlay/commit/4352af0369fe5d4e18c9131db3ed8a44dc879bfd) Updated emacs
* [`cfbc2529`](https://github.com/nix-community/emacs-overlay/commit/cfbc2529bc343fd8bb2c7d69e29f2fe440ce8461) Updated melpa
