### PR TITLE
npins nixpkgs: update ebc08544 -> 73c703c2

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -132,8 +132,8 @@
     "nixpkgs": {
       "type": "Channel",
       "name": "nixpkgs-unstable",
-      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-26.05pre988811.ebc08544afa7/nixexprs.tar.xz",
-      "hash": "sha256-fUlUlthbjH+ppUqSdGoLFM+GbtuxcDhp8V8ouXEAgow="
+      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-26.05pre991389.73c703c22422/nixexprs.tar.xz",
+      "hash": "sha256-bA5oJv7j54PubdUbBlLCwdoK29G2+9sLnc8dDqLQ9YE="
     },
     "powerlevel10k": {
       "type": "Git",


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: release-26.05
Commits: [nixos/nixpkgs@ebc08544...73c703c2](https://github.com/nixos/nixpkgs/compare/ebc08544afa7...73c703c22422)

* [`3a337a0a`](https://github.com/NixOS/nixpkgs/commit/3a337a0a52647f3591bde35e1f3b1a2382696784) nixos/send: Add `environmentFile` option for securely passing secrets
* [`8e41d639`](https://github.com/NixOS/nixpkgs/commit/8e41d6395ff489e87e9705c461d7af857d6596b0) sawfish: change platforms to linux
* [`51d26cc1`](https://github.com/NixOS/nixpkgs/commit/51d26cc134a74881200e613d2df82affca637d20) warpgate: 0.18.0 -> 0.19.0
* [`147c25bc`](https://github.com/NixOS/nixpkgs/commit/147c25bcef02bfb19af23b7604b46588599cb3e6) nixos/warpgate: add `settings.log.format`
* [`174c6333`](https://github.com/NixOS/nixpkgs/commit/174c6333d15e8179dc6b65e257cdc414afcdbb1c) nixos/warpgate: drop `settings.config_provider`
* [`fd31a55c`](https://github.com/NixOS/nixpkgs/commit/fd31a55c2e6fbc6625d4d12ab8f2933e55604c33) warpgate: 0.19.0 -> 0.19.1
* [`0ca83edb`](https://github.com/NixOS/nixpkgs/commit/0ca83edb6d9336d331ccfaffeb9c51ca481bc938) jfsw: 20240303 -> 20260105
* [`c65d0b4f`](https://github.com/NixOS/nixpkgs/commit/c65d0b4ffe4f3241b7bc04f546564925b23e5cf5) termshark: prefer dumpcap from PATH to fix using security wrapper
* [`43d60147`](https://github.com/NixOS/nixpkgs/commit/43d60147a60e2f7387337959a742cfafb5f0a970) license-cli: add updateScript
* [`309d06f7`](https://github.com/NixOS/nixpkgs/commit/309d06f7887c5677c2a335946988bb0aef2e2a59) license-cli: 3.1.0 -> 3.2.1
* [`67b59df6`](https://github.com/NixOS/nixpkgs/commit/67b59df601bcbc2439d0ac68f0146b367121ab7d) litecli: 1.12.3 -> 1.17.1
* [`75225657`](https://github.com/NixOS/nixpkgs/commit/7522565761c7c6393d9c37da84e4bcfc6df473c8) python3Packages.netbox-documents: 0.7.4 -> 0.8.2
* [`8f99b8c4`](https://github.com/NixOS/nixpkgs/commit/8f99b8c4cd54cf1e41805b5802adc3d2da94386a) grafanaPlugins.grafana-clock-panel: 2.1.9 -> 3.2.2
* [`27efcd86`](https://github.com/NixOS/nixpkgs/commit/27efcd86418fa742eb8b3ae90e93da4e1003e19c) codex-acp: 0.9.2 -> 0.9.4
* [`3ddd1a73`](https://github.com/NixOS/nixpkgs/commit/3ddd1a73739511db63cedfbf12d89b2b632d9b25) cli11: 2.6.1 -> 2.6.2
* [`6ad58000`](https://github.com/NixOS/nixpkgs/commit/6ad580001a68808425f50d782f209df4425f8957) mopidy-notify: 0.2.1 -> 0.2.2 + clean + adopt
* [`bcb4fb4c`](https://github.com/NixOS/nixpkgs/commit/bcb4fb4c35e25e4f4a08afbb062314074a4df3d4) warpgate: 0.19.1 -> 0.21.1
* [`ee57154a`](https://github.com/NixOS/nixpkgs/commit/ee57154a67a835d09aaea385f6e5c9acba7ad3ab) nixos/warpgate: add options for Kubernetes listener
* [`bb6f1a7a`](https://github.com/NixOS/nixpkgs/commit/bb6f1a7a4188bf91b80bb75eac1b01325e24e57e) nix-run: fix url
* [`da3181c2`](https://github.com/NixOS/nixpkgs/commit/da3181c20cc707e5a89a99cc58f0276a9660bf30) nixosTests.calibre-web: fix test failure with PrivateTmp hardening
* [`2f609d77`](https://github.com/NixOS/nixpkgs/commit/2f609d7727e711db3468461ee30e28268c9d6a08) nixos/soft-serve: fix executing hooks
* [`f1e11201`](https://github.com/NixOS/nixpkgs/commit/f1e112015096bb519f8096142bdccddc0ac804db) mlxtend: drop redundant patch+test skips
* [`71f379de`](https://github.com/NixOS/nixpkgs/commit/71f379dea1b43eb02d5d96b97cfd5cce46b9eddd) mlxtend: skip failing test_perceptron tests
* [`c33e4fb9`](https://github.com/NixOS/nixpkgs/commit/c33e4fb975cc2b54f5fc15a5ce13707aa64fa59b) maintainers: add katok
* [`76ce75e6`](https://github.com/NixOS/nixpkgs/commit/76ce75e6ca845fb194548efea3dbc5ca6ce709a1) karere: 2.5.3 -> 2.5.5
* [`c90739d2`](https://github.com/NixOS/nixpkgs/commit/c90739d2c676aebda0ee810420a7cd32728c8c4b) doc: add content-visibility: auto
* [`e42c7652`](https://github.com/NixOS/nixpkgs/commit/e42c7652a1ab86965474300b4784611c24ad794e) littlegptracker: update source hash
* [`06708ea5`](https://github.com/NixOS/nixpkgs/commit/06708ea575a5a94c07581e8d5b68519586b04915) checkpwn: 0.5.6 -> 0.6.0
* [`01e0d141`](https://github.com/NixOS/nixpkgs/commit/01e0d141f0bb41200e00930768c52e30085b6882) influxdb: use structuredAttrs instead of passAsFile
* [`e3858935`](https://github.com/NixOS/nixpkgs/commit/e385893559d097e8a2280a71049c9707ccf22092) influxdb: use finalAttrs pattern
* [`26e9dfc2`](https://github.com/NixOS/nixpkgs/commit/26e9dfc2e7d2acf2a613572a702ee6d10e5d3522) influxdb2-server: use structuredAttrs instead of passAsFile
* [`351caafd`](https://github.com/NixOS/nixpkgs/commit/351caafd8791a03fd4522284fd3393ec1da8fa70) Revert "python3Packages.taskw-ng: 0.2.7 -> 2.0.0"
* [`3f1ae69d`](https://github.com/NixOS/nixpkgs/commit/3f1ae69d93b027b3b98708761663a413ce86a8ef) python3Packages.taskw-ng: skipBulkUpdate
* [`3690c3a9`](https://github.com/NixOS/nixpkgs/commit/3690c3a96967191f5041cd9a003796e034be359a) jxscout: init at 0.9.4
* [`f8b767bf`](https://github.com/NixOS/nixpkgs/commit/f8b767bfe779ca0f05b1194f62daec734240008e) maintainers: add kittyandrew
* [`7607d8e1`](https://github.com/NixOS/nixpkgs/commit/7607d8e18daea714a52cbe18f364a2fc77a64d00) grafana-to-ntfy: 0-unstable-2025-01-25 -> 2026.3.15
* [`bae09060`](https://github.com/NixOS/nixpkgs/commit/bae09060c2c1fa11e3bd92290e097524f66c6f73) nixos/grafana-to-ntfy: fix type bugs, add missing options, add NixOS test
* [`2becaca3`](https://github.com/NixOS/nixpkgs/commit/2becaca348d3e6477ba875307469d58857a112ae) quill-qr: update github owner of src
* [`a10e0309`](https://github.com/NixOS/nixpkgs/commit/a10e03093f940f02068ec7b2a734678c6d70410c) jetbrains.jdk: 21.0.9-1163.86 -> 25.0.2-329.72
* [`cebab056`](https://github.com/NixOS/nixpkgs/commit/cebab056b44e0fc3885c392604d16fce2df9af68) jetbrains.jcef: 1086 -> 1131
* [`89622e90`](https://github.com/NixOS/nixpkgs/commit/89622e903676f78a0b88e921808f4a1ba7d5eaf6) victoriametrics: replace custom upadateScript with nix-update-script
* [`31f9ceaa`](https://github.com/NixOS/nixpkgs/commit/31f9ceaa93a0fb0da068667515e43715bf21b30b) libcpucycles: 20250925 -> 20260105
* [`bf664696`](https://github.com/NixOS/nixpkgs/commit/bf664696a65adfe1eca3fbcc6e65d4cbe4342496) jetbrains.dataspell: 2025.3.2 -> 2026.1
* [`6a2f6ef9`](https://github.com/NixOS/nixpkgs/commit/6a2f6ef9096d5c125cafc716ff90d151b1a9c853) python3Packages.netbox-bgp: 0.18.0 -> 0.18.1
* [`565a0456`](https://github.com/NixOS/nixpkgs/commit/565a04569ff7dfe60af7f68ae7411826c25c13e2) c64-debugger: fix the build against `gcc-15`
* [`d6d22741`](https://github.com/NixOS/nixpkgs/commit/d6d2274149147b83bf9dd26933d5768db15fd4fe) maintainers: add mrmaxmeier
* [`44258b99`](https://github.com/NixOS/nixpkgs/commit/44258b99bd86b357f2377eb264b084047a09976d) bombsquad: 1.7.37 -> 1.7.61
* [`a98c6270`](https://github.com/NixOS/nixpkgs/commit/a98c6270147bd0a6ac384574d21b3325bab44128) gammu: add glib and libgudev to build gammu-detect
* [`476009ef`](https://github.com/NixOS/nixpkgs/commit/476009ef9985570a298ce1d586fbc67bf33c76f4) pioasm: 2.1.1 -> 2.2.0
* [`a3975c37`](https://github.com/NixOS/nixpkgs/commit/a3975c372fe38007ef68f49cbfa5a2c55c6d6aec) ht: enable parallel building
* [`ece624ad`](https://github.com/NixOS/nixpkgs/commit/ece624addbd96fc7acc16aedf2cb2e062b365537) python3Packages.netbox-topology-views: 4.5.0 -> 4.5.1
* [`94a19cf7`](https://github.com/NixOS/nixpkgs/commit/94a19cf77a52a465097971d390ec1753fb5aae43) fortran-fpm: 0.11.0 -> 0.13.0
* [`a0b29763`](https://github.com/NixOS/nixpkgs/commit/a0b297630fb12fe04599ea980f2b2e518dde820e) jetbrains.jdk-21, jetbrains.jdk-no-jcef-21: init
* [`973faa3b`](https://github.com/NixOS/nixpkgs/commit/973faa3bb0b60a4de3d4cb38f7e075acc239bcd6) bfs: Fix static build
* [`dd47d727`](https://github.com/NixOS/nixpkgs/commit/dd47d727c0012465db1c0a834010762aab2b1907) mockoon: 9.5.0 -> 9.6.1
* [`3e413e71`](https://github.com/NixOS/nixpkgs/commit/3e413e719f3d4423c14461f3464a6c5a1c6c4253) jetbrains.datagrip: 2026.1.1 -> 2026.1.2
* [`12497753`](https://github.com/NixOS/nixpkgs/commit/124977534776ce8df68d117ef5adb6b74d897749) nano: 8.7.1 -> 9.0
* [`7615d9d3`](https://github.com/NixOS/nixpkgs/commit/7615d9d35bb03ca8c223ee69ffd2f54dc1b00663) acr-cli: 0.18.1 -> 0.19, fix build
* [`f70c7cd3`](https://github.com/NixOS/nixpkgs/commit/f70c7cd3c65bc41d4b01b67337ec7c91ed9649a0) imapgoose: approved universality
* [`6b01c424`](https://github.com/NixOS/nixpkgs/commit/6b01c424537eb8fd2566a21982366307982e661b) imapgoose: added maintainer
* [`003406ee`](https://github.com/NixOS/nixpkgs/commit/003406ee9c8ef4857244ac064ecc557a42b49093) python3Packages.emv: refactored code
* [`65881ce8`](https://github.com/NixOS/nixpkgs/commit/65881ce87e533762c950daa1aa918af9b4ae114a) imapsync: enable strictDeps
* [`95e1d657`](https://github.com/NixOS/nixpkgs/commit/95e1d6572aa0d66cab0dc266cc1ea3f804b3d1b2) imapsync: add versionCheckHook
* [`93a23a8a`](https://github.com/NixOS/nixpkgs/commit/93a23a8ad3a8f6e247844220bc218328e4948a27) openbox: enable strictDeps
* [`249935e4`](https://github.com/NixOS/nixpkgs/commit/249935e48122a7ddcd3e9c21cdb5a4b3490263d2) openbox: add versionCheckHook
* [`f373ef93`](https://github.com/NixOS/nixpkgs/commit/f373ef932b6a20004f05101a217c060a42860d5f) python3Packages.mike: 2.1.3 -> 2.2.0
* [`12be6508`](https://github.com/NixOS/nixpkgs/commit/12be65088153ffcd9b5eab7e2de2ed8052a0cfea) pagefind: 1.4.0 -> 1.5.2
* [`dde7a9a5`](https://github.com/NixOS/nixpkgs/commit/dde7a9a5d1ec8ee973321a3ea5d94297c2177b4e) pagefind: add enableExtended flag, denote so in pname
* [`0d20d14c`](https://github.com/NixOS/nixpkgs/commit/0d20d14c0ae071c29220ef7cf1483150fe18829d) vpl-gpu-rt: 26.1.4 -> 26.1.6
* [`db69a534`](https://github.com/NixOS/nixpkgs/commit/db69a534d7366a8705c641300e01ee7aa46bae0e) netpeek: add passthru.updateScript
* [`0dbd15f3`](https://github.com/NixOS/nixpkgs/commit/0dbd15f3f60b2cf9c628301ad30447f72fc67986) yubioath-flutter: 7.3.2 -> 7.3.3
* [`0425adbd`](https://github.com/NixOS/nixpkgs/commit/0425adbd92bab1b02597f727d1b73631b2f9b54b) questdb: 9.3.2 -> 9.3.5
* [`420d6610`](https://github.com/NixOS/nixpkgs/commit/420d661048d786606354ea444a12e6cfcde4856b) keymapp: move icon to spec-compliant location
* [`94fab6ab`](https://github.com/NixOS/nixpkgs/commit/94fab6ab70c277c6cf5666a4d3a5e8c521a8b361) maintainers: add brett
* [`c6a6551a`](https://github.com/NixOS/nixpkgs/commit/c6a6551a50c3da328f1c7ff8d30abab8e5c26fec) zabbix70: 7.0.24 -> 7.0.25
* [`1a816ef4`](https://github.com/NixOS/nixpkgs/commit/1a816ef4bffbe5db98fdc0ce30d2b115abdc8331) zabbix74: 7.4.8 -> 7.4.9
* [`63e81d50`](https://github.com/NixOS/nixpkgs/commit/63e81d508c8924004b9312b304d69cfb0d5ccefe) jwhois: fix build with gcc15
* [`35047196`](https://github.com/NixOS/nixpkgs/commit/35047196974f201ffdfa4ffeb8baa22b3cf2f071) electricsheep: fix build with boost 1.89
* [`f859ff19`](https://github.com/NixOS/nixpkgs/commit/f859ff19386f327560fc22ee95cae3524739a0b0) diffstat: 1.68 -> 1.69
* [`f289dad0`](https://github.com/NixOS/nixpkgs/commit/f289dad0cf3daf4b5a0b25c915b7b3545b2dd885) package-version-server: 0.0.7 -> 0.0.10
* [`c9e19b6a`](https://github.com/NixOS/nixpkgs/commit/c9e19b6a66426ac8a75a7451fd12ebbf183e5f3f) ivpn-service: set strictDeps and __structuredAttrs
* [`1d9c5afe`](https://github.com/NixOS/nixpkgs/commit/1d9c5afe7947254be45a068a177a791dc5fb7724) burn-central-cli: set strictDeps and __structuredAttrs
* [`46da459c`](https://github.com/NixOS/nixpkgs/commit/46da459cffebc5b951a7b6a0279e8d6483d337b7) oxdraw: set strictDeps and __structuredAttrs
* [`04e631b3`](https://github.com/NixOS/nixpkgs/commit/04e631b3f248201bfaec0a9a980402f1cad510d9) unified-memory-framework: set strictDeps and __structuredAttrs
* [`c701b662`](https://github.com/NixOS/nixpkgs/commit/c701b66268e9600f4601ba64fa7fce5441bcf647) maintainers: add jelni
* [`f1a131a5`](https://github.com/NixOS/nixpkgs/commit/f1a131a53c0214e3f47ece6ccb9877b0e807f96e) lucida-downloader: 0.7.0 -> 0.8.0
* [`1734bba8`](https://github.com/NixOS/nixpkgs/commit/1734bba8c66d59d1fa1087eb9b7c850024a1a19a) nushell-plugin-desktop_notifications: 0.111.0 -> 0.112.2
* [`76c18c8f`](https://github.com/NixOS/nixpkgs/commit/76c18c8f11400ece34b957bccd85e6448edfc879) libunicode: 0.7.0 -> 0.9.0
* [`ea7d5b27`](https://github.com/NixOS/nixpkgs/commit/ea7d5b27b75685daaf2b8b74d5b52b70c99df431) contour: 0.6.2.8008 -> 0.6.3.8249
* [`b0e42139`](https://github.com/NixOS/nixpkgs/commit/b0e42139d55dee05de2fff8d653dde0771b5256c) ivpn: enable __structuredAttrs
* [`48e5964b`](https://github.com/NixOS/nixpkgs/commit/48e5964b4464256bb9b948d8b531c9ef824ef80f) python3Packages.latex2mathml: 3.79.0 -> 3.81.0
* [`9dd5558b`](https://github.com/NixOS/nixpkgs/commit/9dd5558b06dbdacbf635a3dd36dce1b1a7ee3a89) bun: 1.3.11 -> 1.3.13
* [`5ad39f3f`](https://github.com/NixOS/nixpkgs/commit/5ad39f3f218b622d4f0d721f775a724a68c7b759) python3Packages.cx-logging: unbreak on darwin
* [`53465de5`](https://github.com/NixOS/nixpkgs/commit/53465de5d1dc833d7d34d8cb26aa220a353ace6a) sinit: migrate to by-name
* [`a5c83014`](https://github.com/NixOS/nixpkgs/commit/a5c830141cc3e2ffd371fb36f8cdb3ce947fa2dc) sinit: modernize derivation
* [`5323d8b5`](https://github.com/NixOS/nixpkgs/commit/5323d8b5744ad60b21ae43f3a6ffea7ab5662cb0) python3Packages.netbox-dns: 1.4.6 -> 1.5.7
* [`fb340fed`](https://github.com/NixOS/nixpkgs/commit/fb340fed9aa5da1aa36c485a83e3d64eb2bd4943) python3Packages.llm-ollama: 0.15.1 -> 0.16.0
* [`e3cf1b4b`](https://github.com/NixOS/nixpkgs/commit/e3cf1b4b98feac6cc8731ea6fb072632337b82a7) eta: 1.0.1 -> 1.0.1-unstable-2026-01-04
* [`fa7eda09`](https://github.com/NixOS/nixpkgs/commit/fa7eda0942670bd183837f9e36a63089c01ded66) todoman: 4.6.0 -> 4.7.0
* [`7eb08d26`](https://github.com/NixOS/nixpkgs/commit/7eb08d26d3976509bf2c840c43cde35930adea73) trace-cmd: migrate to by-name
* [`cdc37f72`](https://github.com/NixOS/nixpkgs/commit/cdc37f7205ccacb2002877b2b36db5dd4ebe8506) trace-cmd: modernize derivation
* [`ceb4235c`](https://github.com/NixOS/nixpkgs/commit/ceb4235c57d7d1577437090a97cf8f8a0bf9ce52) xpar: 0.7 -> 1.0
* [`baf449ff`](https://github.com/NixOS/nixpkgs/commit/baf449ff8e5382eeb324d9c04a09992858ddb548) python3Packages.cx-freeze: remove unused inputs, unbreak build on darwin
* [`1b18d0e8`](https://github.com/NixOS/nixpkgs/commit/1b18d0e84357ea0300f2dcece8c56385382827b5) python3Packages.netbox-routing: 0.3.2 -> 0.4.2
* [`e7aa8c19`](https://github.com/NixOS/nixpkgs/commit/e7aa8c194fb05e624fd4e7c6534763e0b64a66b0) commafeed: 7.0.0 -> 7.1.0
* [`a120c914`](https://github.com/NixOS/nixpkgs/commit/a120c9144abc03fb45c18de2e3271db273668a83) jaspr_cli: init at 0.23.0
* [`8d12ed00`](https://github.com/NixOS/nixpkgs/commit/8d12ed00a0a9150c9fd3935b96066231b5798c28) dart_frog_cli: init at 1.2.14
* [`3e317113`](https://github.com/NixOS/nixpkgs/commit/3e317113b5b1c2ac59491b08ac3e3c40e958186f) unofficial-homestuck-collection: 2.8.0 -> 2.8.1
* [`96471db3`](https://github.com/NixOS/nixpkgs/commit/96471db37dd3fa591db30c5f3ad1ae1b106c631c) webdev: init at 3.8.1
* [`520cd2c1`](https://github.com/NixOS/nixpkgs/commit/520cd2c1b2079b0353df49499cd2c886afde83fd) mono_repo: init at 6.6.3
* [`4296b8f8`](https://github.com/NixOS/nixpkgs/commit/4296b8f8db26648a75ed006d75788a6cbe044c43) warpgate: 0.21.1 -> 0.23.1
* [`36fa9a85`](https://github.com/NixOS/nixpkgs/commit/36fa9a857f3f7d425f63009cf8c48219103a1508) nixos/warpgate: add protocol specific `external_host`
* [`7688f7f7`](https://github.com/NixOS/nixpkgs/commit/7688f7f735ca862264bcb4d8327170e67fb89782) nixos/warpgate: add `log.audit_retention`
* [`b2a06070`](https://github.com/NixOS/nixpkgs/commit/b2a060703489a024bcec5855550ae4107b6267c3) sope: 5.12.3 -> 5.12.7
* [`d064e53d`](https://github.com/NixOS/nixpkgs/commit/d064e53d6b50af425e958843f0700d10bcdfca4b) fluent-bit: 4.2.2 -> 5.0.3
* [`008e4696`](https://github.com/NixOS/nixpkgs/commit/008e469616c613e4b6197e27baf5276ce78697c8) wasmtime: 43.0.1 -> 44.0.0
* [`16e36124`](https://github.com/NixOS/nixpkgs/commit/16e361240c6387e425dcb19276fb4459ba6d3e2d) qidi-studio: 2.05.01.53 > 2.05.02.50
* [`44c44138`](https://github.com/NixOS/nixpkgs/commit/44c441385f4093c931da83ca628bfae94fe2ab08) python3Packages.pysdl3: 0.9.8b9 -> 0.9.11b0
* [`f6a1ab05`](https://github.com/NixOS/nixpkgs/commit/f6a1ab05159e3fc46fdc608b206fa311a829bcc9) tauon: 8.2.2 -> 9.1.3
* [`38e105ce`](https://github.com/NixOS/nixpkgs/commit/38e105cec4c0eb7a49b780c27479659d59d5b578) youtrack: 2025.3.121962 -> 2026.1.12458
* [`b57ca4e9`](https://github.com/NixOS/nixpkgs/commit/b57ca4e996b3d452611ce2072e59e1490cdbd098) libfrida-core: 17.2.17 -> 17.9.1
* [`c257dde7`](https://github.com/NixOS/nixpkgs/commit/c257dde7648f18e1df48dd141d0342e8bcc1870a) libfrida-core: add nix-update-script passthru
* [`1890f09e`](https://github.com/NixOS/nixpkgs/commit/1890f09e3f06d42f11940300efbb415fca006a6e) libfrida-core: add darwin support
* [`78469b9e`](https://github.com/NixOS/nixpkgs/commit/78469b9e7c85f64081fd605400ca673158155999) ntfs3g: 2022.10.3 -> 2026.2.25
* [`fad918d9`](https://github.com/NixOS/nixpkgs/commit/fad918d9e6a85dd70ca388d633110c8cb4526563) cargo-typify: 0.5.0 → 0.6.1
* [`dd0dd7c7`](https://github.com/NixOS/nixpkgs/commit/dd0dd7c7119a6cba79ba343ba7618a5eead77014) git-fork: point fork binary symlink to fork_cli
* [`03384968`](https://github.com/NixOS/nixpkgs/commit/03384968de1099319d57fb44fa5f146b0f8b3b6b) animeko: mark broken
* [`696cb23a`](https://github.com/NixOS/nixpkgs/commit/696cb23a7d9854fc07d134876b5ac66d2f75d0f2) dashy-ui: 3.3.0 -> 3.3.1
* [`48225b0c`](https://github.com/NixOS/nixpkgs/commit/48225b0c0e8a14975c7451e011e2820a78db22b9) mangowc: Update repository owner and name
* [`3f93f37d`](https://github.com/NixOS/nixpkgs/commit/3f93f37db2c891a092d09bbaa2ee3a81231a4547) mangowc: Update homepage
* [`86b05d35`](https://github.com/NixOS/nixpkgs/commit/86b05d3557d67db8c463afe2ad9913ce9b0651d3) mangowc: 0.12.3 -> 0.12.8
* [`66392cd2`](https://github.com/NixOS/nixpkgs/commit/66392cd25de358e17f33811d21f2b0ef12d04290) home-assistant-custom-lovelace-modules.material-you-utilities: 2.1.6 -> 2.1.8
* [`6eeadab2`](https://github.com/NixOS/nixpkgs/commit/6eeadab2cab4d88769c4aa66133629d8e4044437) webex: 45.10.1.33646 -> 46.4.0.34620
* [`d6a6df66`](https://github.com/NixOS/nixpkgs/commit/d6a6df6661acea806282671d29ed3476e2a9582c) stdenv: set meta.{position,license,teams,identifiers.cpeParts}
* [`7ad76d65`](https://github.com/NixOS/nixpkgs/commit/7ad76d650f55f13b8b65a62ed6071e2f4b48da10) opencc: 1.2.0 -> 1.3.0
* [`93987278`](https://github.com/NixOS/nixpkgs/commit/939872784fa35a8f8921765f19b4f6a2d03f1709) python3Packages.attrs-strict: fix tests
* [`ccd28334`](https://github.com/NixOS/nixpkgs/commit/ccd28334f982e0b491818150b52ca7ea4601eab8) dioxus-cli: 0.7.5 -> 0.7.6
* [`28f3c32c`](https://github.com/NixOS/nixpkgs/commit/28f3c32ccf26c44730b83a632d63476f6615787e) _3proxy: switch to replace-fail
* [`2b59baea`](https://github.com/NixOS/nixpkgs/commit/2b59baeab7772592abf6717858600178aa9f721e) _20kly: switch to replace-fail
* [`102185e7`](https://github.com/NixOS/nixpkgs/commit/102185e743c75577a42ab1cbfe9c519d21d767de) _7zip-zstd: switch to replace-fail
* [`27973787`](https://github.com/NixOS/nixpkgs/commit/27973787bcaf336243650779c0beb71cebc2a94f) _7zz: switch to replace-fail
* [`60c77a3d`](https://github.com/NixOS/nixpkgs/commit/60c77a3dc373a9397826e41920a96401bc03746a) _9base: switch to replace-fail
* [`433a015b`](https://github.com/NixOS/nixpkgs/commit/433a015b2f2cd6f0cb4c35aef6aa511b82a27120) _9pfs: switch to replace-fail
* [`c9c0cb32`](https://github.com/NixOS/nixpkgs/commit/c9c0cb3234d5f1db70d21774b9dba443b95d86b6) a2jmidid: switch to replace-fail
* [`d32e9aee`](https://github.com/NixOS/nixpkgs/commit/d32e9aee36e816fbf1d82a1a0be668ca842728d1) a2ps: switch to replace-fail
* [`8db7f694`](https://github.com/NixOS/nixpkgs/commit/8db7f6941de9cad78f9ee46d718e1001bbe13ebb) aaxtomp3: switch to replace-fail
* [`ee21e544`](https://github.com/NixOS/nixpkgs/commit/ee21e5447b12d80336f4933bcc7eaef849f74fa7) abcde: switch to replace-fail
* [`d5f7e342`](https://github.com/NixOS/nixpkgs/commit/d5f7e342ada86903ac9165e0ea5d1c9fbcffd34f) abi-dumper: switch to replace-fail
* [`37a838bb`](https://github.com/NixOS/nixpkgs/commit/37a838bbc0be92dd30e751db116bbcaf24e26763) abuild: switch to replace-fail
* [`9a22b1dc`](https://github.com/NixOS/nixpkgs/commit/9a22b1dc36fa9938d34a4c3b5f5706c0d7018cd7) acme-dns: switch to replace-fail
* [`585975b5`](https://github.com/NixOS/nixpkgs/commit/585975b55232b4a732379c2bcffafbe459f5f2c7) acme: switch to replace-fail
* [`36b2dc36`](https://github.com/NixOS/nixpkgs/commit/36b2dc36e84b2fd977203068755aa68803c79675) acpic: switch to replace-fail
* [`a14e5e24`](https://github.com/NixOS/nixpkgs/commit/a14e5e249d2d773266684f2ae10a03536ca75a00) acpilight: switch to replace-fail
* [`47297f0a`](https://github.com/NixOS/nixpkgs/commit/47297f0a9557f1614f659f989214ddfccc42449d) activate-linux: switch to replace-fail
* [`3de995ff`](https://github.com/NixOS/nixpkgs/commit/3de995ffc0e2387d7ddfd8c4b0a99728e5d6d1ff) actkbd: switch to replace-fail
* [`3d40f110`](https://github.com/NixOS/nixpkgs/commit/3d40f110ccbf019de8413d79a1697df072e5e12b) adbfs-rootless: switch to replace-fail
* [`7c77c2da`](https://github.com/NixOS/nixpkgs/commit/7c77c2dabeb54754105b2ee1efad11f4df79214c) adcskiller: switch to replace-fail
* [`18f79cc3`](https://github.com/NixOS/nixpkgs/commit/18f79cc34fb94f70737cfcee37aa6e799255778c) adwaita-qt: switch to replace-fail
* [`c517bfea`](https://github.com/NixOS/nixpkgs/commit/c517bfead91c293408f4ba33d089e5b6d8d3055b) aeolus: switch to replace-fail
* [`1798ebf1`](https://github.com/NixOS/nixpkgs/commit/1798ebf1d47386e15802749b030d8feb672653d2) aescrypt: switch to replace-fail
* [`1f08a070`](https://github.com/NixOS/nixpkgs/commit/1f08a07001a0e50bdb3e78a83787cc2d909eb258) afterstep: switch to replace-fail
* [`4758c609`](https://github.com/NixOS/nixpkgs/commit/4758c6098f9650ee240aa2d979a35a9aaeb08337) agg: switch to replace-fail
* [`4a2e7894`](https://github.com/NixOS/nixpkgs/commit/4a2e7894304fd2776f033c48fe79d2d2aae0efbd) airspy: switch to replace-fail
* [`53fbc163`](https://github.com/NixOS/nixpkgs/commit/53fbc163fef711ec3bc5f631760c4b0faabd8f74) phoc: 0.53.0 -> 0.54.0
* [`d48d890b`](https://github.com/NixOS/nixpkgs/commit/d48d890bf6b4e0eed535918a9b6b72b0af0f2685) stevia: 0.52.1 -> 0.54.0
* [`bd6c9f62`](https://github.com/NixOS/nixpkgs/commit/bd6c9f62117d746c694bd0870aeb9475cbfddd8e) rgx: 0.12.0 -> 0.12.1
* [`422e4e90`](https://github.com/NixOS/nixpkgs/commit/422e4e905000021b0ca2a0555049e11fda344f18) glances: 4.5.3.2 -> 4.5.4
* [`7b6fa0ed`](https://github.com/NixOS/nixpkgs/commit/7b6fa0ed395ec1626eca9d80d4fccf73c550345b) python3Packages.primp: 1.2.2 -> 1.2.3
* [`f8f99054`](https://github.com/NixOS/nixpkgs/commit/f8f99054baa38c3badfce9e2b40e4ed7c4f072c3) python3Packages.ddgs: 9.13.1 -> 9.14.1
* [`5ff7c23b`](https://github.com/NixOS/nixpkgs/commit/5ff7c23b89207439af3baa14001ab9a4edf57d5e) phosh-mobile-settings: 0.51.0 -> 0.54.0
* [`70a9cd66`](https://github.com/NixOS/nixpkgs/commit/70a9cd660b984ee062384221124d9be1f482e9a4) qrcodegen: add pkg-config .pc file
* [`bad66831`](https://github.com/NixOS/nixpkgs/commit/bad6683192cd4e69611f162367c3a90dc65a8290) eslint: 10.2.0 -> 10.2.1
* [`99c6c388`](https://github.com/NixOS/nixpkgs/commit/99c6c3881a3cfb8ff48eb4c7dc6e9fcec7d1e515) python3Packages.accelerate: 1.12.0 -> 1.13.0
* [`6aa17ff4`](https://github.com/NixOS/nixpkgs/commit/6aa17ff4eba50c2f4fa9e3aefa096f065726348c) ocamlPackages.ocamlnet: don't use stringy license
* [`313b2c84`](https://github.com/NixOS/nixpkgs/commit/313b2c84191ff62f659f151a239a7d4005247a50) sauerbraten: set license to unfreeRedistributable
* [`09e9c011`](https://github.com/NixOS/nixpkgs/commit/09e9c0110c0b8ed78aa9e33198a7323d298c52d1) nixos/warpgate: align `sso_providers` with config schema
* [`a90b1986`](https://github.com/NixOS/nixpkgs/commit/a90b198644e42d3974216cbd3c453f80e7c17bfd) altermime: set license to sendmail
* [`b3ede4a1`](https://github.com/NixOS/nixpkgs/commit/b3ede4a1235054234b825fdfdc5e1b5a8d7c5594) liberfa: set license to bsd3
* [`e109a967`](https://github.com/NixOS/nixpkgs/commit/e109a96749772e60527a3521fda77b59bd81e2da) typora: fix wayland support
* [`765465df`](https://github.com/NixOS/nixpkgs/commit/765465df47ce72436574ba9ed38460d084634b30) cerberus: disable tests
* [`f38184e9`](https://github.com/NixOS/nixpkgs/commit/f38184e9e775cbfe0dd7937c50c232f89a4e781c) ocamlPackages.dns: 10.2.4 → 10.2.5
* [`6c47f844`](https://github.com/NixOS/nixpkgs/commit/6c47f844208dfc136177005818c4787d419b74eb) abook: fix Darwin build by setting `CFLAGS=-std=gnu17`
* [`e97b3caa`](https://github.com/NixOS/nixpkgs/commit/e97b3caa6d94b46ede78c8f47a395e7cd31ff3b3) hackrf: 2024.02.1 -> 2026.01.3
* [`596789c0`](https://github.com/NixOS/nixpkgs/commit/596789c0e813531142f7dadf4d7efc32a9a7b318) libetpan: fix Darwin build by setting `CFLAGS=-std=gnu17`
* [`c8924be7`](https://github.com/NixOS/nixpkgs/commit/c8924be76edb38245bc0955c2f20db2ec0605a96) bazel: 9.0.1 -> 9.1.0
* [`e3918110`](https://github.com/NixOS/nixpkgs/commit/e3918110e1e7b8685cb7cd961725b46a7e57ca34) nixos/parallels-guest: fix prltoolsd on NixOS for Parallels 26+
* [`d554c58f`](https://github.com/NixOS/nixpkgs/commit/d554c58f5ea538cb6c1f7c4e48a32b166bb50967) nixos/parallels-guest: apply nixfmt formatting
* [`96c5a1f7`](https://github.com/NixOS/nixpkgs/commit/96c5a1f75766cc6e173c4aa5cb536dc63b8fd795) build-support/vm: fix fillDiskWithDebs
* [`99872c2d`](https://github.com/NixOS/nixpkgs/commit/99872c2d5b8d5e3fc6bc7511fc5b415d8f412014) build-support/vm: fix fillDiskWithRPMs
* [`85bdfb8b`](https://github.com/NixOS/nixpkgs/commit/85bdfb8ba6f98c8f30ebe57a70081c380afdf336) build-support/vm: refactor IFS tricks in fillDiskWithDebs
* [`e32534fb`](https://github.com/NixOS/nixpkgs/commit/e32534fb1901caea1ef2c27dbc913eb20b116adc) halo: 2.23.1 -> 2.24.0
* [`8cd66cf9`](https://github.com/NixOS/nixpkgs/commit/8cd66cf9c88927f6c1bac10f1311cd7a20d99003) lp_solve: 5.5.2.11 -> 5.5.2.14
* [`a27f1200`](https://github.com/NixOS/nixpkgs/commit/a27f12009e4c7eda51a83d0859640bb4bc09ddb8) acpica-tools: fix build on aarch64-darwin
* [`85e0d4dd`](https://github.com/NixOS/nixpkgs/commit/85e0d4ddff0b8ef99b0c6291f626934e7ef0f3ce) OVMFFull: fix build on aarch64-darwin
* [`ecbfb55d`](https://github.com/NixOS/nixpkgs/commit/ecbfb55dcc993cda2d6dcdf8cde68acabc79a975) xfce4-session: enable strictDeps
* [`4f7dd7ba`](https://github.com/NixOS/nixpkgs/commit/4f7dd7baff7a17b0c1ffc01d7d814b2639860482) matrix-continuwuity: 0.5.7 -> 0.5.8
* [`af54a4ba`](https://github.com/NixOS/nixpkgs/commit/af54a4bab9209a018d3599b16e7c43956f8d79f2) kubectl: 1.35.4 -> 1.36.0
* [`66459637`](https://github.com/NixOS/nixpkgs/commit/664596378ab7a3f5e339cd715f8349d805b8bc8b) urweb: fix build with gcc15
* [`7e7ecced`](https://github.com/NixOS/nixpkgs/commit/7e7ecced6d8d12c9f3c6b00beb6f878c278add33) urweb: migrate to by-name
* [`735b011a`](https://github.com/NixOS/nixpkgs/commit/735b011a2dfd0feb04277eaf5ba65bc29c086759) sratoolkit: 3.3.0 -> 3.4.1
* [`969f9ae9`](https://github.com/NixOS/nixpkgs/commit/969f9ae9f53e29a1ebc758dd6c2c03f28cdbdb49) wolfstoneextract: change source, modernize
* [`537f1ca5`](https://github.com/NixOS/nixpkgs/commit/537f1ca5b1b5e1e552a1e2d641ea2926f7530766) anchor: 1.0.0 -> 1.0.1
* [`d5015561`](https://github.com/NixOS/nixpkgs/commit/d50155617c82ad7b7da31c48924b68e3596a1aaa) yarn-zpm: 6.0.0-rc.16 -> 6.0.0-rc.18
* [`5e83e5e2`](https://github.com/NixOS/nixpkgs/commit/5e83e5e27f1e358fdb26227f1d1c28813b3e35e4) melonds: 1.1-unstable-2026-02-02 -> 1.1-unstable-2026-04-20
* [`ec3df081`](https://github.com/NixOS/nixpkgs/commit/ec3df081df26d7e49fedad466fb64ca9c2f23db8) aphorme: 0.1.19 -> 0.2.0
* [`2fa1726e`](https://github.com/NixOS/nixpkgs/commit/2fa1726ebf507842c2c835c7c000465ad44c2842) fluxcd-operator-mcp: 0.38.1 -> 0.48.0
* [`aefd3dcb`](https://github.com/NixOS/nixpkgs/commit/aefd3dcb1acf60b1ff01683bdee33e16fbe6ef13) distro-info-data: 0.68 -> 0.69
* [`0a97fc3b`](https://github.com/NixOS/nixpkgs/commit/0a97fc3bec40e21f68f88bbafc069221b21bb645) python3Packages.netbox-interface-synchronization: 4.1.7 -> 4.5.8
* [`608d9feb`](https://github.com/NixOS/nixpkgs/commit/608d9feb412b4f4ce02bfeba765d61eee88d1369) sbcl: set __structuredAttrs and strictDeps
* [`ad93e70a`](https://github.com/NixOS/nixpkgs/commit/ad93e70a98dd8e31f366b8a4a3987f9e77d9ba44) meshcentral: 1.1.57 -> 1.1.59
* [`86fe4eb7`](https://github.com/NixOS/nixpkgs/commit/86fe4eb780726ed0da0ac6f46df0e9b730d6b376) mpvScripts.modernz: 0.3.1 -> 0.3.2
* [`dfbcfa71`](https://github.com/NixOS/nixpkgs/commit/dfbcfa7130a3791dd929c3c5796d7a34313e04c2) Revert "python313Packages.embreex: drop"
* [`9ba420f4`](https://github.com/NixOS/nixpkgs/commit/9ba420f4f894676e202b5ab1a8741e5976766a1b) phosh: 0.51.0 -> 0.54.0
* [`bb9b1423`](https://github.com/NixOS/nixpkgs/commit/bb9b1423ddc09e1d2551d678e9b24aba8babf059) python3Packages.embreex: 2.17.7.post6 -> 4.4.0
* [`29183806`](https://github.com/NixOS/nixpkgs/commit/29183806693eac8a87a0dd15bc9a75b5b371af7c) python3Package.py-radix: init at 1.1.0
* [`26fe4964`](https://github.com/NixOS/nixpkgs/commit/26fe49648c7df7e6217e47d71bd8387f72bd75bb) python3Packages.aggregate6: 1.0.14 -> 1.0.15
* [`5a6c1f5e`](https://github.com/NixOS/nixpkgs/commit/5a6c1f5e534d3fe0f1bc2d535400eed9b51770dd) python3Packages.trimesh: 4.11.5 -> 4.12.1, enable embreex tests
* [`44a79d04`](https://github.com/NixOS/nixpkgs/commit/44a79d04c01779786c8901507f45c28f1c3442ad) noriskclient-launcher-unwrapped: 0.6.19 -> 0.6.20
* [`6ff384ab`](https://github.com/NixOS/nixpkgs/commit/6ff384abf189f9b70b6dd81989f1adfc7af26e18) groff: fix cross-compiling error
* [`e23455f1`](https://github.com/NixOS/nixpkgs/commit/e23455f10f0fcefdd33a688eeec0312528a3bc04) jfbview: 0.6.0 -> 0.6.1
* [`dd77c109`](https://github.com/NixOS/nixpkgs/commit/dd77c109d5134a845eeeb3797533abfd0a17fe5b) rattler-build: 0.62.2 -> 0.63.0
* [`c75c144d`](https://github.com/NixOS/nixpkgs/commit/c75c144d6e642273c5e65ff70d5aabca318865bd) gpupad: 3.1.0 -> 3.4.0
* [`d693e6d1`](https://github.com/NixOS/nixpkgs/commit/d693e6d10c04f13ef18531b003d72d8c4e2b0c8e) kakasi: fix Darwin build by setting `-std=gnu17`
* [`10981980`](https://github.com/NixOS/nixpkgs/commit/109819804485329139adc2b31e6ddd16b3cd33c3) python3Packages.aurorapy: 0.2.7 -> 0.3
* [`915df391`](https://github.com/NixOS/nixpkgs/commit/915df391b1d0545582f65a9a8dd7d71ab6c85062) airwindows: 0-unstable-2026-04-11 -> 0-unstable-2026-04-24
* [`e7d7c53f`](https://github.com/NixOS/nixpkgs/commit/e7d7c53fdad80ba7a5ae2d14506e1d321658cb7b) python3Packages.aioshelly: 13.23.1 -> 13.24.0
* [`57c0190c`](https://github.com/NixOS/nixpkgs/commit/57c0190caf3afbc07ef439c7f48155d2d5df50f4) python2Packages.buildPythonPackage: handle passthru with mkDerivation
* [`f2efb32a`](https://github.com/NixOS/nixpkgs/commit/f2efb32a79198728d1db47a4cc79a0dd784a6370) python2Packages.buildPythonPackage: port respect user-specified passthru attrs
* [`bd2285a8`](https://github.com/NixOS/nixpkgs/commit/bd2285a8a5bb61d747d80324746272eb041977d6) python2Packages.buildPythonPackage: passthru disabled
* [`e05bc0af`](https://github.com/NixOS/nixpkgs/commit/e05bc0af963bc1c440374d73a35c0a252a60a1bf) python2Packages.buildPythonPackage: preserve disabled after <pkg>.overrideAttrs
* [`66e45249`](https://github.com/NixOS/nixpkgs/commit/66e45249897c1e19833504581f170f43834d4e9c) python2Packages.buildPythonPackage: remove ineffective outputs cleanAttrs
* [`ea28d03e`](https://github.com/NixOS/nixpkgs/commit/ea28d03e3313264c579fbb9fdcfde8a6bf240166) python2Packages.buildPytonPackage: restructure with lib.extendMkDerivation
* [`397f1ecd`](https://github.com/NixOS/nixpkgs/commit/397f1ecdb091fd291a7d29d3b297623438e9352f) python2Packages.buildPythonPackage: format expression after lib.extendMkDerivation restructuring
* [`87c94efb`](https://github.com/NixOS/nixpkgs/commit/87c94efb13e8e9d28eb0791578050ca06cbb482d) jetbrains.rust-rover: 2026.1 -> 2026.1.1
* [`41c89063`](https://github.com/NixOS/nixpkgs/commit/41c890633fcda6e42403ff0fca6e41f55f439fb8) jetbrains.ruby-mine: 2026.1 -> 2026.1.1
* [`17b5ea55`](https://github.com/NixOS/nixpkgs/commit/17b5ea5558ed4291694113175dec0400bee41b12) jetbrains.gateway: 2025.3.2 -> 2026.1.1
* [`7e67e03b`](https://github.com/NixOS/nixpkgs/commit/7e67e03bdcac135153e2fde738c4d581f576f500) jetbrains.phpstorm: 2026.1 -> 2026.1.1
* [`6683ec7b`](https://github.com/NixOS/nixpkgs/commit/6683ec7bc69810ddb038b3dcdf50ef344e68f157) jetbrains.clion: 2026.1 -> 2026.1.1
* [`ea264391`](https://github.com/NixOS/nixpkgs/commit/ea26439137937751f0ce501a0cf597ffebb2cb65) jetbrains.goland: 2026.1 -> 2026.1.1
* [`123af3f1`](https://github.com/NixOS/nixpkgs/commit/123af3f15123ca42b6371f12103ee850dbe4b207) ifstate: 2.2.5 -> 2.2.6
* [`82973419`](https://github.com/NixOS/nixpkgs/commit/8297341934e9bc68afac1a09cf4dbb18fbfa0adf) python3Packages.soundcloud-v2: 1.6.2 -> 1.7.0
* [`fb40f073`](https://github.com/NixOS/nixpkgs/commit/fb40f073a57161664d1478937291451d6843bb2c) python3Packages.rctclient: 0.0.4 -> 0.0.5
* [`9c99b098`](https://github.com/NixOS/nixpkgs/commit/9c99b0985e0c54831fcd95e361e9bf0d970031ec) pythpn3Packages.rctclient: migrate to finalAttrs
* [`8d36cdee`](https://github.com/NixOS/nixpkgs/commit/8d36cdee7f1bfe431a6934a3b3181d8b43a6118e) libbluray-full: switch from jdk21_headless to jdk21
* [`d03b142a`](https://github.com/NixOS/nixpkgs/commit/d03b142ab09b0b05f1225f0e53f368a78f607432) wlc: 1.17.2 -> 2.0.0
* [`b53e4966`](https://github.com/NixOS/nixpkgs/commit/b53e4966a10a396578f16ac8e3ec3f7dd7bbfdfe) pyspread: 2.4 -> 2.4.5
* [`269e7fc5`](https://github.com/NixOS/nixpkgs/commit/269e7fc527937ce5173ba4d90ccd289d4f662259) mcp-grafana: 0.11.6 -> 0.12.0
* [`1c741f91`](https://github.com/NixOS/nixpkgs/commit/1c741f9139a3f9f3ef499bb11e08a70acbd6f4cb) python3Packages.apprise: 1.9.9 -> 1.10.0
* [`2fb2da42`](https://github.com/NixOS/nixpkgs/commit/2fb2da4230b47bced3f814e1dd86e081b3fb46af) nmtrust: init at 0.1.0
* [`e270fda6`](https://github.com/NixOS/nixpkgs/commit/e270fda6b02ee25e71ac4d1503beba812ef401c7) nixos/nmtrust: init
* [`28094108`](https://github.com/NixOS/nixpkgs/commit/28094108132259deff5e2bb381062c04d94ff006) frozen-containers: 1.2.0-unstable-2025-07-29 -> 1.2.0-unstable-2026-04-20
* [`7da09142`](https://github.com/NixOS/nixpkgs/commit/7da09142deccd24473a93106921b4de580d5269c) dgop: 0.2.0 -> 0.2.2
* [`be3c9982`](https://github.com/NixOS/nixpkgs/commit/be3c9982ae2395b0c7ac7b9f79318db90a636a97) pocketbase: 0.37.3 -> 0.37.4
* [`c53d0010`](https://github.com/NixOS/nixpkgs/commit/c53d001015d9964bf4db8e79e494e8655a5e566b) paperless-ngx: 2.20.14 -> 2.20.15
* [`2ef4f67a`](https://github.com/NixOS/nixpkgs/commit/2ef4f67a5c56aa589b54531f36cac33419586acc) nixos/dunst: fix config format
* [`018287df`](https://github.com/NixOS/nixpkgs/commit/018287dfea7130629fc00fd92f4b270903e198ba) strace: 6.19 -> 7.0
* [`f07455eb`](https://github.com/NixOS/nixpkgs/commit/f07455ebb688e7c02c9085c396918aea353ec8f3) idescriptor: 0.2.0 -> 0.5.0
* [`cfedc43c`](https://github.com/NixOS/nixpkgs/commit/cfedc43c713b21340571b380337c7b9ba9611a48) waylock: 1.5.0 -> 1.6.0
* [`9281ae11`](https://github.com/NixOS/nixpkgs/commit/9281ae11c05fb6dec827d64a2ea219694884e103) gickup: 0.10.40 -> 0.10.41
* [`23ab3d42`](https://github.com/NixOS/nixpkgs/commit/23ab3d422950771d8fe7b466afe80c745f3b7e6a) rsbkb: 1.4 -> 1.9
* [`47460504`](https://github.com/NixOS/nixpkgs/commit/47460504193652c97f8c2314fee66c69bddbb821) python3Packages.pamqp: 3.3.0 -> 4.0.0
* [`4cd94659`](https://github.com/NixOS/nixpkgs/commit/4cd94659826a441cfe9546fbfc979905c3bfd362) python3Packages.aiormq: 6.9.2 -> 9.6.4
* [`f9ba31af`](https://github.com/NixOS/nixpkgs/commit/f9ba31af4ebc45c1a18dfeb43a14ff391a2ed422) python3Packages.aio-pika: 9.5.8 -> 9.6.2
* [`7bab02cb`](https://github.com/NixOS/nixpkgs/commit/7bab02cbb9300f112e14f6ac30149c7ecf75b480) poedit: 3.6.2 -> 3.9
* [`146bc8dc`](https://github.com/NixOS/nixpkgs/commit/146bc8dcb2c41f221b277042b8f6a9139947c3a7) doc/python: document fixed-point arguments ([nixos/nixpkgs⁠#271387](https://togithub.com/nixos/nixpkgs/issues/271387))
* [`21fd7639`](https://github.com/NixOS/nixpkgs/commit/21fd76392df2db992eb6b817d9fb1bf1e5784a85) ente-web: 1.3.32 -> 1.3.36
* [`5bbf2143`](https://github.com/NixOS/nixpkgs/commit/5bbf21430d51800d1a585367fbcc3af9f93695c4) knot-resolver_6: 6.2.0 -> 6.3.0
* [`99749636`](https://github.com/NixOS/nixpkgs/commit/99749636f1cb133bd1c430dfbd9ca2da3380dddd) ao3downloader: 2026.4.7 -> 2026.4.9
* [`303c5a4a`](https://github.com/NixOS/nixpkgs/commit/303c5a4a6cb62a202d5a9137d432059a3eb7b6f4) teams-for-linux: 2.8.0 -> 2.8.1
* [`1b68f40b`](https://github.com/NixOS/nixpkgs/commit/1b68f40be1038282036247c6c847ae731d81ab6b) nixos/getty: pass --issue-file explicitly
* [`eacc33e4`](https://github.com/NixOS/nixpkgs/commit/eacc33e4cfb849cdd973ba4d6228fb7fff0f1dcc) badrobot: fix changelog
* [`59e3c387`](https://github.com/NixOS/nixpkgs/commit/59e3c3874bf77cffe7be548950ebe68627c720d8) hebbot: update changelog URL
* [`6bc3480f`](https://github.com/NixOS/nixpkgs/commit/6bc3480fdfd1d816ae7efda0aeb548b3db95888c) obconf: fix homepage and changelog
* [`62138a50`](https://github.com/NixOS/nixpkgs/commit/62138a501f129caae6e05c7bb22fe9d53c089acc) python3Packages.greenback: fix changelog link
* [`514430c8`](https://github.com/NixOS/nixpkgs/commit/514430c8711836835632ac7f0507638350e961cc) python3Packages.gguf: 8799 -> 8951
* [`ce2358fd`](https://github.com/NixOS/nixpkgs/commit/ce2358fd36aa77008cf8511d892c7a840d35f683) git: fix meta.changelog link
* [`d51d9aca`](https://github.com/NixOS/nixpkgs/commit/d51d9acab5ed52eb08c749da8405f181ec77bced) python3Packages.datashader: fix changelog link
* [`7910f8dc`](https://github.com/NixOS/nixpkgs/commit/7910f8dcddc5fb41e5011b9bc56e83dc66ad1d68) jetbrains.webstorm: 2025.3.3 -> 2026.1.1
* [`870b2e6d`](https://github.com/NixOS/nixpkgs/commit/870b2e6d4672a19b794941e352dbda570b2a9510) garmin-grafana: 0.3.0 -> 0.5.0
* [`20151edf`](https://github.com/NixOS/nixpkgs/commit/20151edf583dc048ee605c42bedaae65428ad3d0) cudaPackages_13: 13.0.3 -> 13.2.0
* [`6c0e00ba`](https://github.com/NixOS/nixpkgs/commit/6c0e00ba91a15ad74d038b74ffab430b508589e5) python3Packages.tree-sitter-zeek: 0.2.12 -> 0.2.13
* [`efa081c5`](https://github.com/NixOS/nixpkgs/commit/efa081c5211733b56a2c795b7d875a11a113ddb1) zeekscript: switch rev to tag
* [`241c1dc3`](https://github.com/NixOS/nixpkgs/commit/241c1dc305545ff9df46252d494053e4e44e6fa7) zeekscript: 1.3.3 -> 1.3.4
* [`c45cf4c7`](https://github.com/NixOS/nixpkgs/commit/c45cf4c7d6f2edfe833738a3e82d8b125afcb0e8) museum: 1.3.32 -> 1.3.36
* [`eb463580`](https://github.com/NixOS/nixpkgs/commit/eb463580c5b834e9c3abbf93506704a12b6595c9) basedpyright: 1.38.2 -> 1.39.3
* [`d469d3c3`](https://github.com/NixOS/nixpkgs/commit/d469d3c36253081e140b95feef100c8a61aa1122) python3Packages.llm-openrouter: 0.5 -> 0.6
* [`e1ca6b1d`](https://github.com/NixOS/nixpkgs/commit/e1ca6b1d0d819b7802db887c2fd08f67ca34bd18) spectre-meltdown-checker: 26.21.0401891 -> 26.33.0420460
* [`e26157b5`](https://github.com/NixOS/nixpkgs/commit/e26157b56cb3671e0a5ba2a5dba2b85fe7649144) txtpbfmt: 0-unstable-2026-02-17 -> 0-unstable-2026-04-20
* [`21b664f3`](https://github.com/NixOS/nixpkgs/commit/21b664f3e5291d94a9b311f9f64775192eb07e2c) python3Packages.gguf: add meta.downloadPage and meta.changelog
* [`6e77c4bd`](https://github.com/NixOS/nixpkgs/commit/6e77c4bdd24f6c6b7646cff4e12675a47cfd6533) python3Packages.unstructured-client: 0.42.12 -> 0.43.2
* [`ba513186`](https://github.com/NixOS/nixpkgs/commit/ba513186c3bbf6825f44c23d11657374b926a1c7) directx-shader-compiler: 1.9.2602 -> 1.10.2605.2
* [`767e1070`](https://github.com/NixOS/nixpkgs/commit/767e1070a7d8c693f17ca9fa698398817f9a330d) proftpd: 1.3.9 -> 1.3.9a
* [`ab5718da`](https://github.com/NixOS/nixpkgs/commit/ab5718dacfcf85fb1911a6f7a1396486c7db5ccb) lucky-commit: fix Darwin aarch64 cargo deps patch path
* [`c8f0c2c3`](https://github.com/NixOS/nixpkgs/commit/c8f0c2c3c13012700fbcf60324349d87df353ab6) liquidsoap: 2.4.2 → 2.4.4
* [`e873207c`](https://github.com/NixOS/nixpkgs/commit/e873207cdcaeb27c4715ca88d01ec3c49cbf47b0) libblake3: 1.8.4 -> 1.8.5
* [`b6e32a88`](https://github.com/NixOS/nixpkgs/commit/b6e32a8855ad42fabb53c62238fcfa4f78d2acc3) claude-code: 2.1.119 -> 2.1.121
* [`ee24e201`](https://github.com/NixOS/nixpkgs/commit/ee24e2013d9e55420900a3e4c1bfa940d054f04f) linux_xanmod: 6.18.24 -> 6.18.25
* [`3fe53e05`](https://github.com/NixOS/nixpkgs/commit/3fe53e0508b016c237ea35871399b27cbce3c0ce) vscode-extensions.anthropic.claude-code: 2.1.119 -> 2.1.121
* [`79a13f06`](https://github.com/NixOS/nixpkgs/commit/79a13f06887c0e114344b2d4d7b5f314016a92cc) liteparse: 1.4.6 -> 1.5.2
* [`7528daf8`](https://github.com/NixOS/nixpkgs/commit/7528daf8a7f507c222299e782777156738ef69d1) calcurse: Remove dead changelog link
* [`58ae5939`](https://github.com/NixOS/nixpkgs/commit/58ae593979e274d0d4b6616fb9e0c9eb7a241a9a) cargo-info: Fix meta.changelog
* [`18c37ddb`](https://github.com/NixOS/nixpkgs/commit/18c37ddbd4a096c1521d650bf539a7afe4f4b457) kata-runtime: 3.21.0 -> 3.29.0
* [`ab2c92da`](https://github.com/NixOS/nixpkgs/commit/ab2c92daf62d0221ab39c4bdfa35d23c8ea8deda) cargo-public-api: Fix meta.{homepage, changelog} URL
* [`03b68e81`](https://github.com/NixOS/nixpkgs/commit/03b68e81b2d5b46e327cf16eac31b81b64af0ff2) cargo-public-api: Fix meta.changelog URL
* [`768ec16c`](https://github.com/NixOS/nixpkgs/commit/768ec16ccbae9d2e50c35ac237183d60de8472dd) git-gone: Fetch from codeberg
* [`8383269d`](https://github.com/NixOS/nixpkgs/commit/8383269d089ab8d0c18217a054b7e72615dd6b72) gitnr: Remove meta.changelog
* [`c0a36b69`](https://github.com/NixOS/nixpkgs/commit/c0a36b69fb1a18e11b1861bac7c8d4ea28d22351) llmfit: Fix meta.changelog
* [`89f2772c`](https://github.com/NixOS/nixpkgs/commit/89f2772cfb4a6dba13c2b26dc4ad74df092b8bc1) nixos: Set mmap ASLR entropy dynamically
* [`8856bd6b`](https://github.com/NixOS/nixpkgs/commit/8856bd6b371f8c4960f77f55ce345e5c3f8efb6b) wastebin: 3.5.0 -> 3.6.1
* [`246e00b5`](https://github.com/NixOS/nixpkgs/commit/246e00b5898e9d4026513e30d19f889c3c0ee56b) ty: 0.0.32 -> 0.0.33
* [`38c97105`](https://github.com/NixOS/nixpkgs/commit/38c971054f008031adc6e9446ffa9fb87e460d5a) qgroundcontrol: update changelog link
* [`f3f2e579`](https://github.com/NixOS/nixpkgs/commit/f3f2e579517aea2b596d1002275f702da8e15026) renovate: 43.132.1 -> 43.150.1
* [`4f908ffe`](https://github.com/NixOS/nixpkgs/commit/4f908ffed4b11e40402d6d09736f09fef1f45869) azahar: 2125.1 -> 2125.1.1
* [`02f67a77`](https://github.com/NixOS/nixpkgs/commit/02f67a7765caef990429abbb2577a17ddca2f4b4) roc: fix changelog URL
* [`4a154806`](https://github.com/NixOS/nixpkgs/commit/4a15480611165c39afb7eadaedb712ae8fbd09bd) zuban: 0.7.0 -> 0.7.1
* [`0f0f5f6a`](https://github.com/NixOS/nixpkgs/commit/0f0f5f6a2ce29199b90de92df2382167a3a3b5d5) tor-browser: 15.0.10 -> 15.0.11
* [`35761782`](https://github.com/NixOS/nixpkgs/commit/3576178294f088d83bfc85fc145bd8f195b122d0) updatecli: 0.116.0 -> 0.116.3
* [`e64a9b84`](https://github.com/NixOS/nixpkgs/commit/e64a9b84a61afdaa615a4ecff4c93a7c16f7da6f) apt-swarm: 0.5.1 -> 0.6.0
* [`dcb52237`](https://github.com/NixOS/nixpkgs/commit/dcb5223722e7635dbcc8d2c4543e8f49be2d3fe5) linux_xanmod_latest: 6.19.14 -> 7.0.2
* [`522ead47`](https://github.com/NixOS/nixpkgs/commit/522ead47454567b95f5bfb60f9b0528300e97b34) apidog: 2.8.24 -> 2.8.26
* [`8aa784b1`](https://github.com/NixOS/nixpkgs/commit/8aa784b17646066c7d147082f2363f0648881bbd) ryubing: fix changelog
* [`d00e5c41`](https://github.com/NixOS/nixpkgs/commit/d00e5c41bfa77e877b70a0954f26ad22080ef673) shisho: drop
* [`ee594df3`](https://github.com/NixOS/nixpkgs/commit/ee594df3fbabd2e5567c98fe2f01326959760459) pure-ftpd: 1.0.53 -> 1.0.54
* [`29bdb29a`](https://github.com/NixOS/nixpkgs/commit/29bdb29ab29bc50c90b91de29e982401e8a16328) vmalert: Fail if encountering missing rule paths
* [`9a813890`](https://github.com/NixOS/nixpkgs/commit/9a8138904fd4bb7e6991eabfeec20bd193b29dcd) glab: 1.92.1 -> 1.93.0
* [`6fabbf80`](https://github.com/NixOS/nixpkgs/commit/6fabbf80bdaf64834dc07fb18de1ffb6679a78f9) python3Packages.crewai: fix build issue
* [`8f920e52`](https://github.com/NixOS/nixpkgs/commit/8f920e524fac5f13ca4ca0fdb7fbabb091e8738b) prometheus-tibber-exporter: 3.10.0 -> 3.10.2
* [`183373af`](https://github.com/NixOS/nixpkgs/commit/183373af86b6862a1a51b16aa89a2f1305483362) python3Packages.pluginlib: 0.10.0 -> 0.11.0
* [`d8f6dd3a`](https://github.com/NixOS/nixpkgs/commit/d8f6dd3a01f549f8f79fb6ee18aa058f4688f489) libretro.prosystem: 0-unstable-2026-03-31 -> 0-unstable-2026-04-20
* [`efc7009d`](https://github.com/NixOS/nixpkgs/commit/efc7009dd0ef120dfa8126485aceb5262ea5191a) bitwarden-desktop: build desktop_napi with --release
* [`e715a6bf`](https://github.com/NixOS/nixpkgs/commit/e715a6bfe2ad4c35e0e2e1b1045a1f5b5a66204c) python3Packages.requests-hardened: 1.2.0 -> 1.2.2
* [`4d387c2e`](https://github.com/NixOS/nixpkgs/commit/4d387c2ed01118b8322923b70ad199787784b0f6) python3Packages.cssutils: 2.14.0 -> 2.15.0
* [`c32cfc9d`](https://github.com/NixOS/nixpkgs/commit/c32cfc9d2f13cb702aa750e078448e5463e5fc58) osmium: fix missing dependencies
* [`6d6ae522`](https://github.com/NixOS/nixpkgs/commit/6d6ae522a31e151f6d6f7873130a3423f94daa65) ni: 30.0.0 -> 30.1.0
* [`8e1dc59e`](https://github.com/NixOS/nixpkgs/commit/8e1dc59ee89f3a370febb1228e0c3fa409ec0b58) python3Packages.modelscope: 1.35.4 -> 1.36.2
* [`55f70b1a`](https://github.com/NixOS/nixpkgs/commit/55f70b1ae5196acb8f84182ed8859b522c645702) gearboy: 3.8.2 -> 3.8.3
* [`b7d94a8a`](https://github.com/NixOS/nixpkgs/commit/b7d94a8a694128393db9a5b9214226033245213f) lstk: 0.5.7 -> 0.5.8
* [`76e76593`](https://github.com/NixOS/nixpkgs/commit/76e76593f314377fbdda21595cc95b06b8e00421) tfenv: 3.0.0 -> 3.2.1
* [`97cb9f34`](https://github.com/NixOS/nixpkgs/commit/97cb9f343e3e67058f0b4181a14c809cd4e95458) python3Packages.pydantic-monty: 0.0.13 -> 0.0.17
* [`6325e7ff`](https://github.com/NixOS/nixpkgs/commit/6325e7ff1406f7af435042429601dc29d74cbebe) lib.extendDerivation: inline variables
* [`8ccea3bf`](https://github.com/NixOS/nixpkgs/commit/8ccea3bf6cc28d7754f2dd7d4028b96ee0c5212c) lib.extendDerivation: avoid optionalAttrs merge
* [`1e022acb`](https://github.com/NixOS/nixpkgs/commit/1e022acbf5861841e47e8fbac78fb483dc488e94) lib.makeOverridable: inline several variables
* [`c3381171`](https://github.com/NixOS/nixpkgs/commit/c33811716d42e163f76f6d2b5cbe0c1c5777e40a) lib.makeOverridable: avoid optionalAttrs merge
* [`cb1edb81`](https://github.com/NixOS/nixpkgs/commit/cb1edb818340d88e7bd33f061dfa59e058199e89) lib.makeOverridable: inline helper function into its usages
* [`35c8d2dc`](https://github.com/NixOS/nixpkgs/commit/35c8d2dc9c22390dd960e26fdf7bc9ef3a0163c1) iwe: 0.0.67 -> 0.0.70
* [`7204e751`](https://github.com/NixOS/nixpkgs/commit/7204e7512fe2fca0377cbaa1d93ee9afd51b7129) xlights: 2026.06 -> 2026.07
* [`d19d3e9d`](https://github.com/NixOS/nixpkgs/commit/d19d3e9d826711c2f5748399cccd102da014868c) wasm-tools: 1.247.0 -> 1.248.0
* [`9028b9d7`](https://github.com/NixOS/nixpkgs/commit/9028b9d77abcb27d8f2507a8e14763f0775bd94b) yafc-ce: 2.16.0 -> 2.18.1
* [`7c6a1acc`](https://github.com/NixOS/nixpkgs/commit/7c6a1accb3a488b79771342468d65c9043bbd1f6) feishu-cli: 1.21.0 -> 1.22.0
* [`ba56246e`](https://github.com/NixOS/nixpkgs/commit/ba56246e9dab8e620d0bcfbccdd309ebc77488c0) modrinth-app-unwrapped: 0.13.3 -> 0.13.6
* [`3a51643c`](https://github.com/NixOS/nixpkgs/commit/3a51643c664b45ba4161305fbc1fa04007dc102c) onedpl: init at 2022.11.1
* [`0483567e`](https://github.com/NixOS/nixpkgs/commit/0483567e183c3f4295a2098b404d237e64700a21) victoriametrics: 1.141.0 -> 1.142.0
* [`e5791639`](https://github.com/NixOS/nixpkgs/commit/e57916398b98406d9e908e94a6ce39933ed74e0c) ocamlPackages.smtml: 0.25.0 → 0.26.0
* [`22b6cb47`](https://github.com/NixOS/nixpkgs/commit/22b6cb4793974fe76f62c5ac42ba32afc05ac443) python3Packages.allure-python-commons-test: 2.15.3 -> 2.16.0
* [`d453d9fc`](https://github.com/NixOS/nixpkgs/commit/d453d9fc61058c4b4bfc4f8a24cae98a9263316c) linux/common-config: RANDOMIZE_KSTACK_OFFSET_DEFAULT=y
* [`3d80ba51`](https://github.com/NixOS/nixpkgs/commit/3d80ba5174b454fa38d77b11aaae83e2e13ce25b) python3Packages.databricks-sdk: 0.102.0 -> 0.105.0
* [`3c30eb14`](https://github.com/NixOS/nixpkgs/commit/3c30eb1453d9bf0236d72593b6a10aff0cb3565b) vscode-extensions.42crunch.vscode-openapi: fix meta.changelog url
* [`3c6f2003`](https://github.com/NixOS/nixpkgs/commit/3c6f20039d8f04f78fcb8133bbda8cd2c263f34a) python3Packages.google-cloud-asset: fix changelog link
* [`9b897098`](https://github.com/NixOS/nixpkgs/commit/9b8970988199c70b011b705751626893db7bbe0b) matrix-synapse: 1.151.0 -> 1.152.0
* [`2ada20d3`](https://github.com/NixOS/nixpkgs/commit/2ada20d3fcd9b628235dbe06b361d0bd418a7eca) python3Packages.google-cloud-datacatalog: fix changelog link
* [`c79c3dfb`](https://github.com/NixOS/nixpkgs/commit/c79c3dfbf0ec8d5e901edd5e2f005bd465a04eab) super-productivity: 18.2.8 -> 18.3.0
* [`715cb20e`](https://github.com/NixOS/nixpkgs/commit/715cb20ebb38cc6ee4a80631339e31f8d5331446) libretro-shaders-slang: 0-unstable-2026-04-17 -> 0-unstable-2026-04-26
* [`be57facc`](https://github.com/NixOS/nixpkgs/commit/be57faccf28fef1b0e2f4a7cd3a255dc05fb89be) xnlinkfinder: 6.0 -> 8.2
* [`56f675b6`](https://github.com/NixOS/nixpkgs/commit/56f675b682fc438c5b712a605b39a192bc14acb4) gefyra: 2.4.1 -> 2.4.3
* [`181d5214`](https://github.com/NixOS/nixpkgs/commit/181d52146de1c53af300d5f3f60bed02f216960b) python3Packages.thinqconnect: 1.0.11 -> 1.0.12
* [`ecb89df7`](https://github.com/NixOS/nixpkgs/commit/ecb89df78702b95d0a5c0d9efd657d04f29af679) rust-analyzer-unwrapped: 2026-04-13 -> 2026-04-27
* [`cc4b49b8`](https://github.com/NixOS/nixpkgs/commit/cc4b49b8cc72a8e7b3839f5c2978530542245fa5) python3Packages.pyahocorasick: 2.3.0 -> 2.3.1
* [`2faf60c8`](https://github.com/NixOS/nixpkgs/commit/2faf60c811c669d4be094a70b8e93438aeb5bc1a) xwayland: 24.1.10 -> 24.1.11
* [`aacf0a26`](https://github.com/NixOS/nixpkgs/commit/aacf0a26710bd5c236180a45f1fd81ab6353273d) vscode-extensions.danielsanmedium.dscodegpt: 3.17.20 -> 3.17.36
* [`d121483c`](https://github.com/NixOS/nixpkgs/commit/d121483ce39d7d5912b7255094e6b0a2243ffe9b) btest: fix changelog
* [`666b4a56`](https://github.com/NixOS/nixpkgs/commit/666b4a56d23c64bb3fda84b5470273e8b676c7f8) gonzo: fix changelog
* [`d8509858`](https://github.com/NixOS/nixpkgs/commit/d850985826666b52987bb2ea9c6851dda262bee9) jj-pre-push: fix changelog
* [`6d0a55e3`](https://github.com/NixOS/nixpkgs/commit/6d0a55e3511274524c0de2d2bc15be2b6c6e1779) legitify: fix changelog
* [`dfdf258a`](https://github.com/NixOS/nixpkgs/commit/dfdf258aa70c33e19bf9c437280437289eaea8c9) mx-takeover: fix changelog
* [`68be312c`](https://github.com/NixOS/nixpkgs/commit/68be312ccc62564ce02a1ca9c70a060e936e02cf) nile: fix changelog
* [`d2888dc2`](https://github.com/NixOS/nixpkgs/commit/d2888dc2904b3ab70baa8dadde89d870d4f1aa80) regexploit: fix changelog
* [`c712f23e`](https://github.com/NixOS/nixpkgs/commit/c712f23e0363a0cb535871c3e515dbe946ec09bf) sequoia-sop: fix changelog
* [`e5d11d28`](https://github.com/NixOS/nixpkgs/commit/e5d11d28a43ff6f94437f56e6bbf5782f6b349f8) dnsight: fix changelog
* [`0b23aeda`](https://github.com/NixOS/nixpkgs/commit/0b23aedaed20ddba79434c0acf3c5fba7288e1f3) heretic: fix changelog
* [`4b3d3ac0`](https://github.com/NixOS/nixpkgs/commit/4b3d3ac000fdb01a5fcc59e6883aa9dc00f811e8) msoffcrypto-tool: fix changelog
* [`f89b3aee`](https://github.com/NixOS/nixpkgs/commit/f89b3aee40fb51d4532278e7fe4254dff432d94c) python313Packages.aiohttp-asgi-connector: fix changelog
* [`89400615`](https://github.com/NixOS/nixpkgs/commit/89400615e28a3a2ebafcbb563488be04ecd6cf1f) python313Packages.aiopegelonline: fix changelog
* [`f9220b0b`](https://github.com/NixOS/nixpkgs/commit/f9220b0b24a79c580fdc91fc55c664d15d4445e1) python313Packages.aiovlc: fix changelog
* [`2b258c17`](https://github.com/NixOS/nixpkgs/commit/2b258c176eb296391f6b51083d9d59431f9ff37c) python313Packages.asgineer: fix changelog
* [`443b04c2`](https://github.com/NixOS/nixpkgs/commit/443b04c28ce2c2edfdaa567baf05d3f0ad474309) python313Packages.asyncio-dgram: fix changelog
* [`3e56a323`](https://github.com/NixOS/nixpkgs/commit/3e56a323f03d1f0afb51d5e17c761fe98367b7f0) python313Packages.censys: fix changelog
* [`30934fc5`](https://github.com/NixOS/nixpkgs/commit/30934fc5b56f293653cdd7fd6bd9bfe025b1df84) python313Packages.container-inspector: fix changelog
* [`a7683e93`](https://github.com/NixOS/nixpkgs/commit/a7683e93cbdf670908c5bcab9d74461f4df89792) python313Packages.cwl-upgrader: fix changelog
* [`b4e69f91`](https://github.com/NixOS/nixpkgs/commit/b4e69f91fc2ffc170803b7442071a7d7891b38e7) python313Packages.cwl-utils: fix changelog
* [`888bee69`](https://github.com/NixOS/nixpkgs/commit/888bee69813a4a5e30ea6870f6bc122621bb3f2d) python313Packages.django-modeltranslation: fix changelog
* [`812b5ba4`](https://github.com/NixOS/nixpkgs/commit/812b5ba4578a24cd1953feea1018a106d845faa4) python313Packages.dotwiz: fix changelog
* [`9332b20d`](https://github.com/NixOS/nixpkgs/commit/9332b20da97bce6741127d75da9bf54896010acc) python313Packages.emoji-country-flag: fix changelog
* [`aac8bbce`](https://github.com/NixOS/nixpkgs/commit/aac8bbce9168a7e91a0bd2bbfd0764c6113df80a) python313Packages.freebox-api: fix changelog
* [`e3977b85`](https://github.com/NixOS/nixpkgs/commit/e3977b85353c52da660ade02314a87d6db766543) python313Packages.hier-config: fix changelog
* [`8341a8b2`](https://github.com/NixOS/nixpkgs/commit/8341a8b27712ba2a307c06660e93f16a6d08e661) python313Packages.iaqualink: fix changelog
* [`2e3458b0`](https://github.com/NixOS/nixpkgs/commit/2e3458b0f45df01fa1b2433814acefef5a23a25a) python313Packages.irisclient: fix changelog
* [`3eb92b4e`](https://github.com/NixOS/nixpkgs/commit/3eb92b4e645c6ebac5797fc59aeef2ad6cc61a2e) python313Packages.juliandate: fix changelog
* [`20297875`](https://github.com/NixOS/nixpkgs/commit/20297875e9b4d843a0295efee2d6d0f370dae025) python313Packages.logurich: fix changelog
* [`58c537df`](https://github.com/NixOS/nixpkgs/commit/58c537dfdd2739258cba00182d7e00308264fb36) python313Packages.pook: fix changelog
* [`3892f081`](https://github.com/NixOS/nixpkgs/commit/3892f0815f61967aa1cae4b4d70f6ecd5e7fffd5) python313Packages.postgrest: fix changelog
* [`75369317`](https://github.com/NixOS/nixpkgs/commit/75369317d3ab2bdd21b14c500712f33705324454) python313Packages.ppf-datamatrix: fix changelog
* [`fdf5efe9`](https://github.com/NixOS/nixpkgs/commit/fdf5efe944228cc810dcb74f0adc75ad85fbaf15) python313Packages.pyjpegls: fix changelog
* [`7281384c`](https://github.com/NixOS/nixpkgs/commit/7281384c0e786d2fe44bcec988df9166f7630f89) python313Packages.pytest-insta: fix changelog
* [`e3c0fd92`](https://github.com/NixOS/nixpkgs/commit/e3c0fd920fe4887647f105f400e8db8e8adfb5b8) python313Packages.python-obfuscator: fix changelog
* [`0d433644`](https://github.com/NixOS/nixpkgs/commit/0d433644c529b1eee5608ff958fa68ef0ad9f0b5) python313Packages.realtime: fix changelog
* [`eae0f37b`](https://github.com/NixOS/nixpkgs/commit/eae0f37be2af1fa3993edb8387a37b6feb661a88) python313Packages.socid-extractor: fix changelog
* [`f21e9f58`](https://github.com/NixOS/nixpkgs/commit/f21e9f5804efe1c4f622d508cc8d6453f7dca505) python313Packages.starlette-context: fix changelog
* [`4e0bd1ed`](https://github.com/NixOS/nixpkgs/commit/4e0bd1edac347f993c1e2d2963fbca0199f8edd1) python313Packages.storage3: fix changelog
* [`6d184a4d`](https://github.com/NixOS/nixpkgs/commit/6d184a4dbb8427db67d4ff43e109a2305301a0d3) python313Packages.supabase-auth: fix changelog
* [`85a4832e`](https://github.com/NixOS/nixpkgs/commit/85a4832ee4017edf03f570424fdfbe0a555eec3b) python313Packages.supabase-functions: fix changelog
* [`6d86d8f4`](https://github.com/NixOS/nixpkgs/commit/6d86d8f490de5edc1c014cc5d0b1e08fa08ca189) python313Packages.teamcity-messages: fix changelog
* [`3f4b4889`](https://github.com/NixOS/nixpkgs/commit/3f4b4889dd218f8b59f57b6b58c9cd65e9331b40) python313Packages.typst: fix changelog
* [`70b5aad8`](https://github.com/NixOS/nixpkgs/commit/70b5aad8e32c474c1964ea85028075429bcd540b) python313Packages.whodap: fix changelog
* [`01e3a52c`](https://github.com/NixOS/nixpkgs/commit/01e3a52cb13f7cfec9c58c5274040aa38a7d38e9) python313Packages.yaxmldiff: fix changelog
* [`0c3d3705`](https://github.com/NixOS/nixpkgs/commit/0c3d37050da685cd7be51980d7b4747c9a652b5c) statping-ng: fix changelog
* [`0692a5f3`](https://github.com/NixOS/nixpkgs/commit/0692a5f3d81d73008f25280d96d2006e42afd52e) wappalyzergo: fix changelog
* [`d929c0ae`](https://github.com/NixOS/nixpkgs/commit/d929c0ae8ba67509ea7e924669047ef7c351a105) wtcat: fix changelog
* [`59772fb5`](https://github.com/NixOS/nixpkgs/commit/59772fb5a7389f35836400f6d86c66fddb9d3635) zapper: fix changelog
* [`41d7d617`](https://github.com/NixOS/nixpkgs/commit/41d7d6176475cba5368ac4cef733bc9afe54c20f) zgrab2: fix changelog
* [`2c7b1f1f`](https://github.com/NixOS/nixpkgs/commit/2c7b1f1fce759b778d4d786246dfda09c514831d) gh-cherry-pick: 1.4.0 -> 1.5.0
* [`8ba9239a`](https://github.com/NixOS/nixpkgs/commit/8ba9239ad6882d637bec4f3a5e0e1b38e7c7a853) coldsnap: 0.9.0 -> 0.10.0
* [`a976aeb1`](https://github.com/NixOS/nixpkgs/commit/a976aeb19ca78301929a87a0c9a298ca308fc3ca) sbomnix: 1.7.4 -> 1.7.6
* [`65eaaedb`](https://github.com/NixOS/nixpkgs/commit/65eaaedbdcd7f8bc1db7afbc0f3b55791690cb53) di-tui: 1.13.3 -> 1.13.4
* [`a9897a52`](https://github.com/NixOS/nixpkgs/commit/a9897a52574f3ceb0c0e59b5af5998fda1deebf1) amdgpu_top: 0.11.3 -> 0.11.4
* [`ad092226`](https://github.com/NixOS/nixpkgs/commit/ad092226a5b425d8680064dd7498278fb96f9b4a) phpExtensions.swoole: 6.1.7 -> 6.1.8
* [`75377e3b`](https://github.com/NixOS/nixpkgs/commit/75377e3b3696d17a84a12da48cd9fad1064833f4) wofi-power-menu: 0.3.3 -> 0.3.4
* [`0600ec18`](https://github.com/NixOS/nixpkgs/commit/0600ec18d4620e758ad3c6ec49b46b3a67947d97) sdl3-shadercross: 0-unstable-2026-04-11 -> 0-unstable-2026-04-24
* [`23fe94b5`](https://github.com/NixOS/nixpkgs/commit/23fe94b54c94732372a7adc8c4eee851cb6d78c7) libretro.thepowdertoy: 0-unstable-2025-09-16 -> 0-unstable-2026-04-20
* [`52967c5a`](https://github.com/NixOS/nixpkgs/commit/52967c5ae35d2644fc6ff44b5ae1320b8549aa71) scrutiny,scrutiny-collector: 0.9.1 -> 0.9.2
* [`6c6f2656`](https://github.com/NixOS/nixpkgs/commit/6c6f26568f8229cf3cb6bf9d1633e4502a9aa327) libretro.pcsx-rearmed: 0-unstable-2026-04-15 -> 0-unstable-2026-04-25
* [`6856424d`](https://github.com/NixOS/nixpkgs/commit/6856424dc6e1172329a9484900a02cb5f2c791ed) polarity: latest-unstable-2026-03-27 -> latest-unstable-2026-04-28
* [`d12094e1`](https://github.com/NixOS/nixpkgs/commit/d12094e1f35ed98c4efdbcb416d5288d84cba1e3) python3Packages.pygls: use finalAttrs
* [`0fd07b7a`](https://github.com/NixOS/nixpkgs/commit/0fd07b7ab279cdfd1af494d71df705a954222b15) python3Packages.pygls: fix changelog url
* [`0593d854`](https://github.com/NixOS/nixpkgs/commit/0593d8544ef05c80d05ebe095423f4fd521497e0) terraform-mcp-server: 0.5.1 -> 0.5.2
* [`28c07ff2`](https://github.com/NixOS/nixpkgs/commit/28c07ff2bda49456bd72f9dd87fbf6ec259ca8ea) perlPackages.Starman: 0.4017 -> 0.4018
* [`b8342e27`](https://github.com/NixOS/nixpkgs/commit/b8342e276821af85d60ba0934c01855481759008) cargo-udeps: 0.1.60 -> 0.1.61
* [`7aa36d67`](https://github.com/NixOS/nixpkgs/commit/7aa36d67a7ae352be2b7c3b92bd0fc9f64a5c04c) biome: 2.4.12 -> 2.4.13
* [`8caa7a9c`](https://github.com/NixOS/nixpkgs/commit/8caa7a9c6dac02647431b178ee71218c1287c482) igir: 4.3.2 -> 5.0.1
* [`4fccc96f`](https://github.com/NixOS/nixpkgs/commit/4fccc96f710ca093e2deb6329c2c85188aeef156) vimPlugins.argtextobj-vim: add license
* [`eb232ad0`](https://github.com/NixOS/nixpkgs/commit/eb232ad096a167d11894ffedae540b4deae11996) vimPlugins.camelcasemotion: add license
* [`ffcf64c6`](https://github.com/NixOS/nixpkgs/commit/ffcf64c60ef87f80ed3ed4e9e386d102257db2f2) lact: 0.8.4 -> 0.9.0
* [`61f92a24`](https://github.com/NixOS/nixpkgs/commit/61f92a240eda294123629f54954036abb07a2f60) tutanota-desktop: 340.260326.1 -> 345.260424.1
* [`030d223e`](https://github.com/NixOS/nixpkgs/commit/030d223e7f652e6db2c777eb6ef0cd4b2008c8f3) linuxPackages.nvidia_x11.persistenced: fix eval
* [`7f8ff0c5`](https://github.com/NixOS/nixpkgs/commit/7f8ff0c5dc14a697eb32cde2a215cf1777536f39) monkeys-audio: 12.67 -> 12.75
* [`3768694a`](https://github.com/NixOS/nixpkgs/commit/3768694a00ef7e1c885ba35065c8fc547cb9acae) typos: 1.45.1 -> 1.45.2
* [`bc0ffa81`](https://github.com/NixOS/nixpkgs/commit/bc0ffa81c268adbb6dc8415bf44dc6fde55eb28c) spotatui: 0.38.0 -> 0.38.1
* [`14584d33`](https://github.com/NixOS/nixpkgs/commit/14584d3309ca5d5bcc05be8ec75279b14daa4edc) sqlc: 1.31.0 -> 1.31.1
* [`c9fe41bb`](https://github.com/NixOS/nixpkgs/commit/c9fe41bb552bb7716772203c923532da2b6e1b14) stackit-cli: 0.60.0 -> 0.61.0
* [`59920d21`](https://github.com/NixOS/nixpkgs/commit/59920d2112af9b3b27be7c93dd283f4d01cf2d55) ssh-agent-switcher: 1.0.1 -> 1.0.2
* [`48c4d2d4`](https://github.com/NixOS/nixpkgs/commit/48c4d2d4efc313f6bf8126024e55a73f986b747d) t3code: init at 0.0.21
* [`280f56f0`](https://github.com/NixOS/nixpkgs/commit/280f56f085dcbb708cbcff72b64a06be81e659c0) python3Packages.rocketchat-api: 3.5.0 -> 3.6.0
* [`5383d773`](https://github.com/NixOS/nixpkgs/commit/5383d773342cde53d737823b05fded53affbcce2) libretro.stella: 0-unstable-2026-04-19 -> 0-unstable-2026-04-28
* [`d0f44206`](https://github.com/NixOS/nixpkgs/commit/d0f442061f92cc49e10d65ee8178e5f567be2617) vimPlugins.lsp-format-nvim: add license
* [`9c0a0e5e`](https://github.com/NixOS/nixpkgs/commit/9c0a0e5e37ac93208deaca2d66adaa1fef503c25) vimPlugins.tslime-vim: add license
* [`fde36b25`](https://github.com/NixOS/nixpkgs/commit/fde36b25946e046bcd23c948f3ce393d3da4759f) vimPlugins.beancount: add license
* [`04f876a7`](https://github.com/NixOS/nixpkgs/commit/04f876a701f3151c20311645c0eb1db540fef67b) vimPlugins.vim-easymotion: add license
* [`dad5ba16`](https://github.com/NixOS/nixpkgs/commit/dad5ba165ca15b039c13dc2395802d4720396685) vimPlugins.vim-indentwise: add license
* [`3cb74e8d`](https://github.com/NixOS/nixpkgs/commit/3cb74e8d93c3616f6a34a201f13f1e240c5399fb) vimPlugins.textobj-user: add license
* [`0d325fa3`](https://github.com/NixOS/nixpkgs/commit/0d325fa38b46a85eed4f838f140c5fcbd44b9680) vimPlugins.vis: add license
* [`7ec96e54`](https://github.com/NixOS/nixpkgs/commit/7ec96e5447d8c36f8997b9da70f404884d1af99d) textcompare: 0.1.10 -> 0.1.11
* [`67ab3249`](https://github.com/NixOS/nixpkgs/commit/67ab3249abec550afd510cbe5cd717e4d3a7b4ab) postgresqlPackages.timescaledb-apache: 2.26.3 -> 2.26.4
* [`4ce887d8`](https://github.com/NixOS/nixpkgs/commit/4ce887d890479772d40de9e1a96039ec76813d4a) home-assistant-custom-lovelace-modules.atomic-calendar-revive: 10.2.0 -> 10.2.2
* [`5fa55f7c`](https://github.com/NixOS/nixpkgs/commit/5fa55f7cea5548a2a4776795c2f83c650f03074f) python3Packages.pysequoia: 0.1.32 -> 0.1.33
* [`81b8f80a`](https://github.com/NixOS/nixpkgs/commit/81b8f80a01381057c5b11080e834cbe8faa4a45d) picoc: Fix gcc15 build
* [`f2f38721`](https://github.com/NixOS/nixpkgs/commit/f2f38721c2a20bf67a3bc2e9e2c5e7250a48a83d) roon-server: 2.64.1646 -> 2.65.1653
* [`b50b89b4`](https://github.com/NixOS/nixpkgs/commit/b50b89b477f366a4c4bc0e5a9684b54dd478af6d) dms-shell: 1.4.5 -> 1.4.6
* [`bc46c219`](https://github.com/NixOS/nixpkgs/commit/bc46c21915bc26494a14f305b935c73cbc46955a) python3Packages.openapi-core: 0.23.0 -> 0.23.1
* [`1df90553`](https://github.com/NixOS/nixpkgs/commit/1df9055327d255bffe8ecff1c72471c368daa6eb) boinc: 8.2.10 -> 8.2.11
* [`83fdcdf6`](https://github.com/NixOS/nixpkgs/commit/83fdcdf676eb233d0e635c54bbb6d53098459128) tree: 2.3.1 -> 2.3.2
* [`bea63d7a`](https://github.com/NixOS/nixpkgs/commit/bea63d7aaeec54aebc36a132d002164e82b4d86f) nu_scripts: 0-unstable-2026-04-18 -> 0-unstable-2026-04-27
* [`7b52e503`](https://github.com/NixOS/nixpkgs/commit/7b52e503cc62324d93751f9bb97ece358c4d362a) thunderbird-latest-bin-unwrapped: 149.0.2 -> 150.0
* [`13cd7008`](https://github.com/NixOS/nixpkgs/commit/13cd7008d96673f8a4d866ff5f346c75352c84f7) tcld: 0.41.0 -> 0.55.0
* [`9ca02a9a`](https://github.com/NixOS/nixpkgs/commit/9ca02a9a62db9e1153840c2f40d3688f2ceb78ce) librewolf-unwrapped: 150.0-1 -> 150.0.1-1
* [`ab29a4e2`](https://github.com/NixOS/nixpkgs/commit/ab29a4e2e42264532edc5ed45a95cfff7a53a19e) ocamlPackages.yamlx: 0.1.0 → 0.3.0
* [`6e7a99d8`](https://github.com/NixOS/nixpkgs/commit/6e7a99d8a4c5b3c2baca6b770b29189b9add18d9) python3Packages.fastmcp: 2.14.5 -> 3.2.3
* [`4782412c`](https://github.com/NixOS/nixpkgs/commit/4782412c31257713cd2f9f479e9c5a0f630dd0e9) ha-mcp: 6.7.1 -> 7.3.0
* [`406eb95d`](https://github.com/NixOS/nixpkgs/commit/406eb95d5de4444af1c038d19189aad0567f7f05) home-assistant-custom-components.ha_mcp_tools: 7.2.0 -> 7.3.0
* [`d2c23304`](https://github.com/NixOS/nixpkgs/commit/d2c233044de70f0932784687bcabba6349d35f3f) mcp-nixos: 2.3.1 -> 2.4.3
* [`f3463053`](https://github.com/NixOS/nixpkgs/commit/f3463053c54c93acbf65c9efaa233a526494830c) qalculate-gtk: add 2 semantic spacings
* [`9d92cbe4`](https://github.com/NixOS/nixpkgs/commit/9d92cbe427032331b77d3b4b09c008765d19adc7) qalculate-gtk: fix darwin build
* [`340a9621`](https://github.com/NixOS/nixpkgs/commit/340a962145c25d0785ba53305edfd99d23b8f9fe) ocamlPackages.digestif: drop postCheck
* [`070d240e`](https://github.com/NixOS/nixpkgs/commit/070d240eb98688981be614e133b23aadead5f2cd) ocamlPackages.httpcats: drop (implicit) dependency on rresult
* [`6c568f32`](https://github.com/NixOS/nixpkgs/commit/6c568f32a5db7f18612e2c47b1763340de391702) ocamlPackages.bos: 0.2.1 → 0.3.0
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
