### PR TITLE
npins home-manager: update deeb6b7e -> cbb77679

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -48,9 +48,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "deeb6b7eb7e0c44ae1819c051ce175bd92a85100",
-      "url": "https://github.com/nix-community/home-manager/archive/deeb6b7eb7e0c44ae1819c051ce175bd92a85100.tar.gz",
-      "hash": "sha256-ouZe80aWEhMLVMkqICFDN+JUw+0FJtCr/bh+hHtRtMg="
+      "revision": "cbb77679b3d992c8b62f884cd3a84af534a28621",
+      "url": "https://github.com/nix-community/home-manager/archive/cbb77679b3d992c8b62f884cd3a84af534a28621.tar.gz",
+      "hash": "sha256-kGJTc0oEUQuEwV66lSlMxYtOEtpk9N/HS43k+rFAvs8="
     },
     "hs-grille": {
       "type": "Git",


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@deeb6b7e...cbb77679](https://github.com/nix-community/home-manager/compare/deeb6b7eb7e0c44ae1819c051ce175bd92a85100...cbb77679b3d992c8b62f884cd3a84af534a28621)

* [`a2a9fec5`](https://github.com/nix-community/home-manager/commit/a2a9fec5723ce8ca8daf4268d068783cf120dbba) senpai: use correct config directory on darwin systems
* [`abba1081`](https://github.com/nix-community/home-manager/commit/abba1081f5d6e3bf6b0c53644f26ff209888e988) rclone: add nfsmount mount type
* [`6d8d6156`](https://github.com/nix-community/home-manager/commit/6d8d61567802997f9ec3086b2a837e3ef31fac16) herdr: Use the binary outside Nix to reload the config when `package` is unset
* [`041a999e`](https://github.com/nix-community/home-manager/commit/041a999e8c1c5b731913855909e68d30ca69b8e0) modules/misc/ssh-auth-sock: correct nushell init
* [`cbfe6732`](https://github.com/nix-community/home-manager/commit/cbfe6732716e1f46cd158431f34d0ea8b5512108) modules: stop filtering files starting with _
* [`3b0e6bbd`](https://github.com/nix-community/home-manager/commit/3b0e6bbd65869af1beadf5963a99befc179d209f) modules: partially apply `.nix` suffix check
* [`32de400b`](https://github.com/nix-community/home-manager/commit/32de400b6ac9f43042bca706f4a64f6ad08117e8) direnv: fix nushell integration failing to unset variables
* [`40d502fa`](https://github.com/nix-community/home-manager/commit/40d502faf202bbd7a0b3df90d5830acc23b71c6e) sshAuthSock: indent initialization code
* [`079a3b5d`](https://github.com/nix-community/home-manager/commit/079a3b5d1aa6a719920a51316253b7d6dd22738d) sshAuthSock: for Zsh, initialize in .zprofile and .zshenv
* [`6c957965`](https://github.com/nix-community/home-manager/commit/6c957965dbd445deac9a1320753b5cc16f5c1075) wlsunset: make duration optional with manual sunrise/sunset
* [`e83dffa8`](https://github.com/nix-community/home-manager/commit/e83dffa86cccb6237fe194d4eeb47f41557749d1) ci: bump actions/labeler from 6 to 7
* [`0c486d2b`](https://github.com/nix-community/home-manager/commit/0c486d2b21bb1e4d0e5a11e374deb51587267387) Translate using Weblate (Turkish)
* [`cbb77679`](https://github.com/nix-community/home-manager/commit/cbb77679b3d992c8b62f884cd3a84af534a28621) claude-code: link plugins so agents and commands load
