### PR TITLE
npins home-manager: update a184bd2f -> 5de7dbd1

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -61,9 +61,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "a184bd2f8426087bae93f203403cd4b86c99e57d",
-      "url": "https://github.com/nix-community/home-manager/archive/a184bd2f8426087bae93f203403cd4b86c99e57d.tar.gz",
-      "hash": "sha256-0Utnqo+FbB+0CVUi0MI3oonF0Kuzy9VcgRkxl53Euvk="
+      "revision": "5de7dbd151b0bd65d45785553d4a22d832733ffc",
+      "url": "https://github.com/nix-community/home-manager/archive/5de7dbd151b0bd65d45785553d4a22d832733ffc.tar.gz",
+      "hash": "sha256-ikws/ssAmG20AGrEwBuwspwPlkubJu34mB+Uz2fJBJs="
     },
     "hs-grille": {
       "type": "Git",


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@a184bd2f...5de7dbd1](https://github.com/nix-community/home-manager/compare/a184bd2f8426087bae93f203403cd4b86c99e57d...5de7dbd151b0bd65d45785553d4a22d832733ffc)

* [`a7d2aca3`](https://github.com/nix-community/home-manager/commit/a7d2aca3f0dd952b01d8ed5c45536b40af3841eb) opencode: use serve command for web interface
* [`b399348e`](https://github.com/nix-community/home-manager/commit/b399348e9d048872fd9810a6fe8cb20828e430af) tmuxinator: move to dedicated module with projects support
* [`0adb9993`](https://github.com/nix-community/home-manager/commit/0adb9993274f27168ec0d6c13ec292f03dc328d0) Translations update from Hosted Weblate ([nix-community/home-manager⁠#9010](https://togithub.com/nix-community/home-manager/issues/9010))
* [`f2d3e04e`](https://github.com/nix-community/home-manager/commit/f2d3e04e278422c7379e067e323734f3e8c585a7) Translate using Weblate (Czech)
* [`1ce9e626`](https://github.com/nix-community/home-manager/commit/1ce9e62690dfdd7e76bd266ccb9a887778410eb2) mpd: expose generated config ([nix-community/home-manager⁠#8968](https://togithub.com/nix-community/home-manager/issues/8968))
* [`f21d8ebb`](https://github.com/nix-community/home-manager/commit/f21d8ebbc959e5da6fbda105ff47e334f058ac06) neovim: test pure lua dependencies ([nix-community/home-manager⁠#8991](https://togithub.com/nix-community/home-manager/issues/8991))
* [`51f49da1`](https://github.com/nix-community/home-manager/commit/51f49da12cb58883cc2c12d2b30ba211e5fd6532) flake.lock: Update
* [`6267895e`](https://github.com/nix-community/home-manager/commit/6267895e9898399f0ce2fe79b645e9ee4858aaff) opencode: add environmentFile option to set OPENCODE_SERVER_PASSWORD
* [`41e6e2ab`](https://github.com/nix-community/home-manager/commit/41e6e2ab37763c09db4e639033392cf40900440a) codex: add support for managed rules files
* [`eb6f3470`](https://github.com/nix-community/home-manager/commit/eb6f347055769a23967dda70cdc8b46f7d247ab9) aria2: add systemd service
* [`d166a078`](https://github.com/nix-community/home-manager/commit/d166a078541982a76f14d3e06e9665fa5c9ed85e) neovim: fix viml plugin config appearing twice 
* [`f68887a4`](https://github.com/nix-community/home-manager/commit/f68887a4c11e662b0eb0323d34b3fb9506226719) Translate using Weblate (Serbian)
* [`03bdcf84`](https://github.com/nix-community/home-manager/commit/03bdcf84f092956943dcf9ef164481e463512716) awww: rename swww to awww
* [`a61b22e3`](https://github.com/nix-community/home-manager/commit/a61b22e323e3ca9821cd34a8ce5eda02fc099de1) ssh_auth_sock: init module
* [`9dc93220`](https://github.com/nix-community/home-manager/commit/9dc93220c1c9a410ef6277d6dc55c571d9e592d0) ssh_auth_sock: assert that at most one agent is enabled
* [`5b6f55b7`](https://github.com/nix-community/home-manager/commit/5b6f55b7842f027dd7fd50136b215f5486e7edcc) awww: run daemon dependent on program mainProgram name
* [`5ee3b3ef`](https://github.com/nix-community/home-manager/commit/5ee3b3ef63e469c84639c2c9e282726352c86069) awww: remove blank space after awww-daemon when extraArgs is empty
* [`e78a997d`](https://github.com/nix-community/home-manager/commit/e78a997d2e501627c7973406f5cb5c54739cf003) restic: allow setting password command
* [`7923d24b`](https://github.com/nix-community/home-manager/commit/7923d24b0b60e00fdc116634831c5fe8769633b2) home-cursor: use submodule-specific 'size'
* [`8ec54491`](https://github.com/nix-community/home-manager/commit/8ec54491cd17a5b7a019146f5f90a5cec379739a) sshAuthSock: fix naming scheme
* [`1089b2ca`](https://github.com/nix-community/home-manager/commit/1089b2cabad174a2a215c022cdabe128d52588c6) opencode: add programs.opencode.tui option
* [`2097a5c8`](https://github.com/nix-community/home-manager/commit/2097a5c82bdc099c6135eae4b111b78124604554) news: add opencode TUI configuration entry
* [`c65923b5`](https://github.com/nix-community/home-manager/commit/c65923b58dac34a3a67cb00c3a213b9c9cb67329) xdg-mime-apps: document performance caveat
* [`de5154c3`](https://github.com/nix-community/home-manager/commit/de5154c3486d1193e2b13bbf1b1adfe98413e1fb) timidity: remove amesgen as maintainer
* [`7e7269ac`](https://github.com/nix-community/home-manager/commit/7e7269ac064bea120d7b23daed432a096617872d) flake.lock: Update
* [`5de7dbd1`](https://github.com/nix-community/home-manager/commit/5de7dbd151b0bd65d45785553d4a22d832733ffc) restic: escape environment variables
