### PR TITLE
npins nixpkgs: update 2bc24950 -> 82d39796

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -125,9 +125,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "2bc249505bb17b0faa98685c404b5570ef0b382c",
-      "url": "https://github.com/nixos/nixpkgs/archive/2bc249505bb17b0faa98685c404b5570ef0b382c.tar.gz",
-      "hash": "sha256-kVppX4k6QsaJdiM02+1Z6WqtDpfiYwuSm0WsfDJPRGw="
+      "revision": "82d3979605a9d8fd1b7a4dee2f33e4d7d2ee8435",
+      "url": "https://github.com/nixos/nixpkgs/archive/82d3979605a9d8fd1b7a4dee2f33e4d7d2ee8435.tar.gz",
+      "hash": "sha256-TCrC4d/YZpGPeKX0EgkgX5I4/zZAK/6bGnP/eUlZ3Ek="
     },
     "powerlevel10k": {
       "type": "Git",


### PR DESCRIPTION
## Changelog for nixpkgs:
Branch: master
Commits: [nixos/nixpkgs@2bc24950...82d39796](https://github.com/nixos/nixpkgs/compare/2bc249505bb17b0faa98685c404b5570ef0b382c...82d3979605a9d8fd1b7a4dee2f33e4d7d2ee8435)

* [`07a9bb34`](https://github.com/NixOS/nixpkgs/commit/07a9bb342071ab0d73ac0686e2b12ebeabdd1719) ocamlPackages.bstr: 0.0.2 -> 0.0.4
* [`2a385253`](https://github.com/NixOS/nixpkgs/commit/2a385253c79446f2c9fd5307974b10943edaaf09) djgpp_i{5,6}86: use gcc14Stdenv
* [`10dd8618`](https://github.com/NixOS/nixpkgs/commit/10dd8618b720c9f20760ccfe6fdd5c8e84317e4c) hevea: 2.37 -> 2.38
* [`a27f9b60`](https://github.com/NixOS/nixpkgs/commit/a27f9b608781a82fc508abe9b4bd93a02cec6a70) python3Packages.rdflib: 7.5.0 -> 7.6.0
* [`1ff21361`](https://github.com/NixOS/nixpkgs/commit/1ff213616d18c754a038f8a5b35133bc2260e1fb) nixos/qemu-vm: Fix typo in consoles example
* [`2161e61b`](https://github.com/NixOS/nixpkgs/commit/2161e61b7d71bf4822be6207578df82b4ba88602) kde-pim: add akonadi-contacts
* [`d9106a08`](https://github.com/NixOS/nixpkgs/commit/d9106a08b3a47db9eea80147428c7142f7337bb4) nixos/hardware.acpilight: improve the description
* [`a0cf82c6`](https://github.com/NixOS/nixpkgs/commit/a0cf82c61761fe1fb1be7f693e2437d82e907926) pythonPackages.ldap3: add optional support for GSSAPI
* [`ca218862`](https://github.com/NixOS/nixpkgs/commit/ca218862cbdc67091a490a845bf0d15c7f54c5f7) libmtp: 1.1.22 -> 1.1.23
* [`ca890ff1`](https://github.com/NixOS/nixpkgs/commit/ca890ff1eeb59aef23a34889caff8f9b014e0aff) matrix-synapse-plugins.matrix-synapse-mjolnir-antispam: 1.11.0 -> 1.12.1
* [`fd643e0e`](https://github.com/NixOS/nixpkgs/commit/fd643e0ec095920f5332e8fffaf5ba94e8215be7) wch-isp: 0.4.1 -> 0.5.0
* [`5573bc3e`](https://github.com/NixOS/nixpkgs/commit/5573bc3e10166c4b0ac4ce366de3b823dbc8bc14) duat: 0.7.7 -> 0.10.0
* [`188570db`](https://github.com/NixOS/nixpkgs/commit/188570db67bde8a4827f4f02d4ce2d663f2438a6) duat: add dependencies
* [`73eb4f12`](https://github.com/NixOS/nixpkgs/commit/73eb4f12b7843469ada3df3952093443f790ee0c) duat: cleanup
* [`99de890b`](https://github.com/NixOS/nixpkgs/commit/99de890bbe1464a28bd74fd8666a3738f9740c85) orbit: init at 1.5
* [`515b5bb6`](https://github.com/NixOS/nixpkgs/commit/515b5bb6ca9782aa0c57f6112a0800665f69ffc7) nordpass: 6.5.20 -> 7.6.18
* [`b0f611f9`](https://github.com/NixOS/nixpkgs/commit/b0f611f9308fec7f61e27963b6e23f11c86f7231) qt6.qtwebengine: fix darwin build
* [`190af05a`](https://github.com/NixOS/nixpkgs/commit/190af05a72331e3cf298b7bbc0b32dbcfe8b7ae5) rabbitmq-server: 4.2.5 -> 4.3.1
* [`3b0598c6`](https://github.com/NixOS/nixpkgs/commit/3b0598c6db53781597b36c5b2e065356e6e240e2) gnome-secrets: 12.3 -> 13.0.1
* [`e213f335`](https://github.com/NixOS/nixpkgs/commit/e213f335f9976a5bb2bc04dd392d9023821c7bc3) python3Packages.auditok: migrate to pyproject
* [`6973eaac`](https://github.com/NixOS/nixpkgs/commit/6973eaacf861e956e0d6efbfd83359fa8fb5690e) python3Packages.auditok: convert to finalAttrs
* [`72e026ff`](https://github.com/NixOS/nixpkgs/commit/72e026ff5f215b21ba799b597211b033775b0123) hol: remove polyml override
* [`9c0d1fcd`](https://github.com/NixOS/nixpkgs/commit/9c0d1fcda1fbe9442fe32b8698301b71c8f5c6fc) hol: k.14 -> 4-trindemossen-2
* [`d13601de`](https://github.com/NixOS/nixpkgs/commit/d13601de13ec09dca6f3a474432f556e1443e5f4) hid-tools: 0.7 -> 0.12
* [`76c56e20`](https://github.com/NixOS/nixpkgs/commit/76c56e207239938c570a57bcaa75efe817d32ff0) hid-tools: modernize
* [`d37e0052`](https://github.com/NixOS/nixpkgs/commit/d37e005252cf02a99212bda88d2e8e29b3a8c6c1) hid-tools: fix license
* [`b26df0ad`](https://github.com/NixOS/nixpkgs/commit/b26df0add817d8f39b25c29305fa74ff07e8f20a) maintainers/scripts/update.nix: add team argument
* [`d22614f0`](https://github.com/NixOS/nixpkgs/commit/d22614f0c6153357122b246e82b023230d6ec0af) python3Packages.redis-om: 0.3.5 -> 1.1.0
* [`51d13e95`](https://github.com/NixOS/nixpkgs/commit/51d13e959ce4ab9082db71d555860f10bd313201) libdjinterop: 0.26.1 -> 0.27.1
* [`f41789c9`](https://github.com/NixOS/nixpkgs/commit/f41789c9e804a29a518be9539cd1f9b8769207a2) teams/gnome-circle: migrate to github based team
* [`321fd718`](https://github.com/NixOS/nixpkgs/commit/321fd718b7f79d392a99521cbbc0aa2d7d807bc9) libdjinterop: use nixpkgs howard-hinnant-date
* [`d308b901`](https://github.com/NixOS/nixpkgs/commit/d308b9017aca443ace9f4e04ac8e0e2be6c31420) libdjinterop: enable tests and validation for pkg-config and cmake-config
* [`beefc61e`](https://github.com/NixOS/nixpkgs/commit/beefc61e16a7c462e639ab1b0b461ccf24f59d1b) top-level/stage: abort lazily in internallyDisallowedAttrPathsOverlay
* [`ad51eca1`](https://github.com/NixOS/nixpkgs/commit/ad51eca16e09b8a2fbee903a918f8d3358fedf2a) orbit: 1.5 -> 1.6
* [`31f0a8fa`](https://github.com/NixOS/nixpkgs/commit/31f0a8fa8ea01a1325250daa427959849a31357d) python3Packages.azure-mgmt-redhatopenshift: 3.0.0 -> 4.0.0
* [`4dd37d80`](https://github.com/NixOS/nixpkgs/commit/4dd37d80c3de1be68418ac940ffe2774dd517081) nixos/limine: avoid rewriting boot order on update
* [`1dee6189`](https://github.com/NixOS/nixpkgs/commit/1dee618901fe4842a17c1e6a4aed0fffe8f03ea9) opensubdiv: reduce max build core count even more
* [`c734ef79`](https://github.com/NixOS/nixpkgs/commit/c734ef794800a48c63c3a4bdd57dd9b8a5715de1) krita: 6.0.2.1 -> 6.0.3
* [`c49e8d5e`](https://github.com/NixOS/nixpkgs/commit/c49e8d5ec1c111a8673620fe1fe45d926af7d335) ttnn-visualizer: init at 0.88.0
* [`c7d1fa52`](https://github.com/NixOS/nixpkgs/commit/c7d1fa52decb51457433048d39778d45f32c55d2) rofi-rbw-wayland: 1.6.1 -> 1.7.0
* [`e5028d4f`](https://github.com/NixOS/nixpkgs/commit/e5028d4f5b48cf75ca6a5c9ad9b22dfa51dfd503) deluge: fix certificate generation with PyOpenSSL 26
* [`0d6d6221`](https://github.com/NixOS/nixpkgs/commit/0d6d6221c2ac76cdf575cad4dcbe475e484d577e) maintainers: add mugiwarix
* [`eb005c55`](https://github.com/NixOS/nixpkgs/commit/eb005c550a292432171d54efb7d2c2bcf6d83ceb) talloc: 2.4.4 -> 2.5.0
* [`79385e7c`](https://github.com/NixOS/nixpkgs/commit/79385e7caa4c052a3f43652d8efd1d95aff815fa) qgis: 4.0.3 -> 4.2.1
* [`aea30151`](https://github.com/NixOS/nixpkgs/commit/aea30151067eeb733bf932d6bc16ee033c08bcfb) qgis: replace spatialite path patch with substituteInPlace
* [`1210ca5c`](https://github.com/NixOS/nixpkgs/commit/1210ca5c4acbb210d5890c8a1dcdca9643b99f18) openxr-loader: 1.1.54 -> 1.1.62
* [`ceff7f86`](https://github.com/NixOS/nixpkgs/commit/ceff7f865f60a2fcce96078fb43794b96d99e345) palera1n: init at 2.2.1-unstable-2026-01-17
* [`bfce455c`](https://github.com/NixOS/nixpkgs/commit/bfce455cb9a8da6be9528271e1b42111fcd9dd47) python3Packages.tago: drop
* [`35963724`](https://github.com/NixOS/nixpkgs/commit/35963724cf7bc13752bf8b1a87b351a48429a0ab) lib/services: fix test expectations for the reload options
* [`f351415c`](https://github.com/NixOS/nixpkgs/commit/f351415c08a7f41b3799ba2ea3c7076171a5e620) vscode-extensions.ms-azuretools.vscode-bicep: 0.45.15 -> 0.46.1
* [`a05b1545`](https://github.com/NixOS/nixpkgs/commit/a05b1545aa46c28084a8eb7172d772ba8b06c3cb) maintainers: add mmkamron
* [`fdb32500`](https://github.com/NixOS/nixpkgs/commit/fdb3250080800972b609cd5a7e4689845b57350d) jprq: init at 2.4
* [`b0f6776e`](https://github.com/NixOS/nixpkgs/commit/b0f6776ea3084c1a48b8eab4cfde03093a531311) wt: 4.13.2 -> 4.14.1
* [`b644b7e5`](https://github.com/NixOS/nixpkgs/commit/b644b7e50a508f439e52f83b98ea6ac6f6b99c96) _cuda.lib.allowUnfreeCudaPredicate: handle compound licenses
* [`297d9056`](https://github.com/NixOS/nixpkgs/commit/297d905627000a41086bc2d863b26d7d9b4992b1) python3Packages.dj-search-url: format to pyproject, fix license
* [`2db7aecb`](https://github.com/NixOS/nixpkgs/commit/2db7aecbe6207e55290b747ce30acd842ef7708e) python3Packages.django-celery-results: format to pyproject, enable tests
* [`c486f961`](https://github.com/NixOS/nixpkgs/commit/c486f961148c653f90824cd91a7ab6c4c1d09b0a) python3Packages.rasterio: 1.5.0 -> 1.5.1
* [`75ea1b89`](https://github.com/NixOS/nixpkgs/commit/75ea1b89d495fbb9d16043f1048ba386c8778e42) deluge: vendor certificate generation patch
* [`2d557d8f`](https://github.com/NixOS/nixpkgs/commit/2d557d8f02d4109b3d44c38a806884641af4da2d) k6: 2.0.0 -> 2.2.0
* [`de11c51a`](https://github.com/NixOS/nixpkgs/commit/de11c51abef3bc644abadbe4db6679fbab965366) rapidcheck: 0-unstable-2023-12-14 -> 0-unstable-2026-08-06
* [`3ea12826`](https://github.com/NixOS/nixpkgs/commit/3ea128268247927090bf714acd60743893c86b07) nordvpn: fix nix-update support
* [`6b0e311b`](https://github.com/NixOS/nixpkgs/commit/6b0e311b5677ac9435a99acb364da292831576dd) nordvpn: 5.2.0 -> 5.3.0
* [`67d639d8`](https://github.com/NixOS/nixpkgs/commit/67d639d823e9b63170955a8640202bb534bdc921) firezone-gateway: 1.5.2 -> 1.6.0
* [`22a7b4f8`](https://github.com/NixOS/nixpkgs/commit/22a7b4f88fe21a0dd2c82905b2f6e690ab56e3a3) mapproxy: 6.1.1 -> 7.0.0
* [`bb83a184`](https://github.com/NixOS/nixpkgs/commit/bb83a18455cee1f12cc9ca443b9d1e8db445e608) phpPackages.php-codesniffer: 4.0.1 -> 4.0.4
* [`3f52ae50`](https://github.com/NixOS/nixpkgs/commit/3f52ae5076a5ac085c5d4f891438d89311051fd5) gitlab-runner: 19.1.1 -> 19.2.1
* [`b9d6aebf`](https://github.com/NixOS/nixpkgs/commit/b9d6aebf85f0e2212e3c1a0ef852bd498e1b9e05) telegram-desktop.tg_owt: 0-unstable-2026-04-09 -> 0-unstable-2026-08-03
* [`cebce1bc`](https://github.com/NixOS/nixpkgs/commit/cebce1bc4b1c747a601320edc3e80f5b8ef9905e) telegram-desktop: 7.0.2 -> 7.0.9
* [`6dd92175`](https://github.com/NixOS/nixpkgs/commit/6dd92175515cf16dc8652565dce1ff1855c197a6) _64gram: 1.2.5 -> 1.2.6
* [`b33844c3`](https://github.com/NixOS/nixpkgs/commit/b33844c3f24cfa1e40308b4b9275a1bbbf840602) _64gram: 1.2.6 -> 1.2.7
* [`6c35b72e`](https://github.com/NixOS/nixpkgs/commit/6c35b72eb621b3d4cb068f866fb82e560c50f06a) materialgram: 6.7.7.1 -> 7.0.5.1
* [`497aaf86`](https://github.com/NixOS/nixpkgs/commit/497aaf86df1757e24b1641b8e4e14c8f24a716f0) telegram-desktop: build with default ffmpeg
* [`66104fad`](https://github.com/NixOS/nixpkgs/commit/66104fad19feabe258052c64bf345b45f9746a8c) telegram-desktop: use system libfido2
* [`3f79d0dd`](https://github.com/NixOS/nixpkgs/commit/3f79d0dd24af5b12bba64c03c7e6f0c73a490b44) rPackages.buildRPackage: refactor
* [`e34a43b2`](https://github.com/NixOS/nixpkgs/commit/e34a43b2fa699a202304e4afd68b9144553a2417) rPackages.buildRPackage: enable strictDeps
* [`21bc93c9`](https://github.com/NixOS/nixpkgs/commit/21bc93c9676aff71b562127359ba98338c3d1773) rPackages.buildRPackage: enable __structuredAttrs
* [`6b3bf457`](https://github.com/NixOS/nixpkgs/commit/6b3bf457db74f45e36475ea7ac2874d020dc3c58) emacs: slightly improve withPackages test
* [`36e2f99d`](https://github.com/NixOS/nixpkgs/commit/36e2f99d815feb465e8390da983cfae5a6f701c9) emacs: skip with-packages-no-jit-native-comp if not applicable
* [`af8c5fe1`](https://github.com/NixOS/nixpkgs/commit/af8c5fe135fd75ffea07bf286710d0e031d91a48) emacs: test AOT native-comp eln files are available in withPackages
* [`ebeac7a7`](https://github.com/NixOS/nixpkgs/commit/ebeac7a7524a5d269b0b0824a1b0615b81be2a3f) bpf-linker: 0.10.4 -> 0.11.0
* [`092a66fa`](https://github.com/NixOS/nixpkgs/commit/092a66fa0093ded39ce6b248b9a7ec3a53fdb30a) python3Packages.openexr: init at 3.4.13
* [`dd497f7a`](https://github.com/NixOS/nixpkgs/commit/dd497f7abd3c3eb291e9b23374ea50c62040c0c6) rPackages.iscream: fix build with more robust filtering
* [`3ecb4f82`](https://github.com/NixOS/nixpkgs/commit/3ecb4f82d3bdd4bbb8e616412964105bc1d3eaa4) rPackages: don't put R deps into nativeBuildInputs
* [`fd8ab89e`](https://github.com/NixOS/nixpkgs/commit/fd8ab89e5d95beeedd1846cda95eb55c44501b26) rPackages.iscream: remove unused filtering logic
* [`111bc849`](https://github.com/NixOS/nixpkgs/commit/111bc849e07fdc04b738e2ffe5e5b9de3e8eb802) openpgp-ca: 0.14.0 -> 0.14.1
* [`c22ce311`](https://github.com/NixOS/nixpkgs/commit/c22ce311a3726733fcdadecc0a982fd30c67bed3) maintainers: add byteflavour
* [`6cdd063a`](https://github.com/NixOS/nixpkgs/commit/6cdd063a17d541081d72cdc5603a4410ec03eb59) perses: 0.53.1 -> 0.54.0
* [`bf648183`](https://github.com/NixOS/nixpkgs/commit/bf6481830604de1b2c85101c9ab63e2e9d2228db) forgejo-mcp: 2.30.2 -> 2.33.0
* [`cef26c7c`](https://github.com/NixOS/nixpkgs/commit/cef26c7c61d519cc1ebd88981bc408d582e84236) rPackages: strip binaries in common locations
* [`ca2d3ef8`](https://github.com/NixOS/nixpkgs/commit/ca2d3ef80e72e84dce8ad8a1f3e29e824d913631) dpp: 10.1.5 -> 10.1.6
* [`547b9992`](https://github.com/NixOS/nixpkgs/commit/547b9992cd48a6034dc1a57abe85c713194686e9) calamares-nixos-extensions: remove redundant wireplumber default
* [`c85883e7`](https://github.com/NixOS/nixpkgs/commit/c85883e7487d91b542a1747c3e1923dde9ba09a3) calamares-nixos-extensions: harmonize spacing after comment start
* [`f2a63511`](https://github.com/NixOS/nixpkgs/commit/f2a6351124cba95292c61c4399a84e876e589935) rPackages.buildRPackage: fix structuredAttrs support
* [`3d66eae3`](https://github.com/NixOS/nixpkgs/commit/3d66eae3eabd30370efc87a51cecdb1fd603c850) vscode-extensions.angular.ng-template: 22.0.1 -> 22.1.0
* [`19664704`](https://github.com/NixOS/nixpkgs/commit/19664704560935f99bb1e47ed43e6842e3dfc2aa) rPackages.buildRPackage: remove unneeded deps
* [`16eadf10`](https://github.com/NixOS/nixpkgs/commit/16eadf108d624aec5153e451ebd0ec91a138b3ae) rPackages: add more empty list default logic
* [`8c0c0b96`](https://github.com/NixOS/nixpkgs/commit/8c0c0b966ab8f8119f3ee7d27274ba7fe6855033) linuxPackages.drbd: 9.3.2 -> 9.3.3
* [`3ef8579a`](https://github.com/NixOS/nixpkgs/commit/3ef8579a062fd01334834030715109d2ef877852) rubyPackages.loofah: 2.24.1 -> 2.25.2
* [`b771bc96`](https://github.com/NixOS/nixpkgs/commit/b771bc967309063d4925e2d4b3b0635d1c348238) sparkle: support darwin; update sparkle-service
* [`12f5c633`](https://github.com/NixOS/nixpkgs/commit/12f5c63377d07b26aba7d523ca97cc2bed607ae7) vscode-extensions.github.codespaces: 1.18.15 -> 1.18.16
* [`1f5656d6`](https://github.com/NixOS/nixpkgs/commit/1f5656d634bcc4d80c216eebb9769048685b3aee) firefoxpwa-unwrapped: 2.18.4 -> 2.19.0
* [`1e31aed3`](https://github.com/NixOS/nixpkgs/commit/1e31aed3b858024425604f618791cb8b4aba61d9) sidplayfp: 3.1.0 -> 3.2.0
* [`9e4efccb`](https://github.com/NixOS/nixpkgs/commit/9e4efccb2bae33e00c7b82ea744b62368cb6e61e) rPackages.httpuv: use system libuv
* [`33002527`](https://github.com/NixOS/nixpkgs/commit/33002527931cad095f6733d3c07905a2989af15e) rPackages.Rserve: use symlink instead of copying to $out
* [`375523bb`](https://github.com/NixOS/nixpkgs/commit/375523bb1a7d8dc34685ddfc9f49fb51649b7124) rPackages.immunotation: clean up patches
* [`2e59d4ee`](https://github.com/NixOS/nixpkgs/commit/2e59d4eed8a69ed18601c5a993dac5bd72ed0231) matomo: 5.12.0 -> 5.13.0
* [`56ee17ff`](https://github.com/NixOS/nixpkgs/commit/56ee17ff2b7ad1a01a4a124e1027ba10463fab8e) n-m3u8dl-re: 0.5.1-beta -> 0.6.0-beta
* [`a5cfd312`](https://github.com/NixOS/nixpkgs/commit/a5cfd31224ece636641769ac70920188c1cf1c5b) lichess-external-engine: init at a6ef15a
* [`62dd2437`](https://github.com/NixOS/nixpkgs/commit/62dd24376d07250d9594539f5a69ab378bf58bc6) lichess-external-engine: add pyproject false
* [`6bd048ee`](https://github.com/NixOS/nixpkgs/commit/6bd048ee6284e9a42a9767605d254a2905a073ef) lichess-external-engine: rm meta with lib
* [`e704c81a`](https://github.com/NixOS/nixpkgs/commit/e704c81a4b08d26e12185e8e8762b34020d652a6) lichess-external-engine: move python3Packages in the package
* [`fad0bc95`](https://github.com/NixOS/nixpkgs/commit/fad0bc95f06689e3ac93befb0c9c505fa028afa0) lichess-external-engine: rm all-packages.nix addition
* [`c31f8447`](https://github.com/NixOS/nixpkgs/commit/c31f84471bd1f3f6e3466920c45ed2d94b628748) lichess-external-engine: fix version
* [`9fb8aa15`](https://github.com/NixOS/nixpkgs/commit/9fb8aa1506a209ab27ae878717c8f8b73a81db8a) lichess-external-engine: formatting
* [`4a5d8e8a`](https://github.com/NixOS/nixpkgs/commit/4a5d8e8ab86e5c0e80e0fe79005fbb097652cc58) lichess-external-engine: fix src
* [`fc74b288`](https://github.com/NixOS/nixpkgs/commit/fc74b2885a9a3a79a1a1698605ebde5ddf8c0a95) lichess-external-engine: remove doBuild
* [`0d0ee3f2`](https://github.com/NixOS/nixpkgs/commit/0d0ee3f2807ff8c0f167db8235580c9b54d5f6b2) lichess-external-engine: remove redundancy in installPhase
* [`4a55483f`](https://github.com/NixOS/nixpkgs/commit/4a55483f7c1a4b9dbfd4320fe88f5fa1c1bd363f) lichess-external-engine: add __structuredAttrs
* [`c8d6e779`](https://github.com/NixOS/nixpkgs/commit/c8d6e7790c69ead4c296e4d4ec7b79f027281fb7) libdjinterop: dont hardcode versions when patching CMakeLists.txt
* [`5e7cdb62`](https://github.com/NixOS/nixpkgs/commit/5e7cdb626395fcb9ecd309bc7b8b59c949ff9a2a) rPackages.{mongolite,openssl,websocket}: link openssl via pkg-config
* [`7f6bb5ed`](https://github.com/NixOS/nixpkgs/commit/7f6bb5ed1d619a7af433d06949caa330f1700f47) docker-compose: 5.4.0 -> 5.5.0
* [`99e50bae`](https://github.com/NixOS/nixpkgs/commit/99e50baea214cf0c046c9cd841ba26a3aebf6028) R: prepend instead of overriding TCLLIBPATH
* [`180812aa`](https://github.com/NixOS/nixpkgs/commit/180812aa8b2f4245a7d41120f2aa9001319464db) rPackages.rpanel: add tclPackages.bwidget to search path on load
* [`5280777e`](https://github.com/NixOS/nixpkgs/commit/5280777ebaaac11421eebf801a564a3cba31a696) grub2: 2.12 -> 2.14
* [`b064a484`](https://github.com/NixOS/nixpkgs/commit/b064a48442474145159c318ceea3ab73ec01d52b) grub2: use stable savannah repositories
* [`0e1587fa`](https://github.com/NixOS/nixpkgs/commit/0e1587fa4414f4672f432509d810b3b6f6e84b9b) grub2: use freedesktop repository
* [`33e59a88`](https://github.com/NixOS/nixpkgs/commit/33e59a88b228cbbf9854e51db3c1b110e80bda80) factorio: make versions overriding more ergonomic
* [`37d7fd1c`](https://github.com/NixOS/nixpkgs/commit/37d7fd1c8f25de57b94decec328e30fc31247f16) python3Packages.marimo: 0.23.16 -> 0.24.0
* [`929801ec`](https://github.com/NixOS/nixpkgs/commit/929801ec3bdad0f963668f628cb58d0b0665552f) os-prober: 1.84 -> 1.85
* [`15200897`](https://github.com/NixOS/nixpkgs/commit/15200897ace6946a81bffe83d57577dd2350aaba) discordchatexporter-desktop: add philocalyst to maintainers
* [`bcdfa8fe`](https://github.com/NixOS/nixpkgs/commit/bcdfa8feb2a658b4b24af0e03cc73223e51a0642) apache-airflow: 3.3.0 -> 3.3.1
* [`9f6a05bb`](https://github.com/NixOS/nixpkgs/commit/9f6a05bb915019109f3ed3204fd24cf68629bc5e) perlPackages.Imager: 1.031 -> 1.034
* [`692bec9e`](https://github.com/NixOS/nixpkgs/commit/692bec9edf331a32d5911da5431b30f6afcdd499) discordchatexporter-desktop: fix build and support darwin app bundle
* [`adcf77f7`](https://github.com/NixOS/nixpkgs/commit/adcf77f72ed93e03c306f3ec439f4bee8f073d59) vscode-extensions.ms-vscode.cpptools: 1.32.2 -> 1.33.8
* [`cf91d133`](https://github.com/NixOS/nixpkgs/commit/cf91d1336ecd302995dbd68d6f98f9f349730bac) bitwarden-menu: 0.4.5 -> 0.6.0
* [`f12c2fc8`](https://github.com/NixOS/nixpkgs/commit/f12c2fc819121bb6675b84ff2a62cf74169c989a) rPackages: include libintl on darwin
* [`c4f343e0`](https://github.com/NixOS/nixpkgs/commit/c4f343e0916f65b5f43f4732436473249fad5dc9) rPackages.data_table: fix missing openmp dependency
* [`3921cb2f`](https://github.com/NixOS/nixpkgs/commit/3921cb2f525191eb9ca9d8be951281a6b5c5490f) rPackages.ModelMetrics: fix missing openmp dependency
* [`1a57ca2f`](https://github.com/NixOS/nixpkgs/commit/1a57ca2ff4cad0dd9fc0117e3e016da81afa1a39) maintainers: add tobinio
* [`3e8c407b`](https://github.com/NixOS/nixpkgs/commit/3e8c407bf3e071f85a255c8b9324bb0601d72da2) cargo-features-manager: 0.11.0 -> 0.12.0
* [`8ade1f06`](https://github.com/NixOS/nixpkgs/commit/8ade1f069ea8edf31e8883ed946bc02f5b25044f) rPackages: properly handle passed buildInputs
* [`ea3568b6`](https://github.com/NixOS/nixpkgs/commit/ea3568b6040755ef722177e1e9c7c495711536e5) ginkgo: 2.28.1 -> 2.32.1
* [`49e0d60b`](https://github.com/NixOS/nixpkgs/commit/49e0d60b38df163750de3e6744108862159952b4) vscode-extensions.sumneko.lua: 3.18.2 -> 3.19.1
* [`5e087228`](https://github.com/NixOS/nixpkgs/commit/5e087228e29533e4bd155e90c19f5d0ac32acd5b) percona-toolkit: Bump to 3.7.1
* [`b74765c3`](https://github.com/NixOS/nixpkgs/commit/b74765c393813b845c6c0d1bcacdba91d76d7ad0) wasm-bindgen-cli_0_2_127: init at 0.2.127
* [`6049ba36`](https://github.com/NixOS/nixpkgs/commit/6049ba36f4dfb7b76634024664699644f91c1ba6) lubeogger: 1.7.0 -> 1.7.1
* [`103eecaf`](https://github.com/NixOS/nixpkgs/commit/103eecaf19197dcc81b55dbdfbae672abd36004f) lubelogger: add esch to maintainers
* [`24fe59bc`](https://github.com/NixOS/nixpkgs/commit/24fe59bc164123e8ab2579b536906cfa89b442e0) dub: 1.41.0 -> 1.42.0
* [`91d8de0e`](https://github.com/NixOS/nixpkgs/commit/91d8de0e1b959f40b13bc1f580aac0511699f23c) rPackages: clean up installFlags and NIX_CFLAGS_COMPILE
* [`6345f94e`](https://github.com/NixOS/nixpkgs/commit/6345f94ef7d6908995a0cce2191b2cae75737702) nushellPlugins.skim: 0.29.1 -> 0.30.0
* [`6f336db4`](https://github.com/NixOS/nixpkgs/commit/6f336db47673ee882a9604b6937ef50ca854e459) cannelloni: 2.0.1 -> 2.1.2
* [`5bf6dfb0`](https://github.com/NixOS/nixpkgs/commit/5bf6dfb0e7182e928cb21a53a8dc10afddda02f0) nixosTests.os-prober: fix
* [`eac3b505`](https://github.com/NixOS/nixpkgs/commit/eac3b505ee1fe1eb3301bb2bab5a0be62a49488c) grub2: fix grubTarget and restrict platforms for coreboot builds
* [`449bf3e2`](https://github.com/NixOS/nixpkgs/commit/449bf3e2573014d422474f6b1e8a65592cf421c5) rclone-ui: 3.5.4 -> 3.7.2
* [`a6baab76`](https://github.com/NixOS/nixpkgs/commit/a6baab76d16e74ccf99326dd518442eeeefb578b) zola: 0.22.1 -> 0.23.4
* [`f65d8a56`](https://github.com/NixOS/nixpkgs/commit/f65d8a56cebb0881dfb3bc01a46747e28519b2e6) zola: use finalAttrs.finalPackage
* [`624f95ef`](https://github.com/NixOS/nixpkgs/commit/624f95ef1b7d9196efdad615c1f77128688da57b) vscode-extensions.quarto.quarto: init at 1.135.0
* [`996aa29f`](https://github.com/NixOS/nixpkgs/commit/996aa29f91b985b24311bf36013d893796d3f691) lukesmithxyz-st: Fix invalid unstable version scheme
* [`fdad9f5e`](https://github.com/NixOS/nixpkgs/commit/fdad9f5e1be577c4161cc04561bbf96fa653b72c) lukesmithxyz-st: 0-unstable-2021-08-10 -> 0-unstable-2026-04-09
* [`e1c6a14f`](https://github.com/NixOS/nixpkgs/commit/e1c6a14f9b09e7ce5276b24dd644eadfd3da05a9) marksman: fix build in darwin sandbox
* [`bf93e2de`](https://github.com/NixOS/nixpkgs/commit/bf93e2dee5e8d19667ca68917822ccafbbc6eb51) quickshell: 0.3.0 -> 0.3.1
* [`9124e160`](https://github.com/NixOS/nixpkgs/commit/9124e160ee710da42caa6ad3b85572a5d7d3771f) wordpressPackages.plugins.activitypub: init
* [`36089737`](https://github.com/NixOS/nixpkgs/commit/360897378d56bfa70bfde6681a1728f1d107bf17) wordpressPackages.plugins.polls-for-activitypub: init
* [`3be4cb81`](https://github.com/NixOS/nixpkgs/commit/3be4cb8180598e0e410b348a913c88ac97d62941) jrl-cmakemodules: 2.2.4 -> 2.3.0
* [`d9766271`](https://github.com/NixOS/nixpkgs/commit/d9766271fe680e0feeeb588672ab94ec779caf0c) stm32cubemx: 6.17.0 -> 6.18.1
* [`d3aacfd5`](https://github.com/NixOS/nixpkgs/commit/d3aacfd50df529047bcc5c923c6125aabcb97c74) vscode-extensions.biomejs.biome: 2026.7.60717 -> 2026.8.190716
* [`7fa5f841`](https://github.com/NixOS/nixpkgs/commit/7fa5f841799bfa29c26a781e179712d14dcaf8eb) R: use replace-fail for substitutions
* [`898f2911`](https://github.com/NixOS/nixpkgs/commit/898f2911099e5165b8fa9aa601dca46b3f1782c3) python3Packages.nltk: 3.10.0 -> 3.10.3
* [`05be4476`](https://github.com/NixOS/nixpkgs/commit/05be4476d9e4120d55df27cc7f90e6507dcd4b8b) dpkg: enable strictDeps
* [`ee06a4a9`](https://github.com/NixOS/nixpkgs/commit/ee06a4a96fd6268c500ce2c226f89c2df3ebc823) dpkg: enable structuredAttrs
* [`48710539`](https://github.com/NixOS/nixpkgs/commit/48710539c062ec2dae33de18b8d9425e478e55d3) python3Packages.ayla-iot-unofficial: 1.5.0 -> 1.5.1
* [`890511e1`](https://github.com/NixOS/nixpkgs/commit/890511e108dcf1e99f696870f00cdf9fa23fa53f) python3Packages.fortune-python: rename from python3Packages.fortune
* [`bc0a4610`](https://github.com/NixOS/nixpkgs/commit/bc0a461047df19846255b601a41a2085e277eb5b) python3Packages.ayla-iot-unofficial: migrate to finalAttrs
* [`50383adb`](https://github.com/NixOS/nixpkgs/commit/50383adbd00d78b20e7cae3a44042e1b67796a68) nixos/nix: declare .settings.experimental-features
* [`5c1f2da3`](https://github.com/NixOS/nixpkgs/commit/5c1f2da3720e5dcf801c3d04013501f693efbf9f) apftool-rs: 1.2.3 -> 1.2.5
* [`3da18bec`](https://github.com/NixOS/nixpkgs/commit/3da18bec8dc140590112f2297a7ba266101c0a48) ollama: Use passthru.llamaCppSrc
* [`29651e20`](https://github.com/NixOS/nixpkgs/commit/29651e208e1d648d6e9c604ff79355b581a39353) python3Packages.mediawiki-langcodes: 0.2.27 -> 0.2.28
* [`08596076`](https://github.com/NixOS/nixpkgs/commit/0859607696e07840c71ca98e97a27d63c6956171) nixos/syncthing: escape properly ignorePatterns
* [`1af3c0f8`](https://github.com/NixOS/nixpkgs/commit/1af3c0f85faa5122ceadf9ca5652c57bfec50d2e) python3Packages.python-sat: 1.9.dev7 -> 1.9.dev15
* [`f4e5d875`](https://github.com/NixOS/nixpkgs/commit/f4e5d87562d2e0bbd4950dc9083d0a0e5f7cfa34) cosmic-viewer: init at 0-unstable-2026-07-27
* [`0d240f54`](https://github.com/NixOS/nixpkgs/commit/0d240f542ef6fb017b375d0ce012bbcd7a5aafc0) polari: 49.0 -> 50.0
* [`2868078a`](https://github.com/NixOS/nixpkgs/commit/2868078aac5526fcda05a5deefd0014ac00c761c) gemini-cli: remove `_4evy` as maintainer
* [`d26a8b9b`](https://github.com/NixOS/nixpkgs/commit/d26a8b9bf9be8d2032002c1f5161614ad4b2d063) python3Packages.confluent-kafka: fix hung build in darwin sandbox
* [`424c6198`](https://github.com/NixOS/nixpkgs/commit/424c61980b05ece4a0330b44b304c5cb1fa37f11) pdfsam-basic: 5.4.1 -> 6.0.5
* [`717d8ec7`](https://github.com/NixOS/nixpkgs/commit/717d8ec734972568b34dd6680196212cf59c4bbf) pdfsam-basic: rename rev -> tag in src
* [`ae7cca0f`](https://github.com/NixOS/nixpkgs/commit/ae7cca0f28d79074b5d7f134b78e0f265e48513f) vpv: 0.9.0 -> 0.9.1
* [`20f31865`](https://github.com/NixOS/nixpkgs/commit/20f318651a81ce07cfe060a3296f60dd79422bfd) doc/hooks: mention that writableTmpDirAsHomeHook can be used in specific build phases
* [`669501d8`](https://github.com/NixOS/nixpkgs/commit/669501d8c05cf2bf1347ac329cd10ab94c88bfac) ddcci-driver: Fix linux kernel 7.2 build
* [`20aed63e`](https://github.com/NixOS/nixpkgs/commit/20aed63e9061b76fb04c4ae221d2a114a4c10e70) nettle_4: init at 4.0
* [`a52af57d`](https://github.com/NixOS/nixpkgs/commit/a52af57dc45e8d8ed8a3c7ba3ba22f7f529db84e) wasm-bindgen-cli: 0.2.121 -> 0.2.127
* [`4222e966`](https://github.com/NixOS/nixpkgs/commit/4222e966acfffe88f0b650e6c7d50644568205cb) perlPackages.NetOAuth: 0.28 -> 0.33
* [`50f6d7c2`](https://github.com/NixOS/nixpkgs/commit/50f6d7c24993bb9b3bd56c2051026e62de03c4a0) python3Packages.dendropy: 5.0.11 -> 5.0.13
* [`de909388`](https://github.com/NixOS/nixpkgs/commit/de909388130dc9a8aba7a4735d774c24dc871f83) spring-boot-cli: 4.1.0 -> 4.1.1
* [`4b75c71f`](https://github.com/NixOS/nixpkgs/commit/4b75c71f9cb6d129d6724d55387d191b0ed8fc74) google-cloud-sql-proxy: 2.25.2 -> 2.25.3
* [`0eb3a404`](https://github.com/NixOS/nixpkgs/commit/0eb3a4045c3a30491e56531eac1bc32bab460226) prometheus-tailscale-exporter: 0.6.1 -> 0.7.0
* [`4c423007`](https://github.com/NixOS/nixpkgs/commit/4c423007cdc4b1131cbc45598c61c2eebf4ec84a) libasn1c: 0.9.38 -> 0.9.39
* [`d661af07`](https://github.com/NixOS/nixpkgs/commit/d661af078c852b1411d77e1a0e942a44ab4f5608) aws-vault: 7.13.4 -> 7.13.5
* [`c9dd5222`](https://github.com/NixOS/nixpkgs/commit/c9dd52226612c748b0a6e8336f4d56995e4faddc) python3Packages.dicomweb-client: 0.61.1 -> 0.61.2
* [`ca9c5ddf`](https://github.com/NixOS/nixpkgs/commit/ca9c5ddfbf32a13f7ef6845034c6a2059eae9092) s-tui: 1.4.0 -> 1.5.0
* [`cf2a8772`](https://github.com/NixOS/nixpkgs/commit/cf2a87728c53f47fbed1baf36ccc8138783289ca) mieru: 3.35.0 -> 3.36.0
* [`337890d5`](https://github.com/NixOS/nixpkgs/commit/337890d592b17fc939ad72c14c097077d7f01ca9) nixos/journald: migrate to RFC 42-style settings
* [`6cc3634f`](https://github.com/NixOS/nixpkgs/commit/6cc3634f3d4fc04062bd57e010a6160775b07b13) fn-cli: 0.6.63 -> 0.6.64
* [`a2e45301`](https://github.com/NixOS/nixpkgs/commit/a2e453018289c8ab998ceb0c64c5c0957a977870) phrase-cli: 2.65.0 -> 2.67.2
* [`21d29429`](https://github.com/NixOS/nixpkgs/commit/21d2942966e96bf4fb6263660990517290f355d4) nwg-displays: 0.4.3 -> 0.4.4
* [`e48a5f93`](https://github.com/NixOS/nixpkgs/commit/e48a5f934775d26f5d35cdfad2cf37894b7c6fe9) vendir: 0.46.0 -> 0.46.1
* [`7557f6be`](https://github.com/NixOS/nixpkgs/commit/7557f6be4ba19bb988de4f450e71a0fc28c958fa) phpExtensions.blackfire: 2026.8.2 -> 2026.8.6
* [`86013cf7`](https://github.com/NixOS/nixpkgs/commit/86013cf7880fafc3da7fa647c76ea7f316310200) llmfit: 1.1.9 -> 1.1.10
* [`1dd150bc`](https://github.com/NixOS/nixpkgs/commit/1dd150bcf97b84147db6d343d7479501aaa93c9f) python3Packages.aioaquarite: 0.6.1 -> 0.8.0
* [`eba5214a`](https://github.com/NixOS/nixpkgs/commit/eba5214a8cf9d2e730635e8ed6f7f94e1fe3b17a) msgpack-c: 7.0.1 -> 7.0.2
* [`24cc2c69`](https://github.com/NixOS/nixpkgs/commit/24cc2c69ccc973031855e7c851d29f6ba90da3fa) python314Packages.sudachipy: remove broken marker
* [`a2d6bb5b`](https://github.com/NixOS/nixpkgs/commit/a2d6bb5bda32c2f33306585634df811189dfabc6) python3Packages.viser: 1.0.30 -> 1.1.0
* [`a4ee65cb`](https://github.com/NixOS/nixpkgs/commit/a4ee65cba14b28afa8bc355936282cec1b6d706e) CONTRIBUTING: list nix fmt first among formatter commands
* [`b61c629b`](https://github.com/NixOS/nixpkgs/commit/b61c629bb908f591d4c29585a32c72072e1e9fbc) python3Packages.restrictedpython: 8.4 -> 8.5
* [`49144131`](https://github.com/NixOS/nixpkgs/commit/491441311c91218bbfc54eb0e74bfdac7155dc1e) viceroy: 0.20.1 -> 0.21.0
* [`4b9b0e6e`](https://github.com/NixOS/nixpkgs/commit/4b9b0e6ee7e5008a55126e084a4495d863f0958c) darkplaces: add darwin support
* [`81832f6b`](https://github.com/NixOS/nixpkgs/commit/81832f6b769ac7f664c57df6aaada2f5aea7e02f) ovhcloud-cli: 0.12.0 -> 0.13.0
* [`4b5278f0`](https://github.com/NixOS/nixpkgs/commit/4b5278f0b6aeba3b6bdbd94e151235b631e756ff) openfga: 1.18.3 -> 1.19.0
* [`c3a495cf`](https://github.com/NixOS/nixpkgs/commit/c3a495cfbf8c41cf1dd48f8a36005ff57b9e9efb) mcp-grafana: 1.1.0 -> 1.2.0
* [`7641c7b4`](https://github.com/NixOS/nixpkgs/commit/7641c7b48e7e42df0214f78375c9beef953df23c) kubecolor: 0.6.0 -> 0.7.1
* [`e193615a`](https://github.com/NixOS/nixpkgs/commit/e193615a975deca6ec8bc21993438755c2781725) iroh-relay: 1.0.3 -> 1.1.0
* [`d8e6fb37`](https://github.com/NixOS/nixpkgs/commit/d8e6fb3764ed3e916357989b6c2548f4996870a1) go-containerregistry: 0.21.9 -> 0.22.0
* [`7f2a6dd5`](https://github.com/NixOS/nixpkgs/commit/7f2a6dd5e5a0ebe65655e10072b3d839e4f95cb1) plasticscm-client-gui-unwrapped: 11.0.16.10350 -> 11.0.16.10371
* [`485066fa`](https://github.com/NixOS/nixpkgs/commit/485066fa4604567c2f2d96f66a8663ccd8ce9b55) plasticscm-theme: 11.0.16.10350 -> 11.0.16.10371
* [`4e49415d`](https://github.com/NixOS/nixpkgs/commit/4e49415dc751cd5eda1c1bef115e6f09b1872637) plasticscm-client-core-unwrapped: 11.0.16.10350 -> 11.0.16.10371
* [`9b127ede`](https://github.com/NixOS/nixpkgs/commit/9b127ede5c3f28c6046973b0e342b043f4ff9cfa) ab-av1: 0.11.6 -> 0.11.7
* [`c8c5f397`](https://github.com/NixOS/nixpkgs/commit/c8c5f397806b8c6f91509418b635003bf98ac1b5) python3Packages.pkg-about: 2.4.3 -> 2.4.4
* [`281d51bf`](https://github.com/NixOS/nixpkgs/commit/281d51bf98862da385e6dbc1de04dcf3949c37d7) vxwm: init at 2.3-unstable-2026-08-08
* [`3c7c2cfd`](https://github.com/NixOS/nixpkgs/commit/3c7c2cfd4a1ffb2f20e6662e00580c81d93ea9f2) nixos/vxwm: init module
* [`f63902e5`](https://github.com/NixOS/nixpkgs/commit/f63902e5b6e0190de5037d9bb43cb538d478f0ab) python3Packages.zodbpickle: 4.4 -> 4.5
* [`8f60e078`](https://github.com/NixOS/nixpkgs/commit/8f60e0786007f71af7dc6ccb39151e14b80efc25) nixos/libvirtd: disable cloud-hypervisor on unsupported platforms
* [`60b0dd7b`](https://github.com/NixOS/nixpkgs/commit/60b0dd7b4fe5b169cff3a9c8038ee27675e898ea) go-swagger: 0.36.4 -> 0.36.5
* [`947cde19`](https://github.com/NixOS/nixpkgs/commit/947cde1993845f56b8ef046cb46a25dec27be6d2) python314Packages.pyopenjtalk-plus: init at 0.4.1.post9
* [`1a619535`](https://github.com/NixOS/nixpkgs/commit/1a619535dd7f02677a555541e53d96f7f0872999) piper-tts: enable japanese support
* [`5700cd35`](https://github.com/NixOS/nixpkgs/commit/5700cd3574f69e661ef80b1b7659edc446a1146b) xbyak: 7.40 -> 7.40.1
* [`7c6e4152`](https://github.com/NixOS/nixpkgs/commit/7c6e4152f6824a7225604356a7b1d959a61123d9) rocmPackages.sysrootCompiler: use __structuredAttrs instead of passAsFile
* [`1d94e81d`](https://github.com/NixOS/nixpkgs/commit/1d94e81d6419787e7451a4b9a5532b058667c380) nautilus: Add glycin-loaders to wrapper XDG_DATA_DIRS
* [`2dcd5e2f`](https://github.com/NixOS/nixpkgs/commit/2dcd5e2f8458d154ee7275d68ac9e0f15b7ed115) bazel-watcher: 0.32.0 -> 0.33.0
* [`bebb1388`](https://github.com/NixOS/nixpkgs/commit/bebb13881f11759a6f274fc9888df12222d11004) sif: 0-unstable-2026-07-22 -> 0-unstable-2026-08-22
* [`2452ba69`](https://github.com/NixOS/nixpkgs/commit/2452ba690cfa131ce5bb55b2974b99a01ac94709) firefox/wrapper: add appDataDir argument
* [`704cb65f`](https://github.com/NixOS/nixpkgs/commit/704cb65f3b542f23da3a70d5f2017d9fc9120b0b) doc/rl-2611: mention Firefox appDataDir wrapper argument
* [`1a539169`](https://github.com/NixOS/nixpkgs/commit/1a539169916a5054269d904cd2591a8fc88fa68a) prometheus-fastly-exporter: 10.2.0 -> 10.3.0
* [`4b1dd9e6`](https://github.com/NixOS/nixpkgs/commit/4b1dd9e69b4f4c8b08308514152d6fcd2013992d) beads: 1.0.3 -> 1.2.2
* [`71414dd1`](https://github.com/NixOS/nixpkgs/commit/71414dd107991d58ae00f93a23a0025a46831bc6) gcx: 1.1.0 -> 1.2.0
* [`e47ea548`](https://github.com/NixOS/nixpkgs/commit/e47ea548a663577d36a3ae79822f6b6e17ae77a0) osv-scanner: 2.5.0 -> 2.5.1
* [`2434f97e`](https://github.com/NixOS/nixpkgs/commit/2434f97ee57768fd6c953d409b33927196947136) nixos/selfoss: Allow overriding php-fpm pool user
* [`e72b0102`](https://github.com/NixOS/nixpkgs/commit/e72b010254c1db149aa9aede9bc98a0f562199fb) nixos/selfoss: Avoid `with` expression
* [`9e122a71`](https://github.com/NixOS/nixpkgs/commit/9e122a71ee69f2c1bb89e5783c9944af33c1aaf5) nixos/selfoss: Port to RFC42-style settings
* [`a30e4cf8`](https://github.com/NixOS/nixpkgs/commit/a30e4cf80ac62526eeb96cee57a17eca37491ce7) hfst: 3.17.2 -> 3.17.3
* [`06ffd498`](https://github.com/NixOS/nixpkgs/commit/06ffd498a890116308c8cc82dca3946a09bfe990) gb-backup: 0-unstable-2026-06-05 -> 0-unstable-2026-08-17
* [`34653330`](https://github.com/NixOS/nixpkgs/commit/3465333019657415f5c48b63f90a397bc9224cd3) python3Packages.fastcore: 2.2.13 -> 2.2.16
* [`228c14dc`](https://github.com/NixOS/nixpkgs/commit/228c14dc6ce9d3ef0ad1adbdbb78c0b15572358a) openvino: 2026.3.0 -> 2026.3.1
* [`d8c81ffe`](https://github.com/NixOS/nixpkgs/commit/d8c81ffe56b6f789b429820a6c257d6cad0bc2f6) openvino-tokenizers: 2026.3.0.0 -> 2026.3.1.0
* [`6ef07bd3`](https://github.com/NixOS/nixpkgs/commit/6ef07bd365b0f4a9240cb162fb37691451a357c9) openvino-genai: 2026.3.0.0 -> 2026.3.1.0
* [`5f0c95f4`](https://github.com/NixOS/nixpkgs/commit/5f0c95f44f6f639ce5782f0ecf028f4e0062d533) python3Packages.ai-edge-litert: relax libopenvino soversion
* [`61d84bfb`](https://github.com/NixOS/nixpkgs/commit/61d84bfb97ce5751c1903bdfd9448d252ddbdf8a) wealthfolio-server: 3.6.3 -> 3.7.0
* [`35b76958`](https://github.com/NixOS/nixpkgs/commit/35b76958b3ec41a2093c60d149344b632cb41d58) go-swagger: adjust ldflags
* [`81a9c857`](https://github.com/NixOS/nixpkgs/commit/81a9c8575c7fbdfc60441aa38dedf457c21a29b2) libtorrent-rakshasa: 0.16.20 -> 0.16.21
* [`c0052ade`](https://github.com/NixOS/nixpkgs/commit/c0052ade7751982f4e0c4d2d82e16c8482321034) snipe-it: 8.4.1 -> 8.7.2
* [`a2107693`](https://github.com/NixOS/nixpkgs/commit/a21076938a6ed7d1fe03ca40eeb032db8a1cd236) crabz: 0.10.0 -> 0.10.1
* [`92478ec2`](https://github.com/NixOS/nixpkgs/commit/92478ec24d6ece0fb4f5df86cdadb4ef853299ae) matterircd: 0.31.0 -> 0.32.0
* [`ed9b94ec`](https://github.com/NixOS/nixpkgs/commit/ed9b94ec6c08f471ddd7a9223aa5e51ee0662776) livekit: 1.13.5 -> 1.13.6
* [`b71aae4c`](https://github.com/NixOS/nixpkgs/commit/b71aae4c9f6981ac25eedf61faa6f4aa3125c50b) comigo: 1.3.3 -> 1.3.4
* [`d7674e28`](https://github.com/NixOS/nixpkgs/commit/d7674e2817bfe405c8a939e39be443117568f9a5) pumpkin: init at 0.1.0-unstable-2026-07-25
* [`28bcf71a`](https://github.com/NixOS/nixpkgs/commit/28bcf71a2c924a772718637481dcd4302f5e21a4) nixos/pumpkin: init module
* [`b07e33a3`](https://github.com/NixOS/nixpkgs/commit/b07e33a3c21ec5484d8a35fabca257cf17f7e316) evolution{,WithPlugins}: move to pkgs/by-name
* [`8fa23844`](https://github.com/NixOS/nixpkgs/commit/8fa238442f536d006c97142d84067bea13e9c80a) chirpstack-udp-forwarder: 4.3.0 -> 4.3.1
* [`c7d19357`](https://github.com/NixOS/nixpkgs/commit/c7d19357e5d48dbd6cb4ddbdff4f2fecbedb01c4) terraform-mcp-server: 1.2.0 -> 1.3.0
* [`61686564`](https://github.com/NixOS/nixpkgs/commit/6168656427f25c7f30a5c5810d5f4648508eb24e) shadowsocks-rust: 1.24.0 -> 1.25.0
* [`ab040479`](https://github.com/NixOS/nixpkgs/commit/ab0404799f5fb487513c89458a330dd1b04fac94) spicedb-zed: 1.2.0 -> 1.2.1
* [`63f77adf`](https://github.com/NixOS/nixpkgs/commit/63f77adfb19ed13bb9783b61934f888db596b3e1) tomlplusplus: only run checks on GNU platforms
* [`ee4d864e`](https://github.com/NixOS/nixpkgs/commit/ee4d864e38ca534caec26e27e7dba0784aa947ab) tomlplusplus: enable structuredAttrs and strictDeps
* [`0f26f8f3`](https://github.com/NixOS/nixpkgs/commit/0f26f8f3b050ede6975e378d6d7fe19833bcc7e8) freedv: 2.3.1 -> 2.4.0
* [`0d8a3d71`](https://github.com/NixOS/nixpkgs/commit/0d8a3d717a3b94a0288deb4e9cc4d4777b1a9c69) godef: 1.1.2 -> 1.2.0
* [`999d99a3`](https://github.com/NixOS/nixpkgs/commit/999d99a34f01b221d8c816697a8300355ef7571b) qaseprite: init at 1.0.3
* [`d36461d5`](https://github.com/NixOS/nixpkgs/commit/d36461d5ea13625d4026608087ebaeefafe20444) tiled: add qaseprite plugin
* [`8d84686e`](https://github.com/NixOS/nixpkgs/commit/8d84686ee075e9ea8cb62e3e82d2b7384fff1b23) cudaPackages.cutlass: 4.6.2 -> 4.7.1
* [`97913464`](https://github.com/NixOS/nixpkgs/commit/9791346456da6a9f68db04b1855f0352c14c3c2c) vscode-extensions.pkief.material-icon-theme: 5.37.0 -> 5.38.1
* [`29998fa5`](https://github.com/NixOS/nixpkgs/commit/29998fa53c3e6cbd092a05a7017f5e8390de4b3d) balena-cli: 25.2.5 -> 25.2.6
* [`f3d39db6`](https://github.com/NixOS/nixpkgs/commit/f3d39db6c9e981fa03bb04afe54d970aecb31730) berglas: 1.26.3 -> 1.26.6
* [`86c25cbe`](https://github.com/NixOS/nixpkgs/commit/86c25cbea08ab6248504bb0efc2a6be59f9527b0) vscode-extensions.astro-build.astro-vscode: 2.16.18 -> 2.16.20
* [`540f25d9`](https://github.com/NixOS/nixpkgs/commit/540f25d9b413f823dc37e472a81a1a9fd4a8360b) home-assistant-custom-components.auth_oidc: 1.1.1 -> 1.2.1
* [`a33e99f8`](https://github.com/NixOS/nixpkgs/commit/a33e99f87c2541025df9fe96138b7bfc0f7a3982) winboat: 0.9.0 -> 0.9.2
* [`12189926`](https://github.com/NixOS/nixpkgs/commit/1218992641368262b950204a1ffaf4bb0345e4f2) melonds: 1.1-unstable-2026-07-31 -> 1.1-unstable-2026-08-24
* [`20e0ef0e`](https://github.com/NixOS/nixpkgs/commit/20e0ef0e2b67d2fb77c5b045f37517ecfded270e) teamviewer: 15.80.4 -> 15.81.5
* [`d91605dc`](https://github.com/NixOS/nixpkgs/commit/d91605dcdc1971355c36291feed7831ceeb66ffd) samrewritten: 1.4.7 -> 1.5.0
* [`8d57993a`](https://github.com/NixOS/nixpkgs/commit/8d57993a7d0aa9d0280954d10cfe32effe7ad467) python3Packages.biopandas: 0.5.1 -> 0.5.2; fix pandas 3.0 compatibility
* [`35450c55`](https://github.com/NixOS/nixpkgs/commit/35450c558de9a93a7acb7eea1d2e4000c3adbc6a) grafanaPlugins.grafana-exploretraces-app: 2.1.0 -> 2.2.0
* [`17f0d187`](https://github.com/NixOS/nixpkgs/commit/17f0d187b35910ab07a668ab71ca9bdbca8a6816) k8sgpt: 0.4.36 -> 0.4.37
* [`3b12cef8`](https://github.com/NixOS/nixpkgs/commit/3b12cef8da7e90d24453b1cef664c51437ab7877) bitbox: 4.51.3 -> 4.51.4
* [`be5f3b19`](https://github.com/NixOS/nixpkgs/commit/be5f3b19a063ed4be921f50ba2162901475f1453) coqPackages.hierarchy-builder: fix old versions
* [`df9154b7`](https://github.com/NixOS/nixpkgs/commit/df9154b7b5b9d5cafe15a5052f107fadf746d87b) thrift-ls: 0.2.10 -> 0.2.11
* [`6bdd11b4`](https://github.com/NixOS/nixpkgs/commit/6bdd11b4e3dcf85114967a6fcb08d0a520adeb94) libunistring: remove unused argument
* [`e666657a`](https://github.com/NixOS/nixpkgs/commit/e666657ae2ac93fb83728c4544f2771a6b3726ea) u-root: version-regex for updates
* [`222c536e`](https://github.com/NixOS/nixpkgs/commit/222c536e2dbad91247f3fd88b78ca214b69ebec9) athens: 0.18.0 -> 0.18.1
* [`f15c5214`](https://github.com/NixOS/nixpkgs/commit/f15c5214e775e615f339a654a6802db84f59c4cd) keep-sorted: 0.9.0 -> 0.10.0
* [`5dd241d3`](https://github.com/NixOS/nixpkgs/commit/5dd241d39f372ed7f6d42f7b288700e30dacdf15) n8n: 2.34.6 -> 2.36.7
* [`dd9f2e3f`](https://github.com/NixOS/nixpkgs/commit/dd9f2e3f97ba3b962e7d7129f28c692c770ec9c8) vscode-extensions.streetsidesoftware.code-spell-checker: 4.5.6 -> 4.7.3
* [`6dbb5d93`](https://github.com/NixOS/nixpkgs/commit/6dbb5d930483f1479cc4f4f32e73a0fe3cd568ff) gogcli: 0.37.0 -> 0.38.1
* [`dc182bad`](https://github.com/NixOS/nixpkgs/commit/dc182bada8b22593a2684882af340ece0e16261b) socalabs-piano: init at 1.0.14
* [`e7abad2f`](https://github.com/NixOS/nixpkgs/commit/e7abad2faa3e5bfd7f66889949196add1236362a) nsd: 4.15.0 -> 4.15.1
* [`eb23683f`](https://github.com/NixOS/nixpkgs/commit/eb23683f262d398fac5690a24f8ae948ee02f085) maintainers: add dinckelman
* [`54443cb7`](https://github.com/NixOS/nixpkgs/commit/54443cb75f6f29d7834a355797fdd3a501ce349a) maintainers: add rschaffar
* [`e217aa3b`](https://github.com/NixOS/nixpkgs/commit/e217aa3be9698cce5e1ff46d1b69562a089354af) gogcli: add rschaffar as maintainer
* [`3c42b726`](https://github.com/NixOS/nixpkgs/commit/3c42b7266f2169611d55b8d531746db999c3133f) vscode-extensions.ms-ceintl.vscode-language-pack-fr: 1.129.2026071717 -> 1.131.2026082318
* [`24fb4da2`](https://github.com/NixOS/nixpkgs/commit/24fb4da2e6fd935c8b5ce5c83de772832e295be3) webkitgtk_6_0: move to pkgs/by-name
* [`de78ca59`](https://github.com/NixOS/nixpkgs/commit/de78ca592b4d84753dfdf1bbf303aa8f933770a1) bulwark: init at 1.9.2
* [`aa3b69e2`](https://github.com/NixOS/nixpkgs/commit/aa3b69e24eebc59cee2b0cbe4cce1b5ee9ed7ef5) nixos/bulwark: init
* [`67561da7`](https://github.com/NixOS/nixpkgs/commit/67561da780e0ea9e215121b7cd74a50d50f87fc5) nixos/tests/bulwark: add bulwark test
* [`49a7c9be`](https://github.com/NixOS/nixpkgs/commit/49a7c9be551ed365441137fff9d95017d1822b50) nixos/bulwark: cutting down on branding config
* [`a6ec8aaf`](https://github.com/NixOS/nixpkgs/commit/a6ec8aafe9e6bdedcd574bb017217b9aa55445e4) nixos/bulwark: freeform & removing some unimportant options
* [`ae1144e2`](https://github.com/NixOS/nixpkgs/commit/ae1144e27181afeea279fe85070c3d432211c2ef) wasm-tools: 1.256.0 -> 1.258.0
* [`3c156343`](https://github.com/NixOS/nixpkgs/commit/3c1563438b16d8e442b17f6790ba56b6e5be6ae4) nixos/wireless: add pkcs11 option for smartcard/TPM EAP-TLS
* [`2dca23ab`](https://github.com/NixOS/nixpkgs/commit/2dca23ab8aa033ab4ce73f37fd5bd88dc4520027) nixos/wireless: allow PKCS11 token access in the hardened service
* [`dbf30de7`](https://github.com/NixOS/nixpkgs/commit/dbf30de7ee17b18d3339f6ce7c0380bbb916530b) nixos/tests/networkmanager: extract wired hostapd service
* [`a2ed9f77`](https://github.com/NixOS/nixpkgs/commit/a2ed9f773da2a973c2b36dec1c7ae2468ccab6b9) nixos/tests/networkmanager: add E2E test for wpa_supplicant with TPM
* [`0b1b70d4`](https://github.com/NixOS/nixpkgs/commit/0b1b70d4fe793329d54ea5c661d911d7d5fa86f3) ruff: 0.16.4 -> 0.16.5
* [`74c4b94f`](https://github.com/NixOS/nixpkgs/commit/74c4b94fccbdc74f2590669710d5da447e43419b) vscode-extensions.42crunch.vscode-openapi: 5.6.0 -> 5.9.0
* [`d93747f3`](https://github.com/NixOS/nixpkgs/commit/d93747f3d6647a6a3b3ef372c87f488d24e76a19) cargo-rdme: 2.2.1 -> 2.2.2
* [`c0aa3eaf`](https://github.com/NixOS/nixpkgs/commit/c0aa3eaf3959ba30969471a457467b7511e34198) latexml-oxide: init at 0.7.6
* [`572b6785`](https://github.com/NixOS/nixpkgs/commit/572b678504a6cfc4508afe1d9d7e356506e76a4a) garble: 1.15.0 -> 1.17.0
* [`351315da`](https://github.com/NixOS/nixpkgs/commit/351315da2e5e131e02e5288676dc9f7eb3bd4b42) chuffed: 0.13.2 → 0.14.0
* [`0f1185b0`](https://github.com/NixOS/nixpkgs/commit/0f1185b0da5597d1e6a0c2517251819655aec1b8) grafanaPlugins.grafana-metricsdrilldown-app: 2.5.0 -> 2.5.1
* [`51671916`](https://github.com/NixOS/nixpkgs/commit/5167191691ecee9ed1db5b0f765d312a264012aa) home-assistant-custom-components.localthings: 0.22.0 -> 0.24.0
* [`d2450a65`](https://github.com/NixOS/nixpkgs/commit/d2450a6544de4e68a11807b8216214b4580307f0) wayfreeze: 0.2.0 -> 0.2.1
* [`020ab629`](https://github.com/NixOS/nixpkgs/commit/020ab629c7dd5399783de86440df745b62530923) zsign: 1.1.1 -> 1.1.2
* [`67b50b83`](https://github.com/NixOS/nixpkgs/commit/67b50b836d124dafe02a58ddf7c79478b0f0919f) openlogi: bundle the agent on darwin
* [`17504144`](https://github.com/NixOS/nixpkgs/commit/175041440bbe2ad01f402c40cb4651bc61c0f04c) headsetcontrol: 4.0.0 -> 4.1.0
* [`b8eac30a`](https://github.com/NixOS/nixpkgs/commit/b8eac30a5059f9d820c84491174005183d4f8921) oras: 1.3.3 -> 1.3.4
* [`7422f24a`](https://github.com/NixOS/nixpkgs/commit/7422f24af562537328ff52d7f8c4a00a32652bae) luau: 0.734 -> 0.735
* [`b4a58c9c`](https://github.com/NixOS/nixpkgs/commit/b4a58c9ce842bb264f626f6bdb941e54d2935cd3) infrastructure-agent: 1.79.0 -> 1.80.0
* [`ac01152c`](https://github.com/NixOS/nixpkgs/commit/ac01152ca6f518e7ac21c8a0ecd175b8633af2d2) multi-scrobbler: 0.16.4 -> 0.16.5
* [`e5fd21b0`](https://github.com/NixOS/nixpkgs/commit/e5fd21b0e98680320593a9e4d55e7117e0e35ff4) maintainers: add nirvdrum
* [`d706ab42`](https://github.com/NixOS/nixpkgs/commit/d706ab42d23097ea6cf2f37b01eb73bd65992d51) truffleruby: add package-specific meta attributes
* [`ca451321`](https://github.com/NixOS/nixpkgs/commit/ca4513217b02611b8649b999047072c589236847) vscode-extensions.coder.coder-remote: 1.16.0 -> 1.16.2
* [`6b4b0af8`](https://github.com/NixOS/nixpkgs/commit/6b4b0af80fa73a5f98ee9acaebf5fd46548a93d2) traefik: 3.7.10 -> 3.7.12
* [`856c1b34`](https://github.com/NixOS/nixpkgs/commit/856c1b34b8041387e25ed15f1d1eb2ccf9241349) prometheus-ping-exporter: 1.2.1 -> 1.2.3
* [`eb0af2e1`](https://github.com/NixOS/nixpkgs/commit/eb0af2e12214debd4a6c02d298e18a68dc5ca044) cv: 0.3.71 -> 0.3.72
* [`bdf9b55c`](https://github.com/NixOS/nixpkgs/commit/bdf9b55cebd58b070ba0b81e4196299c1349ed7e) civicrm: 6.17.2 -> 6.17.3
* [`25bc7b17`](https://github.com/NixOS/nixpkgs/commit/25bc7b1725d563495a7d598f966353c35582bdb3) pykickstart: 3.77 -> 3.78
* [`72ecc29f`](https://github.com/NixOS/nixpkgs/commit/72ecc29f58e63919b50329c0d45be6d873aae2fd) python3Packages.queuelib: 1.9.0 -> 1.10.0
* [`6941c5e3`](https://github.com/NixOS/nixpkgs/commit/6941c5e3a1d0463b97e53327e37144c042e0254f) python3Packages.fontbakery: switch to fetchFromGitHub
* [`3d4d87d2`](https://github.com/NixOS/nixpkgs/commit/3d4d87d2eab56dc4ef7c286460eb2f06bdb43410) python3Packages.fontbakery: add jopejoe1 as maintainer
* [`2f1bd9db`](https://github.com/NixOS/nixpkgs/commit/2f1bd9db643a4e646e04dac3a67d922bb73964a7) azure-storage-azcopy: 10.32.7 -> 10.32.8
* [`181511de`](https://github.com/NixOS/nixpkgs/commit/181511ded4b759eed732827d5a0d2f56c2bc520d) pop: 0.3.0 -> 0.5.0
* [`24316fe8`](https://github.com/NixOS/nixpkgs/commit/24316fe800e5688e9bed59d1551adc202e735b31) isponsorblocktv: 2.10.0 -> 2.11.0
* [`c770124c`](https://github.com/NixOS/nixpkgs/commit/c770124c9e2586beb6080468a43a5878a5d2e196) grub2: use gnu mirror for locales URL
* [`39ddbbd8`](https://github.com/NixOS/nixpkgs/commit/39ddbbd8ac069b1fb1642c561b845efff57b5000) python3Packages.google-cloud-pubsub: 2.39.1 -> 2.39.2
* [`8373ecfa`](https://github.com/NixOS/nixpkgs/commit/8373ecfa80bf1ecba6b1e007b37ca190ea3ddfcc) ocamlPackages.miou: 0.8.0 -> 0.9.0
* [`a3e0d92d`](https://github.com/NixOS/nixpkgs/commit/a3e0d92d0e3bbd728009f78ce0753af1e77c3b0d) prometheus-atlas-exporter: 1.0.5 -> 1.0.6
* [`3e527095`](https://github.com/NixOS/nixpkgs/commit/3e527095a075ea783ba36ec21e5fa8b567c1f128) opa-envoy-plugin: 1.19.1-envoy -> 1.20.1-envoy
* [`c742ec70`](https://github.com/NixOS/nixpkgs/commit/c742ec70c849553b04aba6b3e53496c08d8ffb02) finetune: init at 1.9.0
* [`60db5c30`](https://github.com/NixOS/nixpkgs/commit/60db5c30f2a61de35876284b3d92e6afad8d0e86) vscode-extensions.ms-windows-ai-studio.windows-ai-studio: 1.6.8 -> 1.6.10
* [`2778556b`](https://github.com/NixOS/nixpkgs/commit/2778556b64f9dcdfc6bab4c1106d4fdc0701df2b) age-plugin-fido2prf: 0.3.0 -> 0.3.1
* [`8d07413c`](https://github.com/NixOS/nixpkgs/commit/8d07413c4314d6b1b9772eccb9fbca94fd2a7ae8) screendrop: init at 0.31.3
* [`0658f7b5`](https://github.com/NixOS/nixpkgs/commit/0658f7b584acabe6c007d3e964c29310a51016cc) font-manager: fix build issue
* [`739bc6cf`](https://github.com/NixOS/nixpkgs/commit/739bc6cf3cb2be2d7cc1aec01dd34ae35e9b6afd) python3Packages.colorthief: migrate to pyproject
* [`8408f25a`](https://github.com/NixOS/nixpkgs/commit/8408f25ad7d406e2280fc069492a7a7cae88e6d2) python3Packages.colorthief: modernize
* [`d0198b26`](https://github.com/NixOS/nixpkgs/commit/d0198b26198c1e39df3557a361bf206a3f277c1f) python3Packages.colout: migrate to pyproject
* [`3701ddb9`](https://github.com/NixOS/nixpkgs/commit/3701ddb94385c49009b132f74c65f7db96150385) python3Packages.colout: modernize
* [`94c5d8b1`](https://github.com/NixOS/nixpkgs/commit/94c5d8b10baaa8cda520395e474b9d55942bc039) python3Packages.contexter: migrate to pyproject
* [`04230aa4`](https://github.com/NixOS/nixpkgs/commit/04230aa49f5d4d25f1789df8cf6f09879cc42b79) python3Packages.contexter: modernize
* [`0e6d027d`](https://github.com/NixOS/nixpkgs/commit/0e6d027dee563fa82c03982de754a937b730eb89) python3Packages.contexter: add meta.homepage
* [`5f3422e2`](https://github.com/NixOS/nixpkgs/commit/5f3422e2933449030069a1014af720fd70ccf302) python3Packages.cookies: migrate to pyproject
* [`58a7dc17`](https://github.com/NixOS/nixpkgs/commit/58a7dc17238049501479db44987bd019238d2198) python3Packages.cookies: modernize
* [`366e7d46`](https://github.com/NixOS/nixpkgs/commit/366e7d463ce72f8861ff00977020e1bc826267b3) python3Packages.csrmesh: migrate to pyproject
* [`9969d04e`](https://github.com/NixOS/nixpkgs/commit/9969d04e48b516cb0fecbe2f19fa0bb1cf34fbc6) python3Packages.csrmesh: modernize
* [`a9287e08`](https://github.com/NixOS/nixpkgs/commit/a9287e08a631fd17fa0bc5df6c1deccbab8c3638) python3Packages.dash-html-components: migrate to pyproject
* [`c9a90070`](https://github.com/NixOS/nixpkgs/commit/c9a90070d0c7dcd8ff402034275bda368464cdaa) python3Packages.dash-html-components: modernize
* [`ae81761b`](https://github.com/NixOS/nixpkgs/commit/ae81761b9f8ece1448245cec1d9972e1fcc4a087) python3Packages.dash-table: migrate to pyproject
* [`6c2cab09`](https://github.com/NixOS/nixpkgs/commit/6c2cab09bfcede5b72ebb4fa77b089e909005861) python3Packages.dash-table: modernize
* [`b95e44c3`](https://github.com/NixOS/nixpkgs/commit/b95e44c3db3ce3e719da768bc521b88346c18bc2) python3Packages.dash-table: unbreak meta.homepage
* [`494ef3cf`](https://github.com/NixOS/nixpkgs/commit/494ef3cf9249caadfeb98f197150044c4674e57e) python3Packages.dbus-signature-pyparsing: migrate to pyproject
* [`f206b4fe`](https://github.com/NixOS/nixpkgs/commit/f206b4fed01255cf1d6d72b31bbebe2c4dfbc691) python3Packages.dbus-signature-pyparsing: modernize
* [`c37d8f26`](https://github.com/NixOS/nixpkgs/commit/c37d8f265ff68e642633ff8a6042445eff659f6a) python3Packages.dissononce: migrate to pyproject
* [`1036adb0`](https://github.com/NixOS/nixpkgs/commit/1036adb068cc3df1971c86464c4fa1ab93cdce5c) python3Packages.dissononce: modernize
* [`7a8edac0`](https://github.com/NixOS/nixpkgs/commit/7a8edac0b573fc408ce724a9fbe6ba97a3b6cd7a) python3Packages.django-ranged-response: migrate to pyproject
* [`ec608842`](https://github.com/NixOS/nixpkgs/commit/ec6088424bf9f71bbbdcba996c2a2394ce98362f) python3Packages.django-ranged-response: modernize
* [`0cb6b877`](https://github.com/NixOS/nixpkgs/commit/0cb6b877975e8de5b25a174ee5009d259e6be20c) python3Packages.sqlalchemy-jsonfield: migrate to pyproject
* [`d5fa1aa3`](https://github.com/NixOS/nixpkgs/commit/d5fa1aa335e90d4fe78d0881e3b7409a28039af2) python3Packages.sqlalchemy-jsonfield: modernize
* [`c52e164f`](https://github.com/NixOS/nixpkgs/commit/c52e164f451624c683fda4f6d4512f40f549f719) python3Packages.srvlookup: migrate to pyproject
* [`ab5cd4a7`](https://github.com/NixOS/nixpkgs/commit/ab5cd4a75e58f01dc0599be9c923d9a91d9726b1) python3Packages.srp: migrate to pyproject
* [`8aa95e67`](https://github.com/NixOS/nixpkgs/commit/8aa95e676a2ce5e5d5fa35ad1a8193b41a41e3f0) python3Packages.sseclient: migrate to pyproject
* [`ee0b05d8`](https://github.com/NixOS/nixpkgs/commit/ee0b05d8a747358089d629e8ebd233be82415515) python3Packages.sseclient: modernize
* [`0aa72857`](https://github.com/NixOS/nixpkgs/commit/0aa72857cad386230bd719a13d42baab354cd707) python3Packages.stdiomask: migrate to pyproject
* [`9f55674a`](https://github.com/NixOS/nixpkgs/commit/9f55674ac24c4e64a2deface89b9651dac0b094d) python3Packages.steamodd: migrate to pyproject
* [`c71dc878`](https://github.com/NixOS/nixpkgs/commit/c71dc8783ff0b0e1f4e98ee6c5cc6d9f0797dd86) python3Packages.streamlabswater: migrate to pyproject
* [`b0ff0cc1`](https://github.com/NixOS/nixpkgs/commit/b0ff0cc1970b5bcc7d835dc08f9d53a17dba2c84) python3Packages.stringcase: migrate to pyproject
* [`f12cafce`](https://github.com/NixOS/nixpkgs/commit/f12cafcef895dab35cc7095369f6862730df7057) python3Packages.stringcase: modernize
* [`a6387570`](https://github.com/NixOS/nixpkgs/commit/a6387570bd4701a3a92e402e2b6077120635d796) python3Packages.stubserver: migrate to pyproject
* [`be324155`](https://github.com/NixOS/nixpkgs/commit/be324155e8034c3c7cdd9ac8785cabdabded6abc) python3Packages.subzerod: migrate to pyproject
* [`7e4f4169`](https://github.com/NixOS/nixpkgs/commit/7e4f41694d91d458407293719c46faa5809b8171) python3Packages.sumtypes: migrate to pyproject
* [`1c2ab133`](https://github.com/NixOS/nixpkgs/commit/1c2ab133cc26886f99a53ab7e596a87f1f9fee2d) python3Packages.stubserver: modernize
* [`06dd6f81`](https://github.com/NixOS/nixpkgs/commit/06dd6f81623e7588f58f40d10eefa6045aa563d9) python3Packages.subzerod: modernize
* [`6a52dc63`](https://github.com/NixOS/nixpkgs/commit/6a52dc6318f0205227c062680fda1c1911e41f04) python3Packages.surt: migrate to pyproject
* [`ce63c5d4`](https://github.com/NixOS/nixpkgs/commit/ce63c5d497a18f74176fc12a63f559e837a00520) python3Packages.sumtypes: modernize
* [`bdb185ff`](https://github.com/NixOS/nixpkgs/commit/bdb185ff490b9b7c81625fac25658c914d7be293) python3Packages.sv-ttk: migrate to pyproject
* [`529ecd23`](https://github.com/NixOS/nixpkgs/commit/529ecd23f3fb207b622cce123024480fbfe9acb6) python3Packages.sv-ttk: modernize
* [`84300f0c`](https://github.com/NixOS/nixpkgs/commit/84300f0c1dc86e0bf8046642519d6b3a265c9929) python3Packages.timeago: migrate to pyproject
* [`0e47465b`](https://github.com/NixOS/nixpkgs/commit/0e47465bf94c4a35d41721bdef6a27c0c1db1ed7) python3Packages.timeago: modernize
* [`376dd899`](https://github.com/NixOS/nixpkgs/commit/376dd8996da4f12e641f65d0e6ecde6b0513d010) python3Packages.tlv8: migrate to pyproject
* [`38edaaca`](https://github.com/NixOS/nixpkgs/commit/38edaaca75ae68ea1b3f1f35cd9a265c0867b444) python3Packages.torchdiffeq: migrate to pyproject
* [`c92e457a`](https://github.com/NixOS/nixpkgs/commit/c92e457a2f0c9eb9017499bc9132bd445c7d66dd) python3Packages.tlv8: modernize
* [`3e54247e`](https://github.com/NixOS/nixpkgs/commit/3e54247e727ff262a13caa951f295b68dae28cfe) python3Packages.torchlibrosa: migrate to pyproject
* [`2547f457`](https://github.com/NixOS/nixpkgs/commit/2547f45722a6f4e93915a3c1c7bd7dbcc5de0e48) python3Packages.torchdiffeq: modernize
* [`f861c353`](https://github.com/NixOS/nixpkgs/commit/f861c35304e5a15eec9e244d44b551b9c13287e3) python3Packages.tlv8: enable tests
* [`b90835d2`](https://github.com/NixOS/nixpkgs/commit/b90835d2ed44c50d8f7580579568f7e44b1e27ad) python3Packages.torchlibrosa: modernize
* [`203eed33`](https://github.com/NixOS/nixpkgs/commit/203eed333ca51aa7b3c00c14422c6f279fea505a) python3Packages.trectools: migrate to pyproject
* [`256d8db9`](https://github.com/NixOS/nixpkgs/commit/256d8db9b2de27bd98fa99e7d7f0458490de8f8a) python3Packages.troposphere: migrate to pyproject
* [`aec5c0e8`](https://github.com/NixOS/nixpkgs/commit/aec5c0e85e9838842d7c1f54fe94df0ed02e5eb5) python3Packages.troposphere: modernize
* [`b531c607`](https://github.com/NixOS/nixpkgs/commit/b531c60713c8908147029255f2b7bbc3f2b9711d) python3Packages.txrequests: migrate to pyproject
* [`80a04efe`](https://github.com/NixOS/nixpkgs/commit/80a04efe59ca4775b5b5ceee5ce129cceef50447) python3Packages.txrequests: modernize
* [`d68e24e4`](https://github.com/NixOS/nixpkgs/commit/d68e24e48acd13e1c2f69f7189b76cd3770883b2) python3Packages.ua-parser-rs: migrate to pyproject
* [`6f135b1d`](https://github.com/NixOS/nixpkgs/commit/6f135b1d924b95687fd68086737d494f827750d1) python3Packages.ua-parser-rs: modernize
* [`2a8fc362`](https://github.com/NixOS/nixpkgs/commit/2a8fc362df632bd258fc791d1b04a628314a2860) python3Packages.ua-parser-rs: unbreak meta.homepage
* [`95e21a04`](https://github.com/NixOS/nixpkgs/commit/95e21a04364c5491ee485460aa0b4c19aa9476da) blowfish-tools: 1.13.1 -> 3.2.0
* [`ca18302d`](https://github.com/NixOS/nixpkgs/commit/ca18302d75f692ef59c87b9525e390a7129278cb) popcorn-cli: 1.3.30 -> 1.3.31
* [`f03ef867`](https://github.com/NixOS/nixpkgs/commit/f03ef86703d26d22ac8c01fe7bda09f5ebfde0c6) rucio: un-pin from python 3.12
* [`f044b37b`](https://github.com/NixOS/nixpkgs/commit/f044b37bb27f3b20b06da61378bedf12375be98a) zensical: 0.0.56 -> 0.0.57
* [`5d9cc81a`](https://github.com/NixOS/nixpkgs/commit/5d9cc81aa69478d5395773101cf69a7dbebc3a27) stp: 2.3.4 -> 2.4.1
* [`cd04f2a5`](https://github.com/NixOS/nixpkgs/commit/cd04f2a5f1d33f89ef12f9a1c2337d000eea4b3a) yanic: Let all references point to Codeberg
* [`fc74a92f`](https://github.com/NixOS/nixpkgs/commit/fc74a92f1eb3f6cbde4167f61a573ada13b4c4b4) yanic: 1.8.3 -> 1.9.0
* [`ce975198`](https://github.com/NixOS/nixpkgs/commit/ce975198fb0554e1938b1894065b32530942395d) yanic: Enable strictDeps and __structuredAttrs
* [`8c4f150b`](https://github.com/NixOS/nixpkgs/commit/8c4f150bc53b295e67174e632065e44499f89338) klee: fix build, llvmPackages_18 -> llvmPackages_19
* [`85c102bb`](https://github.com/NixOS/nixpkgs/commit/85c102bb2e13bba3f8d67a4a3c29f1b6f3cc7545) cloudfoundry-cli: 8.18.4 -> 8.19.0
* [`ac73fb62`](https://github.com/NixOS/nixpkgs/commit/ac73fb6236253c5d083da195020b7bf6b2f6b893) browsers: 0.7.4 -> 0.7.5
* [`5404e060`](https://github.com/NixOS/nixpkgs/commit/5404e0604215a81427829932f755e7e2a94b4f7a) cairomm: rename to cairomm_1_0
* [`1e343162`](https://github.com/NixOS/nixpkgs/commit/1e3431622c555415f1c250cf5d10fc85b9efa0a7) cairomm_1_0: enable structuredAttrs and strictDeps
* [`fb9cd261`](https://github.com/NixOS/nixpkgs/commit/fb9cd261b273a269a9aa5ed377e25047c74ee407) cairomm_1_16: enable structuredAttrs and strictDeps
* [`70bbacf5`](https://github.com/NixOS/nixpkgs/commit/70bbacf5b9bae37eae3191c6cef55d09c2f6c8cd) melange: 0.59.1 -> 0.59.2
* [`35c83af8`](https://github.com/NixOS/nixpkgs/commit/35c83af8b8c49e100e4d6c2b1fbe48a6f7dd41da) R: disable tcltk core test on darwin
* [`561b8843`](https://github.com/NixOS/nixpkgs/commit/561b88438c65f3c0ecc2e3134ec3b2d8a07f0fe6) ardour: 9.7 -> 9.8
* [`a327fd2c`](https://github.com/NixOS/nixpkgs/commit/a327fd2c8de60c5c370823ec185e41c4c046019e) libmsquic: 2.6.0 -> 2.6.1
* [`7d47ca99`](https://github.com/NixOS/nixpkgs/commit/7d47ca99633919c804e72ab47c5d886c829c7a2c) nixos/mediamtx: use correct yaml version
* [`3092217d`](https://github.com/NixOS/nixpkgs/commit/3092217d8d299a58ab9054cbe070b8dc6424b3dd) coroot: 1.24.5 -> 1.25.0
* [`dd5097c8`](https://github.com/NixOS/nixpkgs/commit/dd5097c81193c0a97b1ca841bc7c5961e89b89d6) safecloset: 1.4.2 -> 1.5.0
* [`633d3174`](https://github.com/NixOS/nixpkgs/commit/633d317403a7989be9d84ba3b36efe2761f5fb49) gcc: update darwin 16 patches
* [`7aa4a6c7`](https://github.com/NixOS/nixpkgs/commit/7aa4a6c7cbd35783f682044e01beaa5bb03e42aa) lomiri.lomiri-mediaplayer-app: 1.1.1 -> 1.1.2
* [`fdc62f1f`](https://github.com/NixOS/nixpkgs/commit/fdc62f1f565e1c4fb0e2af638efba0ad27f6899b) ifstate: 2.4.1 -> 2.4.2
* [`a1c6c6a5`](https://github.com/NixOS/nixpkgs/commit/a1c6c6a578472c2f8004003aff8dac143e19fd76) python3Packages.tuya-device-sharing-sdk: 0.2.14 -> 0.2.15
* [`93d69265`](https://github.com/NixOS/nixpkgs/commit/93d692653558285e225d3b577e02e7c019b75caf) talosctl: 1.13.8 -> 1.13.9
* [`fdb66a89`](https://github.com/NixOS/nixpkgs/commit/fdb66a891e225d0ae35ec20e5aef0015028e7960) buildkite-agent: 3.135.0 -> 3.137.2
* [`9c984a96`](https://github.com/NixOS/nixpkgs/commit/9c984a96326ecc45163238f7fd4513799645d884) python3Packages.jupyter-docprovider: 3.0.0 -> 3.0.2
* [`44c06248`](https://github.com/NixOS/nixpkgs/commit/44c06248bc75236a0170d2f917c9379d20e4aedf) rura: 1.12.0 -> 1.13.0
* [`d355170c`](https://github.com/NixOS/nixpkgs/commit/d355170c6a4e4dbd87191ad18dc6522c5a168e50) ggmorse: 0-unstable-2024-05-31 -> 0-unstable-2026-08-24
* [`8c796dc2`](https://github.com/NixOS/nixpkgs/commit/8c796dc206e0140f69bf364e615d3d18f7b98f89) wait4x: 3.7.0 -> 3.7.1
* [`aeac6217`](https://github.com/NixOS/nixpkgs/commit/aeac62175c982fbc5946d0a855d0f29958688d86) goimports-reviser: 3.12.6 -> 3.13.2
* [`ecd7558b`](https://github.com/NixOS/nixpkgs/commit/ecd7558b4d11a94fbfb4944aa50b6a031f4e806d) httplib: 0.53.1 -> 0.54.0
* [`8676ec60`](https://github.com/NixOS/nixpkgs/commit/8676ec60068b9ae15ed0f09dd98f0751a3a9f4fe) vscode-extensions.google.colab: 0.9.0 -> 0.9.3
* [`84df1334`](https://github.com/NixOS/nixpkgs/commit/84df133427a4b09c48fbcc738ea480a2e8565506) miru: 0.6.0 -> 0.7.0
* [`26323889`](https://github.com/NixOS/nixpkgs/commit/26323889bc13072983fefe3397fdc57563b106d8) pkgsStatic.pgbouncer: fix build
* [`d1750d2f`](https://github.com/NixOS/nixpkgs/commit/d1750d2f6984f454c465689ae909be4507d6838e) maintainers: add libewa
* [`3d7bad0e`](https://github.com/NixOS/nixpkgs/commit/3d7bad0eaea1ee9dd6001e8181b9a80be05545ae) python3Packages.huaweicloudsdkcore: 3.1.211 -> 3.1.212
* [`88b583f9`](https://github.com/NixOS/nixpkgs/commit/88b583f9e222687f2c3c745a7c61b554fb4c43b4) terraform: refactor
* [`f2cee69a`](https://github.com/NixOS/nixpkgs/commit/f2cee69a5687797b81c19c197a0771c8774560a7) terraform: move to pkgs/by-name
* [`c4e6a829`](https://github.com/NixOS/nixpkgs/commit/c4e6a8290f661604e0c04f8cd29a57638a3c624a) cook-cli: 0.33.1 -> 0.34.0
* [`10512529`](https://github.com/NixOS/nixpkgs/commit/1051252919655f881dbda8bb4d711df284fa3a61) android-image-kitchen: patch cleanup script name
* [`6888b41b`](https://github.com/NixOS/nixpkgs/commit/6888b41b3a9cc4a6ceba638616fa0184d4857288) xpra: 6.4.4 -> 6.5.3
* [`e9f62cd4`](https://github.com/NixOS/nixpkgs/commit/e9f62cd478581634fcc384e9a3fcbc6ab1a05691) python3Packages.numpy-typing-compat: modernize
* [`09f09372`](https://github.com/NixOS/nixpkgs/commit/09f093721b932e04cfdd02d2edcc3607050df8f0) python3Packages.numpy-typing-compat: 20251206.2.4 -> 20260602.2.5
* [`0e1cc1b4`](https://github.com/NixOS/nixpkgs/commit/0e1cc1b4ab70f479b29c433e35851bab95083aa8) python3Packages.optype: 0.15.0 -> 0.18.0
* [`c6410181`](https://github.com/NixOS/nixpkgs/commit/c6410181ddb4d0268385732d60a657db2a2228ba) python3Packages.scipy-stubs: modernize
* [`df9ae0ff`](https://github.com/NixOS/nixpkgs/commit/df9ae0ffe4ee9c6be0d9826f79b6bf5cdad3aec4) python3Packages.scipy-stubs: 1.17.0.1 -> 1.18.1.0
* [`86f53931`](https://github.com/NixOS/nixpkgs/commit/86f53931a0c16da7695e03a2455b70c59128db23) discount: 3.0.1.3 -> 3.0.2.0
* [`f8e2c22f`](https://github.com/NixOS/nixpkgs/commit/f8e2c22ffe80a739ab4253724cb483a6a949a139) kchat: 3.3.5 -> 3.5.1
* [`0bc98ea8`](https://github.com/NixOS/nixpkgs/commit/0bc98ea856938cd83aab468f6532d615ddf0ab85) curtail: 1.16.1 -> 1.16.2
* [`ce950141`](https://github.com/NixOS/nixpkgs/commit/ce950141f3a604d0c597d254aa562eece40b3d8a) vscode-extensions.unifiedjs.vscode-mdx: 1.8.17 -> 1.8.18
* [`e70ea210`](https://github.com/NixOS/nixpkgs/commit/e70ea2103010cefec6a5094a522da411bb570fe3) codex: 0.149.0 -> 0.151.0
* [`fbb840dd`](https://github.com/NixOS/nixpkgs/commit/fbb840dd847bf4b2d132a68fe93bcb43c3b23214) home-assistant-custom-components.ha_mcp_tools: Add ha-mcp Python module as explicit dependency
* [`7f0678bc`](https://github.com/NixOS/nixpkgs/commit/7f0678bc7016c36029f11dfe867e455a93b1ef26) nexttrace: 1.7.2 -> 1.7.3
* [`47b03274`](https://github.com/NixOS/nixpkgs/commit/47b032747c3efa00dcbb50704465d095241abcd5) tautulli: 2.17.2 -> 2.18.1
* [`c5ec82ba`](https://github.com/NixOS/nixpkgs/commit/c5ec82ba516e0689b64c8e998a88f00403310deb) sidplayfp: Build against system fmt
* [`6229a16a`](https://github.com/NixOS/nixpkgs/commit/6229a16a37ea63e0333eb39c09a209f50ad55528) pkgs/nixos-render-docs: add id-prefix to nav.json
* [`8777e0da`](https://github.com/NixOS/nixpkgs/commit/8777e0da73676a1cfbea4c50c88c79ea48646018) pkgs/nixos-render-docs: add tests for nav.json id-prefix
* [`5dd04ae3`](https://github.com/NixOS/nixpkgs/commit/5dd04ae305069934a9eaf69a073d22cbede6cd1c) bazecor: 1.9.0 -> 1.10.0
* [`fc780582`](https://github.com/NixOS/nixpkgs/commit/fc780582966fba01e2ee0870142973dbacc7e5fe) uutils-procps: 0.0.1-unstable-2026-08-15 -> 0.0.1-unstable-2026-08-23
* [`ca78a33f`](https://github.com/NixOS/nixpkgs/commit/ca78a33f3e7d51b5af96be2ab05ed56c879593b5) lomiri.lomiri-mediaplayer-app: Get checkPhase working
* ... _the rest of the list is truncated due to the maximum length of the PR message on GitHub. Please take a look at the commit message._
