### PR TITLE
npins zsh-patina: update 5a0f7889 -> 96eb9dc3

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -242,9 +242,9 @@
       },
       "branch": "main",
       "submodules": false,
-      "revision": "5a0f7889343c1c14ca2b49372a973c7975033e40",
-      "url": "https://github.com/michel-kraemer/zsh-patina/archive/5a0f7889343c1c14ca2b49372a973c7975033e40.tar.gz",
-      "hash": "sha256-4c7jpWqdqOslXv9D6v1/E9+dRUUtd7xJtNCHlXfZCtc="
+      "revision": "96eb9dc30bf3657f7f70e46ea4be3c120c6a1a1c",
+      "url": "https://github.com/michel-kraemer/zsh-patina/archive/96eb9dc30bf3657f7f70e46ea4be3c120c6a1a1c.tar.gz",
+      "hash": "sha256-ME9JvEG30k4BO9fw3rbo/f6dzDfhkD8crN/qDk1NH/E="
     },
     "zsh-syntax-highlighting": {
       "type": "Git",


### PR DESCRIPTION
## Changelog for zsh-patina:
Branch: main
Commits: [michel-kraemer/zsh-patina@5a0f7889...96eb9dc3](https://github.com/michel-kraemer/zsh-patina/compare/5a0f7889343c1c14ca2b49372a973c7975033e40...96eb9dc30bf3657f7f70e46ea4be3c120c6a1a1c)

* [`8ebbecae`](https://github.com/michel-kraemer/zsh-patina/commit/8ebbecae0515f9f77ced743153b28a0989253e3c) Update Homebrew install instructions
* [`c0bfffba`](https://github.com/michel-kraemer/zsh-patina/commit/c0bfffbaf1d9dd7b70a4348b98dcb1cab0f92702) Update serde_with
* [`995a357a`](https://github.com/michel-kraemer/zsh-patina/commit/995a357ad863a84299c0aab021dcfaf9f2e012a8) Update CHANGELOG
* [`461284e7`](https://github.com/michel-kraemer/zsh-patina/commit/461284e7fc05f268e766f46df207a86e1332596e) Bump up version number to 1.9.0
* [`96eb9dc3`](https://github.com/michel-kraemer/zsh-patina/commit/96eb9dc30bf3657f7f70e46ea4be3c120c6a1a1c) Fix permissions of stale workflow
