### PR TITLE
npins nixpkgs: update 04fdf0e8 -> d6d02fee

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -125,9 +125,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "04fdf0e855fe2fbb8265c4b55e91157b858d0be1",
-      "url": "https://github.com/nixos/nixpkgs/archive/04fdf0e855fe2fbb8265c4b55e91157b858d0be1.tar.gz",
-      "hash": "sha256-aABpzLYFldYBexYuGaqtGs9m8U8wyBYtGgpF6oEgGC4="
+      "revision": "d6d02feee3f04b50845bc743b58d3b88cd173e5f",
+      "url": "https://github.com/nixos/nixpkgs/archive/d6d02feee3f04b50845bc743b58d3b88cd173e5f.tar.gz",
+      "hash": "sha256-hnvtmFEwxEV8wehWmmwtXNMoMo+2eEaoNw8iF0nInO8="
     },
     "powerlevel10k": {
       "type": "Git",


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@04fdf0e8...d6d02fee](https://github.com/nixos/nixpkgs/compare/04fdf0e855fe2fbb8265c4b55e91157b858d0be1...d6d02feee3f04b50845bc743b58d3b88cd173e5f)

* [`2cadaefb`](https://github.com/NixOS/nixpkgs/commit/2cadaefb71ec91d6b62e704d7d22aac904a35d09) nixos/keepalived: support nftables for openFirewall
* [`b3f0199d`](https://github.com/NixOS/nixpkgs/commit/b3f0199d7d1f0e8b750e8e3041f225304f9cf414) jitsi-meet: make excalidraw and secureDomain usable independently of each other
* [`99f178da`](https://github.com/NixOS/nixpkgs/commit/99f178da12e5d424083c7e7f9ade6dd6d9508426) maintainers: add terrorw0lf
* [`ab2bc994`](https://github.com/NixOS/nixpkgs/commit/ab2bc9944360bd1e202d8f70d4814bc579d3566f) nixos/udev: Copy dmi_memory_id only if installed
* [`dacaaa8e`](https://github.com/NixOS/nixpkgs/commit/dacaaa8ef2a2c86135f63389aa2ffd4de155cb6d) maintainers: add uzlkav
* [`5b46bf8e`](https://github.com/NixOS/nixpkgs/commit/5b46bf8e2ceecb446b4953d08dcdc114a53ab334) basedpyright: remove references to nodejs source
* [`689b9668`](https://github.com/NixOS/nixpkgs/commit/689b966851e42866dcd3f16401c31ca374904f6b) python3Packages.coloraide: 7.0 -> 8.8.1
* [`8292d56c`](https://github.com/NixOS/nixpkgs/commit/8292d56c430f3a4724bd09cc9f52dbb7d06ad35f) deskflow: 1.25.0 -> 1.26.0
* [`3d88fa9c`](https://github.com/NixOS/nixpkgs/commit/3d88fa9ca887536d274bb26d23aa250a32908d58) python3Packages.pgvector: use lib.meta.availableOn to only run tests when supported
* [`e99b9048`](https://github.com/NixOS/nixpkgs/commit/e99b9048117a335b51fe152cb709a44bfbe5d139) r2modman: rip out update banner component from build
* [`d6931c46`](https://github.com/NixOS/nixpkgs/commit/d6931c4632f295a595d69f8ee76170ae03667e4d) obs-wayland-hotkeys: init at 1.1.0
* [`1775a78a`](https://github.com/NixOS/nixpkgs/commit/1775a78abeb1980fce5f3226473c72ee30c47549) umami: use finalAttrs pattern on prisma override
* [`97bfb5a0`](https://github.com/NixOS/nixpkgs/commit/97bfb5a0621f7978e73cd68033fc3813cfaf45da) greetd: purge greeter aliases
* [`29b576c7`](https://github.com/NixOS/nixpkgs/commit/29b576c757ba2a7f7591f6179b5c9c6ba0fa3f1c) greetd: correct license
* [`20c0861f`](https://github.com/NixOS/nixpkgs/commit/20c0861f8fe518ffed2d4e539d16ecbfba5d1054) gtkgreet: correct license
* [`329f778b`](https://github.com/NixOS/nixpkgs/commit/329f778bf64ddaaab17964c268bde5215812c1f3) wlgreet: correct license
* [`b6c83598`](https://github.com/NixOS/nixpkgs/commit/b6c8359810152534c8e6bda471e17847d279ef7e) bind: add json_c for JSON statistics channel support
* [`95d571d0`](https://github.com/NixOS/nixpkgs/commit/95d571d0f5e203e6b7238c4251f2364a29c97765) prometheus-bind-exporter: 0.7.0 -> 0.8.0
* [`d9a2e3b3`](https://github.com/NixOS/nixpkgs/commit/d9a2e3b3c0ba8d4edf67475e1c64b00202cc58c6) nixos/prometheus-exporters/bind: update for bind_exporter 0.8.0
* [`f9e4559b`](https://github.com/NixOS/nixpkgs/commit/f9e4559b773822abfa1c3a8decc9377144aa3bb2) nixosTests.prometheus-exporters.bind: check bind_up metric
* [`32594ebc`](https://github.com/NixOS/nixpkgs/commit/32594ebcb2f3ae77b2c846f2117f23c020695810) arelle: 2.38.7 -> 2.39.10
* [`40ff7208`](https://github.com/NixOS/nixpkgs/commit/40ff720834e45f57cda93252b4a2293cbbc0ca28) intel-llvm: support rocm/cuda builds without explicit path parameters
* [`8a1309cd`](https://github.com/NixOS/nixpkgs/commit/8a1309cd7c5d29b36d0c43358b74dffe3155cfd7) terminal-notifier: adopt
* [`e6bc6741`](https://github.com/NixOS/nixpkgs/commit/e6bc67413e560af19a0c58c1edb4d6663d070ef5) terminal-notifier: cleanup
* [`cb772b9e`](https://github.com/NixOS/nixpkgs/commit/cb772b9e7c0b1b3c86cf29ef02abade58df3fcae) terminal-notifier: build from source
* [`84b77664`](https://github.com/NixOS/nixpkgs/commit/84b776646baac3cdef24cebf7dcff65417b2e8c0) maintainers: add tophcodes
* [`b33dd986`](https://github.com/NixOS/nixpkgs/commit/b33dd986040392a9399245b6bdbb96745891abc8) nerdlog: init at 1.10.0
* [`433cbb42`](https://github.com/NixOS/nixpkgs/commit/433cbb426eb6a81b51418fdd4ebdc98050edef77) crowdsec: 1.7.7 -> 1.7.8
* [`518687b5`](https://github.com/NixOS/nixpkgs/commit/518687b52b2c77e4b34034362ff6f0107a400347) nixos/cosmic: remove unnecessary dependency of cosmic-session.target on xdg-desktop-autostart.target
* [`6d04d864`](https://github.com/NixOS/nixpkgs/commit/6d04d8643c699d5bd26fd3adfaca717b59dc58de) maintainers: add Mr-Stoneman
* [`ad73c80d`](https://github.com/NixOS/nixpkgs/commit/ad73c80d33f7a556e52106f2cfd61bf4c7873470) openresty: fix lib.optional misuse in configureFlags
* [`11a88ed4`](https://github.com/NixOS/nixpkgs/commit/11a88ed4561e3f078c468dd54a8d082000fd0c46) zapp: init at 1.0.1
* [`25604d3e`](https://github.com/NixOS/nixpkgs/commit/25604d3e68e4cdfc4d4b6e565eca66d3b32905e0) lib.strings.makeSearchPath: use concatMap rather than map and filter
* [`00f9c30e`](https://github.com/NixOS/nixpkgs/commit/00f9c30eaa178d8fe43584c8bc950c549eedbfd6) lib.strings.makeSearchPathOutput: only map once
* [`f765e4f3`](https://github.com/NixOS/nixpkgs/commit/f765e4f33e141e1d542d9af71098a111b2f01737) lib.strings.splitStringBy: bring map into the inner loop
* [`de312c12`](https://github.com/NixOS/nixpkgs/commit/de312c12a24051baf1667f6a49859942b4a9e68d) lib.strings.toShellVar: only check validity of name once
* [`9f5c9ea4`](https://github.com/NixOS/nixpkgs/commit/9f5c9ea4a8e8a85e040bbe2e66eb724747cd1fc1) lib.strings: throw instead of warning when passed a path
* [`94148625`](https://github.com/NixOS/nixpkgs/commit/94148625b00d3a1d00ffc1ba6f5114a208658739) lib.strings: check if throw is necessary before taking str
* [`35ba0226`](https://github.com/NixOS/nixpkgs/commit/35ba022673a1b3f7e227f33a9c18e14003eb0829) lib.strings: compute prefix and suffix lengths early
* [`28a5dc38`](https://github.com/NixOS/nixpkgs/commit/28a5dc3806d241582006e182d401714f59de7597) lib.strings.normalizePath: use our hasSuffix optimization
* [`7a0811c2`](https://github.com/NixOS/nixpkgs/commit/7a0811c24b36c60d6254271aa003e13f37ced55d) lib.strings.hasInfix: compute escaped infix early
* [`9ff4fe0e`](https://github.com/NixOS/nixpkgs/commit/9ff4fe0e9394f47391c8fc99a38a1c8e7f10147c) lib.strings.splitString: use builtins from global scope
* [`f908b7a7`](https://github.com/NixOS/nixpkgs/commit/f908b7a78c0751e56a88e0381caf4084c7537540) lib.strings.versionAtLeast: avoid an extra function call
* [`4a438d1a`](https://github.com/NixOS/nixpkgs/commit/4a438d1a8ae75fdc07da2aa22cde2491af299f82) lib.strings.toSentenceCase: use -1 trick instead of computing stringLength
* [`eecdf2b0`](https://github.com/NixOS/nixpkgs/commit/eecdf2b0cc813a737524cc7b2a7aa947b034e872) nixos/unifi: pass Java version via passthru
* [`1c2e62b7`](https://github.com/NixOS/nixpkgs/commit/1c2e62b709f9ef7fd086b4a45ad827c845a0bc1f) pg_activity: 3.6.1 -> 3.6.2
* [`60500b63`](https://github.com/NixOS/nixpkgs/commit/60500b6331ad4ab3aeecc4fb2538179cd053daa5) ultralytics: 8.4.48 -> 8.4.51
* [`2c636c76`](https://github.com/NixOS/nixpkgs/commit/2c636c7616026704d4790a0d370051972ee691e6) nixos/pam: allow disabling entirely
* [`43e1e2de`](https://github.com/NixOS/nixpkgs/commit/43e1e2de66bff3c76c8889716ba38adbde2ddeb0) pgroll: 0.16.1 -> 0.16.2
* [`7adb433f`](https://github.com/NixOS/nixpkgs/commit/7adb433f357744311548fa36d158191539165628) anydesk: fix broken updateScript, fix multi-arch hash update
* [`62e926d9`](https://github.com/NixOS/nixpkgs/commit/62e926d9ae741be74b22968ef38513ab226ac69f) by-name-overlay: use lib.flip to memoise {} being passed
* [`004a5b90`](https://github.com/NixOS/nixpkgs/commit/004a5b908d637b6bcd8d949e2c929cfd63648a1d) opencolorio: 2.5.1 -> 2.5.2
* [`281b53df`](https://github.com/NixOS/nixpkgs/commit/281b53df258d3f8df800b30b2cc2ecd1964292e3) fan2go: 0.13.0 -> 0.14.0
* [`cdb35b67`](https://github.com/NixOS/nixpkgs/commit/cdb35b67b3d9828b0eae3769281ffa0f84592882) nixos-test-driver: drop unneeded qemu dep
* [`7af5f08b`](https://github.com/NixOS/nixpkgs/commit/7af5f08b37fad98116c2b7f9b0f861db942fc66d) lsplug: init at 7
* [`a3b079d1`](https://github.com/NixOS/nixpkgs/commit/a3b079d14385f446643dfb43642dfd24cd2f1d4d) nixos-tests: fix qemu-img paths
* [`9cd8c947`](https://github.com/NixOS/nixpkgs/commit/9cd8c94787e96811757dd5b8ab67b966ad5d72e4) pgcenter: 0.9.2 -> 0.10.1
* [`1a74b659`](https://github.com/NixOS/nixpkgs/commit/1a74b659f5ef04e0832ff1255d5c10f2c0bf77c9) libpg_query: 17-6.1.0 -> 18.0.0
* [`20fcf794`](https://github.com/NixOS/nixpkgs/commit/20fcf79448bb9f95a566035686585830881cec0a) wayback-machine-archiver: 1.9.1 -> 3.5.2
* [`3e6aa4a8`](https://github.com/NixOS/nixpkgs/commit/3e6aa4a80c2d2ae1605be2b4aefb76ed91bd787f) autopush-rs: add modular-service doc entry
* [`b82f9c4f`](https://github.com/NixOS/nixpkgs/commit/b82f9c4f6295e05099340ea35b098955baa1cc31) blender: 5.1.1 -> 5.1.2
* [`87096391`](https://github.com/NixOS/nixpkgs/commit/8709639151bcf2d9a9c96e2126275099e73f4c3a) ci/OWNERS: Remove myself from contributor docs
* [`c36bf848`](https://github.com/NixOS/nixpkgs/commit/c36bf848a5ccbc3874b40b7bdd8fe66a9e238a8f) phpPackages.castor: 1.3.0 -> 1.5.0
* [`f173ec33`](https://github.com/NixOS/nixpkgs/commit/f173ec335533331f371e4bf83e06e393c013a5d8) maintainers/README: fix wrong workflow reference
* [`b869059d`](https://github.com/NixOS/nixpkgs/commit/b869059d2db21b4f07493530d0c3d598c3c705e2) libcupsfilters: custom test page
* [`7d6b363b`](https://github.com/NixOS/nixpkgs/commit/7d6b363b76905b6aea72e4313e82fe51c893470d) adw-bluetooth: 1.0.0 -> 1.1.0
* [`a875214e`](https://github.com/NixOS/nixpkgs/commit/a875214e7d216c7b8cad254361e76117ae7719e5) nixos/adw-bluetooth: init module
* [`b2f185c2`](https://github.com/NixOS/nixpkgs/commit/b2f185c25bd77ede3be459e951cea98937c50b67) nixos/etc: inline small regular files into the metadata erofs image
* [`9b14bd07`](https://github.com/NixOS/nixpkgs/commit/9b14bd07ee93cc1f1bece1a52d7da5d21e5ce2e5) glycin-loaders: allow configuring loaders to build via override
* [`f527f6d8`](https://github.com/NixOS/nixpkgs/commit/f527f6d8a87c64a49dfda35068a530c4996a5c6a) glycin-loaders: consistently use `lib.mesonBool`
* [`d4ccc96b`](https://github.com/NixOS/nixpkgs/commit/d4ccc96bfe453bac2bfc6ff0e40a4cee2e8fb70b) glycin-thumbnailer: init at 2.1.1
* [`53716654`](https://github.com/NixOS/nixpkgs/commit/53716654ff45801d54f2a0dda702022e6e993ed5) glycin-loaders: don't install thumbnailer files
* [`3298717b`](https://github.com/NixOS/nixpkgs/commit/3298717b08706d9b95577d846bde6c1f414405c1) libglycin: add glycin-thumbnailer to `passthru.tests`
* [`aac10d39`](https://github.com/NixOS/nixpkgs/commit/aac10d3941fba7db4901830285dcd51ad165f964) glycin-thumbnailer: add thumbnailer package test
* [`c7cd5a89`](https://github.com/NixOS/nixpkgs/commit/c7cd5a89bbae17e0149e09b1a09ebddcaffee3eb) glycin-thumbnailer: add package test for building with all loaders
* [`25b2bbca`](https://github.com/NixOS/nixpkgs/commit/25b2bbcaef963eadb35e29867f0f847c266d022f) barman: 3.19.0 -> 3.19.1
* [`68241438`](https://github.com/NixOS/nixpkgs/commit/68241438a0197b948d14bbdfc6e8400e34841377) {libglycin{,-gtk4},glycin-{loaders,thumbnailer}}: use compound license
* [`433a09a4`](https://github.com/NixOS/nixpkgs/commit/433a09a47be3aae41e47de4c6d9020d97f9e1d97) ccusage: init at 20.0.6
* [`e21e6640`](https://github.com/NixOS/nixpkgs/commit/e21e664067a86ac8c874d697f0b41950552b70b5) nixos/tuwunel: added environmentFile option
* [`4def942e`](https://github.com/NixOS/nixpkgs/commit/4def942e1035e6eccf69106dd19ef86ac66e9da1) hyphen: Support more languages
* [`cd2f95a4`](https://github.com/NixOS/nixpkgs/commit/cd2f95a405a7e90806e45dd8693dbcdc6194f8ec) maintainers: add buggymcbugfix, Vilem Liepelt
* [`3a1f2d4f`](https://github.com/NixOS/nixpkgs/commit/3a1f2d4f837d375be39d572f2a17ca407bf85c15) urweb: add buggymcbugfix as maintainer
* [`2f7a6648`](https://github.com/NixOS/nixpkgs/commit/2f7a6648414e95fb74834376f1a259181ac9571c) cedar: 4.5.1 -> 4.11.0
* [`df320ab8`](https://github.com/NixOS/nixpkgs/commit/df320ab8eaaa53e12514cf2bd21d363a52b72c57) rink: add keysmashes to maintainers
* [`5c322507`](https://github.com/NixOS/nixpkgs/commit/5c3225070dba85c30c2f38313ac5597685623867) fetchPnpmDeps: drop serve
* [`5d516233`](https://github.com/NixOS/nixpkgs/commit/5d516233872c9b5ace045d5c61d6f0066ab5f037) python3Packages.azure-mgmt-common: migrate to pyproject
* [`170a5615`](https://github.com/NixOS/nixpkgs/commit/170a5615332e72bb22d7eaefaff8f501970cee33) python3Packages.azure-mgmt-common: modernize
* [`7bf93009`](https://github.com/NixOS/nixpkgs/commit/7bf9300991286ff93b1ee1a744d73a9c7f970339) python3Packages.baycomp: migrate to pyproject
* [`f959b459`](https://github.com/NixOS/nixpkgs/commit/f959b4590f1684fe3ee63ff3fc3fbe3035b98c2d) python3Packages.bashlex: migrate to pyproject
* [`7b86aa47`](https://github.com/NixOS/nixpkgs/commit/7b86aa479cad81015048cbe4ce80d4b295ffdc09) python3Packages.baycomp: modernize
* [`ad8b2eba`](https://github.com/NixOS/nixpkgs/commit/ad8b2eba951844e27b25b0fe5f6264fe10f2d442) python3Packages.bashlex: modernize
* [`eee0b2bf`](https://github.com/NixOS/nixpkgs/commit/eee0b2bf3bdc42d2bbd70aa4b28bdadb44bf6ca1) python3Packages.bcg: migrate to pyproject
* [`96ecb4aa`](https://github.com/NixOS/nixpkgs/commit/96ecb4aaaa399978031c13c5d381c75c63f02b81) python3Packages.bcf: migrate to pyproject
* [`7028b8f0`](https://github.com/NixOS/nixpkgs/commit/7028b8f0c62f1fab9f934d57fef28c57f375f3e6) python3Packages.bcf: modernize
* [`13869a7b`](https://github.com/NixOS/nixpkgs/commit/13869a7be590ad514f70d1a36cb2743cbbc10671) python3Packages.bcg: modernize
* [`b6c933b7`](https://github.com/NixOS/nixpkgs/commit/b6c933b726fb11486442a2a454f71e52d44d1eb2) python3Packages.betacode: migrate to pyproject
* [`2bf3a1c6`](https://github.com/NixOS/nixpkgs/commit/2bf3a1c66608a026e2d3978033e202e49642ebf1) python3Packages.betacode: modernize
* [`2b6ccdf9`](https://github.com/NixOS/nixpkgs/commit/2b6ccdf9b8b934553bb850fb23748581a64d8980) python3Packages.bluepy: migrate to pyproject
* [`97426fb0`](https://github.com/NixOS/nixpkgs/commit/97426fb0868240ebe3458595e3b8a2d454590f4b) python3Packages.bluepy: modernize
* [`d12419f0`](https://github.com/NixOS/nixpkgs/commit/d12419f0fd6bb50b27ad9650c4dcaa40dc3ad1f5) python3Packages.cachy: migrate to pyproject
* [`b524610f`](https://github.com/NixOS/nixpkgs/commit/b524610f5aa7bc0a13eac9182e28ddaebbe04949) python3Packages.cachy: modernize
* [`b41d1dbc`](https://github.com/NixOS/nixpkgs/commit/b41d1dbc178d8daf93cdd6aad31f467ef3725754) pgpool: 4.7.1 -> 4.7.2
* [`e4d4b7fa`](https://github.com/NixOS/nixpkgs/commit/e4d4b7fa70589f205bf26889967cb8ea3ae04a95) cuda-modules: Allow SBSA Orin to use CUDA 13+
* [`35fd55e8`](https://github.com/NixOS/nixpkgs/commit/35fd55e84d639f66082f3bc894385f5386f66246) kde-rounded-corners: 0.8.7 -> 0.9.0
* [`2ecefb1e`](https://github.com/NixOS/nixpkgs/commit/2ecefb1e84ae6e01b686fee3f4772336fe99bbdd) oui: 0.1.8 -> 2.0.6
* [`8ab93c11`](https://github.com/NixOS/nixpkgs/commit/8ab93c11bf8c68f8a20d172b596934b426ef41c2) mydumper: 1.0.1-3 -> 1.0.3-1
* [`06027eae`](https://github.com/NixOS/nixpkgs/commit/06027eae4cb1dcaa809c7ff9a053c1f1a5f34fbc) ueransim: 3.2.8 -> 3.3.0
* [`52b6a379`](https://github.com/NixOS/nixpkgs/commit/52b6a379397daa0c19d8c423698796c97c72f32d) python3Packages.debugpy: 1.8.20 -> 1.8.21
* [`37f1a3b3`](https://github.com/NixOS/nixpkgs/commit/37f1a3b30a636e1131d87349b4c240b62be35e1b) python3Packages.debugpy: don't disable timeouts
* [`967e3dc3`](https://github.com/NixOS/nixpkgs/commit/967e3dc39cd9054e8615aa8fe36d637a42092361) mealie: move frontend into package.nix
* [`7f08f024`](https://github.com/NixOS/nixpkgs/commit/7f08f024c6b1f93f80086508a23273a6b0a60f1c) pipeline: 4.0.3 -> 4.0.4
* [`ad66fb92`](https://github.com/NixOS/nixpkgs/commit/ad66fb924eab53195855a3c93975a4c7650043cd) wit-bindgen: 0.57.1 -> 0.58.0
* [`ba82d660`](https://github.com/NixOS/nixpkgs/commit/ba82d660dcc1e453b6f51c8cdea5b91486dc2792) badger: 4.9.1 -> 4.9.2
* [`cf4a75e0`](https://github.com/NixOS/nixpkgs/commit/cf4a75e0aab1cda3373e8a15232352847c981324) python3Packages.pyairtable: 3.3.0 -> 3.4.0
* [`92b1f62d`](https://github.com/NixOS/nixpkgs/commit/92b1f62d02c78638438d9906c57127baf055854d) xsecurelock: make authproto_{pamtester,htacceess} optional
* [`b7e2e556`](https://github.com/NixOS/nixpkgs/commit/b7e2e556e1b39a9b71d4f5cbee3281d6a2bf55b7) lixPackageSets.stable: 2.94 -> 2.95
* [`fe18bb82`](https://github.com/NixOS/nixpkgs/commit/fe18bb82a1661e768864b377a5ecd9a2bd10dd6b) nixos/swap: detect whether swap is a device
* [`a8f871c1`](https://github.com/NixOS/nixpkgs/commit/a8f871c1483115f0480ebee2f756141952a065d9) nixos/swap: trigger device readiness
* [`447718ce`](https://github.com/NixOS/nixpkgs/commit/447718ce2f5a6a7bcf3297a45c3fd505b5512c5e) teleport_17: 17.7.24 -> 17.7.25
* [`79d37421`](https://github.com/NixOS/nixpkgs/commit/79d37421dc62fb90ebaf87a53f551e21ad475542) project-graph: 3.0.7 -> 3.0.8
* [`dd362928`](https://github.com/NixOS/nixpkgs/commit/dd362928d5035ead19f27802676ea6848090dec4) althttpd: 0-unstable-2026-03-20 -> 0-unstable-2026-06-03
* [`7037f240`](https://github.com/NixOS/nixpkgs/commit/7037f24083c32e01f5c5b8d7622b1de5ad1fc519) vscode-extensions.banacorn.agda-mode: 0.8.0 -> 0.10.0
* [`73a99119`](https://github.com/NixOS/nixpkgs/commit/73a991196dda93c2da3a6277a2f21241dcf17e5c) andcli: set __structuredAttrs
* [`87e68dd9`](https://github.com/NixOS/nixpkgs/commit/87e68dd9d798abdc5753f69042624025dbbce1ec) gradia: set __structuredAttrs
* [`dcf6a8c0`](https://github.com/NixOS/nixpkgs/commit/dcf6a8c0ee3ced62d267f3d6fdcadf0fc398b892) netpeek: set __structuredAttrs
* [`3428ea4f`](https://github.com/NixOS/nixpkgs/commit/3428ea4fb8445a74f5b8562e8e1a2d7f1cd96ee9) jocalsend: set __structuredAttrs
* [`b29223b7`](https://github.com/NixOS/nixpkgs/commit/b29223b723b4794280404f44752da12c017bfa8d) maintainers: add luuumine
* [`14048916`](https://github.com/NixOS/nixpkgs/commit/140489168ec6a6eaa6e2f10f4e061b3cff20bed1) nixos/uki: use config systemd package
* [`57013627`](https://github.com/NixOS/nixpkgs/commit/5701362722abca4ef07a2592c3661c4c1e14e147) bumpver: 2021.1110 -> 2026.1143
* [`37de9b38`](https://github.com/NixOS/nixpkgs/commit/37de9b38b6ad18a71f708f5521c325ea4926d838) python3Packages.ansible: 13.7.0 -> 14.0.0
* [`941a52f3`](https://github.com/NixOS/nixpkgs/commit/941a52f3ccc5083d3c967e3962d3f288d213b1ac) ocamlPackages.caqti: 2.3.1 -> 2.3.2
* [`b3b5f203`](https://github.com/NixOS/nixpkgs/commit/b3b5f2033ba2503742e2db7573d7421319468e61) gonic: Set PrivateTmp=true for new go-sqlite3 behavior
* [`bccf3954`](https://github.com/NixOS/nixpkgs/commit/bccf39549c7ba61ffc9dc2f17c0a6701d889a012) python3Packages.itables: 2.8.0 -> 2.8.1
* [`279b1290`](https://github.com/NixOS/nixpkgs/commit/279b129035e4e33765e84a1af44574c1a8e81eb5) fetchPnpmDeps: remove redundant guard for pnpm-fixup-state-db override
* [`341137ac`](https://github.com/NixOS/nixpkgs/commit/341137ac3ce1c6ad7d07c677c92fb52fdde8f951) libreoffice-bin: 25.8.6 -> 26.2.4
* [`f47f3444`](https://github.com/NixOS/nixpkgs/commit/f47f34442f81671f51f9b512c3749516a91ba225) id3: 0.81 -> 0.82
* [`1375ad96`](https://github.com/NixOS/nixpkgs/commit/1375ad96202c47bf2814f1eeab58e037a92e117e) python3Packages.jianpu-ly: 1.869 -> 1.870
* [`baf28478`](https://github.com/NixOS/nixpkgs/commit/baf28478fc0be6d3f5b9f12a1d4eaa60786bd434) nixos/dovecot: order non-attrs values first in rendered config
* [`8b1a0159`](https://github.com/NixOS/nixpkgs/commit/8b1a0159c2edca496a908edd8e8d3dca5dc58141) vlc: add libaacs to build and rpath
* [`98cbdb32`](https://github.com/NixOS/nixpkgs/commit/98cbdb32153f860fc2a9fc7f1c12734e19bcfe25) vlc: remove unused variables and update --replace
* [`e05f6640`](https://github.com/NixOS/nixpkgs/commit/e05f6640a28480bed85e253b1f3f218c3dcc3c7a) musescore-evolution: 3.7.0-unstable-2026-03-03 -> 3.7.0-unstable-2026-06-10
* [`cae827dc`](https://github.com/NixOS/nixpkgs/commit/cae827dc2dc72db866f8b1f210f56e105da49c7d) python3Packages.wagtail-modeladmin: 2.3.0 -> 2.4.0
* [`f3423127`](https://github.com/NixOS/nixpkgs/commit/f3423127d8113ee8a1d1b6ea7e903bee63f461fb) pangolin-cli: 0.8.3 -> 0.10.1
* [`fe14e362`](https://github.com/NixOS/nixpkgs/commit/fe14e362b27d99fade2c6b5db6f9fa81c3c1f2fb) npm-groovy-lint: init at 17.0.5
* [`13934c6f`](https://github.com/NixOS/nixpkgs/commit/13934c6f63e2852e1be27684481ffc3011b278e0) starc: 0.8.0 -> 0.8.2
* [`10508dab`](https://github.com/NixOS/nixpkgs/commit/10508dabe4d9b7e053b4093bff427eef5613bc6c) prismlauncher: add wayland to libraries
* [`f9050fe4`](https://github.com/NixOS/nixpkgs/commit/f9050fe4485ccc81464dc476eb186c452c84bf94) kube-state-metrics: 2.17.0 -> 2.19.1
* [`4103eff8`](https://github.com/NixOS/nixpkgs/commit/4103eff8c9d261574d1b80e74b8ce31db25293be) xray: switch to use v2ray-rules-dat
* [`f74b373b`](https://github.com/NixOS/nixpkgs/commit/f74b373b6619c317de4146fa15a265bb9de021ed) diswall: 0.6.1 -> 0.7.2
* [`79c40ccc`](https://github.com/NixOS/nixpkgs/commit/79c40ccc5906e9e43323999436ac55095958a00c) python3Packages.asyncprawcore: 3.0.2 -> 4.0.0
* [`12f77b7a`](https://github.com/NixOS/nixpkgs/commit/12f77b7a7427c5476b0319af91508d4139ad929d) mousam: 1.4.2 -> 2.0.2
* [`08cae254`](https://github.com/NixOS/nixpkgs/commit/08cae25447efe017c10797550af7894de9ffd7bb) bobby: init at 50.0.2
* [`01987f41`](https://github.com/NixOS/nixpkgs/commit/01987f4191f7291f25786b814e96446abffa19aa) everforest-gtk-theme: patch out invalid property in gtk3 theme
* [`a7cb4103`](https://github.com/NixOS/nixpkgs/commit/a7cb41030236a9546c1883f0aa1e671632a51f86) python3Packages.sklearn-compat: 0.1.5 -> 0.1.6
* [`2c2a2215`](https://github.com/NixOS/nixpkgs/commit/2c2a22157ae77c12c6e7dfc36ba9d9a509be38f3) python3Packages.geotorch: 0.3.0 -> 0.4.0
* [`1ad109c7`](https://github.com/NixOS/nixpkgs/commit/1ad109c7f7a67ffb45d3611701d6104c77d09c83) ghost-complete: 0.16.0 -> 0.18.0
* [`8a661c3e`](https://github.com/NixOS/nixpkgs/commit/8a661c3eb1e4bf4c7bdff7c980ff0bcd986ada21) john: add olefile deps to fix office2john.py
* [`a24a4dcc`](https://github.com/NixOS/nixpkgs/commit/a24a4dcc9789fc41f626bdd6868bda2a22cda123) mailspring: build from source, 1.21.1 -> 1.22.0
* [`5ad07b37`](https://github.com/NixOS/nixpkgs/commit/5ad07b37b891b55a4b8cc1569f0ab6a067a98fd8) python3Packages.asyncpraw: 7.8.1-unstable-2025-10-08 -> 8.0.1
* [`4b1e59dc`](https://github.com/NixOS/nixpkgs/commit/4b1e59dc21324b3b1629c6b9a2a2873671f3b2e2) python3Packages.winsspi: migrate to pyproject
* [`76a76041`](https://github.com/NixOS/nixpkgs/commit/76a76041c334048771392f77bda8b19bd5ec765a) python3Packages.winsspi: modernize
* [`6a3e0f35`](https://github.com/NixOS/nixpkgs/commit/6a3e0f353b6b8200a390b40a57eaacd14782628f) python3Packages.woodblock: migrate to pyproject
* [`d2be576c`](https://github.com/NixOS/nixpkgs/commit/d2be576cc600fc6b3d8f84c9ef37638efe2c0be1) python3Packages.woodblock: modernize
* [`a615659f`](https://github.com/NixOS/nixpkgs/commit/a615659f21f4594561e527c96e390d70c929a086) python3Packages.wsgiprox: migrate to pyproject
* [`d9b46edd`](https://github.com/NixOS/nixpkgs/commit/d9b46edd1814df7ea9cb07bdd0bf0b858b56bd2a) python3Packages.wsgiprox: modernize
* [`0ac7ccb9`](https://github.com/NixOS/nixpkgs/commit/0ac7ccb98a38a40f4e766f66bb02ac2543db1a93) python3Packages.xlrd: migrate to pyproject
* [`16ca6be9`](https://github.com/NixOS/nixpkgs/commit/16ca6be93319ef526f9b48c0bbbe29e66bd8f5a9) python3Packages.xlrd: modernize
* [`7730ddcf`](https://github.com/NixOS/nixpkgs/commit/7730ddcf06fa24f0aa517102b68bed18e850834b) python3Packages.xml-marshaller: migrate to pyproject
* [`ef5d2f5b`](https://github.com/NixOS/nixpkgs/commit/ef5d2f5b9fcf10ffbe5ec5b38135138fdf204cb0) python3Packages.xml-marshaller: modernize
* [`8a90480c`](https://github.com/NixOS/nixpkgs/commit/8a90480cfe39bada6f87d23acd8902efdc090e4d) python3Packages.xmljson: migrate to pyproject
* [`6d2a35bb`](https://github.com/NixOS/nixpkgs/commit/6d2a35bbf0204bdf201279253d7c33a2d1f1b55e) python3Packages.xmljson: modernize
* [`1f23f971`](https://github.com/NixOS/nixpkgs/commit/1f23f971a29a42970c8241aaa11c844d0ae5e421) python3Packages.xmodem: migrate to pyproject
* [`a70772a6`](https://github.com/NixOS/nixpkgs/commit/a70772a6a4e3f5961c211fbfcdb2611d9e1916f0) python3Packages.xmodem: modernize
* [`5a6eff40`](https://github.com/NixOS/nixpkgs/commit/5a6eff4063456c6a811fa79c07af06c642fad0a9) python3Packages.xstatic-asciinema-player: migrate to pyproject
* [`c8b4c4ff`](https://github.com/NixOS/nixpkgs/commit/c8b4c4ff0e63dd8cfe448e0426bf3ef6e53fd78f) python3Packages.xstatic-asciinema-player: modernize
* [`f101a8b6`](https://github.com/NixOS/nixpkgs/commit/f101a8b6084ef6375c54caf54d47bfa739c176fa) python3Packages.xstatic-asciinema-player: fix meta.homepage URL
* [`306f1514`](https://github.com/NixOS/nixpkgs/commit/306f15149a68c96d28b4faaf13e6bc5d86f528ce) python3Packages.xstatic-bootbox: migrate to pyproject
* [`5f8a935b`](https://github.com/NixOS/nixpkgs/commit/5f8a935b506d612f249692d28ee2487134a80301) python3Packages.xstatic-bootbox: modernize
* [`5cd7f2b2`](https://github.com/NixOS/nixpkgs/commit/5cd7f2b26762513536fa81bd70e29c6197347093) python3Packages.xstatic-bootstrap: migrate to pyproject
* [`6ef663aa`](https://github.com/NixOS/nixpkgs/commit/6ef663aafea3a176a88a6a821303cbf4124594b9) python3Packages.xstatic-bootstrap: modernize
* [`a244d9ae`](https://github.com/NixOS/nixpkgs/commit/a244d9ae7f72f2a0ca5a49417102d8a702b59db0) python3Packages.xstatic-jquery: migrate to pyproject
* [`0b54644f`](https://github.com/NixOS/nixpkgs/commit/0b54644fec117d1fcf27f91b5356752e6187b48f) python3Packages.xstatic-jquery: modernize
* [`8459d1ee`](https://github.com/NixOS/nixpkgs/commit/8459d1ee700ca14b6adfaf0d5de514a3b3881181) python3Packages.xstatic-jquery-file-upload: migrate to pyproject
* [`a6533c13`](https://github.com/NixOS/nixpkgs/commit/a6533c1309dd99cf2099ed10b9d00e4fb3ddc50a) python3Packages.xstatic-jquery-file-upload: modernize
* [`41b27c41`](https://github.com/NixOS/nixpkgs/commit/41b27c4169b381ee5ab5b38a3bb9579b24688a15) python3Packages.xstatic-jquery-file-upload: unbreak meta.homepage
* [`d6e99b9e`](https://github.com/NixOS/nixpkgs/commit/d6e99b9efe6d42caa58c4751a1a1cb0434c7f333) python3Packages.xstatic-jquery-ui: migrate to pyproject
* [`651cd7fd`](https://github.com/NixOS/nixpkgs/commit/651cd7fd7d1d9b244f289c3c92e899443871a5b9) python3Packages.xstatic-jquery-ui: modernize
* [`2d462333`](https://github.com/NixOS/nixpkgs/commit/2d4623339d6174fc118c2739942e3a1312be2279) python3Packages.xstatic-pygments: migrate to pyproject
* [`68d11310`](https://github.com/NixOS/nixpkgs/commit/68d113104a25859fae19881c5866f9b530113ec6) wasm-tools: drop workaround that's no longer required
* [`d48fad74`](https://github.com/NixOS/nixpkgs/commit/d48fad74cfd61a7324eb404ead75bae5c5659939) python3Packages.xstatic-pygments: modernize
* [`ec0be17e`](https://github.com/NixOS/nixpkgs/commit/ec0be17e667f3ca8d61211e52f2da633abb3f1fb) python3Packages.yamlordereddictloader: migrate to pyproject
* [`3cb90853`](https://github.com/NixOS/nixpkgs/commit/3cb9085385a69499a4ede7fb951bd8f2c20f2a60) python3Packages.yamlordereddictloader: modernize
* [`d1cf792b`](https://github.com/NixOS/nixpkgs/commit/d1cf792b4c9c79a7bf7c596dfb6f449fb61c3908) python3Packages.wavedrom: migrate to pyproject
* [`9c498c29`](https://github.com/NixOS/nixpkgs/commit/9c498c29608fd8588f5674985e5f979d42bb604a) python3Packages.wavedrom: modernize
* [`14f12d1b`](https://github.com/NixOS/nixpkgs/commit/14f12d1b32fc6dbaa266984dc086d85620596daa) python3Packages.waybackpy: migrate to pyproject
* [`ad297ac4`](https://github.com/NixOS/nixpkgs/commit/ad297ac4c9d8fc668ee198ab66a2a3467946b3a5) python3Packages.waybackpy: modernize
* [`c19bacba`](https://github.com/NixOS/nixpkgs/commit/c19bacba11c95546b87884082aa40a797f9b26cf) python3Packages.wcag-contrast-ratio: migrate to pyproject
* [`0bac9312`](https://github.com/NixOS/nixpkgs/commit/0bac9312fc360049b15cce75cc82198a3c0d2630) python3Packages.wcag-contrast-ratio: modernize
* [`d89d3b06`](https://github.com/NixOS/nixpkgs/commit/d89d3b065663137be1099ef43454862320327ec7) python3Packages.web-cache: migrate to pyproject
* [`382e0db1`](https://github.com/NixOS/nixpkgs/commit/382e0db1ee76d680490ae723b69d4d98dbfc1563) python3Packages.web-cache: modernize
* [`0f2057b3`](https://github.com/NixOS/nixpkgs/commit/0f2057b38194a93ce43c4cca0dc3c8603d9aa18d) python3Packages.wheezy-captcha: migrate to pyproject
* [`fc7d0751`](https://github.com/NixOS/nixpkgs/commit/fc7d075163cee95219bf0d4ef2492c5bea44eb0c) python3Packages.wheezy-captcha: modernize
* [`ac2d0144`](https://github.com/NixOS/nixpkgs/commit/ac2d0144c96433461048fa498858f1dc4202181b) wasm-tools: add shell completions
* [`1c03bb6d`](https://github.com/NixOS/nixpkgs/commit/1c03bb6d3396f836584da683e6298806b9347cff) csharpier: 1.2.6 -> 1.3.0
* [`777a6f78`](https://github.com/NixOS/nixpkgs/commit/777a6f788d72bb1bc1d9b45f1c5633402cf6f7e2) everspace: drop
* [`198b92d5`](https://github.com/NixOS/nixpkgs/commit/198b92d5b1895fd20a6e3a90efd40565c05530df) mattermostLatest: 11.7.0 -> 11.8.1
* [`bff3d1a9`](https://github.com/NixOS/nixpkgs/commit/bff3d1a971098e1a7e2ae1c7a1de31f7e04a1d66) libgit2: add withExperimentalSha256 argument
* [`78067eb5`](https://github.com/NixOS/nixpkgs/commit/78067eb5942286a9ade63cdfc6c107c9710b563f) gram: 2.1.2 -> 2.2.0
* [`2e23af70`](https://github.com/NixOS/nixpkgs/commit/2e23af70a8e4528205b3f45472bdb5007e4ab0bc) nixos/systemd-initrd: add systemd.*.services.path to initrd store
* [`742dca5b`](https://github.com/NixOS/nixpkgs/commit/742dca5b347bfb8438071746bfe016e2468e696b) mos: 4.2.0 -> 4.2.1
* [`76d22161`](https://github.com/NixOS/nixpkgs/commit/76d2216159711296b278ea04df668dffcf7f6320) pdns: 5.0.5 -> 5.1.1
* [`36cb8f71`](https://github.com/NixOS/nixpkgs/commit/36cb8f71097818ccc5fa2c6c6631c8a8290dae4d) step-agent: init at 0.67.3
* [`9bee562b`](https://github.com/NixOS/nixpkgs/commit/9bee562b8c8a4dbd40bd4e063328db793a95a24f) python3Packages.openinference-semantic-conventions: init at 0.1.30
* [`e2a64525`](https://github.com/NixOS/nixpkgs/commit/e2a645256b873e9b302075e781e8a98e60f13eff) python3Packages.openinference-instrumentation: init at 0.1.53
* [`0598a8aa`](https://github.com/NixOS/nixpkgs/commit/0598a8aa02bcb84789a18bdcbe842f47c6d66153) python3Packages.openinference-instrumentation-claude-agent-sdk: init at 0.1.6
* [`57d97b59`](https://github.com/NixOS/nixpkgs/commit/57d97b59acd9d63e44b2f9466fe2834b3ecc9738) python3Packages.openinference-instrumentation-openai: init at 0.1.52
* [`15db6b4e`](https://github.com/NixOS/nixpkgs/commit/15db6b4ed23e8415dc3ed3bfc74f31100e24bb75) maintainers: add ghastrum
* [`dc4c196c`](https://github.com/NixOS/nixpkgs/commit/dc4c196c3512a893d3324ed827248b567094823f) wealthfolio-server: init at 3.5.2
* [`c6e7a158`](https://github.com/NixOS/nixpkgs/commit/c6e7a1584a1f79451ee38850dae931f5c03fb92a) telegram-bot-api: 9.2 -> 10.1
* [`a8a1227b`](https://github.com/NixOS/nixpkgs/commit/a8a1227b85c7b95c893e75e0ec4105b4a66aba35) grafanaPlugins.grafana-metricsdrilldown-app: 2.0.3 -> 2.1.0
* [`1b9a6da5`](https://github.com/NixOS/nixpkgs/commit/1b9a6da5308093176671da1b169f4e627f23822c) python3Packages.mne: remove pytestFlag + typo
* [`aa4336b4`](https://github.com/NixOS/nixpkgs/commit/aa4336b4d04faf6854e045ab853ef8381fe1f017) plakar: 1.0.6 -> 1.1.3
* [`6c023011`](https://github.com/NixOS/nixpkgs/commit/6c0230116b8c9baabdc1dfec5e9b93b9e75a9fe9) plakar: add nadir-ishiguro to maintainers
* [`281648dc`](https://github.com/NixOS/nixpkgs/commit/281648dcbdc1b6991b9a1db72e921602ee1cee83) python3Packages.langchain-perplexity: 1.3.2 -> 1.4.0
* [`61e5bd15`](https://github.com/NixOS/nixpkgs/commit/61e5bd15206c2e5d5d5b52d519fddf196d01d6c2) scotch: 7.0.11 -> 7.0.12
* [`a298f9b2`](https://github.com/NixOS/nixpkgs/commit/a298f9b2269e97f8b97c69a56073258caa0a75ca) infrastructure-agent: 1.74.4 -> 1.76.2
* [`b5732489`](https://github.com/NixOS/nixpkgs/commit/b57324890f06e24bca9bd33460d365898489ce9b) t3: 1.0.9 -> 1.1.0
* [`c0b9fcbb`](https://github.com/NixOS/nixpkgs/commit/c0b9fcbb1817b122eb1b530c1fe3426c1299af6c) smuview: migrate to pcre2
* [`547bad7e`](https://github.com/NixOS/nixpkgs/commit/547bad7e4e27786b40cda53885aac3a1bb82a86d) sprite: 0.0.1-rc43 -> 0.0.1-rc44
* [`f5644526`](https://github.com/NixOS/nixpkgs/commit/f564452693ccbd1e3a0116d5cfa3155c60568ec7) sprite: disable upgrade check warning
* [`ad97c22f`](https://github.com/NixOS/nixpkgs/commit/ad97c22f57c97a9e86f9ce608e0dac25e0ed7dc2) pgrok: 1.5.0 -> 1.7.0
* [`27305cdc`](https://github.com/NixOS/nixpkgs/commit/27305cdc8a27e552a621f104b58745dc5b3329f7) python3Packages.cyscale: 0.4.0 -> 0.5.0
* [`2e711aa5`](https://github.com/NixOS/nixpkgs/commit/2e711aa5647da8cc3ba781adba57917557a9415c) python3Packages.exa-py: 2.13.1-unstable-2026-06-03 -> 2.14.0
* [`a61b0024`](https://github.com/NixOS/nixpkgs/commit/a61b0024b128b8866afe01d096f593c6eb1881be) octavePackages.audio: 2.0.11 -> 2.0.12
* [`d3381409`](https://github.com/NixOS/nixpkgs/commit/d33814099cbb61f17f3c6ac215af2edf2174fda7) i-dot-ming: fetch all fonts, fix update script, use installFonts
* [`f73e7919`](https://github.com/NixOS/nixpkgs/commit/f73e79198fcd9497f7ee48c604ab4f08d51db943) fetch: init at 2.1.0
* [`1baaebca`](https://github.com/NixOS/nixpkgs/commit/1baaebca9486d8e1dae65877ecccbf6547f89068) python3Packages.sqlparams: init at 6.2.0
* [`c5619642`](https://github.com/NixOS/nixpkgs/commit/c5619642a1435cbf0a2c3ac1292c32802870981b) intel-graphics-compiler: 2.34.4 -> 2.36.3
* [`3be476ad`](https://github.com/NixOS/nixpkgs/commit/3be476ad02b8c5f524290db630acd6ff63aa4feb) maestro: 2.6.0 -> 2.6.1
* [`bced4a03`](https://github.com/NixOS/nixpkgs/commit/bced4a03e7549a28e3ba3d20cc4957112ffe4bab) lightworks: 2025.1 -> 2025.2
* [`cccc5134`](https://github.com/NixOS/nixpkgs/commit/cccc513447495df4526dd21dda64a495f6e8a987) jetbrains.rust-rover: 2026.1.2 -> 2026.1.3
* [`167a0b78`](https://github.com/NixOS/nixpkgs/commit/167a0b78ea6ca7a573bd439a43be5b75804d77b0) openafs: 1.8.15 → 1.8.16
* [`1008c970`](https://github.com/NixOS/nixpkgs/commit/1008c97051459df1098806565922bf8012d63330) linuxPackages.openafs: Patch for Linux kernel 7.1
* [`12c24e84`](https://github.com/NixOS/nixpkgs/commit/12c24e84fd561540ba6dc7dba7fbf706a0bcb18a) concord-tui: init at 2.2.2
* [`f51d8dfb`](https://github.com/NixOS/nixpkgs/commit/f51d8dfb421858b1a689889c8d76c9596cc42130) pkgs/nixos-render-docs: introduce sidebar navigation
* [`0c3ac859`](https://github.com/NixOS/nixpkgs/commit/0c3ac859aa0bba60d1c2deeb31eac6b62f67be11) alcom: 1.1.5 -> 1.1.6
* [`b83f400a`](https://github.com/NixOS/nixpkgs/commit/b83f400a0fceccdf95877d109370b0dfe12e87d2) alcom: migrate to finalAttrs
* [`3d53a908`](https://github.com/NixOS/nixpkgs/commit/3d53a90818cae9413d94aebf5e5c007271a4e230) alcom: add name to npmDeps derivation
* [`c8ebe4ff`](https://github.com/NixOS/nixpkgs/commit/c8ebe4ff9aed9f5a3f07426b11f5e1d42bfa947f) alcom: add me as maintainer
* [`dc1511c0`](https://github.com/NixOS/nixpkgs/commit/dc1511c0f92373bd7318066518ba6b3e6990baec) scid-vs-pc: 4.26 -> 4.27
* [`8c3117f6`](https://github.com/NixOS/nixpkgs/commit/8c3117f6c5d6f09722890fc968c9d17607a68b4d) homebank: 5.10.1 -> 5.10.2
* [`1edaf990`](https://github.com/NixOS/nixpkgs/commit/1edaf9905e469d102ad3450b8ee0a4a8fe019000) gradle: fix update script with structuredAttrs
* [`5913f299`](https://github.com/NixOS/nixpkgs/commit/5913f299114846016ee2285bc71f2aa83b13a9ec) python3Packages.mlflow: 3.12.0 -> 3.14.0
* [`7c885cbf`](https://github.com/NixOS/nixpkgs/commit/7c885cbf9935ef00f18f408f7673b0592efc5790) maintainers: add demic-dev
* [`2da4cf88`](https://github.com/NixOS/nixpkgs/commit/2da4cf880f35425fc358021c131937a4c6a22b41) proton-authenticator: renamed to 'proton-authenticator-bin'
* [`52ada33e`](https://github.com/NixOS/nixpkgs/commit/52ada33ea686239071db189fecf55ac8d3d9ec8e) tempo: 3.0.1 -> 3.0.2
* [`ff3edfc4`](https://github.com/NixOS/nixpkgs/commit/ff3edfc4dbafa1a1d92d8be2292c7f3b2dfa6451) nginx: 1.30.2 -> 1.30.3; nginxMainline: 1.31.1 -> 1.31.2
* [`5fb00f68`](https://github.com/NixOS/nixpkgs/commit/5fb00f682b1fcff99f07d73650c2d1e765f88ba1) tsx: update to node 24
* [`e196e78b`](https://github.com/NixOS/nixpkgs/commit/e196e78b5bb33c07cf7109a61146dc68aa8f961c) tsx: 4.21.0 -> 4.22.4
* [`baa08b44`](https://github.com/NixOS/nixpkgs/commit/baa08b44d79cd40d09c20a67db97f50a43fe1deb) mixing-station: 2.9.3 -> 3.0.1
* [`83d06f84`](https://github.com/NixOS/nixpkgs/commit/83d06f84aefe9658990293f640a7776076a28a88) lan-mouse: 0.10.0 -> 0.11.0
* [`494b9201`](https://github.com/NixOS/nixpkgs/commit/494b92013764b1e576cdcc4231c31140c949adc6) ruff: 0.15.17 -> 0.15.18
* [`dfb3c084`](https://github.com/NixOS/nixpkgs/commit/dfb3c084b6c03da742fdffe58e187e94066a8cdf) gtkradiant: drop
* [`80693852`](https://github.com/NixOS/nixpkgs/commit/80693852ef8af4a0ac4de6ace89ee252b7c1b70d) python3Packages.imbalanced-learn: 0.14.1->0.14.2
* [`bc7d3e5d`](https://github.com/NixOS/nixpkgs/commit/bc7d3e5dda98e8bb1a813b817f327372cb26f5a1) bind: 9.20.23 -> 9.20.24
* [`bcee192e`](https://github.com/NixOS/nixpkgs/commit/bcee192ea5260509d3ca398fdc84ef64dc31354b) python3Packages.fontpens: 0.3.0 -> 0.4.0
* [`8f3f47dd`](https://github.com/NixOS/nixpkgs/commit/8f3f47dd5f2bc0f50983eb02fc5b52944b3fd28a) svt-av1-hdr: init at 4.1.0
* [`0f9a116c`](https://github.com/NixOS/nixpkgs/commit/0f9a116cf5e69a03b94ec396cc86b26c13dc24b4) maintainers: add 30350n
* [`a6eb3855`](https://github.com/NixOS/nixpkgs/commit/a6eb38554d7952c2d2dbf7f6442f09494817ed6a) svt-av1-hdr: add ccicnce113424 as maintainer
* [`ca5c0186`](https://github.com/NixOS/nixpkgs/commit/ca5c018649d7ac20ed22c659c1672bafa33c7bc7) firewalld-gui: fix firewall-{applet,config}
* [`803113e0`](https://github.com/NixOS/nixpkgs/commit/803113e064b4e3e60dfdb2fb501751ddcf048ad2) pacman: 7.0.0 -> 7.1.0
* [`95b6fb4b`](https://github.com/NixOS/nixpkgs/commit/95b6fb4b949ac77f60d1ef18637367db0cac669e) paru: 2.1.0 -> 2.1.0-unstable-2026-01-09
* [`1ec0b769`](https://github.com/NixOS/nixpkgs/commit/1ec0b769c1eea3714dd1851ef359ab8734cc6c0e) pacman: add bashInteractive dependency
* [`b40b7cf8`](https://github.com/NixOS/nixpkgs/commit/b40b7cf8ea8afc72fc343ae1206bb7fcd8a73cb9) pacman: use tag instead of rev
* [`b8541f16`](https://github.com/NixOS/nixpkgs/commit/b8541f163a0b2db6e244e77fe995b31fa54c5f14) nixVersions.git: 2.35pre20260504 -> 2.35pre20260619
* [`c57d2882`](https://github.com/NixOS/nixpkgs/commit/c57d288273c534c2ee66e0844ff7126f18288ece) nix: comment out unwanted tests directly in `src`
* [`40b1d13a`](https://github.com/NixOS/nixpkgs/commit/40b1d13a21291c43543a0c66f7c285396a5fa5ac) nix: cleanup unused lowdown patch
* [`f35704a4`](https://github.com/NixOS/nixpkgs/commit/f35704a496985c19a04ca51e5963d354a78182b3) ty: 0.0.49 -> 0.0.51
* [`3b4f7595`](https://github.com/NixOS/nixpkgs/commit/3b4f7595b9b85357656b3f5c40f1c133ab26d64d) proton-authenticator: init at 1.1.6 source-compiled package
* [`d8b16de4`](https://github.com/NixOS/nixpkgs/commit/d8b16de49ddea3c9fea3d9fe3c447cf0effd35fc) nixos: fix message on failure to determine mmap ASLR entropy
* [`628ef440`](https://github.com/NixOS/nixpkgs/commit/628ef44091749cf93efd06eb5c3caa7385b63920) basedpyright: 1.39.7 -> 1.39.8
* [`ad3e95b0`](https://github.com/NixOS/nixpkgs/commit/ad3e95b0931c8c618dc3fd017174fd97302c5538) switch-to-configuration-ng: handle socket-activated Accept=yes services
* [`99bfa58a`](https://github.com/NixOS/nixpkgs/commit/99bfa58adb52e3bf3147c1f38cb4d13de44024a2) filebrowser-quantum: 1.3.3-stable -> 1.4.0-stable
* [`917e5f65`](https://github.com/NixOS/nixpkgs/commit/917e5f65050d6662af05c288c090003c9a1c270c) python3Packages.booleanoperations: 0.9.0 -> 0.10.0
* [`a95fcb97`](https://github.com/NixOS/nixpkgs/commit/a95fcb976497422a1df26883b7d3907470c55543) python3Packages.fontparts: 0.13.1 -> 1.0.0
* [`eba1d513`](https://github.com/NixOS/nixpkgs/commit/eba1d513522ab485ec21874498f72e8b011b576a) meta.problems: Internal refactoring
* [`8fcbb359`](https://github.com/NixOS/nixpkgs/commit/8fcbb3592984e1f364ec561f491790d854704264) meta.problems: Fill out output meta with final list of problems
* [`78746f78`](https://github.com/NixOS/nixpkgs/commit/78746f78964e6a3524397cc9c00dda7576e2bb50) hyprlandPlugins.hypr-darkwindow: 0.55.2 -> 0.55.4
* [`2c443cbe`](https://github.com/NixOS/nixpkgs/commit/2c443cbed0420ebd61b27f70a07edf892b71a1bf) octavePackages.control: 3.6.1 -> 4.2.1
* [`b96c6de5`](https://github.com/NixOS/nixpkgs/commit/b96c6de56e3a5af5b50c6d2a530fdd672e5aaf8f) xpipe: 23.4 -> 23.5.2
* [`50eb9777`](https://github.com/NixOS/nixpkgs/commit/50eb9777b9ec508be9c9cae873ad1be94cbd3b4b) matio: 1.5.29 -> 1.5.30
* [`a0096ba0`](https://github.com/NixOS/nixpkgs/commit/a0096ba0058a692bf829dd3c2e5360a726720750) rpi-imager: 2.0.9 -> 2.0.10
* [`e1fb35ed`](https://github.com/NixOS/nixpkgs/commit/e1fb35edd8467ff66083c9584bb9c69ec2c8380b) maintainers: drop mikefaille
* [`5e7b7257`](https://github.com/NixOS/nixpkgs/commit/5e7b7257b8cd0e30e74a930f9c0de4fdaf961e49) mdadm: 4.4 -> 4.6
* [`f266705e`](https://github.com/NixOS/nixpkgs/commit/f266705e0f6a267347a06fe2b75e7c2ffeb84d00) stoat-desktop: 1.3.0 -> 1.4.0
* [`601096b5`](https://github.com/NixOS/nixpkgs/commit/601096b5296bcd0ef301694ae9d5816213799d38) ku: init at 0.7.0
* [`30178364`](https://github.com/NixOS/nixpkgs/commit/301783644aaf25909e871575a00a7ebdb2db1004) python3Packages.ansible-core: 2.21.0 -> 2.21.1
* [`e8cff7ab`](https://github.com/NixOS/nixpkgs/commit/e8cff7ab1fa5d91074156edada57e5ca94107e5d) kubedb-cli: 0.64.0 -> 0.65.0
* [`c09e87ba`](https://github.com/NixOS/nixpkgs/commit/c09e87bad1652edc0b9d2674b9f35a100b5784da) miller: 6.18.1 -> 6.19.0
* [`82225d94`](https://github.com/NixOS/nixpkgs/commit/82225d943f010ae5e02efed2b3a76fad70d80180) rubyfmt: 0.13.0 -> 0.14.1
* [`ac823b87`](https://github.com/NixOS/nixpkgs/commit/ac823b871068e20b4163fdde3331f8dc111d4b41) clpeak: 2.0.0 -> 2.0.13
* [`c69a50cd`](https://github.com/NixOS/nixpkgs/commit/c69a50cd71a62c57a1877342c7485b7ee91baba9) higan: 115-unstable-2024-09-04 -> 115-unstable-2025-08-30
* [`a99d3537`](https://github.com/NixOS/nixpkgs/commit/a99d35372029b8a2262a495b87736e245628752d) gogcli: 0.11.0 -> 0.29.0
* [`d8443960`](https://github.com/NixOS/nixpkgs/commit/d844396089ce2093e04ebc398859bf0eb28c1cf4) sbomnix: 1.7.6 -> 1.8.0
* [`fb1ff995`](https://github.com/NixOS/nixpkgs/commit/fb1ff99516d5ec5dad0bcbc58efdeb6188b061e6) coder: 2.28.6 -> 2.33.9
* [`fad6c551`](https://github.com/NixOS/nixpkgs/commit/fad6c551540c1d85f204504ed423936c3d1e9194) ocamlPackages.ca-certs-nss: 3.121 -> 3.125
* [`ae057ea1`](https://github.com/NixOS/nixpkgs/commit/ae057ea14d2eb0bb54ddcb3d68cda0eb124aa4d5) ayatana-indicator-power: Switch to lomiri-qt6 attrset
* [`ef352e54`](https://github.com/NixOS/nixpkgs/commit/ef352e5401b276b155a93cba39e6a02ac2d7ebfc) nixos/fuse: disable by default
* [`5a7a109c`](https://github.com/NixOS/nixpkgs/commit/5a7a109c5ac4e41c5d508ddfd45129cd9d1f1319) nixos/gvfs: enable fuse
* [`bd44b631`](https://github.com/NixOS/nixpkgs/commit/bd44b6318872853768665494351ad5fe75e83f0d) nixos/kubo: enable programs.fuse
* [`69a96a84`](https://github.com/NixOS/nixpkgs/commit/69a96a84d616f8075fb03c4c233d11ee994cc2d8) nixos/flatpak: enable fuse
* [`28c15019`](https://github.com/NixOS/nixpkgs/commit/28c15019478ea63cb4484f6e819993d9a43f6fb4) nixos/appimage: enable fuse
* [`ab51f0db`](https://github.com/NixOS/nixpkgs/commit/ab51f0dbef1ff1b7ba0fc1b59b3a366117eaefd2) nixos/sshfs: enable fuse
* [`99ed7070`](https://github.com/NixOS/nixpkgs/commit/99ed707074f5a579998e1072a3b83fd9f9d16e97) nixos/test/gocryptfs: enable fuse
* [`a92efa87`](https://github.com/NixOS/nixpkgs/commit/a92efa870c547481956055a2011475aee39b1ae1) nixos/plasma6: opt into fuse
* [`62525d0a`](https://github.com/NixOS/nixpkgs/commit/62525d0ac3a6a921c1bf4630f415cd36a90381c1) mediawiki: fix warning for tablePrefix on non-mysql databases
* [`944a258a`](https://github.com/NixOS/nixpkgs/commit/944a258aebf337420c2aaf0332228682b2dad956) switch-to-configuration-ng: handle transition to socket activation
* [`be9a0ac9`](https://github.com/NixOS/nixpkgs/commit/be9a0ac9924a5c4f116f7f4bc18be335664272e9) nixos/test-driver: properly tokenize udev rule
* [`de520665`](https://github.com/NixOS/nixpkgs/commit/de520665f651a49ac6c56c831c1ba9fc6255aa63) maintainers: remove hypersw
* [`669874b4`](https://github.com/NixOS/nixpkgs/commit/669874b4515ba82311d26d0f8a0984b149d95e03) maintaines: remove trepetti
* [`29d4c28a`](https://github.com/NixOS/nixpkgs/commit/29d4c28ad718031c1cd5f57c906531a240d01463) maintainers: remove vbmithr
* [`e5ebfc92`](https://github.com/NixOS/nixpkgs/commit/e5ebfc9291158dea9b09acf8e1d602b45098e7b7) maintainers: remove afldcr
* [`a08d0192`](https://github.com/NixOS/nixpkgs/commit/a08d0192d83b0cacad1e178b508885a554b57b3b) maintainers: remove f4814n
* [`82f5fdba`](https://github.com/NixOS/nixpkgs/commit/82f5fdbac446d0f5ac273312d07dff8710fb07f0) maintainers: remove deepfire
* [`f62484a5`](https://github.com/NixOS/nixpkgs/commit/f62484a5e2b88ffcd9243dbdad36d64bbd20207d) openttd-jgrpp: 0.72.3 -> 0.72.4
* [`3069c6b6`](https://github.com/NixOS/nixpkgs/commit/3069c6b6bf13c6c6137ac9623b828f6c50bc9d15) ayatana-indicator-session: Switch to lomiri-qt6 attrset
* [`ba61d33e`](https://github.com/NixOS/nixpkgs/commit/ba61d33e7026371bdd0bacbfbd327f89aa637197) python3Packages.stanza: 1.12.2 -> 1.13.0
* [`d7a0ad59`](https://github.com/NixOS/nixpkgs/commit/d7a0ad59b1dbe2b561e0831138819d59eee2e362) slacky: 0.0.8 -> 0.0.9
* [`80c1ad36`](https://github.com/NixOS/nixpkgs/commit/80c1ad36d1966b4b22b9bbb3c86b16a289c16261) hashes: 1.1.2 -> 1.1.4
* [`0d29f877`](https://github.com/NixOS/nixpkgs/commit/0d29f8773c9c9e6e64cd3aab6220d24671693ad2) freelens-bin: 1.9.0 -> 1.10.1
* [`e95fa37b`](https://github.com/NixOS/nixpkgs/commit/e95fa37b159078640be8ec845b6302802b02c925) newelle: 1.3.7 -> 1.4.5
* [`9a519d79`](https://github.com/NixOS/nixpkgs/commit/9a519d79233f9d193326a9cec9e60248d35968d8) officecli: 1.0.102 -> 1.0.116
* [`2cee4df2`](https://github.com/NixOS/nixpkgs/commit/2cee4df2f8ac97ae1029691e3498d613ba13034d) python3Packages.py-synologydsm-api: 2.7.3 -> 2.10.0
* [`8a786fdc`](https://github.com/NixOS/nixpkgs/commit/8a786fdc140c9b3eef6d195376ec7d0f36b648a0) ankiAddons.fsrs4anki-helper: 24.06.3-unstable-2026-04-14 -> 26.06.12-unstable-2026-06-08
* [`2fcb9c40`](https://github.com/NixOS/nixpkgs/commit/2fcb9c40eff813ab6b9a56b215a9a71942a1a25b) petsc: 3.24.6 -> 3.25.2
* [`266819f7`](https://github.com/NixOS/nixpkgs/commit/266819f71a9ea0b0cbd14a4c66be9c6e5c2ab491) slepc: 3.24.3 -> 3.25.1
* [`9f7fe932`](https://github.com/NixOS/nixpkgs/commit/9f7fe9320ff31836c6f946b8ef9efd85c853fe9a) python3Packages.pyadjoint-ad: 2025.10.1 -> 2026.4.1
* [`40a4176d`](https://github.com/NixOS/nixpkgs/commit/40a4176dff767d76cf729976a811e1907103603c) python3Packages.fenics-ufl: 2025.2.1 -> 2026.1.0
* [`e188e365`](https://github.com/NixOS/nixpkgs/commit/e188e3658a17ffab55645e82ca9c3936b09a4638) python3Packages.fenics-basix: 0.10.0.post0 -> 0.11.0
* [`3f7560a0`](https://github.com/NixOS/nixpkgs/commit/3f7560a05191e3c53a89e38fd0465d8f847a1ef4) python3Packages.fenics-ffcx: 0.10.1.post0 -> 0.11.0
* [`14ffb1b8`](https://github.com/NixOS/nixpkgs/commit/14ffb1b87aac7dd706439363c3ee6362284e079f) dolfinx: 0.10.0.post5 -> 0.11.0.post0
* [`b1cdb727`](https://github.com/NixOS/nixpkgs/commit/b1cdb7273b59bbcee2c9ba465f68f24d30cfba25) librepods: set __structuredAttrs & strictDeps
* [`13f9a281`](https://github.com/NixOS/nixpkgs/commit/13f9a2811def39373334851e408a5a6fb822e0e2) tauno-monitor: set __structuredAttrs
* [`cd87b78a`](https://github.com/NixOS/nixpkgs/commit/cd87b78a4a81aa58d4cb7ab4c3c9004a60c1a8a7) pkl-lsp: 0.6.0 -> 0.7.1
* [`e0dedcf0`](https://github.com/NixOS/nixpkgs/commit/e0dedcf0db8647bee4179d72a0451f5ab307c090) starpls: don't build xtask
* [`66d04231`](https://github.com/NixOS/nixpkgs/commit/66d04231d742c3c28703f90cd7d48fcff56cf488) aurulent-sans: add pancaek as maintainer
* [`0b41afab`](https://github.com/NixOS/nixpkgs/commit/0b41afabcf20bc1ed93d653e950e003e50b011f2) libsupermesh: 2025.4 -> 2026.0
* [`5afd89f3`](https://github.com/NixOS/nixpkgs/commit/5afd89f35c1bcfb1a940836539e993a243ff559d) python3Packages.petsctools: 2025.3 -> 2026.0
* [`b594b57d`](https://github.com/NixOS/nixpkgs/commit/b594b57d3792562068dccb980e0b25cf076462b7) python3Packages.firedrake-ufl: init at 2025.3.0
* [`19432ddf`](https://github.com/NixOS/nixpkgs/commit/19432ddf3e4716c6dfd328b874b63162b9d63156) python3Packages.firedrake-fiat: 2025.10.1 -> 2026.4.0
* [`383e038e`](https://github.com/NixOS/nixpkgs/commit/383e038e0bda3a899772886e56f33616c12326b0) python3Packages.firedrake: 2025.10.3 -> 2026.4.1
* [`e0d21c4d`](https://github.com/NixOS/nixpkgs/commit/e0d21c4dcd24145d4e22feb7552aef87cb1bac5b) uftpd: 2.15 -> 2.16
* [`2498d84c`](https://github.com/NixOS/nixpkgs/commit/2498d84c02e6daaee998a9ee77a2b932ba3743e5) pdftitle: use python3Packages.openai
* [`041650c8`](https://github.com/NixOS/nixpkgs/commit/041650c87f71339cf684fcb88ed5b37faac90f14) python3Packages.openai: 2.33.0 -> 2.41.1, openai: drop
* [`9f4df694`](https://github.com/NixOS/nixpkgs/commit/9f4df694e5b05a13059e1db13ae98d297ac05b5c) python3Packages.openai-agents: 0.6.9 → 0.17.6
* [`c9cf6079`](https://github.com/NixOS/nixpkgs/commit/c9cf60793e491f11ab78f5507cfd01d5dde2f3b7) python3Packages.openai-agents: Migrate to finalAttrs
* [`8ad93cb4`](https://github.com/NixOS/nixpkgs/commit/8ad93cb4eeebfb8b96f82fb92adf5252c52988ef) taskflow: 4.0.0 -> 4.1.0
* [`bf33fa5a`](https://github.com/NixOS/nixpkgs/commit/bf33fa5a5d30f098b22b9db49ebc267e3aacf251) python3Packages.django-payments: 3.1.0 -> 4.0.0
* [`270f11ec`](https://github.com/NixOS/nixpkgs/commit/270f11ec388e0c1c85203b06613b2e1c7f7c5a78) python3Packages.rapidfuzz: support taskflow 4.1.0
* [`57cbfa4e`](https://github.com/NixOS/nixpkgs/commit/57cbfa4e94b939000bc1509338633f858a795b28) detect-it-easy: 3.10 -> 3.21
* [`7ffa3b75`](https://github.com/NixOS/nixpkgs/commit/7ffa3b75ebd314e2ed79ee50802ddbef8cd7ac42) jetbrains.jcef: 1131 -> 1207
* [`af9f9241`](https://github.com/NixOS/nixpkgs/commit/af9f9241b9fc54ff5cd6d575012a6d6a3b9f60fe) jetbrains-jdk: 25.0.2b432.48 -> 25.0.3b508.4
* [`6733112c`](https://github.com/NixOS/nixpkgs/commit/6733112c499795205ba3cdc9fddc95fa2e9cce85) pscale: 0.286.0 -> 0.291.0
* [`bbc252da`](https://github.com/NixOS/nixpkgs/commit/bbc252da8eb965e4b474c33863558f6831ab82b5) polybar: Remove unused pcre
* [`4a7fd66a`](https://github.com/NixOS/nixpkgs/commit/4a7fd66a7145fdcda8bf605f2f1f6ebe6a5904fe) phpExtensions.relay: 0.21.0 -> 0.30.0
* [`1ba31d07`](https://github.com/NixOS/nixpkgs/commit/1ba31d074430ea929034e873f35c0c65ad0bb5cd) nzbhydra2: 8.8.3 -> 8.8.4
* [`bf2b43fd`](https://github.com/NixOS/nixpkgs/commit/bf2b43fd7a18b911d39f0f6761640e34d6b0978c) hydrus: 668 -> 673
* [`64a633ed`](https://github.com/NixOS/nixpkgs/commit/64a633ed6d21ec984fd7c4829156efa56c138f5f) hydrus: 673 -> 675
* [`39e3856d`](https://github.com/NixOS/nixpkgs/commit/39e3856dd8b49a25d04f210c5cf69da89d0fdc79) nixos/zigbee2mqtt: add RestartSec
* [`101fd9ad`](https://github.com/NixOS/nixpkgs/commit/101fd9ad153674a222ecccd3410503d8b3877981) lib.cli.toCommandLine: share let variables for a single optionFormat
* [`5bcd2623`](https://github.com/NixOS/nixpkgs/commit/5bcd2623a56cd2e139073366f00f93d5505b9356) hcloud-upload-image: 1.4.0 -> 1.5.0
* [`72785188`](https://github.com/NixOS/nixpkgs/commit/72785188e15648278130ffa65739da5d96467a0a) lib.cli: inherit functions to global scope
* [`1ffe9499`](https://github.com/NixOS/nixpkgs/commit/1ffe9499a21e711952fca064b9158e8e45bc2160) lib.cli.toGNUCommandLine: move variable definition to higher scope
* [`a023145c`](https://github.com/NixOS/nixpkgs/commit/a023145c7091b63894736bb5cfc7475c2fd8359c) lib.cli: use partially applied mkValueStringDefault
* [`0bdf1a16`](https://github.com/NixOS/nixpkgs/commit/0bdf1a162250285451ceae8e6c4b7dd6d3cf6bb8) vscode-extensions.fill-labs.dependi: 0.7.22 -> 0.7.25
* [`64640945`](https://github.com/NixOS/nixpkgs/commit/646409453c90b752eb8c2ff4bf9ee44203232fe3) lib.cli.toGNUCommandLine: beta reduce mkList for free
* [`78d07871`](https://github.com/NixOS/nixpkgs/commit/78d07871f5d0785d4d2780894cb2face90e1b303) nixos/acme: also allow _PATH-suffixed credential files
* [`633f52c0`](https://github.com/NixOS/nixpkgs/commit/633f52c08ecf2677092833ca8e7951b4d31004c8) nixos/acme: remove unused symbols
* [`de48634a`](https://github.com/NixOS/nixpkgs/commit/de48634a6e7a6212ce13cd52c8429029b2f1ff07) python3Packages.flash-linear-attention: 0.5.0 -> 0.5.1
* [`2a5b22c0`](https://github.com/NixOS/nixpkgs/commit/2a5b22c033299b7286d4a36f5aa7a24984f2f575) speakeasy-cli: 1.778.0 -> 1.784.0
* [`1c53d25f`](https://github.com/NixOS/nixpkgs/commit/1c53d25f587f57dc45d3bd39964a039931756a57) lib.attrsets.concatMapAttrs: rewrite for efficiency
* [`f3e6fa55`](https://github.com/NixOS/nixpkgs/commit/f3e6fa555f71f2a4c87e51d457a1eeabcde459a8) lib.attrsets.concatMapAttrs: add test for handling duplicates
* [`107d882d`](https://github.com/NixOS/nixpkgs/commit/107d882dcef2681278518fa1fe566ae270b4dfb2) convertx: 0.17.0 -> 0.18.0
* [`1703857a`](https://github.com/NixOS/nixpkgs/commit/1703857ab0a2f312fb17e5f6442269fb4bd09b2e) decker: 1.66 -> 1.67
* [`aef23e20`](https://github.com/NixOS/nixpkgs/commit/aef23e203deee9fa27b5e5b17562945e6cddac3e) hyprwhspr-rs: 0.3.30 -> 0.3.31
* [`42ba44ef`](https://github.com/NixOS/nixpkgs/commit/42ba44ef064922b598acb142236fba360a216ae5) babeld: 1.13.1 -> 1.14
* [`314584ca`](https://github.com/NixOS/nixpkgs/commit/314584caefb4391eb1ae5c47393d55b05b04691d) python3Packages.csv2md: 1.6.0 -> 1.7.1
* [`99b22eaa`](https://github.com/NixOS/nixpkgs/commit/99b22eaa26ac8a17dafe98ba152148673340e848) fuc: 3.1.1 -> 3.1.7
* [`5400fcaa`](https://github.com/NixOS/nixpkgs/commit/5400fcaa10750b0e97dded6561ee926542fca6de) python3Packages.marimo: 0.23.6 -> 0.23.10
* [`21f49adc`](https://github.com/NixOS/nixpkgs/commit/21f49adcf1eb9cc5aedd2abb8bfdafbc7bd84bd5) kubevirt: 1.8.2 -> 1.8.4
* [`bea101ed`](https://github.com/NixOS/nixpkgs/commit/bea101ed353600714b38c9da4ea513d879e53a8d) okms-cli: 0.4.2 -> 0.4.3
* [`9c08d7e8`](https://github.com/NixOS/nixpkgs/commit/9c08d7e8992de790599ad6cd0e03c02c012412ba) krita: 6.0.1 -> 6.0.2.1
* [`056cdb9f`](https://github.com/NixOS/nixpkgs/commit/056cdb9f8b9e8a885d08ef171a146b18d4602252) clash-rs: 0.10.6 -> 0.10.7
* [`73d93055`](https://github.com/NixOS/nixpkgs/commit/73d930558a453d5258a35c89f4199fd45f27d41e) p2pool: 4.16 -> 4.17
* [`2f440574`](https://github.com/NixOS/nixpkgs/commit/2f4405743316f6a67c534b8362cbfd8dcfb21302) ttyplot: 1.7.4 -> 1.7.5
* [`67e55530`](https://github.com/NixOS/nixpkgs/commit/67e55530a27eee83e81580c3ec33b82b41ee288e) ocamlPackages.pbrt: 2.4 → 4.1
* [`e3ebd836`](https://github.com/NixOS/nixpkgs/commit/e3ebd83643a71be5c449bbb170bedb53af86ac8b) lsp-plugins: 1.2.31 -> 1.2.33
* [`e2cba530`](https://github.com/NixOS/nixpkgs/commit/e2cba53098169636a5a726cb9fb17ad15edb176a) tidal-cycles-full: Init at 1.10.1
* [`e866333c`](https://github.com/NixOS/nixpkgs/commit/e866333c7bce3204862ca7432833a0f89b0d9792) expat: 2.8.0 -> 2.8.1
* [`412b051d`](https://github.com/NixOS/nixpkgs/commit/412b051db6b2f5f49b1a0ddbc414bde79a9f0619) Revert "groff: only apply the latest patch on linux for now"
* [`2102ac37`](https://github.com/NixOS/nixpkgs/commit/2102ac377de6caaba3a6e86a23577fbaebcaa32f) audit: 4.1.2-unstable-2025-09-06 -> 4.1.4
* [`85e30362`](https://github.com/NixOS/nixpkgs/commit/85e30362ddcd34addeaeb91164f88d3516cf6e23) libressl_4_3: init at 4.3.1
* [`fdf4fbeb`](https://github.com/NixOS/nixpkgs/commit/fdf4fbeb3d959d58c76a2f22096ad0f7d86827b6) libressl_4_1: delete unsupported package
* [`d5937f2b`](https://github.com/NixOS/nixpkgs/commit/d5937f2bc8f9cacecd1670ec373699d00746368c) libressl: add ruuda as maintainer
* [`7c651813`](https://github.com/NixOS/nixpkgs/commit/7c6518130da971e6a0823a899f6f08ed30eaf4c4) libressl: enable strictDeps and __structuredAttrs
* [`c0a53e69`](https://github.com/NixOS/nixpkgs/commit/c0a53e695020cfcd935eabf446d2918187aa751b) libressl_4_3: backport executable stack fix
* [`f479a5dc`](https://github.com/NixOS/nixpkgs/commit/f479a5dca236793c02d0c3b6a4d3ecb365d2ac49) openexr: 3.4.10 -> 3.4.11
* [`ab6adf5c`](https://github.com/NixOS/nixpkgs/commit/ab6adf5c8246eff91b48479823125cb44a5da12f) openapv: 0.2.1.2 -> 0.2.1.3
* [`49d2ce08`](https://github.com/NixOS/nixpkgs/commit/49d2ce082a0796988ecd7d1bbe9ec013c0f0ef6c) python3Packages.aiodns: 4.0.0 -> 4.0.3
* [`ebd0392d`](https://github.com/NixOS/nixpkgs/commit/ebd0392d1b23dc81258339cc78f6ba27713b3069) python3Packages.xmltodict: 1.0.2 -> 1.0.4
* [`344a6379`](https://github.com/NixOS/nixpkgs/commit/344a6379c3246ac76e5519b96e9f61b70a89320a) qt5: 5.15.18 -> 5.15.19
* [`e717fb6c`](https://github.com/NixOS/nixpkgs/commit/e717fb6c8feb631205a8b94c41276138664f52cd) openldap: skip flaky syncreplication tests
* [`988d5e4c`](https://github.com/NixOS/nixpkgs/commit/988d5e4c9f5ad27c981d131081bb752d496bb586) nodejs_24: 24.15.0 -> 24.16.0
* [`8861a6b4`](https://github.com/NixOS/nixpkgs/commit/8861a6b466194c3b4604d1ccb01398ac2fad8f66) unbound: 1.25.0 -> 1.25.1
* [`dcbc584e`](https://github.com/NixOS/nixpkgs/commit/dcbc584e5525348077f7c8b31d12efa6596e4769) python3Packages.python-multipart: 0.0.22 -> 0.0.29
* [`44573c77`](https://github.com/NixOS/nixpkgs/commit/44573c77ca46c5cbacba382c0fb023e9f286923d) python3Packages.asgi-csrf: mark broken
* [`5c3ae22a`](https://github.com/NixOS/nixpkgs/commit/5c3ae22a1b76f4e2ebea41459060a1c6233ac261) python3Packages.frictionless: exclude datasette from nativeCheckInputs
* [`8accd653`](https://github.com/NixOS/nixpkgs/commit/8accd65376f0e99cd0d64778f180e039a30345b7) gtk4: make patch unconditional
* [`8e3eb65c`](https://github.com/NixOS/nixpkgs/commit/8e3eb65c3ca2bc14678edf33a304378a119a6e28) python3Packages.aiodns: 4.0.3 -> 4.0.4
* [`c5cd03ad`](https://github.com/NixOS/nixpkgs/commit/c5cd03ad0d9e333731b36d2c627661614ad35214) kdePackages.plasma-workspace: backport patch for Qt 6.11.1 regression
* [`6e264211`](https://github.com/NixOS/nixpkgs/commit/6e26421199965863c60fb52e362b47ae0f166c51) qt6: 6.11.0 -> 6.11.1
* [`bbacb131`](https://github.com/NixOS/nixpkgs/commit/bbacb13154653be5e334c81f7764b71c8dba88ee) glibc: 2.42-61 -> 2.42-67
* [`790c6832`](https://github.com/NixOS/nixpkgs/commit/790c6832f29815016405921bcc43e5b12e3ebd2d) doctest: 2.5.0 -> 2.5.2
* [`8806b112`](https://github.com/NixOS/nixpkgs/commit/8806b112de554ae6b991712b53f08396010c78a8) python3Packages.paramiko: invoke is a required dependency
* [`5eaef153`](https://github.com/NixOS/nixpkgs/commit/5eaef1532890d5a1ba2f4707c15fbc95ce6c3964) duplicity: remove invoke from dependencies
* [`ba90fa78`](https://github.com/NixOS/nixpkgs/commit/ba90fa78f87b021f29e9625497230f019b9cbf83) simdjson: 4.6.0 -> 4.6.4
* [`8b34d586`](https://github.com/NixOS/nixpkgs/commit/8b34d586be2b1dc985cd7c62b9b0b870280479bd) libass: remove libiconv dependency on darwin
* [`9756eaf1`](https://github.com/NixOS/nixpkgs/commit/9756eaf1f856e108847e8cf0b1f484635dbc5b07) assimp: 6.0.4 -> 6.0.5
* [`bd2d251c`](https://github.com/NixOS/nixpkgs/commit/bd2d251cdce34631a6ffeafd4d439a0ac8e84cfe) libcaca: apply patch for CVE-2026-42046
* [`17955724`](https://github.com/NixOS/nixpkgs/commit/179557247bbc7f426f56a16c65eb4ce8f510e359) freetype: 2.14.2 -> 2.14.3
* [`752123aa`](https://github.com/NixOS/nixpkgs/commit/752123aaa9a161eba848be49162de3deb6e1e4c8) libde265: 1.0.18 -> 1.0.19
* [`96f63700`](https://github.com/NixOS/nixpkgs/commit/96f63700bc8536004e18405ee9326a3e2e46a8cf) python3Packages.starlette: 0.52.1 -> 1.1.0
* [`f8562c72`](https://github.com/NixOS/nixpkgs/commit/f8562c72832be386cec783ba2ab5959668d3af82) python3Packages.fastapi: 0.135.3 -> 0.136.3
* [`bc469214`](https://github.com/NixOS/nixpkgs/commit/bc469214f96891e72cef0bff270495c09c1ff19e) kcl: 0.12.3 -> 0.12.4
* [`a7d2d596`](https://github.com/NixOS/nixpkgs/commit/a7d2d596aff1c30c3a752c678f1be62f30a59dfa) systemd: fix tmpfiles errors when mount is noatime
* [`d0551bc0`](https://github.com/NixOS/nixpkgs/commit/d0551bc010492e023fbe37f2ef6f052f57677153) openblas: 0.3.32 -> 0.3.33
* [`a7e09a45`](https://github.com/NixOS/nixpkgs/commit/a7e09a45bbee1dde3f2604abaab38001edc1bb0b) cargo: add patches for CVE-2026-5222 and CVE-2026-5223
* [`8b70ffa9`](https://github.com/NixOS/nixpkgs/commit/8b70ffa9d004dc1bfc8fda5719a380fc7d21243d) libaec: 1.1.6 -> 1.1.7
* [`f4dff6b5`](https://github.com/NixOS/nixpkgs/commit/f4dff6b5f92f72ed287a272ddbd3b10a81c0ca6c) e2fsprogs: 1.47.3 -> 1.47.4
* [`88028946`](https://github.com/NixOS/nixpkgs/commit/880289462edf18d93c7b52d97ed9eac2708c7fb5) libadwaita: 1.9.0 -> 1.9.1
* [`664ed122`](https://github.com/NixOS/nixpkgs/commit/664ed12255eb5f8bca3f5b01e6fc4abf105b00ea) imagemagick: 7.1.2-23 -> 7.1.2-24
* [`fbaac146`](https://github.com/NixOS/nixpkgs/commit/fbaac14681bf6af3fc619693fbddd485be293295) curl: set structuredAttrs
* [`eac01b30`](https://github.com/NixOS/nixpkgs/commit/eac01b30609bc7ee045ee13c1ddaf9b860f80523) fftw: 3.3.10 -> 3.3.11
* [`46b00f0e`](https://github.com/NixOS/nixpkgs/commit/46b00f0ee0ef0d8373f2b29655dd5724628991b7) rsync: skip chgrp test
* [`88fbe351`](https://github.com/NixOS/nixpkgs/commit/88fbe351f206444955adad33486d7e453223f516) python3Packages.mistune: 3.2.0 -> 3.2.1
* [`1ed273b4`](https://github.com/NixOS/nixpkgs/commit/1ed273b4fe75c4bbc50228fee8132abfa607d128) rsync: 3.4.1 -> 3.4.3
* [`671e8aef`](https://github.com/NixOS/nixpkgs/commit/671e8aefd911c8f67dde43263502817dbec494bf) at-spi2-core: 2.60.1 -> 2.60.4
* [`9ad85fe4`](https://github.com/NixOS/nixpkgs/commit/9ad85fe44d8ad4c07040feb066e4147ba433f943) ffmpeg_8: 8.1 -> 8.1.1
* [`dcc6f5d9`](https://github.com/NixOS/nixpkgs/commit/dcc6f5d9625e96e38e578f2daca963cf1c92886d) nodejs: pin icu to newer version
* [`29e701ec`](https://github.com/NixOS/nixpkgs/commit/29e701ec567f38e3318ecd1344b56a9552c676f1) valkey: 9.0.4 -> 9.1.0
* [`b7a103e1`](https://github.com/NixOS/nixpkgs/commit/b7a103e1c957affe138090e1c0a8bbbbc9a31f04) rust-cbindgen: 0.29.2 -> 0.29.3
* [`1526af39`](https://github.com/NixOS/nixpkgs/commit/1526af39b965a485e88ff6ad5a4d3ead9a792c55) publicsuffix-list: 0-unstable-2026-03-26 -> 0-unstable-2026-05-13
* [`dc108799`](https://github.com/NixOS/nixpkgs/commit/dc108799c2593f6847ae4ea10b79afff0e3cd6d7) libheif: 1.21.2 -> 1.22.2
* [`96a47e2c`](https://github.com/NixOS/nixpkgs/commit/96a47e2cd89ca225a4434fbcb6d9cc605b061cd1) python3Packages.pillow-heif: disable tests that abuse spec and break in libheif 1.22.0, disable version check for libheif
* [`3fcd08af`](https://github.com/NixOS/nixpkgs/commit/3fcd08afd1ebdad5669e49cae1d23a7891976d92) curl: backport performance patch
* [`83c65a6c`](https://github.com/NixOS/nixpkgs/commit/83c65a6c3494a62090d714e4ed112eefcb20dfba) gnupatch: disable flaky test
* [`f75e2f09`](https://github.com/NixOS/nixpkgs/commit/f75e2f0964134dd4929264e7881e155d30e21c7d) perlPackages.HTTPDaemon: 6.16 -> 6.17
* [`1b76c291`](https://github.com/NixOS/nixpkgs/commit/1b76c2916059ed3a104de5e99871b779f601854c) sdl3: 3.4.8 -> 3.4.10
* [`68be3d0b`](https://github.com/NixOS/nixpkgs/commit/68be3d0bebd4fc1a6e5041450f9f5a24762faf4e) sdl3: increase test timeout for testrwlock
* [`2a0e0bae`](https://github.com/NixOS/nixpkgs/commit/2a0e0baec1c99cdc087c14f83ac6c31c929d14eb) rustPlatform.fetchCargoVendor: remove duplicate fetcher
* [`b3bdc19f`](https://github.com/NixOS/nixpkgs/commit/b3bdc19f55fe967c0c24e2728d543a9c462f4927) libheif: 1.22.2 -> 1.23.0
* [`e40d42cb`](https://github.com/NixOS/nixpkgs/commit/e40d42cbb7d42823e752693d1e951da7f234fe26) bzip2: patch CVE-2026-42250
* [`15c74e4f`](https://github.com/NixOS/nixpkgs/commit/15c74e4f1eccd9cd6fcfc6d58ae83aca761557c4) libgcrypt: 1.11.2 -> 1.12.2
* [`9b9b7a4d`](https://github.com/NixOS/nixpkgs/commit/9b9b7a4d93c6a21aaa03d11cef8024c222cb991c) go_1_26: 1.26.3 -> 1.26.4
* [`608382cc`](https://github.com/NixOS/nixpkgs/commit/608382cc0c18f8773d5b7f6e3901e5a02885d626) python3Packages.pyjwt: 2.12.1 -> 2.13.0
* [`360c80e2`](https://github.com/NixOS/nixpkgs/commit/360c80e28179890828262156e12ab51ac816f79e) python3Packages.django_5: 5.2.14 -> 5.2.15
* [`1cf8084a`](https://github.com/NixOS/nixpkgs/commit/1cf8084a61a0a5033b77feb7293dce3ff8941255) xvfb: 21.1.22 -> 21.1.23, drop rebuild avoidance
* [`e4f8aa8b`](https://github.com/NixOS/nixpkgs/commit/e4f8aa8b230b279b57f1025b88a1fe206fb3507a) ghostscript: 10.07.0 -> 10.07.1
* [`8336ce23`](https://github.com/NixOS/nixpkgs/commit/8336ce23196cf992a685559f6083b542aee8a3f7) systemd: 260.1 -> 260.2
* [`2b7fc293`](https://github.com/NixOS/nixpkgs/commit/2b7fc293239017429fad1046292f250d671e4259) systemd: drop upstreamed tmpfiles noatime patch
* [`11899547`](https://github.com/NixOS/nixpkgs/commit/11899547f29a22b9e8adef50930ced66ac57c4d5) libde265: 1.0.19 -> 1.1.0
* [`213f8e5f`](https://github.com/NixOS/nixpkgs/commit/213f8e5f584907ba1b6f1419d044af7e7e5c69f9) krb5: 1.22.1 -> 1.22.2
* [`7b571011`](https://github.com/NixOS/nixpkgs/commit/7b5710119386670cb12c68b20fc473cb0ab0c64c) krb5: patch CVE-2026-40355 and CVE-2026-40356
* [`4907a037`](https://github.com/NixOS/nixpkgs/commit/4907a037124adc94b805de978557c06fa8f55213) libxml2: 2.15.2 -> 2.15.3
* [`c6a6976a`](https://github.com/NixOS/nixpkgs/commit/c6a6976a2a2ee65a76071f57de1c44227c2a5717) perl: backport security fixes
* [`8abfd69d`](https://github.com/NixOS/nixpkgs/commit/8abfd69d34c6658e7eed4cd71b7ab4fae7982e83) libpng: 1.6.56 -> 1.6.58
* [`7b8f0d2c`](https://github.com/NixOS/nixpkgs/commit/7b8f0d2c39d3ebe39e044576e6cf80e392648a3f) rustPlatform.fetchCargoVendor: de-duplicate git sources by selector
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
