### PR TITLE
npins powerlevel10k: update 604f19a9 -> a0c9dbe8

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -145,9 +145,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "604f19a9eaa18e76db2e60b8d446d5f879065f90",
-      "url": "https://github.com/romkatv/powerlevel10k/archive/604f19a9eaa18e76db2e60b8d446d5f879065f90.tar.gz",
-      "hash": "sha256-J8qKLkKYd62LuUY2y6Hy+AaokKVDSTucCNQwVQeAaxo="
+      "revision": "a0c9dbe80be404ff58e3ce5d7cf312582e370635",
+      "url": "https://github.com/romkatv/powerlevel10k/archive/a0c9dbe80be404ff58e3ce5d7cf312582e370635.tar.gz",
+      "hash": "sha256-5yASWIMiuEghMU1zEtjT8ztIdWrflWDbaqAt3Yh6o7w="
     },
     "rh": {
       "type": "Git",


### PR DESCRIPTION
## Changelog for powerlevel10k:
Branch: master
Commits: [romkatv/powerlevel10k@604f19a9...a0c9dbe8](https://github.com/romkatv/powerlevel10k/compare/604f19a9eaa18e76db2e60b8d446d5f879065f90...a0c9dbe80be404ff58e3ce5d7cf312582e370635)

* [`31982e20`](https://github.com/romkatv/powerlevel10k/commit/31982e202d2e939e5c35d6a99f97345b43b8d503) emit OSC 133 k=r and k=s for iTerm2 >= 3.7.0 ([romkatv/powerlevel10k⁠#2954](https://togithub.com/romkatv/powerlevel10k/issues/2954))
* [`a0c9dbe8`](https://github.com/romkatv/powerlevel10k/commit/a0c9dbe80be404ff58e3ce5d7cf312582e370635) bump version
