### PR TITLE
npins home-manager: update c555a4a3 -> c1140540

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -61,9 +61,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "c555a4a34a260493be5adb795c54e013c58f2d34",
-      "url": "https://github.com/nix-community/home-manager/archive/c555a4a34a260493be5adb795c54e013c58f2d34.tar.gz",
-      "hash": "sha256-zGuW7C4tsScib2560yE5VV6lY/MdRs30aU9cbg3RP+U="
+      "revision": "c1140540536d483e2730320100f6835d62c94fdf",
+      "url": "https://github.com/nix-community/home-manager/archive/c1140540536d483e2730320100f6835d62c94fdf.tar.gz",
+      "hash": "sha256-PGKgo2dO6fK603QGI+DWXdKmS09pbJjjTxwRHdhkGZA="
     },
     "hs-grille": {
       "type": "Git",


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@c555a4a3...c1140540](https://github.com/nix-community/home-manager/compare/c555a4a34a260493be5adb795c54e013c58f2d34...c1140540536d483e2730320100f6835d62c94fdf)

* [`67f2a145`](https://github.com/nix-community/home-manager/commit/67f2a145a96658d83c9ec05b6f581eab8f68f73f) ci: run both parse checks in one keep-going step
* [`6658732d`](https://github.com/nix-community/home-manager/commit/6658732d338b38c80a5ddfee5f94827428314d77) ci: drop default workflow token permissions
* [`70762722`](https://github.com/nix-community/home-manager/commit/7076272297955163b0cced013798845651d301af) ci: bound runtime and force sandboxed builds
* [`5d564059`](https://github.com/nix-community/home-manager/commit/5d5640599a0050b994330328b9fd45709c909720) atuin: fix logs.dir override for preferXdgDirectories
* [`c77ebe06`](https://github.com/nix-community/home-manager/commit/c77ebe06b49d65f7bb6d9f9bde00306be1d14298) khal: honor explicit default calendar
* [`afd56071`](https://github.com/nix-community/home-manager/commit/afd5607108220437abc9d9568538fdda5347a6f8) rofi: support nested extraConfig sections
* [`f2b06589`](https://github.com/nix-community/home-manager/commit/f2b06589e385a8aacf18df46aa6b0268dbd126f0) thunderbird: add generic per-calendar settings option
* [`875f2fcb`](https://github.com/nix-community/home-manager/commit/875f2fcbb14fa4aca3b1e4a20f1c29691876f40e) kitty: add option to configure `$XDG_CONFIG_HOME/kitty/diff.conf`
* [`936d579f`](https://github.com/nix-community/home-manager/commit/936d579f53afa05fc2939c18541e4c9982421e0a) obsidian: no IFD, use RFC42 settings
* [`c95595f7`](https://github.com/nix-community/home-manager/commit/c95595f732cbe43affdb8acfa36917ac326e7741) chromium: fix native host paths for google-chrome
* [`f4e00884`](https://github.com/nix-community/home-manager/commit/f4e008848afc762ae6cf8754680dd72fa2301bfc) chromium: expose google-chrome dictionaries and native hosts
* [`c5ceab9d`](https://github.com/nix-community/home-manager/commit/c5ceab9d94c494e2bd49bcf6e5160afd34424ef3) tests/darwinScrublist: add chromium packages
* [`36f1bd65`](https://github.com/nix-community/home-manager/commit/36f1bd655f8baedf0566a5a714391c08c54046b5) tests/chromium: add more test coverage
* [`14b81a16`](https://github.com/nix-community/home-manager/commit/14b81a16307a8ce12681f6a5c5d7a8506650d196) chromium: support google-chrome extensions on Darwin
* [`5d947202`](https://github.com/nix-community/home-manager/commit/5d947202cfec7f2da18d5c1fd50636e1cac79b40) chromium: document ungoogled extensions
* [`ca6fd05c`](https://github.com/nix-community/home-manager/commit/ca6fd05c134cb81039e18f0df3e992fb56959cd6) tests/chromium: cover brave package routing
* [`f9d2b2da`](https://github.com/nix-community/home-manager/commit/f9d2b2da819d1428d75299582421371c1e99fc75) chromium: document finalPackage
* [`d79c987e`](https://github.com/nix-community/home-manager/commit/d79c987e654347083e903ab6d2a89ed3d0752177) chromium: install plasma browser integration
* [`38d4260b`](https://github.com/nix-community/home-manager/commit/38d4260bc826c88848a2318fc49094aa272fb810) pipewire: add LADSPA plugin path handling
* [`d1759673`](https://github.com/nix-community/home-manager/commit/d1759673d7c9326304baa8048d336498fc51af6b) tests/pipewire: test for LADSPA
* [`f8e57407`](https://github.com/nix-community/home-manager/commit/f8e57407f4a17ba4e7d4cdd64a2f7b7317bb190d) proton-pass-agent: adapt the services to match the documentation
* [`78bf0fe2`](https://github.com/nix-community/home-manager/commit/78bf0fe29d8f9a2564452fcbc6abcb3409400404) maintainers: add isaacST08
* [`83b3ecce`](https://github.com/nix-community/home-manager/commit/83b3ecce2eafc9082af7375b1a295070e199960a) wayle: add module
* [`6a1992ac`](https://github.com/nix-community/home-manager/commit/6a1992acd9d7ce6554e434c15038ac4cc7bb52b7) mkVesktopLikeModule: init
* [`508daf83`](https://github.com/nix-community/home-manager/commit/508daf831ab8d1b143d908239c39a7d8d39561b2) equibop: init
* [`ad16ee43`](https://github.com/nix-community/home-manager/commit/ad16ee43a8b59500d9838968e8fd4e771dd59dd5) maintainers: add soracat
* [`9c7dcc55`](https://github.com/nix-community/home-manager/commit/9c7dcc55bdedbd078de0bee92543f4cc997110bf) home-manager-auto-upgrade: set maintainer to soracat
* [`8f259af6`](https://github.com/nix-community/home-manager/commit/8f259af671bc9c25763937672d37e5d346aa1bf7) home-manager-auto-upgrade: add switch flags and pre-switch commands
* [`0d1314d6`](https://github.com/nix-community/home-manager/commit/0d1314d6fe5bc2e106b3c121ce2a318fdeee61d0) home-manager-auto-upgrade: clarify option documentation
* [`2706309a`](https://github.com/nix-community/home-manager/commit/2706309aebf4c2dd1a9c7932b1807e9955e352c7) news: add home-manager-auto-upgrade options entry
* [`667b3c47`](https://github.com/nix-community/home-manager/commit/667b3c47325441e6a444faaf405bba76ec70338a) home-manager-auto-upgrade: state-version gate preSwitchCommands
* [`6837e0d6`](https://github.com/nix-community/home-manager/commit/6837e0d6c5eda81fd26308489799fbf83a160465) wayle: fix example
* [`30db803c`](https://github.com/nix-community/home-manager/commit/30db803c98a29dd71b2518fcc8c38094db8e9167) git: support ordered settings fragments
* [`e09259dd`](https://github.com/nix-community/home-manager/commit/e09259dd2e147d35ef889784b51e89b0a10ffe15) git: clean up literalExpression
* [`5a9efa93`](https://github.com/nix-community/home-manager/commit/5a9efa93c586f79e80b0ad7d8036c450f53c3d1d) qalculate: init module
* [`bb0aaf91`](https://github.com/nix-community/home-manager/commit/bb0aaf91cc5cd31f3a7b5c5b3ca397f8f5338e81) tests: split stub derivation attrs from methods
* [`99814d2a`](https://github.com/nix-community/home-manager/commit/99814d2a6773f76b383b549e198caec913de3421) fcitx5: capitalize boolean settings
* [`ae97a154`](https://github.com/nix-community/home-manager/commit/ae97a154557a396b075810643fb582986ca55f9c) rectangle: init module
* [`5bba6a1e`](https://github.com/nix-community/home-manager/commit/5bba6a1e027b79ba56dd6ed8e6edbed80aa8e3cb) flashspace: init module
* [`d035caf3`](https://github.com/nix-community/home-manager/commit/d035caf3ac3f958a08004d75d4a1b32bfb093725) mkFirefoxModule: serialize path prefs as strings
* [`4bf1f0bc`](https://github.com/nix-community/home-manager/commit/4bf1f0bcd156d1f1b23f46902a170c93cd197b88) mkFirefoxModule: reject container id 0
* [`b869d6ca`](https://github.com/nix-community/home-manager/commit/b869d6cadbc6c0d9135799b8ee31fc7275cab225) firefox: default configPath to XDG on 26.05
* [`6012cf1f`](https://github.com/nix-community/home-manager/commit/6012cf1fed3eba66115f3fd117b9be6bd2a15b2f) mkFirefoxModule: make profile extensions extensible
* [`ffbd94a1`](https://github.com/nix-community/home-manager/commit/ffbd94a1c9d7d3e1258e51c084ab2109da04f2b1) tests: support override-inputs in test runner
* [`58268023`](https://github.com/nix-community/home-manager/commit/5826802354a74af18540aef0b01bc1320f82cc17) modules/nix-search-tv: add run and shell actions
* [`026e2103`](https://github.com/nix-community/home-manager/commit/026e21038902970e54226133e718e8c197fac799) firefox: fix legacy configPath default
* [`ed2ee7b3`](https://github.com/nix-community/home-manager/commit/ed2ee7b313d29e9dfae1aa08cf610a66691ab639) tests: enable more tests on darwin
* [`b7d6241c`](https://github.com/nix-community/home-manager/commit/b7d6241c2a0d22d8c05403ed70242d2087e504c3) rofi: fix nested extraConfig rendering
* [`6f59831b`](https://github.com/nix-community/home-manager/commit/6f59831b23d03bbf4fbd13ad167ae25da294cc14) ci: only parse/format on linux
* [`38bf0202`](https://github.com/nix-community/home-manager/commit/38bf0202cae280174cbb80fc24a63978f16333f7) files: change target type to disallow empty strings
* [`3e4b3118`](https://github.com/nix-community/home-manager/commit/3e4b3118423706973c68bc11c44571de68e83901) onlyoffice: fix settings option example type
* [`00b9fac3`](https://github.com/nix-community/home-manager/commit/00b9fac3769b9e5cd2b2e5195e3b8396ba509da9) tests: buildbot tests enableBig
* [`8a2fdaf6`](https://github.com/nix-community/home-manager/commit/8a2fdaf6b4ffeff599b2d2456972aa8cabe0dc47) tests: fix firefox program tests
* [`5bfbc1f6`](https://github.com/nix-community/home-manager/commit/5bfbc1f6ca0c257d8709bf975f6b318d93eb2efc) tests: fix neovim program test
* [`c968134e`](https://github.com/nix-community/home-manager/commit/c968134e0654e5226846a076d19a68dc1c644d78) floorp: fix Darwin app bundle name
* [`7cdccd0d`](https://github.com/nix-community/home-manager/commit/7cdccd0db96fd1d35522634be365ee3b7674efd7) Translate using Weblate (Polish)
* [`0add2d43`](https://github.com/nix-community/home-manager/commit/0add2d439a2c94affd9afadbabeed9524e568f52) Translate using Weblate (French)
* [`c55c498c`](https://github.com/nix-community/home-manager/commit/c55c498c9aa205b16cca78b57a7275625726d532) targets/darwin: set TERMINFO_DIRS
* [`e82d4a4e`](https://github.com/nix-community/home-manager/commit/e82d4a4ecd18363aa2054cbaa3e32e4134c3dbf4) copyApps: workaround for macOS 26.3 signature bug
* [`4883af6e`](https://github.com/nix-community/home-manager/commit/4883af6edbdf222c66edb545d312f4e40030a2be) syncthing: avoid init for default gui address
* [`c97d9213`](https://github.com/nix-community/home-manager/commit/c97d92137300ab075c2eca2d83a8b4d81921a4f0) mkFirefoxModule: add firefox devedition example
* [`7f8bbc93`](https://github.com/nix-community/home-manager/commit/7f8bbc93d63401e41368d6ddc46a4f631610fa90) mkFirefoxModule: document impermanence extensions
* [`e97a9fd6`](https://github.com/nix-community/home-manager/commit/e97a9fd6a63802d1750fb23cd89419d3854a6dba) maintainers: update all-maintainers.nix
* [`b408d49b`](https://github.com/nix-community/home-manager/commit/b408d49b845167add697937761a89c41c996ac7a) syncthing: fix the application of allProxy
* [`466d5909`](https://github.com/nix-community/home-manager/commit/466d5909eb35f0c7d7b7ce6aa2073d5abfde49c8) tests: remove unused file
* [`62f445c1`](https://github.com/nix-community/home-manager/commit/62f445c13c84df6a388b86b0a02f8aa08a7295a3) {bash,zsh}: align sessionVariables type
* [`d45a13f9`](https://github.com/nix-community/home-manager/commit/d45a13f96c3589c92547466c14573f3442496bf2) {home-environment,bash,zsh}: support ignoring null sessionVariables
* [`a28e848a`](https://github.com/nix-community/home-manager/commit/a28e848a01044f47679453aae75f6253bef7903e) chromium: address plasma integration review
* [`c1140540`](https://github.com/nix-community/home-manager/commit/c1140540536d483e2730320100f6835d62c94fdf) gurk: change config signal_db_path to data_dir
