### PR TITLE
npins home-manager: update df391424 -> 1285cd3d

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -48,9 +48,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "df39142474950e42d5fc3bf2fef9d6c62abbe8d7",
-      "url": "https://github.com/nix-community/home-manager/archive/df39142474950e42d5fc3bf2fef9d6c62abbe8d7.tar.gz",
-      "hash": "sha256-01bTMR9ZPG+uxPaZBeOwagg5uxIaFYs2/3YIrOX+bCA="
+      "revision": "1285cd3d6882a9847f2d56ed5541b3350c8a6162",
+      "url": "https://github.com/nix-community/home-manager/archive/1285cd3d6882a9847f2d56ed5541b3350c8a6162.tar.gz",
+      "hash": "sha256-9GAF8sSsnkyCVCWkomXR0T+zdSxyUlfPt6neQidimdg="
     },
     "hs-grille": {
       "type": "Git",


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@df391424...1285cd3d](https://github.com/nix-community/home-manager/compare/df39142474950e42d5fc3bf2fef9d6c62abbe8d7...1285cd3d6882a9847f2d56ed5541b3350c8a6162)

* [`44901283`](https://github.com/nix-community/home-manager/commit/449012836eb1481b75e4c9db581366fb41fe89a3) voxtype: restart service when configuration changes
* [`c58ead12`](https://github.com/nix-community/home-manager/commit/c58ead12efcac436afffa93a22099a5595eb4157) voxtype: assert full service file in test
* [`8ff67d93`](https://github.com/nix-community/home-manager/commit/8ff67d938c5c52f9e68735ec67bd867d4669fc8b) i18n/inputMethod: remove da157 as maintainer
* [`408a6918`](https://github.com/nix-community/home-manager/commit/408a6918a0958e28391eab3afae063456358f13e) docs: advise contributors to generate module news entries
* [`d6f34138`](https://github.com/nix-community/home-manager/commit/d6f3413874fa18e0de53d6a4ab6ce7220658d7bc) nixpkgs-disabled: show offending definition locations in warning
* [`bd427772`](https://github.com/nix-community/home-manager/commit/bd4277722d215970366a405d280301a796a364fc) tests: add nixpkgs-disabled warning/assertion coverage
* [`c30f1777`](https://github.com/nix-community/home-manager/commit/c30f177760b872c2697835f1275758d36a667af4) docs: update release notes for 26.05
* [`6a66db13`](https://github.com/nix-community/home-manager/commit/6a66db1360359ce86fc810339239170fb29dfd0e) mcp: extract helper functions into lib/mcp.nix
* [`ebc55fd1`](https://github.com/nix-community/home-manager/commit/ebc55fd103473bf559587818c51483dd21a1e508) claude-code, codex, antigravity-cli, github-copilot-cli, opencode, vscode, zed-editor: use mcp lib
* [`1ffdc280`](https://github.com/nix-community/home-manager/commit/1ffdc28076a1809ee7c0cf08f06af18f31c480cd) news: add entry for programs.mcp typed schema
* [`cadadbc6`](https://github.com/nix-community/home-manager/commit/cadadbc6f4aa21e290d3e9dd653bd3e4ed6b9061) claude-code: omit unsupported mcp enabled field
* [`6cf5b64c`](https://github.com/nix-community/home-manager/commit/6cf5b64c126b2d675cb7620d9b3950bbc64d0a71) maintainers: add superflash41
* [`74887eae`](https://github.com/nix-community/home-manager/commit/74887eaee2995bbdba1f0fbd64e43c1d14a86eca) kiro-cli: add module
* [`2b394bec`](https://github.com/nix-community/home-manager/commit/2b394beca7413dc4e6050960666f261471c9aa0e) docs: fix sshAuthSock reference in rl-2605
* [`f96f717a`](https://github.com/nix-community/home-manager/commit/f96f717a47589c9d0b6e21f1a0d0d42d2c576f18) vscode: support path literals in userSettings
* [`7dbd305f`](https://github.com/nix-community/home-manager/commit/7dbd305f8b81050f223f00bcfbc8a6b74e048806) darcs: add defaults
* [`bb68a1a2`](https://github.com/nix-community/home-manager/commit/bb68a1a2e773050d64b18f5b23811c8f212c46c8) docs: add release notes contributing guidance
* [`d29e0ab7`](https://github.com/nix-community/home-manager/commit/d29e0ab7c27d95ad49094dba79ec7141f1d3378e) zsh: correctly handle autoloading functions starting with '-'
* [`19c41a5a`](https://github.com/nix-community/home-manager/commit/19c41a5a6d07fcbe585f42ab64bff6f95da5de25) zsh: escape siteFunction names
* [`486595d2`](https://github.com/nix-community/home-manager/commit/486595d2cf49cfcd649b58a284fa11ac0e34da22) zsh: make sure siteFunction names don't contain slashes
* [`c87a39aa`](https://github.com/nix-community/home-manager/commit/c87a39aa979acc4848016d2220c6238390d84779) Translate using Weblate (Italian)
* [`5b6f5733`](https://github.com/nix-community/home-manager/commit/5b6f5733726a1b2ccafb5dec6ac4ca7299fad66c) zed-editor: fix programs.mcp.servers compatibility
* [`1b7fb5e6`](https://github.com/nix-community/home-manager/commit/1b7fb5e6b42799d94a4ce0c8911b7184b0d10b15) maintainers: dump aguirre-matteo from almost all modules
* [`ed8263e7`](https://github.com/nix-community/home-manager/commit/ed8263e7d7813ec8f447e78e5dcd7f94f333f1d5) voxtype: fix output mode `paste`
* [`1285cd3d`](https://github.com/nix-community/home-manager/commit/1285cd3d6882a9847f2d56ed5541b3350c8a6162) keepassxc: Support macOS KeePassXC configuration
