### PR TITLE
npins nixpkgs: update 6cdc7fc7 -> 703c1307

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -125,9 +125,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "6cdc7fc76e8bf7fde9fa43a849fcaaa70e230dee",
-      "url": "https://github.com/nixos/nixpkgs/archive/6cdc7fc76e8bf7fde9fa43a849fcaaa70e230dee.tar.gz",
-      "hash": "sha256-FmieJB8/OUvNxbkboi7+IGfIuSXY3nF/hZQm8kD0r50="
+      "revision": "703c1307f503b7a0926608c9bfcc06714514f253",
+      "url": "https://github.com/nixos/nixpkgs/archive/703c1307f503b7a0926608c9bfcc06714514f253.tar.gz",
+      "hash": "sha256-xuREvqD4K90cf0B2Zp6WvhaOwGeG91FA1qK3t9yTBGQ="
     },
     "powerlevel10k": {
       "type": "Git",


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@6cdc7fc7...703c1307](https://github.com/nixos/nixpkgs/compare/6cdc7fc76e8bf7fde9fa43a849fcaaa70e230dee...703c1307f503b7a0926608c9bfcc06714514f253)

* [`39526ab9`](https://github.com/NixOS/nixpkgs/commit/39526ab98d8c396a334cf8424b7d2f6b448bb7cb) python3Packages.pymdown-extensions: fix pyyaml dependency
* [`edc1ab04`](https://github.com/NixOS/nixpkgs/commit/edc1ab046eb34d122315ea27de413237744c19a3) maintainer: add caguiclajmg
* [`9313f5c5`](https://github.com/NixOS/nixpkgs/commit/9313f5c5fe259ed722008ec54abad18733ba423d) git2cl: modernize & unstable-2008-08-27 -> 3.0
* [`f3fcd71c`](https://github.com/NixOS/nixpkgs/commit/f3fcd71c7abdf5c993e73632fc2326473c271470) python3Packages.libapparmor: fix cross compilation
* [`08fa1fb8`](https://github.com/NixOS/nixpkgs/commit/08fa1fb8790a07133214b6c7b01a3c3ef859ed07) nixos/doc: Clarify the need to update the channel after changing it
* [`8c62961f`](https://github.com/NixOS/nixpkgs/commit/8c62961f488597bfa99c62475bf6193ddfaffb93) cabextract: fix musl build
* [`739c336e`](https://github.com/NixOS/nixpkgs/commit/739c336e8d16c52b239c82c1ae3a63724d497e95) multipath-tools: 0.14.1 -> 0.14.3
* [`eedfe72e`](https://github.com/NixOS/nixpkgs/commit/eedfe72ee29fe6f1bc645a99e6fc0b39094d6a39) tangara-cli: 0.4.3 -> 0.5.2
* [`018b4de7`](https://github.com/NixOS/nixpkgs/commit/018b4de7f3dcc8f7c3200cb31c3356de3b860e9e) libcpr: 1.14.1 -> 1.14.2
* [`87d73452`](https://github.com/NixOS/nixpkgs/commit/87d73452957533a29b64e949fe99d45e90d3a1f5) beeper-bridge-manager: 0.13.0 -> 0.14.0
* [`c41db4db`](https://github.com/NixOS/nixpkgs/commit/c41db4db49deb95a56fd232b2c92f3ee8f394f6e) envfs: 1.1.0 -> 1.2.0
* [`59b42c63`](https://github.com/NixOS/nixpkgs/commit/59b42c632c8a8a6be3a848e89c202e984815a5e9) hubstaff: fix missing desktop item icon
* [`017d9ee2`](https://github.com/NixOS/nixpkgs/commit/017d9ee23684ac222e40028238a2fcf287edc4c1) seclists: 2025.3 -> 2026.1
* [`ff73638f`](https://github.com/NixOS/nixpkgs/commit/ff73638f0bce6e9b8d3c7e9f9f9bf9917de549bc) keyfinder-cli: 1.1.2 -> 1.2.0
* [`0184f0f6`](https://github.com/NixOS/nixpkgs/commit/0184f0f648d4331c3f76a08feaddc3b029cc5ae4) maintainers: add conny
* [`d0e4a4b1`](https://github.com/NixOS/nixpkgs/commit/d0e4a4b1df9ed9672143c025e0102f0352c540ee) python3Packages.spectral-derivatives: init at 0.10
* [`ffb60950`](https://github.com/NixOS/nixpkgs/commit/ffb60950ded2883d2bd4068234f8aa1c54f64d1a) python3Packages.derivative: init at 0.6.3
* [`56b6284f`](https://github.com/NixOS/nixpkgs/commit/56b6284f7500afc71247d53d6f5e961cfa19ee58) python3Packages.pysindy: init at 2.1.0
* [`64fc246e`](https://github.com/NixOS/nixpkgs/commit/64fc246e66aaf5e2f6afce653cb5576deb21e938) python3Packages.tree-sitter-c-sharp: 0.23.1 -> 0.23.5
* [`311aea58`](https://github.com/NixOS/nixpkgs/commit/311aea58e6901ee3a1b65807096d504d2c878291) maintainers: add swaggeroo
* [`e19c192b`](https://github.com/NixOS/nixpkgs/commit/e19c192b142b5e541450f5ff41dcc754262b802c) deej: init at 0.9.10
* [`cd8fc556`](https://github.com/NixOS/nixpkgs/commit/cd8fc556356d4f0f655e7e7bbc86ffaea80196be) pi-coding-agent: add bryanhonof as a maintainer
* [`38a4e6b7`](https://github.com/NixOS/nixpkgs/commit/38a4e6b7f0a22520d134015a13a91639234c97db) maintainers: add rsahwe
* [`dc94bc10`](https://github.com/NixOS/nixpkgs/commit/dc94bc1059a6d1a94364c3524c98445842aecfab) piskel: init at 0.15.2-SNAPSHOT-unstable-2026-04-09
* [`673f2e67`](https://github.com/NixOS/nixpkgs/commit/673f2e677f45c7e78bd4a575253a1c6aed61e827) ideviceinstaller: 1.1.1+date=2023-04-30 -> 1.2.0
* [`5a78b0a0`](https://github.com/NixOS/nixpkgs/commit/5a78b0a092383218bd5a40a77fd22f9e5c645b23) jpmml-evaluator: init at 1.7.7
* [`4c802b67`](https://github.com/NixOS/nixpkgs/commit/4c802b67ad534def924a250699c4e5c7b9f9c32c) sh earlybird: 4.0.0 -> 4.6.0
* [`68810bda`](https://github.com/NixOS/nixpkgs/commit/68810bdac48287887d8d4ba14bac67acc9fe1a70) kapow: 1.5.10 -> 1.7.0
* [`a0292217`](https://github.com/NixOS/nixpkgs/commit/a0292217fcd5803d8ebb74ef3d5edcc6eb79a445) kapow: add tbutter as maintainer
* [`303bd08c`](https://github.com/NixOS/nixpkgs/commit/303bd08c8bb60b7d3bdc384e1d5435bb9e02eec2) edgetx: 2.11.3 -> 2.11.5
* [`edb52fc9`](https://github.com/NixOS/nixpkgs/commit/edb52fc9d6318cce9a1d17d6f60e0344372e93ae) kubernetes-controller-tools: 0.20.1 -> 0.21.0
* [`47cc49ca`](https://github.com/NixOS/nixpkgs/commit/47cc49caf713b721453b2c14a64107de057743c0) equibop: prefix `LD_LIBRARY_PATH` with GCC
* [`e12a3708`](https://github.com/NixOS/nixpkgs/commit/e12a370861423059a62592f7057601d7a9269216) tree-sitter-grammars.tree-sitter-ocaml: 0.24.2 -> 0.25.0
* [`f67c9cd6`](https://github.com/NixOS/nixpkgs/commit/f67c9cd6a6e5311e0b4aef663c38376eb89bc4cd) chkcrontab: migration to pyproject
* [`8dfe329e`](https://github.com/NixOS/nixpkgs/commit/8dfe329ef7af986f515f9d37f5b3f2e51c9fe234) zsync: 0.6.3-unstable-2025-05-29 -> 0.6.4
* [`4bfdcbe0`](https://github.com/NixOS/nixpkgs/commit/4bfdcbe06f6e8eb518eb9634dea80e58c07f68b9) maintainers: add jeremystucki
* [`cf4b4a12`](https://github.com/NixOS/nixpkgs/commit/cf4b4a12ad7b5bcd6ae79c417283eb17e5382bb5) periphery: init at 3.7.4
* [`9d3cf9f9`](https://github.com/NixOS/nixpkgs/commit/9d3cf9f9562099013124cf51b72be6af406a595e) v2rayn: 7.19.4 -> 7.22.2, dotnet 8 -> 10
* [`76e53560`](https://github.com/NixOS/nixpkgs/commit/76e535609641dfcdca1cd7ea9544fb85531b93cb) git-imerge: switch to pyproject
* [`0dd8049e`](https://github.com/NixOS/nixpkgs/commit/0dd8049ea2397052d09d3630b09e22c7c588b248) python3Packages.pyxattr: modernize and migrate to pyproject
* [`8e48ed19`](https://github.com/NixOS/nixpkgs/commit/8e48ed193d5fba1ea13803880b07e806daa4f0d9) brscan5: fix typo
* [`90c3d4d8`](https://github.com/NixOS/nixpkgs/commit/90c3d4d814183841bfd0fad18d1d908f6325f422) brscan5: fix hardware.sane.brscan5 config
* [`32cf90c6`](https://github.com/NixOS/nixpkgs/commit/32cf90c64ef508b5488fcfba5143ec807938ae50) doas-sudo-shim: 0.1.2 -> 0.2.0
* [`fb957e8b`](https://github.com/NixOS/nixpkgs/commit/fb957e8b7c0086c232efc03548d2342d134bec2c) doc: on overriding and excluding packages from TeX Live collections
* [`52af4259`](https://github.com/NixOS/nixpkgs/commit/52af425964c640d11fbe40bee42c3228d18aed76) deck-app: init at 1.4.5
* [`eee88b63`](https://github.com/NixOS/nixpkgs/commit/eee88b63531ffb0caa93dde08f44718ccf6052fc) cardpeek: Fix on Darwin
* [`5a2919de`](https://github.com/NixOS/nixpkgs/commit/5a2919de8b1fc71d66cea9ba0e3fe5f759901522) grcov: 0.9.1 -> 0.10.7
* [`167017f7`](https://github.com/NixOS/nixpkgs/commit/167017f7d62eb4ad94842823af8236a74ea95488) drawy: 1.0.0 -> 1.0.1
* [`ef8b0e25`](https://github.com/NixOS/nixpkgs/commit/ef8b0e25d9f7d7bf1f93a3733a4aa64001ffa4c1) drawy: enable __structuredAttrs
* [`59ac7405`](https://github.com/NixOS/nixpkgs/commit/59ac7405064254ad5e99755a6f72b1792ee5a25a) drawy: shorten buildInput calls
* [`bb28ced1`](https://github.com/NixOS/nixpkgs/commit/bb28ced1c909b90490248ce6e442c47123f47dc6) drawy: correct licenses
* [`91052f12`](https://github.com/NixOS/nixpkgs/commit/91052f123336bfaca0afa2164c9ca6b55d310708) isolate: 2.3 -> 2.5
* [`75970384`](https://github.com/NixOS/nixpkgs/commit/759703846973b5f488e16649cbe6d70b88303b29) maintainers: add FatBoyXPC
* [`13e60f90`](https://github.com/NixOS/nixpkgs/commit/13e60f90701969fa29dd56935574dee31a995544) heptabase: remove
* [`05eb5e18`](https://github.com/NixOS/nixpkgs/commit/05eb5e1867bf6655de744edd2adf26db7943d25e) p4v: 2024.2/2606884 -> 2026.1/2933292
* [`15c26c48`](https://github.com/NixOS/nixpkgs/commit/15c26c48517a05065163bf55d5d6513154febfb6) python3Packages.visions: 0.8.1 -> 0.8.2
* [`3303f8a0`](https://github.com/NixOS/nixpkgs/commit/3303f8a08cce2cb90f4a68ff29fe27bc37c494b6) srsran: various fixes
* [`01b7c591`](https://github.com/NixOS/nixpkgs/commit/01b7c5916295200e5fa34db2afe4e2921e084e87) libhangul: 0.1.0 -> 0.2.0
* [`9eb0df0c`](https://github.com/NixOS/nixpkgs/commit/9eb0df0cd8562c66c4d20bc40cc5643ee945311e) libhangul: add honnip as maintainer
* [`496b0bed`](https://github.com/NixOS/nixpkgs/commit/496b0bed8adef4709137b0f8a62c5eb6dbdefe90) libhangul: update license
* [`24b041cf`](https://github.com/NixOS/nixpkgs/commit/24b041cfa87b0edae65f29682cf5a197917eb8e5) libhangul: build from source
* [`c9dcebf4`](https://github.com/NixOS/nixpkgs/commit/c9dcebf4510616633917ee994bd51241d58ec3e3) pixieditor: 2.1.1.4 -> 2.1.1.5
* [`5b38f302`](https://github.com/NixOS/nixpkgs/commit/5b38f3020078df01e26e094847d0d57bc0fc6868) nushell-plugin-bson: 26.1100.0 -> 26.1130.0
* [`ce152548`](https://github.com/NixOS/nixpkgs/commit/ce15254814d6b6e34067b0e299d34d2c6cf9111d) bloaty: 1.1-unstable-2024-09-23 -> 1.1-unstable-2026-05-31
* [`cd0853c3`](https://github.com/NixOS/nixpkgs/commit/cd0853c3d140472cb2340e57f0004fb00d2ba971) freedoom: look up wads in nix store
* [`ef9e453b`](https://github.com/NixOS/nixpkgs/commit/ef9e453bf36a1faab2d203e3d8da6590f43e91f0) voxtype-onnx: 0.7.2 -> 0.7.5
* [`0dc9359a`](https://github.com/NixOS/nixpkgs/commit/0dc9359a65de6f30a749449ce7a9292e0482864a) lmmatch: use installFonts
* [`2ca20942`](https://github.com/NixOS/nixpkgs/commit/2ca20942341f62c6380cdecaabfdaf18bad11b5a) et-book: use installFonts
* [`c9e375b2`](https://github.com/NixOS/nixpkgs/commit/c9e375b23c6ec7d7ce470b3f83c0db74e14ab294) dezoomify-rs: 2.15.0 -> 2.16.0
* [`95654b8d`](https://github.com/NixOS/nixpkgs/commit/95654b8d44175d1a5b42909f0d67fb6b38467830) python3Packages.bap: migrate to pyproject
* [`78d7d740`](https://github.com/NixOS/nixpkgs/commit/78d7d740c9fa83d4e67cadafd1b94e3265b56a31) python3Packages.bap: modernize
* [`284017c5`](https://github.com/NixOS/nixpkgs/commit/284017c5f1bf673da952f7911420088f51a6b95f) tmuxPlugins.tmux-sm: 0-unstable-2026-05-14 -> 0-unstable-2026-06-06
* [`8050948f`](https://github.com/NixOS/nixpkgs/commit/8050948fa2c1666aa72c7f5086a43bc00a4eecfb) brewtarget: 5.1.0 -> 5.1.1
* [`c39fadf3`](https://github.com/NixOS/nixpkgs/commit/c39fadf32ddf23c35164bfd047e6dfeeb0c62808) eggnog-mapper: 2.1.13 -> 2.1.14
* [`467477e6`](https://github.com/NixOS/nixpkgs/commit/467477e61abd30f71d5264ee3dad5b9a1bab4c61) eggnogg-mapper: fix for python 3.12+
* [`fdab2a41`](https://github.com/NixOS/nixpkgs/commit/fdab2a416e569b1393c902b79805f18aca09da6b) eggnog-mapper: migrate to pyproject
* [`54f1d62c`](https://github.com/NixOS/nixpkgs/commit/54f1d62c3403c770c286bed8c234aa9440b8fbf1) python3Packages.qemu,qemu-python-utils: fix build
* [`11d1537d`](https://github.com/NixOS/nixpkgs/commit/11d1537db4c9603174b031e407d68ffdb5e7a952) remove jmtpfs: Not receiving upstream updates
* [`5acc851f`](https://github.com/NixOS/nixpkgs/commit/5acc851f6a88f7a6504af20f543f22d8e6c58713) nixos/homer: add caching headers and compression to caddy vhost
* [`d39131d8`](https://github.com/NixOS/nixpkgs/commit/d39131d8b5ad9c0f6f6dc4bff733f85f7e4de1c1) libtorrent-rasterbar: 2.0.12 -> 2.0.13
* [`810a3752`](https://github.com/NixOS/nixpkgs/commit/810a37520c64b056129c00c43ac0da9d412a4934) navidromePlugins.discord-rich-presence: 1.0.0 -> 2.0.0
* [`1f155ee1`](https://github.com/NixOS/nixpkgs/commit/1f155ee15b1d0e471ccab604032c1d3e228c904b) moon: 1.41.8 -> 2.3.2
* [`14403d56`](https://github.com/NixOS/nixpkgs/commit/14403d56305e7592b7c9f7f08ae06439bdffd466) makePythonWriter: remove a useless pypy check
* [`908c0cff`](https://github.com/NixOS/nixpkgs/commit/908c0cff7eb0bfb9e5d68a3f69bfc48b84611217) sonar-scanner-cli-minimal: add required modules
* [`b9d39d1e`](https://github.com/NixOS/nixpkgs/commit/b9d39d1ee7321a4bb1238efc1a3a9f053a4cc978) python3Packages.gviz-api: use finalAttrs
* [`65890f65`](https://github.com/NixOS/nixpkgs/commit/65890f658b7b2664d04a2b63a2eadb2cc4ab44b4) python3Packages.gviz-api: enable __structuredAttrs
* [`b4c1054a`](https://github.com/NixOS/nixpkgs/commit/b4c1054ae81f7b9bad2997ce0b2bc4623f9e6d62) python3Packages.gviz-api: migrate to pyproject
* [`3af751c6`](https://github.com/NixOS/nixpkgs/commit/3af751c6de5a576aebbe2f3f8ae902e754bfa2d3) nushell-plugin-highlight: 1.4.12+0.110.0 -> 1.4.15+0.113.1
* [`26a3758f`](https://github.com/NixOS/nixpkgs/commit/26a3758f4b27f2aa91efaaf6410fb030891d6604) maintainers: add lubsch
* [`bf40b8c4`](https://github.com/NixOS/nixpkgs/commit/bf40b8c498802ac4e74e2e90bf1871f3c65f86e3) cypress: codesign darwin binaries
* [`3f6c397a`](https://github.com/NixOS/nixpkgs/commit/3f6c397ab0003fcfcb6435f05a04df22f2e70141) amphetype: conditionally include qtwayland in buildInputs
* [`ec544c11`](https://github.com/NixOS/nixpkgs/commit/ec544c110d4a9784664af4d6c071d93c5d7b7239) python3Packages.niquests: fix build on darwin
* [`35e1e784`](https://github.com/NixOS/nixpkgs/commit/35e1e78480a9dd7378e8f5c6632431aad6d534ba) git-gamble: wrap the other binary
* [`af6d7654`](https://github.com/NixOS/nixpkgs/commit/af6d7654ee0a1b1f3c829e7b4d2e7edc56f150b1) git-gamble: flaky test has been ignored upstream but another one appeared
* [`d32dfb6c`](https://github.com/NixOS/nixpkgs/commit/d32dfb6cc83467614a72b222c77e8240fe385d38) git-gamble: change changelog's URL
* [`d855cc16`](https://github.com/NixOS/nixpkgs/commit/d855cc16b5eb1827a6b9ee8d394c8359d6f77072) git-gamble: 2.14.2 -> 2.14.4
* [`2186fb95`](https://github.com/NixOS/nixpkgs/commit/2186fb955e88654f4f3b866405d06a588381719a) python3Packages.gibberish-detector: use finalAttrs
* [`592bc721`](https://github.com/NixOS/nixpkgs/commit/592bc72109e2877d0bb96752ff58c9b22a6afc10) python3Packages.gibberish-detector: enable __structuredAttrs
* [`053b7827`](https://github.com/NixOS/nixpkgs/commit/053b78277da4a9af0c2e801dc77a015f35006b36) python3Packages.gibberish-detector: migrate to pyproject
* [`0849a96b`](https://github.com/NixOS/nixpkgs/commit/0849a96b0e08194e4c5a029f2a0801924dc5e5d9) plugdata: use upstream desktop item
* [`29798118`](https://github.com/NixOS/nixpkgs/commit/29798118a9fe2325412c1480faeab616bd19ca36) xd: build with webui
* [`a2808548`](https://github.com/NixOS/nixpkgs/commit/a2808548304ec9485b95e4a4f0f16bd01b42cac8) python3Packages.liger-kernel: init at 0.8.0
* [`d0264c34`](https://github.com/NixOS/nixpkgs/commit/d0264c3475fc202f291a28b1969e67eef0fa5088) formatjson5: apply no rewrite if unchanged patch
* [`5144ab1b`](https://github.com/NixOS/nixpkgs/commit/5144ab1b8119fc19a40b467da05083d6b8f1ae8b) pod2mdoc: modernize
* [`4fb2dd20`](https://github.com/NixOS/nixpkgs/commit/4fb2dd2075bd17607ed4da0281a5c945b5a8afc8) insomnia: 12.2.0 -> 13.0.0
* [`9cce258b`](https://github.com/NixOS/nixpkgs/commit/9cce258b9348b8c946da4c0e9c5355ff40537c3e) termirs: 0.3.2 -> 0.3.3
* [`e589e6ad`](https://github.com/NixOS/nixpkgs/commit/e589e6ad5dee25c7dbe232b8cbd14c3c60c3f4cc) reddsaver: fix erroned attribute
* [`044b1b8f`](https://github.com/NixOS/nixpkgs/commit/044b1b8fea44cbff7ecd579841e45ae4847c093b) nixos/plymouth: add showDelay option
* [`0da502fd`](https://github.com/NixOS/nixpkgs/commit/0da502fd0210884d4885fc9a648c4a7f6a3952ec) msedit: 1.2.1 -> 2.0.0
* [`d6fd925c`](https://github.com/NixOS/nixpkgs/commit/d6fd925cb64a30e1440c6c04c13ba0e75a981ae0) python3Packages.glean-parser: 19.2.0 -> 20.0.1
* [`87805ea1`](https://github.com/NixOS/nixpkgs/commit/87805ea105b62f4914bc42d8c43fba3b60030726) redisinsight: 3.4.2 -> 3.6.0
* [`dbc8e73a`](https://github.com/NixOS/nixpkgs/commit/dbc8e73a26128e5645acece52b8890dad70ed01b) ccextractor: 0.94-unstable-2025-05-20 -> 0.96.6
* [`c64a69ac`](https://github.com/NixOS/nixpkgs/commit/c64a69ac8d59bb7665a6c94b1abefffd0d793d28) dotnetCorePackages.dotnet_{8..11}.vmr: reintroduce fix for intermittent compiler error
* [`0e1200be`](https://github.com/NixOS/nixpkgs/commit/0e1200be2a9b4e422907bd43defc9d3bf480454e) protonmail-desktop: 1.13.0 -> 1.13.3
* [`994755f0`](https://github.com/NixOS/nixpkgs/commit/994755f0ede9b16ba5684d38bd54bb6137fd7945) tree-sitter-grammars.tree-sitter-r: 1.2.0 -> 1.3.0
* [`36b9b6e8`](https://github.com/NixOS/nixpkgs/commit/36b9b6e8f863946936063e6e2fe8718aaa660066) cgal: 6.1.1 -> 6.2
* [`bafd18e0`](https://github.com/NixOS/nixpkgs/commit/bafd18e0d8f2edfc7827fbe683eed509f02a3d97) tree-sitter-grammars.tree-sitter-robot: 1.3.0 -> 1.4.0
* [`70849de9`](https://github.com/NixOS/nixpkgs/commit/70849de9e76bd0dc594ecad8e2f6145f2298c4d3) pnmixer: remove unused pcre dependency
* [`1908d92d`](https://github.com/NixOS/nixpkgs/commit/1908d92d4acacb7ca8773a04145bc160e763dc4d) nixosTests.bluesky-pds: migrate to systemd-nspawn
* [`4c89d8ce`](https://github.com/NixOS/nixpkgs/commit/4c89d8ceedf2c6c854ee67e332b55f60c5822d4e) perlPackages.FinanceQuote: 1.68 -> 1.70
* [`57552bb3`](https://github.com/NixOS/nixpkgs/commit/57552bb3433dfae69300517a63197ab00b36f43f) direvent: 5.4 -> 5.5
* [`df57414e`](https://github.com/NixOS/nixpkgs/commit/df57414e817ced48bec37d483706e0c7950f8e01) zsh-patina: init at 1.7.0
* [`0b4b6c94`](https://github.com/NixOS/nixpkgs/commit/0b4b6c94046ab86615c4b3a8131e1effe6b1ad2c) home-assistant-custom-lovelace-modules.fold-entity-row: init at 2.3.2
* [`9a9ef851`](https://github.com/NixOS/nixpkgs/commit/9a9ef8510964a85ad58dd0c0361166c22019f038) maintainers: add Deric-W
* [`168a9c3a`](https://github.com/NixOS/nixpkgs/commit/168a9c3adfc8cb0e77c29f991fce6e665ff5ee16) fail2ban: add Deric-W to maintainers
* [`3be23fba`](https://github.com/NixOS/nixpkgs/commit/3be23fbab1099ddc3d50185d0e64e9cc488be00d) dnsmasq: libidn -> libidn2
* [`ca9a2d87`](https://github.com/NixOS/nixpkgs/commit/ca9a2d87903d35b171641f6e3afe4e4a1df32f7c) tinygo: build with go 1.26
* [`9fe95b60`](https://github.com/NixOS/nixpkgs/commit/9fe95b603f79a9ac0ce49317af98caa0678b3e08) nixosTests.slipshow: migrate to container runtime
* [`307bd1ba`](https://github.com/NixOS/nixpkgs/commit/307bd1baa6c72ebdf38adcd4c8694d3fc461d1b5) nixosTests.blint: migrateo to container runtime
* [`25decb1a`](https://github.com/NixOS/nixpkgs/commit/25decb1a4dde0082408d2dbf0a99022af13b2534) open5gs: 2.7.7 -> 2.8.0
* [`cc19bd18`](https://github.com/NixOS/nixpkgs/commit/cc19bd18527f8674944435e6c54277b74c9c1742) libvlcpp: 0.1.0-unstable-2024-02-04 -> 0.1.0-unstable-2026-04-16
* [`34045fbc`](https://github.com/NixOS/nixpkgs/commit/34045fbc40cd4efff9760524f884f406b3b72613) argc: only set `$LOCALE_ARCHIVE` if we’re running the tests
* [`eae52808`](https://github.com/NixOS/nixpkgs/commit/eae528082df38313afe61947296a046c1be9ef70) argc: use `pkgsCross.gnu64` for cross test on Darwin too
* [`6d7ae07e`](https://github.com/NixOS/nixpkgs/commit/6d7ae07eeb7bc5494a697d9c96e5e704ae182bbb) ni: 30.1.0 -> 30.2.0
* [`1f6deaff`](https://github.com/NixOS/nixpkgs/commit/1f6deaff6d3c8546398eadc710c3fb6fbcaf45e4) maintainers: add David-Moody
* [`f6f55b1d`](https://github.com/NixOS/nixpkgs/commit/f6f55b1da7292da352d455e71f3a1a6ecad637bb) python3Packages.cssbeautifier: 1.15.4 -> 2.0.1
* [`f010aa5c`](https://github.com/NixOS/nixpkgs/commit/f010aa5c7bf76c22ea0a67d97ea0e81f984068eb) vcpkg: 2026.06.01 -> 2026.06.24
* [`aa2d7034`](https://github.com/NixOS/nixpkgs/commit/aa2d70342d383ec8cbfb1f101ca32404df4fc586) tree-sitter-grammars.tree-sitter-powershell: 0.26.3 -> 0.26.5
* [`df01b3b0`](https://github.com/NixOS/nixpkgs/commit/df01b3b0c69ce0c7ff7ff5e8792ca212870e391a) zuban: 0.8.0 -> 0.9.0
* [`f072535e`](https://github.com/NixOS/nixpkgs/commit/f072535eb2847cf3e4606b2e6dd62231c3322c65) nixos/pam: Write all pam.d config in a single derivation
* [`3a768809`](https://github.com/NixOS/nixpkgs/commit/3a768809c6b274da633246a4735ff9e63c200cd4) texlive: make overlaying texlive.pkgs possible
* [`6944c7c7`](https://github.com/NixOS/nixpkgs/commit/6944c7c7f7c82fccfe4e216baafb842c821b729d) blender: respect cudaCapabilities
* [`ba380a05`](https://github.com/NixOS/nixpkgs/commit/ba380a05c9bb31658af8b1d4a144d445a2630f9c) nixos/komodo-periphery: v2.0.0+ support
* [`98befc76`](https://github.com/NixOS/nixpkgs/commit/98befc7667a987f85b6e457fc30560a4e572a370) powerdns-admin: fix reset password
* [`0ec599d5`](https://github.com/NixOS/nixpkgs/commit/0ec599d5f10a41bae9757961c51253cea121a4dd) powerdns-admin: fix oidc auth
* [`789715ba`](https://github.com/NixOS/nixpkgs/commit/789715ba5b2f432b70aaab1bc56ee2d15b43e204) h2o: 2.3.0-rolling-2026-06-25 → 2.3.0-rolling-2026-06-26
* [`58db73c1`](https://github.com/NixOS/nixpkgs/commit/58db73c1953898286aa270e417e0388b0cd68cd6) h2o: optionally add Zstandard support
* [`2546ae0b`](https://github.com/NixOS/nixpkgs/commit/2546ae0b2440b1b56586cd6bc72dfe7b053af730) h2o: 2.3.0-rolling-2026-06-26 → 2.3.0-rolling-2026-06-29
* [`645e76c0`](https://github.com/NixOS/nixpkgs/commit/645e76c0aaafd4d6f967c30d39429110cded43e2) barebox: undrop package
* [`9a1884d6`](https://github.com/NixOS/nixpkgs/commit/9a1884d63280dbe1a0b281c74b341a49e1c14ad3) barebox: 2020.12.0 -> 2026.06.1
* [`0f7f6682`](https://github.com/NixOS/nixpkgs/commit/0f7f6682a57b5510d00f9d9d6eec93a2ea4b5ad6) barebox: support makeOverridable
* [`d95b729b`](https://github.com/NixOS/nixpkgs/commit/d95b729be2c8b3da9f7e28f90843c76e9cb45ed4) auto-editor: 30.4.0 -> 31.0.0
* [`ab5db803`](https://github.com/NixOS/nixpkgs/commit/ab5db8031f23922368fbc5cdedbdb0acc759773b) mediawiki: 1.45.3 -> 1.45.4
* [`7942f76e`](https://github.com/NixOS/nixpkgs/commit/7942f76eac5802be1b28471e2e6d97dd2b5350f3) vpnc-scripts: unstable-2023-01-03 -> unstable-2026-06-29
* [`e4959b7c`](https://github.com/NixOS/nixpkgs/commit/e4959b7c34cd40cbb8aabc4ba546a4686713f4c9) hyprwhspr-rs: 0.3.31 -> 0.3.32
* [`49f9ba60`](https://github.com/NixOS/nixpkgs/commit/49f9ba608f8a7a229f4fd415c5668470505194d2) maintainers: add jayadeep-km-sonarsource
* [`a625efad`](https://github.com/NixOS/nixpkgs/commit/a625efad9c10dee4a5f857c562b5e41626d17cf1) ocamlPackages.ansi: init at 0.7.0
* [`b5c58cfd`](https://github.com/NixOS/nixpkgs/commit/b5c58cfdb67f62ab2d036e35c4eb813829c9fbbb) sonarqube-cli: init at 1.2.0.3278
* [`b77957e2`](https://github.com/NixOS/nixpkgs/commit/b77957e2f6e14d4dc934702c7d24b7feb8218ab8) cursor-cli: 2026.06.19-20-24-33-653a7fb -> 0-unstable-2026-06-26
* [`036cf953`](https://github.com/NixOS/nixpkgs/commit/036cf9534763fd67f1bcb399910a70c003c5f0bc) ollama: mark cross as broken, fix cmake invocation
* [`65f28bb3`](https://github.com/NixOS/nixpkgs/commit/65f28bb3d062657d08c492e8eda4f8aac66e904b) proj: enable strictDeps and __structuredAttrs, cleanup
* [`9aaffcdb`](https://github.com/NixOS/nixpkgs/commit/9aaffcdb9cc988dbfeb03b17dfee82465d69faa9) olm: modernize slightly
* [`59a113f4`](https://github.com/NixOS/nixpkgs/commit/59a113f40ad70e811f40dc388220f09941f8ed9c) qemu_test: 11.0.1 -> 11.0.2
* [`2bbedd08`](https://github.com/NixOS/nixpkgs/commit/2bbedd083d6c436bb922a402a85cb1df31785016) cockpit: deal with data races in tests
* [`89ff3ccf`](https://github.com/NixOS/nixpkgs/commit/89ff3ccfc86f6bb938ce1f7e572d4b94e6a50fb2) rkbin: 0-unstable-2025-06-13 -> 0-unstable-2025-12-30
* [`83599f25`](https://github.com/NixOS/nixpkgs/commit/83599f2574ac4bc347ae170f76b94249bfed978e) thorium-reader: 3.3.0 -> 3.4.0
* [`3004b4f7`](https://github.com/NixOS/nixpkgs/commit/3004b4f781c37e9934be9c9a28f34c41932ca144) barebox: remove rec
* [`c97ec334`](https://github.com/NixOS/nixpkgs/commit/c97ec3340203c9a9f19b3e5cd231646a2f877946) barebox: support version/src arguments
* [`85f445b5`](https://github.com/NixOS/nixpkgs/commit/85f445b51b4b20876b0be6d9e895094597e0241b) barebox: introduce strictDeps, __structuredAttrs
* [`4544c27b`](https://github.com/NixOS/nixpkgs/commit/4544c27b88b801319ae6944e3a116476dbe8537f) barebox: add lz4 dependency
* [`5bae6f22`](https://github.com/NixOS/nixpkgs/commit/5bae6f2287726944fa167d79bb2c681d43a99aeb) ocaml: Update license
* [`9e233e17`](https://github.com/NixOS/nixpkgs/commit/9e233e17ef9fc62ed1de15ed3efd0dd37830548b) webcord: 4.13.0 -> 4.13.2
* [`b057d518`](https://github.com/NixOS/nixpkgs/commit/b057d51894dc5df108d5b0c57a6a120d6fa9784f) python3Packages.signalslot: migrate to pyproject
* [`0db60be2`](https://github.com/NixOS/nixpkgs/commit/0db60be2d3707a89c00ceb739ba21c822fd890f5) python3Packages.signalslot: modernize
* [`1444d7de`](https://github.com/NixOS/nixpkgs/commit/1444d7ded617fb7254961253dcb1b5ae4f3f16d5) python3Packages.simber: migrate to pyproject
* [`fbca1d01`](https://github.com/NixOS/nixpkgs/commit/fbca1d01f0ba115b8ad86e50946b44795d8e0858) python3Packages.simanneal: migrate to pyproject
* [`7dccb372`](https://github.com/NixOS/nixpkgs/commit/7dccb3728a05279bfba8b464b3f4e57e2368be17) python3Packages.simber: modernize
* [`eaa544a9`](https://github.com/NixOS/nixpkgs/commit/eaa544a9f93bbc1433ce230d83cb41d452ef9fe3) python3Packages.simanneal: modernize
* [`7647f73d`](https://github.com/NixOS/nixpkgs/commit/7647f73df896909f212f8d12ed1b98cc0deba01e) nix-index-unwrapped: 0.1.10 -> 0.1.11
* [`1714e644`](https://github.com/NixOS/nixpkgs/commit/1714e644cbaf094fe399730521b8004a575dbb0f) stremio-linux-shell: fix update script
* [`c9257756`](https://github.com/NixOS/nixpkgs/commit/c9257756e408a5694ae0684f76eb007072ef02b9) python3Packages.simple-di: migrate to pyproject
* [`4de824fa`](https://github.com/NixOS/nixpkgs/commit/4de824fa95308e331f404c955bef6089abb89225) python3Packages.simple-di: modernize
* [`60f62af6`](https://github.com/NixOS/nixpkgs/commit/60f62af6ed62bce8f5f455ee79f1f415e6349e0d) gpclient: keep nixpkgs-update opt-out visible
* [`2b686ec2`](https://github.com/NixOS/nixpkgs/commit/2b686ec2f658005ec5d170efbbe1791563a848c9) webtunnel: 0.0.4 -> 0.0.5
* [`8b04a35c`](https://github.com/NixOS/nixpkgs/commit/8b04a35c444cbc41f04eaf2bdfa6ec37be2aae95) cqlsh-rs: init at 0.5.12
* [`3e4bef3e`](https://github.com/NixOS/nixpkgs/commit/3e4bef3e25d830d7b7968514bfa96ee802f478cb) python3Packages.swi-tools: init at 1.6
* [`274049c5`](https://github.com/NixOS/nixpkgs/commit/274049c58c50e26b55a0a0b6fe9491012fc07f2a) bashmount: add runtime dependencies
* [`3319ea78`](https://github.com/NixOS/nixpkgs/commit/3319ea786d5217221be7c0da0f9730e13ed075ef) babashka: remove rlwrap
* [`cc1f7316`](https://github.com/NixOS/nixpkgs/commit/cc1f73169486ab43430c2e1ec7958405675c8714) tree-sitter-grammars.tree-sitter-nim: 0.6.2-unstable-2026-03-21 -> 0.6.2-unstable-2026-07-03
* [`4192b293`](https://github.com/NixOS/nixpkgs/commit/4192b2933effc0414099561658ff20bf828eb9c7) neomutt: 20260105 -> 20260616
* [`bc1876ef`](https://github.com/NixOS/nixpkgs/commit/bc1876eff09be5463913f1e08b1abb115fdf1ac0) t3code: move to unwrapped.nix
* [`d9af9a43`](https://github.com/NixOS/nixpkgs/commit/d9af9a4312052aa9b64522ff4cab50dede5530cf) t3code: split into standalone wrapper
* [`fc8e4620`](https://github.com/NixOS/nixpkgs/commit/fc8e4620a79fa129b2829d317efde36b17f6280b) framework-control: add updateScript
* [`4bc82db0`](https://github.com/NixOS/nixpkgs/commit/4bc82db07926f2d4eabb965461409f9208dc6c5f) stremio-linux-shell: 1.0.2 -> 1.1.1
* [`6effa7d9`](https://github.com/NixOS/nixpkgs/commit/6effa7d92700d98234307f571c3cde2b8e632b2a) stremio-linux-shell: install more files to match upstream packaging
* [`236fd52f`](https://github.com/NixOS/nixpkgs/commit/236fd52fb4d260cca4d80ed7ab488a94f1a5f6c3) accountsservice: 26.13.3 -> 26.27.3
* [`26d352eb`](https://github.com/NixOS/nixpkgs/commit/26d352eb69d996d8af227b014721a5cc37eb42c0) explo: init at 1.1.2
* [`1edf586e`](https://github.com/NixOS/nixpkgs/commit/1edf586e552fd15b48ed0e1c770eb437829d2df6) antigravity-cli: fix updateScript version handling
* [`6f0e650f`](https://github.com/NixOS/nixpkgs/commit/6f0e650ffcf4184fba3d0ba1b430d600941d9060) stremio-linux-shell: add fazzi to maintainers
* [`cc6ad9e2`](https://github.com/NixOS/nixpkgs/commit/cc6ad9e297818dafa6fea7911ecef6eb43543bb3) lmstudio: hdiutil -> back to _7zz
* [`cccaf100`](https://github.com/NixOS/nixpkgs/commit/cccaf100f95a6d143308d759f0435e942feec34f) rhttp: rename from rHttp, enable strictDeps and structuredAttrs
* [`ed47b93c`](https://github.com/NixOS/nixpkgs/commit/ed47b93cb7f325ea07464be9f4b6d047c334975c) python3Packages.rio-tiler: 9.3.0 -> 9.4.0
* [`dad41ac3`](https://github.com/NixOS/nixpkgs/commit/dad41ac31edf388a484c27ada76355bf152f61ad) opentxl: allow disabling compiler in wrapper
* [`9fc91f06`](https://github.com/NixOS/nixpkgs/commit/9fc91f061e2a8991e278c4fa7787763d5108cb8d) spice: apply upstream patches for gcc 16
* [`414f87d9`](https://github.com/NixOS/nixpkgs/commit/414f87d9745f338521ee0df3d998af24cbbc8957) stardust-xr-{kiara, magnetar, phobetor, sphereland}: drop
* [`5826e73f`](https://github.com/NixOS/nixpkgs/commit/5826e73fea5fad55945278cf95993feeec2b00bd) to-html: 0.1.6 -> 0.2.0
* [`3baa565b`](https://github.com/NixOS/nixpkgs/commit/3baa565ba34004a43b61c9d68630cb8272cec218) igir: 5.2.1 -> 5.3.0
* [`b39b1295`](https://github.com/NixOS/nixpkgs/commit/b39b1295f48a93e2d903347cf4642250af5e1cef) firefly-iii-data-importer: 2.3.2 -> 2.3.4
* [`1848b7af`](https://github.com/NixOS/nixpkgs/commit/1848b7afbcae003206df5c9beeb42c781d97df1d) ansible-navigator: 26.4.0 -> 26.6.0
* [`802b3a1e`](https://github.com/NixOS/nixpkgs/commit/802b3a1e170d1832b4321d0adfa3a72aa16381c7) maintainers/team-list: add stardust-xr team; stardust-xr-*: make use of stardust-xr team for maintainers
* [`0b9ef48c`](https://github.com/NixOS/nixpkgs/commit/0b9ef48cbd5752d9d919faa483208b79dc56f4f7) stardust-xr-server: 0.44.1 -> 0.51.1
* [`2036bb16`](https://github.com/NixOS/nixpkgs/commit/2036bb1688b2326c81af978ce318441b8722a302) stardust-xr-non-spatial-input: init at 0.51.1
* [`2f1b4434`](https://github.com/NixOS/nixpkgs/commit/2f1b443434983865193b9eedb5a5fc58f021b056) stardust-xr-*: set platforms to unix, not linux
* [`85bd5348`](https://github.com/NixOS/nixpkgs/commit/85bd5348a6de432a4c018b81b34164520174a111) stardust-xr-*: update updateScript to point at stable
* [`a625f44f`](https://github.com/NixOS/nixpkgs/commit/a625f44f426aab6118e25643cee2416a71e47f67) stardust-xr-*: enable strictDeps and __structuredAttrs where not already enabled
* [`148b37d4`](https://github.com/NixOS/nixpkgs/commit/148b37d4b417d16c1c0b6f5b0ea1a5c0fd0bab66) stardust-xr-atmosphere: 0-unstable-2024-08-22 -> 0.51.1
* [`45ed8329`](https://github.com/NixOS/nixpkgs/commit/45ed8329ddaac73d933f811c85713d98fb9cb7c7) stardust-xr-flatland: 0-unstable-2024-04-13 -> 0.51.1
* [`59f18434`](https://github.com/NixOS/nixpkgs/commit/59f18434185e060b7a763370c2c4247ecb7443e2) stardust-xr-gravity: 0-unstable-2024-12-29 -> 0.51.1
* [`1eb6639c`](https://github.com/NixOS/nixpkgs/commit/1eb6639cd68dce3f42a4b1e347ce6a05406df18b) stardust-xr-protostar: 0-unstable-2024-12-29 -> 0.51.1
* [`763817aa`](https://github.com/NixOS/nixpkgs/commit/763817aa037dc7b37735680a13c90d2f139de960) nixosTests/monado: add xrgears test
* [`d9f3fd4d`](https://github.com/NixOS/nixpkgs/commit/d9f3fd4d31c561b86dd6a393719e0b116389a4f3) qxmpp: 1.15.1 -> 1.16.1
* [`d5f5394b`](https://github.com/NixOS/nixpkgs/commit/d5f5394bc2360bd5a8d7355fc35c03bcc4561f6f) scid-vs-pc: fix tarball hash
* [`a4fadc4a`](https://github.com/NixOS/nixpkgs/commit/a4fadc4ac82db3ebef667ea898fade07387ef080) wayland-colorbar: init at 0.1.1
* [`020d4389`](https://github.com/NixOS/nixpkgs/commit/020d4389018295feed4b3c27ef2fc0e436f8f80d) nixosTests/stardust-xr-{atmosphere,flatland}: init
* [`005ae92e`](https://github.com/NixOS/nixpkgs/commit/005ae92e4f71bef6f60e906b2098bc8df05ae5d6) technitium-dns-server: 15.2.0 -> 15.3.0
* [`d3566fae`](https://github.com/NixOS/nixpkgs/commit/d3566faecc315d6b60028b44427b65d6b1db2fe6) python3Packages.snuggs: migrate to pyproject
* [`b466af55`](https://github.com/NixOS/nixpkgs/commit/b466af555da6da3c956038a206d557a7d9c90551) python3Packages.snuggs: use finalAttrs
* [`15288053`](https://github.com/NixOS/nixpkgs/commit/152880535b8809cc3efefab0a354e964f548f320) jetbrains.webstorm: 2026.1.3 -> 2026.1.4
* [`33aea887`](https://github.com/NixOS/nixpkgs/commit/33aea887d585f7cdc22ddd7dc9c2b7df5b8596eb) d2: add `withImageSupport` guard to allow closure size reduction
* [`9b9845f3`](https://github.com/NixOS/nixpkgs/commit/9b9845f36debdddb7ee6223e2d5e898f9a2c12f1) openra: migrate to pkgs/by-name
* [`35788ba0`](https://github.com/NixOS/nixpkgs/commit/35788ba00fea57d2edd24cbe8677da6f28f4d29f) zabbix-agent2-plugin-postgresql: 7.4.8 -> 7.4.11
* [`4ce1caf2`](https://github.com/NixOS/nixpkgs/commit/4ce1caf2f21cd02dd6524f343e6a64650b900836) bookstack: 26.05.1 -> 26.05.2
* [`2d5a96dc`](https://github.com/NixOS/nixpkgs/commit/2d5a96dca7838acda97c6286c68886f899230622) rc: Simplify build system hack to generate "VERSION" macro
* [`d5cb1535`](https://github.com/NixOS/nixpkgs/commit/d5cb1535ebc4d4a9ad962a2ec73de15605341dbf) freedv: 2.2.1 -> 2.3.1
* [`b00025d8`](https://github.com/NixOS/nixpkgs/commit/b00025d8fa9d67fe23372e0662f1f32680f5160d) librevenge: 0.0.5 -> 0.0.6
* [`194ffa5b`](https://github.com/NixOS/nixpkgs/commit/194ffa5b776fa4d0dfd082d73f0513fe03327f87) maintainers: add cassandracomar
* [`6dcb3384`](https://github.com/NixOS/nixpkgs/commit/6dcb33849f8fa6f864a3ffaa28d0bc279bb08cdb) pinnacle: init at v0.2.4
* [`0a601a67`](https://github.com/NixOS/nixpkgs/commit/0a601a67d729b02d333a6376e97157511954536d) nixos/pinnacle: init module
* [`48a62528`](https://github.com/NixOS/nixpkgs/commit/48a62528dc302c9a4fd827765b80fc34d619a7cb) kdePackages.qtkeychain: 0.16.0 -> 0.17.0
* [`0a7b18c2`](https://github.com/NixOS/nixpkgs/commit/0a7b18c226ae3f9be2b22dcbaf327b0baaf5e307) sdrangel: 7.22.9 -> 7.27.1
* [`05c56af2`](https://github.com/NixOS/nixpkgs/commit/05c56af293649d1c510e2bf8a0e5058837e99b16) gssproxy: init at 0.9.2
* [`e36bc9af`](https://github.com/NixOS/nixpkgs/commit/e36bc9af58f659a675bc4df32cdf959453f1aba7) prometheus-imap-mailstat-exporter: 0.0.1 to 0.7.1
* [`2749226c`](https://github.com/NixOS/nixpkgs/commit/2749226cd3d799334d7fd8f03a791c4d6f890301) domoticz: 2024.7 -> 2026.2
* [`5e5e22b4`](https://github.com/NixOS/nixpkgs/commit/5e5e22b4e8d188fc0932f6529f8bdef75bdb63ef) python3Packages.bytecode: 0.17.0 -> 0.18.1
* [`d0e8dd3b`](https://github.com/NixOS/nixpkgs/commit/d0e8dd3bdabf2ef8bd0ee59a1fbf88c2bbcfcb25) spidermonkey_115: drop
* [`e4eca2ca`](https://github.com/NixOS/nixpkgs/commit/e4eca2cad9c10e134a4a4b122772649a8b65e130) python3Packages.aioslimproto: 3.1.8 -> 3.1.9
* [`3ed8f865`](https://github.com/NixOS/nixpkgs/commit/3ed8f86515fdc54dac4e9cf513b26383ff9b5e0e) libxmp: 4.7.0 -> 4.7.1
* [`c8a05c56`](https://github.com/NixOS/nixpkgs/commit/c8a05c561584af9653ea597ec5c808e3655d6464) stremio-linux-shell: 1.1.1 -> 1.1.2
* [`9e5da930`](https://github.com/NixOS/nixpkgs/commit/9e5da930fd1d65ada7bf1f645355d74be1814bdd) ggmorse: init at 0.1.0-unstable-2024-05-31
* [`dded6426`](https://github.com/NixOS/nixpkgs/commit/dded642635658d66aef7c0e9ba6064625de1875d) inmarsatc: init at 0-unstable-2023-07-10
* [`561238d5`](https://github.com/NixOS/nixpkgs/commit/561238d5e8f17dbbff399ce7d2a874b73b61beb6) sdrangel: add more optional dependencies
* [`836c3d1d`](https://github.com/NixOS/nixpkgs/commit/836c3d1d225cfff4936b0ebc7d64ca79927b277e) sdrangel: various refactors
* [`f4815ad7`](https://github.com/NixOS/nixpkgs/commit/f4815ad77ae4af6e2da830f29dfa5ddd8a90b7af) virtiofsd: 1.13.3 -> 1.14.0
* [`814dbea2`](https://github.com/NixOS/nixpkgs/commit/814dbea27faaa9fa4d7b20541c23237b0a4a386f) nixos/nspawn-container: hash name, remove assertion
* [`2e6f5555`](https://github.com/NixOS/nixpkgs/commit/2e6f5555de91951c95a1d5010b92b2edf6da2ea6) nixosTests.grafana: switch to nspawn containers
* [`07189450`](https://github.com/NixOS/nixpkgs/commit/07189450298cb4959e92c29dfaad45f0a285f2d2) xfstests: fix updateScript for git.kernel.org
* [`44324029`](https://github.com/NixOS/nixpkgs/commit/4432402901795fcc3327c30970507ccb3656d6e3) rauthy: 0.35.2 -> 0.36.0
* [`09bffb61`](https://github.com/NixOS/nixpkgs/commit/09bffb616bf39a8bbc69bf3880266c93223144a9) nixos-rebuild-ng: allow overriding default ssh opts via environment
* [`8de14381`](https://github.com/NixOS/nixpkgs/commit/8de14381defab90bc1892551507585f0add4b0c4) nixos-rebuild-ng: reword docstring
* [`97dd352d`](https://github.com/NixOS/nixpkgs/commit/97dd352dc415e846fb278b773ff476bb38a80afb) iosevka: use nodejs_latest to fix Darwin build
* [`eef8a424`](https://github.com/NixOS/nixpkgs/commit/eef8a4246e493b8bb814ffcc74375e6818f20732) filebrowser: 2.63.15 -> 2.63.18
* [`c58ae3be`](https://github.com/NixOS/nixpkgs/commit/c58ae3be5fedf9350980cc6961281df99abf64e7) maintainers: drop amiddelk
* [`184358b4`](https://github.com/NixOS/nixpkgs/commit/184358b4c5da50f92e7759c918399ec66a1890a3) maintainers: drop orbitz
* [`7db9f922`](https://github.com/NixOS/nixpkgs/commit/7db9f9221e44a4cf35261c7ed11ff7983a5f05b8) maintainers: drop sprock
* [`27915daa`](https://github.com/NixOS/nixpkgs/commit/27915daae97aa0df8163139e17c9e7e9eb9dfa62) maintainers: drop vlstill
* [`5e4abac4`](https://github.com/NixOS/nixpkgs/commit/5e4abac4b0b0d962df865161585f94365138a0d4) calibre: 9.10.0 -> 9.11.0
* [`3fab0235`](https://github.com/NixOS/nixpkgs/commit/3fab0235db609082a25aa468f57576f1674bc210) maintainers: drop ghuntley
* [`868dff10`](https://github.com/NixOS/nixpkgs/commit/868dff10b16e934dab7a2a388868a32d7a09851e) nixos/version: Use null for IMAGE_VERSION
* [`40105b04`](https://github.com/NixOS/nixpkgs/commit/40105b043ddc5042810de23823aa96199bd2d95f) webull-desktop: correct issue [nixos/nixpkgs⁠#537123](https://togithub.com/nixos/nixpkgs/issues/537123)
* [`e679aa51`](https://github.com/NixOS/nixpkgs/commit/e679aa51d59165113754d5658673cead14efc6a8) dropbear: 2026.91 -> 2026.92
* [`f3eb3e92`](https://github.com/NixOS/nixpkgs/commit/f3eb3e922bd37dd2b71bdc9fc6bc9dbf99c34885) dropbear: adopt package
* [`4f4d6bc1`](https://github.com/NixOS/nixpkgs/commit/4f4d6bc1b64229a75c4ad622fea706fda1b8657d) networkmanager-vpnc: fix gui configuration
* [`679bd0b4`](https://github.com/NixOS/nixpkgs/commit/679bd0b4a6f30d900ddb92c330b26f3d8cf52f8c) sdrangel: fix macOS build by disabling qtwebengine & libunwind
* [`4e85f86a`](https://github.com/NixOS/nixpkgs/commit/4e85f86a5724b4936406c0244231ad1fa11b3ed2) nwchem: move arguments out of all-packages.nix
* [`3068e2d8`](https://github.com/NixOS/nixpkgs/commit/3068e2d8edc95bf84afdf0c4fa5d62c1b4ca2c01) nwchem: migrate to finalAttrs, structuredAttrs, and strictDeps
* [`675204a0`](https://github.com/NixOS/nixpkgs/commit/675204a0816f04aada2de59ff1d6906e7876b054) nwchem: migrate to by-name
* [`a380bc05`](https://github.com/NixOS/nixpkgs/commit/a380bc05e4f88cc82d379026de3fe43673bd932d) tree-sitter-grammars.tree-sitter-elm: 5.9.0 -> 5.9.2
* [`fe385d83`](https://github.com/NixOS/nixpkgs/commit/fe385d83f2c4d5c5f5a4d7f2c858d6aba585a31d) openssh: 10.3p1 -> 10.4p1
* [`ca5fb292`](https://github.com/NixOS/nixpkgs/commit/ca5fb292c1b285cbd36d4ef1a21eb2280934873d) openssh: drop old patches that are now never evaluated
* [`d9c82adc`](https://github.com/NixOS/nixpkgs/commit/d9c82adcfb1ae69a727f64a70504692d79cff022) openssh_gssapi: 10.3p1 -> 10.4p1
* [`b36e8003`](https://github.com/NixOS/nixpkgs/commit/b36e8003133bb91e99b41193f9d5594d0dfb33e2) bisq1: 1.10.2 -> 1.10.3 (and add update script)
* [`d7d5100e`](https://github.com/NixOS/nixpkgs/commit/d7d5100e15f230a0d825c996321ada75f2c949bc) wxwidgets_3_2: 3.2.9 -> 3.2.11
* [`fde12a2c`](https://github.com/NixOS/nixpkgs/commit/fde12a2c5936d75458825b7e9efdf079a34263d7) wxwidgets_3_3: 3.3.2 -> 3.3.3.1
* [`cc27836c`](https://github.com/NixOS/nixpkgs/commit/cc27836c63fc03920dbfd5e5fa3ad047894531ca) go_1_27: 1.27rc1 -> 1.27rc2
* [`0d9244b1`](https://github.com/NixOS/nixpkgs/commit/0d9244b1b6f61366ae40ba9c752a53c43e649525) mcphost: drop
* [`be1ca8af`](https://github.com/NixOS/nixpkgs/commit/be1ca8affcbad762080c857aadee7189d418af30) mainsail: 2.17.0 -> 2.18.2
* [`8ad8d5f6`](https://github.com/NixOS/nixpkgs/commit/8ad8d5f68b14586f35c87c51eca79400d8c16f4a) ty: 0.0.56 -> 0.0.57
* [`baf7a394`](https://github.com/NixOS/nixpkgs/commit/baf7a394da2489b2856ea06b7cf9e2ce6d6b1a7b) spideroak: 7.5.0 -> 7.5.2
* [`08c53a9e`](https://github.com/NixOS/nixpkgs/commit/08c53a9ebc4cf5c7219809b769b5c59ed5b9288b) fishPlugins.macos: 7.2.0 -> 7.3.0
* [`3dc7da50`](https://github.com/NixOS/nixpkgs/commit/3dc7da509f84a7aaf321c774296583f7f43b6052) cc-wrapper: Don't force outPath comparisons during metadata evaluation
* [`053be7e8`](https://github.com/NixOS/nixpkgs/commit/053be7e889371008eb919acb104b13c3bd311233) sqlcipher: 4.16.0 -> 4.17.0
* [`af30e6b4`](https://github.com/NixOS/nixpkgs/commit/af30e6b4b12e1e671337af0f52b3827bbeae8634) nixos-rebuild-ng: prevent Man for opening
* [`99178dc6`](https://github.com/NixOS/nixpkgs/commit/99178dc67f8634a4c7f541c26bd3f8db005d853f) nixos-rebuild-ng: Validate Once
* [`eb461e4e`](https://github.com/NixOS/nixpkgs/commit/eb461e4e2cff6f95ae79f13155d6966005d528ca) maskromtool: 2024-08-18 -> 2026-07-04
* [`0a5a53a6`](https://github.com/NixOS/nixpkgs/commit/0a5a53a63a827e38b3680b9680f45884e0cc2e47) pam_ssh_agent_auth: fix runtime error on aarch64
* [`199eb823`](https://github.com/NixOS/nixpkgs/commit/199eb8233a01d76c7a74db229e9f5bb9f6336e75) sidplayfp: 2.16.2 -> 3.1.0
* [`91d7056e`](https://github.com/NixOS/nixpkgs/commit/91d7056e9e0442e5e571107f430b44a006b526ac) shogun: move to by-name/
* [`12aedfe7`](https://github.com/NixOS/nixpkgs/commit/12aedfe7a8d05c90cc6b3cef7307de60d0c8d556) ttf-envy-code-r: use installFonts, fix download url
* [`75e66b55`](https://github.com/NixOS/nixpkgs/commit/75e66b552cccbb19995d718a20d8d50e44b40716) ttf-envy-code-r: add pancaek to maintainers
* [`e058e6fc`](https://github.com/NixOS/nixpkgs/commit/e058e6fc62f17cf671da60d33697cd3d50bcfeac) ttf-envy-code-r: update homepage
* [`2d758e9d`](https://github.com/NixOS/nixpkgs/commit/2d758e9d097f837e7c2e2463240bca1b38794f4d) python3Packages.coredis: 6.6.1 -> 6.7.0
* [`7c284298`](https://github.com/NixOS/nixpkgs/commit/7c284298731bffda8df711307f17218e0d5ee105) commitizen: 4.13.9 -> 4.16.4
* [`fdf59acd`](https://github.com/NixOS/nixpkgs/commit/fdf59acde3b34d6e1d8c17a8522d7c9dc5e119e5) nixos/traccar: fix shellcheck warning in preStart script
* [`7a3c37ee`](https://github.com/NixOS/nixpkgs/commit/7a3c37eeea3693793f1e936096c99a6a40fa33df) routedns: 0.1.209 -> 0.1.223
* [`ee7c57ad`](https://github.com/NixOS/nixpkgs/commit/ee7c57add66af8f1da27c49763a4aab0bfc2d537) {lomiri,lomiri-qt6}.lomiri-thumbnailer: 3.1.2 -> 3.1.3
* [`e86e43b0`](https://github.com/NixOS/nixpkgs/commit/e86e43b074841c05d217f44dfa58e41a569895d5) terra: remove cudatoolkit
* [`58394f14`](https://github.com/NixOS/nixpkgs/commit/58394f14e5fe2021a9b6091bef63ec5b852883af) terra: enable strictDeps, __structuredAttrs
* [`9f3e49bf`](https://github.com/NixOS/nixpkgs/commit/9f3e49bffaaf88895680fa4cacede553017ec60c) {lomiri,lomiri-qt6}.lomiri-url-dispatcher: 0.1.4 -> 0.1.5
* [`0dd197d8`](https://github.com/NixOS/nixpkgs/commit/0dd197d89733c61a267a2a83c8aa057b87321da3) terra: modernize slightly
* [`9a4ee3b3`](https://github.com/NixOS/nixpkgs/commit/9a4ee3b3a9299363453f4be93268324a4c6ad11b) obs-studio-plugins.advanced-scene-switcher: 1.34.2 -> 1.35.1
* [`e0abffec`](https://github.com/NixOS/nixpkgs/commit/e0abffecc00c745cabdb5ea20f693d874881aa94) miracle-wm: 0.9.1 -> 0.10.1
* [`22897b70`](https://github.com/NixOS/nixpkgs/commit/22897b7049b90fc799139694ec283ba20afb3b0f) linuxPackages.ena: 2.17.0 -> 2.17.2
* [`3a79a9de`](https://github.com/NixOS/nixpkgs/commit/3a79a9ded25c8165d93178944d79307bc7b21191) dosbox-x: 2026.06.02 -> 2026.07.02
* [`07a364f9`](https://github.com/NixOS/nixpkgs/commit/07a364f94acc7a9a7e0a05988ecfcbba47b8d2cf) kind: 0.31.0 -> 0.32.0
* [`d47d9018`](https://github.com/NixOS/nixpkgs/commit/d47d9018673b4e0be024a1f62cdeb8c00dc76d32) spla: remove cudatoolkit usage
* [`05570a1c`](https://github.com/NixOS/nixpkgs/commit/05570a1c3e0018501956cf25a7f988ee07a6d351) spla: enable strictDeps, __structuredAttrs
* [`92e7a7ce`](https://github.com/NixOS/nixpkgs/commit/92e7a7cee2107d5430dbe4c897b1479af0a15e22) python3Packages.types-paramiko: 4.0.0.20250822 -> 5.0.0.20260617
* [`b93d8fb3`](https://github.com/NixOS/nixpkgs/commit/b93d8fb3bdb03fd5697718e3a54a42f746957244) bundled-common: use structured attributes
* [`0fe8db35`](https://github.com/NixOS/nixpkgs/commit/0fe8db35da30f20c0ecd80f65cf0d75b949f92f7) bundlerEnv: use structured attributes
* [`6ceb2b2a`](https://github.com/NixOS/nixpkgs/commit/6ceb2b2ae3f58a3ce269e4fbb7e0f1264c63cb8f) gamma-launcher: 3.0 -> 3.1
* [`a171f0f2`](https://github.com/NixOS/nixpkgs/commit/a171f0f221cf4d45c41fb7749aa975f0b3eabfcd) satysfi: fix the ipaexfont is not bundled properly
* [`f0513967`](https://github.com/NixOS/nixpkgs/commit/f0513967563d72eaead12999cd70634ef5d66e4d) mysql-shell_8: 8.4.9 -> 8.4.10
* [`194e2e5e`](https://github.com/NixOS/nixpkgs/commit/194e2e5e46652c2f0b553244243298b22c412a07) mysql-shell_9: 9.7.0 -> 9.7.1
* [`8c948a0d`](https://github.com/NixOS/nixpkgs/commit/8c948a0d0769d97f9c361b0e22d3167e81b3be37) mysql-shell-innovation: alias to mysql-shell_9
* [`2c327785`](https://github.com/NixOS/nixpkgs/commit/2c327785b3f186e8b1455e115a3c22a44c71e6f0) davmail: 6.8.0 -> 6.8.1
* [`5a72a8a0`](https://github.com/NixOS/nixpkgs/commit/5a72a8a0ff1a34d67badcb28cc497f12225c59d1) python3Packages.orjson: fix cross compilation patch (again)
* [`cad704c4`](https://github.com/NixOS/nixpkgs/commit/cad704c42aef88ffe7cca9448e087873e72e2f6d) luaPackages.json: Init at 0.1.2
* [`46911f50`](https://github.com/NixOS/nixpkgs/commit/46911f50942dac5efbd0b3c9e8d0c96e60646888) dovecot: Fix building with Lua
* [`eb516b01`](https://github.com/NixOS/nixpkgs/commit/eb516b012fa17933856a325bc9b0c0b987fd397d) wsjtx: 3.0.1 -> 3.0.2
* [`99f89bb2`](https://github.com/NixOS/nixpkgs/commit/99f89bb27f3865b200b358ce1818a5293e79437b) webex: 46.4.0.34752 -> 46.6.1.35236
* [`67e4b85d`](https://github.com/NixOS/nixpkgs/commit/67e4b85d40ba2809dd1bb293658c5414095f39e9) ocamlPackages.ocsigen-toolkit: 4.2.0 → 4.3.0
* [`2f1ac6b7`](https://github.com/NixOS/nixpkgs/commit/2f1ac6b70f3635777e140fcc93c17e9ed10859c0) python3Packages.requests-cache: 1.3.2 -> 1.3.3
* [`4bd34899`](https://github.com/NixOS/nixpkgs/commit/4bd348992f2aee17552c27245db9aee7cdc3fb48) bbrew: init at 2.3.1
* [`f738a822`](https://github.com/NixOS/nixpkgs/commit/f738a8221a7dcf69fee038b53a46da9a5340aab4) tree-sitter-grammars.tree-sitter-cmake: 0.7.2 -> 0.7.4
* [`5ac9ebd9`](https://github.com/NixOS/nixpkgs/commit/5ac9ebd92cd4d43363c96e5ef8f21d77880e62a7) flyway: 12.10.0 -> 12.11.0
* [`2856e4f6`](https://github.com/NixOS/nixpkgs/commit/2856e4f683a3e160830fba469f2e6e230cc22f95) python3Packages.pytest-ticket: init at 0-unstable-2025-05-15
* [`a857c1a3`](https://github.com/NixOS/nixpkgs/commit/a857c1a343eccc2a02fd048b1bfe193056a8eb4e) evdevremapkeys: 1.0.0 -> 1.0.3
* [`be1416f4`](https://github.com/NixOS/nixpkgs/commit/be1416f43c62fd565c543069733f76dc6ac6e1a4) komari-agent: updateScript use-github-releases
* [`fa8fa6d7`](https://github.com/NixOS/nixpkgs/commit/fa8fa6d754cfbf0b3c132a6b12c0b6c7eb3d88e9) opam: 2.5.1 -> 2.5.2
* [`cfded879`](https://github.com/NixOS/nixpkgs/commit/cfded879f2deed6ff9ba2ebd45d89fba877c405a) steam-art-manager: 3.16.1 -> 3.17.0
* [`c4f3e21a`](https://github.com/NixOS/nixpkgs/commit/c4f3e21a95aace157f7fbbd187ab54c8fd68050e) nextvi: 6.0 -> 6.1
* [`bbad0eca`](https://github.com/NixOS/nixpkgs/commit/bbad0eca6e3c3589e00849978ec0eae23188f06e) python3Packages.energieleser: init at 0.1.5
* [`9a70fe1f`](https://github.com/NixOS/nixpkgs/commit/9a70fe1f1281cd070b0cde9d1e6941487b53d814) home-assistant: update component packages
* [`b4be96f0`](https://github.com/NixOS/nixpkgs/commit/b4be96f0f0374a3f4a37b505f351d03c16c53989) nixos-rebuild-ng: refactor tempdir context manager in test_tmpdir.py
* [`9c010484`](https://github.com/NixOS/nixpkgs/commit/9c010484f7157bca4b9096adbb679bb2cb820f2a) python3Packages.pyenvertechevt800: init at 0.2.4
* [`5aeecf3e`](https://github.com/NixOS/nixpkgs/commit/5aeecf3ee6d504eaee3bca895361389c54ba9ede) home-assistant: update component packages
* [`cc9349a4`](https://github.com/NixOS/nixpkgs/commit/cc9349a4bb416269f1b93034955a6ab4a6eb56a0) ace-of-penguins: fix help triggering segfault
* [`aead86a3`](https://github.com/NixOS/nixpkgs/commit/aead86a3b85421e1dc5d0075a9123afc558fdf61) nixos-rebuild-ng: refactor test_tmpdir.py
* [`4643b729`](https://github.com/NixOS/nixpkgs/commit/4643b729c1725fd036c07857b22dbb427a3adf48) python3Packages.pyhelty: init at 0.2.0
* [`eab755a9`](https://github.com/NixOS/nixpkgs/commit/eab755a9f39b4bff671c46873c2dbc18827cc6d7) home-assistant: update component packages
* [`43c8fbda`](https://github.com/NixOS/nixpkgs/commit/43c8fbda22a8f0457e8806d580ab1d4a13fc9e6a) bazarr: add connor-grady as maintainer
* [`2958cf19`](https://github.com/NixOS/nixpkgs/commit/2958cf1962c88d1c4c0e1b4c2cd7236174e5762f) python3Packages.pyimouapi: init at 1.3.0
* [`6f075c08`](https://github.com/NixOS/nixpkgs/commit/6f075c088ac89e37b64071f6c7b2688d36bb40f9) home-assistant: update component packages
* [`34ab7ca8`](https://github.com/NixOS/nixpkgs/commit/34ab7ca8e670e23f45ca61389e7f2030006d1b08) python3Packages.pyitachip2ir2: init at 0.0.8
* [`0d80ab07`](https://github.com/NixOS/nixpkgs/commit/0d80ab07c0a5115fd33e3437ccf5e0152025e361) home-assistant: update component packages
* [`8cdacbe3`](https://github.com/NixOS/nixpkgs/commit/8cdacbe386ebd5c6d95fc05d4a7f8096a15aadf5) python3Packages.httplib2: 0.31.1 -> 0.32.0
* [`c7d232f6`](https://github.com/NixOS/nixpkgs/commit/c7d232f65cf3f12c10ae3da4f8eb079d25f1bfd7) python3Packages.aiomelcloudhome: init at 0.1.9
* [`efd279f2`](https://github.com/NixOS/nixpkgs/commit/efd279f2800177f1acd82041d5c49cd13aa2ff60) home-assistant: update component packages
* [`4cd430ae`](https://github.com/NixOS/nixpkgs/commit/4cd430ae54d9d53c3041727e32cf8a78b946ea96) nixos/networkd-dispatcher: add warning when useNetworkd is not enabled
* [`e4a2c3a2`](https://github.com/NixOS/nixpkgs/commit/e4a2c3a244d4753e47b8de3c9fe68a68a785d2c1) python3Packages.aio-wattwaechter: init at 1.1.0
* [`9d68701d`](https://github.com/NixOS/nixpkgs/commit/9d68701d5d375bcf562797640829cf7926f03b11) home-assistant: update component packages
* [`2feb8804`](https://github.com/NixOS/nixpkgs/commit/2feb8804f34eab8e0647d860d8f442794826b723) keycloak: 26.6.4 -> 26.7.0
* [`6d8eaba5`](https://github.com/NixOS/nixpkgs/commit/6d8eaba53835447fa9e96cfc8e48609a4e683496) ruff: 0.15.20 -> 0.15.21
* [`baa53ef8`](https://github.com/NixOS/nixpkgs/commit/baa53ef8069e5a7e905a3b81fd4d77153af567a8) python3Packages.python-swisscom-internet-box: init at 0.2.0
* [`09eca48d`](https://github.com/NixOS/nixpkgs/commit/09eca48d97fe65aa01e906d44c09980a444af1a4) home-assistant: update component packages
* [`bce91d0f`](https://github.com/NixOS/nixpkgs/commit/bce91d0f38a8f6789ecf422fc4067678209243f7) citrix-workspace: pin wfica's EGL/GTK backend to X11 to fix Wayland startup segfault
* [`3685500d`](https://github.com/NixOS/nixpkgs/commit/3685500df8022d7aa4209f173894cd284cf400c3) python314Packages.pyopengl-accelerate: inherit from pyopengl
* [`a78507d8`](https://github.com/NixOS/nixpkgs/commit/a78507d8058f0503f44c652ae780b55800becf1d) python314Packages.pyopengl: fetch from github, cleanup
* [`312bdfd9`](https://github.com/NixOS/nixpkgs/commit/312bdfd95eec68e8d19b011d8033e0a8ce46bc57) toolhive: 0.29.1 -> 0.34.0
* [`ddf9e33b`](https://github.com/NixOS/nixpkgs/commit/ddf9e33b85e426e6cd852bde07cb209d3fa6c8e2) python3Packages.async-substrate-interface: 2.2.0 -> 2.2.1
* [`510aab02`](https://github.com/NixOS/nixpkgs/commit/510aab0284212d53ea58611697874801ab3270e2) pana: 0.23.13 -> 0.23.14
* [`453bab71`](https://github.com/NixOS/nixpkgs/commit/453bab7160fa7f81577fe997ef786fee58af42da) netbird: 0.74.2 -> 0.74.3
* [`ebef11de`](https://github.com/NixOS/nixpkgs/commit/ebef11dee413fa5ad423307097ab805f5d286b4a) python3Packages.openai-agents: 0.17.6 -> 0.18.1
* [`21c1bad3`](https://github.com/NixOS/nixpkgs/commit/21c1bad36368bcbd3dbc8712d09825dfb49e4568) pi-coding-agent: 0.80.3 -> 0.80.6
* [`cf2f7bbc`](https://github.com/NixOS/nixpkgs/commit/cf2f7bbc640a080199fa47cf1e58a0f7ed30ee8a) python3Packages.python-qube-heatpump: 1.11.2 -> 1.12.0
* [`aa4290eb`](https://github.com/NixOS/nixpkgs/commit/aa4290eb0a6dbeab6f478d3895c0bcb99a44f8da) yubioath-flutter: 7.3.3 -> 7.4.1
* [`865320f2`](https://github.com/NixOS/nixpkgs/commit/865320f255a4dbba40f5afe135a8b9ab19ec2463) croc: 10.4.6 -> 10.4.12
* [`4dd23d9a`](https://github.com/NixOS/nixpkgs/commit/4dd23d9a4a94271f861628a1cf7ae1779fa3d197) croc: fix passthrough tests
* [`db275fd7`](https://github.com/NixOS/nixpkgs/commit/db275fd72a637f314107b0f871e9a8241ec14f73) croc: bump to v10.4.13
* [`5e187cd0`](https://github.com/NixOS/nixpkgs/commit/5e187cd01b50bab7a59256feb9e5535355089102) obs-studio-plugins.droidcam-obs: 2.4.1 -> 2.5.0
* [`a804fe6f`](https://github.com/NixOS/nixpkgs/commit/a804fe6f41f036822e23166c4609e7fab406f892) dopamine: 3.0.6 -> 3.0.7
* [`d2b1e111`](https://github.com/NixOS/nixpkgs/commit/d2b1e111a6b40aad2b732c16b9f0a3408ff41903) mago: 1.29.0 -> 1.43.0
* [`9159ce73`](https://github.com/NixOS/nixpkgs/commit/9159ce738ce1e8f8702748a3059c5685860b8599) ty: 0.0.57 -> 0.0.58
* [`647f8369`](https://github.com/NixOS/nixpkgs/commit/647f83692467ddc5193d732083ab2082377bf30d) python3Packages.types-freezegun: migrate to pyproject
* [`af26350c`](https://github.com/NixOS/nixpkgs/commit/af26350cddd8509fc7d41aebabe44ccfc088a865) python3Packages.types-freezegun: modernize
* [`a885b2dd`](https://github.com/NixOS/nixpkgs/commit/a885b2dd57967fd7a88cdc9b3646bc942e16f768) fosrl-olm: { 1.6.1 -> 1.7.0, add versionCheckHook }
* [`f0f45392`](https://github.com/NixOS/nixpkgs/commit/f0f45392d9818b3ce428ccae0f658dc2f93a9295) databricks-cli: set version build ldflags
* [`471a77b2`](https://github.com/NixOS/nixpkgs/commit/471a77b25746b817a98ee1020e9a83a8d95f349e) just: 1.55.1 -> 1.56.0
* [`29dc9bdb`](https://github.com/NixOS/nixpkgs/commit/29dc9bdb1d3dfee25aef72451f968f9b172e4573) immich: bump geodata
* [`fa0d69c1`](https://github.com/NixOS/nixpkgs/commit/fa0d69c1b35d34aaab35731ad69d35b49c10b8ad) v2ray-rules-dat: 202606302305 -> 202607092306
* [`06177fed`](https://github.com/NixOS/nixpkgs/commit/06177fed6ffde239dff17f6e244111b1ae586b93) dependency-track: 4.14.1 -> 4.14.2; include patch for node 22 support
* [`8bd903e4`](https://github.com/NixOS/nixpkgs/commit/8bd903e4cd6d44fb3ceca4fe0a6cfa400d2011ac) nagstamon: Add missing dependencies
* [`4e8211fa`](https://github.com/NixOS/nixpkgs/commit/4e8211fa5321cd51af25f12b20c1d225ae55b7dc) octavePackages.datatypes: 1.2.5 -> 1.2.6
* [`359dd19d`](https://github.com/NixOS/nixpkgs/commit/359dd19dc32a15034ccd86892366b6a4486af373) elpa: 2026.02.001 -> 2026.02.002
* [`21a02a34`](https://github.com/NixOS/nixpkgs/commit/21a02a34047d371ae9d2e0b35876b1f151b12c0e) pgdog: 0.1.47 -> 0.1.48
* [`1fe18448`](https://github.com/NixOS/nixpkgs/commit/1fe18448ae75890155487911e19e1316c97b67a1) goldendict-ng: 26.6.1 -> 26.6.2
* [`0235b951`](https://github.com/NixOS/nixpkgs/commit/0235b9517ea76be81eb471bd5cdb1718a6300547) mkCoqDerivation: make a wrapper on top of mkRocqDerivation
* [`962d8fb3`](https://github.com/NixOS/nixpkgs/commit/962d8fb3ed9d715fcefc7b831056ca18b08e1896) mkRocqDerivation: document new parameters useCoq and useCoqifVersion
* [`b20b6d4a`](https://github.com/NixOS/nixpkgs/commit/b20b6d4a1ea871c3f98057cdd9c7c6a1ada759c9) python3Packages.pandas-stubs: 2.3.3.260113 -> 3.0.3.260530
* [`aec70e19`](https://github.com/NixOS/nixpkgs/commit/aec70e19631c8203d255eca0105900cbb8105b17) lasuite-docs{,-frontend,-collaboration-server}: 5.3.0 -> 5.4.1
* [`9ff2dfbc`](https://github.com/NixOS/nixpkgs/commit/9ff2dfbc96bb50c73d6b7974e0cb5ab02f1eb613) python3Packages.dateutils: migrate to pyproject
* [`0f5fcb3f`](https://github.com/NixOS/nixpkgs/commit/0f5fcb3f5aaeb17f45bef6c2656adcc590d0ddb5) python3Packages.datefinder: migrate to pyproject
* [`d8c2da55`](https://github.com/NixOS/nixpkgs/commit/d8c2da55d62c555d486575525017c3d6d4d44a01) python3Packages.dawg-python: migrate to pyproject
* [`467e6ca1`](https://github.com/NixOS/nixpkgs/commit/467e6ca1dffec6529c18447844dd356063fd2ac6) python3Packages.dateutils: modernize
* [`d893e2d0`](https://github.com/NixOS/nixpkgs/commit/d893e2d05cb75b0a0a97341d161b5745ba41431d) python3Packages.dbf: migrate to pyproject
* [`9fe1bcd1`](https://github.com/NixOS/nixpkgs/commit/9fe1bcd1a6d565f1966dd105e9b92a98fded3f12) python3Packages.dawg-python: modernize
* [`e90264fa`](https://github.com/NixOS/nixpkgs/commit/e90264fa6a8a704e931d9af43f7721a59b64dae6) python3Packages.datefinder: modernize
* [`2fb12d05`](https://github.com/NixOS/nixpkgs/commit/2fb12d05111252aa237dbd146f7348fc3a6d5e8a) python3Packages.dbf: modernize
* [`3efe86da`](https://github.com/NixOS/nixpkgs/commit/3efe86da36a02fa4ee336dae5a7e8cb37f7577f6) python3Packages.airly: migrate to pyproject
* [`e2a10bf5`](https://github.com/NixOS/nixpkgs/commit/e2a10bf5bf354737f94f79b2297189712e83ddb1) python3Packages.airly: modernize
* [`48bf81bc`](https://github.com/NixOS/nixpkgs/commit/48bf81bcb4f427f0ac5209392e2b9a77ef5c7a14) python3Packages.airly: re-enable previously-disabled tests
* [`bf44f5ee`](https://github.com/NixOS/nixpkgs/commit/bf44f5ee970a492baade62815bcbf19bfceaf6e8) maintainers: add AlexAntonik
* [`0d624ebe`](https://github.com/NixOS/nixpkgs/commit/0d624ebe41c6dcf9fff70d544b25ce382976f0a5) auge: init at 1.9.0
* [`aeba2fa7`](https://github.com/NixOS/nixpkgs/commit/aeba2fa7b6be8499a2ac405e0227abb28f7c5123) nixos/systemd: allow listenStreams to contain ports
* [`7d57ab12`](https://github.com/NixOS/nixpkgs/commit/7d57ab127ec6799d0106da737a45e5c8a390dc9e) nixos/rsyncd: specify listenStreams as int
* [`172e2f3a`](https://github.com/NixOS/nixpkgs/commit/172e2f3a36bbadc02cdabfa52c3637858e06a12f) nixos-rebuild-ng: run ruff format
* [`d12975a5`](https://github.com/NixOS/nixpkgs/commit/d12975a5c48912b4bcf2b8b9c1a7ee982c65d95d) immich: inline plugin-core and web
* [`a41aa773`](https://github.com/NixOS/nixpkgs/commit/a41aa77372cb691d0d665769681181276e6f43e4) python3Packages.genai-prices: 0.0.69 -> 0.0.71
* [`8e4d714c`](https://github.com/NixOS/nixpkgs/commit/8e4d714c703f53f2d002d62765fb404a15956dec) python3Packages.pydantic-graph: 2.5.0 -> 2.8.0
* [`e6bdae73`](https://github.com/NixOS/nixpkgs/commit/e6bdae73bbea858cfafc4b3022d44a30cccef5e9) python3Packages.pydantic-ai-slim: 2.5.0 -> 2.8.0
* [`48c96f13`](https://github.com/NixOS/nixpkgs/commit/48c96f13a9c66ab491f93933f649563ce398bb3b) vscode-extensions.jacobdufault.fuzzy-search: init at 0.0.3
* [`58516652`](https://github.com/NixOS/nixpkgs/commit/58516652a82146794309d6d5abf597095d598d3f) vscode-extensions.inferrinizzard.prettier-sql-vscode: init at 1.6.0
* [`6b19bd9a`](https://github.com/NixOS/nixpkgs/commit/6b19bd9a3dd4e009d37c2515c8c87ac874aaf4ab) python3Packages.sphinx-llm: init at 0.4.1
* [`90d4d0b7`](https://github.com/NixOS/nixpkgs/commit/90d4d0b7cf883923db990f79c6f6ae2b08dcd732) tts-mod-vault: 2.0.0 -> 2.1.0
* [`b2df76a3`](https://github.com/NixOS/nixpkgs/commit/b2df76a3ec458c4d4ded15ee9b9b0d7b4b83a9be) rebar3: enable __structuredAttrs + strictDeps, cleanup
* [`b910f531`](https://github.com/NixOS/nixpkgs/commit/b910f531faae777cdcd63af3b7395612fa91b0db) maintainers: add antoineco
* [`4ccd659f`](https://github.com/NixOS/nixpkgs/commit/4ccd659f26bebfb21702562f2d6a91a917932714) cider-2: add antoineco as maintainer
* [`1dfba633`](https://github.com/NixOS/nixpkgs/commit/1dfba633c54e2713022a878e8f49eb6a118541f8) cider-2: remove deps on widevine and asar
* [`d0fd6f83`](https://github.com/NixOS/nixpkgs/commit/d0fd6f83bbd6b5f23899dbfd3ab9226741d3965b) vigra: move args out of top-level
* [`b80bfae8`](https://github.com/NixOS/nixpkgs/commit/b80bfae8d11a9d91f282de7763d011976dd302de) vigra: add strictDeps and structuredAttrs
* [`a8c1bfc8`](https://github.com/NixOS/nixpkgs/commit/a8c1bfc86cd7d2a8a76b068b5f623bd2a19472ea) vigra: migrate to by-bane
* [`dac2015d`](https://github.com/NixOS/nixpkgs/commit/dac2015dabc17c5dc76a60498ed98e47d4dbde60) prometheus: Fix update script to handle ordering between pnpm and Go deps
* [`5fd332a0`](https://github.com/NixOS/nixpkgs/commit/5fd332a07aa63f5ea19ebbe8fa6c84004cbf835b) prometheus: 3.13.0 → 3.13.1
* [`67e429d2`](https://github.com/NixOS/nixpkgs/commit/67e429d2fd4a84d461f19dfa6c8be607d0d5a918) fex: use packaging for aarch64_fit_native.py
* [`ac23ecaa`](https://github.com/NixOS/nixpkgs/commit/ac23ecaa136d38c0b2c8dbb62b98c0a01e07671b) mpvScripts.twitch-chat: 0-unstable-2026-06-13 -> 0-unstable-2026-07-02
* [`61191d9f`](https://github.com/NixOS/nixpkgs/commit/61191d9fe8bd684a6b92061f7794c92bc3cf476b) policycoreutils: 3.10 -> 3.11
* [`a8fae374`](https://github.com/NixOS/nixpkgs/commit/a8fae3743bcd5420bdabd99ede2372caa0b9f00f) sqruff: 0.38.0 -> 0.39.0
* [`481d8cbe`](https://github.com/NixOS/nixpkgs/commit/481d8cbe4196b790f5fb78d456908c43b30ad03e) mapserver: 8.6.4 -> 8.6.5
* [`04ce7ea1`](https://github.com/NixOS/nixpkgs/commit/04ce7ea1c441cc69976e44f079ecbb16e3500167) xfr: 0.9.20 -> 0.9.21
* [`5a9a5ab1`](https://github.com/NixOS/nixpkgs/commit/5a9a5ab1b6537f53271ea0f3a596c6c70e6c7973) python3Packages.flufl-bounce: 4.0 -> 5.0.1
* [`79156b22`](https://github.com/NixOS/nixpkgs/commit/79156b225aa730219247784111f14612b346dd7e) python3Packages.pamqp: 4.0.0 -> 4.0.1
* [`bd2ba70f`](https://github.com/NixOS/nixpkgs/commit/bd2ba70f7a41adcf850d35b8956d2ac8b4c8722c) python3Packages.pamqp: use finalAttrs
* [`ad01b3e1`](https://github.com/NixOS/nixpkgs/commit/ad01b3e1556656d732a1fc6e5014e22f797df85c) python3Packages.click-aliases: 1.0.6 -> 1.0.7
* [`8c29b7ae`](https://github.com/NixOS/nixpkgs/commit/8c29b7ae2b6e35f9a0b95443972998414767fb31) temporal-ui-server: 2.49.1 -> 2.52.0
* [`aa47dab8`](https://github.com/NixOS/nixpkgs/commit/aa47dab8645f14360d53bd5ba2d657a3dcfe041b) betteralign: 0.11.0 -> 0.14.0
* [`10658b83`](https://github.com/NixOS/nixpkgs/commit/10658b83fb947e50f513365c2384275da7dc4ee4) surrealdb: 2.6.1 -> 3.0.0
* [`97ef7759`](https://github.com/NixOS/nixpkgs/commit/97ef7759a8cde65fbab9935bd19743bfc4f61dd0) fzf-git-sh: 0-unstable-2026-06-16 -> 0-unstable-2026-07-06
* [`dc4ed616`](https://github.com/NixOS/nixpkgs/commit/dc4ed616b96121b814b38842c4f75cedd96ae99f) tigerbeetle: 0.17.8 -> 0.17.9
* [`ab974121`](https://github.com/NixOS/nixpkgs/commit/ab974121fdd70a93bb54b0e341b014923f98717a) itsycal: build from source
* [`76cf683a`](https://github.com/NixOS/nixpkgs/commit/76cf683aa43560df22ccb6121008e7e7d0f01073) grafanaPlugins.victoriametrics-metrics-datasource: 0.25.1 -> 0.25.2
* [`917f8195`](https://github.com/NixOS/nixpkgs/commit/917f81954906d83572a6e70b5a79333bdb5e33f8) python3Packages.splunk-sdk: 2.1.1 -> 3.0.0
* [`9062f850`](https://github.com/NixOS/nixpkgs/commit/9062f8508bbb24f9346e921d68caee006b636f24) maintainers: add fernvenue
* [`70c02714`](https://github.com/NixOS/nixpkgs/commit/70c02714a576de21c0d53223ecec7bc740dac765) wg-ddns: 1.3 -> 1.4
* [`33b55146`](https://github.com/NixOS/nixpkgs/commit/33b55146e83a21dc5a0a4f75fd6569eec6c084ce) wg-ddns: add fernvenue as maintainer
* [`8f587ed1`](https://github.com/NixOS/nixpkgs/commit/8f587ed1a8eb11bcb04d9ee6312c9091169c85e9) komikku: 50.8.0 -> 50.9.0
* [`9dca027e`](https://github.com/NixOS/nixpkgs/commit/9dca027e36471a2e44c4cd6d613fa1a593e861cf) prometheus-node-exporter: 1.11.1 -> 1.12.0
* [`364c1c11`](https://github.com/NixOS/nixpkgs/commit/364c1c11c9af72c7c3093e7067b9a7f43d0a804b) python3Packages.pip-chill: 1.0.3 -> 1.0.5
* [`6c552c51`](https://github.com/NixOS/nixpkgs/commit/6c552c51cb691601d409c33673af7416dd58f713) steam-rom-manager: 2.5.34 -> 2.5.42
* [`f1bed4e0`](https://github.com/NixOS/nixpkgs/commit/f1bed4e0d2d0836d0081668724edba0c5d332fe0) calibre-web: relax python deps
* [`dbb79fa1`](https://github.com/NixOS/nixpkgs/commit/dbb79fa1d5e419c8f994699a3f6b89ac95fe9969) hcli: 0.18.3 -> 0.18.5
* [`95b84bca`](https://github.com/NixOS/nixpkgs/commit/95b84bcacc82cc368327011f1d1f9636d862c497) python3Packages.matter-ble-proxy: 1.0.0 -> 1.2.2
* [`33af6228`](https://github.com/NixOS/nixpkgs/commit/33af6228446171965a3b4be64489a47442c74f48) python3Packages.llama-index-vector-stores-qdrant: 0.10.1 -> 0.10.2
* [`a16dfad2`](https://github.com/NixOS/nixpkgs/commit/a16dfad27cb7a488ad93949ad398479dee92adf7) python3Packages.llama-index-vector-stores-qdrant: migrate to finalAttrs
* [`1ba3fa90`](https://github.com/NixOS/nixpkgs/commit/1ba3fa905ae18753d9085208c7e2f9db7717bf52) vscode-extensions.rangav.vscode-thunder-client: init at 2.41.0
* [`9809dd65`](https://github.com/NixOS/nixpkgs/commit/9809dd6533b961fb57841cc326fb78cf1311cf6b) gcx: 0.4.3 -> 0.4.4
* [`5f74de9d`](https://github.com/NixOS/nixpkgs/commit/5f74de9d00e6fd37862bb81bf4d6cc67a8bbf683) parca-agent: 0.48.0 -> 0.49.0
* [`7fa9b4e4`](https://github.com/NixOS/nixpkgs/commit/7fa9b4e4793643f370ab019d086f50a70749c5b1) python3Packages.jq: 1.11.0 -> 1.12.0
* [`9307d7ad`](https://github.com/NixOS/nixpkgs/commit/9307d7ada3adab8e657d1039054841a5e39c611d) vscode-extensions.pflannery.vscode-versionlens: init at 1.28.0
* [`50d267b3`](https://github.com/NixOS/nixpkgs/commit/50d267b3df1e81e96560df76f63d5507aeadad5a) python3Packages.denon-rs232: 4.2.0 -> 4.2.1
* [`96ec925c`](https://github.com/NixOS/nixpkgs/commit/96ec925ccf0164c7108097aa0983f94fc2cd985a) railway: 5.23.3 -> 5.26.0
* [`0d7b51ad`](https://github.com/NixOS/nixpkgs/commit/0d7b51ad6994d57302ad431aede88d9b40a38c19) cider-2: allow reading gsettings
* [`03bdb82e`](https://github.com/NixOS/nixpkgs/commit/03bdb82e7d1b4f08114265bfbda811183b4530a6) arkade: 0.11.106 -> 0.11.113
* [`d25d5184`](https://github.com/NixOS/nixpkgs/commit/d25d5184a03dc17ce9d3dd42c21ebaffafd7e3ae) cider-2: suppress substituteInPlace replace warning
* [`5d35a922`](https://github.com/NixOS/nixpkgs/commit/5d35a9225ddb45b2cf42506214cf810a2aac80b0) cider-2: remove superfluous use of pname
* [`10dafbc0`](https://github.com/NixOS/nixpkgs/commit/10dafbc0b2d775cf59c42247fd1a8e745c42b3f6) ntp: make use of lib.licenses
* [`9c089e7a`](https://github.com/NixOS/nixpkgs/commit/9c089e7a30772da51b71a0d6439434b6a71b479b) lib.licenses: add buddy
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
