### PR TITLE
npins nixpkgs: update 4df1b885 -> cbb5cf35

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -133,8 +133,8 @@
       "type": "Channel",
       "name": "nixpkgs-unstable",
       "artifact": "nixexprs.tar.xz",
-      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-26.11pre1008784.4df1b885d76a/nixexprs.tar.xz",
-      "hash": "sha256-bWVU1JP9hCYZzQjMLdMzr/FINF+UvpZGvCJcnNY616k="
+      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-26.11pre1011620.cbb5cf358f50/nixexprs.tar.xz",
+      "hash": "sha256-d86UGSjwACWRttincQzeiAEZYVPtP3kODhr9hYZD4e8="
     },
     "powerlevel10k": {
       "type": "Git",


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: release-26.11
Commits: [nixos/nixpkgs@4df1b885...cbb5cf35](https://github.com/nixos/nixpkgs/compare/4df1b885d76a...cbb5cf358f50)

* [`e5dd8d7e`](https://github.com/NixOS/nixpkgs/commit/e5dd8d7ee483824bcbaee5f9b3f3ee24c2a5519f) usb-modeswitch: fix systemd service
* [`58c26ce6`](https://github.com/NixOS/nixpkgs/commit/58c26ce6dfc7f89bf59aa203feb7cc3189b00260) filebot: 5.2.0 -> 5.2.1
* [`d5fe4cc4`](https://github.com/NixOS/nixpkgs/commit/d5fe4cc48f6e21bd460267d304bda63e2e284976) python3Packages.cvxopt: 1.3.2 -> 1.3.3
* [`6e5359c6`](https://github.com/NixOS/nixpkgs/commit/6e5359c64a5b3a85af97359426bf3b619274b5c1) linuxPackages.vhba: 20250329 -> 20260313
* [`2affe0d8`](https://github.com/NixOS/nixpkgs/commit/2affe0d81f2106ff09f6a1ffeb70960f97111073) gitleaks: remove $out/bin/config
* [`b4c57c52`](https://github.com/NixOS/nixpkgs/commit/b4c57c5210a4ac5b3d5edd6d41f2ec6eda6ac13f) perlPackages: Add MIMEBase32
* [`d0eb1019`](https://github.com/NixOS/nixpkgs/commit/d0eb10197c5f7a6c2dd9a99d8b8586e37dfb1f75) perlPackages.ZonemasterLDNS: 3.2.0 -> 5.0.2
* [`7412be45`](https://github.com/NixOS/nixpkgs/commit/7412be45777aa97e9e9ef0190fcb274495aed323) perlPackages.ZonemasterEngine: 4.6.1 -> 8.1.1
* [`a4cbbabb`](https://github.com/NixOS/nixpkgs/commit/a4cbbabb41bc19cd4a7290cd5c4d30201ea6cf26) perlPackages.ZonemasterCLI: 6.000003 -> 8.0.1
* [`f887f639`](https://github.com/NixOS/nixpkgs/commit/f887f639e2354991fbcc2e39f8fae42dd0db0c72) nixos/bitmagnet: Use up to date configuration values, and open http
* [`eb5013a6`](https://github.com/NixOS/nixpkgs/commit/eb5013a6167711156368d60813b7215269e4256c) gg-jj: 0.37.2 -> 0.39.1
* [`2087fb47`](https://github.com/NixOS/nixpkgs/commit/2087fb4770cc12350b4e15a153463af08339b13a) standardnotes: update homepage
* [`fe7646cb`](https://github.com/NixOS/nixpkgs/commit/fe7646cb0883bdf86e65fc918fc8d9f1e1e483e5) libharu: 2.4.5 -> 2.4.6
* [`81ecb584`](https://github.com/NixOS/nixpkgs/commit/81ecb584760f276d2aa1e93611b8254018e23749) sigil: 2.7.0 -> 2.7.6
* [`ae78b429`](https://github.com/NixOS/nixpkgs/commit/ae78b429cb341987ceb832d4aa15a3d5c99bbb3a) weidu: 249 -> 251
* [`53374873`](https://github.com/NixOS/nixpkgs/commit/5337487344832eebd54d9facbbf38044d0e1cf31) gnomeExtensions.pop-shell: 1.2.0-unstable-2025-10-01 -> 1.2.0-unstable-2026-03-31
* [`1979595b`](https://github.com/NixOS/nixpkgs/commit/1979595bcfc6f66854b41d51d0e25f2a9f291ec6) rhvoice: 1.16.5 -> 1.18.4
* [`2cb9c37a`](https://github.com/NixOS/nixpkgs/commit/2cb9c37ad3a64b397d60b75813d34a70efbab0ec) transmission_4-{mac,qt,qt5}: enable darwin builds, mark strictDeps
* [`3acf3fd8`](https://github.com/NixOS/nixpkgs/commit/3acf3fd83c1fb81fcf89f41adb9c8614d28568a6) minecraft-server-hibernation: 2.5.0 -> 2.5.1
* [`f2d5b283`](https://github.com/NixOS/nixpkgs/commit/f2d5b2835d2374620e45c43bdee76fda7de54c6a) libjcat: 0.2.3 -> 0.2.6
* [`66b99c26`](https://github.com/NixOS/nixpkgs/commit/66b99c26aff52e5f46d2f226f51ce07d06bfdac9) protonplus: 0.5.19 -> 0.5.20
* [`bee86ac5`](https://github.com/NixOS/nixpkgs/commit/bee86ac56808daeb0b488603727afd079e046e8d) protoc-gen-es: 2.11.0 -> 2.12.0
* [`8e8e3ea4`](https://github.com/NixOS/nixpkgs/commit/8e8e3ea4514136664d753a486cc3b8f8098e033b) joe: 4.7 -> 4.8
* [`5aac0a23`](https://github.com/NixOS/nixpkgs/commit/5aac0a234124886afd2041c9710e10291c734e3b) python3Packages.hg-commitsigs: drop
* [`e4df0dba`](https://github.com/NixOS/nixpkgs/commit/e4df0dba66f674a1ed67032631416a33c19e8697) zkfuse: set meta.description
* [`361386a3`](https://github.com/NixOS/nixpkgs/commit/361386a37de1421378d7c22e712f61c651f778a2) line-awesome: use installFonts
* [`71c912d7`](https://github.com/NixOS/nixpkgs/commit/71c912d75a2ba0348ed915f18c2aa2d4cea2039c) blender: remove unused cmake config
* [`377311bc`](https://github.com/NixOS/nixpkgs/commit/377311bc723322985417721d48add5cfceccd4d8) blender: build cycles kernels in parallel
* [`7af23b25`](https://github.com/NixOS/nixpkgs/commit/7af23b25f0cb9fcf466b66e2d38e4d8ac5e5c5ed) blender: remove obsolete comment about license
* [`300e36a1`](https://github.com/NixOS/nixpkgs/commit/300e36a1c0b463e5dabb47e0b8d9927591e76161) blender: alphabetize
* [`abdb14b5`](https://github.com/NixOS/nixpkgs/commit/abdb14b5cf4ca9414635a201f6b5c27ae915f588) blender: lift dep out of both sides of conditional
* [`183ac51d`](https://github.com/NixOS/nixpkgs/commit/183ac51d1f7d559bfadefede0c1efb7a54d282a0) inventree: 1.2.6 -> 1.3.0
* [`c5ab38f5`](https://github.com/NixOS/nixpkgs/commit/c5ab38f5373a401b1cce18011b51ad3c001320f3) blender: do not rename exe when wrapping
* [`9ca1fe5b`](https://github.com/NixOS/nixpkgs/commit/9ca1fe5b1fd1dbbd36ac80b1047614e34dd180c8) nix-fast-build: 1.4.0 -> 1.5.0
* [`7086284f`](https://github.com/NixOS/nixpkgs/commit/7086284f14d654d452f439e3968ee5964a1272b5) dhcpcd: 10.3.1 -> 10.3.2
* [`4f300fa9`](https://github.com/NixOS/nixpkgs/commit/4f300fa962d92222c6806a09f4c1b5f767d14438) libblockdev: 3.4.0 -> 3.5.0
* [`28a6ddd5`](https://github.com/NixOS/nixpkgs/commit/28a6ddd5fa9b93b902963e5820f25671c17ac1f7) qtractor: 1.5.12 -> 1.6.0
* [`fc130d96`](https://github.com/NixOS/nixpkgs/commit/fc130d960758ccd66e1ffc862f2d908e0a9f2ab4) libgsf: 1.14.55 -> 1.14.58
* [`f8ca3825`](https://github.com/NixOS/nixpkgs/commit/f8ca3825af4ff31a0606158f480e34a5748b5cc8) shotcut: 26.2.26 -> 26.4.30
* [`33bce8e7`](https://github.com/NixOS/nixpkgs/commit/33bce8e7a939c20c05e92c5138bbb4f87726d07f) maintainers: add jesssullivan
* [`f6e6f223`](https://github.com/NixOS/nixpkgs/commit/f6e6f223e099c9f08d97b6c874fe30ffffe590e7) unnaturalscrollwheels: 1.3.0 -> 1.4.0
* [`a74c641b`](https://github.com/NixOS/nixpkgs/commit/a74c641b38ccb4ad6a7c50c121022016306d959b) onioncircuits: add missing dependency
* [`4e3c466d`](https://github.com/NixOS/nixpkgs/commit/4e3c466dbf506a20160cb8bfdc6bc3e156633ea1) tm: drop
* [`15e261b8`](https://github.com/NixOS/nixpkgs/commit/15e261b80a3c3cf66f3d7c90d6ab6d08e5832b36) astc-encoder: 5.3.0 -> 5.4.0
* [`2e65db96`](https://github.com/NixOS/nixpkgs/commit/2e65db96600fa7bce8445a857dd74a9140f38a42) adbtuifm: enable darwin support
* [`b5726bd3`](https://github.com/NixOS/nixpkgs/commit/b5726bd3a8fe9b0785ed3b9662eb468218d68463) python3Packages.steamship: drop
* [`c0cbeb9d`](https://github.com/NixOS/nixpkgs/commit/c0cbeb9d8e5a731ba88500fb01690cb92455fc25) nixos/virtualisation: explain resolution is only relevant to grub
* [`44c6c2ef`](https://github.com/NixOS/nixpkgs/commit/44c6c2ef166cc796b417d9885b966489b23a2bf9) nixos/virtualisation: remove hard-coded virtio-gpu-pci device from aarch machines
* [`66f2a9b1`](https://github.com/NixOS/nixpkgs/commit/66f2a9b19c3aca8b344f25e667fe92155e9df36a) pragtical: 3.8.3 -> 3.9.0
* [`5e5ea7a7`](https://github.com/NixOS/nixpkgs/commit/5e5ea7a7037a9f821d819bdfd22697960793d408) boinc: 8.2.11 -> 8.2.13
* [`a44414b5`](https://github.com/NixOS/nixpkgs/commit/a44414b51fb143d14b1dafcdf97c9a18e001cb44) nikto: 2.5.0 -> 2.6.0
* [`9b5701d8`](https://github.com/NixOS/nixpkgs/commit/9b5701d81c69a939d2998b06aa7e0863d5bb4de2) nikto: add tbutter as maintainer
* [`b497e59a`](https://github.com/NixOS/nixpkgs/commit/b497e59ae99a6fa1f1b04fc784c87ec238f5336a) therion: 6.3.4 -> 6.4.0
* [`97c68e5d`](https://github.com/NixOS/nixpkgs/commit/97c68e5d5cac7af2d1bda3f8449f821b9f404961) btrfs-progs: 6.19.1 -> 7.0
* [`875cbab1`](https://github.com/NixOS/nixpkgs/commit/875cbab19fc728a1199b661579f76c42bf2b5503) bigpemu: 1.22 -> 1.221
* [`5a6cda7a`](https://github.com/NixOS/nixpkgs/commit/5a6cda7a65ccf62574c367b00b2f06f6500d1f16) tiddit: 3.6.1 -> 3.9.5
* [`aec40689`](https://github.com/NixOS/nixpkgs/commit/aec406895523ccde39e394b951a2d7cd3010a82b) beadwork: init at 0.13.0
* [`d1a7d6f0`](https://github.com/NixOS/nixpkgs/commit/d1a7d6f00f57a41e9f9ea0a07d16de0225ac3fb5) proton-authenticator: 1.1.4 -> 1.1.5
* [`51fa6640`](https://github.com/NixOS/nixpkgs/commit/51fa6640319cf2e3acdac60f21e4e555fd1f2793) gsasl: 2.2.2 -> 2.2.3
* [`d5ce692b`](https://github.com/NixOS/nixpkgs/commit/d5ce692b704c919f16f0b36ae1193aa9349fe42a) python3Packages.pyopengl: migrate to finalAttrs
* [`a41fd1d9`](https://github.com/NixOS/nixpkgs/commit/a41fd1d9c516dc9214fec3cd7a2a6f6fb1bce319) python3Packages.pyopengl: simplify patching, respect LD_PRELOAD_PATH
* [`a8778fc4`](https://github.com/NixOS/nixpkgs/commit/a8778fc470dd5ad5292cb4fcd4faf425abab3af4) mesa: fix timeout on Darwin
* [`db5e7157`](https://github.com/NixOS/nixpkgs/commit/db5e7157732d5c550c3997209ad822a5f6eb59ce) noson: 5.6.13 -> 5.6.25
* [`484dbb04`](https://github.com/NixOS/nixpkgs/commit/484dbb043aae00b076f1ce45c756ad4b8d9d9507) seaweedfs: 4.19 -> 4.24
* [`e6f84b26`](https://github.com/NixOS/nixpkgs/commit/e6f84b26194088c80babff8669cb36bd2e08073a) istioctl: 1.29.2 -> 1.30.0
* [`e066ac78`](https://github.com/NixOS/nixpkgs/commit/e066ac78e4065eff4e1d164f0ac6427da9783f94) gocover-cobertura: 1.4.0 -> 1.5.0
* [`721887ed`](https://github.com/NixOS/nixpkgs/commit/721887edc010e7dfefb22c5f38a13fa40ffb031a) lomiri.qtmir: 0.8.0-unstable-2025-05-20 -> 0.8.0-unstable-2026-03-11
* [`a392056e`](https://github.com/NixOS/nixpkgs/commit/a392056e863c1db6a27ce121cc0e5da4394072ea) lomiri.qtmir: Fix typo in comment, pull comments out of shell code
* [`e59ae164`](https://github.com/NixOS/nixpkgs/commit/e59ae16417d05f65c1c571af627a51f00766cada) lomiri.qtmir: Add Lomiri VM tests to passthru.tests
* [`27cae711`](https://github.com/NixOS/nixpkgs/commit/27cae711e77c6cae384bd83100ff297d82466154) nixos/fonts: add Noto CJK to default fonts
* [`3a6603b4`](https://github.com/NixOS/nixpkgs/commit/3a6603b494f87264aeb606a922103885abdf7b31) libexttextcat: 3.4.6 -> 3.4.8
* [`27f3d1d4`](https://github.com/NixOS/nixpkgs/commit/27f3d1d43594a67b5975f67972fcf34739d4be0c) libinput: 1.31.1 -> 1.31.2
* [`29d67249`](https://github.com/NixOS/nixpkgs/commit/29d672498f4aff7d692003232e0bd2120e20b323) nixos/timesyncd: drop `with lib;`
* [`4c7d78e0`](https://github.com/NixOS/nixpkgs/commit/4c7d78e0f27abadc3716bd2d21663c4b11e816a3) croc: 10.4.3 -> 10.4.4
* [`ae8161b8`](https://github.com/NixOS/nixpkgs/commit/ae8161b80ab90de4cd6be6cfa00a8ddca143def7) cilium-cli: 0.19.2 -> 0.19.4
* [`915ec927`](https://github.com/NixOS/nixpkgs/commit/915ec9274cce79a95eed160e6cebaf5dca39b6a8) kakoune-unwrapped: 2026.04.12 -> 2026.05.21
* [`54bea898`](https://github.com/NixOS/nixpkgs/commit/54bea898fa36b27298e9cf80debbd58d67d562e1) python3Packages.buildPythonPackage: Don't copy input list when checking inputs
* [`99ea95bc`](https://github.com/NixOS/nixpkgs/commit/99ea95bceb025e47294cad7ae69a7be1862344a4) hwinfo: 25.2 -> 25.3
* [`025c1747`](https://github.com/NixOS/nixpkgs/commit/025c17476f36284fdf762b97d6bc0dd6bac109e4) xrootd: 5.9.1 -> 6.0.2
* [`11518ef8`](https://github.com/NixOS/nixpkgs/commit/11518ef82bf56a235d426b68a57e60d75038c705) xrootd: fix python bindings build
* [`a72d17d3`](https://github.com/NixOS/nixpkgs/commit/a72d17d3ce323844ca8f0602ac212e85c04c4513) recordbox: 0.10.4 -> 0.11.0
* [`ac4c1c99`](https://github.com/NixOS/nixpkgs/commit/ac4c1c99b7f3d28be54a52b32d147bd80e41d1b3) lilex: use installFonts
* [`c83b46d1`](https://github.com/NixOS/nixpkgs/commit/c83b46d1fa162d9bdfab8b0e6f5ac0e4eb49c840) lilex: remove unpackPhase with sourceRoot
* [`479b3ead`](https://github.com/NixOS/nixpkgs/commit/479b3ead8811c346ba9fc372c4f15eed580fb73b) lilex: use finalAttrs
* [`e5317c9e`](https://github.com/NixOS/nixpkgs/commit/e5317c9ede85d443f390926a81c637c95d387931) git-relevant-history: switch to pyproject
* [`5949f728`](https://github.com/NixOS/nixpkgs/commit/5949f728041f18149cc8008c16a9ff2d67314bea) pferd: 3.9.0 -> 3.9.2
* [`76c8d450`](https://github.com/NixOS/nixpkgs/commit/76c8d4509934c8d32a8203a62c36df5aadf7de43) switch-to-configuration-ng: honour X-* directives in user-unit migration pass
* [`6ced06a1`](https://github.com/NixOS/nixpkgs/commit/6ced06a1b337cdf403b1e53407cac9cb156b856b) switch-to-configuration-ng: rework user-unit migration candidate selection
* [`9dc20fcb`](https://github.com/NixOS/nixpkgs/commit/9dc20fcb5590998f4d52f7f5360a06d090de7d55) libgit2: 1.9.3 -> 1.9.4
* [`fd765cb1`](https://github.com/NixOS/nixpkgs/commit/fd765cb11e5483f38db03e69324eb13473c4bad2) Revert "google-chrome: fix CJK fonts by default"
* [`d1bb20ce`](https://github.com/NixOS/nixpkgs/commit/d1bb20ce9a557e881559400faf02bed8094d4753) Revert "microsoft-edge: fix CJK fonts by default"
* [`69c4b8d3`](https://github.com/NixOS/nixpkgs/commit/69c4b8d329278b7af2b3d7df612aa881fe8332ac) python3Packages.llm-ollama: 0.16.0 -> 0.16.1
* [`97d2d9e0`](https://github.com/NixOS/nixpkgs/commit/97d2d9e0fa332425b993d8a613109712ccf4f3c7) mos: drop broken update script
* [`13b51dca`](https://github.com/NixOS/nixpkgs/commit/13b51dcab8837171c4df010bf89b5a842ed9b83d) mos: 4.0.2 -> 4.2.0
* [`d0c7334a`](https://github.com/NixOS/nixpkgs/commit/d0c7334ad6041d16ee5da989f70cd39a2ae208a1) highscore-prosystem: 0-unstable-2025-12-27 -> 0-unstable-2026-05-16
* [`73484639`](https://github.com/NixOS/nixpkgs/commit/734846393f8c523fb79fe21cf6747ebf5306f13a) qemu: 10.2.2 -> 11.0.0
* [`663a59e0`](https://github.com/NixOS/nixpkgs/commit/663a59e0b6d7575d7465ea0f03b6fa66f6298038) nixos/activation: run user nixos-activation.service exactly once per switch
* [`b1a881ed`](https://github.com/NixOS/nixpkgs/commit/b1a881edb95a7caa4b9afbf8114fa718e106dbe1) nixos/user-activation-scripts: refactor assert
* [`cfe6cdf0`](https://github.com/NixOS/nixpkgs/commit/cfe6cdf061909e6e2207b4c817bd77ba06781621) linuxPackages.nvidiaPackages.vulkan_beta: 595.44.08 -> 595.44.09
* [`be9fbb9d`](https://github.com/NixOS/nixpkgs/commit/be9fbb9db55b77104db726398857f82411a18324) containerd: 2.3.0 -> 2.3.1
* [`586b979a`](https://github.com/NixOS/nixpkgs/commit/586b979a8ccb8f35d5fe06645dd678a8b343f16f) davinci-resolve: 20.3.2 -> 20.3.3
* [`273dacf4`](https://github.com/NixOS/nixpkgs/commit/273dacf4f27a7b0ce69f11a409cccef8595772fb) capstone: 5.0.7 -> 5.0.8
* [`ebb11687`](https://github.com/NixOS/nixpkgs/commit/ebb11687f8349bd294a1188d96cbc5fd66b0865c) zoho-mail-desktop: 1.7.4 -> 1.9.2
* [`35d0a84b`](https://github.com/NixOS/nixpkgs/commit/35d0a84b8121852c0355201caa083101a743d891) waves: 0.1.44 -> 0.1.45
* [`69db1ea8`](https://github.com/NixOS/nixpkgs/commit/69db1ea8fd99accd68069a6e332bfa4285269d46) doc: init styleguide
* [`1152ae98`](https://github.com/NixOS/nixpkgs/commit/1152ae98e34f9d0a60f62c61339182eaf70f142b) pacemaker: enable strictDeps
* [`56edd414`](https://github.com/NixOS/nixpkgs/commit/56edd414f6b9f218ba77afbf58b976d97effeed9) pacemaker: use tag/hash in fetcher
* [`6c5cff99`](https://github.com/NixOS/nixpkgs/commit/6c5cff998a322bee516ac0336e9d0f2fb21d84d2) pacemaker: add versionCheckHook
* [`6664618c`](https://github.com/NixOS/nixpkgs/commit/6664618c9923c3dab5302dd7b6272a8f6624306e) python3Packages.ical: 13.2.2 -> 13.2.5
* [`54d31096`](https://github.com/NixOS/nixpkgs/commit/54d31096be65cceac79e4236774180e5cf067814) fluent-bit: 5.0.5 -> 5.0.6
* [`c33058f7`](https://github.com/NixOS/nixpkgs/commit/c33058f7c67b4a11ecda11d97078c1e539d73858) maddy: 0.8.2 -> 0.9.4
* [`f2abedd1`](https://github.com/NixOS/nixpkgs/commit/f2abedd11a7353624f40740d412ec8cbdf9ef91d) maddy: 0.9.4 -> 0.9.5
* [`f7bff1be`](https://github.com/NixOS/nixpkgs/commit/f7bff1be969210e3eecf9e4403fdbaa20f1912f2) catalyst: 2.0.0 -> 2.1.0
* [`84160dde`](https://github.com/NixOS/nixpkgs/commit/84160ddeb87005ca31b58ea0c55c9c7241d1eb77) nixos/firewalld: add reload triggers for config file changes
* [`ff22c1a1`](https://github.com/NixOS/nixpkgs/commit/ff22c1a137752a95feb9e4cc1273bef90e1d0f5c) spotatui: enable cover-art feature
* [`0113170d`](https://github.com/NixOS/nixpkgs/commit/0113170d5e755099c741e7d8939f4079b7c9fa42) graphite: fix update script
* [`a20df1b4`](https://github.com/NixOS/nixpkgs/commit/a20df1b437305f8b18ade81483f4658ef4c82d9f) graphite: 0-unstable-2026-05-02 -> 0-unstable-2026-05-25
* [`36ca45c3`](https://github.com/NixOS/nixpkgs/commit/36ca45c3181ac3f23273d9efc788d58154107d29) doit: 0.36.0 -> 0.37.0
* [`6bbf6293`](https://github.com/NixOS/nixpkgs/commit/6bbf6293ea1687096e9e0d43fae64826e16c99c4) installFonts: install pcf.gz
* [`dd7a495f`](https://github.com/NixOS/nixpkgs/commit/dd7a495f239435d60c05a911e243dbc9260a505e) envypn-font: use installFonts
* [`aba06e67`](https://github.com/NixOS/nixpkgs/commit/aba06e67bf7e69417069d26273c516a04e5edb01) veila: 0.4.0 -> 0.4.1
* [`5a6945ca`](https://github.com/NixOS/nixpkgs/commit/5a6945caae15a065fdf0bc207dc7ac1e431c3596) function-runner: 9.0.0 -> 9.1.2
* [`258f24c2`](https://github.com/NixOS/nixpkgs/commit/258f24c225f22edd29592b6985b7b8d3cbe3f25c) hl-log-viewer: 0.36.1 -> 0.36.2
* [`bc8afa0d`](https://github.com/NixOS/nixpkgs/commit/bc8afa0d9f419e76c4f5f53e98643690ce25f7a1) frr: fix cross build with lua scripting
* [`79700140`](https://github.com/NixOS/nixpkgs/commit/797001408960f0e608fe3d073cda5a8381c15c77) bpftrace: 0.25.1 -> 0.26.0
* [`d72c4f89`](https://github.com/NixOS/nixpkgs/commit/d72c4f89cac3d8a09138adf217ab94ce22ef2a54) nixpkgs-plugin-update: allow semver build tags
* [`fed14bd7`](https://github.com/NixOS/nixpkgs/commit/fed14bd766dfdf22c3886fd127d4591772643df4) nixpkgs-plugin-update: skip prerelease tags
* [`e0e838b0`](https://github.com/NixOS/nixpkgs/commit/e0e838b060bd3ea93ab776d4d9289ea7e474c2d4) nixpkgs-plugin-update: fall back on empty refs
* [`2cb4e23a`](https://github.com/NixOS/nixpkgs/commit/2cb4e23a3d479baee1318f39cd49412aea74b6a4) nixpkgs-plugin-update: keep newer tag base
* [`97c5fd50`](https://github.com/NixOS/nixpkgs/commit/97c5fd50e9d4e17d0c4e808d3426d78abb3c1f3f) nixpkgs-plugin-update: avoid duplicate submodule checks
* [`2d413a5e`](https://github.com/NixOS/nixpkgs/commit/2d413a5e38c08b59e031e3cffe59ee463b63ac32) nixpkgs-plugin-update: preserve slash tags
* [`9d5face4`](https://github.com/NixOS/nixpkgs/commit/9d5face41c3611acfea5694ff9af15dc6cef8ec5) nixpkgs-plugin-update: keep current plugins on fetch failure
* [`743b5ec4`](https://github.com/NixOS/nixpkgs/commit/743b5ec421e39cd48e6dd570bf55fcb9b5028e9d) torrent7z: remove
* [`ee080503`](https://github.com/NixOS/nixpkgs/commit/ee0805035fe5eac7b8b0b19d6a0e560fafe6ceb9) rdma-core: add static platforms to `badPlatforms`
* [`d46a2aee`](https://github.com/NixOS/nixpkgs/commit/d46a2aee5a5accc2505525029e807a0e1d17c286) libcdr: 0.1.8 -> 0.1.9
* [`0c873241`](https://github.com/NixOS/nixpkgs/commit/0c873241f765f004694163bac6241a881803efbd) libabw: 0.1.3 -> 0.1.4
* [`3fd65b2b`](https://github.com/NixOS/nixpkgs/commit/3fd65b2bc8d7de36d27d8a914e1ee7eb60506650) github-desktop: link libexec/git-core into git wrapper
* [`f80d1650`](https://github.com/NixOS/nixpkgs/commit/f80d165041d1fa34f4e87f9844c5028348e61f7d) minizinc: 2.9.3 → 2.9.7
* [`04d580cf`](https://github.com/NixOS/nixpkgs/commit/04d580cf12724de03c482dc92a17035fa9e798d5) stable-diffusion-cpp-rocm: master-625-f683c88 -> master-652-92dc726
* [`da38ab0e`](https://github.com/NixOS/nixpkgs/commit/da38ab0e39b94e1db1247cda2451946005ce9bf3) nixos-rebuild-ng: use hash token in ControlPath
* [`a3929bb4`](https://github.com/NixOS/nixpkgs/commit/a3929bb4bc45a163b5e50a3ee7ec211d1daed705) python3Packages.esig: drop
* [`baacce09`](https://github.com/NixOS/nixpkgs/commit/baacce0936b64e323a16a0dbf20c28cbe27552d4) python3Packages.advantage-air: migrate to pyproject
* [`f5b8fec1`](https://github.com/NixOS/nixpkgs/commit/f5b8fec1b21df2ffe8ba3b7514157d8b2b215871) python3Packages.advantage-air: use finalAttrs
* [`cc471c9c`](https://github.com/NixOS/nixpkgs/commit/cc471c9c68275f999d3e4d9b39c6eadce53789c6) stanc: 2.38.0 -> 2.39.0
* [`23bee868`](https://github.com/NixOS/nixpkgs/commit/23bee868d9bc10afa47af2b66c23aa51fc2b8d19) prooftree: refactor
* [`e20cd6ad`](https://github.com/NixOS/nixpkgs/commit/e20cd6adb006694024503cc668763774d6724f83) nixos-test-driver: adher to `select`'s interface
* [`d3af6793`](https://github.com/NixOS/nixpkgs/commit/d3af6793909e84c96722df4586b38b6690601a21) cmdstan: 2.38.0 -> 2.39.0
* [`c71c2754`](https://github.com/NixOS/nixpkgs/commit/c71c2754ef6b3667968fae930ae72a2f194370c1) python3Packages.cmdstanpy: fix build with cmdstan 2.39.0
* [`6843daf4`](https://github.com/NixOS/nixpkgs/commit/6843daf461a3768e00201a3d942787dc334a46a8) buildah-unwrapped: 1.43.1 -> 1.44.0
* [`fe55e1a3`](https://github.com/NixOS/nixpkgs/commit/fe55e1a3787ab10fa79b35f0ac35a8df821965b7) cudaPackages_13_3: init at 13.3.0
* [`8ddb5bfe`](https://github.com/NixOS/nixpkgs/commit/8ddb5bfe36bb9b00c51c9319cba661a21b33a161) mesa: drop a patch applied in 26.1.1
* [`58c07965`](https://github.com/NixOS/nixpkgs/commit/58c0796598adb70b3c3cfe5de7d3a1b03649a630) appflowy: update license
* [`a601a1e5`](https://github.com/NixOS/nixpkgs/commit/a601a1e51ece8f4a77568d7fe34e0e263fbe7c3f) proxmox-auto-install-assistant: 9.1.6 -> 9.2.5
* [`3133e578`](https://github.com/NixOS/nixpkgs/commit/3133e5783011608e549b82a72daa6d3e2a7593e5) ruff: 0.15.14 -> 0.15.15
* [`14f7284b`](https://github.com/NixOS/nixpkgs/commit/14f7284b835529acc3c7787c938ee8466ea7f630) ns-3: 44 -> 47
* [`5f2c6fff`](https://github.com/NixOS/nixpkgs/commit/5f2c6fffde18eb7f624f9fcbd62bc0ee4a4a5f4d) gui-for-clash: remove
* [`cdbaba82`](https://github.com/NixOS/nixpkgs/commit/cdbaba823ac46c5035c95ed4852cc439b69bca92) netboxPlugins.netbox-qrcode: configure nix-update-script to ignore broken release .0.0.14
* [`05515f59`](https://github.com/NixOS/nixpkgs/commit/05515f5956078c958206563215a28012ac0dba08) netboxPlugins.netbox-qrcode: 0.0.20 -> 0.0.21
* [`88cfc545`](https://github.com/NixOS/nixpkgs/commit/88cfc54552d5678f27d292fd75df963aecd3b357) nix-prefetch-git: disable maintenance mode via environment variables
* [`1109df3c`](https://github.com/NixOS/nixpkgs/commit/1109df3cdf296926c31b1e199a6a296cd433901b) nix-heuristic-gc: 0.7.3 -> 0.7.4
* [`c2c9eb67`](https://github.com/NixOS/nixpkgs/commit/c2c9eb672a134c89fb00700088cf387241ff9864) bicep: 0.36.177 -> 0.39.26
* [`25e22edb`](https://github.com/NixOS/nixpkgs/commit/25e22edb8d11866d9acfcfbc4f9e8c28ba7fd526) python3Packages.flask-apscheduler: init at 1.13.1
* [`f22ec572`](https://github.com/NixOS/nixpkgs/commit/f22ec572042e5c2116de9ed58aa63b6050b5fc48) python3Packages.flask-ldap3-login: init at 1.0.2
* [`59cdf0f1`](https://github.com/NixOS/nixpkgs/commit/59cdf0f127dd6bbbcfe044bbe17f2b7ed951c9a4) nixos-rebuild-ng: introduce Elevator abstraction
* [`b9a7b558`](https://github.com/NixOS/nixpkgs/commit/b9a7b55898b8d3a671694a60ba2a8b8634832c2c) nixos-rebuild-ng: run_wrapper: delegate sudo wrapping to Elevator
* [`c0941322`](https://github.com/NixOS/nixpkgs/commit/c0941322a4f423dc42dd0a4c06be1bc0b513d4c2) nixos-rebuild-ng: thread Elevator through the call chain
* [`a769269a`](https://github.com/NixOS/nixpkgs/commit/a769269aef810723207d77412a61cc651778e2c1) nixos-rebuild-ng: add --elevate and --ask-elevate-password flags
* [`0273aad1`](https://github.com/NixOS/nixpkgs/commit/0273aad113950a3bcaf70b883e4db05637bd8ffc) nixos-rebuild-ng: move password prompt out of Remote
* [`4d4952ae`](https://github.com/NixOS/nixpkgs/commit/4d4952ae28c707aeb66c7def830fd1dd60669510) polkit-stdin-agent: init at 0.3.0
* [`c30b2c06`](https://github.com/NixOS/nixpkgs/commit/c30b2c06d953e6f986162c5809d864eae52e61b5) nixos-rebuild-ng: add --elevate=run0
* [`dbbee0dd`](https://github.com/NixOS/nixpkgs/commit/dbbee0dd3a2219015ca58704100b81377187dad7) nixos-rebuild-ng: document --elevate / --ask-elevate-password
* [`3653274b`](https://github.com/NixOS/nixpkgs/commit/3653274b279b7415b62b23e4edf4ccc5afd55968) vcpkg: 2026.04.27 -> 2026.05.25
* [`189afba2`](https://github.com/NixOS/nixpkgs/commit/189afba2569f75deafb0240c2f1876cc47caca5d) vi-mongo: 0.1.30 -> 0.2.2
* [`efa2e56f`](https://github.com/NixOS/nixpkgs/commit/efa2e56fdb2db0386e4e53195bacc969fd1380d1) kronometer: migrate to pkgs/by-name
* [`82921fdd`](https://github.com/NixOS/nixpkgs/commit/82921fdd3b10231097d130b61c8827d0318a74e1) spade: 0.18.0 -> 0.19.0
* [`6a2ddda7`](https://github.com/NixOS/nixpkgs/commit/6a2ddda788f3762e270c506ce83b72b510d6b178) swim: 0.18.0 -> 0.19.0
* [`443a7efc`](https://github.com/NixOS/nixpkgs/commit/443a7efcc1400bd9a6abf3069a54559499db459e) ostui: 1.0.5 -> 1.1.1
* [`f5c8639d`](https://github.com/NixOS/nixpkgs/commit/f5c8639dd50cb768590f47da7cbdc101ef981215) nixos/nspawn-container: use ty instead of mypy
* [`fb4718b2`](https://github.com/NixOS/nixpkgs/commit/fb4718b204380eb946840f0e32dab5b691815817) teamviewer: 15.74.3 -> 15.78.3
* [`23e29f2c`](https://github.com/NixOS/nixpkgs/commit/23e29f2c81ca30d7dfedca789b0fc065126cbda4) salt: 3007.13 -> 3008.0
* [`ffcfaf97`](https://github.com/NixOS/nixpkgs/commit/ffcfaf97684d508a9441a1ac7ee71426d9a97a94) libwacom: 2.18.0 -> 2.19.0
* [`c14bfbf0`](https://github.com/NixOS/nixpkgs/commit/c14bfbf0463a36a9702c4fc312fa9d5d264d7c45) ty: 0.0.38 -> 0.0.40
* [`61542c96`](https://github.com/NixOS/nixpkgs/commit/61542c96d144e59669ec2c909bc08ed308bb4a38) ty: add ddogfoodd to maintainers
* [`c9e7b7c1`](https://github.com/NixOS/nixpkgs/commit/c9e7b7c1e9339c3a3ba3afc3f4ed95125552fead) exiftool: 13.58 -> 13.59
* [`4f6f2b4d`](https://github.com/NixOS/nixpkgs/commit/4f6f2b4dde0115f532db304f087f7e0395e80eb1) linuxPackages.nvidiaPackages.legacy_580: 580.142 -> 580.159.04
* [`f244ed89`](https://github.com/NixOS/nixpkgs/commit/f244ed8941324d3015c5893371fd5c6643013966) chroma: 2.25.0 → 2.26.0
* [`4b794705`](https://github.com/NixOS/nixpkgs/commit/4b794705ce88d138bd15c239cb735c959fedce89) chroma: 2.26.0 → 2.26.1
* [`c5ebd486`](https://github.com/NixOS/nixpkgs/commit/c5ebd4868cbf86a814c0f52e82fc18db749910f1) dexter: 0.6.0 -> 0.7.0
* [`679238e9`](https://github.com/NixOS/nixpkgs/commit/679238e99bbab7c9a76f09be5372ebbb5c80111c) dev86: 1.0.1-unstable-2025-02-12 -> 1.0.1-unstable-2026-05-15
* [`d0644026`](https://github.com/NixOS/nixpkgs/commit/d0644026a4adbfbb6265347e9abb45a1894cb67b) brave: 1.90.124 -> 1.90.128
* [`5105500b`](https://github.com/NixOS/nixpkgs/commit/5105500b167d2f6754cfa01dddc6aa060a4c9316) spire: 1.15.0 -> 1.15.1
* [`16748537`](https://github.com/NixOS/nixpkgs/commit/16748537bbb4d2c5058cb48cdae745c842447a0f) ios-deploy: fix build
* [`36a83930`](https://github.com/NixOS/nixpkgs/commit/36a8393049930cadd50ae55e8b908b06a5e6de25) python3Packages.zenoh: 1.6.2 -> 1.9.0
* [`cd62aaba`](https://github.com/NixOS/nixpkgs/commit/cd62aaba5939b05045a2592a911698b4c3615776) vscode-extensions.charliermarsh.ruff: 2026.42.0 -> 2026.46.0
* [`cb4d0769`](https://github.com/NixOS/nixpkgs/commit/cb4d0769a44fe23071aa8c6b713d19142c08bd44) python3Packages.ripser: 0.6.14 -> 0.6.15
* [`ecddc8da`](https://github.com/NixOS/nixpkgs/commit/ecddc8dab19824ad4630d25d6e3a9ad4d9f6d095) ktfmt: 0.61 -> 0.63
* [`852b4f37`](https://github.com/NixOS/nixpkgs/commit/852b4f37c4d1f0fc53a04bdf10572b1941d38cf6) vscode-extensions.detachhead.basedpyright: 1.39.3 -> 1.39.6
* [`db81e756`](https://github.com/NixOS/nixpkgs/commit/db81e7567f3b9fcc3465cf42ad032f913b24b34c) linux: use correct strip program when stripping vmlinux
* [`f98b1779`](https://github.com/NixOS/nixpkgs/commit/f98b1779965f33199396e40820e8cf0ce04150bd) snakemake: 9.21.0 -> 9.21.1
* [`bac8de9e`](https://github.com/NixOS/nixpkgs/commit/bac8de9e8e07b7e84232a712955c4e908bb71726) unison-fsmonitor: 0.3.8 -> 0.3.9
* [`418a5391`](https://github.com/NixOS/nixpkgs/commit/418a5391c084e80fe11875af756809858e2217d9) python3Packages.pyhepmc: fix build
* [`515a4a61`](https://github.com/NixOS/nixpkgs/commit/515a4a61ebedbf9ac5862b6d8b29564dade419cc) python3Packages.pyhepmc: use finalAttrs
* [`23089890`](https://github.com/NixOS/nixpkgs/commit/23089890e230ae8fc0fbbce0e68c38d1d206e8b0) python3Packages.ucsmsdk: 0.9.25 -> 0.9.26
* [`a0cafa15`](https://github.com/NixOS/nixpkgs/commit/a0cafa15f86562c50c3fd2138fddbfebf60d58ce) nexttrace: 1.6.5 -> 1.7.0
* [`ea5ff3b2`](https://github.com/NixOS/nixpkgs/commit/ea5ff3b2bc6078cb3655d0cbbc777ccace57f85c) fetchPnpmDeps,pnpmConfigHook: drop pnpmWorkspace migration guards
* [`9c0f1896`](https://github.com/NixOS/nixpkgs/commit/9c0f18961fc09ba4b149cab5c0cf7ba19e7aa8d3) grafanaPlugins.marcusolsson-calendar-panel: 4.2.3 -> 4.2.4
* [`85fb21a3`](https://github.com/NixOS/nixpkgs/commit/85fb21a319a615270188a2d240239613b1cf8caf) spruce: 1.35.4 -> 1.35.5
* [`ed6b641c`](https://github.com/NixOS/nixpkgs/commit/ed6b641c563aad0235967ce523b0ec27bc231687) mdbook-plugins: 0.3.4 -> 1.0.1
* [`fe6216ca`](https://github.com/NixOS/nixpkgs/commit/fe6216caa8e26b5f9c40e0299548081e7bcf6d71) steelix: 0-unstable-2026-05-09 -> 0-unstable-2026-05-21
* [`1f4a3c18`](https://github.com/NixOS/nixpkgs/commit/1f4a3c188ca0523890f353d6952640a5b906f434) nushellPlugins.skim: 0.27.0 -> 0.28.0
* [`357b62df`](https://github.com/NixOS/nixpkgs/commit/357b62df342cbb3ba0136baecb1709d1b3f3ab7c) omnictl: 1.7.3 -> 1.8.0
* [`dc0540f4`](https://github.com/NixOS/nixpkgs/commit/dc0540f4afff2e51ce2b903e71e79ff8ec8c6551) vscode-extensions.gleam.gleam: 2.12.1 -> 2.12.2
* [`abf07c01`](https://github.com/NixOS/nixpkgs/commit/abf07c01a74d157fa778c628926ba10b1953832f) apko: 1.2.13 -> 1.2.14
* [`2544f105`](https://github.com/NixOS/nixpkgs/commit/2544f1053703fe66e880cd1f69f82cdced1153c9) goldendict-ng: 26.3.0 -> 26.5.6
* [`fd573a70`](https://github.com/NixOS/nixpkgs/commit/fd573a70ddefbf3770f8339c956ec53785a99420) capstone: 5.0.8 -> 5.0.9
* [`0643b566`](https://github.com/NixOS/nixpkgs/commit/0643b566e8b3f420abcc2abd876953368790b50c) python3Packages.qpageview: 1.0.4 -> 1.0.5
* [`3a6107a4`](https://github.com/NixOS/nixpkgs/commit/3a6107a40db5e37ec16c5f1df0ac312a445b0dbd) pnpm_10: 10.33.4 -> 10.34.0
* [`1859b4a8`](https://github.com/NixOS/nixpkgs/commit/1859b4a89bc757bd8841520783794f2c0b246f72) nixos/opensnitch: link network_aliases.json to /etc/opensnitchd
* [`7bc226af`](https://github.com/NixOS/nixpkgs/commit/7bc226af6eb50065457c2a7252d65fb12e3e7ee5) sherpa-onnx: 1.12.38 -> 1.13.2
* [`d75b1d02`](https://github.com/NixOS/nixpkgs/commit/d75b1d024232c98f1092a13d6e2833146ff2b38a) aquamarine: 0.11.0 -> 0.12.0
* [`97bbf0fa`](https://github.com/NixOS/nixpkgs/commit/97bbf0faa59063afd7362bb42ebe743fbf6a6d31) lxqt.lxqt-panel: migrate to pcre2
* [`febc51eb`](https://github.com/NixOS/nixpkgs/commit/febc51eba59f25f077de964904915d7409379376) lxqt.lxqt-runner: migrate to pcre2
* [`4c56d845`](https://github.com/NixOS/nixpkgs/commit/4c56d84517791f2c8061292e04b321e11bee94c0) tldx: 1.3.4 -> 1.4.0
* [`03f15a12`](https://github.com/NixOS/nixpkgs/commit/03f15a1233ca2ff3cccf4c0acc4aa08b2aab1f90) glaze: 7.7.0 -> 7.7.1
* [`e9dd2320`](https://github.com/NixOS/nixpkgs/commit/e9dd23201e34cc85c13fc88295b4989418337e4e) pacemaker: optionally enable manpages
* [`68f205e5`](https://github.com/NixOS/nixpkgs/commit/68f205e5ce580485102f3f341274880ed8e43038) dosage: 3.2 -> 3.3
* [`ed01577f`](https://github.com/NixOS/nixpkgs/commit/ed01577f90cc46c747c3c8d33d2f40dc72d02c39) chatbox: drop
* [`a971f414`](https://github.com/NixOS/nixpkgs/commit/a971f4142c8a6aa6d08cd821ee934b5ce6e2f323) rabtap: 1.44.1 -> 1.45.0
* [`c5782c31`](https://github.com/NixOS/nixpkgs/commit/c5782c312db73a9098d8d180cfe9fc3ff299f51d) python3Packages.lizard: 1.22.1 -> 1.22.2
* [`c4abdf28`](https://github.com/NixOS/nixpkgs/commit/c4abdf280b938d083cc0920407c91a0047698c71) libgphoto2: 2.5.33 -> 2.5.34
* [`74a82ccd`](https://github.com/NixOS/nixpkgs/commit/74a82ccd8e8535d32afb1c3f0db9c97cdc088322) camlp5: propagate findlib deps pcre2 and fmt
* [`7579aa29`](https://github.com/NixOS/nixpkgs/commit/7579aa29421e7fb5d2ed7da97040ed9448d1e10a) hol_light: unstable-2024-07-07 -> 0-unstable-2026-05-19
* [`49e5f322`](https://github.com/NixOS/nixpkgs/commit/49e5f32275ea6a56e692a980590178a924eae52b) music-assistant-desktop: 0.3.6 -> 0.3.7
* [`0945d7ed`](https://github.com/NixOS/nixpkgs/commit/0945d7ed77c95b2cb3b320abe53dde496b2e5377) {cri-o,cri-o-unwrapped}: move to by-name
* [`d01101d8`](https://github.com/NixOS/nixpkgs/commit/d01101d8e2b2cec49906c129df48517586c8de65) git: use finalAttrs for doInstallCheck config
* [`68157d88`](https://github.com/NixOS/nixpkgs/commit/68157d88863aa070260b1b970470e1faea78ae3f) linux/common-config: enable deflate/zstd for erofs
* [`2ebf6c55`](https://github.com/NixOS/nixpkgs/commit/2ebf6c55e6b3e42e152510b541a3463b3cbb6870) libkrunfw: fix build with structuredAttrs, use --replace-fail
* [`89631dab`](https://github.com/NixOS/nixpkgs/commit/89631dabdd1436e0b878c27d96538230855fed14) sherpa: fix Darwin build with CMAKE_INSTALL_NAME_DIR
* [`08a2d5ff`](https://github.com/NixOS/nixpkgs/commit/08a2d5fff737305a13c39a47a49cf8590567220d) vscode: 1.119.0 -> 1.122.1
* [`94b4b558`](https://github.com/NixOS/nixpkgs/commit/94b4b5580a5db194b32f6366f3fd9ba6a683accf) python3Packages.facedancer: 3.1.2 -> 3.1.3
* [`0cc71224`](https://github.com/NixOS/nixpkgs/commit/0cc71224c3600689d5eb364399c5451d9266d34e) python3Packages.ufo2ft: 3.7.2 -> 3.8.1
* [`424e59a3`](https://github.com/NixOS/nixpkgs/commit/424e59a33bcb470f80770428584316c34d598db9) vscode-extensions.tombi-toml.tombi: 0.9.24 -> 1.1.1
* [`57b2039b`](https://github.com/NixOS/nixpkgs/commit/57b2039b1a6aec4b5b428421575c483aaeddf27f) fairywren: 0-unstable-2026-05-15 -> 0-unstable-2026-05-30
* [`794f7520`](https://github.com/NixOS/nixpkgs/commit/794f752063e28d8fd9785714857fb44825ce2500) gex: 0.6.4 -> 0.6.7
* [`9bdcc30b`](https://github.com/NixOS/nixpkgs/commit/9bdcc30b0372c3b0188ed6dc8a24e91334cfed15) opl3bankeditor: 1.5.1-unstable-2026-05-04 -> 1.5.1-unstable-2026-05-23
* [`6e5b6335`](https://github.com/NixOS/nixpkgs/commit/6e5b63357b8a0f7cf6625968a1e55d21a33b2904) nixos/etc: create uninitialized /etc/machine-id with readonly /etc/
* [`e4697cad`](https://github.com/NixOS/nixpkgs/commit/e4697cadc969f8cb38dcb843a0862c8b029b9007) python3Packages.yaramod: 4.6.0 -> 4.7.1
* [`26d8119a`](https://github.com/NixOS/nixpkgs/commit/26d8119a24991687a9f06be10864aa629de0c1c2) yabause: migrate to pkgs/by-name
* [`ed1da451`](https://github.com/NixOS/nixpkgs/commit/ed1da4519ab7c856d06220b593acee976295c596) jazz2: 3.5.0 -> 3.6.0
* [`1bc189f2`](https://github.com/NixOS/nixpkgs/commit/1bc189f2e14dd7abb750903697b9683d54c0fcee) balatro-mod-manager: 0.4.0 -> 0.4.1
* [`4224d4ac`](https://github.com/NixOS/nixpkgs/commit/4224d4acd8002ec0f4f211f84c7d778d047be1ee) msgpack-c: 6.1.0 -> 7.0.0
* [`32640952`](https://github.com/NixOS/nixpkgs/commit/3264095251089348bbaf4e0e46234b56cd24228b) open-vm-tools: fix strictDeps inputs
* [`f57b27b1`](https://github.com/NixOS/nixpkgs/commit/f57b27b1cfe5da03d7a08d9150b31bb4060c5f13) sftpgo: 2.7.1 -> 2.7.3
* [`db13566b`](https://github.com/NixOS/nixpkgs/commit/db13566b3e8a759e8399f1f73a80a179985a8cb0) libsForQt5.qtstyleplugin-kvantum: 1.1.7 -> 1.1.8
* [`f94be7e2`](https://github.com/NixOS/nixpkgs/commit/f94be7e2263b22e810aad6a25a1a6adbb5c3f9c7) python3Packages.proton-vpn-local-agent: 1.6.1 -> 1.6.2
* [`109d6f6f`](https://github.com/NixOS/nixpkgs/commit/109d6f6f670ebc8748acc1ca558ae25666d360d7) redumper: enable strictDeps
* [`6ff6a5e5`](https://github.com/NixOS/nixpkgs/commit/6ff6a5e53014fe001cd77d4afe2a3bea79d301b3) redumer: enable __structuredAttrs
* [`e8a5620f`](https://github.com/NixOS/nixpkgs/commit/e8a5620f5289b29d5811165029c750d71fa0698e) redumper: enable on Darwin
* [`2767366b`](https://github.com/NixOS/nixpkgs/commit/2767366b90e007758bb0846358ff001e62b4531d) fastcov: 1.16 -> 1.17
* [`1a06533d`](https://github.com/NixOS/nixpkgs/commit/1a06533d34925edc8c063f75895dc4b04ae1eb96) ario: remove unused libsoup_2_4 dependency
* [`b4447260`](https://github.com/NixOS/nixpkgs/commit/b4447260988b08afbf6d8286a1c3dfe669f04d7f) makeSetupHook: support structuredAttrs to unbreak adding to by-name
* [`5176d7e0`](https://github.com/NixOS/nixpkgs/commit/5176d7e061993bbaf02e9ef30899b3bd3fdeed5c) circumflex: 4.1.1 -> 4.3
* [`55a10692`](https://github.com/NixOS/nixpkgs/commit/55a10692dd8c408fe984034617e8cf86c61a0405) opengrok: 1.14.12 -> 1.14.13
* [`af7bdb9a`](https://github.com/NixOS/nixpkgs/commit/af7bdb9a91aa219a13a2daf6400baac52d999345) openlist: remove fuse
* [`af3091ec`](https://github.com/NixOS/nixpkgs/commit/af3091eccaf18eda979a26b951e556eb4ce232b8) faugus-launcher: 1.16.6 -> 1.20.4
* [`c90c46c3`](https://github.com/NixOS/nixpkgs/commit/c90c46c3cf1dcfdf834192073e2304621d8151a0) openlist: 4.2.1 -> 4.2.2
* [`29da54e3`](https://github.com/NixOS/nixpkgs/commit/29da54e3707f737aa8bda463bf2a4ff17b9edf34) python3Packages.biopandas: fix numpy 2.4 compatibility
* [`9750fb9d`](https://github.com/NixOS/nixpkgs/commit/9750fb9d1990074b637a2f814183e4dd52959ebd) leanify: 0-unstable-2025-12-12 -> 0.4.3-unstable-2025-12-12
* [`6a5db4a3`](https://github.com/NixOS/nixpkgs/commit/6a5db4a3a5dcfb37ad8e27accf44e54efe9da2e1) uutils-acl: 0.0.1-unstable-2026-05-17 -> 0.0.1-unstable-2026-05-29
* [`fae9cc5c`](https://github.com/NixOS/nixpkgs/commit/fae9cc5c16101a5eaaf22807718dcf31efdd386d) uutils-procps: 0.0.1-unstable-2026-05-13 -> 0.0.1-unstable-2026-05-30
* [`07751350`](https://github.com/NixOS/nixpkgs/commit/077513501a115e401f9d44b8d3d4dc4d3fe482b1) boring: 0.14.0 -> 0.15.0
* [`4fb4fda0`](https://github.com/NixOS/nixpkgs/commit/4fb4fda0bdd9ab264664c4c9540db35a683b6049) pulsemeeter: 2.0.0 -> 2.1.1
* [`35e6afa1`](https://github.com/NixOS/nixpkgs/commit/35e6afa1846082566200bc93c18b8ba4bf322c7d) mangareader: 2.5.0 -> 2.5.1
* [`4ce5237d`](https://github.com/NixOS/nixpkgs/commit/4ce5237da11bcb362deb63048222c6c032acd6f0) telemt: 3.4.12 -> 3.4.13
* [`d27c28ea`](https://github.com/NixOS/nixpkgs/commit/d27c28eadba20b0dcb591401a1572f1cc8dcf640) vscode-extensions.ms-python.mypy-type-checker: 2026.4.0 -> 2026.6.0
* [`d72fb516`](https://github.com/NixOS/nixpkgs/commit/d72fb51665ea00e8979dde1884cfbc14781ddb5a) v2ray-domain-list-community: 20260522120028 -> 20260531040030
* [`3e98a893`](https://github.com/NixOS/nixpkgs/commit/3e98a893b69c8f9800007989aaae1221ce1e92dc) bisq2: 2.1.10 -> 2.1.11
* [`c96131c9`](https://github.com/NixOS/nixpkgs/commit/c96131c9f3a35365415bffe30a3da4b09518a9f6) tango-icon-theme: change to SRI hash
* [`2a9b20e0`](https://github.com/NixOS/nixpkgs/commit/2a9b20e0d3b15b074a1df80dfad1d2c98622c192) tango-icon-theme: enable strictDeps and structuredAttrs
* [`b98abf3b`](https://github.com/NixOS/nixpkgs/commit/b98abf3b72fde009596cfecbe7a882edc4521e4e) vscode-extensions.fstarlang.fstar-vscode-assistant: 0.24.0 -> 0.25.0
* [`8ace6ec1`](https://github.com/NixOS/nixpkgs/commit/8ace6ec10141c3c6e814e9fe32efccc08cd149d8) mirrord: 3.211.0 -> 3.213.0
* [`472125f1`](https://github.com/NixOS/nixpkgs/commit/472125f131c83beef216de5767fff4cc8d20fe8a) timr-tui: 1.8.1 -> 1.9.0
* [`329c947e`](https://github.com/NixOS/nixpkgs/commit/329c947ea46d229ad17c9ad5c5f71f8400933bf4) python3Packages.flask-admin: 2.1.0 -> 2.2.0
* [`10c12372`](https://github.com/NixOS/nixpkgs/commit/10c123724e9ebac635ecd89ed88ef4f15cc75ad2) commit-notifier: 0-unstable-2026-02-07 -> 0-unstable-2026-05-31
* [`02190b58`](https://github.com/NixOS/nixpkgs/commit/02190b58d4f43b519ab51857d55264eb4938e97e) chickenPackages.chickenEggs: update
* [`7b3af176`](https://github.com/NixOS/nixpkgs/commit/7b3af176b4a8f6a3636ae462c0ecf30818e0c83e) ngtcp2-gnutls: 1.22.1 -> 1.23.0
* [`42f3b4d0`](https://github.com/NixOS/nixpkgs/commit/42f3b4d0a3ca882d690a79f1aec6d72b415d39e7) python3Packages.tmdbsimple: 2.9.2-unstable-2025-01-07 -> 2.9.6
* [`be6f179c`](https://github.com/NixOS/nixpkgs/commit/be6f179c66c8ad9b24c849d31831700c27a5c443) python3Packages.daft: init at 0.7.14
* [`1e1e98bc`](https://github.com/NixOS/nixpkgs/commit/1e1e98bc1f3816ef94451dc76754866e4f25db51) iperf3: 3.20 -> 3.21
* [`8da5bec8`](https://github.com/NixOS/nixpkgs/commit/8da5bec8ff3fefb456b5da24415dadfa5e840e53) starkiller: 3.4.0 -> 3.5.0
* [`a571238e`](https://github.com/NixOS/nixpkgs/commit/a571238ec6c43d2c400a85c668dc5bf4d4444cfb) ddns-go: 6.17.0 -> 6.17.1
* [`bedfc81b`](https://github.com/NixOS/nixpkgs/commit/bedfc81bce93056c54ccc85cc36065852a70de10) wkg: 0.15.0 -> 0.15.1
* [`93eb8287`](https://github.com/NixOS/nixpkgs/commit/93eb82879196d61e775c817a403e95b0d733930b) prismlauncher: add wrapGAppsHook3
* [`b25e96d6`](https://github.com/NixOS/nixpkgs/commit/b25e96d6122c676f467014bbe0b4d410156f5269) sbb-tui: fix versionCheckHook phase
* [`126d94bf`](https://github.com/NixOS/nixpkgs/commit/126d94bfcdbbe2425ae04ed8709d571bcd948577) deja: fix versionCheckHook phase
* [`bd5cf70e`](https://github.com/NixOS/nixpkgs/commit/bd5cf70ec2800ed1c0106b0e3801637c76b01f33) project-graph: fix versionCheckHook phase
* [`a5cee6f5`](https://github.com/NixOS/nixpkgs/commit/a5cee6f57efb790fc958c3d02eb64804b011337b) xdg-ninja: 0-unstable-2026-05-10 -> 0.2.0.2-unstable-2026-05-10
* [`25f0a586`](https://github.com/NixOS/nixpkgs/commit/25f0a586f2fc33b3cb0af0c825d09ecd34e28e57) probe-rs-tools: install shell completions
* [`a3f0e423`](https://github.com/NixOS/nixpkgs/commit/a3f0e42372fe55170e7d1045edd3df3fe7d420b6) gh-gei: 1.29.1 -> 1.30.0
* [`ec8e7ea6`](https://github.com/NixOS/nixpkgs/commit/ec8e7ea669dbc9be20729c623a3a6d066fc8faa4) git-pkgs: 0.16.1 -> 0.16.2
* [`0d710002`](https://github.com/NixOS/nixpkgs/commit/0d710002c773601f6ffdfd114e5eec1fb9255380) qtox: drop unused pcre dependency
* [`82e77796`](https://github.com/NixOS/nixpkgs/commit/82e77796ba85bf044e35e01d2544345954ddcdfe) john: 1.9.0-Jumbo-1-unstable-2026-04-13 -> 1.9.0-Jumbo-1-unstable-2026-05-31
* [`e2d2948c`](https://github.com/NixOS/nixpkgs/commit/e2d2948cf4d86c4be61960a3124e39feadcec623) redumper: add update script
* [`5fa32392`](https://github.com/NixOS/nixpkgs/commit/5fa32392245c98507b9240863c83a76506b8ddfe) redumper: 709 → 720
* [`1de89b17`](https://github.com/NixOS/nixpkgs/commit/1de89b17c894fe917325b0ae87f8d2e01cb9418b) redumper: use versionCheckHook
* [`855652d1`](https://github.com/NixOS/nixpkgs/commit/855652d14d83420b8ca15d45a207504093a02622) mp3fs: 1.1.1 -> 1.1.1-unstable-2023-01-29
* [`ea812c10`](https://github.com/NixOS/nixpkgs/commit/ea812c1006ae44a709b38d9247918ed272bacdd8) mp3fs: use fuse3
* [`a8cca1cf`](https://github.com/NixOS/nixpkgs/commit/a8cca1cf240b9414bc3eb43030840d062120326b) python3Packages.langchain-protocol: 0.0.15 -> 0.0.16
* [`7d7ce4f5`](https://github.com/NixOS/nixpkgs/commit/7d7ce4f508dfad29708a0b90f16ffd451ec54d61) gcompris: 25.1.1 -> 26.1
* [`e391e72c`](https://github.com/NixOS/nixpkgs/commit/e391e72ce85ae7c0f44f781b5eb7c614da0c8a02) _1password-gui: update.sh - simplify macOS Beta handling
* [`679ea6f2`](https://github.com/NixOS/nixpkgs/commit/679ea6f248d3a7e389f7206187991f7f666f9bd2) _1password-gui: update.sh - Use upstream's APT repo for version checks
* [`446e7a53`](https://github.com/NixOS/nixpkgs/commit/446e7a5382be621be9b61de40a9e23e631db74f3) postgresqlPackages.pg_textsearch: 1.2.0 -> 1.3.0
* [`aa1a659f`](https://github.com/NixOS/nixpkgs/commit/aa1a659f05e0f4bff52ab44c8a64bd67ffa6cd6c) tailscale: 1.98.3 -> 1.98.5
* [`2c01146d`](https://github.com/NixOS/nixpkgs/commit/2c01146d7db33780ce3578c9e9e96e4824abeb94) fetchPnpmDeps: throw on removed fetcherVersion = 1 and 2
* [`3962275b`](https://github.com/NixOS/nixpkgs/commit/3962275b5d93040a62d24e77afe21a0314837051) fetchPnpmDeps,pnpmConfigHook: remove dead fetcherVersion < 3 infrastructure
* [`98d42d95`](https://github.com/NixOS/nixpkgs/commit/98d42d95dd699c224037f8fab809a8b32df80630) redumper: set REDUMPER_VERSION_BUILD to Git tag
* [`1ac3c5dc`](https://github.com/NixOS/nixpkgs/commit/1ac3c5dc9969eb532bc5fb22bfedaa4f2b4293c0) nixos/shadow: use file capabilities for newuidmap/newgidmap
* [`331748b1`](https://github.com/NixOS/nixpkgs/commit/331748b1e9d1ade26aa3ab09dbfc632949df2273) python3Packages.imgsize: 4.0.1 -> 4.0.2
* [`fdd41e90`](https://github.com/NixOS/nixpkgs/commit/fdd41e909e1bcea02dd9587c88d16835fefa82db) versatiles: 4.1.2 -> 4.1.4
* [`93d8842c`](https://github.com/NixOS/nixpkgs/commit/93d8842c937430b3dfcdf2c4a71ff9872f431896) vscode-extensions.cweijan.vscode-database-client2: 8.4.6 -> 8.4.7
* [`88725dae`](https://github.com/NixOS/nixpkgs/commit/88725dae678d92f9fb2bb9ad9d04888661437b66) redumper: use lib.cmakeFeature
* [`a9dcf2a3`](https://github.com/NixOS/nixpkgs/commit/a9dcf2a361591783135a8a6a5f35698805de0dd3) supabase-cli: 2.101.0 -> 2.102.0
* [`25a9fcf4`](https://github.com/NixOS/nixpkgs/commit/25a9fcf472b40915d49a9f9524806a5cb2370cb1) glew: 2.2.0 -> 2.3.1
* [`ce8db96a`](https://github.com/NixOS/nixpkgs/commit/ce8db96ab06bfff062587d1171660af37e93e364) python3Packages.pypdf: 6.10.2 -> 6.12.2
* [`ef322bf3`](https://github.com/NixOS/nixpkgs/commit/ef322bf350e637271ed60f863397638d26e43a9f) flap-alerted: init at 4.5.0
* [`316a705c`](https://github.com/NixOS/nixpkgs/commit/316a705cd716606bb812b5e7cb02b890a27ca9ce) nixos/flap-alerted: init module
* [`d08ca95d`](https://github.com/NixOS/nixpkgs/commit/d08ca95d4d96becd77bb6f38f3e20b0ef118a3b8) nixos/tests/flap-alerted: init
* [`ca380878`](https://github.com/NixOS/nixpkgs/commit/ca3808788d497e238c495e81285200eb5d8821a0) python3Packages.llama-stack-client: 0.7.2 -> 0.7.4
* [`72869bb0`](https://github.com/NixOS/nixpkgs/commit/72869bb06d80a567ed4ee9d7a90d7099604b4b89) python3Packages.aiopyarr: migration to pyproject
* [`3d183204`](https://github.com/NixOS/nixpkgs/commit/3d1832043e646376fdd7c163413346c9897375fd) python3Packages.aiopyarr: replace --replace with --replace-fail
* [`46ccf790`](https://github.com/NixOS/nixpkgs/commit/46ccf790cd9044bd277ff9f989a05394eb442499) python3Packages.aiopyarr: use finalAttrs
* [`3cb9a8de`](https://github.com/NixOS/nixpkgs/commit/3cb9a8deaca2e22ddc9fd25d9719b22e3f0d5452) mpvScripts.videoclip: 0.2-unstable-2026-01-22 -> 0.2-unstable-2026-05-31
* [`442c7b8b`](https://github.com/NixOS/nixpkgs/commit/442c7b8bb94570a47b678b004a401fef0197b52d) glslang: add meta.changelog
* [`47ea2e81`](https://github.com/NixOS/nixpkgs/commit/47ea2e81db8afea8884fd19fbaaa2ef05b5c8105) sshified: 1.2.3 -> 1.2.6
* [`418d9575`](https://github.com/NixOS/nixpkgs/commit/418d9575993e97bf56ea13597c9dc443026bf092) asn1ate: update source to resolve redirection
* [`f015bef5`](https://github.com/NixOS/nixpkgs/commit/f015bef5e3576897994d44326e713d917b10e199) ctrtool: update source to resolve redirection
* [`35c045f7`](https://github.com/NixOS/nixpkgs/commit/35c045f7e0fc1d4fb1dae460d9fd7f2ea21a6efc) nbxplorer: update source to resolve redirection
* [`048325cc`](https://github.com/NixOS/nixpkgs/commit/048325cce322d34c22a56165dad2eec40c3e3e0f) physlock: update source to resolve redirection
* [`84914467`](https://github.com/NixOS/nixpkgs/commit/84914467e83a26ac57cc1acc34f546851e7094a1) syntex: update source to resolve redirection
* [`131c13b4`](https://github.com/NixOS/nixpkgs/commit/131c13b48eab8179a756768c66b0c7d48e1deb2b) pi-coding-agent: 0.75.4 -> 0.78.0
* [`767cc29b`](https://github.com/NixOS/nixpkgs/commit/767cc29b719fb397b1aa43ddbf29457849f3e615) rsshub: 0-unstable-2026-05-23 -> 0-unstable-2026-05-31
* [`42b75c87`](https://github.com/NixOS/nixpkgs/commit/42b75c879b895b41210ff517efeb1ef66582e3fa) cimg: 3.6.3 -> 3.7.6
* [`303cc417`](https://github.com/NixOS/nixpkgs/commit/303cc4174c55aa454744cbef482a5a685b082aa4) gmic: 3.6.3 -> 3.7.6
* [`687054bb`](https://github.com/NixOS/nixpkgs/commit/687054bb0280edfc54b2e021f7d0081bb1b773a5) better-commits: 1.23.1 -> 1.24.0
* [`a8058cdc`](https://github.com/NixOS/nixpkgs/commit/a8058cdc4f509b65d7b962c3d2c694f856bdc04a) gnumeric: 1.12.60 -> 1.12.61
* [`ba698bbb`](https://github.com/NixOS/nixpkgs/commit/ba698bbb48719a4b7e286bd6cdb167995f80fa93) python3Packages.libipld: 3.3.2 -> 3.4.1
* [`d8de2d19`](https://github.com/NixOS/nixpkgs/commit/d8de2d196084380b733c61f21729b9247d97d118) shikane: 1.0.1 -> 1.1.0
* [`c682ad3d`](https://github.com/NixOS/nixpkgs/commit/c682ad3da53172d501ea47baebd4671c55063921) libcdada: 0.6.1 -> 0.6.4
* [`56720e3f`](https://github.com/NixOS/nixpkgs/commit/56720e3f3d457c4edf4d4173eff0946787a4e982) emacsPackages.ebuild-mode: 1.82 -> 1.83
* [`53b04da6`](https://github.com/NixOS/nixpkgs/commit/53b04da6da8b725dfba2a59ce8ae8030441dfb53) ladybugdb: 0.15.3 -> 0.17.0
* [`b59952e5`](https://github.com/NixOS/nixpkgs/commit/b59952e5239ca943c2a36cd63f36eaa08f3099eb) lib/systems: don’t specify `multi_v7_defconfig` explicitly
* [`53f91bee`](https://github.com/NixOS/nixpkgs/commit/53f91beef8956255656ed88407afb5a1f61ca5ea) lib/systems: remove unused `linux-kernel.Major` field
* [`c76c290c`](https://github.com/NixOS/nixpkgs/commit/c76c290c147b7b5b4695e18cad4b773e520b8c42) lib/systems: remove redundant kernel configuration
* [`d408bc4f`](https://github.com/NixOS/nixpkgs/commit/d408bc4f02ecb5a9ee338f6b469834000e7dd6b9) lib/systems: remove obsolete `KS8851_MLL` workaround
* [`9c5ca610`](https://github.com/NixOS/nixpkgs/commit/9c5ca61078405508747011d179690de59d587bdf) lib/systems: remove broken kernel configurations
* [`af648556`](https://github.com/NixOS/nixpkgs/commit/af6485561c479599e1091b8aa9a7b6cb23d14aa4) lib/systems: remove unused platforms
* [`0c19eb3e`](https://github.com/NixOS/nixpkgs/commit/0c19eb3e5559a9e27a3402dda4357d0cd2b58dae) lib/systems: unify ARMv5 platforms with stock kernel configuration
* [`38dec9fc`](https://github.com/NixOS/nixpkgs/commit/38dec9fcff007aac9f36e596f0740ae0dcad63b7) makeInitrd{,NG}: drop legacy U‐Boot image support
* [`efbf25d7`](https://github.com/NixOS/nixpkgs/commit/efbf25d7576b1bb049499e0e5fa09ac120b2bae8) linux: drop uImage support
* [`f25ca45f`](https://github.com/NixOS/nixpkgs/commit/f25ca45fd153d75cde78586102ef9751f277045a) highscore-nestopia: 0-unstable-2026-03-03 -> 0-unstable-2026-05-31
* [`b1261005`](https://github.com/NixOS/nixpkgs/commit/b126100591d393d3ec006d2cfff2bbd532d644fd) qoi: 0-unstable-2026-04-21 -> 0-unstable-2026-05-29
* [`2aae144e`](https://github.com/NixOS/nixpkgs/commit/2aae144ec159b43a09282764c1761c0eb660b5dc) highscore-stella: 0-unstable-2026-04-02 -> 0-unstable-2026-06-01
* [`6c12665b`](https://github.com/NixOS/nixpkgs/commit/6c12665bab074d95fab48b524d924ee3aa7c1ce5) tree-sitter-grammars.tree-sitter-swift: 0.7.2 -> 0.7.3
* [`e56d772f`](https://github.com/NixOS/nixpkgs/commit/e56d772fd0a1a7a2807e15fbf4efc67a285b2ea6) xcape: unstable-2018-03-01 -> 1.2
* [`d68b46dc`](https://github.com/NixOS/nixpkgs/commit/d68b46dc66d749ef86ac13e0226ac17ab77c1111) veryl: 0.20.0 -> 0.20.1
* [`3f67623d`](https://github.com/NixOS/nixpkgs/commit/3f67623d252d96e8a5265fafb91f026e5f1da545) zed-editor: 1.3.6 -> 1.4.4
* [`9385c4bc`](https://github.com/NixOS/nixpkgs/commit/9385c4bcf390650ffd96b1b409a3295a883bd735) gtk-sharp-3_0: 2.99.3 -> 3.22.2
* [`e3b7cbda`](https://github.com/NixOS/nixpkgs/commit/e3b7cbda924edceee19fd04b4bbe9ec5991cbf06) python3Packages.stripe: 15.1.0 -> 15.2.0
* [`11ec9ad3`](https://github.com/NixOS/nixpkgs/commit/11ec9ad32a126ae6946c59928887d4c818c3d160) teamspeak6-client: 6.0.0-beta4 -> 6.0.0-beta4.1
* [`1deb4477`](https://github.com/NixOS/nixpkgs/commit/1deb44775cd5d5552765ea3bfe70d710716b4175) libretro.yabause: 0-unstable-2026-04-20 -> 0-unstable-2026-05-30
* [`899d5beb`](https://github.com/NixOS/nixpkgs/commit/899d5beb16442fc4042964d8db02c11d1ca0ee41) unciv: 4.19.15 -> 4.20.10
* [`176b6384`](https://github.com/NixOS/nixpkgs/commit/176b638426326e66a2c75a6296ae76972fa3af0e) ocamlPackages: remove legacy uses of dune_3
* [`44da25b2`](https://github.com/NixOS/nixpkgs/commit/44da25b281d65821477f2afc83b11b2fcf702263) regname: 0.1.0 -> 0.2.0
* [`1c82216b`](https://github.com/NixOS/nixpkgs/commit/1c82216b08615e30a7eb4ef47762361e725f7613) zsh: 5.9 -> 5.9.1
* [`a8b0f5bb`](https://github.com/NixOS/nixpkgs/commit/a8b0f5bbe815e1fc4381df3284530a1f66b4e4b8) kimai: 2.57.0 -> 2.58.0
* [`50f51886`](https://github.com/NixOS/nixpkgs/commit/50f518860cb61c98f99f8c99a221911746d36d57) alpaca-proxy: 2.0.12 -> 2.0.13
* [`65192aee`](https://github.com/NixOS/nixpkgs/commit/65192aee197c0d1742736d13591da0dfe68be3e9) augustus-go: 0.0.8 -> 0.0.10
* [`76be5d03`](https://github.com/NixOS/nixpkgs/commit/76be5d03685a46b1d9c42e1522eeacedd5e79c00) essh: init at 0.2.8
* [`c39b69db`](https://github.com/NixOS/nixpkgs/commit/c39b69db3177e4156c86cfd63edd33517b92d303) gobgp: 4.5.0 -> 4.6.0
* [`46c66ce6`](https://github.com/NixOS/nixpkgs/commit/46c66ce6c32efa3517102f63291546ac37a7264f) gobgpd: 4.5.0 -> 4.6.0
* [`f6797be0`](https://github.com/NixOS/nixpkgs/commit/f6797be0baa975eb837cb7be2fa358431829c90b) zig: add meta.donationPage
* [`19724fe2`](https://github.com/NixOS/nixpkgs/commit/19724fe21fe3bbac4b47fb1fc934998c70af1480) dlpack: init at 1.3
* [`fa1b9981`](https://github.com/NixOS/nixpkgs/commit/fa1b9981ef937e907e4d48af8e4fb0e81105783b) weechat-unwrapped: 4.9.0 -> 4.9.1
* [`fd95c4bd`](https://github.com/NixOS/nixpkgs/commit/fd95c4bdffb76ed4b80747c5ce0864e98d737757) python3Packages.scikit-posthocs: 0.13.0 -> 0.14.0
* [`8350358f`](https://github.com/NixOS/nixpkgs/commit/8350358fec627f8452d555f2c27d42ced848f3c9) openimageio: 3.1.13.1 -> 3.1.14.0
* [`e26bb57b`](https://github.com/NixOS/nixpkgs/commit/e26bb57b735d4ce3e931d5632ea1a3f0c7fbfcf4) nixos/displayManager: replace ad-hoc type // { check } overrides
* [`45bb9ba6`](https://github.com/NixOS/nixpkgs/commit/45bb9ba612bb4736bb1f43fe11db0212735afcd1) moosefs: migrate fuse2 -> fuse3
* [`afa86a82`](https://github.com/NixOS/nixpkgs/commit/afa86a825f3e16880a9c8b6077e2b426a511cd77) rshim-user-space: 2.6.6 -> 2.7.3
* [`f461ed3c`](https://github.com/NixOS/nixpkgs/commit/f461ed3cfd3b914392d9677f1e837b1b29f7d52d) polyml{56,57}: drop old unused version
* [`f418e625`](https://github.com/NixOS/nixpkgs/commit/f418e625da4d5cdda3e1c72eab2964968ff88f54) polyml: migrate to by-name
* [`6e36170c`](https://github.com/NixOS/nixpkgs/commit/6e36170c0f4d6875795bc52d3d5e7e30c9711646) polyml: cleanup and mark cross broken
* [`d9bf2ea7`](https://github.com/NixOS/nixpkgs/commit/d9bf2ea7eaef208ce218755d80d014c5d38a858b) polyml: replace kovirobi with sempiternal-aurora as maintainer
* [`3a717e75`](https://github.com/NixOS/nixpkgs/commit/3a717e7522076b62cc6a9f49551cd82acb79e8bc) polyml: Fix polyc linking script
* [`dfd908e8`](https://github.com/NixOS/nixpkgs/commit/dfd908e83836fbf184e5fce081ff17bbf27f1f22) upterm: 0.20.0 -> 0.24.0
* [`606be034`](https://github.com/NixOS/nixpkgs/commit/606be03450fc8e959444ca29d53f041f95d9eeb1) maintainers: add nyxar77
* [`f996090d`](https://github.com/NixOS/nixpkgs/commit/f996090d1c65b2b5d177abbf6805c230685fbbd5) base24-schemes: init at 0-unstable-2025-11-08
* [`8598c9d0`](https://github.com/NixOS/nixpkgs/commit/8598c9d048c39be004c1d226b84e8343f718c1b0) ytt: 0.55.0 -> 0.55.1
* [`df057395`](https://github.com/NixOS/nixpkgs/commit/df05739595c0022dc2008137c9959da5ffd7cb69) python3Packages.iamdata: 0.1.202605311 -> 0.1.202606011
* [`097c72d7`](https://github.com/NixOS/nixpkgs/commit/097c72d7032bbd0bef85cbdef410098dee10b7ce) python3Packages.mypy-boto3-groundstation: 1.43.0 -> 1.43.18
* [`ac5443d6`](https://github.com/NixOS/nixpkgs/commit/ac5443d62bc51bbd125fe48f48a6a5ec845790da) python3Packages.mypy-boto3-omics: 1.43.0 -> 1.43.18
* [`cba49da7`](https://github.com/NixOS/nixpkgs/commit/cba49da7412323a51118e1e19a3baca462b4e09d) python3Packages.mypy-boto3-quicksight: 1.43.10 -> 1.43.18
* [`49cb0739`](https://github.com/NixOS/nixpkgs/commit/49cb07398fc468701656e6c0135b3c1d3d53e7ab) python3Packages.mypy-boto3-rds-data: 1.43.0 -> 1.43.18
* [`ded0a107`](https://github.com/NixOS/nixpkgs/commit/ded0a10728abba5f639ee25035d504f8421ec152) leet-helix: 0.2.3-unstable-2026-02-24 -> 0-unstable-2026-03-01
* [`1291208e`](https://github.com/NixOS/nixpkgs/commit/1291208e19a597ac1a90f6e18d7850f4699ba982) python3Packages.mypy-boto3-route53resolver: 1.43.6 -> 1.43.18
* [`763e13a0`](https://github.com/NixOS/nixpkgs/commit/763e13a035d7333c87b0e99ead48c2045da330ac) python3Packages.mypy-boto3-sesv2: 1.43.0 -> 1.43.18
* [`4f5f98fb`](https://github.com/NixOS/nixpkgs/commit/4f5f98fb90ccce4be45fdf5e02cd2f3bcbac92ac) python3Packages.boto3-stubs: 1.43.17 -> 1.43.18
* [`9a87ac89`](https://github.com/NixOS/nixpkgs/commit/9a87ac8952792d0f75591eea1137060195b3609a) gosec: 2.26.1 -> 2.27.0
* [`fadf6f95`](https://github.com/NixOS/nixpkgs/commit/fadf6f958c8783b9fb74fbaae647932b5eb39305) kstars: 3.8.2 -> 3.8.3
* [`3dac7491`](https://github.com/NixOS/nixpkgs/commit/3dac74910b759d0479e9cfeb29d718193b9302a1) vendir: 0.45.3 -> 0.45.4
* [`a498c40a`](https://github.com/NixOS/nixpkgs/commit/a498c40a25b70aabaaf3473d30ad1099f14a0281) bleachbit: 5.0.2 -> 6.0.0
* [`8f52d1e0`](https://github.com/NixOS/nixpkgs/commit/8f52d1e0c2a2b1bb72bfd5192d061be16e1e2918) namespace-cli: 0.0.516 -> 0.0.517
* [`7f7d2e64`](https://github.com/NixOS/nixpkgs/commit/7f7d2e649a7147b6ae275e010d44c156addd96d5) nixos/lxcfs: fuse -> fuse3
* [`f5df5507`](https://github.com/NixOS/nixpkgs/commit/f5df55072b44137887425fdf9b0b157eeba08fef) nixos/pam_mount: migrate to fuse3
* [`054decb0`](https://github.com/NixOS/nixpkgs/commit/054decb03003c225d12ccc78a7fae1ff91223da2) lima-full: 2.1.1 -> 2.1.2
* [`916a7430`](https://github.com/NixOS/nixpkgs/commit/916a74306701f306e0f57464ea99293881e94d98) cudaPackages.cudnn-frontend: 1.16.0 -> 1.24.0
* [`0deabaeb`](https://github.com/NixOS/nixpkgs/commit/0deabaeb431e4e80ca08359d8188463bb5d9a14d) python3Packages.nvidia-cudnn-frontend: init
* [`e5049aed`](https://github.com/NixOS/nixpkgs/commit/e5049aed76965a7075526f6e2a6dd94f5e59daa0) mautrix-meta: 26.05 -> 26.05.1
* [`3c0fa261`](https://github.com/NixOS/nixpkgs/commit/3c0fa2610684b8833b03c3a9c62270fa18768669) imgpkg: 0.48.0 -> 0.48.1
* [`09032360`](https://github.com/NixOS/nixpkgs/commit/09032360da78f3815d228fbe8b0913ab07e7390d) go-car: 2.16.0 -> 2.17.0
* [`9e3d6488`](https://github.com/NixOS/nixpkgs/commit/9e3d6488f359a0446dd623142eb2085158f4b47d) vulkan-cts: 1.4.5.3 -> 1.4.6.0
* [`39387587`](https://github.com/NixOS/nixpkgs/commit/393875874ee8c5aec628abf94e07fb0702351b84) leangz: init at 0.1.19
* [`a5abba83`](https://github.com/NixOS/nixpkgs/commit/a5abba83e98d632cbe50259c95d8704cf2f4ca9d) python3Packages.txtorcon: 24.8.0 -> 26.6.0
* [`be80e7e1`](https://github.com/NixOS/nixpkgs/commit/be80e7e1ee39f85b9ffe2818f015009314e43a74) python3Packages.langgraph-runtime-inmem: 0.28.1 -> 0.29.0
* [`c94da05f`](https://github.com/NixOS/nixpkgs/commit/c94da05fe469a845461ae503894fad568abeb2a6) fence: update upstream repo url
* [`bda3d9ef`](https://github.com/NixOS/nixpkgs/commit/bda3d9ef3698485db769cba08eb6af1341cf6ab0) linux_testing: 7.1-rc4 -> 7.1-rc6
* [`3e9caa18`](https://github.com/NixOS/nixpkgs/commit/3e9caa186f62c8e1dc03b403004f888fc71d6b3c) linux_7_0: 7.0.10 -> 7.0.11
* [`28254d87`](https://github.com/NixOS/nixpkgs/commit/28254d87ca1a4f205a74ca48690daf940d723185) linux_6_18: 6.18.33 -> 6.18.34
* [`221fae9c`](https://github.com/NixOS/nixpkgs/commit/221fae9c48d2b98fc0cb02ef21cfe48a4238d68a) linux_6_12: 6.12.91 -> 6.12.92
* [`10035889`](https://github.com/NixOS/nixpkgs/commit/10035889cf19e0264b390247844d497d716b5c56) linux_6_6: 6.6.141 -> 6.6.142
* [`2a612a8c`](https://github.com/NixOS/nixpkgs/commit/2a612a8cbf3bd600afea16628592ba3d52568d75) linux_6_1: 6.1.174 -> 6.1.175
* [`661833f6`](https://github.com/NixOS/nixpkgs/commit/661833f61e0b987bb8900086a71b8411468de5a4) linux_5_15: 5.15.208 -> 5.15.209
* [`d07b0d9d`](https://github.com/NixOS/nixpkgs/commit/d07b0d9dacbe69dd061c3d738b60c58e9a9db9f4) linux_5_10: 5.10.257 -> 5.10.258
* [`0f1a265d`](https://github.com/NixOS/nixpkgs/commit/0f1a265decf3caa2d6399fede7432d2a6d286f19) vintagestory: 1.22.2 → 1.22.3
* [`67cb8dee`](https://github.com/NixOS/nixpkgs/commit/67cb8deea1a62d5b13da4b5a90c9ea3091c5d3e3) maintainers: add bubylou
* [`f3d66957`](https://github.com/NixOS/nixpkgs/commit/f3d669578491334ab19b550f51d8818a6104bd3c) zuban: 0.7.2 -> 0.8.0
* [`e690d41e`](https://github.com/NixOS/nixpkgs/commit/e690d41e924b1480054e206ba6aed84b4802e4da) vscode-extensions.visualjj.visualjj: add maintainer (me)
* [`9faa86a1`](https://github.com/NixOS/nixpkgs/commit/9faa86a1c939a8cb19da800a679713c7b7969b58) scip-go: 0.2.6 -> 0.2.7
* [`913e3a10`](https://github.com/NixOS/nixpkgs/commit/913e3a1040853a1f90022086cb36e39ca2b5e224) vscode-extensions.visualjj.visualjj: add `autoPatchelfHook`
* [`12f6fb8a`](https://github.com/NixOS/nixpkgs/commit/12f6fb8aec27844695d58f4ef1b74890ce9480a9) updatecli: 0.117.0 -> 0.117.1
* [`85af3751`](https://github.com/NixOS/nixpkgs/commit/85af375155d52d22745ac550776bcf2ec56c6a1f) apidog: 2.8.30 -> 2.8.32
* [`ce2e4f3b`](https://github.com/NixOS/nixpkgs/commit/ce2e4f3b10eb5204d826f512821cbbac3adaebe1) mistral-vibe: 2.12.1 -> 2.13.0
* [`d613d39b`](https://github.com/NixOS/nixpkgs/commit/d613d39bd99b750ea59b4a17448213695939dd5f) eigen_5: add withDoc option, fix [nixos/nixpkgs⁠#526648](https://togithub.com/nixos/nixpkgs/issues/526648)
* [`6ebea2cd`](https://github.com/NixOS/nixpkgs/commit/6ebea2cd59a2f1bf43e8322a2d5ba190f94ffd11) eigen_5: fix Fontconfig error
* [`229c8cdc`](https://github.com/NixOS/nixpkgs/commit/229c8cdc50bf141560922c98ad1800a94b6fda5d) dart-bin: 3.11.6 -> 3.12.1
* [`c0cb6df1`](https://github.com/NixOS/nixpkgs/commit/c0cb6df1b6c980ee59acc97eeaace44a9ab04f6d) warmup-s3-archives: 1.2.0 -> 1.2.1
* [`8659a3da`](https://github.com/NixOS/nixpkgs/commit/8659a3da2343b87ba1197814ff9be9eb5e9bd45a) xremap: 0.15.7 -> 0.15.8
* [`abf5c51c`](https://github.com/NixOS/nixpkgs/commit/abf5c51c47919b6240e8fd66930a12328d19c271) tor: 0.4.9.8 -> 0.4.9.9
* [`d77c57cf`](https://github.com/NixOS/nixpkgs/commit/d77c57cfe0cfec8d29b8b308e2eec2852205491e) ubridge: 0.9.19 -> 1.0.1
* [`4e794c66`](https://github.com/NixOS/nixpkgs/commit/4e794c6622e87a1b13e45ab4111bc5ceb65a719d) vscode-extensions.foam.foam-vscode: 0.40.4 -> 0.42.0
* [`6b9bf624`](https://github.com/NixOS/nixpkgs/commit/6b9bf6240fde3f62a492f0c444e81bb557e3b685) heroic: add `extraEnv` input
* [`27c905ab`](https://github.com/NixOS/nixpkgs/commit/27c905ab1a41116277b1ddf3e75d6642b97b36c8) nixosTests.gocryptfs: init
* [`f63ca3ef`](https://github.com/NixOS/nixpkgs/commit/f63ca3efd9fa770acf6f2df6f59a44547f40b493) kdePackages.kdenlive: add missing qtimageformats dependency
* [`f17acca9`](https://github.com/NixOS/nixpkgs/commit/f17acca9ebdba957e0737d6b8a7d06b068585111) irrlicht: 1.8.4 -> 1.8.5
* [`a56e6d45`](https://github.com/NixOS/nixpkgs/commit/a56e6d45cc435ab3b5564635633ea1e507d3c470) vespa-cli: 8.692.16 -> 8.697.20
* [`0869eb69`](https://github.com/NixOS/nixpkgs/commit/0869eb69cf66b67ae6c5e5169bb557905c4cc241) starlark-rust: 0.13.0 -> 0.14.0
* [`593164e8`](https://github.com/NixOS/nixpkgs/commit/593164e8f8d8e137bb603a2fb00bb9245302003c) slothy: 0.2.0 -> 0.2.1
* [`97de3412`](https://github.com/NixOS/nixpkgs/commit/97de3412493de3134efb14c49cc61ad0b18e4c00) sbom-utility: 0.19.0 -> 0.19.1
* [`09bd6f99`](https://github.com/NixOS/nixpkgs/commit/09bd6f9982506581bdf0eed0f502e6c411c3b22a) virglrenderer: set vulkan-dload to false; fixes venus
* [`705f225e`](https://github.com/NixOS/nixpkgs/commit/705f225eea34b38b72ca52fc82ee432e7ad7b49c) antigravity-cli: 1.0.3 -> 1.0.4
* [`a4be3a1d`](https://github.com/NixOS/nixpkgs/commit/a4be3a1d530cf66757ba38a00ab41e21004975d3) pulumi-esc: 0.24.0 -> 0.25.0
* [`c082c9e1`](https://github.com/NixOS/nixpkgs/commit/c082c9e1504fd80c603cb2cec000c473d5fd6f4e) efficient-compression-tool: fix segfault with gcc15
* [`c270fe24`](https://github.com/NixOS/nixpkgs/commit/c270fe249df5258b2d40771465a67e1794f808fb) labwc: 0.9.7 -> 0.20.0
* [`f3f5047f`](https://github.com/NixOS/nixpkgs/commit/f3f5047f5ae93ff05d2fd0f7b8324ddfc8807810) bats.tests: fix the eval
* [`da4a23fc`](https://github.com/NixOS/nixpkgs/commit/da4a23fcd0cde2e092b94fb5d85577a93cbeea6a) joplin-desktop: fix WMClass to match icon with open window
* [`b599661f`](https://github.com/NixOS/nixpkgs/commit/b599661fe41fd97c39be158636209b5b6910fc8c) nushellPlugins.desktop_notifications: 0.112.2 -> 0.113.1
* [`a26b6633`](https://github.com/NixOS/nixpkgs/commit/a26b66330f6fa572e7005ee2a1eb031093456e6e) lean4: update leanPackages and lean4 4.29.0/1 -> 4.30.0
* [`ca58c884`](https://github.com/NixOS/nixpkgs/commit/ca58c8845af065abeb05f8cbdc05ade7461fe8d2) github-desktop: 3.5.11 -> 3.5.12
* [`3f112c66`](https://github.com/NixOS/nixpkgs/commit/3f112c662ba9ac4105b46416e9cb80a5d962e936) python3Packages.xclim: 0.61.0 -> 0.61.1
* [`801d8901`](https://github.com/NixOS/nixpkgs/commit/801d8901cdeacec4e051fb256bdd350c96debf74) python3Packages.modelscope: 1.37.0 -> 1.37.1
* [`0ead2752`](https://github.com/NixOS/nixpkgs/commit/0ead2752964a6ab63ba02bf3314b2dde96ab0f84) libburn: 1.5.6 -> 1.5.8
* [`4dfe429d`](https://github.com/NixOS/nixpkgs/commit/4dfe429dfd76bedb832a081b665fcb914d81a6a1) zigbee2mqtt: 2.10.1 -> 2.11.0
* [`5cab5486`](https://github.com/NixOS/nixpkgs/commit/5cab54866f34f14d746cc8f7e4800c2d706a41bf) libisoburn: 1.5.6 -> 1.5.8.pl02
* [`7cde996f`](https://github.com/NixOS/nixpkgs/commit/7cde996fab6c147b0e4f97eb4f7427986b71c449) libisofs: 1.5.8 -> 1.5.8.pl02
* [`550360d9`](https://github.com/NixOS/nixpkgs/commit/550360d98e59300a23d52c182c5369fc12e491e9) python3Packages.ale-py: fix darwin build
* [`e4de2834`](https://github.com/NixOS/nixpkgs/commit/e4de28348e786c4d7e95bfdfff6fbbc9c349c9e8) dbip-country-lite: 2026-05 -> 2026-06
* [`4fdaee1d`](https://github.com/NixOS/nixpkgs/commit/4fdaee1d4cf254acd9b5bb8145cf73e205630ac0) dbip-city-lite: 2026-05 -> 2026-06
* [`4e07c61e`](https://github.com/NixOS/nixpkgs/commit/4e07c61e1c7f49dd8a20eab6d94735d78ff07bf1) dbip-asn-lite: 2026-05 -> 2026-06
* [`29640705`](https://github.com/NixOS/nixpkgs/commit/296407053cc40cb777776a1fd209f12ea974372b) lstk: 0.9.0 -> 0.10.0
* [`c96b3b14`](https://github.com/NixOS/nixpkgs/commit/c96b3b146f8c809df329894a698f36ab2cfe79c3) gearboy: 3.8.4 -> 3.8.6
* [`cfb7a7db`](https://github.com/NixOS/nixpkgs/commit/cfb7a7db1e7935d86cdff70d7e1f292b8e4f01ff) python3Packages.iocx: 0.7.4 -> 0.7.4.1
* [`88b021ed`](https://github.com/NixOS/nixpkgs/commit/88b021ed8f33fc754a8c7b28a0a9bc463d4123fe) python3Packages.tencentcloud-sdk-python: 3.1.105 -> 3.1.107
* [`ad64815f`](https://github.com/NixOS/nixpkgs/commit/ad64815fc28223e74e5fa709e8774d63c4c688a7) bmm: 0.3.0 -> 0.3.1
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
