### PR TITLE
npins nixpkgs: update 8c3cede7 -> 9f11f828

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -120,8 +120,8 @@
       "type": "Channel",
       "name": "nixpkgs-unstable",
       "artifact": "nixexprs.tar.xz",
-      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-26.11pre1012902.8c3cede7ddc2/nixexprs.tar.xz",
-      "hash": "sha256-omq0piVC7vKHVxfJi9uIW1EHQLsFSnDhbkLeO2rkSyw="
+      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-26.11pre1015979.9f11f828c213/nixexprs.tar.xz",
+      "hash": "sha256-X8fdRtvrm8OHLZ6Lkg3ZAQm5N6we5mLkdYd92vAw4c8="
     },
     "powerlevel10k": {
       "type": "Git",


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: release-26.11
Commits: [nixos/nixpkgs@8c3cede7...9f11f828](https://github.com/nixos/nixpkgs/compare/8c3cede7ddc2...9f11f828c213)

* [`fbb4ad46`](https://github.com/NixOS/nixpkgs/commit/fbb4ad46da8cd6ab1da3a6b6994059fe6d178f97) rr: enable 32bit support
* [`dfe9e8f3`](https://github.com/NixOS/nixpkgs/commit/dfe9e8f3379665b49617fa0737cf679bbd46c361) dfmt: migrate to pyproject build
* [`65fc6f6c`](https://github.com/NixOS/nixpkgs/commit/65fc6f6cc45468877e3f87b693ce631f25cbdad5) python3Packages.flask-socketio: 5.6.0 -> 5.6.1
* [`3f12ac50`](https://github.com/NixOS/nixpkgs/commit/3f12ac50c2f47b3c862ed88bb6aa25ec78dc76cf) maintainers: add xelacodes
* [`819c8180`](https://github.com/NixOS/nixpkgs/commit/819c818085af709f9607aea1999044c4d9f8e75d) colloid-cursors: init at 2025-07-19
* [`9b4159b0`](https://github.com/NixOS/nixpkgs/commit/9b4159b067f2411136e8422cc444e174bf607f03) mailmap: add dblsaiko
* [`e0c6bed8`](https://github.com/NixOS/nixpkgs/commit/e0c6bed8b97edd1301d57df5d3a3bfe9bc40c043) granted: point to fwdcloudsec github org
* [`0b8f3fac`](https://github.com/NixOS/nixpkgs/commit/0b8f3faca8408c07184675af49f832f7de498706) granted: 0.38.0 -> 0.39.0
* [`bb91a2d2`](https://github.com/NixOS/nixpkgs/commit/bb91a2d28ed24193ff98f4e56c939f92664348de) granted: update changelog URL
* [`ad3d3788`](https://github.com/NixOS/nixpkgs/commit/ad3d3788cdee87ef3a9f7bb70d7b5f95c70a0005) granted: point to release tag
* [`6bfa3481`](https://github.com/NixOS/nixpkgs/commit/6bfa34810938d6f658017ef27abe25e9f0fe05de) kubernetes-helmPlugins.helm-secrets: 4.6.10 -> 4.7.6
* [`6fe4a861`](https://github.com/NixOS/nixpkgs/commit/6fe4a8611c1f0ed90836c9c4183c4e8122d09a7d) maintainers: add gamebeaker
* [`89deb50e`](https://github.com/NixOS/nixpkgs/commit/89deb50e590e7e828720f9af1ac0afc0a386f576) enpass: fix updater script
* [`0bd48eae`](https://github.com/NixOS/nixpkgs/commit/0bd48eae0dad5f4b65d970a754aae579517d10a6) python3Packages.gradient: overhaul package
* [`0790cda9`](https://github.com/NixOS/nixpkgs/commit/0790cda9c44d09709f7802afe87c3b840e7825bf) feedbackd: 0.8.5 -> 0.8.9
* [`8e36f892`](https://github.com/NixOS/nixpkgs/commit/8e36f892744761a8d6f6eed2d8d400abd1829d82) foks: init at 0.1.7
* [`68200e0a`](https://github.com/NixOS/nixpkgs/commit/68200e0a0c83cd3d11a699788146b0a600024c3e) alvr: add patch to make alvr work with steam bubblewrap
* [`9f327470`](https://github.com/NixOS/nixpkgs/commit/9f327470dce404b8ada3a731190e66623a706b4e) python3Packages.inkex: Apply patch to fix binary DXF parsing on big-endian
* [`13d71c3e`](https://github.com/NixOS/nixpkgs/commit/13d71c3e328869c5f19da2e5590aa36951a1007d) nixos/espanso: add extraPackages option
* [`bd67210a`](https://github.com/NixOS/nixpkgs/commit/bd67210ad907e3adc402640d77eb8321ad03db1c) cantata: 3.3.1 -> 3.4.0
* [`c69f4749`](https://github.com/NixOS/nixpkgs/commit/c69f4749777c9d9f6d60ffb77cc6ebbf701b71bc) rink: 0.8.0 -> 0.9.0
* [`6637829d`](https://github.com/NixOS/nixpkgs/commit/6637829dfb0b462c79b50a688e4c5fa1b071eecc) cocogitto: update meta.homepage
* [`c34c32eb`](https://github.com/NixOS/nixpkgs/commit/c34c32eb75ce7efb5da4d3d62915febddf4668a2) cocogitto: add meta.changelog
* [`0eb7a631`](https://github.com/NixOS/nixpkgs/commit/0eb7a6310f153a09a752201858cdafc55f6281fe) envoy-bin: 1.37.2 -> 1.38.0
* [`c31ef2b5`](https://github.com/NixOS/nixpkgs/commit/c31ef2b5e1f62bbfb165f08c8975d198ea1ac701) openshadinglanguage: adopt
* [`b482e627`](https://github.com/NixOS/nixpkgs/commit/b482e627f548e5c3acfb4f2fac18c2f8045c9043) openshadinglanguage: unpin llvm
* [`1a9a7113`](https://github.com/NixOS/nixpkgs/commit/1a9a7113b6b7d59033c8ed8faa325fd63175948e) openshadinglanguage: use cmakeBool & cmakeFeature helpers
* [`e70f67cf`](https://github.com/NixOS/nixpkgs/commit/e70f67cf0f6e89e928e7fc0250fdb52aafc65e77) openshadinglanguage: prefer hexdump over full util-linux
* [`52edbc50`](https://github.com/NixOS/nixpkgs/commit/52edbc5063d54387398d71985c00bfd195cb4948) openshadinglanguage: remove unused cmake flags
* [`5cdc8469`](https://github.com/NixOS/nixpkgs/commit/5cdc846972cb4d8a7f86b5b07cc3a583a7c690f2) openshadinglanguage: explicitly disable Qt to avoid warnings
* [`2f1ec9fe`](https://github.com/NixOS/nixpkgs/commit/2f1ec9fe15f3e5ae4adf631d685c6261ba001eac) openshadinglanguage: prefer postPatch over prePatch
* [`9968c005`](https://github.com/NixOS/nixpkgs/commit/9968c005f713a898727e06ae79dab8ecebff47e7) maintainers: add ReStranger
* [`b5bc8750`](https://github.com/NixOS/nixpkgs/commit/b5bc87500557f9f3af6a8374a0946483e8132bbc) open-websearch: init at 1.2.7
* [`ede6728e`](https://github.com/NixOS/nixpkgs/commit/ede6728ec56c3a1b81b8f1d6a4f7ddbe5fab09f4) undercut-f1: 3.4.32 -> 4.0.73
* [`150e0a85`](https://github.com/NixOS/nixpkgs/commit/150e0a850a067872ccbf2d699b4511a2b9185d57) tetrio-desktop: fix StartupWMClass for Wayland dock icon matching
* [`a8e71cb4`](https://github.com/NixOS/nixpkgs/commit/a8e71cb4121cbd79f1e26b1b1f345ef924a43eb6) vscode-extensions.wgsl-analyzer.wgsl-analyzer: 0.11.262 -> 0.11.318
* [`f01108c7`](https://github.com/NixOS/nixpkgs/commit/f01108c715dad46eb6c57675860aa7ce2503fd95) python3Packages.ossapi: 5.3.4 -> 5.3.5
* [`8f1ac3b3`](https://github.com/NixOS/nixpkgs/commit/8f1ac3b3a04add6310cfbfaa26560f32dd44c7c0) morse_cli: 1.16.4 -> 1.17.8
* [`0f7a408c`](https://github.com/NixOS/nixpkgs/commit/0f7a408c7f3fec3e070012cb64cc6777fc991894) python3Packages.devpi-web: 5.0.2 -> 5.1.0
* [`e074cce0`](https://github.com/NixOS/nixpkgs/commit/e074cce0cc53f0bd02f39671a514a3d30a537098) nethack: 3.6.7 -> 5.0.0
* [`bc672dd0`](https://github.com/NixOS/nixpkgs/commit/bc672dd0eb6684dc42da47e81c95e5af93190b5b) mrustc.bootstrap: fix build
* [`48432ffe`](https://github.com/NixOS/nixpkgs/commit/48432ffec54c4f66524b8b2797dcd6c178b64233) gitbutler: 0.19.7 -> 0.19.9
* [`4b85bbcd`](https://github.com/NixOS/nixpkgs/commit/4b85bbcd387256718c92de5bdceaad9e307cf939) xmp: 4.2.0 -> 4.3.0
* [`8c81cf53`](https://github.com/NixOS/nixpkgs/commit/8c81cf53d34fc3e551b27e97870cf11eb20c3dd2) enpass: fix updater script
* [`c9b268ee`](https://github.com/NixOS/nixpkgs/commit/c9b268ee8dc0ffa6c78700a80cce8dd9d37ec52f) traccar: 6.13.0 -> 6.13.3
* [`9faac3d4`](https://github.com/NixOS/nixpkgs/commit/9faac3d4a3e0fc6258c67dcbaf9757d9f5c8301e) wluma: 4.10.0 -> 4.11.1
* [`a4112cd3`](https://github.com/NixOS/nixpkgs/commit/a4112cd368ac0535a44a9b0f282333eb2b706251) phpExtensions.relay: Fix wrong dylib mapping in Darwin
* [`b30e51cb`](https://github.com/NixOS/nixpkgs/commit/b30e51cb3cf155c3f5c4a78369b98ad3eeafb2f8) wt: 4.12.0 -> 4.13.2
* [`cca19383`](https://github.com/NixOS/nixpkgs/commit/cca19383435dc863fbde0add50b539992628d1b1) flink: 2.2.0 -> 2.2.1
* [`014cee4e`](https://github.com/NixOS/nixpkgs/commit/014cee4ea6623854f054c26ff3ff6d2aeebeb87e) ghostfolio: reduce closure size
* [`a2bce4fd`](https://github.com/NixOS/nixpkgs/commit/a2bce4fdec13308bb6d709448da09d96ec01c445) ghostfolio: 2.254.0 -> 3.2.0, refactor
* [`1f060bfb`](https://github.com/NixOS/nixpkgs/commit/1f060bfb291f422728ae46b6f750c846269e7bba) ghostfolio: add ghostfolio-migrate helper
* [`e6f3d581`](https://github.com/NixOS/nixpkgs/commit/e6f3d5813e58fc1a9124151276d1170e4840c8a0) jetbrains.datagrip: 2026.1.2 -> 2026.1.3
* [`7b761eb5`](https://github.com/NixOS/nixpkgs/commit/7b761eb5740048334bd964926f85332f033f8455) cproto: 4.7y -> 4.8
* [`691c239a`](https://github.com/NixOS/nixpkgs/commit/691c239a1e8ed735e4661099307b6137425f1a45) vk-bootstrap: 1.4.341 -> 1.4.350
* [`1ac185bf`](https://github.com/NixOS/nixpkgs/commit/1ac185bf1bade4202a89ca14fcb62434e133d72f) nethack: Convert the preBuild hook into a postUnpack hook
* [`052b7cc9`](https://github.com/NixOS/nixpkgs/commit/052b7cc9adb0b0d1107e99a2812ff7d2922d375f) nethack: Support cross compilation
* [`bbbb21db`](https://github.com/NixOS/nixpkgs/commit/bbbb21dbe8b7abae42785cabd51b0387eed14d5a) nethack: Only patch the QT settings if qtMode is enabled
* [`7db38460`](https://github.com/NixOS/nixpkgs/commit/7db384606adddb0569fe7c8d5d12db4d6fccfc82) telegram-desktop: 6.8.1 -> 6.8.2
* [`1f5efb34`](https://github.com/NixOS/nixpkgs/commit/1f5efb34d7116e0e704a9ca9576a1688bea07fbe) _64gram: 1.2.1 -> 1.2.2
* [`ef4ebc2a`](https://github.com/NixOS/nixpkgs/commit/ef4ebc2ac90a240196707d735382007b1a6a6aee) nih-plug: init at 0-unstable-2026-05-10
* [`84e9acce`](https://github.com/NixOS/nixpkgs/commit/84e9acce9c5836c27314469666d78c6b9065964b) joplin-cli: 3.5.1 -> 3.6.2
* [`92befa42`](https://github.com/NixOS/nixpkgs/commit/92befa42b6f0fe3291b76814a1667df54f2b08f3) aiken: 1.1.21 -> 1.1.22
* [`a6fbaa15`](https://github.com/NixOS/nixpkgs/commit/a6fbaa1536b302228f8e203b7150bea9886098b8) blast: Add optional OpenMP dependency for Darwin builds
* [`fb0d18ee`](https://github.com/NixOS/nixpkgs/commit/fb0d18ee0b5cff8781c9271772d10d40cabb10e1) testers.lycheeLinkCheck: improve root-relative link UX
* [`c602aa67`](https://github.com/NixOS/nixpkgs/commit/c602aa679a03632a16495ebb932dd4a5820a8b60) six-sines: init at 1.1.0
* [`96e83603`](https://github.com/NixOS/nixpkgs/commit/96e83603fc5221e78e319bba9cce6f001a510844) hstr: 3.1 -> 3.2
* [`04875712`](https://github.com/NixOS/nixpkgs/commit/0487571275fd4fc52c7483bdbb5e5b8dcc2c15e6) ghostfolio: 3.2.0 -> 3.3.0
* [`f60b3ffd`](https://github.com/NixOS/nixpkgs/commit/f60b3ffdd5cc39f16e0c275dc353a3bb0d87d63b) nvtop: Migrate to cudaPackages
* [`33f539df`](https://github.com/NixOS/nixpkgs/commit/33f539df43ae63a09cb69baec738fb43f073e5b4) playwright: 1.59.1 -> 1.60.0
* [`e5ee7648`](https://github.com/NixOS/nixpkgs/commit/e5ee7648ffafe813589928af00970992be5cf7d2) n8n-task-runner-launcher: 1.4.5 -> 1.4.6
* [`fbf4cf25`](https://github.com/NixOS/nixpkgs/commit/fbf4cf2572696c9ddf55751a44009ec415a2ba25) obelisk: migrate to by-name
* [`ad6f2b7e`](https://github.com/NixOS/nixpkgs/commit/ad6f2b7e625fb74fae52dc775f915007e48c15c4) obelisk: modernize derivation
* [`4959eee3`](https://github.com/NixOS/nixpkgs/commit/4959eee3f3b025333957e1162bced7ddd2746347) nixos/systemd/user: drop `with lib;`
* [`0522a75d`](https://github.com/NixOS/nixpkgs/commit/0522a75d354be5d3de10291751d7d58fb4ab84a3) nixos/systemd/user: migrate to RFC 42-style settings
* [`3265da50`](https://github.com/NixOS/nixpkgs/commit/3265da502367f49276d651dfd8155def7aa69586) python3Packages.ultralytics: 8.4.48 -> 8.4.51
* [`e5c2d65f`](https://github.com/NixOS/nixpkgs/commit/e5c2d65fddaf7377abc397f4f037eb6240b528f9) python3Packages.multiregex: 2.0.3 -> 2.0.4
* [`01c12cc0`](https://github.com/NixOS/nixpkgs/commit/01c12cc0443dd411f430baf76aebb8594094f6ea) vcv-rack: fix missing translations
* [`c6a76137`](https://github.com/NixOS/nixpkgs/commit/c6a76137b96a25c8823f4ad6a88fda1b83b6d94e) vcv-rack: fix version
* [`680e579d`](https://github.com/NixOS/nixpkgs/commit/680e579db109cc3be0e22b9b52293afcb46259fe) wlr-layout-ui: 1.6.16 -> 2.0.0
* [`526d0dec`](https://github.com/NixOS/nixpkgs/commit/526d0decdc1af0b2cd1e5a1794a2603548f514cf) oxidized: 0.36.0 -> 0.37.0
* [`1ad86eaf`](https://github.com/NixOS/nixpkgs/commit/1ad86eaf48cf79745beb0dce805d00c0d426398b) virtualbox: fix short-path-literals
* [`aed87cc1`](https://github.com/NixOS/nixpkgs/commit/aed87cc15f7d2a9733751583b64b3d1f5248d875) maestro: 2.5.1 -> 2.6.0
* [`05dce57d`](https://github.com/NixOS/nixpkgs/commit/05dce57d817d45c098f996127e46d07c4d8b3daa) python3Packages.slack-sdk: 3.41.0 -> 3.42.0
* [`7a041511`](https://github.com/NixOS/nixpkgs/commit/7a0415116e29c9325dbf666a2f98f7b4a76b9344) libgcc: replace usage of libgcc.lib with libgcc
* [`ed081185`](https://github.com/NixOS/nixpkgs/commit/ed081185c68fc43c506ad70f55585419c8edaf0b) mixing-station: 2.9.1 -> 2.9.3
* [`64a6456f`](https://github.com/NixOS/nixpkgs/commit/64a6456f520d39e8439f9a1ef613e9040ec4bb5e) nixos/foot: fix zsh prompt marker precmd function being overwritten by the end pipe marker precmd function
* [`691ddc98`](https://github.com/NixOS/nixpkgs/commit/691ddc98741b348e1eddf4d4aa07d4aa59467431) swayimg: 4.7 -> 5.2
* [`bd16774e`](https://github.com/NixOS/nixpkgs/commit/bd16774efe524eb841b240cb152b4c49ccb7069b) clash-verge-rev: 2.4.7 -> 2.5.1
* [`5319be66`](https://github.com/NixOS/nixpkgs/commit/5319be66952711a42be8ad027e9b0681a122efcd) coq-lsp: add `$OCAMLFIND_DESTDIR` to wrapper `OCAMLPATH`
* [`3fd7307e`](https://github.com/NixOS/nixpkgs/commit/3fd7307e917a3a98a7a40d6b9c3c03656eb20ddd) nixos/clash-verge: add StateDirectory for clash-verge-service
* [`3bd8e168`](https://github.com/NixOS/nixpkgs/commit/3bd8e1683294c0179cc6bc5ae00b37287578e34c) krita: add gapps wrapper
* [`26e668a0`](https://github.com/NixOS/nixpkgs/commit/26e668a09ab3bb0ca6d2a6e70afac733ccf49c20) ivpn-service: support quantum resistance
* [`d633cae7`](https://github.com/NixOS/nixpkgs/commit/d633cae73b72cf70737f5f78db3e755dbd83f884) ivpn-service: drop redundant update script
* [`a557cbe7`](https://github.com/NixOS/nixpkgs/commit/a557cbe75fd6b8ef6689c7ae51adaa53fed86fec) ivpn-service: vendor liboqs 0.10.0
* [`068be896`](https://github.com/NixOS/nixpkgs/commit/068be8967670418fa129b0c48453653122a8bf99) decent-sampler: use autoPatchelfHook
* [`0c81de6e`](https://github.com/NixOS/nixpkgs/commit/0c81de6eb3e8be55c05038b64cf413a5735b5c6f) cinny{-unwrapped,-desktop}: 4.12.1 -> 4.12.2
* [`4b54aa4a`](https://github.com/NixOS/nixpkgs/commit/4b54aa4ad3ff5e3630e82e055b1708744df5745f) utterly-nord-plasma: add qsvg to propagatedBuildInputs
* [`1cc0e9f8`](https://github.com/NixOS/nixpkgs/commit/1cc0e9f84a256b73e41e104089bf213880124127) utterly-nord-plasma: 3.2->3.3
* [`55854843`](https://github.com/NixOS/nixpkgs/commit/55854843924fbf0a590c44efe817c5fee6b16f44) ocamlPackages.dockerfile: 8.3.9 -> 8.4.0
* [`d678f570`](https://github.com/NixOS/nixpkgs/commit/d678f570f0db627853794fe1a732208cfe97d659) psrecord: 1.2 -> 1.4
* [`f3c59a78`](https://github.com/NixOS/nixpkgs/commit/f3c59a7864e0429579f7037a8293896e6265bae7) altair: 8.5.0 -> 8.5.3
* [`773fcd0f`](https://github.com/NixOS/nixpkgs/commit/773fcd0f36b0d9c356318a57b0da7948bb0ccfa5) psrecord: move to pkgs/by-name
* [`7d6cf9c9`](https://github.com/NixOS/nixpkgs/commit/7d6cf9c926726ae770b2054f6e6e7b30373dcd46) kicad: Fix rebuild when `compressStep = false`
* [`70b397a7`](https://github.com/NixOS/nixpkgs/commit/70b397a734f4c6ff740615a860acb39bb15571f4) python3Packages.veryprettytable: migrate to pyproject
* [`c3e3ac45`](https://github.com/NixOS/nixpkgs/commit/c3e3ac4553fe5f07981659b1de7f11c9f968bde1) python3Packages.veryprettytable: modernize
* [`0bfaeeec`](https://github.com/NixOS/nixpkgs/commit/0bfaeeec170446a2d93f0d833c08a3baf31c798c) python3Packages.veryprettytable: add pythonImportsCheck
* [`116c3a4a`](https://github.com/NixOS/nixpkgs/commit/116c3a4a700fa3eee0726048c3a0d85e81e7202d) chromium-xorg-conf: drop
* [`71cd871a`](https://github.com/NixOS/nixpkgs/commit/71cd871a03c5d345e5c385b1aeb9ee05e2425547) ibm-plex: 1.1.0 -> 0-unstable-2026-02-12, refactor
* [`69dc1431`](https://github.com/NixOS/nixpkgs/commit/69dc143196c755733f487286bae033c08a53421b) ibm-plex: add update script
* [`8f923979`](https://github.com/NixOS/nixpkgs/commit/8f923979aa877a7551785ddff9f2cf26ac071291) ibm-plex: add maintainer magicquark
* [`ecd3f46f`](https://github.com/NixOS/nixpkgs/commit/ecd3f46f7214ed3f7b27081e61db63a163ba0d13) raylib: 5.5-unstable-2026-01-20 -> 6.0
* [`39c6385b`](https://github.com/NixOS/nixpkgs/commit/39c6385b1db711ed9fc3a7cd5ca412235ec60dca) raylib: refactor
* [`8267aca0`](https://github.com/NixOS/nixpkgs/commit/8267aca00f0b1597a024e6b239093a70ecd6b45a) raylib-games: 2022-10-24 -> 2026-05-07
* [`41c78523`](https://github.com/NixOS/nixpkgs/commit/41c785231dfdb3b0ac58760b8a53837a17bd475c) haruna: 1.7.1 -> 1.8.1
* [`fe37bcee`](https://github.com/NixOS/nixpkgs/commit/fe37bcee2260eada371799ce30f19b534e252d66) vmTools: add Ubuntu 26.04 "Resolute" (amd64) disk image
* [`12f6043d`](https://github.com/NixOS/nixpkgs/commit/12f6043d9e52cf8b44a1974a3e79c6ff946a7e53) helmfile: 1.5.0 -> 1.5.2
* [`c3118ee9`](https://github.com/NixOS/nixpkgs/commit/c3118ee9d52cb8f795b103b0a0db5a9c6acc4d42) rubyPackages.openssl: drop openssl_1_1 support
* [`3141dfe1`](https://github.com/NixOS/nixpkgs/commit/3141dfe178a7b41a89c8ddd0e66bf52947d2ab53) qui: update pnpmDeps' fetcherVersion from 3 to 4
* [`8925b496`](https://github.com/NixOS/nixpkgs/commit/8925b49673f2c05b1da0df0fd053eef6ce236872) maintainers: add jpz13
* [`0643642d`](https://github.com/NixOS/nixpkgs/commit/0643642d9e77e136259027ebed2e0bbab0d58fa4) phpExtensions.blackfire: 1.92.51 -> 2026.5.0
* [`f4e695b9`](https://github.com/NixOS/nixpkgs/commit/f4e695b936c017ee63ac0e27d6c9d9bbbdb5b126) python314Packages.slixmpp: 1.13.2 -> 1.15.0
* [`3ed30090`](https://github.com/NixOS/nixpkgs/commit/3ed300907a6b5ccd3d963cea89d98c4fd4317025) poezio: 0.16 -> 0.18
* [`abde2d14`](https://github.com/NixOS/nixpkgs/commit/abde2d14045fdf24299824ab0638272722efca8c) vscode-extensions.yzane.markdown-pdf: 2.0.1 -> 2.1.0
* [`c73f751b`](https://github.com/NixOS/nixpkgs/commit/c73f751b5d2a5760002e903f6c03ee5de16f42e3) vmTools: update Ubuntu 26.04 commit hashes
* [`7c69005b`](https://github.com/NixOS/nixpkgs/commit/7c69005b703555af1e42535b350c40f7c9d7daea) ethercat: add myself as maintainer, fix license(s)
* [`af49b2a0`](https://github.com/NixOS/nixpkgs/commit/af49b2a0b0134dce99c92d28b9b76bbe04ec0c86) ethercat: add kernel module
* [`64e9c87f`](https://github.com/NixOS/nixpkgs/commit/64e9c87fd740c86ad403400c4abeef794a56dc47) python3Packages.githubkit: mark as broken
* [`84768b3f`](https://github.com/NixOS/nixpkgs/commit/84768b3f75ca5164aa131e08890c05e296f32200) cloudflared: 2026.5.0 -> 2026.5.2
* [`dde9088e`](https://github.com/NixOS/nixpkgs/commit/dde9088ecd1092ef63e45f880165a428c761ffe3) pipekit: init at 6.65.5
* [`e9ef4e8a`](https://github.com/NixOS/nixpkgs/commit/e9ef4e8a7f7a759c5e3c07155a4b33f9c7304b55) level-zero: 1.28.5 -> 1.29.0
* [`b9c2225a`](https://github.com/NixOS/nixpkgs/commit/b9c2225ad4b2859f7dfa7e5af83ca000062d73fd) gr-dect2: init at 0-unstable-2025-03-16
* [`ba4ffb96`](https://github.com/NixOS/nixpkgs/commit/ba4ffb966720b341926b365dec77a1f1b42dfea3) pipeform: init at 0.2.1
* [`e1a6d858`](https://github.com/NixOS/nixpkgs/commit/e1a6d85802413bc6991b0699f892b0c76fed2e47) nixos/boinc: update documentation link
* [`f41804ec`](https://github.com/NixOS/nixpkgs/commit/f41804ec3c3cfcff202c613f83aaf341f578b752) python3Packages.slixmpp: migrate to finalAttrs
* [`29c6bc3a`](https://github.com/NixOS/nixpkgs/commit/29c6bc3a70efb53ff9492be949162219bed98e9d) plasticity: 25.3.9 -> 26.1.3
* [`307bc0c0`](https://github.com/NixOS/nixpkgs/commit/307bc0c0f96c77d6d5022b96fdd308c438881f63) scid-vs-pc: fix build with Tcl stubs default
* [`b00f8202`](https://github.com/NixOS/nixpkgs/commit/b00f8202555887a1640bae96d193480dae04de95) openfga-cli: 0.7.13 -> 0.7.15
* [`2f3422d3`](https://github.com/NixOS/nixpkgs/commit/2f3422d38d70c43a460b3fd70cfef508a1a28309) vscode-extensions.vscjava.vscode-java-pack: 0.30.5 -> 0.31.0
* [`76a4151d`](https://github.com/NixOS/nixpkgs/commit/76a4151ddca8a55019f05a9be76245248a368c66) gonic: make mpv dependency optional
* [`1dcccc09`](https://github.com/NixOS/nixpkgs/commit/1dcccc09c474281350857afe49f6658206b8a1c3) python3Packages.lifx-async: 5.4.8 -> 5.4.9
* [`2d38bc35`](https://github.com/NixOS/nixpkgs/commit/2d38bc350af1de60838c1199a960b8df43768cdb) python3Packages.primp: 1.3.0 -> 1.3.1
* [`04eddd1d`](https://github.com/NixOS/nixpkgs/commit/04eddd1d5fcc13c9abcdc4951ee9c405f57896a2) atkmm: 2.28.4 -> 2.28.5
* [`92cab69c`](https://github.com/NixOS/nixpkgs/commit/92cab69cba8bb4dfda1aeeac88c03c27af39d86b) python3Packages.glean-parser: 19.0.0 -> 19.2.0
* [`cb2fdc48`](https://github.com/NixOS/nixpkgs/commit/cb2fdc48abda3db51da396e98aaccfe2ebc093da) nixos/opensnitch: Set connection timeout of 3s for faster tests
* [`e8b518e6`](https://github.com/NixOS/nixpkgs/commit/e8b518e6b644aed8bfcf9d142c8a946d49d27b31) dusklight: 1.2.0 -> 1.3.1
* [`60804040`](https://github.com/NixOS/nixpkgs/commit/60804040e8bebb9affcffb10bb5bcedbc18016f1) nzbget: 26.0 -> 26.1
* [`09046bfe`](https://github.com/NixOS/nixpkgs/commit/09046bfef2490927eb2baa2a396f3f0124c5ee26) texlive.withPackages: fix typo
* [`895c726b`](https://github.com/NixOS/nixpkgs/commit/895c726b94685f4dde71e1fe7403d0ea516ee45c) texlive.withPackages: treat texsource containers as regular outputs
* [`53a5ed78`](https://github.com/NixOS/nixpkgs/commit/53a5ed78877f78e2a655324810ffc1b235e26102) jetbrains.dataspell: 2026.1 -> 2026.1.2
* [`db0f227c`](https://github.com/NixOS/nixpkgs/commit/db0f227cfccef0f060c3694372699c2d6604d469) jetbrains.pycharm: 2026.1.1 -> 2026.1.2
* [`ed755b09`](https://github.com/NixOS/nixpkgs/commit/ed755b09ed1044777cd8e3f06d373149e28c6d6a) vscode-with-extensions: use the editor's iconName for the desktop icon
* [`574ab12c`](https://github.com/NixOS/nixpkgs/commit/574ab12c16e1d653f55f035d41f9a1565c0f5c7c) gtk-server: remove unused configurationOptions
* [`6b423241`](https://github.com/NixOS/nixpkgs/commit/6b4232410f26164bc9d88c3281b7c6cea2cb8b52) gtk-server: 2.4.6 -> 2.4.7
* [`cbea254e`](https://github.com/NixOS/nixpkgs/commit/cbea254e5d1624c8c223581d433b3d87321d37c8) gtk-server: use gtk4
* [`b3a09ea1`](https://github.com/NixOS/nixpkgs/commit/b3a09ea15d6b468cfd2cead2e3e1119e4242a6cf) gtk-server: add meta.mainProgram
* [`383bd6b1`](https://github.com/NixOS/nixpkgs/commit/383bd6b1c3f6c2ef0e1be3475906a06d0026e48e) criu: enable strictDeps, use --replace-fail, use tag
* [`bb538ea1`](https://github.com/NixOS/nixpkgs/commit/bb538ea125c6a3a9d157daeae1671b821b9c3c8f) criu: add patch to prevent build failures with newer glibc
* [`cc93c954`](https://github.com/NixOS/nixpkgs/commit/cc93c9543f93842791671f41cfb80fcd8b79c23b) blendfarm: switch to pcre2
* [`c230f91c`](https://github.com/NixOS/nixpkgs/commit/c230f91cdc3ec4ceb96301c0fc1e2222c8003412) python3Packages.zipstream-ng: 1.9.0 -> 1.9.2
* [`642c3633`](https://github.com/NixOS/nixpkgs/commit/642c3633c6bf777f5974f59854409fae5749152f) copyq: 15.0.0 -> 16.0.0
* [`f439e787`](https://github.com/NixOS/nixpkgs/commit/f439e787f961f70e075cb18ebf24de6cc84c6de5) grub2: migrate to fuse3
* [`b08f5240`](https://github.com/NixOS/nixpkgs/commit/b08f5240c34dd997c981e2313a77306715abe769) gimp: enable strictDeps and structuredAttrs
* [`fe2bd359`](https://github.com/NixOS/nixpkgs/commit/fe2bd35971c068cd3a24b6f1610041f0a62ae608) openfga: 1.14.2 -> 1.16.1
* [`3f256632`](https://github.com/NixOS/nixpkgs/commit/3f256632654411e17d3ba6d02a7f529bbc7c9a5a) ghr-cli: init at 0.8.1
* [`51978423`](https://github.com/NixOS/nixpkgs/commit/5197842329d5153bc5a3ace63bd7e7d9dc97c83c) nixos/systemd: ship time-set.target
* [`a3079d72`](https://github.com/NixOS/nixpkgs/commit/a3079d72ae818a1abc9cb44c675c18bfcce3867e) qbittorrent-enhanced-nox: 5.1.3.10 -> 5.2.1.10
* [`54c795f4`](https://github.com/NixOS/nixpkgs/commit/54c795f4be65f608c6ab95b14b77ac62a9bfffd1) litestar: 2.21.1 -> 2.23.0
* [`05ea064d`](https://github.com/NixOS/nixpkgs/commit/05ea064dd78edc78f5921a98c5c7a1b6abd4251a) stripe-cli: 1.37.2 -> 1.41.2
* [`3c4dc11e`](https://github.com/NixOS/nixpkgs/commit/3c4dc11eb3362f55a74c4893e55060e70fa92fdf) cppcms: migrate to pcre2
* [`46b194ca`](https://github.com/NixOS/nixpkgs/commit/46b194ca0e7cfbd68061e91821895f4db6b9140d) helmify: init at 0.4.20
* [`2e1d60e1`](https://github.com/NixOS/nixpkgs/commit/2e1d60e197e2c5f5724424e2a24b58cca2631953) nixos-rebuild-ng: disable flake auto-detection when --file or --attr is used
* [`cb998250`](https://github.com/NixOS/nixpkgs/commit/cb998250f23b91901189c66d74a8551536e8d0f9) scanservjs: 3.0.4 -> 3.1.0
* [`e07ad9d0`](https://github.com/NixOS/nixpkgs/commit/e07ad9d0654d4bf887757160355abbd33b3b0d39) linux: Build-in HFS+ support on POWER
* [`48d00af9`](https://github.com/NixOS/nixpkgs/commit/48d00af90d7012116805d5f8e2756c79f7c5c917) linux: Build-in IDE & MacIO support on POWER
* [`47dd26e7`](https://github.com/NixOS/nixpkgs/commit/47dd26e701ea5ec0a7f65ba785c9fdd3acbde5b3) pyprland: 3.4.0 -> 3.4.2
* [`ef4ab8ea`](https://github.com/NixOS/nixpkgs/commit/ef4ab8eaaa66e88acce71c8ce670e1150a974985) nixos/sshd: accept path-typed options
* [`ad9b652a`](https://github.com/NixOS/nixpkgs/commit/ad9b652ab422a6659ce9f663d362314b2c21d769) anytype: migrate patches to ts
* [`235f4631`](https://github.com/NixOS/nixpkgs/commit/235f46316251f4d77ca94086145002f8582439c7) unifi: 10.2.105 -> 10.4.57
* [`ec419f35`](https://github.com/NixOS/nixpkgs/commit/ec419f35be7a8444171805ce21f8b7182e54a304) electron-source: remove unused patches
* [`5f567ce5`](https://github.com/NixOS/nixpkgs/commit/5f567ce58ece474229a4d21e5e9d7133bb94a991) ty: 0.0.40 -> 0.0.42
* [`d2d14933`](https://github.com/NixOS/nixpkgs/commit/d2d149334a9874cb7db679a9ab88f9e206a696a5) requireFile: use stdenvNoCC
* [`e5ec5c94`](https://github.com/NixOS/nixpkgs/commit/e5ec5c94d82e20e3d798e97b6b844de91d63ecb9) nixos/limine: fix fwupd-efi signing script under strict shell checks
* [`b4a2e862`](https://github.com/NixOS/nixpkgs/commit/b4a2e8626bad82a8d519328c8f6af811386f96ca) fetchurl: avoid escaping hash
* [`87163d15`](https://github.com/NixOS/nixpkgs/commit/87163d15c7d6a4024cf84ea7108ef95bb7008935) fetchurl: inherit lib functions to global scope
* [`62972398`](https://github.com/NixOS/nixpkgs/commit/62972398d8f7885900bbcad269dacfcef4b60135) fetchurl: avoid rewriteURL logic if it's null
* [`3d6d604a`](https://github.com/NixOS/nixpkgs/commit/3d6d604a74c7503a9085e4a0662af3b9168b0b80) fetchurl/boot: inherit builtins to global scope
* [`14848d5d`](https://github.com/NixOS/nixpkgs/commit/14848d5db592ca784d28003e9f8abfcd5f8db465) fetchurl/boot: use `head foo` instead of `elemAt foo 0`
* [`4645f84f`](https://github.com/NixOS/nixpkgs/commit/4645f84f9dbee257d97466dab2157adf7a1ed0b0) fetchurl: avoid resolvedUrl thunk
* [`917bf806`](https://github.com/NixOS/nixpkgs/commit/917bf8063235fdcad3759fc6a97cacf11636b814) fetchurl: avoid creating nativeBuildInputs list on every call
* [`d0a6e1a3`](https://github.com/NixOS/nixpkgs/commit/d0a6e1a3fc69804bfa8a30bee703653a2a1537e2) opentofu-mcp-server: init at 1.0.0
* [`f83fc759`](https://github.com/NixOS/nixpkgs/commit/f83fc75975c6709dddbaffd3e450a2ea7c725e1e) python3Packages.netbox-bgp: 0.18.1 -> 0.19.0
* [`beb2ae6c`](https://github.com/NixOS/nixpkgs/commit/beb2ae6c1b358cb32da5b9dbb8310e25f0465880) steelix: add patch for correct grammar extension on darwin
* [`8d06e58e`](https://github.com/NixOS/nixpkgs/commit/8d06e58e43f3dd4f76202c61716255d10b9303a0) steelix: add @⁠aciceri to maintainers
* [`4f55b18b`](https://github.com/NixOS/nixpkgs/commit/4f55b18b6e618ee6f2f97cb2a828caf81d3d1cd2) libslirp: 4.9.1 -> 4.9.3
* [`2f6ab4f9`](https://github.com/NixOS/nixpkgs/commit/2f6ab4f908247309d12322ddb56f9f9faa6e20b0) python3Packages.molecule-plugins: 23.5.3 -> 25.8.12, fetch from github
* [`76aab004`](https://github.com/NixOS/nixpkgs/commit/76aab004931967f92110d5ec798c000a7e3ab08d) mcp-nixos: fix darwin build
* [`553803c6`](https://github.com/NixOS/nixpkgs/commit/553803c6fb2e9d3a07833123183c38d1e45dfa3c) python3Packages.libvirt: 12.2.0 -> 12.4.0
* [`df1dab0f`](https://github.com/NixOS/nixpkgs/commit/df1dab0f4eb5c15f1db847d7b807514b80468e9f) k3d: 5.8.3 -> 5.9.0
* [`853ad2df`](https://github.com/NixOS/nixpkgs/commit/853ad2dfd7a02eb2a1fa282f5f25c42a63e1ba22) prometheus-qbittorrent-exporter: 1.13.0 -> 2.0.1
* [`e916f6aa`](https://github.com/NixOS/nixpkgs/commit/e916f6aac90fb5061aa68736657a1a1b15e49905) autobrr: 1.79.0 -> 1.80.0
* [`9fce930e`](https://github.com/NixOS/nixpkgs/commit/9fce930eb975bc69abfa9245aadc26625a673598) qtwebapp: add pkg-config file
* [`ffd6df87`](https://github.com/NixOS/nixpkgs/commit/ffd6df8706fbf9ed01fab720b6a61155f60f0102) python3Packages.btsmarthub-devicelist: migrate to pyproject
* [`256bcd35`](https://github.com/NixOS/nixpkgs/commit/256bcd350c198fbaa358a4e6622f4287cdfa0e7a) python3Packages.btsmarthub-devicelist: use finalAttrs
* [`f62a8706`](https://github.com/NixOS/nixpkgs/commit/f62a87060d31b68dc9f0a2dfe86fbbe342879ed7) mouser: init at 3.6.0
* [`4818e8d3`](https://github.com/NixOS/nixpkgs/commit/4818e8d3420c675dbb83c5248215f5955fb638c7) python3Packages.pycapnp: 2.2.2 -> 2.2.3
* [`d0ddb3fd`](https://github.com/NixOS/nixpkgs/commit/d0ddb3fdb5c5677e05a6615b36f44f04a82cd70a) bttf: init at 0.1.4
* [`aff25da2`](https://github.com/NixOS/nixpkgs/commit/aff25da20b1a31242d3ce8242a1060f8d8ba33df) libreoffice: unvendor libfreehand
* [`48995a6e`](https://github.com/NixOS/nixpkgs/commit/48995a6ef97c08b338838cb37578ef0aa0b46fd9) nixos/virtualisation: (Aarch64) remove -device virtio-gpu-pci
* [`4ebc5fef`](https://github.com/NixOS/nixpkgs/commit/4ebc5fef4dffd498565220c9c52aa63063ed79c9) ghqr: init at 0.4.2
* [`230d9722`](https://github.com/NixOS/nixpkgs/commit/230d97228d3195ea3191719399f38e512d607b27) lis: 2.1.10 -> 2.1.11
* [`6aacc27c`](https://github.com/NixOS/nixpkgs/commit/6aacc27c2a6918082993ba0056d8135bced3beaf) proton-vpn-local-agent: 1.6.2 -> 1.6.3
* [`e864f0fb`](https://github.com/NixOS/nixpkgs/commit/e864f0fb1db9813a37e2f1df1d6b615a61485c07) proton-vpn-api-core: 5.0.1 -> 5.2.4
* [`ea2c7ee7`](https://github.com/NixOS/nixpkgs/commit/ea2c7ee70bf1a22cc265a4464fae85dcdb2b8ce0) proton-vpn: 4.15.3 -> 4.16.5
* [`cdf24c1f`](https://github.com/NixOS/nixpkgs/commit/cdf24c1fec6c1ec68566b9879a065706d771fd2a) tests.trivial-builders: add requireFile test
* [`91c1efbc`](https://github.com/NixOS/nixpkgs/commit/91c1efbc6be4099fdbe91b6277f45343f9986027) python3Packages.assertpy: migrate to pyproject
* [`5619d8fa`](https://github.com/NixOS/nixpkgs/commit/5619d8fa8c4b49a6c9e07b42858621cadd65584e) python3Packages.assertpy: convert to finalAttrs
* [`d25c7692`](https://github.com/NixOS/nixpkgs/commit/d25c76920d02cf3c966b41316399d05d6c378c95) libqb: 2.0.9 -> 2.0.10
* [`f91ee283`](https://github.com/NixOS/nixpkgs/commit/f91ee283e6e1c577058ac95f3b7ba205a9c39225) python3Packages.assertpy: use tag in src
* [`e25bf712`](https://github.com/NixOS/nixpkgs/commit/e25bf712f95be9ae10bfe8d59e82145b9c03374b) python3Packages.assertpy: use SRI hash format
* [`46925b0a`](https://github.com/NixOS/nixpkgs/commit/46925b0a70a9e0750283840644cb7d9cc00d4a6c) python3Packages.azure-common: migrate to pyproject
* [`290a491b`](https://github.com/NixOS/nixpkgs/commit/290a491b7f820e84aa583afedc3c0cb0128a4344) python3Packages.azure-common: convert to finalAttrs
* [`ce96f104`](https://github.com/NixOS/nixpkgs/commit/ce96f104e11c9cfdd2ab0264b1d22749bfe07eea) python3Packages.azure-cosmosdb-table: migrate to pyproject
* [`20acb70e`](https://github.com/NixOS/nixpkgs/commit/20acb70ec013ea9a928d5458295d17e7e7d4c009) python3Packages.azure-cosmosdb-table: convert to finalAttrs
* [`89797b32`](https://github.com/NixOS/nixpkgs/commit/89797b325ab4b63fe8e6795e3627407d88145fde) nebula-de-esser: init at 3.2.0
* [`da3f42f2`](https://github.com/NixOS/nixpkgs/commit/da3f42f2fff6f813cd237231b5045633b15b07fe) python3Packages.azure-cosmosdb-table: use SRI hash format
* [`9ecff5e5`](https://github.com/NixOS/nixpkgs/commit/9ecff5e56ef7832eee56e28f6047f724a43a0cd1) giada: 1.4.1 -> 1.4.2
* [`12ae2c13`](https://github.com/NixOS/nixpkgs/commit/12ae2c132abed64d9b3f777931d78f1e8b3ae8ed) nixos/cde: replace activation script with tmpfiles
* [`eaa3b1d4`](https://github.com/NixOS/nixpkgs/commit/eaa3b1d4d5095a8821a0969981c4f029c52435fe) dateutils: fix build errors
* [`f0d605d5`](https://github.com/NixOS/nixpkgs/commit/f0d605d58830dc9f2887580c007e9a00453f3cfe) nixos/tests/opensnitch: adopt
* [`df6c9820`](https://github.com/NixOS/nixpkgs/commit/df6c982022cee640fa12bc4f8f0368890283dd73) acl2.libipasir: switch to finalAttrs pattern, switch to SRI hash
* [`26c9cea7`](https://github.com/NixOS/nixpkgs/commit/26c9cea779e28bebb5bb624d16fc79168aa6cfd7) nixos/tests/opensnitch: skip broken ebpf test on aarch64
* [`f91de7a4`](https://github.com/NixOS/nixpkgs/commit/f91de7a4130981b097550dc31bbdd9e2885b0e39) acl2: switch to finalAttrs pattern, switch to hash
* [`15a909e8`](https://github.com/NixOS/nixpkgs/commit/15a909e8d75fff879ca96c9ee9a76193b32b6b7a) maintainers: add jade
* [`fe171cb3`](https://github.com/NixOS/nixpkgs/commit/fe171cb3a8dc1c7da6c73c0b872f902ff32252c7) nixos/opensnitch: define /etc/opensnitchd entries via environment.etc
* [`129cc6fc`](https://github.com/NixOS/nixpkgs/commit/129cc6fc18ad188186a6870cc893bb521bbe0747) swi-prolog: 9.2.9 -> 10.0.2
* [`1277abe2`](https://github.com/NixOS/nixpkgs/commit/1277abe2d647ee072002eff75b250e88d8f9daa9) supercollider: 3.13.1 -> 3.14.1
* [`068cd9df`](https://github.com/NixOS/nixpkgs/commit/068cd9dfef9125286705fba3fdf24b84c497293b) supercollider: add convert KeyboardModifiers to an integer type patch
* [`2a72e808`](https://github.com/NixOS/nixpkgs/commit/2a72e808cd854b429ed2b8ad4317dff217396d8f) sc3-plugins: 3.13.0 -> 3.14.0
* [`69f282cf`](https://github.com/NixOS/nixpkgs/commit/69f282cf85916a65036581d8d81a5e570ac8c974) supercollider: remove 3.12.0-env-dirs patch
* [`3652bf61`](https://github.com/NixOS/nixpkgs/commit/3652bf618273cb823ef595aa9a0de2952c26af41) supercollider: remove spurious comments
* [`61ab732e`](https://github.com/NixOS/nixpkgs/commit/61ab732ed5fe6b85d88240642669c10f6702b245) nixos/opensnitch: make rules path and state directory match
* [`0cc2cc60`](https://github.com/NixOS/nixpkgs/commit/0cc2cc60b9f2ed73548930fd73dcc036bb2703ba) {lomiri,lomiri-qt6}.lomiri-ui-toolkit: 1.3.5905 -> 1.3.5906
* [`352bcd9e`](https://github.com/NixOS/nixpkgs/commit/352bcd9edeebcac821a86bb069ec2e895554dc60) packer: 1.15.3 -> 1.15.4
* [`18195321`](https://github.com/NixOS/nixpkgs/commit/181953216adabac8be7282d68770a2e5a8498fb8) altermime: switch to finalAttrs and SRI hash format
* [`25c52b6c`](https://github.com/NixOS/nixpkgs/commit/25c52b6c7e3f590ee59c99037c798ea69dedfc50) bazel_9: 9.1.0 -> 9.1.1
* [`15b716bd`](https://github.com/NixOS/nixpkgs/commit/15b716bd57c6b8ce448531c07eabda7a88827a69) maintainers: add talal
* [`473a9745`](https://github.com/NixOS/nixpkgs/commit/473a9745a1fa3ac703efbcbff4c956560ab2ea05) quicksand: use installFonts
* [`344a3c24`](https://github.com/NixOS/nixpkgs/commit/344a3c2437fe3b60e063e8571c370808375a14a4) gpclient: disable automatic update
* [`c65d8817`](https://github.com/NixOS/nixpkgs/commit/c65d8817de170b4a977e411417e4dd3ecd7c95bd) gp{auth,client}: 2.5.1 -> 2.5.4
* [`f9f9e010`](https://github.com/NixOS/nixpkgs/commit/f9f9e010cd3a5a64f22f1c74dada2b78b65c6aa2) libtoxcore: 0.2.22 -> 0.2.23
* [`94e0789e`](https://github.com/NixOS/nixpkgs/commit/94e0789e1f38361e6c6afd6a12c9b3d281249b1f) mendeley: 2.144.0 -> 2.145.0
* [`81ff08b2`](https://github.com/NixOS/nixpkgs/commit/81ff08b2623a73eb4eef120388af717d0c921563) system76-firmware: 1.0.74 -> 1.0.76
* [`a5af39d4`](https://github.com/NixOS/nixpkgs/commit/a5af39d45df6b56858289a58fdee1235695bc3c2) maintainers: add elliotberman
* [`49666df2`](https://github.com/NixOS/nixpkgs/commit/49666df29621383f45f3138a52ab612e388deb54) onnxruntime: use latest abseil-cpp
* [`dd509002`](https://github.com/NixOS/nixpkgs/commit/dd509002f831ac2fc63de4e78ac76be572642e6c) onnxruntime: simplify Nix expression
* [`32861fa2`](https://github.com/NixOS/nixpkgs/commit/32861fa28b56f7a3906e1bb267f3264ebc85bc92) linux/common-config: enable ARM_SMMU_V3_SVA on aarch64
* [`699d54fd`](https://github.com/NixOS/nixpkgs/commit/699d54fd13afe8550b0b46d86501b2b29492d80c) scx-loader: init at 1.1.1
* [`472e7bfd`](https://github.com/NixOS/nixpkgs/commit/472e7bfd454db8fe097e100dd9b9eae20877b7a5) nixos/scx-loader: init
* [`62e65ad3`](https://github.com/NixOS/nixpkgs/commit/62e65ad348efac9cb36b7496527ad50fb639b8ae) nixosTests.scx-loader: init
* [`129c29a6`](https://github.com/NixOS/nixpkgs/commit/129c29a68a3c1042538b37bbabe38012b917354c) python3Packages.fontmake: 3.11.1 -> 3.12.1
* [`f2178fed`](https://github.com/NixOS/nixpkgs/commit/f2178fed372df6603301db61caf6d3399dd45533) zarf: 0.76.0 -> 0.77.0
* [`095fb176`](https://github.com/NixOS/nixpkgs/commit/095fb1767671ffd83d05863feb30836c1115c199) nixos-rebuild-ng: add env var to allow use without systemd-run
* [`8894990e`](https://github.com/NixOS/nixpkgs/commit/8894990e8af8dfc14095e479fc884b9ac30ef546) tclPackages.rl_json: 0.16 -> 0.17.6
* [`36cb1fed`](https://github.com/NixOS/nixpkgs/commit/36cb1fed8bb2d52ba6aa94ca6f8a168ee820318a) maintainers: drop cirno-999
* [`78937945`](https://github.com/NixOS/nixpkgs/commit/78937945928f08ced8289136838bb644929ab3b0) tokenspeed-triton-llvm: init at 23.0.0-unstable-2026-04-08
* [`16665aed`](https://github.com/NixOS/nixpkgs/commit/16665aed899f01195a63019dd9a06a46ebf5665a) homebridge: 2.0.2 -> 2.1.0
* [`b63a8116`](https://github.com/NixOS/nixpkgs/commit/b63a81166a10957b70d303c181adbec59c0f74f4) nixos-rebuild-ng: add tests for --file/--attr disabling flake auto-detection
* [`1503d10e`](https://github.com/NixOS/nixpkgs/commit/1503d10ee4e6af997e06545964df06897e54adec) h2o: 2.3.0-rolling-2026-05-15 → 2.3.0-rolling-2026-05-25
* [`e22df827`](https://github.com/NixOS/nixpkgs/commit/e22df82761e44df34d3c6f8e18087c1fbcb05b61) h2o: 2.3.0-rolling-2026-05-25 → 2.3.0-rolling-2026-05-28
* [`80af1649`](https://github.com/NixOS/nixpkgs/commit/80af164903e1e001cf53cd21bc92d9e79dc6b6ac) h2o: 2.3.0-rolling-2026-05-28 → 2.3.0-rolling-2026-05-29
* [`5379e268`](https://github.com/NixOS/nixpkgs/commit/5379e268b1c36d4cf3424d44f3891993de60c339) h2o: 2.3.0-rolling-2026-05-29 → 2.3.0-rolling-2026-06-04
* [`ff9c4a84`](https://github.com/NixOS/nixpkgs/commit/ff9c4a84b39ce6966f32d41ddc1a1b76f8636d6b) python3Packages.ansicolors: migrate to pyproject
* [`84ba23be`](https://github.com/NixOS/nixpkgs/commit/84ba23bef96b09bb58c1fe1fcf02d1f9e2ca9676) python3Packages.ansicolors: modernize
* [`230cf07e`](https://github.com/NixOS/nixpkgs/commit/230cf07ea28b63e3f77311488466da2d093e4642) python3Packages.ansicolors: add meta.changelog
* [`5ac969ba`](https://github.com/NixOS/nixpkgs/commit/5ac969ba618179f5783e82b3f33af8afee1c78f5) python3Packages.aprslib: migrate to pyproject
* [`a041380a`](https://github.com/NixOS/nixpkgs/commit/a041380aacade70f35cc0c65ec99286c83b1f731) python3Packages.aprslib: modernize
* [`25aec847`](https://github.com/NixOS/nixpkgs/commit/25aec847adecb63e115e905b59a4e501ce81bc7a) slurm: 25-11-6-1 -> 26.05.0.1
* [`dba6c890`](https://github.com/NixOS/nixpkgs/commit/dba6c890cbde98e0a428fc6d7bdbd552a35b836a) slurm-spank-stunnel: add backward compatibility patch
* [`99602dbb`](https://github.com/NixOS/nixpkgs/commit/99602dbb5e2709fea4d2aaea516f9e9b92412c2a) slurm-spank-x11: add backward compatibility patch
* [`81e497b4`](https://github.com/NixOS/nixpkgs/commit/81e497b47799696ff59bd32ebd3afa56368bd80f) python3Packages.aprslib: add meta.changelog
* [`4b214528`](https://github.com/NixOS/nixpkgs/commit/4b2145289ad83f63787f01c2de2ccbf620eeb306) python3Packages.arpy: migrate to pyproject
* [`013498f6`](https://github.com/NixOS/nixpkgs/commit/013498f6d1365d98a592ba63193e75a71e96c384) python3Packages.tokenspeed-triton: init at 3.7.10.post20260531
* [`4d411b12`](https://github.com/NixOS/nixpkgs/commit/4d411b1251455e9b90672c0f3f9cb3b68f5432ba) python3Packages.tokenspeed-triton-bin: init at 3.7.10.post20260531
* [`cf6aef35`](https://github.com/NixOS/nixpkgs/commit/cf6aef351e3d98f41e554f0f4e0737cfc82aadae) python3Packages.tokenspeed-mla: init at 0.1.5
* [`53871857`](https://github.com/NixOS/nixpkgs/commit/5387185762a64e5e7f001bccb53baaf782e7dd33) python3Packages.tokenspeed-mla-bin: init at 0.1.5
* [`5e410d36`](https://github.com/NixOS/nixpkgs/commit/5e410d367e55791c3ebcf883dd916d9e7e087de1) python3Packages.lxmf: add missing `qrcode` dependency
* [`940d90c4`](https://github.com/NixOS/nixpkgs/commit/940d90c48e67c1f47f77cca40c6bb7cbfc8eb14d) python3Packages.azure-mgmt-datalake-analytics: migrate to pyproject
* [`6827686f`](https://github.com/NixOS/nixpkgs/commit/6827686fcb80f1ecd86c9f679497a3d5ac81cead) python3Packages.azure-mgmt-authorization: migrate to pyproject
* [`47d342df`](https://github.com/NixOS/nixpkgs/commit/47d342dffc58115b10ca015d8ea427c96e28e309) python3Packages.azure-mgmt-datalake-nspkg: migrate to pyproject
* [`c4a94d18`](https://github.com/NixOS/nixpkgs/commit/c4a94d183f9c205cea0f7a75fd98281cf7d10140) python3Packages.azure-mgmt-hanaonazure: migrate to pyproject
* [`33d5672c`](https://github.com/NixOS/nixpkgs/commit/33d5672cd4b16c983a3b8f9a07e18aa68b5b3ef7) python3Packages.azure-mgmt-devtestlabs: migrate to pyproject
* [`03294ad5`](https://github.com/NixOS/nixpkgs/commit/03294ad594fff70c218148736964933884da9f45) python3Packages.azure-mgmt-devspaces: migrate to pyproject
* [`60e80939`](https://github.com/NixOS/nixpkgs/commit/60e80939afff3756289b3ec567e48757f946a7aa) python3Packages.azure-mgmt-iotcentral: migrate to pyproject
* [`10e668e8`](https://github.com/NixOS/nixpkgs/commit/10e668e80dab83167aa0ed35b49311b1b93b4998) python3Packages.azure-mgmt-maps: migrate to pyproject
* [`2dba73af`](https://github.com/NixOS/nixpkgs/commit/2dba73af0d7514e6d9c830178f66a4e45e99e624) python3Packages.azure-mgmt-marketplaceordering: migrate to pyproject
* [`41501e81`](https://github.com/NixOS/nixpkgs/commit/41501e81bab687c1509912dd0abe45894e180d8f) python3Packages.azure-mgmt-iothubprovisioningservices: migrate to pyproject
* [`a158dbc0`](https://github.com/NixOS/nixpkgs/commit/a158dbc038ac53bcd49cfc849acf09a9c504ca7c) python3Packages.azure-mgmt-loganalytics: migrate to pyproject
* [`1a7b88af`](https://github.com/NixOS/nixpkgs/commit/1a7b88af1dce6292aebd951e69411dc945b567f2) python3Packages.azure-mgmt-machinelearningcompute: migrate to pyproject
* [`35e99c8b`](https://github.com/NixOS/nixpkgs/commit/35e99c8bc6d6596c62d04128162d803a9baecb31) python3Packages.azure-mgmt-managementpartner: migrate to pyproject
* [`63b7d327`](https://github.com/NixOS/nixpkgs/commit/63b7d327dcfeefb021da70c0f1ffa800c4f74263) python3Packages.azure-mgmt-notificationhubs: migrate to pyproject
* [`1ddd60f2`](https://github.com/NixOS/nixpkgs/commit/1ddd60f2a7d8ae10d65c252c65691bc20475c5b7) python3Packages.azure-mgmt-rdbms: migrate to pyproject
* [`f39df46b`](https://github.com/NixOS/nixpkgs/commit/f39df46b051b0e13832a57be29e942390d29ac75) python3Packages.azure-mgmt-redis: migrate to pyproject
* [`ccbb1889`](https://github.com/NixOS/nixpkgs/commit/ccbb18898b32f9e4d66658ac9f35805fe0885555) python3Packages.azure-mgmt-signalr: migrate to pyproject
* [`5bc45a78`](https://github.com/NixOS/nixpkgs/commit/5bc45a784d9d7ec6fd2461c7b7d309ce2e7473f9) python3Packages.azure-mgmt-subscription: migrate to pyproject
* [`66c3c8f8`](https://github.com/NixOS/nixpkgs/commit/66c3c8f85e13e53d48887b69c8fd6edef097260b) python3Packages.azure-nspkg: migrate to pyproject
* [`611d34aa`](https://github.com/NixOS/nixpkgs/commit/611d34aaa381b549b95a3ea72006541c0071986b) pawn-appetit: 0.12.0 -> 0.12.1
* [`67ed8bba`](https://github.com/NixOS/nixpkgs/commit/67ed8bba1543e1ef3815c1b6be49643bf8722990) python3Packages.google-cloud-access-context-manager: 0.5.0 -> 0.6.0
* [`4736e5e5`](https://github.com/NixOS/nixpkgs/commit/4736e5e55f1130d80547d5049d8d835034f3a404) phpPackages.composer: 2.10.0 -> 2.10.1
* [`691dc02d`](https://github.com/NixOS/nixpkgs/commit/691dc02df0111c320cd6697aacd4b113ba632e40) pkgs-lib/formats: Use .attrs.json where possible
* [`55e1858f`](https://github.com/NixOS/nixpkgs/commit/55e1858f04d9b2ce28af2e2888299146285e1245) rns: add optional dependency lxmf
* [`c228984a`](https://github.com/NixOS/nixpkgs/commit/c228984ad626cd35d118e329e967555190443814) plocate: Fix the package license
* [`2854ca9c`](https://github.com/NixOS/nixpkgs/commit/2854ca9ce029fd7d3a7113ea740e2a78f9746ff2) python3Packages: uefi-firmware-parser: 1.13 -> 1.16, updateScript, and maintainer
* [`1087b3eb`](https://github.com/NixOS/nixpkgs/commit/1087b3eb0809c7d67775e271b81e1e65c673d9b5) gnupgMinimal: init
* [`603f171a`](https://github.com/NixOS/nixpkgs/commit/603f171aa868b2281aed24fdca4f62be96052b96) nixos/systemd: gnupg -> gnupgMinimal
* [`108255da`](https://github.com/NixOS/nixpkgs/commit/108255da78127a5b8fb46b081cb889201d8b60ff) home-assistant-custom-components.blueprints-updater: 2.4.0 -> 2.7.2
* [`5e153142`](https://github.com/NixOS/nixpkgs/commit/5e153142f47c0f2600828b91a9d6ca9247a812bc) openlogi: init at 0.3.4
* [`e20ecbf1`](https://github.com/NixOS/nixpkgs/commit/e20ecbf1c70a15d3156554db1af79aaaf05b9d06) worktrunk: 0.53.0 -> 0.56.0
* [`3b9a214c`](https://github.com/NixOS/nixpkgs/commit/3b9a214c60d49a3a40b456a53a70e485e220b38a) python3Packages.arpy: modernize
* [`98a77900`](https://github.com/NixOS/nixpkgs/commit/98a779005c0d6fd9a8caa030975726c15d33858f) python3Packages.azure-mgmt-authorization: modernize
* [`043fd75e`](https://github.com/NixOS/nixpkgs/commit/043fd75eb17eb710c3cc2cf26105347d3d16a199) python3Packages.azure-mgmt-datalake-nspkg: modernize
* [`2b4e34b4`](https://github.com/NixOS/nixpkgs/commit/2b4e34b47c524c3e0c77fc6c6e04e9e1c8320f45) python3Packages.azure-mgmt-devspaces: modernize
* [`6d994405`](https://github.com/NixOS/nixpkgs/commit/6d9944055e795006f4232c95bba6da66de4b2df2) python3Packages.azure-mgmt-datalake-analytics: modernize
* [`bb05f385`](https://github.com/NixOS/nixpkgs/commit/bb05f385eb9eb28e744174f6648f8cd962f54265) python3Packages.azure-mgmt-hanaonazure: modernize
* [`a1090402`](https://github.com/NixOS/nixpkgs/commit/a1090402a06a7d00015f18a4f4f2a641a3dbb176) python3Packages.azure-mgmt-iotcentral: modernize
* [`0c5ac6a7`](https://github.com/NixOS/nixpkgs/commit/0c5ac6a7e81b72513d0d3a77f2955662349bb173) python3Packages.azure-mgmt-devtestlabs: modernize
* [`edaecb7c`](https://github.com/NixOS/nixpkgs/commit/edaecb7cc99e02c9ec3ffd6533923f46d66ede3a) python3Packages.azure-mgmt-iothubprovisioningservices: modernize
* [`a75d94b6`](https://github.com/NixOS/nixpkgs/commit/a75d94b62aa72cf4af9328844c5a45d0be7d033a) python3Packages.azure-mgmt-maps: modernize
* [`1e779650`](https://github.com/NixOS/nixpkgs/commit/1e779650b12cdd81270bf18837ab0a1397d9f643) python3Packages.azure-mgmt-managementpartner: modernize
* [`6e2d3859`](https://github.com/NixOS/nixpkgs/commit/6e2d3859dfc585ee2d3645067d6662955cb7b4c7) python3Packages.azure-mgmt-machinelearningcompute: modernize
* [`d9b333e7`](https://github.com/NixOS/nixpkgs/commit/d9b333e7839893973506921085e440b213f1a1b2) python3Packages.azure-mgmt-loganalytics: modernize
* [`7d710f46`](https://github.com/NixOS/nixpkgs/commit/7d710f46926fd05d5929010078264fbc1bd9c60c) python3Packages.azure-mgmt-marketplaceordering: modernize
* [`8212a2d0`](https://github.com/NixOS/nixpkgs/commit/8212a2d007e9fc5ca5b3e308711999904b10a66f) python3Packages.azure-mgmt-notificationhubs: modernize
* [`8eef6e68`](https://github.com/NixOS/nixpkgs/commit/8eef6e68f3cce03e8d30183f8db28cb485237724) python3Packages.azure-mgmt-rdbms: modernize
* [`c00c0bf7`](https://github.com/NixOS/nixpkgs/commit/c00c0bf72067b544ac49901791e8bddee6d174cb) python3Packages.azure-mgmt-redis: modernize
* [`a312ea28`](https://github.com/NixOS/nixpkgs/commit/a312ea2814ac2dff1e8573c916bd9b258e7f0191) python3Packages.azure-mgmt-signalr: modernize
* [`1d814e39`](https://github.com/NixOS/nixpkgs/commit/1d814e39484002d16f72430f4d1b530033489e24) python3Packages.azure-mgmt-subscription: modernize
* [`c0d9f4fe`](https://github.com/NixOS/nixpkgs/commit/c0d9f4fe8c4b17b6ad30e261b2f0ab1b6d7bad4a) python3Packages.azure-nspkg: modernize
* [`be84ec22`](https://github.com/NixOS/nixpkgs/commit/be84ec22c5a24032337fc05652c0575dd293f807) systemd-logind: allow service reloads to apply new configuration
* [`dc965bdf`](https://github.com/NixOS/nixpkgs/commit/dc965bdf7f16194a1d1ad5eafc23049321ff993f) ty: 0.0.42 -> 0.0.44
* [`32bc26bf`](https://github.com/NixOS/nixpkgs/commit/32bc26bfeb783da6578b7516e759327f761e9b4a) songrec: add tomasrivera as maintainer
* [`3a219f64`](https://github.com/NixOS/nixpkgs/commit/3a219f6445e74752c69afe2eb7189dc40e9f028e) songrec: add changelog
* [`b9497d93`](https://github.com/NixOS/nixpkgs/commit/b9497d93ecbb3fd89148c7f1f623b8c012927170) songrec: add versionCheckHook
* [`08c00dc4`](https://github.com/NixOS/nixpkgs/commit/08c00dc4e1883e8370bd727e43bb691d19bff1d7) songrec: add nix-update-script
* [`79ab0268`](https://github.com/NixOS/nixpkgs/commit/79ab0268148f63a9077ce85889ba1ef994725f2e) songrec: change rev to tag
* [`48675b5d`](https://github.com/NixOS/nixpkgs/commit/48675b5df37ff6ae53dd5ce6b7ad6e3bfe576223) songrec: 0.6.7 -> 0.7.3
* [`3f00ce6e`](https://github.com/NixOS/nixpkgs/commit/3f00ce6ea27e7a67de93ac0be267cdeb461f1023) bindfs: drop fuse2
* [`790a6d3e`](https://github.com/NixOS/nixpkgs/commit/790a6d3e10b60cf500ca2da352c6794ccd3fce22) seaweedfs: 4.24 -> 4.31
* [`47abd35d`](https://github.com/NixOS/nixpkgs/commit/47abd35dc166252f93762c4443513e461609ae24) seaweedfs: mark broken on darwin
* [`77572763`](https://github.com/NixOS/nixpkgs/commit/77572763d48fda5f4df71190da5b42e2b5985d86) htgettoken: migrate to pyproject
* [`64ce3caf`](https://github.com/NixOS/nixpkgs/commit/64ce3caf8a53dcbfd982abbaeea09535e645bedb) senpai: 0.4.1 -> 0.5.0
* [`dead72eb`](https://github.com/NixOS/nixpkgs/commit/dead72ebfb30bd95062f0124d54c2447f9daf0e1) istioctl: 1.30.0 -> 1.30.1
* [`0110fbc5`](https://github.com/NixOS/nixpkgs/commit/0110fbc56e584287ca9cb3e64ee4bcca79f29fff) waydroid-helper: 0.2.7 -> 0.2.9
* [`e0e05cf2`](https://github.com/NixOS/nixpkgs/commit/e0e05cf29b66e2d1042760f5714c480982743082) memos: 0.29.0 -> 0.29.1
* [`4ef2ebdc`](https://github.com/NixOS/nixpkgs/commit/4ef2ebdc7291b849c43bb84b53049a416fae290c) waydroid-helper: bump to fuse3
* [`cf745a37`](https://github.com/NixOS/nixpkgs/commit/cf745a3753866a91e22918c6c986e94925e690e2) wpscan: 3.8.28 -> 4.0.0
* [`b8e7c176`](https://github.com/NixOS/nixpkgs/commit/b8e7c176d2e392405a1973388b63673d67e2dbc6) python314Packages.mocket: align dependencies with upstream
* [`6b6c73f9`](https://github.com/NixOS/nixpkgs/commit/6b6c73f946caace6e7c61e6f17a2028ffdf40b96) python314Packages.pyacoustid: 1.3.0 -> 1.3.1, cleanup, modernise
* [`eb723dfc`](https://github.com/NixOS/nixpkgs/commit/eb723dfccf906b7df0b1ead5ec139117516f966a) oxfmt: 0.52.0 -> 0.53.0
* [`4205569e`](https://github.com/NixOS/nixpkgs/commit/4205569e283098ffb032919ba9f15d4c53286dff) traefik: Reenable upstream package checks
* [`5d7a6d80`](https://github.com/NixOS/nixpkgs/commit/5d7a6d80889cc75da7163a2467d244802b27f402) i7z: refactor
* [`948e656d`](https://github.com/NixOS/nixpkgs/commit/948e656d818f55bae45b818f2d7d19b6a70b26ad) {encfs, gencfsm}: drop
* [`83d18efd`](https://github.com/NixOS/nixpkgs/commit/83d18efd75c42cec007dd4c94b1640b8f1701393) affine: 0.26.6 -> 0.26.7
* [`387d7f40`](https://github.com/NixOS/nixpkgs/commit/387d7f40cc6fd6d89eba4ae56504984fe9a07c92) deno: 2.8.0 -> 2.8.2
* [`6f7b4e1a`](https://github.com/NixOS/nixpkgs/commit/6f7b4e1a0e484423344d32813e474455c870aa4d) python3Packages.babelgladeextractor: migrate to pyproject
* [`f3db7685`](https://github.com/NixOS/nixpkgs/commit/f3db7685d76f45db91af52ffd0aecfcbe573fcb2) python3Packages.babelgladeextractor: modernize
* [`6f64e7b1`](https://github.com/NixOS/nixpkgs/commit/6f64e7b1aa9a5a7fd1f61b7dfeed508c1b71b741) python3Packages.base36: migrate to pyproject
* [`5c3201bd`](https://github.com/NixOS/nixpkgs/commit/5c3201bd2940482a29e7c90edbb3cdaf1b05dbb5) python3Packages.base36: modernize
* [`045207f0`](https://github.com/NixOS/nixpkgs/commit/045207f0e351fc6fd3c28a3c6ef46bce3ef7fe02) cloudlog: 2.8.12 -> 2.8.14
* [`45022f33`](https://github.com/NixOS/nixpkgs/commit/45022f33df1d39ade109cd9998825fcae89cd6fd) warp-terminal: 0.2026.04.15.08.45.stable_04 -> 0.2026.06.03.09.49.stable_01
* [`8376dc5d`](https://github.com/NixOS/nixpkgs/commit/8376dc5d4a0586c22cd3a7396f72ebdbba115b52) budget_tracker_tui: init at 1.4.0
* [`559131a2`](https://github.com/NixOS/nixpkgs/commit/559131a237dff681f0940fd087bfd774b5fba1e1) gogdl: 1.2.1 -> 1.2.2
* [`d379e0fc`](https://github.com/NixOS/nixpkgs/commit/d379e0fca9271052004a64f5c5025973cf5f0d1a) python3Packages.pyfluidsynth: 1.3.4 -> 1.4.0
* [`e8a1870d`](https://github.com/NixOS/nixpkgs/commit/e8a1870dcb8af7df1da0cc89056a362d9786797b) maintainers: add agentelement
* [`38e91d64`](https://github.com/NixOS/nixpkgs/commit/38e91d642391ae2fb7fb52c5b53a26440e7af8e7) ruff: 0.15.15 -> 0.15.16
* [`d2cfbb74`](https://github.com/NixOS/nixpkgs/commit/d2cfbb742d35fcee94b9a475cf73ce393e691aa3) python3Packages.bencoder: migrate to pyproject
* [`179fb98a`](https://github.com/NixOS/nixpkgs/commit/179fb98a04529f56fc9d0c3fffdbe47f0de24682) python3Packages.betamax-serializers: migrate to pyproject
* [`62f0f8f2`](https://github.com/NixOS/nixpkgs/commit/62f0f8f2816a02fa57f867db4354754e898d32ed) python3Packages.bencoder: modernize
* [`f2ea04cf`](https://github.com/NixOS/nixpkgs/commit/f2ea04cffb4ef561edc847576421597396cc3798) python3Packages.betamax-serializers: modernize
* [`ed850ba7`](https://github.com/NixOS/nixpkgs/commit/ed850ba75992608f1d0e53f23a2f38aaf38f5318) python3Packages.bibtexparser: migrate to pyproject
* [`77e20558`](https://github.com/NixOS/nixpkgs/commit/77e2055849eefd66545ee315a6da12ce09d0f5e0) python3Packages.binaryornot: migrate to pyproject
* [`12f29768`](https://github.com/NixOS/nixpkgs/commit/12f29768a75442cf654715e70a8fb90511b84489) python3Packages.bibtexparser: modernize
* [`52991c2d`](https://github.com/NixOS/nixpkgs/commit/52991c2d160d8d12821bcf3b8418f11b73706064) python3Packages.binaryornot: modernize
* [`7ef0805e`](https://github.com/NixOS/nixpkgs/commit/7ef0805ed89975bcbf0a0388d3dd6aada1de979d) jasp-desktop: 0.96.0 -> 0.97.0, add module fetcher script
* [`4fb02c0c`](https://github.com/NixOS/nixpkgs/commit/4fb02c0c8fec8d241a79581c857d40977852e154) pnpmConfigHook: add support for __structuredAttrs = true
* [`57bc3b02`](https://github.com/NixOS/nixpkgs/commit/57bc3b02d71e08e756311f10272f4e17b140741f) fprintd: replace systemd dependency with systemdLibs
* [`548d4c0c`](https://github.com/NixOS/nixpkgs/commit/548d4c0ca1688c0b8fa795ecbafb596433074f78) vscode-extensions.illixion.vscode-vibrancy-continued: 1.1.77 -> 1.1.78
* [`9d3d755e`](https://github.com/NixOS/nixpkgs/commit/9d3d755e8ed372991c373ac185487df09b7d6469) cudaPackages.tensorrt: Add TensorRT 10.16.1 manifest
* [`5bb67e89`](https://github.com/NixOS/nixpkgs/commit/5bb67e892a77f1a4789e9d9a163a28289ba20eb6) cudaPackages.tensorrt-samples: Add support for 10.16.1
* [`d22d1bc9`](https://github.com/NixOS/nixpkgs/commit/d22d1bc9c3443eec5122ea3a6915b1411b1ee4f8) python3Packages.simplemma: 1.1.2 -> 1.2.0
* [`2b36c973`](https://github.com/NixOS/nixpkgs/commit/2b36c973c2c14f9186c606e3799c5b7669becacc) tigerbeetle: 0.17.4 -> 0.17.5
* [`6fe092ad`](https://github.com/NixOS/nixpkgs/commit/6fe092add31ac9a4a208325a2b927c4bd6859cfe) angle: fix pkg-config path string interpolation
* [`ac3ddf45`](https://github.com/NixOS/nixpkgs/commit/ac3ddf45f6cd470a5b95fcdf0be95a0b81931d97) angle: fix dylib path names on darwin
* [`2147efda`](https://github.com/NixOS/nixpkgs/commit/2147efda6fadfd845332b287c59f170df72c80b3) pe-bear: 0.7.1 -> 0.7.2
* [`8a642ae7`](https://github.com/NixOS/nixpkgs/commit/8a642ae706d078d47fb49ce21e570478e1574704) jai-jail: init at 0.3
* [`af7dd49a`](https://github.com/NixOS/nixpkgs/commit/af7dd49a512b3c95f3c6a3b55a6697524bab0c2c) nixos/jai-jail: init jai-jail
* [`c4a9b85e`](https://github.com/NixOS/nixpkgs/commit/c4a9b85e361297f35e3ae7ad153abfb235bf02d8) grafanaPlugins.victoriametrics-metrics-datasource: 0.24.0 -> 0.25.0
* [`ab4375f3`](https://github.com/NixOS/nixpkgs/commit/ab4375f3082c898b689ee8c4d4e36a6b14d085d6) jasp-desktop: 0.97.0 -> 0.97.1
* [`42308103`](https://github.com/NixOS/nixpkgs/commit/423081037386c0ceba5fadbb92bc2bd16325226b) clj-kondo: 2026.04.15 -> 2026.05.25
* [`5dc08e0d`](https://github.com/NixOS/nixpkgs/commit/5dc08e0d9a894c0bdbbe201f69564ff2e2fba96c) gat: 0.27.3 -> 0.30.2
* [`613bce8f`](https://github.com/NixOS/nixpkgs/commit/613bce8f55eee6181c336499838cc1a3f427a2fd) clipse: 1.1.0 -> 1.2.1
* [`d3624302`](https://github.com/NixOS/nixpkgs/commit/d3624302abbbd62633e75454599ad40b6a4136f0) clipse: add maintainer magicquark
* [`67e80825`](https://github.com/NixOS/nixpkgs/commit/67e808253f3ed6a8fd3181e3a44a4ad51188f116) clipse: add meta.changelog
* [`66e65fc8`](https://github.com/NixOS/nixpkgs/commit/66e65fc82e5a8f04accdb695bffdff07346cc537) clipse: use strictDeps and structuredAttrs
* [`a584acd3`](https://github.com/NixOS/nixpkgs/commit/a584acd329ad5df332cf985e8f660b81891ba62f) libxfs: 6.19.0 -> 7.0.1
* [`627d6e94`](https://github.com/NixOS/nixpkgs/commit/627d6e94ebb2301a00d6df8e722057c0a332ef23) python3Packages.bond-async: migrate to pyproject
* [`56dc2b2e`](https://github.com/NixOS/nixpkgs/commit/56dc2b2ec61033f79b03cc26e388ec39d161af96) notesnook: 3.3.20 -> 3.3.21
* [`51a011b8`](https://github.com/NixOS/nixpkgs/commit/51a011b824a9865ffe9990a015eb0e4033a1e78d) python3Packages.bond-async: modernize
* [`52b332f6`](https://github.com/NixOS/nixpkgs/commit/52b332f694e4cdb782eaa64250fe686545702f78) python3Packages.boolean-py: migrate to pyproject
* [`e5e1c6ac`](https://github.com/NixOS/nixpkgs/commit/e5e1c6acd43cf79b59f9d08cca24dddfd6e208d4) python3Packages.boolean-py: modernize
* [`a5edb8f4`](https://github.com/NixOS/nixpkgs/commit/a5edb8f4e64a3b158757cb9bf2db7b67e2741f4b) python3Packages.qcelemental: 0.50.1 -> 0.50.2
* [`89a8313c`](https://github.com/NixOS/nixpkgs/commit/89a8313cefbf68cce589bae9bad688235566d7cf) pcsc-tools: 1.7.4 -> 1.7.5
* [`dd16d43a`](https://github.com/NixOS/nixpkgs/commit/dd16d43a35d19360351c4228ce71146650e27f08) lib.attrsets.mergeAttrsList: use simpler midpoint function
* [`c7816616`](https://github.com/NixOS/nixpkgs/commit/c7816616742f057d529e42963e2887115e5c060d) tests.overriding: attach fetchgit tests
* [`a985feb1`](https://github.com/NixOS/nixpkgs/commit/a985feb1605048c7390bf7cb179f78e01fdae772) vscode: 1.122.1 -> 1.123.0
* [`f3cae98e`](https://github.com/NixOS/nixpkgs/commit/f3cae98e65a3ac8613c371e48095bcb90eb351ab) steam-art-manager: 3.12.1 -> 3.16.0
* [`a7d3347c`](https://github.com/NixOS/nixpkgs/commit/a7d3347c5b9e57783c8ec08a9d6a13f21a98d5e4) kubernetes-helmPlugins.helm-diff: 3.15.7 -> 3.15.8
* [`f388a973`](https://github.com/NixOS/nixpkgs/commit/f388a973249278f3a92770ba73186df8e31e3fa3) htgettoken: wrap secondary programs
* [`5083b137`](https://github.com/NixOS/nixpkgs/commit/5083b1377152b05e24edcc78f6e1c26575b39178) perlPackages.DBI: 1.644 -> 1.648
* [`2de6e483`](https://github.com/NixOS/nixpkgs/commit/2de6e483172c1fb8fe6739862803e9964c562b31) pcloud: 2.1.0 -> 2.1.1
* [`cc079efb`](https://github.com/NixOS/nixpkgs/commit/cc079efbd88aef6188c58fa023f082bab84fddd5) codebuff: 1.0.674 -> 1.0.680
* [`011d17a7`](https://github.com/NixOS/nixpkgs/commit/011d17a76a325d77fee6437c639afd2596ed4bdb) quarkus: 3.35.3 -> 3.36.1
* [`2b7fb790`](https://github.com/NixOS/nixpkgs/commit/2b7fb7906e5292f13fd14817d37bbd4e528e37cc) python3Packages.trackpy: use finalAttrs
* [`53813bc6`](https://github.com/NixOS/nixpkgs/commit/53813bc60361b1e3b4e26e52b9b2ca33e5ab605e) python3Packages.trackpy: migrate to pyproject
* [`d881cf6b`](https://github.com/NixOS/nixpkgs/commit/d881cf6be3dfba42570ba0691294ed031490e8b8) python3Packages.treelog: use finalAttrs
* [`d6a5a17f`](https://github.com/NixOS/nixpkgs/commit/d6a5a17f9e3fb715d619f6f2cbb4e4bcfd5a5bb3) python3Packages.treelog: migrate to pyproject
* [`955aa6de`](https://github.com/NixOS/nixpkgs/commit/955aa6de6c8e0163a7709f467f8876022ea8e070) python3Packages.snakemake: 9.21.1 -> 9.22.0
* [`9d010c79`](https://github.com/NixOS/nixpkgs/commit/9d010c79c3c2ae076eb5cd32e51cd797c201c79c) scx.rustscheds: aarch64-linux is good
* [`ab836146`](https://github.com/NixOS/nixpkgs/commit/ab83614656d9fd079311137dd7ce379418e7958a) git-town: 23.0.1 -> 23.0.2
* [`bd9fecab`](https://github.com/NixOS/nixpkgs/commit/bd9fecab918245e313e47b3a2ec6d79f1b009d37) vscode-extensions.dart-code.flutter: 3.134.0 -> 3.136.0
* [`bb183bf5`](https://github.com/NixOS/nixpkgs/commit/bb183bf5b5dd96bf2bffbc617d390f681464e12e) cent: 2.0.0 -> 2.2.0
* [`3edd9a5d`](https://github.com/NixOS/nixpkgs/commit/3edd9a5d1df97e693dc7fcc97b303995b5c03564) antigravity-cli: clean up derivation
* [`c9e6c110`](https://github.com/NixOS/nixpkgs/commit/c9e6c110409d7adf8fa319b03a2d56e57ccda0d5) tokenspeed-triton-llvm: mark as broken on x86_64-darwin
* [`42a5bd28`](https://github.com/NixOS/nixpkgs/commit/42a5bd28c365c5ff7b217f71b334bfafb68c9977) vscode-extensions.RoweWilsonFrederiskHolme.wikitext: 4.0.4 -> 4.0.5
* [`f69ebf76`](https://github.com/NixOS/nixpkgs/commit/f69ebf763ce9dd38b07fc0d89ceffa13423b60d0) click: modernize
* [`22b65594`](https://github.com/NixOS/nixpkgs/commit/22b655942637b081ef694c162b7e5884d15408bc) ppython3Packages.rometheus-client: replace rec with finalAttrs
* [`08f0eaf0`](https://github.com/NixOS/nixpkgs/commit/08f0eaf008bfbc4981231bb47997b1a1a6676659) python3Packages.prometheus-client: add nix-update-script
* [`eeb56f01`](https://github.com/NixOS/nixpkgs/commit/eeb56f01e1023d6b105fa6d86e60013adf4ad20f) python3Packages.prometheus-client: 0.24.1 -> 0.25.0
* [`f8f995f5`](https://github.com/NixOS/nixpkgs/commit/f8f995f568977642003fbce3a70f6646ab1acb5d) rshell: modernize
* [`4c1ecd93`](https://github.com/NixOS/nixpkgs/commit/4c1ecd939bd63b6d406cfe7d3d9d4052e8dfd1fa) chatgpt: 1.2026.048 -> 1.2026.119
* [`811397a2`](https://github.com/NixOS/nixpkgs/commit/811397a21cd31c2f1d79cbf7dfd02d1f163ef1d8) pocket-id: 2.7.0 -> 2.8.0
* [`b81cffc9`](https://github.com/NixOS/nixpkgs/commit/b81cffc96ec602ee5c004394de9cd5241d2473a8) libtorrent-rakshasa: 0.16.11 -> 0.16.13
* [`0090501f`](https://github.com/NixOS/nixpkgs/commit/0090501fd17af5f2ce67891326aa358220850670) mas: modernize
* [`87262e65`](https://github.com/NixOS/nixpkgs/commit/87262e6569680a49998fb858ca7bd88004428d0e) ripgrep: modernize
* [`834cb1ff`](https://github.com/NixOS/nixpkgs/commit/834cb1ffe950a04d2b8c2aa0ff1c6e6d0f0d672f) vscode-extensions.divyanshuagrawal.competitive-programming-helper: 2026.5.1779885478 -> 2026.6.1780508121
* [`f6cb12e2`](https://github.com/NixOS/nixpkgs/commit/f6cb12e27ac3c96c93e3717b79f085c7b52ba2d6) python3Packages.triton-bin: enable __structuredAttrs
* [`f638d225`](https://github.com/NixOS/nixpkgs/commit/f638d22564c554b02fab46480f509d396b1d12bb) python3Packages.apex: fix CUDA capabilities selection in setup.py
* [`477cd352`](https://github.com/NixOS/nixpkgs/commit/477cd352f0e48956cf8435b8151f6804781f2791) python3Packages.apex: add missing ninja build dependency
* [`68b325de`](https://github.com/NixOS/nixpkgs/commit/68b325de92b55b9c7c9ae392d25bccc442b0df98) python3Packages.apex: rename local lerp to avoid ambiguity with std::lerp
* [`f012a712`](https://github.com/NixOS/nixpkgs/commit/f012a712b4576d41bccf8b4a791f581f7fd4c347) python3Packages.triton-bin: revisit cuda & rocm patching
* [`7e63a2e0`](https://github.com/NixOS/nixpkgs/commit/7e63a2e0093abd596c1033585533a1cba6c49b56) docker: 29.5.2 -> 29.5.3
* [`89fb005a`](https://github.com/NixOS/nixpkgs/commit/89fb005a9c855605afcbf3e885933d45820ebc9b) python3Packages.reflex: 0.9.2 -> 0.9.4
* [`b860e24b`](https://github.com/NixOS/nixpkgs/commit/b860e24bb432f6ec3c42dba018e6a239b50f72a1) python3Packages.certvalidator: migrate to pyproject
* [`8caa0b54`](https://github.com/NixOS/nixpkgs/commit/8caa0b549bcdecd0a8de1e1ed364100043fd0d30) python3Packages.certvalidator: modernize
* [`2e227e98`](https://github.com/NixOS/nixpkgs/commit/2e227e9836cc9ad25efd5b595f1b2d3225db2662) stellar-core: disable flaky PostgreSQL test
* [`3244b07e`](https://github.com/NixOS/nixpkgs/commit/3244b07e04d58b5beca5539a7a4bd49d92877db4) conan: Fix on Darwin
* [`21f2c8b2`](https://github.com/NixOS/nixpkgs/commit/21f2c8b2c7a9c6f3b874a88147549123c56c9477) python3Packages.cielo-connect-api: init at 1.0.6
* [`b98a390b`](https://github.com/NixOS/nixpkgs/commit/b98a390be27bc004003017c9cfad654ed9ddece9) home-assistant: update component packages
* [`cb960045`](https://github.com/NixOS/nixpkgs/commit/cb960045a04485141c5bf386c7c213d1d558ae1f) stellar-core: 26.1.0 -> 27.0.0
* [`89b172df`](https://github.com/NixOS/nixpkgs/commit/89b172dfa90c57a19c10927704b092d9172fb5b4) python3Packages.data-grand-lyon-ha: init at 0.8.0
* [`6fee0003`](https://github.com/NixOS/nixpkgs/commit/6fee000314eb39ddac18ae9ce3009ff8a7122c8f) home-assistant: update component packages
* [`604abf51`](https://github.com/NixOS/nixpkgs/commit/604abf51c26f457e348511c25426088b3fe8234d) python3Packages.chirpstack-api: migrate to pyproject
* [`3b73ba4c`](https://github.com/NixOS/nixpkgs/commit/3b73ba4c35be04b40edbb247c45a3c3e5259c456) python3Packages.chirpstack-api: modernize
* [`a3bb3a2f`](https://github.com/NixOS/nixpkgs/commit/a3bb3a2f50cebe2a2031ff0cfb5c9675aeaadc74) python3Packages.python-duco-connectivity: init at 0.6.0
* [`43e115a6`](https://github.com/NixOS/nixpkgs/commit/43e115a6927a3d0161fe4cd1e4add1bfda5379bd) python3Packages.circuit-webhook: migrate to pyproject
* [`ffa662bb`](https://github.com/NixOS/nixpkgs/commit/ffa662bbd33e42ca7732d2a4866467bf99b221b0) python3Packages.circuit-webhook: modernize
* [`2ccc38c2`](https://github.com/NixOS/nixpkgs/commit/2ccc38c2d19a682e25d8ca15bb7de1995fae50f2) python3Packages.circuitbreaker: migrate to pyproject
* [`f48d8c95`](https://github.com/NixOS/nixpkgs/commit/f48d8c95ab4afa9e94a92c8d48fdb1f841ae50b5) python3Packages.circuitbreaker: modernize
* [`ad1a2c16`](https://github.com/NixOS/nixpkgs/commit/ad1a2c16dd5a608e2e4a7a471f5a1b1fe27eae71) python3Packages.lg-rs232-tv: init at 1.2.0
* [`bb23471c`](https://github.com/NixOS/nixpkgs/commit/bb23471cb34bd44ff984758a491da223141f6ae4) home-assistant: update component packages
* [`569d438b`](https://github.com/NixOS/nixpkgs/commit/569d438b58d0448df289dd0ec3ed8235681e4027) python3Packages.classify-imports: migrate to pyproject
* [`1c8f9802`](https://github.com/NixOS/nixpkgs/commit/1c8f98020052b5aeb51f7ed4e368833836e4a9d1) python3Packages.classify-imports: modernize
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
