### PR TITLE
npins home-manager: update 5d72a29f -> 63d02d1c

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -48,9 +48,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "5d72a29fc36ac21adae6ae35568fe5ee6700850f",
-      "url": "https://github.com/nix-community/home-manager/archive/5d72a29fc36ac21adae6ae35568fe5ee6700850f.tar.gz",
-      "hash": "sha256-slFTUgDy0KTPA4LBAmC/9SngDq8GCPdX+ZR0yQHHN1E="
+      "revision": "63d02d1c19f1c2b47a5bc7e55c620b6af7b218a6",
+      "url": "https://github.com/nix-community/home-manager/archive/63d02d1c19f1c2b47a5bc7e55c620b6af7b218a6.tar.gz",
+      "hash": "sha256-w+YU5vatysjLZIg1wOKSzo/RL9Z66eBQuIjVnBM/1Zg="
     },
     "hs-grille": {
       "type": "Git",


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@5d72a29f...63d02d1c](https://github.com/nix-community/home-manager/compare/5d72a29fc36ac21adae6ae35568fe5ee6700850f...63d02d1c19f1c2b47a5bc7e55c620b6af7b218a6)

* [`2a37d71b`](https://github.com/nix-community/home-manager/commit/2a37d71bbe69e1522ddabf03a4cea0374958bdbe) herdr: add module
* [`2f3da3d4`](https://github.com/nix-community/home-manager/commit/2f3da3d45fbf503f874bd7db7aa2c298e87ab9ea) launchd: fix user domain agents
* [`d3253798`](https://github.com/nix-community/home-manager/commit/d32537981c036473cf6990ae03176a5d84c43b29) lib: escape backslash in `lib.hm.generators.toKDL`
* [`74b38179`](https://github.com/nix-community/home-manager/commit/74b38179ac0820af3ea4a240ff12668fb2b8c72e) kanshi: Reload on config change
* [`ebc87daa`](https://github.com/nix-community/home-manager/commit/ebc87daabc8d3f595e9a8b67107eaaa8115ad582) launchd: only use --wait on macOS 26 and later
* [`c0b7cadd`](https://github.com/nix-community/home-manager/commit/c0b7cadd8194e937f49818d9caf9fbc9084b117f) home: remove redundant non-emptiness assertion
* [`937e85df`](https://github.com/nix-community/home-manager/commit/937e85df03e2cf8bc2c0daafc68b2b2782ddbcec) home: check `username` being non-empty through its type
* [`7b64c06f`](https://github.com/nix-community/home-manager/commit/7b64c06f1d37654e02c8dc79c0d5345f9c451f5c) home: use `lib.literalMD`
* [`f469c79b`](https://github.com/nix-community/home-manager/commit/f469c79b955609d6a8fdd9e689be76a93b1621d7) home: document defaults inherited from NixOS/nix-darwin
* [`2fca6a73`](https://github.com/nix-community/home-manager/commit/2fca6a73722945e3558d89e43d261c147df5805b) atuin: order nushell integration after fzf
* [`31ca071a`](https://github.com/nix-community/home-manager/commit/31ca071a7d2b4d7ee98f93d1795c6ad740b3e871) fzf: remove legacy shell integration fallback
* [`cde77509`](https://github.com/nix-community/home-manager/commit/cde77509b6c13108ec58b18681b0bf2440b0e4ad) fzf: restructure widget options
* [`fe3ce0a5`](https://github.com/nix-community/home-manager/commit/fe3ce0a527367cb3302981137ca890155166cef0) fzf: add historyWidget.command option
* [`2d92f539`](https://github.com/nix-community/home-manager/commit/2d92f5398d7c6489fd45cef39ee3c5f948e50742) fzf: export environment variables to nushell
* [`f15a4bf0`](https://github.com/nix-community/home-manager/commit/f15a4bf0657f3bdbb66ccd1c768a6cbfa25f6b7a) fzf: add per-shell widget overrides
* [`0396024e`](https://github.com/nix-community/home-manager/commit/0396024ea5c0e52d698b475612e00ae4a2834bd4) fzf: warn on conflicting ctrl-r bindings
* [`a4d410db`](https://github.com/nix-community/home-manager/commit/a4d410db95a6416d1008049330bd86b85b5db45a) fzf: group related module attributes
* [`3a60d513`](https://github.com/nix-community/home-manager/commit/3a60d513d0b667b299694b0da7ea7e36ece8f173) clipse: use rfc 042 style settings
* [`1c9ddc70`](https://github.com/nix-community/home-manager/commit/1c9ddc707ce6398abf1b410797d172b0f9373344) kanshi: fix check for empty settings
* [`b2e4390f`](https://github.com/nix-community/home-manager/commit/b2e4390ff35319c52935d6a700b615da4c0f204d) kanshi: Add test to check service when settings are unset
* [`b885baad`](https://github.com/nix-community/home-manager/commit/b885baad531fa3d3beae2ba9a0712d22974d8016) syncthing: add option for ignore patterns
* [`a7209b67`](https://github.com/nix-community/home-manager/commit/a7209b6794f88585c9a6c1f52db6d8c6bf841d88) syncthing: fix badly escaped ignore patterns test
* [`bfb67e07`](https://github.com/nix-community/home-manager/commit/bfb67e07a3b35a4bb30d9c9b2208e8ac45f4c3fa) difftastic: fix jujutsu integration
* [`40545758`](https://github.com/nix-community/home-manager/commit/40545758d839124ad4d238099a762361db28a9f7) flake: bump nixpkgs from `89570f2` to `9e92285`
* [`cf0c5c3e`](https://github.com/nix-community/home-manager/commit/cf0c5c3e9f0d5abdb1cbc666285749b99a638a41) maintainers: drop duplicate yarn entry
* [`a1645f40`](https://github.com/nix-community/home-manager/commit/a1645f40777620c4bd2b6d854b290c2fc354a266) maintainers: regenerate all-maintainers
* [`0d33882b`](https://github.com/nix-community/home-manager/commit/0d33882bd46c1f9ef62276700f5e5f2bd6ff6604) codex: support path-backed hooks
* [`63d02d1c`](https://github.com/nix-community/home-manager/commit/63d02d1c19f1c2b47a5bc7e55c620b6af7b218a6) attic-client: init module
