### PR TITLE
npins nixpkgs: update b63fe7f0 -> 5e11f7ac

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -132,8 +132,8 @@
     "nixpkgs": {
       "type": "Channel",
       "name": "nixpkgs-unstable",
-      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-26.05pre971056.b63fe7f000ad/nixexprs.tar.xz",
-      "hash": "sha256-5QVei2IIfVO3GqMkiiXlrZtaniOkXyMWnqbTVkItrco="
+      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-26.05pre975217.5e11f7acce6c/nixexprs.tar.xz",
+      "hash": "sha256-avkT2TR2Wh/TQTysYGFOkGiF5+2R2nS7TZOfQ4omieQ="
     },
     "powerlevel10k": {
       "type": "Git",


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: release-26.05
Commits: [nixos/nixpkgs@b63fe7f0...5e11f7ac](https://github.com/nixos/nixpkgs/compare/b63fe7f000ad...5e11f7acce6c)

* [`20f01aa7`](https://github.com/NixOS/nixpkgs/commit/20f01aa76c8723300179f1ee94d43d9d8f2452da) nixos/amazon-image: do not force-load xen-blkfront kernel module
* [`b5f59f80`](https://github.com/NixOS/nixpkgs/commit/b5f59f805bdab8d74c1a5ec0b9f06e740e6981d2) auto-rebase: add -f to the filter-branch invocation
* [`81dde829`](https://github.com/NixOS/nixpkgs/commit/81dde829f6035d6eeae6268b9ac1797352d6a33d) ubase: init at 0-unstable-2024-03-07
* [`4346451c`](https://github.com/NixOS/nixpkgs/commit/4346451c0d27a014dc7af35e42803f980dafbe20) realvnc-vnc-viewer: 7.12.1 -> 7.15.1
* [`567a2c26`](https://github.com/NixOS/nixpkgs/commit/567a2c260ed67cc3643245a67d1ba7b4226f48c3) maintainers: add jtamagnan
* [`d4af8731`](https://github.com/NixOS/nixpkgs/commit/d4af8731471a0b4c253827de985648aac52afa8c) render-cli: init at 2.5.0
* [`e605c890`](https://github.com/NixOS/nixpkgs/commit/e605c8903b6ced708bcf795df1f748820db855cc) soapysdr-sdrplay3: add darwin support
* [`e2db5663`](https://github.com/NixOS/nixpkgs/commit/e2db5663aeda2bd61af8383181db1ca4359493ec) soapysdr-sdrplay3: fix cmake minimum version
* [`cbe6c176`](https://github.com/NixOS/nixpkgs/commit/cbe6c1767d43fef95beef325c91d1883a1c295b3) nixos/nixos-containers: fix interface name escaping in systemd.device unit name
* [`6ce61209`](https://github.com/NixOS/nixpkgs/commit/6ce61209e477cc26f8cee4cebbe6600624fa8760) nixos/tests/containers-physical_interfaces: add autoStart test
* [`bf3d134b`](https://github.com/NixOS/nixpkgs/commit/bf3d134bd6aa5a6d4ddbbc8f7b09196c249c6106) nixos/nixos-containers: format
* [`d5a42c07`](https://github.com/NixOS/nixpkgs/commit/d5a42c0770963e990ef01d1d731d8d54e86e4200) qgis, qgis-ltr: fix dependencies and linking on darwin
* [`192501af`](https://github.com/NixOS/nixpkgs/commit/192501af3a8b758fca4ebcbb4b4a5ff38dd9597e) megasync: 5.16.0.2 -> 6.1.1.0
* [`4eb7390c`](https://github.com/NixOS/nixpkgs/commit/4eb7390cb5c15474e64883a5e73d6df6f5186ec8) llama-swap: fix build on Darwin
* [`cad0b88e`](https://github.com/NixOS/nixpkgs/commit/cad0b88e522e47563f87bac02bbf496bd6ab325a) vanilla-dmz: add missing cursor symlinks
* [`485fd701`](https://github.com/NixOS/nixpkgs/commit/485fd70100021c5cfe9a50c7ee0601af7706c849) vanilla-dmz: add amaanq to maintainers
* [`1a105443`](https://github.com/NixOS/nixpkgs/commit/1a105443c9324aa9f7ed81b0456b64c242110e31) config: add recursionMode
* [`1e1115a8`](https://github.com/NixOS/nixpkgs/commit/1e1115a8c78d2a3e4f92277aebcbaadb281b9d3b) tests: make use of recurseIntoAttrsWith
* [`b5cec441`](https://github.com/NixOS/nixpkgs/commit/b5cec4415b610261186edf546d71f9ebdb4c1338) minimal-bootstrap: make use of recurseIntoAttrsWith
* [`9dc126bc`](https://github.com/NixOS/nixpkgs/commit/9dc126bc2460619d39645c76e59570d31d03b209) emacsPackages: make use of recurseIntoAttrsWith
* [`9f1ea860`](https://github.com/NixOS/nixpkgs/commit/9f1ea8601a3d908ade1c40538204de39a80a5293) rPackages: make use of recurseIntoAttrsWith
* [`82a3b269`](https://github.com/NixOS/nixpkgs/commit/82a3b269d66f192bfcf2b9b50ba0615d07dc3cb4) icu78: 78.1 -> 78.2
* [`25c90b36`](https://github.com/NixOS/nixpkgs/commit/25c90b367cf0a9601be88fdfff6d3a1b929b0ded) libhighscore: 0-unstable-2025-12-06 -> 0-unstable-2026-01-30
* [`bcdb329f`](https://github.com/NixOS/nixpkgs/commit/bcdb329ffb71c60343791ab7834382bc639f7fd8) highscore-unwrapped: 0-unstable-2026-01-01 -> 0-unstable-2026-02-01
* [`d3cb3bd0`](https://github.com/NixOS/nixpkgs/commit/d3cb3bd006349d9a372c835ed472783423337894) mathematica: allow user to provide version info
* [`a906f785`](https://github.com/NixOS/nixpkgs/commit/a906f78565efcf4547078334e3911de7942fb2d8) aasvg-rs: init at 1.0.0
* [`2b564349`](https://github.com/NixOS/nixpkgs/commit/2b5643491d0da430c7f8c1cdfa4020cf77476749) gradle: Check that mitmCache.updateScript is run from a valid location
* [`596e4935`](https://github.com/NixOS/nixpkgs/commit/596e4935a7c2b1504c2a3d3d75f4b3169b9becab) maintainers: add cedev-1
* [`ab731f61`](https://github.com/NixOS/nixpkgs/commit/ab731f6125c0dfbc82682c480fae5382af893672) sshm: init at 1.10.0
* [`b3168b3f`](https://github.com/NixOS/nixpkgs/commit/b3168b3fe0f4be76d153752c2655f4e44f80e946) mkKops: use lib.extendMkDerivation
* [`4ed71b97`](https://github.com/NixOS/nixpkgs/commit/4ed71b972d6836e255e16cf0ffe0eaf8062f8a58) kops: modernize
* [`322513ab`](https://github.com/NixOS/nixpkgs/commit/322513ab10bee9d25bcc727be06f0f134a077ecc) openvpn: 2.6.14 -> 2.6.19
* [`7c4c7bfb`](https://github.com/NixOS/nixpkgs/commit/7c4c7bfb99e56d2555d8d9b7103236d60647437b) equibop:  add libstdc++ to runtime path
* [`05a84376`](https://github.com/NixOS/nixpkgs/commit/05a84376ec503e1a4f2f6f42e9d8664537370b09) python3Packages.pip-tools: 7.5.2 -> 7.5.3
* [`6608a960`](https://github.com/NixOS/nixpkgs/commit/6608a9609f25bb4512078c58ee49e55878f974c3) blobtools: fix darwin build
* [`ca83a8ce`](https://github.com/NixOS/nixpkgs/commit/ca83a8ced9c26b3f9f727eb802806901f364a16b) mautrix-discord: 0.7.5 -> 0.7.6
* [`b5626dc3`](https://github.com/NixOS/nixpkgs/commit/b5626dc3f79f139ba1cf0fb862780cb987f775cb) python3Packages.pyslurm: 25.5.0 -> 25.11.0
* [`4d325e15`](https://github.com/NixOS/nixpkgs/commit/4d325e15d19ea6ea5689f8c776178f4d209bacc6) nixos/openrazer: fix driver list
* [`58e662da`](https://github.com/NixOS/nixpkgs/commit/58e662da1f94905aa7302ee6ea596274f62c7d19) waydroid-nftables: 1.6.1 -> 1.6.2
* [`eaef9789`](https://github.com/NixOS/nixpkgs/commit/eaef97894cd897b910ee18aae69b5d4bacdc8919) tree-sitter-grammars.tree-sitter-fish: 3.6.0 -> 3.7.0
* [`f5b6b132`](https://github.com/NixOS/nixpkgs/commit/f5b6b1323e86b9ec9dce72e29cc16bd4d0d58d34) python3Packages.gehomesdk: 2025.11.5 -> 2026.2.0
* [`f6cd0e20`](https://github.com/NixOS/nixpkgs/commit/f6cd0e205968826a03db6a819022e06c78f37c22) _010editor: add updatescript
* [`cceb80f3`](https://github.com/NixOS/nixpkgs/commit/cceb80f319fc6427e55fbad961222305c7b6418e) python314Packages.gehomesdk: migrate to finalAttrs
* [`d12c7147`](https://github.com/NixOS/nixpkgs/commit/d12c71471eca787504a5ec94cf2cbb43557d49dd) python3Packages.tinytuya: 1.17.4 -> 1.17.6
* [`8da14d62`](https://github.com/NixOS/nixpkgs/commit/8da14d62120bbfcf9681f4ef4a0c53621708fae0) python3Packages.ijson: 3.4.0.post0 -> 3.5.0
* [`0e0ef46e`](https://github.com/NixOS/nixpkgs/commit/0e0ef46ea0897a0d6c5a34c21437e899e98a28bf) ubootRaspberryPiAarch64: init
* [`ada325a0`](https://github.com/NixOS/nixpkgs/commit/ada325a08069c73cbc1c5a76082f6ff0f7557b3f) maintainers: add brandonchinn178
* [`e1f0e3f4`](https://github.com/NixOS/nixpkgs/commit/e1f0e3f4f7594b889b5e13fca373303790f9ce8d) python3Packages.types-protobuf: 6.32.1.20251210 -> 6.32.1.20260221
* [`85ffea0e`](https://github.com/NixOS/nixpkgs/commit/85ffea0ee6db05b4c3dc8b8b4332064d5f574f82) tree-sitter-grammars.tree-sitter-powershell: 0.25.10 -> 0.26.3
* [`9e58ee7f`](https://github.com/NixOS/nixpkgs/commit/9e58ee7f7b3422cc376466701eebdead17c16b8d) perl540Packages.ExtUtilsH2PM: init at 0.11
* [`f1c48bcc`](https://github.com/NixOS/nixpkgs/commit/f1c48bcc6a7ea7bbe287db573cc50ed24003b236) perl540Packages.SocketNetlink: init at 0.05
* [`bff2752e`](https://github.com/NixOS/nixpkgs/commit/bff2752ec79e9f9a28375da4437783145238f838) audit.testsuite: init at 0-unstable-2025-08-30
* [`bb62fa7c`](https://github.com/NixOS/nixpkgs/commit/bb62fa7c88576cf3407820b4841db874a815907d) nixos/tests/audit-testsuite: init
* [`358d741e`](https://github.com/NixOS/nixpkgs/commit/358d741e3f71c1811a47baea80eb9dffe00ad95d) freeorion: 0.5.1.1 -> 0.5.1.2
* [`4e238b2c`](https://github.com/NixOS/nixpkgs/commit/4e238b2cee17969d9a27d8dc5d8a48156b3a3dd9) tree-sitter-grammars.tree-sitter-markdown-inline: 0.5.2 -> 0.5.3
* [`fa06f7fc`](https://github.com/NixOS/nixpkgs/commit/fa06f7fc8366c8231c1b104008b9f21ebd9691e8) tree-sitter-grammars.tree-sitter-markdown: 0.5.2 -> 0.5.3
* [`7a5dabd9`](https://github.com/NixOS/nixpkgs/commit/7a5dabd9c8f9bd6748a6356f4c76a8f43f0b8aee) listenbrainz-mpd: add Kladki as maintainer
* [`220d6872`](https://github.com/NixOS/nixpkgs/commit/220d68729d426309b96932caa40d8ea036b89bd0) listenbrainz-mpd: add updateScript
* [`d885f1d3`](https://github.com/NixOS/nixpkgs/commit/d885f1d3f0e0ed9566218b5a43ebbf816750e71c) python3Packages.ephem: 4.2 -> 4.2.1
* [`189afacd`](https://github.com/NixOS/nixpkgs/commit/189afacd24afc35ab8e9ce821a7b512be6d912e9) papra: init at 26.2.2
* [`ed235bc8`](https://github.com/NixOS/nixpkgs/commit/ed235bc82584f15120b5480e38a4157640dcee43) nixos/papra: init
* [`41997d49`](https://github.com/NixOS/nixpkgs/commit/41997d49dae6aec5b29a14b6e9b850835f52d911) nixos/grub: re-install grub on package change
* [`8cd47377`](https://github.com/NixOS/nixpkgs/commit/8cd473775fae255de46c8d599e4b1efa95a304cd) tree-sitter-grammars.tree-sitter-elixir: 0.3.4 -> 0.3.5
* [`9efdfbcd`](https://github.com/NixOS/nixpkgs/commit/9efdfbcd7630f24f433f7059502c5d6beb01b493) i2p: 2.10.0 -> 2.11.0
* [`23e256f0`](https://github.com/NixOS/nixpkgs/commit/23e256f0b29ae7fe07fe3168008a6517ca368639) syncthing-relay: 2.0.12 -> 2.0.15
* [`02a1f1c0`](https://github.com/NixOS/nixpkgs/commit/02a1f1c0cf2e70c0cadbaaa3f5022d70cb6f0f0c) tree-sitter-grammars.tree-sitter-vue: pin to 2026-01-24 commit
* [`b9c9618c`](https://github.com/NixOS/nixpkgs/commit/b9c9618c0dfebf889a6c9aae3e3935be0b617e47) python3Packages.sentry-sdk: 2.53.0 -> 2.54.0
* [`acac56ca`](https://github.com/NixOS/nixpkgs/commit/acac56ca7fde94ab0ed2f5481d483d4300b23f93) python3Packages.intellifire4py: 4.4.0 -> 4.5.0
* [`5dad4a8d`](https://github.com/NixOS/nixpkgs/commit/5dad4a8d6babd6f7bb66ee7fcb0ea67ad9ad2572) python3Packages.markdown2: 2.5.4 -> 2.5.5
* [`d113e69a`](https://github.com/NixOS/nixpkgs/commit/d113e69a87f2ecaa3a4c48492197f7d76b6d7fa0) nixos/prometheus: tests: ui: fix race conditions in Selenium assertions
* [`58be915c`](https://github.com/NixOS/nixpkgs/commit/58be915c55630836d3a15053982178268c0b6d1d) neothesia: modernize derivation
* [`bdf8fbf3`](https://github.com/NixOS/nixpkgs/commit/bdf8fbf3b7442e0d0565bbe874d2633851146b64) tree-sitter-grammars.tree-sitter-unison: 0-unstable-2025-03-06 -> 2.1.3-unstable-2026-02-27
* [`d67ffcae`](https://github.com/NixOS/nixpkgs/commit/d67ffcae5c8f1e8a7136a22c9636ddfb92a48e35) sslh: 2.3.0 -> 2.3.1
* [`54d9df09`](https://github.com/NixOS/nixpkgs/commit/54d9df09e54b6850f0763bcdd22d669076af078d) protonmail-export: 1.0.5 -> 1.0.6
* [`aef562aa`](https://github.com/NixOS/nixpkgs/commit/aef562aa709a2790971f9563bff2491ea374d731) hyprmon: 0.0.12 -> 0.0.13
* [`1994a16a`](https://github.com/NixOS/nixpkgs/commit/1994a16a4bc1e7f9f83368d2ed004f39778c1710) python314Packages.sqlmodel: 0.0.32 -> 0.0.34
* [`d37707e7`](https://github.com/NixOS/nixpkgs/commit/d37707e7ab4f18c3ae75d13977158c50fddc907a) python3Packages.sqlmodel: 0.0.34 -> 0.0.37
* [`5c13deb9`](https://github.com/NixOS/nixpkgs/commit/5c13deb93134ec9e586fa0d7e5facd98b1c63486) python3Packages.aiomealie: 1.2.0 -> 1.2.1
* [`5c1d477d`](https://github.com/NixOS/nixpkgs/commit/5c1d477dcdeb29e97cad8e0742bfc2dbe40c5298) python3Packages.camel-converter: 5.0.0 -> 5.1.0
* [`87004266`](https://github.com/NixOS/nixpkgs/commit/87004266dff8f6f9ccd8f682a9e02b7cf0f64f00) python3Packages.camel-converter: migrate to finalAttrs
* [`81e038fd`](https://github.com/NixOS/nixpkgs/commit/81e038fd8052d26e8fe9d15a15021636a1dec355) python3Packages.aiounifi: 88 -> 89
* [`16652af7`](https://github.com/NixOS/nixpkgs/commit/16652af78484db88a2b8a93fee89c0bc0ed47766) python3Packages.aiounifi: migrate to finalAttrs
* [`695c6c32`](https://github.com/NixOS/nixpkgs/commit/695c6c32426bfdd3a35b471ee8bf3d6c42872cd1) python3Packages.midea-local: 6.5.0 -> 6.6.0
* [`f55d8497`](https://github.com/NixOS/nixpkgs/commit/f55d84973ccaf949d364e5244a186480bf48a626) doge: 3.9.0 -> 3.9.2
* [`4706848d`](https://github.com/NixOS/nixpkgs/commit/4706848d4810153e965dc11697763a5d22ae5e08) assh: 2.17.0 -> 2.17.1
* [`c362c105`](https://github.com/NixOS/nixpkgs/commit/c362c105dccd635a92a6b0a39ed80de71730190f) tree-sitter-grammars.tree-sitter-robot: 1.1.2 -> 1.3.0
* [`c3f0c3ec`](https://github.com/NixOS/nixpkgs/commit/c3f0c3ec350c468e8bde679941366cfb52a27cb6) nixos/limine: add settings autoGenerateKeys & autoEnrollKeys
* [`1c87787f`](https://github.com/NixOS/nixpkgs/commit/1c87787faffe122dcddb5de021e56fd536921e78) iproute2mac: 1.6.0 -> 1.7.2
* [`633f816c`](https://github.com/NixOS/nixpkgs/commit/633f816cca966b66f55f1057a8ec0c7aa805bef7) home-assistant-custom-components.moonraker: 1.13.2 -> 1.13.3
* [`7f41b46f`](https://github.com/NixOS/nixpkgs/commit/7f41b46f01ed176e428a71d6d6b72901eba18adb) wox: 2.0.0 -> 2.0.1
* [`54fe1ba0`](https://github.com/NixOS/nixpkgs/commit/54fe1ba0f231977af5103cbd65cf43a932df7d11) home-assistant-custom-lovelace-modules.kiosk-mode: 10.0.1 -> 11.0.0
* [`5b991cc9`](https://github.com/NixOS/nixpkgs/commit/5b991cc9271800cbf978aaddce10d8e52e6d11a0) dash-mpd-cli: 0.2.31 → 0.2.32
* [`31d81cc5`](https://github.com/NixOS/nixpkgs/commit/31d81cc53c6ad8611cb6158bdeb687d7135bae16) weechat: 4.8.1 -> 4.8.2
* [`f704ec83`](https://github.com/NixOS/nixpkgs/commit/f704ec835eae9023496b1a05e312e2c34221d96e) linuxPackages.xpadneo: 0.9.8 -> 0.10.0
* [`6492b983`](https://github.com/NixOS/nixpkgs/commit/6492b9831bd9937d0aa450c9665292ef44c4dc4b) deno: 2.6.10 -> 2.7.4
* [`7bee4881`](https://github.com/NixOS/nixpkgs/commit/7bee488134254059bc1e1c78728d8bad4ab8fe23) sparkle: skip pre-releases on update script
* [`316eb971`](https://github.com/NixOS/nixpkgs/commit/316eb9715623b366ae502c09f341777ba5f04d76) maintainers: add nemith
* [`c560c39f`](https://github.com/NixOS/nixpkgs/commit/c560c39f949286b35cb4869e2ec1e3079ddc42bc) starship-jj: init at 0.7.0
* [`8abcd1fb`](https://github.com/NixOS/nixpkgs/commit/8abcd1fb0447850aabb2aaf7e882b76abafdaf38) libpcap: allow building with RDMA protocol support
* [`9579e1b4`](https://github.com/NixOS/nixpkgs/commit/9579e1b4d3be9961fe2c0c6fdf037daebc727e64) tree-sitter-grammars.tree-sitter-gitcommit: 0.4.0 -> 0.5.0
* [`66dc105d`](https://github.com/NixOS/nixpkgs/commit/66dc105d66f0e69bee93458227ab8840ea5eb77a) python3Packages.plugwise: 1.11.2 -> 1.11.3
* [`2d69362f`](https://github.com/NixOS/nixpkgs/commit/2d69362f8a25de46b91c1486a6a30d9b679ca2a2) bootdev-cli : 1.24.0 -> 1.26.0
* [`399a7e41`](https://github.com/NixOS/nixpkgs/commit/399a7e410894115b8bb2854efdd0a4867e7868ce) python3Packages.types-pytz: 2025.2.0.20251108 -> 2026.1.1.20260304
* [`eb4f6382`](https://github.com/NixOS/nixpkgs/commit/eb4f6382311b740d6e65df5869aaa7eccec49138) python3Packages.types-pytz: migrate to finalAttrs
* [`56264788`](https://github.com/NixOS/nixpkgs/commit/5626478845d197b1220872a434c462a8b4064355) python3Packages.plugwise: modernize
* [`5d5c795c`](https://github.com/NixOS/nixpkgs/commit/5d5c795c749c729dd6320b8ef110d1bd6e24c9ed) python313Packages.fastremap: unbreak tests
* [`ebe5b812`](https://github.com/NixOS/nixpkgs/commit/ebe5b81260d8f5569ace5b8de0ea7791738295e2) fosrl-pangolin: 1.15.3 -> 1.16.2
* [`6876b118`](https://github.com/NixOS/nixpkgs/commit/6876b11837fa635fb1f53b953eae94db0376929b) bootdev-cli: fix build
* [`a66ed0bc`](https://github.com/NixOS/nixpkgs/commit/a66ed0bc04cec8274fd0bc8a799949d0bf5cacbb) treewide: Remove my maintainer status from some modules
* [`877bfea9`](https://github.com/NixOS/nixpkgs/commit/877bfea9884f1ecd45e95e66936eaa85497c96d5) licenses: add liliq-p-1.1
* [`0c3891ab`](https://github.com/NixOS/nixpkgs/commit/0c3891abdf6699bb00fcecee0d2675d8073684b0) python3Packages.python-overseerr: 0.8.0 -> 0.9.0
* [`e3d8f2c8`](https://github.com/NixOS/nixpkgs/commit/e3d8f2c8eb3a70c524555ba0e67801b2aa9f8b37) racket{,-minimal}: update platforms and badPlatforms
* [`2d14452a`](https://github.com/NixOS/nixpkgs/commit/2d14452af056d873870638b47c1952dd1dba1f10) rwpspread: 0.5.0 -> 0.5.1
* [`6923f19a`](https://github.com/NixOS/nixpkgs/commit/6923f19a69f47a475608d558c146d69a6a66464a) tree-sitter-grammars.tree-sitter-scala: 0.24.0 -> 0.25.0
* [`8544b6ea`](https://github.com/NixOS/nixpkgs/commit/8544b6ea3f98f59c237ed5414adfbf2ba8058900) python3Packages.mozart-api: 5.3.1.108.1 -> 5.3.1.108.2
* [`d78597bc`](https://github.com/NixOS/nixpkgs/commit/d78597bcc1b967ddea985c5fbf6c6a486b6f76de) nixos/libvirtd: fix NSS module logic
* [`e139e363`](https://github.com/NixOS/nixpkgs/commit/e139e363370f590c97abe031a07015f78565c6b6) anytone-emu: unstable-2023-06-15 -> 0.4.0
* [`7da33373`](https://github.com/NixOS/nixpkgs/commit/7da33373e247643d0f55574c914d442850481030) jadx: 1.5.3 -> 1.5.5
* [`15e29379`](https://github.com/NixOS/nixpkgs/commit/15e2937901a7cca18114a9274ef6c8a3fbbb3a27) insulator2: 2.13.2 -> 2.14.0
* [`19a85721`](https://github.com/NixOS/nixpkgs/commit/19a85721226edc09a60e858c0355760ebade43ef) insulator2: modernize
* [`4e4aa69c`](https://github.com/NixOS/nixpkgs/commit/4e4aa69c2258e4acb8b3830264c6176c8a0cea13) opensbi: 1.6 -> 1.8.1
* [`08266009`](https://github.com/NixOS/nixpkgs/commit/082660093584bffe39c5f12fec3a562bda373e20) man-pages: fix `can't resolve man7/groff_man.7` error when running `man man`
* [`81f13fc6`](https://github.com/NixOS/nixpkgs/commit/81f13fc690387ceada06cf9bbf2ec4590a99e06e) bazel_9: init at 9.0.1
* [`05e36fdc`](https://github.com/NixOS/nixpkgs/commit/05e36fdccadd2113c56e4c9caadf9a7072baa110) tree-sitter-grammars.tree-sitter-fstar: init at 0-unstable-2026-03-14
* [`4e8290f9`](https://github.com/NixOS/nixpkgs/commit/4e8290f9278f34b01383fce1558f2a4b65446378) python3Packages.pook: 2.1.4 -> 2.1.6
* [`55633938`](https://github.com/NixOS/nixpkgs/commit/55633938af6286f39a275b2d3015ab7c5d8c7a1b) qidi-studio: 2.04.01.11 > 2.05.01.52
* [`91fcb24c`](https://github.com/NixOS/nixpkgs/commit/91fcb24c70f902d7ddb9ed735ad2346e20bb4308) virt-manager: add appindicator support
* [`9a86a5e2`](https://github.com/NixOS/nixpkgs/commit/9a86a5e21b41f06300f833d0d53e3a6c3225e7bb) python3Packages.geopandas: 1.1.2 -> 1.1.3
* [`3acd000d`](https://github.com/NixOS/nixpkgs/commit/3acd000d3477748ba18a1555eafeb65e2635d1ea) slurm: add pam support
* [`72ec3724`](https://github.com/NixOS/nixpkgs/commit/72ec3724b52991ec16aebab26ae8955c105abfc0) nixos/pam: add slurm_pam(_adopt) support
* [`1680dd9d`](https://github.com/NixOS/nixpkgs/commit/1680dd9de56adbe7c639cbf286f81b5230ddf72a) nixosTests.slurm-pam: add PAM integration testing for Slurm
* [`80d9b9cc`](https://github.com/NixOS/nixpkgs/commit/80d9b9cc39ab85e505aa7ebc8f0c9a85633d1b53) nixosTests.slurm: test cluster and job state
* [`b0627c34`](https://github.com/NixOS/nixpkgs/commit/b0627c345a6881091f4880632133ced13c82dd57) python3Packages.geopandas: modernize
* [`35590875`](https://github.com/NixOS/nixpkgs/commit/355908755a54d1f0c7311284185fcc5b60fb5f68) nixos/network-interfaces: remove network-setup
* [`65c1c008`](https://github.com/NixOS/nixpkgs/commit/65c1c008f252bc3ac4c233262c30d3cf5f000034) nixos/networking-interfaces: add networking-scripted.target
* [`8bc8c596`](https://github.com/NixOS/nixpkgs/commit/8bc8c596ead9703f76af1f65a62f3e31560b0f1e) nixos/doc: update networking chapter
* [`1623fe23`](https://github.com/NixOS/nixpkgs/commit/1623fe233169fc86917ee79b23710eaa6695d109) nixos/release-notes: explain network-interfaces changes
* [`a35b2bc0`](https://github.com/NixOS/nixpkgs/commit/a35b2bc018c892fad5ed435092e9c3aa2f0718fd) gpxsee: 15.11 → 16.0
* [`6c2c08e3`](https://github.com/NixOS/nixpkgs/commit/6c2c08e3272f99f878ca665e4871921b53bb9807) python3Packages.pypdfium2: 5.5.0 -> 5.6.0
* [`fe9ae53f`](https://github.com/NixOS/nixpkgs/commit/fe9ae53f0dbfd49b9378028257277db51267fba7) convoyeur: init at 0.1.1
* [`f5b25da5`](https://github.com/NixOS/nixpkgs/commit/f5b25da5593dc96764c9c9ef3783979b599c8ab6) cudaPackages.nccl-tests: 2.17.10 -> 2.18.2
* [`ba23f427`](https://github.com/NixOS/nixpkgs/commit/ba23f427b764ef9ea86c5e70ec74a9462d838e69) jetbrains.rust-rover: 2025.3.4 -> 2025.3.5
* [`67c1f597`](https://github.com/NixOS/nixpkgs/commit/67c1f597b10b81ffbe94cbb1b5dec537132ae102) jpm: 1.1.0 -> 1.2.0
* [`969dbdbb`](https://github.com/NixOS/nixpkgs/commit/969dbdbbc5c79d70eb7d29b35a421425df394d03) python3Packages.quil: 0.34.0 -> 0.35.0
* [`ffd2f323`](https://github.com/NixOS/nixpkgs/commit/ffd2f32338a1d9ed5a50a4790e06af2440f4b1f4) python3Packages.qcs-sdk-python: 0.21.22 -> 0.26.0
* [`7d0213ac`](https://github.com/NixOS/nixpkgs/commit/7d0213ac696ebf1afc00753396be693d24aae624) tor: Add example to onionServices.name.map
* [`05a2c0ef`](https://github.com/NixOS/nixpkgs/commit/05a2c0ef9caa0f959cbe1b43c1f8d895fb991097) rustup: 1.28.2 -> 1.29.0
* [`e861f051`](https://github.com/NixOS/nixpkgs/commit/e861f051ec91d5e17c341f147018a317d8f05b55) libtorrent-rakshasa: 0.16.6 -> 0.16.8, rtorrent: 0.16.6 -> 0.16.8
* [`e8eec417`](https://github.com/NixOS/nixpkgs/commit/e8eec417318c1e6bd6c37174d48289c53ed68098) dart-sass: 1.97.3 -> 1.98.0
* [`0998cf85`](https://github.com/NixOS/nixpkgs/commit/0998cf85d07207fecf8896b93996ae912e279252) rWrapper,radianWrapper,rstudioWrapper,rstudioServerWrapper: use makeBinaryWrapper
* [`9771742b`](https://github.com/NixOS/nixpkgs/commit/9771742bda2fdc5a22ddfe2ef40b5eca9bc9eb20) R: 4.5.2 -> 4.5.3
* [`77a15389`](https://github.com/NixOS/nixpkgs/commit/77a15389697c2c73ca8edaa4cb8e121c1bc50dc3) rPackages: CRAN and BioC update
* [`2a9a21b9`](https://github.com/NixOS/nixpkgs/commit/2a9a21b9e1286e381af05381a701cb4d441f7e84) fantasque-sans-mono: use installFonts hook
* [`4352d0e5`](https://github.com/NixOS/nixpkgs/commit/4352d0e5e437d2266c52245c941d28aed7578a98) ghidra-extensions.kaiju: 260116 -> 260309
* [`bb913ad5`](https://github.com/NixOS/nixpkgs/commit/bb913ad5207b677e922a649201fed06a7cf33ca8) oci-cli: 3.74.0 -> 3.76.0
* [`bd4d6368`](https://github.com/NixOS/nixpkgs/commit/bd4d6368fc7c2a164486396cb57ebbe496400693) openrazer-daemon: 3.11.0 -> 3.12.0
* [`1694229b`](https://github.com/NixOS/nixpkgs/commit/1694229b544628c832b8b8f9408d798a0701f165) openclaw: fix update script for insecure package
* [`0cbb570b`](https://github.com/NixOS/nixpkgs/commit/0cbb570b0aa41785adcf5a96a6796e620cae0e57) rPackages.ggiraph: fix build
* [`75c4fc2f`](https://github.com/NixOS/nixpkgs/commit/75c4fc2f6ea010b2cca4dc965989cd2a9618687d) inkscape-extensions.textext: don't use texlive.combine
* [`5e0614b9`](https://github.com/NixOS/nixpkgs/commit/5e0614b93c5706abc4378d49ecabbb0b2c2f4ef9) auto-multiple-choice: add tex container for texlive.withPackages
* [`271c68c6`](https://github.com/NixOS/nixpkgs/commit/271c68c670407ffa4ea88de91ba9c6064f1cb8ff) extractpdfmark: don't use texlive.combine
* [`7603c13b`](https://github.com/NixOS/nixpkgs/commit/7603c13b3cb2f0a887e5abb1871ff7b3bd6083bd) python3Packages.pylatex: use texlive.withPackages instead of texlive.combine
* [`f0372796`](https://github.com/NixOS/nixpkgs/commit/f03727969214f979c31c7a2b88d075a65e6b6329) python3Packages.pytikz-allefeld: don't use texlive.combine
* [`429c3474`](https://github.com/NixOS/nixpkgs/commit/429c3474d7000af85e5df7673521537008afb152) _010editor: 16.0.3 -> 16.0.4
* [`524ca256`](https://github.com/NixOS/nixpkgs/commit/524ca256cfa83a85bbdc61ba404552a9f254bbf7) burn-central-cli: init at 0.4.0
* [`19838777`](https://github.com/NixOS/nixpkgs/commit/19838777bf9e488a997267ab063448cda307d297) apngasm: fix build with Boost 1.89+
* [`54d20e19`](https://github.com/NixOS/nixpkgs/commit/54d20e195c724390316c45f9297770110de79f60) pixi: 0.63.2 -> 0.66.0
* [`89396151`](https://github.com/NixOS/nixpkgs/commit/89396151b75e0c5d172480de4751a6f675820ce4) lightgbm: update repo links
* [`022eb3f5`](https://github.com/NixOS/nixpkgs/commit/022eb3f52f6a2e5c71c8ce72b43d94c67098db9a) hooky: init at 1.0.3
* [`17022b41`](https://github.com/NixOS/nixpkgs/commit/17022b416e1f86fb933db65f82e2e8f1a9a60a05) stayrtr: 0.6.2 -> 0.6.4
* [`354b40b8`](https://github.com/NixOS/nixpkgs/commit/354b40b89de04a46b04e959288fc1f4aeac535c8) ppsspp: 1.19.3 -> 1.20.3
* [`c4ae5f6b`](https://github.com/NixOS/nixpkgs/commit/c4ae5f6b7575e5fea0cd066056fdb8adf29498fa) davmail: Revert "fix: temp zulu davmail"
* [`e2363bd8`](https://github.com/NixOS/nixpkgs/commit/e2363bd8e089780d7c2b823ef549595883927895) davmail: Add doronbehar as maintainer
* [`37245a63`](https://github.com/NixOS/nixpkgs/commit/37245a63b555a01579d0555710f4694886f0ca12) uppaal: fix blank window on Wayland
* [`0e9c6257`](https://github.com/NixOS/nixpkgs/commit/0e9c625739802df99dc8367392c0e0231babf840) maintainers: add lnk3
* [`3bd05fb1`](https://github.com/NixOS/nixpkgs/commit/3bd05fb10c2b5a1e613b353121476b478a7c4183) onedriver: 0.14.1 -> 0.15.0
* [`88fcfc49`](https://github.com/NixOS/nixpkgs/commit/88fcfc49363178b0b1ddcdc007a7f2f329d371bd) libcerf: modernize
* [`670b93aa`](https://github.com/NixOS/nixpkgs/commit/670b93aa9d15442fff6d49981f6eff6beb5f33e1) libcerf: 3.2 -> 3.3
* [`752d5ff2`](https://github.com/NixOS/nixpkgs/commit/752d5ff25d495f9aed681cc9098367cf4572c4bf) libcerf: add hythera as maintainer
* [`e49bc575`](https://github.com/NixOS/nixpkgs/commit/e49bc57544169ec6bbbcb7254ae292cb6f2578fe) fira-sans: remove __MACOSX folder causing conflicts
* [`e48bf3b3`](https://github.com/NixOS/nixpkgs/commit/e48bf3b332cee157614638f54e43c35247de3f51) ansel: 0-unstable-2026-03-11 -> 0-unstable-2026-03-19
* [`61dd16da`](https://github.com/NixOS/nixpkgs/commit/61dd16da9af2d0ac5700176a712d3682c48d13c7) davmail: Add shymega to maintainers
* [`63cf11f9`](https://github.com/NixOS/nixpkgs/commit/63cf11f9969f798e7dd9ad0ab2f7593c129e3d7b) openfreebuds: relax all deps, add tests
* [`a8da18f2`](https://github.com/NixOS/nixpkgs/commit/a8da18f2c01af19789c863fe403785dd1f0236a2) intel-oneapi.{base,hpc}.updateScript: unbreak
* [`dfc35065`](https://github.com/NixOS/nixpkgs/commit/dfc3506572999cf65fc579c18d7d09d335bed5e4) intel-oneapi.{base,hpc}.updateScript: remove unused jq import
* [`3338bc56`](https://github.com/NixOS/nixpkgs/commit/3338bc567af738d0a7d8ca8da0554f5ad589929b) intel-oneapi.{base,hpc}.updateScript: reconstruct _offline.sh URLs if not present
* [`ae733679`](https://github.com/NixOS/nixpkgs/commit/ae733679b84abda9b835084dd6b5656aeb8f7c72) intel-oneapi.{base,hpc}.updateScript: nix-hash -> nix hash
* [`6ff5f0c7`](https://github.com/NixOS/nixpkgs/commit/6ff5f0c7ef566ddcf3f25677dc266dabe45aea2c) intel-oneapi.base: 2025.2.1.44 -> 2025.3.1.36
* [`2f7339e9`](https://github.com/NixOS/nixpkgs/commit/2f7339e916a1b5c2cb4b4c4a2fbe2f41640029ba) intel-oneapi.hpc: 2025.2.1.44 -> 2025.3.1.55
* [`52accacf`](https://github.com/NixOS/nixpkgs/commit/52accacfe161ec00d5f2734fc01a69bdf52e0b8e) intel-oneapi.base: ignore new missing dependency libreadline.so.6
* [`97c94811`](https://github.com/NixOS/nixpkgs/commit/97c94811dbc7675ed84e8db6769e71ebe3d30209) nezha: 2.0.5 -> 2.0.6
* [`c9994406`](https://github.com/NixOS/nixpkgs/commit/c9994406a8c9fbca30203bb29a22917dc23c97ae) python3Packages.podcats: fix build failure
* [`a57bd118`](https://github.com/NixOS/nixpkgs/commit/a57bd118815002792c2c9cd54ac811b17af6c0c5) python3Packages.podcats: adopt
* [`b6d5bd53`](https://github.com/NixOS/nixpkgs/commit/b6d5bd536ed3a874b231974db7cf1375d168aad3) ory-hydra: 25.4.0 -> 26.2.0
* [`a07a83a6`](https://github.com/NixOS/nixpkgs/commit/a07a83a6e57de3c62be84f192d82552ec86a74a5) kratos: 25.4.0 -> 26.2.0
* [`47f346ef`](https://github.com/NixOS/nixpkgs/commit/47f346ef6fe6dd58d8f825a899b77584c6682ac2) kratos: add debtquity to maintainers
* [`690e0232`](https://github.com/NixOS/nixpkgs/commit/690e0232535c2acc25d58688b06154833b625e5b) keto: 25.4.0 -> 26.2.0
* [`467f16bf`](https://github.com/NixOS/nixpkgs/commit/467f16bf4da5ac7e0bfa19b4ec4befd80578e19e) diffoscope: 314 -> 315
* [`f9f2df41`](https://github.com/NixOS/nixpkgs/commit/f9f2df411aa530cad7c32f4048664766201d3c64) maintainers: drop Scriptkiddi
* [`677f76f5`](https://github.com/NixOS/nixpkgs/commit/677f76f509bea8685f16736a6d10a61207055f6d) openstack-rs: 0.13.3 -> 0.13.5
* [`90e6d45b`](https://github.com/NixOS/nixpkgs/commit/90e6d45b404f92b49757718ddf28e6427adf6c9b) libbass{,_fx,midi,mix}: support darwin; add ulysseszhan to maintainers
* [`54b9582d`](https://github.com/NixOS/nixpkgs/commit/54b9582d13af461680f6d6fdae4ee138dfd60d23) kitty: 0.46.1 -> 0.46.2
* [`10183441`](https://github.com/NixOS/nixpkgs/commit/10183441d061a972f33975746fc78f49d439eaa6) nixos/grocy: enforce data directory presence
* [`148bd875`](https://github.com/NixOS/nixpkgs/commit/148bd87563903dad18e994e341a459e6e3512275) openexr_2: Replace meta.insecure with meta.knownVulnerabilities
* [`db9e17da`](https://github.com/NixOS/nixpkgs/commit/db9e17da82c3f7d7c1a47c989c36844ab6eac518) ilmbase: Repalce meta.insecure with meta.knownVulnerabilities
* [`4b7353ee`](https://github.com/NixOS/nixpkgs/commit/4b7353eeb5bb6d456a862d01105b66a419f8d0b2) gegl: Switch to openexr v3
* [`ba98e8b0`](https://github.com/NixOS/nixpkgs/commit/ba98e8b017936f32389d40f32c217063e50c78b4) python3Packages.pyreaderwriterlock: drop
* [`05fcd5e6`](https://github.com/NixOS/nixpkgs/commit/05fcd5e64fc9cc900da615011f79a64794033700) starship-sf64: init at 2.0.0
* [`bb5a3f2d`](https://github.com/NixOS/nixpkgs/commit/bb5a3f2d5237b1d0d2f4914d3896c3d6a7f257fd) tshock: 6.0.0-pre1 -> 6.1.0
* [`915c4836`](https://github.com/NixOS/nixpkgs/commit/915c4836e118052d9e474dfc5e52fb8d8acebf41) shark: fix after boost upgrade
* [`09b536d6`](https://github.com/NixOS/nixpkgs/commit/09b536d6ad8e48de21e836a85e42bf6fa470ff43) librespeed-cli: no longer broken on darwin
* [`413f4666`](https://github.com/NixOS/nixpkgs/commit/413f4666cdd4813f34de17b174c7f93dd573ec41) lib/modules: Improve errors involving pushDownProperties
* [`d48a370d`](https://github.com/NixOS/nixpkgs/commit/d48a370de11ccfd407d12ee3f15ac6e7ceedc5cc) lib/modules: Add error message test for pushing down non-attrsets
* [`8e779490`](https://github.com/NixOS/nixpkgs/commit/8e77949010dd5ca0b7fcf272cb8f03f66b5d5ef9) maintainers: drop gschwartz
* [`7058dfc2`](https://github.com/NixOS/nixpkgs/commit/7058dfc2ab7bd315c3b2624314831fc393ec2cc3) python3Packages.hologram: drop
* [`15415424`](https://github.com/NixOS/nixpkgs/commit/15415424ac68b941fd694fc9ee747da50b5a4dee) python3Packages.flake8-future-import: drop
* [`35fc42ab`](https://github.com/NixOS/nixpkgs/commit/35fc42abe1be1ecc2540b0a2d8bfb6cfd1f64412) python3Packages.filebytes: fix build with python 3.14
* [`fc1206e1`](https://github.com/NixOS/nixpkgs/commit/fc1206e1f7612e05f31583f264126602a69a0875) python3Packages.filebytes: fetch `src` from GitHub
* [`468b4dc4`](https://github.com/NixOS/nixpkgs/commit/468b4dc4f9ec0b8231880b3a5a78f3308f133f16) python3Packages.filebytes: fix `meta.license`
* [`f52df0ff`](https://github.com/NixOS/nixpkgs/commit/f52df0ff93097dd82fc91e6919c58ab82ed47b4d) python3Packages.filebytes: modernize
* [`e6ea3f54`](https://github.com/NixOS/nixpkgs/commit/e6ea3f54f7f012920172015d8b8063ba55415c0e) guile-irregex: 0.9.11 -> 0.9.12
* [`6bd3b5e9`](https://github.com/NixOS/nixpkgs/commit/6bd3b5e9ed1451c261592cd3b920a82a7aae7f76) guile-json-rpc: 0.5.0 -> 0.6.1
* [`30f607a2`](https://github.com/NixOS/nixpkgs/commit/30f607a2cc4e237fc8c1040216f86ee56cfbe9e9) guile-srfi-145: 0-unstable-2023-06-04 -> 0-unstable-2025-08-11
* [`3f969bd1`](https://github.com/NixOS/nixpkgs/commit/3f969bd1fe7bf894cf9787c3cbc754289a584050) guile-srfi-180: 0-unstable-2023-06-04 -> 0-unstable-2025-08-11
* [`2e167694`](https://github.com/NixOS/nixpkgs/commit/2e1676940fdc5c8554738c1f7dc79a0a2ca4781f) python3Packages.django-cryptography: drop
* [`e865806c`](https://github.com/NixOS/nixpkgs/commit/e865806c5ea2ffc63f26783dcbb7b71caa2385ec) mtkclient: 2.1.2 -> 2.1.3
* [`fa3cac1f`](https://github.com/NixOS/nixpkgs/commit/fa3cac1f253054f26d4d5d3679a33ed4afa168b4) mtkclient: install MTK-specific udev rules
* [`21530cd9`](https://github.com/NixOS/nixpkgs/commit/21530cd9de08931cc0e70aec27c0682a29a02d02) mtkclient: include source-built kamakiri payloads
* [`b2b81108`](https://github.com/NixOS/nixpkgs/commit/b2b8110884c17c80e537b1f1474f2113152ec318) gitoxide: 0.50.0 -> 0.52.0
* [`13f55e7b`](https://github.com/NixOS/nixpkgs/commit/13f55e7bdd59d09482def68a1d2c1a563650786c) gitoxide: add hythera as maintainer
* [`21eb4694`](https://github.com/NixOS/nixpkgs/commit/21eb469490600fcf077e86fcfba9e19a05f63e43) pdfium-binaries: 7643 -> 7734
* [`4bf98cdf`](https://github.com/NixOS/nixpkgs/commit/4bf98cdf8cc1e4ac186790b20ddc3372d477bf16) mpdscribble: 0.24 -> 0.25
* [`695051d9`](https://github.com/NixOS/nixpkgs/commit/695051d908f207252dced4010b406de53af4cf7b) maintainers: add kybe236
* [`9a8f9c1b`](https://github.com/NixOS/nixpkgs/commit/9a8f9c1b04aec71cb0ea5e6dd4102e35258a7b84) mpdscribble: add kybe236 as co-maintainer
* [`1be82e25`](https://github.com/NixOS/nixpkgs/commit/1be82e25dd7068e76d3f48c68dd4f81fb1842ab1) swww: rename to awww, 0.11.2 -> 0.12.0
* [`5c299d60`](https://github.com/NixOS/nixpkgs/commit/5c299d60bb2332df60b7fee6d41a39d559678558) albyhub: 1.21.0 -> 1.21.6
* [`5ec06994`](https://github.com/NixOS/nixpkgs/commit/5ec0699496255c04123e18d23ff4b3321b24ee24) mtkclient: add a desktop item
* [`03cb46a6`](https://github.com/NixOS/nixpkgs/commit/03cb46a653d0b584c081fa193dbf69d747f110db) mtkclient: 2.1.3 -> 2.1.4.1
* [`16ffd4ed`](https://github.com/NixOS/nixpkgs/commit/16ffd4ed5183bc28a7562a065fd5fff54f095af9) nixosTests.lomiri-clock-app: Fix OCR further
* [`f8072c24`](https://github.com/NixOS/nixpkgs/commit/f8072c24ba5188f22d8471c4542afe0c0c8e02f5) tlclient: 4.19.0 -> 4.20.0
* [`8b822ed1`](https://github.com/NixOS/nixpkgs/commit/8b822ed1bdff1b635f35b3b7d2b8c64c30b8a36c) python3Packages.samplerate: 0.2.3 -> 0.2.4
* [`edb0c8df`](https://github.com/NixOS/nixpkgs/commit/edb0c8df50b0496f518cc389c40ddff5f0dbac5c) bupc: 2020.12.0 -> 2022.10.0
* [`6e0c91f3`](https://github.com/NixOS/nixpkgs/commit/6e0c91f397895a29b8c9f9b027331fe6026b9827) hyprpanel: replace swww to awww; add compat scripts for awww
* [`b318b8a3`](https://github.com/NixOS/nixpkgs/commit/b318b8a30a64d6e90c60fde4fe9c91cb515f9e40) k3s: fix build reproducibility
* [`fa7323d9`](https://github.com/NixOS/nixpkgs/commit/fa7323d91daac43e5a473b03fa5d766b3e210b96) prometheus-domain-exporter: 1.24.1 -> 1.25.0
* [`dcb71e24`](https://github.com/NixOS/nixpkgs/commit/dcb71e24961af3b29636dbdfd69831d37906f5f2) go-licenses: 1.6.0 -> 2.0.1
* [`c3861e79`](https://github.com/NixOS/nixpkgs/commit/c3861e791cbef3549b046c084282233efc0eea15) kirsch: 0.7.2 -> 0.7.3
* [`ff714dad`](https://github.com/NixOS/nixpkgs/commit/ff714dada7c7080a79e10013391bf558278837ac) wasmtime: 42.0.1 -> 43.0.0
* [`c9c6c3d6`](https://github.com/NixOS/nixpkgs/commit/c9c6c3d60d11331231ef3ae56bc2eb34657a85fb) television: 0.15.3 -> 0.15.4
* [`b91eaf9d`](https://github.com/NixOS/nixpkgs/commit/b91eaf9dbacf2a28f1f5c7c28e1c6be2b5ad0a51) hayagriva: add trespaul as maintainer
* [`76d81957`](https://github.com/NixOS/nixpkgs/commit/76d819578212c0f65b5f254a518fe16873fb9589) winbox: set `winbox4` as default
* [`d3dd4a1a`](https://github.com/NixOS/nixpkgs/commit/d3dd4a1adc71ffa4b064c584908c8e227a67fd96) bukubrow: use structuredAttrs instead of passAsFile
* [`04a5570b`](https://github.com/NixOS/nixpkgs/commit/04a5570bfed40992e81d3f57d9f2867771dba3b4) bukubrow: use tag/hash instead of rev/sha256
* [`2e601f1c`](https://github.com/NixOS/nixpkgs/commit/2e601f1c2285efd8c4f2ab50704fdfe6c6e5cc1a) plasma5Packages.qoauth: move NIX_LDFLAGS into env for structuredAttrs
* [`1224274f`](https://github.com/NixOS/nixpkgs/commit/1224274f248094cfa3c3310693e4221f4d28145d) rubyPackages: move env variables into env for structuredAttrs
* [`3393682f`](https://github.com/NixOS/nixpkgs/commit/3393682f5d75693d78ce2dcc1d91a31bf7be4858) plasma5Packages.kinit: move env variables into env for structuredAttrs
* [`74c02814`](https://github.com/NixOS/nixpkgs/commit/74c028148922da73134a5524d4c9e490d84c24fd) linuxPackages.virtualboxGuestAdditions: move env variables into env for structuredAttrs
* [`70f10293`](https://github.com/NixOS/nixpkgs/commit/70f102930a165736e046e705b05fec02049a6fc8) linuxPackages.tmon: move env variables into env for structuredAttrs
* [`5779cdd6`](https://github.com/NixOS/nixpkgs/commit/5779cdd617242f29d5a2c2a02290660451df5656) lomiri.geonames: 0.3.1 -> 0.3.2
* [`60fd853b`](https://github.com/NixOS/nixpkgs/commit/60fd853b38a6d84dbb5c35bf5b9d1dafad25faef) rauthy: build against rust-jemalloc-sys-unprefixed
* [`74217929`](https://github.com/NixOS/nixpkgs/commit/7421792993d3a03392077354d65a7a0651829029) python313Packages.pydicom: 3.0.1 -> 3.0.2
* [`53df49e8`](https://github.com/NixOS/nixpkgs/commit/53df49e814328690df84edbfc92113c6948faeb0) python3Packages.boiboite-opener-framework: drop
* [`00dd8204`](https://github.com/NixOS/nixpkgs/commit/00dd8204829865ad670cdd6ea12351445472db55) python3Packages.async-dns: drop
* [`ef5ffde8`](https://github.com/NixOS/nixpkgs/commit/ef5ffde8878454d10f03c9d4e5a2bb4a6256bff8) rPackages.*: move env variables into env for structuredAttrs
* [`e820d208`](https://github.com/NixOS/nixpkgs/commit/e820d20801dec1e207edc4fb438cd83f7a49c103) linuxPackages.dpdk-kmods: move env variables into env for structuredAttrs
* [`15b92cdc`](https://github.com/NixOS/nixpkgs/commit/15b92cdc2ef42a4c1fcf33b05eeb278682827c5c) linuxPackages.dpdk-kmods: use finalAttrs, hash instead of sha256
* [`531e409d`](https://github.com/NixOS/nixpkgs/commit/531e409d5bfa19f5d0c66c307c82b9bdff3c5c2e) linuxPackages.virtualbox: move env variables into env for structuredAttrs
* [`20cea117`](https://github.com/NixOS/nixpkgs/commit/20cea117c584f2d6c58c265f14fd62807e8a024a) linuxPackages.decklink: move env variables into env for structuredAttrs
* [`2e4dfc66`](https://github.com/NixOS/nixpkgs/commit/2e4dfc66d7c38e4c3cc2b4f3289b6ad7e94516e1) linphonePackages.mediastreamer2: move env variable into env
* [`1f2a70b1`](https://github.com/NixOS/nixpkgs/commit/1f2a70b198f77a46487f8121b5ac09f2c0102e0e) buildEmscriptenPackage: move EMCONFIGURE_JS into env for structuredAttrs
* [`daf9a6b8`](https://github.com/NixOS/nixpkgs/commit/daf9a6b815c8489a7a4bedf0109fbd4b31b6d0d1) aonsoku: 0.9.1 -> 0.13.0
* [`f3c0c0c8`](https://github.com/NixOS/nixpkgs/commit/f3c0c0c860a41b7a3a2c0e12e8a93aaaaffa8cbc) aonsoku: add autrimpo to maintainers
* [`0ae9f156`](https://github.com/NixOS/nixpkgs/commit/0ae9f156faae92d27becda0fd936ee83f6cad4a0) opentelemetry-cpp: 1.25.0 -> 1.26.0
* [`ca9f272b`](https://github.com/NixOS/nixpkgs/commit/ca9f272bf96770ff1b5b75b8ffcf56b74025e1ba) {luajit,luajit_2_0,luajit_openresty}: Add powerpc64-linux to unsupported platforms
* [`6ffb2e7e`](https://github.com/NixOS/nixpkgs/commit/6ffb2e7e2015d681d4457cda0a267121ab5ce2b9) libiscsi: 1.20.0 -> 1.20.3
* [`f15c217e`](https://github.com/NixOS/nixpkgs/commit/f15c217e4a08bfa6ecbaec8e3d4fa2778a5e25b9) luajit_openresty: Remove powerpc64le-linux from badPlatforms
* [`5e054878`](https://github.com/NixOS/nixpkgs/commit/5e054878a16186c1a7bb10815efca72ce68f1c93) tree-sitter-grammars.tree-sitter-heex: 0.8.0 -> 0.9.0
* [`c5d2a873`](https://github.com/NixOS/nixpkgs/commit/c5d2a8735ed20e8420049872abad685d56137f07) harmonoid: fix update script to update all sources
* [`1eff5c26`](https://github.com/NixOS/nixpkgs/commit/1eff5c2675a50dd6f88445a67b95f302feeb12ac) harmonoid: 0.3.21 -> 0.3.22
* [`2d02b4c7`](https://github.com/NixOS/nixpkgs/commit/2d02b4c7562832a9750319cb49fafd218658b29f) ghidra-extensions.ghidra-golanganalyzerextension: 1.2.4 -> 1.3.0
* [`cda17138`](https://github.com/NixOS/nixpkgs/commit/cda171380c45b70443635b4c0cf918e314e1568d) libcupsfilter: link with iconv explicitly on Darwin
* [`54f60bfa`](https://github.com/NixOS/nixpkgs/commit/54f60bfa88c9dfa00c28d53321388a911af9ab5a) libcupsfilter: replace execvpe with execve on Darwin
* [`fcfbb7e3`](https://github.com/NixOS/nixpkgs/commit/fcfbb7e3d0bea1d6110fe038f6c2fbb2ae809363) libcupsfilter: build on all platforms
* [`1169b8dd`](https://github.com/NixOS/nixpkgs/commit/1169b8dd8f2ec8f1ba4df2a3c99ffa4ff55ad0fb) maintainers: remove farcaller
* [`f073b737`](https://github.com/NixOS/nixpkgs/commit/f073b737608a6d6fe2bc738082c523d7db2de156) synthv1: 1.3.2 -> 1.4.1
* [`d73eb261`](https://github.com/NixOS/nixpkgs/commit/d73eb261c4ca1cd256e7b5c486bfc1eae2b6df14) eslint: 10.0.3 -> 10.1.0
* [`81d08b43`](https://github.com/NixOS/nixpkgs/commit/81d08b43d36e0abb6f46f62837a344800c6384c6) pvsneslib: fix build
* [`4e08b0cf`](https://github.com/NixOS/nixpkgs/commit/4e08b0cf550724120bf9bd50ef6c912430cf0c8b) oculante: Generated Nix Path Changed
* [`85edc037`](https://github.com/NixOS/nixpkgs/commit/85edc037e4cbd774af71681560e44c12a6f7359a) linux-rt: remove
* [`98b5b7ac`](https://github.com/NixOS/nixpkgs/commit/98b5b7ac4150282b81cf0eb7146b5a8196f75860) skills: init at 1.4.6
* [`0e95b2a6`](https://github.com/NixOS/nixpkgs/commit/0e95b2a61aeeda0b4b3348fa025da991ec2a016f) mupdf: xcbuild not required
* [`59e03c46`](https://github.com/NixOS/nixpkgs/commit/59e03c4656e6262ade93bdb22befb9911759c86e) chuck: xcbuild not required
* [`8dbcb7f0`](https://github.com/NixOS/nixpkgs/commit/8dbcb7f0b532bf0c875d2dafb1ac46f4ed8cb69f) klipper: 0.13.0-unstable-2026-03-09 -> 0.13.0-unstable-2026-03-21
* [`d5bc0894`](https://github.com/NixOS/nixpkgs/commit/d5bc0894fc273b38ab074459645f2743823e98c9) jogl: remove not required xcbuild
* [`91d5732a`](https://github.com/NixOS/nixpkgs/commit/91d5732a5b70789a190cd3e0ed6092e5fee57aeb) moonlight: 2026.3.2 -> 2026.3.3
* [`12a6b362`](https://github.com/NixOS/nixpkgs/commit/12a6b362611290f616bd4f0a94456d343f984ab0) cdxgen: remove unnecessasry xcbuild
* [`a8166cd1`](https://github.com/NixOS/nixpkgs/commit/a8166cd197d440cdd7c0d3e702f21e99ca2c6eb6) doomrunner: add nix-update-script
* [`ddd32c6f`](https://github.com/NixOS/nixpkgs/commit/ddd32c6f0d0eaeec6e3dbf6cd74f1084b131f332) doomrunner: 1.9.1 -> 1.9.2
* [`2b48f969`](https://github.com/NixOS/nixpkgs/commit/2b48f9699823c74125eadd294341de447178d9cd) zug: 0.1.1 -> 0.1.2
* [`4bc70ce4`](https://github.com/NixOS/nixpkgs/commit/4bc70ce40e00d32f981a1b51660d2f6f96a7a637) freeipmi: 1.6.16 -> 1.6.17
* [`e81555bf`](https://github.com/NixOS/nixpkgs/commit/e81555bfa9ec909d6ea55874bfd3b73b88e6a6c9) stremio-linux-shell: fix fetchCargoVendor path
* [`28923d50`](https://github.com/NixOS/nixpkgs/commit/28923d5072f76ef8296ce1165b626ac654ba5a3b) rmg: patch includes that cause errors
* [`41326ad7`](https://github.com/NixOS/nixpkgs/commit/41326ad76f7e62d38a64c4e9f06930ed29175889) rmg: 0.8.8 -> 0.8.9
* [`bdcd45a0`](https://github.com/NixOS/nixpkgs/commit/bdcd45a03ae3c137d9e010ea5c6fde78bd37bf89) git-branchless: fix fetchCargoVendor path
* [`e49ca5eb`](https://github.com/NixOS/nixpkgs/commit/e49ca5eb1ec80b1d7f5e97b9f677e11eef478d3a) git-branchless: add version check
* [`4400f002`](https://github.com/NixOS/nixpkgs/commit/4400f002e1d7475f127948473d38fbe8bcb83e5d) git-branchless: fix `meta.license`
* [`ccdcdd7c`](https://github.com/NixOS/nixpkgs/commit/ccdcdd7cb6d70c998805f7bf0841328c6b346902) nixos/test-driver: provide machines, machines_qemu, machines_nspawn to testScript
* [`fd2eb432`](https://github.com/NixOS/nixpkgs/commit/fd2eb432697f3cbb1aed941ca821753a1778584b) nixos/test-driver: provide QemuMachine, NspawnMachine types to testScript
* [`84fe17e8`](https://github.com/NixOS/nixpkgs/commit/84fe17e86953dfb45b7b20b6eddc842fda562080) nixos/tests: fix machine type hints
* [`9076a793`](https://github.com/NixOS/nixpkgs/commit/9076a793c8b9fe6772c37d74217f592e218b593a) github-linguist: 9.1.0 -> 9.5.0
* [`5fd29c80`](https://github.com/NixOS/nixpkgs/commit/5fd29c8051f5745d73a5d07123d9f595211be215) uefitool: a72 -> a73
* [`989eb19a`](https://github.com/NixOS/nixpkgs/commit/989eb19a595e4d3b866687618e3a3600a608c6f4) nodejs: remove passthrough nodePackages set
* [`72e3faab`](https://github.com/NixOS/nixpkgs/commit/72e3faabb3f55512cfe6de8c5bef689ec6d26164) doc/vim: delete one line about nodePackages-packaged vim plugins
* [`07f42884`](https://github.com/NixOS/nixpkgs/commit/07f4288475824919849edbb21d640f234bc9f033) nodePackages{,_latest}: remove and throw
* [`6dd5322f`](https://github.com/NixOS/nixpkgs/commit/6dd5322fff644b2cb4f1c0e03c707bfc263e5032) astro-language-server: 2.16.3 -> 2.16.6
* [`db7de8d8`](https://github.com/NixOS/nixpkgs/commit/db7de8d88427ac05a544a5f043b92d28b7bdcd8f) systemd-networkd: add missing linkConfig options to type checker
* [`9ec25357`](https://github.com/NixOS/nixpkgs/commit/9ec2535788bd5964402f5daa688c45a38296789b) gnome2: fix short path literal
* [`a0c65f6a`](https://github.com/NixOS/nixpkgs/commit/a0c65f6a07e1abd700a5bfd4249e2912233736a8) brave: 1.88.134 -> 1.88.136
* [`48a6c410`](https://github.com/NixOS/nixpkgs/commit/48a6c4105f0dd605926574470b2af6be7c9e35d8) ezquake: fix build
* [`6bea196e`](https://github.com/NixOS/nixpkgs/commit/6bea196e926f18a76ce73f63a47fbc97015726f0) barrage: fix build
* [`6eeabf92`](https://github.com/NixOS/nixpkgs/commit/6eeabf92d69db49922f06f91c1d61f6116ce0e00) apt: 3.1.15 -> 3.1.16, add update script
* [`7396c599`](https://github.com/NixOS/nixpkgs/commit/7396c5996c3c03a9bd0e1386e50ccd5bedb56251) calamares-nixos-extensions: incremental installation progress bar
* [`dc46283b`](https://github.com/NixOS/nixpkgs/commit/dc46283b4b330851889405a3050c1d0cb71a49f6) quickjs-ng: 0.11.0 -> 0.13.0
* [`97b4afb8`](https://github.com/NixOS/nixpkgs/commit/97b4afb818b6e60a523b4e7b2da82893ede32c6f) quickjs: mark vulnerable for CVE-2026-3979
* [`bddb3008`](https://github.com/NixOS/nixpkgs/commit/bddb3008a552114ea38bea45d9525eb11b2b234b) opensmtpd: patch another usage of PATH_LIBEXEC
* [`acf8f668`](https://github.com/NixOS/nixpkgs/commit/acf8f668ed0a4068e27c6b4340e08cb59cb40878) doc: backward incompatibility of `opensmtpd-filter-dkimsign`
* [`1c81794e`](https://github.com/NixOS/nixpkgs/commit/1c81794ebd04810568aa3fa81e1e5972ad67f4bb) glances: use finalAttrs
* [`80c4eaf0`](https://github.com/NixOS/nixpkgs/commit/80c4eaf050937e0f042be5d48eb0b7bbe0ae89b9) librewolf-unwrapped: 148.0.2-3 -> 149.0-1
* [`5633be81`](https://github.com/NixOS/nixpkgs/commit/5633be819b3662d500d7f1eb2e2b60df34f23f95) glances: 4.5.0.5 -> 4.5.2
* [`5cade141`](https://github.com/NixOS/nixpkgs/commit/5cade141104d281e0aaba0d7214acf476ac5c7c2) pimsync: install zsh completion
* [`dab8bcc7`](https://github.com/NixOS/nixpkgs/commit/dab8bcc7f6a08d5db002212d08315ead2c6ef56c) netbox_4_4: 4.4.9 -> 4.4.10
* [`fa4524b5`](https://github.com/NixOS/nixpkgs/commit/fa4524b57529982e233f56e3f7954b9eb2bfc6b4) cadabra2: fix build with boost 1.89
* [`951bb50d`](https://github.com/NixOS/nixpkgs/commit/951bb50d8ecdf3a4633c2c5e348967f656dc90f6) python3Packages.nglview: fix build
* [`290ed287`](https://github.com/NixOS/nixpkgs/commit/290ed287f1c2c12aa08facdb56e865b410a18d74) interactive-html-bom: 2.10.0 -> 2.11.0
* [`2b1ffed2`](https://github.com/NixOS/nixpkgs/commit/2b1ffed285611c861b3d6a888be050a56694b5e3) nomad-pack: 0.4.1 -> 0.4.2
* [`07199b02`](https://github.com/NixOS/nixpkgs/commit/07199b02834e4be583cc47ea857f0b19a5d11b84) re-plistbuddy: init at 1.1.0
* [`e9428711`](https://github.com/NixOS/nixpkgs/commit/e942871150a2042a9512612a9387cf33572971f3) yatto: 0.21.7 -> 1.2.0
* [`d9f25fb6`](https://github.com/NixOS/nixpkgs/commit/d9f25fb687190f933af0af4e5c2939044a605e21) betterdisplay,cyberduck,enpass-mac: use re-plistbuddy instead of xcbuild
* [`ed182b54`](https://github.com/NixOS/nixpkgs/commit/ed182b540c16582c6d094f9a92fd8c09ac96d129) wolfssl: 5.8.4 -> 5.9.0
* [`a9438305`](https://github.com/NixOS/nixpkgs/commit/a94383053c4a1b7e70973178acf5fa82e51acf32) ffmpreg: init at 0.1.2-unstable-2026-03-25
* [`c49eca2c`](https://github.com/NixOS/nixpkgs/commit/c49eca2c55b3311c14430e4a6a42af137d6d04f1) lovr: initial commit @ 0.18.0
* [`493236da`](https://github.com/NixOS/nixpkgs/commit/493236daf4b88cd50a438ffd6e33f89d8da1254b) librewolf-bin-unwrapped: 148.0.2-2 -> 149.0-1
* [`1b52227c`](https://github.com/NixOS/nixpkgs/commit/1b52227cd3277e209f919956745b1821473c5d4d) maintainers: remove arnoldfarkas
* [`6500b67d`](https://github.com/NixOS/nixpkgs/commit/6500b67dd56c3bc9c40901d4ea5bc3db14671859) ghidra: 12.0.2 -> 12.0.4
* [`fa1e5b6d`](https://github.com/NixOS/nixpkgs/commit/fa1e5b6d79af6792e51a23cda01c83b6943b084c) stirling-pdf: 2.6.0 -> 2.8.0
* [`8a181e03`](https://github.com/NixOS/nixpkgs/commit/8a181e033cd1dfef17caf9b0d1b7085c768010f4) nixos/stirling-pdf: add integration tests
* [`e3c7fb83`](https://github.com/NixOS/nixpkgs/commit/e3c7fb832554d581a4c078862f094980b3ca4423) winboat: Update build unpinning nodejs and pinning Electron to v40 with Go 1.25 for guest server
* [`dc943556`](https://github.com/NixOS/nixpkgs/commit/dc943556f246d85c6f289e035a38d6e751fa4284) kiwix-apple: init at 3.13.0
* [`9af71e58`](https://github.com/NixOS/nixpkgs/commit/9af71e58c2eaa47d3ffef362d2f53824c7442ee3) renovate: 43.76.5 -> 43.91.1
* [`2938c54e`](https://github.com/NixOS/nixpkgs/commit/2938c54e21f89a824f8626bd3f9489ebd0d6960c) xrizer: 0.4 -> 0.5
* [`e3a9537b`](https://github.com/NixOS/nixpkgs/commit/e3a9537b76c1db954d39917c5de4ffe65d3821ab) pureref: 2.0.3 -> 2.1.1
* [`18f81feb`](https://github.com/NixOS/nixpkgs/commit/18f81feb891a27c2d4f148243d29c31edfcb130a) python3Packages.pylette: 5.1.1 -> 5.1.2
* [`62cac9a0`](https://github.com/NixOS/nixpkgs/commit/62cac9a0456894eac46141859da0db408d0d9760) gradle-completion: 9.3.1 -> 9.4.1
* [`2c93d05b`](https://github.com/NixOS/nixpkgs/commit/2c93d05b8f22cc2993829eeef83ccbdc1a3a259a) netbird-dashboard: 2.34.2 -> 2.36.0
* [`d5af8d04`](https://github.com/NixOS/nixpkgs/commit/d5af8d042da597195b09b0ac5d982a752b7ceae9) home-assistant-custom-components.ingress: 1.2.10 -> 1.3.0
* [`47329aa7`](https://github.com/NixOS/nixpkgs/commit/47329aa76c96d5f537363589047c5b868803825c) n8n: fix update script
* [`2fb5888c`](https://github.com/NixOS/nixpkgs/commit/2fb5888c1e02c438372dbc4e52b3edafea641f6f) n8n: 2.10.4 -> 2.13.3
* [`64afcbae`](https://github.com/NixOS/nixpkgs/commit/64afcbae5057de63acc8dbe05105fadc9c15cfba) antigravity: 1.20.6 -> 1.21.6
* [`e7ad2cea`](https://github.com/NixOS/nixpkgs/commit/e7ad2cea5cc12bb97b7b7c868c2ba5178eb121cf) rPackages.waysign: fix build
* [`22d68fee`](https://github.com/NixOS/nixpkgs/commit/22d68fee42c6b4e95e8071b34d9cefa7ff6d2c43) rPackages.hypeR: revert outdated fix
* [`de6e0460`](https://github.com/NixOS/nixpkgs/commit/de6e046083e46cbc9e09a415d022a8d5d3d1fafe) tilt: 0.36.3 -> 0.37.0
* [`be43741e`](https://github.com/NixOS/nixpkgs/commit/be43741e90b60641439708653529694eab826a62) dart-bin: 3.11.0 -> 3.11.4
* [`b4bb9c85`](https://github.com/NixOS/nixpkgs/commit/b4bb9c85250fe78dee0aadbc727a3e4dec803bd8) nixos-rebuild-ng: redirect switch-to-configuration stdout to stderr
* [`c634b3c4`](https://github.com/NixOS/nixpkgs/commit/c634b3c4a26f374ffd1a0bb2ddb44c12d744142e) gui-for-clash: 1.18.0 -> 1.21.1
* [`dc43bb51`](https://github.com/NixOS/nixpkgs/commit/dc43bb51b9060b7b2d91d8c4da4e7e7a0627b4db) postfix: build with lmdb support
* [`c5adb8ac`](https://github.com/NixOS/nixpkgs/commit/c5adb8ac2db96371a63bcef342b72cf441abcff6) ocamlPackages.caqti-miou: init at 2.2.4
* [`45c295e4`](https://github.com/NixOS/nixpkgs/commit/45c295e4695582523e751725ca4c6db9c362a96e) nufmt: 0-unstable-2025-12-29 -> 0-unstable-2026-03-26
* [`322ae18d`](https://github.com/NixOS/nixpkgs/commit/322ae18d986289bd7750e310b214dbb657565985) kicad: 9.0.8 -> 10.0.0
* [`46e433c4`](https://github.com/NixOS/nixpkgs/commit/46e433c436e555bc11a4862eb3b09921b9c4195b) python3Packages.hyponcloud: init at 0.9.0
* [`50707726`](https://github.com/NixOS/nixpkgs/commit/50707726595bef5ff282a1b74f9d761a1c69066d) maintainers: add korny666
* [`4c8320c4`](https://github.com/NixOS/nixpkgs/commit/4c8320c4f408e22ebec61d402aad324d86bb1e02) mixing-station: init at 2.8.0
* [`9f86c9e8`](https://github.com/NixOS/nixpkgs/commit/9f86c9e8cf9435a32567ce32ab8ef17d6248eed3) nextcloudPackages: update
* [`e47d43c4`](https://github.com/NixOS/nixpkgs/commit/e47d43c4c1c137ad8d107b42bc5087d9b773f322) nextcloud32: 32.0.6 -> 32.0.7
* [`f4e5d5bb`](https://github.com/NixOS/nixpkgs/commit/f4e5d5bb8297ad50417534b3122a125ae2d43e48) nextcloud33: 33.0.0 -> 33.0.1
* [`2dc8245a`](https://github.com/NixOS/nixpkgs/commit/2dc8245afef5e3ef3b6ff1fc2046671573c9f508) ocamlPackages.testo: init at 0.4.0
* [`df96a914`](https://github.com/NixOS/nixpkgs/commit/df96a914b43b683d6633baff01d86096309e3ec8) ocamlPackages.atdml: init at 4.0.0
* [`31c9970a`](https://github.com/NixOS/nixpkgs/commit/31c9970a836be43b86cada6c1440db2c312a1a08) newsboat: 2.42 -> 2.43
* [`8009625c`](https://github.com/NixOS/nixpkgs/commit/8009625c2710c6cace30f3686581529e27762f91) iwe: 0.0.60 -> 0.0.64
* [`434e1270`](https://github.com/NixOS/nixpkgs/commit/434e12708e47aa3274fe7544127f9f7e16dbb276) pdfslicer: drop
* [`81977db4`](https://github.com/NixOS/nixpkgs/commit/81977db45a7aad393dc1b277f3a6d320a2aedaf6) way-edges: 0.11.1 -> 0.12.1
* [`ff077fe9`](https://github.com/NixOS/nixpkgs/commit/ff077fe943fab73adf58ad2f0f7650f49a1fda61) llama-swap: 183 -> 199
* [`7b96b5bf`](https://github.com/NixOS/nixpkgs/commit/7b96b5bfde8fe90d18fcbc4e52311c0279e809d3) domoticz: mark insecure
* [`2ac532a0`](https://github.com/NixOS/nixpkgs/commit/2ac532a06d5eb33bc129a2587ac2c2eaa034c7ba) packer: 1.15.0 -> 1.15.1
* [`c49dbddb`](https://github.com/NixOS/nixpkgs/commit/c49dbddbfb1d71924367397f73d5e7342b247e94) r2modman: 3.2.14 -> 3.2.15
* [`261719a2`](https://github.com/NixOS/nixpkgs/commit/261719a2d4a2899b17bd035ba9ec80da8d04cce0) {libsForQt5.libqtdbustest,libsForQt5.libqtdbusmock}: Rename from {libqtdbustest,libqtdbusmock}
* [`5c1a7e1a`](https://github.com/NixOS/nixpkgs/commit/5c1a7e1ad207a1a373e6dd4e5e937b51db80fef9) libsForQt5.qmenumodel: Rename from qmenumodel
* [`1897a6d4`](https://github.com/NixOS/nixpkgs/commit/1897a6d410fc5ac5c1bcd8dadfa15468af56cbb3) python3Packages.llama-index-embeddings-google: drop
* [`8639b5c1`](https://github.com/NixOS/nixpkgs/commit/8639b5c1d0d1482288f0e159361133af7be4c654) cudaPackages.libnvshmem: 3.4.5-0 -> 3.6.5-0
* [`02e32e37`](https://github.com/NixOS/nixpkgs/commit/02e32e37db8585cbc70020c83872e77fcb2a0d21) cudaPackages.libnvshmem: add GaetanLepage to maintainers
* [`6ca6ecb6`](https://github.com/NixOS/nixpkgs/commit/6ca6ecb6aa648a625e8689e125fd5f0a49c1851b) python3Packages.llama-index-embeddings-gemini: drop
* [`79bcd14b`](https://github.com/NixOS/nixpkgs/commit/79bcd14b8b04fa7bdca40361f7137a1aa8c04f28) python3Packages.llama-index-embeddings-google-genai: init at 0.5.0
* [`5105434f`](https://github.com/NixOS/nixpkgs/commit/5105434f14acc5be8a3b1e606d67f574cdc817e0) home-assistant-custom-components.tibber_local: 2026.2.2 -> 2026.3.4
* [`7a02a600`](https://github.com/NixOS/nixpkgs/commit/7a02a60031c717d956b4af7c7f04c2a343e330f8) ocamlPackages.core: 0.17.1 → 0.17.2
* [`ece7bc6f`](https://github.com/NixOS/nixpkgs/commit/ece7bc6ff49eff255aa497fad9109e7d8c02df4f) jj-fzf: 0.37.0 -> 0.38.0
* [`85b9461a`](https://github.com/NixOS/nixpkgs/commit/85b9461af01c5a7866213cea7e89d9b57a1c6c01) home-assistant-custom-components.plant: 2026.2.1 -> 2026.3.2
* [`44c31659`](https://github.com/NixOS/nixpkgs/commit/44c3165910699f4709a3704a0476db8639a048c8) home-assistant-custom-components.openplantbook: 1.3.3 -> 1.4.0
* [`96efcef0`](https://github.com/NixOS/nixpkgs/commit/96efcef001df60020a085d705bc20167e3539e62) fceux: fix build with minizip 1.3.2
* [`59204f14`](https://github.com/NixOS/nixpkgs/commit/59204f1458efadd0b7316ae6bd2a599248be5dfc) python3Packages.google-cloud-asset: fix broken update
* [`3ac077c5`](https://github.com/NixOS/nixpkgs/commit/3ac077c51f49f3d06499f9d2773202dd1f849392) python3Packages.google-cloud-asset: migrate to finalAttrs
* [`fdc2fab4`](https://github.com/NixOS/nixpkgs/commit/fdc2fab4ab2a1b3a36cf5be18b03d89bbdb977da) python3Packages.semchunk: 3.2.5 -> 4.0.0
* [`f05d5ce6`](https://github.com/NixOS/nixpkgs/commit/f05d5ce625ee165f9a1b12c18402d92a3b0f5879) censor: 0.4.0 -> 0.6.0
* [`26b31cf4`](https://github.com/NixOS/nixpkgs/commit/26b31cf43285ba1fe1292c2c00ff593d0598b949) open-webui: 0.8.10 -> 0.8.12
* [`1bb3ec81`](https://github.com/NixOS/nixpkgs/commit/1bb3ec813a657e7662abde5672189d19fbebf980) weaviate-client: pythonRelaxDeps on protobuf to fix build
* [`7ff22e01`](https://github.com/NixOS/nixpkgs/commit/7ff22e016c3f6cf9421ae34bf571b34381f12598) python313Packages.aiodns: switch to finalAttrs
* [`b5062371`](https://github.com/NixOS/nixpkgs/commit/b5062371447bad21262f8b90792493927d3a92c2) python313Packages.pycares: switch to finalAttrs
* [`98b37f72`](https://github.com/NixOS/nixpkgs/commit/98b37f726dcab9347ba1203ea0597d44942b80d9) bind: 9.20.18 -> 9.20.21
* [`27a13e4b`](https://github.com/NixOS/nixpkgs/commit/27a13e4bbc5d7f015d148c91b5430a950314af85) python3Packages.falconpy: 1.6.0 -> 1.6.1
* [`eeffabac`](https://github.com/NixOS/nixpkgs/commit/eeffabacd0ac09ab0c91eee859b13306576d5782) tdarr: fix update script to handle non-ASCII zip entries
* [`860da1ba`](https://github.com/NixOS/nixpkgs/commit/860da1ba421e76681fa8fdd986912c610ba8d55d) tdarr: 2.58.02 -> 2.66.01
* [`b04e5f48`](https://github.com/NixOS/nixpkgs/commit/b04e5f4892d6e5725a53cd539e722017dab9e65f) home-assistant: add hypontech component
* [`aed8e0f8`](https://github.com/NixOS/nixpkgs/commit/aed8e0f80fbac35a343b6cc711ee6d7df1753562) mprisence: 1.4.3 -> 1.4.5
* [`8c3de7a6`](https://github.com/NixOS/nixpkgs/commit/8c3de7a630b3bcd12244327d604ec4b58114b1a9) python3Packages.pyvicare: 2.58.0 -> 2.58.1
* [`b25b10ca`](https://github.com/NixOS/nixpkgs/commit/b25b10ca8ae32acfd0c83b27569fb509d187cf14) obsidian: expose obsidian-cli
* [`43f0ee29`](https://github.com/NixOS/nixpkgs/commit/43f0ee29e2605febe8d1ba2e044ee3f8d294ce0d) python3Packages.pyworxcloud: 6.1.0 -> 6.1.1
* [`b6f5a433`](https://github.com/NixOS/nixpkgs/commit/b6f5a43336749a0b0106c4a5d67e80d5589c4efa) blockbench: 5.0.7 -> 5.1.1
* [`cc9709b1`](https://github.com/NixOS/nixpkgs/commit/cc9709b1874c08b20e13558effcd1a9e0b6210b8) bella: 0.1.7 -> 0.1.8
* [`209b8538`](https://github.com/NixOS/nixpkgs/commit/209b8538ba02444a9ea63cccdefc0193581a62ae) openfga-cli: 0.7.11 -> 0.7.12
* [`85e272c9`](https://github.com/NixOS/nixpkgs/commit/85e272c96055e8cd937f692d928de06b29ab4151) python3Packages.oslotest: 6.0.0 -> 6.1.0
* [`f075cee9`](https://github.com/NixOS/nixpkgs/commit/f075cee9a63bfb6f748b3fe85e68dee141c858c3) healthchecks: 4.0 -> 4.1.1
* [`d0a7fb96`](https://github.com/NixOS/nixpkgs/commit/d0a7fb96c41a0fc1be05239409bf25dcd71c1e03) hydrus: 663 -> 665
* [`b58d75d6`](https://github.com/NixOS/nixpkgs/commit/b58d75d6ff3c4f955b7849122eafffe899117630) beatprints: 1.1.5 -> 1.1.6
* [`da1b9b38`](https://github.com/NixOS/nixpkgs/commit/da1b9b3893704c8943bdc5bb2d42f09767d14c41) conda: 25.11.1-1 -> 26.1.1-1
* [`5557590c`](https://github.com/NixOS/nixpkgs/commit/5557590cc55190060f13cf5f7b6416dbdef6fad6) findent: init at 4.3.6
* [`9e595890`](https://github.com/NixOS/nixpkgs/commit/9e595890b2825b603331e18b4ba235213d744340) ford: init at 7.0.13
* [`80fdf683`](https://github.com/NixOS/nixpkgs/commit/80fdf683a5b2bc7b4e2c7997ccd7412636ec3c1e) posting: 2.9.2 -> 2.10.0
* [`4dcbc6c7`](https://github.com/NixOS/nixpkgs/commit/4dcbc6c7c7e0a03bd9d3635db20120e6f7d793c8) fflogs: 9.0.24 -> 9.0.33
* [`eff75974`](https://github.com/NixOS/nixpkgs/commit/eff759748a42ea05d7e0660db6f1cae8a9f66dce) lakectl: 1.79.0 -> 1.80.0
* [`40913cf1`](https://github.com/NixOS/nixpkgs/commit/40913cf19069b22109eb70aae9f9f6806aa841aa) asahi-*: add update script
* [`06abbc4e`](https://github.com/NixOS/nixpkgs/commit/06abbc4eb8f28f30e28c62e19729a14822c245bb) asahi-bless: 0.4.1 -> 0.4.3
* [`f9feb024`](https://github.com/NixOS/nixpkgs/commit/f9feb024448c9e684ea60e0302b24f0add8ba0cc) asahi-btsync: 0.2.0 -> 0.2.5
* [`ef733f41`](https://github.com/NixOS/nixpkgs/commit/ef733f4115fa602b6a9bcc27fe2424da7a45b3f5) asahi-fwextract: 0.7.9 -> 0.8.0
* [`679be9d3`](https://github.com/NixOS/nixpkgs/commit/679be9d36b143f25b9ea5897983a3ee089ccba78) asahi-wifisync: 0.2.0 -> 0.2.3
* [`da1b7ce2`](https://github.com/NixOS/nixpkgs/commit/da1b7ce210887118f420273514977637d1553b32) tiny-dfr: 0.3.5 -> 0.3.7
* [`893840f4`](https://github.com/NixOS/nixpkgs/commit/893840f416c417feb5845cb93982359e1db60e55) asahi-nvram: 0.2.3 -> 0.2.4
* [`26301f0e`](https://github.com/NixOS/nixpkgs/commit/26301f0ef42ac507cd3163aef09c19e4c127fc88) searxng: 0-unstable-2026-03-18 -> 0-unstable-2026-03-27
* [`22b8ffa0`](https://github.com/NixOS/nixpkgs/commit/22b8ffa071a257b66ab1cc5dd4889d911abc44ea) tree-sitter-grammars.tree-sitter-go-template: 0-unstable-2025-12-12 -> 0-unstable-2026-03-21
* [`4a4ec3f5`](https://github.com/NixOS/nixpkgs/commit/4a4ec3f56822d4c5d0c1ef3d75f4b3921c86fa81) tree-sitter-grammars.tree-sitter-go-template-helm: init 0-unstable-2026-03-21
* [`da13b735`](https://github.com/NixOS/nixpkgs/commit/da13b735f878e84de91c35beb7d237d9026e8126) zotero: 8.0.3 -> 8.0.5
* [`69612894`](https://github.com/NixOS/nixpkgs/commit/6961289402e6853e49f4c27acdb25404f11a89b5) gauge-unwrapped: 1.6.25 -> 1.6.28
* [`feff7020`](https://github.com/NixOS/nixpkgs/commit/feff702003082d0c8109b8d07ab6021a9a6503d6) vscodium: 1.110.11631 -> 1.112.01907
* [`84b4eb0b`](https://github.com/NixOS/nixpkgs/commit/84b4eb0bed558334032cb43febb1962bab4999a4) osimum: fix desktop item
* [`a90e8157`](https://github.com/NixOS/nixpkgs/commit/a90e815715ca4558822bf1d972a3c24f7fce6fa5) glaze: 7.1.0 -> 7.2.2
* [`790d44e4`](https://github.com/NixOS/nixpkgs/commit/790d44e4c7bfe0c0fce7e5d95376f61b3deafca1) glaze: add meta.homepage, meta.changelog
* [`f34b5e5b`](https://github.com/NixOS/nixpkgs/commit/f34b5e5b67f94c2ea421aef8ee208eeb4da14c50) glaze: add miniharrinn as a maintainer
* [`58e95f89`](https://github.com/NixOS/nixpkgs/commit/58e95f89a900433ff3bb0bbba075d1026f7e8d87) zed-discord-presence: 0.11.1 -> 0.11.2
* [`e1b6c103`](https://github.com/NixOS/nixpkgs/commit/e1b6c10337ab1ba19364b25bc61fea7cdee70875) python3Packages.victron-mqtt: 2026.3.3 -> 2026.3.10
* [`74ba9a88`](https://github.com/NixOS/nixpkgs/commit/74ba9a8857fd51f5c4ac0091fc1d4d6c4579c0be) orage: 4.20.2 -> 4.20.3
* [`ace5cea3`](https://github.com/NixOS/nixpkgs/commit/ace5cea3ec9eacd8a7e0908a2d5117120a669a8e) xfdesktop: 4.20.1 -> 4.20.2
* [`3b772415`](https://github.com/NixOS/nixpkgs/commit/3b772415f5711ceff5a7175ecec0cf1ebca9eda4) burpsuite: 2026.3 -> 2026.3.1
* [`6918c361`](https://github.com/NixOS/nixpkgs/commit/6918c361bffa7a7b538bbf55615f130fa326ecde) python3Packages.dulwich: configure update script
* [`5f79952f`](https://github.com/NixOS/nixpkgs/commit/5f79952ff1003ab9bbcbc8c0ead99f8e17e838bc) nixos/mosquitto: write ACL files to StateDirectory instead of /etc
* [`b7723650`](https://github.com/NixOS/nixpkgs/commit/b7723650892670ae9e5ad6f02da31c6eb198c357) python3Packages.pypdf: 6.8.0 -> 6.9.2
* [`b9decce3`](https://github.com/NixOS/nixpkgs/commit/b9decce359499434eaa43c92766a13a0c0b39722) radicle-node: 1.7.1 -> 1.8.0
* [`f6b8bf4d`](https://github.com/NixOS/nixpkgs/commit/f6b8bf4d8966fae8a38e72e0d81ee024a3303118) radicle-node-unstable: 1.8.0-rc.3 -> 1.8.0
* [`4cce393f`](https://github.com/NixOS/nixpkgs/commit/4cce393f50eec6108e927c1b439434098f2d187f) go-dnscollector: 2.2.0 -> 2.2.1
* [`50e64a90`](https://github.com/NixOS/nixpkgs/commit/50e64a90d9b9ba1a131d754b4b21e5495b66a067) cnspec: 13.1.1 -> 13.2.0
* [`de8b1267`](https://github.com/NixOS/nixpkgs/commit/de8b126768e320cbe9305bcdffaec7897bef166b) spire: 1.14.2 -> 1.14.4
* [`1dacef5c`](https://github.com/NixOS/nixpkgs/commit/1dacef5cc0e61994f4cf27192bf3dd911fd3147c) rebels-in-the-sky: 1.5.1 -> 1.6.0
* [`9bfa457e`](https://github.com/NixOS/nixpkgs/commit/9bfa457e30dd88228725b69c966496f8168fd4ca) python3Packages.streamlit-folium: 0.26.2 -> 0.27.1
* [`4fb1de3d`](https://github.com/NixOS/nixpkgs/commit/4fb1de3ddaf4dafb9f54142abb216d59fe6a6314) rocmPackages: 7.2.0 -> 7.2.1
* [`374d7b4b`](https://github.com/NixOS/nixpkgs/commit/374d7b4b483a3f740980f75762b459227b58c31e) rocmPackages: teach local update script to use finalAttrs and infer config
* [`480a5dae`](https://github.com/NixOS/nixpkgs/commit/480a5dae0de18bc69be60b36e9c991e4d0698b6a) python3Packages.python-pooldose: 0.8.6 -> 0.9.0
* [`5a7ed5ce`](https://github.com/NixOS/nixpkgs/commit/5a7ed5ce4b84c802bb0bceb0f17e97c7464b2162) python3Packages.idasen-ha: 2.6.4 -> 2.6.5
* [`9a40c933`](https://github.com/NixOS/nixpkgs/commit/9a40c93398a31c0efd731dfe8c410416161a8567) python3Packages.hueble: 2.1.1 -> 2.2.0
* [`a866ca17`](https://github.com/NixOS/nixpkgs/commit/a866ca17315add29e2f30ae4b1f620c052185f62) python3Packages.typecode: 30.1.0 -> 30.2.0
* [`04bd440d`](https://github.com/NixOS/nixpkgs/commit/04bd440dbe2a5be7301c161a38f6ded29f45c5c6) python3Packages.urllib3-future: 2.17.903 -> 2.18.901
* [`7ee78378`](https://github.com/NixOS/nixpkgs/commit/7ee7837876fa7474cb6507d8df9a3fa997ed9c0a) maintainers: add Kharacternyk
* [`1c57d02b`](https://github.com/NixOS/nixpkgs/commit/1c57d02b263937fb723b3e1b889fcceb1017d055) python3Packages.azure-mgmt-storage: 24.0.0 -> 24.0.1
* [`b5ca3ee5`](https://github.com/NixOS/nixpkgs/commit/b5ca3ee563ddfe718cfbaebb02a519059cc5110c) vhs: 0.10.0 -> 0.11.0
* [`ca748a82`](https://github.com/NixOS/nixpkgs/commit/ca748a823ae16b5d5085f96d2f1c018075af7097) mixxx: 2.5.4 -> 2.5.6
* [`ca5631ef`](https://github.com/NixOS/nixpkgs/commit/ca5631ef7581b9bece88910702f2e9e70d7dc2b9) wine-staging: 11.1 -> 11.5
* [`5ffe266c`](https://github.com/NixOS/nixpkgs/commit/5ffe266c010271f2d10fa3854b5f7b352db2dec6) lmstudio: 0.4.7.4 -> 0.4.8.1
* [`6ea557ed`](https://github.com/NixOS/nixpkgs/commit/6ea557ed71f6ea713d3b234017c154e7ffd219ab) gcfflasher: 4.11.0 -> 4.12.0
* [`d50b6f37`](https://github.com/NixOS/nixpkgs/commit/d50b6f378ab8bb4cea47bf6c7db569090bb34a89) libdng: enable strictDeps, fix cross compilation
* [`1263485a`](https://github.com/NixOS/nixpkgs/commit/1263485a70c0f16da9005bfddabaa7a3ea887000) flannel: 0.28.1 -> 0.28.2
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
