### PR TITLE
npins home-manager: update 471a1d2f -> 5d72a29f

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -48,9 +48,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "471a1d2f840eb7fcbdfd541d99c13a64096f46db",
-      "url": "https://github.com/nix-community/home-manager/archive/471a1d2f840eb7fcbdfd541d99c13a64096f46db.tar.gz",
-      "hash": "sha256-SA7LyrayyZBvtzZnesnSLV7haciFuVLeZaX2hd5v4j4="
+      "revision": "5d72a29fc36ac21adae6ae35568fe5ee6700850f",
+      "url": "https://github.com/nix-community/home-manager/archive/5d72a29fc36ac21adae6ae35568fe5ee6700850f.tar.gz",
+      "hash": "sha256-slFTUgDy0KTPA4LBAmC/9SngDq8GCPdX+ZR0yQHHN1E="
     },
     "hs-grille": {
       "type": "Git",


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@471a1d2f...5d72a29f](https://github.com/nix-community/home-manager/compare/471a1d2f840eb7fcbdfd541d99c13a64096f46db...5d72a29fc36ac21adae6ae35568fe5ee6700850f)

* [`4b0b9474`](https://github.com/nix-community/home-manager/commit/4b0b9474749820afac53ea30d4ccfef60aba5ce6) zsh: add 'fastSyntaxHighlighting'
* [`83c0e036`](https://github.com/nix-community/home-manager/commit/83c0e036879512d96e8378b24b038f413fdb4021) hyprland-qt-support: init module
* [`16fdc350`](https://github.com/nix-community/home-manager/commit/16fdc3504e9c5d84044fdf7d2a3cca5577a4989e) hyprland-qt-support: add test case
* [`d6b7bf16`](https://github.com/nix-community/home-manager/commit/d6b7bf16955c5a68c5c8a9630ed0e425a62829c2) hyprland-qt-support: add news entry
* [`1ac720f0`](https://github.com/nix-community/home-manager/commit/1ac720f007173754b204c2d25fee9a38680bf9bf) home: document the 'home.profileDirectory' default
* [`06258193`](https://github.com/nix-community/home-manager/commit/062581938b4a378a82dfbb294b494808157153a1) claude-code: reject disabled mcp servers instead of dropping
* [`dc89b0c0`](https://github.com/nix-community/home-manager/commit/dc89b0c0bb4c019e522ee2e2fcbf2e183a3caa5f) launchd: add agent domain option
* [`a9232b8b`](https://github.com/nix-community/home-manager/commit/a9232b8b1004a4fca3f188951a53dc6322303659) launchd: use user domain for background agents
* [`3a70e333`](https://github.com/nix-community/home-manager/commit/3a70e333f2950c302e875c44cfcfaff3f80f36bc) fish: extract completion generator from the fish binary
* [`3b3ff176`](https://github.com/nix-community/home-manager/commit/3b3ff176217fcd165a589cb43bc2de411a573cdc) firefox: legacyUserProfileCustomizations when userChrome is present
* [`085e92b0`](https://github.com/nix-community/home-manager/commit/085e92b04a46f3084040291d07d6788565a7b739) github-copilot-cli: preserve args for local-type MCP servers
* [`3d8f49f3`](https://github.com/nix-community/home-manager/commit/3d8f49f36073e38c212e515024ef58614dba454d) alacritty: normalize key binding escape sequences
* [`9e3e1d95`](https://github.com/nix-community/home-manager/commit/9e3e1d95beecfe090eb6b902ce5223464966be8d) codex: add maintainer khaneliman
* [`01e23f49`](https://github.com/nix-community/home-manager/commit/01e23f497cca8216f937373353b6df6497c0f19c) codex: update upstream config reference
* [`1c64122e`](https://github.com/nix-community/home-manager/commit/1c64122e70ad8e31067a4aa0a9e8ec7650076479) codex: add context override file
* [`64221f9c`](https://github.com/nix-community/home-manager/commit/64221f9c87fc8d7a84b26bfe63d728f971a431e0) codex: add lifecycle hooks option
* [`2ebe9c0f`](https://github.com/nix-community/home-manager/commit/2ebe9c0fe7ac018b57daf2ed5db30e6374df9a11) codex: sanitize plugin cache paths
* [`19d7472a`](https://github.com/nix-community/home-manager/commit/19d7472aca941c7e3d11e8a91d61be47d70c4ab5) codex: reorganize module files
* [`5d320ab3`](https://github.com/nix-community/home-manager/commit/5d320ab301cfaaca7d32514f13815d19d109f5f4) fzf: source nushell integration after carapace
* [`6eba758f`](https://github.com/nix-community/home-manager/commit/6eba758fee9d6de3c3e6cedb407423a4174b14e5) uv: prune Python versions and tools by diff
* [`8d8a6cc5`](https://github.com/nix-community/home-manager/commit/8d8a6cc50ddc60748791a14ee1163c865ec57635) gpg: make package optional
* [`4ad9aaae`](https://github.com/nix-community/home-manager/commit/4ad9aaae70c9aaab504127f926c0fa9cfbc2b365) generic-linux-gpu: add EGL support for Nvidia
* [`abeeea12`](https://github.com/nix-community/home-manager/commit/abeeea1221a356158bc81b1ff285bf3b9c19991a) vscode: fix userMcp option example syntax
* [`1cba40f9`](https://github.com/nix-community/home-manager/commit/1cba40f9317c8aef79b02de7f84d729236d162fc) vscode: refactor profile paths to use unified profileDir helper
* [`2c661cc9`](https://github.com/nix-community/home-manager/commit/2c661cc960846ee4c36db592bc0354ab019a8e5a) flake: bump nixpkgs from `3e41b24` to `89570f2`
* [`789a35fb`](https://github.com/nix-community/home-manager/commit/789a35fbdeb3c46b260096daa0b321c11be527ea) maintainers: remove duplicate maintainers
* [`9eec3ef0`](https://github.com/nix-community/home-manager/commit/9eec3ef087f544c443e0be79e112f31103db8289) maintainers: remove quoted names in set
* [`7042d2b3`](https://github.com/nix-community/home-manager/commit/7042d2b31b5cdca1454555332dd19e8f759e6678) lib/nix: use locked nixpkgs for maintainer extraction
* [`8f096963`](https://github.com/nix-community/home-manager/commit/8f096963ae8f4ddae0f887545ac601657ac3e474) maintainers: regenerate all-maintainers
* [`5d72a29f`](https://github.com/nix-community/home-manager/commit/5d72a29fc36ac21adae6ae35568fe5ee6700850f) hyprpaper: add system target option
