### PR TITLE
npins powerlevel10k: update 3308262d -> d05a1b00

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -138,9 +138,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "3308262dfbd743b6e1d3956a2b5572f7a049d692",
-      "url": "https://github.com/romkatv/powerlevel10k/archive/3308262dfbd743b6e1d3956a2b5572f7a049d692.tar.gz",
-      "hash": "sha256-s0FLaSZdhMTJyHQFtkQWdp0Qi2QAZvy4H40r1FdEOvY="
+      "revision": "d05a1b00f9a61f9578bf9dc19b8451942dde8734",
+      "url": "https://github.com/romkatv/powerlevel10k/archive/d05a1b00f9a61f9578bf9dc19b8451942dde8734.tar.gz",
+      "hash": "sha256-B2Sq/V455mlvMOAv+K7vEyZy53kVdo576ZAMcvbJXgk="
     },
     "rh": {
       "type": "Git",


### PR DESCRIPTION
## Changelog for powerlevel10k:
Branch: master
Commits: [romkatv/powerlevel10k@3308262d...d05a1b00](https://github.com/romkatv/powerlevel10k/compare/3308262dfbd743b6e1d3956a2b5572f7a049d692...d05a1b00f9a61f9578bf9dc19b8451942dde8734)

* [`379240e2`](https://github.com/romkatv/powerlevel10k/commit/379240e2e48a2006b17f453714443bb0a52093c3) Squashed 'gitstatus/' changes from 39d34dff..7822a026
