### PR TITLE
npins zsh-patina: update 63d033ce -> 5319607c

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -242,9 +242,9 @@
       },
       "branch": "main",
       "submodules": false,
-      "revision": "63d033ce397becd7dc325171b7a9b933bda8ea6e",
-      "url": "https://github.com/michel-kraemer/zsh-patina/archive/63d033ce397becd7dc325171b7a9b933bda8ea6e.tar.gz",
-      "hash": "sha256-lsalJHGQIYRzHtqhtXlH0KRTAoW1CdAmvH3vSFR/NPY="
+      "revision": "5319607c43bc2237eda3b95bc8ad2485dd2297e1",
+      "url": "https://github.com/michel-kraemer/zsh-patina/archive/5319607c43bc2237eda3b95bc8ad2485dd2297e1.tar.gz",
+      "hash": "sha256-feBmmR6B83172VBHSlKIZLJuZ/wRx8R/AJ//Dnf/NaQ="
     },
     "zsh-syntax-highlighting": {
       "type": "Git",


### PR DESCRIPTION
## Changelog for zsh-patina:
Branch: main
Commits: [michel-kraemer/zsh-patina@63d033ce...5319607c](https://github.com/michel-kraemer/zsh-patina/compare/63d033ce397becd7dc325171b7a9b933bda8ea6e...5319607c43bc2237eda3b95bc8ad2485dd2297e1)

* [`9bce6283`](https://github.com/michel-kraemer/zsh-patina/commit/9bce62833d78cea88c4bcc2dd6339020e1fa1f76) Resolve named directories w/ communication protocol v3
* [`bb8d0d59`](https://github.com/michel-kraemer/zsh-patina/commit/bb8d0d59923a741ecb677672767b0bc4e57becec) Avoid pre-process scanning for potential named directories
* [`293b0f04`](https://github.com/michel-kraemer/zsh-patina/commit/293b0f04ee10efea16e357f1693e1d709591f1d0) Preserve and patch base styles from the Bash grammar
* [`16b3754b`](https://github.com/michel-kraemer/zsh-patina/commit/16b3754bc8eb599cae277723b7282184dff2183d) Introduce integration tests for named directories
* [`880e3c51`](https://github.com/michel-kraemer/zsh-patina/commit/880e3c519874c7a0997ddbca89955a14fcd0b366) Remove check for 'zsh-patina activate' invoked last in the zshrc
* [`204f7c49`](https://github.com/michel-kraemer/zsh-patina/commit/204f7c494841d8014615261f8a8ffb43ce7ff9ec) Merely recommend zsh-patina activation to come last in zshrc
* [`1a149944`](https://github.com/michel-kraemer/zsh-patina/commit/1a149944494694fac83e4ad60327fb855bb9ba1b) Observe better comments hygiene, address review notes
* [`3b03b843`](https://github.com/michel-kraemer/zsh-patina/commit/3b03b8439be0a80695c1c03076a2755f0163e2e4) Minor cleanup
* [`8f94aedf`](https://github.com/michel-kraemer/zsh-patina/commit/8f94aedf7a4bc476d511d1aa417a4a0b0f517ad4) Minor refactoring to fix clippy warning
* [`52da4bc2`](https://github.com/michel-kraemer/zsh-patina/commit/52da4bc2879c3a8a8c65e1d99c227795ce9a1acb) Document in which versions protocol 1 and daemon PID were deprecated
* [`2b737fc0`](https://github.com/michel-kraemer/zsh-patina/commit/2b737fc069138408f2b32979af8b73acff4ac1f7) Deprecate protocol version 2
* [`e5f29251`](https://github.com/michel-kraemer/zsh-patina/commit/e5f292517306612dc69f91c4a3067d319ac61fe6) Relax generics
* [`a89abd38`](https://github.com/michel-kraemer/zsh-patina/commit/a89abd38fe249360f54d91f280de9c7568cbf399) Verify that highlighter handles named directories
