### PR TITLE
npins home-manager: update 5de7dbd1 -> 8a423e44

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -61,9 +61,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "5de7dbd151b0bd65d45785553d4a22d832733ffc",
-      "url": "https://github.com/nix-community/home-manager/archive/5de7dbd151b0bd65d45785553d4a22d832733ffc.tar.gz",
-      "hash": "sha256-ikws/ssAmG20AGrEwBuwspwPlkubJu34mB+Uz2fJBJs="
+      "revision": "8a423e444b17dde406097328604a64fc7429e34e",
+      "url": "https://github.com/nix-community/home-manager/archive/8a423e444b17dde406097328604a64fc7429e34e.tar.gz",
+      "hash": "sha256-b2pu3Pb28W0bJzQVP3OJHZC5+dgOOeqjlli2WVakKEU="
     },
     "hs-grille": {
       "type": "Git",


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@5de7dbd1...8a423e44](https://github.com/nix-community/home-manager/compare/5de7dbd151b0bd65d45785553d4a22d832733ffc...8a423e444b17dde406097328604a64fc7429e34e)

* [`2bd16b16`](https://github.com/nix-community/home-manager/commit/2bd16b16a77d68a1e14c1b4da725a6590181a706) Translate using Weblate (Catalan)
* [`4bdfeff1`](https://github.com/nix-community/home-manager/commit/4bdfeff1d9b7473e6e58f73f5809576e8a69e406) syncthing: set systemd start limits
* [`b0cf7b52`](https://github.com/nix-community/home-manager/commit/b0cf7b520c7dfad888ba9c61c563028fccc8afe8) vicinae: refresh app list on activation
* [`d65fb79d`](https://github.com/nix-community/home-manager/commit/d65fb79dcc860f920c54e200f8db8373501bc758) maintainers: add philip-730
* [`92d382b9`](https://github.com/nix-community/home-manager/commit/92d382b9821aad4036b9b7e4270a959f24909a67) programs.wezterm: add settings option
* [`530d83a5`](https://github.com/nix-community/home-manager/commit/530d83a5a81778b9191e0130a672ad9274e2c0fb) programs.wezterm: add philip-730 as maintainer
* [`9cc76116`](https://github.com/nix-community/home-manager/commit/9cc761169a1bbf1d9787cdbe9abf07f4bae213a1) tmuxinator: use yml file ending
* [`98b4d61c`](https://github.com/nix-community/home-manager/commit/98b4d61cfaf825c8b691afae0b6e152f0cc05c86) neovim: disable python3 and ruby providers by default
* [`3d822c1d`](https://github.com/nix-community/home-manager/commit/3d822c1dbae858138189262ed194d3bbb3007a77) dbeaver: init module
* [`6f35bb97`](https://github.com/nix-community/home-manager/commit/6f35bb97991f796f1f19734dc3db0f4c50b14e18) tmux: use idempotent new-session to avoid duplicate sessions
* [`41f55c24`](https://github.com/nix-community/home-manager/commit/41f55c248a372215c75da2e1b4fe94200cc6a2f5) ci: limit number of automated reviewer requests
* [`c59483f8`](https://github.com/nix-community/home-manager/commit/c59483f8dca2200bba13a9c2cf4c3a4a78754464) ci: improve robustness of maintainer extraction
* [`f0c13b0e`](https://github.com/nix-community/home-manager/commit/f0c13b0ebc4a5b7780954ab6a97d231f90bf5e6b) ci: limit labeler to small pull requests
* [`34cb41ef`](https://github.com/nix-community/home-manager/commit/34cb41efe49c8058c03b252a7b25057afdb48616) ci: fix labeler file count logic
* [`527e47b7`](https://github.com/nix-community/home-manager/commit/527e47b78fe67213072f706bf933a9705a8c4974) files: handle overlapping file targets
* [`dd827824`](https://github.com/nix-community/home-manager/commit/dd82782450195b62a3bc3e55330e50ab7e51b7a1) flake.lock: Update
* [`991a0017`](https://github.com/nix-community/home-manager/commit/991a0017519e10fb0e5400460566a157d1c5ed2c) mu: KarlJoad -> ravenjoad
* [`4a0ded6f`](https://github.com/nix-community/home-manager/commit/4a0ded6f84553c2fcf2c3c7d8371e1ecaa06b808) mbsync: KarlJoad -> ravenjoad
* [`4ac0a4fd`](https://github.com/nix-community/home-manager/commit/4ac0a4fd1537325d769377d574dccd10b97c28a2) maintainers: update all-maintainers
* [`7843c002`](https://github.com/nix-community/home-manager/commit/7843c0025a16c87dc57193fd791ceb36ea39a709) vicinae: fix x-restart triggers
* [`9ddbb69d`](https://github.com/nix-community/home-manager/commit/9ddbb69d184407c484fed211cb94229d21ecc75c) vicinae: guard refresh-apps activation
* [`01ea51d7`](https://github.com/nix-community/home-manager/commit/01ea51d7065e0ab06a09df9db4d1c17f6eb2675f) treewide: use inherit for attribute assignments
* [`58a6be9f`](https://github.com/nix-community/home-manager/commit/58a6be9faed2212b70a9b4fd6adf538daa2677d5) git: ignore statix inherit commit
* [`74d8d470`](https://github.com/nix-community/home-manager/commit/74d8d470345b9324f89e14d675c14b92dc4a091d) statix: enable collapsible_let_in
* [`838db3b5`](https://github.com/nix-community/home-manager/commit/838db3b5a897c1711489b5052705eed6a707ae0d) git: ignore statix collapsible let in cleanup
* [`5209a256`](https://github.com/nix-community/home-manager/commit/5209a256fd507322b0dd09ade7bc61923da948cf) statix: enable empty_list_concat
* [`11ad9d2e`](https://github.com/nix-community/home-manager/commit/11ad9d2e42ebf6d00db4d7bae252f1c6b7dd36a4) statix: enable useless_has_attr
* [`74b0e979`](https://github.com/nix-community/home-manager/commit/74b0e979375b0ed469e2394820aa50ba2114800b) statix: enable empty_pattern
* [`de90ee24`](https://github.com/nix-community/home-manager/commit/de90ee24082bb8dd44145f5c733b807467856820) statix: enable eta_reduction
* [`f04b520e`](https://github.com/nix-community/home-manager/commit/f04b520e5b01e02a975004ddf5803877fcce009b) git: ignore more statix cleanup commits
* [`23019980`](https://github.com/nix-community/home-manager/commit/230199801b00c63f0fdde3e7e77fc8770b5dcd8f) statix: enable misc rules that we already respect
* [`35f8c398`](https://github.com/nix-community/home-manager/commit/35f8c398b46c9f3d996149451ccd1bfbefa5f0c0) atuin: add default value for log.dir
* [`7ba4ee42`](https://github.com/nix-community/home-manager/commit/7ba4ee4228ed36123c7cb75d50524b43514ef992) thunderbird: allow configuration of EWS accounts
* [`2877554a`](https://github.com/nix-community/home-manager/commit/2877554a72fed1a1ca8bc805e494bfe3f8b144c9) programs.nheko: link to upstream issue in description for settings
* [`c975a66a`](https://github.com/nix-community/home-manager/commit/c975a66a56306b38eaa3108f54bbc11e213f42f6) niriswitcher: remove module
* [`505e91f8`](https://github.com/nix-community/home-manager/commit/505e91f877dab9754c9d4197bc92927342c4c31e) glance: add darwin support
* [`0f9090a7`](https://github.com/nix-community/home-manager/commit/0f9090a77c7af9eafcc79394ac3d258a438f722d) aerc: encode username in account URLs
* [`5ef2b986`](https://github.com/nix-community/home-manager/commit/5ef2b9862f34e3a65b212fd6295224b91d664141) gemini-cli: add skills option
* [`5c663d57`](https://github.com/nix-community/home-manager/commit/5c663d57811fb584182c65c4bb84d63771c98d4f) gemini-cli: add option for integration with `programs.mcp.servers`
* [`a91f37ef`](https://github.com/nix-community/home-manager/commit/a91f37efbaa4572d1e855581be5cc5077a316778) services.darkman: add unified scripts option
* [`7f6c5834`](https://github.com/nix-community/home-manager/commit/7f6c5834caef6a289d3515cff09d8537a7157e93) neovim: change the plugin default type from viml -> lua
* [`fbc97e23`](https://github.com/nix-community/home-manager/commit/fbc97e23f6a7440de1ed6d54759a3e29ecea04ea) lib/deprecations: improve submodule warning support
* [`0eddb2cc`](https://github.com/nix-community/home-manager/commit/0eddb2cc1abc5692935308c5efb4035c023bddc7) neovim: use improved submodule deprecation detection
* [`e35c39fc`](https://github.com/nix-community/home-manager/commit/e35c39fca04fee829cecdf839a50eb9b54d8a701) tmux: reduce default escapeTime
* [`f7f6a559`](https://github.com/nix-community/home-manager/commit/f7f6a559c21dfe5e63108ded0d036ae15e6e9d57) xdg: add support for local bin path
* [`f899c5d6`](https://github.com/nix-community/home-manager/commit/f899c5d6f3aee046fd7cc33acc690ad51da7d87c) pipewire: add module
* [`fb821d64`](https://github.com/nix-community/home-manager/commit/fb821d642253f830d4ccff100b020ab08e191c34) fresh-editor: add extra packages option
* [`b0569dc6`](https://github.com/nix-community/home-manager/commit/b0569dc6ec1e6e7fefd8f6897184e4c191cd768e) fresh-editor: add defaultEditor option
* [`e0ca734f`](https://github.com/nix-community/home-manager/commit/e0ca734ffc85d25297715e98010b93303fa165c4) starship: add extraPackages options
* [`0c8ef0f2`](https://github.com/nix-community/home-manager/commit/0c8ef0f2b93a769cbcbbf83724a2a7db5dbd92ef) jjui: Fix default config directory path on Darwin
* [`44111a5c`](https://github.com/nix-community/home-manager/commit/44111a5c6f78da5c024f222fec352e8ec49d1bc1) jjui: Add options to configure settings in Lua including plugins
* [`23d85301`](https://github.com/nix-community/home-manager/commit/23d85301a5d330f4178774019027c1dc46833a31) copyApps: skip check when migrating from linkApps
* [`fd22058b`](https://github.com/nix-community/home-manager/commit/fd22058b436fd996825e70204b5b38853d9da1d5) copyApps: fix linkApps migration
* [`adf6e3aa`](https://github.com/nix-community/home-manager/commit/adf6e3aafb8e0ad38051b8be41d67b2dbb2cf598) feedr: add module
* [`46ecfa22`](https://github.com/nix-community/home-manager/commit/46ecfa22a61158a811c9f6569543fb7c7a2a75ac) antidote: improve escaping of shell arguments & use pkgs.writeText
* [`89b2d575`](https://github.com/nix-community/home-manager/commit/89b2d575eec0a853c236d01dcd0d2f37bc2b124c) zsh/oh-my-zsh: improve escaping of shell arguments
* [`ffa740c0`](https://github.com/nix-community/home-manager/commit/ffa740c0dfbee917b8bc36efb1c2be46e0dde164) syshud: add module
* [`13df3b4e`](https://github.com/nix-community/home-manager/commit/13df3b4e44bf4784a4167d3b09198e555ef2219c) claude-code: migrate `memory` to `context` & `skills{,Dir}` to `skills`
* [`447796d6`](https://github.com/nix-community/home-manager/commit/447796d64a9ac736b83ff348aa00167cd2c4855d) codex: migrate `custom-instructions` to `context`
* [`d6d2468b`](https://github.com/nix-community/home-manager/commit/d6d2468b88488c141a905e22f57883fb2cb0b83b) opencode: migrate `rules` to `context`
* [`16e50c6f`](https://github.com/nix-community/home-manager/commit/16e50c6ffea28f1999d6cb34dcee1ad0d479d690) gemini-cli: unify `context` description and let `skills` be a directory
* [`30ca31c8`](https://github.com/nix-community/home-manager/commit/30ca31c87a9bfa2c1315330f977ff63356907453) news: add entry about the unification of agents "context" and "skills"
* [`7832a664`](https://github.com/nix-community/home-manager/commit/7832a664c40c98a2dcf45400f60d0f70f8b6fd19) feedr: fix enable option description
* [`f6196e5b`](https://github.com/nix-community/home-manager/commit/f6196e5b4d3f0168d09feab9ba678fa18ca58cbb) oh-my-zsh: Fix plugins escapeShellArgs use
* [`adc677d0`](https://github.com/nix-community/home-manager/commit/adc677d02ead017dcb2d03198209fed54cc5ee52) kakoune: remove unused options
* [`49088dc2`](https://github.com/nix-community/home-manager/commit/49088dc2e7a876e338e510c5f5f60f659819c650) syncthing: rewrite credential management
* [`a5e824c8`](https://github.com/nix-community/home-manager/commit/a5e824c8626dba88fb1c627e5f220d91727c5dde) opencode: align commands directory with upstream documentation
* [`26c9d5dc`](https://github.com/nix-community/home-manager/commit/26c9d5dca1eee9556bb2b256ad2616eb39111980) opencode: align agents directory with upstream documentation
* [`287f8484`](https://github.com/nix-community/home-manager/commit/287f84846c1eb3b72c986f5f6bebcff0bd67440d) opencode: align tools directory with upstream documentation
* [`2de7205c`](https://github.com/nix-community/home-manager/commit/2de7205ce6e10b031151033e69b7ef89708dc282) maintainers: update all-maintainers.nix
* [`71402c5d`](https://github.com/nix-community/home-manager/commit/71402c5df34df5ee7b6c10d738018f9f0c8bde2b) treewide: mark unused lambda arguments
* [`a93d80bc`](https://github.com/nix-community/home-manager/commit/a93d80bcec089abf80894c25ee3934b7e196bbd9) treewide: remove unused attrs patterns
* [`5a728e43`](https://github.com/nix-community/home-manager/commit/5a728e434d12df6f2e6bfb064e918dab2460f426) tests/integration: simplify `pkgs.linkFarm` usage
* [`970cd853`](https://github.com/nix-community/home-manager/commit/970cd853bfb4fb97729415521389e7d71f3b4b62) hyprland: use previously unused lambda parameter
* [`5843fa30`](https://github.com/nix-community/home-manager/commit/5843fa302bbd5028e5c2a2f9ea4b57f772a2f22d) ci: migrate to Dependabot for nix flake updates
* [`eff7ee75`](https://github.com/nix-community/home-manager/commit/eff7ee75f0881e08c500fe90d43607a0b3f923d5) ci: add release branch label
* [`78f7d3d6`](https://github.com/nix-community/home-manager/commit/78f7d3d6ab306643de47d2ba0f509e9b6ca5506f) git: ignore deadnix treewide blame
* [`8a423e44`](https://github.com/nix-community/home-manager/commit/8a423e444b17dde406097328604a64fc7429e34e) ci: adjust flake lock update pr titles
