### PR TITLE
npins home-manager: update 8a423e44 -> c555a4a3

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -61,9 +61,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "8a423e444b17dde406097328604a64fc7429e34e",
-      "url": "https://github.com/nix-community/home-manager/archive/8a423e444b17dde406097328604a64fc7429e34e.tar.gz",
-      "hash": "sha256-b2pu3Pb28W0bJzQVP3OJHZC5+dgOOeqjlli2WVakKEU="
+      "revision": "c555a4a34a260493be5adb795c54e013c58f2d34",
+      "url": "https://github.com/nix-community/home-manager/archive/c555a4a34a260493be5adb795c54e013c58f2d34.tar.gz",
+      "hash": "sha256-zGuW7C4tsScib2560yE5VV6lY/MdRs30aU9cbg3RP+U="
     },
     "hs-grille": {
       "type": "Git",


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@8a423e44...c555a4a3](https://github.com/nix-community/home-manager/compare/8a423e444b17dde406097328604a64fc7429e34e...c555a4a34a260493be5adb795c54e013c58f2d34)

* [`3c7524c6`](https://github.com/nix-community/home-manager/commit/3c7524c68348ef79ce48308e0978611a050089b2) treewide: set git pager for specific commands, not for core.pager
* [`d401492e`](https://github.com/nix-community/home-manager/commit/d401492e2acd4fea42f7705a3c266cea739c9c36) files: prefix relative path literal with './'
* [`6ddeb76a`](https://github.com/nix-community/home-manager/commit/6ddeb76a5db8f5bc57cf1601a761e34cb0dcd8ff) zsh: expose internal lib
* [`8941f29d`](https://github.com/nix-community/home-manager/commit/8941f29d42b444e5956ef6dddc64f311897c2c8e) opencode: add extraPackages option
* [`a0dab602`](https://github.com/nix-community/home-manager/commit/a0dab602845cc7b0b980e201453c7454de24075b) helix: reload config with USR1 signal
* [`08b283ae`](https://github.com/nix-community/home-manager/commit/08b283aeda66c11d0573347c23ff927df99ec340) yazi: add option for {file}`$XDG_CONFIG_HOME/yazi/vfs.toml`
* [`dee1c38c`](https://github.com/nix-community/home-manager/commit/dee1c38cf07e0a19912aed040088c8cf93091421) modules/helix: fix incorrect string escape
* [`565e5349`](https://github.com/nix-community/home-manager/commit/565e5349208fe7d0831ef959103c9bafbeac0681) neovim: expose `sideloadInitLua` option to control the generation of `init.lua`
* [`5b56ad02`](https://github.com/nix-community/home-manager/commit/5b56ad02dc643808b8af6d5f3ff179e2ce9593f4) modules/helix: fix pkill line on Darwin
* [`1e9bdc6d`](https://github.com/nix-community/home-manager/commit/1e9bdc6d35c917f1f2f9f6adddfee7ad9c33a245) swaync: update style documentation link
* [`b85e8fff`](https://github.com/nix-community/home-manager/commit/b85e8fff941d0cce275a627a3c2f40b3c4a96e08) lib/deprecations: suppress no-op state-version warnings
* [`29f355a7`](https://github.com/nix-community/home-manager/commit/29f355a7338f30f32142f4ff44e805d47d0086b1) tests: decode non-UTF-8 nix build output
* [`1ab3a4b7`](https://github.com/nix-community/home-manager/commit/1ab3a4b78ebbf13d4ae786180bc8b7de9741cf30) test(tests): add --big-only filter
* [`12ceb397`](https://github.com/nix-community/home-manager/commit/12ceb3974a79b0bcd78974c86c474a0bd3697e8c) tests/xdg-user-dirs-*: do not use 'PROJECTS'
* [`4bfce11e`](https://github.com/nix-community/home-manager/commit/4bfce11ea820df0359f73736fd59c7e8f53641a6) xdg-user-dirs: add 'projects'
* [`0a8d50ed`](https://github.com/nix-community/home-manager/commit/0a8d50edf28d537ce7538fbbf207fa7939d41abc) docs/nix-flakes: clarify extraSpecialArgs usage
* [`78ceb2dd`](https://github.com/nix-community/home-manager/commit/78ceb2dd5c16309c25ce97ecd4687f24e6ab6366) rbw: do not serialize 'null' settings
* [`1072f064`](https://github.com/nix-community/home-manager/commit/1072f064e2c47a249f09800e7c0fe4e96ab9b433) fish: clarify setCursor option mapping
* [`56b4526c`](https://github.com/nix-community/home-manager/commit/56b4526cfdac480268b54ee1124efb732b792af1) nixos: guard home.uid with tryEval
* [`c81775b6`](https://github.com/nix-community/home-manager/commit/c81775b640d4507339d127f5adb4105f6015edf2) xdg-autostart: allow empty readonly autostart
* [`c555a4a3`](https://github.com/nix-community/home-manager/commit/c555a4a34a260493be5adb795c54e013c58f2d34) ci: add nix and lix parse checks
