### PR TITLE
npins nixpkgs: update 64b7af55 -> 2bc24950

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -125,9 +125,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "64b7af55c5adecff92379d9f7d4b36d36848181d",
-      "url": "https://github.com/nixos/nixpkgs/archive/64b7af55c5adecff92379d9f7d4b36d36848181d.tar.gz",
-      "hash": "sha256-Mq6lgHza7MmXfvOJp7pmiEqcvPBNPX4SZ/9epx1F5Hw="
+      "revision": "2bc249505bb17b0faa98685c404b5570ef0b382c",
+      "url": "https://github.com/nixos/nixpkgs/archive/2bc249505bb17b0faa98685c404b5570ef0b382c.tar.gz",
+      "hash": "sha256-kVppX4k6QsaJdiM02+1Z6WqtDpfiYwuSm0WsfDJPRGw="
     },
     "powerlevel10k": {
       "type": "Git",


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@64b7af55...2bc24950](https://github.com/nixos/nixpkgs/compare/64b7af55c5adecff92379d9f7d4b36d36848181d...2bc249505bb17b0faa98685c404b5570ef0b382c)

* [`812dcda5`](https://github.com/NixOS/nixpkgs/commit/812dcda57399d68da994b8c5f22e2e1bb7f4b2ef) hash-slinger: fix $PATH to make 'openssl' discoverable for it
* [`c6567abb`](https://github.com/NixOS/nixpkgs/commit/c6567abbf1cbb10c28c86e6c4d41ace920c58c68) aroccPackages.latest-unwrapped: 0-unstable-2025-03-05 -> 0-unstable-2025-11-09
* [`6b8c0e00`](https://github.com/NixOS/nixpkgs/commit/6b8c0e00808d072879deec1cd7f4f8d5579cf6cd) home-assistant-custom-components.solarman: use alternative component
* [`3a7f84d0`](https://github.com/NixOS/nixpkgs/commit/3a7f84d0256a91d662e7777bebc283ca829d41bb) python3Packages.coveralls: fix src hash
* [`bf1ac8a0`](https://github.com/NixOS/nixpkgs/commit/bf1ac8a0a52e5b946181a1a7c3dc6ec37842d3ff) maintainers: add opdavies
* [`4c88819c`](https://github.com/NixOS/nixpkgs/commit/4c88819c881fe2d9c8cf281d4381ada39aa0bccd) nixos/cage: group options into a single attrset
* [`9e8e1c5c`](https://github.com/NixOS/nixpkgs/commit/9e8e1c5c0a1e70890dda8e986132d0e4efdbec34) nixos/cage: add restartIfChanged option
* [`9aeef700`](https://github.com/NixOS/nixpkgs/commit/9aeef7005b59660d1011289c837e862d38f938b5) lttoolbox: 3.7.6 -> 3.8.2
* [`57410aee`](https://github.com/NixOS/nixpkgs/commit/57410aee82a312b091f6c41c5044b13bd1baea65) rdfind: 1.7.0 -> 1.8.0
* [`d9e0e029`](https://github.com/NixOS/nixpkgs/commit/d9e0e0290ebca4604b03b022f8a4e197af36dfeb) deff: init at 0.2.4
* [`cbb63496`](https://github.com/NixOS/nixpkgs/commit/cbb6349645a0c796107f40f1f0295397f237f32c) maintainers: add db8le
* [`8289f337`](https://github.com/NixOS/nixpkgs/commit/8289f337e319da514859555ea658ef6c165ad4ba) chirpstack-packet-multiplexer: init at 4.0.0
* [`34051069`](https://github.com/NixOS/nixpkgs/commit/34051069ac5cb8f8b7253c14e8f941577d066f8e) cc-switch-cli: init at 5.0.1
* [`6c5919b4`](https://github.com/NixOS/nixpkgs/commit/6c5919b458cbd626ba7f87965a382aca3b18377d) nixos/calibre-web: add split book directory to config
* [`33dea574`](https://github.com/NixOS/nixpkgs/commit/33dea574e5facedfd482dcd0cc6f82f4e7056b8c) python3Packages.metaflow: 2.19.16 -> 2.19.22
* [`658454bf`](https://github.com/NixOS/nixpkgs/commit/658454bfe8360c9dd3d33d413960011bb4dae270) tomb: build extras/kdf-keys
* [`7ddead5b`](https://github.com/NixOS/nixpkgs/commit/7ddead5bd25692179e80f558a8d4cf6dd01ea063) python3Packages.geoip2: allow local networking on Darwin
* [`b7e18737`](https://github.com/NixOS/nixpkgs/commit/b7e18737a9ced32bda57a465ad49747f1202848a) open-vm-tools: 13.0.5 -> 13.1.0
* [`db343ff1`](https://github.com/NixOS/nixpkgs/commit/db343ff150e458adc72ae5db3d3b6f1018440e8f) open-vm-tools-headless: 13.0.5 -> 13.1.0
* [`ddc2a757`](https://github.com/NixOS/nixpkgs/commit/ddc2a75716e6d70da10aca91771f2dd66057cf5c) python3Packages.unicodedata2: modernize and migrate to pyproject
* [`1e5ea0a2`](https://github.com/NixOS/nixpkgs/commit/1e5ea0a2b9a642bad16dfd500a7c50861ec96810) guile-fibers: 1.3.1 -> 1.4.3
* [`57a48d81`](https://github.com/NixOS/nixpkgs/commit/57a48d81f4739e7545cc0994af6a704fb4bc5ec6) libpcap: enable RDMA for all supported platforms
* [`7cd2df4f`](https://github.com/NixOS/nixpkgs/commit/7cd2df4f5e7314b1160e4207bc3cc2cbd413af5a) python3Packages.casttube: migrate to pyproject
* [`d7cf300c`](https://github.com/NixOS/nixpkgs/commit/d7cf300c5c05ca5b189fb658be0be491d2e72e81) python3Packages.casttube: use finalAttrs
* [`4673314c`](https://github.com/NixOS/nixpkgs/commit/4673314cede82e6e668b0c315363f1b80228da1b) python3Packages.cfn-flip: migrate  to pyproject
* [`e8e0f87b`](https://github.com/NixOS/nixpkgs/commit/e8e0f87b6873251262db1bdafac7fe6b47fee0a0) python3Packages.cfn-flip: use finalAttrs
* [`6c0b9c09`](https://github.com/NixOS/nixpkgs/commit/6c0b9c09a19bfa00790b405b56a97841aa9a0b9e) python3Packages.chacha20poly1305: migrate to pyproject
* [`b4d9470a`](https://github.com/NixOS/nixpkgs/commit/b4d9470a99af53ec7d3cfc7529a041ebb72a8924) python3Packages.chacha20poly1305: use finalAttrs
* [`19469762`](https://github.com/NixOS/nixpkgs/commit/19469762502da6205fbd8c9b747349d7b873e866) python3Packages.chacha20poly1305: update license
* [`eec35ba8`](https://github.com/NixOS/nixpkgs/commit/eec35ba83aaaf30ecbef7dfeff657402500761c5) kwybars: init at 0.2.0
* [`c346537e`](https://github.com/NixOS/nixpkgs/commit/c346537ee0f56c1156b74eca98e86cafd91b5b2d) cups: add `doc` output
* [`2f00ad30`](https://github.com/NixOS/nixpkgs/commit/2f00ad30c5efe1cb9420cf918ee3a3f5dc135715) maintainers: add pierreborine
* [`f8e05b7a`](https://github.com/NixOS/nixpkgs/commit/f8e05b7ab7ed0f6f7f576771315e1105a657ec99) hyprscratch: init at 0.6.5
* [`6641f423`](https://github.com/NixOS/nixpkgs/commit/6641f423297a199102dae735ccda09c38b7d650a) libwebsockets: 4.4.5 -> 4.5.8
* [`4ffeb5ca`](https://github.com/NixOS/nixpkgs/commit/4ffeb5ca50937d635f935ccc2f624e6e564f9837) ecdsautils: adopt and modernize
* [`0a7f341d`](https://github.com/NixOS/nixpkgs/commit/0a7f341dc15318e2bef66178bc0005477ffb4924) nvidia-x11: strip debug info from the kernel modules at install
* [`745ad533`](https://github.com/NixOS/nixpkgs/commit/745ad533d2e0b94e7ae68cf68229659660bfb9a1) apio-udev-rules: 0.9.5 -> 1.5.0
* [`6f501e93`](https://github.com/NixOS/nixpkgs/commit/6f501e939a7173d4650d9028ebd4ab0ec968bbb2) python3Packages.smg-grpc-servicer: 0.5.5 -> 0.5.6
* [`e2771182`](https://github.com/NixOS/nixpkgs/commit/e2771182773b266c94d451f64b5f78e93e22571a) smcroute: 2.5.7 -> 2.6.0
* [`a76ff4f5`](https://github.com/NixOS/nixpkgs/commit/a76ff4f5341d696ed9a181cc0fca91ed92b9eb4b) fabric: rename from Fabric
* [`c668b28d`](https://github.com/NixOS/nixpkgs/commit/c668b28d217334cf68ebf274f647652ff480e410) python3Packages.fabric: use __structuredAttrs = true
* [`e49cb845`](https://github.com/NixOS/nixpkgs/commit/e49cb845fca8a55fede312118dd0dedb488840f6) kitops: init at 1.15.0
* [`d7524656`](https://github.com/NixOS/nixpkgs/commit/d7524656d6ff8c58878c8549f943b3b9256a59b3) kitops: enable tests
* [`f5b2ea87`](https://github.com/NixOS/nixpkgs/commit/f5b2ea87407ebd1ddc1d3fb51e7b0cce13aa1418) mediamtx: 1.18.2 -> 1.19.2
* [`6c665fe6`](https://github.com/NixOS/nixpkgs/commit/6c665fe667f08361bca4eb88450ca080809f6202) python3Packages.absl-py: modernize
* [`9a13708a`](https://github.com/NixOS/nixpkgs/commit/9a13708a730b65a7bd62869951aa9023be61fd9d) python3Packages.absl-py: 2.3.1 -> 2.5.0
* [`0dd40002`](https://github.com/NixOS/nixpkgs/commit/0dd4000289edecb3ca42e82a4fa79417fca87334) python3Packages.dbus-python: Switch to `finalAttrs` pattern
* [`8045ba2f`](https://github.com/NixOS/nixpkgs/commit/8045ba2f61c0cf7f680d2c02059da539aa4da188) python315Packages.dbus-python: Fix runtime error
* [`0e7f3744`](https://github.com/NixOS/nixpkgs/commit/0e7f37444a87d3004b7ad7f6a81d606f43393576) python3Packages.dbus-python: Re-enable tests
* [`c1c1a176`](https://github.com/NixOS/nixpkgs/commit/c1c1a17669fa86dc522e269e973bac97f0eb8407) python3Packages.kivy: 2.3.1 -> 2.3.1-unstable-2026-07-11
* [`2e5f6016`](https://github.com/NixOS/nixpkgs/commit/2e5f6016ece3c479a5981052ff085094742f0c7c) elmPackages: clean up the update script
* [`bab9648f`](https://github.com/NixOS/nixpkgs/commit/bab9648f114253ff920e20ea82ebb822ad559229) elmPackages.elm: 0.19.1 -> 0.19.2
* [`c4328f7c`](https://github.com/NixOS/nixpkgs/commit/c4328f7cca17d687d3b6511fc690b4e4623d5a6a) crossmacro: 1.2.1 -> 1.3.1
* [`6f9dfd69`](https://github.com/NixOS/nixpkgs/commit/6f9dfd69ed5533ae177c8ddedc2c8e2cc1c962fb) crossmacro-daemon: 1.2.1 -> 1.3.1
* [`18a0495c`](https://github.com/NixOS/nixpkgs/commit/18a0495c84a903589ff467b295ad7fd026f8568d) tree-sitter: 0.26.9 -> 0.26.11
* [`3a883ac9`](https://github.com/NixOS/nixpkgs/commit/3a883ac9f6f3ff62fd59386824aafc2b1ec6c075) workout-tracker: 2.6.0 → 2.9.0
* [`cbb6959f`](https://github.com/NixOS/nixpkgs/commit/cbb6959f319444d74f59a3b5de20ef2e652fc603) texinfo: 7.2 -> 7.3
* [`a112a050`](https://github.com/NixOS/nixpkgs/commit/a112a05000a624b42bd31c55c827508acc50b24f) perlPackages.CryptOpenSSLRSA: 0.35 -> 0.41
* [`a0a8c8b1`](https://github.com/NixOS/nixpkgs/commit/a0a8c8b14da64ccc796a3041de7c9be33427aa3d) tree-sitter-grammars.tree-sitter-vim: 0.8.1-unstable-2026-02-26 -> 0.8.1-unstable-2026-07-12
* [`f0b01852`](https://github.com/NixOS/nixpkgs/commit/f0b01852060b27ae25a1ae781626396076641ff4) i2pd: 2.60.0 -> 2.61.0
* [`8faec7a1`](https://github.com/NixOS/nixpkgs/commit/8faec7a14645ab696e6631426e2cc4d915ae1202) git: fix darwin crashes when dealing with unicode filenames
* [`f2e1035a`](https://github.com/NixOS/nixpkgs/commit/f2e1035aa566b07cc831cf25352df918b2b894e3) perlPackages.MojoSAML: select padding to accommodate new CryptOpenSSLRSA
* [`f424a73f`](https://github.com/NixOS/nixpkgs/commit/f424a73f4b9e26fe0f88e7922e6d6d04b1d663fc) cryptsetup: 2.8.6 -> 2.8.7
* [`8f9c7e51`](https://github.com/NixOS/nixpkgs/commit/8f9c7e519ec3fdc70f8a91645f2c2bd08299b3c9) systemd-boot: use correct flag for EFI variables
* [`edee1db4`](https://github.com/NixOS/nixpkgs/commit/edee1db43584ea0ea951ea5dd0e0f91fdc59cea9) python3Packages.ufo2ft: 3.8.2 -> 3.9.0
* [`b2a07777`](https://github.com/NixOS/nixpkgs/commit/b2a077778ebe0b3df43eef885e798cdbad8c7a38) fleet-{desktop,orbit}: init at 1.55.0
* [`803e4d56`](https://github.com/NixOS/nixpkgs/commit/803e4d566ff510850dac200bf47a582634e9f764) nixos/tests/hadoop.hbase: use provided `package`
* [`4c045043`](https://github.com/NixOS/nixpkgs/commit/4c045043325fa228c775707fd284984fba08d208) nixos/tests: set proper derivation names for various tests
* [`5f2b39c5`](https://github.com/NixOS/nixpkgs/commit/5f2b39c55e6db61debb484b3e9c7ab568d308651) webkitgtk_{4_1,6_0}: drop unused libidn dependency
* [`15ee69f7`](https://github.com/NixOS/nixpkgs/commit/15ee69f741133a6ffe57d1963917ac30c9ece52c) mjpegtools: disable building gtk2 programs
* [`dfe22897`](https://github.com/NixOS/nixpkgs/commit/dfe2289780c745ee57534e4420a363a2871d6f50) tree-sitter-grammars.tree-sitter-nu: 0-unstable-2026-04-22 -> 0-unstable-2026-07-01
* [`c66a333e`](https://github.com/NixOS/nixpkgs/commit/c66a333e1ee03d9948895262eb98be615d78e0ac) ubus: unstable-202-10-17 -> 0-unstable-2025-10-17
* [`33c132d1`](https://github.com/NixOS/nixpkgs/commit/33c132d1e4006326b741e39b28e46fb3433e0564) skawarePackages: use output placeholders
* [`42cf0fed`](https://github.com/NixOS/nixpkgs/commit/42cf0fed74227bf768c59313dd062948db360c32) ksnip: remove /usr/bin in .desktop file
* [`f7c0692e`](https://github.com/NixOS/nixpkgs/commit/f7c0692e2ba884227ae814f685dbd375e5103d7e) python3Packages.pywikibot: 10.7.4 -> 11.6.0
* [`735d3749`](https://github.com/NixOS/nixpkgs/commit/735d3749655a071f6c2fede0f421062eae0b76b9) rounded-mgenplus: use mirror URL, modernize
* [`a9142326`](https://github.com/NixOS/nixpkgs/commit/a91423266a9f2186cd70436b0be67105a85e3417) rounded-mgenplus: add shadowrz to maintainers
* [`1a179921`](https://github.com/NixOS/nixpkgs/commit/1a1799214f7237f8036636d8a362380eeb30ef05) sculpin: init at 3.3.1
* [`3c7c7c40`](https://github.com/NixOS/nixpkgs/commit/3c7c7c40ab61658411f78f9a7643ea818015a04f) ocamlPackages.mariadb: 1.3.0 -> 2.0.0
* [`0ab85ca2`](https://github.com/NixOS/nixpkgs/commit/0ab85ca2c20ad3c21cd0868bdba48e71ea6e036c) moarvm: 2026.02 -> 2026.07
* [`7dcca907`](https://github.com/NixOS/nixpkgs/commit/7dcca90785516cc01ca0bd0e9b22bf090dfbdf88) nqp: 2026.02 -> 2026.07
* [`ee2e3c2a`](https://github.com/NixOS/nixpkgs/commit/ee2e3c2a2fb4b4e30c23a6f9a7569ae2f8b86633) rakudo: 2026.02 -> 2026.07
* [`c22d3a9b`](https://github.com/NixOS/nixpkgs/commit/c22d3a9b94abf1d88bffe235e3ace0f8f5b1cbf4) zef: 1.0.0 -> 1.1.3
* [`c75774aa`](https://github.com/NixOS/nixpkgs/commit/c75774aa34a089b81ebeb78a3daca4430d1ca289) openjph: 0.24.1 -> 0.31.0
* [`778afcfd`](https://github.com/NixOS/nixpkgs/commit/778afcfd83cd0f469202fa8de9d790dd83b323bb) libarchive: 3.8.8 -> 3.8.9
* [`4747c0b2`](https://github.com/NixOS/nixpkgs/commit/4747c0b25a5f7406b64bb528f4fc5719454d8a3c) llvmPackages_23: 23.1.0-rc1 -> 23.1.0-rc2
* [`e69eb629`](https://github.com/NixOS/nixpkgs/commit/e69eb629f786d530c39ef39c0bbcb71667dbec56) cosmic-ext-applet-mare-player: init at 0.3.0
* [`b668bf18`](https://github.com/NixOS/nixpkgs/commit/b668bf18ec63c8b98e0d4f322f37bfdd5dd9a184) python3Packages.txzmq: migrate to pyproject
* [`ceeda247`](https://github.com/NixOS/nixpkgs/commit/ceeda24713827547ba4d252b8475fd3143127c26) gnome-desktop: expose OpenGL driver path to thumbnail sandbox
* [`dd8369d9`](https://github.com/NixOS/nixpkgs/commit/dd8369d9982ee5812c5c568f4539d383c1351b28) libnghttp2: 1.69.0 -> 1.70.0
* [`4628aaf2`](https://github.com/NixOS/nixpkgs/commit/4628aaf210b62c642e9b7f8274d6b66283c3c8f4) tree-sitter-grammars.tree-sitter-robot: 1.4.0 -> 1.5.0
* [`d08b2c1d`](https://github.com/NixOS/nixpkgs/commit/d08b2c1d9c00bcbc35073c065012346ff4a432e7) microsoft-rush: init at 5.178.0
* [`583dfe98`](https://github.com/NixOS/nixpkgs/commit/583dfe982182b5f684eb8e3f3ee65ed960b8a342) dorion: 6.12.2 -> 6.13.0
* [`2be83426`](https://github.com/NixOS/nixpkgs/commit/2be83426656b4f6a0ee67f80434c270ec15785a9) skawarePackages: support finalAttrs
* [`2bd54f5f`](https://github.com/NixOS/nixpkgs/commit/2bd54f5f8782c4de55003ed8f9d50391e4373b64) skawarePackages: use pkg-config for dependencies
* [`10669550`](https://github.com/NixOS/nixpkgs/commit/106695500c7f595311b588720f6edc1be29f155a) gawk: `finalAttrs`
* [`d588d92e`](https://github.com/NixOS/nixpkgs/commit/d588d92eefc8e6ca3f8dfe4a1eecafe8eaa03d77) gawk: `__structuredAttrs` & `enableParallelBuilding`
* [`d5ea8e5b`](https://github.com/NixOS/nixpkgs/commit/d5ea8e5b5e170b982ec52b61dea73255079e2273) tree-sitter-grammars.tree-sitter-cairo: 0-unstable-2026-06-14 -> 0-unstable-2026-07-23
* [`920d9cd8`](https://github.com/NixOS/nixpkgs/commit/920d9cd88229240a65f38beccffcf06fe71f1071) minimal-bootstrap.binutils{,-static}: 2.46.0 -> 2.47
* [`d5deacb2`](https://github.com/NixOS/nixpkgs/commit/d5deacb2261ee1c05ce06e941b61b3b149ab542b) minimal-bootstrap.coreutils-{musl,static}: 9.10 -> 9.11
* [`9d91a0b8`](https://github.com/NixOS/nixpkgs/commit/9d91a0b8d87581bd053ec16f68e8eb70f91c78df) minimal-bootstrap.findutils{,-static}: 4.10.0 -> 4.11.0
* [`be7d828e`](https://github.com/NixOS/nixpkgs/commit/be7d828eef866dd2d72a12684d29942f1e6a8c64) minimal-bootstrap.gawk{,-static}: 5.3.2 -> 5.4.1
* [`985bc462`](https://github.com/NixOS/nixpkgs/commit/985bc462dac0af1721c0dc6048560453e1603869) minimal-bootstrap.glibc: 2.42 -> 2.44
* [`4af58188`](https://github.com/NixOS/nixpkgs/commit/4af58188ea8c21ac34cf72dd9a5ba2b8deb448ed) minimal-bootstrap.gnused-static: 4.9 -> 4.10
* [`e8532079`](https://github.com/NixOS/nixpkgs/commit/e8532079faacabf96c1ab9162cd46b9558aa43f1) minimal-bootstrap.patchelf-static: 0.18.0 -> 0.19.1
* [`1f15a58e`](https://github.com/NixOS/nixpkgs/commit/1f15a58e9671545ad638c0ce21ab36009a3638a6) minimal-bootstrap.python: 3.14.4 -> 3.14.6
* [`b93db2c2`](https://github.com/NixOS/nixpkgs/commit/b93db2c233775bb5dbb51a48bb4a31114f71762e) typstyle: 0.15.0 -> 0.15.1
* [`1f710155`](https://github.com/NixOS/nixpkgs/commit/1f71015519574d3a63e1b5fedbd933f14bd56b3f) typstyle: set __structuredAttrs and strictDeps to true
* [`ba616b59`](https://github.com/NixOS/nixpkgs/commit/ba616b59f2d3cc8b81f143c7298b0a8f5b42c08a) proxyt: init at 0.0.7
* [`b7970fa6`](https://github.com/NixOS/nixpkgs/commit/b7970fa66e050e0ce2c3783ba1775073375cc676) vala: 0.56.18 -> 0.56.19
* [`efd1bbda`](https://github.com/NixOS/nixpkgs/commit/efd1bbda01a40cb5183daee3308c7edfcf18157d) clonehero: modernize, add update script
* [`8ce7a877`](https://github.com/NixOS/nixpkgs/commit/8ce7a87700a67f8d540b97df2b2d588409f4c6dc) clonehero: 1.1.0.6085 -> 1.1.0.6142
* [`64927122`](https://github.com/NixOS/nixpkgs/commit/64927122870a0587642a82bd40b808e3c109f77f) linuxHeaders: enable structuredAttrs
* [`39953932`](https://github.com/NixOS/nixpkgs/commit/39953932fe81c37cc02b3a321dd439c79af487d7) glibc: enable structuredAttrs
* [`a6df78ba`](https://github.com/NixOS/nixpkgs/commit/a6df78ba9b0295f37e6aff63d971b6901160f57c) xz: enable structuredAttrs
* [`04155a77`](https://github.com/NixOS/nixpkgs/commit/04155a77f60f5f8ab14436d7742d40d3dc22001f) lix: boost is required to build against lix/libutil
* [`aafeee7f`](https://github.com/NixOS/nixpkgs/commit/aafeee7fba2cfb77debd7260b8baccc687e56bb7) gnu-config: enable structuredAttrs
* [`1cd690ae`](https://github.com/NixOS/nixpkgs/commit/1cd690ae5471ccd59a6858df17f51bd6c317e908) coreutils: enable strictDeps
* [`876cd695`](https://github.com/NixOS/nixpkgs/commit/876cd695b696d82d1b151e62d2a9eae03428683d) coreutils: enable structuredAttrs, use --replace-fail
* [`aa9c9397`](https://github.com/NixOS/nixpkgs/commit/aa9c93970fedc5dd068ce79bfbdb11155aafba5b) autoconf269: enable structuredAttrs, use finalAttrs
* [`4869f0e3`](https://github.com/NixOS/nixpkgs/commit/4869f0e3d6a5352b1a9536df832b40c507ed045a) autoconf: enable structuredAttrs, use finalAttrs
* [`733fcf93`](https://github.com/NixOS/nixpkgs/commit/733fcf93e58e2644158713acff7feda59dfea030) automake116x: enable structuredAttrs, use finalAttrs
* [`0043d4fb`](https://github.com/NixOS/nixpkgs/commit/0043d4fbc70882acde1d150ccc17ac95e884266a) automake: enable structuredAttrs, use finalAttrs
* [`4f61d6c8`](https://github.com/NixOS/nixpkgs/commit/4f61d6c8e9967e36f853348b930254f74f02ab3b) findutils: enable strictDeps
* [`48a056c3`](https://github.com/NixOS/nixpkgs/commit/48a056c33cfeb3f5cc174e544d56adc75f253f04) findutils: enable structuredAttrs
* [`53400743`](https://github.com/NixOS/nixpkgs/commit/53400743749740cbb266557070ad1fa9339021db) gnused: enable strictDeps
* [`75af460b`](https://github.com/NixOS/nixpkgs/commit/75af460bdbd16c197469a5502bcd72b80e90b2e1) patchelf: enable structuredAttrs, modernize
* [`1938a54c`](https://github.com/NixOS/nixpkgs/commit/1938a54c07a338678f53a1098dd18a17790cee8c) findutils: use --replace-fail
* [`195fd12e`](https://github.com/NixOS/nixpkgs/commit/195fd12e68f7e2e83f2f7df102503b1fb47f2579) diffutils: enable strictDeps
* [`b5c3bd02`](https://github.com/NixOS/nixpkgs/commit/b5c3bd029bf468da96331f737aca74b4a77965fb) diffutils: enable structuredAttrs, use finalAttrs
* [`2dd210f9`](https://github.com/NixOS/nixpkgs/commit/2dd210f97759d908eb12aeb001c9e6957f3e23ee) gnum4: enable structuredAttrs
* [`5fb27e02`](https://github.com/NixOS/nixpkgs/commit/5fb27e0291facb7a80e7c091944952efffb7dc11) gettext: enable structuredAttrs, use finalAttrs
* [`5530de9c`](https://github.com/NixOS/nixpkgs/commit/5530de9cca3fb9f3c17d5bc87a9bfdae5da5734b) bison: enable structuredAttrs
* [`3211eabb`](https://github.com/NixOS/nixpkgs/commit/3211eabb3132faa5621c179ee1bd7afbcb9a3620) gettext: move makeFlags into the main attrset
* [`67d950f1`](https://github.com/NixOS/nixpkgs/commit/67d950f1b9c6b4aa3ab4c97a1accaa4133e5bb2b) gmp: enable structuredAttrs, use finalAttrs
* [`e139f7d9`](https://github.com/NixOS/nixpkgs/commit/e139f7d92ab1b7f9b29a564ac879dafed2644519) CONTRIBUTING.md: remove automation policy core team escalation path
* [`2e412b37`](https://github.com/NixOS/nixpkgs/commit/2e412b377ae5686d64f6e5b8a800ba492c6f7db3) libmpc: enable structuredAttrs
* [`a2f8d03c`](https://github.com/NixOS/nixpkgs/commit/a2f8d03cf5d4a93d99affdd2fd714630dd7eddb6) mpfr: enable structuredAttrs, use finalAttrs
* [`56f1badd`](https://github.com/NixOS/nixpkgs/commit/56f1baddcabcd18431e340e6f372bcc1016e1163) zlib: enable structuredAttrs
* [`48e25ca7`](https://github.com/NixOS/nixpkgs/commit/48e25ca7b0604842834caac87129dc27e15b51ac) texinfo: enable structuredAttrs
* [`88a48995`](https://github.com/NixOS/nixpkgs/commit/88a48995c2ceca3321f8b8992020ac84be2a4549) bash: enable structuredAttrs
* [`bbb94bc7`](https://github.com/NixOS/nixpkgs/commit/bbb94bc73cb8bd7323535648a9b51f016a5e2666) isl_0_{20,23,24,27}: enable structuredAttrs
* [`5d290f6a`](https://github.com/NixOS/nixpkgs/commit/5d290f6ac16f8f5bbc608776ac7a36de4fbcf955) gnugrep: enable strictDeps
* [`877c99ae`](https://github.com/NixOS/nixpkgs/commit/877c99aeb3a2ab0e2315a6daa22fefe9d90935f1) gnugrep: enable structuredAttrs
* [`acd18749`](https://github.com/NixOS/nixpkgs/commit/acd187492f929376d6d024985543a3c8fbcca23b) attr: enable strictDeps
* [`00262951`](https://github.com/NixOS/nixpkgs/commit/00262951342b4157cb1c83d0fadeee44cfa6ba40) attr: enable structuredAttrs, use finalAttrs
* [`601183ca`](https://github.com/NixOS/nixpkgs/commit/601183cab00345214a4d15ba1a4bb608558c0bdd) python3Packages.rarfile: 4.2 -> 4.5
* [`4bbf95ce`](https://github.com/NixOS/nixpkgs/commit/4bbf95ce5360b96edb196de61f2ae2d3967dec02) bintools-wrapper: enable structuredAttrs
* [`da2e58bd`](https://github.com/NixOS/nixpkgs/commit/da2e58bdb3c12c1369480c95dfc56c3663f26120) ada: 3.4.4 -> 4.0.0
* [`15c5c3bf`](https://github.com/NixOS/nixpkgs/commit/15c5c3bfd639ac53e597ee45b60de531fa3e371e) python3Packages.fastapi: 0.139.0 -> 0.141.1
* [`6e8d3200`](https://github.com/NixOS/nixpkgs/commit/6e8d3200c15ed8bf00dd1a30a95154ceefaa573b) sdl3: 3.4.12 -> 3.4.14
* [`6570906c`](https://github.com/NixOS/nixpkgs/commit/6570906c23501d3db2243f697cc2cc9b8302cda4) elmPackages.elm-test: 0.19.1-revision17 -> 0.19.2-0
* [`756202a1`](https://github.com/NixOS/nixpkgs/commit/756202a1bdfd95d0dd173e1c835f571187abaff9) geekbench_7: init at 7.0.0
* [`0e2ae962`](https://github.com/NixOS/nixpkgs/commit/0e2ae96228d85c31335f6e224bda30280e042f3d) nixVersions.git: 2.35pre20260619 -> 2.36pre20260804
* [`ffa600c9`](https://github.com/NixOS/nixpkgs/commit/ffa600c96f16cf8a244fa71de6acedd095aacd64) luaPackages.dkjson: 2.10-1 -> 2.11-1
* [`05311a35`](https://github.com/NixOS/nixpkgs/commit/05311a357fdaaefbe6a8f68d161dbf620e9606e3) dwarfs: 0.14.0 -> 0.15.6
* [`f6ad1dd4`](https://github.com/NixOS/nixpkgs/commit/f6ad1dd41af3db5f3bcd89d92c74bca768377ae8) libblake3: 1.8.5 -> 1.8.6
* [`a4b36e33`](https://github.com/NixOS/nixpkgs/commit/a4b36e335661c7b507643ecef2d7ce51c1017105) box64: 0.4.2 -> 0.4.4
* [`0a1332ae`](https://github.com/NixOS/nixpkgs/commit/0a1332ae4fca392f246982fedb68d59bdaac7f8b) nixos/zerotierone: move dir creation out of start script
* [`22be1129`](https://github.com/NixOS/nixpkgs/commit/22be1129128b0165aa787dad7cc502ddab584cd8) nixos/lighttpd/cgit: move dir creation out of start script
* [`3da685ba`](https://github.com/NixOS/nixpkgs/commit/3da685ba519961c75cbecdf4a045add490c1a1a5) nixos/spice-vdagentd: move dir creation out of start script
* [`8e5039da`](https://github.com/NixOS/nixpkgs/commit/8e5039dab7b05a5fc9577e5a836437debfe8e36d) nixos/x2goserver: move dir creation out of start script
* [`f5ecd947`](https://github.com/NixOS/nixpkgs/commit/f5ecd947a990aa5b199197623fae2ec61dce26b4) nixos/nfs: move dir creation out of start script
* [`e980bde5`](https://github.com/NixOS/nixpkgs/commit/e980bde5df327a8deb0bd722482bfbcd0131a808) nixos/sssd: move dir creation out of start script
* [`f6ac44c9`](https://github.com/NixOS/nixpkgs/commit/f6ac44c9a37c05f580045e3870dea8b4158ed9b0) nixos/infinoted: move dir creation out of start script
* [`60c27993`](https://github.com/NixOS/nixpkgs/commit/60c279930713c3cbb1bf8e54c497664856ba985e) nixos/consul: move dir creation out of start script
* [`31d1f529`](https://github.com/NixOS/nixpkgs/commit/31d1f5291a8bbf0b464f99a5ad11c30fd1e08852) nixos/ente: move dir creation out of start script
* [`dc4cd904`](https://github.com/NixOS/nixpkgs/commit/dc4cd904b5904808276d6e54df1c9aad9399bbaf) nixos/selfoss: move dir creation out of start script
* [`cad96b43`](https://github.com/NixOS/nixpkgs/commit/cad96b434dcfdbefaaa36aa339e0cef0a0dd7ab6) nixos/matomo: move dir creation out of start script
* [`d17390c5`](https://github.com/NixOS/nixpkgs/commit/d17390c5390adc411d970f197312a456808ccfa6) nixos/dnsmasq: move dir creation out of start script
* [`ac01896d`](https://github.com/NixOS/nixpkgs/commit/ac01896dd8b87fb2a1af3c70aa301fb79d395fc4) nixos/teamviewer: move dir creation out of start script
* [`c0116a9c`](https://github.com/NixOS/nixpkgs/commit/c0116a9c28c10f981bd1aab1e1fd41dc5b604a7c) nixos/apcupsd: move dir creation out of start script
* [`cc54817d`](https://github.com/NixOS/nixpkgs/commit/cc54817d0468fd64ea8b3b3df91e207cee21fdb4) tauon: use libayatana-appindicator and expose it at runtime
* [`66fb8c83`](https://github.com/NixOS/nixpkgs/commit/66fb8c837e4269ad8299d867468d830ae6cc99e0) linphonePackages.linphone-sdk: 5.4.85 -> 5.5.13
* [`aacfa606`](https://github.com/NixOS/nixpkgs/commit/aacfa606048183eaddc15f0a7aa5b823ad1465e6) wl-clicker: 0.4 -> 0.5.2
* [`49f78952`](https://github.com/NixOS/nixpkgs/commit/49f78952ada9a4260c3c90f54ed467de5f55196f) polkit: use finalAttrs instead of rec, drop unused fetchpatch
* [`42bcfc61`](https://github.com/NixOS/nixpkgs/commit/42bcfc615e27531473411f03163a042b61e6e9f6) polkit: add useConsoleKit option for session tracking
* [`92a285f1`](https://github.com/NixOS/nixpkgs/commit/92a285f1b05010eee2bc90db32a53b63824c3fa4) plover_5: fix missing icons
* [`a4e153fe`](https://github.com/NixOS/nixpkgs/commit/a4e153fe10094e83c21c193d69d0b04c3dc83e83) plover_4: fix build
* [`935889d0`](https://github.com/NixOS/nixpkgs/commit/935889d0981ce4128e6489bc1c9fc834ca649001) duckdb: fix cross compilation
* [`7e52e1b7`](https://github.com/NixOS/nixpkgs/commit/7e52e1b78e196ca9a562863301379282848275c4) nixos/orbit: init module
* [`35bf5426`](https://github.com/NixOS/nixpkgs/commit/35bf5426bff1a58d31ca08dcb4b0876ec727c01e) unbound: 1.25.2 -> 1.26.0
* [`a8c66f90`](https://github.com/NixOS/nixpkgs/commit/a8c66f9011e8714ade1458b2ad44ab1b679acd4d) python3Packages.python-jenkins: Drop setuptools dependency
* [`c32b01ce`](https://github.com/NixOS/nixpkgs/commit/c32b01ce6dacf9d1f24e2d96f6fc7081bf16d03d) python3Packages.pbr: use setuptools_80
* [`95fc5507`](https://github.com/NixOS/nixpkgs/commit/95fc5507b78df8940ecc247bf780c9101045f34d) python3Packages.testscenarios: Drop setuptools dependency
* [`b8c70d6f`](https://github.com/NixOS/nixpkgs/commit/b8c70d6f18afa014d22ec98ef7ca34f13ef677eb) python3Packages.testtools: Drop setuptools dependency
* [`96a11d00`](https://github.com/NixOS/nixpkgs/commit/96a11d00505a49b5a328651bdd41c26e6187f8af) jenkins-job-builder: 6.4.4 -> 6.5.0
* [`aeac5f85`](https://github.com/NixOS/nixpkgs/commit/aeac5f8550eee870bfce858ab9b5a717571bad1b) poppler: fix mat2 build on Darwin by backporting upstream bugfix
* [`0d6d1e53`](https://github.com/NixOS/nixpkgs/commit/0d6d1e535f58b354b262bc56c96a365bcbb21d2c) poppler: add gtk3 to test closure for unit tests
* [`ea654278`](https://github.com/NixOS/nixpkgs/commit/ea6542782d73f7a516052acfc458a78869e53df6) nixos/nginx: generally turn off MemoryDenyWriteExecute
* [`9ace30d9`](https://github.com/NixOS/nixpkgs/commit/9ace30d98e53f0a54f897262d0247437274db244) nixos/{gitea,forgejo}: remove MemoryDenyWriteExecute
* [`009945d8`](https://github.com/NixOS/nixpkgs/commit/009945d81e58f62d708948506f32df3faadb004a) nixos/mympd: rm MemoryDenyWriteExecute
* [`202b9427`](https://github.com/NixOS/nixpkgs/commit/202b9427162d400954dbf6bb6fb385bdafb5a6b3) nixos/mysql: rm MemoryDenyWriteExecute
* [`10f3e699`](https://github.com/NixOS/nixpkgs/commit/10f3e6999aecc8119ec12ad7a3b9704bde0d0ce2) nixos/cyrus-imap: rm MemoryDenyWriteExecute
* [`bff07360`](https://github.com/NixOS/nixpkgs/commit/bff0736024ebf610dc6bd298ab0e5eb7ea7e0c01) nixos/dovecot: rm MemoryDenyWriteExecute
* [`8bddb1da`](https://github.com/NixOS/nixpkgs/commit/8bddb1da20c473bbad815632af120e388cc78c55) nixos/postfix: rm MemoryDenyWriteExecute
* [`3f216b43`](https://github.com/NixOS/nixpkgs/commit/3f216b4311b2a5531ce91eb10d370dc3335e028b) nixos/suricata: rm MemoryDenyWriteExecute
* [`1c1d9c49`](https://github.com/NixOS/nixpkgs/commit/1c1d9c499dfd4d82537d333b85bcb818f8eed49d) nixos/unit: rm MemoryDenyWriteExecute
* [`1e9bd5d9`](https://github.com/NixOS/nixpkgs/commit/1e9bd5d98ffecc4401b30b13b99e0c3945273e7b) pcre2: remove withJitSealloc
* [`54dd9efd`](https://github.com/NixOS/nixpkgs/commit/54dd9efd0425db996f547a45f5d42eb3a4eb6daa) python3Packages.tablib: 3.9.0 -> 3.10.0
* [`b8633aab`](https://github.com/NixOS/nixpkgs/commit/b8633aab225ee3848c8273e95bdd0d754f8a6123) libcanberra: replace systemd dependency with systemdLibs
* [`27d2abf6`](https://github.com/NixOS/nixpkgs/commit/27d2abf6dda2494b19095ea6ba9cd05ff71bd8f9) appstream: replace systemd dependency with systemdLibs
* [`6c224685`](https://github.com/NixOS/nixpkgs/commit/6c224685e7d93d59bfb2658e21ef69dfe2e0c2a8) gitea-mcp-server: 1.4.0 -> 1.6.0
* [`062b0604`](https://github.com/NixOS/nixpkgs/commit/062b060406e488282234810378a438e205d8404c) graphviz: 15.1.0 -> 15.1.1
* [`72ae5b35`](https://github.com/NixOS/nixpkgs/commit/72ae5b355f3c9d9d101e4cfd18d47007228b0c0d) libsodium: 1.0.22-unstable-2026-07-08 -> 1.0.22-unstable-2026-07-31
* [`b11a3626`](https://github.com/NixOS/nixpkgs/commit/b11a3626b181a882ac9a39e8f515b8816b3c0ea5) tree-sitter-grammars.tree-sitter-scala: 0.26.0 -> 0.26.2
* [`14f4b7af`](https://github.com/NixOS/nixpkgs/commit/14f4b7af5a50acfeac4814d0554576a3f8d43ec4) geoclue2: 2.8.1 -> 2.8.2
* [`3286713f`](https://github.com/NixOS/nixpkgs/commit/3286713f3ad1a7de9c0b5f10a183a120f11c487a) maintainers: add jjba23
* [`4a7534d8`](https://github.com/NixOS/nixpkgs/commit/4a7534d8a03f667c3cb2e29f047e9d8adf1f6f77) fmt: unconditionalize patch
* [`f8629eeb`](https://github.com/NixOS/nixpkgs/commit/f8629eeb4bd1f78b65bad68576a6d560a10f47ce) perlPackages.CSSMinifierXS: 0.13 -> 0.15
* [`27574bbd`](https://github.com/NixOS/nixpkgs/commit/27574bbdf94ffde412ac7343ae367dca5785e4d8) perlPackages.CGISession: 4.48 -> 4.49
* [`aa5e047d`](https://github.com/NixOS/nixpkgs/commit/aa5e047da036ff9e1165a1323e09e49b438537c8) perlPackages.HTMLGumbo: 0.18 -> 0.20
* [`9f90bb0e`](https://github.com/NixOS/nixpkgs/commit/9f90bb0e193dab691d56860e75aa226e9013e7cc) python3Packages.unittestCheckHook: make discover optional
* [`11acdf3f`](https://github.com/NixOS/nixpkgs/commit/11acdf3f307c8aa708e62655b7eab4832ac732eb) perlPackages.StringUtil: 1.34 -> 1.36
* [`e15ca91c`](https://github.com/NixOS/nixpkgs/commit/e15ca91c946f0e9285070114cccbac94c95d679f) xdg-desktop-portal-luminous: 0.1.14 -> 0.1.21
* [`d3988cb7`](https://github.com/NixOS/nixpkgs/commit/d3988cb7a81aa4dd16169f0d7db4c99513033c48) iproute2: add `man` output
* [`d24d4b22`](https://github.com/NixOS/nixpkgs/commit/d24d4b22cf1283f86b9b7ab9119f8b7745b6684b) iproute2: remove seemingly useless `DOCDIR`
* [`03c97e7c`](https://github.com/NixOS/nixpkgs/commit/03c97e7c65791fb395d90c5ed530d354d7180518) iproute2: use `finalAttrs`
* [`f4d68ec7`](https://github.com/NixOS/nixpkgs/commit/f4d68ec73cb33eccd8edbf5e4b69c169c7fa2175) iproute2: `strictDeps` & `__structuredAttrs`
* [`33aaeca5`](https://github.com/NixOS/nixpkgs/commit/33aaeca55443b2db97567b97ea26b700953a12ea) shadow: 4.20.0 -> 4.20.2
* [`c7968e66`](https://github.com/NixOS/nixpkgs/commit/c7968e66ccc13758495b21df33962df212c14790) libp11: set p11-kit proxy as default PKCS[nixos/nixpkgs⁠#11](https://togithub.com/nixos/nixpkgs/issues/11) module
* [`d8b1dee5`](https://github.com/NixOS/nixpkgs/commit/d8b1dee56d15ca443d277f3d5bbdbe1faccab3ee) nixos/tpm2: register pkcs11 module with p11-kit
* [`5aacebcd`](https://github.com/NixOS/nixpkgs/commit/5aacebcd9eca53ef64b5eba79121dab6e36cb459) python3Packages.jsonpatch: migrate to pyproject
* [`b35f431c`](https://github.com/NixOS/nixpkgs/commit/b35f431c0db72720057c30a247c847ccad84846f) python3Packages.jsonpatch: use finalAttrs, __structuredAttrs
* [`cd2e71a1`](https://github.com/NixOS/nixpkgs/commit/cd2e71a1ffaead88b457f710e8d308caccb63302) dwarf-fortress-packages.dwarf-fortress-original: 53.15 -> 53.16
* [`9d842783`](https://github.com/NixOS/nixpkgs/commit/9d84278364f097eb170070e5a5fca98cccfaa287) wivrn: enable building debug information
* [`a1f52543`](https://github.com/NixOS/nixpkgs/commit/a1f52543006d25261136adff8917b5743ac9887a) libffi: 3.7.1 -> 3.8.0
* [`670a1650`](https://github.com/NixOS/nixpkgs/commit/670a1650c2b924f116a77b493b306bbf2ec7f104) luajit_2_1: 2.1.1774638290 -> 2.1.1785577137
* [`933765c9`](https://github.com/NixOS/nixpkgs/commit/933765c9ecd54627caeaf66de401bed8a2ddb7c9) nspr: 4.39 -> 4.40
* [`a9ced6e8`](https://github.com/NixOS/nixpkgs/commit/a9ced6e8fa3dfc19c86ec1aa6cfcfb7ea03d2c51) comic-mono: use installFonts hook
* [`0b84fbbc`](https://github.com/NixOS/nixpkgs/commit/0b84fbbc359f06fbe1e932dc164ecf0d170f7038) comic-neue: use installFonts hook
* [`94f12b2d`](https://github.com/NixOS/nixpkgs/commit/94f12b2d47eaf619c00325f2959fa2ed5749fd53) comic-relief: use installFonts hook
* [`e823b289`](https://github.com/NixOS/nixpkgs/commit/e823b289fb8098b4bed9b703e28e714858fb7bac) commit-mono: use installFonts hook
* [`bf368596`](https://github.com/NixOS/nixpkgs/commit/bf36859642a3574cb7005219c6de83399a752a42) cozette: use installFonts hook
* [`7d1afed4`](https://github.com/NixOS/nixpkgs/commit/7d1afed48e67aa301107b61a59037a2b7186f648) scummvm: 2026.1.0 -> 2026.3.0
* [`f8e1ec09`](https://github.com/NixOS/nixpkgs/commit/f8e1ec09f3cb51326c024d2592eba53788f574db) scummvm: modernize, fix for strictDeps
* [`07f0083d`](https://github.com/NixOS/nixpkgs/commit/07f0083d2ef8ff5e50ba62276370c05093579599) nixos/tests/tpm2: check the p11-kit module registration
* [`a617c0f9`](https://github.com/NixOS/nixpkgs/commit/a617c0f9ec4a370e7dd74ae403089c4da733cfe9) python3Packages.tkinter: build with tcl/tk 9.0 for python 3.14+
* [`6e65a577`](https://github.com/NixOS/nixpkgs/commit/6e65a57779925b8fe04a405e3e4e9cf69efa4a7c) libp11: add a test for the default PKCS[nixos/nixpkgs⁠#11](https://togithub.com/nixos/nixpkgs/issues/11) module
* [`416c8cc9`](https://github.com/NixOS/nixpkgs/commit/416c8cc9a08bf3dac7e51a1c49aea1c23a54721f) mbedtls: enable __structuredAttrs
* [`5a2bdee4`](https://github.com/NixOS/nixpkgs/commit/5a2bdee423b8107ee7f157c3158b407610b426ab) python3Packages.openai: 2.41.1 -> 2.53.0
* [`cd5bb46c`](https://github.com/NixOS/nixpkgs/commit/cd5bb46c12bebc844ee81cbb8a3068bd2c90d18b) python3Packages.openai: don't propagate optional dependencies
* [`b5fa4928`](https://github.com/NixOS/nixpkgs/commit/b5fa4928ecbdcdd2d5f71f5654ddfcb7848ce72b) gogdl: 1.2.2 -> 1.3.0
* [`0ef4cd19`](https://github.com/NixOS/nixpkgs/commit/0ef4cd19ecb4d9789a6e1d22d3795f7ca11f051f) legendary-gl: 0.20.34 -> 0.21.0; modernize
* [`f0afd34d`](https://github.com/NixOS/nixpkgs/commit/f0afd34d132c7ea396141ee0ee6493b5ae1a3d8e) heroic{,-unwrapped}: 2.22.0 -> 2.22.1; use nixpkgs legendary-gl
* [`4c66635c`](https://github.com/NixOS/nixpkgs/commit/4c66635ceb0fc92946ddd287558cb3440c6d0e41) bison: enable strictDeps, rework hack
* [`82f41ea7`](https://github.com/NixOS/nixpkgs/commit/82f41ea74450c3dada7bc877f6b43578883b036f) gnugrep: use finalAttrs, substituteInPlace
* [`13a8f1e5`](https://github.com/NixOS/nixpkgs/commit/13a8f1e55a334a01a6a3d09eeb045d625f1b5059) nixos/wivrn: remove unnecessary default service environment variables
* [`2c27e0e3`](https://github.com/NixOS/nixpkgs/commit/2c27e0e3ae83b81425193d5b4951584e43265798) hdrhistogram_c: fix pkgsStatic build
* [`94143794`](https://github.com/NixOS/nixpkgs/commit/94143794fa17ce4d0e40a6e007b2d11a62be0a40) taws: init at 1.2.1
* [`487b6cb0`](https://github.com/NixOS/nixpkgs/commit/487b6cb0d06cab1ad702b3795bf39e62e978cc95) azure-mcp: 3.0.0-beta.10 -> 3.0.0-beta.33
* [`e36b5c4e`](https://github.com/NixOS/nixpkgs/commit/e36b5c4e08699da405b2c321dd7776f8f7803daf) linphonePackages.linphone-desktop: 6.1.0 -> 6.2.0
* [`1c73436b`](https://github.com/NixOS/nixpkgs/commit/1c73436b36ada692ce5e20170822f90354e85c5c) linphonePackages.bc-zxing-cpp: init at 1.4.0-unstable-2026-08-08
* [`b1a9df51`](https://github.com/NixOS/nixpkgs/commit/b1a9df5125ab5083e73feb43e58bd5db2b540cb8) linphonePackages.liblinphone: use BC's fork of zxing-cpp
* [`54d7f724`](https://github.com/NixOS/nixpkgs/commit/54d7f724c55705fcf4d39967d30891074ae9cbbb) python3Packages.typing-inspection: 0.4.2 -> 0.4.3
* [`7b6d7a9c`](https://github.com/NixOS/nixpkgs/commit/7b6d7a9c5b4a2838f2a25ab4ffdf1326491ad822) python3Packages.typing-inspection: use finalAttrs
* [`e0eae1eb`](https://github.com/NixOS/nixpkgs/commit/e0eae1eb29b12f71bf9a00bbe70f06f28fbc7a0d) linphonePackages.linphone-desktop: don't create a `.desktop` file under `~/.local/share/applications`
* [`6161b52e`](https://github.com/NixOS/nixpkgs/commit/6161b52e030c78b7b94fc2fc50e60f2be2a29615) xlights: 2026.12 -> 2026.15
* [`39748eac`](https://github.com/NixOS/nixpkgs/commit/39748eac906d795f3cd811a047ab3fc9913de413) openrct2: support darwin
* [`28d2b87c`](https://github.com/NixOS/nixpkgs/commit/28d2b87c1bcb39bb60d1e5c08a66b02f11c404f2) libinput: specify propagatedBuildOutputs to keep `bin` out of `dev` output
* [`bb97c818`](https://github.com/NixOS/nixpkgs/commit/bb97c818552140416fbbe347c6ae9b4e24e76836) grafanaPlugins.victoriametrics-logs-datasource: 0.30.1 -> 0.31.0
* [`58abfa5c`](https://github.com/NixOS/nixpkgs/commit/58abfa5c4a15ddbe2d9bf6b466d7775ac0409b43) mimalloc: 3.3.2 -> 3.4.5
* [`16cf4a50`](https://github.com/NixOS/nixpkgs/commit/16cf4a503d4016ccbd43276cf0da4baf8fc00b51) elfutils: enable strictDeps
* [`79a0d9bc`](https://github.com/NixOS/nixpkgs/commit/79a0d9bcb3d0c9fa33cd0de36faea4520e5282e9) elfutils: enable structuredAttrs
* [`522dff49`](https://github.com/NixOS/nixpkgs/commit/522dff49c09ccd06162a42757cd113ddef9a44f2) gnutls: enable strictDeps
* [`34ed5d8f`](https://github.com/NixOS/nixpkgs/commit/34ed5d8fcf1f744d282f5c0f398d6c35d99d9287) gnutls: enable structuredAttrs, use finalAttrs
* [`ab0d16db`](https://github.com/NixOS/nixpkgs/commit/ab0d16db059bf354c8a3d8d154131b4e1137250d) ed: enable structuredAttrs
* [`49076b4e`](https://github.com/NixOS/nixpkgs/commit/49076b4ec84292406e66262a7ed7d028dcfe6a6c) expat: 2.8.2 -> 2.8.3
* [`b85b77fd`](https://github.com/NixOS/nixpkgs/commit/b85b77fdb06f04a41b24f11c887f960ba244df17) libtool_1_5: enable strictDeps
* [`7231d490`](https://github.com/NixOS/nixpkgs/commit/7231d4909aea12f3639ff43bb7d9d856963730e9) libtool_1_5: enable structuredAttrs, use finalAttrs
* [`d9d827b8`](https://github.com/NixOS/nixpkgs/commit/d9d827b829edfa651b86542c34e2a1bfb4e27002) libtool: enable structuredAttrs, use finalAttrs
* [`c651e6c1`](https://github.com/NixOS/nixpkgs/commit/c651e6c110948c81ea7ec5c86e46e9fa6fdd93a2) libiconv: enable strictDeps
* [`a3a46b2e`](https://github.com/NixOS/nixpkgs/commit/a3a46b2ed29773f210a0afa433f43c0ff8357cb8) gnupatch: enable structuredAttrs
* [`7d707983`](https://github.com/NixOS/nixpkgs/commit/7d70798391429da7a7911a5fc07b6e0de84dd413) gnumake: enable structuredAttrs, use hash
* [`3bda6b67`](https://github.com/NixOS/nixpkgs/commit/3bda6b678a764205b2437d761d3ca05a345f0e26) auto-patchelf: add --relativize-rpath argument for inferring `$ORIGIN`
* [`191fb7ce`](https://github.com/NixOS/nixpkgs/commit/191fb7ce4035608c2d56a1750d0acd9aa3582b1c) tests.auto-patchelf-hook-relativize-rpath: init
* [`312c732c`](https://github.com/NixOS/nixpkgs/commit/312c732c5e94977dc03be5fb159fde6a27af7f61) samba: replace systemd dependency with systemdLibs
* [`e74710c0`](https://github.com/NixOS/nixpkgs/commit/e74710c0a2d413cafb017d807cb695b887c14351) udisks: replace systemd dependency with systemdLibs
* [`16f4316b`](https://github.com/NixOS/nixpkgs/commit/16f4316b147f18e0752c5fd85c8a395fb5386188) libedit: enable strictDeps
* [`40495abe`](https://github.com/NixOS/nixpkgs/commit/40495abefe7c80ae88500626d79ca385d23461c9) libedit: enable structuredAttrs
* [`338dc981`](https://github.com/NixOS/nixpkgs/commit/338dc981d72996a3cf6b8b4e5ebcb2e3578745d5) libev: enable strictDeps
* [`30197d3e`](https://github.com/NixOS/nixpkgs/commit/30197d3e6e665fdffe5d31878f1e07b7786333a8) libev: enable structuredAttrs
* [`c73a3946`](https://github.com/NixOS/nixpkgs/commit/c73a39460b19ba377bed99e588edb81ebbe64942) rhash: enable strictDeps
* [`088ba535`](https://github.com/NixOS/nixpkgs/commit/088ba535bbc5de88b49f33a27e2af7c531e9cc78) rhash: enable structuredAttrs, use tag/hash
* [`e3fe4e82`](https://github.com/NixOS/nixpkgs/commit/e3fe4e8207d622547c821dacdbc88fdd93daea0a) nettle: enable strictDeps
* [`911921f0`](https://github.com/NixOS/nixpkgs/commit/911921f0a3251222124e5bc09963451148e8cce3) nettle: enable structuredAttrs
* [`9b751352`](https://github.com/NixOS/nixpkgs/commit/9b751352cb50a6544ccdcd0af906e385da421052) mpdecimal: enable strictDeps
* [`96635cdc`](https://github.com/NixOS/nixpkgs/commit/96635cdcabe8f58e2d2f6f7825d1ba48f71f9e93) mpdecimal: enable structuredAttrs
* [`53c7fb0c`](https://github.com/NixOS/nixpkgs/commit/53c7fb0c804e8b8a5cad426dca1cebcb8b508409) asciidoc: enable structuredAttrs, use tag
* [`bb25905f`](https://github.com/NixOS/nixpkgs/commit/bb25905f349f181c434fb8e097dd82dbea1ae2a6) auto-patchelf: enable structuredAttrs
* [`672b9525`](https://github.com/NixOS/nixpkgs/commit/672b952591dc27ba2f02758e56f934e69d1aa785) gtest: enable structuredAttrs, use tag
* [`0c23120b`](https://github.com/NixOS/nixpkgs/commit/0c23120b99ee6476766835928a96c550dd66d780) gtk-doc: enable structuredAttrs, use finalAttrs
* [`72b0888c`](https://github.com/NixOS/nixpkgs/commit/72b0888cd3b54840fc92394e02279f678c267cae) ninja: enable structuredAttrs
* [`fa5bcd11`](https://github.com/NixOS/nixpkgs/commit/fa5bcd11712a0db9676124a3a7752cc49fa6471d) zlib-ng: enable structuredAttrs, use tag
* [`ac0e8148`](https://github.com/NixOS/nixpkgs/commit/ac0e8148b7b637728b832f03b0d400c0b17f63fe) ngtcp2{,-gnutls}: enable structuredAttrs, use finalAttrs
* [`a146e758`](https://github.com/NixOS/nixpkgs/commit/a146e75868551d71b6a8ee9ca3df650afdfdb0e6) ninja: enable strictDeps
* [`9bcd63e5`](https://github.com/NixOS/nixpkgs/commit/9bcd63e541f8700682f3892a57aef4862317f08d) gtest: enable strictDeps
* [`4645c076`](https://github.com/NixOS/nixpkgs/commit/4645c076877016315471eef418289eb40ac165fc) autoconf269: enable strictDeps
* [`e86ec915`](https://github.com/NixOS/nixpkgs/commit/e86ec915a5d377c51027944647d31961e9aa4636) autoconf269: use sri hash
* [`bef5e44c`](https://github.com/NixOS/nixpkgs/commit/bef5e44caf45df44d7ce3857b0dfc3edcd9d664f) automake116x: use sri hash
* [`2f81cc90`](https://github.com/NixOS/nixpkgs/commit/2f81cc90301d0bb3a2876ce3fc95617398d23d3e) ngtcp2{,-gnutls}: enable strictDeps
* [`5baff07c`](https://github.com/NixOS/nixpkgs/commit/5baff07c874a068ca598dfacf36f9e0b213c9efa) luajit_2_1: 2.1.1785577137 -> 2.1.1785763465
* [`7d3b01a9`](https://github.com/NixOS/nixpkgs/commit/7d3b01a9ffa51e7b71a0ff0021f55d0ce711a69f) lmdb: 0.9.35 -> 0.9.36
* [`137c0524`](https://github.com/NixOS/nixpkgs/commit/137c05240f839a0084fc1e60427ebf9a34fe5aec) gstreamer: 1.28.5 -> 1.28.6
* [`a0ea1f70`](https://github.com/NixOS/nixpkgs/commit/a0ea1f703ad59e366a2a4df1ccb47aef3e107a51) python3Packages.gst-python: 1.28.5 -> 1.28.6
* [`8b008fc2`](https://github.com/NixOS/nixpkgs/commit/8b008fc26835247a527558d4e125f482f937499e) gst_all_1.gst-plugins-base: refactor mesonFlags
* [`3c13877d`](https://github.com/NixOS/nixpkgs/commit/3c13877d44d36f7c6f3f8c4ad3e76602d197d7b3) gst_all_1.gst-plugins-good: refactor mesonFlags
* [`1dc7c8fa`](https://github.com/NixOS/nixpkgs/commit/1dc7c8fac4dce2a3d07c15271ab83510a868eb28) libffi: enable structuredAttrs
* [`61a85857`](https://github.com/NixOS/nixpkgs/commit/61a85857c6f0a432f693defbf81b6c0e60826e0e) sstorytime: init at 0-unstable-2026-08-12
* [`6ac83a37`](https://github.com/NixOS/nixpkgs/commit/6ac83a376257ad84178d59e76d1fd72ee49c6937) minimal-bootstrap: stage0: enable structuredAttrs for libc in dummyStdenv
* [`e8434ae0`](https://github.com/NixOS/nixpkgs/commit/e8434ae083d0cb4182b5e511d823dae31299aad5) minimal-bootstrap: stage2: move NIX_CFLAGS_COMPILE override into env
* [`9b7c6984`](https://github.com/NixOS/nixpkgs/commit/9b7c6984563be8b629e9532c31de800bf06bca0c) libidn2: enable structuredAttrs, use finalAttrs
* [`67f2ae77`](https://github.com/NixOS/nixpkgs/commit/67f2ae770a79ca7e3adee6f62300ebf1d538b33a) libidn2: remove unused argument
* [`7611d6ee`](https://github.com/NixOS/nixpkgs/commit/7611d6ee9aa7518c29a4a86dc6732b5af15377c4) binutils-patchelfed-ld: enable structuredAttrs
* [`8f933eda`](https://github.com/NixOS/nixpkgs/commit/8f933eda6c2aecd109ce1005dcce431983a36647) gzip: enable strictDeps
* [`3fff8a93`](https://github.com/NixOS/nixpkgs/commit/3fff8a9301dc1d382776cb44483e777204cdb68f) gzip: enable structuredAttrs
* [`242747fe`](https://github.com/NixOS/nixpkgs/commit/242747fe8a8c16368471b9339f77f531d4b2525e) autoconf-archive: enable structuredAttrs
* [`4101a91e`](https://github.com/NixOS/nixpkgs/commit/4101a91e99d5927bd40a99f844026331f080885e) dns-root-data: enable strictDeps, enable structuredAttrs
* [`7c6ad2e2`](https://github.com/NixOS/nixpkgs/commit/7c6ad2e2ca8c860df9fce06ed8f5f2b8860d6327) libuv: enable strictDeps
* [`9c7408f7`](https://github.com/NixOS/nixpkgs/commit/9c7408f7726d53c754e3ec488ebd210c58863631) expat: enable structuredAttrs
* [`723fcbdd`](https://github.com/NixOS/nixpkgs/commit/723fcbddfc2c2777a2551891afc558d7d87187e2) libssh2: enable strictDeps
* [`802b7402`](https://github.com/NixOS/nixpkgs/commit/802b74024344bacc11a737db3f72bc2d7d289945) libssh2: enable structuredAttrs
* [`2d8dde53`](https://github.com/NixOS/nixpkgs/commit/2d8dde5339215717a4e83eac00c48cc9bc09dbd1) cunit: enable strictDeps
* [`6328665d`](https://github.com/NixOS/nixpkgs/commit/6328665df8135963ff9b29b74cc72dbef5757bbd) cunit: enable structuredAttrs
* [`f3dc70c2`](https://github.com/NixOS/nixpkgs/commit/f3dc70c259c80eca1c86a1aaa21ab4220f52d367) gdbm: enable strictDeps
* [`b79b6323`](https://github.com/NixOS/nixpkgs/commit/b79b63239a611d9fcd98683e4a7cd1691d7c69c0) gdbm: enable structuredAttrs
* [`c13c277d`](https://github.com/NixOS/nixpkgs/commit/c13c277dbde4ed41bea290522a3c53d46fd61f48) libevent: enable strictDeps
* [`6c859e66`](https://github.com/NixOS/nixpkgs/commit/6c859e663663292c93358380d240ffc248372edd) libevent: enable structuredAttrs, use hash
* [`fd87d300`](https://github.com/NixOS/nixpkgs/commit/fd87d300945c8f0179de468eac34df32e32296d3) libtasn1: enable strictDeps
* [`64ebebda`](https://github.com/NixOS/nixpkgs/commit/64ebebdab1d4c7ff231777ea904211bd345d6294) libtasn1: enable structuredAttrs
* [`64856d04`](https://github.com/NixOS/nixpkgs/commit/64856d04debcb459cfbaeb7957f6fc8b2885714d) python3Packages.datamodel-code-generator: fix failing test on Darwin
* [`ab0b6d2c`](https://github.com/NixOS/nixpkgs/commit/ab0b6d2c82044a68c6d895d4b80a44016a9bb927) net-tools: enable strictDeps
* [`a66df804`](https://github.com/NixOS/nixpkgs/commit/a66df804a468a6c922c75f45bcc87b02d6d4043d) net-tools: enable structuredAttrs, use finalAttrs, hash
* [`2ffabbce`](https://github.com/NixOS/nixpkgs/commit/2ffabbce38775c46ea2ad3b48ed7c082c33d0f24) libxml2: enable structuredAttrs
* [`b7fc755c`](https://github.com/NixOS/nixpkgs/commit/b7fc755c29d91e82925cd41e16a69d4b7c43cee2) zstd: enable strictDeps
* [`61a3d2b3`](https://github.com/NixOS/nixpkgs/commit/61a3d2b3c016c7c865d321b1156e878ffb6b6bd6) zstd: enable structuredAttrs, use tag
* [`223da789`](https://github.com/NixOS/nixpkgs/commit/223da789c8100732b67ac8c7bcfa0a046608a37e) libgcrypt: enable structuredAttrs, use finalAttrs
* [`978442ed`](https://github.com/NixOS/nixpkgs/commit/978442edde457484a4c04618927532399d08c3cc) tzdata: enable strictDeps, enable structuredAttrs
* [`515a68fa`](https://github.com/NixOS/nixpkgs/commit/515a68fad06e1025e930a6b4916e78faeb3e1413) swig: enable structuredAttrs, use tag
* [`f53d3b86`](https://github.com/NixOS/nixpkgs/commit/f53d3b8607a3cd5d713521a13892043535a2ce20) publicsuffix-list: enable strictDeps, enable structuredAttrs
* [`4a2272cd`](https://github.com/NixOS/nixpkgs/commit/4a2272cd68b28ea803a23ef42fc04da00858bbd7) lzo: enable structuredAttrs
* [`8f6f404a`](https://github.com/NixOS/nixpkgs/commit/8f6f404a44bf4b56835b6338c34463b2f0120a37) lzo: use sri hash
* [`49e12b08`](https://github.com/NixOS/nixpkgs/commit/49e12b0826d421d2c77ff5ab4b65a5bfc747c0ac) libxslt: enable structuredAttrs
* [`7072d88d`](https://github.com/NixOS/nixpkgs/commit/7072d88d5e8593a9e4aecbee46bcc39e7a76f6a0) nghttp2: enable strictDeps
* [`a2b20fc0`](https://github.com/NixOS/nixpkgs/commit/a2b20fc065590f34f82a9e81d71568466c883bba) nghttp2: enable structuredAttrs, use finalAttrs
* [`24a79c44`](https://github.com/NixOS/nixpkgs/commit/24a79c448adbafabce5dab7a879fd7bdd00216ce) musl-fts: enable strictDeps
* [`72103b68`](https://github.com/NixOS/nixpkgs/commit/72103b68c4cb3570d65339f6f5228800a19ed86a) musl-fts: enable structuredAttrs, use tag
* [`bef44b53`](https://github.com/NixOS/nixpkgs/commit/bef44b5305824f6c055ac6833d2fe371e8681b38) musl-obstack: enable strictDeps
* [`b8ce44e5`](https://github.com/NixOS/nixpkgs/commit/b8ce44e58235e158993a474b3fd01dca5f383aef) musl-obstack: enable structuredAttrs, use tag
* [`0e999569`](https://github.com/NixOS/nixpkgs/commit/0e99956984de69eb3697918b3eed08b1a32be120) nghttp3: enable strictDeps
* [`6d8416f4`](https://github.com/NixOS/nixpkgs/commit/6d8416f4edb57e05b18b65400b4fc6ec2fb387eb) nghttp3: enable structuredAttrs
* [`68ee3c81`](https://github.com/NixOS/nixpkgs/commit/68ee3c81244ca4758ac07ed08ce248579e444db4) libarchive: enable strictDeps
* [`27ff9592`](https://github.com/NixOS/nixpkgs/commit/27ff9592b5b79aabcc68f38b38546b339a25af71) libarchive: enable structuredAttrs
* [`1637d349`](https://github.com/NixOS/nixpkgs/commit/1637d349797dc8e7fc6848c2d4dd6859469a4366) brotli: enable strictDeps
* [`89aa16b6`](https://github.com/NixOS/nixpkgs/commit/89aa16b64250fc43ec2b6a933ac79b4ddcd0aaf0) brotli: enable structuredAttrs
* [`75bd101d`](https://github.com/NixOS/nixpkgs/commit/75bd101d2665506521cdbd83f13931f33c64c332) util-linux: enable strictDeps
* [`3fc9dda8`](https://github.com/NixOS/nixpkgs/commit/3fc9dda8d5a113be2ea0dc2b55a0db59d9c03916) util-linux: enable structuredAttrs
* [`cc022802`](https://github.com/NixOS/nixpkgs/commit/cc022802b463ba3e11fed6426e007205eba2ef64) python3: enable strictDeps
* [`6699a477`](https://github.com/NixOS/nixpkgs/commit/6699a477c8a29f824f1190c9c48ae1907465432a) python3-bootstrap: enable strictDeps, enable structuredAttrs
* [`c330f745`](https://github.com/NixOS/nixpkgs/commit/c330f7459666d77c6d5866a47eec640669397a1c) help2man: enable structuredAttrs
* [`76e94ff2`](https://github.com/NixOS/nixpkgs/commit/76e94ff2d0220b29ebb12223b732f9c8e0d115c7) argp-standalone: enable strictDeps
* [`0d1ecdbf`](https://github.com/NixOS/nixpkgs/commit/0d1ecdbf033355eeffa9b0f9f959fcd9640c87b0) argp-standalone: enable structuredAttrs
* [`5f3cc208`](https://github.com/NixOS/nixpkgs/commit/5f3cc208a38376e196c3259a2186371e9dd0bb8a) dash: enable structuredAttrs
* [`8afda891`](https://github.com/NixOS/nixpkgs/commit/8afda891b48915ece358dbf2d8cdb5b4e07a17f9) getopt: enable strictDeps
* [`d9df72fe`](https://github.com/NixOS/nixpkgs/commit/d9df72fe201997739b39878191e9f3795b12a6bc) getopt: enable structuredAttrs
* [`363309e1`](https://github.com/NixOS/nixpkgs/commit/363309e1b8697370a9f42bdd905246a669a78b93) libpfm: enable strictDeps
* [`f2d074fb`](https://github.com/NixOS/nixpkgs/commit/f2d074fb4c6b58eff64d48feece0df871fa9e38a) libpfm: enable structuredAttrs
* [`107cb328`](https://github.com/NixOS/nixpkgs/commit/107cb3287c2a51ff1434dfd2429c4c2006d4cc98) nss-cacert: enable strictDeps
* [`0e72b805`](https://github.com/NixOS/nixpkgs/commit/0e72b80587d46282c9b1a7f5ea8f5a9a98a1c9ab) nss-cacert: enable structuredAttrs
* [`0389af1b`](https://github.com/NixOS/nixpkgs/commit/0389af1b9fe92ffdf73df91cc2fcb98fef1cc06b) mathematica: 15.0.0 -> 15.0.1
* [`d69298fa`](https://github.com/NixOS/nixpkgs/commit/d69298faf382b2bf589f1ddc83f3f5d95bfd27b8) llvmPackages_23: 23.1.0-rc2 -> 23.1.0-rc3
* [`65e06852`](https://github.com/NixOS/nixpkgs/commit/65e0685245cc06ba6db5aaa457f6aed0b03de104) libtasn1: use optionalString, newer $(...) bash syntax
* [`709a758b`](https://github.com/NixOS/nixpkgs/commit/709a758bfcd66bdecf728767aa69714b7c35e8ad) zvbi: 0.2.44 -> 0.2.45
* [`2c8a0461`](https://github.com/NixOS/nixpkgs/commit/2c8a0461d23ba38d0f3ebc041e4b935dd5c7f1ef) ci/nixpkgs-vet: use temporary Nix store
* [`1b5ccc3a`](https://github.com/NixOS/nixpkgs/commit/1b5ccc3af519b9dadb220ca9f273fd7903795284) openrct2: condense per platform logic
* [`ffe4cab9`](https://github.com/NixOS/nixpkgs/commit/ffe4cab9bcca3cd43f246057b2270e3d37f36fc7) openrct2: add schrobingus as maintainer
* [`1b5674a2`](https://github.com/NixOS/nixpkgs/commit/1b5674a21ba58a9366a8af6256c60dfd43ed52f3) Revert "minimal-bootstrap.glibc: 2.42 -> 2.44"
* [`a2423f21`](https://github.com/NixOS/nixpkgs/commit/a2423f21102a9073d56bff697e1b467843c3cafc) valhalla: 3.6.3 -> 3.8.3
* [`c12fda4a`](https://github.com/NixOS/nixpkgs/commit/c12fda4aebc9ce91bc53bdfe407895c9fd8cba30) valhalla: migrate to pkgs/by-name
* [`b5d66a98`](https://github.com/NixOS/nixpkgs/commit/b5d66a98db3de26e1774b03a0c5a380bb8b6d300) valhalla: add karlbeecken to maintainers
* [`efef4deb`](https://github.com/NixOS/nixpkgs/commit/efef4deb458e5d0234c7ebf3b15e3abf984019a9) go_1_26: 1.26.5 -> 1.26.6
* [`31775096`](https://github.com/NixOS/nixpkgs/commit/31775096ecdabf36a6b14d7aa411bfd36ff27dbc) libcamera: 0.7.0 -> 0.7.1
* [`038675af`](https://github.com/NixOS/nixpkgs/commit/038675afe21c6abaf00a1954160fb90a1f35b9c5) libcamera: 0.7.1 -> 0.7.2
* [`83a43807`](https://github.com/NixOS/nixpkgs/commit/83a43807304780f08dfe6b37a631bc321ed4859c) maintainers: add idkdontaskm3
* [`0524a6c5`](https://github.com/NixOS/nixpkgs/commit/0524a6c5bbd4d88b1f85fcb4ead061918b0aae26) rsync: enable strictDeps
* [`332fb9fa`](https://github.com/NixOS/nixpkgs/commit/332fb9faf98e143410bf0503233eb77b4f4c544a) mediaharbor: init at 2.1.0
* [`65e9f2c0`](https://github.com/NixOS/nixpkgs/commit/65e9f2c04429a9f8787f2d376092a2829ec5d307) libpisp: 1.2.1 -> 1.7.0
* [`278d4d59`](https://github.com/NixOS/nixpkgs/commit/278d4d59cf8b300aa63ca22905d3d563ebf6273d) ffmpeg_9: 9.0 -> 9.0.1
* [`254d04d4`](https://github.com/NixOS/nixpkgs/commit/254d04d4bc8095e8aa8933d9d2b3cb7f06bcac89) unifont: fix cross compilation
* [`64710d6c`](https://github.com/NixOS/nixpkgs/commit/64710d6cc7c15eb7c25d7cc1de01fc3e6ecfed30) nodejs_22,nodejs_24: fix builds with Ada 4.x
* [`24f54f91`](https://github.com/NixOS/nixpkgs/commit/24f54f91271f30a3a5beb68d0c6d41c19d6224e0) opendht: 3.5.4 -> 4.3.1
* [`2d933e02`](https://github.com/NixOS/nixpkgs/commit/2d933e02e27a926d430bb7be5d89064d0e746fde) jami: 20251124.0 -> 20260811.0
* [`8e1d4e81`](https://github.com/NixOS/nixpkgs/commit/8e1d4e81b470df70bf12a775082d3ba20ca6666f) gnused: enable structuredAttrs, use finalAttrs, hash
* [`1716f796`](https://github.com/NixOS/nixpkgs/commit/1716f7964658f9a9987398b6405c87dcfa711234) jq: enable structuredAttrs
* [`e1a66489`](https://github.com/NixOS/nixpkgs/commit/e1a664891adcca96b92b78a1a3edc3d6d79c5b38) libuv: enable structuredAttrs, use tag, reorder args
* [`fdb44f23`](https://github.com/NixOS/nixpkgs/commit/fdb44f23c76087dd7b34d45147071250bc21197a) libuv: remove test hack
* [`a3c24cd2`](https://github.com/NixOS/nixpkgs/commit/a3c24cd214fea98863b733343c7ee8b21740fd96) git: enable strictDeps
* [`c0c3749e`](https://github.com/NixOS/nixpkgs/commit/c0c3749ea6d3f7597613b6428fddffad1c30cd54) git: remove uses of *FlagsArray
* [`e70344ac`](https://github.com/NixOS/nixpkgs/commit/e70344ac2d05ef5864c06b91b7933a0c28544c87) abseil*: enable structuredAttrs
* [`2a0f4fb6`](https://github.com/NixOS/nixpkgs/commit/2a0f4fb6e574840e844943f173c2bd8a058ccf22) boost-build: enable strictDeps
* [`6f695ecc`](https://github.com/NixOS/nixpkgs/commit/6f695ecc0ae5df297890dcfa0a1265406ae747f4) boost-build: enable structuredAttrs, use tag
* [`b970e996`](https://github.com/NixOS/nixpkgs/commit/b970e996081be10e3c41ba6b2ac80bb2ce8090bd) catch2: enable strictDeps
* [`a512cc03`](https://github.com/NixOS/nixpkgs/commit/a512cc03d66083c8ea983b7c9c22381a12cb0199) catch2: enable structuredAttrs, use tag/hash
* [`63c29e78`](https://github.com/NixOS/nixpkgs/commit/63c29e785dc57df76a0923c0bce3223b552d3121) eigen: enable strictDeps
* [`ccad2c35`](https://github.com/NixOS/nixpkgs/commit/ccad2c35cc6e36eff126dbba35a4a49b9120d35a) eigen: enable structuredAttrs
* [`643d4dd1`](https://github.com/NixOS/nixpkgs/commit/643d4dd16962eef129e6ccb3924e1810391c8366) gbenchmark: enable strictDeps
* [`9bf76edf`](https://github.com/NixOS/nixpkgs/commit/9bf76edf5a200c2b4c4e514caf341f3df062284b) gbenchmark: enable structuredAttrs
* [`9c865cbc`](https://github.com/NixOS/nixpkgs/commit/9c865cbc73b4a308ca5da4ca15e14ffd5809731c) maturin: enable structuredAttrs
* [`b46d3023`](https://github.com/NixOS/nixpkgs/commit/b46d3023494e8bb95fc550a731005896d63fa655) re2: enable strictDeps
* [`6502d61f`](https://github.com/NixOS/nixpkgs/commit/6502d61f22617795474d3539d599cd8b12cba3a0) re2: enable structuredAttrs, use tag
* [`f93982ce`](https://github.com/NixOS/nixpkgs/commit/f93982ce4da94ba29eb09a28b94e6a1d28aadf53) lua: enable strictDeps
* [`d45d9dc1`](https://github.com/NixOS/nixpkgs/commit/d45d9dc17fb47307cdb97c0d4807a7f57c3fe381) lua: enable structuredAttrs
* [`77f6b3a6`](https://github.com/NixOS/nixpkgs/commit/77f6b3a664313bd88030ae9c52c2c3a960c3c058) lib.isFunction: add tests
* [`703a4f5e`](https://github.com/NixOS/nixpkgs/commit/703a4f5e0084d91a52a5098e0bb1ca0e26947f6c) lib.isFunction: failing test for non-function __functor
* [`707263e1`](https://github.com/NixOS/nixpkgs/commit/707263e1ba56a9ff03c7cfedf59bf41f3baf8f16) lib.isFunction: no error on non-function __functor
* [`c03412a5`](https://github.com/NixOS/nixpkgs/commit/c03412a579931bd6a7da551ea3973ea3e8c04dd9) tree-sitter-grammars.tree-sitter-diff: 0.1.0 -> 0.2.0
* [`b2dbab49`](https://github.com/NixOS/nixpkgs/commit/b2dbab49281688bdf6e2bfc72cf165e1c77c4c53) cpio: patch CVE-2026-66484, CVE-2026-66485, and CVE-2026-66486
* [`1e1128d4`](https://github.com/NixOS/nixpkgs/commit/1e1128d44308d31fef7d5372bafe89d9bd496eca) libpq: 18.4 -> 18.16
* [`f1f02f03`](https://github.com/NixOS/nixpkgs/commit/f1f02f03cf9a86b9b703ee27840aca9e35e8fc24) aroccPackages.latest-unwrapped: 0-unstable-2025-11-09 -> 0-unstable-2026-04-02
* [`637ca626`](https://github.com/NixOS/nixpkgs/commit/637ca626d2c6c2239651c0bd5aa6df4e1d1b666e) frame-media-converter: 0.31.1 -> 0.33.0
* [`f9ef1d4a`](https://github.com/NixOS/nixpkgs/commit/f9ef1d4ae61cf45819bd74866656e10f009beec8) sandhole: 0.10.2 -> 0.10.3
* [`dac0cee4`](https://github.com/NixOS/nixpkgs/commit/dac0cee4b760a8e8a02104e586fbff2021f67fe1) python3Packages.matplotlib: fix 64 bit -> 32 bit cross
* [`9f4391b1`](https://github.com/NixOS/nixpkgs/commit/9f4391b1d34b02c1b19cb23abd6f79ebef3c87a6) angie: refactor
* [`b120c4cd`](https://github.com/NixOS/nixpkgs/commit/b120c4cd31beae0905cdbae44422175e0dac6f3c) publicsuffix-list: 0-unstable-2026-07-25 -> 0-unstable-2026-08-14
* [`3ea3d743`](https://github.com/NixOS/nixpkgs/commit/3ea3d743cf7def854d9afcdc019647d751148477) jellystat: init at 1.1.11
* [`1c472382`](https://github.com/NixOS/nixpkgs/commit/1c47238221852445f3db3d8a44f2e7ca4bf9cf4d) deno: 2.9.4 -> 2.9.5; rusty-v8: 150.2.0 -> 150.4.0
* [`219eb510`](https://github.com/NixOS/nixpkgs/commit/219eb510152380ee0a36bcd9e55ea36d2a423cef) libpfm: use hash, --replace-fail, group env variables
* [`6b4f2f7a`](https://github.com/NixOS/nixpkgs/commit/6b4f2f7a4d15e63f39d051d464b679264120dfce) ocamlPackages.jsont: 0.2.0 -> 0.3.0
* [`faa34e1e`](https://github.com/NixOS/nixpkgs/commit/faa34e1e7ec3b291375e562f52db3c0cef814ae4) auto-patchelf: enable strictDeps
* [`44960af2`](https://github.com/NixOS/nixpkgs/commit/44960af248d1a8a7b91cbfafaf2136447785dbfc) indilib: 2.2.0 -> 2.2.4.2
* [`f7c0e196`](https://github.com/NixOS/nixpkgs/commit/f7c0e196290e3192a64b6b6110816245ba7c3455) indi-3rdparty: 2.2.0 -> 2.2.4
* [`f68edbe3`](https://github.com/NixOS/nixpkgs/commit/f68edbe38a50e3ef013d093b5d23b175f018e293) famistudio: 4.5.2 -> 4.5.3
* [`3355d916`](https://github.com/NixOS/nixpkgs/commit/3355d9161fdce48d390f7275ff1c6e0cd7f6fb29) kener: init at 4.1.2
* [`2bc37d02`](https://github.com/NixOS/nixpkgs/commit/2bc37d02909dcdcf91523863b2c9c15cbad62b1c) maintainers: add mmfallacy
* [`dd959a04`](https://github.com/NixOS/nixpkgs/commit/dd959a04269a5e34d8585337da8491b53e6af285) nixos/kener: init module
* [`e9c40c11`](https://github.com/NixOS/nixpkgs/commit/e9c40c11afed1a6135abd5947b8ca924e8678048) stb: 0-unstable-2023-01-29 -> 0-unstable-2026-04-15
* [`a47159a5`](https://github.com/NixOS/nixpkgs/commit/a47159a51a7f37e59cca3b2c0cd8ac44b5c6fa84) noctalia{,-greeter}: Remove stb override
* [`9ebef1f4`](https://github.com/NixOS/nixpkgs/commit/9ebef1f4f325e71c294b1fa85afb61f46bd26b05) various: remove stb_image.h fetchers
* [`d24151ce`](https://github.com/NixOS/nixpkgs/commit/d24151ceecbdeb1f1aa3896d3d3478b52013bc24) cfitsio: 4.6.4 -> 4.7.0
* [`de9147b6`](https://github.com/NixOS/nixpkgs/commit/de9147b6d15237256fe4c622e094ce94daf65214) rufin: 0.12.5 -> 0.13.1
* [`e119515f`](https://github.com/NixOS/nixpkgs/commit/e119515fbb4b58ffaa3239bac5450d542a60b297) python3Packages.pyarrow: use pure tzdata in tests
* [`dc161856`](https://github.com/NixOS/nixpkgs/commit/dc1618565dccb3246eebc9f9b0fa1be9770225eb) strace: enable strictDeps
* [`8c5882a4`](https://github.com/NixOS/nixpkgs/commit/8c5882a4d84e1fa359b95a345d664301cb277327) strace: enable structuredAttrs, move enableParallelBuilding
* [`c82ff0ab`](https://github.com/NixOS/nixpkgs/commit/c82ff0ab02ecd25cd9f43fb10d9418f260983736) makeSetupHook: use explicit substitution and enable structuredAttrs
* [`ed9d6018`](https://github.com/NixOS/nixpkgs/commit/ed9d6018dfe4026a463ee82b576bf67ee304f3f7) checkPhaseThreadLimitHook: remove explicit __structuredAttrs = true
* [`e2bdadcc`](https://github.com/NixOS/nixpkgs/commit/e2bdadcc7cc7a02368a22a139a1c14bac9ab553f) pnpmBuildHook: remove explicit __structuredAttrs = true
* [`90c611df`](https://github.com/NixOS/nixpkgs/commit/90c611df0c285d56480c5aa72d2ec0f27c9dcf6d) glibc: 2.42-67 -> 2.42-84, fixes CVE-2026-6368 & CVE-2026-6791
* [`6d27518c`](https://github.com/NixOS/nixpkgs/commit/6d27518c88e9dfecc2a0474f42627f88c7170b3a) nix-output-monitor: allow overriding generated package more easily
* [`4c8b30e2`](https://github.com/NixOS/nixpkgs/commit/4c8b30e2ecdf940b303de76a4c1e7f2d22e0ae6c) python3Packages.pyexiv2: init at 2.16.0
* [`b4a4bd36`](https://github.com/NixOS/nixpkgs/commit/b4a4bd36477b2969012fc4c23ba4d6e2e3f8376d) maintainers: add suorcd
* [`4b388450`](https://github.com/NixOS/nixpkgs/commit/4b38845072b859992c4d437256d0707ee957e17f) rtmpdump: fix pkg-config include directory
* [`19745ce5`](https://github.com/NixOS/nixpkgs/commit/19745ce59c1539beb3cb936d2f0226cb8b26e239) rtmpdump: adopt
* [`53e6f17d`](https://github.com/NixOS/nixpkgs/commit/53e6f17d063a67f37f957dbd8949fcbd315c87c5) tinyalsa: unstable-2022-06-05 -> 2.0.0-unstable-2026-07-27
* [`5abd5b42`](https://github.com/NixOS/nixpkgs/commit/5abd5b424bab34da4150639a4510f8b3adfe00a4) tinyalsa: adopt
* [`8c5eae41`](https://github.com/NixOS/nixpkgs/commit/8c5eae41b46911dd877f337b95c57d1d0361784a) spice-gtk: 0.42 -> 0.43
* [`17efdb63`](https://github.com/NixOS/nixpkgs/commit/17efdb639ae64799d7b70a3f37f324c863bb11eb) spice-gtk: add theCapypara as maintainer
* [`01d482b7`](https://github.com/NixOS/nixpkgs/commit/01d482b74fd3833a5b0b7237f89464aefbde1c45) spice-gtk, spice-glib: split into two packages
* [`a3932d01`](https://github.com/NixOS/nixpkgs/commit/a3932d01b65e7137bc43b43a8f4f10e5812e2606) spice-glib: darwin: remove obsolete patch and add new patch to fix DRM header inclusion
* [`3e1f4478`](https://github.com/NixOS/nixpkgs/commit/3e1f44784c2980ae90507eec236140a3eee9eeea) vintagestory: 1.22.6 → 1.22.7
* [`1d337c34`](https://github.com/NixOS/nixpkgs/commit/1d337c342efb05cf5b20e664372c71e62c485125) rsync: 3.4.4 -> 3.5.0
* [`a9c473db`](https://github.com/NixOS/nixpkgs/commit/a9c473dbce8bfb1e2cdd9ecf5cebc3219323230a) gst_all_1.gst-libav: remove ffmpeg pin
* [`d1db2c4b`](https://github.com/NixOS/nixpkgs/commit/d1db2c4b534628ac6b94024df500f02fa0f9345f) pipewire: replace systemd dependency with systemdLibs
* [`0bd88d4b`](https://github.com/NixOS/nixpkgs/commit/0bd88d4b5d341189f6da3319e9607d92275a6aca) tinyalsa: set updateScript
* [`c33881bc`](https://github.com/NixOS/nixpkgs/commit/c33881bc35d24c80334fe93f87d1bea0b69e3f2b) libnice: fix devdoc and refactor mesonFlags
* [`bd50939c`](https://github.com/NixOS/nixpkgs/commit/bd50939c8a8fdcf13902c84cccae40d8a7e5b60e) libnice: adopt
* [`e7f2b610`](https://github.com/NixOS/nixpkgs/commit/e7f2b610e7aa820bee4522ca5e01c0e3bb45e85d) libnice: declare and test meta.pkgConfigModules
* [`ebdf6ac4`](https://github.com/NixOS/nixpkgs/commit/ebdf6ac4571e8f4fb5f9d68b02fea16a3f9b8b25) libnice: use fetchFromGitLab and set updateScript
* [`c8161027`](https://github.com/NixOS/nixpkgs/commit/c8161027f912bea1ee0953e28d93af099b3b9c0d) vtm: 0.9.99.61 -> 2026.07.30
* [`fdf8bfaf`](https://github.com/NixOS/nixpkgs/commit/fdf8bfaf483474026430d58d9d6cfb8f8ab70494) vtm: adopt
* [`d6e761a9`](https://github.com/NixOS/nixpkgs/commit/d6e761a9557061da749b62192da8f077511857f6) mongodb-7_0: 7.0.39 -> 7.0.40
* [`5977462c`](https://github.com/NixOS/nixpkgs/commit/5977462c4565ea3f933fbcca302b264973dde094) python3Packages.pandas-stubs: 3.0.3.260530 -> 3.0.5.260730
* [`9f711ab9`](https://github.com/NixOS/nixpkgs/commit/9f711ab9c3a4356848d18f53589234d21c634f33) paml: 4.10.7 -> 4.10.10
* [`536a8902`](https://github.com/NixOS/nixpkgs/commit/536a89022d11f025125f217989666a0b16aaa06e) chawan: 0.3.3 -> 0.4.4
* [`9d6ec16e`](https://github.com/NixOS/nixpkgs/commit/9d6ec16ee72812b7c22cdecf8ee503f7b787841e) tree-sitter-grammars.tree-sitter-vhdl: 1.5.0-unstable-2026-06-06 -> 1.5.0-unstable-2026-08-10
* [`f68ba6bd`](https://github.com/NixOS/nixpkgs/commit/f68ba6bdd81845c96d5beb0fabd1baee99656551) snippetexpander: 1.0.3 -> 1.1.2
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
