### PR TITLE
npins home-manager: update 63d02d1c -> a45a7c45

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -48,9 +48,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "63d02d1c19f1c2b47a5bc7e55c620b6af7b218a6",
-      "url": "https://github.com/nix-community/home-manager/archive/63d02d1c19f1c2b47a5bc7e55c620b6af7b218a6.tar.gz",
-      "hash": "sha256-w+YU5vatysjLZIg1wOKSzo/RL9Z66eBQuIjVnBM/1Zg="
+      "revision": "a45a7c451455a51ae740ec3bce4024b312809c29",
+      "url": "https://github.com/nix-community/home-manager/archive/a45a7c451455a51ae740ec3bce4024b312809c29.tar.gz",
+      "hash": "sha256-r376E2XpakiXwModDHIxlvB6qLq4iFVEq730vxOO4JY="
     },
     "hs-grille": {
       "type": "Git",


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@63d02d1c...a45a7c45](https://github.com/nix-community/home-manager/compare/63d02d1c19f1c2b47a5bc7e55c620b6af7b218a6...a45a7c451455a51ae740ec3bce4024b312809c29)

* [`ed10fd39`](https://github.com/nix-community/home-manager/commit/ed10fd394e75fce260fede1a9976f611d5fc488b) clipse: support store paths for theme option
* [`8de7488a`](https://github.com/nix-community/home-manager/commit/8de7488af203647190a878d76b34f95c5998e07c) elephant: fix service unit
* [`16acb8c7`](https://github.com/nix-community/home-manager/commit/16acb8c7ffd899b71d7117bdab6e73df76d0b604) maintainers: add ratakor to walker & elephant
* [`52f93adb`](https://github.com/nix-community/home-manager/commit/52f93adbac32fb52d4a8152ae0a7270d4109cb2d) walker: fix systemd dependency cycle with elephant
* [`cd863288`](https://github.com/nix-community/home-manager/commit/cd863288d41a5025dd610faf17816227274dd467) codex: stop duplicating hook script deployment
* [`f09af494`](https://github.com/nix-community/home-manager/commit/f09af49406ffad37acb6538d3207189a1a1e0b7e) opencode: assume most recent version when `package=null`
* [`3c6f1244`](https://github.com/nix-community/home-manager/commit/3c6f1244ed6b26e40763bd72b1d9af6e908abe41) firefox: allow setting persistent StoreID
* [`2ad49968`](https://github.com/nix-community/home-manager/commit/2ad49968c36044ff10bffc515dc687ea00b4d609) home-cursor: remove legacy enable
* [`53ebbdc4`](https://github.com/nix-community/home-manager/commit/53ebbdc405acc04acd9bb73ccca462b51ddb8c6d) proton-pass-agent: switch to gui domain to prevent error accessing keyring
* [`7a62d637`](https://github.com/nix-community/home-manager/commit/7a62d637072e1f5609fac7031b287e1adfd26771) gpg-agent: switch to gui domain for graphical pinentry support
* [`cee3f0e7`](https://github.com/nix-community/home-manager/commit/cee3f0e7fec85d80c149c7afc29926747f7bd3c2) yubikey-agent: switch to gui domain for hardware key PIN prompts
* [`1aac8895`](https://github.com/nix-community/home-manager/commit/1aac8895fea6fcabc6a0184c63a80fb2f99fd208) home-cursor: warn before removing implicit enable
* [`a1fc9a1c`](https://github.com/nix-community/home-manager/commit/a1fc9a1cc39863fefb0e0296ef464ff2f4fe13ea) maintainers: add reesilva
* [`f4d01c1d`](https://github.com/nix-community/home-manager/commit/f4d01c1d87c7c2ec909549165d5a8338f1bd3315) posting: add module
* [`144f4e36`](https://github.com/nix-community/home-manager/commit/144f4e36d0186195037da9fce80a727108978070) files: respect executable for recursive directories
* [`79e60825`](https://github.com/nix-community/home-manager/commit/79e6082586b3680ff32c8e75127545058f074fa4) launchd: treat absent domain as harmless in bootoutAgent
* [`1c029fb0`](https://github.com/nix-community/home-manager/commit/1c029fb0dc9bd2c7623c6e0fa19bf64230dac25d) claude-code: load plugins without wrapper
* [`5c7199cd`](https://github.com/nix-community/home-manager/commit/5c7199cd3b8321d89830a3dee3cf6991433a38cf) claude-code: split module files
* [`437ae5be`](https://github.com/nix-community/home-manager/commit/437ae5be42e6fba5b72f196ba4ab212c347e2afd) claude-code: test plugin collisions
* [`f9382775`](https://github.com/nix-community/home-manager/commit/f938277527aa084929261879d50d9832b9eab6d3) claude-code: tighten module implementation
* [`3e2af6c9`](https://github.com/nix-community/home-manager/commit/3e2af6c9e5d32d6fa766d4ca675bace5bfe01dc6) tests/darwinScrublist: add colima, gurk-rs
* [`d29a1c0f`](https://github.com/nix-community/home-manager/commit/d29a1c0f34263781a79c15d61afcabb8e73ec3ce) flake: bump nixpkgs from `9e92285` to `767b0d3`
* [`2afec152`](https://github.com/nix-community/home-manager/commit/2afec152df4e284d264f8489d16004c264aebf4c) tests/darwinScrublist: add podman
* [`0992a294`](https://github.com/nix-community/home-manager/commit/0992a2948749a61d54065e96df26d75d1b1da50f) television: add extraPackages option with default dependencies
* [`564bc37d`](https://github.com/nix-community/home-manager/commit/564bc37de50075e03ccfba5dc894ae25804ef3ce) kitty: fix diff.conf being generated regardless of user config
* [`e473bdcd`](https://github.com/nix-community/home-manager/commit/e473bdcd8786928b35061bc281568d91d752a2e6) home-cursor: update URL to Freedesktop.org specs
* [`c74f4f6c`](https://github.com/nix-community/home-manager/commit/c74f4f6cdd3afbfda55995a4a97333ed5cf13f45) opencode: document plugin option usage in settings description
* [`ae6f9760`](https://github.com/nix-community/home-manager/commit/ae6f976083395174f29cccf8d85aaa7182f37bf9) psd: remove aliased packages
* [`7566825d`](https://github.com/nix-community/home-manager/commit/7566825d4652a1b885bd4ce65bd9e8def432fec9) swayimg: support new lua config
* [`a45a7c45`](https://github.com/nix-community/home-manager/commit/a45a7c451455a51ae740ec3bce4024b312809c29) opencode: use `meta.mainProgram` to wrap the main binary
