### PR TITLE
npins zsh-patina: update 0e365ffa -> 63d033ce

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -242,9 +242,9 @@
       },
       "branch": "main",
       "submodules": false,
-      "revision": "0e365ffa038865668cd148b388f142e7e4713613",
-      "url": "https://github.com/michel-kraemer/zsh-patina/archive/0e365ffa038865668cd148b388f142e7e4713613.tar.gz",
-      "hash": "sha256-+DpjlFDm3foyPetFINiuSB7PxtfFLUiIYno8o5mvC34="
+      "revision": "63d033ce397becd7dc325171b7a9b933bda8ea6e",
+      "url": "https://github.com/michel-kraemer/zsh-patina/archive/63d033ce397becd7dc325171b7a9b933bda8ea6e.tar.gz",
+      "hash": "sha256-lsalJHGQIYRzHtqhtXlH0KRTAoW1CdAmvH3vSFR/NPY="
     },
     "zsh-syntax-highlighting": {
       "type": "Git",


### PR DESCRIPTION
## Changelog for zsh-patina:
Branch: main
Commits: [michel-kraemer/zsh-patina@0e365ffa...63d033ce](https://github.com/michel-kraemer/zsh-patina/compare/0e365ffa038865668cd148b388f142e7e4713613...63d033ce397becd7dc325171b7a9b933bda8ea6e)

* [`3b1f2ac9`](https://github.com/michel-kraemer/zsh-patina/commit/3b1f2ac909aebea8bd3f53cc58a6e7b632fa96ca) Add CONTRIBUTING guide
* [`a5f92f1f`](https://github.com/michel-kraemer/zsh-patina/commit/a5f92f1fa8f1edd99d1f97d486a648bb5917e8eb) Fix typo in CONTRIBUTING guide
* [`ea1f44da`](https://github.com/michel-kraemer/zsh-patina/commit/ea1f44dad2eb27a0b0f426c59ccdaf0daa49cdcc) Do not highlight directories as executable unless autocd
* [`a27d38f4`](https://github.com/michel-kraemer/zsh-patina/commit/a27d38f45d346f258dca118909fd90a0819748f6) Adjust completion set-up notes
