### PR TITLE
npins home-manager: update a89686d1 -> b659c7ff

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -61,9 +61,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "a89686d115e970e200eb2caa7603f3673050e00c",
-      "url": "https://github.com/nix-community/home-manager/archive/a89686d115e970e200eb2caa7603f3673050e00c.tar.gz",
-      "hash": "sha256-4MwfrGuqjsnEORQbM3cmkmG/9cWhDV63dTDguDj4FXw="
+      "revision": "b659c7ffd40fc9e3bb60d420c79c67e769b9f4ab",
+      "url": "https://github.com/nix-community/home-manager/archive/b659c7ffd40fc9e3bb60d420c79c67e769b9f4ab.tar.gz",
+      "hash": "sha256-kkUQYSv70wynJ/DfnGals6r98I6bK3CVNVTN1zbAd7Y="
     },
     "hs-grille": {
       "type": "Git",


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@a89686d1...b659c7ff](https://github.com/nix-community/home-manager/compare/a89686d115e970e200eb2caa7603f3673050e00c...b659c7ffd40fc9e3bb60d420c79c67e769b9f4ab)

* [`5be632da`](https://github.com/nix-community/home-manager/commit/5be632dab0be072deadd69ebced5bc7366d71bb8) gpu: use tmpfiles.d to set up the /run/opengl-driver symlink
* [`7ef1c04d`](https://github.com/nix-community/home-manager/commit/7ef1c04d11f7ef69fd946b118c768c32de0b89a5) rclone: rename remote directory to fix failing tests
* [`5a155051`](https://github.com/nix-community/home-manager/commit/5a15505146ffd149dd88126562209028220c93e3) Revert "sshAuthSock: assert that at most one agent is enabled"
* [`d9876178`](https://github.com/nix-community/home-manager/commit/d987617879f613053f6fdf4491fe28ce0283d543) generic-linux-gpu: don't pass kernel
* [`02b61230`](https://github.com/nix-community/home-manager/commit/02b61230c4c24ede54d8cf6799ff35892e1253e9) email: extend `mailbox.org` config flavor
* [`24bac7a6`](https://github.com/nix-community/home-manager/commit/24bac7a6d399e55ded72ffe698ef3569db41946c) Translate using Weblate (Russian)
* [`00ed86e5`](https://github.com/nix-community/home-manager/commit/00ed86e58bb6979a7921859fd1615d19382eac5c) Translate using Weblate (French)
* [`7547f894`](https://github.com/nix-community/home-manager/commit/7547f8942cd2ad9ef572d701db23b4c08bb74fae) quickshell: don't throw error when package is null
* [`75fac363`](https://github.com/nix-community/home-manager/commit/75fac363324f18d2b83a30fd916e509d2a02fb0e) direnv: avoid duplicate fish hook
* [`838330cc`](https://github.com/nix-community/home-manager/commit/838330cc25ab67312cb6963cfad842b92735e3c0) zed-editor: add defaultEditor option
* [`e4419d31`](https://github.com/nix-community/home-manager/commit/e4419d3123b780d5f4c0bceeace450424387638c) zed-editor: add zh4ngx as maintainer
* [`7eb987d1`](https://github.com/nix-community/home-manager/commit/7eb987d1a47e3a542c76f1da0bebdf3dc67a0fa0) manual: fix link in modular services section
* [`cdea7d89`](https://github.com/nix-community/home-manager/commit/cdea7d89f50d60b2e83ff5e33f55c91bcb08a2da) modular-services: rename home-manager -> Home Manager
* [`f77079ee`](https://github.com/nix-community/home-manager/commit/f77079ee8a7acda96819ac57fe1975e5c1bd4554) modular-services: rename system-services -> home-services
* [`db468b48`](https://github.com/nix-community/home-manager/commit/db468b4822f2ad68a29b443aca4b6c0875847f1c) modular-services: make `configdata` test use `assertFileContent`
* [`1aabcdd4`](https://github.com/nix-community/home-manager/commit/1aabcdd4704f2fbe6d9284f368f6cba2ad2e8a4a) modular-services: simple example using `mpd`
* [`61031d42`](https://github.com/nix-community/home-manager/commit/61031d425e3a415f9b68aa74ad27dc68f43381a9) modular-services:rewrite `multi-user.target` to `default.target`
* [`4fa2493b`](https://github.com/nix-community/home-manager/commit/4fa2493b307617e0f24ad6c5742212f6aaf7168c) modular-services: add config files to `X-Reload-Triggers`
* [`67625b8c`](https://github.com/nix-community/home-manager/commit/67625b8c313a23f23e8079c66b89399d611c452e) modular-services: add `php-fpm` as a service meant to run as a user
* [`fdb2ccba`](https://github.com/nix-community/home-manager/commit/fdb2ccba9d5e1238d32e0c4a3ec1a277efa80c1d) modular-services: document ghostunnel as a service that was not written for use as a user-level service
* [`2f419037`](https://github.com/nix-community/home-manager/commit/2f419037039a152448c5f4ae9494154753d1b399) mako: allow null package
* [`dcebe66f`](https://github.com/nix-community/home-manager/commit/dcebe66f958673729896eec2de4abfd86ef22d21) atuin: precompute fish init script
* [`c0729fa3`](https://github.com/nix-community/home-manager/commit/c0729fa3f060008080b2124fd0c3b9285d53b393) kanshi: Remove myself from the maintainers
* [`85ba629c`](https://github.com/nix-community/home-manager/commit/85ba629c79449badf4338117c27f0ee92b4b9f1a) rofi: change configPath type to nonEmptyStr
* [`bc63bedc`](https://github.com/nix-community/home-manager/commit/bc63bedcab3454f11c79fcdbcf90301deb562b6c) email: add warning to documentation of `useStartTls`
* [`5b73f949`](https://github.com/nix-community/home-manager/commit/5b73f949a1765ee018fa402521a5d0e280b7e656) systemd: install systemd files when user is root (revert c2aa831) ([nix-community/home-manager⁠#9274](https://togithub.com/nix-community/home-manager/issues/9274))
* [`b659c7ff`](https://github.com/nix-community/home-manager/commit/b659c7ffd40fc9e3bb60d420c79c67e769b9f4ab) hyprland: update documentation links
