### PR TITLE
npins home-manager: update b659c7ff -> 866412a1

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -61,9 +61,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "b659c7ffd40fc9e3bb60d420c79c67e769b9f4ab",
-      "url": "https://github.com/nix-community/home-manager/archive/b659c7ffd40fc9e3bb60d420c79c67e769b9f4ab.tar.gz",
-      "hash": "sha256-kkUQYSv70wynJ/DfnGals6r98I6bK3CVNVTN1zbAd7Y="
+      "revision": "866412a19866b4a8e32d2306a118040afa2b840c",
+      "url": "https://github.com/nix-community/home-manager/archive/866412a19866b4a8e32d2306a118040afa2b840c.tar.gz",
+      "hash": "sha256-VbiyZkRf8/qr7ObmlyfOHJsNAW5tyZ4MB1+cUwAwdrw="
     },
     "hs-grille": {
       "type": "Git",


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@b659c7ff...866412a1](https://github.com/nix-community/home-manager/compare/b659c7ffd40fc9e3bb60d420c79c67e769b9f4ab...866412a19866b4a8e32d2306a118040afa2b840c)

* [`b3de8ada`](https://github.com/nix-community/home-manager/commit/b3de8ada63521fc16c6e535172085f0863b611f9) maintainers: update all-maintainers.nix
* [`1768d4e4`](https://github.com/nix-community/home-manager/commit/1768d4e49860b86cb7652ee738de0e6b3050dd40) chromium: add Microsoft Edge
* [`755b9931`](https://github.com/nix-community/home-manager/commit/755b9931658ac6ef380b5aec0791ddc424b321ce) fish: fix handler function sourcing
* [`b7e6cad3`](https://github.com/nix-community/home-manager/commit/b7e6cad33548d10e685e9a7ec18d823f45ffd5c2) tests/fish: add non-handler function defined as attrset
* [`eb3e569f`](https://github.com/nix-community/home-manager/commit/eb3e569fd44db25904c2359570b5ce7f027cb664) flake: bump nixpkgs from `1c3fe55` to `da5ad66`
* [`3f640297`](https://github.com/nix-community/home-manager/commit/3f6402974019ae29a45570641ab4641bf87232f4) tests: restore TOML goldens for remarshal
* [`a5e92be8`](https://github.com/nix-community/home-manager/commit/a5e92be80314523e7a8e946046dd69fc463d55fd) maintainers: drop duplicate ojsef39 entry
* [`2d53d45f`](https://github.com/nix-community/home-manager/commit/2d53d45f6b6c7b022cde84720f2b8df6c4648924) tests: avoid removed acd-cli package
* [`5878fdad`](https://github.com/nix-community/home-manager/commit/5878fdadfe2cfe1b3383b38d66117f7b80696b68) tests: avoid removed anime-downloader package
* [`6a0bbd6b`](https://github.com/nix-community/home-manager/commit/6a0bbd6b4720da1c9ce7ebf35ff5c41a82db367a) wallust: fix config location on darwin
* [`7654d90b`](https://github.com/nix-community/home-manager/commit/7654d90b94bab7eba3a52fd6f73b3f5a4c544fa2) mailmap: map NAHO developer identity to Noah Biewesch
* [`acd9d8af`](https://github.com/nix-community/home-manager/commit/acd9d8af2ff46c5737cc9e76bc367e41f54645c4) hyprland: migrate settings to native lua option API
* [`03d2aa63`](https://github.com/nix-community/home-manager/commit/03d2aa63172be70e9488b8a795411b52c6d8a50d) hyprland: submaps option lua support
* [`9760b31d`](https://github.com/nix-community/home-manager/commit/9760b31dab3016fc6e422ca241cfeac605fb89c9) hyprland: generate LuaLS config
* [`41d5f1e5`](https://github.com/nix-community/home-manager/commit/41d5f1e504b5c5833d314991807b8a01b54d3d25) yazi: add plugin setup options
* [`f04b141d`](https://github.com/nix-community/home-manager/commit/f04b141d1a0d6d7d62aa9678aef602dfb61e8bb1) yazi: test plugin setup generation
* [`4f9cbe43`](https://github.com/nix-community/home-manager/commit/4f9cbe4384e00cf2cf80e99741e93f12a67a8f32) tailscale-systray: make theme configurable
* [`c3e7eb98`](https://github.com/nix-community/home-manager/commit/c3e7eb98c3c21f408039d717f5d4bdb0ecf6f158) podman: fix tests
* [`3d4f5477`](https://github.com/nix-community/home-manager/commit/3d4f5477f03e0de9f80ad0da7784d43cd386697c) hyprland: remove old removed options
* [`2809b9e3`](https://github.com/nix-community/home-manager/commit/2809b9e3f83c5eea8818452424ec90386ced1407) ssh: allow explicit "no" for identitiesOnly in matchBlocks
* [`c68d2a24`](https://github.com/nix-community/home-manager/commit/c68d2a24376da3860ef161373d91348b1542356b) ssh-tpm-agent: add extraArgs option
* [`9846abe1`](https://github.com/nix-community/home-manager/commit/9846abe15e7d0d36b8acbd4d05f2b87461744c92) Translate using Weblate (Toki Pona)
* [`3e707f5f`](https://github.com/nix-community/home-manager/commit/3e707f5f93d7be40fd3e4182ed977446bdf2e2c3) eww: remove shell integration
* [`e7a7c550`](https://github.com/nix-community/home-manager/commit/e7a7c550e22ae631cd738db9dcd317a9544962e3) claude-code: add `configDir` option
* [`2cb4f4db`](https://github.com/nix-community/home-manager/commit/2cb4f4db37c13bb51a4c61911aaa210de6525ece) maintainers: add garklein
* [`1bedcc87`](https://github.com/nix-community/home-manager/commit/1bedcc8740b9aa2f7d3e1312a6c88baf00909f54) exwm: add module
* [`ca77575d`](https://github.com/nix-community/home-manager/commit/ca77575d39c908de876c10f93704532689df546f) t3code: add module
* [`c7fad819`](https://github.com/nix-community/home-manager/commit/c7fad8197070948d8aa02cb8922240ee129cab2e) sherlock: update `aliases` example to use the official NixOS Wiki link
* [`3c71cec0`](https://github.com/nix-community/home-manager/commit/3c71cec05da50f0e61b779345b16fe0093636c3c) ci: use `grep -c` instead of `grep|wc -l`
* [`92a87361`](https://github.com/nix-community/home-manager/commit/92a8736142944ed3b2c4aba8b364583b6fda15a5) ci: quote some shell variables
* [`f63af17f`](https://github.com/nix-community/home-manager/commit/f63af17f47af7e11ab526ccc02eb661ede5f3629) podman: quote Quadlet labels with spaces
* [`1772e8fb`](https://github.com/nix-community/home-manager/commit/1772e8fb838e26f9b0f07bcbc5118c62af314d85) qt: pass negative KDE settings as values
* [`32b42d71`](https://github.com/nix-community/home-manager/commit/32b42d71b4b22c4465963285bb6e462d7c93d45e) discord: add option for different config locations
* [`d5ece85b`](https://github.com/nix-community/home-manager/commit/d5ece85b6d3d6b5ab5a514b2785fb952b629bfea) zsh: guard session variables under nounset
* [`26aaab78`](https://github.com/nix-community/home-manager/commit/26aaab785b0bab4af60a2c42b22760fa906ef22a) claude-code: fixes enableMcpIntegration option docstring
* [`bcb774cf`](https://github.com/nix-community/home-manager/commit/bcb774cfc3268120cd61808629f9aa7dad3750a2) git-credential-keepassxc: fix misplaced parentheses
* [`917e3469`](https://github.com/nix-community/home-manager/commit/917e3469fe37f2bcabc4f5efeb8982f657edcbf8) mkFirefoxModule: allow per-extension settings force
* [`355734d8`](https://github.com/nix-community/home-manager/commit/355734d876f103b6f8cd38ba853b7c7d74d2a82f) treewide: remove literalExpression where unneeded
* [`84ddd33e`](https://github.com/nix-community/home-manager/commit/84ddd33ed07a119f090a050f1b1735de64eaf0ef) elephant: add module
* [`d918d224`](https://github.com/nix-community/home-manager/commit/d918d22422c81a5a311461b663e4f5dc8e3bf857) walker: add elephant integration
* [`1bc2cf3e`](https://github.com/nix-community/home-manager/commit/1bc2cf3eedfed36448e809c1cb24462df93ae242) hyprland: support lua variables in settings
* [`08c9d014`](https://github.com/nix-community/home-manager/commit/08c9d01457badce151aa4a983c475042d9dec018) hyprland: add khaneliman maintainer
* [`a2c0bcaf`](https://github.com/nix-community/home-manager/commit/a2c0bcaff4414902d1b735a1f152248b3299378d) fontconfig: document defaulting behavior on NixOS
* [`dd71501f`](https://github.com/nix-community/home-manager/commit/dd71501fb7005264feb4de78444a2e1518cd4f66) treewide: move NixOS-inherited defaults to their option definitions
* [`0f08a37c`](https://github.com/nix-community/home-manager/commit/0f08a37c317111c7fcb53b983c0e49bf4b7fb904) ci: fix module count output
* [`74f170c6`](https://github.com/nix-community/home-manager/commit/74f170c62d57f90e656841f1f699e6bdf40f0a24) maintainers: update all-maintainers.nix
* [`7519f615`](https://github.com/nix-community/home-manager/commit/7519f615df36804ef40bcb03d4114f5ec9216d40) ec: init module
* [`936ae1b1`](https://github.com/nix-community/home-manager/commit/936ae1b1ebcf3bb81ae6b433829c7354439101d7) ssh: add RFC 42 settings option
* [`fab3fd73`](https://github.com/nix-community/home-manager/commit/fab3fd7327a0ac7a1fae5095bf140377704fac7f) ssh: fix ssh `enableDefaultConfig` description
* [`b0e20777`](https://github.com/nix-community/home-manager/commit/b0e2077789e884d66c47274b88aca4899d28b05f) eww: added improvements
* [`3ee415b2`](https://github.com/nix-community/home-manager/commit/3ee415b2922c3cfd3e7c64927a720178d365f513) gnome-shell: use user-themes extension
* [`f968ed59`](https://github.com/nix-community/home-manager/commit/f968ed5961dc72645fbed289684a2ee3f9abf0ed) syncthing: support legacy config dir
* [`736c2084`](https://github.com/nix-community/home-manager/commit/736c2084ea750a049ecdbdd7ff5817d2eeeef444) podman: ensure openssh is available in PATH
* [`866412a1`](https://github.com/nix-community/home-manager/commit/866412a19866b4a8e32d2306a118040afa2b840c) git: use absolute paths for git-lfs in config
