### PR TITLE
npins emacs-overlay: update 42965ee5 -> 07e81b77

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -35,9 +35,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "42965ee54b2d1d93b5e0aaa522d083c7a167c678",
-      "url": "https://github.com/nix-community/emacs-overlay/archive/42965ee54b2d1d93b5e0aaa522d083c7a167c678.tar.gz",
-      "hash": "sha256-+V1imZu7DiALSkBGP6yEZBuY9yt/KpHbE11TYLgLdos="
+      "revision": "07e81b7723eb8fad952340a9d4df1f9132c7aa42",
+      "url": "https://github.com/nix-community/emacs-overlay/archive/07e81b7723eb8fad952340a9d4df1f9132c7aa42.tar.gz",
+      "hash": "sha256-rygcs7erqi9PtuaLSGHYE8WMUReD7bmB5+Q2ex0jUNs="
     },
     "home-manager": {
       "type": "Git",


### PR DESCRIPTION
## Changelog for emacs-overlay:
Branch: master
Commits: [nix-community/emacs-overlay@42965ee5...07e81b77](https://github.com/nix-community/emacs-overlay/compare/42965ee54b2d1d93b5e0aaa522d083c7a167c678...07e81b7723eb8fad952340a9d4df1f9132c7aa42)

* [`e4d18859`](https://github.com/nix-community/emacs-overlay/commit/e4d1885949bf4fcb74e7779564ddb815c7d4bb25) Updated nongnu
* [`3f758cb4`](https://github.com/nix-community/emacs-overlay/commit/3f758cb4f614c5ad9d6bc6b2c9b59558cbb9fa9e) Updated elpa
* [`2ae92204`](https://github.com/nix-community/emacs-overlay/commit/2ae92204d450a15f0e49b249621036c23b67414c) Updated melpa
* [`3a8bbec3`](https://github.com/nix-community/emacs-overlay/commit/3a8bbec3efb56f8f548d8ba427d2a6e95476e38f) Updated flake inputs
* [`42459965`](https://github.com/nix-community/emacs-overlay/commit/42459965c52d322d7ffaa60dc3b9fa6512aab7a2) Updated nongnu
* [`c14a125d`](https://github.com/nix-community/emacs-overlay/commit/c14a125daa840fe4616fe8a550b2615217273b64) Updated elpa
* [`ca8dabe7`](https://github.com/nix-community/emacs-overlay/commit/ca8dabe717ab57595b1d5516a95100cad08b7251) Updated emacs
* [`59ac6b58`](https://github.com/nix-community/emacs-overlay/commit/59ac6b58bee8274fd9d9fd91af897469d6c3e514) Updated melpa
* [`f006a586`](https://github.com/nix-community/emacs-overlay/commit/f006a586b946faf27f21b233987718b51a357608) Updated emacs
* [`024a4aba`](https://github.com/nix-community/emacs-overlay/commit/024a4abac95cc31703797428e980345d0b209fba) Updated melpa
* [`032a6be6`](https://github.com/nix-community/emacs-overlay/commit/032a6be6dae18c35459dd55064b3c12843a6c546) Updated flake inputs
* [`e64d95a8`](https://github.com/nix-community/emacs-overlay/commit/e64d95a8d61ecdfb09e3c3698b11993f20f0f371) Updated nongnu
* [`00e5816e`](https://github.com/nix-community/emacs-overlay/commit/00e5816e2cd6dc0854973588fb1eae975ff154b0) Updated elpa
* [`61bee151`](https://github.com/nix-community/emacs-overlay/commit/61bee151f27035d128e94fbc38dc25cd8bb01a70) Updated melpa
* [`b5ab6295`](https://github.com/nix-community/emacs-overlay/commit/b5ab62957c919772e5ad27301fdb58b4af0bbe74) Updated emacs
* [`7a7f81ef`](https://github.com/nix-community/emacs-overlay/commit/7a7f81efec97f8ef0f7c779fe0e83efd6d40c17a) Updated nongnu
* [`3d4db744`](https://github.com/nix-community/emacs-overlay/commit/3d4db74439e2feb1121716e452785a8414b4a47b) Updated elpa
* [`5f1f28f1`](https://github.com/nix-community/emacs-overlay/commit/5f1f28f1ec8776208886ea105ab0b368e82a47e5) Updated melpa
* [`6886091d`](https://github.com/nix-community/emacs-overlay/commit/6886091d42f56b38c39c2342ef0f0ee7f157cecc) Updated flake inputs
* [`5440d167`](https://github.com/nix-community/emacs-overlay/commit/5440d1678bdd1910f2a5fb49924ae45eabb1929f) Updated melpa
* [`06555b4c`](https://github.com/nix-community/emacs-overlay/commit/06555b4c8ef41909e9b34faef487e06b60e9ad8f) Updated nongnu
* [`67eb9c51`](https://github.com/nix-community/emacs-overlay/commit/67eb9c51ec33e705218b02772c0a5490637fb464) Updated elpa
* [`72fd0d37`](https://github.com/nix-community/emacs-overlay/commit/72fd0d376fe77875ec723275a52b847408850137) Updated melpa
* [`40e759aa`](https://github.com/nix-community/emacs-overlay/commit/40e759aa29f73ab7bfbbb8f3d8ca31817f30e970) Updated flake inputs
* [`0c3b1200`](https://github.com/nix-community/emacs-overlay/commit/0c3b1200bd66925fc0cbdd7d7249f8bd999008ae) Updated nongnu
* [`4c56f94b`](https://github.com/nix-community/emacs-overlay/commit/4c56f94b812bfac7fd1e6533d9ab5dfd47be0861) Updated elpa
* [`d1374910`](https://github.com/nix-community/emacs-overlay/commit/d1374910c2517de11f72e8f8066bf264810ca2cf) Updated emacs
* [`faf42b2c`](https://github.com/nix-community/emacs-overlay/commit/faf42b2cf2dc5a5b0354d4b4effa0288ef1b28f0) Updated melpa
* [`fc55f849`](https://github.com/nix-community/emacs-overlay/commit/fc55f8498eae85edc0d73210168e2ba71acadd0e) Updated flake inputs
* [`0f0e2f86`](https://github.com/nix-community/emacs-overlay/commit/0f0e2f86c499cc6922ed0f9eca493c6423238e18) Updated melpa
* [`726e00b0`](https://github.com/nix-community/emacs-overlay/commit/726e00b0ca45446b26687055640e75b37673d8f7) Updated nongnu
* [`e32b8878`](https://github.com/nix-community/emacs-overlay/commit/e32b887833a32aaf3d8bcab005bf2d11bbba47ed) Updated elpa
* [`7f5a39f8`](https://github.com/nix-community/emacs-overlay/commit/7f5a39f8d87a348dc3690343845e67d0b9c63333) Updated melpa
* [`2011fb83`](https://github.com/nix-community/emacs-overlay/commit/2011fb835af65a963c37dc1dd20765464c7a2dab) Updated emacs
* [`dd02cdb3`](https://github.com/nix-community/emacs-overlay/commit/dd02cdb3d7b6a4f38deaf5afc82afbef56af8300) Updated nongnu
* [`915b1532`](https://github.com/nix-community/emacs-overlay/commit/915b1532890dc1c66892e153c410927ad5d649c7) Updated elpa
* [`af19242c`](https://github.com/nix-community/emacs-overlay/commit/af19242c29b44518cf183b0ac5b54eaef5cafe90) Updated melpa
* [`a7d8e6b0`](https://github.com/nix-community/emacs-overlay/commit/a7d8e6b072d4c0249c00e60aadb9a776568ed58e) Updated flake inputs
* [`2fe2db4f`](https://github.com/nix-community/emacs-overlay/commit/2fe2db4ff893fddd90e2b4aef5106b81eb63d7bd) Updated melpa
* [`ecb39595`](https://github.com/nix-community/emacs-overlay/commit/ecb3959509bde5424dc690ee463c15e18a9d9e07) Updated flake inputs
* [`dcb3c070`](https://github.com/nix-community/emacs-overlay/commit/dcb3c07039b0c2b55c30ece21f1c8520a1c1611e) Updated nongnu
* [`6535951b`](https://github.com/nix-community/emacs-overlay/commit/6535951be790e4c17a9e21825301a839f1a4bed0) Updated elpa
* [`aa59b97d`](https://github.com/nix-community/emacs-overlay/commit/aa59b97d8a3cbd62153e7e3953ff583456fcd79a) Updated emacs
* [`c4cb0dd1`](https://github.com/nix-community/emacs-overlay/commit/c4cb0dd1a73e6520d089859de2bcf65d50423462) Updated melpa
* [`30d87b49`](https://github.com/nix-community/emacs-overlay/commit/30d87b495affbfd90d023909636f8ba9ef827f23) Updated nongnu
* [`98d28fb8`](https://github.com/nix-community/emacs-overlay/commit/98d28fb87d61ec9d998e08ad1a49e5f08e14e458) Updated elpa
* [`34a8fbc9`](https://github.com/nix-community/emacs-overlay/commit/34a8fbc984fc08d8e3fe7f5e492a7b7e4397d7d8) Updated emacs
* [`ce5eca5f`](https://github.com/nix-community/emacs-overlay/commit/ce5eca5f13bc71954e1f9efde385da42afb059d4) Updated melpa
* [`7e7e7780`](https://github.com/nix-community/emacs-overlay/commit/7e7e7780cbc0f1193800d903f8825019eaf0ff24) Updated emacs
* [`cb1e1d65`](https://github.com/nix-community/emacs-overlay/commit/cb1e1d65c9447f78b5acd8af37e0c2615e4deb13) Updated melpa
* [`dddc8149`](https://github.com/nix-community/emacs-overlay/commit/dddc814930ad51a029a7651b843b46f92ad3daa1) Updated nongnu
* [`573740cc`](https://github.com/nix-community/emacs-overlay/commit/573740cc63ba7d8ce2fce61e5e714f3991deac3f) Updated elpa
* [`3e51335d`](https://github.com/nix-community/emacs-overlay/commit/3e51335d5a708e1ba7ebf29cd044bc3fa7dc291a) Updated melpa
* [`a521de6a`](https://github.com/nix-community/emacs-overlay/commit/a521de6a708343e03b4332b62d61c335f585d5f7) Updated flake inputs
* [`d33d0df8`](https://github.com/nix-community/emacs-overlay/commit/d33d0df8b8e4930bd3b45701b9a8258c13b00ed7) Updated elpa
* [`c4c7a77d`](https://github.com/nix-community/emacs-overlay/commit/c4c7a77d52dcf0d9752d3f7c84979675ecfe3b0b) Updated melpa
* [`92ecb243`](https://github.com/nix-community/emacs-overlay/commit/92ecb243d9fe128333edecb6eafecf741de343e2) Updated flake inputs
* [`0442f55f`](https://github.com/nix-community/emacs-overlay/commit/0442f55f3f3661723e45e236d8c7abe60c706024) Updated nongnu
* [`8c35b39f`](https://github.com/nix-community/emacs-overlay/commit/8c35b39f7aa209ac61130d893ca0afb68b99006c) Updated elpa
* [`79418fa6`](https://github.com/nix-community/emacs-overlay/commit/79418fa65611cd28f5d7f8586dd17e0034b6f282) Updated emacs
* [`ef05c5d7`](https://github.com/nix-community/emacs-overlay/commit/ef05c5d71a4c98ebaad5db43e9886681ef095f9b) Updated melpa
* [`2f5a26b4`](https://github.com/nix-community/emacs-overlay/commit/2f5a26b482ea3c0d6c8ab19b6d7a7adcc5ca504f) Updated melpa
* [`8d66403d`](https://github.com/nix-community/emacs-overlay/commit/8d66403d6d935471c573bbc1577e36ef13779f21) Updated nongnu
* [`8e2b3bd5`](https://github.com/nix-community/emacs-overlay/commit/8e2b3bd502adf054bfc80fd12afb4972d5bf2b9e) Updated elpa
* [`188dabd4`](https://github.com/nix-community/emacs-overlay/commit/188dabd48f9c19a13f530a74346bb3f14e1e413a) Updated emacs
* [`1bc3d611`](https://github.com/nix-community/emacs-overlay/commit/1bc3d611f5f4aaec13cb5d0f0e8c7294f36e497c) Updated melpa
* [`193c65a4`](https://github.com/nix-community/emacs-overlay/commit/193c65a41ca61d33e8b6254a014c499620603888) Updated nongnu
* [`ba62c383`](https://github.com/nix-community/emacs-overlay/commit/ba62c3830bbb94300c73a65f2ebc26355363f432) Updated elpa
* [`a90d30f2`](https://github.com/nix-community/emacs-overlay/commit/a90d30f254d16db3bec97eaffb3696c280521d2f) Updated emacs
* [`6d127662`](https://github.com/nix-community/emacs-overlay/commit/6d127662b8b91dfe39db34169fc5a1752f99b918) Updated melpa
* [`244e2176`](https://github.com/nix-community/emacs-overlay/commit/244e2176f5eddfff8a4bc2bed19dca048307fa69) Updated emacs
* [`77dea496`](https://github.com/nix-community/emacs-overlay/commit/77dea4962acf3d4b365a87deacf1c05ed328805a) Updated melpa
* [`8b6739b5`](https://github.com/nix-community/emacs-overlay/commit/8b6739b5ade3ed70bef9fb40052ec3c61d30fac9) Updated flake inputs
* [`930e4c5a`](https://github.com/nix-community/emacs-overlay/commit/930e4c5a32584a14652db3aaf06f9b51d0ed007e) Updated elpa
* [`72599a87`](https://github.com/nix-community/emacs-overlay/commit/72599a870eb698f58f2e063da671df9ab5445d75) Updated nongnu
* [`6c66dd7f`](https://github.com/nix-community/emacs-overlay/commit/6c66dd7f97b5afdbd20a95988ff3c7bd4fb4bfb0) Updated emacs
* [`bdb90d53`](https://github.com/nix-community/emacs-overlay/commit/bdb90d5368ffbfd70517d79286319e473257d5d0) Updated melpa
* [`e1e056ba`](https://github.com/nix-community/emacs-overlay/commit/e1e056ba78463931cffbc11091af835a69ca4449) Updated flake inputs
* [`c82739f5`](https://github.com/nix-community/emacs-overlay/commit/c82739f5789ad711f9e225ce647573032d22bbaf) Updated elpa
* [`604fca50`](https://github.com/nix-community/emacs-overlay/commit/604fca50996d7bc53ba6496e65ac6cef69bdae36) Updated nongnu
* [`5855d09e`](https://github.com/nix-community/emacs-overlay/commit/5855d09ec08cbd5073295a569b8f7104938c22ba) Updated melpa
* [`b111acb2`](https://github.com/nix-community/emacs-overlay/commit/b111acb25e450ccf44083a4717fa376da7add962) Updated melpa
* [`8df9864e`](https://github.com/nix-community/emacs-overlay/commit/8df9864e64c37662845e6d9b795bdec090d5c04b) Updated nongnu
* [`f8d9fcf7`](https://github.com/nix-community/emacs-overlay/commit/f8d9fcf736742e3dcd98754894105eee249e904d) Updated melpa
* [`aac7a079`](https://github.com/nix-community/emacs-overlay/commit/aac7a0796c11bdc564b7a4904dee266c0122fe1a) Updated flake inputs
* [`c9a9701d`](https://github.com/nix-community/emacs-overlay/commit/c9a9701dfa9bab435c44eb6070c3a9f6c2f3e8f7) Updated nongnu
* [`1500f2a7`](https://github.com/nix-community/emacs-overlay/commit/1500f2a74475e0d04f937b174bcc370717c57bfe) Updated elpa
* [`b5677d3a`](https://github.com/nix-community/emacs-overlay/commit/b5677d3a17a2ae527ba5d86ba5afe17d39002794) Updated melpa
* [`f3032b9c`](https://github.com/nix-community/emacs-overlay/commit/f3032b9c99f21dc59e01b90fcf4f1269f6bdefb7) Updated elpa
* [`39ea301a`](https://github.com/nix-community/emacs-overlay/commit/39ea301a7512488c517eb2f02e15e8350559c80f) Updated nongnu
* [`c450874f`](https://github.com/nix-community/emacs-overlay/commit/c450874f05714ba7229a4c4e7b9a80da1dafc3c2) Updated melpa
* [`a201f930`](https://github.com/nix-community/emacs-overlay/commit/a201f9302c3c32dee5636b329ec21ff993a76f57) Updated flake inputs
* [`e29f2544`](https://github.com/nix-community/emacs-overlay/commit/e29f254423b485cb4b54ca9222d04f2ca1fe12c5) Updated emacs
* [`9626b752`](https://github.com/nix-community/emacs-overlay/commit/9626b752f376be3c35444eac084f529be59e738f) Updated melpa
* [`3313a3c3`](https://github.com/nix-community/emacs-overlay/commit/3313a3c392a12ef51210691aab29f491f8444bc2) Updated nongnu
* [`daea9366`](https://github.com/nix-community/emacs-overlay/commit/daea93665a8a03bf3ff9f2ffd4978720f3d89d89) Updated elpa
* [`db307321`](https://github.com/nix-community/emacs-overlay/commit/db30732178e1e91f2240386bbd44b2fd529e567a) Updated melpa
* [`f0abc0e4`](https://github.com/nix-community/emacs-overlay/commit/f0abc0e49d0e038cf603eaa6dcbd918c32193f1a) Updated flake inputs
* [`a303efb3`](https://github.com/nix-community/emacs-overlay/commit/a303efb338f749935674acc22afd46fe29b5c75a) Updated melpa
* [`b5384b04`](https://github.com/nix-community/emacs-overlay/commit/b5384b045682bc500ec6945648cada0ea284b8aa) Updated flake inputs
* [`7fc2729f`](https://github.com/nix-community/emacs-overlay/commit/7fc2729f56e4b2797707fb269f57e7fcb2170383) Updated nongnu
* [`b097d374`](https://github.com/nix-community/emacs-overlay/commit/b097d374c409d9407dad5f87adeca3829998c7a3) Updated elpa
* [`ab776994`](https://github.com/nix-community/emacs-overlay/commit/ab77699455793805a0b6dda9520301afa100d22c) Updated emacs
* [`5be80215`](https://github.com/nix-community/emacs-overlay/commit/5be80215d770810760722db11914d6be09f72cfc) Updated melpa
* [`f2a2075c`](https://github.com/nix-community/emacs-overlay/commit/f2a2075c05458267dada43878ad233dd14103819) Updated nongnu
* [`bf01e3c2`](https://github.com/nix-community/emacs-overlay/commit/bf01e3c2cc06abd402f42054a78d45826484086e) Updated elpa
* [`ca9403a0`](https://github.com/nix-community/emacs-overlay/commit/ca9403a06c3dc3b1af19f4f0715451d777722544) Updated melpa
* [`b64b8c52`](https://github.com/nix-community/emacs-overlay/commit/b64b8c52204cca05594179de2ee27f80086dee84) Updated flake inputs
* [`74bee455`](https://github.com/nix-community/emacs-overlay/commit/74bee45595ac419b21c6bd98ccd00b45420063c7) Updated elpa
* [`cb5640aa`](https://github.com/nix-community/emacs-overlay/commit/cb5640aa6ac28d93b06d36bbefa51d24dfdf8b2f) Updated emacs
* [`f5003665`](https://github.com/nix-community/emacs-overlay/commit/f5003665d13340f3aa6a64a27771ccbc36ef6de3) Updated melpa
* [`471c3a50`](https://github.com/nix-community/emacs-overlay/commit/471c3a504e6e5937eb36fe06e32fe4672d2adbe1) Updated emacs
* [`fd1bf4ef`](https://github.com/nix-community/emacs-overlay/commit/fd1bf4ef5fb371a91fc38611bc6944b05c125c59) Updated melpa
* [`bac9c44f`](https://github.com/nix-community/emacs-overlay/commit/bac9c44f0d0d3101206b087f0f9790ae52de3072) Updated flake inputs
* [`2ac9ab73`](https://github.com/nix-community/emacs-overlay/commit/2ac9ab737fac64eb18e16b0943d93a700bbd0719) Updated nongnu
* [`d1cdfb06`](https://github.com/nix-community/emacs-overlay/commit/d1cdfb0655b3d47ea1338f1a5d81afe39a12d5a9) Updated elpa
* [`2d7dae6b`](https://github.com/nix-community/emacs-overlay/commit/2d7dae6bbae49f9ecf5853eea8470deed88f4b93) Updated emacs
* [`9dcd89c9`](https://github.com/nix-community/emacs-overlay/commit/9dcd89c975c75ad502af7c69dc5018731718ea77) Updated melpa
* [`df838fe5`](https://github.com/nix-community/emacs-overlay/commit/df838fe5b7d8a2cefb3b50c51ae54607623b2342) Updated flake inputs
* [`195ca802`](https://github.com/nix-community/emacs-overlay/commit/195ca8028a0529b76fe99f33040f12212db1ced0) Updated nongnu
* [`885eea2d`](https://github.com/nix-community/emacs-overlay/commit/885eea2dc193870f8541a49d35ddeb5f3da41bdd) Updated elpa
* [`164cb6cc`](https://github.com/nix-community/emacs-overlay/commit/164cb6ccb5c49fb1092291bf4ac73f09e7fe513d) Updated melpa
* [`0bd39d6e`](https://github.com/nix-community/emacs-overlay/commit/0bd39d6e8f837eb2d292565325b43f7a30a7d871) Updated emacs
* [`89ab0192`](https://github.com/nix-community/emacs-overlay/commit/89ab0192d23f0a374a38de73e623d43fcd16d8da) Updated flake inputs
* [`13efa2ba`](https://github.com/nix-community/emacs-overlay/commit/13efa2ba9fe428b4f37a42c7c4e8ce9bc99ed49b) Updated emacs
* [`a16c6feb`](https://github.com/nix-community/emacs-overlay/commit/a16c6febae5d925491760bb81f56b8862bacee33) Updated melpa
* [`eda8451c`](https://github.com/nix-community/emacs-overlay/commit/eda8451c47f4c1130fa48fe1a2202fd1b4d46115) Updated nongnu
* [`363702c3`](https://github.com/nix-community/emacs-overlay/commit/363702c3d82c9c1a7762b985040472c50f1d9fa5) Updated elpa
* [`cbebbf28`](https://github.com/nix-community/emacs-overlay/commit/cbebbf28a38ff758547106c2292b117598ebc6ec) Updated melpa
* [`2be6b887`](https://github.com/nix-community/emacs-overlay/commit/2be6b887612f27e493107dc5b0f22cb5826b541e) Updated nongnu
* [`69328825`](https://github.com/nix-community/emacs-overlay/commit/69328825877356b3ff46f7243d3415b00ff63b4d) Updated elpa
* [`afe5ddc1`](https://github.com/nix-community/emacs-overlay/commit/afe5ddc14ea15db46a4ddc94a1ee04712e25583f) Updated melpa
* [`a1f4c665`](https://github.com/nix-community/emacs-overlay/commit/a1f4c665a3146d5ab9bf245073c6bd7e8ef7397b) Updated nongnu
* [`60563f2f`](https://github.com/nix-community/emacs-overlay/commit/60563f2f74a767de2c0f8ba5e930244059d948bf) Updated emacs
* [`869c90bb`](https://github.com/nix-community/emacs-overlay/commit/869c90bb8b15cb1abf9651474cab66fbdee367c9) Updated melpa
* [`c9d3c6c4`](https://github.com/nix-community/emacs-overlay/commit/c9d3c6c48c2e7d3dcca94671b35b47534362b173) Updated flake inputs
* [`58899f47`](https://github.com/nix-community/emacs-overlay/commit/58899f4747d6d8d30bed7b6d2fb673802021550e) Updated nongnu
* [`5104f10f`](https://github.com/nix-community/emacs-overlay/commit/5104f10fc61e118501ec3903506dd8f8367777b6) Updated elpa
* [`15254cda`](https://github.com/nix-community/emacs-overlay/commit/15254cda6d524eae049f00ec9c6925f3bbe0063e) Updated emacs
* [`5bbca4c0`](https://github.com/nix-community/emacs-overlay/commit/5bbca4c02d8f0237a8f913a9ea29a5d3b33c2d80) Updated melpa
* [`a6b8300a`](https://github.com/nix-community/emacs-overlay/commit/a6b8300aa68b79767f4e4a7332b63e35c0e4382d) Updated melpa
* [`fba72fca`](https://github.com/nix-community/emacs-overlay/commit/fba72fca24202ba5a3076e11909068df90020bfc) Replace stdenv.is* with stdenv.hostPlatform.is*
* [`1a0d732a`](https://github.com/nix-community/emacs-overlay/commit/1a0d732a26519fc6b8618dd67aee237ad7223cd0) Updated nongnu
* [`ba3ee2c4`](https://github.com/nix-community/emacs-overlay/commit/ba3ee2c4220693ea08dc7d5c510030bf1cec1c74) Updated elpa
* [`92db024e`](https://github.com/nix-community/emacs-overlay/commit/92db024e740cc16ebfe8567561c71309e7247b97) Updated emacs
* [`4491e124`](https://github.com/nix-community/emacs-overlay/commit/4491e1243fb8e73e4f163a800d852523b2fbb24c) Updated melpa
* [`b6cc60fd`](https://github.com/nix-community/emacs-overlay/commit/b6cc60fdaaf56701e6c4d0f70b3080314dc46497) Updated nongnu
* [`6db1025d`](https://github.com/nix-community/emacs-overlay/commit/6db1025d148f20170a12173612b0a29d5baf5f32) Updated elpa
* [`40f951bb`](https://github.com/nix-community/emacs-overlay/commit/40f951bb30d68ca9823131b652a09ceaf4f24a1c) Updated melpa
* [`ffd24e90`](https://github.com/nix-community/emacs-overlay/commit/ffd24e90bc2ee10eaaae1a6bb7fe56c2d6a75f96) Updated emacs
* [`4fba13e7`](https://github.com/nix-community/emacs-overlay/commit/4fba13e78a5ba65f738980dc206568203a58a809) Updated melpa
* [`7cc27128`](https://github.com/nix-community/emacs-overlay/commit/7cc27128562fada78d2e77d1b7600916dd63ea40) Updated flake inputs
* [`92b82678`](https://github.com/nix-community/emacs-overlay/commit/92b826788a4f73feecfb013accdecdfe7fd7f30b) Updated nongnu
* [`8e33839a`](https://github.com/nix-community/emacs-overlay/commit/8e33839aa897b0c340d733ae24b99fc2c31b3b01) Updated elpa
* [`462a1118`](https://github.com/nix-community/emacs-overlay/commit/462a11186f4aa36374b437d85870ee6dbefff8f6) Updated emacs
* [`63e3025a`](https://github.com/nix-community/emacs-overlay/commit/63e3025aef30a1ed84600ca11adfd7277c2c454a) Updated melpa
* [`8dcc0ca4`](https://github.com/nix-community/emacs-overlay/commit/8dcc0ca406bb261aef9ce908a8326e07b04de6dd) Updated nongnu
* [`e28f14e5`](https://github.com/nix-community/emacs-overlay/commit/e28f14e5da880b23fe232a9e5d76241831440892) Updated elpa
* [`c81a4174`](https://github.com/nix-community/emacs-overlay/commit/c81a41742154aa3e64ebcd3cef2cad11dceb18e4) Updated melpa
* [`95c77501`](https://github.com/nix-community/emacs-overlay/commit/95c775015f687430dcf287d327a51aa4fe977858) Updated flake inputs
* [`395f4135`](https://github.com/nix-community/emacs-overlay/commit/395f4135ef7163fab36b262599a0c888a3ca9875) Updated melpa
* [`6190b78e`](https://github.com/nix-community/emacs-overlay/commit/6190b78efa84c01f77330fce1ed071630d5c1a62) Updated nongnu
* [`6b0bbb7b`](https://github.com/nix-community/emacs-overlay/commit/6b0bbb7bdcedbefa3efb72383c9605697e427d81) Updated elpa
* [`2e89533d`](https://github.com/nix-community/emacs-overlay/commit/2e89533df9375c48448ba92d7299c4d16b46e06f) Updated melpa
* [`f99930e2`](https://github.com/nix-community/emacs-overlay/commit/f99930e2871e5f0c4322b66679a3f5c4560d8cc1) Updated nongnu
* [`37b2b944`](https://github.com/nix-community/emacs-overlay/commit/37b2b944004eff675e1ecd06dc857ecf29d1f382) Updated elpa
* [`a65bcf36`](https://github.com/nix-community/emacs-overlay/commit/a65bcf36c4d8aa4c5ff51d571f2a2c2555681dad) Updated melpa
* [`afbd98ac`](https://github.com/nix-community/emacs-overlay/commit/afbd98acf0aa3e439037f69513f2f606aabca25c) Updated melpa
* [`ac6349c5`](https://github.com/nix-community/emacs-overlay/commit/ac6349c53134ad0b3a3e48ae820ebc34cd473d5b) Updated flake inputs
* [`7afb10cf`](https://github.com/nix-community/emacs-overlay/commit/7afb10cf1653a51af14483f05b0ba39f258e5c1e) Updated nongnu
* [`f1705b12`](https://github.com/nix-community/emacs-overlay/commit/f1705b12ea3be5f91f2c5ca7f75910280f6c35a5) Updated elpa
* [`5312c2b2`](https://github.com/nix-community/emacs-overlay/commit/5312c2b24b67000a3fd35e83af3176cb4c9c3b1b) Updated melpa
* [`84a19fd2`](https://github.com/nix-community/emacs-overlay/commit/84a19fd2d9d8f31af0893ccab7fad8c771bbc53c) Updated flake inputs
* [`4ad94e77`](https://github.com/nix-community/emacs-overlay/commit/4ad94e77a0b8452c3b3082d8355907cca1744e69) Updated nongnu
* [`d8f6578a`](https://github.com/nix-community/emacs-overlay/commit/d8f6578a31787a97cf2499267a19a5bb22b6717f) Updated elpa
* [`efba0855`](https://github.com/nix-community/emacs-overlay/commit/efba085513b136becbbf4b3ce86291ebecadaac9) Updated melpa
* [`c4fd609b`](https://github.com/nix-community/emacs-overlay/commit/c4fd609b78c2458478f5eaede5aab1696b0b8941) Updated flake inputs
* [`2d6a339d`](https://github.com/nix-community/emacs-overlay/commit/2d6a339dc4a26a5ceaf9f450cc6b80aaf332df03) Updated melpa
* [`60c7a3eb`](https://github.com/nix-community/emacs-overlay/commit/60c7a3eb440ac2ba4e97ecc99f366cbbd692d5f0) Updated flake inputs
* [`363dda18`](https://github.com/nix-community/emacs-overlay/commit/363dda18eba2ef07f9d24cac1e0ab0c77d7c0269) Updated nongnu
* [`87b8fb58`](https://github.com/nix-community/emacs-overlay/commit/87b8fb5822c5e509ba6a6d7f040deff15e558627) Updated elpa
* [`ad0eddae`](https://github.com/nix-community/emacs-overlay/commit/ad0eddaecaa0a36e381401f6aabc71340556a9c9) Updated melpa
* [`df34fdc9`](https://github.com/nix-community/emacs-overlay/commit/df34fdc9c7a5a5228636b940c598b4c3c5dd1178) Remove pinned tramp from overlay
* [`20c43c1a`](https://github.com/nix-community/emacs-overlay/commit/20c43c1a293f76de0a91c182faeea537de8370a1) Updated nongnu
* [`e7a6b41a`](https://github.com/nix-community/emacs-overlay/commit/e7a6b41ab2bbf1713dc6639daaff6d2ce23f33b0) Updated elpa
* [`82513b27`](https://github.com/nix-community/emacs-overlay/commit/82513b270d24695ee551200462a169d72b73e06b) Updated melpa
* [`0c1e023c`](https://github.com/nix-community/emacs-overlay/commit/0c1e023cb189ce1c9a1c60e2c3dd0d94e289aa2d) Ignore nullify-read-symbol-shorthands-[...].patch
* [`13e0c321`](https://github.com/nix-community/emacs-overlay/commit/13e0c32153b203a4e4fd8487873b49ef0a96a04f) Updated melpa
* [`e9b91926`](https://github.com/nix-community/emacs-overlay/commit/e9b91926b90293131e45580ad341c4eeb0bad074) Updated emacs
* [`d0991ece`](https://github.com/nix-community/emacs-overlay/commit/d0991ece92289ea37b2e9ef9a663bb0403e19527) Updated flake inputs
* [`51d52481`](https://github.com/nix-community/emacs-overlay/commit/51d524811b6d1c621e4a0f3e41df90083cf04b9f) Updated emacs
* [`2d882b3c`](https://github.com/nix-community/emacs-overlay/commit/2d882b3cd3c18674cf3f8670c7553b05c1d6e0dc) Updated melpa
* [`d7d24f4c`](https://github.com/nix-community/emacs-overlay/commit/d7d24f4c854dfdc8134cf1861b351cac4adc9876) Updated nongnu
* [`6eb518e8`](https://github.com/nix-community/emacs-overlay/commit/6eb518e896b9245eac377d442b128e646dace252) Updated elpa
* [`b619b48e`](https://github.com/nix-community/emacs-overlay/commit/b619b48e80495053dbebc8ad6d04bf04c8532b22) Updated emacs
* [`f6a1187e`](https://github.com/nix-community/emacs-overlay/commit/f6a1187e02ce51cf4303f348aa35398f57e39fa7) Updated melpa
* [`bf37fb85`](https://github.com/nix-community/emacs-overlay/commit/bf37fb854b9d3dcb7ef0dd8b6deab683bdde1f38) Updated nongnu
* [`02a3898b`](https://github.com/nix-community/emacs-overlay/commit/02a3898bd403e60ed870ee44d45543b361633ff9) Updated elpa
* [`852d078c`](https://github.com/nix-community/emacs-overlay/commit/852d078c1d9bc96cbe13fc1f4b2c5a7f15163cf7) Updated emacs
* [`287832c5`](https://github.com/nix-community/emacs-overlay/commit/287832c56e33d54c01939446fa8c7b31f4de03cc) Updated melpa
* [`e72ff207`](https://github.com/nix-community/emacs-overlay/commit/e72ff207c513f51931ffc4e376a26a6998d0e00e) Updated melpa
* [`6df91eac`](https://github.com/nix-community/emacs-overlay/commit/6df91eac7e86785bb98a97fd6311e13baa81634c) Updated flake inputs
* [`b6f2ebc8`](https://github.com/nix-community/emacs-overlay/commit/b6f2ebc86ccabb39b20be35328c5147a7d7d7b7d) Updated nongnu
* [`5b33ca05`](https://github.com/nix-community/emacs-overlay/commit/5b33ca054272e4fa7655fb335bdbc2262d5d8d6f) Updated emacs
* [`714313e2`](https://github.com/nix-community/emacs-overlay/commit/714313e2792b4142781a9551a3e9ba09a52852fd) Updated melpa
* [`3c9aaf2e`](https://github.com/nix-community/emacs-overlay/commit/3c9aaf2e624a3a72672697ee979cf352ffffb564) Updated nongnu
* [`fdf023e3`](https://github.com/nix-community/emacs-overlay/commit/fdf023e3fb3c1dea00404c3568d8b31c5a733138) Updated elpa
* [`03c16e1b`](https://github.com/nix-community/emacs-overlay/commit/03c16e1bd516fe7f8ac6aaa72983ac38b0a11b9a) Updated melpa
* [`63cad059`](https://github.com/nix-community/emacs-overlay/commit/63cad05958ad638c0423b922f23db06d6edcc1a8) Updated melpa
* [`6b203c07`](https://github.com/nix-community/emacs-overlay/commit/6b203c072e057b124e299745b66678b46a2eee43) Updated flake inputs
* [`76cb1963`](https://github.com/nix-community/emacs-overlay/commit/76cb1963eb4910716a09b4643fe90f59e391f618) Updated elpa
* [`a71da210`](https://github.com/nix-community/emacs-overlay/commit/a71da2107908a5ec2762585cb74a84bbe2850061) Updated melpa
* [`ae1b8063`](https://github.com/nix-community/emacs-overlay/commit/ae1b806314ab9df1c7e8bcb9a69011787b9c94e7) Updated nongnu
* [`367877c5`](https://github.com/nix-community/emacs-overlay/commit/367877c50243042a316d21890d42907c09a82698) Updated elpa
* [`6339cb83`](https://github.com/nix-community/emacs-overlay/commit/6339cb83538d8390590fdbd130e83f734e6a2da3) Updated emacs
* [`03abacf3`](https://github.com/nix-community/emacs-overlay/commit/03abacf330d64b222b26adc5a7077c2f46468ac9) Updated melpa
* [`d64224e0`](https://github.com/nix-community/emacs-overlay/commit/d64224e0965d8f5b69fe3ac816b29d9d98912672) Updated emacs
* [`30ddd549`](https://github.com/nix-community/emacs-overlay/commit/30ddd549e2850ff92448dc15de9b75b7d8712837) Updated melpa
* [`f5a97702`](https://github.com/nix-community/emacs-overlay/commit/f5a97702efefb375e68007441e8b813d80304653) Updated flake inputs
* [`b3960b77`](https://github.com/nix-community/emacs-overlay/commit/b3960b7742c4bd65175c1a67a2a3dbbcbc1b636c) Updated nongnu
* [`0e3c5bbe`](https://github.com/nix-community/emacs-overlay/commit/0e3c5bbe49e831a442b0e959a84663fe3e7ddde3) Updated elpa
* [`69b49ec5`](https://github.com/nix-community/emacs-overlay/commit/69b49ec59c2bc328d316da0ca30bd956e331debf) Updated emacs
* [`33fffe7e`](https://github.com/nix-community/emacs-overlay/commit/33fffe7e6c2e87732a09fd90513749d687733099) Updated melpa
* [`c34456d2`](https://github.com/nix-community/emacs-overlay/commit/c34456d2811db7cd85ea91b14aaa0c4fccf25bf0) Updated nongnu
* [`2da76444`](https://github.com/nix-community/emacs-overlay/commit/2da764443e11dc87214ee453d9ed40f63f506561) Updated elpa
* [`b205eac5`](https://github.com/nix-community/emacs-overlay/commit/b205eac5a0b18e797ed9efbba3572137dbc8c2a4) Updated melpa
* [`4d99c36c`](https://github.com/nix-community/emacs-overlay/commit/4d99c36cc2dc0c58c72464502a4de89296e8b942) Updated flake inputs
* [`8e52a982`](https://github.com/nix-community/emacs-overlay/commit/8e52a98268150ef95a4b36d0a017bbb4502df259) Updated nongnu
* [`bdbe12ed`](https://github.com/nix-community/emacs-overlay/commit/bdbe12ed45e0a87708a0c1cf45e77fec04db6a74) Updated melpa
* [`60e259ad`](https://github.com/nix-community/emacs-overlay/commit/60e259adc6d8f3c1580183fbf24ca9aaf92ae2a3) Updated flake inputs
* [`f04c74bc`](https://github.com/nix-community/emacs-overlay/commit/f04c74bc68c384e36660333fd9f440974c03324d) Updated nongnu
* [`245e5537`](https://github.com/nix-community/emacs-overlay/commit/245e553785bb5779761e41feb88cfc860da43dc0) Updated elpa
* [`9d4cf3e5`](https://github.com/nix-community/emacs-overlay/commit/9d4cf3e5a26475d3083c7d2e325152d652386e42) Updated melpa
* [`310a9af8`](https://github.com/nix-community/emacs-overlay/commit/310a9af807997c395d816ae827f7d91692eeb4f2) Updated melpa
* [`56e54a4e`](https://github.com/nix-community/emacs-overlay/commit/56e54a4ef8c82183ea17fa4f73960964028334b5) Updated flake inputs
* [`d07d286c`](https://github.com/nix-community/emacs-overlay/commit/d07d286c378783a94363685fea65b2afbeac425b) Updated nongnu
* [`101fa6c6`](https://github.com/nix-community/emacs-overlay/commit/101fa6c6ca011197c18858282416049adba713c9) Updated nongnu
* [`2194aca8`](https://github.com/nix-community/emacs-overlay/commit/2194aca85f485259bbb73a0b3f6fa8c61c59b688) Updated elpa
* [`ed7e9bda`](https://github.com/nix-community/emacs-overlay/commit/ed7e9bdae50653a62b35e807f746b3a5ed3e9ab5) Updated melpa
* [`49b54cc1`](https://github.com/nix-community/emacs-overlay/commit/49b54cc128924701e4cf12517deb499f138198e4) Updated emacs
* [`74e36da9`](https://github.com/nix-community/emacs-overlay/commit/74e36da9446c671dcda7b0006b9dab9084af2001) Updated nongnu
* [`700030fc`](https://github.com/nix-community/emacs-overlay/commit/700030fc9e3ce94b04cd5afcb955b3d183676990) Updated elpa
* [`fb4ba820`](https://github.com/nix-community/emacs-overlay/commit/fb4ba8205e5bc1904427a5b56e644295402e5d51) Updated emacs
* [`114185a4`](https://github.com/nix-community/emacs-overlay/commit/114185a4f857a4d07520e2d7c73347c322e1c300) Updated melpa
* [`f0323f44`](https://github.com/nix-community/emacs-overlay/commit/f0323f4464de42f6d190b0f16f2493ca82f6108a) Updated flake inputs
* [`2fa0e8c6`](https://github.com/nix-community/emacs-overlay/commit/2fa0e8c6c13d0f360470298a282699e46ab79c92) Updated nongnu
* [`89003b20`](https://github.com/nix-community/emacs-overlay/commit/89003b200d1077cf10209d10685b765c05ffa4ea) Updated elpa
* [`8dc89caf`](https://github.com/nix-community/emacs-overlay/commit/8dc89caf030bdbae6019140e1d2451227f8e80e7) Updated melpa
* [`56314097`](https://github.com/nix-community/emacs-overlay/commit/56314097fae6b46a4a3b38bbb124a73d73a9baf8) Updated flake inputs
* [`5a10c10d`](https://github.com/nix-community/emacs-overlay/commit/5a10c10d30c49e88bebe76f26d148c1aab9b623c) Updated elpa
* [`98ff9205`](https://github.com/nix-community/emacs-overlay/commit/98ff9205347992fc173fb228ee54cb0aaf3681fd) Updated nongnu
* [`aa7352f2`](https://github.com/nix-community/emacs-overlay/commit/aa7352f2aac735e9ece2ad25cf1bb8a553c0c668) Updated melpa
* [`2e09ecaf`](https://github.com/nix-community/emacs-overlay/commit/2e09ecaf9c6b801d655822a0ffb914b3ba1bc1e8) Remove project-store since it is renamed[0] to project-nix-store
* [`b31474f8`](https://github.com/nix-community/emacs-overlay/commit/b31474f86363bd8dd7b168ecbe238a6ec7acf75c) Updated nongnu
* [`f288a3de`](https://github.com/nix-community/emacs-overlay/commit/f288a3de060cceb127c6cd99f264335a81af3ea7) Updated elpa
* [`1f789ca4`](https://github.com/nix-community/emacs-overlay/commit/1f789ca45d7657a8a3daef590eed07085eb8e011) Updated emacs
* [`5b8f060a`](https://github.com/nix-community/emacs-overlay/commit/5b8f060a63e9edc248eee5a258f5abcd2f128caa) Updated melpa
* [`1abc82b2`](https://github.com/nix-community/emacs-overlay/commit/1abc82b29c01af63950dd3b82a9ec9efdc7dfcb6) Updated flake inputs
* [`e2186fad`](https://github.com/nix-community/emacs-overlay/commit/e2186fadf37b4a6c9f55dd58d555c061600fa5e4) Updated nongnu
* [`d70a5ff9`](https://github.com/nix-community/emacs-overlay/commit/d70a5ff9d67d2e94943bb734a83007fde1c2b187) Updated elpa
* [`315b117d`](https://github.com/nix-community/emacs-overlay/commit/315b117d1580efb5dbabc3c4664dc97d109bcd1c) Updated emacs
* [`8f023219`](https://github.com/nix-community/emacs-overlay/commit/8f0232196e24fa28aa356d267f89c8395d80fde4) Updated melpa
* [`0f8471b8`](https://github.com/nix-community/emacs-overlay/commit/0f8471b870c51c3ed6dcd09c01e88bb0f790da01) Don't double-apply CVE-2026-79992 fix
* [`d9bf6879`](https://github.com/nix-community/emacs-overlay/commit/d9bf6879e798a6138543f4f400b9655a355d3953) Updated nongnu
* [`5aae030f`](https://github.com/nix-community/emacs-overlay/commit/5aae030f3ae325b7110a9b6c564d0217d1605cec) Updated elpa
* [`c9f70b95`](https://github.com/nix-community/emacs-overlay/commit/c9f70b95f8d32f29ba2910a8a4f1a520138efbe7) Updated emacs
* [`10565a8e`](https://github.com/nix-community/emacs-overlay/commit/10565a8ebafff3ab3d865a4f4e66cd47180a95ae) Updated melpa
* [`682c8861`](https://github.com/nix-community/emacs-overlay/commit/682c8861b52019d12d38c065c59a2661b7638143) Updated melpa
* [`e4f930a7`](https://github.com/nix-community/emacs-overlay/commit/e4f930a717957b97cb7f415b7176ec5a481a22ab) Updated flake inputs
* [`62709d0d`](https://github.com/nix-community/emacs-overlay/commit/62709d0dc2eb817041d49f6156dcfafb715c7c48) Updated elpa
* [`d8c4d939`](https://github.com/nix-community/emacs-overlay/commit/d8c4d9394a300c80b1eb49dfc4cfe2c5a91b1170) Updated melpa
* [`53a80cc7`](https://github.com/nix-community/emacs-overlay/commit/53a80cc7aca5627601d17084e4091ac9b5e5dfd0) Updated flake inputs
* [`89f7419e`](https://github.com/nix-community/emacs-overlay/commit/89f7419e9cb3bee9ec9d99821cdc588fbac9e10e) Updated melpa
* [`c16ace25`](https://github.com/nix-community/emacs-overlay/commit/c16ace2584962ee7b11614c2d010dcadec5364a6) Updated flake inputs
* [`f64ce728`](https://github.com/nix-community/emacs-overlay/commit/f64ce72806266bcaa9393bbfb0e041d70bd0733d) Updated melpa
* [`f6229276`](https://github.com/nix-community/emacs-overlay/commit/f6229276417aa356ae16dfd3b21b51525f55083f) Updated melpa
* [`5d317360`](https://github.com/nix-community/emacs-overlay/commit/5d317360f8bea65b22d273461c97b2c103d7eac2) Updated nongnu
* [`15cf709b`](https://github.com/nix-community/emacs-overlay/commit/15cf709baef8f17304cae083a511a4550c47768e) Updated elpa
* [`10582c9f`](https://github.com/nix-community/emacs-overlay/commit/10582c9fb87fec4440f439117552ef39afe7f74f) Updated melpa
* [`b38d8b58`](https://github.com/nix-community/emacs-overlay/commit/b38d8b584b6aaa8ab1d5294badff6533a4e95c4c) Updated flake inputs
* [`3242e311`](https://github.com/nix-community/emacs-overlay/commit/3242e3112cd1a5316c9c2b305a648bdce15be86e) Updated nongnu
* [`4290162f`](https://github.com/nix-community/emacs-overlay/commit/4290162fd7c3e90d3a285ce12ac56cab9441c4c9) Updated elpa
* [`07e81b77`](https://github.com/nix-community/emacs-overlay/commit/07e81b7723eb8fad952340a9d4df1f9132c7aa42) Updated melpa
