### PR TITLE
npins doomemacs: update 6ba99cb5 -> 5119e22e

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -22,9 +22,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "6ba99cb50cddc4441963a0ef68f971112ab4807e",
-      "url": "https://github.com/doomemacs/doomemacs/archive/6ba99cb50cddc4441963a0ef68f971112ab4807e.tar.gz",
-      "hash": "sha256-cmQ2/kRScuwyywxWbiofdlL/KCQL9txWQecYC63uf+k="
+      "revision": "5119e22e18dd279d0bead3845d2953733e42bc7b",
+      "url": "https://github.com/doomemacs/doomemacs/archive/5119e22e18dd279d0bead3845d2953733e42bc7b.tar.gz",
+      "hash": "sha256-Ca6D/aolXWn2jozSIhLCvrKjwqkHHIaZCH+x39Gt3ow="
     },
     "emacs-overlay": {
       "type": "Git",


### PR DESCRIPTION
## Changelog for doomemacs:
Branch: master
Commits: [doomemacs/doomemacs@6ba99cb5...5119e22e](https://github.com/doomemacs/doomemacs/compare/6ba99cb50cddc4441963a0ef68f971112ab4807e...5119e22e18dd279d0bead3845d2953733e42bc7b)

* [`2162b09e`](https://github.com/doomemacs/core/commit/2162b09e1f3c5b8c2183bb651befcec813c8be58) refactor(lib): dissolve lib/indent.el
* [`a1029961`](https://github.com/doomemacs/core/commit/a10299614bac5d3a5fa63685a54a205841406c82) refactor(lib): move lib/docs.el to new doom-docs.el
* [`c538bce8`](https://github.com/doomemacs/core/commit/c538bce8bf7ba8706b9179bcd7e431f56c52d842) docs(cli): add demos for sh!, sh<, sh? macros
* [`6f1ef568`](https://github.com/doomemacs/core/commit/6f1ef5681d4ea8b2891e9a78e3f3ba00ad0cb75a) bump: sources/doom+
* [`6b855e89`](https://github.com/doomemacs/core/commit/6b855e89cb4088a1bacd8ce7fe573ef45a87944e) release: 2.2.2
* [`f6f07696`](https://github.com/doomemacs/core/commit/f6f0769678017ccb7bf0545a2bf98d364540a610) tweak(lib): doom/reload: don't auto-close popup
* [`385cfaca`](https://github.com/doomemacs/core/commit/385cfaca01588f86639640f938fc013e4470dbaa) nit(docs): correct indentation
* [`34608da8`](https://github.com/doomemacs/core/commit/34608da8db344917bf0165a1177c7664c165e1b8) feat(docs): transform labeled quote blocks into notices
* [`db0d5ca8`](https://github.com/doomemacs/core/commit/db0d5ca86cd4f275bf03887b9342299a5742c4dc) refactor(docs): remove doom-executable:* link
* [`001a7ce6`](https://github.com/doomemacs/core/commit/001a7ce6b8aaaf2b2b0403d2431a0bdb4d6de5b3) docs(lib): {add,remove}-hook!: remove mention of unquoted modes
* [`dbe364f1`](https://github.com/doomemacs/core/commit/dbe364f13257b1e028bff593fda0589e561758de) fix: save-place not being activated
* [`ce95e992`](https://github.com/doomemacs/core/commit/ce95e992138a1575931cf1d7ed594d18b377bd35) refactor: remove redundant doom-module--depth< def
* [`c62745e1`](https://github.com/doomemacs/core/commit/c62745e1a13a13382c180af9e7463d3381ff628d) fix(docs): fail gracefully if nerd-icons is absent
* [`f9236165`](https://github.com/doomemacs/core/commit/f9236165330200808a3b06abe25ea3046cc6c31f) fix(docs): org <=9.6 support
* [`5db44fe1`](https://github.com/doomemacs/core/commit/5db44fe10ad35adb4f58cd16b0acc3824e55a0fc) docs: use new notice format & use mode lines
* [`79338695`](https://github.com/doomemacs/core/commit/79338695ce86048532d22130edb7c81af148d8bb) fix(docs): doom-docs-minor-mode: move cursor to visible region
* [`90b1c391`](https://github.com/doomemacs/core/commit/90b1c391d1fad714886caa27ff11a83262787bcc) refactor(docs): clean up
* [`e8961659`](https://github.com/doomemacs/core/commit/e8961659fc853aec650875b2ffe94f7673e52bcc) tweak(docs): reduce org-modern-mode impact in docs
* [`ad55ed08`](https://github.com/doomemacs/core/commit/ad55ed08df3a1d3398d136d07b60ba2ad00fb91b) feat(lib): doom/report-bug: prompt for repo
* [`1d83972a`](https://github.com/doomemacs/core/commit/1d83972a9eb08d82d989d371feef6f3056ccc1fe) fix: don't inhibit-redisplay during startup
* [`50f7a48b`](https://github.com/doomemacs/core/commit/50f7a48bbc61067305d6eec1e9d8b8910cc607ca) refactor: remove pcache-directory, move desktop-dirname
* [`dc037e51`](https://github.com/doomemacs/core/commit/dc037e51eb43672693a25a2d55aad9aba6265cdd) dev: simplify 'doom make LICENSE' task
* [`40c9c423`](https://github.com/doomemacs/core/commit/40c9c423add1a864c0432a5dead58f223bd6a4e0) nit: move package.el config to built-in section
* [`5e5ea461`](https://github.com/doomemacs/core/commit/5e5ea46131de66f46c43a01286ea74dadde19e03) fix: uninterpolated profile-id in error signal
* [`70717a7e`](https://github.com/doomemacs/core/commit/70717a7e009ce2cfd1578015a404ff9482ec7142) refactor(docs): rewrite doom-docs API
* [`33c39d83`](https://github.com/doomemacs/core/commit/33c39d83abe86b5a5184862a87764b1bf3ca320f) docs: revise FAQs
* [`1437a4b2`](https://github.com/doomemacs/core/commit/1437a4b2f82238d3648e5b6bc0ea4668a4833f38) docs: standardize don't-read-on-github notice
* [`6885a525`](https://github.com/doomemacs/core/commit/6885a5250a555b869f298d2645c848662b763ffd) fix(docs): ensure notice symbol doesn't change color
* [`7713314c`](https://github.com/doomemacs/core/commit/7713314c21dca02eb7dbc114419c85e4ad3f5d11) feat(lib): add doom/bump-packages-in-dir
* [`0deceecf`](https://github.com/doomemacs/core/commit/0deceecf9edc7d4cd15db3e931452e12d762b1b1) bump: sources/doom+
* [`11dcc6ae`](https://github.com/doomemacs/core/commit/11dcc6aebfdd2a17d67f1b49ae76d188b63da744) fix(docs): repo:* link
* [`afdd5f54`](https://github.com/doomemacs/core/commit/afdd5f54c8c8d07c3d5a81affd370b15302c4e42) refactor!(cli): rewrite CI commands & commit linter
* [`29210747`](https://github.com/doomemacs/core/commit/292107475b3e82cb2ca8964184efe6969db6f504) dev: update commit linter config
* [`a4d067f3`](https://github.com/doomemacs/core/commit/a4d067f3cae388ef94be129fc13ca2483114329b) dev: remove publish config
* [`d29d1d8c`](https://github.com/doomemacs/core/commit/d29d1d8ce807fc31dc8a189b9914280af2216626) dev: redesign shell.nix
* [`ce80cf85`](https://github.com/doomemacs/core/commit/ce80cf853ae6a06c10988e865326ade4051c2757) bump: :doom
* [`0921eb00`](https://github.com/doomemacs/core/commit/0921eb00ee4b4051a99644287269cf199dd72c10) fix(lib): doom-region: flipped strip-properties arg
* [`98585957`](https://github.com/doomemacs/core/commit/9858595794c41c4f4b14d1c94edeb12985704656) fix(lib): doom-debug-mode clobbering debug vars
* [`bd42c93b`](https://github.com/doomemacs/core/commit/bd42c93b106319022add7696baa1bc82bcbfb766) docs(profiles): minor docstring revisions
* [`34272989`](https://github.com/doomemacs/core/commit/34272989d1c96b328d50643b1e26c308ad74dae7) feat(docs): highlight broken file links w/ error face
* [`67bd64a9`](https://github.com/doomemacs/core/commit/67bd64a96ca3124ab34393505b222b78eab56588) fix(cli): +commit-linter: module scope checker
* [`90eb2c3d`](https://github.com/doomemacs/core/commit/90eb2c3d1935b0e039f75fe3348d394216c347d0) nit: minor revisions in comments & docstrings
* [`8a2cc959`](https://github.com/doomemacs/core/commit/8a2cc959eb299d58d0a4d37dd463a50c14f58bfb) tweak(docs): remove underline from broken file: links
* [`28be5941`](https://github.com/doomemacs/core/commit/28be594171782bc406053f11e23f06d2369b9134) refactor(docs): how local org-startup settings are initialized
* [`c7de39f3`](https://github.com/doomemacs/core/commit/c7de39f32f6a0a6db7438864db25e91a88a988f0) tweak(docs): use simpler org-todo-keyword-face
* [`3a21c109`](https://github.com/doomemacs/core/commit/3a21c1092e9c1e358a478244863b31dc89036ebd) refactor(docs): remove unused doom-docs-font-lock-keywords
* [`9bda1a7b`](https://github.com/doomemacs/core/commit/9bda1a7bc73ed84439260413fe5b9222acfc814c) feat(lib): add with-delayed-gc! macro
* [`329366dd`](https://github.com/doomemacs/core/commit/329366dd8ac00db2af63409e3148e02f1fda449a) tweak(docs): disable org-modern-mode & org-appear-mode
* [`8678eaa9`](https://github.com/doomemacs/core/commit/8678eaa97005dd0dbd9ea7048bfbc3b0012cb43a) tweak(docs): doom-docs-minor-mode: disable indent-bars-mode
* [`cc6e8400`](https://github.com/doomemacs/core/commit/cc6e8400a43350be06301954320061331d0e051a) refactor(docs): remove unused org-modern-* settings
* [`c7ffc3bb`](https://github.com/doomemacs/core/commit/c7ffc3bbd0496647f8c9eb8b736601df6860abea) fix(docs): respect #+STARTUP visibility options
* [`9efcfb83`](https://github.com/doomemacs/core/commit/9efcfb83d3670bcf7a67d49056e2d8cc58e6df10) fix(docs): hiding types for unbracketed links
* [`7cbb1b39`](https://github.com/doomemacs/core/commit/7cbb1b394a4161253376ae162be241df40f74191) fix(docs): hide :: in help-echo if no postamble
* [`6e69a0ad`](https://github.com/doomemacs/core/commit/6e69a0ad7d33c5225c3ef6dc066d31d1cacadf40) fix(docs): add missing : delimiter in some links' :help-name
* [`b1fca18a`](https://github.com/doomemacs/core/commit/b1fca18a887a5fcd8d5863de2e5239440a86e8c3) fix(docs): type errors by window/buffer context errors
* [`55cd21c9`](https://github.com/doomemacs/core/commit/55cd21c9ec328523cfec08788f57eddef7ebe594) feat(docs): add abbr:* link
* [`a676d413`](https://github.com/doomemacs/core/commit/a676d4137657ccf0de57fed3d1c7bf3b6ac4756a) feat(docs): add doom-docs-{title,info} faces
* [`6d2c4bf9`](https://github.com/doomemacs/core/commit/6d2c4bf95d52e033fb4054cf7997f5677cae48eb) docs: remove defunct show[2-5]levels* settings
* [`492f1a28`](https://github.com/doomemacs/core/commit/492f1a287bb26d630e867681bac3b0917dcd1ae2) fix(lib): don't double use doom-font-increment
* [`088bf8df`](https://github.com/doomemacs/core/commit/088bf8dfc2b0bbddade85d5c247e52fdda2352c7) bump: sources/doom+
* [`0873a943`](https://github.com/doomemacs/core/commit/0873a94339c6133ca78c2aa497d97fd66bc94d00) release: 2.2.3
* [`e89050cf`](https://github.com/doomemacs/core/commit/e89050cf4d3aec2c6609869cc6193cb7d330519d) fix(cli): change loaddef reset strategy
* [`73428cdb`](https://github.com/doomemacs/core/commit/73428cdbb192b1c533b3bdf1af43b41bd8dfe2ab) feat(docs): open magit/vc-log on doom-history: header link
* [`26db7cda`](https://github.com/doomemacs/core/commit/26db7cdac26527971d85a2840c2678fca73416ff) fix(docs): doom-help: header link
* [`4bca3163`](https://github.com/doomemacs/core/commit/4bca316356c8072f2da88600210c14a8068ba9e4) fix(docs): doom/reload-docs: don't read IDs in open org buffers
* [`66b29a91`](https://github.com/doomemacs/core/commit/66b29a91f8105ec5ad349cb6989094e577f4e5f6) fix(docs): expand subtree after following header link
* [`2805281b`](https://github.com/doomemacs/core/commit/2805281b314c6ccd6e18945c9f2fcc8553b9cc86) refactor(docs): move & simplify help commands
* [`87b8afe6`](https://github.com/doomemacs/core/commit/87b8afe6e2ff0a5debbad96534ea131277a4df64) tweak(docs): exclude appendix.org from doom/docs-headings
* [`b429b4d1`](https://github.com/doomemacs/core/commit/b429b4d127b23ba7fafa6e39f5d62825705aa42c) docs: update discord/GH discussions links
* [`0d78de8a`](https://github.com/doomemacs/core/commit/0d78de8ad18dbb9fede13b6eba15a76a41fec825) fix(docs): order of minor-mode settings
* [`bf3b23da`](https://github.com/doomemacs/core/commit/bf3b23daf0dc756c0e36c914c9399c2ad03ad073) refactor(lib): doom/help-* commands & rename them
* [`8d45a7df`](https://github.com/doomemacs/core/commit/8d45a7dfae6244d3803833d4fe315ceebc5ec408) feat: add doom-module-completing-read function
* [`c7255aa1`](https://github.com/doomemacs/core/commit/c7255aa15b354c37b0550652f92fb59ce6aac8a8) refactor(docs): rename doom/describe-module to doom/docs-module
* [`9a24ea52`](https://github.com/doomemacs/core/commit/9a24ea5239f95b6de867cb6c57bc514ac40fda74) fix: void-function doom-module--completion-sort error
* [`6ecefb2d`](https://github.com/doomemacs/core/commit/6ecefb2dd920c7215efafbd35707d25b01a48eff) fix(docs): autoload doom/docs-module
* [`1d9c68c6`](https://github.com/doomemacs/core/commit/1d9c68c6c6464e9de75ccedc33b9f8fd50ae3b15) fix: doom-module-completing-read: use v3 key format
* [`b6227370`](https://github.com/doomemacs/core/commit/b62273708029bf9c844d3b107b7552c61297949e) feat: doom-module-key: handle v3 keys
* [`9ad1aba5`](https://github.com/doomemacs/core/commit/9ad1aba52b6898611b1f29585c315aa3c95607a2) feat(docs): doom/docs: prefix arg = open docs site
* [`f2a0b0ba`](https://github.com/doomemacs/core/commit/f2a0b0ba70f22bc111f5906d603b1657c1896675) perf(docs): doom/docs-module: improve first-load UX
* [`d510675d`](https://github.com/doomemacs/core/commit/d510675dcba55b7e4a3d92b3df4d445bee65155b) refactor(docs): hoist GC deferral/load message into function
* [`81dce4c6`](https://github.com/doomemacs/core/commit/81dce4c6c2bb1d81098d48e54348a0916e8f1092) fix: doom-module-at-point: gate fallback to current file's module
* [`af20ae1a`](https://github.com/doomemacs/core/commit/af20ae1a38b2c728d2ef7554faa70e4fce969561) refactor(docs): doom/docs-module
* [`89db1bf0`](https://github.com/doomemacs/core/commit/89db1bf0c6a5a4d2118b43bc70428d1e189c2377) feat(docs): support :exports & :hide in all org blocks
* [`2d1382b4`](https://github.com/doomemacs/core/commit/2d1382b45152d7a2f8ad1d03f91a7b6ad7456ac3) tweak(docs): disable org-modern-mode in doom-docs-mode
* [`d57f1b34`](https://github.com/doomemacs/core/commit/d57f1b345fafd833967b21cad81e1616247192f0) feat(docs): abbreviate repo:* links w/ long commit hashes
* [`266fd960`](https://github.com/doomemacs/core/commit/266fd96058a7bbbe5414da495dea9440026d3b8c) refactor(docs): doom-docs-minor-mode -> doom-docs-view-mode
* [`bbfdad7e`](https://github.com/doomemacs/core/commit/bbfdad7e93d2ea2d4508163e4d7dcfa31a2be616) tweak(docs): doom-docs-mode: mode-name = "Doom Docs"
* [`0089ef0f`](https://github.com/doomemacs/core/commit/0089ef0f20dd76f9ab50fc3b3692ca192648d391) docs: add :hide yes to top-level notices
* [`9a1978b3`](https://github.com/doomemacs/core/commit/9a1978b3b9369c23ce6358ab98fbf7c5f857f1e0) tweak(docs): use link-visited face for elisp:* links
* [`ab9ea6c2`](https://github.com/doomemacs/core/commit/ab9ea6c27102411e5df3e8683cd424ab6c1f0a7c) docs: 30.2 -> 31.1
* [`0dff6c03`](https://github.com/doomemacs/core/commit/0dff6c03ac819d148e188bdb5383e25467f0afe1) feat(docs): align tags to the right
* [`59d90349`](https://github.com/doomemacs/core/commit/59d903495bc334ce79fbf39da84fe08cf26d32b4) fix(docs): org-hide-block-startup = nil
* [`3a6a3f12`](https://github.com/doomemacs/core/commit/3a6a3f12665068363356767716dcb8af52f1a2c2) nit(docs): doom-docs-link--kbd-activate: fix indentation
* [`daf7fdd0`](https://github.com/doomemacs/core/commit/daf7fdd0504042f710a34057be7290f5821b2682) fix: so-long invoking too eagerly
* [`f9720387`](https://github.com/doomemacs/core/commit/f9720387f497c61e67d0cad9cfac09d35554962d) fix(docs): fontification of unbracketed M-x:* links
* [`d7c2832f`](https://github.com/doomemacs/core/commit/d7c2832f9c8d7fe4d5bb1b9ff5cbf8915d3aeb4b) docs(cli): 30.2 -> 31.1 (part 2)
* [`225ae956`](https://github.com/doomemacs/core/commit/225ae9568246ec76325cd49a82802495c15a6085) fix(docs): doom/docs-module: append / to dir
* [`8de9c6ac`](https://github.com/doomemacs/core/commit/8de9c6aca192c07c5a625f754613a75ff2fdf091) tweak(docs): don't prompt to create headings on broken links
* [`40d733c4`](https://github.com/doomemacs/core/commit/40d733c42de4182a0c110f9a7a1c5cdb03384d9c) tweaK(docs): disable diff-hl-mode
* [`8b469906`](https://github.com/doomemacs/core/commit/8b469906084428f5d491a9d3df19c2e9f41f02f0) fix(docs): "Suggest edits" header link
* [`3450f9bb`](https://github.com/doomemacs/core/commit/3450f9bba4ed75c98696a811879e19ab331a5b01) perf(docs): speed up header links
* [`d9ea8219`](https://github.com/doomemacs/core/commit/d9ea82195bc44364cdd1c161a2ee941a76940ab9) refactor(docs): inline header links keymap
* [`9e1d0539`](https://github.com/doomemacs/core/commit/9e1d0539a56ea4ed09526e34ba2713e91059d7f0) fix(docs): copy sub-lists in org-link-parameters too
* [`ffe75ce4`](https://github.com/doomemacs/core/commit/ffe75ce4cd49fcdc1ad42274be6b8cdaf0e55b88) fix(lib): letf!: format call with no format fields
* [`ebd04ef6`](https://github.com/doomemacs/core/commit/ebd04ef6114095510f570758fb365193da75f81c) fix(docs): clean up header when doom-docs-view-mode is off
* [`f8b0d6dc`](https://github.com/doomemacs/core/commit/f8b0d6dc3e94c7466de3f1fdfb760105d0ca8084) perf(docs): don't respect org-export-use-babel
* [`4113a6f0`](https://github.com/doomemacs/core/commit/4113a6f05ece821a505c548c2e98645604ac4e9f) fix(docs): how destination is unfolded following link
* [`62b30941`](https://github.com/doomemacs/core/commit/62b30941dd82347dc349f1ebf1d876dac2a45be9) nit: add $EMACSDIR/user-lisp in load order comment
* [`224b1505`](https://github.com/doomemacs/core/commit/224b150546821879119375803446a988803e587e) refactor(docs): remove doom/docs-faq
* [`ac283ea7`](https://github.com/doomemacs/core/commit/ac283ea737c6da8791df97537606f1e687db4711) feat(docs): add filter:* links
* [`e4cce1c6`](https://github.com/doomemacs/core/commit/e4cce1c6ec336317630d1b2ea8eae5b3b4d55e4f) fix(cli): doctor: bleeding-edge check (30 -> 31)
* [`e4717ff7`](https://github.com/doomemacs/core/commit/e4717ff77c42785410facd7fd9aa539923c3a3ab) fix(docs): strip out org links in abbr:* help-echo
* [`fb73b8de`](https://github.com/doomemacs/core/commit/fb73b8de625e2c43866ac0743762097c74b6c3b0) feat(docs): add doomemacs.org link abbrevs
* [`1404f1ba`](https://github.com/doomemacs/core/commit/1404f1bac5a2ae8602b4d861f7805e194c05d28c) docs: add rudimentary LLM policy
* [`334dd195`](https://github.com/doomemacs/core/commit/334dd195533d87f43e9a223088c9efc5e2fd4ff8) fix(lib): doom-log: respect log-level in interactive sessions
* [`3365d85d`](https://github.com/doomemacs/core/commit/3365d85d2209af441c6572523a608d82e8334851) feat(lib): doom-log: more info in log output
* [`6b4c1d6c`](https://github.com/doomemacs/core/commit/6b4c1d6c47c08dd9b15befc88a0699737bd77b37) nit: update load order comment
* [`c187cdcb`](https://github.com/doomemacs/core/commit/c187cdcb56b91e4bc561d1b31e76d8beb2ad3302) fix: unset native-comp-async-on-battery-power
* [`8720bbe9`](https://github.com/doomemacs/core/commit/8720bbe92be50bb18eb0a59b50566dd7dfc441ed) fix: abbreviate paths added to trusted-content
* [`82ee179f`](https://github.com/doomemacs/core/commit/82ee179fc489c27f71eb0cff0d8d207a6b8b4d99) fix(cli): doctor: bleeding-edge check (30 -> 31) (part 2)
* [`d64c3679`](https://github.com/doomemacs/core/commit/d64c3679cea8229883524d06448f96a4a17413d5) refactor(docs): use var instead of hook for doom-docs-view-mode
* [`154c13c6`](https://github.com/doomemacs/core/commit/154c13c66b9ae6fd02cde62710fa340a309e999b) fix(lib): defer-feature!: don't double-provide a feature
* [`cc989870`](https://github.com/doomemacs/core/commit/cc989870709578d5aa4e4dedae8fd84c76a9b260) fix(docs): kbd/M-x/package link text property unsetters
* [`50cc9c7a`](https://github.com/doomemacs/core/commit/50cc9c7abb4f64fcd0d3858da42b6a5c53664fe7) feat(docs): add :follow function for kbd:* links
* [`7d8b45ee`](https://github.com/doomemacs/core/commit/7d8b45ee8d34c4a032ae91986def7965a2743b9f) docs(cli): doctor: generalize Emacs version check
* [`b4f1f1d5`](https://github.com/doomemacs/core/commit/b4f1f1d5749bb6d04cb72ec2162de84a7b338da0) fix(lib): letf!: mutated arguments across expansions
* [`bb88ec77`](https://github.com/doomemacs/core/commit/bb88ec777ea951bdeffd984710a38b540dc1ec2a) revert: feat(docs): doom/docs: prefix arg = open docs site
* [`bba8975f`](https://github.com/doomemacs/core/commit/bba8975f345dc6364e1915dbe00ce9d172ec3f1f) feat(docs): add doom/docs-find-file
* [`0c24887b`](https://github.com/doomemacs/core/commit/0c24887bb4fc1292d0db04334e0c8798f6640cef) refactor: simplify 27/29 version check
* [`aafc1e1c`](https://github.com/doomemacs/core/commit/aafc1e1cd2e80d313994b90434918763074f6bc9) dev: add 31.1 to shell.nix
* [`d45a7461`](https://github.com/doomemacs/core/commit/d45a7461ef3509a52d39d441a8c6f7dc26aa8e05) refactor: recentf: deprecate text-property sanitizer
* [`8ed7a083`](https://github.com/doomemacs/core/commit/8ed7a083eeb0cb82522de1ec55d4a5b818eae5dc) refactor: use recentf-track-opened-file & remove redundant hook
* [`1a8dba4f`](https://github.com/doomemacs/core/commit/1a8dba4fe105d9c5fdcf9482f378870d2afadcdd) fix: savehist: don't save mark rings
* [`c080b3f3`](https://github.com/doomemacs/core/commit/c080b3f3adb3e9bcad60b971cdd20f076e282a72) feat: savehist: sanitize text-property for more vars
* [`0e279b5d`](https://github.com/doomemacs/core/commit/0e279b5d47cf8bdaa2c2b0edaca27324301421fb) fix: recentf: bump mru list on buffer focus
* [`bd60bc4d`](https://github.com/doomemacs/core/commit/bd60bc4d6dd8bb54182511486839eb0a5e335732) refactor: deprecate doom--dont-prettify-saveplace-cache-a
* [`b97885f7`](https://github.com/doomemacs/core/commit/b97885f7a1aee80b137bb98538b5b7c56470eb7c) fix: reduce doom-switch-buffer-hook triggers in minibuffer
* [`2849ba15`](https://github.com/doomemacs/core/commit/2849ba15cd8abe8d23548e83d81976403bf88600) revert: refactor(lib): advise setopt
* [`910afe28`](https://github.com/doomemacs/core/commit/910afe2838f344169d330fd5f7798d68cf1540de) fix: max-lisp-eval-depth overflow sanitizing savehis
* [`5119e22e`](https://github.com/doomemacs/core/commit/5119e22e18dd279d0bead3845d2953733e42bc7b) bump: sources/doom+
