### PR TITLE
npins nerd-icons.el: update a1d33ee7 -> 2247dfb5

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -99,9 +99,9 @@
       },
       "branch": "main",
       "submodules": false,
-      "revision": "a1d33ee76d33fa5cd61b36b0de5d56b822fcd09e",
-      "url": "https://github.com/rainstormstudio/nerd-icons.el/archive/a1d33ee76d33fa5cd61b36b0de5d56b822fcd09e.tar.gz",
-      "hash": "sha256-Lb2NT6ddp66dPE9FAGXErFnONtSVfKYxR4iXt2t1CJY="
+      "revision": "2247dfb513a80aa5b1047f04fd9f2e9b41f336fd",
+      "url": "https://github.com/rainstormstudio/nerd-icons.el/archive/2247dfb513a80aa5b1047f04fd9f2e9b41f336fd.tar.gz",
+      "hash": "sha256-q0CcOHXVbQzUYNio70IKwM9Y2rU0txZjdW9QuTAxeOw="
     },
     "niv": {
       "type": "Git",


### PR DESCRIPTION
## Changelog for nerd-icons.el:
Branch: main
Commits: [rainstormstudio/nerd-icons.el@a1d33ee7...2247dfb5](https://github.com/rainstormstudio/nerd-icons.el/compare/a1d33ee76d33fa5cd61b36b0de5d56b822fcd09e...2247dfb513a80aa5b1047f04fd9f2e9b41f336fd)

* [`72d97a68`](https://github.com/rainstormstudio/nerd-icons.el/commit/72d97a68e7de4c411e5804ee944bec0b7515f1f6) feat(icons): Add new config and cache folder icons support
* [`158c5c19`](https://github.com/rainstormstudio/nerd-icons.el/commit/158c5c19f5e3fb5985c9887c5decde7162eeb1ce) feat(icons): Add support for test and gem folder icons
* [`72f13d98`](https://github.com/rainstormstudio/nerd-icons.el/commit/72f13d980aa43894e95b015eae0af76c9184d564) feat(icons): Add icon mapping for "src" folder
* [`7409583c`](https://github.com/rainstormstudio/nerd-icons.el/commit/7409583c9b87204b1ece0fc631beb564a6fa3295) feat(icons): Add icon mapping for "Applications" folder
* [`a9a9177e`](https://github.com/rainstormstudio/nerd-icons.el/commit/a9a9177e135dd407d508609ac4d9915eb8608b4f) feat(icons): Add SSH folder icon mapping
* [`2247dfb5`](https://github.com/rainstormstudio/nerd-icons.el/commit/2247dfb513a80aa5b1047f04fd9f2e9b41f336fd) ci(workflows): Update checkout action to version 7
