### PR TITLE
npins nixpkgs: update 95e7ef5e -> 6cdc7fc7

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -125,9 +125,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "95e7ef5ed77baf8e2939ff3770b9eb02632389fe",
-      "url": "https://github.com/nixos/nixpkgs/archive/95e7ef5ed77baf8e2939ff3770b9eb02632389fe.tar.gz",
-      "hash": "sha256-hSwFn3/e70Z32AozXOadpmCub4ITFrqChPJJJ/qOAVY="
+      "revision": "6cdc7fc76e8bf7fde9fa43a849fcaaa70e230dee",
+      "url": "https://github.com/nixos/nixpkgs/archive/6cdc7fc76e8bf7fde9fa43a849fcaaa70e230dee.tar.gz",
+      "hash": "sha256-FmieJB8/OUvNxbkboi7+IGfIuSXY3nF/hZQm8kD0r50="
     },
     "powerlevel10k": {
       "type": "Git",


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@95e7ef5e...6cdc7fc7](https://github.com/nixos/nixpkgs/compare/95e7ef5ed77baf8e2939ff3770b9eb02632389fe...6cdc7fc76e8bf7fde9fa43a849fcaaa70e230dee)

* [`48fbfc79`](https://github.com/NixOS/nixpkgs/commit/48fbfc7974917e455c54a83c6ec62b9a031780a5) maintainers: add mcuste
* [`75f358e0`](https://github.com/NixOS/nixpkgs/commit/75f358e0e06042c591158f01d8cdc10e1dfd7cb8) maintainers: add joelgranados
* [`977b54aa`](https://github.com/NixOS/nixpkgs/commit/977b54aa41870073d15f336f20f1b4f006e496a9) maintainers: add mrbjarksen
* [`a7a8da9d`](https://github.com/NixOS/nixpkgs/commit/a7a8da9df3e96a34856a9874d6d679ef88abc98d) openvscode-server: Add support for use with pkgs.vscode-with-extensions
* [`c11c13a5`](https://github.com/NixOS/nixpkgs/commit/c11c13a5d9b4a0bc3e22710f6d954583ac937b4c) nixos/mjpeg-streamer: add package option
* [`93309d7b`](https://github.com/NixOS/nixpkgs/commit/93309d7b76f9969c0bd3d96166d8fbaaa821bfe5) gst_all_1.gst-plugins-bad: don't build with gtk3 by default
* [`40092a22`](https://github.com/NixOS/nixpkgs/commit/40092a228d3a850f924a0f3cc723fb39bac15752) libnice: 0.1.22 -> 0.1.23
* [`83d1e42b`](https://github.com/NixOS/nixpkgs/commit/83d1e42b411f5ea3fa23c978a401208dd4c54a9b) ace-of-penguins: Update URLs
* [`7e23356f`](https://github.com/NixOS/nixpkgs/commit/7e23356fcd4d9ce25cfeedf12b3e5b21cfdd07d7) doc: fix path to manual as described in contributing
* [`470cbe3d`](https://github.com/NixOS/nixpkgs/commit/470cbe3d39b8b46ec2d49c2cfc7aced1e7e7e542) byacc: 20241231 -> 20260126
* [`2ae3d0ab`](https://github.com/NixOS/nixpkgs/commit/2ae3d0ab89adf70a97711ac661e6ec9d0c9c2512) sord: 0.16.20 -> 0.16.22
* [`222a2527`](https://github.com/NixOS/nixpkgs/commit/222a2527d2dd16a0a24053cd99bfd96e7dc042c8) awscli2: replace vendored certs
* [`c110df0c`](https://github.com/NixOS/nixpkgs/commit/c110df0ccebea65a1e2715ec8974fa0511f25684) python3Packages.botocore: replace vendored certs
* [`b3ebd106`](https://github.com/NixOS/nixpkgs/commit/b3ebd1069ea3132b7de8f42e148e58af17448c9e) pkgsMusl.nix: fix build
* [`8ceb1235`](https://github.com/NixOS/nixpkgs/commit/8ceb12357abe8f37f9ab18796ee8b25181a21dc4) pngcheck: 3.0.2 -> 4.0.1
* [`c4831d59`](https://github.com/NixOS/nixpkgs/commit/c4831d5909c65bbd71b42951dc6d3d15066950aa) abseil-cpp: add pkg-config validation
* [`8c764638`](https://github.com/NixOS/nixpkgs/commit/8c76463804dab5aaf1b56c67236f3bbfd6220527) kluctl: build with webui
* [`7e7159ed`](https://github.com/NixOS/nixpkgs/commit/7e7159ede3180958d0d5e58c90f81511d7906a3b) discordchatexporter-desktop: support aarch64-linux
* [`2c528161`](https://github.com/NixOS/nixpkgs/commit/2c5281616010ee627abf04761500335941b4cc55) prefetch-npm-deps: support file: scheme for dependencies
* [`f33cf3c0`](https://github.com/NixOS/nixpkgs/commit/f33cf3c09ed6c4345ca13f46df17012fda9d46c4) meson.setupHook: fix enableParallelChecking
* [`9088b3d1`](https://github.com/NixOS/nixpkgs/commit/9088b3d1674994911e0d24c851fb46cca48871a0) python3Packages.paramiko: invoke is a required dependency
* [`b6254c48`](https://github.com/NixOS/nixpkgs/commit/b6254c48df9b757515242f80d7f78a598333b941) duplicity: remove invoke from dependencies
* [`23c46c60`](https://github.com/NixOS/nixpkgs/commit/23c46c60c0dca1e971425b43903dd87ea206e674) bintools-wrapper: use `tr` for uppercase
* [`358b2e10`](https://github.com/NixOS/nixpkgs/commit/358b2e106a381d25a8398bab0737bca027244012) komorebi: fix by moving to webkitgtk_4_1
* [`f6da9198`](https://github.com/NixOS/nixpkgs/commit/f6da9198396a515d12e2f9d41bc7d6b45aa28209) gbenchmark: 1.9.4 -> 1.9.5
* [`63ac700b`](https://github.com/NixOS/nixpkgs/commit/63ac700b307cfca805d642d85a459e8c3371526b) gbenchmark: add miniharinn as a maintainer
* [`5bbc0ca2`](https://github.com/NixOS/nixpkgs/commit/5bbc0ca205eb1ec55775d34f62ad6d359912346e) openusage: init at 0.6.13
* [`68ee0a8e`](https://github.com/NixOS/nixpkgs/commit/68ee0a8e0e154d5a31018fe69053e5f17012fbe5) libcbor: 0.13.0 -> 0.14.0
* [`216e73bd`](https://github.com/NixOS/nixpkgs/commit/216e73bd0ffce505b23e5396c8ae6304d9149a04) cmocka: 2.0.1 -> 2.0.2
* [`97662022`](https://github.com/NixOS/nixpkgs/commit/976620227c535b72fcd0f2f89d903711c88b6afe) logseq: enable text_input_v3 protocol
* [`3e85677f`](https://github.com/NixOS/nixpkgs/commit/3e85677fa702783b6d5a8b2b721fd9fad153625c) playonlinux: pin Python version to 3.12
* [`8b7658bf`](https://github.com/NixOS/nixpkgs/commit/8b7658bfa57bcc361bdb7d79c80f9cf0bde62db0) installer/nixos-generate-config: use lib.getExe
* [`623ec633`](https://github.com/NixOS/nixpkgs/commit/623ec633ba806be11031a0cd1760649edd9d5c3a) nixos-generate-config: substitute bcachefs
* [`e7d1fca5`](https://github.com/NixOS/nixpkgs/commit/e7d1fca56e9878d4f7e70ad1b8678e913a4b2316) netpbm: 11.13.3 -> 11.14.0
* [`6c4ea36a`](https://github.com/NixOS/nixpkgs/commit/6c4ea36aa2a000b29975b2923592c448d6ef4b90) mkfontdir: 1.2.3 -> 1.2.4
* [`2b8ae0a0`](https://github.com/NixOS/nixpkgs/commit/2b8ae0a0f1e2a1c302cab306ee8926f0214f71ba) openssl*: enable strictDeps and __structuredAttrs
* [`40041739`](https://github.com/NixOS/nixpkgs/commit/40041739c7dc0885be77d3dc259b10354ed9d189) elfutils: 0.194 -> 0.195
* [`95f82fa6`](https://github.com/NixOS/nixpkgs/commit/95f82fa6e711b63f1b94ba2b30ba9bfd0f2e46ca) fluidsynth: 2.5.3 -> 2.5.4
* [`22c16508`](https://github.com/NixOS/nixpkgs/commit/22c16508ff059a8625045fc49667ab82ede36240) maintainers: add tiptenbrink
* [`c1fde5e8`](https://github.com/NixOS/nixpkgs/commit/c1fde5e8adc88ec9a133913b2b67c61b1a4d666e) game-music-emu: 0.6.4 -> 0.6.5
* [`4ec33b01`](https://github.com/NixOS/nixpkgs/commit/4ec33b014efb87a9a6997bdf8bdd4e9f62790272) md4c: 0.5.2 -> 0.5.3
* [`4f723415`](https://github.com/NixOS/nixpkgs/commit/4f72341536ca5fdb7520328e835802476a897f1b) valgrind: 3.26.0 -> 3.27.0
* [`f20fda6d`](https://github.com/NixOS/nixpkgs/commit/f20fda6d42187f1c54896b1356941472cc844972) gnused: 4.9 -> 4.10
* [`75eb3476`](https://github.com/NixOS/nixpkgs/commit/75eb347675416d3bdb8d0b9b2324b18b540a3607) libmpc: 1.4.0 -> 1.4.1
* [`0cad835b`](https://github.com/NixOS/nixpkgs/commit/0cad835b0178a71d5e6020b50be14f6f2da02fa6) fnox: init at 1.20.0
* [`66f8b347`](https://github.com/NixOS/nixpkgs/commit/66f8b34702e9383982299dff12febaa8e2734195) asdf-vm: 0.18.1 -> 0.19.0
* [`9dbaf2b0`](https://github.com/NixOS/nixpkgs/commit/9dbaf2b09f8e512f13c68ff4c583103f14c84fa7) libhwy: 1.3.0 -> 1.4.0
* [`02ddf0a0`](https://github.com/NixOS/nixpkgs/commit/02ddf0a084f082c1f9bdd8b8f16fae66d0f8ae14) libxslt: fixup cmake so it can properly find lib outputs
* [`a0329b88`](https://github.com/NixOS/nixpkgs/commit/a0329b88aed371b01b272c79b63f7097e66f8315) libmicrohttpd: 1.0.2 -> 1.0.5
* [`2ba029a7`](https://github.com/NixOS/nixpkgs/commit/2ba029a78e1fc8804152a62e4202215264554b6c) openblas: 0.3.32 -> 0.3.33
* [`57cd8cc8`](https://github.com/NixOS/nixpkgs/commit/57cd8cc8a3a34e5d97b64885973eef72dbfd24ef) mpg123: 1.33.4 -> 1.33.5
* [`7bd3d8da`](https://github.com/NixOS/nixpkgs/commit/7bd3d8daf2081be2a6a0aa44b54f0df58f95c7d4) doctest: 2.5.0 -> 2.5.2
* [`b0af5522`](https://github.com/NixOS/nixpkgs/commit/b0af552236ff2e10d2fd7c3de4819079062c8055) assimp: 6.0.4 -> 6.0.5
* [`fc513d02`](https://github.com/NixOS/nixpkgs/commit/fc513d020b35545da312241125fa5cb60b3d4a0f) nixos/systemd-lib: use structuredAttrs instead of passAsFile for makeUnit
* [`06b17cff`](https://github.com/NixOS/nixpkgs/commit/06b17cff7d67f07779cc4b2adae419012c90f677) libapparmor: 4.1.7 -> 5.0.0
* [`bdf0f784`](https://github.com/NixOS/nixpkgs/commit/bdf0f78441fed57554d61c43c3ce8bdb7838403f) python3Packages.sphinx-last-updated-by-git: remove changelog
* [`f0847890`](https://github.com/NixOS/nixpkgs/commit/f0847890f4303c4c69c3c252eb183bf60fc46a45) srt: 1.5.4 -> 1.5.5
* [`feb7c9ff`](https://github.com/NixOS/nixpkgs/commit/feb7c9ff7812521077ce8ac75c0cdc8f5de31152) libressl_4_3: init at 4.3.1
* [`0bfe3de9`](https://github.com/NixOS/nixpkgs/commit/0bfe3de9edd95a12bd7049dcd03055d796124a31) libressl_4_1: delete unsupported package
* [`16656233`](https://github.com/NixOS/nixpkgs/commit/16656233905ab0ff2fa329c86593cb925094b1e7) libressl: add ruuda as maintainer
* [`c74cade4`](https://github.com/NixOS/nixpkgs/commit/c74cade494dc95a74dd75099bf700e9bab5deb35) libressl: enable strictDeps and __structuredAttrs
* [`63147b12`](https://github.com/NixOS/nixpkgs/commit/63147b12a5831e23ce5e88f5f9a35fe8997e9978) openldap: skip flaky syncreplication tests
* [`21622bac`](https://github.com/NixOS/nixpkgs/commit/21622bac70c240e85777be65c5b65bac6c3f3553) freetype: 2.14.2 -> 2.14.3
* [`efdf5458`](https://github.com/NixOS/nixpkgs/commit/efdf5458bd1bbff0bb38dba4b05ac1766ecd9590) python3Packages.mistune: 3.2.0 -> 3.2.1
* [`b926d50a`](https://github.com/NixOS/nixpkgs/commit/b926d50aaf166585c1395092adbdaaa7b572632b) minimal-bootstrap: reduce bootstrap time
* [`6014579a`](https://github.com/NixOS/nixpkgs/commit/6014579a95320d82b7d483ac2392d4a134541685) clang, cc-wrapper: make wrapper flang-aware
* [`324f837b`](https://github.com/NixOS/nixpkgs/commit/324f837bf1a8cd5f1378501cedeb9b80f037081b) flang-rt: add runtime package
* [`1ba36147`](https://github.com/NixOS/nixpkgs/commit/1ba36147a8db08211ee1e08ef61af09aad489deb) flang: package standalone flang with LLVM 20+ driver fixes
* [`7e8258d3`](https://github.com/NixOS/nixpkgs/commit/7e8258d3af32103093ec90a6f9b4ae191f4fd5b0) llvm/mlir: fix MLIRConfig.cmake to support external tablegen overrides
* [`f6dbd25f`](https://github.com/NixOS/nixpkgs/commit/f6dbd25fcd03a206dee2c3e49a5f824927d88063) python3Packages.magika: 1.0.2 -> 1.0.3
* [`09bb0b6e`](https://github.com/NixOS/nixpkgs/commit/09bb0b6ec4d020e2e1ca78b03af7ebd67385e309) yara: 4.5.5 -> 4.5.6
* [`6bfe46da`](https://github.com/NixOS/nixpkgs/commit/6bfe46da49c97390f2a81d3fd2bdc2281fae2af7) hwdata: 0.406 -> 0.407
* [`99cda4d5`](https://github.com/NixOS/nixpkgs/commit/99cda4d5c7e6f7b427dea344b91f3207e5e6e11d) hotdoc: use callPackage, refactor clang usage
* [`eeb1649a`](https://github.com/NixOS/nixpkgs/commit/eeb1649a2fa25faf1c8cfdfe009dc7f174f12c4b) python3Packages.xmltodict: 1.0.2 -> 1.0.4
* [`00c938ca`](https://github.com/NixOS/nixpkgs/commit/00c938cad9fb1ad0f5e332811ea923879f2a1c7b) hotdoc: move to pkgs/by-name
* [`230567bf`](https://github.com/NixOS/nixpkgs/commit/230567bf2bf1a6cecd3a3a2c956eeb02cf451c29) python3Packages.xmltodict: add dotlambda to maintainers
* [`19df48b9`](https://github.com/NixOS/nixpkgs/commit/19df48b95abeaa4a18df925c21356d5d994e21c6) hunspell: 1.7.2 -> 1.7.3
* [`16ed2d73`](https://github.com/NixOS/nixpkgs/commit/16ed2d73444b123572b501142e046265b8013b3a) djvulibre: 3.5.29 -> 3.5.30
* [`dd134e69`](https://github.com/NixOS/nixpkgs/commit/dd134e69e6f64e4a7f6f6e260dfc25776cd89b93) minimal-bootstrap: fix early-musl-userland flake on parallel builds
* [`08521f3b`](https://github.com/NixOS/nixpkgs/commit/08521f3b58242c879b96105dc23102c8ea708d5f) minimal-bootstrap.binutils: --disable-{gold,plugins}
* [`9eb073da`](https://github.com/NixOS/nixpkgs/commit/9eb073dafa87aa513a1ac5e353c3c9948903f072) minimal-bootstrap.glibc: --disable-{nscd,build-nscd,profile,timezone-tools,mathvec}
* [`4791df24`](https://github.com/NixOS/nixpkgs/commit/4791df2472f2b75a852a49306884d9b88e2e6c56) minimal-bootstrap.gcc46-cxx: --disable-{libsanitizer,shared}
* [`1ea118f2`](https://github.com/NixOS/nixpkgs/commit/1ea118f2b0a43aa573848517968a1ac90ff3e225) minimal-bootstrap.gcc10: drop ISL, --disable-{libstdcxx-filesystem-ts,shared}
* [`9ced5a33`](https://github.com/NixOS/nixpkgs/commit/9ced5a330a4bca970d931aa622ddab02eef359bc) minimal-bootstrap.gcc-latest: drop ISL, --disable-shared
* [`0571f521`](https://github.com/NixOS/nixpkgs/commit/0571f521a81fbd72eda2f9c8dae949ad54594f1c) minimal-bootstrap.gcc-glibc: drop ISL, --disable-libstdcxx-{backtrace,filesystem-ts}
* [`04d41267`](https://github.com/NixOS/nixpkgs/commit/04d4126705c928fc30af301c62d98ef2fb4e3c75) amf-headers: 1.5.0 -> 1.5.2
* [`918f96b7`](https://github.com/NixOS/nixpkgs/commit/918f96b7000f7b6d9a294d997787d3ca34c17dd8) maintainers: add roman-16
* [`6517fae6`](https://github.com/NixOS/nixpkgs/commit/6517fae64e6b483e510f46db6d0f970f1fbdcf84) pypy3Packages.meson: fix postPatch
* [`8a07895d`](https://github.com/NixOS/nixpkgs/commit/8a07895dc2b3ecb7fec03b14ced0d3fe533c4884) pypy3Packages.sphinx: update disabled test paths
* [`957d7443`](https://github.com/NixOS/nixpkgs/commit/957d7443453c3d11cb74aa35c181d1ec9f75ca20) pypy3Packages.zopfli: replace setuptools version pin for pypy
* [`a6a28182`](https://github.com/NixOS/nixpkgs/commit/a6a281823a9daf610ca1dd7b4247d2fde394fda2) libcap: 2.77 -> 2.78
* [`097bc92d`](https://github.com/NixOS/nixpkgs/commit/097bc92dee5a3acc370b19c4356fc8533891884d) lulu: init at 4.3.1
* [`82b80522`](https://github.com/NixOS/nixpkgs/commit/82b80522840cef13d64123b66915470568dc27f4) buildLakePackage: force pname, version, and structured attrs
* [`d6926637`](https://github.com/NixOS/nixpkgs/commit/d692663784e44b1f6d757f61e61c8dce9e8ed9c8) buildLakePackage: Remove redundant bindings
* [`cada9af7`](https://github.com/NixOS/nixpkgs/commit/cada9af7d2c62e7922742bac8e0361b2abec5113) buildLakePackage: make FOD use extendMkDerivation as well
* [`2bb9b3d1`](https://github.com/NixOS/nixpkgs/commit/2bb9b3d1669a9bd7c6425c84da9732759c7bedb0) gnutls: remove unused inputs
* [`e34ea07f`](https://github.com/NixOS/nixpkgs/commit/e34ea07f9349b703764bfa81d9a9b65c42367f02) proton-cli: init at 1.4.0
* [`9fafdc76`](https://github.com/NixOS/nixpkgs/commit/9fafdc761f765fd292105a2050be9c6fe279eade) Reapply "nodejs_24: fix majorVersion check"
* [`02d2fdd6`](https://github.com/NixOS/nixpkgs/commit/02d2fdd686118eed0091ea82b41310dc74e571fd) openapv: 0.2.1.2 -> 0.2.1.3
* [`d37588df`](https://github.com/NixOS/nixpkgs/commit/d37588dfa3c8eb4d90c07d8b6b429c75a90d4019) doxygen: 1.16.1 -> 1.17.0
* [`4cdf41c3`](https://github.com/NixOS/nixpkgs/commit/4cdf41c344968cf9f49cfcf46f71dab1c4586475) libfyaml: patch for C11 atomics detection and macros
* [`6cf5d064`](https://github.com/NixOS/nixpkgs/commit/6cf5d0644f4b3dc950fe87c9d61682f049bade27) libedit: 20251016-3.1 -> 20260508-3.1
* [`00b0ebee`](https://github.com/NixOS/nixpkgs/commit/00b0ebee830ecfdb7d54efef0d57b07bd78ab2d6) dash: 0.5.13.3 -> 0.5.13.4
* [`5e1b9875`](https://github.com/NixOS/nixpkgs/commit/5e1b98759ee1c37fd8e516cae6779581f758dd47) yara: fix the hash
* [`32f67f00`](https://github.com/NixOS/nixpkgs/commit/32f67f000b22d422e36befbbabd36279e2a660a2) openexr: 3.4.10 -> 3.4.11
* [`04928a61`](https://github.com/NixOS/nixpkgs/commit/04928a618027c1780f162aab5880d304d2c356bc) python314: 3.14.4 -> 3.14.5
* [`194e729c`](https://github.com/NixOS/nixpkgs/commit/194e729c3a36c371590d4f3f6f8d610253f75da2) cpython: kill dead code
* [`778a572c`](https://github.com/NixOS/nixpkgs/commit/778a572c94d6f2d89b83f4aa2b6fa902633eb9dd) prek: 0.3.11 -> 0.3.13
* [`4ed3b8cb`](https://github.com/NixOS/nixpkgs/commit/4ed3b8cbf6e463ee73eecfe45e5adea72985492e) spandsp3: fix test failure on musl
* [`f97af3c9`](https://github.com/NixOS/nixpkgs/commit/f97af3c9f75fea16d1a022937633cc75deda12d6) libgpg-error: 1.59 -> 1.61
* [`b78dd5d2`](https://github.com/NixOS/nixpkgs/commit/b78dd5d217924d72cb1e058422e01a0f43714c1a) luaPackages.luarocks_bootstrap: properly configure luarocks to set LUA_LIBDIR
* [`3803be52`](https://github.com/NixOS/nixpkgs/commit/3803be5263c98b9e52d0e6f791272137f5e1e193) simdjson: 4.6.0 -> 4.6.4
* [`fe1ca2c5`](https://github.com/NixOS/nixpkgs/commit/fe1ca2c575fa37169ccb114ffc9a5581aa44860d) expat: 2.8.0 -> 2.8.1
* [`18366e70`](https://github.com/NixOS/nixpkgs/commit/18366e70a82125a938b33f5eceaafd762c768768) gdb: 17.1 -> 17.2
* [`c547b0d1`](https://github.com/NixOS/nixpkgs/commit/c547b0d10bdf20d9d5a1e4d3cdf49b01ed866148) maintainers: add jeremystucki
* [`9b556d8f`](https://github.com/NixOS/nixpkgs/commit/9b556d8f14f87012ce74d6f54eaea0c6bbbdc655) license-plist: init at 3.27.7
* [`00cd8e64`](https://github.com/NixOS/nixpkgs/commit/00cd8e646c7da669125ae26acf4b47079826e1f0) libcaca: apply patch for CVE-2026-42046
* [`1860b778`](https://github.com/NixOS/nixpkgs/commit/1860b778a5a8abe503b0f6098d292514bc8560ae) libfyaml: fixing pflag mismatched intention
* [`59edd93a`](https://github.com/NixOS/nixpkgs/commit/59edd93aa956ce3b5ec85c492bbc70c3fc932fa7) libfyaml: patch for libm "none required" issues
* [`37cad8f4`](https://github.com/NixOS/nixpkgs/commit/37cad8f4e382617c3a98aa5af8b1efb4acac5e81) catch2_3: 3.14.0 -> 3.15.0
* [`b2e8b0c6`](https://github.com/NixOS/nixpkgs/commit/b2e8b0c6028f84faa0cf2b959732f30591c7f18f) Revert "groff: only apply the latest patch on linux for now"
* [`5198c49a`](https://github.com/NixOS/nixpkgs/commit/5198c49a5a58932c1a782aee9ad2fd6509f935e1) libressl_4_3: backport executable stack fix
* [`2b8ed1fe`](https://github.com/NixOS/nixpkgs/commit/2b8ed1fe219eb6783afc4081e3ab62e8ee99ee39) audit: 4.1.2-unstable-2025-09-06 -> 4.1.4
* [`6c0ee887`](https://github.com/NixOS/nixpkgs/commit/6c0ee887326898b4baae9a977347ca05b0fde76c) glslang: 16.2.0 -> 16.3.0
* [`b3147b17`](https://github.com/NixOS/nixpkgs/commit/b3147b179a9b64b835c6cc6ad88c3dc5021b3739) vulkan-headers: 1.4.341.0 -> 1.4.350.0
* [`c2b36e9c`](https://github.com/NixOS/nixpkgs/commit/c2b36e9c51e7c167e296b0fc9c95968731efefff) vulkan-loader: 1.4.341.0 -> 1.4.350.0
* [`353dd30c`](https://github.com/NixOS/nixpkgs/commit/353dd30c46cf461890e9903976178e16f6cfff4e) vulkan-validation-layers: 1.4.341.0 -> 1.4.350.0
* [`f86d7dfd`](https://github.com/NixOS/nixpkgs/commit/f86d7dfdee90d252f21603919561f662a39f3588) vulkan-tools: 1.4.341.0 -> 1.4.350.0
* [`de214862`](https://github.com/NixOS/nixpkgs/commit/de214862bb241fe227fb8f3993afcadcc1a41c14) vulkan-tools-lunarg: 1.4.341.0 -> 1.4.350.0
* [`8924c245`](https://github.com/NixOS/nixpkgs/commit/8924c245e7e8c9ae432e405038eb778022e2eb20) vulkan-extension-layer: 1.4.341.0 -> 1.4.350.0
* [`e494c958`](https://github.com/NixOS/nixpkgs/commit/e494c9581f738b7ec34c1e972308a5226ab557d8) vulkan-utility-libraries: 1.4.341.0 -> 1.4.350.0
* [`b0cff5e2`](https://github.com/NixOS/nixpkgs/commit/b0cff5e20f3598e0bf581ab2942614bb49a69d00) spirv-cross: 1.4.341.0 -> 1.4.350.0
* [`c832986d`](https://github.com/NixOS/nixpkgs/commit/c832986da6f651660d271194dad9f951c1719fa9) vulkan-volk: 1.4.341.0 -> 1.4.350.0
* [`ea3998dd`](https://github.com/NixOS/nixpkgs/commit/ea3998dd4348525ca588cb7ffa797b57f8457ba6) spirv-tools: 1.4.341.0 -> 1.4.350.0
* [`bbfc13f3`](https://github.com/NixOS/nixpkgs/commit/bbfc13f3fe4253beda6d14bc9dcaa84cdd4e08da) spirv-headers: 1.4.341.0 -> 1.4.350.0
* [`3b9aea24`](https://github.com/NixOS/nixpkgs/commit/3b9aea2467ea586ad703b1e390fd7f0a47f4a206) sqlite: 3.51.2 -> 3.53.1
* [`fad1bd87`](https://github.com/NixOS/nixpkgs/commit/fad1bd870d529e9739978d06206156d64034da8e) guile: set `meta.mainProgram`
* [`61b63e8b`](https://github.com/NixOS/nixpkgs/commit/61b63e8b5a57f9d3a75b03f698e1f31cc5ce55c5) python314Packages.gast: remove astunparse
* [`fbe89543`](https://github.com/NixOS/nixpkgs/commit/fbe89543131df4abbc8fb9b368bdbe0a42566e1d) python314Packages.astunparse: drop not required wheel dependency
* [`a14b8f95`](https://github.com/NixOS/nixpkgs/commit/a14b8f95cc4d7f8b2e75f701501c0544c417a041) python314Packages.astunparse: set pyproject = true
* [`b7da8e82`](https://github.com/NixOS/nixpkgs/commit/b7da8e825ddf25cf8d6df1eb9ef2165a2804f944) luaPackages.dkjson: 2.8-2 -> 2.9-1
* [`8e730cb7`](https://github.com/NixOS/nixpkgs/commit/8e730cb76072abfa046465399edad890ca75328e) luaPackages.dkjson: 2.9-1 -> 2.10-1
* [`2351a8df`](https://github.com/NixOS/nixpkgs/commit/2351a8df54be7484c7da7f6fbe1f24ac1db7a0e4) minimal-bootstrap: only create one derivation for mes sources
* [`a7338726`](https://github.com/NixOS/nixpkgs/commit/a7338726f54dca2fbb8d0f5eb1297af20febd57e) minimal-bootstrap: avoid forcing meta definition
* [`d240d8ae`](https://github.com/NixOS/nixpkgs/commit/d240d8ae80d9cf1b76c59375f1c90cdee2eb190b) libmd: 1.1.0 -> 1.2.0
* [`757acf21`](https://github.com/NixOS/nixpkgs/commit/757acf21b82a3ca9a070e0267acc10faced77bb3) x265: 4.1 -> 4.2
* [`a7daddef`](https://github.com/NixOS/nixpkgs/commit/a7daddef5b46fd55f43e3aad943882516d5609c7) handbrake: 1.10.2 -> 1.11.1
* [`ecc16d32`](https://github.com/NixOS/nixpkgs/commit/ecc16d328b05308abd7b80af1fdb33def80ffd6b) tinyxxd: 1.3.15 -> 1.3.16
* [`c8a15a9b`](https://github.com/NixOS/nixpkgs/commit/c8a15a9b709bd7bb191ad7587a9ea55e54116f7b) libei: 1.5.0 -> 1.6.0
* [`3c52efb0`](https://github.com/NixOS/nixpkgs/commit/3c52efb060ec585d4b6adbf09822ab75f3476ecb) libunistring: enable __structuredAttrs
* [`65c17bdb`](https://github.com/NixOS/nixpkgs/commit/65c17bdbe095b5ab84f03b2d8214d596573b1ca0) utf8cpp: 4.0.9 -> 4.1.0
* [`35441d74`](https://github.com/NixOS/nixpkgs/commit/35441d748159534185e67177d683e3c58a41321e) c-ares: enable strictDeps, structuredAttrs
* [`01e4dac6`](https://github.com/NixOS/nixpkgs/commit/01e4dac6b3c1ca14ebebe2b59b06f48c692a9be6) boost: strictDeps
* [`097b8a0e`](https://github.com/NixOS/nixpkgs/commit/097b8a0ef0503be85b9845d483a5445b567e4160) python3Packages.boost: fix use of user-config.jam
* [`52a17d79`](https://github.com/NixOS/nixpkgs/commit/52a17d79945fd79d6ef161d708b3a277336a9b7a) boost191: init at 1.91.0
* [`e7c43248`](https://github.com/NixOS/nixpkgs/commit/e7c432489f86d2650d6dd9bc95ea01cf46c86257) fuse3: 3.17.4 -> 3.18.2
* [`c7c2309c`](https://github.com/NixOS/nixpkgs/commit/c7c2309c84a1729387b3a315b373c97de8f8833a) fuse3: modernize
* [`329b59d0`](https://github.com/NixOS/nixpkgs/commit/329b59d07d7f527a9dcb25481b3504804b8cd70b) dbus: fix install name on installed binaries
* [`171926f8`](https://github.com/NixOS/nixpkgs/commit/171926f883a3ea50add3939d569a75417982f72c) dbus: default to using tmpdir instead of launchd activation
* [`033d41e2`](https://github.com/NixOS/nixpkgs/commit/033d41e2e542a1449f933113a601e77220755897) darwin.sourceRelease: 26.3 -> 26.4
* [`5663b169`](https://github.com/NixOS/nixpkgs/commit/5663b16973445e8f1c58057f55599b3c9882cbc7) darwin.adv_cmds: fix build after 26.4 source release update
* [`63d7cdac`](https://github.com/NixOS/nixpkgs/commit/63d7cdac01939aa8fd7dd5561a63b152dc2d63aa) darwin.AvailabilityVersions: 155 -> 157.2
* [`10bb94fb`](https://github.com/NixOS/nixpkgs/commit/10bb94fb92560bd6a169b4b106098ddc0f17bfed) darwin.copyfile: 230.0.1.0.1 -> 240
* [`89251e81`](https://github.com/NixOS/nixpkgs/commit/89251e8199cd1bf5740e8088e85d6afe24aa093e) darwin.developer_cmds: 87 -> 89
* [`3ea2eff0`](https://github.com/NixOS/nixpkgs/commit/3ea2eff071bad9cb03b3582c2e02309125be3011) darwin.diskdev_cmds: 751.80.2 -> 757
* [`ad15de5d`](https://github.com/NixOS/nixpkgs/commit/ad15de5dbd17c591bc755ead6f2981d0d8d28f61) darwin.dyld: 1340 -> 1376.6
* [`ca6d6d58`](https://github.com/NixOS/nixpkgs/commit/ca6d6d5817edb91338ff221a63f30fb38bd33589) darwin.file_cmds: 475 -> 479
* [`4c124e96`](https://github.com/NixOS/nixpkgs/commit/4c124e96a89c72f71026522204a1c6b8bb13600a) darwin.ICU: 76142.3.1.1 -> 76142.4.7
* [`6575bc02`](https://github.com/NixOS/nixpkgs/commit/6575bc0242017976bd3924c72d6d498f79f014bf) darwin.libiconv: 113 -> 115.100.1
* [`0d5d9a51`](https://github.com/NixOS/nixpkgs/commit/0d5d9a512954686344ed5e5346bab660983c5cfc) darwin.libpcap: 144 -> 146
* [`11e16349`](https://github.com/NixOS/nixpkgs/commit/11e16349972656869ac34c91b73ea50fecb82f17) darwin.libresolv: 93 -> 96
* [`a90fc627`](https://github.com/NixOS/nixpkgs/commit/a90fc6279376633863e9f9bd52d1a9719630a9fe) darwin.mail_cmds: 41 -> 43
* [`362d374d`](https://github.com/NixOS/nixpkgs/commit/362d374daf44df736ebbbd86288f66669476cd4f) darwin.network_cmds: 730.80.3 -> 741.100.2
* [`857fccfb`](https://github.com/NixOS/nixpkgs/commit/857fccfb375188654f8947495860739c4e898dd9) darwin.patch_cmds: 72 -> 75
* [`68030807`](https://github.com/NixOS/nixpkgs/commit/68030807a152264bfedb00dafacdc71a3ded0874) darwin.PowerManagement: 1846.81.1 -> 1846.101.2
* [`b850d472`](https://github.com/NixOS/nixpkgs/commit/b850d4728a31bb7922d3e912a95712dbe18bef2a) darwin.remote_cmds: 306 -> 308
* [`03761fb9`](https://github.com/NixOS/nixpkgs/commit/03761fb93a51622cc14c1f20aa17dfaf8a121341) darwin.removefile: 84 -> 85.100.6
* [`4c232cc2`](https://github.com/NixOS/nixpkgs/commit/4c232cc2669e1e272771a095719af84748c15f57) darwin.shell_cmds: 326 -> 329
* [`7a1aca16`](https://github.com/NixOS/nixpkgs/commit/7a1aca160150d04be12b8b00ba56aa1b21914888) darwin.system_cmds: 1039 -> 1042.100.6.0.1
* [`976af9ca`](https://github.com/NixOS/nixpkgs/commit/976af9cac6bf77cea6594526473cdf68df3fc5bf) darwin.text_cmds: 197 -> 199
* [`127450a4`](https://github.com/NixOS/nixpkgs/commit/127450a4fc9134531b214aa72d467232fc7e4e0f) ld64: 956.6 -> 957.1
* [`a81408d1`](https://github.com/NixOS/nixpkgs/commit/a81408d15c1368116b81656f2074d4f405e333e1) apple-sdk_26: 26.4 -> 26.5
* [`516deee1`](https://github.com/NixOS/nixpkgs/commit/516deee1c136242d983d0f510ecb7ca42d885aff) xar: 501 -> 503
* [`6d8c12b2`](https://github.com/NixOS/nixpkgs/commit/6d8c12b2b36e3d5993c522516e533a4c740c27fd) lttng-ust: 2.14.0 -> 2.15.0
* [`facfd506`](https://github.com/NixOS/nixpkgs/commit/facfd506e2abbe3375c7ad8a13a36d6b1f2d4f35) avahi: fix static build
* [`8a93a5d6`](https://github.com/NixOS/nixpkgs/commit/8a93a5d60f68c890877555cdfe449017da27cf1b) bmake: fix cross
* [`d6937f6a`](https://github.com/NixOS/nixpkgs/commit/d6937f6ae7b9e1f2e5f50e6020e5b4db864d7691) x265: fix i686 build
* [`f6172a10`](https://github.com/NixOS/nixpkgs/commit/f6172a101fe458c28e6d70de9e530b2699693d0d) libass: remove libiconv dependency on darwin
* [`bbad6942`](https://github.com/NixOS/nixpkgs/commit/bbad6942e5605f0aa12a8de3e8a290181f23f58a) libusb1: 1.0.29 -> 1.0.30
* [`963f597b`](https://github.com/NixOS/nixpkgs/commit/963f597bc3ffcf2c03004e6df66537a0741b5036) publicsuffix-list: 0-unstable-2026-03-26 -> 0-unstable-2026-05-13
* [`030523c9`](https://github.com/NixOS/nixpkgs/commit/030523c9b86d56c75841ac0381cf6478f7493041) maturin: 1.12.6 -> 1.13.3
* [`fea908fd`](https://github.com/NixOS/nixpkgs/commit/fea908fde99e4dc812e973459875a082c72523f4) stdenv: do not leak outputName out of loop
* [`a0ee8970`](https://github.com/NixOS/nixpkgs/commit/a0ee89704420278abb4c28c7b974500b0d19d39c) wrapGAppsHook: prepare for structuredAttrs
* [`0ddb2c50`](https://github.com/NixOS/nixpkgs/commit/0ddb2c508c423ce9df7a073fbe1db2deb84b41ba) python3Packages.librt: fix cross compilation
* [`789f939d`](https://github.com/NixOS/nixpkgs/commit/789f939dcb76779dca085fe9594c22bb2fd26648) gpgme: 2.0.1 -> 2.1.0
* [`fb0f146a`](https://github.com/NixOS/nixpkgs/commit/fb0f146a68b5c7fe6f776a6f7a3aa7195ad54739) gpgmepp: 2.0.0 -> 2.1.0
* [`ce52fbf0`](https://github.com/NixOS/nixpkgs/commit/ce52fbf05707870a85c04c6f428d1b6558a5b124) qt6Packages.qgpgme: 2.0.0 -> 2.1.0
* [`a74e4f1c`](https://github.com/NixOS/nixpkgs/commit/a74e4f1c48e260b21410ca0143797b944f5eb9cf) nix: remove util-linux test special-casing
* [`28dd6b9d`](https://github.com/NixOS/nixpkgs/commit/28dd6b9df1650e52f3564ee98ec3ebea744b0ca8) util-linux: 2.42 -> 2.42.1
* [`e07e1835`](https://github.com/NixOS/nixpkgs/commit/e07e1835f583ad3af59b8a0c5d93fc529bfec2ff) libxi: 1.8.2 -> 1.8.3
* [`b3e12e96`](https://github.com/NixOS/nixpkgs/commit/b3e12e96da2fdb5c4bca369136dcb9e219002e20) libksba: 1.6.7 -> 1.8.0
* [`b54e4a6c`](https://github.com/NixOS/nixpkgs/commit/b54e4a6c055fcc26b8e22d76adf41e344b3aec06) valgrind: remove pname substitution
* [`4a8e8392`](https://github.com/NixOS/nixpkgs/commit/4a8e8392a42c9668f1ba0af081b4f6195f2341cb) glibc: 2.42-61 -> 2.42-67
* [`0d82881a`](https://github.com/NixOS/nixpkgs/commit/0d82881a6ad2273e718af745cabbcdfe4f7121a0) linuxHeaders: 6.18.7 -> 7.0
* [`f39c4273`](https://github.com/NixOS/nixpkgs/commit/f39c427320106c7f59d11c7c03122972491bb37b) python3Packages.numpy: 2.4.4 -> 2.4.6
* [`a700f706`](https://github.com/NixOS/nixpkgs/commit/a700f706078ba51f1c7a7113cc47e3c5843954a1) libopenmpt: 0.8.6 -> 0.8.7
* [`78f51bc5`](https://github.com/NixOS/nixpkgs/commit/78f51bc5bcc5037966c06d952debc2e3c05f65ba) python3Packages.aiodns: 4.0.0 -> 4.0.3
* [`70d339f3`](https://github.com/NixOS/nixpkgs/commit/70d339f357ec9f39f6afb6cdeab341b48f21aac7) python3Packages.xmltodict: 1.0.2 -> 1.0.4
* [`64b6d4ba`](https://github.com/NixOS/nixpkgs/commit/64b6d4ba189dc1c8eda1b24adcbd39255c9bf33f) vt-cli: 1.3.0 -> 1.3.1
* [`7096ab78`](https://github.com/NixOS/nixpkgs/commit/7096ab788ff94e63a572f77862bcbfd5a8251a77) spidermonkey_140: 140.9.0 -> 140.11.0
* [`8aa7c75b`](https://github.com/NixOS/nixpkgs/commit/8aa7c75b47254ac38ee2470c3ad42a7d6af5bb99) libde265: 1.0.18 -> 1.0.19
* [`83594b90`](https://github.com/NixOS/nixpkgs/commit/83594b903142a5f02015987a98b706416e4161ec) python3Packages.python-multipart: 0.0.22 -> 0.0.29
* [`1355d225`](https://github.com/NixOS/nixpkgs/commit/1355d225b662faa1bb9bdbbfce935c416e2a17a0) python3Packages.asgi-csrf: mark broken
* [`2ca587c6`](https://github.com/NixOS/nixpkgs/commit/2ca587c6020fd949a963f8d30e0bcde6b0a72c60) lcms: 2.18 -> 2.19.1
* [`2318abaa`](https://github.com/NixOS/nixpkgs/commit/2318abaa0baf8fb9db893bee05ba627773b4545b) Revert "nodejs: re-introduce `nodejs.src`"
* [`b7ce3b1b`](https://github.com/NixOS/nixpkgs/commit/b7ce3b1b3fff62a1100e5a38793a8573fb1e6715) karmor: 1.4.6 -> 1.4.7
* [`ba2df560`](https://github.com/NixOS/nixpkgs/commit/ba2df560b675f7f17843675cfce3422fb758745f) python3Packages.frictionless: exclude datasette from nativeCheckInputs
* [`4d809381`](https://github.com/NixOS/nixpkgs/commit/4d80938179e0f3f158caa76d43a019a9b203b46c) python3Packages.sympy: build from GitHub sources, cleanup
* [`db738de1`](https://github.com/NixOS/nixpkgs/commit/db738de1ef7bacf19d46f56b7a8a448a0a87291a) python3Packages.sympy: add GaetanLepage to maintainers
* [`5f6876fa`](https://github.com/NixOS/nixpkgs/commit/5f6876faa1b340550c753e750e7ef03b3cee4996) python3Packages.systemd-python: switch to systemdLibs
* [`470b4097`](https://github.com/NixOS/nixpkgs/commit/470b4097c36f3cb48863f87fb56f86d832b2f2ac) protobuf: enable __structuredAttrs
* [`6481565e`](https://github.com/NixOS/nixpkgs/commit/6481565e50709a9e66e8eaea24f4a0900aad449b) protobuf: 34.1 -> 35.0
* [`5dc0e319`](https://github.com/NixOS/nixpkgs/commit/5dc0e319f9b90fdd54a556974c860a484ccf9d44) protobuf_34: 34.1 -> 34.2
* [`55a082e9`](https://github.com/NixOS/nixpkgs/commit/55a082e984daad073d56896b5673f865c0630ff2) valgrind: 3.27.0 -> 3.27.1
* [`0c98395b`](https://github.com/NixOS/nixpkgs/commit/0c98395be2ba98874b055e6ed709c385446bfe06) unbound: 1.25.0 -> 1.25.1
* [`8aa04404`](https://github.com/NixOS/nixpkgs/commit/8aa0440403113b6fd399b9d7bc62889db9320b9a) microsoft-gsl: 4.2.1 -> 4.2.2
* [`52afc5fa`](https://github.com/NixOS/nixpkgs/commit/52afc5fa587029d9eb09757b68199aea80226062) qt5: 5.15.18 -> 5.15.19
* [`e9b7cf21`](https://github.com/NixOS/nixpkgs/commit/e9b7cf21331391509ae684ab5530fd43373dbd0c) nodejs_24: 24.15.0 -> 24.16.0
* [`aac6f377`](https://github.com/NixOS/nixpkgs/commit/aac6f377a01906dd907e0ccfb6f4d2c4fb76b467) gn: 0-unstable-2026-03-05 -> 0-unstable-2026-04-01
* [`f013dc41`](https://github.com/NixOS/nixpkgs/commit/f013dc41fefa4641fb138a8d1b4dc30af8ae3148) git-toolbelt: 1.10.0 -> 1.11.0
* [`6a792a71`](https://github.com/NixOS/nixpkgs/commit/6a792a71bfd22611ad167767298bee9244d5c339) libaec: 1.1.6 -> 1.1.7
* [`ace84983`](https://github.com/NixOS/nixpkgs/commit/ace84983c415e2f4c20bcb3e561f1bde840ae5e6) gtk4: make patch unconditional
* [`a53c6a38`](https://github.com/NixOS/nixpkgs/commit/a53c6a389758b5517c67c2481d49656191a20880) python3Packages.aiodns: 4.0.3 -> 4.0.4
* [`c18979f7`](https://github.com/NixOS/nixpkgs/commit/c18979f7b2d585ff869d16429675618584d1c1c5) rhash: disable compile-time SHA-NI for x86_64 compatibility
* [`5131deab`](https://github.com/NixOS/nixpkgs/commit/5131deab4ec023f576cd4e6b0519c282dab8206d) libgcrypt: 1.11.2 -> 1.12.2
* [`8007e967`](https://github.com/NixOS/nixpkgs/commit/8007e967b33514b9b71ac6a0245c53ebff775d4e) duckdb: 1.5.2 -> 1.5.3
* [`963d350e`](https://github.com/NixOS/nixpkgs/commit/963d350eecafb5555700ca2a6ec857fc739409cc) which: 2.23 -> 2.25
* [`ce3f5238`](https://github.com/NixOS/nixpkgs/commit/ce3f5238f07e55b399acd5d8b5939972730f20ca) utf8cpp: 4.1.0 -> 4.1.1
* [`66adfb9d`](https://github.com/NixOS/nixpkgs/commit/66adfb9dab823f579f9d45ee241731a10fb4e7eb) kdePackages.plasma-workspace: backport patch for Qt 6.11.1 regression
* [`1b3320b2`](https://github.com/NixOS/nixpkgs/commit/1b3320b2d9c665aa4689ea2661221a7753afb974) qt6: 6.11.0 -> 6.11.1
* [`6f40c4f1`](https://github.com/NixOS/nixpkgs/commit/6f40c4f10c3e1166f2e9ee552f5b8f28c967b763) tree-sitter: 0.26.8 -> 0.26.9
* [`9d229c78`](https://github.com/NixOS/nixpkgs/commit/9d229c780ed441cda7dcf943718cc8aa3aa53492) rsync: skip chgrp test
* [`11aa871c`](https://github.com/NixOS/nixpkgs/commit/11aa871c2290aa6407227e255da0820a575d2109) python3Packages.mypy: fix cross compilation
* [`39d6b815`](https://github.com/NixOS/nixpkgs/commit/39d6b815825efe757e1616fb80190a4e66c85bdd) bmake: restore missing bsd.*.mk symlinks on Darwin
* [`bb9fb0a2`](https://github.com/NixOS/nixpkgs/commit/bb9fb0a2eb6b9481c8d48597f9da1c9fc2022459) bmake: enable __structuredAttrs
* [`5f3abe53`](https://github.com/NixOS/nixpkgs/commit/5f3abe53c32f4bf6aa20e4bfa582566d21d5e085) python3Packages.urllib3: 2.6.3 -> 2.7.0
* [`b353c0a0`](https://github.com/NixOS/nixpkgs/commit/b353c0a0f82604f8d0ae661c268594011039606c) python3Packages.urllib3: use finalAttrs
* [`c146bd08`](https://github.com/NixOS/nixpkgs/commit/c146bd0855981393886d773bf056bc0039bcd64b) tunnelgraf: mark insecure
* [`30a78f29`](https://github.com/NixOS/nixpkgs/commit/30a78f292564a1d67ba2eff1701bc268d21bbb1b) python3Packages.paramiko: 4.0.0 -> 5.0.0
* [`a8643c62`](https://github.com/NixOS/nixpkgs/commit/a8643c627799de71d9f10605370b8ed3a478a8b2) python3Packages.paramiko: use finalAttrs
* [`9305bbec`](https://github.com/NixOS/nixpkgs/commit/9305bbec01cdd5c5b08f076b0fe136b267596786) python3Packages.twisted: 25.5.0 -> 26.4.0
* [`3c5b8bbd`](https://github.com/NixOS/nixpkgs/commit/3c5b8bbdbaea8e109f0194917257d9cfbc75aff3) python3Packages.scrapy: 2.14.1 -> 2.16.0
* [`948ae444`](https://github.com/NixOS/nixpkgs/commit/948ae444f28653e219f6be6a01a1f376e7dc20a8) mdbook: 0.5.2 -> 0.5.3
* [`a17a97fe`](https://github.com/NixOS/nixpkgs/commit/a17a97fe7e53c20617fbec8112db78bf75badb2b) python3Packages.opentelemetry-api: 1.34.0 -> 1.40.0
* [`d40d2aad`](https://github.com/NixOS/nixpkgs/commit/d40d2aaddf1821f005e4faf984400115563670fd) python3Packages.opentelemetry-instrumentation: 0.55b0 -> 0.61b0
* [`a84547aa`](https://github.com/NixOS/nixpkgs/commit/a84547aa748905969c54c0b5a5a154f552d1eb09) python3Packages.opentelemetry-instrumentation-requests: fix test fixtures
* [`e708eaa2`](https://github.com/NixOS/nixpkgs/commit/e708eaa2be3978abc319c810b2ed10cf09da028b) python3Packages.opentelemetry-semantic-conventions-ai: init at 0.4.15
* [`d2a5f7f0`](https://github.com/NixOS/nixpkgs/commit/d2a5f7f0cafe93df429883d62a6365ec7f4db78c) libadwaita: 1.9.0 -> 1.9.1
* [`eb99a699`](https://github.com/NixOS/nixpkgs/commit/eb99a699438577d486d66e3d860c3ba67facbb1b) at-spi2-core: 2.60.1 -> 2.60.4
* [`4bb8e4bd`](https://github.com/NixOS/nixpkgs/commit/4bb8e4bdb522b174b3ce139cc5dd8f16a4f325c2) valgrind.meta.mainProgram: init
* [`6e3f57e4`](https://github.com/NixOS/nixpkgs/commit/6e3f57e4db27a98f0d9e7de6f91f3040722333b7) pgcopydb: 0.17 -> 0.17-unstable-2026-05-21
* [`6afef1c8`](https://github.com/NixOS/nixpkgs/commit/6afef1c80a05389c7e96bc78c4341fd70fe18179) pgcopydb: propagate postgresql's buildInputs
* [`9c5e58d0`](https://github.com/NixOS/nixpkgs/commit/9c5e58d0798fb7d328e984eafc0d819e46ad68b1) postgresql: 17 -> 18
* [`ec4a8ef6`](https://github.com/NixOS/nixpkgs/commit/ec4a8ef68a685636b208b21291c4612cf96984b8) libretro.mame2015: move env variable into env for structuredAttrs
* [`3c879e9d`](https://github.com/NixOS/nixpkgs/commit/3c879e9d158061f58ddfd4a1751e6fc360294366) gnome2.libglade: move env variable into env for structuredAttrs
* [`85fec585`](https://github.com/NixOS/nixpkgs/commit/85fec585ad053aae1695f5235b6bf7d70640f709) lomiri.geonames: move env variable into env for structuredAttrs
* [`e9d415c2`](https://github.com/NixOS/nixpkgs/commit/e9d415c211771e4ac18c522d1cdeda7b7a354b50) lomiri.libusermetrics: move env variable into env for structuredAttrs
* [`287994f1`](https://github.com/NixOS/nixpkgs/commit/287994f163dadb629c2aa8e92e6c5f8068265e5a) java-properties: move env variable into env for structuredAttrs
* [`59a14778`](https://github.com/NixOS/nixpkgs/commit/59a147780b55787b12d8436ce67b8d5b8e467a42) tree-sitter-grammars: move env variable into env for structuredAttrs
* [`8ee15adf`](https://github.com/NixOS/nixpkgs/commit/8ee15adfece7d34ce1de614e6a40bb469da01d54) tree-sitter-grammars: set __structuredAttrs
* [`51f6d0a4`](https://github.com/NixOS/nixpkgs/commit/51f6d0a44cbf2051f267b101abd331b4fd372915) valkey: 9.0.4 -> 9.1.0
* [`035848a2`](https://github.com/NixOS/nixpkgs/commit/035848a217ee2b409b20e647f33a57a9e797226c) xleak: 0.2.5 -> 0.2.6
* [`e456e5c0`](https://github.com/NixOS/nixpkgs/commit/e456e5c07f724241d7a02932aec97cba63f8d011) cargo-c: 0.10.19 -> 0.10.22
* [`aac345d2`](https://github.com/NixOS/nixpkgs/commit/aac345d252c9b9bf6aad461c4eadbba96971f29e) agent-safehouse: init at 0.10.1
* [`99c95868`](https://github.com/NixOS/nixpkgs/commit/99c958682d291c05ae2a0a044f16aa1cdb997e9e) less: 692 -> 702
* [`3d799a0c`](https://github.com/NixOS/nixpkgs/commit/3d799a0c8fb4bb552fc6d18f89c9b122a6b4185f) double-conversion: 3.3.1 -> 3.4.0
* [`ec681ffc`](https://github.com/NixOS/nixpkgs/commit/ec681ffc8f0d1277b5f5a19ad844c5a7d3fda2b1) e2fsprogs: 1.47.3 -> 1.47.4
* [`b5ea1ced`](https://github.com/NixOS/nixpkgs/commit/b5ea1ced768bb4cfcfee96d1ca792f057bdbb2a4) swtpm: 0.10.1 -> 0.10.1-unstable-05-06-2026
* [`83ece5c3`](https://github.com/NixOS/nixpkgs/commit/83ece5c3a1e6340a1d9b9b40db3d5c50e9e05672) python3Packages.starlette: 0.52.1 -> 1.1.0
* [`b481729f`](https://github.com/NixOS/nixpkgs/commit/b481729faf5004e2da0fa3b932a6f2696b4cc98c) python3Packages.fastapi: 0.135.3 -> 0.136.3
* [`81d174f7`](https://github.com/NixOS/nixpkgs/commit/81d174f747c20e3283d967915d8e990700bbb26f) pipewire: 1.6.5 -> 1.6.6
* [`509c59e6`](https://github.com/NixOS/nixpkgs/commit/509c59e6fc23ddb5bcb1e793be83e1b6750c77ad) dotnet_{8,9,10,11}.vmr: move env variable into env for structuredAttrs
* [`785fcc8e`](https://github.com/NixOS/nixpkgs/commit/785fcc8edcec64ee191010697cf648be7fb3090f) dino: migrate to by-name
* [`8d2dbc32`](https://github.com/NixOS/nixpkgs/commit/8d2dbc322b1436ad3941738b428103423f9463da) python3Packages.certbot: 5.4.0 -> 5.6.0
* [`c0495d49`](https://github.com/NixOS/nixpkgs/commit/c0495d494a91369cbbca91616a74a94baaad1479) python3Packages.certbot: add miniharinn as a maintainer
* [`be1f6a33`](https://github.com/NixOS/nixpkgs/commit/be1f6a337333de4cf993cf8f54c6736ef1244d5f) python3Packages.certbot: use finalAttrs
* [`02d0ef1c`](https://github.com/NixOS/nixpkgs/commit/02d0ef1ce000de8f47e56363fb80bbf3ea1a6cf9) python3Packages.hass-nabucasa: unpin acme
* [`4a101f0c`](https://github.com/NixOS/nixpkgs/commit/4a101f0ce85487c821f8cd07e0a9715e4a1389d6) imagemagick: 7.1.2-23 -> 7.1.2-24
* [`160ca655`](https://github.com/NixOS/nixpkgs/commit/160ca6558e44577004c7660a41e6cf50557d7661) curl: set structuredAttrs
* [`d28f57cd`](https://github.com/NixOS/nixpkgs/commit/d28f57cdff13598302f9cbebf024a02530893d03) systemd: fix tmpfiles errors when mount is noatime
* [`27470b5f`](https://github.com/NixOS/nixpkgs/commit/27470b5f24b8a1eb6c543d8dd9e590ddcc75d3a2) libxmlb: 0.3.25 -> 0.3.27
* [`91518f18`](https://github.com/NixOS/nixpkgs/commit/91518f18f5de0f58d3cd532a8eeb227d78b5159f) ffmpeg_8: 8.1 -> 8.1.1
* [`07e44fb2`](https://github.com/NixOS/nixpkgs/commit/07e44fb25f474a24adf65c976ff72677ad637a4a) fftw: 3.3.10 -> 3.3.11
* [`0b780db8`](https://github.com/NixOS/nixpkgs/commit/0b780db8ebf8df374e506dbc70ca31d2da42ffa3) python3Packages.chardet: 5.2.0 -> 6.0.0.post1
* [`9dfc99b8`](https://github.com/NixOS/nixpkgs/commit/9dfc99b8d876daacfb34786a0af0ebcd3097e2c6) python3Packages.chardet: use finalAttrs
* [`1e059097`](https://github.com/NixOS/nixpkgs/commit/1e0590976310901b97d40324705d71746d9b63bd) python3Packages.httpx: skip tests broken by chardet v6
* [`f21fec38`](https://github.com/NixOS/nixpkgs/commit/f21fec3871a704863b2e32afc818cf35337fd7ff) tinysparql: include upstream patch for sqlite float-related test fixes
* [`e38a2c41`](https://github.com/NixOS/nixpkgs/commit/e38a2c417533158c391897e6e8d229e752f931e1) opencv4: use ffmpeg-headless
* [`057bd4a5`](https://github.com/NixOS/nixpkgs/commit/057bd4a56cea3d910100441ab47ade8135efaf56) python314Packages.opentelemetry-semantic-conventions-ai: update meta.homepage
* [`1daeb43e`](https://github.com/NixOS/nixpkgs/commit/1daeb43ea555600ccc024e6a1a4e12fbd209cbe9) mate-panel-with-applets: re-enable man output
* [`6f04e4e7`](https://github.com/NixOS/nixpkgs/commit/6f04e4e7027cb6ecb7d696cacc31ef785a142021) rsync: 3.4.1 -> 3.4.3
* [`481208bd`](https://github.com/NixOS/nixpkgs/commit/481208bdff2dc2f61d4f4fde51e6bd2a939f7d68) cc-wrapper, gcc, gnat, gnat-bootstrap: fix GCC 13 and GNAT 13/14/15 builds on darwin
* [`3df63464`](https://github.com/NixOS/nixpkgs/commit/3df63464830fe406d9bdc3fdb209df94c164c370) python314Packages.opentelemetry-semantic-conventions-ai: run the test
* [`fea17e2a`](https://github.com/NixOS/nixpkgs/commit/fea17e2a81c81a3a8141d23f4dc306d246db9487) vim: 9.2.0389 -> 9.2.0541
* [`6787f46a`](https://github.com/NixOS/nixpkgs/commit/6787f46af71ab63b31f0d87110275c9a2d890ffd) libsodium: 1.0.22-unstable-2026-04-09 -> 1.0.22-unstable-2026-04-16
* [`20c65e56`](https://github.com/NixOS/nixpkgs/commit/20c65e561681133532832ed922e5906493dcc06b) python3Packages.certbot-nginx: fix build with certbot 5.6.0
* [`fd4f3737`](https://github.com/NixOS/nixpkgs/commit/fd4f3737156ff8f2aa524f07771581c3b29ca103) libheif: 1.21.2 -> 1.22.2
* [`117c2f76`](https://github.com/NixOS/nixpkgs/commit/117c2f76a71c2185e4430cbe83f86d92ebf7eb8e) rust: 1.95.0 -> 1.96.0
* [`95df8255`](https://github.com/NixOS/nixpkgs/commit/95df82556d5d03a18490ef4cfad6ff063f3c38ad) maintainers: add examosa
* [`aa0e627f`](https://github.com/NixOS/nixpkgs/commit/aa0e627f6e00f52ca5ca10cf48f71f73fb2f49a9) libavif: 1.4.1 -> 1.4.2
* [`c87a95cb`](https://github.com/NixOS/nixpkgs/commit/c87a95cbd3a3b06d829d86bf30c093016a47e2bb) cc-wrapper: enable tlsdesc on i686, x86_64 linux
* [`851fd940`](https://github.com/NixOS/nixpkgs/commit/851fd9401f8f79454d1e3e0b786ba4afcaecd134) elfutils: apply patch allowing R_386_TLS_DESC in shared libraries with elflint
* [`817b0e13`](https://github.com/NixOS/nixpkgs/commit/817b0e1338faca6deebeb9fca8beeef8409dbeea) ffmpeg: use unwrapped clang for cuda-llvm support
* [`3bef031c`](https://github.com/NixOS/nixpkgs/commit/3bef031c681b7c166dfd94aff0054c674a9b83c3) python3Packages.fonttools: 4.61.1 -> 4.63.0
* [`b84bd317`](https://github.com/NixOS/nixpkgs/commit/b84bd317d02036f02ad3875e7bf83f1d3e90b165) python3Packages.fonttools: use finalAttrs
* [`ca049638`](https://github.com/NixOS/nixpkgs/commit/ca04963848648973a36563cbe75246df5451361e) python3Packages.redis: 7.4.0 -> 8.0.0
* [`c0bb1a03`](https://github.com/NixOS/nixpkgs/commit/c0bb1a038834705436cc4e266b75e74f7920c26a) python3Packages.redis: use finalAttrs
* [`580c4bea`](https://github.com/NixOS/nixpkgs/commit/580c4bea8e9685918e83c71d5dfaa40c0f313ba0) python3Packages.redis: add passthru.tests
* [`a2e41bb7`](https://github.com/NixOS/nixpkgs/commit/a2e41bb76c7f3b1fca68f135e4029254225c5aa9) rust-cbindgen: 0.29.2 -> 0.29.3
* [`bec52240`](https://github.com/NixOS/nixpkgs/commit/bec5224047e5eea5ec52f7ef11c9d7c391f78cb2) gssdp_1_6: 1.6.4 -> 1.6.5, gupnp_1_6: 1.6.9 -> 1.6.10
* [`ddda3ed8`](https://github.com/NixOS/nixpkgs/commit/ddda3ed831d0d9f26f2fb446f8986b2c2fae4bc2) rustPlatform.fetchCargoVendor: remove duplicate fetcher
* [`37ff020c`](https://github.com/NixOS/nixpkgs/commit/37ff020c2fefcccc4a354c0f8a193da9b700aea0) python3Packages.pillow-heif: disable tests that abuse spec and break in libheif 1.22.0, disable version check for libheif
* [`1a817546`](https://github.com/NixOS/nixpkgs/commit/1a817546620f1988b2330765f94db19f96b76210) nixos/pcscd: expose package as option
* [`1468d638`](https://github.com/NixOS/nixpkgs/commit/1468d638d9872ddb999cfc3053cc66a0089eb59b) pcsclite: enable structuredAttrs, separateDebugInfo, strictDeps
* [`629e94d9`](https://github.com/NixOS/nixpkgs/commit/629e94d9f8a60ac5d9ebf634722c0422371996f6) libbacktrace: 0-unstable-2024-03-02 -> 0-unstable-2026-05-03
* [`783dea20`](https://github.com/NixOS/nixpkgs/commit/783dea20a27c7e49ab239583288166c2fdf3cac6) svt-av1: 3.1.2 -> 4.1.0
* [`8cd7c741`](https://github.com/NixOS/nixpkgs/commit/8cd7c741b06e03540da23de65cfd0868cb716bf4) ffmpeg_7: add patch for svt-av1 4.0
* [`e64abb9c`](https://github.com/NixOS/nixpkgs/commit/e64abb9c87f7cb0758d29d84f630bc88802c56a4) handbrake: drop unused patches
* [`1c2d1b16`](https://github.com/NixOS/nixpkgs/commit/1c2d1b16049b36ebec45c8cc17f16e5a702b3e0f) libdrm: 2.4.133 -> 2.4.134
* [`4f574aac`](https://github.com/NixOS/nixpkgs/commit/4f574aac567ca60ec3bd37a2a670b99491cad5e6) {khronos-ocl-icd-loader,opencl-clhpp,opencl-headers}: 2025.07.22 -> 2026.05.29
* [`96b557f6`](https://github.com/NixOS/nixpkgs/commit/96b557f6aebbcdcf316c060cb98bc925a6fffd53) brutespray: 2.6.1 -> 2.6.2
* [`64ae7d0e`](https://github.com/NixOS/nixpkgs/commit/64ae7d0e374a774bb78520e6b0f320e804317d70) gnupatch: disable flaky test
* [`adb4fccd`](https://github.com/NixOS/nixpkgs/commit/adb4fccdc759cc12b4791e486df9412190a308d9) python3: 3.13 -> 3.14
* [`2fb19430`](https://github.com/NixOS/nixpkgs/commit/2fb194308fdf9d22879c9bfc46228e2e991121e1) zstd: remove fetchpatch usage
* [`6c1d92da`](https://github.com/NixOS/nixpkgs/commit/6c1d92dac9ae370ea4c8780d02ee23d1fbe28a2e) python3Minimal: exclude zstd on minimal
* [`7385b536`](https://github.com/NixOS/nixpkgs/commit/7385b5369eb87464fc2a2ad05ad97699664beb90) python3Packages.installer: 1.0.0 -> 1.0.1
* [`202edcd5`](https://github.com/NixOS/nixpkgs/commit/202edcd58283cd0fa5e1a2a0770d6504c2de898a) python3Packages.build: 1.4.4 -> 1.5.0
* [`a76a96a0`](https://github.com/NixOS/nixpkgs/commit/a76a96a0855da3a5c98444d4fc283e33adcca017) python3Packages.wheel: 0.46.1 -> 0.47.0
* [`5aba6aeb`](https://github.com/NixOS/nixpkgs/commit/5aba6aebb6996044bc15a3bb11a3855fa486845e) python3Packages.distutils_80: init at 80.10.2
* [`a0d82aa8`](https://github.com/NixOS/nixpkgs/commit/a0d82aa87667d55a44560f9f8e5e20d0660bf32e) python3Packages.setuptools: 80.10.1 -> 82.0.1
* [`38845897`](https://github.com/NixOS/nixpkgs/commit/388458978c392b723a844df7b5f906684a96f974) python3Packages.distutils: 80.10.1 -> 82.0.1
* [`a03725a6`](https://github.com/NixOS/nixpkgs/commit/a03725a6c6bdaa098a6e48a70c447a102385ff7a) python3Packages.setuptools_80: init at 80.10.2
* [`d00eb269`](https://github.com/NixOS/nixpkgs/commit/d00eb26967dfa68e63cd0d901e6a50e9ce0ea8b6) python3Packages.vcs-versioning: init at 1.1.1
* [`729d33e3`](https://github.com/NixOS/nixpkgs/commit/729d33e350be215e02394760f6caa6cea36766ad) python3Packages.setuptools-scm: 9.2.2 -> 10.0.5
* [`2372f065`](https://github.com/NixOS/nixpkgs/commit/2372f065add76dcb494b003989827c862231c461) python3Packages.zope-event: 6.1 -> 6.2
* [`73b7906d`](https://github.com/NixOS/nixpkgs/commit/73b7906d92df92fad0ca571aa6d52df7bc2e9aa7) python3Packages.poetry-core: 2.3.2 -> 2.4.0
* [`ed3453c6`](https://github.com/NixOS/nixpkgs/commit/ed3453c6941da21956553959ece02f42bd119d09) python3Packages.uv-build: 0.10.0 -> 0.11.8
* [`ddb28fa0`](https://github.com/NixOS/nixpkgs/commit/ddb28fa0cb827873e6c51e86909433ed4312e627) python3Packages.filelock: 3.20.3 -> 3.29.0
* [`53b29af4`](https://github.com/NixOS/nixpkgs/commit/53b29af49e5ba0b41134cefdc725b4c1f16af357) python3Packages.virtualenv: 20.36.1 -> 21.2.4
* [`01204a51`](https://github.com/NixOS/nixpkgs/commit/01204a518c1c5d7cde86e36259f5fb3eb4e1c95e) python3Packages.starlette: cleanup
* [`c04487ac`](https://github.com/NixOS/nixpkgs/commit/c04487ac166ea634cd2a2ab70604d2321dd48019) python3Packages.fastapi-cli: 0.0.20 -> 0.0.24
* [`ec7194a3`](https://github.com/NixOS/nixpkgs/commit/ec7194a37a87948f0e3de2411fed623a30d5775d) python3Packages.fastapi: update dependencies
* [`b35c7a16`](https://github.com/NixOS/nixpkgs/commit/b35c7a165927f2f25a9c9831670f8ecb37de0017) python3Packages.html5lib: pin to setuptools_80
* [`bffbd23f`](https://github.com/NixOS/nixpkgs/commit/bffbd23fea6a2f260b60204fdd13e450641459b1) python3Packages.packaging: 26.1 -> 26.2
* [`d937cb6e`](https://github.com/NixOS/nixpkgs/commit/d937cb6e2d2d3f9e47dc7ae82bb54a27a64f2e99) python3Packages.certifi: 2026.01.04 -> 2026.04.22
* [`11c393f1`](https://github.com/NixOS/nixpkgs/commit/11c393f1bd8e6177d463d051c3cb132e6148bfe2) python3Packages.click: 8.3.1 -> 8.3.3
* [`ff97264d`](https://github.com/NixOS/nixpkgs/commit/ff97264d4555e412ed674c38e24973eecdaf4127) python3Packages.idna: 3.13 -> 3.14
* [`39e8a44d`](https://github.com/NixOS/nixpkgs/commit/39e8a44dd31601b1ffd5a913aa1889de329ac845) python3Packages.wcwidth: 0.6.0 -> 0.7.0
* [`e80b4d99`](https://github.com/NixOS/nixpkgs/commit/e80b4d990b1ef0abd8f988622856c056228059c7) python3Packages.babel: 2.17.0 -> 2.18.0
* [`a0709bc8`](https://github.com/NixOS/nixpkgs/commit/a0709bc85f0e6d181639caad91ea50aa871cc837) python3Packages.click-repl: 0.3.0 -> 0.3.0-unstable-2026-03-26
* [`b4b0de8c`](https://github.com/NixOS/nixpkgs/commit/b4b0de8c2515e014a0509241522bb5152525f022) python3Packages.lxml: 6.0.2 -> 6.1.0
* [`d7aa737a`](https://github.com/NixOS/nixpkgs/commit/d7aa737a85346c2dc8c1bc80501949dc2174dcc2) python3Packages.backports-zstd: 1.3.0 -> 1.4.0
* [`65a18839`](https://github.com/NixOS/nixpkgs/commit/65a18839e72199f2a6ad332565b8a94e7776648d) python3Packages.typeguard: 4.4.4 -> 4.5.1
* [`e59adf72`](https://github.com/NixOS/nixpkgs/commit/e59adf722657f3305cf80855365362c2c2281633) python3Packages.requests: 2.33.1 -> 2.34.0
* [`a9b867c2`](https://github.com/NixOS/nixpkgs/commit/a9b867c25b3f7c5419547102286cee3e2dd89792) python3Packages.importlib-resources: 6.5.2 -> 7.1.0
* [`b8e8ef27`](https://github.com/NixOS/nixpkgs/commit/b8e8ef279380136c1ceccb4c442afec26d7ef41f) python3Packages.cryptography: disable problematic test
* [`5d71cbba`](https://github.com/NixOS/nixpkgs/commit/5d71cbbabe6aa159eaa35d0de1d95979cfbd2fff) python3Packages.pandas: 2.3.3 -> 3.0.3
* [`527b1026`](https://github.com/NixOS/nixpkgs/commit/527b10263179b75f9ad1f71aa2e74ad3a2641651) python3Packages.pycurl: 7.45.6 -> 7.46.0
* [`81d9d52b`](https://github.com/NixOS/nixpkgs/commit/81d9d52bf7a580609f6885fda75f085617be2d9e) python3Packages.pydantic-core: 2.41.5 -> 2.46.4
* [`a03c2ddc`](https://github.com/NixOS/nixpkgs/commit/a03c2ddc0f4f4e7727d46d0f1f7f3cde79074b33) python3Packages.pydantic: 2.12.5 -> 2.13.4
* [`ff4c4962`](https://github.com/NixOS/nixpkgs/commit/ff4c4962d28ba2140f8b0bb8d2705d2c1903584d) python3Packages.mashumaro: 3.17 -> 3.21
* [`5addde92`](https://github.com/NixOS/nixpkgs/commit/5addde923dd9b990d839992a20ea379eab46333a) python3Packages.platformdirs: 4.5.1 -> 4.9.6
* [`7bd04c00`](https://github.com/NixOS/nixpkgs/commit/7bd04c0097c8e274f1090eb2d3c6f390217c7605) python3Packages.pathspec: 1.0.4 -> 1.1.1
* [`2d6cb393`](https://github.com/NixOS/nixpkgs/commit/2d6cb39369369a3ba4d77291e1b2acb628427f2d) python3Packages.zipp: 3.23.1 -> 4.0.0
* [`83fbf8eb`](https://github.com/NixOS/nixpkgs/commit/83fbf8ebee98139688e59d538b3c0e89191a80c4) python3Packages.skia-pathops: 0.9.1 -> 0.9.2
* [`95dd19e3`](https://github.com/NixOS/nixpkgs/commit/95dd19e324a1bf808b8518b7c12836927ec4b266) python3Packages.mako: 1.3.10 -> 1.3.12
* [`d59d2825`](https://github.com/NixOS/nixpkgs/commit/d59d282564af6ac82e99ca5915a4e95e27c7760c) python3Packages.ast-serialize: init at 0.3.0
* [`c5d5b722`](https://github.com/NixOS/nixpkgs/commit/c5d5b72238ae3cb8764a30d85691139a8d61e49a) python3Packages.mypy: 1.20.1 -> 2.1.0
* [`a9349934`](https://github.com/NixOS/nixpkgs/commit/a9349934d2f581c60de5018b20bdaa33a9f65788) python3Packages.charset-normaler: expose withMypyc flag
* [`3ca34d25`](https://github.com/NixOS/nixpkgs/commit/3ca34d25fce6a6cf70a3284446ee2d96c6dbc558) fetchCargoVendor: break infinite recursion with ast-serialize
* [`ca8d5fbb`](https://github.com/NixOS/nixpkgs/commit/ca8d5fbb3d8512fc85ef938839e6682d69e1df67) python3Packages.librt: 0.9.0 -> 0.11.0
* [`0bb3a590`](https://github.com/NixOS/nixpkgs/commit/0bb3a590b3da000f848a777f1b30d287b3761a71) python3Packages.pytz: 2026.1.post1 -> 2026.2
* [`04038fde`](https://github.com/NixOS/nixpkgs/commit/04038fded705355bb482068b3abd493c399ebe84) python3Packages.pytest-subprocess: 1.5.4 -> 1.6.0
* [`404b6579`](https://github.com/NixOS/nixpkgs/commit/404b6579059b783d5dae16cc15662691b7abfd7c) python3Packages.trove-classifiers: 2026.4.28.13 -> 2026.5.7.17
* [`bc9158e8`](https://github.com/NixOS/nixpkgs/commit/bc9158e81e11c409651030dc153469b9c336fa9d) python3Packages.pendulum: 3.1.0-unstable-2025-10-28 -> 3.2.0
* [`ca7a8d53`](https://github.com/NixOS/nixpkgs/commit/ca7a8d536044be0bdd903da251ff7552c052f543) python3Packages.pendulum: use finalAttrs
* [`6b54753c`](https://github.com/NixOS/nixpkgs/commit/6b54753cb103db12dc383131d2e724f4847f91ee) python3Packages.uvicorn: 0.40.0 -> 0.46.0
* [`db883c3f`](https://github.com/NixOS/nixpkgs/commit/db883c3f8ea329bb682b750996e97e566a4ba0a0) python3Packages.filelock: disable flaky locking tests
* [`73599831`](https://github.com/NixOS/nixpkgs/commit/73599831a40bdf3e1e777de1721a73d446239d99) python3Packages.charset-normalizer: provide ast-serialize build dep
* [`29184d79`](https://github.com/NixOS/nixpkgs/commit/29184d79fafd851f7f99926042c595eecd39cd48) python3Packages.matplotlib: relax setuptools-scm constraint
* [`5a1cd9cc`](https://github.com/NixOS/nixpkgs/commit/5a1cd9cc55dddb9a0ef3babd914f1f7d0cb8907f) python3Packages.rich: 14.3.3 -> 15.0.0
* [`8ea0b4f2`](https://github.com/NixOS/nixpkgs/commit/8ea0b4f2556c15e9736c87e5bb9862f161986b4b) python3Packages.pylama: pin to setuptools_80
* [`1434d078`](https://github.com/NixOS/nixpkgs/commit/1434d0780e5235485f7ab251f4be595ab2cf34ee) python3Packages.deprecated: pin to setuptools_80
* [`fb8cdd0d`](https://github.com/NixOS/nixpkgs/commit/fb8cdd0dba95d2d293b648e7156b1419a96725e1) python3Packages.blockdiag: pin to setuptools_80
* [`f3964c18`](https://github.com/NixOS/nixpkgs/commit/f3964c18d6dc142d8cfda6bb1ade6f1e3fb0a09f) python3Packages.uvloop: pin to setuptools_80
* [`604a2a80`](https://github.com/NixOS/nixpkgs/commit/604a2a80c0026f8ed880ef5e6d6c05f5e535b57b) python3Packages.distutils: disable failing tests
* [`b5c57c52`](https://github.com/NixOS/nixpkgs/commit/b5c57c52c8bf0af4ef51b3f5a5023d07611ac29c) python3Packages.python-ldap: 3.4.5 -> 3.4.6
* [`16c46466`](https://github.com/NixOS/nixpkgs/commit/16c46466218e025e73e6ad7de125069df62e82c0) python3Packages.tqdm: 4.67.1 -> 4.67.3
* [`3f544ddd`](https://github.com/NixOS/nixpkgs/commit/3f544ddd49d65aadaea5fa53ee65bd1c1c129a6f) python3Packages.scikit-build-core: 0.11.6 -> 0.12.2
* [`e03a9010`](https://github.com/NixOS/nixpkgs/commit/e03a9010055c6c3c91c51ee529d29a5cd43dd601) python3Packages.pikepdf: 10.5.1 -> 10.6.0
* [`3043c255`](https://github.com/NixOS/nixpkgs/commit/3043c255b3f63d82df004cc8fa29b6a19013fbf1) spidermonkey: pin to python 3.13
* [`b7a93ec9`](https://github.com/NixOS/nixpkgs/commit/b7a93ec9e6b5dd233d70b1c9dc1ca2740773d881) buildMozillaMach: use python3.13 for versions below 143.0
* [`3ccd0260`](https://github.com/NixOS/nixpkgs/commit/3ccd026063e5b6836980dad734554ebdcf59c533) python3Packages.face-recognition-models: pin setuptools_80
* [`a04da3fd`](https://github.com/NixOS/nixpkgs/commit/a04da3fde40e75e24b1f22ab83281303e786602a) python3Packages.apswutils: pin setuptools_80
* [`e4d45548`](https://github.com/NixOS/nixpkgs/commit/e4d45548b4aab765d44e0be313d8dbc0eada07eb) python3Packages.zope-testing: relax setuptools constraint
* [`47cb1d0c`](https://github.com/NixOS/nixpkgs/commit/47cb1d0c8ef0815fdd2c2c5fc7c208c71c55b285) python3Packages.pytest-mypy-plugins: 4.0.2 -> 4.0.3
* [`116e9f56`](https://github.com/NixOS/nixpkgs/commit/116e9f56ccdbf7571273708dd4431896e317a4cd) python3Packages.jupyter-packaging: disable FutureWarning
* [`fc149bad`](https://github.com/NixOS/nixpkgs/commit/fc149bad32bfab5e8004960cc053e8b3748cc2df) python3Packages.aiohasupervisor: drop wheel build dep
* [`720b51f8`](https://github.com/NixOS/nixpkgs/commit/720b51f8029f4a02f0dc010b3f3d9c5693067e26) python3Packages.xlib: pin setuptools_80
* [`3dc26f2e`](https://github.com/NixOS/nixpkgs/commit/3dc26f2e52e702403288e7854101e5ee9e732d34) python3Packages.syrupy: 5.1.0 -> 5.2.0
* [`065869b1`](https://github.com/NixOS/nixpkgs/commit/065869b1b2d0a6894eba98a8967263c97dca45eb) python3Packages.syrupy: use finalAttrs
* [`0d33bcce`](https://github.com/NixOS/nixpkgs/commit/0d33bcce4ecd82a7568ff200c6c65dfc3af9357b) python3Packages.numcodecs: 0.16.3 -> 0.16.5
* [`3c13010a`](https://github.com/NixOS/nixpkgs/commit/3c13010a19b2e933f509109ea0ae3b63aef74853) python3Packages.llvmlite: 0.46.0 -> 0.47.0
* [`2b81f14f`](https://github.com/NixOS/nixpkgs/commit/2b81f14fb44b825dbf2ef44e0da0842b823b3c78) python3Packages.numba: 0.63.1 -> 0.65.1
* [`ea45d1e8`](https://github.com/NixOS/nixpkgs/commit/ea45d1e8606c9b820d85f5c038b215957621406b) python3Packages.torch: relax setuptools
* [`4143982e`](https://github.com/NixOS/nixpkgs/commit/4143982e36f38bc219d93fae4069f0b32ab5e1ad) python3Packages.coreapi: pin to setuptools_80
* [`b44ac20d`](https://github.com/NixOS/nixpkgs/commit/b44ac20dfb04f54187e6a7dd95cdbfe83de341b2) python3Packages.scales: pin to setuptools_80
* [`9e8a6e9c`](https://github.com/NixOS/nixpkgs/commit/9e8a6e9c9bd02489a59ea0a637bbd58ea6866987) python3Packages.plaster-pastedeploy: pep517 build, setuptools 81 pin
* [`e4c7627d`](https://github.com/NixOS/nixpkgs/commit/e4c7627d6ae57a55fc178392aab0a1822eb09da0) python3Packages.mcp: 1.26.0 -> 1.27.1
* [`7b235832`](https://github.com/NixOS/nixpkgs/commit/7b235832bc2996c42b5b74d9952c41015dff71f4) afew: pin to setuptools_80
* [`4b583d74`](https://github.com/NixOS/nixpkgs/commit/4b583d748c40e8ddf8c309a710f81027ec9cf981) python3Packages.home-assistant-chip-wheels: provide ast-serialize
* [`9518afa8`](https://github.com/NixOS/nixpkgs/commit/9518afa893a183c0154b8597d6f5cd587dc1b5a1) python3Packages.pycapnp: backport patch for py314 compat
* [`654d103b`](https://github.com/NixOS/nixpkgs/commit/654d103b12e185401fdbede9b6d543932fff6dd4) python3Packages.scikit-build: 0.18.1 -> 0.19.0
* [`158b6a83`](https://github.com/NixOS/nixpkgs/commit/158b6a83f793b2f1ce7acd9c72b89dacd8291e76) python3Packages.apscheduler: pin to setuptools_80
* [`b4538c1c`](https://github.com/NixOS/nixpkgs/commit/b4538c1c7c54dfdee811dd694a4b7d8e0a4223d2) python3Packages.makefun: pin to setuptools_80
* [`6c81b30e`](https://github.com/NixOS/nixpkgs/commit/6c81b30e2cd1aa5d76191ae549726cfc4cc31ae1) python313Packages.fs: pin to setuptools_80
* [`b9c3d1c0`](https://github.com/NixOS/nixpkgs/commit/b9c3d1c0ffa85fcaa1b757685771d92f8ba6425e) python3Packages.cu2qu: pin to setuptools_80
* [`b473e844`](https://github.com/NixOS/nixpkgs/commit/b473e8448f2c8d47bffb9ef1411926c53b889579) python3Packages.omegaconf: pin to setuptools_80
* [`eeaaa9d0`](https://github.com/NixOS/nixpkgs/commit/eeaaa9d01b937c3a6760c662b0244d348925a607) python3Packages.duckdb: propagate typing-extensions
* [`1aaa1baa`](https://github.com/NixOS/nixpkgs/commit/1aaa1baa60ff884f0cd68fa3ca969b6fc9237860) python3Packages.cmd2: disable failing test
* [`fe760b16`](https://github.com/NixOS/nixpkgs/commit/fe760b16bc9d76d483406d5070bf171216d03fbd) python3Packages.pyramid: 2.0.2 -> 2.1
* [`d5ff76f1`](https://github.com/NixOS/nixpkgs/commit/d5ff76f1cf5a04039ab8b0f2475aa01f7c6344a6) python3Packages.prawcore: disable failing test
* [`4f399b1d`](https://github.com/NixOS/nixpkgs/commit/4f399b1dae36318a2ba050f91fa5c9b0c301f187) python3Packages.idna: 3.14 -> 3.15
* [`ef431c73`](https://github.com/NixOS/nixpkgs/commit/ef431c73be68d3b9a1f968fd517621a7809a21f6) python313Packages.backports-zstd: 1.4.0 -> 1.5.0
* [`8fc19d25`](https://github.com/NixOS/nixpkgs/commit/8fc19d25f3bc2e6f58094390324a670e99889591) darwin.stdenv: fix infinite recursion due to Python 3.14 upgrade
* [`e9bb1dd3`](https://github.com/NixOS/nixpkgs/commit/e9bb1dd3f36a813e4ce3d819326be3f2d42d4062) python3Packages.pandas: make src reproducible
* [`1d5c2a8b`](https://github.com/NixOS/nixpkgs/commit/1d5c2a8b871c5b295897e3f3cf5f974ba6435f05) python3Packages.cffsubr: pin to setuptools 80
* [`7676fdd6`](https://github.com/NixOS/nixpkgs/commit/7676fdd6ad59e7444d0566d591edabdb11d56317) python3Packages.yarl: 1.23.0 -> 1.24.2
* [`4105de03`](https://github.com/NixOS/nixpkgs/commit/4105de0322de93ff1b9d03b18e878d1bee15d6d8) python3Packages.tabcmd: 2.0.18 -> 2.0.20
* [`b56b7a36`](https://github.com/NixOS/nixpkgs/commit/b56b7a3671f8f56740b171abb779ec16602516e1) python3Packages.tank-utility: pin to setuptools 80
* [`9c013026`](https://github.com/NixOS/nixpkgs/commit/9c013026b9854fa3c5ea38965ad0b55a94597824) python3Packages.typer: 0.24.0 -> 0.25.1
* [`292f1bcb`](https://github.com/NixOS/nixpkgs/commit/292f1bcbd43dae3ba1103ebc1c9041b983c93492) python3Packages.pytokens: init at 0.4.1
* [`cafee09a`](https://github.com/NixOS/nixpkgs/commit/cafee09a901be684d083111ff4483cbd93faa507) black: 25.1.0 -> 26.5.1
* [`5bb6e1f6`](https://github.com/NixOS/nixpkgs/commit/5bb6e1f605eddcb72957fdc2a2bfa9912cecfb9d) python3Packages.masky: pep517 build, pin setuptools 80
* [`8d493968`](https://github.com/NixOS/nixpkgs/commit/8d493968f57ace53c0f4ee7bc3e3511ce9996c4a) python3Packages.pytest-logdog: pep517 build, pin setuptools 80
* [`16d1c62a`](https://github.com/NixOS/nixpkgs/commit/16d1c62a28f584d97f28746a04c099ff1a0be837) python3Packages.python-ldap: 3.4.6 -> 3.4.7
* [`e936451e`](https://github.com/NixOS/nixpkgs/commit/e936451e5803e96160c892826dd8d236289b4b4e) python3Packages.certomancer: 0.13.0 -> 0.14.0
* [`a41d6b2f`](https://github.com/NixOS/nixpkgs/commit/a41d6b2f06659724d1ee7bc7289c0b030341ad3b) python3Packages.launchpadlib: pin setuptools 80
* [`3d53e58a`](https://github.com/NixOS/nixpkgs/commit/3d53e58aad1a8a32670ad3b5f55a6cbc055a11fb) python3Packages.pyhanko: 0.34.1 -> 0.35.1
* [`7add03eb`](https://github.com/NixOS/nixpkgs/commit/7add03ebc953e3847fcea47e60a3a491a04a4232) python3Packages.pathable: 0.5.0 -> 0.6.0
* [`1010b888`](https://github.com/NixOS/nixpkgs/commit/1010b888452029ebeb25d1e46cd4448cfc2ecba1) python3Packages.jsonschema-path: 0.4.6 -> 0.5.0
* [`d8e3c884`](https://github.com/NixOS/nixpkgs/commit/d8e3c884537f7f94e1a5ffbd42d64570c3435368) python3Packages.pikepdf: 10.6.0 -> 10.7.0
* [`cfc4aab3`](https://github.com/NixOS/nixpkgs/commit/cfc4aab3490772bea291b63818f3e077ed98e07d) python3Packages.trove-classifiers: 2026.5.7.17 -> 2026.5.20.19
* [`3c1a2152`](https://github.com/NixOS/nixpkgs/commit/3c1a2152d0ed6c1fff4921d2065d0245eb0b4faf) python3Packages.pikepdf: 10.7.0 -> 10.7.1
* [`aaa1dd20`](https://github.com/NixOS/nixpkgs/commit/aaa1dd2051a1e298b8d627a81282d5085d42e576) python3Packages.cassandra-driver: 3.29.3 -> 3.30.0
* [`f90f7a64`](https://github.com/NixOS/nixpkgs/commit/f90f7a646ab118ba24ac48c93cc9cc39e4127b93) python3Packages.wxpython: 4.2.4 -> 4.2.5
* [`0073ff9c`](https://github.com/NixOS/nixpkgs/commit/0073ff9cf24341384998b94d3f1bf04f3d921417) python3Packages.pysmi: 1.6.3 -> 2.0.2
* [`9d95ab00`](https://github.com/NixOS/nixpkgs/commit/9d95ab00dccb89e17616f57c0fb1f74fba95484f) python3Packages.pysnmp: 7.1.24 -> 7.1.27
* [`b77987ff`](https://github.com/NixOS/nixpkgs/commit/b77987ff5cdd4c90094cea50949428a12587bc23) python3Packages.db-dtypes: 1.5.0 -> 1.6.0
* [`e00dc717`](https://github.com/NixOS/nixpkgs/commit/e00dc7175e90e5d3cc4cfc6d847a1044102d1744) python3Packages.db-dtypes: support pandas 3.0
* [`e4599fe4`](https://github.com/NixOS/nixpkgs/commit/e4599fe4ce68693b49609eeae449851e129a0d57) python3Packages.db-dtypes: use finalAttrs
* [`05c10670`](https://github.com/NixOS/nixpkgs/commit/05c1067067263ab0945cd6a68da869fea49160b9) python3Packages.openapi-core: fix build with jsonschema-path 0.5.0
* [`3bf49825`](https://github.com/NixOS/nixpkgs/commit/3bf49825cb3fdd061450222fee69420aa8cd4f58) python3Packages.xmlsec: unpin lxml
* [`e09d96cb`](https://github.com/NixOS/nixpkgs/commit/e09d96cba6f73c0d31009076f9a16b03a215408a) python3Packages.google-cloud-bigquery: 3.40.0 -> 3.41.0
* [`62a20150`](https://github.com/NixOS/nixpkgs/commit/62a201505988284b8e63ba4a3caf5d457551834f) python3Packages.ast-serialize: 0.3.0 -> 0.5.0
* [`e8a86698`](https://github.com/NixOS/nixpkgs/commit/e8a86698fb5a52c2fd64f274ba322f1aa1882110) python3Packages.coredis: 5.6.0 -> 6.6.1
* [`d3ec3c97`](https://github.com/NixOS/nixpkgs/commit/d3ec3c976fbcf94dc6447ca30aab6fe5c0c87b9f) python3Packages.coredis: use finalAttrs
* [`eb3b83f3`](https://github.com/NixOS/nixpkgs/commit/eb3b83f3573b46a7be1c65822df45974ef70de3c) python3Packages.litellm: unpin pydantic
* [`df634cee`](https://github.com/NixOS/nixpkgs/commit/df634ceed92b51d0f6815c4df320e7c338bfb8cd) python3Packages.slowapi: skip tests broken by starlette 1.0
* [`d38ef98c`](https://github.com/NixOS/nixpkgs/commit/d38ef98cdadcf520666a2b34851bcaccc9dc769e) python3Packages.uv-build: 0.11.8 -> 0.11.16
* [`d8055d7e`](https://github.com/NixOS/nixpkgs/commit/d8055d7eba08187915876c6a6cbe49e41bf2d0e9) python3Packages.sqlalchemy: 2.0.49 -> 2.0.50
* [`ccd892ab`](https://github.com/NixOS/nixpkgs/commit/ccd892abf03a7edf54b3d19d7a50f7f0c11f14cc) python3Packages.adax-local: pin to setuptools 80
* [`61727d1d`](https://github.com/NixOS/nixpkgs/commit/61727d1d60cd321d089c72bd41c2a12329071053) alerta-server: pep517, pin to setuptools 80
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
