### PR TITLE
npins nixpkgs: update 9f11f828 -> 3e41b24a

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -120,8 +120,8 @@
       "type": "Channel",
       "name": "nixpkgs-unstable",
       "artifact": "nixexprs.tar.xz",
-      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-26.11pre1015979.9f11f828c213/nixexprs.tar.xz",
-      "hash": "sha256-X8fdRtvrm8OHLZ6Lkg3ZAQm5N6we5mLkdYd92vAw4c8="
+      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-26.11pre1017567.3e41b24abd26/nixexprs.tar.xz",
+      "hash": "sha256-eM+l4TVD26SNoEjcxRcpispqZi5Qrqj/G0ZY4LfqwfM="
     },
     "powerlevel10k": {
       "type": "Git",


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: release-26.11
Commits: [nixos/nixpkgs@9f11f828...3e41b24a](https://github.com/nixos/nixpkgs/compare/9f11f828c213...3e41b24abd26)

* [`582dc4aa`](https://github.com/NixOS/nixpkgs/commit/582dc4aab06d42cc2d2797d8280d5fec93ca345d) installer: remove all deprecated sd-image
* [`99c421b9`](https://github.com/NixOS/nixpkgs/commit/99c421b943c1286e4f35a9500da3db1f088fea90) vscode-extensions.ginfuru.better-solarized: init at 0.10.9
* [`f343fcf6`](https://github.com/NixOS/nixpkgs/commit/f343fcf6ebd8fd7f467d1b991cb0a2e2f7a2d16e) vscode-extensions.sourcery.sourcery: 1.37.0 -> 1.43.0, make sources different per platform
* [`7245b8ff`](https://github.com/NixOS/nixpkgs/commit/7245b8ff3087022145b9c1a56b12afa9f7e9b147) sourcery: 1.37.0 -> 1.43.0
* [`35ea5267`](https://github.com/NixOS/nixpkgs/commit/35ea5267403db0e2ecac272fa016e0a5f4b51f20) python3Packages.iplotx: 1.6.0 -> 1.7.1
* [`47df79e0`](https://github.com/NixOS/nixpkgs/commit/47df79e056c77436adabc5f0865dc96d2e0f4312) pj: 1.13.0 -> 1.14.0
* [`a2c16892`](https://github.com/NixOS/nixpkgs/commit/a2c168923d054830222be49f5b737f56a2131107) cni-plugins: 1.9.0 -> 1.9.1
* [`e5d27c1b`](https://github.com/NixOS/nixpkgs/commit/e5d27c1b2be0165d6c7ce83ffd652c18f382c590) ttdl: 4.25.1 -> 6.0.0
* [`22f3d00f`](https://github.com/NixOS/nixpkgs/commit/22f3d00fd6940262817277cc422fb7b2989599a9) vokoscreen-ng: 4.8.3 -> 4.9.0
* [`903b8bc1`](https://github.com/NixOS/nixpkgs/commit/903b8bc1c69ec3dc56858ab25762649a31b7e93f) python3Packages.pinecone-plugin-assistant: 3.0.2 -> 3.0.3
* [`335fb3d6`](https://github.com/NixOS/nixpkgs/commit/335fb3d68e7a99e2d8ad35d27499e3db44a09051) goaccess: 1.9.4 -> 1.10.2
* [`24eeb3b5`](https://github.com/NixOS/nixpkgs/commit/24eeb3b56ad53b2d4a37e8429e8270e9d9f30f50) python3Packages.junitparser: 4.0.2 -> 5.0.0
* [`953dd06e`](https://github.com/NixOS/nixpkgs/commit/953dd06ec644f340669c72d5ec2c556302d1fcb0) astroterm: 1.0.10 -> 1.2.0
* [`ac5c6d2d`](https://github.com/NixOS/nixpkgs/commit/ac5c6d2da0e7228699f9008912c2385d11023ee2) python3Packages.qemu-qmp: 0.0.5 -> 0.0.6
* [`8a566cb9`](https://github.com/NixOS/nixpkgs/commit/8a566cb9b57663630c628cc8a21b8fd282eb1387) python3Packages.libbs: fix dependencies
* [`af3057b2`](https://github.com/NixOS/nixpkgs/commit/af3057b2fe4e6be485cf5037795f5ef7a13b84db) python3Packages.ghidra-bridge: drop
* [`1e331e9d`](https://github.com/NixOS/nixpkgs/commit/1e331e9dbff0a1a2da78668a06f2fb7d65d6a868) python3Packages.jfx-bridge: drop
* [`6896a860`](https://github.com/NixOS/nixpkgs/commit/6896a860c53b658fcf5493c297fe6a2b010cb54c) deadbeefPlugins.statusnotifier: 1.6 -> 1.7
* [`a1e68111`](https://github.com/NixOS/nixpkgs/commit/a1e6811139347628cd1177535c702fc2a7b7e9c4) dvdisaster: 0.79.10-pl5 -> 0.79.10-pl6
* [`793d22a5`](https://github.com/NixOS/nixpkgs/commit/793d22a596c1a540aad8ead4f0f3c5c2ae30af02) monetdb: 11.55.3 -> 11.55.5
* [`6f44f7e5`](https://github.com/NixOS/nixpkgs/commit/6f44f7e5e421f2f8e62bc16704b7777e5e0c161f) boundary: 0.19.0 -> 0.21.2
* [`ad65d372`](https://github.com/NixOS/nixpkgs/commit/ad65d37200733423fa49ca2ec87b116a382d2dbd) ghq: 1.9.4 -> 1.10.1
* [`2122ecb7`](https://github.com/NixOS/nixpkgs/commit/2122ecb7418fbefd22bd4fe27e8132fb49ffd607) linuxPackages.facetimehd: 0.6.13 -> 0.7.0.1
* [`76a02b04`](https://github.com/NixOS/nixpkgs/commit/76a02b042d8fdf0423530c2c2592b50d01426827) vscode-extensions.sumneko.lua: 3.18.1 -> 3.18.2
* [`36f32084`](https://github.com/NixOS/nixpkgs/commit/36f3208413b6fa8e104e120dde7db918c153f9ae) python3Packages.pyhidra: drop
* [`69dfb709`](https://github.com/NixOS/nixpkgs/commit/69dfb709feb667b16ce5302be15db4a7bbbe9a6b) grafanaPlugins.grafana-googlesheets-datasource: 1.2.14 -> 2.5.0
* [`f6c3a18d`](https://github.com/NixOS/nixpkgs/commit/f6c3a18d60ddf603fbb00ce39a4e9c52137110b9) ettercap: fix link to changelog
* [`5093e727`](https://github.com/NixOS/nixpkgs/commit/5093e727357706df6630baff313c0cf47dc1cc7b) global: fix link to changelog
* [`c4063a05`](https://github.com/NixOS/nixpkgs/commit/c4063a05b2123795ba0b7ad21cbfd828a85661b0) tmux-plugins: add tmux-window-name
* [`ef9bed19`](https://github.com/NixOS/nixpkgs/commit/ef9bed19d2b5a64fe4d944cea0c7febd56bf3d3f) tmux-plugins.tmux-window-name: update description
* [`343be418`](https://github.com/NixOS/nixpkgs/commit/343be41891b6b37b5d1c21a12a46c1b33b732d39) maintainers: add ndom91
* [`23598472`](https://github.com/NixOS/nixpkgs/commit/23598472cfba0cb5aa50c4f9680e15a39cdc9ca8) tmux-plugins: reformat
* [`5a607ffd`](https://github.com/NixOS/nixpkgs/commit/5a607ffd37d88dcd29d5e8f5948d99221e3b3fc5) tmux-plugins.tmux-window-name: resolve home at runtime
* [`41bc5f42`](https://github.com/NixOS/nixpkgs/commit/41bc5f42608e257759ffafc3879ee716c9401ec7) avell-unofficial-control-center: migrate to pyproject
* [`bf01ec83`](https://github.com/NixOS/nixpkgs/commit/bf01ec83e9fe8f7630c8b78b9a28f44c80800946) vscode-extensions.ms-python.debugpy: 2025.18.0 -> 2026.6.0
* [`b5263579`](https://github.com/NixOS/nixpkgs/commit/b526357975c88437cd1db813b5cf6c70877f395f) vscode-extensions.ms-vscode.cpptools: 1.31.5 -> 1.32.2
* [`4d1cc139`](https://github.com/NixOS/nixpkgs/commit/4d1cc1390c326ab12cc7701867e8c0352269c744) ttdl: 6.0.0 -> 6.1.1
* [`ecec6419`](https://github.com/NixOS/nixpkgs/commit/ecec641991166650d6b88d48524450bfdfe10c46) python3Packages.retryhttp: 1.3.1 -> 1.4.0
* [`81dc56e4`](https://github.com/NixOS/nixpkgs/commit/81dc56e474cac53cf8e2a66f028283165a6743a5) maintainers: add joaosreis
* [`0fd25756`](https://github.com/NixOS/nixpkgs/commit/0fd25756ed8a38c3d305bc3df7ed8b8ee45fc4b0) todoist-cli: init at 1.61.2
* [`57a00e96`](https://github.com/NixOS/nixpkgs/commit/57a00e96fa2e2d86e7b02b900446edf65781f1eb) headlamp-server: 0.41.0 -> 0.42.0
* [`c92de47e`](https://github.com/NixOS/nixpkgs/commit/c92de47e8f2513edd061a2e6a505c2291b04257d) i-pi: 3.1.12 -> 3.2.0
* [`2ff989da`](https://github.com/NixOS/nixpkgs/commit/2ff989da5fcb9bb7c650b62a47babf2dd37f98a0) thcrap-steam-proton-wrapper: update repo owner
* [`72dc0b04`](https://github.com/NixOS/nixpkgs/commit/72dc0b04b41e69d7b58c48369ff3c5c783ed4b81) thcrap-steam-proton-wrapper: remove zenity dependency
* [`dea75373`](https://github.com/NixOS/nixpkgs/commit/dea75373f2eb9f7b4dfc0e9ba8eea6416530a8f3) thcrap-steam-proton-wrapper: 0-unstable-2024-04-03 -> 0-unstable-2026-02-11
* [`f4d4104b`](https://github.com/NixOS/nixpkgs/commit/f4d4104b16c4960ca76dbde59231e8be93963f01) ed-odyssey-materials-helper: 3.6.6 -> 3.7.0
* [`da20a2fe`](https://github.com/NixOS/nixpkgs/commit/da20a2fea6f212f3628d35ae79bc64d28aec8761) vscode-extensions.ms-azuretools.vscode-bicep: 0.42.1 -> 0.43.8
* [`f43ce11e`](https://github.com/NixOS/nixpkgs/commit/f43ce11e628e69d3ff4a6b4d33df13ac1624ba8f) homepage-dashboard: 1.12.3 -> 1.13.1
* [`e12e8340`](https://github.com/NixOS/nixpkgs/commit/e12e83406075733de4214b70693223ed7bfd0cce) zotero: Use release channel
* [`33880313`](https://github.com/NixOS/nixpkgs/commit/33880313864c9c8e78734d325aac085edee7d134) dxmt: init at 0.80
* [`28944238`](https://github.com/NixOS/nixpkgs/commit/28944238b88cf11b6b88e74c7e56b5e4cefb05bc) twitch-hls-client: 1.6.2 -> 1.7.0
* [`1e80c7f7`](https://github.com/NixOS/nixpkgs/commit/1e80c7f7ee6f8e20fb390206a97c0f5c2400c2ee) vscode-extensions.timonwong.shellcheck: 0.39.3 -> 0.39.5
* [`3a43b7e8`](https://github.com/NixOS/nixpkgs/commit/3a43b7e82e693b02acd6dd970692f232556bef6d) plezy: add opt-in workaround for aarch64-linux 16K page size bug
* [`f5862a51`](https://github.com/NixOS/nixpkgs/commit/f5862a51fbd01c012d5d134711643265b36270c7) openapi-changes: 0.0.78 -> 0.2.6
* [`36901508`](https://github.com/NixOS/nixpkgs/commit/36901508c755dbf7afa69266962b6a3e1d1ed9b8) python3Packages.entsoe-apy: 0.9.2 -> 1.1.0
* [`b8e9331d`](https://github.com/NixOS/nixpkgs/commit/b8e9331d8f2fde1100b0ef6de38f32e7b2636838) vscode-extensions.wakatime.vscode-wakatime: 30.0.8 -> 30.2.0
* [`5e9d9e6d`](https://github.com/NixOS/nixpkgs/commit/5e9d9e6d4293d042a4f0d03bf1c1cb650bd0d1eb) python3Packages.odfdo: 3.22.3 -> 3.22.8
* [`525daf9a`](https://github.com/NixOS/nixpkgs/commit/525daf9a0a122ed97195d3eca0241f9185278d8f) xq: 0.4.1 -> 0.5.0
* [`1e309fc6`](https://github.com/NixOS/nixpkgs/commit/1e309fc66db0ab78b2bdf5e330079fc5103f98d6) topydo: switch to PEP517 format
* [`6e189364`](https://github.com/NixOS/nixpkgs/commit/6e189364b4429ff27a18ee842005227fb66c5efd) python3Packages.pysdl3: add alfarel as maintainer
* [`71ca5aa7`](https://github.com/NixOS/nixpkgs/commit/71ca5aa786081e8b642567e556f7fcb6348e8f1d) digidrie: init at 0.3.1
* [`7cdf79c0`](https://github.com/NixOS/nixpkgs/commit/7cdf79c0c5eda656079b8889bfee9659f5da5e5d) python3Packages.troposphere: 4.10.1 -> 4.10.2
* [`a5875211`](https://github.com/NixOS/nixpkgs/commit/a587521131a9f30f8a382720851bbf028ba91fb9) maintainers: add vavakado
* [`1a1c1997`](https://github.com/NixOS/nixpkgs/commit/1a1c199750d38a6f5063eb7f5a78c6cbfc98b0b0) vscode-extensions.ndonfris.fish-lsp: 0.1.20 -> 0.1.22
* [`e2b10e67`](https://github.com/NixOS/nixpkgs/commit/e2b10e67a84813b5f362efc5340143609ca76405) vscode-extensions.scalameta.metals: 1.65.0 -> 1.66.0
* [`2bf8e5b7`](https://github.com/NixOS/nixpkgs/commit/2bf8e5b7e40f85a456bcfa0f26447e64fd7758b7) clickgen: migrate to pyproject
* [`09745cf3`](https://github.com/NixOS/nixpkgs/commit/09745cf3e9876ea80e12c6df2c01fa276372eb2c) clickgen: use finalAttrs
* [`636a7711`](https://github.com/NixOS/nixpkgs/commit/636a771192d0882c6906530bdde28caded9e2802) credslayer: drop
* [`748df122`](https://github.com/NixOS/nixpkgs/commit/748df122798f55333367c7025e2ca96be3a19e3b) vscode-extensions.ms-dotnettools.csharp: 2.131.79 -> 2.140.8
* [`8056882e`](https://github.com/NixOS/nixpkgs/commit/8056882e21679efde65763f65f1ee268403e8e34) pmbootstrap: 3.10.2 -> 3.10.3
* [`96a484e2`](https://github.com/NixOS/nixpkgs/commit/96a484e28e9b210ec25b50c619344541aac69dee) zotero: Fix build on x86_64-darwin
* [`1270538a`](https://github.com/NixOS/nixpkgs/commit/1270538a46501dbc5751600be063cab923a0f8d5) vscode-extensions.rooveterinaryinc.roo-cline: 3.52.0 -> 3.54.0
* [`134ab599`](https://github.com/NixOS/nixpkgs/commit/134ab5999edb7360150d1f4a5875718bf6566941) shpool: 0.9.8 -> 0.10.1
* [`9a03e493`](https://github.com/NixOS/nixpkgs/commit/9a03e4931fda89c2daa00b2846a7d88387966841) caffeine-ng: 4.2.0 -> 4.3.2
* [`bc775519`](https://github.com/NixOS/nixpkgs/commit/bc7755192748b43c1c19c994c0ae5eb86a71f388) inlyne: 0.5.0 -> 0.5.2
* [`7b38b2c0`](https://github.com/NixOS/nixpkgs/commit/7b38b2c0ded6b3f4068071432d2860b63c5dc82e) unofficial-homestuck-collection: upgrade Electron requirement to 14
* [`5c89ab85`](https://github.com/NixOS/nixpkgs/commit/5c89ab858d4470e7469a603cba739b8623e2acd2) stdenv/problems: only run problem if it's not ignored
* [`9a6ef996`](https://github.com/NixOS/nixpkgs/commit/9a6ef99663aa9f817cc90d8cb631b98f37bd3902) vscode-extensions.ms-pyright.pyright: 1.1.408 -> 1.1.410
* [`8e0a307e`](https://github.com/NixOS/nixpkgs/commit/8e0a307eaaabd5513987b4e424f24f299ad87220) gitlab-runner: 18.11.3 -> 19.0.0
* [`71faab30`](https://github.com/NixOS/nixpkgs/commit/71faab303130b724e7ae1c26ec68de485151cf1d) py-spy: 0.4.0 -> 0.4.2
* [`47bf2e23`](https://github.com/NixOS/nixpkgs/commit/47bf2e232a04f7c9aaccfdf9263d2f099d7457d9) identity: add glycin-loaders
* [`fa695d88`](https://github.com/NixOS/nixpkgs/commit/fa695d885eb613113e9f95c3799948d3cbfb0c44) nixos/fontconfig: add alias support
* [`3a86ce67`](https://github.com/NixOS/nixpkgs/commit/3a86ce673d4a245803c71c833016a823f95c5622) pandora-launcher-unwrapped: fix darwin build
* [`f42c7559`](https://github.com/NixOS/nixpkgs/commit/f42c7559a20b05d0dcddadc1b6632900832d3caa) python3Packages.frida-python: 17.5.1 -> 17.9.11
* [`3f6396ab`](https://github.com/NixOS/nixpkgs/commit/3f6396ab50007c7e9422c3071c35a41472d10d6c) hyprls: 0.13.0 -> 0.14.0
* [`bf6d12cb`](https://github.com/NixOS/nixpkgs/commit/bf6d12cbd8435e95bd1616c82a2f924a7da62bcc) material-design-icons: use installFonts
* [`d6e28363`](https://github.com/NixOS/nixpkgs/commit/d6e283635bd78248e69540932fe95b12cc7f80fb) metarial-design-icons: use finalAttrs
* [`3922abef`](https://github.com/NixOS/nixpkgs/commit/3922abef635d5eff49df931e9702617562e5c227) vscode-extensions.pkief.material-icon-theme: 5.33.1 -> 5.35.0
* [`33bb95df`](https://github.com/NixOS/nixpkgs/commit/33bb95dfa0a1764ab501245d963da8afdfde1889) hinoirisetr: init at 1.6.3
* [`f878a706`](https://github.com/NixOS/nixpkgs/commit/f878a706771ff08693e1b518f871d782f27a39a4) vscode-extensions.bmewburn.vscode-intelephense-client: 1.16.5 -> 1.18.4
* [`97f02cbd`](https://github.com/NixOS/nixpkgs/commit/97f02cbdeba44db2f248f1ed6aad92e14fb2f596) nixseparatedebuginfod2: 2.0.0 -> 2.0.1
* [`b5eba65f`](https://github.com/NixOS/nixpkgs/commit/b5eba65f8d0b66db0209f9a7afe24417fdde7c20) vscode-extensions.gitlab.gitlab-workflow: 6.78.1 -> 6.81.0
* [`5600422f`](https://github.com/NixOS/nixpkgs/commit/5600422f2ab56b230fb66ef2826a381cf68ee1bc) font-v: migrate to pyproject
* [`ac6aefc0`](https://github.com/NixOS/nixpkgs/commit/ac6aefc0846af68ddd00432e500ba51657bed300) font-v: use finalAttrs
* [`9f9d870b`](https://github.com/NixOS/nixpkgs/commit/9f9d870b0788fad33e7a1c8e27adc92b7c8db2a6) font-v: add changelog
* [`b8809193`](https://github.com/NixOS/nixpkgs/commit/b88091931b9a6c2993cd8aa98051909b790421df) gpaste: 45.3 → 45.5
* [`a0291726`](https://github.com/NixOS/nixpkgs/commit/a0291726b0f2e5d3598c800e3900faba619083dd) gemini-cli: 0.43.0 -> 0.44.1
* [`e2e2418e`](https://github.com/NixOS/nixpkgs/commit/e2e2418e60287c1a30a6254b84607de143eabfdd) byobu: 6.13 -> 6.15
* [`96ba26bd`](https://github.com/NixOS/nixpkgs/commit/96ba26bdc47374b8916297592f7cda3447d040bf) python3Packages.netbox-contract: 2.4.5 -> 2.4.6
* [`b88fba2f`](https://github.com/NixOS/nixpkgs/commit/b88fba2fba59c0addc1ca7c26445f4d212299bf6) stdenv/problems: avoid creating manual problems attrset
* [`5616e3d9`](https://github.com/NixOS/nixpkgs/commit/5616e3d9255badfaf9ad1940659b9ac6342d01e3) stdenv/problems: use early knowledge of allowBroken and allowBrokenPredicate
* [`753e43c9`](https://github.com/NixOS/nixpkgs/commit/753e43c931d8e6caadf6eca4cbe7bdfe8d7a42de) stdenv/problems: avoid a lookup for meta.broken
* [`41bafcbc`](https://github.com/NixOS/nixpkgs/commit/41bafcbc3488533fcb64a84e6df885f03c53957c) stdenv/problems: reverse parameter order for handlerForProblem
* [`0b304744`](https://github.com/NixOS/nixpkgs/commit/0b304744b80c6f5146c8a074f41316d94adc92ec) stdenv/problems: make handlerForProblem more performant with partial application
* [`85e32af8`](https://github.com/NixOS/nixpkgs/commit/85e32af8ef67bde9c5a8c7dbf06bb9dcec392c9f) stdenv/problems: don't create pname variable
* [`b575d12f`](https://github.com/NixOS/nixpkgs/commit/b575d12f87a0483a8a477711185c9810d071d3b2) vscode: append commandLineArgs after user args
* [`fa768397`](https://github.com/NixOS/nixpkgs/commit/fa768397acb50d570b801394843f52f299895f04) python3Packages.btrfsutil: migrate to pyproject
* [`5d833cec`](https://github.com/NixOS/nixpkgs/commit/5d833cec52078fcea43cdf57a92101ea90158f3a) python3Packages.btrfsutil: update homepage
* [`7b944799`](https://github.com/NixOS/nixpkgs/commit/7b944799c98421b873982b4cc8fb3836447eeeb8) rmapi: add boltzmannrain to maintainers
* [`d8df746f`](https://github.com/NixOS/nixpkgs/commit/d8df746f980bd5310367cb22a27fa12e44553ed9) python3Packages.gdown: 5.2.1 -> 6.1.0
* [`a07adfaa`](https://github.com/NixOS/nixpkgs/commit/a07adfaaaaa7df0ae236fbc4860a4a29aff4e99d) neomutt: 20260105 → 20260504
* [`2f40a56b`](https://github.com/NixOS/nixpkgs/commit/2f40a56b080e16aca69710f626bed167b4e0ee51) compsize: add myself as maintainer
* [`8a0c212b`](https://github.com/NixOS/nixpkgs/commit/8a0c212b74a3406368d9dc50fdd65acdfbca9b45) compsize: fix build with newer btrfs-progs
* [`92dc181a`](https://github.com/NixOS/nixpkgs/commit/92dc181ae124197f6d7a6c1e54ba02269d8b4e88) rhodium-libre: use installFonts hook
* [`a1cf905d`](https://github.com/NixOS/nixpkgs/commit/a1cf905d64b7385ecbf93d42eaf6890ca0ad5b10) vt323: use installFonts hook
* [`17117364`](https://github.com/NixOS/nixpkgs/commit/17117364c7190254004bf300d1d75175eccefd33) ostrich-sans: use installFonts hook
* [`5c67f42f`](https://github.com/NixOS/nixpkgs/commit/5c67f42faa526611fb7d1fc09bf71fa384b823bd) zilla-slab: use installFonts hook
* [`a1ccf58e`](https://github.com/NixOS/nixpkgs/commit/a1ccf58e341b3ef0429f7d35780a5a622fd0abec) drafting-mono: use installFonts hook
* [`e8a9da85`](https://github.com/NixOS/nixpkgs/commit/e8a9da85099afd09d6ff63108f61f93824089638) yafc-ce: 2.18.1 -> 2.19.0
* [`ee65c785`](https://github.com/NixOS/nixpkgs/commit/ee65c7852dcc61b78d3e5be8e90d5ed068d8ec56) rke2_1_33: 1.33.12+rke2r1 -> 1.33.12+rke2r2
* [`65cc3fa3`](https://github.com/NixOS/nixpkgs/commit/65cc3fa3deec298ba7cdc7d02bd602cb92aedb05) rke2_1_34: 1.34.8+rke2r1 -> 1.34.8+rke2r2
* [`e977b2b6`](https://github.com/NixOS/nixpkgs/commit/e977b2b66367e7ea24d30ea9717fc41601a3f45d) rke2_1_35: 1.35.5+rke2r1 -> 1.35.5+rke2r2
* [`84c6214d`](https://github.com/NixOS/nixpkgs/commit/84c6214db80e69fd965e9ad8ae26261a157d6d5d) rke2_1_36: 1.36.1+rke2r1 -> 1.36.1+rke2r2
* [`7ed40d1a`](https://github.com/NixOS/nixpkgs/commit/7ed40d1afc2d951690270be9e0e954b462f3d4bc) doc/release-notes: mention rke2 ingress-nginx retirement
* [`c1b9d04d`](https://github.com/NixOS/nixpkgs/commit/c1b9d04d9cf9ef877ffba9ba2efdd22f3bb98f3e) maintainers: drop momeemt
* [`9a19e598`](https://github.com/NixOS/nixpkgs/commit/9a19e5983d25c0fb9b698d9de984efc9ba807ffb) python3Packages.anyqt: migrate to pyproject
* [`0cf9d2ef`](https://github.com/NixOS/nixpkgs/commit/0cf9d2ef8e8d4e9155a7d75e8a9e5ca05df70d82) python3Packages.anyqt: modernize
* [`122520e8`](https://github.com/NixOS/nixpkgs/commit/122520e8ed54a0ba2b242a27a9999506cdfc23c9) python3Packages.anyqt: add meta.changelog
* [`a934c32d`](https://github.com/NixOS/nixpkgs/commit/a934c32d27702bc34b4553aa79a471715f1a0b22) btrfs-heatmap: adopt
* [`808e1300`](https://github.com/NixOS/nixpkgs/commit/808e13005f1c60abfc213129570f93830eaab850) btrfs-heatmap: modernize a bit
* [`b70f790b`](https://github.com/NixOS/nixpkgs/commit/b70f790be90eb88990bc9548b1d955233be76e7f) python3Packages.maubot: migrate to pyproject
* [`36383b07`](https://github.com/NixOS/nixpkgs/commit/36383b078df5e7e97af1eef87dd37fd316142884) python3Packages.maubot: migrate from rec to finalAttrs
* [`c5e10a38`](https://github.com/NixOS/nixpkgs/commit/c5e10a38d1c3679585c16e2db71cd870962c27f4) gif-for-cli: migrate to pyproject
* [`c3641d62`](https://github.com/NixOS/nixpkgs/commit/c3641d62717bf025bdf675121c1fdea39b62eec9) gif-for-cli: add ambossmann as maintainer
* [`07d5c6bc`](https://github.com/NixOS/nixpkgs/commit/07d5c6bc856f2a76287a070e2df4e7f6cf14f478) python3Packages.anyqt: re-enable tests via offscreen Qt platform
* [`64aee2f5`](https://github.com/NixOS/nixpkgs/commit/64aee2f5767e2245fbdbf6e19454bf3a7d900ee7) python3Packages.anyqt: disable failing tests on darwin
* [`7564b1fb`](https://github.com/NixOS/nixpkgs/commit/7564b1fb2589a87647ee3eb9ea815f2c296697ba) Revert "orca-slicer: add nanum font dependency"
* [`2a1cae7c`](https://github.com/NixOS/nixpkgs/commit/2a1cae7c678def180f6e5a54a7c0150e43d415b5) cpufetch: fix x86_64-darwin build (add sysctl.c on Darwin too)
* [`3e0a1edf`](https://github.com/NixOS/nixpkgs/commit/3e0a1edf88e45b9e20a2697434b55c0635bd545b) vscode-extensions.grafana.grafana-alloy: init at 0.2.0
* [`7800fc57`](https://github.com/NixOS/nixpkgs/commit/7800fc57dee70ec8db48a6a2674afdaee96675cc) python3Packages.maubot: use sqlalchemy_1_3 instead of custom one
* [`6629220f`](https://github.com/NixOS/nixpkgs/commit/6629220f5a47c043ef8dc1faa2e60fe20922eca8) aws-lc: 1.69.0 -> 5.0.0
* [`18ed2697`](https://github.com/NixOS/nixpkgs/commit/18ed26979e702670938a10b1478c00927d074045) blocky: 0.30.0 -> 0.31.0
* [`d4394b01`](https://github.com/NixOS/nixpkgs/commit/d4394b0197421fc818615ad3aad21792f3eb70d1) python3Packages.bch: migrate to pyproject
* [`ad3f2a85`](https://github.com/NixOS/nixpkgs/commit/ad3f2a854b460daaef3d6426f35c6058e6464b24) python3Packages.bencode-py: migrate to pyproject
* [`032ba37a`](https://github.com/NixOS/nixpkgs/commit/032ba37a5d12a309b67bdf8de5ff7e751f54289e) python3Packages.bencode-py: modernize
* [`4a511e15`](https://github.com/NixOS/nixpkgs/commit/4a511e15d052281bbb3c8cbb957209c364cfd956) python3Packages.biplist: migrate to pyproject
* [`977859e6`](https://github.com/NixOS/nixpkgs/commit/977859e62ad3134c4a32c8cf03845eca117bdf27) python3Packages.biplist: modernize
* [`8bbf639d`](https://github.com/NixOS/nixpkgs/commit/8bbf639d5d6f35e5af9e9e76240c56074d416852) python3Packages.brotli-asgi: migrate to pyproject
* [`52e3616c`](https://github.com/NixOS/nixpkgs/commit/52e3616c5486294472aa5d26bdf1b61e8ec339b2) maintainers: drop cameronfyfe
* [`271cc169`](https://github.com/NixOS/nixpkgs/commit/271cc169aebbcb02f4f44bde287d0d7ec0327dd5) panache: 2.49.0 -> 2.51.0
* [`fa6994dd`](https://github.com/NixOS/nixpkgs/commit/fa6994dd35cea16a2a5a112c299f6fa75b0467b4) haproxy: 3.3.10 -> 3.4.0
* [`be59fc82`](https://github.com/NixOS/nixpkgs/commit/be59fc82760a4bbc5a56144010372eb1dda5173a) python3Packages.azure-mgmt-domainregistration: init at 1.0.0b1
* [`5d06290b`](https://github.com/NixOS/nixpkgs/commit/5d06290ba0a0cca7f0f117f0f030f4c18c331e6e) azure-cli: 2.86.0 -> 2.87.0
* [`e863f1b7`](https://github.com/NixOS/nixpkgs/commit/e863f1b77d3dcb803e1a2da400eb68bbec350906) azure-cli-extensions.fileshare: init at 1.0.2
* [`d213b25f`](https://github.com/NixOS/nixpkgs/commit/d213b25fa3a89de52a7b505bff07523296dc602a) azure-cli-extensions.quantum: 1.0.0b13 -> 1.0.0b16
* [`d94d0530`](https://github.com/NixOS/nixpkgs/commit/d94d053017fdee4220120cadc0bcde266e47aaf1) azure-cli-extensions.oracle-database: 2.0.1 -> 2.0.3
* [`8d6b29a8`](https://github.com/NixOS/nixpkgs/commit/8d6b29a81ce5d57e695152c70335ba156b88fba1) azure-cli-extensions.fleet: 1.10.0 -> 1.10.1
* [`5abf4a5c`](https://github.com/NixOS/nixpkgs/commit/5abf4a5c15d57abd7199e7f2217d560a7c34994c) azure-cli-extensions.dataprotection: 1.10.0 -> 1.11.1
* [`40ce78a1`](https://github.com/NixOS/nixpkgs/commit/40ce78a18aa49254f8f0e8d017605eee87ae9061) azure-cli-extensions.appservice-kube: 0.1.11 -> 1.0.0b1
* [`c3728597`](https://github.com/NixOS/nixpkgs/commit/c372859756181f1877d874e22b481279d811edf2) azure-cli-extensions.azure-changesafety: 1.0.0b1 -> 1.0.0b2
* [`a734b579`](https://github.com/NixOS/nixpkgs/commit/a734b579cda3e30d023d0d551aa888080ceff92f) azure-cli-extensions.aks-preview: 20.0.0b8 -> 21.0.0b4
* [`1aa7e6b7`](https://github.com/NixOS/nixpkgs/commit/1aa7e6b7aea755d0f80be6e07aae03cf1705668a) azure-cli-extensions.site: 1.0.0b1 -> 1.0.0b2
* [`91aa08a4`](https://github.com/NixOS/nixpkgs/commit/91aa08a4dfb35026a3dbde9bce450290c0939896) azure-cli-extensions.amg: 2.8.1 -> 3.0.0
* [`f226a076`](https://github.com/NixOS/nixpkgs/commit/f226a076c98243852e35a94abdd0859f5a47322e) azure-cli-extensions.computelimit: 1.0.0b1 -> 1.0.0
* [`be5ab44c`](https://github.com/NixOS/nixpkgs/commit/be5ab44c632a00fa8f5b5d2730ee4173951750e3) azure-cli-extensions.networkcloud: 5.0.0b1 -> 5.0.0b2
* [`c696831a`](https://github.com/NixOS/nixpkgs/commit/c696831a2c33558cdff18522fce2c6ff4ae0e0f2) azure-cli-extensions.fileshares: remove
* [`c1e619e2`](https://github.com/NixOS/nixpkgs/commit/c1e619e2439a5c1d155f1389d0f85a59eb66fbc7) zotero: add nix test that builds with checks
* [`02aa57fa`](https://github.com/NixOS/nixpkgs/commit/02aa57fadd9f9c6259159feb40915b8c2e54b663) python3Packages.pipcl: 4 -> 7
* [`3a190696`](https://github.com/NixOS/nixpkgs/commit/3a1906969dca027edcfdbeec361e8430f209f1b0) fetchFromGitHub: allows overriding function name
* [`db29024d`](https://github.com/NixOS/nixpkgs/commit/db29024dbc110383e66abc6198cd77690e42a2d7) fetchFromGitea: allow overriding function name
* [`764db9de`](https://github.com/NixOS/nixpkgs/commit/764db9de84048c0b7a04a32222fb118244402a5d) fetchFromCodeberg: allow overriding function name
* [`c0c72e98`](https://github.com/NixOS/nixpkgs/commit/c0c72e9823b894589608aa0cd6beb9ba8b171444) python3Packages.scalar-fastapi: 1.6.1 -> 1.8.2
* [`26ae25d1`](https://github.com/NixOS/nixpkgs/commit/26ae25d15884aeeefa957a262d2fc9638cd3efc7) vscode-extensions.ms-azuretools.vscode-containers: 2.4.2 -> 2.4.5
* [`729cecc2`](https://github.com/NixOS/nixpkgs/commit/729cecc23f71f720e9b657266df2becafcf0e778) python3Packages.scalib: make portable
* [`2ec4a11a`](https://github.com/NixOS/nixpkgs/commit/2ec4a11a78abb311125854326ba3e8664fd7e75b) python3Packages.scalib: add nix-update-script
* [`880e95f7`](https://github.com/NixOS/nixpkgs/commit/880e95f7aa914573f23ad3deb2d7347a629e2533) python3Packages.streamlit: 1.55.0 -> 1.58.0
* [`45da54d8`](https://github.com/NixOS/nixpkgs/commit/45da54d89d2b9034ab3459c983666966179867e2) nixos-firewall-tool: set pname and version
* [`ff64d762`](https://github.com/NixOS/nixpkgs/commit/ff64d7622c1c702111dd07e4830e4dad2b3a5f1d) vscode-extensions.github.copilot-chat: 0.45.1 -> 0.48.1
* [`6adc99a7`](https://github.com/NixOS/nixpkgs/commit/6adc99a7af74812fec4ffb4faacb6b403506a316) python3Packages.co2signal: migrate to pyproject
* [`1aa1d55b`](https://github.com/NixOS/nixpkgs/commit/1aa1d55ba512a5bba8c707f9b7f982d84822394a) python3Packages.co2signal: modernize
* [`78abd8cb`](https://github.com/NixOS/nixpkgs/commit/78abd8cbd071d75bb0f337bec1ddbf011a0de528) vscode-extensions.detachhead.basedpyright: 1.39.6 -> 1.39.7
* [`aae28619`](https://github.com/NixOS/nixpkgs/commit/aae286190995cc4aa2f5c3bb88de38e4f54d0a13) nsc: 2.12.2 -> 2.15.0
* [`79abb5fd`](https://github.com/NixOS/nixpkgs/commit/79abb5fdca913d2e57891f647d83dc3f00c9e369) maintainers: remove maintainers with deleted GitHub accounts
* [`d1e32a66`](https://github.com/NixOS/nixpkgs/commit/d1e32a669df0ad55d22b3cfa4a84dbc09529b882) devbox: 0.17.2 -> 0.17.3
* [`2944a759`](https://github.com/NixOS/nixpkgs/commit/2944a759e2c967d3d3b0eb1c605f6e457591af0f) libmspub: 0.1.4 -> 0.1.5
* [`60188695`](https://github.com/NixOS/nixpkgs/commit/60188695d3fba9cf329ceb0bd7782d7ed3876d4b) libnfs: 5.0.2 -> 5.0.3
* [`ea283e2f`](https://github.com/NixOS/nixpkgs/commit/ea283e2fac23b9e613e56a58523f98e53547c761) hqplayerd: mark broken due to libsoup 2.4 removal
* [`0675a5f5`](https://github.com/NixOS/nixpkgs/commit/0675a5f5fb5d41aa58db06918c39be90d5831f9f) citrix_workspace: mark broken due to libsoup 2.4 removal
* [`f85c6a18`](https://github.com/NixOS/nixpkgs/commit/f85c6a18a02e13be0b094dc019c8fe17fe89278b) pragha: remove withLibsoup override option
* [`17cd1f1e`](https://github.com/NixOS/nixpkgs/commit/17cd1f1e60b7b8b26c93d12f2aa98730ac659c3f) desktop-postflop: drop
* [`f64a0024`](https://github.com/NixOS/nixpkgs/commit/f64a00248956c38fc3c57f13c175bfb39f2a5ec6) fondo: drop
* [`5d191f25`](https://github.com/NixOS/nixpkgs/commit/5d191f25c869b1a9aecf4637ec5234bbb28a90e5) gamehub: drop
* [`c3f3d49f`](https://github.com/NixOS/nixpkgs/commit/c3f3d49ff555948543117eee3449632665bb1a6c) glom: drop
* [`ee03cfe8`](https://github.com/NixOS/nixpkgs/commit/ee03cfe88587502c64bbcb4d0935c4f681e18a4a) libsigcxx30: 3.6.0 -> 3.8.1
* [`84b59faf`](https://github.com/NixOS/nixpkgs/commit/84b59fafeda7ce60f7ef06bf6e907c733e8deb3d) libepc: drop
* [`1e7e61c6`](https://github.com/NixOS/nixpkgs/commit/1e7e61c6c3f84360dc0459be0d15d059fbf2de3b) gupnp: drop
* [`aa960730`](https://github.com/NixOS/nixpkgs/commit/aa960730ff8d95b3baaedef9ca2014be324ab13c) gssdp: drop
* [`14d99f9d`](https://github.com/NixOS/nixpkgs/commit/14d99f9d242a7539291c11f5209cf983f9e5659d) mouse-actions-gui: drop
* [`27eb6c78`](https://github.com/NixOS/nixpkgs/commit/27eb6c78c3ceee52cdb3361c43abae5bc0dc20da) squirreldisk: drop
* [`27a1416e`](https://github.com/NixOS/nixpkgs/commit/27a1416e735b7aa6e07f659d177da980515ff383) xplorer: drop
* [`478173a5`](https://github.com/NixOS/nixpkgs/commit/478173a5ed92a45840010b6e8c41c66c4952cb14) alexandria: drop
* [`5eea0aab`](https://github.com/NixOS/nixpkgs/commit/5eea0aaba059e410cbbcb72d95cb102bd5d6b748) cargo-tauri_1: drop
* [`b8fd224d`](https://github.com/NixOS/nixpkgs/commit/b8fd224dc03cc5c55ca3ec8f9a3353d3a65f4129) nu-lint: 1.1.2 -> 1.2.1
* [`a28026df`](https://github.com/NixOS/nixpkgs/commit/a28026df2708570bbfc410e21b3ef14b11f7f862) zapzap: 6.5.0.0.1 -> 6.5.1
* [`5525b547`](https://github.com/NixOS/nixpkgs/commit/5525b5476b2ce300de7c6c3a67901faf08e947e2) maintainers: add 0xSA7
* [`b858e5f9`](https://github.com/NixOS/nixpkgs/commit/b858e5f918bd0a5cc4767e1a31ec7065ad3950b5) coulomb: fix wrapper injection, missing GUI icons, and add co-maintainer
* [`6602b3e2`](https://github.com/NixOS/nixpkgs/commit/6602b3e2fcc00d25b2d76ed346427ef198ca7285) vscode-extensions.ms-windows-ai-studio.windows-ai-studio: 1.0.1 -> 1.4.2
* [`5a938581`](https://github.com/NixOS/nixpkgs/commit/5a938581cb6c15abcc9a149d69358af00a7d4328) redo-apenwarr: fix tests in sandboxed darwin
* [`8d4e7807`](https://github.com/NixOS/nixpkgs/commit/8d4e7807ab3e657015000a2bb5c87165503a6ff7) ghidra-extensions.findcrypt: 3.1.8 -> 3.1.9
* [`9046dc10`](https://github.com/NixOS/nixpkgs/commit/9046dc105c7e2ef27de2692f07cbcee85263429b) python3Packages.pymeshlab: add missing dep
* [`c117cc6d`](https://github.com/NixOS/nixpkgs/commit/c117cc6dc124072973b957d6ed63c84298411be9) octavePackages.dicom: 0.7.2 -> 0.7.3
* [`c6ce45d5`](https://github.com/NixOS/nixpkgs/commit/c6ce45d55d5cd2067656c4b01e43254d4673bd21) door-knocker: 0.8.0 -> 0.9.0
* [`6e358fb2`](https://github.com/NixOS/nixpkgs/commit/6e358fb2edc6dba0b9763d32d1dafe048d38df48) apache-airflow: switch to finalAttrs, inline let binding
* [`5376b6f7`](https://github.com/NixOS/nixpkgs/commit/5376b6f7cefea3d306ac49d2480000f5e1a30fd5) libunibreak: 6.1 -> 7.0
* [`214e546f`](https://github.com/NixOS/nixpkgs/commit/214e546fc4fe3882b3c221b1c78194cc4b3717f3) haskellPackages: regenerate hackage packages
* [`8b79d460`](https://github.com/NixOS/nixpkgs/commit/8b79d46084a37016cf96bde6a86e831f2886f287) haskellPackages.{gi-soup2,spike}: mark broken
* [`7ab90434`](https://github.com/NixOS/nixpkgs/commit/7ab90434751fa1dbd05f0ed8f9ace7bd1d3c5ad9) libsoup_2_4: drop
* [`1e4bb05f`](https://github.com/NixOS/nixpkgs/commit/1e4bb05fbdca28db4047fe270851b21357e66ad5) haskellPackages: regenerate hackage packages after libsoup_2_4 drop
* [`3958be52`](https://github.com/NixOS/nixpkgs/commit/3958be52dee06cb2f3abb031f1a744cbc4a6784f) opl3bankeditor: 1.5.1-unstable-2026-05-23 -> 1.5.1-unstable-2026-06-06
* [`ebfc3f35`](https://github.com/NixOS/nixpkgs/commit/ebfc3f35f6b55f5d831bf0d6f9430f8e2f220010) secp256k1-jdk: init at 0.3
* [`7370ab89`](https://github.com/NixOS/nixpkgs/commit/7370ab8979b6cbfd61cd52b827176c940be46a1d) darwin.PowerManagement: update xcodeHash
* [`790e4890`](https://github.com/NixOS/nixpkgs/commit/790e489027d0305f9d89b79cae9d846c045a661d) qemu: 11.0.0 -> 11.0.1
* [`581de4f0`](https://github.com/NixOS/nixpkgs/commit/581de4f0111e342a0ebc1a13b515f5789a976335) matrix-commander-rs: 1.0.0 -> 1.0.1
* [`fd6d44b8`](https://github.com/NixOS/nixpkgs/commit/fd6d44b84961c1c015d55296ecb44a5b8ccd0d21) mt32emu-smf2wav: 1.9.2 -> 1.9.3
* [`a8626677`](https://github.com/NixOS/nixpkgs/commit/a862667798fedec66d6e9e0722b6fde3751f4393) mt32emu-qt: 1.12.1 -> 1.12.2
* [`fd125ef2`](https://github.com/NixOS/nixpkgs/commit/fd125ef2dce1de1defd2330ef9eeff657e2e82ad) devin-cli: optimize update.sh
* [`3041c741`](https://github.com/NixOS/nixpkgs/commit/3041c741c927e2aa4bd5441f468fbb1bd420f0eb) vscode-extensions.gruntfuggly.todo-tree: move to a separate file
* [`e42efda3`](https://github.com/NixOS/nixpkgs/commit/e42efda306ebc7ae691c413a6d2c395b15484819) vscode-extensions.gruntfuggly.todo-tree: adopt
* [`4cd58283`](https://github.com/NixOS/nixpkgs/commit/4cd58283471a7604545ea53be92af40e267fe9a6) vscode-extensions.gruntfuggly.todo-tree: modernize
* [`4f1d484e`](https://github.com/NixOS/nixpkgs/commit/4f1d484e4ee91eb5dd5043fafd8d60b4dbec892b) vscode-extensions.gruntfuggly.todo-tree: bundle ripgrep
* [`27096a58`](https://github.com/NixOS/nixpkgs/commit/27096a58408f5a641855ed9ac759362f521be7d1) napari: add requests module as dependency
* [`0c1890a8`](https://github.com/NixOS/nixpkgs/commit/0c1890a8006f3cd0346112399603eb769b866fcf) syncthing: add zainkergaye as maintainer
* [`a22e20d7`](https://github.com/NixOS/nixpkgs/commit/a22e20d775005c5d1ad847b8f33f129d7aa963ff) syncthing: 2.0.15 -> 2.1.0
* [`2e2ebf63`](https://github.com/NixOS/nixpkgs/commit/2e2ebf63acc70889b72ba2065a33f89208b11788) python3Packages.google-cloud-secret-manager: 2.28.0 -> 2.29.0
* [`0fc257bd`](https://github.com/NixOS/nixpkgs/commit/0fc257bd853c0d9e719f18aa796031f659d4f990) vscode-extensions.yy0931.vscode-sqlite3-editor: 1.0.212 -> 1.0.214
* [`da065749`](https://github.com/NixOS/nixpkgs/commit/da065749a3e4074e0c9ec32eb3c4675feffed935) python3Packages.pysmart: 1.4.2 -> 1.4.3
* [`124317ad`](https://github.com/NixOS/nixpkgs/commit/124317ad25cd677a767cca632976ffdcc1360e73) upx: 5.1.1 -> 5.2.0
* [`9c6576c9`](https://github.com/NixOS/nixpkgs/commit/9c6576c9290b1f92ca04872f182151fc5bc6264a) python3Packages.pymdown-extensions: 10.21.2 → 10.21.3
* [`cd580da6`](https://github.com/NixOS/nixpkgs/commit/cd580da6fb5f978aac7653cc87d39faea41e3dd8) vscode-extensions.fstarlang.fstar-vscode-assistant: 0.25.0 -> 0.25.4
* [`ea30bc14`](https://github.com/NixOS/nixpkgs/commit/ea30bc1408005565ac22f344882e7a22e0410e41) qgis-ltr: 3.44.10 -> 3.44.11
* [`08575002`](https://github.com/NixOS/nixpkgs/commit/0857500295e5c83fe24a1977be7419f086c97e98) tmuxPlugins.fingers: 2.6.2 -> 2.7.1
* [`eb5b956e`](https://github.com/NixOS/nixpkgs/commit/eb5b956e1a1e65d67da7d1d44bdeb39f6a2f95ee) galaxy-buds-client: 5.2.0 -> 5.2.1
* [`e4ee2531`](https://github.com/NixOS/nixpkgs/commit/e4ee25311f425f5704ef5a06f0dcd21ddcc38c9f) homebank: 5.10 -> 5.10.1
* [`17094c78`](https://github.com/NixOS/nixpkgs/commit/17094c7888874da144daf511abbbe5a49066df3c) python3Packages.primp: remove Cargo.lock
* [`9e389887`](https://github.com/NixOS/nixpkgs/commit/9e3898872c7cca39920ab56c89a715e333cbaa34) python3Packages.pysdl3: fix docfile hashes for 0.9.11b1
* [`de0b8778`](https://github.com/NixOS/nixpkgs/commit/de0b8778777c94355f690a5e1764b8c73290ad07) python3Packages.torchio: 1.2.0 -> 1.2.1
* [`08d6b594`](https://github.com/NixOS/nixpkgs/commit/08d6b5947a3234e8b4f881b3f3f8e8b935f724f8) devin-cli: 2026.5.26-6 -> 2026.5.26-8
* [`36d6ddd4`](https://github.com/NixOS/nixpkgs/commit/36d6ddd4dc712b47c3c92a951203ce593b6cea79) btrfs-auto-snapshot: 2.0.4 -> 2.1.1
* [`c974f3ca`](https://github.com/NixOS/nixpkgs/commit/c974f3caec00b7f5be43eaad8c37dd9cdf17c41e) brave: 1.91.168 -> 1.91.171
* [`4d11dd63`](https://github.com/NixOS/nixpkgs/commit/4d11dd63488e76280445544e9e3b8f39a0aa2e71) prowlarr: 2.3.5.5327 -> 2.4.0.5397
* [`459544c8`](https://github.com/NixOS/nixpkgs/commit/459544c809a2324861548ec03f3f87c7efbaa0a0) gitkraken: 12.1.2 -> 12.2.0
* [`46e86b0c`](https://github.com/NixOS/nixpkgs/commit/46e86b0c45e095c2e9f8f9c3ac952c34b863dc06) komodo: 1.19.5 -> 2.2.0
* [`e45516ba`](https://github.com/NixOS/nixpkgs/commit/e45516ba3bf2cccc2bb34fec7e4e4477a71a365b) rocqPackages.micromega-plugin: fix hash
* [`97c54d4c`](https://github.com/NixOS/nixpkgs/commit/97c54d4c1b143e861a469a57ef464efff9a4cd1a) xpipe: 23.3 -> 23.4
* [`a7be344f`](https://github.com/NixOS/nixpkgs/commit/a7be344fe775f9153f08ee95d7dbbc5ac75c072d) nixos/system/boot/tzpfms: init
* [`b7efdea3`](https://github.com/NixOS/nixpkgs/commit/b7efdea3083d3a39eba89cac50366725fd817043) nixosTests.tzpfms: init
* [`bba79401`](https://github.com/NixOS/nixpkgs/commit/bba794014d834b033a19cad8be1702924566f5de) vscode-extensions.betterthantomorrow.calva: 2.0.572 -> 2.0.591
* [`5c2334fb`](https://github.com/NixOS/nixpkgs/commit/5c2334fb9f3dfb1a9240627e6097264d8e41c2d5) ReGreet: add missing GStreamer dependencies
* [`e68093e1`](https://github.com/NixOS/nixpkgs/commit/e68093e1dbeb729f0efd855d6c72afd1fe1f5dd5) serve: remove unused args
* [`641e69c8`](https://github.com/NixOS/nixpkgs/commit/641e69c8100d9419b39fdaf49308a8687fc12a91) serve: 14.2.4 -> 14.2.6
* [`98db5ab6`](https://github.com/NixOS/nixpkgs/commit/98db5ab60e5845078d4c6061e790f36bb7c3cad3) serve: bump to pnpm 10
* [`f11399b4`](https://github.com/NixOS/nixpkgs/commit/f11399b492ab06f7cbd35daa73316e64f5fbdec6) kimai: 2.58.0 -> 2.59.0
* [`f1ddb60c`](https://github.com/NixOS/nixpkgs/commit/f1ddb60c45beb91a8b9e28eaa6cc21d766bf05a9) blackfire: 2.29.7 -> 2026.6.0
* [`13366479`](https://github.com/NixOS/nixpkgs/commit/133664791d9f3b537367698e9a5890a9ea6e457b) dotnetCorePackages.sdk_8_0: 8.0.421 -> 8.0.422
* [`36654459`](https://github.com/NixOS/nixpkgs/commit/366544599124ace5b81cc55c1c4df2823237e0ae) dotnetCorePackages.sdk_9_0: 9.0.314 -> 9.0.315
* [`381da955`](https://github.com/NixOS/nixpkgs/commit/381da955cb03aaa991c7ce15961d3fe50351f895) dotnetCorePackages.sdk_10_0: 10.0.300 -> 10.0.301
* [`65116f97`](https://github.com/NixOS/nixpkgs/commit/65116f97fcc597187930ee04acc296a747f632d3) nixos/xdg/autostart: actually disable generation of autostart units
* [`c6e5eed1`](https://github.com/NixOS/nixpkgs/commit/c6e5eed1b555fe2e4fbc1af84c1a06a79b42f442) python3Packages.g2pkk: enable __structuredAttrs
* [`fe808bb7`](https://github.com/NixOS/nixpkgs/commit/fe808bb787deab1610cdbcd02ef3774119602b3d) python3Packages.g2pkk: migrate to pyproject
* [`6e9b489e`](https://github.com/NixOS/nixpkgs/commit/6e9b489ec5ac4c2b55f8dbfc8d3dc7b8c68c0382) wikicurses: migrate to pyproject
* [`16acddf7`](https://github.com/NixOS/nixpkgs/commit/16acddf7e9a061be778b20a1b8c26ac544f21b89) wikicurses: use tag and hash
* [`854bc198`](https://github.com/NixOS/nixpkgs/commit/854bc198f2d3b2c047fe8bfcc42f7665c7cf2d56) blesh: build from source
* [`51c2ff34`](https://github.com/NixOS/nixpkgs/commit/51c2ff341a00095efd1cf7b315529a345937ff39) blesh: 0.4.0-devel3-unstable-2026-03-10 -> 0.4.0-devel3-unstable-2026-05-28
* [`32c82043`](https://github.com/NixOS/nixpkgs/commit/32c82043c91cac137df166bef02d237af1464d65) python3Packages.stravaweblib: use finalAttrs
* [`50dc5998`](https://github.com/NixOS/nixpkgs/commit/50dc5998315e783c5efffc14a7e31e7d7f2642fc) python3Packages.stravaweblib: enable __structuredAttrs
* [`0d041b8c`](https://github.com/NixOS/nixpkgs/commit/0d041b8c24af31d4d1b92c3256e20aa960de051a) python3Packages.stravaweblib: migrate to pyproject
* [`c594b885`](https://github.com/NixOS/nixpkgs/commit/c594b8858cd733301cb89141dbb9c9410ab1aa15) maintainers: remove berce
* [`7affa3eb`](https://github.com/NixOS/nixpkgs/commit/7affa3ebd17f3fbb8491706fc1ca084e23b4f29b) dotnetCorePackages.sdk_11_0: 11.0.100-preview.4.26230.115 -> 11.0.100-preview.5.26302.115
* [`d0dd8b45`](https://github.com/NixOS/nixpkgs/commit/d0dd8b455543fb4a4a9e7ac85f4dbac843dbf791) corefonts: use installFonts
* [`4c378e30`](https://github.com/NixOS/nixpkgs/commit/4c378e3078f593645a985446a62243fc6444a432) ty: 0.0.46 -> 0.0.47
* [`13b4ac09`](https://github.com/NixOS/nixpkgs/commit/13b4ac09e298203f8d2caefc39fd2513f5c9a88e) mergerfs: 2.41.1 -> 2.42.0
* [`9d985c5a`](https://github.com/NixOS/nixpkgs/commit/9d985c5ae84e3363bccd33ca7e52819a3927aa26) feishu-cli: 1.29.0 -> 1.32.0
* [`8e300bc8`](https://github.com/NixOS/nixpkgs/commit/8e300bc8eefd50a0756b259ccaa8b573f914c7c6) opn2bankeditor: 1.3-unstable-2026-01-01 -> 1.3-unstable-2026-05-05, switch to Qt6
* [`42ad0601`](https://github.com/NixOS/nixpkgs/commit/42ad0601dae873ec6898fb00d3526257cb356b55) shikane: 1.1.0 -> 1.1.1
* [`5b28b7f9`](https://github.com/NixOS/nixpkgs/commit/5b28b7f98e84da9639d35e4bc6c6c66cf3ddda25) ty: 0.0.47 -> 0.0.48
* [`af2a6623`](https://github.com/NixOS/nixpkgs/commit/af2a6623612da89775eb1728582e5c027e43ff32) gscreenshot: use hash
* [`18563e88`](https://github.com/NixOS/nixpkgs/commit/18563e8812fd2e5c95858f14ff399b49f0fc650f) gscreenshot: migrate to pyproject
* [`512b81bf`](https://github.com/NixOS/nixpkgs/commit/512b81bf8e0c81ec2cf5901ed71509ae41771704) gscreenshot: doCheck
* [`8c423e79`](https://github.com/NixOS/nixpkgs/commit/8c423e795b66ad33d9166b223f496324a393879f) python3Packages.types-urllib3: use finalAttrs
* [`80d610f4`](https://github.com/NixOS/nixpkgs/commit/80d610f4f607e07ddb0a4c7cb971bd513a9459e6) python3Packages.types-urllib3: enable __structuredAttrs
* [`7d9c064e`](https://github.com/NixOS/nixpkgs/commit/7d9c064e5ef036d49f6f3f46d7484addcffc331c) python3Packages.types-urllib3: migrate to pyproject
* [`30045e91`](https://github.com/NixOS/nixpkgs/commit/30045e9150a6b6483098bd52048a727ab77813e8) python3Packages.syslog-rfc5424-formatter: use finalAttrs
* [`99b6bf5e`](https://github.com/NixOS/nixpkgs/commit/99b6bf5ee9c557a35ae39d37bc43d40374200409) python3Packages.syslog-rfc5424-formatter: enable __structuredAttrs
* [`2ca78923`](https://github.com/NixOS/nixpkgs/commit/2ca789232f46ce8635f0f9f24f5aa6027429f006) python3Packages.syslog-rfc5424-formatter: migrate to pyproject
* [`d7094b96`](https://github.com/NixOS/nixpkgs/commit/d7094b961e2d411a3cb171d0fc5975d7e2453f11) python3Packages.syslog-rfc5424-formatter: add changelog
* [`5683ebbb`](https://github.com/NixOS/nixpkgs/commit/5683ebbb6c8a5ad89fc97d0c7c24da1572c67eed) slurm-spank-x11: run pre/post hooks for install and build phase
* [`2bd77eb5`](https://github.com/NixOS/nixpkgs/commit/2bd77eb5a48ba03b4146ae8e38e1f18f1e9e7e1a) slurm-spank-stunnel: cleanup
* [`0cc16429`](https://github.com/NixOS/nixpkgs/commit/0cc1642964e4fba7b0d9730305ef2493d1556437) h2o: 2.3.0-rolling-2026-06-04 → 2.3.0-rolling-2026-06-10
* [`8f5437cf`](https://github.com/NixOS/nixpkgs/commit/8f5437cf20d11ed4da6d78e140c4ef303eadcc7e) discord: recreate module symlinks on every launch
* [`47e5bac9`](https://github.com/NixOS/nixpkgs/commit/47e5bac99a97c1a10d6dec5a041e8927ccd76722) pypy3: fix mainProgram attribute for nix run
* [`3a8b38d4`](https://github.com/NixOS/nixpkgs/commit/3a8b38d4ee7cb9ecc9221af00f6eb4a0c43b8a19) nixos/polkit: modernize
* [`e88efa73`](https://github.com/NixOS/nixpkgs/commit/e88efa73069adf9abd9b0e78d10a1367560728d2) nixos/polkit: make pkexec opt-in
* [`0c1e323f`](https://github.com/NixOS/nixpkgs/commit/0c1e323f6aadc184674e45e1fcc3890d0108444c) nixos/installers/calamares: opt into pkexec
* [`581de971`](https://github.com/NixOS/nixpkgs/commit/581de9713ce0a5736a5680721222d31583d058ca) nixos/throne: opt into pkexec
* [`85af1956`](https://github.com/NixOS/nixpkgs/commit/85af19563a855c79870a03df8607ee998422bfff) nixos/xfce: opt into pkexec
* [`29e29c39`](https://github.com/NixOS/nixpkgs/commit/29e29c39b151f03795f8a4c9f9f2151959fa178f) nixos/cinnamon: opt into pkexec
* [`861d61d3`](https://github.com/NixOS/nixpkgs/commit/861d61d3a8ba08c67f875669f23843da10f75ec1) nixos/cosmic: opt into pkexec
* [`6e6895d6`](https://github.com/NixOS/nixpkgs/commit/6e6895d6bfbfcd889a98a4e6f001e0818467aba2) nixos/budgie: opt into pkexec
* [`947ef21d`](https://github.com/NixOS/nixpkgs/commit/947ef21d343d41b0fac2180afbc54acc8c55bef1) nixos/gnome: opt into pkexec
* [`00343843`](https://github.com/NixOS/nixpkgs/commit/00343843d4a153e1cbb0bace3d0bbeea0457f924) nixos/tuned: opt into pkexec
* [`6ef165d2`](https://github.com/NixOS/nixpkgs/commit/6ef165d25f172500e308e8dd2d3893ec9e774d2b) nixos/tests/timekpr: hook up in all-tests, migrate to container
* [`45d40120`](https://github.com/NixOS/nixpkgs/commit/45d40120be493bea3566af42aee59d8727618ae5) nixos/security/run0: enable guard, polkit, refactor
* [`f252c482`](https://github.com/NixOS/nixpkgs/commit/f252c4820dad8bb37d2b45e8b0d45a4b08321dee) nixos/gnome-remote-desktop: opt into pkexec
* [`3da26874`](https://github.com/NixOS/nixpkgs/commit/3da268745ad0ce3d36520bcd5dff78ec33a5ae61) nixos/installer/tools: enable run0 module
* [`517a082a`](https://github.com/NixOS/nixpkgs/commit/517a082accdd727933b69cf16809867b450ebb09) nixos/polkit: stop if changed
* [`36e2217e`](https://github.com/NixOS/nixpkgs/commit/36e2217e8c30e59f1708e44df9bf00c31565e476) discord: add Vulkan driver files in wrapper
* [`73c9e8d0`](https://github.com/NixOS/nixpkgs/commit/73c9e8d0fa59da12e5b8bd95ba010693f2eb2435) nixos/test/lomiri/desktop-appinteractions: use run0 for elevation
* [`1b92c623`](https://github.com/NixOS/nixpkgs/commit/1b92c623ee72fceb65d82c8f043789616ae9434e) ruff: 0.15.16 -> 0.15.17
* [`7a3819ed`](https://github.com/NixOS/nixpkgs/commit/7a3819ed28c9daf01944f51f31628ce9d3345e01) nixos/gamemode: opt into pkexec
* [`80ea7e8f`](https://github.com/NixOS/nixpkgs/commit/80ea7e8f54c5f3cb0e0f5f610051de3189377c3b) vscode-extensions.ms-dotnettools.vscode-dotnet-runtime: 3.0.0 -> 3.1.0
* [`65b4c272`](https://github.com/NixOS/nixpkgs/commit/65b4c272a698feccaa2226e435be767ac5f4d210) seconlay: 0-unstable-2026-05-29 -> 0-unstable-2026-06-09
* [`208d1083`](https://github.com/NixOS/nixpkgs/commit/208d1083a7c572a9a52f6c1b3aa24510dd4dae04) python3Packages.fastcore: 1.12.39 -> 1.13.3
* [`6ba3bb1c`](https://github.com/NixOS/nixpkgs/commit/6ba3bb1ceb41ef587402e68b2251c5ce312f365c) pulseaudio-module-xrdp: fix typo
* [`dd759b7e`](https://github.com/NixOS/nixpkgs/commit/dd759b7e0c3df554e7797f39be9e7f129c9c2368) python3Packages.google-cloud-appengine-logging: 1.8.0 -> 1.10.0
* [`90d45d9c`](https://github.com/NixOS/nixpkgs/commit/90d45d9cfa7f5724bf1e956a1ffaf2c5ade620c7) home-assistant-custom-components.polaris-mqtt: 1.1.4 -> 1.1.5
* [`0fafb687`](https://github.com/NixOS/nixpkgs/commit/0fafb6873a61c4531cc1ff1786060bb3beca3f74) python3Packages.growattserver: 2.1.0 -> 2.2.0
* [`bbf5214b`](https://github.com/NixOS/nixpkgs/commit/bbf5214bdc8813635b5bd259241bc8cd78f8f7fc) python3Packages.pyworxcloud: 6.4.0 -> 6.4.1
* [`62792026`](https://github.com/NixOS/nixpkgs/commit/62792026d8b0812da03459aadc5b4163d23e9371) musescore: simplify qt6.qtdeclarative override
* [`ad4fffd4`](https://github.com/NixOS/nixpkgs/commit/ad4fffd4f9d6d9e9bff11ba1567baeb228be97c6) musescore: 4.7.2 -> 4.7.3
* [`0f74ce6c`](https://github.com/NixOS/nixpkgs/commit/0f74ce6cef178c67c6a8aaf33d6bc7ed94721805) python3Packages.kafka-python: re-init at 2.3.2
* [`156b8dba`](https://github.com/NixOS/nixpkgs/commit/156b8dbaac8ca57b5d42d435993407fbc260441f) python3Packages.pytest-kafka: depend on kafka-python
* [`1ed537fb`](https://github.com/NixOS/nixpkgs/commit/1ed537fbefcb216dac074e0d8247ca5be0b36ba7) ty: 0.0.48 -> 0.0.49
* [`dc1be6a4`](https://github.com/NixOS/nixpkgs/commit/dc1be6a49893d33cc030527710c4fd52035d89d9) vscode-extensions.ms-vscode-remote.remote-containers: 0.447.0 -> 0.459.1
* [`73aed1eb`](https://github.com/NixOS/nixpkgs/commit/73aed1eb2a7b82f07cad3b3bd517e24a887fac06) llama-cpp: 9503 -> 9608
* [`5d496b05`](https://github.com/NixOS/nixpkgs/commit/5d496b05c32151272008f4971d97c4d390c983af) deno: de-vendor libffi in rusty-v8
* [`2e3c13c4`](https://github.com/NixOS/nixpkgs/commit/2e3c13c459af40de53bb9a3385497ea0bf280a53) clojure: add versionCheckHook
* [`cf7a0129`](https://github.com/NixOS/nixpkgs/commit/cf7a01297bc64b1ccfa4399f72c55cc50b41d6bf) ntpd-rs: 1.8.0 -> 1.9.0
* [`25be1beb`](https://github.com/NixOS/nixpkgs/commit/25be1beb51dc9c289635cea57caec21abc8a9ab6) mattermostLatest: 11.7.2 -> 11.7.3
* [`c85b1949`](https://github.com/NixOS/nixpkgs/commit/c85b1949aa3c396aa8dc12b511bf60d7c90264b6) python3Packages.opentelemetry-instrumentation-psycopg: init at 0.63b1
* [`478109bb`](https://github.com/NixOS/nixpkgs/commit/478109bb6c1e956612d9a9f7c90010b1b075120d) python3Packages.translate-toolkit: 3.19.5 -> 3.19.10
* [`fb9c3e09`](https://github.com/NixOS/nixpkgs/commit/fb9c3e09b4627fdb373cb07088d74e2680a0f2c9) python3Packages.social-auth-core: 4.8.5 -> 4.9.1
* [`181a52a4`](https://github.com/NixOS/nixpkgs/commit/181a52a4999773451cfe8d3cf7bcf507580d3db3) python3Packages.social-auth-app-django: 5.8.0 -> 5.9.0
* [`f7923509`](https://github.com/NixOS/nixpkgs/commit/f7923509f8a86ff9bda102a9b89d421b7b78d5b2) python3Packages.weblate-schemas: 2025.6 -> 2026.4, use fetchFromGitHub
* [`79f4be41`](https://github.com/NixOS/nixpkgs/commit/79f4be41c286b2f7eee03fab76629ac14ba303cc) python3Packages.translate-toolkit: 3.19.10 -> 3.19.11
* [`0d890069`](https://github.com/NixOS/nixpkgs/commit/0d890069f0e2674bd2457d6fd88e132f30f006f3) python3Packages.translation-finder: 2.24 -> 3.1
* [`9a4c4ed4`](https://github.com/NixOS/nixpkgs/commit/9a4c4ed4491c3cb90ac6032d6ea9dcf7a5e0f85d) weblate: 5.17 -> 2026.6.1
* [`01969555`](https://github.com/NixOS/nixpkgs/commit/01969555eec8b8732979a675ab5ed153dc42d635) python3Packages.dulwich: 1.2.1 -> 1.2.6
* [`167992c3`](https://github.com/NixOS/nixpkgs/commit/167992c3305f2fc6e4f3d2cb0974191fddcd3e09) python3Packages.ocrmypdf: 17.5.0 -> 17.6.0
* [`50ba7068`](https://github.com/NixOS/nixpkgs/commit/50ba7068921d70a164cc9f09007b86199bab5e79) vips: 8.18.2 -> 8.18.3
* [`7a991309`](https://github.com/NixOS/nixpkgs/commit/7a9913093a726a6870a58ed38e2684e0a318a9f9) plausible: 3.0.1 -> 3.2.1
* [`65cdf7a6`](https://github.com/NixOS/nixpkgs/commit/65cdf7a6ea369e232ea84417743967f653ca8fc5) routedns: 0.1.191 -> 0.1.208
* [`f104359e`](https://github.com/NixOS/nixpkgs/commit/f104359e69b356bf422962eae70dd97e93525dc0) node-gyp: 12.3.0 -> 13.0.0
* [`4985af20`](https://github.com/NixOS/nixpkgs/commit/4985af20df0af9470bfbbab6dfe994e7d84bbaac) python3Packages.curl-cffi: 0.14.0 -> 0.15.0
* [`8966c817`](https://github.com/NixOS/nixpkgs/commit/8966c8175a8e3d4013aaf45fc65d50d6bb603a9d) nzbhydra2: 8.8.1 -> 8.8.3
* [`1e63e85a`](https://github.com/NixOS/nixpkgs/commit/1e63e85a180ec8c7c8019aabeb035b5845bffd39) kdiskmark: 3.2.0 -> 3.3.0
* [`2bc09fbf`](https://github.com/NixOS/nixpkgs/commit/2bc09fbf7404c275da5a5287b565bace1fd52ccb) cppzmq: add panicgh to maintainers
* [`cfb7f7e2`](https://github.com/NixOS/nixpkgs/commit/cfb7f7e280f5332ffa53d6260b65b3140f095979) python3Packages.aioamazondevices: 14.0.0 -> 14.0.4
* [`ed102ca4`](https://github.com/NixOS/nixpkgs/commit/ed102ca478ce5df4388e7fcadaaef8214a1dc345) python3Packages.bthome-ble: 3.23.2 -> 3.23.4
* [`a35be327`](https://github.com/NixOS/nixpkgs/commit/a35be32796c6953f7e62d38695e3cdcd1debea80) python3Packages.ydiff: migrate to pyproject
* [`891b8d9d`](https://github.com/NixOS/nixpkgs/commit/891b8d9d2e64101469b879f67ba4733c61dda048) python3Packages.yubico-client: migrate to pyproject
* [`3dd35f36`](https://github.com/NixOS/nixpkgs/commit/3dd35f36709b1f3a44cdaee9a6562a85ddff241c) python3Packages.yoyo-migrations: migrate to pyproject
* [`2f70d13a`](https://github.com/NixOS/nixpkgs/commit/2f70d13a748807e30ae84336f9a0f97fec306745) python3Packages.yubico: migrate to pyproject
* [`a61d7fc7`](https://github.com/NixOS/nixpkgs/commit/a61d7fc7b4d8d560f9d947d4ff298a30b9fb5a97) python3Packages.yoyo-migrations: modernize
* [`190ba167`](https://github.com/NixOS/nixpkgs/commit/190ba167117a16d709622d49fcd978ee908641da) python3Packages.yubico: modernize
* [`9b07f7bd`](https://github.com/NixOS/nixpkgs/commit/9b07f7bd57852f73255cd98a0ddd9c8301f4f3b4) python3Packages.yubico-client: modernize
* [`05b52ad9`](https://github.com/NixOS/nixpkgs/commit/05b52ad9c5b846ea5a8af56a6adff8f276585df8) python3Packages.ydiff: modernize
* [`67fb5db0`](https://github.com/NixOS/nixpkgs/commit/67fb5db021f6e7b14bb3ab9823ea990d08ece4b3) spacetimedb: 2.4.0 -> 2.5.0-hotfix1
* [`9e6ec866`](https://github.com/NixOS/nixpkgs/commit/9e6ec866bf147eb0a7e3bc3d6cbf4afd998b6421) mutt: 2.3.2 -> 2.3.3
* [`537522bd`](https://github.com/NixOS/nixpkgs/commit/537522bdd48f50d6a72ae348e11cbc67b3276259) easycrypt: 2026.05 -> 2026.06
* [`815a7509`](https://github.com/NixOS/nixpkgs/commit/815a75098f69e15c03cf3ee4071e53aa799c470f) liferea: 1.16.10 -> 1.16.11
* [`852fa1bf`](https://github.com/NixOS/nixpkgs/commit/852fa1bf52e20c39714d19ae03760d5db9ebb6f6) gpu-viewer: 3.34 -> 3.35
* [`b72aa0e2`](https://github.com/NixOS/nixpkgs/commit/b72aa0e2903cc97624cb8c66d43d5bd99729cc4a) vectorscan: make use of compound licenses
* [`3b2e99d3`](https://github.com/NixOS/nixpkgs/commit/3b2e99d335cf0df38e74c491c01ef0381784c6c0) python3Packages.pyperscan: make use of compound licenses
* [`51c432fc`](https://github.com/NixOS/nixpkgs/commit/51c432fc5e99434790a40860d2281fcccf92e4e4) oniux: make use of compund licenses
* [`78fa7efe`](https://github.com/NixOS/nixpkgs/commit/78fa7efe8073b58d2bcd186e454b65524aae1f3d) cyme: 3.0.0 -> 3.0.1
* [`e8a87769`](https://github.com/NixOS/nixpkgs/commit/e8a87769f199a5a91e6bd32f5d02cfa851b353ac) python3Packages.zigpy-cc: migrate to pyproject
* [`9ee7545c`](https://github.com/NixOS/nixpkgs/commit/9ee7545cf9096e172d5397422ef2cc178aadc975) python3Packages.zxcvbn: migrate to pyproject
* [`5f486598`](https://github.com/NixOS/nixpkgs/commit/5f486598e62d6c74f0ee3f868e79f6fed9c31426) python3Packages.zigpy-cc: modernize
* [`787d6a89`](https://github.com/NixOS/nixpkgs/commit/787d6a89b8a8f262dc47531b2284cbc467dc9bbe) python3Packages.zxcvbn: modernize
* [`80dfb7cc`](https://github.com/NixOS/nixpkgs/commit/80dfb7cc82c903d460ca189cc3028faae886564a) yt-dlp: split `man` & `doc` outputs
* [`0d2f565f`](https://github.com/NixOS/nixpkgs/commit/0d2f565f17b617b2fe80a19ede36744aad7d8aa4) yt-dlp: `__structuredAttrs = true;`
* [`77a5e34b`](https://github.com/NixOS/nixpkgs/commit/77a5e34b11b5218f8dda31d9573c5a8008e337d1) python3Packages.vsts: migrate to pyproject
* [`c8c1a247`](https://github.com/NixOS/nixpkgs/commit/c8c1a2476ca086876d70193208a3ce06b0b511b6) python3Packages.vsts: modernize
* [`89cf5728`](https://github.com/NixOS/nixpkgs/commit/89cf57284e70900200272b3bb3c91c1db160a97b) python3Packages.opt-einsum-fx: init at 0.1.4
* [`8d8a002a`](https://github.com/NixOS/nixpkgs/commit/8d8a002aba3ff7a6f36604cb214dd857219321ef) python3Packages.e3nn: init at 0.6.0
* [`e749bb11`](https://github.com/NixOS/nixpkgs/commit/e749bb1151ce7086384cea0c35d88b3f6dd532c9) python3Packages.pytest-subtests: init at 0.15.0
* [`3e17027d`](https://github.com/NixOS/nixpkgs/commit/3e17027d913a93d61b0791a680690cf790dd31dc) python3Packages.matscipy: init at 1.2.0
* [`04b3bd8e`](https://github.com/NixOS/nixpkgs/commit/04b3bd8efca17267b1040711907326fb076aceb2) python3Packages.torch-ema: init at 0.3.0
* [`8b2f221d`](https://github.com/NixOS/nixpkgs/commit/8b2f221d44487d00d8ce76e878aa93a256240ac2) python3Packages.python-hostlist: init at 2.3.0
* [`f03ca2e0`](https://github.com/NixOS/nixpkgs/commit/f03ca2e04c7765cbefabfa49d97d67bdf33a08c7) python3Packages.mace-torch: init at 0.3.16
* [`541b6372`](https://github.com/NixOS/nixpkgs/commit/541b6372e7b1ca703b9084af78daaf8aaab2399b) python3Packages.triton-bin: 3.6.0 -> 3.7.0
* [`01134f01`](https://github.com/NixOS/nixpkgs/commit/01134f0172249c68a56adfb68a8e3392ce04fea7) python3Packages.hassil: 3.5.0 -> 3.7.0
* [`88d80f58`](https://github.com/NixOS/nixpkgs/commit/88d80f58b315eb0775ea6ef96114c1c0e29e69e4) python3Packages.pytrydan: 1.0.1 -> 1.0.2
* [`5d57dbb2`](https://github.com/NixOS/nixpkgs/commit/5d57dbb29310cc9716a978ba8324805491a95fd6) python3Packages.reolink-aio: 0.20.1 -> 0.21.0
* [`25a36905`](https://github.com/NixOS/nixpkgs/commit/25a36905be6e9a39def20406bc9018aa469d4638) home-assistant.frontend: 20260527.5 -> 20260527.6
* [`36fec065`](https://github.com/NixOS/nixpkgs/commit/36fec0654455b5eabbc6ad707725db319c0c8bcc) home-assistant: 2026.6.2 -> 2026.6.3
* [`76d906ad`](https://github.com/NixOS/nixpkgs/commit/76d906ada00902a4790a557a4a5d8e41bec5ba6e) home-assistant-custom-components.better_thermostat: 1.8.0 -> 1.8.1
* [`d85f04b8`](https://github.com/NixOS/nixpkgs/commit/d85f04b88693be50e60dc5fccc848cd379eaeb31) home-assistant-custom-components.blueprints-updater: 2.7.3 -> 2.7.4
* [`45562f44`](https://github.com/NixOS/nixpkgs/commit/45562f44f82541142816467aa79997dd6c7acc14) home-assistant-custom-components.dreo: 1.9.12 -> 1.9.13
* [`6310b395`](https://github.com/NixOS/nixpkgs/commit/6310b395fc3b2f5ec7be7bc25fd760e897b978e4) home-assistant-custom-components.polaris-mqtt: 1.1.4 -> 1.1.5
* [`3d62ab0d`](https://github.com/NixOS/nixpkgs/commit/3d62ab0dc46225581a7c72de6f207dc4538ec429) home-assistant-custom-components.yandex-station: 3.21.1 -> 3.21.2
* [`5d702ad3`](https://github.com/NixOS/nixpkgs/commit/5d702ad35a3c02cbf6b09c4de5ce5d28d11fd05f) home-assistant-custom-lovelace-modules.auto-entities: 2.3.1 -> 2.4.0
* [`dfb51b5a`](https://github.com/NixOS/nixpkgs/commit/dfb51b5a0f233818753040f197dce2188d14ff0f) stalwart-proxy: init at 1.0.0
* [`06a0e10b`](https://github.com/NixOS/nixpkgs/commit/06a0e10bd7daa74bc186a38f253ec303ac5a17e8) stalwart-vandelay: init at 1.0.2
* [`fec7aa49`](https://github.com/NixOS/nixpkgs/commit/fec7aa499b913fa0861eb30ec9fec7c1fe6a5dbc) hyprwhspr-rs: 0.3.29 -> 0.3.30
* [`46511941`](https://github.com/NixOS/nixpkgs/commit/465119411ac66ebe3ad21b00dbbce11d0204e0a1) vale: 3.14.2 -> 3.15.1
* [`256e4dfb`](https://github.com/NixOS/nixpkgs/commit/256e4dfb521ce8310a3833c1f8c8d304e24b4db9) libmt32emu: 2.8.2 -> 2.8.3
* [`b2737626`](https://github.com/NixOS/nixpkgs/commit/b2737626a03d2a2c5027a1a48a7678a55ce5243d) davmail: 6.7.0 -> 6.8.0
* [`ab447599`](https://github.com/NixOS/nixpkgs/commit/ab44759955d8b1185e0e2b785f7d394942c33c14) python3Packages.temporalio: 1.27.2 -> 1.28.0
* [`ce3af6b0`](https://github.com/NixOS/nixpkgs/commit/ce3af6b00b62c506cb7b212b6404cf0246c42c46) nvibrant: 1.2.0-unstable-595.58.03 -> 1.2.1-unstable-610.43.02
* [`12ebfbe9`](https://github.com/NixOS/nixpkgs/commit/12ebfbe912fd3b90f68203146f15ef15b24a6dff) claude-code: 2.1.175 -> 2.1.177
* [`cdb3bbf1`](https://github.com/NixOS/nixpkgs/commit/cdb3bbf1d2bca274631f1a36197386632a4ccda6) wasmi: 1.0.9 -> 1.1.0
* [`d0e07671`](https://github.com/NixOS/nixpkgs/commit/d0e076717f0f5a4ff174c3bb0262da735a72b03b) python314Packages.homeassistant-stubs: 2026.6.2 -> 2026.6.3
* [`28f78862`](https://github.com/NixOS/nixpkgs/commit/28f78862b1f2cbb63d3b0bda82568802f8685be0) shotwell: 0.32.16 -> 0.32.17
* [`f898d5da`](https://github.com/NixOS/nixpkgs/commit/f898d5da7fba151ca646aca6e6bb814fdcd25934) python3Packages.iamdata: 0.1.202606121 -> 0.1.202606131
* [`a5233e4b`](https://github.com/NixOS/nixpkgs/commit/a5233e4bc0180b9b5fc81b8280c49637cdf45f1d) python3Packages.mypy-boto3-acm: 1.43.0 -> 1.43.29
* [`668e1ffa`](https://github.com/NixOS/nixpkgs/commit/668e1ffaf47a3f9cba7d5bba09fce8403b72c0c5) python3Packages.mypy-boto3-eks: 1.43.28 -> 1.43.29
* [`18eec5cf`](https://github.com/NixOS/nixpkgs/commit/18eec5cf037404455b488e5c5a16e8da6b950455) python3Packages.mypy-boto3-firehose: 1.43.0 -> 1.43.29
* [`6afcabdf`](https://github.com/NixOS/nixpkgs/commit/6afcabdf66d67484048a153a2686c85ecf409f09) python3Packages.mypy-boto3-glue: 1.43.23 -> 1.43.29
* [`7fb11b21`](https://github.com/NixOS/nixpkgs/commit/7fb11b214ad5af9e4ba48a329b547541a4342275) python3Packages.mypy-boto3-iam: 1.43.2 -> 1.43.29
* [`ff4e1c7e`](https://github.com/NixOS/nixpkgs/commit/ff4e1c7ef97de753058fe5d91c56d4fc1cf89635) python3Packages.mypy-boto3-sagemaker-runtime: 1.43.0 -> 1.43.29
* [`ec86f830`](https://github.com/NixOS/nixpkgs/commit/ec86f8300f87a1c75e8b0f7cdf081b62903023ae) python3Packages.boto3-stubs: 1.43.28 -> 1.43.29
* [`0aa54ed1`](https://github.com/NixOS/nixpkgs/commit/0aa54ed1134b5dcf51949b37ca45ddbbc230c970) allmytoes: init at 0.5.1
* [`adc8c99c`](https://github.com/NixOS/nixpkgs/commit/adc8c99c6eec3080553bdc806ba4967551b61420) cargo-temp: 0.4.0 -> 0.4.1
* [`c88d408f`](https://github.com/NixOS/nixpkgs/commit/c88d408f308e38d1698efb1b40b7b824978cc0fa) yaziPlugins.allmytoes: init at 0-unstable-2025-11-05
* [`400ca636`](https://github.com/NixOS/nixpkgs/commit/400ca6362c69c4d43719587adea6f03330d0af5f) changie: 1.24.0 -> 1.24.1
* [`7ec9e020`](https://github.com/NixOS/nixpkgs/commit/7ec9e02044ce37cb4d15c117a12278e282a4ad22) matrix-alertmanager-receiver: 2026.6.3 -> 2026.6.10
* [`02f3c435`](https://github.com/NixOS/nixpkgs/commit/02f3c435d7d09e5fcaa54161817d0da4147ef5f6) vscode-extensions.vue.volar: 3.3.3 -> 3.3.5
* [`da525beb`](https://github.com/NixOS/nixpkgs/commit/da525beb6c40ee2245e7f8acdb6d316082b2a550) python3Packages.plover_5: handle PySide6-Essentials exclusion with pythonRemoveDeps
* [`22ecf4e4`](https://github.com/NixOS/nixpkgs/commit/22ecf4e4ab34caa7d5669d39e11bc5917d5aba65) plover_4, plover_5: add optional-dependencies.gui-qt
* [`54bbf1ff`](https://github.com/NixOS/nixpkgs/commit/54bbf1ffabc1249f413c605347a7016cb0f80aef) lsp-plugins: 1.2.29 -> 1.2.31
* [`ab1289f2`](https://github.com/NixOS/nixpkgs/commit/ab1289f284e8ecc91ca129cc222f64d94d20fe41) home-assistant-themes.material-you-theme: 5.0.13 -> 5.0.14
* [`5cf42582`](https://github.com/NixOS/nixpkgs/commit/5cf4258201a6f4d2dbae94b2274daa10897c4ca7) sublime: drop
* [`b53623ab`](https://github.com/NixOS/nixpkgs/commit/b53623ab0ed0f3914fde208a8d66a4e68d4f62d4) python3Packages.aioghost: 0.4.16 -> 0.4.17
* [`08b04d35`](https://github.com/NixOS/nixpkgs/commit/08b04d3581dc13760f5861bb0e034c91b4e7fca3) nixtamal: 1.5.4 → 1.6.0
* [`2785ccf8`](https://github.com/NixOS/nixpkgs/commit/2785ccf81c58da1ebd3a179e9a6aac4faec7fee8) mise: 2026.6.0 -> 2026.6.5
* [`85e46a1d`](https://github.com/NixOS/nixpkgs/commit/85e46a1d85cb0fedc6eeff33a2772b139dcc83bc) python3Packages.bleak-esphome: 3.9.1 -> 3.9.4
* [`47119c56`](https://github.com/NixOS/nixpkgs/commit/47119c56edb3ccf3a4f2014cd5acfd81d41961fa) vimPlugins.pantran-nvim: init at 0-unstable-2025-04-07
* [`3009f188`](https://github.com/NixOS/nixpkgs/commit/3009f1882839a5c967e5c18b8b84c3c5407b29a9) rr: only enable 32-bit support on x86_64
* [`bbc84aaf`](https://github.com/NixOS/nixpkgs/commit/bbc84aaf4e64390982580081874bea222ca76caa) python3Packages.pyghmi: 1.6.16 -> 1.6.17
* [`c3ab882d`](https://github.com/NixOS/nixpkgs/commit/c3ab882d9b6091e4a0016a3eafd46d8c96b86580) vacuum-go: 0.29.0 -> 0.29.2
* [`27b56516`](https://github.com/NixOS/nixpkgs/commit/27b5651677723199403c40592278a580ecd10a2d) dashy-ui: 4.2.2 -> 4.3.3
* [`9439a6d4`](https://github.com/NixOS/nixpkgs/commit/9439a6d40466b594fbbc2213d1b91c84b2d8e9cd) plausible: drop xanderio and e1mo as maintainers
* [`612e2b10`](https://github.com/NixOS/nixpkgs/commit/612e2b10c4fbe91253f28e9ac2276835886bfc78) python3Packages.py-tes: 1.1.2 -> 1.1.4
* [`32cb541c`](https://github.com/NixOS/nixpkgs/commit/32cb541cb12aefc7df80599079d7b51d38f0bea3) python3Packages.py-tes: migrate to finalAttrs
* [`2d2bf941`](https://github.com/NixOS/nixpkgs/commit/2d2bf941c924048d7003a755c12ae27e313384ea) python3Packages.plotnine: 0.15.6 -> 0.15.7
* [`30480a3c`](https://github.com/NixOS/nixpkgs/commit/30480a3cf9ce3ce25840630e4641f7d7e8aa6d48) python3Packages.types-awscrt: 0.33.0 -> 0.34.1
* [`872982f8`](https://github.com/NixOS/nixpkgs/commit/872982f894e4f47289cab6ad35e123060b802f8a) trivy: 0.71.0 -> 0.71.1
* [`db922240`](https://github.com/NixOS/nixpkgs/commit/db922240e209ed8986f905091be8f9dad0618401) maintainers: remove olebedev
* [`3e185214`](https://github.com/NixOS/nixpkgs/commit/3e1852144b4662fa27f37a6e1d4535ea6cd44e80) cudaPackages.gdrcopy: 2.5.2 -> 2.6
* [`e37315ec`](https://github.com/NixOS/nixpkgs/commit/e37315eca6f440b045d238c1482338e085b4f622) modprobed-db: 2.48 -> 2.50
* [`41ce8327`](https://github.com/NixOS/nixpkgs/commit/41ce8327861161e1492146b07e729c80729a472c) nirius: 0.7.1 -> 0.7.2
* [`57168743`](https://github.com/NixOS/nixpkgs/commit/57168743718ed7dd0c7fe390abf5a65eec5ab58a) maintainers: remove elasticdog
* [`2a73bf3e`](https://github.com/NixOS/nixpkgs/commit/2a73bf3e84bb0db4c76da5420172a9a3512d4d36) python3Packages.low-index: add update script
* [`5d6d986a`](https://github.com/NixOS/nixpkgs/commit/5d6d986a6466f2f0485de3ca04da3d0c8c945ee6) python3Packages.low-index: 1.2.1 -> 1.3
* [`27a2b77a`](https://github.com/NixOS/nixpkgs/commit/27a2b77a02b915449dbf00d78b169e1730991112) stalwart-cli: 0.15.5 -> 1.0.8
* [`28d26454`](https://github.com/NixOS/nixpkgs/commit/28d264547e5a2c2b73804039f66879e0ee89d4d5) swpui: 0.8.0 -> 0.9.0
* [`d88c6ea6`](https://github.com/NixOS/nixpkgs/commit/d88c6ea64d4bf9553dbdb6d68c41ebfe4a59524d) python3Packages.sonos-websocket: 0.1.3 -> 0.2.0
* [`fcadc5e1`](https://github.com/NixOS/nixpkgs/commit/fcadc5e1ce96516a8d169068e5a2b2f48c31c9fb) python3Packages.sonos-websocket: migrate to finalAttrs
* [`9fa50108`](https://github.com/NixOS/nixpkgs/commit/9fa50108ae12c18c5075eaf61396a13a62643c1d) trivy: clean-up
* [`2fe270b6`](https://github.com/NixOS/nixpkgs/commit/2fe270b6547fcb2939d06069796865902823d53b) bazel-gazelle: 0.47.0 -> 0.51.3
* [`b58a0c0c`](https://github.com/NixOS/nixpkgs/commit/b58a0c0caaa5876a4a45775dacb070840b83ecda) python3Packages.rf-protocols: 4.0.1 -> 4.2.0
* [`8a1d2aa2`](https://github.com/NixOS/nixpkgs/commit/8a1d2aa20ba34fc6ab05c4658f9bbb5c02b7dcfb) bazel-gazelle: modernize
* [`8970b145`](https://github.com/NixOS/nixpkgs/commit/8970b14527c6ca5e745bed07415c641208ff2795) bazel-gazelle: add hythera as maintainer
* [`22a42983`](https://github.com/NixOS/nixpkgs/commit/22a42983e56c9e6c134abcd01cb9eb638faee309) python3Packages.pyxbe: 1.0.3 -> 1.0.4
* [`b7ffb832`](https://github.com/NixOS/nixpkgs/commit/b7ffb83264c43f0b6c549afe2b4bc4a6de0530e1) python3Packages.pyxbe: migrate to finalAttrs
* [`33a471d3`](https://github.com/NixOS/nixpkgs/commit/33a471d3977f32f7d5a76d89d9ecb62eaec1a92f) python3Packages.pyworxcloud: 6.4.0 -> 6.4.1
* [`47868112`](https://github.com/NixOS/nixpkgs/commit/47868112099af99f34249a162aaf9ce611196bef) python3Packages.pytrydan: 1.0.1 -> 1.0.2
* [`5744c3b8`](https://github.com/NixOS/nixpkgs/commit/5744c3b8228d98b950eeedd423f085fa5853fe0f) sketchybar-app-font: 2.0.60 -> 2.0.62
* [`14e5d958`](https://github.com/NixOS/nixpkgs/commit/14e5d9588e575f3e0d90742d44073876afdcf34f) yaziPlugins.omni-trash: init at 0-unstable-2026-06-10
* [`49ac72e6`](https://github.com/NixOS/nixpkgs/commit/49ac72e6bbfd635e01418f50b90b0957da22ae40) home-assistant.python3Packages.pytest-homeassistant-custom-component: 0.13.338 -> 0.13.339
* [`e878e862`](https://github.com/NixOS/nixpkgs/commit/e878e862110e93d952c418172ca3fc22bb4d56c9) terraform-providers.auth0_auth0: 1.48.0 -> 1.49.0
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
