### PR TITLE
npins doomemacs: update 85ccc61d -> 6be3337b

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -22,9 +22,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "85ccc61ddc2ac7a2206159f51d75b78e87957c70",
-      "url": "https://github.com/doomemacs/doomemacs/archive/85ccc61ddc2ac7a2206159f51d75b78e87957c70.tar.gz",
-      "hash": "sha256-CI1WrgT0Pljkt3DXFkr+Smf5VokEskEZPTzu7K1/J24="
+      "revision": "6be3337b49867bd86f90fe5ca4beeb6b38afaddb",
+      "url": "https://github.com/doomemacs/doomemacs/archive/6be3337b49867bd86f90fe5ca4beeb6b38afaddb.tar.gz",
+      "hash": "sha256-7ErKUgw6Ch7hP1oBjMSos8xXRD+rxxjaOldRn+TcClo="
     },
     "emacs-overlay": {
       "type": "Git",


### PR DESCRIPTION
## Changelog for doomemacs:
Branch: master
Commits: [doomemacs/doomemacs@85ccc61d...6be3337b](https://github.com/doomemacs/doomemacs/compare/85ccc61ddc2ac7a2206159f51d75b78e87957c70...6be3337b49867bd86f90fe5ca4beeb6b38afaddb)

* [`bd949b71`](https://github.com/doomemacs/doomemacs/commit/bd949b718f22d9179037ddbcecfdc40879732255) refactor(lib): deprecate doom-compile-functions
* [`1c330ead`](https://github.com/doomemacs/doomemacs/commit/1c330eadce0b2723cd035d691d853dc090106fd9) refactor(lib): deprecate doom-load-envvars-file
* [`304030fd`](https://github.com/doomemacs/doomemacs/commit/304030fdf8ba628fc0a23a25bda6869291d5a056) refactor(lib): deprecate setq!
* [`59f9e1f5`](https://github.com/doomemacs/doomemacs/commit/59f9e1f5bb5ffb490adf415c6bba21885f3193d2) docs(lib): revise doom-log & doom-run-hooks docstrings
* [`5311d459`](https://github.com/doomemacs/doomemacs/commit/5311d4592daf027f71fb3d1ec10eee62c12fe602) fix: minor typo in cli restart logs
* [`2428689f`](https://github.com/doomemacs/doomemacs/commit/2428689f3b765fab894260bba30293d8a9ad06b7) fix(evil): appease byte-compiler (unused var)
* [`d9014ec4`](https://github.com/doomemacs/doomemacs/commit/d9014ec4c5ecd6785183626e6acaf125348951b3) fix: copy initial-value for load-path, exec-path, process-environment
* [`e2bdb43b`](https://github.com/doomemacs/doomemacs/commit/e2bdb43bf66723241197f7d532f01c769f12b4b0) fix(cli): doom emacs: forward $HOME using environment
* [`4425bd89`](https://github.com/doomemacs/doomemacs/commit/4425bd898f4cd53d777190359a85a3d80f8d01eb) perf(vertico): cache doom-project-root w/ marginalia
* [`e5bbae81`](https://github.com/doomemacs/doomemacs/commit/e5bbae81441f2aaef7c63cc964735c664222056a) feat(lib): introduce doom-kill-childframes-h
* [`f8598501`](https://github.com/doomemacs/doomemacs/commit/f8598501306179f0d24776f5e1437b2ab9adf6cd) nit: fix indent for hl-line config
* [`a9af7810`](https://github.com/doomemacs/doomemacs/commit/a9af7810fec22413d61f22cb39d8b970b9d47107) refactor(vertico): rename +vertico/embark-doom-package-map
* [`88e2a0d5`](https://github.com/doomemacs/doomemacs/commit/88e2a0d5dea807487d880b36e8afab30067deb5b) feat(evil,vertico): merge evil's into emacs' registers
* [`c3ff78ff`](https://github.com/doomemacs/doomemacs/commit/c3ff78ff533c5d868e0e392464008a9d054a738a) nit(vertico): reformat & revise comments
* [`3d61a7b4`](https://github.com/doomemacs/doomemacs/commit/3d61a7b487cd04246b2b602df35c39cbc8866cad) refactor(vertico): rename +vertico-highlight-* functions
* [`2c42e47a`](https://github.com/doomemacs/doomemacs/commit/2c42e47a30e7d044ae731b267ddcfc6d3b1cccc3) nit(evil): reformat & revise comments
* [`10d0b60f`](https://github.com/doomemacs/doomemacs/commit/10d0b60f5dea1467a1f63a34c0bee6f84e61ef4c) refactor(lib): deprecate pushnew!
* [`da36f152`](https://github.com/doomemacs/doomemacs/commit/da36f15296f471c22f03ad95db47023ec18703e9) fix(llm): don't clone gptel recursively
* [`605437b8`](https://github.com/doomemacs/doomemacs/commit/605437b8b84794e0507444f87e23554ab68c00b4) fix(direnv): restart lsp/eglot clients on reload/allow/deny
* [`994b7be3`](https://github.com/doomemacs/doomemacs/commit/994b7be3dff28bc2906cd65a77dcad45da049013) refactor(direnv): remove +direnv--load-info-a
* [`f4d970fd`](https://github.com/doomemacs/doomemacs/commit/f4d970fdf8f76a836af74ca6de01c719c26d10f5) fix(lib,workspaces): arity error on persp-after-load-state-functions
* [`c21b80d7`](https://github.com/doomemacs/doomemacs/commit/c21b80d7ff904ccf79942a40c42d400faf338f05) fix(debugger): remove dap-mode packages
* [`9f00e2e8`](https://github.com/doomemacs/doomemacs/commit/9f00e2e816ed1d75ff17a845719d5f43460f6b2d) release(modules): 26.04.0-dev
* [`a55d6ad9`](https://github.com/doomemacs/doomemacs/commit/a55d6ad95813e7de297b5820789014182425c651) bump: :doom
* [`470e653f`](https://github.com/doomemacs/doomemacs/commit/470e653f08cfe85bbc02516af65e44d3b9c735b8) bump: :app :config :editor :emacs :email :input
* [`b01e8c95`](https://github.com/doomemacs/doomemacs/commit/b01e8c9572696212514a37da823c2e443f918284) refactor(org,pdf): move org-pdftools to :tools pdf
* [`a3b1be01`](https://github.com/doomemacs/doomemacs/commit/a3b1be01211519d2da3ccde85c55d7e38f14e831) refactor(org,magit): move orgit{,-forge} to :tools magit
* [`04701547`](https://github.com/doomemacs/doomemacs/commit/04701547b1dba6b57dfabe01c91f1ed1cfd65d22) bump: :completion :ui :tools
* [`680d1350`](https://github.com/doomemacs/doomemacs/commit/680d135062ac8129ae6abdbb39400788e886fff8) bump: :lang
* [`6c0881c6`](https://github.com/doomemacs/doomemacs/commit/6c0881c6843e04d07685bee2da9ae769d92d76fe) nit: revise TODO/FIXME/HACK/REVIEW/etc in comments
* [`68ed9665`](https://github.com/doomemacs/doomemacs/commit/68ed966569e2c4bea6a570ceb3cfd409fc77c0ae) refactor(vc): remove +vc--compat-31-a
* [`2105bf59`](https://github.com/doomemacs/doomemacs/commit/2105bf59c32b385a28ba02c688b2118264391fa8) nit: minor reformatting & revise comments
* [`dc20cc79`](https://github.com/doomemacs/doomemacs/commit/dc20cc790165544a45d71e843c95ea3075de011c) refactor: minor revisions
* [`a2e0e9c8`](https://github.com/doomemacs/doomemacs/commit/a2e0e9c8cf4d669608969871298ada741e36b525) docs: doctor: revise emacs versions checks
* [`51fe3798`](https://github.com/doomemacs/doomemacs/commit/51fe3798b250df23f440b1e663bc08986560a84b) docs: doctor: improve $HOME project root check
* [`d2d805a4`](https://github.com/doomemacs/doomemacs/commit/d2d805a42b141a03c17e5e957bb0b236d691b971) fix(org): C-c TAB not bound to org-ctrl-c-ctrl-c
* [`013c5f5a`](https://github.com/doomemacs/doomemacs/commit/013c5f5a2880fcec4d39d654d952ead87b13509a) revert: bump: package-lint
* [`7f17dcf0`](https://github.com/doomemacs/doomemacs/commit/7f17dcf09aa1510c482847136c3ac23b7dbf7dc7) fix(cli): doom emacs: use --init-directory if available
* [`eccde787`](https://github.com/doomemacs/doomemacs/commit/eccde78741cf7b319e052f44b208a251e17f92e8) fix(use-package): use-package-ensure-function
* [`c174b25d`](https://github.com/doomemacs/doomemacs/commit/c174b25d5749317535c5bc7bd729f692274e141b) fix(syntax): {next,previous}-error
* [`6556a79a`](https://github.com/doomemacs/doomemacs/commit/6556a79abc40feb6d89b4669a9660d87672cb3e7) revert: polymode
* [`dc0fc9d4`](https://github.com/doomemacs/doomemacs/commit/dc0fc9d4f46dca2ad5af8870ade9ee3d7da69d67) tweak(syntax): configure flymake even without +flymake
* [`a6c57fd4`](https://github.com/doomemacs/doomemacs/commit/a6c57fd4fdd99e9e0af2736bbd61335e06bc5b0e) fix: save after recentf-cleanup on exit
* [`dc7c43b6`](https://github.com/doomemacs/doomemacs/commit/dc7c43b6d383026600a4108b716d72095e27e1c1) refactor: use supported recentf-auto-cleanup value
* [`c95dcfee`](https://github.com/doomemacs/doomemacs/commit/c95dcfee437b8a7f8f364fc83278579f2dba1efc) perf(magit): minor optimizations
* [`e11816e7`](https://github.com/doomemacs/doomemacs/commit/e11816e71120ee4c10ff3a99c0bd6f68237746ef) fix: doom-initialize-packages: don't activate package.el
* [`fd4a8d99`](https://github.com/doomemacs/doomemacs/commit/fd4a8d99ea5e3f512daf32069288271698a80a3a) fix(use-package): use-package-ensure-function (part 2)
* [`d23bbe87`](https://github.com/doomemacs/doomemacs/commit/d23bbe87721c61f4d5a605f2914b32780bb89949) fix(evil): +evil--use-evil-registers-a: recursive advice
* [`d23abed6`](https://github.com/doomemacs/doomemacs/commit/d23abed66d334f81f65c7f7124d02fa7657b4671) perf(magit): use /usr/bin/git on macos
* [`974e45df`](https://github.com/doomemacs/doomemacs/commit/974e45dfd3e432d55e3f2c6d5c7b0372d6da3fd0) fix(javascript): use nodejs-repl-send-* commands
* [`b87034c9`](https://github.com/doomemacs/doomemacs/commit/b87034c95d630db7675d66e9d15805a3af9d5213) docs: doctor: do non-POSIX shell check after loading $DOOMDIR
* [`a5552a70`](https://github.com/doomemacs/doomemacs/commit/a5552a701b9034badd4f66da112edb5002cf6175) docs: doctor: do ripgrep check after loading $DOOMDIR
* [`08ab5d53`](https://github.com/doomemacs/doomemacs/commit/08ab5d53b46784c48432dff17bc2a918cb3b7c11) docs: update doomemacs repo urls
* [`85f6952d`](https://github.com/doomemacs/doomemacs/commit/85f6952dd17585ad74f3045aa5d609a0a9f5fa29) fix(eval): +eval/send-region-to-repl: premature truncation
* [`15d55259`](https://github.com/doomemacs/doomemacs/commit/15d55259159d471f5bd329c712f1010c39e3cc37) tweak(tree-sitter): use maintained systemverilog grammar
* [`be07b41e`](https://github.com/doomemacs/doomemacs/commit/be07b41ed4cbb680152de49d4143dd9f4eb37684) perf: run doom-optimize-for-large-files-h earlier in find-file-hook
* [`de28f4ec`](https://github.com/doomemacs/doomemacs/commit/de28f4ec84b3d951f2ac362af388e9d9aab56c00) perf(vc): don't auto-detect merge conflicts in large files
* [`d1ca5fe8`](https://github.com/doomemacs/doomemacs/commit/d1ca5fe8c82bd336cc36877c264a9b6fa5b2c185) fix(fold): remove references to +compat flag
* [`9840f8e4`](https://github.com/doomemacs/doomemacs/commit/9840f8e45451c383d5c288eb42d07766807e6a97) fix: don't activate global-hl-line-mode when hl-line-mode is on
* [`4cf886ba`](https://github.com/doomemacs/doomemacs/commit/4cf886ba3025d2c6601ad8435fa89b120f465895) refactor: remove old unit tests
* [`45dfc8f6`](https://github.com/doomemacs/doomemacs/commit/45dfc8f60cf432ddfdc1a91547447b1cb2059f15) module: add :ui dashboard
* [`dd72eac1`](https://github.com/doomemacs/doomemacs/commit/dd72eac1971616a6ebe81067cca33b14c148cbcd) bump: :tools
* [`9530c6fb`](https://github.com/doomemacs/doomemacs/commit/9530c6fbfa61b4bcdd4a93eabc1ef5b34493bdcb) fix(magit): motion/TAB misbehavior w/ long lines
* [`0b1de48d`](https://github.com/doomemacs/doomemacs/commit/0b1de48daa44d2cbfb006046ed227836c80469f7) feat(lib): replace doom-region & add doom-region-bounds
* [`4fe1cbed`](https://github.com/doomemacs/doomemacs/commit/4fe1cbeddb821d67986066e2ecac7627ba3cd86d) refactor: s/when-let/when-let*/
* [`9405a061`](https://github.com/doomemacs/doomemacs/commit/9405a061414bda0a9728c69ac957fe155197bb41) refactor(emacs-lisp): eval handler & working buffer command
* [`f8c3decb`](https://github.com/doomemacs/doomemacs/commit/f8c3decb0a5d3427286af27bf3e650ad921dca94) tweak(eval): remap eval-{region,buffer} to module commands
* [`04ef44d9`](https://github.com/doomemacs/doomemacs/commit/04ef44d9c862832a584ede0461b403d374965125) refactor(eval): rewrite module
* [`b4917ef4`](https://github.com/doomemacs/doomemacs/commit/b4917ef4f30022231cde2430e291e5da0b269d67) fix: remove vestigial references to setq!
* [`9e8f1ecd`](https://github.com/doomemacs/doomemacs/commit/9e8f1ecd7c5ef4f08aeb8889dade0a746ad202ae) refactor(org): use new :preview mechanism
* [`5351f186`](https://github.com/doomemacs/doomemacs/commit/5351f18611975b68af6396d9915ad4ffd79fb320) fix(dashboard): parent group and remove :prefix
* [`f0da6a2c`](https://github.com/doomemacs/doomemacs/commit/f0da6a2c313d9f9d1be032d8e943938a4b10b99e) fix(lib): doom-context-pop: logged output
* [`f573c7a1`](https://github.com/doomemacs/doomemacs/commit/f573c7a1ee719cf4d98dfa6b631a189acaa586f3) fix: don't trigger doom-first-buffer-hook too early
* [`d771e24e`](https://github.com/doomemacs/doomemacs/commit/d771e24efa8be71a24aed84afbb98ec7bd969a4b) fix(common-lisp): +lisp/reload-project
* [`379d7d71`](https://github.com/doomemacs/doomemacs/commit/379d7d714768d19bb596bb96a7da7c86ebb191a6) fix(yaml): +tree-sitter: use 0.7.2 grammar when ABI==15
* [`0bbece56`](https://github.com/doomemacs/doomemacs/commit/0bbece56f1ce0a887c6a06d1c1c27c0685c64a38) refactor(vertico): marginalia-command-category: hoist to callers
* [`73693a8a`](https://github.com/doomemacs/doomemacs/commit/73693a8a2d675bc121f09b476df70e89eaf902bd) perf(vertico): reduce project-root calls by one
* [`7d6a0eb7`](https://github.com/doomemacs/doomemacs/commit/7d6a0eb74eb6b4ccb728fafdbe540995e3dbd4b7) fix(vertico): appease byte-compiler
* [`18671e43`](https://github.com/doomemacs/doomemacs/commit/18671e43a176b00191112a4d77347503f6207f9c) fix(vertico): escaping async split separators in consult prompts
* [`698ca04e`](https://github.com/doomemacs/doomemacs/commit/698ca04e0a1e5d2ff42774d80f203e6ece15ac48) nit(vertico): reformat
* [`4fec01b7`](https://github.com/doomemacs/doomemacs/commit/4fec01b7eadccb3403af0d3b22fe8b5b915f8b00) revert: perf(magit): use /usr/bin/git on macos
* [`dfc75cc5`](https://github.com/doomemacs/doomemacs/commit/dfc75cc56efd390f2b8ea787b4d7a46456aadc02) tweak(evil): increase evil-ex-hl-update-delay for special-mode
* [`c1928bf0`](https://github.com/doomemacs/doomemacs/commit/c1928bf0815db05115b8d136987558bbf2d497e5) nit(magit): annotate comment with HACK
* [`73d643da`](https://github.com/doomemacs/doomemacs/commit/73d643da8315809e6e5293503b9da2d6b5130683) fix: appease byte-compiler across the board
* [`2c412fb3`](https://github.com/doomemacs/doomemacs/commit/2c412fb310d19f883758be227f1f904d1ea006e1) fix: straight: respect :branch in package! statement
* [`faf98f02`](https://github.com/doomemacs/doomemacs/commit/faf98f02b476d2d7e9f7fa4d6efc04143363e316) tweak(beancount): use green nf-fa-money icon for *.bean(count)
* [`77851622`](https://github.com/doomemacs/doomemacs/commit/77851622b303a6cd4b7f1183e34c7cce2003a57a) fix(org): reload org-agenda buffer on first invocation
* [`21e372b5`](https://github.com/doomemacs/doomemacs/commit/21e372b53190472b0856c77b0db11561d4d4a738) bump: :lang org
* [`0ec6255f`](https://github.com/doomemacs/doomemacs/commit/0ec6255f23aedf65f287ca1f5af613af4b3813c9) fix(llm): gptel-magit: interop w/ gptel-include-reasoning
* [`b30f5ca6`](https://github.com/doomemacs/doomemacs/commit/b30f5ca6dfa1c410b613ab39264d3503e8ab491e) fix(llm): gptel-magit: non-string responses
* [`22b99ca9`](https://github.com/doomemacs/doomemacs/commit/22b99ca92f72a1b7f97f1b18b07e6c3e183b66b3) fix(llm): void-variable gptel--openrouter error
* [`92a2ad30`](https://github.com/doomemacs/doomemacs/commit/92a2ad302a0fd093849d09340fcc7b298a5c5cc3) tweak: add +local to :lang agda by default
* [`a28c5f6e`](https://github.com/doomemacs/doomemacs/commit/a28c5f6eef3378f4416bce7f75b894b521215482) fix(cli): remove unused lexical var
* [`4b09424c`](https://github.com/doomemacs/doomemacs/commit/4b09424cf69119fe7d5ea8c186bc7dca15ba2cee) feat(llm): set-debug-variable!: gptel-log-level = 'debug
* [`b75897a8`](https://github.com/doomemacs/doomemacs/commit/b75897a8e42e1a860ea04bb06c49f0a993e00006) fix(llm): +llm-fix-gptel-magit--non-string-responses-a
* [`f8329b44`](https://github.com/doomemacs/doomemacs/commit/f8329b44f7effa142759365b57f65fd9376c19fa) revert: jupyter
* [`f2257c3f`](https://github.com/doomemacs/doomemacs/commit/f2257c3fa98ebbe964b5af74513e64b35ca427f4) fix: defcustom :type specifiers
* [`fabdaa40`](https://github.com/doomemacs/doomemacs/commit/fabdaa40a046f87f6cf10693981d397c7628204f) refactor!(org): remove ob-clojure-literate
* [`f2685a88`](https://github.com/doomemacs/doomemacs/commit/f2685a884e61ed43333e22edc5579d6d920a7baa) docs(org): update ob-* packages list
* [`698d5227`](https://github.com/doomemacs/doomemacs/commit/698d52276ee2d518b6d1f1f43c63554ef589ad7e) perf: avoid doom-fallback-buffer in doom-first-buffer-hook trigger
* [`be55ba25`](https://github.com/doomemacs/doomemacs/commit/be55ba25717456043b1653e8e6da6849e94fa69d) fix(default): don't reload keybindings
* [`ff75c105`](https://github.com/doomemacs/doomemacs/commit/ff75c10550a55d27b0014ef8ad6c1675d19a75f1) fix(lib): doom/reload: isolate reload environment more
* [`3381577f`](https://github.com/doomemacs/doomemacs/commit/3381577fb238ab0de51dc42a88a3f012fc115f02) fix(lib): doom/reload-autoloads
* [`9292af3e`](https://github.com/doomemacs/doomemacs/commit/9292af3e2c8e87d9ffc4a3a5c8369d482f4dd51f) docs: remove docs/modules.org
* [`3a2c1207`](https://github.com/doomemacs/doomemacs/commit/3a2c12073fa6023ae8f77a20209a0e7a06ba631e) refactor: s/set-debug-variable!/set-debug-var!/
* [`165032cf`](https://github.com/doomemacs/doomemacs/commit/165032cfec62270c63ca3f2ab507a64c078a83b8) refactor(lib): remove doom/dumb-{de,in}dent commands
* [`2df631ff`](https://github.com/doomemacs/doomemacs/commit/2df631ff588f40b19e9b9c6213ca784a3e667901) refactor: introduce doom-auto-revert-mode
* [`c0662f6e`](https://github.com/doomemacs/doomemacs/commit/c0662f6ea1d5cb9def857d9b39e87ca947797ddd) feat(lib): introduce set-indent-vars! & doom-indent API
* [`6fdbe8c0`](https://github.com/doomemacs/doomemacs/commit/6fdbe8c07df3c2edf36b5f1cd905ce427c90cd83) refactor: remove <=27 compatibility fixes in modules
* [`92b03811`](https://github.com/doomemacs/doomemacs/commit/92b0381168a1a4bd4867cb540a9301ed59ff69cb) refactor(emacs-lisp): reformat and use defgroup & defcustom
* [`370777f3`](https://github.com/doomemacs/doomemacs/commit/370777f398d2988ff8c3a957367c454fe7df8b44) fix(lib): doom-indent: void-variable errors
* [`7d89804c`](https://github.com/doomemacs/doomemacs/commit/7d89804c97db46124c9dc54e45572289653d3e4f) bump: :tools lsp
* [`8b475fcb`](https://github.com/doomemacs/doomemacs/commit/8b475fcb2574286d7f4413c22cc7902d80d21ced) docs(org): +roam: update outdated docstring
* [`e368d2da`](https://github.com/doomemacs/doomemacs/commit/e368d2da1454ebcc09e067e35e17d0d38ce1bdba) fix(lib): doom-indent: if multiple indent vars are nil
* [`bcbb5199`](https://github.com/doomemacs/doomemacs/commit/bcbb5199bf31638ebde00f2b1a943b7e0cb9f22f) tweak(indent-guides): indent-bars-display-on-blank-lines = 'least
* [`bccbbdd6`](https://github.com/doomemacs/doomemacs/commit/bccbbdd61bd71de7754d52be8f7f815b2dd59934) fix(indent-guides): activate reasonably late
* [`6ea2a016`](https://github.com/doomemacs/doomemacs/commit/6ea2a016d16df0ccb29f203250b66c678ea829a4) refactor!(org): remove +pomodoro +contacts +hugo +passwords
* [`1b1838e1`](https://github.com/doomemacs/doomemacs/commit/1b1838e1605a44bae529c7050c26ccb1c288a9bc) perf: comint: no-op advice in read-only buffers
* [`c0935959`](https://github.com/doomemacs/doomemacs/commit/c09359594741c6f06d73803151b7e746c071884d) perf: compilation: rate-limit comint-truncate-buffer
* [`25e4c731`](https://github.com/doomemacs/doomemacs/commit/25e4c73137df36ad179b41a848a1a120c8a76675) tweak: compilation-max-output-line-length = nil
* [`a6a25521`](https://github.com/doomemacs/doomemacs/commit/a6a25521dc56c4bb21fc420cda7e5aeaee71df8f) fix(ruby): rspec-compilation popup rule overriding global rule
* [`a629b154`](https://github.com/doomemacs/doomemacs/commit/a629b154cc713b4ef7f77fca5a172e436111f72a) feat: support for MPS garbage collector (igc)
* [`95d47b48`](https://github.com/doomemacs/doomemacs/commit/95d47b48478b7acf51b598fe22205cb38347b127) fix(dashboard): repeated risky-local-var prompts
* [`a796b67f`](https://github.com/doomemacs/doomemacs/commit/a796b67f3485c63b580803bf67b13831a0be17b9) fix(lsp): void-variable gcmh-high-cons-threshold error
* [`ebf77f71`](https://github.com/doomemacs/doomemacs/commit/ebf77f71c43cf4ff2cef5fb7f29cb3e189f17647) bump: :ui
* [`0ac2c77d`](https://github.com/doomemacs/doomemacs/commit/0ac2c77d3c63c0e6e51712e6680f78366697abfb) fix(popup): rule for *Local Variables* popup
* [`0d35240e`](https://github.com/doomemacs/doomemacs/commit/0d35240e70b660d2bafa19062d649f6a1e481bb0) refactor: large file optimizations
* [`bfbdb460`](https://github.com/doomemacs/doomemacs/commit/bfbdb46092dde83d43c279b9cf05d5800ee71aee) fix(lsp,org): appease byte-compiler-sama
* [`cb639fb1`](https://github.com/doomemacs/doomemacs/commit/cb639fb1595e29ba1f2bf5ba712582da4030f494) bump: :doom
* [`127e54c1`](https://github.com/doomemacs/doomemacs/commit/127e54c1ddebda76e528ead0336374b7bc7a3a9a) nit(whitespace): revise global-dtrt-indent-mode comment
* [`23d1547b`](https://github.com/doomemacs/doomemacs/commit/23d1547be606c3497279cfe3ad7d1bbd5909f76f) fix(indent-guides): interop with vimish-fold
* [`a8369118`](https://github.com/doomemacs/doomemacs/commit/a8369118a18279a5c7e91e740294307edbea3edb) refactor(indent-guides): use frame-parent
* [`290798eb`](https://github.com/doomemacs/doomemacs/commit/290798eb15c2a4038c9f287e31a832b20d47ca86) refactor(zen): reformat & minor revisions
* [`f4c2890e`](https://github.com/doomemacs/doomemacs/commit/f4c2890e126e2e0f03196de9d81249f544f36b8a) fix(zen): remove +zen-toggle-large-window-dividers-h
* [`9eab5dde`](https://github.com/doomemacs/doomemacs/commit/9eab5dde5b73758d5fdd7f01964d6e9c2cad5499) tweak(popup): cancel compilation process if closed
* [`d8d75443`](https://github.com/doomemacs/doomemacs/commit/d8d75443d39d95f3c5256504eb838e0acc62ef44) refactor(org): roam: use visual-line-mode directly
* [`0876796e`](https://github.com/doomemacs/doomemacs/commit/0876796e7ae100ad977c5037e3f3d7701b5e7b3b) feat(zen): add +focus flag
* [`e71ca792`](https://github.com/doomemacs/doomemacs/commit/e71ca792fcefb1e0d634d26a591934ae8f27e0f7) fix(japanese): support more migemo-dictionary locations
* [`4d73f4bc`](https://github.com/doomemacs/doomemacs/commit/4d73f4bcb3650a0f9d55bf76d4b92392005cec52) refactor(lib): remove doom/{issue-track,discourse} commands
* [`aeb81e81`](https://github.com/doomemacs/doomemacs/commit/aeb81e81a71e5a16154b2b3cc23ecc33cbf8cae3) fix(corfu): +corfu/toggle-auto-complete: void-function corfu--auto-post-command
* [`f55e3369`](https://github.com/doomemacs/doomemacs/commit/f55e3369207bc54eabe00e8f025d97c97f8e1f44) tweak(corfu): don't initiate completion on TAB by default
* [`baee82f7`](https://github.com/doomemacs/doomemacs/commit/baee82f75b54fefe3034ca210b53dbd29a44f78b) fix(corfu): +corfu/dabbrev-or-*: use new variable
* [`f50213a8`](https://github.com/doomemacs/doomemacs/commit/f50213a80c2b4ff6df53c4f0d77708e4e7b4b8d6) refactor(corfu): general reformat and revise
* [`b1684131`](https://github.com/doomemacs/doomemacs/commit/b1684131957afe4467e0f1043060a2ce74e560ad) docs(janet): add janet-ts-mode to package list
* [`6f18301b`](https://github.com/doomemacs/doomemacs/commit/6f18301b5443cfb9098756ab6d60394320a704d6) feat(janet): add flymake-janet
* [`1e92ba28`](https://github.com/doomemacs/doomemacs/commit/1e92ba280ea85234b65257116cac432d6be4fe59) refactor(python): remove +python/optimize-imports
* [`1385e71d`](https://github.com/doomemacs/doomemacs/commit/1385e71d63dac72dd9fa1312878568257845704e) refactor(electric): general reformat and revise
* [`bbfa7df3`](https://github.com/doomemacs/doomemacs/commit/bbfa7df304a197d0fddbbda1bf8c4d5d69a261f8) refactor(ruby): general reformat and revise
* [`84f1eef8`](https://github.com/doomemacs/doomemacs/commit/84f1eef8b0192674271fad33e86b71f256d4a580) refactor: hl-line config
* [`dd1e2527`](https://github.com/doomemacs/doomemacs/commit/dd1e25279d570a8b0572a3a428344ad2212739c8) fix(japanese): s/file-directory-p/file-exists-p/
* [`ba511fcb`](https://github.com/doomemacs/doomemacs/commit/ba511fcbfb53d8922ede1600cf49076284a28e99) fix(lib): provided-mode-derived-p calls on Emacs <=29
* [`9c3b5cbd`](https://github.com/doomemacs/doomemacs/commit/9c3b5cbda3cc782fc64ef228d3db9d1dd2a8feff) fix(zen): focus-mode not deactivating with writeroom
* [`9e495522`](https://github.com/doomemacs/doomemacs/commit/9e49552283d3083ccdfd38dc902c3d58915c40e0) refactor(zen): remove unused variable
* [`43912efd`](https://github.com/doomemacs/doomemacs/commit/43912efdcbc9d63f84becfd6cfde86dec04c168d) fix(calendar): open to today by default
* [`3c0f7ab0`](https://github.com/doomemacs/doomemacs/commit/3c0f7ab076dab1e01be8718ffcec91f99289d175) feat(evil): extend embrace support to more modes
* [`8f97fe4a`](https://github.com/doomemacs/doomemacs/commit/8f97fe4afff07b16d0a1a64f179e4cf31d037345) refactor(evil): general reformat and revise
* [`77f2b5ab`](https://github.com/doomemacs/doomemacs/commit/77f2b5abbb4d50a21531d620ac5fa27c35415f7a) refactor(dashboard): reduce work on init
* [`d3aaf2f9`](https://github.com/doomemacs/doomemacs/commit/d3aaf2f9ba79f3d0268b9db0b2b764fb955e0f21) fix(dashboard): revert-buffer-function
* [`3921e74b`](https://github.com/doomemacs/doomemacs/commit/3921e74b5348989ced8b13f913abb7c783d10040) fix(clojure): cider-mode integration
* [`f90b9417`](https://github.com/doomemacs/doomemacs/commit/f90b9417e153e465ea0b659c7a3a88fa8360f41c) fix(swift): treesit integration
* [`ea9cd787`](https://github.com/doomemacs/doomemacs/commit/ea9cd787126383b38145df9a5a94c09936bf4a0e) fix(swift): don't load flycheck-swift if +flymake
* [`1b54462d`](https://github.com/doomemacs/doomemacs/commit/1b54462d589002909eebc130465ef4d427c3805e) docs(swift): minor revision & reformatting
* [`bac27e1f`](https://github.com/doomemacs/doomemacs/commit/bac27e1f8de20837761911d517d2ddbba83371a7) tweak(qt): set-eglot-client! with or without +lsp
* [`69fc1014`](https://github.com/doomemacs/doomemacs/commit/69fc1014a903b73c1c577e057602b06c6dea8cd0) fix(clojure): disable cider-auto-mode to preserve keybindings on REPL quit
* [`40e40f1b`](https://github.com/doomemacs/doomemacs/commit/40e40f1bd7e4ab0e0022b29ce435da4f3d0fe5bc) docs(fold): update package list
* [`b1ce26fa`](https://github.com/doomemacs/doomemacs/commit/b1ce26faa535f145cef7e2523ed94655765e4bc0) docs(zig): revise +lsp docs
* [`b613a6a7`](https://github.com/doomemacs/doomemacs/commit/b613a6a73964e2d5bf494e4ca7ab80e65bb5842a) refactor(treemacs): general reformat and revise
* [`e81228b4`](https://github.com/doomemacs/doomemacs/commit/e81228b42dc3787a0e7f5d258ea2b1cfef94deda) refactor(calendar): make calfw-* package contingent on calfw
* [`7c9e9216`](https://github.com/doomemacs/doomemacs/commit/7c9e92162c470803ce9ec50702a1a22b3489027b) refactor(rss): remove unused +rss-split-direction
* [`f4f7acc5`](https://github.com/doomemacs/doomemacs/commit/f4f7acc5a77b8c5725f208e340fc3c5132ecfed2) refactor(rss): general reformat and revise
* [`651c713e`](https://github.com/doomemacs/doomemacs/commit/651c713e0cc96db3fdd075ea84854101bbae92ec) revert: docs(irc): add circe notification warning
* [`a4745e72`](https://github.com/doomemacs/doomemacs/commit/a4745e7242858f7437e93432b8827c82d4bf6580) refactor(irc): general reformat and revise
* [`18696ae3`](https://github.com/doomemacs/doomemacs/commit/18696ae30b7c98d00e8b56fd5052896792833711) refactor(notmuch): general reformat and revise
* [`f7c37391`](https://github.com/doomemacs/doomemacs/commit/f7c373910c8b673dec653dd3b28f06d94d9239dd) refactor(helm): remove unused variables
* [`a89c8e68`](https://github.com/doomemacs/doomemacs/commit/a89c8e689f6f314b374cb4fdb260a68e50a29b27) refactor(ido): remove unused variables
* [`38f93d24`](https://github.com/doomemacs/doomemacs/commit/38f93d24440596dec45b3f92242d1e24d5e3747e) bump: :ui :tools :editor
* [`4d327a7e`](https://github.com/doomemacs/doomemacs/commit/4d327a7ec8a9f6b0cc28fc26a25e3b8ce039e8e8) bump: :os :input :email :emacs :config :app
* [`78129e47`](https://github.com/doomemacs/doomemacs/commit/78129e4727ddca3a17fbc3215a6082f06bf5ccd0) bump: :doom
* [`02812df3`](https://github.com/doomemacs/doomemacs/commit/02812df398b000ffbae04d0af241de9de8ff491f) feat(emacs-lisp): add package-lint-flymake
* [`0365c1a9`](https://github.com/doomemacs/doomemacs/commit/0365c1a91619c5c7bf17e4703aaeabe6b41e4bef) fix(emacs-lisp): suppress prefix warnings for doom-*
* [`7a068acc`](https://github.com/doomemacs/doomemacs/commit/7a068accbfedf2eda8bf4ea7dbd8317b742984c1) perf: gc-cons-percentage = 1.0 during startup
* [`252b8dc8`](https://github.com/doomemacs/doomemacs/commit/252b8dc8f4a43616afd3aa0fc1f4c2bcfe343a0c) fix(lib): unused lexical variable nomessage
* [`12918745`](https://github.com/doomemacs/doomemacs/commit/129187458dd2ac9fa1b404a629e139d1777307d7) refactor: s/doom-partial/apply-partially/
* [`6b724bdd`](https://github.com/doomemacs/doomemacs/commit/6b724bddcaa3ae88159e2c6704744820c8602708) fix(cc): cmake-ts-mode detection
* [`80349320`](https://github.com/doomemacs/doomemacs/commit/80349320b1ffa67db6cd3fd4f6739434b81c059b) refactor(terraform): general revision
* [`fc855460`](https://github.com/doomemacs/doomemacs/commit/fc8554604893f688edd03ef871730c333b315d8c) module: add :lang odin
* [`d5d5bfad`](https://github.com/doomemacs/doomemacs/commit/d5d5bfaddfb292e2bfad31c7a0a43d40403f586c) refactor: drop igc pseudo-feature
* [`3c248708`](https://github.com/doomemacs/doomemacs/commit/3c248708c988df4e8953eec9a821246cef96ec50) revert: fix(lispy): evil-escape keybind collision on j
* [`5eea0ae5`](https://github.com/doomemacs/doomemacs/commit/5eea0ae546ee1f99f4dfebf27eebf19f15545874) refactor(python): general reformat and revise
* [`5e290e8e`](https://github.com/doomemacs/doomemacs/commit/5e290e8e795dbeb694a93da132f1c29ee4f179a0) fix: recognize more non-standard indent variables
* [`11a022f6`](https://github.com/doomemacs/doomemacs/commit/11a022f68f0ea8f654f90946274dc31375fe7a07) fix: use relative :height for non-default faces in doom-init-fonts-h
* [`ed67d0dd`](https://github.com/doomemacs/doomemacs/commit/ed67d0dde3f4aba273f9a06ec1eb56ef9fb53e97) fix(evil): update cursor colors before they're applied
* [`eb40bec3`](https://github.com/doomemacs/doomemacs/commit/eb40bec314d963436018904ab6d23cc575be3744) fix(lib): doom-set-indent: handling nil or undefined vars
* [`731ea5b1`](https://github.com/doomemacs/doomemacs/commit/731ea5b17e6553bb8ed2d92ce783cc79f12d6337) fix(haskell): reduce indent-vars to haskell-indent-offset
* [`1bdcb81f`](https://github.com/doomemacs/doomemacs/commit/1bdcb81febbb1d2e28d6aa4facbcfa5ddbba5089) refactor!(lib): set-indent-vars!: change signature
* [`a725ba4a`](https://github.com/doomemacs/doomemacs/commit/a725ba4a1b24bc2679f9624ae17a764c44a94b81) docs: remove v3 demo for doom!
* [`e72bcdcf`](https://github.com/doomemacs/doomemacs/commit/e72bcdcf7cd2b06dd6ca0c998338305a677507b5) fix(lib): set-indent-vars!: non-list MODES argument
* [`61f56672`](https://github.com/doomemacs/doomemacs/commit/61f566724a6b9eb0ee155e00a6f1d636e233cbcb) fix(dashboard): don't switch to dashboard on doom/reload
* [`80c4e049`](https://github.com/doomemacs/doomemacs/commit/80c4e0498ebb773adc753bacfee96da5b5e90c44) refactor: native-comp-eln-load-path setter
* [`fb1194b1`](https://github.com/doomemacs/doomemacs/commit/fb1194b141008d7f067bd9867bfd03c18ae5f79e) tweak: read-extended-command-predicate = command-completion-default-include-p
* [`9597cf80`](https://github.com/doomemacs/doomemacs/commit/9597cf805623308e654aac69e233d07a0149885d) release(modules): 26.05.0-dev
* [`4f4911fe`](https://github.com/doomemacs/doomemacs/commit/4f4911fed96739aebbb6d1dbadf0cadbd418fb9a) release: 2.1.0
* [`548d164e`](https://github.com/doomemacs/doomemacs/commit/548d164e1b37fb3214f1f864554415cfd37edb0d) fix: s/3.0.0-pre/2.1.0/ in deprecation warnings
* [`598ee8ad`](https://github.com/doomemacs/doomemacs/commit/598ee8ad81ea80e38514d04e3576666fa5011f18) fix(cli): upgrade: failure to fetch Doom on tagged commits
* [`26f2cf9a`](https://github.com/doomemacs/doomemacs/commit/26f2cf9ae3f6fb6e8fc57ca05154570752ea9e97) fix(hl-todo): enable in more modes
* [`c9ca981f`](https://github.com/doomemacs/doomemacs/commit/c9ca981f10a47ab62e63b61596f88dfedc0d7cb5) fix(web): adapt to new set-indent-vars! signature
* [`6c13db26`](https://github.com/doomemacs/doomemacs/commit/6c13db26bf16ee9a16b227068bd97f1759e0d6a4) bump: :ui
* [`51f7d21f`](https://github.com/doomemacs/doomemacs/commit/51f7d21f35ea565cea581e2aa76ff2ee5bfc3e9f) bump: :tools
* [`7cf7ac5b`](https://github.com/doomemacs/doomemacs/commit/7cf7ac5b2b8de323391de322c5d67cc59624d7cc) bump: :input :editor
* [`9b078b92`](https://github.com/doomemacs/doomemacs/commit/9b078b92e87b6d6525a13e3f4e3dc8d7a5943a6b) bump: :lang
* [`53ff2440`](https://github.com/doomemacs/doomemacs/commit/53ff24402376c4ae07251468f8fdd4c9fcdf8056) feat(erlang): add flymake support
* [`93db182c`](https://github.com/doomemacs/doomemacs/commit/93db182c78ad90259caea20f2cddf5c93aafe178) feat(erlang): register inferior-erlang as REPL handler
* [`b275c4da`](https://github.com/doomemacs/doomemacs/commit/b275c4daa2fa6427b4005fe7f4880afedc80a2c5) fix(erlang): LSP activation in erlang-ts-mode
* [`d0ee9668`](https://github.com/doomemacs/doomemacs/commit/d0ee96687a4e55d91ff5311e462510d8d6997aaa) feat(fsharp): add +tree-sitter
* [`e9cd2a8b`](https://github.com/doomemacs/doomemacs/commit/e9cd2a8b2ddd396cdd996a1fee990828b3365be9) fix(rust): cyclical major mode hierarchy
* [`05ce715c`](https://github.com/doomemacs/doomemacs/commit/05ce715c0fcd9e33708698c9672f1a734b12b8cf) fix(julia): set repl handler sooner
* [`f661a801`](https://github.com/doomemacs/doomemacs/commit/f661a8010fbda49c89540a2d6d5c3d7a60cc8d48) fix(julia): hide repl M-x commands depending on +snail
* [`f2f33bd1`](https://github.com/doomemacs/doomemacs/commit/f2f33bd19091baaa8b65d739e71699345c63ab52) refactor(latex): general reformat and revise
* [`297b8d57`](https://github.com/doomemacs/doomemacs/commit/297b8d5788fdf6a1bae68d75937b01ba01f958f4) fix(lib): doom-set-indent: detect *-ts-indent-offset vars
* [`88651c8e`](https://github.com/doomemacs/doomemacs/commit/88651c8ea85058d3d09e0b1d4b45941759824df4) feat(rust): tree-sitter-rust v0.24.0 -> v0.24.2
* [`72d0ad02`](https://github.com/doomemacs/doomemacs/commit/72d0ad0214f2d740d0c2545e2d24bfcf7d6fb29c) revert: polymode
* [`738321be`](https://github.com/doomemacs/doomemacs/commit/738321be8d5c5e71034fdd3f28ff0769de69837b) feat(lib): package!: add :freeze
* [`81b7b7d6`](https://github.com/doomemacs/doomemacs/commit/81b7b7d68f5c540ceaa355e79d5a6142c610840c) bump: gnuplot
* [`eeabbbb9`](https://github.com/doomemacs/doomemacs/commit/eeabbbb9dc3b58567723f908621de2f055f99c0d) fix(cli): add commit linter scopes/types for project
* [`289d8937`](https://github.com/doomemacs/doomemacs/commit/289d89377ba8606ef779d576ef7d7b41f197dc9b) fix(workspaces): freeze persp-mode
* [`c7667145`](https://github.com/doomemacs/doomemacs/commit/c766714546bfbfb77b2a22333cc26691ec0c6828) fix(cli): doomscript: EMACS_PLUS_NO_PATH_INJECTION=1
* [`534b6403`](https://github.com/doomemacs/doomemacs/commit/534b6403508136e6667a26b43c12c63f053f9b35) fix(cli): doomscript: supppress lexical-binding warnings
* [`b165a92f`](https://github.com/doomemacs/doomemacs/commit/b165a92f2fce8323c8eac5f628e449c126f78d65) revert: jupyter
* [`4a5046c4`](https://github.com/doomemacs/doomemacs/commit/4a5046c4294f70e09609f7d7d62db399747edb58) fix(cli): doomscript: end-of-file error
* [`491a360f`](https://github.com/doomemacs/doomemacs/commit/491a360f9238fbb2553cb9ccead51bb2b126134e) revert: refactor(dashboard): reduce work on init
* [`f950926c`](https://github.com/doomemacs/doomemacs/commit/f950926c881ff26d86b59effb5adf5cb58b448d6) fix(lib): package!: exclude underscore prefixed :env vars
* [`ed01bf47`](https://github.com/doomemacs/doomemacs/commit/ed01bf47e5c2636c529cea41a6223c70566a0dfc) bump: :lang org
* [`62af9974`](https://github.com/doomemacs/doomemacs/commit/62af9974abf04dd0140ca3103a024b4c36178af7) module: remove :themes
* [`6728bf26`](https://github.com/doomemacs/doomemacs/commit/6728bf2694ad88bafe0d2f70c7be352f25ac5622) tweak(org): +org/dwim-at-point: respect org-return-follows-link
* [`3fcd5cca`](https://github.com/doomemacs/doomemacs/commit/3fcd5ccaa53fb9c8e6fc9a87a008d7a49b58994c) fix(csharp): use grammar based on treesit ABI
* [`cfb5aef1`](https://github.com/doomemacs/doomemacs/commit/cfb5aef1e9422dc02ac16da99919294d58e687e5) docs(csharp): mention roslyn-language-server
* [`a27f38ff`](https://github.com/doomemacs/doomemacs/commit/a27f38ff0cd9e3d5af6e0f7de19512099a36cdb1) fix(go): use tree-sitter-go@v0.23.4 in 30.x
* [`abc07a32`](https://github.com/doomemacs/doomemacs/commit/abc07a328148cdf0f4603418064e40af46bafd70) fix(org): autoload links in ol-{info,bibtex,eww}
* [`d6caad29`](https://github.com/doomemacs/doomemacs/commit/d6caad2948fec776b189016f42afe4f1420ebb7e) refactor: s/when-let/when-let*/
* [`bde6fc6a`](https://github.com/doomemacs/doomemacs/commit/bde6fc6a2687acd03df4caa6df0044734a2d4c13) refactor: hoist doom-run-first-hooks-if-files-open-h to doom-finalize
* [`91864558`](https://github.com/doomemacs/doomemacs/commit/91864558b0ba07fefb9c31d643e31190f33a3a6f) refactor: remove ansi-color-for-comint-mode setting
* [`e2867830`](https://github.com/doomemacs/doomemacs/commit/e2867830346e66859f8867daf9125729aa1ba6b2) fix: projectile-files-to-ensure sets default-directory to nil
* [`54fbde72`](https://github.com/doomemacs/doomemacs/commit/54fbde7246c79fcf832999444933f5bd57284ada) feat(spell): implement +spell/previous-error w/o evil
* [`ec43b712`](https://github.com/doomemacs/doomemacs/commit/ec43b712653350ef4a079c8220f88a8385c6c3ac) feat(gdscript): use tree-sitter-gdscript@v6.1.0
* [`4248c5ef`](https://github.com/doomemacs/doomemacs/commit/4248c5ef5998d51f27ac57406f605a5957911003) fix(gdscript): ts-mode integration
* [`422e9226`](https://github.com/doomemacs/doomemacs/commit/422e9226de21d3bedc52333f32ecac282c5dbb88) fix(fsharp): use tree-sitter-fsharp@v0.1.0 if ABI==14
* [`5fc96adc`](https://github.com/doomemacs/doomemacs/commit/5fc96adc17943590b6a5662aeaf24769eb1e2bb0) fix(sml): use tree-sitter-sml@v0.23.0 if ABI==14
* [`81fbc39f`](https://github.com/doomemacs/doomemacs/commit/81fbc39f70a69edceb9d8006c13391e1169daa6a) docs: don't suggest 'doom sync' to recompile doom.el
* [`249e81c5`](https://github.com/doomemacs/doomemacs/commit/249e81c5c1164a25ad3adb06c9d84335b1879dc4) fix(clojure): activate cider-mode in more ts-modes
* [`e7407f61`](https://github.com/doomemacs/doomemacs/commit/e7407f61bf090eca42778ff625b9a03c04ba2316) fix(clojure): remove ts-modes from {auto,interpreter}-mode-alist
* [`5eb006f4`](https://github.com/doomemacs/doomemacs/commit/5eb006f455f0558c97210ba7579880aacb045b67) tweak(goggles): disable non-evil goggles delete-region hinting
* [`386c866f`](https://github.com/doomemacs/doomemacs/commit/386c866f810532e7c8888ea0c571ca6419399801) feat(everywhere): add hyprland/niri support
* [`b6bffa26`](https://github.com/doomemacs/doomemacs/commit/b6bffa2616066ff7a93742709d3f0c51dfe3ba38) fix(rss): elfeed-search-* ops affecting +1 selected line
* [`7fe5efe1`](https://github.com/doomemacs/doomemacs/commit/7fe5efe157dc19f08e4f1ded4e7fea598c1ba8bc) bump: :tools llm
* [`d1d23910`](https://github.com/doomemacs/doomemacs/commit/d1d2391035dd9582bf5e5e73be1d84f587e9d8bd) bump: :lang org
* [`944a70ea`](https://github.com/doomemacs/doomemacs/commit/944a70eaa81c54bbb9f499089314889fc8102a1e) bump: :tools lsp
* [`860a91aa`](https://github.com/doomemacs/doomemacs/commit/860a91aaac235701f30b70fdc74259d438818968) fix(lib): doom/help-packages: paths for codeberg packages
* [`740e7185`](https://github.com/doomemacs/doomemacs/commit/740e7185b4a0e2f222ba37da63130c2b5afbd2ec) fix(:lang): don't override default electric-indent-chars
* [`678efcb2`](https://github.com/doomemacs/doomemacs/commit/678efcb2fb1971611a05c70a9d73baba1c46ffdd) revert: fix: use relative :height for non-default faces in doom-init-fonts-h
* [`707da6f7`](https://github.com/doomemacs/doomemacs/commit/707da6f7e90f26a4e00e5f8f98f29fd08824e71e) bump: :editor lispy
* [`0359ab11`](https://github.com/doomemacs/doomemacs/commit/0359ab11bb477de46d573fc35595683b6811fd60) fix(cc): use tree-sitter-cpp@HEAD if ABI==15
* [`1fba9711`](https://github.com/doomemacs/doomemacs/commit/1fba9711d2ea600fd889e5ecc83462c0ef6a4982) refactor(word-wrap): general reformat and revise
* [`3fd1e509`](https://github.com/doomemacs/doomemacs/commit/3fd1e509d8e72d03c52804ba648c26e425553f9a) refactor(electric): s/+electric-indent-char-fn/+electric-indent-words-fn/
* [`ae70a26d`](https://github.com/doomemacs/doomemacs/commit/ae70a26dee86294b95ff11f6ec27c978057670a6) feat(electric): continue comments on RET
* [`472053fd`](https://github.com/doomemacs/doomemacs/commit/472053fd79fe810c605b7c747048650be0de5823) tweak(evil): +evil:help
* [`c060cee5`](https://github.com/doomemacs/doomemacs/commit/c060cee5f4b62bfb5a05f1b39ddbfddabd6f4a90) feat(emacs-lisp): add let-completion
* [`07e7b4b4`](https://github.com/doomemacs/doomemacs/commit/07e7b4b41edead248ae02cfca69402216124e31c) feat(word-wrap): accept minor modes in +word-wrap-visual-modes
* [`502cb4e2`](https://github.com/doomemacs/doomemacs/commit/502cb4e2099b8f8fbd5d5a5219a904cef395222e) refactor(evil): remove +evil:read
* [`3f3bfdf2`](https://github.com/doomemacs/doomemacs/commit/3f3bfdf27371fa080fe843d3fce92af8539ffe41) refactor(evil): remove unused, redundant, or defunct ex commands
* [`d4d78b23`](https://github.com/doomemacs/doomemacs/commit/d4d78b23ea17f966837d953ae2f46ae4e2e2eb18) fix(evil): ex commands
* [`8bfd1cb8`](https://github.com/doomemacs/doomemacs/commit/8bfd1cb890b597b37acf9230423e1bbe80c0f3fb) refactor(evil): rename :messages ex command to :msg
* [`b4218799`](https://github.com/doomemacs/doomemacs/commit/b42187998df1f23fbe2fb1789fb328aadda7eca8) docs(evil): update list of ex commands
* [`ef7189da`](https://github.com/doomemacs/doomemacs/commit/ef7189da041838ea4b719fd8b2e4e16904faf141) fix(magit): update incremental-load list
* [`3baa406d`](https://github.com/doomemacs/doomemacs/commit/3baa406d6596eb52e38461e6de4393f69d5cbd3a) fix(org): +roam: update incremental-load list
* [`cf59eedd`](https://github.com/doomemacs/doomemacs/commit/cf59eedd9cb88330dedf6b54c8f2244990eb5fe1) fix(dashboard): hide cursor if no buttons
* [`bc3c7e74`](https://github.com/doomemacs/doomemacs/commit/bc3c7e74f48a41e0b24eabc287d9a1d1d8f95cf8) docs(dashboard): add & revise docstrings
* [`1aabae72`](https://github.com/doomemacs/doomemacs/commit/1aabae7265acab73c03d040d10e763569df22a09) fix(lib): doom/reload-theme: reload theme's source
* [`92e815fb`](https://github.com/doomemacs/doomemacs/commit/92e815fb3215e0311504d731fd9e27adfb204e0c) feat(dashboard): add +dashboard-anchor setting
* [`51ad758e`](https://github.com/doomemacs/doomemacs/commit/51ad758eb8b189418d457699ca326d54f9ebbf14) bump: :tools
* [`c6dda22a`](https://github.com/doomemacs/doomemacs/commit/c6dda22a8147c86f9a2d0e7ad69ec34add3c389f) fix(llm): autoload gptel-org commands bound at leader
* [`12e35c10`](https://github.com/doomemacs/doomemacs/commit/12e35c10dac711a57394dbeaa87f57a4b07788aa) fix(dired): void-function dirvish--find-entry error
* [`6be3337b`](https://github.com/doomemacs/doomemacs/commit/6be3337b49867bd86f90fe5ca4beeb6b38afaddb) fix(evil): tab ex commands
