### PR TITLE
npins nerd-icons.el: update f12d1e46 -> 1e75075e

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -99,9 +99,9 @@
       },
       "branch": "main",
       "submodules": false,
-      "revision": "f12d1e4619aa5ed7d1c1ddf837d4335015bdfd4d",
-      "url": "https://github.com/rainstormstudio/nerd-icons.el/archive/f12d1e4619aa5ed7d1c1ddf837d4335015bdfd4d.tar.gz",
-      "hash": "sha256-ARBOiN3IdayarC9p5FwCgP5zh7BNqfsn8x0TTPGj+bM="
+      "revision": "1e75075e323dedaf9f2fd5837082c60a2d0dfae3",
+      "url": "https://github.com/rainstormstudio/nerd-icons.el/archive/1e75075e323dedaf9f2fd5837082c60a2d0dfae3.tar.gz",
+      "hash": "sha256-LtHyI6HMvlzPwt/ld+fw1sxwxtbbw+TJCZhr8Dsm8uc="
     },
     "niv": {
       "type": "Git",


### PR DESCRIPTION
## Changelog for nerd-icons.el:
Branch: main
Commits: [rainstormstudio/nerd-icons.el@f12d1e46...1e75075e](https://github.com/rainstormstudio/nerd-icons.el/compare/f12d1e4619aa5ed7d1c1ddf837d4335015bdfd4d...1e75075e323dedaf9f2fd5837082c60a2d0dfae3)

* [`f8fc07d3`](https://github.com/rainstormstudio/nerd-icons.el/commit/f8fc07d35cfe53739198ce51eaeee847f8cfeee1) feat(icons): add icon for mistty mode
* [`1e75075e`](https://github.com/rainstormstudio/nerd-icons.el/commit/1e75075e323dedaf9f2fd5837082c60a2d0dfae3) feat(icons): add icon for pr-review-mode
