### PR TITLE
npins home-manager: update c03e4752 -> 471a1d2f

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -48,9 +48,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "c03e4752899e55705dfa63979abd885c582a5c48",
-      "url": "https://github.com/nix-community/home-manager/archive/c03e4752899e55705dfa63979abd885c582a5c48.tar.gz",
-      "hash": "sha256-QOIRYSUFSq7L5mY3dZymaVhcnne3tPgoR9riB0WocjA="
+      "revision": "471a1d2f840eb7fcbdfd541d99c13a64096f46db",
+      "url": "https://github.com/nix-community/home-manager/archive/471a1d2f840eb7fcbdfd541d99c13a64096f46db.tar.gz",
+      "hash": "sha256-SA7LyrayyZBvtzZnesnSLV7haciFuVLeZaX2hd5v4j4="
     },
     "hs-grille": {
       "type": "Git",


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@c03e4752...471a1d2f](https://github.com/nix-community/home-manager/compare/c03e4752899e55705dfa63979abd885c582a5c48...471a1d2f840eb7fcbdfd541d99c13a64096f46db)

* [`34dd288e`](https://github.com/nix-community/home-manager/commit/34dd288e65012954cf7170658e0e6a61255b0327) antigravity-cli: update skills deployment path
* [`df4e0465`](https://github.com/nix-community/home-manager/commit/df4e0465717a2d34f05b8ccd967275aaf3ceaa01) codex: Add support for installing plugins and marketplaces
* [`45e97d1e`](https://github.com/nix-community/home-manager/commit/45e97d1e8815564784e2d8fb0d9a429fc8751ddd) television: remove da157 from maintainers
* [`2a7b54df`](https://github.com/nix-community/home-manager/commit/2a7b54df12f9a7f4971effd162fd0c623ea43a59) prismlauncher: add themes option
* [`7664e05e`](https://github.com/nix-community/home-manager/commit/7664e05e2413d5e2b8c54a884eb8ea0f8a504fc2) maintainers: add ErinaYip
* [`524d73a9`](https://github.com/nix-community/home-manager/commit/524d73a9038e88a6b9c4945c6467da5f4e093b3d) mise: add bash completion to bash integration
* [`89fda224`](https://github.com/nix-community/home-manager/commit/89fda2248ec65b319c3cfc67a0d74f5429553e53) mise: add usage dependency for shell completions
* [`a2e23ee8`](https://github.com/nix-community/home-manager/commit/a2e23ee8f8699f8971b4fde86efc1b7ec1e19681) helix: make package nullable
* [`d2d79394`](https://github.com/nix-community/home-manager/commit/d2d79394a41aaa8677a6a8ce96f9ef2e6e694ae6) maintainers: remove adisbladis
* [`fa4e2f7e`](https://github.com/nix-community/home-manager/commit/fa4e2f7e101c2a656bdd910e49ae485bd2d8a358) modules/kdeconnect: stop overriding PATH, remove support for prehistoric versions
* [`a69e55d0`](https://github.com/nix-community/home-manager/commit/a69e55d05b7448e0f321aa01cf6bb390397b5114) fusuma: use lib.makeBinPath for service PATH
* [`ce68ac69`](https://github.com/nix-community/home-manager/commit/ce68ac69583368add045a38630f99d5a828a2199) lib/generators: short-circuit important-field check with any
* [`b8818d5a`](https://github.com/nix-community/home-manager/commit/b8818d5a65d34c84178e28e31608946b544b3e19) neovim: collect plugin configs with filter and map
* [`71b4b46f`](https://github.com/nix-community/home-manager/commit/71b4b46f23619ec60e18dc70ae2d1117dbae4545) thunderbird: use foldl' for profiles.ini merge
* [`9b262cb7`](https://github.com/nix-community/home-manager/commit/9b262cb73852bbdd779b7bc77625fb4e6318b348) browserpass: merge home.file entries with mergeAttrsList
* [`b06723c4`](https://github.com/nix-community/home-manager/commit/b06723c4d49310c4e982639d08e3bbe2deefa589) getmail: merge home.file entries with mergeAttrsList
* [`cbbddc4a`](https://github.com/nix-community/home-manager/commit/cbbddc4a6f9548fcc47a455e80b951dce10690b3) go: merge package src links with mergeAttrsList
* [`b3f454e5`](https://github.com/nix-community/home-manager/commit/b3f454e5c2bbc111d8d80a2396fdf51485dfe912) zsh: merge plugin home.file entries with mergeAttrsList
* [`50978d4b`](https://github.com/nix-community/home-manager/commit/50978d4bf61bc70a291a2ea97134b15ffab386af) neomutt: merge account rc files with mergeAttrsList
* [`ea0bf49c`](https://github.com/nix-community/home-manager/commit/ea0bf49c9d2a9c8f5548d116d63a7a1a35d1193d) thunderbird: merge account prefs with mergeAttrsList
* [`bfc00317`](https://github.com/nix-community/home-manager/commit/bfc003171bf09b633b1f3740d0de9f9bb203d45b) maintainers: add bittner
* [`a6931787`](https://github.com/nix-community/home-manager/commit/a69317872e58b84baf8c509a408fbcf7bf46a6aa) uv: add bittner as a maintainer
* [`c51ac59e`](https://github.com/nix-community/home-manager/commit/c51ac59e59f2a7362d71d1d01ab68b2c09d09347) uv: manage Python versions and tools
* [`a20c21b2`](https://github.com/nix-community/home-manager/commit/a20c21b2fedb701059d4416c21f84c57c37f90d7) maintainers: add csanthiago
* [`eb0eb170`](https://github.com/nix-community/home-manager/commit/eb0eb170bb0ec9eb27d3e46d3d2bf0085b642139) television: add csanthiago as maintainer
* [`c1870029`](https://github.com/nix-community/home-manager/commit/c187002980e3e7dfa584ec1f32d58fc0805945f9) television: add themes option
* [`5bcff431`](https://github.com/nix-community/home-manager/commit/5bcff43156c0eebe68759338b7879c8e1b2e2bd0) antigravity-cli: fix mcp validation error for remote/local servers
* [`652f7546`](https://github.com/nix-community/home-manager/commit/652f75468661f94b73361f8acbe0a84d4ac312be) difftastic: support difftool-only git integration
* [`6716d811`](https://github.com/nix-community/home-manager/commit/6716d811e5f6a0b9f014af3dcdfb9571e383e8cc) lib: add DAG-aware format generators
* [`b9a29e51`](https://github.com/nix-community/home-manager/commit/b9a29e51c52b4fd4064ed0b4ab93010ab1877e8d) opencode: support ordered settings entries
* [`5ccd408c`](https://github.com/nix-community/home-manager/commit/5ccd408ca759e695cde78b0bd9189d5dbde3b57b) dunst: use DAG ordered generator helper
* [`6274683e`](https://github.com/nix-community/home-manager/commit/6274683ee49d61bed9432764985eb116447e537b) mkFirefoxModule: add warning for dropped options on wrapped packages
* [`d456f483`](https://github.com/nix-community/home-manager/commit/d456f483f157d4b706416005da226234b9c116ff) codex: add profile config support
* [`8af17160`](https://github.com/nix-community/home-manager/commit/8af17160d162bda6f0861c5c7249347c5df16635) nixgl: preserve `__functionArgs` when forwarding `.override`
* [`9f9b23ae`](https://github.com/nix-community/home-manager/commit/9f9b23ae218b8484ef183d47ddf588e2def0f7c2) mkFirefox: add policy to accept added extensions
* [`a7860676`](https://github.com/nix-community/home-manager/commit/a786067676c8f4d4c705e2681448eaaa12679634) mkFirefoxModule: assert managed package for global extensions
* [`82432731`](https://github.com/nix-community/home-manager/commit/82432731d3251c80a68dee31434aef34023bb989) fontconfig: check warning in legacy default test
* [`4666af39`](https://github.com/nix-community/home-manager/commit/4666af39e94395b7ede108807b611ce4d63ecf12) fontconfig: clarify 'configFile.<name>.*' descriptions
* [`4ce68264`](https://github.com/nix-community/home-manager/commit/4ce682641dd935d12562c37ed6d67dcd4cdbf919) fontconfig: add 'configFile.<name>.target' option
* [`27a3154f`](https://github.com/nix-community/home-manager/commit/27a3154f427c17724659df859b54c04126365464) fontconfig: disallow null as config file source
* [`44414466`](https://github.com/nix-community/home-manager/commit/44414466726dce8b516048156c7489f5670b3ce1) fontconfig: generate config with `pkgs.formats.xml`
* [`c8f0b8ed`](https://github.com/nix-community/home-manager/commit/c8f0b8ed441c95bfeaf33555e7631044bb09f384) fontconfig: add RFC42-style config file settings
* [`0f4a317c`](https://github.com/nix-community/home-manager/commit/0f4a317c06ed69a4b15441490d46cdccd24c98c7) lib.hm.dag: performance improvements
* [`3abeedcf`](https://github.com/nix-community/home-manager/commit/3abeedcf409ecd8fca201646074bfb31797e8cc2) zellij: Avoid starting on dumb terminals
* [`26621164`](https://github.com/nix-community/home-manager/commit/266211649f4729ce7d52d6249f063c2c78aa8906) hyprland: fix plugin loading when using lua
* [`c804fab6`](https://github.com/nix-community/home-manager/commit/c804fab681f03ec772390af4421bcc9bce80c1d9) difftastic: fix typo in example
* [`43f9f0ab`](https://github.com/nix-community/home-manager/commit/43f9f0abc60d267585e61400b64a7f55f38a8c54) misc: move modules spanning multiple files into subdirs
* [`0043376f`](https://github.com/nix-community/home-manager/commit/0043376f4e861a6306cfb0de361cef4ae47bf0eb) docs: clarify module contribution guidance
* [`9b2afbdd`](https://github.com/nix-community/home-manager/commit/9b2afbdd4783ebcfb2885dad8079f7f37bb0f04e) docs: add contributing pointer
* [`6aaf73d1`](https://github.com/nix-community/home-manager/commit/6aaf73d18dca882b8e133f9aec7e299204f8ebe9) docs: build manual with mdbook
* [`fea02179`](https://github.com/nix-community/home-manager/commit/fea021792d4e33a2dd55f2a328a8851949d436ec) treefmt: format Python with ruff
* [`55730a2e`](https://github.com/nix-community/home-manager/commit/55730a2e34e71fafaf9b95eab98fb7b062b5f194) ssh: document DAG ordering patterns
* [`e061b008`](https://github.com/nix-community/home-manager/commit/e061b008856927dacf7adfcd44343f353413cbd8) broot: fix nushell integration br command
* [`153bad8f`](https://github.com/nix-community/home-manager/commit/153bad8fb58fd3ad9bbfcbdd0a965acc89a869e1) qt: stop rewriting platformTheme name gtk to gtk2
* [`37f21dfa`](https://github.com/nix-community/home-manager/commit/37f21dfa5d27e71b75bacd9418b156f9265e312e) tests: fix integration tests
* [`c3dfce6c`](https://github.com/nix-community/home-manager/commit/c3dfce6c630f22d98fd1976cb55df4b1fd657ab2) ci: bump actions/checkout from 6 to 7
* [`a4ee5403`](https://github.com/nix-community/home-manager/commit/a4ee5403cafbc708ad0f0d585965f1931ec340a8) home-manager: Pass extraArgs to nix-instantiate
* [`72a8bf11`](https://github.com/nix-community/home-manager/commit/72a8bf11c8448e16c94f8e71a5a692ca54f1e371) flake: bump nixpkgs from `ffa10e2` to `3e41b24`
* [`87622620`](https://github.com/nix-community/home-manager/commit/87622620549a8d92caf7e0203dd510071276fbfd) tests/darwinScrublist: add parallel-full
* [`8695ecb3`](https://github.com/nix-community/home-manager/commit/8695ecb389cb43449fba0494ffc21065c7cde39d) tests/firefox: avoid building librewolf
* [`61157d3c`](https://github.com/nix-community/home-manager/commit/61157d3c01f9790e53b9c98c343a0603d36ea8f5) pimsync: have type be the first directive in storage blocks
* [`ee6b160b`](https://github.com/nix-community/home-manager/commit/ee6b160bcb1d01307e79fcae5063c5bca2b8ef14) ci: avoid fork head checkout in backport
* [`78e7d8b1`](https://github.com/nix-community/home-manager/commit/78e7d8b13ecd7f5256a5c11ce216876164099d9f) ci: checkout base ref for backports
* [`e3e24bfd`](https://github.com/nix-community/home-manager/commit/e3e24bfd0f09cb64435b090409b1c3de820ef16e) podman: generate v2 registries.conf
* [`d1ccd072`](https://github.com/nix-community/home-manager/commit/d1ccd0721ec599866622665f3651e19e6e2d4c6a) news: add podman registries v2 entry
* [`5bf17310`](https://github.com/nix-community/home-manager/commit/5bf17310cf3399f6b61f1fdc459a79ccf0f3e4d0) docs: preserve legacy manual links
* [`8f3bc611`](https://github.com/nix-community/home-manager/commit/8f3bc611923787774852b09b556d62dfd97ebaf2) news: remove duplicate module announcements
* [`e45cc6e1`](https://github.com/nix-community/home-manager/commit/e45cc6e15ada91d078d84bee61819d1e64ec61f1) docs: fix manpage path
* [`e731ff60`](https://github.com/nix-community/home-manager/commit/e731ff60ec559ab29f70837561b918a288b37499) docs: correct test command guidance
* [`db97e414`](https://github.com/nix-community/home-manager/commit/db97e414d5457538f21bb332b972e13c609cbeba) docs: describe embedded module integration
* [`f3dc0b85`](https://github.com/nix-community/home-manager/commit/f3dc0b85833c6c9946ad1349ab810d07e0bdf761) docs: update platform module guidance
* [`d8dac1f6`](https://github.com/nix-community/home-manager/commit/d8dac1f668fd861369571be3678ec75b1573e7e3) ci: build docs in buildbot output
* [`979bfee6`](https://github.com/nix-community/home-manager/commit/979bfee6e1a7996fc395270d54c9b59e88762494) vicinae: add firefox mesaging host
* [`66eb0fc1`](https://github.com/nix-community/home-manager/commit/66eb0fc116a8ffce4810e09500d002d7b3ac254a) docs: clarify new module news conditions
* [`af11a877`](https://github.com/nix-community/home-manager/commit/af11a877f238208676b596a5b6c3f3d8dcf5a86b) nvibrant: add module
* [`cb6bcc43`](https://github.com/nix-community/home-manager/commit/cb6bcc43e7367fbfac62fc7ff1ae2d677de3d031) fzf: add nushell integration
* [`351959fc`](https://github.com/nix-community/home-manager/commit/351959fcdbe5cadec1c3434d7abd14dff31af2d5) fzf: Add tests
* [`6cb9da2a`](https://github.com/nix-community/home-manager/commit/6cb9da2a4deb02b6b7a2956d30002fd191a92dad) devenv: init module
* [`471a1d2f`](https://github.com/nix-community/home-manager/commit/471a1d2f840eb7fcbdfd541d99c13a64096f46db) news: Add devenv entry
