### PR TITLE
npins doomemacs: update 6be3337b -> aac84622

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -22,9 +22,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "6be3337b49867bd86f90fe5ca4beeb6b38afaddb",
-      "url": "https://github.com/doomemacs/doomemacs/archive/6be3337b49867bd86f90fe5ca4beeb6b38afaddb.tar.gz",
-      "hash": "sha256-7ErKUgw6Ch7hP1oBjMSos8xXRD+rxxjaOldRn+TcClo="
+      "revision": "aac84622b8bbe615832d3c49f8fe42fbda6841d3",
+      "url": "https://github.com/doomemacs/doomemacs/archive/aac84622b8bbe615832d3c49f8fe42fbda6841d3.tar.gz",
+      "hash": "sha256-DKLoxL7R54eQfrA2HRHKJYzNfoEkKlmHGIP37yJiUD4="
     },
     "emacs-overlay": {
       "type": "Git",


### PR DESCRIPTION
## Changelog for doomemacs:
Branch: master
Commits: [doomemacs/doomemacs@6be3337b...aac84622](https://github.com/doomemacs/doomemacs/compare/6be3337b49867bd86f90fe5ca4beeb6b38afaddb...aac84622b8bbe615832d3c49f8fe42fbda6841d3)

* [`d42c5b9e`](https://github.com/doomemacs/core/commit/d42c5b9ecb11f18af5c321ac40d816c1687bf2e8) fix(snippets): suppress prompts in completion/doc popups
* [`5a7e6caf`](https://github.com/doomemacs/core/commit/5a7e6caf491f1caa1a94a3008f92ae82cad0c0ee) perf: ffap-machine-p-known = accept
* [`aa670797`](https://github.com/doomemacs/core/commit/aa670797bbe39ff513c99e9ac3f641e34767856b) tweak(org): org-cycle-emulate-tab = nil for evil users
* [`4e0dbb9d`](https://github.com/doomemacs/core/commit/4e0dbb9dc5a3986303295cd7ce5e9faf113c4a57) release(modules): 26.06.0-dev
* [`0cd3812c`](https://github.com/doomemacs/core/commit/0cd3812cfd8a85ed774ed61c066947399627fcb2) bump: :doom
* [`fcf9f9f3`](https://github.com/doomemacs/core/commit/fcf9f9f3e57b021a38040c1dda8803ded06f860e) bump: :tools
* [`575975c6`](https://github.com/doomemacs/core/commit/575975c6a62339abdef30532052947b40eb7856b) bump: :ui
* [`bd143318`](https://github.com/doomemacs/core/commit/bd143318e6db3cdf5a87b05bae37ec86af8816a8) bump: :term :os :input :config :app
* [`db26d6f5`](https://github.com/doomemacs/core/commit/db26d6f57da934b5b4e3c0c668f5fbd1902a0d4e) bump: :checkers
* [`5eaf1215`](https://github.com/doomemacs/core/commit/5eaf12158a16efee969b40438ead5bc83e1c429f) bump: :completion
* [`2cfa2ff0`](https://github.com/doomemacs/core/commit/2cfa2ff00bba403979e5cbd52702cb901d9b6dbf) bump: :editor
* [`9fbae872`](https://github.com/doomemacs/core/commit/9fbae872c57e044e3aff1614d88b603d69b9c791) refactor!: modules: drop Emacs 28 support
* [`2b482746`](https://github.com/doomemacs/core/commit/2b482746af95fcdda6bf9e6440f72d7965e8ac88) refactor(org): remove org-modern-hide-stars fix
* [`ee7e6d60`](https://github.com/doomemacs/core/commit/ee7e6d60b1c2ba4b7dff955f6647a09c94e58e6d) fix(format): properly forward from lsp to chained formatters
* [`0ffacdea`](https://github.com/doomemacs/core/commit/0ffacdeab498342b4f427d6ba2db15c34836ca97) bump: :lang
* [`d0602da8`](https://github.com/doomemacs/core/commit/d0602da8237d869a8f53ac7c223a8253c254bad4) fix(emms): match emms' :files from upstream recipe
* [`712db1e7`](https://github.com/doomemacs/core/commit/712db1e7a76194a773dfb0e8330c179a533d039b) fix: arity error on projectile-get-ext-command
* [`bead7a77`](https://github.com/doomemacs/core/commit/bead7a77483d4b11404f408c4b218f6dc7c220ee) refactor!: backport mode-line-invisible-mode & drop hide-mode-line
* [`d73d9555`](https://github.com/doomemacs/core/commit/d73d9555b6a21142aa5c74c128dc3a8535a9d47c) tweak(tty): enable xterm-mouse-mode conditionally
* [`720ea30b`](https://github.com/doomemacs/core/commit/720ea30ba6b54fff728630cc73a66c766838fc8e) tweak: native-comp-async-on-battery-power = nil
* [`2d24c07c`](https://github.com/doomemacs/core/commit/2d24c07cdd55e3e046cf5f7d3aec089c63bdfbfd) feat(syntax): use upstream flymake
* [`469693e8`](https://github.com/doomemacs/core/commit/469693e8ebb053badc43015215c75017b8d59ce2) refactor(dashboard): hide cursor in evil correctly
* [`0efa0365`](https://github.com/doomemacs/core/commit/0efa03654c16a59d8f3ba69a07543bb8c4851b05) fix: factor out buffer-local-* API from mode-line-invisible backport
* [`9c686033`](https://github.com/doomemacs/core/commit/9c68603315294073079d632eb4764fa2b81b1527) fix(evil): evil-collection-repl-submit-state = insert
* [`a174a692`](https://github.com/doomemacs/core/commit/a174a69259e082bcc743d472377a9a2035c79537) fix(evil): evil-collection: ensure defaults are eval'ed early
* [`07530448`](https://github.com/doomemacs/core/commit/075304486d134cdbe2498d62003d334353c8a3f5) tweak: add $EMACSDIR/$DOOMDIR to trusted-content
* [`76d69c2f`](https://github.com/doomemacs/core/commit/76d69c2f5ab03d649b100206a600ec2dde76e03b) refactor: move doom project config to doom-start
* [`54120719`](https://github.com/doomemacs/core/commit/541207196fd1ec71bc81393f57ca91263c23b682) fix(evil): evil-numbers: void-function incf error
* [`b52818be`](https://github.com/doomemacs/core/commit/b52818be56638f42ceed86a9209b1bfeb7034032) refactor: modules: drop Emacs 28 support (part 2)
* [`a5a6c409`](https://github.com/doomemacs/core/commit/a5a6c409fe51a194ff9d917aea902c28b1366c16) bump: polymode
* [`dfd506bb`](https://github.com/doomemacs/core/commit/dfd506bbba268d1f6cc684c92e3e1f0f735309dd) fix(ligatures): doctor.el: comment header & lexical-binding
* [`195a978b`](https://github.com/doomemacs/core/commit/195a978ba8aacdfaa9c0d58903f6eac1b06097ec) fix: avoid `file-name-concat` in early-init
* [`ff439b1f`](https://github.com/doomemacs/core/commit/ff439b1f43dd62a5a61cc2656af16da2a6cdb6b0) fix(evil): don't byte-compile evil-numbers for now
* [`f22dcc6b`](https://github.com/doomemacs/core/commit/f22dcc6b03c9a255855816397a7250c2e647c0c4) perf(lib): doom-quit-p: optimize real-buffer check
* [`410a9bf3`](https://github.com/doomemacs/core/commit/410a9bf397c4b3577628b808e89eca3d83d07b10) fix(racket): void-variable flycheck-disabled-checkers error
* [`a4697ebc`](https://github.com/doomemacs/core/commit/a4697ebc3c799e518653efbd831f8c5616228758) fix(eval): keybinds to replaced command +eval/send-region-to-repl
* [`a02f985e`](https://github.com/doomemacs/core/commit/a02f985ea6161401dbced055c901682dc59b0d7b) fix(dashboard): uncentered first line on small displays
* [`b04599f3`](https://github.com/doomemacs/core/commit/b04599f3746fbe5aa8fba572130a0257f3ecc8a6) tweak(dashboard): reduce banner's bottom padding by 1
* [`90bc8d5f`](https://github.com/doomemacs/core/commit/90bc8d5fd04172721c3eb2da3775e742373e44ad) fix(vertico): s/seperator/separator/
* [`90925eaa`](https://github.com/doomemacs/core/commit/90925eaa770c19286c467222215eb64a8f223388) fix(eww): s/ewe-mode/eww-mode/
* [`de250ad3`](https://github.com/doomemacs/core/commit/de250ad3c20039af454640ad5af43f58861414f1) fix(syntax): disable org-lint for now
* [`cec45658`](https://github.com/doomemacs/core/commit/cec45658f6ad6fd655e4a748428684171171730f) fix(emacs-lisp,racket,eshell): void-function highlight-quoted-mode error
* [`179e5fb3`](https://github.com/doomemacs/core/commit/179e5fb320279580bf596b2a69cc3b091bbc607f) fix(snippets): copy-and-edit workflow
* [`a543cb70`](https://github.com/doomemacs/core/commit/a543cb7083a705aef1b4efae0fb9b9fbd9313260) fix(emacs-lisp): void-variable all-buffers error
* [`c9f702d7`](https://github.com/doomemacs/core/commit/c9f702d79d4c0201c56285141312ba9fe3eade8a) bump: dirvish
* [`58321be5`](https://github.com/doomemacs/core/commit/58321be5e203f78590f4b3600a215fd104960664) bump: :tools
* [`8a3f52ba`](https://github.com/doomemacs/core/commit/8a3f52ba7a9168bfb08c085e3957b95ec117c95d) bump: :ui
* [`cc6c98c9`](https://github.com/doomemacs/core/commit/cc6c98c94ed3bb54fd0bcc596b4cd583af591b0e) bump: :term :email :app
* [`916a5560`](https://github.com/doomemacs/core/commit/916a5560d9c02bb7b5aaf4534fbb6542c8acaf52) bump: :editor evil
* [`cba1eaee`](https://github.com/doomemacs/core/commit/cba1eaee07a1285739bb518f71b5d9ad4c4f5c28) refactor(lib): use display-line-numbers-mode
* [`e53b9dfe`](https://github.com/doomemacs/core/commit/e53b9dfecea20f26e654902b272453359b938a36) fix(word-wrap): accommodate line numbers
* [`c2ff579a`](https://github.com/doomemacs/core/commit/c2ff579a28ecfec90c343417bc04b2a9569d9ed7) fix(java): use settings.gradle as project root marker
* [`96a0c77c`](https://github.com/doomemacs/core/commit/96a0c77ce13be49d057ac29b89f4028d89e91b19) fix(org): defining as dynamic an already lexical var error
* [`8beae081`](https://github.com/doomemacs/core/commit/8beae0811981a7fd0a1ff9c42e223d0ec440597b) fix(markdown): markdown-ts-mode: expand tree-sitter support
* [`a881e191`](https://github.com/doomemacs/core/commit/a881e19100228cbb7dae21fc4e319687383aca5a) feat(markdown): add +lsp support
* [`a3794156`](https://github.com/doomemacs/core/commit/a3794156acddeb30d72e48e599a22f5715380052) refactor(markdown): general reformat and revise
* [`22170383`](https://github.com/doomemacs/core/commit/221703836fe3e70ca790e8efb1705f3e007bfcb5) fix(cli): doom: handle spaces in $HOME
* [`6430a673`](https://github.com/doomemacs/core/commit/6430a673f2e1b90a0118318abc717391e22f6c8d) fix: hl-line-mode not activating on Emacs <=29
* [`beddd81a`](https://github.com/doomemacs/core/commit/beddd81aa353037ec0e810c1b43ec47b2028b7b2) fix(vc-gutter): reset face bg colors after loading a theme
* [`d6281808`](https://github.com/doomemacs/core/commit/d6281808e082404f142e461a9fe653f1bb7ab152) fix(tree-sitter): Pin LaTeX grammar to make it build
* [`589630b1`](https://github.com/doomemacs/core/commit/589630b1ed2d2e09de946ea4aab284804f27185b) fix(tree-sitter): Rename verilog to systemverilog
* [`f95b8c9e`](https://github.com/doomemacs/core/commit/f95b8c9e5e5cb67139ee17280d12255d4c503e1c) fix(markdown): s/markddown/markdown
* [`b02cc296`](https://github.com/doomemacs/core/commit/b02cc296e1cb2deff4723016e89d4a35405f37d6) fix: doom-rcfile-read: don't return version string
* [`07de65e2`](https://github.com/doomemacs/core/commit/07de65e25abe8526c4c6e1eb24588c096e4a5497) fix(lib): read .doomprofile into profile loader
* [`b49761f2`](https://github.com/doomemacs/core/commit/b49761f2610e102af9364cf776f1b748ce6afec3) fix(common-lisp): suppress completion candidates on no matches
* [`61e0b248`](https://github.com/doomemacs/core/commit/61e0b2486a5b647ed690a682477d4a8cbf7322cc) fix(org): org-re-reveal: avoid use-package :after keyword
* [`b3a11982`](https://github.com/doomemacs/core/commit/b3a119823faced6c5768bb9d749dd57d300cacb5) nit: document why use-package's :after is avoided
* [`1cd1145b`](https://github.com/doomemacs/core/commit/1cd1145bf3a9434598bacd2cce4fc5c67357ad36) fix(evil,default): use :r[ead] for 'SPC i p'
* [`fefc4a1b`](https://github.com/doomemacs/core/commit/fefc4a1b527c403d81ae14404a1779ef649959c4) fix(evil): unimpaired encode/decode operators
* [`60df78d2`](https://github.com/doomemacs/core/commit/60df78d22697f5a5315ddebaeb954bb493876725) fix(default): +default/search-buffer: use elisp regexp
* [`7161a938`](https://github.com/doomemacs/core/commit/7161a9387cb5e2e734d48ccf54dfd01f691e2210) fix(cli): sync profiles after Emacs version line
* [`72da7b21`](https://github.com/doomemacs/core/commit/72da7b21b7b58b363652cdadea1132eaa10d657c) tweak(cli): always sync profiles
* [`1b27fda6`](https://github.com/doomemacs/core/commit/1b27fda69020ac2a4cb5111ada875c53b82dcce2) fix(layout): CLRF line endings in +azerty.el
* [`9cfed8f1`](https://github.com/doomemacs/core/commit/9cfed8f129430c15d3d3c66974b81b2636761cd3) refactor(layout): +azerty: simplify
* [`b2bea09e`](https://github.com/doomemacs/core/commit/b2bea09e16ae4d9a44a19ceb7d6b0aa8088c76b0) tweak(default): remove C-v yank keybind
* [`3a69827e`](https://github.com/doomemacs/core/commit/3a69827e408c3391c6b1b568aea8f83f10ec0e00) tweak: recentf: auto cleanup & save in daemon sessions
* [`dbeab878`](https://github.com/doomemacs/core/commit/dbeab878589364bad852aaff667086b970a30820) bump: :emacs dired
* [`d255ae9f`](https://github.com/doomemacs/core/commit/d255ae9f72581bf674abadfc47cb794b3cc3ffd2) fix(vertico): +vertico-orderless-disamiguation-dispatch
* [`64dcaece`](https://github.com/doomemacs/core/commit/64dcaece3673e75732e0af02333726de5c3783e4) fix(default): don't enable evil in non-evil buffers on newline
* [`174517c6`](https://github.com/doomemacs/core/commit/174517c6a7c1b709d9ff60af13d5ce95cff78b99) fix(dired): dirvish: use new name of renamed function
* [`0f1064ef`](https://github.com/doomemacs/core/commit/0f1064ef0155a0471e9da260ccab866bdbf1dccf) fix(mu4e): org-msg signature advice
* [`5335baba`](https://github.com/doomemacs/core/commit/5335babaca95d184a0bb04c6845083f54c7fa95c) tweak: disable line numbers in minimal-UI buffers
* [`902a6fca`](https://github.com/doomemacs/core/commit/902a6fca36c986cd5039129425ef5b3db990a95c) feat(cli): upgrade: init and update submodules
* [`c44363fe`](https://github.com/doomemacs/core/commit/c44363fe46d283f467e6437d2cc3fa847fdcd8af) feat(vterm): 0 and dd keybinds for evil users
* [`587f91a3`](https://github.com/doomemacs/core/commit/587f91a3ed939e61e7291479416a91d73a4766de) fix(lib): toggle line numbers only if necessary
* [`c9c56985`](https://github.com/doomemacs/core/commit/c9c56985dcdf93c081423c048d2597e78bc602af) fix(cli): upgrade: submodule update running in wrong dir
* [`c87a2dbc`](https://github.com/doomemacs/core/commit/c87a2dbc99dcc7a9aaa3c61f6ff61c57fa46e887) release(modules): 26.07.0-dev
* [`1d7a94b9`](https://github.com/doomemacs/core/commit/1d7a94b96b4410a3747ec579c728a79413379e64) release: 2.1.1
* [`cc6ca892`](https://github.com/doomemacs/core/commit/cc6ca8929afe11adbb480f972493a604a8dff8da) fix(cli): upgrade: branch detection on detached HEADs
* [`af60e070`](https://github.com/doomemacs/core/commit/af60e07039fd5cb40515be296a3b6ea2707d63bb) fix(magit): defining as dynamic an already lexical var: projectile-verbose
* [`c024479c`](https://github.com/doomemacs/core/commit/c024479ce7adc85035c1a43e77787b48eeb555b9) fix(cli): error and log output handler
* [`1a67504f`](https://github.com/doomemacs/core/commit/1a67504f188049a5d73ebe6debef852736646540) fix(default): +default/new-buffer: use evil-buffer-new
* [`30f1bf1e`](https://github.com/doomemacs/core/commit/30f1bf1ef18e6b2add008e1333726c2362827571) docs: revise various module docs & doctors
* [`bbecac89`](https://github.com/doomemacs/core/commit/bbecac892dbfbfd53bcef4aaceba55ff0ddc11e4) dev: ISSUE_TEMPLATE/bug_report.yml: use new type field
* [`951d9727`](https://github.com/doomemacs/core/commit/951d9727bc2d8e4b3c1bf28744caf73f9d5dc7cb) tweak(racket): don't enable racket-smart-open-bracket-mode
* [`d6385b60`](https://github.com/doomemacs/core/commit/d6385b60564f45ffcf557fc15c02e0e6ca2b5835) fix(dashboard): show hl-line and only on current line
* [`35961c70`](https://github.com/doomemacs/core/commit/35961c70637d9a906102c3fe76c2e6c050f70eeb) fix: move global-hl-line-mode to doom-first-input-hook
* [`9bacb340`](https://github.com/doomemacs/core/commit/9bacb340501c0953844c0ba6823280f017e55cf8) fix(dashboard): how point is repositioned between buttons
* [`41b694fa`](https://github.com/doomemacs/core/commit/41b694fa4793280d80c096a001fa06891e682727) fix(dashboard): how point is repositioned between buttons (part 2)
* [`5893455e`](https://github.com/doomemacs/core/commit/5893455e2c3f7b68ff3ab228c431bc2a21df6c18) fix(spell): autoload spell-fu commands
* [`aff4238f`](https://github.com/doomemacs/core/commit/aff4238fc8d7d0a331e26ac0612775048b6eba11) fix(macos): move keychain auth-sources to end
* [`23e43db9`](https://github.com/doomemacs/core/commit/23e43db9ee2c1b85e5c5a2ac63647c949d722821) tweak(word-wrap): +word-wrap-extra-indent = 0
* [`ff6e9511`](https://github.com/doomemacs/core/commit/ff6e951150af9227699ea5f1e1d1ffa01e03f587) refactor(cli): error handling
* [`e2704b79`](https://github.com/doomemacs/core/commit/e2704b79295bbe13ea83b00b8469c3825a441608) fix(cli): remove redundant pipe handling logic
* [`ec889421`](https://github.com/doomemacs/core/commit/ec889421f8c57d0b0ef462855004c09eb247ca33) bump: :doom
* [`a27a2ea4`](https://github.com/doomemacs/core/commit/a27a2ea4e8e284d9c036bbb3168b292e3af067af) bump: :editor :tools
* [`df4b4334`](https://github.com/doomemacs/core/commit/df4b4334dd3897479578e58eaa0ed79d4617ce86) bump: :term :os :input
* [`ceb03710`](https://github.com/doomemacs/core/commit/ceb03710deeb56db0c1d5042e615af7ed7b1737c) bump: :ui :emacs :app
* [`6b900923`](https://github.com/doomemacs/core/commit/6b90092390eb9a2337855ae08bdbd8dde88d4ce7) fix(magit): avoid use-package :after keyword
* [`cc24d3ca`](https://github.com/doomemacs/core/commit/cc24d3ca2bac7c2433d5a9235f8c78bebc3677fc) fix(magit): code-review: evil keybinds
* [`7016f3cb`](https://github.com/doomemacs/core/commit/7016f3cbc596ad2901f550447e754a251559e3e3) fix(magit): void-variable evil-default-state error
* [`3edfc827`](https://github.com/doomemacs/core/commit/3edfc82788f4d77772dae824bde30b22a2eb9c2f) fix(magit): void-variable evil-binding error
* [`80ac0036`](https://github.com/doomemacs/core/commit/80ac0036b3e0cf64946b2a5fecb78bc16c1c47b1) refactor(cli): doom-cli-initialize: cleanup & comment revision
* [`5115e5c3`](https://github.com/doomemacs/core/commit/5115e5c301a76ae93cee4439bc70c7c297b5d47e) refactor: remove extra output in daemon sessions
* [`55999900`](https://github.com/doomemacs/core/commit/5599990072f0cd2f5bd1aa63f41a9f2ffbcbd6b2) fix(dashboard): repositioning point outside the dashboard
* [`5c208a29`](https://github.com/doomemacs/core/commit/5c208a2928a3222fda8433b29f386e7a29bd15f7) refactor(vertico): remove +vertico--marginalia-project-root-a
* [`9845d96d`](https://github.com/doomemacs/core/commit/9845d96dc217d06f40b6a293f8c8f28c865dd518) bump: projectile
* [`ae0a6acd`](https://github.com/doomemacs/core/commit/ae0a6acdb1c55217cd009281567968de5af262b2) fix(cli): unprompted DEBUG=3 in multi-step CLI sessions
* [`6518b194`](https://github.com/doomemacs/core/commit/6518b194bc753deb7ad802c12db6120950bc28eb) fix(cli): depth tracking in multi-step CLI sessions
* [`1a9ae841`](https://github.com/doomemacs/core/commit/1a9ae8415029c75ead7c6b41449781ec84d5fd9d) fix(cli): doom-cli-handle-error call typo
* [`9261562d`](https://github.com/doomemacs/core/commit/9261562da31181292332feee46cd46f36bf33faa) fix(lib): doom/help-modules: in modules w/o a README
* [`fd4a4c5d`](https://github.com/doomemacs/core/commit/fd4a4c5d6a4f3cd498ed70cac7535da58b18a044) dev: simplify issue templates
* [`90f9a4af`](https://github.com/doomemacs/core/commit/90f9a4afd3d443e1c76608410dd14701438fe203) dev: update CODEOWNERS
* [`dba9aa63`](https://github.com/doomemacs/core/commit/dba9aa6363b9c0bada796ee3e8e26adb84a9c43a) feat(lib): doom/info: show `save-buffer` hint in header
* [`e4e19c68`](https://github.com/doomemacs/core/commit/e4e19c683053533712d82f8d9c7bad7f98dd8357) module: add :doom compat
* [`373ea9ed`](https://github.com/doomemacs/core/commit/373ea9ed2af5847dee09885fba8faf34c9c51943) refactor: remove old core module stubs
* [`49f5641a`](https://github.com/doomemacs/core/commit/49f5641ac42425acff841b99ee09a2c5df9ff294) fix(compat): restore deprecated IS-* constant (until v3)
* [`ea09f5a7`](https://github.com/doomemacs/core/commit/ea09f5a78d2ad58c0090b5c69e05ab10612df537) tweak(cli): doom version: replace -{v,-version} w/ -{s,-short}
* [`ba11be9c`](https://github.com/doomemacs/core/commit/ba11be9c4d0c7a194908225a6cdb9eeb7608c077) refactor!: redesign & rename doom-rcfile API
* [`4bf60553`](https://github.com/doomemacs/core/commit/4bf6055380eacfd5dfe2d2b85b9b3065509fa22a) fix(cli): update submodules in doom {upgrade,install}
* [`eb04484c`](https://github.com/doomemacs/core/commit/eb04484c1c708283cfd45775c5397591075976be) refactor!: move modules out of core
* [`743686f5`](https://github.com/doomemacs/core/commit/743686f503792adbe8bca15b2ccffaf154e190dd) dev: update & simplify .doom
* [`e1153b97`](https://github.com/doomemacs/core/commit/e1153b97ca366fd3046b12bbf5724e2733323382) dev: gitignore modules/ & sources/
* [`9f643edf`](https://github.com/doomemacs/core/commit/9f643edfb401d2382dd65168f94ae948d82348cd) fix: add .gitmodules
* [`a663e0d3`](https://github.com/doomemacs/core/commit/a663e0d38348ae61f9d286a4d05ad611f82863b5) fix: void-variable v error on obsolete modules
* [`a7c7dcda`](https://github.com/doomemacs/core/commit/a7c7dcdadf6a8cda2dff4d0c33736265319c3b74) release: 2.2.0
* [`fc7650c4`](https://github.com/doomemacs/core/commit/fc7650c4f695471f18fa1c328c6e51cd329c2504) fix(cli): doctor: error if $DOOMDIR/modules doesn't exist
* [`11455aa7`](https://github.com/doomemacs/core/commit/11455aa7c1f3aa39e6a2de85a56088ee24fe156c) fix(cli): backtrace on CLI errors
* [`c87610ad`](https://github.com/doomemacs/core/commit/c87610ad3baa37d58248f704f46496878d34f71f) refactor: don't use rings for theme history
* [`ed164284`](https://github.com/doomemacs/core/commit/ed1642844aad10412cf1f96edf5af89a468b211a) docs(cli): doom upgrade: update manual install steps
* [`167abe96`](https://github.com/doomemacs/core/commit/167abe966c6279683d82680c384d5f3f5bd7da2b) dev: fix module/source exceptions in .gitignore
* [`bcfc0db7`](https://github.com/doomemacs/core/commit/bcfc0db7e71f99bfcebf05cab1cf2934bb5a334c) dev: .doom: fix publish & commit linter configs
* [`8e2d1f06`](https://github.com/doomemacs/core/commit/8e2d1f06ff40edfb34589f79570100c1fedc6300) docs(cli): doom upgrade: s/submodules/submodule/
* [`bcf55ab7`](https://github.com/doomemacs/core/commit/bcf55ab7143cb6c31e09276f41bb70166136b96b) dev: make CODEOWNERS static
* [`1ad236fc`](https://github.com/doomemacs/core/commit/1ad236fcdc461e69385d38f00c65487cdf3c2d51) refactor: move core module files to :doom
* [`b4c55ccc`](https://github.com/doomemacs/core/commit/b4c55ccc5f7c2f5af98bf0dfb0a254424b4bdab2) refactor(compat): add +use-package flag
* [`11844a5d`](https://github.com/doomemacs/core/commit/11844a5d2eceab8efe434d36d4fb345a093c8b06) docs: update & reformat demos.org
* [`c0f383a8`](https://github.com/doomemacs/core/commit/c0f383a812ebeaf9ad3c14a70796497efff5a3df) tweak: re-enable Customize family of commands
* [`a9430033`](https://github.com/doomemacs/core/commit/a943003337e59a4dd044473a97eb4046ece971a7) refactor: move smartparens to :doom compat
* [`7ef14e58`](https://github.com/doomemacs/core/commit/7ef14e58c4e40f55e8ebe0e717af50a84074dda8) fix(compat): gate package behind +use-package
* [`6d557514`](https://github.com/doomemacs/core/commit/6d557514413aa0b5611b2561ebbf3b8eee3abb2d) refactor: redesign core architecture
* [`f86f1a15`](https://github.com/doomemacs/core/commit/f86f1a15611f78b90dd5b796b166e356a4d257d0) fix(cli): doom upgrade: failed to fetch straight recipe
* [`8071cb65`](https://github.com/doomemacs/core/commit/8071cb65a93bd06403180fbab8b4b4cf71a4a564) fix(cli): doom upgrade: failed to fetch straight recipe (part 2)
* [`7635aabb`](https://github.com/doomemacs/core/commit/7635aabb758e3a002a3a7de16b2c9f7bc2bf88ee) fix(:doom): unquoted package-archives ref w/ add-to-list
* [`e337a375`](https://github.com/doomemacs/core/commit/e337a37504fa0bd968fa8898814ca20d09d83138) fix(:doom): recognize .doom{modules,profiles} files
* [`a3b2d1d1`](https://github.com/doomemacs/core/commit/a3b2d1d18a0b506fe042ff8b2889a1a8ada4d3e3) fix: remove references to doom-start
* [`6fdcfe0f`](https://github.com/doomemacs/core/commit/6fdcfe0f780d6ecc7752bfc019aaf8ce764309b0) fix: set load-path in lisp/doom.el
* [`6d5b676f`](https://github.com/doomemacs/core/commit/6d5b676fcedcfb05834aa91f8157300ca5d86b1f) nit: update & revise comments
* [`0a4baf96`](https://github.com/doomemacs/core/commit/0a4baf9636f423e5e7de03d49082bc918ecefcce) docs: doomemacs/doomemacs -> doomemacs/core
* [`040e9af7`](https://github.com/doomemacs/core/commit/040e9af7efbb8f432aa8bf95b10f8babdcc14baf) fix(lib): remove redundant obsolete function aliases
* [`c4eb05b5`](https://github.com/doomemacs/core/commit/c4eb05b53cc55c21f8c0c4120de26525d4ccdb8e) refactor(:doom): move more obsolete aliases to :doom compat
* [`1f4fca0b`](https://github.com/doomemacs/core/commit/1f4fca0b5207c82812851ed2c5589a87c28ddb6c) fix(lib): doom-module-from-path: in nested modules/
* [`4359c2c2`](https://github.com/doomemacs/core/commit/4359c2c2f3fffb4df940c7e988f4c66433e49342) fix(lib): doom-module-locate-path: only search first module
* [`21d2d35d`](https://github.com/doomemacs/core/commit/21d2d35d91de871565b83a9232cb7bce7b363b13) refactor(compat): move more obsolete aliases
* [`81360ffc`](https://github.com/doomemacs/core/commit/81360ffcfdde7cf75f16b6310af9fe7fa2d5223d) refactor(compat): move :config default +smartparens here
* [`da28e76a`](https://github.com/doomemacs/core/commit/da28e76acfe63816ba25ab8f161b4da3e0cb57cb) refactor: move general/which-key to :doom compat
* [`2f487499`](https://github.com/doomemacs/core/commit/2f487499f63ed9bc8abc6a0ea497105f93e92c5b) refactor: move better-jumper to :doom compat
* [`964ad524`](https://github.com/doomemacs/core/commit/964ad524e71c261e6f05912a4c8a61bed7272861) refactor: move projectile to :doom compat
* [`09cc25ee`](https://github.com/doomemacs/core/commit/09cc25ee497b3b96f093cf8c2a02ac63cbbc0100) refactor: move auto-minor-mode to :doom compat
* [`9bb542cd`](https://github.com/doomemacs/core/commit/9bb542cd8878116600a81583698960ea59808edf) revert: Fix [doomemacs/doomemacs⁠#2742](https://togithub.com/doomemacs/doomemacs/issues/2742): cursor offset in artist-mode
* [`59283594`](https://github.com/doomemacs/core/commit/592835940bc4991fbac1376b64df302ba4f75963) revert: image-animate-loop = t
* [`c029324b`](https://github.com/doomemacs/core/commit/c029324bb0084288ba5ba8a8fcc699e1347021d0) fix(lib): avoid pcase-setq
* [`c09f9420`](https://github.com/doomemacs/core/commit/c09f942047727668d82f0b7dabc351a7fa5ff651) fix: file-name-concat error on Emacs 27
* [`1123dc57`](https://github.com/doomemacs/core/commit/1123dc57934d79978d8b4f6185b50c5ee4ab38ab) refactor(:doom): move some interactive config back to core
* [`be4dc51c`](https://github.com/doomemacs/core/commit/be4dc51c4e1b618d07673cd74a9b85c42cf9770b) fix(cli): doom-startup: require doom-emacs
* [`bd993c10`](https://github.com/doomemacs/core/commit/bd993c100f114e3f4a946e3b76d420ae7b3dc426) fix: doom-profile-load-path
* [`975485a9`](https://github.com/doomemacs/core/commit/975485a908e37e2b68756a7ce1c9857459ec9821) docs: init.example.el: add :lang scad
* [`cb850fde`](https://github.com/doomemacs/core/commit/cb850fde342c54f101c284c64cd58e6d5e6296dc) fix: move auto-mode-alist entries to :doom
* [`8a3dc4ab`](https://github.com/doomemacs/core/commit/8a3dc4abe2f293700275dde3f90b469538404e8a) fix(cli): doom upgrade -p: stringify --jobs argument
* [`3806055a`](https://github.com/doomemacs/core/commit/3806055a09a44243287a6ae9e7bd5a6cbe03dbbd) feat(cli): doom env: change envvar file format to elisp
* [`834169dd`](https://github.com/doomemacs/core/commit/834169dd582bbf1d1a347ab41164e1ea7217b490) feat(lib): doom-info: add sources section
* [`1f20b7e5`](https://github.com/doomemacs/core/commit/1f20b7e506bf0fe943575739189084582811afb0) fix: restore old usage of doom-profile-init-file
* [`4a541f1f`](https://github.com/doomemacs/core/commit/4a541f1f35d8d0077311f91f9c236fbb82f83bce) fix(cli): doom env: merge into environment
* [`dd931f57`](https://github.com/doomemacs/core/commit/dd931f57dfabcb4454e274c7a9ae9ad154e92a90) bump: sources/doom+
* [`0cb80182`](https://github.com/doomemacs/core/commit/0cb80182e0c4f2cbf8c524744d3d03e369dd7ffb) fix: <C-i> being ignored for TAB
* [`11468a6c`](https://github.com/doomemacs/core/commit/11468a6cba5c09f4ef7d021cfdbaca2c1f931f27) refactor(lib): remove no-ops for define-fringe-bitmap & set-fontset-font
* [`20cb7132`](https://github.com/doomemacs/core/commit/20cb713222e0c58bc1de9699a5d3557384301770) refactor(lib): break up & remove doom-compat.el
* [`fa455dd9`](https://github.com/doomemacs/core/commit/fa455dd934d3b0eec8f1210d6dcf49430e044db1) nit: doom-emacs.el: move hooks to correct section
* [`e5f5a7c9`](https://github.com/doomemacs/core/commit/e5f5a7c94b44c79239f94a11aa6409ad2d745c95) refactor: early-init: set w32 IO vars sooner
* [`26dbb560`](https://github.com/doomemacs/core/commit/26dbb560919266b41ced4116703b5c322a08ea3a) refactor(lib): move format-spec autoload to doom-cli
* [`ff0a8366`](https://github.com/doomemacs/core/commit/ff0a83665321d92a13e8b1b4fe5ab46b189d61ae) feat(lib): add directory helpers
* [`cf771df2`](https://github.com/doomemacs/core/commit/cf771df284f69ef8b1584017d84fccf0ef38eb07) fix(lib): add-hook!: use closures as-is
* [`e3f0ec1e`](https://github.com/doomemacs/core/commit/e3f0ec1e75ef7cb9597de4962be1c7a51a632027) fix(cli): don't set DOOMPROFILE if it wasn't already
* [`a65d53f1`](https://github.com/doomemacs/core/commit/a65d53f1a8718a8953d11701c97e83ca3b812d1e) fix: move server-start to doom-finalize
* [`5cc36a30`](https://github.com/doomemacs/core/commit/5cc36a30a4b66e1a88072e239c02d67ae6029b2f) refactor: don't defer C-i/C-m fallback keybinds
* [`ef93cba3`](https://github.com/doomemacs/core/commit/ef93cba3ab6ca60c9f0b195dd499f127603c503b) refactor(lib): deprecate doom-module-load-path function
* [`fa27238d`](https://github.com/doomemacs/core/commit/fa27238d61e8838c8d9b5012e81311fbd81e6a40) fix(lib): doom-autoloads--scan: scan files only once
* [`5b93f851`](https://github.com/doomemacs/core/commit/5b93f851d8ddebf15a5200ad3cc98144d56feeb3) refactor(lib): simplify error API
* [`cdcb1c3a`](https://github.com/doomemacs/core/commit/cdcb1c3ad68433d3318c4847114496290b2821a0) fix(compat): don't unset leader key on reload
* [`dce7f1d3`](https://github.com/doomemacs/core/commit/dce7f1d376cc21619cf161d288cc34512a211445) docs(lib): doom/reload: revise docstring
* [`685a38b6`](https://github.com/doomemacs/core/commit/685a38b69c53de9dbd801ede1901554a8548a2e3) refactor: more lib/{profiles.modules,packages}.el to doom-*.el
* [`177e7759`](https://github.com/doomemacs/core/commit/177e77593f4edae931b2c348a5fefc7a4704da45) refactor: doom-module-locate-path: don't consult module table
* [`3e83eb74`](https://github.com/doomemacs/core/commit/3e83eb74609433257c478d39bc838714e64c4904) fix: don't index autoloads for shadowed modules
* [`dd7903fd`](https://github.com/doomemacs/core/commit/dd7903fdcb1ed770faa4ca37bf9adfa9b41f7c42) refactor: redesign profile generation
* [`8fba7c19`](https://github.com/doomemacs/core/commit/8fba7c19be9b228f9c604cb778e592da52216f9f) nit: reformat & standardize comment TOC
* [`74bb093b`](https://github.com/doomemacs/core/commit/74bb093bd96aef2de3465cb6450a308b48d89a78) fix: doom-finalize: persist startup context until end
* [`13bf6ae0`](https://github.com/doomemacs/core/commit/13bf6ae0ba56d9160ba3f118c1ac6b1eaf839051) fix(cli): abort if default-directory does not exist
* [`99c0e7e6`](https://github.com/doomemacs/core/commit/99c0e7e63e3b0d7db00206b73dab4b355df79806) refactor(lib): move kbd! to :doom compat
* [`3f434bb1`](https://github.com/doomemacs/core/commit/3f434bb12555016aa09a99869b0c60b1ec353c0b) fix(lib): doom-autoloads--scan: set load-in-progress
* [`3de2b5e6`](https://github.com/doomemacs/core/commit/3de2b5e699dacdbdad87f899e9f14f34620f0bde) refactor(lib): move module/profile/package APIs
* [`013ccd49`](https://github.com/doomemacs/core/commit/013ccd491f71b24d80b0a0f26cd6477ed123dab0) refactor(lib): remove doom-autoloads-file var
* [`cdeab097`](https://github.com/doomemacs/core/commit/cdeab0975ea09f01f19fcbbff33cc8427f10d8b6) fix: don't pretty-print doom's loaddefs
* [`32f31d2b`](https://github.com/doomemacs/core/commit/32f31d2ba626f9fa6de2729a22d8889df40d98ad) fix: doom-package-list: not reading :user packages
* [`ebf4d261`](https://github.com/doomemacs/core/commit/ebf4d261e1f745f32487019b62db4bfcc6f045a7) fix(cli): premature "Script was abrupted aborted" error
* [`d7d7b5f6`](https://github.com/doomemacs/core/commit/d7d7b5f6f1c54f47806456b63f11378961e47f39) fix(cli): doom sync: only emit "Using Emacs" line once
* [`46687e54`](https://github.com/doomemacs/core/commit/46687e54eebb05f1477686fb996f1a8172b17f29) fix: doom-module-locate-path: file-missing case & non-cons key
* [`f8c5541b`](https://github.com/doomemacs/core/commit/f8c5541b727d4ec487f11e81fd6f813f5b297fbb) fix: namespace profile init files
* [`8e15f5f6`](https://github.com/doomemacs/core/commit/8e15f5f6342f87a56f14ff3022357782d3e64abc) refactor(cli): move requires to doom-cli
* [`d4d4c11e`](https://github.com/doomemacs/core/commit/d4d4c11e2a3ef507537aac668d11919a3d00984b) feat(cli): doom sync: add {-r,--reload} option
* [`3fc787bc`](https://github.com/doomemacs/core/commit/3fc787bced542cf1405f33af8deedfaec66e5916) refactor(lib): remove doom/reload-autoloads command
* [`0012109e`](https://github.com/doomemacs/core/commit/0012109e82f55299c38df7444daf0470f716e023) feat(cli): redesign envvar generation
* [`152ad662`](https://github.com/doomemacs/core/commit/152ad662526ccc97bbcfcace07e379c59675a08f) fix(cli): doom env: error on missing containing directory
* [`07cf68a7`](https://github.com/doomemacs/core/commit/07cf68a7f8bdf97e853855b7c3a54badd8ffd68d) fix(lib): doom/reload-env: emit more helpful error
* [`cf7d5fc6`](https://github.com/doomemacs/core/commit/cf7d5fc617d1871a6031124b0523cc9151c23773) feat(cli): autoload public variables
* [`46dc9311`](https://github.com/doomemacs/core/commit/46dc9311ef1897385a3c7bbd626297f3aa69a167) refactor: move doom-module-*-file vars to doom-modules.el
* [`9f41eb86`](https://github.com/doomemacs/core/commit/9f41eb86e3f301cb67fe79726b45b2214ae0139a) refactor: move incremental loader/local-vars hooks to doom-emacs.el
* [`fd3839f9`](https://github.com/doomemacs/core/commit/fd3839f9a8fb068233e39d9c0e4fe4d19a70d2c5) fix: {early-init.el,bin/doom}: resist byte-compilation
* [`db780259`](https://github.com/doomemacs/core/commit/db78025936410b0cb4a72f242af507f1379714f2) fix: set lexical-binding in packages.el files
* [`2698abb7`](https://github.com/doomemacs/core/commit/2698abb722d770a3c62db5090f5b17fa0387a8dd) nit: standardize file comment headings
* [`844dc9fd`](https://github.com/doomemacs/core/commit/844dc9fd7dff72acdf1fcc0d0ed9fa794082bf97) refactor(cli): doom emacs: remove unneeded require's
* [`1ecb935e`](https://github.com/doomemacs/core/commit/1ecb935e52cba4760e6fdf7ac1fb2a9933cf09a1) fix(cli): appease byte-compiler-sama
* [`3ae74b03`](https://github.com/doomemacs/core/commit/3ae74b03e6dffe73ce246452f836532912f7088e) docs: doom-system: mention first element = the OS
* [`912c1144`](https://github.com/doomemacs/core/commit/912c11449932babd3b1ced0d7456757be86a33fa) fix: doom-profile-generate: suppress errors during failure cleanup
* [`ef473206`](https://github.com/doomemacs/core/commit/ef47320605387e47dd189d3b12fd671b3999f100) fix(cli): use defcustom for doom-env-allow
* [`b0c9aa3c`](https://github.com/doomemacs/core/commit/b0c9aa3c91c34a5c68986e2ff46b2d2b887b20cd) fix(cli): doom upgrade: delete *.elc before restarting
* [`851f1244`](https://github.com/doomemacs/core/commit/851f124416fb4927d8da83f08b6b6a96b924ca4b) feat: add doom-module-cli-file var
* [`ab8e54bf`](https://github.com/doomemacs/core/commit/ab8e54bfc7f78160dc2884c719edf80ad0a622cb) fix(lib): doom/info: envvar file detector
* [`21166d11`](https://github.com/doomemacs/core/commit/21166d118449ea3ca07334748453bf8151704b25) bump: sources/doom+
* [`555dc5f0`](https://github.com/doomemacs/core/commit/555dc5f0459344e86c01e9a72bceea92631f0db0) fix: doom-startup: move context checks to startup--load-user-init-file
* [`056559a8`](https://github.com/doomemacs/core/commit/056559a8139609e4e2e0229198b0cc78430fd37d) refactor(lib): deprecate lib/plist.el
* [`74c519e8`](https://github.com/doomemacs/core/commit/74c519e8e8c59dc4d4540f115011f5a10c9cc214) refactor(lib): deprecate lib/store.el
* [`c43f02e9`](https://github.com/doomemacs/core/commit/c43f02e993ca47cbececb52651a89a1057d52196) fix(cli): load :doom CLIs without a +prefix
* [`d09c5ee4`](https://github.com/doomemacs/core/commit/d09c5ee425876e533a34a1025b61c480c25944ef) refactor(cli): remove cli/test.el
* [`4be87ec6`](https://github.com/doomemacs/core/commit/4be87ec62ec8ad6901d096e68b51e56355592218) feat(lib): dir!: turn into a path constructor
* [`3f00d9bf`](https://github.com/doomemacs/core/commit/3f00d9bfdc0ea4b196d375a33096202008637b0c) refactor(cli): remove unneeded defcustom :group properties
* [`01d2054c`](https://github.com/doomemacs/core/commit/01d2054caf69bac37526efbfa1b5229f16bde669) refactor!: change doom-profile to struct
* [`41e7e85f`](https://github.com/doomemacs/core/commit/41e7e85f05510fcff7d533227fc554c0e88e1fa8) fix(cli): move default cli load-path to bin/doom
* [`50e0e331`](https://github.com/doomemacs/core/commit/50e0e331aefe8ee710da594ee5cafb10eec31594) feat(cli): formalize doom-cli-load-path & $DOOMPATH
* [`37dbb4b8`](https://github.com/doomemacs/core/commit/37dbb4b87afaac59a53638c9daffd206c8ed4566) feat(cli): add CLI autoloads to profile init file
* [`c1c6b1de`](https://github.com/doomemacs/core/commit/c1c6b1de39657d28829b6f7e2239e4e0a3b4635b) refactor(cli): move cli/*.el to bin/doom-*
* [`fd1b5cbd`](https://github.com/doomemacs/core/commit/fd1b5cbd3db552c050c14cdc314fe3f423227277) fix(cli): doom-help: omit aliases
* [`80cd06ba`](https://github.com/doomemacs/core/commit/80cd06ba57fe3ea04261489d671a1b9bb371c15c) refactor(lib): remove/deprecate unused parts of autoloads API
* [`29e69e47`](https://github.com/doomemacs/core/commit/29e69e479f1f6bac72358f81d61500a0e8711757) refactor(cli): don't load doom-lib-{git,plist} libs
* [`ff08de43`](https://github.com/doomemacs/core/commit/ff08de4340be16bf64dbe536856536dcc0e4db53) feat(cli): scan lisp/cli/*.el for autoloads
* [`2014f96c`](https://github.com/doomemacs/core/commit/2014f96c46a02e7feec9b57137b926a18c68eb8d) feat(lib): new loaddefs.el library
* [`8a5bc43d`](https://github.com/doomemacs/core/commit/8a5bc43d2d04cb8d2091313277e04a90501f626b) fix(cli): prevent compile-time syntax from breaking profile init
* [`6e7cbdff`](https://github.com/doomemacs/core/commit/6e7cbdffffe9b67fcb9dbca565411bf00aed547a) docs(lib): document PROFILE arg in directory helpers
* [`e20ff981`](https://github.com/doomemacs/core/commit/e20ff98175bbadef6b17d14759edcaa70c3b3a46) bump: sources/doom+
* [`80a3f681`](https://github.com/doomemacs/core/commit/80a3f6810ef724f3fc9a7311d9ee874fbbf21f00) fix: doom-profile->id: remove incomplete type check
* [`58644dce`](https://github.com/doomemacs/core/commit/58644dce7dee321b99fd1a1c19e5452a0412c8d7) docs: doom-profile-key: revise docstring
* [`45e45cea`](https://github.com/doomemacs/core/commit/45e45cea85d8e230559d7fbc466da7e30a3f9f3c) docs: demos.org: remove pushnew! demo
* [`2da3d968`](https://github.com/doomemacs/core/commit/2da3d968e4e5bac44e4a51117c3ce72dbfe2de9b) fix(lib): doom--profile: uninterpolated value in backquote
* [`ecb8e305`](https://github.com/doomemacs/core/commit/ecb8e305ba9b2b8ae5a1a647b4adacc8944bd365) fix: doom-initialize: don't suppress IO errors
* [`b25028ff`](https://github.com/doomemacs/core/commit/b25028ffe16302b5adb7a13e9470b6bbb868a776) fix: doom-initialize: init doom-cli after profile init
* [`a52b997d`](https://github.com/doomemacs/core/commit/a52b997daed5467267a78f7b7dc025350350364a) refactor(cli): move cli libs to lisp/cli/
* [`899bef7d`](https://github.com/doomemacs/core/commit/899bef7d8f4aa0a386293cf94a857b16b7a6de6e) refactor: remove unused files
* [`cc6c480a`](https://github.com/doomemacs/core/commit/cc6c480a8f5c380e04f0157f60242470bdff5850) fix: autoloaded module commands not found
* [`3afd5f43`](https://github.com/doomemacs/core/commit/3afd5f431f4cd00c685e34d4f072799979dfaa6b) fix(cli): bin/doom-profile.el: remove file extension
* [`cf29603c`](https://github.com/doomemacs/core/commit/cf29603ca58021df4566e9c275ceb55a2fed4375) fix(cli): unexpanded autoload paths
* [`46ad5ef8`](https://github.com/doomemacs/core/commit/46ad5ef81dd26db3e17ba37dec6b75baab9bf29d) fix(cli): not reading changed `doom!` module list
* [`3b0d3831`](https://github.com/doomemacs/core/commit/3b0d3831ff434ce57564adedba0e1f30cf5df51c) docs(cli): doom help: mention $DOOMDIR/bin & $DOOMPATH
* [`197676a9`](https://github.com/doomemacs/core/commit/197676a901e6109e934f0c39c79833e98eddeaf0) bump: sources/doom+
* [`e5ea7a1b`](https://github.com/doomemacs/core/commit/e5ea7a1b3f63dbb7b80245115e217b3e4a05cb65) fix(lib): doom/{version,info}: errors wrt doom-print-* API
* [`5d13b854`](https://github.com/doomemacs/core/commit/5d13b8541853b2a60d1917e756c2ce0c66969390) fix(cli): 'doom doc' not resolving to 'doom doctor'
* [`259ac4eb`](https://github.com/doomemacs/core/commit/259ac4eb324fdba9fce9e8bd948b746cfa7ccb23) fix(cli): doom help: show full docs for aliases
* [`5e668c1c`](https://github.com/doomemacs/core/commit/5e668c1c33df41a3f8ea44c33642ee60fa88733b) feat: add transient config
* [`123ffc7e`](https://github.com/doomemacs/core/commit/123ffc7eeaa432eb97cf53eaeca82759be62b0e5) fix(lib): autoload cli/print
* [`9a86f384`](https://github.com/doomemacs/core/commit/9a86f384c0d5426f87ca6a60596526454969f85f) bump: :doom
* [`0dd5b057`](https://github.com/doomemacs/core/commit/0dd5b0573aa918ab79a49a7a4c19508ad770aeca) fix(cli): doom.ps1: suppress lexical-binding warnings
* [`5c488998`](https://github.com/doomemacs/core/commit/5c48899840e6480a2e092f9a682f58380df03e0f) fix(cli): doom-cli-executable-p: use file-readable-p on windows
* [`aac84622`](https://github.com/doomemacs/core/commit/aac84622b8bbe615832d3c49f8fe42fbda6841d3) fix(cli): doom.ps1: errors on unnecessarily escaped double-quotes
