### PR TITLE
npins nixpkgs: update 18fb4828 -> 64b7af55

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -125,9 +125,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "18fb4828e1f85a2c994608252217a8796e659a02",
-      "url": "https://github.com/nixos/nixpkgs/archive/18fb4828e1f85a2c994608252217a8796e659a02.tar.gz",
-      "hash": "sha256-kIVH8uflRODlyU0abn2wBx1M+H63qy5tSXdV2tTQLdQ="
+      "revision": "64b7af55c5adecff92379d9f7d4b36d36848181d",
+      "url": "https://github.com/nixos/nixpkgs/archive/64b7af55c5adecff92379d9f7d4b36d36848181d.tar.gz",
+      "hash": "sha256-Mq6lgHza7MmXfvOJp7pmiEqcvPBNPX4SZ/9epx1F5Hw="
     },
     "powerlevel10k": {
       "type": "Git",


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@18fb4828...64b7af55](https://github.com/nixos/nixpkgs/compare/18fb4828e1f85a2c994608252217a8796e659a02...64b7af55c5adecff92379d9f7d4b36d36848181d)

* [`4cd31785`](https://github.com/NixOS/nixpkgs/commit/4cd317856811945da13e0897b4e47628ccb91102) nixos/netdata: use literalExpression on example of extraNdsudoPackages
* [`fc2b06c2`](https://github.com/NixOS/nixpkgs/commit/fc2b06c28c5aa785965648fdc2bedd0d384f7130) factorio: make it possible to use `impureEnvVars` for username and token
* [`a42db87b`](https://github.com/NixOS/nixpkgs/commit/a42db87bd2f5b8b6072f3d9425b509a35a48e4c9) dlib: 20.0 -> 20.0.1
* [`a053f0a8`](https://github.com/NixOS/nixpkgs/commit/a053f0a80a3d911369fe8475502b2d5aa539af18) python3Packages.habanero: adding missing dependency
* [`e1c2ccfc`](https://github.com/NixOS/nixpkgs/commit/e1c2ccfc28ff7df7f6657fc1002482fe729bf374) wiliwili: 1.5.3 -> 1.6.0
* [`2868833a`](https://github.com/NixOS/nixpkgs/commit/2868833a7e0934bef07339358f5adb9fff9f9b52) alfaview: 9.24.1 -> 9.26.6
* [`2f669bf8`](https://github.com/NixOS/nixpkgs/commit/2f669bf82adb807560ec89dc8438cf4bfcf93acb) nixos/varnish: set LimitMEMLOCK systemd service process property to `infinity`
* [`48e76023`](https://github.com/NixOS/nixpkgs/commit/48e760239859a230a3d8e50f203acc7db7575bd8) fetchtorrent: use a random name for downloadedDirectory
* [`2e3d501f`](https://github.com/NixOS/nixpkgs/commit/2e3d501f48e2a882f8f6d44868ecdb1898075d07) fetchtorrent: handle single-file downloads
* [`a59ff0d1`](https://github.com/NixOS/nixpkgs/commit/a59ff0d1231d6773e5a1ce377b722e888f29ac68) fetchtorrent: actually emit flatten warnings
* [`b20865b7`](https://github.com/NixOS/nixpkgs/commit/b20865b73214f86db1fbec25ed7ccb4835f69183) fetchtorrent: disable tests that now warn about future deprecation
* [`d0a09641`](https://github.com/NixOS/nixpkgs/commit/d0a09641e4309f2f765a69ac2690b5855a53c4c9) fetchtorrent: actually fail tests when they fail
* [`b077f0d1`](https://github.com/NixOS/nixpkgs/commit/b077f0d1170ea5eb76161f1da405a20c9ab556a5) fetchtorrent: test single-file torrents
* [`9192e4bc`](https://github.com/NixOS/nixpkgs/commit/9192e4bce1c0179ec9854eac8c932551cc758d8b) tmuxPlugins.tmux-fzf: unstable-2023-10-24 -> unstable-2025-09-24
* [`7ea0e2f9`](https://github.com/NixOS/nixpkgs/commit/7ea0e2f9c87c9932444bd2bd3fafcd1c88ada443) hyprland-preview-share-picker: init at 0.2.1
* [`f745d445`](https://github.com/NixOS/nixpkgs/commit/f745d445c21451979bc6ef610548bc189fd71818) dtools: 2.110.0 -> 2.112.1
* [`a5db30d3`](https://github.com/NixOS/nixpkgs/commit/a5db30d30db8ea23e509737a857a5ed33bafc46c) dub: 1.39.0 -> 1.41.0
* [`35887906`](https://github.com/NixOS/nixpkgs/commit/358879062d8cd08d71679947880106d509d39690) dmd: 2.110.0 -> 2.112.1
* [`2754bd81`](https://github.com/NixOS/nixpkgs/commit/2754bd81f26cd8d118ba44c58597117a3ba2346b) prometheus-tailscale-exporter: 0.6.0 -> 0.6.1
* [`b1103937`](https://github.com/NixOS/nixpkgs/commit/b1103937194acf7f485a4aeba168b388be0750de) ldc: 1.41.0 -> 1.42.0
* [`f3f83ec4`](https://github.com/NixOS/nixpkgs/commit/f3f83ec4ed2bcb75a6c90240a9075b399d39ba20) maintainers: add gl1tchxd
* [`055d8572`](https://github.com/NixOS/nixpkgs/commit/055d85726a7d2c8854c6f4a7ee18af4e96800fa7) maintainers: add edgarpost
* [`25f38066`](https://github.com/NixOS/nixpkgs/commit/25f38066ebef70d516637ec206b0b998381877b1) roon-bridge: 1.8-1125 -> 2.60.1501
* [`8fc02c53`](https://github.com/NixOS/nixpkgs/commit/8fc02c532a62c09d05de1cbf88fcfa3dfaeca34a) python3Packages.ajpy: migrate to pyproject
* [`0961172d`](https://github.com/NixOS/nixpkgs/commit/0961172dcda915a2bc405dead877db787bd81a90) python3Packages.ajpy: use finalAttrs
* [`ff53b20c`](https://github.com/NixOS/nixpkgs/commit/ff53b20c9ea15d507c978982a96c15f1264127b2) python3Packages.unicodecsv: modernize and migrate to pyproject
* [`42d34929`](https://github.com/NixOS/nixpkgs/commit/42d349298a74ab8ac9cdaf3948d471b78874816b) python3Packages.unicodecsv: 0.14.1 -> 0.14.2
* [`53b7c86b`](https://github.com/NixOS/nixpkgs/commit/53b7c86bdad529f75bcd1943f7fb991ddbe9bc7c) tetro-tui: init at 3.6.1
* [`b87647b2`](https://github.com/NixOS/nixpkgs/commit/b87647b2c1ae6b35533c70eea5180504cd364116) python3Packages.amarna: migrate to pyproject
* [`1fc67b28`](https://github.com/NixOS/nixpkgs/commit/1fc67b28979b5a78d09b352412b0f2041896a2fb) python3Packages.amarna: use finalAttrs
* [`871d42f4`](https://github.com/NixOS/nixpkgs/commit/871d42f4e29e53f1559a84dd1787219cb030de69) python3Packges.ajpy: fix license
* [`7db7b274`](https://github.com/NixOS/nixpkgs/commit/7db7b274a923440bfd2018c91aedc625c31ca2b1) python3Packages.anonip: migrate to pyproject
* [`62c5d943`](https://github.com/NixOS/nixpkgs/commit/62c5d9430f19ea977b37ac4c5bfab5c3fb4c64e0) python3Packages.anonip: use finalAttrs
* [`8d7e6abd`](https://github.com/NixOS/nixpkgs/commit/8d7e6abdf93d07bcc2341b4bfc1cae079d2a4bf9) arachne-pnr: refactor
* [`34dc50ac`](https://github.com/NixOS/nixpkgs/commit/34dc50acae62d59428d75fda54b572ed24ed8669) xr-chaperone: init at 0-unstable-2026-05-20
* [`f97f58d4`](https://github.com/NixOS/nixpkgs/commit/f97f58d42e9206a8019e4d827548c18e641c45df) python3Packages.pyinstaller-hooks-contrib: 2026.1 -> 2026.6
* [`abb92b4a`](https://github.com/NixOS/nixpkgs/commit/abb92b4a345d5d566b932f7c2289221748c30715) eclipses.eclipse-platform: 4.39 -> 4.40
* [`cfd574bd`](https://github.com/NixOS/nixpkgs/commit/cfd574bd2a34d8a652829609fb365049fcd1f493) gp-saml-gui: use finalAttrs
* [`8bd541bf`](https://github.com/NixOS/nixpkgs/commit/8bd541bff318f7c9d983bda68d1da9d4582ae8f1) gp-saml-gui: migrate to pyproject
* [`32051cc6`](https://github.com/NixOS/nixpkgs/commit/32051cc6e278fa999ea4fbf401265e04e3356acf) learn6502: 0.6.5 -> 0.7.0
* [`cd9c622f`](https://github.com/NixOS/nixpkgs/commit/cd9c622f33b47246e375eb61a225ee0a01a528db) gp-saml-gui: follow version conventions
* [`5dcbc8d7`](https://github.com/NixOS/nixpkgs/commit/5dcbc8d79a0fa6c731df5d3457b2b032c9691887) hermitcli: 0.52.1 -> 0.52.3
* [`63bbb2b2`](https://github.com/NixOS/nixpkgs/commit/63bbb2b29fb096bff58a99010b0907a63fe28939) jsvc: 1.5.1 -> 1.6.1
* [`5334f8bf`](https://github.com/NixOS/nixpkgs/commit/5334f8bf2d9440a8e8bbbfbf7919975fe56dfc94) roboto: 3.015 -> 3.016
* [`0f4b36e1`](https://github.com/NixOS/nixpkgs/commit/0f4b36e1d453b4c8d77bcbc57dee4ed9abcb49d6) lycheeslicer: 7.6.5 -> 7.6.6
* [`e6ed17b9`](https://github.com/NixOS/nixpkgs/commit/e6ed17b9184373cd145b1ede0872daeef2b5a253) nixos/github-runners: GitHub App authentication and multi-org runners
* [`c369496a`](https://github.com/NixOS/nixpkgs/commit/c369496ad70540bafb13d116364c69cb874d0447) gswatcher: 1.7.5 -> 1.8.0
* [`f9e4de7b`](https://github.com/NixOS/nixpkgs/commit/f9e4de7bd867a2585cbd6f4dad2bc970fafaca2e) meld: 3.23.1 -> 3.24.0
* [`1d8730f3`](https://github.com/NixOS/nixpkgs/commit/1d8730f3dbe86771838ee64f5cdf872fac93859e) mackup: 0.10.3 -> 0.11.1
* [`41567316`](https://github.com/NixOS/nixpkgs/commit/4156731635f1f425db5fcbe3911efd7ca2c52bfa) kwok: 0.7.0 -> 0.8.0
* [`ce699155`](https://github.com/NixOS/nixpkgs/commit/ce699155327d5e3fb43c2d29059a5aef635d5c20) python3Packages.update-copyright: use finalAttrs
* [`4ac9ecb5`](https://github.com/NixOS/nixpkgs/commit/4ac9ecb52e2242927acb26f8b23e84fb7b074a24) python3Packages.update-copyright: enable __structuredAttrs
* [`3941ea66`](https://github.com/NixOS/nixpkgs/commit/3941ea6656c9dccdd0cabe4eb71545adc5752650) python3Packages.update-copyright: migrate to pyproject
* [`6f0d2118`](https://github.com/NixOS/nixpkgs/commit/6f0d211814621ee784aab8da94331772c731ad16) python3Packages.update-copyright: disambiguate license
* [`143c3517`](https://github.com/NixOS/nixpkgs/commit/143c3517e7079d919643a4671691ba0560f193fc) python3Packages.update-copyright: remove isPy3k check
* [`5111debb`](https://github.com/NixOS/nixpkgs/commit/5111debba9857dc3b82fb9b2b9998c04b14f303d) python3Packages.update-copyright: add pythonImportsCheck
* [`49178e28`](https://github.com/NixOS/nixpkgs/commit/49178e282a12aca0c89d390af09c06ddaada98e8) python3Packages.update-copyright: use SRI hash
* [`b84a68a3`](https://github.com/NixOS/nixpkgs/commit/b84a68a37908fbaed8d27871a664acab5150fb1a) schleuder: refresh lockfile to fix build
* [`20dffb7a`](https://github.com/NixOS/nixpkgs/commit/20dffb7a6c256adb00cb940662d36fa1734b430b) linuxPackages.v4l2loopback: 0.15.3 -> 0.15.4
* [`b1e95146`](https://github.com/NixOS/nixpkgs/commit/b1e951466a01afd116038ed49dd38b5d37b5563c) pa-dlna: 1.2 -> 1.2.1
* [`303ee351`](https://github.com/NixOS/nixpkgs/commit/303ee351e498ca6cc4ea981a766586dbc5452c8b) vokoscreen-ng: 4.9.0 -> 4.10.0
* [`45d8cb15`](https://github.com/NixOS/nixpkgs/commit/45d8cb153e2a632e4984cf0b41ec22d15a857e4e) libredwg: 0.13.4.8200 -> 0.14
* [`0f9c6f9a`](https://github.com/NixOS/nixpkgs/commit/0f9c6f9a5af3fafd8ae9bc6f3fd503938d3bab61) python3Packages.asyncpraw: 8.0.1 -> 8.0.2
* [`600cdd6f`](https://github.com/NixOS/nixpkgs/commit/600cdd6fb9fe7975fb536bca40a509d1e9cefe8a) iprange: 2.0.0 -> 2.1.1
* [`54aa8627`](https://github.com/NixOS/nixpkgs/commit/54aa862749215377af12a5f00f49bbd47a1940aa) maintainers: add zeusec
* [`4c69de3a`](https://github.com/NixOS/nixpkgs/commit/4c69de3ac3f946d87586a079cccb366a737978c8) nvidia-container-toolkit: add zeusec as maintainer
* [`45de554d`](https://github.com/NixOS/nixpkgs/commit/45de554dee6fd66881f95bdef12ee0d266fe75e4) tlp: fix makefile patch
* [`bcbda113`](https://github.com/NixOS/nixpkgs/commit/bcbda113448ec428ec7b35ac18e1451c804da273) ts: 1.0.3 -> 1.0.4
* [`58e98d73`](https://github.com/NixOS/nixpkgs/commit/58e98d739dc1f9a9c6714e96c792525b125464b3) cyberia: init at 0.2.8
* [`50a9793e`](https://github.com/NixOS/nixpkgs/commit/50a9793ef6a5467efbbc6e2f1074148961c9a4d1) mbt: 3.11 -> 3.12
* [`72d880b1`](https://github.com/NixOS/nixpkgs/commit/72d880b16b2c9301fd4dd8ddf7c62ce4a19effeb) bee: 2.8.0 -> 2.8.1
* [`dc4082a4`](https://github.com/NixOS/nixpkgs/commit/dc4082a45359f97525cab96c8990b2b773ff2070) log4cplus: 2.1.2 -> 2.2.0.1
* [`9e0f2546`](https://github.com/NixOS/nixpkgs/commit/9e0f254624b39de52dc89bac625cda416b255368) nixos/beszel-hub: fix "unknown command" for migration
* [`07ec624b`](https://github.com/NixOS/nixpkgs/commit/07ec624b825abeccb0210c664d623ebb5fd1c07d) teamtype: 0.9.1 -> 0.9.2
* [`714db525`](https://github.com/NixOS/nixpkgs/commit/714db5254f3b036d69afd171642cb4e02346e301) tradingview: 3.2.0 -> 3.3.0
* [`4b4be60d`](https://github.com/NixOS/nixpkgs/commit/4b4be60deba928841da50c5649a06320437317b4) mytetra: 1.44.183 -> 1.44.232
* [`109bb8c3`](https://github.com/NixOS/nixpkgs/commit/109bb8c38a9368ae8955466c27edadea0d1f1852) pinniped: 0.46.0 -> 0.47.0
* [`d72952aa`](https://github.com/NixOS/nixpkgs/commit/d72952aa102f80228975a9fb8a18126463d49434) gatekeeper: 3.22.2 -> 3.23.0
* [`67efe2e3`](https://github.com/NixOS/nixpkgs/commit/67efe2e36b9b99a4537bbd0bad462f7764418389) calicoctl: 3.31.6 -> 3.32.1
* [`27ff9bb3`](https://github.com/NixOS/nixpkgs/commit/27ff9bb305a9ecb37db114a9607243bb7c9f376e) poethepoet: 0.46.0 -> 0.48.0
* [`b4565479`](https://github.com/NixOS/nixpkgs/commit/b4565479ba2df99adcec1b0e6c0d819b7ad1cecc) qspeakers: 1.8.5 -> 1.8.6
* [`e621cf21`](https://github.com/NixOS/nixpkgs/commit/e621cf21402dd091e3164da759dddb954bcf12a9) tinc: 1.0.36 -> 1.0.37
* [`bdbd0eb0`](https://github.com/NixOS/nixpkgs/commit/bdbd0eb062bac58d5ad4046527f55197fc538a2c) xlsatoms: 1.1.4 -> 1.1.5
* [`ef6e6abd`](https://github.com/NixOS/nixpkgs/commit/ef6e6abd839ee7bfa6c53bfc1170daa625bc3b3b) geoipupdate: 7.1.1 -> 8.0.0
* [`cab0078c`](https://github.com/NixOS/nixpkgs/commit/cab0078c256d1bf79d15881c157036d177573fc2) tlp: 1.9.1 -> 1.10.2
* [`d9e87c97`](https://github.com/NixOS/nixpkgs/commit/d9e87c972f159bf2975ca91da7dc177edb10c054) oras: 1.3.0 -> 1.3.3
* [`4ee22d54`](https://github.com/NixOS/nixpkgs/commit/4ee22d54431daab5187dd3bf9257722ecaf8591d) lsh: 1.6.3 -> 1.7.0
* [`01313d51`](https://github.com/NixOS/nixpkgs/commit/01313d5181becb977c0c0f3efd3089b462e7f040) codebuff: 1.0.681 -> 1.0.684
* [`46c2f462`](https://github.com/NixOS/nixpkgs/commit/46c2f4622bdf2653ef4d2713724e4a2ed7557388) kubectl-view-allocations: 1.1.1 -> 3.0.2
* [`4a85945a`](https://github.com/NixOS/nixpkgs/commit/4a85945a3f4e4dbe2e67652e8f574d05edc4c90a) prs: 0.5.6 -> 0.5.7
* [`493fe388`](https://github.com/NixOS/nixpkgs/commit/493fe388bd9d4e537fa9a6c01c1d4fad540e32a9) nixos/crowdsec: allow `systemd reload`ing the service
* [`2cd746bb`](https://github.com/NixOS/nixpkgs/commit/2cd746bba7a315ca15c146ecc497959ddf494ef9) simple-binary-encoding: 1.37.1 -> 1.39.0
* [`4646c337`](https://github.com/NixOS/nixpkgs/commit/4646c3370431fb02a9524a631fd8a467eaaf631b) python3Packages.simp-sexp: init at 0.3.1
* [`5b08d696`](https://github.com/NixOS/nixpkgs/commit/5b08d69612e5675603891184341fb299c88cc2f2) python3Packages.skidl: fix build
* [`24d5709f`](https://github.com/NixOS/nixpkgs/commit/24d5709f444287206580ac33b35ed07b73adeb9b) ngircd: 27 -> 28
* [`fa558039`](https://github.com/NixOS/nixpkgs/commit/fa558039ccea208d6c77d2f31fdc88bd4f693681) testssl: 3.2.3 -> 3.2.4
* [`01013175`](https://github.com/NixOS/nixpkgs/commit/0101317508d3313a8787df61020f5230cf2361c3) wayland-bongocat: 2.0.0 -> 2.0.2
* [`d27c298a`](https://github.com/NixOS/nixpkgs/commit/d27c298a52c04d12ff246c8ba2781a44202835cb) ttyplot: 1.7.5 -> 1.7.6
* [`7a06cedc`](https://github.com/NixOS/nixpkgs/commit/7a06cedc1d5810020882e94a517d2685574775a9) igir: 5.3.0 -> 5.4.0
* [`2005dea3`](https://github.com/NixOS/nixpkgs/commit/2005dea3ffe243e4ccf788bb0a192ac20f0df937) gonzo: 0.3.0 -> 0.4.3
* [`1d77363e`](https://github.com/NixOS/nixpkgs/commit/1d77363e263d749a688538edc327cb9eb9cbdf7c) nwipe: 0.41 -> 0.42
* [`e2a1dcb8`](https://github.com/NixOS/nixpkgs/commit/e2a1dcb873d73d1ef6fe8d20c6d2b5b590637364) capnproto: fix static/cross compilation
* [`4e31f1cf`](https://github.com/NixOS/nixpkgs/commit/4e31f1cf140476ac73e316d091ecc442582923d0) scroll-reverser: Use direct link
* [`50bb2745`](https://github.com/NixOS/nixpkgs/commit/50bb2745c7b1b4432c421a38d59489498778998b) scroll-reverser: Add update script
* [`5c0faa5e`](https://github.com/NixOS/nixpkgs/commit/5c0faa5e0c1538909762e647b552bd3f25e0d238) saxon-he: 12.9 -> 12.10
* [`476611d7`](https://github.com/NixOS/nixpkgs/commit/476611d79c5de719dbdd207265a190d3cc4bd3b3) wl-proxy: init at 0.1.4
* [`f486cef4`](https://github.com/NixOS/nixpkgs/commit/f486cef4d63d59b7354e1d72439ac62a3f63ea21) staruml: 7.0.0 -> 7.1.0
* [`e20ef60d`](https://github.com/NixOS/nixpkgs/commit/e20ef60d730054a46b3e12cfb292e3e7d9ddca90) irtt: 0.9.1 -> 0.9.2
* [`a4702f0b`](https://github.com/NixOS/nixpkgs/commit/a4702f0b5a03ccbba8373fb33cecbcc996511e23) context-mode: init at 1.0.143
* [`00885f00`](https://github.com/NixOS/nixpkgs/commit/00885f00887792245c9340effc13676cfe62b1b4) quickemu: use Microsoft Secure Boot variables
* [`44ea856f`](https://github.com/NixOS/nixpkgs/commit/44ea856fe5e0c68d345dd88efc6b5bd7cfbf0d29) quickemu: add native AAVMF firmware paths
* [`8c029eb2`](https://github.com/NixOS/nixpkgs/commit/8c029eb201eb14af545d9a8c02beb9755d1e3ec6) mpvpaper: 1.8 -> 1.9
* [`a04a1c9b`](https://github.com/NixOS/nixpkgs/commit/a04a1c9b9320d401e6e63e6e1fe68243d3025941) cargo-risczero: 3.0.5 -> 3.0.6
* [`9a00fe27`](https://github.com/NixOS/nixpkgs/commit/9a00fe275e647724ab1859ce1a363a08e46316e0) xlockmore: 5.88 -> 5.89
* [`55e07b59`](https://github.com/NixOS/nixpkgs/commit/55e07b59cb888a4e4eb395a9773761de84bb275f) xtrans: fix darwin fortify crash in xorg-server
* [`10fb16bd`](https://github.com/NixOS/nixpkgs/commit/10fb16bd8607faf0f0ec9d29204b15e69abf9a5d) xorg-server: enable strictflexarrays1 on darwin
* [`4a822b35`](https://github.com/NixOS/nixpkgs/commit/4a822b35265d71172165371db4990ef0601842d0) fmit: 1.3.3 -> 1.4.6
* [`8370d749`](https://github.com/NixOS/nixpkgs/commit/8370d7490ad881c737f49f6eda9a01e30c33d6a6) maintainers: Add colepearson27 to maintainers
* [`08301f0a`](https://github.com/NixOS/nixpkgs/commit/08301f0a99a90f1f267fe9c94b77329abf99c864) python3Packages.android-backup: migrate to pyproject
* [`22452819`](https://github.com/NixOS/nixpkgs/commit/22452819f22889aa980df01f18917c6b5f0cb058) python3Packages.android-backup: use tag
* [`825561a0`](https://github.com/NixOS/nixpkgs/commit/825561a0dc053bde6e34604400b26fb25a26eb52) python3Packages.android-backup: use pytestCheckHook
* [`244057cf`](https://github.com/NixOS/nixpkgs/commit/244057cf9fe516aad51a689de8519daedf49dc97) nixos/lib/testing: `builtins.length (lib.attrNames ...) > 0 -> != to the empty set
* [`bb321565`](https://github.com/NixOS/nixpkgs/commit/bb3215658765d60e8086585dfbcd10038599bfdb) nixos/lib/testing: don't require kvm if only containers are specified
* [`0f2e0fad`](https://github.com/NixOS/nixpkgs/commit/0f2e0fad95dbd67da5f6dd008f90b713dcc15be6) toybox: 0.8.13 -> 0.8.14
* [`2c954ce7`](https://github.com/NixOS/nixpkgs/commit/2c954ce732c93742c89e3d1637667a19172c7534) vega-cli: 6.2.0 -> 6.3.0
* [`93f1f28e`](https://github.com/NixOS/nixpkgs/commit/93f1f28e3c03bfcfe07be59ea7a7728adce576ca) nomacs: 3.23.1 -> 3.23.3
* [`c8c97c37`](https://github.com/NixOS/nixpkgs/commit/c8c97c3720baea696f07224b9e24dae7fdc2f65d) pure-prompt: 1.28.1 -> 1.28.3
* [`10593d10`](https://github.com/NixOS/nixpkgs/commit/10593d10f97d3cccaf463084341fea5b3a3a6261) tracelinks: 1.0.2 -> 1.1.0
* [`cc4e2b8a`](https://github.com/NixOS/nixpkgs/commit/cc4e2b8a06f41e156cf0597d75cc2f35464bfd93) marp-cli: 4.4.0 -> 4.5.0
* [`c7ac88e3`](https://github.com/NixOS/nixpkgs/commit/c7ac88e3cc2aedcfccc8ac7c7ce0ff4336d4b4cb) zsnes2: 2.1.1 -> 2.2.2
* [`099daec8`](https://github.com/NixOS/nixpkgs/commit/099daec8ba687189f6fef6fadba8d55e94081336) nakama: 3.39.0 -> 3.40.0
* [`000f7268`](https://github.com/NixOS/nixpkgs/commit/000f726846000b05293d92ecbd5a9e79dff74d62) schemacrawler: 17.11.4 -> 17.12.2
* [`18b3cbec`](https://github.com/NixOS/nixpkgs/commit/18b3cbec3776bdcb54b4fe0d40157d1664b7ace7) gpu-screen-recorder-gtk: 5.7.9 -> 5.8.0
* [`f575d4d5`](https://github.com/NixOS/nixpkgs/commit/f575d4d53a39174c791752bda5ba379d9a65f8c1) minizinc-ide: 2.9.7 -> 2.10.0
* [`b4687584`](https://github.com/NixOS/nixpkgs/commit/b46875840bbba134c5da3fc23c1bafdcabfcf663) snapraid: 14.7 -> 14.9
* [`f24e4c94`](https://github.com/NixOS/nixpkgs/commit/f24e4c9474213589b256e7285046c8f72acde657) focuswriter: 1.9.0 -> 1.9.1
* [`8af4a236`](https://github.com/NixOS/nixpkgs/commit/8af4a236d92bf4bb55a1c068909da4e82973ad5c) plakar: remove fuse
* [`84e6d9fe`](https://github.com/NixOS/nixpkgs/commit/84e6d9fef24d0042c036e0c66636c90beed8aafa) fishPlugins.fifc: 0.1.1 -> 0.3.4
* [`291c1f9f`](https://github.com/NixOS/nixpkgs/commit/291c1f9f87d90e3359e169bc41838f16383095a9) transcribe: 9.60.0 -> 9.60.3
* [`3fb97d52`](https://github.com/NixOS/nixpkgs/commit/3fb97d52ed3e79928a8734d04108a05d2077718d) python3Packages.ufonormalizer: migrate to pyproject
* [`50d4ce5f`](https://github.com/NixOS/nixpkgs/commit/50d4ce5f6a91719d7b151323efc43102dea1ac91) sngrep: 1.8.3 -> 1.8.4
* [`79ce338f`](https://github.com/NixOS/nixpkgs/commit/79ce338fe0e6547e04c717c91dce6ed887a0cab1) hcloud: 1.66.0 -> 1.67.0
* [`19e3e272`](https://github.com/NixOS/nixpkgs/commit/19e3e2720c18c3ae5a6fa0c8e6f568242eaea9b1) blst: 0.3.16 -> 0.3.17
* [`095e9edb`](https://github.com/NixOS/nixpkgs/commit/095e9edbc6479000fc069a13b010f4f460b2bd98) cheating-daddy: 0.7.0 -> 0.8.0
* [`e1845029`](https://github.com/NixOS/nixpkgs/commit/e1845029cde2049393d3aaade0e54ca6257ce0e4) myanon: 0.8.3 -> 0.8.4
* [`ee53873c`](https://github.com/NixOS/nixpkgs/commit/ee53873c2f1c1c24f283b8a8ef28a6a54191f005) valijson: 1.1.1 -> 1.1.3
* [`d2d81ffc`](https://github.com/NixOS/nixpkgs/commit/d2d81ffce8851acc91923fe80ef7f39b39b500fd) xandikos: 0.4.2 -> 0.4.5
* [`f37aff72`](https://github.com/NixOS/nixpkgs/commit/f37aff724cfb6c8969b368c48ae07a8dd7226cb9) kubevela: 1.10.9 -> 1.11.0
* [`2cfe875a`](https://github.com/NixOS/nixpkgs/commit/2cfe875a3b3b7a85e7edb8ddff3d891d7f4e0ae5) xload: 1.2.0 -> 1.2.1
* [`d707ee86`](https://github.com/NixOS/nixpkgs/commit/d707ee86e855db6baf0713565d6307c530855c80) yabasic: 2.91.4 -> 2.92.1
* [`79cb1bde`](https://github.com/NixOS/nixpkgs/commit/79cb1bdec0956c5977b584b02ff794443a54d30f) ocenaudio: 3.20.0 -> 3.20.1
* [`d2ce6385`](https://github.com/NixOS/nixpkgs/commit/d2ce6385c89808d7919aea24317f496c2b4f42e3) python3Packages.qpsolvers: 4.12.0 -> 4.13.0
* [`6718b04e`](https://github.com/NixOS/nixpkgs/commit/6718b04e13563ced9be8a616d85187ac0d384583) nixos/crab-hole: Add `openFirewall` option to `services.crab-hole`
* [`89244cc2`](https://github.com/NixOS/nixpkgs/commit/89244cc2bbaf47b29be4573aef7d1ec69271d3aa) bicgl: fix version scheme
* [`a98e0b55`](https://github.com/NixOS/nixpkgs/commit/a98e0b55a2ea17692f43fd0f82aabd3ce62d24f7) dnscrypt-proxy: 2.1.15 -> 2.1.18
* [`f451d227`](https://github.com/NixOS/nixpkgs/commit/f451d227d28672640ddd9ca96cf6a0e8dd8a74d4) python3Packages.qasync: fix build
* [`eef27c03`](https://github.com/NixOS/nixpkgs/commit/eef27c03a4937c08239ea88bbcf917779f2d2b61) obs-studio: 32.1.2 -> 32.2.1
* [`43e97ede`](https://github.com/NixOS/nixpkgs/commit/43e97ede9f30d94f3bfad2bf14949de84eaa2dd5) libweaver: 0-unstable-2025-12-18 -> 0-unstable-2026-07-25
* [`9aed7d3f`](https://github.com/NixOS/nixpkgs/commit/9aed7d3f7f90c02a79d6880608afe6fa6a54fb02) byzanz: fix version, homepage
* [`35e82764`](https://github.com/NixOS/nixpkgs/commit/35e8276463bc8bd221d5c123001738ebcc1f414b) ocamlPackages.pacomb: 1.4.3 -> 1.4.4
* [`65361b54`](https://github.com/NixOS/nixpkgs/commit/65361b5475ec3ba1a7c0e44c555f6246fcea0e7e) smithy-cli: 1.68.0 -> 1.72.1
* [`f32878b4`](https://github.com/NixOS/nixpkgs/commit/f32878b4767eb232319b0ea18dc23d3d947f5760) boogie: 3.5.6 -> 3.5.7
* [`9e7ce790`](https://github.com/NixOS/nixpkgs/commit/9e7ce790b4d6756ad5a0ff1c1ef125b846e804a1) btrbk: 0.32.6 -> 0.32.7
* [`943f2d41`](https://github.com/NixOS/nixpkgs/commit/943f2d41d8fb7e8a33f68c7e41b469211d4b9817) go-enum: init at 0.9.4
* [`b11ee824`](https://github.com/NixOS/nixpkgs/commit/b11ee82483dc9b92d7006dce2579866361bd9abd) dms: 1.7.2 -> 1.8.0
* [`ca0f1250`](https://github.com/NixOS/nixpkgs/commit/ca0f1250672e1658f05b72c712f855f47b13213b) kokkos: 5.1.1 -> 5.2.0
* [`75952545`](https://github.com/NixOS/nixpkgs/commit/759525454cb2f92bc5cb27a35d032378811a32ad) ldc: 1.41.0 -> 1.42.0
* [`7c425fd9`](https://github.com/NixOS/nixpkgs/commit/7c425fd9947732fca4dbe3a3a2d211319a46ed67) keepalived: 2.3.4 -> 2.4.3
* [`8c33ba0f`](https://github.com/NixOS/nixpkgs/commit/8c33ba0fdbf942e112bdffdf89ad34e50462c480) doc: fix capitalization and use consistent terminology
* [`a6ca6b9a`](https://github.com/NixOS/nixpkgs/commit/a6ca6b9a51f586cdc2e015dddedfeb8ff60feea9) doc: remove meta-commentary
* [`217e6db6`](https://github.com/NixOS/nixpkgs/commit/217e6db613b0836a436b85d4dc5ace68051cbeec) doc: cut filler and use plain words
* [`afbf43f1`](https://github.com/NixOS/nixpkgs/commit/afbf43f1c535dbf235d9f3d745a6974e64dbe523) doc: drop hedging and state facts
* [`dfe2d17e`](https://github.com/NixOS/nixpkgs/commit/dfe2d17e1ec12268bc1ddd9bd6d60d25cf3aec56) doc: use present tense and active voice
* [`d193b7bb`](https://github.com/NixOS/nixpkgs/commit/d193b7bb35af46c67a6dc1c782ecd104ea154166) doc: break long sentences into short ones
* [`8ddc1668`](https://github.com/NixOS/nixpkgs/commit/8ddc1668f7a27e6593f92d4429d7a3ae536ab291) doc: drop the finding-examples section
* [`8dfcbe2d`](https://github.com/NixOS/nixpkgs/commit/8dfcbe2d539fe1f1403bcc847b414f96b2c2383f) doc: fix grammatical errors
* [`4cdded4d`](https://github.com/NixOS/nixpkgs/commit/4cdded4d02b81c66eef135fe8cbf74040ce6be5b) doc: address review comments
* [`63e0a491`](https://github.com/NixOS/nixpkgs/commit/63e0a49102608a5b8e4511c791862b98f1fb4269) doc: add additional redirects for JavaScript examples
* [`2ab37bc2`](https://github.com/NixOS/nixpkgs/commit/2ab37bc2265bd7ced20e5ec61ec1650f0f088fc0) elinks: 0.19.1 -> 0.20.0
* [`ae439c72`](https://github.com/NixOS/nixpkgs/commit/ae439c7292c43fb9e6f78b40dfbc587702c75a0e) rtz: 0.7.1 -> 0.10.0
* [`a058ddc7`](https://github.com/NixOS/nixpkgs/commit/a058ddc745b6fc860db39272dbc9172ead1048da) crimson-pro: fix version, use installFonts
* [`d853f44f`](https://github.com/NixOS/nixpkgs/commit/d853f44f2df9d24fa5b566f0e66d7af1c2f1f047) fabric-installer: 1.1.1 -> 1.1.2
* [`d23e20ac`](https://github.com/NixOS/nixpkgs/commit/d23e20acb148dbf3d04fde285b4a3490c7e3bde4) dab_lib: fix version, license
* [`4af0d91b`](https://github.com/NixOS/nixpkgs/commit/4af0d91bdd42e4a29ecc687ddbeb35fff31857d0) deadbeefPlugins.lyricbar: fix version
* [`6540684b`](https://github.com/NixOS/nixpkgs/commit/6540684b26a72d5a8e310b897cc5af86ae8cb8eb) xfstests: 2026.06.21 -> 2026.07.21
* [`f38e9f24`](https://github.com/NixOS/nixpkgs/commit/f38e9f249051b88eaced0839925db3b966089f60) notesnook: 3.3.21 -> 3.4.5
* [`02610009`](https://github.com/NixOS/nixpkgs/commit/0261000941d111806ff46e307a31e65fa34300b6) python3Packages.python-decouple: use finalAttrs
* [`0c367d16`](https://github.com/NixOS/nixpkgs/commit/0c367d16d96e449733a1156a609fa738a57f8c6c) python3Packages.python-decouple: enable __structuredAttrs
* [`4b1f0db7`](https://github.com/NixOS/nixpkgs/commit/4b1f0db79e44e19ff762fd61495c6d50d7203359) python3Packages.python-decouple: migrate to pyproject
* [`dc0feca5`](https://github.com/NixOS/nixpkgs/commit/dc0feca5115a2e2532af139bf25b318a7deb592a) bicgl: cleanup
* [`776337e7`](https://github.com/NixOS/nixpkgs/commit/776337e78d0c82b78457f97816218674713b9657) rutorrent: 5.3.6 -> 5.3.11
* [`37e52ed9`](https://github.com/NixOS/nixpkgs/commit/37e52ed95ea1723391521c60edbd5b33fb49bf76) pve-tool: init at 0.1.2
* [`261af494`](https://github.com/NixOS/nixpkgs/commit/261af4942d958ab7486c83c9d5862043a7354821) node-problem-detector: 1.35.2 -> 1.36.0
* [`17a7d29d`](https://github.com/NixOS/nixpkgs/commit/17a7d29d183de50cdaf2097099a42609c9513712) czkawka: 12.0.0 -> 12.0.1
* [`bb8ac5e7`](https://github.com/NixOS/nixpkgs/commit/bb8ac5e7cd0104b84b3197d7fbfcfedf360d77c6) nirimod: init at 0-unstable-2026-07-27
* [`999e86c4`](https://github.com/NixOS/nixpkgs/commit/999e86c47fb393389026db423257f40b07153f68) noti: 3.8.0 -> 3.9.0
* [`91094779`](https://github.com/NixOS/nixpkgs/commit/910947799a4d50207d800568dcc14b305c52c9b4) pymp4: init at 1.4.0
* [`39f82096`](https://github.com/NixOS/nixpkgs/commit/39f82096d8d8dd504daa48311015f4664bd38418) obsidian-headless: init at 0.0.14
* [`01b6afa1`](https://github.com/NixOS/nixpkgs/commit/01b6afa103ab18c43082cbe9dee375f07852df0c) hyprquickframe: init at 1.1.0
* [`78e61ead`](https://github.com/NixOS/nixpkgs/commit/78e61ead15bb0449f2f0d17fa565c3c151a8dac3) ccmeter: init at 2.0.0
* [`b301b4cc`](https://github.com/NixOS/nixpkgs/commit/b301b4cccbf2a314743e46a42abdcb65ccb41171) terminal-oscilloscope: init at 0.1.0-unstable-2026-04-07
* [`cdeb027c`](https://github.com/NixOS/nixpkgs/commit/cdeb027c6969cab5ba58292a45d57db3c27989ab) nixos/tinyauth: add enableUnixSocket option
* [`76bc5148`](https://github.com/NixOS/nixpkgs/commit/76bc5148001aac38d37747a95faf92ef85694468) notmuch-bower: 1.1.1 -> 1.2
* [`c8729c46`](https://github.com/NixOS/nixpkgs/commit/c8729c462420da20ee0ef50ff48c3958adc3a9ec) flrig: 2.0.10 -> 2.0.12
* [`552c38cf`](https://github.com/NixOS/nixpkgs/commit/552c38cf75f6328a2db99b3e3a18e28a07a85e00) xmp: 4.3.0 -> 4.3.1
* [`69844398`](https://github.com/NixOS/nixpkgs/commit/69844398964b94ce6806ffb1dc724baa00bd8347) explain: `finalAttrs`
* [`c9ac275e`](https://github.com/NixOS/nixpkgs/commit/c9ac275ee3621fa25835f7868da5358e5cc7b3b9) explain: `enableParallelBuilding`
* [`0792ae21`](https://github.com/NixOS/nixpkgs/commit/0792ae2146d813337454e4106f6ec40e9cc97010) explain: `__structuredAttrs`, `strictDeps`
* [`ed3846f5`](https://github.com/NixOS/nixpkgs/commit/ed3846f528243098756111b8a372b6ac991ddf81) infrastructure-agent: 1.77.0 -> 1.78.1
* [`ae680d51`](https://github.com/NixOS/nixpkgs/commit/ae680d51ed7cd484cb2696b06de357b8282dde0a) zabbix-cli: 3.6.3 -> 3.7.0
* [`140b638f`](https://github.com/NixOS/nixpkgs/commit/140b638f65586ba2d09112b26274b484b6428341) shaarli: 0.16.3 -> 0.16.5
* [`a54a9ab1`](https://github.com/NixOS/nixpkgs/commit/a54a9ab19f342e8f95cb7ced62621f723d759511) kargo: 1.10.9 -> 1.11.0
* [`64c84326`](https://github.com/NixOS/nixpkgs/commit/64c843263c1b9bb338b7b7a1b9808ea9ed9a183d) zabbix-cli: add versionCheckHook, meta.changelog
* [`0de5d68d`](https://github.com/NixOS/nixpkgs/commit/0de5d68df10b44f2022e84ad3af64e54f1faa23c) novelwriter: 26.1 -> 26.1.2
* [`5a00946a`](https://github.com/NixOS/nixpkgs/commit/5a00946af20100b8c3d6d3c8e85c8e5c24b0986d) hisat2: 2.2.2 -> 2.2.3
* [`4bf6c22f`](https://github.com/NixOS/nixpkgs/commit/4bf6c22fbcd9e02311defae8fc91d7f5c840023b) awatcher: 0.3.3 -> 0.4.0
* [`f300e638`](https://github.com/NixOS/nixpkgs/commit/f300e6383fc3eb02795ead41557ec47079a2fbfc) gauge-unwrapped: 1.6.32 -> 1.6.35
* [`ac233f79`](https://github.com/NixOS/nixpkgs/commit/ac233f79e3727dc4623391d5bb01ac46b597deb7) itd: 1.1.0 -> 1.1.1
* [`a24c1037`](https://github.com/NixOS/nixpkgs/commit/a24c10374d9ab07cd93d7825de72a92633d0e4c2) phpExtensions.luasandbox: 4.1.3 -> 4.1.4
* [`41966100`](https://github.com/NixOS/nixpkgs/commit/41966100200b06f131783087c2a96574021e6732) tarlz: 0.29 -> 0.30
* [`15b7b881`](https://github.com/NixOS/nixpkgs/commit/15b7b8817d653bb16cb3df40da243efdec7366a8) pgf3: 3.1.11a -> 3.1.12
* [`61e70c19`](https://github.com/NixOS/nixpkgs/commit/61e70c19ca13ec8eff005a86ed0daee97f1c7ba2) loco: 0.16.3 -> 1.0.0
* [`2ef399f1`](https://github.com/NixOS/nixpkgs/commit/2ef399f1b8279d444082bdd3c9d59dbfef799c2e) coc-clangd: 0-unstable-2026-07-01 -> 0-unstable-2026-08-01
* [`2f3bb5a2`](https://github.com/NixOS/nixpkgs/commit/2f3bb5a283d04c387b6576e7381244b9caaa17cc) yarp: 3.12.2 -> 4.0.0
* [`211398fa`](https://github.com/NixOS/nixpkgs/commit/211398fafeb590884c276cb45b685a0a5300c030) seadrive-gui: 3.0.23 -> 3.0.24
* [`d5bc20be`](https://github.com/NixOS/nixpkgs/commit/d5bc20be8f6ec2c75a0b9d781757376c02b2c691) seadrive-fuse: 3.0.23 -> 3.0.24
* [`06299bc0`](https://github.com/NixOS/nixpkgs/commit/06299bc0eb5ce0f22fa11edb210cc5e066f1f5ca) pipeline: 4.0.4 -> 4.1.0
* [`b94714ba`](https://github.com/NixOS/nixpkgs/commit/b94714baca7c4853c012e947d137f32e46c6e10b) discourse: 2026.1.4 -> 2026.7.0
* [`3bf11276`](https://github.com/NixOS/nixpkgs/commit/3bf11276482378cdeabf2cb2caabffb8c3a5e33a) nixos/discourse: update config to match v2026.7.0
* [`7191c857`](https://github.com/NixOS/nixpkgs/commit/7191c8573c036c73af0193ed94ec60ca2e95666e) discourse: 2026.7.0 -> 2026.7.1
* [`01674ae7`](https://github.com/NixOS/nixpkgs/commit/01674ae727cd10cf6370d892c39a72865eff5585) vue-language-server: 3.3.7 -> 3.3.9
* [`4ba025af`](https://github.com/NixOS/nixpkgs/commit/4ba025af5ea9e2ebba892ffb72b98c0121c3e014) juicefs: 1.3.1 -> 1.4.1
* [`a8699095`](https://github.com/NixOS/nixpkgs/commit/a86990952d96ac1b45fd93a23cbea7b0770cc221) deno: fix find expression in preInstall
* [`f47a0d15`](https://github.com/NixOS/nixpkgs/commit/f47a0d15e19f1a657cf26a19833b5d20013cb8dc) gruvbox-gtk-theme: re-init at 0-unstable-2025-10-23
* [`76e838ec`](https://github.com/NixOS/nixpkgs/commit/76e838ecbec13ed5cb96226d4909b080de923222) butler: 15.27.0 -> 15.30.0
* [`8cc057ae`](https://github.com/NixOS/nixpkgs/commit/8cc057ae271c327087204516b05058e018be8b4f) kubectl-gadget: 0.54.1 -> 0.55.0
* [`538f25fb`](https://github.com/NixOS/nixpkgs/commit/538f25fba3cd5442151418fda5f4829bf5c453c3) opengamepadui: 0.45.1 -> 0.46.0
* [`6214c0ff`](https://github.com/NixOS/nixpkgs/commit/6214c0ff9bddda03152d525dae44680a56888626) rust-analyzer-unwrapped: 2026-06-15 -> 2026-08-03
* [`e138d3aa`](https://github.com/NixOS/nixpkgs/commit/e138d3aa7503ed4d96629319af07f04a0fc69372) xen: 4.20.4 -> 4.22.0
* [`b59e8eeb`](https://github.com/NixOS/nixpkgs/commit/b59e8eeb82a01eb2f5da7f7d35d8836fb3ba23d2) xen: split ocaml library into a separate output
* [`947098f3`](https://github.com/NixOS/nixpkgs/commit/947098f3570396e8197969e4768383c7cb207926) ocamlPackages.oxenstored: init at 25.3.0
* [`dc060282`](https://github.com/NixOS/nixpkgs/commit/dc0602827c33484b9a225c10786a35dc7e6e061f) doc/release-notes: mention oxenstored split
* [`c86fab43`](https://github.com/NixOS/nixpkgs/commit/c86fab4333c60aac28e5842fac4f766df907c2e4) nixos/xen: support the separate ocaml store package
* [`2bcbd687`](https://github.com/NixOS/nixpkgs/commit/2bcbd6876b7a4cea757916adb1d3dbb07922d5c6) bilibili: 1.17.9-2 -> 1.18.0-1
* [`1c0d6311`](https://github.com/NixOS/nixpkgs/commit/1c0d63115d4d984bb01b14ef523bc0dde51b309f) officecli: 1.0.129 -> 1.0.143
* [`72eb3ef3`](https://github.com/NixOS/nixpkgs/commit/72eb3ef3c787b8a6a5921524846af09c93f5cca8) lark-cli: 1.0.58 -> 1.0.83
* [`7d5335b3`](https://github.com/NixOS/nixpkgs/commit/7d5335b38ff8f52b596ab58a0e84b58eb9a22e27) dracula-theme: reinstate at 4.0.0-unstable
* [`1a1e114c`](https://github.com/NixOS/nixpkgs/commit/1a1e114ca59287afba815de5ee9554a41cedca43) ncdu_1: 1.22 -> 1.23.0
* [`84f84f6b`](https://github.com/NixOS/nixpkgs/commit/84f84f6bd1efbd5e40f33d62277eaff4a7be2d43) nixos/grafana: remove obsolete tools symlink
* [`a46a1834`](https://github.com/NixOS/nixpkgs/commit/a46a1834efc75f1a27ae90d5dc6868e809b23f1a) obah: init at 0.1.1
* [`a16a7c26`](https://github.com/NixOS/nixpkgs/commit/a16a7c260c33007102f6e6cc7106264cd408322e) lisette: 0.2.1 -> 0.11.1
* [`6b403343`](https://github.com/NixOS/nixpkgs/commit/6b403343d3e2ffd324fad9593862e8786ab5326a) p2pool: 4.17.1 -> 4.18
* [`5be0dbec`](https://github.com/NixOS/nixpkgs/commit/5be0dbecb98c83f55252faeb85dd8fa57143d24f) gallery-dl: 1.32.8 -> 1.32.9
* [`cb0de830`](https://github.com/NixOS/nixpkgs/commit/cb0de830f8f81dba8adf849bcc3dbe2ce1677dc6) libfrida-core: 17.16.4 -> 17.17.0
* [`a22147a3`](https://github.com/NixOS/nixpkgs/commit/a22147a377692e0baa85858a2e872d8e43aa71ac) nixos.security: remove option unprivilegedUsernsClone
* [`f68ef375`](https://github.com/NixOS/nixpkgs/commit/f68ef375490f1002cbe8a65a832a71f60af20790) lilypond-unstable: 2.27.1 -> 2.27.2
* [`f47ddb1b`](https://github.com/NixOS/nixpkgs/commit/f47ddb1b7906501f11217ee0b0d4d2819e2540f9) otel-desktop-viewer: 0.3.2 -> 0.4.1
* [`9f0d8ea5`](https://github.com/NixOS/nixpkgs/commit/9f0d8ea57d5838c387b09b53d9ec5ccbcaa29aae) tym: 3.6.0 -> 3.7.0
* [`e74bc3aa`](https://github.com/NixOS/nixpkgs/commit/e74bc3aa0c56c1b57b815c5406dbdc8dac8f9dcc) fldigi: 4.2.11 -> 4.2.13
* [`129fc8da`](https://github.com/NixOS/nixpkgs/commit/129fc8dad6844b5c725e2078095434227e336f68) unimatrix: 0-unstable-2023-04-25 -> 0-unstable-2026-05-20
* [`0e1ef3bc`](https://github.com/NixOS/nixpkgs/commit/0e1ef3bc11d47ed853f3156b8988d2035cd656fc) maintainers: add mmclinton
* [`f4d73063`](https://github.com/NixOS/nixpkgs/commit/f4d730636f2348e085e9cf428519d5be078de1bd) nmap: 7.99 -> 7.991
* [`2597a6b7`](https://github.com/NixOS/nixpkgs/commit/2597a6b7e5f4bb4d8397e82221f7131368f20136) spectral-mic: init at 0.8.0
* [`dc6f7941`](https://github.com/NixOS/nixpkgs/commit/dc6f7941c679a4e917b835a65a3a89d871f53cbe) postcss: 8.5.15 -> 8.5.26
* [`c7c13954`](https://github.com/NixOS/nixpkgs/commit/c7c1395400be8b46ca04b9a067c688d43e096022) mieru: 3.34.0 -> 3.35.0
* [`c106d56e`](https://github.com/NixOS/nixpkgs/commit/c106d56e49c0a9e2f2d28f42edd9da197723a637) lib.licenses: add blessing
* [`f47a3818`](https://github.com/NixOS/nixpkgs/commit/f47a3818e1dc9366830f44f9ba6d1ffa22ffabe9) sqlite: use blessing license
* [`40a49078`](https://github.com/NixOS/nixpkgs/commit/40a490784e10dfe9ed0b2fdf91c46af97226ddbd) unimatrix: trigger CI
* [`200f33a7`](https://github.com/NixOS/nixpkgs/commit/200f33a7332b8897c5a107606bd99259c93cdbba) nixos/getty: remove dash from closure if autologinOnce is disabled
* [`3058da3f`](https://github.com/NixOS/nixpkgs/commit/3058da3f7d74a2b181a02dbbe56834af43598107) mirrorbits: 0.6.1 -> 0.6.2
* [`a48e2014`](https://github.com/NixOS/nixpkgs/commit/a48e2014daf2ea8c71e80c23edab1ff8a8b3554d) steam-rom-manager: 2.5.43 -> 2.5.44
* [`bd870c99`](https://github.com/NixOS/nixpkgs/commit/bd870c99e77e416d17e0c72804f52bf060c77364) weaviate: 1.38.5 -> 1.39.0
* [`8a446854`](https://github.com/NixOS/nixpkgs/commit/8a446854863de54fe3c66ffa6cfd0a33401f75c0) flannel: 0.28.8 -> 0.28.9
* [`58eaccce`](https://github.com/NixOS/nixpkgs/commit/58eaccce94dbb0bed972b1628b5232f7e368854b) vultr-cli: 3.10.0 -> 3.11.0
* [`f5df7c0f`](https://github.com/NixOS/nixpkgs/commit/f5df7c0f7d6d4a2f8dae9b845fa31349627047d3) omnictl: 1.9.3 -> 1.10.0
* [`c12fc772`](https://github.com/NixOS/nixpkgs/commit/c12fc7722ae4d30235c0e80de9a0a9f22f98707f) pomerium-cli: 0.33.0 -> 0.33.1
* [`3a722d08`](https://github.com/NixOS/nixpkgs/commit/3a722d081ffa22dcfc3a7063724ccf8382eabf64) pik: 1.0.0 -> 1.0.1
* [`34825c64`](https://github.com/NixOS/nixpkgs/commit/34825c6438789ea083e63388e668c2cbfb55879d) lakefs: 1.85.0 -> 1.86.0
* [`a2841d8f`](https://github.com/NixOS/nixpkgs/commit/a2841d8f46047d64dec328da287b310c4844fe0b) sonarqube-cli: 1.4.0.3748 -> 1.5.0.4158
* [`aa30529d`](https://github.com/NixOS/nixpkgs/commit/aa30529d5a91248ef339eb796147fec60af4a8c1) the-powder-toy: 100.0.399 -> 100.1.400
* [`a81a97d9`](https://github.com/NixOS/nixpkgs/commit/a81a97d9ae3cd07031b0f4e2c6be5ead4877f45a) tree-sitter-grammars.tree-sitter-hledger: init at 0-unstable-2026-03-11
* [`cbe07dd0`](https://github.com/NixOS/nixpkgs/commit/cbe07dd0a160ef02fbbe7b7691c3208e300d3d59) chezmoi: 2.70.5 -> 2.72.0
* [`cd6f94ca`](https://github.com/NixOS/nixpkgs/commit/cd6f94caa8eea5063874f42a610fddfdc713c124) nixos/hostapd: fix WPA3 transition mode
* [`10fc77b5`](https://github.com/NixOS/nixpkgs/commit/10fc77b5cab1779e551db7ab61321f3e705365e6) stump: 0.1.5 -> 0.1.6
* [`cd3399fc`](https://github.com/NixOS/nixpkgs/commit/cd3399fc2386165925576a203e2cbb74dc531c79) gildas: 20260601_a -> 20260801_a
* [`226693cf`](https://github.com/NixOS/nixpkgs/commit/226693cf71d85956c6c0465897aa29f3f68e1da0) gnmic: 0.46.0 -> 0.47.0
* [`7a1cb9e6`](https://github.com/NixOS/nixpkgs/commit/7a1cb9e65e9ca4d19948c6a18c09d8c14af23f99) teamviewer: 15.78.3 -> 15.80.4
* [`3315d5b5`](https://github.com/NixOS/nixpkgs/commit/3315d5b526f42f20bbbbd7e8985da9fd4d147da8) gitolite: 3.6.14 -> 3.6.15
* [`fc7b58bd`](https://github.com/NixOS/nixpkgs/commit/fc7b58bd623f48ee1f8561a0172d68280f224a98) gogup: 1.7.1 -> 1.8.0
* [`20aad839`](https://github.com/NixOS/nixpkgs/commit/20aad83995cf1c4b8f88d35f45199ea477405d76) python3Packages.sanic: 25.12.0 -> 25.12.1
* [`8b420c4e`](https://github.com/NixOS/nixpkgs/commit/8b420c4eadcb3093d22cfbeda23521fbf73c6bd2) fluxcd-operator-mcp: 0.52.0 -> 0.58.0
* [`e2c97ea0`](https://github.com/NixOS/nixpkgs/commit/e2c97ea04fc447afd4fbd277d680bed3fd2caac6) listmonk: use tag as source
* [`856bb03f`](https://github.com/NixOS/nixpkgs/commit/856bb03fa0a2b5a9e4c493515c7e452c97a99a68) linuxPackages.nct6687d: 0-unstable-2026-03-13 -> 0-unstable-2026-08-08
* [`c662228c`](https://github.com/NixOS/nixpkgs/commit/c662228c3919032542a15c9756490691ce9c0164) home-assistant-custom-components.daikin_onecta: 4.6.13 -> 4.6.15
* [`7a9a1dfc`](https://github.com/NixOS/nixpkgs/commit/7a9a1dfca0adfa8dda905973fa5ed088b5a2dc4d) fava: 1.30.13 -> 1.30.14
* [`5f635dc7`](https://github.com/NixOS/nixpkgs/commit/5f635dc76952822880a92bacfb6603b12623f0ce) cdk8s-cli: 2.207.41 -> 2.207.47
* [`fafb923e`](https://github.com/NixOS/nixpkgs/commit/fafb923effaa4fc422420fc9ac54fb9171155af4) typst: Update typst packages from typst universe 08/09/2026
* [`afeec6f6`](https://github.com/NixOS/nixpkgs/commit/afeec6f6f2a1fbab8d33cee9f66993433586ba21) python3Packages.xstatic-font-awesome: format to pyproject
* [`d7e72246`](https://github.com/NixOS/nixpkgs/commit/d7e72246f178c635d0a7b1370ea8e64edd70edbc) python3Packages.django-admin-datta: format to pyproject
* [`48fd3033`](https://github.com/NixOS/nixpkgs/commit/48fd3033d7e71ce92d22558a915bad03439b68f1) rustical: 0.14.1 -> 0.15.0
* [`d2c59f4e`](https://github.com/NixOS/nixpkgs/commit/d2c59f4e96c395bf5f2fe18f5db10abed23ace10) nagios: 4.5.13 -> 4.5.14
* [`0489cc8a`](https://github.com/NixOS/nixpkgs/commit/0489cc8a4801ef441e142c591666ef8182d62e47) repomix: 1.16.1 -> 1.18.0
* [`832827f4`](https://github.com/NixOS/nixpkgs/commit/832827f40a9b95fa8e8103f0503eba0eb3b132a3) percona-server: provide separate client package
* [`d4b77de4`](https://github.com/NixOS/nixpkgs/commit/d4b77de4a03992635d3bfbcaa084646fb6c906a3) mariadb{,_106,_1011,_114,_118}: specify mainProgram for client and server
* [`c7df2b34`](https://github.com/NixOS/nixpkgs/commit/c7df2b348587f48d4fe83ecfd311a8e456beacc6) nixos/tests/mysql: use separate client packages
* [`f3fa5322`](https://github.com/NixOS/nixpkgs/commit/f3fa5322e10351cfa65c4547dfd75d13982c284d) mysql84: provide separate client package
* [`2fd02739`](https://github.com/NixOS/nixpkgs/commit/2fd02739f9c8faa8fd2c359340a26d9e21e10bca) nixosTests.mysql: clean ups
* [`58721266`](https://github.com/NixOS/nixpkgs/commit/587212660b6ee58a8c7fae87ac078ce22710849a) doc/rl-2611: mention mysql client packages
* [`beb166db`](https://github.com/NixOS/nixpkgs/commit/beb166db5fdda375259d4a94c449408c4824e13f) mysql84: use client package as dependencies for some packages
* [`c660ce10`](https://github.com/NixOS/nixpkgs/commit/c660ce10956a41792130d6992499cc0f89482200) mariadb: introduce finalAttrs to improve overridability
* [`659659a4`](https://github.com/NixOS/nixpkgs/commit/659659a4a7e8c73d7e3c7b8f2232e7563f194124) cobang: 2.5.2 -> 2.7.1
* [`c34fe3d7`](https://github.com/NixOS/nixpkgs/commit/c34fe3d767c9656df101070ffe7df6b1ddbeba04) komga: 1.25.0 -> 1.26.1
* [`894f2bb3`](https://github.com/NixOS/nixpkgs/commit/894f2bb355f727d0432750b32c15c0b5219962b1) jetbrains.rust-rover: 2026.2 -> 2026.2.1
* [`e2f92cc3`](https://github.com/NixOS/nixpkgs/commit/e2f92cc382e29bec96f0f47006789a46a89b1eb6) reticulum-go: 0.9.6 -> 1.0.1
* [`5e780a79`](https://github.com/NixOS/nixpkgs/commit/5e780a7986aa40745eff29a1eb29e2e0ff6966c2) go-containerregistry: 0.21.6 -> 0.21.9
* [`acd95e50`](https://github.com/NixOS/nixpkgs/commit/acd95e50dd3507df90654e7cbd0a376bdb767031) code: 0.6.162 -> 0.6.171
* [`5d2d5a90`](https://github.com/NixOS/nixpkgs/commit/5d2d5a90e21cbffc814b22ec81a8f45468572204) rosenpass: 0.2.2 -> 0.2.3
* [`95609abe`](https://github.com/NixOS/nixpkgs/commit/95609abe35a8baacb067c3940f0ac25294b9bf5e) pureref: add updateScript
* [`2743a20d`](https://github.com/NixOS/nixpkgs/commit/2743a20db7ba62de7dba12588ebd98d2d7a15629) openbsd: fix eval on riscv64-linux
* [`b71bd5f8`](https://github.com/NixOS/nixpkgs/commit/b71bd5f8eb962f1f1bdecb165c2dfc0805a18bc9) neargye-semver: 0.3.1 -> 1.0.1
* [`149fd233`](https://github.com/NixOS/nixpkgs/commit/149fd233b4adf4daa1af0018e4671a531005605b) python3Packages.django-contrib-comments: format to pyproject
* [`2ca0d3e5`](https://github.com/NixOS/nixpkgs/commit/2ca0d3e58e1ce697cb3adf6d82755dc7459883ef) python3Packages.google-cloud-audit-log: 0.6.0 -> 0.6.1
* [`54a72342`](https://github.com/NixOS/nixpkgs/commit/54a7234250767692bd742afc9d873354957f9256) rocksndiamonds: 4.4.2.2 -> 4.4.2.4
* [`8694cc91`](https://github.com/NixOS/nixpkgs/commit/8694cc911c10f4c8625cb19f11a630b666eae028) lxmf-rs: 0.9.7 -> 0.9.8
* [`8559b584`](https://github.com/NixOS/nixpkgs/commit/8559b58434eb136d1892aa68ea6d680dcb4f3cff) cef-binary: 149.0.5 -> 151.3.16
* [`5186d3a7`](https://github.com/NixOS/nixpkgs/commit/5186d3a70db52fd6664e8282f04a3c13a8d020d3) haskellPackages.hnix-store-nar: init at 0.1.2.0
* [`368fb95a`](https://github.com/NixOS/nixpkgs/commit/368fb95ad952c107228cae081e5e2379a565dbab) cachix: 1.11.1 -> 1.12.0
* [`7d9551f6`](https://github.com/NixOS/nixpkgs/commit/7d9551f6ceb6e05d8fd26c966a42688665470567) python3Packages.langgraph-checkpoint: 4.1.1 -> 4.2.0
* [`2f6ca561`](https://github.com/NixOS/nixpkgs/commit/2f6ca56124e5e50b13ad1e8141557495263b8a8f) python3Packages.tree-sitter-zeek: 0.2.15 -> 0.2.16
* [`ec1c60c9`](https://github.com/NixOS/nixpkgs/commit/ec1c60c92eb9f7c21475ab15dded686e56d22233) inshellisense: 0.0.2 -> 0.0.3
* [`8e863104`](https://github.com/NixOS/nixpkgs/commit/8e8631042e92e5f890823a24a42fe4e3a147d94e) pantheon.switchboard-with-plugs: use structuredAttrs instead of passAsFile
* [`e2255804`](https://github.com/NixOS/nixpkgs/commit/e225580444614fbd7a07f2105cbe5ec5ea4c544a) pantheon.wingpanel-with-indicators: use structuredAttrs instead of passAsFile
* [`0f5b0252`](https://github.com/NixOS/nixpkgs/commit/0f5b025268375fc4e2268836f23e34bd1152597f) home-assistant-custom-components.bodymiscale: 2026.7.0 -> 2026.8.0
* [`80993d97`](https://github.com/NixOS/nixpkgs/commit/80993d97e234b09813f8b04e402dcfbe874700b8) aws-lc: 5.0.0 -> 5.5.0
* [`fab298bd`](https://github.com/NixOS/nixpkgs/commit/fab298bd49ee5ee550fb7d503cb77d85d35090ce) pfcpsim: init at 1.4.4
* [`1993a792`](https://github.com/NixOS/nixpkgs/commit/1993a792e1d557852fe0d457afd1777a805c69a3) python3Packages.cftime: migrate to pyproject
* [`d2ecc015`](https://github.com/NixOS/nixpkgs/commit/d2ecc015b89b871aacc93edc9d5316b7e7c2b0cf) python3Packages.cftime: use finalAttrs
* [`a54e6a37`](https://github.com/NixOS/nixpkgs/commit/a54e6a37a9d754aa6c14ca3ffbba47611a419054) python3Packages.cftime: add changelog
* [`c51160df`](https://github.com/NixOS/nixpkgs/commit/c51160df39c306c9f33b03ce6fda34c4987c5dab) fava: simplify frontend compilation
* [`3899048f`](https://github.com/NixOS/nixpkgs/commit/3899048f8e177410dacdccbb25be50badd161678) python3Packages.google-cloud-storage-control: 1.12.0 -> 1.13.0
* [`7cf63182`](https://github.com/NixOS/nixpkgs/commit/7cf6318212ee4178a53e3af3035597752391a92f) dokuwiki: 2026-07-14a -> 2026-07-14b
* [`00a6f7bd`](https://github.com/NixOS/nixpkgs/commit/00a6f7bd33f6bd41ef4b1ebafd12058e84d8e0ef) eigenwallet: 4.10.0 -> 4.13.3
* [`771a83d1`](https://github.com/NixOS/nixpkgs/commit/771a83d12b394b92454e179dd71918d041ea0e0b) cnijfilter_4_00: unpin gcc13, pass -std=c90
* [`e093801d`](https://github.com/NixOS/nixpkgs/commit/e093801d692f238dff3f63e68fd5ade720ad5928) yandex-cloud: 0.193.0 -> 1.25.0
* [`4797802f`](https://github.com/NixOS/nixpkgs/commit/4797802f4adb3501815d8c399df6eb6d6167b0f8) gh-aw: 0.83.1 -> 0.85.4
* [`3eaa2e40`](https://github.com/NixOS/nixpkgs/commit/3eaa2e40ba8af00a24ce8710db9a235d7dd7ccfb) ubridge: 1.0.1 -> 1.2.1
* [`39a5c2f9`](https://github.com/NixOS/nixpkgs/commit/39a5c2f99535e284f535070b761d20321fed87c5) gearboy: 3.8.11 -> 3.8.12
* [`27d54b78`](https://github.com/NixOS/nixpkgs/commit/27d54b78e2ca6bfd149e4722a27b68a2ed594279) telepresence2: 2.27.3 -> 2.31.2
* [`9280b09b`](https://github.com/NixOS/nixpkgs/commit/9280b09b198a54ef58ac7975c425d0fa944d03ee) containerlab: 0.76.1 -> 0.78.0
* [`c9678586`](https://github.com/NixOS/nixpkgs/commit/c9678586835dad07d94f67b5052b962c7d223a3c) nixos/getty: writeDash -> writeShellApplication for autologinOnce
* [`653db2a3`](https://github.com/NixOS/nixpkgs/commit/653db2a3394f6355d9d45405df490d26ac7537a6) vscode-extensions.oxc.oxc-vscode: 1.59.0 -> 1.60.0
* [`79512e2b`](https://github.com/NixOS/nixpkgs/commit/79512e2b6903c4907a0f09b039f04e3994141a44) directx-shader-compiler: 1.10.2605.24 -> 1.10.2605.37
* [`3e918620`](https://github.com/NixOS/nixpkgs/commit/3e9186206e37c0f26a734ba7c05d5a283ebbe298) qemu: build, check and install via Make
* [`dbdfa5ea`](https://github.com/NixOS/nixpkgs/commit/dbdfa5ea418b2ef58446fa2207c9563667b4b9cf) qemu: remove obsolete substitution
* [`2febe9cf`](https://github.com/NixOS/nixpkgs/commit/2febe9cff51e904a39bef44048b32e44664200b9) qemu: --replace -> --replace-fail
* [`e76f373e`](https://github.com/NixOS/nixpkgs/commit/e76f373ea39f8687d28be327ffc8139a8423745f) qemu: 11.0.3 -> 11.1.0
* [`f7c5354b`](https://github.com/NixOS/nixpkgs/commit/f7c5354bb9f0574dd12a84cce8303b0696a8efbc) home-assistant-custom-components.ingress: 1.3.0 -> 1.3.2
* [`89402ee0`](https://github.com/NixOS/nixpkgs/commit/89402ee03db854bbdd472cccd2748d63870acb39) genemichaels: 0.9.6 -> 0.12.2
* [`89568758`](https://github.com/NixOS/nixpkgs/commit/8956875863aa283c08f2f9f43dcfb9316ebcfab7) fosrl-pangolin: 1.21.0 -> 1.21.1
* [`5a83b159`](https://github.com/NixOS/nixpkgs/commit/5a83b159a1557d8398a47ef487e0328b61f18cd6) whitesur-icon-theme: 2025-12-27 -> 2026-08-11
* [`4a0b344b`](https://github.com/NixOS/nixpkgs/commit/4a0b344b08dff7fd93738a76c9f77553836ee5d7) firecrawl-cli: init at 1.20.0
* [`336b5b48`](https://github.com/NixOS/nixpkgs/commit/336b5b489ab41d5cea534a77d8e0429e5320ce20) firecrawl-mcp: init at 3.24.0
* [`8be30817`](https://github.com/NixOS/nixpkgs/commit/8be30817629dcaf5a2a811e8f55ed36136e78228) python3Packages.pybase64: 1.4.3 -> 1.5.0
* [`3af94254`](https://github.com/NixOS/nixpkgs/commit/3af94254ebc8b8c1a846fdfd74b949f8a1935f2e) chatgpt: split into chatgpt and chatgpt-classic
* [`a3d00153`](https://github.com/NixOS/nixpkgs/commit/a3d00153f937106af5b3f5754ae89a9e1cd7dfdb) maintainers: add nolight132
* [`aea3c5ec`](https://github.com/NixOS/nixpkgs/commit/aea3c5ec69899a17bc3cfc06713259424ab71fc4) coccinelle: modern derivation, move args out of top-level
* [`0ef414db`](https://github.com/NixOS/nixpkgs/commit/0ef414db0c096f585705485ee2a700af50ab5059) coccinelle: migrate to by-name
* [`03902513`](https://github.com/NixOS/nixpkgs/commit/03902513113bb004aa348f348e53513d29d4de58) npm-lockfile-fix: add cacert for Darwin sandbox
* [`3848af11`](https://github.com/NixOS/nixpkgs/commit/3848af11ed4ee270e23039db84b7a7f9a4d996c4) _2ship2harkinian: 4.0.2 -> 5.0.0
* [`fd03211c`](https://github.com/NixOS/nixpkgs/commit/fd03211cbace30c86ffa2ec8f5bc8d74781042ce) lenovo-legion: 0.0.20-unstable-2026-05-12 -> 0.0.21-unstable-2026-08-07
* [`92cc458e`](https://github.com/NixOS/nixpkgs/commit/92cc458e18e3240858e8fcd22856c6fab33a49bb) terser: 5.47.1 -> 5.49.2
* [`417f6f6f`](https://github.com/NixOS/nixpkgs/commit/417f6f6fdbe63f1cafffe613d06aaf76c84aae51) python3Packages.lark-oapi: 1.7.1 -> 1.7.2
* [`c1014f70`](https://github.com/NixOS/nixpkgs/commit/c1014f7070ba1ffee0b87f7bfd964e5bd7bb26a0) python3Packages.hydra-core: 1.3.4 -> 1.3.5
* [`3a00dffc`](https://github.com/NixOS/nixpkgs/commit/3a00dffcb03a5cc64a75448c4ebe6e65e2749972) ty: 0.0.70 -> 0.0.71
* [`8f54e9f2`](https://github.com/NixOS/nixpkgs/commit/8f54e9f26c67117275ea5620f205a77dcb934793) nixos/prometheus-exporters/kvrocks: init
* [`b350ef75`](https://github.com/NixOS/nixpkgs/commit/b350ef752a8d12dd34a24923265f4758b23c5833) openssh: 10.4p1 -> 10.5p1
* [`270ca476`](https://github.com/NixOS/nixpkgs/commit/270ca476883da5aaabd7a195773cccd207b4b2ae) openssh_hpn: 10.3p1 -> 10.5p1
* [`c6abd8aa`](https://github.com/NixOS/nixpkgs/commit/c6abd8aadb81010c2d4fec16f23f016403a4c667) slackdump: 4.3.0 -> 4.4.3
* [`670f473e`](https://github.com/NixOS/nixpkgs/commit/670f473e0aca91adf52aa9b8922a366bf9ef32af) blackmagic-desktop-video: 16.0 -> 16.3
* [`2280f2bb`](https://github.com/NixOS/nixpkgs/commit/2280f2bb2a14b3b6448f7df9ad66f3e06d1ab22b) vikunja: build veans package
* [`6bde8a74`](https://github.com/NixOS/nixpkgs/commit/6bde8a74e22d7f9923fca5ed78dd90cdcd0fc13f) ante: 0-unstable-2025-07-12 -> 0-unstable-2026-08-11, llvmPackages_18 -> llvmPackages_21
* [`e465c6fc`](https://github.com/NixOS/nixpkgs/commit/e465c6fcc2ce7fbc80006282379611c67de80eed) python3Packages.adlfs: 2026.5.0 -> 2026.8.0
* [`7c6e3c03`](https://github.com/NixOS/nixpkgs/commit/7c6e3c03df8883c44b4ac85c0702c3b8943eee37) adaptivecpp: 25.02.0 -> 25.10.0, llvmPackages_18 -> llvmPackages_20
* [`2cfa66b0`](https://github.com/NixOS/nixpkgs/commit/2cfa66b08fcbbd8d70728329f1f702e74db3d9a9) intel-npu-driver: 1.28.0 -> 1.35.0
* [`e890d003`](https://github.com/NixOS/nixpkgs/commit/e890d0032f07097fb38d6a2c6ca684d2ed7e60d5) nixos-generate-config: update Intel NPU PCI IDs
* [`a55050b6`](https://github.com/NixOS/nixpkgs/commit/a55050b6a4a924e874fe8da52d6c13b887e12859) formats.yaml_1_1,formats.yaml_1_2: add tags option
* [`f0157fb6`](https://github.com/NixOS/nixpkgs/commit/f0157fb6f68b626c1b80ed80f537f4c55af020a3) ruff: 0.16.2 -> 0.16.3
* [`824db64f`](https://github.com/NixOS/nixpkgs/commit/824db64fa6d71155a0c101d6a8ef288252346f24) python3Packages.pytest-playwright: 0.8.0 -> 0.9.0
* [`52525902`](https://github.com/NixOS/nixpkgs/commit/5252590203eca927b74d473481b94db0a8efeb97) ioquake3: fix riscv cross-compilation
* [`c03ab83f`](https://github.com/NixOS/nixpkgs/commit/c03ab83f8e27efa1c93d96b81e021ce7855d017f) files-cli: 2.15.381 -> 2.15.442
* [`4cdf6cae`](https://github.com/NixOS/nixpkgs/commit/4cdf6cae6f4f221120ae97843b13385ab98f4c14) nixos/qemu-vm: drop useSecureBoot, always use OVMFFull
* [`e530d4fc`](https://github.com/NixOS/nixpkgs/commit/e530d4fc30be04fb65dceb980ad7cab21d7ae065) vicinae: 0.23.2 -> 0.25.0
* [`2aea93e0`](https://github.com/NixOS/nixpkgs/commit/2aea93e065800ee03f0cfd73d55df085817d3a71) wayvr: 26.7.1 -> 26.8.0
* [`95d30c22`](https://github.com/NixOS/nixpkgs/commit/95d30c22ffd927dd7f176d5f5e6340920c06ff07) wayvr: fix xwayland-satellite executable path
* [`01dc2822`](https://github.com/NixOS/nixpkgs/commit/01dc282204efbfb4ba7c53aacada0576a183b534) wayvr: patch uidev rpath so dlopen'd dependencies are found
* [`22fead9e`](https://github.com/NixOS/nixpkgs/commit/22fead9e5f259949025d49ce61d120bdf4440781) wayvr: add me as maintainer
* [`7f1ced7b`](https://github.com/NixOS/nixpkgs/commit/7f1ced7b075d0dff12542f80bf952e81b05e014b) maintainers: add ceridwen15
* [`7e014df8`](https://github.com/NixOS/nixpkgs/commit/7e014df80a534bb6e64be8cd56bd67965abff159) wine-staging: 11.14 -> 11.15
* [`beac5ec1`](https://github.com/NixOS/nixpkgs/commit/beac5ec1a1fb36f47e8e141062d869380c38dff8) amneziawg-go: 3.0.3 -> 3.1.20260814
* [`b3396e74`](https://github.com/NixOS/nixpkgs/commit/b3396e74833af485adc75ccd174277fa1cb04557) python3Packages.aiohttp-socks: 0.11.0 -> 0.12.0
* [`441c65f4`](https://github.com/NixOS/nixpkgs/commit/441c65f443dcd2fd0d3a542e64062f84b8f456e0) lark-cli: add updateScript
* [`94d8e54d`](https://github.com/NixOS/nixpkgs/commit/94d8e54d0ca2526181169d5f6cb57303dfcc360e) pb: 0.7.0 -> 1.0.0
* [`93f4274d`](https://github.com/NixOS/nixpkgs/commit/93f4274dcbfe6360881c2159fe82f76ac4fca2b9) v2rayn: 7.24.5 -> 7.24.6
* [`3445bb88`](https://github.com/NixOS/nixpkgs/commit/3445bb88e7d175f204ad218e07f4fb3c924d16e9) graphify: 0.9.28 -> 0.9.42
* [`bb2d51d1`](https://github.com/NixOS/nixpkgs/commit/bb2d51d1d6ace75f4c953b080bd2d31e7e04dff0) qtcreator: 19.0.1 -> 20.0.1
* [`a3a60720`](https://github.com/NixOS/nixpkgs/commit/a3a6072022aefb369d4455e3a7b6cad202e9d91e) mchprs: 0.5.1 -> 0.5.2
* [`85facaec`](https://github.com/NixOS/nixpkgs/commit/85facaec869342592fa91a71f47a84f0fbdf451e) libfishsound: 1.0.0 -> 1.0.1
* [`8a41621d`](https://github.com/NixOS/nixpkgs/commit/8a41621d41f6428181a4af5ec95ddbade194b681) python3Packages.wfuzz: fix build
* [`9f704839`](https://github.com/NixOS/nixpkgs/commit/9f70483965a821a98915899f8b268541cb0c7c28) python3Packages.wfuzz: vendor patch
* [`526ab2a3`](https://github.com/NixOS/nixpkgs/commit/526ab2a38c0a74a8cebe200e68860cda80581df2) python3Packages.wfuzz: use writableTmpDirAsHomeHook
* [`3551d0f0`](https://github.com/NixOS/nixpkgs/commit/3551d0f06369d1ad70e43956fd6933428bb65994) nixos/doc/rl-2611: Mention minimal postgresql requirement for gitlab 19
* [`b5fd9528`](https://github.com/NixOS/nixpkgs/commit/b5fd952888bbc7a13b05a0cf8964b0fd8eae4d89) cni-plugin-flannel: update source hash
* [`f25f4a9b`](https://github.com/NixOS/nixpkgs/commit/f25f4a9bd7bc9ce0d507f49b877e0a74aa309f71) wealthfolio-server: 3.6.2 -> 3.6.3
* [`214fc7d7`](https://github.com/NixOS/nixpkgs/commit/214fc7d76ae18a24eab4935153548a0052785463) cni-plugin-flannel: add antoineco to maintainers
* [`89789946`](https://github.com/NixOS/nixpkgs/commit/897899460a8811ed34b868e368694fb2c31e7e35) gitlab: 19.0.4 -> 19.2.2
* [`4188789b`](https://github.com/NixOS/nixpkgs/commit/4188789b70600867285dde96d1d69156ad86d75f) nixos/krill: init
* [`b6e03e62`](https://github.com/NixOS/nixpkgs/commit/b6e03e62a22f1d31ca0e1d066fda46e2c8704979) nixos/tests/krill: init
* [`52de0c60`](https://github.com/NixOS/nixpkgs/commit/52de0c604fda338ac2bf44f161fe580b87021b2b) nixos/gitlab: add another state folder
* [`c2e32682`](https://github.com/NixOS/nixpkgs/commit/c2e32682650bd29f65d5472198bfa95ff2c9f8ee) python3Packages.drf-spectacular-sidecar: 2026.7.1 -> 2026.8.1
* [`04f5d2a2`](https://github.com/NixOS/nixpkgs/commit/04f5d2a224d413a617598bee5a9bc45f1e0e4c2e) ankacoder: migrate to finalAttrs, use installFonts
* [`4985404c`](https://github.com/NixOS/nixpkgs/commit/4985404c5380e71300e8577b4bde813ddb965a70) perlPackages.Test2Harness: not broken on Darwin anymore
* [`130148d9`](https://github.com/NixOS/nixpkgs/commit/130148d9088e13b5114fbeceb4d625fdb7683ca1) libpqxx: Only override stdenv for GCC, not for clang
* [`eb904152`](https://github.com/NixOS/nixpkgs/commit/eb9041526d7e81bac2c16a8d0509b44b7daa4238) perlPackages.HashSharedMem: 0.005 -> 0.006
* [`8ef92c2e`](https://github.com/NixOS/nixpkgs/commit/8ef92c2e370cd8f65615c76acc3a67430995bbcd) spotify: update ffmpeg from 4 to 7
* [`9aa74de0`](https://github.com/NixOS/nixpkgs/commit/9aa74de08272f68284a1aa864d6de6b6b1999205) kodiPackages.controller-topology-project: 1.0.11 -> 1.0.13
* [`959b3fe5`](https://github.com/NixOS/nixpkgs/commit/959b3fe57e8e12bae3e76162d0ae10331439ecf8) newlib-cygwin: declare the thread model and mark the headers-only build
* [`a2b6a1c0`](https://github.com/NixOS/nixpkgs/commit/a2b6a1c0c30325918df6449c5b485c20fa232f2f) dump_syms: 2.3.8 -> 2.3.9
* [`e2520630`](https://github.com/NixOS/nixpkgs/commit/e25206301a146bc357bdbef6ca433d1b5f0f495f) python3.passthru.doc: enable strictDeps, structuredAttrs
* [`58cdb3ff`](https://github.com/NixOS/nixpkgs/commit/58cdb3ff23e4963500a375bf984ddbd90bca40b3) b3sum: 1.8.5 -> 1.8.6
* [`3013771f`](https://github.com/NixOS/nixpkgs/commit/3013771f94802c8ebe9f8c555a855ec32394daad) cargo-rdme: 2.2.0 -> 2.2.1
* [`a1176b9e`](https://github.com/NixOS/nixpkgs/commit/a1176b9ee76d2e2cbffc88ac08b6d174f242de35) gutenprint: remove `gimp2Support` since `gimp2` is deprecated
* [`08d09573`](https://github.com/NixOS/nixpkgs/commit/08d0957397f35b4a4831001381839d7c0f76d288) secretspec-ffi: reduce library size
* [`5c365368`](https://github.com/NixOS/nixpkgs/commit/5c365368a625a39d5262bd3db12d73cc2b46fcf7) libgit2: 1.9.4 -> 1.9.7
* [`7817c77a`](https://github.com/NixOS/nixpkgs/commit/7817c77a65fd972f1d7c0b7c8fe05c888f81090d) knockoutcitylauncher: init at 2.4.6
* [`87f880bb`](https://github.com/NixOS/nixpkgs/commit/87f880bbc5a393b4e8ecc6a8e8b8f4fd639fceb7) globalplatform: 2.4.2 -> 3.0.0
* [`d96a126e`](https://github.com/NixOS/nixpkgs/commit/d96a126ee8f0a2eb5d49fd3fdc166103700583e6) taskjuggler: 3.8.1 -> 3.8.4
* [`45b29785`](https://github.com/NixOS/nixpkgs/commit/45b29785f2baeafe68f99265c46912414c4aee61) zellij-unwrapped: make web server optional
* [`8d069a25`](https://github.com/NixOS/nixpkgs/commit/8d069a2582fc83270f3576656fab8fec5e0ca4e0) mediawiki: 1.45.4 -> 1.46.0
* [`9e15c84f`](https://github.com/NixOS/nixpkgs/commit/9e15c84f58571d270caa3dfc3d4898b9dacd0ee3) nixos/tests/mediawiki: migrate to containers
* [`1d6a6434`](https://github.com/NixOS/nixpkgs/commit/1d6a64346c0062899c8478d2554724093f017157) ammonite: add agilesteel as maintainer
* [`8d07bd18`](https://github.com/NixOS/nixpkgs/commit/8d07bd18ab61b189087fd56cf1307658a7166b9f) ammonite: pin the packaged jre
* [`9b95c296`](https://github.com/NixOS/nixpkgs/commit/9b95c2963108b0ac7a36ba67372ee4debc56c422) ammonite: limit platforms to those the jre supports
* [`86783af9`](https://github.com/NixOS/nixpkgs/commit/86783af97da71c65d350f3411b0325c580f507ed) ammonite: rework update script
* [`adbce884`](https://github.com/NixOS/nixpkgs/commit/adbce88404ee295286cf3c6977cf29c4b9c63c34) ammonite: fill in meta
* [`9c433886`](https://github.com/NixOS/nixpkgs/commit/9c4338865e46f8e2f1db8c560973003a7869d579) ammonite: always give the launcher a shebang
* [`f94d2111`](https://github.com/NixOS/nixpkgs/commit/f94d2111ce7796af69e3ddac5f14048bb3dee65c) ammonite: drop the disableRemoteLogging argument
* [`e55394a1`](https://github.com/NixOS/nixpkgs/commit/e55394a12b7c26918648367d4fcf0465c83846cd) ammonite: pass the packaged jre to child processes
* [`007dcd6b`](https://github.com/NixOS/nixpkgs/commit/007dcd6b29108cde40e36d07755e2b7c707a4b15) bloop: fix stale fish completions
* [`08651af9`](https://github.com/NixOS/nixpkgs/commit/08651af96e2468c76b790ea284f97f33a17bf2b2) bloop: drop dead x86_64-darwin asset
* [`4524d6c7`](https://github.com/NixOS/nixpkgs/commit/4524d6c79d525c05305d89971bd15d4c0f32e3c3) bloop: move sources into sources.json
* [`3e7f7b6e`](https://github.com/NixOS/nixpkgs/commit/3e7f7b6ecd45cea554d6fb87626b9fddbb606f6c) ammonite: require Java 11 or newer
* [`3d05d7dd`](https://github.com/NixOS/nixpkgs/commit/3d05d7dd470fbba43973e3dd080ff161c615b41a) bloop: add passthru test
* [`9081ee55`](https://github.com/NixOS/nixpkgs/commit/9081ee558494230b1535bb216c94a894cf890c6b) ammonite: name the scala version in the description
* [`a614f262`](https://github.com/NixOS/nixpkgs/commit/a614f2623a8f679523667e463be653cc2bf30256) coursier: add agilesteel as maintainer
* [`32dc321a`](https://github.com/NixOS/nixpkgs/commit/32dc321aa955eedcaac8e5c69aca600231cc5a2a) coursier: limit platforms to those the jre supports
* [`e75a833b`](https://github.com/NixOS/nixpkgs/commit/e75a833b889dad31243f595b43a3b20794a63ae9) coursier: fill in meta
* [`76b0c643`](https://github.com/NixOS/nixpkgs/commit/76b0c643ca7e715999c3995207e6a1b6dfdc6c7d) coursier: rework update script
* [`3747e084`](https://github.com/NixOS/nixpkgs/commit/3747e0844422099dda4131c786069604c58cd3a7) coursier: pass the packaged jre to child processes
* [`ecff117c`](https://github.com/NixOS/nixpkgs/commit/ecff117c0b3f9a352948a0710c6893824de995ab) metals: add agilesteel as maintainer
* [`10a31933`](https://github.com/NixOS/nixpkgs/commit/10a319331c44455432260202d872cdc9d36b63d7) metals: drop dead coursier resolvers
* [`d9266c2b`](https://github.com/NixOS/nixpkgs/commit/d9266c2b3cdbe7660b8f65b786aa05298bf37526) metals: stop leaking deps and extraJavaOpts into the build
* [`f79ea254`](https://github.com/NixOS/nixpkgs/commit/f79ea25431a11532af3a5266ff123f664dc47ae4) metals: run the install hooks
* [`881b2476`](https://github.com/NixOS/nixpkgs/commit/881b2476ddd91d8781b91a26e6a1457bd19ab20f) metals: fill in meta
* [`71f437dc`](https://github.com/NixOS/nixpkgs/commit/71f437dc50b1dd4b57ff17174e4489104b0e8c86) mill: add agilesteel as maintainer
* [`c7669ff9`](https://github.com/NixOS/nixpkgs/commit/c7669ff9c0d8b190eb6e29a09e4e3e7c8110dc52) mill: fix preferLocalBuild typo
* [`62740768`](https://github.com/NixOS/nixpkgs/commit/627407680bf64ac3e585d83ab5c50ffda852e165) mill: add changelog to meta
* [`80ecba1f`](https://github.com/NixOS/nixpkgs/commit/80ecba1f7f6c533abce5cd9d97ccbbbd49a8e191) mill: collapse the platform tables
* [`bb281ebb`](https://github.com/NixOS/nixpkgs/commit/bb281ebb7c3f89d4bbc47d36d02b5d239f6841bd) mill: rework update script
* [`cb59e51d`](https://github.com/NixOS/nixpkgs/commit/cb59e51d99a1bab62e8ece8157284fd0c5ca244f) mill: 1.1.7 -> 1.1.8
* [`867a1a78`](https://github.com/NixOS/nixpkgs/commit/867a1a78a39fedb088832daef84755733b26dafb) mill: pin JAVA_HOME rather than defaulting it
* [`575b4919`](https://github.com/NixOS/nixpkgs/commit/575b4919e43dc0986ab2cb9b0ad0b7850a4f6ba1) sbt: move to pkgs/by-name
* [`142941fd`](https://github.com/NixOS/nixpkgs/commit/142941fdcf873189b43cf8fe075b06401411f212) mill: require Java 17 or newer
* [`8117b3d9`](https://github.com/NixOS/nixpkgs/commit/8117b3d9ba32a0a5e9cf7e1e9f5a85a1b321d685) sbt: add agilesteel as maintainer
* [`a76f1df4`](https://github.com/NixOS/nixpkgs/commit/a76f1df43198a47fd9759d6fcfbada2dddb66ee6) sbt: 1.12.13 -> 2.0.6
* [`5862b549`](https://github.com/NixOS/nixpkgs/commit/5862b54947f11fc1836c6bf09162c74564efbe22) sbt: require Java 17 or newer
* [`0cde6c77`](https://github.com/NixOS/nixpkgs/commit/0cde6c774f50366f90bea2814391dc945cf5d926) sbt: fix license
* [`fbb83045`](https://github.com/NixOS/nixpkgs/commit/fbb83045e584cfdac311b99419a5de5caa330693) sbt: add changelog to meta
* [`37373885`](https://github.com/NixOS/nixpkgs/commit/3737388577512dd61c5d34cb74f87a366195f4c4) sbt: only install sbtn where upstream ships one
* [`c7348201`](https://github.com/NixOS/nixpkgs/commit/c73482011760ecc868762f4c91fcc41a1a28f612) sbt: limit platforms to those the jre supports
* [`e2b08cee`](https://github.com/NixOS/nixpkgs/commit/e2b08cee63b8cddc997d7e5a9abaa5576a895650) sbt: put ncurses on PATH instead of propagating it
* [`ad200d88`](https://github.com/NixOS/nixpkgs/commit/ad200d888f862ea423c8bb8006476a96c0be9e81) sbt: add an install check
* [`75f0cb85`](https://github.com/NixOS/nixpkgs/commit/75f0cb85baf8cf79c87de1223cd786ef0bdc764f) sbt: add a passthru test
* [`a3e1a87d`](https://github.com/NixOS/nixpkgs/commit/a3e1a87d406abbeb7636b679627fe106a5512179) sbt: add an update script
* [`e2da40fd`](https://github.com/NixOS/nixpkgs/commit/e2da40fd9dedd730b7e2f5140da03c0e754c257b) sbt-with-scala-native: mention the toolchain in the description
* [`3d0af17b`](https://github.com/NixOS/nixpkgs/commit/3d0af17bec4aa6594e445e462b335b0c60e93c00) scala-cli: use SRI hashes in sources.json
* [`94418ccb`](https://github.com/NixOS/nixpkgs/commit/94418ccbb397c7a652ca28483eff100a70fcf8da) sbt-with-scala-native: wrap sbtn as well
* [`0ff6cbfc`](https://github.com/NixOS/nixpkgs/commit/0ff6cbfc19654f1da76c69803f52278e896754ae) nixos/tests/mediawiki: drop random extension
* [`478ef0a5`](https://github.com/NixOS/nixpkgs/commit/478ef0a5bad9110485f114839bc140c49387ef1f) nixos/tests/mediawiki: reduce code duplication
* [`e8a42ba6`](https://github.com/NixOS/nixpkgs/commit/e8a42ba6f764954e8b7de5cf64c2d4f1987817d5) proftpd: 1.3.9c -> 1.3.9d
* [`22968a14`](https://github.com/NixOS/nixpkgs/commit/22968a14bb1b4fd331bceba97f7485c3b102a6f5) protonup-rs: 0.14.0 -> 0.15.0
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
