### PR TITLE
npins zsh-patina: update 96eb9dc3 -> 3d980f07

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -242,9 +242,9 @@
       },
       "branch": "main",
       "submodules": false,
-      "revision": "96eb9dc30bf3657f7f70e46ea4be3c120c6a1a1c",
-      "url": "https://github.com/michel-kraemer/zsh-patina/archive/96eb9dc30bf3657f7f70e46ea4be3c120c6a1a1c.tar.gz",
-      "hash": "sha256-ME9JvEG30k4BO9fw3rbo/f6dzDfhkD8crN/qDk1NH/E="
+      "revision": "3d980f076fef130403e5fcccdac9510c234ca6fd",
+      "url": "https://github.com/michel-kraemer/zsh-patina/archive/3d980f076fef130403e5fcccdac9510c234ca6fd.tar.gz",
+      "hash": "sha256-8RgWgLZZeQZGRleKcCGpQk2Ipubk5PBdDzfUUDS9OT8="
     },
     "zsh-syntax-highlighting": {
       "type": "Git",


### PR DESCRIPTION
## Changelog for zsh-patina:
Branch: main
Commits: [michel-kraemer/zsh-patina@96eb9dc3...3d980f07](https://github.com/michel-kraemer/zsh-patina/compare/96eb9dc30bf3657f7f70e46ea4be3c120c6a1a1c...3d980f076fef130403e5fcccdac9510c234ca6fd)

* [`bda9d1e3`](https://github.com/michel-kraemer/zsh-patina/commit/bda9d1e3573166494efcfcfb75e119e442f2fcd1) Fix file descriptor leak
* [`fc34bd4f`](https://github.com/michel-kraemer/zsh-patina/commit/fc34bd4fe56791684299e8cd54fa4e36210f48d6) Fix daemon keeping inherited file descriptors open
