### PR TITLE
npins nerd-icons.el: update ae1b85c4 -> b63f9f9f

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -112,9 +112,9 @@
       },
       "branch": "main",
       "submodules": false,
-      "revision": "ae1b85c487c2b0bb1efb8bc0edc23af74282eec2",
-      "url": "https://github.com/rainstormstudio/nerd-icons.el/archive/ae1b85c487c2b0bb1efb8bc0edc23af74282eec2.tar.gz",
-      "hash": "sha256-3BLTL4Imncin4bG+jmFMzCgu1a8nWEObsovAV3woYkU="
+      "revision": "b63f9f9fda431dd4a9e8dc7ccb8e02996fbeca77",
+      "url": "https://github.com/rainstormstudio/nerd-icons.el/archive/b63f9f9fda431dd4a9e8dc7ccb8e02996fbeca77.tar.gz",
+      "hash": "sha256-iK/kmbYFOn8B/r0L0zRoWip+2M+I4mVt+rKnFkR0Nj4="
     },
     "niv": {
       "type": "Git",


### PR DESCRIPTION
## Changelog for nerd-icons.el:
Branch: main
Commits: [rainstormstudio/nerd-icons.el@ae1b85c4...b63f9f9f](https://github.com/rainstormstudio/nerd-icons.el/compare/ae1b85c487c2b0bb1efb8bc0edc23af74282eec2...b63f9f9fda431dd4a9e8dc7ccb8e02996fbeca77)

* [`b63f9f9f`](https://github.com/rainstormstudio/nerd-icons.el/commit/b63f9f9fda431dd4a9e8dc7ccb8e02996fbeca77) Add nerd-icons-multimodal to related packages and fnl file icon ([rainstormstudio/nerd-icons.el⁠#154](https://togithub.com/rainstormstudio/nerd-icons.el/issues/154))
