### PR TITLE
npins home-manager: update 1dc2d1f7 -> 2c0350c7

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -48,9 +48,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "1dc2d1f720ab17fc7981e087346bf54b26d284b1",
-      "url": "https://github.com/nix-community/home-manager/archive/1dc2d1f720ab17fc7981e087346bf54b26d284b1.tar.gz",
-      "hash": "sha256-G0F2rFORVcFkEvVdE/qWQTnYekIc77YP5/vRF9nZlxU="
+      "revision": "2c0350c759688177331b8f5242311fae8877bdb3",
+      "url": "https://github.com/nix-community/home-manager/archive/2c0350c759688177331b8f5242311fae8877bdb3.tar.gz",
+      "hash": "sha256-v9wJd32eZ2bvhBzVOd7TIjLQd011P7nwOhjKtWlci5I="
     },
     "hs-grille": {
       "type": "Git",


### PR DESCRIPTION
## Changelog for home-manager:
Branch: master
Commits: [nix-community/home-manager@1dc2d1f7...2c0350c7](https://github.com/nix-community/home-manager/compare/1dc2d1f720ab17fc7981e087346bf54b26d284b1...2c0350c759688177331b8f5242311fae8877bdb3)

* [`acf5b0fc`](https://github.com/nix-community/home-manager/commit/acf5b0fcf38cfc1dbf6979e94ca71f4f2450e997) zathura: make package field nullable
* [`d64da6fd`](https://github.com/nix-community/home-manager/commit/d64da6fdab4726dc6efd8836346869f27aec12c9) copyq: add settings
* [`ead131eb`](https://github.com/nix-community/home-manager/commit/ead131eb1ec3088a11a23638b99f89c50422fbd3) copyq: change maintainer
* [`29388c81`](https://github.com/nix-community/home-manager/commit/29388c81143457c316544ffcf2703dc1411f80cc) maintainers: add ekhh
* [`b8350fcd`](https://github.com/nix-community/home-manager/commit/b8350fcdf54ccf553e46408053b1ac5b7038c18b) libreoffice: add module
* [`d9d750e4`](https://github.com/nix-community/home-manager/commit/d9d750e4fc11c10cab2da677bdd31e427f3a3a71) maintainers: update all-maintainers.nix
* [`aa308770`](https://github.com/nix-community/home-manager/commit/aa308770461dcf22c333a5e8a31c8bddbde5bee9) ripasso: add module
* [`3291d030`](https://github.com/nix-community/home-manager/commit/3291d0309b2d719a92455b35c66d1f731f0650e4) home-environment: honor fish.preferAbbrs for shell aliases
* [`693e8ce0`](https://github.com/nix-community/home-manager/commit/693e8ce0fb240a73c116a03cfd7b19269c87af88) git: add allowedSigners option
* [`df6fe1a6`](https://github.com/nix-community/home-manager/commit/df6fe1a630d5137c32fc3ee9964b28e79b427a5a) docs: use module path in NixOS installation example
* [`caa6dc59`](https://github.com/nix-community/home-manager/commit/caa6dc59c445ef78b82b8684103d02095158fd82) secretspec: init
* [`8381f348`](https://github.com/nix-community/home-manager/commit/8381f3481e4424ea0b53c9e7469c14da799d5822) pomo: init module
* [`03259bae`](https://github.com/nix-community/home-manager/commit/03259bae86097e8274879ab62efb013b73df518d) flake: bump nixpkgs from `391b592` to `e8be781`
* [`078aa674`](https://github.com/nix-community/home-manager/commit/078aa674eb815763cf7368a22117a47dfc7900ec) mpv: make package field nullable
* [`4c57ede0`](https://github.com/nix-community/home-manager/commit/4c57ede073e6b06f3a9b36cc24462b595aee5076) omniwm: add module
* [`beccc6e1`](https://github.com/nix-community/home-manager/commit/beccc6e1151ec73a133a212c8154da20aca21bc4) keepassxc: add native messaging host for LibreWolf
* [`11f7a2df`](https://github.com/nix-community/home-manager/commit/11f7a2df92b132274c49d2645cacd375d4345cf4) wayland.windowManager.niri: add opt-in upstream defaults
* [`a49f50d5`](https://github.com/nix-community/home-manager/commit/a49f50d59510d49b0e1c48090b6e504975beeda9) gram: add module
* [`f938f207`](https://github.com/nix-community/home-manager/commit/f938f207311b1866992998f4b9541b7ba5af4e27) firefoxpwa: add ilovelinux as maintainer
* [`2dab262b`](https://github.com/nix-community/home-manager/commit/2dab262b6ccafe43baf34dec24d74e2596227338) firefoxpwa: improve support for non-PWA websites
* [`e3722aa9`](https://github.com/nix-community/home-manager/commit/e3722aa98bd1ed7b15a8b6ffab5dafc042c726cb) firefoxpwa: add news about improved support for non-PWA websites
* [`2c0350c7`](https://github.com/nix-community/home-manager/commit/2c0350c759688177331b8f5242311fae8877bdb3) firefoxpwa: add test for non-PWA websites
