### PR TITLE
npins nerd-icons.el: update 35f6b8f1 -> a1d33ee7

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -99,9 +99,9 @@
       },
       "branch": "main",
       "submodules": false,
-      "revision": "35f6b8f1330049f20766d827148a7a1e261852e7",
-      "url": "https://github.com/rainstormstudio/nerd-icons.el/archive/35f6b8f1330049f20766d827148a7a1e261852e7.tar.gz",
-      "hash": "sha256-/OJLlZjPWFScbVtCFwNhFhZ0JpYThrICAgVJ7af/nfo="
+      "revision": "a1d33ee76d33fa5cd61b36b0de5d56b822fcd09e",
+      "url": "https://github.com/rainstormstudio/nerd-icons.el/archive/a1d33ee76d33fa5cd61b36b0de5d56b822fcd09e.tar.gz",
+      "hash": "sha256-Lb2NT6ddp66dPE9FAGXErFnONtSVfKYxR4iXt2t1CJY="
     },
     "niv": {
       "type": "Git",


### PR DESCRIPTION
## Changelog for nerd-icons.el:
Branch: main
Commits: [rainstormstudio/nerd-icons.el@35f6b8f1...a1d33ee7](https://github.com/rainstormstudio/nerd-icons.el/compare/35f6b8f1330049f20766d827148a7a1e261852e7...a1d33ee76d33fa5cd61b36b0de5d56b822fcd09e)

* [`e7d6eb59`](https://github.com/rainstormstudio/nerd-icons.el/commit/e7d6eb59a07ef8718f8c35d27cc08035457fe3e3) feat(icons): Update folder icon mappings and add `.npm` folder icon
* [`2d45867a`](https://github.com/rainstormstudio/nerd-icons.el/commit/2d45867a1083a21f0a087959df6ba97821e06186) feat(icons): Add icon for .cache folders
* [`b691c136`](https://github.com/rainstormstudio/nerd-icons.el/commit/b691c136995321e20e961518e704712a2640da46) fix(icons): correct icon for .cache folder
* [`a1d33ee7`](https://github.com/rainstormstudio/nerd-icons.el/commit/a1d33ee76d33fa5cd61b36b0de5d56b822fcd09e) feat(icons): Add icon for OTF font files
