### PR TITLE
npins nerd-icons.el: update 3f6e8b36 -> ae1b85c4

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -112,9 +112,9 @@
       },
       "branch": "main",
       "submodules": false,
-      "revision": "3f6e8b36436d99659234d5bbbd84ba5c09282692",
-      "url": "https://github.com/rainstormstudio/nerd-icons.el/archive/3f6e8b36436d99659234d5bbbd84ba5c09282692.tar.gz",
-      "hash": "sha256-ihoQZ+9JOy6fmAiU1qFvk3CG5TvR2PIEa0r+YDqk0/Q="
+      "revision": "ae1b85c487c2b0bb1efb8bc0edc23af74282eec2",
+      "url": "https://github.com/rainstormstudio/nerd-icons.el/archive/ae1b85c487c2b0bb1efb8bc0edc23af74282eec2.tar.gz",
+      "hash": "sha256-3BLTL4Imncin4bG+jmFMzCgu1a8nWEObsovAV3woYkU="
     },
     "niv": {
       "type": "Git",


### PR DESCRIPTION
## Changelog for nerd-icons.el:
Branch: main
Commits: [rainstormstudio/nerd-icons.el@3f6e8b36...ae1b85c4](https://github.com/rainstormstudio/nerd-icons.el/compare/3f6e8b36436d99659234d5bbbd84ba5c09282692...ae1b85c487c2b0bb1efb8bc0edc23af74282eec2)

* [`27e86619`](https://github.com/rainstormstudio/nerd-icons.el/commit/27e86619c574aede034a5d575f347c221c92d57e) Add `tab-line-nerd-icons` to Related Packages
