### PR TITLE
npins home-manager: update 866412a1 -> 1a95e2ef

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -61,9 +61,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "866412a19866b4a8e32d2306a118040afa2b840c",
-      "url": "https://github.com/nix-community/home-manager/archive/866412a19866b4a8e32d2306a118040afa2b840c.tar.gz",
-      "hash": "sha256-VbiyZkRf8/qr7ObmlyfOHJsNAW5tyZ4MB1+cUwAwdrw="
+      "revision": "1a95e2efb477959b70b4a14c51035975c0481df6",
+      "url": "https://github.com/nix-community/home-manager/archive/1a95e2efb477959b70b4a14c51035975c0481df6.tar.gz",
+      "hash": "sha256-/p37CB5n6Wpw250b0Lq0CYwNq2D8uGKzDoBulyLcQqA="
     },
     "hs-grille": {
       "type": "Git",


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@866412a1...1a95e2ef](https://github.com/nix-community/home-manager/compare/866412a19866b4a8e32d2306a118040afa2b840c...1a95e2efb477959b70b4a14c51035975c0481df6)

* [`16663cb1`](https://github.com/nix-community/home-manager/commit/16663cb13826d6aa519fb8c622460e3ce2a04dc1) ssh: add settings.<name>.header option
* [`5df5159c`](https://github.com/nix-community/home-manager/commit/5df5159c784f05d9799c48e9768fb82251291858) rclone: default cache-dir to xdg.cacheHome on Darwin
* [`1060e2e1`](https://github.com/nix-community/home-manager/commit/1060e2e1708a26596e86bdc6750f30df928cbcd9) rclone: parameterize mkRcloneSidecars over a value builder
* [`f99cd3d4`](https://github.com/nix-community/home-manager/commit/f99cd3d4f4986aca800c74a9a50a221aa14e4439) rclone: lift config-install script to a named derivation
* [`2b6c692c`](https://github.com/nix-community/home-manager/commit/2b6c692c954268ba6aaf46752b65e893fab74453) rclone: add rclone-sidecar-wrapper derivation
* [`fd3a68e6`](https://github.com/nix-community/home-manager/commit/fd3a68e6405635af0922b3733185046dcec6f837) rclone tests: cross-platform basic-configuration gating
* [`d4e01575`](https://github.com/nix-community/home-manager/commit/d4e015754e4575121d9da6373f8764b79bd8be0a) rclone: add launchd config agent for Darwin
* [`13e12967`](https://github.com/nix-community/home-manager/commit/13e1296711d6db1a986cc4f7d944548599f760bd) rclone: add launchd mount/serve sidecar agents for Darwin
* [`6f5d4125`](https://github.com/nix-community/home-manager/commit/6f5d41250171eea5863dedfde080939e9a31d4cc) rclone tests: add Darwin serve sidecar test
* [`2f578ccd`](https://github.com/nix-community/home-manager/commit/2f578ccd993ec5c1af0f1d5394860bb680423a7c) rclone: document macFUSE requirement and Darwin requiresUnit semantics
* [`6cfa655a`](https://github.com/nix-community/home-manager/commit/6cfa655a2032ad1bb502d352b5ea71f1f78ea99e) rclone: clarify secrets description for both Linux and Darwin
* [`8da35b6f`](https://github.com/nix-community/home-manager/commit/8da35b6f14b01ee8da10d24c0db4d1dcd63ad604) rclone: drop unused sidecarType arg from sidecar builders
* [`fd272ce7`](https://github.com/nix-community/home-manager/commit/fd272ce76e7d2e266f82a8dbefa2b37d1f0d2e60) rclone: make requiresUnit read-only on non-systemd platforms
* [`93b932fd`](https://github.com/nix-community/home-manager/commit/93b932fdbb76433467b189628729839bb8a69b85) rclone: extend mount unit PATH for non-NixOS fusermount
* [`bd868f76`](https://github.com/nix-community/home-manager/commit/bd868f769a69d3b6091a1da68a75cb83a181033c) nushell: create if environment variable exists
* [`f9be3dd4`](https://github.com/nix-community/home-manager/commit/f9be3dd495e5af37095f5385ab2f170456bffd23) maintainers: add SunOfLife1
* [`62b325b4`](https://github.com/nix-community/home-manager/commit/62b325b47cebe02bbeb670d460e9517899091ec8) fish: add SunOfLife1 as a maintainer
* [`374742ad`](https://github.com/nix-community/home-manager/commit/374742adb6d5102f95af65af7d52c26b530abe23) maintainers: update all-maintainers.nix
* [`928d7237`](https://github.com/nix-community/home-manager/commit/928d72376949e222ea4f07b44828a55b0136422e) dunst: support ordered settings
* [`509ed3c6`](https://github.com/nix-community/home-manager/commit/509ed3c603349a9d43de9e2ae6613baea6bd5b34) Translate using Weblate (Dutch)
* [`6e92bf09`](https://github.com/nix-community/home-manager/commit/6e92bf094d45bc33d754e2b0f75d9ca1827cc363) nix-darwin: pass DRY_RUN to activation
* [`64f1f8dd`](https://github.com/nix-community/home-manager/commit/64f1f8dd8dbe10704e8ea0b7efa3c727365af2a3) flake: bump nixpkgs from `da5ad66` to `f83fc3c`
* [`50aaf8f2`](https://github.com/nix-community/home-manager/commit/50aaf8f2841d8ff6624aa957cf7ce8533c32a3ef) tests/darwinScrublist: add intelli-shell
* [`23703a32`](https://github.com/nix-community/home-manager/commit/23703a32ef3d7803a2f1bb9909a3f46fc5185e37) betterlockscreen: drop sebtm
* [`044c30c1`](https://github.com/nix-community/home-manager/commit/044c30c19550c0557997dece4ce9e54d2fa77ba1) vicinae: allow npmDepsHash for extensions
* [`f9833292`](https://github.com/nix-community/home-manager/commit/f98332929bef04961f4ef3b2804d712d32d85d03) flake: bump nixpkgs from `f83fc3c` to `2991645`
* [`612bbe3b`](https://github.com/nix-community/home-manager/commit/612bbe3b405ad5f71d7bf9edecc04b678a061652) tests/darwinScrublist: add pimsync
* [`f4df9da9`](https://github.com/nix-community/home-manager/commit/f4df9da9603acbd0deb74f97e997d7ee4c9306d5) maintainers: update all-maintainers.nix
* [`1a95e2ef`](https://github.com/nix-community/home-manager/commit/1a95e2efb477959b70b4a14c51035975c0481df6) home-manager: set 26.05 as stable
