### PR TITLE
npins zsh-patina: update fdbdce45 -> 5a0f7889

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -242,9 +242,9 @@
       },
       "branch": "main",
       "submodules": false,
-      "revision": "fdbdce4514b146afbead7362d3f31662bbcd111b",
-      "url": "https://github.com/michel-kraemer/zsh-patina/archive/fdbdce4514b146afbead7362d3f31662bbcd111b.tar.gz",
-      "hash": "sha256-M14IeK+Nsst+6RK6ayhq37YSoFPVptNqE9blVHDI1YM="
+      "revision": "5a0f7889343c1c14ca2b49372a973c7975033e40",
+      "url": "https://github.com/michel-kraemer/zsh-patina/archive/5a0f7889343c1c14ca2b49372a973c7975033e40.tar.gz",
+      "hash": "sha256-4c7jpWqdqOslXv9D6v1/E9+dRUUtd7xJtNCHlXfZCtc="
     },
     "zsh-syntax-highlighting": {
       "type": "Git",


### PR DESCRIPTION
## Changelog for zsh-patina:
Branch: main
Commits: [michel-kraemer/zsh-patina@fdbdce45...5a0f7889](https://github.com/michel-kraemer/zsh-patina/compare/fdbdce4514b146afbead7362d3f31662bbcd111b...5a0f7889343c1c14ca2b49372a973c7975033e40)

* [`ccba5750`](https://github.com/michel-kraemer/zsh-patina/commit/ccba57509aa00f2b3c9c2ad0eeed856dc375cb69) Update dependencies
* [`7050b6db`](https://github.com/michel-kraemer/zsh-patina/commit/7050b6dbc69f398b663af73665fa5088bc1791b5) Raise MSRV to 1.89
* [`5a0f7889`](https://github.com/michel-kraemer/zsh-patina/commit/5a0f7889343c1c14ca2b49372a973c7975033e40) Use file lock to prevent race condition when starting the daemon
