### PR TITLE
npins nixpkgs: update e9f00bd8 -> 36279194

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -132,8 +132,8 @@
     "nixpkgs": {
       "type": "Channel",
       "name": "nixpkgs-unstable",
-      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-25.11pre868392.e9f00bd89398/nixexprs.tar.xz",
-      "hash": "1n08xvypbyygjzrrkyna06sjbxg987jvmvdib5qmzp8avx6dlprb"
+      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-25.11pre875978.362791944032/nixexprs.tar.xz",
+      "hash": "0a2nwmvncax6kan9zbsq7xh9cf98x1hbgcr826j612svy6gzr4sr"
     },
     "powerlevel10k": {
       "type": "Git",


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: release-25.11
Commits: [nixos/nixpkgs@e9f00bd8...36279194](https://github.com/nixos/nixpkgs/compare/e9f00bd89398...362791944032)

* [`8061d426`](https://github.com/NixOS/nixpkgs/commit/8061d426132e2742be812f5e91f75d380a751536) xmlformat: switch to someth2say's fork
* [`d0196280`](https://github.com/NixOS/nixpkgs/commit/d0196280155f09daa7ca44814663c02d9ef0adf0) xmlformat: add maintainer gepbird
* [`9559fa2a`](https://github.com/NixOS/nixpkgs/commit/9559fa2a9b503c106e974589e38b296a1de6abfa) xmlformat: cleanup
* [`0e864793`](https://github.com/NixOS/nixpkgs/commit/0e864793f19ed1c009d59cbef2fc8e2555612d1b) xmlformat: add update script
* [`ce313d71`](https://github.com/NixOS/nixpkgs/commit/ce313d7143011086dc0c8b7697a1e6af20e2d15f) nixos/limesurvey: fix default config merging when config is defined, set userquestionthemerootdir default
* [`ef4d5eb7`](https://github.com/NixOS/nixpkgs/commit/ef4d5eb74b15b763582442f6f4b0d82e2d80c62a) lomiri.suru-icon-theme: 2024.10.13 -> 2025.05.0
* [`d822afa8`](https://github.com/NixOS/nixpkgs/commit/d822afa8f4d215ac2d9ddf8b4d1e8715bbfce0e9) replaceDependencies: fix with ca-derivations
* [`e72eda8d`](https://github.com/NixOS/nixpkgs/commit/e72eda8dc7047b4a74319d82a2e645655602c1e0) python3Packages.msgspec: fix src hash
* [`8f10f4f4`](https://github.com/NixOS/nixpkgs/commit/8f10f4f46933b60711e16ef2fd9bf7e33f69dae7) llvmPackages.libunwind: condition doFakeLibgcc on !stdenv.hostPlatform.isStatic
* [`f8f7f453`](https://github.com/NixOS/nixpkgs/commit/f8f7f45376b9266f4911f8d813451af263ba4573) python3Packages.jupyterlab-vim: init at 4.1.4
* [`774a74d2`](https://github.com/NixOS/nixpkgs/commit/774a74d2e4edaaee31843b7bd4028987a1b3fc5b) endless-sky: 0.10.12 -> 0.10.14
* [`916b3f3b`](https://github.com/NixOS/nixpkgs/commit/916b3f3bbea4efa5acdbfdc605d62b9eb4dfb2b5) nixos/hddtemp: allow use of command substitutions in drives option
* [`a135e736`](https://github.com/NixOS/nixpkgs/commit/a135e7366e89178052a3c79f5b67b759a1687e8f) nixos/hddfancontrol: loosen pwmPaths and disks types
* [`f874ab42`](https://github.com/NixOS/nixpkgs/commit/f874ab4297f696e8c4f09b68c9c81cffa1632a03) wasabibackend: remove `with lib`, order meta attrs
* [`841482e6`](https://github.com/NixOS/nixpkgs/commit/841482e6f28a09dc10b1235f98adfe331f5bcd4d) wasabibackend: add update script
* [`eb08f2e5`](https://github.com/NixOS/nixpkgs/commit/eb08f2e5cd19d6e54f5bd0110867ca04382437d8) wasabibackend: 2.0.2.1 -> 2.3.1
* [`11d1ab63`](https://github.com/NixOS/nixpkgs/commit/11d1ab6321ddf54bebb1720a787a3128d7343afb) wasabibackend: only install main executable
* [`216707af`](https://github.com/NixOS/nixpkgs/commit/216707af62de56b90fa30f05ef87907a3ae3284d) wasabibackend: add changelog and mainProgram
* [`5970f4d5`](https://github.com/NixOS/nixpkgs/commit/5970f4d5370277c26d3cd9c36571a6249af0d58b) nixos/opentabletdriver: refactor
* [`13864f4a`](https://github.com/NixOS/nixpkgs/commit/13864f4ab91df8b580b4dbe77c2f24e153517cae) kaitai-struct-compiler: use jre instead of jdk8
* [`de056b7f`](https://github.com/NixOS/nixpkgs/commit/de056b7fccc0d207fb628feefb2f23c585aae849) python3Packages.docutils: Fix upstream URL (repo.or.cz -> sourceforge)
* [`ddc45de2`](https://github.com/NixOS/nixpkgs/commit/ddc45de27bf5464794d34c4d2ed94e27cbef06f8) python3Packages.docutils: Various minor updates/modernization
* [`5acfbdaa`](https://github.com/NixOS/nixpkgs/commit/5acfbdaa66fddbb7e50f09322c7f0cf84d34c17b) libimagequant: 4.3.4 -> 4.4.0
* [`8c082fbc`](https://github.com/NixOS/nixpkgs/commit/8c082fbce50631ee503a9d15b14c0e43ebbadb32) linuxPackages_latest.systemtap: 5.2 -> 5.3
* [`5b9f2c0d`](https://github.com/NixOS/nixpkgs/commit/5b9f2c0db2d668cd54cb145ea2112927acb196bc) openresolv: 3.16.5 -> 3.17.0
* [`eaffffb6`](https://github.com/NixOS/nixpkgs/commit/eaffffb6919d3e9dcb862fa1dee2bf2eef3fefc3) pixman: 0.46.2 -> 0.46.4
* [`24d285e6`](https://github.com/NixOS/nixpkgs/commit/24d285e61fad95d8868597a77e7d6d7e26908884) deniseemu: init at 2.6
* [`15772822`](https://github.com/NixOS/nixpkgs/commit/15772822901d7bceaaeea7e3c38920d092726c73) gjs: Skip umlaut test that fails on ZFS
* [`08e22028`](https://github.com/NixOS/nixpkgs/commit/08e220283a9930e861675546043aa3865aa375d8) restic: add openssh to PATH, refactor
* [`5d57f609`](https://github.com/NixOS/nixpkgs/commit/5d57f609916b8c475b9616be756bcd01116bf3ad) nixos/github-runner: use apply to override package
* [`9a0f9647`](https://github.com/NixOS/nixpkgs/commit/9a0f9647e5bb6965ad5129404860db7f83b2e485) ell: 0.78 -> 0.79
* [`8bbba0e9`](https://github.com/NixOS/nixpkgs/commit/8bbba0e9ecc9ed84df587a2f347aaea6aa476718) zaparoo: init at 2.5.1
* [`981e563e`](https://github.com/NixOS/nixpkgs/commit/981e563eb817dfea6c8dc0d0ed0ca3b6b7490385) xcbuild: replace use of system mkdir, ln, and sh binaries
* [`5853cc29`](https://github.com/NixOS/nixpkgs/commit/5853cc29013ff0beec176ed68f42c8d8c51e1229) ld64: fix build on case‐sensitive stores
* [`b80c7eef`](https://github.com/NixOS/nixpkgs/commit/b80c7eef65ce7e4cd61b0d1aa466a1407a2959c1) maintainers: add Leonard Menzel
* [`6516f9f0`](https://github.com/NixOS/nixpkgs/commit/6516f9f0d8144cbf80d3f896823ba0b70bb1549f) ghc: 9.8.4 -> 9.10.2
* [`a3ecaf36`](https://github.com/NixOS/nixpkgs/commit/a3ecaf36f17eba0558be468cc0c73105655cde67) haskell.packages.ghc910.cabal-install-parsers: rm obsolete override
* [`659e6d46`](https://github.com/NixOS/nixpkgs/commit/659e6d4647a0f4516203d0d1b6d868d414410abc) haskell.packages.ghc910.ghc-exactprint*: drop obsolete overrides
* [`8c07a1b7`](https://github.com/NixOS/nixpkgs/commit/8c07a1b7717e018f25984323e5e0439cf3b9fe13) haskell.packages.ghc91*.haskell-language-server: drop old override
* [`0710e6eb`](https://github.com/NixOS/nixpkgs/commit/0710e6eb64ac3f583a1688d8be93a91c4f10b973) haskell.packages.ghc910.hashable: drop obsolete override
* [`2ade9353`](https://github.com/NixOS/nixpkgs/commit/2ade93531fa629d4c7a9b479a790801dc1d2e383) haskell.packages.*.hpack: adjust to 0.37.0 -> 0.38.1
* [`9d4fb241`](https://github.com/NixOS/nixpkgs/commit/9d4fb241b3063824499bdaac7eb450c5d7cc9fdb) haskellPackages.tasty-quickcheck: break infinite recursion
* [`65a0876a`](https://github.com/NixOS/nixpkgs/commit/65a0876ad9b2be747e5144511d62e1f22fc2241e) haskellPackages.doctest: adjust to 0.22.6 -> 0.24.2
* [`b79070e2`](https://github.com/NixOS/nixpkgs/commit/b79070e272c02b1a92ea2c1b9f5e56abb55414a1) haskellPackages.optparse-applicative: fix for QuickCheck >= 2.15
* [`3093ce5f`](https://github.com/NixOS/nixpkgs/commit/3093ce5f9985a2a503d01db611a8e6ec8261705a) haskellPackages.vector: fix build with doctest >= 0.24
* [`b7fce00d`](https://github.com/NixOS/nixpkgs/commit/b7fce00d23e42522fd080df947fc1eb2480cd913) haskellPackages.xml-conduit: drop released patch
* [`26184608`](https://github.com/NixOS/nixpkgs/commit/26184608746bc2a3e71bbe9d7a2cf1b22788f68f) cabal-install: adjust to 3.14.1.0 -> 3.16.0.0
* [`572bbe6d`](https://github.com/NixOS/nixpkgs/commit/572bbe6d9f50fb4c13d28d9cd74307c81617a47b) haskellPackages.commonmark-pandoc: 0.2.23 -> 0.2.3
* [`1663ea41`](https://github.com/NixOS/nixpkgs/commit/1663ea41e69655107c28e4f8ccbb2f19aa903b35) haskellPackages.pandoc: drop released patches and re-enable tests
* [`2eb4ddfa`](https://github.com/NixOS/nixpkgs/commit/2eb4ddfa59c1cff98adf7ae1c5c5375c8d617e9e) haskellPackages.gi-g*k_4: remove aliases
* [`baff43c6`](https://github.com/NixOS/nixpkgs/commit/baff43c6dddefd83061ba52b17702a4ca4caea33) haskellPackages.cvss: drop obsolete override
* [`b4b3f6c0`](https://github.com/NixOS/nixpkgs/commit/b4b3f6c0fd321b0d3886e04e47d6ef0ac0b6f204) haskellPackages.Unique: update overrides for Unique >= 4.8
* [`bdecd29f`](https://github.com/NixOS/nixpkgs/commit/bdecd29f297a3e43f12d8a4ef7eb90accaee92f5) jacinda: drop obsolete override, now using happy == 2.1.6 by default
* [`380a1f7b`](https://github.com/NixOS/nixpkgs/commit/380a1f7b76bcff449d426fd8d434575a1e331c86) haskell.packages.ghc912: drop obsolete overrides
* [`78e96057`](https://github.com/NixOS/nixpkgs/commit/78e96057b22a7d2236dfac5f8884620a459cfc89) haskellPackages.path: disable broken test suite
* [`e48f0698`](https://github.com/NixOS/nixpkgs/commit/e48f0698e7be58648c04a4f0fb2ad53044b8a112) haskellPackages.algebraic-graphs: allow inspection-testing >= 0.6
* [`e68a86c6`](https://github.com/NixOS/nixpkgs/commit/e68a86c6a3d3797fe98c47076cf1b0375df067e1) haskellPackages.cabal2nix-unstable: preserve previous passthru set
* [`8fec8af6`](https://github.com/NixOS/nixpkgs/commit/8fec8af67a377fa7f8440d819be29fbe677f093d) haskellPackages.cabal2nix-unstable: use separate bin output
* [`7dfed147`](https://github.com/NixOS/nixpkgs/commit/7dfed14799c10b7694b7fb0b372b29a6b4576357) haskellPackages.cabal2nix-unstable: don't wrap with runtime deps
* [`68877280`](https://github.com/NixOS/nixpkgs/commit/68877280ed1c427cc218e53d63db72b7a70d779e) spago: remove redundant cabal2nix from update script
* [`b5d4467c`](https://github.com/NixOS/nixpkgs/commit/b5d4467cc3b6142842785bee771e8f9e4d5a0e57) haskell.packages.ghc{810,90}.os-string: use 1.0.0
* [`376e3742`](https://github.com/NixOS/nixpkgs/commit/376e374218c7aceedd53752e2ba540ad91d92885) haskell.packages.ghc9{2,4,6,8}.os-string: use 2.0.7
* [`f1285d93`](https://github.com/NixOS/nixpkgs/commit/f1285d93c58a8644681944d60051ee3d5c8646f8) haskell.packages.ghc{810,9{0,2,4,6}}.hashable: use 1.4.7.0
* [`5b0fd960`](https://github.com/NixOS/nixpkgs/commit/5b0fd96022957e7745bcb102aec454410592adfa) top-level/all-packages.nix: fix formatting
* [`68df86e9`](https://github.com/NixOS/nixpkgs/commit/68df86e9340f8d52eb181d76d66c19c542027dd5) hledger-check-fancyassertions: update source hash for 1.43.2
* [`ec9dac01`](https://github.com/NixOS/nixpkgs/commit/ec9dac01bf318754d4a84741d2d954381590bf7e) git-annex: update sha256 for 10.20250416
* [`da2f5fb7`](https://github.com/NixOS/nixpkgs/commit/da2f5fb7a93b2219b6b8c662d4a3fcf0709388aa) haskellPackages.cborg: use patch for 32bit support by upstream
* [`bd6abcb8`](https://github.com/NixOS/nixpkgs/commit/bd6abcb8b56e36e0941ad9938c2718cfb1811f0f) haskellPackages.mod: drop upstreamed patch
* [`7eafc3a0`](https://github.com/NixOS/nixpkgs/commit/7eafc3a0ea767844a59c83293d1f468050d23b3f) haskellPackages.heist: apply upstream patch for tests
* [`5d4b546d`](https://github.com/NixOS/nixpkgs/commit/5d4b546d4ecf30a09b6c11c095fdd8793bf7e5b2) haskellPackages.Cabal_3_16_0_0: ignore unix >= 2.8.6.0 bound
* [`5fa8956b`](https://github.com/NixOS/nixpkgs/commit/5fa8956b96019c043c6ef8876d1372481a13a362) haskell.packages.*.cabal-install: rebase patch lifting unix bound
* [`b45efb7a`](https://github.com/NixOS/nixpkgs/commit/b45efb7ab07c5cf23925389c52a70df9d519f830) haskellPackages.chs-cabal: 0.1.1.1 -> 0.1.1.2
* [`2f420c43`](https://github.com/NixOS/nixpkgs/commit/2f420c4320360cc5a610487c5891b9d60b5301df) haskellPackages.extensions: make 0.1.0.2 the default version
* [`4031404b`](https://github.com/NixOS/nixpkgs/commit/4031404b9030418d0f5366f9049821ba14df2a96) python313Packages.auditwheel: 6.4.0 -> 6.4.2
* [`29279dd6`](https://github.com/NixOS/nixpkgs/commit/29279dd6fbd1ccd47efac5d51984aadca588fa84) haskellPackages.htree: drop unnecessary version constraint
* [`4fd88c33`](https://github.com/NixOS/nixpkgs/commit/4fd88c333935d715b6a6823654885839ba99369d) haskellPackages.system-filepath: disable chell-quickcheck test suite
* [`84ece926`](https://github.com/NixOS/nixpkgs/commit/84ece926a6577cc97a9f9897d217b80e73626417) haskellPackages.diagrams-input: 0.1.3.1 -> 0.1.5
* [`6a78c1f4`](https://github.com/NixOS/nixpkgs/commit/6a78c1f44381c1f37cbc283cf3ff167513179599) haskell.packages.ghc810.ghc-bignum: move polyfill into 8.10 config
* [`03df99ea`](https://github.com/NixOS/nixpkgs/commit/03df99eabc0b2d444d35e927d806dd6ed2571fd7) amazonka: 2.0-unstable-2025-01-23 -> 2.0-unstable-2025-04-16
* [`809f2298`](https://github.com/NixOS/nixpkgs/commit/809f22983b7929c78bed270adae1a838fcaeeb73) haskellPackages.pandoc-crossref: 0.3.19 -> 0.3.20
* [`18dc520f`](https://github.com/NixOS/nixpkgs/commit/18dc520f2382759a6218dd530fbbf9ad01ecfc0f) haskellPackages.nix-derivation: allow filepath >= 1.5
* [`330ee35a`](https://github.com/NixOS/nixpkgs/commit/330ee35adbdd038c31de518cf2a3e08112e3a3f8) haskellPackages.hnix-store-*: 0.6.* -> 0.7.*
* [`33e227d6`](https://github.com/NixOS/nixpkgs/commit/33e227d64eb5125e3196c0bd9d40d8a5be3821fc) haskellPackages.hsc3: 0.20 -> 0.21
* [`cfcb09ad`](https://github.com/NixOS/nixpkgs/commit/cfcb09ad62290f1e449ba1fe56bebeabf96adb03) haskell.packages.ghc910.apply-refact: don't try to build
* [`26ed0359`](https://github.com/NixOS/nixpkgs/commit/26ed035905b57dece2c0829a667569e01540289c) haskellPackages.{basement,memory}: make i686 patches unconditional
* [`14e0b023`](https://github.com/NixOS/nixpkgs/commit/14e0b023ab128bf9c8bb52933f9a0d50379586e6) haskell.packages.ghc8107.ghc-bignum: reenable testing on Hydra
* [`c2f527b2`](https://github.com/NixOS/nixpkgs/commit/c2f527b2841f263977cdfba4e239e67d8926ad23) .git-blame-ignore-revs: add reformat/merge of haskell-updates branch
* [`620f813e`](https://github.com/NixOS/nixpkgs/commit/620f813ef4019c5f409f0e4ede7d08ccdf5a3c0f) nixos/services.mysql: Fix restart on-abnormal
* [`a3ae815d`](https://github.com/NixOS/nixpkgs/commit/a3ae815d4b6dedb4adb97b3923ddce7fdb2c1fee) haskellPackages.extensions: put executable in bin output
* [`dd3972a8`](https://github.com/NixOS/nixpkgs/commit/dd3972a847e989a4b418242f76a76ea5e0ca09f0) nix-derivation: use enableSeparateBinOutput
* [`63708791`](https://github.com/NixOS/nixpkgs/commit/63708791a84c350b39de25bb74e66241184059c0) haskellPackages: run treefmt
* [`3ae41ba4`](https://github.com/NixOS/nixpkgs/commit/3ae41ba4ad9a91c70c08c0a0f68596002d957e8f) haskell.packages.ghc98.megaparsec: fix eval
* [`8e31f1f4`](https://github.com/NixOS/nixpkgs/commit/8e31f1f44cc05f700de6c2cb999f8560955d28be) haskell.packages.ghc98: fix warnAfterVersion error message
* [`d6fb71fd`](https://github.com/NixOS/nixpkgs/commit/d6fb71fd4fe78646152cb71c394a50c2eb3bb7d6) libffi: 3.5.1 -> 3.5.2
* [`1b537710`](https://github.com/NixOS/nixpkgs/commit/1b5377100b83e18d0b6b4e18fe2dadbadaf98e0f) haskell.packages.ghc{94,96,98}.ghc-lib-parser: fix eval
* [`3d24d56f`](https://github.com/NixOS/nixpkgs/commit/3d24d56fad0425469f21b72187ff1ed37510f2b2) haskell.packages.ghc{96,98}.ghc-lib-parser{,-ex}: pin at 9.10.*
* [`57500a36`](https://github.com/NixOS/nixpkgs/commit/57500a368893dad05cb276472176c377045d7a60) haskellPackages.skeletest: drop outdated broken flag
* [`e89cc35c`](https://github.com/NixOS/nixpkgs/commit/e89cc35c70f16afca01296ded83ac8950ea48c7b) haskellPackages.haddock-use-refs: drop outdated broken flag
* [`d3e9ec72`](https://github.com/NixOS/nixpkgs/commit/d3e9ec723da7d09766e0eef107041baac76279d4) haskellPackages.chell-quickcheck: mark as broken
* [`2c2d5ab7`](https://github.com/NixOS/nixpkgs/commit/2c2d5ab77ef983ee0b7c2437ed3b971382bb754f) haskellPackages.hs-tree-sitter-capi: disable broken test suite
* [`c4c0446f`](https://github.com/NixOS/nixpkgs/commit/c4c0446ff9dadc941babc25a333104a9793b9da6) openssl: 3.5.1 -> 3.5.2
* [`d106c3cf`](https://github.com/NixOS/nixpkgs/commit/d106c3cfed8b5e2cbc8260f2140cc46495c461e1) libheif: 1.19.8 -> 1.20.2
* [`516d609d`](https://github.com/NixOS/nixpkgs/commit/516d609d5679cd1e76fd93d4217813a3b08f41d4) haskell.packages.ghc{810,90,92}.ghc-internal: add missing attribute
* [`a4cbfd11`](https://github.com/NixOS/nixpkgs/commit/a4cbfd11e2797deb0420510495074accc73d8c28) haskell.packages.*.ghc-{toolchain,platform}: make sure attr exists
* [`bf2e1e9c`](https://github.com/NixOS/nixpkgs/commit/bf2e1e9c2bf0581da50b88ded1e8328cd49ac538) haskellPackages: stackage LTS 24.2 -> LTS 24.3
* [`3ef35819`](https://github.com/NixOS/nixpkgs/commit/3ef35819276367f54bd214ed498e5de68d0dbf83) top-level/release-haskell.nix: drop redundant jobs
* [`6f2e4f7b`](https://github.com/NixOS/nixpkgs/commit/6f2e4f7b1e335f94edc0875ded8012a5de8a351c) haskellPackages: remove unneeded patches
* [`7040b77b`](https://github.com/NixOS/nixpkgs/commit/7040b77b40b52155b62db484aafc2987883ba050) top-level/release-haskell.nix: remove wstunnel
* [`2a999490`](https://github.com/NixOS/nixpkgs/commit/2a999490532ab41257605fa888893098be291d8b) haskellPackages.dotenv: allow data-default-class-0.2.0.0
* [`0947d6fc`](https://github.com/NixOS/nixpkgs/commit/0947d6fc317136347c6b6c0b53a57e58f1320c92) haskellPackages.dotenv: re-enable test suite
* [`5d0598ae`](https://github.com/NixOS/nixpkgs/commit/5d0598aea1c36f0111b86671ec7871ffca2ab9f7) haskellPackages.req: drop obsolete override
* [`cf670157`](https://github.com/NixOS/nixpkgs/commit/cf670157430334144cd9f029b4730dc5f2a54214) top-level/release-haskell.nix: re-enable vaultenv
* [`ff017b96`](https://github.com/NixOS/nixpkgs/commit/ff017b96cbe9516a1c6e9ceb330da34ba86f5ea7) lvm2: 2.03.33 -> 2.03.34
* [`f2205ad7`](https://github.com/NixOS/nixpkgs/commit/f2205ad7de74c5b238226f1ce6eb9f9535b4d6c4) sqlite: 3.50.2 -> 3.50.4
* [`f49a538a`](https://github.com/NixOS/nixpkgs/commit/f49a538a337d625e0d5a516b05161547d7c6e1b9) nixos/gitlab: add proxyWebsockets as recommended nginx setting
* [`1a43387e`](https://github.com/NixOS/nixpkgs/commit/1a43387e17dc01b3e8e5240dc475015163a5d90f) tdb: 1.4.13 -> 1.4.14
* [`847899e5`](https://github.com/NixOS/nixpkgs/commit/847899e52b79d20a26009c76b474fe3f3fd36117) haskellPackages.fused-effects: jailbreak for inspection-testing >= 0.6
* [`54487675`](https://github.com/NixOS/nixpkgs/commit/54487675162345ab2e9f7715fed5e802733c0930) haskellPackages.selective: allow new QuickCheck
* [`0c0992bb`](https://github.com/NixOS/nixpkgs/commit/0c0992bb993108c67f33e795112441885cd87099) ninja: remove impure dependency on /bin/sh
* [`89a2a6fa`](https://github.com/NixOS/nixpkgs/commit/89a2a6fa579401cda594da4ba84bed8d526d97c2) haskellPackages.hercules-ci-optparse-applicative: 0.18.1-fork -> 0.19.0.0-fork-0
* [`f3cdf06c`](https://github.com/NixOS/nixpkgs/commit/f3cdf06c2da506de41920212b5efcbd847ae0228) python3Packages.simplejson: re-enable darwin tests
* [`d58aef56`](https://github.com/NixOS/nixpkgs/commit/d58aef56802d01e8b91dd6042d2add3d3fc9a68d) python3Packages.trio: re-enable darwin tests
* [`c71354f3`](https://github.com/NixOS/nixpkgs/commit/c71354f35744eeb0389d4c0db7579e0e63338574) haskellPackages.amazonka-test: use src override
* [`4b07a218`](https://github.com/NixOS/nixpkgs/commit/4b07a218e80b2794d8ab48064554ba61e0d69b53) haskell.packages.ghc.910.ghc-lib{,-parser,-parser-ex}: 9.10.2.20250515 -> 9.12.2.20250421
* [`6a91782a`](https://github.com/NixOS/nixpkgs/commit/6a91782abbf262e386c99866617802ea052d7738) haskellPackages.libssh2: unbreak ([nixos/nixpkgs⁠#424042](https://togithub.com/nixos/nixpkgs/issues/424042))
* [`1f230cdd`](https://github.com/NixOS/nixpkgs/commit/1f230cdd50509f7cfcd1de42a3de1fc8a8fab692) haskellPackages.cabal2nix-unstable: 2025-06-14 -> 2025-08-10
* [`eab821f2`](https://github.com/NixOS/nixpkgs/commit/eab821f29829d07ba18eaf270bea6c2c4ce45e58) perl540Packages.AuthenSASL: 2.1700 -> 2.1900
* [`922f0e98`](https://github.com/NixOS/nixpkgs/commit/922f0e98a799ae06ba3cc938897423bfe27c9f28) bash-git-prompt: init at 2.7.1-unstable-2025-04-23
* [`cc8e0406`](https://github.com/NixOS/nixpkgs/commit/cc8e0406f1db99d0f902554d6d4a991209588e86) haskellPackages.threadscope: use wrapGAppsHook
* [`5104e593`](https://github.com/NixOS/nixpkgs/commit/5104e593ae5b35511dc1702a59183aaed9523c30) haskellPackages.data-default-instances-*: mark as broken
* [`d587dd97`](https://github.com/NixOS/nixpkgs/commit/d587dd97fef82330ca0e5952c0ba43935b013597) feyngame: init at 3.0.0
* [`ed862966`](https://github.com/NixOS/nixpkgs/commit/ed862966a33a20ff433095e5654439b0c9f55c9c) python3Packages.sqlalchemy: 2.0.42 -> 2.0.43
* [`19fae07d`](https://github.com/NixOS/nixpkgs/commit/19fae07daa776ee8a26767b15cfb4a050a2e1b7f) haskellPackages.wai-app-file-cgi: fix missing +x in test scripts
* [`b0820d6f`](https://github.com/NixOS/nixpkgs/commit/b0820d6fb55f35333df267d837b819e9b72d7fc8) haskellPackages.mighttpd2: unbreak and adopt
* [`e0f87912`](https://github.com/NixOS/nixpkgs/commit/e0f87912595d33f498230f44dd9c96b57af07b77) maintainers/haskell/hydra-report.hs: use eitherDecodeStrictText
* [`bbefb1d4`](https://github.com/NixOS/nixpkgs/commit/bbefb1d4629cec2a6b4675bccfce0d54afbdc85e) maintainers/hydra-report.hs: migrate to nix-eval-jobs
* [`26dc439e`](https://github.com/NixOS/nixpkgs/commit/26dc439eb43654b66056ce1d3d252d7db6ad0789) haskell.compiler.ghcHEAD: 9.13.20250428 -> 9.15.20250805
* [`09d584ea`](https://github.com/NixOS/nixpkgs/commit/09d584eab58d2baf2aa6bcfc23dd0421c7e28e3d) haskell.compiler.*.ghc.hadrian:only jailbreak directory if necessary
* [`906105ed`](https://github.com/NixOS/nixpkgs/commit/906105ed78fa2a1aeff45692f5dea6347e73dbf4) Revert "haskell.compiler.ghc981: build stage 2 compiler for “native cross”"
* [`baa05219`](https://github.com/NixOS/nixpkgs/commit/baa0521980c423be7a8de06d18757ef4af4d22f0) haskellPackages.statistics: allow building with doctest >= 0.24
* [`e0268b1b`](https://github.com/NixOS/nixpkgs/commit/e0268b1bc1434918109884f6d321d0fddd700bad) haskell.compiler.ghcHEAD: 9.15.20250805 -> 9.15.20250811
* [`f1524fa0`](https://github.com/NixOS/nixpkgs/commit/f1524fa0dc69de8ba328f107b2284a16c092c84e) haskellPackages.weeder: disable failing tests
* [`4056a90f`](https://github.com/NixOS/nixpkgs/commit/4056a90f6949a0b603ac45f80ff943164e02c6ef) xcbuild: fix crash when home directory is missing
* [`a550ff27`](https://github.com/NixOS/nixpkgs/commit/a550ff271dd4f789d937fae30b6b6f0b014dbba3) haskell.packages.ghcHEAD: fix configuration path
* [`b93cba9d`](https://github.com/NixOS/nixpkgs/commit/b93cba9d953f1273cfd57361b6c49b9ec66311fa) python3Packages.image: init at 1.5.33
* [`33fba9b6`](https://github.com/NixOS/nixpkgs/commit/33fba9b6ba43838fa6b01fbc0733e04d4ec2174b) bili-live-tool: init at 0.3.9
* [`e5a3365b`](https://github.com/NixOS/nixpkgs/commit/e5a3365b46980fe4b13d7640f490287a9e7af67d) ld64: fix build with LLVM 21
* [`6a6e2749`](https://github.com/NixOS/nixpkgs/commit/6a6e27495b587d38a82413147a099f8f377d3bee) nixos: fix 'do not exist' typos
* [`0c8c3843`](https://github.com/NixOS/nixpkgs/commit/0c8c38432b49fd9b164f83ed0fe1b2a9049d63d1) cmocka: 1.1.7 -> 1.1.8
* [`795dc1a9`](https://github.com/NixOS/nixpkgs/commit/795dc1a9914afad8a32921025cdad413bf3eeb8e) haskell.packages.ghc94.tar: pin at 0.6.3.0
* [`6ee67461`](https://github.com/NixOS/nixpkgs/commit/6ee67461aeff03c89038622cafd90b793ed2cc96) nixos/asterisk: fix reloading command
* [`2e5f32fc`](https://github.com/NixOS/nixpkgs/commit/2e5f32fc6326aab7a5d418edf6d2436fc211f846) 64tass: init at 1.60.3243
* [`323636a6`](https://github.com/NixOS/nixpkgs/commit/323636a6aff45a48dd7a5c284fdae6d9a8e86d36) krb5: Fix build with gcc=15
* [`82b27bd9`](https://github.com/NixOS/nixpkgs/commit/82b27bd911b50e2f9814eb7b6cd80e24ca4fee72) expect: Fix build with gcc=15
* [`ecea3c1b`](https://github.com/NixOS/nixpkgs/commit/ecea3c1bceb89911c86263fb731f3511d01d89fa) gpm: Fix build with gcc=15
* [`4e2d61f0`](https://github.com/NixOS/nixpkgs/commit/4e2d61f0a10650a627c7d5fef502515b0ea39ca3) w3m: Fix build with gcc=15
* [`466efda0`](https://github.com/NixOS/nixpkgs/commit/466efda0b6dafd55378bc50045974ac800812f8c) nodehun: fix build at 3.0.2
* [`c36dbedd`](https://github.com/NixOS/nixpkgs/commit/c36dbedd95db9a48aeab1ff89fa4fa41f261711f) haskellPackages.{liquidhaskell, liqquidhaskell-boot, liquid-fixpoint, smtlib-backends-process, smtlib-backends-tests}: unbreak
* [`53923e20`](https://github.com/NixOS/nixpkgs/commit/53923e2091dbccc9de5565e8ab17024605a275b9) haskellPackages.ghc-typelits-natnormalise: jailbreak and patch tests ([nixos/nixpkgs⁠#432513](https://togithub.com/nixos/nixpkgs/issues/432513))
* [`cd96e1b0`](https://github.com/NixOS/nixpkgs/commit/cd96e1b0268f01c364c5c599c72f5f7702a15c64) catch: drop
* [`d760b57d`](https://github.com/NixOS/nixpkgs/commit/d760b57dbcbaa99d3170d5cbdb35cab655ac72c3) python3Packages.pybind11: catch -> catch2
* [`a412eebf`](https://github.com/NixOS/nixpkgs/commit/a412eebf7ac038cc96c16e6d8cd29533a1556db4) phpExtensions.spx: adopt
* [`84dced5a`](https://github.com/NixOS/nixpkgs/commit/84dced5a94ed901362dc6e285d0ac0c08ba671ff) python3Packages.pytest: don't wrap binaries
* [`9378e3a8`](https://github.com/NixOS/nixpkgs/commit/9378e3a8abbb66967824ecc198f446588d6edaf2) python3Packages.pybind11: postInstallCheck -> postCheck
* [`8f17a775`](https://github.com/NixOS/nixpkgs/commit/8f17a775a4b031e38bbccb01b90881a503699a5e) haskellPackages.mysql-haskell: allow data-default-class 0.2
* [`dc3beb23`](https://github.com/NixOS/nixpkgs/commit/dc3beb2346073ffeb382152278d0e94255c72ad9) haskellPackages.crucible: apply fix for base >= 4.20 (foldl' export)
* [`5c9786f6`](https://github.com/NixOS/nixpkgs/commit/5c9786f64741519d33c64e39d2bfe26c28cc35fa) haskellPackages: fix build of packages maintained by me
* [`3e8aa828`](https://github.com/NixOS/nixpkgs/commit/3e8aa82884c4546fd038bcf530e82c0bcb9d354c) haskellPackages: stackage LTS 24.3 -> LTS 24.4
* [`2d98f4f2`](https://github.com/NixOS/nixpkgs/commit/2d98f4f2e826f899efe10da329d4399380b1449b) haskellPackages: stackage LTS 24.3 -> LTS 24.6
* [`7fc00bf4`](https://github.com/NixOS/nixpkgs/commit/7fc00bf43ae0a999a9b93064cc686d140e6e7472) libgcrypt: 1.11.1 -> 1.11.2
* [`6f7a2188`](https://github.com/NixOS/nixpkgs/commit/6f7a2188aa75d3c5a7184ebb4c9f42cee3b5afca) python3Packages.requests: 2.32.4 -> 2.32.5
* [`069f7209`](https://github.com/NixOS/nixpkgs/commit/069f7209960f08074f9587f2a5534421a726087d) python3Packages.markdown2: 2.5.2 -> 2.5.4
* [`8de45689`](https://github.com/NixOS/nixpkgs/commit/8de45689608489c4ee317f71e5aa0c29f50e4b7a) haskellPackages.dual-game: jailbreak
* [`67dba26a`](https://github.com/NixOS/nixpkgs/commit/67dba26a99fc67a33ac51feb9850cefdbb04e112) haskellPackages.{smtlib-backends-tests, liquidhaskell-boot, liquidhaskell, rest-rewrite}: no jailbreak needed anymore
* [`c03b87fb`](https://github.com/NixOS/nixpkgs/commit/c03b87fb9cdcb97f81de1bfc868238eeabb7e268) jasper: 4.2.6 -> 4.2.8
* [`f4a923a0`](https://github.com/NixOS/nixpkgs/commit/f4a923a0060b66edbbc8e7c099ee3100659de1a7) ed: 1.21.1 -> 1.22.2
* [`e16595cb`](https://github.com/NixOS/nixpkgs/commit/e16595cb9cd3bbc122ea0886017d41848e2551ba) python3Packages.json-stream-rs-tokenizer: 0.4.29 -> 0.4.30
* [`266fc1e0`](https://github.com/NixOS/nixpkgs/commit/266fc1e094135303dbe0c1a7c1baf8cb13144aba) python3Packages.textx: 4.0.1 -> 4.2.2
* [`ba5e631b`](https://github.com/NixOS/nixpkgs/commit/ba5e631bd7056178cb54e9e6717c74c67ef232b9) libtirpc: 1.3.6 -> 1.3.7
* [`6faa1152`](https://github.com/NixOS/nixpkgs/commit/6faa1152889c088dc8d82fb4c9c0ce7bdc42f057) python3Packages.quantities: 0.16.1 -> 0.16.2
* [`6d4c0772`](https://github.com/NixOS/nixpkgs/commit/6d4c0772888cca2c8be5e007729dd1a9be3afbaf) s2n-tls: 1.5.24 -> 1.5.25
* [`c8281b87`](https://github.com/NixOS/nixpkgs/commit/c8281b8783041de984deedba2f1d187722722f4f) fractal: fix cross compilation
* [`3bb83bd1`](https://github.com/NixOS/nixpkgs/commit/3bb83bd10ccd571bcbd7d8821f32a5ef16264f75) modules/image/repart: repart.imageFile(Basename) -> image.baseName
* [`f35d4ec9`](https://github.com/NixOS/nixpkgs/commit/f35d4ec9e6b158d1ceb1bf530faffd5df60513ab) python3Packages.aio-pika: 9.5.5 -> 9.5.6
* [`591a8906`](https://github.com/NixOS/nixpkgs/commit/591a8906e4dcd1956b74ef4f0842d36110261084) haskellPackages.inflections: jailbreak
* [`5684229c`](https://github.com/NixOS/nixpkgs/commit/5684229ccf75fbd05a219c51ccba781027c4d7ae) viewres: refactor and move to pkgs/by-name from xorg namespace
* [`8d6077c1`](https://github.com/NixOS/nixpkgs/commit/8d6077c1efd4997d9e5c5d3465333a32fd725985) listres: refactor and move to pkgs/by-name from xorg namespace
* [`ec5f820b`](https://github.com/NixOS/nixpkgs/commit/ec5f820b38b3cda32c393d4ba8c35268782b9f4a) smproxy: refactor and move to pkgs/by-name from xorg namespace
* [`4cd91610`](https://github.com/NixOS/nixpkgs/commit/4cd91610a474a98a2b9e7daefb4bc222e1b853d5) xconsole: refactor and move to pkgs/by-name from xorg namespace
* [`458daf8c`](https://github.com/NixOS/nixpkgs/commit/458daf8c44874a96bd6371f4608d2208f529db7f) libxcb-cursor: refactor, move to pkgs/by-name and rename from xorg.xcbutilcursor
* [`9dcebc5e`](https://github.com/NixOS/nixpkgs/commit/9dcebc5e97ecd575208620a3cc40a0c3c02207af) xfontsel: 1.0.6 -> 1.1.1 & refactor; xorg.xfontsel: drop and alias to top-level xfontsel
* [`227c2a7c`](https://github.com/NixOS/nixpkgs/commit/227c2a7ccccf99a9d81e894262b43fc9ca99d244) xmag: refactor and move to pkgs/by-name from xorg namespace
* [`6f159706`](https://github.com/NixOS/nixpkgs/commit/6f159706b73ea8b8de64f334e4c130d6aa016031) xmessage: refactor and move to pkgs/by-name from xorg namespace
* [`9b4e7b6f`](https://github.com/NixOS/nixpkgs/commit/9b4e7b6fdedf43c76d650b5ce0e656fc1b1f6e4e) xmore: refactor and move to pkgs/by-name from xorg namespace
* [`eaed8b15`](https://github.com/NixOS/nixpkgs/commit/eaed8b1530ce9eb9f674677003866d2d793b90fa) papers: fix cross compilation
* [`fd2b94e5`](https://github.com/NixOS/nixpkgs/commit/fd2b94e52cc96be7ed47163bece3170b66799141) gixy: 0.1.20 -> 0.1.21
* [`22c2c095`](https://github.com/NixOS/nixpkgs/commit/22c2c095673323356b86bbb0ac0c6aab34068fcc) python3Packages.plux: 1.12.0 -> 1.13.0
* [`e88c6851`](https://github.com/NixOS/nixpkgs/commit/e88c68514d8db9eff4b5d38741c2da0ec1f6a608) nixos/lib/systemd: introduce settingsToSections
* [`a27a4333`](https://github.com/NixOS/nixpkgs/commit/a27a433370f620ef178c3b5c2e01ccebc93b2e6a) nixos/lib/systemd: migrate single-section attrsToSection to settingsToSections
* [`98c8230c`](https://github.com/NixOS/nixpkgs/commit/98c8230c883eeb9a7bcb22e9aafd7f7f621333c0) nixos/systemd: write systemd.settings using settingsToSections
* [`51ac6e36`](https://github.com/NixOS/nixpkgs/commit/51ac6e36ba2de2c9b86d4f0cd7cacb519ff5fc50) nixos/systemd: write boot.initrd.systemd.settings using settingsToSections
* [`55f3ead1`](https://github.com/NixOS/nixpkgs/commit/55f3ead1941fff22870c8f513b70e6f2b4f38edc) nixos/logind: write services.logind.settings using settingsToSections
* [`1f1ef6bd`](https://github.com/NixOS/nixpkgs/commit/1f1ef6bd0859099a90b916c0c7333e8539803d6a) nixos/systemd-oomd: migrate extraConfig to systemd-respecting rfc42 settings.OOM
* [`1dfd2497`](https://github.com/NixOS/nixpkgs/commit/1dfd249772354e4d323ec2ac59c507279b68ea36) nixos/systemd-oomd: align DefaultMemoryPressureDurationSec with upstream systemd
* [`5d32ace7`](https://github.com/NixOS/nixpkgs/commit/5d32ace785cc338e4e7d831a989721b95c41764f) python3Packages.pyshp: 3.0.0 -> 3.0.1
* [`12f6b114`](https://github.com/NixOS/nixpkgs/commit/12f6b114029493ba951291240730a38f0c79ad51) haskellPackages.postgrest: fix build
* [`826d9716`](https://github.com/NixOS/nixpkgs/commit/826d9716e2bcae236d1dfef80cafb6c9a3de7adb) postgrest: 13.0.4 -> 13.0.5
* [`951376ce`](https://github.com/NixOS/nixpkgs/commit/951376cede0c69d8746d9cbb94080e0cc774832a) haskellPackages.stripe-{concepts,signature,wreq}: jailbreak
* [`9bf01eef`](https://github.com/NixOS/nixpkgs/commit/9bf01eef452d46c2990cdc872017f1015892ea7d) snapshot: fix cross compilation
* [`4205e484`](https://github.com/NixOS/nixpkgs/commit/4205e48493cfb6193f0e643e140180874a6a7a8a) python3Packages.accelerate: 1.10.0 -> 1.10.1
* [`dba6dca4`](https://github.com/NixOS/nixpkgs/commit/dba6dca44d4b771f32f6cf55cd5e171b271174d5) nftables: 1.1.4 -> 1.1.5
* [`eb77cc0a`](https://github.com/NixOS/nixpkgs/commit/eb77cc0aa08628a2a2e96cfc5546c33331bd0f21) haskellPackages: Rebuild package set based on current config
* [`faa6bed4`](https://github.com/NixOS/nixpkgs/commit/faa6bed4eda2a1aa2d8e7501f4bdc9e3d8b3a8f9) haskellPackages: Update do not distribute list
* [`87d72e55`](https://github.com/NixOS/nixpkgs/commit/87d72e557092e823cedc11b89996989ec957b36a) python3Packages.daqp: 0.7.1 -> 0.7.2
* [`fb683326`](https://github.com/NixOS/nixpkgs/commit/fb683326efc4948a645ffdb0032cda31424ca7ca) haskellPackages.conduit-concurrent-map: disable tests for say dependency
* [`fb6bdb45`](https://github.com/NixOS/nixpkgs/commit/fb6bdb4545a6d3ab3c14364d7709edbf5044765d) python3Packages.packageurl-python: 0.17.3 -> 0.17.5
* [`9c2cd839`](https://github.com/NixOS/nixpkgs/commit/9c2cd839c814865cad2e75ba1ca3079ba9111eef) haskellPackages.cachix: fix ambiguous 'show' reference
* [`74a43ef1`](https://github.com/NixOS/nixpkgs/commit/74a43ef18c810deeb8b23206d31bf06b5dadb6a9) haskellPackages.hercules-ci-cnix-store: 0.3.7.0 -> 0.4.0.0
* [`243c85bd`](https://github.com/NixOS/nixpkgs/commit/243c85bd5c3a691728bacd4252a52a4513943a9c) haskellPackages.hercules-ci-cnix-expr: 0.4.0.0 -> 0.5.0.0
* [`5b3fc5c3`](https://github.com/NixOS/nixpkgs/commit/5b3fc5c3a8c7148dd8d32f508942bceaef9cf645) haskellPackages.hercules-ci-agent: 0.10.6 -> 0.10.7
* [`3d197848`](https://github.com/NixOS/nixpkgs/commit/3d19784820ccfc186eb21e68aa2f5a3a937be287) haskellPackages.changelog-d: 1.0.1 -> 1.0.2
* [`69857a2b`](https://github.com/NixOS/nixpkgs/commit/69857a2b1ae0b4d3d4e2acff1e1b213692bc38a0) python3Packages.pytomlpp: 1.0.13 -> 1.0.14
* [`30f2d758`](https://github.com/NixOS/nixpkgs/commit/30f2d758dbe609fb09fa57fdbd05608c1a12121c) python3Packages.pyaxmlparser: 0.3.27 -> 0.3.31
* [`8bf8b2bb`](https://github.com/NixOS/nixpkgs/commit/8bf8b2bbc985f7baf75a3bdd7f1a0185e9b3eb8c) python3Packages.exifread: 3.4.0 -> 3.5.1
* [`453d0f8e`](https://github.com/NixOS/nixpkgs/commit/453d0f8eab3c0fb27968705d7f8a45328b7cc03b) haskellPackages.cabal2nix-unstable: set version according to contribution guidelines
* [`4a45ef52`](https://github.com/NixOS/nixpkgs/commit/4a45ef52a1bbf6bbddeb98480b301444086be3b9) python3Packages.superqt: 0.7.5 -> 0.7.6
* [`a68196dc`](https://github.com/NixOS/nixpkgs/commit/a68196dc69ee94a7345fa9bfc7d3e8048f17622f) python3Packages.django-storages: 1.14.5 -> 1.14.6
* [`e4e98bb0`](https://github.com/NixOS/nixpkgs/commit/e4e98bb0743eb03720f77068cc2949d83c3121ab) cpio: Fix build with gcc=15
* [`9c4557cf`](https://github.com/NixOS/nixpkgs/commit/9c4557cf5a201ae1dddf0d58bec6756b4e0586de) haskellPackages.fix-whitespace: enable separate bin output
* [`bd4a36f9`](https://github.com/NixOS/nixpkgs/commit/bd4a36f924725866d34a4446f135bc872a3aa12e) git-annex: 10.20250416 -> 10.20250721
* [`6b3c5f79`](https://github.com/NixOS/nixpkgs/commit/6b3c5f79faf64b36c488320239f3c150c663ce08) pcre2: 10.44 -> 10.46
* [`25f95e92`](https://github.com/NixOS/nixpkgs/commit/25f95e922fe71f2ac55c63a850b52d09a38baf38) haskellPackages: stackage LTS 24.6 -> LTS 24.7
* [`17849973`](https://github.com/NixOS/nixpkgs/commit/178499735d997d1a0b7d96b5a03e49a7198b2a72) python3Packages.azure-mgmt-mysqlflexibleservers: 1.0.0b2 -> 1.0.0b3
* [`097eac95`](https://github.com/NixOS/nixpkgs/commit/097eac95943ba9e1807a856589a7530c76655122) python3Packages.mistune: 3.1.3 -> 3.1.4
* [`4810ad5b`](https://github.com/NixOS/nixpkgs/commit/4810ad5bdae10d0726469c11bec68303dbecf91c) python3Packages.flasgger: run tests
* [`4b43c356`](https://github.com/NixOS/nixpkgs/commit/4b43c35610412b944d76997068a2bf3200539c1a) catch2_3: 3.8.1 -> 3.9.1
* [`acb05054`](https://github.com/NixOS/nixpkgs/commit/acb05054f64df107cf18e07b6846473253f6bf70) catch2_3: move to pkgs/by-name
* [`638d0c82`](https://github.com/NixOS/nixpkgs/commit/638d0c828f7d502caddf513d535b0df818fab683) catch2: move to pkgs/by-name
* [`7160501d`](https://github.com/NixOS/nixpkgs/commit/7160501dbef5969e75f3a71f7fb530c40d9e1344) lvm2: make manpage generation reproducible
* [`5bbc98a9`](https://github.com/NixOS/nixpkgs/commit/5bbc98a99cd687ef897d505705611110b32cdc17) python3Packages.pypika: 0.48.9 -> 0.49.0
* [`fd5fe1ca`](https://github.com/NixOS/nixpkgs/commit/fd5fe1ca4f6d32128527191c9849423e0070d648) python3Packages.peft: 0.17.0 -> 0.17.1
* [`9da35b8f`](https://github.com/NixOS/nixpkgs/commit/9da35b8f6b08742c21ad3a5f099a07139cd657ad) ulauncher: Fix with webkitgtk_4_1
* [`bb1a1f5c`](https://github.com/NixOS/nixpkgs/commit/bb1a1f5cfbd6d9b40f8582d7ae5e3d2c3a80b4af) haskellPackages.mysql-haskell: drop patch in favor of revised metadata
* [`b571594f`](https://github.com/NixOS/nixpkgs/commit/b571594fe22803bfe310a71294d769ac8e9ce4a2) python3Packages.wagtail: 7.1 -> 7.1.1
* [`68602c46`](https://github.com/NixOS/nixpkgs/commit/68602c46e8588c2686424cfeb95ffa4d32e6a3ff) haskellPackages.ghc-typelits-natnormalise: drop released patch
* [`fcb9e683`](https://github.com/NixOS/nixpkgs/commit/fcb9e683e08805e75d78e4582c78dda513c947c3) maturin: 1.9.3 -> 1.9.4
* [`3e41af4a`](https://github.com/NixOS/nixpkgs/commit/3e41af4a133bf771d334aa239021cb0cf75c6282) ncurses: make `separateDebugInfo` work without broken symlinks
* [`78c85d77`](https://github.com/NixOS/nixpkgs/commit/78c85d77ea18643b0f705509954b720b1d451f00) home-assistant-custom-components.xiaomi_home: init at 0.4.2
* [`66c345cf`](https://github.com/NixOS/nixpkgs/commit/66c345cf6f0cc89920674879008049a0af46d83e) vips: 8.16.1 -> 8.17.1
* [`1f8f6612`](https://github.com/NixOS/nixpkgs/commit/1f8f6612c106533271a6b3f9c75d775f4f5e9b83) haskellPackages.sitemap: add maintainer mpscholten
* [`08267ddb`](https://github.com/NixOS/nixpkgs/commit/08267ddb9866e2ce2de6d23654c385b5b8ab4fd6) haskellPackages.taggy-lens: dontCheck and unbreak
* [`4cbb6bd6`](https://github.com/NixOS/nixpkgs/commit/4cbb6bd6cb7942843d16714adf124a9249996809) guile: disable stripping on `linux` as well (`binutils-2.45` compat)
* [`413f9491`](https://github.com/NixOS/nixpkgs/commit/413f94911546b19aa961799fe7dd823b0ca28ea0) xset: refactor and move to pkgs/by-name from xorg namespace
* [`f25482f3`](https://github.com/NixOS/nixpkgs/commit/f25482f3dcb3c9e282abca1a9df41b1b56dedd26) xsetroot: refactor and move to pkgs/by-name from xorg namespace
* [`9c66bf85`](https://github.com/NixOS/nixpkgs/commit/9c66bf85e8617e523c574d99c221337dd0d2fcb5) xsm: refactor and move to pkgs/by-name from xorg namespace
* [`10a2efa5`](https://github.com/NixOS/nixpkgs/commit/10a2efa52e7974da4bffb17ab061c7a6f6bc64f4) xstdcmap: refactor and move to pkgs/by-name from xorg namespace
* [`eb9c77d5`](https://github.com/NixOS/nixpkgs/commit/eb9c77d573a646ebeeab287f4b389604af3c40d7) libcbor: 0.12.0 -> 0.13.0
* [`71d4f71c`](https://github.com/NixOS/nixpkgs/commit/71d4f71cbdbe87d1c2bd07ab7b0e69ab1470600f) termius: fix [nixos/nixpkgs⁠#438763](https://togithub.com/nixos/nixpkgs/issues/438763)
* [`a2776896`](https://github.com/NixOS/nixpkgs/commit/a277689646fb3663c032f1a52bae7122d9af6433) ruff: 0.12.10 -> 0.12.11
* [`4f33bcb8`](https://github.com/NixOS/nixpkgs/commit/4f33bcb8744a595ee8a85c2b6a19cf11d10d0c8f) gitit: relax upper bounds on pandoc and xml-conduit
* [`c3e95a2e`](https://github.com/NixOS/nixpkgs/commit/c3e95a2eaad24c9d5babad3ebd419de95eaff619) git-annex: update sha256 for 10.20250828
* [`f96dd2fe`](https://github.com/NixOS/nixpkgs/commit/f96dd2fe5249e283fd4118aaee2e128c3f47f337) woff2: Fix build with gcc=15
* [`62b3542a`](https://github.com/NixOS/nixpkgs/commit/62b3542ad412d5dbef4dfa5586e844bbe7bde626) rustPlatform.fetchCargoVendor: add python3Package.pysocks to dependencies
* [`d2425910`](https://github.com/NixOS/nixpkgs/commit/d2425910a66db94122e943a8bb587dbaee20cfa5) coreutils: Skip tests that are flaky on ZFS-backed NFS filesystems
* [`30759281`](https://github.com/NixOS/nixpkgs/commit/307592818c3b17871ed476402dba848525183a84) util-linux: fix the use of `finalAttrs` pattern, remove rec
* [`8ad6e0a2`](https://github.com/NixOS/nixpkgs/commit/8ad6e0a2663ed779108ae5b173e1c9c07958b97a) util-linux: re-organize attributes and simplify `post-install` step
* [`64d3b1c1`](https://github.com/NixOS/nixpkgs/commit/64d3b1c1df3fb27d7a75a2b37d6087b7c7e65c24) util-linux: use `systemdLibs`
* [`a495ffb2`](https://github.com/NixOS/nixpkgs/commit/a495ffb2e2c6cdb9e37986aacb47949bd7455ac7) haskellPackage.linear-tests: disable flaky (?) test suite
* [`631661e6`](https://github.com/NixOS/nixpkgs/commit/631661e66cb097c9f3b4b15eb0f6464ce6ac8007) haskellPackages.cabal2nix-unstable: override with unstable dependencies
* [`73a77f68`](https://github.com/NixOS/nixpkgs/commit/73a77f686bb0ca9441e72d3b4bfa33559f5b1a2e) haskellPackages.optics: Fix build
* [`2ccace98`](https://github.com/NixOS/nixpkgs/commit/2ccace98841b5e63e888fc0135c1ac8f42435841) gsm: 1.0.22 -> 1.0.23
* [`b58a3504`](https://github.com/NixOS/nixpkgs/commit/b58a3504175a3b182c4bccd893f6626a99950a0b) redis: set upper limit for parallelism in test-suite
* [`e7263d83`](https://github.com/NixOS/nixpkgs/commit/e7263d832ba08bf0f9fe69ba8e637d85456aa15d) python3Packages.pip.meta.mainProgram: init
* [`096e742c`](https://github.com/NixOS/nixpkgs/commit/096e742c7dacb1f28bc887b226d230c6873ee515) publicsuffix-list: 0-unstable-2025-07-22 -> 0-unstable-2025-08-28
* [`8b3d840a`](https://github.com/NixOS/nixpkgs/commit/8b3d840ac8cf6eaddd714182c9cf3ad4c5f28512) postgrest: 13.0.5 -> 13.0.6
* [`8a6f83ce`](https://github.com/NixOS/nixpkgs/commit/8a6f83ce3ba5d8d6bda49825dbec687d65bbdddd) libinput: 1.29.0 -> 1.29.1
* [`b5787eff`](https://github.com/NixOS/nixpkgs/commit/b5787effec77b2adc222276840457687a6f363df) svt-av1: 3.0.2 -> 3.1.2
* [`3fa399ad`](https://github.com/NixOS/nixpkgs/commit/3fa399ad20fe0ede2b6da6da975753982973e42c) nlohmann_json: 3.11.3 -> 3.12.0
* [`d2c88a8a`](https://github.com/NixOS/nixpkgs/commit/d2c88a8af58d3d3f466424c59df3ef7b619025c0) python3Packages.orjson: 3.10.18 -> 3.11.3
* [`05f22326`](https://github.com/NixOS/nixpkgs/commit/05f2232646efe71929996b4e99fb3f198e5d11de) hwdata: 0.398 -> 0.399
* [`6fdf6957`](https://github.com/NixOS/nixpkgs/commit/6fdf69579f43e7b87b5826fd8be9086d29e7a766) util-linux: replace hardcoded path to `/usr/bin/mv`
* [`26dd794d`](https://github.com/NixOS/nixpkgs/commit/26dd794dc027088a2b0122965eb6c4779e3f0cbd) phpPackages.psalm: 6.8.6 -> 6.13.1
* [`56551e3e`](https://github.com/NixOS/nixpkgs/commit/56551e3e23e2158e4bd6e79745f793c845cdfd1f) bmake: cmd-interrupt test tries to `SIGINT` make itself, is flaky as a result
* [`bf045ee2`](https://github.com/NixOS/nixpkgs/commit/bf045ee2be0c994a12e14426ab47231f8836f681) sdl3: 3.2.20 -> 3.2.22
* [`41c6ba8d`](https://github.com/NixOS/nixpkgs/commit/41c6ba8dff6a3321357b4272578369527649ad79) sdl3: disable runtime library loading
* [`fc96568d`](https://github.com/NixOS/nixpkgs/commit/fc96568d4285fb3631c8960e7590e87a9544e0a9) mercurial: 6.9.4 -> 7.1
* [`8a7b729e`](https://github.com/NixOS/nixpkgs/commit/8a7b729e1caf5cc9def5a5fc7e00dc7d44327b6a) haskellPackages.data-clist: jailbreak for QuickCheck >= 2.15
* [`e3ffeb20`](https://github.com/NixOS/nixpkgs/commit/e3ffeb20ce3666cee184bd39dea61772b13dc3b7) licenses: add CNRI-Python
* [`b3f1614a`](https://github.com/NixOS/nixpkgs/commit/b3f1614a9779f98fd09dbf3637c4ff8b882f6a48) python313Packages.regex: fix homepage and license
* [`48da58ce`](https://github.com/NixOS/nixpkgs/commit/48da58cef040182fa40d1418aabaf8b78a86ecda) python313Packages.regex: set pyproject = true
* [`30423764`](https://github.com/NixOS/nixpkgs/commit/3042376469d8940a95b7294273fdbf1fa0d0ec67) nodejs: simplify GYP patching
* [`4ccc7c31`](https://github.com/NixOS/nixpkgs/commit/4ccc7c3197c670baa2e76a1acbfcaade8746250b) emscripten: fix cross-compilation by using host python
* [`514ca337`](https://github.com/NixOS/nixpkgs/commit/514ca33745e0f366c8e62e95dd5e0b2ca91e6df8) procps: use `finalAttrs` pattern
* [`de62b313`](https://github.com/NixOS/nixpkgs/commit/de62b313252c42baec203efbbec0682b82fcbf9a) procps: use `lib.optionals`
* [`ec8cebbd`](https://github.com/NixOS/nixpkgs/commit/ec8cebbdc94fddab2c7d0a7a5368d14f87aec77f) procps: add missing phase hooks
* [`c6e588c6`](https://github.com/NixOS/nixpkgs/commit/c6e588c6caf9682f0b8eddedc35b1887210a72d5) procps: use `systemdLibs`
* [`17dde350`](https://github.com/NixOS/nixpkgs/commit/17dde350e9fa9d48346984ddf674c49154668013) python3Packages.av: 14.1.0 -> 15.1.0
* [`c566a272`](https://github.com/NixOS/nixpkgs/commit/c566a2727e44f9f4f028b6db8339db00d4e4c7da) aalib: fix build with clang 19
* [`56852299`](https://github.com/NixOS/nixpkgs/commit/56852299a63c9781fbb96298d253f36ad5bbd25e) sdl3: remove zenity from buildInputs
* [`d566fed6`](https://github.com/NixOS/nixpkgs/commit/d566fed62e4603e91623013b06feff8fc679f238) nodejs*: remove http-parser dependency
* [`73642e98`](https://github.com/NixOS/nixpkgs/commit/73642e9827ffe1a3b0bdef0a36de432d0a885561) pmount: add maintainer ratakor
* [`8f6f920b`](https://github.com/NixOS/nixpkgs/commit/8f6f920b57d2de48cbdc39b8c588464d608906ff) pmount: Fix LUKS integration
* [`116ed8c4`](https://github.com/NixOS/nixpkgs/commit/116ed8c489a2273d336df8f810f78772f65bedb2) vscode-extensions.elijah-potter.harper: init at 0.61.0
* [`64df704a`](https://github.com/NixOS/nixpkgs/commit/64df704a2504e738f7fcdb205257bbff949def3c) pmount: Update patches from debian
* [`926e4159`](https://github.com/NixOS/nixpkgs/commit/926e4159a25ecf7029afd24d9aadaa12170f0f1d) uv: 0.8.14 -> 0.8.15
* [`ec68dba5`](https://github.com/NixOS/nixpkgs/commit/ec68dba529347f3bd663f894a030a5c3f8df5fb9) haskellPackages.ilist: allow base 4.20
* [`90cbf553`](https://github.com/NixOS/nixpkgs/commit/90cbf553761a8684d61fa56363288d6ee6d5bacb) haskellPackages.hs-opentelemetry-api: apply patch to fix text 2.1.1
* [`c05fef41`](https://github.com/NixOS/nixpkgs/commit/c05fef415af4c528f91d35fd5c3aab2c4ca57809) haskellPackages.ascii-case: allow base 4.20 and hashable 1.5
* [`c0b0dab6`](https://github.com/NixOS/nixpkgs/commit/c0b0dab6ccec164f303fb148aaee49c184a8c773) haskellPackages.hw-prim: allow QuickCheck 2.15
* [`731fc6c5`](https://github.com/NixOS/nixpkgs/commit/731fc6c5c19818459ac5a3f076bf899f90fd41b1) haskellPackages.ghc-typelits-extra: disable tests
* [`9f3d0ece`](https://github.com/NixOS/nixpkgs/commit/9f3d0ece19743e82a64965d60576887081aad08e) haskellPackages.aeson-optics: allow base 4.20
* [`2d68b3f4`](https://github.com/NixOS/nixpkgs/commit/2d68b3f4952a613af3fbaca458e919a3564a9544) gn: 0-unstable-2025-06-19 -> 0-unstable-2025-07-29
* [`2752e080`](https://github.com/NixOS/nixpkgs/commit/2752e0802a471a297962fb3830f2654d0bdf0d7e) haskellPackages.hashing: allow bytestring 0.12
* [`62423a67`](https://github.com/NixOS/nixpkgs/commit/62423a67f9546e35e06c47210908bad24194bac6) haskellPackages.hevm: jailbreak
* [`d5e8da50`](https://github.com/NixOS/nixpkgs/commit/d5e8da50f7310da4f1affac0611aa67df520bcc0) libjpeg8: 3.1.1 -> 3.1.2
* [`04a9c31e`](https://github.com/NixOS/nixpkgs/commit/04a9c31ebfc297006cc31a64ccc67cefbcdb3bd3) fluidsynth: 2.4.7 -> 2.4.8
* [`800d264b`](https://github.com/NixOS/nixpkgs/commit/800d264bed4ea94235d0de1e205768fe15fb83f8) catch2_3: 3.9.1 -> 3.10.0
* [`62092edb`](https://github.com/NixOS/nixpkgs/commit/62092edbd177b401a818cc62d187dff1d5ffded3) docs: updated zfs snapshotter support for k3s
* [`910a369f`](https://github.com/NixOS/nixpkgs/commit/910a369fe7c5c3bac3f200a230f9ea032895fbcd) electrum: fix check without qt
* [`58137239`](https://github.com/NixOS/nixpkgs/commit/581372390f4793f003acbbfd28b7e84a31cc7f0d) tayga: fix build on 32-bit host platform
* [`0e70ce7d`](https://github.com/NixOS/nixpkgs/commit/0e70ce7d5ad808a2140103f2caaedcb353fa2ad2) systemd: 257.8 -> 257.9
* [`28e044e3`](https://github.com/NixOS/nixpkgs/commit/28e044e3c8cc36483959fee335cbbd0234a1169d) python3Packages.vfblib: 0.10.2 -> 0.10.4
* [`d5951ce2`](https://github.com/NixOS/nixpkgs/commit/d5951ce2bf20bbe3fd34c38a3df49aba16adfcfe) python3Packages.pbr: 6.1.1 -> 7.0.0
* [`a39b6f75`](https://github.com/NixOS/nixpkgs/commit/a39b6f75e2f0abea93607e00077c02f9df305dbe) python3Packages.pbr: 7.0.0 -> 7.0.1
* [`b54968e3`](https://github.com/NixOS/nixpkgs/commit/b54968e301e9f8d61a366cd6dd1753fbc1b81741) python3Packages.lxml: 6.0.0 -> 6.0.1
* [`2fcaf394`](https://github.com/NixOS/nixpkgs/commit/2fcaf39495719098eccaa112a00ca81180e3acfe) remarshal: 1.0.1 -> 1.2.0
* [`22d0b359`](https://github.com/NixOS/nixpkgs/commit/22d0b3593d7bff7756ce622d0d6ca80d13458021) python3Packages.h2: 4.2.0 -> 4.3.0
* [`941f0025`](https://github.com/NixOS/nixpkgs/commit/941f0025d075ff29d24c8f18472b45506902080a) libunwind: 1.8.2 -> 1.8.3
* [`7c2b1111`](https://github.com/NixOS/nixpkgs/commit/7c2b1111657f951ce551fd69473bd9c3d9ad0682) catch2_3: add spdlog to passthru.tests
* [`5ec404e5`](https://github.com/NixOS/nixpkgs/commit/5ec404e57d622232fb6764a757965bd7d776d074) spdlog: fix build with Catch2 3.9.0
* [`bbe4974c`](https://github.com/NixOS/nixpkgs/commit/bbe4974cda93e630e0c504479cb754f7526a3611) chatterino{2,7}: patch elf rpath with libpulseaudio
* [`7edc3230`](https://github.com/NixOS/nixpkgs/commit/7edc323045c293ae5e8c22db42bc17771724e8e8) haskell.compiler.ghc946: remove left-over patch
* [`a24e99ea`](https://github.com/NixOS/nixpkgs/commit/a24e99ea74e19eed447af06037fd499fd4a4c122) haskell.compiler.ghc947: drop
* [`78f24837`](https://github.com/NixOS/nixpkgs/commit/78f24837ced61196d7b18073b3bf1a7bbf14773f) haskell.compiler.ghc964: drop
* [`ef2d9b7f`](https://github.com/NixOS/nixpkgs/commit/ef2d9b7ffad0facb5e39278f538b050e357c2086) haskell.compiler.ghc965: drop
* [`a8920172`](https://github.com/NixOS/nixpkgs/commit/a8920172f0ee823eb9e2371a24c600d0f9f599fc) haskell.compiler.ghc966: drop
* [`50b634db`](https://github.com/NixOS/nixpkgs/commit/50b634db21784896375bcdbd6fba8009772ed9c8) haskell.compiler.ghc981: drop
* [`1874b16d`](https://github.com/NixOS/nixpkgs/commit/1874b16d387f9009b1ff28d9123b3ad74dcff669) haskell.compiler.ghc982: drop
* [`0943cd95`](https://github.com/NixOS/nixpkgs/commit/0943cd9574fa533ec39da3ed435b9fe225934e22) haskell.compiler.ghc983: drop
* [`5230750e`](https://github.com/NixOS/nixpkgs/commit/5230750e7459f931c8bdd855ba92a36032c937f2) python3Packages.av: remove unnecessary env variable
* [`f0c0a2e8`](https://github.com/NixOS/nixpkgs/commit/f0c0a2e8d1ddf7fe13900a7b6f2cf102af693a94) perlPackages.XSParseKeyword: 0.46 → 0.48
* [`4fa819a4`](https://github.com/NixOS/nixpkgs/commit/4fa819a43c2097b4e5daf27adc3c6a8c3799f0d8) editline: 1.17.1 → 1.17.1-unstable-2025-05-24
* [`036660e6`](https://github.com/NixOS/nixpkgs/commit/036660e6294d7ae6e4bfd1b0f4e3f4dc2d53c483) pkgsLLVM.linuxPackages.ch9344: fix build
* [`df4ee604`](https://github.com/NixOS/nixpkgs/commit/df4ee604e88c7b902b8af09a33782c63b10d5ae7) pkgsLLVM.linuxPackages.nvidia: fix build
* [`e85d0f0f`](https://github.com/NixOS/nixpkgs/commit/e85d0f0f8cdd8663b6533bb67e111e6af8d4a8be) python3Packages.pytest-mock: 3.14.1 -> 3.15.0
* [`8f302ef0`](https://github.com/NixOS/nixpkgs/commit/8f302ef016907a31201804a70869df9fe1da915f) python3Packages.markdown: 3.8.2 -> 3.9.0
* [`592aac63`](https://github.com/NixOS/nixpkgs/commit/592aac63376afdfb455c62c94bd2aa04599ffea9) python3Packages.botocore: 1.40.4 -> 1.40.18
* [`238f4f85`](https://github.com/NixOS/nixpkgs/commit/238f4f85a3be3b7a226f40f4db2e057e4503b9ec) awscli: 1.42.4 -> 1.42.18
* [`f090e19e`](https://github.com/NixOS/nixpkgs/commit/f090e19e031a586a5ff635ffab14315ed4819212) python3Packages.moto: 5.1.9 -> 5.1.11
* [`9545cf3c`](https://github.com/NixOS/nixpkgs/commit/9545cf3c74482f775f0b4c478cb9b5ef260e9f35) python3Packages.aiobotocore: 2.23.2 -> 2.24.2
* [`e136b31d`](https://github.com/NixOS/nixpkgs/commit/e136b31d19d98a9efc10f5569b34423332fc391a) haskell.packages.ghc8107.bytestring-handle: allow QuickCheck >= 2.15
* [`4d5d2bbf`](https://github.com/NixOS/nixpkgs/commit/4d5d2bbf0e596e315a9fc72fe38db637b6380631) maintainers/haskell/hydra-report.hs: stop referencing infra issue
* [`800393c9`](https://github.com/NixOS/nixpkgs/commit/800393c9059977f92aa04e10224d835c243274b3) haskellPackages: unbreak various packages
* [`a486739e`](https://github.com/NixOS/nixpkgs/commit/a486739e74654ff7cca0408fa3d5531f97cd865c) lcevcdec: 3.3.8 -> 4.0.1
* [`f703f1e4`](https://github.com/NixOS/nixpkgs/commit/f703f1e4b6007b3fc10ff61754b1f2f2e5337276) ffmpeg: fix build against newer lcevcdec lib
* [`027094de`](https://github.com/NixOS/nixpkgs/commit/027094de97fd6dfe9ba1fa44c57d75701b5f1c35) fontconfig: 2.16.2 -> 2.17.1
* [`ae493e85`](https://github.com/NixOS/nixpkgs/commit/ae493e85606dedbf147d0a8ab503fa14d715563d) cosmic-ext-applet-external-monitor-brightness: init at 0.0.1-unstable-2025-08-05
* [`88b014f3`](https://github.com/NixOS/nixpkgs/commit/88b014f3ae8247c42b18820c9eda31cc3c0ad161) haskell/broken.yaml: remove left-overs
* [`686a6b4d`](https://github.com/NixOS/nixpkgs/commit/686a6b4d03af8fdfd3ade4ecdc5a9b9c6b97dfbc) python3Packages.netbox-bgp: 0.16.0 -> 0.17.0
* [`3c0099c8`](https://github.com/NixOS/nixpkgs/commit/3c0099c8b93b8da26cc4a43238b4f6228cfd3a5d) Reapply "go_1_25: 1.25.0 -> 1.25.1"
* [`b5a41bca`](https://github.com/NixOS/nixpkgs/commit/b5a41bcaf6a20d59729c5512583ae53c2e59588f) Revert "haskell/broken.yaml: remove left-overs"
* [`e6527ac2`](https://github.com/NixOS/nixpkgs/commit/e6527ac25f45a33e0b164ade1d598cab57320640) python3Packages.netbox-qrcode: 0.0.18 -> 0.0.19
* [`9a2fb1ec`](https://github.com/NixOS/nixpkgs/commit/9a2fb1ec7e28fcc9a5771ceebcdda7e5851c1b02) tab-window-manager: refactor, move to pkgs/by-name & rename from xorg.twm
* [`111ec2bf`](https://github.com/NixOS/nixpkgs/commit/111ec2bfcebffbdc927f16e501e899360fb11e13) xauth: refactor and move to pkgs/by-name from xorg namespace
* [`5c340597`](https://github.com/NixOS/nixpkgs/commit/5c340597a9063d512baf9e26a64525a634bad479) xbacklight: refactor and move to pkgs/by-name from xorg namespace
* [`422a6e0a`](https://github.com/NixOS/nixpkgs/commit/422a6e0a4e0a0ff788986fc346985c55ea78dd42) celestegame: init at 1.4.0.0{,+everest.5806}
* [`41f34ef1`](https://github.com/NixOS/nixpkgs/commit/41f34ef183f1dbcabbae23a71b59dbea28e0cea2) solaar: fix /usr/bin/getfacl path
* [`694ac98b`](https://github.com/NixOS/nixpkgs/commit/694ac98bd67e148f55e2ad9b2fba4213b00c7ad3) nftables: fix static build
* [`9e7f2c9b`](https://github.com/NixOS/nixpkgs/commit/9e7f2c9bd1d9e85610a57fba619abcfabbd9fcfb) yara: 4.5.2 -> 4.5.4
* [`28c56ae2`](https://github.com/NixOS/nixpkgs/commit/28c56ae27f58412485c042cb50359ec3421b9c05) envoy-bin: 1.35.2 -> 1.35.3
* [`1e82a2f3`](https://github.com/NixOS/nixpkgs/commit/1e82a2f358a50a453388a586c4741be19c5ab440) doc: fix typos
* [`7b646b7f`](https://github.com/NixOS/nixpkgs/commit/7b646b7f6d2baef403c318119a072d728fdf38ce) nixos: fix typos
* [`bc28bc58`](https://github.com/NixOS/nixpkgs/commit/bc28bc583a76c66c68798f8b915aa97549b2b5fc) llvm: fix typo in readme
* [`0849a4f6`](https://github.com/NixOS/nixpkgs/commit/0849a4f6cd1b47ab4db9883d0021462ab6ee4016) maintainers: fix typos in md files
* [`5b8a747a`](https://github.com/NixOS/nixpkgs/commit/5b8a747acd7702c9d59809d522dacce404240206) README: adjust wording
* [`807ce4b7`](https://github.com/NixOS/nixpkgs/commit/807ce4b7b340eb5bdb9439e1183172a80a208ad1) ci/eval/README.md: adjust wording
* [`ed23526c`](https://github.com/NixOS/nixpkgs/commit/ed23526c32f4f3cb0761b8682cb6f60c344281d2) pkgs/stdenv: fix typos
* [`78f10f55`](https://github.com/NixOS/nixpkgs/commit/78f10f55a2ca392aa870d9bae5b3f5fb30c147e5) pkgs/os-specific: fix typos
* [`64fb0fc9`](https://github.com/NixOS/nixpkgs/commit/64fb0fc99b32923933d72dcf7932934c64fb3766) nixos/doc: fix typos
* [`010527b7`](https://github.com/NixOS/nixpkgs/commit/010527b7d56a6b2c7064b89dfd3e8857b87da3bd) pkgs/build-support: fix typos
* [`c9857b2f`](https://github.com/NixOS/nixpkgs/commit/c9857b2ffa45226585dbb138df557e6c18e43da3) maintainers: add albertlarsan68
* [`8d8b6e7b`](https://github.com/NixOS/nixpkgs/commit/8d8b6e7b59fff47766790386ed2afc2050b6a3ed) yggdrasil-jumper: 0.3.1 -> 0.4.1
* [`7e94f37a`](https://github.com/NixOS/nixpkgs/commit/7e94f37aebc704fbfea155da0c05ad36954ec3a7) cjson: 1.7.18 -> 1.7.19
* [`cc5a1ded`](https://github.com/NixOS/nixpkgs/commit/cc5a1dedb7e04671edfd97d92978569ff75f569a) python313Packages.habiticalib: 0.4.4 -> 0.4.5
* [`ff6b7e46`](https://github.com/NixOS/nixpkgs/commit/ff6b7e46be5ed56e246d44fd7d038e62e3f41c97) minio: 2025-07-23T15-54-02Z -> 2025-09-07T16-13-09Z
* [`09fdc5c7`](https://github.com/NixOS/nixpkgs/commit/09fdc5c791b5a8a0e925a3b02a4c471b6aef1773) xterm: 401 -> 402
* [`e3bf0d65`](https://github.com/NixOS/nixpkgs/commit/e3bf0d65e8177dcc1686d8c91adf8dc2b7a29ff9) libssh: 0.11.2 -> 0.11.3
* [`3eb02946`](https://github.com/NixOS/nixpkgs/commit/3eb0294617c94b0a297037f61a0180e875330ee1) ghostscript: 10.05.1 -> 10.06.0
* [`dafd3bb7`](https://github.com/NixOS/nixpkgs/commit/dafd3bb7fbb7f14d9bfe4a46d23b828668c63ebd) libpng: 1.6.49 -> 1.6.50
* [`b2b8e2c5`](https://github.com/NixOS/nixpkgs/commit/b2b8e2c5a7594807259808b3e1cf8295dcf44f81) remctl: quote filename with comment marker
* [`40723b42`](https://github.com/NixOS/nixpkgs/commit/40723b42a3a41854b7455fc47a665c9f2e71a5aa) thinkfan: 1.3.1 -> 2.0.0
* [`ca7b9fdc`](https://github.com/NixOS/nixpkgs/commit/ca7b9fdc6b33020ce036bd95e5a4f077f03edb06) thinkfan: use finalAttrs
* [`8101dc14`](https://github.com/NixOS/nixpkgs/commit/8101dc14557f5375ee8e3c56b92e9ca73ed1f1cc) thinkfan: use --replace-fail
* [`b503007d`](https://github.com/NixOS/nixpkgs/commit/b503007d8409142ce5e6800f6f800b820925bd17) haskell-language-server: Fix build
* [`f16a133f`](https://github.com/NixOS/nixpkgs/commit/f16a133fcd9dbc3544a67a4743baf98d537f5706) openblas: avoid building tests with doCheck=false
* [`fec607a9`](https://github.com/NixOS/nixpkgs/commit/fec607a9e37ab99e962501a7d6662e63b7ab5589) openblas: add patch to disable buggy SME SGEMM kernel
* [`fc433765`](https://github.com/NixOS/nixpkgs/commit/fc43376598ebb7b04609547556954fd20a27aec1) curlMinimal: 8.14.1 -> 8.16.0
* [`1fa17f4f`](https://github.com/NixOS/nixpkgs/commit/1fa17f4fa34ff00147ac23dd0679b456646987c1) buildGoModule: reference allowGoReference from finalAttrs
* [`de854a65`](https://github.com/NixOS/nixpkgs/commit/de854a65f2ba5e3385c0aa7615bc3eb10fb64c42) buildGoModule: remove unused argument defaults
* [`3f7c2865`](https://github.com/NixOS/nixpkgs/commit/3f7c2865fc17fb6fe24fbaf8e5f4a80fa64274c3) python313Packages.bitarray: 3.6.0 -> 3.7.1
* [`d88d6248`](https://github.com/NixOS/nixpkgs/commit/d88d624829a482a345dbda87ef594da049fd8782) doctest: 2.4.11 -> 2.4.12
* [`04c3ccc7`](https://github.com/NixOS/nixpkgs/commit/04c3ccc7d7e154644106e80e56ff57e95b9594f6) librsvg: 2.60.0 -> 2.61.1
* [`c497663f`](https://github.com/NixOS/nixpkgs/commit/c497663ffc27d338c2a6ea40aca2f65220546189) nuspell: to by-name
* [`3c718c07`](https://github.com/NixOS/nixpkgs/commit/3c718c07e2f9c3b64c9406ecd44c280f85a0ce6f) nuspell: Refactor to finalAttrs, ctestCheckHook
* [`1b7cdedc`](https://github.com/NixOS/nixpkgs/commit/1b7cdedcf2ad0979da0d6ec802b18cc4e6742886) nuspell: Add withDict wrapper to bring in line with hunspell
* [`bd925d62`](https://github.com/NixOS/nixpkgs/commit/bd925d62d0028711040454fd2c370c1e677db326) python3Packages.pytools: 2025.2.2 -> 2025.2.4
* [`75271d60`](https://github.com/NixOS/nixpkgs/commit/75271d60768ebc13cadf0f6d5ad12e1d10181f3d) audit: 4.1.1-unstable-2025-08-01 -> 4.1.2-unstable-2025-09-06
* [`ef0f4c0c`](https://github.com/NixOS/nixpkgs/commit/ef0f4c0c5f7f16254e0c005b87587f326154f045) audit: enable checks
* [`7596747f`](https://github.com/NixOS/nixpkgs/commit/7596747f62b44b2b4a651d8e8c4896dd0a198715) audit: disable static by default
* [`c0e0f97a`](https://github.com/NixOS/nixpkgs/commit/c0e0f97a5dcb60f585f6907ebd247bc2ce99db8e) audit: clean up passthru.tests
* [`211b818f`](https://github.com/NixOS/nixpkgs/commit/211b818f9f88ee31fe5b5e5552e15b6282a27864) audit: enable python on cross
* [`d54599d8`](https://github.com/NixOS/nixpkgs/commit/d54599d8e5e9dde1fecabd23c810f1b7b04a542c) audit: fix augenrules script
* [`c98add00`](https://github.com/NixOS/nixpkgs/commit/c98add0012fbf265bd16d417dcee1c962823eeb4) python3Packages.audit: init from audit
* [`1884f0fa`](https://github.com/NixOS/nixpkgs/commit/1884f0fa52aab905609d3ec3981f1e12f4b28e72) nixos/audit: rename service to audit-rules-nixos to avoid collisions with the upstream unit
* [`f063f324`](https://github.com/NixOS/nixpkgs/commit/f063f32450a5f383e9a45667a576bdddfefd212c) nixos/auditd: Use new default socket path
* [`7d5e1d98`](https://github.com/NixOS/nixpkgs/commit/7d5e1d984bc04f1b13695fbe9ced102ef9bb980e) nixos/auditd: use upstream unit
* [`08e44062`](https://github.com/NixOS/nixpkgs/commit/08e440629d0205f1e64df5308cf1945e7968a606) opensnitch: allow configuring audit socket path
* [`d4ebfe38`](https://github.com/NixOS/nixpkgs/commit/d4ebfe389fb23492887e76ae05bdeafb0bc937e0) nixos/opensnitch: add audit socket path option
* [`cbf006b0`](https://github.com/NixOS/nixpkgs/commit/cbf006b0440e2392b39b171328ac2d1369d36e4c) pipewire: 1.4.7 -> 1.4.8
* [`474af6bf`](https://github.com/NixOS/nixpkgs/commit/474af6bfcfd47206ecf463526a9d83ee08b74f8e) ruff: 0.12.11 -> 0.13.0
* [`22aa9763`](https://github.com/NixOS/nixpkgs/commit/22aa9763169f28394f129df6eb9614b394bd52ca) haskell.compiler.*: only set LANG if necessary
* [`a8e9468f`](https://github.com/NixOS/nixpkgs/commit/a8e9468fc90c9cc9b1ab1ecfb24474bde30cf76f) boehmgc: Enable __structuredAttrs
* [`99d4c189`](https://github.com/NixOS/nixpkgs/commit/99d4c189314ac0eccc97b972a63a0cea3ad826de) xmrig-cuda{,-mo}: init at 6.22.1{,-mo1}
* [`d834c6e3`](https://github.com/NixOS/nixpkgs/commit/d834c6e3b51c8751bc24d1bebc5e0cb9b5805f3a) utf8proc: 2.10.0 -> 2.11.0
* [`692c64c1`](https://github.com/NixOS/nixpkgs/commit/692c64c10cb1f70cad92f9fdd4a88ba6b2209372) nixos/sddm: add example for option sddm.theme
* [`aca6b30d`](https://github.com/NixOS/nixpkgs/commit/aca6b30ddc5222985b3806fd7a00af953e80b241) spirv-headers: 1.4.321.0 -> 1.4.321.0-unstable-2025-06-24
* [`6e4008fe`](https://github.com/NixOS/nixpkgs/commit/6e4008fe94e8ac4ff46ade1a1d4a97841ee49ae2) spirv-tools: 1.4.321.0 -> 1.4.321.0-unstable-2025-06-25
* [`14181d99`](https://github.com/NixOS/nixpkgs/commit/14181d999fd187bba034680a1e871544715b3bd9) spirv-llvm-translator: unmark broken for LLVM 21
* [`777c7d1b`](https://github.com/NixOS/nixpkgs/commit/777c7d1b0ef65f36b2ca78f3c4c250088889191b) cups: 2.4.12 -> 2.4.13
* [`47b7fd14`](https://github.com/NixOS/nixpkgs/commit/47b7fd149947dd2c987b1fb0194c82fffa2742d7) vid-stab: unstable-2022-05-30 -> 1.1.1-unstable-2025-08-21
* [`14d481d4`](https://github.com/NixOS/nixpkgs/commit/14d481d462e11be4249760f1f599e09fe5732627) libcbor: clean up rebuild avoidance
* [`b5c0cef7`](https://github.com/NixOS/nixpkgs/commit/b5c0cef7ddcf008cf135b66d62b7c345b34979ad) python3Packages.asgiref: 3.8.1 -> 3.9.1
* [`04c4971b`](https://github.com/NixOS/nixpkgs/commit/04c4971bc5d1a7b2d248f5fb5c19563426310fb7) haskellPackages: stackage LTS 24.7 -> LTS 24.9
* [`f6660bb0`](https://github.com/NixOS/nixpkgs/commit/f6660bb07a52c798c66fd71ede3dd45975c02c08) haskell.compiler.*: only set LANG if necessary
* [`e2daad4d`](https://github.com/NixOS/nixpkgs/commit/e2daad4d9da87f6a838e76ce65040b1ffabb1993) protobuf: 32.0 -> 32.1
* [`ed65db9c`](https://github.com/NixOS/nixpkgs/commit/ed65db9c51f0556a2b7a5072226428ff1188d6f5) ghc: 9.10.2 -> 9.10.3
* [`5e6a6e2f`](https://github.com/NixOS/nixpkgs/commit/5e6a6e2f361d4435deb7c30abe198bab3d31baea) haskellPackages.conduit-concurrent-map: drop workaround for GHC < 9.10.3
* [`fb56a433`](https://github.com/NixOS/nixpkgs/commit/fb56a4336fb04388a245e89a21c801823ee4c585) jansson: 2.14 -> 2.14.1
* [`07b28d71`](https://github.com/NixOS/nixpkgs/commit/07b28d71eadc49c77f5b76ff0056e86a0257a4e8) jansson: fix build with CMake 4
* [`1d57f82c`](https://github.com/NixOS/nixpkgs/commit/1d57f82c4c77d5000bade9d7583d6ba3e611a672) doxygen: devendor `fmt`
* [`a612f9a3`](https://github.com/NixOS/nixpkgs/commit/a612f9a3068f256dff84083f11986cb3463ecb3b) fmt_11: add upstream patch for libc++ ≥ 21
* [`44c777dc`](https://github.com/NixOS/nixpkgs/commit/44c777dcb9df351d99f229ed8bd7623a2e97cee2) fmt: fmt_10 -> fmt_11
* [`3d71d3e3`](https://github.com/NixOS/nixpkgs/commit/3d71d3e33b79843e4df13f7a189c6ceba9e660ef) treewide: fmt_11 -> fmt
* [`24041592`](https://github.com/NixOS/nixpkgs/commit/240415924d50146d04af5274e9ee10d6a007d97b) kompute: add upstream patch for fmt ≥ 11
* [`730b7914`](https://github.com/NixOS/nixpkgs/commit/730b7914ff474eb1cddfefb8297fa2d2a1bae222) justbuild: use default `fmt`
* [`2c1d8481`](https://github.com/NixOS/nixpkgs/commit/2c1d848118d9649c1dad01c198ec9da627ef89fe) dolphin-emu: use default `fmt`
* [`a9d1253d`](https://github.com/NixOS/nixpkgs/commit/a9d1253dabbc1f1cf181fd206d9f4690a72170b2) lokinet: mark broken
* [`dc1a255c`](https://github.com/NixOS/nixpkgs/commit/dc1a255cb5906b8020165659ec841481df880015) spdlog: 1.15.2 -> 1.15.3
* [`7c98af33`](https://github.com/NixOS/nixpkgs/commit/7c98af33bec55022043f16da7cc3f97947adcf62) python313Packages.scikit-build-core: fix `cmakeFlags`
* [`6fe4137a`](https://github.com/NixOS/nixpkgs/commit/6fe4137aacaf8dc7185d9cdfbc0de2b0008c3982) python313Packages.pybind11: no with lib; in meta
* [`79ee13f1`](https://github.com/NixOS/nixpkgs/commit/79ee13f14167c884199ffa87d5f140f1097e4ace) Revert "git-annex: patch another test failure"
* [`315801a9`](https://github.com/NixOS/nixpkgs/commit/315801a9c53c0dd0c3161533de1cf0a3dcf8a5ad) echidna: 2.2.6 -> 2.2.7
* [`d13c4852`](https://github.com/NixOS/nixpkgs/commit/d13c48521ef6f07266c582cc7990af109b7b55ef) python3Packages.typer{,-slim}: 0.16.0 -> 0.17.4
* [`cc1dd77b`](https://github.com/NixOS/nixpkgs/commit/cc1dd77b30ba566a66c7f056010ccf0eba4dec0c) libcerf: 3.1 -> 3.2
* [`14b6fdf8`](https://github.com/NixOS/nixpkgs/commit/14b6fdf867b0679c33d6f527b540b9d0a7e7bfe7) gperftools: 2.17 -> 2.17.2
* [`a7aadb16`](https://github.com/NixOS/nixpkgs/commit/a7aadb167bb1724345973361b870da80dffb8271) xorg.libXpresent: 1.0.1 -> 1.0.2
* [`2ed47db6`](https://github.com/NixOS/nixpkgs/commit/2ed47db6241182825bff3067504c673cdd4280e4) ruby_3_5: init at preview1
* [`2e306afa`](https://github.com/NixOS/nixpkgs/commit/2e306afa6898bd0a3154a45f854ddd62e6c22d3b) maintainers/scripts/haskell/hydra-report: speed up with --no-instantiate
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
