### PR TITLE
npins home-manager: update c1140540 -> a89686d1

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -61,9 +61,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "c1140540536d483e2730320100f6835d62c94fdf",
-      "url": "https://github.com/nix-community/home-manager/archive/c1140540536d483e2730320100f6835d62c94fdf.tar.gz",
-      "hash": "sha256-PGKgo2dO6fK603QGI+DWXdKmS09pbJjjTxwRHdhkGZA="
+      "revision": "a89686d115e970e200eb2caa7603f3673050e00c",
+      "url": "https://github.com/nix-community/home-manager/archive/a89686d115e970e200eb2caa7603f3673050e00c.tar.gz",
+      "hash": "sha256-4MwfrGuqjsnEORQbM3cmkmG/9cWhDV63dTDguDj4FXw="
     },
     "hs-grille": {
       "type": "Git",


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@c1140540...a89686d1](https://github.com/nix-community/home-manager/compare/c1140540536d483e2730320100f6835d62c94fdf...a89686d115e970e200eb2caa7603f3673050e00c)

* [`79f8430e`](https://github.com/nix-community/home-manager/commit/79f8430e7d3fb61f947971432fd2527d591df4c7) restic: unset systemd `PrivateTmp` option
* [`dd6a8772`](https://github.com/nix-community/home-manager/commit/dd6a8772d4faa9627fd342342c77b0afca59eba3) qalculate: add autocalc to the example
* [`4f77c535`](https://github.com/nix-community/home-manager/commit/4f77c535e06fdb6a91d576dd465bb0d1d865b5ae) thunderbird: html signature support
* [`98213962`](https://github.com/nix-community/home-manager/commit/982139628581c309b6a25c55deed564b546ebf74) thunderbird: add msg filter rules description
* [`8ec5a714`](https://github.com/nix-community/home-manager/commit/8ec5a714dbbeb3fda00bd9758175555ebbad4d07) rofi: allow list values in extraConfig
* [`ae6aeb9d`](https://github.com/nix-community/home-manager/commit/ae6aeb9dbce75c2f2f262eb1adc6971046ccaf64) thunderbird: map account auth methods
* [`c2f07e2d`](https://github.com/nix-community/home-manager/commit/c2f07e2dca4ca9426446578921474921b4275109) thunderbird: default office365 to oauth2
* [`c3571827`](https://github.com/nix-community/home-manager/commit/c3571827078769e4ae4cc4612385c01c38d608d1) thunderbird: support ews accounts
* [`b1b08eea`](https://github.com/nix-community/home-manager/commit/b1b08eeaff1bb794b0deeea54c6749b1e15ca910) thunderbird: clarify external gnupg
* [`af59809e`](https://github.com/nix-community/home-manager/commit/af59809e9413ec8adb9597a8636491af356fe525) thunderbird: add language packs and policies
* [`d3b4e4b1`](https://github.com/nix-community/home-manager/commit/d3b4e4b1bd59aedd3d4eb0a8df7162edb6da4607) services.walker: fix paths for walker v2
* [`8c8e5389`](https://github.com/nix-community/home-manager/commit/8c8e5389e75a36bee53920de8ee24f017b3ae03e) tldr-update: add dependency on network-online
* [`f92e976f`](https://github.com/nix-community/home-manager/commit/f92e976f404151b818da26a00acde5328095798a) maintainers: add ojsef39
* [`503480e5`](https://github.com/nix-community/home-manager/commit/503480e51357c7beca8c19bde560af1491a372d0) github-copilot-cli: add module
* [`7a45713b`](https://github.com/nix-community/home-manager/commit/7a45713b5df3f7225c6c22b139bb3d3b82aae04b) maintainers: add dsqr
* [`2e54a938`](https://github.com/nix-community/home-manager/commit/2e54a938cdd4c8e414b2518edc3d82308027c670) exo: add module
* [`899c08a1`](https://github.com/nix-community/home-manager/commit/899c08a15beae5da51a5cecd6b2b994777a948da) github-copilot-cli: fix mcp integration
* [`e6613dd6`](https://github.com/nix-community/home-manager/commit/e6613dd625122fa1d545611805859ee1d8cdd467) codex: keep managed skills under CODEX_HOME
* [`f92dc916`](https://github.com/nix-community/home-manager/commit/f92dc91642acc19f0c4e17cbdb8699f2d9578e24) Translate using Weblate (Arabic)
* [`94db0286`](https://github.com/nix-community/home-manager/commit/94db02863273736b57b9dcb1b5c4e873705c64c0) Translate using Weblate (French)
* [`d181e6ac`](https://github.com/nix-community/home-manager/commit/d181e6ac2ad01e50c914220d7478fed50b1dbf68) treewide: support store path strings for skills dirs
* [`9a3efa07`](https://github.com/nix-community/home-manager/commit/9a3efa079c3a91567c4bedeadc9a58f47244ef4b) maintainers: update all-maintainers.nix
* [`feda4150`](https://github.com/nix-community/home-manager/commit/feda41500ec53fcd4e3131de7b0441bce08fd3e9) github-copilot-cli: add context, agents, and skills
* [`edf3f599`](https://github.com/nix-community/home-manager/commit/edf3f59954f4ea31bfb08d09f5c2a392286ce2f6) github-copilot-cli: add lsp server support
* [`d955574e`](https://github.com/nix-community/home-manager/commit/d955574ea4f371988c658027ed02eab4fc6a5cd8) keynav: add configuration option
* [`5c1b7490`](https://github.com/nix-community/home-manager/commit/5c1b74905c7261e8280dcda3623dbe677a1bc158) keynav: add tests
* [`9cb587ad`](https://github.com/nix-community/home-manager/commit/9cb587ade2aa1b4a7257f0238d41072690b0ca4f) launchd: use bootout --wait to wait for the service to stop
* [`7c28dd52`](https://github.com/nix-community/home-manager/commit/7c28dd52cb15a106cc358ec8fbfad707b99c74b4) macchina: fix palette spacing config being missing
* [`9ce9f7f1`](https://github.com/nix-community/home-manager/commit/9ce9f7f128c5834bb71a4f5c62232187371379b6) shell: support boolean sessionVariables
* [`beae317d`](https://github.com/nix-community/home-manager/commit/beae317ddb6a36e2a5a2b00653d8cb970c64c67a) foot: configurable systemd target
* [`a53beb63`](https://github.com/nix-community/home-manager/commit/a53beb6353dab9f839b8f65d212841fb4b15ee94) foot: require WAYLAND_DISPLAY env var
* [`561bd674`](https://github.com/nix-community/home-manager/commit/561bd674646db26ebfccc79b4fbef89f335505db) wlsunset: require WAYLAND_DISPLAY env var
* [`0379e433`](https://github.com/nix-community/home-manager/commit/0379e433a85184be523f98ffd1715d0fb4320bc9) delta: configure as pager for git blame
* [`fdf4d549`](https://github.com/nix-community/home-manager/commit/fdf4d549ed5d90b3c4b89b7f1e32d27eb45df04e) flake: bump nixpkgs from `68d8aa3` to `1c3fe55`
* [`7229dde6`](https://github.com/nix-community/home-manager/commit/7229dde629a635d38c5f79d252d5b22867dfd81e) tests/vicinae: stub extensions
* [`1e313820`](https://github.com/nix-community/home-manager/commit/1e313820a346eb9bd8cef30f8b26e90187b7734b) treewide: adapt toml generator changes
* [`b4b920d9`](https://github.com/nix-community/home-manager/commit/b4b920d9ecb7725d4f4cf4290e6e9551820f46c8) tests/lutris: stub packages
* [`9c9fc936`](https://github.com/nix-community/home-manager/commit/9c9fc9368a6d9e698d03d3780d3b930ebc060334) tests/anki: stub packages
* [`b9311028`](https://github.com/nix-community/home-manager/commit/b9311028044a9e9b2cf27db15ef0a87d464e212d) rclone: add serve options
* [`b5e86c1b`](https://github.com/nix-community/home-manager/commit/b5e86c1b19f178a8ee10f7cb747325e02e3d3991) treewide: remove network-online.target
* [`4625f262`](https://github.com/nix-community/home-manager/commit/4625f26228f4f7ea3cf65eee3023359a8221fcff) neovim: Support configuring plugins using Fennel
* [`f02e422b`](https://github.com/nix-community/home-manager/commit/f02e422b3ed060b7aca83c27391326f1208a7152) man: add mandoc and man-db option
* [`7914f8d7`](https://github.com/nix-community/home-manager/commit/7914f8d7d7948b5c217ccf8ba59b7004f085795d) tests/man: add tests for man-db/mandoc
* [`1b4806c5`](https://github.com/nix-community/home-manager/commit/1b4806c50b2cb337083b35962d960340c6a1c85a) news: add news entry for programs.man.{man-db,mandoc}
* [`71ad4614`](https://github.com/nix-community/home-manager/commit/71ad461413b8ee86f7a616014b3febb270a6ad0f) man-db: add assertion for man.man-db.extraConfig when man.generateCaches is false
* [`26412a22`](https://github.com/nix-community/home-manager/commit/26412a220b7da23fe5c419716ae81c47753c33f1) vscode: extract mkVscodeModule factory function
* [`80ab64bb`](https://github.com/nix-community/home-manager/commit/80ab64bb796a89c6e73056fb98381c18c0a76d73) vscode: add dedicated modules for VSCode forks
* [`c909892d`](https://github.com/nix-community/home-manager/commit/c909892de502b4de9e92838a503c09a9c8ebe4aa) vscode: warn when package is a known fork and remove `pname` option
* [`9c6f1307`](https://github.com/nix-community/home-manager/commit/9c6f1307e1d76a2285d8001e1b8bc281bfe15dac) kitty/fix-git-integration: fix typo trustExistCode -> trustExitCode
* [`fb6a0c6d`](https://github.com/nix-community/home-manager/commit/fb6a0c6d398179f746ac6636d1acdf757e19eded) modules: add modular services support
* [`d6c1bb35`](https://github.com/nix-community/home-manager/commit/d6c1bb355fe57e5660704bb274e0ea5357f5a154) maintainers: update all-maintainers.nix
* [`e70904b3`](https://github.com/nix-community/home-manager/commit/e70904b3af1d362da9de52023f9f661e78c5db53) docs: clarify update and upgrade workflows
* [`c3387b41`](https://github.com/nix-community/home-manager/commit/c3387b41c96033eb22ed1ab4202483ed9da592d2) docs: document unstable packages with flakes
* [`938311a3`](https://github.com/nix-community/home-manager/commit/938311a3bde90dc1356e5c55f1fe864ce79d9bed) docs: clarify package overrides with flakes
* [`0ecfc72c`](https://github.com/nix-community/home-manager/commit/0ecfc72c7c882bdafe60fe3c5cdf58088801f2a2) docs: explain file collision handling
* [`a89686d1`](https://github.com/nix-community/home-manager/commit/a89686d115e970e200eb2caa7603f3673050e00c) git: avoid implicit signing config
