### PR TITLE
npins nixpkgs: update 13043924 -> 566acc07

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -132,8 +132,8 @@
     "nixpkgs": {
       "type": "Channel",
       "name": "nixpkgs-unstable",
-      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-26.05pre978638.13043924aaa7/nixexprs.tar.xz",
-      "hash": "sha256-qTVvODr6edFBLD2lncXPF8yTQeCafZUuKVtpV3Xb3yM="
+      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-26.05pre980800.566acc07c54d/nixexprs.tar.xz",
+      "hash": "sha256-bo9Hbl5yPjDRldsn1Stnbsmn/nPF0cVlowuLSGHduuA="
     },
     "powerlevel10k": {
       "type": "Git",


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: release-26.05
Commits: [nixos/nixpkgs@13043924...566acc07](https://github.com/nixos/nixpkgs/compare/13043924aaa7...566acc07c54d)

* [`1bc1e275`](https://github.com/NixOS/nixpkgs/commit/1bc1e2755c91336284b6aff295fe95bf953cfa14) remarkable-mouse: add missing dependency
* [`af6aee18`](https://github.com/NixOS/nixpkgs/commit/af6aee18fe1d9aab5ad522acb24cc0eab92d0986) remarkable-mouse: 7.1.1 -> unstable-2024-02-23
* [`40d2be94`](https://github.com/NixOS/nixpkgs/commit/40d2be94285c4c80d1107675594f99ca1583b2ab) nixos/peering-manager: replace grab_prefixes with get_irr_data
* [`26aa9a9f`](https://github.com/NixOS/nixpkgs/commit/26aa9a9f87935d616977748902a2da9d1c0635a4) nixos/wordpress: add finalPackage attribute
* [`76d004cd`](https://github.com/NixOS/nixpkgs/commit/76d004cde0a8831693ce1f5bbe1cede464bdc8be) python313Packages.asyncio-dgram: 2.2.0 -> 3.0.0
* [`7eab10d4`](https://github.com/NixOS/nixpkgs/commit/7eab10d4130c2fbe91a8fcbf25c2969aee07aae3) python313Packages.asyncio-dgram: migrate to finalAttrs
* [`ede03b9d`](https://github.com/NixOS/nixpkgs/commit/ede03b9dcfc464f11c969ec904fb704edbf2ea47) nixosTests.gitlab.runner: add garbage collection to daemon
* [`08ffe3e2`](https://github.com/NixOS/nixpkgs/commit/08ffe3e209de57456bc703d67b01f0f309512d65) yacreader: 9.15.0 -> 9.16.3
* [`23043ef3`](https://github.com/NixOS/nixpkgs/commit/23043ef3a0be40eff80050f62d2a3074425a8fbe) cxxtest: migrate to by-name
* [`c5e8c25a`](https://github.com/NixOS/nixpkgs/commit/c5e8c25a060c9901e2ebb00ce07c75d14549f09c) pure-ftpd: 1.0.52 -> 1.0.53
* [`0553e319`](https://github.com/NixOS/nixpkgs/commit/0553e31990eea0b2b36d2a83983ec09b79bb1658) libvisio2svg: 0.5.6 -> 0.5.8
* [`c6b665d3`](https://github.com/NixOS/nixpkgs/commit/c6b665d373eb36a18b6e9ad7d1594957b8b12e7f) tqsl: 2.8.2 -> 2.8.4
* [`ba52c960`](https://github.com/NixOS/nixpkgs/commit/ba52c96059a084b9aa6622016c010f3f52ac4004) asunder: 3.0.1 -> 3.0.2
* [`6b2ce710`](https://github.com/NixOS/nixpkgs/commit/6b2ce71060df376d599347d49605d53b5768bed0) shot-scraper: 1.9 -> 1.9.1
* [`90cf19a8`](https://github.com/NixOS/nixpkgs/commit/90cf19a85c010ad61e398f919c750177b2a09b42) elinks: 0.19.0 -> 0.19.1
* [`e88e2da9`](https://github.com/NixOS/nixpkgs/commit/e88e2da91ffae4d76fbdee81f8a4d79787834cc5) yapesdl: 0.80.1 -> 0.81.1
* [`98f26b48`](https://github.com/NixOS/nixpkgs/commit/98f26b485a6a33c674040113c839bdb5ba8a7ce8) nfdump: 1.7.6 -> 1.7.7
* [`4dccee9d`](https://github.com/NixOS/nixpkgs/commit/4dccee9dae28f4b25d69ea4129eab129816cf8ed) glslviewer: 3.5.1 -> 3.5.2
* [`2b1c8c0f`](https://github.com/NixOS/nixpkgs/commit/2b1c8c0f90715e8dfa2dfb0be293485d2a3836f4) xbps: 0.60.6 -> 0.60.7
* [`f9e77374`](https://github.com/NixOS/nixpkgs/commit/f9e7737427873e854e12ee3ee55963b41912dd46) zexy: 2.4.3 -> 2.4.4
* [`ed225aaa`](https://github.com/NixOS/nixpkgs/commit/ed225aaa84b793cec4789a683f91b8f8867fa4d6) thermald: 2.5.10 -> 2.5.11
* [`eef71f1b`](https://github.com/NixOS/nixpkgs/commit/eef71f1b209700467392149ff0c97fca4fbe7d84) x42-gmsynth: 0.6.3 -> 0.6.4
* [`0b801dd7`](https://github.com/NixOS/nixpkgs/commit/0b801dd71cbd7ae17942e8c6ad588def724919a1) xlockmore: 5.87 -> 5.88
* [`90b78ca5`](https://github.com/NixOS/nixpkgs/commit/90b78ca5a092aea7c4128d352e7a22ea1ebe568b) florist: 24.2 -> 26.1
* [`32978b37`](https://github.com/NixOS/nixpkgs/commit/32978b37825513f4ba28f0a164142b577d707c92) druid: 34.0.0 -> 36.0.0
* [`47ab5522`](https://github.com/NixOS/nixpkgs/commit/47ab5522b7c6da584d6c6d1d9c73976e7ec5804a) python3Packages.pypiserver: 2.4.0 -> 2.4.1
* [`8c874b2b`](https://github.com/NixOS/nixpkgs/commit/8c874b2b5fafd82597932db38e45069ecfd05434) mosdepth: 0.3.12 -> 0.3.13
* [`61986ae1`](https://github.com/NixOS/nixpkgs/commit/61986ae1db978ef6752e6fc0baad504fdb0cf3b5) jsonnet-language-server: 0.16.0 -> 0.17.0
* [`52836902`](https://github.com/NixOS/nixpkgs/commit/5283690260c8ebd3b41829bdca6b7052818de18d) dazel: migrate to by-name
* [`2c39b0b8`](https://github.com/NixOS/nixpkgs/commit/2c39b0b82206c3c4f1614d37e63ac3045e377d6b) dazel: switch to finalAttrs
* [`2af134f8`](https://github.com/NixOS/nixpkgs/commit/2af134f83a8802f62d76bd3be77df364dc3d9fa6) ginac: 1.8.9 -> 1.8.10
* [`03d37494`](https://github.com/NixOS/nixpkgs/commit/03d37494d205b5da2a9502c83fbf8a7b13f45bf1) debos: 1.1.5 -> 1.1.7
* [`fa9e7043`](https://github.com/NixOS/nixpkgs/commit/fa9e70433c66f23d0086363e162a8649ca4113e1) wiki-js: 2.5.311 -> 2.5.312
* [`e9550f73`](https://github.com/NixOS/nixpkgs/commit/e9550f73a288b05ebf9987f3d821bd0a91efb9ac) asmrepl: migrate to pkgs/by-name
* [`6be28121`](https://github.com/NixOS/nixpkgs/commit/6be281212cdeafddce4e3b80a874b29d128df9d8) asmrepl: update bundler dependencies
* [`c2f61ddd`](https://github.com/NixOS/nixpkgs/commit/c2f61dddda94cb6f6fde53e104ca375fb1d5b5ba) asmrepl: 1.0.3 -> 1.2.0
* [`936facdd`](https://github.com/NixOS/nixpkgs/commit/936facddd30477503b7ed6c1c978df17316a82ea) prometheus-frr-exporter: fix group
* [`21b40b0d`](https://github.com/NixOS/nixpkgs/commit/21b40b0d4976a592a5c00a0aaa844568170f8306) mautrix-slack: 25.11 -> 26.02
* [`d92b2507`](https://github.com/NixOS/nixpkgs/commit/d92b25079f657852085ba2341145a1ee1baa8668) caido: split into caido-cli and caido-desktop
* [`896010e0`](https://github.com/NixOS/nixpkgs/commit/896010e08afb65095ecffbde920e4f9b91155d12) ocamlPackages.dns: 10.2.3 -> 10.2.4
* [`dfe75f20`](https://github.com/NixOS/nixpkgs/commit/dfe75f202bc784232d949f644c690ab091f3471a) maintainers: add bartoostveen
* [`64200a80`](https://github.com/NixOS/nixpkgs/commit/64200a80613cda3654d6bc570d15274192f76fd0) prometheus-fail2ban-exporter: init at 0.10.3
* [`bc6335aa`](https://github.com/NixOS/nixpkgs/commit/bc6335aa3bb22177e8b0c123e780321adff8ff42) logisim-evolution: 4.0.0 -> 4.1.0
* [`852ce9ce`](https://github.com/NixOS/nixpkgs/commit/852ce9cee188078cd40c5aa222c9be241f0dbfac) opl3bankeditor: migrate to by-name, hardcode values
* [`d97f4dd2`](https://github.com/NixOS/nixpkgs/commit/d97f4dd2abe5ac658c820a8f154756ebe12d0bfd) opl3bankeditor: modernize derivation, switch to finalAttrs
* [`6f5cef5c`](https://github.com/NixOS/nixpkgs/commit/6f5cef5ce039aa6db2b65cb46e140720243ac1c5) opn2bankeditor: migrate to by-name, hardcode values
* [`3b1d00b3`](https://github.com/NixOS/nixpkgs/commit/3b1d00b3fe769a9ba2f772c454a824c7fbfcc6c4) opn2bankeditor: modernize derivation
* [`ce5dcbf1`](https://github.com/NixOS/nixpkgs/commit/ce5dcbf15cc119eb2b6e123370b5076cbc8f910a) opl3bankeditor: remove common file
* [`5046d0ac`](https://github.com/NixOS/nixpkgs/commit/5046d0ac80bb9bee73fe6e54d38844fac0412f65) lutris-unwrapped: 0.5.20 -> 0.5.22
* [`1d769388`](https://github.com/NixOS/nixpkgs/commit/1d76938896f58994a1a86eedf3888aa555d8b225) dart.flutter_vodozemac: add 0.5.0 version
* [`5831c2ea`](https://github.com/NixOS/nixpkgs/commit/5831c2ea98567809a760f3080252a2a28c5a050a) mindustry: 154.3 → 155.4
* [`af3450f3`](https://github.com/NixOS/nixpkgs/commit/af3450f35ae5e9fe0a83030d4c301541e71c1735) nixpkgs/aliases: add backward compat alias for caido -> caido-desktop
* [`7aabe3a1`](https://github.com/NixOS/nixpkgs/commit/7aabe3a1aa31e4206b81baa17a891215758a3eb6) quickemu: add coreutils to path
* [`749d2ae0`](https://github.com/NixOS/nixpkgs/commit/749d2ae0c8cbd9b341305f3461d20feabe925619) yo: 5.1.0 -> 7.0.0
* [`d4f1ad9f`](https://github.com/NixOS/nixpkgs/commit/d4f1ad9f8b0dd65ee81ce12a021f25e4f0acdf26) yo: add install check and update script
* [`3ffa4a0e`](https://github.com/NixOS/nixpkgs/commit/3ffa4a0ec1a20f9af86f9c0095d70afaaef0d263) yo: adopted by chillcicada
* [`6daefb8c`](https://github.com/NixOS/nixpkgs/commit/6daefb8c616a2c2a13671928d4f8e0508c359816) python3Packages.colcon: 0.19.0 -> 0.20.1
* [`c3f34fb1`](https://github.com/NixOS/nixpkgs/commit/c3f34fb1c57c334ced95675574fb16cf284cf95a) google-cloud-sdk: use structuredAttrs instead of passAsFile
* [`b6456d64`](https://github.com/NixOS/nixpkgs/commit/b6456d64faa0c45b32a88e3325cd9cf316ce4204) nixos/prometheus-exporters/fail2ban: init
* [`50ddaa9f`](https://github.com/NixOS/nixpkgs/commit/50ddaa9f6779a3fd493e1d39daab9314568cb451) dstask: enable darwin platform
* [`96ee407b`](https://github.com/NixOS/nixpkgs/commit/96ee407b5860a79956aec4ef709b3ecca575f324) sqlit-tui: 1.3.1 -> 1.3.1.1
* [`355adc74`](https://github.com/NixOS/nixpkgs/commit/355adc747edf0c5418558880b62c750f80d42564) acr: 2.2.4 -> 2.2.6
* [`e6ee482c`](https://github.com/NixOS/nixpkgs/commit/e6ee482cb4aeecde69a5593b22b2b827e3988d71) vk-bootstrap: 1.4.335 -> 1.4.341
* [`c07cb1be`](https://github.com/NixOS/nixpkgs/commit/c07cb1bed4d6eaa904601dabdf0b6bee474fefb0) kodi: inherit underlying kodi's `meta` when wrapping
* [`c705c325`](https://github.com/NixOS/nixpkgs/commit/c705c325bd9a600b0a3f2bbad1c45191b1ea0054) koreader: fix Japanese text selection with patched luajit
* [`545ed395`](https://github.com/NixOS/nixpkgs/commit/545ed3952541dc60b9afe8af2ba6bf9b1771b1f5) release-cross: Add fd to common
* [`5d04a54d`](https://github.com/NixOS/nixpkgs/commit/5d04a54d07e84bd46fdd8376b4677987d782fbf1) mautrix-slack: 26.02 -> 26.03
* [`2595b5f0`](https://github.com/NixOS/nixpkgs/commit/2595b5f0592534492bce3cb61c2c9bf5ba03ffbe) bepasty: fix dependencies
* [`b428b906`](https://github.com/NixOS/nixpkgs/commit/b428b90696f772159a14af7376201c4a09355305) wleave: 0.6.2 -> 0.7.1
* [`eb3b3239`](https://github.com/NixOS/nixpkgs/commit/eb3b323912638a922e1cf4c5285ef8c5f9e1d249) buildbox: 1.3.54 -> 1.4.0
* [`e005bc00`](https://github.com/NixOS/nixpkgs/commit/e005bc00244fa23185ac3390d59ec732b0c018c2) guile-websocket: 0.2.1 -> 0.3.0
* [`7081de57`](https://github.com/NixOS/nixpkgs/commit/7081de57d8ff197336e5b23bcf114ec6996d7a9b) gource: 0.55 -> 0.56
* [`15166f17`](https://github.com/NixOS/nixpkgs/commit/15166f17be12303e81e279a266f41277e170760a) zrythm: switch to KDE6 Package set
* [`9884f1e9`](https://github.com/NixOS/nixpkgs/commit/9884f1e93fffbe583b877522ae4ebc894e217234) zrythm: hardcode pname
* [`015b71d7`](https://github.com/NixOS/nixpkgs/commit/015b71d7b8ffd353903cf95d2181a68e26d4f245) dcnnt: modernize derivation, switch to PEP517
* [`cc8738df`](https://github.com/NixOS/nixpkgs/commit/cc8738df4d38c8baea83da91dc33658365f340b1) python3Packages.latex2mathml: 3.78.1 -> 3.79.0, use finalAttrs
* [`1a817faf`](https://github.com/NixOS/nixpkgs/commit/1a817faf1292092f6b31a51148546413d33063bb) python3Packages.sqlalchemy_1_4: 1.4.54 -> 1.4.54-unstable-2025-08-16
* [`572b2bd4`](https://github.com/NixOS/nixpkgs/commit/572b2bd42fb1c9a55a08a9c423ee3224fd37c162) peering-manager: 1.10.3 -> 1.10.4
* [`abd94905`](https://github.com/NixOS/nixpkgs/commit/abd94905b5a26111f13c1ee46483ee02218769b1) nixos/regreet: fix extraCss store paths written as literal text
* [`dccadf1f`](https://github.com/NixOS/nixpkgs/commit/dccadf1f7a85992beeaa99f0d315068aa4184633) eas-cli: add nodejs to bin path
* [`285a2304`](https://github.com/NixOS/nixpkgs/commit/285a2304729553b3bc3f5c9810c56b3ea6a1629e) .devcontainer: update devcontainer image version to 5-linux
* [`c7f73397`](https://github.com/NixOS/nixpkgs/commit/c7f733979de2a93c0708f5b4267f9379325db013) fastmail-desktop: 1.1.0 -> 1.2.1
* [`e6cdd1cc`](https://github.com/NixOS/nixpkgs/commit/e6cdd1cc34a7f7ee415242a07faeb8333563a443) fastmail-desktop: remove LD_LIBRARY_PATH and musl dependenciess
* [`23be6e35`](https://github.com/NixOS/nixpkgs/commit/23be6e35ffe28956f8198bd36acabbbfbdc7dbaf) python3Packages.snowflake-connector-python: 4.2.0 -> 4.3.0
* [`5c685454`](https://github.com/NixOS/nixpkgs/commit/5c68545421329eb51fb30b784c7fc53feec3af2f) czkawka: Add Krokiet .desktop, icon and metainfo
* [`7dfab0e1`](https://github.com/NixOS/nixpkgs/commit/7dfab0e1380d912406e2b740aa05715a8cf8e6cb) nixos/librenms: Use new Artisan Console Command
* [`953d68a8`](https://github.com/NixOS/nixpkgs/commit/953d68a88d7e966a5f3f944a7b531d4834462e6d) fflogs: fix invalid icon cache
* [`fb29b53f`](https://github.com/NixOS/nixpkgs/commit/fb29b53f462cdc79ba1cd41dae513813b3caffff) morewaita-icon-theme: propagate adwaita-icon-theme
* [`05dc2f78`](https://github.com/NixOS/nixpkgs/commit/05dc2f782992f86c8c3c983270b59e9e50b2223b) python3Packages.python-sat: 1.8.dev30 -> 1.9.dev2
* [`20d7a5f3`](https://github.com/NixOS/nixpkgs/commit/20d7a5f326acc7800119c7dff100f4a4446a0442) python3Packages.ansible-core: patch cli stub
* [`f3ca1ba8`](https://github.com/NixOS/nixpkgs/commit/f3ca1ba821bf2c313da9e07a6115357e6a782088) hashlink: change mbedtls_2 to mbedtls
* [`c696ad86`](https://github.com/NixOS/nixpkgs/commit/c696ad86bb4cf228fabdd1f5598a1a75bb7d8692) hashlink: remove unneeded patch
* [`15fbd2d8`](https://github.com/NixOS/nixpkgs/commit/15fbd2d84e55d676c24825766c81296002eef36b) hashlink: backport CMakeLists.txt version fix
* [`0e44b69d`](https://github.com/NixOS/nixpkgs/commit/0e44b69db033d6b2feada010035118c80b16e263) guile-hoot: add missing dependencies for hoot repl
* [`3611f04f`](https://github.com/NixOS/nixpkgs/commit/3611f04f447ae66912ecc010e3b6e959b77dcdc8) opentrack: 2026.1.0-unstable-2026-03-16 -> 2026.1.0-unstable-2026-03-25
* [`fd3e58af`](https://github.com/NixOS/nixpkgs/commit/fd3e58af5b23c6298b2320ad40b6c4a0e267eeab) phoc: add test to check that the version of a dependency is correct
* [`f55435fc`](https://github.com/NixOS/nixpkgs/commit/f55435fc4bbce9ad6001b05da4bbed3008b8ac0a) nixos/tests/phosh: fix
* [`88d71f8c`](https://github.com/NixOS/nixpkgs/commit/88d71f8c9407f3a6c2055f691b912aec0733e0c3) phoc: 0.51.0 -> 0.53.0
* [`99f9c7ce`](https://github.com/NixOS/nixpkgs/commit/99f9c7ce70eeb7eafe4522b7f7e396fddeb66b9c) maintainers: add lks
* [`4ccbe12a`](https://github.com/NixOS/nixpkgs/commit/4ccbe12a716e84b17c8df22eb7019e5aa6254c6a) fwupd: 2.0.19 -> 2.1.1
* [`4ba5b1ad`](https://github.com/NixOS/nixpkgs/commit/4ba5b1adf5d8aa2edcdc3be901319e83d1f989c8) obs-backgroundremoval: 1.1.13 -> 1.3.7
* [`4b86011d`](https://github.com/NixOS/nixpkgs/commit/4b86011d17505e6c0213bc44711705604871aac9) go-tpc: init at 1.0.12
* [`f32c37b8`](https://github.com/NixOS/nixpkgs/commit/f32c37b88cb1cfbed408eca10d78b5db77516806) lib.types.defaultTypeMerge: Fix for functors with no `wrapped` attr
* [`5448db58`](https://github.com/NixOS/nixpkgs/commit/5448db58821d63356daf1aa123551526b4da58b7) gallery-dl: 1.31.9 -> 1.31.10
* [`58bf9af9`](https://github.com/NixOS/nixpkgs/commit/58bf9af9b9cdcd885a7bf63f9038fa6ff0076710) usque: use buildGo125Module
* [`5fa67f76`](https://github.com/NixOS/nixpkgs/commit/5fa67f761738c6f7d2e438869ac1d0e856d7116a) wechat-uos: 4.1.0.12 -> 4.1.1.4
* [`aaa9da61`](https://github.com/NixOS/nixpkgs/commit/aaa9da61bfa0221a399eae6ec6d6e07ac0899e66) raffi: 0.12.0 -> 0.20.0
* [`525d9c75`](https://github.com/NixOS/nixpkgs/commit/525d9c75f6949e6c574dee411d3e1f73466e116b) librespot: migrate to by-name
* [`e542067c`](https://github.com/NixOS/nixpkgs/commit/e542067c766e40676a4d772955c5e4544820278b) qt6Packages.ktactilefeedback: init at 0-unstable-2025-07-25
* [`8fb2a33e`](https://github.com/NixOS/nixpkgs/commit/8fb2a33e2d758c0e00e744d3b687cbc5cb7539b3) lomiri-qt6.lomiri-ui-toolkit: Add ktactilefeedback
* [`0a6efe1a`](https://github.com/NixOS/nixpkgs/commit/0a6efe1affa562907326e5695a395d115a546532) livekit: 1.10.0 -> 1.10.1
* [`6a4cf18e`](https://github.com/NixOS/nixpkgs/commit/6a4cf18e0b7ba2ee3cf160c8446a95d154a080d0) onnx: enable ONNX_ML
* [`d31cf4a3`](https://github.com/NixOS/nixpkgs/commit/d31cf4a3206f72382dd5bd5a53917274be56d4d5) python3Packages.skl2onnx: add import check
* [`d918c048`](https://github.com/NixOS/nixpkgs/commit/d918c048fa2adc21610de361bad3ad47dfd0c948) khard: Revert "fix build failure caused by sphinx"
* [`bb81525d`](https://github.com/NixOS/nixpkgs/commit/bb81525d2a669add3fdcd577d7853dc511179125) khard: use fetchFromGitHub
* [`1bafbc01`](https://github.com/NixOS/nixpkgs/commit/1bafbc011d73d02c47e3f593aae67178e1f095c3) bitwarden-directory-connector: 2026.2.0 -> 2026.3.0
* [`526b0e09`](https://github.com/NixOS/nixpkgs/commit/526b0e090c346597db1e0e12ffe0ced15600e647) clickable: 8.7.0 -> 8.8.0
* [`a7dafbb4`](https://github.com/NixOS/nixpkgs/commit/a7dafbb4988d5f0d131f08dabf173cc2e3dff329) khard: enable most tests
* [`9e1ec59a`](https://github.com/NixOS/nixpkgs/commit/9e1ec59af260280c8a667949862a81f8518d1c87) khard: bring back man page generations with proper upstream fix
* [`2ffdaae9`](https://github.com/NixOS/nixpkgs/commit/2ffdaae9b44232ac92ee625652e0214231b2d877) goldberg-emu: migrate to by-name
* [`adbbd122`](https://github.com/NixOS/nixpkgs/commit/adbbd1227253bb23e45a8097b4cb9b72a1e75fc5) goldberg-emu: switch from rev to tag
* [`b808848f`](https://github.com/NixOS/nixpkgs/commit/b808848f77ec6d406f1daf21c7607bc8a5fea804) material-symbols: preserve upstream filenames
* [`5a078a38`](https://github.com/NixOS/nixpkgs/commit/5a078a3850dccb72ff395a6c670610f38f67a209) wasm-bindgen-cli_0_2_117: init at 0.2.117
* [`3fea8d0a`](https://github.com/NixOS/nixpkgs/commit/3fea8d0a0309b887f1f432a1cc7911e1140bd779) noti: update project home
* [`d1af2704`](https://github.com/NixOS/nixpkgs/commit/d1af2704d4c70e2dee726170261ab3bf049749ef) mfcl8690cdwlpr: 1.3.0-0 -> 1.5.0-3
* [`a9aabd6f`](https://github.com/NixOS/nixpkgs/commit/a9aabd6f6660a582305643168217e24b5b8348d3) mfcl8690cdwcupswrapper: 1.4.0-0 -> 1.5.0-3
* [`ff273939`](https://github.com/NixOS/nixpkgs/commit/ff273939adf28bc71e35b987403b3cb21162fe68) zathura,zathuraPkgs.*: add mithicspirit as maintainer
* [`3582fabb`](https://github.com/NixOS/nixpkgs/commit/3582fabbd1941c9ed5fa071b4188287218df59ee) lima-full: 2.0.3 -> 2.1.1
* [`a01d719c`](https://github.com/NixOS/nixpkgs/commit/a01d719cdc6e2b39e40c78514a3b08f6ed7c806c) maintainers: remove hqurve
* [`ae83f2f2`](https://github.com/NixOS/nixpkgs/commit/ae83f2f2a48144aaa5a3bfc0578ebf3f2698d354) darkplaces: unstable-2022-05-10 -> 20140513-unstable-2026-01-22
* [`a55d7554`](https://github.com/NixOS/nixpkgs/commit/a55d7554a7738c4c92a6737364329db072c67ccd) nexuiz: use darkplaces from nixpkgs
* [`3576826c`](https://github.com/NixOS/nixpkgs/commit/3576826ca1b68f4c04d2bace5ae06bba85e2f696) log4cxx: 1.6.1 -> 1.7.0
* [`94690a55`](https://github.com/NixOS/nixpkgs/commit/94690a55f2129d996dcc4c8c4579ffd95248d1cb) maintainers: drop Gonzih
* [`b27dfb41`](https://github.com/NixOS/nixpkgs/commit/b27dfb41d0719d2b8e3f614f46a7913179a2ff3e) csvtool: migrate to by-name
* [`b13b75c8`](https://github.com/NixOS/nixpkgs/commit/b13b75c8f94de7a9a76e6b763c58a5a38c72d8c4) c-blosc2: 2.22.0 -> 2.23.1
* [`9c72a507`](https://github.com/NixOS/nixpkgs/commit/9c72a507de8ea6e54e54aaea830b2a6b8fb67fad) gdash: init at 0-unstable-2023-06-24
* [`e6909f5a`](https://github.com/NixOS/nixpkgs/commit/e6909f5ac7b4ed569276c5a104201c589ee7b5ca) nixos/systemd-initrd: support omitting kernel parameter root
* [`67553de7`](https://github.com/NixOS/nixpkgs/commit/67553de7d8c0c1f1a1bd49cf8a74b762c86895a7) kubernetes-helm: 3.19.1 -> 3.20.1
* [`00998872`](https://github.com/NixOS/nixpkgs/commit/00998872527220688507b26d2e8a3752aecb15d3) rocmPackages.rocprofiler-register: remove rocm-runtime/clr dependency
* [`7520f4a0`](https://github.com/NixOS/nixpkgs/commit/7520f4a03e94d64973f3848157a2bd1857d41fd7) rocmPackages.rocprofiler-register: remove GPU_TARGETS
* [`d547f87a`](https://github.com/NixOS/nixpkgs/commit/d547f87a3bf27dd9f7e6da932584124c6c1416ab) rocmPackages.rocprofiler-register: vendor dependencies
* [`d8342e2d`](https://github.com/NixOS/nixpkgs/commit/d8342e2dc8e4899ed5ecc01e956cad824aaefc8d) rocmPackages.clr: enable rocprofiler-register integration
* [`1a78444b`](https://github.com/NixOS/nixpkgs/commit/1a78444b1fa5301e598dac2671286200781e3562) rocmPackages.rocm-runtime: enable rocprofiler-register integration
* [`74b66f78`](https://github.com/NixOS/nixpkgs/commit/74b66f785b29076740c822afafcab99fa33768f7) nixos/module: init rsshub
* [`553b8b5e`](https://github.com/NixOS/nixpkgs/commit/553b8b5ea215e74ffca897c24ea632ffcc040418) nixosTests.rsshub: init
* [`f493239e`](https://github.com/NixOS/nixpkgs/commit/f493239edaf0da179df5cf3e568e68fb70d5b987) maintainers: add jujb233
* [`ca99a0b0`](https://github.com/NixOS/nixpkgs/commit/ca99a0b04cd92ada6bba417d8a915935e7f1057d) datovka: migrate to by-name
* [`9fe62e4b`](https://github.com/NixOS/nixpkgs/commit/9fe62e4b1953ac841f45f7c1cf6195d40c6bd2ac) datovka: modernize derivation
* [`e50f4ab5`](https://github.com/NixOS/nixpkgs/commit/e50f4ab5be87d87bb3f1ef7c9d0458e150c6875b) elfio: 3.10 -> 3.12
* [`0673bfc6`](https://github.com/NixOS/nixpkgs/commit/0673bfc6dd11d66b7cf2ccb233f26a2c0fcd9288) cgif: 0.5.2 -> 0.5.3
* [`e789ccec`](https://github.com/NixOS/nixpkgs/commit/e789ccec415e10d5a00cbff09e5e70ec93a7de66) fdtools: 2020.05.04 -> 2024.12.07
* [`f5fa94da`](https://github.com/NixOS/nixpkgs/commit/f5fa94dac5c060ebccf4132565c53b976573ad15) musicfree-desktop: fix build by updating better-sqlite3
* [`86d196fa`](https://github.com/NixOS/nixpkgs/commit/86d196fad6900b51c7283c28285dccd40e8cd383) wsjtx: add update script
* [`f31b67a4`](https://github.com/NixOS/nixpkgs/commit/f31b67a4c281dd3d3b328d7e10744a1fc0749df1) wsjtx: move to by-name
* [`86abce96`](https://github.com/NixOS/nixpkgs/commit/86abce96b1a86226ab2c4f16af957fb33d16bafc) wsjtz: don't use wsjtx update script
* [`8c84a28c`](https://github.com/NixOS/nixpkgs/commit/8c84a28cfc0fd60c1e7e1f9e381020e72c4a3e34) llvmPackages_git: 23.0.0-unstable-2026-03-29 -> 23.0.0-unstable-2026-04-05
* [`4f7a3ea2`](https://github.com/NixOS/nixpkgs/commit/4f7a3ea25850c00b1073efd0d6aece6fa1a23acd) saber: 1.31.1 -> 1.33.0
* [`7a19ba11`](https://github.com/NixOS/nixpkgs/commit/7a19ba11e0a0e4c46b60e890e5a26100f048fd48) zrok: 2.0.0-rc4 -> 2.0.1
* [`ca9588ad`](https://github.com/NixOS/nixpkgs/commit/ca9588ad53126c4d86c31168f6a5ccd0c864b318) casilda: 1.2.0 -> 1.2.2
* [`8ec536a0`](https://github.com/NixOS/nixpkgs/commit/8ec536a05c76fbe81c3f253523a2e5e49b2011e8) metadata-cleaner: 2.5.6 -> 4.0.0
* [`cdf5c4eb`](https://github.com/NixOS/nixpkgs/commit/cdf5c4eb3b70c9b943a9875506e8c8694d6ef414) python3Packages.xgrammar: 0.1.31 -> 0.1.33
* [`438e2fa7`](https://github.com/NixOS/nixpkgs/commit/438e2fa7944ee33aa6a43ab5e0ae174fab8ac5c5) nextcloud31Packages.apps.recognize: drop
* [`2bace809`](https://github.com/NixOS/nixpkgs/commit/2bace809c7fdef4281797e519ef2c7f6a05f1f30) nextcloud33Packages.apps.recognize: init at 11.0.1
* [`ee19f70a`](https://github.com/NixOS/nixpkgs/commit/ee19f70a50035b5a7fbf78a3e3775c4c6c497118) gaiasky: init at 3.7.1
* [`d36077c0`](https://github.com/NixOS/nixpkgs/commit/d36077c0b686c91cea9d20edd58da632d4f28318) nixos/systemd: fix modprobe
* [`fb75f91b`](https://github.com/NixOS/nixpkgs/commit/fb75f91b22e9bb509c43156f6de912db556f4570) prowlarr: 2.3.0.5236 -> 2.3.5.5327
* [`5cac8ff7`](https://github.com/NixOS/nixpkgs/commit/5cac8ff7291159095b2e97d9acc0048ed2f7310f) famistudio: 4.4.4 -> 4.5.0
* [`cb6caa4c`](https://github.com/NixOS/nixpkgs/commit/cb6caa4c64d7db1a3cbd4d30eb23e88b3606dc93) spoof-mac: migrate to by-name
* [`957f4b35`](https://github.com/NixOS/nixpkgs/commit/957f4b35eae119052c348d8137ae0b562cf5cf9c) spoof-mac: switch to hash, add missing version string
* [`1b3b4128`](https://github.com/NixOS/nixpkgs/commit/1b3b41288caf7b6c928c46b7b48d4e3e24e607b6) snmalloc: init at 0.7.4
* [`4a59d690`](https://github.com/NixOS/nixpkgs/commit/4a59d6908cf4c991be8283917011fe4c76d51bea) chatbox: 1.19.1 -> 1.20.0
* [`861de83e`](https://github.com/NixOS/nixpkgs/commit/861de83e8e45a1aff9de842a507d955e4afda28c) nixos/syncthing: fix unix socket guiAddress handling
* [`6708130f`](https://github.com/NixOS/nixpkgs/commit/6708130feb4f98429da27ef7727f95b94062757a) nixosTests.syncthing-folders: cover unix socket usage
* [`f01e4c84`](https://github.com/NixOS/nixpkgs/commit/f01e4c84a49eec21438eb56987022b76a1fc7717) python3Packages.blosc2: 3.12.2 -> 4.1.2
* [`1b61c5b3`](https://github.com/NixOS/nixpkgs/commit/1b61c5b3b9ed3249d7464423b9d2110ce5cae2b6) draupnir: 2.9.0 -> 3.0.0
* [`ade3bfce`](https://github.com/NixOS/nixpkgs/commit/ade3bfce37077a7b7aa6f004ac4e8d14d257780b) prusa-slicer: add x-scheme-handler/prusaslicer to desktop file
* [`b163ec77`](https://github.com/NixOS/nixpkgs/commit/b163ec7789cb859016a0dfc6cbd7da6eb1ce4cc8) fcitx5: fix updateScript
* [`56117629`](https://github.com/NixOS/nixpkgs/commit/56117629ad573a1f3afd8308740150a6de51aab1) jabcode-{reader,writer}: fix build
* [`760f43a6`](https://github.com/NixOS/nixpkgs/commit/760f43a69e47fbbca3a9db56dcf7ac0c1d307ca3) nixos/firewall: disable refused connections logging
* [`0d7de04c`](https://github.com/NixOS/nixpkgs/commit/0d7de04c0c246ea33ee9c4764781be9752c29bf1) nixos/systemd-stage-1: Enable dbus by default
* [`2af90822`](https://github.com/NixOS/nixpkgs/commit/2af908228dff2083cff13b5d2c4a95931dc79b0d) nixos/systemd-stage-1: Support rd.systemd.break=
* [`1ea02ad8`](https://github.com/NixOS/nixpkgs/commit/1ea02ad83f1229cb630317895548c60ee0deee45) nixos/tests/boot-stage2: Explicitly disable systemd stage 1
* [`8cd4240c`](https://github.com/NixOS/nixpkgs/commit/8cd4240c6c053df53deb5f3a70c5396d022ca3cf) nixos/tests/initrd-network: Explicitly disable systemd stage 1
* [`e7a9b6a1`](https://github.com/NixOS/nixpkgs/commit/e7a9b6a1a2fdc37f97f122ebe388402d787dfd96) nixos/tests/iscsi: Explicitly disable systemd stage 1
* [`a261a22e`](https://github.com/NixOS/nixpkgs/commit/a261a22e18f6d98c46a7e6135f0c20ae3f915022) nixos/tests/boot-stage1: Explicitly disable systemd stage 1
* [`482da791`](https://github.com/NixOS/nixpkgs/commit/482da791bfe649278e988f7414a322d7a43897c9) nixos/tests/initrd-network-ssh: Explicitly disable systemd stage 1
* [`de7ea54d`](https://github.com/NixOS/nixpkgs/commit/de7ea54d822f6af969fff218689f11a085439fe9) nixos/tests/luks: Explicitly disable systemd stage 1
* [`fef6d22a`](https://github.com/NixOS/nixpkgs/commit/fef6d22a872d14381771490b9e3c872fad3084ff) nixos/tests/predictable-interface-names: Explicitly set 'boot.initrd.systemd.enable'
* [`1718e9f7`](https://github.com/NixOS/nixpkgs/commit/1718e9f745006f167c9566bc29e13ece087b02ae) nixos/tests/initrd-luks-empty-passphrase: Explicitly set 'boot.initrd.systemd.enable'
* [`ee5dd908`](https://github.com/NixOS/nixpkgs/commit/ee5dd90859c7a5dd76603d60f02c9a472f25d942) nixos/tests/initrd-network-opentvpn: Explicit systemdStage1 arg
* [`0f146213`](https://github.com/NixOS/nixpkgs/commit/0f146213ded8979a4cc323edc8c081ba6b5f4542) nixos/tests/hibernate: Explicit systemdStage1 arg
* [`8a6ac4af`](https://github.com/NixOS/nixpkgs/commit/8a6ac4af8d4301a0aac6e582627abeae997a85f9) nixos/tests/systemd-shutdown: Explicit systemdStage1 arg
* [`58dc3d61`](https://github.com/NixOS/nixpkgs/commit/58dc3d61dc022b93e548614103e0b37fed9b51b6) nixos/tests/envfs: Explicit systemdStage1 arg
* [`94a06492`](https://github.com/NixOS/nixpkgs/commit/94a06492e2848085389bbc5242c381bc876e2265) nixos/tests/non-default-filesystems/btrfs: Use systemd stage 1
* [`61305d14`](https://github.com/NixOS/nixpkgs/commit/61305d14147e05b60c6bad4e7c8d91dfcc7a6e37) nixos/tests/initrd-secrets: Use systemd stage 1
* [`1288734d`](https://github.com/NixOS/nixpkgs/commit/1288734d0986dd2f63f172ffd9f0969650b15315) nixos/tests/swap: Use systemd stage 1
* [`5e0a4d73`](https://github.com/NixOS/nixpkgs/commit/5e0a4d739ddd85e045e684a74660b6f8e0b9f705) nixos/tests/installer: Support both stage 1 implementations
* [`0b198b61`](https://github.com/NixOS/nixpkgs/commit/0b198b61f6e739bca7451793d53aa5601b0674ec) nixos/tests/ec2-nixops: Support both stage 1 implementations
* [`65090b23`](https://github.com/NixOS/nixpkgs/commit/65090b23f6ec329bcc1d54eb970299395ed85ccd) nixos/tests/qemu-vm-external-disk-image: Increase bootSize
* [`222ee6e2`](https://github.com/NixOS/nixpkgs/commit/222ee6e2451960162ef53b5c0c30bc8e64d2c8a3) nixos/luksroot: Unhide crypttabExtraOpts
* [`5312ce1b`](https://github.com/NixOS/nixpkgs/commit/5312ce1bae2879cc2ff7a3e2851bf32918099079) nixos/systemd-stage-1/users-groups: Assert against cryptsetup-askpass
* [`5620d245`](https://github.com/NixOS/nixpkgs/commit/5620d245adf03c58b74f803031ba2a85d204db31) nixos/systemd-stage-1: Enable by default
* [`67e6de79`](https://github.com/NixOS/nixpkgs/commit/67e6de7939e27b92a7b87fbfc58aea135936c5cf) htop: Fix static build
* [`9935801f`](https://github.com/NixOS/nixpkgs/commit/9935801fb0e5dfea1139a04829e0bf96295610da) python3Packages.lupa: 2.6 -> 2.7
* [`e10ee240`](https://github.com/NixOS/nixpkgs/commit/e10ee240a967a69ee009f45330b2d8593c066da3) pythpn3Packages.lupa: migrate to finalAttrs
* [`363ae292`](https://github.com/NixOS/nixpkgs/commit/363ae292bfdea54b73aa71ea22206f8953e47f21) splice: defer per-output spliceReal recursion behind genAttrs
* [`537e567d`](https://github.com/NixOS/nixpkgs/commit/537e567dddc7dea43053e0f0f4a5ed81194f8af6) peco: 0.5.11 -> 0.6.0
* [`b6f7d1c8`](https://github.com/NixOS/nixpkgs/commit/b6f7d1c851e90f540e938db89e934b8b1c5e4ffe) nixos/tmpfiles: fix layer inversion
* [`013aa281`](https://github.com/NixOS/nixpkgs/commit/013aa2812eb8d587d297495720e2c38f3346d43b) odiff: 4.3.2 -> 4.3.3
* [`34f69a13`](https://github.com/NixOS/nixpkgs/commit/34f69a13cdc16f13e577a7824e8099c345346ccc) memcached-exporter: 0.15.5 -> 0.16.0
* [`606195ba`](https://github.com/NixOS/nixpkgs/commit/606195baa7e650c19e05d73c9d6440de61a79e07) peco: modernize fetchFromGitHub attrs (rev->tag, sha256->hash)
* [`13db9e22`](https://github.com/NixOS/nixpkgs/commit/13db9e228d1b4a38a7a5448e90c5c8dabaa2b83d) music-assistant: unify frontend maintainers with server package
* [`6a13d037`](https://github.com/NixOS/nixpkgs/commit/6a13d037952afd3d037199bb47543aa9d59ba9cb) music-assistant: require at least upstream package versions instead of relaxing almost all deps
* [`c13975b5`](https://github.com/NixOS/nixpkgs/commit/c13975b5c8bab554f2e94de346ee1c853fc9b977) nixos/music-assistant: open port for snapcast provider
* [`442da807`](https://github.com/NixOS/nixpkgs/commit/442da807a1e5ba671e12515b4e154c0e3b046830) nixos/music-assistant: also open firewall for avahi
* [`67ccbd4d`](https://github.com/NixOS/nixpkgs/commit/67ccbd4dc70a8c98c9feed52deebbcee29f96b5f) python3Packages.music-assistant-models: convert to finalAttrs, test music-assistant in passthru.tests
* [`1e4eb2df`](https://github.com/NixOS/nixpkgs/commit/1e4eb2df3fe59c4ef9a20830a18ae2771b8bfa45) nixos: completely remove systemd-udev-settle.service
* [`35c3b96b`](https://github.com/NixOS/nixpkgs/commit/35c3b96ba86853397b4b5b17b317cc7f85042774) nixos/zfs: remove udev settle hack
* [`515d1a12`](https://github.com/NixOS/nixpkgs/commit/515d1a12649d96e333c4055db40c985fd00dfdd9) xivlauncher: 1.3.1 -> 1.4.0
* [`9a0ea068`](https://github.com/NixOS/nixpkgs/commit/9a0ea0689bcbf7ab854d3c5c605d7eb3df572dfb) nixos/tests: Fix installer systemdStage1 argument
* [`5d7323cf`](https://github.com/NixOS/nixpkgs/commit/5d7323cf8f87abe23ac298ef6411718647394381) television: 0.15.4 -> 0.15.5
* [`bf4b9cae`](https://github.com/NixOS/nixpkgs/commit/bf4b9cae816ccc94037b7c9d78b380655a3d6266) home-manager: 0-unstable-2026-03-13 -> 0-unstable-2026-04-08
* [`fc00e745`](https://github.com/NixOS/nixpkgs/commit/fc00e7451b1ce76b57696bb0608b36956bdc9e07) n8n: 2.14.2 -> 2.15.0
* [`859e7a2a`](https://github.com/NixOS/nixpkgs/commit/859e7a2a9d14360181d137136d21387019eb195d) pi-coding-agent: 0.64.0 -> 0.66.1
* [`e01a584a`](https://github.com/NixOS/nixpkgs/commit/e01a584a0ff478d4353107588d3a7562d60025bf) platformio-chrootenv: add cmake, ninja, wheel, virtualenv
* [`a6dde306`](https://github.com/NixOS/nixpkgs/commit/a6dde30645aa4a2cd56478842bb0110bb14c33e1) armagetronad: fix build with newer protobuf, update sty, allow overrides
* [`48606789`](https://github.com/NixOS/nixpkgs/commit/486067894a146062ef6e406d4e95130812255cde) gmobile: 0.6.0 -> 0.7.0
* [`1a2ffa77`](https://github.com/NixOS/nixpkgs/commit/1a2ffa77bc35e69f985769fcab13927f0e68957c) seaweedfs: 4.18 -> 4.19
* [`4888cf8a`](https://github.com/NixOS/nixpkgs/commit/4888cf8a16edef7a42751dc49c199db61327b3e4) python3Packages.pymitsubishi: 0.5.0 -> 0.5.1
* [`99035ea5`](https://github.com/NixOS/nixpkgs/commit/99035ea502d9cc5715ad955872d7e018a90c30e5) sideswap: 1.8.2 -> 1.9.0
* [`6a8feae7`](https://github.com/NixOS/nixpkgs/commit/6a8feae7e23181854b09c6569f9b070c2cd8ff3c) wox: 2.0.1 -> 2.0.2
* [`4cc13109`](https://github.com/NixOS/nixpkgs/commit/4cc131092c01293740c6f51b3a5e85d9fca5b7b7) nix-functional-tests: move env variables into env for structuredAttrs
* [`d691a992`](https://github.com/NixOS/nixpkgs/commit/d691a9929e1810e30d9a350c76433830d227d63d) nix-functional-tests: nix fmt
* [`8a8dd3e0`](https://github.com/NixOS/nixpkgs/commit/8a8dd3e060fb5104bc3934a27f5d31074a6479ce) fwupd: only enable HSI on x86
* [`d7fc07c5`](https://github.com/NixOS/nixpkgs/commit/d7fc07c54fcc433209a43aaeed2841e5e7b6bfc8) nixos/tests/fwupd: drop FWUPD_VERBOSE again
* [`d62b05d7`](https://github.com/NixOS/nixpkgs/commit/d62b05d75b4835711bab2f4fab3b4dc70b4bd08d) nixos/nfc-nci: Adjust pcscd system call hardening
* [`afd024ff`](https://github.com/NixOS/nixpkgs/commit/afd024ffa386f1674785bd5751f3cda60d196ce0) ruff: 0.15.9 -> 0.15.10
* [`d6db0831`](https://github.com/NixOS/nixpkgs/commit/d6db0831ab1dd367210438650d7630824e6b0a05) epson-escpr2: remove shawn8901 as maintainer
* [`1cdf4c9a`](https://github.com/NixOS/nixpkgs/commit/1cdf4c9a179bab1124039db5ed7d7ce3a656e6f0) rectangle: 0.94 -> 0.95
* [`1b48f0ea`](https://github.com/NixOS/nixpkgs/commit/1b48f0ea51bf9fe580904fb59277e28bd54ac1b5) birdfont: fix build failure
* [`3a2e5330`](https://github.com/NixOS/nixpkgs/commit/3a2e5330884bb8bb5855208f946e4939e0c5b75e) birdfont: adopt
* [`cd7d6b34`](https://github.com/NixOS/nixpkgs/commit/cd7d6b34535713f5dd737f784a739956ef9abe12) birdfont: modernize
* [`f9c6f9ee`](https://github.com/NixOS/nixpkgs/commit/f9c6f9ee9772d728eec853cb9c88a1a6bf4a7515) xmlbird: adopt
* [`f5ac2f9f`](https://github.com/NixOS/nixpkgs/commit/f5ac2f9fa860f434bb96c5b4c290e9b9894d90cd) python3Packages.rapidocr: 3.7.0 -> 3.8.0
* [`a90c083c`](https://github.com/NixOS/nixpkgs/commit/a90c083c4c1c7e0cdf9ae8f11252bc7ecbac6823) vikunja: 2.2.2 -> 2.3.0
* [`886d933b`](https://github.com/NixOS/nixpkgs/commit/886d933be714227ce68f5f26762598dd436d1477) opencommit: 3.2.14 -> 3.2.18
* [`a70a5f89`](https://github.com/NixOS/nixpkgs/commit/a70a5f890cccc2177bacf23cb0875ca4248a447e) burpsuite: 2026.3.1 -> 2026.3.2
* [`ee97c52f`](https://github.com/NixOS/nixpkgs/commit/ee97c52f4e38fbd4c7135028e74db30f63fb8565) maestro: 2.3.0 -> 2.4.0
* [`042a82f0`](https://github.com/NixOS/nixpkgs/commit/042a82f0e82e4eb513b71de5a2cedb1d61b6bd16) pmbootstrap: 3.9.0 -> 3.10.1
* [`4c5b0e3a`](https://github.com/NixOS/nixpkgs/commit/4c5b0e3a5d8b2ae3055e84038c3aa04ed2a56511) darwin.ICU: avoid conflicts with the system libicucore
* [`7064303e`](https://github.com/NixOS/nixpkgs/commit/7064303eb16b8e170bca56db51e1cae7460178e9) pay-respects: 0.7.13 -> 0.8.5
* [`c06e2776`](https://github.com/NixOS/nixpkgs/commit/c06e27769046c99d2e5119058f1b3c234d346633) nixos/documentation/modular-services: document that services should be added to modular-services.nix
* [`b36d5966`](https://github.com/NixOS/nixpkgs/commit/b36d596602867efb00111e298f7c0429ad44a460) nixos/documentation/modular-services: add snid
* [`93e2d702`](https://github.com/NixOS/nixpkgs/commit/93e2d702a35f1f254b03608a139f4fd81b718a49) pcm: 202509 -> 202604
* [`e5d2fff0`](https://github.com/NixOS/nixpkgs/commit/e5d2fff0267741152a85bde88cb0bec1ca058e0e) kyverno-chainsaw: fix build with go 1.26
* [`e06513b1`](https://github.com/NixOS/nixpkgs/commit/e06513b171fabd77727473431d2f9124750e6a06) kyverno-chainsaw: minor improvements
* [`1c18b07c`](https://github.com/NixOS/nixpkgs/commit/1c18b07c49e148e474a88deaacb9a56a752531c5) vultisig-cli: 0.6.0 -> 0.12.0
* [`faa02b0a`](https://github.com/NixOS/nixpkgs/commit/faa02b0a6aa7935544da9f00f4bbafba67946107) xlights: 2026.04 -> 2026.05
* [`7b64be3d`](https://github.com/NixOS/nixpkgs/commit/7b64be3da2a138e63034d555ce2c9c7efdc14b0e) giff: init at 1.1.0
* [`cdff0551`](https://github.com/NixOS/nixpkgs/commit/cdff05511e0da0b2fc21204df4a7ef8f3b4db707) giff: Add myself to maintainers
* [`4a40583d`](https://github.com/NixOS/nixpkgs/commit/4a40583d7336dbb0f84c431e75351e4d2c536892) giff: 1.1.0 -> 1.2.0
* [`360eba24`](https://github.com/NixOS/nixpkgs/commit/360eba2432facbef26fdc6e350cc68317cd8e483) giff: Add __structuredAttrs = true
* [`33b4d77b`](https://github.com/NixOS/nixpkgs/commit/33b4d77b8527b826eab9498896407c51e0e6907f) shairport-sync: use new names of pipewire and pulseaudio backends
* [`431c40bb`](https://github.com/NixOS/nixpkgs/commit/431c40bb4bd08408753e26076ab245f788d2329e) sdl3-mixer: init at 3.2.0
* [`8d28e4bd`](https://github.com/NixOS/nixpkgs/commit/8d28e4bd08d19378d709adf4e10aaa9300a40957) python3Packages.pydevccu: 0.1.21 -> 0.2.3
* [`e2c4964a`](https://github.com/NixOS/nixpkgs/commit/e2c4964a737b17ab89d5f621dd82452525397f0d) python3Packages.aiohomematic: 2026.4.0 -> 2026.4.6
* [`5d533110`](https://github.com/NixOS/nixpkgs/commit/5d533110fb2f0a1b7051af0339370ffee21a03c4) python3Packages.aiohomematic-config: 2026.3.5 -> 2026.4.1
* [`2aabf7b0`](https://github.com/NixOS/nixpkgs/commit/2aabf7b04791a73ddf6faf31d4a6f33b3ba4908c) home-assistant-custom-components.homematicip_local: 2.5.2 -> 2.6.0
* [`ec6e94a4`](https://github.com/NixOS/nixpkgs/commit/ec6e94a495f048d06447f829244826656a758074) python3Packages.a2a-sdk: 0.3.25 -> 0.3.26
* [`6afb4fcf`](https://github.com/NixOS/nixpkgs/commit/6afb4fcfe0bbf1bb34bd47afc640dc324190a272) vscode-extensions.drblury.protobuf-vsc: init at 1.6.0
* [`17dc0895`](https://github.com/NixOS/nixpkgs/commit/17dc0895c46310da8889f250f9d9e5e3ed551e69) osmium-tool: 1.19.0 → 1.19.1
* [`51a23844`](https://github.com/NixOS/nixpkgs/commit/51a23844dd2702658219883a55f299bfeecd344f) rocmPackages.composable_kernel: use jemalloc at build time to speed up build by ≈7%
* [`eadbefa6`](https://github.com/NixOS/nixpkgs/commit/eadbefa672a6780cab460132e6c72ca38b2eb9df) shapelib: 1.6.2 → 1.6.3
* [`d4db925e`](https://github.com/NixOS/nixpkgs/commit/d4db925e47b28f6b63fb63be6f7edda29260020f) openjump: 2.3.0 → 2.4.0
* [`59ffef84`](https://github.com/NixOS/nixpkgs/commit/59ffef8450bce36066f2045a1621cce05aede2ed) github-desktop: add dtomvan as a maintainer
* [`4c6e3a21`](https://github.com/NixOS/nixpkgs/commit/4c6e3a214f1ac238da025e5f69f3149295f265c9) flatpak: 1.16.4 -> 1.16.6
* [`24941111`](https://github.com/NixOS/nixpkgs/commit/24941111e4530c1b2104b0f3612c55b659e22ec6) kernel: enable CONFIG_HW_RANDOM to be built-in
* [`be59a576`](https://github.com/NixOS/nixpkgs/commit/be59a576f7e63733cbadbfdbe08c723989094a11) python3Packages.pontos: 26.2.0 -> 26.4.0
* [`3040774c`](https://github.com/NixOS/nixpkgs/commit/3040774c2f99756cc03c28dd78bbcb2bbd4e73f9) wolfssl: 5.9.0 -> 5.9.1
* [`a90d314a`](https://github.com/NixOS/nixpkgs/commit/a90d314ae62e93355c7ce691564e7c62c81ead81) authelia: 4.39.12 -> 4.39.18
* [`ae561772`](https://github.com/NixOS/nixpkgs/commit/ae5617725313df28ad14e1d21651edb02cba2548) dbeaver-bin: 26.0.1 -> 26.0.2
* [`11db3eeb`](https://github.com/NixOS/nixpkgs/commit/11db3eeb36a02d88317764002405419d60c988a0) xmlbird: modernize
* [`d7b13db5`](https://github.com/NixOS/nixpkgs/commit/d7b13db5771ca50b76e1a2b7645e29982775d187) birdfont,xmlbird: move to by-name
* [`bce91a28`](https://github.com/NixOS/nixpkgs/commit/bce91a286cbedf86a6de5201d32c5c35514a0941) domino-chain: fix build with boost 1.89
* [`db20a03b`](https://github.com/NixOS/nixpkgs/commit/db20a03bd0c0d4f4dbf2a48bc7d7ff7730930ae9) nixos/drupal: change state directory modules and themes symlinks
* [`3af48616`](https://github.com/NixOS/nixpkgs/commit/3af48616d727ba0eb86da6f005374e1bffbe8707) uutils-util-linux: 0.0.1-unstable-2026-04-01 -> 0.0.1-unstable-2026-04-10
* [`ceb175c3`](https://github.com/NixOS/nixpkgs/commit/ceb175c332260a35bc04bd65a5ab92da5b69945f) uutils-procps: 0.0.1-unstable-2026-03-28 -> 0.0.1-unstable-2026-04-10
* [`00b5080c`](https://github.com/NixOS/nixpkgs/commit/00b5080cb7e5b84538a36031f6777ed77e66973e) goeland: 0.22.1 -> 0.23.0
* [`ee9322ed`](https://github.com/NixOS/nixpkgs/commit/ee9322ed6affcb0c50792a22ab7e4d0e0ebaa8f1) xxh: 0.8.14 -> 0.8.16
* [`27c09a7f`](https://github.com/NixOS/nixpkgs/commit/27c09a7f0aaa74b308fc7c96f31b5f16ca46efc3) certigo: 1.17.1 -> 1.18.0
* [`adb6055f`](https://github.com/NixOS/nixpkgs/commit/adb6055f858601f1ff364503588adf5a5150b938) ols: dev-2026-02 -> dev-2026-03
* [`f80cb855`](https://github.com/NixOS/nixpkgs/commit/f80cb855aa68087cc778bd04e85fff3d2ca5f7fb) glow: 2.1.1 -> 2.1.2
* [`ac8ccc52`](https://github.com/NixOS/nixpkgs/commit/ac8ccc528a4b1c17eaf478f70da04bfc10d65283) mangareader: 2.3.0 -> 2.4.0
* [`3e5adab0`](https://github.com/NixOS/nixpkgs/commit/3e5adab0bbd4f3f6bbbc74ae753a042e1eeb04ca) motrix-next: 3.6.3 -> 3.6.8, move gapp wrapping to postFixup
* [`abbfb759`](https://github.com/NixOS/nixpkgs/commit/abbfb75941291845995c8efff6ef1b6402792cd6) libtsm: enable `strictDeps` and `__structuredAttrs`
* [`24970ea0`](https://github.com/NixOS/nixpkgs/commit/24970ea02cba5e6f4ffd3fb8f2fddb7307919761) kmscon: enable `__structuredAttrs`
* [`c1df5b4f`](https://github.com/NixOS/nixpkgs/commit/c1df5b4f1d1540e4517d2801c896cfa4913eea63) zed-editor: fixes and corrections
* [`7d318c05`](https://github.com/NixOS/nixpkgs/commit/7d318c0508537260e11727bbbaabb865de953476) libretro.opera: 0-unstable-2026-03-31 -> 0-unstable-2026-04-10
* [`560d08f1`](https://github.com/NixOS/nixpkgs/commit/560d08f1001f8d844be34de5fe66072b29c25f53) nixos/cockpit: disable LoginTo by default
* [`5e60d658`](https://github.com/NixOS/nixpkgs/commit/5e60d658e8a6f9b78b220247da9046c689757608) python3Packages.whenever: 0.10.0b3 -> 0.10.0
* [`8d18ed88`](https://github.com/NixOS/nixpkgs/commit/8d18ed88df2943b01ff05cffbdb9d078c1a78422) postgresqlPackages.timescaledb-apache: 2.26.1 -> 2.26.2
* [`7d44da80`](https://github.com/NixOS/nixpkgs/commit/7d44da8085a0e19c248739abfcb530aeb37ae54e) python3Packages.http-sf: 1.1.1 -> 1.2.0
* [`db0a3f91`](https://github.com/NixOS/nixpkgs/commit/db0a3f91d84ff068e1bc65c9ae551122049bc191) podman-desktop: pin nodejs version for fetchPnpmDeps
* [`edbc8101`](https://github.com/NixOS/nixpkgs/commit/edbc81012a3c746302b741f9c7f10fc467361e44) podman-desktop: extract nodejs version from package.json
* [`edae3a21`](https://github.com/NixOS/nixpkgs/commit/edae3a213ba469f63cf51b65a4d32af57fcb4e54) filebeat8: 8.19.13 -> 8.19.14
* [`0d6ce019`](https://github.com/NixOS/nixpkgs/commit/0d6ce0194076a63dd1a2def6f0d6feac67f0a979) python3Packages.environs: 15.0.0 -> 15.0.1
* [`78fa158c`](https://github.com/NixOS/nixpkgs/commit/78fa158c69e35ab2a376faeab6cd911ed508f29d) perlPackages.NetCIDRLite: 0.22 -> 0.23
* [`b5aeef31`](https://github.com/NixOS/nixpkgs/commit/b5aeef311689873efc7b4cfedb3ae4847cdb9e20) dovecot{,_pigeonhole}: make 2.4 the default version
* [`ad56a1d9`](https://github.com/NixOS/nixpkgs/commit/ad56a1d988b448518aaad2bc5577b3059c8dfd12) nixos/dovecot: add settings option (RFC42)
* [`d49db5bd`](https://github.com/NixOS/nixpkgs/commit/d49db5bd9653c04dab56e3b2255e518c381f3b1d) nixos/dovecot: add compatibility for Dovecot 2.4
* [`8df2a9cb`](https://github.com/NixOS/nixpkgs/commit/8df2a9cbab64ed655a04dacceaeacbac022984f1) nixos/dovecot: define module defaults as options
* [`0ad86118`](https://github.com/NixOS/nixpkgs/commit/0ad86118b7b977437d136d104fe3b5e6f1a906e4) nixosTests.dovecot: use matching dovecot_pigeonhole
* [`c52bb71f`](https://github.com/NixOS/nixpkgs/commit/c52bb71f0cbfb5a996f9c6eb311e5bb60b6caedd) nixosTests.dovecot: set dovecot_{config,storage}_version
* [`400aecc2`](https://github.com/NixOS/nixpkgs/commit/400aecc29b905b717b4a608bd37406451b74de99) nixos/dovecot: remove defaults for PAM and mail driver/path
* [`3fe307bd`](https://github.com/NixOS/nixpkgs/commit/3fe307bd52b9b8b8f6f4e61b41fe7c66f795fb78) nixos/dovecot: add release notes
* [`2167d634`](https://github.com/NixOS/nixpkgs/commit/2167d634c647f3d58870bc443ee6832953e33f60) sdl_gamecontrollerdb: 0-unstable-2026-04-02 -> 0-unstable-2026-04-10
* [`6ff4a4ad`](https://github.com/NixOS/nixpkgs/commit/6ff4a4adfb64441ec951cacd41f02896efb8e74f) libretro.prboom: 0-unstable-2026-03-31 -> 0-unstable-2026-04-10
* [`8ec2fb02`](https://github.com/NixOS/nixpkgs/commit/8ec2fb0281778042d0f54a3f3b62ddd7270edbb2) shellhub-agent: 0.24.0 -> 0.24.1
* [`692e94a1`](https://github.com/NixOS/nixpkgs/commit/692e94a1cf24eeab2129935c63a5094611389b1b) nixos-rebuild-ng: don't resolve /run/current-system symlink for --diff
* [`f6bb2f78`](https://github.com/NixOS/nixpkgs/commit/f6bb2f78160082bfde9da49ad44cd0ee726935af) parsedmarc: 9.5.5 -> 9.6.0
* [`64ba6f72`](https://github.com/NixOS/nixpkgs/commit/64ba6f72ff8ae5b459eedc114f6c17ad4739d6d3) pocketbase: 0.36.8 -> 0.36.9
* [`7114e767`](https://github.com/NixOS/nixpkgs/commit/7114e76717383169a44bf5ac97bc8237902bfd86) hieroglyphic: 2.2.0 -> 2.3.0
* [`40b3b096`](https://github.com/NixOS/nixpkgs/commit/40b3b096a9d35effce234a530d2eff9ed0077f3d) zinit: use $man and normalize install permissions
* [`b42737cf`](https://github.com/NixOS/nixpkgs/commit/b42737cf8a938d713836d4498c54ba8892691109) diff-so-fancy: add updateScript
* [`e523d563`](https://github.com/NixOS/nixpkgs/commit/e523d5636f2edfa5688d5fa05b3adc64ef6d9a89) diff-so-fancy: 1.4.8 -> 1.4.10
* [`b6f90b0d`](https://github.com/NixOS/nixpkgs/commit/b6f90b0d833d81c3f8827ba9064e465069a8dc73) sqlcmd: 1.9.0 -> 1.10.0
* [`6c4da7fd`](https://github.com/NixOS/nixpkgs/commit/6c4da7fdb57c7ee434bec173bf15a40aae69c7e9) dwproton-bin: dwproton-10.0-22 -> dwproton-10.0-23
* [`d767cd1c`](https://github.com/NixOS/nixpkgs/commit/d767cd1c72f8fbf778a32a211018603f921481ff) ceph: 19.2.3 -> 20.2.0
* [`24b84ece`](https://github.com/NixOS/nixpkgs/commit/24b84ecea9683feed5158ad9d307fddd6ebb09a7) ceph: no null defaults
* [`36f54b56`](https://github.com/NixOS/nixpkgs/commit/36f54b568e3339faea0c2a9c6527a4b48756fc4f) ceph: lib.cmake{Bool,Feature,OptionType}
* [`b3f38f83`](https://github.com/NixOS/nixpkgs/commit/b3f38f8397bbed9ddc507641993a28db2e0881c6) ceph: modern python build system invocation
* [`10d11ec9`](https://github.com/NixOS/nixpkgs/commit/10d11ec9651aa80aaa417af0de1f16ed5987ed1e) rl-2605: ceph 20.2.0 major update
* [`3828d1e9`](https://github.com/NixOS/nixpkgs/commit/3828d1e9ba633fbd01fe5b91e215958cdf4833f5) ceph: 20.2.0 -> 20.2.1
* [`277c1865`](https://github.com/NixOS/nixpkgs/commit/277c18651616998dcce7d70be6eaae80aefc36c4) nixos/tests/ceph-single-node: add ceph dashboard test coverage
* [`69fa5f7f`](https://github.com/NixOS/nixpkgs/commit/69fa5f7f7d8a119cb7ef8346d649c213a8b2ea85) nixos/tests/ceph-single-node: add ceph rgw dashboard test coverage
* [`312e4af5`](https://github.com/NixOS/nixpkgs/commit/312e4af562f3cfc23e64883f40ab9490355b50fc) dopewars: fix build with gcc15
* [`82ebeb39`](https://github.com/NixOS/nixpkgs/commit/82ebeb39cb4951cc7aad0b52f803a99b95bcdb0a) saga: 9.11.3 -> 9.11.4
* [`356ee919`](https://github.com/NixOS/nixpkgs/commit/356ee9197f29211f99dd9f7bc52fb56477002d1a) webull-desktop: fix unfindable .desktop file
* [`be45f239`](https://github.com/NixOS/nixpkgs/commit/be45f239d79a23fedde8e048cae33f7ed975b6bb) vimPlugins.fff-nvim: 0.5.1 -> 0.5.2
* [`f8ce33f9`](https://github.com/NixOS/nixpkgs/commit/f8ce33f97829d023760c1969f92a2a255c93779a) seanime: 3.5.0 -> 3.5.2, refactor
* [`6750952b`](https://github.com/NixOS/nixpkgs/commit/6750952b5fa6eea93036d3f1ce7398369061bd61) rustical: 0.12.10 -> 0.12.11
* [`c6e705f7`](https://github.com/NixOS/nixpkgs/commit/c6e705f7e4d565b4d51b49586283cb020d6aedc3) nerva: 1.2.0 -> 1.3.0
* [`0fca3515`](https://github.com/NixOS/nixpkgs/commit/0fca351507047fea4afc6dec834e6126a6fe4293) openmm: 8.5.0 -> 8.5.1
* [`551cb191`](https://github.com/NixOS/nixpkgs/commit/551cb1912a3a2f53d1f4e70ee0db38bd77db3055) python3Packages.openmm: 8.5.0 -> 8.5.1
* [`a0f50bab`](https://github.com/NixOS/nixpkgs/commit/a0f50bab3623e0b415485b04c71b5dad90a6eacd) elvis-erlang: 5.0.2 -> 5.0.3
* [`395b84b0`](https://github.com/NixOS/nixpkgs/commit/395b84b0a4a866986aa4cf84f4604b43e646a420) kubernetes-helmPlugins.helm-diff: 3.15.4 -> 3.15.5
* [`bd4c541a`](https://github.com/NixOS/nixpkgs/commit/bd4c541a469f39a4f7d8f68dc9c659d263ab7060) elpaPackages: update on 2026-04-11 (from emacs-overlay)
* [`3953527c`](https://github.com/NixOS/nixpkgs/commit/3953527ccb02098f643c356ddc7248fe850ae621) elpaDevelPackages: update on 2026-04-11 (from emacs-overlay)
* [`40a8f2e5`](https://github.com/NixOS/nixpkgs/commit/40a8f2e59b15878887c637bbc1a38ae5030239af) melpaPackages, melpaStablePackages: update on 2026-04-11 (from emacs-overlay)
* [`2e174b52`](https://github.com/NixOS/nixpkgs/commit/2e174b522f9b2ded174f4beaf63b27b4837770c3) nongnuPackages: update on 2026-04-11 (from emacs-overlay)
* [`bfba9dc3`](https://github.com/NixOS/nixpkgs/commit/bfba9dc3452d6facabfd24a8450b78b084ba886e) nongnuDevelPackages: update on 2026-04-11 (from emacs-overlay)
* [`d068d801`](https://github.com/NixOS/nixpkgs/commit/d068d80167df0b184f6b8ddcaaa9917314c52afa) tombi: 0.9.13 -> 0.9.16
* [`a3a9b7c7`](https://github.com/NixOS/nixpkgs/commit/a3a9b7c71895d097d13484bf2af33285fc4841ba) fishPlugins.exercism-cli-fish-wrapper: 0-unstable-2026-02-23 -> 0-unstable-2026-04-06
* [`a822ec5a`](https://github.com/NixOS/nixpkgs/commit/a822ec5a8e9f3c006c418e1525d2f82d86707bd8) python3Packages.pysnooper: disable timing-sensitive test on all Darwin
* [`6c530595`](https://github.com/NixOS/nixpkgs/commit/6c530595f6f1ea4d245e3475b3846e6b1cf0c62b) dosage-tracker: 2.1.5 -> 2.1.6
* [`f6767537`](https://github.com/NixOS/nixpkgs/commit/f676753706a985c3a1f994a463295666c589adc0) ansible-navigator: 26.1.3 -> 26.4.0
* [`61828db6`](https://github.com/NixOS/nixpkgs/commit/61828db603c2df2831b429a178ec23d675ec3295) starkiller: 3.3.0 -> 3.4.0
* [`9624ef5a`](https://github.com/NixOS/nixpkgs/commit/9624ef5a2e95a464455733f73d2b1c9822aef299) python3Packages.apycula: 0.31 -> 0.32
* [`347c38c9`](https://github.com/NixOS/nixpkgs/commit/347c38c949bc4e23166d03108ac78a444fe2854f) python3Packages.sklearn2pmml: 0.129.2 -> 0.130.0
* [`44cae4b7`](https://github.com/NixOS/nixpkgs/commit/44cae4b72824506ced9821083049e3cb236cccda) ente-web: 1.3.24 -> 1.3.32
* [`cafe89fe`](https://github.com/NixOS/nixpkgs/commit/cafe89fe26a09559c30e4317e1618ec05625dd96) jellyfin-tui: 1.4.1 -> 1.4.2
* [`d8ebeb73`](https://github.com/NixOS/nixpkgs/commit/d8ebeb7399ab052b9dd29afba06bee84c4898cbc) python3Packages.socid-extractor: 0.0.27 -> 0.0.28
* [`755334ed`](https://github.com/NixOS/nixpkgs/commit/755334ed6159a73490e3625acde66421bb3df9cc) gradle: workaround for multiple console arguments error
* [`f2f0f328`](https://github.com/NixOS/nixpkgs/commit/f2f0f3282186671a22a896f9fcff7c96e4392f10) apacheHttpdPackages.php: 8.4.19 -> 8.4.20
* [`8ab319b8`](https://github.com/NixOS/nixpkgs/commit/8ab319b87ed60eb234751b42e9b7abb0f1ffb5ef) s7: 11.8-unstable-2026-04-02 -> 11.8-unstable-2026-04-08
* [`eaa2277e`](https://github.com/NixOS/nixpkgs/commit/eaa2277e8d4c03f72926dffa14103e4cdee1f046) nixos/systemd: fix service `sshd-vsock@`
* [`44a66581`](https://github.com/NixOS/nixpkgs/commit/44a66581f5fb35cb31c5a211ebc860dc4cf04249) all-the-package-names: 2.0.2405 -> 2.0.2413
* [`39178881`](https://github.com/NixOS/nixpkgs/commit/3917888188ac400b737d4c394fbbb8a06d9a3daf) pyroscope: 1.19.1 -> 1.20.3
* [`a6556611`](https://github.com/NixOS/nixpkgs/commit/a6556611cbd1b963dd10f2143fe5e4e8ecf4db1e) python3Packages.pytenable: 1.9.0 -> 1.9.1
* [`713b19b5`](https://github.com/NixOS/nixpkgs/commit/713b19b56e89fe65c660bf151c6c88e10fc92725) python3Packages.mypy-boto3-connect: 1.42.85 -> 1.42.88
* [`f4235106`](https://github.com/NixOS/nixpkgs/commit/f4235106b2ebbf0ec288653ca41d629feebc879c) python3Packages.mypy-boto3-ecs: 1.42.85 -> 1.42.88
* [`8b14aeb5`](https://github.com/NixOS/nixpkgs/commit/8b14aeb5818d86fc09166c9b27f90d95eed55804) python3Packages.mypy-boto3-imagebuilder: 1.42.83 -> 1.42.88
* [`e301dc49`](https://github.com/NixOS/nixpkgs/commit/e301dc49d066adf21e9935c1ad8de54c0cbd4164) python3Packages.mypy-boto3-mediaconvert: 1.42.71 -> 1.42.88
* [`952e3ead`](https://github.com/NixOS/nixpkgs/commit/952e3ead72340205475dd532b61c8aedfb267c76) python3Packages.mypy-boto3-sagemaker: 1.42.87 -> 1.42.88
* [`3c888cd2`](https://github.com/NixOS/nixpkgs/commit/3c888cd243e8b1af5c08f2d591c41343f50b67ef) python3Packages.boto3-stubs: 1.42.87 -> 1.42.88
* [`839c2c77`](https://github.com/NixOS/nixpkgs/commit/839c2c777a5f41db93035c3449ba04c65c90dac2) python3Packages.publicsuffixlist: 1.0.2.20260410 -> 1.0.2.20260411
* [`92105b74`](https://github.com/NixOS/nixpkgs/commit/92105b74aff0e3a2767c846a54779aa97f815b88) limine: 11.2.1 -> 11.3.1
* [`e22e4517`](https://github.com/NixOS/nixpkgs/commit/e22e4517b3b55cab8769c15cc9bb9a70b76ef4e1) google-lighthouse: 13.0.3 -> 13.1.0
* [`566977e0`](https://github.com/NixOS/nixpkgs/commit/566977e07c6cacb8438e4eda3c2283710a30dc9e) quickjs-ng: 0.13.0 -> 0.14.0
* [`9af19e3e`](https://github.com/NixOS/nixpkgs/commit/9af19e3e7a14802d7ddbaebaa005ba49e4a798a2) kazumi: 2.0.6 -> 2.0.7
* [`1998d598`](https://github.com/NixOS/nixpkgs/commit/1998d59849f83d79c85690bd1b8d90d2b51e6b56) webdav: 5.11.4 -> 5.11.5
* [`1346f957`](https://github.com/NixOS/nixpkgs/commit/1346f9578d3a8b87e561c9034fcdaf540a69a7c7) python3Packages.weaviate-client: 4.20.4 -> 4.20.5
* [`ae688060`](https://github.com/NixOS/nixpkgs/commit/ae6880608184866b0dbb9f4d149657d498074df0) inspircd: 4.10.0 -> 4.10.1
* [`7f3917eb`](https://github.com/NixOS/nixpkgs/commit/7f3917eb2611a622912247829d8c4d9aa6cab7ae) python3Packages.ai-edge-litert: 2.1.3 -> 2.1.4
* [`324cfa33`](https://github.com/NixOS/nixpkgs/commit/324cfa33ae83cc1fc05b98127c540619eb65ce74) python3Pakcages.socid-extractor: migrate to finalAttrs
* [`bf17e84d`](https://github.com/NixOS/nixpkgs/commit/bf17e84d656b177e91502702c315fb2ec4e4e839) libgedit-gfls: 0.4.0 -> 0.4.1
* [`d017cb71`](https://github.com/NixOS/nixpkgs/commit/d017cb7164575a9a288454561d99218a5a1f1e54) tidb: fix build by using buildGo125Module
* [`8c054b1d`](https://github.com/NixOS/nixpkgs/commit/8c054b1d0b609e3b98156c9166719a25785b7a5d) activemq: 6.2.1 -> 6.2.4
* [`8a422e62`](https://github.com/NixOS/nixpkgs/commit/8a422e625fb7328d28435d925384a6445e7dc9a0) fex: 2603 -> 2604
* [`e8c3cd34`](https://github.com/NixOS/nixpkgs/commit/e8c3cd34b56f2d1cf7b90cfff527bbc4b9da67a9) apkid: 3.0.0 -> 3.1.0
* [`f71266bc`](https://github.com/NixOS/nixpkgs/commit/f71266bc37ad3092243eb63a9e34c4c5c7adb462) goshs: 2.0.0-beta.3 -> 2.0.0-beta.5
* [`7dcab9a9`](https://github.com/NixOS/nixpkgs/commit/7dcab9a94514f6198fcd7ba9934fc07d28d7ccc0) temporal: 1.30.3 -> 1.30.4
* [`6c43eafa`](https://github.com/NixOS/nixpkgs/commit/6c43eafa84a6cdaa2a3ef6202fc3a45d370b0c57) python3Packages.zwave-js-server-python: 0.68.0 -> 0.69.0
* [`6b47267b`](https://github.com/NixOS/nixpkgs/commit/6b47267b2b8cb978c81324b36cb8c38ed463a97d) museum: 1.3.28 -> 1.3.32
* [`6fd614c5`](https://github.com/NixOS/nixpkgs/commit/6fd614c54f1779db8d34d5bcf549dae949b58fa4) rio: 0.3.1 -> 0.3.4
* [`99430236`](https://github.com/NixOS/nixpkgs/commit/99430236f77a5711c9f7d71cb60e75fac4e567f5) mupdf: 1.27.0 -> 1.27.2
* [`8edb50ea`](https://github.com/NixOS/nixpkgs/commit/8edb50ea73b38e80cfe8d6d47a81f1f4ac756053) anchor: 0.31.1 -> 1.0.0
* [`d2bd7d91`](https://github.com/NixOS/nixpkgs/commit/d2bd7d91e06c502ff696745b1ebdc04c0ab7dd8e) nixos/{pipewire,wireplumber}: add LADSPA plugin path setup
* [`c2ded5ea`](https://github.com/NixOS/nixpkgs/commit/c2ded5ea3a1059164fa8585f9918a88869ff62b7) python3Packages.niquests: 3.18.4 -> 3.18.5
* [`036756aa`](https://github.com/NixOS/nixpkgs/commit/036756aadb1c595eb1451e3c3886fd0b6a815523) python3Packages.llama-stack-client: 0.7.1 -> 0.7.2
* [`0233beda`](https://github.com/NixOS/nixpkgs/commit/0233beda0fa041859d84536d10b1ced84fd17f58) nix: add throw aliases for the removed 2.33 and 2.34
* [`32772455`](https://github.com/NixOS/nixpkgs/commit/32772455232c9bb5aa1277a653af34c303d3db95) julia_112-bin: 1.12.5 -> 1.12.6
* [`fc0efc8e`](https://github.com/NixOS/nixpkgs/commit/fc0efc8eeee70baee5568681be96e1482730a9a4) julia_112: 1.12.5 -> 1.12.6
* [`0f2cacf9`](https://github.com/NixOS/nixpkgs/commit/0f2cacf9da8525dba94c448bf65795edf7cd5afe) brutus: 1.2.1 -> 1.3.0
* [`45c1e56b`](https://github.com/NixOS/nixpkgs/commit/45c1e56b1fb693b541a8c72d2b955778844fffc1) usque: 1.4.2 -> 2.0.1
* [`b4d17f0c`](https://github.com/NixOS/nixpkgs/commit/b4d17f0cfa3f1154d85b8b1a179b31245af81500) haskell.compiler.native-bignum: don't evaluate compiler exprs
* [`0ff3c4a8`](https://github.com/NixOS/nixpkgs/commit/0ff3c4a82e92ba61d553704b8ed54ce7fa1a6d46) qwen-code: 0.14.0 -> 0.14.3
* [`488bb0f6`](https://github.com/NixOS/nixpkgs/commit/488bb0f65235e4394d234fe6761dc267400b8e7e) python3Packages.telnetlib3: 4.0.1 -> 4.0.2
* [`3c44c722`](https://github.com/NixOS/nixpkgs/commit/3c44c722b4b568056ffd6aa781d2d1e831d24c87) python3Packages.losant-rest: 2.1.3 -> 2.1.4
* [`3ce568b2`](https://github.com/NixOS/nixpkgs/commit/3ce568b26a90e8360f93535b2f1cff6be2f888e0) identity: 25.10.1 -> 26.03
* [`513dfd22`](https://github.com/NixOS/nixpkgs/commit/513dfd22b818dade5ee0ba800a198c199fe55ee4) peazip: add ProxyVT as maintainer
* [`721dd9c6`](https://github.com/NixOS/nixpkgs/commit/721dd9c62459d1f60fd5bb6a80aa87ac2cef9238) linux_testing: 7.0-rc6 -> 7.0-rc7
* [`6f8920ea`](https://github.com/NixOS/nixpkgs/commit/6f8920ea4656734fbb6490907774a58c448a5167) sptlrx: 1.3.0 -> 1.3.1
* [`27ba00de`](https://github.com/NixOS/nixpkgs/commit/27ba00deb7c28b8eba4798c4b73e265493618e22) sampo: 0.17.2 -> 0.17.3
* [`ca1e1fbc`](https://github.com/NixOS/nixpkgs/commit/ca1e1fbc50c9a0be6facfd3c12882671ff2c7cd9) linux_6_19: 6.19.11 -> 6.19.12
* [`c25eab49`](https://github.com/NixOS/nixpkgs/commit/c25eab496979a9283a37e559fb95ad8eb311aeae) linux_6_18: 6.18.21 -> 6.18.22
* [`c9c2a2b5`](https://github.com/NixOS/nixpkgs/commit/c9c2a2b5753618a9fcb98032cb5918e4a293a269) linux_6_12: 6.12.80 -> 6.12.81
* [`6ad3e8ad`](https://github.com/NixOS/nixpkgs/commit/6ad3e8add4b5e27ff1f24b47d11a51702687125d) linux_6_6: 6.6.132 -> 6.6.134
* [`6f346323`](https://github.com/NixOS/nixpkgs/commit/6f3463230872eb1c491d292aaa3d3208cfdbf87d) linux_6_1: 6.1.167 -> 6.1.168
* [`4afdaea0`](https://github.com/NixOS/nixpkgs/commit/4afdaea00c753810dfa961a3d7f19b0ef249c321) postgresqlPackages.system_stats: 3.2.1 -> 4.0
* [`381c05cd`](https://github.com/NixOS/nixpkgs/commit/381c05cdbde705ed996678555ef478783b96a102) rgx: 0.10.1 -> 0.10.2
* [`f541fda2`](https://github.com/NixOS/nixpkgs/commit/f541fda2e07e1fd4cb80b43f01f6c2b0fe7d434d) python3Packages.satel-integra: 1.0.0 -> 1.1.0
* [`9d72eaf4`](https://github.com/NixOS/nixpkgs/commit/9d72eaf4215cb4e7aa70a919e50dddbdbdcb8c8a) systemd: passthru withLogind
* [`8f846120`](https://github.com/NixOS/nixpkgs/commit/8f84612000162cb81025ceae990d3d7697e428b1) zat: init at 0.5.3
* [`cec12e4f`](https://github.com/NixOS/nixpkgs/commit/cec12e4f1fe2c4e41037046d42a801616025afa5) equibop: 3.1.8 -> 3.1.9
* [`490f1bdb`](https://github.com/NixOS/nixpkgs/commit/490f1bdb043ea3b5ca4315d7e8147fbf96d1d741) typora: 1.12.4 -> 1.13.2
* [`7fe1b2df`](https://github.com/NixOS/nixpkgs/commit/7fe1b2df2739d84fe81383acae303769c43ba22b) go-ios: 1.0.206 -> 1.0.207
* [`fa98e57f`](https://github.com/NixOS/nixpkgs/commit/fa98e57f86fa5d139683d630b27da89dc5c02c19) grafanaPlugins.grafana-opensearch-datasource: 2.24.0 -> 2.33.0
* [`b2e08cbf`](https://github.com/NixOS/nixpkgs/commit/b2e08cbff239ae8dbd82ffb58dd2529b525b9335) python3Packages.pynintendoparental: 2.3.3 -> 2.3.4
* [`fa67e022`](https://github.com/NixOS/nixpkgs/commit/fa67e022a560afd6b8e9fef5737902996556f4bc) python3Packages.actron-neo-api: 0.4.1 -> 0.5.1
* [`fc5b6c35`](https://github.com/NixOS/nixpkgs/commit/fc5b6c35691705df21e8d453fff6d87ab755dbd8) vscode-extensions.vytautassurvila.csharp-ls: 0.0.30 -> 0.0.31
* [`ef30ce05`](https://github.com/NixOS/nixpkgs/commit/ef30ce0571478d2fb00c19510d0a49867d611bf9) python3Packages.git-find-repos: 2.1.0 -> 2.1.1
* [`267f1c71`](https://github.com/NixOS/nixpkgs/commit/267f1c712e8ddad0fcd61b71a4f21c34cd5d12d3) highscore-mupen64plus: 0-unstable-2026-01-05 -> 0-unstable-2026-04-10
* [`8a0fe3e3`](https://github.com/NixOS/nixpkgs/commit/8a0fe3e3afd2ba7da9f67c20990f7f9196990963) complgen: 0.8.3 -> 0.9.0
* [`7ce2f610`](https://github.com/NixOS/nixpkgs/commit/7ce2f6105f78710630cfef8929c273b9cfc0daef) gotools: 0.34.0 -> 0.44.0
* [`e9489fa0`](https://github.com/NixOS/nixpkgs/commit/e9489fa0806f77c53807016634cff2c56c8b512d) _3proxy: 0.9.5 -> 0.9.6
* [`8d3d761d`](https://github.com/NixOS/nixpkgs/commit/8d3d761dcc6c9da60f9b151e597051bccf7a947a) mopidy-argos: 1.16.1 -> 1.17.0
* [`d3d6e2f3`](https://github.com/NixOS/nixpkgs/commit/d3d6e2f38b510bc41e98bf386e34429af6accd2a) bats: use writeText instead of passAsFile
* [`5f5d29e3`](https://github.com/NixOS/nixpkgs/commit/5f5d29e3a23c775790e3ca6aabdac716306622f9) bats: add let binding to passthru.tests.libraries
* [`5eca6592`](https://github.com/NixOS/nixpkgs/commit/5eca65929e3f5c921a7e5feb34ac852697f6fe96) bats.withLibraries: inherit meta from bats
* [`8a1527a1`](https://github.com/NixOS/nixpkgs/commit/8a1527a1be9ec70aad23f156a6d5726f6648c8b6) openapi-generator-cli: use more idiomatic formats.json instead of toFile/toJSON
* [`a276841f`](https://github.com/NixOS/nixpkgs/commit/a276841f672f81f60208be3166b1af789f5cd3e3) json-schema-catalog-rs-formats: use more idiomatic formats.json instead of toFile/toJSON
* [`84c13f16`](https://github.com/NixOS/nixpkgs/commit/84c13f1619e6fb94a9840465036b33f4f8e6a2e7) terraform-providers.aliyun_alicloud: 1.274.0 -> 1.275.0
* [`1825b8b4`](https://github.com/NixOS/nixpkgs/commit/1825b8b419b9d0ac2b7648e8bde50970477fcd62) dasel: document v2 to v3 breaking changes
* [`c9b3c4a7`](https://github.com/NixOS/nixpkgs/commit/c9b3c4a7c1e17db08f8831a20a2cb8ed11ec7525) libzim: 9.5.1 -> 9.6.0
* [`0cebcf63`](https://github.com/NixOS/nixpkgs/commit/0cebcf63f406f46b42b42f5e7e5eedf29cac24ad) code-cursor: update hash for {aarch64,x86_64}-linux
* [`d9337fdd`](https://github.com/NixOS/nixpkgs/commit/d9337fdd460bc48e9ed26f56e372f443a10f34c9) everest: 6194 -> 6249
* [`30eec28a`](https://github.com/NixOS/nixpkgs/commit/30eec28a3e289b26542742775b0251b070f215a8) justbuild: 1.6.4 -> 1.6.5
* [`efdf5e1f`](https://github.com/NixOS/nixpkgs/commit/efdf5e1f017f25b72bdf9994b6bc119a61294dcd) trilium-desktop: 0.102.1 -> 0.102.2
* [`7745830a`](https://github.com/NixOS/nixpkgs/commit/7745830a7c504a2bc20df991ff22fbe6d2f73cf0) rclone-ui: 3.5.0 -> 3.5.3
* [`bd9809cb`](https://github.com/NixOS/nixpkgs/commit/bd9809cb194247287d270021cbd07db946150c04) grafanaPlugins.volkovlabs-form-panel: 6.3.1 -> 6.3.2
* [`b9c92a83`](https://github.com/NixOS/nixpkgs/commit/b9c92a83a9733f8072662be9ac96dc430eba875a) grafanaPlugins.grafana-lokiexplore-app: 2.0.1 -> 2.0.3
* [`129064c3`](https://github.com/NixOS/nixpkgs/commit/129064c380b6ef2f3a5cf7658fa3967b0508d816) solanum: 0-unstable-2026-03-25 -> 0-unstable-2026-04-09
* [`db609f68`](https://github.com/NixOS/nixpkgs/commit/db609f68ff1bb27f03022feea2667775e8f396a0) libretro.yabause: 0-unstable-2025-12-20 -> 0-unstable-2026-04-10
* [`11d83ca0`](https://github.com/NixOS/nixpkgs/commit/11d83ca0722ad8809a776b613de5618456234a67) python3Packages.compressed-tensors: 0.14.0.1 -> 0.15.0.1
* [`65e12b96`](https://github.com/NixOS/nixpkgs/commit/65e12b960f55a16c1121d77cb00d01f077bfe560) yaziPlugins: init split-tabs
* [`1988ea5e`](https://github.com/NixOS/nixpkgs/commit/1988ea5e07ba87ee47cba0a27363d16036b09d41) rcu: 4.0.33 -> 4.0.34
* [`d904f096`](https://github.com/NixOS/nixpkgs/commit/d904f09652f0f7c884bcd12da5d6b5e7d6dfa49a) rcu: Fix passthru.tests.version check
* [`4324c79e`](https://github.com/NixOS/nixpkgs/commit/4324c79ea787baf3ac1526ffdbf9dfc06726321a) dnsmonster: fix build using buildGo125Module
* [`fcf23489`](https://github.com/NixOS/nixpkgs/commit/fcf234898e4d5761d3e37b0c14e01b9ebf3bd3ff) rofi: remove workaround for missing root user
* [`5658a627`](https://github.com/NixOS/nixpkgs/commit/5658a6277ad88e4b11539d6b63a06df195ae0ff7) tandoor-recipes: 2.6.4 -> 2.6.6
* [`694c89ec`](https://github.com/NixOS/nixpkgs/commit/694c89ec5e92349f6fd3d74e1a41126cdcdea60d) openspec: add kalbasit as maintainer
* [`63a69c78`](https://github.com/NixOS/nixpkgs/commit/63a69c78aaa4f41b3f7d4a63db73a0098e9446ce) openspec: add update script
* [`b25c0c8c`](https://github.com/NixOS/nixpkgs/commit/b25c0c8c9cf90a2dc12e42bfdba94ed8c9b29730) openspec: 1.2.0 -> 1.3.0
* [`48b46015`](https://github.com/NixOS/nixpkgs/commit/48b46015139ee107c44c611c0fc1c7e7677f8e1b) liteparse: 1.4.4 -> 1.4.6
* [`2dcd7e06`](https://github.com/NixOS/nixpkgs/commit/2dcd7e0684477ac035cc9f284cd5dce24aa5bac5) drift: 0.11.0 -> 1.0.1
* [`96862439`](https://github.com/NixOS/nixpkgs/commit/968624394dd8c5023da349b12da35f98e6601f73) zluda: 6-preview.55 -> 6-preview.63
* [`b3981c08`](https://github.com/NixOS/nixpkgs/commit/b3981c089675691f4e805a37c67fe39673744b57) requireFile: don't perform Bash expansion
* [`910b6afc`](https://github.com/NixOS/nixpkgs/commit/910b6afc38db9970e24eab51fa033e5afc1cf27d) python3Packages.mhcgnomes: 3.19.0 -> 3.31.1
* [`df256c93`](https://github.com/NixOS/nixpkgs/commit/df256c9333010db58aabb891812491754d9a0f1e) rapidraw: 1.5.2 -> 1.5.3
* [`54dfa0a7`](https://github.com/NixOS/nixpkgs/commit/54dfa0a78d5bec8cd95cd150d31bbf042916f61f) tenv: 4.9.3 -> 4.10.1
* [`0bb40e8e`](https://github.com/NixOS/nixpkgs/commit/0bb40e8e610996805a094038710ef29257582adc) roslyn-ls: 5.6.0-2.26163.11 -> 5.7.0-1.26203.6
* [`913747b8`](https://github.com/NixOS/nixpkgs/commit/913747b843a499ccabf467dce268cb118419cbdb) nixos/logind: only enable if systemd-logind was built
* [`ddb45b48`](https://github.com/NixOS/nixpkgs/commit/ddb45b48cd84ca36ee66c982b1720fcd783ff263) corn-cli: init at 0.10.1
* [`b3f14a7e`](https://github.com/NixOS/nixpkgs/commit/b3f14a7e684387f963a4adfaf81ef5a94c7cb114) mle: 1.7.2 -> 1.8.1
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
