### PR TITLE
npins home-manager: update 03f4cd46 -> 1dc2d1f7

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -48,9 +48,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "03f4cd46bc1dd4f3a96da778d2ce9f7ce39dd450",
-      "url": "https://github.com/nix-community/home-manager/archive/03f4cd46bc1dd4f3a96da778d2ce9f7ce39dd450.tar.gz",
-      "hash": "sha256-MHwk52ty3NsLhq9a1IbIfBJZlCUJIdiUYFo52JLK9hY="
+      "revision": "1dc2d1f720ab17fc7981e087346bf54b26d284b1",
+      "url": "https://github.com/nix-community/home-manager/archive/1dc2d1f720ab17fc7981e087346bf54b26d284b1.tar.gz",
+      "hash": "sha256-G0F2rFORVcFkEvVdE/qWQTnYekIc77YP5/vRF9nZlxU="
     },
     "hs-grille": {
       "type": "Git",


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@03f4cd46...1dc2d1f7](https://github.com/nix-community/home-manager/compare/03f4cd46bc1dd4f3a96da778d2ce9f7ce39dd450...1dc2d1f720ab17fc7981e087346bf54b26d284b1)

* [`b48c2636`](https://github.com/nix-community/home-manager/commit/b48c26361abb7910f4596879a80df60d607418c8) zsh: make the package option nullable
* [`fb4e41e4`](https://github.com/nix-community/home-manager/commit/fb4e41e48612ba07d879a2d68cb677cd2e317014) zsh: make the package option nullable
* [`52c3a588`](https://github.com/nix-community/home-manager/commit/52c3a5881c821ad7367bbde075e52b76cdb378ab) nushell: Improve error message on outdated plugin
* [`6840c9a8`](https://github.com/nix-community/home-manager/commit/6840c9a8f50722944eb106ce8bb237c138584f2a) direnv: allow nullable mise package
* [`7690127e`](https://github.com/nix-community/home-manager/commit/7690127e7e1c90ab1dcaff525d0dafbeb7e14182) maintainers: update all-maintainers.nix
* [`66c4403a`](https://github.com/nix-community/home-manager/commit/66c4403a0ebfaebe31b246b6c83ab0a3835367fb) ci: do not publish GH pages in forks
* [`0a364342`](https://github.com/nix-community/home-manager/commit/0a364342a66bcecfc8a00d2fc38c6c29eee7bc5e) stylua: init module
* [`6b449e35`](https://github.com/nix-community/home-manager/commit/6b449e35980e1b75dd17da2d6d9b66e757194f1c) zk: export configured notebook directory
* [`9dc641cd`](https://github.com/nix-community/home-manager/commit/9dc641cd5243420033731784b4cad15b16d8f47c) voxtype: start after graphical-session.target
* [`99c9ec63`](https://github.com/nix-community/home-manager/commit/99c9ec63390f1d8c14d95d9e8b17cc29cfbd4e11) home-manager-auto-upgrade: respect nix.package
* [`82c265fa`](https://github.com/nix-community/home-manager/commit/82c265faf4e3161d6015db07c9b0f1ee36a9029b) Add translation using Weblate (Croatian)
* [`9ffeb2e5`](https://github.com/nix-community/home-manager/commit/9ffeb2e59d01ca404229940ca135a90d62c213fc) carapace: add `environment` option
* [`9ebb1805`](https://github.com/nix-community/home-manager/commit/9ebb1805be84716a8dd3cdec3890d6b173f2a8aa) carapace: add `extraPackages` option
* [`f772b7f9`](https://github.com/nix-community/home-manager/commit/f772b7f968365e7b2b70a860c509d214639556fe) carapace: add news entry
* [`50ef465c`](https://github.com/nix-community/home-manager/commit/50ef465c6d21ecb55fcbb87e4c09d895270ae0d3) direnv: nix-direnv.enable default to true
* [`1dc2d1f7`](https://github.com/nix-community/home-manager/commit/1dc2d1f720ab17fc7981e087346bf54b26d284b1) Translate using Weblate (Croatian)
