### PR TITLE
npins nixpkgs: update 703c1307 -> ba41c576

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -125,9 +125,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "703c1307f503b7a0926608c9bfcc06714514f253",
-      "url": "https://github.com/nixos/nixpkgs/archive/703c1307f503b7a0926608c9bfcc06714514f253.tar.gz",
-      "hash": "sha256-xuREvqD4K90cf0B2Zp6WvhaOwGeG91FA1qK3t9yTBGQ="
+      "revision": "ba41c57689f1d839d9eeaea0952df4cc99682a45",
+      "url": "https://github.com/nixos/nixpkgs/archive/ba41c57689f1d839d9eeaea0952df4cc99682a45.tar.gz",
+      "hash": "sha256-TMqc8ZRqVosOOXjZ7HNSV51wImDQK6BkxwXYaUPkT+w="
     },
     "powerlevel10k": {
       "type": "Git",


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@703c1307...ba41c576](https://github.com/nixos/nixpkgs/compare/703c1307f503b7a0926608c9bfcc06714514f253...ba41c57689f1d839d9eeaea0952df4cc99682a45)

* [`f337efba`](https://github.com/NixOS/nixpkgs/commit/f337efba641f79ae3b8d7bc14adfd522eb2e4ec1) python312Packages.pycparser: fix tests for clang stdenv
* [`8748d67a`](https://github.com/NixOS/nixpkgs/commit/8748d67aacde4401fc446ebea9e541ff76a3910c) makeScriptWrapper: warn if target file does not exist
* [`bd17e51c`](https://github.com/NixOS/nixpkgs/commit/bd17e51cdeb7fcf0143b773ab0c4010ea4a011fc) makeBinaryWrapper: warn if target file does not exist
* [`9d20e72b`](https://github.com/NixOS/nixpkgs/commit/9d20e72bc4f9333cab3b7da25664c1af907d419c) libuvc: unstable-2020-11-29 -> 0.0.7-unstable-2024-03-05
* [`27b2f9e3`](https://github.com/NixOS/nixpkgs/commit/27b2f9e31473c61c3c8f71d992224c7462ed01d8) libuvc: avoid with lib;
* [`4355f310`](https://github.com/NixOS/nixpkgs/commit/4355f310c67ab912c92375e21ccdf6962d888db7) maintainers: add jack-avery
* [`1f6eba8e`](https://github.com/NixOS/nixpkgs/commit/1f6eba8e14ce902c21f4c512cf8a5b42832d77ff) hdf5: remove old assert on mutually exclusive cpp/mpi, allowing users to override
* [`9e2a988b`](https://github.com/NixOS/nixpkgs/commit/9e2a988b667e038ad005284dc4c56d16c828e585) bees: add missing verbosity level 8
* [`3d38015f`](https://github.com/NixOS/nixpkgs/commit/3d38015f9045a45b81bdcd32b17dee20de4bcc5a) libajantv2: correctly generate pc module for the dev output
* [`580b8ad7`](https://github.com/NixOS/nixpkgs/commit/580b8ad7bfa2e99b6ebc6bbee8562320f11f2399) tetrd: 1.0.4 -> 1.3.1-1
* [`6057da3e`](https://github.com/NixOS/nixpkgs/commit/6057da3eeab871ffb1af89e06707eca0ff4adff5) makeBinaryWrapper: fix passthru.extractCmd on darwin
* [`4f2971fd`](https://github.com/NixOS/nixpkgs/commit/4f2971fd5a0e185757ac907dd7e773aec65b6a36) python3Packages.ledger-bitcoin: add missing hidapi dependency
* [`63866146`](https://github.com/NixOS/nixpkgs/commit/63866146ae7f1a665c0b162e2e336b05cee15d67) nixos/tetrd: add package option | fix resolve.conf
* [`4411b09a`](https://github.com/NixOS/nixpkgs/commit/4411b09a245502035c223fa73e0eef8b985ec839) pianoteq.trial_9: init at 9.1.2
* [`86185f6e`](https://github.com/NixOS/nixpkgs/commit/86185f6eb9c4c01917b2ec7cc8bd330547a05ccd) pianoteq.stage_9: init at 9.1.2
* [`fd08f5a9`](https://github.com/NixOS/nixpkgs/commit/fd08f5a97384c0ed9e43c5d9e11031981eb87ea8) nixos/errbot: Use systemd-tmpfiles instead of ExecPreStart to create directories
* [`1234cd4c`](https://github.com/NixOS/nixpkgs/commit/1234cd4ca401c9f8f06b0e29ec13f02359c2bec8) maintainers: add mugaizzo
* [`aaa47dc0`](https://github.com/NixOS/nixpkgs/commit/aaa47dc07784a363ab4c0b09b717b46d8cac8f59) sqlite-vec: 0.1.6 -> 0.1.9
* [`8eba8a53`](https://github.com/NixOS/nixpkgs/commit/8eba8a5341f8feef7909fe1414ac4f6152e1fc58) pcre2: modernize
* [`4564ed7a`](https://github.com/NixOS/nixpkgs/commit/4564ed7a7618d93e986d0d11393b260c67d9af2e) pcre2: 10.46 -> 10.47
* [`b8024fc6`](https://github.com/NixOS/nixpkgs/commit/b8024fc691454177963054027fde06a446282127) python3Packages.electrum-ecc: 0.0.6 -> 0.0.7
* [`e749b0a6`](https://github.com/NixOS/nixpkgs/commit/e749b0a6c79dd13e42d84ad26f6761518d8bf1bd) cargo: remove runtime references to cargo-bootstrap
* [`8eb3c825`](https://github.com/NixOS/nixpkgs/commit/8eb3c82575d6ea29bb031db9ac450847d73069f9) rustPlatform.rust: undeprecate
* [`126bd3b5`](https://github.com/NixOS/nixpkgs/commit/126bd3b578fdeedd9af7887e028dfdfbf4a223dd) cargo: disallow references to bootstrap cargo, rustc
* [`19d080de`](https://github.com/NixOS/nixpkgs/commit/19d080de23ecc22a508509f0f6734c972a785e62) rustc-unwrapped: disallow references to build rustc/cargo
* [`7fce89da`](https://github.com/NixOS/nixpkgs/commit/7fce89da5259517e9f519aab3be7fdd9084e68e0) graphene-hardened-malloc: 2025092700 -> 14
* [`670c53d9`](https://github.com/NixOS/nixpkgs/commit/670c53d92a157a0ae827331ba4072017550d12f6) silverbullet-cli: init at 2.6.1
* [`61875ed0`](https://github.com/NixOS/nixpkgs/commit/61875ed0e53d68b194207a187af195cd91f59b28) maintainers: add layzyoldman
* [`8230ad42`](https://github.com/NixOS/nixpkgs/commit/8230ad42940f15bf730bbbd1285fb400e8f10870) vesta-viewer: fix file save/export crash from missing GSettings
* [`8f443661`](https://github.com/NixOS/nixpkgs/commit/8f44366127a8d394b038c9d03e3731d7e84955ba) python3Packages.rcon: init at 2.4.9
* [`e1a817a3`](https://github.com/NixOS/nixpkgs/commit/e1a817a38c08f56e02b099cffc79edca07f9270f) maintainers: add auscaster
* [`18ab73a2`](https://github.com/NixOS/nixpkgs/commit/18ab73a2929154273e7f4ba5615532e39d4f9d4d) maintainers: add vokinn
* [`10215847`](https://github.com/NixOS/nixpkgs/commit/1021584703a5f6231b0d2a9eb0eac6214f031773) pesde: init at 0.7.3
* [`4dc18b30`](https://github.com/NixOS/nixpkgs/commit/4dc18b3075c2e7fc15ea43ebac4199e06ced16e5) fishPlugins.bass: 1.0-unstable-2021-02-18 -> 1.0-unstable-2023-12-17
* [`0d56703d`](https://github.com/NixOS/nixpkgs/commit/0d56703d1e6365ed26b442ba0630be3f6d9cbe98) nomad_2_0: init at 2.0.0
* [`112e7742`](https://github.com/NixOS/nixpkgs/commit/112e7742ee239adde09d8fc1cc6489b10d2468a3) distroshelf: 1.0.15 -> 1.4.8
* [`b0f330ee`](https://github.com/NixOS/nixpkgs/commit/b0f330ee1ee487515a6f8a684e02e5b8ad4ab597) nixos/vaultwarden: add example for .domain option
* [`5d35db6f`](https://github.com/NixOS/nixpkgs/commit/5d35db6f4e6921d1d65eda07d34be249acb7af37) maintainers: add ambiso
* [`68b0f06c`](https://github.com/NixOS/nixpkgs/commit/68b0f06c1a9c8c88caf38b365e7c0628d5df98fb) addchain: init at 0.4.0
* [`cf414a6b`](https://github.com/NixOS/nixpkgs/commit/cf414a6ba870d43b7778da985b82ef6b8cbefebf) python3Packages.isort: 7.0.0 -> 8.0.1
* [`8c49060c`](https://github.com/NixOS/nixpkgs/commit/8c49060c450611c63931108b6d07d5bad56df6eb) nixos/dms-greeter: added mango, labwc, and miracle-wm as supported compositor options
* [`dbe6a06f`](https://github.com/NixOS/nixpkgs/commit/dbe6a06f97b0158823aebdb6143e62c568443c34) schedctl: init at 1.2.1
* [`e8372172`](https://github.com/NixOS/nixpkgs/commit/e8372172633233072f78e86b325b4526557eac8c) auto-patchelf: catch OSError for ZSTD-compressed ELF sections
* [`83419e79`](https://github.com/NixOS/nixpkgs/commit/83419e790f38be5dd1088737199945d8bb518850) azure-mcp: init at 3.0.0-beta.10
* [`6f39241f`](https://github.com/NixOS/nixpkgs/commit/6f39241f3379cd976c0fd22af3da3a7af3454a76) houdini: update link to download requireFile
* [`032fd2f4`](https://github.com/NixOS/nixpkgs/commit/032fd2f44188b07b4bed677b3efd6922c97fa7f3) nym: 2024.14-crunch-patched -> 2026.9-venaco
* [`f52e868a`](https://github.com/NixOS/nixpkgs/commit/f52e868a2efa822f943113badb06dad709ade9c1) buildGoModule: supported structuredAttrs with subPackages
* [`4f7994e4`](https://github.com/NixOS/nixpkgs/commit/4f7994e44a1e5893a8400dd97e26b2ed2c523f72) neo-cowsaw: to __structuredAttrs = true
* [`1b3a9c7c`](https://github.com/NixOS/nixpkgs/commit/1b3a9c7c2ac0339a7e73a2790c63a15a3a4635ae) nixos/jellyfin: fix hevc10bit decoding toggle being silently ignored
* [`5b7ff1e0`](https://github.com/NixOS/nixpkgs/commit/5b7ff1e07e61cc7c85551db3ac06b7880fa028aa) freecad: fix crash on GNOME/Wayland when opening/saving files by adding GSettings schemas to XDG_DATA_DIRS
* [`9f5d0e78`](https://github.com/NixOS/nixpkgs/commit/9f5d0e782d107b71f7a36146eaaad0bf722820cf) modular-services: document VM test best practices
* [`3cb487b5`](https://github.com/NixOS/nixpkgs/commit/3cb487b5a903b0f20e76344ccf3e3784ad4ca0d0) icu: advance the default to icu78
* [`d42e82be`](https://github.com/NixOS/nixpkgs/commit/d42e82be525ad8954ceef6408dbe97c7f3f6d8bc) python3Packages.ezdxf: 1.4.3 -> 1.4.4
* [`c5d51591`](https://github.com/NixOS/nixpkgs/commit/c5d51591b45608482ac0af34005cf7d7cb691f26) markitdown: add top-level alias
* [`5b75bc36`](https://github.com/NixOS/nixpkgs/commit/5b75bc36e15f51a51f0fd597f971c3dcf6877c0f) liquibase: 5.0.2 -> 5.0.3
* [`ff7b6221`](https://github.com/NixOS/nixpkgs/commit/ff7b6221c0aae333bd326d95adbf54ae1c911db7) maintainers: add ckgxrg
* [`6c0944bd`](https://github.com/NixOS/nixpkgs/commit/6c0944bdc06c6c9a31ebe6f4fc2cd0fb842eb2be) nixos/anubis: make all instances part of a system slice
* [`697246d7`](https://github.com/NixOS/nixpkgs/commit/697246d757212cd0135f2dae4fd24f5a37f89311) commet-chat: init at 0.4.2+hotfix.2
* [`8bb7c16a`](https://github.com/NixOS/nixpkgs/commit/8bb7c16a500627e0cc790e0bc00812d9181beb9c) tilem: switch to GTK 3 fork
* [`c81dbffc`](https://github.com/NixOS/nixpkgs/commit/c81dbffc4ffdd566c712d9652d9ef34613fd1abe) tclPackages.expect: 5.45.4 -> 6.0a1
* [`084c1661`](https://github.com/NixOS/nixpkgs/commit/084c166151e93dfacb5b0608a1baea903552d435) nixos/qbittorrent: drop trailing slash from `profileDir`
* [`341ec419`](https://github.com/NixOS/nixpkgs/commit/341ec4198d06f7312d63b970d92292be38ca2b7a) curl{,Minimal}: patch shebang of wcurl script with host runtimeShell
* [`c580aa91`](https://github.com/NixOS/nixpkgs/commit/c580aa919cb696a41b28e9e95eb5c1845db0b916) zscroll: drop
* [`0c29ab05`](https://github.com/NixOS/nixpkgs/commit/0c29ab05e47d3968ccffb5b23319902803b25e0e) pure-maps: 3.4.2 -> 3.5.1
* [`d15af2a4`](https://github.com/NixOS/nixpkgs/commit/d15af2a4ae6edecde533ffda68ba744737d3f8c3) crystalline: 0.17.1 -> 0.18.0
* [`c45e9fd9`](https://github.com/NixOS/nixpkgs/commit/c45e9fd973d8112b5cd6fe2923da6c37760c7d04) nixos/ly: substack login in PAM
* [`f941d78c`](https://github.com/NixOS/nixpkgs/commit/f941d78c5a1853479357a69f4b5f813a2f9075ba) nixos/greetd: substack login in PAM
* [`dbeaedd0`](https://github.com/NixOS/nixpkgs/commit/dbeaedd0402382c9b373f8a44b8428c629099ff9) kamailio: 6.0.5 -> 6.1.3
* [`c780cdde`](https://github.com/NixOS/nixpkgs/commit/c780cdde61466af2b4f2efc60912945746dcf500) kn: 1.22.0 -> 1.22.1
* [`3c1cdb24`](https://github.com/NixOS/nixpkgs/commit/3c1cdb241984ecddaafc94a689833dd3ef94f8d9) dkimpy: migrate to pyproject
* [`f8dbf24c`](https://github.com/NixOS/nixpkgs/commit/f8dbf24ce1bdbd1e2f6013b1c8d7e3854db4efdb) dkimpy: use pytestCheckHook
* [`e8c3df13`](https://github.com/NixOS/nixpkgs/commit/e8c3df1315fb7a98e13bd3aec84c89d985eea058) dkimpy: modernize
* [`67ed43b6`](https://github.com/NixOS/nixpkgs/commit/67ed43b6749365627efc3e33e5b6012e415954cd) agi: migrate to finalAttrs
* [`46f5fe2a`](https://github.com/NixOS/nixpkgs/commit/46f5fe2a356eb57b458e85a0b5e50a048005d292) pappl: 1.4.10 -> 1.4.11
* [`d1af90a2`](https://github.com/NixOS/nixpkgs/commit/d1af90a2286b74025bb4f5821f334b266c01ee2b) python3Packages.jsonrpclib-pelix: 1.0.0 -> 1.1.0
* [`1a3cf0df`](https://github.com/NixOS/nixpkgs/commit/1a3cf0df7bfd535fa369a7eb1c228b03e274f5df) python3Packages.python-arango: 8.3.2 -> 8.3.3
* [`618cae28`](https://github.com/NixOS/nixpkgs/commit/618cae2866ae70530c727e7f080f5bed0d06f9f4) python3Packages.kopf: 1.44.5 -> 1.44.6
* [`bf6855be`](https://github.com/NixOS/nixpkgs/commit/bf6855be79dcf742403084ab8851121e03261949) libssh: Add optional support for gssapi
* [`09c2f240`](https://github.com/NixOS/nixpkgs/commit/09c2f2401300d7300d9cc771b2dd00ac76435833) serd: 0.32.8 -> 0.32.10
* [`b0daf461`](https://github.com/NixOS/nixpkgs/commit/b0daf4616bc0c3307be285e06ee895b08d0c625b) python3Packages.scikit-bio: 0.7.2 -> 0.7.3
* [`26eb89ec`](https://github.com/NixOS/nixpkgs/commit/26eb89ec07bb99b7acd6bf347da9877206070d89) perlPackages.mod_perl2: add `__darwinAllowLocalNetworking`
* [`35a12eb0`](https://github.com/NixOS/nixpkgs/commit/35a12eb082d9117214fe4056208747f286109ba2) python3Packages.azure-storage-queue: 12.15.0 -> 12.17.0
* [`dfde99fd`](https://github.com/NixOS/nixpkgs/commit/dfde99fd70050d75307eae7e30bc0cd249c9f2a7) formats.javaProperties: use structuredAttrs instead of passAsFile
* [`3cb8b078`](https://github.com/NixOS/nixpkgs/commit/3cb8b0787dae828c47132f7aba3c12a285caf9db) formats.javaProperties: use structuredAttrs instead of passAsFile in test
* [`320f4f3e`](https://github.com/NixOS/nixpkgs/commit/320f4f3e959aaae38242c91faa1eba5b26520e0e) python3Packages.google-cloud-monitoring: 2.30.0 -> 2.31.0
* [`66eeea87`](https://github.com/NixOS/nixpkgs/commit/66eeea8723a7439c9461b63d196c5c2049b79959) ocamlPackages.dockerfile: 8.4.0 -> 8.4.1
* [`b30343e6`](https://github.com/NixOS/nixpkgs/commit/b30343e67afeeb4c5daecdc7b88312cdc3211cd3) bolt-launcher: remove openssl_1_1, mark as broken with RS3
* [`0fc90c3e`](https://github.com/NixOS/nixpkgs/commit/0fc90c3e06254ff22e07ab2c25fe2091e75fd05d) mpg123: 1.33.5 -> 1.33.6
* [`0150e189`](https://github.com/NixOS/nixpkgs/commit/0150e1894f23407a9766d9a3ac3bb5911b2c0639) minimal-bootstrap: Use minimal gcc wrapper
* [`821c3b4a`](https://github.com/NixOS/nixpkgs/commit/821c3b4aaf986ce67284c85a195821d66d240e90) syslogng: 4.11.0 -> 4.12.0
* [`9dbf5bd0`](https://github.com/NixOS/nixpkgs/commit/9dbf5bd0f6dbde429c478256cee1d08c30f1c75e) pugixml: 1.15 -> 1.16
* [`0356dd37`](https://github.com/NixOS/nixpkgs/commit/0356dd376d9b5b6a157aca0e2dad087466961f37) python3Packages.jug: fix dependencies attribute
* [`745f1246`](https://github.com/NixOS/nixpkgs/commit/745f12467cb3410993c1e708178c0082cea1cbea) minimal-bootstrap: Fix tools in preparation for early cross-compilation
* [`929dd649`](https://github.com/NixOS/nixpkgs/commit/929dd649d08ade98dec295fe7cf2542d4d5c5949) oidcwarden: init at 2026.4.2-1
* [`2d80d648`](https://github.com/NixOS/nixpkgs/commit/2d80d64878e8182e26891b0db275d34abaf33521) bash: 5.3p9 -> 5.3p15
* [`ff85c2b9`](https://github.com/NixOS/nixpkgs/commit/ff85c2b93b8e5cea4a224c58a422dd61c6ab7dd8) zix: 0.6.2 -> 0.8.2
* [`523a4dc4`](https://github.com/NixOS/nixpkgs/commit/523a4dc4187ec7edacf15820e2468553eb210a38) zix: adopt
* [`81fbb6a0`](https://github.com/NixOS/nixpkgs/commit/81fbb6a0c335167b648da56d2093b777c107fd29) zix: modernize
* [`e197a90d`](https://github.com/NixOS/nixpkgs/commit/e197a90da72ddba320fbbbdddbd202e674a7d9a1) python3Packages.mock: switch to pyproject
* [`559ec51b`](https://github.com/NixOS/nixpkgs/commit/559ec51b02722903e0c8ac6560c9896a7c9a94ff) libffiReal: 3.5.2 -> 3.6.0
* [`813c10f1`](https://github.com/NixOS/nixpkgs/commit/813c10f1d6363f5a7f67c504719d5f0999063a1c) xkeyboard-config: 2.47 -> 2.48
* [`aaba92e0`](https://github.com/NixOS/nixpkgs/commit/aaba92e0cc6e37c4ef9eb951ac9b94bae9034ecf) nixos-test-driver: reintroduce `--test-script` flag
* [`5fa3ac88`](https://github.com/NixOS/nixpkgs/commit/5fa3ac888c021700145f7f7dec8cfcf2dc9c2029) duckdb: 1.5.3 -> 1.5.4
* [`0645730a`](https://github.com/NixOS/nixpkgs/commit/0645730af245152db047cb5bb8599daf797c62b6) jbang: enable __structuredAttrs and strictDeps
* [`f64c797b`](https://github.com/NixOS/nixpkgs/commit/f64c797b774418ced584c2e6fd38ee378dbbc5a2) intel-oneapi-toolkit: 2026.0.0.198 -> 2026.0.1.27
* [`6814bd04`](https://github.com/NixOS/nixpkgs/commit/6814bd04b1eff489a22f851dbf080239ed23cde2) intel-oneapi-toolkit: drive updateScript off Intel's productsinfo API
* [`67112370`](https://github.com/NixOS/nixpkgs/commit/671123705f14f443e89353053b4eefb7f1a0e2dc) intel-oneapi-toolkit: add kilyanni as maintainer
* [`2c9c1c82`](https://github.com/NixOS/nixpkgs/commit/2c9c1c82efe822bf5b15512bb1cb1b0b3a9fd8e1) libressl: fix static build
* [`66353ca9`](https://github.com/NixOS/nixpkgs/commit/66353ca989dd68b3070f8932c048860e8354bc01) nixos/resolved: apply transformations to keys within resolved section
* [`f9e10631`](https://github.com/NixOS/nixpkgs/commit/f9e1063171bf862c4d17997769cc0795223f6730) merve: add support for building without simdutf support
* [`cba47cf5`](https://github.com/NixOS/nixpkgs/commit/cba47cf5e84bdc7a2c5d1ef9507fe42bb4948610) nodejs_24: fix merve dependency
* [`fd587853`](https://github.com/NixOS/nixpkgs/commit/fd5878533a8db6bd401be1863a39c813f3d0b366) python3Packages.strct: support setuptools 82
* [`b545bebf`](https://github.com/NixOS/nixpkgs/commit/b545bebf4294e5bf9b92b0419aa274b4a1ee71f4) nodejs: call configure.py directly
* [`504f6c93`](https://github.com/NixOS/nixpkgs/commit/504f6c930735259be2440a797e4318352840f6a4) nodejs_24: fix fs tracking warnings on Darwin
* [`09614c7c`](https://github.com/NixOS/nixpkgs/commit/09614c7c7db1f2fc7ce9c6f7b2a067160e43bd7f) cmake: 4.1.2 -> 4.3.4
* [`703a55dd`](https://github.com/NixOS/nixpkgs/commit/703a55ddf48d1ebb4ace62665dfec573e7cbe933) sqlite, sqlite-analyzer: 3.53.1 -> 3.53.3
* [`cb7ec1e7`](https://github.com/NixOS/nixpkgs/commit/cb7ec1e71814d63516992dff2790388d786d721d) cargo-auditable: clean up rebuild avoidance
* [`9714f07c`](https://github.com/NixOS/nixpkgs/commit/9714f07c1f6e4c7611533c6715eb899c63e08656) nodejs: require big-parallel system feature
* [`91916cd9`](https://github.com/NixOS/nixpkgs/commit/91916cd91572d0553382b1b5a290b1a57d6db4a9) alsa-lib: 1.2.16 -> 1.2.16.1
* [`15d080f2`](https://github.com/NixOS/nixpkgs/commit/15d080f2505130339cb088f1a350b2fd4439db8e) alsa-ucm-conf: 1.2.16 -> 1.2.16.1
* [`2a90ef80`](https://github.com/NixOS/nixpkgs/commit/2a90ef803ff71a935d1e1c7d2f4d57fe53c493c9) alsa-utils: add meta.changelog
* [`c3ad924a`](https://github.com/NixOS/nixpkgs/commit/c3ad924a7d0b0fa6239f05e77a9605e94f294f9b) luaPackages: Add maintainer flag for assorted LuaRocks I maintain upstream
* [`ba13cc99`](https://github.com/NixOS/nixpkgs/commit/ba13cc996e3c61073ea06af735938589fade71c5) gssdp_1_6: 1.6.5 -> 1.6.6
* [`64bc83e5`](https://github.com/NixOS/nixpkgs/commit/64bc83e5e664a06b57d5fc79d41e10342ad14277) gitlab-ci-local: 4.64.1 -> 4.73.0
* [`22eda77d`](https://github.com/NixOS/nixpkgs/commit/22eda77d98d8ce851be280be2310a53405e136f2) nodejs_24: limit pinning of LLVM to darwin
* [`c72f684b`](https://github.com/NixOS/nixpkgs/commit/c72f684b1d63a7f51463f7d0e9431829dfd182f5) quarkdown: init at 1.6.1
* [`38c44143`](https://github.com/NixOS/nixpkgs/commit/38c44143d78644394f0b50c5695904c58e33c213) nodejs_24: fix typo in derivation
* [`06506eaf`](https://github.com/NixOS/nixpkgs/commit/06506eaf4c2b90bee5222db4cb5c5923351006e6) python3Packages.neo: 0.14.4 -> 0.14.5
* [`a8f76836`](https://github.com/NixOS/nixpkgs/commit/a8f768361ea0d4b2234b88199e231680e832bebe) libadwaita: 1.9.1 -> 1.9.2
* [`135034ac`](https://github.com/NixOS/nixpkgs/commit/135034ac717fd02a478c869bd355f41cb36e5adf) curl: allow runtimeShellPackage to be referenced by curl.dev
* [`d0c0d01a`](https://github.com/NixOS/nixpkgs/commit/d0c0d01afc8ea5d0f189fd4f4805e98b136a7299) libressl_4_3: 4.3.1 -> 4.3.2
* [`e6c219c3`](https://github.com/NixOS/nixpkgs/commit/e6c219c3d7886e6d28493c792b44ac48cf7dbe9b) maintainers: add untio11
* [`c057afbc`](https://github.com/NixOS/nixpkgs/commit/c057afbc4d8ea908adc18855c9ecb890a7802c51) python3Packages.pytest-memray: init at 1.8.0
* [`4ddd9cf2`](https://github.com/NixOS/nixpkgs/commit/4ddd9cf2489a4b8a68f38318b671605fa6a71bd1) python314Packages.pyturbojpeg: enable tests
* [`eb58007a`](https://github.com/NixOS/nixpkgs/commit/eb58007af76c976a03436887b5325d18c492ddb0) attr: 2.5.2 -> 2.6.0
* [`e9feb05a`](https://github.com/NixOS/nixpkgs/commit/e9feb05aafb373a2fa392e4d2f7f99a9d2d3760c) vesta-viewer: use makeWrapper instead of symlinks for GSettings on KDE
* [`3e9573a9`](https://github.com/NixOS/nixpkgs/commit/3e9573a974855d064f8ec0d7a96e7bf800da67f7) acl: 2.3.2 -> 2.4.0
* [`61bf4912`](https://github.com/NixOS/nixpkgs/commit/61bf491213fb6da0b7067d1ed0c4a642e0104519) gnutar: avoid name conflicts with acl 2.4.0
* [`b71417e7`](https://github.com/NixOS/nixpkgs/commit/b71417e791dcf9d48a42a3c052fe572a4f420c9f) isa-l: mark unbroken for aarch64-darwin
* [`a74c47e5`](https://github.com/NixOS/nixpkgs/commit/a74c47e5d1cdbcf8e0a3be7ed83ce567bf497ff1) isa-l: mark unbroken for i686-linux
* [`8ee90271`](https://github.com/NixOS/nixpkgs/commit/8ee90271bed9a9ab63e1b18b6ba32b4a04cbd8db) python314Packages.aiohttp: drop unused inputs
* [`f1921ed9`](https://github.com/NixOS/nixpkgs/commit/f1921ed9229bfb199dfda3aa397e3defa3fc0a37) python314Packages.aiohttp: remove now unused isal condition
* [`a2d5d093`](https://github.com/NixOS/nixpkgs/commit/a2d5d0934258f1343ebeb2aea77560cd66312403) libvgm: 0-unstable-2026-06-07 -> 0-unstable-2026-06-23
* [`5c62da7e`](https://github.com/NixOS/nixpkgs/commit/5c62da7ead7f27c60229be52f015007c7f9a5217) libmemcached: make the patch unconditional
* [`89cdf1a8`](https://github.com/NixOS/nixpkgs/commit/89cdf1a803f1754210b69696181b73d78a47b2c9) git: fix update script
* [`72a17135`](https://github.com/NixOS/nixpkgs/commit/72a17135131f7f79f72c055d034ebeeffa534064) maintainers: add rootile
* [`98ada3a5`](https://github.com/NixOS/nixpkgs/commit/98ada3a5420244f4c430563b00bc0019667ca06b) waypaper-engine: init at 3.0.0
* [`b7b9f65c`](https://github.com/NixOS/nixpkgs/commit/b7b9f65c486108453f26e48de473a154558c8a6d) publicsuffix-list: 0-unstable-2026-05-13 -> 0-unstable-2026-06-24
* [`620dc9f4`](https://github.com/NixOS/nixpkgs/commit/620dc9f4555d3230254d85e449832de27f8cdfa8) nasm: 3.01 -> 3.02
* [`8515b91b`](https://github.com/NixOS/nixpkgs/commit/8515b91b88f3a27584324effe33a24df2ed15fae) glibc: fix CVE-2026-5435 and CVE-2026-6238
* [`775b8685`](https://github.com/NixOS/nixpkgs/commit/775b8685460eedfa44a686bc453b9078616c5edc) sbsigntool: make unused-but-set-variable non-fatal for gcc 16
* [`2555c865`](https://github.com/NixOS/nixpkgs/commit/2555c86506cb9b298c8ad6e41cc9125d09612abc) libxml2: fix CVE-2026-11979
* [`d1e81cb2`](https://github.com/NixOS/nixpkgs/commit/d1e81cb2d58014c4cc2ffd510c797a301c30a595) jemalloc: enable heap profiling by default
* [`174e0a3a`](https://github.com/NixOS/nixpkgs/commit/174e0a3aa3b5dbc11a0507631f6a8f768484bb83) pulumi: 3.192.0 -> 3.248.0
* [`c210d6bb`](https://github.com/NixOS/nixpkgs/commit/c210d6bb892f5844bbd35534cfc9c7fba9ee81bc) pulumiPackages.pulumi-go: 3.192.0 -> 3.248.0
* [`1bfac9c3`](https://github.com/NixOS/nixpkgs/commit/1bfac9c378dcab6425eda2aadf12a5d8412e69ee) pulumiPackages.node-js: 3.192.0 -> 3.248.0
* [`9ca5a1b1`](https://github.com/NixOS/nixpkgs/commit/9ca5a1b103a16cee72d4cad95ef2a2a5825cc8d1) pulumiPackages.pulumi-python: 3.192.0 -> 3.248.0
* [`46714b05`](https://github.com/NixOS/nixpkgs/commit/46714b0550580902eb85e41abac4b4be8edb25d7) maintainers: add niklasravnsborg
* [`4c551237`](https://github.com/NixOS/nixpkgs/commit/4c551237f8eea52c06127c6ac628c8b138bcf3e2) libsepol: 3.10 -> 3.11
* [`a7a6bd99`](https://github.com/NixOS/nixpkgs/commit/a7a6bd99a28765c664f1863db885b36dc64f5547) gzip: security fixes
* [`4fadb90a`](https://github.com/NixOS/nixpkgs/commit/4fadb90a41288f56f0d7856458d5fbdafd743999) sdl3: 3.4.10 -> 3.4.12
* [`6a94b923`](https://github.com/NixOS/nixpkgs/commit/6a94b9238fa7a2ea78143562e933bcddc52fb16c) ostree-full: 2026.1 -> 2026.2
* [`c516683a`](https://github.com/NixOS/nixpkgs/commit/c516683a6a4fe1baac0a0d6d707fc1441dd79cda) libjxl: 0.11.2 -> 0.12.0
* [`c5423a55`](https://github.com/NixOS/nixpkgs/commit/c5423a5587e9dac3453be777ac08170f47ae26af) python3Packages.{pyside6,shiboken,shiboken-generator}: 6.11.0 -> 6.11.1
* [`5178946d`](https://github.com/NixOS/nixpkgs/commit/5178946d548b0247d75d9e65a956f3a8f8bd3e34) python3Packages.pyside6-qtads: 4.5.0 -> 5.0.0
* [`dd405da7`](https://github.com/NixOS/nixpkgs/commit/dd405da7eb365091fa682d40fe24b77c908905c1) libevent: 2.1.12 -> 2.1.13
* [`fabe4a9a`](https://github.com/NixOS/nixpkgs/commit/fabe4a9ad0e26295f32a42a99a79ac0784d29b73) pulumiPackages.pulumi-bun: init at 3.248.0
* [`76fd246b`](https://github.com/NixOS/nixpkgs/commit/76fd246bc5a079068a954f20aa02fb7dfb666205) libva-minimal: 2.23.0 -> 2.24.0
* [`d0a2b56b`](https://github.com/NixOS/nixpkgs/commit/d0a2b56b4fd0927ebf3a4ef599b388f21bbb619b) python314Packages.ipython: disable timing sensitive tests
* [`b9d7f2b1`](https://github.com/NixOS/nixpkgs/commit/b9d7f2b1a0559d5434ff86984eb617058d4cb71a) libjxl: Update comments
* [`c8369558`](https://github.com/NixOS/nixpkgs/commit/c8369558a81876a37fb6333027398e54843a326a) netpbm: 11.14.0 -> 11.15.1
* [`1729877a`](https://github.com/NixOS/nixpkgs/commit/1729877a4ca6625f751fd6248ade9419d720a4c9) tcl-9_0: 9.0.3 -> 9.0.4
* [`009447e4`](https://github.com/NixOS/nixpkgs/commit/009447e425837be08e446078d971762d0d7b1ccf) pyrra: 0.10.0 -> 0.10.1
* [`dac44d4a`](https://github.com/NixOS/nixpkgs/commit/dac44d4a952eb3c4da690aad741c1e3254788429) unixodbcDrivers.psql: 18.00.0001 -> 18.00.0002
* [`755201c8`](https://github.com/NixOS/nixpkgs/commit/755201c866fb7d77fe858124891840151845a863) lief: 0.17.0 -> 0.17.6
* [`08c17b3d`](https://github.com/NixOS/nixpkgs/commit/08c17b3d486d591e6478bdfc35ad47fa3686e2e6) pcre2: `finalAttrs`
* [`5985f549`](https://github.com/NixOS/nixpkgs/commit/5985f549584a93f543f141d5b22187091ce06c75) pcre2: `__structuredAttrs`, `strictDeps`, `enableParallelBuilding`
* [`8746d3ca`](https://github.com/NixOS/nixpkgs/commit/8746d3caee7a256a2a1638da3e357ae666a6f47d) glibc: set default zonedir to match fhs
* [`17e6e533`](https://github.com/NixOS/nixpkgs/commit/17e6e533cc76bc80c9d502c02180f11598283483) uvwasi: add support for static-only builds
* [`770e746d`](https://github.com/NixOS/nixpkgs/commit/770e746d5eaf0fc0abe0994206cbdd3dea6d37ee) libssc: 0.2.2 -> 0.4.4
* [`f73e5587`](https://github.com/NixOS/nixpkgs/commit/f73e5587b6d10c416f7bfa984b9e4a54082f35c9) buildVscode{,Marketplace}Extension: enable strictDeps, __structuredAttrs
* [`9fb8d43c`](https://github.com/NixOS/nixpkgs/commit/9fb8d43cff63c5c082da6697ab44670b55e7346d) buildTypstPackage: enable strictDeps, __structuredAttrs
* [`73f7a6a9`](https://github.com/NixOS/nixpkgs/commit/73f7a6a95667f82ab8968887df3823f2e2a7f8c1) vscode-extensions.ms-vscode.cpptools: move jq to nativeBuildInputs
* [`56a51760`](https://github.com/NixOS/nixpkgs/commit/56a517608a37460461087779bd8fb488573a5b69) omnictl: 1.9.0 -> 1.9.1
* [`92849858`](https://github.com/NixOS/nixpkgs/commit/92849858f938668467d43408335b1c6f4c5e2fe0) noctalia-greeter: init at 1.0.0
* [`b70af925`](https://github.com/NixOS/nixpkgs/commit/b70af925f2d5cda466c203a79dc487ec3a2b4ddc) sbcl: 2.6.5 -> 2.6.6
* [`d15b45bb`](https://github.com/NixOS/nixpkgs/commit/d15b45bb338629e08d6830d37650ba33febed81f) sbcl: add iolib and stumpwm to passthru.tests
* [`fbaf84e7`](https://github.com/NixOS/nixpkgs/commit/fbaf84e753694d02b23dba85c162badcd372f00f) onednn: 3.11.2 -> 3.12.2
* [`cd1ed7d8`](https://github.com/NixOS/nixpkgs/commit/cd1ed7d80e813dc87e925e854b4937516fa22748) hongdown: 0.3.4 -> 0.5.1
* [`d83657c9`](https://github.com/NixOS/nixpkgs/commit/d83657c9d0398cc240d1bf6aa187ff60116e5947) storebackup: rename from storeBackup, enable structuredAttrs
* [`a2904ce4`](https://github.com/NixOS/nixpkgs/commit/a2904ce42c3c5b6581a0dadffbcfcd27078ddcb5) python3Packages.numpy: 2.5.0 -> 2.5.1
* [`bd08be1b`](https://github.com/NixOS/nixpkgs/commit/bd08be1bd2eebea287857355095d8f1271f8ceb0) bash-completion: 2.17.0 -> 2.18.0
* [`e32b3af8`](https://github.com/NixOS/nixpkgs/commit/e32b3af849f4e3d4e8b691368a7246f6bd636a73) nixos/nginx: setup logrotate to send kill USR1 signal only once
* [`83f8878a`](https://github.com/NixOS/nixpkgs/commit/83f8878ab89c3a791f0a29964f8fc7c6238823d5) warp-plus: drop
* [`55e100be`](https://github.com/NixOS/nixpkgs/commit/55e100bea88c9140dc04292118c3d9c7e730f6e5) openresolv: 3.17.0 -> 3.17.4
* [`ac514adc`](https://github.com/NixOS/nixpkgs/commit/ac514adcff0789275bbac2db355599bdb6009d05) jtdx: add meta.{license,platforms}
* [`154f4693`](https://github.com/NixOS/nixpkgs/commit/154f4693b95591112f77ae07ef511f09dbba8bc8) ffmpeg: don't clobber clang build with unwrapped compiler
* [`f8219af8`](https://github.com/NixOS/nixpkgs/commit/f8219af8483808b16116442a0b9338287c68a369) lerc: 4.1.0 -> 4.1.1
* [`b276999b`](https://github.com/NixOS/nixpkgs/commit/b276999b1f4362dfc2cb895ef7b1a41a6c7b100f) maintainers: add jonascarpay
* [`f40e1287`](https://github.com/NixOS/nixpkgs/commit/f40e1287c318f93583da11df68fcaade54f4a7c0) freqle: init at 0.1.0
* [`39e9d62c`](https://github.com/NixOS/nixpkgs/commit/39e9d62cea529108e8a55e9c513b1537b3f0cf0d) OVMF-amdsev: init at 202605
* [`aaf848db`](https://github.com/NixOS/nixpkgs/commit/aaf848db834a721e9790aa9900da709d8753105e) OVMF-inteltdx: init at 202605
* [`b66a81ae`](https://github.com/NixOS/nixpkgs/commit/b66a81ae48a9ffcd8be3942050d8cd68588f994d) scipopt-soplex: 8.0.2 -> 8.0.3
* [`2619c3a5`](https://github.com/NixOS/nixpkgs/commit/2619c3a59a4046c2291da7d5054ec3cb34e046f1) nixos/lix: init buildMachines
* [`0c409ea6`](https://github.com/NixOS/nixpkgs/commit/0c409ea61899f8fde15d13417a422285670d619c) python3Packages.fastapi: use finalAttrs pattern
* [`40d7bc5a`](https://github.com/NixOS/nixpkgs/commit/40d7bc5a60a5fd585a5818977c9f25ac0dbcef98) python3Packages.fastapi: 0.136.3 -> 0.139.0
* [`22ab7ac1`](https://github.com/NixOS/nixpkgs/commit/22ab7ac180af00130df05c8fc03e65df72d42f4c) python3Packages.fastapi: set strictDeps & __structuredAttrs
* [`c9bccd97`](https://github.com/NixOS/nixpkgs/commit/c9bccd97ca86a84cb4cce385a85e0141fa2dff9f) glog: Enable generation of pkg-config .pc file so dependents can find it
* [`067f836b`](https://github.com/NixOS/nixpkgs/commit/067f836b5d5db56533a4f309cfa4ca04e152e5bf) redis: move tests to passthru
* [`eba8e3dd`](https://github.com/NixOS/nixpkgs/commit/eba8e3dd5164ba9c75e07d7cacfa7a9cd0d41f10) valkey: move tests to passthru
* [`47f7109d`](https://github.com/NixOS/nixpkgs/commit/47f7109d73cf814264f925736523ae2b5bde52e7) tree-sitter-grammars: enable __structuredAttrs
* [`fd86301e`](https://github.com/NixOS/nixpkgs/commit/fd86301e0431977e327bb5beb44bb5c7668e4397) valkey: disable flaky dual-channel-replication test
* [`26317899`](https://github.com/NixOS/nixpkgs/commit/26317899f1d6165752798f9b71601f7d7ddb618d) python3Packages.hypothesis: 6.151.10 -> 6.156.1
* [`1eb59292`](https://github.com/NixOS/nixpkgs/commit/1eb592928127cabe94171c763f624f3c1443f090) c-ares: 1.34.6 -> 1.34.7
* [`b7511a62`](https://github.com/NixOS/nixpkgs/commit/b7511a628d08daeec0143a3c23cbbd58bdf96198) python3Packages.filelock: 3.29.0 -> 3.29.5
* [`f3269a5a`](https://github.com/NixOS/nixpkgs/commit/f3269a5a833483c5e154abf222b22dbd7a4c6f87) mailspring: fix linux desktop file, package using darwin .app
* [`0dd411dc`](https://github.com/NixOS/nixpkgs/commit/0dd411dc05ecf646881a25493dad8c9d042f8abd) rkmon: init at 0.3.1
* [`3172f85a`](https://github.com/NixOS/nixpkgs/commit/3172f85a7e6df8e3bb738fc60d5c0de656c34d46) OVMF: ship qemu firmware descriptors
* [`553e5b52`](https://github.com/NixOS/nixpkgs/commit/553e5b526ccebad5d6f670b0d23126f1d841e368) oxigraph: 0.5.7 -> 0.5.9
* [`0dafa129`](https://github.com/NixOS/nixpkgs/commit/0dafa129ecbafde9d10ca0a712e5653444ac7af9) nodejs: enable use-prefix-to-find-headers
* [`4fca7cee`](https://github.com/NixOS/nixpkgs/commit/4fca7cee9b157b70e993ce91f8d43c4124436db4) bundlerApp: set __StructuredAttrs = true for result package
* [`eb8d97ca`](https://github.com/NixOS/nixpkgs/commit/eb8d97ca2d234b6259911bb70175c3f73ea1f2e6) libapparmor: 5.0.0 -> 5.0.1
* [`97b993b6`](https://github.com/NixOS/nixpkgs/commit/97b993b6dec7c4e91fceabbcecff9b3cd84160a7) go_1_26: 1.26.4 -> 1.26.5
* [`1e7d4675`](https://github.com/NixOS/nixpkgs/commit/1e7d467566f5640431265feea3c22546009ce26e) libxfont_2: 2.0.7 -> 2.0.8
* [`5285fba2`](https://github.com/NixOS/nixpkgs/commit/5285fba2417d291d6b9c052acaf51057d3f62e2a) c-ares: 1.34.7 -> 1.34.8
* [`d655e286`](https://github.com/NixOS/nixpkgs/commit/d655e286eb6a4b4a28d7065b6d7bfbdd46e6fe50) anytype: fix build that may not be deterministic
* [`db597c3c`](https://github.com/NixOS/nixpkgs/commit/db597c3cdb5ccd8f4ac30167c87d29dc533e4c8e) camunda-modeler: 5.48.0 -> 5.49.0
* [`2822a3ac`](https://github.com/NixOS/nixpkgs/commit/2822a3accefae3a31d852b14a6633ff490d7565b) nixos/mango: rename from mangowc
* [`f83e77f4`](https://github.com/NixOS/nixpkgs/commit/f83e77f48fb8a253e928a957413a4bde21d0c1a7) openboardview: use finalAttrs
* [`16ab2db8`](https://github.com/NixOS/nixpkgs/commit/16ab2db83bb798e401ff54712605f2bacf0ac11e) openboardview: Add link to the changelog
* [`01397f03`](https://github.com/NixOS/nixpkgs/commit/01397f0372c643f056695da63b3b8d79ac3017fd) openboardview: 9.95.2 -> 10.0.0
* [`ddab5852`](https://github.com/NixOS/nixpkgs/commit/ddab585265ba2f87f813bba9e51e382c4f8ee344) libffiReal: 3.6.0 -> 3.7.0
* [`006c7936`](https://github.com/NixOS/nixpkgs/commit/006c7936a2e92017d4d7812baeeb9f0dea1fc8f8) python3Packages.pythonMetadataCheckHook: init
* [`4752f979`](https://github.com/NixOS/nixpkgs/commit/4752f9796258eb1518231cf5d0bd31d999b075d7) python3Packages.pytest-cov-stub: align project name with pname
* [`b72cbb85`](https://github.com/NixOS/nixpkgs/commit/b72cbb85d8e6db4a033a25fe3a082d3b543c4c81) python3Packages.ancpbids: rename from ancp-bids
* [`6ac3a341`](https://github.com/NixOS/nixpkgs/commit/6ac3a34121e7da64375c9749e188b4d50653f5c9) python3Packages.aiotarfile: fix version in Cargo.toml
* [`0ab37222`](https://github.com/NixOS/nixpkgs/commit/0ab3722264ad3efa8632dbac103a2b97a64d6b99) python3Packages.approvaltests: fix version in version.py
* [`b21d0c87`](https://github.com/NixOS/nixpkgs/commit/b21d0c873967fce2506f7379b3a3a34cd637e183) python3Packages.aspell-python-py3: rename from aspell-python
* [`d43850d6`](https://github.com/NixOS/nixpkgs/commit/d43850d6edeb2dcdb5a33c0e5d303690585925d3) python3Packages.aurorapy: fix version in setup.py
* [`20382e39`](https://github.com/NixOS/nixpkgs/commit/20382e39add419d95c24492106f299c97825be8f) python3Packages.python-augeas: rename from augeas
* [`70feff95`](https://github.com/NixOS/nixpkgs/commit/70feff954018c337a1efd00d0dd6f1c45b3d8265) python3Packages.awsiotpythonsdk: fix version in AWSIoTPythonSDK/__init__.py
* [`ca7c1b88`](https://github.com/NixOS/nixpkgs/commit/ca7c1b884ad9fddd057d47d1402de62d22e5be76) python3Packages.mako: don't add a .dev0 suffix to version
* [`a4c7bb7c`](https://github.com/NixOS/nixpkgs/commit/a4c7bb7c2d7a22a8e02d80cf28ae94330d4225ba) python3Packages.pytest-lazy-fixtures: fix version in pyproject.toml
* [`c9cf1135`](https://github.com/NixOS/nixpkgs/commit/c9cf1135181739a3d5bd10e9849d95f470fe5842) python3Packages.caio: fix version in caio/version.py
* [`6c3967b6`](https://github.com/NixOS/nixpkgs/commit/6c3967b67006ae2e632359aa4241944a5003be0b) python3Packages.python-memcached: fix version in memcache.py
* [`46bac7fd`](https://github.com/NixOS/nixpkgs/commit/46bac7fdab8ce685d0f5a2e23e89ae686bcf35b5) python3Packages.iso4217: don't append date to version
* [`01308886`](https://github.com/NixOS/nixpkgs/commit/013088869220aab51bcd71e88e0319d5ecd36437) python3Packages.cramjam: fix version in pyproject.toml
* [`596866e0`](https://github.com/NixOS/nixpkgs/commit/596866e0a8e1e9b5c72c4e7712bae165e8f4b227) python3Packages.nest-asyncio: fix version in setup.cfg
* [`eb8b88ae`](https://github.com/NixOS/nixpkgs/commit/eb8b88ae6b8e7f251ae05e49717b616d9ab46e15) python3Packages.nbmake: fix version in pyproject.toml
* [`9e255a89`](https://github.com/NixOS/nixpkgs/commit/9e255a89ddac3b9459b66b21917c2444d865c6ca) python3Packages.rf-protocols: fix version in pyproject.toml
* [`4087f5d7`](https://github.com/NixOS/nixpkgs/commit/4087f5d72de69ea0f1509553c0870049e5039cff) python3Packages.sure: fix version in setup.py
* [`52573cc0`](https://github.com/NixOS/nixpkgs/commit/52573cc0e719302a84d24676770f9e89f783a318) python3Packages.libvalkey: align pname with attribute name
* [`2bb7a686`](https://github.com/NixOS/nixpkgs/commit/2bb7a68648d997a82f7be3f598fa9d42f1247cc4) python3Packages.apischema: fix version in pyproject.toml
* [`1995f3e0`](https://github.com/NixOS/nixpkgs/commit/1995f3e0bbdc172a15ef7be807c849dbe012f805) python3Packages.pproxy: use setuptools-scm to get correct version
* [`bb997bc7`](https://github.com/NixOS/nixpkgs/commit/bb997bc7d765012361fc0be17943ce39323f5a73) python3Packages.psycopg-pool: don't check metadata
* [`b5e21ce9`](https://github.com/NixOS/nixpkgs/commit/b5e21ce95d236be0c327ba31ef3c642128a08177) python3Packages.pyvis: patch version in pyvis/_version.py
* [`d7951b35`](https://github.com/NixOS/nixpkgs/commit/d7951b35db5169e1e830ee6f03230555ff219d70) python3Packages.clang: enable tests
* [`757cb598`](https://github.com/NixOS/nixpkgs/commit/757cb598d7a376b977bc2f1a70e3e3d278c45a8e) python3Packages.dacite: fix version in setup.py
* [`51adff44`](https://github.com/NixOS/nixpkgs/commit/51adff44f676b5b6a38fc57bacd69877def2e271) buildbotPackages.buildbot-pkg: fix version in setup.py
* [`38911fbe`](https://github.com/NixOS/nixpkgs/commit/38911fbe61b33cb8fb57a36355550cc10251a6a8) python3Packages.diskcache-stubs: fix version in pyproject.toml
* [`a1c6e435`](https://github.com/NixOS/nixpkgs/commit/a1c6e43548cf9fa17723754149e12e7d30b5a9fb) python3Packages.asyncclick: remove version suffix
* [`3f0f7cef`](https://github.com/NixOS/nixpkgs/commit/3f0f7cef473657aba5864542761c2516db024a8d) python3Packages.tag-expressions: fix version in setup.py
* [`8121751f`](https://github.com/NixOS/nixpkgs/commit/8121751fd4d7ffdbb8e24503986106769637744e) python3Packages.compressed-rtf: fetch tag
* [`9f1baceb`](https://github.com/NixOS/nixpkgs/commit/9f1baceb91642eacf72a05beed2d9c1f1ba869c7) python3Packages.gpiod: don't check metadata
* [`ac36e0ac`](https://github.com/NixOS/nixpkgs/commit/ac36e0ac0352f3a688e88b11e7c554da9fa64bc6) python3Packages.ttp-templates: fix version in pyproject.toml
* [`0fdd6cab`](https://github.com/NixOS/nixpkgs/commit/0fdd6cabaa1acf4af5087003c5aabab31bf9d94e) buildbotPackages.buildbot-worker: don't check metadata
* [`ab4ae03b`](https://github.com/NixOS/nixpkgs/commit/ab4ae03bc7d1be53123e58e85ca2c61d732bd0a4) python3Packages.pyexcel-io: fix version in setup.py
* [`20f34825`](https://github.com/NixOS/nixpkgs/commit/20f348252a33b338ad28c722b56f6d86e51f4793) python3Packages.syrupy: fix version in pyproject.toml
* [`2a50b443`](https://github.com/NixOS/nixpkgs/commit/2a50b443b50e6403336a59a204e429e1c2f7fdbe) python3Packages.flatten-dict: fix version in pyproject.toml
* [`f121b630`](https://github.com/NixOS/nixpkgs/commit/f121b630ae8ccdaf3a273349425ef8a3ee381919) python3Packages.obsws-python: fix version
* [`701ebd45`](https://github.com/NixOS/nixpkgs/commit/701ebd45f1f8f2eeefae45d4aa064b6e219b7848) python3Packages.victron-mqtt: fix version in pyproject.toml
* [`fd360c44`](https://github.com/NixOS/nixpkgs/commit/fd360c4429648db133f7c0a13c6182d1a6aaebce) python3Packages.cgal: fix version in setup.py
* [`f4b20637`](https://github.com/NixOS/nixpkgs/commit/f4b20637d7a4586dae431a2014ce88c9cd770db3) python3Packages.kgb: don't add a .dev0 suffix to version
* [`528e62ce`](https://github.com/NixOS/nixpkgs/commit/528e62cee44c9dff7db510b66a072cdefe5345be) python3Packages.aiomusiccast: fix version in aiomusiccast/__init__.py
* [`72dcf41a`](https://github.com/NixOS/nixpkgs/commit/72dcf41a6f5b56f15a08bf033ae9766e247cf0f0) python3Packages.aiofile: unpin caio
* [`978b351b`](https://github.com/NixOS/nixpkgs/commit/978b351bf7d105956ece4083340dfea424d5f995) python3Packages.aiotractive: fix version in pyproject.toml
* [`889ea4c0`](https://github.com/NixOS/nixpkgs/commit/889ea4c0319be40c017a48027b201cccb4319501) python3Packages.word2number: fix version in setup.py
* [`c2e63d6b`](https://github.com/NixOS/nixpkgs/commit/c2e63d6bcb4ab26f81556a3cd98738b729dbe027) python3Packages.flask-login: fix version
* [`b973eed9`](https://github.com/NixOS/nixpkgs/commit/b973eed9ea1a3680d38353c7cf5b767e81a2c17c) python3Packages.multiaddr: rename from py-multiaddr
* [`9650af3a`](https://github.com/NixOS/nixpkgs/commit/9650af3a296de326de9f4cbf850c58aea9a930b9) python3Packages.stups-tokens: fix version in tokens/__init__.py
* [`fb290d5d`](https://github.com/NixOS/nixpkgs/commit/fb290d5d24ff35af71102ad0bd878d908c2977b5) python3Packages.pyspx: fix version in setup.py
* [`5f0ee842`](https://github.com/NixOS/nixpkgs/commit/5f0ee842597f22dcf06e1e4643457295de0b740e) python3Packages.yamlloader: fix version in pyproject.toml
* [`a16de1dc`](https://github.com/NixOS/nixpkgs/commit/a16de1dccf36e33726bba9238a84cd817cf21f29) python3Packages.chroma-hnswlib: fix version in setup.py
* [`a55f8f39`](https://github.com/NixOS/nixpkgs/commit/a55f8f39bf1744187cf77fdfe26231e165a1b990) python3Packages.cx-logging: fix version in VERSION
* [`f0c9c596`](https://github.com/NixOS/nixpkgs/commit/f0c9c59635b042337af205cfe1ac0911768fe4e3) python3Packages.minimock: fix version in minimock.py
* [`3a4ada4f`](https://github.com/NixOS/nixpkgs/commit/3a4ada4f4d2d73ded0e372aaf0ec557b934dddef) python3Packages.openant: fix pname
* [`2538c000`](https://github.com/NixOS/nixpkgs/commit/2538c000a624873209a93bec4e3c14ab71c92b3e) python3Packages.python3-nmap: fix version in setup.py
* [`94d27db0`](https://github.com/NixOS/nixpkgs/commit/94d27db0150acace1735f4a934039a5ffe1ec7de) python3Packages.tlsh: fix version in py_ext/setup.py
* [`66086b79`](https://github.com/NixOS/nixpkgs/commit/66086b79bac26db5a0ca59bb61eaf98f7650242d) python3Packages.riden: fix version in pyproject.toml
* [`4bc8a3b4`](https://github.com/NixOS/nixpkgs/commit/4bc8a3b4ac24a598f2bdf8dba3481c7a976aa718) python3Packages.pysmi: fix version in pyproject.toml
* [`12efcad2`](https://github.com/NixOS/nixpkgs/commit/12efcad2434397f97efdf7cde247d9c9ad371432) python3Packages.pylbfgs: rename from dedupe-pylbfgs
* [`fe925637`](https://github.com/NixOS/nixpkgs/commit/fe92563706cf70c45001ad2dc642434ad56d1a39) python3Packages.goodwe: fix version in VERSION
* [`cc89337b`](https://github.com/NixOS/nixpkgs/commit/cc89337b564ea76a5048d162d1901acc6adce00d) python3Packages.pycasbin: fix version in pyproject.toml
* [`0763df01`](https://github.com/NixOS/nixpkgs/commit/0763df0110d4bd8fece56b1757ec72874b756ead) python3Packages.pyequihash: don't check metadata
* [`388a7324`](https://github.com/NixOS/nixpkgs/commit/388a73241ce513a0f5ae3a81164d65f1e33d7c39) python3Packages.sphinxfeed-lsaffre: fix version in sphinxfeed.py
* [`4ec747bd`](https://github.com/NixOS/nixpkgs/commit/4ec747bd48f934be0f5af60c1482fc50570145cc) python3Packages.pymilter: fix version in setup.py
* [`00278dcc`](https://github.com/NixOS/nixpkgs/commit/00278dcc759fb538e300755606de47305fed3218) python3Packages.iterative-telemetry: fix pname
* [`d8f24a5d`](https://github.com/NixOS/nixpkgs/commit/d8f24a5dd02ab1a565aefeace68cd5d2d03a7ec8) python3Packages.accuweather: fix version in pyproject.toml
* [`34f55ec3`](https://github.com/NixOS/nixpkgs/commit/34f55ec38cf54f883df37865c86c043ff6fbf3c4) python3Packages.aioazuredevops: remove .dev0 suffix from version
* [`40abd3e2`](https://github.com/NixOS/nixpkgs/commit/40abd3e2cbd43c6a289177c8a3ddd11460b52e1b) python3Packages.aioecowitt: fix version in pyproject.toml
* [`f6229cee`](https://github.com/NixOS/nixpkgs/commit/f6229cee1bbf2791deca48d66de163cdc16a2fb4) pythonPackages.aioshelly: fix version in pyproject.toml
* [`db5d42a1`](https://github.com/NixOS/nixpkgs/commit/db5d42a1fb4584587772930acad7ae6d9d276b96) python3Packages.ttp: fix wrong version metadata in pyproject.toml
* [`6d8fcd0e`](https://github.com/NixOS/nixpkgs/commit/6d8fcd0ed4abf65053bb6fc06c50f1ba2850c13d) python3Packages.inkex: don't check metadata
* [`152201b5`](https://github.com/NixOS/nixpkgs/commit/152201b5f8e3b1aeec5a371fbd9b11d31562455c) python3Packages.openai-whisper: fix pname
* [`16294a25`](https://github.com/NixOS/nixpkgs/commit/16294a2525f58cd9116a8a0e1d06419678b89b27) python3Packages.simpleitk: remove +ggit.n suffix from metadata version
* [`a3d32276`](https://github.com/NixOS/nixpkgs/commit/a3d32276688924001dfcfc18cfbabe619deb98ad) python3Packages.git-versioner: fix version in pyproject.toml
* [`434bdf3e`](https://github.com/NixOS/nixpkgs/commit/434bdf3e314e0f8b6024a050f609803ccb2bd58e) python3Packages.gattlib: fix version
* [`e6bf6e9f`](https://github.com/NixOS/nixpkgs/commit/e6bf6e9fdcf5b9c7a833d05b3f8857142924fe50) python3Packages.osadl-matrix: fix version in VERSION
* [`b29ec619`](https://github.com/NixOS/nixpkgs/commit/b29ec61921f769e6aaf8a2ee0e24f915dd2327b5) python3Packages.pyhanko.testData: fix version in pyproject.toml
* [`a372dc5e`](https://github.com/NixOS/nixpkgs/commit/a372dc5edb1c02096a3e07caf4e01661529d7b46) python3Packages.vncdotool: rename from vncdo
* [`61ac5736`](https://github.com/NixOS/nixpkgs/commit/61ac5736f427642244c265c76857eb450a4db982) python3Packages.vncdotool: use __structuredAttrs
* [`a8ea58d3`](https://github.com/NixOS/nixpkgs/commit/a8ea58d3664c38cb3e1400e268c84190d52025a8) python3Packages.bencode-py: fix pname
* [`5f2bcd2a`](https://github.com/NixOS/nixpkgs/commit/5f2bcd2a01e3d0580eba02bacbdb4eedd8863219) python3Packages.sqlite-vec: fix version in pyproject.toml
* [`1f07ef19`](https://github.com/NixOS/nixpkgs/commit/1f07ef191f4d0dae5c655e71c5c7e1abe6c68e70) python3Packages.gradio.sans-reverse-dependencies: don't check metadata
* [`8ca5e474`](https://github.com/NixOS/nixpkgs/commit/8ca5e47471b3bf9d1b3973874dd22fa09dda6c4f) python3Packages.dlms-cosem: fix version in setup.py
* [`691f9d4a`](https://github.com/NixOS/nixpkgs/commit/691f9d4a8a24afd771501e580c76eb0548b5fca4) python3Packages.python-apt: fix pname
* [`00766a5d`](https://github.com/NixOS/nixpkgs/commit/00766a5d4fbf94fcc18aae768d72a2ba386e56c0) python3Packages.laszip: fix pname
* [`e1b40f53`](https://github.com/NixOS/nixpkgs/commit/e1b40f53816ac5713addbb7f4e1dd1a07414a801) python3Packages.ourgroceries: fix version in setup.py
* [`be1222f4`](https://github.com/NixOS/nixpkgs/commit/be1222f4f69f3a1f4b4d378dac89215975ab6c6d) python3Packages.pyportainer: fix version in pyproject.toml
* [`694bc89e`](https://github.com/NixOS/nixpkgs/commit/694bc89ebc86b2e3a170ec1e9a8494a4b7bda87a) python3Packages.meteo-lt-pkg: fix version in pyproject.toml
* [`7991a730`](https://github.com/NixOS/nixpkgs/commit/7991a730996469fe3960d705dc111ce3c4bd71b6) python3Packages.london-tube-status: fix version in setup.py
* [`5c2746b3`](https://github.com/NixOS/nixpkgs/commit/5c2746b34c0b26a00ce26ae75c53f8e72e65c12a) python3Packages.knocki: fix version in pyproject.toml
* [`5acdac64`](https://github.com/NixOS/nixpkgs/commit/5acdac6455601cd53b551f4f539df252155ba3c0) python3Packages.nyt-games: fix version in pyproject.toml
* [`efa4c69a`](https://github.com/NixOS/nixpkgs/commit/efa4c69a952f8591eec174648fce9854b067a953) python3Packages.ha-philipsjs: don't check metadata
* [`64c320b8`](https://github.com/NixOS/nixpkgs/commit/64c320b8d26f872dad526815c45c2a7a79b151b7) python3Packages.imgw-pib: fix version in pyproject.toml
* [`d4856b14`](https://github.com/NixOS/nixpkgs/commit/d4856b14c29cf3e0891b0c6b3f51f02275811be9) python3Packages.python-homeassistant-analytics: fix version in pyproject.toml
* [`84b47fef`](https://github.com/NixOS/nixpkgs/commit/84b47fef2f55b0fa70af3ada58f885fc8427c660) python3Packages.aiomealie: fix version in pyproject.toml
* [`b99e5687`](https://github.com/NixOS/nixpkgs/commit/b99e56874cbc02553db31d5e95818d8696189fc0) python3Packages.ovoenergy: remove .dev0 suffix from version
* [`71596123`](https://github.com/NixOS/nixpkgs/commit/715961232de96e6f1ebe69a789909d84cba6cfdf) python3Packages.youless-api: fix version in setup.py
* [`ba7c0447`](https://github.com/NixOS/nixpkgs/commit/ba7c0447e4880fe0629ff6ac96048eeed13e37c3) python3Packages.pyanglianwater: fix version in pyanglianwater/_version.py
* [`5c418480`](https://github.com/NixOS/nixpkgs/commit/5c418480fbb489a1b4a889a009eda76281b88810) python3Packages.pysmartthings: fix version in pyproject.toml
* [`7c0a098a`](https://github.com/NixOS/nixpkgs/commit/7c0a098ada389af2044298445fc305da740d8572) python3Packages.aiowaqi: fix version in pyproject.toml
* [`46488a93`](https://github.com/NixOS/nixpkgs/commit/46488a93442ef3c921a8b24e812c779ac6ba18b5) python3Packages.eq3btsmart: fix version in pyproject.toml
* [`34af3065`](https://github.com/NixOS/nixpkgs/commit/34af3065e5f1beea8c1f127daf4ebf7a8faefd8e) python3Packages.powerfox: fix version in pyproject.toml
* [`d4b703e7`](https://github.com/NixOS/nixpkgs/commit/d4b703e78434371c9ebf3718f8d79b296e26db1e) python3Packages.nextcloudmonitor: fix version in setup.py
* [`2736b2e9`](https://github.com/NixOS/nixpkgs/commit/2736b2e92296585c64ff53675e73cf89f546c848) python3Packages.qnapstats: fix version in setup.py
* [`4f5c0a44`](https://github.com/NixOS/nixpkgs/commit/4f5c0a4447c73489d50a2edb438fc517ff477ee0) python3Packages.youtubeaio: fix version in pyproject.toml
* [`6f4a56db`](https://github.com/NixOS/nixpkgs/commit/6f4a56db8ee5de1c4359e662a6acf5c9aa53f6ca) python3Packages.awesomeversion: use pyprojectVersionPatchHook
* [`75395c05`](https://github.com/NixOS/nixpkgs/commit/75395c0592e6384aea676afd9ecf247da526bfd1) python3Packages.tuya-device-handlers: fix version in pyproject.toml
* [`e5a478dc`](https://github.com/NixOS/nixpkgs/commit/e5a478dc03466f65efca92f832fe2aeb2bd88334) python3Packages.aiowithings: fix version in pyproject.toml
* [`6552955c`](https://github.com/NixOS/nixpkgs/commit/6552955c764533b13a6716c8f21c98a5cc787fc8) python3Packages.nsw-fuel-api-client: fix version in nsw_fuel/__init__.py
* [`3ba12cd3`](https://github.com/NixOS/nixpkgs/commit/3ba12cd3e48bb0427c518485f33253b45b1f18e2) python3Packages.here-transit: fix version in pyproject.toml
* [`2248791f`](https://github.com/NixOS/nixpkgs/commit/2248791fc5ee80643dc84ac02ac1c624ef39667a) python3Packages.here-routing: fix version in pyproject.toml
* [`842f0627`](https://github.com/NixOS/nixpkgs/commit/842f0627437dddaee9ac4cc454dcc010fd7a117b) python3Packages.aioskybell: use finalAttrs
* [`cb157f07`](https://github.com/NixOS/nixpkgs/commit/cb157f07f972b91a6de8797589cb3f2f1b210abe) python3Packages.python-opensky: use pyprojectVersionPatchHook
* [`09ffbef1`](https://github.com/NixOS/nixpkgs/commit/09ffbef1deea4c0d626755cef6e081ef9b57f580) python3Packages.python-melcloud: fix version in pyproject.toml
* [`5c560639`](https://github.com/NixOS/nixpkgs/commit/5c560639cc580bfde65a246d2e9518d75adaca57) python3Packages.greeneye-monitor: use poetry-core
* [`576e53b2`](https://github.com/NixOS/nixpkgs/commit/576e53b26317188bd5b7306147819f5646a46a8c) python3Packages.aiowebdav2: fix version in pyproject.toml
* [`38af1bb8`](https://github.com/NixOS/nixpkgs/commit/38af1bb8e43fd3231d0da1dc3f06bcef26a28af3) python3Packages.python-technove: fix version in pyproject.toml
* [`6dd6e9ec`](https://github.com/NixOS/nixpkgs/commit/6dd6e9ec1a08e16f06aa2cc31447448cdbf653d9) python3Packages.trmnl: fix version in pyproject.toml
* [`f43e09c1`](https://github.com/NixOS/nixpkgs/commit/f43e09c13b6c8cb41b7dafa090a1de9fd3e333aa) python3Packages.aiobafi6: fix version in pyproject.toml
* [`dc9b2d36`](https://github.com/NixOS/nixpkgs/commit/dc9b2d36d5e53ca6729bde2c1fb47ef32e1a6b1e) python3Packages.pycfdns: use pyprojectVersionPatchHook
* [`4cf7f131`](https://github.com/NixOS/nixpkgs/commit/4cf7f131b7c2c3c3fd9ca40a8dad625ca4a8393e) python3Packages.letpot: fix version in pyproject.toml
* [`1297b0e3`](https://github.com/NixOS/nixpkgs/commit/1297b0e3ea06217cfeac1b1e3eb2d2338b4939c4) python3Packages.bluecurrent-api: fix version in pyproject.toml
* [`dc3e1832`](https://github.com/NixOS/nixpkgs/commit/dc3e183262bab5f95acfa49f93c388830a4102ee) python3Packages.aiolyric: remove .dev0 suffix from version
* [`4d1475e1`](https://github.com/NixOS/nixpkgs/commit/4d1475e1ceb9ae96e08b5bf3e809171fe93eb5ab) python3Packages.fressnapftracker: fix version in pyproject.toml
* [`10f52e1f`](https://github.com/NixOS/nixpkgs/commit/10f52e1ff08f2e41760e58651acb9b748ff4c6ab) python3Packages.forecast-solar: fix version in pyproject.toml
* [`38f72584`](https://github.com/NixOS/nixpkgs/commit/38f72584a703617fe77db207fc4beae1e8032723) python3Packages.brother: fix version in pyproject.toml
* [`dbe230e5`](https://github.com/NixOS/nixpkgs/commit/dbe230e5f789d805e0f1d52da2e41c01ddcf6e3a) python3Packages.volvocarsapi: fix version in pyproject.toml
* [`b076d257`](https://github.com/NixOS/nixpkgs/commit/b076d257c0460319dba1bd5a2039cf0d451e5e0e) python3Packages.systembridgeconnector: remove .dev0 suffix from version
* [`672778a2`](https://github.com/NixOS/nixpkgs/commit/672778a2730391c94406525ed841e26cdb47aca6) python3Packages.tessie-api: fix version in pyproject.toml
* [`b0b09e5b`](https://github.com/NixOS/nixpkgs/commit/b0b09e5b61d9d5a995db7e3186b5f818bd8aa059) libressl: 4.2 -> 4.3
* [`0eb9fc4c`](https://github.com/NixOS/nixpkgs/commit/0eb9fc4c11da43dd8a511d143d5e2a012800a1b3) rust: 1.96.1 -> 1.97.0
* [`64f1104d`](https://github.com/NixOS/nixpkgs/commit/64f1104dea3cfbcd78d9485af61fb7412d7403e1) nixos/unbound: resolveLocalQueries with resolved
* [`5739891e`](https://github.com/NixOS/nixpkgs/commit/5739891e2ae3e66e66b8ae935ea46d815909a95e) python3Packages.drf-spectacular-sidecar: 2026.1.1 -> 2026.7.1
* [`6e22635a`](https://github.com/NixOS/nixpkgs/commit/6e22635a6fa67f95cf56424535448f8a74ebc096) pipewire: 1.6.7 -> 1.6.8
* [`ad865d00`](https://github.com/NixOS/nixpkgs/commit/ad865d0009fe55914cba111f3ae8a93e3c8c23e8) python3Packages.pywaze: fix version in pyproject.toml
* [`fdf6502e`](https://github.com/NixOS/nixpkgs/commit/fdf6502eb38268f8476e80362b75666f31d536bb) python3Packages.pynordpool: fix version in pyproject.toml
* [`2b69b6b9`](https://github.com/NixOS/nixpkgs/commit/2b69b6b9287a0bc49b204da94d6a6ffe4c043bc0) python3Packages.gios: fix version in pyproject.toml
* [`b71eecfb`](https://github.com/NixOS/nixpkgs/commit/b71eecfbbe1d6950a47d62d5dda82529730921fc) python3Packages.zinvolt: fix version in pyproject.toml
* [`49abeb2e`](https://github.com/NixOS/nixpkgs/commit/49abeb2ebc31bb01257834842a3088e3f5c1f043) python3Packages.python-overseerr: fix version in pyproject.toml
* [`c1f7c0ec`](https://github.com/NixOS/nixpkgs/commit/c1f7c0ec1d251062baaf2d77b18d6583bfdca9aa) python3Packages.goslide-api: fix version in stup.py
* [`5bffa343`](https://github.com/NixOS/nixpkgs/commit/5bffa343a125df8afa6f8ae98f98ab6d99937bc8) python3Packages.starlette: 1.1.0 -> 1.3.1
* [`6b7ce512`](https://github.com/NixOS/nixpkgs/commit/6b7ce5124480002df7e1670978d2f7b5c367ce9b) bundlerApp: set strictDeps = true
* [`8fe06cd8`](https://github.com/NixOS/nixpkgs/commit/8fe06cd8ba8e80505328c702ebe6a1ad9e4585fe) Reapply "hdrhistogram_c: 0.11.9 -> 0.11.10"
* [`bdd297d0`](https://github.com/NixOS/nixpkgs/commit/bdd297d0ff90c2218927d14cbc33ff765ca7e8d6) python3Packages.hypothesis: fix build
* [`5d0c21d2`](https://github.com/NixOS/nixpkgs/commit/5d0c21d22241b8d60a2ffec03f1274df19d6210d) cmake: fix parenthesis in patch
* [`8a597f5a`](https://github.com/NixOS/nixpkgs/commit/8a597f5ae61cb69aa166f77e585b96c1277723bb) checkPhaseThreadLimitHook: rename from openmpCheckPhaseHook, set more thread env vars
* [`1d057965`](https://github.com/NixOS/nixpkgs/commit/1d0579657427fb77f57e6f1d57bc5a63b2fd119d) treewide: openmpCheckPhaseHook -> checkPhaseThreadLimitHook
* [`b96ed4d6`](https://github.com/NixOS/nixpkgs/commit/b96ed4d6020e57af1bba316256ca71f0399ded01) treewide: add checkPhaseThreadLimitHook to more things used in parallel checks
* [`1488f541`](https://github.com/NixOS/nixpkgs/commit/1488f541dc3309d5e9b64470ce9890aa4a3fcbba) gawk: 5.4.0 -> 5.4.1
* [`95b1a219`](https://github.com/NixOS/nixpkgs/commit/95b1a21908ac832bcdd37b2a441da4a621e91c2b) jemalloc: skip extent test with profiling enabled
* [`5e53adb2`](https://github.com/NixOS/nixpkgs/commit/5e53adb250811a149e016dfc99edf1f196b62a17) isa-l: 2.32.0 -> 2.32.1
* [`c181c999`](https://github.com/NixOS/nixpkgs/commit/c181c999d910e0bc0b7d839f2d092adfd93a02b9) isa-l: run upstream test suite
* [`93b21781`](https://github.com/NixOS/nixpkgs/commit/93b21781633dee2329b025bc419e5ee932e86e55) nixos/testing: allow `meta.teams` in tests, fix maintainer pings for tests
* [`b62eea41`](https://github.com/NixOS/nixpkgs/commit/b62eea41c7571ed7b971ab8a4c458edfed0a5d03) python3Packages.dfdiskcache: relax pandas<3 upper bound
* [`78120fb2`](https://github.com/NixOS/nixpkgs/commit/78120fb26ad712d00c5556ce81bd0cea565933eb) handy: 0.9.0 -> 0.9.1
* [`9d5e5260`](https://github.com/NixOS/nixpkgs/commit/9d5e5260274646472a5738cd4cffc836b91ecfd1) cargo-psp: 0.2.8 -> 0.2.9
* [`e45f55ed`](https://github.com/NixOS/nixpkgs/commit/e45f55ed6741e7275c07674ecc4a1a20160511bd) gpgme: 2.1.0 -> 2.1.2
* [`cd840af2`](https://github.com/NixOS/nixpkgs/commit/cd840af23fd582042ad68111b417eb531d6eaffb) catch2_3: 3.15.0 -> 3.15.2
* [`e2b2429b`](https://github.com/NixOS/nixpkgs/commit/e2b2429b6ce3fa107e217ba21f81dbd3103e7388) python313Packages.backports-zstd: 1.5.0 -> 1.6.0
* [`46df23cb`](https://github.com/NixOS/nixpkgs/commit/46df23cb09b2bfb122fe78c9c5d8b15ce78a55a8) python3Packages.pikepdf: 10.8.0 -> 10.10.0
* [`ff9eb359`](https://github.com/NixOS/nixpkgs/commit/ff9eb359ed9f145af9ebde84a0d12760b942b499) python3Packages.pikepdf: use finalAttrs
* [`ac0fa268`](https://github.com/NixOS/nixpkgs/commit/ac0fa2681b5f32abbf27648e7a852ba62a7c6d2c) python3Packages.pydocket: 0.22.0 -> 0.23.0
* [`d4aeb8b3`](https://github.com/NixOS/nixpkgs/commit/d4aeb8b3d18705aeb71f80efb29a6c7b85dfc68b) vscode-extensions.illixion.vscode-vibrancy-continued: 1.1.84 -> 1.1.85
* [`fcd9d5b2`](https://github.com/NixOS/nixpkgs/commit/fcd9d5b20b8b027c258722b1d4805149583eeb2c) xrdb: 1.2.2 -> 1.2.3
* [`4b55fc92`](https://github.com/NixOS/nixpkgs/commit/4b55fc928b47b385c3c9a70e4fe7e9c173eeb416) lib.licenses: add ogluk30
* [`253475c4`](https://github.com/NixOS/nixpkgs/commit/253475c406c1b845bf89c8d6b8781a23d0e2dba9) python3Packages.flask-reverse-proxy-file: use lib.licenses.ogluk30
* [`f86c4d8b`](https://github.com/NixOS/nixpkgs/commit/f86c4d8b290e462d87d35a6ba3a0276e3b6fd549) python3Packages.cross-web: fix version in pyproject.toml
* [`a187cae4`](https://github.com/NixOS/nixpkgs/commit/a187cae4ae6036d4c321c35a6b6bd3121e9d8df2) python3Packages.python-fasthtml: rename from fasthtml
* [`ef2d4cd6`](https://github.com/NixOS/nixpkgs/commit/ef2d4cd63aa34ce80eef9e807b25428e169b0e84) python3Packages.speechbrain: fix version in pyproject.toml
* [`b0114972`](https://github.com/NixOS/nixpkgs/commit/b01149720fb7a0a4c78ec20ab1317e688fb5f585) file: relax landlock sandboxing for tar.bz2 compat
* [`c0cc2fda`](https://github.com/NixOS/nixpkgs/commit/c0cc2fda7040bc5d3e36121123efb2125a8c6c13) firefox: fix flaky dylib check due to SIGPIPE race
* [`7d44dc49`](https://github.com/NixOS/nixpkgs/commit/7d44dc49ab50decbbe70519b159818b095afd88c) git: 2.54.0 -> 2.55.0
* [`94ff2f02`](https://github.com/NixOS/nixpkgs/commit/94ff2f02a40db7469e78f1e07b509a1ed63433d3) systemd: Fix path to find_program('clang', ...) replacement
* [`2a0fe992`](https://github.com/NixOS/nixpkgs/commit/2a0fe99286c94917de66955dd83d6620098a50bc) systemd: substituteInPlace --replace-fail everywhere
* [`bb507abc`](https://github.com/NixOS/nixpkgs/commit/bb507abce1fc804bcf882b05f5f82393451c59a8) graphviz: build Quartz plugin on Darwin
* [`6cbdc117`](https://github.com/NixOS/nixpkgs/commit/6cbdc11793f4add233597c276c4ed9e3e0db1f21) vim: 9.2.0541 -> 9.2.0782
* [`60869099`](https://github.com/NixOS/nixpkgs/commit/608690995f214acda4d642fcb37259c26e0970f8) nixos/modular-services: add portable `process.environment`
* [`bb50b6eb`](https://github.com/NixOS/nixpkgs/commit/bb50b6eb9d1b860f45f873cf2e3af73f76adab05) chromium: remove broken `pulseSupport = false;` override
* [`f583642a`](https://github.com/NixOS/nixpkgs/commit/f583642a9a3d89a35ea8176fe333881dce41524d) dwz: 0.16 -> 0.17
* [`747f448a`](https://github.com/NixOS/nixpkgs/commit/747f448ad115b8d01a8525ec46bc9babc6ba6fe9) mdbook: 0.5.3 -> 0.5.4
* [`6304b10b`](https://github.com/NixOS/nixpkgs/commit/6304b10b4389694fc7acd46462d5d3f11978ee8a) python3Packages.fastapi: remove strictDeps already set by default
* [`243cd823`](https://github.com/NixOS/nixpkgs/commit/243cd8239c58435dd51cda020757fc6177f75c0e) python3Packages.fastapi: use httpx in optional dependencies
* [`2c350d98`](https://github.com/NixOS/nixpkgs/commit/2c350d98c2bacb28861a14d7065d53f2aacc2a8d) python3Packages.python-multipart: 0.0.30 -> 0.0.32
* [`1ad21ce2`](https://github.com/NixOS/nixpkgs/commit/1ad21ce2a76ba05eb2a786be459385f202da0c65) xset: 1.2.5 -> 1.2.6
* [`795b41fd`](https://github.com/NixOS/nixpkgs/commit/795b41fda6a531a14fa1c0b04d60843ae6ed26f3) python3Packages.pyturbojpeg: 2.3.0 -> 2.4.0
* [`c186f8b3`](https://github.com/NixOS/nixpkgs/commit/c186f8b3bd6131e99584b6b8a05f781df7a14cb9) python3Packages.pyturbojpeg: use finalAttrs
* [`ad2ee0f5`](https://github.com/NixOS/nixpkgs/commit/ad2ee0f5dc920ecce94b436315380a5397b20e0a) python3Packages.tzlocal: 5.3.1 -> 5.4.4
* [`3b4d9199`](https://github.com/NixOS/nixpkgs/commit/3b4d9199edfa503509060e2529128f198b8f0197) python3Packages.trove-classifiers: 2026.5.20.19 -> 2026.6.1.19
* [`7b1cb1ff`](https://github.com/NixOS/nixpkgs/commit/7b1cb1ff899744ec4823c740a616569009e2a959) python3Packages.trove-classifiers: use finalAttrs
* [`5a147b95`](https://github.com/NixOS/nixpkgs/commit/5a147b95c69153d76ae3d4422123ad9717af1039) libseccomp: 2.6.0 -> 2.6.1
* [`59ae9321`](https://github.com/NixOS/nixpkgs/commit/59ae93215f296286cc7f08a895d685c5a1e193d9) hwdata: 0.408 -> 0.409
* [`ebab660e`](https://github.com/NixOS/nixpkgs/commit/ebab660e15a2474a53fd28bdca94c184c96b434b) sideband: 1.9.7 -> 1.9.8
* [`573018d9`](https://github.com/NixOS/nixpkgs/commit/573018d964de228a53584f4811c2c7129330b96b) python3Packages.drf-spectacular: 0.29.0 -> 0.30.0
* [`2aeb37aa`](https://github.com/NixOS/nixpkgs/commit/2aeb37aa7831ca831c29deadc0ccc5b06fe04446) peazip: 11.1.0 -> 11.2.0
* [`90d18d00`](https://github.com/NixOS/nixpkgs/commit/90d18d00f75e1001343c9856940ae68c0f23880e) maubot: remove from python3Packages
* [`229de01b`](https://github.com/NixOS/nixpkgs/commit/229de01b92140711618fd03dbffe2fd76325d3ec) maubot: remove sqliteSupport
* [`48aa64a5`](https://github.com/NixOS/nixpkgs/commit/48aa64a559702762a594a4db65ea6b6609b86780) i3-rounded: 4.20.1 -> 4.21.1
* [`afed8099`](https://github.com/NixOS/nixpkgs/commit/afed809954178530aaafe14182271262d22dcbca) mako: route D-Bus activation through mako.service
* [`189a9e6e`](https://github.com/NixOS/nixpkgs/commit/189a9e6e09994233428b4b0899dd86c971854633) phpunit: 13.2.1 -> 13.2.4
* [`e7ae8d7f`](https://github.com/NixOS/nixpkgs/commit/e7ae8d7f1ff36f551d78b7287d36eb0fdbba2c0f) bosh-cli: 7.9.18 -> 7.10.7
* [`2120146b`](https://github.com/NixOS/nixpkgs/commit/2120146b3900e0ca9f7329f83244518206f74dc4) ibus-engines.libthai: 0.1.5 -> 0.1.6
* [`bd4ae610`](https://github.com/NixOS/nixpkgs/commit/bd4ae61091e4c9b9f64284ea41d9868e15f82082) gmap: 0.3.3 -> 0.4.0
* [`0f366630`](https://github.com/NixOS/nixpkgs/commit/0f3666306c85c0720c5b4c1cbd52a760da850873) tiddlywiki: 5.4.0 -> 5.4.1
* [`9aa9153c`](https://github.com/NixOS/nixpkgs/commit/9aa9153c4a7ced2ccaf0dd4dc61c2c04fb102fa5) netcdf: 4.9.3 -> 4.10.1
* [`72c659e4`](https://github.com/NixOS/nixpkgs/commit/72c659e45032533aed2ad6b7081aaff98f7ac848) gitlab-runner: 19.0.0 -> 19.1.1
* [`a51f7712`](https://github.com/NixOS/nixpkgs/commit/a51f7712fa52cb9060fe048eac5e2859094ee707) fuc: 3.1.7 -> 3.2.0
* [`3f606b75`](https://github.com/NixOS/nixpkgs/commit/3f606b755e417d9596ad8fee9d1c6f49c38d042b) nodejs_20: drop
* [`0473ed3f`](https://github.com/NixOS/nixpkgs/commit/0473ed3fb0cf97cebeab79dbedb0ae188c16ceff) opencv: Add JPEG-XL support
* [`a0f770b1`](https://github.com/NixOS/nixpkgs/commit/a0f770b1e044b2b4d28259a5dac0817687dbb8ed) grpc: 1.81.0 -> 1.82.1
* [`a9b7ff9f`](https://github.com/NixOS/nixpkgs/commit/a9b7ff9f68b049b334c709bb96116a0bd8ba5eda) python3Packages.grpcio: 1.81.0 -> 1.82.1
* [`a27367ce`](https://github.com/NixOS/nixpkgs/commit/a27367ce58bf9760987ae84362317c5b7bef224a) python3Packages.grpcio-channelz: 1.81.0 -> 1.82.1
* [`f97c842f`](https://github.com/NixOS/nixpkgs/commit/f97c842f381d6992d46006e98c5785a607a68f95) python3Packages.grpcio-health-checking: 1.81.0 -> 1.82.1
* [`ef130ba3`](https://github.com/NixOS/nixpkgs/commit/ef130ba3c372430fa67bb310a7a3b3c085be5c1c) python3Packages.grpcio-reflection: 1.81.0 -> 1.82.1
* [`d3291efa`](https://github.com/NixOS/nixpkgs/commit/d3291efa1c8d40a17a185b95a7f207be42062c83) python3Packages.grpcio-status: 1.81.0 -> 1.82.1
* [`60f84450`](https://github.com/NixOS/nixpkgs/commit/60f84450ab470a20d49eb609bca6a577e68a8a66) python3Packages.grpcio-testing: 1.81.0 -> 1.82.1
* [`ce64f07d`](https://github.com/NixOS/nixpkgs/commit/ce64f07dd25c32af8207035126819f3720607b10) python3Packages.grpcio-tools: 1.81.0 -> 1.82.1
* [`322b9e93`](https://github.com/NixOS/nixpkgs/commit/322b9e93891d6bd08369eb232aed36557f39af01) tomcat: 11.0.22 -> 11.0.24
* [`3d32e070`](https://github.com/NixOS/nixpkgs/commit/3d32e0705a3e04ef756b6852364ac273ff67b23f) nixos/pam: remove explicit hardcoded yescrypt
* [`56f89898`](https://github.com/NixOS/nixpkgs/commit/56f89898daebb29e85eb6bd62329b8e9469e28c3) nixos/tests/login{,-nosuid}: assert yescrypt password format
* [`00c97895`](https://github.com/NixOS/nixpkgs/commit/00c97895aa823459f6326c3dd83e6da7bebcf5b8) qemu_test: Remove hostCpuOnly flag
* [`a1b14218`](https://github.com/NixOS/nixpkgs/commit/a1b1421843883a498028c333bb0302516259d22e) nocturne: add versionCheckHook
* [`87e75334`](https://github.com/NixOS/nixpkgs/commit/87e75334f80171bf3abe21e7a4f716651de1ba7c) python3Packages.ha-mqtt-discoverable: 0.24.2 -> 0.25.2
* [`93c5137c`](https://github.com/NixOS/nixpkgs/commit/93c5137c1cff0645d70a11ebdf9ad5fa53fff58a) matomo: 5.10.0 -> 5.12.0
* [`0c096610`](https://github.com/NixOS/nixpkgs/commit/0c096610cd8af4c047e0fc2e330163d35ed5f72a) python3Packages.numexpr: relax thread limit hook
* [`60d60de3`](https://github.com/NixOS/nixpkgs/commit/60d60de3deb0f99c09c3128d91aae4adbe104509) doc: fix typo
* [`60b2653a`](https://github.com/NixOS/nixpkgs/commit/60b2653a8116c9cfcd91b0161444cb227920b9a2) ocamlPackages.digestif: 1.3.0 -> 1.3.1
* [`8a1dc046`](https://github.com/NixOS/nixpkgs/commit/8a1dc046f19705bb3bf4d10c387f62d8696d05a0) ocamlPackages.mimic: 0.0.9 -> 0.0.10
* [`9b735fd2`](https://github.com/NixOS/nixpkgs/commit/9b735fd27dcb06e453397490fff2aae588981ec2) python3Packages.wirerope: unbreak with setuptools_80
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
