### PR TITLE
npins zsh-syntax-highlighting: update c4d95591 -> 2fc57d63

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -255,9 +255,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "c4d95591843d49838b7ad30081e7aba3135a6703",
-      "url": "https://github.com/zsh-users/zsh-syntax-highlighting/archive/c4d95591843d49838b7ad30081e7aba3135a6703.tar.gz",
-      "hash": "sha256-4XXqgMaB+l8ZKRJEuxuC1yqQRFhP/0ySELsSJTvjf8k="
+      "revision": "2fc57d63067c18b1100ecdbf684fa5baf49459d1",
+      "url": "https://github.com/zsh-users/zsh-syntax-highlighting/archive/2fc57d63067c18b1100ecdbf684fa5baf49459d1.tar.gz",
+      "hash": "sha256-d/io9jvBn6XuSPWQia4OPWDwZRS8Pt74XG9VWqIYFFw="
     },
     "zsh-you-should-use": {
       "type": "Git",


### PR DESCRIPTION
## Changelog for zsh-syntax-highlighting:
Branch: master
Commits: [zsh-users/zsh-syntax-highlighting@c4d95591...2fc57d63](https://github.com/zsh-users/zsh-syntax-highlighting/compare/c4d95591843d49838b7ad30081e7aba3135a6703...2fc57d63067c18b1100ecdbf684fa5baf49459d1)

* [`2fc57d63`](https://github.com/zsh-users/zsh-syntax-highlighting/commit/2fc57d63067c18b1100ecdbf684fa5baf49459d1) tests: fix relative links in tests/README.md
