### PR TITLE
npins nerd-icons.el: update b63f9f9f -> d33d12f5

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -112,9 +112,9 @@
       },
       "branch": "main",
       "submodules": false,
-      "revision": "b63f9f9fda431dd4a9e8dc7ccb8e02996fbeca77",
-      "url": "https://github.com/rainstormstudio/nerd-icons.el/archive/b63f9f9fda431dd4a9e8dc7ccb8e02996fbeca77.tar.gz",
-      "hash": "sha256-iK/kmbYFOn8B/r0L0zRoWip+2M+I4mVt+rKnFkR0Nj4="
+      "revision": "d33d12f5dcb6bf2fb23c3f75df5de85beb4afd95",
+      "url": "https://github.com/rainstormstudio/nerd-icons.el/archive/d33d12f5dcb6bf2fb23c3f75df5de85beb4afd95.tar.gz",
+      "hash": "sha256-kMvhhWmRaH0jpxqID6jwNNde4w0aE6QL5ivUbe2TER8="
     },
     "niv": {
       "type": "Git",


### PR DESCRIPTION
## Changelog for nerd-icons.el:
Branch: main
Commits: [rainstormstudio/nerd-icons.el@b63f9f9f...d33d12f5](https://github.com/rainstormstudio/nerd-icons.el/compare/b63f9f9fda431dd4a9e8dc7ccb8e02996fbeca77...d33d12f5dcb6bf2fb23c3f75df5de85beb4afd95)

* [`a5b6899d`](https://github.com/rainstormstudio/nerd-icons.el/commit/a5b6899dd529cac195179feb6b32b32379fda22a) feat(nerd-icons): Add Bash icon configuration
* [`d33d12f5`](https://github.com/rainstormstudio/nerd-icons.el/commit/d33d12f5dcb6bf2fb23c3f75df5de85beb4afd95) Disable case-fold-search in nerd-icons-match-to-alist ([rainstormstudio/nerd-icons.el⁠#155](https://togithub.com/rainstormstudio/nerd-icons.el/issues/155))
