### PR TITLE
npins nerd-icons.el: update 1e75075e -> 17faac79

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -99,9 +99,9 @@
       },
       "branch": "main",
       "submodules": false,
-      "revision": "1e75075e323dedaf9f2fd5837082c60a2d0dfae3",
-      "url": "https://github.com/rainstormstudio/nerd-icons.el/archive/1e75075e323dedaf9f2fd5837082c60a2d0dfae3.tar.gz",
-      "hash": "sha256-LtHyI6HMvlzPwt/ld+fw1sxwxtbbw+TJCZhr8Dsm8uc="
+      "revision": "17faac7977242b470732efd417d3bcc8eb5a830e",
+      "url": "https://github.com/rainstormstudio/nerd-icons.el/archive/17faac7977242b470732efd417d3bcc8eb5a830e.tar.gz",
+      "hash": "sha256-OuB4MRI7ji7UQ//zH7KtOCV76N0Mkz++pcqYrL21PNU="
     },
     "niv": {
       "type": "Git",


### PR DESCRIPTION
## Changelog for nerd-icons.el:
Branch: main
Commits: [rainstormstudio/nerd-icons.el@1e75075e...17faac79](https://github.com/rainstormstudio/nerd-icons.el/compare/1e75075e323dedaf9f2fd5837082c60a2d0dfae3...17faac7977242b470732efd417d3bcc8eb5a830e)

* [`8e1a8a14`](https://github.com/rainstormstudio/nerd-icons.el/commit/8e1a8a144e9a89faf44882a5612c3575810eac77) Update to Nerd Fonts 3.5.0
* [`7c51b3fc`](https://github.com/rainstormstudio/nerd-icons.el/commit/7c51b3fcd9d43b55a1540fa31174fb4589993249) Update bundled font to Nerd Fonts 3.5.1
