### PR TITLE
npins emacs-overlay: update 2dfb8da9 -> 4d84d5c3

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -35,9 +35,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "2dfb8da9598d2cd2c41d52ebe2461e9a8a63c9b3",
-      "url": "https://github.com/nix-community/emacs-overlay/archive/2dfb8da9598d2cd2c41d52ebe2461e9a8a63c9b3.tar.gz",
-      "hash": "sha256-N4hYRtyf3PXEhhDQ6RJoSOrcsVzyCYHVeTtQGrOx2Ok="
+      "revision": "4d84d5c37f28595b34858e4ae9c76c11e7c257ab",
+      "url": "https://github.com/nix-community/emacs-overlay/archive/4d84d5c37f28595b34858e4ae9c76c11e7c257ab.tar.gz",
+      "hash": "sha256-FxU58LNvJzcOU9K6xUyE01GvB8x5Vtm0b6sUbjB82WE="
     },
     "fast-syntax-highlighting": {
       "type": "Git",


### PR DESCRIPTION
## Changelog for emacs-overlay:
Branch: master
Commits: [nix-community/emacs-overlay@2dfb8da9...4d84d5c3](https://github.com/nix-community/emacs-overlay/compare/2dfb8da9598d2cd2c41d52ebe2461e9a8a63c9b3...4d84d5c37f28595b34858e4ae9c76c11e7c257ab)

* [`32ee0c6b`](https://github.com/nix-community/emacs-overlay/commit/32ee0c6b83d8d5f5566ad684f87a4c8089df05f7) Updated flake inputs
* [`3da65932`](https://github.com/nix-community/emacs-overlay/commit/3da65932271bb86d3b7fdf6e64eb144bc27fc09c) Updated nongnu
* [`bbe7382b`](https://github.com/nix-community/emacs-overlay/commit/bbe7382b7c63f263cc9306496f023d7d1e3cf43e) Updated elpa
* [`d126ee36`](https://github.com/nix-community/emacs-overlay/commit/d126ee365d140820f7039297bc9146dfd397a3ce) Updated emacs
* [`6078cd4e`](https://github.com/nix-community/emacs-overlay/commit/6078cd4e42b10ab5e2ddc6e7205878974dbe1ec4) Updated melpa
* [`4ca27864`](https://github.com/nix-community/emacs-overlay/commit/4ca2786402796a7b46e6c124cd971ca02e7368ae) Updated nongnu
* [`4c6b3d65`](https://github.com/nix-community/emacs-overlay/commit/4c6b3d6580b6568e8ff5b44e5f6863ed15033098) Updated nongnu
* [`29ea7ebe`](https://github.com/nix-community/emacs-overlay/commit/29ea7ebe3d19bf60ad8e9127c02b9aecd6075c2d) Updated elpa
* [`b1057345`](https://github.com/nix-community/emacs-overlay/commit/b105734505f77244dda9f3722bc7b5e21c9e3129) Updated emacs
* [`f99d61b5`](https://github.com/nix-community/emacs-overlay/commit/f99d61b5ee1831be80ef1369846493251f04a12f) Updated melpa
* [`58e16378`](https://github.com/nix-community/emacs-overlay/commit/58e16378fb5a70e511b36764818fe2119dba61be) Updated flake inputs
* [`1581226c`](https://github.com/nix-community/emacs-overlay/commit/1581226ca2b6a7cc32432fb0e2c54efa0b641ec8) Updated nongnu
* [`c7c37fd0`](https://github.com/nix-community/emacs-overlay/commit/c7c37fd02ffa8e1ff4eef787a054f2219aa84351) Updated elpa
* [`be30211f`](https://github.com/nix-community/emacs-overlay/commit/be30211f8eefa3567a5fe7d49fc653c8071b8bfc) Updated emacs
* [`1ed2bcb9`](https://github.com/nix-community/emacs-overlay/commit/1ed2bcb9db3d09f7db878c18226fd0a049914e39) Updated melpa
* [`1d065870`](https://github.com/nix-community/emacs-overlay/commit/1d065870c35420813d9d23c990206e61b23cdecb) Updated elpa
* [`592fd9c0`](https://github.com/nix-community/emacs-overlay/commit/592fd9c0d18cd1e2b04369a27225964a66ab5e61) Updated emacs
* [`71d60877`](https://github.com/nix-community/emacs-overlay/commit/71d60877e4b6caff448aa698efdf79335692162a) Updated melpa
* [`d5dadae9`](https://github.com/nix-community/emacs-overlay/commit/d5dadae960cbfd33ed0bbd45eb57635855695c41) Updated emacs
* [`14ea9f20`](https://github.com/nix-community/emacs-overlay/commit/14ea9f209dd9a5d3249432b7c2fa98e6310a768e) Updated melpa
* [`56072ed5`](https://github.com/nix-community/emacs-overlay/commit/56072ed54f7f64e358dc629a0e422bbf000b5d0e) Updated nongnu
* [`0480a047`](https://github.com/nix-community/emacs-overlay/commit/0480a047b0092f8341c270c874d21f498dedaf09) Updated flake inputs
* [`3bb8eda5`](https://github.com/nix-community/emacs-overlay/commit/3bb8eda55d0d8c0e12ce7336178c4c8bde50ac1e) Updated nongnu
* [`32794a2d`](https://github.com/nix-community/emacs-overlay/commit/32794a2dfb9f70ba6dde151468f537df2a3bc850) Updated elpa
* [`daa61ce7`](https://github.com/nix-community/emacs-overlay/commit/daa61ce7596558ab0863826db57a534795385357) Updated emacs
* [`4bc2fcfc`](https://github.com/nix-community/emacs-overlay/commit/4bc2fcfc49ab353bce6adb43ce5687b4eba843ca) Updated melpa
* [`e6ffe8e1`](https://github.com/nix-community/emacs-overlay/commit/e6ffe8e1dc820391611678881d896f3f414a79ac) Updated nongnu
* [`cc735279`](https://github.com/nix-community/emacs-overlay/commit/cc73527961d3fa021c382ebec5d78e57064f51b3) Updated elpa
* [`18223d59`](https://github.com/nix-community/emacs-overlay/commit/18223d59b877ed39a370668c49afc6f427f93e1c) Updated emacs
* [`47fbb642`](https://github.com/nix-community/emacs-overlay/commit/47fbb6421ecf881d82a56eedf17028ad0041b838) Updated melpa
* [`9599aa4d`](https://github.com/nix-community/emacs-overlay/commit/9599aa4d86b18f81eee6555578dbf3456ce15cc6) Updated nongnu
* [`e71af116`](https://github.com/nix-community/emacs-overlay/commit/e71af11606d09bdd664c318273efa505deaac4e2) Updated flake inputs
* [`13a5e3dc`](https://github.com/nix-community/emacs-overlay/commit/13a5e3dcd3eb24030066dc331b995e79a1b446ad) Updated elpa
* [`877d5390`](https://github.com/nix-community/emacs-overlay/commit/877d53901ad99e44e1ec00b56b0fdfa443d1d35d) Updated melpa
* [`54af2ae9`](https://github.com/nix-community/emacs-overlay/commit/54af2ae96631311dc4d2686a07e4f472fb36f516) Updated emacs
* [`59bc428e`](https://github.com/nix-community/emacs-overlay/commit/59bc428eb9173402460cc9365b23810d9d4d6d8d) Updated nongnu
* [`52a09589`](https://github.com/nix-community/emacs-overlay/commit/52a095892ca74be27cd229accd59cc61df21d48a) Updated emacs
* [`640fb209`](https://github.com/nix-community/emacs-overlay/commit/640fb2092ce9e7547e5d717ff621e561ea5d12a4) Updated melpa
* [`82c1d02f`](https://github.com/nix-community/emacs-overlay/commit/82c1d02f0a95ac631859d9e863f3646beb828674) Updated nongnu
* [`5ec710e5`](https://github.com/nix-community/emacs-overlay/commit/5ec710e5f2dded1069500d6930be998b173248d8) Updated elpa
* [`d30c19fc`](https://github.com/nix-community/emacs-overlay/commit/d30c19fcdd80bb6970e2ff36792a8fe92b0f9a31) Updated emacs
* [`cced6b8c`](https://github.com/nix-community/emacs-overlay/commit/cced6b8c32a8f0b8590fce78323ba7421f3eb0af) Updated melpa
* [`4fd9bbcc`](https://github.com/nix-community/emacs-overlay/commit/4fd9bbcc33128db58bd2b0b68a7247751a3ad298) Updated elpa
* [`4e34916c`](https://github.com/nix-community/emacs-overlay/commit/4e34916c88ec645b0a4bfff6347dbcca81852f82) Updated emacs
* [`594ce4b6`](https://github.com/nix-community/emacs-overlay/commit/594ce4b67cd089110785a9c23731f61767d233d3) Updated melpa
* [`1dc0cfc1`](https://github.com/nix-community/emacs-overlay/commit/1dc0cfc1b5444e0ef94dad4b01dbb85083feed75) Updated elpa
* [`41e24385`](https://github.com/nix-community/emacs-overlay/commit/41e24385775c8e33e4a160f110f046a83fb751d9) Updated emacs
* [`229fe796`](https://github.com/nix-community/emacs-overlay/commit/229fe7967f93909583745950fd2051603b86b051) Updated melpa
* [`527dd7a3`](https://github.com/nix-community/emacs-overlay/commit/527dd7a31297604d1c2d94714c62ef227f335de5) Updated emacs
* [`f7c1efda`](https://github.com/nix-community/emacs-overlay/commit/f7c1efda4d0c14f5090813c60cf4fb87fa1a5e2b) Updated melpa
* [`43293ebb`](https://github.com/nix-community/emacs-overlay/commit/43293ebbb7e48caf7694cd5a983475261cb50f67) Updated flake inputs
* [`a5b73fed`](https://github.com/nix-community/emacs-overlay/commit/a5b73fed008d79fa2be2a09c2839ed8debf922c9) Updated elpa
* [`daed5481`](https://github.com/nix-community/emacs-overlay/commit/daed54819376dcc0532ec252015911ea9aa547d0) Updated emacs
* [`02de2883`](https://github.com/nix-community/emacs-overlay/commit/02de28837fe7e824bdb6bae4d5c18c28ff500f0d) Updated melpa
* [`24c17f43`](https://github.com/nix-community/emacs-overlay/commit/24c17f4314cb2299f1ecb476240d8caa789d5e05) Updated nongnu
* [`ef11e7de`](https://github.com/nix-community/emacs-overlay/commit/ef11e7dede194d3c800db49000f37c8bcf1671b9) Updated elpa
* [`e79ff2ee`](https://github.com/nix-community/emacs-overlay/commit/e79ff2ee70726430d6f7cf36fcd08fa62237497a) Updated emacs
* [`286f2878`](https://github.com/nix-community/emacs-overlay/commit/286f28782f03dcfbd6713fce333785e9f8c754e4) Updated melpa
* [`63f633ad`](https://github.com/nix-community/emacs-overlay/commit/63f633ad9e82f887b8f3ceee01a0489eff8c3792) Updated melpa
* [`ff1c7595`](https://github.com/nix-community/emacs-overlay/commit/ff1c7595a7ba4b969e998863d86d19c7db13f345) Updated nongnu
* [`00a0b8bf`](https://github.com/nix-community/emacs-overlay/commit/00a0b8bf501bb19913b6a380abdc45e610c59764) Updated nongnu
* [`28f6837d`](https://github.com/nix-community/emacs-overlay/commit/28f6837dd1479705fef1c96f1f13bfba216a769a) Updated elpa
* [`471526e3`](https://github.com/nix-community/emacs-overlay/commit/471526e3549a11d4c0021d4ad2bfbce4d110a748) Updated emacs
* [`a0c56789`](https://github.com/nix-community/emacs-overlay/commit/a0c56789c42102f02795a7cfe2623b5600d2d356) Updated melpa
* [`d7310453`](https://github.com/nix-community/emacs-overlay/commit/d7310453099e60245b42bdd372ae417fcf814d0d) Updated nongnu
* [`9e2abd1b`](https://github.com/nix-community/emacs-overlay/commit/9e2abd1b158a0b78b8e0b6e692f8cafc906286d8) Updated flake inputs
* [`089fd46d`](https://github.com/nix-community/emacs-overlay/commit/089fd46d73d07865b8b8969e5e767d3bb0b45858) Updated nongnu
* [`d27b6a29`](https://github.com/nix-community/emacs-overlay/commit/d27b6a29049816938e1e1c73c046ff4e24601e4a) Updated elpa
* [`23b1d7cf`](https://github.com/nix-community/emacs-overlay/commit/23b1d7cfde2a05d94db6561d262328c31837392d) Updated emacs
* [`9974fdcb`](https://github.com/nix-community/emacs-overlay/commit/9974fdcbaf14baea1b5f292b3b845c045169e2a8) Updated melpa
* [`5eea6418`](https://github.com/nix-community/emacs-overlay/commit/5eea6418ad2ddb79245f753bcf3f1fc385a26817) Updated elpa
* [`651ef488`](https://github.com/nix-community/emacs-overlay/commit/651ef488f9e8c1a413a967c1c12b4d49987c14ed) Updated emacs
* [`298c5510`](https://github.com/nix-community/emacs-overlay/commit/298c5510f5145fc18b5968844d4fd9297ad500be) Updated melpa
* [`94da08ec`](https://github.com/nix-community/emacs-overlay/commit/94da08ec63858a4481ff5410b9e5f4106e3de5b6) Updated nongnu
* [`9c64e1ba`](https://github.com/nix-community/emacs-overlay/commit/9c64e1ba45c0eb6f7fe997c33fe86808472ef47d) Updated elpa
* [`f714bba5`](https://github.com/nix-community/emacs-overlay/commit/f714bba5c9a2b4f4bee88441735307070dd7d6e7) Updated emacs
* [`d7f82c36`](https://github.com/nix-community/emacs-overlay/commit/d7f82c36dd7aed0d8a9526f581ea7f11cb017a9e) Updated melpa
* [`f551d446`](https://github.com/nix-community/emacs-overlay/commit/f551d446feb44ad60b46afe3bc901c2cbeb25f2d) Updated nongnu
* [`419fe196`](https://github.com/nix-community/emacs-overlay/commit/419fe196067af8368fb470f91cbcb5b33ecfdaa1) Updated nongnu
* [`b3c99015`](https://github.com/nix-community/emacs-overlay/commit/b3c99015f6140c610a6cbe3a28b367381208401b) Updated flake inputs
* [`eb0fbe28`](https://github.com/nix-community/emacs-overlay/commit/eb0fbe2846713ba1e13b4bdff87962dc0bff841a) Updated elpa
* [`55d5a79a`](https://github.com/nix-community/emacs-overlay/commit/55d5a79a9f7ca73f5d25a21b58833c4c65c16fbd) Updated emacs
* [`8166f96d`](https://github.com/nix-community/emacs-overlay/commit/8166f96d36cc75e32e0aef7c26236b8a6f43a9c4) Updated melpa
* [`1ff84225`](https://github.com/nix-community/emacs-overlay/commit/1ff842257826fff31ba6d78b4464716dcf58008d) Updated elpa
* [`fe578f11`](https://github.com/nix-community/emacs-overlay/commit/fe578f112c15b275d59b756f29e30981d2a65080) Updated nongnu
* [`2f64b0ba`](https://github.com/nix-community/emacs-overlay/commit/2f64b0baedd2d02b0c613bd01a1da4574deb54df) Updated flake inputs
* [`7b14813f`](https://github.com/nix-community/emacs-overlay/commit/7b14813f253fbb1825ff417fabe2141db7f496d2) Updated elpa
* [`ae17e9bf`](https://github.com/nix-community/emacs-overlay/commit/ae17e9bfd674e97800f43d15c77dfbfe813fecf5) Updated emacs
* [`3bd386f2`](https://github.com/nix-community/emacs-overlay/commit/3bd386f244f04071005f586b2babc8d19eed329d) Updated melpa
* [`7440fb92`](https://github.com/nix-community/emacs-overlay/commit/7440fb92bd4f38dd351dd3410f711f4aa7a4e7e8) Updated nongnu
* [`006700df`](https://github.com/nix-community/emacs-overlay/commit/006700df3b345ac5901ea057e07f0a283cace689) Updated nongnu
* [`f60a4bb4`](https://github.com/nix-community/emacs-overlay/commit/f60a4bb430af5ec8dead7e8bb56f49d4ceb7fe86) Updated elpa
* [`2c70d640`](https://github.com/nix-community/emacs-overlay/commit/2c70d640462b3f7ab32ccfee090310ec2de30652) Updated emacs
* [`6a3d47b9`](https://github.com/nix-community/emacs-overlay/commit/6a3d47b976c5a1cd4a93e14246d77bb42217d115) Updated melpa
* [`0eebfe7b`](https://github.com/nix-community/emacs-overlay/commit/0eebfe7b972948b37abc47e2b7e7d95c461bc73e) Updated emacs
* [`47921059`](https://github.com/nix-community/emacs-overlay/commit/47921059effcb4e9b2de4d8b853261f173ee58bc) Updated melpa
* [`f7d22181`](https://github.com/nix-community/emacs-overlay/commit/f7d22181c202b479127233bc15d67d7b7d9ab057) Updated flake inputs
* [`20e4a98a`](https://github.com/nix-community/emacs-overlay/commit/20e4a98a43db00f7c0a17d39c8da6f9f0cfc62d9) Updated nongnu
* [`d393acaf`](https://github.com/nix-community/emacs-overlay/commit/d393acaf8c23f39a7e22aa240f89e456384ec776) Follow upstream feature/igc branch renaming ([nix-community/emacs-overlay⁠#529](https://togithub.com/nix-community/emacs-overlay/issues/529))
* [`c6ac7fdd`](https://github.com/nix-community/emacs-overlay/commit/c6ac7fdd2ceb22dd8285388f53e37b295f5d5dfb) Updated nongnu
* [`6f29f05c`](https://github.com/nix-community/emacs-overlay/commit/6f29f05cacb30834599799258c394d9c74e10624) Updated elpa
* [`e6105121`](https://github.com/nix-community/emacs-overlay/commit/e6105121d0a5de3c996d6a15e2999046c6c536de) Updated emacs
* [`afb96197`](https://github.com/nix-community/emacs-overlay/commit/afb96197838b182c8cdd221016539ecb14ec0d9d) flake: bump nixpkgs-stable to 25.11
* [`c1c190ef`](https://github.com/nix-community/emacs-overlay/commit/c1c190ef22db59c892572f8a5358aa04e7ffa44a) Updated melpa
* [`bf7daa49`](https://github.com/nix-community/emacs-overlay/commit/bf7daa495d8badc9fb3e4bf7e55a77f562d59b96) Updated nongnu
* [`91496e01`](https://github.com/nix-community/emacs-overlay/commit/91496e01932c8269d3360d0cfd65f0a7a995675d) Updated elpa
* [`87a27693`](https://github.com/nix-community/emacs-overlay/commit/87a276933b67e1e3bb11194e834a5ed94e787f35) Updated emacs
* [`d41bac14`](https://github.com/nix-community/emacs-overlay/commit/d41bac14f7061dccdceb4ce7300b3ccbc6f2960a) Updated melpa
* [`900852ac`](https://github.com/nix-community/emacs-overlay/commit/900852ac410181022d57ca3409d111c9319d3ae0) Updated flake inputs
* [`d7ab733e`](https://github.com/nix-community/emacs-overlay/commit/d7ab733e8cef35e6aba24221c58b11db7b516e17) Updated emacs
* [`a5509c96`](https://github.com/nix-community/emacs-overlay/commit/a5509c964e73c76676fc23781c146a7ce149e04a) Updated melpa
* [`a04497af`](https://github.com/nix-community/emacs-overlay/commit/a04497af4b6098fcb4d68beddbf5359636f6e5a4) Updated flake inputs
* [`00b59e34`](https://github.com/nix-community/emacs-overlay/commit/00b59e340dc23ee0d3cd24830d2a2ee14021bc50) Updated nongnu
* [`5933da8d`](https://github.com/nix-community/emacs-overlay/commit/5933da8ddb1672d0e502670ebd93228a399118bf) Updated elpa
* [`5da5872d`](https://github.com/nix-community/emacs-overlay/commit/5da5872d0e75600b0932fad1006e0489b0e1928b) Updated emacs
* [`67f790b2`](https://github.com/nix-community/emacs-overlay/commit/67f790b2a92a9a6b3c31238ed52a3c256e72101c) Updated melpa
* [`4324d77f`](https://github.com/nix-community/emacs-overlay/commit/4324d77f52437de0bad990148f550611f32a8d1c) Updated nongnu
* [`222f784f`](https://github.com/nix-community/emacs-overlay/commit/222f784f9943ef4a307a99a8d69e963d79c40c11) Updated elpa
* [`d2a838cb`](https://github.com/nix-community/emacs-overlay/commit/d2a838cbb365d2584232aa8e8b75ba57e8b8d693) Updated melpa
* [`4b38e67e`](https://github.com/nix-community/emacs-overlay/commit/4b38e67e60c0010dd4efb8ee5d88e08db14cb079) Updated emacs
* [`dc9a2af6`](https://github.com/nix-community/emacs-overlay/commit/dc9a2af69876788c9b9eaf3f2c58beb14496f157) Updated flake inputs
* [`eedb3bac`](https://github.com/nix-community/emacs-overlay/commit/eedb3bacda984630b4f02e385fc39783299d0c7f) Updated emacs
* [`75050bdc`](https://github.com/nix-community/emacs-overlay/commit/75050bdcce17ce5219adc6501dc46fb66d0aef0a) Updated melpa
* [`26ab04c0`](https://github.com/nix-community/emacs-overlay/commit/26ab04c0ae5928d6cdd9ca866202f2a4ad2bf701) Updated nongnu
* [`551783d7`](https://github.com/nix-community/emacs-overlay/commit/551783d72322677f386a1fa444539aa5241247c3) Updated nongnu
* [`deaf4524`](https://github.com/nix-community/emacs-overlay/commit/deaf452467d43196f1cc89a2421b6a34deb207fb) Updated flake inputs
* [`4fba5ab1`](https://github.com/nix-community/emacs-overlay/commit/4fba5ab134ec5e6de48074be34842f635c4f613d) Updated elpa
* [`aa47fa19`](https://github.com/nix-community/emacs-overlay/commit/aa47fa1975846f88fd887ddaf00a7dc5ac96cdc9) Updated melpa
* [`73dcf114`](https://github.com/nix-community/emacs-overlay/commit/73dcf114c2bab0f2bbd8b922beb1c6dafee6846c) Updated emacs
* [`dabfb6b1`](https://github.com/nix-community/emacs-overlay/commit/dabfb6b12f1443330e906c678ccc54dbad129307) Updated flake inputs
* [`64b4878d`](https://github.com/nix-community/emacs-overlay/commit/64b4878d1a328f8968311000245c622092a08684) Updated nongnu
* [`55013eb3`](https://github.com/nix-community/emacs-overlay/commit/55013eb30de53a93a95eaa7e1cc94d3a507b1b95) Updated nongnu
* [`c6f6f35e`](https://github.com/nix-community/emacs-overlay/commit/c6f6f35edeeed531254f6cc428f1c7c8644e8c97) Updated elpa
* [`e3f5e282`](https://github.com/nix-community/emacs-overlay/commit/e3f5e28254249a2e53ee3b74304065e3b60a52b4) Updated emacs
* [`6d9b553c`](https://github.com/nix-community/emacs-overlay/commit/6d9b553cc230acc7a8eadbcadccc0fc785f95f7d) Updated melpa
* [`431d5a19`](https://github.com/nix-community/emacs-overlay/commit/431d5a19ffe2d8cfaaa9d53c14970f99e884c467) Updated flake inputs
* [`4ce92db8`](https://github.com/nix-community/emacs-overlay/commit/4ce92db83efd3393ba51df6bbc06cc34f48c4475) Updated melpa
* [`698ab275`](https://github.com/nix-community/emacs-overlay/commit/698ab27553fb6d1da8c32808e0a3ebf5ae95575f) Updated nongnu
* [`d7708ffb`](https://github.com/nix-community/emacs-overlay/commit/d7708ffb07c85bb2c6f2f70302b0f2d8a340e985) Updated nongnu
* [`2d2377b7`](https://github.com/nix-community/emacs-overlay/commit/2d2377b736b3b890a65f769d51ee0af04d08bfd7) Updated elpa
* [`286b5126`](https://github.com/nix-community/emacs-overlay/commit/286b51263072928560813a83e08b2b7b52375d1f) Updated melpa
* [`4266ecce`](https://github.com/nix-community/emacs-overlay/commit/4266ecce978692439ef3560ae23d2a87fc7579cb) Updated emacs
* [`2f30afcd`](https://github.com/nix-community/emacs-overlay/commit/2f30afcd2ca141e1cf9745439fffcf5fb044dfc8) Updated nongnu
* [`d8e29695`](https://github.com/nix-community/emacs-overlay/commit/d8e296950bd9d56a727097a2ef847d10b20c625c) Updated nongnu
* [`efa1d225`](https://github.com/nix-community/emacs-overlay/commit/efa1d2253095cc62fae754f09a8379e75ada3a41) Updated elpa
* [`dca6ab41`](https://github.com/nix-community/emacs-overlay/commit/dca6ab41049d4f2815f7e02e0eab0290288bbb88) Updated melpa
* [`c006890a`](https://github.com/nix-community/emacs-overlay/commit/c006890a36ebf27a31298eabb2dc31c515618dbe) Updated emacs
* [`c2da5226`](https://github.com/nix-community/emacs-overlay/commit/c2da522611582215eb38d4028aca0dbcbf737b6e) Updated flake inputs
* [`e7876ebe`](https://github.com/nix-community/emacs-overlay/commit/e7876ebeff5bd7dcb1fcec5222f9f3a6f2ec7d89) Updated nongnu
* [`b9ef5d91`](https://github.com/nix-community/emacs-overlay/commit/b9ef5d91b573168df5b58d9d21b6caab113194d0) Updated nongnu
* [`cc288f91`](https://github.com/nix-community/emacs-overlay/commit/cc288f918615db71ed0afeff4342caab52ffa0e9) Updated elpa
* [`43cfb867`](https://github.com/nix-community/emacs-overlay/commit/43cfb867652da3e43e0c9f342ab321da457449be) Updated melpa
* [`1bc53a0f`](https://github.com/nix-community/emacs-overlay/commit/1bc53a0f3e7add50c0356b4e43394cb79ee73112) Updated emacs
* [`4f7b5653`](https://github.com/nix-community/emacs-overlay/commit/4f7b5653f8845eee7c41c9a029d7bc22aaca4e67) Updated nongnu
* [`a094e4de`](https://github.com/nix-community/emacs-overlay/commit/a094e4def5a06fe6db99af862bc85c324814ded6) Updated nongnu
* [`b1e36c59`](https://github.com/nix-community/emacs-overlay/commit/b1e36c59bd95d39627b4d555be9010195e870c4f) Updated elpa
* [`aed515b5`](https://github.com/nix-community/emacs-overlay/commit/aed515b59c7e932a476a55b589ee0bfa456b9746) Bump cachix/cachix-action from 16 to 17
* [`c4b7915a`](https://github.com/nix-community/emacs-overlay/commit/c4b7915a9467aa611c7346d2322514cdf8c1ba45) Updated flake inputs
* [`c6d506a5`](https://github.com/nix-community/emacs-overlay/commit/c6d506a570ba31b95efb89fefb2e4b53dee19846) Updated melpa
* [`eedc208a`](https://github.com/nix-community/emacs-overlay/commit/eedc208a1db00cfdbc75a8689ac1127444930765) Updated emacs
* [`e954ff9e`](https://github.com/nix-community/emacs-overlay/commit/e954ff9e8dd6602da39ffe2f16ab057fd419696e) Updated flake inputs
* [`3607975d`](https://github.com/nix-community/emacs-overlay/commit/3607975db9979a70bebd47f74a7d797334660bcc) Updated nongnu
* [`4315c894`](https://github.com/nix-community/emacs-overlay/commit/4315c8948fabe4b82527062c06b2c94a0a3d09b4) Updated nongnu
* [`18f2244b`](https://github.com/nix-community/emacs-overlay/commit/18f2244b2a4c4b1b4a3783057153424d4fe128ef) Updated elpa
* [`53da35c1`](https://github.com/nix-community/emacs-overlay/commit/53da35c12b4ebf46d5bb54e88ae124403dd4cb50) Updated melpa
* [`3f444419`](https://github.com/nix-community/emacs-overlay/commit/3f4444191f7f21e71d32545b07801bda413a41c6) Updated emacs
* [`f570a081`](https://github.com/nix-community/emacs-overlay/commit/f570a0815a5ef99aaf46c9fa7c7595585e74cd07) Updated nongnu
* [`ae7ea713`](https://github.com/nix-community/emacs-overlay/commit/ae7ea713b088e3929608072c91f345a0aeb0824e) Updated elpa
* [`81a70b64`](https://github.com/nix-community/emacs-overlay/commit/81a70b645e1642afe42158c535196292615c7f3a) Updated emacs
* [`ddff84ff`](https://github.com/nix-community/emacs-overlay/commit/ddff84ff692ec4414129ed7d726ffb4572be67a0) Updated melpa
* [`50f2b677`](https://github.com/nix-community/emacs-overlay/commit/50f2b677ad3a353413ce009dc2feb3a3526b31a3) Updated nongnu
* [`76d4d75f`](https://github.com/nix-community/emacs-overlay/commit/76d4d75ff909ee3135462c776d01b7fee71af379) Updated elpa
* [`13cec183`](https://github.com/nix-community/emacs-overlay/commit/13cec1835f81f64076f672f32572bcad6af81e41) Updated emacs
* [`c1eb782c`](https://github.com/nix-community/emacs-overlay/commit/c1eb782c6b3c72b00d67fcc144a1a457e8149ec0) Updated melpa
* [`35e79fe9`](https://github.com/nix-community/emacs-overlay/commit/35e79fe95d7cec6365a08e3759819420e89b73f2) Updated melpa
* [`6e74b7dd`](https://github.com/nix-community/emacs-overlay/commit/6e74b7ddb7926312b244a4f8a5e7733864fbed5f) Updated nongnu
* [`7bde06de`](https://github.com/nix-community/emacs-overlay/commit/7bde06de73a19eef2525c7fac43092b7077f02aa) Updated elpa
* [`0db43abd`](https://github.com/nix-community/emacs-overlay/commit/0db43abd8aa50b9b2ca0750a5a59429f1b0111ee) Updated melpa
* [`cf21cf80`](https://github.com/nix-community/emacs-overlay/commit/cf21cf8083c233a3593ecee0a30393cec99bd269) Updated emacs
* [`dd0c2d5b`](https://github.com/nix-community/emacs-overlay/commit/dd0c2d5b34899efb33662f6f8e635c185b59ce2f) Updated flake inputs
* [`ce86e017`](https://github.com/nix-community/emacs-overlay/commit/ce86e017b695f34b962ab49abeacd5a47484a3d8) Updated nongnu
* [`2414ff03`](https://github.com/nix-community/emacs-overlay/commit/2414ff0364864b3820ec3ef0aa13a21024fa8303) Updated elpa
* [`2d651a70`](https://github.com/nix-community/emacs-overlay/commit/2d651a70def778658dcb1a542c329a3b4b26b23a) Updated melpa
* [`aedc3813`](https://github.com/nix-community/emacs-overlay/commit/aedc3813aa6452f5bc466bdbef7daa60ecae2bc5) Updated emacs
* [`38521c12`](https://github.com/nix-community/emacs-overlay/commit/38521c12b9e81a1b264eb80ed1a4c3b50e2243db) Updated emacs
* [`f0dc0c79`](https://github.com/nix-community/emacs-overlay/commit/f0dc0c796cf1c489b38a8cade69370b958d07fe8) Updated melpa
* [`ddf8ecc8`](https://github.com/nix-community/emacs-overlay/commit/ddf8ecc8b382fb10dff931b7fbca06aa8cb0a4ba) Updated flake inputs
* [`b1b27f2f`](https://github.com/nix-community/emacs-overlay/commit/b1b27f2f0922a986b6cc0aac1e91e886311c1d31) Updated nongnu
* [`f3141a65`](https://github.com/nix-community/emacs-overlay/commit/f3141a658f22d6e5e8b4f85811d7612f32a09a9d) Updated nongnu
* [`ced91634`](https://github.com/nix-community/emacs-overlay/commit/ced9163493c162272dd764c8de5ff86e86c012bd) Updated elpa
* [`322712b1`](https://github.com/nix-community/emacs-overlay/commit/322712b1e8685aeceddd6aa781c646a24d14510e) Updated emacs
* [`6763245b`](https://github.com/nix-community/emacs-overlay/commit/6763245bda7274bf6b9eb62a65838d3241553385) Updated melpa
* [`199a1fe2`](https://github.com/nix-community/emacs-overlay/commit/199a1fe2e47f7fb68cb7aa8616f3a1344355dbaf) Updated nongnu
* [`cb622a30`](https://github.com/nix-community/emacs-overlay/commit/cb622a300eb66730f9c848f4fec58a83c2cf9b37) Updated nongnu
* [`2b9e501b`](https://github.com/nix-community/emacs-overlay/commit/2b9e501bcd1fbf4d41b613bc2edf0bef4bed3592) Updated elpa
* [`519b69f8`](https://github.com/nix-community/emacs-overlay/commit/519b69f8256a48c99d2210f84c44201c1099c619) Updated emacs
* [`5c303fb8`](https://github.com/nix-community/emacs-overlay/commit/5c303fb84c850ad232522a0c99f2c717fe2ce16a) Updated melpa
* [`ea735098`](https://github.com/nix-community/emacs-overlay/commit/ea735098e185ae5764c5676f4df97acb95b7549e) Updated nongnu
* [`d4ed9942`](https://github.com/nix-community/emacs-overlay/commit/d4ed9942f593b0c0d31b8c424098c10f2e426b32) Updated nongnu
* [`7f8f1e78`](https://github.com/nix-community/emacs-overlay/commit/7f8f1e78aa145d0e317bd8c1647c7122a3e60bbd) Updated elpa
* [`d3ba96f8`](https://github.com/nix-community/emacs-overlay/commit/d3ba96f83fe40914394fc3f58f705c0723cdceaf) Updated melpa
* [`59d9e08a`](https://github.com/nix-community/emacs-overlay/commit/59d9e08a9c0998096a0d486b58173e79bc0a21a1) Updated emacs
* [`c869f61c`](https://github.com/nix-community/emacs-overlay/commit/c869f61c8459e7ddadc8867b54dc775d0c7605e0) Updated melpa
* [`0f54cda7`](https://github.com/nix-community/emacs-overlay/commit/0f54cda77a06e9e463eda02f8590495c7aeb3b05) Updated nongnu
* [`626f5ff4`](https://github.com/nix-community/emacs-overlay/commit/626f5ff4a5fab6c3a7d8db8b415a5d9575f861df) Updated flake inputs
* [`ccfb636f`](https://github.com/nix-community/emacs-overlay/commit/ccfb636fcb4d94323df0d8169a6faae483861911) Updated nongnu
* [`45607a37`](https://github.com/nix-community/emacs-overlay/commit/45607a37e07584f2d51c3205abec96448a4c4e43) Updated nongnu
* [`4627a115`](https://github.com/nix-community/emacs-overlay/commit/4627a115d6169feff1518ed0b243734f6cce717d) Updated nongnu
* [`377ea521`](https://github.com/nix-community/emacs-overlay/commit/377ea5216e5fa4c8c6c8925bf2d3b015d89d3dcd) Updated flake inputs
* [`0b7fafc2`](https://github.com/nix-community/emacs-overlay/commit/0b7fafc2fb9cbaa39c3171ba4d9741ff6fa2e5e9) Updated nongnu
* [`a9e9eb76`](https://github.com/nix-community/emacs-overlay/commit/a9e9eb764093aa6760d7ca4b77a7d850e45d5dd5) Updated elpa
* [`5f5a7eec`](https://github.com/nix-community/emacs-overlay/commit/5f5a7eec35a7fdaa1325390f5ffa1ad4b0317fb6) Updated melpa
* [`094e01b3`](https://github.com/nix-community/emacs-overlay/commit/094e01b35f12cb2e4b1f2e9d957f2cca89929d7f) Updated emacs
* [`78edc8a6`](https://github.com/nix-community/emacs-overlay/commit/78edc8a6fe8948c30816887f836a93fcc770d534) Updated emacs
* [`ff3c21bc`](https://github.com/nix-community/emacs-overlay/commit/ff3c21bca4ee39de2d8b8c2cb557d40f726f89b9) Updated melpa
* [`953a130e`](https://github.com/nix-community/emacs-overlay/commit/953a130e11be7a68556fc34de18dd597fc5e0865) Updated elpa
* [`36e021ce`](https://github.com/nix-community/emacs-overlay/commit/36e021ce5db96d12a2a4ebd3a1e8e44644163cc0) Updated melpa
* [`3805a810`](https://github.com/nix-community/emacs-overlay/commit/3805a81092f6bb2588d1411334afdda3bb839ef8) Updated emacs
* [`452c177f`](https://github.com/nix-community/emacs-overlay/commit/452c177f2f0ce8d13d2ed3910ccf9b75a37acd51) Updated nongnu
* [`afba1773`](https://github.com/nix-community/emacs-overlay/commit/afba1773231f42ac441a477a0c58d76d2af634ea) Updated elpa
* [`d10a7f2a`](https://github.com/nix-community/emacs-overlay/commit/d10a7f2a1a09656f82e7eb9d2981216b7f094dc1) Updated emacs
* [`a42f7036`](https://github.com/nix-community/emacs-overlay/commit/a42f70362a7ff572f3dcf1be10498abcc48b6328) Updated melpa
* [`b6fe7020`](https://github.com/nix-community/emacs-overlay/commit/b6fe70205da870c7e39d9462724d68afcc06e861) Updated flake inputs
* [`120ce115`](https://github.com/nix-community/emacs-overlay/commit/120ce11560e7ce7c73b9977ca15fe9915b921e82) Updated nongnu
* [`976a86a6`](https://github.com/nix-community/emacs-overlay/commit/976a86a65ce187c9aaf5ef9ef4e5be58b39522c8) Updated flake inputs
* [`406de119`](https://github.com/nix-community/emacs-overlay/commit/406de119774200fbf1cb0cfb5bf8626e3127182e) Updated nongnu
* [`8b996e4e`](https://github.com/nix-community/emacs-overlay/commit/8b996e4e2d1486d8290fa30a68664324a8a16b8e) Updated elpa
* [`eb10459a`](https://github.com/nix-community/emacs-overlay/commit/eb10459a5a10bc3794655740e439e4d5ce8b5b79) Updated emacs
* [`2a0acfc6`](https://github.com/nix-community/emacs-overlay/commit/2a0acfc631795bcd717234dbda80ec6cbd309374) Updated melpa
* [`059c997f`](https://github.com/nix-community/emacs-overlay/commit/059c997f211557b6077980c700095d5408a61d70) Updated emacs
* [`0e315e6c`](https://github.com/nix-community/emacs-overlay/commit/0e315e6cbe18c6174a62f13f458e2077d8073fbf) Updated melpa
* [`1a10da90`](https://github.com/nix-community/emacs-overlay/commit/1a10da906c8625da49e8fba9ddae9022c2a9e119) Updated nongnu
* [`1352ba40`](https://github.com/nix-community/emacs-overlay/commit/1352ba406242e7e8beb93ec8b99787bb8edbed04) Updated elpa
* [`f4a4f40b`](https://github.com/nix-community/emacs-overlay/commit/f4a4f40b827c760c2b8e949ad0e67650f344172e) Updated nongnu
* [`e4ea46a4`](https://github.com/nix-community/emacs-overlay/commit/e4ea46a459d553fb654699ee65e64749763a70eb) Updated nongnu
* [`a94a3bc6`](https://github.com/nix-community/emacs-overlay/commit/a94a3bc6b82d7c9713eb756a867d09836143f14c) Updated elpa
* [`a773309d`](https://github.com/nix-community/emacs-overlay/commit/a773309d7e63142a20b245f68b342f12fb3ab313) Updated melpa
* [`d30ce28e`](https://github.com/nix-community/emacs-overlay/commit/d30ce28e8e49100ed15a5c684df372266994d9f4) Updated emacs
* [`e917580b`](https://github.com/nix-community/emacs-overlay/commit/e917580b8a1cbf8661c404148bdba0dd59de0a2d) Updated nongnu
* [`e5a5509e`](https://github.com/nix-community/emacs-overlay/commit/e5a5509ef7d53a551242f4cfb08b38c9680aac3c) Updated elpa
* [`509fb7de`](https://github.com/nix-community/emacs-overlay/commit/509fb7de1730ba1f3d56a2f30256e6125ad22737) Updated nongnu
* [`fd960404`](https://github.com/nix-community/emacs-overlay/commit/fd960404027cd572d6250882c2e01ba4756e155e) Updated elpa
* [`496d2de3`](https://github.com/nix-community/emacs-overlay/commit/496d2de354c53229f4ae7137d518c757f69349eb) Updated melpa
* [`dd2448f7`](https://github.com/nix-community/emacs-overlay/commit/dd2448f71b6984ebd6575b0f49ddbbaee0e18b3f) Updated emacs
* [`fc303c65`](https://github.com/nix-community/emacs-overlay/commit/fc303c6560d87efb534c7b80728def8e6168ba03) Updated emacs
* [`c868f794`](https://github.com/nix-community/emacs-overlay/commit/c868f794043735f1e2cc8d93f6a6d947bfa9e0f0) Updated melpa
* [`908befef`](https://github.com/nix-community/emacs-overlay/commit/908befefab789147dd97c02692f445627f462eae) Updated nongnu
* [`e99da850`](https://github.com/nix-community/emacs-overlay/commit/e99da8509c65ad680dc662238c478aad094ab621) Updated flake inputs
* [`e40238e6`](https://github.com/nix-community/emacs-overlay/commit/e40238e6e0eb51e16341aad0c46109f3468324ee) Updated nongnu
* [`9714d18e`](https://github.com/nix-community/emacs-overlay/commit/9714d18e3b55f61531a42795779a941365cb2588) Updated flake inputs
* [`6877822f`](https://github.com/nix-community/emacs-overlay/commit/6877822fc1855f248077d7833f25432e21940543) Updated nongnu
* [`3497e75a`](https://github.com/nix-community/emacs-overlay/commit/3497e75abfca9a5ed7fa65f5e47f046e1f2a00f4) Updated nongnu
* [`14c3eb0e`](https://github.com/nix-community/emacs-overlay/commit/14c3eb0e10fbc48012b73ef785ae7645297372f6) Updated flake inputs
* [`cfeea8b7`](https://github.com/nix-community/emacs-overlay/commit/cfeea8b78511e06caf1ab4318a1a898a7f1fa523) Updated nongnu
* [`ee918476`](https://github.com/nix-community/emacs-overlay/commit/ee918476d580db5c60d5ab101c0fb592843d3684) Updated elpa
* [`389d3c05`](https://github.com/nix-community/emacs-overlay/commit/389d3c05801c1f7e6fb3d9fa4295305f33e71e29) Updated emacs
* [`f99fd9f7`](https://github.com/nix-community/emacs-overlay/commit/f99fd9f78b95f7f98da2646e5955306e0d99ec3a) Updated melpa
* [`116e5388`](https://github.com/nix-community/emacs-overlay/commit/116e5388413e10a56d0d2ad807dbb690d166d649) Updated flake inputs
* [`84968230`](https://github.com/nix-community/emacs-overlay/commit/849682305f0da62f51ae1f260ede513a7e22466b) Updated nongnu
* [`ea399f87`](https://github.com/nix-community/emacs-overlay/commit/ea399f874bf7bbf139025b915c8046eb6138cd51) Updated elpa
* [`53c17428`](https://github.com/nix-community/emacs-overlay/commit/53c17428fc4a70ba79f841ce16854cea60a60b61) Updated emacs
* [`6727826c`](https://github.com/nix-community/emacs-overlay/commit/6727826cfa556a7b79afc2e30ad52acb6ce6e53c) Updated melpa
* [`42980d23`](https://github.com/nix-community/emacs-overlay/commit/42980d238b4d1943c33e42b6a4ee5b9fc8cd11b1) Updated nongnu
* [`0ddac56c`](https://github.com/nix-community/emacs-overlay/commit/0ddac56c1779b26c601badce4fc7bd798a80cd56) Updated flake inputs
* [`6d6645be`](https://github.com/nix-community/emacs-overlay/commit/6d6645be944e752dd55e682aefdae3b498455c07) Updated nongnu
* [`86942702`](https://github.com/nix-community/emacs-overlay/commit/86942702c0a6de3e3d07a1a9a1cda0cfa2cac0af) Updated elpa
* [`8d4d36e6`](https://github.com/nix-community/emacs-overlay/commit/8d4d36e62a3715ed453dc7b53f58454861e6b7fb) Updated emacs
* [`dcd018db`](https://github.com/nix-community/emacs-overlay/commit/dcd018dbd7b1cf0addf581f3aae39f3ca32d2a23) Updated melpa
* [`d3058757`](https://github.com/nix-community/emacs-overlay/commit/d3058757a7beff19e8f955ba8b571b1f338d91cc) Updated flake inputs
* [`917f2409`](https://github.com/nix-community/emacs-overlay/commit/917f24098c52efd720fb4742c68e7663e735395e) Updated nongnu
* [`4f147ede`](https://github.com/nix-community/emacs-overlay/commit/4f147eded1609a6930f0a16eb4c8ff708875ac3b) Updated elpa
* [`c4006e58`](https://github.com/nix-community/emacs-overlay/commit/c4006e58bdcffdac456f300cf5d7a45c9452648f) Updated emacs
* [`d563e40d`](https://github.com/nix-community/emacs-overlay/commit/d563e40d245fb24f0f3017a3c8eb573322eeacde) Updated melpa
* [`d620f283`](https://github.com/nix-community/emacs-overlay/commit/d620f2831e367850fb9310849db3049587151ad1) Updated nongnu
* [`04d8a7f6`](https://github.com/nix-community/emacs-overlay/commit/04d8a7f6c66dc6a95efa1ad4aabc5816f606bf62) Updated nongnu
* [`ff96d2fc`](https://github.com/nix-community/emacs-overlay/commit/ff96d2fce6a0e1253ec7921c5551243367e47bda) Updated elpa
* [`f7308817`](https://github.com/nix-community/emacs-overlay/commit/f73088170dc4e825e39625eeddfdf5de56389796) Updated emacs
* [`5987a329`](https://github.com/nix-community/emacs-overlay/commit/5987a3297723b982c102c00f5d1b6f09a28763d1) Updated melpa
* [`5155f890`](https://github.com/nix-community/emacs-overlay/commit/5155f8907be589ea1e5c950511dcf6fa20ec12fb) Updated nongnu
* [`33e23003`](https://github.com/nix-community/emacs-overlay/commit/33e23003fb0258d94704ebebe7ca1fedf238b54d) Updated elpa
* [`7f98586f`](https://github.com/nix-community/emacs-overlay/commit/7f98586f33557ba759eee83ee947fd5ba2c8ecf6) Updated emacs
* [`f850dc2a`](https://github.com/nix-community/emacs-overlay/commit/f850dc2a2f7c3086a3dbea79b8bfd03680b0b745) Updated melpa
* [`000ca2cd`](https://github.com/nix-community/emacs-overlay/commit/000ca2cd866f7c37a8c0cc96dd2aff457ee4c865) Updated nongnu
* [`8ece71ce`](https://github.com/nix-community/emacs-overlay/commit/8ece71ceab03954e043b1e692989bbf001d5967b) Updated flake inputs
* [`b4e36560`](https://github.com/nix-community/emacs-overlay/commit/b4e36560da897d15e33c474b17c33654e56830d1) Updated nongnu
* [`a5cf91bf`](https://github.com/nix-community/emacs-overlay/commit/a5cf91bf5b01b6866a5fa1a232be1ef9a04682a4) Updated elpa
* [`648283c1`](https://github.com/nix-community/emacs-overlay/commit/648283c1e23b0ea58f83ca7e4e06d87e366e47bf) Updated emacs
* [`d5ddc836`](https://github.com/nix-community/emacs-overlay/commit/d5ddc836655da49a11eee312223d4fa2dee90694) Updated melpa
* [`ccf01e65`](https://github.com/nix-community/emacs-overlay/commit/ccf01e6567f5adf31b7856d6444361e889adc321) Updated nongnu
* [`4585b7c8`](https://github.com/nix-community/emacs-overlay/commit/4585b7c8a08be9f220a07d6522ed999e6c07e538) Updated elpa
* [`b5ce15a4`](https://github.com/nix-community/emacs-overlay/commit/b5ce15a4884a2ce5fbf90eea62dffa76386925cb) Updated emacs
* [`8bff507b`](https://github.com/nix-community/emacs-overlay/commit/8bff507b5c426fce89f23a4ff02e929efdae1e40) Updated melpa
* [`fff5dfce`](https://github.com/nix-community/emacs-overlay/commit/fff5dfce2dc5f132d07a8092e14a4362442a1a3f) Updated nongnu
* [`68166ba6`](https://github.com/nix-community/emacs-overlay/commit/68166ba63f8ef81b2e5ca71b8e6e3387b9a6ff2e) Updated elpa
* [`d7e3e24c`](https://github.com/nix-community/emacs-overlay/commit/d7e3e24c47c016baec22fde84ed1ba791840bbf5) Updated emacs
* [`71ed8b0b`](https://github.com/nix-community/emacs-overlay/commit/71ed8b0b4028730d51155cd042f40f0426ad7ffe) Updated melpa
* [`3d8d2a94`](https://github.com/nix-community/emacs-overlay/commit/3d8d2a949cccc69d8f4a84429c5145bb70222ce8) Updated flake inputs
* [`69219b6d`](https://github.com/nix-community/emacs-overlay/commit/69219b6d06187571c042f2e5e48f9e263f677704) Updated nongnu
* [`b4829479`](https://github.com/nix-community/emacs-overlay/commit/b482947942bc6d014c75da14217359affdf9da7b) Updated elpa
* [`13b38aec`](https://github.com/nix-community/emacs-overlay/commit/13b38aecb4c1076161484c5791fcf8c0964ec419) Updated emacs
* [`c4618282`](https://github.com/nix-community/emacs-overlay/commit/c4618282508a890ca2f352486f65e7006df87be4) Updated melpa
* [`23055e4c`](https://github.com/nix-community/emacs-overlay/commit/23055e4c66f6b873d6d6299bf5a7fdfe6012be5c) Updated nongnu
* [`4f2cf9a4`](https://github.com/nix-community/emacs-overlay/commit/4f2cf9a4fcb9c28e981df253c5e25c4c7ce14e49) Updated elpa
* [`cb197a11`](https://github.com/nix-community/emacs-overlay/commit/cb197a110ecdc4d87964d1160e81c357743445fb) Updated emacs
* [`1a0129b3`](https://github.com/nix-community/emacs-overlay/commit/1a0129b355cbc765ae868529997175a5af59959d) Updated melpa
* [`94209fef`](https://github.com/nix-community/emacs-overlay/commit/94209fef6a0dc24830d2b9be3d9d1189364b0ed0) Updated flake inputs
* [`31339b3a`](https://github.com/nix-community/emacs-overlay/commit/31339b3ad88d4664207f1281db4360873750a51c) Updated nongnu
* [`f1d0032f`](https://github.com/nix-community/emacs-overlay/commit/f1d0032f0b9a95efab99f1be99c6054e18ed5039) Updated nongnu
* [`84e5db02`](https://github.com/nix-community/emacs-overlay/commit/84e5db029cb329f9156cdbcd57aa4332dcd98f46) Updated elpa
* [`f188652e`](https://github.com/nix-community/emacs-overlay/commit/f188652e2cbea570880d983968a152cd76b68315) Updated melpa
* [`0e6d7115`](https://github.com/nix-community/emacs-overlay/commit/0e6d7115f962555e98571fcbe4991e3b0eb371e3) Updated emacs
* [`513e332b`](https://github.com/nix-community/emacs-overlay/commit/513e332b074507e1b46992952e7d83f329f2c22c) Updated nongnu
* [`021ef41b`](https://github.com/nix-community/emacs-overlay/commit/021ef41bee0aceea12407b0394eea713483c3784) Updated flake inputs
* [`e3eede7f`](https://github.com/nix-community/emacs-overlay/commit/e3eede7f9a0a35a944c7933adbffa6fe0bd8ed90) Updated elpa
* [`7de7d612`](https://github.com/nix-community/emacs-overlay/commit/7de7d6126e9f74e86d2ccf4017498a258836814d) Updated emacs
* [`5c1c84b8`](https://github.com/nix-community/emacs-overlay/commit/5c1c84b8c216121f77bfeaf583e9f443c10d9966) Updated melpa
* [`be79dbb9`](https://github.com/nix-community/emacs-overlay/commit/be79dbb9a0fc22db5f0f4d4abb4d9e0d7abee683) Updated nongnu
* [`9cc096b5`](https://github.com/nix-community/emacs-overlay/commit/9cc096b5a59b0311d4b4475274afcdbb4472f595) Updated elpa
* [`306c3fde`](https://github.com/nix-community/emacs-overlay/commit/306c3fdecca382d085abea4b0924708db69da0aa) Updated emacs
* [`abf902e6`](https://github.com/nix-community/emacs-overlay/commit/abf902e6e53c604d565f2a69c1569211c3e7853b) Updated melpa
* [`7dc1923c`](https://github.com/nix-community/emacs-overlay/commit/7dc1923c1d3464291aeae94ef065c6d7dcb0a90e) Updated nongnu
* [`c9acda13`](https://github.com/nix-community/emacs-overlay/commit/c9acda138586e128801cc2251e4306573ecd2f71) Updated elpa
* [`de1fdbe4`](https://github.com/nix-community/emacs-overlay/commit/de1fdbe439c17854bc8a587d8ab3bf614bd7287b) Updated emacs
* [`0ab23f05`](https://github.com/nix-community/emacs-overlay/commit/0ab23f059a8a22b421a5298aca8b54ddb233935d) Updated melpa
* [`f24c7984`](https://github.com/nix-community/emacs-overlay/commit/f24c798451ddd0209f04cebce3fb675166c853d5) Updated emacs
* [`ebbb9710`](https://github.com/nix-community/emacs-overlay/commit/ebbb9710a27f87a7a5a0847a35bdd686f0971ed6) Updated melpa
* [`c9409021`](https://github.com/nix-community/emacs-overlay/commit/c9409021d14888b710082622aa27890a3b6171e1) Updated nongnu
* [`9348d72d`](https://github.com/nix-community/emacs-overlay/commit/9348d72d818562946e132ac9e07a91c24dd3372c) Updated nongnu
* [`0109c7e0`](https://github.com/nix-community/emacs-overlay/commit/0109c7e0822b9de566fcbf14f99572905ad39392) Updated elpa
* [`aeb99640`](https://github.com/nix-community/emacs-overlay/commit/aeb99640e786a93bddaf2084c9205ad43df4bf9e) Updated melpa
* [`9322f578`](https://github.com/nix-community/emacs-overlay/commit/9322f578922df113e5f7514afd65863d6e832dba) Updated emacs
* [`e7f9a14c`](https://github.com/nix-community/emacs-overlay/commit/e7f9a14c7e9a9808e50e8e383cd2f35311fec5ed) Updated flake inputs
* [`4938f195`](https://github.com/nix-community/emacs-overlay/commit/4938f195cba5642e4c36244076e16015dd544b47) Updated nongnu
* [`c065bba6`](https://github.com/nix-community/emacs-overlay/commit/c065bba6fa3ec61a16444fa08620050dc19c4596) Updated elpa
* [`01941f16`](https://github.com/nix-community/emacs-overlay/commit/01941f16c77ef080c601091dc8a31ee8c0a732ce) Updated melpa
* [`acdd0aad`](https://github.com/nix-community/emacs-overlay/commit/acdd0aad1616886943ea60d8b1376418d1a2cc4c) Updated emacs
* [`38d55463`](https://github.com/nix-community/emacs-overlay/commit/38d5546367bc6c183342d5508c4e02e6d3881eab) Updated nongnu
* [`e5dbd7c2`](https://github.com/nix-community/emacs-overlay/commit/e5dbd7c247c0b90aa82714f3d2d782fd0ebc77c1) Updated elpa
* [`c6ec2b24`](https://github.com/nix-community/emacs-overlay/commit/c6ec2b248ba6f81eb9bb386ce1e2498d320eee7b) Updated melpa
* [`81e37ec0`](https://github.com/nix-community/emacs-overlay/commit/81e37ec0c4c741896cb1bc316fa2c012e7fa1bd5) Updated emacs
* [`6cfbee0d`](https://github.com/nix-community/emacs-overlay/commit/6cfbee0dea41d2e63be7230e8b287370b319fd52) Updated flake inputs
* [`16ae2dfb`](https://github.com/nix-community/emacs-overlay/commit/16ae2dfbc543c18b78c69afae0fe1fcd0368d7cb) Updated elpa
* [`02170c7c`](https://github.com/nix-community/emacs-overlay/commit/02170c7c1e8c57486a209f2c5ec0e5537840a1dc) Updated emacs
* [`6ec95e11`](https://github.com/nix-community/emacs-overlay/commit/6ec95e112689489f76e180106f882e3ff73cc538) Updated melpa
* [`87dff52c`](https://github.com/nix-community/emacs-overlay/commit/87dff52c245cba0c5103cf89b964e508ed9bb720) Updated nongnu
* [`453b5745`](https://github.com/nix-community/emacs-overlay/commit/453b57451549242692aba7ee429c2572f3b2442a) Updated flake inputs
* [`f9d21a08`](https://github.com/nix-community/emacs-overlay/commit/f9d21a08a5783795bae91d091d62bb6554558c61) Updated nongnu
* [`32f7f124`](https://github.com/nix-community/emacs-overlay/commit/32f7f12480ae05b1f89d06161230ac16cb4656ef) Updated nongnu
* [`ec533a57`](https://github.com/nix-community/emacs-overlay/commit/ec533a575637bff9d33e26407e690522d8b56294) Updated elpa
* [`0041dd57`](https://github.com/nix-community/emacs-overlay/commit/0041dd571ebebe8fa779b940fb13b6d447a48b87) Updated melpa
* [`a6bdd96d`](https://github.com/nix-community/emacs-overlay/commit/a6bdd96d34147049bd4191f368058222a4d93ec0) Updated emacs
* [`f9b22d9d`](https://github.com/nix-community/emacs-overlay/commit/f9b22d9d611b13d68480d3e899877e2647f4f1a2) Updated nongnu
* [`adb05e7c`](https://github.com/nix-community/emacs-overlay/commit/adb05e7c6d058c657190fbb0cee9e92c563a2aa6) Updated nongnu
* [`7cc3d0e4`](https://github.com/nix-community/emacs-overlay/commit/7cc3d0e4a23c1802a9879a2d84a693ad6b678650) Updated elpa
* [`cfba7594`](https://github.com/nix-community/emacs-overlay/commit/cfba75948fe0d9a89ddea6dc338a341b025a7bf6) Updated emacs
* [`bbb5148f`](https://github.com/nix-community/emacs-overlay/commit/bbb5148fa2579456dc7da3741e9d8543ce7d3ef1) Updated melpa
* [`309edf48`](https://github.com/nix-community/emacs-overlay/commit/309edf483f99d31b1a744c688f59f900c32e7707) Updated emacs
* [`ba12171e`](https://github.com/nix-community/emacs-overlay/commit/ba12171ea387d4d4fa4bc46db75d6969fe904b65) Updated melpa
* [`c6d7f4a5`](https://github.com/nix-community/emacs-overlay/commit/c6d7f4a50a27111004a384418fdec3fccecfae69) Hardcode patches for emacs-git variants instead of inheriting...
* [`c7b4d362`](https://github.com/nix-community/emacs-overlay/commit/c7b4d3627ebb58d68e0e4a0d251fa9870893224e) fixup! Hardcode patches for emacs-git variants instead of inheriting...
* [`59e2f556`](https://github.com/nix-community/emacs-overlay/commit/59e2f5560f58fecdc245f54f160baf165dc1460c) Revert "fixup! Hardcode patches for emacs-git variants instead of inheriting..."
* [`44fdc959`](https://github.com/nix-community/emacs-overlay/commit/44fdc9594397516460804187ec7cc7be087fd68d) Revert "Hardcode patches for emacs-git variants instead of inheriting..."
* [`c4bd0f48`](https://github.com/nix-community/emacs-overlay/commit/c4bd0f48b7c721b7cf5a0d6b48ce87bf89855230) Hardcode patches for emacs-git variants instead of inheriting...
* [`3fc6d873`](https://github.com/nix-community/emacs-overlay/commit/3fc6d873bea48bf1446f1c55a62a5f344a429ba1) Updated flake inputs
* [`42711d50`](https://github.com/nix-community/emacs-overlay/commit/42711d50137a45b8065c3e329946e2d4525235d0) Updated nongnu
* [`d7709b9b`](https://github.com/nix-community/emacs-overlay/commit/d7709b9b22886140195e8880249c70d4de01c1f9) Updated elpa
* [`bb629635`](https://github.com/nix-community/emacs-overlay/commit/bb629635f302daf652b369b09ec7885665d0c122) Updated emacs
* [`7bb042b8`](https://github.com/nix-community/emacs-overlay/commit/7bb042b8832f916ebc8de9823cc8db69cd134d3c) Updated melpa
* [`16185535`](https://github.com/nix-community/emacs-overlay/commit/16185535edd3baa7c5d610550b822426b750bb74) Updated elpa
* [`dcc2c983`](https://github.com/nix-community/emacs-overlay/commit/dcc2c983a06f5a90e64c6c6c7420d3c26c4da9dd) Updated emacs
* [`d7d0c87d`](https://github.com/nix-community/emacs-overlay/commit/d7d0c87d15148472eef847dfe298095ef4298dc1) Updated melpa
* [`ef37c228`](https://github.com/nix-community/emacs-overlay/commit/ef37c2288f4e1f709f0317757527f52c8563651b) Updated nongnu
* [`3595bee6`](https://github.com/nix-community/emacs-overlay/commit/3595bee61a711b882cbd9921124e5d1d005e40e1) Updated elpa
* [`976dab3e`](https://github.com/nix-community/emacs-overlay/commit/976dab3e09b75513fbe77bbfa85c7008f5f041b7) Updated emacs
* [`5fd9b883`](https://github.com/nix-community/emacs-overlay/commit/5fd9b88340ccddc02059500a1b6a819fdc4c1178) Updated melpa
* [`b8c98cb9`](https://github.com/nix-community/emacs-overlay/commit/b8c98cb9c827cec88f6159456129d7cac4840256) Updated nongnu
* [`8e4ab12c`](https://github.com/nix-community/emacs-overlay/commit/8e4ab12cfbf0b867942f9ac505af4b4b24104f93) Updated elpa
* [`83b0b8aa`](https://github.com/nix-community/emacs-overlay/commit/83b0b8aa0f7bc041ac8c62df5f0d1e7f332455b5) Updated emacs
* [`c6c9ea2d`](https://github.com/nix-community/emacs-overlay/commit/c6c9ea2df2df04e1e723c634078ee91d4cff9865) Updated melpa
* [`e6687ca5`](https://github.com/nix-community/emacs-overlay/commit/e6687ca57ea1d982e05c89273796a99f8dc0e8e4) Updated flake inputs
* [`b1f88788`](https://github.com/nix-community/emacs-overlay/commit/b1f88788b2f0e31cfa42e9dffbc5e9de218369de) Updated nongnu
* [`4fce98dc`](https://github.com/nix-community/emacs-overlay/commit/4fce98dcb27d83ab137d4ea6f70fb2b0739cd530) Updated nongnu
* [`bb4c2845`](https://github.com/nix-community/emacs-overlay/commit/bb4c2845b9b974c3965266aa6f29f96dda8e9d1c) Updated elpa
* [`aac8d639`](https://github.com/nix-community/emacs-overlay/commit/aac8d63955c3749108ca31e8a8e41ec3ac7b0cff) Manually update emacsGit
* [`dd3b17c6`](https://github.com/nix-community/emacs-overlay/commit/dd3b17c608252cc107e3df25496132d04c9c0233) Remove now-unnecessary patch
* [`3374c8d3`](https://github.com/nix-community/emacs-overlay/commit/3374c8d371ab7a2bd5938b10163fec2e550a6a7e) Updated emacs
* [`8bddffbe`](https://github.com/nix-community/emacs-overlay/commit/8bddffbeab720ae66b723f26fb43e568421a3229) Updated melpa
* [`b1f0d661`](https://github.com/nix-community/emacs-overlay/commit/b1f0d6617ca484adaf0c3ea410f9681f1532b460) Updated nongnu
* [`4f7bf17a`](https://github.com/nix-community/emacs-overlay/commit/4f7bf17a1ace8b4674b9e673b967ee4e72de2bd6) Updated nongnu
* [`de522266`](https://github.com/nix-community/emacs-overlay/commit/de522266c0e9e501d8825126ccf4eb9ab1b1cbc4) Updated elpa
* [`bf1e4ea1`](https://github.com/nix-community/emacs-overlay/commit/bf1e4ea11eb464a6801d934e64e57a8909502f89) Updated emacs
* [`caffeac5`](https://github.com/nix-community/emacs-overlay/commit/caffeac5f51131d1fc095da8d526e0a94443e2d0) Updated melpa
* [`62c7057a`](https://github.com/nix-community/emacs-overlay/commit/62c7057a5b047e7b04a1fd86bfaf3fffb35e021d) Updated flake inputs
* [`d70c8f5e`](https://github.com/nix-community/emacs-overlay/commit/d70c8f5ea48e5f805f67e2437f08f2d90331c626) Revert "Remove now-unnecessary patch"
* [`ad573d42`](https://github.com/nix-community/emacs-overlay/commit/ad573d427a50bb83f54586b93375dc8d65d7567c) Revert "Hardcode patches for emacs-git variants instead of inheriting..."
* [`28396995`](https://github.com/nix-community/emacs-overlay/commit/2839699563c2df82fc6620ee83fef8a557b75201) Filter out inapplicable patches
* [`7e93b513`](https://github.com/nix-community/emacs-overlay/commit/7e93b5130f393a62def9cbd565308e5ff97d65b9) Updated emacs
* [`479c9ccf`](https://github.com/nix-community/emacs-overlay/commit/479c9ccfd4f156e72c5cbef6538b5151e72dc7ff) Updated melpa
* [`12f3383f`](https://github.com/nix-community/emacs-overlay/commit/12f3383f6296fbe1ea2eb2b4ad666185fee36f42) Updated nongnu
* [`346bd3de`](https://github.com/nix-community/emacs-overlay/commit/346bd3de87bb008fcd87ca98fed11633a796ce81) Updated nongnu
* [`986e76b9`](https://github.com/nix-community/emacs-overlay/commit/986e76b9224a9f52525ea92b474f73de9153f7c0) Updated elpa
* [`7d382fec`](https://github.com/nix-community/emacs-overlay/commit/7d382fec215041d6c5e08ddcee3c8ffd7962bf43) Updated emacs
* [`8e7ec3b8`](https://github.com/nix-community/emacs-overlay/commit/8e7ec3b883b7dcaa41274c34f55a4005d3200259) Updated melpa
* [`5ad6eb87`](https://github.com/nix-community/emacs-overlay/commit/5ad6eb872dccdca75c070e6bc006de8845a1e3b2) Updated nongnu
* [`ff9b89bf`](https://github.com/nix-community/emacs-overlay/commit/ff9b89bf90faf36fb8ed72368eb9638ca840fe6a) Updated flake inputs
* [`55b9bd83`](https://github.com/nix-community/emacs-overlay/commit/55b9bd836f08ec5b31f919fbc383d00cabd2bb2b) Updated nongnu
* [`4d84d5c3`](https://github.com/nix-community/emacs-overlay/commit/4d84d5c37f28595b34858e4ae9c76c11e7c257ab) Updated elpa
