### PR TITLE
npins home-manager: update cbb77679 -> bf9ce9fe

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -48,9 +48,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "cbb77679b3d992c8b62f884cd3a84af534a28621",
-      "url": "https://github.com/nix-community/home-manager/archive/cbb77679b3d992c8b62f884cd3a84af534a28621.tar.gz",
-      "hash": "sha256-kGJTc0oEUQuEwV66lSlMxYtOEtpk9N/HS43k+rFAvs8="
+      "revision": "bf9ce9fec78f95f374e8dd3b503863a3ec128ebe",
+      "url": "https://github.com/nix-community/home-manager/archive/bf9ce9fec78f95f374e8dd3b503863a3ec128ebe.tar.gz",
+      "hash": "sha256-vkMnV0JIyw+g/NmcfoajlGaAO+9a0ezia+FZohQJrik="
     },
     "hs-grille": {
       "type": "Git",


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@cbb77679...bf9ce9fe](https://github.com/nix-community/home-manager/compare/cbb77679b3d992c8b62f884cd3a84af534a28621...bf9ce9fec78f95f374e8dd3b503863a3ec128ebe)

* [`5a9c98a3`](https://github.com/nix-community/home-manager/commit/5a9c98a31a388f97ece5fda45de08cc16e4bed2a) wayland.windowManager.niri: add module
* [`1a58287e`](https://github.com/nix-community/home-manager/commit/1a58287e952138703fc9febf3f0f736d7b6665d8) wayland.windowManager.niri: add tests
* [`4b9337e3`](https://github.com/nix-community/home-manager/commit/4b9337e3bc1a03e482bdda3f7484dfb6550f82fa) wayland.windowManager.niri: apply minor cleanups from review
* [`923de3ea`](https://github.com/nix-community/home-manager/commit/923de3ea34b1222625e7a173ddbb9ae15e6c4b80) wayland.windowManager.niri: consolidate generated config file comments into a single header
* [`b8324779`](https://github.com/nix-community/home-manager/commit/b8324779d178e484b54cf7c202f87ec8c500a3d3) wayland.windowManager.niri: add myself as module maintainer
* [`8e6e0286`](https://github.com/nix-community/home-manager/commit/8e6e0286117b8775d14182984cedebc850cca101) ci: restore maintainer update push trigger
* [`42bb40f7`](https://github.com/nix-community/home-manager/commit/42bb40f7aaab63a107b64a20c4a4ade6550758d0) Translate using Weblate (Bosnian)
* [`fe6c9626`](https://github.com/nix-community/home-manager/commit/fe6c96269436ba80aa6453714947ce8dccdc7689) services-modular: accept both shapes of the nixpkgs service module
* [`aab62b30`](https://github.com/nix-community/home-manager/commit/aab62b300b74d2ad3a6225184cda1c48bbd359ba) launchd: add waitForNixStore agent option
* [`750ea013`](https://github.com/nix-community/home-manager/commit/750ea01379fcae2a006c48e3cc0b1f2b4521f16c) flake: bump nixpkgs from `767b0d3` to `38a4887`
* [`7a0f860e`](https://github.com/nix-community/home-manager/commit/7a0f860e663864e896ae47b75e3f6317580c473f) maintainers: rsahwe moved to nixpkgs
* [`0df0df1a`](https://github.com/nix-community/home-manager/commit/0df0df1aeebbe92d45ac019aa15576e50dfcd51b) maintainers: ckgxrg moved to nixpkgs
* [`f719fae5`](https://github.com/nix-community/home-manager/commit/f719fae554642a162b46b21e6644938e0db0b1d4) maintainers: regenerate all-maintainers.nix
* [`26e67a64`](https://github.com/nix-community/home-manager/commit/26e67a647b45fcf36c4cfc00498e01299dc3447c) tests: preserve stubs through package overrides
* [`1817fbe1`](https://github.com/nix-community/home-manager/commit/1817fbe17930e5e81831dec8020afa4d2b906527) flake: adapt to nixpkgs 26.11
* [`10174c0f`](https://github.com/nix-community/home-manager/commit/10174c0fe02099dbdee2bf918f1a92659fc9217f) zsh: fix quotes in initContent description
* [`43228e08`](https://github.com/nix-community/home-manager/commit/43228e08c09fdef4afa42c625d1b53cf130f49ff) wayland.windowManager.niri: escape backslashes in KDL strings
* [`3d25fa94`](https://github.com/nix-community/home-manager/commit/3d25fa94cf355cf7da64c77bb9c3c15806486329) lib: option to escape tabs in lib.hm.generators.toKDL
* [`a14065d1`](https://github.com/nix-community/home-manager/commit/a14065d14edbb0d0bccf9c70e0c9cfcda5f1771d) firefox: more precise documentation of StoreID
* [`17a47e6c`](https://github.com/nix-community/home-manager/commit/17a47e6cb81803d35e0985c44238027c614c0166) hyprlauncher: preserve launched applications
* [`4ebe20f1`](https://github.com/nix-community/home-manager/commit/4ebe20f1126cf4554e4b876dcd9fb0e159f88116) ghostty: source shell integration only when present
* [`28942e21`](https://github.com/nix-community/home-manager/commit/28942e2165e8555d437979620c7f1eca3f89b684) easyeffects: handle null extra presets
* [`eca53f53`](https://github.com/nix-community/home-manager/commit/eca53f53b249b90269aedc2a005e9aeb9914a37c) vdirsyncer: keep active service during activation
* [`36662afe`](https://github.com/nix-community/home-manager/commit/36662afed2fa1c9b69bdd03edb92ad572202ca20) vdirsyncer: test keep-old service switch
* [`e705714e`](https://github.com/nix-community/home-manager/commit/e705714e918c3b11affcdd15db2cbe3a070420a0) fcitx5: improve flexibility
* [`ca287c20`](https://github.com/nix-community/home-manager/commit/ca287c205447e1671c52c2400b262e735e5657ca) buildbot-nix: build release branches
* [`277f1299`](https://github.com/nix-community/home-manager/commit/277f129993e89e78805fb7881a27896a52445e50) hyprland: fix session cleanup with systemd integration enabled
* [`6d25edfb`](https://github.com/nix-community/home-manager/commit/6d25edfbd109bd6c0bb950a2fb6c37141795e3f1) hyprland: fix session cleanup with systemd (hyprlang)
* [`2e671597`](https://github.com/nix-community/home-manager/commit/2e6715977106c498355a70bcefd2c78a33c94558) mise: allow mutable global configuration
* [`e8827fbb`](https://github.com/nix-community/home-manager/commit/e8827fbbb12015a8dd9f66285aec79d655bcb9f6) Translate using Weblate (Hungarian)
* [`02711ea9`](https://github.com/nix-community/home-manager/commit/02711ea959a70e031c52e1e44b4b25d2c72de32f) nixbot: migrate buildbot-nix config to nixbot
* [`47a42757`](https://github.com/nix-community/home-manager/commit/47a4275796d486fece3dfa7b55c31c723afb5386) docs: fix link to allowed-users documentation
* [`bf9ce9fe`](https://github.com/nix-community/home-manager/commit/bf9ce9fec78f95f374e8dd3b503863a3ec128ebe) chromium: add support for brave-origin
