### PR TITLE
npins niv: update 368268e4 -> e9519949

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -125,9 +125,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "368268e45dee0c94d1cf898381a384856379ad76",
-      "url": "https://github.com/nmattia/niv/archive/368268e45dee0c94d1cf898381a384856379ad76.tar.gz",
-      "hash": "sha256-w+vYrx0fx3ueBmeiZ4YPOY8YJ3lWl4iycN58VfGxA8w="
+      "revision": "e9519949d2b39bc9574b10f6ba216d65f014874e",
+      "url": "https://github.com/nmattia/niv/archive/e9519949d2b39bc9574b10f6ba216d65f014874e.tar.gz",
+      "hash": "sha256-6JhsgP7MYv00Y3V7E8jEP5PfO+8AgAOnmGAAr2k6Y9c="
     },
     "nixpkgs": {
       "type": "Channel",


### PR DESCRIPTION
## Changelog for niv:
Branch: master
Commits: [nmattia/niv@368268e4...e9519949](https://github.com/nmattia/niv/compare/368268e45dee0c94d1cf898381a384856379ad76...e9519949d2b39bc9574b10f6ba216d65f014874e)

* [`e40217d3`](https://github.com/nmattia/niv/commit/e40217d319a6fb19bd106770df0209d88444ed84) Bump cachix/install-nix-action from 30 to 31 ([nmattia/niv⁠#418](https://togithub.com/nmattia/niv/issues/418))
* [`16977e16`](https://github.com/nmattia/niv/commit/16977e168fb17b23673370028716d075e6c5f773) Bump cachix/cachix-action from 15 to 17 ([nmattia/niv⁠#417](https://togithub.com/nmattia/niv/issues/417))
* [`e9519949`](https://github.com/nmattia/niv/commit/e9519949d2b39bc9574b10f6ba216d65f014874e) Bump actions/checkout from 4 to 6 ([nmattia/niv⁠#419](https://togithub.com/nmattia/niv/issues/419))
