### PR TITLE
npins zsh-patina: update efe6e759 -> fdbdce45

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -236,9 +236,9 @@
       },
       "branch": "main",
       "submodules": false,
-      "revision": "efe6e7593b9b21959996f0eee03b12db988b3e13",
-      "url": "https://github.com/michel-kraemer/zsh-patina/archive/efe6e7593b9b21959996f0eee03b12db988b3e13.tar.gz",
-      "hash": "sha256-hE7PFVE7CmLUALHwSfNWhwwXcy9ORiXYd4aP2Mg+c80="
+      "revision": "fdbdce4514b146afbead7362d3f31662bbcd111b",
+      "url": "https://github.com/michel-kraemer/zsh-patina/archive/fdbdce4514b146afbead7362d3f31662bbcd111b.tar.gz",
+      "hash": "sha256-M14IeK+Nsst+6RK6ayhq37YSoFPVptNqE9blVHDI1YM="
     },
     "zsh-syntax-highlighting": {
       "type": "Git",


### PR DESCRIPTION
## Changelog for zsh-patina:
Branch: main
Commits: [michel-kraemer/zsh-patina@efe6e759...fdbdce45](https://github.com/michel-kraemer/zsh-patina/compare/efe6e7593b9b21959996f0eee03b12db988b3e13...fdbdce4514b146afbead7362d3f31662bbcd111b)

* [`99bec55e`](https://github.com/michel-kraemer/zsh-patina/commit/99bec55ea79aad4d07084c59389fc4c745a65424) Add support for AUTO_CD option
* [`1359ede4`](https://github.com/michel-kraemer/zsh-patina/commit/1359ede4fd5da2276655881c50543115c8135fc6) Quote parameters to protect against SH_WORD_SPLIT being enabled
* [`d555f30b`](https://github.com/michel-kraemer/zsh-patina/commit/d555f30b1a5391eaf84ccce81a589374eacd7b63) Fix integration tests
* [`3a355859`](https://github.com/michel-kraemer/zsh-patina/commit/3a355859c66c58d52930a1abdf410eaca7e0611c) Specify when the protocol version number MUST be increased
* [`44baff27`](https://github.com/michel-kraemer/zsh-patina/commit/44baff277126c0d13d31473d54fe6ff83229f060) Update CHANGELOG
* [`fdbdce45`](https://github.com/michel-kraemer/zsh-patina/commit/fdbdce4514b146afbead7362d3f31662bbcd111b) Bump up version number to 1.8.0
