### PR TITLE
npins home-manager: update a45a7c45 -> deeb6b7e

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -48,9 +48,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "a45a7c451455a51ae740ec3bce4024b312809c29",
-      "url": "https://github.com/nix-community/home-manager/archive/a45a7c451455a51ae740ec3bce4024b312809c29.tar.gz",
-      "hash": "sha256-r376E2XpakiXwModDHIxlvB6qLq4iFVEq730vxOO4JY="
+      "revision": "deeb6b7eb7e0c44ae1819c051ce175bd92a85100",
+      "url": "https://github.com/nix-community/home-manager/archive/deeb6b7eb7e0c44ae1819c051ce175bd92a85100.tar.gz",
+      "hash": "sha256-ouZe80aWEhMLVMkqICFDN+JUw+0FJtCr/bh+hHtRtMg="
     },
     "hs-grille": {
       "type": "Git",


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@a45a7c45...deeb6b7e](https://github.com/nix-community/home-manager/compare/a45a7c451455a51ae740ec3bce4024b312809c29...deeb6b7eb7e0c44ae1819c051ce175bd92a85100)

* [`6dc9e081`](https://github.com/nix-community/home-manager/commit/6dc9e081ba2afc8c3b81ccddcb895f786155b292) docs: fix cross-page links broken by mdbook migration
* [`165228b0`](https://github.com/nix-community/home-manager/commit/165228b0efefc3e635e5174020c40ea64271dc25) launchd: restore gui domain defaults
* [`c71e83ef`](https://github.com/nix-community/home-manager/commit/c71e83ef50cddf0ba8528347beaf26094453594e) maintainers: update all-maintainers.nix
* [`18f90473`](https://github.com/nix-community/home-manager/commit/18f90473407ac9a919e0b108fbd5da3d347dd9ff) navi: update url for config file docs
* [`46010800`](https://github.com/nix-community/home-manager/commit/460108009ca1ff69ca2ff19079ca2c838d6e3080) herdr: Automatically reload config
* [`39411a8e`](https://github.com/nix-community/home-manager/commit/39411a8e12a5526d992e65bc7e3dc9a4414d6713) syncthing: use localhost authority for unix-socket REST calls
* [`3139deb8`](https://github.com/nix-community/home-manager/commit/3139deb8cafbe73b39b24451255b2fdd3426077e) maintainers: remove diniamo
* [`e3dea8e4`](https://github.com/nix-community/home-manager/commit/e3dea8e4792b09a6c0eb5836b0284ad05b1acba0) tirith: zsh initExtra -> initContent
* [`7d7a2566`](https://github.com/nix-community/home-manager/commit/7d7a2566f6578f82ee478c8fdf6da1737eba3197) Translate using Weblate (Italian)
* [`7834e3fb`](https://github.com/nix-community/home-manager/commit/7834e3fb36a685e0cea0290312b4d200d06649ef) Translate using Weblate (Chinese (Simplified Han script))
* [`411408f5`](https://github.com/nix-community/home-manager/commit/411408f523b59d6c781d9f8176ce749c4f0d5aa3) lib/file-type: partially apply hasPrefix and removePrefix
* [`a02190ed`](https://github.com/nix-community/home-manager/commit/a02190edf9a79d8da191da75eced1ce1ae5e2408) wlsunset: add duration option
* [`56ccab89`](https://github.com/nix-community/home-manager/commit/56ccab89189f63dcd14a3f5710c8d3577d81f22a) programs.claude-code: avoid watching the Nix store
* [`7e2199f4`](https://github.com/nix-community/home-manager/commit/7e2199f4bc76f96e557d35ac84523852dc67e302) rclone: set `programs.fuse.enable` to fix integration tests
* [`cbcbd8b0`](https://github.com/nix-community/home-manager/commit/cbcbd8b043a666b0c7566d8d80f6d772fce0568d) kanshi: Fix scale example values from int to float
* [`deeb6b7e`](https://github.com/nix-community/home-manager/commit/deeb6b7eb7e0c44ae1819c051ce175bd92a85100) files: fix unintended subshell expansion
