### PR TITLE
npins nixpkgs: update ba41c576 -> 3939c15d

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -125,9 +125,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "ba41c57689f1d839d9eeaea0952df4cc99682a45",
-      "url": "https://github.com/nixos/nixpkgs/archive/ba41c57689f1d839d9eeaea0952df4cc99682a45.tar.gz",
-      "hash": "sha256-TMqc8ZRqVosOOXjZ7HNSV51wImDQK6BkxwXYaUPkT+w="
+      "revision": "3939c15de1fe3ee41f23f0ae1710c3a375c99f21",
+      "url": "https://github.com/nixos/nixpkgs/archive/3939c15de1fe3ee41f23f0ae1710c3a375c99f21.tar.gz",
+      "hash": "sha256-RUHYwOMO4ENeDLSKlYeajjwn/d96h5rSCbBWpOVYHkE="
     },
     "powerlevel10k": {
       "type": "Git",


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@ba41c576...3939c15d](https://github.com/nixos/nixpkgs/compare/ba41c57689f1d839d9eeaea0952df4cc99682a45...3939c15de1fe3ee41f23f0ae1710c3a375c99f21)

* [`b3d1604a`](https://github.com/NixOS/nixpkgs/commit/b3d1604ae137eefd34c2f7878d4967fe18c33765) gradle: reduce keytool noise
* [`4e981782`](https://github.com/NixOS/nixpkgs/commit/4e981782ed4eb3adc047351a16821059154b50a1) guile-chickadee: ensure `chickadee` binary can resolve dynamic libaries via `LD_LIBARY_PATH`
* [`99c9e165`](https://github.com/NixOS/nixpkgs/commit/99c9e16523e4cbde1e49b6bea9c706da0bb05f43) apacheHttpd: make dependency on lynx optional
* [`0565c966`](https://github.com/NixOS/nixpkgs/commit/0565c966047ffa8a76f9a1baf5b3bdcab037ce7c) libmysofa: 1.3.3 -> 1.3.4
* [`e421e1d9`](https://github.com/NixOS/nixpkgs/commit/e421e1d99a93c21e67bc0025c677bebc9a4e4189) mame: use sdl3 directly; fix Darwin build
* [`7c074574`](https://github.com/NixOS/nixpkgs/commit/7c0745748a9f7811202a6b73fa4a56215cd6db3a) tests.makeBinaryWrapper: fix broken tests
* [`a536dcec`](https://github.com/NixOS/nixpkgs/commit/a536dcec6d57921bb1d86d093dae25f6df61994b) upower: 1.91.1 -> 1.91.2
* [`1be26a9f`](https://github.com/NixOS/nixpkgs/commit/1be26a9f6b65bf7fe145773774f33cddffd39b41) alibuild: 1.17.31 -> 1.17.42
* [`5e1d21dd`](https://github.com/NixOS/nixpkgs/commit/5e1d21ddf67d53d603c2fb24fca8eee770a751ca) python3Packages.stamina: 25.2.0 -> 26.1.0
* [`0b7b35fa`](https://github.com/NixOS/nixpkgs/commit/0b7b35fa8bc0334a3ae556246a19401c90e54254) systemtap-unwrapped: 5.4 -> 5.5
* [`ea774ba3`](https://github.com/NixOS/nixpkgs/commit/ea774ba3fa66d616f779b1e21cc9ccef4b6cdbd3) libsystemtap: 5.3 -> 5.5
* [`f5c3d4f9`](https://github.com/NixOS/nixpkgs/commit/f5c3d4f9ddc40164100270fdd9191c301f4774f2) nixos/vaultwarden: respect DATA_FOLDER override in backup service
* [`b3a0b192`](https://github.com/NixOS/nixpkgs/commit/b3a0b192711280d0f077c1b2da4795f3700c331d) geoclue2: 2.7.2 -> 2.8.1
* [`7b061019`](https://github.com/NixOS/nixpkgs/commit/7b0610191d9d28aa7b141b0137cdf55462e5c446) gmobile: 0.7.0 -> 0.7.1
* [`0db0f7c9`](https://github.com/NixOS/nixpkgs/commit/0db0f7c99ffb2ed9ba3a1c472d2dfcc1d415656c) terraform-docs: 0.22.0 -> 0.24.0
* [`efa3365f`](https://github.com/NixOS/nixpkgs/commit/efa3365f88d283857e61ef2ed7aa33c8c0375968) crossplane: migrate to pyproject
* [`206aba50`](https://github.com/NixOS/nixpkgs/commit/206aba50c0671f50ee53d2898dce713bb5f0c480) crossplane: use finalAttrs
* [`b16956ee`](https://github.com/NixOS/nixpkgs/commit/b16956eed45cd34ccc0bacb02ca8d7102291d3b3) cryptop: migrate to pyproject
* [`ba185709`](https://github.com/NixOS/nixpkgs/commit/ba1857095fd6fb35fabdafe858fe855773568d0d) gmp: enable assembly for aarch64-darwin
* [`e9b4b773`](https://github.com/NixOS/nixpkgs/commit/e9b4b773086ceae117321911f96f7ec2f2a9a0b3) vscode-extensions.42crunch.vscode-openapi: 4.40.0 -> 5.6.0
* [`6220e645`](https://github.com/NixOS/nixpkgs/commit/6220e645d5dd2dfabdb1e79be5eef7592a24a135) gnome-shell: patch to use host gjs, set strictDeps
* [`213d934e`](https://github.com/NixOS/nixpkgs/commit/213d934e3767ad9d5c5b0b9dc42348bd22042813) sushi: patch to use host gjs, set strictDeps
* [`c13af4fc`](https://github.com/NixOS/nixpkgs/commit/c13af4fcb5133514f4e8c18e81c3008fab2b446a) linuxKernel.packages.linux_7_0.tsme-test: 7.0.10-unstable-2022-12-07 -> 7.0.10-unstable-2026-02-09
* [`21e35e6a`](https://github.com/NixOS/nixpkgs/commit/21e35e6af8e41af4cb64c836211108cf549ec831) liblinear: mark as unsupported for static platforms
* [`6f3275cd`](https://github.com/NixOS/nixpkgs/commit/6f3275cd9c5e85d35587ac021c28c135697b03e6) mba6x_bl: mark broken for kernel >= 6.1
* [`54f9f79a`](https://github.com/NixOS/nixpkgs/commit/54f9f79ae6911e35fa473e7780667f62cedac868) source-sans: use installFonts
* [`8b41c4f0`](https://github.com/NixOS/nixpkgs/commit/8b41c4f055703fc69ae6582e68ebfa53d5bc05a9) nmap: fix static build
* [`ed9cec9d`](https://github.com/NixOS/nixpkgs/commit/ed9cec9d257d2a626c1fe9d0e37406b2cd292bb1) formats.libconfig: use structuredAttrs instead of passAsFile
* [`d68ab3b1`](https://github.com/NixOS/nixpkgs/commit/d68ab3b186068d5ede590ee65eb97e6ae0674415) pq-cli: 1.0.2-unstable-2025-04-10 -> 1.0.4
* [`ba9121f9`](https://github.com/NixOS/nixpkgs/commit/ba9121f9e25f5e1a9feca5b3daa0121b85e85092) read-it-later: 0.6.2 -> 0.6.3
* [`6b95de29`](https://github.com/NixOS/nixpkgs/commit/6b95de29eda49925c3bb5c39702e68831e508c2e) nixos/bind: print invalid config with lines
* [`c46f2f08`](https://github.com/NixOS/nixpkgs/commit/c46f2f08a0c5c31ffe2668c98c8de866af98aca7) vscode-extensions.ms-toolsai.datawrangler: 1.24.0 -> 1.24.2
* [`b791b85e`](https://github.com/NixOS/nixpkgs/commit/b791b85ec13f762eb8e4467618b9c08821962ab4) jbig2enc: 0.31 -> 0.32
* [`a8fd9ed4`](https://github.com/NixOS/nixpkgs/commit/a8fd9ed4a69cfe713b96ead44de794ab017a4f0f) binaryen: 129 -> 130
* [`0f9db2ae`](https://github.com/NixOS/nixpkgs/commit/0f9db2ae74e6783eef2d692c8f768caff2bd89e1) nixos/nfc-nci: remove forced module loading
* [`bec08ff3`](https://github.com/NixOS/nixpkgs/commit/bec08ff32ea284caea70776e9f505056b7a2507b) solaar: 1.1.19 -> 1.1.20
* [`e4f64d8f`](https://github.com/NixOS/nixpkgs/commit/e4f64d8fb514678c59ebb7eeae47a79e06e9cdda) trayscale: add macOS application bundle
* [`32c3bbd5`](https://github.com/NixOS/nixpkgs/commit/32c3bbd5b688955ebb06931c8f38caecd03d4ddc) sourceHighlight: patch to fix build with gcc 16
* [`2ce153e2`](https://github.com/NixOS/nixpkgs/commit/2ce153e20d7e5170681c4f9800514bcd86ff1d2e) libfaketime: add patch for gcc 16
* [`14700de3`](https://github.com/NixOS/nixpkgs/commit/14700de3afdcead99fa2d71d0b7af934e2d97a77) onetbb: never treat warnings as fatal
* [`5cc1bf97`](https://github.com/NixOS/nixpkgs/commit/5cc1bf97155c9ff2cf6534473966b5755a273d9e) grub2_efi: apply patch for gcc 16
* [`a92c44f0`](https://github.com/NixOS/nixpkgs/commit/a92c44f00f61f21d791e2b2ef28e6bbad15532e8) vscode-extensions.amazonwebservices.amazon-q-vscode: 2.3.0 -> 2.4.0
* [`4a2acc3c`](https://github.com/NixOS/nixpkgs/commit/4a2acc3c769c7a0c92e5d1a3661b0883abea73c0) toml11: make maybe-uninitialized non-fatal for gcc 16
* [`0885fb7f`](https://github.com/NixOS/nixpkgs/commit/0885fb7fa1163a2cabba85281c2faed92de4da47) iaito: 6.1.6 -> 6.1.8
* [`c4df48e4`](https://github.com/NixOS/nixpkgs/commit/c4df48e4e22af2fa166c129edfeec07c5f7b4a42) glog: disable optimization-dependent stacktrace test
* [`65d32de5`](https://github.com/NixOS/nixpkgs/commit/65d32de56d080553f7fd20075ae7a51cfd50ff29) opencommit: 3.2.19 -> 3.3.9
* [`18d8eb67`](https://github.com/NixOS/nixpkgs/commit/18d8eb673884f3368249f0f27303a7f1b8f29080) gpxsee: 16.9 -> 16.11
* [`537be29b`](https://github.com/NixOS/nixpkgs/commit/537be29ba3d932c0155e93f3038cd552da92bfc3) foxglove-studio: 2.49.0 -> 2.56.0
* [`83024e02`](https://github.com/NixOS/nixpkgs/commit/83024e02237ed6aa047f63ef66e88708510ccdbf) pioasm: 2.2.0 -> 2.3.0
* [`df914c22`](https://github.com/NixOS/nixpkgs/commit/df914c22706feea26890cce0f4d8c2d09b3db7b9) wayback: 0.20.1 -> 0.21.1
* [`bfd1d30b`](https://github.com/NixOS/nixpkgs/commit/bfd1d30bf983cd01135123a0a9dc9a4ee8af6aeb) ratty: 0.4.2 -> 0.5.0
* [`32593983`](https://github.com/NixOS/nixpkgs/commit/3259398327131f38738e0971c8eca677f2df24de) libtiff: 4.7.1 -> 4.7.2
* [`4e28403d`](https://github.com/NixOS/nixpkgs/commit/4e28403d673e4260ef35036f6c38038dbab22b3b) picotool: 2.2.0-a4 -> 2.3.0
* [`fd40d7c1`](https://github.com/NixOS/nixpkgs/commit/fd40d7c13450209aa06bd4c95e316898a64498d0) openexr: 3.4.11 -> 3.4.13
* [`d0664894`](https://github.com/NixOS/nixpkgs/commit/d066489411b1a54f4243fe9b816dd0c06f1b7c70) doctest: 2.5.2 -> 2.5.3
* [`37ba5520`](https://github.com/NixOS/nixpkgs/commit/37ba552065b39d6cb2fa475603bbd8f818a3f4ea) nixos/eval-config: remove deprecated extraArgs and check parameters
* [`12c92e5c`](https://github.com/NixOS/nixpkgs/commit/12c92e5c7ed2c3dd5a9491eab68ba0a9e8283a9b) vscode-extensions.biomejs.biome: 2026.6.181955 -> 2026.7.60717
* [`6b905e28`](https://github.com/NixOS/nixpkgs/commit/6b905e28e3d559d714d90081f91c986bc096900d) scdoc: 1.11.4 -> 1.11.5
* [`509c4ef6`](https://github.com/NixOS/nixpkgs/commit/509c4ef63f1bf513ef100477bbc360f04d34d934) qbittorrent-nox: 5.2.2 -> 5.2.3
* [`affcb204`](https://github.com/NixOS/nixpkgs/commit/affcb204fbf9c13db67675cb85168c2c01a6bdda) linux-router-without-wifi: 0.8.1 -> 0.8.2
* [`d14289b4`](https://github.com/NixOS/nixpkgs/commit/d14289b44548ffacf8503650acd977a307cb2c6d) xvfb: 21.1.23 -> 21.1.24, drop rebuild avoidance
* [`9539e138`](https://github.com/NixOS/nixpkgs/commit/9539e138083dfa7435a7289b120996982f0c2600) bitcoin: 31.0 -> 31.1
* [`2356d4e7`](https://github.com/NixOS/nixpkgs/commit/2356d4e708e3a4ad4cb3cd6bb196d2fef78af3d8) libmodsecurity: 3.0.15 -> 3.0.16
* [`ccf6ab0b`](https://github.com/NixOS/nixpkgs/commit/ccf6ab0bff548155f513ea551dca4e9e13620f88) sgx-psw: 2.27 -> 2.29; nixos/aesmd: update
* [`5526f30e`](https://github.com/NixOS/nixpkgs/commit/5526f30e5aced751a1c48f11d9114d9749b0e0ec) tzdata: 2026b -> 2026c
* [`ee3d936b`](https://github.com/NixOS/nixpkgs/commit/ee3d936b51e926a6a498de91df4cc15720947f64) balena-compose-parser: init at 0.2.6
* [`b60fec09`](https://github.com/NixOS/nixpkgs/commit/b60fec097126ea92c298f3de51ee8add75d86505) balena-cli: install `balena-compose-parser` binary into `@⁠balena/compose-parser`
* [`34374517`](https://github.com/NixOS/nixpkgs/commit/3437451776ae2e80bf37c4846dc90a37b0c8dbfa) darwin.xcode: add 26.6
* [`35bc5963`](https://github.com/NixOS/nixpkgs/commit/35bc5963173e21d180dcc5b710bfa529de227a31) systemd: 261 -> 261.1
* [`9508ddad`](https://github.com/NixOS/nixpkgs/commit/9508ddad2bc47296254da425127ff1b2d9b4c9c9) fontconfig: 2.18.1 -> 2.18.2
* [`df13b3e4`](https://github.com/NixOS/nixpkgs/commit/df13b3e4a4813eb24ebf7a43824505f7a63120d8) libressl: Actually utilize cacert
* [`f186affb`](https://github.com/NixOS/nixpkgs/commit/f186affb81e3a868e0b703c94b39e5756ec6957a) libressl: Test for cacert binary match
* [`5614859b`](https://github.com/NixOS/nixpkgs/commit/5614859b5ae42fe612f0bf24a47e08d2076c09a5) graphviz-nox: 14.1.2 -> 15.1.0
* [`d88eb9f1`](https://github.com/NixOS/nixpkgs/commit/d88eb9f1717da48ae255788838d782ec4d0de63c) findutils: 4.10.0 -> 4.11.0
* [`9b1e8ee8`](https://github.com/NixOS/nixpkgs/commit/9b1e8ee851d08b19452e59f3e3219c00df0c1059) stax: 0.37.0 -> 0.74.0
* [`12babd1e`](https://github.com/NixOS/nixpkgs/commit/12babd1e2a87b0eb1147e4dc3acf69707dfd5b91) libsodium: 1.0.22-unstable-2026-04-16 -> 1.0.22-unstable-2026-07-08
* [`2c64ad16`](https://github.com/NixOS/nixpkgs/commit/2c64ad166ce92c0049daf75f3a5623e2d85a2a3a) weasis: 4.6.6 -> 4.7.1
* [`cbd66b68`](https://github.com/NixOS/nixpkgs/commit/cbd66b68e2eeebccd29d17927e5e3e51397e7cf7) libffiReal: 3.7.0 -> 3.7.1
* [`5964572d`](https://github.com/NixOS/nixpkgs/commit/5964572d17730bf5569fcc11926928298fd05efc) libffiReal: add aduh95 as maintainer
* [`5b3b2601`](https://github.com/NixOS/nixpkgs/commit/5b3b260188eea44cb994f164a14f045101e39691) vscode-extensions.kddejong.vscode-cfn-lint: 0.26.6 -> 0.27.0
* [`6204aa29`](https://github.com/NixOS/nixpkgs/commit/6204aa2983578ae637ad0d4a52eb5a8aca97a12b) ethtool: 7.0 -> 7.1
* [`80131825`](https://github.com/NixOS/nixpkgs/commit/801318251c6ecaf2a3179c736398887f6a0e966f) percona-server: 8.4.8-8 -> 8.4.10-10
* [`de2ab905`](https://github.com/NixOS/nixpkgs/commit/de2ab9052f95a890ba0c2dd7ec6da8c91191ee31) vscode-extensions.dart-code.dart-code: 3.136.1 -> 3.138.0
* [`eb062080`](https://github.com/NixOS/nixpkgs/commit/eb062080d04766dd3e2cf5dbb418018b9b47a7c4) ddhx: 0.10.0 -> 0.11.0
* [`9f15ca6d`](https://github.com/NixOS/nixpkgs/commit/9f15ca6df1b6d752e0cf75dff9e4731c92fce3bc) armadillo: 15.2.3 -> 15.4.1
* [`02cdacd8`](https://github.com/NixOS/nixpkgs/commit/02cdacd8266bc012b1b740635c11d73071a13b37) cudaPackages.nccl-tests: 2.19.1 -> 2.19.6
* [`cb1152a4`](https://github.com/NixOS/nixpkgs/commit/cb1152a48d68f17371c0eabfb9695f4e851f1377) python3Packages.triton.gpuCheck: fix failing tests
* [`22bd0fa8`](https://github.com/NixOS/nixpkgs/commit/22bd0fa8fb0214f17fbe79dac72cc729605de5dc) ocamlPackages.wayland: 2.2 -> 2.3
* [`5ab5bf98`](https://github.com/NixOS/nixpkgs/commit/5ab5bf9818b7f54d67e9fe74194ea69d7eef534d) wayland-proxy-virtwl: 0-unstable-2026-04-16 -> 0-unstable-2026-07-08
* [`4e046963`](https://github.com/NixOS/nixpkgs/commit/4e046963da267269fa1fe18fd322dc39b14ec0b3) wox: 2.2.0 -> 2.3.0
* [`5072d98c`](https://github.com/NixOS/nixpkgs/commit/5072d98cd0b0a77a8a45cc293f221b4dd2788e9b) python3Packages.ament-package: 0.19.0 -> 0.19.1
* [`55781a05`](https://github.com/NixOS/nixpkgs/commit/55781a05ed00e68a43223952cf8f98c28b5ec170) gn: 0-unstable-2026-04-01 -> 0-unstable-2026-05-27
* [`4db39131`](https://github.com/NixOS/nixpkgs/commit/4db391310c4fbba099f0683f83cf7feb6cbb9d9e) python3Packages.rich-rst: 2.0.2 -> 2.1.0
* [`af4ee80f`](https://github.com/NixOS/nixpkgs/commit/af4ee80f56ddcdfc42b07a1c7cafa2c300ecce6d) wealthfolio: 3.6.1 -> 3.6.2
* [`60451d9f`](https://github.com/NixOS/nixpkgs/commit/60451d9fcf5531a68fa146555189a5782f1289e6) sox: fix version scheme
* [`df080976`](https://github.com/NixOS/nixpkgs/commit/df0809760cafcbb215f566f33227560605a6a3e4) sox: Remove src.name since going trough staging
* [`af253c90`](https://github.com/NixOS/nixpkgs/commit/af253c905aa77ac05f4c4b220ad3753f13017a93) libapparmor: 5.0.1 -> 5.0.2
* [`50d878de`](https://github.com/NixOS/nixpkgs/commit/50d878deeef7da3125f8eed14efbffee1a402403) sox: use finalAttrs
* [`aaee0af2`](https://github.com/NixOS/nixpkgs/commit/aaee0af229c4c7c5b617e954dcf1df7cba84c478) nixos-artwork.wallpapers: fix incorrect pname
* [`bc4d862e`](https://github.com/NixOS/nixpkgs/commit/bc4d862eba126b12f6849a1bb22fe606f067677b) nixos-artwork.wallpapers: add KDE Plasma 6 support
* [`27ffce9d`](https://github.com/NixOS/nixpkgs/commit/27ffce9d573933f2931e7061e6e2cea00ca1797d) nixos-enter: set pname and version
* [`1c34bdfe`](https://github.com/NixOS/nixpkgs/commit/1c34bdfe4cc2374dafefd2454eb39f8e798f2d6c) nixos-install: set pname and version
* [`5dbb5ece`](https://github.com/NixOS/nixpkgs/commit/5dbb5ece48b017ffd495930c7a8e8289c0a4f527) libgpg-error: Fix t-printf test on some platforms, patch around failures on others
* [`35121883`](https://github.com/NixOS/nixpkgs/commit/351218832216acf809d37bc92dde583eb6e03c41) yara: 4.5.6 -> 4.5.7
* [`4b309135`](https://github.com/NixOS/nixpkgs/commit/4b309135ab26e150db4679bcd1f5eea6c644e294) nixos-build-vms: set pname and version
* [`15f04744`](https://github.com/NixOS/nixpkgs/commit/15f04744d9d1b35d302c9d7e91684a9ccc874d8d) nixos-container: set pname and version
* [`f5429bc2`](https://github.com/NixOS/nixpkgs/commit/f5429bc2df4060e532300bab5dc543d724835190) filius: 2.12.1 -> 2.13.0
* [`2ddd87e9`](https://github.com/NixOS/nixpkgs/commit/2ddd87e93bb34b4cb5075d797754cebda5a168f4) mkShell: don't allow substitutes by default
* [`09218284`](https://github.com/NixOS/nixpkgs/commit/0921828452678acc291dfebb8acb9acdc3af935a) pico-sdk: 2.2.0 -> 2.3.0
* [`3bd37f85`](https://github.com/NixOS/nixpkgs/commit/3bd37f85e2b936bd9a018dafd037446de2760464) runCommandWith: move default lists to higher scope
* [`7f6463e1`](https://github.com/NixOS/nixpkgs/commit/7f6463e135d037805c449beca196d06a38b53622) runCommandWith: stop doing a no-op merge
* [`067ef31e`](https://github.com/NixOS/nixpkgs/commit/067ef31e04b759e5e8445ecd8519efe5818dd577) writeTextFile: move default lists to higher scope
* [`9e680274`](https://github.com/NixOS/nixpkgs/commit/9e680274fe07ab7ea6e4bd28eac802d9fd236856) symlinkJoin: move function to higher scope
* [`b4907bda`](https://github.com/NixOS/nixpkgs/commit/b4907bdaa73f2a0da447ac2af2d3f4a072b0092c) symlinkJoin: move lists to higher scope
* [`0ffa8a6b`](https://github.com/NixOS/nixpkgs/commit/0ffa8a6b3a6ad5bfc53ca4b858414f947eb6f28c) symlinkJoin: prevent no-op merge
* [`4379e9a0`](https://github.com/NixOS/nixpkgs/commit/4379e9a0d400fbd93f992cdcbe0e17deb95ec133) trivial-builders: partially apply hasPrefix calls
* [`e1521ee4`](https://github.com/NixOS/nixpkgs/commit/e1521ee42f94ab76e07d381e43ab7b0293b2d6ae) pico-sdk: update withSubmodules hash automatically
* [`21bd18d7`](https://github.com/NixOS/nixpkgs/commit/21bd18d769409117dc732aa80934f7377759eba0) miniupnpd: 2.3.9 -> 2.3.10
* [`26482ee8`](https://github.com/NixOS/nixpkgs/commit/26482ee87c2bf3518c64a6d65c2c388eb99d91da) nixos/tests/systemd-boot: Preserve length in sed
* [`02e0629f`](https://github.com/NixOS/nixpkgs/commit/02e0629f5777108112bc92d98e9550012efe30ae) nixos/lib/systemd-lib: remove optionalAttrs chain
* [`e0471652`](https://github.com/NixOS/nixpkgs/commit/e047165213f0897f6dd3596bd31af7fe18642016) vvenc: fix pkg-config paths
* [`d632c4d4`](https://github.com/NixOS/nixpkgs/commit/d632c4d40029bf5f926271e6c6a001313195e117) python3Packages.requests-hardened: 1.2.2 -> 1.3.0
* [`089e996b`](https://github.com/NixOS/nixpkgs/commit/089e996b666a9ee1e66b106bced2320be74554fb) keycloak.plugins.keycloak-2fa-sms-authenticator: 26.4.10 -> 26.6.5
* [`b0ec0535`](https://github.com/NixOS/nixpkgs/commit/b0ec0535e11d6d0af6128500ad3792ddeeae03d5) keycloak.plugins.keycloak-enforce-mfa-authenticator: 26.4.10 -> 26.6.5
* [`c76151c2`](https://github.com/NixOS/nixpkgs/commit/c76151c2259356feb9b1d40d9af3a7f23d3fb660) keycloak.plugins.keycloak-magic-link: 0.52 -> 0.74
* [`838e2790`](https://github.com/NixOS/nixpkgs/commit/838e2790ae5642ce296a87080b0c61e12a6b5db0) keycloak.plugins.keycloak-orgs: 0.126 -> 0.168
* [`928ff850`](https://github.com/NixOS/nixpkgs/commit/928ff850cba8f7f21971930eb4eb110d435b281b) keycloak.plugins.keycloak-discord: fix build with maven 3.9.16
* [`21933a21`](https://github.com/NixOS/nixpkgs/commit/21933a219ef51e262949dd851b3e3905d48e495c) keycloak.plugins.keycloak-remember-me-authenticator: fix build with maven 3.9.16
* [`a7dff89c`](https://github.com/NixOS/nixpkgs/commit/a7dff89c8a7054043087c0c0b7d1843be98360b9) keycloak.plugins.keycloak-restrict-client-auth: fix build with maven 3.9.16
* [`bd2940cc`](https://github.com/NixOS/nixpkgs/commit/bd2940cc0313f090127956e008a748abc24aa1fc) keycloak.plugins.keycloak-secrets-vault-provider: modernize
* [`f40ea516`](https://github.com/NixOS/nixpkgs/commit/f40ea516dc68b8bbf51d59559690b4385b149c46) keycloak.plugins.keycloak-2fa-app-authenticator: init at 26.6.5
* [`523c0c68`](https://github.com/NixOS/nixpkgs/commit/523c0c68674c758b88907e7a343798c63e2e537c) keycloak.plugins.keycloak-2fa-email-authenticator: init at 26.6.5
* [`b8e3bc8e`](https://github.com/NixOS/nixpkgs/commit/b8e3bc8ec68bdff655707bc8589e7b71abe37828) keycloak.plugins: factor out shared netzbegruenung MFA builder
* [`210d0877`](https://github.com/NixOS/nixpkgs/commit/210d0877af3478da39d1d1e269a68a38b52b4511) keycloakPlugins: init
* [`d14ec645`](https://github.com/NixOS/nixpkgs/commit/d14ec64548c403f0105987a2fc03c152b7f2ca28) ausweisapp: 2.5.3 -> 2.5.4
* [`56074fde`](https://github.com/NixOS/nixpkgs/commit/56074fdee9ea4d2b54ddde1a1906d4911c8fbec4) quill-log: 12.0.0 -> 12.1.0
* [`b968df7e`](https://github.com/NixOS/nixpkgs/commit/b968df7e7e9f6dea6d66620e7798543ef62b821d) linux-exploit-suggester: fix pname
* [`dbd0f871`](https://github.com/NixOS/nixpkgs/commit/dbd0f87198dc2b9d61997027a4ca1f689f89f0b7) spirv-tools: backport fix for crash on newer Vulkan
* [`370f7e51`](https://github.com/NixOS/nixpkgs/commit/370f7e5169e286472bde62dde7c028179d77cce3) hamlib_4: 4.7.1 -> 4.7.2
* [`b84f21ed`](https://github.com/NixOS/nixpkgs/commit/b84f21ed2ccfe3ad9459ad8fcb7ef73ecf419b8d) python3Packages.labelbox: 7.8.0 -> 7.9.0
* [`74444fb4`](https://github.com/NixOS/nixpkgs/commit/74444fb4e5b72142bc546530ae3b7a5540b73022) chromium: remove no longer needed version conditionals
* [`2213bc07`](https://github.com/NixOS/nixpkgs/commit/2213bc070c67753bfee08241b6e934b6b78d4033) chromium: remove warnObsoleteVersionConditional
* [`4893b4e9`](https://github.com/NixOS/nixpkgs/commit/4893b4e92dbd3858eae5624f290ec49512dcbdf8) rust: 1.97.0 -> 1.97.1
* [`bfad0596`](https://github.com/NixOS/nixpkgs/commit/bfad0596435443e2aaa6bff61f3db41de5bf4424) python3Packages.envisage: 7.0.4 -> 7.0.4-unstable-2026-07-07
* [`d1f0bc16`](https://github.com/NixOS/nixpkgs/commit/d1f0bc168f035d5e180a3529a7a7546b59062d21) vscode-extensions.betterthantomorrow.calva: 2.0.593 -> 2.0.594
* [`50e42b2d`](https://github.com/NixOS/nixpkgs/commit/50e42b2d6c84d54f0c40d88eb4e54c171549d87a) xsimd: 14.2.0 -> 14.3.0
* [`33f1076b`](https://github.com/NixOS/nixpkgs/commit/33f1076b16c9ee1ffe9e8b7c667b231e1cd2620d) fluidsynth: 2.5.5 -> 2.5.6
* [`700c47a5`](https://github.com/NixOS/nixpkgs/commit/700c47a50451a3ab4000954f363a5ccbaf35fb94) tree-sitter-grammars.tree-sitter-wit: 1.3.0 -> 1.4.0
* [`68a131f6`](https://github.com/NixOS/nixpkgs/commit/68a131f652e821c0f26995927e686448b590bfda) fluidsync: add meta.changelog
* [`3ab68ce9`](https://github.com/NixOS/nixpkgs/commit/3ab68ce9e32e056c2107887e046128cf7bc480e0) vivaldi: use bundled libffmpeg.so instead of nixpkgs ffmpeg
* [`5240ad85`](https://github.com/NixOS/nixpkgs/commit/5240ad85d7b3d396db235836fa58f6dc6d20043a) vscode-extensions.antfu.slidev: 52.15.0 -> 52.18.0
* [`fc438784`](https://github.com/NixOS/nixpkgs/commit/fc43878475cd978e5996a73e9d9d952ded17f404) wechat-uos: fix download by adding User-Agent header
* [`4f116ee1`](https://github.com/NixOS/nixpkgs/commit/4f116ee1e497d1b2f09195a75739ac974a66d8e6) mbedtls: fix cross build
* [`5575434e`](https://github.com/NixOS/nixpkgs/commit/5575434e6d84d3d433936052aa4b5f0615ad888b) dovecot: disable tests on 32-bit to fix build
* [`b030adbe`](https://github.com/NixOS/nixpkgs/commit/b030adbe571c302949c5dfed00a4851e5c219bed) python3Packages.geopy: 2.4.1 -> 2.5.0
* [`0b99f61e`](https://github.com/NixOS/nixpkgs/commit/0b99f61e568d0f6712ebb3982610a5dd8b7cc3a1) python314Packages.filelock: add another timeout sensitive test file
* [`4c4644e4`](https://github.com/NixOS/nixpkgs/commit/4c4644e487e28df2400e148cba2858e1f18659f7) python314Packages.sh: ignore timing sensitive tests
* [`449b91ed`](https://github.com/NixOS/nixpkgs/commit/449b91edfb1d63815dd825f356a94cb3dc446817) flatpak-builder: fix building with svg icons
* [`03fdd7b0`](https://github.com/NixOS/nixpkgs/commit/03fdd7b0557f03609f9d5e269460231912c5d7ed) python3Packages.ansible: 14.1.0 -> 14.2.0
* [`5b1b4307`](https://github.com/NixOS/nixpkgs/commit/5b1b43076eee4720ea4f484c0a9d0d5f56713feb) rufin: 0.8.0 -> 0.9.0
* [`b4f5b4ef`](https://github.com/NixOS/nixpkgs/commit/b4f5b4ef7f8eb71efac80a712ca1ed9b9580a0fd) aerospace: 0.21.2-Beta -> 0.21.3-Beta
* [`0e0204bf`](https://github.com/NixOS/nixpkgs/commit/0e0204bf39e5ef1f4baffa97d15d338a9ae04df9) python3Packages.faust-cchardet: 2.1.19 -> 2.1.20
* [`226af3ac`](https://github.com/NixOS/nixpkgs/commit/226af3aca7508c59e65aca5ba54894356f41f2ea) fsnav: add darwin to supported platforms
* [`b20b61a5`](https://github.com/NixOS/nixpkgs/commit/b20b61a5d80116506431e6f8ed3604fe8b3a1420) fsnav: cleanup derivation
* [`64b0e245`](https://github.com/NixOS/nixpkgs/commit/64b0e245396b1617a2a859945d3ca9085785a74e) apache-orc: 2.3.0 -> 2.3.1
* [`441a0046`](https://github.com/NixOS/nixpkgs/commit/441a0046695058c1c11b39cd09db61e1b10ca3bc) python3Packages.lmdb: 2.2.1 -> 2.3.0
* [`412579fa`](https://github.com/NixOS/nixpkgs/commit/412579fa0cb95f1e6e6fc32d67808f705d6b807f) protobuf_{21,25,27,29,30,31}: fix 32-bit build
* [`074f3053`](https://github.com/NixOS/nixpkgs/commit/074f3053d13f6b2f6ce650de9b6e9af78fcd3e0d) coqPackages.coq-lsp: include `pet-server` and wrap all binaries
* [`36077ec8`](https://github.com/NixOS/nixpkgs/commit/36077ec8f885d97b4c106c6aa41522884184788b) python3Packages.rf-protocols: remove dependency on prek
* [`df6f1df4`](https://github.com/NixOS/nixpkgs/commit/df6f1df4355d8f11622820f23fde534f1b100815) weechat-matrix-rs: 0-unstable-2025-10-09 -> 0-unstable-2026-07-16
* [`007ea29d`](https://github.com/NixOS/nixpkgs/commit/007ea29d17cdd15d65c3641489c4992153e3eabc) mbedtls: 3.6.6 -> 3.6.7
* [`67204887`](https://github.com/NixOS/nixpkgs/commit/67204887a8063f488e9077aa4c9da7946d9de780) mbedtls_4: 4.1.0 -> 4.2.0
* [`b843237b`](https://github.com/NixOS/nixpkgs/commit/b843237b4c1fdff035ce5ff9463205ed9b062741) solaar: set `__structuredAttrs`, add changelog
* [`a4583618`](https://github.com/NixOS/nixpkgs/commit/a45836187bcb807cdce1b81ac51d7804f9b79d51) solaar: add ilkecan to maintainers
* [`781c3e5b`](https://github.com/NixOS/nixpkgs/commit/781c3e5b32880fe0c40fc3c8772ce4c32dd8e81f) systemtap-unwrapped: enable __structuredAttrs, strictDeps
* [`9d034b39`](https://github.com/NixOS/nixpkgs/commit/9d034b39c9cc414694868fff8b699b06cc8854e1) vscode-extensions.ms-vscode-remote.remote-containers: 0.459.1 -> 0.466.0
* [`4331ea9f`](https://github.com/NixOS/nixpkgs/commit/4331ea9fd7dd65dcbfae3f6f78dc2d662c91736a) angular-language-server: 21.2.2 -> 22.0.1
* [`1c9ab4f5`](https://github.com/NixOS/nixpkgs/commit/1c9ab4f50792a6fb1dfeb33809d8333264e9fa6b) nixos/stash-clipboard: allow setting service arguments
* [`d16f4179`](https://github.com/NixOS/nixpkgs/commit/d16f417901796e2055a8b21b4a246eebf23f0caa) stash-clipboard: create symlinks by default
* [`b8849050`](https://github.com/NixOS/nixpkgs/commit/b8849050c9063d723bde55e220c2834871f1063e) hdrhistogram_c: unconditionalize patch
* [`f90532ca`](https://github.com/NixOS/nixpkgs/commit/f90532cae4fd234b97913b10a1d4fe5511eaf903) isponsorblocktv: 2.6.1 -> 2.10.0
* [`21057e59`](https://github.com/NixOS/nixpkgs/commit/21057e59ed39c6eabb6237f3d1d9b50f58387dd7) fmd-server: use pnpm_11, fix fetchPnpmDeps pnpm locking, adopt
* [`183da973`](https://github.com/NixOS/nixpkgs/commit/183da9734f3091bc8284cef5bd32a46b5b70627c) modrinth-app: fix build
* [`4e31eef3`](https://github.com/NixOS/nixpkgs/commit/4e31eef320450491f1984dc8d747da838b15d4c4) alot: 0.11 -> 0.12
* [`9652e133`](https://github.com/NixOS/nixpkgs/commit/9652e1332dde25759901369a315c665da85fb214) cacert: 3.125 -> 3.126
* [`4e9e3578`](https://github.com/NixOS/nixpkgs/commit/4e9e357815254bb52d4b72ea69ff8c3c7d3c1d44) fetchers: add fetchFromHuggingFace
* [`8c16aa03`](https://github.com/NixOS/nixpkgs/commit/8c16aa031cdebf664213ba4be684c5a6a49183ef) lug-helper: 4.13 -> 4.14
* [`1d221105`](https://github.com/NixOS/nixpkgs/commit/1d2211050751ea37a172b259443567887b326109) pacu: 1.6.2 -> 1.7.0, drop sqlalchemy v1.4
* [`4f89b254`](https://github.com/NixOS/nixpkgs/commit/4f89b254c8c290d20dcbfb53c51287fc7f84690e) kubeconform: 0.7.0 -> 0.8.0
* [`4643de13`](https://github.com/NixOS/nixpkgs/commit/4643de1365037be5ed44eb406ad1a392e3d0a0cc) rivalcfg: 4.15.0 → 4.17.0
* [`d3ea2a31`](https://github.com/NixOS/nixpkgs/commit/d3ea2a3180dab2b836565a2136cf3c0788ca80ef) python3Packages.matplotlib: 3.11.0 -> 3.11.1
* [`fa8127e5`](https://github.com/NixOS/nixpkgs/commit/fa8127e51afd2f94032e41ae00a5530142298c66) obs-wayland-hotkeys: 1.1.0 -> 1.1.1
* [`3278ab71`](https://github.com/NixOS/nixpkgs/commit/3278ab71fddfae3636935adaf5b09ae4fcc372c3) kew: 4.1.8 -> 4.2.7
* [`2f70457b`](https://github.com/NixOS/nixpkgs/commit/2f70457b5e145f217c4bb743da5b587522019627) python3Packages.ray: 2.56.0 -> 2.56.1
* [`16228224`](https://github.com/NixOS/nixpkgs/commit/162282246652bff6a2f80d5fd7ebfeac9cb4885a) borgbackup: 1.4.4 -> 1.4.5
* [`be8bc646`](https://github.com/NixOS/nixpkgs/commit/be8bc646d4426b513e034388760ab826ac81aef7) python3Packages.multipart: 1.3.1 -> 2.0.0
* [`80d7920b`](https://github.com/NixOS/nixpkgs/commit/80d7920bddf598391f6321de783d8c1dcac9df3b) python3Packages.multipart: use finalAttrs
* [`ed1ce88d`](https://github.com/NixOS/nixpkgs/commit/ed1ce88df90daf40b21ad3b5fda28c16536635ff) python3Packages.bincopy: enable tests
* [`3fe0244f`](https://github.com/NixOS/nixpkgs/commit/3fe0244f3b11bbf6d316e4a24ba1b48ffa1d7cea) python3Packages.clarabel: enable tests
* [`79a0d176`](https://github.com/NixOS/nixpkgs/commit/79a0d1767d0b8b687e7f147f870465b8bd75655c) python3Packages.clarabel: use finalAttrs
* [`339a5cf6`](https://github.com/NixOS/nixpkgs/commit/339a5cf6de7d76347f106fc0adf43f2591aa33f4) python3Packages.click-log: enable tests
* [`7f253265`](https://github.com/NixOS/nixpkgs/commit/7f25326568afd89a5cb0844084d7e1e7ecc04234) wootility: 5.3.2 -> 5.4.1
* [`ec5218c4`](https://github.com/NixOS/nixpkgs/commit/ec5218c4b6574091ed3e29e5858d57ae6d924542) kitty: fix libxkbcommon runtime lookup
* [`6065ca97`](https://github.com/NixOS/nixpkgs/commit/6065ca97dc6febb148997230872f953ed7adfee7) tree-sitter-grammars.tree-sitter-qmljs: 0.3.0 -> 0.3.1
* [`9c922bf5`](https://github.com/NixOS/nixpkgs/commit/9c922bf55afcbdfd442244989a9464f9be5314cd) yams: use buildPythonApplication
* [`b3c8e28e`](https://github.com/NixOS/nixpkgs/commit/b3c8e28eeffc139c6c618415b6af3072d3a97009) yams: use finalAttrs
* [`5e9b29e3`](https://github.com/NixOS/nixpkgs/commit/5e9b29e3e8cbd1f7d375971938308ad801a8c108) yams: use tag and SRI hash in src
* [`77056ce8`](https://github.com/NixOS/nixpkgs/commit/77056ce88a7dea06f75f62b6f46e9f5baa2176e7) yams: remove `doCheck = false`
* [`ebacc39c`](https://github.com/NixOS/nixpkgs/commit/ebacc39c0b83efe74f617d555c82422b07f6a5d5) yams: adopt by acidbong
* [`593526ba`](https://github.com/NixOS/nixpkgs/commit/593526ba2a0bdefeb68d9475759f59c7a7e43e52) ndi-6: 6.3.1.0 -> 6.3.2.0
* [`ed201646`](https://github.com/NixOS/nixpkgs/commit/ed20164679d7997c2e531a667051855f4b29d3a7) hercules: 4.8 -> 4.9.1
* [`f9e9e895`](https://github.com/NixOS/nixpkgs/commit/f9e9e8955256a004c44f43e2c3ccc7375012ef4c) python3Packages.css-parser: enable tests
* [`024cb923`](https://github.com/NixOS/nixpkgs/commit/024cb92304f6d787fc5b82af1c5c0194b5d61c83) python3Packages.css-parser: migrate to pyproject
* [`54697f38`](https://github.com/NixOS/nixpkgs/commit/54697f38c6d48c6318b5e43611a59bf255742cb9) python3Packages.css-parser: use finalAttrs
* [`eaaeed2a`](https://github.com/NixOS/nixpkgs/commit/eaaeed2a57e7161933d7f059e9c11c9c770d2095) prek: 0.4.4 -> 0.4.10
* [`09dc6df6`](https://github.com/NixOS/nixpkgs/commit/09dc6df6646aab26ac91c2b59c6a50fd5dcbb6eb) maintainers: add malix
* [`3f94089d`](https://github.com/NixOS/nixpkgs/commit/3f94089ddaa7fa12addeddf58112471cc9314de9) bcc: 0.36.1 -> 0.37.0
* [`90c2cdec`](https://github.com/NixOS/nixpkgs/commit/90c2cdecb05a2e44bcd91901b9823ac05bbf8008) llvmPackages_git: 23.0.0-unstable-2026-07-12 -> 23.1.0-rc1
* [`73c0a1b3`](https://github.com/NixOS/nixpkgs/commit/73c0a1b3237e9682c5342d6880417d535ac64d13) esh: modernize
* [`acccf0fd`](https://github.com/NixOS/nixpkgs/commit/acccf0fdbf17421c9a940508114289362e788854) llvmPackages_23: init from git
* [`505ba675`](https://github.com/NixOS/nixpkgs/commit/505ba675fe6d58b1b9c9d8e71bbbfb697def7806) llvmPackages_git: 23.0.0-unstable-2026-07-12 -> 24.0.0-unstable-2026-07-19
* [`a8fdd07f`](https://github.com/NixOS/nixpkgs/commit/a8fdd07f3bb3f4ea6fe14964c8cdd6c756c63710) python3Packages.langchain: 1.3.13 -> 1.3.14
* [`06bffc41`](https://github.com/NixOS/nixpkgs/commit/06bffc41f7e428092369610a9dcea2007c5d430e) vscode-extensions.ms-azuretools.vscode-bicep: 0.43.8 -> 0.45.15
* [`31015bf1`](https://github.com/NixOS/nixpkgs/commit/31015bf18b923709725879797e551a1d0921099f) electron-source.electron_41: 41.9.1 -> 41.10.2
* [`5e60b82d`](https://github.com/NixOS/nixpkgs/commit/5e60b82d490323be8240b65956880504106071eb) segger-jlink: Fix typo in update.py
* [`e4d5ca3f`](https://github.com/NixOS/nixpkgs/commit/e4d5ca3f95f42ba25421616db0030b5bb4549a36) segger-jlink: 874 -> 952
* [`524354e1`](https://github.com/NixOS/nixpkgs/commit/524354e103dfca8661ddea462e4387864553674f) electron-source.electron_42: 42.5.1 -> 42.7.0
* [`9392ebbc`](https://github.com/NixOS/nixpkgs/commit/9392ebbc91e995b02e4ae247937d2e5184c21d9f) electron-source.electron_43: 43.1.0 -> 43.1.1
* [`ac882579`](https://github.com/NixOS/nixpkgs/commit/ac882579e91f7a5cf2476a817c7f45b0d66fe697) dash: 0.5.13.4 -> 0.5.13.5
* [`8e2fd17f`](https://github.com/NixOS/nixpkgs/commit/8e2fd17f00c260e2e3fe7e9c8cc58bfe16008c9b) python314Packages.flash-attn: replace self with finalAttrs.finalPackage pattern
* [`769c438a`](https://github.com/NixOS/nixpkgs/commit/769c438adb12dab0561a0cebd4d442131245c7a7) python314Packages.flash-attn: remove psutil from setup_requires as we do not require it because we set MAX_JOBS
* [`7bb08865`](https://github.com/NixOS/nixpkgs/commit/7bb08865d00b8d6baed82ac149561f10fb43552b) thrift: set meta.downloadPage
* [`5cf2644c`](https://github.com/NixOS/nixpkgs/commit/5cf2644c4f842a634750bf2c2b49c74ab2e8f5f6) thrift: fix cross build
* [`7d387561`](https://github.com/NixOS/nixpkgs/commit/7d3875618f9a72d16f920a2aa5b0ff30f99e24aa) minimal-boostrap.mes: use vendored ldexpl.c
* [`889c98a5`](https://github.com/NixOS/nixpkgs/commit/889c98a5a59aa473bc01d73c327bad3cd7e2f1fe) element-call: 0.20.3 -> 0.22.0
* [`2bf695d8`](https://github.com/NixOS/nixpkgs/commit/2bf695d804728fd30b2001e63a5f9ff9aef7bd48) electron_41-bin: 41.9.1 -> 41.10.2
* [`65fb975e`](https://github.com/NixOS/nixpkgs/commit/65fb975e2efc9eba6fa5f6a387b01c3798fcb403) electron-chromedriver_41: 41.9.1 -> 41.10.2
* [`e7832884`](https://github.com/NixOS/nixpkgs/commit/e78328843cb1c92aa64da9913ebcfe50a4c2aa8c) electron_42-bin: 42.5.1 -> 42.7.0
* [`4398dd27`](https://github.com/NixOS/nixpkgs/commit/4398dd27900f2ab0edbff6c21fd46ad08c9650b6) electron-chromedriver_42: 42.5.1 -> 42.7.0
* [`fa7a5e6c`](https://github.com/NixOS/nixpkgs/commit/fa7a5e6cc04f5a4640e1e5817cb46676f7fc9190) electron_43-bin: 43.1.0 -> 43.1.1
* [`acc1fac4`](https://github.com/NixOS/nixpkgs/commit/acc1fac4b5fb1d2d2b794c76747c6825301463db) electron-chromedriver_43: 43.1.0 -> 43.1.1
* [`2afb7bd2`](https://github.com/NixOS/nixpkgs/commit/2afb7bd2dda4b172593e6a00c1f6b09a531e426b) git-recent: 2.0.4 -> 2.1.0
* [`572bf8ab`](https://github.com/NixOS/nixpkgs/commit/572bf8abb5d7a93705ecdf2834f0bd7d675c7e95) libssh2: patch CVE-2026-58050 and CVE-2026-58051
* [`b2aab90a`](https://github.com/NixOS/nixpkgs/commit/b2aab90a9cfcb16849ed41b5a5f8a2f8e220d194) srt: 1.5.5 -> 1.5.6
* [`fb6f0040`](https://github.com/NixOS/nixpkgs/commit/fb6f0040bafdb77272a8b0ab329664c3c0abc5e3) python3Packages.aiohttp: 3.14.1 -> 3.14.2
* [`12fb0623`](https://github.com/NixOS/nixpkgs/commit/12fb062335d4ebf71773fbd31de98a1db9150072) pleroma-bot: modernize
* [`a44cb2f8`](https://github.com/NixOS/nixpkgs/commit/a44cb2f821a6bcd3bcc80f23cb96a4193fd5d2e1) wfview: fix build on Qt 6.11.1
* [`c3576a51`](https://github.com/NixOS/nixpkgs/commit/c3576a51da92def325b8188c1071990644cdf450) pleroma-bot: 0.8.6 -> 1.2.0
* [`ca13224d`](https://github.com/NixOS/nixpkgs/commit/ca13224dfbe825588a167658fecab2524be513d8) netpbm: 11.15.1 -> 11.15.3
* [`f5248277`](https://github.com/NixOS/nixpkgs/commit/f5248277bd62385ec41d139c3fa67ba2e51c5628) jemalloc: add patch to fix build under gcc 16
* [`f4229491`](https://github.com/NixOS/nixpkgs/commit/f4229491c3bc50d0b6135fac05f92478cea00d46) weave: init at 0.3.6
* [`2709d6b4`](https://github.com/NixOS/nixpkgs/commit/2709d6b4f480169cc6a5dc91f79dbc3430e13e3d) python3Packages.feedgen: migrate to pyproject
* [`f6c46604`](https://github.com/NixOS/nixpkgs/commit/f6c466042e0c3989b48b1388690996c2c9be15da) python3Packages.feedgen: use finalAttrs
* [`8741663b`](https://github.com/NixOS/nixpkgs/commit/8741663b371389fdc1423bd6c0eefc36a673b149) python3Packages.feedgen: enable tests
* [`52325bf8`](https://github.com/NixOS/nixpkgs/commit/52325bf86527dda6ca551e1881f9437aaa83574e) python3Packages.fields: migrate to pyproject
* [`72dfbeef`](https://github.com/NixOS/nixpkgs/commit/72dfbeef2f500405853cd0fb996777281f01ef54) python3Packages.fields: use finalAttrs
* [`951e50ec`](https://github.com/NixOS/nixpkgs/commit/951e50ec2b3a74ec32032a7625f2d7fb5bc4d229) python3Packges.fields: mark tests as disabled
* [`4e2d29b8`](https://github.com/NixOS/nixpkgs/commit/4e2d29b83e12867c1501fa1d7dff0542ee6fdb60) Revert "python3Packages.pyobjc-framework-Cocoa: work around `ld64` hardening issue"
* [`5b28e90f`](https://github.com/NixOS/nixpkgs/commit/5b28e90f97ef01e14859bef4e3d8fa07534ea522) Revert "pango: fix build on darwin"
* [`9da838c8`](https://github.com/NixOS/nixpkgs/commit/9da838c81aba8fb132f07223d1274be6aaca28aa) Revert "tk: fix build on darwin"
* [`2698646a`](https://github.com/NixOS/nixpkgs/commit/2698646a86aa3c5a33f4718baa472559d8d35554) Revert "gst_all_1.gst-plugins-bad: only set NIX_CLAGS_LINK on darwin"
* [`16477632`](https://github.com/NixOS/nixpkgs/commit/16477632da77c1bb7469dbeb24298c7420d9bb2a) Revert "gst_all_1.gst-plugins-bad: work around `ld64` hardening issue"
* [`c11900ef`](https://github.com/NixOS/nixpkgs/commit/c11900eff6cde8c37c971bab012a648896a4f28b) Revert "qt5.qtmultimedia: work around `ld64` hardening issue"
* [`9a9c6815`](https://github.com/NixOS/nixpkgs/commit/9a9c68153820826b77744fa337b6de099246776e) Revert "qt6.qtmultimedia: work around `ld64` hardening issue"
* [`88a69da5`](https://github.com/NixOS/nixpkgs/commit/88a69da533047536c1166180861acaa391057c9b) Revert "qt6.qtdeclarative: work around `ld64` hardening issue"
* [`77e7e6b1`](https://github.com/NixOS/nixpkgs/commit/77e7e6b150ee92b4cc820ec9dcee22f5e83ce6a6) pythonPackages.dragonfly: mark as linux only
* [`8754cb78`](https://github.com/NixOS/nixpkgs/commit/8754cb78a75b3c43bc900e71a13f562447999404) xdotool: enable on darwin
* [`566499ca`](https://github.com/NixOS/nixpkgs/commit/566499ca035af27f35788d17d303026416458781) alttab: 1.7.1 -> 1.8.0
* [`737bea02`](https://github.com/NixOS/nixpkgs/commit/737bea02912e74362cb257b1254d97b2a9823d53) imagemagick: Generic GCC arch
* [`0e9dd5bd`](https://github.com/NixOS/nixpkgs/commit/0e9dd5bd4a6dfd62cc0232ded43f4850364c6e1b) vscode-extensions.github.vscode-pull-request-github: 0.138.0 -> 0.158.0
* [`bdd41cf2`](https://github.com/NixOS/nixpkgs/commit/bdd41cf25ff46202d27f60e979c6311c70e47067) spidermonkey_140: 140.11.0 -> 140.13.0
* [`19c05bc5`](https://github.com/NixOS/nixpkgs/commit/19c05bc5b549b436bd25fcd136d3af9d0bc964dc) libssh2: remove SuperSandro2000 as maintainer
* [`6df3905c`](https://github.com/NixOS/nixpkgs/commit/6df3905cd551c9708481ee83b9e7e0d1b39cbb9c) nixos/headscale: fix split DNS option path
* [`41e84e45`](https://github.com/NixOS/nixpkgs/commit/41e84e455482f110bfdf15454f97865265dff4b9) nixos/headscale: migrate ephemeral timeout setting
* [`b360de16`](https://github.com/NixOS/nixpkgs/commit/b360de16fc47a7d445f13d4b82449085339aa9ff) ponyc: 0.64.0 -> 0.67.0
* [`f0af23a2`](https://github.com/NixOS/nixpkgs/commit/f0af23a2a35c4b19ca9c620418e42ed52652f2de) outline: 1.9.1 -> 1.9.2
* [`7973bd60`](https://github.com/NixOS/nixpkgs/commit/7973bd606a8925d4fff6b22879cd954e0b44ae10) libssh: 0.12.0 -> 0.12.1
* [`813921e4`](https://github.com/NixOS/nixpkgs/commit/813921e4237a4684eb4869c38ea3e171866c11dc) home-manager: 0-unstable-2026-04-24 -> 0-unstable-2026-07-21
* [`b1cd9634`](https://github.com/NixOS/nixpkgs/commit/b1cd9634f135bac445843abce1cd14b3034c8368) plakar-plugin-etcd: init at 1.1.0
* [`bb6dd26c`](https://github.com/NixOS/nixpkgs/commit/bb6dd26c4db96e04f9589e2e3204a22345064046) plakar-plugin-ftp: init at 1.1.2
* [`6fd8810c`](https://github.com/NixOS/nixpkgs/commit/6fd8810c9c4f860e46119ac965723a4710c1d176) plakar-plugin-gcs: init at 1.1.0
* [`fa6680c1`](https://github.com/NixOS/nixpkgs/commit/fa6680c104c277c117e02c97a2772987cd7eeaea) plakar-plugin-imap: init at 1.1.0
* [`436a2eae`](https://github.com/NixOS/nixpkgs/commit/436a2eae4e938b5cf3c2f37e92027140155c1836) plakar-plugin-k8s: init at 1.1.7
* [`6df46c97`](https://github.com/NixOS/nixpkgs/commit/6df46c975a8fa2f8e15aaa8ac003abc26528ff3b) plakar-plugin-nfs: init at 1.1.0
* [`a72f9e15`](https://github.com/NixOS/nixpkgs/commit/a72f9e152e606b2780464fd117be69c424e8298f) plakar-plugin-proxmox: init at 1.1.0-rc.1
* [`193d311a`](https://github.com/NixOS/nixpkgs/commit/193d311aa213d823e3f58ea651ed9416117c36d8) plakar-plugin-rclone: init at 1.1.0-beta.10
* [`de720951`](https://github.com/NixOS/nixpkgs/commit/de72095193211f674d847b17b58ca3b7f63b9451) plakar-plugin-s3: init at 1.1.5
* [`2dbf06ce`](https://github.com/NixOS/nixpkgs/commit/2dbf06ce2479c7af347146e66000df1ff57e77d0) plakar-plugin-sftp: init at 1.1.4
* [`9e80a8b7`](https://github.com/NixOS/nixpkgs/commit/9e80a8b70f31ee76d3a218c140eea45d069cfb18) plakar-plugin-smb: init at 1.1.0
* [`67b215ee`](https://github.com/NixOS/nixpkgs/commit/67b215ee81d569e861bba16198aac0aa6a1cb9e9) plakar-plugin-sqlite: init at 1.0.5
* [`2fb4956d`](https://github.com/NixOS/nixpkgs/commit/2fb4956daccfbcf0c25307cdb78f245762f22e6c) sqlpage: 0.44.1 -> 0.45.0
* [`f28dd0d0`](https://github.com/NixOS/nixpkgs/commit/f28dd0d049ed30d1f3524564a60834465127c753) vscode-extensions.ms-ceintl.vscode-language-pack-fr: 1.110.2026041514 -> 1.129.2026071717
* [`d81fbecb`](https://github.com/NixOS/nixpkgs/commit/d81fbecb6a1b3cb5d8a89ec79356b5e6d15761ad) beekeeper-studio: 5.8.1 -> 5.9.2
* [`4a3f5579`](https://github.com/NixOS/nixpkgs/commit/4a3f55798ba2de9bfc0d9d73e6fe92799fc4e62b) foundationdb: support aarch64-darwin
* [`bf76761f`](https://github.com/NixOS/nixpkgs/commit/bf76761f81e62bcb3d53afe071c919173e5de59e) pack: 0.38.2 -> 0.40.8
* [`390c6674`](https://github.com/NixOS/nixpkgs/commit/390c66743f7f7359b62b55fa88b13cdc081695a1) hyprlandPlugins.hypr-dynamic-cursors: 0-unstable-2026-06-03 -> 0-unstable-2026-07-21
* [`2979dcc7`](https://github.com/NixOS/nixpkgs/commit/2979dcc74d2ce0bf6dbf582af39fba72ea0fb18f) spinshare: init at 3.32.1
* [`a4973ac2`](https://github.com/NixOS/nixpkgs/commit/a4973ac2d498d79c8c205f120e3ebfc3b1357226) valkey: 9.1.0 -> 9.1.1
* [`4c78f6f1`](https://github.com/NixOS/nixpkgs/commit/4c78f6f1311a9acd2002dacef4b542591fdc86f2) linphone-desktop: Fix missing ringtones
* [`42074a2b`](https://github.com/NixOS/nixpkgs/commit/42074a2be418aa2285fd6e9cfe72ab3418fdc459) context7-mcp: 3.2.3 -> 3.2.4
* [`e7e6a986`](https://github.com/NixOS/nixpkgs/commit/e7e6a986607d5925c7558ee6cb19b8e5ecc5fcf9) aliae: 1.1.1 -> 1.5.0
* [`841d05a8`](https://github.com/NixOS/nixpkgs/commit/841d05a8f6906d05a77c3f6a80c088f8a9cedee0) gokrazy: 0-unstable-2026-01-09 -> 0-unstable-2026-07-23
* [`d2cff906`](https://github.com/NixOS/nixpkgs/commit/d2cff906ccda0f0d676331e0d1b8a9b6e5df713e) unbound: 1.25.1 -> 1.25.2
* [`238fe1fe`](https://github.com/NixOS/nixpkgs/commit/238fe1feccc68419ddc2bdded35cf55f458db1a8) ngrok: update without separate versions.json
* [`311df0ad`](https://github.com/NixOS/nixpkgs/commit/311df0ada36e8a4e090081f975accad7f20e6c6f) gstreamer: 1.28.4 -> 1.28.5
* [`cda27cc0`](https://github.com/NixOS/nixpkgs/commit/cda27cc0cbd024fef01d74a22147c9cb27699f5d) python3Packages.gst-python: 1.28.4 -> 1.28.5
* [`610a1811`](https://github.com/NixOS/nixpkgs/commit/610a181162043000330c8be1ce74978311cef3d6) noaa-apt: 1.4.0 -> 1.4.1
* [`06ba43ca`](https://github.com/NixOS/nixpkgs/commit/06ba43ca20765445a5cafcc1fbd948b6d20d855a) airwindows: 0-unstable-2026-05-02 -> 0-unstable-2026-07-19
* [`c7a53a11`](https://github.com/NixOS/nixpkgs/commit/c7a53a11c44dc2bbeafceecea2b2357c315f6af1) dawarich: 1.9.2 -> 1.10.1
* [`f8a79cab`](https://github.com/NixOS/nixpkgs/commit/f8a79cab67522860ec6287fe0b59d939e7e59e07) gdal: 3.13.1 -> 3.13.2
* [`63e0ce2c`](https://github.com/NixOS/nixpkgs/commit/63e0ce2cbf7fb1e5c35255480595eba03722470d) maintainers: add vitrial
* [`2e948d71`](https://github.com/NixOS/nixpkgs/commit/2e948d71cbf2b02d5471681a11c1d015d2d237a6) maintainers: add findus
* [`63ab58e1`](https://github.com/NixOS/nixpkgs/commit/63ab58e13ea9a29f242980ee1f3752109ea3e30d) pkgs: update oven-media-engine to 0.20.5
* [`b240a809`](https://github.com/NixOS/nixpkgs/commit/b240a809a85bc19828b5b947f0438d1db87a4a39) python3Packages.mistune: 3.3.3 -> 3.3.4
* [`9e52eb44`](https://github.com/NixOS/nixpkgs/commit/9e52eb44000183ef8b035babb8cea042a4a81b3e) gui-for-singbox: 1.25.4 -> 1.26.1
* [`0d35eb61`](https://github.com/NixOS/nixpkgs/commit/0d35eb61ce791a63613f7ea9633817eebb1ca62e) maestro: 2.6.1 -> 2.7.0
* [`091502e0`](https://github.com/NixOS/nixpkgs/commit/091502e00dd25cf2e2b0e5dfeb8d80189fc24133) knightos-z80e: 0.5.3 -> 0.5.4
* [`f4148ff1`](https://github.com/NixOS/nixpkgs/commit/f4148ff1e0b625dec5516ab4183b20e20491d5c5) knightos-kpack: 1.1.1 -> 1.2.0
* [`0c9b6d4c`](https://github.com/NixOS/nixpkgs/commit/0c9b6d4c9e3e510df592ff3e36b04e493afc3195) the-powder-toy: 99.5.394 -> 100.0.399
* [`58a5ee84`](https://github.com/NixOS/nixpkgs/commit/58a5ee84683d73184db183bef6b70cc6c9cdf35b) trealla: 2.100.9 -> 2.106.1
* [`c109d777`](https://github.com/NixOS/nixpkgs/commit/c109d77771cd084a1e47a00a370d3f5164d0a39b) python3Packages.crossandra: fix build
* [`82f6ed66`](https://github.com/NixOS/nixpkgs/commit/82f6ed66751e32eefb47ad0fefe65fc1970b60a4) gnome-icon-theme: drop
* [`e6c092c3`](https://github.com/NixOS/nixpkgs/commit/e6c092c39e5b48bf786d29176e4e305fe1fbdcb2) vscode-extensions.ms-windows-ai-studio.windows-ai-studio: 1.6.2 -> 1.6.5
* [`9d8df69d`](https://github.com/NixOS/nixpkgs/commit/9d8df69daf48e85db35f15a7f4a1d6c1868728c0) scap-security-guide: 0.1.79 -> 0.1.81
* [`f327ca5d`](https://github.com/NixOS/nixpkgs/commit/f327ca5d64caf2f41380b6767ddac3ee762c6080) scap-security-guide: Add robsliwi as maintainer
* [`e393b159`](https://github.com/NixOS/nixpkgs/commit/e393b159eaf036cdc126dc87c09e12450b05a01b) openjdk: drop gtk2 support
* [`b170e54f`](https://github.com/NixOS/nixpkgs/commit/b170e54faa77fa54746dff88e5304396575eb408) elasticsearch: tag with knownVulnerabililities
* [`7bf6274c`](https://github.com/NixOS/nixpkgs/commit/7bf6274c72ac333404d4f721855928ec3952f4d4) build-support/php: don't override meta.platforms
* [`23991ae3`](https://github.com/NixOS/nixpkgs/commit/23991ae32b0e0949f15d6f6190e22b12fd5072cd) keyd: add updateScript and do some housekeeping
* [`e7fc5f59`](https://github.com/NixOS/nixpkgs/commit/e7fc5f592978ec4cdc98ef5198c40693aa8844ab) libtool: 2.5.4 -> 2.6.2
* [`75eca026`](https://github.com/NixOS/nixpkgs/commit/75eca02672c5bae157b63971690528ec5ff5620c) libmicrohttpd: 1.0.5 -> 1.0.6
* [`a5f4424a`](https://github.com/NixOS/nixpkgs/commit/a5f4424afe571e1644b9d299cf46bbd7a1288a21) bind: enable tests, always disable time_test partially
* [`3af077a0`](https://github.com/NixOS/nixpkgs/commit/3af077a023c39694c0c72d75f3c4e1922873c149) bind: enable structuredAttrs
* [`dc51fd73`](https://github.com/NixOS/nixpkgs/commit/dc51fd7311aa5c07ebb050111a3e659d9ccc7287) bind: add bartoostveen as a maintainer
* [`d4b42fbc`](https://github.com/NixOS/nixpkgs/commit/d4b42fbc4106dd472f6f028b4aa38c1b0f28350b) bind: 9.20.24 -> 9.20.26
* [`02dd4616`](https://github.com/NixOS/nixpkgs/commit/02dd461696cbddd1dfefc196ad6fb52b5b43e78b) beeref: fix build
* [`36058367`](https://github.com/NixOS/nixpkgs/commit/360583675643171062cb0b90ee9c4d2fd0310a61) passt: 2025_09_19.623dbf6 -> 2026_07_16.090d739
* [`6096796a`](https://github.com/NixOS/nixpkgs/commit/6096796a2be65fe166f7f538d93f390ca2beda4a) musl: 1.2.5 -> 1.2.6
* [`654caa4a`](https://github.com/NixOS/nixpkgs/commit/654caa4a5da14dda5914bc70a400a650ca5bf30d) incus-spawn: 0.2.14 -> 0.2.15
* [`b81b7320`](https://github.com/NixOS/nixpkgs/commit/b81b7320604a6de1200fe61c5155bf75d183231a) minizinc: 2.9.7 → 2.10.0
* [`52616da0`](https://github.com/NixOS/nixpkgs/commit/52616da039136a42908b8b1e931e13483c2b5e2b) lean-lsp-mcp: 0.26.2 -> 0.28.1
* [`a453e915`](https://github.com/NixOS/nixpkgs/commit/a453e9151ef80e33920c732fc6bdc05c94066ac8) python3Packages.numpy_2: fix for test failure on i686
* [`de8e14f8`](https://github.com/NixOS/nixpkgs/commit/de8e14f822fae85f614639b93a37833fb2594a1c) python3Packages.cxxheaderparser: 1.8.1 -> 1.9.2
* [`cf49cb98`](https://github.com/NixOS/nixpkgs/commit/cf49cb9883eacca258c8166a73c123a3ff9011ba) doc: fix fetchPnpmDeps fetcherVersion typo
* [`dd68e5b8`](https://github.com/NixOS/nixpkgs/commit/dd68e5b8d5b0f65b34fb7ebdb07de424bdb49c9f) pkgsStatic.coreutils: fix build
* [`6d5c5482`](https://github.com/NixOS/nixpkgs/commit/6d5c548236fccc5a597a8edcfa51acac7269e4d5) python3Packages.rio-tiler: 9.4.0 -> 9.4.2
* [`79adfd14`](https://github.com/NixOS/nixpkgs/commit/79adfd14c4a2e15db84878ef27bba6b9dbb1680a) onednn: 3.12.2 -> 3.13
* [`c920197e`](https://github.com/NixOS/nixpkgs/commit/c920197e1b8e63c2310ba1ae42d703fb0fab76f4) tdarr: Fix pnpm packaging regression
* [`155fe67a`](https://github.com/NixOS/nixpkgs/commit/155fe67aa5dc371d82ef5643efb97008d017b327) electron-source.electron_41: 41.10.2 -> 41.10.3
* [`c654dd70`](https://github.com/NixOS/nixpkgs/commit/c654dd70f5a18b2da3305bd908fe9e3db5c3ab82) electron-source.electron_42: 42.7.0 -> 42.7.1
* [`b804fa46`](https://github.com/NixOS/nixpkgs/commit/b804fa464fe6b6a4b427c58ec9b57c1a12a11279) xdg-desktop-portal: 1.20.4 -> 1.22.1
* [`90ba4924`](https://github.com/NixOS/nixpkgs/commit/90ba4924ca2f7a670b2c8558be7e57c5d52ae9c9) electron-source.electron_43: 43.1.1 -> 43.2.0
* [`017bc3fd`](https://github.com/NixOS/nixpkgs/commit/017bc3fdef12c78b9d12a5d682db6fe191cedd44) electron_41-bin: 41.10.2 -> 41.10.3
* [`52a7fdd5`](https://github.com/NixOS/nixpkgs/commit/52a7fdd51b24f429b377252b3bfe9340927ad543) electron-chromedriver_41: 41.10.2 -> 41.10.3
* [`304c6ae4`](https://github.com/NixOS/nixpkgs/commit/304c6ae4b5affc78b8c12c3a2d13cb01a64dac32) electron_42-bin: 42.7.0 -> 42.7.1
* [`96e22e82`](https://github.com/NixOS/nixpkgs/commit/96e22e823fd6095734ea12fddda3c1dc9360cb6a) electron-chromedriver_42: 42.7.0 -> 42.7.1
* [`66a73d0f`](https://github.com/NixOS/nixpkgs/commit/66a73d0fbca81c7861e4693bf5b8934035a4be80) electron_43-bin: 43.1.1 -> 43.2.0
* [`154de68c`](https://github.com/NixOS/nixpkgs/commit/154de68c3e448ad5b4dc9e306578c4237263c477) electron-chromedriver_43: 43.1.1 -> 43.2.0
* [`fbe13755`](https://github.com/NixOS/nixpkgs/commit/fbe137550b487895ddacab3a784057201931de1d) immichframe: 1.0.35.0 -> 1.0.37.0
* [`4fe22fdb`](https://github.com/NixOS/nixpkgs/commit/4fe22fdbf28ed444dfa2879837550614566d1b2f) nimble: 0.20.1 -> 0.24.1
* [`50ec0c0d`](https://github.com/NixOS/nixpkgs/commit/50ec0c0d9b1bd9c54521f7fb274a1437cc8baa49) nixos-test-driver: Drop temporary directory in copy_from_machine
* [`587b6d52`](https://github.com/NixOS/nixpkgs/commit/587b6d522a62b374b706ac11134c85693077b980) maintainers: add jamesbrink
* [`d9497f05`](https://github.com/NixOS/nixpkgs/commit/d9497f054c7aa05b05b1be14b04f74537449c4fa) bisq2: make Java classpath deterministic
* [`9fcb0693`](https://github.com/NixOS/nixpkgs/commit/9fcb0693b8a6069464cf0bf91b508cd70be6645e) ty: 0.0.61 -> 0.0.63
* [`9467d656`](https://github.com/NixOS/nixpkgs/commit/9467d656c2476a367936173f7995a4706d0f2f3f) headsetcontrol: 3.1.0 -> 4.0.0
* [`78f5700a`](https://github.com/NixOS/nixpkgs/commit/78f5700a554abe89fee5760911ee199c31fdf19d) openctm: remove the gtk2 viewer on linux
* [`26f4f2b5`](https://github.com/NixOS/nixpkgs/commit/26f4f2b5ba5db576d38797ca48508638d686ad88) wails3: init at 3.0.0-alpha2.117
* [`bbe5f38b`](https://github.com/NixOS/nixpkgs/commit/bbe5f38b9a9c319ab13d0e568feba4fd22d0e8b3) netbird: 0.74.3 -> 0.75.0
* [`61ff3c44`](https://github.com/NixOS/nixpkgs/commit/61ff3c44f132ecb9df41d8c0b51d489a57c723c2) python3Packages.opencc: 1.2.0 -> 1.4.1
* [`c2d75211`](https://github.com/NixOS/nixpkgs/commit/c2d75211345b0ab33507b7c8c191277edb46dcd4) netbird-dashboard: 2.90.3 -> 2.90.6
* [`9eb9dda0`](https://github.com/NixOS/nixpkgs/commit/9eb9dda0213c35f21330953a1df6c3ba0eab6965) ruff: 0.15.22 -> 0.16.0
* [`6d32bd9e`](https://github.com/NixOS/nixpkgs/commit/6d32bd9e9c4b5a9842b0f7855f7ee3de0ff6cccd) etcd_3_5: 3.5.32 -> 3.5.33
* [`a94cc7f6`](https://github.com/NixOS/nixpkgs/commit/a94cc7f6b43d6bff11665a9cbc14436e9c4b8c0f) etcd_3_6: 3.6.13 -> 3.6.14
* [`9581b8af`](https://github.com/NixOS/nixpkgs/commit/9581b8afbcecdaa53649896cb65a4a42abf041d5) libretro.citra: 0-unstable-2025-08-17 -> 0-unstable-2026-07-21
* [`2949e11a`](https://github.com/NixOS/nixpkgs/commit/2949e11af1c839fe56b3055d45d1535c52064cf9) zoom-us: 7.1.0.3715 -> 7.1.5.4332
* [`cb191f02`](https://github.com/NixOS/nixpkgs/commit/cb191f029e8e93a7e647ca1045dcce1c93d36b2a) oapi-codegen: 2.5.1 -> 2.8.0
* [`7451ea5f`](https://github.com/NixOS/nixpkgs/commit/7451ea5fc78843a600ac84f861d9c9b10c6987af) naps2: add maintainer
* [`fd6e2aa8`](https://github.com/NixOS/nixpkgs/commit/fd6e2aa871ffb18e0320f3538f31726a1db7bf79) naps2: 8.2.1 -> 8.3.2
* [`bd10e903`](https://github.com/NixOS/nixpkgs/commit/bd10e9034d3bbce5545c24bc99f704afec5a6d75) python3Packages.udatetime: migrate to pyproject
* [`92e86d0f`](https://github.com/NixOS/nixpkgs/commit/92e86d0f2135c616de67be2ac887bad63d64dd95) python3Packages.udatetime: modernize
* [`92674d92`](https://github.com/NixOS/nixpkgs/commit/92674d927bfcee4fabb1f30bd2c31b547a4fb081) home-assistant-custom-components.opensprinkler: 1.5.5 -> 1.5.6
* [`1c9ca938`](https://github.com/NixOS/nixpkgs/commit/1c9ca9386f8f4af51fe59b33a277f53be46fab94) ols: dev-2026-05 -> dev-2026-06
* [`5fe66fcf`](https://github.com/NixOS/nixpkgs/commit/5fe66fcffe54ab89c77ed4ad9186989127aa382d) haskell.compiler.ghc984Binary: workaround com.apple.provenance xattr
* [`e101ce99`](https://github.com/NixOS/nixpkgs/commit/e101ce996b152e9ef722b65348b488007d2eb04a) virtualbox: 7.2.12 -> 7.2.14
* [`717e330f`](https://github.com/NixOS/nixpkgs/commit/717e330f8efda3c9227c39818a58e3ffeb1b0263) tests.problems: only match on the error message
* [`9db14358`](https://github.com/NixOS/nixpkgs/commit/9db1435899174136aef4532c13abd43a5aa7fdbe) tests.problems: regenerate all the test fixtures
* [`7079e863`](https://github.com/NixOS/nixpkgs/commit/7079e863e74eb5e6a6424900af72b39c7043ba94) .github: Bump actions/checkout from 6.0.3 to 7.0.1
* [`17e108bc`](https://github.com/NixOS/nixpkgs/commit/17e108bcda7271e5a77b5b2fc3981b3c61c9246c) litestream: 0.5.11 -> 0.5.15
* [`05c36f66`](https://github.com/NixOS/nixpkgs/commit/05c36f66d6c1abc43fe925fb40b439dde6425f29) clj-kondo: 2026.05.25 -> 2026.07.24
* [`0885304a`](https://github.com/NixOS/nixpkgs/commit/0885304a54fbdd2d4388afbc8c1678ee5dd38910) scala: 3.3.6 -> 3.3.8
* [`1a57aeb6`](https://github.com/NixOS/nixpkgs/commit/1a57aeb6186123a33b2f5f97014790d2af110319) scala-next: 3.8.3 -> 3.8.4
* [`e71de6ec`](https://github.com/NixOS/nixpkgs/commit/e71de6ec0a0e9ab55b88b40dc6e2ee95cd7c1b06) vscode-extensions.ms-dotnettools.csharp: write install.Lock into $out
* [`210237e8`](https://github.com/NixOS/nixpkgs/commit/210237e80bd3d8eb6936d17747dfdb681ace1448) fstar: fix build of z3-4.8.5 after setuptool update
* [`0efb0140`](https://github.com/NixOS/nixpkgs/commit/0efb0140f1c2d0f14ca79cde54d948a4d96f2ab7) rocqPackages.stdlib: 9.1.0 -> 9.2.0
* [`f06fb2a3`](https://github.com/NixOS/nixpkgs/commit/f06fb2a37347cb020e561f76602262f47c79a104) easycrypt: 2026.06 → 2026.07
* [`12f11545`](https://github.com/NixOS/nixpkgs/commit/12f115452cd0c5172083faf965fe49da3f42b768) python3Packages.httpcore2: 2.5.0 -> 2.9.1
* [`232cf6b9`](https://github.com/NixOS/nixpkgs/commit/232cf6b9db521ef4cdbef40f6f0266e710c80170) python3Packages.httpx2: 2.5.0 -> 2.9.1
* [`fe72f7a7`](https://github.com/NixOS/nixpkgs/commit/fe72f7a7a7099175c20918de263bef2e0bd2c8b9) litestream: add konradmalik to maintainers
* [`c622850c`](https://github.com/NixOS/nixpkgs/commit/c622850c2aa0c260f83f3e33b1c5d15e8f68fd0f) tinyauth: 5.1.1 -> 5.1.2
* [`3110e744`](https://github.com/NixOS/nixpkgs/commit/3110e744a14edb60fffbd309bcf8738256918fee) python3Packages.pycrdt: 0.14.1 -> 0.14.2
* [`0f00451a`](https://github.com/NixOS/nixpkgs/commit/0f00451ae0701aa51d0a9e3c013e11ab3a09b0cb) python3Packages.pandas-stubs: pin pytest to 9.0
* [`61e6dad9`](https://github.com/NixOS/nixpkgs/commit/61e6dad91eda3f6d1aba30a288792d6680ce7e7d) python314Packages.psycopg.c: nuke libpq.dev refs in cython files
* [`c0d2154c`](https://github.com/NixOS/nixpkgs/commit/c0d2154cccd12b38e08f149a4a72c5e69f371244) stalwart_0_16: install webui to webui.zip instead of webui.tar.gz
* [`6862cf85`](https://github.com/NixOS/nixpkgs/commit/6862cf855ece91ec64c600ef8ec5c3298453ec28) assimp: never treat warnings as fatal
* [`1e66ea15`](https://github.com/NixOS/nixpkgs/commit/1e66ea15e00d2c4d37363a48212282b1161f4cb5) owntone: 29.2 -> 29.3
* [`bffac658`](https://github.com/NixOS/nixpkgs/commit/bffac658435efe9c2b977d07cafaab308846ac5c) linux/common-config: enable TCP_AO on >= 6.7
* [`f0ab3b8f`](https://github.com/NixOS/nixpkgs/commit/f0ab3b8f15dc17d5d642d9bdfb71c4079722b0a1) renode: add aarch64-linux support
* [`838f6858`](https://github.com/NixOS/nixpkgs/commit/838f68584abad7848141efddee08d0347832e40f) python3Packages.aiohttp: 3.14.2 -> 3.14.3
* [`7f6b809a`](https://github.com/NixOS/nixpkgs/commit/7f6b809aa5cda12b67d54bfcbfbc2a7c278d6f85) python3Packages.yarl: 1.24.2 -> 1.24.5
* [`5e3b1889`](https://github.com/NixOS/nixpkgs/commit/5e3b18898a5e5457060cc458eb8e3abcd70a1118) python3Packages.yarl: use finalAttrs
* [`6f97a4f3`](https://github.com/NixOS/nixpkgs/commit/6f97a4f3631c3b03d2e317ca53da0d73d303b808) ghqr: 0.5.0 -> 0.5.1
* [`9a1f41b1`](https://github.com/NixOS/nixpkgs/commit/9a1f41b1d26a19f1108253a22a79a7d2431384c7) prowlarr: 2.4.0.5397 -> 2.5.2.5491
* [`dbce7bdf`](https://github.com/NixOS/nixpkgs/commit/dbce7bdf5feef17adcfa0af7b4d8bedde5f7fe98) ffmpeg: remove-references-to cuda llvm
* [`c7010daa`](https://github.com/NixOS/nixpkgs/commit/c7010daad2adde95d4887e36e28347bcb0475edf) zxing-cpp: add qweered to maintainers
* [`2f81259e`](https://github.com/NixOS/nixpkgs/commit/2f81259e5680f75c73b8177f5818c6fc544dddfc) zxing-cpp: 2.3.0 -> 3.0.2
* [`4e8a4a13`](https://github.com/NixOS/nixpkgs/commit/4e8a4a1312859e64fc5089eaefa225ada3ba7661) statime: init at 0.4.0
* [`85c5d0e6`](https://github.com/NixOS/nixpkgs/commit/85c5d0e6652c6e08c21d5c1d399d4cf76be83f7e) inko: 0.20.0 -> 0.21.1
* [`ce70ace7`](https://github.com/NixOS/nixpkgs/commit/ce70ace726fe73aabfb6230c0294699ca5064d79) tauon: build and bundle lrclib-solver
* [`4a64cc97`](https://github.com/NixOS/nixpkgs/commit/4a64cc975c7474b95e5a5130ff9040150331ede3) bazecor: 1.8.3 -> 1.9.0
* [`c5481d89`](https://github.com/NixOS/nixpkgs/commit/c5481d89f4cf59cf31778df354243fe40b6bdfeb) paperless-ngx: relax zxing-cpp dependency
* [`aec4b0a8`](https://github.com/NixOS/nixpkgs/commit/aec4b0a8f3af7940541f28c65b60a02bb24ce4d8) dutctl: 1.0.0-alpha.1-unstable-2026-07-05 -> 1.0.0-alpha.1-unstable-2026-07-24
* [`9b97dae0`](https://github.com/NixOS/nixpkgs/commit/9b97dae064ce1e1ff318d3e3db251e3d6455e243) jan: use stdenvNoCC on darwin
* [`80084dbc`](https://github.com/NixOS/nixpkgs/commit/80084dbcadafc67331a2ed9f4acb11a4070ad505) anki: meta: add changelog
* [`e9d414af`](https://github.com/NixOS/nixpkgs/commit/e9d414af8068ba69e6a5e514ba2341866e055138) chafa: meta: add changelog
* [`7e0419cf`](https://github.com/NixOS/nixpkgs/commit/7e0419cf17c58512884bbd4e68d0c1ee684ca0ca) ghc: meta: add changelog
* [`dfc7c972`](https://github.com/NixOS/nixpkgs/commit/dfc7c972535574f6d8f9d88d55e377d7dfbc2f75) mozc: meta: add changelog
* [`e824f8c7`](https://github.com/NixOS/nixpkgs/commit/e824f8c7a940649b89d71475ce390be7066a69fa) obs-studio: meta: add changelog
* [`8b9d794a`](https://github.com/NixOS/nixpkgs/commit/8b9d794a860cdda49a60c552294fdd4279b9fe6c) rsync: meta: add changelog
* [`39d05cfa`](https://github.com/NixOS/nixpkgs/commit/39d05cfa48099893c1683bf0d6a8abd58654079c) rustup: meta: add changelog
* [`e50a4a0b`](https://github.com/NixOS/nixpkgs/commit/e50a4a0bb92817d55cff745e16210893f6e4321b) shfmt: meta: add changelog
* [`0ff12097`](https://github.com/NixOS/nixpkgs/commit/0ff1209768b48c9e7e36b8fdd56bd566dcf18950) throne: meta: add changelog
* [`fab26c6d`](https://github.com/NixOS/nixpkgs/commit/fab26c6d1c1517d52aa42c6de10e4339afddac12) kubernix: 0.3.3 -> 0.3.4
* [`b1983cbb`](https://github.com/NixOS/nixpkgs/commit/b1983cbb2449503571745f4e15e76200c9d17988) gcsfuse: 3.11.0 -> 3.11.2
* [`b03d2038`](https://github.com/NixOS/nixpkgs/commit/b03d20386858618793c2cf61fca59931700a16d8) steam-lancache-prefill: 3.5.1 -> 3.6.1
* [`6e769f49`](https://github.com/NixOS/nixpkgs/commit/6e769f4929928cd7bdf68976d9ba39db423f13b8) vscode-extensions.vytautassurvila.csharp-ls: 0.0.33 -> 0.0.34
* [`0a59223b`](https://github.com/NixOS/nixpkgs/commit/0a59223b3a37f364cc4cb7dd4ff709218d408d73) python3Packages.aiovodafone: 3.3.0 -> 3.3.1
* [`abd02ded`](https://github.com/NixOS/nixpkgs/commit/abd02dedcd89e0aee44d033d665e48aa0eb5c74b) prometheus-storagebox-exporter: 1.0.0 -> 1.1.0
* [`4c9fbba8`](https://github.com/NixOS/nixpkgs/commit/4c9fbba869f8bcbe7a66fae9e1d03ca82d2c0a22) nixos/tests/prometheus-exporters: Remove workaround for storagox exporter
* [`23cd53d8`](https://github.com/NixOS/nixpkgs/commit/23cd53d8c39a3768c17b8048a7a74af700e79a52) crowdin-cli: 4.14.4 -> 4.15.0
* [`112a1f05`](https://github.com/NixOS/nixpkgs/commit/112a1f05fae4b328a9880806ff6e79b7d9ee10ee) python3Packages.libtfr: 2.1.9 -> 2.1.10
* [`2dcaafe3`](https://github.com/NixOS/nixpkgs/commit/2dcaafe3c6dba6a4f8e111f552819d0272d5da49) bazel-watcher: 0.30.0 -> 0.32.0
* [`c41b9017`](https://github.com/NixOS/nixpkgs/commit/c41b9017a02bc50d463540768eaab3f8bb67a6bc) qt6Packages.mapbox-gl-qml: init at 3.2.2
* [`e6ad6415`](https://github.com/NixOS/nixpkgs/commit/e6ad6415696460b7be5053b3301ceac82bd3ed86) python3Packages.gguf: add pyprojectVersionPatchHook
* [`1b53ece5`](https://github.com/NixOS/nixpkgs/commit/1b53ece58ce3bcaaacdfb3169958f4cfbf42baef) vivaldi-ffmpeg-codecs: fix update script
* [`8ecbac7a`](https://github.com/NixOS/nixpkgs/commit/8ecbac7ad252e82078134bbe6562a847d3d44387) vivaldi-ffmpeg-codecs: (mixed) -> 123075
* [`626e6c9d`](https://github.com/NixOS/nixpkgs/commit/626e6c9d61f052eddcf7ac00ec45148c22b91619) btcd: 0.26.0 -> 0.26.2
* [`591a9f05`](https://github.com/NixOS/nixpkgs/commit/591a9f05d04e8e7efce954e56d193024980b6f4b) python3Packages.comet-ml: 3.58.3 -> 3.58.4
* [`69e2a2df`](https://github.com/NixOS/nixpkgs/commit/69e2a2df53228cef7782aa9e9cb39a3ffa143f54) nextcloud-notify_push: 1.3.3 -> 1.3.5
* [`211dfafe`](https://github.com/NixOS/nixpkgs/commit/211dfafe1a5ba5e2997dc63c5b2b9ee0581cd74d) pcloud: 2.1.1 -> 2.2.1
* [`cfb40819`](https://github.com/NixOS/nixpkgs/commit/cfb40819d7db5b7e818a9900c16d845c4a35f5f5) grafanaPlugins.grafana-lokiexplore-app: 2.2.1 -> 2.4.0
* [`fc7af1d4`](https://github.com/NixOS/nixpkgs/commit/fc7af1d4a0a3144488b94ca8de32e8e8b65fb07a) shopify-cli: 4.5.1 -> 4.5.2
* [`fe11a354`](https://github.com/NixOS/nixpkgs/commit/fe11a3544701a0d5bba5da9b2e00864f77b91845) eslint: 10.7.0 -> 10.8.0
* [`9151db7e`](https://github.com/NixOS/nixpkgs/commit/9151db7ef62c295118b18f7275b6f5d2051ad9a5) wf-touch: 0-unstable-2021-03-19 -> 0-unstable-2026-07-18
* [`b06abb1a`](https://github.com/NixOS/nixpkgs/commit/b06abb1a820ccb5e60df1817473e9e6c7be51cc4) artalk: switch to finalAttrs; split frontend package
* [`de09a3af`](https://github.com/NixOS/nixpkgs/commit/de09a3af11a17e63c9120ef8b5d6a5d0704684d9) wvkbd: 0.19.4 -> 0.20
* [`f558356d`](https://github.com/NixOS/nixpkgs/commit/f558356de3feb21652bf45698a2032c633afcedc) ffsubsync: 0.4.31 -> 0.5.1
* [`03408319`](https://github.com/NixOS/nixpkgs/commit/03408319758fa793df77523d684dd8d1e96a081f) python3Packages.locust-cloud: relax gevent dependency
* [`895ff067`](https://github.com/NixOS/nixpkgs/commit/895ff067769a9f83bb9ee29b1b257b3de75442a7) flow-state: 1.0.3 -> 1.0.6
* [`79c74b4f`](https://github.com/NixOS/nixpkgs/commit/79c74b4f32a9e589bc5efbe05d1e80e22b1e9ac0) python3Packages.cadwyn: 7.0.0 -> 7.1.1
* [`23e9089e`](https://github.com/NixOS/nixpkgs/commit/23e9089eb1e44346404feea0bea5fb4def3dc1cb) julia-mono: 0.63 -> 0.63.2
* [`8b01f0ee`](https://github.com/NixOS/nixpkgs/commit/8b01f0eebc0fe8527008c7dcdf99c22ff7c79b06) ycm-cmake-modules: 0.18.5 -> 0.18.6
* [`8946c090`](https://github.com/NixOS/nixpkgs/commit/8946c090c53a5d302641a7a59523bc1a1ee3c058) mihomo: 1.19.27 -> 1.19.29
* [`c741259c`](https://github.com/NixOS/nixpkgs/commit/c741259c7649a97d00365a9dee7702e14ed6659d) python3Packages.locust: 2.43.1 -> 2.46.2
* [`acedc973`](https://github.com/NixOS/nixpkgs/commit/acedc973a8e0cfccd8be1ed421c9654eb63d4963) opengist: 1.13.1 -> 1.14.0
* [`410f5631`](https://github.com/NixOS/nixpkgs/commit/410f56318a9294f1d510d406a0d536385220ca3a) vscode-extensions.jnoortheen.nix-ide: 0.5.10 -> 0.5.13
* [`4aa94905`](https://github.com/NixOS/nixpkgs/commit/4aa949058b98774e13502ba5de88f813f2075d96) ubports-pdk: 0-unstable-2026-02-20 -> 0-unstable-2026-07-23
* [`0061a202`](https://github.com/NixOS/nixpkgs/commit/0061a2027a9f46d25011f437b5f8892895c84cc2) python3Packages.pyg-lib: 0.7.0 -> 0.8.0
* [`e033b09b`](https://github.com/NixOS/nixpkgs/commit/e033b09bfe6e97ea88d9517622110ce557ff9791) tflint: 0.63.1 -> 0.64.0
* [`2dc0d421`](https://github.com/NixOS/nixpkgs/commit/2dc0d42192388dff951eed8d89d427471c599668) audit: 4.1.4 -> 4.2
* [`a1f4109b`](https://github.com/NixOS/nixpkgs/commit/a1f4109bfc9dd61f48072c3a76b807c40e11814b) emacs: move withPackages test file into a dir
* [`5a97a90c`](https://github.com/NixOS/nixpkgs/commit/5a97a90c3ba3d87608ec660b20d8f6a33b12574a) emacs: replace magit with dash in withPackages test
* [`f2929549`](https://github.com/NixOS/nixpkgs/commit/f2929549d3e431a961054605d2a1c00d853fa912) emacs: refactor withPackages test to use ERT
* [`b48b3d94`](https://github.com/NixOS/nixpkgs/commit/b48b3d94a9c430895ee2eaf4e3016c5c39b35dab) electron-source: fix build with node_openssl_path
* [`f54941cc`](https://github.com/NixOS/nixpkgs/commit/f54941cc45ecd7ebc88c84ec39ae99697a74c576) ffsubsync: add davinci42 as maintainer
* [`7990e968`](https://github.com/NixOS/nixpkgs/commit/7990e968cb8d784d87113e4af7a32e8ee4d456ec) cudaPackages.setupCudaHook: include nvcc in CUDAToolkit_ROOT
* [`d4536df1`](https://github.com/NixOS/nixpkgs/commit/d4536df1c9f64773622a64c15eb68682278b6978) wine-staging: 11.12 -> 11.14
* [`00d5c65c`](https://github.com/NixOS/nixpkgs/commit/00d5c65c63bbdfecf9bc8be587ffe353ed1a3fe1) gh-aw: 0.80.9 -> 0.83.1
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
