### PR TITLE
npins nixpkgs: update d6d02fee -> 95e7ef5e

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -125,9 +125,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "d6d02feee3f04b50845bc743b58d3b88cd173e5f",
-      "url": "https://github.com/nixos/nixpkgs/archive/d6d02feee3f04b50845bc743b58d3b88cd173e5f.tar.gz",
-      "hash": "sha256-hnvtmFEwxEV8wehWmmwtXNMoMo+2eEaoNw8iF0nInO8="
+      "revision": "95e7ef5ed77baf8e2939ff3770b9eb02632389fe",
+      "url": "https://github.com/nixos/nixpkgs/archive/95e7ef5ed77baf8e2939ff3770b9eb02632389fe.tar.gz",
+      "hash": "sha256-hSwFn3/e70Z32AozXOadpmCub4ITFrqChPJJJ/qOAVY="
     },
     "powerlevel10k": {
       "type": "Git",


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@d6d02fee...95e7ef5e](https://github.com/nixos/nixpkgs/compare/d6d02feee3f04b50845bc743b58d3b88cd173e5f...95e7ef5ed77baf8e2939ff3770b9eb02632389fe)

* [`aa2ccac1`](https://github.com/NixOS/nixpkgs/commit/aa2ccac114986608f365207a587ed122dde5b4e0) nixos/immersed: add option to open firewall ports
* [`2db04557`](https://github.com/NixOS/nixpkgs/commit/2db0455735ed2f181ae83d551dbc6ac090b209cb) immersed: add libraries to support Intel hardware encoding
* [`df60c7d7`](https://github.com/NixOS/nixpkgs/commit/df60c7d7a1683e352aa230c2b3dd34522d7c20ad) cddl: 0.12.9 -> 0.12.11
* [`ba0e806e`](https://github.com/NixOS/nixpkgs/commit/ba0e806e9334a776cb1b684bc4683153bb6f3c66) arduino-cli: add python3 to its environment
* [`873e690a`](https://github.com/NixOS/nixpkgs/commit/873e690a5bdeeffd7d39a369698cf65dcaa7c84c) maintainers: add ekisu
* [`c79c23b4`](https://github.com/NixOS/nixpkgs/commit/c79c23b4ab3dccc9048327102214146abd7f984d) nixos/cloudlog: fix QSL image serving and assets management
* [`ba98ad04`](https://github.com/NixOS/nixpkgs/commit/ba98ad04f280f27006ffb2353dc429d136e5fb7b) xlights: add .desktop file & icon
* [`9109f574`](https://github.com/NixOS/nixpkgs/commit/9109f5749810173c08090a62f2a1d418f945ca36) vita3k: init at 3821
* [`dbef88f5`](https://github.com/NixOS/nixpkgs/commit/dbef88f5e0924a6ab32bad0b1d7f6c550f2924f7) python3Packages.pyannote-database: 6.1.0 -> 6.1.1
* [`e4b9fd37`](https://github.com/NixOS/nixpkgs/commit/e4b9fd3714c0326a5929a7037f1fecf53384771a) nixos/hardware: always add renesas kernel module to initrd
* [`4f10f5d4`](https://github.com/NixOS/nixpkgs/commit/4f10f5d413149feef8c17628f9d267709832dd31) nixos/nginx: not using reuseport for unix domain listens
* [`e5179db7`](https://github.com/NixOS/nixpkgs/commit/e5179db788212ab6b7818c9429834f8672daf98f) jack-passthrough: cleanup, add nix-update-script
* [`bee37c0b`](https://github.com/NixOS/nixpkgs/commit/bee37c0bd80af0a59c834da7f23e139fad3819f8) jack-passthrough: add maintainer l1npengtul
* [`e206d733`](https://github.com/NixOS/nixpkgs/commit/e206d73395a9ddde19ccaa5fe211e78f247007ae) vscode-extensions.tomblind.local-lua-debugger-vscode: init at 0.3.3
* [`8c5b78a0`](https://github.com/NixOS/nixpkgs/commit/8c5b78a04e7e5b56b0d560907aab0f08ae852ac6) mpvScripts.thumbfast-vanilla-osc: init at 0-unstable-2025-02-04
* [`11f4e50e`](https://github.com/NixOS/nixpkgs/commit/11f4e50e2dca0329d28441ff8a86f51fe52c1d59) nushellPlugins.desktop_notifications: add darwin platforms
* [`9f182eb0`](https://github.com/NixOS/nixpkgs/commit/9f182eb031e6b6c7ca06bede2c6bf56be0e90054) python3Packages.{kazoo,pure-sasl}: add optional dependencies
* [`4689925c`](https://github.com/NixOS/nixpkgs/commit/4689925cf269d6eca487f012ea4300106c4fa0ac) sagittarius-scheme: fix broken download link after recompiling
* [`af350846`](https://github.com/NixOS/nixpkgs/commit/af350846a16d3879e8f277c7e843b3228a6c1e2a) sagittarius-scheme: 0.9.12 -> 0.9.14
* [`4e595535`](https://github.com/NixOS/nixpkgs/commit/4e59553531a376083d2dc8cbc94f4d1482ed44ac) dethrace: 0.9.0 -> 0.10.1
* [`a9e4be38`](https://github.com/NixOS/nixpkgs/commit/a9e4be382516036d415dbb27fddcddca2a96239b) python3Packages.array-api-compat: 1.13 -> 1.14
* [`8c345c31`](https://github.com/NixOS/nixpkgs/commit/8c345c31a1a902cee3e229cacbd1ed2859d19e21) python3Packages.cashews: 7.4.4 -> 7.5.0
* [`d1e2b980`](https://github.com/NixOS/nixpkgs/commit/d1e2b980f607346644f8dea865f485aad07f5706) _4ti2: 1.6.14 -> 1.6.15
* [`3bbe46a3`](https://github.com/NixOS/nixpkgs/commit/3bbe46a3f31bfb10a5157e3ecdf6dd8c24fc9061) burp: 2.4.0 -> 3.2.0
* [`83b4d3a1`](https://github.com/NixOS/nixpkgs/commit/83b4d3a1e66426038ce99a577185c39f34b5ee4d) python3Packages.scramp: update src to reflect upstream move to Codeberg
* [`8bcf312f`](https://github.com/NixOS/nixpkgs/commit/8bcf312f00bbc6d6c52ed187887dadb05211e7d2) libdwarf: 2.2.0 -> 2.3.1
* [`938da573`](https://github.com/NixOS/nixpkgs/commit/938da573e5d020968e8399636c14fffa4988c785) appgate-sdp: 6.4.2 -> 6.5.4
* [`0e7657de`](https://github.com/NixOS/nixpkgs/commit/0e7657deb081a605da701c0ca0127e49d1fd31ef) linuxPackages.xone: 0.5.7 -> 0.5.8
* [`b1a373ab`](https://github.com/NixOS/nixpkgs/commit/b1a373ab03a7a24686d408ba2a5a5082a4e5d252) matugen: 4.0.0 -> 4.1.0
* [`8d910659`](https://github.com/NixOS/nixpkgs/commit/8d910659e140fa64141aad4abd74a45ccf5db2e3) cargo-risczero: 1.1.2 -> 3.0.5
* [`2d04b5a9`](https://github.com/NixOS/nixpkgs/commit/2d04b5a999fc443f98e7e4ba5945060b13dafbd9) r0vm: remove package
* [`f8b1507d`](https://github.com/NixOS/nixpkgs/commit/f8b1507d959857b5a1e22a825a5284b0df264c83) maintainers: add jiamingc
* [`23fc9a21`](https://github.com/NixOS/nixpkgs/commit/23fc9a2140b35e10383dd5e61e01e3d8cb567218) stockfish: fix build for armv7l
* [`b94db73b`](https://github.com/NixOS/nixpkgs/commit/b94db73b55258bf90d2c364b14060f256a0a7c1a) curlconverter: init at 4.12.0
* [`d6fac895`](https://github.com/NixOS/nixpkgs/commit/d6fac895224daf8a40ef7c95a1af19681d68a3e8) awatcher: 0.3.1 -> 0.3.3
* [`084664e4`](https://github.com/NixOS/nixpkgs/commit/084664e4607ee4f1b0ced7d051ebb5ab5d95b4c5) scipopt-soplex: 8.0.1 -> 8.0.2
* [`d7d79e8e`](https://github.com/NixOS/nixpkgs/commit/d7d79e8e871b64f7bd6218d26e152ce94ed18ba3) geoserver: add service
* [`c7fcbdc5`](https://github.com/NixOS/nixpkgs/commit/c7fcbdc5445a2b73cd2f90319e086733617d2d6a) elfutils: always depend on pkg-config
* [`19ec02c4`](https://github.com/NixOS/nixpkgs/commit/19ec02c44ef4afeda985d48bc61a3ada7ccf9db3) fable: enable on Darwin
* [`ac49b04e`](https://github.com/NixOS/nixpkgs/commit/ac49b04e19e46ce2a716f175c23039c38456a8a1) notesnook: move icon to spec-compliant location
* [`5204fe85`](https://github.com/NixOS/nixpkgs/commit/5204fe85d689d9b965209532c8efe01a94c6c42d) whatsapp-emoji-font: 2.25.9.78-3 -> 2.26.8.72-1
* [`36efd3ed`](https://github.com/NixOS/nixpkgs/commit/36efd3ed00f7f1887dc3378db8aa2389706305f2) python3Packages.beetcamp: 0.24.2 -> 0.24.3
* [`68780c2a`](https://github.com/NixOS/nixpkgs/commit/68780c2a6e5c798049eadf358ffe69e9b49bcf6e) immichframe: refactor to add `updateScript`
* [`3416a77b`](https://github.com/NixOS/nixpkgs/commit/3416a77b10effb06e39a72692bf0065e82ec9c55) immichframe: 1.0.29.0 -> 1.0.33.0
* [`d9ce769f`](https://github.com/NixOS/nixpkgs/commit/d9ce769f499dc603a53193ba81d83b151a066430) sonar-scanner-cli: 7.3.0.5189 -> 8.1.0.6389
* [`5ac8f415`](https://github.com/NixOS/nixpkgs/commit/5ac8f415c9a50f61030021757cdee0ecb65d1e2d) scitokens-cpp: 1.3.0 -> 1.4.1
* [`69800465`](https://github.com/NixOS/nixpkgs/commit/6980046568bb8649947ef8331826da9128356aad) acme-sh: 3.1.2 -> 3.1.3
* [`2b22f8a2`](https://github.com/NixOS/nixpkgs/commit/2b22f8a2f7b1bf350baaecafccebaf1841add914) sonic-pi: pin ruby 3.3 and boost 1.86 and unmark as broken
* [`5bf68e9f`](https://github.com/NixOS/nixpkgs/commit/5bf68e9f7e458165cfcd029e9dde1f79b67a6ce6) tableplus: 0.1.284 -> 0.1.296
* [`d9acd4c9`](https://github.com/NixOS/nixpkgs/commit/d9acd4c9328ffc55776fee469010b5360ef7d7d0) firezone-gateway: 1.4.18 -> 1.5.2
* [`0be98faa`](https://github.com/NixOS/nixpkgs/commit/0be98faa2c54211fa87e5bb13731d54ecc6b4581) tinycbor: 0.6.1 -> 7.0
* [`dc778b11`](https://github.com/NixOS/nixpkgs/commit/dc778b11851fcb342ade64e91fdef74ff4adb757) python3Packages.robot-descriptions: 1.22.0 -> 2.0.0
* [`6a569f7c`](https://github.com/NixOS/nixpkgs/commit/6a569f7ce309a9a498c63f082209cd23a09ad9e9) python3Packages.chromadb: 1.5.8 -> 1.5.9
* [`acd5a822`](https://github.com/NixOS/nixpkgs/commit/acd5a8225eaccd0300a465c6245bfa9e97daee9e) xacro: init at 2.1.1
* [`a5d2178c`](https://github.com/NixOS/nixpkgs/commit/a5d2178c460e634ba4ce1f3f10805a2d628838d8) xacrodoc: init at 2.0.1
* [`bc00f47c`](https://github.com/NixOS/nixpkgs/commit/bc00f47c44f4cfe7bab2f260d17662da9a5e8247) xacro: no tests before [nixos/nixpkgs⁠#517456](https://togithub.com/nixos/nixpkgs/issues/517456)
* [`38774537`](https://github.com/NixOS/nixpkgs/commit/387745378edc883b3138796784ef3417c8f7193a) xdg-desktop-portal-hyprland: add grim dependency
* [`489b3331`](https://github.com/NixOS/nixpkgs/commit/489b3331324dbf4f615ef175e67d8b10ee6861b6) blink1-tool: 2.4.0 -> 2.5.0
* [`63b5d394`](https://github.com/NixOS/nixpkgs/commit/63b5d39440b087498fa511697165bcf7d534c164) lc0: 0.31.2 -> 0.32.1
* [`68872307`](https://github.com/NixOS/nixpkgs/commit/68872307f176046b55d171e7518753e385662462) immichframe: use `tag` instead of `rev`
* [`7342b8f9`](https://github.com/NixOS/nixpkgs/commit/7342b8f9d5f214245fe9cb4f9116f1eb4c4bdc32) vikunja-desktop: fix darwin build
* [`1b283d8d`](https://github.com/NixOS/nixpkgs/commit/1b283d8da5c1b7274e292df12ac7736cf4ceb3df) vikunja-desktop: 2.2.2 -> 2.3.0
* [`d67d2c22`](https://github.com/NixOS/nixpkgs/commit/d67d2c224b56cc16c919abd552390bf782c19a8b) scss-lint: update ffi dependency
* [`c75130cf`](https://github.com/NixOS/nixpkgs/commit/c75130cf85a46b04ca233e682412cb280e558f53) python3Packages.jsonpath-python: 1.1.5 -> 1.1.6
* [`083465fe`](https://github.com/NixOS/nixpkgs/commit/083465fed949f413631232f4b97eec815fbf5b64) python3Packages.deepface: 0.0.97 -> 0.0.100
* [`7df86bff`](https://github.com/NixOS/nixpkgs/commit/7df86bff55ed2a526f5a1741fdd85bc835bbbec1) sqlcipher: 4.14.0 -> 4.16.0
* [`6316ae4c`](https://github.com/NixOS/nixpkgs/commit/6316ae4c30ec956a32ad8e5b588fbfceabb6f76f) dovecot: add mysql-config dependency
* [`8cea71a3`](https://github.com/NixOS/nixpkgs/commit/8cea71a36000dabf14b462c838d13a02cf7ced6e) maintainers: add temidaradev
* [`81a53b7b`](https://github.com/NixOS/nixpkgs/commit/81a53b7b6c2842cd4d766124b628a3a11cae4f64) python3Packages.patool: 4.0.4 -> 4.0.5
* [`03a8a70f`](https://github.com/NixOS/nixpkgs/commit/03a8a70fda9930e8266e507839737b7ae979e0bc) zigfetch: 0.25.0 -> 0.27.1
* [`99d0d605`](https://github.com/NixOS/nixpkgs/commit/99d0d6055bf24306e5f2551ab0dcbde1f7da2156) taisei: added philocalyst as maintainer
* [`aa7cae85`](https://github.com/NixOS/nixpkgs/commit/aa7cae855436b558bc89b10ef3d7d928dd0faff0) kopuz: init at 0.6.0
* [`e53ed8f0`](https://github.com/NixOS/nixpkgs/commit/e53ed8f0318d91a43b492299e6f91c5ffd56d1ca) versitygw: 1.3.1 -> 1.4.1
* [`ecd6e3e9`](https://github.com/NixOS/nixpkgs/commit/ecd6e3e99aac38fa529c1c96ab177eabbd78f287) python3Packages.pycups: modernize and migrate to pyproject
* [`9e5226c5`](https://github.com/NixOS/nixpkgs/commit/9e5226c5a4626080227305b3f0a9e56948730746) intiface-central: fix hang on splash screen
* [`1cb19ef4`](https://github.com/NixOS/nixpkgs/commit/1cb19ef4c8255bc87010a2a2cdd8a02117c84df5) maintainers: add yarn
* [`fae40fa1`](https://github.com/NixOS/nixpkgs/commit/fae40fa193d838bd2f7e8021ddabb65902021d63) libcotp: 3.1.1 -> 4.1.0
* [`ec082eaf`](https://github.com/NixOS/nixpkgs/commit/ec082eafd0ea69d40106dd6b0b77bfa95531ed87) qmplay2: use deno as yt-dlp js-runtime
* [`08c56e4d`](https://github.com/NixOS/nixpkgs/commit/08c56e4d4f520fb718fbeb7e09df74dd63b1cd52) adif-multitool: 0.1.20 -> 0.1.22
* [`ba6eca1d`](https://github.com/NixOS/nixpkgs/commit/ba6eca1dfc3c91716d357674f975e24ac225b3de) webwormhole: 0-unstable-2023-11-15 -> 0-unstable-2025-12-22
* [`6ede14b0`](https://github.com/NixOS/nixpkgs/commit/6ede14b0ce591cccba2d5038f1b371b3c91b52fd) xmrig: 6.25.0 -> 6.26.0, make parametrizable
* [`d1bda4a0`](https://github.com/NixOS/nixpkgs/commit/d1bda4a0056c1ab2eddaa17a9fbd9e7c071e02db) krunkit: install missing firmware
* [`4bfafef8`](https://github.com/NixOS/nixpkgs/commit/4bfafef8b4b0f34d584d1a5e22ed5c062fc172bc) krunkit: add boot regression test
* [`b4e72c54`](https://github.com/NixOS/nixpkgs/commit/b4e72c546611cc806c7b6e855e555eede13cc36c) podman-desktop: add krunkit to closure on darwin
* [`26d180ea`](https://github.com/NixOS/nixpkgs/commit/26d180eac2014aa909faf0168eda40e25d5bf860) cope: unbreak
* [`4b207b2a`](https://github.com/NixOS/nixpkgs/commit/4b207b2ad9d4d7c7ea8cddd47be520a42cefce7c) python3Packages.pytenable: 1.9.1 -> 26.5.1
* [`b7558138`](https://github.com/NixOS/nixpkgs/commit/b755813867a8bf91180c773d731c98754e4247ab) raspberrypifw: 1.20250430 -> 1.20260521
* [`be329780`](https://github.com/NixOS/nixpkgs/commit/be32978058f024f0d5bb329a0e0831ea75992e1f) organicmaps: 2026.01.26-11 -> 2026.05.27-11, devendor dependencies
* [`687b46d1`](https://github.com/NixOS/nixpkgs/commit/687b46d1eb812daa171c8ca858575de65b762b24) maintainers: add dshatz
* [`ff928226`](https://github.com/NixOS/nixpkgs/commit/ff928226bc70c0425a52a54be8a4d9fcb5e9583d) lyricspot: init at 2.0.0
* [`9f49d219`](https://github.com/NixOS/nixpkgs/commit/9f49d219bfcd63b65f724005e322b0b85cd81809) python3Packages.adbutils: init at 2.12.0
* [`f983beed`](https://github.com/NixOS/nixpkgs/commit/f983beed685b64db591e5c36dd053678813b5da1) revive: 1.11.0 -> 1.15.0
* [`f1c02cad`](https://github.com/NixOS/nixpkgs/commit/f1c02cad9633c6b29178ddb06a0ece2c286eed5c) maintainers: add benhaskins
* [`8e714dad`](https://github.com/NixOS/nixpkgs/commit/8e714dad857f4c01d77483dbf193557ec325e22e) positron-bin: 2026.02.1-5 -> 2026.06.0-211
* [`e07c093c`](https://github.com/NixOS/nixpkgs/commit/e07c093cea4fbe4fabebbd8c9d51b5bc7b2e3a6b) maintainers: add yarn
* [`cad2211b`](https://github.com/NixOS/nixpkgs/commit/cad2211b674138cd22d9b21f539ec77834ab926d) kotofetch: init at 0.2.22
* [`0432f5e6`](https://github.com/NixOS/nixpkgs/commit/0432f5e6f3f446ee1cdd38eee728f8681be98068) graphite-cli: 1.7.20 -> 1.8.6
* [`6494aa1d`](https://github.com/NixOS/nixpkgs/commit/6494aa1de64ad0b150b19a520b851fb6b8f4022f) nushellPlugins.bson: 26.1100.0 -> 26.1130.0
* [`0ad9a4ab`](https://github.com/NixOS/nixpkgs/commit/0ad9a4ab539769ec8575642b3c5bbdd515554785) pkgit: init at 0.0.11
* [`765a316f`](https://github.com/NixOS/nixpkgs/commit/765a316fe16c765d4a283b1bcd99158f04c5daf6) recordbox: add gst_all_1.gst-libav
* [`0a03e5ae`](https://github.com/NixOS/nixpkgs/commit/0a03e5aed7e17b67732b5ca9f036b6fb193863ce) nixos/incus: add storage.truenas.enable option
* [`4ee4fa98`](https://github.com/NixOS/nixpkgs/commit/4ee4fa98d522ccea580c0afafaf20ddec45c81f7) bacnet-stack: 1.3.5 -> 1.5.0
* [`2739ab05`](https://github.com/NixOS/nixpkgs/commit/2739ab054777da5331c8baf408870d7967a195cb) cri-o-unwrapped: 1.36.0 -> 1.36.1
* [`403f212c`](https://github.com/NixOS/nixpkgs/commit/403f212cbdd18e328a7778f796ae950cc88a5968) itch: 26.9.0 -> 26.13.0
* [`d4934647`](https://github.com/NixOS/nixpkgs/commit/d49346473a815901ad6afb9ad5b9070dc50540d1) maintainers: add kinnrai
* [`81a56518`](https://github.com/NixOS/nixpkgs/commit/81a56518803e6b148ed80039e0358265a752194a) swipeaerospace: init at 0.3.0
* [`d9d779c2`](https://github.com/NixOS/nixpkgs/commit/d9d779c24d5b16f2c6da23c8fdd57e93c58a903e) nixos/adguardhome: fix shellcheck error in pre-start script
* [`e78eaae7`](https://github.com/NixOS/nixpkgs/commit/e78eaae751288fc13167dbad17f087a032a895bd) python3Packages.pysunspec2: 1.3.5 -> 1.3.6
* [`48524bb8`](https://github.com/NixOS/nixpkgs/commit/48524bb89dedeecd83ff9afb59894d10be997dac) fedistar: 1.13.0 -> 1.13.1
* [`6a6430d9`](https://github.com/NixOS/nixpkgs/commit/6a6430d96b54e6c50c0e64b5b3adbb810a04317f) python3Packages.pysunspec2: migrate to finalAttrs
* [`3629ab97`](https://github.com/NixOS/nixpkgs/commit/3629ab97a9e28d35485ae66397275c739fb91baa) maintainers: add fstracke
* [`b5b1b487`](https://github.com/NixOS/nixpkgs/commit/b5b1b487dea951e7dc28115bd74994962390647f) python3Packages.baselines: migrate to pyproject
* [`f3de1810`](https://github.com/NixOS/nixpkgs/commit/f3de18104755bec9584f6f836aa436122cff1d1a) python3Packages.baselines: modernize
* [`2c3f6afe`](https://github.com/NixOS/nixpkgs/commit/2c3f6afeb286fca3e8d4ce45d281899234ac75cc) python3Packages.bleach-allowlist: migrate to pyproject
* [`8ab3a9d7`](https://github.com/NixOS/nixpkgs/commit/8ab3a9d763e8edbfb764ec2153d7f9b8c9f2ce73) python3Packages.bleach-allowlist: modernize
* [`b0669eff`](https://github.com/NixOS/nixpkgs/commit/b0669effd647b04b2ab8af85805f8700f716b170) jan: 0.7.9 -> 0.8.2
* [`e65099c8`](https://github.com/NixOS/nixpkgs/commit/e65099c8f1691d30aa513c7fd272c562d318eb0f) python3Packages.bsdiff4: migrate to pyproject
* [`76f4d9ea`](https://github.com/NixOS/nixpkgs/commit/76f4d9eabd0758101de7bcbacead1317fd0b946c) python3Packages.bottleneck: migrate to pyproject
* [`a9be4d8f`](https://github.com/NixOS/nixpkgs/commit/a9be4d8f3cf5a734a7830e3fb553ade8b957383a) python3Packages.bsdiff4: modernize
* [`dd6067b1`](https://github.com/NixOS/nixpkgs/commit/dd6067b1f2d8089f6967b8d05b995ec378480368) python3Packages.bottleneck: modernize
* [`6874b4a2`](https://github.com/NixOS/nixpkgs/commit/6874b4a20df56ed9268db249144ded5f6d75aefc) python3Packages.bottleneck: re-enable previously-disabled tests
* [`d20c1190`](https://github.com/NixOS/nixpkgs/commit/d20c11908887cf4ffc2ffd42091799d4848d0a8f) mcat-unwrapped: 0.6.1 -> 0.6.2
* [`aaf67a70`](https://github.com/NixOS/nixpkgs/commit/aaf67a701840cc21acb39f0cd8a2e9b0b2f0fd5e) maintainers: add voidlily
* [`65500922`](https://github.com/NixOS/nixpkgs/commit/65500922f1d8813e226347072782fcf97bc1f8ed) stakk: init at 1.15.0
* [`a70a17a2`](https://github.com/NixOS/nixpkgs/commit/a70a17a293844ab256638058accfee8e83b2dee0) termius: 9.36.2 -> 9.39.0
* [`9cfffc01`](https://github.com/NixOS/nixpkgs/commit/9cfffc01fb075d79d9d63084b07933906ca407e9) python3Packages.clean-fid: migrate to pyproject
* [`8724b8cd`](https://github.com/NixOS/nixpkgs/commit/8724b8cd53b3f8ef3e7ed1e5969efb144c9b4195) python3Packages.clean-fid: modernize
* [`4996773c`](https://github.com/NixOS/nixpkgs/commit/4996773caf9ff946bf6393755e5f8aaec8559e37) mariadb-galera: 26.4.24 -> 26.4.27
* [`03dbe79b`](https://github.com/NixOS/nixpkgs/commit/03dbe79b7aa06a9084bd7f0acb70a2c9da9ece48) maintainers: add different-error
* [`9524d71b`](https://github.com/NixOS/nixpkgs/commit/9524d71bd77c4022ed7d1329344e6870f1155851) extism-js-core: mark as broken on darwin
* [`b4b662eb`](https://github.com/NixOS/nixpkgs/commit/b4b662eb6e280b12e6d19084c37184979e7b2b7a) cliflux: 1.9.1 -> 1.10.0, migrate to codeberg.org
* [`a4d0b6d4`](https://github.com/NixOS/nixpkgs/commit/a4d0b6d4eb2a66467a9bc5270f3e3de196ee7674) sunsama: 3.1.1 -> 3.4.6
* [`d81d1a7f`](https://github.com/NixOS/nixpkgs/commit/d81d1a7fd6a6a6fa90184835badc7fd5d1dd25a2) syncthing: set meta.donationPage
* [`d7925a95`](https://github.com/NixOS/nixpkgs/commit/d7925a9590a47a6267f558fc273109c616ca7263) thunderbird{-bin}: set meta.donationPage; update meta.homepage
* [`1a52daf3`](https://github.com/NixOS/nixpkgs/commit/1a52daf3e7f0e2fe14125de11602b5dae7eeaf78) shelter: init at 0-unstable-2026-06-05
* [`82c1517e`](https://github.com/NixOS/nixpkgs/commit/82c1517ecf9d2bbbf14a18b73e7cdc19ca0ba605) dorion: use shelter from nixpkgs
* [`4804ea1a`](https://github.com/NixOS/nixpkgs/commit/4804ea1ac70ccc7580a12b28f9a52621adc06ce9) fail2ban: revert fix for dovecot filter's journalmatch
* [`439e1a48`](https://github.com/NixOS/nixpkgs/commit/439e1a48e981691121c07b15602349f796a41df4) taisei: added changelog
* [`ac6d3384`](https://github.com/NixOS/nixpkgs/commit/ac6d3384c55f78c45d819ada9f5e92c84ef89601) taisei: fix darwin build
* [`e9394667`](https://github.com/NixOS/nixpkgs/commit/e9394667ae03f4640f004f7b81c64bb38add595c) openshadinglanguage: 1.15.3.0 -> 1.15.5.0
* [`205937cd`](https://github.com/NixOS/nixpkgs/commit/205937cd5b86d3210d911e728307a464393be753) filen-desktop: refactor
* [`6b7defce`](https://github.com/NixOS/nixpkgs/commit/6b7defceaf971f16d315bfa1270683a1daac4e42) hss: 1.0.1 -> 1.1.0
* [`9911678f`](https://github.com/NixOS/nixpkgs/commit/9911678f69b5a5087b48077272b5f462935e57e3) stabber: 2020-06-08 -> 2026-03-05
* [`66092a5e`](https://github.com/NixOS/nixpkgs/commit/66092a5e1e2f7894a85ca97b8b3eeaf497ffb202) profanity: 0.17.0 -> 0.18.2
* [`809df45b`](https://github.com/NixOS/nixpkgs/commit/809df45b785db25c57d61466b92d35db0ecb4794) vwifi: 6.3-unstable-2025-02-04 -> 7.1
* [`2055a00f`](https://github.com/NixOS/nixpkgs/commit/2055a00f76a20cf118c8a357fd29a1a0bbe8e652) hue-plus: use finalAttrs, tag and hash
* [`ce632c95`](https://github.com/NixOS/nixpkgs/commit/ce632c9556a3e3e18a6eed36a049eecf442dff69) hue-plus: use mainProgram
* [`51170f88`](https://github.com/NixOS/nixpkgs/commit/51170f885ea9e7a760e3d89e915362d11daa8994) hue-plus: migrate to pyproject
* [`9d008f89`](https://github.com/NixOS/nixpkgs/commit/9d008f892012aafd2391010fe96c94452a3d39c8) hue-plus: doCheck
* [`66f38ea4`](https://github.com/NixOS/nixpkgs/commit/66f38ea435fcafe538e4cee68f1189f01348903c) python3Packages.awacs: 2.5.0 -> 2.6.0
* [`bd90f47a`](https://github.com/NixOS/nixpkgs/commit/bd90f47a4fa93b27d8f3226b4e11fe9dce237c89) python3Packages.lime: use finalAttrs
* [`f4ebcc19`](https://github.com/NixOS/nixpkgs/commit/f4ebcc196ffc4486bf209a228eb7403ebcba99b2) python3Packages.lime: enable __structuredAttrs
* [`66afda3c`](https://github.com/NixOS/nixpkgs/commit/66afda3cdafd82f35ecd504a82f7b31cfc24d680) python3Packages.lime: migrate to pyproject
* [`4888b12c`](https://github.com/NixOS/nixpkgs/commit/4888b12c8ee3ec6837d36bb0482a52f96ce6b447) python3Packages.lime: disable flaky test
* [`aaaa7e88`](https://github.com/NixOS/nixpkgs/commit/aaaa7e8879388216f383800830aaeb0825bd6d57) node-red: 4.1.8 -> 5.0.0
* [`204daa86`](https://github.com/NixOS/nixpkgs/commit/204daa866443f18e1e23cf59433acf29452f5e32) openrsync: add update script
* [`6df24e2b`](https://github.com/NixOS/nixpkgs/commit/6df24e2bafcb61b580223e734bcefca694de959f) openrsync: unstable-2025-01-27 -> 0.5.0-unstable-2026-05-31
* [`561f7bb9`](https://github.com/NixOS/nixpkgs/commit/561f7bb9c92738f28b649a75998ef00d95e67a83) openrsync: modernize
* [`5c1cfd99`](https://github.com/NixOS/nixpkgs/commit/5c1cfd9941141b1fda0331cc3f32f64e77f442c7) codegraph: init at 0.9.9
* [`b73c42bf`](https://github.com/NixOS/nixpkgs/commit/b73c42bfa51a2be3fe1b915a3b66d45a8b3bed4c) nixosTests.accountsservice: init
* [`3817d2eb`](https://github.com/NixOS/nixpkgs/commit/3817d2eb24080c7ff09c852442fe451b453b55ec) rpcs3: override glew to disable EGL
* [`070895c8`](https://github.com/NixOS/nixpkgs/commit/070895c80ff68f31681c976005218c36c2fb04a3) python3Packages.zict: disable one test
* [`785d3609`](https://github.com/NixOS/nixpkgs/commit/785d3609240bbe07e5b6ad5b0d8e702b4d94f95d) kip: init at 0.15.0
* [`2832d2b0`](https://github.com/NixOS/nixpkgs/commit/2832d2b0f583112f9a308b7d5858e0f3a77d5069) jellyfin: fix reproducibility of build timestamp leaking into output
* [`9c0c9517`](https://github.com/NixOS/nixpkgs/commit/9c0c9517bbcd8b04cdc039172ad7c52e0760b68b) thokr: modernize
* [`a18ad235`](https://github.com/NixOS/nixpkgs/commit/a18ad235233782fb607c7d711132fe3bf89b665b) thokr: add aiyion as maintainer
* [`a742a240`](https://github.com/NixOS/nixpkgs/commit/a742a240a73e990caf58c5c3b768c9e53807d6be) doc/javascript.section: recommend fetcherVersion 4
* [`d8365777`](https://github.com/NixOS/nixpkgs/commit/d836577704ed3521adcab4991711738561c6d103) nixos/cloudflared: add per-tunnel protocol option
* [`34e7918c`](https://github.com/NixOS/nixpkgs/commit/34e7918c86322476f4308b98a0b7232a476a2d78) freeradius: 3.2.8 -> 3.2.10
* [`aaf0d6f6`](https://github.com/NixOS/nixpkgs/commit/aaf0d6f6d9ce78f8e5226c7ad9eb8e66d7263391) vimhjkl: init at 0.5.1
* [`96bff117`](https://github.com/NixOS/nixpkgs/commit/96bff11764d44c7206e043b2c55b7446a9841232) maintainers: add dfjay
* [`037cb5b6`](https://github.com/NixOS/nixpkgs/commit/037cb5b6fd9ab6b69ee43cf30432cc96cbe923a7) jan: add dfjay as maintainer
* [`2668e515`](https://github.com/NixOS/nixpkgs/commit/2668e51569910b4bdb50d908e59ee2092af91cdc) flix: 0.69.1 -> 0.73.0
* [`78fc2c83`](https://github.com/NixOS/nixpkgs/commit/78fc2c830d9f21e81d32f951e7653ae34b408a61) python3Packages.parselmouth: disable test
* [`5faa73af`](https://github.com/NixOS/nixpkgs/commit/5faa73af1db4258328925792ed56e2204c9a181d) sssd: 2.13.0 -> 2.13.1
* [`9b4856af`](https://github.com/NixOS/nixpkgs/commit/9b4856af471db1e7eaff9486c5dcccd53d287454) logic2-automation: init at 1.0.11
* [`c0993ded`](https://github.com/NixOS/nixpkgs/commit/c0993dedbbd35cef78122fbbbdfa50596260d873) zed-wakatime-ls: init at 0.1.10
* [`72cc0a0c`](https://github.com/NixOS/nixpkgs/commit/72cc0a0cd15c387c362a605256fa9d19d0425421) mdbook-linkcheck2: 0.12.0 -> 0.12.2
* [`32c2e0c6`](https://github.com/NixOS/nixpkgs/commit/32c2e0c69e9d94aea52801fbde839175a1749215) flutter: enable strict deps and structured attrs
* [`245d2209`](https://github.com/NixOS/nixpkgs/commit/245d220928cc72aa59f9147c1338df587d1cc49f) shantell-sans: init at 1.011
* [`30ac03c4`](https://github.com/NixOS/nixpkgs/commit/30ac03c4b20278f6b2d2d2b6ee4b1323baa3acd6) scid: fix the build after `enable stubs by default` change
* [`0e99d673`](https://github.com/NixOS/nixpkgs/commit/0e99d67346ae2ca90cfdd9ac01918f31876919ac) backintime-qt: don't inherit `meta`
* [`f236e945`](https://github.com/NixOS/nixpkgs/commit/f236e94578fe2b0367afa54cd569b89f1268a410) backintime-common: split `doc` & `man` outputs
* [`be6a0d69`](https://github.com/NixOS/nixpkgs/commit/be6a0d69f7b7c946454942fd1a25cb6c645e0ab5) backintime-common: `__structuredAttrs`, `strictDeps`, `enableParallelBuilding`
* [`fd7b9a85`](https://github.com/NixOS/nixpkgs/commit/fd7b9a8554e535c13ecb2fb1c41fbb765a9b0a30) maintainers: add justkrysteq
* [`74a7a22e`](https://github.com/NixOS/nixpkgs/commit/74a7a22ea1d26fec31df5205e2af0a78f62ef375) aws-lc: generate Rust bindings
* [`7ecbcdbc`](https://github.com/NixOS/nixpkgs/commit/7ecbcdbc955c65bebcfd6bd187d0f75840ed5493) libetpan: 1.10 -> 1.10.1
* [`71f1c075`](https://github.com/NixOS/nixpkgs/commit/71f1c075231ceb3e1ea27f69d91437312176df6f) python3Packages.clean-fid: move to better homepage + add downloadPage
* [`247e161d`](https://github.com/NixOS/nixpkgs/commit/247e161da4380bb126b020e9bd61c88e210ab7fa) dae: 1.0.0 -> 1.1.0
* [`42b3aa13`](https://github.com/NixOS/nixpkgs/commit/42b3aa135718e754c00d66456dc68903927cffb8) lemmy: update documentation
* [`9ce8e7b0`](https://github.com/NixOS/nixpkgs/commit/9ce8e7b037af487005483c304885da209bed8810) nvs: 1.12.1 -> 1.14.0
* [`c20f86c3`](https://github.com/NixOS/nixpkgs/commit/c20f86c3286dd6c954054e0bde74ba31e5e9e461) privoxy: migrate to by-name
* [`6baa82fa`](https://github.com/NixOS/nixpkgs/commit/6baa82facdcc22b6b63c8da1e191a690ab3cdb85) spoofer-gui: migrate to by-name
* [`4eeb359f`](https://github.com/NixOS/nixpkgs/commit/4eeb359f65cdff75c10207770d59021b2e0ad648) spoofer: migrate to by-name
* [`50f2a13e`](https://github.com/NixOS/nixpkgs/commit/50f2a13e49a21c2a6d017c7813970b27debcd863) mir-qualia: migrate to by-name
* [`1aa08524`](https://github.com/NixOS/nixpkgs/commit/1aa08524d6282b64ffcef7e1aaa9b15aac748cb7) openconnect{,_openssl}: migrate to by-name
* [`2d839f48`](https://github.com/NixOS/nixpkgs/commit/2d839f48efe00f8a42b2b99a42e4c1378caa238a) apc-temp-fetch: migrate to by-name
* [`a591bc84`](https://github.com/NixOS/nixpkgs/commit/a591bc846de9c37d2a9dec896325d48d81b5d4c0) knock: init at 0.0.2 by migrating to by-name
* [`a8a39fcf`](https://github.com/NixOS/nixpkgs/commit/a8a39fcfb3483f7a9df3cb38c4f2e9d9792fc272) rmlint: migrate to by-name
* [`831c33cd`](https://github.com/NixOS/nixpkgs/commit/831c33cd715f0698f35cfbd6d9a2a0747f55462d) curaengine_stable: migrate to by-name
* [`8438e7f8`](https://github.com/NixOS/nixpkgs/commit/8438e7f8db1205b30aacff3627b829128cd818b2) attempto-clex: migrate to by-name
* [`8e530800`](https://github.com/NixOS/nixpkgs/commit/8e530800899d1757f87155f1d3d801e86adc6e1e) shogun: migrate to by-name
* [`5e211460`](https://github.com/NixOS/nixpkgs/commit/5e211460be6ee2721a940a8c06053b1f5c32aad2) cubicle: migrate to by-name
* [`092b433c`](https://github.com/NixOS/nixpkgs/commit/092b433c333ba418d4bde633f4630bd2e1a02a05) statverif: migrae to by-name
* [`c88ffd2d`](https://github.com/NixOS/nixpkgs/commit/c88ffd2d5f6bf91a4d0525d10d93871edb604101) tamarin-prover: migrate to by-name
* [`dae9680c`](https://github.com/NixOS/nixpkgs/commit/dae9680cc0f379b96004939ab114f989d67852b4) satallax: migrate to by-name
* [`89526200`](https://github.com/NixOS/nixpkgs/commit/89526200b42ce72de8973bb2efb98d21c0fb74e3) homepage-dashboard: 1.13.1 -> 1.13.2
* [`f7d1edf6`](https://github.com/NixOS/nixpkgs/commit/f7d1edf68ecb911b85719d15547fdab08641df52) bkyml: drop
* [`658f16c1`](https://github.com/NixOS/nixpkgs/commit/658f16c12667eaf0ff165b1f203a876005340765) handheld-daemon: 4.1.9 -> 4.1.10
* [`44b0aef1`](https://github.com/NixOS/nixpkgs/commit/44b0aef16cfc9fe6812e95550cc667f53880c7fb) zabbix-cli: 3.6.2 -> 3.6.3
* [`913133b2`](https://github.com/NixOS/nixpkgs/commit/913133b2f2a935cb5b59300010f50fdfbb8d3f4c) rust-analyzer-unwrapped: 2026-06-01 -> 2026-06-15
* [`49b87c1c`](https://github.com/NixOS/nixpkgs/commit/49b87c1c96e2a444e03d979d8d1dc7e3a00767f5) rasqal: remove erroned attribute
* [`887dddbb`](https://github.com/NixOS/nixpkgs/commit/887dddbb10fdd5379c12d39f42a9d1698de34985) python3Packages.archspec: remove erroned attribute
* [`ae4069a9`](https://github.com/NixOS/nixpkgs/commit/ae4069a9b53372efa3355f8abb7fef9287c4a319) graalvmPackages: update to 25.0.3
* [`c90ab902`](https://github.com/NixOS/nixpkgs/commit/c90ab90243eebc7ee04f18bd8f6dd4b87e5b51a3) maintainers: add ELHart05
* [`56a0ea24`](https://github.com/NixOS/nixpkgs/commit/56a0ea2486c081729d57e99535cb3fb624ef266a) syncpack: init at 15.3.2
* [`7db3d861`](https://github.com/NixOS/nixpkgs/commit/7db3d8617a49f81f61b452bfd248aa198a1e20e7) fetchFromSourcehut: expose tag in derivation attrs
* [`9fd63d7c`](https://github.com/NixOS/nixpkgs/commit/9fd63d7c6baedb1bb1eca7e43698bf52e5a5c665) python3Packages.git-revise: 0.7.0-unstable-2025-01-28 -> 0.8.0
* [`935a49e9`](https://github.com/NixOS/nixpkgs/commit/935a49e91c0ee8f8a48fb68f7618986f5bc232d9) nitter: 0-unstable-2026-01-29 -> 0-unstable-2026-06-16
* [`3cc7a811`](https://github.com/NixOS/nixpkgs/commit/3cc7a811a7db00c90ba3845b9267a64048c063c7) flyway: 12.0.0 -> 12.8.1
* [`339fd804`](https://github.com/NixOS/nixpkgs/commit/339fd804110234f34ea4561a11fd6f5481076347) rnmon: init at 0.3.4
* [`a6082955`](https://github.com/NixOS/nixpkgs/commit/a60829559ccf753d2012250047f22d72f8ef5b2c) dotnet-ef: 10.0.2 -> 10.0.9
* [`d21f72ab`](https://github.com/NixOS/nixpkgs/commit/d21f72abf4050c40bdf4a60afe0f49a8b94f44b6) nixos/sabnzbd: offload config format to pkgs.formats.configobj
* [`5eaeb473`](https://github.com/NixOS/nixpkgs/commit/5eaeb47340df725060cef31fa120bbfda0fd9fa2) coqPackages.aac-tactics: modernize mkCoqDerivation release hash format
* [`e81aa9a3`](https://github.com/NixOS/nixpkgs/commit/e81aa9a3cf9ad997907ddf3180ed599339d7529c) coqPackages.addition-chains: modernize mkCoqDerivation release hash format
* [`731a7b09`](https://github.com/NixOS/nixpkgs/commit/731a7b0994a1dfc16737167d47605a921abd9346) coqPackages.async-test: modernize mkCoqDerivation release hash format
* [`bf203cad`](https://github.com/NixOS/nixpkgs/commit/bf203cad2a2bb6b3a7ffa43aad51819f56c1c09b) coqPackages.atbr: modernize mkCoqDerivation release hash format
* [`a986951c`](https://github.com/NixOS/nixpkgs/commit/a986951c3a719c6ae468524d9710fa8397f72328) coqPackages.autosubst-ocaml: modernize mkCoqDerivation release hash format
* [`c94a5014`](https://github.com/NixOS/nixpkgs/commit/c94a50148924872553e9ba7d62da1ecf13f7334a) coqPackages.autosubst: modernize mkCoqDerivation release hash format
* [`24bd0856`](https://github.com/NixOS/nixpkgs/commit/24bd08564f1d06d0d3ea75f78e8a48826c32eb8c) coqPackages.bbv: modernize mkCoqDerivation release hash format
* [`967d6efa`](https://github.com/NixOS/nixpkgs/commit/967d6efae4abf29d73715519f91f06b808ee4b86) coqPackages.bignums: modernize mkCoqDerivation release hash format
* [`f652c7f1`](https://github.com/NixOS/nixpkgs/commit/f652c7f1fb441157f77760d18997664a5dda71ca) coqPackages.CakeMLExtraction: modernize mkCoqDerivation release hash format
* [`2896c5c1`](https://github.com/NixOS/nixpkgs/commit/2896c5c13b7679d8cc2aab2bf565c26dc1e0a2a3) coqPackages.category-theory: modernize mkCoqDerivation release hash format
* [`1cef0cb1`](https://github.com/NixOS/nixpkgs/commit/1cef0cb18d5ad62019c03da30fe6c9cb21dc54d7) coqPackages.ceres-bs: modernize mkCoqDerivation release hash format
* [`daf9b16b`](https://github.com/NixOS/nixpkgs/commit/daf9b16b13eb175e98f44afedaf441895c1bf1f8) coqPackages.ceres: modernize mkCoqDerivation release hash format
* [`4915373d`](https://github.com/NixOS/nixpkgs/commit/4915373d76d7322f0c9456e7b238de98abdca7bc) coqPackages.CertiRocq: modernize mkCoqDerivation release hash format
* [`523653be`](https://github.com/NixOS/nixpkgs/commit/523653be9790307594ca08a07671004de80bb9d8) coqPackages.Cheerios: modernize mkCoqDerivation release hash format
* [`80cc0d0e`](https://github.com/NixOS/nixpkgs/commit/80cc0d0eb744902cec080dedbdff2bc6f6b74448) coqPackages.coinduction: modernize mkCoqDerivation release hash format
* [`0a448e2e`](https://github.com/NixOS/nixpkgs/commit/0a448e2ebbbe6fde6154fa3a60a693fe28862657) coqPackages.CoLoR: modernize mkCoqDerivation release hash format
* [`91930ffa`](https://github.com/NixOS/nixpkgs/commit/91930ffa4d9cd0ce18463e56351fb1ff6b57b66a) pothos: drop
* [`8cfef789`](https://github.com/NixOS/nixpkgs/commit/8cfef789b34885028009f3e03927a835260e8f03) coqPackages.compcert: modernize mkCoqDerivation release hash format
* [`1e27971d`](https://github.com/NixOS/nixpkgs/commit/1e27971d483117c52f6b7a182c167c5bf14aef92) coqPackages.ConCert: modernize mkCoqDerivation release hash format
* [`a0b18667`](https://github.com/NixOS/nixpkgs/commit/a0b18667f53bb00861e18c27202eff1d62897c8b) coqPackages.coq-bits: modernize mkCoqDerivation release hash format
* [`ef400b2d`](https://github.com/NixOS/nixpkgs/commit/ef400b2de933c0ca009b4db4b49b1974dbe91fe1) coqPackages.coq-elpi: modernize mkCoqDerivation release hash format
* [`3146d6f0`](https://github.com/NixOS/nixpkgs/commit/3146d6f0703e599c19e7fa8f20106d9052d5f763) coqPackages.coq-hammer-tactics: modernize mkCoqDerivation release hash format
* [`f5b91479`](https://github.com/NixOS/nixpkgs/commit/f5b9147921279fbb40ebded80367a66f2aeadf1e) coqPackages.coq-haskell: modernize mkCoqDerivation release hash format
* [`217f63ec`](https://github.com/NixOS/nixpkgs/commit/217f63ec6bb2fbf63e8c64da9ce0c9bbc42ede75) coqPackages.coq-lsp: modernize mkCoqDerivation release hash format
* [`4f0f37bc`](https://github.com/NixOS/nixpkgs/commit/4f0f37bcbc0bf819b4bc4f29b7e96cba0eda16b5) coqPackages.CoqMatrix: modernize mkCoqDerivation release hash format
* [`077d45d3`](https://github.com/NixOS/nixpkgs/commit/077d45d30b8b950ffedaa55bcfef69ef4c83e5e1) coqPackages.coq-record-update: modernize mkCoqDerivation release hash format
* [`6a728a7e`](https://github.com/NixOS/nixpkgs/commit/6a728a7eea470fe65b075601fa66ff29eb5cef19) coqPackages.coq-tactical: modernize mkCoqDerivation release hash format
* [`a4b34ff8`](https://github.com/NixOS/nixpkgs/commit/a4b34ff8c3a2d761a170056fd9cc4856d8ed1373) coqPackages.coqeal: modernize mkCoqDerivation release hash format
* [`4541dd71`](https://github.com/NixOS/nixpkgs/commit/4541dd71edc60ac91bc0e4f55dfebb38e8bac8be) coqPackages.coqfmt: modernize mkCoqDerivation release hash format
* [`46e6fe18`](https://github.com/NixOS/nixpkgs/commit/46e6fe186b98b57c3e6f57fbd923a3b0c7b48c8d) coqPackages.coqhammer: modernize mkCoqDerivation release hash format
* [`cb652af1`](https://github.com/NixOS/nixpkgs/commit/cb652af10b0f5e086bf856dc178e164a85713fe3) coqPackages.coqprime: modernize mkCoqDerivation release hash format
* [`d496653b`](https://github.com/NixOS/nixpkgs/commit/d496653b3d9f8ba48b04b8dc1c1dfdd363ba9ba0) coqPackages.coqtail-math: modernize mkCoqDerivation release hash format
* [`92a18471`](https://github.com/NixOS/nixpkgs/commit/92a184718c7773b2ab24bad473a9d509fb264c51) coqPackages.coquelicot: modernize mkCoqDerivation release hash format
* [`3730ba92`](https://github.com/NixOS/nixpkgs/commit/3730ba921c8b5859ddfa78196a69fb715e5da597) coqPackages.coqutil: modernize mkCoqDerivation release hash format
* [`13b98ceb`](https://github.com/NixOS/nixpkgs/commit/13b98ceb6d1bfec87da50c9e1b9ba7a1ffc5c45f) coqPackages.corn: modernize mkCoqDerivation release hash format
* [`d3abdfc7`](https://github.com/NixOS/nixpkgs/commit/d3abdfc7ca6d9952368817d827baf1bafebbe870) coqPackages.deriving: modernize mkCoqDerivation release hash format
* [`4e17bea8`](https://github.com/NixOS/nixpkgs/commit/4e17bea8a527166181f0e6898e7817bb657ebd5e) coqPackages.dpdgraph: modernize mkCoqDerivation release hash format
* [`3612ccd7`](https://github.com/NixOS/nixpkgs/commit/3612ccd7190fc5b1a2c45278f900651430aae3f7) coqPackages.ElmExtraction: modernize mkCoqDerivation release hash format
* [`b53de1d3`](https://github.com/NixOS/nixpkgs/commit/b53de1d3309a17ea8f6a5d979ddad453cbc29f8c) coqPackages.equations: modernize mkCoqDerivation release hash format
* [`fee3983b`](https://github.com/NixOS/nixpkgs/commit/fee3983be5e40a7fcb1236af39a9e9560b49274f) coqPackages.ExtLib: modernize mkCoqDerivation release hash format
* [`acb5cdf7`](https://github.com/NixOS/nixpkgs/commit/acb5cdf7e3bf756de5c4c39e63bc13e5f22f16c8) coqPackages.extructures: modernize mkCoqDerivation release hash format
* [`8e6115f9`](https://github.com/NixOS/nixpkgs/commit/8e6115f919704e7b71dd4cf464f270bb059766c7) coqPackages.fcsl-pcm: modernize mkCoqDerivation release hash format
* [`5914e2ae`](https://github.com/NixOS/nixpkgs/commit/5914e2aecffbd59840711e629ef95387a6a610da) coqPackages.flocq: modernize mkCoqDerivation release hash format
* [`b153e366`](https://github.com/NixOS/nixpkgs/commit/b153e366c1bac9f57fb7b6209753a46e49e8a568) coqPackages.fourcolor: modernize mkCoqDerivation release hash format
* [`9894ad3e`](https://github.com/NixOS/nixpkgs/commit/9894ad3e50294ea2f6821ad7c3f2d7dd6de85aed) coqPackages.gaia-hydras: modernize mkCoqDerivation release hash format
* [`5a28392b`](https://github.com/NixOS/nixpkgs/commit/5a28392bc3821d7705beb4f0c5900d5f40d35aff) coqPackages.gaia: modernize mkCoqDerivation release hash format
* [`c23cb265`](https://github.com/NixOS/nixpkgs/commit/c23cb265c59df5dfc156554ce65b4ddc9e3e8746) coqPackages.gappalib: modernize mkCoqDerivation release hash format
* [`10a97234`](https://github.com/NixOS/nixpkgs/commit/10a972341157726c2e4ccb2c8d3e494f697a3e8c) coqPackages.goedel: modernize mkCoqDerivation release hash format
* [`b1dbcbb9`](https://github.com/NixOS/nixpkgs/commit/b1dbcbb9e3576d7d1bb4136005440fd9102ee14a) coqPackages.graph-theory: modernize mkCoqDerivation release hash format
* [`d54dca5d`](https://github.com/NixOS/nixpkgs/commit/d54dca5dd980588e3200569937569d2e975477a3) maintainers: add wjohnsto
* [`bf839fea`](https://github.com/NixOS/nixpkgs/commit/bf839fea4887bebe9cf2455ee953b2adae1139ac) coqPackages.heq: modernize mkCoqDerivation release hash format
* [`74ccd3b2`](https://github.com/NixOS/nixpkgs/commit/74ccd3b2dd4ff6df3dc432541dc8fcc40474b763) coqPackages.hierarchy-builder: modernize mkCoqDerivation release hash format
* [`533ca2fd`](https://github.com/NixOS/nixpkgs/commit/533ca2fd89567d239b81204f969389b63d5efed7) coqPackages.high-school-geometry: modernize mkCoqDerivation release hash format
* [`b13fcebd`](https://github.com/NixOS/nixpkgs/commit/b13fcebdd0ae5b61f769488d8d0fb3f3bc00aae2) coqPackages.HoTT: modernize mkCoqDerivation release hash format
* [`08b3fb32`](https://github.com/NixOS/nixpkgs/commit/08b3fb32064320c6278ba6248fdaeca87e1d4522) coqPackages.http: modernize mkCoqDerivation release hash format
* [`fe02b1d3`](https://github.com/NixOS/nixpkgs/commit/fe02b1d3cd975e05ed7a61a6d29520602dc97287) coqPackages.hydra-battles: modernize mkCoqDerivation release hash format
* [`fdaa8f59`](https://github.com/NixOS/nixpkgs/commit/fdaa8f59a28f78fc9c8c1e69177f2d8702af9fed) coqPackages.InfSeqExt: modernize mkCoqDerivation release hash format
* [`4a84c62f`](https://github.com/NixOS/nixpkgs/commit/4a84c62ffb33f7dae180def1744f1e655b4b68b3) coqPackages.interval: modernize mkCoqDerivation release hash format
* [`5a97fea7`](https://github.com/NixOS/nixpkgs/commit/5a97fea75478e40583150dcaba328866df2175db) coqPackages.iris-named-props: modernize mkCoqDerivation release hash format
* [`13eda00a`](https://github.com/NixOS/nixpkgs/commit/13eda00ab789fd59fda9e0dffe35a16b6411509e) coqPackages.iris: modernize mkCoqDerivation release hash format
* [`f9f0f9ac`](https://github.com/NixOS/nixpkgs/commit/f9f0f9acfa89fc168fc47c85414578381f90393d) coqPackages.itauto: modernize mkCoqDerivation release hash format
* [`6b7f2d1b`](https://github.com/NixOS/nixpkgs/commit/6b7f2d1bdfc20652e94d7ef3f4037b98ede9fc26) coqPackages.itree-io: modernize mkCoqDerivation release hash format
* [`2e9005d0`](https://github.com/NixOS/nixpkgs/commit/2e9005d061072903cd07f9636bc9b6f4a9c6bb03) coqPackages.ITree: modernize mkCoqDerivation release hash format
* [`ebf177f7`](https://github.com/NixOS/nixpkgs/commit/ebf177f72ff432273058a564179b00adefe61d46) coqPackages.jasmin: modernize mkCoqDerivation release hash format
* [`8c3394af`](https://github.com/NixOS/nixpkgs/commit/8c3394af13cd1ef7e57a9818677e4546a4fed4e8) coqPackages.json: modernize mkCoqDerivation release hash format
* [`88b2189a`](https://github.com/NixOS/nixpkgs/commit/88b2189a357f591025e9db1726375a146de79fe4) coqPackages.lemma-overloading: modernize mkCoqDerivation release hash format
* [`16ff2901`](https://github.com/NixOS/nixpkgs/commit/16ff2901b55f989a59d5d2a66b3cb88c21f225af) coqPackages.LibHyps: modernize mkCoqDerivation release hash format
* [`727a946e`](https://github.com/NixOS/nixpkgs/commit/727a946e3cac563634891ff2b5c3f6209882db5e) coqPackages.ltac2: modernize mkCoqDerivation release hash format
* [`66b27564`](https://github.com/NixOS/nixpkgs/commit/66b275646ef6f921d1297c3eb6c6f51bcccfae59) coqPackages.math-classes: modernize mkCoqDerivation release hash format
* [`a1c9258b`](https://github.com/NixOS/nixpkgs/commit/a1c9258b45a9bd4b78bd4a00aa967e6a58fb5dc9) coqPackages.mathcomp-abel: modernize mkCoqDerivation release hash format
* [`bf09bdd6`](https://github.com/NixOS/nixpkgs/commit/bf09bdd606a59f6561a8fe05cf600f50f4a6ed9c) coqPackages.mathcomp-algebra-tactics: modernize mkCoqDerivation release hash format
* [`ccefd47c`](https://github.com/NixOS/nixpkgs/commit/ccefd47cbd4cab469ce00dc661e036a1ac4b02bd) coqPackages.mathcomp-analysis: modernize mkCoqDerivation release hash format
* [`b090f22d`](https://github.com/NixOS/nixpkgs/commit/b090f22d418802282b5e33b4cb5186082cb88259) coqPackages.mathcomp-apery: modernize mkCoqDerivation release hash format
* [`2606ddba`](https://github.com/NixOS/nixpkgs/commit/2606ddbaf9dcb1a48efa7f5f84f2a419e05e837f) coqPackages.mathcomp-bigenough: modernize mkCoqDerivation release hash format
* [`14f26566`](https://github.com/NixOS/nixpkgs/commit/14f265661182d2c58491bcca50df38492fb58872) coqPackages.mathcomp-finmap: modernize mkCoqDerivation release hash format
* [`7581c3b9`](https://github.com/NixOS/nixpkgs/commit/7581c3b967fb28d77336a147889b228abe4794c0) coqPackages.mathcomp-infotheo: modernize mkCoqDerivation release hash format
* [`a665ab9a`](https://github.com/NixOS/nixpkgs/commit/a665ab9a131df8597559df0d4cf43d99632f19ca) coqPackages.mathcomp-real-closed: modernize mkCoqDerivation release hash format
* [`b6d7dab2`](https://github.com/NixOS/nixpkgs/commit/b6d7dab2e51e75e23ff91ee59681fe728b36c1c3) coqPackages.mathcomp-tarjan: modernize mkCoqDerivation release hash format
* [`6738ce06`](https://github.com/NixOS/nixpkgs/commit/6738ce06701c0ada0aea49175de65dd97a35fe9b) coqPackages.mathcomp-word: modernize mkCoqDerivation release hash format
* [`ea90735c`](https://github.com/NixOS/nixpkgs/commit/ea90735c72420c59908fcce738d09b159fc8a437) coqPackages.mathcomp-zify: modernize mkCoqDerivation release hash format
* [`5e2c21a1`](https://github.com/NixOS/nixpkgs/commit/5e2c21a18f9c5807be24f0a7d6665a37dc89fa41) coqPackages.mathcomp: modernize mkCoqDerivation release hash format
* [`908d234b`](https://github.com/NixOS/nixpkgs/commit/908d234bbb1255cd5293d05f24bb9b14d0cb90c2) coqPackages.MenhirLib: modernize mkCoqDerivation release hash format
* [`079cac31`](https://github.com/NixOS/nixpkgs/commit/079cac3184494d457602514d8e7f7dcf31878251) coqPackages.metacoq: modernize mkCoqDerivation release hash format
* [`08dea0e9`](https://github.com/NixOS/nixpkgs/commit/08dea0e977496c038cbce5caa2db88a006095174) coqPackages.metalib: modernize mkCoqDerivation release hash format
* [`4c60cf69`](https://github.com/NixOS/nixpkgs/commit/4c60cf6979330c43d691ce75c8cbe8f049a235ca) coqPackages.metarocq: modernize mkCoqDerivation release hash format
* [`543e7c1e`](https://github.com/NixOS/nixpkgs/commit/543e7c1e6e06da6212a5ad7004627119b63a4704) coqPackages.mtac2: modernize mkCoqDerivation release hash format
* [`611c412e`](https://github.com/NixOS/nixpkgs/commit/611c412e17f885883ea075cf6f92c943928e86db) coqPackages.multinomials: modernize mkCoqDerivation release hash format
* [`f8b01a78`](https://github.com/NixOS/nixpkgs/commit/f8b01a78ab2159fd3289f29806b8eb25f683cfe1) coqPackages.odd-order: modernize mkCoqDerivation release hash format
* [`e1528bba`](https://github.com/NixOS/nixpkgs/commit/e1528bbab0115b4bc90294ecec60b29c097b8990) coqPackages.Ordinal: modernize mkCoqDerivation release hash format
* [`00cdb73f`](https://github.com/NixOS/nixpkgs/commit/00cdb73f9e3082252ae8a967c5b65bf97b71ca55) coqPackages.paco: modernize mkCoqDerivation release hash format
* [`a178de67`](https://github.com/NixOS/nixpkgs/commit/a178de67baac2a3822f3fbb04e176757d16ba813) coqPackages.paramcoq: modernize mkCoqDerivation release hash format
* [`049e371f`](https://github.com/NixOS/nixpkgs/commit/049e371f8953ea267a44289b3c375002ff92ffcf) coqPackages.parsec: modernize mkCoqDerivation release hash format
* [`22109292`](https://github.com/NixOS/nixpkgs/commit/22109292e280e8bd064ae07e043f82f2a90f8b52) coqPackages.parseque: modernize mkCoqDerivation release hash format
* [`434eafb2`](https://github.com/NixOS/nixpkgs/commit/434eafb298aea5ad84fbe635e8fae30391d53426) coqPackages.pocklington: modernize mkCoqDerivation release hash format
* [`9cf86897`](https://github.com/NixOS/nixpkgs/commit/9cf868977f807c588cdc22aacd5cdbc718ad00d8) coqPackages.QuickChick: modernize mkCoqDerivation release hash format
* [`7ef5c700`](https://github.com/NixOS/nixpkgs/commit/7ef5c7008e4c5123a7de7da2e1286034fdddb61e) coqPackages.reglang: modernize mkCoqDerivation release hash format
* [`7aec8dc5`](https://github.com/NixOS/nixpkgs/commit/7aec8dc57bae23777348cfeabcd0afc23b4645ea) coqPackages.relation-algebra: modernize mkCoqDerivation release hash format
* [`591803e2`](https://github.com/NixOS/nixpkgs/commit/591803e2532ee96e063b08436ee8f9d06938c75d) coqPackages.rewriter: modernize mkCoqDerivation release hash format
* [`81c69e09`](https://github.com/NixOS/nixpkgs/commit/81c69e0934092548f94dfcdd48cdb5becc336daa) coqPackages.RustExtraction: modernize mkCoqDerivation release hash format
* [`9dd99058`](https://github.com/NixOS/nixpkgs/commit/9dd99058f1dcdf4d22903fe150e76b999d08adae) coqPackages.semantics: modernize mkCoqDerivation release hash format
* [`e4abd8da`](https://github.com/NixOS/nixpkgs/commit/e4abd8dab11a8258c9261fc6d2c1cc342513b92c) coqPackages.serapi: modernize mkCoqDerivation release hash format
* [`3e74d65c`](https://github.com/NixOS/nixpkgs/commit/3e74d65c065f2dbd6e1dea6cb97a1b2b7ff64cba) coqPackages.simple-io: modernize mkCoqDerivation release hash format
* [`d41437e8`](https://github.com/NixOS/nixpkgs/commit/d41437e84cc8f3c7ff94fa3af13f531011cc9769) coqPackages.smpl: modernize mkCoqDerivation release hash format
* [`1dedfb45`](https://github.com/NixOS/nixpkgs/commit/1dedfb45b3a4f96160330dc7b7e1243445391c66) coqPackages.smtcoq: modernize mkCoqDerivation release hash format
* [`7173d123`](https://github.com/NixOS/nixpkgs/commit/7173d123d457bf36a9b70d040f410ac515f2f164) coqPackages.ssprove: modernize mkCoqDerivation release hash format
* [`758feba0`](https://github.com/NixOS/nixpkgs/commit/758feba058441bc6b95ff882699923d7ede82746) coqPackages.stalmarck-tactic: modernize mkCoqDerivation release hash format
* [`8202f380`](https://github.com/NixOS/nixpkgs/commit/8202f38070274b95bfa584350aa4a361a5d33acc) coqPackages.stdlib: modernize mkCoqDerivation release hash format
* [`297c15a7`](https://github.com/NixOS/nixpkgs/commit/297c15a7dff7ad2bcbb9e138f508559f0ff4d53d) coqPackages.stdpp: modernize mkCoqDerivation release hash format
* [`10f15122`](https://github.com/NixOS/nixpkgs/commit/10f15122dd2f09ef7fe85fd787e288489c69c966) coqPackages.StructTact: modernize mkCoqDerivation release hash format
* [`bdf85f40`](https://github.com/NixOS/nixpkgs/commit/bdf85f40f2ac23283853302ab6f12931165fd753) coqPackages.tlc: modernize mkCoqDerivation release hash format
* [`2bbeb65b`](https://github.com/NixOS/nixpkgs/commit/2bbeb65bde2c25ded5f48b7677977aac0f8d79fc) coqPackages.topology: modernize mkCoqDerivation release hash format
* [`5a240848`](https://github.com/NixOS/nixpkgs/commit/5a240848a7ea90700e46b03bb37fe350694ec7b2) coqPackages.trakt: modernize mkCoqDerivation release hash format
* [`099a9d8a`](https://github.com/NixOS/nixpkgs/commit/099a9d8ac87caf25c1e40d870d40d811fd30d3da) coqPackages.TypedExtraction: modernize mkCoqDerivation release hash format
* [`91c9a399`](https://github.com/NixOS/nixpkgs/commit/91c9a3993f533311738d252c1f7820e7734e41f9) coqPackages.unicoq: modernize mkCoqDerivation release hash format
* [`ad797a21`](https://github.com/NixOS/nixpkgs/commit/ad797a21b63695c1e9cf469f5ae35492c0a779b9) coqPackages.validsdp: modernize mkCoqDerivation release hash format
* [`3d7afbfa`](https://github.com/NixOS/nixpkgs/commit/3d7afbfaf9641fff762b4256197bac02d062af51) coqPackages.vcfloat: modernize mkCoqDerivation release hash format
* [`673d5894`](https://github.com/NixOS/nixpkgs/commit/673d5894c05e0844fa8ae5a802c349944dfee0e3) coqPackages.Velisarios: modernize mkCoqDerivation release hash format
* [`068f2f2b`](https://github.com/NixOS/nixpkgs/commit/068f2f2b80c0fa72970931978b2d3aa5dc82c5f4) coqPackages.Verdi: modernize mkCoqDerivation release hash format
* [`aabd366d`](https://github.com/NixOS/nixpkgs/commit/aabd366d445539851d845269526b68a7fa51e3f2) coqPackages.Vpl: modernize mkCoqDerivation release hash format
* [`85f89ea6`](https://github.com/NixOS/nixpkgs/commit/85f89ea677bbc587959e8a4c4bcd62815c14c523) coqPackages.VplTactic: modernize mkCoqDerivation release hash format
* [`3205ae21`](https://github.com/NixOS/nixpkgs/commit/3205ae21142a205ea4989dab65688d8c1ba76326) coqPackages.VST: modernize mkCoqDerivation release hash format
* [`a1095db5`](https://github.com/NixOS/nixpkgs/commit/a1095db5c969291784c70cda73e2ceeb2427f4cc) coqPackages.wasmcert: modernize mkCoqDerivation release hash format
* [`e417f814`](https://github.com/NixOS/nixpkgs/commit/e417f8140cad85e47cd6a2886c26865fe68cebc4) coqPackages.waterproof: modernize mkCoqDerivation release hash format
* [`f348a2b7`](https://github.com/NixOS/nixpkgs/commit/f348a2b7e31beb5c288e4d8af4b36917522af799) coqPackages.zorns-lemma: modernize mkCoqDerivation release hash format
* [`79d4812a`](https://github.com/NixOS/nixpkgs/commit/79d4812a85ebbdf6898a8c685bfe9400c8356808) mint: 0.28.1 -> 0.29.0
* [`f7a123eb`](https://github.com/NixOS/nixpkgs/commit/f7a123ebc8bfc1e5bb6ced26842ea761de3c04d7) jffi: 1.3.13 -> 1.3.15
* [`f7bf9767`](https://github.com/NixOS/nixpkgs/commit/f7bf97677d08132d0c479861dba5c477680cf081) bpf-linker: 0.10.3 -> 0.10.4
* [`e701169b`](https://github.com/NixOS/nixpkgs/commit/e701169bd8a5d0a31e3e90d7f85f3f0d4d95e8a7) python3Packages.pysail: init at 0.6.4
* [`0170a63c`](https://github.com/NixOS/nixpkgs/commit/0170a63c181814a412360acfba3b3a7d191528ce) keylights: init at 0.1.0
* [`e8330e52`](https://github.com/NixOS/nixpkgs/commit/e8330e521e7aea8f08011b48ca54a58b8190232d) rang: 3.2 -> 3.3
* [`c39e2c50`](https://github.com/NixOS/nixpkgs/commit/c39e2c50351fd73b1f4119496f66cd4fe5d1ea8c) vscode-extensions.vadimcn.vscode-lldb: 1.12.1 -> 1.12.2
* [`6a8949cb`](https://github.com/NixOS/nixpkgs/commit/6a8949cbf9f8ab56d1086937e0897b00121b7402) notable: move icon to spec-compliant location
* [`ed5a53fa`](https://github.com/NixOS/nixpkgs/commit/ed5a53fa5445cd31bc0c309e941c9b7e330a2615) notable: cleanup
* [`9ab07e24`](https://github.com/NixOS/nixpkgs/commit/9ab07e24302ffba0d06e14616e456baf5eefe695) nixosTests.luks-suspend: init
* [`6e618e63`](https://github.com/NixOS/nixpkgs/commit/6e618e63104b918765697cdc3f968d5fbbaabf32) mouser: darwin build is fixed
* [`d0169b96`](https://github.com/NixOS/nixpkgs/commit/d0169b96fbe8340d4f8d0b9cece6512a4565a779) docs/readme: reword 'devmode' -> Live preview
* [`0f67da8a`](https://github.com/NixOS/nixpkgs/commit/0f67da8a356c3ccacdd302240bd05412c9dc3320) mathematica: 14.3.0 -> 15.0.0
* [`495906d5`](https://github.com/NixOS/nixpkgs/commit/495906d50abddbe724d52b5bb29987bab7ba7272) lib.types: types.attrTag declaration info
* [`10f864f9`](https://github.com/NixOS/nixpkgs/commit/10f864f976bd38cba41ab685156b6b17b32833ac) roadrunner: fix ldflags, add versionCheckHook
* [`22e84a64`](https://github.com/NixOS/nixpkgs/commit/22e84a648a82e2e3e5b73389528e91f38727258d) roadrunner: 2025.1.6 -> 2025.1.14
* [`45867203`](https://github.com/NixOS/nixpkgs/commit/4586720308e594153d582cc8777aecab8baae83f) roadrunner: remove obsolete patch
* [`76d8f97d`](https://github.com/NixOS/nixpkgs/commit/76d8f97d7f3567af9bb94000b5588eda3294daab) maintainers: add fred441a
* [`65d2254d`](https://github.com/NixOS/nixpkgs/commit/65d2254ded04e4e8a2b49b8acdf33d45614752da) maintainers: add jromer
* [`f71782a9`](https://github.com/NixOS/nixpkgs/commit/f71782a90cd00a9e77326863c47efe4f7146ba1f) libmodsecurity: migrate to pcre2
* [`73ac6f01`](https://github.com/NixOS/nixpkgs/commit/73ac6f0131b7408dc98c0dd701c8ed0998253029) vscode-extensions.vadimcn.vscode-lldb: remove r4v3n6101 from maintainers
* [`bb7ea6fc`](https://github.com/NixOS/nixpkgs/commit/bb7ea6fc0a9f7a3fa448c3b23c1b5bd2a5ef1305) python3Packages.junit2html: 31.1.3 -> 31.1.4
* [`b964c606`](https://github.com/NixOS/nixpkgs/commit/b964c6066a911f5df52a3681f9da1f3b426c4272) gfan: fix licensing
* [`fa37940b`](https://github.com/NixOS/nixpkgs/commit/fa37940bfe22a20ca1c8733858086ac98101a6b7) nixos/tests/victoriametrics: migrate to container tests
* [`0c6ed3ed`](https://github.com/NixOS/nixpkgs/commit/0c6ed3edff1b6e8f1c0a20f3778897272045f310) python3Packages.livekit-protocol: 1.1.2 -> 1.1.17
* [`ad845e4f`](https://github.com/NixOS/nixpkgs/commit/ad845e4f3d3db0da0e324b40f1f2ca7dd0b5639f) veracrypt: modernize, build with fuse3
* [`728a0645`](https://github.com/NixOS/nixpkgs/commit/728a0645abef307ced95a452d9ffd96d80a98035) roadrunner: add myself as maintainer
* [`453581a2`](https://github.com/NixOS/nixpkgs/commit/453581a2d66478750142db4ae2e1f1cd6f0200f9) doctoc: 2.2.0 -> 2.5.0
* [`59e4046c`](https://github.com/NixOS/nixpkgs/commit/59e4046c0f13788f016c31f7004b9dc1a3f42d1b) clickable: 8.8.0 -> 8.9.0
* [`371a0326`](https://github.com/NixOS/nixpkgs/commit/371a0326766852bbf36544a1ea4ae066a0fa860a) cpat: init at 1.4.2
* [`3c38ce64`](https://github.com/NixOS/nixpkgs/commit/3c38ce64928e717d8219125ef6ca1d928045d524) libwebsockets: fix plugin search path
* [`63090808`](https://github.com/NixOS/nixpkgs/commit/630908081af4b5923a7db6cc286077819ce9c973) turborepo-remote-cache: 2.7.3 -> 2.11.2
* [`fe291c4a`](https://github.com/NixOS/nixpkgs/commit/fe291c4aee8ab42088535b4195aa047e6c867805) instant-space-switcher: init at 2.0
* [`846c20e3`](https://github.com/NixOS/nixpkgs/commit/846c20e3702f4e3fd46c3058b48c78cac37a34bc) python3Packages.labelbox: 7.3.0 -> 7.8.0
* [`0b452c4a`](https://github.com/NixOS/nixpkgs/commit/0b452c4a9bffa91d7e08e54032e05abb49f27273) python3Packages.linode-api: 5.39.0 -> 5.45.0
* [`9b73ac2b`](https://github.com/NixOS/nixpkgs/commit/9b73ac2bfce54e346a5244559386d69215d08c86) mdfried: add pdf support
* [`020480e6`](https://github.com/NixOS/nixpkgs/commit/020480e61ecf8ed7e683d9e3a689c2dee96d2827) lyx: 2.4.4 -> 2.5.1
* [`f13ff041`](https://github.com/NixOS/nixpkgs/commit/f13ff041c7ee463861f35e14a9db92b81145ef3c) python3Packages.comet-ml: 3.58.1 -> 3.58.3
* [`faf8db43`](https://github.com/NixOS/nixpkgs/commit/faf8db43abfd35ddc80859d9f8faf65ee7138d4d) interval-tree: init at 3.1.1
* [`08f0acf2`](https://github.com/NixOS/nixpkgs/commit/08f0acf227b623db036989fc4563c0ade7ee458f) gfan: 0.6.2->0.7
* [`009a683b`](https://github.com/NixOS/nixpkgs/commit/009a683bacea209f4abfe6d167930abd8773c9de) maintainers: add OJII3
* [`0c5164d8`](https://github.com/NixOS/nixpkgs/commit/0c5164d8f4e76e0dcad815b5ac9bdb309e4c9751) gwq: init at 0.1.1
* [`e3df111f`](https://github.com/NixOS/nixpkgs/commit/e3df111f9fa76529aa697254ec6891ff299b7d13) zoneminder: 1.36.38 -> 1.38.3 + a number of fixes
* [`ae5fe904`](https://github.com/NixOS/nixpkgs/commit/ae5fe9045c670b8682e186b048bfdb7d6e475e16) nixos/doc: mention ZoneMinder major update in release note
* [`dd1f6663`](https://github.com/NixOS/nixpkgs/commit/dd1f66632e241e12e63dd7a18f0934842b9a456a) zoneminder: volunteer myself (peat-psuwit) to be a maintainer
* [`01408971`](https://github.com/NixOS/nixpkgs/commit/01408971cf3ed91b5a5348843112e1e64926a7bf) python3Packages.inject: 5.3.0-unstable-2026-01-05 -> 5.4.0
* [`28af1176`](https://github.com/NixOS/nixpkgs/commit/28af1176fd1da8a0dc6e2b31a1dc0fd0163c8440) python3Packages.gdsfactory: 9.39.3 -> 9.44.0
* [`acfef4b4`](https://github.com/NixOS/nixpkgs/commit/acfef4b46a2a433c8e06de1286d66bd146c4d31f) rofimoji: 6.7.0 -> 6.8.0
* [`d5e79aa5`](https://github.com/NixOS/nixpkgs/commit/d5e79aa57ec2fb595a526c375998106a4d3b3bd4) gpu-screen-recoder: 5.13.8 -> 5.13.9
* [`3c0a7119`](https://github.com/NixOS/nixpkgs/commit/3c0a7119efb780a09912b62092b0a28638102f26) cwm: add iamanaws as maintainer
* [`da0e02d5`](https://github.com/NixOS/nixpkgs/commit/da0e02d5c81007bd6b586e225cb192ac1fc65180) cwm: 7.4 -> 7.9
* [`d16f265f`](https://github.com/NixOS/nixpkgs/commit/d16f265fb80dbddbedfcdd4584fab4a0b0f8d493) oscar: fix icon, clean up installPhase
* [`1250fc04`](https://github.com/NixOS/nixpkgs/commit/1250fc046fb0a0adcf0f23069b3f006b7df00729) vscode-extensions.biomejs.biome: 2026.3.311859 -> 2026.6.181955
* [`6bfbf7b5`](https://github.com/NixOS/nixpkgs/commit/6bfbf7b56fd032bf1b13830f052cfdce0a173f43) angie: 1.11.5 -> 1.11.8
* [`c7dd4ff5`](https://github.com/NixOS/nixpkgs/commit/c7dd4ff50679e35f201b236ca12240437b0cec5a) sosreport: 4.11.1 -> 4.11.2
* [`b5f4480b`](https://github.com/NixOS/nixpkgs/commit/b5f4480bd81b2a3d4a108e20e2e3e17f49e2b619) mendingwall: init at 0.3.8
* [`50947728`](https://github.com/NixOS/nixpkgs/commit/50947728598f2dd65d4f96eb53c428da44e11565) drm_info: 2.8.0 -> 2.10.0
* [`389ad66c`](https://github.com/NixOS/nixpkgs/commit/389ad66caaf36cfb980fd7b7340e943bda2d9818) python3Packages.django-reversion: 6.1.0 -> 6.3.0
* [`f3e8af23`](https://github.com/NixOS/nixpkgs/commit/f3e8af23b290d8722afcac59822990413b534078) treewide: Fix malformed input hashes
* [`195e14bd`](https://github.com/NixOS/nixpkgs/commit/195e14bd80159e75a12c4194a52e322fb2443dd9) semantic-release: 25.0.2 -> 25.0.5
* [`615e6a6c`](https://github.com/NixOS/nixpkgs/commit/615e6a6ca95a5fd8beb73136d250d2c0483f40f1) courier-unicode: 2.5.0 -> 2.6.0
* [`0d785bcb`](https://github.com/NixOS/nixpkgs/commit/0d785bcb40cecbe34d55b9a223947b76eb8d6697) sonobuoy: 0.57.3 -> 0.57.4
* [`45fd270f`](https://github.com/NixOS/nixpkgs/commit/45fd270fb8507f5cd9b70c27699374c2350f7b08) vscode-extensions.azdavis.millet: 0.15.1 -> 0.15.2
* [`f60322f9`](https://github.com/NixOS/nixpkgs/commit/f60322f99a0417099d7138a21101dee7a706fabd) swayimg: 5.2 -> 5.4
* [`d528156e`](https://github.com/NixOS/nixpkgs/commit/d528156e993c28b0c24d5079628e2d0ea2d9b5ed) mysql84: 8.4.9 -> 8.4.10
* [`8cb0d847`](https://github.com/NixOS/nixpkgs/commit/8cb0d847ec07d403732693dc407fe3e0c81a8c1e) {libsForQt5,qt6Packages}.libqtdbustest: 0.4.0 -> 0.4.1
* [`5e06a7bc`](https://github.com/NixOS/nixpkgs/commit/5e06a7bc76ee3d875b936171a97792acfae56a2a) net-cpp: 3.2.1 -> 3.2.2
* [`70cf3e5e`](https://github.com/NixOS/nixpkgs/commit/70cf3e5ed7caf9c44af12ee7cb0286b65b1532e4) {lomiri,lomiri-qt6}.gmenuharness: 0.1.5 -> 0.1.6
* [`cbdc0607`](https://github.com/NixOS/nixpkgs/commit/cbdc0607fd32e99120288694442defe0e7fd10e4) tap: init at 0.1.10
* [`729733ad`](https://github.com/NixOS/nixpkgs/commit/729733adb82715c3bd7b35690f483e0aaa987aae) nixos/tap: init
* [`6617de4f`](https://github.com/NixOS/nixpkgs/commit/6617de4fb8d2123bead5760e69174837da2198eb) sudachi-rs: 0.6.10 -> 0.6.11
* [`35b13666`](https://github.com/NixOS/nixpkgs/commit/35b136661766c52ebc7ad24534df91c08e1836b4) lomiri.libusermetrics: 1.4.1 -> 1.4.2
* [`cef2ac97`](https://github.com/NixOS/nixpkgs/commit/cef2ac97db72a1f0261377a47c792bf6cb54a5c2) ticker: 5.2.1 -> 5.3.0
* [`f7dad419`](https://github.com/NixOS/nixpkgs/commit/f7dad419d79b21d1baa11673ac61787f5d4089f6) {lomiri,lomiri-qt6}.lomiri-app-launch: 0.1.12 -> 0.2.0
* [`19f2b69e`](https://github.com/NixOS/nixpkgs/commit/19f2b69e3078e3da2626b2d4414a5766f763d3c4) lomiri.mediascanner2: 0.200 -> 0.201
* [`9a48e2f7`](https://github.com/NixOS/nixpkgs/commit/9a48e2f706c07aa29dc8753278bffe19e674d7bb) lomiri-qt6.mediascanner2: init at 0.201
* [`a517bf63`](https://github.com/NixOS/nixpkgs/commit/a517bf63b4e14795c98e8497b24c1801b9e5a801) {lomiri,lomiri-qt6}.lomiri-thumbnailer: 3.1.1 -> 3.1.2
* [`00f2e9ea`](https://github.com/NixOS/nixpkgs/commit/00f2e9ea5ef93595137bedb5281bbece8298d9e9) {lomiri,lomiri-qt6}.lomiri-download-manager: 0.3.1 -> 0.3.2
* [`12530ddf`](https://github.com/NixOS/nixpkgs/commit/12530ddf817cdf64eaf8af61d27cd39dc8efeb10) unpoller: 2.39.0 -> 3.3.1
* [`d7d3acc5`](https://github.com/NixOS/nixpkgs/commit/d7d3acc5c3f84b010e682a767c572992f1cace43) python3Packages.wagtail: 7.4.1 -> 7.4.2
* [`2947494f`](https://github.com/NixOS/nixpkgs/commit/2947494f7cceab3ebb2ed0e9607f8341e310cfbc) python3Packages.temporalio: 1.28.0 -> 1.29.0
* [`c42e8a4f`](https://github.com/NixOS/nixpkgs/commit/c42e8a4fb9a5a6419ce2ae7973c6237fa40906ae) liquidsoap: fix hash
* [`3d3d6664`](https://github.com/NixOS/nixpkgs/commit/3d3d66646cb2b9f55f8da443f8e4942535766dc8) rdup: 1.1.15 -> 1.1.16-unstable-2024-03-05
* [`334cee49`](https://github.com/NixOS/nixpkgs/commit/334cee49e7ea8b39cec44e989fe1330d0963bf7d) calico-app-policy: 3.31.5 -> 3.31.6
* [`7b1a37cb`](https://github.com/NixOS/nixpkgs/commit/7b1a37cb382c8126b5fc04b5ea8aa3b289274dbe) calicoctl: 3.31.5 -> 3.31.6
* [`514096e3`](https://github.com/NixOS/nixpkgs/commit/514096e32ac21e0aeabac652beffadce796a1b79) gajim: 2.4.6 → 2.4.7
* [`a139ccd2`](https://github.com/NixOS/nixpkgs/commit/a139ccd2791768d14cf4804c13c33d2111b46e5c) python3Packages.pyghmi: 1.6.17 -> 1.6.18
* [`1a247910`](https://github.com/NixOS/nixpkgs/commit/1a247910d693f2bb6e9f4bfcfba96be9c0769e05) ltex-ls-plus: 18.6.1 -> 18.7.0
* [`1c9e2fea`](https://github.com/NixOS/nixpkgs/commit/1c9e2fea81adcc787c53f899a8b2853f67828017) dbgate: 6.6.9 -> 7.2.1
* [`28c1cf76`](https://github.com/NixOS/nixpkgs/commit/28c1cf7691dbf97f0110ad4639698871e25cabde) python3Packages.semchunk: 4.0.0 -> 4.1.0
* [`d72a8cee`](https://github.com/NixOS/nixpkgs/commit/d72a8cee3b8b0fc639f4cf3072b902b0daa3b5a0) turborepo-remote-cache: add ibizaman as maintainer
* [`3a5486f7`](https://github.com/NixOS/nixpkgs/commit/3a5486f70846ea75c9735f77b8b5bfee498cb117) deluge: guard gui libraries behind withGUI
* [`0738d64c`](https://github.com/NixOS/nixpkgs/commit/0738d64c6245e447adfdc9dc450b2aefc127ac9c) python3Packages.zeep: 4.3.2 -> 4.3.3
* [`25b02e1a`](https://github.com/NixOS/nixpkgs/commit/25b02e1a0b37d57f5b501027e3f403b61709bea1) rio: 0.4.5 -> 0.4.7
* [`952e4912`](https://github.com/NixOS/nixpkgs/commit/952e4912c8c1c9c902dea13ce44f13b4cc4786d7) corrosion: fix dependent packages
* [`94275d85`](https://github.com/NixOS/nixpkgs/commit/94275d853b97d231137124e90da04fb72f4c4c35) vscode-extensions.mshr-h.veriloghdl: 1.25.0 -> 1.27.1
* [`a1714ebd`](https://github.com/NixOS/nixpkgs/commit/a1714ebd5a045bcfa56c8d583fe922ef05f01e64) python3Packages.mpire: remove
* [`92e58ee3`](https://github.com/NixOS/nixpkgs/commit/92e58ee3e36f2efdd06cf59981c0c9d8985263a2) python3Packages.sphinx-versions: remove
* [`26222d00`](https://github.com/NixOS/nixpkgs/commit/26222d00c1a94917bd25dcf51c444e221c94b80e) python3Packages.sphinxcontrib-images: remove
* [`57c2e76c`](https://github.com/NixOS/nixpkgs/commit/57c2e76cd4cf8b5bc78d99bca2ae7489c5e695b1) victoriametrics: 1.145.0 -> 1.146.0
* [`c760cde8`](https://github.com/NixOS/nixpkgs/commit/c760cde863a281d159827e100c60d914cc7c30f8) octavePackages.datatypes: 1.2.4 -> 1.2.5
* [`9a908cdd`](https://github.com/NixOS/nixpkgs/commit/9a908cdda411dc289a5dd265a5c3eac3321f671b) fa_1: use installFonts
* [`378fd36b`](https://github.com/NixOS/nixpkgs/commit/378fd36bd0893a95f0776936ddf1d2c9feb9f450) sbt: 1.12.11 -> 1.12.13
* [`d1dd7e6e`](https://github.com/NixOS/nixpkgs/commit/d1dd7e6eb005cae72cb1248044e50d5d27c8a9cf) circumflex: install man page, shell completions; cleanup
* [`e722fc90`](https://github.com/NixOS/nixpkgs/commit/e722fc90d945858f0529a74aa2a1826eb5de9ddb) talosctl: 1.13.4 -> 1.13.5
* [`4cc6296c`](https://github.com/NixOS/nixpkgs/commit/4cc6296c79709eb37c56bf27f8a41606fd7ed5cc) ramalama: 0.19.0 -> 0.22.0
* [`d7fbbb0b`](https://github.com/NixOS/nixpkgs/commit/d7fbbb0ba22f1ca4ac4fdea8d880c4ca6e336054) vault: 1.21.4 -> 2.0.3
* [`910f5e30`](https://github.com/NixOS/nixpkgs/commit/910f5e30a36e5e1d13d9f01a54d3aff2319f349c) apfel-llm: 1.0.5 -> 1.6.1
* [`8c166272`](https://github.com/NixOS/nixpkgs/commit/8c166272d0c32e0083bc215c2b16f19dfcb8bcf2) boat-cli: init at 0.9.1
* [`cd4f09c0`](https://github.com/NixOS/nixpkgs/commit/cd4f09c07965510f1102a55f9194fc1e40cf6db6) packer: add withPlugins
* [`0ec07173`](https://github.com/NixOS/nixpkgs/commit/0ec07173de10560797eb6f61f551edb1b2fa9cd9) maintainers: add FabricSoul
* [`c930c98d`](https://github.com/NixOS/nixpkgs/commit/c930c98d263bc5f4a4162c2152987b31cee06e2e) mango: rename from mangowc
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
