### PR TITLE
npins doomemacs: update aac84622 -> 6ba99cb5

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -22,9 +22,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "aac84622b8bbe615832d3c49f8fe42fbda6841d3",
-      "url": "https://github.com/doomemacs/doomemacs/archive/aac84622b8bbe615832d3c49f8fe42fbda6841d3.tar.gz",
-      "hash": "sha256-DKLoxL7R54eQfrA2HRHKJYzNfoEkKlmHGIP37yJiUD4="
+      "revision": "6ba99cb50cddc4441963a0ef68f971112ab4807e",
+      "url": "https://github.com/doomemacs/doomemacs/archive/6ba99cb50cddc4441963a0ef68f971112ab4807e.tar.gz",
+      "hash": "sha256-cmQ2/kRScuwyywxWbiofdlL/KCQL9txWQecYC63uf+k="
     },
     "emacs-overlay": {
       "type": "Git",


### PR DESCRIPTION
## Changelog for doomemacs:
Branch: master
Commits: [doomemacs/doomemacs@aac84622...6ba99cb5](https://github.com/doomemacs/doomemacs/compare/aac84622b8bbe615832d3c49f8fe42fbda6841d3...6ba99cb50cddc4441963a0ef68f971112ab4807e)

* [`1db20b21`](https://github.com/doomemacs/core/commit/1db20b215735a222d1b15b6c4afe81c311888f91) feat(lib): doom-config: hoist into separate functions
* [`638b0a57`](https://github.com/doomemacs/core/commit/638b0a573010803c420dc19b83200451bca08858) refactor: move :path resolution to doom-module--put
* [`71d59f12`](https://github.com/doomemacs/core/commit/71d59f126d08bba02adfaf226a110cdbf71c8e77) fix: doom-module-mplist-map: only log new module once
* [`02aafb8a`](https://github.com/doomemacs/core/commit/02aafb8a788b7fed7e783cf6c61720e55b301f61) refactor: doom-module-from-path: partial backport
* [`d8d76544`](https://github.com/doomemacs/core/commit/d8d765443d9d5a1282d8994aa0ca2ad6965b24cc) feat(lib): cmd!!: use remapping if available
* [`eb5a3b5e`](https://github.com/doomemacs/core/commit/eb5a3b5e0d73c4a704571f88991688e34c473abd) refactor: doom-module-context: avoid pcase this early
* [`a7ae601d`](https://github.com/doomemacs/core/commit/a7ae601d34d65684f8158f1ab44e5bedbe73779f) docs: doom-module: mention hot cache in docstring
* [`b634cd6c`](https://github.com/doomemacs/core/commit/b634cd6c9634f3dad425043ca2defbf294999388) refactor: doom-initialize: DRY it up
* [`925d6551`](https://github.com/doomemacs/core/commit/925d6551a5483792d7338765ca009907dc7d35bf) fix: type error if non-existent module is enabled
* [`0b367b2c`](https://github.com/doomemacs/core/commit/0b367b2ca7886c51721c83fee988473467c52836) bump: sources/doom+
* [`faec6f9d`](https://github.com/doomemacs/core/commit/faec6f9de9500a753f77ba43e3e4c43e0637927c) fix(lib): (invalid-function doom-config-file) error
* [`3a9b07bf`](https://github.com/doomemacs/core/commit/3a9b07bf36511e51b13ffdc29733057f20ef1aa1) fix(lib): doom/version without git checkout
* [`ce615084`](https://github.com/doomemacs/core/commit/ce615084fff939096c40d4f1dc161eab5e051312) fix: stale module hot cache poisoning doom-modules
* [`bd083688`](https://github.com/doomemacs/core/commit/bd083688541ffb402ffb0602f42099ca554eaaab) bump: sources/doom+
* [`8e4fbbae`](https://github.com/doomemacs/core/commit/8e4fbbae048a9abe897bf1878cbd32732a6d41d7) fix: doom-module-context returning nil
* [`80ad3cd9`](https://github.com/doomemacs/core/commit/80ad3cd9198b5920430d8c200739e34b67469715) bump: :doom
* [`c4c0c1cf`](https://github.com/doomemacs/core/commit/c4c0c1cf85af98cb8ce489c8018fae55802ec1fe) refactor: throw better errors
* [`e0a53ca3`](https://github.com/doomemacs/core/commit/e0a53ca386ae86e304dd49591ed6471794621611) fix(compat): unconditionally install use-package
* [`b4c2f89c`](https://github.com/doomemacs/core/commit/b4c2f89cce102eaaaf42488d603f3c38ecf36d72) fix(lib): doom-{call,exec}-process: only strip final newline
* [`cbec7761`](https://github.com/doomemacs/core/commit/cbec776174a7a358700eec713b52ce230acf4463) fix: doom sync -r ignoring persisted init files
* [`476b04d6`](https://github.com/doomemacs/core/commit/476b04d630814a8cb9dca0424d7833794078bc99) tweak(compat): use built-in use-package, if available
* [`afadd7ad`](https://github.com/doomemacs/core/commit/afadd7ad3367b4311b6ced1c8d5839baf72ad79b) fix(lib): doom-real-buffer-modes: remove vterm
* [`e5699e4a`](https://github.com/doomemacs/core/commit/e5699e4ab2738bc5fd7b8fb4805c1bc99fb67bd8) feat(cli): add new cli/sh.el library
* [`08fbf507`](https://github.com/doomemacs/core/commit/08fbf5073c34c17c19dccc4ac505314621749583) fix(cli): doom install: don't quote error handler
* [`bf57f46a`](https://github.com/doomemacs/core/commit/bf57f46a55452ce4a31aa5b2004de70e47c6e067) refactor(cli): get! & put!
* [`de2a3364`](https://github.com/doomemacs/core/commit/de2a3364afbe6f6bdff6c9d38d3fa00494de29f6) refactor: re-integrate which-key into core
* [`6a6589c6`](https://github.com/doomemacs/core/commit/6a6589c625608e07715d7a76a2d2648427732956) bump: sources/doom+
* [`b5814087`](https://github.com/doomemacs/core/commit/b5814087bd09467f76269214494a8e254e4255fd) fix(lib): doom-{exec,call}-process regression
* [`ba57bb08`](https://github.com/doomemacs/core/commit/ba57bb08609c79d462435137fa0fdab3b5161b0f) fix: duplicate package! for which-key & general
* [`39452782`](https://github.com/doomemacs/core/commit/394527828a223f91bd5490aeb3931e295e171ea5) fix(cli): ci: git hook regression
* [`fcb48100`](https://github.com/doomemacs/core/commit/fcb48100f19cfcd16aa36c3eb031bcbcdc14437a) fix: package!: avoid map-delete
* [`e9ef35c5`](https://github.com/doomemacs/core/commit/e9ef35c5ba7c2efd7a60778f7254769e281477c9) fix(cli): sh!: not converting numeric switches to string
* [`f25753f3`](https://github.com/doomemacs/core/commit/f25753f32e0522a821f09f82cfbcce6d9546a17e) feat(cli): add sh& macro & pipes/redirects support
* [`a2438789`](https://github.com/doomemacs/core/commit/a24387890d6d5ea201165c92f14cfc1d2fae3911) fix(cli): deprecation notice for sh!!
* [`5fa66e30`](https://github.com/doomemacs/core/commit/5fa66e30fd567972dea7bdd15340282a77e1541a) fix(cli): remove parens around user-error output
* [`9feed15f`](https://github.com/doomemacs/core/commit/9feed15fdea4ecd7f10b8f2d37196e9442582d42) fix(cli): doom upgrade: reformat & revise output/errors
* [`d300105d`](https://github.com/doomemacs/core/commit/d300105dda17af9b21afba3b4aaa6cd557a6d719) bump: projectile
* [`a8a05877`](https://github.com/doomemacs/core/commit/a8a0587756e0cfc030848d5a3d1ac59efe1f3654) feat(lib): backport dlet macro from 28.1
* [`0d1b0640`](https://github.com/doomemacs/core/commit/0d1b06408720e7642bde537083ffb267a838256c) refactor(lib): doom-load-session
* [`635bc939`](https://github.com/doomemacs/core/commit/635bc939d3cb835873d7039a6505d78cdb99d313) fix!(lib): map!: which-key labels on :prefix
* [`26d7d145`](https://github.com/doomemacs/core/commit/26d7d1451567eb0fa0bfaff396e63b52e302fe3c) docs(lib): map!: fix :leader description
* [`0e078676`](https://github.com/doomemacs/core/commit/0e07867633f74a6e59cdd7f999278d7966f94478) fix(cli): sh{!,<,?}: appease byte-compiler
* [`f51749ca`](https://github.com/doomemacs/core/commit/f51749ca5200a2bb161f9ec26429f1dc544dc393) fix(cli): appease byte-compiler
* [`d19a264b`](https://github.com/doomemacs/core/commit/d19a264ba857724608457c625d9cdece8c1c22b8) fix: include built-in packages in profile autoloads
* [`e04b08b3`](https://github.com/doomemacs/core/commit/e04b08b365885994a66ef681b3fce5800dc4dcdb) fix(cli): doom env: quote allow/deny cookies
* [`a305b91f`](https://github.com/doomemacs/core/commit/a305b91f44d491fb1ed40e66065bc11d2d759cb4) fix(cli): doom env: properly quote allow/deny cookies
* [`77318fc1`](https://github.com/doomemacs/core/commit/77318fc188cd98ebf49736664a17ccac686dca24) fix(cli): doom env: type error on relative path in same CWD
* [`070d8bbb`](https://github.com/doomemacs/core/commit/070d8bbb6f63bcdf79dc862d921c0525e3cf872c) fix: doom-module-from-path: expand PATH
* [`3f842919`](https://github.com/doomemacs/core/commit/3f842919275c50189063dea34bb208fad8a0ad7b) refactor(lib): doom-file-cookie-p: remove redundancy
* [`7e98f188`](https://github.com/doomemacs/core/commit/7e98f188f3ff686ba82e138dcaebfd7bb22af9a0) refactor(cli): doom-cli-load-path: remove $EMACSDIR/lisp/cli
* [`6f4a4cfc`](https://github.com/doomemacs/core/commit/6f4a4cfca2573ff0d82181462fd74d7be88b1d02) fix(cli): loaddefs: unquotes substitution for #$
* [`221eb0ff`](https://github.com/doomemacs/core/commit/221eb0ffb17459cdb35bc78f85c2347947ae6701) fix(cli): doom env: add tmpdir vars to default deny list
* [`d1986c01`](https://github.com/doomemacs/core/commit/d1986c0181aadcbfe0d118fd1ae713fac8da7fab) refactor(cli): doom env: read allow/deny cookies with doom-file-cookie
* [`8b7c2e57`](https://github.com/doomemacs/core/commit/8b7c2e57b44565caccef4637ffbd23766dbd5c25) fix(cli): doom sync: update recipe repos on -u
* [`27e7bce3`](https://github.com/doomemacs/core/commit/27e7bce33380dddfe6de554d68dcbfec17201d4a) refactor(cli): remove .doomrc/$DOOMRC
* [`0dace1dd`](https://github.com/doomemacs/core/commit/0dace1dd637d0ab0ac30ec8fdf4d8d1a5cfcec66) fix(cli): generate separate doom-cli loaddefs file
* [`beb6b855`](https://github.com/doomemacs/core/commit/beb6b8556e9c25526f95334d298b57fd054c7bfa) fix(cli): doom upgrade: if doom is a git submodule
* [`f3e1bf2e`](https://github.com/doomemacs/core/commit/f3e1bf2eb7580e94d2f3e5a06a0d99fd7cd016e3) fix: which-key-mode not activating on Emacs <=29
* [`1477019d`](https://github.com/doomemacs/core/commit/1477019d2b837ac49a6cf61ebeb6194431184fb4) perf(lib): optimize & simplify fn! & lambda! macros
* [`6987923c`](https://github.com/doomemacs/core/commit/6987923ca6160ec39e78756b5572b3193b547225) refactor!(lib): letf! macro
* [`bfd97bc8`](https://github.com/doomemacs/core/commit/bfd97bc819a584f3dd8e2ecc6cca9770c5c6c5c4) fix: package!: set :type built-in only if actually built-in
* [`04b2956b`](https://github.com/doomemacs/core/commit/04b2956bafd883e5da7c530f8e0fbd22b1fe7af8) bump: sources/doom+
* [`b1266272`](https://github.com/doomemacs/core/commit/b1266272893a7d35a6d6ab89c893ed560ef45c0b) refactor(cli): remove lisp/cli/*.el from bin/doom loaddefs
* [`50bb54a6`](https://github.com/doomemacs/core/commit/50bb54a6ef8eca1cd4f385c62e7278e437bd170b) fix: which-key on first keypress in session
* [`dd44681c`](https://github.com/doomemacs/core/commit/dd44681c3207aefe9e4575befcbb0be9a9d32a8b) refactor(cli): cli/sh.el library
* [`81731351`](https://github.com/doomemacs/core/commit/81731351dce8f175f47c74d3679ddc78612e3335) refactor: clean up which-key config
* [`0412ed5e`](https://github.com/doomemacs/core/commit/0412ed5effbb4fd2b2001846a603a6343eea6f2a) revert: fix(cli): doom env: add tmpdir vars to default deny list
* [`7b240eb7`](https://github.com/doomemacs/core/commit/7b240eb7471499f15b3149944d2eaa6f18a85b0e) fix(cli): bin/doom-* loaddefs missing from doom-cli-loaddefs
* [`66162863`](https://github.com/doomemacs/core/commit/661628637f413876ec19291bbf9813658ca87229) fix(cli): doom info: emit info into current buffer
* [`bd25d982`](https://github.com/doomemacs/core/commit/bd25d9826d87d8188525bd7920a8efefa77060b8) refactor: use dlet more
* [`ed428133`](https://github.com/doomemacs/core/commit/ed428133663fb15ee7a8ea93af6fdbdd66f5f554) fix(cli): make autoloads in doom-cli-loaddefs relative
* [`7b59f8d2`](https://github.com/doomemacs/core/commit/7b59f8d2e088121bf123e3b429ad12c3ba3764b9) feat(cli): add $__DOOM_LOADDEFS_FILE envvar
* [`d5e0cbfc`](https://github.com/doomemacs/core/commit/d5e0cbfce5bb248879494d6ec162ec08b08230e8) bump: sources/doom+
* [`8a301d98`](https://github.com/doomemacs/core/commit/8a301d98d0d6d1aa7c54a8f8df48de7b2c886b2e) release: 2.2.1
* [`cdfaab08`](https://github.com/doomemacs/core/commit/cdfaab088d9543158e6873816523aca8243c52b5) revert: feat(cli): add $__DOOM_LOADDEFS_FILE envvar
* [`ac4035eb`](https://github.com/doomemacs/core/commit/ac4035eb497d53c500d04fc8231fad0034320b32) docs(cli): doom sync: warn user to restart daemon
* [`db52a1e4`](https://github.com/doomemacs/core/commit/db52a1e4b54339ffaa00dc4d14bd7b7c6a77e6f1) fix(cli): doom sync: don't sync profiles from non-default profile
* [`d05346fb`](https://github.com/doomemacs/core/commit/d05346fb721fb4c7efbefe0b56a4249ba1d41141) refactor(cli): doom profile: move doom-profile-cache-file
* [`32b881f9`](https://github.com/doomemacs/core/commit/32b881f9b7f59c3e65c9c6d42a7c0c4de7812092) fix(lib): pure/side-effect-free declarations
* [`d5289ac1`](https://github.com/doomemacs/core/commit/d5289ac15e8a805c56ce874b0230e6ff648d49f5) refactor: remove unused variables
* [`d5aae5a1`](https://github.com/doomemacs/core/commit/d5aae5a1da7f6735f5253523dd80d8133a02dbfe) refactor(lib): encapsulate doom-config API further
* [`6ba99cb5`](https://github.com/doomemacs/core/commit/6ba99cb50cddc4441963a0ef68f971112ab4807e) refactor(cli): doom: inline doom-loaddefs--scan-for-cli
