### PR TITLE
npins home-manager: update 1285cd3d -> c03e4752

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -48,9 +48,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "1285cd3d6882a9847f2d56ed5541b3350c8a6162",
-      "url": "https://github.com/nix-community/home-manager/archive/1285cd3d6882a9847f2d56ed5541b3350c8a6162.tar.gz",
-      "hash": "sha256-9GAF8sSsnkyCVCWkomXR0T+zdSxyUlfPt6neQidimdg="
+      "revision": "c03e4752899e55705dfa63979abd885c582a5c48",
+      "url": "https://github.com/nix-community/home-manager/archive/c03e4752899e55705dfa63979abd885c582a5c48.tar.gz",
+      "hash": "sha256-QOIRYSUFSq7L5mY3dZymaVhcnne3tPgoR9riB0WocjA="
     },
     "hs-grille": {
       "type": "Git",


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@1285cd3d...c03e4752](https://github.com/nix-community/home-manager/compare/1285cd3d6882a9847f2d56ed5541b3350c8a6162...c03e4752899e55705dfa63979abd885c582a5c48)

* [`a813a041`](https://github.com/nix-community/home-manager/commit/a813a0411300c832bcf8c980fe33ec663b498601) antigravity-cli: fix programs.mcp.servers integration for remote servers
* [`8aec76cc`](https://github.com/nix-community/home-manager/commit/8aec76cc1e045f37b55d82ca3cee4910ae04d3db) mkFirefoxModule: fix unexpected argument error on derivatives
* [`2d4f4e27`](https://github.com/nix-community/home-manager/commit/2d4f4e2788605eb8fe40fa5c7c63f3a7336b2367) maintainers: update all-maintainers.nix
* [`c03e4752`](https://github.com/nix-community/home-manager/commit/c03e4752899e55705dfa63979abd885c582a5c48) programs/thunderbird: stop writing directory prefs
