### PR TITLE
npins nixpkgs: update 3939c15d -> 0eae3d8b

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -125,9 +125,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "3939c15de1fe3ee41f23f0ae1710c3a375c99f21",
-      "url": "https://github.com/nixos/nixpkgs/archive/3939c15de1fe3ee41f23f0ae1710c3a375c99f21.tar.gz",
-      "hash": "sha256-RUHYwOMO4ENeDLSKlYeajjwn/d96h5rSCbBWpOVYHkE="
+      "revision": "0eae3d8bc21612049425097335e17dae1a268d41",
+      "url": "https://github.com/nixos/nixpkgs/archive/0eae3d8bc21612049425097335e17dae1a268d41.tar.gz",
+      "hash": "sha256-FQFNo9f/TEhmMiyELLfBO5OXWWAbJ/pTIVql4Rts4Ko="
     },
     "powerlevel10k": {
       "type": "Git",


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@3939c15d...0eae3d8b](https://github.com/nixos/nixpkgs/compare/3939c15de1fe3ee41f23f0ae1710c3a375c99f21...0eae3d8bc21612049425097335e17dae1a268d41)

* [`78b3de68`](https://github.com/NixOS/nixpkgs/commit/78b3de68a94eb7ec43c6cef1d9b1ebceccc02214) ament-cmake-core-jazzy: init at 2.5.4-1
* [`834b0372`](https://github.com/NixOS/nixpkgs/commit/834b0372be09558397517c96526d94ab67166221) emacsPackages.wat-mode: switch to `nix-update-script`
* [`45f34c98`](https://github.com/NixOS/nixpkgs/commit/45f34c984d2a4d943b8db99be68ce253ae37a866) emacsPackages.manualPackages.eaf-browser: 0-unstable-2025-06-14 -> 0-unstable-2025-06-13
* [`a5267ddd`](https://github.com/NixOS/nixpkgs/commit/a5267dddf42a67081a1679d62733ca3915545c0d) emacsPackages.manualPackages.eaf-map: 0-unstable-2025-07-04 -> 0-unstable-2025-07-26
* [`3cd9f831`](https://github.com/NixOS/nixpkgs/commit/3cd9f831a6c4e1bdf67f1b75c16e7ad6fc13262b) emacsPackages.manualPackages.eaf-pyqterminal: 0-unstable-2025-05-05 -> 0-unstable-2025-10-19
* [`899609af`](https://github.com/NixOS/nixpkgs/commit/899609aff5d86e8556746b8a01e764b708ebdbce) emacsPackages.manualPackages.elpaca: 0-unstable-2025-02-16 -> 0-unstable-2025-11-06
* [`1c03cb69`](https://github.com/NixOS/nixpkgs/commit/1c03cb6920e67b031b7c93e58b56f6ea2038920f) emacsPackages.manualPackages.git-undo: 0-unstable-2022-08-07 -> 0-unstable-2025-09-22
* [`f439ad87`](https://github.com/NixOS/nixpkgs/commit/f439ad871984d95abd3fa8c94ff4a2970b6384f8) emacsPackages.manualPackages.emacs-application-framework: 0-unstable-2025-08-22 -> 0-unstable-2025-08-29
* [`dd49658c`](https://github.com/NixOS/nixpkgs/commit/dd49658c3004669850b1d2cbe36074b3d907f8c4) emacsPackages.manualPackages.straight: 0-unstable-2025-01-30 -> 0-unstable-2025-11-21
* [`1fe23b03`](https://github.com/NixOS/nixpkgs/commit/1fe23b03ce4a8e1e016cfada58bb105383abdf26) emacsPackages.manualPackages.notdeft: 0-unstable-2025-02-04 -> 0-unstable-2025-06-14
* [`3e50c165`](https://github.com/NixOS/nixpkgs/commit/3e50c16508611c8381b6521150dd127b23764941) ghq: enable tests
* [`1b713f3d`](https://github.com/NixOS/nixpkgs/commit/1b713f3d13ad855e271899eb3293fa9c5b0129d6) maintainers: add macaquinyho
* [`a6ab8ff8`](https://github.com/NixOS/nixpkgs/commit/a6ab8ff8e430610335e0c9f973122a3c6ed79203) vali: init at version 0.1.1
* [`381e534e`](https://github.com/NixOS/nixpkgs/commit/381e534e23d384f2b9c2cd7d1bd11d7be4136cea) kanshi: 1.8.0 -> 1.9.0
* [`0e715993`](https://github.com/NixOS/nixpkgs/commit/0e715993468a55d6e5ac636c06e994a4e76a9354) nixos/kanshi: init module
* [`eaa12161`](https://github.com/NixOS/nixpkgs/commit/eaa12161a0d6791a8a95bf98333486a969d1c664) amdenc: 1.0-1787253 -> 25.10-2203192
* [`de04d825`](https://github.com/NixOS/nixpkgs/commit/de04d8259eb6bb7a191b27727391a6f377d3cc80) amf: 1.4.34-1787253 -> 1.4.37-2203192
* [`f4265280`](https://github.com/NixOS/nixpkgs/commit/f426528010730d0291356102134bc698553363e6) networkmanager-iodine: 1.2.0-unstable-2025-12-22 -> 1.2.0-unstable-2026-03-14
* [`49051a8d`](https://github.com/NixOS/nixpkgs/commit/49051a8dab88094305a66d3e30018420012f46fc) avalonia-ilspy: migrate to by-name
* [`77341391`](https://github.com/NixOS/nixpkgs/commit/77341391de8fc5d4e9d1e74b1ba99d1162017563) alac: 0.0.7-unstable-2024-10-16 -> 0.0.7-unstable-2026-04-10
* [`45d0ddc9`](https://github.com/NixOS/nixpkgs/commit/45d0ddc9ad39ae2d1b4eacd7bc28fbcd399fa64a) oracle-instantclient: remove unused optionals from inherit
* [`b8cc960e`](https://github.com/NixOS/nixpkgs/commit/b8cc960e34bdc3514cef06b691bf1dedd2e4991d) blitz: fix unused let bindings
* [`0dc8665d`](https://github.com/NixOS/nixpkgs/commit/0dc8665db2764a7c4108e0733c92a87b0be39728) gsm: fix unused let bindings
* [`c0e9b137`](https://github.com/NixOS/nixpkgs/commit/c0e9b137e9d5b213c4acc21eafae75147f663b5f) libmikmod: fix unused let bindings
* [`dd24e8bf`](https://github.com/NixOS/nixpkgs/commit/dd24e8bf8039408429af175785c670964a5cde86) squeezelite: fix unused let bindings
* [`3c489835`](https://github.com/NixOS/nixpkgs/commit/3c48983574d113d1e507b6e871ec3b1bf22732b1) stable-diffusion-cpp: fix unused let bindings
* [`f7677c31`](https://github.com/NixOS/nixpkgs/commit/f7677c31039f9d11fe0b723499f2e7166583eba5) minc_tools: migrate to by-name
* [`1a13db43`](https://github.com/NixOS/nixpkgs/commit/1a13db43e496229b70d9e42c8ae11eb0b621dc18) safeeyes: 3.3.0 -> 3.5.0
* [`2dae572f`](https://github.com/NixOS/nixpkgs/commit/2dae572f529125e4cca9bc0c0d784685cff21b47) alpine: 2.29.9 -> 2.29.99
* [`7bd6dfde`](https://github.com/NixOS/nixpkgs/commit/7bd6dfde2feeb6d8472eb36f87c549b791665e38) emacs/wrapper.nix: expose extra package binaries via PATH
* [`6c93afb8`](https://github.com/NixOS/nixpkgs/commit/6c93afb84bc3b54969fed7353a4f0c5b6199470e) python313Packages.colcon-ed: init at 0.3.0
* [`aff3386f`](https://github.com/NixOS/nixpkgs/commit/aff3386ffd1c00309e8e12b0919cb03c1a346263) python313Packages.colcon-bash: init at 0.5.0
* [`39f7e919`](https://github.com/NixOS/nixpkgs/commit/39f7e919f2e29d9d0965d2898535a399cdd8d5c1) liberation_ttf: use installFonts hook
* [`3a32efc2`](https://github.com/NixOS/nixpkgs/commit/3a32efc2eaa2014fe86c6a24b8e7baab98327ac1) lohit-fonts: use installFonts
* [`bcab0f4f`](https://github.com/NixOS/nixpkgs/commit/bcab0f4fb97d00a15714f4b832f8c4696cf90bb6) data/fonts/gdouros: use installFonts
* [`c01bebe4`](https://github.com/NixOS/nixpkgs/commit/c01bebe4a52cfc7f5b2140b9f0f3e9d94ac1db58) mplus-outline-fonts: use installFonts
* [`318f67fc`](https://github.com/NixOS/nixpkgs/commit/318f67fcf0a58542726eed1c2b6cf25425a8dcb3) data/fonts/open-relay: use installFonts
* [`f0671ea3`](https://github.com/NixOS/nixpkgs/commit/f0671ea36c1cbb46ef40cc8174b06b8b4aa22baf) aurulent-sans: migration to installFonts
* [`b239b59a`](https://github.com/NixOS/nixpkgs/commit/b239b59aed020513436a198f1c31698b0c89057b) aurulent-sans: use finalAttrs
* [`6b8165ba`](https://github.com/NixOS/nixpkgs/commit/6b8165ba6e53c03ce9cab0f2e13f939e09e27a38) aurulent-sans: fix description
* [`a21a33f5`](https://github.com/NixOS/nixpkgs/commit/a21a33f50d4c9c9d4bf203ae386f8594520f77a9) inputplumber: fix config files not linked by default
* [`3189debe`](https://github.com/NixOS/nixpkgs/commit/3189debed6b4762800b9e215de1ce451ec120507) firejail: 0.9.76 -> 0.9.80
* [`4944d89f`](https://github.com/NixOS/nixpkgs/commit/4944d89f96ce656473e25082152a135d6d15f8c4) dr14_tmeter: migrate to pyproject
* [`aa243c4d`](https://github.com/NixOS/nixpkgs/commit/aa243c4dd245ed7b4f254cd544e4ce9aa703a7a0) awesome: migrate to by-name
* [`26faa80a`](https://github.com/NixOS/nixpkgs/commit/26faa80acc00b2ba331ccdcdfeff426f33a8afee) marelle: init at 1.004
* [`89a80332`](https://github.com/NixOS/nixpkgs/commit/89a8033268e207083ad32bf04c73201fdec04580) lib.attrsets.genAttrs: redefine genAttrs' logic inline
* [`6efa05fb`](https://github.com/NixOS/nixpkgs/commit/6efa05fb8b63c0cb82b4bdbf00f800bdff7c7e7e) ubuntu-sans-mono: 1.006 -> 1.100
* [`dac30f5f`](https://github.com/NixOS/nixpkgs/commit/dac30f5f49b4db567b24d2985ed80c8248f7f6ac) nixos/stage-1: make "testing patched programs" build output more useful
* [`354c3791`](https://github.com/NixOS/nixpkgs/commit/354c3791937b0f79496596881c7c0e6d97cb943e) python3Packages.addict: migrate to pyproject
* [`de6ab85f`](https://github.com/NixOS/nixpkgs/commit/de6ab85fc63a66119126f236ddb082351eab7fe7) python3Packages.addict: use finalAttrs
* [`3c9635b5`](https://github.com/NixOS/nixpkgs/commit/3c9635b553c6476c7ae98e04d0c71095c2cc5f88) python3Packages.aiokef: migrate to pyproject
* [`6648ba71`](https://github.com/NixOS/nixpkgs/commit/6648ba71f122bc66a1545e6c382659e573f8e668) python3Packages.aiokef: use finalAttrs
* [`cc0e43d2`](https://github.com/NixOS/nixpkgs/commit/cc0e43d22ab54951ccdd311bf414d02e5d250597) miro: 0.8.1 -> 0.10.1
* [`d5000c9f`](https://github.com/NixOS/nixpkgs/commit/d5000c9f6e4f3b3ece6ae1157f09d614fee3ea33) crystfel-headless: migrate to by-name
* [`9d397fe1`](https://github.com/NixOS/nixpkgs/commit/9d397fe1910cf6f7e6cdc3b4f9f119c4403743f1) gmrender-resurrect: migrate to by-name
* [`1ac89ed4`](https://github.com/NixOS/nixpkgs/commit/1ac89ed4e8015d2141da72587ac2f4a2f7b282ee) super: fix license
* [`85eb9100`](https://github.com/NixOS/nixpkgs/commit/85eb9100ec7f5c19fdb1d2c675a5e1abe342217a) nagios: 4.5.11 -> 4.5.13
* [`f66eef4d`](https://github.com/NixOS/nixpkgs/commit/f66eef4d528c160112939173fd5fc6f48ff1dd8e) python3Packages.stim: 1.15.0 -> 1.16.0
* [`c707a103`](https://github.com/NixOS/nixpkgs/commit/c707a103a415bc10b46a99e5b66b50b30f7f6e8a) doxx: 0.1.2 -> 0.1.4
* [`a00eacba`](https://github.com/NixOS/nixpkgs/commit/a00eacba227891cc15aa873e29865bb2716f73a1) drbd: 9.2.16 -> 9.3.2
* [`71d9c5b5`](https://github.com/NixOS/nixpkgs/commit/71d9c5b5bb9219db41885c89aa151a834e062082) linuxPackages.lkrg: 1.0.0 -> 1.0.1
* [`1b9d9e1c`](https://github.com/NixOS/nixpkgs/commit/1b9d9e1cfc379ef9639765fadce8248353e2f71b) gz-cmake: 5.0.0 -> 5.1.1
* [`e09e290a`](https://github.com/NixOS/nixpkgs/commit/e09e290a8bbac7fefa15375d2fa28834fe123c87) gz-utils: 3.1.1 -> 4.0.0
* [`5c150cdf`](https://github.com/NixOS/nixpkgs/commit/5c150cdfc9143009c2928f713029a146573c082e) gz-math: init at 9.1.0
* [`5487e1e0`](https://github.com/NixOS/nixpkgs/commit/5487e1e0f3987e3f57fa6d259a4928e667b040cc) python3Packages.bangla: migrate to pyproject
* [`7ce9753b`](https://github.com/NixOS/nixpkgs/commit/7ce9753bd8f7b4939eefae50efa244a78c69db67) nixos/niri: pin defaultSession so GDM 50 stops bouncing to gnome-session
* [`0c3e3b3a`](https://github.com/NixOS/nixpkgs/commit/0c3e3b3ae23013ddeeadf950a8bed85290d52699) python3Packages.bangla: modernize
* [`ed16d0b5`](https://github.com/NixOS/nixpkgs/commit/ed16d0b5c180a18792b7fb73d45df2fded56e0b7) python3Packages.bnunicodenormalizer: migrate to pyproject
* [`425d74bf`](https://github.com/NixOS/nixpkgs/commit/425d74bf5b91be822896e85a4ba32866faa3ea09) python3Packages.bnunicodenormalizer: modernize
* [`ff951ec2`](https://github.com/NixOS/nixpkgs/commit/ff951ec23a3019f369a3d9d9949f083b3765806b) dtrx: sort inputs
* [`09f6b1b7`](https://github.com/NixOS/nixpkgs/commit/09f6b1b74e01349f3b8f5ad00724a52b6a2fcc4f) dtrx: extract `archivers` to toplevel
* [`2a41b598`](https://github.com/NixOS/nixpkgs/commit/2a41b5985f0ac0fede492d5f9eca8d6856737f78) dtrx: enable tests + more archivers
* [`592d5a1f`](https://github.com/NixOS/nixpkgs/commit/592d5a1f3cdf9fdf6b4e0ac0e1fca937bc7e43c4) dtrx: use unwrapped binutils
* [`eca56b5a`](https://github.com/NixOS/nixpkgs/commit/eca56b5a7d857175f6615310fd06e11065f13a06) dtrx: remove a usage of `with`
* [`9da43531`](https://github.com/NixOS/nixpkgs/commit/9da43531d2609af8f80e0cd992ff0ae7438392d3) pocketsphinx: 5.0.4 -> 5.1.1
* [`1a90b50c`](https://github.com/NixOS/nixpkgs/commit/1a90b50c6a0e64dc6bbf8536ff999c9b93a42ee9) python3Packages.manuel: use finalAttrs
* [`37ddc688`](https://github.com/NixOS/nixpkgs/commit/37ddc68876ddd65fcd4439ab0f65206d94593f33) python3Packages.manuel: enable __structuredAttrs
* [`bccb7873`](https://github.com/NixOS/nixpkgs/commit/bccb7873c194170acb97d13f450bc946ab14e1ac) python3Packages.manuel: migrate to pyproject
* [`06cc3b00`](https://github.com/NixOS/nixpkgs/commit/06cc3b00504df267452bdfa9769a407064a9a8b5) python3Packages.manuel: remove unneeded patch and dependency
* [`1f2644b8`](https://github.com/NixOS/nixpkgs/commit/1f2644b804f7eb903f73d453614579c7028d44e7) python3Packages.manuel: add changelog
* [`1ca26aac`](https://github.com/NixOS/nixpkgs/commit/1ca26aacba7dab29b7419bb5ab29dc172dc972cb) python3Packages.manuel: enable tests
* [`f3b65469`](https://github.com/NixOS/nixpkgs/commit/f3b65469de837f0ec01fa8ca867acb9c4f74f778) faiss: 1.14.2 -> 1.14.3
* [`29fbfdee`](https://github.com/NixOS/nixpkgs/commit/29fbfdeec9c8dad760b6837fdfdb3c70f39b2b7f) vscode-extensions.angular.ng-template: 22.0.0 -> 22.0.1
* [`f6484bc1`](https://github.com/NixOS/nixpkgs/commit/f6484bc1fb9adcf4d23e805c35b2f5a78627bbba) bigquery-emulator: 0.6.6 -> 0.8.1
* [`54717de1`](https://github.com/NixOS/nixpkgs/commit/54717de1699ca1641ad8b5d2b3e298db9bfa88b2) lincity-ng: 2.14.2 -> 2.15.0
* [`70f51cc0`](https://github.com/NixOS/nixpkgs/commit/70f51cc0b2ec472a85e06cb88b7e6542cb612bd8) cairo: default ipc_rmid_deferred_release to false
* [`cb294301`](https://github.com/NixOS/nixpkgs/commit/cb2943013d75163a9cfe9295ff3d3bf12c1bfaed) nixos/version: add system.moduleStateRevisions
* [`a102251d`](https://github.com/NixOS/nixpkgs/commit/a102251d665d158c81b83b7d0bdd4641e467a26c) utils.mkStateRevisionOption: init
* [`4a2b484e`](https://github.com/NixOS/nixpkgs/commit/4a2b484ec82f65d78947962152d449a69e9aa40a) nixos/seerr: use utils.mkStateRevisionOption
* [`1037ad3c`](https://github.com/NixOS/nixpkgs/commit/1037ad3cdfc7da9748df0e112bf811d4e97a73cd) radvd: set sysconfdir
* [`092986fe`](https://github.com/NixOS/nixpkgs/commit/092986fe6bcd362d7c251ddad1d5ef2d3be8e41a) guile-gnutls: 5.0.1 -> 5.0.2
* [`c6259aa2`](https://github.com/NixOS/nixpkgs/commit/c6259aa239bc687967d4594321c98d8260f5cb68) nwg-dock-hyprland: 0.4.9 -> 0.4.11
* [`2ffbde27`](https://github.com/NixOS/nixpkgs/commit/2ffbde2794b411b3952bc064a24a8321edacff8d) bender: 0.28.2 -> 0.31.0
* [`66ce2498`](https://github.com/NixOS/nixpkgs/commit/66ce24982a4ab5cae62c025be5beec721776f4d6) texmacs: inline font sources and remove common.nix indirection
* [`be53552a`](https://github.com/NixOS/nixpkgs/commit/be53552a2dc0e7d438eda38c3c893f95d960f398) texmacs: migrate to by-name
* [`411e96cf`](https://github.com/NixOS/nixpkgs/commit/411e96cfa2518135fd9efb2df37cc2f21c5ca70b) lib.attrsets.getAttrFromPath: beta reduce
* [`75cf7254`](https://github.com/NixOS/nixpkgs/commit/75cf72544421a0767ff9c7f3e6cfa215bf0b0da4) lib.attrsets.recurseIntoAttrs: only create attrset once
* [`27e8b1f6`](https://github.com/NixOS/nixpkgs/commit/27e8b1f69fc73156ff429df49b7931c5b9429c57) lib.attrsets.dontRecurseIntoAttrs: only create attrset once
* [`8760d9db`](https://github.com/NixOS/nixpkgs/commit/8760d9dbed9900956e2390c96926dbd9ec71940b) lib.attrsets.collect: use recurse function to avoid passing pred
* [`15f85c33`](https://github.com/NixOS/nixpkgs/commit/15f85c338ebb1c17920de5f7406a3b006bf79f49) bender: 0.31.0 -> 0.32.0
* [`17c6f784`](https://github.com/NixOS/nixpkgs/commit/17c6f78468cf10d80246ac5a48ee234a007dae8e) fooyin: 0.9.2 -> 0.11.1
* [`26ddb0d8`](https://github.com/NixOS/nixpkgs/commit/26ddb0d85727164a04a8113b384b813e027230d2) lib.attrsets.getFirstOutput: inline variable
* [`24b77159`](https://github.com/NixOS/nixpkgs/commit/24b77159debed0cb44dcb66f8693fec42eeee865) lib.attrsets.getFirstOutput: use ? instead of hasAttr
* [`ebbae956`](https://github.com/NixOS/nixpkgs/commit/ebbae9566aafbb0127d81f131ff486dbe37da7e9) lib.attrsets.getFirstOutput: avoid builtins lookup
* [`442c1d92`](https://github.com/NixOS/nixpkgs/commit/442c1d929674ea685afc703ba08fb2bf7289ec0d) lib.attrsets.mapAttrsRecursive: beta reduce
* [`24868ea8`](https://github.com/NixOS/nixpkgs/commit/24868ea8195df9da96d8782196dc749dda8fa7e2) unrar-wrapper: enable __structuredAttrs
* [`efe00033`](https://github.com/NixOS/nixpkgs/commit/efe00033e89c285a0a91a5c6d2fe9736402d15ea) unrar-wrapper: migrate to pyproject
* [`eb31ab22`](https://github.com/NixOS/nixpkgs/commit/eb31ab22111cf52193ae2ec8daa377a7c80eeb17) unrar-wrapper: enable tests
* [`4052e6b3`](https://github.com/NixOS/nixpkgs/commit/4052e6b3db96aef7ca375a2ba3cfe0e78b76631a) hydrogen-web{,-unwrapped}: migrate to finalAttrs, move config parameter out of top-level
* [`e6d29683`](https://github.com/NixOS/nixpkgs/commit/e6d29683dd5bc6654003f669e39c33599b8ef9cb) hydrogen-web{,-unwrapped}: migrate to by-name
* [`4ffc664c`](https://github.com/NixOS/nixpkgs/commit/4ffc664cd166cfe74c033e54f5513237daa612d2) nixos/systemd: generate boot random seed with config esp path
* [`b40e31b1`](https://github.com/NixOS/nixpkgs/commit/b40e31b17d12f7a545ede705164c1232196ef6fc) python3Packages.sqlmodel: 0.0.38 -> 0.0.39
* [`a13398a4`](https://github.com/NixOS/nixpkgs/commit/a13398a4e7d060143ced2b03929aabb88b83e69a) nixos/gnome: add glycin-thumbnailer and gst-thumbnailers
* [`64262df5`](https://github.com/NixOS/nixpkgs/commit/64262df5c3cd5405117ac819d3770ffbd7c7b7e0) glycin-thumbnailer: remove redundant `shopt -s failglob`
* [`bbed7f42`](https://github.com/NixOS/nixpkgs/commit/bbed7f42209c9dab75f8bec032dcacb426970765) adminneo: 5.4.1 -> 5.5.0
* [`a16da51a`](https://github.com/NixOS/nixpkgs/commit/a16da51ac23d7375fe7970d8f4d9fdc87f449cb9) carapace: 1.7.1 -> 1.7.3
* [`b62797c4`](https://github.com/NixOS/nixpkgs/commit/b62797c417ea3dbbef19fc64ebbbd6e5155c2c61) _389-ds-base: 3.1.3 -> 3.3.0
* [`236dd2ac`](https://github.com/NixOS/nixpkgs/commit/236dd2aca172678828395452a9ae8e960b9fe8e0) jack-passthrough: 0-unstable-2021-9-25 -> 0-unstable-2021-09-25
* [`2457e894`](https://github.com/NixOS/nixpkgs/commit/2457e894ba8e631cb94cfb2190ada50b0d3d5b83) python3Packages.sgmllib3k: migrate to pyproject
* [`489562d3`](https://github.com/NixOS/nixpkgs/commit/489562d3b1e895ac40b02ae8766093095b27641d) ncdu: 2.9.2 -> 2.10.0, update source
* [`3cfd6122`](https://github.com/NixOS/nixpkgs/commit/3cfd6122b297201279c37ac82db3f9e00e7e1d6e) unrar-wrapper: use tag instead of rev
* [`ed7c0431`](https://github.com/NixOS/nixpkgs/commit/ed7c043162eb1e423f280d04ff099741b367f5f5) packer: add all official plugins
* [`a270c211`](https://github.com/NixOS/nixpkgs/commit/a270c211db16229ebd63c8a35f798199e7f02db1) python3Packages.notobuilder: 0-unstable-2026-02-25 -> 0-unstable-2026-06-26
* [`86c915a3`](https://github.com/NixOS/nixpkgs/commit/86c915a38078a4fb52622e2d87d7418ca07e3d26) easytier.services.default: init
* [`bcc11dfd`](https://github.com/NixOS/nixpkgs/commit/bcc11dfd7a50a04204f0d9c9100bca9ef551ff02) nixosTests.easytier-modular: init
* [`dfba3a7b`](https://github.com/NixOS/nixpkgs/commit/dfba3a7bc1faf13a531e9f4249df3e93a25d228c) nixos/security.wrappers: include CAP_LAST_CAP when raising ambient capabilities
* [`3b2c2a6e`](https://github.com/NixOS/nixpkgs/commit/3b2c2a6e60d41d4d99c3a80aa547f084f814976c) gnome-contacts: add glycin-loaders to buildInputs
* [`f596d492`](https://github.com/NixOS/nixpkgs/commit/f596d4920a24fe0e9a68aa15d7b6c5fad76beedf) vips: 8.18.3 -> 8.18.4
* [`7e81743a`](https://github.com/NixOS/nixpkgs/commit/7e81743aa6fc659cab13f4fc9b93028a5fe1e3be) lib.systems: add GOARCH for big-endian mips64
* [`a06c213c`](https://github.com/NixOS/nixpkgs/commit/a06c213ca965848e499181c96e744cf36ca941a2) putty: move arguments out of top-level
* [`76f610d4`](https://github.com/NixOS/nixpkgs/commit/76f610d42e3dbf739369a4902f3d7273ef1b19a6) putty: use finalAttrs, strictDeps and structuredAttrs
* [`554a9e5a`](https://github.com/NixOS/nixpkgs/commit/554a9e5a74f4b4edf7f430715470cff4e1c737ad) putty: migrate to by-name
* [`1e20e6f6`](https://github.com/NixOS/nixpkgs/commit/1e20e6f6f208c3cb2b197556c4451ace793f271a) mcpelauncher-{client,ui-qt}: 1.6.4-qt6 -> 1.7.6-qt6
* [`089ea70b`](https://github.com/NixOS/nixpkgs/commit/089ea70ba8c3d30d455913f0aec6acb6426c4e8f) python3Packages.types-futures: migrate to pyproject
* [`f530f2e6`](https://github.com/NixOS/nixpkgs/commit/f530f2e67469361668c8d2f5e72476a43292b063) python3Packages.types-protobuf: migrate to pyproject
* [`ddea34a9`](https://github.com/NixOS/nixpkgs/commit/ddea34a987e728766adda8b1060c28c275664d26) python3Packages.types-pillow: migrate to pyproject
* [`622ee391`](https://github.com/NixOS/nixpkgs/commit/622ee391c8e42ce6b4ca1ed066823ac58c0dd6e0) python3Packages.types-pillow: modernize
* [`7b482337`](https://github.com/NixOS/nixpkgs/commit/7b48233784dcc86fd4cc855102bc40a36b518305) python3Packages.types-protobuf: modernize
* [`e0250af0`](https://github.com/NixOS/nixpkgs/commit/e0250af0c5d36dc7395167622d3f788a7270c64b) gnomeExtensions.appindicator: Hardcode gjs path
* [`00f1b267`](https://github.com/NixOS/nixpkgs/commit/00f1b2674f521daf2c1237ffbf6ccb8c5c4002bf) python3Packages.aioredis: migrate to pyproject
* [`018c3d82`](https://github.com/NixOS/nixpkgs/commit/018c3d8271fddba04666552bebe22f20b1ddf243) gambit-project: 16.6.0 -> 16.7.0
* [`33b760a3`](https://github.com/NixOS/nixpkgs/commit/33b760a3168b375b965bcdec149aba9027aa3a4b) python3Packages.oslo-i18n: 6.8.0 -> 6.9.0
* [`929106f3`](https://github.com/NixOS/nixpkgs/commit/929106f36ebfad9c18248407e631e2996dde9360) python3Packages.oslo-context: 6.3.0 -> 6.5.0
* [`74e4b1d9`](https://github.com/NixOS/nixpkgs/commit/74e4b1d9d71e0103e3be6fa7d41dc49d89260010) python3Packages.pipcl: 11 -> 12
* [`60954604`](https://github.com/NixOS/nixpkgs/commit/6095460439dc2c1e81393e13f6fd5b6406dc7be7) autopush-rs.services.{autoconnect,authoendpoint}: rename package attribute
* [`31edeb65`](https://github.com/NixOS/nixpkgs/commit/31edeb652d0dad962f1f3cccde2bff4b058d7aee) mitm-cache: fetch: drop query
* [`3609aec2`](https://github.com/NixOS/nixpkgs/commit/3609aec22472624e932bd09b055aedcc7ea68a5f) swagger-typescript-api: 13.9.3 -> 13.12.4
* [`8bb850c5`](https://github.com/NixOS/nixpkgs/commit/8bb850c5662d70123d51f2744c5b01f5a9335cc8) python3Packages.oslo-serialization: 5.9.1 -> 5.11.0
* [`e3a1dc95`](https://github.com/NixOS/nixpkgs/commit/e3a1dc95530582634180bb444209f2db2535cf8e) python3Packages.ansible-core: 2.21.1 -> 2.21.2
* [`192ef8c7`](https://github.com/NixOS/nixpkgs/commit/192ef8c70d48b1f7582d5fb1a2a2f39a2ca27aa0) opendrop: drop
* [`7244c725`](https://github.com/NixOS/nixpkgs/commit/7244c725a05cd163ca6ed60a92f2d2968aba1080) owl: drop
* [`ccb49ccc`](https://github.com/NixOS/nixpkgs/commit/ccb49ccc9f9925eea99952623c26bfa20d0811fe) factorio-experimental: 2.1.10 -> 2.1.11
* [`c78a4538`](https://github.com/NixOS/nixpkgs/commit/c78a453825c201435b1b4901f8955de7ac14060d) python3Packages.pgvector: 0.4.2 -> 0.5.0
* [`6dea70a5`](https://github.com/NixOS/nixpkgs/commit/6dea70a58cb7bc29b89c37469c0073269fb3ce41) maintainers: add irgendeinwer
* [`7ddbc35e`](https://github.com/NixOS/nixpkgs/commit/7ddbc35e37b7eb03d7b6436ad43fd760768c1e5b) verible: fix hash mismatch and build in bazel sandbox on darwin
* [`5d750c58`](https://github.com/NixOS/nixpkgs/commit/5d750c586651309622cfcb25b3224403511c2108) rpi-imager: 2.0.10 -> 2.0.10-1-proto1
* [`dcceb50b`](https://github.com/NixOS/nixpkgs/commit/dcceb50b55a119fd132a3ef5f62ffa1eb1add714) lib.licenses: add bugroff
* [`ee282178`](https://github.com/NixOS/nixpkgs/commit/ee282178bfe608193f3156b6355046eae87ca0ee) lib.licenses: add llgplPreamble
* [`7bf884a9`](https://github.com/NixOS/nixpkgs/commit/7bf884a90cf933f793c93ca3f6160d42f332379c) sbclPackages.fset: make use of compound licenses
* [`92ab499a`](https://github.com/NixOS/nixpkgs/commit/92ab499a4f315db75a21df1c26028f1edb233d40) cl-launch: make use of compound licenses
* [`1abbdf4b`](https://github.com/NixOS/nixpkgs/commit/1abbdf4b916a1cc6e3f8bd3d2cb684502a94c41e) acl2: make use of compound licenses
* [`8a29e58f`](https://github.com/NixOS/nixpkgs/commit/8a29e58f768babd9e0bf72a9c5df841edcc581b9) lib.licenses: drop llgpl21
* [`411a1103`](https://github.com/NixOS/nixpkgs/commit/411a1103c35271443e93fe440c1fe22aad7099ad) nixos/technitium-dns-server: set WorkingDirectory on systemd service
* [`404c544b`](https://github.com/NixOS/nixpkgs/commit/404c544b1ff13ffbdd0e216d55644ae5a73e0e5f) doc/readme: align with new commit convention
* [`e6a50d4d`](https://github.com/NixOS/nixpkgs/commit/e6a50d4d565be351bf578823aedec084aa10bf0f) akku: 1.1.0-unstable-2026-01-09 -> 1.1.0-unstable-2026-07-08
* [`17533980`](https://github.com/NixOS/nixpkgs/commit/1753398017f0b0ac83a701112bd5f3409a624594) python3Packages.hankel: fix changelog
* [`7ae1e7bb`](https://github.com/NixOS/nixpkgs/commit/7ae1e7bb8114522e5929385532400a5c4e043b35) nixos/hostapd: set ieee80211w to 2 for wpa3-sae
* [`bb16c4d7`](https://github.com/NixOS/nixpkgs/commit/bb16c4d7a8f380e68faa9534384069de035a8d5c) wakapi: 2.17.4 -> 2.17.5
* [`a4952026`](https://github.com/NixOS/nixpkgs/commit/a4952026d240b18ffc5503c9b481aac861fbe35b) npc: init at 1.0.0
* [`a5d57dc9`](https://github.com/NixOS/nixpkgs/commit/a5d57dc91f98fcd2befaa90a03a8b940150df620) python3Packages.oslo-config: 10.5.0 -> 10.6.0
* [`3fcb06d1`](https://github.com/NixOS/nixpkgs/commit/3fcb06d18ab90f175b4ff1a1118a9fd5fe526617) lms: 3.78.0 -> 3.79.0
* [`b1797c03`](https://github.com/NixOS/nixpkgs/commit/b1797c03b7596eee4d698223d9f694f38cdafba2) gexiv2_0_16: 0.16.0 -> 0.16.1
* [`9aa64382`](https://github.com/NixOS/nixpkgs/commit/9aa64382928a36f8db26837237a841365069205a) glibmm_2_68: 2.88.0 -> 2.88.1
* [`9c5ec6df`](https://github.com/NixOS/nixpkgs/commit/9c5ec6dfca3e9a1443101fdd4a058d55890d44f4) libglycin: 2.1.1 -> 2.1.5
* [`0bfb4488`](https://github.com/NixOS/nixpkgs/commit/0bfb44884086c79cdfe46e9ef28f64d5e5ee299f) gnome-remote-desktop: 50.1 -> 50.2
* [`93866ee2`](https://github.com/NixOS/nixpkgs/commit/93866ee249bd4b103061b7d78fbe994a99b09aab) gnome-shell: 50.2 -> 50.3
* [`bbe8ee46`](https://github.com/NixOS/nixpkgs/commit/bbe8ee46ae72372cffabf8d17d5a38822d6fdd45) mm-common: 1.0.7 -> 1.0.8
* [`b5f9ec60`](https://github.com/NixOS/nixpkgs/commit/b5f9ec6012825e2f4c3d25fa8cc14919496b1489) mutter: 50.2 -> 50.3
* [`d4347366`](https://github.com/NixOS/nixpkgs/commit/d43473666e6119e057b1d32262ac64b6f26bcfba) pangomm_2_48: 2.56.1 -> 2.56.2
* [`b171759c`](https://github.com/NixOS/nixpkgs/commit/b171759c4053bced2c6071e185dd26670152259e) vscode-extensions.github.vscode-github-actions: 0.31.5 -> 0.32.3
* [`3fb6b541`](https://github.com/NixOS/nixpkgs/commit/3fb6b541b7d8de97d57a707c61ee5cf725f37e77) codexbar: 0.43.0 -> 0.45.1
* [`e77c4d15`](https://github.com/NixOS/nixpkgs/commit/e77c4d15d2a3602b1af67124d06bd97a33266791) qbittorrent-enhanced-nox: 5.2.1.10 -> 5.2.3.10
* [`ed7a5b38`](https://github.com/NixOS/nixpkgs/commit/ed7a5b3882d62c054e84323e6d60cac650d136ee) python3Packages.dictionaries: drop
* [`b91faa7a`](https://github.com/NixOS/nixpkgs/commit/b91faa7a5aa1a6e7061ad0a3ff7aa6e8cdefe531) python3Packages.easyprocess: enable tests
* [`8a263e32`](https://github.com/NixOS/nixpkgs/commit/8a263e32ac63d7fd3ace65066b65177fa96d302d) maintainers: add logn
* [`d55dc77c`](https://github.com/NixOS/nixpkgs/commit/d55dc77c6d514e725681ccdab745af30b40b0b1a) dbmail: 3.5.5 -> 3.5.6
* [`809a75c9`](https://github.com/NixOS/nixpkgs/commit/809a75c923b750e33b7c090f34421acf0624e793) python3Packages.colorlog: 6.10.1 -> 6.11.0
* [`44bddfb0`](https://github.com/NixOS/nixpkgs/commit/44bddfb04045c9992431aaa695334764139fc21b) python3Packages.colorlog: use finalAttrs
* [`151e1e25`](https://github.com/NixOS/nixpkgs/commit/151e1e250b152aacefd7f86a32898688faca1c2f) python3Packages.gepa: init at 0.1.3
* [`3e5af3a7`](https://github.com/NixOS/nixpkgs/commit/3e5af3a758fca059c20d5e5c81bd3c978800e97b) infisical: 0.41.90 -> 0.43.110
* [`1c5803b9`](https://github.com/NixOS/nixpkgs/commit/1c5803b9b6a882a3f9f97c2813eefa7fa46c88d6) python3Packages.moocore: 0.3.1 -> 0.3.2
* [`d00bdef7`](https://github.com/NixOS/nixpkgs/commit/d00bdef79be1c7b729be994396816929dd1b3a62) python3Packages.strawberry-graphql-django: 0.86.0 -> 0.86.5
* [`1dac0f36`](https://github.com/NixOS/nixpkgs/commit/1dac0f367bfc96101f0b2185caa56f49cbb37b66) basicswap: 0.14.4 -> 0.17.5
* [`746dc8f5`](https://github.com/NixOS/nixpkgs/commit/746dc8f5399f9b5e717a9ccea310980b3a952ca5) vzvm: init at 1.0.0
* [`9287d561`](https://github.com/NixOS/nixpkgs/commit/9287d5617a8dcac607b1816cd225f475d43409c0) nix-builder: split up NixOS module into generic and qemu-specific part
* [`e7c55acd`](https://github.com/NixOS/nixpkgs/commit/e7c55acd40fcd4f19c28df0f7e8dc0ffa386e91c) linux-builder-vz: init modules and package
* [`7e947577`](https://github.com/NixOS/nixpkgs/commit/7e947577046ea75c07be8ce7f9f9b47c0aa49b5c) linux-builder-vz: Add release notes and documentation
* [`cd7634cf`](https://github.com/NixOS/nixpkgs/commit/cd7634cf89620b2f5be8c9cd4550a8a6cb20ef44) python3Packages.ttfautohint-py: 0.6.0 -> 0.6.1
* [`004d8397`](https://github.com/NixOS/nixpkgs/commit/004d8397a9d835acabb46686b0795cf5e4107cc4) nixos/test-driver: read test script from store instead of env var
* [`4c345f2a`](https://github.com/NixOS/nixpkgs/commit/4c345f2aeea660b39c056e60ba79b08c918eefe5) mpvScripts.uosc-danmaku: 2.0.0 -> 2.1.0
* [`29441cdc`](https://github.com/NixOS/nixpkgs/commit/29441cdcc401546afd9a61da7947ee776bc1fa6f) adl: various
* [`80abbdeb`](https://github.com/NixOS/nixpkgs/commit/80abbdebacc10da544ccf60b1ab22ef3fe7b84aa) xwayland-satellite: 0.8.1 -> 0.8.2
* [`a8ec42c9`](https://github.com/NixOS/nixpkgs/commit/a8ec42c929cc891dce027aec06c41e79a596c99a) suil: remove gtk 2 support
* [`a2ba8dd7`](https://github.com/NixOS/nixpkgs/commit/a2ba8dd70df0f7b9405f91011bc7fa08f98ab7d0) pcmanfm: remove gtk 2 support
* [`689dd7d7`](https://github.com/NixOS/nixpkgs/commit/689dd7d79d1eeaa7348a187dbd7291253289b8ca) lxappearance: remove gtk 2 support
* [`786a7824`](https://github.com/NixOS/nixpkgs/commit/786a782451f0edbd1e1565920cfe161183830833) lxpanel: remove gtk 2 support
* [`42a7ebd1`](https://github.com/NixOS/nixpkgs/commit/42a7ebd15f19f4aa38abd752e52fa356addeca85) pktgen: remove gtk 2 support
* [`610d2daf`](https://github.com/NixOS/nixpkgs/commit/610d2daffb2aab64dffcf2a5bbc9268b3d0a6105) perf: remove gtk 2 support
* [`e6d9672c`](https://github.com/NixOS/nixpkgs/commit/e6d9672c1307b853e8a1c0244aaa1eb1f18a39a0) yersinia: remove gtk 2 support
* [`90d5812c`](https://github.com/NixOS/nixpkgs/commit/90d5812cb9f5e3512117635df284e797f97ab659) grafanaPlugins.grafana-mqtt-datasource: 1.3.3 -> 1.3.5
* [`97581f4d`](https://github.com/NixOS/nixpkgs/commit/97581f4d142c2c990ea3e0a7acb0547d5afa78bd) esphome-device-builder: init at 1.6.1
* [`930f6c53`](https://github.com/NixOS/nixpkgs/commit/930f6c53398bee6c5051d9ba5fe02e4d2986c9aa) davmail: remove gtk 2 support
* [`69ce3302`](https://github.com/NixOS/nixpkgs/commit/69ce33021c5aac61a928149c2dcccd0902340ba6) thc-hydra: remove gtk 2 support
* [`ca234eeb`](https://github.com/NixOS/nixpkgs/commit/ca234eeb2e2c117bdb206ffe543ca4788ecbc0e4) amazon-cloudwatch-agent: 1.300070.0 -> 1.300071.0
* [`320950aa`](https://github.com/NixOS/nixpkgs/commit/320950aa7523cb484b63ac7d9b6b979d365165f9) rubyPackages.puma: 7.1.0 -> 8.0.2
* [`9e062ae0`](https://github.com/NixOS/nixpkgs/commit/9e062ae093c2ca9e3d37a326a226c46a69a84982) nsf-ordlista: unstable-2023-08-20 -> 2025
* [`f9e071a5`](https://github.com/NixOS/nixpkgs/commit/f9e071a5656dab346248d934463af171dabec345) python3Packages.loro: 1.13.1 -> 1.13.2
* [`abd183c6`](https://github.com/NixOS/nixpkgs/commit/abd183c6d7bbdf9f1b55070d78aa2dddbc2a4ec0) socalabs-papu: 1.2.5 -> 1.2.7
* [`c99419b3`](https://github.com/NixOS/nixpkgs/commit/c99419b3ff82019ea2045ff19521ed7c13d3f51a) python3Packages.plumbum: 1.10.0 -> 2.0.1
* [`23656966`](https://github.com/NixOS/nixpkgs/commit/2365696627e689ffc74d0e0ab926c914223baedb) libosip: 5.3.1 -> 5.3.2
* [`fb93b8e4`](https://github.com/NixOS/nixpkgs/commit/fb93b8e49543a937988109c77a7525cddc08c8e4) fwts: remove efi_runtime module
* [`2b3072b6`](https://github.com/NixOS/nixpkgs/commit/2b3072b66ad2339e79eb354c8d319169859c6c50) fwts: 25.09.00 -> 26.07.00
* [`7f5c1b25`](https://github.com/NixOS/nixpkgs/commit/7f5c1b254d4f97349bd5e664d33a022180c196b9) fwts: remove pcre
* [`01cb532c`](https://github.com/NixOS/nixpkgs/commit/01cb532cf998462b003ae024f9bd736f6343fe43) jrl-cmakemodules: run tests
* [`c7080d8c`](https://github.com/NixOS/nixpkgs/commit/c7080d8ceea8817b5b03f554cd6929d8cb5d7614) cmake-parser: init at v0.9.2
* [`20150a6a`](https://github.com/NixOS/nixpkgs/commit/20150a6a619d3ee4231a5f748c531ec5e9874595) jrl-cmakemodules-scripts: init at v2.1.0
* [`d315d53c`](https://github.com/NixOS/nixpkgs/commit/d315d53c3b2adca08cab7ea9c568eb3e9889665a) jrl-cmakemodules: add passthru helpers to build doc in dependent packages
* [`2add6231`](https://github.com/NixOS/nixpkgs/commit/2add623150c92b6fa77a889f78223bc3226913a1) proxsuite: use jrl-cmakemodules docs helper
* [`c6c59bae`](https://github.com/NixOS/nixpkgs/commit/c6c59baed92292155ab67a35da4b9f92b134bf44) python3Packages.eigenpy: use jrl-cmakemodules docs helper
* [`5e3a123b`](https://github.com/NixOS/nixpkgs/commit/5e3a123bebcd048bb41e6dc00c857390c284ab82) tutanota-desktop: 355.260710.0 -> 355.260720.0
* [`9c32ac9e`](https://github.com/NixOS/nixpkgs/commit/9c32ac9e9768e90d1d4832fb0431de22a3d55821) python3Packages.nanoeigenpy: use jrl-cmakemodules docs helper
* [`47aab6da`](https://github.com/NixOS/nixpkgs/commit/47aab6da10b096e7b7a38a97e5b3a0be40b08f19) coal: use jrl-cmakemodules docs helper
* [`88b3b32f`](https://github.com/NixOS/nixpkgs/commit/88b3b32f4972b3227114da1c4c44c168c4fab0c4) pinocchio: use jrl-cmakemodules docs helper
* [`ed012f79`](https://github.com/NixOS/nixpkgs/commit/ed012f795c53ca7282b408310939cdf084892fa2) example-robot-data: use jrl-cmakemodules docs helper
* [`854650f0`](https://github.com/NixOS/nixpkgs/commit/854650f051b8d819b8ae467cbaa0a8fc56519378) eiquadprog: use jrl-cmakemodules docs helper
* [`a6d994dd`](https://github.com/NixOS/nixpkgs/commit/a6d994dd138069abc7c970888ec18f9057eba450) tsid: use jrl-cmakemodules docs helper
* [`5b0d88db`](https://github.com/NixOS/nixpkgs/commit/5b0d88db874ccccda72782a9f07cec0a83fe93ce) ndcurves: use jrl-cmakemodules docs helper
* [`a18c3da3`](https://github.com/NixOS/nixpkgs/commit/a18c3da3cd41193c76e77ffc325127c74f973ccf) crocoddyl: use jrl-cmakemodules docs helper
* [`d9151d76`](https://github.com/NixOS/nixpkgs/commit/d9151d769d8441420a3fc78d743489454dec4f5e) crocoddyl: fix fontconfig error
* [`bfd058c6`](https://github.com/NixOS/nixpkgs/commit/bfd058c62efa725a8b40546266bbb712d5b3cdaa) aligator: use jrl-cmakemodules docs helper
* [`4cf5a4f6`](https://github.com/NixOS/nixpkgs/commit/4cf5a4f646818a98aa4775e27a149a028e4785fd) mim-solvers: use jrl-cmakemodules docs helper
* [`72b22f4c`](https://github.com/NixOS/nixpkgs/commit/72b22f4cef60d251a22001b712d9122de46935c2) tutanota-desktop: add darwin support
* [`e2f817fd`](https://github.com/NixOS/nixpkgs/commit/e2f817fd21542a5a081cd73f0cf5c075dce1cb48) tutanota-desktop: add update script
* [`af51b76d`](https://github.com/NixOS/nixpkgs/commit/af51b76dc8128a0aa05cf4876392b18243090a5b) supercronic: 0.2.47 -> 0.2.48
* [`64e4b57c`](https://github.com/NixOS/nixpkgs/commit/64e4b57c617d0bbdd4a10aaa79a1756bf88cf239) curl-impersonate: set __structuredAttrs and separateDebugInfo
* [`27924af3`](https://github.com/NixOS/nixpkgs/commit/27924af3bc8cfbde55753d807e97c6df3ded15e3) grayjay: add pandapip1 to maintainers
* [`ec52d7df`](https://github.com/NixOS/nixpkgs/commit/ec52d7dfe7b0200a31d8b797f0a91b3f614c24a2) grayjay: split off grayjay-frontend; grayjay-frontend: init
* [`64101129`](https://github.com/NixOS/nixpkgs/commit/64101129c982dc3391dd9690b651c4f59d85e1bb) curl-impersonate: add c-ares support
* [`3d122ee1`](https://github.com/NixOS/nixpkgs/commit/3d122ee1a2f22782fe8c92946010b43a8c25be40) grayjay-libcurlshim: init
* [`76df39cd`](https://github.com/NixOS/nixpkgs/commit/76df39cd1c29ce894ce01eecfdf75b56c078a160) grayjay: unvendor and fix aarch64 build
* [`3c3142d7`](https://github.com/NixOS/nixpkgs/commit/3c3142d79b26096babdfc5b1d934aae0967f2cfa) grayjay: enable __structuredAttrs and strictDeps
* [`76b525e2`](https://github.com/NixOS/nixpkgs/commit/76b525e22bdad739a6d5aa5c993219febc5018dc) ghostty: replace absolute paths in desktop file
* [`d7afd283`](https://github.com/NixOS/nixpkgs/commit/d7afd283c5262717b55d2685a76f6e302445cedf) laurel: 0.7.3 -> 0.8.2
* [`df06bafc`](https://github.com/NixOS/nixpkgs/commit/df06bafc707d27d796f13de99fd59b23d604a3af) ultimate-doom-builder: drop gtk2, link libxfixes directly
* [`886870e9`](https://github.com/NixOS/nixpkgs/commit/886870e92dde6f8b5ff865b57bf69500828f9852) updatecli: 0.117.1 -> 0.119.0
* [`6bf6d4c6`](https://github.com/NixOS/nixpkgs/commit/6bf6d4c64fa3673ec19b33aef7481938d05a5cbb) nix-cl: avoid empty path segments in prefixed env variables
* [`4587ac9d`](https://github.com/NixOS/nixpkgs/commit/4587ac9da565f76e66ffdca709bbc5d7a95f1b33) profanity: switch from rev to tag, move variables out of top-level
* [`424d5fec`](https://github.com/NixOS/nixpkgs/commit/424d5fecf67215979acfefc6a2dcc901cd305da6) profanity: migrate to by-name
* [`4c897d3c`](https://github.com/NixOS/nixpkgs/commit/4c897d3c26cf15bde453e4bfaf7cc544fbe205b0) youki: 0.6.0 -> 0.7.0
* [`25c139e2`](https://github.com/NixOS/nixpkgs/commit/25c139e20144e4b87e650334819e00de203f79f2) atomgit-cli: 0.5.0 -> 0.6.0
* [`5db467c3`](https://github.com/NixOS/nixpkgs/commit/5db467c30d7960a8544b47f90366f01aa8f8dd6e) obs-studio-plugins.obs-backgroundremoval: 1.3.7 -> 1.4.1
* [`ea040368`](https://github.com/NixOS/nixpkgs/commit/ea040368e2f7d264d849d2263410cf5cdceffdbd) texlive-bin-big: autoreconf to fix build with gcc 16
* [`3766ab47`](https://github.com/NixOS/nixpkgs/commit/3766ab47674a8bb9d7a1b9f12d78c5aa7bef4ed1) marvin: 25.5.0 -> 26.1.1
* [`3aff4d1c`](https://github.com/NixOS/nixpkgs/commit/3aff4d1c49432f147c27526886d6cd5f383ba642) bats: 1.12.0 -> 1.14.0
* [`e64d5b6f`](https://github.com/NixOS/nixpkgs/commit/e64d5b6f231de717d158dea5c80ec21ca2de0bd6) dbus-broker: fix CVE-2026-16730
* [`58558fec`](https://github.com/NixOS/nixpkgs/commit/58558fec0bbccdf8c9c5124d3cdbcfa5305c9850) lib/services: fix test expectations for the reload options
* [`85f295f5`](https://github.com/NixOS/nixpkgs/commit/85f295f5665e2d66ac5bb8af8d60e52389f8c5a6) lib/services/service: add flags and flagFormat options
* [`639d4f74`](https://github.com/NixOS/nixpkgs/commit/639d4f74e5fa78e70fc774c5e2603d2f29b60204) lib/services/service: pin flag ordering relative to argv
* [`89e1ea15`](https://github.com/NixOS/nixpkgs/commit/89e1ea15f2c1e16775401206ef235f496611d399) snid: use process.flags to construct process.argv
* [`7621519a`](https://github.com/NixOS/nixpkgs/commit/7621519ad17005d26f4863327557de0e102ab6b1) gitlab-duo: 9.3.0 -> 9.6.0
* [`82f2d5a5`](https://github.com/NixOS/nixpkgs/commit/82f2d5a58d07b143b2ce4360194b7671f0263962) iroh-relay: 1.0.1 -> 1.0.3
* [`485b1d73`](https://github.com/NixOS/nixpkgs/commit/485b1d73f6d187eeff5a793636ef060cbd0709a2) monotone: switch to finalAttrs, use SRI hash, add strictDeps and structuredAttrs, hardcode pname
* [`d1436a51`](https://github.com/NixOS/nixpkgs/commit/d1436a5139567ac9864afac60ee1456ae9332d49) monotone: migrate to by-name
* [`57fb13a1`](https://github.com/NixOS/nixpkgs/commit/57fb13a18c3710c47c6c401a0f6ea90e7aacd24a) pdfpc: modernize derivation
* [`793208e1`](https://github.com/NixOS/nixpkgs/commit/793208e1509de1b5a72eb8555958ed7d8d244002) pdfpc: migrate to by-name
* [`aab410f9`](https://github.com/NixOS/nixpkgs/commit/aab410f988165cc1aa9136497df5020ec3bc1abf) sslscan: modernize derivation
* [`4d4c5042`](https://github.com/NixOS/nixpkgs/commit/4d4c5042dda0920ad212f326052ce3b3c6e2595d) sslscan: migrate to by-name
* [`a528096b`](https://github.com/NixOS/nixpkgs/commit/a528096b5506a0a95f82ca694910eb9666633051) evilwm: switch to finalAttrs, use strictDeps and structuredAttrs, move args out of top-level
* [`fee37c06`](https://github.com/NixOS/nixpkgs/commit/fee37c069cd9b4bc7b03614fefdad19bc687c6f4) evilwm: migrate to by-name
* [`ff0d874f`](https://github.com/NixOS/nixpkgs/commit/ff0d874f9b18ec7fb47c2e9d48e3b08ad04bac68) phonetisaurus: migrate to by-name, fix GCC errors, modernize
* [`23d01238`](https://github.com/NixOS/nixpkgs/commit/23d01238ad15e8e90e5e1b38cab3f81517635eb6) kepler: unstable-2023-07-19 -> 1.0.1, modernize
* [`e9a4a3c6`](https://github.com/NixOS/nixpkgs/commit/e9a4a3c628deb1aba703cd93c4856182787f1370) python3Packages.swh-scanner: enable __structuredAttrs
* [`5ee7e391`](https://github.com/NixOS/nixpkgs/commit/5ee7e3914c03c4bd88f2666493345774f62e557c) bspwm: modernize
* [`415ba31c`](https://github.com/NixOS/nixpkgs/commit/415ba31cda8051a1b9085d1bf13810e90dd0908a) iplan: modernize
* [`6e4a0429`](https://github.com/NixOS/nixpkgs/commit/6e4a04297dbfac28ef7fda73db8525c99a60f150) firefox/wrapper: dont re-inherit description
* [`fb0f3b9d`](https://github.com/NixOS/nixpkgs/commit/fb0f3b9d908c5d0325af95f5eb8b68d0f0967c90) tomcat: modernize
* [`04ba732d`](https://github.com/NixOS/nixpkgs/commit/04ba732d757802e0e3811eb88ddf8da09d66d618) github-runner: 2.335.1 -> 2.336.0
* [`64513caf`](https://github.com/NixOS/nixpkgs/commit/64513caf3b92fb89bb9c354fb04b1c0823347e96) comigo: 1.3.0 -> 1.3.3
* [`430a3562`](https://github.com/NixOS/nixpkgs/commit/430a3562d330660c63c95766e3504129362a006a) codegraph: 1.4.1 -> 1.5.0
* [`347aa08f`](https://github.com/NixOS/nixpkgs/commit/347aa08f13542502a209191f0986afdca9a1a1db) bambuddy: 0.2.4.8 -> 1.2.5.1
* [`73e70046`](https://github.com/NixOS/nixpkgs/commit/73e70046d045bad29d9ef44d615467ac6bceabf8) nip2: Remove for gtk2 removal [nixos/nixpkgs⁠#410814](https://togithub.com/nixos/nixpkgs/issues/410814)
* [`39cab7b2`](https://github.com/NixOS/nixpkgs/commit/39cab7b27ec047cdc82671ddb0c2a486a7e3c697) sea-orm-cli: 1.1.19 -> 2.0.0
* [`41f54966`](https://github.com/NixOS/nixpkgs/commit/41f54966af4030a1d854097b6ff894a3a3da1cc2) sea-orm-cli: enable strictDeps and __structuredAttrs, add changelog
* [`185d011b`](https://github.com/NixOS/nixpkgs/commit/185d011b91ff6869d25477589e70cebfde1c39fc) sea-orm-cli: add anish as maintainer
* [`5626dc28`](https://github.com/NixOS/nixpkgs/commit/5626dc28aa59e26117366ec7e7476141de6b4646) spandrel: init at 0.22.4
* [`7c956675`](https://github.com/NixOS/nixpkgs/commit/7c9566751be225ed0d5443ce7ea84f30e6faf2ae) proxysql: fix build by adjusting for gcc 15
* [`96a07652`](https://github.com/NixOS/nixpkgs/commit/96a0765201e00fcc88ce876781d728d2c80cbf85) python314Packages.chromadb: remove unused build time only build dependency
* [`be04cfe2`](https://github.com/NixOS/nixpkgs/commit/be04cfe2ec5c60c2f26800e4b443c1d512312d76) tdarr-node: 2.81.01 -> 2.85.01
* [`d1196d07`](https://github.com/NixOS/nixpkgs/commit/d1196d079c13dbe0841604efaa9d3cc6b092ef55) verilator: fix build on darwin
* [`be41645c`](https://github.com/NixOS/nixpkgs/commit/be41645c2461e894eaa81ae0fd8351d56cbed3e9) debcraft: 0.9.2 -> 0.9.3
* [`d40ec2ae`](https://github.com/NixOS/nixpkgs/commit/d40ec2ae1b873119d21ea13d982ee9a520a71327) openshadinglanguage: remove unneeded flags and inputs
* [`fc6c01f1`](https://github.com/NixOS/nixpkgs/commit/fc6c01f1e4d22b934d1d4bda596a8d7cf96ab29f) openshadinglanguage: remove libclang as shared lib
* [`241b93d0`](https://github.com/NixOS/nixpkgs/commit/241b93d01a1cc757a294bfa6a68e8256e6cd5e60) dart-source: apply upstream patches for gcc 16
* [`7bd54db1`](https://github.com/NixOS/nixpkgs/commit/7bd54db11233202d345e4e83d7d4f8a9a8433415) ocamlPackages.ppx_import: make compatible with OCaml 5.5
* [`5ae00f6d`](https://github.com/NixOS/nixpkgs/commit/5ae00f6dc7c803d607e5da5e554e572a7fae0865) ocamlPackages.uring: 2.7.0 → 2.14.0
* [`f881e50d`](https://github.com/NixOS/nixpkgs/commit/f881e50d1776997409e7b6ffa0fe48078a898655) ocamlPackages.uring: remove pname usage in strings + fix changelog URL
* [`9ba1fb86`](https://github.com/NixOS/nixpkgs/commit/9ba1fb868ec05b76a8fb02150b962821284cdfbb) ocamlPackages.uring: remove rec
* [`56c236fc`](https://github.com/NixOS/nixpkgs/commit/56c236fc6f67f63beb6e055c08460b2ed0080d4c) ocamlPackages.uring: 2.14.0 → 2.15.0
* [`c52cb8ad`](https://github.com/NixOS/nixpkgs/commit/c52cb8ad5790b22713d924db4dbd85c1f85f1fd8) ocamlPackages.eio: 1.3 → 1.4
* [`6a236543`](https://github.com/NixOS/nixpkgs/commit/6a236543258b79ddb0ef87062111faee9c1ce1a2) steamtinkerlaunch: yad 15 compat patch
* [`be7ea35e`](https://github.com/NixOS/nixpkgs/commit/be7ea35ed6536ddb602279058f49da21912d0608) flux9s: 0.12.0 -> 1.0.0
* [`e71224d2`](https://github.com/NixOS/nixpkgs/commit/e71224d2fab6378b77a2a29c030da49783390161) keepass: 2.60 -> 2.61.1
* [`1bd44b71`](https://github.com/NixOS/nixpkgs/commit/1bd44b7142920adffc766f1fe7291466b10e5ffc) floorp-bin: 12.15.2 -> 12.16.4
* [`288887a2`](https://github.com/NixOS/nixpkgs/commit/288887a20afd9bc518be524faf9a62c6a58a2b1d) reqable: 3.2.10 -> 3.2.16
* [`9bfe8c6b`](https://github.com/NixOS/nixpkgs/commit/9bfe8c6be1ce4ff7cd0eec2fa1e2c96b25378add) famistudio: 4.5.1 -> 4.5.2
* [`0e536da5`](https://github.com/NixOS/nixpkgs/commit/0e536da5e15dc606f6981edce6397e30dc553729) gladtex: unstable-2023-01-22->4.0
* [`c60a9e98`](https://github.com/NixOS/nixpkgs/commit/c60a9e982c1ec7a848e74e998a161e909a961e7b) python313Packages.tree-sitter-grammars.*: fix pname
* [`3a84c13b`](https://github.com/NixOS/nixpkgs/commit/3a84c13b4565ecea7a2e02c5522747a48a3b1a58) nixos/nix: Move nix.enable and nix.package to settings module
* [`a52deb5e`](https://github.com/NixOS/nixpkgs/commit/a52deb5e3c2c5c6328f80e2faf0500062f556eae) pkgs/README.md: update the vulnerability tracking section with the security tracker
* [`058289cc`](https://github.com/NixOS/nixpkgs/commit/058289cc6a49015ed9fd14e12c32f51bad243023) nixos/nix: Move systemPackages, tmpfiles, and build users to settings module
* [`94e1aa63`](https://github.com/NixOS/nixpkgs/commit/94e1aa6387fc26c8a2f1673251e9e1923af5906a) nixos/nix-daemon: flatten unnecessary mkMerge
* [`80958945`](https://github.com/NixOS/nixpkgs/commit/80958945e2c297deba63401858401acf914acfe2) nixos/nix-daemon: Add daemon.enable option and assertions
* [`d48c2f78`](https://github.com/NixOS/nixpkgs/commit/d48c2f788622d9da064c7235eb4f676cb2276ccd) nixos/nix-daemon: Add VM test for local store
* [`9f263ff4`](https://github.com/NixOS/nixpkgs/commit/9f263ff49632a7cc3b9fd52d5920a135a3bb0a47) nixos/lix: Add basic VM test for lix daemon
* [`e7bcf8e1`](https://github.com/NixOS/nixpkgs/commit/e7bcf8e15a92b006624d4b9af6022a440ade6fa1) nixos/doc: add release note for daemonless nix support
* [`f688bfed`](https://github.com/NixOS/nixpkgs/commit/f688bfedb94dd8b1f2df8f38a99f85e6ddf6d5a0) sonarr: 4.0.18.2971 -> 4.0.19.2979
* [`05d095b3`](https://github.com/NixOS/nixpkgs/commit/05d095b3dbb814d6a96f79155fe67e19de75db1a) home-assistant-custom-lovelace-modules.flower-card: 2026.6.1 -> 2026.7.0
* [`920eb62e`](https://github.com/NixOS/nixpkgs/commit/920eb62e834d27cab3bdcaeef0ff6fdc1c319403) layerx: 1.5.3 -> 1.6.0
* [`13d70ec3`](https://github.com/NixOS/nixpkgs/commit/13d70ec3674ddbf16a311ac9bada50f01bcd69e8) ntfy-sh: 2.26.0 -> 2.26.3
* [`83c16242`](https://github.com/NixOS/nixpkgs/commit/83c16242a2678b433f5851e67230a604d82ae835) grafanaPlugins.grafana-pyroscope-app: 2.0.6 -> 2.2.0
* [`071ecc62`](https://github.com/NixOS/nixpkgs/commit/071ecc6285f61f7329d82844a710c43905155808) svelte-check: 4.3.1 -> 4.7.4
* [`1a93bd55`](https://github.com/NixOS/nixpkgs/commit/1a93bd55d22ebc7f08f7fc867a2b41a12403e725) mcporter: 0.12.3 -> 0.12.4
* [`5ebfab17`](https://github.com/NixOS/nixpkgs/commit/5ebfab17de5a7b4a91b17a0945e4feed0876b6aa) sxhkd: modernize
* [`ae44949c`](https://github.com/NixOS/nixpkgs/commit/ae44949c64e03b8d49ca43142ca00b4938fb9cbd) apriltag: fix cuda build
* [`6926aa78`](https://github.com/NixOS/nixpkgs/commit/6926aa78c59ad15ede9bda3c257303f89ea910c0) nix-direnv: 3.1.2 -> 3.2.0
* [`b0326a57`](https://github.com/NixOS/nixpkgs/commit/b0326a57f3aa27ebe449e135422a6d78062157e6) python3Packages.python-datauri: rename from datauri; fix pname
* [`f29c2fe3`](https://github.com/NixOS/nixpkgs/commit/f29c2fe3cc05a5edda1b32921052ebc6430cb8ee) fatou: init at 0.6.0
* [`b0a0caab`](https://github.com/NixOS/nixpkgs/commit/b0a0caabcfe86a225c92fc9d70e3b83147bb0a74) arity: init at 0.13.0
* [`62b4783c`](https://github.com/NixOS/nixpkgs/commit/62b4783ce7bd7a3b13b238ce1813aa8e2815a58e) brise: fix version
* [`b02006ab`](https://github.com/NixOS/nixpkgs/commit/b02006abd1e4e11c8d05812089618dae10c19c52) bwa-mem2: unstable-2023-03-18->2.3, add versionCheckHook
* [`d49165d3`](https://github.com/NixOS/nixpkgs/commit/d49165d3b1f25bd9b0b95d320b5f8e58d08b4d87) {python3Packages.,}soapysdr: 0.8.1-unstable-2025-10-05-03 -> 0.8.1-unstable-2026-01-02
* [`caeafd05`](https://github.com/NixOS/nixpkgs/commit/caeafd05ce916ca424deae18bb7844f4c1e5b365) stable-diffusion-cpp: master-782-b290693 -> master-797-5ef4a75
* [`1296fcb6`](https://github.com/NixOS/nixpkgs/commit/1296fcb67866b195723b7dfbac0a4415d5cb048b) stable-diffusion-cpp-vulkan: master-782-b290693 -> master-797-5ef4a75
* [`978fe4d7`](https://github.com/NixOS/nixpkgs/commit/978fe4d7cf3106582905109a3b85b7cd12693bf8) stable-diffusion-cpp-cuda: master-782-b290693 -> master-797-5ef4a75
* [`1501a05a`](https://github.com/NixOS/nixpkgs/commit/1501a05a79c8c719ee16720532696d6af64fbb9a) nurl: modernize
* [`0f2a8f91`](https://github.com/NixOS/nixpkgs/commit/0f2a8f919d5adcc85bdc673f8660e48b4e0ae11a) python3Packages.gtts-token: migrate to pyproject
* [`9ce95861`](https://github.com/NixOS/nixpkgs/commit/9ce95861997fcc437a0d1b061813a3931fc37619) python3Packages.gtts-token: modernize
* [`d067f96b`](https://github.com/NixOS/nixpkgs/commit/d067f96b34ee3bc20268405f420eb1eddd1d7b8b) python3Packages.tmb: migrate to pyproject
* [`dd29a222`](https://github.com/NixOS/nixpkgs/commit/dd29a22242be17713c6ac423368639d8819212e5) python3Packages.translatepy: migrate to pyproject
* [`84ed04d9`](https://github.com/NixOS/nixpkgs/commit/84ed04d9991cf4242f25ff0872591a8f9b6c9792) python3Packages.translitcodec: migrate to pyproject
* [`fccaa341`](https://github.com/NixOS/nixpkgs/commit/fccaa3415ec41fcad485b0cbfdaf304e5bea5e9d) python3Packages.tmb: modernize
* [`0ac754de`](https://github.com/NixOS/nixpkgs/commit/0ac754de82eeda510bcf640c97ce5006c0998137) python3Packages.translatepy: modernize
* [`b090451d`](https://github.com/NixOS/nixpkgs/commit/b090451d714a4b410edde5240599ba519753acd3) python3Packages.translitcodec: modernize
* [`42851100`](https://github.com/NixOS/nixpkgs/commit/4285110002a72252d622a6314db046d01c211445) python3Packages.txdbus: migrate to pyproject
* [`b7b7bc60`](https://github.com/NixOS/nixpkgs/commit/b7b7bc60405992a66d7438e57d88d8d7d776eff4) python3Packages.txdbus: modernize
* [`44e4eed2`](https://github.com/NixOS/nixpkgs/commit/44e4eed2ccf8a4b1da1d66557e07cae43c8ea2b6) ocamlPackages.elpi: fix typo
* [`eb037b56`](https://github.com/NixOS/nixpkgs/commit/eb037b56fd57ffbe6e4e80b8b33aecabca590d2d) coqPackages.QuickChick: disable broken versions
* [`69904f2e`](https://github.com/NixOS/nixpkgs/commit/69904f2e6a80969ceafb4aabcd6e84bc516f42c6) coqPackages.simple-io: disable broken versions
* [`db6568df`](https://github.com/NixOS/nixpkgs/commit/db6568dfd8141963f46d8e125eade0c8fa256133) atop: 2.12.1 -> 2.13.0
* [`a414415c`](https://github.com/NixOS/nixpkgs/commit/a414415cc412917cdc9e06a17386e3c2874c10db) mozhi: 0-unstable-2026-04-09 -> 0-unstable-2026-06-11
* [`d4c5158a`](https://github.com/NixOS/nixpkgs/commit/d4c5158a0c9b5e98d6c94616f8671be891aea532) git-delete-merged-branches: 7.5.1 -> 7.6.1
* [`f01d62b6`](https://github.com/NixOS/nixpkgs/commit/f01d62b694694a2c76687befb147e23faf101f19) maintainers: add indium114
* [`28ade83d`](https://github.com/NixOS/nixpkgs/commit/28ade83defedba012311d419981ac2c5846a5daf) mindustry: add indium114 as maintainer
* [`e7f115fa`](https://github.com/NixOS/nixpkgs/commit/e7f115faa20194c87e8d701eca3af16a0e4cc7e4) python3Packages.pytest-docker-tools: 3.1.9 -> 3.1.10
* [`bc93deee`](https://github.com/NixOS/nixpkgs/commit/bc93deee131821a9782225f4739484ff13af9aa3) samba: 4.23.8 -> 4.23.10
* [`5e1a052b`](https://github.com/NixOS/nixpkgs/commit/5e1a052b44715b172c4fa5e438ca65eb61305ec0) pg_exporter: init at 1.4.0
* [`a46c09b3`](https://github.com/NixOS/nixpkgs/commit/a46c09b39da0bdd4afd823974a47cbcdef2a49d6) nocturne: 1.4.2 -> 1.5.1
* [`58863ea4`](https://github.com/NixOS/nixpkgs/commit/58863ea42e5b399a98e1610e43c5128520cf5a3e) xscreensaver: 6.13 -> 6.15
* [`f3854ab5`](https://github.com/NixOS/nixpkgs/commit/f3854ab53621d9c6a9955051776cc6ca22e78082) gomuks-desktop: init at 26.07
* [`4377d542`](https://github.com/NixOS/nixpkgs/commit/4377d54226f39dc22e03e75eb2ab9b46ef13b18b) python3Packages.mfusepy: fix build with setuptools 83
* [`53f980a9`](https://github.com/NixOS/nixpkgs/commit/53f980a9b3f8de3089223a0729967d6fc6d5c6f1) maintainers: add fkomarek
* [`2a44e801`](https://github.com/NixOS/nixpkgs/commit/2a44e80177c56dee9acb875a451805b1a16316d0) dvdisaster: fix build
* [`02d5d3c5`](https://github.com/NixOS/nixpkgs/commit/02d5d3c5392d6cd46a4e9a480dfa9b739f815942) tun2proxy: 0.7.20 -> 0.8.3
* [`ca6284e4`](https://github.com/NixOS/nixpkgs/commit/ca6284e45f07e761bf5f596ac5ffb456a310e75f) home-assistant-custom-components.mass-queue: 0.10.1 -> 0.10.2
* [`18d41632`](https://github.com/NixOS/nixpkgs/commit/18d41632731088e0c44947af1c00a8fb6e6e9a0e) ekam: fix version, modernize
* [`c831bab4`](https://github.com/NixOS/nixpkgs/commit/c831bab4acdeeae7ffd247ae44b6d45e203350cc) appimageTools: warn on deprecated type-specific aliases
* [`9ceb7115`](https://github.com/NixOS/nixpkgs/commit/9ceb7115999d13309b9fa6a69e6969a695580ffb) setools: 4.7.0 -> 4.7.1
* [`0e9a7137`](https://github.com/NixOS/nixpkgs/commit/0e9a71377dd6200ce4294a0eb4e40c62d6d133c6) google-chat-linux: 5.39.24-1 -> 5.39.26-1
* [`5a9431ba`](https://github.com/NixOS/nixpkgs/commit/5a9431baaf4fa442601b4f44b92636836173f115) sleek-todo: 2.0.14 -> 2.0.26
* [`7441c5f6`](https://github.com/NixOS/nixpkgs/commit/7441c5f67421ee8cdf2e388674a84a29aeece505) multiviewer-for-f1: 2.7.3 -> 2.8.3
* [`a6e60877`](https://github.com/NixOS/nixpkgs/commit/a6e60877e7c394e723da6832b655406edb2d25d0) oxvg: 0.0.5 -> 0.0.6
* [`0f6c7435`](https://github.com/NixOS/nixpkgs/commit/0f6c7435a7cc458e7b0bcb94371533ae345570ef) kid3: 3.9.7 -> 3.10.1
* [`a0eecb76`](https://github.com/NixOS/nixpkgs/commit/a0eecb768419db2ab4a305e5e0cfd1a36d2b2625) matrix-media-repo: bump `libheif` dependency
* [`b0620953`](https://github.com/NixOS/nixpkgs/commit/b0620953938ffa6eef7ad8ee03bae29dd009466c) throne: 1.1.2 -> 1.1.6
* [`0cbdc25b`](https://github.com/NixOS/nixpkgs/commit/0cbdc25b4df6051689052125cb550485f09dfb59) throne: 1.1.6 -> 1.2.2
* [`a8c2914f`](https://github.com/NixOS/nixpkgs/commit/a8c2914fb83c09161badb3e319064a8d0f800fba) factor-lang: drop unused factor99.nix file
* [`89aedb2b`](https://github.com/NixOS/nixpkgs/commit/89aedb2b5565dfeb33ad8c26df572a5d15293ac0) intel-media-driver: 26.1.6 -> 26.2.4
* [`e74c1dad`](https://github.com/NixOS/nixpkgs/commit/e74c1dad9dee26a72feb1f693c296df94194f25d) lib: improve implementation of `overrideExisting`
* [`2344734f`](https://github.com/NixOS/nixpkgs/commit/2344734fddd5854341a6b97e229a56393a079e6c) vscode-extensions.github.vscode-pull-request-github: 0.158.0 -> 0.162.0
* [`b947b577`](https://github.com/NixOS/nixpkgs/commit/b947b5773234ccc54b879cb7fe33770dca4ef0d5) wlr-utils: init at 1.6.0
* [`331c4cf6`](https://github.com/NixOS/nixpkgs/commit/331c4cf6997c480aee2575a8fd3c6333def3a6d5) lib: improve implementation of `foldAttrs`
* [`c08c053f`](https://github.com/NixOS/nixpkgs/commit/c08c053f26918096fecc23dfaaae53b1f6aa099c) linux-builder-vz: reuse vsock comms from test vms
* [`325e6b23`](https://github.com/NixOS/nixpkgs/commit/325e6b23317592181bb966b7f082d3f6f797a7a4) qemu-vm and vz-vm: deduplicate erofs image creation
* [`34ab5d3a`](https://github.com/NixOS/nixpkgs/commit/34ab5d3a787c7331b5e5d8813edaf5990d2f48be) formats.yaml_1_1: use remarshal v2
* [`74dc5556`](https://github.com/NixOS/nixpkgs/commit/74dc5556d14b67164f2f1f8e406317515eecb3a5) nixos/knot-resolver: use remarshal v2
* [`2db095e2`](https://github.com/NixOS/nixpkgs/commit/2db095e2e758f0f666919e112e86b85d13376e8f) gramps: 6.0.6 -> 6.0.8
* [`782d32e6`](https://github.com/NixOS/nixpkgs/commit/782d32e6c88d4e8b88aea1d5ea6b5ab4e9151718) mysql84: 8.4.10 -> 8.4.11
* [`278786b6`](https://github.com/NixOS/nixpkgs/commit/278786b6b19f46686939e31b2ff5a46e8dab8f48) dashy-ui: use YAML 1.2
* [`98ffd805`](https://github.com/NixOS/nixpkgs/commit/98ffd805ef1b2e3515f200710f582d46d82452c9) remarshal_0_17: drop
* [`e828cc63`](https://github.com/NixOS/nixpkgs/commit/e828cc631764757683df5f9ab7a9e942ae4e29ca) qtwebapp: bump cxx version used for darwin
* [`b1a219e5`](https://github.com/NixOS/nixpkgs/commit/b1a219e58faeda005dfc5443f59ddd3c49478092) diffoscope: 325 -> 326
* [`0dbe3c3c`](https://github.com/NixOS/nixpkgs/commit/0dbe3c3c96e37945c1be66f6b7af01409e057379) ibm-plex: 0-unstable-2026-05-26 > 0-unstable-2026-07-30
* [`aeda64b2`](https://github.com/NixOS/nixpkgs/commit/aeda64b2ec870ea97ebafbaf4fe2c195204d631a) mongodb-7_0: 7.0.37 -> 7.0.39
* [`34836ead`](https://github.com/NixOS/nixpkgs/commit/34836eadc0acdf88ad0dec270efcfd962456d00c) arc_unpacker: fix version, add stricDeps, __structuredAttrs
* [`3336ba22`](https://github.com/NixOS/nixpkgs/commit/3336ba22ce40e87e2c695a076f8cf4bf4f4336b4) arc-unpacker: rename from arc_unpacker
* [`115953e9`](https://github.com/NixOS/nixpkgs/commit/115953e9d353361e413ee616aec6b65253fa80c8) proton-ge-bin: GE-Proton11-1 -> GE-Proton11-3
* [`e2c07623`](https://github.com/NixOS/nixpkgs/commit/e2c0762329ba72e31df485dd15f9f978044ea752) vscode-extensions.tuttieee.emacs-mcx: 0.111.0 -> 0.111.1
* [`6b1c1c1f`](https://github.com/NixOS/nixpkgs/commit/6b1c1c1f33fca134ec4961bdd8408acb05a04c2d) xmoto: fix build on darwin
* [`fc5c56a5`](https://github.com/NixOS/nixpkgs/commit/fc5c56a52ea00df76bf0747c37c62c8c227e923b) musescore-evolution: fix darwin build
* [`d9d8d8d4`](https://github.com/NixOS/nixpkgs/commit/d9d8d8d437f2fe6790a47cd513cecfcf62f1ac28) vulkan-caps-viewer: 4.11 -> 4.12
* [`fca89ca6`](https://github.com/NixOS/nixpkgs/commit/fca89ca63a6d79ec4260ce295b202abbd8de8abc) traefik: 3.7.8 -> 3.7.10
* [`13f693e6`](https://github.com/NixOS/nixpkgs/commit/13f693e65bc8de342c2679a16be76cf5a3b6da13) vintagestory: 1.22.5 → 1.22.6
* [`8389f1a9`](https://github.com/NixOS/nixpkgs/commit/8389f1a9ab574700fe402aeea7f07a635eadf251) sprite: 0.0.1-rc46 -> 0.0.1-rc47
* [`910a5486`](https://github.com/NixOS/nixpkgs/commit/910a5486ba5aa1fc293669f537bb6ec42b7ff5c4) Revert "yaru-theme: remove"
* [`880a6376`](https://github.com/NixOS/nixpkgs/commit/880a6376dace57144ffba52738ecda9361c5e965) yaru-theme: revert removal and remove gtk-engine-murrine dep
* [`7bedc6c3`](https://github.com/NixOS/nixpkgs/commit/7bedc6c39818d6d314be134528888647af25ea74) camunda-modeler: 5.49.0 -> 5.50.0
* [`84afb765`](https://github.com/NixOS/nixpkgs/commit/84afb7657d3d0366e83d4807564511efc338fa62) python3Packages.streamdeck: migrate to pyproject
* [`d47a65b9`](https://github.com/NixOS/nixpkgs/commit/d47a65b9ec7c945070fa4717ece6401066e88377) python3Packages.streamdeck: modernize
* [`e1ac77d3`](https://github.com/NixOS/nixpkgs/commit/e1ac77d3379fada83175d7ee23dc1eb68a5ed724) qemu: fix minimal build
* [`bb90d8ed`](https://github.com/NixOS/nixpkgs/commit/bb90d8ed014b7794aed79a5a93d3bf178df674e6) python3Packages.spinners: migrate to pyproject
* [`4862a619`](https://github.com/NixOS/nixpkgs/commit/4862a6198d730b4ab20d54d77dfef91079896365) python3Packages.spotipy: migrate to pyproject
* [`112b1d28`](https://github.com/NixOS/nixpkgs/commit/112b1d28cc57af5123699d7d407ce910d44d784e) python3Packages.spinners: modernize
* [`16eaa492`](https://github.com/NixOS/nixpkgs/commit/16eaa49204f8aaa2f69ef33c0acfe921479cbd22) python3Packages.spotipy: modernize
* [`db7ab7aa`](https://github.com/NixOS/nixpkgs/commit/db7ab7aa6e2d44bc0b862d3bc768840a9c58a440) python3Packages.squarify: migrate to pyproject
* [`3c40c93a`](https://github.com/NixOS/nixpkgs/commit/3c40c93a82653cd8ccee6d5a03ce4bc72f82dd5e) python3Packages.sre-yield: migrate to pyproject
* [`11509c54`](https://github.com/NixOS/nixpkgs/commit/11509c54b925f821b97b468c4ce1fb9c1b2c8a13) python3Packages.squarify: modernize
* [`cf059f88`](https://github.com/NixOS/nixpkgs/commit/cf059f88a45c643bb90f90421bd23f99874df841) python3Packages.srptools: migrate to pyproject
* [`007b9785`](https://github.com/NixOS/nixpkgs/commit/007b97854c775238a8f5b65111897e384d14046f) python3Packages.srptools: modernize
* [`f5c0af40`](https://github.com/NixOS/nixpkgs/commit/f5c0af4057d9d65fbf157f4ef975b27f7f4ec12f) python3Packages.sre-yield: modernize
* [`4e5bd3d5`](https://github.com/NixOS/nixpkgs/commit/4e5bd3d5408f76e924ede5323f107781db531f55) python3Packages.srt: migrate to pyproject
* [`94a2a3d8`](https://github.com/NixOS/nixpkgs/commit/94a2a3d8e93c69dd22dc9ee91f29b8436d9dfb65) maintainer-list: add maintainer mershl
* [`184408a0`](https://github.com/NixOS/nixpkgs/commit/184408a04a87d211db055f6fab2931f8ad6ce3a5) yaru-theme: add maintainer mershl
* [`cd304afb`](https://github.com/NixOS/nixpkgs/commit/cd304afb3e0373be5f7af96c1c0fb5b9302fffec) python3Packages.srt: modernize
* [`3c9eb03a`](https://github.com/NixOS/nixpkgs/commit/3c9eb03a054db5c7e4904f99d1357d3ea050d7c0) atmos: 1.220.0 -> 1.224.1
* [`eee871ad`](https://github.com/NixOS/nixpkgs/commit/eee871ad5e4f7c453108e12b1293e47e1c7045c3) baresip: 4.9.0 -> 4.10.0
* [`8086d60c`](https://github.com/NixOS/nixpkgs/commit/8086d60c4ad461a36a9b618f7b16b9cb14154de4) vscode-extensions.ms-windows-ai-studio.windows-ai-studio: 1.6.5 -> 1.6.6
* [`114c70a6`](https://github.com/NixOS/nixpkgs/commit/114c70a6c998d2641c072d5e140ac74303f243bb) libudev-zero: 1.0.4 -> 1.0.5
* [`44675a79`](https://github.com/NixOS/nixpkgs/commit/44675a79edd2b7df5c258eddafe7c43385e788be) valeStyles.microsoft: 0.14.2 -> 0.15.0
* [`116b43e4`](https://github.com/NixOS/nixpkgs/commit/116b43e4c5e99b6eb914c62ff7f3470980a2dc09) maintainers: add Username404-59
* [`8c4c2ee4`](https://github.com/NixOS/nixpkgs/commit/8c4c2ee44058421fd856057663dba3e3083f9b76) mattermost: 11.7.7 -> 11.7.8
* [`4a5d68df`](https://github.com/NixOS/nixpkgs/commit/4a5d68df826739830bdaf856650e91044b133b7b) sq: add iamanaws as maintainer
* [`c69fb72b`](https://github.com/NixOS/nixpkgs/commit/c69fb72baec19b6da1733b6f6d99328862434de4) sq: 0.50.0 -> 0.54.1
* [`6a905ae3`](https://github.com/NixOS/nixpkgs/commit/6a905ae3de0f5b1582ef699de4fc988790a6d707) gnuplot: 6.0.4 -> 6.0.5
* [`34e3a995`](https://github.com/NixOS/nixpkgs/commit/34e3a9954e51001bcfd1eb8dfd0040e8fa79e36c) apache-jena: 6.1.0 -> 6.2.0
* [`7a8fc732`](https://github.com/NixOS/nixpkgs/commit/7a8fc7326993c60374799b9e57bac88110d31278) pinnacle: pin to libdisplay-info_0_3 to fix build
* [`1fbeed30`](https://github.com/NixOS/nixpkgs/commit/1fbeed304854cd1d04928ff40a698fce3052fa08) mongodb-compass: 1.49.10 -> 1.49.12
* [`e2ba942b`](https://github.com/NixOS/nixpkgs/commit/e2ba942b07be026b89d3247844e3c7cc310f97a0) pinnacle: mark aarch64-linux as a bad platform
* [`d5de2395`](https://github.com/NixOS/nixpkgs/commit/d5de239545f91a641406725af8c44dadf82d20e1) nixos/murmur: Use lib.types.ints.unsigned where it's appropriate
* [`6f699c28`](https://github.com/NixOS/nixpkgs/commit/6f699c28af531efe2b29a3f7efc31cee6a0205a7) python3Packages.mlx: skip flaky test on darwin
* [`9db25568`](https://github.com/NixOS/nixpkgs/commit/9db255681117954d41923c8c1f45d1ff9c38582a) mitmproxy: drop unused msgpack dependency
* [`2526d72d`](https://github.com/NixOS/nixpkgs/commit/2526d72d463e4bee8c725d6f4b8c56d02a1117d4) nixos/jenkins: Harden /proc visibility by setting `ProcSubset` to `pid`
* [`38b07bd7`](https://github.com/NixOS/nixpkgs/commit/38b07bd7158c108f29f26519054af6d2ca0b6cec) kubectl-ktop: remove duplicate
* [`74e43a47`](https://github.com/NixOS/nixpkgs/commit/74e43a479842525da693269cfba3ce5734f40970) jetbrains.dataspell: 2026.1.2 -> 2026.1.3
* [`ebc389b2`](https://github.com/NixOS/nixpkgs/commit/ebc389b21cce256e7306eedd62e79cc109ebf516) jetbrains.datagrip: 2026.2.1 -> 2026.2.2
* [`19c7019c`](https://github.com/NixOS/nixpkgs/commit/19c7019c1cf51b306513d8955cb29b28b73c99e5) jetbrains.pycharm: 2026.2 -> 2026.2.0.1
* [`737e9afb`](https://github.com/NixOS/nixpkgs/commit/737e9afb7091fcb05d9addf9c89aa331249bba97) sbcl_2_4_6: skip `elf-sans-immobile.test.sh` to avoid ZFS hang
* [`61d2f3ca`](https://github.com/NixOS/nixpkgs/commit/61d2f3cad5db50a090b468d1d5626f84e6d93bbc) gildas: build with gtk3, fix homepage
* [`ca88151e`](https://github.com/NixOS/nixpkgs/commit/ca88151ea457baa33869559cfae3fd6edeba612e) python3Packages.exllamav3: 1.2.1 -> 1.3.0
* [`78c2ffc2`](https://github.com/NixOS/nixpkgs/commit/78c2ffc20a1a10caf64fc28726fbce27027e92b7) tabbyapi: 0-unstable-2026-07-18 -> 0-unstable-2026-07-31
* [`44b673b2`](https://github.com/NixOS/nixpkgs/commit/44b673b294ebf3eaa4fec0d9fc9d5e84558e952c) immich-public-proxy: 3.0.2 -> 3.2.0
* [`93cacbcf`](https://github.com/NixOS/nixpkgs/commit/93cacbcfe776b7cc8a584a54068129b0530463bc) nixos/tabbyapi: sync with upstream options; add assert for deprecated option
* [`23a0a2fc`](https://github.com/NixOS/nixpkgs/commit/23a0a2fc2d6d35882422f9d5b5236e32434ab192) nano: 9.1 -> 9.2
* [`9db0983a`](https://github.com/NixOS/nixpkgs/commit/9db0983ad2767250bfa9a5998ad96f2f63617b34) proxyman: add darwin support
* [`9bfea0d0`](https://github.com/NixOS/nixpkgs/commit/9bfea0d0f1c884c5b432ca522b680f9216933b00) proxyman: add maintainer
* [`f54392fb`](https://github.com/NixOS/nixpkgs/commit/f54392fbcdc40c4e07ee460253b2ba6f9eb3cc82) python3Packages.openimageio: 3.1.15.0 -> 3.1.16.0
* [`81cb6015`](https://github.com/NixOS/nixpkgs/commit/81cb6015ff88949a2059607fe27a6756a0585e9e) xen: 4.20.3 -> 4.20.4
* [`6bd80a1d`](https://github.com/NixOS/nixpkgs/commit/6bd80a1daf66be4321984e1ada8fc2b36ec71da1) python3Packages.datamodel-code-generator: cleanup
* [`35a43584`](https://github.com/NixOS/nixpkgs/commit/35a435847524cdb57e6b443d6ae9face5feb817d) python3Packages.datamodel-code-generator: skip failing tests
* [`ca17ba08`](https://github.com/NixOS/nixpkgs/commit/ca17ba08bc6a47a32306279845c6a76815c4290a) menumaker: 0.99.13 -> 0.99.14
* [`dca91925`](https://github.com/NixOS/nixpkgs/commit/dca91925519c86720b0b3653973b3caf2071b50c) emacs: remove override for packages that are removed from ELPAs
* [`f160542b`](https://github.com/NixOS/nixpkgs/commit/f160542b8d4574d5962a8af2232add2e536a05ac) yosys: add slang support
* [`ffda69a3`](https://github.com/NixOS/nixpkgs/commit/ffda69a34002ee55405662fe16c2e153135769ce) emacs: remove unneeded buildWithGit override for elisp packages
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
