### PR TITLE
npins home-manager: update 1a95e2ef -> a7a41588

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -61,9 +61,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "1a95e2efb477959b70b4a14c51035975c0481df6",
-      "url": "https://github.com/nix-community/home-manager/archive/1a95e2efb477959b70b4a14c51035975c0481df6.tar.gz",
-      "hash": "sha256-/p37CB5n6Wpw250b0Lq0CYwNq2D8uGKzDoBulyLcQqA="
+      "revision": "a7a415883195ffbd4dabec8f098f201e6eaaadf8",
+      "url": "https://github.com/nix-community/home-manager/archive/a7a415883195ffbd4dabec8f098f201e6eaaadf8.tar.gz",
+      "hash": "sha256-PRJj9RKTEf/sITycujP1c/BrvLJKMYXzcpwTsXNulXQ="
     },
     "hs-grille": {
       "type": "Git",


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@1a95e2ef...a7a41588](https://github.com/nix-community/home-manager/compare/1a95e2efb477959b70b4a14c51035975c0481df6...a7a415883195ffbd4dabec8f098f201e6eaaadf8)

* [`874ae4cc`](https://github.com/nix-community/home-manager/commit/874ae4cccfbd1b4525a5459f9043449b9d944a35) Translate using Weblate (Spanish)
* [`d17712ec`](https://github.com/nix-community/home-manager/commit/d17712ec7a9f8682919b4659a3975018e8ed9dcb) Translate using Weblate (Chinese (Simplified Han script))
* [`61e2c965`](https://github.com/nix-community/home-manager/commit/61e2c9659324181e0f0ed911958c536333b1d4f6) voxtype: initial module implementation
* [`94875306`](https://github.com/nix-community/home-manager/commit/948753061a4a8d8655678aefbd6c53e6a470aeca) home-manager: prepare 26.11
* [`da8f8fcd`](https://github.com/nix-community/home-manager/commit/da8f8fcd69fe5a961ff75c44ea67f165c6ff6d3d) ci: update release branch
* [`7d8127d3`](https://github.com/nix-community/home-manager/commit/7d8127d308c3fb9664f7e643eec944be74ebb37d) flake: track nixpkgs-unstable
* [`16110b65`](https://github.com/nix-community/home-manager/commit/16110b65b21d29f6be9cedd3f5e70c15165ad9f5) maintainers: update all-maintainers.nix
* [`c53d0150`](https://github.com/nix-community/home-manager/commit/c53d0150e999a60c6b260695449a1ed77184085b) prismlauncher: fix string escaping and hygiene
* [`3d64f287`](https://github.com/nix-community/home-manager/commit/3d64f2875eed47965dc360a478eb03f85e599e17) podman: fix container config mount on Darwin
* [`8962c2a0`](https://github.com/nix-community/home-manager/commit/8962c2a0f464a5054bb77fade78eac568cd01264) Translate using Weblate (Azerbaijani)
* [`5a608a62`](https://github.com/nix-community/home-manager/commit/5a608a621b001922dd708ca51a6260d5bef9e29b) infat: allow customization of autoActivate
* [`d0af9b8b`](https://github.com/nix-community/home-manager/commit/d0af9b8bf3b4a1d449be7034bebc9f8f9fd6ee99) claude-code: mark hook scripts executable
* [`04ec113f`](https://github.com/nix-community/home-manager/commit/04ec113f8bab80fe476b69310a5a1b0a0e1da4a8) zsh: load session vars from zprofile for login shells
* [`112a3a37`](https://github.com/nix-community/home-manager/commit/112a3a37835010924e9f3940d6a78863cbf0b6ef) zsh: add common plugin function paths
* [`d00b16c5`](https://github.com/nix-community/home-manager/commit/d00b16c51115e41b00e0bf4a1ec3b539b8a91c6a) zsh: escape cdpath entries
* [`3e17edd5`](https://github.com/nix-community/home-manager/commit/3e17edd5e6d75e3908338e28b7101e847182b581) zsh: escape named directory hashes
* [`c7c139f7`](https://github.com/nix-community/home-manager/commit/c7c139f7427b9900876ebd8217ed32193e06b19d) zsh: escape double-quoted values
* [`c7e4087b`](https://github.com/nix-community/home-manager/commit/c7e4087b4da746d61f654a6e7971d3e693e188fd) zsh: rename plugin completions to functions
* [`51480019`](https://github.com/nix-community/home-manager/commit/5148001968d1189a3715759998b6dcce5ba3ac5f) nix-search-tv: add keybindings and actions
* [`a6a13bb0`](https://github.com/nix-community/home-manager/commit/a6a13bb0a0a33f67cdfc4b0879b0e333737ab276) hyprland: add extraLuaFiles option
* [`26e34a99`](https://github.com/nix-community/home-manager/commit/26e34a99e464d2a660c2e6d132ac1ea5b5f0fe6c) hyprland: reorganize config generation
* [`27429964`](https://github.com/nix-community/home-manager/commit/274299642bb423b2832850b8fcece0df0d62a133) vscode: make keybindings submodule freeform
* [`a7a41588`](https://github.com/nix-community/home-manager/commit/a7a415883195ffbd4dabec8f098f201e6eaaadf8) infat: use list for autoActivate extraArgs
