### PR TITLE
npins home-manager: update c30c7955 -> 35374258

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -48,9 +48,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "c30c7955cec30d664a9baced6bc0112e263d4647",
-      "url": "https://github.com/nix-community/home-manager/archive/c30c7955cec30d664a9baced6bc0112e263d4647.tar.gz",
-      "hash": "sha256-ou8fYz5w9yhXC8YbvvExybFIa19MyW5G/8dEPqa90hM="
+      "revision": "353742587cbaf079b3caee743115d037bc51fea6",
+      "url": "https://github.com/nix-community/home-manager/archive/353742587cbaf079b3caee743115d037bc51fea6.tar.gz",
+      "hash": "sha256-MTGMFlLDTklsXhCp4r5GXB4VAVadPdalXLvUjd/K7h0="
     },
     "hs-grille": {
       "type": "Git",


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@c30c7955...35374258](https://github.com/nix-community/home-manager/compare/c30c7955cec30d664a9baced6bc0112e263d4647...353742587cbaf079b3caee743115d037bc51fea6)

* [`f404edbf`](https://github.com/nix-community/home-manager/commit/f404edbfa4117810c96b97048299242fc50e5362) niri: preserve string context in generated config
* [`99e84ee7`](https://github.com/nix-community/home-manager/commit/99e84ee7387ff24cd112ff51f71c3465eb9cb770) pistol: revert config path for macOS ([nix-community/home-manager⁠#9798](https://togithub.com/nix-community/home-manager/issues/9798))
* [`40c28d28`](https://github.com/nix-community/home-manager/commit/40c28d282a3328fe1522ee3db0bf4aad42f199eb) vdirsyncer: support read-only local storages
* [`ad952916`](https://github.com/nix-community/home-manager/commit/ad9529169459ad1369c60dc285f8355e9f3c94e9) vdirsyncer: test read-only local storages
* [`f8badd57`](https://github.com/nix-community/home-manager/commit/f8badd57bac448d07fb93a7884a207ecb0927e95) vdirsyncer: add local read-only news
* [`a0d058ef`](https://github.com/nix-community/home-manager/commit/a0d058ef22fcdf325dad57c52b345aabc2f09162) docs: link release note highlights to module pages
* [`e13ba5e5`](https://github.com/nix-community/home-manager/commit/e13ba5e5abbd9b912fa8c6979bd119e87ca7fdd9) docs: link module pages without an invalid anchor
* [`0668fdbc`](https://github.com/nix-community/home-manager/commit/0668fdbc15bd602e463cab37ff64346021193652) treewide: stdenv.is* -> stdenv.hostPlatform.is*
* [`2d1bac51`](https://github.com/nix-community/home-manager/commit/2d1bac51b2513914ace47797765c3265164de78e) tests: fix integration tests
* [`c554d344`](https://github.com/nix-community/home-manager/commit/c554d3441f725537854e877519f01cbd60680174) lorri: add Darwin daemon
* [`83b7606d`](https://github.com/nix-community/home-manager/commit/83b7606dcf44abe3a94b86e8bb2b3355d22e8797) lorri: update deprecated `stdenv.*` alias
* [`58405b3b`](https://github.com/nix-community/home-manager/commit/58405b3b0ce13e9cd4af7dc697687b4d9b74e56d) mblaze: add module
* [`c8058ecc`](https://github.com/nix-community/home-manager/commit/c8058ecc1329a71a3c99c4d0353dba4009a66152) mblaze: add to labeler mail entry
* [`5bd50596`](https://github.com/nix-community/home-manager/commit/5bd505963717a894b02a57cdbcc00db28d9b029f) hyprtoolkit: add module
* [`fa4717d1`](https://github.com/nix-community/home-manager/commit/fa4717d13d8aaf3311db066a984862c4a7fc902e) claude-code: avoid IFD for skill paths
* [`d330408f`](https://github.com/nix-community/home-manager/commit/d330408f8146ed20b06b42248f52da345c38fa64) codex: avoid IFD for derived paths
* [`7ccdf17f`](https://github.com/nix-community/home-manager/commit/7ccdf17fddce6828f88409d2659d19149083733b) opencode: avoid IFD for skill paths
* [`2e5052fc`](https://github.com/nix-community/home-manager/commit/2e5052fc725be2b63855883098185b2b4fcc1446) antigravity-cli: avoid IFD for skill paths
* [`dca466f1`](https://github.com/nix-community/home-manager/commit/dca466f13221367ebb9b13194af0d2b4450d4fde) github-copilot-cli: avoid IFD for path inputs
* [`85a5c1f6`](https://github.com/nix-community/home-manager/commit/85a5c1f69c27faeb7efc0dfe1185bf0fbce1f541) crush: avoid IFD for skill paths
* [`313aabfb`](https://github.com/nix-community/home-manager/commit/313aabfb207cacdf30e6c0508b401893466889e4) ollama: allow `acceleration = "vulkan";`
* [`c507a06b`](https://github.com/nix-community/home-manager/commit/c507a06bd1caba17e96b7f36725864d248859817) antigravity-cli: emit disabled for disabled MCP servers
* [`aac4965d`](https://github.com/nix-community/home-manager/commit/aac4965ddb7ea2ff0f3cadd9502c7042b7aa07ba) antigravity-cli: use lib.hm.mcp.resolveEnabled for MCP server resolution
* [`ec161155`](https://github.com/nix-community/home-manager/commit/ec161155d76f7ec25404c0da2fa9f5f133f6ae4c) hyprland: add XDPH settings
* [`35374258`](https://github.com/nix-community/home-manager/commit/353742587cbaf079b3caee743115d037bc51fea6) concord: add module
