### PR TITLE
npins zsh-patina: update 5319607c -> 42e5071a

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -242,9 +242,9 @@
       },
       "branch": "main",
       "submodules": false,
-      "revision": "5319607c43bc2237eda3b95bc8ad2485dd2297e1",
-      "url": "https://github.com/michel-kraemer/zsh-patina/archive/5319607c43bc2237eda3b95bc8ad2485dd2297e1.tar.gz",
-      "hash": "sha256-feBmmR6B83172VBHSlKIZLJuZ/wRx8R/AJ//Dnf/NaQ="
+      "revision": "42e5071ac3cc32ea6abe10bfe709a253dead2020",
+      "url": "https://github.com/michel-kraemer/zsh-patina/archive/42e5071ac3cc32ea6abe10bfe709a253dead2020.tar.gz",
+      "hash": "sha256-uJlJCVe3jt4xIZAb5TMgkcva2WVKBQ2zVavHmpvG26s="
     },
     "zsh-syntax-highlighting": {
       "type": "Git",


### PR DESCRIPTION
## Changelog for zsh-patina:
Branch: main
Commits: [michel-kraemer/zsh-patina@5319607c...42e5071a](https://github.com/michel-kraemer/zsh-patina/compare/5319607c43bc2237eda3b95bc8ad2485dd2297e1...42e5071ac3cc32ea6abe10bfe709a253dead2020)

* [`82511af0`](https://github.com/michel-kraemer/zsh-patina/commit/82511af0d80b3b314611a69bdffb004314c224a9) Add install instructions for more plugin managers and add .plugin.zsh file
* [`071f03f2`](https://github.com/michel-kraemer/zsh-patina/commit/071f03f21cdda3e542bd581de754d147311b53ed) Enable completions by default for plugin managers
* [`2dfac12a`](https://github.com/michel-kraemer/zsh-patina/commit/2dfac12ac274d82bd870b08ba0ba4fafc051b90d) Fix formatting of toc
* [`1ecbbd77`](https://github.com/michel-kraemer/zsh-patina/commit/1ecbbd77dbeccc37bb66a2ee78bb7206598380e3) Remove duplicate space character
* [`43f21625`](https://github.com/michel-kraemer/zsh-patina/commit/43f216254c48539de30a403834a4634551507cad) Add highlight subcommand
* [`76581d67`](https://github.com/michel-kraemer/zsh-patina/commit/76581d677734f874035cd36f8300a86b896141f6) Show error when input path is not a regular file
* [`fa174766`](https://github.com/michel-kraemer/zsh-patina/commit/fa1747664c2e79c81c373e8cab9da0951ca3a108) Correctly convert highlight styles with multiple attributes
* [`f8d71a62`](https://github.com/michel-kraemer/zsh-patina/commit/f8d71a626df5c1fa0942689009bc2a9f781cbe76) Add integration tests for highlight subcommand
* [`e0979cc8`](https://github.com/michel-kraemer/zsh-patina/commit/e0979cc837cd8507a2b522daad8710d113e00688) Build test image only once
* [`47195cbd`](https://github.com/michel-kraemer/zsh-patina/commit/47195cbdfaa0b7a6fdafa1b6be18b76b9f382086) Make integration tests for highlight subcommand more reliable
* [`b185ad2e`](https://github.com/michel-kraemer/zsh-patina/commit/b185ad2e836e161b1b0a8c1c8fbb0b417d9a39d3) Improve install instructions
* [`a7240b71`](https://github.com/michel-kraemer/zsh-patina/commit/a7240b716e62354c81bad85ff362e6b15ae746ee) Remove install instructions for antigen
* [`94e87e54`](https://github.com/michel-kraemer/zsh-patina/commit/94e87e54fb4eb4b0af262122b611cf110f2ad7d4) Update CHANGELOG
* [`42e5071a`](https://github.com/michel-kraemer/zsh-patina/commit/42e5071ac3cc32ea6abe10bfe709a253dead2020) Bump up version number to 1.10.0
