### PR TITLE
npins nixpkgs: update d2339023 -> 3d8f0f3f

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -132,8 +132,8 @@
     "nixpkgs": {
       "type": "Channel",
       "name": "nixpkgs-unstable",
-      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-26.05pre998534.d233902339c0/nixexprs.tar.xz",
-      "hash": "sha256-vZOcDniDPc1cS8A4Xi5YE6AGyPIvEpy4GMyayA3SWIM="
+      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-26.05pre1003764.3d8f0f3f72a6/nixexprs.tar.xz",
+      "hash": "sha256-Zc5W2GRfLZtIDsEn0A5kzoN0+yNWq/3MzzoXGu0ytMU="
     },
     "powerlevel10k": {
       "type": "Git",


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: release-26.05
Commits: [nixos/nixpkgs@d2339023...3d8f0f3f](https://github.com/nixos/nixpkgs/compare/d233902339c0...3d8f0f3f72a6)

* [`5df7a56a`](https://github.com/NixOS/nixpkgs/commit/5df7a56a74ed868ef1985620f84d8796e031d272) libcanberra: enable parallel building
* [`0e4c2571`](https://github.com/NixOS/nixpkgs/commit/0e4c25710c2b1fffda86fb3ba17ae30a523264d7) maintainers: add lvanasse
* [`bf3fcbe6`](https://github.com/NixOS/nixpkgs/commit/bf3fcbe60b759375eba80bc521e963fec14156d8) blowfish-tools: 1.10.0 -> 1.13.1
* [`b3953b61`](https://github.com/NixOS/nixpkgs/commit/b3953b613373003d9f2cfb907104ff5b6409b9f2) firefox: allow customising generated autoconfig.js
* [`45d01afb`](https://github.com/NixOS/nixpkgs/commit/45d01afb40aa36e26834ac95add831f12f059756) nixos/mullvad-vpn: include pkgs prefix in package example
* [`26dbb73c`](https://github.com/NixOS/nixpkgs/commit/26dbb73c9ddeb1bb07ac1da880183ced6f9fe49b) nixos/systemd/tpm2: add pcrphase services
* [`54be2f64`](https://github.com/NixOS/nixpkgs/commit/54be2f6470bf2a28c9e50fc36c330c55bec90768) yquake2: move icon to spec-compliant location
* [`de44764f`](https://github.com/NixOS/nixpkgs/commit/de44764f21a454d4543a8539b6fd45576984f0fe) haskellPackages.basement: fix on ghcjs
* [`5bda4227`](https://github.com/NixOS/nixpkgs/commit/5bda4227ab5cafaf6e56665c8b007f03c19aad76) haskellPackages.foundation: fix on ghcjs
* [`b2236f4a`](https://github.com/NixOS/nixpkgs/commit/b2236f4a585c31438718a76165aa854ca4001fe7) yquake2: fix build with GCC 15
* [`4bcf914d`](https://github.com/NixOS/nixpkgs/commit/4bcf914d0f5ee20c7b768f7f9f4ba5eb283762af) reredirect: 0.3 -> unstable-2026-02-15
* [`60270b0b`](https://github.com/NixOS/nixpkgs/commit/60270b0be261410e66cda73cc975e6b8a2ecd14d) yosys: set YOSYS_PLUGIN_PATH
* [`5db0ab5b`](https://github.com/NixOS/nixpkgs/commit/5db0ab5b0b97272a15b1b9025818924283ae1415) fnm: 1.38.1 -> 1.39.0
* [`e7e8527e`](https://github.com/NixOS/nixpkgs/commit/e7e8527e9a2ca118fe91a191d795b99c7e09e97a) libiconvReal: 1.18 -> 1.19
* [`e8d36115`](https://github.com/NixOS/nixpkgs/commit/e8d36115f1eb996a7b47b7aaa4feb1fb12946065) various: fixup leftover pixmaps references
* [`6f094e4d`](https://github.com/NixOS/nixpkgs/commit/6f094e4d62acd6b0d67031681ed94a9246141c7e) rofi-rbw-wayland: 1.5.1 -> 1.6.1
* [`fc4320f3`](https://github.com/NixOS/nixpkgs/commit/fc4320f33012aff235023c39cc1e7746d6109192) libxml2: 2.15.1 -> 2.15.2
* [`22e3e45e`](https://github.com/NixOS/nixpkgs/commit/22e3e45edd81f4ac15e2a697b2282a11d3c54f20) capacities: 1.57.24 -> 1.59.1
* [`a05078ee`](https://github.com/NixOS/nixpkgs/commit/a05078ee87d67aced807c06ba646445b9f3ddf98) buildGoModule: expand excludedPackages for structuredAttrs
* [`3750bf46`](https://github.com/NixOS/nixpkgs/commit/3750bf46f315929a74426eafa80b3f99492eb208) haskellPackages.iserv-proxy: fix on GHC 9.6
* [`8a5a1102`](https://github.com/NixOS/nixpkgs/commit/8a5a110275962ad1fa8295f973797238399142fe) haskellPackages.iserv-proxy: test on Hydra
* [`b388850c`](https://github.com/NixOS/nixpkgs/commit/b388850ca4cf925e67ca757f599202288cebad60) haskellPackages: fix eval cycle when doCheck is enabled for cross
* [`37a7f5f5`](https://github.com/NixOS/nixpkgs/commit/37a7f5f534e26c1fc58eafa44e4f08d5aad9f3da) chromium: don't greet emacs
* [`4e916734`](https://github.com/NixOS/nixpkgs/commit/4e91673453dd1c6e8ee3972134ded4f81d1d195c) haskellPackages.nix-paths: relax platform equality to 'canExecute' check
* [`63c072d0`](https://github.com/NixOS/nixpkgs/commit/63c072d0a99830377ad31237691cc3a337d01786) python3Packages.twisted: skip flaky test_fullWriteBufferAfterByteExchange on macOS
* [`8f960c36`](https://github.com/NixOS/nixpkgs/commit/8f960c365db087e2712b4c383146802be339095d) nixos/pihole-ftl: fix setup script to add allow and block lists
* [`65f50e65`](https://github.com/NixOS/nixpkgs/commit/65f50e65e36cb46b145f5b638c16b3adbc2b68c1) nsjail: 3.4 -> 3.6
* [`d7a46110`](https://github.com/NixOS/nixpkgs/commit/d7a461100a01674971d6837b1a23ba710900366f) nixos/system/activation: use structuredAttrs instead of passAsFile
* [`43019792`](https://github.com/NixOS/nixpkgs/commit/43019792096d2c64ff5db1727cfdaf75267acfcd) ndppd: 0.2.5 -> 0.2.6
* [`28a604bb`](https://github.com/NixOS/nixpkgs/commit/28a604bbcd44dc101fdf5ae4f1809f4559565fb3) wayland: 1.24.0 -> 1.25.0
* [`bd794a22`](https://github.com/NixOS/nixpkgs/commit/bd794a22dddb7187a788f5a3c6d322c24a8326c0) blazesym-c: init at 0.1.7
* [`e9852acd`](https://github.com/NixOS/nixpkgs/commit/e9852acde4b4e1be3840a357ebc95535d41993d6) python3Packages.mpmath: 1.3.0 -> 1.4.1
* [`6a5c136b`](https://github.com/NixOS/nixpkgs/commit/6a5c136b72eebe8443b0f8292259d94e0a3b7e1f) kapacitor: use structuredAttrs instead of passAsFile
* [`21ab0d33`](https://github.com/NixOS/nixpkgs/commit/21ab0d33fd53a2ef42504c3513a3c1afa93fe20f) python3Packages.diofant: fix build
* [`9d5e2be9`](https://github.com/NixOS/nixpkgs/commit/9d5e2be9c849e228b7f2053fac46e70bcf7e078b) diofant: remove suhr from contributors
* [`d1bcc8d9`](https://github.com/NixOS/nixpkgs/commit/d1bcc8d9e8b8c88662f633c719923edb5e734781) haskellPackages.*: fix build with Darwin sandbox enabled
* [`55f167d8`](https://github.com/NixOS/nixpkgs/commit/55f167d8c13d56973a4be1f39997376bca46575f) haskellPackages: use 'overrideCabal' instead of 'overrideAttrs' on darwin overrides
* [`47440224`](https://github.com/NixOS/nixpkgs/commit/474402246adf049a7093a29e91fa7c8d2d48b981) harfbuzz: 12.3.0 -> 13.2.1
* [`54627f21`](https://github.com/NixOS/nixpkgs/commit/54627f2186cd8b906f752cb4b9a47b5d2a8269b3) nixos/tests/prometheus-exporters: Fix storagebox
* [`c10ec04c`](https://github.com/NixOS/nixpkgs/commit/c10ec04c4cdf61f956b09d7afe7a52619bbeb1b6) python3Packages.scalib: init at 0.6.4
* [`ef1cd0d2`](https://github.com/NixOS/nixpkgs/commit/ef1cd0d24a44ad7a2f8af7c94280a770081af5a1) python313Packages.graphql-core: actually execute some tests
* [`b06215bc`](https://github.com/NixOS/nixpkgs/commit/b06215bc0a6fb9e8a471e7d97ca9cf83230031e4) python313Packages.graphql-core: avoid big pytest-benchmark dependency
* [`d81dcd93`](https://github.com/NixOS/nixpkgs/commit/d81dcd939a7c72babddff10a2d6b4742254e35ef) git: use cargoShortTarget for RUST_TARGET_DIR in cross compilation
* [`4b9dd82a`](https://github.com/NixOS/nixpkgs/commit/4b9dd82a45ef86027e82d31da07179db012da4df) python3Packages.attrs: 25.4.0 -> 26.1.0
* [`f18788f0`](https://github.com/NixOS/nixpkgs/commit/f18788f08dd8177fb8a996d6b2ca96cd372c0335) haskellPackages: hackage 2026-03-15T11:30:53Z -> 2026-03-27T12:41:48Z
* [`6b19d9b1`](https://github.com/NixOS/nixpkgs/commit/6b19d9b1c4dfa0b9c11ea88bcd5e5c4ba641693e) coreboot-toolchain: 25.12 -> 26.03
* [`d15d59cc`](https://github.com/NixOS/nixpkgs/commit/d15d59cc0afcc46e5bb1ed44595c3febc4cda8b7) haskellPackages.ghc-debug-client: remove jailbreak
* [`e8fe63b4`](https://github.com/NixOS/nixpkgs/commit/e8fe63b46b5a07cdd0d533bba71053e06bb116d8) haskellPackages.ghc-debug-common: remove jailbreak
* [`6f194951`](https://github.com/NixOS/nixpkgs/commit/6f194951975464c3208dc0f6781d23fb6a0a360d) maintainers/scripts/haskell/update-stackage.sh: fix cassava replacement
* [`7bc7b474`](https://github.com/NixOS/nixpkgs/commit/7bc7b47410aa92f920838b0603c6e80ebbd7955a) haskellPackages: stackage LTS 24.34 -> LTS 24.35
* [`17caee69`](https://github.com/NixOS/nixpkgs/commit/17caee69418e62fa34ee185ba3ec764e4841ee5b) haskellPackages.hell: unbreak
* [`23f5520c`](https://github.com/NixOS/nixpkgs/commit/23f5520c3b8a9a3ef3bcbb9b1485c0951e41baf4) haskellPackages: regenerate hackage-packages.nix
* [`89bca40b`](https://github.com/NixOS/nixpkgs/commit/89bca40b71fc8e531976814daf427cfe89154b18) haskellPackages.geojson: enable tests
* [`eb071756`](https://github.com/NixOS/nixpkgs/commit/eb0717565cf096353a978b511eae04e1f2237727) haskellPackages.reanimate-svg: unbreak
* [`d4f018a2`](https://github.com/NixOS/nixpkgs/commit/d4f018a21efec4509febbdb5b00e67f02341a31b) haskellPackages.reanimate: unbreak
* [`9ddef6a5`](https://github.com/NixOS/nixpkgs/commit/9ddef6a598613121516b940325092b02ac45de3c) haskellPackages.svgone: jailbreak
* [`6a3e5410`](https://github.com/NixOS/nixpkgs/commit/6a3e5410eb4ec9396eb2b9ce4b69ef5107dfe9f5) maintainers: add Ai-Ya-Ya
* [`4b717429`](https://github.com/NixOS/nixpkgs/commit/4b7174296d5929928e666f05a4b25bcd3b6fd37b) haskellPackages.reanimate{,-svg}: add Ai-Ya-Ya as maintainer
* [`768a8230`](https://github.com/NixOS/nixpkgs/commit/768a8230250bf7cc177831778db0492515a167cc) python3Packages.discid: 1.3.0 -> 1.4.0
* [`4a407246`](https://github.com/NixOS/nixpkgs/commit/4a40724685a0a0b3583c9c024b2eaba55ff6305e) haskellPackages.ptr-peeker: unbreak
* [`887ea160`](https://github.com/NixOS/nixpkgs/commit/887ea1604a57df5f39260bc6080938346e10d9b2) haskellPackages.jsaddle{,-warp}: drop applied patches
* [`4a2f25da`](https://github.com/NixOS/nixpkgs/commit/4a2f25da5dd9962b414b71ddae48a86c4d5be95f) haskellPackages.criterion: fix test race condition with tasty 1.5.4
* [`540f1e4f`](https://github.com/NixOS/nixpkgs/commit/540f1e4f84858d684120c29d17a3d0c4e0c86a20) haskellPackages.socket: avoid test race condition with tasty >= 1.5.4
* [`da7cfed9`](https://github.com/NixOS/nixpkgs/commit/da7cfed9420d99406efc0f8fd42421190d8fe878) listmonk: 6.0.0 -> 6.1.0
* [`15c8ea3b`](https://github.com/NixOS/nixpkgs/commit/15c8ea3b6e936cbda0487649e628e371f0a235f6) cdb: migrate to by-name
* [`c5c3522c`](https://github.com/NixOS/nixpkgs/commit/c5c3522cf9af5840338be99a843ca634a674a412) haskellPackages.socket-unix: avoid race condition due to tasty-1.5.4
* [`3fe03955`](https://github.com/NixOS/nixpkgs/commit/3fe03955dc16d07e76d1e78857ae3fd2038ac332) sdl3: 3.4.2 -> 3.4.4
* [`a9605c14`](https://github.com/NixOS/nixpkgs/commit/a9605c1498818bd3a9b43f104095625a7d635587) pandoc: work around test suite race condition due to tasty 1.5.4
* [`5da5e258`](https://github.com/NixOS/nixpkgs/commit/5da5e2581f043a947da26b2639e3a0708c8c469c) haskellPackages.mighttpd2: pin to 4.0.9 for Stackage LTS compat
* [`85a70fc1`](https://github.com/NixOS/nixpkgs/commit/85a70fc119fe424e182ae17bd88ad3ee275f2f8d) hledger-web: allow building against yesod-static 1.6.1.2
* [`3481640d`](https://github.com/NixOS/nixpkgs/commit/3481640d1832b3494512e62cb872be53bc388dfe) hledger-interest: allow hledger 1.52 by jailbreaking
* [`0feac0d3`](https://github.com/NixOS/nixpkgs/commit/0feac0d32b97c0bf033ae7068bd5a811d56bcdd4) hledger-check-fancyassertions: update hash for 1.52
* [`a160adce`](https://github.com/NixOS/nixpkgs/commit/a160adce1e80c5517a5a78d6374b7fba6ca54e6e) haskellPackages.cabal2nix-unstable: 2026-01-25 -> 2026-03-07
* [`2a56eea3`](https://github.com/NixOS/nixpkgs/commit/2a56eea3be9d3538c82e5cccb49b05d5bb7700fd) haskellPackages.cabal2nix-unstable: 2.21.2-unstable-2026-03-07 -> 2.21.3-unstable-2026-03-30
* [`9b8ae1fc`](https://github.com/NixOS/nixpkgs/commit/9b8ae1fcb2774815492e9c0d7d9d97cbfc97cb9c) gdk-pixbuf: 2.44.5 -> 2.44.6
* [`6371df1a`](https://github.com/NixOS/nixpkgs/commit/6371df1a2f4a9e5c22d2dd3b0447178b9fdf1cd0) imapgoose: install zsh completion
* [`53a4565b`](https://github.com/NixOS/nixpkgs/commit/53a4565bcea8db9605a07d88b3026303d27b52d2) git-annex: fix hash for 10.20260316
* [`7f4582ea`](https://github.com/NixOS/nixpkgs/commit/7f4582ea1acf8cd61ea33242e81a37d90d3927ae) haskellPackages.hpc-codecov: fix tests with tasty 1.5.4
* [`ea3d4871`](https://github.com/NixOS/nixpkgs/commit/ea3d4871db266949fedf663a883bf6209d0c4dcb) haskellPackages.hpc-codecov: add wolfgangwalther as maintainer
* [`ca14dff9`](https://github.com/NixOS/nixpkgs/commit/ca14dff974907029c02c895e3c8b6186d2f0672b) haskellPackages.snappy-hs: jailbreak
* [`41ecde38`](https://github.com/NixOS/nixpkgs/commit/41ecde38fa43f1f5864a3cc2348a5f744af05041) ffmpeg_8: 8.0.1 -> 8.1
* [`79ba6be5`](https://github.com/NixOS/nixpkgs/commit/79ba6be5f8f3be23429e8bfec0ef6069db2f502f) haskell.packages.ghc914.HTTP: 4000.4.1 -> 4000.5.0
* [`5ae7e44e`](https://github.com/NixOS/nixpkgs/commit/5ae7e44eedcf541f209a69a6f7764e4acf1d3cf9) haskell.packages.ghc914.blaze-markup: allow containers 0.8 in tests
* [`f4b432d2`](https://github.com/NixOS/nixpkgs/commit/f4b432d29c8b2093edeedb6f62bfe01fce5f0cb0) haskell.packages.ghc914.blaze-html: allow containers 0.8 in tests
* [`5d07e380`](https://github.com/NixOS/nixpkgs/commit/5d07e3806531acba775a79772331af9ba43b6e91) haskell.packages.ghc914.feed: allow core pkg versions of time, base
* [`cfd032a5`](https://github.com/NixOS/nixpkgs/commit/cfd032a5477f245b7c5206b60807f97060733384) haskellPackages.feed: execute main test suite at least
* [`46823c16`](https://github.com/NixOS/nixpkgs/commit/46823c161a582d84e686964e6152bc50535076ed) haskellPackages.pandoc: patch test suite race condition, enable -j
* [`a75667a0`](https://github.com/NixOS/nixpkgs/commit/a75667a07b61f270a9f8b3ac7b8ff2dd39127bab) xdg-dbus-proxy: 0.1.6 -> 0.1.7
* [`9fca99b8`](https://github.com/NixOS/nixpkgs/commit/9fca99b8b28faa36713e969473aad799d52a115f) git-annex: work around test suite race condition w/ tasty-1.5.4
* [`5184d1a9`](https://github.com/NixOS/nixpkgs/commit/5184d1a93ca3d7fdb75320cecaae87eaeebc2a26) go_1_26: 1.26.1 -> 1.26.2
* [`978ad05c`](https://github.com/NixOS/nixpkgs/commit/978ad05cb855c0a166dd5ee3011dc6daca95f220) python3Packages.aiohttp: 3.13.4 -> 3.13.5
* [`51c6e5d2`](https://github.com/NixOS/nixpkgs/commit/51c6e5d2b4f5f5c7e3eb08a28cc7d76f36506ade) python315: 3.15.0a7 -> 3.15.0a8
* [`e5a825f3`](https://github.com/NixOS/nixpkgs/commit/e5a825f3cb5cde6a9a655154e641c580acb641fc) python314: 3.14.3 -> 3.14.4
* [`582d8cde`](https://github.com/NixOS/nixpkgs/commit/582d8cde6d7f15d8eeb609cbec382cfc214a0556) Revert "util-linux: avoid rebuild on non-musl for now"
* [`7ab95c37`](https://github.com/NixOS/nixpkgs/commit/7ab95c37b1952321aa7febc0fcab4d0f7f1e4649) jamin: 0.95.0 -> 0.98.9-unstable-2015-01-14
* [`782609f5`](https://github.com/NixOS/nixpkgs/commit/782609f5f75089d8f6e47f105fcb71b8a935412d) openssl_3: 3.0.19 -> 3.0.20
* [`50e30251`](https://github.com/NixOS/nixpkgs/commit/50e302513acc6ad4c2777f9ef7f6e49455710615) openssl_3_5: 3.5.5 -> 3.5.6
* [`8390a9a1`](https://github.com/NixOS/nixpkgs/commit/8390a9a137608411c0e3921235f12af37c9819ec) openssl_3_6: 3.6.1 -> 3.6.2
* [`f386db92`](https://github.com/NixOS/nixpkgs/commit/f386db92db039d62a2c111b46953a15c143701e8) avahi: Add disabled patch for CVE-2024-52615
* [`10557b50`](https://github.com/NixOS/nixpkgs/commit/10557b50b5e7d25289dbbbeea8ee6bab9acc2c3f) avahi: Add commented-out `knownVulnerabilities` for CVE-2024-52615
* [`284f3600`](https://github.com/NixOS/nixpkgs/commit/284f3600c416f97156f2ccee83dd008ef8616bbb) avahi: Handle 5 security findings
* [`8074d489`](https://github.com/NixOS/nixpkgs/commit/8074d489442e74f748847aadefa7de5e5ee440ea) nixos/avahi: Disable wideArea by default (CVE-2024-52615)
* [`f715bbf5`](https://github.com/NixOS/nixpkgs/commit/f715bbf5a4de2c4c1914548a657894f57a0a6881) nixos/avahi: Warn when susceptible to CVE-2024-52615
* [`aca34429`](https://github.com/NixOS/nixpkgs/commit/aca3442971bf98f0be6c16d4888d6aae6101f3b5) haskellPackages.iserv-proxy: 9.3-unstable-2026-02-04 -> 9.3-unstable-2026-04-08
* [`ab55e053`](https://github.com/NixOS/nixpkgs/commit/ab55e053ce7668ec4c26c58edec16d4fb27a7be6) minimal-bootstrap.xz: 5.4.7 -> 5.8.3
* [`80e07c82`](https://github.com/NixOS/nixpkgs/commit/80e07c82a10b9bdba887799afd84f2d7b4183020) minimal-bootstrap.xz-static: 5.8.2 -> 5.8.3
* [`d2e8530b`](https://github.com/NixOS/nixpkgs/commit/d2e8530be23b2f54611e5c10312df882cb4f8901) haskellPackages.iserv-proxy: use in subprocess mode when doing cross
* [`634df81a`](https://github.com/NixOS/nixpkgs/commit/634df81a6bde9521cc2c14bc512ba5b2a89ae13f) python313: 3.13.12 -> 3.13.13
* [`850edd4d`](https://github.com/NixOS/nixpkgs/commit/850edd4d5870de1b4b74b7086d144e132156628a) pciutils: 3.14.0 -> 3.15.0
* [`b5d70d2f`](https://github.com/NixOS/nixpkgs/commit/b5d70d2ffbf2b9e7ed52ba256d5e633d1404b0d2) make-initrd-ng: suppress spurious glibc dependency warnings
* [`a62f385d`](https://github.com/NixOS/nixpkgs/commit/a62f385df3b74ccb12613001b3f2c95afb089b78) ber_metaocaml: 114 -> 153
* [`75c9bbc4`](https://github.com/NixOS/nixpkgs/commit/75c9bbc4f5ea653fb1c627f11c6abc27365a97ff) minimal-bootstrap.gnum4: 1.4.20 -> 1.4.21
* [`c6416da9`](https://github.com/NixOS/nixpkgs/commit/c6416da9d9ec050d1434773e90a404fe4b25885d) minimal-bootstrap.python: 3.14.2 -> 3.14.4
* [`0d64a659`](https://github.com/NixOS/nixpkgs/commit/0d64a659eba4998eef3f9b290d1dacc4d3495711) minimal-bootstrap.zlib: 1.3.1 -> 1.3.2
* [`cee236c3`](https://github.com/NixOS/nixpkgs/commit/cee236c32081eefe5a9bc807a2b380d5b2d67339) minimal-bootstrap.coreutils-musl: 9.9 -> 9.10
* [`97c6d1a8`](https://github.com/NixOS/nixpkgs/commit/97c6d1a8787f89db94b8c156448b1ab8feade41a) minimal-bootstrap.coreutils-static: 9.9 -> 9.10
* [`fe8fcfd2`](https://github.com/NixOS/nixpkgs/commit/fe8fcfd271242db08cdf28b44ff18b73162afb42) tcl.tclRequiresCheckHook: make compatible with structuredAttrs
* [`3620884c`](https://github.com/NixOS/nixpkgs/commit/3620884cac636750716fff98bd0347e683f39d14) python3Packages.cryptography: 46.0.6 -> 46.0.7
* [`6e9c1d19`](https://github.com/NixOS/nixpkgs/commit/6e9c1d19b72e16c1ab247e967f15041af6d958b6) psqlodbc: 17.00.0008 -> 18.00.0001
* [`48f7a8d2`](https://github.com/NixOS/nixpkgs/commit/48f7a8d223320079073352f1d6f7c2f50d8322bc) doc/release-notes: Document breaking change from avahi mitigation
* [`f61a00a7`](https://github.com/NixOS/nixpkgs/commit/f61a00a7530a0aad1fe8f71a22a2f20967d42407) openssl: cleanup already upstreamed patches
* [`ae8e5411`](https://github.com/NixOS/nixpkgs/commit/ae8e5411434a0ed50970d7bc31d54461c2e39459) haskellPackages: unbreak
* [`4346b3bf`](https://github.com/NixOS/nixpkgs/commit/4346b3bf8498de5a5105b81ff926aa4fb618559b) systemd: add patch policy
* [`b5611f96`](https://github.com/NixOS/nixpkgs/commit/b5611f96b6e1be1bf94165b3acd3bf49970a4c56) systemd: drop 0001-Start-device-units-for-uninitialised-encrypted-devic.patch
* [`207fe325`](https://github.com/NixOS/nixpkgs/commit/207fe325e9b0ac42c44009e5d600ea227ce26ada) systemd: drop 0003-Fix-NixOS-containers.patch
* [`a9bf6722`](https://github.com/NixOS/nixpkgs/commit/a9bf6722aea43a911da94d80013b0df24ea12161) systemd: drop 0004-Add-some-NixOS-specific-unit-directories.patch
* [`d02b5e8d`](https://github.com/NixOS/nixpkgs/commit/d02b5e8de41752d2dec4f7b5bfb6bf994de7c8ea) systemd: drop 0005-Get-rid-of-a-useless-message-in-user-sessions.patch
* [`84cc9d46`](https://github.com/NixOS/nixpkgs/commit/84cc9d46366074cc3066ca5e0b53060383198af4) systemd: drop 0006-hostnamed-localed-timedated-disable-methods-that-cha.patch
* [`c2b2ba82`](https://github.com/NixOS/nixpkgs/commit/c2b2ba8274bbe50de8facbffc3cddfad532a47ba) systemd: drop 0008-localectl-use-etc-X11-xkb-for-list-x11.patch
* [`cdc746ff`](https://github.com/NixOS/nixpkgs/commit/cdc746ff13296f064ca6e0a09e689df3fa8dab59) systemd: drop 0010-systemd-shutdown-execute-scripts-in-etc-systemd-syst.patch
* [`4f2d03b9`](https://github.com/NixOS/nixpkgs/commit/4f2d03b91ad366ecbffda485dea644369a0bb622) systemd: drop 0011-systemd-sleep-execute-scripts-in-etc-systemd-system-.patch
* [`e73170e3`](https://github.com/NixOS/nixpkgs/commit/e73170e38a27be96071b8da0f18c0e2b150dc627) systemd: drop 0013-inherit-systemd-environment-when-calling-generators.patch
* [`ab1dc94d`](https://github.com/NixOS/nixpkgs/commit/ab1dc94dd392784b368511840ed103386385a550) systemd: drop 0015-tpm2_context_init-fix-driver-name-checking.patch
* [`8b5d4b74`](https://github.com/NixOS/nixpkgs/commit/8b5d4b743c0aeb7d8cbd60f372731589e04f289e) systemd: drop 0016-systemctl-edit-suggest-systemdctl-edit-runtime-on-sy.patch
* [`6e92ac9c`](https://github.com/NixOS/nixpkgs/commit/6e92ac9c5860dcd48a93add5bdabe3d6d840d691) systemd: drop 0017-meson-Don-t-link-ssh-dropins.patch
* [`61d3aeee`](https://github.com/NixOS/nixpkgs/commit/61d3aeeea1da59c8a352154f5f2e65c33a4d0923) nixos/rl-notes: add section on removing support for imperatively installed systemd units
* [`73a808c2`](https://github.com/NixOS/nixpkgs/commit/73a808c27d3491fe82d33319aa33ca9a68aff685) python3Packages.librt: 0.7.8 -> 0.9.0
* [`115c6e1c`](https://github.com/NixOS/nixpkgs/commit/115c6e1ce8f50ff9a0efac88ca9bf95f313c920a) python3Packages.pathspec: 0.12.1 -> 1.0.4
* [`073693ba`](https://github.com/NixOS/nixpkgs/commit/073693badd1e4858ff7cb870a9cc6d9108ac09bc) python3Packages.pytest: 9.0.2 -> 9.0.3
* [`bc69cb50`](https://github.com/NixOS/nixpkgs/commit/bc69cb503d4a70df1f12ea9fad63366ed6f62b3c) setuptools: fix WHEEL file reproducibility by hardcoding version
* [`8618bb50`](https://github.com/NixOS/nixpkgs/commit/8618bb50f0f52f4b285055fcf4ff93ae5c9401fb) haskellPackages: stackage LTS 24.35 -> LTS 24.36
* [`e28db541`](https://github.com/NixOS/nixpkgs/commit/e28db541d494c968731dfc312e3f1e1d97c598b8) haskell.compiler.ghc9102: drop
* [`6a42f32f`](https://github.com/NixOS/nixpkgs/commit/6a42f32f4b67671132778f675ccb803d51889a74) ghc/common-hadrian: skip .1 on versionOlder checks
* [`005ca04d`](https://github.com/NixOS/nixpkgs/commit/005ca04d7fd7f591c24759361e5aaa37d8db2f85) python3Packages.mypy: 1.19.1 -> 1.20.0
* [`05d3491b`](https://github.com/NixOS/nixpkgs/commit/05d3491ba47c448604eeda4812111e905bf01199) python3Packages.exceptiongroup: update repr patch after 3.14 backport
* [`19885395`](https://github.com/NixOS/nixpkgs/commit/19885395bb05c186e12118d5b14153da788b79c8) haskell.compiler.ghc9122: drop
* [`f72cd500`](https://github.com/NixOS/nixpkgs/commit/f72cd5008e110688f07ab30c15fab1b938412e32) python3Packages.charset-normalizer: 3.4.4 -> 3.4.7
* [`be45b7d4`](https://github.com/NixOS/nixpkgs/commit/be45b7d487be5a92dd7c2a72c6b82aee3261b7e5) python3Packages.cryptography: 46.0.6 -> 46.0.7
* [`2aba6ba2`](https://github.com/NixOS/nixpkgs/commit/2aba6ba2d6c7a45ceab658e923cae129e59f7242) hledger-interest: drop obsolete override
* [`7e69395a`](https://github.com/NixOS/nixpkgs/commit/7e69395a034646216aecf6aba135ea34a80e9cb0) neovim-unwrapped: `ln -sf` grammars instead  of `ln -s`
* [`9958a6f8`](https://github.com/NixOS/nixpkgs/commit/9958a6f815611afc36de20ec9a9ad6fb5d121e91) libraqm: 0.10.4 -> 0.10.5
* [`65c38847`](https://github.com/NixOS/nixpkgs/commit/65c38847368519e9152178b5e6da3f3f64624232) samba: fix build on Darwin with newer clang
* [`0bd69584`](https://github.com/NixOS/nixpkgs/commit/0bd69584847b63747c9dea12518812ca2323ce02) ioq3-scion: fix build with gcc15
* [`88fa9f0f`](https://github.com/NixOS/nixpkgs/commit/88fa9f0fe045bf0b81bf7841773798551bf81372) Revert "openblas: avoid rebuilds on non-aarch64 temporarily"
* [`f534a134`](https://github.com/NixOS/nixpkgs/commit/f534a134d4aa7dc9281ec4c20a517519ced58d2a) Revert "gts: only rebuild on *-darwin for now"
* [`74082163`](https://github.com/NixOS/nixpkgs/commit/74082163b3281d015def8309af1ec535505a6710) systemd: reflow patches
* [`41b1ca53`](https://github.com/NixOS/nixpkgs/commit/41b1ca532a1f17203c262971141b2d7d63ce7ae8) linuxPackages.kernel.configfile: use writeText instead of passAsFile
* [`827a794c`](https://github.com/NixOS/nixpkgs/commit/827a794ce4c87ac6dea043fd5ec5dd32e5331ed6) coreutils: skip flaky du tests
* [`f6533015`](https://github.com/NixOS/nixpkgs/commit/f65330156d1df80f448e3fe6251c73f0d4912778) monaspace: 1.301 -> 1.400
* [`d1579460`](https://github.com/NixOS/nixpkgs/commit/d15794607d45b26ed470d6d7d0e0f34a54717d14) python3Packages.modern-colorthief: 0.1.12 -> 0.2.0
* [`b19b2c68`](https://github.com/NixOS/nixpkgs/commit/b19b2c6844c2c97a0958d11f67685f36e99eb40f) gnumake: cleanup
* [`a0312a1b`](https://github.com/NixOS/nixpkgs/commit/a0312a1b4cdaf5eac0f5c82ff0b9a0ce1a43d8e5) gnumake: migrate to by-name
* [`2ff762cc`](https://github.com/NixOS/nixpkgs/commit/2ff762ccf7b402df0d01d9e616ac006c9f1388ca) gnumake: enable strictDeps
* [`4d636a2c`](https://github.com/NixOS/nixpkgs/commit/4d636a2c3e0daaf506aac307f979fe4b12313e88) systemd: remove unused inputs
* [`db6719e9`](https://github.com/NixOS/nixpkgs/commit/db6719e99e72df9e613bdc44f49e25d7e184ff29) systemd: remove gnutar
* [`ccbc105e`](https://github.com/NixOS/nixpkgs/commit/ccbc105ed011a7f0fbca4586982900e9d3938bc8) gnumake: fix nixpkgs-vet
* [`0190e23d`](https://github.com/NixOS/nixpkgs/commit/0190e23d7659184ddd96bfb6c3e6427cb53f0acf) es: 0.9.2 -> 0.10.0
* [`26a1dbc1`](https://github.com/NixOS/nixpkgs/commit/26a1dbc1a4e12a232b4964c91812de503a4af5c1) gupnp-tools: Work around `xmlIndentTreeOutput` deprecation
* [`9af66e9a`](https://github.com/NixOS/nixpkgs/commit/9af66e9a80757d102cd154544dbce5f6993a436a) haskellPackages: regenerate hackage-packages.nix
* [`da187510`](https://github.com/NixOS/nixpkgs/commit/da1875105f94d32d524573a0f5ca0b275eff2e10) python3Packages.fastapi: 0.128.0 -> 0.135.3
* [`d2ee5881`](https://github.com/NixOS/nixpkgs/commit/d2ee588137705c5fa05e262c7dfb9549f1ab1862) python3Packages.httpx-curl-cffi: init at 0.1.5
* [`c7e1be87`](https://github.com/NixOS/nixpkgs/commit/c7e1be87d27d8095b1b7c9fe6ab8e842fd358ca7) futhark: fix build
* [`9a998f52`](https://github.com/NixOS/nixpkgs/commit/9a998f52f808f59eb6bee78963db8a8518979e85) haskellPackages: mark builds failing on hydra as broken
* [`8985b80c`](https://github.com/NixOS/nixpkgs/commit/8985b80c45ce3c2126965eb969467cad1e4408e0) gdb: enable strictDeps
* [`6a753dc5`](https://github.com/NixOS/nixpkgs/commit/6a753dc54bdb54dffeba93684c857778298c0ffa) gdb: add versionCheckHook
* [`c2d82c91`](https://github.com/NixOS/nixpkgs/commit/c2d82c917284f025f98f81b9ef9f81fff8d2b606) gdb: remove redundant antiquotations
* [`a8aa19d0`](https://github.com/NixOS/nixpkgs/commit/a8aa19d00440612c6ba4857b7b40b03bb9f6a912) haskellPackages.text-zipper: add hspec-discover
* [`8f68ae99`](https://github.com/NixOS/nixpkgs/commit/8f68ae99df23469d9cf3402daba23cbfc8c2294d) libsodium: 1.0.21-unstable-2026-02-11 -> 1.0.22-unstable-2026-04-09
* [`a6e5ff5e`](https://github.com/NixOS/nixpkgs/commit/a6e5ff5e50da8f152f520a2e2003a95b64e65a52) icon-naming-utils: enable strictDeps
* [`22705373`](https://github.com/NixOS/nixpkgs/commit/227053736e8a45bac6b69aa0480d5e810b7c62e3) lib2geom: enable strictDeps
* [`1d30cdc3`](https://github.com/NixOS/nixpkgs/commit/1d30cdc312fbbd5d1398c5d04c62f4340d02b8f5) lispPackages.frugal-uuid: drop frugal-uuid/benchmark system
* [`6668b455`](https://github.com/NixOS/nixpkgs/commit/6668b455cea63959bfcca74ea51758f336e847f5) opensp: fix formatting
* [`98cc0cc2`](https://github.com/NixOS/nixpkgs/commit/98cc0cc2eb14f1b1f6a796f544122eeba2a1b99c) python3Packages.discid: build docs as well
* [`3eea9d81`](https://github.com/NixOS/nixpkgs/commit/3eea9d81421b3874415682cb5f9b93655ad7af8c) python3Packages.discid: run tests
* [`6556e1e4`](https://github.com/NixOS/nixpkgs/commit/6556e1e4a5abcb254bffee62b2a0bf41acf27f0b) impression: 3.6.0 -> 3.7.0
* [`e2bbe4ff`](https://github.com/NixOS/nixpkgs/commit/e2bbe4ff80b0b4511db7a90a9cd54cad26ea6334) libraw: 0.22.0 -> 0.22.1
* [`cbb85a56`](https://github.com/NixOS/nixpkgs/commit/cbb85a5622cda521db9179851b4dcba8b91cd080) jemalloc: 5.3.0-unstable-2025-09-12 -> 5.3.1
* [`2c4f0637`](https://github.com/NixOS/nixpkgs/commit/2c4f063788b1724b8f6c7edb0bcbabccfd56a072) simdutf: 8.1.0 -> 8.2.0
* [`6388411e`](https://github.com/NixOS/nixpkgs/commit/6388411ec2959f754029160cca7b88c30f935e52) treewide: stabilize fetchpatch GitHub compare URLs
* [`2be5dcd9`](https://github.com/NixOS/nixpkgs/commit/2be5dcd9dbbd47e9e18c023160798ced6932a9f6) top-level/release-haskell.nix: don't test microhs on musl, add hugs
* [`b16ab340`](https://github.com/NixOS/nixpkgs/commit/b16ab340aad52c31249edc718d7417928f90f5ab) libarchive: 3.8.6 -> 3.8.7
* [`07f318c8`](https://github.com/NixOS/nixpkgs/commit/07f318c8ee924bc70e85499a4d30654826791402) libexif: 0.6.25 -> 0.6.26
* [`e9c6c029`](https://github.com/NixOS/nixpkgs/commit/e9c6c029ee79d718e7801a179e6268248386d8aa) python3Packages.ipyniivue: add package-lock.json
* [`be49150b`](https://github.com/NixOS/nixpkgs/commit/be49150ba8ce8c30881ac29d9a9f89389a733f08) hdf5: use a general name for api version expression argument
* [`61ab2478`](https://github.com/NixOS/nixpkgs/commit/61ab2478c3bdb8fcf71432ffb4a3529a1afb137a) hdf5: use lib.cmakeBool for all cmakeFlags
* [`be36545b`](https://github.com/NixOS/nixpkgs/commit/be36545b301bb7e4e0f46dd949db092a30a963d2) jq: apply CVE patches
* [`85d58871`](https://github.com/NixOS/nixpkgs/commit/85d58871aebce2ac2a1a04b8812a4a8869827bf3) nixos-test-driver: Use ty instead of mypy for test driver package
* [`7c7fa82b`](https://github.com/NixOS/nixpkgs/commit/7c7fa82b6c27c8d9562f7e9d099845b47e91b7ee) treewide: Don't stabilize fetchpatch GitHub compare URLs
* [`c22d6f24`](https://github.com/NixOS/nixpkgs/commit/c22d6f248bc106069f0f80479ce7c1da22c18e50) libbpf: 1.6.3 -> 1.7.0
* [`9689c7da`](https://github.com/NixOS/nixpkgs/commit/9689c7da53d50951158ef088e177e05d7cd3081a) Revert "xvfb: don't update for now"
* [`af8ed54e`](https://github.com/NixOS/nixpkgs/commit/af8ed54e68b17685d4b11e2790a0ea1322472251) SDL2_image: 2.8.8 -> 2.8.10
* [`98942d4b`](https://github.com/NixOS/nixpkgs/commit/98942d4ba09b27c8d1b4ac78c0222518e121f0b5) xterm: 407 -> 409
* [`25f408e8`](https://github.com/NixOS/nixpkgs/commit/25f408e860e4daafcc2982353b900ea7b577ce89) hdf5: small formatting adjustment to postInstall
* [`cc3efd54`](https://github.com/NixOS/nixpkgs/commit/cc3efd541144f02154faa74d4f2dc0b272a85ed6) hdf5: remove BUILD_WITH_INSTALL_NAME cmake flag
* [`96e0d84b`](https://github.com/NixOS/nixpkgs/commit/96e0d84b53f99bed4da918282644c73a4c9ca8dc) hdf5: enable szip with libaec
* [`d4366ecf`](https://github.com/NixOS/nixpkgs/commit/d4366ecfef04a389d0116ec9c3d3bb07e2e17c18) python3Packages.pyasn1: 0.6.2 -> 0.6.3
* [`693eb1a3`](https://github.com/NixOS/nixpkgs/commit/693eb1a3073278309aa9b87f20bbd7ae61161e00) python3Packages.brother: 6.0.0 -> 6.1.0
* [`f87eb386`](https://github.com/NixOS/nixpkgs/commit/f87eb3860377f0fcdf76be7c755245e939caa3d5) libfido2: 1.16.0 -> 1.17.0
* [`6809a773`](https://github.com/NixOS/nixpkgs/commit/6809a773a36d3c6c27a08d1114fa8947b0feeb9c) atf: fix cross build on Darwin
* [`33cb704f`](https://github.com/NixOS/nixpkgs/commit/33cb704f75e9e03ef13d9324e4c9927c8510187e) nodejs_24: 24.14.1 -> 24.15.0
* [`409f4670`](https://github.com/NixOS/nixpkgs/commit/409f467077b9c82e3d15b2a22b8c5fd26e716dad) nodejs_24: fix openssl related tests
* [`da8bac81`](https://github.com/NixOS/nixpkgs/commit/da8bac81b2e245ce344798abd6159a0d704fa600) nodejs_25: fix openssl related tests
* [`d6b7ea63`](https://github.com/NixOS/nixpkgs/commit/d6b7ea6320aa4a897168e9cc798d8e4360bc1ae1) python3Packages.pyopenssl: 25.3.0 -> 26.0.0
* [`a053d33d`](https://github.com/NixOS/nixpkgs/commit/a053d33da81c9ac93afc1644be1b3b7cb6b2f6bb) aws-c-event-stream: 0.5.7 -> 0.7.0, fix CVE-2026-5190
* [`26c4d48a`](https://github.com/NixOS/nixpkgs/commit/26c4d48abf36cbd2cea47dc5dadbacebc406c45a) mautrix-gmessages: 25.11 -> 26.01
* [`e795d028`](https://github.com/NixOS/nixpkgs/commit/e795d0289905dc409ae29639a71a0d8f5ace6331) mautrix-gmessages: 26.01 -> 26.02
* [`ab3c4875`](https://github.com/NixOS/nixpkgs/commit/ab3c487585a8535f4914d0c40f13817b2120a4c4) mautrix-gmessages: 26.02 -> 26.04
* [`b1bf5f8a`](https://github.com/NixOS/nixpkgs/commit/b1bf5f8ae621d52c879579abeaf85adb2cf6566c) mautrix-gmessages: enable checks
* [`74a062a7`](https://github.com/NixOS/nixpkgs/commit/74a062a7fabd5f09e68825f55e496d7b0b8b3bd2) mautrix-meta: 25.12 -> 26.02
* [`726bf459`](https://github.com/NixOS/nixpkgs/commit/726bf45962f45433ba40aa833f713c6f3395101d) mautrix-meta: 26.02 -> 26.04
* [`c0131eae`](https://github.com/NixOS/nixpkgs/commit/c0131eae359dfd2cb3c664bce6a23e9e153e8fa2) meowlnir: 26.01 -> 26.02
* [`fae808fa`](https://github.com/NixOS/nixpkgs/commit/fae808fa837862fbc0f5044b5478e977cc552f1c) meowlnir: 26.02 -> 26.03
* [`3b4a856c`](https://github.com/NixOS/nixpkgs/commit/3b4a856c4153f65e6359154310a1aedd93c53d7d) meowlnir: 26.03 -> 26.04
* [`232133c0`](https://github.com/NixOS/nixpkgs/commit/232133c0a0ab1dd7678c0c175bff68e9bfbe84db) haskellPackages.duckdb-ffi: disable problematic test
* [`b7996f94`](https://github.com/NixOS/nixpkgs/commit/b7996f9430ef97b868ff8baf5afe8a9a9ee5f12b) cacert: 3.121 -> 3.123
* [`a663b65b`](https://github.com/NixOS/nixpkgs/commit/a663b65b90cd0bde109151c02cc64aad5c00a77e) exhaustive: fix build with go 1.25
* [`f5248024`](https://github.com/NixOS/nixpkgs/commit/f5248024d1a33a17fb381e9afb019b0189b2737c) nodejs_{20,22}: disable broken openssl tests
* [`31fc844e`](https://github.com/NixOS/nixpkgs/commit/31fc844e0bd4597e107b5364785bbf33b1664318) notify-osd-customizable: drop
* [`e08d9a44`](https://github.com/NixOS/nixpkgs/commit/e08d9a444bccb9fe7baded44f248a434ddbef91a) vikunja-desktop: 2.2.2 -> 2.3.0
* [`d12d39d3`](https://github.com/NixOS/nixpkgs/commit/d12d39d30cd2ade891f5a18e58941e30cfc246a9) ant: 1.10.15 -> 1.10.17
* [`31555b59`](https://github.com/NixOS/nixpkgs/commit/31555b59a090861d8cd173e81e375a5053458ee9) maintainers: add asimpson
* [`b0771a50`](https://github.com/NixOS/nixpkgs/commit/b0771a5099a35ef9530038262513be2bac98e58e) haskellPackages: stackage LTS 24.36 -> LTS 24.37
* [`acc4e548`](https://github.com/NixOS/nixpkgs/commit/acc4e548e105f8ab99063369fa6f411e62cbde1b) maintainers/scripts/haskell: drop obsolete workaround for cassava
* [`42ac7e81`](https://github.com/NixOS/nixpkgs/commit/42ac7e8197944b09542689bae812e75967bc3974) spacecookie: 1.0.0.3 -> 1.1.0.1
* [`0e7e79e7`](https://github.com/NixOS/nixpkgs/commit/0e7e79e7fb5b97f52544a46e805b4fc47cfe390b) haskell.packages.microhs: fix eval
* [`04ecfade`](https://github.com/NixOS/nixpkgs/commit/04ecfade8a19839595a898ef1ace9394b00fdbdc) ocamlPackages.elpi: Add update.sh
* [`e5128054`](https://github.com/NixOS/nixpkgs/commit/e5128054e62315bc565ee6f21d0848b518d5f904) luajit_2_0: 2.0.1741557863 -> 2.0.1774896119
* [`7d8e96c0`](https://github.com/NixOS/nixpkgs/commit/7d8e96c03a4d668a63821ea0deded8222df5dace) luajit_2_1: 2.1.1741730670 -> 2.1.1774638290
* [`9da46051`](https://github.com/NixOS/nixpkgs/commit/9da46051aff0118c570b7e56d1b6f6b67fc0f656) ngtcp2: 1.22.0 -> 1.22.1
* [`5ca7f3d9`](https://github.com/NixOS/nixpkgs/commit/5ca7f3d9ee0f7dc576bf4497f4cab4cfa06f6020) mealie: 3.12.0 -> 3.16.0
* [`6534ba3f`](https://github.com/NixOS/nixpkgs/commit/6534ba3f79b4bd1eeb009c3c79c919f1a450552a) rust: 1.94.1 -> 1.95.0
* [`d1d424de`](https://github.com/NixOS/nixpkgs/commit/d1d424dee179feeca445ec61ff84d8cd0ce9d584) xxhash: set __structuredAttrs and strictDeps
* [`55e87a1d`](https://github.com/NixOS/nixpkgs/commit/55e87a1daae1589b1770b76df5fd5578948ab454) xdg-user-dirs: 0.19 -> 0.20
* [`74fe81b7`](https://github.com/NixOS/nixpkgs/commit/74fe81b7a3ae191fcd8c3c90d7cdf2ed6588f0d2) haskellPackages: fix typos of `__darwinAllowLocalNetworking` argument
* [`4d14bd2c`](https://github.com/NixOS/nixpkgs/commit/4d14bd2cfe7e9df62fc1fd10f762342e446ed447) haskell.packages.ghc914.hie-bios: fix eval
* [`e3165357`](https://github.com/NixOS/nixpkgs/commit/e3165357192a4275e0c4c542cf39465422fb13c1) systemd: remove gnupg dependency
* [`74f9684a`](https://github.com/NixOS/nixpkgs/commit/74f9684a0a2f74257795a04190d95f9c64e1de01) nixos/systemd: include gpg in path for relevant units
* [`8a17f4b9`](https://github.com/NixOS/nixpkgs/commit/8a17f4b9720e7a5849aba135d0cf7fd9b5d4b191) systemd: remove replacing modprobe
* [`62bfb23a`](https://github.com/NixOS/nixpkgs/commit/62bfb23a26bd730af99518908fe8bb121b0060b5) systemd: remove remaining binaryReplacements
* [`14694560`](https://github.com/NixOS/nixpkgs/commit/14694560509a50cb0a7db3c6486e4eab60bef371) systemd: move ntp-server option to mesonOption
* [`a423c2b8`](https://github.com/NixOS/nixpkgs/commit/a423c2b8b516ed9e2f80d365e1046c7af2553c37) systemd: remove superfluous rm of rpm files
* [`89335953`](https://github.com/NixOS/nixpkgs/commit/89335953f8106229a33455a421c31ae789c34522) systemd: remove superfluous postInstall
* [`da6b84db`](https://github.com/NixOS/nixpkgs/commit/da6b84dbdc276815bf3d3dadd6998f5700549b42) github/workflows: build nixos manual on PRs targeting staging-nixos
* [`fe55d033`](https://github.com/NixOS/nixpkgs/commit/fe55d033b95a713223349575b32f9355d593e049) libao: enable parallel building
* [`8e5edd46`](https://github.com/NixOS/nixpkgs/commit/8e5edd46052ca2e64b4f795636ca25555d34003f) avahi: enable parallel building
* [`560e9f3b`](https://github.com/NixOS/nixpkgs/commit/560e9f3b31a0baf6dd4020220c913bc0d390e4f0) dbus_cplusplus: enable parallel building
* [`718273ba`](https://github.com/NixOS/nixpkgs/commit/718273bab006ac5e55ce140f485949640fe98952) ld64: 954.16 -> 956.6
* [`586e3798`](https://github.com/NixOS/nixpkgs/commit/586e37985a783513e0bbd1b8e5e4888615b95570) haskellPackages.range: 0.3.2.1 -> 0.3.2.2
* [`4fee1a3b`](https://github.com/NixOS/nixpkgs/commit/4fee1a3b230a0664c165b7407afd9408f9724362) haskellPackages.Cabal-hooks: update required Cabal version
* [`3ee53e06`](https://github.com/NixOS/nixpkgs/commit/3ee53e0631e2a3d5f40efdd7caf9aa5563067a56) ghostscript: 10.06.0 -> 10.07.0
* [`d67bdb69`](https://github.com/NixOS/nixpkgs/commit/d67bdb69d130cf0c406362fa17223d1aba22702f) pkgs-lib/formats: use structuredAttrs instead of passAsFile
* [`2d509fc4`](https://github.com/NixOS/nixpkgs/commit/2d509fc402fef172fb05c87f2f4f6a616bbe3bad) psitransfer: 2.4.1 -> 2.4.3
* [`05e1670c`](https://github.com/NixOS/nixpkgs/commit/05e1670c58040da42e998fce3ee57fa589683c85) python3Packages.contourpy: fix cross
* [`6db1a80a`](https://github.com/NixOS/nixpkgs/commit/6db1a80a735ff1684ac32c8779170247d83aecaf) Revert "ghostscript: avoid rebuild on linux for now"
* [`9c162876`](https://github.com/NixOS/nixpkgs/commit/9c162876141c6a67cad24a63a5aeef56b39263b8) listres: 1.0.6 -> 1.0.7
* [`8e74441e`](https://github.com/NixOS/nixpkgs/commit/8e74441e0cc240889613d68ad3fefcd5a1a7337e) icu: patch pkgconfig paths too
* [`52b76ad3`](https://github.com/NixOS/nixpkgs/commit/52b76ad35e1aa02a88c7dae82ac6d74f6c86da3f) openssh_gssapi: 10.2p1 -> 10.3p1
* [`5a6a0c6d`](https://github.com/NixOS/nixpkgs/commit/5a6a0c6d7a59f356a0a1c060040feb377d3ab45c) util-linux: update patches
* [`ba7be2f0`](https://github.com/NixOS/nixpkgs/commit/ba7be2f0512d71474b2ee5715b886efb3321dd3c) tcl.tclRequiresCheckHook: use structuredAttrs... structurally
* [`5cddaf9e`](https://github.com/NixOS/nixpkgs/commit/5cddaf9e1dbc9cda8d858a58445ce876531860a2) haskellPackages.postgresql-types: unbreak, run unit tests
* [`21ef12e9`](https://github.com/NixOS/nixpkgs/commit/21ef12e92e0d259a7b0e4c3453ac0e3a05b2946c) haskellPackages.{beam-duckdb,duckdb-{ffi,simple}}: add Ai-Ya-Ya as maintainer
* [`175e8da4`](https://github.com/NixOS/nixpkgs/commit/175e8da441a6384d93f27461c7dd3d3ecf0a2f8c) haskellPackages.postgresql-simple-postgresql-types: unbreak
* [`ca4100c3`](https://github.com/NixOS/nixpkgs/commit/ca4100c3c01e22d386858eee11f6de02cbf73532) nodejs_20: mark as insecure
* [`81de7980`](https://github.com/NixOS/nixpkgs/commit/81de7980ba69fa89250e79c32511d54ff8b38015) proton-pass: 1.36.0 -> 1.36.1
* [`cbf6dd14`](https://github.com/NixOS/nixpkgs/commit/cbf6dd147a4e1d4fa53e75d54597946a705a4a6c) nodejs_latest: 25.9.0 -> 26.0.0-rc.1
* [`2acf7cd6`](https://github.com/NixOS/nixpkgs/commit/2acf7cd603498a4d02b9f0489f0bd59a086f8ad9) python3Packages.trio-websocket: disable failing test due to race condition on Darwin
* [`af85cdee`](https://github.com/NixOS/nixpkgs/commit/af85cdee0a2861efb22982acaeacffebdaa11a00) lvm2: 2.03.38 -> 2.03.39
* [`398677c9`](https://github.com/NixOS/nixpkgs/commit/398677c9251252c61214e7ebb66b8dbd1072d2d5) pvetui: init at 1.3.2
* [`86dce66a`](https://github.com/NixOS/nixpkgs/commit/86dce66a491b2df0a3888d93894bfd718518a247) debian-devscripts: Add missing dependencies
* [`592a4561`](https://github.com/NixOS/nixpkgs/commit/592a45615414b8db78e1ed1915ccdf8fa999a99f) debian-devscripts: Write to stdout and exit 0 for --help, --version
* [`789e2a46`](https://github.com/NixOS/nixpkgs/commit/789e2a4620962a0f852770719c0e7e165ed3144a) debian-devscripts: Add test for --help, --version
* [`689b24f7`](https://github.com/NixOS/nixpkgs/commit/689b24f7da82c9f581255062537783d7bb6b9d6a) ragnarwm: drop
* [`afe6607f`](https://github.com/NixOS/nixpkgs/commit/afe6607f13e57dabfdf89a84d1e414855401c62b) git: 2.53.0 -> 2.54.0
* [`28db277a`](https://github.com/NixOS/nixpkgs/commit/28db277a66b5e5212a04d7ccf4b3a71b1bedf411) python3Packages.pysnmp: 7.1.22 -> 7.1.24
* [`a0d464cb`](https://github.com/NixOS/nixpkgs/commit/a0d464cbf74a60e5e53edbc19333aebd6fcbba1b) intel-oneapi.base: add stdenv
* [`00664561`](https://github.com/NixOS/nixpkgs/commit/0066456110afbe0e7a983f1a35969a3744cdf5f0) pipewire: 1.6.3 -> 1.6.4
* [`f2275024`](https://github.com/NixOS/nixpkgs/commit/f2275024f82f71be7594fae9077bdc02f592c56c) python3Packages.tenacity: fetch from github, use lambda style
* [`3cdadc60`](https://github.com/NixOS/nixpkgs/commit/3cdadc60251373b1279a6c9a40623e072ef6c518) python3Packages.tenacity: 9.1.2 -> 9.1.4
* [`ef8114aa`](https://github.com/NixOS/nixpkgs/commit/ef8114aaf6b6214c15f347f21e3b3b6a0a52e549) intel-oneapi.base: move tests into dedicated file and add icpx tests
* [`dee374eb`](https://github.com/NixOS/nixpkgs/commit/dee374ebea962c01667166380feae7d3c0f8fcab) intel-oneapi.base: fix mkl-libs test passing without finding mkl
* [`f14aea98`](https://github.com/NixOS/nixpkgs/commit/f14aea98e37cdb37ebcbf8bfb4244a1ea73d2356) python3Packages.pelican: 4.11.0 -> 4.12.0
* [`2d44018b`](https://github.com/NixOS/nixpkgs/commit/2d44018bab19437709b166f48b48827841fbcafe) miracle-wm: 0.8.3 -> 0.9.0
* [`859ea72d`](https://github.com/NixOS/nixpkgs/commit/859ea72d655b4dd710e77a0ed25d1c89669e91e0) mir: 2.25.2 -> 2.26.0
* [`bdef44df`](https://github.com/NixOS/nixpkgs/commit/bdef44dfe971d60387aa20b51e56168ad05936ad) libxpm: 3.5.18 -> 3.5.19
* [`c4d4f209`](https://github.com/NixOS/nixpkgs/commit/c4d4f2099fc7c594e4eecb9061631895432d66aa) python3Packages.python-dotenv: 1.2.1 -> 1.2.2
* [`eb3d1f27`](https://github.com/NixOS/nixpkgs/commit/eb3d1f2783175d484db9bc39e38505f94643220d) darwin.sourceRelease: update to 15.6
* [`2664d285`](https://github.com/NixOS/nixpkgs/commit/2664d28566aea67ec813e5e865e0f7228dbcaeee) apple-sdk: 26.0 -> 26.4
* [`f57948a7`](https://github.com/NixOS/nixpkgs/commit/f57948a7e1be000875b4dae96780af63950a30ac) darwin.AvailabilityVersions: remove source release bootstrap workaround
* [`209b0e39`](https://github.com/NixOS/nixpkgs/commit/209b0e39ab944be4fa3d73184be0f9af27a71d8b) darwin.bootstrap_cmds: remove source release bootstrap workaround
* [`2586fb25`](https://github.com/NixOS/nixpkgs/commit/2586fb25a2bc85e28565c5c33ee46a24c8e2bfd1) darwin.diskdev_cmds: remove source release bootstrap workaround
* [`61896b19`](https://github.com/NixOS/nixpkgs/commit/61896b19c397d6e3ce659a584a3eb80bd8a61c0c) darwin.diskdev_cmds: fix build with updated source release headers
* [`c31a9b49`](https://github.com/NixOS/nixpkgs/commit/c31a9b491256bbb5c608965ea5fd97fe01808f2a) darwin.doc_cmds: remove source release bootstrap workaround
* [`8e87b5c4`](https://github.com/NixOS/nixpkgs/commit/8e87b5c47fc995a81b1f4d7f27c07742899fe409) darwin.dyld: remove source release bootstrap workaround
* [`4303a89e`](https://github.com/NixOS/nixpkgs/commit/4303a89e8ee89fe7d1c8137f90fe8164b489b462) darwin.dyld: fix build with updated source release headers
* [`d8c22782`](https://github.com/NixOS/nixpkgs/commit/d8c22782d2008dbdbca39c9d2337bdf5e9a60f59) darwin.dyld: fix install name of dsc_extractor.bundle
* [`170f6443`](https://github.com/NixOS/nixpkgs/commit/170f6443e4be3e0162145951cf5c911575d2cdf9) darwin.file_cmds: remove source release bootstrap workaround
* [`2a0b077d`](https://github.com/NixOS/nixpkgs/commit/2a0b077d49f46996a2e0ce56a4bd91fc80fb0efb) darwin.IOKitTools: remove source release bootstrap workaround
* [`fcafb8b9`](https://github.com/NixOS/nixpkgs/commit/fcafb8b98c7f4a25c7bdf484004dbf44e8b7faaf) darwin.libpcap: use XNU source release headers
* [`2cf34d4d`](https://github.com/NixOS/nixpkgs/commit/2cf34d4d1b58a3dccffc41f824d0db7c5b2969a6) darwin.libresolv: fix build with updated source release headers
* [`d62cc6db`](https://github.com/NixOS/nixpkgs/commit/d62cc6db8828c94d21dae7ff806c6fd06c492a28) darwin.network_cmds: use XNU source release headers
* [`68653ffc`](https://github.com/NixOS/nixpkgs/commit/68653ffc3b6e6b0bc449fa6a04ca13d4876d59af) darwin.PowerManagement: remove source release bootstrap workaround
* [`6c1dd21a`](https://github.com/NixOS/nixpkgs/commit/6c1dd21a49c791eb59f6a87ad4415d9f98d582ff) darwin.shell_cmds: remove source release bootstrap workaround
* [`df0da640`](https://github.com/NixOS/nixpkgs/commit/df0da6402217ca6c5c812785b3747312e86f7247) darwin.system_cmds: use XNU source release headers
* [`8c87fae2`](https://github.com/NixOS/nixpkgs/commit/8c87fae2a71228bc4c1fc561df876dd3d157d9d4) darwin.system_cmds: use public libdispatch headers
* [`576a1b9c`](https://github.com/NixOS/nixpkgs/commit/576a1b9c858c6769e28a624c1b65a452c32c8d32) darwin.text_cmds: remove source release bootstrap workaround
* [`7e44c276`](https://github.com/NixOS/nixpkgs/commit/7e44c27671e0447855b4f9b6413a8645dc9aaa92) darwin.top: remove source release bootstrap workaround
* [`7deae6f7`](https://github.com/NixOS/nixpkgs/commit/7deae6f79d7e422a1d458dcace3bd254b247f5b5) darwin.developer_cmds: 401.100.3 -> 411
* [`1b74a2fd`](https://github.com/NixOS/nixpkgs/commit/1b74a2fd7c93c32d151dab4b49b6ec3876f17720) lsyncd: remove source release bootstrap workaround
* [`c4eaa7e2`](https://github.com/NixOS/nixpkgs/commit/c4eaa7e21baaf4f8d02f5286115c8d83d9d6ca8f) ocamlPackages.cmdliner: 2.1.0 -> 2.1.1
* [`c42235a7`](https://github.com/NixOS/nixpkgs/commit/c42235a7815138eb74ab129a9dadb69820374686) python3Packages.pint: don't depend on pytest-benchmark
* [`5e26f5d3`](https://github.com/NixOS/nixpkgs/commit/5e26f5d37c1e8e9894d514a8d8779a4025e207b4) simdutf: 8.2.0 -> 9.0.0
* [`b30db246`](https://github.com/NixOS/nixpkgs/commit/b30db24642b0c3871c1ab00fbde91c0f71742b04) haskellPackages: update hackage2nix configuration to match generated output
* [`ab08bb02`](https://github.com/NixOS/nixpkgs/commit/ab08bb0237d106725b9b8a6b69e628650b026706) haskellPackages.{inline-c-win32,Southpaw}: track platforms in hackage2nix
* [`a5dcb106`](https://github.com/NixOS/nixpkgs/commit/a5dcb10639c873026b94576520998289eb04a515) haskellPackages.tmp-postgres: move override to configuration-nix
* [`d4d7a067`](https://github.com/NixOS/nixpkgs/commit/d4d7a06796c2be32eefe9d325a815bd5b875b230) haskellPackages.inline-java: move override to configuration-nix
* [`c9771f6d`](https://github.com/NixOS/nixpkgs/commit/c9771f6df780d8a42fa3df7d229df234496e8642) haskellPackages: move various dep overrides to configuration-nix
* [`88ea2396`](https://github.com/NixOS/nixpkgs/commit/88ea2396954cd56b4b731c6237bc3d182d2060f6) haskellPackages.hgeometry-combinatorial: move test suite override
* [`89a53c5e`](https://github.com/NixOS/nixpkgs/commit/89a53c5e8f398bbc4e170e82a64166801a7ce289) haskellPackages.dom-parser: prevent revision from breaking the build
* [`f9e7c251`](https://github.com/NixOS/nixpkgs/commit/f9e7c251b9f6fc0f653a19be54fbb7c261902af1) haskellPackages.http2-tls: pin to 0.4.5 to match crypton/tls
* [`0acbc12e`](https://github.com/NixOS/nixpkgs/commit/0acbc12ee90ca629f33d126f0916d552d27b00a6) haskellPackages.cryptol: move override to configuration-nix
* [`fa9c3289`](https://github.com/NixOS/nixpkgs/commit/fa9c3289790885b80c06326d95cd7c050d5d15f1) haskellPackages.d-bus: drop override
* [`a5014527`](https://github.com/NixOS/nixpkgs/commit/a50145273535115e02bf4448e1dafe0965d86911) haskellPackages.crypt-sha512: relax too strict bound on base
* [`32e90277`](https://github.com/NixOS/nixpkgs/commit/32e90277e042c15f4d43599c1219951304b69b51) haskellPackages.hgmp: allow QuickCheck 2.15
* [`082e61fa`](https://github.com/NixOS/nixpkgs/commit/082e61fa841b4a0c5ae34bae2ed43926c0f25842) haskellPackages.hw-{hedgehog,string-parse}: allow doctest >= 0.24
* [`00df3d0a`](https://github.com/NixOS/nixpkgs/commit/00df3d0a7994fca1739f98af8cdd2704403b4793) haskellPackages: remove overrides for various broken packages
* [`65222096`](https://github.com/NixOS/nixpkgs/commit/65222096aae23ab19f1129e13b591e03943e66b2) haskellPackages.paypal-adaptive-hoops: move override to -nix
* [`c328b2a0`](https://github.com/NixOS/nixpkgs/commit/c328b2a02fa93515ed044d14d90e27c2ce9d58e5) haskellPackages.{ghc-mod,structured-haskell-mode,haskell-to-elm}: drop overrides
* [`d341aa8d`](https://github.com/NixOS/nixpkgs/commit/d341aa8d6d2f9695e77a6f7ef0687e442d61eab6) maintainers/haskell/test-configuration.nix: disallow aliases
* [`43dc57e8`](https://github.com/NixOS/nixpkgs/commit/43dc57e8913e166084fcbe3946bf67b34f9d022e) libfabric: 2.5.0 -> 2.5.1
* [`9896f1c3`](https://github.com/NixOS/nixpkgs/commit/9896f1c341a94861ab266525328739bde4e8df75) python3Packages.idna: 3.11 -> 3.13
* [`559bc6b9`](https://github.com/NixOS/nixpkgs/commit/559bc6b969b89fdf50218ef31f3a7ce714cada87) kitty: fix build in Darwin sandbox
* [`70fa0789`](https://github.com/NixOS/nixpkgs/commit/70fa0789bcb0990a2b61908bec869a32a46cb48c) tdns-cli: unstable-2021-02-19 -> 0.0.5-unstable-2026-02-23
* [`28f2c00b`](https://github.com/NixOS/nixpkgs/commit/28f2c00b143150689ef0220a07bca5b02c754797) tzdata: 2026a -> 2026b
* [`82d41811`](https://github.com/NixOS/nixpkgs/commit/82d41811a596b74461f9bdeeb3d131dadf1e5011) bubblewrap: 0.11.1 -> 0.11.2
* [`afa2ed4a`](https://github.com/NixOS/nixpkgs/commit/afa2ed4af838f8eed9c60c1b30f527333f4a1bad) coreutils: 9.10 -> 9.11
* [`9a509306`](https://github.com/NixOS/nixpkgs/commit/9a5093062002a795ebde4b306e10617a9cc40814) nss: 3.112.3 -> 3.112.5
* [`11228566`](https://github.com/NixOS/nixpkgs/commit/112285666ccb47389e5ba057b8bd5337c8ad69e9) vim: 9.2.0340 -> 9.2.0389
* [`f5988209`](https://github.com/NixOS/nixpkgs/commit/f59882096e06dfbccc8ca0cbd788a9e5d45a991c) kubernetes-helm: fix build in Darwin sandbox
* [`e3733092`](https://github.com/NixOS/nixpkgs/commit/e3733092cb9688c38f99b4a84ab6e82ec6606a10) imagemagick: 7.1.2-19 -> 7.1.2-21
* [`c5086c36`](https://github.com/NixOS/nixpkgs/commit/c5086c36e4aa0489df1a0fbbc8d28ba9c168cc42) expat: 2.7.5 -> 2.8.0
* [`1baec239`](https://github.com/NixOS/nixpkgs/commit/1baec23947f334b219725da84092cabc4f3fb013) python3Packages.python-multipart: add patches for CVE-2026-40347
* [`12be1084`](https://github.com/NixOS/nixpkgs/commit/12be108473e588bd6bfab28aefcc76383c59ba51) tartan: use llvmPackages_20
* [`9c9ef3db`](https://github.com/NixOS/nixpkgs/commit/9c9ef3db7f7d32f2f24e0692a946753e9a93b53b) cri-tools: 1.35.0 -> 1.36.0
* [`b68a43f8`](https://github.com/NixOS/nixpkgs/commit/b68a43f8645dc95fd2b4a18e02d3ae9650c546be) python3Packages.tzdata: 2026.1 -> 2026.2
* [`69c7004f`](https://github.com/NixOS/nixpkgs/commit/69c7004f2875b3e21191213d67674486501ac11e) haskellPackages: stackage LTS 24.37 -> LTS 24.38
* [`d79d276b`](https://github.com/NixOS/nixpkgs/commit/d79d276b638dda0a8c8355417a3aec2263d457a5) iproute2: 6.19.0 -> 7.0.0
* [`8bdc8b81`](https://github.com/NixOS/nixpkgs/commit/8bdc8b8186f3bb710354b063e4f764a04214c26b) python3Packages.build: 1.4.2 -> 1.4.4
* [`652d2da1`](https://github.com/NixOS/nixpkgs/commit/652d2da1822415c76c3a27b1993d36a3b1add9d6) npmBuildHook: fix logging of the build command
* [`ff37bd99`](https://github.com/NixOS/nixpkgs/commit/ff37bd99e79834cca226aabdbf8c055cc9390bb0) spidermonkey_{115,128,140}: provide sdkroot directly
* [`a42c6cd1`](https://github.com/NixOS/nixpkgs/commit/a42c6cd10936a0d563627252ae79aa427ea24a8a) php: remove buildtime xcbuild dependency
* [`4f7e27e5`](https://github.com/NixOS/nixpkgs/commit/4f7e27e50fb352239154c19e4ebfcfac22c9646a) python312Packages.scipy: remove xcbuild from build dependencies
* [`eef309bf`](https://github.com/NixOS/nixpkgs/commit/eef309bf3dc68b17ccdb0db667d1fa2336d507c0) gobang: remove due to upstream maintaince
* [`fad2a962`](https://github.com/NixOS/nixpkgs/commit/fad2a962a45b31cd5de6312714887cff58883cd2) python3Packages.cryptography: 46.0.6 -> 47.0.0
* [`8c911994`](https://github.com/NixOS/nixpkgs/commit/8c9119949864731cdee821ea769be059c715aa25) libcap_ng: 0.9.2 -> 0.9.3
* [`821d9852`](https://github.com/NixOS/nixpkgs/commit/821d9852410c7b45d7d36eb49ea1f7474272b293) nixos/wpa_supplicant: add extraConfigFiles to BindReadOnlyPaths
* [`0758fc3a`](https://github.com/NixOS/nixpkgs/commit/0758fc3addcc74b4f8ef5a6467a6f573ef161c1f) darwin.libcxx: 20.1.0+apple-sdk-26.0 -> 21.1.6+apple-sdk-26.4
* [`fb89d29d`](https://github.com/NixOS/nixpkgs/commit/fb89d29df6fe83f060d94a742825cf8c6de9dd24) darwin.sourceRelease: 15.6 -> 26.3
* [`25b86489`](https://github.com/NixOS/nixpkgs/commit/25b86489c924b7e3be4ff7e0f19ca7f6dd1a14ce) darwin.xnuHeaders: init at 12377.81.4
* [`6426bafd`](https://github.com/NixOS/nixpkgs/commit/6426bafdc87c03f8143f230e4279f1819a4fa8c4) darwin.adv_cmds: 235 -> 237
* [`999ae132`](https://github.com/NixOS/nixpkgs/commit/999ae132ea995cb0881c479b0f77aa8a15a06d14) darwin.adv_cmds: restore mklocale and colldef
* [`7a629f7c`](https://github.com/NixOS/nixpkgs/commit/7a629f7c27c9a16af5f611b8638d92b628c10d0a) darwin.AvailabilityVersions: 151 -> 155
* [`5f997076`](https://github.com/NixOS/nixpkgs/commit/5f9970769325fb61e3699c77bed422afe0fd8608) darwin.copyfile: 224 -> 230.0.1.0.1
* [`cd56e1b4`](https://github.com/NixOS/nixpkgs/commit/cd56e1b409dc45a23152d8b30d19723438c046b5) darwin.diskdev_cmds: 737.140.4 -> 751.80.2
* [`79d1a1db`](https://github.com/NixOS/nixpkgs/commit/79d1a1dbd58731701ed8518ebf176939cd75e278) darwin.dyld: 1335 -> 1340
* [`c9d502a8`](https://github.com/NixOS/nixpkgs/commit/c9d502a8cb46162643e6276d9dbb9afbf02dab94) darwin.file_cmds: 457.140.3 -> 475
* [`d92e1071`](https://github.com/NixOS/nixpkgs/commit/d92e10712536f0c7cf653c65056da2c2c13a1d4f) darwin.ICU: 76104.4 -> 76142.3.1.1
* [`23bc365e`](https://github.com/NixOS/nixpkgs/commit/23bc365e6114e32f59fbcdc13d09e864655870ba) darwin.libiconv: 109.100.2 -> 113
* [`b0afb220`](https://github.com/NixOS/nixpkgs/commit/b0afb22046eea3fa591f331017ad17a5627b0fd9) darwin.libpcap: 140 -> 144
* [`dccdc3df`](https://github.com/NixOS/nixpkgs/commit/dccdc3df2d55a4d07baeac87ad41f4df5be0cb95) darwin.libresolv: 91 -> 93
* [`b1e1d4ff`](https://github.com/NixOS/nixpkgs/commit/b1e1d4fff6c7244cc80c4a7f370ecfea22e26ac4) darwin.libutil: 72 -> 73
* [`debcaca4`](https://github.com/NixOS/nixpkgs/commit/debcaca475a0ad9bf2ab148546138c41518b993e) darwin.mail_cmds: 38.0.1 -> 41
* [`b6a4b2a1`](https://github.com/NixOS/nixpkgs/commit/b6a4b2a1fbbbc5082c1ab235452d83e0c02c995d) darwin.network_cmds: switch to using xnuHeaders
* [`38093848`](https://github.com/NixOS/nixpkgs/commit/380938484b4bb6781e10982641965bb34f7ac400) darwin.network_cmds: 705.100.5 -> 730.80.3
* [`0c52d1c9`](https://github.com/NixOS/nixpkgs/commit/0c52d1c9c7ff0a5aacf1e0f343c41f7b64ffa7eb) darwin.PowerManagement: 1754.140.4 -> 1846.81.1
* [`d055bafa`](https://github.com/NixOS/nixpkgs/commit/d055bafaafaf5af18d7ceab68ea600e886848961) darwin.removefile: 81 -> 84
* [`3622869a`](https://github.com/NixOS/nixpkgs/commit/3622869ad13a1660c898b4f3707d1c6fdaa37eb0) darwin.system_cmds: 1026.140.2 -> 1039
* [`a53b49a2`](https://github.com/NixOS/nixpkgs/commit/a53b49a266e5c302cb7488eeb8a8b914f96226ee) darwin.text_cmds: 195 -> 197
* [`844f0b84`](https://github.com/NixOS/nixpkgs/commit/844f0b84b245a4a9a4883540e590ee57b12cf64c) darwin.top: 139.40.2 -> 144
* [`423fc131`](https://github.com/NixOS/nixpkgs/commit/423fc131ada71826bf9af1f1b2e3b5d570d835a6) gscreenshot: meta.mainProgram
* [`33bb7428`](https://github.com/NixOS/nixpkgs/commit/33bb7428e1023bad1c2219ffbc28fe1311378315) gn: 0-unstable-2026-02-05 -> 0-unstable-2026-03-05
* [`77778878`](https://github.com/NixOS/nixpkgs/commit/7777887803aab7a109fa43b126ea4202568a854e) python3.pkgs.matplotlib: 3.10.8 -> 3.10.9
* [`7cbfe302`](https://github.com/NixOS/nixpkgs/commit/7cbfe3026975549a5f27ce370474ec17c24aba1d) jemalloc: fix src hash after 5.3.1 re-tag
* [`e269b384`](https://github.com/NixOS/nixpkgs/commit/e269b3843b2d96d7c2ab15c1e595361fd028433e) writeTextFile: pass destination and make it overridable
* [`26a8b088`](https://github.com/NixOS/nixpkgs/commit/26a8b0882916e6b257220d0e9da0c33b3446b396) writeTextFile: lower destination assertion to its value
* [`6efcea03`](https://github.com/NixOS/nixpkgs/commit/6efcea0362c574022c4bc7643c10403eaecb57fe) writeTextFile: lower matches let-in down to meta's value
* [`d4135b14`](https://github.com/NixOS/nixpkgs/commit/d4135b1403ff09a83d8c9fdfe59f175c895176f0) xrandr: 1.5.3 -> 1.5.4
* [`c2f1b6df`](https://github.com/NixOS/nixpkgs/commit/c2f1b6df2330a907791c58761787999918476433) xrand: switch to `meson` build system
* [`55f0cfdc`](https://github.com/NixOS/nixpkgs/commit/55f0cfdc928ee4866cc44a44444433e4ed9d2243) writeTextFile: simplify meta.mainProgram
* [`fc0e29b4`](https://github.com/NixOS/nixpkgs/commit/fc0e29b4a68867b6f56be8c03ba8d343361d5798) writeTextFile: restructure with stdenvNoCC.mkDerivation
* [`363654f8`](https://github.com/NixOS/nixpkgs/commit/363654f8e5b8ddb69cbb864bcde90b630eb39f3b) writeTextFile: reference finalAttrs destination and executable
* [`2670ee06`](https://github.com/NixOS/nixpkgs/commit/2670ee064002906af2cfdc2ef6e16a0c50a6cf64) writeTextFile: reformat after restructuring with stdenvNoCC.mkDerivation
* [`46494179`](https://github.com/NixOS/nixpkgs/commit/4649417945b3252148eebddcaab952ad6a51e2d1) pinentry_mac: remove xcbuild dependency
* [`7cd8f438`](https://github.com/NixOS/nixpkgs/commit/7cd8f438a286c18974b4c8ac3e7a5433052732f1) python3.pkgs.{numpy,numpy_1}: remove unused xcbuild dependency
* [`c7f9da02`](https://github.com/NixOS/nixpkgs/commit/c7f9da02abdce029981a33a9e9c803236e031605) dolphin-emu: replace xcbuild with the specific re-plistbuddy
* [`35e8ddca`](https://github.com/NixOS/nixpkgs/commit/35e8ddca56e197eb49b59fa2d92318c10fc6581f) misskey: remove unused xcbuild dependency
* [`1c511cda`](https://github.com/NixOS/nixpkgs/commit/1c511cda0ff7a81418ad8b5ca09f8518cad85122) openexr: 3.3.8 -> 3.4.10
* [`c1c905f3`](https://github.com/NixOS/nixpkgs/commit/c1c905f3649f4a77d82d83d6a5dc770dea7f2195) writeTextFile: restructure with lib.extendMkDerivation
* [`ba8dee09`](https://github.com/NixOS/nixpkgs/commit/ba8dee09e35646ace1b0dc6e606e53268e6a32d9) writeTextFile: format after restructuring with lib.extendMkDerivation
* [`f8fb59f3`](https://github.com/NixOS/nixpkgs/commit/f8fb59f3ea5a46857f2f019e213c34c042c7de2e) haskellPackages.railroad: drop obsolete override
* [`d0a2ca9b`](https://github.com/NixOS/nixpkgs/commit/d0a2ca9b6d14c44ecbe616e04442524528061871) haskellPackages.range: drop obsolete override
* [`3a02cd41`](https://github.com/NixOS/nixpkgs/commit/3a02cd4124c9a958c4634b6f5925fd18ec3d01ce) python3Packages.executing: don't depend on rich
* [`8eed2073`](https://github.com/NixOS/nixpkgs/commit/8eed2073da711482aa1636b76c79f1ce9ecebfe2) restman: 0.3.0 -> 0.4.9
* [`59169a15`](https://github.com/NixOS/nixpkgs/commit/59169a1511e87a40ce3802808402db50b89575db) curl: clean up rebuild avoidance
* [`7c93f05a`](https://github.com/NixOS/nixpkgs/commit/7c93f05a6dce96f8bf10d2af301e61242d653db5) python3Packages.sphinx-autodoc-typehints: 3.9.9 -> 3.10.2
* [`4dfc641c`](https://github.com/NixOS/nixpkgs/commit/4dfc641c2f060360678df693d603779edfb722be) ffmpeg: limit patch application to versions < 8.1
* [`f6bbbded`](https://github.com/NixOS/nixpkgs/commit/f6bbbded6dba37cb706a498f05d4e545f81b000e) minimal-bootstrap: trim configure flags and slim python
* [`b141bb23`](https://github.com/NixOS/nixpkgs/commit/b141bb23c9717adec15d71ae9d306be0997d6571) minimal-bootstrap: post-install trim of locale data, docs, and unused python extensions
* [`1413d4cd`](https://github.com/NixOS/nixpkgs/commit/1413d4cda42345b9290c7d334892172bc127546b) python3Packages.packaging: 25.0 -> 26.1
* [`729dbf3d`](https://github.com/NixOS/nixpkgs/commit/729dbf3d0ed187f02eca3e201b7cb806ed10daa5) python3Packages.mypy: 1.20.0 -> 1.20.1
* [`8dfab621`](https://github.com/NixOS/nixpkgs/commit/8dfab6210ae01b5fe34b57978f28b1dddec71e0f) python3Packages.cadwyn: 6.0.1 -> 6.2.0
* [`1d0e07d5`](https://github.com/NixOS/nixpkgs/commit/1d0e07d56b130928b9b2ff1a3d87fd0d10b00b08) python3Packages.charset-normalizer: relax mypy dependency
* [`766e0032`](https://github.com/NixOS/nixpkgs/commit/766e0032e68b1b5cc7f3a4b6399b13987b244eda) python3Packages.aiohttp: disable failing cookie header test
* [`8c3b5b13`](https://github.com/NixOS/nixpkgs/commit/8c3b5b13876ea5397d61cda1fd5d1384e12aac2a) python3Packages.pip-tools: fix failing test
* [`992b633d`](https://github.com/NixOS/nixpkgs/commit/992b633dc2d53ffd4673f9af6a80a400bd178c27) libnghttp2: 1.68.1 -> 1.69.0
* [`dde2aba7`](https://github.com/NixOS/nixpkgs/commit/dde2aba74fff3c283e845f3899e864c1493574d6) mbedtls: 3.6.5 -> 3.6.6
* [`71ed59cc`](https://github.com/NixOS/nixpkgs/commit/71ed59cc0b2f15b430c4ae0aba6b1f32310ecc02) skaffold: 2.18.3 -> 2.19.0
* [`c461129f`](https://github.com/NixOS/nixpkgs/commit/c461129fd5545b855aadd04f9233496a60896542) haskellPackages.lager: disable nonterminating test suite
* [`eb612333`](https://github.com/NixOS/nixpkgs/commit/eb612333aa378cd344472e2456b4b22bc5ec9ab3) hledger-web: drop upstreamed patch
* [`3edcad64`](https://github.com/NixOS/nixpkgs/commit/3edcad645d025ea87439fdfc15c18344d9d91988) git-annex: update sha256 for 10.20260421
* [`b84c4e52`](https://github.com/NixOS/nixpkgs/commit/b84c4e5221e8c983d27cc2594c1ffb27ef325da5) haskellPackages.kdl-hs: skip broken test suite
* [`eca7764b`](https://github.com/NixOS/nixpkgs/commit/eca7764bd42578071e03c8e5b13382d8dc4cf207) haskellPackages.hs-opentelemetry-api: jailbreak
* [`59dafcbd`](https://github.com/NixOS/nixpkgs/commit/59dafcbd716f3ba6843842bb761c114069d08215) gdk-pixbuf: fixup after the last update
* [`77b0200c`](https://github.com/NixOS/nixpkgs/commit/77b0200c615445d66c70ff106fc4c74f80ddacda) libdrm: 2.4.131 -> 2.4.133
* [`04c94fd2`](https://github.com/NixOS/nixpkgs/commit/04c94fd20625ee0a0f3d5eaea8382594227f91d8) gurk-rs: 0.9.1 -> 0.9.3
* [`b6377c36`](https://github.com/NixOS/nixpkgs/commit/b6377c3648e8c0e8933e7adadb3e07446a6116f7) util-linux: set --sysconfdir=/etc
* [`c000d372`](https://github.com/NixOS/nixpkgs/commit/c000d37230a711e05ab391c92009381c1b1209d7) colmap: 4.0.3 -> 4.0.4
* [`2970aa97`](https://github.com/NixOS/nixpkgs/commit/2970aa97f74e35c443885bc7fef6b1f48ce3429f) obsidian: use arm64 tarball on aarch64-linux
* [`98d8c856`](https://github.com/NixOS/nixpkgs/commit/98d8c8567181f5a38badd6cac81b315fdeaad539) libqmi: enable strictDeps
* [`35149e9e`](https://github.com/NixOS/nixpkgs/commit/35149e9e848b0ce8deee3890129e9f1184ef0718) dash: 0.5.13.2 -> 0.5.13.3
* [`d94f65ae`](https://github.com/NixOS/nixpkgs/commit/d94f65ae850761f0f97684b60a42b7f450d4f21f) python3Packages.regex: 2026.2.19 -> 2026.4.4
* [`f5be35ad`](https://github.com/NixOS/nixpkgs/commit/f5be35adeb5d9a5c8939f184020670358bf171b0) python3Packages.joserfc: disable failing tests
* [`23f24b5b`](https://github.com/NixOS/nixpkgs/commit/23f24b5bc43195a57edbdb287192027b834c5f7b) minimal-bootstrap: trim python and glibc closure further
* [`b5cb2cc4`](https://github.com/NixOS/nixpkgs/commit/b5cb2cc43f95415f9c9fc997eb5a5874af7d223d) clevis: add boot.initrd.clevisLuksAskpass module
* [`fdc60ea7`](https://github.com/NixOS/nixpkgs/commit/fdc60ea709ef5a1635642ccaeb9ce1d138d1e925) clevis: drop redundant systemd-reply-password meson patch
* [`6b07fb09`](https://github.com/NixOS/nixpkgs/commit/6b07fb09c2435d07b9656c3874fcd0670222817a) python3.pkgs.pyqt6: use finalAttrs
* [`ee4a8675`](https://github.com/NixOS/nixpkgs/commit/ee4a8675f4248d194eddbff4ea593fd82929551e) python3.pkgs.pyqt6: use fetchPypi
* [`509d72cb`](https://github.com/NixOS/nixpkgs/commit/509d72cb121cf9baadd0fcb65c5d39829ac60ba1) python3.pkgs.pyqt6: 6.9.0 -> 6.11.0
* [`84e12b93`](https://github.com/NixOS/nixpkgs/commit/84e12b93615cb9ff9aead062ebc01155722e6b12) cups: migrate to `finalAttrs`
* [`fc3d4074`](https://github.com/NixOS/nixpkgs/commit/fc3d40744435510b2538f0c98d17892fbbbd510d) cups: enable `__structuredAttrs`
* [`996cb771`](https://github.com/NixOS/nixpkgs/commit/996cb7716a290b80edcf93b0a390a3414ca98b02) cups: enable `strictDeps`
* [`fe6b3b95`](https://github.com/NixOS/nixpkgs/commit/fe6b3b95c3e35b6abb3c8df2b8c00f7058290a9e) cups: 2.4.16 -> 2.4.19
* [`5c0a211a`](https://github.com/NixOS/nixpkgs/commit/5c0a211a58cb25a4ee17e3fb46ec6b8ec3e7bd64) _7zz: 26.00 -> 26.01
* [`3d093d4b`](https://github.com/NixOS/nixpkgs/commit/3d093d4b61662d4042df7bbe0ded55d0ae18e5a8) apache-airflow: 3.1.7 - > 3.2.1
* [`0eced05a`](https://github.com/NixOS/nixpkgs/commit/0eced05aae1e4493a97609f3c3f7613ecf55f91f) lean4: Pin cadical version to 2.1.3 to fix bv_decide
* [`8d7bfe2d`](https://github.com/NixOS/nixpkgs/commit/8d7bfe2d7623fddbbba9ce744d9008eb414e1e35) opkssh: 0.13.0 -> 0.14.0
* [`3acc323b`](https://github.com/NixOS/nixpkgs/commit/3acc323bb3f0ffeb670475e5d2bf3d75a1a3dd7f) owmods-gui: 0.15.4 -> 0.15.6
* [`d438068c`](https://github.com/NixOS/nixpkgs/commit/d438068c8974d6dc3c624999136330cdbdbb46ff) ibm-plex: keep hinted fonts in output
* [`195ac282`](https://github.com/NixOS/nixpkgs/commit/195ac282644122af4433e8781ab23f32a0608fc5) python3Packages.ansible: 13.5.0 -> 13.6.0
* [`575aa672`](https://github.com/NixOS/nixpkgs/commit/575aa672550846f71c0d8cabc0c46e39b38aa64d) python3Packages.polars: 1.36.1 -> 1.40.1
* [`8d2139ea`](https://github.com/NixOS/nixpkgs/commit/8d2139eac5286974ffcf26384748ef576e0b6d81) python3Packages.trove-classifiers: 2026.1.14.14 -> 2026.4.28.13
* [`56735047`](https://github.com/NixOS/nixpkgs/commit/567350478a4118ca92824b25f07a3d0ca7da3913) python3Packages.pybind11: 3.0.3 -> 3.0.4
* [`f7393efe`](https://github.com/NixOS/nixpkgs/commit/f7393efec5db3eebeda4f057ca6f398b63551a4a) python3Packages.inline-snapshot: reduce test dependencies
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
