### PR TITLE
npins nixpkgs: update b86751bc -> ebc08544

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -132,8 +132,8 @@
     "nixpkgs": {
       "type": "Channel",
       "name": "nixpkgs-unstable",
-      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-26.05pre981196.b86751bc4085/nixexprs.tar.xz",
-      "hash": "sha256-mBqzkn7oJti2hqeO8iTbDxKw+1ifxpP53feQ0CEXies="
+      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-26.05pre988811.ebc08544afa7/nixexprs.tar.xz",
+      "hash": "sha256-fUlUlthbjH+ppUqSdGoLFM+GbtuxcDhp8V8ouXEAgow="
     },
     "powerlevel10k": {
       "type": "Git",


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: release-26.05
Commits: [nixos/nixpkgs@b86751bc...ebc08544](https://github.com/nixos/nixpkgs/compare/b86751bc4085...ebc08544afa7)

* [`ce96bc54`](https://github.com/NixOS/nixpkgs/commit/ce96bc54ec76ee74b2c28eb2e1d41448d478ebc2) gradle: fix usage of update-deps script without bwrap
* [`e4e5628b`](https://github.com/NixOS/nixpkgs/commit/e4e5628b7f2410a75c30623fe40e218e6d2ee419) harfbuzz: fix `checkPhase` on sandboxed Darwin
* [`81b35731`](https://github.com/NixOS/nixpkgs/commit/81b35731ebd8302f6d91f511015c2ba4e2704218) nixos/proxmox-image: add cloudImage build output
* [`4b4b4f94`](https://github.com/NixOS/nixpkgs/commit/4b4b4f9423fe09812513877661443ee6934adbac) nixos/proxmox-image: make filename consistent with package name
* [`498d57b2`](https://github.com/NixOS/nixpkgs/commit/498d57b2155871dfb51e8c81bc5272607219a083) ddns-updater: Fix stuck-in-dns-resolver error
* [`5eecc693`](https://github.com/NixOS/nixpkgs/commit/5eecc693f5ec876f6c3ee28825334ee27ae2eea8) vscode-extensions.eugleo.magic-racket: 0.7.0 -> 0.8.0
* [`edf458e4`](https://github.com/NixOS/nixpkgs/commit/edf458e4b76de54ef7937c35dbd81975937ce1b1) vscode-extensions.bmalehorn.vscode-fish: 1.0.39 -> 1.0.49
* [`afc10ba2`](https://github.com/NixOS/nixpkgs/commit/afc10ba24ff55d5ea0c51feb0e9e7a573310b1a6) vscode-extensions.ocamllabs.ocaml-platform: 1.32.4 -> 2.0.1
* [`fd0e6ce8`](https://github.com/NixOS/nixpkgs/commit/fd0e6ce8677d861eeb7d1293356cd90f4de59e65) python3Packages.pybase64: 1.4.2 -> 1.4.3
* [`5cfb732b`](https://github.com/NixOS/nixpkgs/commit/5cfb732bcff03a52c50612da8d020438021f1648) vscode-extensions.ms-dotnettools.vscode-dotnet-runtime: 2.3.7 -> 3.0.0
* [`b58bbed8`](https://github.com/NixOS/nixpkgs/commit/b58bbed8653f8802103201f2df1474c61d13cdb7) xorgproto: inline patch due to errors fetching from AUR
* [`3f779c93`](https://github.com/NixOS/nixpkgs/commit/3f779c9356d9db8b2737d4a7d6f6cf9e137a7b6f) vscode-extensions.tombi-toml.tombi: init at 0.7.7
* [`3a6077c2`](https://github.com/NixOS/nixpkgs/commit/3a6077c25d624cb10a1d95829250d7328dcea5da) vscode-extensions.ms-vscode-remote.remote-ssh: 0.120.0 -> 0.122.0
* [`6dc2c857`](https://github.com/NixOS/nixpkgs/commit/6dc2c857a99e4ec426794bc12f4ee381306e4e8f) vscode-extensions.vscodevim.vim: 1.32.2 -> 1.32.4
* [`04c3e0de`](https://github.com/NixOS/nixpkgs/commit/04c3e0defa78848cccbf0b38e8a47e9a1cb626bd) rustPlatform.buildRustPackage: fix cargoDeps inherited attribute overriding
* [`74fdf75f`](https://github.com/NixOS/nixpkgs/commit/74fdf75ff3adff1b99cd8de3871f5d3f8112b927) taradino: add update script
* [`28c10ac2`](https://github.com/NixOS/nixpkgs/commit/28c10ac22bbe48f6347adc7f8ec35275b56ca72a) taradino: 20251031 -> 20251222
* [`edee972a`](https://github.com/NixOS/nixpkgs/commit/edee972a6e4e5781629dd23967bc95fb4249a235) nixos/blueman: Add option to enable Blueman tray applet
* [`4a7e14bf`](https://github.com/NixOS/nixpkgs/commit/4a7e14bf851605d35468a37b635bdff5d2fd94bb) bitcoin: Remove libsodium transistive dependency from bitcoin
* [`57b26dec`](https://github.com/NixOS/nixpkgs/commit/57b26dec73a9f26c301322e4ceec0618a51994aa) bitcoin: Remove zlib transistive dependency from bitcoin
* [`d985cfb5`](https://github.com/NixOS/nixpkgs/commit/d985cfb589dc57d595e8579ebf54de483f679721) vscode-extensions.fortran-lang.linter-gfortran: 3.4.2025030111 -> 4.0.0
* [`a9a81d91`](https://github.com/NixOS/nixpkgs/commit/a9a81d9147efc7e9a92a850df1971bb7a913ba1b) armitage: fix build with jdk17 + gradle_8
* [`fe247124`](https://github.com/NixOS/nixpkgs/commit/fe247124a38be45fc3b265a373fbee25bcd01e5b) exodus: 25.28.4 -> 26.1.5
* [`3a242c87`](https://github.com/NixOS/nixpkgs/commit/3a242c87c60746f304401e7d0f057402b9dbc038) vscode-extensions.tabnine.tabnine-vscode: 3.326.0 -> 3.335.0
* [`da84f1c3`](https://github.com/NixOS/nixpkgs/commit/da84f1c3ec2756056cdb58baf387623ab18f87ef) nixos/starship: add package to systemPackages
* [`e0ee30bc`](https://github.com/NixOS/nixpkgs/commit/e0ee30bc83f0fba6fed8649c3a3fc5a575621382) vscode-extensions.visualstudiotoolsforunity.vstuc: 1.1.3 -> 1.2.1
* [`e225f159`](https://github.com/NixOS/nixpkgs/commit/e225f159713a34995f14b510e96f703721bf5858) pgbackrest: 2.57.0 -> 2.58.0
* [`620dbdbd`](https://github.com/NixOS/nixpkgs/commit/620dbdbdc51d60029e7fe36f0926f4adfd63ce00) why3find: 1.2.0 -> 1.3.0
* [`f83867d2`](https://github.com/NixOS/nixpkgs/commit/f83867d2d443a254b44223b1fa2b043f5e1b3b2f) buildPythonPackage: comment on passthru.__stdenvPythonCompat
* [`9aad7fae`](https://github.com/NixOS/nixpkgs/commit/9aad7fae690a422e0692e05e74c81a93ad6d895c) libraw: 0.21.5b -> 0.22.0
* [`fb4eccca`](https://github.com/NixOS/nixpkgs/commit/fb4eccca212b6bbe24110b1e0d626077a383a61d) sonarr: add packaging info
* [`773f5cc8`](https://github.com/NixOS/nixpkgs/commit/773f5cc8c8e18127258a5eafcd1875f369fb7862) buildPythonPackage: overrideStdenvCompat: add position to warning message
* [`bc5d9615`](https://github.com/NixOS/nixpkgs/commit/bc5d961527885fdaa44c61d96170bf84f53d0169) python313Packages.tkinter: fix nix-shell usage
* [`e074c87f`](https://github.com/NixOS/nixpkgs/commit/e074c87f12633af32ef3f0dc84494fac495fc118) gettext: 0.26 -> 1.0
* [`c45208ce`](https://github.com/NixOS/nixpkgs/commit/c45208cea5538ce6d3d12e6cc317a7ec53c908cc) po4a: 0.73 -> 0.74
* [`c1663a92`](https://github.com/NixOS/nixpkgs/commit/c1663a924aaf3a1c785a6e278171b2db75e4a10e) noriskclient-launcher-unwrapped: 0.6.17 -> 0.6.19
* [`2e9e1e41`](https://github.com/NixOS/nixpkgs/commit/2e9e1e41e09213f9d590923bafc0b26a8f664635) vscode-extensions.cweijan.vscode-database-client2: 8.4.2 -> 8.4.5
* [`611910f0`](https://github.com/NixOS/nixpkgs/commit/611910f00c7346dca1d2c923d45075b6b8ffd010) build-support/node/prefetch-npm-deps: prepare for structuredAttrs
* [`21df8c56`](https://github.com/NixOS/nixpkgs/commit/21df8c56b8b3919538f94823f016db014fa39726) maintainers/haskell: record pnames, not attr names to transitive broken
* [`e2a60581`](https://github.com/NixOS/nixpkgs/commit/e2a60581caf760b9b0d195ff8c2e6111138c6cf1) binutils-unwrapped: 2.44 -> 2.46
* [`e69cbb5f`](https://github.com/NixOS/nixpkgs/commit/e69cbb5feaf2e46bc1efa3850be1dffe2d92a7cc) d2: fix missing playwright dependencies
* [`5f7f61bc`](https://github.com/NixOS/nixpkgs/commit/5f7f61bc5f6b02ae720fb53e18f5406b6c25da3f) fishPlugins.hydro: `0-unstable-2024-11-02` -> `0-unstable-2025-12-31`
* [`6c856e87`](https://github.com/NixOS/nixpkgs/commit/6c856e87254110df91aae623cdaa7f1c92bee936) haskellPackages: set prefix directory when running under Wine
* [`762762f4`](https://github.com/NixOS/nixpkgs/commit/762762f482d40e594d72388f88fd8f00d265b4c7) haskellPackages: use correct platform extension when running iserv-proxy-interpreter
* [`d0a1b36c`](https://github.com/NixOS/nixpkgs/commit/d0a1b36ceaa104d784feb1386a914710a28ed7cb) haskellPackages.iserv-proxy: workaround runtime failure due to pseudo relocation
* [`2accbad1`](https://github.com/NixOS/nixpkgs/commit/2accbad1227ce563b8d578ebb43cd8a3e0fb45f6) haskellPackages.network: fix crash when running inside Wine
* [`a4e653d5`](https://github.com/NixOS/nixpkgs/commit/a4e653d56fe23f19879804a9daea7a21bf48886c) wine: accept device paths when loading DLLs
* [`fa7d26d0`](https://github.com/NixOS/nixpkgs/commit/fa7d26d067586edc3877d1eb62ad8856bd5250f0) haskellPackages: include pthread libraries when using the external interpreter on Windows
* [`18b7ec14`](https://github.com/NixOS/nixpkgs/commit/18b7ec148d7607b9e0c9732970f14ac03883d718) haskellPackages: silence wine debug messages
* [`b80d3415`](https://github.com/NixOS/nixpkgs/commit/b80d341522cd29778c100f0f633487aee12533b0) emscripten: 4.0.23 -> 5.0.0
* [`7afdc4d0`](https://github.com/NixOS/nixpkgs/commit/7afdc4d099a594f74c79634b41668af22115078c) python3Packages.python-debian: 1.0.1 -> 1.1.0
* [`bc177295`](https://github.com/NixOS/nixpkgs/commit/bc1772954dea8880ae3f40a39f153864ef601a46) python314Packages.python-debian: migrate to finalAttrs
* [`164311ba`](https://github.com/NixOS/nixpkgs/commit/164311ba41f781260907f6dd3c6c44b3fa7c7cc8) sratom: 0.6.20 -> 0.6.22
* [`9a8e2a93`](https://github.com/NixOS/nixpkgs/commit/9a8e2a9308d2137400b5940a7178f23ce62518d3) nodejs: fix treefmt after merge commit
* [`db34ffd0`](https://github.com/NixOS/nixpkgs/commit/db34ffd0a218941a43a293cbf02689ce0cd79410) moe: 1.15 -> 1.16
* [`ac812449`](https://github.com/NixOS/nixpkgs/commit/ac8124497c83b46837a1f12e9211e5642c7df243) hockeypuck: 2.1.0 -> 2.3.2
* [`750b4c29`](https://github.com/NixOS/nixpkgs/commit/750b4c295f55df02e782c424a5d3e7a79bbfc78e) libfontenc: 1.1.8 -> 1.1.9
* [`b67242ab`](https://github.com/NixOS/nixpkgs/commit/b67242ab87d45f6de925d6b098eeabc4f1a23b4c) haskellPackages.streaming-commons: remove upstreamed patch
* [`47f400c5`](https://github.com/NixOS/nixpkgs/commit/47f400c51b343fe1355e8e874be873040cca6e38) haskellPackages.vector: gate rather than set `doCheck` attribute
* [`ba8adba7`](https://github.com/NixOS/nixpkgs/commit/ba8adba7434bc4605f60254f362adb52a4b5bf0e) haskellPackages.unix-time: add dependency on `pthreads` for windows
* [`b2b6246e`](https://github.com/NixOS/nixpkgs/commit/b2b6246ed8ede6b4e5601554dcf28b2fc9854ed8) haskellPackages.basement: apply patch for integer cast
* [`35dd3a3a`](https://github.com/NixOS/nixpkgs/commit/35dd3a3a2a294d5a51a7920c3db39b74224792d6) haskellPackages.http-client: add dependency on `safe` for windows
* [`531aa6ec`](https://github.com/NixOS/nixpkgs/commit/531aa6ec70acbfaba4e911a6e750b7c518ad6027) haskellPackages.crypton-x509-system: fix case on library dependency
* [`6fd18ccf`](https://github.com/NixOS/nixpkgs/commit/6fd18ccf1a8b63c6910752f063bd4423a90d3ea1) python3Packages.setuptools-git-versioning: fix eval
* [`6e418aa5`](https://github.com/NixOS/nixpkgs/commit/6e418aa53dc4ad06edcca858277947661fe8b6d0) aligator: 0.16.0 -> 0.18.0
* [`ecea3af0`](https://github.com/NixOS/nixpkgs/commit/ecea3af07db963c2863d075ff46bd98da2b6567c) aligator: remove suitesparse
* [`b9ff1f05`](https://github.com/NixOS/nixpkgs/commit/b9ff1f05690aab512e621dd317fd7695f0f0ee2b) fortify-headers: switch source from alpine to github
* [`d8bcd485`](https://github.com/NixOS/nixpkgs/commit/d8bcd4850391e9fc882d5620a48d85be76bf9d1c) fortify-headers: 1.1 -> 3.0.1
* [`bbe0f302`](https://github.com/NixOS/nixpkgs/commit/bbe0f3022885d71a20fd59831160906efbbe2768) haskellPackages: add missing dependencies on windows
* [`1cb5e9f6`](https://github.com/NixOS/nixpkgs/commit/1cb5e9f635081ce7ef2962c3804a22d3afb5205e) haskellPackages: don't use external interpreter by default in ghcjs
* [`b0b0d5cb`](https://github.com/NixOS/nixpkgs/commit/b0b0d5cb7df2b70b4dc4bfaa58f9daea4e4d6785) sbclPackages.cl-ana_dot_makeres: remove override for package deleted in Quicklisp update
* [`092f6f26`](https://github.com/NixOS/nixpkgs/commit/092f6f26ab1ff85a60f507958fed53dd67eb853c) python-packages.nix: run treefmt
* [`ce35c1b3`](https://github.com/NixOS/nixpkgs/commit/ce35c1b37ce268aa67b9d20c7c03e4d41f417473) haskell.compiler.ghcHEAD: 9.15.20251225 -> 9.15.20260218
* [`cd957465`](https://github.com/NixOS/nixpkgs/commit/cd957465c4b3d524a7f4c493e1d023c675e72acb) himalaya: 1.1.0 -> 1.2.0
* [`4e8f1086`](https://github.com/NixOS/nixpkgs/commit/4e8f1086c5b765a8716924039856a6cdd7c76f62) xorg.*: remove several darwin exclusions for several packages
* [`86b68b8a`](https://github.com/NixOS/nixpkgs/commit/86b68b8a4baf8e62c2144849be55d4a48c55976f) serd: 0.32.6 -> 0.32.8
* [`d09dda80`](https://github.com/NixOS/nixpkgs/commit/d09dda8038d75eeb2bb3b24b700c1be5758f86c4) sddm-astronaut: refactor
* [`5bc013ae`](https://github.com/NixOS/nixpkgs/commit/5bc013aed0f64d5513c0b537dd5e9fe67792489f) sddm-astronaut: add nix-update-script with version branch
* [`56939149`](https://github.com/NixOS/nixpkgs/commit/569391490853cb90f4e52f55df7eee9f9ba2d38c) sddm-astronaut: 1.0-unstable-2025-01-05 -> 0-unstable-2025-12-06
* [`0415b16d`](https://github.com/NixOS/nixpkgs/commit/0415b16d1f0562b7bfdce74574b29c1b829d07b1) sddm-astronaut: add qweered as maintainer
* [`f0529567`](https://github.com/NixOS/nixpkgs/commit/f05295674ba68ce2ea091b63075ee2f8bc310e57) sddm-astronaut: avoid .dev outputs propagation
* [`6de6be77`](https://github.com/NixOS/nixpkgs/commit/6de6be775a1499c11cf5eec8789711459fc5c87c) haskellPackages.require: jailbreak
* [`c971eead`](https://github.com/NixOS/nixpkgs/commit/c971eead70dea41bb9e30660e4fa74da39b71b14) ov: 0.50.2 -> 0.51.1
* [`2ac0b1ff`](https://github.com/NixOS/nixpkgs/commit/2ac0b1ff7b89e30a312a80936cef76fdd218f023) devede: 4.21.0 -> 4.21.3.1
* [`a1d3dbb0`](https://github.com/NixOS/nixpkgs/commit/a1d3dbb09397fbe33f3dbc536b455f7d512c9966) githooks: 3.0.4 -> 3.0.5
* [`25f0d94e`](https://github.com/NixOS/nixpkgs/commit/25f0d94ececfb94d491ce05f735323cd8138c339) python3Packages.pylint: 4.0.4 -> 4.0.5
* [`729704e1`](https://github.com/NixOS/nixpkgs/commit/729704e1afbee4b0ab9d0489b23e489538bbec34) wayland: drop Darwin patch
* [`eb0e2e28`](https://github.com/NixOS/nixpkgs/commit/eb0e2e28a5942157da7411bc96d42ff4dc25f947) nixos/scrutiny: harden systemd service
* [`04349a73`](https://github.com/NixOS/nixpkgs/commit/04349a7338b7e2c96a063c689283acf7206c51c7) haskellPackages.cabal-install: fix build when cross compiling
* [`22b889f9`](https://github.com/NixOS/nixpkgs/commit/22b889f9d6a2f8ba83775d8d64d9075c72b93ea7) goose: 3.26.0 -> 3.27.0
* [`9dd7204f`](https://github.com/NixOS/nixpkgs/commit/9dd7204f9fe12be20714f940fda2769c55360d70) haskellPackages.hip: increase simplifier ticks
* [`9d484a32`](https://github.com/NixOS/nixpkgs/commit/9d484a32e8ac648e0b656bf05d7ba2c9ee6e0d61) haskellPackages.dataframe: pin to 0.3.3.6
* [`aa89b331`](https://github.com/NixOS/nixpkgs/commit/aa89b33126b690b8b1bc6586bd535c892f6735e1) haskellPackages.ihaskell-dataframe: jailbreak
* [`ade72069`](https://github.com/NixOS/nixpkgs/commit/ade72069e8cbb7db28078ba164722027a0d038eb) haskellPackages.dataframe-persistent: jailbreak
* [`87e91676`](https://github.com/NixOS/nixpkgs/commit/87e91676c7e7bd9a1798e52f3dcc188a6927b81f) netpbm: 11.13.2 -> 11.13.3
* [`b40cd566`](https://github.com/NixOS/nixpkgs/commit/b40cd566cca356792ae2b274dd9f13a8eb31c4f9) nghttp3: 1.14.0 -> 1.15.0
* [`79024f14`](https://github.com/NixOS/nixpkgs/commit/79024f14f9376909ef5b0d4772a05f17a9e86f0e) docs: pkgs/README.md: promote 3rd-party flake search
* [`2ab2e2dc`](https://github.com/NixOS/nixpkgs/commit/2ab2e2dc3229513fa76ec2be507f4f5e5b966ceb) top-level/release-haskell.nix: remove GHC 9.10.2 jobs
* [`ea6599a9`](https://github.com/NixOS/nixpkgs/commit/ea6599a9362fb70809470712a2621706c772f679) top-level/release-haskell.nix: hlint, weeder build with 9.10.3
* [`16333c9a`](https://github.com/NixOS/nixpkgs/commit/16333c9ad1fb9ef6fc90c0d03634edc67834141d) python3Packages.python-multipart: 0.0.21 -> 0.0.22
* [`6aff81db`](https://github.com/NixOS/nixpkgs/commit/6aff81db3dcc605bd05a3b4aa2ae5717d52df292) python3Packages.nicegui: 3.7.1 -> 3.8.0
* [`9ca9e6ef`](https://github.com/NixOS/nixpkgs/commit/9ca9e6efffd4620ebd2e58a16a9c804a6da6ccf0) haskell.packages.ghc{94,96,98}: add missing ghc-experimental attr
* [`3e55e876`](https://github.com/NixOS/nixpkgs/commit/3e55e876e1de5e0ddb72052544628d3c239333ab) haskellPackages: stackage LTS 24.29 -> LTS 24.32
* [`fb11607c`](https://github.com/NixOS/nixpkgs/commit/fb11607cf5babf489ebf06d3bcb120373a6c21a0) gawk: 5.3.2 -> 5.4.0
* [`78d9620f`](https://github.com/NixOS/nixpkgs/commit/78d9620f669cf74aabb89b18ef5cb825a037d054) dnglab: 0.7.1 -> 0.7.2
* [`6a558123`](https://github.com/NixOS/nixpkgs/commit/6a558123863fabb44c05f8eba1bc7e7709d7d9fd) libunistring: 1.4.1 -> 1.4.2
* [`39e07a55`](https://github.com/NixOS/nixpkgs/commit/39e07a554e3e0fbdef3470cde10788fd1c3aa17c) quint: 0.30.0 -> 0.31.0
* [`8b721080`](https://github.com/NixOS/nixpkgs/commit/8b721080d678e1da76f5f99b3db2fbdd789b9b1a) p11-kit: 0.26.1 -> 0.26.2
* [`086c134b`](https://github.com/NixOS/nixpkgs/commit/086c134b78fd6282cbebcb66b67b7133d7108500) aspell: 0.60.8.1 -> 0.60.8.2
* [`8f104311`](https://github.com/NixOS/nixpkgs/commit/8f1043116020c88415511851a47faacb9ff9515a) lilv: 0.26.2 -> 0.26.4
* [`2ecc93fb`](https://github.com/NixOS/nixpkgs/commit/2ecc93fb907b8820072434802ba77078382cda82) python3Packages.python-multipart: migrate to finalAttrs
* [`9c201cbe`](https://github.com/NixOS/nixpkgs/commit/9c201cbefadb005735c53926379e88d84a4605a5) python3Packages.torchio: update changelog URL
* [`dfd0f18d`](https://github.com/NixOS/nixpkgs/commit/dfd0f18d9df417bb185d95ac806c220049fbfca1) nixos/zfs: default `forceImportRoot` to false for stateVersion >= 26.11 and warn before that
* [`17fd12ce`](https://github.com/NixOS/nixpkgs/commit/17fd12ce9c20f388a042cf1651917f9d1f9a4ddc) nixos/zfs: rename `allowHibernation` to `unsafeAllowHibernation`
* [`15d0d82f`](https://github.com/NixOS/nixpkgs/commit/15d0d82ff1941dbf8161b1f2334bb919a4f97ccb) python3Packages.gemmi: 0.7.4 -> 0.7.5
* [`37a2b8ca`](https://github.com/NixOS/nixpkgs/commit/37a2b8caccfffc34b00ee029ed41604ef6069ca0) cc-wrapper: remove trailing and leading spaces from flags
* [`582ca75a`](https://github.com/NixOS/nixpkgs/commit/582ca75ae00d58dc48c9df438406461c1a4892d2) qt5.qtbase: replace lib.optional with lib.optionals
* [`eb58c6ec`](https://github.com/NixOS/nixpkgs/commit/eb58c6ec15285b7a58159f47fc931bd46513dca8) qt5.qtbase: fix incorrect use of lib.optional
* [`cb6c8386`](https://github.com/NixOS/nixpkgs/commit/cb6c8386bbea5360a150fb31e845031bc06e7012) qt5.qtbase: move PSQL_LIBS env variable into env
* [`4cf52e64`](https://github.com/NixOS/nixpkgs/commit/4cf52e64108284233080118242c295d2b4538db5) qt5.qtbase: avoid using spaces in flags
* [`100be6d9`](https://github.com/NixOS/nixpkgs/commit/100be6d94d6c1bdb7b40eb42c4413502db8f1572) qt5.qtbase: use --replace-fail instead deprecated --replace
* [`8f4338bd`](https://github.com/NixOS/nixpkgs/commit/8f4338bd67815c60bf321c4626f6cdcb81248669) nextflow: fix NXF_OPTS wrapper to expand $USER at runtime
* [`bb7cc873`](https://github.com/NixOS/nixpkgs/commit/bb7cc8731b16fef035417d9fb084f1799562d6f7) python3Packages.jupyterlab-git: 0.51.4 -> 0.52.0
* [`81800aee`](https://github.com/NixOS/nixpkgs/commit/81800aeeda3eeb321c956530f78afc5f355a146a) pandoc: update test suite for skylighting-format-blaze-html >= 0.1.2
* [`249cbe13`](https://github.com/NixOS/nixpkgs/commit/249cbe13330004fde0b27974db178b911848c30a) opus-tools: add versionCheckHook for opusenc
* [`3ee93f5d`](https://github.com/NixOS/nixpkgs/commit/3ee93f5d52fe30a17b75c7afca2d2e4d0e41736a) opus-tools: switch to fetchFromGitLab
* [`fa5768bd`](https://github.com/NixOS/nixpkgs/commit/fa5768bdbd9e4c371d29a041c02216bbf12ed4c9) python3Packages.azure-mgmt-netapp: 14.0.1 -> 15.0.0
* [`935c6ef5`](https://github.com/NixOS/nixpkgs/commit/935c6ef5208127b5d4de06a5f8e837f4e29d48d5) maintainers: add joshgodsiff
* [`cfe0627f`](https://github.com/NixOS/nixpkgs/commit/cfe0627fabcedd10c6c0633eb23b64522b8e2524) smithy-cli: init at version 1.68.0
* [`077df6b9`](https://github.com/NixOS/nixpkgs/commit/077df6b93493abaf8dfb2a6c9e39cd483d27cd3e) lsof: 4.99.5 -> 4.99.6
* [`dd8adf0f`](https://github.com/NixOS/nixpkgs/commit/dd8adf0f6d6726ed5418e65302fb8737b6e1c3af) xe-guest-utilities: 8.4.0 -> 10.0.0
* [`a200cf1d`](https://github.com/NixOS/nixpkgs/commit/a200cf1dac3de0a89474d5a65337b43b1722ead1) qt5.qtbase: avoid relying on env variables, enable __structuredAttrs
* [`a17ca394`](https://github.com/NixOS/nixpkgs/commit/a17ca394c3a4a7a884e9d8fed139e5ad14216a2e) cocogitto: 6.5.0 -> 7.0.0
* [`fa3f4ed2`](https://github.com/NixOS/nixpkgs/commit/fa3f4ed2f51363fff1f3bda5f5d9d6b2bfed9bd8) qt5.qtwebengine: use lib.optionals for consistency and better readability
* [`fc475357`](https://github.com/NixOS/nixpkgs/commit/fc47535731bf138762257f043bda1b894c6eb6b1) qt5.qtwebkit: use lib.optionals for consistency and better readability
* [`ce272c05`](https://github.com/NixOS/nixpkgs/commit/ce272c05ac5a49d7423a6fcdf3bf8e65ad42c804) qt5.qtmultimedia: move NIX_LDFLAGS into env
* [`05a47919`](https://github.com/NixOS/nixpkgs/commit/05a47919fd7819a672cb4f93a096ec05b091e4de) qt5.qtwebview: move NIX_LDFLAGS into env
* [`6f1c706b`](https://github.com/NixOS/nixpkgs/commit/6f1c706bb412515806dd7c26c1c4e045cd79a63a) qt5.qtwebengine: fix use of lib.optional
* [`28eae7c5`](https://github.com/NixOS/nixpkgs/commit/28eae7c50b7a59f417f85c7e3dba21770b6c2bfb) qt5.qtModule: avoid relying on env variables, enable __structuredAttrs
* [`02f547c8`](https://github.com/NixOS/nixpkgs/commit/02f547c8cc5a41aa1bc07d91a43796ed26f59219) vscode-extensions.haskell.haskell: 2.6.1 -> 2.8.0
* [`d66b335e`](https://github.com/NixOS/nixpkgs/commit/d66b335e05f166bd5a88b0c170dff35e643659d4) build-support/node/build-npm-package: fix npm-config-hook.sh for structuredAttrs
* [`9b23b183`](https://github.com/NixOS/nixpkgs/commit/9b23b183807fa0a1d553d22099ce035f82a776bd) freetype: 2.13.3 -> 2.14.2
* [`043a5a82`](https://github.com/NixOS/nixpkgs/commit/043a5a82d669184afc354b5a861de5984eaaf8c2) directx-shader-compiler: 1.8.2505.1 -> 1.9.2602
* [`16fbb05e`](https://github.com/NixOS/nixpkgs/commit/16fbb05ea31905e522780a26d5564d6299bc473b) jasper: 4.2.8 -> 4.2.9
* [`290d89c7`](https://github.com/NixOS/nixpkgs/commit/290d89c7f76aa0bc26aa9d84e4f5100b30bb677a) dwl: 0.7 -> 0.8
* [`bb0468a8`](https://github.com/NixOS/nixpkgs/commit/bb0468a831535b5a573b7ad413c6581b565e0498) nixos/modules/profiles/nix-builder-vm: remove suffix from system version
* [`4543182b`](https://github.com/NixOS/nixpkgs/commit/4543182ba2b5ebd69032143cb639678134ee248e) velero: 1.17.2 -> 1.18.0
* [`9276f664`](https://github.com/NixOS/nixpkgs/commit/9276f66460637b6d326082fadf4e3b25f28301f9) openexr: 3.3.5 -> 3.3.8
* [`3ca13016`](https://github.com/NixOS/nixpkgs/commit/3ca130162fc391513fdb85859f745066f6c23ad7) python3Packages.tinyhtml5: 2.0.0 -> 2.1.0
* [`004a4de6`](https://github.com/NixOS/nixpkgs/commit/004a4de6079eb45c2fac207f6da8f218f8045cd0) python3Packages.qcodes-contrib-drivers: 0.24.0 -> 0.24.1
* [`d077a4dc`](https://github.com/NixOS/nixpkgs/commit/d077a4dc0a8625c8186b9fbdd6b3bb6f9ab31025) xxhash: rename from xxHash
* [`e0c64f81`](https://github.com/NixOS/nixpkgs/commit/e0c64f816bee9716b57f04cdfcf8e3cad4d0d2a7) libqmi: 1.36.0 -> 1.38.0
* [`310e7fbc`](https://github.com/NixOS/nixpkgs/commit/310e7fbc49b282ec71f9653d8b1d78f38cb1d384) python3Packages.glean-parser: 18.2.0 -> 19.0.0
* [`14ea6786`](https://github.com/NixOS/nixpkgs/commit/14ea6786cde88fd644635ab5f75cc36578bc5d09) linux/common-config: EFI_VARS_PSTORE=y
* [`2e3767c9`](https://github.com/NixOS/nixpkgs/commit/2e3767c90239e2fb5f01d6306625f2ed8a8064ca) ethtool: 6.15 -> 6.19
* [`49e44efa`](https://github.com/NixOS/nixpkgs/commit/49e44efa09d08b5f6dd2574879c2ce55eecb096c) tclPackages.mkTclDerivation: enable stubs by default
* [`50cfe698`](https://github.com/NixOS/nixpkgs/commit/50cfe69800efb559c931dd9a7a52c2c64a46ba2e) {openssl_3_5,openssl_3_6}: Fix ELF ABI mismatch on powerpc64
* [`ac26283c`](https://github.com/NixOS/nixpkgs/commit/ac26283caadf39cb44196a1944b3703b3513f65a) gsm: 1.0.23 -> 1.0.24
* [`822c7dfb`](https://github.com/NixOS/nixpkgs/commit/822c7dfb3d9472fff98732cf9187132cd243513b) memcached: 1.6.40 -> 1.6.41
* [`05f0f216`](https://github.com/NixOS/nixpkgs/commit/05f0f216ba2a67e16f565b88468ea7a1b9907b25) haskell.packages.ghc914.haskell-debugger-view: unmarkBroken
* [`3792514e`](https://github.com/NixOS/nixpkgs/commit/3792514ebfa8f990094965762f6fe95d4964e389) haskell.packages.ghc914.ghc-exactprint: add missing deps
* [`0652b232`](https://github.com/NixOS/nixpkgs/commit/0652b232438f0ffa6691d3ecd833ba283a7cde10) haskell.packages.ghc914.doctest-parallel: fix build with patch
* [`9faf3c4a`](https://github.com/NixOS/nixpkgs/commit/9faf3c4a8ca0b9d5e4777f197c8bdd724f086b63) haskell.packages.ghc914.boring: jailbreak
* [`ed3b0207`](https://github.com/NixOS/nixpkgs/commit/ed3b0207b8952c8d091107264ee10732ec2fd7d5) haskell.packages.ghc914.{hedgehog, lifted-async}: use latest version
* [`f2646927`](https://github.com/NixOS/nixpkgs/commit/f26469276b0a91b0958e96c2a25a1ae5c5d9cc7a) haskell.packages.ghc914.haskell-debugger: fix compilation
* [`6ad188f0`](https://github.com/NixOS/nixpkgs/commit/6ad188f0c4154df793bd9ac2cdb4700e0a777117) haskell.packages.ghc914.haskell-debugger: add myself as maintainer
* [`b917f5f9`](https://github.com/NixOS/nixpkgs/commit/b917f5f990334f8fe2dc233441266baeacc80b0d) python3Packages.dockerflow: 2026.01.26 -> 2026.03.04
* [`ed11acb4`](https://github.com/NixOS/nixpkgs/commit/ed11acb4697d155f30c4a08ba388a4311b2f3153) nixos/slurm: expose NVML library when NVIDIA datacenter is enabled
* [`e5841789`](https://github.com/NixOS/nixpkgs/commit/e58417895d35fcbabba1b06cd70feaf97ca83237) ucc: 1.6.0 -> 1.7.0
* [`a1ea284f`](https://github.com/NixOS/nixpkgs/commit/a1ea284f74f0a86d54d519b88c3f768bbcf8fb76) haskellPackages.cabal2nix-unstable: 2026-01-25 -> 2026-03-07
* [`25eb3594`](https://github.com/NixOS/nixpkgs/commit/25eb3594716b6f1c344ca632d82aeb228084e27b) haskellPackages.cabal2nix-unstable: build against Cabal 3.16
* [`72ee4fc7`](https://github.com/NixOS/nixpkgs/commit/72ee4fc7f9c12f48585f43d0e1c858479b56eb60) maintainers/haskell/dependencies: work around throwing ghcup alias
* [`dd910a50`](https://github.com/NixOS/nixpkgs/commit/dd910a5077c68f36f6696adbcbe64ddd274c86bf) haskellPackages.http2-tls: drop override of broken package
* [`34f316a9`](https://github.com/NixOS/nixpkgs/commit/34f316a97a3e0e69bea9b44cd1142f7e73557437) haskellPackages.{lsp*,hie-bios}: pin to HLS compatible versions
* [`234a1c3e`](https://github.com/NixOS/nixpkgs/commit/234a1c3e98be1df7a5f885b1a8613cb70a6f8deb) python3Packages.django-postgresql-netfields: 1.3.2 -> 1.4.1
* [`531dd889`](https://github.com/NixOS/nixpkgs/commit/531dd889923156875128688df98c1c9574ed6c2d) git-annex: adjust for 10.20260213
* [`78ad85cb`](https://github.com/NixOS/nixpkgs/commit/78ad85cb66c1d03850c83ec7f8a2d27dd0501379) haskellPackages.mkDerivation: explicitly take glibcLocales for buildPackages
* [`bc12d923`](https://github.com/NixOS/nixpkgs/commit/bc12d9236515413829b1a60528805e33ea08859e) ldns: 1.8.4 -> 1.9.0
* [`89f90ee3`](https://github.com/NixOS/nixpkgs/commit/89f90ee3ceee028af7749b8c857040e0bf8260e0) stripe-cli: 1.37.1 -> 1.37.2
* [`d5274a45`](https://github.com/NixOS/nixpkgs/commit/d5274a45ac8ddcf20d72a9165eaaf7e46ef9ba2f) highscore-nestopia: 0-unstable-2025-12-30 -> 0-unstable-2026-03-03
* [`af0e5316`](https://github.com/NixOS/nixpkgs/commit/af0e53168682d619819cddf6759d5ce1d214777a) unixodbc: fix pname
* [`a486bc63`](https://github.com/NixOS/nixpkgs/commit/a486bc63cd04736ac2df72566510189f4630ad88) lua{5_{1,2,3,4},jit}Packages.wrapLua: remove sed that does nothing
* [`408c71c3`](https://github.com/NixOS/nixpkgs/commit/408c71c35e7d1922f3fd2ea855bcc52c4c6983cd) simdutf: 8.0.0 -> 8.1.0
* [`677d53cd`](https://github.com/NixOS/nixpkgs/commit/677d53cdf8fa37c251654e0d13d5dcd76e11482b) python3Packages.twisted: disable flaky test on Darwin
* [`90cad09e`](https://github.com/NixOS/nixpkgs/commit/90cad09ecbec0bbf5fcb8be9aed14d5ff05ce46f) python3Packages.apispec: 6.9.0 -> 6.10.0
* [`74aa977d`](https://github.com/NixOS/nixpkgs/commit/74aa977dce57c49cf0b954c43bb47d08f3258eae) python3Packages.bce-python-sdk: 0.9.59 -> 0.9.63
* [`0bb1068f`](https://github.com/NixOS/nixpkgs/commit/0bb1068f31493dce335215b6ef91f7c412fddcc3) libevdev: 1.13.4 -> 1.13.6
* [`7a118762`](https://github.com/NixOS/nixpkgs/commit/7a118762ba59893f73ab9971a30fab4ea9f79d4f) libaec: 1.1.5 -> 1.1.6
* [`7b9e4c75`](https://github.com/NixOS/nixpkgs/commit/7b9e4c7595832c9e2fa05212888fc2369c50eef1) buildLuarocksPackage: fix cross compilation wrapping
* [`589dbec2`](https://github.com/NixOS/nixpkgs/commit/589dbec25ffdded748c9917458dcc7d35c7e10e6) python3Packages.numpy: 2.4.2 -> 2.4.3
* [`4563829b`](https://github.com/NixOS/nixpkgs/commit/4563829b7da8a9209ddaf1b18cc25a5fab78d06d) libid3tag: 0.16.3 -> 0.16.4
* [`12979e3a`](https://github.com/NixOS/nixpkgs/commit/12979e3acabeffcc72c49b8f9436c1d3517f2d5b) tpm2-tss: Fix build on darwin
* [`d61c78f4`](https://github.com/NixOS/nixpkgs/commit/d61c78f4921b1622127584d67b2e9afddf588c92) python3Packages.triton: add patch to support ROCm gfx906 target
* [`dd558987`](https://github.com/NixOS/nixpkgs/commit/dd5589875dba691ac811f318452bc9df0eef48f5) python3Packages.segments: 2.3.0 -> 2.4.0
* [`8d1fb1fa`](https://github.com/NixOS/nixpkgs/commit/8d1fb1fa97e206f5f4d85fd615ba8b4449ab3741) lerc: 4.0.0 -> 4.1.0
* [`ff5e8e10`](https://github.com/NixOS/nixpkgs/commit/ff5e8e10a08c007399d22c159fcce6c317bab0fb) python3Packages.generic: 1.1.6 -> 1.1.7
* [`29401f2c`](https://github.com/NixOS/nixpkgs/commit/29401f2c7d5eae5a439705ab6bbcb865882e4658) apitrace: 13.0 -> 14.0
* [`87f68e99`](https://github.com/NixOS/nixpkgs/commit/87f68e99d72000e58b091a0ddbbdd266fc5196d2) python3Packages.pikepdf: 10.3.0 -> 10.5.0
* [`76609c3c`](https://github.com/NixOS/nixpkgs/commit/76609c3cd6721dec2f458741389a79d0bb3d00aa) libarchive: 3.8.4 -> 3.8.6
* [`d02c27e5`](https://github.com/NixOS/nixpkgs/commit/d02c27e5cb47df667fbf47a67e0267d210ecc9ac) pat: 0.19.1 -> 0.19.2
* [`311b41b1`](https://github.com/NixOS/nixpkgs/commit/311b41b13fd06966a2f97647a8183fc589102b18) libnetfilter_conntrack: 1.1.0 -> 1.1.1
* [`934737b1`](https://github.com/NixOS/nixpkgs/commit/934737b1ecaedfe07e7d687e1de545ea257369e4) haskell.packages.ghc9123.fourmolu: fix missing executable in tests
* [`ebd59d46`](https://github.com/NixOS/nixpkgs/commit/ebd59d461079093a8c6c223d9f663dd608531bc1) haskell.packages.ghc9123.cabal-add: fix missing executable in tests
* [`eb4dcd05`](https://github.com/NixOS/nixpkgs/commit/eb4dcd05a562702824d87a671d255ad917d1caa6) haskellPackages.{cabal-add,fourmolu}: don't unnecessarily add prog to PATH
* [`5e74d3ca`](https://github.com/NixOS/nixpkgs/commit/5e74d3ca0ed98be26146f7e13e12a4eac4c7312e) haskell.compiler.ghc912: 9.12.2 -> 9.12.3
* [`e935bceb`](https://github.com/NixOS/nixpkgs/commit/e935bceb4728eaabcec22f630dda6aa385ad279b) linuxPackages.akvcam: 1.3.0 -> 1.4.0
* [`265fc0a7`](https://github.com/NixOS/nixpkgs/commit/265fc0a7a0afb1ecedec92dcf5d44ba9621e91af) ungit: 1.5.28 -> 1.5.30
* [`e6a89323`](https://github.com/NixOS/nixpkgs/commit/e6a89323f2fd5edc6bad011cf661b10d1a0270d3) gnum4: 1.4.20 -> 1.4.21
* [`34e36a57`](https://github.com/NixOS/nixpkgs/commit/34e36a57a36ff6ca40dda978694962d69778ca8a) haskellPackages.failure: fix build via forward-compat
* [`0f5dd37f`](https://github.com/NixOS/nixpkgs/commit/0f5dd37f62e955a68ad0ce4936a7b8aeab4ab250) haskellPackages.util: jailbreak
* [`7d0dfa35`](https://github.com/NixOS/nixpkgs/commit/7d0dfa354f8e581fdf12ab33a0b80c2ee6838a44) haskellPackages.accelerate: update source
* [`e28bd58b`](https://github.com/NixOS/nixpkgs/commit/e28bd58b3e602d8e88ce93d4dfddaecc6feb9683) haskellPackages: regenerate package set based on current config
* [`19477313`](https://github.com/NixOS/nixpkgs/commit/19477313d9f751f15b8fe341241670addf5d6f9a) haskellPackages.{comonad-coaction,io-sim}: tests don't like QC 2.15
* [`40780ca4`](https://github.com/NixOS/nixpkgs/commit/40780ca470986768f47d0b68fb337c2b3cc9b5b8) haskellPackages.distributors: disable broken doctests
* [`3a5167f7`](https://github.com/NixOS/nixpkgs/commit/3a5167f79f6ed74f4c90ead4ff228c8ca0ed263a) upx: 5.1.0 -> 5.1.1
* [`23769557`](https://github.com/NixOS/nixpkgs/commit/237695574b65f260f58cf68838d6cb4b33aae960) haskell.packages.ghc9141.scrod: test on Hydra
* [`9a50be5a`](https://github.com/NixOS/nixpkgs/commit/9a50be5a131b4c27bbd7c12d65031752b0a50159) haskellPackages.railroad: ignore too strict upper bounds
* [`ffe0111b`](https://github.com/NixOS/nixpkgs/commit/ffe0111b604fa8b40cde278c0df920c09be1c6dc) systemd: set kexec-path meson option
* [`786bcc30`](https://github.com/NixOS/nixpkgs/commit/786bcc30c9ad91a425579b13413af5343048cc3b) julia_110: 1.10.10 -> 1.10.11
* [`7f6b9a7b`](https://github.com/NixOS/nixpkgs/commit/7f6b9a7b237b28b687bb99de774ba1d3ab941b0b) haskellPackages: mark builds failing on hydra as broken
* [`26f809bd`](https://github.com/NixOS/nixpkgs/commit/26f809bd670b7f53b760b53058c585be748a930d) haskellPackages: allow local networking when using iserv-proxy
* [`07247c6c`](https://github.com/NixOS/nixpkgs/commit/07247c6c55752490175663bc654bb683bba6ffd1) julia_110-bin: 1.10.10 -> 1.10.11
* [`00367277`](https://github.com/NixOS/nixpkgs/commit/00367277d504210b6d26ccf7d04e9399d20c045f) haskell.packages.ghc9141.haskell-debugger: test on Hydra
* [`59e7c02b`](https://github.com/NixOS/nixpkgs/commit/59e7c02b9d6826bcac6b88ea7291e90d590c2480) python3Packages.msprime: 1.3.4 -> 1.4.1
* [`25e25846`](https://github.com/NixOS/nixpkgs/commit/25e258465949dcb690161c92c4ef9b0e8d868595) wabt: 1.0.39 -> 1.0.40
* [`1bc2381c`](https://github.com/NixOS/nixpkgs/commit/1bc2381cebc91f4a30652cda0c84766ca4b75b05) psqlodbc: 17.00.0007 -> 17.00.0008
* [`df6cab7c`](https://github.com/NixOS/nixpkgs/commit/df6cab7c12820f42c8b586be4ad87d900475b0be) curl: 8.18.0 -> 8.19.0
* [`5013c241`](https://github.com/NixOS/nixpkgs/commit/5013c241b0a7fe19d6dcd123a9b234aa31edb139) libapparmor: 4.1.3 -> 4.1.7
* [`3e75691d`](https://github.com/NixOS/nixpkgs/commit/3e75691db8ea5424e448a3137e5eced142696798) assimp: 6.0.2 -> 6.0.4
* [`2e258302`](https://github.com/NixOS/nixpkgs/commit/2e2583028dcfecaea41e00fe4148e77fc3cdafd0) nodejs: fix shared dependencies
* [`9538e395`](https://github.com/NixOS/nixpkgs/commit/9538e395495211268b461ceab7fe6fd1f0b2bc6e) cgtcalc: auto-update from the default branch
* [`c71d9bc4`](https://github.com/NixOS/nixpkgs/commit/c71d9bc4b4ed0da4cef0ff5a450211adaea800dd) proxypin: 1.2.4 -> 1.2.6
* [`70f650df`](https://github.com/NixOS/nixpkgs/commit/70f650dfcd7d0391acb95b1663763665b41822d3) lzlib: 1.15 -> 1.16
* [`e783cdf7`](https://github.com/NixOS/nixpkgs/commit/e783cdf76a452fba728fa3a392daf153693f9b43) spdlog: fix musl build
* [`18c8ab53`](https://github.com/NixOS/nixpkgs/commit/18c8ab53721a796e2f44356554f7bdefcc97095f) python3Packages.ttkbootstrap: 1.20.0 -> 1.20.2
* [`e576b4e5`](https://github.com/NixOS/nixpkgs/commit/e576b4e5cb4f644d5427715fe38cc9292393d74c) haskell.packages.ghc914.hie-bios: jailbreak
* [`4a3027d2`](https://github.com/NixOS/nixpkgs/commit/4a3027d2080a69131c69725788f6f709aba8f740) imath: 3.2.1 -> 3.2.2
* [`8ecb1fc9`](https://github.com/NixOS/nixpkgs/commit/8ecb1fc9857f515472ba008a880b43f893f16a7e) ruby_3_4: 3.4.8 -> 3.4.9
* [`30b3103f`](https://github.com/NixOS/nixpkgs/commit/30b3103f30c23f35ee3d6c924c7064cada6e8c61) kcl-kafka: init at 0.17.0
* [`b10ce090`](https://github.com/NixOS/nixpkgs/commit/b10ce0908db9e5ea87f15c4248a1d7afbe8c42b7) elfutils: Fix build on aarch64-linux
* [`f949e4c7`](https://github.com/NixOS/nixpkgs/commit/f949e4c7ca792d59409b5dd9f07535d1bb25607a) haskellPackages.quick-process: provide git for testsuite compilation
* [`a8c65aff`](https://github.com/NixOS/nixpkgs/commit/a8c65affa21af0c2d6c21428627089ac119298d5) haskellPackages.esqueleto-postgis: disable db reliant tests
* [`21a685fb`](https://github.com/NixOS/nixpkgs/commit/21a685fbaf575c4ab2d0b6964581b9d5ce5e43c6) haskellPackages.{nix-serve-ng,libriscv}: adopt
* [`51beefa3`](https://github.com/NixOS/nixpkgs/commit/51beefa3bc3ae0a11c31b9956730824c242d6139) haskellPackages: mark failing builds as broken
* [`675234b0`](https://github.com/NixOS/nixpkgs/commit/675234b0cef7fdcee350ab6a0b9635816ee6231d) maintainers: add korkutkardes7
* [`71003837`](https://github.com/NixOS/nixpkgs/commit/71003837ddbcea5b62136f886e4ff6b393d4de64) stdenv: move NIX_CFLAGS_LINK into env by default for makeStaticBinaries
* [`e00cfe67`](https://github.com/NixOS/nixpkgs/commit/e00cfe671f3ef227d4206718c760b60dbbadfe61) build-support/node/import-npm-lock: use structuredAttrs instead of passAsFile
* [`58e8a11f`](https://github.com/NixOS/nixpkgs/commit/58e8a11f998be20ed397fe5fb4bf50e62adc8805) python3Packages.orange-canvas-core: 0.2.7 -> 0.2.8
* [`24749e0f`](https://github.com/NixOS/nixpkgs/commit/24749e0faa5476eee4875d5478294374ad0c74f9) vscode-extensions.seatonjiang.gitmoji-vscode: 1.3.0 -> 2026.3.6
* [`f555ddaf`](https://github.com/NixOS/nixpkgs/commit/f555ddafda99194b033ba4a2b93c3415fef6c53c) backintime: fix missing crontab
* [`6dcb0fc5`](https://github.com/NixOS/nixpkgs/commit/6dcb0fc58aa6f62b385a95eb79411043a06829f1) backintime: 1.5.6 -> 1.6.1
* [`9e0c4016`](https://github.com/NixOS/nixpkgs/commit/9e0c40162ea87227c2122475be9ff74897b748ae) backintime: add gocryptfs, meld/kompare support
* [`c7672db1`](https://github.com/NixOS/nixpkgs/commit/c7672db19cd153f2268d292939248fdae46460e2) backintime: add keyringBackends
* [`eaf6c374`](https://github.com/NixOS/nixpkgs/commit/eaf6c3747309572fe334769383e49fedaa1cbf1b) risor: 1.8.1 -> 2.1.0
* [`488f9ade`](https://github.com/NixOS/nixpkgs/commit/488f9ade0d3ea2a9f2efb61364b18dbef478dff8) vim: 9.2.0106 -> 9.2.0140
* [`4f521fcf`](https://github.com/NixOS/nixpkgs/commit/4f521fcf669c6731e3468858fa2a13915b0736cd) openapv: 0.2.1.1 -> 0.2.1.2
* [`1074e71c`](https://github.com/NixOS/nixpkgs/commit/1074e71c07e3fb20e13c76d771b60a1742a1e7c7) pspp: 2.0.1 -> 2.1.1
* [`efba1c47`](https://github.com/NixOS/nixpkgs/commit/efba1c47ce26c9fdc0351063f563de38260ea5b9) libmaxminddb: 1.12.2 -> 1.13.3
* [`499232e5`](https://github.com/NixOS/nixpkgs/commit/499232e57b133d3bca311abb51ec4637f362bdec) build-support/rustc-wrapper: use explicit substitution instead of substituteAll
* [`ff956807`](https://github.com/NixOS/nixpkgs/commit/ff9568073070e0e44c26c55b6d1333355a59af5d) egl-wayland2: init at 1.0.1
* [`03c069fb`](https://github.com/NixOS/nixpkgs/commit/03c069fb7048b6a1d1fbb71cdd21584028969022) Revert "openblas: avoid rebuilds except aarch64-darwin for now"
* [`e01ab042`](https://github.com/NixOS/nixpkgs/commit/e01ab042879d3baf93072080a3339e6b2aa8213f) systemd: 259.3 -> 259.5
* [`b57b183d`](https://github.com/NixOS/nixpkgs/commit/b57b183d7a7f75bf3600f9adb1e5eb53bf2d2d80) intel-cmt-cat: 25.04 -> 26.03
* [`53001a0c`](https://github.com/NixOS/nixpkgs/commit/53001a0ccc52f5685fe62d8983e1466a09d72155) kdePackages.taglib: 2.1.1 -> 2.2.1
* [`7e5c062a`](https://github.com/NixOS/nixpkgs/commit/7e5c062a3f17162704747ebbc36b6ae03b7c85b7) python3Packages.sphinx-autoapi: 3.7.0 -> 3.8.0
* [`566c3e6a`](https://github.com/NixOS/nixpkgs/commit/566c3e6a0d1a06849b4b4702864189a5c10b2194) grpc: 1.78.0 -> 1.78.1
* [`35738dbe`](https://github.com/NixOS/nixpkgs/commit/35738dbe14ddd4c3e3f3aca89bb909391e787b72) python3Packages.grpcio: 1.78.0 -> 1.78.1
* [`6612aeb2`](https://github.com/NixOS/nixpkgs/commit/6612aeb290571eec8c5c2f6897032c7e69649bfc) python3Packages.grpcio-channelz: 1.78.0 -> 1.78.1
* [`7e45accf`](https://github.com/NixOS/nixpkgs/commit/7e45accfa710ec239fed61a8963e1a24ef1c398b) python3Packages.grpcio-health-checking: 1.78.0 -> 1.78.1
* [`3799325d`](https://github.com/NixOS/nixpkgs/commit/3799325da34560e0d22535448e4453a65fbd209b) python3Packages.grpcio-reflection: 1.78.0 -> 1.78.1
* [`1e65a547`](https://github.com/NixOS/nixpkgs/commit/1e65a5471c1548c811d140168e92ff486a4778d9) python3Packages.grpcio-status: 1.78.0 -> 1.78.1
* [`c9ea834d`](https://github.com/NixOS/nixpkgs/commit/c9ea834dc5224c242e43f12918ee0c6030974d1f) python3Packages.grpcio-testing: 1.78.0 -> 1.78.1
* [`71eb33e7`](https://github.com/NixOS/nixpkgs/commit/71eb33e7fcc2890b42b8e886d1502c27130a7c5c) python3Packages.grpcio-tools: 1.78.0 -> 1.78.1
* [`ae1f1603`](https://github.com/NixOS/nixpkgs/commit/ae1f16035b9b09e78e7f632c05edd1f40a927fbf) srtp: 2.7.0 -> 2.8.0
* [`52d3c614`](https://github.com/NixOS/nixpkgs/commit/52d3c614a257d6a6e1a404d5ec9f044457b3197c) oneanime: 1.4.4 -> 1.4.5
* [`a2e6723a`](https://github.com/NixOS/nixpkgs/commit/a2e6723a9283655d286ef03072c725acc9822ad3) libavif: 1.3.0 -> 1.4.0
* [`6ab5ecc5`](https://github.com/NixOS/nixpkgs/commit/6ab5ecc583158cf335f382a40039677eecda195b) haskellPackages: stackage LTS 24.32 -> LTS 24.34
* [`e8830daa`](https://github.com/NixOS/nixpkgs/commit/e8830daad376d34951e9f286ebde5ef55812e4fd) haskellPackages.brillo*: drop obsolete overrides
* [`c6e67b45`](https://github.com/NixOS/nixpkgs/commit/c6e67b45f5cc9353033d739e4447388e42f9dbb2) wire-desktop: build from source
* [`bac91ef9`](https://github.com/NixOS/nixpkgs/commit/bac91ef9338e977cb58770cf7bd79acf4eef11f3) haskellPackages.avif: use -std=gnu17 with GCC 15
* [`1279bbbc`](https://github.com/NixOS/nixpkgs/commit/1279bbbc4b6f3420e231619b7badcc043e78f42f) haskellPackages.{opentracing-*, opentracing, lightstep-haskell}: drop
* [`1f55b03b`](https://github.com/NixOS/nixpkgs/commit/1f55b03b166166032336bc5d94c92fac177be3c4) haskellPackages.doctest-parallel: drop released patches
* [`911fdad8`](https://github.com/NixOS/nixpkgs/commit/911fdad84d20497ae0baa7b930d699c92d85e91b) haskellPackages.cassava: prevent deprecated/broken 0.5.5.0 from being picked
* [`c8834c10`](https://github.com/NixOS/nixpkgs/commit/c8834c10905e49cf28b70d245ccb15284bbc12dd) python3Packages.multipart: 1.3.0 -> 1.3.1
* [`ed2d50fc`](https://github.com/NixOS/nixpkgs/commit/ed2d50fcac5b51985df879a98402ec5ccf636e0a) libadwaita: 1.8.4 -> 1.8.5.1
* [`433429dd`](https://github.com/NixOS/nixpkgs/commit/433429ddbd7f40397a52c27eda555dca68eb8a03) meson: 1.10.1 -> 1.10.2
* [`61288782`](https://github.com/NixOS/nixpkgs/commit/61288782add47302823e827e4f31891cb0ea5760) re2c: apply patch for CVE-2026-2903
* [`0e3c5266`](https://github.com/NixOS/nixpkgs/commit/0e3c5266f0f4316b316703dbea70a930f802b80c) python3Packages.redis: 7.2.1 -> 7.3.0
* [`923a023d`](https://github.com/NixOS/nixpkgs/commit/923a023d8d33ff42dbca013053381e36d359bf31) python3Packages.pathable: 0.4.4 -> 0.5.0
* [`859606d8`](https://github.com/NixOS/nixpkgs/commit/859606d889d7a0bc42aeba640cca08471defd337) python3Packages.jsonschema-path: 0.3.4 -> 0.4.5
* [`abb607be`](https://github.com/NixOS/nixpkgs/commit/abb607be92140394af5d6dec1071e24787558916) python3Packages.openapi-schema-validator: 0.6.3 -> 0.8.1
* [`4c0bcddf`](https://github.com/NixOS/nixpkgs/commit/4c0bcddf32f5d8cc1c8eaad9d8b23612c4835a51) python3Packages.openapi-spec-validator: 0.7.2 -> 0.8.4
* [`68198e7e`](https://github.com/NixOS/nixpkgs/commit/68198e7e80acf05b711e746f0bfff3e117aef972) python3Packages.openapi-core: 0.22.0 -> 0.23.0
* [`e1283fbe`](https://github.com/NixOS/nixpkgs/commit/e1283fbe8807e5bc74f6e4a373f29b349728737f) futhark: build against lsp >= 2.8 as requested
* [`9a6845e5`](https://github.com/NixOS/nixpkgs/commit/9a6845e5295674e83b236e897498031df428e4e3) haskellPackages.futhark-server: pin to 1.3.0.0 to match futhark
* [`262f3f23`](https://github.com/NixOS/nixpkgs/commit/262f3f23bad5b1a9db60232976ec0549f60a3ca8) fq: 0.16.0 -> 0.17.0
* [`6b627405`](https://github.com/NixOS/nixpkgs/commit/6b6274053cebf751f64d07a931c13a1db631fb92) etesync-dav: fix web UI and do_POST for Radicale >= 3.6.0
* [`b07f6438`](https://github.com/NixOS/nixpkgs/commit/b07f64381c1adcea7945bbfcc289a0adf6f533d1) cairosvg: 2.8.2 -> 2.9.0
* [`8bbaf1bb`](https://github.com/NixOS/nixpkgs/commit/8bbaf1bb886ed997e8c68625ba021c7439bb7f8e) haskellPackages.notion-client: disable tests which need network/API
* [`85cb24fa`](https://github.com/NixOS/nixpkgs/commit/85cb24fa20b919b9c77c324590ee6af9b8ae4908) haskellPackages.dataframe: allow granite >= 0.4
* [`dbf36e49`](https://github.com/NixOS/nixpkgs/commit/dbf36e4903838275ad10b7a26f83dfa1c7e66b16) haskellPackages.lzlib: disable test suite due to missing test files
* [`c3ed1171`](https://github.com/NixOS/nixpkgs/commit/c3ed117150e4dc34c37eeafc5ea5f3d68d67e3f8) haskellPackages.scgrep: skip broken test suite
* [`743c1539`](https://github.com/NixOS/nixpkgs/commit/743c15393166a8c978f9b2bed3a23369f8755f13) haskellPackages.mysql-haskell: skip test suite requiring server
* [`90354e5c`](https://github.com/NixOS/nixpkgs/commit/90354e5ce0f9788254617eaa621d94b8208bc8d0) haskellPackages: mark builds failing on hydra as broken
* [`8ea97c92`](https://github.com/NixOS/nixpkgs/commit/8ea97c92410abaab537002f641c856fbd3386a47) python3Packages.dploot: 3.1.3 -> 3.2.2
* [`aa491a7e`](https://github.com/NixOS/nixpkgs/commit/aa491a7e8d0a64a996ac17f47d571d51a09375a6) texlive: 2025.20260202 -> 2025-final
* [`0c11e21c`](https://github.com/NixOS/nixpkgs/commit/0c11e21c5ac26880d4ce6b8bb2b18a9253eb2ecd) mssql_jdbc: 13.2.1 -> 13.4.0
* [`ba5589fc`](https://github.com/NixOS/nixpkgs/commit/ba5589fc4fc4b9d7225b61b0d5ed462452db1bad) inetutils: apply patches for CVE-2026-32746 and CVE-2026-28372
* [`438acd10`](https://github.com/NixOS/nixpkgs/commit/438acd10c551af49af9c0f1f3be2f07adeade96e) haskellPackages.hell: mark unbroken
* [`c182d8a2`](https://github.com/NixOS/nixpkgs/commit/c182d8a22747f3ba2f094ef7591b0e31b3f0fc45) libssh: 0.11.3 -> 0.11.4
* [`695906ba`](https://github.com/NixOS/nixpkgs/commit/695906ba972c355abf772dcae3419869f6d92287) clzip: 1.15 -> 1.16
* [`1ee4ac5c`](https://github.com/NixOS/nixpkgs/commit/1ee4ac5c17c04abff6bd6774083fefe89d43a0cf) lua51Packages.libluv: 1.51.0-2 -> 1.52.1-0
* [`f9e91528`](https://github.com/NixOS/nixpkgs/commit/f9e91528eb8c38ec2cebc29ff61bb819b1a560a8) gstreamer: 1.26.5 -> 1.26.11, adopt
* [`776c1cad`](https://github.com/NixOS/nixpkgs/commit/776c1caddbf88fd3d9388b999ea4c85cab87956b) pythonPackages.gst-python: 1.26.0 -> 1.26.11
* [`d93d078c`](https://github.com/NixOS/nixpkgs/commit/d93d078ce161de169a221dd5ae5645a34d6b2c1a) libheif: 1.20.2 -> 1.21.2
* [`9f467635`](https://github.com/NixOS/nixpkgs/commit/9f467635b53b8192d63f30e265c0a3da5f688f3a) openldap: 2.6.9 -> 2.6.13
* [`06959ca4`](https://github.com/NixOS/nixpkgs/commit/06959ca492816e0ead38d972ac6783af3b2fa5e3) clevis: 21 -> 22
* [`f6c757af`](https://github.com/NixOS/nixpkgs/commit/f6c757afc6315cf5e3ebaa82b531e1693b1f0f8b) icu78: 78.1 -> 78.2
* [`2b5aa67c`](https://github.com/NixOS/nixpkgs/commit/2b5aa67c5305bfac3d20feea454b6c1b95aa76b5) symbolicator: 26.2.1 -> 26.3.0
* [`7ae65a0b`](https://github.com/NixOS/nixpkgs/commit/7ae65a0b79494591595ee47170a76c7e078fe24f) libfyaml: 0.9.5 -> 0.9.6
* [`c5b713f2`](https://github.com/NixOS/nixpkgs/commit/c5b713f266a3cb5f44af27029e259cd3ad7ba659) python3Packages.pybind11: 3.0.1 -> 3.0.2
* [`bb4c9078`](https://github.com/NixOS/nixpkgs/commit/bb4c9078100105c75980cd82426d7d37ddcb53aa) protobuf: fix big-endian upb decoding issues
* [`7842b63d`](https://github.com/NixOS/nixpkgs/commit/7842b63d3f3a8983135e07290527d4e16d52eba6) amnezia-vpn: 4.8.14.1 -> 4.8.14.5
* [`8ab4d52d`](https://github.com/NixOS/nixpkgs/commit/8ab4d52d7fd46f51a4062fdf11f9275113446f46) facter: Add a missing gem
* [`55d5a4fb`](https://github.com/NixOS/nixpkgs/commit/55d5a4fb18176341839d77d25baa5fb950453197) openldap: enable spasswd for sasl passthrough authentication
* [`ba03f57c`](https://github.com/NixOS/nixpkgs/commit/ba03f57c17460d36dc222dcb3aae46b1e6dc173e) pkgsStatic.llhttp: fix building static archives
* [`bf9ed600`](https://github.com/NixOS/nixpkgs/commit/bf9ed600bb5abd63642fd1878464bbafc672f1fb) python3Packages.pybind11: use finalAttrs
* [`27c7ddbb`](https://github.com/NixOS/nixpkgs/commit/27c7ddbb8c9188b3cd36f2808618b24654733aa0) zulu17: 17.0.12 -> 17.0.18
* [`c4f5dfad`](https://github.com/NixOS/nixpkgs/commit/c4f5dfad0dfd4a7c29ae40bbf7951e2371c28d8b) treewide: Remove continuation escape at end of commands
* [`f17f8772`](https://github.com/NixOS/nixpkgs/commit/f17f8772e3d971d36ae1f35483bf664155616d05) btrfs-progs: use separateDebugInfo
* [`6700d238`](https://github.com/NixOS/nixpkgs/commit/6700d238aec51853637813869616d8f6b58a53e2) texlive: fix eval
* [`50fca07b`](https://github.com/NixOS/nixpkgs/commit/50fca07b8e98d987eab929212651a9e004e959e7) groff: 1.23.0 -> 1.24.1
* [`efb792de`](https://github.com/NixOS/nixpkgs/commit/efb792de48f15c951a7b3075f46eb1b82aca5118) groff: Add enableUrwFonts option
* [`a36b00e4`](https://github.com/NixOS/nixpkgs/commit/a36b00e4d1a46bbdc1be34fd6aa19e6ded96ca39) neon: 0.36.0 -> 0.37.1
* [`3053f4ef`](https://github.com/NixOS/nixpkgs/commit/3053f4ef2e369a7446f8987d7753f826fa7017c7) kdePackages.kquickimageedit: 0.6.0 -> 0.6.1
* [`4b7b1b8c`](https://github.com/NixOS/nixpkgs/commit/4b7b1b8c2a0c57a99cbbf4a9298ecc9294189b3a) vscode-extensions.ms-vscode.js-debug: 1.105.0 -> 1.112.0
* [`87040a68`](https://github.com/NixOS/nixpkgs/commit/87040a68a0c3884db118cc33e8b16e6ab2831285) nix-fast-build: 1.3.0 -> 1.4.0
* [`38982e45`](https://github.com/NixOS/nixpkgs/commit/38982e45a4be03c79810d80d7f4ef605822123ae) python3Packages.optuna: 4.7.0 -> 4.8.0
* [`910bdbb0`](https://github.com/NixOS/nixpkgs/commit/910bdbb033609558bba2d2bb443819b31ad60709) tcl.tclRequiresCheckHook: init
* [`dcc17ba9`](https://github.com/NixOS/nixpkgs/commit/dcc17ba988a0e1b6abc651d709c168e84e8af52d) tclPackages.expect: use tclRequiresCheck
* [`b748eac9`](https://github.com/NixOS/nixpkgs/commit/b748eac9991f87504a072942e300b7a9274d9866) tclPackages.tcllib: use tclRequiresCheck
* [`469a917c`](https://github.com/NixOS/nixpkgs/commit/469a917cd6013440170ea8d9d6565f31f92f30b7) tclPackages.tclreadline: use tclRequiresCheck
* [`ef4315ef`](https://github.com/NixOS/nixpkgs/commit/ef4315efe9f18f8d69f5cb5ff94fbdd602936b78) tclPackages.tcltls: use tclRequiresCheck
* [`623d2ed3`](https://github.com/NixOS/nixpkgs/commit/623d2ed3a0650182c9058cd9613dc4a6d201264b) woomer: unbreak on aarch64-linux
* [`299461e2`](https://github.com/NixOS/nixpkgs/commit/299461e29d144fa50ce50108c096c869f228ed9d) python3Packages.pyjwt: 2.11.0 -> 2.12.1
* [`37927481`](https://github.com/NixOS/nixpkgs/commit/379274810ad86df33635fd814e5d311eb5b15961) bmake: 20251111 -> 20260313
* [`fc155674`](https://github.com/NixOS/nixpkgs/commit/fc1556741a1cc81373982dc0e7c9f6067fd818eb) python3Packages.openstep-plist: 0.5.1 -> 0.5.2
* [`f2f21ce6`](https://github.com/NixOS/nixpkgs/commit/f2f21ce6aabf0e54e4ae347b3611035305dc695f) vscode-extensions.vue.volar: 3.1.2 -> 3.2.6
* [`3d07c38e`](https://github.com/NixOS/nixpkgs/commit/3d07c38e2f32122dacaf2bcd29864a9dbf267836) qt5.qtbase: fix mysql support for cross builds
* [`3c4e9f1c`](https://github.com/NixOS/nixpkgs/commit/3c4e9f1c86544bf107a3c2d56a0dd3ebc03d481c) whisper-cpp-vulkan: 1.8.3 -> 1.8.4
* [`d63fab02`](https://github.com/NixOS/nixpkgs/commit/d63fab02b08c35eeb35ba21d2123a21df35daa06) tests.buildenv: init test harness
* [`cf7ebfa6`](https://github.com/NixOS/nixpkgs/commit/cf7ebfa6ae07f9f85476db53522679c16b904750) tests.buildenv: test name/pname/version handling
* [`c4275776`](https://github.com/NixOS/nixpkgs/commit/c42757764ca0fcfb190a535a92fd04111f331a4a) buildEnv: specify extraPathsFrom a string as expected by the builder
* [`72699937`](https://github.com/NixOS/nixpkgs/commit/726999375d0d1fe2d2536a0997759d66f9499697) buildEnv: construct with extendMkDerivation and stdenvNoCC.mkDerivation
* [`ae8cb8c6`](https://github.com/NixOS/nixpkgs/commit/ae8cb8c65e33cb2e28d61d6dcfbfeba0e098362b) buildEnv: reference attributes from finalAttrs
* [`7e851e1c`](https://github.com/NixOS/nixpkgs/commit/7e851e1cf52234d0b5e53a6dcbb7f7fa702df7b0) buildEnv: take derivationArgs
* [`31825672`](https://github.com/NixOS/nixpkgs/commit/31825672716a16c6a13d1225eb2c7985e97e14de) doc: buildenv.section.md: init
* [`3b82db18`](https://github.com/NixOS/nixpkgs/commit/3b82db18813dbb9e30d3ef05a31a0680275bd188) rl-2511.section.md: document buildEnv's supporting finalAttrs and <pkg>.overridAttrs
* [`72690726`](https://github.com/NixOS/nixpkgs/commit/7269072659f41fdfc11ec5d3198925f911b4bb1d) buildEnv: fix passthru merging
* [`179ca985`](https://github.com/NixOS/nixpkgs/commit/179ca9859eb30e351bb86bb43e3eab1876b55f96) doc: buildenv.section.md: fix argument name, default, and grammar
* [`150cd2ae`](https://github.com/NixOS/nixpkgs/commit/150cd2ae3299c370b83583977059fb5e33212a6d) tests.buildenv: test passthru.paths injection
* [`effd58ab`](https://github.com/NixOS/nixpkgs/commit/effd58ab3e1f0c55f4595d5912c5214aeb2f65cf) tests.buildenv: test finalAttrs self-reference
* [`fc93a905`](https://github.com/NixOS/nixpkgs/commit/fc93a905634029d1c8cf87b6ee0f3f3b2beb377d) tests.buildenv: test overrideAttrs
* [`dbf1fa96`](https://github.com/NixOS/nixpkgs/commit/dbf1fa96d84f0f0414eac45228b3cb9eb07dfc48) tests.buildenv: test passthru merging
* [`83669e31`](https://github.com/NixOS/nixpkgs/commit/83669e31a201c95d34f16d85d26e39c6d15c5cfd) tests.buildenv: test derivationArgs forwarding
* [`42a88a96`](https://github.com/NixOS/nixpkgs/commit/42a88a9634f23d25eb64a63ce0c6e986ac56f43b) tests.buildenv: add build tests for output verification
* [`61eaaf61`](https://github.com/NixOS/nixpkgs/commit/61eaaf618422f26f7d3772285eccb595ba2ea48d) tests.buildenv: assert that structuredAttrs is broken
* [`536033e0`](https://github.com/NixOS/nixpkgs/commit/536033e04b7180f42efffcb0945bb5071430e52f) libipt: 2.1.2 -> 2.2
* [`f93f7755`](https://github.com/NixOS/nixpkgs/commit/f93f7755a04c890d9058d7b8d998ac513fd13899) libipt: modernize
* [`4cbb8f5e`](https://github.com/NixOS/nixpkgs/commit/4cbb8f5e1c37d2ee5a20753a100902c43fd29c0f) cataclysm-dda: 0.H -> 0.H-2025-07-10-0402
* [`8e670dac`](https://github.com/NixOS/nixpkgs/commit/8e670dac8ae97a45fd912655e3412d6ae9062e99) jsoncpp: 1.9.6 -> 1.9.7
* [`4fc62969`](https://github.com/NixOS/nixpkgs/commit/4fc62969ea2708c6dfaa5e090922264d832c342f) python3Packages.bot-safe-agents: 1.1 -> 1.2
* [`dc4b9cac`](https://github.com/NixOS/nixpkgs/commit/dc4b9cacfc86cade7c89904ed266d342ea6214a4) itgmania: add myself as maintainer
* [`9db4a5b6`](https://github.com/NixOS/nixpkgs/commit/9db4a5b6a4c9c8a40f9fb5c225a695c6fd5c0a77) itgmania: add nix-update-script
* [`73f432fd`](https://github.com/NixOS/nixpkgs/commit/73f432fd71b1920274e2a892ddfd5ac2f017a68f) qtractor: 1.5.11 -> 1.5.12
* [`91a25122`](https://github.com/NixOS/nixpkgs/commit/91a251227e6b01053da82f58520077bc4a25ec04) brutespray: 2.4.1 -> 2.6.0
* [`e6e897d3`](https://github.com/NixOS/nixpkgs/commit/e6e897d3cc40c96874b7dc7a0911d49e3913893a) goose-cli: 1.23.2 -> 1.28.0
* [`6ec1e96e`](https://github.com/NixOS/nixpkgs/commit/6ec1e96e19af8e918b0a875a16685faec994c404) goose-cli: add versionCheckHook
* [`f3fb000b`](https://github.com/NixOS/nixpkgs/commit/f3fb000b1f413730ec29eb50660928a9f2a15dda) yoshimi: 2.3.5.3 -> 2.3.6.2
* [`bae40407`](https://github.com/NixOS/nixpkgs/commit/bae4040734f48b1059b22b36487cd82b2e5bf08f) expat: 2.7.4 -> 2.7.5
* [`1ccdaaf2`](https://github.com/NixOS/nixpkgs/commit/1ccdaaf217ec5c2b6a04b3f99bc7fb0117d40d5c) protobuf_33: 33.5 -> 33.6
* [`fde57e05`](https://github.com/NixOS/nixpkgs/commit/fde57e05c6f7c73db6d99b3afc274008abe2d785) nakama: 3.37.0 -> 3.38.0
* [`e675071e`](https://github.com/NixOS/nixpkgs/commit/e675071e19be431903d26f32cf5c332200e20a77) libfabric: 2.4.0 -> 2.5.0
* [`ccc3d60e`](https://github.com/NixOS/nixpkgs/commit/ccc3d60e3bdf9544bedc7758afbc8bbd0232100d) python3Packages.mfusepy: 3.1.0 -> 3.1.1
* [`6b80bdb7`](https://github.com/NixOS/nixpkgs/commit/6b80bdb738cfa872242feda9da3e142a1f8af36f) libpciaccess: 0.18.1 -> 0.19
* [`05187de9`](https://github.com/NixOS/nixpkgs/commit/05187de9d6bc19812d4e8ee4db8499f9b44a9bf0) labwc: 0.9.3 -> 0.9.6
* [`ae580b01`](https://github.com/NixOS/nixpkgs/commit/ae580b011f4abeab1c4ddb3af988393aba126ea2) goose-cli: skip broken tests on aarch64-linux
* [`0f594fac`](https://github.com/NixOS/nixpkgs/commit/0f594fac96e6f35dd5d711ca700c2732187dbff4) python3Packages.msgspec: enable tests
* [`b6c0061b`](https://github.com/NixOS/nixpkgs/commit/b6c0061b8ec0713f4395d445bb94d742e7c9b182) python3Packages.gst-python: fixup after updating
* [`7b59523f`](https://github.com/NixOS/nixpkgs/commit/7b59523f6e806ea8148f2b17366a19304a0426ef) protobuf: 34.0 -> 34.1
* [`805e277b`](https://github.com/NixOS/nixpkgs/commit/805e277b0b0addc9b3d04a185932a799f694448a) dash: 0.5.13.1 -> 0.5.13.2
* [`d5bd8511`](https://github.com/NixOS/nixpkgs/commit/d5bd85118304f228a244d1c0568a7d0bb94b414e) snd: 26.0 -> 26.2
* [`3d1e794b`](https://github.com/NixOS/nixpkgs/commit/3d1e794b93a6c874a45f266964101cf1d3cbb726) po4a: fix compatibility with gettext 1.0
* [`ca4595bc`](https://github.com/NixOS/nixpkgs/commit/ca4595bcfb8f7179cf4e96727af039018b8412b1) ghostty: add missing GStreamer dependencies
* [`04cddf7b`](https://github.com/NixOS/nixpkgs/commit/04cddf7ba05a70cc71785666e1979af534587dd0) bubblewrap: 0.11.0 -> 0.11.1
* [`616ce0be`](https://github.com/NixOS/nixpkgs/commit/616ce0be05a5fd5de4fd36e150c5a64552634479) swig: 4.3.1 -> 4.4.1
* [`1494b3eb`](https://github.com/NixOS/nixpkgs/commit/1494b3eb6a8f2fe4a3a6fbffa9e5b688fec7ce86) swig: add hythera as maintainer
* [`02aa02ac`](https://github.com/NixOS/nixpkgs/commit/02aa02aca98b93739882af666ec8d1fbb2ec443d) gcsfuse: 3.6.0 -> 3.8.0
* [`d7018b1d`](https://github.com/NixOS/nixpkgs/commit/d7018b1d3a396fdb17284d1d4df3613abfc8e3cd) libde265: 1.0.16 -> 1.0.18
* [`0793099b`](https://github.com/NixOS/nixpkgs/commit/0793099bf720684606f435ae20c56a6888c4aa38) ell: 0.82 -> 0.83
* [`76ec555e`](https://github.com/NixOS/nixpkgs/commit/76ec555e9ecbc48e1d3a2014ca0164618598d80d) space-station-14-launcher:  add dbus
* [`0ffcd005`](https://github.com/NixOS/nixpkgs/commit/0ffcd005bc8704e8f23ba248f8b1e3394dc44a2d) hyprls: 0.12.0 -> 0.13.0
* [`2c889f2a`](https://github.com/NixOS/nixpkgs/commit/2c889f2a8d163d6d927efd3004481029aee151d5) amtterm: fix broken homepage link
* [`74b44bcb`](https://github.com/NixOS/nixpkgs/commit/74b44bcbf27bdaa13142c51c155df7671a68ffe7) nixos/documentation: use structuredAttrs instead of passAsFile
* [`d997cac9`](https://github.com/NixOS/nixpkgs/commit/d997cac9c23af20840f2a936fca9db7d39ac2e02) build-support/node/import-npm-lock: use printf instead of echo
* [`d421f81f`](https://github.com/NixOS/nixpkgs/commit/d421f81f9a043aff1bd786b368b76c7744fd4f4e) alioth: 0.11.0 -> 0.12.0
* [`c541aa54`](https://github.com/NixOS/nixpkgs/commit/c541aa54f2b3152c15dd6b75bcca0856ef37b66b) spaghettikart: 0.9.9.1-unstable-2025-12-23 -> 1.0.0
* [`1629f968`](https://github.com/NixOS/nixpkgs/commit/1629f9680682a489eb6fd3d77d05d89580057dca) starcharts: 1.9.1 -> 1.11.0
* [`b624ca79`](https://github.com/NixOS/nixpkgs/commit/b624ca79ab57c801dc90148eedd8ed0cb6d83ec6) python: apply hacl patch unconditionally
* [`ab9b92fc`](https://github.com/NixOS/nixpkgs/commit/ab9b92fc8bf1e149506ce49e226fb44759606b4a) python3Packages.pytest-subprocess: 1.5.3 -> 1.5.4
* [`d1b64895`](https://github.com/NixOS/nixpkgs/commit/d1b64895ed5cd230a94b6a0b366b72ce2dafcb3f) python3Packages.asdf: 5.1.0 -> 5.2.0
* [`faeb6a37`](https://github.com/NixOS/nixpkgs/commit/faeb6a374cf12223ef71220fe69c9f6b9813c109) simple-http-server: enable TLS by default
* [`7fe0511a`](https://github.com/NixOS/nixpkgs/commit/7fe0511ae5ae58f60a96ae09b0f4fdc66c9ae41a) tf-summarize: 0.3.15 -> 0.3.20
* [`8bf1fef2`](https://github.com/NixOS/nixpkgs/commit/8bf1fef23e664fae5e4d535686640e00fd8c41c9) brickstore: 2024.12.3 -> 2026.3.2
* [`712705a2`](https://github.com/NixOS/nixpkgs/commit/712705a21310a7f814f60e519793ba5851300fbd) spoolman: 0.22.1 -> 0.23.1
* [`afba7b3a`](https://github.com/NixOS/nixpkgs/commit/afba7b3a1397672bde04f87ce21178ab5c5d4e4c) libuv: 1.52.0 -> 1.52.1
* [`769f3d8e`](https://github.com/NixOS/nixpkgs/commit/769f3d8ee3241560f8170169306f4d858fc073a1) marp-cli: 4.2.3 -> 4.3.1
* [`5b8f8484`](https://github.com/NixOS/nixpkgs/commit/5b8f8484daa5a54cc5f9b9a1be48f3d780e400d9) python3Packages.pytest-cov: 7.0.0 -> 7.1.0
* [`2851c612`](https://github.com/NixOS/nixpkgs/commit/2851c6124e9496a9388650b4fbe6b7d3f6e08005) traefik: 3.7.0-ea.1 -> 3.7.0-ea.2
* [`5f76eee6`](https://github.com/NixOS/nixpkgs/commit/5f76eee6b77ccd33d4a5c69181bfdcafb0d5c08f) clickup: 3.5.120 -> 3.5.185, add update script
* [`81aba0fb`](https://github.com/NixOS/nixpkgs/commit/81aba0fbbe17f0b4df0e3d22a7e9d14e8e649555) libopenmpt: 0.8.4 -> 0.8.5
* [`93e8c9e1`](https://github.com/NixOS/nixpkgs/commit/93e8c9e165bed4eb28556719056b21b6a36dbd84) command-not-found: enable and default to channel release's dbPath
* [`95a44252`](https://github.com/NixOS/nixpkgs/commit/95a44252d15b3068fa637ca9f7a7df4205cf8278) glibc,iconv,libc,mtrace: move NIX_NO_SELF_RPATH into env
* [`dba312e0`](https://github.com/NixOS/nixpkgs/commit/dba312e0767f2a1458297c404777b8ad9bcf7371) gtk3: 3.24.51 -> 3.24.52
* [`81c3814e`](https://github.com/NixOS/nixpkgs/commit/81c3814ea7e1adf14aa35cb708aaa2b1b895a86e) lprobe: 0.1.7 -> 0.1.9
* [`5f526272`](https://github.com/NixOS/nixpkgs/commit/5f526272fcd93579611b3095bb5abfcac65e43b2) chelf: mark as linux-only
* [`eb67d7ee`](https://github.com/NixOS/nixpkgs/commit/eb67d7ee81e781b9ef40ae16c4eb311b6640b1b7) libglibutil: 1.0.80 -> 1.0.81
* [`23886ff6`](https://github.com/NixOS/nixpkgs/commit/23886ff699d9da6f09ff1de2bbcc318814c3376c) python3Packages.slack-sdk: disable failing test on aarch64-darwin
* [`8b003f25`](https://github.com/NixOS/nixpkgs/commit/8b003f2590a4630056bcd366ae4b63554fd84b55) gn: 0-unstable-2026-01-07 -> 0-unstable-2026-02-05
* [`8bc04477`](https://github.com/NixOS/nixpkgs/commit/8bc0447726d365c9fa9c543b31488f6fa9b6a98b) python3Packages.sphinx-autodoc-typehints: 3.9.2 -> 3.9.9
* [`3e9c65b4`](https://github.com/NixOS/nixpkgs/commit/3e9c65b4f7dea91f6b8a257726e18d608dca06a7) regal: 0.38.1 -> 0.39.0
* [`5a967c01`](https://github.com/NixOS/nixpkgs/commit/5a967c01e9fde0071b11b5ecb64199b65553cf86) conmon-rs: 0.7.3 -> 0.8.0
* [`392ecf33`](https://github.com/NixOS/nixpkgs/commit/392ecf3352b23bf82576026296798372ed2ec595) libldac-dec: fix decoder initialization failure
* [`4f9eda21`](https://github.com/NixOS/nixpkgs/commit/4f9eda21d97a6881eb35e68ac93095fdb899bca4) rustPlatform.importCargoLock: use structuredAttrs instead of passAsFile
* [`c3f36177`](https://github.com/NixOS/nixpkgs/commit/c3f361772d1c3f53b2eb9875384d8b5f380ddcfe) rustPlatform.importCargoLock: switch if/else statements
* [`75544d2e`](https://github.com/NixOS/nixpkgs/commit/75544d2e52f2cb2372ece200fe66289466cdc655) mesa-libgbm: 25.1.0 -> 26.0.3
* [`b00967b5`](https://github.com/NixOS/nixpkgs/commit/b00967b5744870d5c717d6bcf6c078a15f78b77d) ent-go: 0.14.3 -> 0.14.6
* [`6103b257`](https://github.com/NixOS/nixpkgs/commit/6103b2579c416be2662c4a59b5b81cb096039fcf) drumkv1: 1.3.2 -> 1.4.1
* [`0cda1bf2`](https://github.com/NixOS/nixpkgs/commit/0cda1bf293132a62a25956068b788dffd56c67f4) imagemagick: 7.1.2-17 -> 7.1.2-18
* [`c12a6136`](https://github.com/NixOS/nixpkgs/commit/c12a6136480073f65281ab6cf5f7733f16d2a302) sonarlint-ls: 4.8.0.77946 -> 4.15.0.78211
* [`92b72501`](https://github.com/NixOS/nixpkgs/commit/92b725011c913863fe2f815675f5316940c2f109) iptables: 1.8.12 -> 1.8.13
* [`ec5fa03f`](https://github.com/NixOS/nixpkgs/commit/ec5fa03f61ca59de55543ea8a33db7b9e4d73e60) readest: fix Login by adding glib-networking
* [`23ee0966`](https://github.com/NixOS/nixpkgs/commit/23ee096620ec60eb1cf205be57c02d01ae331abe) zlib: fix build on s390x
* [`e1a2b315`](https://github.com/NixOS/nixpkgs/commit/e1a2b315e2b3a156f1adcaf9b9202080db09a4c0) go-jsonnet: 0.21.0 -> 0.22.0
* [`fd9c81c6`](https://github.com/NixOS/nixpkgs/commit/fd9c81c6a385c80c5d4b74ed0eb463eeccf501c4) nodejs_24: 24.14.0 -> 24.14.1
* [`36b96a2e`](https://github.com/NixOS/nixpkgs/commit/36b96a2ed895fec2d54ecd95051a833c08e624a5) python3Packages.ase: 3.26.0 -> 3.28.0
* [`c032a9c5`](https://github.com/NixOS/nixpkgs/commit/c032a9c5612092f47e45c5f57207e6de6b64440b) libspectrum: 1.5.0 -> 1.6.0
* [`21c5a59f`](https://github.com/NixOS/nixpkgs/commit/21c5a59f7bfc5ad2cc193a6ebaf456be8e41d8fa) python3Packages.prometheus-async: 25.1.0 -> 26.1.0
* [`d206494e`](https://github.com/NixOS/nixpkgs/commit/d206494ed2f227da3328a80fdc36f7d2360cfe40) texlive: buildTeXEnv: use buildEnv with derivationArgs instead of custom buildEnv'
* [`6432891c`](https://github.com/NixOS/nixpkgs/commit/6432891ca64a720bf227283f3d1dbefb98488448) texlive: buildTeXEnv: format expression
* [`1b0981b3`](https://github.com/NixOS/nixpkgs/commit/1b0981b3cbf6132eb0a557a1fb1be51cd0f3b7e1) buildEnv: explicitly set __structuredAttrs = false
* [`e661f631`](https://github.com/NixOS/nixpkgs/commit/e661f63187875ab884fd73fb7a6baf374ab7f5de) zenity: 4.2.1 -> 4.2.2
* [`4b943245`](https://github.com/NixOS/nixpkgs/commit/4b94324556a0d802ad3316b936547dfed4842896) python3Packages.pygments: patch CVE-2026-4539
* [`9bb5ec2a`](https://github.com/NixOS/nixpkgs/commit/9bb5ec2a32e46077051c341f0b1d6a1b8a90fe3d) gnutar: enable strictDeps
* [`0b45e7f9`](https://github.com/NixOS/nixpkgs/commit/0b45e7f961d19b0e617bc7349c81debe852b8c2f) gnutar: cleanup
* [`0fbb9827`](https://github.com/NixOS/nixpkgs/commit/0fbb9827f2edcaa368a8717b7d89f4b59c6c9933) gnutar: migrate to by-name
* [`87bc1235`](https://github.com/NixOS/nixpkgs/commit/87bc1235066a3ffeaeecdab9ed794413a99b0ab5) blender: 5.0.1 -> 5.1.0
* [`f2c276da`](https://github.com/NixOS/nixpkgs/commit/f2c276dae152d6c9189ebc5f1b0c1c110e6e5967) systemd: 259.5 -> 260
* [`30b1e384`](https://github.com/NixOS/nixpkgs/commit/30b1e384354c95a8773cf759d26c70a1c31066f5) nixos/journald: add systemd-journalctl varlink socket
* [`8de047d3`](https://github.com/NixOS/nixpkgs/commit/8de047d3fabfc5dc14b5e01bcd3d86d7b98e3ea3) nixos/networkd: add systemd-networkd-varlink-metrics socket
* [`13b2a085`](https://github.com/NixOS/nixpkgs/commit/13b2a08502704a4d14b6077131bdcee89d6652a8) systemd: 260 -> 260.1
* [`9e26436f`](https://github.com/NixOS/nixpkgs/commit/9e26436f7e5e7a328dd169f8898f2747dee79031) nodejs: re-introduce `nodejs.src`
* [`058e9198`](https://github.com/NixOS/nixpkgs/commit/058e91986909e61b134350a762c282259dee1b62) gdb: fix build for musl
* [`8987de47`](https://github.com/NixOS/nixpkgs/commit/8987de478a6cde1e0fa112d2e9f3f315d0c993a3) maiko: 250616-de1fafba -> 260319-9259716e
* [`86577b31`](https://github.com/NixOS/nixpkgs/commit/86577b31cde95f421898a8d614a5e3934994d67c) deadbeef: 1.10.0 -> 1.10.2
* [`88afa3aa`](https://github.com/NixOS/nixpkgs/commit/88afa3aa957762e43f88607f1434bb63778f59c9) althttpd: 0-unstable-2026-01-27 -> 0-unstable-2026-03-20
* [`35c09df3`](https://github.com/NixOS/nixpkgs/commit/35c09df3aeb43eafcd68a6781a019f38b2673493) libvmaf: replace xxd dependency with minimal shell shim
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
