### PR TITLE
npins nixpkgs: update 73c703c2 -> b3da6560

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -132,8 +132,8 @@
     "nixpkgs": {
       "type": "Channel",
       "name": "nixpkgs-unstable",
-      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-26.05pre991389.73c703c22422/nixexprs.tar.xz",
-      "hash": "sha256-bA5oJv7j54PubdUbBlLCwdoK29G2+9sLnc8dDqLQ9YE="
+      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-26.05pre994919.b3da656039dc/nixexprs.tar.xz",
+      "hash": "sha256-lMg7Dj7kyGN5cj9RGag5Is100HnQPKM9zEsuAOL2TLA="
     },
     "powerlevel10k": {
       "type": "Git",


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: release-26.05
Commits: [nixos/nixpkgs@73c703c2...b3da6560](https://github.com/nixos/nixpkgs/compare/73c703c22422...b3da656039dc)

* [`a2cd0a2c`](https://github.com/NixOS/nixpkgs/commit/a2cd0a2cf7ea53ec71fd799c0e132acb09429a91) nixos-containers: allow hard-coding container veth MAC address
* [`dee54f29`](https://github.com/NixOS/nixpkgs/commit/dee54f2955af81786400208973d751f4b0c741e6) nixos/tests: add test for NixOS container using IPv6 SLAAC
* [`22f19b99`](https://github.com/NixOS/nixpkgs/commit/22f19b998281032b29dbb3f6f368870429a66d32) nixos/btrbk: add extraArgs option
* [`66584745`](https://github.com/NixOS/nixpkgs/commit/66584745cbfe51aafb2503254751722d04c58572) python3Packages.jobspy: 1.1.79 -> 1.1.82
* [`917556e8`](https://github.com/NixOS/nixpkgs/commit/917556e83426ce86f0e31c25f880ae84df28a0ed) intel-media-sdk: Disable tests
* [`7c416174`](https://github.com/NixOS/nixpkgs/commit/7c41617446828fa232699bec630ff5a831f1efc8) maintainers: add panakotta00
* [`3ca354a9`](https://github.com/NixOS/nixpkgs/commit/3ca354a905b39552bceac7596ac2d002164b1bed) python3Packages.feedparser: clean up
* [`a8442bd3`](https://github.com/NixOS/nixpkgs/commit/a8442bd3b7b3be9ef7eb05193bf70b3ccf937744) nixos/lldap: harden systemd service
* [`121ce67b`](https://github.com/NixOS/nixpkgs/commit/121ce67bf8adfd01f8abed732a7657a816811aca) htgettoken: prefix instead of set for PYTHONPATH
* [`9c617714`](https://github.com/NixOS/nixpkgs/commit/9c61771437e20bf4f86e40de33ae7e4bba16615d) evolution-ews: 3.58.2 -> 3.58.3
* [`519be18d`](https://github.com/NixOS/nixpkgs/commit/519be18d9af75ae6a51b36f6afc8aaa3513d1a7a) material-maker: 1.3 -> 1.5
* [`5c7798fe`](https://github.com/NixOS/nixpkgs/commit/5c7798fe3057f3d94b6c12b425af736a0e3e1733) coredns: fix externalPlugins
* [`3edc0096`](https://github.com/NixOS/nixpkgs/commit/3edc00967576da20e32eeb2676da574429c3fd31) aqbanking: 6.8.1 -> 6.9.1
* [`0cd6144a`](https://github.com/NixOS/nixpkgs/commit/0cd6144a2cb7cc9925ecd0818fdd3672df52cf09) niftyreg: 1.3.9 -> 2.0.0
* [`b0d4f07f`](https://github.com/NixOS/nixpkgs/commit/b0d4f07f60ce9ba0eaf0af9f980758a624638d8e) nixos/sunshine: use hardware.uinput.enable
* [`5c59cf26`](https://github.com/NixOS/nixpkgs/commit/5c59cf26bbfe0f6753414344de54ed1021bbae33) poptracker: don't restrict to x86_64-linux
* [`d201b90a`](https://github.com/NixOS/nixpkgs/commit/d201b90a5ef38ebc634d14b76611123a451a41ce) castxml: 0.6.13 -> 0.7.0
* [`1acb3d5a`](https://github.com/NixOS/nixpkgs/commit/1acb3d5a3a2cc52bd4d91425a3cbc4ee4721994f) anilibria-winmaclinux: 2.2.34 -> 2.2.35
* [`764dfbc5`](https://github.com/NixOS/nixpkgs/commit/764dfbc538ee2d1723e4f7c4cfbf041fe33fa2db) python3Packages.maestral, maestral-qt: set updateScript
* [`420c60f6`](https://github.com/NixOS/nixpkgs/commit/420c60f61ab5f39a88f6d7b90408e1dcfd1d47f8) dupeguru: migrate to pkgs/by-name
* [`012ca49b`](https://github.com/NixOS/nixpkgs/commit/012ca49b73329916ea8e5b1dc5b14809c3d090e8) dupeguru: update licence from bsd to gplv3
* [`16c7b8cd`](https://github.com/NixOS/nixpkgs/commit/16c7b8cd98c8548a5233d2116c09077c0afec8be) dupeguru: 4.3.1 -> 4.3.1-unstable-2026-01-06
* [`1b67fe9e`](https://github.com/NixOS/nixpkgs/commit/1b67fe9e5a4bd201e5a5bf7c198cf812495f4e85) dupeguru: modernise
* [`37ab0d56`](https://github.com/NixOS/nixpkgs/commit/37ab0d560ef8fa12d79df54e7b48aa45d49df433) dupeguru: ensure documentation is built
* [`8e34c54e`](https://github.com/NixOS/nixpkgs/commit/8e34c54e06ba585d39d2a2eaae6c733b96a4e24d) dejavu_fonts: match description to actual font names
* [`21992f81`](https://github.com/NixOS/nixpkgs/commit/21992f8177db733f8a184f1f5bf5c694b23096f4) python3Packages.pecan: 1.7.0 -> 1.8.0
* [`b21b0ab6`](https://github.com/NixOS/nixpkgs/commit/b21b0ab66bd0532ae776b349519cffdf20aaf3fa) libamplsolver: 20211109 -> 1.0.1
* [`065b2caa`](https://github.com/NixOS/nixpkgs/commit/065b2caa5d052c9d71ebc7459579a2d8bc993673) libkrun-efi: symlink libkrun-efi.dylib -> libkrun.dylib in output
* [`4b61b6c2`](https://github.com/NixOS/nixpkgs/commit/4b61b6c206b189706e46c81851f65a1478129ae8) krunkit: 1.1.1 -> 1.2.1
* [`0c7cc1e3`](https://github.com/NixOS/nixpkgs/commit/0c7cc1e38ca340aacfa73db88a6bb17b13481cae) librealsense-gui: 2.56.3 -> 2.57.7
* [`2a564467`](https://github.com/NixOS/nixpkgs/commit/2a564467d5dadf22ebabef4d377c5255af6c107e) gnome-extensions-cli: 0.10.8 -> 0.11.0
* [`c8e2dee2`](https://github.com/NixOS/nixpkgs/commit/c8e2dee28379778d275a8cc9684c0faeceb790ba) ctx7: init at 0.3.9
* [`75165c32`](https://github.com/NixOS/nixpkgs/commit/75165c323040c8008ba9fe1eeae5f8e691953891) {python3Packages.,}catboost: 1.2.7 -> 1.2.10
* [`d4820717`](https://github.com/NixOS/nixpkgs/commit/d48207170337e6b92bd48e90f6e7079735776d22) flaca: 3.5.3 -> 3.6.1
* [`23369557`](https://github.com/NixOS/nixpkgs/commit/233695570c89d30964c1ef7789c96bed209dcce4) busybox: add patch to fix syslogd local logging
* [`d6f46e60`](https://github.com/NixOS/nixpkgs/commit/d6f46e60b01ed28b3f333566b05b21770a61b593) python313Packages.torchio: 0.21.2 -> 1.0.1
* [`a4f37707`](https://github.com/NixOS/nixpkgs/commit/a4f377070abcf10e029657038abdaa8357ba445b) fetchmail: 6.6.2 -> 6.6.3
* [`f7ad9a49`](https://github.com/NixOS/nixpkgs/commit/f7ad9a49d3d681ac75d37c8b0265e5b4d34e0589) tdarr: add missing packages to build and path
* [`fd7d2abb`](https://github.com/NixOS/nixpkgs/commit/fd7d2abb2139638a72d999f05aff417d4faf579b) aws-cdk-cli: 2.1104.0 -> 2.1116.0
* [`228cc9cb`](https://github.com/NixOS/nixpkgs/commit/228cc9cbfc950e21ff92682f69469597a04b7c30) wails: 2.11.0 -> 2.12.0
* [`bf90ee24`](https://github.com/NixOS/nixpkgs/commit/bf90ee240334f2348c8bcbab5c654c186ca8f192) lovely-injector: 0.8.0 -> 0.9.0
* [`693565f5`](https://github.com/NixOS/nixpkgs/commit/693565f5b05daa9706727c34a8a305e9696c1ff1) atool: add desktop item for aunpack
* [`7b24fb81`](https://github.com/NixOS/nixpkgs/commit/7b24fb817ad7b2ab1f1609fbb12e40b42063dfac) octodns-providers.cloudflare: 1.0.0 -> 1.1.0
* [`e6d25f13`](https://github.com/NixOS/nixpkgs/commit/e6d25f13f255455c0416985d6eb6a5dc19efced9) python3Packages.django-lasuite: 0.0.23 -> 0.0.26
* [`65fac803`](https://github.com/NixOS/nixpkgs/commit/65fac803f61a14ec924bdef522b769b98679ed9a) python3Packages.pricehist: move from 'pkgs/by-name'
* [`736d3135`](https://github.com/NixOS/nixpkgs/commit/736d313569786068bbcebd11a1cd058050af5500) newflasher: init at 59
* [`8ea4f3c2`](https://github.com/NixOS/nixpkgs/commit/8ea4f3c2cc818fe0406027ae8e1f5faaf3c0ca1c) prichehist: use 'toPythonApplication'
* [`1be23a24`](https://github.com/NixOS/nixpkgs/commit/1be23a24b242c38fc03a78a6cc509f39d6239659) kbdd: unstable-2021-04-26 -> unstable-2025-08-10
* [`078aa6be`](https://github.com/NixOS/nixpkgs/commit/078aa6be34523923038c31b6d9a8f837ac28d788) python313Packages.afdko: remove ~65 MB of unnecessary tests, cache and source code
* [`8a43395e`](https://github.com/NixOS/nixpkgs/commit/8a43395eaf2064129bde4de1b69f43e09b303971) affine: 0.26.4 -> 0.26.6
* [`b6d691ad`](https://github.com/NixOS/nixpkgs/commit/b6d691ad1af680fc89f60b68ee61df0b6a6c9935) haxe: 4.3.6 -> 4.3.7
* [`2ca0abd7`](https://github.com/NixOS/nixpkgs/commit/2ca0abd7eccc13d25e8aa26a96e0148128c63c0e) your_spotify: 1.16.0 -> 1.19.0
* [`38e335db`](https://github.com/NixOS/nixpkgs/commit/38e335db8a7db1d05e0c85ae12f4920cd36cc5ae) bio-gappa: fix build with gcc15
* [`0899677a`](https://github.com/NixOS/nixpkgs/commit/0899677a019803ba66dd8cdf43fc44fb30f46087) iqueue: drop
* [`0570bc97`](https://github.com/NixOS/nixpkgs/commit/0570bc976739a495a3270eb8b84fe55fea80bf47) rimsort: 1.0.73 -> 1.0.76, add update script
* [`663fd4ec`](https://github.com/NixOS/nixpkgs/commit/663fd4ec34f90ad88fa2ee44f2276cd60224a3c5) libgpiod: 2.2.2 -> 2.2.4
* [`0b7034c1`](https://github.com/NixOS/nixpkgs/commit/0b7034c1429eb09a790c19bb7a60bd7219c4c850) bookstack: 25.12.8 -> 26.03.3
* [`484beba6`](https://github.com/NixOS/nixpkgs/commit/484beba690c35ce7783cabd7abd84b38fb436e33) cyclone-scheme: fix build with GCC 15
* [`f8a7f3e3`](https://github.com/NixOS/nixpkgs/commit/f8a7f3e34c848b9f6c76aab9f5bb2ed57a13f634) zoom-us: 6.7.5.6891 -> 7.0.0.1666
* [`ac8206b0`](https://github.com/NixOS/nixpkgs/commit/ac8206b020529fd1acd463c89633e1215cae44dd) zoom-us: drop maintainer yarny (=myself)
* [`64e18cc0`](https://github.com/NixOS/nixpkgs/commit/64e18cc08059588ba555843de98e33ce51fa72ca) kakoune: 2025.06.03 -> 2026.04.12
* [`eaffed94`](https://github.com/NixOS/nixpkgs/commit/eaffed94dbc410ba6009a84003d283031a3a5496) krita-unwrapped: 6.0.0 -> 6.0.1
* [`ce430e4d`](https://github.com/NixOS/nixpkgs/commit/ce430e4d510a4f9ae7ad97640e2a2f3826a96666) python3Packages.arxiv: 2.4.1 -> 3.0.0
* [`95dfeb4d`](https://github.com/NixOS/nixpkgs/commit/95dfeb4d974add75751b5df4dd6bc69e596ea66f) libhandy: enable strictDeps
* [`19967f20`](https://github.com/NixOS/nixpkgs/commit/19967f20e1a2744b551fd2457cc52578b8a4ce34) tauno-monitor: set meta.platforms
* [`01f58076`](https://github.com/NixOS/nixpkgs/commit/01f58076623191c532f28b792f878402c8e299f2) tauno-monitor: add passthru.updateScript
* [`994d0c7e`](https://github.com/NixOS/nixpkgs/commit/994d0c7ec6cb676b9486d6f5f605d0a89ea3245b) mbedtls_4: init at 4.1.0
* [`2458142b`](https://github.com/NixOS/nixpkgs/commit/2458142bb09e964902932cfe13a905d45ea3d4ef) regreet: 0.2.0 -> 0.3.0
* [`dd407a5e`](https://github.com/NixOS/nixpkgs/commit/dd407a5e58daa1c0e5f055fa09530d78f572c6c0) iio-niri: 1.3.0 -> 2.0.0
* [`1294a779`](https://github.com/NixOS/nixpkgs/commit/1294a77959ed2d7a7ac18c764447c1da2d465d2a) libinput: 1.29.2 -> 1.31.0
* [`6e0d2bd4`](https://github.com/NixOS/nixpkgs/commit/6e0d2bd48218119c73696653a5c1bb67a2e32b0b) libinput: 1.31.0 -> 1.31.1
* [`adcdb28c`](https://github.com/NixOS/nixpkgs/commit/adcdb28c450d26f23fb67832433fe3aba5b0d619) minimal-bootstrap: Honor config.contentAddressedByDefault
* [`29149282`](https://github.com/NixOS/nixpkgs/commit/29149282ff95203c5fcefaaaf421cc77a54f005c) python3Packages.asyncinotify: 4.4.0 -> 4.4.4
* [`a6655085`](https://github.com/NixOS/nixpkgs/commit/a665508586a2b94d89294de130bf4fa37596d555) qemu-guest: Add virtiofs
* [`39bb28ca`](https://github.com/NixOS/nixpkgs/commit/39bb28cac5e1d55dc7e764f7b53a4e8e1c10a428) nixos/tests/machinectl: Remove virtiofs
* [`fd419db8`](https://github.com/NixOS/nixpkgs/commit/fd419db8f863f934d9746cc2975f033d30cbb15e) lessc: 4.2.2 -> 4.6.3
* [`2907e0a3`](https://github.com/NixOS/nixpkgs/commit/2907e0a3f832af9167b70521b4b5f79731fb9475) andcli: add passthru.updateScript
* [`2088e670`](https://github.com/NixOS/nixpkgs/commit/2088e670576636c35b71c50042a7a2d365b6b558) imapgoose: 0.5.0 -> 0.5.2
* [`673ff919`](https://github.com/NixOS/nixpkgs/commit/673ff919b040629533ebb4a2352c13e858cac9bc) dillo-plus: fix build with gcc15
* [`d28c93ea`](https://github.com/NixOS/nixpkgs/commit/d28c93eaa5ff204debd73bef6669539aa12f678b) libsForQt5.maplibre-native-qt: fix build with gcc15
* [`950e64cb`](https://github.com/NixOS/nixpkgs/commit/950e64cb40220ec384bc795d16e159f2be23cefb) libsForQt5.maplibre-gl-native: drop
* [`b5b050d1`](https://github.com/NixOS/nixpkgs/commit/b5b050d1274e70bc51a6291eae518bd816336eba) firefoxpwa-unwrapped: 2.18.0 -> 2.18.2
* [`a9068e40`](https://github.com/NixOS/nixpkgs/commit/a9068e40732b39e3f014da37e4355806abb343ab) mrustc: 0.11.2 -> 0.12.0
* [`320df88c`](https://github.com/NixOS/nixpkgs/commit/320df88cd7fc4369530784edab0c070e4f349382) python3Packages.airthings-cloud: 0.2.0 -> 0.3.0
* [`46b7ed6a`](https://github.com/NixOS/nixpkgs/commit/46b7ed6a9d49a6b45cd226cc012dd4413cc5493e) ytalk: fix build with gcc15
* [`efad3589`](https://github.com/NixOS/nixpkgs/commit/efad35892a29939a57925e362eeb8314de204dfc) parted: cleanup
* [`8ff2d24c`](https://github.com/NixOS/nixpkgs/commit/8ff2d24cd67d431bdb0c5dec7dd81ccb73f255e3) qboot: 20200423 -> 20220919; nixos/tests/qboot: switch from deprecated handleTestOn to runTestOn
* [`81b61ada`](https://github.com/NixOS/nixpkgs/commit/81b61ada960b8fe244c8ec8219b418a5626b108c) yersinia: fix build with gcc15
* [`a5789507`](https://github.com/NixOS/nixpkgs/commit/a5789507f570e33977d0df2bfccd975db2133339) yasr: fix build with gcc15
* [`bf216b7b`](https://github.com/NixOS/nixpkgs/commit/bf216b7bc5452906a1d8f8eef79e883b3f0d4a80) xbyak: 7.36 -> 7.36.2
* [`f3b69f2a`](https://github.com/NixOS/nixpkgs/commit/f3b69f2a714843892605c70449c7db89bbb6b613) nixos/test-driver: colorized warnings
* [`47972071`](https://github.com/NixOS/nixpkgs/commit/479720717159c91bc9c1133328a8393367a3358b) nixos/test-driver: deprecate using `machine` variable when only VM has a different name
* [`69eb0ce7`](https://github.com/NixOS/nixpkgs/commit/69eb0ce7388df039603a161624155aed11ea8126) nixos/freetube: fix `machine` usage deprecation
* [`884b0970`](https://github.com/NixOS/nixpkgs/commit/884b0970ff60b31a16963d2507fce981d786e378) nixos/benchexec: fix `machine` usage deprecation
* [`42ae5b83`](https://github.com/NixOS/nixpkgs/commit/42ae5b83cba0a365ae2adcf9119e7781dd9e6911) nixos/drawterm: fix `machine` usage deprecation
* [`f311969b`](https://github.com/NixOS/nixpkgs/commit/f311969b39dc023167bdb6a9b81ad76f4220ae97) nixos/mympd: fix `machine` usage deprecation
* [`57774583`](https://github.com/NixOS/nixpkgs/commit/577745837ff1d0f25406eef1538bf5e903d5c63f) nixos/openresty-lua: fix `machine` usage deprecation
* [`f042b570`](https://github.com/NixOS/nixpkgs/commit/f042b57046e04a432e16708b7e01503078c2876b) nixos/paisa: fix `machine` usage deprecation
* [`3c26854e`](https://github.com/NixOS/nixpkgs/commit/3c26854ed0492e0f03c4d70652a5085502587f90) nixos/snmpd: fix `machine` usage deprecation
* [`516d8d69`](https://github.com/NixOS/nixpkgs/commit/516d8d69b02c2d59580cc02e6f621a9e9bcc74ed) nixos/tang: fix `machine` usage deprecation
* [`947ba1d6`](https://github.com/NixOS/nixpkgs/commit/947ba1d67b24cf632a182315bc46dc1cc9e6e70f) nixos/strichliste: fix `machine` usage deprecation
* [`5bb3e900`](https://github.com/NixOS/nixpkgs/commit/5bb3e900986fa7381cb29c82d8faccd870710eb8) nixos/windmill: fix `machine` usage deprecation
* [`6c4ee701`](https://github.com/NixOS/nixpkgs/commit/6c4ee70185bdeab8d6645d335e9c509ae1cf0de3) nixos/quickwit: fix `machine` usage deprecation
* [`fe3c437b`](https://github.com/NixOS/nixpkgs/commit/fe3c437b4a99a25d15c1af288c146190afa7c60d) nixos/systemd-journal-gateway: fix `machine` usage deprecation
* [`ee5465f4`](https://github.com/NixOS/nixpkgs/commit/ee5465f41a766d02da158d4a05b1895535833e2c) nixos/vscodium: fix `machine` usage deprecation
* [`20985100`](https://github.com/NixOS/nixpkgs/commit/20985100c41563eb427a475bfc383cf780b8e995) meteor: add passthru.updateScript
* [`7ee18fd7`](https://github.com/NixOS/nixpkgs/commit/7ee18fd77a4ace0d76520ac2e9c1d104d87d8176) meteor: 2.7.3 -> 3.4
* [`f7681805`](https://github.com/NixOS/nixpkgs/commit/f76818059636c59d0e78f544e57108a0e5088527) meteor: add hythera as maintainer
* [`1b7aa48a`](https://github.com/NixOS/nixpkgs/commit/1b7aa48aff10124a2535c86b68d0c9dbdd1a84e9) libplist: fix build on aarch64-darwin
* [`b0171edf`](https://github.com/NixOS/nixpkgs/commit/b0171edfa35ea5fc1553fedfdf1921e246f73c8c) python3Packages.python-lsp-server: fix build on x86_64-darwin
* [`dc32f1a2`](https://github.com/NixOS/nixpkgs/commit/dc32f1a22ae555691a93d67491b9a48d5b7897d2) dnsenum: 1.2.4.2 -> 1.3.2
* [`66e5611b`](https://github.com/NixOS/nixpkgs/commit/66e5611b2e4eb4b2adc211679447ddc5fd5db916) python3Packages.scikits-odes-daepack: fix build with gcc15
* [`1b291ded`](https://github.com/NixOS/nixpkgs/commit/1b291ded6f91b4f295185cdc80b87a1299ba6603) stremio-linux-shell: add `meta.sourceProvenance`
* [`46ebee95`](https://github.com/NixOS/nixpkgs/commit/46ebee95a84c01b2b1e60027ba3f4eee9f21f943) stremio-linux-shell: use compound license
* [`5eeb49e1`](https://github.com/NixOS/nixpkgs/commit/5eeb49e1e22895758ae4fb8eed366e5ad0d7f029) stremio-linux-shell: enable `strictDeps` and `__structuredAttrs`
* [`efc12082`](https://github.com/NixOS/nixpkgs/commit/efc1208270723cd1c08d9334cb4167d58fe5a91d) python3Packages.hishel: 1.1.8 -> 1.1.10
* [`fe0787ab`](https://github.com/NixOS/nixpkgs/commit/fe0787ab283397ac3f6ea4204f0e6ec5577588c9) cockpit-zfs: 1.2.12-2 -> 1.2.16
* [`ae21f6c0`](https://github.com/NixOS/nixpkgs/commit/ae21f6c0b8ca1baa2c30781c18c8e814a5fa56ff) cockpit-zfs: add nix-update-script
* [`b2990a80`](https://github.com/NixOS/nixpkgs/commit/b2990a80704803f2434152f8b9c955693225bade) fzf-zsh-plugin: add update script
* [`3194a38d`](https://github.com/NixOS/nixpkgs/commit/3194a38dd28aea818ba7753b110ecd389fb93154) fzf-zfs-plugin: 1.0.0-unstable-2025-12-15 -> 1.0.0-unstable-2026-03-03
* [`73d44b26`](https://github.com/NixOS/nixpkgs/commit/73d44b2631ddf50ef031caeac5548b8b6e822528) jmc2obj: add updatescript
* [`744a1077`](https://github.com/NixOS/nixpkgs/commit/744a1077c9fa4483be03ac107f578a18d77cbd02) jmc2obj: 126 -> 128
* [`60c16a62`](https://github.com/NixOS/nixpkgs/commit/60c16a62a23c0adca67a6a6b61fafe7dedf85fd7) melos: use finallAttrs instead of let in
* [`b5dfa4a0`](https://github.com/NixOS/nixpkgs/commit/b5dfa4a061857d7bb210c7511350a2365498d4a0) melos: add update script
* [`131610c2`](https://github.com/NixOS/nixpkgs/commit/131610c27f8ebaa4c1d20b1bf7849a3a81389ce1) melos: 7.3.0 -> 7.4.1
* [`34760492`](https://github.com/NixOS/nixpkgs/commit/347604926dda4910b293009788596510a21c14fc) cockpit-zfs: fix cross-compilation
* [`be327308`](https://github.com/NixOS/nixpkgs/commit/be3273088cffe3b04fc03334120c0db955fa2c88) jmc2obj: use tag instead of rev
* [`cb39a7f7`](https://github.com/NixOS/nixpkgs/commit/cb39a7f717ba1efb53a4b5261673a1f1b41d3c11) cockpit-zfs: use postPatch phase instead of patchPhase
* [`55fa17cb`](https://github.com/NixOS/nixpkgs/commit/55fa17cbcb756273a64b0a814e20a4826b9570fb) python3Packages.scikits-odes: fix tests
* [`0a1a5629`](https://github.com/NixOS/nixpkgs/commit/0a1a562959adceaadc944dc579e62829a0946fa1) xskat: fix build with gcc15
* [`f463b268`](https://github.com/NixOS/nixpkgs/commit/f463b2681f9a387b7d6886e591714f945e215f7a) odoo18: 18.0.20250506 -> 18.0.20260420
* [`bb06eb42`](https://github.com/NixOS/nixpkgs/commit/bb06eb42a739eb965922a28297ea7820b0cce44c) maintainers: add Simon-Weij
* [`aa347d68`](https://github.com/NixOS/nixpkgs/commit/aa347d6855fab890b9199acb3271630a3f431e35) storrent: 0-unstable-2023-01-14 -> 0-unstable-2026-01-08
* [`d397d664`](https://github.com/NixOS/nixpkgs/commit/d397d664f5164d13bc62c83fef2482499072b0b5) structorizer: 3.32-34 -> 3.32-35
* [`26524263`](https://github.com/NixOS/nixpkgs/commit/26524263e0c4f15e32851f20e1951896f5aefa1b) ramalama: 0.18.0 -> 0.19.0
* [`2d72cc45`](https://github.com/NixOS/nixpkgs/commit/2d72cc4501f6aaec2ac76db6066fb27577147ec0) python3Packages.oslotest: 6.1.0 -> 6.1.1
* [`cf99afe0`](https://github.com/NixOS/nixpkgs/commit/cf99afe00bf14a6a43ee428483749bb3c99a2275) maintainers: add quio
* [`a9181314`](https://github.com/NixOS/nixpkgs/commit/a91813148989982e8e441a95e873cc17f28d8de8) rustup-toolchain-install-master: 1.10.0 -> 1.12.0
* [`684fdce3`](https://github.com/NixOS/nixpkgs/commit/684fdce34ee795b834501c72572cb9b8e1c464cf) wine-staging: 11.6 -> 11.7
* [`5defdff4`](https://github.com/NixOS/nixpkgs/commit/5defdff4eec7db1d5ff58c87078e84fa58cde64b) fusesoc: update license, adopt
* [`2dc5ad02`](https://github.com/NixOS/nixpkgs/commit/2dc5ad0227c3d074bfa1dbeb5a7d27d18adbe1ec) darkstat: 3.0.721 -> 3.0.722
* [`94247f28`](https://github.com/NixOS/nixpkgs/commit/94247f280e124e2da40d59b98d3f2d55e7ba5e02) wimboot: 2.8.0 -> 2.9.0
* [`da75c3d6`](https://github.com/NixOS/nixpkgs/commit/da75c3d6f94f291e98dee6f0b86fabe94b070a1f) python3Packages.harlequin-postgres: 1.3.0 -> 1.3.1
* [`42c0c0e6`](https://github.com/NixOS/nixpkgs/commit/42c0c0e6d4c4729932a02f542d502eff485e8512) virtualbox: 7.2.6 -> 7.2.8
* [`5b2253f1`](https://github.com/NixOS/nixpkgs/commit/5b2253f15eeb7106ebd08b106ee68993bee51206) python3Packages.azure-keyvault-certificates: 4.10.0 -> 4.11.0
* [`45969d9c`](https://github.com/NixOS/nixpkgs/commit/45969d9c68490b2e7bbe67cc7b45e6d26527c4b4) mysql-shell_8: 8.4.8 -> 8.4.9
* [`b331db8a`](https://github.com/NixOS/nixpkgs/commit/b331db8a380bc729ddcaba2f90e6f7aa1ccefef2) mysql-shell-innovation: 9.6.0 -> 9.7.0
* [`5009afab`](https://github.com/NixOS/nixpkgs/commit/5009afabcd245ade6d0b62829adb0df8b230a88c) mysql-shell_9: init at 9.7.0
* [`41022d99`](https://github.com/NixOS/nixpkgs/commit/41022d99893e657c01eb3cb2461dc38653da1e59) tiddlywiki: 5.3.8 -> 5.4.0
* [`5bf18b03`](https://github.com/NixOS/nixpkgs/commit/5bf18b033f3b40052a2176dcb317ec944580ab12) kubeshark: 52.10.3 -> 53.2.3
* [`f6c95045`](https://github.com/NixOS/nixpkgs/commit/f6c950452318f8200ce047cfa53e968b4d081840) kubeshark: add miniharinn to maintainers
* [`5d63225a`](https://github.com/NixOS/nixpkgs/commit/5d63225acaffd65d9320f21ddd90a10f18117a78) python3Packages.nbxmpp: 7.1.0 -> 7.2.0
* [`2d351f7b`](https://github.com/NixOS/nixpkgs/commit/2d351f7b2c4eae14c1b4408af008fd8300e43475) uif2iso: fix build with gcc15, fix version
* [`1ba513f3`](https://github.com/NixOS/nixpkgs/commit/1ba513f3a700ca72c7f030e9f618a221b9cc59d0) python3Packages.lazr-uri: 1.0.7 -> 1.0.8
* [`9114a731`](https://github.com/NixOS/nixpkgs/commit/9114a731a9c6b2b3bdf6865b7f6134bccc58afaf) python3Packages.ledger-bitcoin: 0.4.0 -> 0.4.1
* [`e388d898`](https://github.com/NixOS/nixpkgs/commit/e388d8988e581d46e912f3f961c66e388a670fc7) libmysqlconnectorcpp: 9.6.0 -> 9.7.0
* [`0b9676de`](https://github.com/NixOS/nixpkgs/commit/0b9676de7629d445235cadaaefda412cd21fc27d) postcss: 8.5.8 -> 8.5.10
* [`9276bc4e`](https://github.com/NixOS/nixpkgs/commit/9276bc4e1055345152edc3cabf15fc43f33ab1bc) charles: 5.0.3 -> 5.1
* [`0a7c96e0`](https://github.com/NixOS/nixpkgs/commit/0a7c96e0c45da5bb351ecbeacf9ab1a092b090b8) nomachine-client: 9.2.18_3 -> 9.4.14_1
* [`93148951`](https://github.com/NixOS/nixpkgs/commit/93148951d5e279035e38061bb47596da7a54a8d4) thc-secure-delete: fix build with gcc15
* [`b4b4dbf2`](https://github.com/NixOS/nixpkgs/commit/b4b4dbf2814f1eb13162009cc45a5552b9cd7abb) tmuxPlugins.tmux-toggle-popup: 0.4.4 -> 0.5.1
* [`cf73106e`](https://github.com/NixOS/nixpkgs/commit/cf73106ed4e8c470bba870bf4214a46865841cec) mullvad-vpn: 2025.14 -> 2026.1
* [`a89cb68f`](https://github.com/NixOS/nixpkgs/commit/a89cb68fee0532381188642fe321097780fea647) temporal-ui-server: 2.44.1 -> 2.49.1
* [`cbcbede8`](https://github.com/NixOS/nixpkgs/commit/cbcbede8e0aaf050406da3f7b5eaaf185da77f6b) config.nix: document `packageOverrides` and `perlPackageOverrides`
* [`2e870216`](https://github.com/NixOS/nixpkgs/commit/2e8702164bcd2688ff67ce008458cbb5d884562c) config.nix: add optional docPrefix
* [`f981cdbb`](https://github.com/NixOS/nixpkgs/commit/f981cdbb26d6492a4c829dd5899b088f19ac0a25) clouddrive2: 1.0.5 -> 1.0.6
* [`6b33c9dc`](https://github.com/NixOS/nixpkgs/commit/6b33c9dcfb21123b0337e00bac72965e6a14ba0f) nixseparatedebuginfod2: 1.0.1 -> 2.0.0
* [`2b7f24ee`](https://github.com/NixOS/nixpkgs/commit/2b7f24eeb87e8ed1df82d13f1b74347bd7f9d970) lib.licenses: add mpich2
* [`732cf8d4`](https://github.com/NixOS/nixpkgs/commit/732cf8d4e870c72f783082b8072e7e371f9d53bc) nixos/installation-cd-graphical-calamares-cosmic: init
* [`093591b5`](https://github.com/NixOS/nixpkgs/commit/093591b535e118553f4c37f1451d10bde141cdea) mpich: set license to mpich2
* [`31428cfa`](https://github.com/NixOS/nixpkgs/commit/31428cfafc1c1169893c285b44559ed19c522ef4) leptosfmt: add progrm_jarvis to maintainers
* [`0ad49a32`](https://github.com/NixOS/nixpkgs/commit/0ad49a328055804ac7ccb95b4d91becf81391f01) citrix-workspace: rewrite desktop launchers for wrapped binaries
* [`17ad7dfd`](https://github.com/NixOS/nixpkgs/commit/17ad7dfd9a159a05eb80505724ca0ecd4cf28bd7) qtpass: 1.4.0 -> 1.7.0
* [`a6f384cc`](https://github.com/NixOS/nixpkgs/commit/a6f384ccb31a7fe5f9b77988871dff960e5f990d) tla: drop
* [`416f5d00`](https://github.com/NixOS/nixpkgs/commit/416f5d002fd4c7c65bbfd2fe59294ce3153205b1) maintainers: add ranidspace
* [`9efb6e9d`](https://github.com/NixOS/nixpkgs/commit/9efb6e9d621d55fcbb9ba4c9ea0364d8074b1f11) tacacsplus: 4.0.4.28 -> 4.0.4.31
* [`59806f98`](https://github.com/NixOS/nixpkgs/commit/59806f98d9fba074bcef90aab71b3211cee16932) python3Packages.pyslurm: 25.11.1 -> 25.11.2
* [`a11ce20e`](https://github.com/NixOS/nixpkgs/commit/a11ce20ea6cbf97eea064bc9426e7fdd7d2ec2b9) nxdumpclient: init at 1.1.4
* [`059f30e8`](https://github.com/NixOS/nixpkgs/commit/059f30e89e56967b0507038a096cf6be66d24896) nixos/programs/nxdumpclient: init
* [`1a1a59d2`](https://github.com/NixOS/nixpkgs/commit/1a1a59d28f59a7e0edb8ae98990ed4ab04dbcffa) python3Packages.aiousbwatcher: 1.1.1 -> 1.1.2
* [`a7eee90e`](https://github.com/NixOS/nixpkgs/commit/a7eee90e6d15269df7b1f3f8c1bba2657008e997) nxdumpclient: add strictDeps and __structuredAttrs
* [`2d25c021`](https://github.com/NixOS/nixpkgs/commit/2d25c021ce8896c4ac07d58e9e317bdad7d3d0ea) vowpal-wabbit: 9.10.0 -> 9.11.2
* [`b1a13cc8`](https://github.com/NixOS/nixpkgs/commit/b1a13cc8a40e764ba11c0638ebe783938ef6fdef) tecoc: fix build with gcc15
* [`46478989`](https://github.com/NixOS/nixpkgs/commit/46478989e33507c5895d44d5b6c42e2a5693cace) sqlit-tui: 1.3.1.1 -> 1.4.0
* [`5dd46c1f`](https://github.com/NixOS/nixpkgs/commit/5dd46c1f1f65573cad888d5a95abfa53f42d8af8) python3Packages.eccodes: 2.44.0 -> 2.47.0
* [`fa449138`](https://github.com/NixOS/nixpkgs/commit/fa449138f1b48d3f47610c7ac94b031d53ab4588) chuck: 1.5.5.6 -> 1.5.5.8
* [`b3ff8fc9`](https://github.com/NixOS/nixpkgs/commit/b3ff8fc96799851d93c6fa2f753424aa406e2529) tinyfugue: fix build with gcc15; migrate to pcre2
* [`5d116eb6`](https://github.com/NixOS/nixpkgs/commit/5d116eb686e57fdbe38a4dd123b82ee2a407dcd8) guitarix-vst: init at 0.5
* [`8cceb8ad`](https://github.com/NixOS/nixpkgs/commit/8cceb8ad510f6267d0a957dd7a805935bc9b5c3d) leptosfmt: add nix-update-script
* [`73c90e86`](https://github.com/NixOS/nixpkgs/commit/73c90e863bea35b3792db5fb5937ac99502452a1) ripsecrets: add progrm_jarvis to maintainers
* [`1e10d06f`](https://github.com/NixOS/nixpkgs/commit/1e10d06fb79b7d2e95e10a2fb7378da10a19de78) ripsecrets: add nix-update-script
* [`c4811c72`](https://github.com/NixOS/nixpkgs/commit/c4811c72b9633fb9c10573d3219a59cd0bf57257) simple-binary-encoding: 1.37.0 -> 1.37.1
* [`a5693ac8`](https://github.com/NixOS/nixpkgs/commit/a5693ac807c89dc6d1c5bab3a99c63219b4b0ba3) openclaw: 2026.4.21 -> 2026.4.22
* [`1fde8910`](https://github.com/NixOS/nixpkgs/commit/1fde89101af22ecb19385098b123f25f85db20e0) telegram-desktop: 6.7.6 -> 6.7.7
* [`7850a918`](https://github.com/NixOS/nixpkgs/commit/7850a918013d0fe376f782f9db3d31f5b9e85f29) telegram-desktop: 6.7.7 -> 6.7.8
* [`efbc4105`](https://github.com/NixOS/nixpkgs/commit/efbc4105c932d540f5f9c3f8ca432c75f36de442) materialgram: 6.4.0.1 -> 6.7.7.1
* [`b81eb9c4`](https://github.com/NixOS/nixpkgs/commit/b81eb9c43b957ca1c12a9c39280958a262b148e2) typeshare: add progrm_jarvis to maintainers
* [`44ad1666`](https://github.com/NixOS/nixpkgs/commit/44ad1666bc1e8f68676f9a1ecc5c65c7181c4844) rustnet: init at 1.2.0
* [`5e610069`](https://github.com/NixOS/nixpkgs/commit/5e610069af38ba40cf6bacde29d2c16baecc9bd0) dum: add progrm_jarvis to maintainers
* [`be2af66e`](https://github.com/NixOS/nixpkgs/commit/be2af66ea819b07df5e3163436e403f7f6ad1e8b) dum: add nix-update-script
* [`fcab10d1`](https://github.com/NixOS/nixpkgs/commit/fcab10d1f668036af030944f7cfb15e14de8e56c) kubefwd: 1.25.13 -> 1.25.14
* [`8cf6ba00`](https://github.com/NixOS/nixpkgs/commit/8cf6ba00a6541dc3daebbec9f2e5f36387fa61a7) bartib: add progrm_jarvis to maintainers
* [`084d1fa6`](https://github.com/NixOS/nixpkgs/commit/084d1fa6df8f90ff679a1905f0c7bcbcca564663) bartib: add nix-update-script
* [`56bf7ec1`](https://github.com/NixOS/nixpkgs/commit/56bf7ec14a08c7179f4a7f6a1dfc87759e14ee41) pw-viz: add progrm_jarvis to maintainers
* [`51118bde`](https://github.com/NixOS/nixpkgs/commit/51118bde63cf0238dc5c2414a85d05c49c9faf0e) gcsfuse: 3.8.0 -> 3.9.0
* [`28325ac1`](https://github.com/NixOS/nixpkgs/commit/28325ac196a4179ba61e2ad4052473d9d5630276) pw-viz: fix run
* [`27790dc1`](https://github.com/NixOS/nixpkgs/commit/27790dc12b5b2d3fb57cbbb1f281a4db8011ec71) mysql_jdbc: 9.6.0 -> 9.7.0
* [`3e64451f`](https://github.com/NixOS/nixpkgs/commit/3e64451f3cc342e34d4e886f825c6de6285d4e24) sayonara: 1.10.0-stable1 -> 1.11.0-stable1
* [`0809ab09`](https://github.com/NixOS/nixpkgs/commit/0809ab092eda2abdba665988a40a9d0f34d771dc) squishyball: fix build with gcc15
* [`e20e034d`](https://github.com/NixOS/nixpkgs/commit/e20e034de003865eb038af5a56d7827b6c0d6304) devilspie2: 0.44 -> 0.45
* [`d103a97f`](https://github.com/NixOS/nixpkgs/commit/d103a97f9155d64fec4b8ba3947e8bf76e8de022) nomacs: 3.21.1 -> 3.22.0
* [`43ea0c9a`](https://github.com/NixOS/nixpkgs/commit/43ea0c9a5a1d29990d013003108b136a26666e7f) gqlgen: 0.17.89 -> 0.17.90
* [`35e31c98`](https://github.com/NixOS/nixpkgs/commit/35e31c986d3cffcc1dd7a3dcad8460327c95c911) python3Packages.reno: fix build
* [`34ab0886`](https://github.com/NixOS/nixpkgs/commit/34ab0886e3e4a6ac8b2260f59035bef7d036acda) python3Packages.reno: use finalAttrs
* [`e87d7221`](https://github.com/NixOS/nixpkgs/commit/e87d72216a12e3882deba5da05a18adce6f776ba) python3Packages.jax: Include only jax.* in the built wheel
* [`248d4975`](https://github.com/NixOS/nixpkgs/commit/248d497547398dd866c2e9a748095974f23cfe59) mozillavpn: 2.35.0 → 2.36.0
* [`766cd7ab`](https://github.com/NixOS/nixpkgs/commit/766cd7ab20584bb637dcbd487432ca6ca7b0236e) encode-sans: use installFonts
* [`605febd0`](https://github.com/NixOS/nixpkgs/commit/605febd00ff98c9caaed82b69c7e669dbbe5f1f4) encode-sans: move to finalAttrs
* [`34a829d0`](https://github.com/NixOS/nixpkgs/commit/34a829d08d90f4740bc9547f059aa9f1748a772f) encode-sans: add pancaek as maintainer
* [`2da52875`](https://github.com/NixOS/nixpkgs/commit/2da528753ce28680de7d9b16ac46b1730154b2e1) libre-baskerville: use installFonts
* [`c5eafc82`](https://github.com/NixOS/nixpkgs/commit/c5eafc824dd418995b5e9457ab6f1bf8bb9181d3) libre-baskerville: move to finalAttrs
* [`412b84a8`](https://github.com/NixOS/nixpkgs/commit/412b84a85b7a8f6d4b6a8ad1fd0f7409d5f969ab) libre-baskerville: add pancaek as maintainer
* [`fe380d30`](https://github.com/NixOS/nixpkgs/commit/fe380d300f7d02ee900590238d63d3d442c3563e) berglas: 2.0.11 -> 2.0.12
* [`cf61c20d`](https://github.com/NixOS/nixpkgs/commit/cf61c20d5e7940524c363c474a6b2b956d2ea27f) lego: 4.31.0 -> 4.35.2
* [`177d8686`](https://github.com/NixOS/nixpkgs/commit/177d8686f4504ce21e8910844b9a20645501eefe) tau-hydrogen: drop
* [`bee88117`](https://github.com/NixOS/nixpkgs/commit/bee88117c1ffc2580e872cce2e7bcfb63b8d28e7) projectable: add progrm_jarvis to maintainers
* [`08af88cd`](https://github.com/NixOS/nixpkgs/commit/08af88cd72d3fe745865c7305b581b5a2e1e47ab) projectable: add nix-update-script
* [`19ef8e0f`](https://github.com/NixOS/nixpkgs/commit/19ef8e0f0bbd23eeae5c23dc5d86e63dc6796af9) python3Packages.pyclip: unbreak on darwin
* [`f2b66014`](https://github.com/NixOS/nixpkgs/commit/f2b6601479f301d69bd79f76d5ac37985832a0f9) keyscope: 1.4.0 -> 1.4.2
* [`e1489edc`](https://github.com/NixOS/nixpkgs/commit/e1489edcf0e2e385695807f2d878ae1f102e8475) daktari: init at 0.0.319
* [`079f5022`](https://github.com/NixOS/nixpkgs/commit/079f50225317d32ac119275555d930039abdc172) fluent-reader: 1.2.1 -> 1.2.2
* [`1d3923eb`](https://github.com/NixOS/nixpkgs/commit/1d3923eb606d15cfcdfe605c08b02e3a796e06e1) hello: enable __structuredAttrs
* [`e32e95a9`](https://github.com/NixOS/nixpkgs/commit/e32e95a90b25d25e780745e1f6fb8ab090b05ccf) subfinder: 2.13.0 -> 2.14.0
* [`60ef0fef`](https://github.com/NixOS/nixpkgs/commit/60ef0fef3a455fea406e132e8ab3a8bb80c19e79) dockerfile-pin: init at 1.3.0
* [`106e92d0`](https://github.com/NixOS/nixpkgs/commit/106e92d0ff13f7b36adc8045083a1b346eef59cb) rsonpath: 0.9.1-unstable-2024-11-15 -> 0.10.0
* [`b23dd319`](https://github.com/NixOS/nixpkgs/commit/b23dd31994cd91f783347c4d7b6b4a09cb64809f) odoo17: fix longpoll server start
* [`e926a193`](https://github.com/NixOS/nixpkgs/commit/e926a193afb32ab29ca70e0680e9047a77da3a60) odoo18: fix longpoll server start
* [`d6f5f087`](https://github.com/NixOS/nixpkgs/commit/d6f5f08713afd5c20bd120c2288e78f27913bd70) odoo19: fix longpoll server start
* [`6d72b67f`](https://github.com/NixOS/nixpkgs/commit/6d72b67f3e363471f2e670ec3d9599f412654792) nixos/odoo: add workers option to settings
* [`98a3cc14`](https://github.com/NixOS/nixpkgs/commit/98a3cc1471182af269d86d762167c085e294817c) nixosTests/odoo: add new multi-process test
* [`516a5684`](https://github.com/NixOS/nixpkgs/commit/516a56840ee24b8e29ed14a4f681a318efac906a) kodiPackages.jurialmunkey: 0.2.29 -> 0.2.35
* [`99dbe19a`](https://github.com/NixOS/nixpkgs/commit/99dbe19a17356102129f8252d651f788cbe011be) distrobox: 1.8.2.4 -> 1.8.2.5
* [`0f1eb41d`](https://github.com/NixOS/nixpkgs/commit/0f1eb41d59c5002b5450e88618a256336afc79fd) intel-llvm: use --strip-unneeded to reduce NAR size
* [`decd7e0f`](https://github.com/NixOS/nixpkgs/commit/decd7e0ff493ae9d87765fdb16e20a4ed145caf4) talos-pilot: init at 0.1.9
* [`9221ddbc`](https://github.com/NixOS/nixpkgs/commit/9221ddbc49f720adbafcdd0ce6189693dca3d8c1) python3Packages.langchain-protocol: init at 0.0.12
* [`afcbedc1`](https://github.com/NixOS/nixpkgs/commit/afcbedc1e04a42e54a0daeb0a72e8be5fc90c602) python3Packages.anthropic: 0.94.0 -> 0.97.0
* [`f30b55a4`](https://github.com/NixOS/nixpkgs/commit/f30b55a46f98ff2c811056bbc260fcc16b76fee4) wireshark: ln ext bins to $out for discoverability
* [`d170df7c`](https://github.com/NixOS/nixpkgs/commit/d170df7c9542f82315da961a32db65f265f816a2) python3Packages.llm-anthropic: 0.24 -> 0.25
* [`e963079d`](https://github.com/NixOS/nixpkgs/commit/e963079dc508837841e0186b033b758145bd7e19) ioskeley-mono: v2.0.0-beta.1 -> v2.0.0
* [`49c31b0d`](https://github.com/NixOS/nixpkgs/commit/49c31b0de8f4a85a1dcf4b45d180bfd2a60ec423) nats-server: 2.12.7 -> 2.12.8
* [`79228e9d`](https://github.com/NixOS/nixpkgs/commit/79228e9d7534e23bf20a231d78f76775e2d1be0f) opencollada-blender: drop
* [`bfb2fd8f`](https://github.com/NixOS/nixpkgs/commit/bfb2fd8f8cb69527f0766bef440fdd3697a34ad6) opencollada: drop
* [`0c4e7790`](https://github.com/NixOS/nixpkgs/commit/0c4e77908e1204498184d81cda8716e1ba4c47af) php85Extensions.grpc: unbreak for PHP 8.5
* [`0828d1a8`](https://github.com/NixOS/nixpkgs/commit/0828d1a8544812649f5ec26369daa61b1d089922) xen: 4.20.2 -> 4.20.3
* [`33b3eddb`](https://github.com/NixOS/nixpkgs/commit/33b3eddb2ed3e9705e1d869b2babfd51f497c341) prometheus-siebenmann-zfs-exporter: init at unstable-2022-08-17
* [`c81f0002`](https://github.com/NixOS/nixpkgs/commit/c81f00020376fbbb40fc723e0f393363b9ee0b82) nixos/prometheus-exporters: add zfs-siebenmann exporter
* [`95aa2f8b`](https://github.com/NixOS/nixpkgs/commit/95aa2f8bc3ebe334b1a681c14204ca61f1285e6c) maintainers: add _7591yj
* [`9bc0701c`](https://github.com/NixOS/nixpkgs/commit/9bc0701c3bc6620753411080eeb54785903b172f) nawk: add nix-update-script
* [`c2a6fda5`](https://github.com/NixOS/nixpkgs/commit/c2a6fda55675b4b7bccc9523add5d273376657e6) nawk: 20251225 -> 20260426
* [`95b5a194`](https://github.com/NixOS/nixpkgs/commit/95b5a194c6c064f5bc8616e225c9a879100a9544) maintainers: add sarowish
* [`a8f7483d`](https://github.com/NixOS/nixpkgs/commit/a8f7483d920f062a76a6d8675446356230ac927a) github-desktop: set meta.platforms to just linuxes
* [`6c3a60c1`](https://github.com/NixOS/nixpkgs/commit/6c3a60c1da577d0ef10a315aaad6a4e840eba470) ytsub: init at 0.9.0
* [`7b252fb4`](https://github.com/NixOS/nixpkgs/commit/7b252fb4edd20232f4e10719fc6f04fbd156df71) netbox: 4.5.7 -> 4.5.9
* [`9c76ff31`](https://github.com/NixOS/nixpkgs/commit/9c76ff315748e4f2dc057eff506985c63d9d381b) netbox: fix use of django-tables2 3.0
* [`9bdc55cf`](https://github.com/NixOS/nixpkgs/commit/9bdc55cfb71dc8a74c57ec4bc97d024c6c799a84) nixos/netbox: increase start timeout
* [`33adf02e`](https://github.com/NixOS/nixpkgs/commit/33adf02e929dbbe0151253cc2b8601a0a99c4279) novnc: 1.6.0 -> 1.7.0
* [`1c069fad`](https://github.com/NixOS/nixpkgs/commit/1c069fad1ab1f0dae8a13fe46e8cc8311d7190f5) python3Packages.langchain-text-splitters: 1.1.1 -> 1.1.2
* [`3ec13015`](https://github.com/NixOS/nixpkgs/commit/3ec130156ecc251cc64a77bf050b184fbc38bedd) phylophlan: cleanup the nix declaration
* [`dae1980b`](https://github.com/NixOS/nixpkgs/commit/dae1980bf763b2f58043d1ee54712bee4f449c2f) sftool-gui: 1.0.3 -> 1.1.4-unstable-2026-04-16
* [`ac1d85ce`](https://github.com/NixOS/nixpkgs/commit/ac1d85ce8fd8da845add1b735267a1140188ca44) matrix-authentication-service: 1.15.0 -> 1.16.0
* [`67910025`](https://github.com/NixOS/nixpkgs/commit/67910025b0e134827593164af8718c3acc5fd2ee) python3Packages.chipwhisperer: mark broken
* [`39b022f8`](https://github.com/NixOS/nixpkgs/commit/39b022f8e77f1e157f6eaea330e2794e41410208) gexiv2_0_16: init at 0.16.0
* [`697437a8`](https://github.com/NixOS/nixpkgs/commit/697437a88bdee668ff75150ae250eddca4d07f3d) material-maker: 1.5 -> 1.6
* [`6dcc0e98`](https://github.com/NixOS/nixpkgs/commit/6dcc0e98a79c9636ef903848b16f5e265a2071b6) ghdl: replace all-packages.nix callPackage with ghdl.override
* [`eb81d8c3`](https://github.com/NixOS/nixpkgs/commit/eb81d8c39c209a2c72181c7373a723da6a3f90ad) ghdl: add sempiternal-aurora as maintainer
* [`922ccc33`](https://github.com/NixOS/nixpkgs/commit/922ccc33640ba1ccc595d16e9bf465e6ded12c18) ghdl: 5.1.1 -> 6.0.0, fix gcc build
* [`2159fa67`](https://github.com/NixOS/nixpkgs/commit/2159fa6704641885998438e9a5f56da55317644e) ghdl: enable __structuredAttrs and strictDeps
* [`ee5f854b`](https://github.com/NixOS/nixpkgs/commit/ee5f854be79aa4f0cc28f885ac1c3e7a74ffe574) ghdl: fix environment for llvm and gcc backends
* [`05cc3ded`](https://github.com/NixOS/nixpkgs/commit/05cc3dede90d92092c93dac0c037bd8809b6c1b6) m1n1: add sempiternal-aurora as maintainer
* [`c992d736`](https://github.com/NixOS/nixpkgs/commit/c992d736096f43564b09a07a5ca64b77e896f7c6) m1n1: fix platforms
* [`6a493053`](https://github.com/NixOS/nixpkgs/commit/6a493053c0ee08397494021702fd9a9b3ceb2b44) onlykey: fix broken gui
* [`8697fed9`](https://github.com/NixOS/nixpkgs/commit/8697fed9308a396e9799d5b7aaa0420717a45c30) dawarich: remove openssl hotfix
* [`9910eaa5`](https://github.com/NixOS/nixpkgs/commit/9910eaa565c9999f528b72a279d41bee9c4f0bdc) maintainers: add stealthybox
* [`c5d0e8a4`](https://github.com/NixOS/nixpkgs/commit/c5d0e8a4c377bce4980c4df7f873a6993ba0f5a2) fluxcd-operator: 0.40.0 -> 0.48.0
* [`0caf6059`](https://github.com/NixOS/nixpkgs/commit/0caf6059bdd5acf1e9a615927539a0da8f4c2c30) protonup-rs: 0.10.0 -> 0.12.1
* [`b5858dd6`](https://github.com/NixOS/nixpkgs/commit/b5858dd6e09f506dda6ab301887ce68c4f8f4d04) rocmPackages.clr: add gfx950 (MI350x, MI355X) to gpuTargets
* [`32271580`](https://github.com/NixOS/nixpkgs/commit/32271580219a89a34906a12f6171df17053726dd) lib.meta.availableOn: move negation outside loop
* [`57b321c1`](https://github.com/NixOS/nixpkgs/commit/57b321c19098f311478c037842433cfed8358fd4) stdenv/check-meta: inline negation of availableOn
* [`7c145d03`](https://github.com/NixOS/nixpkgs/commit/7c145d032046cb1e2ebfa3e179e854391f49cc86) stdenv/check-meta: check condition before typechecking
* [`1d12e66b`](https://github.com/NixOS/nixpkgs/commit/1d12e66bc2bd4f7074051c4138e08aea89052ef2) stdenv/check-meta: check config before checking meta outputs
* [`1be6d007`](https://github.com/NixOS/nixpkgs/commit/1be6d007b897797a7d2081dc00ad168434eb5a1f) stdenv/check-meta: check that allowlist/blocklist nonempty first
* [`3a7b5044`](https://github.com/NixOS/nixpkgs/commit/3a7b504487cf8f30900f1f62a98a1ac760bc7cae) stdenv/check-meta: check that sources allowed first
* [`4084a18f`](https://github.com/NixOS/nixpkgs/commit/4084a18fb16e211666544fd223dcbba48b17f4d7) stdenv/check-meta: exit early if no meta defined
* [`fe037eed`](https://github.com/NixOS/nixpkgs/commit/fe037eedc6eee0d521012f2460641ccd6cac45b4) stdenv/check-meta: inline verify call
* [`bf4f4336`](https://github.com/NixOS/nixpkgs/commit/bf4f43369be7abab2bc44420c65234ac649458ff) limine: sync list of licenses with upstream
* [`8d04e4c0`](https://github.com/NixOS/nixpkgs/commit/8d04e4c0a0035c25f7e8aa5c218dbdd4ace29236) python3Packages.langchain-core: 1.2.27 -> 1.3.1
* [`89be282a`](https://github.com/NixOS/nixpkgs/commit/89be282a132c9f3b060d94c1ca778c29cd7ab964) python3Packages.langchain-tests: 1.1.6 -> 1.1.7
* [`57326694`](https://github.com/NixOS/nixpkgs/commit/5732669403c2136ba3ee8a52a2d6d3e925b91536) python3Packages.langchain-openai: 1.1.12 -> 1.2.0
* [`6358a7ae`](https://github.com/NixOS/nixpkgs/commit/6358a7ae117e4f8c8bc71da9f569559356a10bb7) rocmPackages.clr: add gfx1103 (RDNA 3 iGPU, Radeon 780M) to gpuTargets
* [`531765a3`](https://github.com/NixOS/nixpkgs/commit/531765a3da586796604f14364b178cc2658796e0) python3Packages.langchain-aws: 1.4.4 -> 1.4.5
* [`7d9dd0c5`](https://github.com/NixOS/nixpkgs/commit/7d9dd0c5b87dcf4e91fcbd6f60390fa653046d6f) python3Packages.langchain-classic: 1.0.3 -> 1.0.4
* [`cdc871f6`](https://github.com/NixOS/nixpkgs/commit/cdc871f6fdf1fd3c8d560c57043f109aac2ceb29) python3Packages.langchain-fireworks: 1.1.0 -> 1.2.0
* [`d6185316`](https://github.com/NixOS/nixpkgs/commit/d61853166eb494a7fed8601bfd924838614eba8a) python3Packages.langchain-google-genai: 4.2.1 -> 4.2.2
* [`3905d5cf`](https://github.com/NixOS/nixpkgs/commit/3905d5cf9069c51f0f8d41fc6975564709958aa3) python3Packages.langchain-huggingface: 1.2.1 -> 1.2.2
* [`4c47eeb6`](https://github.com/NixOS/nixpkgs/commit/4c47eeb6e74cede2da2b62897d396d8845a4c8d8) python3Packages.langgraph: 1.1.6 -> 1.1.10
* [`5d474cfd`](https://github.com/NixOS/nixpkgs/commit/5d474cfd815f4089739f04a427ff80d9077d7698) python3Packages.langgraph-checkpoint: 4.0.2 -> 4.0.3
* [`503bcc53`](https://github.com/NixOS/nixpkgs/commit/503bcc53df6055ea8130812dc0ab87f7517e3a87) python3Packages.langgraph-runtime-inmem: 0.27.3 -> 0.28.0
* [`5bfa780b`](https://github.com/NixOS/nixpkgs/commit/5bfa780b7fd152fa87f3465dd658cd1067c40aa7) python3Packages.langgraph-prebuilt: 1.0.9 -> 1.0.12
* [`bb8f55a2`](https://github.com/NixOS/nixpkgs/commit/bb8f55a27892d8d89c14705932ba1406f8c6c84c) python3Packages.langchain-anthropic: 1.4.0 -> 1.4.1
* [`5504ca76`](https://github.com/NixOS/nixpkgs/commit/5504ca76921c4c69444f9821749f518b77f51c55) bcompare4: rename from bcompare
* [`35f917ef`](https://github.com/NixOS/nixpkgs/commit/35f917effbe041fc458141518b14d07674939e30) linuxPackages_7_0.virtualboxGuestAdditions: do not install vboxvideo
* [`2d524083`](https://github.com/NixOS/nixpkgs/commit/2d52408364d51e960a993a6d8015c040eb4e2b79) gamepad-mirror: init at 0.3-unstable-2025-10-18
* [`dc0976b2`](https://github.com/NixOS/nixpkgs/commit/dc0976b277bbad4bd583ac3dcceed53a45f211d7) citrix-workspace: 25_08_10 -> 26_01_0; support 26.01 core app
* [`d5402db1`](https://github.com/NixOS/nixpkgs/commit/d5402db15b96d222ffd8dc879fbeeeb1c933aaad) citrix-workspace: add webcam GStreamer runtime support
* [`a4bdf572`](https://github.com/NixOS/nixpkgs/commit/a4bdf572b19dded5f85c1525b8a8d901e848ee41) python3Packages.pyngrok: 8.0.0 -> 8.1.2
* [`296af852`](https://github.com/NixOS/nixpkgs/commit/296af85293514739a9528efdff04cc4e22ffa157) qt6Packages.qtkeychain: 0.15.0 -> 0.16.0
* [`b553e927`](https://github.com/NixOS/nixpkgs/commit/b553e927d2857f1f5e5dee29bf6bc791e1104b1c) python2Packages.setuptools: mark insecure
* [`60d68c19`](https://github.com/NixOS/nixpkgs/commit/60d68c19f9acff9c3582726fa0e3cdda1f4ae370) linuxPackages.opensnitch-ebpf: fix build with kernel >= 6.19
* [`4a96c539`](https://github.com/NixOS/nixpkgs/commit/4a96c539a8a875118851990e369f80492cbdc542) mangohud: 0.8.2 -> 0.8.3
* [`aeb63ecb`](https://github.com/NixOS/nixpkgs/commit/aeb63ecb6b7d347f7e6b46a785d66fac4fa34208) metasploit: 6.4.128 -> 6.4.130
* [`0b9e598a`](https://github.com/NixOS/nixpkgs/commit/0b9e598a01b84ae5af036912464cb5dc965796fd) recyclarr: 8.5.1 -> 8.6.0
* [`48cf70a9`](https://github.com/NixOS/nixpkgs/commit/48cf70a92ec469f48acb3ab21fff8e36e765b4b7) python3Packages.disposable-email-domains: 0.0.172 -> 0.0.177
* [`e2865bdd`](https://github.com/NixOS/nixpkgs/commit/e2865bddcff5602bf3588168ef54548500d8d1e3) h2o: 2.3.0-rolling-2026-04-15 → 2.3.0-rolling-2026-04-30
* [`85bf2e8a`](https://github.com/NixOS/nixpkgs/commit/85bf2e8a81978b6dd1b645c803ac18b7334dad80) citrix-workspace: add PulseAudio runtime path
* [`a7e0c352`](https://github.com/NixOS/nixpkgs/commit/a7e0c352f0e6ccbb61338113bcd96fdc49e0ba24) thunderbird-cli: init at 1.0.2
* [`e2f71a4e`](https://github.com/NixOS/nixpkgs/commit/e2f71a4e5c4dbafbf4ebc88d47282c3789ddfb14) thunderbird-cli-bridge: init at 1.0.2
* [`f44fb3ff`](https://github.com/NixOS/nixpkgs/commit/f44fb3ff1eade1f609c2cf82c979eda5470f1984) thunderbird-cli-mcp: init at 1.0.2
* [`418a0ae8`](https://github.com/NixOS/nixpkgs/commit/418a0ae8f9e7e28dec3386e923bab98919c712a0) switch-to-configuration-ng: Stop drop-in template instances
* [`575bbbbc`](https://github.com/NixOS/nixpkgs/commit/575bbbbc76d5ef0b272127cc871ad7108477b9e2) switch-to-configuration-ng: Escape unit paths in drop-in glob
* [`959218ab`](https://github.com/NixOS/nixpkgs/commit/959218abd6adaa06b80e9adde009ca71ef16694b) switch-to-configuration-ng: take &Path in is_unit_disabled
* [`b12732fb`](https://github.com/NixOS/nixpkgs/commit/b12732fb6ca5b4a08046984b612f948a68db4a2a) switch-to-configuration-ng: fix dropins_removed comments
* [`99b70cdb`](https://github.com/NixOS/nixpkgs/commit/99b70cdb1dbd54af799d2839f0081e7bdfd3fede) switch-to-configuration-ng: replace is_unit_disabled with UnitFileState
* [`ed6c1b08`](https://github.com/NixOS/nixpkgs/commit/ed6c1b08f9ff07d6e10406650b4924874a2757ec) nixos/console: Fix systemd-vconsole-setup
* [`a79b2f4e`](https://github.com/NixOS/nixpkgs/commit/a79b2f4ef03a005a635698ca401cdcaaa8bc0edf) sd-switch: 0.6.2 -> 0.6.3
* [`002648b7`](https://github.com/NixOS/nixpkgs/commit/002648b782f8af41b4916e6cebd6b68d1d076513) nixos: unset vm.mmap_rnd_compat_bits on loongarch64
* [`4d63ca28`](https://github.com/NixOS/nixpkgs/commit/4d63ca28b503587809ef14d4633343c6c02a374a) etherpad-lite: 2.6.1 -> 2.7.2
* [`3ded8701`](https://github.com/NixOS/nixpkgs/commit/3ded8701adb13083ed7532343b997e560e97b4e2) alfis: 0.8.9 -> 0.8.10
* [`aaf01ab7`](https://github.com/NixOS/nixpkgs/commit/aaf01ab77ad49b4a7f09b7c60d80ac1b7f19e2a8) maintainers: add eduardofuncao
* [`a77979b0`](https://github.com/NixOS/nixpkgs/commit/a77979b0ee4836795a455ef3eacba2db29ad9d18) litecli: add iamanaws as maintainer
* [`7b385747`](https://github.com/NixOS/nixpkgs/commit/7b385747bb72fbe7bd4078ac3432099ea9eade5c) cargo-typify: add iamanaws as maintainer
* [`49f5f323`](https://github.com/NixOS/nixpkgs/commit/49f5f323e942576e5dd20ed3b283f7c31fd045fc) squix: init at 0.4.0-beta
* [`19ef658f`](https://github.com/NixOS/nixpkgs/commit/19ef658fe384d191009eaf3195b4833b329abec6) cargo-typify: 0.6.1 -> 0.6.2
* [`eaab6245`](https://github.com/NixOS/nixpkgs/commit/eaab6245f6603995b38889243bbd3a8aca0f5dea) python3Packages.clickhouse-connect: fix checks (pandas, skip HTTP client tests)
* [`ffbb5fbe`](https://github.com/NixOS/nixpkgs/commit/ffbb5fbea8d913fac36e35b2bd412fa30657add0) sunvox: 2.1.4 -> 2.1.4d
* [`59f4a8c4`](https://github.com/NixOS/nixpkgs/commit/59f4a8c4ac6b295cbfd9b16a6a877924b70af57f) surrealdb-surrealkv: init at 2.6.1
* [`d964bbea`](https://github.com/NixOS/nixpkgs/commit/d964bbeabd121aac884bf1cb8e8596ce0c368e96) codex: 0.125.0 -> 0.128.0
* [`15be48cb`](https://github.com/NixOS/nixpkgs/commit/15be48cbc0f38614efd8ce85276b4e714e11e918) k3s: remove unneeded patch file
* [`04e11f3e`](https://github.com/NixOS/nixpkgs/commit/04e11f3ee15e8145ba4aaaaa1d2c7209a45d4c28) k3s_1_33: 1.33.9+k3s1 -> 1.33.11+k3s1
* [`a18f0b1e`](https://github.com/NixOS/nixpkgs/commit/a18f0b1e37707d2839a5e2fb4b482058b76dbedf) k3s_1_34: 1.34.5+k3s1 -> 1.34.7+k3s1
* [`a9efc066`](https://github.com/NixOS/nixpkgs/commit/a9efc066e682854eae0a139a1e66300ba790ee8e) k3s_1_35: 1.35.2+k3s1 -> 1.35.4+k3s1
* [`cb973bea`](https://github.com/NixOS/nixpkgs/commit/cb973beae0eeedc1cabdd239818bf0e7b5a98db0) maintainers: add frostplexx
* [`bbade2db`](https://github.com/NixOS/nixpkgs/commit/bbade2db94423988ab7a235271d295fdb838ff05) tidal: init at 2.41.3
* [`cbf1d507`](https://github.com/NixOS/nixpkgs/commit/cbf1d507ddbf2ca2acf4750a740fdc96031cc032) dockerfmt: 0.3.9 -> 0.5.2
* [`a9a11d29`](https://github.com/NixOS/nixpkgs/commit/a9a11d2959a86584af8fe30f8a4fb1d77d24e3bd) gitlab: use nodejs 22
* [`ad00d71d`](https://github.com/NixOS/nixpkgs/commit/ad00d71d8d14da4e7fbff4fc4ade124331d66ca9) gitlab: 18.11.1 -> 18.11.12
* [`88a0224a`](https://github.com/NixOS/nixpkgs/commit/88a0224a3021796f1a73cee1b325b950a0f9d106) varnish77: drop
* [`649ecb52`](https://github.com/NixOS/nixpkgs/commit/649ecb520a5e1fdaed5664a5c3e271dcb89f9e08) gotenberg: 8.31.0 -> 8.32.0
* [`e4586d18`](https://github.com/NixOS/nixpkgs/commit/e4586d18a74a96fc12f66cc8be3dc89ad9a7ec26) victoriatraces: 0.8.0 -> 0.8.2
* [`b81bd98c`](https://github.com/NixOS/nixpkgs/commit/b81bd98c6501970b6b531d79e86a953bb12fd3b8) fence: 0.1.49 -> 0.1.54
* [`e1564fe2`](https://github.com/NixOS/nixpkgs/commit/e1564fe25d354effaae312d9ce4b5a667853fa76) libev: Add meta.homepage
* [`ad52c402`](https://github.com/NixOS/nixpkgs/commit/ad52c402b392bde9cf4b53530e4125a91a6df5d9) brltty: Replace hardcoded path to /usr/bin/setfacl in new udev beeper rules
* [`520b47aa`](https://github.com/NixOS/nixpkgs/commit/520b47aa268b5aa42f31e9fcfcc3baf98a93a746) lx-music-desktop: 2.12.1 -> 2.12.2
* [`2dafc1cc`](https://github.com/NixOS/nixpkgs/commit/2dafc1ccfb9642be3d614d87a999146f764e197f) lx-music-desktop: unpin nodejs
* [`eadc665b`](https://github.com/NixOS/nixpkgs/commit/eadc665baae51da55bf741e75543cec0b9283c45) padthv1: 1.4.1 -> 1.4.2
* [`7a51481f`](https://github.com/NixOS/nixpkgs/commit/7a51481f57792e91e0fa19457083036d3d28c2b6) libreoffice: init collaboara-coda variant at 25.04.9.2-2
* [`79df972b`](https://github.com/NixOS/nixpkgs/commit/79df972b33a17639ed8a08fef3f6544a1f442147) lavacli: 2.7 -> 2.8
* [`281f3d84`](https://github.com/NixOS/nixpkgs/commit/281f3d84024b8dbde372c66fe3788312db4ae764) intelephense: 1.16.5 -> 1.18.1
* [`95e798fb`](https://github.com/NixOS/nixpkgs/commit/95e798fba92cf3978fbc58c65fbf247a3437ef03) gerrit: 3.13.5 -> 3.13.6
* [`f705b6a9`](https://github.com/NixOS/nixpkgs/commit/f705b6a9e85e4e9079e004d21866ce5c089bc434) coqPackages.compcert: fix compilation on Rocq master
* [`45b3decf`](https://github.com/NixOS/nixpkgs/commit/45b3decff22b506cb166090db69ec9547302f1e8) logseq: pin electron to electron_39 to fix plugin loading
* [`0c21327c`](https://github.com/NixOS/nixpkgs/commit/0c21327ce508e62ba85b165ef06e7ea83dc3128c) whisper: drop
* [`bf632643`](https://github.com/NixOS/nixpkgs/commit/bf632643fd5647bcf366c68c496041fd5e9c8c37) babashka-unwrapped: 1.12.217 -> 1.12.218; migrate to by-name
* [`8459e161`](https://github.com/NixOS/nixpkgs/commit/8459e1615b6f5bc128f6bf798dcd1411feee5c1d) autobrr: 1.76.0 -> 1.77.0
* [`164b56d3`](https://github.com/NixOS/nixpkgs/commit/164b56d3698064e92527ed6f6dd780c5d7459e95) autobrr: make 'autobrr-web' easily overridable
* [`0ec82e44`](https://github.com/NixOS/nixpkgs/commit/0ec82e44fcf268ddea62bcea38b925a095b3defe) entire: 0.4.7 -> 0.5.6
* [`0184ab34`](https://github.com/NixOS/nixpkgs/commit/0184ab34585a2ca99d5041675eb30e4e7dd23c90) venator: fix build
* [`41089fb2`](https://github.com/NixOS/nixpkgs/commit/41089fb2c1cfa05fbbf1a7720f5a922b5a69b351) easycrypt: 2026.03 -> 2026.05
* [`55098681`](https://github.com/NixOS/nixpkgs/commit/5509868187c6d66b331baaaba98facc89e894425) venator: fix blank UI on NVIDIA GPU and X11
* [`63eae1ae`](https://github.com/NixOS/nixpkgs/commit/63eae1aea8f3f068e5653126b77ad6782f6b43a9) wordpressPackages.plugins.so-clean-up-wp-seo: drop
* [`333fd09c`](https://github.com/NixOS/nixpkgs/commit/333fd09c15a2193b44babab39c9e3acea2f8698b) cdktn-cli: 0.22.0 -> 0.22.1; bump node version
* [`f6c72135`](https://github.com/NixOS/nixpkgs/commit/f6c72135a9887e3ea7a38096473641e1ca4fb4ee) jfrog-cli: 2.78.10 -> 2.103.0
* [`9e2cda8d`](https://github.com/NixOS/nixpkgs/commit/9e2cda8d87f5b278e164903b36f3271aa95d7dfe) mgmt: 1.0.1 -> 1.0.2
* [`308434e4`](https://github.com/NixOS/nixpkgs/commit/308434e44e631962007875b42d8d4fcb01c0cca0) ansel: 0-unstable-2026-04-21 -> 0-unstable-2026-05-01
* [`044e0032`](https://github.com/NixOS/nixpkgs/commit/044e0032cc385abab3a0383d5108f2acc7fb8d1d) piliplus: 2.0.4 -> 2.0.6
* [`02fa307a`](https://github.com/NixOS/nixpkgs/commit/02fa307a8193e6a06f78d1132ce9d7bcaeb137e6) ps3-disc-dumper: 4.4.4 -> 4.5.1
* [`addfc133`](https://github.com/NixOS/nixpkgs/commit/addfc1330e17dc1d129ae1c48e847367ddc75359) mew: 1.0-unstable-2025-06-20 -> 1.0-unstable-2026-03-18
* [`a3fc897b`](https://github.com/NixOS/nixpkgs/commit/a3fc897b40d491fd5a9f971aeae32d3a6a2d66da) dbip-asn-lite: 2026-04 -> 2026-05
* [`89856aca`](https://github.com/NixOS/nixpkgs/commit/89856aca206d441d0ff953261465f5e77b13bacf) dbip-city-lite: 2026-04 -> 2026-05
* [`62b4a5e1`](https://github.com/NixOS/nixpkgs/commit/62b4a5e13077d9a9ed05ff64dbf3f9a981bcf066) dbip-country-lite: 2026-04 -> 2026-05
* [`47edec92`](https://github.com/NixOS/nixpkgs/commit/47edec92b565b553c1065f6421fecae9865f0907) k0sctl: 0.28.0 -> 0.30.0
* [`f07457fd`](https://github.com/NixOS/nixpkgs/commit/f07457fd1676d548a1f3e7a6fc0d1479430d05d6) peertube: 8.0.2 -> 8.1.5; bump nodejs version from 20 to 24
* [`ff4cd7e1`](https://github.com/NixOS/nixpkgs/commit/ff4cd7e1d7364812ef29bf1ce0f20b561a78177c) send: use nodejs_22
* [`7b4a250d`](https://github.com/NixOS/nixpkgs/commit/7b4a250d71382643ed429213beec5cff8042ffca) efitools: patch make output parameter name
* [`b4097429`](https://github.com/NixOS/nixpkgs/commit/b409742911835ee955d74f75ec23a60677261aa3) headlamp-server: init at 0.41.0
* [`1780a515`](https://github.com/NixOS/nixpkgs/commit/1780a5156c4f58ba91f4ae61a4dc3a850e4a970e) headlamp-frontend: init at 0.41.0
* [`3711f251`](https://github.com/NixOS/nixpkgs/commit/3711f251d961001a94a2ab3ca6d35f831fe94092) headlamp: init at 0.41.0
* [`d889d957`](https://github.com/NixOS/nixpkgs/commit/d889d9570e7d4041d02c6454f375f6333b606fbd) python3Packages.lineax: 0.1.0 -> 0.1.1
* [`a0d19d9c`](https://github.com/NixOS/nixpkgs/commit/a0d19d9c5de7618ee7fb2a497fb9aa067a240288) python3Packages.pymc: 5.28.4 -> 5.28.5
* [`8a22f6e0`](https://github.com/NixOS/nixpkgs/commit/8a22f6e029be3c8acf38d05b22c0054bd3d155ba) little_boxes: 1.10.0 -> 1.12.1
* [`24a914f8`](https://github.com/NixOS/nixpkgs/commit/24a914f85988febfa2e851906a652528ff252169) python3Packages.meraki: 2.1.0 -> 3.0.1
* [`62d11491`](https://github.com/NixOS/nixpkgs/commit/62d11491bc9709195fe43fdd7fb251fd458dc3e7) korrect: 0.3.7 -> 0.3.8
* [`61d753a2`](https://github.com/NixOS/nixpkgs/commit/61d753a276ecdc3e5d8c1208c72b5e21207147a2) pkgs/top-level: remove unused let bindings
* [`58674f3a`](https://github.com/NixOS/nixpkgs/commit/58674f3a187c30d08ca16ecc023a6e3cf8d9f28d) cplay-ng: 5.4.0 -> 5.5.0
* [`1dcbce2c`](https://github.com/NixOS/nixpkgs/commit/1dcbce2c67020513b5cadaffcf18da4b96dd75a4) hare: fix musl build
* [`6bc5caf0`](https://github.com/NixOS/nixpkgs/commit/6bc5caf0eecb0822c2c916ee393a71e62915328d) linja-sike: update source
* [`ae5b047c`](https://github.com/NixOS/nixpkgs/commit/ae5b047c46f6cf8268795a68f21c76a9d70baed9) ccache: 4.13.2 -> 4.13.5
* [`df47acb1`](https://github.com/NixOS/nixpkgs/commit/df47acb1a4474216205cd765b81a619f19835be9) jackett: 0.24.1591 -> 0.24.1807
* [`df3a40c6`](https://github.com/NixOS/nixpkgs/commit/df3a40c667deda4d85915f7a10d251dc4f84639f) ddns-go: 6.16.10 -> 6.17.0
* [`ea5ce1af`](https://github.com/NixOS/nixpkgs/commit/ea5ce1af2fa5ea73cfd7b10d1d3a71861785d966) litecli: cleanup
* [`4323a56d`](https://github.com/NixOS/nixpkgs/commit/4323a56d2e20272d3a8b593b200e5e12f72880e0) grafanaPlugins.grafana-pyroscope-app: 2.0.4 -> 2.0.5
* [`dbc50a92`](https://github.com/NixOS/nixpkgs/commit/dbc50a92e888866d2a0d74f3e80567cc070d2660) chatzone-desktop: 5.6.1 -> 5.6.2
* [`f715e3cc`](https://github.com/NixOS/nixpkgs/commit/f715e3cc9abbfafb3bb8b8ea0070fc0a7c3a5898) lazycommit: 1.4.2 -> 1.5.3
* [`123bc613`](https://github.com/NixOS/nixpkgs/commit/123bc61355d0b677d29d621ba0b2313c1c13aef6) uboot*: use structuredAttrs instead of passAsFile
* [`64e3c5b2`](https://github.com/NixOS/nixpkgs/commit/64e3c5b23e2b2f2b7abbbe975d162d93defa7348) commons-io: 2.21.0 -> 2.22.0
* [`e997e52e`](https://github.com/NixOS/nixpkgs/commit/e997e52e1e0d9592801da5145928ff6e610f378d) gitsign: 0.14.0 -> 0.15.0
* [`86fb9ad8`](https://github.com/NixOS/nixpkgs/commit/86fb9ad84cc46e7c16a07efc90fb40e8bd766d9b) svu: 3.4.0 -> 3.4.1
* [`2e87c2f8`](https://github.com/NixOS/nixpkgs/commit/2e87c2f8f45e4680b8ec408c5dfbe43e36702776) nixos/*: remove unused let bindings
* [`2faa5fcf`](https://github.com/NixOS/nixpkgs/commit/2faa5fcf9f26fe535326928548523ada1045b3cd) python3Packages.ultralytics-thop: 2.0.18 -> 2.0.19
* [`a3e08f72`](https://github.com/NixOS/nixpkgs/commit/a3e08f72a0596db3175c8368f30e3b9254e1b317) treemd: 0.5.10 -> 0.5.11
* [`86cb60e7`](https://github.com/NixOS/nixpkgs/commit/86cb60e7900a74389253877c9cd843c915d07c54) jj-pre-push: 0.4.0 -> 0.4.4
* [`289b7b1f`](https://github.com/NixOS/nixpkgs/commit/289b7b1f427dcf827759f87087b29cfba489c0eb) fluxcd: rewrite update script to use nix-update
* [`115d1ee2`](https://github.com/NixOS/nixpkgs/commit/115d1ee263396f8346ffc7481e20f0be336056bd) fluxcd: build with CGO_ENABLED=0 to match upstream
* [`0ba12358`](https://github.com/NixOS/nixpkgs/commit/0ba12358445bd4a7b23c3e57f24d2cbd9b8640be) codex-acp: 0.9.2 -> 0.12.0
* [`ca6ef234`](https://github.com/NixOS/nixpkgs/commit/ca6ef2340673e28801635fadecf1ce46df8cca68) codex-acp: add update script
* [`5c8d88ee`](https://github.com/NixOS/nixpkgs/commit/5c8d88ee00c52928c19dc1edd288e926017e5cda) codex-acp: address review feedback
* [`c4ba4d4e`](https://github.com/NixOS/nixpkgs/commit/c4ba4d4e8629cb1749cbf8e5aebaf2fbf7fb3a3a) ugm: 1.8.0 -> 1.9.0
* [`d8527b96`](https://github.com/NixOS/nixpkgs/commit/d8527b960e1920c843a79700a90f383841efc3b7) pkarr: 5.0.2 -> 5.0.5
* [`c344cfcc`](https://github.com/NixOS/nixpkgs/commit/c344cfcc3aff1c4c07b6286e7758751c0070eb68) chatbox: 1.20.1 -> 1.20.3
* [`e3d5e71c`](https://github.com/NixOS/nixpkgs/commit/e3d5e71c74c03564bb1bb1755695df193795ec64) svelte-language-server: 0.17.30 -> 0.17.31
* [`9b97343a`](https://github.com/NixOS/nixpkgs/commit/9b97343a01e108c51962fb02ae3c22e4b2c3e22c) google-alloydb-auth-proxy: 1.14.2 -> 1.14.3
* [`292e6487`](https://github.com/NixOS/nixpkgs/commit/292e6487ca12594f64a68241c988c3edc4b5d46c) xfr: 0.9.10 -> 0.9.11
* [`b698aeff`](https://github.com/NixOS/nixpkgs/commit/b698aeff88422227fb5dcc3b1554988cfea4ea6a) deno: 2.7.13 -> 2.7.14
* [`474b7b36`](https://github.com/NixOS/nixpkgs/commit/474b7b36c875aefd19fb0b859bbf24cdab297860) collabora-desktop: init at 25.04.9.2-2
* [`242249aa`](https://github.com/NixOS/nixpkgs/commit/242249aa9220d7f45e4f8e44616c5f1d7f5059c9) ty: 0.0.33 -> 0.0.34
* [`1241804d`](https://github.com/NixOS/nixpkgs/commit/1241804dfa1e8d85621ed2a3f52bdaab299bc9d8) linyaps: 1.12.2 -> 1.12.3
* [`d7db00fc`](https://github.com/NixOS/nixpkgs/commit/d7db00fc37d032d5c0484a0ac44694117e1b54d3) go-grip: 0.9.1 -> 0.9.2
* [`f1d28bd0`](https://github.com/NixOS/nixpkgs/commit/f1d28bd02cec6ab16b1aa9ce44b0617aaa40e9fa) helmfile: 1.4.4 -> 1.4.5
* [`1b0bcdc6`](https://github.com/NixOS/nixpkgs/commit/1b0bcdc68623d28353ebd63e93ed343992d860ab) librecad: 2.2.1.4 -> 2.2.1.5
* [`493f54e6`](https://github.com/NixOS/nixpkgs/commit/493f54e6412523d856780bb75bcb1c09ff2e1844) chirp: 0.4.0-unstable-2026-04-18 -> 0.4.0-unstable-2026-04-30
* [`1cb4cb8c`](https://github.com/NixOS/nixpkgs/commit/1cb4cb8c8df9aa0c6a0a1cca468caad0bae52007) libretro.beetle-psx: 0-unstable-2026-04-20 -> 0-unstable-2026-05-01
* [`97de9a1e`](https://github.com/NixOS/nixpkgs/commit/97de9a1e933014c5407ecc9c660f1f52638d9279) commitlint: 20.5.0 -> 20.5.3
* [`0eaa3304`](https://github.com/NixOS/nixpkgs/commit/0eaa3304a6869460541b5970e0e322a1b5fc1c74) ultralytics: 8.4.41 -> 8.4.46
* [`7f7c590a`](https://github.com/NixOS/nixpkgs/commit/7f7c590ae2b0c33c8e57b186e69a722274ae582a) wit-bindgen: 0.56.0 -> 0.57.1
* [`e9149c63`](https://github.com/NixOS/nixpkgs/commit/e9149c635cd2699477c1d85ca572b34403dac48a) zerofs: 1.0.8 -> 1.1.0
* [`acc02f5d`](https://github.com/NixOS/nixpkgs/commit/acc02f5dffc8fff4a3140383791b381232faf19e) vscode-extensions.illixion.vscode-vibrancy-continued: 1.1.76 -> 1.1.77
* [`b641d001`](https://github.com/NixOS/nixpkgs/commit/b641d0015e92c7937612860a707eb384f6562e43) python3Packages.cloudevents: migrate to finalAttrs
* [`d6908853`](https://github.com/NixOS/nixpkgs/commit/d69088533e4a0e14cfb125a2eb797471e58df0af) peergos: 1.24.0 -> 1.25.0
* [`78a57646`](https://github.com/NixOS/nixpkgs/commit/78a57646bb71fb04ffefa964012f3049d0a237ae) microsoft-edge: 147.0.3912.60 -> 147.0.3912.98
* [`f6131a57`](https://github.com/NixOS/nixpkgs/commit/f6131a57107cd4ac79c82a88264203ca7e858a37) pay-respects: 0.8.5 -> 0.8.8
* [`c6d0e1ed`](https://github.com/NixOS/nixpkgs/commit/c6d0e1edfc3fa910f6661d04cb2c2a0f16a2b16d) mullvad-vpn: {add jackr airone01 sigmasquadron as maintainers, modernize}
* [`fdea3e24`](https://github.com/NixOS/nixpkgs/commit/fdea3e24768d1ef819a73f8e1a6fc7c1573e726a) linuxPackages.nvidiaPackages.vulkan_beta: 595.44.05 -> 595.44.06
* [`b7582dc2`](https://github.com/NixOS/nixpkgs/commit/b7582dc2d7c55f7fa0c2eecba812c361355a6c5e) xpra: 6.3.6 -> 6.4.3
* [`279f7389`](https://github.com/NixOS/nixpkgs/commit/279f7389dd5cedf860d1cd8989ea6b442905c87f) todoist: 0.23.0 -> 0.24.0
* [`85259194`](https://github.com/NixOS/nixpkgs/commit/85259194ba521ba565e0a3ec662b6c4f902a11a4) video-compare: 20260308 -> 20260502
* [`adb9b7d8`](https://github.com/NixOS/nixpkgs/commit/adb9b7d8f9e489c0230c842d78d0bc21c4bad6d7) buf: 1.68.4 -> 1.69.0
* [`5ef4fff9`](https://github.com/NixOS/nixpkgs/commit/5ef4fff90b14da90c80d4e4db254f4b356212b08) prek: 0.3.10 -> 0.3.11
* [`8e30a41e`](https://github.com/NixOS/nixpkgs/commit/8e30a41e3e38e034f5320d4fdd63b4d7fb8c56be) julec: 0.2.0 -> 0.2.1
* [`ba4edac0`](https://github.com/NixOS/nixpkgs/commit/ba4edac0a41ece808ae5128cd3cd6e7f8cc70083) lib.licenses: add DocBook DTD License
* [`be1f2b3b`](https://github.com/NixOS/nixpkgs/commit/be1f2b3b7d2fd10d8581af2c3ac4173bfea8f4f0) docbook_sgml_dtd_45: init at 4.5
* [`be431d2d`](https://github.com/NixOS/nixpkgs/commit/be431d2db070a25550435fac070d376720deeec0) nbd: 3.25 -> 3.27.1
* [`91045aad`](https://github.com/NixOS/nixpkgs/commit/91045aadd9808ef5bb3af9fc4d71e4abc206ab2d) nixos/nbd: unset user and group in config
* [`636a10cd`](https://github.com/NixOS/nixpkgs/commit/636a10cd9b9329dafc6e86bca8a96ccc478c9d45) nixos/nbd: do not daemonize the main process
* [`a1f75200`](https://github.com/NixOS/nixpkgs/commit/a1f75200d5e7debd06b1b74ed59ca7a03bd829a9) stern: 1.33.1 -> 1.34.0
* [`392f3f8f`](https://github.com/NixOS/nixpkgs/commit/392f3f8fc1dd55b90c4de2a378edf260decd5cfe) nixos-test-driver: Use `ty` anf `ruff` instead of `mypy` and `pyflakes`
* [`786d0f43`](https://github.com/NixOS/nixpkgs/commit/786d0f43741cb93ac586f04534e7d4580831dd93) nixosTests.hostname: Fix
* [`f99f0269`](https://github.com/NixOS/nixpkgs/commit/f99f026911c95af3f9d760582f3e2e457192a73f) nixosTests: switch from deprecated copy_from_vm to copy_from_machine
* [`73789d37`](https://github.com/NixOS/nixpkgs/commit/73789d37d61c2e8059093f81b1ab79d9cb54bc4b) nixosTests: fix missing imports
* [`bdde743d`](https://github.com/NixOS/nixpkgs/commit/bdde743d2d347cb90de3d02eda5777364b4bc8e2) nixosTests.cloud-init: fix hostname
* [`76fd8788`](https://github.com/NixOS/nixpkgs/commit/76fd8788cd067805d52a460c31bd736b2a626a3e) nixosTests.ipv6: fix regular expression match conditions
* [`6323489f`](https://github.com/NixOS/nixpkgs/commit/6323489f80256ac5984b3ed3454090698c1ad438) nixosTests.amazon-init: Fix hostname
* [`79100aff`](https://github.com/NixOS/nixpkgs/commit/79100aff14e76a791c9bb2de0741fb629e887adc) nixos/test-driver: fix duplicate names in type check
* [`5b78f851`](https://github.com/NixOS/nixpkgs/commit/5b78f8515484cbd2a43b2a122b03c749f04c72ec) nixos-test-driver: don't make warnings in the linter errors at this
* [`18eae4ef`](https://github.com/NixOS/nixpkgs/commit/18eae4ef102cbb6143ef0ac3729c27ca331c0b1e) nixosTests.scion-freestanding-deployment: Fix machine type assumption
* [`ab48cf9d`](https://github.com/NixOS/nixpkgs/commit/ab48cf9d3d3612379d8995daa3c22188ea7ab534) radioboat: 0.6.0 -> 0.7.0
* [`ac904cbb`](https://github.com/NixOS/nixpkgs/commit/ac904cbba2adee14ddea04f6644e43224c0862d1) forgejo-mcp: 2.18.0 -> 2.19.0
* [`731afede`](https://github.com/NixOS/nixpkgs/commit/731afede0ec3f1e3ac7744d8d2ec29cd5eaf88f4) httrack: 3.49.2 -> 3.49.6
* [`6fe8a05b`](https://github.com/NixOS/nixpkgs/commit/6fe8a05b3a02202b2eedc3e72b0c02d63dca9fdf) vacuum-go: 0.26.1 -> 0.26.4
* [`0a915863`](https://github.com/NixOS/nixpkgs/commit/0a9158631498b9183e367d64a064a2a62c3b82ad) python3packages.pyghmi: remove six from dependencies
* [`f49203b1`](https://github.com/NixOS/nixpkgs/commit/f49203b1e534ca8b42956f99359f8ed963627a5b) lfk: init at 0.9.36
* [`5762348d`](https://github.com/NixOS/nixpkgs/commit/5762348dbdac46a3c9b16dde183595d7b9fcd5a2) pyrra: 0.9.5 -> 0.10.0
* [`b3b2449b`](https://github.com/NixOS/nixpkgs/commit/b3b2449b855ef4982df4699e76471d873cc44120) nixos/openbao: allow unix socket to be optionally accessed by others
* [`6746f1a4`](https://github.com/NixOS/nixpkgs/commit/6746f1a41f3e8e5257e9cc8453b75726bb8b46c8) nixos/tests/openbao: test Unix Socket listener customization
* [`cc81216c`](https://github.com/NixOS/nixpkgs/commit/cc81216caffd156ec44ac4bb5f38637d73bfe918) gammu: 1.42.0 -> 1.43.2
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
