### PR TITLE
npins nixpkgs: update cbb5cf35 -> 8c3cede7

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -133,8 +133,8 @@
       "type": "Channel",
       "name": "nixpkgs-unstable",
       "artifact": "nixexprs.tar.xz",
-      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-26.11pre1011620.cbb5cf358f50/nixexprs.tar.xz",
-      "hash": "sha256-d86UGSjwACWRttincQzeiAEZYVPtP3kODhr9hYZD4e8="
+      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-26.11pre1012902.8c3cede7ddc2/nixexprs.tar.xz",
+      "hash": "sha256-omq0piVC7vKHVxfJi9uIW1EHQLsFSnDhbkLeO2rkSyw="
     },
     "powerlevel10k": {
       "type": "Git",


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: release-26.11
Commits: [nixos/nixpkgs@cbb5cf35...8c3cede7](https://github.com/nixos/nixpkgs/compare/cbb5cf358f50...8c3cede7ddc2)

* [`0a4142ba`](https://github.com/NixOS/nixpkgs/commit/0a4142ba91af42e72dc00ada7d7a9f8c516d24fc) python3Packages.pydub: ffmpeg-full -> ffmpeg
* [`3afae404`](https://github.com/NixOS/nixpkgs/commit/3afae4043a8f2f069263a6fd3711525f253c0e94) usbmuxd: switch to finalAttrs
* [`aaf2bd4a`](https://github.com/NixOS/nixpkgs/commit/aaf2bd4a4d8b0eee6c2be0a486c0d6699f3881df) usbmuxd: add ProxyVT as maintainer
* [`6c49efdb`](https://github.com/NixOS/nixpkgs/commit/6c49efdbdc39e9c5cd5fbc7f43df184660e91ed6) usbmuxd: 1.1.1+date=2023-05-05 -> 1.1.1+date=2025-12-06
* [`0cec514b`](https://github.com/NixOS/nixpkgs/commit/0cec514b9a214638a02775cb5fde2c3aa4d7d488) orbstack: Adds shell completions to orbstack package
* [`55d00aa8`](https://github.com/NixOS/nixpkgs/commit/55d00aa8e050c4d26b2d9e98b6811ded88366a47) fatrop: 0.0.4 -> 1.0.0
* [`311f4fd0`](https://github.com/NixOS/nixpkgs/commit/311f4fd078957b1d0ab66de9a37f1df8838f42f8) obs-studio-plugins.obs-source-clone: 0.2.1 -> 0.2.3
* [`138757ac`](https://github.com/NixOS/nixpkgs/commit/138757acab4243cd6c5a76d3c5e1789dbf0e89eb) unityhub: add p7zip as dependency to allow Unity Hub to extract Windows Build Support
* [`dec9f2e9`](https://github.com/NixOS/nixpkgs/commit/dec9f2e927be57c6b9468795731de07e50ee282f) antidote: 1.10.3 -> 2.1.0
* [`0c3dde83`](https://github.com/NixOS/nixpkgs/commit/0c3dde83e2b26dcf1fde36befbb24e4f5e74876b) libreoffice-bin: 25.2.1 -> 25.8.6
* [`30bf82ff`](https://github.com/NixOS/nixpkgs/commit/30bf82ff5abf0563e48b27431cc9a1eab49eedba) surf: fix build and force use of X11
* [`e7d8ed1a`](https://github.com/NixOS/nixpkgs/commit/e7d8ed1a7851591e48566c63c3b6d6b1dc60df81) python3Packages.rigour: 1.7.5 -> 1.8.2
* [`deeef424`](https://github.com/NixOS/nixpkgs/commit/deeef424cfe9e966b3b046b8f0204d2bb34ea48d) rutorrent: 5.2.10 -> 5.3.1
* [`d1b42099`](https://github.com/NixOS/nixpkgs/commit/d1b42099abfe45b694226883fc75c10dd3f7dc5d) kavita: fix update-script for by-name
* [`b439fd07`](https://github.com/NixOS/nixpkgs/commit/b439fd07ab02afedc52f2c68e3bae99ec0c9f966) symphony: fix changelog url
* [`5f1357f5`](https://github.com/NixOS/nixpkgs/commit/5f1357f5a93b92aa7c0bbbcf1daf23e0b94a29a7) busybox: add tests
* [`5bfa313f`](https://github.com/NixOS/nixpkgs/commit/5bfa313fb72d132501807b1330bbd035fc63a8ff) tableplus: 538 -> 662
* [`ccc29ad8`](https://github.com/NixOS/nixpkgs/commit/ccc29ad84ef8f3d3c0ef4a551ef63b526a282a8e) dar: 2.8.2 -> 2.8.5
* [`8275ce3c`](https://github.com/NixOS/nixpkgs/commit/8275ce3cd0166ed3c4d9cb7cd501d74a368b37ec) aptly: stop shipping `files` binary
* [`d0d9909d`](https://github.com/NixOS/nixpkgs/commit/d0d9909d8b691bec16f3e38b1bc03872109e1902) konbucase: 4.4.0 -> 4.5.1
* [`12c9198f`](https://github.com/NixOS/nixpkgs/commit/12c9198f83452ac3073e200fbd048c13a4d051dc) amiberry: 8.1.5 -> 8.1.6
* [`d8ce3968`](https://github.com/NixOS/nixpkgs/commit/d8ce396858320ad3241638a15c826126639f5dc6) libminc: 2.4.07 -> 2.5.0
* [`c0c84227`](https://github.com/NixOS/nixpkgs/commit/c0c842272d99eb11b614f444cd5bbdeb83dbf46e) commitlint: 20.5.3 -> 21.0.0
* [`6572ed6b`](https://github.com/NixOS/nixpkgs/commit/6572ed6bd64b9305c9a00ed9eea9aa7d52dbad37) proxsuite: 0.7.2 -> 0.7.3
* [`6e8f9504`](https://github.com/NixOS/nixpkgs/commit/6e8f9504c9e21cd5e236a26d309c719b44ee445a) python3Packages.daqp: 0.7.2 -> 0.8.4
* [`fe364b0e`](https://github.com/NixOS/nixpkgs/commit/fe364b0e512f9b9bdd1ca768a42e9a0f23856a77) python3Packages.qpsolvers: 4.11.0 -> 4.12.0
* [`5aa29153`](https://github.com/NixOS/nixpkgs/commit/5aa291539ccd670aca2ef2cebe0c868d5d6ef556) python3Packages.aerosandbox: add missing pythonRemoveDeps
* [`35b99305`](https://github.com/NixOS/nixpkgs/commit/35b99305ad7e61f9f0cd9c94020008eb5df97e5c) rubyfmt: 0.11.0 -> 0.13.0
* [`9101b36c`](https://github.com/NixOS/nixpkgs/commit/9101b36c67fd4c1e223de0ec9af775e2ad7b5786) simple-dftd3: 1.3.2 -> 1.4.0
* [`3e4c3fde`](https://github.com/NixOS/nixpkgs/commit/3e4c3fdebd480cbc20da9d1d7cc1c9b1e0ccaa85) python3Packages.torchio: 1.0.1 -> 1.2.0
* [`9d9388f9`](https://github.com/NixOS/nixpkgs/commit/9d9388f94b5741b8cdb6756213014b565701ae37) mksh: fix changelog link
* [`50275084`](https://github.com/NixOS/nixpkgs/commit/502750842ee558aef61207bba285035cc8b1e496) vscode-extensions.amazonwebservices.amazon-q-vscode: fix changelog
* [`53e2ab43`](https://github.com/NixOS/nixpkgs/commit/53e2ab43132b2ff51e671d66e2b7ac972d4b3e5e) bcg729: fix changelog filename
* [`16fb0a5a`](https://github.com/NixOS/nixpkgs/commit/16fb0a5a2a2c6876a78559c47834d068bf87162b) cherrytree: fix changelog version
* [`cdb091f3`](https://github.com/NixOS/nixpkgs/commit/cdb091f343b3a5d6e5e2cfc2764f29fd955b3f7e) cq: fix changelog url
* [`d7f88a87`](https://github.com/NixOS/nixpkgs/commit/d7f88a87bf166e11688180c993d1aeb17d47f98b) discordchatexporter-cli: fix changelog
* [`0fa82727`](https://github.com/NixOS/nixpkgs/commit/0fa827275867a97e3535f7869ffd16657cd3c84f) discordchatexporter-desktop: fix changelog
* [`536606e2`](https://github.com/NixOS/nixpkgs/commit/536606e220f72157fa18c49e49e0c49a6884ac5a) dyndnsc: use changelog file instead of release notes
* [`29899cf6`](https://github.com/NixOS/nixpkgs/commit/29899cf64ab828abb9f09a7be2722b96805e4d46) frawk: remove changelog
* [`a8559b4e`](https://github.com/NixOS/nixpkgs/commit/a8559b4e5742c3d70ee42e540db8a92a41f8852d) fmt: fix changelog file extension
* [`8f2ae1d2`](https://github.com/NixOS/nixpkgs/commit/8f2ae1d2b5ba1b1028dff35af83c1e6475b746fb) seadrive-gui: 3.0.19 -> 3.0.22
* [`fdb3fb44`](https://github.com/NixOS/nixpkgs/commit/fdb3fb44db4818bbe4be924b4dc06fd06146b12e) croaring: 3.6.1 -> 4.7.0
* [`bd5ab38d`](https://github.com/NixOS/nixpkgs/commit/bd5ab38d8246714cb39e445df28e1c11fabb6a12) websurfx: cleanup nix declaration
* [`54ea0dec`](https://github.com/NixOS/nixpkgs/commit/54ea0dec2b6e04de6b4ec7d3e88ea654b4e2ed35) python3Packages.pricehist: 1.4.14 -> 1.4.16
* [`b99f2ea0`](https://github.com/NixOS/nixpkgs/commit/b99f2ea02b9a76eaa3ea921965dfcf1de82dbf82) gh-cherry-pick -> ghcherry: 1.5.0 -> 1.6.0
* [`0530770a`](https://github.com/NixOS/nixpkgs/commit/0530770a8639ebbe7db47fde60920a8646c45e97) go-jsonschema: 0.22.0 -> 0.23.1
* [`746c4c23`](https://github.com/NixOS/nixpkgs/commit/746c4c23e3b070010174f247c7a9f17025ec4697) factoriolab: 3.20.0 -> 3.21.2
* [`095d60d4`](https://github.com/NixOS/nixpkgs/commit/095d60d45261633e00f2c0828fbf61dba5ba5abe) inklecate: 1.1.1 -> 1.2.1
* [`08dc6a87`](https://github.com/NixOS/nixpkgs/commit/08dc6a8739ca34918ea72812f94bd4873bd514aa) kavita: 0.8.8.3 -> 0.9.0.2
* [`545e5841`](https://github.com/NixOS/nixpkgs/commit/545e5841f30f07f0eb687173fabb04879ae129ed) fheroes2: 1.1.13 -> 1.1.16
* [`9c1ff373`](https://github.com/NixOS/nixpkgs/commit/9c1ff3733700139bf65cbf39eb9ef76b6064b4eb) pioneer: 20250501 -> 20260203
* [`266b2ef8`](https://github.com/NixOS/nixpkgs/commit/266b2ef8f7f05670c7bfa447f6ab65287e73980d) mbuffer: 20251025 -> 20260511
* [`184da5f1`](https://github.com/NixOS/nixpkgs/commit/184da5f11ce3b04e90b7e09c2896bc93bd832369) haveged: 1.9.20 -> 1.9.21
* [`fe2e008b`](https://github.com/NixOS/nixpkgs/commit/fe2e008b8812c1bfa935b3ead94b2a6dee3b01b4) navidromePlugins.audiomuseai: init at 8
* [`3d703647`](https://github.com/NixOS/nixpkgs/commit/3d7036473f2158fb003365cc8a2909da78d4ff32) pure-prompt: 1.27.0 -> 1.28.0
* [`b98a281e`](https://github.com/NixOS/nixpkgs/commit/b98a281e783d046cd9111acc90a13d2fae804829) slimevr: 18.2.0 -> 20.1.0
* [`5e1fd131`](https://github.com/NixOS/nixpkgs/commit/5e1fd13190c5f3ecd14593eb22840d04923aedcb) fatrop: 1.0.0 -> 1.0.1.mod
* [`255aa6d6`](https://github.com/NixOS/nixpkgs/commit/255aa6d6620f54b7e807ba0925e4d24419313eb6) yarn-berry-fetchers: Allow impure env vars
* [`14f6089d`](https://github.com/NixOS/nixpkgs/commit/14f6089d54fd478a11736d6e0def24b08091587b) vja: 5.0.0 -> 5.3.0
* [`d98d8825`](https://github.com/NixOS/nixpkgs/commit/d98d8825508385cf39a80e339099add2e9b90079) viber: 24.9.0.3 -> 27.3.0.2
* [`ee40a45b`](https://github.com/NixOS/nixpkgs/commit/ee40a45bbb49541f22be08541e8d04fedf358acb) wordpress: 6.9.4 -> 7.0
* [`d56a00fe`](https://github.com/NixOS/nixpkgs/commit/d56a00feb6cd5235776c7c2ffe321799e8e48e2e) mangayomi: move icon to spec-compliant location
* [`bf309d01`](https://github.com/NixOS/nixpkgs/commit/bf309d01a0426c1f1d31f2035835724862a5a205) R: 4.5.3 -> 4.6.0
* [`c8c8e732`](https://github.com/NixOS/nixpkgs/commit/c8c8e732c76ce068fb033b29e47855698904aabf) rPackages: CRAN and BioC update
* [`b020b942`](https://github.com/NixOS/nixpkgs/commit/b020b942abb0a4d655a96dcea2ee7944baf42a4b) rmapi: 0.0.32 -> 0.0.34
* [`1147b90b`](https://github.com/NixOS/nixpkgs/commit/1147b90b92ac96fbd2cca55480b53d45b447eead) sylkserver: 6.5.0 -> 6.6.0
* [`3b877f97`](https://github.com/NixOS/nixpkgs/commit/3b877f97fdc03d51653643dcafd538c4203ab816) e-imzo: 6.3.7 -> 6.4.7
* [`25f9394b`](https://github.com/NixOS/nixpkgs/commit/25f9394b8a6cb5273d8650bfea949e8f690dc12d) ci/eval/compare: show performance comparison even when package sets differ
* [`21939014`](https://github.com/NixOS/nixpkgs/commit/21939014dccc37c8d32f09bf7fef4f43188eb1fb) kubeval-schema: migrate to by-name
* [`78477a84`](https://github.com/NixOS/nixpkgs/commit/78477a84d3e4503cbd74f7d67f055612df2b65cd) kubeval: migrate to by-name
* [`ed079ded`](https://github.com/NixOS/nixpkgs/commit/ed079ded3d55fdba7505538259cdd0b6e14e35d4) kubeval: modernize derivation
* [`8ee070ca`](https://github.com/NixOS/nixpkgs/commit/8ee070ca0c41823a08bec4559d199cba23aabfb9) rPackages.fs: fix build
* [`3cf78769`](https://github.com/NixOS/nixpkgs/commit/3cf7876904f4a217236e15da78e2ec6c39034bc1) catppuccin-hyprland: 1.3 -> 2.0.0
* [`cdf72f04`](https://github.com/NixOS/nixpkgs/commit/cdf72f041d694aa07b1ada99a81e7982092ad67c) tiny-wii-backup-manager: init at 6.0.4
* [`a69e6bbd`](https://github.com/NixOS/nixpkgs/commit/a69e6bbde8a3d14dbe4416b7c2e2c2b6b9b6b2ce) maintainers: add ckruse
* [`2059d077`](https://github.com/NixOS/nixpkgs/commit/2059d07759407db2cca25fe8a32477381d33a33d) libqxp: 0.0.2 -> 0.0.3
* [`86f6ef85`](https://github.com/NixOS/nixpkgs/commit/86f6ef85d89d40154dbc37a9b833afd04b7beb5c) livekit-cli: 2.16.2 -> 2.16.4
* [`65e3bf32`](https://github.com/NixOS/nixpkgs/commit/65e3bf3236ddf89fafd11ad92728b022d84267ef) vkbasalt: move let binding into file
* [`5fb8102c`](https://github.com/NixOS/nixpkgs/commit/5fb8102c19ad35cb905e9a39c08873dbfc234fe6) vkbasalt: migrate to by-name
* [`41845b3c`](https://github.com/NixOS/nixpkgs/commit/41845b3c0d81f593a91031a68613d3ee1c50552e) openmeters: unstable-2025-12-15 -> 1.4.1
* [`1b1c3cff`](https://github.com/NixOS/nixpkgs/commit/1b1c3cff53c0a5ad96f5a37dd253c29742200950) linuxPackages.hid-fanatecff: 0.2.2 -> 0.2.3
* [`abc18cbd`](https://github.com/NixOS/nixpkgs/commit/abc18cbdcbe9102a86c4c4a84e4baaf1fb9e1d3b) katago: 1.15.3 -> 1.16.4
* [`69f4858e`](https://github.com/NixOS/nixpkgs/commit/69f4858ea0074fa3c32437182a11d03c3a11f96b) mitimasu: use installFonts
* [`b177033e`](https://github.com/NixOS/nixpkgs/commit/b177033e62a2ca32915552fce7574e0875614d8e) python3Packages.atproto: 0.0.65 -> 0.0.67
* [`a4664b81`](https://github.com/NixOS/nixpkgs/commit/a4664b81962c06bcf5a7e028554125d57feac200) rPackages.Rhdf5lib: fix build
* [`a52facf1`](https://github.com/NixOS/nixpkgs/commit/a52facf1ebef0955118d1c71311546b60206ed6a) rPackages.rhdf5: update patch
* [`22d8ed93`](https://github.com/NixOS/nixpkgs/commit/22d8ed93f3023be80ae144525a45c82ab277b986) rPackages.fixest: fix build
* [`79bcae29`](https://github.com/NixOS/nixpkgs/commit/79bcae29d496ec1bd13ad408f88691eff2446d88) rPackages.rlas: fix build
* [`2ad1656d`](https://github.com/NixOS/nixpkgs/commit/2ad1656d06fa9cf0d56b5069b505454ec5b39a09) rPackages.metan: fixed build
* [`37edf38e`](https://github.com/NixOS/nixpkgs/commit/37edf38e7966579bbd2561cf72706fd05e6755e2) rPackages.RProtoBuf: fixed build
* [`06437cad`](https://github.com/NixOS/nixpkgs/commit/06437cadfd5818bcd94296e3e7b4170d88d8c047) rPackages.survivalsvm: fixed build
* [`56dec1ba`](https://github.com/NixOS/nixpkgs/commit/56dec1ba0d5b94757de04701418faa4018f00a8b) rPackages.tinyimg: fixed build
* [`15672e34`](https://github.com/NixOS/nixpkgs/commit/15672e349cf7ba2a4b073fc125b11f89b6dd33ca) rPackages.FKF_SP: update hash
* [`0a69a399`](https://github.com/NixOS/nixpkgs/commit/0a69a399aaa019ebf2d06573fcc43afa5e7f027d) sherlock: 0.16.0 -> 0.16.0-unstable-2026-05-09
* [`0c95ddf8`](https://github.com/NixOS/nixpkgs/commit/0c95ddf8de58769fa8b62a9da7ce0c2ab1f66557) wazero: 1.11.0 -> 1.12.0
* [`2836d504`](https://github.com/NixOS/nixpkgs/commit/2836d50419e9e61cae7dd461c37174d4d434855a) buildkite-agent: 3.127.0 -> 3.127.1
* [`b34fda17`](https://github.com/NixOS/nixpkgs/commit/b34fda17c9d812194fb7f0e31af3df4933363ca4) unison-ucm: 1.2.0 -> 1.3.0
* [`e3e2d932`](https://github.com/NixOS/nixpkgs/commit/e3e2d9323a235b50fcd7b5f445923c00568f2144) ut1999: provide ISO file sources as passthru
* [`05ac4bdd`](https://github.com/NixOS/nixpkgs/commit/05ac4bdd103f95dd69ad73a368ef9d968c70736a) kubernetes-helmPlugins.helm-dt: 0.7.1 -> 0.8.0
* [`2e66047c`](https://github.com/NixOS/nixpkgs/commit/2e66047cf731ea46cb62c16d567f6c868eff760d) waytrogen: 0.9.5 -> 0.9.8
* [`609709a1`](https://github.com/NixOS/nixpkgs/commit/609709a1f5aabae76d6ef0e3609d2403554e733e) mangohud: 0.8.3 -> 0.8.4
* [`8cb32721`](https://github.com/NixOS/nixpkgs/commit/8cb32721813223db3819a29dae85136105535706) netboxPlugins.netbox-attachments: set structuredAttrs
* [`886afd31`](https://github.com/NixOS/nixpkgs/commit/886afd31d7c2fcd09e3026d070c37789f98cc83f) netboxPlugins.netbox-bgp: set structuredAttrs
* [`758a4159`](https://github.com/NixOS/nixpkgs/commit/758a4159ca54ce1fce4beb4c470eea6069f6e87b) netboxPlugins.netbox-contextmenus: set structuredAttrs
* [`fbaad2a1`](https://github.com/NixOS/nixpkgs/commit/fbaad2a1426bd3c7de500bb3cd68089042570325) netboxPlugins.netbox-contract: set structuredAttrs
* [`4465d18c`](https://github.com/NixOS/nixpkgs/commit/4465d18c4eacddf67706842232c282784bbaad56) netboxPlugins.netbox-dns: set structuredAttrs
* [`c23ebd50`](https://github.com/NixOS/nixpkgs/commit/c23ebd5041ab6bedd885920a4dbd3bcc4a65e288) netboxPlugins.netbox-documents: set structuredAttrs
* [`9e76e2f1`](https://github.com/NixOS/nixpkgs/commit/9e76e2f15a1b5e4be808a8fac884cfc435d9a5a5) netboxPlugins.netbox-floorplan-plugin: set structuredAttrs
* [`2226563e`](https://github.com/NixOS/nixpkgs/commit/2226563e5496f15078a577c03b5a52766261a7ec) netboxPlugins.netbox-interface-synchronization: set structuredAttrs
* [`77a3a6dc`](https://github.com/NixOS/nixpkgs/commit/77a3a6dcfbf35f0cff2d4556fb79545d9ba73b59) netboxPlugins.netbox-napalm-plugin: set structuredAttrs
* [`f09f433a`](https://github.com/NixOS/nixpkgs/commit/f09f433ad5553d8c735e833c0a0756d5a173152e) netboxPlugins.netbox-plugin-prometheus-sd: set structuredAttrs
* [`f9901cae`](https://github.com/NixOS/nixpkgs/commit/f9901caee181b9a6444abe847e67e5c941b964f7) netboxPlugins.netbox-qrcode: set structuredAttrs
* [`d2ec79da`](https://github.com/NixOS/nixpkgs/commit/d2ec79da65441ce9b3c9585b4d3a3ef43a9377cb) netboxPlugins.netbox-reorder-rack: set structuredAttrs
* [`fe8b39d2`](https://github.com/NixOS/nixpkgs/commit/fe8b39d2cddc3a4497c27103fc3941b6ce30bb5c) netboxPlugins.netbox-routing: set structuredAttrs
* [`53e34ccd`](https://github.com/NixOS/nixpkgs/commit/53e34ccd1b01a3f788aae188c7af1e9c26cacfee) netboxPlugins.netbox-topology-views: set structuredAttrs
* [`d11cc3b3`](https://github.com/NixOS/nixpkgs/commit/d11cc3b3ff876d41fdea0fce5c0cda5e499d6f99) tauon: add myself as maintainer
* [`cd8a4c87`](https://github.com/NixOS/nixpkgs/commit/cd8a4c871d9ff10094aef441518f6f25d31f9882) tauon: 9.1.3 -> 10.0.1
* [`fd0e507b`](https://github.com/NixOS/nixpkgs/commit/fd0e507b58d23259b5614fde1106ef1cc0b253e1) tauon: use upstream pypresence again
* [`d6ce54ca`](https://github.com/NixOS/nixpkgs/commit/d6ce54cada76bdf1887024f9e2d9e9c563a1ab60) tree-sitter-grammars.tree-sitter-sshclientconfig: 2026.4.23 -> 2026.5.28
* [`7195e583`](https://github.com/NixOS/nixpkgs/commit/7195e583ce61da209431d542eeac577ea40ec43e) nixos/prometheus-elasticsearch-exporter: init
* [`6ee906ac`](https://github.com/NixOS/nixpkgs/commit/6ee906acd0e5cafc449414c21e8b034c17349eb1) maintainers: remove shreerammodi
* [`3408da49`](https://github.com/NixOS/nixpkgs/commit/3408da498440c04181dfac3a6c46810482519b3d) youtrack: 2026.1.12458 -> 2026.1.13570
* [`fef158bc`](https://github.com/NixOS/nixpkgs/commit/fef158bc4224b13d873482bd98ca9a331a558ab9) x2gokdriveclient: migrate to pkgs/by-name
* [`77ba1762`](https://github.com/NixOS/nixpkgs/commit/77ba176203946529ca5b3f23cfcfe23484726287) git-credential-manager: move to by-name
* [`f7198d40`](https://github.com/NixOS/nixpkgs/commit/f7198d40011568932572deffd987a175fe3ccdc7) github-changelog-generator: move to by-name
* [`0927e122`](https://github.com/NixOS/nixpkgs/commit/0927e1224de9809aa28fa3a1ef7e91e11f563a2e) {mypaint-brushes,mypaint-brushes1}: move to by-name
* [`2c976c67`](https://github.com/NixOS/nixpkgs/commit/2c976c67894b2ad4c01679c60e0ae309e75de8e4) {geany,geany-with-vte}: move to by-name
* [`6d1e3a27`](https://github.com/NixOS/nixpkgs/commit/6d1e3a272e5071953f107c1b1c3f4c126f6ae733) {m17n_lib,libotf}: move to by-name
* [`2b715ee0`](https://github.com/NixOS/nixpkgs/commit/2b715ee0a03fc259494d9570141a4e830947db5e) compass: move to by-name
* [`c4705f76`](https://github.com/NixOS/nixpkgs/commit/c4705f766acce05efc1c976b1d54a7a53b8bd267) doc: Fix URL for file `licenses.nix`
* [`480c99a0`](https://github.com/NixOS/nixpkgs/commit/480c99a0d5a1884d599cc99e9a85c3783d976f07) ratty: 0.3.0 -> 0.4.1
* [`d48e349d`](https://github.com/NixOS/nixpkgs/commit/d48e349d2fb67ac5a416dba9a2f9961db3334de1) chrome-token-signing: migrate to pkgs/by-name
* [`7fdb2326`](https://github.com/NixOS/nixpkgs/commit/7fdb2326f00d5e70490112486b2aad6efa597762) qbit-manage: 4.7.1 -> 4.8.0
* [`ef0e9e75`](https://github.com/NixOS/nixpkgs/commit/ef0e9e75da19c9c436c958a2520ac67a3392563f) maintainers: add ozturkkl
* [`36f1458f`](https://github.com/NixOS/nixpkgs/commit/36f1458f9ba248d255a1a2b42a784361ab6fd7ee) framework-control: init at 0.5.2
* [`0b8f171f`](https://github.com/NixOS/nixpkgs/commit/0b8f171fe416ccb9e0e0224b96b7a05b72688bf3) nixos/framework-control: init module
* [`de5637b6`](https://github.com/NixOS/nixpkgs/commit/de5637b622f5b3653d29003e2dafacce349866c0) boa: add iamanaws as maintainer
* [`18d30c9b`](https://github.com/NixOS/nixpkgs/commit/18d30c9bd157637795c15c4b40488886bd611f98) boa: 0.20 -> 0.21.1
* [`cf7a16f0`](https://github.com/NixOS/nixpkgs/commit/cf7a16f0c611a7f76a0a4e8803975fac3ceb02b8) rqlite: add iamanaws as maintainer
* [`c87d4bcc`](https://github.com/NixOS/nixpkgs/commit/c87d4bcc5070cb9e0c3536835224d16a01b1877a) rqlite: 9.4.5 -> 10.2.0
* [`3741d634`](https://github.com/NixOS/nixpkgs/commit/3741d634d20ed5e870aac8794ccfeb8fd90058f0) fluentd: move to by-name
* [`5ac5c543`](https://github.com/NixOS/nixpkgs/commit/5ac5c543852afcf7e9745111a5d97413b363c915) python3Packages.langgraph-checkpoint: 4.0.3 -> 4.1.1
* [`dc947916`](https://github.com/NixOS/nixpkgs/commit/dc9479162bc0f3adcb190b35c3dcd3f611f285c5) dustracing2d: init at 2.2.0
* [`68d772a3`](https://github.com/NixOS/nixpkgs/commit/68d772a38f6a588dd0c1f369a46ae74677eb46ac) octavePackages.netcdf: Bootstrap sources ourselves
* [`e0630ede`](https://github.com/NixOS/nixpkgs/commit/e0630ede07535a463085ca22ee76e27b28326660) octavePackages.netcdf: 1.0.19 -> 1.0.20
* [`98715467`](https://github.com/NixOS/nixpkgs/commit/98715467d2a2c7c18ea55683da60dc2eed4dd62d) ngrok: Update download refs for ngrok, no longer use equinox.io and instead use ngrok.com
* [`5d813cf4`](https://github.com/NixOS/nixpkgs/commit/5d813cf4018e0e2622f9b3bfb31f6e174d349917) ngrok: 3.31.0 -> 3.39.5
* [`b4b37fc7`](https://github.com/NixOS/nixpkgs/commit/b4b37fc72f2dd75855c513a5fc2a1d3ec80d5c7b) manix: 0.8.0 -> 0.9.0
* [`acdf6c02`](https://github.com/NixOS/nixpkgs/commit/acdf6c0206258343dacf7ad9188d6ee6f86f20f8) mumble, murmur: add hax404 as maintainer
* [`61a8b26a`](https://github.com/NixOS/nixpkgs/commit/61a8b26a0fd841f4529c6dd58e2325f829cb9da5) glm: 1.0.2 -> 1.0.3
* [`1e683163`](https://github.com/NixOS/nixpkgs/commit/1e68316353c5a8a46fd17ac33f2e1cd1e61f59ba) glm_1_0_1: use tag and hash
* [`e79b8a1a`](https://github.com/NixOS/nixpkgs/commit/e79b8a1afaa09dba0429e9b1411fd24d13801e63) vrcvideocacher: 2026.5.1 -> 2026.5.2
* [`d99a72f2`](https://github.com/NixOS/nixpkgs/commit/d99a72f271feab96507821d3631e7f9ddb229c74) ponyc: 0.60.6 -> 0.64.0
* [`2de3b61a`](https://github.com/NixOS/nixpkgs/commit/2de3b61a68eeb9ada9398420c389d6c1b842eb44) pony-corral: fix compile with 0.63+
* [`48184bfa`](https://github.com/NixOS/nixpkgs/commit/48184bfa157669ac3fc56556eefbb2a8d80266f0) xpipe: 22.10 -> 23.3
* [`0917fee1`](https://github.com/NixOS/nixpkgs/commit/0917fee1c3834689cf16784781c0cc02421b92d8) llvmPackages_git: 23.0.0-unstable-2026-05-24 -> 23.0.0-unstable-2026-05-31
* [`2adf523d`](https://github.com/NixOS/nixpkgs/commit/2adf523d60bb76c215c7018ed56bd32d61c2d4ec) caido-cli: 0.56.0 -> 0.56.2
* [`30b95b46`](https://github.com/NixOS/nixpkgs/commit/30b95b461e470f2daf59e102ddab99fdcaf28929) caido-desktop: 0.56.0 -> 0.56.2
* [`3695d1c8`](https://github.com/NixOS/nixpkgs/commit/3695d1c87d7b4e17b62a59458405ca3c67b9e97c) fatrop: deactivate failing test on darwin
* [`9460594d`](https://github.com/NixOS/nixpkgs/commit/9460594d8d9493c001ad63f39089eb53b5a7b4f7) dufs: fix build by adding cacert to preCheck
* [`9b735aa0`](https://github.com/NixOS/nixpkgs/commit/9b735aa0c2716d7eda5355e039d8161f3b8dab0d) bookstack: 26.03.3 -> 26.05
* [`2f5857b9`](https://github.com/NixOS/nixpkgs/commit/2f5857b93e610106fa95f649ce3360e4437fe04a) postgresqlPackages.plr: 8.4.8 -> 8.4.8.6
* [`8bc5acd2`](https://github.com/NixOS/nixpkgs/commit/8bc5acd2a035600acae7d833f0aeb7531f2adb00) netatalk: enable Spotlight search
* [`09d3443b`](https://github.com/NixOS/nixpkgs/commit/09d3443b49c777157dd564612c8fd0b200b2af98) beamPackages.rebar3: patch to fix OTP 29 support
* [`94faa3fa`](https://github.com/NixOS/nixpkgs/commit/94faa3fad4e985c0cb70d53de6c2ae06c6334f39) nsis: 3.11 -> 3.12
* [`efab0ae3`](https://github.com/NixOS/nixpkgs/commit/efab0ae3b35e6d3ce9819000235a08f525ecf7e5) mpvScripts.modernx-zydezu: 0.4.5 -> 0.4.6
* [`db670e41`](https://github.com/NixOS/nixpkgs/commit/db670e41977c769259deb22ccf039073f95e11b3) fatrop: 1.0.1.mod -> 1.1.0
* [`dada8c9e`](https://github.com/NixOS/nixpkgs/commit/dada8c9e081cf8c1f5b9c7db2869afe614f6df98) fatrop: update license
* [`72e80ed3`](https://github.com/NixOS/nixpkgs/commit/72e80ed34d0316e22bbe25d8b0d053fe8b725c64) icewm: 3.8.2 -> 4.0.0
* [`0bea21a4`](https://github.com/NixOS/nixpkgs/commit/0bea21a448d960a07b86da4a41714f2fbb931b43) intel-vaapi-driver: 2.4.1-unstable-2024-10-29 -> 2.4.5
* [`583becdb`](https://github.com/NixOS/nixpkgs/commit/583becdb797f962f5a83d8412900022787471ba8) xev: 1.2.6 -> 1.2.7
* [`0556177e`](https://github.com/NixOS/nixpkgs/commit/0556177ed5a1aabc13f640111714f66a1a0575b2) python3Packages.openfga-sdk: Fix tests on Python 3.12
* [`8487e31f`](https://github.com/NixOS/nixpkgs/commit/8487e31f4c1a79da15f61eeb141e6698b30e516f) etcd_3_4: 3.4.44 -> 3.4.45
* [`891682df`](https://github.com/NixOS/nixpkgs/commit/891682df55356e05e0ffbd9222ee8f8355a141fd) etcd_3_5: 3.5.30 -> 3.5.31
* [`f25166dd`](https://github.com/NixOS/nixpkgs/commit/f25166ddca8fed8b65d3b549c831f62b4cd96845) etcd_3_6: 3.6.11 -> 3.6.12
* [`3ae002d9`](https://github.com/NixOS/nixpkgs/commit/3ae002d94705ff4b63d053df681e82ca6c11c442) plasticity: 25.3.9 -> 26.1.3
* [`60d2d38d`](https://github.com/NixOS/nixpkgs/commit/60d2d38d85d8b84162de214bb3558cd981bb21b5) calibre: 9.8.0 -> 9.9.0
* [`8337b8db`](https://github.com/NixOS/nixpkgs/commit/8337b8db6ed7b937842d711da845ed9bbce7ade8) boost-sml: 1.1.13 -> 1.2.0
* [`4c292ca1`](https://github.com/NixOS/nixpkgs/commit/4c292ca105ef5cd71baa25442cb55cedf1970831) discord: 1.0.138 -> 1.0.141
* [`49f94750`](https://github.com/NixOS/nixpkgs/commit/49f947504d5ebd4bde3a4b909fafb8cdbfd34b5f) python3Packages.qh3: 1.8.1 -> 1.9.1
* [`49f59414`](https://github.com/NixOS/nixpkgs/commit/49f594144d71b40546db04d2eb324340d934078e) python3Packages.urllib3-future: 2.21.900 -> 2.21.902
* [`a6136968`](https://github.com/NixOS/nixpkgs/commit/a613696825856b7a002d022a6a81ec59ae4b1888) python3Packages.niquests: 3.18.8 -> 3.19.0
* [`1f835d06`](https://github.com/NixOS/nixpkgs/commit/1f835d061cea659acd7886b1b9758abf9330f3d3) libcmis: 0.6.2 -> 0.6.3
* [`9ae23a4d`](https://github.com/NixOS/nixpkgs/commit/9ae23a4d5287752a1d31227e19005baa53c1b4b6) rPackages.ramr: fix build
* [`208a93bc`](https://github.com/NixOS/nixpkgs/commit/208a93bc945a3062b10a8c3d0ef8b47ba4393e44) rPackages.lpsymphony: fix build
* [`48c8a7d9`](https://github.com/NixOS/nixpkgs/commit/48c8a7d9513ac0306b3464df6952f2858f015504) wordpress_6_7: drop
* [`dff867e3`](https://github.com/NixOS/nixpkgs/commit/dff867e30062a1c27c4e6a52e6aae0ad168781a9) wordpressPackages: update plugins and themes
* [`1b20888d`](https://github.com/NixOS/nixpkgs/commit/1b20888d2b5717e62c2f4590d92ce4ede1373752) wordpress_*: modernize
* [`18efcbed`](https://github.com/NixOS/nixpkgs/commit/18efcbed8d98481ded121c6ac0f1d2bde06ef770) wordpress_*: add bartoostveen as a maintainer
* [`80af90c7`](https://github.com/NixOS/nixpkgs/commit/80af90c747bbbe2b3acf9165dcb69d21edbdf489) maintainers: add mach
* [`5ab9958e`](https://github.com/NixOS/nixpkgs/commit/5ab9958ecf49b262759ea42c2dee9126a82b42f4) python3Packages.trsfile: init at 2.2.5
* [`ca182473`](https://github.com/NixOS/nixpkgs/commit/ca1824739588f414a6cfb66a90165fabdf19c065) html5validator: migrate to pyproject
* [`147d0224`](https://github.com/NixOS/nixpkgs/commit/147d022441b8c9c86c9b1ff8025701be5f00f1c6) xan: 0.57.1 -> 0.58.0
* [`b0e90aeb`](https://github.com/NixOS/nixpkgs/commit/b0e90aeb66133af3b41af50aef84ee5a6ea8dc9c) pokemini: Add pokemini libretro core for RetroArch
* [`155e0adb`](https://github.com/NixOS/nixpkgs/commit/155e0adb57cfb7b8d8c554e896eb284d0ca55ad6) ghidra: use finalAttrs in binary-file-toolkit derivation
* [`6d3bd7aa`](https://github.com/NixOS/nixpkgs/commit/6d3bd7aa7ecde089f0f117e58af78c4499802cb8) libfreehand: 0.1.2 -> 0.1.3
* [`2466aeb0`](https://github.com/NixOS/nixpkgs/commit/2466aeb073bea92ef868822389247bd8fad4cf9c) libetpan: 1.9.4 -> 1.10
* [`6b39d1c6`](https://github.com/NixOS/nixpkgs/commit/6b39d1c6a0d8db8c427212199869b6ea0ac02b45) tree-sitter-grammars.tree-sitter-zig: 0-unstable-2024-10-13 -> 1.1.2-unstable-2025-09-10
* [`b0e5fd9e`](https://github.com/NixOS/nixpkgs/commit/b0e5fd9ee5dab232ea48a5c9af6c28377338d3ca) python3Packages.datastar-py: 1.0.0 -> 1.0.2
* [`e4cf177f`](https://github.com/NixOS/nixpkgs/commit/e4cf177fa4607a36db5165f81ef70168d88a5bf5) freeipmi: 1.6.17 -> 1.6.18
* [`22ffe0a4`](https://github.com/NixOS/nixpkgs/commit/22ffe0a4bacd77cec52cd274712694498215fb2d) rPackages.GOCompare: fix hash
* [`80cfb6fe`](https://github.com/NixOS/nixpkgs/commit/80cfb6fe573914a9b10907bb5a85d7174c9f782b) rPackages.NCFP: fix hash
* [`65136023`](https://github.com/NixOS/nixpkgs/commit/6513602344d72cc59fb982beddf09f496ff6ea1e) rPackages.Path_Analysis: fix hash
* [`4d6b55a1`](https://github.com/NixOS/nixpkgs/commit/4d6b55a1c904e623a4649d95cf161ca4ff661674) rPackages.aglm: fix hash
* [`7494fc77`](https://github.com/NixOS/nixpkgs/commit/7494fc77443854d908075c8329e083611d7bd3b5) rPackages.clugenr: fix hash
* [`a8cb4326`](https://github.com/NixOS/nixpkgs/commit/a8cb43260ba775ab96e9da30a65dca54d527aa3f) rPackages.complexlm: fix hash
* [`513d50ef`](https://github.com/NixOS/nixpkgs/commit/513d50ef4a1b0ca130c617498a5db76a5fa7735b) rPackages.maczic: fix hash
* [`4389f026`](https://github.com/NixOS/nixpkgs/commit/4389f0263b1606fae3bc39ff7aea119129f422c4) rPackages.poolr: fix hash
* [`ee7a2937`](https://github.com/NixOS/nixpkgs/commit/ee7a29379ba731543c03697645792a95117a92ad) rPackages.prospectr: fix hash
* [`5a36e09a`](https://github.com/NixOS/nixpkgs/commit/5a36e09add41d7bbfaaccf10c12055f380ca480c) rPackages.rYWAASB: fix hash
* [`6f46fbd1`](https://github.com/NixOS/nixpkgs/commit/6f46fbd12c3c4ab22e2ba0bb4cd60c429b1d2262) rPackages.robust2sls: fix hash
* [`1d7a5c4a`](https://github.com/NixOS/nixpkgs/commit/1d7a5c4a40ab67955984905541139256ad25a062) rPackages.sjSDM: fix hash
* [`332fa655`](https://github.com/NixOS/nixpkgs/commit/332fa655d0077cafb16f149901489c18dfe2132d) spectre-meltdown-checker: 26.33.0420460 -> 26.36.0602723
* [`24a26950`](https://github.com/NixOS/nixpkgs/commit/24a269500a2311288ce708aaad9ebd42f794d691) qq: 2026-04-01 -> 2026-05-28
* [`86219132`](https://github.com/NixOS/nixpkgs/commit/8621913229c00d87488c5d5d664ee3a77efd2f06) libgdiplus: 6.1 -> 6.2
* [`9232e2a9`](https://github.com/NixOS/nixpkgs/commit/9232e2a9e64a74be89c017e3b7d252fa40c87951) zabbix74: 7.4.10 -> 7.4.11
* [`92771ca0`](https://github.com/NixOS/nixpkgs/commit/92771ca00b91702376320907254418b1c2843354) zabbix70: 7.0.26 -> 7.0.27
* [`8301e811`](https://github.com/NixOS/nixpkgs/commit/8301e8113bee1738c8f90dfb2b474ba636b3b6d2) obs-studio-plugins.advanced-scene-switcher: 1.32.6 -> 1.34.2
* [`14f09308`](https://github.com/NixOS/nixpkgs/commit/14f093082b0de2644c540e768232703b74c99da4) tup: clarify license
* [`04088caa`](https://github.com/NixOS/nixpkgs/commit/04088caaa61db9aaa944fe5997a0a13e96827746) tup: use installShellFiles
* [`ff9bbc19`](https://github.com/NixOS/nixpkgs/commit/ff9bbc194a3b59dbf6045dc93e19088f79803b48) tup: add runHook to configurePhase
* [`626703c3`](https://github.com/NixOS/nixpkgs/commit/626703c3ba308c760ad7175f09c02d47a1343e32) proxsuite: rev -> tag
* [`9005a984`](https://github.com/NixOS/nixpkgs/commit/9005a984223e73b9a0ba6924d5c8fa5fed682af2) corrscope: Add explicit passthru.updateScript
* [`027f1a47`](https://github.com/NixOS/nixpkgs/commit/027f1a475dbaffe08f0773f9a8329f8d8894eaf7) cook-cli: build js during preBuild
* [`bec5b60a`](https://github.com/NixOS/nixpkgs/commit/bec5b60ae1dbcb0c22ac77c826da2d16d758ea08) python3Packages.asyncio-rlock: migrate to pyproject
* [`49f2b321`](https://github.com/NixOS/nixpkgs/commit/49f2b321aeac34edc0171d8018897e764bf5fef1) python3Packages.asyncio-rlock: convert to finalAttrs
* [`a888e68e`](https://github.com/NixOS/nixpkgs/commit/a888e68eefce50f96c8e80c4067fb0cdc0ffdb68) python3Packages.atomicwrites: migrate to pyproject
* [`836d619e`](https://github.com/NixOS/nixpkgs/commit/836d619e6c0aaf32536f89517afed1f1c5458cdf) python3Packages.asyncio-rlock: use SRI hash format
* [`c4986380`](https://github.com/NixOS/nixpkgs/commit/c4986380de32a4b6d5c2c9fcdff01633dc0f282a) python3Packages.atomicwrites: convert to finalAttrs
* [`6de5ce17`](https://github.com/NixOS/nixpkgs/commit/6de5ce1715db2c4f2a075d406f447f4a62c1fbc9) kotlin: 2.3.21 -> 2.4.0
* [`8f46736a`](https://github.com/NixOS/nixpkgs/commit/8f46736a5f665ecda9b498ab327f9bac6b3a5e81) python3Packages.avro-python3: migrate to pyproject
* [`984b9014`](https://github.com/NixOS/nixpkgs/commit/984b9014793a99055aba3abd2610b5065de65d85) python3Packages.avro-python3: convert to finalAttrs
* [`4586e574`](https://github.com/NixOS/nixpkgs/commit/4586e5741305daad8d2a84c921f50c4f1f0b9d43) python3Packages.azure-applicationinsights: migrate to pyproject
* [`bf3176a8`](https://github.com/NixOS/nixpkgs/commit/bf3176a89afad73058be3aad4a88ceff314561e4) python3Packages.avro-python3: use SRI hash format
* [`bce9800b`](https://github.com/NixOS/nixpkgs/commit/bce9800bed8e1a5a71a7d237c3621300882e9596) python3Packages.azure-applicationinsights: convert to finalAttrs
* [`590672d3`](https://github.com/NixOS/nixpkgs/commit/590672d307dd402b07a52272499bcfa50bbb8eed) python3Packages.azure-cosmosdb-nspkg: migrate to pyproject
* [`cbce6f20`](https://github.com/NixOS/nixpkgs/commit/cbce6f20bd83834ccd556b20f94ff0e21c9a903b) python3Packages.azure-cosmosdb-nspkg: convert to finalAttrs
* [`077da835`](https://github.com/NixOS/nixpkgs/commit/077da835f04a51fd6a4e01eb4b16d9cdf18eb3ec) python3Packages.azure-datalake-store: migrate to pyproject
* [`ff00896c`](https://github.com/NixOS/nixpkgs/commit/ff00896c7cc8531ef29b5ab0e9c330f39d62a118) dawarich: 1.7.5 -> 1.7.11
* [`d387e154`](https://github.com/NixOS/nixpkgs/commit/d387e15483ef01860dec55438a7d6adb772441f5) python3Packages.azure-cosmosdb-nspkg: use SRI hash format
* [`dfef183f`](https://github.com/NixOS/nixpkgs/commit/dfef183f17481ba2f9e3fc9aed0515925d1c6589) python3Packages.azure-datalake-store: convert to finalAttrs
* [`d4b9693e`](https://github.com/NixOS/nixpkgs/commit/d4b9693e0fe7e4f5cf9b6a0c9dd98eddc390b04f) python3Packages.hiredis: 3.3.1 -> 3.4.0
* [`c8fe7b0a`](https://github.com/NixOS/nixpkgs/commit/c8fe7b0ad9e30f4a3b9bcaf8ec57f19a204712be) python3Packages.hiredis: modernize
* [`7b8e4fa0`](https://github.com/NixOS/nixpkgs/commit/7b8e4fa0b10b95f8e0adcbf5b1bba1d55e6b97b9) python3Packages.hiredis: add hythera as maintainer
* [`a0a4aba2`](https://github.com/NixOS/nixpkgs/commit/a0a4aba280614aab4876456bb0af46a658f8ef94) hyprwhspr-rs: 0.3.28 -> 0.3.29
* [`f9c51806`](https://github.com/NixOS/nixpkgs/commit/f9c51806df3cd96665240db3e257c26af7dc3cad) arti: 2.3.0 -> 2.4.0
* [`b765e8c6`](https://github.com/NixOS/nixpkgs/commit/b765e8c67820868f0f7412f0094211abe0371fc7) {palemoon-bin,palemoon-gtk2-bin}: 34.2.2 -> 34.3.0
* [`c8d2c2cc`](https://github.com/NixOS/nixpkgs/commit/c8d2c2cc134ac499013f598f05dd23ad2c8676ab) {libsForQt5,qt6Packages}.qzxing: Fix passthru.updateScript
* [`d355b592`](https://github.com/NixOS/nixpkgs/commit/d355b592b89e3d2fc4ba8b50e98322cc777395da) arti: add patch for TROVE-2026-024
* [`361e93dd`](https://github.com/NixOS/nixpkgs/commit/361e93dd22459110c163724b482a8f35db27a1f3) liblangtag: 0.6.7 -> 0.6.8
* [`404357cb`](https://github.com/NixOS/nixpkgs/commit/404357cbaa5e74ae8c0f0274f235e2eed6d6ca27) liblo: 0.32 -> 0.35
* [`94bb01d2`](https://github.com/NixOS/nixpkgs/commit/94bb01d2747bd1acc6b81f9a753574cdc852ff62) pacman-game: build for Linux too, not just Darwin
* [`3e799787`](https://github.com/NixOS/nixpkgs/commit/3e799787979ebb07cd81e38539951d201b4a380c) python3Packages.ingredient-parser-nlp: 2.6.0 -> 2.7.0
* [`ba64ff96`](https://github.com/NixOS/nixpkgs/commit/ba64ff9604600267e4896ec77c5a135185ae2314) style50: 2.11.0 -> 3.0.0
* [`9cb511ed`](https://github.com/NixOS/nixpkgs/commit/9cb511ed55def8443f9bc4d5b917fcc6e8b819d3) saga: 9.12.4 -> 9.12.5
* [`7560a8fb`](https://github.com/NixOS/nixpkgs/commit/7560a8fb46a3eb2edf8e3fe0f769a85e9b34c8ca) ryzen-smu: 0.1.7-unstable-2025-10-22 -> 0.1.7-unstable-2026-04-25
* [`0566aebe`](https://github.com/NixOS/nixpkgs/commit/0566aebe67a2e03d6bc6623a04a92677cb4363d4) rustdesk: 1.4.6 -> 1.4.7
* [`726fd9f7`](https://github.com/NixOS/nixpkgs/commit/726fd9f7993e5a6fc427f0441baa2dd63e84b615) pi-coding-agent: remove koffi removal (it has been removed upstream)
* [`f5f657ac`](https://github.com/NixOS/nixpkgs/commit/f5f657ac66360c086e09c5eeb75dcbb69922e7e3) rapidraw: 1.5.5 -> 1.5.6
* [`06107dd5`](https://github.com/NixOS/nixpkgs/commit/06107dd528bf2ed4e86906976f53d66de934fabe) rgx: 0.12.4 -> 0.12.6
* [`cfe306cf`](https://github.com/NixOS/nixpkgs/commit/cfe306cfe52908320da49457d86c21fca9280e9e) python3Packages.iterable-io: 1.0.1 -> 1.0.4
* [`6e8ff63c`](https://github.com/NixOS/nixpkgs/commit/6e8ff63c21d710c65c1b1ff23cfc5c3b9be71e48) css-variables-language-server: fix darwin build
* [`235013cf`](https://github.com/NixOS/nixpkgs/commit/235013cf37a7ef61d817af1e4c6115b295293bc4) treewide: drop unnecessary toString calls
* [`551adc4c`](https://github.com/NixOS/nixpkgs/commit/551adc4c1b704e9d517f804cc169ee329cea494b) ostui: 1.1.1 -> 1.3.2
* [`5148bf43`](https://github.com/NixOS/nixpkgs/commit/5148bf43fd827ed56e3c7d1a104409ec72bb0089) python3Packages.apcaccess: migrate to pyproject
* [`0c3441fa`](https://github.com/NixOS/nixpkgs/commit/0c3441fa08418895ced3091c4cac58b55d760fea) python3Packages.apcaccess: modernize
* [`61006c1b`](https://github.com/NixOS/nixpkgs/commit/61006c1b34f70d670b9de64bca0e8ec501326345) python3Packages.apcaccess: add meta.changelog
* [`e3e7b79a`](https://github.com/NixOS/nixpkgs/commit/e3e7b79a30ca7c8a035b139c8f3bde1f116aaebb) Revert "nixos/pantheon: Disable x-d-p-pantheon"
* [`89a360d8`](https://github.com/NixOS/nixpkgs/commit/89a360d8dad2acd8fbf7ef41c48309a102ccfd95) Revert "pantheon.elementary-screenshot: Do not use portals"
* [`91268630`](https://github.com/NixOS/nixpkgs/commit/9126863098dcc806c2adc5ac247abd1f788c5cfb) pantheon.elementary-screenshot: 8.0.3 -> 8.0.4
* [`2e71cb5e`](https://github.com/NixOS/nixpkgs/commit/2e71cb5e5f0741bb2d66d1cdc36b40b561036e8a) python3Packages.applicationinsights: migrate to pyproject
* [`4653c84d`](https://github.com/NixOS/nixpkgs/commit/4653c84dc890f645c7db6a3554fe6c443c69fffc) python3Packages.applicationinsights: modernize
* [`b0e1f5b6`](https://github.com/NixOS/nixpkgs/commit/b0e1f5b65f354054119657b89267403c4d5b83ec) python3Packages.applicationinsights: add meta.changelog
* [`95592994`](https://github.com/NixOS/nixpkgs/commit/9559299408a649b697f9d4c77a3f502494f77244) pureref: 2.1.2 -> 2.1.3
* [`cb41a302`](https://github.com/NixOS/nixpkgs/commit/cb41a30241568cc086a39724d7d24f50e9cfb829) antidote: add NanamiNakano as maintainer
* [`018fe67a`](https://github.com/NixOS/nixpkgs/commit/018fe67a343270038932d3b61ededbae02a4c863) backblaze-b2: 4.6.0 -> 4.7.0
* [`715ec4dd`](https://github.com/NixOS/nixpkgs/commit/715ec4ddc86981f22af28c383feed4bdf02958bf) nixos-render-docs: add viewport meta tag to manual
* [`ef09d3e3`](https://github.com/NixOS/nixpkgs/commit/ef09d3e3c79e853c289f0797020ab5e5fcef4f6a) python3Packages.azure-mgmt-core: migrate to pyproject
* [`0c499291`](https://github.com/NixOS/nixpkgs/commit/0c499291fcf1e3d2fbbfc8797efe6a6aef33eedf) toolhive: 0.26.1 -> 0.29.1
* [`e29d520a`](https://github.com/NixOS/nixpkgs/commit/e29d520a1f2527447c57e4c58b3a8c2b1979d162) python3Packages.pyzx: 0.9.0 -> 0.10.3
* [`1497247b`](https://github.com/NixOS/nixpkgs/commit/1497247b4a2140bce52b1161a8dbb60f3064216f) python3Packages.azure-mgmt-servicelinker: migrate to pyproject
* [`fbc7b7e6`](https://github.com/NixOS/nixpkgs/commit/fbc7b7e6ca08b0ea27aa6cc7fbe3df09b63fb0a5) python3Packages.azure-synapse-artifacts: migrate to pyproject
* [`c1360c5b`](https://github.com/NixOS/nixpkgs/commit/c1360c5b7b02f10c5a3de1f8665b82506520f03a) tdarr-node: 2.74.01 -> 2.77.01
* [`96526e68`](https://github.com/NixOS/nixpkgs/commit/96526e68b0d2d3dfa91d239f6964945d6b9c9a78) pizauth: add doronbehar to maintainers
* [`987a1216`](https://github.com/NixOS/nixpkgs/commit/987a1216a15085045a501587f51ddb691e3b391a) ankacoder-condensed: migrate to finalAttrs
* [`9cbc0b1d`](https://github.com/NixOS/nixpkgs/commit/9cbc0b1da57c4463cf8361e3ed88a9abf0036823) pigz: adopt
* [`164e921f`](https://github.com/NixOS/nixpkgs/commit/164e921f9423e06e9bbe30741b6a38b4f00db605) drawio: 29.7.9 -> 30.0.4
* [`584296bc`](https://github.com/NixOS/nixpkgs/commit/584296bc783c8ffcda839e9a3bd4fe7f88c20083) regreet: 0.3.0 -> 0.4.0
* [`7d1111fb`](https://github.com/NixOS/nixpkgs/commit/7d1111fbc02e51053ce504ec4035013069fc758a) matrix-synapse-unwrapped: 1.153.0 -> 1.154.0
* [`4b0398fd`](https://github.com/NixOS/nixpkgs/commit/4b0398fd2c8205ce10c81aef2f1b63cadd75241a) pizauth: use upstream's install targets
* [`2bf63ea4`](https://github.com/NixOS/nixpkgs/commit/2bf63ea403f710d270f9f5f16f6f568f0c00ffbe) reticulum-go: init at 0.9.5
* [`118c0192`](https://github.com/NixOS/nixpkgs/commit/118c019290d819932879a4254ccd395175f9ae41) apache-jena: migrate to finalAttrs
* [`ee8fb5d2`](https://github.com/NixOS/nixpkgs/commit/ee8fb5d26bf0016e648da7701e71ca424934df44) apache-jena-fuseki: migrate to finalAttrs
* [`f8c0d3a5`](https://github.com/NixOS/nixpkgs/commit/f8c0d3a5063c6a7a5f9e550e577156cf96fffeae) maintainers: add tiebe
* [`33394080`](https://github.com/NixOS/nixpkgs/commit/33394080e7aef8f364d29ff304408d6d4f971313) pigz: enable `strictDeps` & `__structuredAttrs`
* [`ec0bef96`](https://github.com/NixOS/nixpkgs/commit/ec0bef96ec323f16e2c343e8e4456911fa7262d0) pigz: split outputs
* [`e67ecb4b`](https://github.com/NixOS/nixpkgs/commit/e67ecb4b3d7a4a49cad5fea9f432cd28ecb210c0) pigz: drop `util-linux` from `buildInputs`
* [`f9770c70`](https://github.com/NixOS/nixpkgs/commit/f9770c70876d1a7130da2659dbe2ff834e6bc181) pigz: dont guess `cc` executable name
* [`d4df27fe`](https://github.com/NixOS/nixpkgs/commit/d4df27fea5b30b5d81a5d51b3bc835b6422cd1c1) pigz: add some `nativeCheckInputs`
* [`2f469e5b`](https://github.com/NixOS/nixpkgs/commit/2f469e5b317aa089a4241dac0d7f36ec74491b2f) pigz: add updateScript
* [`826df638`](https://github.com/NixOS/nixpkgs/commit/826df6385405623e35a413aa292e8b90a1f8352e) gdcm: 3.2.6 -> 3.2.7
* [`0febaeb1`](https://github.com/NixOS/nixpkgs/commit/0febaeb18bc96ddd0dc9334c4bd9de2739591c86) gitte: init at 0.6.1
* [`d9bf382c`](https://github.com/NixOS/nixpkgs/commit/d9bf382cadd49163245d2723ab62b8be5183d65f) nixos/fwupd: allow fwupd-refresh user to refresh metadata via polkit
* [`c57635e2`](https://github.com/NixOS/nixpkgs/commit/c57635e287ef742955ae73a78c1f5dcd7f6f54c1) brave: 1.90.128 -> 1.91.168
* [`fd2f3a0e`](https://github.com/NixOS/nixpkgs/commit/fd2f3a0e644553a1c954d2aa426a41125456b844) shotwell: 0.32.15 -> 0.32.16
* [`a3978a18`](https://github.com/NixOS/nixpkgs/commit/a3978a188d0a3f530b146f93e6d549b08cc5a6e7) ansel: 0-unstable-2026-05-26 -> 0-unstable-2026-06-04
* [`76abc5fb`](https://github.com/NixOS/nixpkgs/commit/76abc5fb2aad6b980ba4613f61bf588e54881223) python3Packages.azure-mgmt-servicelinker: modernize
* [`7f6e8041`](https://github.com/NixOS/nixpkgs/commit/7f6e80418830eb9fd468ffdfdeeeb3d7dfd52bc9) python3Packages.azure-synapse-artifacts: modernize
* [`4051453c`](https://github.com/NixOS/nixpkgs/commit/4051453c1e849d1a61fc3f6c99f42218eae31407) ttfautohint: use qt5 instead of libsForQt5.qt5
* [`40b97a46`](https://github.com/NixOS/nixpkgs/commit/40b97a4639388e9ea2eafcb8cb6e4ed9092b4743) openscad-unstable: use libsForQt5 instead of libsForQt5.qt5
* [`0c310ad8`](https://github.com/NixOS/nixpkgs/commit/0c310ad8a722a93fa59243e8b9a170139d18213d) magicq: use qt5 instead of libsForQt5.qt5
* [`13a70fb1`](https://github.com/NixOS/nixpkgs/commit/13a70fb17c343d51bf29e83014be9d10d5ee4156) lmms: use qt5 instead of libsForQt5.qt5
* [`aa7dbe4b`](https://github.com/NixOS/nixpkgs/commit/aa7dbe4bf375e86d38ce994aa36849ec9fa890b1) isync: use qt5 instead of libsForQt5.qt5
* [`cea626bd`](https://github.com/NixOS/nixpkgs/commit/cea626bd84d2ff81b49864c6866f5f10ce8a795d) ideamaker: use qt5 instead of libsForQt5.qt5
* [`6a7b97ee`](https://github.com/NixOS/nixpkgs/commit/6a7b97eec887ace49db64c2ec52112c0b3a13826) dsremote: use qt5 instead of libsForQt5.qt5
* [`cd495ee6`](https://github.com/NixOS/nixpkgs/commit/cd495ee673eadf3c8e653cbd264f07bd9cc0fbc3) caneda: use libsForQt5 instead of libsForQt5.qt5
* [`3c9c38f1`](https://github.com/NixOS/nixpkgs/commit/3c9c38f12e489bdc869039e572908a1ef5de5a85) bitbox: use qt5 instead of libsForQt5.qt5
* [`49871147`](https://github.com/NixOS/nixpkgs/commit/498711475d508b7d0b5ee3941fa3309d5b8b8c32) animeko: use qt5 instead of libsForQt5.qt5
* [`a6a1c7bf`](https://github.com/NixOS/nixpkgs/commit/a6a1c7bf488bcf98592d33bed56dee5c92fb4032) nixosTests.qgis: use qt5 instead of libsForQt5.qt5
* [`bf0acd29`](https://github.com/NixOS/nixpkgs/commit/bf0acd291e772545bcb0c6bb4daa6fd4fd2b69f7) libsForQt5.ldutils: use qt5 libraries directly
* [`f32eca55`](https://github.com/NixOS/nixpkgs/commit/f32eca55c7fe4c1ad91ad2990ecb2340d80d9df4) ocs-url: use qt5 instead of libsForQt5.qt5
* [`73729190`](https://github.com/NixOS/nixpkgs/commit/7372919063bfa0982813ff35336367afb33d70ed) sqlitestudio: use qt5 instead of libsForQt5.qt5
* [`ded692b1`](https://github.com/NixOS/nixpkgs/commit/ded692b17ed50a235b855490274890bb56abbc54) wpsoffice: use qt5 instead of libsForQt5.qt5
* [`1e250832`](https://github.com/NixOS/nixpkgs/commit/1e2508320b39a6a81696a4de8a50226b6314a41b) libsForQt5.qt5: remove attribute
* [`96cd39ec`](https://github.com/NixOS/nixpkgs/commit/96cd39ecd8eaf9fba7215b50088375ced1d27861) python3Packages.azure-mgmt-core: modernize
* [`5c92ff40`](https://github.com/NixOS/nixpkgs/commit/5c92ff402f558c9fc1e091ef777fcaa98ab9d379) coolercontrol: 4.3.0 -> 4.3.1
* [`db8b9a24`](https://github.com/NixOS/nixpkgs/commit/db8b9a24937afe784f4cf4a01573b54bc9feb348) glab: 1.99.0 → 1.101.0
* [`f9d12768`](https://github.com/NixOS/nixpkgs/commit/f9d1276863ee22c1e94cc884103a2298947dd7ee) pnpm_11: 11.5.1 -> 11.5.2
* [`a15b2651`](https://github.com/NixOS/nixpkgs/commit/a15b2651a05175215cb0b0eb5b4a8b42afd6a150) wdfs: drop
* [`d55bfd14`](https://github.com/NixOS/nixpkgs/commit/d55bfd140fd3fbdc47accab9e1e768d1deb587e2) jfrog-cli: 2.104.1 -> 2.107.0
* [`b9f721f1`](https://github.com/NixOS/nixpkgs/commit/b9f721f17bcea268c0919fe150bac185f6f5f429) xlights: 2026.08 -> 2026.10
* [`fd711cd2`](https://github.com/NixOS/nixpkgs/commit/fd711cd2489e8a079c6070f81417126bf929d401) nixos/wpa_supplicant: use lib.warn for warnings
* [`742d9516`](https://github.com/NixOS/nixpkgs/commit/742d9516f4b791dd749813e337bd3e4641a84db3) nirimon: init at 2026.605.1
* [`0a95ede7`](https://github.com/NixOS/nixpkgs/commit/0a95ede7cfc09d37f0fbb776076e02b372ef4b6a) python3Packages.django-silk: fix tests
* [`c26d2edf`](https://github.com/NixOS/nixpkgs/commit/c26d2edff5a8e72d36eb9ed6ca4226d149022c4f) python3Packages.django-silk: 5.4.3 -> 5.5.0
* [`6cd1976d`](https://github.com/NixOS/nixpkgs/commit/6cd1976d0fb87ec3b1b158b81b83bc3544297c73) victoriatraces: 0.9.0 -> 0.9.2
* [`6eec1807`](https://github.com/NixOS/nixpkgs/commit/6eec1807f1aa3c65214133764103081f02265e03) php84: 8.4.21 -> 8.4.22
* [`fc47b454`](https://github.com/NixOS/nixpkgs/commit/fc47b4549ba60ec8882d87d774aae134b42c119c) php85: 8.5.6 -> 8.5.7
* [`142ae7dd`](https://github.com/NixOS/nixpkgs/commit/142ae7dd6979abeecda224ff7651c5f0c43fbe3a) klog-rs: 0.5.1 -> 0.6.0
* [`c5adebba`](https://github.com/NixOS/nixpkgs/commit/c5adebba699d8134b7e91611af15c18d95c2d322) syncthingtray: 2.1.1 -> 2.1.2
* [`986271ec`](https://github.com/NixOS/nixpkgs/commit/986271ec2061c40e8a2498ee481f5b873e23a272) julec: 0.2.1 -> 0.2.2
* [`1e9315fd`](https://github.com/NixOS/nixpkgs/commit/1e9315fd0c7b8117528beaafa9a31ce72242963f) ollama: use `tag` field for llama.cpp pin + drop redundant version comment
* [`d5a560ba`](https://github.com/NixOS/nixpkgs/commit/d5a560ba175eb6f893c0c2b0bb2c6ff4252d1d23) megabasterd: 8.51 -> 8.57
* [`5c747b5f`](https://github.com/NixOS/nixpkgs/commit/5c747b5f78de475e1a27f43bb8dd9e64446794f2) poedit: 3.9 -> 3.9.1
* [`f3797847`](https://github.com/NixOS/nixpkgs/commit/f37978477bb931ceac4e730d201fe2a089c8c9f6) opencode: 1.15.13 -> 1.16.2
* [`906bf1df`](https://github.com/NixOS/nixpkgs/commit/906bf1dfb571c79aae0eeafa951b4af1f5439385) bitfocus-companion: init at 4.3.4
* [`4cf90455`](https://github.com/NixOS/nixpkgs/commit/4cf90455889272f70140582c508bd085c42bcb14) python3Packages.baron: migrate to pyproject
* [`ea7bf4f7`](https://github.com/NixOS/nixpkgs/commit/ea7bf4f7d094917b301a3110ea58904cd5ab5904) transmission_4-gtk: add `libayatana-appindicator` dependency for system tray icon
* [`d4a21f6c`](https://github.com/NixOS/nixpkgs/commit/d4a21f6c0a7d75746b71680bbe61ad803aebe7b9) python3Packages.baron: modernize
* [`b5c46dfd`](https://github.com/NixOS/nixpkgs/commit/b5c46dfd87234d8ab26c791f63d59c7c6d0d4db1) python3Packages.baseline: migrate to pyproject
* [`7fd02748`](https://github.com/NixOS/nixpkgs/commit/7fd0274834c8b2c0c4204bc3686e1e41d97ac902) python3Packages.basemap-data: migrate to pyproject
* [`80b7c3da`](https://github.com/NixOS/nixpkgs/commit/80b7c3dabd10d2006ee080dfd00227ba42d2bc25) python3Packages.basiciw: migrate to pyproject
* [`c8685a3d`](https://github.com/NixOS/nixpkgs/commit/c8685a3dab5e4ede9a136a7ad44e8d65e0fc53cd) python3Packages.baseline: modernize
* [`e1d51552`](https://github.com/NixOS/nixpkgs/commit/e1d51552ce58f327982b112846b9774aaad62d7b) python3Packages.basiciw: modernize
* [`e5db326c`](https://github.com/NixOS/nixpkgs/commit/e5db326ce3440e0a9a6e5b3671912f3ac81386d1) python3Packages.basemap-data: modernize
* [`28a3d556`](https://github.com/NixOS/nixpkgs/commit/28a3d556e68fbba07c91a8c7ae1e3ca0278db2f5) python3Packages.bcdoc: migrate to pyproject
* [`1aa9ed72`](https://github.com/NixOS/nixpkgs/commit/1aa9ed729a8959305b281aced8799dd1844a9fc3) python3Packages.beautiful-date: migrate to pyproject
* [`58425602`](https://github.com/NixOS/nixpkgs/commit/58425602c3c0805dc35eccbacea7c62d594f1474) python3Packages.bcdoc: modernize
* [`68b4ac2e`](https://github.com/NixOS/nixpkgs/commit/68b4ac2e473af7e91e23d445a9df4dcd90d5fd66) python3Packages.beautiful-date: modernize
* [`f2bc7d71`](https://github.com/NixOS/nixpkgs/commit/f2bc7d7124a329730b89ba2dff70aa147d737270) python3Packages.bech32: migrate to pyproject
* [`08cf3d95`](https://github.com/NixOS/nixpkgs/commit/08cf3d9531e45dc02bd78e0ff5f499b60461baa1) python3Packages.before-after: migrate to pyproject
* [`37bcd412`](https://github.com/NixOS/nixpkgs/commit/37bcd412acf90ec84b28c5dc3623f3181015888d) python3Packages.before-after: modernize
* [`32d41f5d`](https://github.com/NixOS/nixpkgs/commit/32d41f5d6300641e594655d5388eaa2ac80368ca) python3Packages.bech32: modernize
* [`5c812b4e`](https://github.com/NixOS/nixpkgs/commit/5c812b4e7078300f05b5d6a236f32e4bbc859f9f) python3Packages.bech32: fix meta.homepage URL
* [`cd492607`](https://github.com/NixOS/nixpkgs/commit/cd492607a9b5e918631a8c806f288fd4e64ea029) python3Packages.binho-host-adapter: migrate to pyproject
* [`f9764da1`](https://github.com/NixOS/nixpkgs/commit/f9764da1c2a8ccbfa71e3f9afb8ba8dd037d2220) python3Packages.bincopy: migrate to pyproject
* [`8b0a3869`](https://github.com/NixOS/nixpkgs/commit/8b0a38697ea2fe4ec126c66ab3274aeb521650b5) python3Packages.binho-host-adapter: modernize
* [`0a141673`](https://github.com/NixOS/nixpkgs/commit/0a1416733381981d45c6835475ce0a1491c2e0c4) python3Packages.bincopy: modernize
* [`da106b56`](https://github.com/NixOS/nixpkgs/commit/da106b56f616de436e612f67b8037a89f970c9dc) python3Packages.bitvavo-aio: migrate to pyproject
* [`5ad0be81`](https://github.com/NixOS/nixpkgs/commit/5ad0be813a7fa92c23ceb659dbc6aac2aa9ad7c6) python3Packages.bitvavo-aio: modernize
* [`21c91b2d`](https://github.com/NixOS/nixpkgs/commit/21c91b2da5fb6a5095315b68193f8bf7fe577e8b) t3code: 0.0.24 -> 0.0.25
* [`9aab88c8`](https://github.com/NixOS/nixpkgs/commit/9aab88c8bd745e624b6f3492f0ad7cf2c588676d) qbz: 1.2.14 -> 1.2.15
* [`aaf3376a`](https://github.com/NixOS/nixpkgs/commit/aaf3376a93021b96d79058994a7ba0b17d57cd6c) python3Packages.blobfile: migrate to pyproject
* [`6a245fcf`](https://github.com/NixOS/nixpkgs/commit/6a245fcf26534ee1d3755dbea5b8575533b64e0c) python3Packages.blobfile: modernize
* [`4e6a8838`](https://github.com/NixOS/nixpkgs/commit/4e6a8838d6d8f930523f43e01f83462f8f309c96) blazingjj: fix build
* [`15e1236a`](https://github.com/NixOS/nixpkgs/commit/15e1236a531ec75e2ae699a33e7f884e41aff8ec) weaviate: 1.37.4 -> 1.38.0
* [`2081c7ff`](https://github.com/NixOS/nixpkgs/commit/2081c7ffd4828dd6f857191e2b1edf7e9616e6fa) pragtical: 3.9.0 -> 3.11.2
* [`8dea1163`](https://github.com/NixOS/nixpkgs/commit/8dea11636de12461aea44d8618bf479da14bb4dc) oxicloud: remove target-cpu=native flag to make builds more portable
* [`d77b0f74`](https://github.com/NixOS/nixpkgs/commit/d77b0f7467e0c372addee5b18fd4abdd35e9fb65) microsoft-edge: 148.0.3967.83 -> 149.0.4022.52
* [`e59dabc4`](https://github.com/NixOS/nixpkgs/commit/e59dabc436e1f5c5edab0057915e210119c1fdec) zlequalizer: 1.1.1 -> 1.2.1
* [`16a2c8a3`](https://github.com/NixOS/nixpkgs/commit/16a2c8a348ee5b09e973fe9e2a45aedc565242a0) oci-cli: 3.84.0 -> 3.85.0
* [`55adea6c`](https://github.com/NixOS/nixpkgs/commit/55adea6c165fdc97ac8628b851837776e6cdcd34) crocoddyl: enable multithread
* [`b2afa58a`](https://github.com/NixOS/nixpkgs/commit/b2afa58a06df354b0f868b9542bac2c46bd16aca) mim-solvers: enable multithread
* [`5ced1bb0`](https://github.com/NixOS/nixpkgs/commit/5ced1bb0661c89afbdb9b2bc5b0b33f3a699b7c9) netbird: 0.71.4 -> 0.72.1
* [`23987400`](https://github.com/NixOS/nixpkgs/commit/23987400506c14d9f4e18bdf77eb01c57cff911b) netbird-dashboard: 2.38.1 -> 2.39.0
* [`50e92c43`](https://github.com/NixOS/nixpkgs/commit/50e92c439d4ca01d5461be3b3849c779ddccb143) librewolf: only do LTO on linux
* [`002daad8`](https://github.com/NixOS/nixpkgs/commit/002daad8e09cafd3adb71f35fe8b8a874f4308dd) llmfit: 0.9.28 -> 0.9.30
* [`cf4f3bc0`](https://github.com/NixOS/nixpkgs/commit/cf4f3bc0ff8409f4066e38196292d58830df507a) hubble: 1.19.3 -> 1.19.4
* [`1a80d9fb`](https://github.com/NixOS/nixpkgs/commit/1a80d9fbfd4d89be4e05646288ea28861937537f) orbstack: 2.1.3-20115 -> 2.2.1-20628
* [`d4889183`](https://github.com/NixOS/nixpkgs/commit/d4889183d92afa7e34c7a0231125470e2e25777a) ardour: 9.5 -> 9.7
* [`d6ced4c2`](https://github.com/NixOS/nixpkgs/commit/d6ced4c232dcaa9ffafc64a4bafff06dd5c8ae3e) python3Packages.exa-py: 2.12.0-unstable-2026-04-15 -> 2.13.1-unstable-2026-06-03
* [`4c462905`](https://github.com/NixOS/nixpkgs/commit/4c4629059d23a42f12dbd501acddddd371cfa70d) xev: adopt
* [`e082e86a`](https://github.com/NixOS/nixpkgs/commit/e082e86aaa1fc4f8474b2f8e5da4e0fc95c3d01f) samrewritten: 1.4.0 -> 1.4.2
* [`a0871bdc`](https://github.com/NixOS/nixpkgs/commit/a0871bdcb9de38b22889e00b6de0cea5ff30b4bb) rumdl: 0.2.2 -> 0.2.8
* [`5c42544d`](https://github.com/NixOS/nixpkgs/commit/5c42544d3a93855767a93a47182d289ccbb792f2) python3Packages.bluepy-devices: migrate to pyproject
* [`dd5da593`](https://github.com/NixOS/nixpkgs/commit/dd5da59395eaadfa7b37d2fcea853458b2e368d2) python3Packages.bond-api: migrate to pyproject
* [`8b52a252`](https://github.com/NixOS/nixpkgs/commit/8b52a252d6ac329e078a7845419905d57e1c7674) python3Packages.boa-api: migrate to pyproject
* [`5fd82807`](https://github.com/NixOS/nixpkgs/commit/5fd82807a708bd4c32b04d830f9321254a1e1776) python3Packages.bond-api: modernize
* [`eeb5f408`](https://github.com/NixOS/nixpkgs/commit/eeb5f408a6b5585abdd26cc0045c7a0ddebf0e71) python3Packages.boa-api: modernize
* [`2f3dc172`](https://github.com/NixOS/nixpkgs/commit/2f3dc172218e247c01b424715dc3baae84077fb7) python3Packages.applicationinsights: use __structuredAttrs
* [`16624665`](https://github.com/NixOS/nixpkgs/commit/16624665e40e8e2703eae974198009743693c82b) python3Packages.bluepy-devices: modernize
* [`f0fa9fd0`](https://github.com/NixOS/nixpkgs/commit/f0fa9fd068e6915a067c7c408900b4df5ffe7bdb) python3Packages.brottsplatskartan: migrate to pyproject
* [`46267d42`](https://github.com/NixOS/nixpkgs/commit/46267d428d9667b161f980eb9168e6c4abb213b3) python3Packages.brelpy: migrate to pyproject
* [`db6f5bca`](https://github.com/NixOS/nixpkgs/commit/db6f5bcae2efeed3d5b189fd148bda83e66c5f62) python3Packages.bravia-tv: migrate to pyproject
* [`0de00ad7`](https://github.com/NixOS/nixpkgs/commit/0de00ad7b907f8b6ba5a81cf92a3a70bdc3fc0b9) python3Packages.brelpy: modernize
* [`2aaa03fd`](https://github.com/NixOS/nixpkgs/commit/2aaa03fd309389d17ac58ca679589337364f8708) python3Packages.bt-proximity: migrate to pyproject
* [`0090e8fc`](https://github.com/NixOS/nixpkgs/commit/0090e8fcde7c4212372bdfd5543da4c23663e2af) python3Packages.brottsplatskartan: modernize
* [`45015a18`](https://github.com/NixOS/nixpkgs/commit/45015a185516e479a039341098ea982317bfe604) python3Packages.bravia-tv: modernize
* [`8372431e`](https://github.com/NixOS/nixpkgs/commit/8372431e85a92f2072f7b859f8ff90621135641e) python3Packages.brunt: migrate to pyproject
* [`aaf7cc98`](https://github.com/NixOS/nixpkgs/commit/aaf7cc98271189e348eba7d8af5407dbe0120528) python3Packages.bt-proximity: modernize
* [`98b2e390`](https://github.com/NixOS/nixpkgs/commit/98b2e390fc8bc3780438dcfcf28c599755720237) python3Packages.brunt: modernize
* [`b419a335`](https://github.com/NixOS/nixpkgs/commit/b419a335da28391508a400f817cfecfe72cc9713) python3Packages.cart: migrate to pyproject
* [`db9fab6d`](https://github.com/NixOS/nixpkgs/commit/db9fab6d4ceca03a0708131bf5e01cb11364f9d5) python3Packages.calysto: migrate to pyproject
* [`2f3bdc7f`](https://github.com/NixOS/nixpkgs/commit/2f3bdc7f64d5093d2c2698882efa7950a9e1d72b) python3Packages.cart: modernize
* [`1cfa9ce4`](https://github.com/NixOS/nixpkgs/commit/1cfa9ce4a598725721fdf133e1a21cb01bc058ea) python3Packages.calysto: modernize
* [`125de9a4`](https://github.com/NixOS/nixpkgs/commit/125de9a4c31aa3595aa5e5b1676bd69c9b0f14a3) stdenv: do not pass crossOverlays redundantly
* [`b9e52062`](https://github.com/NixOS/nixpkgs/commit/b9e52062740278903f9db96940a8a6803deaa4b2) stdenv: drop redundant crossOverlays defaults
* [`cf31d4eb`](https://github.com/NixOS/nixpkgs/commit/cf31d4eb3279707f3e995fb34ab29f2306a99e1c) python3Packages.viser: 1.0.29 -> 1.0.30
* [`8322afea`](https://github.com/NixOS/nixpkgs/commit/8322afea5d02c6e4d2a28a235a90922b9881e8b5) sub-store-frontend: 2.17.19 -> 2.17.31
* [`f37db05b`](https://github.com/NixOS/nixpkgs/commit/f37db05b879dadda9e48f3472f937909979b7c28) phpactor: 2025.12.21.1 -> 2026.05.30.1
* [`4a6c3b27`](https://github.com/NixOS/nixpkgs/commit/4a6c3b273e4f7d7fbd5a839dec2cab59c82b3d33) tt-topology: 1.2.13 -> 1.2.19
* [`dba33eec`](https://github.com/NixOS/nixpkgs/commit/dba33eec9edd3abd0b043246457e334ed38e83fe) atril: 1.28.5 -> 1.28.6
* [`7de43b90`](https://github.com/NixOS/nixpkgs/commit/7de43b90edb0f4d16132e4d1baba83a440e47295) zwave-js-ui: 11.19.0 -> 11.19.1
* [`d236a69d`](https://github.com/NixOS/nixpkgs/commit/d236a69de2b6964eef29920e1c9e07a4f29a51bf) emacsPackages.ghostel: 0.31.0-unstable-2026-06-01 -> 0.33.0-unstable-2026-06-06
* [`a9f5b0fa`](https://github.com/NixOS/nixpkgs/commit/a9f5b0fa43717857cb8badaeb337341cce71c84f) snixembed: modernize package, add maintainer
* [`4c34fd1a`](https://github.com/NixOS/nixpkgs/commit/4c34fd1a458fbfbd1bcc6ea2ff63879a93738da1) python3Packages.gguf: 9222 -> 9538
* [`25d7e26a`](https://github.com/NixOS/nixpkgs/commit/25d7e26a99a9347d102ade4ab5c4d16064649dc8) forgejo-cli: set __structuredAttrs, add versionCheckHook
* [`7e6e6d9b`](https://github.com/NixOS/nixpkgs/commit/7e6e6d9b496010bfb215bcbeb602efd052715c7e) netwatch: init at 0.25.4
* [`6f028a80`](https://github.com/NixOS/nixpkgs/commit/6f028a807eb3c007c4db8c26fa3883c8d07e3eeb) python3Packages.iamdata: 0.1.202606051 -> 0.1.202606061
* [`9486d44b`](https://github.com/NixOS/nixpkgs/commit/9486d44b015c520ec165d91df49e054715244f8f) librime: 1.16.1 -> 1.17.0
* [`66e9632c`](https://github.com/NixOS/nixpkgs/commit/66e9632c20a835283eb8e847b9cd69fbaf032f62) python3Packages.opower: 0.18.2 -> 0.18.3
* [`f32007bd`](https://github.com/NixOS/nixpkgs/commit/f32007bd08562de2e0129851254be75c1a257bf5) python3Packages.cpe-search: 0.2.8 -> 0.2.9
* [`9f9cea39`](https://github.com/NixOS/nixpkgs/commit/9f9cea391ede1f74757da3c97a28a5c2cf692444) python3Packages.aiostreammagic: 2.13.1 -> 2.13.2
* [`aa751c51`](https://github.com/NixOS/nixpkgs/commit/aa751c512f4a58bf97c712d6dd847cfd88d66e4a) tt-burnin: 0.2.4 -> 0.4.0
* [`2dc8368d`](https://github.com/NixOS/nixpkgs/commit/2dc8368de4bc2ba5b7e5274c116e867636e7e565) tt-burnin: remove pyluwen dependency relaxation
* [`d34c103d`](https://github.com/NixOS/nixpkgs/commit/d34c103df231f66aeec60c630ef8d9972dd6f7e0) python3Packages.strawberry-graphql: migrate to finalAttrs
* [`c451f91f`](https://github.com/NixOS/nixpkgs/commit/c451f91f5d000b1bc74e9f8b84dd474e4b62ea60) python3Packages.cross-web: 0.4.1 -> 0.7.0
* [`4c6d7913`](https://github.com/NixOS/nixpkgs/commit/4c6d79135e1fcc1d81769410d11c42e2110ebe53) python3Packages.strawberry-graphql: 0.289.2 -> 0.316.0
* [`6b6ae19d`](https://github.com/NixOS/nixpkgs/commit/6b6ae19d39a1cae69a4159bb3365b2c84f14e40c) python3Packages.strawberry-django: 0.75.1 -> 0.86.0
* [`e9b11db0`](https://github.com/NixOS/nixpkgs/commit/e9b11db082cd3e2b40eb15e9affafa8e654cabef) python3Packages.rpy2: 3.6.4 -> 3.6.7
* [`177e9f54`](https://github.com/NixOS/nixpkgs/commit/177e9f5409b1419cf2ea82543fb2a51fab9d0699) perlPackages.ArchiveTar: 3.10 -> 3.12
* [`3019e342`](https://github.com/NixOS/nixpkgs/commit/3019e3420b276ac969f3868a9e21437e16ba861d) domain-check: init at 1.0.2
* [`56892c17`](https://github.com/NixOS/nixpkgs/commit/56892c177ef779c2939f9998f58ed8bb0a929e54) python3Packages.unstructured: bundle NLTK data to fix import-time download
* [`cd0d93b5`](https://github.com/NixOS/nixpkgs/commit/cd0d93b50dffdb4c0f0fef6fc4c4591b2aa050d9) python3Packages.microsoft-kiota-authentication-azure: 1.10.1 -> 1.10.2
* [`9e959ee6`](https://github.com/NixOS/nixpkgs/commit/9e959ee6076a64c2d26d2df24daab010c5dec4c9) git-pages-cli: 1.8.2 -> 1.9.0
* [`29d33f76`](https://github.com/NixOS/nixpkgs/commit/29d33f76797e2dbc53dff9dacf2865413d8e0aae) jx: 3.17.1 -> 3.17.6
* [`85073b92`](https://github.com/NixOS/nixpkgs/commit/85073b9231b809f2b5be2cf7683dc85bf306daa9) keep-sorted: 0.8.0 -> 0.9.0
* [`f5316f16`](https://github.com/NixOS/nixpkgs/commit/f5316f16f6114a955bb0e201c4a9259de8af72ef) python3Packages.pyluwen: cleanup
* [`32aad6a0`](https://github.com/NixOS/nixpkgs/commit/32aad6a0c07602cd06347006e9bb70168b976f3c) python3Packages.tt-flash: cleanup, enable tests
* [`4e336001`](https://github.com/NixOS/nixpkgs/commit/4e336001b4fcbf7fc0873d0e973ab8fa7cd5df65) codex: 0.136.0 -> 0.137.0
* [`4e861c21`](https://github.com/NixOS/nixpkgs/commit/4e861c2161d192c3964ede870a2d7cca71457d5b) nixos/mautrix-discord: refactor
* [`ad68e829`](https://github.com/NixOS/nixpkgs/commit/ad68e8293e0b64973789b162403290e7c045cf49) principia: 2025.04.05 -> 2026.06.06
* [`5760cf80`](https://github.com/NixOS/nixpkgs/commit/5760cf8087080677622a1083bc5181be227acb5c) python3Packages.fastapi-pagination: 0.15.13 -> 0.15.14
* [`75ca23c8`](https://github.com/NixOS/nixpkgs/commit/75ca23c8314fd98d2e048a9a979343084f0cab0b) tt-smi: add changelog
* [`6ef31ad2`](https://github.com/NixOS/nixpkgs/commit/6ef31ad2f4e75cf137bf548e800948f6015ac580) vscode-extensions.ms-python.black-formatter: 2026.4.0 -> 2026.6.0
* [`8416fbe5`](https://github.com/NixOS/nixpkgs/commit/8416fbe563c38ab35c0ec57515262fef1220ff4f) renode-dts2repl: 0-unstable-2026-05-19 -> 0-unstable-2026-05-28
* [`1f108de9`](https://github.com/NixOS/nixpkgs/commit/1f108de93450ad0c26c63c23a231e197f9e5b82f) libgourou: 0.8.8 -> 0.8.9
* [`e4c958a6`](https://github.com/NixOS/nixpkgs/commit/e4c958a6390ad28a78320854f1fc9618d8538f79) apktool: 2.2.1 -> 3.0.2
* [`d4d0ba39`](https://github.com/NixOS/nixpkgs/commit/d4d0ba39c66fa8ec4e1be1c3161314829bfbe663) deno: avoid functions in tests array
* [`aa5bfc91`](https://github.com/NixOS/nixpkgs/commit/aa5bfc912568458c8bf879ebfaf8e5e8856e700c) leanify: 0.4.3-unstable-2025-12-12 -> 0.4.3-unstable-2026-06-05
* [`8bbe6ec5`](https://github.com/NixOS/nixpkgs/commit/8bbe6ec5c9373fd8b899e9510fede169b3f71647) pt2-clone: 1.88 -> 1.89
* [`449258d6`](https://github.com/NixOS/nixpkgs/commit/449258d6b1bac0e4633bf9c4098df0d99b81707f) graphite: 0-unstable-2026-05-25 -> 0-unstable-2026-06-06
* [`cbbbe5d4`](https://github.com/NixOS/nixpkgs/commit/cbbbe5d41a75c74de6717e596904a63a1029eaed) kilo: init at 7.3.40
* [`273cbef2`](https://github.com/NixOS/nixpkgs/commit/273cbef2d907d6d59fc146c0701a3c7fcee381c2) kilocode-cli: drop package, recommend kilo
* [`88fa806e`](https://github.com/NixOS/nixpkgs/commit/88fa806e94dba526c186b2155de3fe571172df40) python3Packages.claude-agent-sdk: 0.2.91 -> 0.2.93
* [`c6124f5a`](https://github.com/NixOS/nixpkgs/commit/c6124f5ab1c10d00c7dda53abb057c635bedb6bf) satty: 0.20.1 -> 0.21.1
* [`7769f4e3`](https://github.com/NixOS/nixpkgs/commit/7769f4e3ee5ed204d4c560083dbd364150dfcfef) apm-cli: 0.15.0 -> 0.18.0
* [`7a3739e1`](https://github.com/NixOS/nixpkgs/commit/7a3739e1350b1e5a85aaca47c4ac7225b44a6859) simh: bump to pcre2
* [`ed8bb235`](https://github.com/NixOS/nixpkgs/commit/ed8bb235409babb92ebc8c2d5a2e490e0bb9a36c) kulala-core: 0.13.0 -> 0.14.1
* [`67dac1e2`](https://github.com/NixOS/nixpkgs/commit/67dac1e20de412fc55d18bd3b9cb58f27b98e133) inspircd: 4.10.1 -> 4.11.0
* [`21963ee1`](https://github.com/NixOS/nixpkgs/commit/21963ee1bc53c74a64af40e0dfb6541c2d0a9d34) kulala-fmt: 1.4.0 -> 3.1.0
* [`cfad9787`](https://github.com/NixOS/nixpkgs/commit/cfad978796f5f7c36dc180f3ab40227c214bca5f) matterjs-server: add myself as a maintainer
* [`c8b54a3b`](https://github.com/NixOS/nixpkgs/commit/c8b54a3b4c668a3039b299b7895ab8b3e2e43233) umockdev: fix musl build
* [`95f66653`](https://github.com/NixOS/nixpkgs/commit/95f66653f3b00c5a4a248601d9cb81ac0e1b3234) cockpit-files: 40 -> 41
* [`5028aec7`](https://github.com/NixOS/nixpkgs/commit/5028aec7a081371b243491e7e14bbc8d56758517) cockpit-podman: 126 -> 127
* [`3cf8ae56`](https://github.com/NixOS/nixpkgs/commit/3cf8ae56a23af920dc793a43e96bfdde1fdfb9f4) vimPlugins.*: ensure `passthru.vimPlugin = true`
* [`16fbaedc`](https://github.com/NixOS/nixpkgs/commit/16fbaedc1bb2fe457b981d7ea4cc0347fe4870c2) repath-studio: 0.4.14 -> 0.4.15
* [`8555f757`](https://github.com/NixOS/nixpkgs/commit/8555f757532973e5d38cd1a550382ed3e119b467) objfw: 1.5.4 -> 1.5.5
* [`fe5499dc`](https://github.com/NixOS/nixpkgs/commit/fe5499dc0289926584c7cccbb491e5331ebee2c0) iaito: 6.1.4 -> 6.1.6
* [`560a2a82`](https://github.com/NixOS/nixpkgs/commit/560a2a82755c5984cf4b74f646b2bae26d30a600) lasuite-docs{,-frontend,-collaboration-server}: 5.2.0 -> 5.2.1
* [`40f77ee5`](https://github.com/NixOS/nixpkgs/commit/40f77ee5620658cbcd57338c8adeaa838d6f271d) gvm-libs: 23.1.0 -> 23.2.2
* [`d332e23d`](https://github.com/NixOS/nixpkgs/commit/d332e23d908bfe6477082dc2dc92dad9ede5f4f1) python3Packages.whichcraft: use finalAttrs
* [`8bd5bfec`](https://github.com/NixOS/nixpkgs/commit/8bd5bfeceb3880ba7b850ce6f9cb2e8855bcd806) python3Packages.whichcraft: cleanup unused glibcLocales
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
