### PR TITLE
npins nixpkgs: update 566acc07 -> b86751bc

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -132,8 +132,8 @@
     "nixpkgs": {
       "type": "Channel",
       "name": "nixpkgs-unstable",
-      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-26.05pre980800.566acc07c54d/nixexprs.tar.xz",
-      "hash": "sha256-bo9Hbl5yPjDRldsn1Stnbsmn/nPF0cVlowuLSGHduuA="
+      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-26.05pre981196.b86751bc4085/nixexprs.tar.xz",
+      "hash": "sha256-mBqzkn7oJti2hqeO8iTbDxKw+1ifxpP53feQ0CEXies="
     },
     "powerlevel10k": {
       "type": "Git",


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: release-26.05
Commits: [nixos/nixpkgs@566acc07...b86751bc](https://github.com/nixos/nixpkgs/compare/566acc07c54d...b86751bc4085)

* [`3210c830`](https://github.com/NixOS/nixpkgs/commit/3210c83024ae9acd2d3693f17d1ffbca03bdaaa2) coccinelle: 1.3.0 -> 1.3.1
* [`4653d818`](https://github.com/NixOS/nixpkgs/commit/4653d8180c44698a759dfe5963a83fbc7060e61b) tvm: 0.22.0 -> 0.23.0
* [`b719420e`](https://github.com/NixOS/nixpkgs/commit/b719420ee3c5eb1beebc1b385f7b0eb14b874061) python3Packages.django-soft-delete: 1.0.22 -> 1.0.23
* [`3a9de947`](https://github.com/NixOS/nixpkgs/commit/3a9de94773f386e085141c6bf9c3c8e5d215863d) python3Packages.whitenoise: 6.11.0 -> 6.12.0
* [`8ec1ed83`](https://github.com/NixOS/nixpkgs/commit/8ec1ed830a0fa98a97c4a4d6585e9002444eadf5) python3Packages.dj-database-url: 3.1.0 -> 3.1.2
* [`d7d1ad9e`](https://github.com/NixOS/nixpkgs/commit/d7d1ad9e90d8a6c68ab5ec7ef32670749aa7b221) budgie-desktop-with-plugins: use structuredAttrs instead of passAsFile
* [`b0066a2a`](https://github.com/NixOS/nixpkgs/commit/b0066a2a036f11fb90e2119d8a1b9f63f8c1feb8) kak-tree-sitter-unwrapped: 3.1.3 -> 3.2.0
* [`14c0e8b7`](https://github.com/NixOS/nixpkgs/commit/14c0e8b759c294083fd45892b8ecea09fda96d2e) go-csp-collector: 0.0.17-unstable-2025-11-24 -> 0.0.17
* [`6d3f2e15`](https://github.com/NixOS/nixpkgs/commit/6d3f2e15e81fb2da110c18e639fdf2ec2fca92f1) octavePackages.audio: 2.0.10 -> 2.0.11
* [`ca394c56`](https://github.com/NixOS/nixpkgs/commit/ca394c56a21f4cb54cd9d147a9515edfbde39808) perlPackages.NetIPXS: 0.22 -> 0.23
* [`1aeee74f`](https://github.com/NixOS/nixpkgs/commit/1aeee74f9f6ea76e44b057ebbcbf09670303b477) keepass: use writeText instead of passAsFile
* [`901d3bd9`](https://github.com/NixOS/nixpkgs/commit/901d3bd9d34208d427f499dae0f288567cbf501a) perlPackages.ack: 3.8.2 -> 3.9.0
* [`50a3a816`](https://github.com/NixOS/nixpkgs/commit/50a3a816f6d8ccc55e4c004b2f791fa0ce08bd80) python3Packages.google-cloud-monitoring: 2.29.1 -> 2.30.0
* [`4a1a222f`](https://github.com/NixOS/nixpkgs/commit/4a1a222f73cadad33db4d36a233734963d386e35) vim: enable fortify when using clang
* [`3a8c4e69`](https://github.com/NixOS/nixpkgs/commit/3a8c4e697ca1d22a8f5fd017a4ad8b96f6d42607) nixos/limine: pass distroName using JSON
* [`f6687979`](https://github.com/NixOS/nixpkgs/commit/f6687979350c92ec3085f8287eaa34aaccf27379) python3Packages.qh3: skip broken tests on darwin
* [`5fddbbe0`](https://github.com/NixOS/nixpkgs/commit/5fddbbe01823cff6bdad6bd1e6a9da472993b703) octavePackages.datatypes: 1.2.0 -> 1.2.2
* [`deec62b2`](https://github.com/NixOS/nixpkgs/commit/deec62b2ad51eb1838c87e1e3f404cc7757a462b) homepage-dashboard: 1.12.1 -> 1.12.3
* [`b2e0549b`](https://github.com/NixOS/nixpkgs/commit/b2e0549bcbcccb51845369ae4b2f1054dae5deb4) python3Packages.pypdfium2: 5.6.0 -> 5.7.0
* [`7a022121`](https://github.com/NixOS/nixpkgs/commit/7a02212111ca2ab20b71d72b7a311b86821e9212) python3Packages.django-debug-toolbar: 6.2.0 -> 6.3.0
* [`f1ac2e85`](https://github.com/NixOS/nixpkgs/commit/f1ac2e855c361fabe0e0c442a47df1e4b71f2cab) mcp-grafana: 0.11.4 -> 0.11.6
* [`b34ad9eb`](https://github.com/NixOS/nixpkgs/commit/b34ad9eb377ed4b244035e8139aba0a87d843755) octavePackages.dicom: Run autoconf to build the necessary C++
* [`b1340a1f`](https://github.com/NixOS/nixpkgs/commit/b1340a1f88017a4076e5ebe02129cc3964b03402) octavePackages.dicom: 0.7.1 -> 0.7.2
* [`14391aa2`](https://github.com/NixOS/nixpkgs/commit/14391aa2c4303628147589b8b49bce5b718724df) maintainers: add xeni
* [`856228c1`](https://github.com/NixOS/nixpkgs/commit/856228c18cc9ebf44cee9f683104d620d911d4c2) schildi-revenge: 26.03.03 -> 26.04.04
* [`477f8347`](https://github.com/NixOS/nixpkgs/commit/477f8347a011120a7d33af8ed6b79cd60139a27b) mkvtoolnix: 97.0 -> 98.0
* [`0fafbbb0`](https://github.com/NixOS/nixpkgs/commit/0fafbbb05ba524c7e3d33b0579770f19d0d789dd) sketchybar-app-font: 2.0.55 -> 2.0.58
* [`613c0768`](https://github.com/NixOS/nixpkgs/commit/613c076842e8fd80eaf1d2331e313349991ec401) enlightenment.evisum: 1.2.1 -> 1.2.2
* [`c53e99ff`](https://github.com/NixOS/nixpkgs/commit/c53e99ffe9b6cb4dc4629b730bd98b253d4c0cdb) python3Packages.pypdf: 6.9.2 -> 6.10.0
* [`b99b6d4c`](https://github.com/NixOS/nixpkgs/commit/b99b6d4cf1027b4a4e20cd3516fc63b918c02a88) uhhyou-plugins: 0.69.0 -> 0.70.0
* [`4ad50d60`](https://github.com/NixOS/nixpkgs/commit/4ad50d60631d5ef12f487081e36a6b9b4c56f3c3) nixosTests.opensmtpd: fixup for new dovecot module
* [`070a701e`](https://github.com/NixOS/nixpkgs/commit/070a701e69d11f36f7131ca7dd10138029319675) nixosTests.alps: fixup for new dovecot module
* [`5d9157f0`](https://github.com/NixOS/nixpkgs/commit/5d9157f0773e230ddfe4488cd039fffed75527d5) nixosTests.discourse: fixup for new dovecot module
* [`db2a583e`](https://github.com/NixOS/nixpkgs/commit/db2a583e7d11082389c937adebbbbcb056c55c5c) nixosTests.rss2email: fixup for new dovecot module
* [`3e05bcbf`](https://github.com/NixOS/nixpkgs/commit/3e05bcbf0cd8f92d16445c39d4944a5be5dd97da) high-tide: 1.2.0 -> 1.3.0
* [`822792e1`](https://github.com/NixOS/nixpkgs/commit/822792e19fdf1b5d0ecdc5d3ef2cd4b8be76e301) ocamlPackages.mariadb: 1.1.6 → 1.3.0
* [`f4d0915c`](https://github.com/NixOS/nixpkgs/commit/f4d0915cf970f223b6afa233f16109934d3f87a2) seerr: 3.1.0 -> 3.1.1
* [`a92918f7`](https://github.com/NixOS/nixpkgs/commit/a92918f723a122ce7c07d31d8cf7943ee1848aaa) amp-cli: 0.0.1775463997-ga80857 -> 0.0.1776125492-g5cb0c2
* [`2caf4b0a`](https://github.com/NixOS/nixpkgs/commit/2caf4b0a50806c6ab3f336573a255fefaaa67cdf) davinci-resolve: add auxiliary apps, udev rules, and desktop entries
* [`1afc66bb`](https://github.com/NixOS/nixpkgs/commit/1afc66bbf65e910e8b248c9d1898ac323fffc611) davinci-resolve: add cafkafk as maintainer
* [`5d216b39`](https://github.com/NixOS/nixpkgs/commit/5d216b39e999f65685c331a12e449815f63bc476) ocamlPackages.yamlx: init at 0.1.0
* [`cffa3daf`](https://github.com/NixOS/nixpkgs/commit/cffa3daf9fe779628fa5b1c08d72a10c96ecbfde) b4: 0.15.1 -> 0.15.2
* [`36906f45`](https://github.com/NixOS/nixpkgs/commit/36906f45e006a4078a4a3458875c1f7e933e382a) claude-code-bin: 2.1.104 -> 2.1.107
* [`7a73ac90`](https://github.com/NixOS/nixpkgs/commit/7a73ac90f054b9867f821d6766a7ee1332f8db9c) vscode-extensions.anthropic.claude-code: 2.1.101 -> 2.1.107
* [`c49d2483`](https://github.com/NixOS/nixpkgs/commit/c49d2483125f58453f0aa80ead070310fd99aac8) claude-code: 2.1.104 -> 2.1.107
* [`c45a0b1d`](https://github.com/NixOS/nixpkgs/commit/c45a0b1da5a71179f38ca85d770d02ccd4bb4e26) worktrunk: 0.34.2 -> 0.37.0
* [`9e45b43c`](https://github.com/NixOS/nixpkgs/commit/9e45b43c5374a27799394c5b5d149c14581bd055) etherape: 0.9.21 -> 0.9.22
* [`f8e8e6bb`](https://github.com/NixOS/nixpkgs/commit/f8e8e6bb178640c6329f0a6cf5ffa7abd4b4cc8d) webkitgtk_6_0: 2.52.1 → 2.52.2
* [`76c84802`](https://github.com/NixOS/nixpkgs/commit/76c84802512c1024a4ba213910c4dd9a00d5fb61) python3Packages.ddgs: 9.13.0 -> 9.13.1
* [`9ee15cb2`](https://github.com/NixOS/nixpkgs/commit/9ee15cb23d067993cf1c029feb9ae9a892b734c0) vim: 9.2.0106 -> 9.2.0340
* [`69a32875`](https://github.com/NixOS/nixpkgs/commit/69a32875c416046360ab39e963da59d813af0839) infrastructure-agent: 1.73.0 -> 1.73.1
* [`b18142da`](https://github.com/NixOS/nixpkgs/commit/b18142da0d42de5626d2e5b5c419ece9f7e080ee) nats-server: 2.12.6 -> 2.12.7
* [`c6960169`](https://github.com/NixOS/nixpkgs/commit/c696016909d980ff84871d74cdf090e9c236be5a) zap-chip: 2025.07.24 -> 2026.02.26
* [`6152e8cb`](https://github.com/NixOS/nixpkgs/commit/6152e8cbfa2549f3655067949fc7c0c10969c46c) lib/systems: add ARC (Synopsys DesignWare ARC) cross-compilation support
* [`2134dd24`](https://github.com/NixOS/nixpkgs/commit/2134dd24de15ea29450a850a5e34c4645b98a918) python3Packages.deltachat2: 0.9.0 -> 0.10.0
* [`43bc7062`](https://github.com/NixOS/nixpkgs/commit/43bc7062dc7d05ff29c9306764a0ec0802b1f0c8) curl-impersonate: 1.5.1 -> 1.5.2
* [`d408d5bb`](https://github.com/NixOS/nixpkgs/commit/d408d5bb1129d3a3eb3c1c5c03d0781b080d05f1) python3Packages.twilio: 9.10.4 -> 9.10.5
* [`ad38b4da`](https://github.com/NixOS/nixpkgs/commit/ad38b4da20485d131825ef0bd1bd37ef9a1ca323) paperless-ngx: 2.20.13 -> 2.20.14
* [`98fd1b90`](https://github.com/NixOS/nixpkgs/commit/98fd1b90d233be35529601ea7a64a3328efa62ed) python3Packages.cramjam: 2.11.0.post1 -> 2.12.0
* [`5486f98e`](https://github.com/NixOS/nixpkgs/commit/5486f98e62953d5a5649b7672f1074bf7cde1683) python3Packages.celery: 5.6.2 -> 5.6.3
* [`785a28de`](https://github.com/NixOS/nixpkgs/commit/785a28de174bc9b33b5a723a7a2507e077550e6e) python3Packages.pyshark: cleanup
* [`194010e6`](https://github.com/NixOS/nixpkgs/commit/194010e6cb1fdac0ae2054ffb9d5f0208bc88c10) python3Packages.pyshark: disable on python>=3.14
* [`f337673a`](https://github.com/NixOS/nixpkgs/commit/f337673a0199366b1ea1ce74fd82c334895bb6c7) libpulsar: 3.7.2 -> 4.1.0, move to by-name, cleanup
* [`02d1c9ad`](https://github.com/NixOS/nixpkgs/commit/02d1c9ad58d56732a5ae2412981aca62ac4777fa) python3Packages.pulsar-client: 3.9.0 -> 3.10.0
* [`c33f0be9`](https://github.com/NixOS/nixpkgs/commit/c33f0be957ba3fdeb6ba8cd60e73139854afc1ae) grafanaPlugins.grafana-github-datasource: 1.9.2 -> 2.8.0
* [`efc9d597`](https://github.com/NixOS/nixpkgs/commit/efc9d597cc1921597a06b59d68749e02609299c8) chatbox: 1.20.0 -> 1.20.1
* [`4b8286ee`](https://github.com/NixOS/nixpkgs/commit/4b8286eec28b61caead01630f2f486fb1d56a693) deno: 2.7.9 -> 2.7.12
* [`6b1f6939`](https://github.com/NixOS/nixpkgs/commit/6b1f69394d93c8f9b866644b8a53f4ce1c78a219) kronosnet: 1.32 -> 1.33
* [`590f05ac`](https://github.com/NixOS/nixpkgs/commit/590f05ac663786b76d8ee17fd15d4db4b6db7326) python3Packages.pywebtransport: init at 0.16.1
* [`3af49c40`](https://github.com/NixOS/nixpkgs/commit/3af49c40ccf9eaf11a9d0af20ac33fed326157d4) ramalama: 0.17.1 -> 0.18.0
* [`fc29ba15`](https://github.com/NixOS/nixpkgs/commit/fc29ba153fa0fd192a8182b19fd32cbfbce8785e) orthanc: 1.12.10 -> 1.12.11
* [`b914a9a0`](https://github.com/NixOS/nixpkgs/commit/b914a9a017eb170078272d5a484034037f070f09) python3Packages.pywal16: 3.8.14 -> 3.8.15
* [`c0e74793`](https://github.com/NixOS/nixpkgs/commit/c0e7479327332b3ad56c4f195c2cff7d9f415f1b) libmsquic: 2.5.6 -> 2.5.7
* [`dd52084f`](https://github.com/NixOS/nixpkgs/commit/dd52084f6810f28a13bc58205ccbb880b4a354b0) sendspin-go: 1.1.0 -> 1.2.0
* [`233790b8`](https://github.com/NixOS/nixpkgs/commit/233790b80f3ff45723f8bde0260260dd4301ed65) chirp: 0.4.0-unstable-2026-03-24 -> 0.4.0-unstable-2026-04-14
* [`d3add3b7`](https://github.com/NixOS/nixpkgs/commit/d3add3b77c2c236c8e11962f2455312f328f0c8d) livekit-cli: 2.16.0 -> 2.16.2
* [`d2189b2d`](https://github.com/NixOS/nixpkgs/commit/d2189b2de5cfc1e173d41973cc4a9d10d605d6ec) alt-tab-macos: 10.11.0 -> 10.12.0
* [`194b6ea5`](https://github.com/NixOS/nixpkgs/commit/194b6ea5b1860100dd439e754937bd9a8ceafa41) pywal16: 3.8.14 -> 3.8.15
* [`2a8e509e`](https://github.com/NixOS/nixpkgs/commit/2a8e509e8144cbc4620ba5f7516455c9773ee85a) python3Packages.imap-tools: 1.11.1 -> 1.12.0
* [`f69f4b0d`](https://github.com/NixOS/nixpkgs/commit/f69f4b0db616ea05dbbc8bf218212460bb585b26) ultralytics: 8.4.34 -> 8.4.37
* [`ad1ed1f5`](https://github.com/NixOS/nixpkgs/commit/ad1ed1f50ff2ef8d7489752da7f201bcad1853d0) ttop: 1.5.7 -> 1.6.1
* [`079df8a1`](https://github.com/NixOS/nixpkgs/commit/079df8a167f603830dd49b882a17f3d9fb1db731) eas-cli: 16.32.0 -> 18.7.0
* [`96f1cf63`](https://github.com/NixOS/nixpkgs/commit/96f1cf63a65a326c8c7edc4c341d232d1bfebde9) webanalyze: 0.4.1 -> 0.4.3
* [`1fac1b56`](https://github.com/NixOS/nixpkgs/commit/1fac1b56d57ec6cf58bb50fac7f55721df2619b2) witness: 0.10.2 -> 0.11.0
* [`0ef47c14`](https://github.com/NixOS/nixpkgs/commit/0ef47c143f3f2c3c4d56e3bc9c0a262931d1531f) jikken: 0.8.2 -> 0.8.4
* [`5a7e1767`](https://github.com/NixOS/nixpkgs/commit/5a7e17678cb4f7bf9cd7b27f6057390d60c601eb) boulder: 0.20251118.0 -> 0.20260331.0
* [`d15899f1`](https://github.com/NixOS/nixpkgs/commit/d15899f11707c6fa4ba0f8dff0adc47c9513cca0) boulder: use finalAttrs
* [`98ee7489`](https://github.com/NixOS/nixpkgs/commit/98ee748981ad6527a67e6cbc541b10088f5ceca1) boulder: add miniharinn as a maintainer
* [`04655019`](https://github.com/NixOS/nixpkgs/commit/0465501929222d9bdb250b570eb11ab897628228) gnss-sdr: fix build against boost 1.89
* [`1392c5c1`](https://github.com/NixOS/nixpkgs/commit/1392c5c1aca07b6bf86dcf7f6a467a4490c45ed4) minio-warp: 1.4.0 -> 1.4.1
* [`0f173d54`](https://github.com/NixOS/nixpkgs/commit/0f173d541f586c75f92e8035aee3dc21eb19366a) vscode-extensions.illixion.vscode-vibrancy-continued: 1.1.73 -> 1.1.75
* [`1f5ab16a`](https://github.com/NixOS/nixpkgs/commit/1f5ab16a0ee78563d909cd8473cfc41e8490293e) python3Packages.jsonalias: init at 0.1.2
* [`8ec5e5de`](https://github.com/NixOS/nixpkgs/commit/8ec5e5de85041bc6bc7e753ac6806d5b6fb9fce5) oci-cli: 3.77.0 -> 3.79.0
* [`a080aa5e`](https://github.com/NixOS/nixpkgs/commit/a080aa5e3f5522a312f21bb54b6ab231f1a32575) python3Packages.solders: init at 0.27.1
* [`29febf3a`](https://github.com/NixOS/nixpkgs/commit/29febf3a052921dba7ccb4f14472fd7818b8c37e) python3Packages.iocsearcher: 2.5.7 -> 2.7.2
* [`bd381a71`](https://github.com/NixOS/nixpkgs/commit/bd381a717f2d2fce10665593741e3dfd87bf0d1e) grafanaPlugins.victoriametrics-metrics-datasource: 0.23.3 -> 0.23.4
* [`44630770`](https://github.com/NixOS/nixpkgs/commit/44630770ce2af9e12f8e1cfeb8f235a8cdea7452) opencode: 1.4.3 -> 1.4.6
* [`ae0518b8`](https://github.com/NixOS/nixpkgs/commit/ae0518b8a8c2a42850dffe2597d2d0e781afead5) python3Packages.cryptg: 0.5.2 -> 0.6.0
* [`60a90b25`](https://github.com/NixOS/nixpkgs/commit/60a90b25ded5e9dad77e50a9c919c40ffa4dcd6a) ranger: 1.9.4-unstable-2026-04-02 -> 1.9.4-unstable-2026-04-14
* [`11ebe42e`](https://github.com/NixOS/nixpkgs/commit/11ebe42ea2bf64651928b92328aea251893fb2e0) vscode-extensions.yzane.markdown-pdf: 1.5.0 -> 2.0.1
* [`1513e6e6`](https://github.com/NixOS/nixpkgs/commit/1513e6e698227802d0b1e736a50453214a93c032) drupal: 11.3.5 -> 11.3.6
* [`32aadc79`](https://github.com/NixOS/nixpkgs/commit/32aadc795b33ca31f846f82a645ba4e78e1e74a9) prismlauncher-unwrapped: 11.0.1 -> 11.0.2
* [`32c56098`](https://github.com/NixOS/nixpkgs/commit/32c56098eaf998b684f584ece5b3b890edfc8cf9) parca-agent: 0.46.0 -> 0.47.0
* [`f0f0ca57`](https://github.com/NixOS/nixpkgs/commit/f0f0ca576fdc97a2036a657430874af2b33b2f83) mitex: 0.2.6 -> 0.2.7
* [`5bc6b0df`](https://github.com/NixOS/nixpkgs/commit/5bc6b0df45d3109b580dbe2e047a3d80dbafb3e2) vacuum-go: 0.25.5 -> 0.25.8
* [`c30e1e91`](https://github.com/NixOS/nixpkgs/commit/c30e1e91381b495f8c10cd139928ffc832632e72) python3Packages.pymilvus: 2.6.9 -> 2.6.12
* [`3c6d7aad`](https://github.com/NixOS/nixpkgs/commit/3c6d7aad7473c65c53c36451749e6a80f947dcbf) jellyfin-mpv-shim: fix discord rich presence by adding dependencie
* [`35fd5539`](https://github.com/NixOS/nixpkgs/commit/35fd5539532c44dcc4be6fda1f5e489c1cd81bc9) vimPlugins.mellow-nvim: init at 0-unstable-2026-03-30
* [`de70fcab`](https://github.com/NixOS/nixpkgs/commit/de70fcaba288a65d360fbbf7b2c089d7d7353434) php85: 8.5.4 -> 8.5.5
* [`102f7d97`](https://github.com/NixOS/nixpkgs/commit/102f7d9715c9ab37e6f4bd0e16580d4480ec49ac) mark: 16.2.0 -> 16.3.0
* [`d28bf36e`](https://github.com/NixOS/nixpkgs/commit/d28bf36ecdad4ab56baf6109cd4c58efcd1ad86f) asccli: 1.1.1 -> 1.2.2
* [`8c26bd08`](https://github.com/NixOS/nixpkgs/commit/8c26bd086cf600fc3271df052dfba5b4eacd6d39) komikku: 50.1.0 -> 50.2.0
* [`a30fa8df`](https://github.com/NixOS/nixpkgs/commit/a30fa8df99dc24e2e3d8017a7d19af1456839e79) asusctl: 6.3.6 -> 6.3.7
* [`b7412691`](https://github.com/NixOS/nixpkgs/commit/b74126914d2c1162d4926bde981edd9d2fe413bc) terraform-providers.rancher_rancher2: 13.1.4 -> 14.1.0
* [`face395a`](https://github.com/NixOS/nixpkgs/commit/face395a6ffcc5b6dd3a650adc3dd1e4edbcaecc) libutempter: 1.2.1 -> 1.2.3
* [`1494fbca`](https://github.com/NixOS/nixpkgs/commit/1494fbca677d40ff8f09429bd7e19ab73945cc54) vscode-extensions.editorconfig.editorconfig: 0.18.1 -> 0.18.2
* [`36d1a775`](https://github.com/NixOS/nixpkgs/commit/36d1a77540bcbc8a48349de2c71b9293e49fcdbb) python3Packages.gftools: 0.9.994 -> 0.9.995
* [`b0d6b673`](https://github.com/NixOS/nixpkgs/commit/b0d6b673974ebac1c16b2b649f210a0b7089c5e9) vscode: 1.115.0 -> 1.116.0
* [`a2d326cd`](https://github.com/NixOS/nixpkgs/commit/a2d326cd8021f5ef7172dd35a6cf98d9a2efb7f5) terraform-providers.hashicorp_google: 7.26.0 -> 7.28.0
* [`afa88a05`](https://github.com/NixOS/nixpkgs/commit/afa88a05b3bb2db11f4a47ea021f6464fbbcbe02) vgm2x: Pin to old C standard
* [`d2892e58`](https://github.com/NixOS/nixpkgs/commit/d2892e588fc76ac2559531e1a97d6cdb64fb8598) rustls-ffi: 0.15.1 -> 0.15.2
* [`4eff0902`](https://github.com/NixOS/nixpkgs/commit/4eff0902fa8d8b996f5d2d0a2d22c500896368c9) krep: 2.2.0 -> 2.3.0
* [`02fa1b14`](https://github.com/NixOS/nixpkgs/commit/02fa1b14fcea26133e43268a23cee174dc5bb296) nelm: 1.21.0 -> 1.23.2
* [`8cee6dfd`](https://github.com/NixOS/nixpkgs/commit/8cee6dfd2254761ca002eb4a4781ef66ce488b01) python3Packages.pytorch3d: cleanup, fix build with cudaSupport
* [`0b446c54`](https://github.com/NixOS/nixpkgs/commit/0b446c54ce27af249dad6037b2e6288bc2575b01) greenmask: 0.2.18 -> 0.2.19
* [`c62b7e77`](https://github.com/NixOS/nixpkgs/commit/c62b7e77b8d1fece7f757f9973ac10500044c59c) cosmic-applets: drop upstream patch to bump version to 1.0.10
* [`a3b76be8`](https://github.com/NixOS/nixpkgs/commit/a3b76be862c2da917c2ba18755bf4dc239b33f68) cosmic-applets: 1.0.8 -> 1.0.10
* [`1d47f9b0`](https://github.com/NixOS/nixpkgs/commit/1d47f9b0fa1aec45c2a12bfe65f406bffe4bdf2d) cosmic-applibrary: 1.0.8 -> 1.0.10
* [`f97289b4`](https://github.com/NixOS/nixpkgs/commit/f97289b411eca871e0bb60120c809484669449e7) cosmic-bg: 1.0.8 -> 1.0.10
* [`a3ac98f4`](https://github.com/NixOS/nixpkgs/commit/a3ac98f4092cd04f7dc72b6466f85d64398572c6) cosmic-comp: 1.0.8 -> 1.0.10
* [`b1d31b0b`](https://github.com/NixOS/nixpkgs/commit/b1d31b0b70e3c755265a52dee118eab30da2707c) cosmic-edit: 1.0.8 -> 1.0.10
* [`f2f23a2d`](https://github.com/NixOS/nixpkgs/commit/f2f23a2dcdd5e2a6ea079365bd39eee1f10c5438) cosmic-files: drop upstream patch to bump version to 1.0.10
* [`644b02f1`](https://github.com/NixOS/nixpkgs/commit/644b02f101a026d02f6c4221fcf3548a95e0b8b4) cosmic-files: 1.0.8 -> 1.0.10
* [`4d624c46`](https://github.com/NixOS/nixpkgs/commit/4d624c46e0e3aa012aedcb4021290e506ca00914) cosmic-greeter: drop upstream patch to bump version to 1.0.10
* [`310f5c15`](https://github.com/NixOS/nixpkgs/commit/310f5c15b291f551da42b87e9290b74d5a586bad) cosmic-greeter: 1.0.8 -> 1.0.10
* [`c6c4fc27`](https://github.com/NixOS/nixpkgs/commit/c6c4fc27a5fac104fe3d184f7482592c5c4ec46d) cosmic-icons: 1.0.8 -> 1.0.10
* [`24f893df`](https://github.com/NixOS/nixpkgs/commit/24f893df9b0b7540c074285ca9f298b4b4d84d53) cosmic-idle: 1.0.8 -> 1.0.10
* [`b16e5071`](https://github.com/NixOS/nixpkgs/commit/b16e50714f005bad5cb3e507e14e9d5cd0a6e4c0) cosmic-initial-setup: 1.0.8 -> 1.0.10
* [`b6d81b7b`](https://github.com/NixOS/nixpkgs/commit/b6d81b7b4c7e936d040b60858171abd662d1c64f) cosmic-launcher: 1.0.8 -> 1.0.10
* [`b7997b3a`](https://github.com/NixOS/nixpkgs/commit/b7997b3a3532cdbee37cb6d0f17d4b041706bb10) cosmic-notifications: 1.0.8 -> 1.0.10
* [`9d8a32f4`](https://github.com/NixOS/nixpkgs/commit/9d8a32f483f2b5ad80bec7d6dade46234dc5ef92) cosmic-osd: 1.0.8 -> 1.0.10
* [`c68a447f`](https://github.com/NixOS/nixpkgs/commit/c68a447f15bbf3c33f29ce4adaea25c18575a80c) cosmic-panel: 1.0.8 -> 1.0.10
* [`16b3a4f0`](https://github.com/NixOS/nixpkgs/commit/16b3a4f0ea256817147f27b94fcdc4a032bda74b) cosmic-player: 1.0.8 -> 1.0.10
* [`107e2579`](https://github.com/NixOS/nixpkgs/commit/107e2579e4a42d3cb198c889c60e0c6fede92cb5) cosmic-randr: 1.0.8 -> 1.0.10
* [`a9c2e079`](https://github.com/NixOS/nixpkgs/commit/a9c2e0799e10842794106e8d0b8639014dfb9c18) cosmic-reader: 0-unstable-2026-03-09 -> 0-unstable-2026-04-14
* [`4095d8ef`](https://github.com/NixOS/nixpkgs/commit/4095d8ef61457d7e667e8038f5c886495ca59823) cosmic-screenshot: 1.0.8 -> 1.0.10
* [`d06b31a3`](https://github.com/NixOS/nixpkgs/commit/d06b31a3bf76e01a15c9d4d90165b66e1dd1c3ce) cosmic-session: 1.0.8 -> 1.0.10
* [`9247b996`](https://github.com/NixOS/nixpkgs/commit/9247b99670fba3dc0aeb155018ded70423132462) cosmic-settings: 1.0.8 -> 1.0.10
* [`ac6d3ea9`](https://github.com/NixOS/nixpkgs/commit/ac6d3ea9a9177e78113999b3c936509362f283c5) cosmic-settings-daemon: drop upstream patch to bump version to 1.0.10
* [`32d19a48`](https://github.com/NixOS/nixpkgs/commit/32d19a4867ecb2c655ece18e76126c2f99f2ed69) cosmic-settings-daemon: 1.0.8 -> 1.0.10
* [`bbc7a5ef`](https://github.com/NixOS/nixpkgs/commit/bbc7a5efeac6177b3e9f7ff943ad1747fb082ce1) cosmic-store: 1.0.8 -> 1.0.10
* [`52e2ff8f`](https://github.com/NixOS/nixpkgs/commit/52e2ff8f9014909ab40c29a14df4ae10645f66b2) cosmic-term: 1.0.8 -> 1.0.10
* [`779ada9f`](https://github.com/NixOS/nixpkgs/commit/779ada9fbf2b4767ec404b9f9934cd3a6e1fb1b5) cosmic-wallpapers: 1.0.8 -> 1.0.10
* [`887bc54b`](https://github.com/NixOS/nixpkgs/commit/887bc54bf686ed7e9a0cd0593e486065d102aa2f) cosmic-workspaces-epoch: 1.0.8 -> 1.0.10
* [`9a39e192`](https://github.com/NixOS/nixpkgs/commit/9a39e19259613d898c686fe209a1c16ebdc47630) xdg-desktop-portal-cosmic: 1.0.8 -> 1.0.10
* [`609b063a`](https://github.com/NixOS/nixpkgs/commit/609b063a11e504c48e78ff38509abd49edf061a2) plexRaw: 1.43.0.10492-121068a07 -> 1.43.1.10611-1e34174b1
* [`e6dc712a`](https://github.com/NixOS/nixpkgs/commit/e6dc712a58e7b0d410d986784425c6ffd0051da8) zed-editor: fix 2x icon path
* [`63b6b419`](https://github.com/NixOS/nixpkgs/commit/63b6b41948b9e04082f064a064fedd037c171b87) codeql: 2.25.1 -> 2.25.2
* [`fbf8fc9b`](https://github.com/NixOS/nixpkgs/commit/fbf8fc9be0600cab1f144a6ebbebc3d2ec81cca7) syncthingtray: 2.0.9 -> 2.0.10
* [`b36235f9`](https://github.com/NixOS/nixpkgs/commit/b36235f9a11f90adbccd650ba88d8ec06ccf59ff) shrinkray: 26.3.17.0 -> 26.4.14.0
* [`f69e968b`](https://github.com/NixOS/nixpkgs/commit/f69e968b3a83a27e1c78de822d11dc3cb93df445) v2ray: 5.48.0 -> 5.49.0
* [`0664580f`](https://github.com/NixOS/nixpkgs/commit/0664580f9a83e5ba7c9ea3492ecb1a09725ae1be) python3Packages.apache-beam: 2.71.0 -> 2.72.0
* [`f83a2b8c`](https://github.com/NixOS/nixpkgs/commit/f83a2b8c27afefa3bf7c3b315285596b3bde0dde) bluesky-pds: 0.4.208 -> 0.4.219
* [`7e6ebca4`](https://github.com/NixOS/nixpkgs/commit/7e6ebca4ba6c529074502b56d0bdab9eddc3833b) rocmPackages.rocprofiler-sdk: set updateScript
* [`23b4647c`](https://github.com/NixOS/nixpkgs/commit/23b4647cf9b27cbd408a8aa7a8a5acf63f78ee7f) dcrwallet: 2.1.4 -> 2.1.5
* [`8f3e7a46`](https://github.com/NixOS/nixpkgs/commit/8f3e7a4682ed5afc368a127d4892d68d31cdfaee) jx: 3.16.59 -> 3.16.71
* [`388127f0`](https://github.com/NixOS/nixpkgs/commit/388127f06ebcb0b91a149765dd037d61029a0124) rocmPackages: 7.2.1 -> 7.2.2
* [`c61b99ff`](https://github.com/NixOS/nixpkgs/commit/c61b99ff8d5e3e6c84cdd50ce619da8d2dc1012f) panache: 2.31.0 -> 2.34.0
* [`c1708d28`](https://github.com/NixOS/nixpkgs/commit/c1708d286aed5f296b4c267284ff6a41818716d0) lux-cli: 0.27.0 -> 0.28.1
* [`9ad8eb5e`](https://github.com/NixOS/nixpkgs/commit/9ad8eb5e6e8f0692432a91ec09379741595dac08) phrase-cli: 2.58.0 -> 2.60.0
* [`63a954cf`](https://github.com/NixOS/nixpkgs/commit/63a954cf5b1aae6a5124c66051e1bf40c3e00204) openroad: 26Q1 -> 26Q2
* [`f4a5cc4d`](https://github.com/NixOS/nixpkgs/commit/f4a5cc4db01153d7c7ad9af0e15cf1fa2b586376) python3Packages.jupyter-ydoc: 3.4.0 -> 3.4.1
* [`7469307f`](https://github.com/NixOS/nixpkgs/commit/7469307ff148f2881ca59abf2ebf3df8ef944c5c) ty: 0.0.30 -> 0.0.31
* [`ba84957b`](https://github.com/NixOS/nixpkgs/commit/ba84957b9ffff6c75ebfeaafcfc2ecffde42d742) mdns-scanner: add passthru.updateScript
* [`1023e6a9`](https://github.com/NixOS/nixpkgs/commit/1023e6a950950102597aadc1a41391f2e7e6501f) renode-dts2repl: 0-unstable-2026-03-31 -> 0-unstable-2026-04-15
* [`a2448ed6`](https://github.com/NixOS/nixpkgs/commit/a2448ed6cef4d0bc240fd30420c03b03758d0670) terraform-providers.baidubce_baiducloud: 1.22.22 -> 1.22.25
* [`b653283e`](https://github.com/NixOS/nixpkgs/commit/b653283efcbce716f9b4abdd1dbbc1c482f16c98) mastodon: 4.5.8 -> 4.5.9
* [`54371691`](https://github.com/NixOS/nixpkgs/commit/543716918b9f99a7f683ea7661a03d95891e2bdb) xan: 0.57.0 -> 0.57.1
* [`97eb44af`](https://github.com/NixOS/nixpkgs/commit/97eb44afde42d83f12c5b36176bb54273379a1af) mdns-scanner: 0.27.0 -> 0.27.1
* [`91640764`](https://github.com/NixOS/nixpkgs/commit/916407646aefdb48f23208a7a7432427aa198188) pijul: 1.0.0-beta.9 -> 1.0.0-beta.11
* [`4bc0a3b7`](https://github.com/NixOS/nixpkgs/commit/4bc0a3b7dc9b53fef6c5867a970f0b135ef6e4ac) zeno: 2.0.21 -> 2.0.23
* [`dcd514ab`](https://github.com/NixOS/nixpkgs/commit/dcd514ab8a7192906d595a404b9dbf0635f30ffa) python3Packages.claude-agent-sdk: 0.1.58 -> 0.1.59
* [`abe016dc`](https://github.com/NixOS/nixpkgs/commit/abe016dce5537e61099cb80e30974aad38d34b33) just-lsp: 0.4.1 -> 0.4.2
* [`dbbab34f`](https://github.com/NixOS/nixpkgs/commit/dbbab34fa8876d2c1e42cfb237b2f30fe5f5b1ae) chromium,chromedriver: 147.0.7727.55 -> 147.0.7727.101
* [`db0d0fd3`](https://github.com/NixOS/nixpkgs/commit/db0d0fd35e0acc3fb52436b99ac790da8ab10b45) paperless-ngx: unpin imap-tools
* [`e5787208`](https://github.com/NixOS/nixpkgs/commit/e57872084b9a011baf1f184a65fae8d0e5972f42) ghr: 0.18.0 -> 0.18.3
* [`d1a410f6`](https://github.com/NixOS/nixpkgs/commit/d1a410f65d18de00534f69d76d1c3d7d95204b7c) vimPlugins.nvim-dap-docker: init at 0.2.0-unstable-2026-04-15
* [`ba8edf77`](https://github.com/NixOS/nixpkgs/commit/ba8edf778fd95198365f5b481ddaea63dca5fc51) vals: 0.43.8 -> 0.43.9
* [`22a7fc83`](https://github.com/NixOS/nixpkgs/commit/22a7fc831529bc3e9791754420172da0f2b32868) home-assistant-custom-components.battery_notes: 3.4.3 -> 3.4.4
* [`6e8cdf1f`](https://github.com/NixOS/nixpkgs/commit/6e8cdf1f116383dccae68c112b8c9b720c2bdef2) coroot-node-agent: 1.31.0 -> 1.32.0
* [`5a500395`](https://github.com/NixOS/nixpkgs/commit/5a500395028c11ba1c72357efea9775a94ecdf6e) cni-plugin-flannel: 1.9.0-flannel1 -> 1.9.1-flannel1
* [`4683c143`](https://github.com/NixOS/nixpkgs/commit/4683c143f348ab715a66d8ab1e8bd1e17c1e468d) doc/stdenv: add a note about __structuredAttrs
* [`7e9c5353`](https://github.com/NixOS/nixpkgs/commit/7e9c5353f60cf45c48383f9a58efaf43b3a3d87f) cargo-machete: 0.9.1 -> 0.9.2
* [`467b096e`](https://github.com/NixOS/nixpkgs/commit/467b096e9243e9f4d7e93a7d01622b1f9c80e9ed) google-chrome: 147.0.7727.55 -> 147.0.7727.101
* [`9b5cfc24`](https://github.com/NixOS/nixpkgs/commit/9b5cfc24de11518e48cf69199d6d89ab57b38ef5) python3Packages.django-cachalot: 2.8.0 -> 2.9.0
* [`abb63286`](https://github.com/NixOS/nixpkgs/commit/abb63286f6b038724f797ec95c7fd525526fd57d) github-desktop: 3.5.7 -> 3.5.8
* [`8e87f5d6`](https://github.com/NixOS/nixpkgs/commit/8e87f5d656aa0dc2907959c69a65828b7bcc31d6) paperless-ngx: unpin django-cachalot
* [`bec19e60`](https://github.com/NixOS/nixpkgs/commit/bec19e60a7991b2719f7e40741d6e07bff665492) python3Packages.linear-operator: 0.6 -> 0.6.1
* [`c3f75226`](https://github.com/NixOS/nixpkgs/commit/c3f75226099c5f8c1d0bb4543c95bcf18cb1ca8b) perplexity-mcp: 0-unstable-2026-03-23 -> 0-unstable-2026-04-14
* [`01802c56`](https://github.com/NixOS/nixpkgs/commit/01802c56406c01656861050eaaf419e32c12efae) python3Packages.django-filter: 25.1 -> 25.2
* [`0015cfcd`](https://github.com/NixOS/nixpkgs/commit/0015cfcdf25ddab2917501425de5abf861bf1dbf) pretix: unpin django-filter
* [`38e02414`](https://github.com/NixOS/nixpkgs/commit/38e02414f1dda4cd79460e40226afbabcee3277d) task-keeper: 0.30.1 -> 0.33.0
* [`aa83f8af`](https://github.com/NixOS/nixpkgs/commit/aa83f8af517135435f265368ba444cfc21936213) pretix: return to default python
* [`c4082242`](https://github.com/NixOS/nixpkgs/commit/c4082242072ef6b171ae8fe1de4de065aa5d5008) python3Packages.gpytorch: 1.15.1 -> 1.15.2
* [`f703360e`](https://github.com/NixOS/nixpkgs/commit/f703360eff32f2e44ddc4ff075d8cecca2d1ae9b) python3Packages.pylint-django: 2.6.1-unstable-2025-11-09 -> 2.7.0
* [`da26db7b`](https://github.com/NixOS/nixpkgs/commit/da26db7be45ea9a205f708f97076d83ccd4853ed) vintagestory: factor out `makeWrapperArgs`
* [`fa576c40`](https://github.com/NixOS/nixpkgs/commit/fa576c401a07bf6aa65989e3e4502ec5d3d9f369) vintagestory: remove scripts that should not get invoked on NixOS
* [`068fa9e2`](https://github.com/NixOS/nixpkgs/commit/068fa9e2d58a640986cc31eadb5668bfe784cd3d) vintagestory: remove gtk2 ([nixos/nixpkgs⁠#410814](https://togithub.com/nixos/nixpkgs/issues/410814))
* [`3649c251`](https://github.com/NixOS/nixpkgs/commit/3649c2512d12df7898ca04783fea02d7e52f2ca0) vintagestory: remove unused deps
* [`f92f8e2a`](https://github.com/NixOS/nixpkgs/commit/f92f8e2ac3548208307d15d9ae9abd4582bb4584) vintagestory: enable versionCheckHook
* [`cdfe9595`](https://github.com/NixOS/nixpkgs/commit/cdfe9595794dffd41c2054466099968b20393f57) vintagestory: set `meta.platforms = ["x86_64-linux"]`
* [`3c810023`](https://github.com/NixOS/nixpkgs/commit/3c8100234107b680e15f0620e0b2f070ae37b66f) python3Packages.botorch: 0.17.0 -> 0.17.2
* [`5c7cc268`](https://github.com/NixOS/nixpkgs/commit/5c7cc26854bcf24b7478f0c02747473b0faf3d0e) python3Packages.ax-platform: 1.2.3 -> 1.2.4
* [`6d7c3293`](https://github.com/NixOS/nixpkgs/commit/6d7c32939046005ddedfdf1cc7eb1471a1fa4dcf) python3Packages.sentry-sdk: 2.54.0 -> 2.58.0
* [`a2755f65`](https://github.com/NixOS/nixpkgs/commit/a2755f65ee720880cc1d57c50d8bee36ea085a45) python3Packages.willow: disable flaky test
* [`56dee843`](https://github.com/NixOS/nixpkgs/commit/56dee8430c838eb5360e9271308a630cc33a49a6) python3Packages.pydantic-graph: 1.79.0 -> 1.82.0
* [`bfd95095`](https://github.com/NixOS/nixpkgs/commit/bfd95095bd961e2623f76b8ecd0981263719a51e) python3Packages.pydantic-ai-slim: 1.79.0 -> 1.82.0
* [`d3b4cb4b`](https://github.com/NixOS/nixpkgs/commit/d3b4cb4b5a86229db38287c501765ec8bcf48d7c) python3Packages.resvg-py: 0.3.0 -> 0.3.1
* [`3bc991b0`](https://github.com/NixOS/nixpkgs/commit/3bc991b00fdadf7ef7b2eedcc38febc0f6be8270) rasdaemon: add maintainer
* [`688e80b3`](https://github.com/NixOS/nixpkgs/commit/688e80b3971c84d09e29dc92a555fdc768857eac) zizmor: 1.23.1 -> 1.24.1
* [`10cfa231`](https://github.com/NixOS/nixpkgs/commit/10cfa23144e9aece536ff2014725eea5162d6246) nixos/rasdaemon: inherit maintainers from package
* [`21d46f43`](https://github.com/NixOS/nixpkgs/commit/21d46f4397692d883ac45d307b28f6159e6bc363) rasdaemon: add patch for ras-mc-ctl
* [`bb3fb72a`](https://github.com/NixOS/nixpkgs/commit/bb3fb72adea545ef02488ac2cfa6870e497f99a7) Revert "nixosTests.rasdaemon: mark as broken"
* [`10252f59`](https://github.com/NixOS/nixpkgs/commit/10252f5936beba890ae3251d112621af646135ef) vacuum-tube: 1.6.1 -> 1.6.2
* [`57ef295d`](https://github.com/NixOS/nixpkgs/commit/57ef295d60871d2c671b038deeb24fdfa8eb447f) treewide: fix icon by moving to valid path
* [`6c2bd24e`](https://github.com/NixOS/nixpkgs/commit/6c2bd24e2e81cbbef246cdc29abeb95c97bec679) python3Packages.pyseventeentrack: 1.1.2 -> 1.1.3
* [`e2b0a9a8`](https://github.com/NixOS/nixpkgs/commit/e2b0a9a84683520a45147126cb8860a59209ba55) qownnotes: 26.4.11 -> 26.4.14
* [`023b2632`](https://github.com/NixOS/nixpkgs/commit/023b26322f5db62e7d44a22d9e48a64c2d85d5ab) qownnotes: update UI tests
* [`972c91ee`](https://github.com/NixOS/nixpkgs/commit/972c91ee5c4e2815a1ec8054578e9e920a8cc203) luanti: 5.15.1 -> 5.15.2
* [`b71c3965`](https://github.com/NixOS/nixpkgs/commit/b71c3965ae02e6788567965c91976020509a0710) mesa: 26.0.4 -> 26.0.5
