### PR TITLE
npins nixpkgs: update 5e11f7ac -> 13043924

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -132,8 +132,8 @@
     "nixpkgs": {
       "type": "Channel",
       "name": "nixpkgs-unstable",
-      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-26.05pre975217.5e11f7acce6c/nixexprs.tar.xz",
-      "hash": "sha256-avkT2TR2Wh/TQTysYGFOkGiF5+2R2nS7TZOfQ4omieQ="
+      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-26.05pre978638.13043924aaa7/nixexprs.tar.xz",
+      "hash": "sha256-qTVvODr6edFBLD2lncXPF8yTQeCafZUuKVtpV3Xb3yM="
     },
     "powerlevel10k": {
       "type": "Git",


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: release-26.05
Commits: [nixos/nixpkgs@5e11f7ac...13043924](https://github.com/nixos/nixpkgs/compare/5e11f7acce6c...13043924aaa7)

* [`ea969a5a`](https://github.com/NixOS/nixpkgs/commit/ea969a5ade68748e063c550cbec45e5d63e51b5c) ndi: add ffmpeg to rpath and fixup patchelf script
* [`2916db79`](https://github.com/NixOS/nixpkgs/commit/2916db79f3920b750c1835753ff8e49785e15d92) lib/modules: remove silent failure of 'mkAliasIfDef'
* [`95afd78e`](https://github.com/NixOS/nixpkgs/commit/95afd78e868c9d06ad3d7e013cf4f81ef99507f5) lib/modules: inline trivial 'mkAliasIfDef'
* [`6ca8927e`](https://github.com/NixOS/nixpkgs/commit/6ca8927eb02a89d4df4e4639ca9af6c8e40f0256) lib/modules: deprecate 'mkAliasIfDef'
* [`f4ae8e46`](https://github.com/NixOS/nixpkgs/commit/f4ae8e467395686a3bd0c1dec2c557dd48467317) maintainers: add MrSmör
* [`f6384eae`](https://github.com/NixOS/nixpkgs/commit/f6384eae1e76dd85c79954d74e69690accaeb0a4) jellyfish: init at 0-unstable-2024-05-27
* [`033229eb`](https://github.com/NixOS/nixpkgs/commit/033229ebe3b24a09ecf2f11da5cbd0629d28cf06) jello-lang: init at 0-unstable-2025-01-07
* [`40c21b15`](https://github.com/NixOS/nixpkgs/commit/40c21b15cdee8302afb5d89a140daf0114fdf147) nixos/programs/fish: set absolute path in babelfishTranslate
* [`ec58f7a8`](https://github.com/NixOS/nixpkgs/commit/ec58f7a89224028f3e1dbe73b72ae429faba602c) python3Packages.aiodukeenergy: 0.3.0 -> 1.0.0
* [`506a00b6`](https://github.com/NixOS/nixpkgs/commit/506a00b67f3db304a50bf29a77c1fc6f2ca1a021) meshoptimizer: fix cmakeFlags for optional dependencies
* [`47952939`](https://github.com/NixOS/nixpkgs/commit/4795293924462348f8a5765480a3014d29d9ce99) irqbalance: 1.9.4-unstable-2025-06-10 -> 1.9.5
* [`5b851ac0`](https://github.com/NixOS/nixpkgs/commit/5b851ac087c537cabbde84e0102185b971f52bf8) cartero: 25 -> 26
* [`9182c43b`](https://github.com/NixOS/nixpkgs/commit/9182c43b961d2de67db3f7ad9d74e12407e60b4f) lazycommit: init at 1.4.0
* [`938dd03f`](https://github.com/NixOS/nixpkgs/commit/938dd03fe107985a698c322507eaae89e8a707b4) chore: remove unused code
* [`2e2398b2`](https://github.com/NixOS/nixpkgs/commit/2e2398b2135f804bc566af9b971501efe67a5619) maintainers: remove maintainers
* [`8b7559fd`](https://github.com/NixOS/nixpkgs/commit/8b7559fd36424ecb5ade5b3b5dab6454913edfbf) maintainers: add m7medvision as maintainer
* [`6f1cdfed`](https://github.com/NixOS/nixpkgs/commit/6f1cdfed2083f59854add1d1793eeeb3673d3ece) iroh-{dns-server,relay}: 0.95.1 -> 0.96.0
* [`f6053d57`](https://github.com/NixOS/nixpkgs/commit/f6053d57ebea4e0158068ea27f3318d06edc7859) dsvpn: 0.1.4 -> 0.1.5
* [`fa87d21a`](https://github.com/NixOS/nixpkgs/commit/fa87d21ae226682c7d049d97034aa4b096d61d72) maintainers: add BIOS9
* [`bc2a0355`](https://github.com/NixOS/nixpkgs/commit/bc2a035553b0c018dc08e1bd7c39d01153372ecb) slinktool: init at 4.5.0
* [`e7b6af9d`](https://github.com/NixOS/nixpkgs/commit/e7b6af9d4f189e1fc58eec32c01529dc6a05fe43) brewtarget: fix wrapper for non-gnome environments
* [`f7ad9ac3`](https://github.com/NixOS/nixpkgs/commit/f7ad9ac398279f94306e52fa9a50efbcd2e2a539) brewtarget: add ilkecan to maintainers
* [`288d5fd3`](https://github.com/NixOS/nixpkgs/commit/288d5fd327eb22b47d589bc64828ab5b3d51086d) fritzing: fix wrapper for non-gnome environments
* [`7235e9c7`](https://github.com/NixOS/nixpkgs/commit/7235e9c773f542b842b0f9f8569b0ab17937e6cc) dnote: 0.15.1 -> 0.16.0
* [`a53dac45`](https://github.com/NixOS/nixpkgs/commit/a53dac458e0278449cd956daf6ad5b6321a69f28) fix: correct grammer and spelling errors
* [`bf11ee59`](https://github.com/NixOS/nixpkgs/commit/bf11ee597009371370008126e24532ace10eb706) chore: remove subPackages
* [`0ba918e2`](https://github.com/NixOS/nixpkgs/commit/0ba918e29914b264ddc3793bf25620a6fa58c4db) qt6Packages.waylib: drop
* [`8b4606b7`](https://github.com/NixOS/nixpkgs/commit/8b4606b7558eb0ca36412fe8c5ddbc5604920d7c) qt6Packages.qwlroots: drop
* [`f43a2aaf`](https://github.com/NixOS/nixpkgs/commit/f43a2aaf79c12b2028d29a77b9519e86f0e94cd8) qt6Packages: add aliases for dropped packages
* [`05c4d0f8`](https://github.com/NixOS/nixpkgs/commit/05c4d0f86a469651e5cc8fe21e594ff23338a815) nixos/crowdsec-firewall-bouncer: Add tornax as maintainer
* [`e931ac1f`](https://github.com/NixOS/nixpkgs/commit/e931ac1f0a9c4b1c35102de534eb231d264509f5) nixos/crowdsec-firewall-bouncer: Fix missing systemd dependencies to firewall services
* [`c05bdb94`](https://github.com/NixOS/nixpkgs/commit/c05bdb9470662e4577e548e61f06816d6088860a) cursor-clip: init at 0-unstable-2026-02-10
* [`d28265ec`](https://github.com/NixOS/nixpkgs/commit/d28265ec7e602001449b3adbd40be2d50135335b) clyp: init at 0.9.6
* [`22f2d939`](https://github.com/NixOS/nixpkgs/commit/22f2d93996e7fd2d038130a7f78df4b70af72cce) tomlc17: fix update script
* [`44f4e95f`](https://github.com/NixOS/nixpkgs/commit/44f4e95ff0febb81567a2fd28e01a006eba0b3e9) obs-studio-plugins.obs-move-transition: 3.1.5 -> 3.2.1
* [`a7d4d741`](https://github.com/NixOS/nixpkgs/commit/a7d4d7418ba835b695de85e4d82c2ec9423ba146) nixos/netbird: fixes login not working properly on first login
* [`26b6d485`](https://github.com/NixOS/nixpkgs/commit/26b6d485cc0de1f431a55021ada5d9a4accadc7e) catppuccin-sddm: avoid .dev outputs propagation
* [`91d56f2f`](https://github.com/NixOS/nixpkgs/commit/91d56f2fd4362e522ae7f1e6bfbcf23655e70681) catppuccin-sddm-corners: avoid .dev outputs propagation
* [`80579d36`](https://github.com/NixOS/nixpkgs/commit/80579d36f5cb0452bb299f9c4e9cbe0579d27953) where-is-my-sddm-theme: avoid .dev outputs propagation
* [`f1058fdf`](https://github.com/NixOS/nixpkgs/commit/f1058fdf675de7faa3f9af072de17f74d0d6f0e7) elegant-sddm: avoid .dev outputs propagation
* [`942e6226`](https://github.com/NixOS/nixpkgs/commit/942e62266583dd3fcf08d47099e8364b4d2135df) sddm-chili-theme: avoid .dev outputs propagation, add qtquickcontrols
* [`959507da`](https://github.com/NixOS/nixpkgs/commit/959507dace3fc30c801911ea49bd218369bd5860) sddm-sugar-dark: avoid .dev outputs propagation
* [`aef93624`](https://github.com/NixOS/nixpkgs/commit/aef93624f94983b51b3b9d12a3421300174d0818) utterly-nord-plasma: avoid .dev outputs propagation
* [`378d1825`](https://github.com/NixOS/nixpkgs/commit/378d1825bf977e2e4c491658aa23a29d4257ed46) nordic: avoid .dev outputs propagation
* [`827f771c`](https://github.com/NixOS/nixpkgs/commit/827f771c063be19cef00c4d5bfb3e24ea2478099) blivet: 3.12.1 -> 3.13.1
* [`a8dd4443`](https://github.com/NixOS/nixpkgs/commit/a8dd44432d4bace9cb4e94a8f45de8f1403eb261) blivet: add LVM module import check
* [`2930054a`](https://github.com/NixOS/nixpkgs/commit/2930054a0da19f4c3a8303172c2e58a8e1624a7b) z3: 4.15.8 -> 4.16.0
* [`d06dc4c8`](https://github.com/NixOS/nixpkgs/commit/d06dc4c8541d40d631014ab7e10b6653ff05e4a3) slsk-batchdl: dotnet 8 -> 10
* [`adcd0616`](https://github.com/NixOS/nixpkgs/commit/adcd0616494d4c75f8bd291599d098a40bec871e) ipatool: 2.2.0 -> 2.3.0
* [`2ca0360e`](https://github.com/NixOS/nixpkgs/commit/2ca0360e0fa1f1c15135eb266941b8bdc9ffc11b) iortcw: set pname and version
* [`41897c02`](https://github.com/NixOS/nixpkgs/commit/41897c023f464cdcfb8ae1ec9db8b1d07ab3a1ee) yaml-schema-router: init at 0.2.0
* [`96cebd87`](https://github.com/NixOS/nixpkgs/commit/96cebd87e9bcff06d610c095e8a184ffa53722f3) graphite-cli: 1.7.18 -> 1.7.20
* [`5a717874`](https://github.com/NixOS/nixpkgs/commit/5a7178746709bb3781aa0fcd612bd169310e4037) kyverno: 1.16.2 -> 1.17.1
* [`2b6bde5a`](https://github.com/NixOS/nixpkgs/commit/2b6bde5a5316cf48a46d4c249ff726de4aae7dff) cgit: 1.2.3 -> 1.3
* [`239b950d`](https://github.com/NixOS/nixpkgs/commit/239b950d44ad67933f0e505066413c4e2cd8f6a6) sccmhunter: 1.1.10 -> 2.0.0
* [`e3b7c926`](https://github.com/NixOS/nixpkgs/commit/e3b7c926d0e6c633bc7c737e022adccbdf8e539d) python3Packages.pycasbin: 2.7.1 -> 2.8.0
* [`e0ec541d`](https://github.com/NixOS/nixpkgs/commit/e0ec541d3b3223ecbfd6fb6a8522df14bee19765) mobsql: 0.9.0 -> 0.10.0
* [`40e86301`](https://github.com/NixOS/nixpkgs/commit/40e8630165883403f2065e3bff5bc004a9e9bea5) magika-cli: 1.0.1 -> 1.0.2
* [`9070363b`](https://github.com/NixOS/nixpkgs/commit/9070363bfc882c60f4af9a608bd4711618e15e90) rustcast: init at 0.5.6
* [`73efbfe0`](https://github.com/NixOS/nixpkgs/commit/73efbfe0765f716aa5bb8330e1824fe3e44193cb) seatd: 0.9.2 -> 0.9.3
* [`33a22fc1`](https://github.com/NixOS/nixpkgs/commit/33a22fc16b2c3b4ac64fe7c28a425e7b5da9fb7e) minimal-bootstrap.mes: convert sources from Nix to JSON
* [`1d2cd594`](https://github.com/NixOS/nixpkgs/commit/1d2cd594f96f2072416d216c42903359c18fd1ea) rimsort: 1.0.47 -> 1.0.73
* [`82c6fd53`](https://github.com/NixOS/nixpkgs/commit/82c6fd5344442d856fce325382c72d776eaa9440) pkgsi686Linux.pkgsMusl.gcc: Use libssp_nonshared from musl
* [`42d97148`](https://github.com/NixOS/nixpkgs/commit/42d97148a41b93703ab31526aedd58a51a5e0bd5) phpPackages.php-cs-fixer: add updateScript
* [`e84fb323`](https://github.com/NixOS/nixpkgs/commit/e84fb323a9cae0e2ddd7fb1f393bb1ca748397b6) tree-sitter-grammars.tree-sitter-matlab: 1.3.0-unstable-2025-11-22 -> 1.3.0-unstable-2026-03-04
* [`8a9c90e6`](https://github.com/NixOS/nixpkgs/commit/8a9c90e696a7f0e68e04bce1447091850fe46ca1) nixos/zswap: init module
* [`c1870198`](https://github.com/NixOS/nixpkgs/commit/c1870198aa5bd254efc932b11aa6d1475a195275) nixos/zswap: add activationScripts
* [`9bcddd22`](https://github.com/NixOS/nixpkgs/commit/9bcddd22fd5454aaa97345975837518686dd658c) nixos/zswap: use boot.kernel.sysfs to simplify dynamic reload
* [`4dcbbb35`](https://github.com/NixOS/nixpkgs/commit/4dcbbb3576302ecccd06c1cbdd5c0e7d97fa9346) otel-tui: init at 0.7.1
* [`52186e6c`](https://github.com/NixOS/nixpkgs/commit/52186e6c48c4e45b582052a1cfb9826035eca05f) phpPackages.castor: 1.2.0 -> 1.3.0
* [`95b9b8ca`](https://github.com/NixOS/nixpkgs/commit/95b9b8ca1e5ff9f07c3a29f2ddfec1a27f33e8c1) install-nothing: cleanup
* [`e48a1f9b`](https://github.com/NixOS/nixpkgs/commit/e48a1f9b1da9923ff72a3b16e15140618795fe71) install-nothing: 0.3.0 -> 0.5.0
* [`bb94b9c8`](https://github.com/NixOS/nixpkgs/commit/bb94b9c8ccc6dc16577a0390fe341f899bd66c43) qsynth: 1.0.4 -> 1.0.5
* [`ee979d9c`](https://github.com/NixOS/nixpkgs/commit/ee979d9ced99bc2d7aae6bde0b07acaf84d4596e) python3Packages.kaldi-native-fbank: init at 1.22.3
* [`3df7af72`](https://github.com/NixOS/nixpkgs/commit/3df7af7263ee28ff5b1d4c1bba5631c0c1f812b7) bitwarden-desktop: disable coredumps on Linux
* [`61674b99`](https://github.com/NixOS/nixpkgs/commit/61674b99fc3eb420a713819d8e9ca488c3a21948) json-schema-catalog-rs: use toFile instead of passAsFile
* [`d7a54753`](https://github.com/NixOS/nixpkgs/commit/d7a54753c969f73069cd1b0b835f934a16681ae9) python3Packages.pytest-celery: 1.2.1 -> 1.3.0
* [`421414c3`](https://github.com/NixOS/nixpkgs/commit/421414c3b2b45a18c3226b0cfcb2a92ba6ae364e) python3Packages.netbox-attachments: 11.0.0b2 -> 11.0.1
* [`135badcf`](https://github.com/NixOS/nixpkgs/commit/135badcfa2a4ba62810ef4f37e5b9d950c3418db) nixos/esphome: add options for setting environment variables
* [`86096c22`](https://github.com/NixOS/nixpkgs/commit/86096c22912605eea82a54cd8683538c9bb5c7ba) grafanaPlugins.grafana-clickhouse-datasource: 4.8.2 -> 4.14.0
* [`4fdedf5f`](https://github.com/NixOS/nixpkgs/commit/4fdedf5f0810efc4dd28f4586c2f7e972e60acc5) grafanaPlugins: prefer per-platform hashes to 'any'
* [`19df2b0e`](https://github.com/NixOS/nixpkgs/commit/19df2b0eb2f2bbff61410d0455d7359f85caf712) nixos/esphome: use %S specifier to find state directory root
* [`ef94c8eb`](https://github.com/NixOS/nixpkgs/commit/ef94c8eb9cb0204c65358245064d4244cd1bba3f) rofi-rbw-x11: 1.5.1 -> 1.6.1
* [`712d742e`](https://github.com/NixOS/nixpkgs/commit/712d742e0185145d90d6b79e2b9f851370db52b1) python3Packages.oras: 0.2.41 -> 0.2.42
* [`d3e15cd7`](https://github.com/NixOS/nixpkgs/commit/d3e15cd7b18da416ea54c999cb6b49f280462adf) nixos/esphome: add state directory to ExecPaths= and ReadWritePaths=
* [`a7b3afcd`](https://github.com/NixOS/nixpkgs/commit/a7b3afcd38593bbbace4cc4df630c2f3b55e81ce) ffizer: 2.13.7 -> 2.13.8
* [`0346c36e`](https://github.com/NixOS/nixpkgs/commit/0346c36ebc0458e4ee489f01408ce87c5da0aabe) moe: add maintainer videl
* [`3da75797`](https://github.com/NixOS/nixpkgs/commit/3da757976b64e20e17eaccb4ae0f7f9e56a3451c) moe: 1.15 -> 1.16
* [`26c59d4b`](https://github.com/NixOS/nixpkgs/commit/26c59d4b2a85b12041341f1ca258e8174eb5d905) octoprint: use headless ffmpeg by default
* [`9504b014`](https://github.com/NixOS/nixpkgs/commit/9504b0148d8bba1602481413de62792ed10375b1) maintainers: add nuexq
* [`3ea837cd`](https://github.com/NixOS/nixpkgs/commit/3ea837cd43c8581385da961d1a8b16663a277240) liquibase: 5.0.1 -> 5.0.2
* [`031cf746`](https://github.com/NixOS/nixpkgs/commit/031cf746283b50141441364878c031001197871e) hpp2plantuml: fix build
* [`45ed0fed`](https://github.com/NixOS/nixpkgs/commit/45ed0fed81214baded760449d740a0098e47e99c) mcrl2: fixed darwin build
* [`1af19561`](https://github.com/NixOS/nixpkgs/commit/1af1956174a7db5e9f8046cbeb92bc1e0d49175b) xcompose: init at 0.5.1
* [`e392deb9`](https://github.com/NixOS/nixpkgs/commit/e392deb9cb94240ef29e69a832d6e8d545d45bd9) gargoyle: 2023.1 -> 2026.1.1
* [`1f4d0fc3`](https://github.com/NixOS/nixpkgs/commit/1f4d0fc3652fafabe4c1b73ef4cf9195cb418489) cucumber: 9.2.1 -> 10.2.0
* [`0d439672`](https://github.com/NixOS/nixpkgs/commit/0d439672eec88f713835aaa4bf9de87bb4895077) kythe: 0.0.74 -> 0.0.75
* [`0f363a1c`](https://github.com/NixOS/nixpkgs/commit/0f363a1cb4f1a29a95f94c27ca22e4bcca93224f) nixos: replace container activation scripts
* [`a513c0a4`](https://github.com/NixOS/nixpkgs/commit/a513c0a4162a126cd83a1f1e60c8e97ca4819b9a) plasticscm-client-gui-unwrapped: 11.0.16.9973 -> 11.0.16.9998
* [`0d4956c5`](https://github.com/NixOS/nixpkgs/commit/0d4956c51b2365839af59105e5c32ff37f66543d) plasticscm-theme: 11.0.16.9973 -> 11.0.16.9998
* [`b6febb90`](https://github.com/NixOS/nixpkgs/commit/b6febb90bad61dde2b57c0319b87816dc6076c13) plasticscm-client-core-unwrapped: 11.0.16.9973 -> 11.0.16.9998
* [`3f9bf102`](https://github.com/NixOS/nixpkgs/commit/3f9bf10204d0ded09abb5b63d9faa09bcc97cb8d) python3Packages.datamodel-code-generator: 0.53.0 -> 0.55.0
* [`2607b463`](https://github.com/NixOS/nixpkgs/commit/2607b463ccdcf0cb20d5874b46473d4c0e122e5f) convertall: add updateScript
* [`3f4c955c`](https://github.com/NixOS/nixpkgs/commit/3f4c955c88a50e3726420998358ff95e7fb89136) convertall: 1.0.2 -> 1.0.3
* [`13b202fb`](https://github.com/NixOS/nixpkgs/commit/13b202fb25f0902be35687fc3351d44db508d3ca) python3Packages.pynitrokey: 0.11.3 -> 0.11.4
* [`6f6a452a`](https://github.com/NixOS/nixpkgs/commit/6f6a452afd46634aecf4070231e6961dd067b543) python3Packages.snakemake-interface-executor-plugins: 9.3.9 -> 9.4.0
* [`bf3c403a`](https://github.com/NixOS/nixpkgs/commit/bf3c403a55db504cac79264bed7517ef9f412c86) python3Packages.llama-index-readers-twitter: 0.4.1 -> 0.5.0
* [`122e0d26`](https://github.com/NixOS/nixpkgs/commit/122e0d2604f193bd159283b0e66c2003a3cb4723) python3Packages.django-allauth: 65.14.3 -> 65.15.0
* [`85bff7f2`](https://github.com/NixOS/nixpkgs/commit/85bff7f20f90048e4af8621d52a20543bce80800) python3Packages.metakernel: 0.30.4 -> 0.32.0
* [`23fdec93`](https://github.com/NixOS/nixpkgs/commit/23fdec939ec7be60421de9401bd1101ccd0709cb) python3Packages.language-tool-python: 3.2.2 -> 3.3.0
* [`92498765`](https://github.com/NixOS/nixpkgs/commit/92498765b4b678733e02dee8c81ec8f015e0b53c) nixos/tor: test: Build out a private Tor network to make test end-to-end
* [`1ac2b4bc`](https://github.com/NixOS/nixpkgs/commit/1ac2b4bc0c3eeb3135946e98ff5e407f1eb90149) arti: Add NixOS test for Tor
* [`8c7199ef`](https://github.com/NixOS/nixpkgs/commit/8c7199ef552a42443e5a29a88dafff9d8a59c19d) python3Packages.a2a-sdk: 0.3.24 -> 0.3.25
* [`576f385e`](https://github.com/NixOS/nixpkgs/commit/576f385ec26975719c25b178c75a8e3a9c9df876) python3Packages.azure-mgmt-datafactory: 9.2.0 -> 9.3.0
* [`5371f012`](https://github.com/NixOS/nixpkgs/commit/5371f0121f02ba461a7f5602f4c0438cc71c4ca3) gnubg: 1.07.001 -> 1.08.003
* [`b6b70c23`](https://github.com/NixOS/nixpkgs/commit/b6b70c2365bc61b7da7f2361be0f4b5c6e8b99e4) python3Packages.spdx-tools: 0.8.4 -> 0.8.5
* [`3a151be7`](https://github.com/NixOS/nixpkgs/commit/3a151be7e6a0144f266b9a88858fd215ce117516) wl-tray-bridge: init at 0.1.0-unstable-2026-02-16
* [`6647aefb`](https://github.com/NixOS/nixpkgs/commit/6647aefb7f1e7f679c2adcd61256cfebc1995321) python3Packages.proton-vpn-daemon: 0.13.5 -> 0.13.6
* [`33cc0a80`](https://github.com/NixOS/nixpkgs/commit/33cc0a803d0efe0d7124167507e17128c113b9d1) qgis-ltr: 3.40.15 -> 3.44.8
* [`1717091b`](https://github.com/NixOS/nixpkgs/commit/1717091b1fcbcfea3b108b9238617e4d4231dcab) betterdisplay: 4.0.4 -> 4.2.3
* [`587ea6e2`](https://github.com/NixOS/nixpkgs/commit/587ea6e226bc29d65964ec7cd01e38d2f2b053a8) python3Packages.gotenberg-client: 0.13.1 -> 0.14.0
* [`76a1eca9`](https://github.com/NixOS/nixpkgs/commit/76a1eca99253f707f891eb3e158ba1318993b564) python3Packages.logboth: 0.2.0 -> 0.3.0
* [`a468c13a`](https://github.com/NixOS/nixpkgs/commit/a468c13a407c7e781b84b80d494b3585f74fd652) python3Packages.pykka: 4.4.1 -> 4.4.2
* [`911e1d98`](https://github.com/NixOS/nixpkgs/commit/911e1d9892caf3ffc64748ff3904658759e1ef77) mullvad: 2025.14 -> 2026.1
* [`284c8d6b`](https://github.com/NixOS/nixpkgs/commit/284c8d6b2ce6656e6490e9218f2f64bfe34b7442) emilua: 0.11.7 -> 0.12.1
* [`773a1f0b`](https://github.com/NixOS/nixpkgs/commit/773a1f0bf399df948a6f552328ffd45dc245f7c8) jay: 1.11.1 -> 1.12.0
* [`60156615`](https://github.com/NixOS/nixpkgs/commit/601566155bc2d4689bd97d7ca1fe30489fcb6ee9) dhcpcd: 10.3.0 -> 10.3.1
* [`f272d819`](https://github.com/NixOS/nixpkgs/commit/f272d819c1363badcfe210ca8d293b63f50ae72d) dotnetCorePackages.fetchNupkg: neutralize avalonia.buildservices
* [`8a8ff586`](https://github.com/NixOS/nixpkgs/commit/8a8ff586cccbec8954052427f6023873897dc490) distcc: 2021-03-11 -> 3.4
* [`cba8e890`](https://github.com/NixOS/nixpkgs/commit/cba8e89065401e9786aa66507f1ad5dd2ab3b97c) python313Packages.pymupdf: 1.27.1 -> 1.27.2
* [`bbda6720`](https://github.com/NixOS/nixpkgs/commit/bbda6720b5b12c6e8c436ff3ec86f0fad8a1e464) python3Packages.qpsolvers: 4.8.2 -> 4.11.0
* [`23b59a31`](https://github.com/NixOS/nixpkgs/commit/23b59a318908abe51657f9af5bb0ee99d7bac897) bisq2: 2.1.9 -> 2.1.10
* [`fe4cebdc`](https://github.com/NixOS/nixpkgs/commit/fe4cebdc6bda9d27b82f6c593dbc3e2589d98cbb) python3Packages.tika-client: 0.10.0 -> 0.11.0
* [`82d490a6`](https://github.com/NixOS/nixpkgs/commit/82d490a68eb5983ed3e96bb128dfcac9cc50cd6c) python3Packages.ipyparallel: 9.0.2 -> 9.1.0
* [`890ae29c`](https://github.com/NixOS/nixpkgs/commit/890ae29cb89d426c6d30b8b00c10e08f8e406c74) audiosource: 1.4 -> 1.5
* [`5541b290`](https://github.com/NixOS/nixpkgs/commit/5541b29046f40bf343d8867f7a5e81e3c5b4d15b) pulsar: 1.131.1 -> 1.131.2
* [`a5f2323f`](https://github.com/NixOS/nixpkgs/commit/a5f2323fdbaa9e1061fb989b2134321313318af5) java-service-wrapper: 3.6.4 -> 3.6.5
* [`d370f2f8`](https://github.com/NixOS/nixpkgs/commit/d370f2f8789ddf129418c20e3a75bd51a373feb9) importNpmLock: handle commit in resolved git url
* [`61425f10`](https://github.com/NixOS/nixpkgs/commit/61425f107b2b26c6ed11fd7b2fd926b99b8fedef) nixos/tests/incus: test config creation and switch-to-configuration
* [`8a5fc818`](https://github.com/NixOS/nixpkgs/commit/8a5fc818da16aa7299835911a91b5e497bd794cf) flow: 0.299.0 -> 0.305.1
* [`5cdb2562`](https://github.com/NixOS/nixpkgs/commit/5cdb256262c76c77a8fdd7b0ea56ef1d7e884c54) flow: add miniharinn
* [`825d7cb8`](https://github.com/NixOS/nixpkgs/commit/825d7cb8e857a97694e1008c3a2612a93324e9cd) python3Packages.jug: 2.4.0 -> 2.5.0
* [`99ab2550`](https://github.com/NixOS/nixpkgs/commit/99ab2550e7ed83597c9b753a0adbc0b5e07cd65d) appendOverlays: return spliced packages on empty overlay list
* [`51452954`](https://github.com/NixOS/nixpkgs/commit/514529545bab291d6351935baeb409355c608207) tests.top-level: add test for appendOverlays preserving splicing
* [`6dd27a61`](https://github.com/NixOS/nixpkgs/commit/6dd27a616e52d31e8ad9e4af60790a8fdbd56224) x2t: move under onlyoffice-documentserver
* [`92c7d23e`](https://github.com/NixOS/nixpkgs/commit/92c7d23ecbb13ce588c450a5439e30502d799ffa) pencil2d: 0.7.1 -> 0.7.2
* [`947d5957`](https://github.com/NixOS/nixpkgs/commit/947d59574877188d121e1e7b0f659391725c07ea) python3Packages.fastparquet: 2025.12.0 -> 2026.3.0
* [`bbc65f1e`](https://github.com/NixOS/nixpkgs/commit/bbc65f1ec646d1d233d1b420b297a286edcd0ab8) git-cola: 4.17.1 -> 4.18.2
* [`3ad13542`](https://github.com/NixOS/nixpkgs/commit/3ad13542c182a1504d1e1ed6f198adc0ad812ed8) maintainers: add leoflo
* [`e5c1a88d`](https://github.com/NixOS/nixpkgs/commit/e5c1a88dcac52518648c64eece66ce48f9f913e7) python3Packages.langgraph-sdk: 0.3.11 -> 0.3.12
* [`50a34146`](https://github.com/NixOS/nixpkgs/commit/50a34146c22882234496d0fa0795fd0b4ee8fc5f) python3Packages.hiredis: 3.3.0 -> 3.3.1
* [`6b4efeca`](https://github.com/NixOS/nixpkgs/commit/6b4efecad47dbe18ce564481a575dd78c4689f1c) delve: add shell completion files
* [`ea3bb75c`](https://github.com/NixOS/nixpkgs/commit/ea3bb75c0dba88737ed9a7314e8f08f277b618e5) switchres: 2.2.1 -> 2.2.2
* [`791cb782`](https://github.com/NixOS/nixpkgs/commit/791cb78299d9dca352af41cf68c1c4a37a3e6b0f) ipsw: init at 3.1.665
* [`2220963f`](https://github.com/NixOS/nixpkgs/commit/2220963fcd01df2b24d088cbed22ce20b2ae3d03) grafanaPlugins.marcusolsson-json-datasource: 1.3.27 -> 1.3.28
* [`46a7610e`](https://github.com/NixOS/nixpkgs/commit/46a7610ee1440e49183919502fa02640b87bf1fb) perses: 0.53.0 -> 0.53.1
* [`55ccba28`](https://github.com/NixOS/nixpkgs/commit/55ccba28fbe3accd0c98a1a1828e11ced4916963) mkbootimg-osm0sis: init at 2022.11.09-unstable-2025-03-10
* [`c77d10fd`](https://github.com/NixOS/nixpkgs/commit/c77d10fd73025c2b74704b1f3d165da7c1de47d2) unpackelf: init at 2022.11.09
* [`8d223ecd`](https://github.com/NixOS/nixpkgs/commit/8d223ecdc6252302192b89fb9b1db70c670c95ae) dhtbsign: init at 0-unstable-2022-11-10
* [`b2bb4607`](https://github.com/NixOS/nixpkgs/commit/b2bb4607400e1b14ffcb586b0eddc33dda89c6a6) elftool: init at 0-unstable-2022-11-10
* [`3fe7909d`](https://github.com/NixOS/nixpkgs/commit/3fe7909d82a66215b5899c4cea2f9614064e7b6d) futility: init at 0-release-R144-16503.B
* [`da751d8f`](https://github.com/NixOS/nixpkgs/commit/da751d8fbd642192597abfa162b6f8457060afd1) loki-tool: init at 0-unstable-2016-06-27
* [`53700c11`](https://github.com/NixOS/nixpkgs/commit/53700c115555219e9f4e0136bdbd3eef9e1e0ac2) mboot: init at 0-unstable-2022-11-10
* [`3c5f4ba7`](https://github.com/NixOS/nixpkgs/commit/3c5f4ba726a73b8274fa176c8502478f5111fd9b) mkmtkhdr: init at 0-unstable-2022-11-10
* [`0ad524ec`](https://github.com/NixOS/nixpkgs/commit/0ad524ecde251210af9b2f50f3cbf85f8145b06e) sony-dump: init at 0-unstable-2019-11-03
* [`a2b7868c`](https://github.com/NixOS/nixpkgs/commit/a2b7868c4e4ca42d984451284040a5fb5b334584) android-image-kitchen: init at 0-unstable-2025-10-17
* [`49a9dd1c`](https://github.com/NixOS/nixpkgs/commit/49a9dd1c349cd4259b101bd0734ed1b6f54bfd17) opentxl: use generated code as src instead of repo
* [`6f27c3f6`](https://github.com/NixOS/nixpkgs/commit/6f27c3f6833f05d423bbfa7115193bff9fd55301) blueprint-compiler: 0.18.0 -> 0.20.4
* [`2df10041`](https://github.com/NixOS/nixpkgs/commit/2df10041fce3d9de6141adbfd997c80ffbe8c7e9) python314Packages.python-ldap: fix build
* [`815a2677`](https://github.com/NixOS/nixpkgs/commit/815a267708b72ec99c70b92d93a2a6001f4db1a0) xonsh: clean up disabled tests
* [`6a8a3248`](https://github.com/NixOS/nixpkgs/commit/6a8a32481c1bc5daf8438faf5836a4f25dbca7d6) iamb: temporary fix for matrix-sdk-sqlite failure
* [`76affadd`](https://github.com/NixOS/nixpkgs/commit/76affaddd246fbb26dece2fbcd2da0fad93ced0e) shrinkray: Fix broken shrinkray-worker invocation
* [`ab2b06e4`](https://github.com/NixOS/nixpkgs/commit/ab2b06e48ea10edb95fd68349bfa7b1e1a6b75ec) processing: Use jogl from nixpkgs
* [`148a5ecf`](https://github.com/NixOS/nixpkgs/commit/148a5ecf9de7380ce8c6b38932eb7bc98f9ca1eb) mojoshader: init at 0-unstable-2026-02-10
* [`dc3de074`](https://github.com/NixOS/nixpkgs/commit/dc3de0749d0f6197b150f6032a5a0bb7e46af51e) intune-portal: 1.2511.7-noble -> 1.2603.31-noble
* [`e1e70b7e`](https://github.com/NixOS/nixpkgs/commit/e1e70b7ec4e45db5e961b7b6caede1ddb0e43c83) xonsh: disable failing tests on darwin
* [`0222eed7`](https://github.com/NixOS/nixpkgs/commit/0222eed7a7307b20206f1b871ce2d3757194f94d) dcpj785dw{lpr,-cupswrapper}: init at 1.0.0_0
* [`d4d8d95d`](https://github.com/NixOS/nixpkgs/commit/d4d8d95dcd721948e34900bef6e3c045cef8a812) tree-sitter-grammars.tree-sitter-php-only: 0.24.2-unstable-2025-11-24 -> 0.24.2-unstable-2026-03-19
* [`ef102bed`](https://github.com/NixOS/nixpkgs/commit/ef102bed75b9625eebe54d8aa9f82fb17978d8e5) proj: 9.7.1 -> 9.8.0
* [`b6300674`](https://github.com/NixOS/nixpkgs/commit/b6300674121d5cf4b917fddca4fd0e9d21302949) python3Packages.pyproj: fix build with proj 9.8.0
* [`d777e6d6`](https://github.com/NixOS/nixpkgs/commit/d777e6d6e44fee9a3d350ac763d739bd2d6844f4) dart.fetchGitHashesScript: fetch submodules to match behavior of fetchgit
* [`f69cbc9e`](https://github.com/NixOS/nixpkgs/commit/f69cbc9e2aa81cde38eba6453982a622d7794431) finamp: add update script
* [`faa5144a`](https://github.com/NixOS/nixpkgs/commit/faa5144a470d4a2ce8b6cc905cec89220e6ffde3) motioneye: init at 0.43.1
* [`ba1b5eba`](https://github.com/NixOS/nixpkgs/commit/ba1b5ebad68971658b8e98d7869c418c244db7d4) tree-sitter-grammars.tree-sitter-sshclientconfig: 2026.2.18 -> 2026.3.19
* [`7508a033`](https://github.com/NixOS/nixpkgs/commit/7508a0338e13e9068e70df45b31f104ef9fdfb6a) nixos/qemu-vm: replace postBootCommands by a systemd service
* [`d292d475`](https://github.com/NixOS/nixpkgs/commit/d292d475265fa54d56a69408a23b6f27535f9af1) nixos/channel: convert postBootCommands to a systemd service
* [`6ab12a51`](https://github.com/NixOS/nixpkgs/commit/6ab12a513a4debf1443a583fb5b2a3a072d561a7) nixos: convert remaining postBootCommands that load the nix DB to systemd services
* [`7a4d539c`](https://github.com/NixOS/nixpkgs/commit/7a4d539cbeb0f067bd03b2605300dcb2cf69da6a) python3Packages.mkdocs-material: use finalAttrs
* [`37b21f06`](https://github.com/NixOS/nixpkgs/commit/37b21f065623c943550d13b78fdec784f51c0060) python3Packages.mkdocs-material: 9.7.1 -> 9.7.6
* [`92279148`](https://github.com/NixOS/nixpkgs/commit/92279148f5effe9dce137f33e2c5f8e5244c361a) postman: 11.88.3 -> 11.89.0
* [`6bcbd06f`](https://github.com/NixOS/nixpkgs/commit/6bcbd06fa61a8c1001749a377d5a778f6a16469e) python3Packages.cocotb: disable for python 3.14+
* [`81905444`](https://github.com/NixOS/nixpkgs/commit/81905444163afcc413ad7cca5c33f8f8ddfdccec) python314Packages.cirq-core: fix build
* [`f32c64ed`](https://github.com/NixOS/nixpkgs/commit/f32c64ed54aa39ef7bf5839c3b0595da022658a6) python3Packages.cinemagoer: 2023.5.1 -> 2025.12.31
* [`8dd328de`](https://github.com/NixOS/nixpkgs/commit/8dd328defb3973abb806ae523a2e6b5c0db5e17a) heimdall-proxy: 0.17.9 -> 0.17.12
* [`5492d23d`](https://github.com/NixOS/nixpkgs/commit/5492d23dcce90112af6b9265122fff8d59865870) lp_solve: migrate to by-name
* [`09a85412`](https://github.com/NixOS/nixpkgs/commit/09a85412e03fd08839a38a6aa2d5da1e6e026d13) lp_solve: refactor
* [`c7411de5`](https://github.com/NixOS/nixpkgs/commit/c7411de5c0986f767c8d25475e4614309c8b04a3) ilspycmd: migrate to by-name
* [`7181b4e7`](https://github.com/NixOS/nixpkgs/commit/7181b4e7f7da0e77c28bf9040dc3998fcf5d59a4) ilspycmd: refactor
* [`be49d3a9`](https://github.com/NixOS/nixpkgs/commit/be49d3a94515ea1b64b773897b957ed875b1bb1c) python3Packages.langchain-aws: 1.4.0 -> 1.4.1
* [`7a399bb7`](https://github.com/NixOS/nixpkgs/commit/7a399bb7465111bf63f70c522463fe9c46a9ca6d) buildRustCrate: support Cargo.toml [lints] table
* [`38ad34b5`](https://github.com/NixOS/nixpkgs/commit/38ad34b5d6aceb38dd72ded6f973192479000ce3) maintainers: add barrettruth
* [`bffa60ae`](https://github.com/NixOS/nixpkgs/commit/bffa60aeb23093f689ea93d356a522009c12ad43) gradia: fix patch for blueprint-compiler 0.20.4
* [`612c21ba`](https://github.com/NixOS/nixpkgs/commit/612c21bae471a887181e239ec0f7f50f4d19b6c8) nomad_1_11: 1.11.1 -> 1.11.3
* [`0283946b`](https://github.com/NixOS/nixpkgs/commit/0283946b367803d4bc0bea5621aed1897e56d4ea) nixos/motioneye: init
* [`533f26ae`](https://github.com/NixOS/nixpkgs/commit/533f26ae7c83bff67986c2183b8019b116903f23) samplv1: 1.3.2 -> 1.4.1
* [`93db890c`](https://github.com/NixOS/nixpkgs/commit/93db890c7ef9e5ad0f36349a887bc5debaa61ad3) proxyman: 3.9.0 -> 3.10.0
* [`21739cc7`](https://github.com/NixOS/nixpkgs/commit/21739cc788d696f67e06672ff17351a42623d6c1) clickhouse: 26.2.4.23-stable -> 26.2.5.45-stable
* [`a91a30e7`](https://github.com/NixOS/nixpkgs/commit/a91a30e7f4f9868c6c9c2fc04386df888d4db6e9) pianobooster: 1.0.0 -> 1.0.0-unstable-2023-01-22; add ulysseszhan as maintainer
* [`1a5b402f`](https://github.com/NixOS/nixpkgs/commit/1a5b402f4665d2c107af60d2440065874c056598) python3Packages.indexed-zstd: 1.6.1 -> 1.7.1
* [`2fb61586`](https://github.com/NixOS/nixpkgs/commit/2fb61586561284e52eecc587401ed3fe433d757e) zsnes2: 2.0.12 -> 2.1.0
* [`e14eb2ec`](https://github.com/NixOS/nixpkgs/commit/e14eb2ecfe5d21725026c3366c4232245bf8cdca) element-call: 0.11.1 -> 0.18.0
* [`616ba4bf`](https://github.com/NixOS/nixpkgs/commit/616ba4bf2473f95cee3f271dd6ef3ea772192fa9) nexttrace: 1.5.0 -> 1.6.1
* [`9fd2b8c7`](https://github.com/NixOS/nixpkgs/commit/9fd2b8c767a416bd5be8289c531b7ea2584121a1) buildRustCrate: set CARGO_BIN_EXE_<name> for integration tests
* [`7821a105`](https://github.com/NixOS/nixpkgs/commit/7821a105024f04f32ff2d7b7ddba627d717dcacd) python3Packages.beets-audible: 1.3.1 -> 1.4.0
* [`900d87ec`](https://github.com/NixOS/nixpkgs/commit/900d87ec963e99bd7666c00cf0ec9fa84bbf8a7f) python3Packages.skein: use `meta.problems` instead of `lib.traceIf`
* [`f517b3da`](https://github.com/NixOS/nixpkgs/commit/f517b3da23a7f10bf038a49d24dcb43f8a59c924) clash-rs: clean up flags
* [`45677415`](https://github.com/NixOS/nixpkgs/commit/45677415e39b231d32867df43ef343f900af4261) ytermusic: 0.1.0 -> 0.1.5
* [`1d5a9126`](https://github.com/NixOS/nixpkgs/commit/1d5a9126a2837d49230d435724410957e8899c21) yubihsm-shell: 2.7.1 -> 2.7.2
* [`583b8e44`](https://github.com/NixOS/nixpkgs/commit/583b8e446c0abd82983c268a4ab4e0de6a41775f) yaup: unstable-2019-10-16 -> 0-unstable-2026-03-25
* [`558eec4a`](https://github.com/NixOS/nixpkgs/commit/558eec4a931854039ced605ea5aa9779e3c20986) unvanquished: 0.55.3 -> 0.56.1
* [`a12343ae`](https://github.com/NixOS/nixpkgs/commit/a12343aeae5e9b89ac2516fd79c3d7a6736a342f) python3Packages.postgrest: 2.28.0 -> 2.28.3
* [`903db576`](https://github.com/NixOS/nixpkgs/commit/903db57604f3f21c954aed57e4234326d407c579) python3Packages.realtime: 2.28.0 -> 2.28.3
* [`d737794a`](https://github.com/NixOS/nixpkgs/commit/d737794aa38ce3bbcaf219f39e813a35bda88d83) python3Packages.storage3: 2.28.0 -> 2.28.3
* [`f08301b0`](https://github.com/NixOS/nixpkgs/commit/f08301b0d752f17674892a395ec3fa3cdf39185f) python3Packages.supabase-auth: 2.28.0 -> 2.28.3
* [`74b6f68b`](https://github.com/NixOS/nixpkgs/commit/74b6f68b35a1c3eae69000c359807e3605f3d863) python3Packages.supabase-functions: 2.28.0 -> 2.28.3
* [`10fe0c1b`](https://github.com/NixOS/nixpkgs/commit/10fe0c1b715f2066618094483d1f538de17e678c) python3Packages.supabase: 2.28.0 -> 2.28.3
* [`f88494e5`](https://github.com/NixOS/nixpkgs/commit/f88494e53da00b552e3d1a0631b665c8506a7b12) openapi-generator-cli: 7.18.0 -> 7.21.0
* [`7dda3f6a`](https://github.com/NixOS/nixpkgs/commit/7dda3f6a84c704537a67c9a71b15bdfe19548d04) nixos/rancher: fix warnings/assertions being silently dropped
* [`d23ca67c`](https://github.com/NixOS/nixpkgs/commit/d23ca67c2f2dfd1f8c058669fca47c04c716e71d) certinfo: set version via ldflags and drop stale libx11 input
* [`d0e117df`](https://github.com/NixOS/nixpkgs/commit/d0e117df9af55bca0a414ec137a078c4dbee2106) python3Packages.ansible: 13.3.0 -> 13.5.0
* [`0a8686a2`](https://github.com/NixOS/nixpkgs/commit/0a8686a247b33a3492690f3b54990f350e10aaab) chirpstack-gateway-mesh: init at 4.1.3
* [`f0706e48`](https://github.com/NixOS/nixpkgs/commit/f0706e48d6655b8d96cf7a76469c1853f304755d) pyedbglib: use tag, support finalAttrs
* [`84eca77e`](https://github.com/NixOS/nixpkgs/commit/84eca77efae2485aa8a4ee03695641aeffa9a9cf) pymcuprog: use tag, support finalAttrs
* [`4ddfd80f`](https://github.com/NixOS/nixpkgs/commit/4ddfd80f1a91eca48f8b8ae40bb10393cabcf26d) pyhanko: 0.33.0 -> 0.34.1
* [`26a153f8`](https://github.com/NixOS/nixpkgs/commit/26a153f86f1595eb0937193d2eac8883075ef47b) pyhanko-cli: 0.2.1 -> 0.3.1
* [`b7547244`](https://github.com/NixOS/nixpkgs/commit/b7547244dc6a3b32b376511b868de175e467d93f) nitrokey-fido2-firmware: drop
* [`417b3463`](https://github.com/NixOS/nixpkgs/commit/417b346321e1637ba0f48dc4e512c968527e4391) shrinkray: Disable timing sensitive test
* [`deff67ea`](https://github.com/NixOS/nixpkgs/commit/deff67ea124ff626f313eeeff7d53f3cb8e18937) nixos/netbird: fix coturn TURN port for UDP
* [`a91da62e`](https://github.com/NixOS/nixpkgs/commit/a91da62e79f2cb9084b3c3a46e0390d812630477) vault: remove postPatch, use finalAttrs
* [`112ee413`](https://github.com/NixOS/nixpkgs/commit/112ee413f003576f38f6eea6e7e80dadcb8f1d0c) python3Packages.python-gvm: 26.10.1 -> 26.11.1
* [`11ae3fca`](https://github.com/NixOS/nixpkgs/commit/11ae3fcad63fe661a52fb6d6084f624417a8f103) finamp: 0.9.22-beta -> 0.9.23-beta
* [`15f9d915`](https://github.com/NixOS/nixpkgs/commit/15f9d9156797d534f2c38392a8e6ea9c7154b816) argocd: use go list to get kubectl version
* [`2f1e98e7`](https://github.com/NixOS/nixpkgs/commit/2f1e98e7200dfc2ef3b1a09e032269829de97df8) ashell: 0.7.0 -> 0.8.0
* [`02ab4a03`](https://github.com/NixOS/nixpkgs/commit/02ab4a0319cc246eb7733be949d0f9d87edd0d98) comaps: 2025.11.07-2 -> 2026.03.23-5
* [`2ad8bf20`](https://github.com/NixOS/nixpkgs/commit/2ad8bf20edd3a4dffb834f38ae370f90877721bd) tsm-client: 8.1.27.1 -> 8.2.1.0
* [`7767dd4b`](https://github.com/NixOS/nixpkgs/commit/7767dd4b4e33b016a6ec7283b50a1629e781e002) turbo-unwrapped: fix passthru.updateScript
* [`3bb0e128`](https://github.com/NixOS/nixpkgs/commit/3bb0e12822c83ef69c2909f419d559fb3c8c2a66) {,python3Packages.}rpatool: init at 1.0.0
* [`58c8ba0c`](https://github.com/NixOS/nixpkgs/commit/58c8ba0cbe4ab41be5a2c3df73a867755b79b387) z3: fix cross build by using correct python intepreter
* [`10e6892e`](https://github.com/NixOS/nixpkgs/commit/10e6892e35afd87d293e95e7f7c0d4fa9020e621) fontc: 0.3.0 -> 0.6.0, switch to fetchCrate, add updateScript
* [`e81bb99e`](https://github.com/NixOS/nixpkgs/commit/e81bb99e10cb1b9ace02e651cb3cd732aa3ee02b) geph: fix scripts and dependencies in env
* [`ae4384c2`](https://github.com/NixOS/nixpkgs/commit/ae4384c28b2cd2b37f71552aa9667904537b2ee5) nixos/geph: init module
* [`45e71a15`](https://github.com/NixOS/nixpkgs/commit/45e71a1565189ccb92abce92efc920ea22655b57) pony-corral: fix aarch64 build
* [`048af610`](https://github.com/NixOS/nixpkgs/commit/048af6100f1c7a105cf4393568fec7ef83e62315) cq: 2024.06.24-12.10 -> 2026.01.09-17.19
* [`1bcb441b`](https://github.com/NixOS/nixpkgs/commit/1bcb441b7b5bf7f645292c63e32e9b6d711d71d5) iortcw: fix build
* [`7213d375`](https://github.com/NixOS/nixpkgs/commit/7213d375b57792d5e1dcd38471e4794f755610c4) codeql: 2.24.3 -> 2.25.1
* [`ae708590`](https://github.com/NixOS/nixpkgs/commit/ae708590e2ae5bcab88c1fb42b13586778ddad9c) trucky: init at 3.8.2
* [`2c4ec9bc`](https://github.com/NixOS/nixpkgs/commit/2c4ec9bc7d4c291730f129f7ff2f1377fef814ca) syncyomi: 1.1.4 -> 1.1.7
* [`ef6a1bdf`](https://github.com/NixOS/nixpkgs/commit/ef6a1bdf7caadc78c90a264dad646b06076fd9fb) syncyomi: add miniharinn as a maintainer
* [`2fbaf6ce`](https://github.com/NixOS/nixpkgs/commit/2fbaf6ce6f8c1fefa078de05de0746affb4ccb11) syncyomi: add passthru.updateScript
* [`894ab666`](https://github.com/NixOS/nixpkgs/commit/894ab666b3f206d72cbc0480884d04b1ca3b4bf9) syncyomi: fix failed checks on darwin
* [`4653086f`](https://github.com/NixOS/nixpkgs/commit/4653086ff638f8053e35108f4ab9af6e4ce75761) heptabase: 1.85.1 -> 1.87.2
* [`17ca51d8`](https://github.com/NixOS/nixpkgs/commit/17ca51d81a58dca32597da11ccafb1b071b50abe) jj-pre-push: 0.3.4 -> 0.3.5
* [`9d109343`](https://github.com/NixOS/nixpkgs/commit/9d1093434e6367cff85a4b6a25756098d89bbab7) rapidraw: 1.5.1 -> 1.5.2
* [`00e01c0f`](https://github.com/NixOS/nixpkgs/commit/00e01c0f2124f7dd6f222b05fd72b761b4b87515) koboldcpp: 1.105.4 -> 1.110
* [`d0a9fcb7`](https://github.com/NixOS/nixpkgs/commit/d0a9fcb7b6ad89e4b79468db1605469d00be6ba4) koboldcpp: move `shaderc` to `nativeBuildInputs`
* [`99906e35`](https://github.com/NixOS/nixpkgs/commit/99906e3539c9356dee2e4b1e3281baa40b8e1de5) python3Packages.phonopy: 3.2.1 -> 3.4.0
* [`8321c4a3`](https://github.com/NixOS/nixpkgs/commit/8321c4a38f05e0d8d33a0d3a1ecb6ca80cecb559) onefetch: 2.26.1 -> 2.27.1
* [`71b52df8`](https://github.com/NixOS/nixpkgs/commit/71b52df8b3b63e2221a71b0498864cf5e8b3cdd0) atlantis: 0.39.0 -> 0.41.0
* [`67baa5e8`](https://github.com/NixOS/nixpkgs/commit/67baa5e8ec7edf872c8827a5cc9fc6ba61fa1404) engelsystem: 3.6.0 -> 3.7.0, adopt
* [`0e8ad2db`](https://github.com/NixOS/nixpkgs/commit/0e8ad2db2f87cd88d974606f977d07ff2a70b19b) nixos/gamemode: remove wantedBy directive
* [`c86edb33`](https://github.com/NixOS/nixpkgs/commit/c86edb33231cdf3525eedd1887da86526604f330) protontricks: add freetype to steam-run fhs
* [`3543789f`](https://github.com/NixOS/nixpkgs/commit/3543789f1d84b5d22a2cf02f5df538e13c00df32) protontricks: 1.14.0 -> 1.14.1
* [`c2562a32`](https://github.com/NixOS/nixpkgs/commit/c2562a326633d515a45a5e63ead1f0e61fa626e1) maintainers: add wishstudio
* [`64aefa9c`](https://github.com/NixOS/nixpkgs/commit/64aefa9ccb54f8bd48cea383041574d0d98cdf05) graphite: 0-unstable-2026-03-13 -> 0-unstable-2026-03-29
* [`fa23b0fe`](https://github.com/NixOS/nixpkgs/commit/fa23b0fe540fe707829fb1390b9265718094e058) brave-search-cli: init at 1.2.0
* [`a2089c8c`](https://github.com/NixOS/nixpkgs/commit/a2089c8cb9479381e7353951d30a206f33b355ab) gnucash: fix update-script
* [`8e52f0f6`](https://github.com/NixOS/nixpkgs/commit/8e52f0f6e961e7ac126c9858ebed835c51d9655b) gnucash: 5.14 -> 5.15
* [`dbb5885d`](https://github.com/NixOS/nixpkgs/commit/dbb5885d2af6a11d56ca73fbab0261c42e807947) duckdb: add cameronraysmith as maintainer
* [`c817228a`](https://github.com/NixOS/nixpkgs/commit/c817228a5fbd894d0d76616f9fbbd32c44a78362) duckdb: 1.4.4 -> 1.5.1
* [`8674da8f`](https://github.com/NixOS/nixpkgs/commit/8674da8f81ece1d3e51fd416284e2fd1d0eae3ee) duckdb: exclude iejoin tests on darwin
* [`e438f472`](https://github.com/NixOS/nixpkgs/commit/e438f4724e8c3c379d9cd0dbdec26a13f170e34c) inlyne: fix build on linux
* [`5f298cd7`](https://github.com/NixOS/nixpkgs/commit/5f298cd77de05f3acda2448c74ab87ea00b011c1) libblake3: 1.8.3 -> 1.8.4
* [`e4286d26`](https://github.com/NixOS/nixpkgs/commit/e4286d264bd69dc69c59f200d6226a899a6929fa) python3Packages.netbox-floorplan-plugin: 0.9.0 -> 0.9.1
* [`2f81f5cd`](https://github.com/NixOS/nixpkgs/commit/2f81f5cd8408173cf396069263fc37966b79ef29) jan: 0.7.5 -> 0.7.9
* [`4b2b5be2`](https://github.com/NixOS/nixpkgs/commit/4b2b5be22fa3e34fd1e5a6a60f355f70fcba8b20) uboot: 2025.10 -> 2026.01
* [`bab1276f`](https://github.com/NixOS/nixpkgs/commit/bab1276fe9b5c1e2d50b2d761b870ac09cee896c) k3s_1_32: drop
* [`df5a3c38`](https://github.com/NixOS/nixpkgs/commit/df5a3c388da9b4261c8232a9082a1a8b9052da18) nixos/rancher: fix warning
* [`da5f13b4`](https://github.com/NixOS/nixpkgs/commit/da5f13b42a5c43cc927242c72ea650b147951efd) pi-coding-agent: switch to npx tsgo to avoid version mismatch
* [`5d2994f4`](https://github.com/NixOS/nixpkgs/commit/5d2994f470a870607e56e2d832c132672369a94f) nixos/rancher: add nodeExternalIP option to match nodeIP option
* [`415730d7`](https://github.com/NixOS/nixpkgs/commit/415730d7fa98556df3a1ce62a9ef0dfcffce012e) prisma_7, prisma-engines_7: 7.5.0 -> 7.6.0
* [`4e5d84a1`](https://github.com/NixOS/nixpkgs/commit/4e5d84a1c8df6d0a3814abb54e697dd63ac8082b) cassandra: use python3Packages
* [`72fc26fb`](https://github.com/NixOS/nixpkgs/commit/72fc26fb705feaa2b6031a56ec70932a90f3d1ce) pinecone: remove
* [`3a83af70`](https://github.com/NixOS/nixpkgs/commit/3a83af709f7fd4493df000974895f0ea07829c0d) teamviewer: migrate to by-name
* [`b7ee3ad5`](https://github.com/NixOS/nixpkgs/commit/b7ee3ad5baa5e8f227cf835f39e1faacefcedf0d) teamviewer: use finalAttrs
* [`81d2f116`](https://github.com/NixOS/nixpkgs/commit/81d2f116a09e85a4a7d12cc0d2aa96181c908e9f) shh: 2026.1.27 -> 2026.3.8
* [`966b542c`](https://github.com/NixOS/nixpkgs/commit/966b542c68e7e0d5f28d2f5450ca953b792479ff) all-packages: Drop unused cassandra python argument
* [`ab2aa991`](https://github.com/NixOS/nixpkgs/commit/ab2aa9915c2373a646a912cdf499b4bd6967d013) cassandra: Use correct nixosTests attribute
* [`b376c14b`](https://github.com/NixOS/nixpkgs/commit/b376c14b43fa39add20d58adf7bf0d34f06f1754) cassandra: Use our cassandra-driver for cqlsh
* [`b283f04b`](https://github.com/NixOS/nixpkgs/commit/b283f04b18418a10398928f903b08e9c0f90201c) python3Packages.copier: 9.14.0 -> 9.14.1
* [`011c5db1`](https://github.com/NixOS/nixpkgs/commit/011c5db1e94b1f54995f65e3a0901e56cf56e270) hextazy: 0.8.5 -> 0.8.6
* [`0553a6c6`](https://github.com/NixOS/nixpkgs/commit/0553a6c60ccc5eb74ae67f3a69e7dc3bad648cca) opensc: 0.26.1 -> 0.27.1
* [`4a9de275`](https://github.com/NixOS/nixpkgs/commit/4a9de2759e5279a636aca6b6ed71803004c37e46) oxidized: 0.35.0 -> 0.36.0
* [`282ac9ef`](https://github.com/NixOS/nixpkgs/commit/282ac9efad6f97420ec2485daa9770c96eb3e56a) gitlab: 18.9.3 -> 18.10.1
* [`7c0e7b7c`](https://github.com/NixOS/nixpkgs/commit/7c0e7b7ce377d210bff380f355be496b1f786249) sparrow: add passthru.updateScript
* [`e7518849`](https://github.com/NixOS/nixpkgs/commit/e7518849995899c045852dcc387f9a69f225de47) sparrow: 2.4.0 -> 2.4.2
* [`74fa42ae`](https://github.com/NixOS/nixpkgs/commit/74fa42ae539c7af9ee6d22f4e0ccd4c1c16d1d16) python3Packages.obspec: init at 0.1.0
* [`dbe04393`](https://github.com/NixOS/nixpkgs/commit/dbe04393a8fd50d17837990d911b4fc22a88a689) python3Packages.async-tiff: init at 0.7.1
* [`c0715220`](https://github.com/NixOS/nixpkgs/commit/c0715220056add043f40b31435ec499e702114e3) python3Packages.async-geotiff: init at 0.4.0
* [`7dd6d4b8`](https://github.com/NixOS/nixpkgs/commit/7dd6d4b8d0d51281d09507eb1577f18e41909514) python3Packages.rio-tiler: 8.0.5 -> 9.0.4
* [`aba74a90`](https://github.com/NixOS/nixpkgs/commit/aba74a9054540570e66cc7ca4a0a399afd80fdf7) installFontsHook: install some more font formats
* [`22ea9286`](https://github.com/NixOS/nixpkgs/commit/22ea9286c5a2d996557e10bc321fe0283e87a9ac) tfenv: init at 3.0.0
* [`ca1a2dfd`](https://github.com/NixOS/nixpkgs/commit/ca1a2dfd55d92dfe546248ef08e439426062415f) python3Packages.odfdo: init at 3.22.3
* [`f7a983f6`](https://github.com/NixOS/nixpkgs/commit/f7a983f69633ce3b6f8c781821251b5d0781b661) airwindows: 0-unstable-2026-03-14 -> 0-unstable-2026-04-01
* [`bf4e057a`](https://github.com/NixOS/nixpkgs/commit/bf4e057ad8409804f460fe7a2446a7460a30de58) python3Packages.odsgenerator: init at 1.12.0
* [`0dd3bfc7`](https://github.com/NixOS/nixpkgs/commit/0dd3bfc74f3b8d8a1b2b5963fd758f263421b9a0) python3Packages.odsparsator: init at 1.14.0
* [`3b23ea3c`](https://github.com/NixOS/nixpkgs/commit/3b23ea3cec41dd09bb49a48f6a14578397aa62e8) prisma_6, prisma-engines_6: 6.19.1 -> 6.19.3
* [`2d4cd5a0`](https://github.com/NixOS/nixpkgs/commit/2d4cd5a04f51eea41492ca52657e57c6fe2f7611) python3Packages.manifestoo-core: add changelog location
* [`3d1b1be0`](https://github.com/NixOS/nixpkgs/commit/3d1b1be0efb8c25935eabe26ad075aa9ab7cf45b) anyk: 3.45.0 -> 3.48.0
* [`bc3d169f`](https://github.com/NixOS/nixpkgs/commit/bc3d169fccc80484f38c5a0c62fa63fb31aef12c) smiley-sans: adopt by pancaek
* [`d9d29581`](https://github.com/NixOS/nixpkgs/commit/d9d2958104e59a016388d5246851e8f26177f145) xkcd-font: adopt by pancaek
* [`3eb5a62e`](https://github.com/NixOS/nixpkgs/commit/3eb5a62e720e20196c934b2d443d1aee874821ca) hubot-sans: adopt by pancaek
* [`683f35b5`](https://github.com/NixOS/nixpkgs/commit/683f35b5e75d786eea2ebf57638d400491aa6c94) hubot-sans: use installFonts hook
* [`78d3c7a2`](https://github.com/NixOS/nixpkgs/commit/78d3c7a20d6e6ee77f5462aaa5e5515b168bd6e4) borg-sans-mono: adopt by pancaek
* [`88d506f7`](https://github.com/NixOS/nixpkgs/commit/88d506f72d71d0c488d0e816b854f95284e19347) borg-sans-mono: use installFonts hook
* [`75ed0742`](https://github.com/NixOS/nixpkgs/commit/75ed07429729eab8e3f125b27c613f042e0ca7c1) xkcd-font: use installFonts hook
* [`6deb09d6`](https://github.com/NixOS/nixpkgs/commit/6deb09d6561a0cbe84f1320da9ec9bf1d2e438dd) proton-vpn-cli: 0.1.6 -> 0.1.9
* [`46ed882f`](https://github.com/NixOS/nixpkgs/commit/46ed882f41ac048fae96f67a1b21f737811fc194) python3Packages.proton-vpn-api-core: 4.16.0 -> 4.18.0
* [`654b5f55`](https://github.com/NixOS/nixpkgs/commit/654b5f555587446ac2a69600c406ab7a55ec3934) smiley-sans: use installFonts hook
* [`7e4b5892`](https://github.com/NixOS/nixpkgs/commit/7e4b58921565b8b7dbe711c9b7f2b622aa80c2f9) smiley-sans: switch to finalAttrs
* [`29e9f876`](https://github.com/NixOS/nixpkgs/commit/29e9f8761f515145c922e717704c33313cf7386c) ferrum: use installFonts hook
* [`c04e0bf6`](https://github.com/NixOS/nixpkgs/commit/c04e0bf63641db550e6c4fc3fddb3564489143ea) wqy_microhei: use installFonts hook
* [`69d3932e`](https://github.com/NixOS/nixpkgs/commit/69d3932e8593e389443d25c1fe23c48e49d0b074) wqy_microhei: switch to finalAttrs
* [`ebfb9344`](https://github.com/NixOS/nixpkgs/commit/ebfb9344abf7c549072bef6ed801583887f7ab8c) veryl: 0.19.0 -> 0.19.1
* [`f6cd92e5`](https://github.com/NixOS/nixpkgs/commit/f6cd92e5c3e43aad786610e1c63907ae32a116a8) mph_2b_damase: use installFonts hook
* [`1bbd493a`](https://github.com/NixOS/nixpkgs/commit/1bbd493abef5e407a5bb9b58c1f1ad22c9431034) jigmo: adopt by pancaek
* [`cd1b1bee`](https://github.com/NixOS/nixpkgs/commit/cd1b1bee36b7b7a295a5df2ac1ca1d18219fe24e) jigmo: use installFonts hook
* [`bc587734`](https://github.com/NixOS/nixpkgs/commit/bc5877340156157a65d2c81d19076ffdfeb5e2a5) jigmo: switch to finalAttrs
* [`f7691fe2`](https://github.com/NixOS/nixpkgs/commit/f7691fe2f6d61dd3b122c72cc6cc920b5b8bf601) behdad-fonts: adopt by pancaek
* [`9abb134d`](https://github.com/NixOS/nixpkgs/commit/9abb134d8645ecce11caef45b4493a55cc4c7911) behdad-fonts: use installFonts hook
* [`4eee6745`](https://github.com/NixOS/nixpkgs/commit/4eee67458101ae7d02047dc335bee687987e5523) stress-ng: 0.20.01 -> 0.21.00
* [`8bf408f5`](https://github.com/NixOS/nixpkgs/commit/8bf408f553dce51db28bca06f21b5a6e9128563e) nixos/unifi: fix stop behavior
* [`2f3f0ec3`](https://github.com/NixOS/nixpkgs/commit/2f3f0ec35bd4e655521892fb74ae982d11ba3185) lunar-client: 3.6.1 -> 3.6.3
* [`f45fba02`](https://github.com/NixOS/nixpkgs/commit/f45fba0201743bb2c193f7bfc8d8d1edde3c2982) processing: Remove unused nixpkgs dependencies
* [`bc3ea32f`](https://github.com/NixOS/nixpkgs/commit/bc3ea32f034bdc22eedd2a0daa787b26cd24fd2a) processing: Add libXxf86vm as a dynamically loaded runtime dependency
* [`b857b91d`](https://github.com/NixOS/nixpkgs/commit/b857b91dbadd58e9838582203177b93a3dba5406) imapgoose: 0.4.2 -> 0.5.0
* [`f72c6437`](https://github.com/NixOS/nixpkgs/commit/f72c643757c819e8a77368204a5882109cadc9be) home-assistant-custom-lovelace-modules.material-you-utilities: 2.1.4 -> 2.1.5
* [`f00aa3bd`](https://github.com/NixOS/nixpkgs/commit/f00aa3bd4017fbe353046b98dc5a40eef9f8a916) code: 0.6.83 -> 0.6.90
* [`a34e8cb2`](https://github.com/NixOS/nixpkgs/commit/a34e8cb2eb580d9f15c39bc487687b5928b7d220) attyx: 0.2.47 -> 0.3.6
* [`98d231d9`](https://github.com/NixOS/nixpkgs/commit/98d231d9cad3993470e30dc01169bdc2a254537e) ocamlPackages.miou: 0.4.0 → 0.5.5
* [`6037fd8f`](https://github.com/NixOS/nixpkgs/commit/6037fd8f1ca827fbac105ce65830d85f50be2c9c) python3Packages.tuya-device-sharing-sdk: 0.2.8 -> 0.2.9
* [`754097db`](https://github.com/NixOS/nixpkgs/commit/754097dbc4af44d4beb45f655eddb4694db6a8bb) opensearch: 2.19.2 -> 3.5.0
* [`7334dd90`](https://github.com/NixOS/nixpkgs/commit/7334dd90969d8e0075c56b708497bdbba14defda) lib.types: add types.option
* [`548ad216`](https://github.com/NixOS/nixpkgs/commit/548ad21664766e8f328ac580c669549dda5e7f9f) foxglove-studio: 2.44.0 -> 2.49.0
* [`ca60c04e`](https://github.com/NixOS/nixpkgs/commit/ca60c04e7b0213e04c783bdc91566f7ef77a21fc) mcrl2: added wrapper
* [`2506b044`](https://github.com/NixOS/nixpkgs/commit/2506b044feed0c79def13c444c85e57ba617b933) zinit: refactor to allow darwin builds
* [`bc95e4b6`](https://github.com/NixOS/nixpkgs/commit/bc95e4b6021ac28631e0656083897da5559fe04e) recyclarr: 7.4.1 -> 8.2.1
* [`75430f0a`](https://github.com/NixOS/nixpkgs/commit/75430f0a9e383b914b902367466da2234e6e13df) recyclarr: 8.2.1 -> 8.5.0
* [`ce565c33`](https://github.com/NixOS/nixpkgs/commit/ce565c33865dca787290db8f899727a6771226b4) recyclarr: disable concurrency when building
* [`0ed20069`](https://github.com/NixOS/nixpkgs/commit/0ed20069c0c1cb9e51d2c9a29d1dd7f16c113f78) recyclarr: 8.5.0 -> 8.5.1
* [`dfbf1720`](https://github.com/NixOS/nixpkgs/commit/dfbf172015cce3f52877ff2742a0a6d047816cb7) bottles-unwrapped: 62.0 -> 63.2
* [`60cfc689`](https://github.com/NixOS/nixpkgs/commit/60cfc689ad69a863e9e51dab1d72348ea6ff3fe9) scientifica: use installFonts
* [`9487bbae`](https://github.com/NixOS/nixpkgs/commit/9487bbae12def1d287e96233dbe212af6c221b9b) fastlane: 2.229.1 -> 2.232.2
* [`01086cc5`](https://github.com/NixOS/nixpkgs/commit/01086cc5273a8cd67b20cd5a84f1d0fee21d9ed7) python31{3,4}Packages.docutils-stubs: init at 0.0.22
* [`633f9c7e`](https://github.com/NixOS/nixpkgs/commit/633f9c7ece879d3350c83cef4d4699881745699d) docstrfmt: 1.11.0 -> 2.0.2
* [`902d3e6e`](https://github.com/NixOS/nixpkgs/commit/902d3e6ee902b4f96e65b7a7417de4f13cc989b9) livekit-cli: 1.5.1 -> 2.16.0; modernize
* [`be3bce45`](https://github.com/NixOS/nixpkgs/commit/be3bce45f4de97b44ff85042d0205bfbfc0ae8a1) maintainers: add carschandler
* [`964fc08d`](https://github.com/NixOS/nixpkgs/commit/964fc08d185d9b5ef08f9e850444b7b90af0bbf4) livekit-cli: add faukah, carschandler to maintainers
* [`2a3d48ea`](https://github.com/NixOS/nixpkgs/commit/2a3d48eae93a2407cea3addfbed4dd2c6c0c0838) microsoft-identity-broker: 2.5.0 -> 3.0.1
* [`a6b683fe`](https://github.com/NixOS/nixpkgs/commit/a6b683fe51910269d41d6bc91ab5ae5c91daa0d3) odafileconverter: 26.7.0.0 → 27.1.0.0
* [`595b930f`](https://github.com/NixOS/nixpkgs/commit/595b930f8b415c2512b3f7dc184d927d37392f1b) diffoscope: 315 -> 316
* [`c36842cf`](https://github.com/NixOS/nixpkgs/commit/c36842cf49b2d8ed368819808851057cd9138438) cloudflare-ddns: 1.15.1 -> 1.16.2
* [`588b6b4b`](https://github.com/NixOS/nixpkgs/commit/588b6b4b7c40907ca6a9b74c797da778706eb81c) cwal: 0.8.2 -> v0.8.4
* [`57cbe42c`](https://github.com/NixOS/nixpkgs/commit/57cbe42cc2e91853217408168607ac14b16792f2) elogind: fixup hardcoded references to /sbin
* [`90187790`](https://github.com/NixOS/nixpkgs/commit/90187790bc8fbace37b65ef404ed95f7dde1bb70) elogind: fixup rules to work with eudev
* [`6b4db724`](https://github.com/NixOS/nixpkgs/commit/6b4db724eb52eaeb0a78b11f707fbe211e844dc1) fastcap: fix build with gcc15
* [`c29b6493`](https://github.com/NixOS/nixpkgs/commit/c29b6493f6a96e954a566f475152d37954a7d184) mirrord: 3.194.0 -> 3.198.0
* [`7af9d2c8`](https://github.com/NixOS/nixpkgs/commit/7af9d2c8b44ff5b618537afbf6fda93e3a69a50c) openpbs: 23.06.06-unstable-2026-01-29 -> 23.06.06-unstable-2026-04-02
* [`4461a27e`](https://github.com/NixOS/nixpkgs/commit/4461a27ef34ef2fd69bd94e02bc77281b184d4c1) openpbs: disable fortify hardening
* [`6a81f2d4`](https://github.com/NixOS/nixpkgs/commit/6a81f2d493570dd0af16b8097772b1b74a2cdc4f) python3Packages.pulumi-aws: 7.23.0 -> 7.24.0
* [`27977ee1`](https://github.com/NixOS/nixpkgs/commit/27977ee14dc75b5eb0e03efa99dd955f75c50b5a) scipopt-scip: 10.0.1 -> 10.0.2
* [`4810328c`](https://github.com/NixOS/nixpkgs/commit/4810328c448e0dd64182ca6528c42876efeecafe) runc: 1.4.1 -> 1.4.2
* [`e1270ee8`](https://github.com/NixOS/nixpkgs/commit/e1270ee8200f77ac1afd6cd067770ad4ff9d96cf) tree-sitter-grammars.tree-sitter-t32: 7.2.5 -> 7.2.6
* [`67cff4ab`](https://github.com/NixOS/nixpkgs/commit/67cff4ab78d2946b1b132ac9965c87c6b74bc662) nixos/squeezelite: add pulseaudio support and refresh options
* [`057951bd`](https://github.com/NixOS/nixpkgs/commit/057951bd18182bc5d25392f53531c3030f74627e) jetty: 12.1.7 -> 12.1.8
* [`27689388`](https://github.com/NixOS/nixpkgs/commit/2768938886693eb73402c4d6f31571d3911d8472) easyeffects: 8.1.6 -> 8.1.8
* [`ae7fedec`](https://github.com/NixOS/nixpkgs/commit/ae7fedec186adc53aebdbacaa89887d01528d8f2) lmstudio: 0.4.8.1 -> 0.4.9.1
* [`490777d8`](https://github.com/NixOS/nixpkgs/commit/490777d8fea2c8f352fc96e6e4245ae12c0806e8) python3Packages.aioghost: init at 0.4.0
* [`b3220449`](https://github.com/NixOS/nixpkgs/commit/b3220449f776b0666c1087e368addeaf62dde99f) home-assistant: update component-packages.nix
* [`36b987aa`](https://github.com/NixOS/nixpkgs/commit/36b987aa5233165502896b5882452651b47b293c) filebrowser: 2.61.2 -> 2.62.2
* [`6e9e87c0`](https://github.com/NixOS/nixpkgs/commit/6e9e87c03dc95541bcfd3761334851275d0fae25) openscreen: 1.2.0 -> 1.3.0
* [`f8fc81b7`](https://github.com/NixOS/nixpkgs/commit/f8fc81b7e648150b76476c946bfb28a5d5f94ded) filebrowser: fix updateScript for ryantm builds
* [`8fd3b753`](https://github.com/NixOS/nixpkgs/commit/8fd3b75380c33cbf497f9ce39d66018ed39ff638) github-runner: 2.332.0 -> 2.333.1
* [`077656f7`](https://github.com/NixOS/nixpkgs/commit/077656f725361783a09573251c0f80c0c911b88c) python3Packages.langgraph: 1.1.3 -> 1.1.4
* [`d965362c`](https://github.com/NixOS/nixpkgs/commit/d965362c0d1633423a88e644b4e620bd22f8ef06) nixos/roundcube: increase client_max_body_size for maxAttachmentSize
* [`17c056fa`](https://github.com/NixOS/nixpkgs/commit/17c056fa24cd332e064e561f7b3950fe22214120) lib.types.optionDeclaration: test error
* [`7f707274`](https://github.com/NixOS/nixpkgs/commit/7f707274cf4908379f92f49a5f6ee21f4cbd4013) doc: fix `nix repl` command in NixOS manual
* [`af977e3b`](https://github.com/NixOS/nixpkgs/commit/af977e3b88093703b6f02e79501be0ec5f3d2a8e) odin: dev-2026-02 -> dev-2026-04
* [`3051db43`](https://github.com/NixOS/nixpkgs/commit/3051db438bec9dd9d2cc041b0ca9fb85c118ec82) python3Packages.instructor: 1.14.5 -> 1.15.1
* [`5121c4b0`](https://github.com/NixOS/nixpkgs/commit/5121c4b0228fcc1385081fc70cafdfcbb79db7a0) felix86: init at 26.04
* [`43e0c326`](https://github.com/NixOS/nixpkgs/commit/43e0c326fe80c7ab6191713d7db4c6737f03c2a6) museum: 1.3.24 -> 1.3.28
* [`151a8ecf`](https://github.com/NixOS/nixpkgs/commit/151a8ecf057a35a92954c9729ab943d7d2222465) pi-coding-agent: 0.62.0 -> 0.64.0
* [`4928dc2e`](https://github.com/NixOS/nixpkgs/commit/4928dc2e67a1a02f33412ae414ea2b96ea7697bd) python3Packages.py-deprecate: 0.4.0 -> 0.7.0
* [`d2de9199`](https://github.com/NixOS/nixpkgs/commit/d2de91995b45cc2f55739af2264a4b1d2d101eeb) asymptote: 3.09 -> 3.10
* [`59074211`](https://github.com/NixOS/nixpkgs/commit/590742114197aae5e39d3440d093f0cda62af402) siyuan: 3.6.2 -> 3.6.3
* [`7263812e`](https://github.com/NixOS/nixpkgs/commit/7263812eaa4abc8e16a761eb2833df1eb1265d15) sptlrx: 1.2.2 -> 1.3.0
* [`46484284`](https://github.com/NixOS/nixpkgs/commit/464842845b63fefa54b509f94f927a75a13280ba) sampo: 0.17.0 -> 0.17.2
* [`6e628ddd`](https://github.com/NixOS/nixpkgs/commit/6e628ddd5b3bcb8d9a2fd0761ed8f401b993aaff) go-ios: 1.0.204 -> 1.0.206
* [`0142ccc9`](https://github.com/NixOS/nixpkgs/commit/0142ccc9879794c11d232ea263000e8fe3fad488) python3Packages.pglast: 7.11 -> 7.13
* [`de82779c`](https://github.com/NixOS/nixpkgs/commit/de82779ca8b556dacf752ef3e40aea46ab95233b) python3Packages.milc: 1.9.1 -> 1.10.0
* [`e3b68c15`](https://github.com/NixOS/nixpkgs/commit/e3b68c153320103cd7983b3d635cec52042b5c1a) gitbutler: 0.18.8 -> 0.19.7
* [`ba918186`](https://github.com/NixOS/nixpkgs/commit/ba918186918d9b1d6f3dd565b2f7128027dd6f59) python3Packages.mkdocs-include-markdown-plugin: 7.2.1 -> 7.2.2
* [`3f672122`](https://github.com/NixOS/nixpkgs/commit/3f672122e2c4b2db121cfd32fdab8766f61c64c4) times-newer-roman: use installFonts
* [`3d537532`](https://github.com/NixOS/nixpkgs/commit/3d5375321ea4f0114467db6fa05cfcd37df787ec) times-newer-roman: add maintainer
* [`1c58afac`](https://github.com/NixOS/nixpkgs/commit/1c58afac2754de2085935d7f973a9247c7f35b62) openrct2: add overrides for rct1/2 installation paths
* [`80f2bb90`](https://github.com/NixOS/nixpkgs/commit/80f2bb9041b4e7c899a1eaee53529e68cb0e3f3a) linuxPackages.nvidiaPackages.vulken_beta: 595.44.03 -> 595.44.05
* [`fb483a1e`](https://github.com/NixOS/nixpkgs/commit/fb483a1efa7c2cfe3ad72378d185ede3fcdfa158) pyroscope: fix package tag (1.18.1 -> 1.19.1)
* [`1a919d95`](https://github.com/NixOS/nixpkgs/commit/1a919d95253392e82c1b2fc5823a51e877ba486f) postgresqlPackages.pg_search: 0.22.4 -> 0.22.5
* [`d58be298`](https://github.com/NixOS/nixpkgs/commit/d58be2983b1d776f6f188a248603dba4684ebd40) kurve: 3.5.0 -> 3.5.1
* [`03a050cb`](https://github.com/NixOS/nixpkgs/commit/03a050cbe1ccd4b074495b9714c9b8b3feb17f9f) cargo-vet: 0.10.1 -> 0.10.2
* [`33d4ab86`](https://github.com/NixOS/nixpkgs/commit/33d4ab869b2885621bc74b8b2e7763afc97f9895) cargo-vet: add ilkecan to maintainers
* [`f46da4b1`](https://github.com/NixOS/nixpkgs/commit/f46da4b139eedc2e96a88ab2e73635366c9cb7a5) python3Packages.stripe: 14.4.1 -> 15.0.1
* [`abfac116`](https://github.com/NixOS/nixpkgs/commit/abfac11651324e7ec9938471c1e90ab060ea2a28) dawarich: 1.3.4 -> 1.6.1
* [`6aba2da9`](https://github.com/NixOS/nixpkgs/commit/6aba2da99ecb71eefa0909b322e786df7444b86c) greed: 4.3 -> 4.5
* [`2aa8856c`](https://github.com/NixOS/nixpkgs/commit/2aa8856cf99e61b1aa2ff7b67c98e3c3af40205c) hey-mail: 1.2.17 -> 1.3.1
* [`99b0cc81`](https://github.com/NixOS/nixpkgs/commit/99b0cc81fa31b4bd32320c18e935a7520109494d) poptracker: 0.34.0 -> 0.35.0
* [`3d3dd2dc`](https://github.com/NixOS/nixpkgs/commit/3d3dd2dc8f5fbc21df791b6314f5f749fd4bff4a) libretro.neocd: 0-unstable-2024-10-21 -> 0-unstable-2026-03-31
* [`69175ad7`](https://github.com/NixOS/nixpkgs/commit/69175ad7ff06cbcacb1a73f923b6f287f0b5a790) nexa: init at 0.2.73
* [`6b157b57`](https://github.com/NixOS/nixpkgs/commit/6b157b57dbe1ce639dac75db6601556805e3dd2f) xash: 0-unstable-2026-02-25 -> 0-unstable-2026-04-03
* [`b719d987`](https://github.com/NixOS/nixpkgs/commit/b719d987c5e475f2702c354f9c81c5da7a489ef5) rs-tftpd: 0.5.2 -> 0.5.3
* [`f64e43e4`](https://github.com/NixOS/nixpkgs/commit/f64e43e4ad1c54b9d6a696c97bf39d33c7c1fa88) eigenwallet: 4.1.0 -> 4.2.4
* [`362efc76`](https://github.com/NixOS/nixpkgs/commit/362efc76fb9bb3c710908602556489448fdb77fb) odafileconverter: fix .desktop file
* [`9d4597d7`](https://github.com/NixOS/nixpkgs/commit/9d4597d7dbf091deac9c094fc2b60ec973ada1a7) ossia-score: 3.8.1 -> 3.8.2
* [`fc252263`](https://github.com/NixOS/nixpkgs/commit/fc252263c2b414be82598b0bc78d2483542cb7d0) kaminpar: 3.7.2 -> 3.7.3
* [`9a2e28f5`](https://github.com/NixOS/nixpkgs/commit/9a2e28f58b937b0d78ec877f67d33ed231cd7556) rcp: 0.21.1 -> 0.31.0
* [`266226e6`](https://github.com/NixOS/nixpkgs/commit/266226e64bedc4951ccc39169e374ba99717bb53) automatic-timezoned: 2.0.124 -> 2.0.125
* [`39197fac`](https://github.com/NixOS/nixpkgs/commit/39197fac4958654f18e8b41b2b9e2ad7884b8481) pikchr: 0-unstable-2026-01-02 -> 0-unstable-2026-04-03
* [`58948fd7`](https://github.com/NixOS/nixpkgs/commit/58948fd76bccaaf426d1e44b5c57816cda3b5e25) python3Packages.succulent: 0.4.3 -> 0.4.4
* [`2d759ec0`](https://github.com/NixOS/nixpkgs/commit/2d759ec0ba28e10a8189699b9a01a72ac5ef7ea8) kubevela: 1.10.7 -> 1.10.8
* [`588bc149`](https://github.com/NixOS/nixpkgs/commit/588bc1493fc5b50367ee00c4c3c02940b85ffdaf) mtx: fix build failure
* [`cfb3ae95`](https://github.com/NixOS/nixpkgs/commit/cfb3ae95f208a36f9295f393b57c05d9a8f7d556) bird3: 3.2.0 -> 3.2.1
* [`6a3412b4`](https://github.com/NixOS/nixpkgs/commit/6a3412b49a0a482453d55dbcdac2866a20cbe2c9) fteqw: fix build
* [`eb9b20d3`](https://github.com/NixOS/nixpkgs/commit/eb9b20d313be7e12c561127a7bc605bcf3781fc2) release-cross: remove redox
* [`1c121257`](https://github.com/NixOS/nixpkgs/commit/1c121257af6f8a7893c6005884be4deb62ac2679) buildkit: 0.28.1 -> 0.29.0
* [`261366ba`](https://github.com/NixOS/nixpkgs/commit/261366ba0c0c4ed44b8a638b3056a57bc493c81d) vscode-extensions.wakatime.vscode-wakatime: 29.0.3 -> 30.0.4
* [`ee8bab0c`](https://github.com/NixOS/nixpkgs/commit/ee8bab0c2908dd9db6fb5957b4cf9a805df66367) python3Packages.ignite: 0.5.3 -> 0.5.4
* [`93acef76`](https://github.com/NixOS/nixpkgs/commit/93acef76fe3f95d5bc030199809b5d40a298b5af) python3Packages.fluss-api: 0.1.9.20 -> 0.2.0
* [`65867338`](https://github.com/NixOS/nixpkgs/commit/65867338be7e756d7b992643ee04a89a0b9e8fbf) vscode-extensions.foam.foam-vscode: 0.33.0 -> 0.35.0
* [`96b1fff2`](https://github.com/NixOS/nixpkgs/commit/96b1fff2db51285ff7aeb84abec12885821b4736) vscode-extensions.waderyan.gitblame: 13.0.0 -> 13.0.1
* [`443d06dc`](https://github.com/NixOS/nixpkgs/commit/443d06dce6a2f0bf7bb6ecdf223f90e91d442d44) vscode-extensions.prisma.prisma: 31.6.0 -> 31.8.0
* [`839a7292`](https://github.com/NixOS/nixpkgs/commit/839a72923371688b2fa01ca2a9a0a8d82bb647a0) multivnc: fix semver
* [`6c6ef070`](https://github.com/NixOS/nixpkgs/commit/6c6ef070c44e270cf8898bdae75a956caff3f1c3) arkade: 0.11.91 -> 0.11.92
* [`0aeb7a09`](https://github.com/NixOS/nixpkgs/commit/0aeb7a099a22e5777cb46ce1042d44752e2068e8) python3Packages.whenever: 0.10.0b2 -> 0.10.0b3
* [`7fb210d2`](https://github.com/NixOS/nixpkgs/commit/7fb210d2bcffc0459a9c3095049a0eb7214dcc7f) libretro-shaders-slang: 0-unstable-2026-03-16 -> 0-unstable-2026-04-03
* [`ce246cd3`](https://github.com/NixOS/nixpkgs/commit/ce246cd37193f7038b6805a67241bae4d381141f) sogo: 5.12.4 -> 5.12.7
* [`a338deb8`](https://github.com/NixOS/nixpkgs/commit/a338deb8a1d11ead60c3d20b03f466b745514c38) lib/services: move portable service infrastructure out of nixos/
* [`dce9b149`](https://github.com/NixOS/nixpkgs/commit/dce9b149ffc4d72df62a1c1f5309a432dc0560bd) ddns-go: 6.16.2 -> 6.16.4
* [`ee2d68e0`](https://github.com/NixOS/nixpkgs/commit/ee2d68e0b5a5542f097d1a7e9102c9a7660c4610) python3Packages.flask-compress: 1.23 -> 1.24
* [`a7947b66`](https://github.com/NixOS/nixpkgs/commit/a7947b664b0736d71d776a6d4e530cd3248383b1) amdgpu_top: 0.11.2 -> 0.11.3
* [`959920e3`](https://github.com/NixOS/nixpkgs/commit/959920e31a128ce8d10e3312bc548f4c24db7cdd) python3Packages.edk2-pytool-library: 0.23.11 -> 0.23.12
* [`0782c1cd`](https://github.com/NixOS/nixpkgs/commit/0782c1cdc7e36b6e30232cf2034c0cee39669f3a) typos-lsp: 0.1.50 -> 0.1.51
* [`bf2329ea`](https://github.com/NixOS/nixpkgs/commit/bf2329ea02728323866a1f59dcbe5edabd5a1c14) sone: init at 0.14.1
* [`9649d22e`](https://github.com/NixOS/nixpkgs/commit/9649d22e6b6bedc071c3e254af5ecd8978e9d524) meshoptimizer: 1.0.1 -> 1.1
* [`f41372db`](https://github.com/NixOS/nixpkgs/commit/f41372db10f7108c5e098b06be6a5b574fef12fb) inventree: Init at 1.2.6
* [`1baf57f3`](https://github.com/NixOS/nixpkgs/commit/1baf57f3a0a12a99c1f1e74134e3df09c6ef7bfb) nixos/modules/docs: fix documentation build
* [`abd5a162`](https://github.com/NixOS/nixpkgs/commit/abd5a162c1de5ddb2800d40a1c42536006838d9c) python3Packages.sphinx-togglebutton: 0.4.4 -> 0.4.5
* [`2f636795`](https://github.com/NixOS/nixpkgs/commit/2f636795fd33a3d1b2bfb7df21a1bb900767c431) laravel: 5.24.10 -> 5.25.2
* [`d88651d8`](https://github.com/NixOS/nixpkgs/commit/d88651d80b1eed99ecb09691edf1a63ece9772c7) netbox_4_5: 4.5.5 -> 4.5.7
* [`e0507a0d`](https://github.com/NixOS/nixpkgs/commit/e0507a0d770d620d0165d1f8e050d57de668f3c0) python3Packages.web3: 7.14.1 -> 7.15.0
* [`be488cb0`](https://github.com/NixOS/nixpkgs/commit/be488cb0e20f674795c598766c07423f6146785f) octodns-providers.gandi: 1.1.0 -> 1.2.0
* [`9fdde482`](https://github.com/NixOS/nixpkgs/commit/9fdde482abd8d8b4a5a3cd0f333357c29083c7e1) doc: document `pkgs<theirHost><theirTarget>` better
* [`dd921753`](https://github.com/NixOS/nixpkgs/commit/dd921753e5fd969fc5fef5e25f3c49d724ce1e89) opengamepadui: 0.44.3 -> 0.45.0
* [`67bb7b8f`](https://github.com/NixOS/nixpkgs/commit/67bb7b8fbf4c492ea81715dd0724791f6ea71471) intiface-central: 3.0.0 -> 3.0.4+40
* [`cd0acd1a`](https://github.com/NixOS/nixpkgs/commit/cd0acd1a3b8ef132dcbb26023619c6a195df3be8) argocd: 3.3.5 -> 3.3.6
* [`474a028d`](https://github.com/NixOS/nixpkgs/commit/474a028dad5a8a2b3cb28b34d4ae26fa3dcc56d1) inspircd: 4.9.0 -> 4.10.0
* [`a67a3732`](https://github.com/NixOS/nixpkgs/commit/a67a373271dba96d140dd8572319f5a23d2eab13) typos: 1.44.0 -> 1.45.0
* [`298f96eb`](https://github.com/NixOS/nixpkgs/commit/298f96ebd6dc31b7cd6e76cffd43b3f673e589a6) leetgo: 1.4.16 -> 1.4.17
* [`a1e83cbd`](https://github.com/NixOS/nixpkgs/commit/a1e83cbd19b8d5369bf475dd0bdfa4e392ee5f28) lilex: 2.621 -> 2.700
* [`99a5ae7c`](https://github.com/NixOS/nixpkgs/commit/99a5ae7c7b62423e35b3330b6fc45950848ac6d2) matrix-alertmanager-receiver: 2026.3.25 -> 2026.4.1
* [`9847fee5`](https://github.com/NixOS/nixpkgs/commit/9847fee5ab36bdd57d6d59571253ff764a294d7a) catimg: 2.7.0 -> 2.8.0
* [`9b11cc90`](https://github.com/NixOS/nixpkgs/commit/9b11cc90ea247391e3bc4ae18b1cea8a208a87e4) roon-server: 2.62.1641 -> 2.64.1646
* [`b6570d71`](https://github.com/NixOS/nixpkgs/commit/b6570d712e3b50dcb45912d18a1e37a0e477d586) dolibarr: 23.0.0 -> 23.0.2
* [`7d90cce6`](https://github.com/NixOS/nixpkgs/commit/7d90cce6417c241936dada82f51945197819cb59) cargo-diet: 1.2.7 -> 1.3.0
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
