### PR TITLE
npins home-manager: update a7a41588 -> df391424

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -61,9 +61,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "a7a415883195ffbd4dabec8f098f201e6eaaadf8",
-      "url": "https://github.com/nix-community/home-manager/archive/a7a415883195ffbd4dabec8f098f201e6eaaadf8.tar.gz",
-      "hash": "sha256-PRJj9RKTEf/sITycujP1c/BrvLJKMYXzcpwTsXNulXQ="
+      "revision": "df39142474950e42d5fc3bf2fef9d6c62abbe8d7",
+      "url": "https://github.com/nix-community/home-manager/archive/df39142474950e42d5fc3bf2fef9d6c62abbe8d7.tar.gz",
+      "hash": "sha256-01bTMR9ZPG+uxPaZBeOwagg5uxIaFYs2/3YIrOX+bCA="
     },
     "hs-grille": {
       "type": "Git",


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@a7a41588...df391424](https://github.com/nix-community/home-manager/compare/a7a415883195ffbd4dabec8f098f201e6eaaadf8...df39142474950e42d5fc3bf2fef9d6c62abbe8d7)

* [`07c723c3`](https://github.com/nix-community/home-manager/commit/07c723c3fe06c8e24d76882184e8bdee0073ba34) zsh: fix oh-my-zsh custom path expansion
* [`c0436bc0`](https://github.com/nix-community/home-manager/commit/c0436bc028b1f4a8e346f32ae76a91b53a9eecc5) fontconfig: enable config files by default
* [`af1588ad`](https://github.com/nix-community/home-manager/commit/af1588ad6fb3fc41fcaf9e2e41f1a389a483a41c) fontconfig: add test for default fonts
* [`68227a93`](https://github.com/nix-community/home-manager/commit/68227a9363266a1d1b51469bfcd31679855d2e62) fontconfig: add test for font discovery
* [`f15c764b`](https://github.com/nix-community/home-manager/commit/f15c764b1449f45c9034b2f67873f8c4164ea21c) password-store: improve warning message
* [`58e05d16`](https://github.com/nix-community/home-manager/commit/58e05d16d771614f061e46a7afb77e98fcdc4c75) aerospace: skip config reload when AeroSpace is not running
* [`70fc4b4b`](https://github.com/nix-community/home-manager/commit/70fc4b4b5efce98ac2329bd6ebf9e6c2f656a19b) aerospace: add regression test for reload guard
* [`a7c15f4f`](https://github.com/nix-community/home-manager/commit/a7c15f4f6508eb15d7f10364d2f732429a6fdd4f) maintainers: add kayskayskays
* [`f384af1b`](https://github.com/nix-community/home-manager/commit/f384af1bec6423a0d4ba1855917ab948f64e5808) macos-terminal: add module
* [`4c5c1e8b`](https://github.com/nix-community/home-manager/commit/4c5c1e8ba14f1c7475fa31ff11bc1c19cd220974) alacritty: fix toml escape generation
* [`5ded124f`](https://github.com/nix-community/home-manager/commit/5ded124f913d27a605fc873551ab492c98e623d5) lib: add deprecated option warning helpers
* [`ff53fe10`](https://github.com/nix-community/home-manager/commit/ff53fe10e02b2d48304a7cf42ae1b8fb6be67c71) qt: assert kde6 migration warning
* [`9a638c14`](https://github.com/nix-community/home-manager/commit/9a638c1442a2e547887eba55522f24aa252942c2) swayidle: assert events migration warning
* [`c81a3d23`](https://github.com/nix-community/home-manager/commit/c81a3d2383a9bfdc0cd07f3d973100012ebefad3) helix: assert languages migration warning
* [`6a6941ad`](https://github.com/nix-community/home-manager/commit/6a6941ad20b7d5836a7dc9418dd62b907f02a2ea) hyprpanel: assert theme name warning
* [`6459fc4a`](https://github.com/nix-community/home-manager/commit/6459fc4aeec03f4cd1d89288dc4e14221a3674c6) firefox: assert bookmarks migration warning
* [`18b4e1ea`](https://github.com/nix-community/home-manager/commit/18b4e1ea6f1655b3b3fb7625893fa500b51e1d33) xdg-user-dirs: assert extraConfig key warning
* [`dc641330`](https://github.com/nix-community/home-manager/commit/dc641330e236cd2f6f4a8b7634468045d35898c2) infat: use deprecation warning helper
* [`efe95f11`](https://github.com/nix-community/home-manager/commit/efe95f113aac9923bbc9f0f9cf1174399c17ab8b) sshAuthSock: use enable flag instead of nullable submodule
* [`f4534a4f`](https://github.com/nix-community/home-manager/commit/f4534a4f3cc20e663b2a8c5814044f12013f7c19) sshAuthSock: add option for initialization in Zsh
* [`f1d5aa6f`](https://github.com/nix-community/home-manager/commit/f1d5aa6f690b46440ce3b36b0d50ae984e82c82e) sshAuthSock: set in systemd
* [`447fd9ff`](https://github.com/nix-community/home-manager/commit/447fd9ff62501dae7206dfe180ee89f8de27b7d5) sshAuthSock: add news entry
* [`5fadbec0`](https://github.com/nix-community/home-manager/commit/5fadbec07a5cb4c4d58fa2ff0263f620151e8b84) maintainers: add semi710
* [`37e8eef9`](https://github.com/nix-community/home-manager/commit/37e8eef933c68a4ca58e351b2ae31fb9f6631535) pi-coding-agent: add module
* [`04505748`](https://github.com/nix-community/home-manager/commit/0450574818af22e3090f52d10e9bd76440ac428f) flake: gate development outputs to supported systems
* [`ff77a72f`](https://github.com/nix-community/home-manager/commit/ff77a72fe5fbfd5767bef332b996aba8965db824) antigravity-cli: rename gemini-cli module
* [`eaca478c`](https://github.com/nix-community/home-manager/commit/eaca478c9505aeafadccf5f4621f56f3a9dd7e56) antigravity-cli: add migration news
* [`d33c97ec`](https://github.com/nix-community/home-manager/commit/d33c97ec1b3f26d6a2d4d6ec0246af48a1a2259d) lib/strings: add isPathLike helper
* [`3a647b15`](https://github.com/nix-community/home-manager/commit/3a647b158e69895f4f7f1194175db07bc2798bdf) antigravity-cli: use lib.hm.strings.isPathLike
* [`09ff165b`](https://github.com/nix-community/home-manager/commit/09ff165ba6ed95c85be9dba95c8d638289686fa2) claude-code: use lib.hm.strings.isPathLike
* [`4b9a9955`](https://github.com/nix-community/home-manager/commit/4b9a9955195db1f7e0069e2f3baf359e35910d03) codex: use lib.hm.strings.isPathLike
* [`6d4fb02e`](https://github.com/nix-community/home-manager/commit/6d4fb02e3406c4076444586cb79159d10fc72e4a) github-copilot-cli: use lib.hm.strings.isPathLike
* [`c321a1c8`](https://github.com/nix-community/home-manager/commit/c321a1c8a7ef15fce4314c247ba8ff9c5408d85d) opencode: use lib.hm.strings.isPathLike
* [`e621f12c`](https://github.com/nix-community/home-manager/commit/e621f12c02b7193240540c9f760c75f4ac2dc199) pi-coding-agent: use lib.hm.strings.isPathLike
* [`b2b7db48`](https://github.com/nix-community/home-manager/commit/b2b7db486e06e098711dc291bb25db82850e1d16) antigravity-cli: robust rename support
* [`ddb70826`](https://github.com/nix-community/home-manager/commit/ddb7082625bd0c0c568e6ffaff00e72b7a724b27) lib: separate eval config file
* [`d4d5d9bb`](https://github.com/nix-community/home-manager/commit/d4d5d9bb4ae5d97b2af13ad26b0c5704cd485714) nushell: add abbreviations option
* [`e4b8f8c8`](https://github.com/nix-community/home-manager/commit/e4b8f8c8bfd44024ec407a43269c8989100f5aef) flake: bump nixpkgs from `4100e83` to `ffa10e2`
* [`aa14fc7b`](https://github.com/nix-community/home-manager/commit/aa14fc7b467fffc4dae4bcabbb1c04facdcb83b8) tests: update generated TOML expectations
* [`0c42c7a6`](https://github.com/nix-community/home-manager/commit/0c42c7a66f0af09b0dfc3bce4846c784de96a2da) darkman: replace removed python2 in test
* [`4fe95527`](https://github.com/nix-community/home-manager/commit/4fe95527cbe952713318ada8a4d122e1a6ab120f) pi-coding-agent: scrub package in Darwin tests
* [`5c34a3c7`](https://github.com/nix-community/home-manager/commit/5c34a3c7590cfadd0784ee879998509daf3e665b) maintainers: update all-maintainers.nix
* [`78da10c4`](https://github.com/nix-community/home-manager/commit/78da10c4af3c897cce979efb8f0d3da014c4e4e9) zed-editor: wrap meta.mainProgram
* [`ec56189b`](https://github.com/nix-community/home-manager/commit/ec56189b4f94a81e1aef3b1b42ee5d880fd7261b) zellij: add myself to maintainers
* [`301871cd`](https://github.com/nix-community/home-manager/commit/301871cd96c005a410e8317e90b80d59ac312c4a) zellij: add support for plugins
* [`e9cbe698`](https://github.com/nix-community/home-manager/commit/e9cbe69850d67c2b472db8416faca7292960f99f) sshAuthSock: avoid cycles for socket providers
* [`df391424`](https://github.com/nix-community/home-manager/commit/df39142474950e42d5fc3bf2fef9d6c62abbe8d7) nushell: remove redundant abbreviations option
