### PR TITLE
npins nixpkgs: update b3da6560 -> d2339023

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -132,8 +132,8 @@
     "nixpkgs": {
       "type": "Channel",
       "name": "nixpkgs-unstable",
-      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-26.05pre994919.b3da656039dc/nixexprs.tar.xz",
-      "hash": "sha256-lMg7Dj7kyGN5cj9RGag5Is100HnQPKM9zEsuAOL2TLA="
+      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-26.05pre998534.d233902339c0/nixexprs.tar.xz",
+      "hash": "sha256-vZOcDniDPc1cS8A4Xi5YE6AGyPIvEpy4GMyayA3SWIM="
     },
     "powerlevel10k": {
       "type": "Git",


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: release-26.05
Commits: [nixos/nixpkgs@b3da6560...d2339023](https://github.com/nixos/nixpkgs/compare/b3da656039dc...d233902339c0)

* [`6c3ae0b7`](https://github.com/NixOS/nixpkgs/commit/6c3ae0b70e4d5b1ebae495bad867c0e837e54068) fishPlugins.ai: init at 0-unstable-2025-02-14
* [`c1c241df`](https://github.com/NixOS/nixpkgs/commit/c1c241dffd7a4a6a301b431d72d61feab68f472a) writefreely: Remove faulty backslash in script
* [`0bb0193a`](https://github.com/NixOS/nixpkgs/commit/0bb0193a5093fc33700118ca40ee3b769dc00752) nixos/writefreely: add support for email smtp password
* [`fbe6fd7e`](https://github.com/NixOS/nixpkgs/commit/fbe6fd7edd1f92023e5468a3800161222bd559c0) nixos/writefreely: add openssl to service path.
* [`023e9300`](https://github.com/NixOS/nixpkgs/commit/023e9300bbd09201741ac4a5924d533d41f74473) lib/modules: document limitations of 'mkRenamedOptionModule'
* [`c61b71e2`](https://github.com/NixOS/nixpkgs/commit/c61b71e2da42d651b64dc91510c71a02217c2b6a) nixos/lasuite-docs: fix styling on admin pages
* [`4ee2a9a0`](https://github.com/NixOS/nixpkgs/commit/4ee2a9a01856d534e7c52ef305995f83306f83bf) keyd: cleanup
* [`f7eefe7e`](https://github.com/NixOS/nixpkgs/commit/f7eefe7eb2ccae6148e218fbd165c246b2a1b236) nixos/keyd: cleanup
* [`d462c4dd`](https://github.com/NixOS/nixpkgs/commit/d462c4dd2cca89b9907e767d733e13db92306fa6) nixos/redis: set config group for service user
* [`9f3fa31c`](https://github.com/NixOS/nixpkgs/commit/9f3fa31c0e8f436c3ab28f48ecfd151f71da5e70) pdftoipe: 7.2.29.1 -> 7.2.29.2
* [`fd300c2d`](https://github.com/NixOS/nixpkgs/commit/fd300c2df73ae56559f7acb7ba5023aad0933ec9) python3Packages.stumpy: 1.13.0 -> 1.14.1
* [`b39b4987`](https://github.com/NixOS/nixpkgs/commit/b39b4987900bebf7b110c6f4c59231e75d27ec14) zesarux: unstable-2023-10-31 -> 12.1
* [`adb61b40`](https://github.com/NixOS/nixpkgs/commit/adb61b4058b09638a78ac94687fe1bc405f4206f) highlight: 4.18 -> 4.19
* [`2492d059`](https://github.com/NixOS/nixpkgs/commit/2492d0593f7212232b4276d1717aa5f3f7ab6a90) python3Packages.pysma: 1.1.1 -> 1.1.3
* [`b7b4b005`](https://github.com/NixOS/nixpkgs/commit/b7b4b005f513af76623b8cb2a13c4a9bdfb1959c) docs/readme: add 'examples first' convention
* [`e854fff0`](https://github.com/NixOS/nixpkgs/commit/e854fff069646957bb5dd8483407407d633716ab) rott{,-shareware}: drop
* [`8590bd26`](https://github.com/NixOS/nixpkgs/commit/8590bd26baaeeea8fcf000af456f1921e38cc843) vesktop: add "x-scheme-handler/discord" mime type
* [`51a87105`](https://github.com/NixOS/nixpkgs/commit/51a87105129d3ba4cbae3a06da751f981d271e21) ob-xf: init at 1.0.3
* [`e9ede67a`](https://github.com/NixOS/nixpkgs/commit/e9ede67aa9193ec3811ceadd52678e2834264abc) maintainers: add Marker06
* [`47f8355c`](https://github.com/NixOS/nixpkgs/commit/47f8355c8a0b2e4084f89c581e12bd8971676cdd) extract-xiso: init at 202505152050
* [`8d982dd6`](https://github.com/NixOS/nixpkgs/commit/8d982dd6ca4f91c8c31c641fb90eb7843457cfb1) nixos/bazarr: fix unit: add RequiresMountsFor for data directory
* [`61791898`](https://github.com/NixOS/nixpkgs/commit/617918980fc826f8f92330fb1300204d4ae3f90e) nixos/seerr: fix unit: RequiresMountsFor for config directory
* [`3f192fbc`](https://github.com/NixOS/nixpkgs/commit/3f192fbc4002c63de5595dd7a9e50c76136ea844) nixos/prowlarr: fix unit: RequiresMountsFor for data directory
* [`94d2a37b`](https://github.com/NixOS/nixpkgs/commit/94d2a37b2a6e638f61a24a5ddf6fb172d298076b) lsp-plugins: 1.2.27 -> 1.2.29
* [`1bf01fe6`](https://github.com/NixOS/nixpkgs/commit/1bf01fe6e5dcdfaf35ad38df1766c78101a63ac2) vcpkg-tool: fix compatibility with BSD install
* [`c946f379`](https://github.com/NixOS/nixpkgs/commit/c946f379ae67cabe7a89ea8386210d27b483f711) tomcat10: 10.1.52 -> 10.1.54
* [`e747a7b1`](https://github.com/NixOS/nixpkgs/commit/e747a7b1d7449afedfc17079cafc16054f0d00cf) tomcat11: 11.0.20 -> 11.0.21
* [`3e8e73b8`](https://github.com/NixOS/nixpkgs/commit/3e8e73b859a05ad8253a6ec48c06e1fa7da63782) noctalia-qs: 0.0.10 -> 0.0.12
* [`6f12c48b`](https://github.com/NixOS/nixpkgs/commit/6f12c48b933470a8614a85462df8efd3bd70c90d) build-rust-crate: support propagatedBuildInputs in crate overrides
* [`9e74156c`](https://github.com/NixOS/nixpkgs/commit/9e74156c7ddf27fff6d59f089921ec516dd85ea7) tomcat9: 9.0.115 -> 9.0.117
* [`1a503f07`](https://github.com/NixOS/nixpkgs/commit/1a503f071720f7c8b7b96d4bd985f85c933d8fcd) quarto: 1.8.26 -> 1.9.37
* [`ec899328`](https://github.com/NixOS/nixpkgs/commit/ec899328090f0b5e32345daca33983b70303e620) maintainers: add j10ccc
* [`3de61ea5`](https://github.com/NixOS/nixpkgs/commit/3de61ea5e0721aebe03e67bfd02f13c99f90384c) gegl: enable strictDeps
* [`99d62657`](https://github.com/NixOS/nixpkgs/commit/99d62657f5eefac06c177d3e9e777266a93f21d7) proj: 9.8.0 -> 9.8.1
* [`ade95bb0`](https://github.com/NixOS/nixpkgs/commit/ade95bb0608b686d15ecbd39311e008e1b3f383f) kakoune-lsp: 19.0.1 -> 20.0.0
* [`a86d6ed9`](https://github.com/NixOS/nixpkgs/commit/a86d6ed9b1aa42abace60a1f70676c26c9326c75) nixos/acme: make webroot world-readable at creation
* [`d25d6390`](https://github.com/NixOS/nixpkgs/commit/d25d63903113ef973cc627ebc63641eb9900a40b) nixos/acme: remove scripted webroot creation
* [`157e8846`](https://github.com/NixOS/nixpkgs/commit/157e88467bf15c8d1ff9a02f7e0ece78b7685a7f) insomnia: move icon to spec-compliant location
* [`1707bbd6`](https://github.com/NixOS/nixpkgs/commit/1707bbd6f3312d9c6271eb5ec0aad104c48c80dc) firefly-desktop: move icon to spec-compliant location
* [`d8135805`](https://github.com/NixOS/nixpkgs/commit/d8135805d7cf8da51f3009da4e0c010b1cf6e158) firefly-desktop: use replace-fail
* [`c87f0c93`](https://github.com/NixOS/nixpkgs/commit/c87f0c9382972776d087866bef66df58a66f226d) cubelify: move icon to spec-compliant location
* [`a81ac64b`](https://github.com/NixOS/nixpkgs/commit/a81ac64b89a41901399518848b04f1edda19a3f1) lunar-client: move icon to spec-compliant location
* [`9a6f6afa`](https://github.com/NixOS/nixpkgs/commit/9a6f6afaefbe49507e61c305f367862a2f928f10) rare: move icon to spec-compliant location
* [`6d328b2c`](https://github.com/NixOS/nixpkgs/commit/6d328b2c60a3c9c2778a50e6a856fbdc7dc68012) caido-desktop: fix exec in desktop file
* [`14d96abb`](https://github.com/NixOS/nixpkgs/commit/14d96abb46f28c1ff91fd33b21438f358d9242d6) lely-core: fix build with gcc15
* [`3c3a2129`](https://github.com/NixOS/nixpkgs/commit/3c3a21292be90c033590da3eaea1a1cf96c0c4f8) agent-browser: 0.25.4 -> 0.26.0
* [`c3fee635`](https://github.com/NixOS/nixpkgs/commit/c3fee6350608b2645c60b74a5ca0097638981a07) sonoscli: init at 0.1.0
* [`0b580746`](https://github.com/NixOS/nixpkgs/commit/0b5807460f785acb8f222cf025c950ead779043f) masterpdfeditor: 5.9.94 -> 5.9.98
* [`f696ae3c`](https://github.com/NixOS/nixpkgs/commit/f696ae3c9141b8347383818bb40acafa2cf86ae4) php: fix infinite recursion with overrideAttrs
* [`07841512`](https://github.com/NixOS/nixpkgs/commit/07841512d2dc3014f82bdd37fe072e0611eaf43f) nixos/tests/etc-overlay-mutable: add regression test for opaque upperdir
* [`bb438ccf`](https://github.com/NixOS/nixpkgs/commit/bb438ccfad2bb11107289f098422d76a5348e788) vscode-js-debug: 1.104.0 -> 1.117.0
* [`ff90b2c1`](https://github.com/NixOS/nixpkgs/commit/ff90b2c1192d96d39da067e2e1561765cd50b279) hat-trie: init at 0.7.1
* [`2af6f234`](https://github.com/NixOS/nixpkgs/commit/2af6f23402a7a7bad6a8bc6739b2668c3ef8a2fa) maintainers: add couldbemathijs
* [`2614d7e1`](https://github.com/NixOS/nixpkgs/commit/2614d7e1dad3172889a53d443903875017aa3028) kwin-effect-geometry-change: init at 1.5.0
* [`53939f34`](https://github.com/NixOS/nixpkgs/commit/53939f341f642c2100f9553781f04ec53934209e) joystickwake: change `src` origin to Codeberg
* [`382a86a5`](https://github.com/NixOS/nixpkgs/commit/382a86a5fe760abfe659b71e81d861827fd30e0f) opensrc: init at 0.7.2
* [`171da095`](https://github.com/NixOS/nixpkgs/commit/171da0951473c9adbbe6b3d8266cceb9bd00e335) linuxwave: 0.3.0 -> 0.4.0
* [`47d3fa5b`](https://github.com/NixOS/nixpkgs/commit/47d3fa5bdf8a219d504f7c676fee19d8f16cc5a1) box64: 0.4.0 -> 0.4.2
* [`3c5db5ce`](https://github.com/NixOS/nixpkgs/commit/3c5db5ceba893467cee119845b10588fd8309b0b) nixos-init: add clear-etc-opaque entrypoint
* [`1c7c4d22`](https://github.com/NixOS/nixpkgs/commit/1c7c4d2291cfdace47c1b448aa19a396f99e7036) nixos/etc: clear stale opaque markers from mutable overlay upperdir
* [`89fd1156`](https://github.com/NixOS/nixpkgs/commit/89fd11569b40f75031ae284aa5cd6c8cfe27bd0d) welle-io: fix permission error creating /Applications folder
* [`05dfcf90`](https://github.com/NixOS/nixpkgs/commit/05dfcf90621107bb5ec7e104becd8f2404a009c7) swagger-cli: drop
* [`2bf66db7`](https://github.com/NixOS/nixpkgs/commit/2bf66db78be8a9dfd6f5e42b738a10bdcd240b36) vangers: pin to ffmpeg 7
* [`7a59715b`](https://github.com/NixOS/nixpkgs/commit/7a59715b110dafa212a19b912f12df02735905d1) cockpit-machines: 351 -> 352
* [`8ff35148`](https://github.com/NixOS/nixpkgs/commit/8ff35148c929b37b02604bfd69b2f1882e6b8afa) cockpit-files: 39 -> 40
* [`60809056`](https://github.com/NixOS/nixpkgs/commit/60809056cb0f097a281f3ec9f94e0853f23a7cb1) cockpit-podman: 124 -> 125
* [`534194d1`](https://github.com/NixOS/nixpkgs/commit/534194d1a2697e6caa57d782c09a438337429322) maintainers: add fraioveio
* [`0afa9278`](https://github.com/NixOS/nixpkgs/commit/0afa9278be9dd9f1eded17b85c414ad193c12510) nixos/roundcube: set nginx client_max_body_size for attachments
* [`f914d7e3`](https://github.com/NixOS/nixpkgs/commit/f914d7e320518c8d7ec6f1bc79035ca605c76c63) nixos-shell: add updateScript
* [`43e5365e`](https://github.com/NixOS/nixpkgs/commit/43e5365edada73b6edea0bc7da197a864d186705) nixos-shell: 2.0.0 -> 2.2.0
* [`adc71aa1`](https://github.com/NixOS/nixpkgs/commit/adc71aa1a270fc5f362a60f4d7d80838bd44ca10) cage: 0.2.1 -> 0.3.0
* [`00aaffcb`](https://github.com/NixOS/nixpkgs/commit/00aaffcbf620148233c62c02454024091de20699) joystickwake: 0.4.2 -> 0.5.2
* [`c8116258`](https://github.com/NixOS/nixpkgs/commit/c811625838ea39f2d2f94dc1b4d077d460d91e3c) kicad-testing-small: 10.0-2026-04-22 -> 10.0-2026-04-24
* [`18a42a06`](https://github.com/NixOS/nixpkgs/commit/18a42a06313fd01c3d32df41ff3a32407d188b16) omnictl: 1.6.2 -> 1.7.1
* [`a6850f73`](https://github.com/NixOS/nixpkgs/commit/a6850f73632274d446ca6529b45df51c666de220) verilator: 5.046 -> 5.048
* [`062624d5`](https://github.com/NixOS/nixpkgs/commit/062624d590dd52a05740005be14fd858201c724e) dillo: 3.2.0 -> 3.3.0, add update script
* [`590d99ed`](https://github.com/NixOS/nixpkgs/commit/590d99ed5f9e0a7250f7fd684542bd8c7f89a626) lib/systems: remove old isCompatible
* [`0f0f29fc`](https://github.com/NixOS/nixpkgs/commit/0f0f29fcf1a17717ebd1f0fff951838562198835) lib/systems: store version of elaborated system without functions
* [`2d7e4a07`](https://github.com/NixOS/nixpkgs/commit/2d7e4a0780af03f9c5398168856e4f2114574f14) buildpack: 0.37.0 -> 0.40.3
* [`bdb94e30`](https://github.com/NixOS/nixpkgs/commit/bdb94e30e42f67528ec759826a980eea66724267) nixos/logiops: init
* [`01e4565a`](https://github.com/NixOS/nixpkgs/commit/01e4565a07d1c0165c6dfef506b8ce08b9cc2651) python3Packages.policy-sentry: 0.15.1 -> 0.16.0
* [`64381b15`](https://github.com/NixOS/nixpkgs/commit/64381b15766f2f5d3f7f4df365f3c26052d33bcf) heimdall-proxy: 0.17.13 -> 0.17.14
* [`9c6c7af4`](https://github.com/NixOS/nixpkgs/commit/9c6c7af4b8e226c1b7edbec68910266f143282f3) nixos/systemd: install soft-reboot units
* [`46a87f1d`](https://github.com/NixOS/nixpkgs/commit/46a87f1df968ec6625585a78514dac1f9173a907) python3Packages.langsmith: 0.7.32 -> 0.7.37
* [`7fa1eb37`](https://github.com/NixOS/nixpkgs/commit/7fa1eb373833c5a7546d3b94bdc87c9b2e41e136) kimai: 2.55.0 -> 2.56.0
* [`62e2e3b8`](https://github.com/NixOS/nixpkgs/commit/62e2e3b83dffe4fd974cf2167ec6be5326ded3df) mullvad: 2026.1 -> 2026.2
* [`986cb78f`](https://github.com/NixOS/nixpkgs/commit/986cb78f05538197ed0929c3bbcb9ffd427e9abe) Reapply "lib/strings.concatLines: call concatStringsSep directly"
* [`c7f825c0`](https://github.com/NixOS/nixpkgs/commit/c7f825c0fbb6ba2c4889af1130ca6b135026e157) prometheus-speedtest-exporter: init at 0.0.5
* [`7d6226f8`](https://github.com/NixOS/nixpkgs/commit/7d6226f8560ce7848956070cfed61c81173a2345) nixos/prometheus-exporters: add speedtest exporter
* [`aa2961d3`](https://github.com/NixOS/nixpkgs/commit/aa2961d365aa4fd71e57a3d4251857970cfd9cfa) nixos/prometheus-exporters: fix missing port for speedtest exporter
* [`1eb691b7`](https://github.com/NixOS/nixpkgs/commit/1eb691b7e7710fa33f00cdf4bf95b976c4fec16f) maintainers: add roehrijn
* [`319ce849`](https://github.com/NixOS/nixpkgs/commit/319ce849244eb95617cf8c10735398c6f28095d7) vcluster: 0.31.0 -> 0.33.2
* [`42e88a3b`](https://github.com/NixOS/nixpkgs/commit/42e88a3bb5c3f38126a4be45104444c2342a4f26) equibop: 2.1.9 -> 2.2.0
* [`39aea2d5`](https://github.com/NixOS/nixpkgs/commit/39aea2d52a1a0b1e63c7cc6bb344eaed0f8559ab) lychee: 0.23.0 -> 0.24.1
* [`ce4d1f66`](https://github.com/NixOS/nixpkgs/commit/ce4d1f665ded48cbfa6ed4451e7ea26a5ff03ce7) nominatim: 5.2.0 -> 5.3.2
* [`4164acfa`](https://github.com/NixOS/nixpkgs/commit/4164acfae4ad1b7bd20cc1768d0dd510ca77f83b) gdal: fix build on darwin
* [`72a094ca`](https://github.com/NixOS/nixpkgs/commit/72a094ca2cd69a03c455790d8f4812853847aec7) render-cli: 2.15.1 -> 2.16.0
* [`46855ba7`](https://github.com/NixOS/nixpkgs/commit/46855ba7e67e6e7a0593047d1694884bf50ae2d0) source-meta-json-schema: 14.13.4 -> 15.2.0
* [`1c3fbfd0`](https://github.com/NixOS/nixpkgs/commit/1c3fbfd0713120c5a39479569a60003f11e3b4d9) dstask: add shell completion support
* [`712b471f`](https://github.com/NixOS/nixpkgs/commit/712b471f8b2691d385e74a9b16a32ddc36de7d94)  maintainers: add remidupre
* [`0f2be1f7`](https://github.com/NixOS/nixpkgs/commit/0f2be1f70b1fb91a99fe21b3820a39bbf5c11e16) dstask: add remidupre to maintainers
* [`68661b7b`](https://github.com/NixOS/nixpkgs/commit/68661b7b16253944044a9dcde20f454e57d6c857) tinygo: 0.40.1 -> 0.41.1
* [`538ab9ca`](https://github.com/NixOS/nixpkgs/commit/538ab9caf00a19ebf5f1c6e252a94645ba0c7dd1) john: rolling-2404 -> rolling-2604
* [`b4598a64`](https://github.com/NixOS/nixpkgs/commit/b4598a64ea0550d1ef14555df0b29c90d98d8fb3) netbird-dashboard: 2.36.0 -> 2.37.1
* [`0fcd5fad`](https://github.com/NixOS/nixpkgs/commit/0fcd5fadd87c5dcf5687d6c5459dbc2876d90a1f) vcpkg: 2026.03.18 -> 2026.04.27
* [`fd5b98b3`](https://github.com/NixOS/nixpkgs/commit/fd5b98b3b0bd6aebd270062cb47ea97558fe1331) buildkite-cli: 3.32.2 -> 3.40.0
* [`f096459f`](https://github.com/NixOS/nixpkgs/commit/f096459f72b61e9d81e7155b2267184af233b21c) lazytrivy: 1.2.0 -> 1.3.3
* [`12b1adec`](https://github.com/NixOS/nixpkgs/commit/12b1adec9a81bc8aeb7c1b80bf9ddd220cfbd082) noto-fonts: 2026.04.01 -> 2026.05.01
* [`6074eff3`](https://github.com/NixOS/nixpkgs/commit/6074eff3b9f376a93973c240a17e64a915fbe48c) tdl: 0.19.0 -> 0.20.2
* [`47db9588`](https://github.com/NixOS/nixpkgs/commit/47db95888ad97161fa42243f4a062f57d2e3a5cc) headplane: 0.6.1 -> 0.6.2
* [`9dae218b`](https://github.com/NixOS/nixpkgs/commit/9dae218b4c28df7520c0b6ce4e5e254f1e7374ef) python3Packages.lxml-html-clean: 0.4.3 -> 0.4.4
* [`ab8d1efd`](https://github.com/NixOS/nixpkgs/commit/ab8d1efd3c27f53f130e33bf1cd45de59660e1d5) ticktick: 8.0.0 -> 8.0.10
* [`5a631804`](https://github.com/NixOS/nixpkgs/commit/5a631804a3f43e22884ad32d993c634234f72776) nedit: 5.7 -> 5.8
* [`8e65b596`](https://github.com/NixOS/nixpkgs/commit/8e65b596270afc07bcd65a8a1230bfa0295706e4) synthv1: 1.4.1 -> 1.4.2
* [`c1fa146a`](https://github.com/NixOS/nixpkgs/commit/c1fa146ac1092134b44929d7833a958b5d00298a) samplv1: 1.4.1 -> 1.4.2
* [`39f805e0`](https://github.com/NixOS/nixpkgs/commit/39f805e0c853f4a5ff3f7a4cc6e8e4ee71787751) drumkv1: 1.4.1 -> 1.4.2
* [`cbd6f703`](https://github.com/NixOS/nixpkgs/commit/cbd6f703e50858f77086a028ab4b8cf3f01a3b61) kent: 492 -> 497
* [`b4b1ca25`](https://github.com/NixOS/nixpkgs/commit/b4b1ca25b06a35cd2dedb441d7f632ba77188861) bcc: apply upstream patch
* [`afdf462d`](https://github.com/NixOS/nixpkgs/commit/afdf462d7e853bb2a81217dee631dcac7261eb90) kokkos: 5.1.0 -> 5.1.1
* [`33fbbdb0`](https://github.com/NixOS/nixpkgs/commit/33fbbdb04f4b7f571f29c0471035758fdd2d31aa) radicle-explorer: refactor
* [`088daa4b`](https://github.com/NixOS/nixpkgs/commit/088daa4b922b17640900d7d32c2030e61b8699a4) shelfmark{,-frontend}: 1.2.1 -> 1.2.2
* [`15552e03`](https://github.com/NixOS/nixpkgs/commit/15552e032fe756180e2c0d9186137bca85fe58d4) shelfmark: inline frontend and add updateScript
* [`13f0bd5f`](https://github.com/NixOS/nixpkgs/commit/13f0bd5f924c4498e734aa501fac5baefccd1ffd) Revert "Revert [nixos/nixpkgs⁠#481473](https://togithub.com/nixos/nixpkgs/issues/481473) "nixos/network-interfaces: remove network-setup""
* [`ff3a0a45`](https://github.com/NixOS/nixpkgs/commit/ff3a0a4565cf666bf316337b00563219decf5b73) nixos/networking-interfaces-scripted: add fix for systemd initrd
* [`49b3bfe0`](https://github.com/NixOS/nixpkgs/commit/49b3bfe001859d85e4722d14805aa27db1177f92) python3Packages.qiskit: 2.3.1 -> 2.4.1
* [`3f9a20d0`](https://github.com/NixOS/nixpkgs/commit/3f9a20d09bbc5d338bb906685953adcf5aab6ef3) simple-completion-language-server: unstable-2025-07-29 -> unstable-2026-04-21
* [`3149e245`](https://github.com/NixOS/nixpkgs/commit/3149e24583ae8f8f426208535888714f79b3d5d7) mongodb-7_0: 7.0.31 -> 7.0.32
* [`ff26205d`](https://github.com/NixOS/nixpkgs/commit/ff26205d89f90feea321dfb94395c8b6d6cfb1fe) iterm2: fix download URL extraction in update script
* [`3f060303`](https://github.com/NixOS/nixpkgs/commit/3f060303eb6cc079b6692dfd7081d7d9bcfde6b2) maintainers: add caseyavila
* [`bb9a28b2`](https://github.com/NixOS/nixpkgs/commit/bb9a28b2ba9b251e333d4a5ebcaebcfbd99fc0b6) nb: 7.25.3 -> 7.25.4
* [`7bbd4f8b`](https://github.com/NixOS/nixpkgs/commit/7bbd4f8bfcab69e02546440b1f8258c6607e6bf6) headplane: fix 0.6.2 options
* [`692911f6`](https://github.com/NixOS/nixpkgs/commit/692911f6a0289844d4fc098cc85e24ef5cd6ec43) headplane: fix 0.6.2 release note
* [`3bd93d9c`](https://github.com/NixOS/nixpkgs/commit/3bd93d9c0e7dbfbad08fb69250013904c32cfcb7) python3.pkgs.django-mdeditor: mark as vulnerable
* [`356c711b`](https://github.com/NixOS/nixpkgs/commit/356c711b9a3eb986cdc5a081383995b608cf40e5) ranger: 1.9.4-unstable-2026-04-14 -> 1.9.4-unstable-2026-04-26
* [`90a2d70a`](https://github.com/NixOS/nixpkgs/commit/90a2d70abe2d07121f9f95bc2a93163423e3fe89) nixos/lib/make-multi-disk-zfs-image: use structuredAttrs instead of passAsFile
* [`340a2d69`](https://github.com/NixOS/nixpkgs/commit/340a2d696982f4196fc2ef3c97354870a29ba18f) nixos/lib/make-single-disk-zfs-image: use structuredAttrs instead of passAsFile
* [`3aa172c2`](https://github.com/NixOS/nixpkgs/commit/3aa172c2edbcbfd5bb7edf7c55a7dc217c147f9c) shelfmark: 1.2.2 -> 1.2.3
* [`71791c37`](https://github.com/NixOS/nixpkgs/commit/71791c37408b235510cc4dafaf91c4dce5eb9e67) mmtui: fix update script
* [`3b97b0e4`](https://github.com/NixOS/nixpkgs/commit/3b97b0e489c7f91052cd752d3d22dac7a0a1c4d4) golines: 0.13.0 -> 0.15.0
* [`3bb0e09f`](https://github.com/NixOS/nixpkgs/commit/3bb0e09f742467c68be0eb8acc98ea578dac5cdc) cef-binary: 142.0.10 -> 147.0.10
* [`ebe40cd2`](https://github.com/NixOS/nixpkgs/commit/ebe40cd20222009b0301bb1d5d6cae0d057a071b) graphite: 0-unstable-2026-03-29 -> 0-unstable-2026-05-02
* [`ed11b643`](https://github.com/NixOS/nixpkgs/commit/ed11b643dfd7e155068e44a69652475e757bf054) graphite: patch cef-rs to stop checking for exact cef version
* [`79aec2d4`](https://github.com/NixOS/nixpkgs/commit/79aec2d4bf0bee9bae16df5cbb0be4bc2917ae16) stdenv.mkDerivation: avoid // merge if meta.mainProgram not set
* [`efa31b9d`](https://github.com/NixOS/nixpkgs/commit/efa31b9d8b442e92afc0609827816110638d0b50) stdenv.mkDerivation: invert conditions, move stdenv check upwards
* [`9e49230e`](https://github.com/NixOS/nixpkgs/commit/9e49230e6dcc8315535b4e2c5ade12e87f6d9ab9) stdenv.mkDerivation: check if host suffix is necessary
* [`0d2799e6`](https://github.com/NixOS/nixpkgs/commit/0d2799e68b582e6655857b0394f147cc8849f88b) stdenv.mkDerivation: check that build inputs are empty individually
* [`0ae0cab0`](https://github.com/NixOS/nixpkgs/commit/0ae0cab0b834ff7b8fe56e4f2a62cfac3e15293d) stdenv.mkDerivation: fallback to knownHardeningFlags directly with stdenvNoCC
* [`9897c149`](https://github.com/NixOS/nixpkgs/commit/9897c149b65a037b1a231b16ae8170d381ee186b) laszip: 3.4.4 -> 3.5.0
* [`8c674613`](https://github.com/NixOS/nixpkgs/commit/8c6746131dd85e15863d86f320cc4e61756630b6) laszip: add hythera as maintainer
* [`abd4c3be`](https://github.com/NixOS/nixpkgs/commit/abd4c3beffeb69f8e338873e0179ffc075baca69) sesh: use __structuredAttrs
* [`72911b31`](https://github.com/NixOS/nixpkgs/commit/72911b31cde976ece2f3df36edcca676e4a8b43c) subxt: rev -> tag
* [`d9ee7d67`](https://github.com/NixOS/nixpkgs/commit/d9ee7d67f53f586272d196aaacea400b1882e0a6) subxt: update meta, adopt
* [`c0407c87`](https://github.com/NixOS/nixpkgs/commit/c0407c87aee1dc35a665063c8facda54138dab3e) subxt: drop stale cmake dep
* [`f6631470`](https://github.com/NixOS/nixpkgs/commit/f663147035746fdc5d889ef77977bb0202f299db) subxt: 0.44.2 -> 0.50.0
* [`b8c21e8c`](https://github.com/NixOS/nixpkgs/commit/b8c21e8c64c130eba68ee7371f250417126e8d2a) snd: 26.2 -> 26.3
* [`1b1895e3`](https://github.com/NixOS/nixpkgs/commit/1b1895e3d46970b9b759f7f0450abdcac381e937) vscode-extensions.dart-code.flutter: 3.132.0 -> 3.134.0
* [`67bf3bcc`](https://github.com/NixOS/nixpkgs/commit/67bf3bcc1ad15029ebedf0988461b6a162da0b0e) cjdns: 22.1 -> 22.3
* [`e5b091ce`](https://github.com/NixOS/nixpkgs/commit/e5b091cee35b09cb2b789cdae379bdd90aa8efa5) python3Packages.typeshed-client: 2.8.2 -> 2.11.0
* [`9c375747`](https://github.com/NixOS/nixpkgs/commit/9c375747c62c4a4fc13de9fb73dbccdfba5e864c) halo: 2.24.0 -> 2.24.2
* [`4f3c3a4f`](https://github.com/NixOS/nixpkgs/commit/4f3c3a4f085720de9f99d33acf7bf9cdd62ab15c) minizinc-ide: 2.9.5 -> 2.9.7
* [`54a4afd7`](https://github.com/NixOS/nixpkgs/commit/54a4afd79c7142239b6f0a1122497345e724453c) python3Packages.sdkmanager: 0.6.11 -> 0.7.0
* [`948c5d0d`](https://github.com/NixOS/nixpkgs/commit/948c5d0da2da9331dbeb215ffce1e5ba831cd023) nixos-test-driver: fix vlan/bridge cleanup
* [`927c5b72`](https://github.com/NixOS/nixpkgs/commit/927c5b72f13a78d9f1dc4cfd60b5fa771a69a1c1) openttd-jgrpp: 0.69.2 -> 0.72.0
* [`58bd6226`](https://github.com/NixOS/nixpkgs/commit/58bd622688e74b239cd6a152d20e438a0073c94f) luaPackages.mega-logging: init at 1.1.6
* [`37d80aea`](https://github.com/NixOS/nixpkgs/commit/37d80aeaeebaf644fdccbdc90cecb9b5ee2293ef) luaPackages.mega-cmdparse: init at 1.2.1
* [`61feedfa`](https://github.com/NixOS/nixpkgs/commit/61feedfa7d3fb10491bbfac0f418eed46465ed31) ophcrack: fix build
* [`ecc62941`](https://github.com/NixOS/nixpkgs/commit/ecc62941b65ca1630919bf135e7d366598374ef5) etcd*: cleanup
* [`ad5451d1`](https://github.com/NixOS/nixpkgs/commit/ad5451d16746cef5bda0b2b7a471e766e5f1a41d) etcd_3_4: 3.4.42 -> 3.4.44
* [`4c344cde`](https://github.com/NixOS/nixpkgs/commit/4c344cdeae8d1a1f32f774d33ae48eb1fc6fa1ad) etcd_3_5: 3.5.29 -> 3.5.30
* [`1eae869c`](https://github.com/NixOS/nixpkgs/commit/1eae869c69e69c8c661b77c4442308e590357437) etcd_3_6: 3.6.10 -> 3.6.11
* [`9a0bec4b`](https://github.com/NixOS/nixpkgs/commit/9a0bec4b8860f4740dd5440e4d7730593eea0536) maintainers: add artifycz
* [`da2f3797`](https://github.com/NixOS/nixpkgs/commit/da2f37970281cf2eee19d55ca9d7468865a1667d) openttd-jgrpp: add artifycz as maintainer
* [`8dcee6bb`](https://github.com/NixOS/nixpkgs/commit/8dcee6bba035d74836b55162d7b8f05ffa34db8a) box64: Enable new DynaRec on powerpc64le
* [`3b280244`](https://github.com/NixOS/nixpkgs/commit/3b2802441fc789bc664e5171ff31c902070a4bb5) envision{,-unwrapped}: mark as broken, remove pandapip1 and add coolGi as maintainer
* [`3d38296a`](https://github.com/NixOS/nixpkgs/commit/3d38296a2f7a43bd61c80b4a044ef854a1813d98) nixos/motioneye: use ffmpeg-headless
* [`63e5d6b5`](https://github.com/NixOS/nixpkgs/commit/63e5d6b5d3af307f86a8aeaa90d207976b6d70cf) petidomo: fix build with gcc15
* [`e2c3d187`](https://github.com/NixOS/nixpkgs/commit/e2c3d18728720070af61e569a88181193f568c14) thc-hydra: 9.6 -> 9.7
* [`81f37d7a`](https://github.com/NixOS/nixpkgs/commit/81f37d7aec6ba3802ddf14382dce106600f66081) vscode-extensions.dart-code.dart-code: 3.132.0 -> 3.134.0
* [`805911be`](https://github.com/NixOS/nixpkgs/commit/805911be4e5e7fe4fb182b30a20e3745f42d2325) vscode-extensions.tuttieee.emacs-mcx: 0.110.7 -> 0.110.9
* [`2069340b`](https://github.com/NixOS/nixpkgs/commit/2069340b1f47a88b973113e14eb5be9c6524f357) frescobaldi: 4.0.4 -> 4.0.6
* [`00258ebc`](https://github.com/NixOS/nixpkgs/commit/00258ebc5ebc995b80c80fab2308158ea81630f0) rc-9front: 0-unstable-2025-06-14 -> 0-unstable-2026-05-01
* [`52417df9`](https://github.com/NixOS/nixpkgs/commit/52417df974f604fb09ab6b4572cf87b8be07e15c) vscode-extensions.coder.coder-remote: 1.14.3 -> 1.14.5
* [`e93563e6`](https://github.com/NixOS/nixpkgs/commit/e93563e6a8bc0130c9122cf07406fafa96c7bafb) python3Packages.pyramid-beaker: set license
* [`c28707dd`](https://github.com/NixOS/nixpkgs/commit/c28707dd5b6c57b54317028f7adb98c870a915f3) cli53: 0.8.22 -> 0.9.0
* [`98572815`](https://github.com/NixOS/nixpkgs/commit/98572815b5b6c5a7786c6673b8e8d7c5f6294a52) novelwriter: 2.8.2 -> 26.1
* [`beab2cf3`](https://github.com/NixOS/nixpkgs/commit/beab2cf395e54b6085768ef13c91b39852e029fa) python3Packages.recursive-pth-loader: set license
* [`816dadc5`](https://github.com/NixOS/nixpkgs/commit/816dadc58cd2ffedd868cc84f5a6a6ad613cf255) python3Packages.unicodecsv: set license
* [`b2f966f7`](https://github.com/NixOS/nixpkgs/commit/b2f966f7f803eed11f7e8fedbbeca89840fb73ce) ubootRock3C: init at 2026.04
* [`d887cb97`](https://github.com/NixOS/nixpkgs/commit/d887cb9758b6fbc43d2217202be3474933a5921c) ocamlPackages.reason-native.src: set license
* [`7c97a316`](https://github.com/NixOS/nixpkgs/commit/7c97a31684befa0cc98672e664ca1a88680d0534) ubootRock3C: enable strictDeps
* [`0c6a7ede`](https://github.com/NixOS/nixpkgs/commit/0c6a7eded1abcdd24f5f6a2b477889ce97ce984b) qbittorrent: fix licenses
* [`7be34c16`](https://github.com/NixOS/nixpkgs/commit/7be34c16424684ce7bb65b4bca33096e0ba82055) dolt: 1.86.2 -> 1.86.6
* [`29581302`](https://github.com/NixOS/nixpkgs/commit/29581302780f3be8c705b2560046fbe095c131bd) gscan2pdf: disable a failing test
* [`4212cf4a`](https://github.com/NixOS/nixpkgs/commit/4212cf4a7e6b925125e8afccb9b036ed388bf5c6) python3Packages.colorcet: 3.1.0 -> 3.2.1
* [`cc55ed09`](https://github.com/NixOS/nixpkgs/commit/cc55ed09afaf0e3788e3dafdf6777598dc25a2cf) nixos/gitea-actions-runner: re-register on token change
* [`c51299c5`](https://github.com/NixOS/nixpkgs/commit/c51299c5132a5143017ce0f09d423bd053dee060) qmplay2-qt6: add rubberband build input
* [`b8ab8e20`](https://github.com/NixOS/nixpkgs/commit/b8ab8e2023221d0750c8a67a5afc19749357a328) kn: 1.20.0 -> 1.22.0
* [`bf802eef`](https://github.com/NixOS/nixpkgs/commit/bf802eef35a41896fc4681e16f8debd523dc9f0b) python3Packages.opensfm: unstable-2023-12-09 -> 0.5.1-unstable-2026-05-04
* [`45b61eaa`](https://github.com/NixOS/nixpkgs/commit/45b61eaae7445c3bb042557aebf8334ba07058e4) python3Packages.opensfm: add passthru.tests
* [`e3988987`](https://github.com/NixOS/nixpkgs/commit/e39889873e7ecbcd0276a85cebcb9677345bf8b2) maintainers: add naomieow
* [`201ae320`](https://github.com/NixOS/nixpkgs/commit/201ae320539573a8f159d09757b8027d1530daf5) clojure-lsp: 2025.11.28-12.47.43 -> 2026.02.20-16.08.58
* [`15fe2c25`](https://github.com/NixOS/nixpkgs/commit/15fe2c25461674086e63701278dcba9bb2a635a4) clojure-lsp: modernize
* [`c5024840`](https://github.com/NixOS/nixpkgs/commit/c50248404d3812d1bca8232b5a32fd14fe338caa) pdf-oxide: 0.3.38 -> 0.3.43
* [`b06c87ca`](https://github.com/NixOS/nixpkgs/commit/b06c87cab9be1a9995c8566abf387c1ff8a8b6c1) python3Packages.sqlfmt: 0.29.0 -> 0.30.0
* [`be1aa7bf`](https://github.com/NixOS/nixpkgs/commit/be1aa7bf49ce600220c859016b8afa2c1c99d20f) gst123: 0.4.1 -> 0.4.1-unstable-2025-11-28
* [`071f6a5b`](https://github.com/NixOS/nixpkgs/commit/071f6a5bca23efd6dd237d16ceaaef3b25ed2e8e) python3Packages.mbstrdecoder: 1.1.4 -> 1.1.5
* [`1ab5f1e8`](https://github.com/NixOS/nixpkgs/commit/1ab5f1e87fc709c0d3a4aa3281e002bc1e6746ed) python3Packages.sqlfmt: modernize
* [`26480f73`](https://github.com/NixOS/nixpkgs/commit/26480f73386b9edced17982b962810f1e578be5d) vscode-extensions.ms-python.mypy-type-checker: 2025.2.0 -> 2026.4.0
* [`3f7dbf01`](https://github.com/NixOS/nixpkgs/commit/3f7dbf019207086bf5855157282161d684f7cd54) tilt: 0.37.0 -> 0.37.3
* [`96b54b19`](https://github.com/NixOS/nixpkgs/commit/96b54b19433a2dfb09430a24e22a11dab30fd9e8) quill-qr: set license
* [`748036a3`](https://github.com/NixOS/nixpkgs/commit/748036a3df1a94f5f97dd15b6af0dcae24f126d6) replace: set license
* [`ab481c5c`](https://github.com/NixOS/nixpkgs/commit/ab481c5c42c962c25f847a42b1b720f4ad1e414e) rofi-menugen: set license
* [`629ef043`](https://github.com/NixOS/nixpkgs/commit/629ef0430dada7da0e16f7223aed3b2f5fc70c38) rofi-power-menu: set license
* [`a352e327`](https://github.com/NixOS/nixpkgs/commit/a352e32786fb99922864944e1503e185a68a086c) rt: set license
* [`7a72b3ec`](https://github.com/NixOS/nixpkgs/commit/7a72b3ecb54c69e94e84d45c8e70eb13d26ad46e) writeHaskell: allow providing function for libraries
* [`ac5f3d19`](https://github.com/NixOS/nixpkgs/commit/ac5f3d1916f258397537d85c439f7cef2572759e) maintainers: add baba
* [`0bedef69`](https://github.com/NixOS/nixpkgs/commit/0bedef69d94798619f3246aad0f29889a3b9d785) rubik: set license
* [`304be792`](https://github.com/NixOS/nixpkgs/commit/304be79271cf70a42db5da3cf12ac33de72e4b3b) setconf: set license
* [`b5702359`](https://github.com/NixOS/nixpkgs/commit/b5702359f00e0274bd7773bab40564d97a475beb) sqlboiler-crdb: set license
* [`0c86c139`](https://github.com/NixOS/nixpkgs/commit/0c86c139b1561781fa96ae6526e56953294d1a61) tesh: set license
* [`41eb2fde`](https://github.com/NixOS/nixpkgs/commit/41eb2fdedf16abb07eafb8bbd75b9c8920ae9b5c) python3Packages.pyrealsense2: fix build
* [`48e35efd`](https://github.com/NixOS/nixpkgs/commit/48e35efd78209c4458d7efe8705c18627b5cd03c) webdav: 5.11.7 -> 5.11.8
* [`b261cc60`](https://github.com/NixOS/nixpkgs/commit/b261cc609e258251c39b52e5b2f8159515c9d6ab) torcs: 1.3.8 -> 1.3.9
* [`1d32899a`](https://github.com/NixOS/nixpkgs/commit/1d32899a5c292b3236556d29c9232dbb2766f73a) vscode-extensions.sonarsource.sonarlint-vscode: 5.2.0 -> 5.2.1
* [`73c44f28`](https://github.com/NixOS/nixpkgs/commit/73c44f28fcf57be81fb33485daaaa43649d2eca6) nixos/lasuite-docs: add easier django manage access
* [`efe2b49c`](https://github.com/NixOS/nixpkgs/commit/efe2b49cb3e8dbe83e1b7d1cfb16d5afcf7ad2d1) terminal-rain: init at 0-unstable-2026-04-30
* [`70d71edf`](https://github.com/NixOS/nixpkgs/commit/70d71edf851a7bb71a948e7f7deedc146caea22c) spade: 0.17.0 -> 0.18.0
* [`d72c3365`](https://github.com/NixOS/nixpkgs/commit/d72c336516b9b019028790b9eb354ddcff310c9a) CuboCore.corehunt: 5.0.0 -> 5.0.1
* [`002357d1`](https://github.com/NixOS/nixpkgs/commit/002357d1ebf0bf3f1d6f7efcff179b8fc6e18343) CuboCore.coregarage: 5.0.0 -> 5.0.1
* [`133c71ba`](https://github.com/NixOS/nixpkgs/commit/133c71ba43c9499a32331ce6a4d3af536c9afd6a) CuboCore.coreinfo: 5.0.0 -> 5.0.1
* [`3ae60723`](https://github.com/NixOS/nixpkgs/commit/3ae60723c13824ebf7626503ad9d4f776ae40a6d) CuboCore.corestats: 5.0.0 -> 5.0.1
* [`068f4aee`](https://github.com/NixOS/nixpkgs/commit/068f4aee657e8bd2c6a493bf79afd66fa4fa41f3) CuboCore.corepdf: 5.0.0 -> 5.0.1
* [`77848959`](https://github.com/NixOS/nixpkgs/commit/778489591fbbbba4a96e120d298dc10041336bc1) CuboCore.corerenamer: 5.0.0 -> 5.0.1
* [`caa16025`](https://github.com/NixOS/nixpkgs/commit/caa16025efb6da2da3e0a6d95dda9d3e6cf6d3d1) CuboCore.corepins: 5.0.0 -> 5.0.1
* [`978254bd`](https://github.com/NixOS/nixpkgs/commit/978254bdf02f70e81a73c4ff3410419dc8287d87) CuboCore.corearchiver: 5.0.0 -> 5.0.1
* [`96135b36`](https://github.com/NixOS/nixpkgs/commit/96135b3649e65542b27ab76996c5227b1d153d7b) CuboCore.corekeyboard: 5.0.0 -> 5.0.1
* [`50d093fa`](https://github.com/NixOS/nixpkgs/commit/50d093faa59782605d98a54c8dee6348d6958c24) CuboCore.corepad: 5.0.0 -> 5.0.1
* [`55c8a6f5`](https://github.com/NixOS/nixpkgs/commit/55c8a6f521c834ed20a811c80bd9bd779303ccea) CuboCore.coreimage: 5.0.0 -> 5.0.1
* [`d5e74892`](https://github.com/NixOS/nixpkgs/commit/d5e7489277f53ab9b47e2c1c70525c97f6a45ac8) CuboCore.corepaint: 5.0.0 -> 5.0.1
* [`dd4121aa`](https://github.com/NixOS/nixpkgs/commit/dd4121aa4dc55f963d0ef37722de835242d02a3a) CuboCore.coreaction: 5.0.0 -> 5.0.1
* [`6f5cd1ec`](https://github.com/NixOS/nixpkgs/commit/6f5cd1ec38dcf356d61835edb7dcc51b66a65564) swim: 0.17.0 -> 0.18.0
* [`d227ed25`](https://github.com/NixOS/nixpkgs/commit/d227ed25c6ae89b426ffb9170fd23a28b34ec5d0) python3Packages.onnxslim: 0.1.82 -> 0.1.92
* [`63ea0d3a`](https://github.com/NixOS/nixpkgs/commit/63ea0d3a7af7aa0653b160c144fe0bbd3e0d66e0) pipeline: 3.3.1 -> 4.0.2
* [`ce5e5116`](https://github.com/NixOS/nixpkgs/commit/ce5e5116a00c234decb2098ddcfa2fa62243ae57) zsh-autoenv: set license
* [`17964c96`](https://github.com/NixOS/nixpkgs/commit/17964c96aa5e2685f07bd5f774bc849677012b57) rumqttd: fix build
* [`fd66ed2a`](https://github.com/NixOS/nixpkgs/commit/fd66ed2aa99156eeb713ad94cc93d7e89befe0bf) maintainers: add xmnlz
* [`6d828320`](https://github.com/NixOS/nixpkgs/commit/6d8283204ed34023c45c702e70ad3862d8488561) xvfb-run: enable darwin support
* [`b3d7a3b3`](https://github.com/NixOS/nixpkgs/commit/b3d7a3b3372a9ba66edb072d87317a172314da92) teamspeak6-client: 6.0.0-beta3.4 -> 6.0.0-beta4
* [`effcd023`](https://github.com/NixOS/nixpkgs/commit/effcd023cb4b5372836b280d0335a2d1b3ed8adf) anydesk: add missing aarch64 dependencies
* [`b76a1254`](https://github.com/NixOS/nixpkgs/commit/b76a1254d915b969ea43bdb4daa61e696375e646) lycheeslicer: 7.6.4 -> 7.6.5
* [`ca755772`](https://github.com/NixOS/nixpkgs/commit/ca755772d127612ecb172753d71125382ffaf329) anydesk: 7.1.3 -> 8.0.2
* [`25b3f18c`](https://github.com/NixOS/nixpkgs/commit/25b3f18c18a5784245e99660e6052e92d209fcc2) anytype: fix desktop entry
* [`2d0bc098`](https://github.com/NixOS/nixpkgs/commit/2d0bc09836222fa058beb455b518a568d2e9dc82) hidden-bar: 1.9 -> 1.10
* [`a95ef697`](https://github.com/NixOS/nixpkgs/commit/a95ef697318fb74fdaddc63ee5ac5618eefa8c3c) maintainers: remove mmai
* [`e6e93ef6`](https://github.com/NixOS/nixpkgs/commit/e6e93ef65a420488ff0e0290b54cb516f0e15ffa) goofcord: 2.2.0 -> 2.2.1
* [`71b2c2d3`](https://github.com/NixOS/nixpkgs/commit/71b2c2d35a0fd8dbffea7dfdf68670dd8ac2c426) rocmPackages: 7.2.2 -> 7.2.3
* [`708b3c9a`](https://github.com/NixOS/nixpkgs/commit/708b3c9a83bc97d96e6a6ad635b5ae3481978e02) libgit2: 1.9.2 -> 1.9.3
* [`257689de`](https://github.com/NixOS/nixpkgs/commit/257689de3d626085b008ecc0c05d940acf7c4e27) mailutils: fix portability issue affecting musl
* [`e59d4a1f`](https://github.com/NixOS/nixpkgs/commit/e59d4a1f1af3c2a5a018ad2f11a0fac3b11a729c) goaway: 0.63.7 -> 0.63.15
* [`0f857ff9`](https://github.com/NixOS/nixpkgs/commit/0f857ff930674beaed29b7c1cba597b1278b209b) teams-for-linux: 2.8.1 -> 2.9.0
* [`9a37f4ea`](https://github.com/NixOS/nixpkgs/commit/9a37f4ead7442edd568f3f2b72b46d6e85909fe3) zuban: 0.7.1 -> 0.7.2
* [`55216bc8`](https://github.com/NixOS/nixpkgs/commit/55216bc8d523bda62d8699d0c6691fa054d22835) apidog: 2.8.26 -> 2.8.27
* [`6bb4c2a4`](https://github.com/NixOS/nixpkgs/commit/6bb4c2a4d0727c80db48821f66738fb1ed43089c) mise: add git to nativeCheckInputs
* [`748385d9`](https://github.com/NixOS/nixpkgs/commit/748385d9a6488a524770cdb74df2c958fbc59929) claude-agent-acp: build wrapper with set-default
* [`f069e07d`](https://github.com/NixOS/nixpkgs/commit/f069e07d2bff540335b01f31920c54c6877f5e97) discord-canary: 1.0.962 -> 1.0.1033
* [`b45dc308`](https://github.com/NixOS/nixpkgs/commit/b45dc30858ce125bb5ba6d117a2072df10783909) discord-development: 1.0.976 -> 1.0.980
* [`a7c378c0`](https://github.com/NixOS/nixpkgs/commit/a7c378c095f4f13bd1be524c4f668dd95e60259b) discord-ptb: 1.0.188 -> 1.0.189
* [`48dd7b3c`](https://github.com/NixOS/nixpkgs/commit/48dd7b3c34fff167391ced88bc97a1b66e7cd353) discord: 0.0.134 -> 0.0.135
* [`0f6c97b5`](https://github.com/NixOS/nixpkgs/commit/0f6c97b536c10d40518fb2dbc28e5b747f137374) discord: update distro source generation
* [`fda82730`](https://github.com/NixOS/nixpkgs/commit/fda82730c08c4dc68f53917f8530a635aae60279) discord-canary: 0.0.1088 -> 0.0.1102
* [`19aa7391`](https://github.com/NixOS/nixpkgs/commit/19aa7391cae79ed6b97917f5f331ddee0fc476cb) discord-development: 1.0.982 -> 1.0.987
* [`b851333c`](https://github.com/NixOS/nixpkgs/commit/b851333c77487f0e6a680bc0305d4b321b4ca0df) discord-ptb: 0.0.231 -> 0.0.232
* [`b7c15d7f`](https://github.com/NixOS/nixpkgs/commit/b7c15d7f2e30e0db5549f1deb97eb2519fde1233) discord: 0.0.387 -> 0.0.389
* [`2a82a954`](https://github.com/NixOS/nixpkgs/commit/2a82a95464b9aae569a39e9018cf12e25b3d9fc3) discord: use distro layout on Darwin
* [`b49b623a`](https://github.com/NixOS/nixpkgs/commit/b49b623ae22c544c250e891d3fdbec82ed5f3393) discord: use distro layout for stable on Linux
* [`86105808`](https://github.com/NixOS/nixpkgs/commit/86105808a68cf3cae8e9ef3aa45db7408b43daa3) clpeak: 1.1.7 -> 2.0.0
* [`2b7759ff`](https://github.com/NixOS/nixpkgs/commit/2b7759ffccb95ef1f818c596d28cfb7149908b54) wootility: 5.3.0 -> 5.3.1
* [`a6f37ca3`](https://github.com/NixOS/nixpkgs/commit/a6f37ca30c27fc06d4266a79dd95c0515bde54e7) asha-pipewire-sink: 0-unstable-2024-10-22 -> 0-unstable-2025-05-20
* [`c46626f8`](https://github.com/NixOS/nixpkgs/commit/c46626f825f8fe7286b9a4a50b97b932a12f0619) tinty: 0.29.0 -> 0.32.2
* [`5902512f`](https://github.com/NixOS/nixpkgs/commit/5902512fe65333938580cdf5490cac9dcda82230) cue: ensure passthru attrs use final overriden package
* [`e5cea90e`](https://github.com/NixOS/nixpkgs/commit/e5cea90ef00a8bf9d2a966b846da7b06229085b7) cue: add tests.cue-validation to tests
* [`f9923189`](https://github.com/NixOS/nixpkgs/commit/f99231891b47de770283338af36cebb155c6dbe7) siril: 1.4.0 -> 1.4.2
* [`e2395519`](https://github.com/NixOS/nixpkgs/commit/e2395519fab18db812f2a8243ac7aa7929f7fc3e) zabbix74: 7.4.9 -> 7.4.10
* [`72a1ff70`](https://github.com/NixOS/nixpkgs/commit/72a1ff7016d7da21c696fdcf226f2a9eb802f73d) zabbix70: 7.0.25 -> 7.0.26
* [`299fd303`](https://github.com/NixOS/nixpkgs/commit/299fd30373515a4deb1c05a20988b960c63db07b) zabbix: 6.0.45 -> 6.0.46
* [`877ddad0`](https://github.com/NixOS/nixpkgs/commit/877ddad0aea471a921196445b8d02c19b004e29b) bitwig-studio6: 6.0 -> 6.0.6
* [`af6d58f9`](https://github.com/NixOS/nixpkgs/commit/af6d58f9b5fb54e890e6c1535d25ae1a553909cf) ugarit-manifest-maker: drop
* [`022c56df`](https://github.com/NixOS/nixpkgs/commit/022c56dfb26b64624bc218976e66a0c0affad433) python3.pkgs.beets: 2.10.0 -> 2.11.0
* [`c874469f`](https://github.com/NixOS/nixpkgs/commit/c874469f273138eeab6c3eadcb5b72c127afb6f7) nixos/virtualisation.kvmgt: use newlines to separate sentences in docstrings
* [`7c9a87f0`](https://github.com/NixOS/nixpkgs/commit/7c9a87f0176869d7dbb75f46170dc0943629a944) nixos/virtualisation.kvmgt: explain explicitly it is meant for host
* [`8673085b`](https://github.com/NixOS/nixpkgs/commit/8673085b0311bbc2b7b37d53f89b170d883c4df9) motus: init at 0.4.0
* [`00148f72`](https://github.com/NixOS/nixpkgs/commit/00148f722d6c0d912ae1398292ca5915d99be9b5) spotify: (linux) 1.2.82.428.g0ac8be2b -> 1.2.84.475.ga1a748ff
* [`19a404db`](https://github.com/NixOS/nixpkgs/commit/19a404dbde3fe0fcb28f6469455f982d554d196f) spotify: (darwin) 1.2.84.476 -> 1.2.88.483
* [`880a0623`](https://github.com/NixOS/nixpkgs/commit/880a0623fa1fbc19ff7a9964b4b4d3d953435569) pnpm_10: 10.33.2 -> 10.33.4
* [`12a89387`](https://github.com/NixOS/nixpkgs/commit/12a893878e0677334c629b521a366c4b65c295cd) shell-gpt: 1.4.5 -> 1.5.1
* [`1ce65572`](https://github.com/NixOS/nixpkgs/commit/1ce65572695ec7c712778fe5e74d55c439fc70f5) factoriolab: fix changelog url
* [`c9f72372`](https://github.com/NixOS/nixpkgs/commit/c9f72372b593cbf19d7bbb5059fb5405e76fefdf) factoriolab: 3.19.2 -> 3.20.0
* [`0934c918`](https://github.com/NixOS/nixpkgs/commit/0934c918d27d88fd67d92b8b8580745fbbbb7b41) firefly-iii: Download translations from release
* [`459a13da`](https://github.com/NixOS/nixpkgs/commit/459a13da1b21e10f1c4dc1efef13405dfbbe9b16) datadog_trace: 1.16.0 -> 1.19.2
* [`afb1bec5`](https://github.com/NixOS/nixpkgs/commit/afb1bec526ad965c0f427ae103b0b0e196cd9343) workflows/backport: Label failed backports
* [`5e2a8995`](https://github.com/NixOS/nixpkgs/commit/5e2a8995d975fef94b55f5d77a9b25724593fb78) thunderbird-latest-bin-unwrapped: 150.0 -> 150.0.1
* [`86cd4e7b`](https://github.com/NixOS/nixpkgs/commit/86cd4e7bc84cda9fe8d341a1d9a82574827fb8f3) Reapply "nixos/nixpkgs.config: make use of the module defined in config.nix"
* [`baa1fd09`](https://github.com/NixOS/nixpkgs/commit/baa1fd0958af059dc4fa350ed6136aedfc942cdf) maintainers: add coolcuber
* [`092dfcc0`](https://github.com/NixOS/nixpkgs/commit/092dfcc0dda9efcf26103a20c0de42e21b4fe71a) ocamlPackages.bytesrw: 0.2.0 → 0.3.0
* [`7e60541a`](https://github.com/NixOS/nixpkgs/commit/7e60541a0dd38c854072368b1f918c6d9e302560) fedistar: 1.11.3 -> 1.13.0
* [`6651e5ed`](https://github.com/NixOS/nixpkgs/commit/6651e5ed37b4850cc5b80024697fbec51c989cfc) enzyme: 0.0.256 -> 0.0.258
* [`5e918e01`](https://github.com/NixOS/nixpkgs/commit/5e918e015ebb6026056966d425bcc1c22fb9ab94) inklingreader: unstable-2017-09-07 -> 0.8-unstable-2026-05-06
* [`41443052`](https://github.com/NixOS/nixpkgs/commit/414430524b930bbb33b24e412333980203050823) pdfrip: 2.0.1 -> 3.0.0
* [`bd7e23dd`](https://github.com/NixOS/nixpkgs/commit/bd7e23dd1e151e7524af837c887526ec8a54f8b6) nixd: 2.9.0 -> 2.9.1
* [`39b4788c`](https://github.com/NixOS/nixpkgs/commit/39b4788c934e8aacaafa7ea760f61785a4022123) python3Packages.pdf-oxide: skip failing tests
* [`7ef4e339`](https://github.com/NixOS/nixpkgs/commit/7ef4e3393f0cc887cb15d1d1a62a921ee5f2f870) tautulli: 2.17.0 -> 2.17.1
* [`658f0872`](https://github.com/NixOS/nixpkgs/commit/658f087283122b2872702b4e16328a5cad51a1e8) cosmic-applets: 1.0.10 -> 1.0.12
* [`41b4f136`](https://github.com/NixOS/nixpkgs/commit/41b4f1360cc39daa232b4033a14e61d1ab40b233) cosmic-applibrary: 1.0.10 -> 1.0.12
* [`c46dd195`](https://github.com/NixOS/nixpkgs/commit/c46dd1950b04d11c4cedce7282923eee99baaa9f) cosmic-bg: 1.0.10 -> 1.0.12
* [`d9e8b474`](https://github.com/NixOS/nixpkgs/commit/d9e8b4746957028b3ecb88e085e43073197ca2f6) cosmic-comp: 1.0.10 -> 1.0.12
* [`cf77a8fc`](https://github.com/NixOS/nixpkgs/commit/cf77a8fc1f299bd22b165e1d4c4fca06dc28e697) cosmic-edit: 1.0.10 -> 1.0.12
* [`f6f80f89`](https://github.com/NixOS/nixpkgs/commit/f6f80f890bf13fa6dd40741b93ed20c1280c32ae) cosmic-files: 1.0.10 -> 1.0.12
* [`b816d891`](https://github.com/NixOS/nixpkgs/commit/b816d891390382ddeac0e7fa7404a72435c8db9b) cosmic-greeter: 1.0.10 -> 1.0.12
* [`63c4b4da`](https://github.com/NixOS/nixpkgs/commit/63c4b4da6faac272d7875bda7a49f4911bcc88bb) cosmic-icons: 1.0.10 -> 1.0.12
* [`d593c600`](https://github.com/NixOS/nixpkgs/commit/d593c60078348e816ee39f550835b2eb06e315ca) cosmic-idle: 1.0.10 -> 1.0.12
* [`0faf3879`](https://github.com/NixOS/nixpkgs/commit/0faf38796175bdf9cca8349172a27d712d70979d) cosmic-initial-setup: 1.0.10 -> 1.0.12
* [`75a07d0a`](https://github.com/NixOS/nixpkgs/commit/75a07d0a10d14b0271d75a82ec04713151c6e120) cosmic-launcher: 1.0.10 -> 1.0.12
* [`41696519`](https://github.com/NixOS/nixpkgs/commit/4169651992d7c81b99bc0ae21fb7d96810539ada) cosmic-notifications: 1.0.10 -> 1.0.12
* [`5ab208d6`](https://github.com/NixOS/nixpkgs/commit/5ab208d6678212baa397239c0229e24dd3096a4f) cosmic-osd: 1.0.10 -> 1.0.12
* [`a06f5dc0`](https://github.com/NixOS/nixpkgs/commit/a06f5dc064c1c4bd8468bcf97dcb28e98e244bcb) cosmic-panel: 1.0.10 -> 1.0.12
* [`78429de2`](https://github.com/NixOS/nixpkgs/commit/78429de29c9bcb8a5265d322f1a6a64ffbed55ba) cosmic-player: 1.0.10 -> 1.0.12
* [`325922b4`](https://github.com/NixOS/nixpkgs/commit/325922b4330ec25de82eaa776aa692af0550812e) cosmic-randr: 1.0.10 -> 1.0.12
* [`8f5b5ee7`](https://github.com/NixOS/nixpkgs/commit/8f5b5ee799aee26ccc750566b5466b1b112dc848) cosmic-screenshot: 1.0.10 -> 1.0.12
* [`a2403d2a`](https://github.com/NixOS/nixpkgs/commit/a2403d2ab3531b7f22f4aad57d9e565ad745ca1c) cosmic-session: 1.0.10 -> 1.0.12
* [`b329a1fc`](https://github.com/NixOS/nixpkgs/commit/b329a1fc490ddcce48a7d24c45102921ce44e543) cosmic-settings: 1.0.10 -> 1.0.12
* [`0b6cea6a`](https://github.com/NixOS/nixpkgs/commit/0b6cea6a354a2ab48858d9dd88c8fa8514881de1) cosmic-settings-daemon: 1.0.10 -> 1.0.12
* [`d3e4b617`](https://github.com/NixOS/nixpkgs/commit/d3e4b617600949a90491664e694e9fbc75c9b648) cosmic-store: 1.0.10 -> 1.0.12
* [`1dddbc4d`](https://github.com/NixOS/nixpkgs/commit/1dddbc4d0bdbb03788584ce97df77776abfc9adf) cosmic-term: 1.0.10 -> 1.0.12
* [`ea688ea2`](https://github.com/NixOS/nixpkgs/commit/ea688ea28867a68ff7d527a8340ef8fc4c242124) cosmic-wallpapers: 1.0.10 -> 1.0.12
* [`ca3fdc25`](https://github.com/NixOS/nixpkgs/commit/ca3fdc25ef377af97505ecf9b8125ffc1faa4464) cosmic-workspaces-epoch: 1.0.10 -> 1.0.12
* [`9787156d`](https://github.com/NixOS/nixpkgs/commit/9787156d30973918e9954f110a3c6b1a766cdd0e) xdg-desktop-portal-cosmic: 1.0.10 -> 1.0.12
* [`8bb89359`](https://github.com/NixOS/nixpkgs/commit/8bb89359e7045ed9eab7a83e64a2be0f38588d76) telegram-desktop: 6.7.8 -> 6.8.0
* [`e358234d`](https://github.com/NixOS/nixpkgs/commit/e358234db656a59e384044a12f3e5bc645178297) _64gram: 1.2.0 -> 1.2.1
* [`98e1d413`](https://github.com/NixOS/nixpkgs/commit/98e1d4139af8cb0468a4c0a2b723c79012cca7cf) ayugram-desktop: 6.3.10 -> 6.7.8
* [`054392b9`](https://github.com/NixOS/nixpkgs/commit/054392b92a85b63e7cbec87659e0df24ea2e21b7) librewolf-unwrapped: 150.0.1-1 -> 150.0.2-1
* [`b851d316`](https://github.com/NixOS/nixpkgs/commit/b851d316f152db02bb730f6c621365c169e25957) socalabs-voc: 1.1.1 -> 1.1.5
* [`8d1876b4`](https://github.com/NixOS/nixpkgs/commit/8d1876b47a04f526b677e04a50914a32817e29c7) socalabs-sn76489: 1.1.1 -> 1.1.5
* [`ff548819`](https://github.com/NixOS/nixpkgs/commit/ff5488197f6b1a6bb1c01785778e1a81ccf13d82) dioxus-cli: 0.7.7 -> 0.7.9
* [`1cebc277`](https://github.com/NixOS/nixpkgs/commit/1cebc277d6f3416b6400a6e29d7d07b5e155506c) home-assistant-custom-components.blueprints-updater: init at 2.4.0
* [`283964a3`](https://github.com/NixOS/nixpkgs/commit/283964a390e700769ebfc48e2846881c6d993ae2) nixos/reframe: start configured reframe-server@ instances automatically
* [`9f4adaaf`](https://github.com/NixOS/nixpkgs/commit/9f4adaafb176d2e80258f2cde32a6bea6dfcbbe4) betula: 1.6.0 -> 1.7.0
* [`e888dc4c`](https://github.com/NixOS/nixpkgs/commit/e888dc4c3bd7ecad4eecb7cd15da2296fa441213) python3Packages.granian: 2.7.2 -> 2.7.4
* [`bd1234e4`](https://github.com/NixOS/nixpkgs/commit/bd1234e4757c879e80f2b6c5dbb736e898b84213) typodermic-{free-fonts,public-domain}: drop
* [`e968009a`](https://github.com/NixOS/nixpkgs/commit/e968009ab411506d917ba8e81ac75228201d2a4f) nixos/prometheus-exporters: change repo to updated fork
* [`b582171d`](https://github.com/NixOS/nixpkgs/commit/b582171d3334903c126909d18d179ba40275ef98) seconlay: 0-unstable-2026-04-13 -> 0-unstable-2026-04-30
* [`43e6dae8`](https://github.com/NixOS/nixpkgs/commit/43e6dae8a0366f15bb9e0e925ece16941139120b) python3Packages.plover-dict-commands: init at 0.2.5
* [`e6eb178c`](https://github.com/NixOS/nixpkgs/commit/e6eb178c41e1a278cc25d679fc670ab83b51133f) python3Packages.plover-last-translation: init at 00.2
* [`e0a26f0a`](https://github.com/NixOS/nixpkgs/commit/e0a26f0ad6f2646070f464974b327562769e0929) python3Packages.plover-modal-dictionary: init at 0.0.3
* [`6174a628`](https://github.com/NixOS/nixpkgs/commit/6174a6280b758cdcf0def35d149c7dfa997e749d) python3Packages.plover-python-dictionary: init at 1.2.1
* [`2fcae69c`](https://github.com/NixOS/nixpkgs/commit/2fcae69cac2cc6a4b0712f42d280c211985c9ac3) python3Packages.plover-stiching: init at 0.1.0
* [`d47f39df`](https://github.com/NixOS/nixpkgs/commit/d47f39df07dbfdc8d350e79b20a431df9ab3a239) plover-lapwing-aio: init at 1.5.0
* [`506906e4`](https://github.com/NixOS/nixpkgs/commit/506906e470fe10b2640511625e209d70cf711d5a) python3Packages.netbox-routing: 0.4.2 -> 0.4.3
* [`6402fc28`](https://github.com/NixOS/nixpkgs/commit/6402fc286fbc8b71ae067bb8b07cf1e8a94c7c22) strobealign: fix build with gcc 15
* [`383e5481`](https://github.com/NixOS/nixpkgs/commit/383e54818742de1aa4d254141b61db9ae67ab12a) wtfutil: 0.46.1 -> 0.49.1
* [`7f172e35`](https://github.com/NixOS/nixpkgs/commit/7f172e35fd796451f621bc0a3824e6a12eb51016) sortmerna: fix build with gcc 15
* [`9c3db7cf`](https://github.com/NixOS/nixpkgs/commit/9c3db7cffbc448ec3f1c5c1c1ab3a02a6d5c170c) flutter: add shell completions
* [`ac7fc5fc`](https://github.com/NixOS/nixpkgs/commit/ac7fc5fc4c57ad1d6fd3e73ef0f419cb04e4c94b) fluffychat: 2.4.1 -> 2.5.1
* [`62ebbdb1`](https://github.com/NixOS/nixpkgs/commit/62ebbdb129bb48e969655bce9e3d5bd03680e8d8) maintainers: add fxai
* [`25053479`](https://github.com/NixOS/nixpkgs/commit/250534797c3887e7637c730c5b0e466588ed7b49) raspa: fix build with gcc 15
* [`1a3f63b0`](https://github.com/NixOS/nixpkgs/commit/1a3f63b09c8d976835be6f3a8ebfcab0e4798530) lib.license: add JSON
* [`95eb8bc4`](https://github.com/NixOS/nixpkgs/commit/95eb8bc485373baeea06ca8a64ff601ee88b5a6f) python3Packages.amplitude-analytics: init at 1.2.3
* [`51d066a5`](https://github.com/NixOS/nixpkgs/commit/51d066a573feb4e68219fa58000a8f4c9a162fdb) python3Packages.fakeredis: 2.33.0 -> 2.35.1
* [`f79a8405`](https://github.com/NixOS/nixpkgs/commit/f79a8405b424bca432896026af76b0dcb823a54a) taskhound: 1.0.0 -> 1.1.5
* [`f38f2997`](https://github.com/NixOS/nixpkgs/commit/f38f299750d1a39a7a7698a28e3198d6d5d408cb) vimPlugins.barbar-nvim: set license
* [`4a5e26bc`](https://github.com/NixOS/nixpkgs/commit/4a5e26bc8315c579d3ff50bbbb030de708c52cb4) python3Packages.burner-redis: init at 0.1.6
* [`d5be99d6`](https://github.com/NixOS/nixpkgs/commit/d5be99d65e2020960c1427541ad92235e7269ead) python3Packages.uncalled-for: 0.3.1 -> 0.3.2
* [`ceeb4f09`](https://github.com/NixOS/nixpkgs/commit/ceeb4f09855d4dcd58be6d90875ac2267c11215b) python3Packages.pydocket: 0.17.1 -> 0.20.1
* [`71081b57`](https://github.com/NixOS/nixpkgs/commit/71081b578dc79915ba20750d52108e754f2d9091) prefect: use toPythonApplication
* [`1f554f28`](https://github.com/NixOS/nixpkgs/commit/1f554f28ab920967a377b4cdd294c9e145c5edba) fosrl-pangolin: 1.17.1 -> 1.18.3
* [`79a640a7`](https://github.com/NixOS/nixpkgs/commit/79a640a7f101bccbeeb1d58e818226471cb33237) .github: Bump actions/labeler from 6.0.1 to 6.1.0
* [`ba32be8d`](https://github.com/NixOS/nixpkgs/commit/ba32be8d8973392554ac4e5e20f97fec98109c56) python3Packages.prefect: 3.5.0 -> 3.7.0
* [`b323966a`](https://github.com/NixOS/nixpkgs/commit/b323966ae803c7c4f497684cc5e5721acf42d836) nixosTests.prefect: fix
* [`c69e85dc`](https://github.com/NixOS/nixpkgs/commit/c69e85dc55537c6ab63c517f6a22dc272604faf4) python3Packages.prefect: add check dependencies
* [`b79e6c87`](https://github.com/NixOS/nixpkgs/commit/b79e6c873dfbfa36130aaa622452ab1ae10abc19) dns-collector: 2.2.2 -> 2.2.3
* [`3f9c7922`](https://github.com/NixOS/nixpkgs/commit/3f9c7922a5db6ae7857ef4822408f3213a2609d7) volatility3: 2.27.0 -> 2.28.0
* [`fac86c55`](https://github.com/NixOS/nixpkgs/commit/fac86c55a0a7b473ca7cb1651e11dc92f4c64e15) maintainers: update wolfram444 github's name
* [`0db9fb25`](https://github.com/NixOS/nixpkgs/commit/0db9fb252ff5b9802e8a7f02d23d9c62272ab464) nixos/i2c: update udev rules
* [`bd89bb04`](https://github.com/NixOS/nixpkgs/commit/bd89bb04d19f380dd6b8825c46a8992fa17a133d) batmon: 0.0.1 -> 0.2.0
* [`0d5165a3`](https://github.com/NixOS/nixpkgs/commit/0d5165a32a2d0b972d85bcd70f5c6489e9ca117a) mytetra: fix build with gcc 15
* [`d18aee9c`](https://github.com/NixOS/nixpkgs/commit/d18aee9ca8e4e84d0068f6b9adeaa8b3e1333daf) php82: 8.2.30 -> 8.2.31
* [`61d1912a`](https://github.com/NixOS/nixpkgs/commit/61d1912a476bcca12f3cf34dd533d1d80f409464) php83: 8.3.30 -> 8.3.31
* [`91efa679`](https://github.com/NixOS/nixpkgs/commit/91efa6792a47c5e8241443793c2e51d7df0bed32) php84: 8.4.20 -> 8.4.21
* [`92f7590b`](https://github.com/NixOS/nixpkgs/commit/92f7590b6f66ddd9b2a12dd882fb300e7d34122e) librewolf-bin-unwrapped: 150.0.1-1 -> 150.0.2-1
* [`21081190`](https://github.com/NixOS/nixpkgs/commit/210811905c766ca7b1434da28d8b0be548edfbce) anki: 25.09.2 -> 25.09.3
* [`0d8ad9a1`](https://github.com/NixOS/nixpkgs/commit/0d8ad9a1ee9f9169440216bf627e30c1fa50083f) lsd2dsl: fix build with boost 1.89
* [`c1c00aed`](https://github.com/NixOS/nixpkgs/commit/c1c00aed43dd92e558a524a1c1125e04d2733df3) lifelines: fix autoreconf failure from missing m4 dir
* [`833337b6`](https://github.com/NixOS/nixpkgs/commit/833337b6b7b800ad37978c539417745e375299cd) python3Packages.mypy-boto3-glue: 1.43.0 -> 1.43.5
* [`2be00d01`](https://github.com/NixOS/nixpkgs/commit/2be00d01f3a21ace0128285dc59e5850375949ae) python3Packages.mypy-boto3-imagebuilder: 1.43.0 -> 1.43.5
* [`b666f621`](https://github.com/NixOS/nixpkgs/commit/b666f6218d1df5e9289c0034252277be8e08c86c) python3Packages.mypy-boto3-lexv2-models: 1.43.0 -> 1.43.5
* [`01fc0abc`](https://github.com/NixOS/nixpkgs/commit/01fc0abc1a598fea8afd42aaf19649ace5af82db) python3Packages.mypy-boto3-mwaa: 1.43.0 -> 1.43.5
* [`7f2da5e7`](https://github.com/NixOS/nixpkgs/commit/7f2da5e77cf1941041ddf1cc3aed48be5b77188f) python3Packages.mypy-boto3-s3: 1.43.0 -> 1.43.5
* [`a1bc61ea`](https://github.com/NixOS/nixpkgs/commit/a1bc61ea69c3398a7c0c575348c54e0f112c2114) python3Packages.mypy-boto3-sagemaker: 1.43.4 -> 1.43.5
* [`f18afceb`](https://github.com/NixOS/nixpkgs/commit/f18afcebb6c3fac30f15c2f79afe03f1ec8fab2f) python3Packages.mypy-boto3-securityhub: 1.43.0 -> 1.43.5
* [`a8701175`](https://github.com/NixOS/nixpkgs/commit/a8701175a36b4e3d1590f4da913a5f0c851c98a5) python3Packages.boto3-stubs: 1.43.4 -> 1.43.5
* [`6bf0ec87`](https://github.com/NixOS/nixpkgs/commit/6bf0ec87f33107ca05c67997725fae17d905a66c) python3Packages.mypy-boto3-ec2: 1.43.3 -> 1.43.6
* [`afd0d3d3`](https://github.com/NixOS/nixpkgs/commit/afd0d3d3fa3cca20090d969ce79fdd327763e917) python3Packages.mypy-boto3-guardduty: 1.43.0 -> 1.43.6
* [`953a3dac`](https://github.com/NixOS/nixpkgs/commit/953a3dac67e089c4916f16995696ff263fa480e5) python3Packages.mypy-boto3-route53resolver: 1.43.0 -> 1.43.6
* [`17243abf`](https://github.com/NixOS/nixpkgs/commit/17243abf43922c96af7f6a0360c555f53f61b9a8) python3Packages.boto3-stubs: 1.43.5 -> 1.43.6
* [`02a1a07e`](https://github.com/NixOS/nixpkgs/commit/02a1a07e54b2b137d40c59b5d8446a4146670596) python3Packages.nomadnet: 0.9.11 -> 1.0.1
* [`ce8326d5`](https://github.com/NixOS/nixpkgs/commit/ce8326d56341cf4f4d64aa2f8b576dd28c631c18) python3Packages.rns: 1.2.3 -> 1.2.4
* [`e8ede596`](https://github.com/NixOS/nixpkgs/commit/e8ede596c884f504d94996f2e9dcf514372969e8) snyk: remove nodejs version pin
* [`8bb573b5`](https://github.com/NixOS/nixpkgs/commit/8bb573b59fc1447602523532b61ec011af0c40f6) python3Packages.appthreat-vulnerability-db: 6.6.1 -> 6.6.2
* [`45de457e`](https://github.com/NixOS/nixpkgs/commit/45de457e570dad1f8e8e0dd3ae024751e5f57f81) python3Packages.appimage: 1.0.0 -> 1.2.0
* [`3d39855f`](https://github.com/NixOS/nixpkgs/commit/3d39855fb256af9202d99e1086d1f5c46ea021a6) python3Packages.appimage: migrate to finalAttrs
* [`88dc2a2c`](https://github.com/NixOS/nixpkgs/commit/88dc2a2cf3a69719f8bfa8176d3c194fc5820fb3) wine-staging: 11.7 -> 11.8
* [`e50772d7`](https://github.com/NixOS/nixpkgs/commit/e50772d7e3326e0e03952243633c18b71ca12cc4) fastly: 14.3.1 -> 15.0.0
* [`2d3e596c`](https://github.com/NixOS/nixpkgs/commit/2d3e596c1e15bec0aa7d5ec511da01163a9a2aad) nimlangserver: 1.12.0 -> 1.14.0
* [`bfb59334`](https://github.com/NixOS/nixpkgs/commit/bfb59334d051ae7c497b2f42771b616cb4d6667f) kty: use system oniguruma to fix build
* [`44ada94b`](https://github.com/NixOS/nixpkgs/commit/44ada94b292b6ad8c72f2af28c0ed7f878062730) hacompanion: 1.0.27 -> 1.0.30
* [`f8637ce0`](https://github.com/NixOS/nixpkgs/commit/f8637ce0f82482c6d2922646c8f410356b3c2929) libuiohook: fix build with gcc 15
* [`1caf270e`](https://github.com/NixOS/nixpkgs/commit/1caf270ef386d9585641bf16bae6d429dd6d6819) pantheon.elementary-files: 7.3.0 -> 7.3.1
* [`9d726623`](https://github.com/NixOS/nixpkgs/commit/9d726623de4a7eb689070e4a3a9ca0adeb244f0d) ctre: 3.10.0 -> 3.11.0
* [`4d58a56b`](https://github.com/NixOS/nixpkgs/commit/4d58a56bf8e7d1fec675c4e7304588c654fdb885) python3Packages.jupyterlab: 4.5.3 -> 4.5.7
* [`5e9a1bed`](https://github.com/NixOS/nixpkgs/commit/5e9a1bed258882d0fb83e43d61b6880059112b0a) python3Packages.notebook: 7.5.3 -> 7.5.6
* [`6262b28b`](https://github.com/NixOS/nixpkgs/commit/6262b28bb50404550b2ac52e2c4a224324b38563) python3Packages.adlfs: 2026.4.0 -> 2026.5.0
* [`6a97bf0f`](https://github.com/NixOS/nixpkgs/commit/6a97bf0f3622ce46c966f1030a746f14dc782599) brave: 1.89.145 -> 1.90.121
* [`6951377e`](https://github.com/NixOS/nixpkgs/commit/6951377e1d8c8e51f255199ad8d124d739851925) nixos/prometheus-exporters: use finalAttrs pattern
* [`db75133b`](https://github.com/NixOS/nixpkgs/commit/db75133b96496e0a4acf01ad3678565f6ea6d3d9) subjack: init at 3.0.0
* [`a689c613`](https://github.com/NixOS/nixpkgs/commit/a689c61315d45ec7f7785503dd3a8e6602323741) ophcrack: fix darwin build
* [`29c41af6`](https://github.com/NixOS/nixpkgs/commit/29c41af60ec25de27b7ca476848a11bbca49c42a) nixos/zfs: fix indentation
* [`3559bcc4`](https://github.com/NixOS/nixpkgs/commit/3559bcc40a089130bb8c80635f86c5bef5e31c5f) home-assistant-custom-lovelace-modules.navbar-card: use finalAttrs, add update script, support aarch64-linux
* [`f5ee5762`](https://github.com/NixOS/nixpkgs/commit/f5ee5762f0d76ccb3908a83f397ac182e16977e7) ci/github-script/manual-file-edits: skip on PRs from one dev branch to another
* [`f72ac56d`](https://github.com/NixOS/nixpkgs/commit/f72ac56df28d638720d76b98e845e3855a2031b8) dotnet: fix indentation in update scripts
* [`5a2c4a38`](https://github.com/NixOS/nixpkgs/commit/5a2c4a386e482fe0a217d4a29aec9fcc21b60cac) dotnet: don't evaluate missing packages
* [`fc35ff6c`](https://github.com/NixOS/nixpkgs/commit/fc35ff6c8566fd8939b8055356f6d82cdf710fff) amnezia-vpn: rework premium
* [`5b511c17`](https://github.com/NixOS/nixpkgs/commit/5b511c170c0d3680808b58ef351f569460f7dfbd) ryubing: migrate to forgejo
* [`b8178f50`](https://github.com/NixOS/nixpkgs/commit/b8178f50daa0dcab133a89c7c1c5cb78bcccb719) {libcss, libdom}: set propagatedBuildInputs
* [`71e0b21b`](https://github.com/NixOS/nixpkgs/commit/71e0b21b3a25e70a59988f196379a351a69cbfc7) elinks: build with meson
* [`8347e356`](https://github.com/NixOS/nixpkgs/commit/8347e356e54549ae97588e1d7c72fb459cc060fe) telegram-desktop: 6.8.0 -> 6.8.1
* [`80cb4d6d`](https://github.com/NixOS/nixpkgs/commit/80cb4d6d45812bcf5fd0cd63de4f7cd3230d541b) tsshd: 0.1.6 -> 0.1.7
* [`06afa7d1`](https://github.com/NixOS/nixpkgs/commit/06afa7d13bbf8fd2fc3954f8c9cd887fa60276c2) routedns: 0.1.159 -> 0.1.169
* [`546b2bf7`](https://github.com/NixOS/nixpkgs/commit/546b2bf70258d39fc796ef823270a1d8ecf70224) git-xet: 0.2.0 -> 0.2.1
* [`c4e699b2`](https://github.com/NixOS/nixpkgs/commit/c4e699b29282dc1ecac8d1d7db70e281da5a1fe0) wasmtime: 44.0.0 -> 44.0.1
* [`cbd2f72d`](https://github.com/NixOS/nixpkgs/commit/cbd2f72d5dc945e1571eef28d4fe1809f84a3ae0) matlab-language-server: 1.3.10 -> 1.3.11
* [`43d0eaac`](https://github.com/NixOS/nixpkgs/commit/43d0eaac89a0246a1760f12d0aaa2a7e604c8811) honggfuzz: 2.6 -> 2.6-unstable-2026-04-13
* [`9161d5f1`](https://github.com/NixOS/nixpkgs/commit/9161d5f1974127ef4e2fcf16166f90a495543647) josh: 26.04.19 -> 26.05.08
* [`7b98a8ee`](https://github.com/NixOS/nixpkgs/commit/7b98a8ee2334a018e9f27d7c3362fbaa41b31902) vencord: 1.14.11 -> 1.14.13
* [`83471e14`](https://github.com/NixOS/nixpkgs/commit/83471e14ee397a6c26bfb0d95d5dcd649d632efa) nzbhydra2: 8.8.0 -> 8.8.1
* [`b31d77f6`](https://github.com/NixOS/nixpkgs/commit/b31d77f6e408ca9737ada25562fb29c6e90c0f88) enlightenment.evisum: 1.2.3 -> 2.0.7
* [`98bd2571`](https://github.com/NixOS/nixpkgs/commit/98bd2571745fa2ba48149e2b0b09d38cf7f943f2) jdupes: fix Darwin build
* [`19786230`](https://github.com/NixOS/nixpkgs/commit/197862308f32089bf027713757e8bdfb436a1a24) llama-cpp: 8983 -> 9080
* [`7682ddab`](https://github.com/NixOS/nixpkgs/commit/7682ddab75199ec318cc42e615147e45da5db0d7) kiro-cli: 2.2.0 -> 2.2.2
* [`f65b98c8`](https://github.com/NixOS/nixpkgs/commit/f65b98c8834a0de3bfb91fd8dae616118c4922e3) files-cli: 2.15.282 -> 2.15.287
* [`58cbdfee`](https://github.com/NixOS/nixpkgs/commit/58cbdfee0c74194bf5cf57f25aadf9a913664f7e) linux_6_1: 6.1.171 -> 6.1.172
* [`370865ad`](https://github.com/NixOS/nixpkgs/commit/370865adc5135438aa34d9f84ef20b8797451f83) linux_5_15: 5.15.205 -> 5.15.206
* [`eb123b45`](https://github.com/NixOS/nixpkgs/commit/eb123b458b96dce745aea292be7d0deb3fc451f4) python3Packages.hcloud: 2.19.0 -> 2.20.0
* [`c7f1840d`](https://github.com/NixOS/nixpkgs/commit/c7f1840da2bfc094d3fefb97ecc448517dc0c816) python3Packages.disposable-email-domains: 0.0.177 -> 0.0.181
* [`2f715416`](https://github.com/NixOS/nixpkgs/commit/2f715416cc4103a9921ef0ac000af4d627660a57) zed-editor: 1.1.6 -> 1.1.7
* [`52fd7bf8`](https://github.com/NixOS/nixpkgs/commit/52fd7bf87ee83b5c86dadfb4fde4c6cfbaab4027) nixos/oauth2-proxy: add trustedProxyIP option and warning when it is not set in combination with reverseProxy
* [`d2b349c2`](https://github.com/NixOS/nixpkgs/commit/d2b349c2a4684d429b5195c37139bab0a3066c4f) python3Packages.countryinfo: 1.0.0 -> 1.0.1
* [`2bcfe886`](https://github.com/NixOS/nixpkgs/commit/2bcfe88606b1313be541297962398a8820b08768) python3Packages.countryinfo: clean-up
* [`316f867e`](https://github.com/NixOS/nixpkgs/commit/316f867e7d03a96e28fe6cdfa3a91e229a4ee502) spacetimedb: 2.1.0 -> 2.2.0
* [`3dabcae4`](https://github.com/NixOS/nixpkgs/commit/3dabcae4c36bc10eecf4a30b4240808ab5a03122) anda: init at 0.5.4
* [`33c4942a`](https://github.com/NixOS/nixpkgs/commit/33c4942a1d298862e7d90e54afa855aad5e58ee6) dns-collector: clean-up
* [`fde15f53`](https://github.com/NixOS/nixpkgs/commit/fde15f53336e3559ad072909ba6c584554b15e01) home-assistant-custom-components.plant: 2026.3.2 -> 2026.5.0
* [`5236c263`](https://github.com/NixOS/nixpkgs/commit/5236c26383b20db4d8dede203c0a7e5c41d6a28a) home-assistant-custom-components.pi-hole-v6: init at 1.17.0
* [`ea9cb940`](https://github.com/NixOS/nixpkgs/commit/ea9cb940c0da04abbd7a45b23e696a8cb5b39f2b) libastyle: 3.6.14 -> 3.6.15
* [`78f08517`](https://github.com/NixOS/nixpkgs/commit/78f08517872118be75fdbc456d239014e6385d24) pgbouncer: 1.25.1 -> 1.25.2
* [`9d27c50a`](https://github.com/NixOS/nixpkgs/commit/9d27c50ac8cc4c255febf5348742c5e85d5f6300) git-codereview: 1.19.0 -> 1.20.0
* [`b1b519b0`](https://github.com/NixOS/nixpkgs/commit/b1b519b097f5b5b7d3e0d28250573fae9402b607) ciel: 3.10.3 -> 3.10.4
* [`e6823e88`](https://github.com/NixOS/nixpkgs/commit/e6823e8808c1484f1f5b5e0e39abd0fa612cb451) nerva: 1.3.0 -> 1.4.0
* [`ba83e354`](https://github.com/NixOS/nixpkgs/commit/ba83e354e435c5333fae878a53206c2a3a1f4540) jsonschema-cli: 0.46.3 -> 0.46.4
* [`569c783e`](https://github.com/NixOS/nixpkgs/commit/569c783e73ef5067bd1a225f20ac5d5102219345) codex: 0.128.0 -> 0.130.0
* [`1f63447f`](https://github.com/NixOS/nixpkgs/commit/1f63447f7dcfd439d0117378f64c4e8d6cc63a56) terraform-providers.linode_linode: 3.11.0 -> 3.12.0
* [`9b9f8f82`](https://github.com/NixOS/nixpkgs/commit/9b9f8f8202f400c0619d720d29a11b05249f8665) cnspec: 13.7.0 -> 13.8.2
* [`c24eb315`](https://github.com/NixOS/nixpkgs/commit/c24eb315d2fcbc390015adfa1d611fb6ba5bf7e2) libmsquic: 2.5.7 -> 2.5.8
* [`e7c071f1`](https://github.com/NixOS/nixpkgs/commit/e7c071f1da22ef37eb4d7f2117ef9e3ea1dd297b) python314Packages.aubio-ledfx: init at 0.4.11 and replace python3Packages.aubio
* [`e8e00aa5`](https://github.com/NixOS/nixpkgs/commit/e8e00aa57136f3bf5405eccfd1273c2b49a50669) mysql-shell_8: unpin stdenv
* [`b72b434f`](https://github.com/NixOS/nixpkgs/commit/b72b434f0bdb703cf74e0e6dc74482868478f0af) mysql-shell_9: unpin stdenv
* [`710e70e2`](https://github.com/NixOS/nixpkgs/commit/710e70e2154bdf35a55c7db35f2a4bb65dd4946b) mysql-shell_innovation: unpin stdenv
* [`beed25aa`](https://github.com/NixOS/nixpkgs/commit/beed25aab6e0d496cf95ea8c86a5b87fa7a19074) python3Packages.pyobjc-framework-CoreAudio: init at 11.1
* [`16dfcd3e`](https://github.com/NixOS/nixpkgs/commit/16dfcd3e0ffa89f8d7e41199e6bb22ab7f90a14b) python314Packages.audio-hotplug: init at 0.1.0
* [`2db9058c`](https://github.com/NixOS/nixpkgs/commit/2db9058c303e903e7f1b2a2af2903143729ae104) python314Packages.pyfastnoiselite: init at 0.0.7
* [`4a792e7f`](https://github.com/NixOS/nixpkgs/commit/4a792e7f4e6abbed6d70dd61b4eb52e047ab0d08) python314Packages.pyflac: init at 3.0.0
* [`1d08d405`](https://github.com/NixOS/nixpkgs/commit/1d08d405a0a6dedce89d4e1f6732eb726bccfeee) python314Packages.samplerate-ledfx: init at 0.2.6
* [`d295473d`](https://github.com/NixOS/nixpkgs/commit/d295473de08ee150a78ce2e21a9dbbcf52461e7f) python314Packages.lifx-emulator-core: init at 3.6.3
* [`c69a27c1`](https://github.com/NixOS/nixpkgs/commit/c69a27c1ff566c10fec70c2bdeca37a2d7deec1c) python314Packages.lifx-async: init at 5.4.8
* [`dd9242cb`](https://github.com/NixOS/nixpkgs/commit/dd9242cbd0d24d7867c2b39df051b46b763eee5f) python314Packages.flux-led: enable on darwin
* [`a9f6a1fe`](https://github.com/NixOS/nixpkgs/commit/a9f6a1fed056c278b6fbeb630526f34e70940df1) ledfx: 2.1.0 -> 2.1.8
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
