### PR TITLE
npins nixpkgs: update 0eae3d8b -> 18fb4828

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -125,9 +125,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "0eae3d8bc21612049425097335e17dae1a268d41",
-      "url": "https://github.com/nixos/nixpkgs/archive/0eae3d8bc21612049425097335e17dae1a268d41.tar.gz",
-      "hash": "sha256-FQFNo9f/TEhmMiyELLfBO5OXWWAbJ/pTIVql4Rts4Ko="
+      "revision": "18fb4828e1f85a2c994608252217a8796e659a02",
+      "url": "https://github.com/nixos/nixpkgs/archive/18fb4828e1f85a2c994608252217a8796e659a02.tar.gz",
+      "hash": "sha256-kIVH8uflRODlyU0abn2wBx1M+H63qy5tSXdV2tTQLdQ="
     },
     "powerlevel10k": {
       "type": "Git",


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@0eae3d8b...18fb4828](https://github.com/nixos/nixpkgs/compare/0eae3d8bc21612049425097335e17dae1a268d41...18fb4828e1f85a2c994608252217a8796e659a02)

* [`28458575`](https://github.com/NixOS/nixpkgs/commit/28458575ac8f54b4192a24964271c9c8496dd3ed) libsegfault: 0-unstable-2022-11-13 -> 0-unstable-2025-10-01
* [`da4950fe`](https://github.com/NixOS/nixpkgs/commit/da4950fe16384dde3f72a5bc84cb7d73796a3505) nitrokey-trng-rs232-firmware: 1.0.0 -> 1.1.0
* [`f707d060`](https://github.com/NixOS/nixpkgs/commit/f707d060209707c184b6ed711cde3d559f0af7dc) gl3w: 0-unstable-2025-09-23 -> 0-unstable-2025-11-07
* [`ce004a4a`](https://github.com/NixOS/nixpkgs/commit/ce004a4ac97ed1c6a10a65e65895b2aa5a0bd437) cewler: 1.3.1 -> 1.4.1
* [`195f2a4d`](https://github.com/NixOS/nixpkgs/commit/195f2a4dac65f01b9119de6f773aa008776f17b3) worker: 5.2.2 -> 5.3.1
* [`9aa26f3d`](https://github.com/NixOS/nixpkgs/commit/9aa26f3d98371afe2d6f41292af4ebcb00d7e39a) networkmanager-openvpn: 1.12.3 -> 1.12.5
* [`c45a9628`](https://github.com/NixOS/nixpkgs/commit/c45a96286d3e51c434618502b852be359f9a6399) ghidra: add ghidralib
* [`87069815`](https://github.com/NixOS/nixpkgs/commit/8706981538d4a8075227de5dd23361cb5b426940) smpq: 1.6 -> 1.7
* [`6e8cdcad`](https://github.com/NixOS/nixpkgs/commit/6e8cdcad67dff499961880daf87775528018f0ec) python3Packages.pyld: 1.0.5 -> 2.0.4
* [`8ad37d38`](https://github.com/NixOS/nixpkgs/commit/8ad37d38378c9134633122145f081dd2c3a78c2d) kdePackages.qt6gtk2: 0.6 -> 0.7
* [`55358e9f`](https://github.com/NixOS/nixpkgs/commit/55358e9f62cb2b6f469cd5d3229672bde271004c) resnap: 2.5.2 -> 2.5.3
* [`5d71d2f4`](https://github.com/NixOS/nixpkgs/commit/5d71d2f4870ffd4f3d9aa370982d1baaf52e62c7) muffon: 2.3.0 -> 2.4.0
* [`6864eea9`](https://github.com/NixOS/nixpkgs/commit/6864eea99eb2b782dc958e79f45a3b2283b3e5de) memtier-benchmark: adds Darwin/macOS support
* [`aee0f554`](https://github.com/NixOS/nixpkgs/commit/aee0f5547aea4aa3fb3e85716ac734148d594890) prism-model-checker: 4.9 -> 4.10
* [`fdd4d5e6`](https://github.com/NixOS/nixpkgs/commit/fdd4d5e666568eed57a595bbb2059f8c1ad6ccdc) spleen: 2.1.0 -> 2.2.0
* [`36abc6da`](https://github.com/NixOS/nixpkgs/commit/36abc6daccb810372a573d98779b60095835d9f5) kooha: 2.2.4 -> 2.3.0
* [`a0b4de2f`](https://github.com/NixOS/nixpkgs/commit/a0b4de2f09f51af6533aa7d6d556cbb8c3e7f169) jbake: 2.6.7 -> 2.7.0
* [`d35fc8e0`](https://github.com/NixOS/nixpkgs/commit/d35fc8e03583f5b59841d5921845f02e62cefe0c) normaliz: 3.11.0 -> 3.11.1
* [`9fa42747`](https://github.com/NixOS/nixpkgs/commit/9fa427470c566e1d2ce0f90bbbc41a298b82c408) moonlight-embedded: 2.7.0 -> 2.7.1
* [`a77a4d4a`](https://github.com/NixOS/nixpkgs/commit/a77a4d4a479d2d810bf1561c612dcf8e5f6949a2) fiji: 20250408-1717 -> 20250514-1117
* [`816b99b4`](https://github.com/NixOS/nixpkgs/commit/816b99b4a03c446d29bf75825730f168d3be1b6a) tintin: 2.02.60 -> 2.02.61
* [`e6de9f3e`](https://github.com/NixOS/nixpkgs/commit/e6de9f3e3401e0141b10e181dc76ad06c745ed3c) geist-font: 1.5.0 -> 1.7.0
* [`9f665b02`](https://github.com/NixOS/nixpkgs/commit/9f665b02d17153097d9ae0aa31418826c4a829dc) optifine: 1.21.4_HD_U_J3 -> 1.21.11_HD_U_J9
* [`8778486d`](https://github.com/NixOS/nixpkgs/commit/8778486df6be9a7fc94122e65b1bcedf25c9df1a) hyx: 2024.02.29 -> 2026.01.11
* [`b26511ab`](https://github.com/NixOS/nixpkgs/commit/b26511aba45063caf5aa94ac98f0ce39b2eef3cc) duo-unix: 2.2.1 -> 2.2.3
* [`8692c46d`](https://github.com/NixOS/nixpkgs/commit/8692c46da78fcdaa733c9ec79e2587fa599fb4a6) convimg: 9.4 -> 10.3
* [`aa29b3e6`](https://github.com/NixOS/nixpkgs/commit/aa29b3e6c9523179e7284698f2d2316aae3d544a) darkman: 2.2.0 -> 2.3.1
* [`dd67bf84`](https://github.com/NixOS/nixpkgs/commit/dd67bf8486a1edb23a9356a5463772e12b28ce0b) pest-ide-tools: 0.3.11 -> 0.13.2
* [`34b42757`](https://github.com/NixOS/nixpkgs/commit/34b427571b680719d6acf1098b3ed0fb1d4787d3) inspectrum: build on darwin
* [`c9821d8e`](https://github.com/NixOS/nixpkgs/commit/c9821d8e128ab7433a95e779afd6f06ef1a84f33) libmodplug: use the configured includedir in pc file
* [`668e7992`](https://github.com/NixOS/nixpkgs/commit/668e7992ae75815d9e4cacd04f199bbefd2ec660) ibus-engines.table-others: 1.3.21 -> 1.3.22
* [`a0ca378c`](https://github.com/NixOS/nixpkgs/commit/a0ca378cedc723f751df1d7b785b316f4d19a62d) xtl: 0.8.0 -> 0.8.2
* [`d57dcaf8`](https://github.com/NixOS/nixpkgs/commit/d57dcaf81e0c469da0c5b42a989626c6b16e5c80) python3Packages.model-bakery: 1.23.2 -> 1.23.3
* [`25cfe5a0`](https://github.com/NixOS/nixpkgs/commit/25cfe5a024defe87761162c9371ab3623de689cb) python3Packages.scheduler: 0.8.8 -> 0.8.11
* [`d5c60030`](https://github.com/NixOS/nixpkgs/commit/d5c600301d568d5917e687dc9bad4084a232b329) python3Packages.linuxpy: 0.23.0 -> 0.24.0
* [`10de7651`](https://github.com/NixOS/nixpkgs/commit/10de7651e920f12b12704ee01f799d01dbf9e4e1) nbstripout: 0.8.2 -> 0.9.1
* [`2ad4c129`](https://github.com/NixOS/nixpkgs/commit/2ad4c129cdc1a3cfa94c7d1ad703d32331bb0299) k40-whisperer: 0.68 -> 0.71
* [`bec390f2`](https://github.com/NixOS/nixpkgs/commit/bec390f200131f2cbacca8f5783d9560ac3845da) subtitleeditor: 0.55.0 -> 0.56.2
* [`625cebeb`](https://github.com/NixOS/nixpkgs/commit/625cebebfd83674d98483e3885e1327d9aa6a8fc) nix-snapshotter: 0.3.0 -> 0.4.0
* [`795d69be`](https://github.com/NixOS/nixpkgs/commit/795d69beac880fc7e0850ef32e3ce34f2b456fd4) pattypan: 22.03 -> 26.02
* [`c5fa819d`](https://github.com/NixOS/nixpkgs/commit/c5fa819d641b9368df19ee02fc37508328e01714) amazon-ecr-credential-helper: 0.11.0 -> 0.12.0
* [`925c3b91`](https://github.com/NixOS/nixpkgs/commit/925c3b91a4e5e6bbc2bf3826151a6d0832bbc584) ocserv: 1.4.0 -> 1.4.1
* [`14fa8cce`](https://github.com/NixOS/nixpkgs/commit/14fa8ccede167b9978237cbf158137c8bfbf73df) openpace: 1.1.3 -> 1.1.4
* [`a5bcfbef`](https://github.com/NixOS/nixpkgs/commit/a5bcfbef2ebdd461f1e2734d11742849f26c7837) xastir: 2.2.2 -> 2.2.4
* [`5f4e81b7`](https://github.com/NixOS/nixpkgs/commit/5f4e81b7a68f75f7bdd7d6c3edfa74a0f57cbda7) mcap-cli: 0.0.61 -> 0.0.62
* [`99e44405`](https://github.com/NixOS/nixpkgs/commit/99e44405b40d9a5405362b7b6367ea404933ec0b) minicom: 2.10 -> 2.11.1
* [`3a835ce7`](https://github.com/NixOS/nixpkgs/commit/3a835ce7c7c2c127b8cb7f1ff8c8d2768d31ce26) paper-age: 1.4.0 -> 1.5.0
* [`9dbf6699`](https://github.com/NixOS/nixpkgs/commit/9dbf6699a3f18a578dd8f3a073f35a64661abb33) simpleproxy: 3.5 -> 3.6
* [`59116acb`](https://github.com/NixOS/nixpkgs/commit/59116acb2ce2b09f6a750567e94e97f1709dea33) yourkit-java: 2025.9-b175 -> 2025.9-b191
* [`7cdf2fdf`](https://github.com/NixOS/nixpkgs/commit/7cdf2fdfeacaf823aaeacda89bd7f66f830022ff) chessx: 1.6.2 -> 1.6.10
* [`7203d4b8`](https://github.com/NixOS/nixpkgs/commit/7203d4b8797aa52a5ea5b2913ecf4eb9d16c82bc) bootstrap-studio: 7.1.2 -> 8.0.1
* [`59462b0f`](https://github.com/NixOS/nixpkgs/commit/59462b0f12e5c623aaa7cf75337600f1621ae13f) libtickit: 0.4.5 -> 0.4.6
* [`32bec6b8`](https://github.com/NixOS/nixpkgs/commit/32bec6b85cc72b12cd57eeb00940474370352a36) cargo-sonar: 1.5.0 -> 1.6.0
* [`fd7249c4`](https://github.com/NixOS/nixpkgs/commit/fd7249c4371386309b6ad5c76064ade83ed5d598) sil-padauk: 5.100 -> 6.000
* [`cfa6b853`](https://github.com/NixOS/nixpkgs/commit/cfa6b853784044c627c0b4e772c0299269ad98d5) numcpp: 2.16.0 -> 2.16.1
* [`52c949ec`](https://github.com/NixOS/nixpkgs/commit/52c949ec4d060cc959854a40437513caf718db65) libtraceevent: fix update-bot error
* [`2d234b7b`](https://github.com/NixOS/nixpkgs/commit/2d234b7b094859de68168d06a046d998d82553a3) system76-keyboard-configurator: 1.3.12 -> 1.3.13
* [`6183d419`](https://github.com/NixOS/nixpkgs/commit/6183d4191bcdecb51d688b540bd568d81a5c4412) beszel-agent: add dataDir option
* [`2933b579`](https://github.com/NixOS/nixpkgs/commit/2933b579e587bf04c57085ab384017c2be96fa89) ngt: 2.6.0 -> 2.7.2
* [`386df124`](https://github.com/NixOS/nixpkgs/commit/386df12493012666d096eafb0c1912359e583027) heroku: 10.16.0 -> 11.0.0
* [`f6d18f45`](https://github.com/NixOS/nixpkgs/commit/f6d18f45600c24cf9febe4811260f9ea4c6fc973) coc-nginx: 0.5.0 -> 0.5.1
* [`ca81f1ef`](https://github.com/NixOS/nixpkgs/commit/ca81f1efa98827a29df962fc17be556fcb60b2f6) mlmmj: 1.5.0 -> 1.8.0
* [`a369f831`](https://github.com/NixOS/nixpkgs/commit/a369f831a66bd58579550abc9c0b745c7ca92725) gtranslator: 49.0 -> 50.0
* [`8a8926bc`](https://github.com/NixOS/nixpkgs/commit/8a8926bc33c0668aaea801c62bef8ce99db2dfe2) lazyjournal: 0.8.4 -> 0.8.6
* [`1a3e65d6`](https://github.com/NixOS/nixpkgs/commit/1a3e65d6365f44fddea556da27f5d3365ead5281) gopeed: 1.9.0 -> 1.9.3
* [`e74d98b2`](https://github.com/NixOS/nixpkgs/commit/e74d98b24343b137bc6f6862440be88f013e40f7) python3Packages.diffsync: 2.2.0 -> 2.2.3
* [`78c53d4f`](https://github.com/NixOS/nixpkgs/commit/78c53d4fb8af8102fe2c15e2faded69e5d75f972) plzip: disable tests on darwin
* [`09005180`](https://github.com/NixOS/nixpkgs/commit/09005180578e6e770aca5704c2862b92332515a8) python3Packages.httpx-ws: 0.8.2 -> 0.9.0
* [`b0e2a9b5`](https://github.com/NixOS/nixpkgs/commit/b0e2a9b51061f0ecc34f9f6bfe14a677d7568acb) tuptime: 5.2.4 -> 5.2.6
* [`b2b5d42c`](https://github.com/NixOS/nixpkgs/commit/b2b5d42c3cb3baebef895118bc4fcda046c57b48) gremlin-console: 3.8.0 -> 3.8.1
* [`ac7f5e52`](https://github.com/NixOS/nixpkgs/commit/ac7f5e52ea364da156607ab2eaa3523741bd4a4f) avalanchego: 1.14.1 -> 1.14.2
* [`cab784bc`](https://github.com/NixOS/nixpkgs/commit/cab784bc72d0f967e2b1d788a2debf344b73c347) pounce: 3.1 -> 3.2
* [`a1c8b301`](https://github.com/NixOS/nixpkgs/commit/a1c8b301918836f886c6e1a61f83b46fc8900ea4) ghost-cli: 1.28.6 -> 1.29.1
* [`edc57bb9`](https://github.com/NixOS/nixpkgs/commit/edc57bb97ceb6e7116d9ab9ef6cfad1fca973b2a) skrooge: 25.10.0 -> 26.4.0
* [`a506f9b9`](https://github.com/NixOS/nixpkgs/commit/a506f9b9a063f72358f6b4fa516390c7547741cd) certstream-server-go: 1.8.2 -> 1.9.0
* [`46759e4b`](https://github.com/NixOS/nixpkgs/commit/46759e4bcde670d9ee55e6f85e9c715a8bef9989) kube-router: 2.7.1 -> 2.8.1
* [`6e95569b`](https://github.com/NixOS/nixpkgs/commit/6e95569b9f4d71ba83fb1016eba924d5125540ee) quiet: 6.6.0 -> 7.0.1
* [`0d4db066`](https://github.com/NixOS/nixpkgs/commit/0d4db066bf05fa02713ee58201ecc75e81f63a10) messer-slim: 5.1 -> 5.2
* [`ed27a4ee`](https://github.com/NixOS/nixpkgs/commit/ed27a4ee17d005fad71b53a96c924890b8cd2672) docuum: 0.26.1 -> 0.27.0
* [`7aed0ebb`](https://github.com/NixOS/nixpkgs/commit/7aed0ebbc1fc47cb2459b4dab1ca5e84fba0f429) libcoap: 4.3.5a -> 4.3.5b
* [`203c7ddf`](https://github.com/NixOS/nixpkgs/commit/203c7ddf4f66f83ab044f2cad98e123e683e6dce) gwyddion: 2.70 -> 2.71
* [`73ded0ee`](https://github.com/NixOS/nixpkgs/commit/73ded0ee337c1ebf72ef7d0ec2037631b997a5f1) fennel-ls: 0.2.3 -> 0.2.4
* [`0acc864e`](https://github.com/NixOS/nixpkgs/commit/0acc864e52937a890470eeb33447bf73b4746f31) schemesh: fix build on darwin
* [`4ca4e7ad`](https://github.com/NixOS/nixpkgs/commit/4ca4e7ad04404af7ee8250fbca7cfea1514e7e5e) ocamlPackages.ocaml_sqlite3: 5.3.1 -> 5.4.1
* [`30376c26`](https://github.com/NixOS/nixpkgs/commit/30376c26dcb27bc028d5f467f659edf399e97ec9) git-credential-aol: 5.6.2 -> 5.9.1
* [`9e0febdf`](https://github.com/NixOS/nixpkgs/commit/9e0febdf9ef4cc9bc42e8c1f5ed8315b04556a9f) ico: 1.0.6 -> 1.0.7
* [`943763ee`](https://github.com/NixOS/nixpkgs/commit/943763ee950a8433ab4eca5702b32c47106d6241) subnetcalc: 2.6.5 -> 2.6.6
* [`4925e823`](https://github.com/NixOS/nixpkgs/commit/4925e8237bb30f1c7ee8942d1754957e499a70eb) vms-empire: 1.18 -> 1.20
* [`9338f059`](https://github.com/NixOS/nixpkgs/commit/9338f059a57dda74b4045c53da3a9bb3ce24f014) collector: 0-unstable-2026-02-04 -> 0-unstable-2026-04-17
* [`096e2a50`](https://github.com/NixOS/nixpkgs/commit/096e2a50044443cfd8611ca1722af0c7accd4312) guile-goblins: 0.17.0 -> 0.18.0
* [`bb219ada`](https://github.com/NixOS/nixpkgs/commit/bb219ada17b2bd05663f846ad3d4fdfd53f7231d) pjsip: 2.16 -> 2.17
* [`ee0f790e`](https://github.com/NixOS/nixpkgs/commit/ee0f790e5bf6b99e0d4ffc6a93f05e85e0d797b6) git-quick-stats: 2.8.0 -> 2.11.0
* [`aefa577f`](https://github.com/NixOS/nixpkgs/commit/aefa577fffd41657bcee40bf71ca0ce495aaf518) cables: 0.10.2 -> 0.10.6
* [`5259c6c7`](https://github.com/NixOS/nixpkgs/commit/5259c6c7bee30ee11663ada809954847a43ab0a4) qbec: 0.30.0 -> 0.31.0
* [`7eb3ef0b`](https://github.com/NixOS/nixpkgs/commit/7eb3ef0b764cdd5366fd1d3ad799ccd03bbb1145) scorecard: 5.4.0 -> 5.5.0
* [`6c79af29`](https://github.com/NixOS/nixpkgs/commit/6c79af2994fd26a6d165afa7e4be919fbc51e5df) anki: fix microphone recording
* [`f86c70e0`](https://github.com/NixOS/nixpkgs/commit/f86c70e01dba8af5181c42ba4be264229833eca7) annotator: 2.0.2 -> 2.0.3
* [`8145d401`](https://github.com/NixOS/nixpkgs/commit/8145d4011f68804baaad89a2fda335e6289243c8) gnote: 49.2 -> 50.1
* [`618a7ebc`](https://github.com/NixOS/nixpkgs/commit/618a7ebce3263b039d22c99622cde5743eaa8199) qiv: 3.0.2 -> 3.0.4
* [`8c12cab6`](https://github.com/NixOS/nixpkgs/commit/8c12cab6f5f99b76b3fcbebb531d79a44b9606bc) conntrack-tools: 1.4.8 -> 1.4.9
* [`bfae77f9`](https://github.com/NixOS/nixpkgs/commit/bfae77f9e43a2096f36d1aafee8395c21557d37c) mosdepth: 0.3.13 -> 0.3.14
* [`056eff12`](https://github.com/NixOS/nixpkgs/commit/056eff12497c9b0e98a4c058ec50ea8cdf3d40a9) xconsole: 1.1.0 -> 1.1.1
* [`c9db2a17`](https://github.com/NixOS/nixpkgs/commit/c9db2a17a893969f933c295a18d70cefe6e01c02) gnome-commander: 1.18.5 -> 1.18.6
* [`c97e6fdd`](https://github.com/NixOS/nixpkgs/commit/c97e6fddc534bbd929b3c3db6bea49c5dc1cacbd) xf86-video-nv: 2.1.23 -> 2.1.24
* [`2ed83652`](https://github.com/NixOS/nixpkgs/commit/2ed836520f1996b8b5e0d3520f9923e9ea387d60) jacktrip: 2.7.2 -> 3.0.0
* [`413e978a`](https://github.com/NixOS/nixpkgs/commit/413e978af330e66e290afa5d7b036d0692612817) hockeypuck: 2.3.2 -> 2.3.3
* [`fb8266a9`](https://github.com/NixOS/nixpkgs/commit/fb8266a908b5d5f49c1329d3773acf46a1d156fe) lombok: 1.18.42 -> 1.18.46
* [`9830d017`](https://github.com/NixOS/nixpkgs/commit/9830d0171493ca91693ee6adba812d8fb43dde7e) aws-lc: restore postFixup dropped in 1.65.0 bump
* [`7b19f1f0`](https://github.com/NixOS/nixpkgs/commit/7b19f1f05a8840e76210301d01e6b89c1a020a3a) git-pw: 2.7.1 -> 2.8.1
* [`51029858`](https://github.com/NixOS/nixpkgs/commit/510298586f628d549ab8e09475ff95ab43309c20) python3Packages.uhi: 1.0.0 -> 1.1.1
* [`1c22909c`](https://github.com/NixOS/nixpkgs/commit/1c22909ccb587584f5322326b332c3f3afee0ec2) bazel-kazel: 0.2.5 -> 0.2.6
* [`aabd8e43`](https://github.com/NixOS/nixpkgs/commit/aabd8e43c5f40fb896d4a90614ba161de12e46c2) gretl: 2026a -> 2026b
* [`662ce007`](https://github.com/NixOS/nixpkgs/commit/662ce007cc937dc10682e849ff19cef22e59e1ec) python3Packages.edalize: 0.6.1 -> 0.6.8
* [`34ca0d3b`](https://github.com/NixOS/nixpkgs/commit/34ca0d3b2d33eda895fe75c7a486f8907c3a60ce) spotify-qt: 4.0.3 -> 4.0.4
* [`977dea41`](https://github.com/NixOS/nixpkgs/commit/977dea41702bfbecbf928e68d45b24456af0853b) thedesk: 25.3.1 -> 25.4.0
* [`f52f0e36`](https://github.com/NixOS/nixpkgs/commit/f52f0e36ffcad657ee752402a1bc1c24ed394908) millipixels: 0.23.0 -> 0.24.0
* [`68e47aae`](https://github.com/NixOS/nixpkgs/commit/68e47aaead8978d1eb7fbe0fae43e30c86c1983d) smatch: 1.74 -> 1.75
* [`facbed26`](https://github.com/NixOS/nixpkgs/commit/facbed264944df361326b55d50fe649f784ec571) ipsw: 3.1.672 -> 3.1.673
* [`d77b04fa`](https://github.com/NixOS/nixpkgs/commit/d77b04fad4e34abd9484c93acb9a5dec30dea050) wiki-js: 2.5.312 -> 2.5.314
* [`0c847f5e`](https://github.com/NixOS/nixpkgs/commit/0c847f5eff5e1f57be2cabb9fea0917613b7a71d) hcledit: 0.2.17 -> 0.2.18
* [`632d991c`](https://github.com/NixOS/nixpkgs/commit/632d991c980be234ac9c030fa5b95d92e2978d1c) mandelbulber: 2.33 -> 2.34
* [`31b3d166`](https://github.com/NixOS/nixpkgs/commit/31b3d166a34ea07da07c4ebd1c5ce98b967fdf27) manifest-tool: 2.2.1 -> 2.2.2
* [`dec14fa0`](https://github.com/NixOS/nixpkgs/commit/dec14fa01a0c69919c35c20708d294840ee59ee5) setbfree: 0.8.13 -> 0.8.15
* [`5f2758ca`](https://github.com/NixOS/nixpkgs/commit/5f2758caf5a9b1ac0f4317f73192632131a42fe5) pythia: migrate to by-name
* [`3a73a0c0`](https://github.com/NixOS/nixpkgs/commit/3a73a0c0aba6bdb4bcd44029c537c5ea8557980b) pythia: modernize derivation
* [`78cf3d3a`](https://github.com/NixOS/nixpkgs/commit/78cf3d3a48e6b452585478e0f9f9809f47235b50) hepmc3: migrate to by-name
* [`40bd7e81`](https://github.com/NixOS/nixpkgs/commit/40bd7e817bd6c66020964e7ed0a4e3ff84cae7f4) hepmc3: modernize derivation
* [`b1b884f2`](https://github.com/NixOS/nixpkgs/commit/b1b884f2b28928829dfcd8193dedfec9ade79cb9) generic-sycl-components: init at unstable-2025-08-04
* [`62f726b8`](https://github.com/NixOS/nixpkgs/commit/62f726b836dabc44c5b8c5afb07cf0ebbe84382a) znc: 1.10.1 -> 1.10.2
* [`56ff4faa`](https://github.com/NixOS/nixpkgs/commit/56ff4faaa10b4b9063b66e44c9172c0740c7aa2b) kitex: 0.16.1 -> 0.16.2
* [`853d1d6f`](https://github.com/NixOS/nixpkgs/commit/853d1d6f2ff4ac917bc5a875c55d17fc4a243bc6) friture: fix
* [`44e99d2c`](https://github.com/NixOS/nixpkgs/commit/44e99d2ced29e922a5eab2aa54b4ae8b8ebedfa9) gibo: 3.0.21 -> 3.0.22
* [`e7731028`](https://github.com/NixOS/nixpkgs/commit/e773102824701c5c20eec329d3a060d82ebab0ef) cockatrice: 2026-02-22-Release-2.10.3 -> 2026-05-08-Release-3.0.0
* [`d39da1f4`](https://github.com/NixOS/nixpkgs/commit/d39da1f41b0be4a44e0d7cf32478db10cbfdce9b) jql: 8.0.10 -> 8.1.2
* [`c139b5c1`](https://github.com/NixOS/nixpkgs/commit/c139b5c1d0ffd423241da25a9127510e059836ef) druid: 36.0.0 -> 37.0.0
* [`cd83c8d2`](https://github.com/NixOS/nixpkgs/commit/cd83c8d2134fa604988241f838e460a9c5b91369) mgrep: 0.1.10 -> 0.1.13
* [`5d3d8618`](https://github.com/NixOS/nixpkgs/commit/5d3d86187f5b03edf5edbd65e662cec7f2e63183) ocrs: 0.12.0 -> 0.12.2
* [`56006de2`](https://github.com/NixOS/nixpkgs/commit/56006de25a660f0b8ff99c40e652fab7e9514ad4) dmtcp: 4.1.0 -> 4.1.1
* [`b00bc89f`](https://github.com/NixOS/nixpkgs/commit/b00bc89fe57db81408c4cf5ef80080920e1c373e) ibus-engines.table: 1.17.18 -> 1.17.19
* [`b10cffbc`](https://github.com/NixOS/nixpkgs/commit/b10cffbcf069a4a3a1f3aa0ec3b8c53540db59fb) roxterm: 3.17.2 -> 3.18.2
* [`64945ea1`](https://github.com/NixOS/nixpkgs/commit/64945ea1f8a91619bc62606e4bdd036374fa6fa7) falcoctl: 0.11.4 -> 0.13.0
* [`1139530b`](https://github.com/NixOS/nixpkgs/commit/1139530b065c5a240786d40b1f45eda602d69435) tana: 1.515.0 -> 1.520.0
* [`18c31f8b`](https://github.com/NixOS/nixpkgs/commit/18c31f8bdc8d3189259bed90a7b81082f08fbb88) lipo-go: 0.9.4 -> 0.10.0
* [`eb629517`](https://github.com/NixOS/nixpkgs/commit/eb629517cbbf0d031d53eb33d408850e750cc179) terminaltexteffects: 0.14.2 -> 0.15.0
* [`033294da`](https://github.com/NixOS/nixpkgs/commit/033294da91b0b6d14ec741327dc5ce29b6d6295a) libcouchbase: 3.3.18 -> 3.3.19
* [`8108e5d6`](https://github.com/NixOS/nixpkgs/commit/8108e5d6dd12ac449ef879c7b9ebcda326cd8c40) couchdb3: 3.5.1 -> 3.5.2
* [`9eee18de`](https://github.com/NixOS/nixpkgs/commit/9eee18dea4fd57b9affc3be650492728fb4164f6) coldsnap: 0.10.0 -> 0.11.0
* [`7b90c961`](https://github.com/NixOS/nixpkgs/commit/7b90c9612bfdc2fdc1d1ae1cb76cc7f3d784e1f8) kodiPackages.osmc-skin: fix build
* [`cb34dcc8`](https://github.com/NixOS/nixpkgs/commit/cb34dcc8e77fe6497ceb1a7d9544e1215c57defa) lla: 0.5.4 -> 0.5.7
* [`c73060a4`](https://github.com/NixOS/nixpkgs/commit/c73060a41cd8833b1e3fe9a45221ed8f10cc5333) memtest86plus: 8.00 -> 8.10
* [`d741acba`](https://github.com/NixOS/nixpkgs/commit/d741acba86ded27d8470889157ed16ae752a07b3) transcrypt: 2.3.1 -> 2.3.2
* [`83cb00b1`](https://github.com/NixOS/nixpkgs/commit/83cb00b1645274119821ce1c12400083481719c7) podlet: 0.3.1 -> 0.3.2
* [`76c1ef38`](https://github.com/NixOS/nixpkgs/commit/76c1ef38f697ef12a13b6d03fdcd20c0625de99e) chirp: 0.4.0-unstable-2026-05-07 -> 0.4.0-unstable-2026-05-18
* [`a4ac9c01`](https://github.com/NixOS/nixpkgs/commit/a4ac9c01a714265c5f397358cdb657e0db87d202) ibus-engines.bamboo: 0.8.4-rc6 -> 0.8.5
* [`2a717d97`](https://github.com/NixOS/nixpkgs/commit/2a717d975bbb1c36bbc5bec2edc25bfc3c3b0ffe) skribilo: 0.10.0 -> 0.11.1
* [`2d5af9a6`](https://github.com/NixOS/nixpkgs/commit/2d5af9a61608189cca179436667069b88cebfcce) melodeon: 0.5.1 -> 0.6.0
* [`b9a006be`](https://github.com/NixOS/nixpkgs/commit/b9a006be612e624290ee4baa2bfb79c43580ad05) webdis: 0.1.23 -> 0.1.25
* [`7729b563`](https://github.com/NixOS/nixpkgs/commit/7729b563f8bb4bce9ea32af86cc4c15c62b523a7) tailspin: 5.5.0 -> 6.1.0
* [`c7cd74a3`](https://github.com/NixOS/nixpkgs/commit/c7cd74a3ae08481926c961da766eb9fa98bcfd70) yatto: 1.2.0 -> 1.4.0
* [`1fee819e`](https://github.com/NixOS/nixpkgs/commit/1fee819e48e41bfdc456a9d50ced7363d0e397af) nixtract: 0.3.0 -> 0.4.0
* [`7dbab785`](https://github.com/NixOS/nixpkgs/commit/7dbab785d34c5247c09e1aaca899f21bd6dde541) morgen: 4.0.4 -> 4.0.6
* [`5f385b71`](https://github.com/NixOS/nixpkgs/commit/5f385b716d173266e8493bd1999b0cff265411df) bign-handheld-thumbnailer: 1.2.0 -> 1.2.1
* [`cb1757b7`](https://github.com/NixOS/nixpkgs/commit/cb1757b77803b3f650c7984a317e73fa5453a840) nixos/anki-sync-server: Improve unset users assert message
* [`50b58d89`](https://github.com/NixOS/nixpkgs/commit/50b58d899d794e1a015769b6b54b029512a16fde) ubootNanoPCT4: fix build
* [`409e30b4`](https://github.com/NixOS/nixpkgs/commit/409e30b4fee572f08a287368c9ad59ae57d68e30) biglybt: 3.9.0.0 -> 4.1.0.0
* [`001f1ed1`](https://github.com/NixOS/nixpkgs/commit/001f1ed1303a296d3b418de61c85a2b7bf5e8039) re-flex: 6.0.0 -> 6.3.0
* [`210a0011`](https://github.com/NixOS/nixpkgs/commit/210a0011ce40956b190ffb9c11f6a8fec60f36d0) edwood: 0.3.1 -> 0.4.0
* [`c36def6a`](https://github.com/NixOS/nixpkgs/commit/c36def6a9b7fb07f93011a43bfeb2b9024f8de5f) sem: 0.35.0 -> 0.36.0
* [`75019e40`](https://github.com/NixOS/nixpkgs/commit/75019e40f83eecfa4f4eedf68e816ece57434efc) python3Packages.hydrus-api: 5.1.1 -> 5.3.0
* [`32ec24e0`](https://github.com/NixOS/nixpkgs/commit/32ec24e04e24a4d13d9cbaa63e2f879e4bc9a758) slumber: 4.3.1 -> 5.3.0
* [`92858ae7`](https://github.com/NixOS/nixpkgs/commit/92858ae73e2c1e7f99867c1a6e5c543e66923aba) jbrowse: 3.6.5 -> 4.3.0
* [`69517a81`](https://github.com/NixOS/nixpkgs/commit/69517a811da14311a69f53e4042fa281912db7ac) butterfly: 2.5.1 -> 2.5.2
* [`74dd0bf1`](https://github.com/NixOS/nixpkgs/commit/74dd0bf18e665c4cd22429d2c41534b5abcd810e) kent: 497 -> 498
* [`b8da7d68`](https://github.com/NixOS/nixpkgs/commit/b8da7d68386468a669cb02e138b1c98088e68551) ceph-csi: 3.16.2 -> 3.17.0
* [`88364f21`](https://github.com/NixOS/nixpkgs/commit/88364f2148f5325f7cd6ee4dbe92c15fc5ec1051) xlsclients: 1.1.5 -> 1.1.6
* [`84232092`](https://github.com/NixOS/nixpkgs/commit/84232092eeaa41b559fbf5c631a853d0952cd093) atkmm_2_36: 2.36.3 -> 2.36.4
* [`3771880f`](https://github.com/NixOS/nixpkgs/commit/3771880fb682a805f022d1c350692ced5183759f) quodlibet: broken on darwin
* [`8dee35c9`](https://github.com/NixOS/nixpkgs/commit/8dee35c9a7b71ac90fe64a8fcc391fd26558c83a) lunacy: 12.3 -> 14.1
* [`6bac08dc`](https://github.com/NixOS/nixpkgs/commit/6bac08dc0c708cdef6bb355daea7f3830fe274b3) reco: 5.1.1 -> 5.2.1
* [`5b046152`](https://github.com/NixOS/nixpkgs/commit/5b046152cd10953cc1649cb6da1a483b2b9cccb6) mdsf: 0.11.1 -> 0.12.1
* [`90863b83`](https://github.com/NixOS/nixpkgs/commit/90863b83b78de895afc0bd6eeeac02c412969fc1) maim: 5.8.1 -> 5.8.2
* [`19c9c142`](https://github.com/NixOS/nixpkgs/commit/19c9c1427423f8b36a47a94ff2354de06045d3b7) wrangler: 4.93.0 -> 4.94.0
* [`d3162b17`](https://github.com/NixOS/nixpkgs/commit/d3162b170671af734e30958103e7d2f79415f635) tartube-yt-dlp: 2.5.164 -> 2.5.231
* [`d96498a4`](https://github.com/NixOS/nixpkgs/commit/d96498a47b377d7ccaea14bb8c4035aa3cc79669) tboot: 1.11.9 -> 1.11.10
* [`7fc9ce04`](https://github.com/NixOS/nixpkgs/commit/7fc9ce0477e71f75351c8ec114992f25e09af42d) yaws: 2.2.0 -> 2.3.1
* [`c113169e`](https://github.com/NixOS/nixpkgs/commit/c113169e3fa1ccac69c53cb4add9a494a027cc8c) kubie: 0.26.1 -> 0.28.0
* [`e85090ef`](https://github.com/NixOS/nixpkgs/commit/e85090efbad567e62e0a2b36d9fe7cec49cc3ff7) prettierd: 0.27.0 -> 0.28.0
* [`2edce34e`](https://github.com/NixOS/nixpkgs/commit/2edce34e5244d1cd7b1da0ea8b06fd6b2aa3fbf8) schismtracker: 20251014 -> 20260524
* [`62486031`](https://github.com/NixOS/nixpkgs/commit/6248603192dd886517d47b6fc1309e441d25ae27) lyra: 1.7.0 -> 1.8.0
* [`4c358875`](https://github.com/NixOS/nixpkgs/commit/4c358875389046e7b567a082ae3c53be7a7db8e5) qsynth: 1.0.5 -> 1.0.6
* [`87ae7f67`](https://github.com/NixOS/nixpkgs/commit/87ae7f67bfc7da8e20b9e51305b9bfe3610e3062) zef: 1.0.0 -> 1.1.3
* [`6ea49afa`](https://github.com/NixOS/nixpkgs/commit/6ea49afa8faba218c4d08c326ed8b7a1d30d76df) system-syzygy: improve meta
* [`5d5c0074`](https://github.com/NixOS/nixpkgs/commit/5d5c0074b8883b6441559b9f8e175855a8a1b504) system-syzygy: improve desktop integration
* [`7c4c40fb`](https://github.com/NixOS/nixpkgs/commit/7c4c40fb1603b04cdbfb6ca9476b33bf8b97ac4e) system-syzygy: switch to makeBinaryWrapper
* [`86811838`](https://github.com/NixOS/nixpkgs/commit/86811838616e0c34ec2b212dee5079b9a2b2665f) system-syzygy: add macOS support
* [`feee1a40`](https://github.com/NixOS/nixpkgs/commit/feee1a40bb83bf9e675b2d59fbac1949bd02a0d7) system-syzygy: added philocalyst to maintainers
* [`dd26c50f`](https://github.com/NixOS/nixpkgs/commit/dd26c50ff4dc9883d47d4cec8400f11aa5b18c23) python3Packages.cachey: migrate to pyproject
* [`3381a78c`](https://github.com/NixOS/nixpkgs/commit/3381a78c9d6c0ff48f824f8b2cea537af0942be8) python3Package.cachey: use finalAttrs
* [`ece55c64`](https://github.com/NixOS/nixpkgs/commit/ece55c64eb48ccc5f5c0b158be1aff5a899ee4b5) python3Packages.casa-formats-io: migrate to pyproject
* [`f9c5cb6a`](https://github.com/NixOS/nixpkgs/commit/f9c5cb6aa33f918d91331c0842a9bead355f8937) python3Packages.casa-formats-io: use finalAttrs
* [`d30977d0`](https://github.com/NixOS/nixpkgs/commit/d30977d070643164fe975070fc717328f898b389) python3Packages.cbor: migrate to pyproject
* [`f46b5ac0`](https://github.com/NixOS/nixpkgs/commit/f46b5ac046edf44c2ff286c72e8aa3160d362c05) python3Packages.cbor: use finalAttrs
* [`0dc39126`](https://github.com/NixOS/nixpkgs/commit/0dc3912639a7b908f08a6b94343bae275d3a04ee) qsampler: 1.0.1 -> 1.0.2
* [`ebc376c4`](https://github.com/NixOS/nixpkgs/commit/ebc376c445199e2dbf2b074442cb74d3b773234d) amiri: switch to finalAttrs
* [`a7191393`](https://github.com/NixOS/nixpkgs/commit/a719139336dc2ee5b5bb7d178a2a34be3b779052) soapui: 5.9.1 -> 5.10.0
* [`cc080181`](https://github.com/NixOS/nixpkgs/commit/cc0801814478f5881251543c27bb56b359c66a0a) libjson-rpc-cpp: add support for darwin
* [`bbe4b5c9`](https://github.com/NixOS/nixpkgs/commit/bbe4b5c99d7abd71f4b37509c50e5406b6725cae) goctl: 1.9.4 -> 1.10.2
* [`ccddb8a7`](https://github.com/NixOS/nixpkgs/commit/ccddb8a77ea23b28d98fbdcc6d5b4f6302551f05) tqsl: 2.8.4 -> 2.8.6
* [`632ad21a`](https://github.com/NixOS/nixpkgs/commit/632ad21a6754e8d7901e2146f904959ec2011d4f) amrwb: migrate to finalAttrs, fix broken url
* [`db7bf3c2`](https://github.com/NixOS/nixpkgs/commit/db7bf3c2bbc2300a17ec2684a14d9a1e50363ffb) agdsn-zsh-config: switch to finalAttrs
* [`819bda22`](https://github.com/NixOS/nixpkgs/commit/819bda225abb4c6156d6bdc52ddaa82a3dff025e) anakron: migrate to finalAttrs
* [`b2b912fd`](https://github.com/NixOS/nixpkgs/commit/b2b912fd5279a2b91affb6cfa5760e360ffc252b) polkit: replace systemdMinimal dependency with systemdLibs
* [`d4fb7e62`](https://github.com/NixOS/nixpkgs/commit/d4fb7e627b18a196aee52668017cefc64bcdf99b) balatro: rename conflicting src attribute
* [`85564b1e`](https://github.com/NixOS/nixpkgs/commit/85564b1e6005e56c5ee00798d5592d0aac0c60b6) zeno: 2.0.24 -> 2.0.26
* [`e4b8108f`](https://github.com/NixOS/nixpkgs/commit/e4b8108f85456b635892502852b546d2e300458f) rosegarden: 25.06 -> 26.06
* [`420b7929`](https://github.com/NixOS/nixpkgs/commit/420b7929abd89cb0f7cfa537cc19bbb20e1a738c) cirrus-cli: 0.165.1 -> 1.0.0
* [`22fc2ab1`](https://github.com/NixOS/nixpkgs/commit/22fc2ab1e57e3558b041aff42c32ed94635f4526) qtox: 1.18.3 -> 1.18.5
* [`caa8720a`](https://github.com/NixOS/nixpkgs/commit/caa8720aa8fda170d0d32af4b5b139314c251866) rotonda: 0.5.0 -> 0.6.0
* [`5c4108db`](https://github.com/NixOS/nixpkgs/commit/5c4108db616f7ad5d701fe1513628a2ffda8fa66) coredns: Fix on Darwin
* [`a13425c0`](https://github.com/NixOS/nixpkgs/commit/a13425c0ab0014288b812de5fa0095b5a6547276) vulkan-memory-allocator: 3.3.0 -> 3.4.0
* [`f0d7d1e2`](https://github.com/NixOS/nixpkgs/commit/f0d7d1e219f2d404ef8978e295d7333718e536f2) hermit: refactor to use installFonts hook and finalAttrs
* [`fcac3222`](https://github.com/NixOS/nixpkgs/commit/fcac322241f41f00ae5329b50b18b22525ccef53) libnats-c: 3.11.0 -> 3.13.0
* [`3e374b9a`](https://github.com/NixOS/nixpkgs/commit/3e374b9a94407405aac667347b96c6d528b08b42) frescobaldi: 4.0.6 -> 4.0.7
* [`5c3ecc29`](https://github.com/NixOS/nixpkgs/commit/5c3ecc29ed6c3b241c255f1b819b0d76ac4369a7) xosview2: 2.3.4 -> 2.3.5
* [`8a46bb94`](https://github.com/NixOS/nixpkgs/commit/8a46bb94958bd7bab2255b431bf930a284d68102) csmith: modernize package derivations, fix broken download link
* [`66357837`](https://github.com/NixOS/nixpkgs/commit/663578378217eca4349a078bea8b88f41196f973) dhewm3: 1.5.4 -> 1.5.5
* [`84a6403f`](https://github.com/NixOS/nixpkgs/commit/84a6403f93b9efa858b6d428f800e82a311490ad) fcron: 3.4.0 -> 3.4.1
* [`b198af31`](https://github.com/NixOS/nixpkgs/commit/b198af31e60d9031f446dafd2b51acdab63b714e) kubetui: 1.12.1 -> 1.14.0
* [`124c937b`](https://github.com/NixOS/nixpkgs/commit/124c937b42338fb3a03660795ece4129a7df726a) gut: 0.3.2 -> 0.3.3
* [`f3c54971`](https://github.com/NixOS/nixpkgs/commit/f3c5497125d813fd732965d132859a63955b73c8) duperemove: `__structuredAttrs`, `strictDeps`, `enableParallelBuilding`
* [`2a2aba9a`](https://github.com/NixOS/nixpkgs/commit/2a2aba9a404d8413c29d9206043dc2764eb2d3cb) duperemove: use `versionCheckHook`
* [`389ccd66`](https://github.com/NixOS/nixpkgs/commit/389ccd66cc6831a6171b1abb8961c078f55fa7d9) duperemove: use `tag` instead of `rev`
* [`49e9bd6b`](https://github.com/NixOS/nixpkgs/commit/49e9bd6b7c1bc8067f8cc6fadd93044ec501223d) duperemove: `updateScript`
* [`048399bf`](https://github.com/NixOS/nixpkgs/commit/048399bfe2ed18d01aeecb8495bf31bf72ffb67c) duperemove: split `man` output
* [`e8a08745`](https://github.com/NixOS/nixpkgs/commit/e8a08745f8ea5e9e7bd8bb19902519b794dae058) duperemove: add changelog
* [`f1faebd1`](https://github.com/NixOS/nixpkgs/commit/f1faebd1106087ffcdb495430b66255aac50ece0) duperemove: a few finishing touches
* [`0c4b4978`](https://github.com/NixOS/nixpkgs/commit/0c4b49781873ccd364fc25b8a720f5d76c75d12f) cudaPackages.buildRedist: allow zstd compressed tarballs
* [`d5640231`](https://github.com/NixOS/nixpkgs/commit/d5640231c335ce7fb92ae3ebbaffb29023a62652) filezilla: 3.70.5 -> 3.70.6
* [`66e45857`](https://github.com/NixOS/nixpkgs/commit/66e4585782479134e1533d8d3ac9278d7031aadc) fzssh: 1.2.1 -> 1.3.0
* [`814742ec`](https://github.com/NixOS/nixpkgs/commit/814742ec13aad8673c9d6894302e13471ea859d1) libfilezilla: 0.55.5 -> 0.56.1
* [`5dee807c`](https://github.com/NixOS/nixpkgs/commit/5dee807c8f45b0f99ae7b4204baf72f0f299a830) cudaPackages.tensorrt: Support new 11x URL convention
* [`28fe7e37`](https://github.com/NixOS/nixpkgs/commit/28fe7e37e209c077366d59e5fcc8f59c070adf3f) cudaPackages.tensorrt: Add 11.0.0 TensorRT release manifest
* [`4e72179a`](https://github.com/NixOS/nixpkgs/commit/4e72179a5a86c35f9052c30a2d109660dd6102af) cudaPackages.tensorrt-samples: Support TensorRT 11.0.0
* [`b0833763`](https://github.com/NixOS/nixpkgs/commit/b08337635134506e4888cc7f6d26aa942032d48f) http-nu: 0.9.0 -> 0.17.2
* [`895ee4fb`](https://github.com/NixOS/nixpkgs/commit/895ee4fbd30675587097d31a4ac4440e096f8207) restream: 1.4.0 -> 1.5.0
* [`0947f856`](https://github.com/NixOS/nixpkgs/commit/0947f85636faea5cb67450bda429b04eb109c3fc) enroot: 3.5.0 -> 4.2.1
* [`5cb5028d`](https://github.com/NixOS/nixpkgs/commit/5cb5028d2d2bcef828ecb4efbbd36ef268b05213) pkgs-lib/hocon: use structuredAttrs instead of passAsFile
* [`a9fd7065`](https://github.com/NixOS/nixpkgs/commit/a9fd7065edd83628ac3d49ec3577cad5b56f8515) createrepo_c: 1.2.3 -> 1.2.4
* [`7b5cc37a`](https://github.com/NixOS/nixpkgs/commit/7b5cc37a51c720014333406c6db1eb38e0c9acca) darkly: 0.5.32 -> 0.5.38
* [`4c14eadd`](https://github.com/NixOS/nixpkgs/commit/4c14eadd01de4ce288839f240d81a4b1c80fddff) sjasmplus: 1.23.0 -> 1.23.1
* [`a67787e9`](https://github.com/NixOS/nixpkgs/commit/a67787e921b9b06a2e6aa70c52c7162ae9fce6d8) ytree: 2.12 -> 2.13
* [`35335fec`](https://github.com/NixOS/nixpkgs/commit/35335fec850616fa1a7512775a28bf165199d2f6) thermald: 2.5.11 -> 2.5.12
* [`c03cf871`](https://github.com/NixOS/nixpkgs/commit/c03cf8712cfee97548db820a2255a823cb289e59) kubernetes-helmPlugins.helm-schema: 2.4.0 -> 2.5.0
* [`64de379e`](https://github.com/NixOS/nixpkgs/commit/64de379e05301cb1bd17958d4d0dc7f76b3a1d17) python3Packages.pyomo: 6.9.5 -> 6.10.1
* [`a148b20f`](https://github.com/NixOS/nixpkgs/commit/a148b20f3dbd160cbaa26abd4d1934273e2c5081) git-extras: split `man` output
* [`ac71bc83`](https://github.com/NixOS/nixpkgs/commit/ac71bc835b272af5d0a5f176d9e337febfe213b9) git-extras: `strictDeps` & `__structuredAttrs`
* [`813e6bc1`](https://github.com/NixOS/nixpkgs/commit/813e6bc18f094f8fea8892131d06ec096e5f8c23) backblaze-b2: 4.7.0 -> 4.7.1
* [`a11f01c6`](https://github.com/NixOS/nixpkgs/commit/a11f01c6948ee03334130fd6696a8c59fa96d488) particl-core: 23.2.9.0 -> 23.2.10.0
* [`8c7b82a6`](https://github.com/NixOS/nixpkgs/commit/8c7b82a69022ab5d8eb60f560a391249b7ab946e) spring-boot-cli: 4.0.1 -> 4.1.0
* [`06efad4c`](https://github.com/NixOS/nixpkgs/commit/06efad4c986232f8753df39f88b3ac7243a70239) libpulsar: 4.1.0 -> 4.2.0
* [`e8e19cd8`](https://github.com/NixOS/nixpkgs/commit/e8e19cd83af014df578705f05e859ae2b204c2de) gomi: 1.6.2 -> 1.6.4
* [`d4c02765`](https://github.com/NixOS/nixpkgs/commit/d4c02765a877890a4d200acb0ad100d4df5582b2) grandorgue: 3.16.3-1 -> 3.17.2-1
* [`edf46e68`](https://github.com/NixOS/nixpkgs/commit/edf46e6822a58556f12b1f183d8b91899abdae9e) habitat: 1.6.1245 -> 2.1.23
* [`f3e262f5`](https://github.com/NixOS/nixpkgs/commit/f3e262f5679489a28119ee385aefc8eb5b5c904a) asyncapi: 6.0.0 -> 6.0.2
* [`ab30a395`](https://github.com/NixOS/nixpkgs/commit/ab30a39530dc82e5adcee8903335fc1e479f0c40) boinc: 8.2.13 -> 8.2.15
* [`6264959f`](https://github.com/NixOS/nixpkgs/commit/6264959f0f300a4e3a8d8ce4cf5c918c9ae5dde7) calcure: 3.2.1 -> 3.3
* [`deec773d`](https://github.com/NixOS/nixpkgs/commit/deec773dd31c12781cf967acea99e748701a547f) darklua: 0.17.3 -> 0.19.0
* [`f0580f28`](https://github.com/NixOS/nixpkgs/commit/f0580f28caf61e0c4e014aa1424767d2bcd168b8) alienarena: 7.71.7 -> 7.72.1
* [`4b7c9730`](https://github.com/NixOS/nixpkgs/commit/4b7c9730a83a36bd4ab0991f31d2304bc30c031a) gssdp_1_6: remove unused Python input
* [`2d8e6e2b`](https://github.com/NixOS/nixpkgs/commit/2d8e6e2b5097496aa2f2e380ce71716872e9f97b) gssdp_1_6: disable introspection if unavailable
* [`c821e3a3`](https://github.com/NixOS/nixpkgs/commit/c821e3a3fe1d5c5dc55413035b0ee9710eae5f57) arduino-ide: 2.3.7 -> 2.3.10
* [`6952eb7a`](https://github.com/NixOS/nixpkgs/commit/6952eb7a48c195600f3694f2fefc8822df4e08e0) opcr-policy: 0.3.6 -> 0.4.0
* [`1c9e1874`](https://github.com/NixOS/nixpkgs/commit/1c9e18749cdca65c341d152f0260333277a5512e) python3Packages.zm-py: 0.5.4 -> 0.5.6
* [`a5dbc2cf`](https://github.com/NixOS/nixpkgs/commit/a5dbc2cf7f2fb033852d42a317e0ed5d04196f8e) opengrok: 1.14.13 -> 1.14.15
* [`4de10293`](https://github.com/NixOS/nixpkgs/commit/4de10293b240230088decc6b6b02bd1b831903b7) netmaker: 1.1.0 -> 1.6.0
* [`cfc7f41e`](https://github.com/NixOS/nixpkgs/commit/cfc7f41e07e9af76dc72db66298f88fc03cbc1e3) netclient: 1.1.0 -> 1.6.0
* [`e40d4425`](https://github.com/NixOS/nixpkgs/commit/e40d442509bb5b724720ee58cf5c43e7f5c1ebd5) millet: 0.14.9 -> 0.15.2
* [`70bc3c9e`](https://github.com/NixOS/nixpkgs/commit/70bc3c9ef24f28a49c2cd0095f4e17646a840b95) sendme: 0.33.0 -> 0.36.0
* [`1cd65f9d`](https://github.com/NixOS/nixpkgs/commit/1cd65f9d041a90e0b98bfb0f3d17ea685a7732e4) feishu: 7.66.10 -> 7.66.11
* [`f31af0de`](https://github.com/NixOS/nixpkgs/commit/f31af0de6e5d56a59561d21960322503c3a74323) stgit: 2.5.5 -> 2.6.1
* [`2460ff87`](https://github.com/NixOS/nixpkgs/commit/2460ff879488ba653fad822bc1723cbac2e9cfb2) newcomputermodern: 7.1.1 -> 8.1.1
* [`73a90896`](https://github.com/NixOS/nixpkgs/commit/73a90896282f1d2f54df6c6f927b61158035d7ec) iqtree: 3.0.1 -> 3.1.3
* [`1148372a`](https://github.com/NixOS/nixpkgs/commit/1148372a48bfa9f1ca0519d652276b2c59d2064a) amf-headers: package build speedup
* [`883a46c8`](https://github.com/NixOS/nixpkgs/commit/883a46c87326f611fc01df73fdbb5402c448d7e0) linuxPackages.corefreq: 2.1.0 -> 2.1.2
* [`87bb466d`](https://github.com/NixOS/nixpkgs/commit/87bb466d8d208099febdf60266f48b0555165aa5) mpris-scrobbler: 0.5.7 -> 0.5.9
* [`c57ff82d`](https://github.com/NixOS/nixpkgs/commit/c57ff82d2efc51386a24bddc19816776cb8b9efc) dput-ng: 1.44 -> 1.46
* [`ca7a0be5`](https://github.com/NixOS/nixpkgs/commit/ca7a0be5359d5e80f53d839863a88bd37d62a608) maintainers: add Mowerick
* [`52f977f0`](https://github.com/NixOS/nixpkgs/commit/52f977f030f1ec27275d3be1a75c6680e5ac4533) notion-electron: init at 2.2.3
* [`7f98b355`](https://github.com/NixOS/nixpkgs/commit/7f98b355088042694f7fc4f8ca00d4a8f29afc56) enpass-cli: 1.7.0 -> 1.12.0
* [`0c94bb3e`](https://github.com/NixOS/nixpkgs/commit/0c94bb3e24e641314bb948a807825cfd308e8c96) lifecycled: 3.3.0 -> 3.6.0
* [`f6ddc178`](https://github.com/NixOS/nixpkgs/commit/f6ddc178af7aa4d8bb3fd2b525cc2b67eddef92c) fuse-emulator: 1.6.0 -> 1.9.0
* [`58f71ffd`](https://github.com/NixOS/nixpkgs/commit/58f71ffd8179861bbb68d6848536968eaae5dcc5) asciigraph: 0.7.3 -> 0.10.0
* [`d83b24f9`](https://github.com/NixOS/nixpkgs/commit/d83b24f908236c235d86d57785500462ef7a558d) tkrev: 9.6.1 -> 9.6.2
* [`d637ac4c`](https://github.com/NixOS/nixpkgs/commit/d637ac4c84f0a60c293bd77b96a22dd4a22c6fb7) calamares-nixos-extensions: don't enable X11 for GNOME
* [`505042a4`](https://github.com/NixOS/nixpkgs/commit/505042a43725350dec24809b5808d68f9b06e33d) calamares-nixos-extensions: use renamed GNOME options
* [`c6b4612a`](https://github.com/NixOS/nixpkgs/commit/c6b4612a163873d3ff8ad063e4853985298b6f9e) calamares-nixos-extensions: suggest wireplumber instead of media-session
* [`578f4a9d`](https://github.com/NixOS/nixpkgs/commit/578f4a9d7f6705a08290dbbcc6bb7ee7b1197279) calamares-nixos-extensions: use renamed libinput option
* [`0ced3bcc`](https://github.com/NixOS/nixpkgs/commit/0ced3bccbb95aef3ff3cfd153540fc0ad6b85765) calamares-nixos-extensions: remove redundant GNOME autologin workaround
* [`bd92f786`](https://github.com/NixOS/nixpkgs/commit/bd92f7863db15155d35489bc99826d86ef3e3f6e) calamares-nixos-extensions: use `"""\` at start of config snippets
* [`6c1d4e5d`](https://github.com/NixOS/nixpkgs/commit/6c1d4e5d2746eff58d643ffa601ff3df946ad5fa) calamares-nixos-extensions: sync some config with nixos-generate-config
* [`91a2f9ed`](https://github.com/NixOS/nixpkgs/commit/91a2f9ed9f197fb0cbdf5e1aaa2429d58c72336a) mackerel-agent: 0.85.2 -> 0.87.0
* [`a231a7fe`](https://github.com/NixOS/nixpkgs/commit/a231a7fe7e9f1518114981b0f82eb92e0933a891) fetchurl: make progress meter visible
* [`1b89d64f`](https://github.com/NixOS/nixpkgs/commit/1b89d64fe653c0921a19e3898dba4ee2ea537842) iio-oscilliscope: 0.17 -> 0.18
* [`eb51bb49`](https://github.com/NixOS/nixpkgs/commit/eb51bb493dae66dc1501880e24f7af8388d27ee5) mdbook-pandoc: 0.11.0 -> 0.11.1
* [`0d665774`](https://github.com/NixOS/nixpkgs/commit/0d665774b30baedfbc11a785cd4eee25e556aae8) nixos/containers: fix IPv4-mapped addresses
* [`018bb036`](https://github.com/NixOS/nixpkgs/commit/018bb0361a06a7125381e796e9dc3deb858fe6bf) maintainers: add skirlez
* [`bd57e6e1`](https://github.com/NixOS/nixpkgs/commit/bd57e6e1f595e8341ef2bdc7e75c3d0a357eade0) gping: 1.20.1 -> 1.20.4
* [`71f56798`](https://github.com/NixOS/nixpkgs/commit/71f567985fad696b74ddf8002892c96a46355c4b) lbreakouthd: 1.2.2 -> 1.2.3
* [`65f33328`](https://github.com/NixOS/nixpkgs/commit/65f33328bfd0e9c3d7fbdae3c790deb2de31701f) python3Packages.spyder: 6.1.2 -> 6.1.5
* [`54177bce`](https://github.com/NixOS/nixpkgs/commit/54177bce37e29d021330fc0ec0e7b6a69b00fdfa) vitess: 23.0.3 -> 24.0.2
* [`609b50c9`](https://github.com/NixOS/nixpkgs/commit/609b50c9bee94c4725882950255278130f8e443f) ares-cli: 3.2.4 -> 3.2.5
* [`8222430b`](https://github.com/NixOS/nixpkgs/commit/8222430b0b083ae0773edabd9aa0ee4c84d52ee3) barrage: 1.0.7 -> 1.0.8
* [`0b5b8095`](https://github.com/NixOS/nixpkgs/commit/0b5b80956ab8e5db7be6890558849af9701b2ab2) sqlite_modern_cpp: init at 3.2-unstable-2023-12-03
* [`df5ff59b`](https://github.com/NixOS/nixpkgs/commit/df5ff59b605d06d21cbe294e93747e1c313abfea) python3Packages.pyvmomi: 9.0.0.0 -> 9.1.0.0
* [`7e469caa`](https://github.com/NixOS/nixpkgs/commit/7e469caa382f9107aebad147946eeee4ff5062af) darwin.adv_cmds: fix build with llvm 22
* [`29d41a5e`](https://github.com/NixOS/nixpkgs/commit/29d41a5e41eaeba9ae47b44ab5b7a84aff411841) dbus: fix build with llvm 22
* [`e48514a0`](https://github.com/NixOS/nixpkgs/commit/e48514a021aac2255767c189ee4a4afbed0998a1) fontforge: fix build with llvm 22
* [`1b539713`](https://github.com/NixOS/nixpkgs/commit/1b539713f395098dcf597451cca1d779e32e7642) gbenchmark: fix build with llvm 22
* [`7999dd97`](https://github.com/NixOS/nixpkgs/commit/7999dd971e7d3c4acf206e1822af61a4746077e5) tlwg: 0.7.3 -> 0.7.4
* [`cd465e02`](https://github.com/NixOS/nixpkgs/commit/cd465e025d940ee7f394ecef3fc6f62866dfccd5) httm: 0.50.0 -> 0.50.2
* [`985fb95e`](https://github.com/NixOS/nixpkgs/commit/985fb95e01e3d41de54e5eb9d7f23edbe59eea14) fheroes2: 1.1.16 -> 1.1.17
* [`41a57929`](https://github.com/NixOS/nixpkgs/commit/41a579293d2fb1e989a0c2aa1edc0f9259c25ce1) ibus-engines.m17n: 1.4.37 -> 1.4.40
* [`3bfb01f0`](https://github.com/NixOS/nixpkgs/commit/3bfb01f0610e24eb98c2419c60b6939a9bb2c412) gapless: 4.6 -> 4.6.2
* [`75062727`](https://github.com/NixOS/nixpkgs/commit/7506272718d304d9d78829f3bd8336753b4e38a8) svelte-language-server: 0.18.0 -> 0.18.3
* [`10a35c9f`](https://github.com/NixOS/nixpkgs/commit/10a35c9f4f55685c5197c710805c905b2966deff) materialx: 1.39.4 -> 1.39.5; migrate to pkgs/by-name
* [`2b48ee2f`](https://github.com/NixOS/nixpkgs/commit/2b48ee2fef57869436e4ac772a2da56ce9f12cab) fission: 1.22.0 -> 1.27.0
* [`2c32a539`](https://github.com/NixOS/nixpkgs/commit/2c32a539cfd9d9cf8f7df477b86db667f2f7bcce) velero: 1.18.0 -> 1.18.2
* [`8780b96d`](https://github.com/NixOS/nixpkgs/commit/8780b96d5aa6be8d4a78b3a6c2869f772a8b3e52) haveged: 1.9.21 -> 1.9.26
* [`e6e7dc5e`](https://github.com/NixOS/nixpkgs/commit/e6e7dc5e320073efd25558209e060a395523d7a4) protobufc: unpin standard version to fix build with gcc 16
* [`f9a17088`](https://github.com/NixOS/nixpkgs/commit/f9a1708872c749e28014296f912f0aa793421933) go-task: 3.48.0 -> 3.52.0
* [`ea1241d9`](https://github.com/NixOS/nixpkgs/commit/ea1241d96c0690b814ae2ce99cb11b11e28336fa) python3Packages.devpi-web: 5.1.0 -> 5.1.1
* [`7ab313ef`](https://github.com/NixOS/nixpkgs/commit/7ab313ef24e1088123357dc551478841f7fdb607) libmsquic: 2.5.8 -> 2.5.9
* [`37946f0f`](https://github.com/NixOS/nixpkgs/commit/37946f0f63c3d3f4e45166d06aa9b2159caf7519) harsh: 0.14.1 -> 0.14.5
* [`a0ce7895`](https://github.com/NixOS/nixpkgs/commit/a0ce789548b93626b2bd778d2bf827de2c8a733c) aws-signing-helper: 1.7.3 -> 1.8.4
* [`2d7bbea2`](https://github.com/NixOS/nixpkgs/commit/2d7bbea2ed2b7c74ad815a0bf7dd0ef644cb76c5) python3Packages.glueviz: 1.24.1 -> 1.27.0
* [`103e9492`](https://github.com/NixOS/nixpkgs/commit/103e949280de849d33c6332801b10b4f8e3e4e96) cockpit-dockermanager: init at 1.0.8.2
* [`b0f6a427`](https://github.com/NixOS/nixpkgs/commit/b0f6a427ed07bb5b5de0e44b70b341e1b34c68eb) python3Packages.pytapo: 3.4.15 -> 3.4.18
* [`f3c771e9`](https://github.com/NixOS/nixpkgs/commit/f3c771e978d358c1ceb66a694178f3794febfc09) nixos/misskey: fixes for attrTag submodule docs
* [`af11c3d0`](https://github.com/NixOS/nixpkgs/commit/af11c3d0c8cf6feca5003a595792163c60fd4446) nixos/readeck: copy config file to mutable place
* [`0e649c19`](https://github.com/NixOS/nixpkgs/commit/0e649c1936aea3b64b1f8530245f85ed49754ec8) python3Packages.sklearn2pmml: 0.131.0 -> 0.132.0
* [`8be6c327`](https://github.com/NixOS/nixpkgs/commit/8be6c32707f38e8a7bbf7941be5f9f4f68f973d6) xmpp-dns: init at 0.6.3
* [`c6c3547e`](https://github.com/NixOS/nixpkgs/commit/c6c3547e07e8ea0ce18c23cbe95389e8292c113b) requestly: 1.6.0 -> 26.6.29
* [`4ac5f414`](https://github.com/NixOS/nixpkgs/commit/4ac5f4143019a227830c2828d16513f35beb83ab) python3Packages.azure-keyvault-keys: 4.11.0 -> 4.11.1
* [`89dfac49`](https://github.com/NixOS/nixpkgs/commit/89dfac494736dc40ff4cf580f76d1a5593417af4) alembic: 1.8.8 -> 1.8.12
* [`6ba89e3f`](https://github.com/NixOS/nixpkgs/commit/6ba89e3fc2066079ca60e0a393c171155a172ef4) iio-oscilliscope: add darwin support
* [`5a539604`](https://github.com/NixOS/nixpkgs/commit/5a539604c668ad6b4924fae94fd7502a72a5f287) bfs: 4.1 -> 4.1.4
* [`9a0604e2`](https://github.com/NixOS/nixpkgs/commit/9a0604e2c4c2ccf00c3a88a40220e0101b81a59b) nixos/p2pool: init module
* [`20c1f5ac`](https://github.com/NixOS/nixpkgs/commit/20c1f5ac700cde377d8bbc20a20f5bc5d2e3897c) python3Packages.mautrix: 0.21.0 -> 0.21.1
* [`ff728db2`](https://github.com/NixOS/nixpkgs/commit/ff728db245d44c20ab8707cbfca3942f2d245fa9) typical: 0.15.0 -> 0.16.0
* [`8752d836`](https://github.com/NixOS/nixpkgs/commit/8752d836ffa19096b4baa52f27d5eb938ed2530a) maintainers: add jsqu4re
* [`a9c78bf4`](https://github.com/NixOS/nixpkgs/commit/a9c78bf4da7bedf23ba44c63b9aa1fb5035d8018) september: init at 0.4.1
* [`c5290ce2`](https://github.com/NixOS/nixpkgs/commit/c5290ce22dc0a83b091cad2b58c810e7ae1ed2d2) firecracker: 1.15.1 -> 1.16.1
* [`a447a3a6`](https://github.com/NixOS/nixpkgs/commit/a447a3a61165819b18bb2f4f3574e451da685330) juju: 3.6.21 -> 4.0.12
* [`697d4a36`](https://github.com/NixOS/nixpkgs/commit/697d4a365293800638d2f00d35a185849e21cc04) kalker: 2.2.2 -> 2.2.3
* [`369b307a`](https://github.com/NixOS/nixpkgs/commit/369b307ab6a8c6ebc92f63130eb0f2e4dc50c64a) nixos/rsync: add ssh to $PATH
* [`439cf4fd`](https://github.com/NixOS/nixpkgs/commit/439cf4fd668a9f734bf7fc76234ec9ce6161811a) orca: Remove unused `dbus-python` dependency
* [`c61a6399`](https://github.com/NixOS/nixpkgs/commit/c61a639923fb9225f9b3a47e96f00affbb5cfded) kubeseal: 0.36.0 -> 0.38.4
* [`4e702a3b`](https://github.com/NixOS/nixpkgs/commit/4e702a3b9b96fce8610b383dacce7c977201ad02) consul-template: 0.41.4 -> 0.42.1
* [`4fc0d789`](https://github.com/NixOS/nixpkgs/commit/4fc0d78915d5c76bfdbb01badd664797976e5e5b) papilo: 2.4.4 -> 3.0.1
* [`238876cd`](https://github.com/NixOS/nixpkgs/commit/238876cd9f6bdd48710a0cb2139607f473affd54) ejsonkms: 0.3.1 -> 0.3.3
* [`1a0873ac`](https://github.com/NixOS/nixpkgs/commit/1a0873acb8a297bef750cdf102c284ceefab1a5b) orca: Apply upstream subprocess-reduction patch
* [`da0d6c0f`](https://github.com/NixOS/nixpkgs/commit/da0d6c0f40a92d8c9ed7a4656d0830e602814ebb) orca: Add missing `at-spi2-core` PyGObject overrides
* [`3dcb2338`](https://github.com/NixOS/nixpkgs/commit/3dcb2338404aaf4f049f3b4b93af90ba379af9e6) tarantool: 3.6.0 -> 3.8.0
* [`0b41263c`](https://github.com/NixOS/nixpkgs/commit/0b41263c03f16d47435a8ff4db6bbb6df9131015) uefitool: A73 -> A75
* [`49385ba0`](https://github.com/NixOS/nixpkgs/commit/49385ba00fe5601ba505914f9a78772f1405fa09) buildkite-agent-metrics: 5.12.3 -> 5.12.4
* [`c50cd7f5`](https://github.com/NixOS/nixpkgs/commit/c50cd7f5452db95eefc4d67a780009bc6e4ef2d8) at-spi2-core: 2.60.4 → 2.60.5
* [`21a26014`](https://github.com/NixOS/nixpkgs/commit/21a2601472fc62edfea2a377d7163a1bdf5ba5c6) at-spi2-core: Find `dbus-daemon` and `dbus-broker-launch` on `PATH`
* [`19b09e48`](https://github.com/NixOS/nixpkgs/commit/19b09e486f9d90e17726636123df1a57066bb7b8) civo: 1.5.1 -> 1.5.4
* [`35839304`](https://github.com/NixOS/nixpkgs/commit/358393045b785a4c9bbb2faedef0eca591e2e5f4) orca: Enable tests
* [`f1550b3a`](https://github.com/NixOS/nixpkgs/commit/f1550b3ada95acff48f6d3de407d86991d5763b2) azure-storage-azcopy: 10.31.1 -> 10.32.6
* [`6aa6fdd3`](https://github.com/NixOS/nixpkgs/commit/6aa6fdd354e70644eba00babb3e5f1aafbc231e6) lix: Apply upstream patch to raise functional2 test timeout
* [`c961ba43`](https://github.com/NixOS/nixpkgs/commit/c961ba43f5a1c05338faf9e151591ca309e108cd) python3Packages.types-mock: 5.2.0.20250924 -> 5.2.0.20260518
* [`0f182798`](https://github.com/NixOS/nixpkgs/commit/0f18279834e08178df7440ebd5222f6b079b05bf) nitter: 0-unstable-2026-06-16 -> 0-unstable-2026-07-11
* [`c839a2fc`](https://github.com/NixOS/nixpkgs/commit/c839a2fcf97b5815f3111805fbd567f627ce999c) mpv: sandbox profile no longer required on darwin
* [`cecaac10`](https://github.com/NixOS/nixpkgs/commit/cecaac10c40927b1d89990ccc5337d2010ed858e) slint-viewer: Build with the the gettext feature
* [`1c59e938`](https://github.com/NixOS/nixpkgs/commit/1c59e938649d134ef235a23c8529b416a92b59f5) nnd: 0.77 -> 0.80
* [`ed74b24e`](https://github.com/NixOS/nixpkgs/commit/ed74b24ec62209c2ef9b1021683a086e3c5f1bb9) pyenv: 2.6.31 -> 2.8.0
* [`4d753273`](https://github.com/NixOS/nixpkgs/commit/4d75327389b51cea1d5c0ce4a53f064777656a1b) ffizer: 2.13.10 -> 2.13.12
* [`116d515c`](https://github.com/NixOS/nixpkgs/commit/116d515cdd9fdb9ce4767683db2a97805938abda) toxic: 0.16.1 -> 0.16.3
* [`a27bda6f`](https://github.com/NixOS/nixpkgs/commit/a27bda6f62120823d27ec4fc0ce88d93cc04d91e) oneMath: init at 0.9
* [`71ed1083`](https://github.com/NixOS/nixpkgs/commit/71ed108393e83e27347858622906f716c9911fae) materia-everforest-kvantum: init at 0-unstable-2024-01-22
* [`a1e1eb21`](https://github.com/NixOS/nixpkgs/commit/a1e1eb219478d5b2db6e2ea3abcc2821eab47086) slint-viewer: Fix macos build
* [`bcc95dfe`](https://github.com/NixOS/nixpkgs/commit/bcc95dfe4b8d71eaf6bb136d36a421ff8846d98c) ivpn-service: 3.15.6 -> 3.15.13
* [`b34dd15c`](https://github.com/NixOS/nixpkgs/commit/b34dd15c6a7980a204825a71d1449d1a78d1508e) ivpn: 3.15.6 -> 3.15.13
* [`d7b79ebf`](https://github.com/NixOS/nixpkgs/commit/d7b79ebf62c4c8c385c28a949c1b35d4addef501) ivpn-ui: 3.15.6 -> 3.15.13
* [`ed99b569`](https://github.com/NixOS/nixpkgs/commit/ed99b569cdda44a177814191a3b2064abe6dcf20) freeciv: 3.2.2 -> 3.2.5
* [`10762d02`](https://github.com/NixOS/nixpkgs/commit/10762d021493b97cd13c03d4f400e30d65877c6f) python3Packages.types-greenlet: 3.3.0.20251206 -> 3.5.0.20260518
* [`df96ee14`](https://github.com/NixOS/nixpkgs/commit/df96ee14465990f377a88f75e7e20167887f74df) consul: 1.22.7 -> 2.0.2
* [`56d565c8`](https://github.com/NixOS/nixpkgs/commit/56d565c8fe87516ce11b0009a8d1ebeba7557bc8) maintainers: add ad-si
* [`3d537076`](https://github.com/NixOS/nixpkgs/commit/3d537076cb57833c846c16b17458e13df92455c5) stdenv: fix replaceStdenv evaluation
* [`dab5832f`](https://github.com/NixOS/nixpkgs/commit/dab5832fa58c75f63279121c7c15c27451e8dd2c) rkik: 2.1.0 -> 2.2.2
* [`2ad7c76f`](https://github.com/NixOS/nixpkgs/commit/2ad7c76f91a483f3507fdc9a831b376137848d5d) metee: 6.2.3 -> 6.2.5
* [`08a7fb80`](https://github.com/NixOS/nixpkgs/commit/08a7fb809dd4c98877d88112d02fc11104797ba3) healthchecks: 4.1.1 -> 4.3
* [`53a719f4`](https://github.com/NixOS/nixpkgs/commit/53a719f45288918e4c56cf085a58defb4893ea17) tclPackages.expect_5: init
* [`a7a06571`](https://github.com/NixOS/nixpkgs/commit/a7a065714456bf8c74172020b6985fce412b566b) expect: switch to tcl8Packages.expect_5
* [`2559a0f3`](https://github.com/NixOS/nixpkgs/commit/2559a0f30478b0906f3bc361a637c2c82bf2c0d7) gdk-pixbuf: 2.44.6 -> 2.44.7
* [`757b81a5`](https://github.com/NixOS/nixpkgs/commit/757b81a53b41e062290007938cf71af6c578da4f) gjs: 1.88.0 -> 1.88.1
* [`083d79ca`](https://github.com/NixOS/nixpkgs/commit/083d79ca343013c9883cb2c9a2aa530aae5bdf69) python3Packages.beets-filetote: remove unneeded check inputs
* [`09009d38`](https://github.com/NixOS/nixpkgs/commit/09009d3835d36a996e3a25576b026534e2cb782f) wtp: init at 2.10.3
* [`196bcb0c`](https://github.com/NixOS/nixpkgs/commit/196bcb0c780013a9cb9f6409a3bf2820c2f019df) stdenv: avoid reimporting bootstrap stages
* [`6183cdb3`](https://github.com/NixOS/nixpkgs/commit/6183cdb311710a1883044fdc5fbc8f3cbbf18ad2) stdenv: inline the replacement stage
* [`0a354bd1`](https://github.com/NixOS/nixpkgs/commit/0a354bd12ac4eb4813302d5757983818bd3cd730) stdenv: remove redundant replacement assertions
* [`bbb150a3`](https://github.com/NixOS/nixpkgs/commit/bbb150a3314670a6147a72f8485f1200435fdcdf) stdenv: remove redundant cygwin switch
* [`2dd13490`](https://github.com/NixOS/nixpkgs/commit/2dd1349006abecf79eb0c53473191d48207ff34d) stdenv: stop passing crossSystem to local stages
* [`5792d049`](https://github.com/NixOS/nixpkgs/commit/5792d04959c96761356993b57f5b10cd42761341) sigil: 2.7.6 -> 2.8.1
* [`e2f8b021`](https://github.com/NixOS/nixpkgs/commit/e2f8b021bd3208a53dd124f5a3527e34af2451a9) xed: 2025.12.14 -> 2026.07.15
* [`0e0dab29`](https://github.com/NixOS/nixpkgs/commit/0e0dab2990bb00e1717886cfb7388033d4fd0a80) bluefish: 2.2.19 -> 2.4.2
* [`4ce6722e`](https://github.com/NixOS/nixpkgs/commit/4ce6722eec0b5a040a850a370e36904db1807b59) python3Packages.deepspeed: init at 0.19.2
* [`c831bccf`](https://github.com/NixOS/nixpkgs/commit/c831bccf07ddd69811f610fefe24288712b0d0f9) mozart2: move top-level definitions to derivation
* [`ef863197`](https://github.com/NixOS/nixpkgs/commit/ef86319729ca0b3064132d28399c1776c511cb7c) mozart2: modernize derivation, fix hashes, enable structured attrs
* [`90f33301`](https://github.com/NixOS/nixpkgs/commit/90f333012824303baad8ec059cd49dafda4130f2) mozart-binary: modernize derivation, switch to finalAttrs, update hash
* [`b9a2920c`](https://github.com/NixOS/nixpkgs/commit/b9a2920c0e7b3c9d23bd37419163b7da8e00df95) mozart2{,-binary}: migrate to pkgs/by-name
* [`5923e6a6`](https://github.com/NixOS/nixpkgs/commit/5923e6a6991c10a0689dbcd9792a18f547f3f799) maintainers: add rdk31
* [`6aa7ffd9`](https://github.com/NixOS/nixpkgs/commit/6aa7ffd9fc8c53f75389a9fa8669a615b4336a71) plantuml: 1.2026.3 -> 1.2026.6, build from source
* [`27cedc53`](https://github.com/NixOS/nixpkgs/commit/27cedc53a692f5341942777cdc20730c6ac2df89) fanbox-dl: 0.28.1 -> 0.29.1
* [`c30175d5`](https://github.com/NixOS/nixpkgs/commit/c30175d57c3e167ad0a6857171ec0ddee2ce5377) hebcal: 5.9.4 -> 5.15.0
* [`15d5b932`](https://github.com/NixOS/nixpkgs/commit/15d5b9327afe839b6d8621544668a3a78b0f16e4) python3Packages.cyclopts: 4.20.0 -> 4.21.0
* [`6db7bf1d`](https://github.com/NixOS/nixpkgs/commit/6db7bf1d6e10126b85dd941b9f8a3700d82eede9) python3Packages.cyclopts: 4.21.0 -> 4.22.0
* [`717c0b5b`](https://github.com/NixOS/nixpkgs/commit/717c0b5b7da5d4f9b8f3359d4c53d49828ab5019) protobuf: Apply patch to fix BoolKeys test big-endian
* [`654698b3`](https://github.com/NixOS/nixpkgs/commit/654698b382a3785d381d3678a41ee098a1822072) protobuf_35: Add back fix-upb-packed-enum-be.patch
* [`ac81fe1b`](https://github.com/NixOS/nixpkgs/commit/ac81fe1b1b18b4c4080e6f51e8a7b9172e3a7564) python3Packages.pygraphviz: 2.0 -> 2.0.1
* [`142ebddd`](https://github.com/NixOS/nixpkgs/commit/142ebddd80251e0de0bbe68804fc3dad09db537c) nbdkit: 1.44.1 -> 1.48.0
* [`570ffe5a`](https://github.com/NixOS/nixpkgs/commit/570ffe5a882bc32c06001c89afd57de11409397e) hamrs-pro: 2.47.1 -> 2.52.0
* [`8c5838cc`](https://github.com/NixOS/nixpkgs/commit/8c5838cc90ac30da3dce1fbdde6b021e7d48573f) setup-hooks/strip: fix double space in printed output
* [`2480949e`](https://github.com/NixOS/nixpkgs/commit/2480949e85e79d1b08718e1e4291a8e4f32f45fd) maintainers: add annoyingrains
* [`d5caafb5`](https://github.com/NixOS/nixpkgs/commit/d5caafb56c48421b2ea7140b37a98233a7f3d5f5) fsel: 3.1.0 -> 3.6.0
* [`9e50ad36`](https://github.com/NixOS/nixpkgs/commit/9e50ad3651f79f4a065e50f02a6e9794aa13b683) xfsdump: fix buffer overflow crash
* [`f9de68cf`](https://github.com/NixOS/nixpkgs/commit/f9de68cf6908ac9b23645fbd68f3b39a445e767f) sssd: enable __structuredAttrs, strictDeps
* [`45b440cd`](https://github.com/NixOS/nixpkgs/commit/45b440cd7b9899a112932398397d3e34b7d841ea) jbang: 0.136.0 -> 0.141.0
* [`2a7cabbb`](https://github.com/NixOS/nixpkgs/commit/2a7cabbb43921c2c0c885c69ef073c32de3179f4) maintainers: add edoars
* [`03981231`](https://github.com/NixOS/nixpkgs/commit/039812311ae83efa69fc1e855dfd863937073547) github-runner: 2.335.1 -> 2.336.0
* [`14e4152d`](https://github.com/NixOS/nixpkgs/commit/14e4152d002aec91bab648db78ed0686fd9ff572) github-runner: add myself as maintainer
* [`1065b952`](https://github.com/NixOS/nixpkgs/commit/1065b9527b9c1fce400764a845d6d859abbaa8d8) python314Packages.ctranslate2: explicitly set library_dirs through build system env
* [`eb2d35ae`](https://github.com/NixOS/nixpkgs/commit/eb2d35ae0269c3023f99d8735ca51965fe354ac8) practrand: init at 0.96
* [`10099455`](https://github.com/NixOS/nixpkgs/commit/100994556cabb6ade221edbf8d6271920d6cf03b) terragrunt: 1.0.4 -> 1.0.5
* [`568261f7`](https://github.com/NixOS/nixpkgs/commit/568261f7af58368988199a66d7dd15feaa1b1bf1) terragrunt: 1.0.5 -> 1.0.6
* [`d32233e4`](https://github.com/NixOS/nixpkgs/commit/d32233e4306e1f01203f707091bbea1ad290696b) terragrunt: 1.0.6 -> 1.0.7
* [`b9edbb68`](https://github.com/NixOS/nixpkgs/commit/b9edbb68140804a01c04905458fcb7e93f169531) terragrunt: 1.0.7 -> 1.0.8
* [`a4760c5b`](https://github.com/NixOS/nixpkgs/commit/a4760c5b7fe61f36a659ea29b78284d327452f2e) terragrunt: 1.0.8 -> 1.1.0
* [`291ef795`](https://github.com/NixOS/nixpkgs/commit/291ef7953a449bc6ea1c235b3496583a67ae9ebb) terragrunt: 1.1.0 -> 1.1.1
* [`3f90fe00`](https://github.com/NixOS/nixpkgs/commit/3f90fe00534cc8ab13ebc9953ad0f085d2ff5c88) python3Packages.dlinfo: unbreak darwin
* [`78825550`](https://github.com/NixOS/nixpkgs/commit/78825550c92d40a7c2210d2cbeedd9febb967f89) libkrun-efi: 1.19.3 -> 1.19.4
* [`27141693`](https://github.com/NixOS/nixpkgs/commit/2714169300222c59961856ab8e734f3bbc19b716) crate2nix: modernize slightly
* [`e7393d20`](https://github.com/NixOS/nixpkgs/commit/e7393d209086c90d3ff05309edec7bdd23b8d006) sssd: remove no longer required extra include flag
* [`93186429`](https://github.com/NixOS/nixpkgs/commit/93186429f2bf3339ffa9855888ca841c1f37a8b9) ocamlPackages.camlimages: drop camlimages.lablgtk2
* [`a2dd9bb9`](https://github.com/NixOS/nixpkgs/commit/a2dd9bb9ec2568505236149dce51beea5a76ae13) libraqm: 0.10.5 -> 0.11.0
* [`4b5231a6`](https://github.com/NixOS/nixpkgs/commit/4b5231a6ba8324eeecc274c4e0aa27bf689dc3e1) python3Packages.python-pkcs11: 0.9.3 -> 0.9.4
* [`4717c96e`](https://github.com/NixOS/nixpkgs/commit/4717c96e6a517ccd2df3c223af63855f646377ba) pascube: remove
* [`2ed55e79`](https://github.com/NixOS/nixpkgs/commit/2ed55e79de627e75a46753b594f5554edfa9c183) maintainers: add 66hex
* [`4d4f52ab`](https://github.com/NixOS/nixpkgs/commit/4d4f52ab65fa3cffb063d1b2d2be3833e2f6f377) frame-media-converter: init at 0.31.1
* [`9c63d6c2`](https://github.com/NixOS/nixpkgs/commit/9c63d6c2a2655a63db9c88fdbedcce9b96a7d79d) nixos/isolate: fix type for uid/gid options
* [`23333b36`](https://github.com/NixOS/nixpkgs/commit/23333b36b2a90c8a1fce8bdf1f71aec1420faede) coder: fix eval on unsupported systems
* [`490ce91b`](https://github.com/NixOS/nixpkgs/commit/490ce91b62ce5adb73dc9f00841d2df071857c1b) angie: 1.11.8 -> 1.12.1
* [`2a9fb549`](https://github.com/NixOS/nixpkgs/commit/2a9fb549d9c1e8f41b886c0c94a6c07e7d2c39da) easylpac: create .app bundle on darwin
* [`05ca2c64`](https://github.com/NixOS/nixpkgs/commit/05ca2c64e63d9ed0c55adf5ceb0b5362f9f1968f) am2rlauncer: upgrade to webkitgtk_4_1
* [`2d4daee2`](https://github.com/NixOS/nixpkgs/commit/2d4daee216dcc914442c5e1087ec9b00c67451f6) pixelflasher: 8.14.3.1 -> 9.1.5.0
* [`38ac535c`](https://github.com/NixOS/nixpkgs/commit/38ac535cc66317d6ad746286944bfb37630fed5e) libvirt: remove xhtml1
* [`921182a0`](https://github.com/NixOS/nixpkgs/commit/921182a0763e3e1f36918a351bc844a11f174294) xhtml1: drop
* [`ab3a09c3`](https://github.com/NixOS/nixpkgs/commit/ab3a09c3d5c20398ecd9a928cd0ee21cf0ae8489) wildmidi: 0.4.6 -> 0.5.0
* [`df8ea717`](https://github.com/NixOS/nixpkgs/commit/df8ea7179adcecc143db9b812d5aa6ec47411731) fable: 5.0.0 -> 5.13.0
* [`eba134ec`](https://github.com/NixOS/nixpkgs/commit/eba134eca772f724793b48416ccc8528be743283) duckdb: 1.5.4 -> 1.5.5
* [`bc009599`](https://github.com/NixOS/nixpkgs/commit/bc009599430fce205371bd801bb779bb884bd5aa) stylelint: 17.11.0 -> 17.14.1
* [`d328bfb5`](https://github.com/NixOS/nixpkgs/commit/d328bfb521b56b8fa7fe8d2cd3a0f11ba9114909) pkgsStatic.lua.pkgs.libluv: fix build
* [`6e4941d3`](https://github.com/NixOS/nixpkgs/commit/6e4941d3acf19c831c9343d962ec527ada172b8c) pkgsStatic.lua.pkgs.luarocks_bootstrap: fix build
* [`4c82c0d5`](https://github.com/NixOS/nixpkgs/commit/4c82c0d5e05ecf877deb5fb097ec6b4f3810731c) lua.pkgs.libluv: reformat with "nixfmt -s"
* [`7450f4f0`](https://github.com/NixOS/nixpkgs/commit/7450f4f070d049a01dbb81f7c76b5d5838b8d006) taterclient-ddnet: add git shortrev hash
* [`289f2090`](https://github.com/NixOS/nixpkgs/commit/289f209083df5078d6de228fe5f1f8c5fd5689d6) assimp: devendor pugixml, rapidjson, and utf8cpp
* [`4bf3bbfc`](https://github.com/NixOS/nixpkgs/commit/4bf3bbfcdb0cfe8cb233e7485d202c9141904c7a) cherrytree: 1.6.3 -> 1.7.1
* [`be14c759`](https://github.com/NixOS/nixpkgs/commit/be14c7595d7a47589caa0bbfcb5fb7b5d703e87e) pwsafe: 1.23.0 -> 1.25.0
* [`15b3e77a`](https://github.com/NixOS/nixpkgs/commit/15b3e77a1d75a8d5c471dceb6967c3f6fb6f6e33) lerc: 4.1.1 -> 4.2.0
* [`0c50a2d8`](https://github.com/NixOS/nixpkgs/commit/0c50a2d8e46723cc363b8afeb09674a373f4118e) python3Packages.fx2: 0.14 -> 0.16
* [`c56aff11`](https://github.com/NixOS/nixpkgs/commit/c56aff11bc1fec1d5f93d728bdb41f72346fb734) python3Packages.enum-tools: init at 0.13.0
* [`20cb6b0b`](https://github.com/NixOS/nixpkgs/commit/20cb6b0b5d2e109fe94c39291e4ca08e2eb8cf34) glasgow: 0-unstable-2025-12-22 -> 0-unstable-2025-07-25
* [`ab65a38c`](https://github.com/NixOS/nixpkgs/commit/ab65a38c3d4535a4d13258c1ff23a45c3bb17dda) python3Packages.starfile: init at 0.5.13
* [`8e41b275`](https://github.com/NixOS/nixpkgs/commit/8e41b2756684e628bc2192cb48e8003602b3b5de) freecad: add `versionCheckHook`
* [`dfb33d7b`](https://github.com/NixOS/nixpkgs/commit/dfb33d7ba60526373aaefcfa473f38edb1452ebf) freecad: set `meta.mainProgram`
* [`70adbe78`](https://github.com/NixOS/nixpkgs/commit/70adbe787e16f2e0dad3f539db8bd4988c4c95b3) freecad: 1.1.1 -> 1.1.3
* [`d9ec8ea4`](https://github.com/NixOS/nixpkgs/commit/d9ec8ea40b4242164756360fc7720a7e71e357b4) freecad: add acuteaangle to maintainers
* [`25e320c7`](https://github.com/NixOS/nixpkgs/commit/25e320c7427370864f1e26b6a6f9e38068177b6c) neural-amp-modeler-lv2: 0.1.4 -> 0.2.3
* [`9cbca0ab`](https://github.com/NixOS/nixpkgs/commit/9cbca0ab5756d854ac6ca33b98bc0824d7bd7fd1) ssh-vault: 1.2.14 -> 1.3.2
* [`8ded43db`](https://github.com/NixOS/nixpkgs/commit/8ded43dbdea0a7c4ca5e05f12a6d86790bbd9299) fswatch: 1.18.3 -> 1.22.0
* [`3bd3b595`](https://github.com/NixOS/nixpkgs/commit/3bd3b595b4ea2ec187626f06fb76b96b87de64ae) maintainers: add WOnder93
* [`f488e86f`](https://github.com/NixOS/nixpkgs/commit/f488e86f974d96bfc7f5c10de83e3f39d1f25eb8) ptouch-print: Add missing argp-standalone arg for Darwin
* [`3dea6a7b`](https://github.com/NixOS/nixpkgs/commit/3dea6a7bda151ba1b19a60de144afdccfeaf17ab) imagemagick: replace hard-coded store path with $NIX_STORE
* [`49a5e191`](https://github.com/NixOS/nixpkgs/commit/49a5e191c77b428045cfb1cbef22eda991221969) quartus-prime-lite: avoid using `${pname}` from Nix
* [`86ddb6e2`](https://github.com/NixOS/nixpkgs/commit/86ddb6e2f2ef5cb3c98a939d591936b88da68acc) clickup: 3.5.185 -> 3.5.262
* [`155c8dea`](https://github.com/NixOS/nixpkgs/commit/155c8dea99a81d5c65cd60c91550440a17be8f2f) pandoc-cli: test lua and server features are enabled by default
* [`553fd0f0`](https://github.com/NixOS/nixpkgs/commit/553fd0f06e77a93c177433d46b3908cc9ca8e7cc) converseen: 0.15.1.3 -> 0.15.2.7
* [`34d39eed`](https://github.com/NixOS/nixpkgs/commit/34d39eed55476d95c07beb7c4e5c527c80cf8921) python3Packages.pebble: 5.2.0 -> 5.2.1
* [`3cb435e5`](https://github.com/NixOS/nixpkgs/commit/3cb435e5dc9de964d69ea3c2229d1f0a02a0e4a9) ts-warp: 1.5.8 -> 1.5.11
* [`86edfb3a`](https://github.com/NixOS/nixpkgs/commit/86edfb3a1237a85221314f65f426c047bd552435) scalafmt: 3.11.4 -> 3.11.5
* [`fbc1858e`](https://github.com/NixOS/nixpkgs/commit/fbc1858e72e4894b902a09fb528cf22bdd1af877) python3Packages.pythonMetadataCheckHook: avoid leaking internal variables
* [`85141fe0`](https://github.com/NixOS/nixpkgs/commit/85141fe0eed89918e13a4f32f850055dfb85b541) python3Packages.pythonMetadataCheckHook: fix typo
* [`37ef2a8e`](https://github.com/NixOS/nixpkgs/commit/37ef2a8e473fd421d23f3becd283192b9e83eceb) legit-web: copy potentially modified directories instead of $src
* [`7209270d`](https://github.com/NixOS/nixpkgs/commit/7209270d24e033a512f5acf60ffe2b3285671f78) nixos/legit-web: make package easier to customize
* [`945300a3`](https://github.com/NixOS/nixpkgs/commit/945300a3251ade9b117a2a412f3d0ee759c80aa7) minimal-bootstrap.libgmp: init at 6.3.0
* [`ab3dec4e`](https://github.com/NixOS/nixpkgs/commit/ab3dec4efda1008c8a09e264d0fcd949aa245b04) minimal-bootstrap.libmpfr: init at 4.2.2
* [`da19a96b`](https://github.com/NixOS/nixpkgs/commit/da19a96b09793c6cce046dee4da939f2f519c889) minimal-bootstrap.libmpc: init at 1.3.1
* [`12f89dcf`](https://github.com/NixOS/nixpkgs/commit/12f89dcfe5da7c99d3859f8592b6ada42e81581a) minimal-bootstrap.glibc-headers: init at 2.42
* [`d48885de`](https://github.com/NixOS/nixpkgs/commit/d48885dee82b8c4935d5307374142964724cdecb) minimal-bootstrap.musl-headers: init at 1.2.6
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
