### PR TITLE
npins zsh-you-should-use: update ff371d6a -> 5f3d1298

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -262,9 +262,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "ff371d6a11b653e1fa8dda4e61c896c78de26bfa",
-      "url": "https://github.com/MichaelAquilina/zsh-you-should-use/archive/ff371d6a11b653e1fa8dda4e61c896c78de26bfa.tar.gz",
-      "hash": "sha256-a/DNVxD55Bh6AmSh5C4z4JpZM5xUiQgoaFoDgYPQsbo="
+      "revision": "5f3d129864ee4505043d88c3486224f1d75b692e",
+      "url": "https://github.com/MichaelAquilina/zsh-you-should-use/archive/5f3d129864ee4505043d88c3486224f1d75b692e.tar.gz",
+      "hash": "sha256-1ojmr9+Wg5+X5Dip4sKjP4IKKACMncPQDZ8RtYQSQ80="
     }
   },
   "version": 8


### PR DESCRIPTION
## Changelog for zsh-you-should-use:
Branch: master
Commits: [MichaelAquilina/zsh-you-should-use@ff371d6a...5f3d1298](https://github.com/MichaelAquilina/zsh-you-should-use/compare/ff371d6a11b653e1fa8dda4e61c896c78de26bfa...5f3d129864ee4505043d88c3486224f1d75b692e)

* [`b746e37b`](https://github.com/MichaelAquilina/zsh-you-should-use/commit/b746e37bba8f715d4ef5e3726127dee389d38fcc) fix: don't downgrade an already-best compound alias in BESTMATCH mode
