### PR TITLE
npins doomemacs: update e10477d6 -> 5e7e93be

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -22,9 +22,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "e10477d6d1f1cd8c9369daad6b74f7d2e6e9fad9",
-      "url": "https://github.com/doomemacs/doomemacs/archive/e10477d6d1f1cd8c9369daad6b74f7d2e6e9fad9.tar.gz",
-      "hash": "08hfa5aaxwv76gv7p5j2zfm0w4vsnvqsmy0lr5zd6sni19zpg74i"
+      "revision": "5e7e93beb9f2b5a81768aaf4950203ceea21c4f6",
+      "url": "https://github.com/doomemacs/doomemacs/archive/5e7e93beb9f2b5a81768aaf4950203ceea21c4f6.tar.gz",
+      "hash": "08naf16b8svsxw2lqhvxglz8xvw5cz28rj7gjg7nhcf392hyibk3"
     },
     "emacs-overlay": {
       "type": "Git",


### PR DESCRIPTION
## Changelog for doomemacs:
Branch: master
Commits: [doomemacs/doomemacs@e10477d6...5e7e93be](https://github.com/doomemacs/doomemacs/compare/e10477d6d1f1cd8c9369daad6b74f7d2e6e9fad9...5e7e93beb9f2b5a81768aaf4950203ceea21c4f6)

* [`95a37518`](https://github.com/doomemacs/doomemacs/commit/95a375182b71aaa8bd99f2a25a800bc60b9d47c3) fix(python): remove 'basedpyright --stdio'
* [`e87a92be`](https://github.com/doomemacs/doomemacs/commit/e87a92be7572fec04b8a383acdace32f867130e8) tweak(magit): only preserve point if region-active-p
* [`6a270b64`](https://github.com/doomemacs/doomemacs/commit/6a270b64d57fc49e4f9ef8f491ff719b2fc0a78d) fix(direnv): void-variable Info-directory-list error
* [`fd03386f`](https://github.com/doomemacs/doomemacs/commit/fd03386f6dcf96ab5a885e235deb6c4f899b35dc) fix(org): jupyter-org-interaction-mode: remove redundant hook
* [`979b3aa8`](https://github.com/doomemacs/doomemacs/commit/979b3aa8c1c2f9615734bc790a463aabec5131b1) refactor(org): +jupyter: loader & ob-async blacklist
* [`e0729fa7`](https://github.com/doomemacs/doomemacs/commit/e0729fa7d7a0a22b5c431617ed362454aca11171) refactor!(debugger): remove dap-mode
* [`5614faca`](https://github.com/doomemacs/doomemacs/commit/5614faca7aa30a26dc22d541a3f38d87a3620f2c) docs(tree-sitter): revise installation docs
* [`4a6f9f74`](https://github.com/doomemacs/doomemacs/commit/4a6f9f741dc9a2c9a69ca9297385ffc0ab3f52cd) feat(tree-sitter): add +tree-sitter/doctor command
* [`395a807a`](https://github.com/doomemacs/doomemacs/commit/395a807aae955c47fe00fab79120ec3f20da1e4e) refactor(lib): move fringe/fontset autodefs to doom-compat
* [`7b35a313`](https://github.com/doomemacs/doomemacs/commit/7b35a31322a987b8f490623ca0ace3f6b7e5a549) fix(org): +jupyter: syntax highlighting for remapped modes
* [`6a630660`](https://github.com/doomemacs/doomemacs/commit/6a630660acfafd77e700c50d51984e326bdfdab0) fix(org): +jupyter: wrong-number-of-args error
* [`a4526fd1`](https://github.com/doomemacs/doomemacs/commit/a4526fd10dafe8f85ff573308bc3259493169197) refactor(org): remove ob-ditaa fix
* [`6eb46766`](https://github.com/doomemacs/doomemacs/commit/6eb467668e8111942126a3b831a55c5b7fe949f5) fix(org): update org-babel-python-command-nonsession
* [`b277d96d`](https://github.com/doomemacs/doomemacs/commit/b277d96d3ad0c5be5abc76959fa1932595545640) nit(tramp): simplify comments
* [`5217f377`](https://github.com/doomemacs/doomemacs/commit/5217f37703b03ee7125c1c3ae8849b033d807246) fix(tramp): magit-tramp-pipe-stty-settings typo
* [`b2c9faf3`](https://github.com/doomemacs/doomemacs/commit/b2c9faf3458667a1d807fb6eb03962300eb91e70) tweak(tramp): remote-file-name-inhibit-auto-save-visited = t
* [`0fb377c0`](https://github.com/doomemacs/doomemacs/commit/0fb377c0576b8e5269ab3e18b2966582bd750983) fix(tramp): direct-async + lsp-mode/eglot interop
* [`1b4a6298`](https://github.com/doomemacs/doomemacs/commit/1b4a629897fe78c129d5e321dcca57e3c7acc0f9) perf(tramp): memoize common TRAMP I/O
* [`63653091`](https://github.com/doomemacs/doomemacs/commit/63653091642a60d378a4dcf96bcf811c45d35cc7) tweak: use :tools (lsp +eglot) by default
* [`4159a4f7`](https://github.com/doomemacs/doomemacs/commit/4159a4f7da35aee8d04a8e25820b6e470b51d623) refactor(default): remove defunct taskrunner keybinds
* [`4c9dee2c`](https://github.com/doomemacs/doomemacs/commit/4c9dee2c7892175ea9d7ed53ded432e7bba5467d) fix(tree-sitter): treesit-extra-load-path: use file-name-concat
* [`a72c865c`](https://github.com/doomemacs/doomemacs/commit/a72c865c35b5ccd880078e96439107e48110599e) tweak(org): don't configure ob-python
* [`09a80927`](https://github.com/doomemacs/doomemacs/commit/09a80927f3708aa15febf7d7429782c934ad42da) docs(editorconfig): remove obsolete hack
* [`64b085b3`](https://github.com/doomemacs/doomemacs/commit/64b085b3816f557a6d66579532e90708e5b5f14f) fix(editorconfig): default to native binary, if available
* [`f3b4314d`](https://github.com/doomemacs/doomemacs/commit/f3b4314ddaf8f7253283f4bb001432fab8459f00) docs(editorconfig): revise usage section
* [`9debe1b3`](https://github.com/doomemacs/doomemacs/commit/9debe1b3fc62ed62e40243871dfb7c70b75ffdf8) bump: centered-window
* [`a9e08e15`](https://github.com/doomemacs/doomemacs/commit/a9e08e15d7edc015b664a984815dfdcc2f358d06) fix(php): treesit: PSR-2 indentation for chained methods
* [`ba189678`](https://github.com/doomemacs/doomemacs/commit/ba189678558efe0ae6b9a56a45d7935f4698ddc8) module: move :core to :doom
* [`849b1e4a`](https://github.com/doomemacs/doomemacs/commit/849b1e4aa8a5089943c0254e68db4a0bc40371d9) feat(org): org-roam-insert spacing in normal mode
* [`6ea4332b`](https://github.com/doomemacs/doomemacs/commit/6ea4332b854d311d7ec8ae6384fae8d9871f5730) docs(tramp): add hacks & minor revisions
* [`d92883bf`](https://github.com/doomemacs/doomemacs/commit/d92883bff8ff5457faa09b41a1e8e404c3693594) refactor!(org): remove org-roam v1
* [`3f964df0`](https://github.com/doomemacs/doomemacs/commit/3f964df041c96703c3ddc7622c21cd69a70fc359) fix(org): +roam: revert org-roam-db-gc-threshold to default
* [`3c10db68`](https://github.com/doomemacs/doomemacs/commit/3c10db6824df3b125744d3f898fbb463ccdc548c) fix(sml): company-mlton support in sml-ts-mode
* [`05578804`](https://github.com/doomemacs/doomemacs/commit/055788047c33b902e97ad51979a43cdb5f16f75b) fix(sml): mirror sml-mode config to sml-ts-mode
* [`2a652507`](https://github.com/doomemacs/doomemacs/commit/2a65250743497e55fbb423fc5cb68c4daa6d65d9) refactor(org): +roam: remove org-roam-v2-ack
* [`b43d748d`](https://github.com/doomemacs/doomemacs/commit/b43d748d673ef6d0a12f6c18ec464356be50e39d) fix(default): corfu-indexed-mode & RET interop
* [`eacd1a03`](https://github.com/doomemacs/doomemacs/commit/eacd1a030e31a7685f0b73bc0a30f04e03e0508f) fix(biblio): helm + org-cite-insert interop
* [`3436b2c3`](https://github.com/doomemacs/doomemacs/commit/3436b2c3baddca41a8d9f7e9f51f8d6ac0eb9dc5) fix: nerd-icons: overeager gopher icon
* [`fffefc31`](https://github.com/doomemacs/doomemacs/commit/fffefc311816aacec3961d19e4755ff21d19af5c) fix(format): consolidate save-without-formatting keybind
* [`c48aa185`](https://github.com/doomemacs/doomemacs/commit/c48aa1851ceb71d4f894a44deef1833df8175e6a) fix(org): load +roam.el for +roam2
* [`bdacdfa6`](https://github.com/doomemacs/doomemacs/commit/bdacdfa67cbf5bf10448bd27d6f6a09338136596) fix(format): register more ts-modes
* [`c27621a7`](https://github.com/doomemacs/doomemacs/commit/c27621a777c11354a4913c7eb455db3766984709) fix(evil): evil-respect-visual-line-mode: up/down/end/home keys
* [`fa6a2607`](https://github.com/doomemacs/doomemacs/commit/fa6a2607b723dfc99ece76870e909ae3284ef953) fix(lib): doom/sandbox: tree-sitter extra load path
* [`31c43cdc`](https://github.com/doomemacs/doomemacs/commit/31c43cdceb5d1390246414d9f081ef9ffe02416c) fix(ada): use gpr-specific modes and indent properly
* [`2b17ddc2`](https://github.com/doomemacs/doomemacs/commit/2b17ddc2cfec5118aa576dc6a740af4de023e1e4) docs(tramp): mention gdb-mi incompatibility
* [`fb9b359d`](https://github.com/doomemacs/doomemacs/commit/fb9b359dbe96809b741d347236f3dde399d27059) bump: nerd-icons
* [`230f8999`](https://github.com/doomemacs/doomemacs/commit/230f8999abf68848020258afb7ccc02765921933) fix(php): tree-sitter indent rule should use cdar instead of cadr
* [`4de16210`](https://github.com/doomemacs/doomemacs/commit/4de162108e1e521e26dfc4865e7df522592dddb0) feat: retry straight operations if they fail
* [`4f62b503`](https://github.com/doomemacs/doomemacs/commit/4f62b503b9c0eaaf35515b4e9c3f73d035665ba6) fix(elixir): use elixir-ls if in $PATH
* [`093488fc`](https://github.com/doomemacs/doomemacs/commit/093488fcb7c620a4a62734389c2a00c8380119aa) fix(lib): dependence on hash-table insertion order
* [`1bc2af6c`](https://github.com/doomemacs/doomemacs/commit/1bc2af6ce58073c4abf1ffdccdbbb65050879f4a) fix(lib): remove black hole insertions
* [`87a7efce`](https://github.com/doomemacs/doomemacs/commit/87a7efcea622eb4c59442298e3262940bb1f377f) fix(lib): package!: add :env property
* [`e2977963`](https://github.com/doomemacs/doomemacs/commit/e29779638714e9f6d91099807f629d5ae3bbcc86) fix(lsp): rebuild lsp-mode if lsp-use-plists is changed
* [`7e711d53`](https://github.com/doomemacs/doomemacs/commit/7e711d53cac8badaaa1a458e3e80d16495832a50) tweak(cli): only display the last, failed straight command
* [`22f86d25`](https://github.com/doomemacs/doomemacs/commit/22f86d25e9d7f26d4e27004c4788639846c72ad1) fix(elixir): void-variable lsp-elixir-server-command
* [`fbdde6b5`](https://github.com/doomemacs/doomemacs/commit/fbdde6b5f4ef27401f32c070b54c7080095a9f0b) module!: add :editor whitespace
* [`e32f39f5`](https://github.com/doomemacs/doomemacs/commit/e32f39f5e3ce22be1cbd02ca8e72bfa795701d02) refactor: s/doom-projectile-cache-dir/doom-project-cache-dir/
* [`395a058d`](https://github.com/doomemacs/doomemacs/commit/395a058d7de861a2883e65a52b79fa44bd7f16d9) feat(terraform): eglot: use tofu-ls if present
* [`1b6b8c5f`](https://github.com/doomemacs/doomemacs/commit/1b6b8c5fdee2a20a20ceb5b7381d34d95ffcf5ba) fix(editorconfig): only set tab-width in old org-mode
* [`f782b0d0`](https://github.com/doomemacs/doomemacs/commit/f782b0d0214f2256e43b8eb2656e23f8bf465c91) fix(vertico): search for ripgrep on remote machine
* [`97854432`](https://github.com/doomemacs/doomemacs/commit/97854432ce5b8984bdfeb4a78ce765888cf8beea) feat(gdscript): add treesit support
* [`5b9978c6`](https://github.com/doomemacs/doomemacs/commit/5b9978c6366551238befe7f436a53c06d724d2b2) fix(gdscript): add interpreter-mode-alist entry
* [`d6e1f25e`](https://github.com/doomemacs/doomemacs/commit/d6e1f25e779ba3f6baaa6245fd861d932f5897f9) tweak(lsp): eglot-code-action-indications: remove margin
* [`0e784755`](https://github.com/doomemacs/doomemacs/commit/0e784755eb283bc649e40551c3e72a40ba65eb13) fix(lib): void-variable type
* [`07d5cc81`](https://github.com/doomemacs/doomemacs/commit/07d5cc8124dba7fa9fe4756f414c5637766ece9e) nit(tramp): fix comment about ssh>scp
* [`7c425b80`](https://github.com/doomemacs/doomemacs/commit/7c425b80728ecb473cd28bf62de62d75326cfbd1) docs(upload): revise & clarify
* [`db33b94c`](https://github.com/doomemacs/doomemacs/commit/db33b94cf1ab5fce120428eda99e5c1ca5caa9fd) feat(upload): activate ssh-deploy-line-mode
* [`b7d9c180`](https://github.com/doomemacs/doomemacs/commit/b7d9c1801dfa6c4adc96ef1cbe372ec092f8d28b) feat(upload): add commands for manual/temporary mappings
* [`1a116f51`](https://github.com/doomemacs/doomemacs/commit/1a116f51a9b6b6fc0162dff8dcc1358cffa15d75) fix(upload): ensure ssh-deploy is loaded
* [`722a8d3c`](https://github.com/doomemacs/doomemacs/commit/722a8d3c7aeb47825f0cc21b37e2c82dc56cb1b6) refactor(default): move whitespace & tramp config
* [`2acc9c50`](https://github.com/doomemacs/doomemacs/commit/2acc9c50a0c1e3cca877ce976b1483713f084868) nit(tramp): fix comment about ssh>scp (part 2)
* [`b793fb56`](https://github.com/doomemacs/doomemacs/commit/b793fb5642a1d5fe2f6bb20d9c7e8a298837aa32) tweak: do *not* download package archives by default
* [`ef94c82e`](https://github.com/doomemacs/doomemacs/commit/ef94c82e0308c32539c155e8bc05cd3fff42b70b) fix(lua): treesit: use tree-sitter-lua@v0.3.0 on <= 29
* [`1d1d17e9`](https://github.com/doomemacs/doomemacs/commit/1d1d17e9c910146731cb7b19d5bcbf6c4b283a74) fix(upload): +upload/register-remote: don't overwrite old values
* [`24f99186`](https://github.com/doomemacs/doomemacs/commit/24f9918694750d8b97bf1770bf63bd07e14c5666) refactor(whitespace): conform to naming conventions
* [`c63b207e`](https://github.com/doomemacs/doomemacs/commit/c63b207e4f251c9cbe3b4f4606b1f0e9e5f67978) fix(evil): add error handling for :h[elp] ex command
* [`bc9618d7`](https://github.com/doomemacs/doomemacs/commit/bc9618d744ede9cfd069ea361ce8d2502169a1b3) fix(cc): ffap in C modes (and ts-modes)
* [`5e7e93be`](https://github.com/doomemacs/doomemacs/commit/5e7e93beb9f2b5a81768aaf4950203ceea21c4f6) fix(vc): browse-at-remote: adapt to vc-git--call
