### PR TITLE
npins nerd-icons.el: update 1db0b0b9 -> 3f6e8b36

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -112,9 +112,9 @@
       },
       "branch": "main",
       "submodules": false,
-      "revision": "1db0b0b9203cf293b38ac278273efcfc3581a05f",
-      "url": "https://github.com/rainstormstudio/nerd-icons.el/archive/1db0b0b9203cf293b38ac278273efcfc3581a05f.tar.gz",
-      "hash": "sha256-LkbSi0xMBzoT9+a6HMtqO9lBISmCUk2w2AOKQS6q/Gw="
+      "revision": "3f6e8b36436d99659234d5bbbd84ba5c09282692",
+      "url": "https://github.com/rainstormstudio/nerd-icons.el/archive/3f6e8b36436d99659234d5bbbd84ba5c09282692.tar.gz",
+      "hash": "sha256-ihoQZ+9JOy6fmAiU1qFvk3CG5TvR2PIEa0r+YDqk0/Q="
     },
     "niv": {
       "type": "Git",


### PR DESCRIPTION
## Changelog for nerd-icons.el:
Branch: main
Commits: [rainstormstudio/nerd-icons.el@1db0b0b9...3f6e8b36](https://github.com/rainstormstudio/nerd-icons.el/compare/1db0b0b9203cf293b38ac278273efcfc3581a05f...3f6e8b36436d99659234d5bbbd84ba5c09282692)

* [`ceeb39df`](https://github.com/rainstormstudio/nerd-icons.el/commit/ceeb39df59440c650b9fb12e467fcd081f754d53) Add the possibility to provide a specific path on Windows
* [`525e58cd`](https://github.com/rainstormstudio/nerd-icons.el/commit/525e58cda24a89cdddc12c995fa08fbfc02c9a13) add automatic install explanations
* [`d0a5fa65`](https://github.com/rainstormstudio/nerd-icons.el/commit/d0a5fa6583435f696cffe81d79966a2769b139b0) small formatting fix
