### PR TITLE
npins nerd-icons.el: update d33d12f5 -> 35f6b8f1

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -99,9 +99,9 @@
       },
       "branch": "main",
       "submodules": false,
-      "revision": "d33d12f5dcb6bf2fb23c3f75df5de85beb4afd95",
-      "url": "https://github.com/rainstormstudio/nerd-icons.el/archive/d33d12f5dcb6bf2fb23c3f75df5de85beb4afd95.tar.gz",
-      "hash": "sha256-kMvhhWmRaH0jpxqID6jwNNde4w0aE6QL5ivUbe2TER8="
+      "revision": "35f6b8f1330049f20766d827148a7a1e261852e7",
+      "url": "https://github.com/rainstormstudio/nerd-icons.el/archive/35f6b8f1330049f20766d827148a7a1e261852e7.tar.gz",
+      "hash": "sha256-/OJLlZjPWFScbVtCFwNhFhZ0JpYThrICAgVJ7af/nfo="
     },
     "niv": {
       "type": "Git",


### PR DESCRIPTION
## Changelog for nerd-icons.el:
Branch: main
Commits: [rainstormstudio/nerd-icons.el@d33d12f5...35f6b8f1](https://github.com/rainstormstudio/nerd-icons.el/compare/d33d12f5dcb6bf2fb23c3f75df5de85beb4afd95...35f6b8f1330049f20766d827148a7a1e261852e7)

* [`839337dc`](https://github.com/rainstormstudio/nerd-icons.el/commit/839337dcbbb1c48e5f486b4ffffc928819bc78ab) feat(nerd-icons): Add case-insensitive matching for directory icons
* [`a193563d`](https://github.com/rainstormstudio/nerd-icons.el/commit/a193563d49bba2088c4a17ea527eddae06d16f6a) fix(nerd-icons): correct regex for JetBrains matching
* [`c77d5979`](https://github.com/rainstormstudio/nerd-icons.el/commit/c77d597942b2c6e70ca39ff375e1298da32bb9ff) fix(icons): Match "code" folder name case-insensitively
* [`35f6b8f1`](https://github.com/rainstormstudio/nerd-icons.el/commit/35f6b8f1330049f20766d827148a7a1e261852e7) feat(nerd-icons): support test folder
