### PR TITLE
npins emacs-overlay: update 4d84d5c3 -> 049348f7

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -35,9 +35,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "4d84d5c37f28595b34858e4ae9c76c11e7c257ab",
-      "url": "https://github.com/nix-community/emacs-overlay/archive/4d84d5c37f28595b34858e4ae9c76c11e7c257ab.tar.gz",
-      "hash": "sha256-FxU58LNvJzcOU9K6xUyE01GvB8x5Vtm0b6sUbjB82WE="
+      "revision": "049348f7a64744506ea5dfb6c939d780de5214c8",
+      "url": "https://github.com/nix-community/emacs-overlay/archive/049348f7a64744506ea5dfb6c939d780de5214c8.tar.gz",
+      "hash": "sha256-2Pz2ajx4elc6+J1ptkGAi4HLYTW2vW/jJhQfeZsXq9U="
     },
     "home-manager": {
       "type": "Git",


### PR DESCRIPTION
## Changelog for emacs-overlay:
Branch: master
Commits: [nix-community/emacs-overlay@4d84d5c3...049348f7](https://github.com/nix-community/emacs-overlay/compare/4d84d5c37f28595b34858e4ae9c76c11e7c257ab...049348f7a64744506ea5dfb6c939d780de5214c8)

* [`dd35f07c`](https://github.com/nix-community/emacs-overlay/commit/dd35f07c8f4cd9611903240ec1605f8933ce5f6e) Updated nongnu
* [`b6a0a770`](https://github.com/nix-community/emacs-overlay/commit/b6a0a770b57dff7d4e8816258be5627b57e97fed) Updated elpa
* [`3511c053`](https://github.com/nix-community/emacs-overlay/commit/3511c053f4f64b06fdf0e92d234c9b499dd30942) Updated emacs
* [`eb5a1855`](https://github.com/nix-community/emacs-overlay/commit/eb5a1855628d327e61203641dd17cec536d0ab98) Updated melpa
* [`67783c6c`](https://github.com/nix-community/emacs-overlay/commit/67783c6cc9fe29ff1abde88262e6dd61cb4f1191) Updated nongnu
* [`00b08969`](https://github.com/nix-community/emacs-overlay/commit/00b089698f39f7c41eabe8a8d9869ebbc1759a7e) Updated elpa
* [`d6937ddd`](https://github.com/nix-community/emacs-overlay/commit/d6937ddd008952b1ceb22ff767d12539e1eff0e0) Updated emacs
* [`00b5f387`](https://github.com/nix-community/emacs-overlay/commit/00b5f387f4f557a0f5a3902023b62aa15d020683) Updated melpa
* [`7e9c996e`](https://github.com/nix-community/emacs-overlay/commit/7e9c996eadfff226bccc1d68664240e0cb5ef444) Updated nongnu
* [`8f68ac17`](https://github.com/nix-community/emacs-overlay/commit/8f68ac1754dcde4d6ff249719091e77d710d3747) Updated elpa
* [`c231bdc8`](https://github.com/nix-community/emacs-overlay/commit/c231bdc86cc7352b9bc65817c1a219c9d9664a29) Updated flake inputs
* [`0c01d3f8`](https://github.com/nix-community/emacs-overlay/commit/0c01d3f81a5df88f78d92e8750dcae295237bf7b) Updated nongnu
* [`31042994`](https://github.com/nix-community/emacs-overlay/commit/31042994dbce7c0ea7233ec993c37e8e81007e47) Updated elpa
* [`93e63b03`](https://github.com/nix-community/emacs-overlay/commit/93e63b03e1ab5a27778331225dcf8221a12ccfeb) Updated nongnu
* [`7695295f`](https://github.com/nix-community/emacs-overlay/commit/7695295f332c37e9c96a601a74b642db7db7e741) Updated nongnu
* [`b628c685`](https://github.com/nix-community/emacs-overlay/commit/b628c685d51298a5d264dd20b2e0b584130aaac0) Updated elpa
* [`23c83ba8`](https://github.com/nix-community/emacs-overlay/commit/23c83ba8134e6770bf7d8999d8642f8294b69cf0) Updated flake inputs
* [`f8595289`](https://github.com/nix-community/emacs-overlay/commit/f85952894cfbc4f6dae2f12e28cefc6bdcbb6ece) Updated nongnu
* [`a99d9be8`](https://github.com/nix-community/emacs-overlay/commit/a99d9be87334e0431a3a1b5baa521c865793a8ed) Updated nongnu
* [`8be3ca28`](https://github.com/nix-community/emacs-overlay/commit/8be3ca282a583717650d51e075745b97ec021b36) Updated nongnu
* [`1746faa2`](https://github.com/nix-community/emacs-overlay/commit/1746faa2845d304d6a54434a4b54b042327d61a7) Updated elpa
* [`92e150bc`](https://github.com/nix-community/emacs-overlay/commit/92e150bc65aa273a487f3bb92d76090e7fbe8842) Updated nongnu
* [`a6a16b98`](https://github.com/nix-community/emacs-overlay/commit/a6a16b9842a6eaf029a1f899661b133c7940792c) Updated elpa
* [`f728be42`](https://github.com/nix-community/emacs-overlay/commit/f728be42b2cff184f626acf5fae4d235f1605650) Updated nongnu
* [`695015ae`](https://github.com/nix-community/emacs-overlay/commit/695015ae8c42435944f62d25e6b5546948ea3e1e) Updated elpa
* [`bea3cd99`](https://github.com/nix-community/emacs-overlay/commit/bea3cd99e510d77b01218a680a1b6306ce72f998) Updated flake inputs
* [`cdcdfc25`](https://github.com/nix-community/emacs-overlay/commit/cdcdfc25df20b5622b5de289decaed93456bea0d) Updated emacs
* [`a4dca412`](https://github.com/nix-community/emacs-overlay/commit/a4dca412694e9d1c2b19218ac0e722baecd6103a) Updated melpa
* [`02c127ba`](https://github.com/nix-community/emacs-overlay/commit/02c127ba1edb846cd7358c06644d2edced2062b0) Updated flake inputs
* [`522f0c15`](https://github.com/nix-community/emacs-overlay/commit/522f0c1535cf260f26485ee96b512ba2df057542) Updated nongnu
* [`57eeb100`](https://github.com/nix-community/emacs-overlay/commit/57eeb1001897f40368287a1a8bb7123f1b96ed66) Updated nongnu
* [`12320c4f`](https://github.com/nix-community/emacs-overlay/commit/12320c4f8cca562e2b032ff3f6d29372867c27c7) Updated elpa
* [`d0d70670`](https://github.com/nix-community/emacs-overlay/commit/d0d70670bf31687d71a6365f0005c6c71dc07af9) Updated nongnu
* [`a17704b6`](https://github.com/nix-community/emacs-overlay/commit/a17704b6d09900a9475493d6560292951a71295b) Updated elpa
* [`b310b15e`](https://github.com/nix-community/emacs-overlay/commit/b310b15ea4fb48fb24ad864467822e984d890353) Updated nongnu
* [`5bf13078`](https://github.com/nix-community/emacs-overlay/commit/5bf130789d22455c6adec4de06074ebf2af50a63) Updated elpa
* [`8f89a2c3`](https://github.com/nix-community/emacs-overlay/commit/8f89a2c36a7ebf1374d86f7db1602b55bb777e07) Updated nongnu
* [`779be430`](https://github.com/nix-community/emacs-overlay/commit/779be4306d10a1d3b5c1d896155bc8a44dee6f73) Updated nongnu
* [`7a91993a`](https://github.com/nix-community/emacs-overlay/commit/7a91993a030242372267785a66cd7bbc6d0cdc28) Updated elpa
* [`34a676d7`](https://github.com/nix-community/emacs-overlay/commit/34a676d7dac5dd30dd9736e6883677111bf0f916) Updated melpa
* [`325b5768`](https://github.com/nix-community/emacs-overlay/commit/325b57680b1b301e70b97bf57d5fa52899bd8e26) Updated emacs
* [`a63610b5`](https://github.com/nix-community/emacs-overlay/commit/a63610b5d388b610bad32939ccac1c9d3cc64303) Updated emacs
* [`5dab538f`](https://github.com/nix-community/emacs-overlay/commit/5dab538fce92fd1fe70acecf34496fa85f81c1e9) Updated melpa
* [`f14d0074`](https://github.com/nix-community/emacs-overlay/commit/f14d0074de9f9737b234ce8b00d9787f60ff833f) Updated nongnu
* [`e276c5e0`](https://github.com/nix-community/emacs-overlay/commit/e276c5e0f6eeb82f88ef8f153139052c3fe9ba17) Updated nongnu
* [`0d43c1b2`](https://github.com/nix-community/emacs-overlay/commit/0d43c1b2bf83db3b4376eb8944ea666d67df5c1b) Updated elpa
* [`5c845c25`](https://github.com/nix-community/emacs-overlay/commit/5c845c25adc78307bfb6abdb6e91d082a17340e6) Updated melpa
* [`297f58eb`](https://github.com/nix-community/emacs-overlay/commit/297f58eb2bc5eedcc0321a23e118ff1dffe1fe50) Updated nongnu
* [`9ea9de45`](https://github.com/nix-community/emacs-overlay/commit/9ea9de45e69d9754a33b1fb9731835f60467183b) Updated elpa
* [`42c82694`](https://github.com/nix-community/emacs-overlay/commit/42c82694b484006ae3a1aa64b773b4bc061c9827) Updated melpa
* [`1d74328a`](https://github.com/nix-community/emacs-overlay/commit/1d74328a860cffe8ddb00193c6fea760f6e3d119) Updated nongnu
* [`279af1bb`](https://github.com/nix-community/emacs-overlay/commit/279af1bb71762f74f6b210dc48fa0dde10f59710) Updated elpa
* [`b16a1401`](https://github.com/nix-community/emacs-overlay/commit/b16a1401c94ee3be59b39dcfc4fb40c5c72780b0) Updated emacs
* [`d2ea185a`](https://github.com/nix-community/emacs-overlay/commit/d2ea185a22e058703c129c34be58a09b75f7cf52) Updated melpa
* [`be91311e`](https://github.com/nix-community/emacs-overlay/commit/be91311e0859d39a3a5906d06a1e50b6244fa416) Updated nongnu
* [`b4285e87`](https://github.com/nix-community/emacs-overlay/commit/b4285e87b7f1eb0824b264a90316b3ccac9da1d8) Updated elpa
* [`46cb5dbe`](https://github.com/nix-community/emacs-overlay/commit/46cb5dbe52fd129119dd02eee5f51e76d0f3afc3) Updated nongnu
* [`aea5950a`](https://github.com/nix-community/emacs-overlay/commit/aea5950aa134de15e4c301f144d383d49b3ea8ef) Updated elpa
* [`832c684b`](https://github.com/nix-community/emacs-overlay/commit/832c684b4f4b13ee5357190ed48bbcbfb5488bbe) Updated flake inputs
* [`d3b52595`](https://github.com/nix-community/emacs-overlay/commit/d3b525951181218595677c3d92c5ecfaa4e80572) Updated nongnu
* [`56370355`](https://github.com/nix-community/emacs-overlay/commit/56370355602779cab851eb4ce94252e8c792284c) Updated nongnu
* [`4ad0a7ee`](https://github.com/nix-community/emacs-overlay/commit/4ad0a7ee7ced5ade705e2fa796dadcc403567bf7) Updated elpa
* [`b0f3ba6b`](https://github.com/nix-community/emacs-overlay/commit/b0f3ba6b14b266fd302acda496ce6932cbe8844b) Updated flake inputs
* [`81213cc0`](https://github.com/nix-community/emacs-overlay/commit/81213cc0984da51cbce0283e43b28cf01e89de71) Updated melpa
* [`87a80d77`](https://github.com/nix-community/emacs-overlay/commit/87a80d77365462d9e7ea132c69d322463083fdb9) Updated emacs
* [`92d87426`](https://github.com/nix-community/emacs-overlay/commit/92d87426011191ac2fdcf677195e2bdba485ae97) Updated nongnu
* [`409b2511`](https://github.com/nix-community/emacs-overlay/commit/409b251125f9368bd15710f6b7a9e486e6616f8b) Updated nongnu
* [`847cbbb4`](https://github.com/nix-community/emacs-overlay/commit/847cbbb49917ebf266477e0bbc1e800e58f69a2c) Updated elpa
* [`69d6ee2e`](https://github.com/nix-community/emacs-overlay/commit/69d6ee2e8ee0f7c3c5aa0898ba1d975bf187a983) Updated nongnu
* [`129eda49`](https://github.com/nix-community/emacs-overlay/commit/129eda492de5f3fbafd4cc2d5c2202aba48654fa) Updated elpa
* [`2aa0a867`](https://github.com/nix-community/emacs-overlay/commit/2aa0a86786182e99c80f9b72a02d9aff2a93710c) Updated nongnu
* [`43f15b53`](https://github.com/nix-community/emacs-overlay/commit/43f15b530a2b44ff83efdeae10e157d001f74433) Updated elpa
* [`21ac9813`](https://github.com/nix-community/emacs-overlay/commit/21ac9813c414eafede4c6ab572a989f742c3f99f) Updated emacs
* [`370a91d7`](https://github.com/nix-community/emacs-overlay/commit/370a91d75e2945cda4e29525891a75c859f658b7) Updated melpa
* [`edf8c260`](https://github.com/nix-community/emacs-overlay/commit/edf8c260d6f10a51d61f7498fde57dd91e9ba4fd) Updated nongnu
* [`9f195ea6`](https://github.com/nix-community/emacs-overlay/commit/9f195ea69ca8f83d98db59bcd4f4a863ea45584b) Updated flake inputs
* [`dffe4cec`](https://github.com/nix-community/emacs-overlay/commit/dffe4cec2b07a61b4898a1c8eb49cbe3a03c3288) Updated elpa
* [`1af1fd26`](https://github.com/nix-community/emacs-overlay/commit/1af1fd26707816c817eaa0c656b531345001c9db) Updated nongnu
* [`ff4e6dca`](https://github.com/nix-community/emacs-overlay/commit/ff4e6dca536170d29a7098c3da256e22799b2985) Updated nongnu
* [`d96361f2`](https://github.com/nix-community/emacs-overlay/commit/d96361f29cf6dd8e1006097132b2a04b8ab07131) Updated flake inputs
* [`42fe2483`](https://github.com/nix-community/emacs-overlay/commit/42fe24832f66bfe42b1e8f2838133e958403ed0a) Updated elpa
* [`0a0831aa`](https://github.com/nix-community/emacs-overlay/commit/0a0831aa5d4d5a90ef1f25c650b179dff1754e4d) Updated nongnu
* [`8d140f7f`](https://github.com/nix-community/emacs-overlay/commit/8d140f7ffea6b884960655e2ee23de0f6ff735ad) Updated elpa
* [`2aaa6cc9`](https://github.com/nix-community/emacs-overlay/commit/2aaa6cc9012ff559131aff6a461a3f1889c2e1ec) Updated nongnu
* [`9a22c9c8`](https://github.com/nix-community/emacs-overlay/commit/9a22c9c814e0606699820faebbb3b2a2911f2bb1) Updated elpa
* [`ebbc48c5`](https://github.com/nix-community/emacs-overlay/commit/ebbc48c580036ab22a5583b9cf248e654299cd56) Updated melpa
* [`7c4d2bd6`](https://github.com/nix-community/emacs-overlay/commit/7c4d2bd60c459f5a53b5d71620f7b41e5dfdab55) Updated emacs
* [`edee48ab`](https://github.com/nix-community/emacs-overlay/commit/edee48ab90f0548aabc63526ed8ddbac59f3e2d6) Updated nongnu
* [`58d6223a`](https://github.com/nix-community/emacs-overlay/commit/58d6223a7c0d1634249111413c7d88b2ac7bef61) Updated nongnu
* [`1afa8d5f`](https://github.com/nix-community/emacs-overlay/commit/1afa8d5f7dd8305cccae67934aae73a44f97e27d) Updated elpa
* [`81631d5a`](https://github.com/nix-community/emacs-overlay/commit/81631d5afa88c4550aab1670f804f9e5fbeee95a) Updated melpa
* [`db950f81`](https://github.com/nix-community/emacs-overlay/commit/db950f81a500042ec9a158a52bcae76475039e8f) Updated emacs
* [`1649b28e`](https://github.com/nix-community/emacs-overlay/commit/1649b28edda15ac7db2c41081cd26816b047e8be) Revert "Work around race of git between elpa and nongnu"
* [`9289efe8`](https://github.com/nix-community/emacs-overlay/commit/9289efe8d985c882ef73b2fba9716ee909dbbc44) Work around race condition of git between elpa and nongnu
* [`db591e92`](https://github.com/nix-community/emacs-overlay/commit/db591e92ceac935e19c6727254f9a2ce1a81ad81) Updated nongnu
* [`98d48641`](https://github.com/nix-community/emacs-overlay/commit/98d48641b320afbb855d7d6ac9c632d4065bec94) Updated elpa
* [`b7730eee`](https://github.com/nix-community/emacs-overlay/commit/b7730eee21a9e66247f6883e1e98e261e9222cd3) Updated emacs
* [`84633a8c`](https://github.com/nix-community/emacs-overlay/commit/84633a8c887a908356149cfaf660b704cced4b93) Updated melpa
* [`cacaec29`](https://github.com/nix-community/emacs-overlay/commit/cacaec2965f7c22b1d5283cf89a3095ddba3e7fa) Updated elpa
* [`f93acb2b`](https://github.com/nix-community/emacs-overlay/commit/f93acb2bfc2c53072017b5df585e5d26fa6a7d17) Updated emacs
* [`f713f9b7`](https://github.com/nix-community/emacs-overlay/commit/f713f9b77b49ac403e8ac16e3412cfb02c604b2f) Updated melpa
* [`85984514`](https://github.com/nix-community/emacs-overlay/commit/859845141484c8cf7932009fda48bf28df5ace6e) Updated nongnu
* [`a572313a`](https://github.com/nix-community/emacs-overlay/commit/a572313aa371509f8792de911e33c62204bd0af1) Updated elpa
* [`ed52ad0a`](https://github.com/nix-community/emacs-overlay/commit/ed52ad0af15f03b2d4266d5174b79b6edf558e03) Updated flake inputs
* [`a48a8845`](https://github.com/nix-community/emacs-overlay/commit/a48a88453fbdaa9f78b5a26dd55a814dd912ce51) ci: allow update job of emacs to fail
* [`525c0cf4`](https://github.com/nix-community/emacs-overlay/commit/525c0cf41352c1dab4cf4a92d574c335e7ccfa36) Updated nongnu
* [`85701b03`](https://github.com/nix-community/emacs-overlay/commit/85701b03a9e2eed26fb3b122aea76bf302174f91) Updated elpa
* [`9244f2d9`](https://github.com/nix-community/emacs-overlay/commit/9244f2d9eaa8ddbe13fd1113af86fa440b0ed0d0) Updated emacs
* [`5f8f3a12`](https://github.com/nix-community/emacs-overlay/commit/5f8f3a12b25e29c1dd0a6363b61eba7d2f9944fe) Updated melpa
* [`2f333a3c`](https://github.com/nix-community/emacs-overlay/commit/2f333a3c6732c66d36c52d629b14f786a2d73a7e) Updated nongnu
* [`2e7945f6`](https://github.com/nix-community/emacs-overlay/commit/2e7945f6d922b53d4229b92dad064d2247678d61) Updated elpa
* [`61f21349`](https://github.com/nix-community/emacs-overlay/commit/61f21349706fe449d5687bd5d999d4530d8a8c8d) Updated melpa
* [`653ab7b9`](https://github.com/nix-community/emacs-overlay/commit/653ab7b9585a3af449112f16ad0fa44dc5ac984a) Updated nongnu
* [`7b51068b`](https://github.com/nix-community/emacs-overlay/commit/7b51068ba75ab9ea0375feb2bcdefead8e47c03b) Updated elpa
* [`0fefbcec`](https://github.com/nix-community/emacs-overlay/commit/0fefbcec2743543654581c2ddabdecea0f2cb543) Updated emacs
* [`700f001b`](https://github.com/nix-community/emacs-overlay/commit/700f001bac93c3b9ea848b9af0c2b940d8e3e593) Updated melpa
* [`b18f99ff`](https://github.com/nix-community/emacs-overlay/commit/b18f99fff6ff977109cd4ba1197478061aeb185e) Updated nongnu
* [`a795ef68`](https://github.com/nix-community/emacs-overlay/commit/a795ef6807d43191d5c8af06b797e38eec342525) Updated elpa
* [`6bdd8c00`](https://github.com/nix-community/emacs-overlay/commit/6bdd8c0015e2ca41863863f25a204f5e424e5d86) Updated melpa
* [`c0ee65d4`](https://github.com/nix-community/emacs-overlay/commit/c0ee65d473ebdd79e27ae32636054ea89ec990a8) Updated melpa
* [`23c9f87d`](https://github.com/nix-community/emacs-overlay/commit/23c9f87d5f34a4ba0c62d6b94ce92e794b7d722f) Updated nongnu
* [`1176f39b`](https://github.com/nix-community/emacs-overlay/commit/1176f39b816de96a869bf8881c34ccb51fc47f1d) Updated elpa
* [`0472770a`](https://github.com/nix-community/emacs-overlay/commit/0472770ab78eb62a02b4d3794be4a038450af287) Updated melpa
* [`ca68979c`](https://github.com/nix-community/emacs-overlay/commit/ca68979cb12d81f2f5cc4e3b12800d9756f0f7ba) Updated nongnu
* [`208caf9d`](https://github.com/nix-community/emacs-overlay/commit/208caf9d4983f881252fc0cfd2f586d10a04a1a4) Updated elpa
* [`09a07284`](https://github.com/nix-community/emacs-overlay/commit/09a07284b79d5d41c23fe0ed81ce96f94542f0d3) Updated melpa
* [`703883bc`](https://github.com/nix-community/emacs-overlay/commit/703883bc3f470fb7964e94d89f374f0f5f7ed690) Updated melpa
* [`e22e6d4a`](https://github.com/nix-community/emacs-overlay/commit/e22e6d4ad84534503154216805ad70a9cd39f9c1) Updated flake inputs
* [`48fd10e0`](https://github.com/nix-community/emacs-overlay/commit/48fd10e009803da7fc2505e37456d7111e68f9c1) Updated nongnu
* [`caa07b2f`](https://github.com/nix-community/emacs-overlay/commit/caa07b2f8c9299de25e3650f6ae7ee93d0499aaa) Updated elpa
* [`5a6afe30`](https://github.com/nix-community/emacs-overlay/commit/5a6afe3095b3a8b77cc36229b440fc7c72168199) Updated melpa
* [`d5117a45`](https://github.com/nix-community/emacs-overlay/commit/d5117a45e17c774d3eedde66a227ca24f481d127) Updated emacs
* [`753982a6`](https://github.com/nix-community/emacs-overlay/commit/753982a6e5932746111945fbca5362848a4128ed) Updated nongnu
* [`7f69e608`](https://github.com/nix-community/emacs-overlay/commit/7f69e608e6ac16770c3bcd28acb188adcf1b67a2) Updated elpa
* [`13cfd6c1`](https://github.com/nix-community/emacs-overlay/commit/13cfd6c1ddfa68268cefb0e283878d251372b6f2) Updated emacs
* [`e8271947`](https://github.com/nix-community/emacs-overlay/commit/e827194784bb83fb298784d1c9b5a7d48de1b23d) Updated melpa
* [`abaf50fa`](https://github.com/nix-community/emacs-overlay/commit/abaf50fa4428dea6464d95ba58dbe1eb598c9a2f) Updated melpa
* [`d9d18b96`](https://github.com/nix-community/emacs-overlay/commit/d9d18b9621cea345ccd85085abd79cc4a5f3463a) Updated flake inputs
* [`c5dcd4d0`](https://github.com/nix-community/emacs-overlay/commit/c5dcd4d0b86f6a89cb910754e04c6e7ec8c2c943) Updated nongnu
* [`19d303bf`](https://github.com/nix-community/emacs-overlay/commit/19d303bf444ef552a2a31103c99d2c83885a7ccd) Updated elpa
* [`cda7cb04`](https://github.com/nix-community/emacs-overlay/commit/cda7cb049709f2fc2dc6f0007f4831dfdcf23cf4) Updated emacs
* [`1dc69d66`](https://github.com/nix-community/emacs-overlay/commit/1dc69d6661320f9490c01f417f4ec16ef2cf7af5) Updated melpa
* [`5c99ab24`](https://github.com/nix-community/emacs-overlay/commit/5c99ab24f90d156e0356e30c8e74ba81baeef22d) Updated nongnu
* [`87e73f63`](https://github.com/nix-community/emacs-overlay/commit/87e73f63254bb7cc69d7f84f708f2ef31275dfe1) Updated elpa
* [`14d3fb8e`](https://github.com/nix-community/emacs-overlay/commit/14d3fb8ebabfc1b0c2e73a7b7c54184b94472d84) Updated melpa
* [`c7633af6`](https://github.com/nix-community/emacs-overlay/commit/c7633af680b7c1b3186b389ef5abce9abd6ba442) Updated flake inputs
* [`748d9304`](https://github.com/nix-community/emacs-overlay/commit/748d9304a472fb772cb8e6affba0ffe03e401371) Updated melpa
* [`37a81c00`](https://github.com/nix-community/emacs-overlay/commit/37a81c00a1703d8928ecf4f33f700bb31d54144c) Updated nongnu
* [`1aea2ff6`](https://github.com/nix-community/emacs-overlay/commit/1aea2ff63be429967f9cfad026b2b9e7734cdd64) Updated elpa
* [`0680daad`](https://github.com/nix-community/emacs-overlay/commit/0680daade6db6b2bc60408f1f02917ac6d48c7a9) Updated melpa
* [`97bcb9a5`](https://github.com/nix-community/emacs-overlay/commit/97bcb9a55b029bbc51cefcaa21541265cd8359a6) Updated nongnu
* [`4040e496`](https://github.com/nix-community/emacs-overlay/commit/4040e496ee9a52d4659e06f2e39edcfd841065f0) Updated elpa
* [`32b86954`](https://github.com/nix-community/emacs-overlay/commit/32b869548700ce1ecf63fd95a9cb35289a922714) Updated melpa
* [`b17c7e8c`](https://github.com/nix-community/emacs-overlay/commit/b17c7e8ca08fa5f6ac667f6adfc61786f5a42004) Updated emacs
* [`8e1b03fd`](https://github.com/nix-community/emacs-overlay/commit/8e1b03fd7ad5d6231a5486e6dff48e17db2a56b3) Updated flake inputs
* [`c7704e43`](https://github.com/nix-community/emacs-overlay/commit/c7704e4387f66c07a9ce2c76f5081848c61a3f1c) Updated melpa
* [`2d896b77`](https://github.com/nix-community/emacs-overlay/commit/2d896b772f50ab8dc711b5761a23404d43129bb8) Updated flake inputs
* [`a4127a58`](https://github.com/nix-community/emacs-overlay/commit/a4127a58d11ed90c16631f9132263332ca002834) Updated nongnu
* [`22a03074`](https://github.com/nix-community/emacs-overlay/commit/22a03074bb1a3191e97c60aa2343390fcd4540b2) Updated elpa
* [`0ad3ae2f`](https://github.com/nix-community/emacs-overlay/commit/0ad3ae2f5d2b3797520d4e38bc26533d623504ca) Updated melpa
* [`a0d52330`](https://github.com/nix-community/emacs-overlay/commit/a0d52330050ca3da6610e6449d5f5d58a520f78c) Updated nongnu
* [`297c2576`](https://github.com/nix-community/emacs-overlay/commit/297c2576e69e4bdcb1cebb736c22969e282624d7) Updated elpa
* [`5a6425a7`](https://github.com/nix-community/emacs-overlay/commit/5a6425a7a1144748a49b25ab5d2d91ccd0ec09d1) Updated melpa
* [`e4f64d25`](https://github.com/nix-community/emacs-overlay/commit/e4f64d25c8c7828615267f9c222e1dab0d6973ba) Updated elpa
* [`741c2296`](https://github.com/nix-community/emacs-overlay/commit/741c22966b60320c1c7715f0e08ba87af43b99de) Updated melpa
* [`059eb08c`](https://github.com/nix-community/emacs-overlay/commit/059eb08cba94cd08895f3b5dded73956582be4e7) Updated emacs
* [`ef470316`](https://github.com/nix-community/emacs-overlay/commit/ef47031630d02e2e0a7fcf646439ddb0b7b20519) Updated emacs
* [`542fa643`](https://github.com/nix-community/emacs-overlay/commit/542fa64371e1ebc6dfe61402301f955e39a3a649) Updated melpa
* [`fc7da4a3`](https://github.com/nix-community/emacs-overlay/commit/fc7da4a357e4eefa92244be5494b3dd9ecc5ef23) Updated nongnu
* [`e8e8422d`](https://github.com/nix-community/emacs-overlay/commit/e8e8422d5982359b1780029a036b41d1ff09145d) Updated elpa
* [`f3d81144`](https://github.com/nix-community/emacs-overlay/commit/f3d81144f3b6cd06e32a4c67f1bd55b8bb3f57a4) Updated melpa
* [`7e4ccb84`](https://github.com/nix-community/emacs-overlay/commit/7e4ccb84c40542dc8e2eeed516cc17ef21a0fb7b) Updated nongnu
* [`c8a49d62`](https://github.com/nix-community/emacs-overlay/commit/c8a49d620866ac8d50a653d6240ead37b7a808e2) Updated elpa
* [`a2250d81`](https://github.com/nix-community/emacs-overlay/commit/a2250d8117c811a007be7989bab9db85545dbc5e) Updated melpa
* [`c94e6693`](https://github.com/nix-community/emacs-overlay/commit/c94e6693bcee617675796b2017c4fa47d0f7c55e) Updated nongnu
* [`ba1421fa`](https://github.com/nix-community/emacs-overlay/commit/ba1421fa656154da848a94eb781275541a2668e2) Updated elpa
* [`ebe9dfd6`](https://github.com/nix-community/emacs-overlay/commit/ebe9dfd676484feb43d1f4e9204b9f81434238e2) Updated melpa
* [`3597bfbb`](https://github.com/nix-community/emacs-overlay/commit/3597bfbbe7ed696cbe628ae1e157e6809b48da8a) Updated nongnu
* [`582cc5c0`](https://github.com/nix-community/emacs-overlay/commit/582cc5c014d7f0bbe199693bbad4b2cf1363656c) Updated elpa
* [`3cfd1dd9`](https://github.com/nix-community/emacs-overlay/commit/3cfd1dd923240becae9de45e1eb71f214a6293d5) Updated melpa
* [`c0588a50`](https://github.com/nix-community/emacs-overlay/commit/c0588a506c8980f3c4cb8461abf91397fae5ec61) Updated flake inputs
* [`1824c29d`](https://github.com/nix-community/emacs-overlay/commit/1824c29d2b3e96f6e812480a17a5b82f6e67dc1b) Updated emacs
* [`f4976ced`](https://github.com/nix-community/emacs-overlay/commit/f4976ced9eb4ef3d987457c43ef1f816b4ea2361) Updated melpa
* [`4a7112fc`](https://github.com/nix-community/emacs-overlay/commit/4a7112fc83949de16b2f7792d5eb646328562632) Updated elpa
* [`44a305c2`](https://github.com/nix-community/emacs-overlay/commit/44a305c2cd136b6be6bbe5ff9dbf6d1b0edef004) Updated nongnu
* [`ca2ba4e2`](https://github.com/nix-community/emacs-overlay/commit/ca2ba4e27b8b6c4b3e889d498ee1d393131eb595) Updated melpa
* [`609461bd`](https://github.com/nix-community/emacs-overlay/commit/609461bdfb8f768490da0a6ea16f363d1699d78e) Replace pkgs.recurseIntoAttrs with lib.recurseIntoAttrs
* [`07cf53a4`](https://github.com/nix-community/emacs-overlay/commit/07cf53a4b108e72ced180250dd40a7c8c35f1370) flake: bump nixpkgs-stable to 26.05
* [`2bd9a5f5`](https://github.com/nix-community/emacs-overlay/commit/2bd9a5f59c664ff22fed9304d584a65068f78abb) Updated nongnu
* [`26aa1770`](https://github.com/nix-community/emacs-overlay/commit/26aa1770705b2948def0201902bbf8d431fb9386) Updated elpa
* [`375c8cc8`](https://github.com/nix-community/emacs-overlay/commit/375c8cc854c1ee3b5094887061271def4ff2c863) Updated emacs
* [`6115e0be`](https://github.com/nix-community/emacs-overlay/commit/6115e0beeb4646b42d128487f7744a12a799cb46) Updated melpa
* [`197b1ee1`](https://github.com/nix-community/emacs-overlay/commit/197b1ee14b90bd669ef5188848e746eed7246530) Updated melpa
* [`75733620`](https://github.com/nix-community/emacs-overlay/commit/757336201befa969f6aaefcf959626793942dff0) Updated nongnu
* [`c1df81d6`](https://github.com/nix-community/emacs-overlay/commit/c1df81d636fbd01696137884376cc51b738cbed2) Updated elpa
* [`5e1a66d7`](https://github.com/nix-community/emacs-overlay/commit/5e1a66d7833eede45cbc510f8e3d1ed65fcc310c) Updated melpa
* [`9b255271`](https://github.com/nix-community/emacs-overlay/commit/9b255271b0ce90c06922c6d4a17e87995c2c0aa3) Updated nongnu
* [`5506467b`](https://github.com/nix-community/emacs-overlay/commit/5506467b0036fed0aa16370f34813b660c31c6ae) Updated elpa
* [`bf9bf1b4`](https://github.com/nix-community/emacs-overlay/commit/bf9bf1b404390ddeab3a3ef54bad7afb1cba351d) Updated melpa
* [`4377e167`](https://github.com/nix-community/emacs-overlay/commit/4377e16762345554db6e94aa1d536b17839b914a) Updated emacs
* [`5b8c6d93`](https://github.com/nix-community/emacs-overlay/commit/5b8c6d93e08a4cd591f9c4fe4bffd7e31bd50681) Updated melpa
* [`e2a9ca8c`](https://github.com/nix-community/emacs-overlay/commit/e2a9ca8cc167483162ea06597681e7fe9db3c850) Updated flake inputs
* [`a61ffb75`](https://github.com/nix-community/emacs-overlay/commit/a61ffb75029544016cd9f5d9b0eac4caa7bcd23b) Updated nongnu
* [`26496901`](https://github.com/nix-community/emacs-overlay/commit/26496901f6ca2da6a1724215a08cd47c37f4f701) Updated elpa
* [`e6fdad24`](https://github.com/nix-community/emacs-overlay/commit/e6fdad24d1ef68f0adde1f750343cc0222d7de9a) Updated emacs
* [`58d7e036`](https://github.com/nix-community/emacs-overlay/commit/58d7e0363b8749568b976787c9eaf1ec68f8fee9) Updated melpa
* [`cbdb72c4`](https://github.com/nix-community/emacs-overlay/commit/cbdb72c46387cd25c08f65dd4f8968c323249ac5) Updated nongnu
* [`eee13492`](https://github.com/nix-community/emacs-overlay/commit/eee13492ed7228d9f63d03212c08b5a07b3d1c6b) Updated elpa
* [`9eae2655`](https://github.com/nix-community/emacs-overlay/commit/9eae265510d009608fd842118a5e2b59e2e3818d) Updated emacs
* [`0ccbdaea`](https://github.com/nix-community/emacs-overlay/commit/0ccbdaeadd69f609823701cf601b6915bee8bc18) Updated melpa
* [`d47a2047`](https://github.com/nix-community/emacs-overlay/commit/d47a204715e50b297267395719eadf3509f670fa) Updated melpa
* [`b9a1f1b1`](https://github.com/nix-community/emacs-overlay/commit/b9a1f1b1851889d07db2bb5cbc88c406c85a6c5b) Updated nongnu
* [`d4af417d`](https://github.com/nix-community/emacs-overlay/commit/d4af417db738bdac42f314bc428295050cf26f5e) Updated elpa
* [`039abde7`](https://github.com/nix-community/emacs-overlay/commit/039abde79117f2c7f95bb4642cbba8318613f3fe) Updated melpa
* [`680b2af8`](https://github.com/nix-community/emacs-overlay/commit/680b2af8a4bd991576660060be7a33cb9dc54b0d) Updated nongnu
* [`1294ccb9`](https://github.com/nix-community/emacs-overlay/commit/1294ccb9b417f4f71d7469f21e52f04f0db3a0bb) Updated elpa
* [`adf2e0de`](https://github.com/nix-community/emacs-overlay/commit/adf2e0de0eb41afdceaddfd6c78ad332866ce8b5) Updated melpa
* [`e49f3daa`](https://github.com/nix-community/emacs-overlay/commit/e49f3daaab1b31071c67814889e97ed081a38d83) Updated emacs
* [`7d50a467`](https://github.com/nix-community/emacs-overlay/commit/7d50a46748a6f5462f8bb32aa6c1a8aaa50ff842) Updated melpa
* [`1e8570e9`](https://github.com/nix-community/emacs-overlay/commit/1e8570e9a7eecde3606c3f9e2ff7e9e3aeac0e6f) Updated nongnu
* [`97f26efd`](https://github.com/nix-community/emacs-overlay/commit/97f26efd919922570838b3ad02e27848fe4df9f3) Updated elpa
* [`b8e282a3`](https://github.com/nix-community/emacs-overlay/commit/b8e282a36872823a454ff065298f055da5ca711b) Updated melpa
* [`dd2d4a58`](https://github.com/nix-community/emacs-overlay/commit/dd2d4a58962c8ecc2c68cdf82aff12596ccc0f26) Updated nongnu
* [`61c716a7`](https://github.com/nix-community/emacs-overlay/commit/61c716a7f0fdc7088305e98a9f9189c1835a0314) Updated elpa
* [`c556ab34`](https://github.com/nix-community/emacs-overlay/commit/c556ab3421d2e59abc22bf8f072dc1ca0cb1453d) Updated emacs
* [`b6f6b737`](https://github.com/nix-community/emacs-overlay/commit/b6f6b737d932c7b7a93c04d0815319d9752e4d8f) Updated emacs
* [`c336ca20`](https://github.com/nix-community/emacs-overlay/commit/c336ca20df05c8071b9bca5c579a5d4cbf77d8aa) Updated nongnu
* [`38bbab98`](https://github.com/nix-community/emacs-overlay/commit/38bbab98e1a76ac901714fdfdd48b9d26de10fd2) Updated elpa
* [`2ace24de`](https://github.com/nix-community/emacs-overlay/commit/2ace24de010b2b967768a23c442fffaa52b6095b) Updated emacs
* [`9d5bd978`](https://github.com/nix-community/emacs-overlay/commit/9d5bd97826560f4560dfa03ac781b1d2db8fe4b4) Updated melpa
* [`58712654`](https://github.com/nix-community/emacs-overlay/commit/587126546679f1ec025ca7bbb8cfeff8df92f151) Updated nongnu
* [`d968cac5`](https://github.com/nix-community/emacs-overlay/commit/d968cac56f43b365adec14e33f2f64d929eced72) Updated elpa
* [`82202b8a`](https://github.com/nix-community/emacs-overlay/commit/82202b8a770eb4639858cec6ec44c45b136520f4) Updated melpa
* [`1f756562`](https://github.com/nix-community/emacs-overlay/commit/1f756562a2c02f860bc3e7f0a1bf51fc7a5f7198) Updated flake inputs
* [`be227ccc`](https://github.com/nix-community/emacs-overlay/commit/be227ccc5cbd297ca6b2609b551d251d7adf0212) Updated melpa
* [`63b80024`](https://github.com/nix-community/emacs-overlay/commit/63b800240f70ea1f790a84bb7cd7d21ec8d10f02) Updated emacs
* [`9c2c1995`](https://github.com/nix-community/emacs-overlay/commit/9c2c19952a661e5bd1b564a01cc5c4893e447dda) Updated flake inputs
* [`4cae6e9c`](https://github.com/nix-community/emacs-overlay/commit/4cae6e9cea09c8e9a2bcd49ab57a5135e31a650e) Updated nongnu
* [`7191389a`](https://github.com/nix-community/emacs-overlay/commit/7191389ae7d376bb466a500f9bfa605320136f86) Updated elpa
* [`dc5b7a16`](https://github.com/nix-community/emacs-overlay/commit/dc5b7a162ee248da61b932f973bbdc4a05a55aba) Updated melpa
* [`6b07e29d`](https://github.com/nix-community/emacs-overlay/commit/6b07e29dee15448341df2fa82e1a2bbb13f23fd4) Updated emacs
* [`43564360`](https://github.com/nix-community/emacs-overlay/commit/43564360e80702e0a012db5e15fb0209d3b50821) Updated nongnu
* [`36ca4fc9`](https://github.com/nix-community/emacs-overlay/commit/36ca4fc9822c1f1a34dbda213710f8582a4dc914) Updated elpa
* [`ceccd74a`](https://github.com/nix-community/emacs-overlay/commit/ceccd74a239b98276eb7bc6e14ca21512b019a0a) Updated emacs
* [`9cce44d3`](https://github.com/nix-community/emacs-overlay/commit/9cce44d3cd446421c1f35498d2659ca11ae041ad) Updated melpa
* [`60fabfd7`](https://github.com/nix-community/emacs-overlay/commit/60fabfd7dfd5cc7351cd088e88eafbe15a7d84bd) Bump actions/checkout from 6.0.2 to 6.0.3
* [`c292b1ae`](https://github.com/nix-community/emacs-overlay/commit/c292b1ae807bff8f8c76071ab6096c2797394bf2) Updated flake inputs
* [`e57000d9`](https://github.com/nix-community/emacs-overlay/commit/e57000d9f9864d642f39c3bdc4ec051f7d31023f) Updated emacs
* [`db22c164`](https://github.com/nix-community/emacs-overlay/commit/db22c1641c439653db978dae7de159fc84fb738f) Updated melpa
* [`64f102cd`](https://github.com/nix-community/emacs-overlay/commit/64f102cd918d845e223f01f4f214a12a9096e1a9) Updated nongnu
* [`6da0420e`](https://github.com/nix-community/emacs-overlay/commit/6da0420e2a78ebff120a4ecd94eabe15e9d91f0a) Updated elpa
* [`c8ae9435`](https://github.com/nix-community/emacs-overlay/commit/c8ae943599b545e2acde372cab4188d21a50b2f7) Updated melpa
* [`b257d78c`](https://github.com/nix-community/emacs-overlay/commit/b257d78c69a6785e76703f4edc18d037b5d2132f) Updated nongnu
* [`f0172d08`](https://github.com/nix-community/emacs-overlay/commit/f0172d0839fc77741b1b8732f08a17753a4cc9d8) Updated elpa
* [`2aba9beb`](https://github.com/nix-community/emacs-overlay/commit/2aba9beb9b36aa281e4677c2bc519f2cca2173c7) Updated melpa
* [`92ce8bce`](https://github.com/nix-community/emacs-overlay/commit/92ce8bce0857519b8d25eaa24a52722d941f3a87) Updated melpa
* [`a7a88ae0`](https://github.com/nix-community/emacs-overlay/commit/a7a88ae076266ef00278ecb6dc175c868d452512) Updated elpa
* [`b9cce2b7`](https://github.com/nix-community/emacs-overlay/commit/b9cce2b7b3ee03b801fd3d7d2bbc0ea55a4a8b72) Updated nongnu
* [`92c08017`](https://github.com/nix-community/emacs-overlay/commit/92c080174ce56968a5e211ef1e1bd6eb21a9b9d8) Updated melpa
* [`6b0bff3f`](https://github.com/nix-community/emacs-overlay/commit/6b0bff3fdc8c04e9c1d8acaf9adbea6e7c5ec9ba) Updated emacs
* [`a8432dc0`](https://github.com/nix-community/emacs-overlay/commit/a8432dc0481d8f21d142807f261cc4cae7727220) Updated nongnu
* [`22377de8`](https://github.com/nix-community/emacs-overlay/commit/22377de815c2cd42aff995851d66d748e7a19ef5) Updated elpa
* [`010336f9`](https://github.com/nix-community/emacs-overlay/commit/010336f93168551e7b86307611f41c99606fc02d) Updated emacs
* [`b18d638b`](https://github.com/nix-community/emacs-overlay/commit/b18d638bb31bd254ab7c34f1c56b9cfd231e6853) Updated melpa
* [`9885466f`](https://github.com/nix-community/emacs-overlay/commit/9885466f56690ae41686ce9ca90a5959b783ba0c) Updated emacs
* [`588ecbea`](https://github.com/nix-community/emacs-overlay/commit/588ecbea13bbeb79e99187e85ddae93a9bc590cd) Updated melpa
* [`f797f631`](https://github.com/nix-community/emacs-overlay/commit/f797f6311ab4efdd22749f0e4fe7fea88c971f8a) Updated nongnu
* [`60242566`](https://github.com/nix-community/emacs-overlay/commit/602425667cd274a4ff0311ad4f045147e92a7b30) Updated elpa
* [`4e86b57f`](https://github.com/nix-community/emacs-overlay/commit/4e86b57f28807556e9454476dcf150b23efd660d) Updated melpa
* [`c2c88acc`](https://github.com/nix-community/emacs-overlay/commit/c2c88acc127dfbc28927089d21c7c967c0be62be) Updated nongnu
* [`580ff3aa`](https://github.com/nix-community/emacs-overlay/commit/580ff3aa89cf682fed0b7b8681e7032b37c580fa) Updated elpa
* [`046347ed`](https://github.com/nix-community/emacs-overlay/commit/046347edfd41448300fc61d0aa44efd6d0426a1f) Updated emacs
* [`c9dbf716`](https://github.com/nix-community/emacs-overlay/commit/c9dbf7166b93432de7edae92113d628ca84e796e) Updated melpa
* [`6cbac845`](https://github.com/nix-community/emacs-overlay/commit/6cbac845556ceffec3d6a13df74b7ee51aa29b37) Updated melpa
* [`d6fed498`](https://github.com/nix-community/emacs-overlay/commit/d6fed498269b411c1aff52332811787d4870a150) Updated flake inputs
* [`c0bb4669`](https://github.com/nix-community/emacs-overlay/commit/c0bb46692f2c9c27ec87189ebb539174a510757a) Updated nongnu
* [`f6405200`](https://github.com/nix-community/emacs-overlay/commit/f64052004a20fb75db64d1cec8c4d9b48984b9eb) Updated elpa
* [`0f89f9af`](https://github.com/nix-community/emacs-overlay/commit/0f89f9afff6c18162fcb78290fa74c6aa19a824b) Updated melpa
* [`c616997b`](https://github.com/nix-community/emacs-overlay/commit/c616997bedac36a7048a5421a7e2c39e035ecbaa) Updated emacs
* [`acc5eb1a`](https://github.com/nix-community/emacs-overlay/commit/acc5eb1a68a3ab92239f902207cecbd08505c2dd) Updated nongnu
* [`fac500b6`](https://github.com/nix-community/emacs-overlay/commit/fac500b62447e36aff69fc34581b99cffde576cf) Updated elpa
* [`29c4aa98`](https://github.com/nix-community/emacs-overlay/commit/29c4aa9830511b504c6e372ef3e63d213962a262) Updated melpa
* [`a077fdfd`](https://github.com/nix-community/emacs-overlay/commit/a077fdfd7255236bd68c74a30437411dfe33ee6c) Updated emacs
* [`a2d93f7a`](https://github.com/nix-community/emacs-overlay/commit/a2d93f7a11593d4a2eb31bc11d7d657d6f875bcb) Updated melpa
* [`c9bc6758`](https://github.com/nix-community/emacs-overlay/commit/c9bc6758f19a2ddb2bb719a6b5c20bf19be9692f) Updated nongnu
* [`c3eee89c`](https://github.com/nix-community/emacs-overlay/commit/c3eee89cab0ce7f50517c5993281180089ae289d) Updated elpa
* [`51ecc521`](https://github.com/nix-community/emacs-overlay/commit/51ecc521a0cc49abed6094a9b16448124394e23e) Updated melpa
* [`3eb5a6b5`](https://github.com/nix-community/emacs-overlay/commit/3eb5a6b5f2f7f9030682d8052028226cfc3a803e) Updated nongnu
* [`84a9b710`](https://github.com/nix-community/emacs-overlay/commit/84a9b7108c0206812e2bb55cd5959a84c8c23973) Updated elpa
* [`f4655857`](https://github.com/nix-community/emacs-overlay/commit/f465585781c8a3b70b799ff5e21f665f6ba53091) Updated melpa
* [`7cd15114`](https://github.com/nix-community/emacs-overlay/commit/7cd15114fbf7b3d118b62686226b0666642bdf23) Updated emacs
* [`d6f892bd`](https://github.com/nix-community/emacs-overlay/commit/d6f892bd9570237c69a3e1c42b465594d54d477a) Updated melpa
* [`9c316c6e`](https://github.com/nix-community/emacs-overlay/commit/9c316c6e2b0c6399c86d9246a9903107ae910073) Updated flake inputs
* [`cc44ec82`](https://github.com/nix-community/emacs-overlay/commit/cc44ec82517025579bf682c81f8fc40835b31579) Updated nongnu
* [`a70e07ed`](https://github.com/nix-community/emacs-overlay/commit/a70e07edec1a02cd03c18adb5c7a5ffc385fde02) Updated elpa
* [`6ee0ccf4`](https://github.com/nix-community/emacs-overlay/commit/6ee0ccf4b1979eb243bf7881b40da5520a150086) Updated emacs
* [`17858086`](https://github.com/nix-community/emacs-overlay/commit/178580864930491ee6382ac79d6d8035fbe75c87) Updated melpa
* [`da5a960c`](https://github.com/nix-community/emacs-overlay/commit/da5a960c12d49229cb4f15f1d01e409faa933ae9) Updated nongnu
* [`c37020fa`](https://github.com/nix-community/emacs-overlay/commit/c37020faea5af04da80f1e97f9d144a864ed6e1f) Updated elpa
* [`73967550`](https://github.com/nix-community/emacs-overlay/commit/7396755065ffd237e26b4404637ed39f250ee415) Updated emacs
* [`07e6b138`](https://github.com/nix-community/emacs-overlay/commit/07e6b1383f0331d64333944274170cd39c9b31b5) Updated melpa
* [`6e0678b1`](https://github.com/nix-community/emacs-overlay/commit/6e0678b1c499f616e71e08e7859959d3864d6a4c) Updated melpa
* [`1eeeca2f`](https://github.com/nix-community/emacs-overlay/commit/1eeeca2f78de3e3627ca05aba41beaed9fd011d4) Updated nongnu
* [`c1c50230`](https://github.com/nix-community/emacs-overlay/commit/c1c502303cd188dc700661adefcc9ec257f434dc) Updated elpa
* [`40f4eb0b`](https://github.com/nix-community/emacs-overlay/commit/40f4eb0b670cda550b545f877289056cd4474c3b) Updated melpa
* [`03b9f27a`](https://github.com/nix-community/emacs-overlay/commit/03b9f27ada8241a6684a55c701e7b23a3dc1ae9d) Updated nongnu
* [`7c56d9c6`](https://github.com/nix-community/emacs-overlay/commit/7c56d9c6b77f9eb769a44251dd914c8529ccee6e) Updated elpa
* [`730b1c14`](https://github.com/nix-community/emacs-overlay/commit/730b1c14cd09d50a06f6254cb156a616b81e7af9) Updated emacs
* [`4e006e97`](https://github.com/nix-community/emacs-overlay/commit/4e006e9741eff4cb4b02545c904a4ff3e9897b1e) Updated melpa
* [`9a85bd27`](https://github.com/nix-community/emacs-overlay/commit/9a85bd27f18363085f94e44b770c3f1df2450d72) Updated melpa
* [`7278d2a6`](https://github.com/nix-community/emacs-overlay/commit/7278d2a62434b73874b5e345090b02469ed2ffd2) Updated nongnu
* [`28f979c6`](https://github.com/nix-community/emacs-overlay/commit/28f979c6938fb6d35f3c87acae0a206fb321af35) Updated melpa
* [`c5d35592`](https://github.com/nix-community/emacs-overlay/commit/c5d3559293fb0dfa0bafc916127c005d8a11a7d3) Updated nongnu
* [`67bfde84`](https://github.com/nix-community/emacs-overlay/commit/67bfde8414e70df865287e8c755471fdbebfe9c4) Updated elpa
* [`d656a41e`](https://github.com/nix-community/emacs-overlay/commit/d656a41e54f872fa87b798ba66011f7c02d2037f) Updated emacs
* [`174540c6`](https://github.com/nix-community/emacs-overlay/commit/174540c6860fc4d16dd6019327958326e47a236f) Updated melpa
* [`77a66f31`](https://github.com/nix-community/emacs-overlay/commit/77a66f31af6fad2763de6813c004f18c9c91376b) Updated melpa
* [`a86addac`](https://github.com/nix-community/emacs-overlay/commit/a86addac63ea125a933a639f6ac91dad12deffc2) Updated flake inputs
* [`85670ebc`](https://github.com/nix-community/emacs-overlay/commit/85670ebc4f078c7a1e7415d8efdf2a76f39b9a82) Updated nongnu
* [`a80164b0`](https://github.com/nix-community/emacs-overlay/commit/a80164b06c20aec76291bf71aedde9840775b5bb) Updated elpa
* [`eb0ef840`](https://github.com/nix-community/emacs-overlay/commit/eb0ef8409e0580e03ca51566c4ed985055d3cf8a) Updated melpa
* [`ff597e53`](https://github.com/nix-community/emacs-overlay/commit/ff597e53914a447470f61938192ce79465d6a812) Updated emacs
* [`6374534a`](https://github.com/nix-community/emacs-overlay/commit/6374534a0a0789bad0cf89aca35c9a7664b1bef8) Updated nongnu
* [`e2df5b36`](https://github.com/nix-community/emacs-overlay/commit/e2df5b369175e708da5f7cc9ff44c5ea1f759031) Updated elpa
* [`68ce9d74`](https://github.com/nix-community/emacs-overlay/commit/68ce9d74e5bb2e5ff70c1dde499c12635635b47b) Updated melpa
* [`35f6f217`](https://github.com/nix-community/emacs-overlay/commit/35f6f217038b2a42970c2932e3e1a7248868423e) Updated emacs
* [`534d77d0`](https://github.com/nix-community/emacs-overlay/commit/534d77d08521153c497432dd48e848e6f88a20f2) Updated melpa
* [`0e4e320d`](https://github.com/nix-community/emacs-overlay/commit/0e4e320deec828fa8a6c0bcb9949a6d598cf0967) Updated nongnu
* [`642a4c80`](https://github.com/nix-community/emacs-overlay/commit/642a4c8015e9702a89a35c3b15681d1417523d95) Updated elpa
* [`cb3beb2e`](https://github.com/nix-community/emacs-overlay/commit/cb3beb2e3882334176dbb38b9f38944d49f46099) Updated melpa
* [`5816b86d`](https://github.com/nix-community/emacs-overlay/commit/5816b86d2439352f20d1be6365f05671dde7c974) Updated nongnu
* [`a918a779`](https://github.com/nix-community/emacs-overlay/commit/a918a7799671ae9001ef0157e1926dc30a84402b) Updated elpa
* [`2a564fc3`](https://github.com/nix-community/emacs-overlay/commit/2a564fc31d2f77b26f1a180589599afe756f74a6) Updated melpa
* [`1f3e9a7b`](https://github.com/nix-community/emacs-overlay/commit/1f3e9a7ba27be1617caa577bd206b0d91477591e) Updated emacs
* [`6b6fef15`](https://github.com/nix-community/emacs-overlay/commit/6b6fef1565727983e1626009929c37204147abd5) Updated melpa
* [`4e61ca81`](https://github.com/nix-community/emacs-overlay/commit/4e61ca81de2d1f33f859236dbbfb968d8ba62fe9) Updated nongnu
* [`20944cec`](https://github.com/nix-community/emacs-overlay/commit/20944cecf034e31bf167dd253c7dc1a927fd8750) Updated elpa
* [`6392c804`](https://github.com/nix-community/emacs-overlay/commit/6392c804c62167b2007d5c2f4522993ea9354a4c) Updated melpa
* [`6224dba1`](https://github.com/nix-community/emacs-overlay/commit/6224dba12489d00fa93031a1516be6c85b70d65f) Updated nongnu
* [`9acccdc9`](https://github.com/nix-community/emacs-overlay/commit/9acccdc94e6237e4d938616a7c100a20165a8345) Updated elpa
* [`7c3f1b39`](https://github.com/nix-community/emacs-overlay/commit/7c3f1b39e964716644c7e2ffd6878a60dc3ac1d3) Updated melpa
* [`c587fe2a`](https://github.com/nix-community/emacs-overlay/commit/c587fe2a8caa505d636a6ecf3ec99ab3ecc06beb) Updated emacs
* [`2b678fe6`](https://github.com/nix-community/emacs-overlay/commit/2b678fe66be40034629fb9460ed2519f43d1a57f) Updated melpa
* [`1ae9875b`](https://github.com/nix-community/emacs-overlay/commit/1ae9875b9a20bc4e77d58b9cc111e9e8de155ffa) Updated nongnu
* [`cf7e7ca2`](https://github.com/nix-community/emacs-overlay/commit/cf7e7ca2aca6e0bd352c65a9042e0af11733ec75) Updated elpa
* [`ccf1a389`](https://github.com/nix-community/emacs-overlay/commit/ccf1a389b9c6a3f162788d0c53c1eae13f112592) Updated melpa
* [`e3a47929`](https://github.com/nix-community/emacs-overlay/commit/e3a47929b245f8bb497edbf6ab6f9f7e6257afe1) Updated nongnu
* [`4d4f5b48`](https://github.com/nix-community/emacs-overlay/commit/4d4f5b48da584aad4155952cfc9567f60c11f656) Updated elpa
* [`3935a333`](https://github.com/nix-community/emacs-overlay/commit/3935a333953221c83b71438b909a4e359ecc0c0d) Updated emacs
* [`cce65e99`](https://github.com/nix-community/emacs-overlay/commit/cce65e997eb8e09cf47847d289b598ee90773739) Updated melpa
* [`0e45912e`](https://github.com/nix-community/emacs-overlay/commit/0e45912e3f09ce018178b6648014a6c3f9e02458) Updated emacs
* [`0b640555`](https://github.com/nix-community/emacs-overlay/commit/0b640555c21a4be40b088502f438a90fec20e05e) Updated melpa
* [`9cd6d6ab`](https://github.com/nix-community/emacs-overlay/commit/9cd6d6ab138512cc026d637c6454284f5ffc0b98) Updated nongnu
* [`7edb4db9`](https://github.com/nix-community/emacs-overlay/commit/7edb4db9da401f1676477ddef5acb9e2fbea5bd2) Updated elpa
* [`ada5a893`](https://github.com/nix-community/emacs-overlay/commit/ada5a89385ca183989c37e6030b4435f3de80b25) Updated melpa
* [`6c5500e9`](https://github.com/nix-community/emacs-overlay/commit/6c5500e93767251ce3cd7c8b307ac882ad5e0d52) Updated nongnu
* [`1fbd6e89`](https://github.com/nix-community/emacs-overlay/commit/1fbd6e8995a5edc0e41b2147ee515b53e98532e5) Updated elpa
* [`fee960f0`](https://github.com/nix-community/emacs-overlay/commit/fee960f0f42d444773d55c495f53fd9214322893) Updated melpa
* [`e5f5b783`](https://github.com/nix-community/emacs-overlay/commit/e5f5b783c4557c67e9af58d704ab3619d4c7469e) Updated emacs
* [`38446b80`](https://github.com/nix-community/emacs-overlay/commit/38446b80c54c8149b3df1d57ae4df6fcb05d1d1f) Updated melpa
* [`c38d5ed5`](https://github.com/nix-community/emacs-overlay/commit/c38d5ed534b8c1fb86abeb6a068b550b1ce3ccbf) Bump actions/checkout from 6.0.3 to 7.0.0
* [`53c34041`](https://github.com/nix-community/emacs-overlay/commit/53c340417f1ce9af2bad29c3ce0c6cb24abab476) Updated nongnu
* [`70c45947`](https://github.com/nix-community/emacs-overlay/commit/70c459479b92fa26aefc5ef6718d28f82f574b6f) Updated elpa
* [`1df5f5e6`](https://github.com/nix-community/emacs-overlay/commit/1df5f5e631c25a3af9935e8979ae8888b12dd39e) Updated emacs
* [`60912b91`](https://github.com/nix-community/emacs-overlay/commit/60912b9120486acb3eb3823bf811d6676e4b9a8c) Updated melpa
* [`cb316f95`](https://github.com/nix-community/emacs-overlay/commit/cb316f958e710689d7d9eb6a2e3db8a3adb8e1da) Updated flake inputs
* [`c291647b`](https://github.com/nix-community/emacs-overlay/commit/c291647b5019e37c5d76c13f2956e4824b03cfc4) Updated nongnu
* [`0aabf2cb`](https://github.com/nix-community/emacs-overlay/commit/0aabf2cb457b222dc348c3e6c5b691711ddce4b9) Updated elpa
* [`a0df5d4a`](https://github.com/nix-community/emacs-overlay/commit/a0df5d4ac5e97009cd9916eb7df54b8c5a9aab31) Updated emacs
* [`a75ed1b5`](https://github.com/nix-community/emacs-overlay/commit/a75ed1b52ce01aa12107d2ceee7e5a92dc06d8e0) Updated melpa
* [`56473314`](https://github.com/nix-community/emacs-overlay/commit/5647331411a8fcb187750efcde9ce66857d4c89f) Updated emacs
* [`98c79811`](https://github.com/nix-community/emacs-overlay/commit/98c79811f03c4303ac44cb0f05639cb1f190b608) Updated melpa
* [`f43cf678`](https://github.com/nix-community/emacs-overlay/commit/f43cf67882ce91f121e252d32455bd2146608b5b) Updated nongnu
* [`aaa2af16`](https://github.com/nix-community/emacs-overlay/commit/aaa2af1654561552bf20d00f7bbd48b750436bd1) Updated elpa
* [`03e2ad42`](https://github.com/nix-community/emacs-overlay/commit/03e2ad42a7c577492e1a2ae53f5cc0cf545782f5) Updated melpa
* [`c5cffe3a`](https://github.com/nix-community/emacs-overlay/commit/c5cffe3a1720b96bbff1bc73f8fad5a15dee2a14) Updated flake inputs
* [`a76edb51`](https://github.com/nix-community/emacs-overlay/commit/a76edb511a8cf3ff4b5480a2f7a0042e5e821810) Updated nongnu
* [`7e398ee3`](https://github.com/nix-community/emacs-overlay/commit/7e398ee3e2a9f6faf01aaaba496cc461559f58cf) Updated elpa
* [`30cf2da9`](https://github.com/nix-community/emacs-overlay/commit/30cf2da9069ab10ad52bf4ef2cbdc39d7de2cd91) Updated emacs
* [`ab63a704`](https://github.com/nix-community/emacs-overlay/commit/ab63a70479f1a6a413d4019d30f61f57b8e3c93d) Updated melpa
* [`e6a5046f`](https://github.com/nix-community/emacs-overlay/commit/e6a5046f8912da3298289fd4a5c6b7a1746e721d) Updated melpa
* [`65a62ae2`](https://github.com/nix-community/emacs-overlay/commit/65a62ae2d69330d994000c08157a36418dbc9294) Updated nongnu
* [`b86ff410`](https://github.com/nix-community/emacs-overlay/commit/b86ff410d1997c41caf1deb79066ed52b7d5603f) Updated elpa
* [`7823d160`](https://github.com/nix-community/emacs-overlay/commit/7823d160c64dd2e8a31987107a27157541d06934) Updated emacs
* [`6f3e9c97`](https://github.com/nix-community/emacs-overlay/commit/6f3e9c97bbd8d3c926742d1dfb30edefed562444) Updated melpa
* [`fe8f5b8d`](https://github.com/nix-community/emacs-overlay/commit/fe8f5b8d61ca21403a1de8f21d6542aae0fbe7cf) Updated nongnu
* [`86b537fc`](https://github.com/nix-community/emacs-overlay/commit/86b537fc83b83907290438d4e6d5f7b96a32d44a) Updated elpa
* [`7fb675bb`](https://github.com/nix-community/emacs-overlay/commit/7fb675bb8e7f433fec4640b518944ae8bf9c6384) Updated emacs
* [`05d06425`](https://github.com/nix-community/emacs-overlay/commit/05d06425c4e17fdf1cbc5cdbf744e5d635993245) Updated melpa
* [`dcb3dc01`](https://github.com/nix-community/emacs-overlay/commit/dcb3dc018fe121a94dbd9519bac4af32790de379) Updated emacs
* [`fcfa8883`](https://github.com/nix-community/emacs-overlay/commit/fcfa8883e001877fc0d4592244596f9e76f83b95) Updated melpa
* [`f1900300`](https://github.com/nix-community/emacs-overlay/commit/f1900300c2d972ad5bf15728d1639c6f55f15dd6) Updated nongnu
* [`24c0e039`](https://github.com/nix-community/emacs-overlay/commit/24c0e0397e20bbb4d7a7927dd482bb11e5cab311) Updated elpa
* [`7d92e905`](https://github.com/nix-community/emacs-overlay/commit/7d92e9053a312e303b53369b2271f00e856a60bd) Updated melpa
* [`bb8778a8`](https://github.com/nix-community/emacs-overlay/commit/bb8778a8e94df0e26cae5959083913005d56b20b) Updated flake inputs
* [`03f87693`](https://github.com/nix-community/emacs-overlay/commit/03f87693f9731c870ffcbe4b18c291ecad019003) Updated nongnu
* [`7987cfb2`](https://github.com/nix-community/emacs-overlay/commit/7987cfb2b98d6d0c690b26a0779366c8dd1fda19) Updated elpa
* [`b1033755`](https://github.com/nix-community/emacs-overlay/commit/b10337552c4d311c0a53cdcc788f13c5cd734c56) Updated emacs
* [`9b216323`](https://github.com/nix-community/emacs-overlay/commit/9b216323cc5203e782f4909b0e1901d71dac4d81) Updated melpa
* [`4d6b177c`](https://github.com/nix-community/emacs-overlay/commit/4d6b177ce77e8513f6209d6b4e806a60edda2dd9) Updated emacs
* [`d0a6c1c5`](https://github.com/nix-community/emacs-overlay/commit/d0a6c1c5a80bd2c33cce663c6a85e71c694b8e2d) Updated melpa
* [`fc6a0d9d`](https://github.com/nix-community/emacs-overlay/commit/fc6a0d9d4e5372b52520cc57d9f5f2a9a7d37392) Updated nongnu
* [`e2fd27be`](https://github.com/nix-community/emacs-overlay/commit/e2fd27be9f3625bb38deababa8ae8e4d824a82a7) Updated elpa
* [`fcd413f4`](https://github.com/nix-community/emacs-overlay/commit/fcd413f427db43f6e33c1248949dedcdeeda38a2) Updated melpa
* [`eba751ad`](https://github.com/nix-community/emacs-overlay/commit/eba751adc4573a5f65187409a61663ee87ea21c0) Updated nongnu
* [`f77c1620`](https://github.com/nix-community/emacs-overlay/commit/f77c162095bd492be9ae4016174cc1bffb2081fd) Updated elpa
* [`99ab614e`](https://github.com/nix-community/emacs-overlay/commit/99ab614eda3e6faabcc00399dc7ae3e75dbdd2b9) Updated emacs
* [`2bf35364`](https://github.com/nix-community/emacs-overlay/commit/2bf353646c1b711c445a7888f15520158b8ab7a4) Updated melpa
* [`bbf3b018`](https://github.com/nix-community/emacs-overlay/commit/bbf3b018ecf3462389aa50d597dc05f4f1b7850d) Updated flake inputs
* [`53917740`](https://github.com/nix-community/emacs-overlay/commit/539177406a9630098b479b739f278fa7aaea1737) Updated melpa
* [`3dfa5707`](https://github.com/nix-community/emacs-overlay/commit/3dfa5707734d6cb06d459a0963628c9ecb6efd53) Updated emacs
* [`a028d650`](https://github.com/nix-community/emacs-overlay/commit/a028d6507be219f46338f495d4ebcffe37171fec) Updated flake inputs
* [`6aff15a1`](https://github.com/nix-community/emacs-overlay/commit/6aff15a1fdbbb58439678ba1a52dd6d086167516) Updated nongnu
* [`36fa9aab`](https://github.com/nix-community/emacs-overlay/commit/36fa9aabdf5740786265e390dc2e8153b543bcfd) Updated elpa
* [`1e417334`](https://github.com/nix-community/emacs-overlay/commit/1e417334dd66ea4b6862bb023424cb1a227b4af8) Updated melpa
* [`0ce5a1d8`](https://github.com/nix-community/emacs-overlay/commit/0ce5a1d854965187138a9e46ea5230f86a325e9a) Updated elpa
* [`e9e3f15a`](https://github.com/nix-community/emacs-overlay/commit/e9e3f15a040d6a005e92455d2b44b27366b91ef2) Updated nongnu
* [`a0927d37`](https://github.com/nix-community/emacs-overlay/commit/a0927d37392a4a7361e67e28d0abac9670457536) Updated emacs
* [`9f9cc155`](https://github.com/nix-community/emacs-overlay/commit/9f9cc155c00a8cfd5680dabf408816eaad4851d7) Updated melpa
* [`2f50d949`](https://github.com/nix-community/emacs-overlay/commit/2f50d94932a7544de87c7a39186cc384fd8a2a7b) Updated emacs
* [`b087e228`](https://github.com/nix-community/emacs-overlay/commit/b087e22860a758babad4c03607389d76f9847100) Updated melpa
* [`779de3d0`](https://github.com/nix-community/emacs-overlay/commit/779de3d0bda5323f6942b6f2306aa2b45cac6f7f) Updated nongnu
* [`c936dded`](https://github.com/nix-community/emacs-overlay/commit/c936dded092a34f55a773edc088487c334557de5) Updated elpa
* [`42a2510b`](https://github.com/nix-community/emacs-overlay/commit/42a2510bebcf05f3573be5ddc32ce4d4a5cd9947) Updated melpa
* [`c8695fd2`](https://github.com/nix-community/emacs-overlay/commit/c8695fd2805ff07d5d8710477f53b57ecee491d6) Updated nongnu
* [`33b60e23`](https://github.com/nix-community/emacs-overlay/commit/33b60e23e6d8ded7e7c5276f2b40a03b389ce298) Updated elpa
* [`fa211877`](https://github.com/nix-community/emacs-overlay/commit/fa2118770f8066ea7d8cb2e2d7b6158f91f6d613) Updated melpa
* [`1415cbf0`](https://github.com/nix-community/emacs-overlay/commit/1415cbf05d3986a6c8c68817fb17dd89843a287b) Updated flake inputs
* [`66a245bb`](https://github.com/nix-community/emacs-overlay/commit/66a245bb3af63d38971270739cec941c4020d573) Updated melpa
* [`ff30c446`](https://github.com/nix-community/emacs-overlay/commit/ff30c446ab5ab2e06feab4e3d510f2448f12cefb) Updated nongnu
* [`1083f336`](https://github.com/nix-community/emacs-overlay/commit/1083f33656abfd1686390f045ed6a73fe5a5f386) Updated elpa
* [`5fa77aba`](https://github.com/nix-community/emacs-overlay/commit/5fa77aba1e46ff11df0b9986d0c9bbb9e9332d2e) Updated melpa
* [`8ada9f7e`](https://github.com/nix-community/emacs-overlay/commit/8ada9f7e13f9200259ec00412553de1a9ff4d410) Updated nongnu
* [`d320b50c`](https://github.com/nix-community/emacs-overlay/commit/d320b50cd9c67b20838bac0b6343201814c3d702) Updated elpa
* [`65b43d8f`](https://github.com/nix-community/emacs-overlay/commit/65b43d8f64b8e14ff055ceb315780d419b10be3b) Updated emacs
* [`6fd613e1`](https://github.com/nix-community/emacs-overlay/commit/6fd613e122e2d74b516203d24518f083df423c83) Updated melpa
* [`ee4d174f`](https://github.com/nix-community/emacs-overlay/commit/ee4d174f747fec210bc9cac44a10666a693e9e3d) Updated emacs
* [`9d7cd44c`](https://github.com/nix-community/emacs-overlay/commit/9d7cd44cee7b104f3e683f9a5695896829ee7245) Updated melpa
* [`12074575`](https://github.com/nix-community/emacs-overlay/commit/120745752388e00bc750bad7b7447f360f45d200) Updated nongnu
* [`e2cde9a6`](https://github.com/nix-community/emacs-overlay/commit/e2cde9a6d9e3e12d3ff2dab806b741476547ffdb) Updated elpa
* [`be08305e`](https://github.com/nix-community/emacs-overlay/commit/be08305e372d57a1733795945c18e15c37801364) Updated melpa
* [`6f5597ac`](https://github.com/nix-community/emacs-overlay/commit/6f5597acfb86db588a4a62b44a904c99f1f67b58) Updated flake inputs
* [`3321ed64`](https://github.com/nix-community/emacs-overlay/commit/3321ed640b96e1af041a236f84b017f9118118a0) Updated elpa
* [`90000a8c`](https://github.com/nix-community/emacs-overlay/commit/90000a8c7cf9fa5149c007725e56b3357e97a0bf) Updated nongnu
* [`b4cc9132`](https://github.com/nix-community/emacs-overlay/commit/b4cc9132f8ded6135bba1950eb8a554054fe7f6e) Updated melpa
* [`eb5f589e`](https://github.com/nix-community/emacs-overlay/commit/eb5f589e803e64484f82a428c600be8f4df9f042) Updated melpa
* [`049348f7`](https://github.com/nix-community/emacs-overlay/commit/049348f7a64744506ea5dfb6c939d780de5214c8) Updated emacs
