### PR TITLE
npins powerlevel10k: update a0c9dbe8 -> 9253fb1c

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -132,9 +132,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "a0c9dbe80be404ff58e3ce5d7cf312582e370635",
-      "url": "https://github.com/romkatv/powerlevel10k/archive/a0c9dbe80be404ff58e3ce5d7cf312582e370635.tar.gz",
-      "hash": "sha256-5yASWIMiuEghMU1zEtjT8ztIdWrflWDbaqAt3Yh6o7w="
+      "revision": "9253fb1c5034410c43a0c681ff8294181c54016c",
+      "url": "https://github.com/romkatv/powerlevel10k/archive/9253fb1c5034410c43a0c681ff8294181c54016c.tar.gz",
+      "hash": "sha256-m1IM5sEEf/yVkISC12oVLdgyk0z98hp8OqolGu098zM="
     },
     "rh": {
       "type": "Git",


### PR DESCRIPTION
## Changelog for powerlevel10k:
Branch: master
Commits: [romkatv/powerlevel10k@a0c9dbe8...9253fb1c](https://github.com/romkatv/powerlevel10k/compare/a0c9dbe80be404ff58e3ce5d7cf312582e370635...9253fb1c5034410c43a0c681ff8294181c54016c)

* [`9253fb1c`](https://github.com/romkatv/powerlevel10k/commit/9253fb1c5034410c43a0c681ff8294181c54016c) fix a bug that triggers when SH_GLOB is set ([romkatv/powerlevel10k⁠#2887](https://togithub.com/romkatv/powerlevel10k/issues/2887))
