### PR TITLE
npins home-manager: update bf9ce9fe -> c30c7955

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -48,9 +48,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "bf9ce9fec78f95f374e8dd3b503863a3ec128ebe",
-      "url": "https://github.com/nix-community/home-manager/archive/bf9ce9fec78f95f374e8dd3b503863a3ec128ebe.tar.gz",
-      "hash": "sha256-vkMnV0JIyw+g/NmcfoajlGaAO+9a0ezia+FZohQJrik="
+      "revision": "c30c7955cec30d664a9baced6bc0112e263d4647",
+      "url": "https://github.com/nix-community/home-manager/archive/c30c7955cec30d664a9baced6bc0112e263d4647.tar.gz",
+      "hash": "sha256-ou8fYz5w9yhXC8YbvvExybFIa19MyW5G/8dEPqa90hM="
     },
     "hs-grille": {
       "type": "Git",


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@bf9ce9fe...c30c7955](https://github.com/nix-community/home-manager/compare/bf9ce9fec78f95f374e8dd3b503863a3ec128ebe...c30c7955cec30d664a9baced6bc0112e263d4647)

* [`380c55ae`](https://github.com/nix-community/home-manager/commit/380c55aeae9745bc94c010996753850d975b8f59) files: batch link creation and target checks
* [`a9bcd005`](https://github.com/nix-community/home-manager/commit/a9bcd0057073751a54ce5fd4b0dc63a391b6f349) flake-edit: init
* [`b0ba2580`](https://github.com/nix-community/home-manager/commit/b0ba2580ded6fc1d4998b4ae843fad70e584cd21) texlive: replace deprecated texlive.combine with texlive.withPackages
* [`95675bc3`](https://github.com/nix-community/home-manager/commit/95675bc36353303f129b83c3b7099f21c20531ce) easyeffects: add global settings option
* [`e91d4c16`](https://github.com/nix-community/home-manager/commit/e91d4c16982ae46884463c0bb8f2c86c215c5cd1) easyeffects: support paired presets
* [`c66b595c`](https://github.com/nix-community/home-manager/commit/c66b595cf29f1112954ef5e4fe8375c5b86634ca) easyeffects: support separate startup presets
* [`63bd543c`](https://github.com/nix-community/home-manager/commit/63bd543c9eb774a53be7650536a1da9e12bfc657) maintainers: add rachitvrma
* [`c2cef1e7`](https://github.com/nix-community/home-manager/commit/c2cef1e7e07bb6b4c5b9f37184f40afd45097d4f) dprint: add module
* [`ff174130`](https://github.com/nix-community/home-manager/commit/ff1741309ec30dce33bc35986045d283333b3e96) maintainers: add vidhanio
* [`44a1a0ab`](https://github.com/nix-community/home-manager/commit/44a1a0ab16b1b6b8e6b673227d870c3a89cab35e) crush: add module
* [`cc51f24b`](https://github.com/nix-community/home-manager/commit/cc51f24b9ba245d4c528dd6210eb095693df9f08) claude-code: allow hooks to accept a path like skills/commands
* [`a7c70cc2`](https://github.com/nix-community/home-manager/commit/a7c70cc290290f373f50cd820403833d250459ac) maintainers: update all-maintainers.nix
* [`c1b62f9b`](https://github.com/nix-community/home-manager/commit/c1b62f9b55b4ed3c7647f796b27981d802e6a94b) maintainers: update rachitvrma
* [`18c17cab`](https://github.com/nix-community/home-manager/commit/18c17cab653e4f34dfb62588147ff86c3a670fd7) wiremix: add module
* [`7834e825`](https://github.com/nix-community/home-manager/commit/7834e82588860aaf780cec1366524456a70898d7) wlr-which-key: add `programs.wlr-which-key`
* [`367f7ef8`](https://github.com/nix-community/home-manager/commit/367f7ef80856d18438953d54dda235d42a46ba31) claude-code: shorten generated plugin name to "hm"
* [`c30c7955`](https://github.com/nix-community/home-manager/commit/c30c7955cec30d664a9baced6bc0112e263d4647) maintainers: update all-maintainers.nix
