### PR TITLE
npins zsh-patina: update 3d980f07 -> 0e365ffa

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -242,9 +242,9 @@
       },
       "branch": "main",
       "submodules": false,
-      "revision": "3d980f076fef130403e5fcccdac9510c234ca6fd",
-      "url": "https://github.com/michel-kraemer/zsh-patina/archive/3d980f076fef130403e5fcccdac9510c234ca6fd.tar.gz",
-      "hash": "sha256-8RgWgLZZeQZGRleKcCGpQk2Ipubk5PBdDzfUUDS9OT8="
+      "revision": "0e365ffa038865668cd148b388f142e7e4713613",
+      "url": "https://github.com/michel-kraemer/zsh-patina/archive/0e365ffa038865668cd148b388f142e7e4713613.tar.gz",
+      "hash": "sha256-+DpjlFDm3foyPetFINiuSB7PxtfFLUiIYno8o5mvC34="
     },
     "zsh-syntax-highlighting": {
       "type": "Git",


### PR DESCRIPTION
## Changelog for zsh-patina:
Branch: main
Commits: [michel-kraemer/zsh-patina@3d980f07...0e365ffa](https://github.com/michel-kraemer/zsh-patina/compare/3d980f076fef130403e5fcccdac9510c234ca6fd...0e365ffa038865668cd148b388f142e7e4713613)

* [`55e66149`](https://github.com/michel-kraemer/zsh-patina/commit/55e66149ec37071c879b02cbbd560a6c6b83f1fe) Update dependencies
* [`2f017e7f`](https://github.com/michel-kraemer/zsh-patina/commit/2f017e7f6b7a5f4c616db18635d94785c34d4c06) Update action dependencies
* [`e5e1ff39`](https://github.com/michel-kraemer/zsh-patina/commit/e5e1ff3948b01e5d9d401b8528d08fba956d3f07) Deprecate flake.nix
