### PR TITLE
npins home-manager: update 35374258 -> 03f4cd46

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -48,9 +48,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "353742587cbaf079b3caee743115d037bc51fea6",
-      "url": "https://github.com/nix-community/home-manager/archive/353742587cbaf079b3caee743115d037bc51fea6.tar.gz",
-      "hash": "sha256-MTGMFlLDTklsXhCp4r5GXB4VAVadPdalXLvUjd/K7h0="
+      "revision": "03f4cd46bc1dd4f3a96da778d2ce9f7ce39dd450",
+      "url": "https://github.com/nix-community/home-manager/archive/03f4cd46bc1dd4f3a96da778d2ce9f7ce39dd450.tar.gz",
+      "hash": "sha256-MHwk52ty3NsLhq9a1IbIfBJZlCUJIdiUYFo52JLK9hY="
     },
     "hs-grille": {
       "type": "Git",


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@35374258...03f4cd46](https://github.com/nix-community/home-manager/compare/353742587cbaf079b3caee743115d037bc51fea6...03f4cd46bc1dd4f3a96da778d2ce9f7ce39dd450)

* [`08283c74`](https://github.com/nix-community/home-manager/commit/08283c7415b39431abf7e41ca295304c84ef5f3e) flake: bump nixpkgs from `38a4887` to `d482ef8`
* [`7e6826db`](https://github.com/nix-community/home-manager/commit/7e6826db49e41cddc38abc93f30b8e7c180da64c) hexchat: remove module
* [`02de3cc0`](https://github.com/nix-community/home-manager/commit/02de3cc079e458a24d34a4b3931db1df0c46d60e) tests/services-modular: drop empty ExecReload expectation
* [`79a57dd9`](https://github.com/nix-community/home-manager/commit/79a57dd996228885860b7067f62414f02a4c28ac) tests/neovim: give the stub a real license
* [`3c3ede6a`](https://github.com/nix-community/home-manager/commit/3c3ede6ad886a6d9b0938ef19112523118fe62c2) tests: update YAML expectations for remarshal v2
* [`152b9dca`](https://github.com/nix-community/home-manager/commit/152b9dcad099ed3d85d4f90152a110dd8b84c73f) maintainers: update all-maintainers.nix
* [`c53d643b`](https://github.com/nix-community/home-manager/commit/c53d643b3737e2fcd04e6cb3b3580ef50b2087a0) atuin: replace outdated links leading to error 404
* [`da8581b1`](https://github.com/nix-community/home-manager/commit/da8581b115968db9dc8a497c89339a99e7b6bf1a) flake: bump nixpkgs from `6b5e5b7` to `b47ad65`
* [`43bf54a9`](https://github.com/nix-community/home-manager/commit/43bf54a92f024091605ce818146d49e1179ada0d) animdl: remove module
* [`42c3fc30`](https://github.com/nix-community/home-manager/commit/42c3fc301e4df2125bf2e39962b19888a096258b) maintainers: remove duplicate nixpkgs maintainers
* [`ec1a8fdf`](https://github.com/nix-community/home-manager/commit/ec1a8fdf74ed3f276148ee106299a2ba0e65d51f) maintainers: update all-maintainers.nix
* [`cfba7ad5`](https://github.com/nix-community/home-manager/commit/cfba7ad5886b342b8dd63ba74354b3853ea4cfc9) khard: Avoid absolute path literal
* [`15253ef5`](https://github.com/nix-community/home-manager/commit/15253ef574d6ec6ef1b9b137e5099eefff644f09) eilmeldung: init module
* [`1cdf49fd`](https://github.com/nix-community/home-manager/commit/1cdf49fd9b36e56aa827b020b3e6afab74eaa516) Translate using Weblate (Chinese (Traditional Han script))
* [`ef01547e`](https://github.com/nix-community/home-manager/commit/ef01547e1a4f01ea29ba813fa92c1a2cd3fad16e) Translate using Weblate (Chinese (Traditional Han script))
* [`9f56e690`](https://github.com/nix-community/home-manager/commit/9f56e690e4524aa029efeae52fbaa3972d70658f) claude-code: disable automatic updates for managed marketplaces
* [`03f4cd46`](https://github.com/nix-community/home-manager/commit/03f4cd46bc1dd4f3a96da778d2ce9f7ce39dd450) noctalia: init module
