### PR TITLE
npins home-manager: update 12fa8548 -> 929535c3

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -61,9 +61,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "12fa8548feefa9a10266ba65152fd1a787cdde8f",
-      "url": "https://github.com/nix-community/home-manager/archive/12fa8548feefa9a10266ba65152fd1a787cdde8f.tar.gz",
-      "hash": "0dyy7wdbj1qcksf9z6rvwm2iz95bjvlbm1kfbc2zkbnz2nqvri8k"
+      "revision": "929535c3082afdf0b18afec5ea1ef14d7689ff1c",
+      "url": "https://github.com/nix-community/home-manager/archive/929535c3082afdf0b18afec5ea1ef14d7689ff1c.tar.gz",
+      "hash": "1rchg5h4rfp5ky1fh8m1hs2apar4q8mikqnwhbyhsvkcjravp4g9"
     },
     "hs-grille": {
       "type": "Git",


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@12fa8548...929535c3](https://github.com/nix-community/home-manager/compare/12fa8548feefa9a10266ba65152fd1a787cdde8f...929535c3082afdf0b18afec5ea1ef14d7689ff1c)

* [`9e0453a9`](https://github.com/nix-community/home-manager/commit/9e0453a9b0c8ef22de0355b731d712707daa6308) zsh: source session variable file directly
* [`a65df807`](https://github.com/nix-community/home-manager/commit/a65df807835d3ba8b13604da34f730d2fc616a31) algia: add module
* [`48e7d821`](https://github.com/nix-community/home-manager/commit/48e7d821876baee76553435104f91f1543881587) news: add algia entry
* [`10bcab77`](https://github.com/nix-community/home-manager/commit/10bcab77af34616244a2eca5dde5d15dcd37151c) aliae: add module
* [`dcf52ade`](https://github.com/nix-community/home-manager/commit/dcf52ade95a79eb2a02aa9e80ae6763aa1ee610d) news: add aliae entry
* [`5a21f481`](https://github.com/nix-community/home-manager/commit/5a21f4819ee1be645f46d6b255d49f4271ef6723) fish: support theme plugins
* [`6b1b122c`](https://github.com/nix-community/home-manager/commit/6b1b122c1bb58b9beb68a42ae3d2aabc0e4e77d2) tests: fix zsh-session-variables test
* [`9d5b443c`](https://github.com/nix-community/home-manager/commit/9d5b443cc88fee03542a2af659ef960ecba40d96) flake.lock: Update
* [`5890176f`](https://github.com/nix-community/home-manager/commit/5890176f856dcaf55f3ab56b25d4138657531cbd) ci: backport use ubuntu latest
* [`a42e05d9`](https://github.com/nix-community/home-manager/commit/a42e05d9b13069eb1d122f565a312c011b09cafe) Revert "fish: support theme plugins"
* [`7500458e`](https://github.com/nix-community/home-manager/commit/7500458e853e17bb1a03f0142d24069ba02ad0f5) files: improve collision error message formatting for readability
* [`004753ae`](https://github.com/nix-community/home-manager/commit/004753ae6b04c4b18aa07192c1106800aaacf6c3) home-manager: add backup overwrite option
* [`6bbfe2d6`](https://github.com/nix-community/home-manager/commit/6bbfe2d6973fb16137d3ef5e322b4591c22948b1) alistral: add module
* [`dd2b0f74`](https://github.com/nix-community/home-manager/commit/dd2b0f74920541d5dc3a5f4e1a12a19e77f5eacc) news: add alistral entry
* [`bd92e8ee`](https://github.com/nix-community/home-manager/commit/bd92e8ee4a6031ca3dd836c91dc41c13fca1e533) asciinema: Add module to configure package
* [`2126d13d`](https://github.com/nix-community/home-manager/commit/2126d13d7f0049b2731e586f8e611eb8f775bcd3) aliae: add configLocation option
* [`edafd6da`](https://github.com/nix-community/home-manager/commit/edafd6da1936426708f1be0b1a4288007f16639a) news: add aliae's configLocation option entry
* [`edfbe06e`](https://github.com/nix-community/home-manager/commit/edfbe06e1a67d0fb3e3c04c2651eecab39e96928) treewide: remove aidalgol
* [`bdf78c2d`](https://github.com/nix-community/home-manager/commit/bdf78c2d2c285683b02abca8071f11a1667b212a) hyprshell: fixed path for style file
* [`66e9a024`](https://github.com/nix-community/home-manager/commit/66e9a024b901034a311cab145e1d6935f66f30bb) hyprshell: fixed tests to use correct name for style file
* [`817ace49`](https://github.com/nix-community/home-manager/commit/817ace497b72b38da0c08728a683b7febaccf9cf) lorri: make notifications service auto-start if enabled
* [`03f83f51`](https://github.com/nix-community/home-manager/commit/03f83f513de3f32a4539875d64e8511fbcfdaeb4) vscode: get paths from product.json
* [`5f06ceaf`](https://github.com/nix-community/home-manager/commit/5f06ceafc6c9b773a776b9195c3f47bbe1defa43) vscode: also test unknown package if IFD is enabled
* [`2b64e332`](https://github.com/nix-community/home-manager/commit/2b64e332a047ec8d3695946bfded39bc3f3583bb) amber: add module
* [`8b624044`](https://github.com/nix-community/home-manager/commit/8b62404497528386642f4368dc552a8f79d9febe) news: add amber entry
* [`87570dbc`](https://github.com/nix-community/home-manager/commit/87570dbc43fafb99081a24353a26763acdad6f76) am2rlauncher: add module
* [`9070d7d3`](https://github.com/nix-community/home-manager/commit/9070d7d32b3d4317e95b6b92f98fee850c1f116d) news: add am2rlauncher entry
* [`b52ece2b`](https://github.com/nix-community/home-manager/commit/b52ece2bb670e888fa39ea7ef7cce523839a9452) flake.lock: Update
* [`06e268d6`](https://github.com/nix-community/home-manager/commit/06e268d66bbf6d606b349a4f0be3af66ab3ea2be) services/barrier: drop module
* [`51870a37`](https://github.com/nix-community/home-manager/commit/51870a37a354a37dc3bd32f3a5a7c9054249492d) grep: fix sessionVariables mkIf evaluation error
* [`78fda50b`](https://github.com/nix-community/home-manager/commit/78fda50bd6e1f26ae914ae77d66e6d2381b64507) gcc: fix sessionVariables mkIf evaluation error
* [`c2e3f1ca`](https://github.com/nix-community/home-manager/commit/c2e3f1cacd0c6b2609552cb6eb1801afe1e6cc3c) tests/gcc: add tests
* [`994d854a`](https://github.com/nix-community/home-manager/commit/994d854a4a90df8d8f661b19d05eb1cb6a951419) tests/grep: add tests
* [`aa10fe09`](https://github.com/nix-community/home-manager/commit/aa10fe094b444e173d5d51ee8bf5f07e7e72e473) discocss: fix discordPackage override
* [`f72f6609`](https://github.com/nix-community/home-manager/commit/f72f660976628775d8a5bb5ea6a3ba7ad2000cdb) discocss: only generate css when provided
* [`6e8ab005`](https://github.com/nix-community/home-manager/commit/6e8ab005bc65649428cba369f2730f01955b3d6a) tests/darwinscrublist: add discocss and discord
* [`3c3076b1`](https://github.com/nix-community/home-manager/commit/3c3076b1c1b941715302d731a4a978bca88fa16f) tests/discoss: add tests
* [`9f2912e3`](https://github.com/nix-community/home-manager/commit/9f2912e3a6c4665bebe3d61ba967ddc65ecd18d4) hyprshot: add platform assertion
* [`5b45dcf4`](https://github.com/nix-community/home-manager/commit/5b45dcf4790bb94fec7e550d2915fc2540a3cdd6) tests/hyprshot: add tests
* [`3f07ce05`](https://github.com/nix-community/home-manager/commit/3f07ce05c3b6d59602bc380e42320483081fa38f) deprecations: add deprecations/removal module
* [`6f4021da`](https://github.com/nix-community/home-manager/commit/6f4021da5d2bb5ea7cb782ff413ecb7062066820) deprecations: move just module deprecation to new module
* [`b72be79a`](https://github.com/nix-community/home-manager/commit/b72be79a42d470e4bafb5348dc62df484b6baab3) smug: add new option introduced by v0.3.7 ([nix-community/home-manager⁠#7930](https://togithub.com/nix-community/home-manager/issues/7930))
* [`e46b52ab`](https://github.com/nix-community/home-manager/commit/e46b52ab56ec5f981491a61e9aececa9e50f712c) darwinScrublist: add difftastic
* [`d328666d`](https://github.com/nix-community/home-manager/commit/d328666dbac08aefd639019516f22c61be14a326) git: add tests for difftastic
* [`1652349e`](https://github.com/nix-community/home-manager/commit/1652349e57daa25217f32656216e404948e512f3) git: add option for difftastic context
* [`7d3d323e`](https://github.com/nix-community/home-manager/commit/7d3d323e906a06247920c0a8fb2fa473a3770fb9) git: add `extraArgs` option for difftastic
* [`ed100232`](https://github.com/nix-community/home-manager/commit/ed10023224107dc8479ead95a448d66f046785e0) maintainers: update all-maintainers.nix
* [`929535c3`](https://github.com/nix-community/home-manager/commit/929535c3082afdf0b18afec5ea1ef14d7689ff1c) git: difftastic: use 'option' attrset
