### PR TITLE
npins powerlevel10k: update 9253fb1c -> 3308262d

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -138,9 +138,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "9253fb1c5034410c43a0c681ff8294181c54016c",
-      "url": "https://github.com/romkatv/powerlevel10k/archive/9253fb1c5034410c43a0c681ff8294181c54016c.tar.gz",
-      "hash": "sha256-m1IM5sEEf/yVkISC12oVLdgyk0z98hp8OqolGu098zM="
+      "revision": "3308262dfbd743b6e1d3956a2b5572f7a049d692",
+      "url": "https://github.com/romkatv/powerlevel10k/archive/3308262dfbd743b6e1d3956a2b5572f7a049d692.tar.gz",
+      "hash": "sha256-s0FLaSZdhMTJyHQFtkQWdp0Qi2QAZvy4H40r1FdEOvY="
     },
     "rh": {
       "type": "Git",


### PR DESCRIPTION
## Changelog for powerlevel10k:
Branch: master
Commits: [romkatv/powerlevel10k@9253fb1c...3308262d](https://github.com/romkatv/powerlevel10k/compare/9253fb1c5034410c43a0c681ff8294181c54016c...3308262dfbd743b6e1d3956a2b5572f7a049d692)

* [`58e13d16`](https://github.com/romkatv/powerlevel10k/commit/58e13d16a50e1d6908e39e20a670896808ccf350) bug fix: slap (V) on the content of `package` ([romkatv/powerlevel10k⁠#2961](https://togithub.com/romkatv/powerlevel10k/issues/2961))
* [`242ccfae`](https://github.com/romkatv/powerlevel10k/commit/242ccfaef86ab3ab6a5f3c19f3396cdbc1049968) Squashed 'gitstatus/' changes from 075baf6e..39d34dff
