### PR TITLE
npins emacs-overlay: update 049348f7 -> 42965ee5

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -35,9 +35,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "049348f7a64744506ea5dfb6c939d780de5214c8",
-      "url": "https://github.com/nix-community/emacs-overlay/archive/049348f7a64744506ea5dfb6c939d780de5214c8.tar.gz",
-      "hash": "sha256-2Pz2ajx4elc6+J1ptkGAi4HLYTW2vW/jJhQfeZsXq9U="
+      "revision": "42965ee54b2d1d93b5e0aaa522d083c7a167c678",
+      "url": "https://github.com/nix-community/emacs-overlay/archive/42965ee54b2d1d93b5e0aaa522d083c7a167c678.tar.gz",
+      "hash": "sha256-+V1imZu7DiALSkBGP6yEZBuY9yt/KpHbE11TYLgLdos="
     },
     "home-manager": {
       "type": "Git",


### PR DESCRIPTION
## Changelog for emacs-overlay:
Branch: master
Commits: [nix-community/emacs-overlay@049348f7...42965ee5](https://github.com/nix-community/emacs-overlay/compare/049348f7a64744506ea5dfb6c939d780de5214c8...42965ee54b2d1d93b5e0aaa522d083c7a167c678)

* [`0db64b92`](https://github.com/nix-community/emacs-overlay/commit/0db64b92d546ddef86e6af642158da2f20f71e1d) Updated flake inputs
* [`5b81ce7f`](https://github.com/nix-community/emacs-overlay/commit/5b81ce7f989bf2721ec9959f4db9d24a4f4617b7) Updated nongnu
* [`af5acbec`](https://github.com/nix-community/emacs-overlay/commit/af5acbec8c6e266dff7a8f3befda2ae819a59bfd) Updated elpa
* [`72c957de`](https://github.com/nix-community/emacs-overlay/commit/72c957de7b9395c4ea2f14b9ab4251457c1d18b8) Updated emacs
* [`7f74f99e`](https://github.com/nix-community/emacs-overlay/commit/7f74f99e8c227635dd1ccf4c4de119a2dc26c503) Updated melpa
* [`c9d782b6`](https://github.com/nix-community/emacs-overlay/commit/c9d782b6bba4fd6419d455c8e456909da96ebaa9) Updated emacs
* [`8e0f88fd`](https://github.com/nix-community/emacs-overlay/commit/8e0f88fd2a5cb5052965adef9886361df0f1d2d3) Updated melpa
* [`b24d7c38`](https://github.com/nix-community/emacs-overlay/commit/b24d7c38967fb75588a40945383fd82e296f59e2) Updated elpa
* [`1b62b41f`](https://github.com/nix-community/emacs-overlay/commit/1b62b41fb3d92e0b2d20d72a0f3bd2d60ddf0c32) Updated nongnu
* [`0aaf947b`](https://github.com/nix-community/emacs-overlay/commit/0aaf947b1731531c770aa8f09fc84a3e26af0682) Updated melpa
* [`8123fa04`](https://github.com/nix-community/emacs-overlay/commit/8123fa047aaa21c28a9fea757e4023abdd4e4033) Updated nongnu
* [`2e324dc0`](https://github.com/nix-community/emacs-overlay/commit/2e324dc07cec4b30a9e4d58d5d71f9dc71e96c00) Updated elpa
* [`512a307e`](https://github.com/nix-community/emacs-overlay/commit/512a307e1d5b1eb5046d0181ff0c72e5838b7985) Updated emacs
* [`683b462a`](https://github.com/nix-community/emacs-overlay/commit/683b462a455f041b9a2201c2e2386915fa0f65ad) Updated melpa
* [`91b3eaf2`](https://github.com/nix-community/emacs-overlay/commit/91b3eaf21d8ed0a121c260adf0c50095d912e0e5) Updated emacs
* [`89295cc7`](https://github.com/nix-community/emacs-overlay/commit/89295cc78aff3450ec13903cc47ffde2945383b9) Updated melpa
* [`8ad58307`](https://github.com/nix-community/emacs-overlay/commit/8ad58307c81947c5d8100bf11771b836def84d04) Updated nongnu
* [`4ef36e7d`](https://github.com/nix-community/emacs-overlay/commit/4ef36e7d817047181b1045df6e73a729d5f40d4c) Updated elpa
* [`2c3d2ecb`](https://github.com/nix-community/emacs-overlay/commit/2c3d2ecbd8c0c1f2abfe4faa69724e8cadd91195) Updated melpa
* [`23917337`](https://github.com/nix-community/emacs-overlay/commit/239173373063c96434c1ccee6766476cbdb97fe9) Updated nongnu
* [`2708336a`](https://github.com/nix-community/emacs-overlay/commit/2708336a13929321314ca6094511d8b494fce42b) Updated emacs
* [`06debba2`](https://github.com/nix-community/emacs-overlay/commit/06debba25ef32e35822315a37a601a3e3e9424f5) Updated melpa
* [`8eb5fada`](https://github.com/nix-community/emacs-overlay/commit/8eb5fada90f17ad128506ed6b2b5b2369494719b) Updated melpa
* [`aaec8129`](https://github.com/nix-community/emacs-overlay/commit/aaec8129f9a09f9317ca2a940e42fea764a3f23d) Updated flake inputs
* [`0352fbf4`](https://github.com/nix-community/emacs-overlay/commit/0352fbf4fb46f22b4bbc11775910a31bf7c68d12) Updated nongnu
* [`a7e3762f`](https://github.com/nix-community/emacs-overlay/commit/a7e3762f4833a8989a9e33e44f96f2e62812bbca) Updated elpa
* [`395c73ad`](https://github.com/nix-community/emacs-overlay/commit/395c73adb2f7f4217ec78dc714b8ba15c24b1e25) Updated melpa
* [`2fd47365`](https://github.com/nix-community/emacs-overlay/commit/2fd47365907b12b754533809022cb817583af64e) Updated flake inputs
* [`f66e617e`](https://github.com/nix-community/emacs-overlay/commit/f66e617e9189876f324a515b7472c7a99b5a5750) Updated nongnu
* [`2eeddece`](https://github.com/nix-community/emacs-overlay/commit/2eeddeceb43a18a712988529fbb97a8347dcb3d9) Updated elpa
* [`0bae2fa5`](https://github.com/nix-community/emacs-overlay/commit/0bae2fa57105df240502b07d352aee3f2cd30d68) Updated emacs
* [`37c0aa19`](https://github.com/nix-community/emacs-overlay/commit/37c0aa1964dfa3e8b224d8d692ff5468efafa0eb) Updated melpa
* [`6e788954`](https://github.com/nix-community/emacs-overlay/commit/6e78895460ebfc9064b21abb897a312cd323afa6) Updated emacs
* [`060e968e`](https://github.com/nix-community/emacs-overlay/commit/060e968e57472764d3c4bc5f30bacb96255f84ee) Updated melpa
* [`102628f7`](https://github.com/nix-community/emacs-overlay/commit/102628f780d7c0b3eb7fc729c7609f7f5dc08b30) Updated flake inputs
* [`49e1c88a`](https://github.com/nix-community/emacs-overlay/commit/49e1c88afc38753d8fe7f5badc7fbf2635e48b31) Updated nongnu
* [`68ca633c`](https://github.com/nix-community/emacs-overlay/commit/68ca633c230812d3ea2b218269714a96f55ed5d4) Updated elpa
* [`4de04da8`](https://github.com/nix-community/emacs-overlay/commit/4de04da83d63dd9749b04fd31263f127b5b9a691) Updated emacs
* [`092de36e`](https://github.com/nix-community/emacs-overlay/commit/092de36ee2f94fb94a9c183833e81a8c311b7529) Updated melpa
* [`ea1d95a3`](https://github.com/nix-community/emacs-overlay/commit/ea1d95a34f405de01299f20be6a60a19a1ca24fc) Updated nongnu
* [`b40c9944`](https://github.com/nix-community/emacs-overlay/commit/b40c99449ce4e4a6309d154bd4ed2b4ce6cdcb8c) Updated elpa
* [`caeb26e5`](https://github.com/nix-community/emacs-overlay/commit/caeb26e5aa99a5ebd97bcfd224222c46fc00e683) Updated emacs
* [`5abcbe07`](https://github.com/nix-community/emacs-overlay/commit/5abcbe07ea3550e8312c7327693c144dc8c2e2a9) Updated melpa
* [`7f2a82a1`](https://github.com/nix-community/emacs-overlay/commit/7f2a82a1dbea3c6ea80c3a42ca24cbe78d21a652) Updated flake inputs
* [`219ffd02`](https://github.com/nix-community/emacs-overlay/commit/219ffd028dc6628bfaf5417ab3193708f1cb7387) Updated melpa
* [`e4fb345f`](https://github.com/nix-community/emacs-overlay/commit/e4fb345f024c54befe3d766f45dff7e77d2013f9) Updated elpa
* [`eaf950bb`](https://github.com/nix-community/emacs-overlay/commit/eaf950bb501aad544a91296d4c0c274052bf7a7b) Updated nongnu
* [`155c5c72`](https://github.com/nix-community/emacs-overlay/commit/155c5c72e100ba763f53f2e16c56b1cf4792656c) Updated emacs
* [`06b6d9af`](https://github.com/nix-community/emacs-overlay/commit/06b6d9af774e25db79a40bad9f68539240ef1e25) Updated melpa
* [`f13422fa`](https://github.com/nix-community/emacs-overlay/commit/f13422fa6df11e991c9fb63fa7188858a0e84bb1) Updated elpa
* [`f358c202`](https://github.com/nix-community/emacs-overlay/commit/f358c202b69a4f79305d8fc1f528d2a5ac44db50) Updated melpa
* [`4fa0bfaf`](https://github.com/nix-community/emacs-overlay/commit/4fa0bfaf711687fbee6977615b3aa70068aefc40) Updated emacs
* [`afbea9ce`](https://github.com/nix-community/emacs-overlay/commit/afbea9cedba4e2746f5b0ec68805e4c9313cb6a4) Updated melpa
* [`c51e9cef`](https://github.com/nix-community/emacs-overlay/commit/c51e9cef5ddf3a439d0ac7f8b026cf3e5d3d26a7) Updated melpa
* [`69fe7ef8`](https://github.com/nix-community/emacs-overlay/commit/69fe7ef830364378e58f731f43d47885c65173a7) Updated emacs
* [`fa518f84`](https://github.com/nix-community/emacs-overlay/commit/fa518f84fa7e60eef450bc4551cea5d510347ed6) Updated melpa
* [`326804be`](https://github.com/nix-community/emacs-overlay/commit/326804be0a5a2cc2a3e447154f478fdc2bd799c7) Updated emacs
* [`d3ec864c`](https://github.com/nix-community/emacs-overlay/commit/d3ec864c649dc93b29a3cf04b10c1772fccb2c43) Updated melpa
* [`1fafa57b`](https://github.com/nix-community/emacs-overlay/commit/1fafa57be02599dc96e6fb76579b92595f65d0e8) Updated flake inputs
* [`1e584e12`](https://github.com/nix-community/emacs-overlay/commit/1e584e127a059864af77f4e30bfc805041266331) Updated nongnu
* [`ef1c90c7`](https://github.com/nix-community/emacs-overlay/commit/ef1c90c757bbbe749043e81313b46e0c7415239d) Updated elpa
* [`5f712bbd`](https://github.com/nix-community/emacs-overlay/commit/5f712bbd17df232fb4900e8fc236516c4d854d84) Updated melpa
* [`3511edaa`](https://github.com/nix-community/emacs-overlay/commit/3511edaaf67d8c8e73b31806e48fe631fcd24239) Updated melpa
* [`840b4cf4`](https://github.com/nix-community/emacs-overlay/commit/840b4cf4db4d697d6a801460504eea2206f5bc0b) Updated melpa
* [`1fec683c`](https://github.com/nix-community/emacs-overlay/commit/1fec683cd434eebc2b5050fb5ff1d36ee523b164) Updated nongnu
* [`489b1453`](https://github.com/nix-community/emacs-overlay/commit/489b1453bbe2cd616f06f4f1fe73071ce103d329) Updated elpa
* [`5443e671`](https://github.com/nix-community/emacs-overlay/commit/5443e671783cad46463e2641975fa8db33d4e9b8) Updated melpa
* [`38111711`](https://github.com/nix-community/emacs-overlay/commit/381117114ff001e4ab8a4c3b9996a628866380cf) Updated nongnu
* [`7a8475b7`](https://github.com/nix-community/emacs-overlay/commit/7a8475b7dd7e7e3cacad99031a70277609dfb924) Updated melpa
* [`155dd729`](https://github.com/nix-community/emacs-overlay/commit/155dd729975ae8ac7fd5ecf466695f6a7d16072c) Updated melpa
* [`8c114a63`](https://github.com/nix-community/emacs-overlay/commit/8c114a6397ea7b2e75a04b8fc03284d685ee52f6) Updated nongnu
* [`1fc04561`](https://github.com/nix-community/emacs-overlay/commit/1fc0456171d15a33323da13840d8b6e13324a571) Updated elpa
* [`c48bc338`](https://github.com/nix-community/emacs-overlay/commit/c48bc3386b8f9e224157c4238cdc95d9ab06a8d3) Updated melpa
* [`aa70345c`](https://github.com/nix-community/emacs-overlay/commit/aa70345c819c8a6d4aaaae8dc2a385b5f5732b0d) Updated flake inputs
* [`54f58f34`](https://github.com/nix-community/emacs-overlay/commit/54f58f34e11aeaed5ee69a6c9e5e504526b769e9) Updated nongnu
* [`e53cfb13`](https://github.com/nix-community/emacs-overlay/commit/e53cfb13ae0b9e2a44180e22eff7e70a394aadf5) Updated elpa
* [`8a07da50`](https://github.com/nix-community/emacs-overlay/commit/8a07da50735e9bb7a888c296643152f04d360619) Updated melpa
* [`b93bfd42`](https://github.com/nix-community/emacs-overlay/commit/b93bfd424f99867102e0418b7e5ebfc6423b8f31) Updated melpa
* [`c1b5ea45`](https://github.com/nix-community/emacs-overlay/commit/c1b5ea4528116631b606c17b3213b46d349f657a) Updated flake inputs
* [`41907a8a`](https://github.com/nix-community/emacs-overlay/commit/41907a8a29ee5b103911b44e521f40c983057dc2) Updated nongnu
* [`2aed0436`](https://github.com/nix-community/emacs-overlay/commit/2aed04366703b9b869620d1174eeb4d0aaa96231) Updated elpa
* [`14c6235a`](https://github.com/nix-community/emacs-overlay/commit/14c6235a724a2382b998714eb8239b29fc120bf6) Updated melpa
* [`8406ba21`](https://github.com/nix-community/emacs-overlay/commit/8406ba211acef902386385f4c68ae39bca737b6b) Updated nongnu
* [`b8471744`](https://github.com/nix-community/emacs-overlay/commit/b84717449b396a7647a12583879cd647f589c44a) Updated elpa
* [`1169a339`](https://github.com/nix-community/emacs-overlay/commit/1169a3392c5f827d351153555945f367b15a4695) Updated melpa
* [`cc5b5c45`](https://github.com/nix-community/emacs-overlay/commit/cc5b5c4510317ead0c72ac2f4f669327d1a31613) Updated flake inputs
* [`d21ae0c4`](https://github.com/nix-community/emacs-overlay/commit/d21ae0c4e6a1d81192bfe5a36ca7815a705b46a3) Updated melpa
* [`766fb10b`](https://github.com/nix-community/emacs-overlay/commit/766fb10b4c8c8feb58e7691a39905c89228ea268) Updated flake inputs
* [`53835a0b`](https://github.com/nix-community/emacs-overlay/commit/53835a0be1dc9619ee02e36d5adbf755172514fb) Updated nongnu
* [`723bc7fa`](https://github.com/nix-community/emacs-overlay/commit/723bc7fa2449e2cba507fb3bcd5caaa67728e023) Updated elpa
* [`fcd1944e`](https://github.com/nix-community/emacs-overlay/commit/fcd1944e3fea0f99a5e1e5bec7c8a7bec01b0000) Updated melpa
* [`544ddc07`](https://github.com/nix-community/emacs-overlay/commit/544ddc07f0a2f1e1f1fa3f7656e5aafa87e09bb8) Updated elpa
* [`c80d0bf4`](https://github.com/nix-community/emacs-overlay/commit/c80d0bf4911a5841ced1721cd35920037e1532a3) Updated nongnu
* [`73fc9645`](https://github.com/nix-community/emacs-overlay/commit/73fc964501c04526300c70a59b544fc3076b319c) Updated melpa
* [`c46cc86c`](https://github.com/nix-community/emacs-overlay/commit/c46cc86cbf2b1628d8fb823b09bd367800aad114) Updated melpa
* [`12b6f68f`](https://github.com/nix-community/emacs-overlay/commit/12b6f68ff6550166dd827d230fc806f25e58e919) Updated nongnu
* [`7e3ce7a5`](https://github.com/nix-community/emacs-overlay/commit/7e3ce7a5841cb84c22ae3187191380f47cc1f1c1) Updated elpa
* [`c184b1fa`](https://github.com/nix-community/emacs-overlay/commit/c184b1fa06e3b675df9c88ca529f0d7168f9ef2b) Updated melpa
* [`c23894c2`](https://github.com/nix-community/emacs-overlay/commit/c23894c2a92620c9ea1257a55d2b47ff37d67ee3) Updated flake inputs
* [`c9463a4b`](https://github.com/nix-community/emacs-overlay/commit/c9463a4bd17030d231990f1b30ad1fc01e9ec92c) Updated nongnu
* [`4d1f8b51`](https://github.com/nix-community/emacs-overlay/commit/4d1f8b51db1a1344a21f4ce26691032358ad80e6) Updated elpa
* [`9bae184e`](https://github.com/nix-community/emacs-overlay/commit/9bae184ed0c04cf270fbb0c9ba886d49bc9cc5e2) Updated melpa
* [`49a08d03`](https://github.com/nix-community/emacs-overlay/commit/49a08d03a3e10501b8ecc6c23d2f04050ebca62e) Updated melpa
* [`6a9c7251`](https://github.com/nix-community/emacs-overlay/commit/6a9c7251e32cd56d7e6571d20a05de4798b910d6) Updated nongnu
* [`8b5927c2`](https://github.com/nix-community/emacs-overlay/commit/8b5927c273776024dcdff49d1904a147ac673648) Updated elpa
* [`dc3f65ad`](https://github.com/nix-community/emacs-overlay/commit/dc3f65ad4abb74e7f3ff2b2580c888cccf1b13b2) Updated melpa
* [`66cba15b`](https://github.com/nix-community/emacs-overlay/commit/66cba15b469e63c476d2f407c960ff181a9ec3cf) Updated nongnu
* [`20878296`](https://github.com/nix-community/emacs-overlay/commit/208782966dbdbf7f5ba3c97f4e408131c7bed63e) Updated elpa
* [`9bde7e55`](https://github.com/nix-community/emacs-overlay/commit/9bde7e55642ecebd1b36b796220317f8914f5bdc) Updated melpa
* [`09739c7c`](https://github.com/nix-community/emacs-overlay/commit/09739c7c0e0d4678f249de67f2a54cceefa06994) Updated flake inputs
* [`73d5d861`](https://github.com/nix-community/emacs-overlay/commit/73d5d861f5b42752af837e0caf55f077c22690ad) Updated melpa
* [`b4c88377`](https://github.com/nix-community/emacs-overlay/commit/b4c88377e698fc31d7b5b842b5352cb06b98e2ba) Updated nongnu
* [`b8c2255a`](https://github.com/nix-community/emacs-overlay/commit/b8c2255a59eae09b6c69b6e823b8fb4c501b6869) Updated melpa
* [`47e52d3c`](https://github.com/nix-community/emacs-overlay/commit/47e52d3caef61f6c700c2757117cd0bc6a3bf795) Updated nongnu
* [`42235249`](https://github.com/nix-community/emacs-overlay/commit/422352494e740d44d7551549916655b122a9fd01) Updated elpa
* [`679c5747`](https://github.com/nix-community/emacs-overlay/commit/679c57473f06d80be69256ded0d88731fa6877b3) Updated melpa
* [`46b50e63`](https://github.com/nix-community/emacs-overlay/commit/46b50e638a363b4f4579740f29e16789d4ceace9) Updated melpa
* [`d0685197`](https://github.com/nix-community/emacs-overlay/commit/d0685197c3082fd4b6e44df22382b71b2cf936c7) Updated nongnu
* [`f3040db4`](https://github.com/nix-community/emacs-overlay/commit/f3040db4a7afc1638c348e4239a55f077688ec53) Updated elpa
* [`b91feab1`](https://github.com/nix-community/emacs-overlay/commit/b91feab148473e2b79a18f2d2514a723118fa429) Updated melpa
* [`ed20e253`](https://github.com/nix-community/emacs-overlay/commit/ed20e253e46fb92da6074e000713f501e83d7103) Updated flake inputs
* [`e8d43232`](https://github.com/nix-community/emacs-overlay/commit/e8d43232cd9428cb6db6bf485b9f6d62fad0719d) Updated nongnu
* [`b3db7442`](https://github.com/nix-community/emacs-overlay/commit/b3db7442afc82836b91f0aa13d7aea3219e02d76) Updated elpa
* [`b55fd6ef`](https://github.com/nix-community/emacs-overlay/commit/b55fd6efc384839f7ec0943c4b997b1bed2c4f3a) Updated flake inputs
* [`6135cba5`](https://github.com/nix-community/emacs-overlay/commit/6135cba58a88136c6de2b6dc41f2c75ed8b76503) Updated melpa
* [`d788cbc3`](https://github.com/nix-community/emacs-overlay/commit/d788cbc3044faa35722f86eea7db777ccd7f5529) Updated nongnu
* [`71cd80b2`](https://github.com/nix-community/emacs-overlay/commit/71cd80b24b650e7becc18c495d73118af3e1f8f4) Updated elpa
* [`addb4be2`](https://github.com/nix-community/emacs-overlay/commit/addb4be2ce30f2bf4fc10e575a7de80d3bb3668f) Updated melpa
* [`a3d640bd`](https://github.com/nix-community/emacs-overlay/commit/a3d640bdaab3a37c31f0d155e3f8ee072ca4dea5) Updated nongnu
* [`8b5da395`](https://github.com/nix-community/emacs-overlay/commit/8b5da395cfd870e61401323738d31ef09823e0cf) Updated elpa
* [`3a74d26c`](https://github.com/nix-community/emacs-overlay/commit/3a74d26c30bdfda35adcb3b394c77953290dc972) Updated melpa
* [`b404f95e`](https://github.com/nix-community/emacs-overlay/commit/b404f95e3e8e44f408ea650b1ebead1abfe31c77) Updated melpa
* [`1a77d187`](https://github.com/nix-community/emacs-overlay/commit/1a77d18719575996fcbfda493fa7ac95970e659c) Updated flake inputs
* [`78d3381d`](https://github.com/nix-community/emacs-overlay/commit/78d3381dc5dd1e86c429104c19467a72a44ff729) Updated nongnu
* [`abb55886`](https://github.com/nix-community/emacs-overlay/commit/abb55886bc60ed82dd418f004471628c25eca83c) Updated elpa
* [`af2225ab`](https://github.com/nix-community/emacs-overlay/commit/af2225abe7652d866d5cd1edc646d87b20524a91) Updated melpa
* [`60d806a7`](https://github.com/nix-community/emacs-overlay/commit/60d806a7f10958fd2461c198f159c190fb530256) Updated nongnu
* [`b4248ab2`](https://github.com/nix-community/emacs-overlay/commit/b4248ab2cadf27595b4a95172c0fbe1816403c39) Updated elpa
* [`d62d2ca6`](https://github.com/nix-community/emacs-overlay/commit/d62d2ca65d09abf724e39d6fcd3600ef646fcc3e) Updated flake inputs
* [`71e94848`](https://github.com/nix-community/emacs-overlay/commit/71e94848029a0bff7e27620a0248b73e8ea8b294) Updated emacs
* [`a285daa1`](https://github.com/nix-community/emacs-overlay/commit/a285daa159d0ca679b902a995295aaeeeea38a96) Updated melpa
* [`a09afa0b`](https://github.com/nix-community/emacs-overlay/commit/a09afa0b71098f2c0672a7a7765b842ed6fbe2df) Updated nongnu
* [`ee6c4596`](https://github.com/nix-community/emacs-overlay/commit/ee6c4596e37483bb614f7847926f08f1ea97f06f) Updated elpa
* [`ddc68e35`](https://github.com/nix-community/emacs-overlay/commit/ddc68e352bb0ed829bf819058a8924b60e53d720) Updated melpa
* [`c5278a7c`](https://github.com/nix-community/emacs-overlay/commit/c5278a7cc18248dee82440cacd3ed80695cfe17b) Updated nongnu
* [`3a4dd576`](https://github.com/nix-community/emacs-overlay/commit/3a4dd576bd7d6df76c09abae93852919cc655a83) Updated elpa
* [`1e043af5`](https://github.com/nix-community/emacs-overlay/commit/1e043af5c33810914ca5bbb11624fce6d1e7fead) Updated melpa
* [`59d5b1e9`](https://github.com/nix-community/emacs-overlay/commit/59d5b1e924f1c234c7f889965300d40fa98bcc50) Updated melpa
* [`6a1295f0`](https://github.com/nix-community/emacs-overlay/commit/6a1295f0d5e4c03fca8d5aaa8734a275056dbd81) Updated flake inputs
* [`2280a9fd`](https://github.com/nix-community/emacs-overlay/commit/2280a9fd714f6dfa5984c5af23aea54b82790c0b) Updated elpa
* [`7b537658`](https://github.com/nix-community/emacs-overlay/commit/7b537658f67f5299e3af9797edc1ddf15782b165) Updated nongnu
* [`c2ec1336`](https://github.com/nix-community/emacs-overlay/commit/c2ec1336078ead34e26db6243f070de2e07c853b) Updated melpa
* [`0336d666`](https://github.com/nix-community/emacs-overlay/commit/0336d6664888444d59a12becf2528093e0ad95b7) Updated flake inputs
* [`ca16bf90`](https://github.com/nix-community/emacs-overlay/commit/ca16bf90cb65a4a884b9460887eae275bc7a6e52) Updated nongnu
* [`9faf91af`](https://github.com/nix-community/emacs-overlay/commit/9faf91af00053e3df18256c9db626fc2ba4507aa) Updated elpa
* [`b90ebb6e`](https://github.com/nix-community/emacs-overlay/commit/b90ebb6e171b263604fd112e6e2a47b8f12ce6da) Updated melpa
* [`b4c482de`](https://github.com/nix-community/emacs-overlay/commit/b4c482de2d884020f3fa0d913aeab9adfefb24e7) Updated melpa
* [`fdd6dac2`](https://github.com/nix-community/emacs-overlay/commit/fdd6dac2c986e5e9bd75ae3474fb354d39686509) Updated nongnu
* [`ae719247`](https://github.com/nix-community/emacs-overlay/commit/ae71924753e1b20b2a8229f878f6a27d133e2692) Updated elpa
* [`c985bf85`](https://github.com/nix-community/emacs-overlay/commit/c985bf858cce9beedf0e3cf47d36800e4a2043e0) Updated melpa
* [`90d5982e`](https://github.com/nix-community/emacs-overlay/commit/90d5982e0b89127e5e629ed3647bb59d5be673e3) Updated nongnu
* [`6e45766c`](https://github.com/nix-community/emacs-overlay/commit/6e45766c914b6651067b46b3062bc884d7b758d8) Updated elpa
* [`4c705e03`](https://github.com/nix-community/emacs-overlay/commit/4c705e0365872601b40d3012aae9e4ed95f8594b) Updated melpa
* [`2b417ffd`](https://github.com/nix-community/emacs-overlay/commit/2b417ffdabb717e42bfec7d579e6544b43b7915e) Updated melpa
* [`12d8d830`](https://github.com/nix-community/emacs-overlay/commit/12d8d8305891adaa9f8bcd4667f3998ba722dc3f) Updated nongnu
* [`86788d02`](https://github.com/nix-community/emacs-overlay/commit/86788d0250037c811fb40c1cc845374378a4cd13) Updated elpa
* [`7afa88db`](https://github.com/nix-community/emacs-overlay/commit/7afa88db29499bd1c41dad09c493f7262e851956) Updated melpa
* [`76be1ae9`](https://github.com/nix-community/emacs-overlay/commit/76be1ae988379797e9eda0903a77624cd051072e) Updated nongnu
* [`86f02f1a`](https://github.com/nix-community/emacs-overlay/commit/86f02f1aa2f0fec9f6d4e06dc033eb0e9f1c3ee2) Updated elpa
* [`4c1eec02`](https://github.com/nix-community/emacs-overlay/commit/4c1eec029e47524a205f6f08440cb678dd203565) Updated melpa
* [`10576951`](https://github.com/nix-community/emacs-overlay/commit/1057695101686dcde2ffc51fd891d348a22c6da9) Updated emacs
* [`d2e09015`](https://github.com/nix-community/emacs-overlay/commit/d2e090155296156531b5ea5a461a8eedb78526e6) Updated melpa
* [`68bce01d`](https://github.com/nix-community/emacs-overlay/commit/68bce01dd1a729dc3f950e9a5be39861229908b2) Updated nongnu
* [`7b54804f`](https://github.com/nix-community/emacs-overlay/commit/7b54804fa8ab6c207ac3a7496050f79881d71ae7) Updated elpa
* [`9317a3e1`](https://github.com/nix-community/emacs-overlay/commit/9317a3e13c67cfe16c2827297e3b103fb4c26831) Updated melpa
* [`699f4ad4`](https://github.com/nix-community/emacs-overlay/commit/699f4ad4abfe7eaf19cf637c116d20be73d47bdf) Updated nongnu
* [`07968b3c`](https://github.com/nix-community/emacs-overlay/commit/07968b3ca59b9f243ffecc2bc999107016def1c0) Updated elpa
* [`c7ee960e`](https://github.com/nix-community/emacs-overlay/commit/c7ee960e58f984b0bbbcec7a5350e2f823a11ca5) Updated emacs
* [`f6471dc6`](https://github.com/nix-community/emacs-overlay/commit/f6471dc6d86853c4d0694aa050041b86fbf78e48) Updated melpa
* [`b32148e4`](https://github.com/nix-community/emacs-overlay/commit/b32148e4ba1c567fcabee54b8a8f99067a81e54c) Updated flake inputs
* [`bff8e530`](https://github.com/nix-community/emacs-overlay/commit/bff8e530a513c61562d75b204ca1ada1175e6a95) Updated melpa
* [`7eb02535`](https://github.com/nix-community/emacs-overlay/commit/7eb02535bfd5d7fbd70ab106bbe3fcf6f93ac42e) Updated emacs
* [`843797ff`](https://github.com/nix-community/emacs-overlay/commit/843797ffb32fbd7a889a24e3b661ebdd22ccc861) Updated elpa
* [`2d7babf0`](https://github.com/nix-community/emacs-overlay/commit/2d7babf01f3181ff199e8aadc360bffad4f39465) Updated nongnu
* [`20458ff8`](https://github.com/nix-community/emacs-overlay/commit/20458ff80479d22e8e683dba4dad4befb00745b9) Updated emacs
* [`b2865e25`](https://github.com/nix-community/emacs-overlay/commit/b2865e251c6ca6230cae22f5628c48a7a4c8c7a1) Updated melpa
* [`bb333520`](https://github.com/nix-community/emacs-overlay/commit/bb33352085b6a339fda214fc5610e454f0554160) Updated flake inputs
* [`c2be465c`](https://github.com/nix-community/emacs-overlay/commit/c2be465c3967c0becd80e3cc1db379ba90e5eed6) Updated nongnu
* [`2c41d571`](https://github.com/nix-community/emacs-overlay/commit/2c41d57198bdb7e8c39bb102644bfd830f8087d4) Updated elpa
* [`d3a02725`](https://github.com/nix-community/emacs-overlay/commit/d3a02725717e8124f8d4e65ad53dfbe5e342a10d) Updated melpa
* [`e3c5ad1b`](https://github.com/nix-community/emacs-overlay/commit/e3c5ad1be12117823fbd618ba3e1f4e4448d802a) Updated emacs
* [`7b16634a`](https://github.com/nix-community/emacs-overlay/commit/7b16634a8273cb66206b756a47d7d2ea8f73f475) Updated melpa
* [`b8e000a9`](https://github.com/nix-community/emacs-overlay/commit/b8e000a90ecb9b6dffc57eeed46767fb4dce0109) Updated emacs
* [`48412ebe`](https://github.com/nix-community/emacs-overlay/commit/48412ebe57ee8a4dd1b3b2d86c773e5c7320168a) Updated nongnu
* [`d1d00706`](https://github.com/nix-community/emacs-overlay/commit/d1d00706eba4999cad4675b6c1fe8c9e8ab67fad) Updated elpa
* [`43a53b53`](https://github.com/nix-community/emacs-overlay/commit/43a53b53a61e9eb0a07794686d808015d5201f65) Updated emacs
* [`32ac6e14`](https://github.com/nix-community/emacs-overlay/commit/32ac6e14639198b1b254c8742d9151b468d320e7) Updated melpa
* [`da75776e`](https://github.com/nix-community/emacs-overlay/commit/da75776e00ace95f8215dfb86c99bf5773d6e148) Updated flake inputs
* [`e46cf1c9`](https://github.com/nix-community/emacs-overlay/commit/e46cf1c91f0bac285dcce5ed7abab01836bc00dc) Updated elpa
* [`ddfe8d3d`](https://github.com/nix-community/emacs-overlay/commit/ddfe8d3d64c01dcbda2e07b17c8eceaa52e3fccd) Updated nongnu
* [`6339a5ae`](https://github.com/nix-community/emacs-overlay/commit/6339a5ae2c57fb2b5b94bbaef929bebffe052eb7) Updated emacs
* [`7afa297a`](https://github.com/nix-community/emacs-overlay/commit/7afa297a367ad6d2ad8d7a709960c21bf595cd21) Updated melpa
* [`50c7c057`](https://github.com/nix-community/emacs-overlay/commit/50c7c057b5c0ac06864cfd85f1c0c0895b0bfedf) Updated melpa
* [`0ab92f47`](https://github.com/nix-community/emacs-overlay/commit/0ab92f478822ff9f7081938d7f87cd69498c51cc) Updated nongnu
* [`815b45de`](https://github.com/nix-community/emacs-overlay/commit/815b45de5b350a2c062c29f2e89bfd01725a050b) Updated elpa
* [`f084d571`](https://github.com/nix-community/emacs-overlay/commit/f084d5719f5a34668e2eb16419e8e0ccdb97e915) Updated emacs
* [`4ed71f48`](https://github.com/nix-community/emacs-overlay/commit/4ed71f48c0194ed33e92ae7aa61c80d11b58ad23) Updated melpa
* [`1fdc994d`](https://github.com/nix-community/emacs-overlay/commit/1fdc994d3f942e66401ca2df1f9017de3945541d) Updated nongnu
* [`aa6933ed`](https://github.com/nix-community/emacs-overlay/commit/aa6933edb40a38be04a826628ac7596094cf8a15) Updated elpa
* [`ecf4a1a2`](https://github.com/nix-community/emacs-overlay/commit/ecf4a1a2d40f5cf118e7ffa255212ffba6036151) Updated melpa
* [`7ac5d651`](https://github.com/nix-community/emacs-overlay/commit/7ac5d651743df221c360e4bcae32cf48b09b1276) Updated melpa
* [`9b847911`](https://github.com/nix-community/emacs-overlay/commit/9b8479118e019da3006d914b5d7024ae912283af) Updated flake inputs
* [`27c64a75`](https://github.com/nix-community/emacs-overlay/commit/27c64a75df907286bab0f722a830de716d41b6d8) Updated nongnu
* [`ccc23998`](https://github.com/nix-community/emacs-overlay/commit/ccc23998e54eebaa88bcf78eec754323fa831113) Updated elpa
* [`722f8fa7`](https://github.com/nix-community/emacs-overlay/commit/722f8fa7f47c3868016489576e23d839d0988e3c) Updated emacs
* [`c4988af8`](https://github.com/nix-community/emacs-overlay/commit/c4988af836837d97f8660dbedbf01e50f982d5e7) Updated melpa
* [`196f7df7`](https://github.com/nix-community/emacs-overlay/commit/196f7df7b6ff9fb4206e4b7f19d9e2216cbfc9ce) Updated flake inputs
* [`528830e8`](https://github.com/nix-community/emacs-overlay/commit/528830e840e782f3225389c074f5912269334ca7) Updated nongnu
* [`a8965326`](https://github.com/nix-community/emacs-overlay/commit/a896532613ecd8ac95d82c78c1074deb0d9a58cc) Updated elpa
* [`66e39666`](https://github.com/nix-community/emacs-overlay/commit/66e39666e733e9704028afc8e432c1592ff24698) Updated emacs
* [`14ab0d66`](https://github.com/nix-community/emacs-overlay/commit/14ab0d66de5a9f22baebaad4973b87318cbf9813) Updated melpa
* [`f112d939`](https://github.com/nix-community/emacs-overlay/commit/f112d939228329bc0609b2aadcf465fe61d1347d) Bump actions/checkout from 7.0.0 to 7.0.1
* [`ee57cfbe`](https://github.com/nix-community/emacs-overlay/commit/ee57cfbe938a5838f8e05ae29051254dc1ff4e9f) Updated emacs
* [`16874f5d`](https://github.com/nix-community/emacs-overlay/commit/16874f5dbccb89bf17b7b4aa99b4e5f904572e20) Updated melpa
* [`37a7dbef`](https://github.com/nix-community/emacs-overlay/commit/37a7dbefb3b9f58daa28b9651144f8f8417e26c1) Updated nongnu
* [`6f47983a`](https://github.com/nix-community/emacs-overlay/commit/6f47983aca2665bb91dbc0972714fefdc676159b) Updated elpa
* [`99ce9431`](https://github.com/nix-community/emacs-overlay/commit/99ce943199a8c82fb46b5e1a78538effd1787f10) Updated emacs
* [`6584a669`](https://github.com/nix-community/emacs-overlay/commit/6584a669e2f0e4abce2c147725c26db55923f742) Updated melpa
* [`17a088fe`](https://github.com/nix-community/emacs-overlay/commit/17a088fecba8793fc17ea59f14490c8e83f71b51) Updated nongnu
* [`d1580fba`](https://github.com/nix-community/emacs-overlay/commit/d1580fba26afac0bf5a9a84476b0064d34033dab) Updated elpa
* [`82fe2449`](https://github.com/nix-community/emacs-overlay/commit/82fe24495b77a85eea7a4a9ffc7fedb1d979b7b4) Updated melpa
* [`d6d8a905`](https://github.com/nix-community/emacs-overlay/commit/d6d8a9055a2a167426080ec16ad218b457419420) Updated melpa
* [`8dcbd898`](https://github.com/nix-community/emacs-overlay/commit/8dcbd898254d1db000915ecae6536f7c7129c29a) Updated flake inputs
* [`4a9c65c0`](https://github.com/nix-community/emacs-overlay/commit/4a9c65c01397f6135d78d154bf91d5e4593a6424) Updated nongnu
* [`23314a92`](https://github.com/nix-community/emacs-overlay/commit/23314a92e95d39a1ab1c4770e7edf3954544fb0d) Updated elpa
* [`4e9e8da0`](https://github.com/nix-community/emacs-overlay/commit/4e9e8da09c84cc9c65c1852d6546d858734286b0) Updated emacs
* [`f872f15f`](https://github.com/nix-community/emacs-overlay/commit/f872f15fdab1a029108cfca9296531d56872e27f) Updated melpa
* [`0382c51d`](https://github.com/nix-community/emacs-overlay/commit/0382c51d5a3db18f833d573ba0374bc035621820) Updated nongnu
* [`6bdaa973`](https://github.com/nix-community/emacs-overlay/commit/6bdaa9738c8cec37a4a6a3f2fd3b3bd6513c7364) Updated elpa
* [`693b7dfd`](https://github.com/nix-community/emacs-overlay/commit/693b7dfdabd31b59d447bd0ed6ee329052daffc9) Updated melpa
* [`b27f80fd`](https://github.com/nix-community/emacs-overlay/commit/b27f80fd6933db1be7c4d3095b2e9c6785c93264) Updated emacs
* [`207cd03d`](https://github.com/nix-community/emacs-overlay/commit/207cd03de87851d5c66399b43014c9db51fff174) Updated melpa
* [`da63b52d`](https://github.com/nix-community/emacs-overlay/commit/da63b52d31f8c5ac51ddba25011bd2e5ff90c1e7) Updated flake inputs
* [`9299af42`](https://github.com/nix-community/emacs-overlay/commit/9299af4201fd25785e1d09efa0c1040c95b81a10) Updated nongnu
* [`6745ee3a`](https://github.com/nix-community/emacs-overlay/commit/6745ee3a8872b9ceb6b7e16d3c09d25f7a622168) Updated elpa
* [`32c641ff`](https://github.com/nix-community/emacs-overlay/commit/32c641ff498d54f2cf8fe1301e58513d6f9fe067) Updated melpa
* [`564594d9`](https://github.com/nix-community/emacs-overlay/commit/564594d92c82219100222f15915cb4273545e801) Updated nongnu
* [`b73c0a38`](https://github.com/nix-community/emacs-overlay/commit/b73c0a387348b7b4295300b8907d071e94ac2787) Updated elpa
* [`954a4c57`](https://github.com/nix-community/emacs-overlay/commit/954a4c57d4c68a3a7371b8d81e63540ba1c36849) Updated melpa
* [`f2e28828`](https://github.com/nix-community/emacs-overlay/commit/f2e288282bf9494773457da73bd614ba15109067) Updated emacs
* [`e00d8188`](https://github.com/nix-community/emacs-overlay/commit/e00d8188f6d3f9e8ee762dbf2bc1824542bbc4c5) Updated flake inputs
* [`afe13446`](https://github.com/nix-community/emacs-overlay/commit/afe13446de914dadfdbe53ee160b8e2bdc917aed) Updated emacs
* [`fc487ea1`](https://github.com/nix-community/emacs-overlay/commit/fc487ea169bb3e039f2ab379e0dd605a1c301204) Updated melpa
* [`c90af230`](https://github.com/nix-community/emacs-overlay/commit/c90af230a175b00e893044733be20eb5cca233cf) Updated nongnu
* [`6f25b30c`](https://github.com/nix-community/emacs-overlay/commit/6f25b30cf5a1e76a94f67997957aa67362350701) Updated elpa
* [`c882f160`](https://github.com/nix-community/emacs-overlay/commit/c882f160c5c4337e0bd79c266452d9ca01801d3b) Updated emacs
* [`af1b6cd2`](https://github.com/nix-community/emacs-overlay/commit/af1b6cd203866500df68781801a6f29349bf2375) Updated melpa
* [`3f9d5351`](https://github.com/nix-community/emacs-overlay/commit/3f9d53512a23dcac7765c436efd0ea04d1e361c6) Updated flake inputs
* [`8ab4270c`](https://github.com/nix-community/emacs-overlay/commit/8ab4270c84958e61b4de2c6d0c96b3bb275a4b4c) Updated nongnu
* [`6655fb66`](https://github.com/nix-community/emacs-overlay/commit/6655fb668e5f99436426028e2bc049c3aabd7445) Updated elpa
* [`cdb09b97`](https://github.com/nix-community/emacs-overlay/commit/cdb09b974b18c7ae075875cf9cc9f9254edc97fa) Updated emacs
* [`ba51b495`](https://github.com/nix-community/emacs-overlay/commit/ba51b49589d3b40e9cc30a6e4ae1ec02d2b0cece) Updated melpa
* [`279f1d7f`](https://github.com/nix-community/emacs-overlay/commit/279f1d7fb8194f3d11aabac81354f41cec7be77c) Updated emacs
* [`42965ee5`](https://github.com/nix-community/emacs-overlay/commit/42965ee54b2d1d93b5e0aaa522d083c7a167c678) Updated melpa
